### PR TITLE
Cleanup travis script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ notifications:
     on_success: change
     on_failure: always
 
-sudo: required
+sudo: no
 dist: trusty
 
 language: c


### PR DESCRIPTION
This commit introduces the following changes:
  * Use a git clone depth of 3. We don't need any more than that
  * Disable use of ccache. Since each instance is building only one
  version of Mutt, ccache gives us no speedup advantage at all
  * Use ./prepare instead of autoreconf -i && ./configure. Eliminate
  need for a before_script step.

EDIT: Also use sudo:no to enable the container based architecture which promises to be faster. 