### PR TITLE
Switching to stdbool logic

### DIFF
--- a/alias.c
+++ b/alias.c
@@ -602,7 +602,7 @@ static int string_is_address(const char *str, const char *u, const char *d)
   return 0;
 }
 
-/* returns TRUE if the given address belongs to the user. */
+/* returns true if the given address belongs to the user. */
 int mutt_addr_is_user (ADDRESS *addr)
 {
   const char *fqdn;

--- a/attach.c
+++ b/attach.c
@@ -919,7 +919,7 @@ int mutt_print_attachment (FILE *fp, BODY *a)
   {
     char command[_POSIX_PATH_MAX+STRING];
     rfc1524_entry *entry;
-    int piped = FALSE;
+    int piped = false;
 
     dprint (2, (debugfile, "Using mailcap...\n"));
     

--- a/browser.c
+++ b/browser.c
@@ -267,13 +267,13 @@ folder_format_str (char *dest, size_t destlen, size_t col, int cols, char op, co
     case 'D':
       if (folder->ff->local)
       {
-	int do_locales = TRUE;
+	int do_locales = true;
 
 	if (op == 'D') {
 	  t_fmt = NONULL(DateFmt);
 	  if (*t_fmt == '!') {
 	    ++t_fmt;
-	    do_locales = FALSE;
+	    do_locales = false;
 	  }
 	} else {
 	  tnow = time (NULL);

--- a/commands.c
+++ b/commands.c
@@ -234,7 +234,7 @@ int mutt_display_message (HEADER *cur)
       mutt_error (_("Error running \"%s\"!"), buf);
     unlink (tempfile);
     if (!option (OPTNOCURSES))
-      keypad (stdscr, TRUE);
+      keypad (stdscr, true);
     if (r != -1)
       mutt_set_flag (Context, cur, MUTT_READ, 1);
     if (r != -1 && option (OPTPROMPTAFTER))
@@ -889,7 +889,7 @@ int mutt_save_message (HEADER *h, int delete,
 
 #ifdef USE_NOTMUCH
       if (Context->magic == MUTT_NOTMUCH)
-        nm_longrun_init(Context, TRUE);
+        nm_longrun_init(Context, true);
 #endif
       for (i = 0; i < Context->vcount; i++)
       {

--- a/copy.c
+++ b/copy.c
@@ -132,7 +132,7 @@ mutt_copy_hdr (FILE *in, FILE *out, LOFF_T off_start, LOFF_T off_end, int flags,
 
   hdr_count = 1;
   x = 0;
-  error = FALSE;
+  error = false;
 
   /* We are going to read and collect the headers in an array
    * so we are able to do re-ordering.
@@ -302,7 +302,7 @@ mutt_copy_hdr (FILE *in, FILE *out, LOFF_T off_start, LOFF_T off_end, int flags,
 				   flags & CH_PREFIX ? prefix : 0,
                                    mutt_window_wrap_cols (MuttIndexWindow, Wrap), flags) == -1)
 	{
-	  error = TRUE;
+	  error = true;
 	  break;
 	}
       }
@@ -310,7 +310,7 @@ mutt_copy_hdr (FILE *in, FILE *out, LOFF_T off_start, LOFF_T off_end, int flags,
       {      
 	if (fputs (headers[x], out) == EOF)
 	{
-	  error = TRUE;
+	  error = true;
 	  break;
 	}
       }

--- a/curs_lib.c
+++ b/curs_lib.c
@@ -98,8 +98,8 @@ void mutt_refresh (void)
    customize this is of course the Mutt way.  */
 void mutt_need_hard_redraw (void)
 {
-  keypad (stdscr, TRUE);
-  clearok (stdscr, TRUE);
+  keypad (stdscr, true);
+  clearok (stdscr, true);
   set_option (OPTNEEDREDRAW);
 }
 
@@ -216,8 +216,8 @@ void mutt_edit_file (const char *editor, const char *data)
   /* the terminal may have been resized while the editor owned it */
   mutt_resize_screen ();
 #endif
-  keypad (stdscr, TRUE);
-  clearok (stdscr, TRUE);
+  keypad (stdscr, true);
+  clearok (stdscr, true);
 }
 
 int mutt_yesorno (const char *msg, int def)

--- a/curs_main.c
+++ b/curs_main.c
@@ -231,7 +231,7 @@ short mutt_ts_capability(void)
   /* If XT (boolean) is set, then this terminal supports the standard escape. */
   /* Beware: tigetflag returns -1 if XT is invalid or not a boolean. */
 #ifdef HAVE_USE_EXTENDED_NAMES
-  use_extended_names (TRUE);
+  use_extended_names (true);
   tcapi = tigetflag("XT");
   if (tcapi == 1)
     return 1;
@@ -1045,7 +1045,7 @@ int mutt_index_menu (void)
 	 * force a real complete redraw.  clrtobot() doesn't seem to be able
 	 * to handle every case without this.
 	 */
-	clearok(stdscr,TRUE);
+	clearok(stdscr,true);
 	continue;
       }
 #endif
@@ -1557,7 +1557,7 @@ int mutt_index_menu (void)
 
       case OP_REDRAW:
 
-	clearok (stdscr, TRUE);
+	clearok (stdscr, true);
 	menu->redraw = REDRAW_FULL;
 	break;
 
@@ -1755,12 +1755,12 @@ int mutt_index_menu (void)
 	if (tag) {
 	  for (j = 0; j < Context->vcount; j++) {
 	    if (Context->hdrs[Context->v2r[j]]->tagged) {
-	      Context->hdrs[Context->v2r[j]]->quasi_deleted = TRUE;
-	      Context->changed = TRUE;
+	      Context->hdrs[Context->v2r[j]]->quasi_deleted = true;
+	      Context->changed = true;
 	    }
 	  }
 	} else {
-	  CURHDR->quasi_deleted = TRUE;
+	  CURHDR->quasi_deleted = true;
 	  Context->changed = 1;
 	}
 	break;
@@ -1826,7 +1826,7 @@ int mutt_index_menu (void)
 	    mutt_progress_init(&progress, msgbuf, MUTT_PROGRESS_MSG,
 				   1, Context->tagged);
 	  }
-	  nm_longrun_init(Context, TRUE);
+	  nm_longrun_init(Context, true);
 	  for (px = 0, j = 0; j < Context->vcount; j++) {
 	    if (Context->hdrs[Context->v2r[j]]->tagged) {
 	      if (!Context->quiet)
@@ -1834,8 +1834,8 @@ int mutt_index_menu (void)
 	      nm_modify_message_tags(Context, Context->hdrs[Context->v2r[j]], buf);
 	      if (op == OP_MAIN_MODIFY_LABELS_THEN_HIDE)
 	      {
-		Context->hdrs[Context->v2r[j]]->quasi_deleted = TRUE;
-	        Context->changed = TRUE;
+		Context->hdrs[Context->v2r[j]]->quasi_deleted = true;
+	        Context->changed = true;
 	      }
 	    }
 	  }
@@ -1850,8 +1850,8 @@ int mutt_index_menu (void)
 	  }
 	  if (op == OP_MAIN_MODIFY_LABELS_THEN_HIDE)
 	  {
-	    CURHDR->quasi_deleted = TRUE;
-	    Context->changed = TRUE;
+	    CURHDR->quasi_deleted = true;
+	    Context->changed = true;
 	  }
 	  if (menu->menu == MENU_PAGER)
 	  {

--- a/edit.c
+++ b/edit.c
@@ -325,7 +325,7 @@ int mutt_builtin_editor (const char *path, HEADER *msg, HEADER *cur)
   int i;
   char *p;
   
-  scrollok (stdscr, TRUE);
+  scrollok (stdscr, true);
 
   be_edit_header (msg->env, 0);
 

--- a/handler.c
+++ b/handler.c
@@ -1309,7 +1309,7 @@ static int autoview_handler (BODY *a, STATE *s)
   FILE *fpin = NULL;
   FILE *fpout = NULL;
   FILE *fperr = NULL;
-  int piped = FALSE;
+  int piped = false;
   pid_t thepid;
   int rc = 0;
 

--- a/init.c
+++ b/init.c
@@ -3027,7 +3027,7 @@ static int complete_all_nm_tags (const char *pt)
   memset (Matches, 0, Matches_listsize);
   memset (Completed, 0, sizeof (Completed));
 
-  nm_longrun_init(Context, FALSE);
+  nm_longrun_init(Context, false);
 
   /* Work out how many tags there are. */
   if (nm_get_all_tags(Context, NULL, &tag_count_1) || tag_count_1 == 0)

--- a/keymap.c
+++ b/keymap.c
@@ -693,7 +693,7 @@ void init_extended_keys(void)
 #ifdef NCURSES_VERSION
   int j;
 
-  use_extended_names(TRUE);
+  use_extended_names(true);
 
   for (j = 0; KeyNames[j].name; ++j)
   {

--- a/lib.h
+++ b/lib.h
@@ -35,6 +35,7 @@
 # include <time.h>
 # include <limits.h>
 # include <stdarg.h>
+# include <stdbool.h>
 # include <signal.h>
 
 # ifndef _POSIX_PATH_MAX
@@ -53,9 +54,6 @@
 #  define _(a) (a)
 #  define N_(a) a
 # endif
-
-# define TRUE 1
-# define FALSE 0
 
 # define HUGE_STRING     8192
 # define LONG_STRING     1024

--- a/main.c
+++ b/main.c
@@ -156,7 +156,7 @@ static void start_curses (void)
   mutt_signal_init ();
 #endif
   ci_start_color ();
-  keypad (stdscr, TRUE);
+  keypad (stdscr, true);
   cbreak ();
   noecho ();
   nonl ();
@@ -164,7 +164,7 @@ static void start_curses (void)
   typeahead (-1);       /* simulate smooth scrolling */
 #endif
 #if HAVE_META
-  meta (stdscr, TRUE);
+  meta (stdscr, true);
 #endif
 init_extended_keys();
   mutt_reflow_windows ();

--- a/menu.c
+++ b/menu.c
@@ -1016,7 +1016,7 @@ int mutt_menuLoop (MUTTMENU *menu)
       mutt_resize_screen ();
       menu->redraw = REDRAW_FULL;
       SigWinch = 0;
-      clearok(stdscr,TRUE);/*force complete redraw*/
+      clearok(stdscr,true);/*force complete redraw*/
     }
 #endif
 
@@ -1152,7 +1152,7 @@ int mutt_menuLoop (MUTTMENU *menu)
 	break;
 
       case OP_REDRAW:
-	clearok (stdscr, TRUE);
+	clearok (stdscr, true);
 	menu->redraw = REDRAW_FULL;
 	break;
 

--- a/mutt.h
+++ b/mutt.h
@@ -34,6 +34,7 @@
 #include <time.h>
 #include <limits.h>
 #include <stdarg.h>
+#include <stdbool.h>
 #include <signal.h>
 /* On OS X 10.5.x, wide char functions are inlined by default breaking
  * --without-wc-funcs compilation
@@ -57,12 +58,21 @@
 #define PATH_MAX _POSIX_PATH_MAX
 #endif
 
+#include <libgen.h>
 #include <pwd.h>
 #include <grp.h>
 
 #include "rfc822.h"
 #include "hash.h"
 #include "charset.h"
+
+#ifndef __bool_true_false_are_defined
+# define boot int
+# define _Bool int
+# define false 0
+# define true (!false)
+# define __bool_true_false_are_defined 1
+#endif
 
 #ifndef HAVE_WC_FUNCS
 # ifdef MB_LEN_MAX
@@ -1127,3 +1137,7 @@ typedef struct
 #include "globals.h"
 
 #endif /*MUTT_H*/
+
+
+
+

--- a/mutt_notmuch.c
+++ b/mutt_notmuch.c
@@ -503,7 +503,7 @@ static notmuch_database_t *get_db(struct nm_ctxdata *data, int writable)
 		const char *db_filename = get_db_filename(data);
 
 		if (db_filename)
-			data->db = do_database_open(db_filename, writable, TRUE);
+			data->db = do_database_open(db_filename, writable, true);
 	}
 	return data->db;
 }
@@ -1160,7 +1160,7 @@ int nm_read_query(CONTEXT *ctx)
 
 	nm_progress_reset(ctx);
 
-	q = get_query(data, FALSE);
+	q = get_query(data, false);
 	if (q) {
 		switch(get_query_type(data)) {
 		case NM_QUERY_TYPE_MESGS:
@@ -1200,7 +1200,7 @@ int nm_read_entire_thread(CONTEXT *ctx, HEADER *h)
 
 	if (!data)
 		return -1;
-	if (!(db = get_db(data, FALSE)) || !(msg = get_nm_message(db, h)))
+	if (!(db = get_db(data, false)) || !(msg = get_nm_message(db, h)))
 		goto done;
 
 	dprint(1, (debugfile, "nm: reading entire-thread messages...[current count=%d]\n",
@@ -1439,7 +1439,7 @@ int nm_modify_message_tags(CONTEXT *ctx, HEADER *hdr, char *buf)
 	if (!buf || !*buf || !data)
 		return -1;
 
-	if (!(db = get_db(data, TRUE)) || !(msg = get_nm_message(db, hdr)))
+	if (!(db = get_db(data, true)) || !(msg = get_nm_message(db, hdr)))
 		goto done;
 
 	dprint(1, (debugfile, "nm: tags modify: '%s'\n", buf));
@@ -1450,7 +1450,7 @@ int nm_modify_message_tags(CONTEXT *ctx, HEADER *hdr, char *buf)
 	mutt_set_header_color(ctx, hdr);
 
 	rc = 0;
-	hdr->changed = TRUE;
+	hdr->changed = true;
 done:
 	if (!is_longrun(data))
 		release_db(data);
@@ -1509,7 +1509,7 @@ static int remove_filename(struct nm_ctxdata *data, const char *path)
 	notmuch_status_t st;
 	notmuch_filenames_t *ls;
 	notmuch_message_t *msg = NULL;
-	notmuch_database_t *db = get_db(data, TRUE);
+	notmuch_database_t *db = get_db(data, true);
 	int trans;
 
 	dprint(2, (debugfile, "nm: remove filename '%s'\n", path));
@@ -1565,7 +1565,7 @@ static int rename_filename(struct nm_ctxdata *data,
 	notmuch_status_t st;
 	notmuch_filenames_t *ls;
 	notmuch_message_t *msg;
-	notmuch_database_t *db = get_db(data, TRUE);
+	notmuch_database_t *db = get_db(data, true);
 	int trans;
 
 	if (!db || !new || !old || access(new, F_OK) != 0)
@@ -1796,7 +1796,7 @@ int nm_nonctx_get_count(char *path, int *all, int *new)
 
 	/* don't be verbose about connection, as we're called from
 	 * sidebar/buffy very often */
-	db = do_database_open(db_filename, FALSE, FALSE);
+	db = do_database_open(db_filename, false, false);
 	if (!db)
 		goto done;
 
@@ -1911,7 +1911,7 @@ static int nm_check_database(CONTEXT *ctx, int *index_hint)
 
 	dprint(1, (debugfile, "nm: checking (db=%d ctx=%d)\n", mtime, ctx->mtime));
 
-	q = get_query(data, FALSE);
+	q = get_query(data, false);
 	if (!q)
 		goto done;
 
@@ -2013,7 +2013,7 @@ int nm_record_message(CONTEXT *ctx, char *path, HEADER *h)
 
 	if (!path || !data || access(path, F_OK) != 0)
 		return 0;
-	db = get_db(data, TRUE);
+	db = get_db(data, true);
 	if (!db)
 		return -1;
 
@@ -2064,7 +2064,7 @@ int nm_get_all_tags(CONTEXT *ctx, char **tag_list, int *tag_count)
 	if (!data)
 		return -1;
 
-	if (!(db = get_db(data, FALSE)) ||
+	if (!(db = get_db(data, false)) ||
 			!(tags = notmuch_database_get_all_tags(db)))
 		goto done;
 

--- a/nntp.c
+++ b/nntp.c
@@ -819,7 +819,7 @@ static int nntp_query (NNTP_DATA *nntp_data, char *line, size_t linelen)
 static int nntp_fetch_lines (NNTP_DATA *nntp_data, char *query, size_t qlen,
 			char *msg, int (*funct) (char *, void *), void *data)
 {
-  int done = FALSE;
+  int done = false;
   int rc;
 
   while (!done)
@@ -861,7 +861,7 @@ static int nntp_fetch_lines (NNTP_DATA *nntp_data, char *query, size_t qlen,
       {
 	if (buf[1] == '\0')
 	{
-	  done = TRUE;
+	  done = true;
 	  break;
 	}
 	if (buf[1] == '.')
@@ -2192,7 +2192,7 @@ int nntp_check_new_groups (NNTP_SERVER *nserv)
   char buf[LONG_STRING];
   char *msg = _("Checking for new newsgroups...");
   unsigned int i;
-  int rc, update_active = FALSE;
+  int rc, update_active = false;
 
   if (!nserv || !nserv->newgroups_time)
     return -1;
@@ -2211,7 +2211,7 @@ int nntp_check_new_groups (NNTP_SERVER *nserv)
 	if (rc < 0)
 	  return -1;
 	if (rc > 0)
-	  update_active = TRUE;
+	  update_active = true;
       }
     }
     /* select current newsgroup */
@@ -2274,7 +2274,7 @@ int nntp_check_new_groups (NNTP_SERVER *nserv)
 	mutt_progress_update (&progress, ++count, -1);
       }
     }
-    update_active = TRUE;
+    update_active = true;
     rc = 1;
   }
   if (update_active)

--- a/pager.c
+++ b/pager.c
@@ -2151,7 +2151,7 @@ mutt_pager (const char *banner, const char *fname, int flags, pager_t *extra)
       }
 
       SigWinch = 0;
-      clearok(stdscr,TRUE);/*force complete redraw*/
+      clearok(stdscr,true);/*force complete redraw*/
       continue;
     }
 #endif
@@ -2545,7 +2545,7 @@ search_next:
 	break;
 
       case OP_REDRAW:
-	clearok (stdscr, TRUE);
+	clearok (stdscr, true);
 	redraw = REDRAW_FULL;
 	break;
 

--- a/pattern.c
+++ b/pattern.c
@@ -702,8 +702,8 @@ static int eat_date (pattern_t *pat, BUFFER *s, BUFFER *err)
   {
     const char *pc = buffer.data;
 
-    int haveMin = FALSE;
-    int untilNow = FALSE;
+    int haveMin = false;
+    int untilNow = false;
     if (isdigit ((unsigned char)*pc))
     {
       /* minimum date specified */
@@ -712,7 +712,7 @@ static int eat_date (pattern_t *pat, BUFFER *s, BUFFER *err)
 	FREE (&buffer.data);
 	return (-1);
       }
-      haveMin = TRUE;
+      haveMin = true;
       SKIPWS (pc);
       if (*pc == '-')
       {

--- a/resize.c
+++ b/resize.c
@@ -72,7 +72,7 @@ void mutt_resize_screen (void)
   SLsmg_reset_smg ();
   SLsmg_init_smg ();
   stdscr = newwin (0, 0, 0, 0);
-  keypad (stdscr, TRUE);
+  keypad (stdscr, true);
 #else
   resizeterm (SLtt_Screen_Rows, SLtt_Screen_Cols);
 #endif

--- a/rfc1524.c
+++ b/rfc1524.c
@@ -59,7 +59,7 @@ int rfc1524_expand_command (BODY *a, char *filename, char *_type,
     char *command, int clen)
 {
   int x=0,y=0;
-  int needspipe = TRUE;
+  int needspipe = true;
   char buf[LONG_STRING];
   char type[LONG_STRING];
   
@@ -100,7 +100,7 @@ int rfc1524_expand_command (BODY *a, char *filename, char *_type,
       else if (command[x] == 's' && filename != NULL)
       {
 	y += mutt_quote_filename (buf + y, sizeof (buf) - y, filename);
-	needspipe = FALSE;
+	needspipe = false;
       }
       else if (command[x] == 't')
       {
@@ -178,7 +178,7 @@ static int rfc1524_mailcap_parse (BODY *a,
   size_t buflen;
   char *ch;
   char *field;
-  int found = FALSE;
+  int found = false;
   int copiousoutput;
   int composecommand;
   int editcommand;
@@ -199,7 +199,7 @@ static int rfc1524_mailcap_parse (BODY *a,
 
   /* find length of basetype */
   if ((ch = strchr (type, '/')) == NULL)
-    return FALSE;
+    return false;
   btlen = ch - type;
 
   if ((fp = fopen (filename, "r")) != NULL)
@@ -226,11 +226,11 @@ static int rfc1524_mailcap_parse (BODY *a,
 	entry->command = safe_strdup (field);
 
       /* parse the optional fields */
-      found = TRUE;
-      copiousoutput = FALSE;
-      composecommand = FALSE;
-      editcommand = FALSE;
-      printcommand = FALSE;
+      found = true;
+      copiousoutput = false;
+      composecommand = false;
+      editcommand = false;
+      printcommand = false;
 
       while (ch)
       {
@@ -241,38 +241,38 @@ static int rfc1524_mailcap_parse (BODY *a,
 	if (!ascii_strcasecmp (field, "needsterminal"))
 	{
 	  if (entry)
-	    entry->needsterminal = TRUE;
+	    entry->needsterminal = true;
 	}
 	else if (!ascii_strcasecmp (field, "copiousoutput"))
 	{
-	  copiousoutput = TRUE;
+	  copiousoutput = true;
 	  if (entry)
-	    entry->copiousoutput = TRUE;
+	    entry->copiousoutput = true;
 	}
 	else if (!ascii_strncasecmp (field, "composetyped", 12))
 	{
 	  /* this compare most occur before compose to match correctly */
 	  if (get_field_text (field + 12, entry ? &entry->composetypecommand : NULL,
 			      type, filename, line))
-	    composecommand = TRUE;
+	    composecommand = true;
 	}
 	else if (!ascii_strncasecmp (field, "compose", 7))
 	{
 	  if (get_field_text (field + 7, entry ? &entry->composecommand : NULL,
 			      type, filename, line))
-	    composecommand = TRUE;
+	    composecommand = true;
 	}
 	else if (!ascii_strncasecmp (field, "print", 5))
 	{
 	  if (get_field_text (field + 5, entry ? &entry->printcommand : NULL,
 			      type, filename, line))
-	    printcommand = TRUE;
+	    printcommand = true;
 	}
 	else if (!ascii_strncasecmp (field, "edit", 4))
 	{
 	  if (get_field_text (field + 4, entry ? &entry->editcommand : NULL,
 			      type, filename, line))
-	    editcommand = TRUE;
+	    editcommand = true;
 	}
 	else if (!ascii_strncasecmp (field, "nametemplate", 12))
 	{
@@ -302,7 +302,7 @@ static int rfc1524_mailcap_parse (BODY *a,
 	    if (mutt_system (test_command))
 	    {
 	      /* a non-zero exit code means test failed */
-	      found = FALSE;
+	      found = false;
 	    }
 	    FREE (&test_command);
 	  }
@@ -312,22 +312,22 @@ static int rfc1524_mailcap_parse (BODY *a,
       if (opt == MUTT_AUTOVIEW)
       {
 	if (!copiousoutput)
-	  found = FALSE;
+	  found = false;
       }
       else if (opt == MUTT_COMPOSE)
       {
 	if (!composecommand)
-	  found = FALSE;
+	  found = false;
       }
       else if (opt == MUTT_EDIT)
       {
 	if (!editcommand)
-	  found = FALSE;
+	  found = false;
       }
       else if (opt == MUTT_PRINT)
       {
 	if (!printcommand)
-	  found = FALSE;
+	  found = false;
       }
       
       if (!found)
@@ -382,7 +382,7 @@ int rfc1524_mailcap_lookup (BODY *a, char *type, rfc1524_entry *entry, int opt)
 {
   char path[_POSIX_PATH_MAX];
   int x;
-  int found = FALSE;
+  int found = false;
   char *curr = MailcapPath;
 
   /* rfc1524 specifies that a path of mailcap files should be searched.


### PR DESCRIPTION
I did not change the types of function prototypes, just switched from the basic `TRUE`/`FALSE` to standard C99 `true`/`false`.

I noticed many function are doing return a boolean value coded with `-1` (fail) `0` (success), which feels very wrong (that logic should only be used on `exit()`, or when returning from `main()`).

Many functions have an `int` return value, with only `1` or `0` as return values. Those can easily be converted at a later stage.

I kept this commit as atomic as possible to avoid merging friction, thus focusing on adding stdbool and switching `TRUE`→`true` and `FALSE`→`false`, for the matter I used a bit of sed magic:

```
sed -i 's/TRUE/true/g' *.[ch]
sed -i 's/FALSE/false/g' *.[ch]
```