### PR TITLE
Support for aborting mailbox loading

### DIFF
--- a/mbox.c
+++ b/mbox.c
@@ -126,6 +126,10 @@ int mmdf_parse_mailbox (CONTEXT *ctx)
     if (fgets (buf, sizeof (buf) - 1, ctx->fp) == NULL)
       break;
 
+    if (SigInt == 1) {
+      break;
+    }
+
     if (mutt_strcmp (buf, MMDF_SEP) == 0)
     {
       loc = ftello (ctx->fp);
@@ -220,7 +224,12 @@ int mmdf_parse_mailbox (CONTEXT *ctx)
   if (ctx->msgcount > oldmsgcount)
     mx_update_context (ctx, ctx->msgcount - oldmsgcount);
 
-  return (0);
+  if (SigInt == 1) {
+      SigInt = 0;
+      return -2;
+  }
+
+  return 0;
 }
 
 /* Note that this function is also called when new mail is appended to the
@@ -273,7 +282,7 @@ int mbox_parse_mailbox (CONTEXT *ctx)
   }
 
   loc = ftello (ctx->fp);
-  while (fgets (buf, sizeof (buf), ctx->fp) != NULL)
+  while ((fgets (buf, sizeof (buf), ctx->fp) != NULL) && (SigInt != 0))
   {
     if (is_from (buf, return_path, sizeof (return_path), &t))
     {
@@ -408,7 +417,12 @@ int mbox_parse_mailbox (CONTEXT *ctx)
     mx_update_context (ctx, count);
   }
 
-  return (0);
+  if (SigInt == 1) {
+    SigInt = 0;
+    return -2;
+  }
+
+  return 0;
 }
 
 #undef PREV

--- a/mh.c
+++ b/mh.c
@@ -842,7 +842,7 @@ static int maildir_parse_dir (CONTEXT * ctx, struct maildir ***last,
   if ((dirp = opendir (buf)) == NULL)
     return -1;
 
-  while ((de = readdir (dirp)) != NULL)
+  while ((de = readdir (dirp)) != NULL && (SigInt != 1))
   {
     if ((ctx->magic == MUTT_MH && !mh_valid_message (de->d_name))
 	|| (ctx->magic == MUTT_MAILDIR && *de->d_name == '.'))
@@ -884,6 +884,11 @@ static int maildir_parse_dir (CONTEXT * ctx, struct maildir ***last,
   }
 
   closedir (dirp);
+
+  if (SigInt == 1) {
+    SigInt = 0;
+    return -2;
+  }
 
   return 0;
 }

--- a/mx.c
+++ b/mx.c
@@ -672,7 +672,7 @@ CONTEXT *mx_open_mailbox (const char *path, int flags, CONTEXT *pctx)
 
   rc = ctx->mx_ops->open(ctx);
 
-  if (rc == 0)
+  if ((rc == 0) || (rc == -2))
   {
     if ((flags & MUTT_NOSORT) == 0)
     {
@@ -684,6 +684,8 @@ CONTEXT *mx_open_mailbox (const char *path, int flags, CONTEXT *pctx)
     }
     if (!ctx->quiet)
       mutt_clear_error ();
+    if (rc == -2)
+      mutt_error(_("Reading from %s interrupted..."), ctx->path);
   }
   else
   {


### PR DESCRIPTION
- Added new return value for mx_ops.open() signature: -2 value means
  aborted mailbox load ;
- Added check for SigInt in mail loading routine

Added support for Notmuch, Maildir and mbox.

fixes #248