### PR TITLE
Fix buffer overrun in search for attach keyword

### DIFF
--- a/send.c
+++ b/send.c
@@ -1247,7 +1247,7 @@ mutt_search_attach_keyword (char *filename)
   char *lowerKeyword = safe_malloc (klen);
   char *inputline = safe_malloc (LONG_STRING);
   int i;
-  for (i = 0; i <= klen; i++)
+  for (i = 0; i < klen; i++)
     lowerKeyword[i] = tolower (AttachKeyword[i]);
 
   int found = 0;


### PR DESCRIPTION
Regression introduced by 395911ea4c20e57f121cb169e0f2083ff5e1ae33.

In the process of tidying

```c
char* lowerKeyword = malloc(strlen(AttachKeyword)+1);
...
for (i=0; i <= strlen(AttachKeyword); i++)
```

was changed to

```c
int klen = mutt_strlen (AttachKeyword) + 1;
...
char *lowerKeyword = safe_malloc (klen);
...
for (i = 0; i <= klen; i++)
```

Now that klen is the actual allocation length, instead of the string
length, the loop comparison needs to be adjusted accordingly.