### PR TITLE
Remove two use-after free in global hooks

### DIFF
--- a/hook.c
+++ b/hook.c
@@ -587,7 +587,6 @@ void mutt_timeout_hook (void)
 
     if (mutt_parse_rc_line (hook->command, &token, &err) == -1)
     {
-      FREE (&token.data);
       mutt_error ("%s", err.data);
       mutt_sleep (1);
 
@@ -595,6 +594,7 @@ void mutt_timeout_hook (void)
        * failed, we'll carry on with the others. */
     }
   }
+  FREE (&token.data);
 }
 
 /**
@@ -622,11 +622,11 @@ void mutt_startup_shutdown_hook (int type)
 
     if (mutt_parse_rc_line (hook->command, &token, &err) == -1)
     {
-      FREE (&token.data);
       mutt_error ("%s", err.data);
       mutt_sleep (1);
 
     }
   }
+  FREE (&token.data);
 }
 


### PR DESCRIPTION
Fixes #347
In both mutt_timeout_hook and mutt_startup_shutdown_hook, we iterate on
the list of hooks and try to execute the right ones, always using the
same buffer. The buffer must be free'd after all the hooks have been
checked and not after the first hook which fails. This also removes a
memory leak, because the buffer was never freed if no hook failed.