### PR TITLE
fix new mail notifications on mbox on noatime filesystems

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -564,6 +564,8 @@ AC_CHECK_FUNCS(ftruncate, , [AC_CHECK_LIB(x, chsize)])
 dnl SCO has strftime() in libintl
 AC_CHECK_FUNCS(strftime, , [AC_CHECK_LIB(intl, strftime)])
 
+AC_CHECK_FUNCS(futimens)
+
 dnl AIX may not have fchdir()
 AC_CHECK_FUNCS(fchdir, , [mutt_cv_fchdir=no])
 

--- a/mbox.c
+++ b/mbox.c
@@ -436,6 +436,7 @@ static int mbox_open_mailbox (CONTEXT *ctx)
     rc = mmdf_parse_mailbox (ctx);
   else
     rc = -1;
+  mutt_touch_atime (fileno (ctx->fp));
 
   mbox_unlock_mailbox (ctx);
   mutt_unblock_signals ();
@@ -1254,6 +1255,8 @@ int mutt_reopen_mailbox (CONTEXT *ctx, int *index_hint)
     ctx->quiet = 0;
     return (-1);
   }
+
+  mutt_touch_atime (fileno (ctx->fp));
 
   /* now try to recover the old flags */
 

--- a/muttlib.c
+++ b/muttlib.c
@@ -2008,6 +2008,16 @@ void mutt_set_mtime (const char* from, const char* to)
   }
 }
 
+/* set atime to current time, just as read() would do on !noatime.
+ * Silently ignored if unsupported. */
+void mutt_touch_atime (int f)
+{
+#ifdef HAVE_FUTIMENS
+  struct timespec times[2]={{0,UTIME_NOW},{0,UTIME_OMIT}};
+  futimens(f, times);
+#endif
+}
+
 const char *mutt_make_version (void)
 {
   static char vstring[STRING];

--- a/protos.h
+++ b/protos.h
@@ -132,6 +132,7 @@ time_t mutt_local_tz (time_t);
 time_t mutt_mktime (struct tm *, int);
 time_t mutt_parse_date (const char *, HEADER *);
 int is_from (const char *, char *, size_t, time_t *);
+void mutt_touch_atime (int);
 
 const char *mutt_attach_fmt (
 	char *dest,

--- a/version.c
+++ b/version.c
@@ -211,6 +211,11 @@ static struct compile_options comp_opts[] =
 #else
   { "HAVE_REGCOMP", 0 },
 #endif
+#ifdef HAVE_FUTIMENS
+  { "HAVE_FUTIMENS", 1 },
+#else
+  { "HAVE_FUTIMENS", 0 },
+#endif
 #ifdef HAVE_RESIZETERM
   { "HAVE_RESIZETERM", 1 },
 #else


### PR DESCRIPTION
There are many reasons to mount all your filesystems with noatime.  The only non-fringe downside of doing so is breaking new mail notifications on mbox files -- you're wrongly told that you have new mail.

But these notifications can be fixed by having every mail client (there's not that many of them) manually touch atime (via futimens(fd, {UTIME_NOW, UTIME_OMIT})) upon reading the mbox.  There's no cost for doing so -- if automatic atime updates are on, the inode will be dirty by the read you just did.