### PR TITLE
Enable reconstruct-thread in the pager

### DIFF
--- a/curs_main.c
+++ b/curs_main.c
@@ -1269,80 +1269,80 @@ int mutt_index_menu (void)
 	CHECK_ATTACH;
 	if (Context->magic == MUTT_NNTP)
 	{
-	  int oldmsgcount = Context->msgcount;
-	  int oldindex = CURHDR->index;
-	  int rc = 0;
+    int oldmsgcount = Context->msgcount;
+    int oldindex = CURHDR->index;
+    int rc = 0;
 
-	  if (!CURHDR->env->message_id)
-	  {
-	    mutt_error _("No Message-Id. Unable to perform operation.");
-	    break;
-	  }
+    if (!CURHDR->env->message_id)
+    {
+      mutt_error _("No Message-Id. Unable to perform operation.");
+      break;
+    }
 
-	  mutt_message _("Fetching message headers...");
-	  if (!Context->id_hash)
-	    Context->id_hash = mutt_make_id_hash (Context);
-	  strfcpy (buf, CURHDR->env->message_id, sizeof (buf));
+    mutt_message _("Fetching message headers...");
+    if (!Context->id_hash)
+      Context->id_hash = mutt_make_id_hash (Context);
+    strfcpy (buf, CURHDR->env->message_id, sizeof (buf));
 
-	  /* trying to find msgid of the root message */
-	  if (op == OP_RECONSTRUCT_THREAD)
-	  {
-	    LIST *ref = CURHDR->env->references;
-	    while (ref)
-	    {
-	      if (hash_find (Context->id_hash, ref->data) == NULL)
-	      {
-		rc = nntp_check_msgid (Context, ref->data);
-		if (rc < 0)
-		  break;
-	      }
+    /* trying to find msgid of the root message */
+    if (op == OP_RECONSTRUCT_THREAD)
+    {
+      LIST *ref = CURHDR->env->references;
+      while (ref)
+      {
+        if (hash_find (Context->id_hash, ref->data) == NULL)
+        {
+          rc = nntp_check_msgid (Context, ref->data);
+          if (rc < 0)
+            break;
+        }
 
-	      /* the last msgid in References is the root message */
-	      if (!ref->next)
-		strfcpy (buf, ref->data, sizeof (buf));
-	      ref = ref->next;
-	    }
-	  }
+        /* the last msgid in References is the root message */
+        if (!ref->next)
+          strfcpy (buf, ref->data, sizeof (buf));
+        ref = ref->next;
+      }
+    }
 
-	  /* fetching all child messages */
-	  if (rc >= 0)
-	    rc = nntp_check_children (Context, buf);
+    /* fetching all child messages */
+    if (rc >= 0)
+      rc = nntp_check_children (Context, buf);
 
-	  /* at least one message has been loaded */
-	  if (Context->msgcount > oldmsgcount)
-	  {
-	    HEADER *hdr;
-	    int i, quiet = Context->quiet;
+    /* at least one message has been loaded */
+    if (Context->msgcount > oldmsgcount)
+    {
+      HEADER *hdr;
+      int i, quiet = Context->quiet;
 
-	    if (rc < 0)
-	      Context->quiet = 1;
-	    mutt_sort_headers (Context, (op == OP_RECONSTRUCT_THREAD));
-	    Context->quiet = quiet;
+      if (rc < 0)
+        Context->quiet = 1;
+      mutt_sort_headers (Context, (op == OP_RECONSTRUCT_THREAD));
+      Context->quiet = quiet;
 
-	    /* if the root message was retrieved, move to it */
-	    hdr = hash_find (Context->id_hash, buf);
-	    if (hdr)
-	      menu->current = hdr->virtual;
+      /* if the root message was retrieved, move to it */
+      hdr = hash_find (Context->id_hash, buf);
+      if (hdr)
+        menu->current = hdr->virtual;
 
-	    /* try to restore old position */
-	    else
-	    {
-	      for (i = 0; i < Context->msgcount; i++)
-	      {
-		if (Context->hdrs[i]->index == oldindex)
-		{
-		  menu->current = Context->hdrs[i]->virtual;
-		  /* as an added courtesy, recenter the menu
-		   * with the current entry at the middle of the screen */
-		  menu_check_recenter (menu);
-		  menu_current_middle (menu);
-		}
-	      }
-	    }
-	    menu->redraw = REDRAW_FULL;
-	  }
-	  else if (rc >= 0)
-	    mutt_error _("No deleted messages found in the thread.");
+      /* try to restore old position */
+      else
+      {
+        for (i = 0; i < Context->msgcount; i++)
+        {
+          if (Context->hdrs[i]->index == oldindex)
+          {
+            menu->current = Context->hdrs[i]->virtual;
+            /* as an added courtesy, recenter the menu
+             * with the current entry at the middle of the screen */
+            menu_check_recenter (menu);
+            menu_current_middle (menu);
+          }
+        }
+      }
+      menu->redraw = REDRAW_FULL;
+    }
+    else if (rc >= 0)
+      mutt_error _("No deleted messages found in the thread.");
 	}
 	break;
 #endif

--- a/curs_main.c
+++ b/curs_main.c
@@ -1311,6 +1311,7 @@ int mutt_index_menu (void)
     /* at least one message has been loaded */
     if (Context->msgcount > oldmsgcount)
     {
+      HEADER *oldcur = CURHDR;
       HEADER *hdr;
       int i, quiet = Context->quiet;
 
@@ -1318,6 +1319,16 @@ int mutt_index_menu (void)
         Context->quiet = 1;
       mutt_sort_headers (Context, (op == OP_RECONSTRUCT_THREAD));
       Context->quiet = quiet;
+
+      /* Similar to OP_MAIN_ENTIRE_THREAD, keep displaying the old message, but
+         update the index */
+      if (menu->menu == MENU_PAGER)
+      {
+        menu->current = oldcur->virtual;
+        menu->redraw = REDRAW_STATUS | REDRAW_INDEX;
+        op = OP_DISPLAY_MESSAGE;
+        continue;
+      }
 
       /* if the root message was retrieved, move to it */
       hdr = hash_find (Context->id_hash, buf);
@@ -1342,7 +1353,16 @@ int mutt_index_menu (void)
       menu->redraw = REDRAW_FULL;
     }
     else if (rc >= 0)
+    {
       mutt_error _("No deleted messages found in the thread.");
+      /* Similar to OP_MAIN_ENTIRE_THREAD, keep displaying the old message, but
+         update the index */
+      if (menu->menu == MENU_PAGER)
+      {
+        op = OP_DISPLAY_MESSAGE;
+        continue;
+      }
+    }
 	}
 	break;
 #endif

--- a/functions.h
+++ b/functions.h
@@ -275,6 +275,9 @@ const struct binding_t OpPager[] = { /* map: pager */
   { "exit",		OP_EXIT,			"q" },
   { "reply",		OP_REPLY,			"r" },
   { "recall-message",	OP_RECALL_MESSAGE,		"R" },
+#ifdef USE_NNTP
+  { "reconstruct-thread",	OP_RECONSTRUCT_THREAD,			NULL },
+#endif
   { "read-thread",	OP_MAIN_READ_THREAD,		"\022" },
   { "read-subthread",	OP_MAIN_READ_SUBTHREAD,		"\033r" },
   { "resend-message",	OP_RESEND,			"\033e" },


### PR DESCRIPTION
and make it behave like notmuchs entire-thread function - that is, keep displaying the message that was displayed when reconstruct-thread was called, but redisplay the index.

Note that the code changes themselves are fairly small, but there's an additional commit in this pull request that reindents the code in this branch to get rid of the mix of tabs and spaces. If that's not ok with you, I can remove that commit again :-)

Note number 2: This would need an update to the features website as well.