### PR TITLE
Use `mutt_buffer_init` instead of `memset`

### DIFF
--- a/alias.c
+++ b/alias.c
@@ -344,53 +344,49 @@ retry_name:
   else
     Aliases = new;
 
-  for (LIST *AliasFile = AliasFiles; AliasFile != NULL;
-      AliasFile = AliasFile->next)
+  strfcpy (buf, NONULL (AliasFile), sizeof (buf));
+  if (mutt_get_field (_("Save to file: "), buf, sizeof (buf), MUTT_FILE) != 0)
+    return;
+  mutt_expand_path (buf, sizeof (buf));
+  if ((rc = fopen (buf, "a+")))
   {
-    strfcpy(buf, NONULL(AliasFile->data), sizeof(buf));
-    if (mutt_get_field(_("Save to file: "), buf, sizeof(buf), MUTT_FILE) != 0)
-      return;
-    mutt_expand_path(buf, sizeof(buf));
-    if ((rc = fopen(buf, "a+")))
+    /* terminate existing file with \n if necessary */
+    if (fseek (rc, 0, SEEK_END))
+      goto fseek_err;
+    if (ftell(rc) > 0)
     {
-      /* terminate existing file with \n if necessary */
-      if (fseek(rc, 0, SEEK_END))
-        goto fseek_err;
-      if (ftell(rc) > 0)
+      if (fseek (rc, -1, SEEK_CUR) < 0)
+	goto fseek_err;
+      if (fread(buf, 1, 1, rc) != 1)
       {
-        if (fseek(rc, -1, SEEK_CUR) < 0)
-          goto fseek_err;
-        if (fread(buf, 1, 1, rc) != 1)
-        {
-          mutt_perror(_("Error reading alias file"));
-          safe_fclose(&rc);
-          return;
-        }
-        if (fseek(rc, 0, SEEK_END) < 0)
-          goto fseek_err;
-        if (buf[0] != '\n')
-          fputc('\n', rc);
+	mutt_perror (_("Error reading alias file"));
+	safe_fclose (&rc);
+	return;
       }
-
-      if (mutt_check_alias_name(new->name, NULL, 0))
-        mutt_quote_filename(buf, sizeof(buf), new->name);
-      else
-        strfcpy(buf, new->name, sizeof(buf));
-      recode_buf(buf, sizeof(buf));
-      fprintf(rc, "alias %s ", buf);
-      buf[0] = 0;
-      rfc822_write_address(buf, sizeof(buf), new->addr, 0);
-      recode_buf(buf, sizeof(buf));
-      write_safe_address(rc, buf);
-      fputc('\n', rc);
-      if (safe_fsync_close(&rc) != 0)
-        mutt_message("Trouble adding alias: %s.", strerror(errno));
-      else
-        mutt_message(_("Alias added."));
+      if (fseek (rc, 0, SEEK_END) < 0)
+	goto fseek_err;
+      if (buf[0] != '\n')
+	fputc ('\n', rc);
     }
+
+    if (mutt_check_alias_name (new->name, NULL, 0))
+      mutt_quote_filename (buf, sizeof (buf), new->name);
     else
-      mutt_perror(buf);
+      strfcpy (buf, new->name, sizeof (buf));
+    recode_buf (buf, sizeof (buf));
+    fprintf (rc, "alias %s ", buf);
+    buf[0] = 0;
+    rfc822_write_address (buf, sizeof (buf), new->addr, 0);
+    recode_buf (buf, sizeof (buf));
+    write_safe_address (rc, buf);
+    fputc ('\n', rc);
+    if (safe_fsync_close(&rc) != 0)
+      mutt_message ("Trouble adding alias: %s.", strerror(errno));
+    else
+      mutt_message (_("Alias added."));
   }
+  else
+    mutt_perror (buf);
 
   return;
   

--- a/globals.h
+++ b/globals.h
@@ -31,7 +31,7 @@ WHERE char *MuttDotlock;
 WHERE ADDRESS *EnvFrom;
 WHERE ADDRESS *From;
 
-WHERE LIST *AliasFiles;
+WHERE char *AliasFile;
 WHERE char *AliasFmt;
 WHERE char *AssumedCharset;
 WHERE char *AttachSep;

--- a/hook.c
+++ b/hook.c
@@ -113,7 +113,7 @@ int mutt_parse_hook (BUFFER *buf, BUFFER *s, unsigned long data, BUFFER *err)
     }
 
     FREE (&pattern.data);
-    memset (&pattern, 0, sizeof (pattern));
+    mutt_buffer_init(&pattern);
     pattern.data = safe_strdup (path);
   }
 #ifdef USE_COMPRESSED
@@ -138,7 +138,7 @@ int mutt_parse_hook (BUFFER *buf, BUFFER *s, unsigned long data, BUFFER *err)
     strfcpy (tmp, pattern.data, sizeof (tmp));
     mutt_check_simple (tmp, sizeof (tmp), DefaultHook);
     FREE (&pattern.data);
-    memset (&pattern, 0, sizeof (pattern));
+    mutt_buffer_init(&pattern);
     pattern.data = safe_strdup (tmp);
   }
 
@@ -147,7 +147,7 @@ int mutt_parse_hook (BUFFER *buf, BUFFER *s, unsigned long data, BUFFER *err)
     strfcpy (path, command.data, sizeof (path));
     mutt_expand_path (path, sizeof (path));
     FREE (&command.data);
-    memset (&command, 0, sizeof (command));
+    mutt_buffer_init(&command);
     command.data = safe_strdup (path);
   }
 
@@ -578,7 +578,7 @@ void mutt_timeout_hook (void)
 
   err.data = buf;
   err.dsize = sizeof (buf);
-  memset (&token, 0, sizeof (token));
+  mutt_buffer_init(&token);
 
   for (hook = Hooks; hook; hook = hook->next)
   {
@@ -613,7 +613,7 @@ void mutt_startup_shutdown_hook (int type)
 
   err.data = buf;
   err.dsize = sizeof (buf);
-  memset (&token, 0, sizeof (token));
+  mutt_buffer_init(&token);
 
   for (hook = Hooks; hook; hook = hook->next)
   {

--- a/init.c
+++ b/init.c
@@ -3807,10 +3807,10 @@ void mutt_init (int skip_sys_rc, LIST *commands)
     }
   }
 
-  if (Muttrc)
+  if (Muttrc && Muttrc->data)
   {
-    FREE (&AliasFiles);
-    AliasFiles = mutt_copy_list(Muttrc);
+    FREE (&AliasFile);
+    AliasFile = safe_strdup (Muttrc->data);
   }
 
   /* Process the global rc file if it exists and the user hasn't explicity

--- a/init.c
+++ b/init.c
@@ -2607,10 +2607,10 @@ static int parse_set (BUFFER *tmp, BUFFER *s, unsigned long data, BUFFER *err)
   return (r);
 }
 
-/* Heap structure
+/* Stack structure
  * FILO designed to contain the list of config files that have been sourced
  * and avoid cyclic sourcing */
-static HEAP *MuttrcHeap;
+static LIST *MuttrcStack;
 
 /* Use POSIX functions to convert a path to absolute, relatively to another path
  * Args:
@@ -2676,15 +2676,15 @@ static int source_rc (const char *rcfile_path, BUFFER *err)
 
   if (rcfile[rcfilelen-1] != '|')
   {
-      if (!to_absolute_path(rcfile, mutt_front_heap(MuttrcHeap)))
+      if (!to_absolute_path(rcfile, mutt_front_list(MuttrcStack)))
       {
         mutt_error("Error: impossible to build path of '%s'.", rcfile_path);
         return (-1);
       }
 
-      if (!MuttrcHeap || mutt_find_heap(MuttrcHeap, rcfile) == NULL)
+      if (!MuttrcStack || mutt_find_list(MuttrcStack, rcfile) == NULL)
       {
-        mutt_push_heap(&MuttrcHeap, rcfile);
+        mutt_push_list(&MuttrcStack, rcfile);
       }
       else
       {
@@ -2744,7 +2744,7 @@ static int source_rc (const char *rcfile_path, BUFFER *err)
     rc = -1;
   }
 
-  mutt_pop_heap(&MuttrcHeap);
+  mutt_pop_list(&MuttrcStack);
 
   return (rc);
 }

--- a/init.h
+++ b/init.h
@@ -123,7 +123,7 @@ struct option_t MuttVars[] = {
   ** check only happens after the \fIfirst\fP edit of the file).  When set
   ** to \fIno\fP, composition will never be aborted.
   */
-  { "alias_file",	DT_PATH, R_NONE, UL &AliasFiles, UL "~/.muttrc" },
+  { "alias_file",	DT_PATH, R_NONE, UL &AliasFile, UL "~/.muttrc" },
   /*
   ** .pp
   ** The default file in which to save aliases created by the

--- a/mutt.h
+++ b/mutt.h
@@ -640,8 +640,6 @@ typedef struct list_t
   struct list_t *next;
 } LIST;
 
-typedef struct list_t HEAP;
-
 typedef struct rx_list_t
 {
   REGEXP *rx;
@@ -659,11 +657,6 @@ typedef struct spam_list_t
 inline LIST *mutt_new_list()
 {
   return safe_calloc (1, sizeof (LIST));
-}
-
-inline HEAP *mutt_new_heap()
-{
-  return safe_calloc (1, sizeof (HEAP));
 }
 
 inline RX_LIST *mutt_new_rx_list()
@@ -689,11 +682,10 @@ LIST *mutt_add_list_n (LIST*, const void *, size_t);
 LIST *mutt_find_list (LIST *, const char *);
 int mutt_remove_from_rx_list (RX_LIST **l, const char *str);
 
-/* handle heap */
-void mutt_push_heap(HEAP **head, const char *data);
-int mutt_pop_heap(HEAP **head);
-const char *mutt_front_heap(HEAP *head);
-HEAP *mutt_find_heap(HEAP *head, const char *data);
+/* handle stack */
+void mutt_push_list(LIST **head, const char *data);
+int mutt_pop_list(LIST **head);
+const char *mutt_front_list(LIST *head);
 
 void mutt_init (int, LIST *);
 

--- a/muttlib.c
+++ b/muttlib.c
@@ -57,7 +57,6 @@
  * External definitions for inline functions in mutt.h
  */
 extern LIST *mutt_new_list();
-extern HEAP *mutt_new_heap();
 extern RX_LIST *mutt_new_rx_list();
 extern SPAM_LIST *mutt_new_spam_list();
 extern PARAMETER *mutt_new_parameter();
@@ -295,18 +294,18 @@ LIST *mutt_find_list (LIST *l, const char *data)
   return NULL;
 }
 
-void mutt_push_heap(HEAP **head, const char *data)
+void mutt_push_list(LIST **head, const char *data)
 {
-  HEAP *tmp;
-  tmp = safe_malloc(sizeof(HEAP));
+  LIST *tmp;
+  tmp = safe_malloc(sizeof(LIST));
   tmp->data = safe_strdup(data);
   tmp->next = *head;
   *head = tmp;
 }
 
-int mutt_pop_heap(HEAP **head)
+int mutt_pop_list(LIST **head)
 {
-  HEAP *elt = *head;
+  LIST *elt = *head;
   if (!elt)
     return 0;
   *head = elt->next;
@@ -315,16 +314,11 @@ int mutt_pop_heap(HEAP **head)
   return 1;
 }
 
-const char *mutt_front_heap(HEAP *head)
+const char *mutt_front_list(LIST *head)
 {
   if (!head || !head->data)
     return "";
   return head->data;
-}
-
-HEAP *mutt_find_heap(HEAP *head, const char *data)
-{
-  return (HEAP *) mutt_find_list((LIST *) head, data);
 }
 
 int mutt_remove_from_rx_list (RX_LIST **l, const char *str)


### PR DESCRIPTION
The mutt_buffer_init function does a memset to 0 of its argument, so use
it instead of doing a manual memset.

I noticed (thanks to @guyzmo) that a number of buffer used in hooks where
initialised using memset instead of this dedicated function. This
remedies to that.

Fixes #369