### PR TITLE
fixing vim syntax file for index-color commands

### DIFF
--- a/doc/vimrc.index-color
+++ b/doc/vimrc.index-color
@@ -9,4 +9,4 @@ syntax keyword muttrcColorField contained index_label
 syntax keyword muttrcColorField contained index_number
 syntax keyword muttrcColorField contained index_size
 syntax keyword muttrcColorField contained index_subject
-
+syn region muttrcColorLine keepend start=/^\s*color\s\+index_\%(author\|collapsed\|date\|flags\|label\|number\|size\|subject\)/ skip=+\\$+ end=+$+ contains=muttrcColorKeyword,muttrcComment,muttrcUnHighlightSpace


### PR DESCRIPTION
color higlighting of muttrc file in vim was not correct
for entries like:

color index_subject color... color...  "!~D ~sSPAM"

This was problem for all colors specified like `color index_...`
from patch-index-color-neomutt