### PR TITLE
Avoid searching for attachment keywords when it's unnecessary

### DIFF
--- a/send.c
+++ b/send.c
@@ -1896,8 +1896,8 @@ main_loop:
 #endif
 
   if (quadoption(OPT_ATTACH) != MUTT_NO &&
-         mutt_search_attach_keyword (msg->content->filename) &&
          !msg->content->next &&
+         mutt_search_attach_keyword (msg->content->filename) &&
          query_quadoption (OPT_ATTACH, _("No attachments, cancel sending?")) != MUTT_NO)
   {
     /* if the abort is automatic, print an error message */

--- a/send.c
+++ b/send.c
@@ -1895,7 +1895,8 @@ main_loop:
   }
 #endif
 
-  if (mutt_search_attach_keyword (msg->content->filename) &&
+  if (quadoption(OPT_ATTACH) != MUTT_NO &&
+         mutt_search_attach_keyword (msg->content->filename) &&
          !msg->content->next &&
          query_quadoption (OPT_ATTACH, _("No attachments, cancel sending?")) != MUTT_NO)
   {

--- a/send.c
+++ b/send.c
@@ -1252,7 +1252,8 @@ mutt_search_attach_keyword (char *filename)
   while (!feof (attf))
   {
     fgets (inputline, LONG_STRING, attf);
-    if (regexec (AttachKeyword.rx, inputline, 0, NULL, 0) == 0)
+    if (regexec (QuoteRegexp.rx, inputline, 0, NULL, 0) != 0 &&
+        regexec (AttachKeyword.rx, inputline, 0, NULL, 0) == 0)
     {
       found = 1;
       break;


### PR DESCRIPTION
Resolves the "easy" portion of #180 by checking the `abort_noattach`/`OPT_ATTACH` option and does not search the message text if the option is set to `MUTT_NO`.

The second commit similarly short circuits avoiding the search if there is an attachment. At least, that's my understanding of what that portion of the conditional is. That commit is separate and can be excluded from the final merge.

I'll be looking at skipping quoted message sections from the search on the next flight. #180 mentions using `$indent_string` but in IRC @flatcap mentioned `$quote_regexp`. I've only had a chance to quickly grep through the changelog to see which is which, but it looks like the quote regexp would be the one to check message text against.

Feedback gladly appreciated. Thanks! 