### PR TITLE
Simplify imap_keepalive + some cleanup

### DIFF
--- a/curs_main.c
+++ b/curs_main.c
@@ -1666,7 +1666,7 @@ int mutt_index_menu (void)
 #ifdef USE_IMAP
       case OP_MAIN_IMAP_FETCH:
 	if (Context && Context->magic == MUTT_IMAP)
-	  imap_check_mailbox (Context, &index_hint, 1);
+	  imap_check_mailbox (Context, 1);
         break;
 
       case OP_MAIN_IMAP_LOGOUT_ALL:

--- a/imap/imap.h
+++ b/imap/imap.h
@@ -33,9 +33,9 @@ typedef struct
 
 /* imap.c */
 int imap_access (const char*, int);
-int imap_check_mailbox (CONTEXT *ctx, int *index_hint, int force);
-int imap_delete_mailbox (CONTEXT* idata, IMAP_MBOX mx);
-int imap_sync_mailbox (CONTEXT *ctx, int expunge, int *index_hint);
+int imap_check_mailbox (CONTEXT* ctx, int force);
+int imap_delete_mailbox (CONTEXT* ctx, IMAP_MBOX mx);
+int imap_sync_mailbox (CONTEXT *ctx, int expunge);
 int imap_close_mailbox (CONTEXT *ctx);
 int imap_buffy_check (int force, int check_stats);
 int imap_status (char *path, int queue);

--- a/imap/imap_private.h
+++ b/imap/imap_private.h
@@ -226,11 +226,9 @@ typedef struct
 } IMAP_DATA;
 /* I wish that were called IMAP_CONTEXT :( */
 
-/* -- macros -- */
-#define CTX_DATA ((IMAP_DATA *) ctx->data)
-
 /* -- private IMAP functions -- */
 /* imap.c */
+int imap_check (IMAP_DATA* idata, int force);
 int imap_create_mailbox (IMAP_DATA* idata, char* mailbox);
 int imap_rename_mailbox (IMAP_DATA* idata, IMAP_MBOX* mx, const char* newname);
 IMAP_STATUS* imap_mboxcache_get (IMAP_DATA* idata, const char* mbox,

--- a/imap/message.c
+++ b/imap/message.c
@@ -413,7 +413,7 @@ int imap_fetch_message (CONTEXT *ctx, MESSAGE *msg, int msgno)
    * fails. Thanks Sam. */
   short fetched = 0;
 
-  idata = (IMAP_DATA*) ctx->data;
+  idata = ctx->data;
   h = ctx->hdrs[msgno];
 
   if ((msg->fp = msg_cache_get (idata, h)))
@@ -629,7 +629,7 @@ int imap_append_message (CONTEXT *ctx, MESSAGE *msg)
   IMAP_MBOX mx;
   int rc;
 
-  idata = (IMAP_DATA*) ctx->data;
+  idata = ctx->data;
 
   if (imap_parse_path (ctx->path, &mx))
     return -1;
@@ -768,7 +768,7 @@ int imap_copy_messages (CONTEXT* ctx, HEADER* h, char* dest, int delete)
   int err_continue = MUTT_NO;
   int triedcreate = 0;
 
-  idata = (IMAP_DATA*) ctx->data;
+  idata = ctx->data;
 
   if (imap_parse_path (dest, &mx))
   {
@@ -777,7 +777,7 @@ int imap_copy_messages (CONTEXT* ctx, HEADER* h, char* dest, int delete)
   }
 
   /* check that the save-to folder is in the same account */
-  if (!mutt_account_match (&(CTX_DATA->conn->account), &(mx.account)))
+  if (!mutt_account_match (&(idata->conn->account), &(mx.account)))
   {
     dprint (3, (debugfile, "imap_copy_messages: %s not same server as %s\n",
       dest, ctx->path));
@@ -994,7 +994,7 @@ int imap_cache_del (IMAP_DATA* idata, HEADER* h)
 static int msg_cache_clean_cb (const char* id, body_cache_t* bcache, void* data)
 {
   unsigned int uv, uid, n;
-  IMAP_DATA* idata = (IMAP_DATA*)data;
+  IMAP_DATA* idata = data;
 
   if (sscanf (id, "%u-%u", &uv, &uid) != 2)
     return 0;
@@ -1108,7 +1108,7 @@ static int msg_fetch_header (CONTEXT* ctx, IMAP_HEADER* h, char* buf, FILE* fp)
   long bytes;
   int rc = -1; /* default now is that string isn't FETCH response*/
 
-  idata = (IMAP_DATA*) ctx->data;
+  idata = ctx->data;
 
   if (buf[0] != '*')
     return rc;

--- a/mx.c
+++ b/mx.c
@@ -1018,7 +1018,7 @@ int mx_close_mailbox (CONTEXT *ctx, int *index_hint)
   /* allow IMAP to preserve the deleted flag across sessions */
   if (ctx->magic == MUTT_IMAP)
   {
-    if ((check = imap_sync_mailbox (ctx, purge, index_hint)) != 0)
+    if ((check = imap_sync_mailbox (ctx, purge)) != 0)
     {
       ctx->closing = 0;
       return check;
@@ -1242,7 +1242,7 @@ int mx_sync_mailbox (CONTEXT *ctx, int *index_hint)
 
 #ifdef USE_IMAP
   if (ctx->magic == MUTT_IMAP)
-    rc = imap_sync_mailbox (ctx, purge, index_hint);
+    rc = imap_sync_mailbox (ctx, purge);
   else
 #endif
     rc = sync_mailbox (ctx, index_hint);


### PR DESCRIPTION
1. introduce private `int imap_check (IMAP_DATA* idata, int force); `
2. turn `int imap_check_mailbox (CONTEXT* ctx, int* index_hint, int force);` into a wrapper around 1.
3. refactor and simplify `imap_keepalive`
4. remove some useless (and dangerous) casts
5. remove some unused parameters