### PR TITLE
Add skip_quoted_offset variable

### DIFF
--- a/globals.h
+++ b/globals.h
@@ -203,6 +203,7 @@ WHERE short ReflowWrap;
 WHERE short SaveHist;
 WHERE short SendmailWait;
 WHERE short SleepTime INITVAL (1);
+WHERE short SkipQuotedOffset;
 WHERE short TimeInc;
 WHERE short Timeout;
 WHERE short Wrap;

--- a/init.h
+++ b/init.h
@@ -2633,6 +2633,12 @@ struct option_t MuttVars[] = {
   ** replacing ``%s'' with the supplied string.
   ** For the default value, ``joe'' would be expanded to: ``~f joe | ~s joe''.
   */
+  { "skip_quoted_offset", DT_NUM, R_NONE, UL &SkipQuotedOffset, 0 },
+  /*
+  ** .pp
+  ** Lines of quoted text that are displayed before the unquoted text after
+  ** 'skip to quoted' command (S)
+  */
   { "sleep_time",	DT_NUM, R_NONE, UL &SleepTime, 1 },
   /*
   ** .pp

--- a/pager.c
+++ b/pager.c
@@ -2248,11 +2248,11 @@ search_next:
 	  int dretval = 0;
 	  int new_topline = topline;
 
-	  while ((new_topline < lastLine ||
+	  while ((new_topline + SkipQuotedOffset < lastLine ||
 		  (0 == (dretval = display_line (fp, &last_pos, &lineInfo,
 			 new_topline, &lastLine, &maxLine, M_TYPES | (flags & M_PAGER_NOWRAP),
 			 &QuoteList, &q_level, &force_redraw, &SearchRE))))
-		 && lineInfo[new_topline].type != MT_COLOR_QUOTED)
+		 && lineInfo[new_topline + SkipQuotedOffset].type != MT_COLOR_QUOTED)
 	    new_topline++;
 
 	  if (dretval < 0)
@@ -2261,11 +2261,11 @@ search_next:
 	    break;
 	  }
 
-	  while ((new_topline < lastLine ||
+	  while ((new_topline + SkipQuotedOffset < lastLine ||
 		  (0 == (dretval = display_line (fp, &last_pos, &lineInfo,
 			 new_topline, &lastLine, &maxLine, M_TYPES | (flags & M_PAGER_NOWRAP),
 			 &QuoteList, &q_level, &force_redraw, &SearchRE))))
-		 && lineInfo[new_topline].type == MT_COLOR_QUOTED)
+		 && lineInfo[new_topline + SkipQuotedOffset].type == MT_COLOR_QUOTED)
 	    new_topline++;
 
 	  if (dretval < 0)


### PR DESCRIPTION
Testing the neomutt workflow with a simple feature patch from my local stash.
---
Tunable for number of lines of quoted text that are displayed before the
unquoted text after 'skip to quoted' command (S).

Signed-off-by: David Sterba <dsterba@suse.cz>