### PR TITLE
add options to disable fake Folder: and Tags: headers for neomutt messages

### DIFF
--- a/copy.c
+++ b/copy.c
@@ -200,9 +200,7 @@ mutt_copy_hdr (FILE *in, FILE *out, LOFF_T off_start, LOFF_T off_end, int flags,
 
       /* note: CH_FROM takes precedence over header weeding. */
       if (!((flags & CH_FROM) && (flags & CH_FORCE_FROM) && this_is_from) &&
-	  (flags & CH_WEED) &&
-	  mutt_matches_ignore (buf, Ignore) &&
-	  !mutt_matches_ignore (buf, UnIgnore))
+	  (flags & CH_WEED) && mutt_matches_ignore (buf))
 	continue;
       if ((flags & CH_WEED_DELIVERED) &&
 	  ascii_strncasecmp ("Delivered-To:", buf, 13) == 0)

--- a/copy.c
+++ b/copy.c
@@ -431,7 +431,7 @@ mutt_copy_header (FILE *in, HEADER *h, FILE *out, int flags, const char *prefix)
   {
     /* Add some fake headers based on notmuch data */
     char *folder = nm_header_get_folder(h);
-    if (folder)
+    if (folder && !(option (OPTWEED) && mutt_matches_ignore ("folder")))
     {
       char buffer[LONG_STRING];
       strfcpy (buffer, folder, sizeof (buffer));
@@ -442,7 +442,7 @@ mutt_copy_header (FILE *in, HEADER *h, FILE *out, int flags, const char *prefix)
       fputc ('\n', out);
     }
     char *tags = nm_header_get_tags(h);
-    if (tags)
+    if (tags && !(option (OPTWEED) && mutt_matches_ignore ("tags")))
     {
       fputs ("Tags: ", out);
       fputs (tags, out);

--- a/mutt.h
+++ b/mutt.h
@@ -657,7 +657,8 @@ void mutt_free_list (LIST **);
 void mutt_free_rx_list (RX_LIST **);
 void mutt_free_spam_list (SPAM_LIST **);
 LIST *mutt_copy_list (LIST *);
-int mutt_matches_ignore (const char *, LIST *);
+int mutt_matches_ignore (const char *);
+int mutt_matches_list (const char *, LIST *);
 
 /* add an element to a list */
 LIST *mutt_add_list (LIST *, const char *);

--- a/muttlib.c
+++ b/muttlib.c
@@ -382,7 +382,7 @@ void mutt_free_header (HEADER **h)
 }
 
 /* returns true if the header contained in "s" is in list "t" */
-int mutt_matches_ignore (const char *s, LIST *t)
+int mutt_matches_list (const char *s, LIST *t)
 {
   for (; t; t = t->next)
   {
@@ -390,6 +390,11 @@ int mutt_matches_ignore (const char *s, LIST *t)
       return 1;
   }
   return 0;
+}
+
+/* checks Ignore and UnIgnore using mutt_matches_list */
+int mutt_matches_ignore (const char *s) {
+    return mutt_matches_list (s, Ignore) && !mutt_matches_list (s, UnIgnore);
 }
 
 /* prepend the path part of *path to *link */

--- a/parse.c
+++ b/parse.c
@@ -1347,8 +1347,7 @@ int mutt_parse_rfc822_line (ENVELOPE *e, HEADER *hdr, char *line, char *p, short
     /* restore the original line */
     line[strlen (line)] = ':';
     
-    if (weed && option (OPTWEED) && mutt_matches_ignore (line, Ignore)
-	&& !mutt_matches_ignore (line, UnIgnore))
+    if (weed && option (OPTWEED) && mutt_matches_ignore (line))
       goto done;
 
     if (last)

--- a/url.c
+++ b/url.c
@@ -316,7 +316,7 @@ int url_parse_mailto (ENVELOPE *e, char **body, const char *src)
      * choose to create a message with only a subset of the headers given in
      * the URL.
      */
-    if (mutt_matches_ignore(tag, MailtoAllow))
+    if (mutt_matches_list (tag, MailtoAllow))
     {
       if (!ascii_strcasecmp (tag, "body"))
       {


### PR DESCRIPTION
Hi folks,

At present, notmuch messages are always displayed with fake Tags: and Folder: headers. This takes up a couple lines of screen real estate, which is inconvenient (at least for me).

This is a pretty simple patch that adds two boolean options to disable these. Default behavior is the same as now (show both).

Thanks for your hard work!