### PR TITLE
fixing vim syntax file for index-color commands

### DIFF
--- a/doc/mutt-1.7.0-syntax.vim
+++ b/doc/mutt-1.7.0-syntax.vim
@@ -590,7 +590,7 @@ syn match muttrcColorFGNL	contained skipnl "\s*\\$" nextgroup=muttrcColorFG,mutt
 syn match muttrcColorContext 	contained /\s*[$]\?\w\+/ contains=muttrcColorField,muttrcVariable,muttrcUnHighlightSpace nextgroup=muttrcColorFG,muttrcColorFGNL
 syn match muttrcColorNL 	contained skipnl "\s*\\$" nextgroup=muttrcColorContext,muttrcColorNL
 syn match muttrcColorKeyword	contained /^\s*color\s\+/ nextgroup=muttrcColorContext,muttrcColorNL
-syn region muttrcColorLine keepend start=/^\s*color\s\+\%(index\|header\)\@!/ skip=+\\$+ end=+$+ contains=muttrcColorKeyword,muttrcComment,muttrcUnHighlightSpace
+syn region muttrcColorLine keepend start=/^\s*color\s\+\%(index\%(_\)\@!\|header\)\@!/ skip=+\\$+ end=+$+ contains=muttrcColorKeyword,muttrcComment,muttrcUnHighlightSpace
 " Now for the structure of the color index line
 syn match muttrcPatternNL	contained skipnl "\s*\\$" nextgroup=muttrcPattern,muttrcPatternNL
 syn match muttrcColorBGI	contained /\s*[$]\?\w\+\s*/ contains=muttrcColor,muttrcVariable,muttrcUnHighlightSpace nextgroup=muttrcPattern,muttrcPatternNL


### PR DESCRIPTION
color higlighting of muttrc file in vim was not correct
for entries like:

color index_subject color... color...  "!~D ~sSPAM"

This was problem for all colors specified like `color index_...`
from patch-index-color-neomutt