### PR TITLE
added gtags files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,7 @@ txt2c
 
 neomutt-*.tar.gz
 
+# gtags things
+GPATH
+GRTAGS
+GTAGS


### PR DESCRIPTION
The Source code tagging system [GNU Global](https://www.gnu.org/software/global/) (very similar to ctags and such) creates during its indexing step various binary files to save the results. Those files are git-ignored with this PR.