### PR TITLE
Fix the NeoMutt version string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,10 +47,10 @@ mutt
 mutt_dotlock
 mutt_dotlock.c
 mutt_md5
+oldmutt_ver.h
 patchlist.c
 pgpewrap
 pgpring
-reldate.h
 smime_keys
 stamp-h1
 txt2c

--- a/Makefile.am
+++ b/Makefile.am
@@ -18,7 +18,7 @@ if BUILD_HCACHE
 HCVERSION = hcversion.h
 endif
 
-BUILT_SOURCES = keymap_defs.h patchlist.c reldate.h conststrings.c hcachever.sh $(HCVERSION) $(top_srcdir)/.version
+BUILT_SOURCES = keymap_defs.h patchlist.c oldmutt_ver.h conststrings.c hcachever.sh $(HCVERSION) $(top_srcdir)/.version
 
 bin_PROGRAMS = mutt $(DOTLOCK_TARGET) $(PGPAUX_TARGET)
 mutt_SOURCES = \
@@ -150,11 +150,16 @@ keymap_alldefs.h: $(srcdir)/OPS $(srcdir)/OPS.SIDEBAR $(srcdir)/OPS.NOTMUCH $(sr
 		$(srcdir)/OPS.MIX $(srcdir)/OPS.CRYPT $(srcdir)/OPS.SMIME \
 			> keymap_alldefs.h
 
-reldate.h:
-	date=`head -n 1 $(top_srcdir)/ChangeLog.neomutt | LC_ALL=C cut -b 1-10` && \
-	echo 'const char *ReleaseDate = "'$$date'";' > reldate.h.tmp; \
-	cmp -s reldate.h.tmp reldate.h || cp reldate.h.tmp reldate.h; \
-	rm reldate.h.tmp
+oldmutt_ver.h:
+	version=`git tag | grep ^mutt- | sort -V | tail -1 | LC_ALL=C cut -b 6-` && \
+	echo 'const char *OldMuttVer = "'$$version'";' > oldmutt_ver.h.tmp; \
+	cmp -s oldmutt_ver.h.tmp oldmutt_ver.h || mv oldmutt_ver.h.tmp oldmutt_ver.h
+
+# reldate.h:
+# 	date=`head -n 1 $(top_srcdir)/ChangeLog.neomutt | LC_ALL=C cut -b 1-10` && \
+# 	echo 'const char *ReleaseDate = "'$$date'";' > reldate.h.tmp; \
+# 	cmp -s reldate.h.tmp reldate.h || cp reldate.h.tmp reldate.h; \
+# 	rm reldate.h.tmp
 
 # The '#undef ENABLE_NLS' is to work around an automake ordering issue:
 # BUILT_SOURCES are processed before SUBDIRS.

--- a/commands.c
+++ b/commands.c
@@ -942,7 +942,7 @@ int mutt_save_message (HEADER *h, int delete,
 
 void mutt_version (void)
 {
-  mutt_message ("NeoMutt %s (%s)", PACKAGE_VERSION, ReleaseDate);
+  mutt_message ("NeoMutt %s (%s)", PACKAGE_VERSION, OldMuttVer);
 }
 
 void mutt_edit_content_type (HEADER *h, BODY *b, FILE *fp)

--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@ dnl !!! TO DUMP THEIR RESULTS WHEN MUTT -V IS CALLED            !!!
 CFLAGS=$CFLAGS
 LDFLAGS=$LDFLAGS
 
-AC_INIT([NeoMutt], m4_esyscmd(./git-version-gen --prefix "neomutt-" .tarball-version), [neomutt-devel@neomutt.org], [neomutt], [http://www.neomutt.org])
+AC_INIT([NeoMutt], m4_esyscmd(./git-version-gen .tarball-version 's/neomutt-/v/g'), [neomutt-devel@neomutt.org], [neomutt], [http://www.neomutt.org])
 AC_CONFIG_SRCDIR(mutt.h)
 AM_INIT_AUTOMAKE
 AC_CONFIG_HEADERS([config.h])

--- a/dotlock.c
+++ b/dotlock.c
@@ -53,7 +53,7 @@
 #endif
 
 #ifdef DL_STANDALONE
-# include "reldate.h"
+# include "oldmutt_ver.h"
 #endif
 
 #define MAXLINKS 1024 /* maximum link depth */
@@ -339,7 +339,7 @@ END_PRIVILEGED (void)
 static void 
 usage (const char *av0)
 {
-  fprintf (stderr, "dotlock [NeoMutt %s (%s)]\n", PACKAGE_VERSION, ReleaseDate);
+  fprintf (stderr, "dotlock [NeoMutt %s (%s)]\n", PACKAGE_VERSION, OldMuttVer);
   fprintf (stderr, "usage: %s [-t|-f|-u|-d] [-p] [-r <retries>] file\n",
 	  av0);
 

--- a/globals.h
+++ b/globals.h
@@ -172,7 +172,7 @@ WHERE char *CurrentFolder;
 WHERE char *LastFolder;
 
 
-WHERE const char *ReleaseDate;
+WHERE const char *OldMuttVer;
 
 WHERE HASH *Groups;
 WHERE HASH *Labels;
@@ -339,5 +339,5 @@ extern const char * const Months[];
 #include "buffy.h"
 #include "sort.h"
 #include "mutt_crypt.h"
-#include "reldate.h"
+#include "oldmutt_ver.h"
 #endif /* MAIN_C */

--- a/init.c
+++ b/init.c
@@ -3157,8 +3157,8 @@ static void start_debug (void)
   if ((debugfile = safe_fopen(buf, "w")) != NULL)
   {
     setbuf (debugfile, NULL); /* don't buffer the debugging output! */
-    dprint(1,(debugfile,"Mutt/%s (%s) debugging at level %d\n",
-				PACKAGE_VERSION, ReleaseDate, debuglevel));
+    dprint(1,(debugfile,"NeoMutt/%s (%s) debugging at level %d\n",
+				PACKAGE_VERSION, OldMuttVer, debuglevel));
   }
 }
 #endif

--- a/muttlib.c
+++ b/muttlib.c
@@ -1988,7 +1988,7 @@ const char *mutt_make_version (void)
 {
   static char vstring[STRING];
   snprintf (vstring, sizeof (vstring), "NeoMutt %s (%s)",
-	    PACKAGE_VERSION, ReleaseDate);
+	    PACKAGE_VERSION, OldMuttVer);
   return vstring;
 }
 

--- a/sendlib.c
+++ b/sendlib.c
@@ -2107,7 +2107,7 @@ int mutt_write_rfc822_header (FILE *fp, ENVELOPE *env, BODY *attach,
   if (mode == 0 && !privacy && option (OPTXMAILER) && !has_agent)
   {
     /* Add a vanity header */
-    fprintf (fp, "User-Agent: Mutt/%s (%s)\n", PACKAGE_VERSION, ReleaseDate);
+    fprintf (fp, "User-Agent: NeoMutt/%s (%s)\n", PACKAGE_VERSION, OldMuttVer);
   }
 
   return (ferror (fp) == 0 ? 0 : -1);


### PR DESCRIPTION
The original Mutt version string came with only a version number.
However, in NeoMutt, the versioning is done solely on the release date.
Hence, change how the version string is printed to reflect this change.