### PR TITLE
build without any network module

### DIFF
--- a/version.c
+++ b/version.c
@@ -162,7 +162,9 @@ static struct compile_options comp_opts[] = {
 #else
 	{ "HAVE_CURS_SET", 0 },
 #endif
+#ifdef HAVE_GETADDRINFO
 	{ "HAVE_GETADDRINFO", HAVE_GETADDRINFO },
+#endif
 	{ "HAVE_GETSID",      HAVE_GETSID      },
 	{ "HAVE_ICONV",       HAVE_ICONV       },
 #ifdef HAVE_LANGINFO_CODESET


### PR DESCRIPTION
should fix the build failure with this run of configure:

``./configure --with-homespool=~/.maildir --enable-sidebar --enable-notmuch --with-bdb --disable-full-doc --enable-hcache``
