### PR TITLE
Make sure INBOX appears first in the list.

### DIFF
--- a/browser.c
+++ b/browser.c
@@ -102,8 +102,9 @@ static int browser_compare_subject (const void *a, const void *b)
   struct folder_file *pa = (struct folder_file *) a;
   struct folder_file *pb = (struct folder_file *) b;
 
-  int r = mutt_is_inbox (pa->name) ? -1 :
-          mutt_is_inbox (pb->name) ?  1 :
+  int same_path = mutt_same_path (pa->name, pb->name);
+  int r = (same_path && mutt_is_inbox (pa->name)) ? -1 :
+          (same_path && mutt_is_inbox (pb->name)) ?  1 :
           mutt_strcoll  (pa->name, pb->name);
 
   return ((BrowserSort & SORT_REVERSE) ? -r : r);

--- a/browser.c
+++ b/browser.c
@@ -102,7 +102,9 @@ static int browser_compare_subject (const void *a, const void *b)
   struct folder_file *pa = (struct folder_file *) a;
   struct folder_file *pb = (struct folder_file *) b;
 
-  int r = mutt_strcoll (pa->name, pb->name);
+  int r = mutt_is_inbox (pa->name) ? -1 :
+          mutt_is_inbox (pb->name) ?  1 :
+          mutt_strcoll  (pa->name, pb->name);
 
   return ((BrowserSort & SORT_REVERSE) ? -r : r);
 }
@@ -1085,6 +1087,8 @@ void _mutt_select_file (char *f, size_t flen, int flags, char ***files, int *num
       state.imap_browse = 1;
       if (!imap_browse (f, &state))
         strfcpy (LastDir, state.folder, sizeof (LastDir));
+      else
+        browser_sort (&state);
     }
     else
     {

--- a/imap/browse.c
+++ b/imap/browse.c
@@ -35,7 +35,6 @@ static int browse_add_list_result (IMAP_DATA* idata, const char* cmd,
   struct browser_state* state, short isparent);
 static void imap_add_folder (char delim, char *folder, int noselect,
   int noinferiors, struct browser_state *state, short isparent);
-static int compare_names(struct folder_file *a, struct folder_file *b);
 
 /* imap_browse: IMAP hook into the folder browser, fills out browser_state,
  *   given a current folder to browse */
@@ -192,9 +191,6 @@ int imap_browse (char* path, struct browser_state* state)
   }
 
   mutt_clear_error ();
-
-  qsort(&(state->entry[nsup]),state->entrylen-nsup,sizeof(state->entry[0]),
-	(int (*)(const void*,const void*)) compare_names);
 
   if (save_lsub)
     set_option (OPTIMAPCHECKSUBSCRIBED);
@@ -445,9 +441,4 @@ static void imap_add_folder (char delim, char *folder, int noselect,
   (state->entrylen)++;
 
   FREE (&mx.mbox);
-}
-
-static int compare_names(struct folder_file *a, struct folder_file *b) 
-{
-  return mutt_strcmp(a->name, b->name);
 }

--- a/lib.c
+++ b/lib.c
@@ -1087,3 +1087,9 @@ int mutt_atol (const char *str, long *dst)
     return -1;
   return 0;
 }
+
+int  mutt_is_inbox(const char *path)
+{
+  size_t plen = mutt_strlen(path);
+  return plen >= 5 && 0 == mutt_strcasecmp(path + plen - 5, "inbox");
+}

--- a/lib.c
+++ b/lib.c
@@ -1088,8 +1088,24 @@ int mutt_atol (const char *str, long *dst)
   return 0;
 }
 
-int  mutt_is_inbox(const char *path)
+int mutt_is_inbox(const char *path)
 {
   size_t plen = mutt_strlen(path);
   return plen >= 5 && 0 == mutt_strcasecmp(path + plen - 5, "inbox");
+}
+
+int mutt_same_path(const char *a, const char *b)
+{
+  const char * a_end = strrchr(a, '/');
+  const char * b_end = strrchr(b, '/');
+  int ret = 0;
+  if (!(!a_end ^ !b_end)) {
+      if (!a_end) {
+          ret = 1;
+      } else {
+          size_t a_len = a_end - a;
+          ret = a_len == b_end - b && 0 == mutt_strncasecmp(a, b, a_len);
+      }
+  }
+  return ret;
 }

--- a/lib.h
+++ b/lib.h
@@ -222,6 +222,7 @@ void mutt_unlink (const char *);
 void safe_free (void *);
 void safe_realloc (void *, size_t);
 int  mutt_is_inbox(const char *path);
+int  mutt_same_path(const char *a, const char *b);
 
 const char *mutt_strsysexit(int e);
 #endif

--- a/lib.h
+++ b/lib.h
@@ -221,6 +221,7 @@ void mutt_str_adjust (char **p);
 void mutt_unlink (const char *);
 void safe_free (void *);
 void safe_realloc (void *, size_t);
+int  mutt_is_inbox(const char *path);
 
 const char *mutt_strsysexit(int e);
 #endif

--- a/sidebar.c
+++ b/sidebar.c
@@ -305,10 +305,13 @@ static int cb_qsort_sbe (const void *a, const void *b)
       result = (b2->msg_flagged - b1->msg_flagged);
       break;
     case SORT_PATH:
-      result = mutt_is_inbox (b1->path) ? -1 :
-               mutt_is_inbox (b2->path) ?  1 :
+    {
+      int same_path = mutt_same_path (b1->path, b2->path);
+      result = (same_path && mutt_is_inbox (b1->path)) ? -1 :
+               (same_path && mutt_is_inbox (b2->path)) ?  1 :
                mutt_strcoll (b1->path, b2->path);           
       break;
+    }
   }
 
   if (SidebarSortMethod & SORT_REVERSE)

--- a/sidebar.c
+++ b/sidebar.c
@@ -305,7 +305,9 @@ static int cb_qsort_sbe (const void *a, const void *b)
       result = (b2->msg_flagged - b1->msg_flagged);
       break;
     case SORT_PATH:
-      result = mutt_strcoll (b1->path, b2->path);
+      result = mutt_is_inbox (b1->path) ? -1 :
+               mutt_is_inbox (b2->path) ?  1 :
+               mutt_strcoll (b1->path, b2->path);           
       break;
   }
 


### PR DESCRIPTION
This affects (and makes consistent) the order of folders in the sidebar and the folder browser.

`compare_names` in `imap/browse.c` had no effect as the folders were sorted by the caller and thus has been removed.