### PR TITLE
Allow creating Distribution Tarballs with autogen sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ doc/stamp-doc-xml
 
 po/POTFILES
 
+.version
 aclocal.m4
 compile
 config.guess

--- a/Makefile.am
+++ b/Makefile.am
@@ -22,7 +22,7 @@ if BUILD_HCACHE
 HCVERSION = hcversion.h
 endif
 
-BUILT_SOURCES = keymap_defs.h patchlist.c reldate.h conststrings.c $(HCVERSION)
+BUILT_SOURCES = keymap_defs.h patchlist.c reldate.h conststrings.c hcachever.sh $(HCVERSION) $(top_srcdir)/.version
 
 bin_PROGRAMS = mutt $(DOTLOCK_TARGET) $(PGPAUX_TARGET)
 mutt_SOURCES = \
@@ -65,21 +65,22 @@ EXTRA_mutt_SOURCES = account.c bcache.c compress.c crypt-gpgme.c crypt-mod-pgp-c
 	bcache.h browser.h hcache.h mbyte.h mutt_idna.h remailer.h url.h
 
 EXTRA_DIST = COPYRIGHT GPL OPS OPS.PGP OPS.CRYPT OPS.SMIME TODO UPDATING \
-	configure account.h \
+	account.h \
 	attach.h buffy.h charset.h compress.h copy.h crypthash.h dotlock.h functions.h gen_defs \
 	globals.h hash.h history.h init.h keymap.h mutt_crypt.h \
 	mailbox.h mapping.h md5.h mime.h mutt.h mutt_curses.h mutt_menu.h \
 	mutt_regex.h mutt_sasl.h mutt_socket.h mutt_ssl.h mutt_tunnel.h \
 	mx.h pager.h pgp.h pop.h protos.h rfc1524.h rfc2047.h \
-	rfc2231.h rfc822.h rfc3676.h sha1.h sort.h mime.types VERSION prepare \
+	rfc2231.h rfc822.h rfc3676.h sha1.h sort.h mime.types VERSION \
 	nntp.h ChangeLog.nntp \
 	_regex.h OPS.MIX README.SECURITY remailer.c remailer.h browser.h \
 	mbyte.h lib.h extlib.c pgpewrap.c smime_keys.pl pgplib.h \
-	README.SSL smime.h group.h \
-	pgppacket.h depcomp ascii.h BEWARE PATCHES patchlist.sh \
-	ChangeLog mkchangelog.sh mutt_idna.h sidebar.h OPS.SIDEBAR \
+	README.SSL README.md README.neomutt smime.h group.h \
+	pgppacket.h depcomp ascii.h PATCHES patchlist.sh \
+	ChangeLog ChangeLog.neomutt mutt_idna.h sidebar.h OPS.SIDEBAR \
 	snprintf.c regex.c crypt-gpgme.h hcachever.sh.in sys_socket.h \
-	txt2c.c txt2c.sh version.sh check_sec.sh version.h
+	txt2c.c txt2c.sh version.sh version.h \
+	$(top_srcdir)/.version git-version-gen
 
 EXTRA_SCRIPTS = smime_keys
 
@@ -89,7 +90,7 @@ mutt_LDADD += $(NOTMUCH_LIBS)
 endif
 
 # kz
-EXTRA_DIST += UPDATING.kz README.notmuch OPS.NOTMUCH
+EXTRA_DIST += UPDATING.kz OPS.NOTMUCH
 
 
 mutt_dotlock_SOURCES = mutt_dotlock.c
@@ -133,6 +134,12 @@ ACLOCAL_AMFLAGS = -I m4
 
 LDADD = $(LIBOBJS) $(INTLLIBS)
 
+$(top_srcdir)/.version:
+	echo $(VERSION) > $@-t && mv $@-t $@
+
+dist-hook:
+	echo $(VERSION) > $(distdir)/.tarball-version
+
 smime_keys: $(srcdir)/smime_keys.pl
 	cp $(srcdir)/smime_keys.pl smime_keys
 	chmod +x smime_keys
@@ -146,7 +153,7 @@ keymap_alldefs.h: $(srcdir)/OPS $(srcdir)/OPS.SIDEBAR $(srcdir)/OPS.NOTMUCH $(sr
 		$(srcdir)/OPS.MIX $(srcdir)/OPS.CRYPT $(srcdir)/OPS.SMIME \
 			> keymap_alldefs.h
 
-reldate.h: $(top_srcdir)/ChangeLog.neomutt
+reldate.h:
 	date=`head -n 1 $(top_srcdir)/ChangeLog.neomutt | LC_ALL=C cut -b 1-10` && \
 	echo 'const char *ReleaseDate = "'$$date'";' > reldate.h.tmp; \
 	cmp -s reldate.h.tmp reldate.h || cp reldate.h.tmp reldate.h; \

--- a/complete.c
+++ b/complete.c
@@ -109,7 +109,7 @@ int mutt_complete (char *s, size_t slen)
       }
     }
 
-    strcpy (s, filepart);
+    strfcpy (s, filepart, slen);
     return (init ? 0 : -1);
   }
 #endif

--- a/compress.c
+++ b/compress.c
@@ -557,7 +557,7 @@ comp_open_read (CONTEXT *ctx)
 
 	endwin();
 	fflush (stdout);
-	sprintf(echo_cmd,_("echo Decompressing %s..."),ctx->realpath);
+	sprintf(echo_cmd,_("echo Decompressing %s..."),ctx->realpath); /* __SPRINTF_CHECKED__ */
 	mutt_system(echo_cmd);
 	rc = mutt_system (cmd);
 	unlock_mailbox (ctx, fp);
@@ -675,7 +675,7 @@ comp_sync (CONTEXT *ctx)
 
 	endwin();
 	fflush (stdout);
-	sprintf(echo_cmd,_("echo Compressing %s..."), ctx->realpath);
+	sprintf(echo_cmd,_("echo Compressing %s..."), ctx->realpath); /* __SPRINTF_CHECKED__ */
 	mutt_system(echo_cmd);
 	if (mutt_system (cmd) != 0) {
 		mutt_any_key_to_continue (NULL);
@@ -796,9 +796,9 @@ comp_slow_close (CONTEXT *ctx)
 	fflush (stdout);
 
 	if (append == ci->close) {
-		sprintf(echo_cmd,_("echo Compressing %s..."), ctx->realpath);
+		sprintf(echo_cmd,_("echo Compressing %s..."), ctx->realpath); /* __SPRINTF_CHECKED__ */
 	} else {
-		sprintf(echo_cmd,_("echo Compressed-appending to %s..."), ctx->realpath);
+		sprintf(echo_cmd,_("echo Compressed-appending to %s..."), ctx->realpath); /* __SPRINTF_CHECKED__ */
 	}
 	mutt_system(echo_cmd);
 

--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@ dnl !!! TO DUMP THEIR RESULTS WHEN MUTT -V IS CALLED            !!!
 CFLAGS=$CFLAGS
 LDFLAGS=$LDFLAGS
 
-AC_INIT([NeoMutt], [m4_esyscmd(./git-version-gen --prefix "neomutt-" .tarball-version)], [https://github.com/neomutt/neomutt/issues], [neomutt], [http://www.neomutt.org])
+AC_INIT([NeoMutt], m4_esyscmd(./git-version-gen --prefix "neomutt-" .tarball-version), [https://github.com/neomutt/neomutt/issues], [neomutt], [http://www.neomutt.org])
 AC_CONFIG_SRCDIR(mutt.h)
 AM_INIT_AUTOMAKE
 AC_CONFIG_HEADERS([config.h])

--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@ dnl !!! TO DUMP THEIR RESULTS WHEN MUTT -V IS CALLED            !!!
 CFLAGS=$CFLAGS
 LDFLAGS=$LDFLAGS
 
-AC_INIT([NeoMutt], [m4_esyscmd(tr -d \\n <VERSION)], [https://github.com/neomutt/neomutt/issues], [mutt], [http://www.neomutt.org])
+AC_INIT([NeoMutt], [m4_esyscmd(./git-version-gen --prefix "neomutt-" .tarball-version)], [https://github.com/neomutt/neomutt/issues], [neomutt], [http://www.neomutt.org])
 AC_CONFIG_SRCDIR(mutt.h)
 AM_INIT_AUTOMAKE
 AC_CONFIG_HEADERS([config.h])

--- a/contrib/Makefile.am
+++ b/contrib/Makefile.am
@@ -11,12 +11,14 @@ EXTRA_DIST = language.txt language50.txt  \
 	patch.slang-1.2.2.keypad.1	\
 	$(SAMPLES) \
 	iconv/README \
-	iconv/make.sh
+	iconv/make.sh \
+	vim-keybindings \
+	keybase
 
 CONTRIB_DIRS = vim-keybindings keybase
 
 install-data-local:
-	$(MKDIR_P) $(DESTDIR)$(docdir)/samples $(DESTDIR)$(docdir)/samples/iconv
+	$(INSTALL) -d -m 755 $(DESTDIR)$(docdir)/samples $(DESTDIR)$(docdir)/samples/iconv
 	for f in $(SAMPLES) ; do \
 		$(INSTALL) -m 644 $(srcdir)/$$f $(DESTDIR)$(docdir)/samples ;	\
 	done
@@ -24,7 +26,12 @@ install-data-local:
 		$(INSTALL) -m 644 $$f $(DESTDIR)$(docdir)/samples/iconv	  ;	\
 	done
 	for d in $(CONTRIB_DIRS); do						\
-		cp -r $(srcdir)/$$d $(DESTDIR)$(docdir);			\
+		echo "Installing $$d" ;	\
+		$(INSTALL) -d -m 755 $(DESTDIR)$(docdir)/$$d ;\
+		for f in $(srcdir)/$$d/*; do	\
+			echo "Installing $$f" ;	\
+			$(INSTALL) -m 644 $$f $(DESTDIR)$(docdir)/$$d ; \
+		done \
 	done
 
 uninstall-local:

--- a/copy.c
+++ b/copy.c
@@ -451,7 +451,7 @@ mutt_copy_header (FILE *in, HEADER *h, FILE *out, int flags, const char *prefix)
           (option(OPTKEYWORDSLEGACY) || option(OPTKEYWORDSSTANDARD) == 0))
       {
         mutt_labels(buf, sizeof(buf), h->env, XlabelDelim);
-        tmp = strdup(buf);
+        tmp = safe_strdup(buf);
         rfc2047_encode_string(&tmp);
         fail = fprintf(out, "X-Label: %s\n", tmp) != 10 + strlen(tmp);
         FREE(&tmp);
@@ -461,7 +461,7 @@ mutt_copy_header (FILE *in, HEADER *h, FILE *out, int flags, const char *prefix)
           (option(OPTKEYWORDSLEGACY) || option(OPTKEYWORDSSTANDARD) == 0))
       {
         mutt_labels(buf, sizeof(buf), h->env, " ");
-        tmp = strdup(buf);
+        tmp = safe_strdup(buf);
         rfc2047_encode_string(&tmp);
         fail = fprintf(out, "X-Keywords: %s\n", tmp) != 13 + strlen(tmp);
         FREE(&tmp);
@@ -471,7 +471,7 @@ mutt_copy_header (FILE *in, HEADER *h, FILE *out, int flags, const char *prefix)
           (option(OPTKEYWORDSLEGACY) || option(OPTKEYWORDSSTANDARD) == 0))
       {
         mutt_labels(buf, sizeof(buf), h->env, " ");
-        tmp = strdup(buf);
+        tmp = safe_strdup(buf);
         rfc2047_encode_string(&tmp);
         fail = fprintf(out, "X-Mozilla-Keys: %s\n", tmp) != 17 + strlen(tmp);
         FREE(&tmp);
@@ -481,7 +481,7 @@ mutt_copy_header (FILE *in, HEADER *h, FILE *out, int flags, const char *prefix)
                         option(OPTKEYWORDSSTANDARD)))
       {
         mutt_labels(buf, sizeof(buf), h->env, NULL);
-        tmp = strdup(buf);
+        tmp = safe_strdup(buf);
         rfc2047_encode_string(&tmp);
         fail = fprintf(out, "Keywords: %s\n", tmp) != 11 + strlen(tmp);
         FREE(&tmp);

--- a/crypt.c
+++ b/crypt.c
@@ -243,7 +243,7 @@ int mutt_protect (HEADER *msg, char *keylist)
  		 
 			  tmp_pbody = crypt_smime_build_smime_entity (tmp_smime_pbody, new_keylist);
 			  if (new_keylist != keylist)
-				  safe_free((void **)&new_keylist);
+				  FREE(&new_keylist);
 			  
 			  if (!tmp_pbody)
       {

--- a/curs_main.c
+++ b/curs_main.c
@@ -611,7 +611,7 @@ mutt_draw_statusline (int cols, const char *buf, int buflen)
 		mutt_paddstr (cols - width, "");
 	}
 dsl_finish:
-	safe_free (&syntax);
+	FREE(&syntax);
 }
 
 static int main_change_folder(MUTTMENU *menu, int op, char *buf, size_t bufsz,

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -36,8 +36,7 @@ EXTRA_DIST = dotlock.man		\
 
 CHUNKED_DOCFILES = index.html intro.html gettingstarted.html \
 	configuration.html mimesupport.html advancedusage.html \
-	optionalfeatures.html security.html tuning.html reference.html miscellany.html \
-	compressed-folders.html
+	optionalfeatures.html security.html tuning.html reference.html miscellany.html
 
 HTML_DOCFILES = manual.html $(CHUNKED_DOCFILES)
 
@@ -74,9 +73,6 @@ install-data-local: makedoc-all instdoc
 	./instdoc $(srcdir)/mbox.man $(DESTDIR)$(mandir)/man5/mbox.5
 	./instdoc $(srcdir)/mmdf.man $(DESTDIR)$(mandir)/man5/mmdf.5
 	$(MKDIR_P) $(DESTDIR)$(docdir)
-	for f in $(topsrcdir_DOCFILES) ; do \
-		$(INSTALL) -m 644 $(top_srcdir)/$$f $(DESTDIR)$(docdir) ; \
-	done
 	for f in $(srcdir_DOCFILES) ; do \
 		$(INSTALL) -m 644 $(srcdir)/$$f $(DESTDIR)$(docdir) ; \
 	done
@@ -194,7 +190,7 @@ smime_keys.1: $(srcdir)/smime_keys.man
 
 stamp-doc-xml: makedoc$(EXEEXT) $(top_srcdir)/init.h \
                manual.xml.head $(top_srcdir)/functions.h $(top_srcdir)/OPS* manual.xml.tail \
-               $(srcdir)/gen-map-doc $(top_srcdir)/VERSION $(top_srcdir)/ChangeLog.neomutt
+               $(srcdir)/gen-map-doc $(top_srcdir)/VERSION
 	( date=`head -n 1 $(top_srcdir)/ChangeLog.neomutt | LC_ALL=C cut -b 1-10` && \
 	  sed -e "s/@VERSION\@/`$(top_srcdir)/version.sh` ($$date)/" $(srcdir)/manual.xml.head && \
 	  $(MAKEDOC_CPP) $(top_srcdir)/init.h | ./makedoc$(EXEEXT) -s && \

--- a/git-version-gen
+++ b/git-version-gen
@@ -1,0 +1,226 @@
+#!/bin/sh
+# Print a version string.
+scriptversion=2016-05-08.18; # UTC
+
+# Copyright (C) 2007-2016 Free Software Foundation, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# This script is derived from GIT-VERSION-GEN from GIT: http://git.or.cz/.
+# It may be run two ways:
+# - from a git repository in which the "git describe" command below
+#   produces useful output (thus requiring at least one signed tag)
+# - from a non-git-repo directory containing a .tarball-version file, which
+#   presumes this script is invoked like "./git-version-gen .tarball-version".
+
+# In order to use intra-version strings in your project, you will need two
+# separate generated version string files:
+#
+# .tarball-version - present only in a distribution tarball, and not in
+#   a checked-out repository.  Created with contents that were learned at
+#   the last time autoconf was run, and used by git-version-gen.  Must not
+#   be present in either $(srcdir) or $(builddir) for git-version-gen to
+#   give accurate answers during normal development with a checked out tree,
+#   but must be present in a tarball when there is no version control system.
+#   Therefore, it cannot be used in any dependencies.  GNUmakefile has
+#   hooks to force a reconfigure at distribution time to get the value
+#   correct, without penalizing normal development with extra reconfigures.
+#
+# .version - present in a checked-out repository and in a distribution
+#   tarball.  Usable in dependencies, particularly for files that don't
+#   want to depend on config.h but do want to track version changes.
+#   Delete this file prior to any autoconf run where you want to rebuild
+#   files to pick up a version string change; and leave it stale to
+#   minimize rebuild time after unrelated changes to configure sources.
+#
+# As with any generated file in a VC'd directory, you should add
+# /.version to .gitignore, so that you don't accidentally commit it.
+# .tarball-version is never generated in a VC'd directory, so needn't
+# be listed there.
+#
+# Use the following line in your configure.ac, so that $(VERSION) will
+# automatically be up-to-date each time configure is run (and note that
+# since configure.ac no longer includes a version string, Makefile rules
+# should not depend on configure.ac for version updates).
+#
+# AC_INIT([GNU project],
+#         m4_esyscmd([build-aux/git-version-gen .tarball-version]),
+#         [bug-project@example])
+#
+# Then use the following lines in your Makefile.am, so that .version
+# will be present for dependencies, and so that .version and
+# .tarball-version will exist in distribution tarballs.
+#
+# EXTRA_DIST = $(top_srcdir)/.version
+# BUILT_SOURCES = $(top_srcdir)/.version
+# $(top_srcdir)/.version:
+#	echo $(VERSION) > $@-t && mv $@-t $@
+# dist-hook:
+#	echo $(VERSION) > $(distdir)/.tarball-version
+
+
+me=$0
+
+version="git-version-gen $scriptversion
+
+Copyright 2011 Free Software Foundation, Inc.
+There is NO warranty.  You may redistribute this software
+under the terms of the GNU General Public License.
+For more information about these matters, see the files named COPYING."
+
+usage="\
+Usage: $me [OPTION]... \$srcdir/.tarball-version [TAG-NORMALIZATION-SED-SCRIPT]
+Print a version string.
+
+Options:
+
+   --prefix PREFIX    prefix of git tags (default 'v')
+   --fallback VERSION
+                      fallback version to use if \"git --version\" fails
+
+   --help             display this help and exit
+   --version          output version information and exit
+
+Running without arguments will suffice in most cases."
+
+prefix=v
+fallback=
+
+while test $# -gt 0; do
+  case $1 in
+    --help) echo "$usage"; exit 0;;
+    --version) echo "$version"; exit 0;;
+    --prefix) shift; prefix=${1?};;
+    --fallback) shift; fallback=${1?};;
+    -*)
+      echo "$0: Unknown option '$1'." >&2
+      echo "$0: Try '--help' for more information." >&2
+      exit 1;;
+    *)
+      if test "x$tarball_version_file" = x; then
+        tarball_version_file="$1"
+      elif test "x$tag_sed_script" = x; then
+        tag_sed_script="$1"
+      else
+        echo "$0: extra non-option argument '$1'." >&2
+        exit 1
+      fi;;
+  esac
+  shift
+done
+
+if test "x$tarball_version_file" = x; then
+    echo "$usage"
+    exit 1
+fi
+
+tag_sed_script="${tag_sed_script:-s/x/x/}"
+
+nl='
+'
+
+# Avoid meddling by environment variable of the same name.
+v=
+v_from_git=
+
+# First see if there is a tarball-only version file.
+# then try "git describe", then default.
+if test -f $tarball_version_file
+then
+    v=`cat $tarball_version_file` || v=
+    case $v in
+        *$nl*) v= ;; # reject multi-line output
+        [0-9]*) ;;
+        *) v= ;;
+    esac
+    test "x$v" = x \
+        && echo "$0: WARNING: $tarball_version_file is missing or damaged" 1>&2
+fi
+
+if test "x$v" != x
+then
+    : # use $v
+# Otherwise, if there is at least one git commit involving the working
+# directory, and "git describe" output looks sensible, use that to
+# derive a version string.
+elif test "`git log -1 --pretty=format:x . 2>&1`" = x \
+    && v=`git describe --abbrev=4 --match="$prefix*" HEAD 2>/dev/null \
+          || git describe --abbrev=4 HEAD 2>/dev/null` \
+    && v=`printf '%s\n' "$v" | sed "$tag_sed_script"` \
+    && case $v in
+         $prefix[0-9]*) ;;
+         *) (exit 1) ;;
+       esac
+then
+    # Is this a new git that lists number of commits since the last
+    # tag or the previous older version that did not?
+    #   Newer: v6.10-77-g0f8faeb
+    #   Older: v6.10-g0f8faeb
+    case $v in
+        *-*-*) : git describe is okay three part flavor ;;
+        *-*)
+            : git describe is older two part flavor
+            # Recreate the number of commits and rewrite such that the
+            # result is the same as if we were using the newer version
+            # of git describe.
+            vtag=`echo "$v" | sed 's/-.*//'`
+            commit_list=`git rev-list "$vtag"..HEAD 2>/dev/null` \
+                || { commit_list=failed;
+                     echo "$0: WARNING: git rev-list failed" 1>&2; }
+            numcommits=`echo "$commit_list" | wc -l`
+            v=`echo "$v" | sed "s/\(.*\)-\(.*\)/\1-$numcommits-\2/"`;
+            test "$commit_list" = failed && v=UNKNOWN
+            ;;
+    esac
+
+    # Change the first '-' to a '.', so version-comparing tools work properly.
+    # Remove the "g" in git describe's output string, to save a byte.
+    v=`echo "$v" | sed 's/-/./;s/\(.*\)-g/\1-/'`;
+    v_from_git=1
+elif test "x$fallback" = x || git --version >/dev/null 2>&1; then
+    v=UNKNOWN
+else
+    v=$fallback
+fi
+
+v=`echo "$v" |sed "s/^$prefix//"`
+
+# Test whether to append the "-dirty" suffix only if the version
+# string we're using came from git.  I.e., skip the test if it's "UNKNOWN"
+# or if it came from .tarball-version.
+if test "x$v_from_git" != x; then
+  # Don't declare a version "dirty" merely because a time stamp has changed.
+  git update-index --refresh > /dev/null 2>&1
+
+  dirty=`exec 2>/dev/null;git diff-index --name-only HEAD` || dirty=
+  case "$dirty" in
+      '') ;;
+      *) # Append the suffix only if there isn't one already.
+          case $v in
+            *-dirty) ;;
+            *) v="$v-dirty" ;;
+          esac ;;
+  esac
+fi
+
+# Omit the trailing newline, so that m4_esyscmd can use the result directly.
+printf %s "$v"
+
+# Local variables:
+# eval: (add-hook 'write-file-hooks 'time-stamp)
+# time-stamp-start: "scriptversion="
+# time-stamp-format: "%:y-%02m-%02d.%02H"
+# time-stamp-time-zone: "UTC0"
+# time-stamp-end: "; # UTC"
+# End:

--- a/hcache.c
+++ b/hcache.c
@@ -805,10 +805,8 @@ mutt_hcache_fetch_raw (header_cache_t *h, const char *filename,
   }
   /* Caller frees the data we return, so I MUST make a copy of it */
 
-  char *d = malloc(data.mv_size);
-  if (d) {
-    memcpy(d, data.mv_data, data.mv_size);
-  }
+  char *d = safe_malloc(data.mv_size);
+  memcpy(d, data.mv_data, data.mv_size);
   mdb_txn_reset(h->txn);
 
   return d;

--- a/newsrc.c
+++ b/newsrc.c
@@ -54,10 +54,11 @@ static NNTP_DATA *nntp_data_find (NNTP_SERVER *nserv, const char *group)
 
   if (!nntp_data)
   {
+    int len = strlen (group) + 1;
     /* create NNTP_DATA structure and add it to hash */
-    nntp_data = safe_calloc (1, sizeof (NNTP_DATA) + strlen (group) + 1);
+    nntp_data = safe_calloc (1, sizeof (NNTP_DATA) + len);
     nntp_data->group = (char *)nntp_data + sizeof (NNTP_DATA);
-    strcpy (nntp_data->group, group);
+    strfcpy (nntp_data->group, group, len);
     nntp_data->nserv = nserv;
     nntp_data->deleted = 1;
     if (nserv->groups_hash->nelem < nserv->groups_hash->curnelem * 2)
@@ -338,7 +339,7 @@ static int update_file (char *filename, char *buf)
   while (1)
   {
     snprintf (tmpfile, sizeof (tmpfile), "%s.tmp", filename);
-    fp = fopen (tmpfile, "w");
+    fp = safe_fopen (tmpfile, "w");
     if (!fp)
     {
       mutt_perror (tmpfile);

--- a/nntp.c
+++ b/nntp.c
@@ -289,8 +289,9 @@ static int nntp_attempt_features (NNTP_SERVER *nserv)
 	    off = colon + 1 - nserv->overview_fmt;
 	  if (!strcasecmp (nserv->overview_fmt + b, "Bytes:"))
 	  {
-	    strcpy (nserv->overview_fmt + b, "Content-Length:");
-	    off = b + strlen (nserv->overview_fmt + b);
+            int len = strlen (nserv->overview_fmt + b);
+	    strfcpy (nserv->overview_fmt + b, "Content-Length:", len + 1);
+	    off = b + len;
 	  }
 	  nserv->overview_fmt[off++] = '\0';
 	  b = off;

--- a/parse.c
+++ b/parse.c
@@ -1361,7 +1361,7 @@ int mutt_parse_rfc822_line (ENVELOPE *e, HEADER *hdr, char *line, char *p, short
   if (kwtype)
   {
     char *last, *label;
-    char *text = strdup(p);
+    char *text = safe_strdup(p);
     char *sep;
 
     if (kwtype == M_KEYWORDS)

--- a/sidebar.c
+++ b/sidebar.c
@@ -1230,7 +1230,7 @@ mutt_sb_toggle_virtual (void)
 	BUFFY *b;
 
 	EntryCount = 0;
-	FREE(Entries);
+	FREE(&Entries);
 	for (b = get_incoming(); b; b = b->next)
 		mutt_sb_notify_mailbox (b, 1);
 

--- a/strndup.c
+++ b/strndup.c
@@ -11,7 +11,7 @@
 char *strndup(const char *s, size_t n)
 {
 	size_t len = strnlen(s, n);
-	char *new = (char *) malloc((len + 1) * sizeof(char));
+	char *new = safe_malloc((len + 1) * sizeof(char));
 	if (!new)
 		return NULL;
 	new[len] = '\0';


### PR DESCRIPTION
With this commit `make dist` works again. The following changes were
made:
  * Change how versioning is done. We now use the `git-version-gen`
  script from gnulib to generate a tarball version based on the latest
  git tag.
  * Ignored files in distribution: Some autogenerated files don't need to be in the distribution tarball:
    * hcachever.sh
    * mkchangelog.sh
    * prepare (Doesn't need to be since tarballs don't use it)
    * BEWARE (Is to scare developers, not users)
    * check_sec.sh (For devs to test)
    * README.notmuch (Installed as a generated file with other READMEs)
  * Added files to the tarball:
    * README.md
    * README.neomutt
    * ChangeLog.neomutt
    * .version
  * Fixed various issues preventing `make dist` from completing