### PR TITLE
fix: bug introduced by mkdir changes

### DIFF
--- a/newsrc.c
+++ b/newsrc.c
@@ -960,6 +960,7 @@ NNTP_SERVER *nntp_select_server (char *server, int leave_lock)
       mutt_error (_("Can't create %s: %s."), file, strerror (errno));
       mutt_sleep (2);
     }
+    nserv->cacheable = 1;
   }
 
   /* load .newsrc */


### PR DESCRIPTION
When converting NNTP to use mutt_mkdir() a line of code got lost.
Commit: 6800b2a nntp: use mutt_mkdir

Closes #338