### PR TITLE
Change 'attach_keyword' option from string to regex

### DIFF
--- a/README.neomutt
+++ b/README.neomutt
@@ -64,10 +64,11 @@ Here's a list of everyone who's helped NeoMutt:
 Alex Pearce, Ander Punnar, Antonio Radici, Baptiste Daroussin, Chris Salzberg,
 Christoph Berg, Darshit Shah, David Sterba, Elimar Riesebieter, Evgeni Golov,
 Fabian Groffen, Fabio Alessandro Locati, Faidon Liambotis, Guillaume Brogi,
-Ivan Tham, Johannes Frankenau, Joshua Jordi, Karel Zak, Kurt Jaeger,
-Marco Hinz, Matteo Vescovi, Pierre-Elliott Bécue, Richard Hartmann,
-Richard Russon, Santiago Torres, Sven Guckes, Thomas Klausner, Udo Schweigert,
-Vsevolod Volkov, Werner Fink, Yoshiki Vázquez Baeza.
+Ivan Tham, Johannes Frankenau, Johannes Weißl, Joshua Jordi, Karel Zak,
+Kurt Jaeger, Marco Hinz, Matteo Vescovi, Pierre-Elliott Bécue,
+Richard Hartmann, Richard Russon, Santiago Torres, Sven Guckes,
+Thomas Klausner, Udo Schweigert, Vsevolod Volkov, Werner Fink,
+Yoshiki Vázquez Baeza.
 
 ## Original Patch Authors
 

--- a/doc/manual.xml.head
+++ b/doc/manual.xml.head
@@ -10046,8 +10046,8 @@ set pgp_encrypt_self = &quot;no&quot;
         <tbody>
           <row>
             <entry><literal>attach_keyword</literal></entry>
-            <entry>string</entry>
-            <entry><literal>attached</literal></entry>
+            <entry>regular expression</entry>
+            <entry><literal>\\&lt;attach(|ed|ments?)\\&gt;</literal></entry>
           </row>
           <row>
             <entry><literal>abort_noattach</literal></entry>
@@ -10065,12 +10065,12 @@ set pgp_encrypt_self = &quot;no&quot;
 <emphasis role="comment"># Example NeoMutt config file for the forgotten-attachment feature.
 
 # The 'forgotten-attachment' feature provides a new setting for Mutt that
-# alerts the user if the message body contains a certain keyword but there are
+# alerts the user if the message body contains a certain regular expression but there are
 # no attachments added. This is meant to ensure that the user does not forget
 # to attach a file after promising to do so in the mail.
 
-# Search for the following keyword in the body of the email</emphasis>
-set attach_keyword = &quot;attached&quot;
+# Search for the following regular expression in the body of the email</emphasis>
+set attach_keyword = &quot;\\&lt;attach(|ed|ments?)\\&gt;&quot;
 
 <emphasis role="comment"># Ask if the user wishes to abort sending if $attach_keyword is found in the
 # body, but no attachments have been added</emphasis>
@@ -10100,6 +10100,7 @@ set abort_noattach = ask-yes
     <itemizedlist>
     <listitem><para>Darshit Shah <email>darnir@gmail.com</email></para></listitem>
     <listitem><para>Richard Russon <email>rich@flatcap.org</email></para></listitem>
+    <listitem><para>Johannes Wei&szlig;l <email>jargon@molb.org</email></para></listitem>
     </itemizedlist>
   </sect2>
 </sect1>

--- a/doc/manual.xml.head
+++ b/doc/manual.xml.head
@@ -10045,7 +10045,7 @@ set pgp_encrypt_self = &quot;no&quot;
         </thead>
         <tbody>
           <row>
-            <entry><literal>attach-keyword</literal></entry>
+            <entry><literal>attach_keyword</literal></entry>
             <entry>string</entry>
             <entry><literal>attached</literal></entry>
           </row>

--- a/doc/muttrc.forgotten-attachment
+++ b/doc/muttrc.forgotten-attachment
@@ -5,8 +5,8 @@
 # no attachments added. This is meant to ensure that the user does not forget
 # to attach a file after promising to do so in the mail.
 
-# Search for the following keyword in the body of the email
-set attach_keyword = "attached"
+# Search for the following regular expression in the body of the email
+set attach_keyword = "\\<attach(|ed|ments?)\\>"
 
 # Ask if the user wishes to abort sending if $attach_keyword is found in the
 # body, but no attachments have been added

--- a/globals.h
+++ b/globals.h
@@ -39,7 +39,7 @@ WHERE char *Attribution;
 WHERE char *AttributionLocale;
 WHERE char *AttachCharset;
 WHERE char *AttachFormat;
-WHERE char *AttachKeyword;
+WHERE REGEXP AttachKeyword;
 WHERE char *Charset;
 WHERE char *ComposeFormat;
 WHERE char *ConfigCharset;

--- a/init.h
+++ b/init.h
@@ -90,8 +90,8 @@ struct option_t MuttVars[] = {
   { "abort_noattach", DT_QUAD, R_NONE, OPT_ATTACH, MUTT_NO },
   /*
   ** .pp
-  ** If set to \fIyes\fP, when composing messages containing the word
-  ** specified by $attach_keyword (default is "attach") and no attachments
+  ** If set to \fIyes\fP, when composing messages containing the regular expression
+  ** specified by $attach_keyword (default is "\\<attach(|ed|ments?)\\>") and no attachments
   ** are given, composition will be aborted. If set to \fIno\fP, composing
   ** messages as such will never be aborted.
   */
@@ -267,12 +267,12 @@ struct option_t MuttVars[] = {
   ** .pp
   ** For an explanation of ``soft-fill'', see the $$index_format documentation.
   */
-  { "attach_keyword",  DT_STR,  R_NONE, UL &AttachKeyword, UL "attach" },
+  { "attach_keyword",  DT_RX,  R_NONE, UL &AttachKeyword, UL "\\<attach(|ed|ments?)\\>" },
   /*
   ** .pp
   ** If $abort_noattach is not set to no, then the body of the message
-  ** will be scanned for this keyword, and if found, you will be prompted
-  ** if there are no attachments. This is case insensitive.
+  ** will be scanned for this regular expression, and if found, you will
+  ** be prompted if there are no attachments.
   */
   { "attach_sep",	DT_STR,	 R_NONE, UL &AttachSep, UL "\n" },
   /*


### PR DESCRIPTION
A regular expression is much more useful than a single word to check for forgotten attachments, especially when writing in multiple languages.

This is inspired by the [muttng patchset abort_noattach](https://github.com/codito/muttng-patchset/blob/master/patches/muttng.abort_noattach.diff), which I use for years, but newly implemented to make minimal changes to the neomutt source code.

The keyword is no longer mentioned in the error message as regular expressions tend to be longer.

The option 'attach_keyword' could be renamed 'attach_remind_regex' as in the muttng patch.

This pull request would solve #138.