### PR TITLE
Fixes repaint problem with $pager_index_lines #159

### DIFF
--- a/pager.c
+++ b/pager.c
@@ -1958,25 +1958,28 @@ mutt_pager (const char *banner, const char *fname, int flags, pager_t *extra)
 	mutt_draw_statusline (pager_status_window->cols, bn, sizeof (bn));
       }
       NORMAL_COLOR;
-      if (option(OPTTSENABLED) && TSSupported)
+
+      /*
+       * update terminal status line
+       */
+      if (option(OPTTSENABLED) && TSSupported && index)
       {
-	menu_status_line (buffer, sizeof (buffer), index, NONULL (TSStatusFormat));
-	mutt_ts_status(buffer);
-	menu_status_line (buffer, sizeof (buffer), index, NONULL (TSIconFormat));
-	mutt_ts_icon(buffer);
+         menu_status_line (buffer, sizeof (buffer), index, NONULL (TSStatusFormat));
+         mutt_ts_status(buffer);
+         menu_status_line (buffer, sizeof (buffer), index, NONULL (TSIconFormat));
+         mutt_ts_icon(buffer);
       }
     }
 
-    if ((redraw & REDRAW_INDEX) && index)
+    /* redraw the pager_index indicator, because the
+     * flags for this message might have changed. */
+    if ((redraw & REDRAW_INDEX) && index && index_window->rows > 0)
     {
-      /* redraw the pager_index indicator, because the
-       * flags for this message might have changed. */
-      if (index_window->rows > 0)
-        menu_redraw_current (index);
+      menu_redraw_current (index);
 
       /* print out the index status bar */
       menu_status_line (buffer, sizeof (buffer), index, NONULL(Status));
- 
+
       mutt_window_move (index_status_window, 0, 0);
       SETCOLOR (MT_COLOR_STATUS);
       mutt_paddstr (index_status_window->cols, buffer);


### PR DESCRIPTION
Commit 6b4c4ca changed the behaviour of mutt_pager to build the
pager index even if pager_index_lines was set to 0 to (fixing #143).

The code redrawing the pager status line was relying on the pager index
beeing NULL to determine if a redraw should take place. Now
index_window->rows is used as an additional safeguard.

Also added a check if pager index is set to the terminal status line update
code as it was unguarded and old default behaviour might be introduced
later.

Fixes #159