### PR TITLE
Added -S option to -D dump option to hide senstitive info

### DIFF
--- a/init.c
+++ b/init.c
@@ -3317,12 +3317,12 @@ int mutt_query_variables (LIST *queries)
 }
 
 /* dump out the value of all the variables we have */
-int mutt_dump_variables (void)
+int mutt_dump_variables (int hide_sensitive)
 {
-  int i;
-  
+  int i, j;
+
   char command[STRING];
-  
+
   BUFFER err, token;
 
   mutt_buffer_init (&err);
@@ -3330,7 +3330,7 @@ int mutt_dump_variables (void)
 
   err.dsize = STRING;
   err.data = safe_malloc (err.dsize);
-  
+
   for (i = 0; MuttVars[i].option; i++)
   {
     if (MuttVars[i].type == DT_SYN)
@@ -3345,7 +3345,18 @@ int mutt_dump_variables (void)
 
       return 1;
     }
-    printf("%s\n", err.data);
+    if (hide_sensitive && (strstr(err.data, "\"\"") == NULL)) {
+      for (j = 0; MuttSensitiveVars[j]; ++j) {
+	if (!strcmp(MuttVars[i].option, MuttSensitiveVars[j])) {
+	  printf("%s='******'\n", MuttVars[i].option);
+	  break;
+	}
+      }
+      if (!MuttSensitiveVars[j])
+	printf("%s\n", err.data);
+    }
+    else
+      printf("%s\n", err.data);
   }
   
   FREE (&token.data);

--- a/init.h
+++ b/init.h
@@ -4483,3 +4483,14 @@ const struct command_t Commands[] = {
   { "unsubscribe",	parse_unsubscribe,	0 },
   { NULL,		NULL,			0 }
 };
+
+char *MuttSensitiveVars[] = {
+    "imap_login", "imap_pass",
+    "nntp_user", "nntp_pass", 
+    "pop_user", "pop_pass", 
+    "smtp_pass", 
+    NULL
+};
+
+
+

--- a/main.c
+++ b/main.c
@@ -90,6 +90,7 @@ static void mutt_usage (void)
        mutt [<options>] -A <alias> [...]\n\
        mutt [<options>] -Q <query> [...]\n\
        mutt [<options>] -D\n\
+       mutt [<options>] -D -S\n\
        mutt -v[v]\n");
 
   puts _("\
@@ -99,7 +100,8 @@ options:\n\
 \t\tthe list of files must be terminated with the \"--\" sequence\n\
   -b <address>\tspecify a blind carbon-copy (BCC) address\n\
   -c <address>\tspecify a carbon-copy (CC) address\n\
-  -D\t\tprint the value of all variables to stdout");
+  -D\t\tprint the value of all variables to stdout\n\
+  -DS\t\tprint the value of all variables to stdout (hiding sensitive info)");
 #if DEBUG
   puts _("  -d <level>\tlog debugging output to ~/.muttdebug0");
 #endif
@@ -196,6 +198,7 @@ int main (int argc, char **argv, char **environ)
   int version = 0;
   int i;
   int explicit_folder = 0;
+  int hide_sensitive_variables = 0;
   int dump_variables = 0;
   int edit_infile = 0;
   extern char *optarg;
@@ -262,9 +265,9 @@ int main (int argc, char **argv, char **environ)
     }
 
 #ifdef USE_NNTP
-    if ((i = getopt (argc, argv, "+A:a:b:F:f:c:Dd:Ee:g:GH:s:i:hm:npQ:RvxyzZ")) != EOF)
+    if ((i = getopt (argc, argv, "+A:a:b:F:f:c:Dd:Ee:g:GH:Ss:i:hm:npQ:RvxyzZ")) != EOF)
 #else
-    if ((i = getopt (argc, argv, "+A:a:b:F:f:c:Dd:Ee:H:s:i:hm:npQ:RvxyzZ")) != EOF)
+    if ((i = getopt (argc, argv, "+A:a:b:F:f:c:Dd:Ee:H:Ss:i:hm:npQ:RvxyzZ")) != EOF)
 #endif
       switch (i)
       {
@@ -298,6 +301,11 @@ int main (int argc, char **argv, char **environ)
 
       case 'D':
 	dump_variables = 1;
+	break;
+
+      case 'S':
+	if (dump_variables)
+          hide_sensitive_variables = 1;
 	break;
 
       case 'd':
@@ -449,7 +457,7 @@ int main (int argc, char **argv, char **environ)
     return mutt_query_variables (queries);
   }
   if (dump_variables)
-    return mutt_dump_variables();
+    return mutt_dump_variables(hide_sensitive_variables);
 
   if (alias_queries)
   {

--- a/protos.h
+++ b/protos.h
@@ -317,7 +317,7 @@ int mutt_compose_attachment (BODY *a);
 int mutt_copy_body (FILE *, BODY **, BODY *);
 int mutt_decode_save_attachment (FILE *, BODY *, char *, int, int);
 int mutt_display_message (HEADER *h);
-int mutt_dump_variables (void);
+int mutt_dump_variables (int hide_sensitive);
 int mutt_edit_attachment(BODY *);
 int mutt_edit_message (CONTEXT *, HEADER *);
 int mutt_fetch_recips (ENVELOPE *out, ENVELOPE *in, int flags);


### PR DESCRIPTION
- added MuttSensitiveVar list at the end of init.h
- added variable in main() to check for -S
- updated mutt_dump_variables

fixes #236