### PR TITLE
patch 1.5.24.aw.timeouthook.1 from http://wolfermann.org/mutt.html

### DIFF
--- a/PATCHES
+++ b/PATCHES
@@ -1,3 +1,4 @@
+patch-1.5.24.aw.timeouthook.1
 patch-quasi-delete-neo-git
 patch-progress-neo-git
 patch-status-color-neo-git

--- a/curs_main.c
+++ b/curs_main.c
@@ -949,8 +949,10 @@ int mutt_index_menu (void)
 
       dprint(4, (debugfile, "mutt_index_menu[%d]: Got op %d\n", __LINE__, op));
 
-      if (op == -1)
-	continue; /* either user abort or timeout */
+      if (op == -1) {
+        mutt_timeout_hook(".");
+ 	continue; /* either user abort or timeout */
+      }
 
       mutt_curs_set (1);
 

--- a/hook.c
+++ b/hook.c
@@ -154,7 +154,7 @@ int mutt_parse_hook (BUFFER *buf, BUFFER *s, unsigned long data, BUFFER *err)
 	ptr->rx.not == not &&
 	!mutt_strcmp (pattern.data, ptr->rx.pattern))
     {
-      if (data & (M_FOLDERHOOK | M_SENDHOOK | M_SEND2HOOK | M_MESSAGEHOOK | M_ACCOUNTHOOK | M_REPLYHOOK | M_CRYPTHOOK))
+      if (data & (M_FOLDERHOOK | M_SENDHOOK | M_SEND2HOOK | M_MESSAGEHOOK | M_ACCOUNTHOOK | M_REPLYHOOK | M_CRYPTHOOK | M_TIMEOUTHOOK))
       {
 	/* these hooks allow multiple commands with the same
 	 * pattern, so if we've already seen this pattern/command pair, just
@@ -506,6 +506,33 @@ LIST *mutt_crypt_hook (ADDRESS *adr)
   return _mutt_list_hook (adr->mailbox, M_CRYPTHOOK);
 }
 
+
+void mutt_timeout_hook (const char *chs)
+{
+  HOOK* hook;
+  BUFFER token;
+  BUFFER err;
+  char buf[STRING];
+
+  err.data = buf;
+  err.dsize = sizeof (buf);
+  memset (&token, 0, sizeof (token));
+
+  for (hook = Hooks; hook; hook = hook->next)
+  {
+    if (! (hook->command && (hook->type & M_TIMEOUTHOOK)))
+      continue;
+
+    if (mutt_parse_rc_line (hook->command, &token, &err) == -1)
+    {
+      FREE (&token.data);
+      mutt_error ("%s", err.data);
+      mutt_sleep (1);
+
+      return;
+    }
+  }
+}
 #ifdef USE_SOCKET
 void mutt_account_hook (const char* url)
 {

--- a/init.h
+++ b/init.h
@@ -4315,6 +4315,7 @@ const struct command_t Commands[] = {
   { "spam",		parse_spam_list,	M_SPAM },
   { "nospam",		parse_spam_list,	M_NOSPAM },
   { "subscribe",	parse_subscribe,	0 },
+  { "timeout-hook",	mutt_parse_hook,	M_TIMEOUTHOOK },
   { "toggle",		parse_set,		M_SET_INV },
   { "unalias",		parse_unalias,		0 },
   { "unalternative_order",parse_unlist,		UL &AlternativeOrderList },

--- a/mutt.h
+++ b/mutt.h
@@ -164,6 +164,7 @@ typedef enum
 #define M_APPENDHOOK	(1<<13)
 #define M_CLOSEHOOK	(1<<14)
 #endif
+#define M_TIMEOUTHOOK	(1<<15)
 
 /* tree characters for linearize_tree and print_enriched_string */
 #define M_TREE_LLCORNER		1

--- a/protos.h
+++ b/protos.h
@@ -154,6 +154,7 @@ const char *mutt_get_name (ADDRESS *);
 char *mutt_get_parameter (const char *, PARAMETER *);
 LIST *mutt_crypt_hook (ADDRESS *);
 char *mutt_make_date (char *, size_t);
+void mutt_timeout_hook (const char *);
 
 const char *mutt_make_version (void);
 


### PR DESCRIPTION
Adds a timeout-hook to allow arbitrary commands to run when the timer expires.  Original credit to: http://wolfermann.org/mutt.html

-----------

This patch implements a new hook that is called periodically when Mutt checks for new mail. To call the hook every minute add set `timeout=60` to your .muttrc.

Example: `timeout-hook . "exec sync-mailbox"`