### PR TITLE
Add new_mail_command

### DIFF
--- a/curs_main.c
+++ b/curs_main.c
@@ -755,6 +755,12 @@ int mutt_index_menu (void)
 	  mutt_message _("New mail in this mailbox.");
 	  if (option (OPTBEEPNEW))
 	    beep ();
+    if (NewMailCmd)
+    {
+      char cmd[LONG_STRING];
+      menu_status_line(cmd, sizeof(cmd), menu, NONULL(NewMailCmd));
+      mutt_system(cmd);
+    }
 	} else if (check == M_FLAGS)
 	  mutt_message _("Mailbox was externally modified.");
 
@@ -776,11 +782,17 @@ int mutt_index_menu (void)
        menu->redraw |= REDRAW_STATUS;
      if (do_buffy_notify)
      {
-       if (mutt_buffy_notify())
+       if (mutt_buffy_notify ())
        {
          menu->redraw |= REDRAW_STATUS;
          if (option (OPTBEEPNEW))
-           beep();
+           beep ();
+         if (NewMailCmd)
+         {
+           char cmd[LONG_STRING];
+           menu_status_line(cmd, sizeof(cmd), menu, NONULL(NewMailCmd));
+           mutt_system(cmd);
+         }
        }
      }
      else

--- a/doc/manual.xml.head
+++ b/doc/manual.xml.head
@@ -6724,7 +6724,10 @@ New mail for Maildir is assumed if there is one message in the
 <link linkend="maildir-trash">$maildir_trash</link>). For MH folders, a
 mailbox is considered having new mail if there's at least one message in
 the <quote>unseen</quote> sequence as specified by <link
-linkend="mh-seq-unseen">$mh_seq_unseen</link>.
++linkend="mh-seq-unseen">$mh_seq_unseen</link>. Optionally, <link
++linkend="new_mail_command">$new_mail_command</link> can be configured to
++execute an external program every time new mail is detected in the current
++inbox.
 </para>
 
 <para>

--- a/globals.h
+++ b/globals.h
@@ -111,6 +111,7 @@ WHERE char *Postponed;
 WHERE char *PostponeEncryptAs;
 WHERE char *Prefix;
 WHERE char *PrintCmd;
+WHERE char *NewMailCmd;
 WHERE char *QueryCmd;
 WHERE char *QueryFormat;
 WHERE char *Realname;

--- a/init.h
+++ b/init.h
@@ -291,6 +291,13 @@ struct option_t MuttVars[] = {
   { "beep",		DT_BOOL, R_NONE, OPTBEEP, 1 },
   /*
   ** .pp
+  ** If \fIset\fP, Mutt will call this command after a new message is received.
+  ** See the $$status_format documentation for the values that can be formatted
+  ** into this command.
+  */
+  { "new_mail_command",	DT_PATH, R_NONE, UL &NewMailCmd, UL NULL },
+  /*
+  ** .pp
   ** When this variable is \fIset\fP, mutt will beep when an error occurs.
   */
   { "beep_new",		DT_BOOL, R_NONE, OPTBEEPNEW, 0 },


### PR DESCRIPTION
@SantiagoTorres and me pair-programmed this patch to add a new setting that you can configure to execute a command every time new mail is found in your current mailbox.

In OSX I have it set to the following:
```
set new_command="terminal-notifier -title '%v' -subtitle 'New Mail in %f' -message \
'%n new messages, %u unread.' -activate %'com.apple.Terminal'; afplay \
%'/Applications/Mail.app/Contents/Resources/New Mail.aiff' &"
```

The first part will format some information about the status of the mailbox and pass it on to terminal-notifier (https://github.com/alloy/terminal-notifier) then use OSX's afplay to play the classic "new mail" sound.

---------------

Original thread on the mutt-dev ML:
http://marc.info/?l=mutt-dev&m=142239376026527&w=2