### PR TITLE
factorize base64 usage

### DIFF
--- a/base64.c
+++ b/base64.c
@@ -48,7 +48,7 @@
 
 #define BAD     -1
 
-const char B64Chars[64] = {
+static const char B64Chars[64] = {
   'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O',
   'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd',
   'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's',

--- a/base64.c
+++ b/base64.c
@@ -48,6 +48,14 @@
 
 #define BAD     -1
 
+const char B64Chars[64] = {
+  'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O',
+  'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd',
+  'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's',
+  't', 'u', 'v', 'w', 'x', 'y', 'z', '0', '1', '2', '3', '4', '5', '6', '7',
+  '8', '9', '+', '/'
+};
+
 /**
  * mutt_to_base64 - convert raw bytes to null-terminated base64 string.
  *

--- a/mime.h
+++ b/mime.h
@@ -57,7 +57,6 @@ enum
 #ifndef _SENDLIB_C
 extern const int Index_hex[];
 extern const int Index_64[];
-extern const char B64Chars[];
 #endif
 
 #define hexval(c) Index_hex[(unsigned int)(c)]

--- a/rfc2047.c
+++ b/rfc2047.c
@@ -197,35 +197,21 @@ static size_t b_encoder (char *s, ICONV_CONST char *d, size_t dlen,
   memcpy (s, "=?", 2), s += 2;
   memcpy (s, tocode, strlen (tocode)), s += strlen (tocode);
   memcpy (s, "?B?", 3), s += 3;
-  for (;;)
+
+  while (dlen)
   {
-    if (!dlen)
-      break;
-    else if (dlen == 1)
-    {
-      *s++ = B64Chars[(*d >> 2) & 0x3f];
-      *s++ = B64Chars[(*d & 0x03) << 4];
-      *s++ = '=';
-      *s++ = '=';
-      break;
-    }
-    else if (dlen == 2)
-    {
-      *s++ = B64Chars[(*d >> 2) & 0x3f];
-      *s++ = B64Chars[((*d & 0x03) << 4) | ((d[1] >> 4) & 0x0f)];
-      *s++ = B64Chars[(d[1] & 0x0f) << 2];
-      *s++ = '=';
-      break;
-    }
-    else
-    {
-      *s++ = B64Chars[(*d >> 2) & 0x3f];
-      *s++ = B64Chars[((*d & 0x03) << 4) | ((d[1] >> 4) & 0x0f)];
-      *s++ = B64Chars[((d[1] & 0x0f) << 2) | ((d[2] >> 6) & 0x03)];
-      *s++ = B64Chars[d[2] & 0x3f];
-      d += 3, dlen -= 3;
-    }
+    char encoded[11];
+    size_t ret, i;
+    size_t in_len = MIN(3, dlen);
+
+    ret = mutt_to_base64 (encoded, d, in_len, sizeof(encoded));
+    for (i = 0; i < ret; i++)
+      *s++ = encoded[i];
+
+    dlen -= in_len;
+    d += in_len;
   }
+
   memcpy (s, "?=", 2), s += 2;
   return s - s0;
 }


### PR DESCRIPTION
This pull request intends to factorize the usage of various base64 encoding functions.

sendlib.c and rfc2047.c had custom implementations which have been removed in favor of mutt_to_base64. This allows to make B64Chars static to base64.c.

I mostly tested the changes in sendlib.c by sending files and checking I got the same results, so it's only lightly tested and I might have missed some corner cases.