### PR TITLE
Relative ranges and goodies in oldie absolute ranges

### DIFF
--- a/curs_main.c
+++ b/curs_main.c
@@ -880,6 +880,9 @@ int mutt_index_menu (void)
       unset_option (OPTREDRAWTREE);
     }
 
+    if (Context)
+      Context->menu = menu;
+
     if (Context && !attach_msg)
     {
       int check;

--- a/doc/manual.xml.head
+++ b/doc/manual.xml.head
@@ -5967,6 +5967,39 @@ string.  This example matches messages whose senders are known aliases.
 </screen>
 </example>
 
+<sect3 id="message-ranges">
+  <title>Message Ranges</title>
+
+  <para>
+    description of range types -- absolute, relative
+    mnemonics: ^ . $
+    closed vs open ranges
+  </para>
+
+  <table id="message-range-examples">
+    <title>Message Range Examples</title>
+    <tgroup cols="2">
+      <thead>
+        <row>
+          <entry>Range</entry>
+          <entry>Start</entry>
+          <entry>End</entry>
+          <entry>Description</entry>
+        </row>
+      </thead>
+      <tbody>
+        <row>
+          <entry>-3,2</entry>
+          <entry>Previous three emails</entry>
+          <entry>Next two emails</entry>
+          <entry>Relative to current email</entry>
+        </row>
+      </tbody>
+    </tgroup>
+  </table>
+
+</sect3>
+
 </sect2>
 
 <sect2 id="simple-searches">

--- a/mutt.h
+++ b/mutt.h
@@ -124,12 +124,6 @@ typedef struct
   int destroy;	/* destroy `data' when done? */
 } BUFFER;
 
-typedef struct
-{
-  int ch; /* raw key pressed */
-  int op; /* function op */
-} event_t;
-
 /* flags for _mutt_system() */
 #define MUTT_DETACH_PROCESS	1	/* detach subprocess from group */
 
@@ -1005,6 +999,8 @@ struct mx_ops
   int (*open_new_msg) (struct _message *, struct _context *, HEADER *);
 };
 
+#include "mutt_menu.h"
+
 typedef struct _context
 {
   char *path;
@@ -1032,6 +1028,8 @@ typedef struct _context
   int deleted;			/* how many deleted messages */
   int flagged;			/* how many flagged messages */
   int msgnotreadyet;		/* which msg "new" in pager, -1 if none */
+
+  MUTTMENU *menu;               /* needed for pattern compilation */
 
   short magic;			/* mailbox type */
 

--- a/mutt_curses.h
+++ b/mutt_curses.h
@@ -76,6 +76,12 @@ void mutt_curs_set (int);
 #define CI_is_return(c) ((c) == '\r' || (c) == '\n')
 #endif
 
+typedef struct
+{
+  int ch; /* raw key pressed */
+  int op; /* function op */
+} event_t;
+
 event_t mutt_getch (void);
 
 void mutt_endwin (const char *);
@@ -146,8 +152,8 @@ typedef struct color_line
   regex_t rx;
   int match; /* which substringmap 0 for old behaviour */
   char *pattern;
-  pattern_t *color_pattern; /* compiled pattern to speed up index color
-                               calculation */
+  struct pattern_t *color_pattern; /* compiled pattern to speed up index color
+                                      calculation */
   short fg;
   short bg;
   int pair;


### PR DESCRIPTION
@flatcap 

Here is the first chunk of work on the relative range patterns.

What it does: it implements your proposal completely (IMO) , but _only_ for the relative syntax.  As of now, I've left the old absolute ranges exactly as they were - no new code, no new syntax.

I want you to criticize this part first so I get a sense of your taste in code, before I proceed to mess up the existing code path.  (And eventually write docs - cough.)

Also let me know if I need to clean up the git side.  (I re-based on neomutt branch once and somehow I ended up with two copies of the commits - I don't know why or how to fix it :-0 )
