### PR TITLE
Fix compiler warnings due to always true condition

### DIFF
--- a/mutt_notmuch.c
+++ b/mutt_notmuch.c
@@ -1728,7 +1728,7 @@ char *nm_get_description(CONTEXT *ctx)
 	BUFFY *p;
 
 	for (p = VirtIncoming; p; p = p->next)
-		if (p->path && p->desc && strcmp(p->path, ctx->path) == 0)
+		if (p->desc && strcmp(p->path, ctx->path) == 0)
 			return p->desc;
 
 	return NULL;
@@ -1742,7 +1742,7 @@ int nm_description_to_path(const char *desc, char *buf, size_t bufsz)
 		return -EINVAL;
 
 	for (p = VirtIncoming; p; p = p->next)
-		if (p->path && p->desc && strcmp(desc, p->desc) == 0) {
+		if (p->desc && strcmp(desc, p->desc) == 0) {
 			strncpy(buf, p->path, bufsz);
 			buf[bufsz - 1] = '\0';
 			return 0;


### PR DESCRIPTION
BUFFY declares path as a char array. Hence, p->path will always resolve
to a valid array location making the check redundant. It causes a
compiler warning. Hence, remove the redundant check to silence the
warning.