### PR TITLE
notmuch: option to affect visibility of tags

### DIFF
--- a/hdrline.c
+++ b/hdrline.c
@@ -812,11 +812,14 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
       tags = driver_tags_get_transformed(&hdr->tags);
       if (!optional)
       {
-        colorlen = add_index_color(buf, buflen, flags, MT_COLOR_INDEX_TAGS);
-        mutt_format_s(buf + colorlen, buflen - colorlen, prec, NONULL(tags));
-        add_index_color(buf + colorlen, buflen - colorlen, flags, MT_COLOR_INDEX);
+        if (ShowTags)
+        {
+          colorlen = add_index_color(buf, buflen, flags, MT_COLOR_INDEX_TAGS);
+          mutt_format_s(buf + colorlen, buflen - colorlen, prec, NONULL(tags));
+          add_index_color(buf + colorlen, buflen - colorlen, flags, MT_COLOR_INDEX);
+        }
       }
-      else if (!tags)
+      else if (!tags || !ShowTags)
         optional = 0;
       FREE(&tags);
       break;

--- a/init.h
+++ b/init.h
@@ -2151,6 +2151,12 @@ struct Option MuttVars[] = {
   ** connect to news server.
   */
 #endif
+  { "show_tags", DT_BOOL, R_TREE | R_BOTH, UL &ShowTags, 1 },
+  /*
+   ** .pp
+   ** Show tag vaules in format via %g specifier (default). Allow to hide the
+   ** tags if there's large number tags per message. In bindings use 'toggle'.
+   */
   { "pager",            DT_PATH, R_NONE, UL &Pager, UL "builtin" },
   /*
   ** .pp

--- a/options.h
+++ b/options.h
@@ -272,6 +272,7 @@ WHERE bool XCommentTo;
 #ifdef USE_NOTMUCH
 WHERE bool VirtualSpoolfile;
 WHERE bool NmRecord;
+WHERE bool ShowTags;
 #endif
 
 #endif /* _MUTT_OPTIONS_H_ */


### PR DESCRIPTION
Allow to show/hide notmuch labels on the index line, default is to show.
Useful in case there are a lot of labels that cover the subject line. No

Signed-off-by: David Sterba dsterba@suse.cz