### PR TITLE
[preview] pager: skip to body for skip-quoted

### DIFF
--- a/pager.c
+++ b/pager.c
@@ -2439,6 +2439,18 @@ search_next:
 	  int dretval = 0;
 	  int new_topline = topline;
 
+	  if (ISHEADER(lineInfo[new_topline].type)) {
+	    while ((new_topline < lastLine ||
+		    (0 == (dretval = display_line (fp, &last_pos, &lineInfo,
+			   new_topline, &lastLine, &maxLine, MUTT_TYPES | (flags & MUTT_PAGER_NOWRAP),
+			   &QuoteList, &q_level, &force_redraw, &SearchRE, pager_window))))
+		   && ISHEADER(lineInfo[new_topline].type)) {
+	      new_topline++;
+	    }
+	    topline = new_topline;
+	    break;
+	  }
+
 	  while (((new_topline + SkipQuotedOffset) < lastLine ||
 		  (0 == (dretval = display_line (fp, &last_pos, &lineInfo,
 			 new_topline, &lastLine, &maxLine, MUTT_TYPES | (flags & MUTT_PAGER_NOWRAP),


### PR DESCRIPTION
In mails with many headers that fill the whole screen, it's convenient
to jump to the body, implemented as a side-efect of the <skip-quoted>
command.

Signed-off-by: David Sterba <dsterba@suse.cz>

NOTE: piggy-backing on the skip-quoted is not necessarily the best way, but avoids adding new special command and it's something like "skip to something of interest". I haven't used the feature for a long time but somebody might find it useful.