### PR TITLE
Add Kyoto Cabinet header cache

### DIFF
--- a/PATCHES
+++ b/PATCHES
@@ -8,6 +8,7 @@ patch-ifdef-neomutt
 patch-index-color-neomutt
 patch-initials-neomutt
 patch-keywords-neomutt
+patch-kyoto-neomutt
 patch-limit-current-thread-neomutt
 patch-lmdb-neomutt
 patch-multiple-fcc-neomutt

--- a/configure.ac
+++ b/configure.ac
@@ -903,6 +903,7 @@ db_requested=auto
 hcache_db_used=no
 AC_ARG_ENABLE(hcache, AS_HELP_STRING([--enable-hcache],[Enable header caching]))
 AC_ARG_WITH(tokyocabinet, AS_HELP_STRING([--without-tokyocabinet],[Don't use tokyocabinet even if it is available]))
+AC_ARG_WITH(kyotocabinet, AS_HELP_STRING([--without-kyotocabinet],[Don't use kyotocabinet even if it is available]))
 AC_ARG_WITH(qdbm, AS_HELP_STRING([--without-qdbm],[Don't use qdbm even if it is available]))
 AC_ARG_WITH(gdbm, AS_HELP_STRING([--without-gdbm],[Don't use gdbm even if it is available]))
 AC_ARG_WITH(bdb, AS_HELP_STRING([--with-bdb@<:@=DIR@:>@],[Use BerkeleyDB4 if gdbm is not available]))
@@ -923,6 +924,15 @@ then
     if test -n "$with_tokyocabinet" && test "$with_tokyocabinet" != "no"
     then
       db_requested=TokyoCabinet
+    fi
+    if test -n "$with_kyotocabinet" && test "$with_kyotocabinet" != "no"
+    then
+      if test "$db_requested" != "auto"
+      then
+        AC_MSG_ERROR([more than one header cache engine requested.])
+      else
+        db_requested=KyotoCabinet
+      fi
     fi
     if test -n "$with_qdbm" && test "$with_qdbm" != "no"
     then
@@ -981,6 +991,29 @@ then
       if test "$db_requested" != auto && test "$db_found" != "$db_requested"
       then
         AC_MSG_ERROR([Tokyo Cabinet could not be used. Check config.log for details.])
+      fi
+    fi
+
+    dnl -- Kyoto Cabinet --
+    if test "$with_kyotocabinet" != "no" \
+        && test "$db_requested" = auto -o "$db_requested" = KyotoCabinet
+    then
+      if test -n "$with_kyotocabinet" && test "$with_kyotocabinet" != "yes"
+      then
+        CPPFLAGS="$CPPFLAGS -I$with_kyotocabinet/include"
+        LDFLAGS="$LDFLAGS -L$with_kyotocabinet/lib"
+      fi
+
+      AC_CHECK_HEADER(kclangc.h,
+      AC_CHECK_LIB(kyotocabinet, kcdbopen,
+        [MUTTLIBS="$MUTTLIBS -lkyotocabinet"
+         AC_DEFINE(HAVE_KC, 1, [Kyoto Cabinet Support])
+         db_found=KyotoCabinet],
+        [CPPFLAGS="$OLDCPPFLAGS"
+         LDFLAGS="$OLDLDFLAGS"]))
+      if test "$db_requested" != auto && test "$db_found" != "$db_requested"
+      then
+        AC_MSG_ERROR([Kyoto Cabinet could not be used. Check config.log for details.])
       fi
     fi
 
@@ -1134,7 +1167,7 @@ then
 
     if test $db_found = no
     then
-        AC_MSG_ERROR([You need Tokyo Cabinet, QDBM, GDBM, Berkeley DB4 or LMDB for hcache])
+        AC_MSG_ERROR([You need Tokyo Cabinet, Kyoto Cabinet, QDBM, GDBM, Berkeley DB4 or LMDB for hcache])
     fi
 fi
 hcache_db_used=$db_found

--- a/doc/manual.xml.head
+++ b/doc/manual.xml.head
@@ -8789,7 +8789,7 @@ per message.)
 Header caching can be enabled via the configure script and the
 <emphasis>--enable-hcache</emphasis> option. It's not turned on by
 default because external database libraries are required: one of
-tokyocabinet, qdbm, gdbm or bdb must be present.
+tokyocabinet, kyotocabinet, qdbm, gdbm, lmdb or bdb must be present.
 </para>
 
 <para>
@@ -10773,52 +10773,62 @@ bind index,pager y edit-label
   </sect2>
 </sect1>
 
-<sect1 id="FEATURE-NAME">
-  <title>FEATURE-NAME Feature</title>
-  <subtitle>DESCRIPTION</subtitle>
+<sect1 id="kyoto-cabinet">
+  <title>Kyoto Cabinet Feature</title>
+  <subtitle>Kyoto Cabinet backend for the header cache</subtitle>
 
-  <sect2 id="FEATURE-NAME-support">
+  <sect2 id="kyoto-cabinet-support">
     <title>Support</title>
 
     <para>
-      To check if Mutt supports <quote>FEATURE-NAME</quote>, look for
-      <quote>patch-FEATURE-NAME</quote> in the mutt version.
-      See: <xref linkend="mutt-patches"/>.
+      To check if Mutt supports Kyoto Cabinet, look for
+
+      <itemizedlist>
+        <listitem><quote>patch-kyoto</quote> in the mutt version. See: <xref linkend="mutt-patches"/>.</listitem>
+        <listitem><quote>+USE_HCACHE</quote> in the compile options</listitem>
+        <listitem><quote>hcache backend: kyotocabinet</quote> in the mutt version</listitem>
+      </itemizedlist>
     </para>
 
     <itemizedlist>
       <title>Dependencies:</title>
       <listitem><para>mutt-1.7.0</para></listitem>
+      <listitem><para><ulink url="http://fallabs.com/kyotocabinet/">Kyoto Cabinet libraries</ulink></para></listitem>
     </itemizedlist>
 
     <para>This feature is part of the <ulink url="http://www.neomutt.org/">NeoMutt Project</ulink>.</para>
   </sect2>
 
-  <sect2 id="FEATURE-NAME-intro">
+  <sect2 id="kyoto-cabinet-intro">
     <title>Introduction</title>
 
     <para>
-      SIMPLE DESCRIPTION OF FEATURE
+      This feature adds support for using Kyoto Cabinet, the successor to Tokyo
+      Cabinet, as a storage backend for Mutt's header cache (hcache). It is
+      enabled at configure time with the
+      <emphasis>--with-kyotocabinet=&lt;path&gt;</emphasis> switch.
     </para>
   </sect2>
 
-  <sect2 id="FEATURE-NAME-see-also">
+  <sect2 id="kyoto-cabinet-see-also">
     <title>See Also</title>
 
     <itemizedlist>
-      <listitem><para><link linkend="regexp">LINK-DESCRIPTION</link></para></listitem>
+      <listitem><para><ulink url="http://www.neomutt.org/">NeoMutt Project</ulink></para></listitem>
+      <listitem><para><link linkend="caching">Local Caching</link></para></listitem>
+      <listitem><para><ulink url="http://fallabs.com/kyotocabinet/">Kyoto Cabinet</ulink></para></listitem>
     </itemizedlist>
   </sect2>
 
-  <sect2 id="FEATURE-NAME-known-bugs">
+  <sect2 id="kyoto-cabinet-known-bugs">
     <title>Known Bugs</title>
     <para>None</para>
   </sect2>
 
-  <sect2 id="FEATURE-NAME-credits">
+  <sect2 id="kyoto-cabinet-credits">
     <title>Credits</title>
     <itemizedlist>
-    <listitem><para>FIRST LAST <email>EMAIL_ADDRESS</email></para></listitem>
+    <listitem><para>Clemens Lang <email>neverpanic@gmail.com</email></para></listitem>
     </itemizedlist>
   </sect2>
 </sect1>

--- a/doc/manual.xml.head
+++ b/doc/manual.xml.head
@@ -10773,6 +10773,56 @@ bind index,pager y edit-label
   </sect2>
 </sect1>
 
+<sect1 id="FEATURE-NAME">
+  <title>FEATURE-NAME Feature</title>
+  <subtitle>DESCRIPTION</subtitle>
+
+  <sect2 id="FEATURE-NAME-support">
+    <title>Support</title>
+
+    <para>
+      To check if Mutt supports <quote>FEATURE-NAME</quote>, look for
+      <quote>patch-FEATURE-NAME</quote> in the mutt version.
+      See: <xref linkend="mutt-patches"/>.
+    </para>
+
+    <itemizedlist>
+      <title>Dependencies:</title>
+      <listitem><para>mutt-1.7.0</para></listitem>
+    </itemizedlist>
+
+    <para>This feature is part of the <ulink url="http://www.neomutt.org/">NeoMutt Project</ulink>.</para>
+  </sect2>
+
+  <sect2 id="FEATURE-NAME-intro">
+    <title>Introduction</title>
+
+    <para>
+      SIMPLE DESCRIPTION OF FEATURE
+    </para>
+  </sect2>
+
+  <sect2 id="FEATURE-NAME-see-also">
+    <title>See Also</title>
+
+    <itemizedlist>
+      <listitem><para><link linkend="regexp">LINK-DESCRIPTION</link></para></listitem>
+    </itemizedlist>
+  </sect2>
+
+  <sect2 id="FEATURE-NAME-known-bugs">
+    <title>Known Bugs</title>
+    <para>None</para>
+  </sect2>
+
+  <sect2 id="FEATURE-NAME-credits">
+    <title>Credits</title>
+    <itemizedlist>
+    <listitem><para>FIRST LAST <email>EMAIL_ADDRESS</email></para></listitem>
+    </itemizedlist>
+  </sect2>
+</sect1>
+
 <sect1 id="limit-current-thread">
   <title>Limit-Current-Thread Feature</title>
   <subtitle>Focus on one Email Thread</subtitle>

--- a/hcache.c
+++ b/hcache.c
@@ -28,6 +28,8 @@
 #include <villa.h>
 #elif HAVE_TC
 #include <tcbdb.h>
+#elif HAVE_KC
+#include <kclangc.h>
 #elif HAVE_GDBM
 #include <gdbm.h>
 #elif HAVE_DB4
@@ -63,6 +65,13 @@ struct header_cache
 struct header_cache
 {
   TCBDB *db;
+  char *folder;
+  unsigned int crc;
+};
+#elif HAVE_KC
+struct header_cache
+{
+  KCDB *db;
   char *folder;
   unsigned int crc;
 };
@@ -750,6 +759,9 @@ mutt_hcache_fetch_raw (header_cache_t *h, const char *filename,
 #elif HAVE_TC
   void *data;
   int sp;
+#elif HAVE_KC
+  void *data;
+  size_t sp;
 #elif HAVE_GDBM
   datum key;
   datum data;
@@ -826,6 +838,10 @@ mutt_hcache_fetch_raw (header_cache_t *h, const char *filename,
   return data;
 #elif HAVE_TC
   data = tcbdbget(h->db, path, ksize, &sp);
+
+  return data;
+#elif HAVE_KC
+  data = kcdbget(h->db, path, ksize, &sp);
 
   return data;
 #elif HAVE_GDBM
@@ -938,6 +954,8 @@ mutt_hcache_store_raw (header_cache_t* h, const char* filename, void* data,
   return vlput(h->db, path, ksize, data, dlen, VL_DOVER);
 #elif HAVE_TC
   return tcbdbput(h->db, path, ksize, data, dlen);
+#elif HAVE_KC
+  return kcdbset(h->db, path, ksize, data, dlen);
 #elif HAVE_GDBM
   key.dptr = path;
   key.dsize = ksize;
@@ -1071,6 +1089,73 @@ mutt_hcache_delete(header_cache_t *h, const char *filename,
   ksize = strlen(h->folder) + keylen(path + strlen(h->folder));
 
   return tcbdbout(h->db, path, ksize);
+}
+
+#elif HAVE_KC
+static int
+hcache_open_kc (struct header_cache* h, const char* path)
+{
+  char kcdbpath[_POSIX_PATH_MAX];
+  int printfresult;
+
+  printfresult = snprintf(kcdbpath, sizeof(kcdbpath),
+                          "%s#type=kct#opts=%s#rcomp=lex",
+                          path, option(OPTHCACHECOMPRESS) ? "lc" : "l");
+  if (printfresult < 0 || printfresult >= sizeof(kcdbpath)) {
+    return -1;
+  }
+
+  h->db = kcdbnew();
+  if (!h->db)
+      return -1;
+
+  if (kcdbopen(h->db, kcdbpath, KCOWRITER | KCOCREATE))
+    return 0;
+  else
+  {
+#ifdef DEBUG
+    int ecode = kcdbecode (h->db);
+    dprint (2, (debugfile, "kcdbopen failed for %s: %s (ecode %d)\n", kcdbpath, kcdbemsg (h->db), ecode));
+#endif
+    kcdbdel(h->db);
+    return -1;
+  }
+}
+
+void
+mutt_hcache_close(header_cache_t *h)
+{
+  if (!h)
+    return;
+
+  if (!kcdbclose(h->db))
+  {
+#ifdef DEBUG
+    int ecode = kcdbecode (h->db);
+    dprint (2, (debugfile, "kcdbclose failed for %s: %s (ecode %d)\n", h->folder, kcdbemsg (h->db), ecode));
+#endif
+  }
+  kcdbdel(h->db);
+  FREE(&h->folder);
+  FREE(&h);
+}
+
+int
+mutt_hcache_delete(header_cache_t *h, const char *filename,
+		   size_t(*keylen) (const char *fn))
+{
+  char path[_POSIX_PATH_MAX];
+  int ksize;
+
+  if (!h)
+    return -1;
+
+  strncpy(path, h->folder, sizeof (path));
+  safe_strcat(path, sizeof (path), filename);
+
+  ksize = strlen(h->folder) + keylen(path + strlen(h->folder));
+
+  return kcdbremove(h->db, path, ksize);
 }
 
 #elif HAVE_GDBM
@@ -1341,7 +1426,9 @@ mutt_hcache_open(const char *path, const char *folder, hcache_namer_t namer)
 #if HAVE_QDBM
   hcache_open = hcache_open_qdbm;
 #elif HAVE_TC
-  hcache_open= hcache_open_tc;
+  hcache_open = hcache_open_tc;
+#elif HAVE_KC
+  hcache_open = hcache_open_kc;
 #elif HAVE_GDBM
   hcache_open = hcache_open_gdbm;
 #elif HAVE_DB4
@@ -1443,5 +1530,17 @@ const char *mutt_hcache_backend (void)
 const char *mutt_hcache_backend (void)
 {
   return "tokyocabinet " _TC_VERSION;
+}
+#elif HAVE_KC
+const char *mutt_hcache_backend (void)
+{
+  /* 128 should be more than enough for KCVERSION */
+  static int initialized = 0;
+  static char version_cache[12 + 1 + 128];
+  if (!initialized) {
+    snprintf(version_cache, sizeof(version_cache), "kyotocabinet %s", KCVERSION);
+    initialized = 1;
+  }
+  return version_cache;
 }
 #endif

--- a/init.h
+++ b/init.h
@@ -1058,7 +1058,7 @@ struct option_t MuttVars[] = {
   ** Header caching can greatly improve speed when opening POP, IMAP
   ** MH or Maildir folders, see ``$caching'' for details.
   */
-#if defined(HAVE_QDBM) || defined(HAVE_TC)
+#if defined(HAVE_QDBM) || defined(HAVE_TC) || defined(HAVE_KC)
   { "header_cache_compress", DT_BOOL, R_NONE, OPTHCACHECOMPRESS, 1 },
   /*
   ** .pp

--- a/init.h
+++ b/init.h
@@ -1062,12 +1062,13 @@ struct option_t MuttVars[] = {
   { "header_cache_compress", DT_BOOL, R_NONE, OPTHCACHECOMPRESS, 1 },
   /*
   ** .pp
-  ** When mutt is compiled with qdbm or tokyocabinet as header cache backend,
-  ** this option determines whether the database will be compressed.
-  ** Compression results in database files roughly being one fifth
-  ** of the usual diskspace, but the decompression can result in a
-  ** slower opening of cached folder(s) which in general is still
-  ** much faster than opening non header cached folders.
+  ** When mutt is compiled with qdbm, tokyocabinet or kyotocabinet
+  ** as header cache backend, this option determines whether the
+  ** database will be compressed. Compression results in database
+  ** files roughly being one fifth of the usual diskspace, but the
+  ** decompression can result in a slower opening of cached folder(s)
+  ** which in general is still much faster than opening non header
+  ** cached folders.
   */
 #endif /* HAVE_QDBM */
 #if defined(HAVE_GDBM) || defined(HAVE_DB4)

--- a/mutt.h
+++ b/mutt.h
@@ -397,7 +397,7 @@ enum
   OPTFORWQUOTE,
 #ifdef USE_HCACHE
   OPTHCACHEVERIFY,
-#if defined(HAVE_QDBM) || defined(HAVE_TC)
+#if defined(HAVE_QDBM) || defined(HAVE_TC) || defined(HAVE_KC)
   OPTHCACHECOMPRESS,
 #endif /* HAVE_QDBM */
 #endif


### PR DESCRIPTION
Tokyo Cabinet's website now "strongly recommends" using Kyoto Cabinet instead of Tokyo Cabinet because it claims to be superior. Add Kyoto Cabinet as an option.

In some preliminary testing, the performance seems to be on-par with Tokyo Cabinet, but not better. Kyoto Cabinet seems to need a little more space, but the difference is probably not significant.

Note that since this does not actually provide any improvement other than not using the older (and possibly unmaintained?) Tokyo Cabinet libraries, it might be a valid decision to not merge this pull request at all. Since there are a couple of attempts at implementing support for Kyoto Cabinet spread over Gists and patches, opening a PR here at least makes it more visible that the code has already been written.