### PR TITLE
Do a buffy check after shell escape

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -620,7 +620,8 @@ void mutt_shell_escape (void)
       mutt_endwin (NULL);
       fflush (stdout);
       if (mutt_system (buf) != 0 || option (OPTWAITKEY))
-	mutt_any_key_to_continue (NULL);
+        mutt_any_key_to_continue (NULL);
+      mutt_buffy_check(1);
     }
   }
 }


### PR DESCRIPTION
Here's a trivial patch that made my user experience much better.

When the command called from a shell escape is something like fetchmail, rsync, or (in my case - I kid you not) unison, it helps to see which mailboxes were affected, immediately.

(I think the space kink in the diff is not my fault - looks like it was indented just 1 space before.)