### PR TITLE
debug: remove dprint in favor of mutt_debug

### DIFF
--- a/alias.c
+++ b/alias.c
@@ -59,7 +59,8 @@ static ADDRESS *mutt_expand_aliases_r (ADDRESS *a, LIST **expn)
 	{
 	  if (mutt_strcmp (a->mailbox, u->data) == 0) /* alias already found */
 	  {
-	    dprint (1, (debugfile, "mutt_expand_aliases_r(): loop in alias found for '%s'\n", a->mailbox));
+	    mutt_debug (1, "mutt_expand_aliases_r(): loop in alias found for '%s'\n",
+		        a->mailbox);
 	    i = 1;
 	    break;
 	  }
@@ -610,53 +611,60 @@ int mutt_addr_is_user (ADDRESS *addr)
   /* NULL address is assumed to be the user. */
   if (!addr)
   {
-    dprint (5, (debugfile, "mutt_addr_is_user: yes, NULL address\n"));
+    mutt_debug (5, "mutt_addr_is_user: yes, NULL address\n");
     return 1;
   }
   if (!addr->mailbox)
   {
-    dprint (5, (debugfile, "mutt_addr_is_user: no, no mailbox\n"));
+    mutt_debug (5, "mutt_addr_is_user: no, no mailbox\n");
     return 0;
   }
 
   if (ascii_strcasecmp (addr->mailbox, Username) == 0)
   {
-    dprint (5, (debugfile, "mutt_addr_is_user: yes, %s = %s\n", addr->mailbox, Username));
+    mutt_debug (5, "mutt_addr_is_user: yes, %s = %s\n",
+                addr->mailbox, Username);
     return 1;
   }
   if (string_is_address(addr->mailbox, Username, Hostname))
   {
-    dprint (5, (debugfile, "mutt_addr_is_user: yes, %s = %s @ %s \n", addr->mailbox, Username, Hostname));
+    mutt_debug (5, "mutt_addr_is_user: yes, %s = %s @ %s \n",
+                addr->mailbox, Username, Hostname);
     return 1;
   }
   fqdn = mutt_fqdn (0);
   if (string_is_address(addr->mailbox, Username, fqdn))
   {
-    dprint (5, (debugfile, "mutt_addr_is_user: yes, %s = %s @ %s \n", addr->mailbox, Username, NONULL(fqdn)));
+    mutt_debug (5, "mutt_addr_is_user: yes, %s = %s @ %s \n",
+                addr->mailbox, Username, NONULL(fqdn));
     return 1;
   }
   fqdn = mutt_fqdn (1);
   if (string_is_address(addr->mailbox, Username, fqdn))
   {
-    dprint (5, (debugfile, "mutt_addr_is_user: yes, %s = %s @ %s \n", addr->mailbox, Username, NONULL(fqdn)));
+    mutt_debug (5, "mutt_addr_is_user: yes, %s = %s @ %s \n",
+                addr->mailbox, Username, NONULL(fqdn));
     return 1;
   }
 
   if (From && !ascii_strcasecmp (From->mailbox, addr->mailbox))
   {
-    dprint (5, (debugfile, "mutt_addr_is_user: yes, %s = %s\n", addr->mailbox, From->mailbox));
+    mutt_debug (5, "mutt_addr_is_user: yes, %s = %s\n",
+                addr->mailbox, From->mailbox);
     return 1;
   }
 
   if (mutt_match_rx_list (addr->mailbox, Alternates))
   {
-    dprint (5, (debugfile, "mutt_addr_is_user: yes, %s matched by alternates.\n", addr->mailbox));
+    mutt_debug (5, "mutt_addr_is_user: yes, %s matched by alternates.\n",
+                addr->mailbox);
     if (mutt_match_rx_list (addr->mailbox, UnAlternates))
-      dprint (5, (debugfile, "mutt_addr_is_user: but, %s matched by unalternates.\n", addr->mailbox));
+      mutt_debug (5, "mutt_addr_is_user: but, %s matched by unalternates.\n",
+                  addr->mailbox);
     else
       return 1;
   }
   
-  dprint (5, (debugfile, "mutt_addr_is_user: no, all failed.\n"));
+  mutt_debug (5, "mutt_addr_is_user: no, all failed.\n");
   return 0;
 }

--- a/attach.c
+++ b/attach.c
@@ -106,8 +106,7 @@ int mutt_compose_attachment (BODY *a)
       if (rfc1524_expand_filename (entry->nametemplate,
 				      a->filename, newfile, sizeof (newfile)))
       {
-	dprint(1, (debugfile, "oldfile: %s\t newfile: %s\n",
-				  a->filename, newfile));
+	mutt_debug (1, "oldfile: %s\t newfile: %s\n", a->filename, newfile);
 	if (safe_symlink (a->filename, newfile) == -1)
 	{
 	  if (mutt_yesorno (_("Can't match nametemplate, continue?"), MUTT_YES) != MUTT_YES)
@@ -238,8 +237,7 @@ int mutt_edit_attachment (BODY *a)
       if (rfc1524_expand_filename (entry->nametemplate,
 				      a->filename, newfile, sizeof (newfile)))
       {
-	dprint(1, (debugfile, "oldfile: %s\t newfile: %s\n",
-				  a->filename, newfile));
+	mutt_debug (1, "oldfile: %s\t newfile: %s\n", a->filename, newfile);
 	if (safe_symlink (a->filename, newfile) == -1)
 	{
 	  if (mutt_yesorno (_("Can't match nametemplate, continue?"), MUTT_YES) != MUTT_YES)
@@ -317,8 +315,8 @@ void mutt_check_lookup_list (BODY *b, char *type, int len)
                 n == TYPETEXT ? "text" :
                 n == TYPEVIDEO ? "video" : "other",
                 tmp.subtype);
-      dprint(1, (debugfile, "mutt_check_lookup_list: \"%s\" -> %s\n", 
-        b->filename, type));
+      mutt_debug (1, "mutt_check_lookup_list: \"%s\" -> %s\n",
+                  b->filename, type);
     }
     if (tmp.subtype) 
       FREE (&tmp.subtype);
@@ -518,7 +516,8 @@ int mutt_view_attachment (FILE *fp, BODY *a, int flag, HEADER *hdr,
 	decode_state.fpout = safe_fopen(pagerfile, "w");
 	if (!decode_state.fpout)
 	{
-	  dprint(1, (debugfile, "mutt_view_attachment:%d safe_fopen(%s) errno=%d %s\n", __LINE__, pagerfile, errno, strerror(errno)));
+	  mutt_debug (1, "mutt_view_attachment:%d safe_fopen(%s) errno=%d %s\n",
+	              __LINE__, pagerfile, errno, strerror(errno));
 	  mutt_perror(pagerfile);
 	  mutt_sleep(1);
 	  goto return_error;
@@ -527,7 +526,8 @@ int mutt_view_attachment (FILE *fp, BODY *a, int flag, HEADER *hdr,
 	decode_state.flags = MUTT_CHARCONV;
 	mutt_decode_attachment(a, &decode_state);
 	if (fclose(decode_state.fpout) == EOF)
-	  dprint(1, (debugfile, "mutt_view_attachment:%d fclose errno=%d %s\n", __LINE__, pagerfile, errno, strerror(errno)));
+	  mutt_debug (1, "mutt_view_attachment:%d fclose errno=%d %s\n",
+	              __LINE__, pagerfile, errno, strerror(errno));
       }
       else
       {
@@ -921,7 +921,7 @@ int mutt_print_attachment (FILE *fp, BODY *a)
     rfc1524_entry *entry;
     int piped = false;
 
-    dprint (2, (debugfile, "Using mailcap...\n"));
+    mutt_debug (2, "Using mailcap...\n");
     
     entry = rfc1524_new_entry ();
     rfc1524_mailcap_lookup (a, type, entry, MUTT_PRINT);
@@ -1009,8 +1009,8 @@ int mutt_print_attachment (FILE *fp, BODY *a)
     if (mutt_decode_save_attachment (fp, a, newfile, MUTT_PRINTING, 0) == 0)
     {
       
-      dprint (2, (debugfile, "successfully decoded %s type attachment to %s\n",
-		  type, newfile));
+      mutt_debug (2, "successfully decoded %s type attachment to %s\n",
+                  type, newfile);
       
       if ((ifp = fopen (newfile, "r")) == NULL)
       {
@@ -1018,7 +1018,7 @@ int mutt_print_attachment (FILE *fp, BODY *a)
 	goto bail0;
       }
 
-      dprint (2, (debugfile, "successfully opened %s read-only\n", newfile));
+      mutt_debug (2, "successfully opened %s read-only\n", newfile);
       
       mutt_endwin (NULL);
       if ((thepid = mutt_create_filter (NONULL(PrintCmd), &fpout, NULL, NULL)) < 0)
@@ -1027,7 +1027,7 @@ int mutt_print_attachment (FILE *fp, BODY *a)
 	goto bail0;
       }
 
-      dprint (2, (debugfile, "Filter created.\n"));
+      mutt_debug (2, "Filter created.\n");
       
       mutt_copy_stream (ifp, fpout);
 

--- a/bcache.c
+++ b/bcache.c
@@ -60,7 +60,7 @@ static int bcache_path(ACCOUNT *account, const char *mailbox,
   url.path = NULL;
   if (url_ciss_tostring (&url, host, sizeof (host), U_PATH) < 0)
   {
-    dprint (1, (debugfile, "bcache_path: URL to string failed\n"));
+    mutt_debug (1, "bcache_path: URL to string failed\n");
     return -1;
   }
 
@@ -70,12 +70,12 @@ static int bcache_path(ACCOUNT *account, const char *mailbox,
 		  host, path,
 		  (*path && path[mutt_strlen (path) - 1] == '/') ? "" : "/");
 
-  dprint (3, (debugfile, "bcache_path: rc: %d, path: '%s'\n", len, dst));
+  mutt_debug (3, "bcache_path: rc: %d, path: '%s'\n", len, dst);
 
   if (len < 0 || len >= dstlen-1)
     return -1;
 
-  dprint (3, (debugfile, "bcache_path: directory: '%s'\n", dst));
+  mutt_debug (3, "bcache_path: directory: '%s'\n", dst);
 
   return 0;
 }
@@ -122,7 +122,7 @@ FILE* mutt_bcache_get(body_cache_t *bcache, const char *id)
 
   fp = safe_fopen (path, "r");
 
-  dprint (3, (debugfile, "bcache: get: '%s': %s\n", path, fp == NULL ? "no" : "yes"));
+  mutt_debug (3, "bcache: get: '%s': %s\n", path, fp == NULL ? "no" : "yes");
 
   return fp;
 }
@@ -153,7 +153,7 @@ FILE* mutt_bcache_put(body_cache_t *bcache, const char *id, int tmp)
   }
 
   snprintf(path, sizeof (path), "%s%s%s", bcache->path, id, tmp ? ".tmp" : "");
-  dprint (3, (debugfile, "bcache: put: '%s'\n", path));
+  mutt_debug (3, "bcache: put: '%s'\n", path);
 
   return safe_fopen(path, "w+");
 }
@@ -178,7 +178,7 @@ int mutt_bcache_move(body_cache_t* bcache, const char* id, const char* newid)
   snprintf (path, sizeof (path), "%s%s", bcache->path, id);
   snprintf (newpath, sizeof (newpath), "%s%s", bcache->path, newid);
 
-  dprint (3, (debugfile, "bcache: mv: '%s' '%s'\n", path, newpath));
+  mutt_debug (3, "bcache: mv: '%s' '%s'\n", path, newpath);
 
   return rename (path, newpath);
 }
@@ -194,7 +194,7 @@ int mutt_bcache_del(body_cache_t *bcache, const char *id)
   safe_strncat (path, sizeof (path), bcache->path, bcache->pathlen);
   safe_strncat (path, sizeof (path), id, mutt_strlen (id));
 
-  dprint (3, (debugfile, "bcache: del: '%s'\n", path));
+  mutt_debug (3, "bcache: del: '%s'\n", path);
 
   return unlink (path);
 }
@@ -217,7 +217,7 @@ int mutt_bcache_exists(body_cache_t *bcache, const char *id)
   else
     rc = S_ISREG(st.st_mode) && st.st_size != 0 ? 0 : -1;
 
-  dprint (3, (debugfile, "bcache: exists: '%s': %s\n", path, rc == 0 ? "yes" : "no"));
+  mutt_debug (3, "bcache: exists: '%s': %s\n", path, rc == 0 ? "yes" : "no");
 
   return rc;
 }
@@ -235,7 +235,7 @@ int mutt_bcache_list(body_cache_t *bcache,
 
   rc = 0;
 
-  dprint (3, (debugfile, "bcache: list: dir: '%s'\n", bcache->path));
+  mutt_debug (3, "bcache: list: dir: '%s'\n", bcache->path);
 
   while ((de = readdir (d)))
   {
@@ -243,7 +243,8 @@ int mutt_bcache_list(body_cache_t *bcache,
 	mutt_strncmp (de->d_name, "..", 2) == 0)
       continue;
 
-    dprint (3, (debugfile, "bcache: list: dir: '%s', id :'%s'\n", bcache->path, de->d_name));
+    mutt_debug (3, "bcache: list: dir: '%s', id :'%s'\n",
+                bcache->path, de->d_name);
 
     if (want_id && want_id (de->d_name, bcache, data) != 0)
       goto out;
@@ -257,6 +258,6 @@ out:
     if (closedir (d) < 0)
       rc = -1;
   }
-  dprint (3, (debugfile, "bcache: list: did %d entries\n", rc));
+  mutt_debug (3, "bcache: list: did %d entries\n", rc);
   return rc;
 }

--- a/browser.c
+++ b/browser.c
@@ -1779,7 +1779,8 @@ void _mutt_select_file (char *f, size_t flen, int flags, char ***files, int *num
           /* When in mailboxes mode, disables this feature */
           if (Maildir)
           {
-            dprint(5, (debugfile, "= hit! Maildir: %s, LastDir: %s\n", Maildir, LastDir));
+            mutt_debug (5, "= hit! Maildir: %s, LastDir: %s\n",
+                        Maildir, LastDir);
             if (!GotoSwapper[0])
             {
               if (mutt_strcmp (LastDir, Maildir) != 0)

--- a/buffy.c
+++ b/buffy.c
@@ -264,7 +264,8 @@ int mutt_parse_mailboxes (BUFFER *path, BUFFER *s, unsigned long data, BUFFER *e
     {
       if (mutt_strcmp (p ? p : buf, (*tmp)->realpath) == 0)
       {
-	dprint(3,(debugfile,"mailbox '%s' already registered as '%s'\n", buf, (*tmp)->path));
+        mutt_debug (3, "mailbox '%s' already registered as '%s'\n",
+                    buf, (*tmp)->path);
 	break;
       }
     }
@@ -498,7 +499,8 @@ int mutt_parse_virtual_mailboxes (BUFFER *path, BUFFER *s, unsigned long data, B
     {
       if (mutt_strcmp (buf, (*tmp)->path) == 0)
       {
-	dprint(3,(debugfile,"virtual mailbox '%s' already registered as '%s'\n", buf, (*tmp)->path));
+        mutt_debug (3, "virtual mailbox '%s' already registered as '%s'\n",
+                    buf, (*tmp)->path);
 	break;
       }
     }

--- a/color.c
+++ b/color.c
@@ -289,8 +289,8 @@ int mutt_alloc_color (int fg, int bg)
 
   init_pair(i, fg, bg);
 
-  dprint (3, (debugfile,"mutt_alloc_color(): Color pairs used so far: %d\n",
-	      UserColors));
+  mutt_debug (3, "mutt_alloc_color(): Color pairs used so far: %d\n",
+              UserColors);
 
   return (COLOR_PAIR (p->index));
 }
@@ -308,8 +308,8 @@ void mutt_free_color (int fg, int bg)
       if (p->count > 0) return;
 
       UserColors--;
-      dprint(1,(debugfile,"mutt_free_color(): Color pairs used so far: %d\n",
-                           UserColors));
+      mutt_debug (1, "mutt_free_color(): Color pairs used so far: %d\n",
+                  UserColors);
 
       if (p == ColorList)
       {
@@ -451,8 +451,8 @@ mutt_do_uncolor (BUFFER *buf, BUFFER *s, COLOR_LINE **ColorList,
 	  {
             *do_cache = 1;
           }
-          dprint (1, (debugfile,"Freeing pattern \"%s\" from ColorList\n",
-                               tmp->pattern));
+          mutt_debug (1, "Freeing pattern \"%s\" from ColorList\n",
+                      tmp->pattern);
           if (last)
 	  {
             last->next = tmp->next;

--- a/complete.c
+++ b/complete.c
@@ -53,7 +53,7 @@ int mutt_complete (char *s, size_t slen)
   char imap_path[LONG_STRING];
 #endif
 
-  dprint (2, (debugfile, "mutt_complete: completing %s\n", s));
+  mutt_debug (2, "mutt_complete: completing %s\n", s);
 
 #ifdef USE_NNTP
   if (option (OPTNEWS))
@@ -186,7 +186,8 @@ int mutt_complete (char *s, size_t slen)
 
   if (dirp == NULL)
   {
-    dprint (1, (debugfile, "mutt_complete(): %s: %s (errno %d).\n", exp_dirpart, strerror (errno), errno));
+    mutt_debug (1, "mutt_complete(): %s: %s (errno %d).\n",
+                exp_dirpart, strerror (errno), errno);
     return (-1);
   }
 

--- a/copy.c
+++ b/copy.c
@@ -142,12 +142,12 @@ mutt_copy_hdr (FILE *in, FILE *out, LOFF_T off_start, LOFF_T off_end, int flags,
   {
     for (t = HeaderOrderList; t; t = t->next)
     {
-      dprint(3, (debugfile, "Reorder list: %s\n", t->data));
+      mutt_debug (3, "Reorder list: %s\n", t->data);
       hdr_count++;
     }
   }
 
-  dprint (1, (debugfile, "WEED is %s\n", (flags & CH_WEED) ? "Set" : "Not"));
+  mutt_debug (1, "WEED is %s\n", (flags & CH_WEED) ? "Set" : "Not");
 
   headers = safe_calloc (hdr_count, sizeof (char *));
 
@@ -233,7 +233,7 @@ mutt_copy_hdr (FILE *in, FILE *out, LOFF_T off_start, LOFF_T off_end, int flags,
 	{
 	  if (!ascii_strncasecmp (buf, t->data, mutt_strlen (t->data)))
 	  {
-	    dprint(2, (debugfile, "Reorder: %s matches %s\n", t->data, buf));
+	    mutt_debug (2, "Reorder: %s matches %s\n", t->data, buf);
 	    break;
 	  }
 	}
@@ -244,7 +244,7 @@ mutt_copy_hdr (FILE *in, FILE *out, LOFF_T off_start, LOFF_T off_end, int flags,
 
     if (!ignore)
     {
-      dprint (2, (debugfile, "Reorder: x = %d; hdr_count = %d\n", x, hdr_count));
+      mutt_debug (2, "Reorder: x = %d; hdr_count = %d\n", x, hdr_count);
       if (!this_one) {
 	this_one = safe_strdup (buf);
 	this_one_len = mutt_strlen (this_one);
@@ -784,7 +784,7 @@ mutt_copy_message (FILE *fpout, CONTEXT *src, HEADER *hdr, int flags,
   if ((r = _mutt_copy_message (fpout, msg->fp, hdr, hdr->content, flags, chflags)) == 0 
       && (ferror (fpout) || feof (fpout)))
   {
-    dprint (1, (debugfile, "_mutt_copy_message failed to detect EOF!\n"));
+    mutt_debug (1, "_mutt_copy_message failed to detect EOF!\n");
     r = -1;
   }
   mx_close_message (src, &msg);

--- a/crypt-gpgme.c
+++ b/crypt-gpgme.c
@@ -1657,7 +1657,7 @@ static int verify_one (BODY *sigbdy, STATE *s,
   gpgme_release (ctx);
   
   state_attach_puts (_("[-- End signature information --]\n\n"), s);
-  dprint (1, (debugfile, "verify_one: returning %d.\n", badsig));
+  mutt_debug (1, "verify_one: returning %d.\n", badsig);
   
   return badsig? 1: anywarn? 2 : 0;
 }
@@ -2051,7 +2051,7 @@ static int pgp_gpgme_extract_keys (gpgme_data_t keydata, FILE** fp, int dryrun)
 
   if ((err = gpgme_new (&tmpctx)) != GPG_ERR_NO_ERROR)
   {
-    dprint (1, (debugfile, "Error creating GPGME context\n"));
+    mutt_debug (1, "Error creating GPGME context\n");
     return rc;
   }
   
@@ -2060,7 +2060,7 @@ static int pgp_gpgme_extract_keys (gpgme_data_t keydata, FILE** fp, int dryrun)
     snprintf (tmpdir, sizeof(tmpdir), "%s/mutt-gpgme-XXXXXX", Tempdir);
     if (!mkdtemp (tmpdir))
     {
-      dprint (1, (debugfile, "Error creating temporary GPGME home\n"));
+      mutt_debug (1, "Error creating temporary GPGME home\n");
       goto err_ctx;
     }
 
@@ -2069,7 +2069,7 @@ static int pgp_gpgme_extract_keys (gpgme_data_t keydata, FILE** fp, int dryrun)
       engineinfo = engineinfo->next;
     if (!engineinfo)
     {
-      dprint (1, (debugfile, "Error finding GPGME PGP engine\n"));
+      mutt_debug (1, "Error finding GPGME PGP engine\n");
       goto err_tmpdir;
     }
 
@@ -2077,14 +2077,14 @@ static int pgp_gpgme_extract_keys (gpgme_data_t keydata, FILE** fp, int dryrun)
                                      engineinfo->file_name, tmpdir);
     if (err != GPG_ERR_NO_ERROR)
     {
-      dprint (1, (debugfile, "Error setting GPGME context home\n"));
+      mutt_debug (1, "Error setting GPGME context home\n");
       goto err_tmpdir;
     }
   }
 
   if ((err = gpgme_op_import (tmpctx, keydata)) != GPG_ERR_NO_ERROR)
   {
-    dprint (1, (debugfile, "Error importing key\n"));
+    mutt_debug (1, "Error importing key\n");
     goto err_tmpdir;
   }
 
@@ -2129,7 +2129,7 @@ static int pgp_gpgme_extract_keys (gpgme_data_t keydata, FILE** fp, int dryrun)
   }
   if (gpg_err_code (err) != GPG_ERR_EOF)
   {
-    dprint (1, (debugfile, "Error listing keys\n"));
+    mutt_debug (1, "Error listing keys\n");
     goto err_fp;
   }
 
@@ -2371,7 +2371,7 @@ int pgp_gpgme_application_handler (BODY *m, STATE *s)
 
   char body_charset[STRING];  /* Only used for clearsigned messages. */
 
-  dprint (2, (debugfile, "Entering pgp_application_pgp handler\n"));
+  mutt_debug (2, "Entering pgp_application_pgp handler\n");
 
   /* For clearsigned messages we won't be able to get a character set
      but we know that this may only be text thus we assume Latin-1
@@ -2589,7 +2589,7 @@ int pgp_gpgme_application_handler (BODY *m, STATE *s)
                            " of PGP message! --]\n\n"), s);
       return 1;
     }
-  dprint (2, (debugfile, "Leaving pgp_application_pgp handler\n"));
+  mutt_debug (2, "Leaving pgp_application_pgp handler\n");
 
   return err;
 }
@@ -2610,7 +2610,7 @@ int pgp_gpgme_encrypted_handler (BODY *a, STATE *s)
   int is_signed;
   int rc = 0;
   
-  dprint (2, (debugfile, "Entering pgp_encrypted handler\n"));
+  mutt_debug (2, "Entering pgp_encrypted handler\n");
 
   mutt_mktemp (tempfile, sizeof (tempfile));
   if (!(fpout = safe_fopen (tempfile, "w+")))
@@ -2668,7 +2668,7 @@ int pgp_gpgme_encrypted_handler (BODY *a, STATE *s)
 
   safe_fclose (&fpout);
   mutt_unlink(tempfile);
-  dprint (2, (debugfile, "Leaving pgp_encrypted handler\n"));
+  mutt_debug (2, "Leaving pgp_encrypted handler\n");
 
   return rc;
 }
@@ -2682,7 +2682,7 @@ int smime_gpgme_application_handler (BODY *a, STATE *s)
   int is_signed;
   int rc = 0;
 
-  dprint (2, (debugfile, "Entering smime_encrypted handler\n"));
+  mutt_debug (2, "Entering smime_encrypted handler\n");
   
   a->warnsig = 0;
   mutt_mktemp (tempfile, sizeof (tempfile));
@@ -2742,7 +2742,7 @@ int smime_gpgme_application_handler (BODY *a, STATE *s)
   
   safe_fclose (&fpout);
   mutt_unlink(tempfile);
-  dprint (2, (debugfile, "Leaving smime_encrypted handler\n"));
+  mutt_debug (2, "Leaving smime_encrypted handler\n");
   
   return rc;
 }
@@ -4192,18 +4192,18 @@ static crypt_key_t *crypt_getkeybyaddr (ADDRESS * a, short abilities,
   if (!keys)
     return NULL;
   
-  dprint (5, (debugfile, "crypt_getkeybyaddr: looking for %s <%s>.",
-	      a->personal, a->mailbox));
+  mutt_debug (5, "crypt_getkeybyaddr: looking for %s <%s>.",
+              a->personal, a->mailbox);
 
   for (k = keys; k; k = k->next)
     {
-      dprint (5, (debugfile, "  looking at key: %s `%.15s'\n",
-                  crypt_keyid (k), k->uid));
+      mutt_debug (5, "  looking at key: %s `%.15s'\n",
+                  crypt_keyid (k), k->uid);
       
       if (abilities && !(k->flags & abilities))
         {
-          dprint (5, (debugfile, "  insufficient abilities: Has %x, want %x\n",
-                      k->flags, abilities));
+          mutt_debug (5, "  insufficient abilities: Has %x, want %x\n",
+                      k->flags, abilities);
           continue;
         }
 
@@ -4338,8 +4338,8 @@ static crypt_key_t *crypt_getkeybystr (char *p, short abilities,
       if (abilities && !(k->flags & abilities))
         continue;
 
-      dprint (5, (debugfile, "crypt_getkeybystr: matching \"%s\" against "
-                  "key %s, \"%s\": ",  p, crypt_long_keyid (k), k->uid));
+      mutt_debug (5, "crypt_getkeybystr: matching \"%s\" against "
+                  "key %s, \"%s\": ",  p, crypt_long_keyid (k), k->uid);
 
       if (!*p
           || (pfcopy && mutt_strcasecmp (pfcopy, crypt_fpr (k)) == 0)
@@ -4349,7 +4349,7 @@ static crypt_key_t *crypt_getkeybystr (char *p, short abilities,
         {
           crypt_key_t *tmp;
 
-          dprint (5, (debugfile, "match.\n"));
+          mutt_debug (5, "match.\n");
 
           *matches_endp = tmp = crypt_copy_key (k);
           matches_endp = &tmp->next;

--- a/curs_lib.c
+++ b/curs_lib.c
@@ -347,7 +347,7 @@ static void curses_message (int error, const char *fmt, va_list ap)
 
   vsnprintf (scratch, sizeof (scratch), fmt, ap);
 
-  dprint (1, (debugfile, "%s\n", scratch));
+  mutt_debug (1, "%s\n", scratch);
   mutt_format_string (Errorbuf, sizeof (Errorbuf),
 		      0, MuttMessageWindow->cols, FMT_LEFT, 0, scratch, sizeof (scratch), 0);
 
@@ -419,7 +419,7 @@ void mutt_progress_init (progress_t* progress, const char *msg,
     return;
   }
   if (gettimeofday (&tv, NULL) < 0)
-    dprint (1, (debugfile, "gettimeofday failed: %d\n", errno));
+    mutt_debug (1, "gettimeofday failed: %d\n", errno);
   /* if timestamp is 0 no time-based suppression is done */
   if (TimeInc)
     progress->timestamp = ((unsigned int) tv.tv_sec * 1000)
@@ -530,7 +530,7 @@ void mutt_progress_update (progress_t* progress, long pos, int percent)
     else
       snprintf (posstr, sizeof (posstr), "%ld", pos);
 
-    dprint (5, (debugfile, "updating progress: %s\n", posstr));
+    mutt_debug (5, "updating progress: %s\n", posstr);
 
     progress->pos = pos;
     if (now)
@@ -583,7 +583,7 @@ void mutt_reflow_windows (void)
   if (option (OPTNOCURSES))
     return;
 
-  dprint (2, (debugfile, "In mutt_reflow_windows\n"));
+  mutt_debug (2, "In mutt_reflow_windows\n");
 
   MuttStatusWindow->rows = 1;
   MuttStatusWindow->cols = COLS;
@@ -743,8 +743,8 @@ void mutt_perror (const char *s)
 {
   char *p = strerror (errno);
 
-  dprint (1, (debugfile, "%s: %s (errno = %d)\n", s, 
-      p ? p : "unknown error", errno));
+  mutt_debug (1, "%s: %s (errno = %d)\n",
+              s, p ? p : "unknown error", errno);
   mutt_error ("%s: %s (errno = %d)", s, p ? p : _("unknown error"), errno);
 }
 

--- a/curs_main.c
+++ b/curs_main.c
@@ -1055,7 +1055,7 @@ int mutt_index_menu (void)
 
       op = km_dokey (MENU_MAIN);
 
-      dprint(4, (debugfile, "mutt_index_menu[%d]: Got op %d\n", __LINE__, op));
+      mutt_debug (4, "mutt_index_menu[%d]: Got op %d\n", __LINE__, op);
 
       if (op == -1) {
         mutt_timeout_hook();
@@ -1892,7 +1892,7 @@ int mutt_index_menu (void)
         break;
 
       case OP_MAIN_WINDOWED_VFOLDER_BACKWARD:
-        dprint(2, (debugfile, "OP_MAIN_WINDOWED_VFOLDER_BACKWARD\n"));
+        mutt_debug (2, "OP_MAIN_WINDOWED_VFOLDER_BACKWARD\n");
         if (NotmuchQueryWindowDuration <= 0)
         {
           mutt_message (_("Windowed queries disabled."));
@@ -1928,7 +1928,7 @@ int mutt_index_menu (void)
             mutt_message (_("Failed to create query, aborting."));
         else
         {
-          dprint(2, (debugfile, "nm: + windowed query (%s)\n", buf));
+          mutt_debug (2, "nm: + windowed query (%s)\n", buf);
           main_change_folder(menu, op, buf, sizeof (buf), &oldcount, &index_hint, 0);
         }
         break;
@@ -2998,7 +2998,7 @@ int mutt_index_menu (void)
                by whatever they typed at the prompt.) */
 	    snprintf(buf, sizeof(buf), _("Message bound to %s."), str);
 	    mutt_message(buf);
-	    dprint (1, (debugfile, "Mark: %s => %s\n", str, macro));
+	    mutt_debug (1, "Mark: %s => %s\n", str, macro);
 	  }
 	}
 	else

--- a/from.c
+++ b/from.c
@@ -76,7 +76,7 @@ int is_from (const char *s, char *path, size_t pathlen, time_t *tp)
   if (!*s)
     return 0;
 
-  dprint (3, (debugfile, "\nis_from(): parsing: %s", s));
+  mutt_debug (3, "\nis_from(): parsing: %s", s);
 
   if (!is_day_name (s))
   {
@@ -105,7 +105,8 @@ int is_from (const char *s, char *path, size_t pathlen, time_t *tp)
       p = strchr(p + 4, ' ');
       if (!p)
       {
-	dprint (1, (debugfile, "is_from(): error parsing what appears to be a pipermail-style obscured return_path: %s\n", s));
+        mutt_debug (1, "is_from(): error parsing what appears to be a "
+                       "pipermail-style obscured return_path: %s\n", s);
 	return 0;
       }
     }
@@ -117,7 +118,7 @@ int is_from (const char *s, char *path, size_t pathlen, time_t *tp)
 	len = pathlen - 1;
       memcpy (path, s, len);
       path[len] = 0;
-      dprint (3, (debugfile, "is_from(): got return path: %s\n", path));
+      mutt_debug (3, "is_from(): got return path: %s\n", path);
     }
     
     s = p + 1;
@@ -127,7 +128,7 @@ int is_from (const char *s, char *path, size_t pathlen, time_t *tp)
 
     if (!is_day_name (s))
     {
-      dprint(1, (debugfile, "is_from():  expected weekday, got: %s\n", s));
+      mutt_debug (1, "is_from():  expected weekday, got: %s\n", s);
       return 0;
     }
   }
@@ -188,8 +189,8 @@ int is_from (const char *s, char *path, size_t pathlen, time_t *tp)
   if (sscanf (s, "%d", &yr) != 1) return 0;
   tm.tm_year = yr > 1900 ? yr - 1900 : (yr < 70 ? yr + 100 : yr);
   
-  dprint (3,(debugfile, "is_from(): month=%d, day=%d, hr=%d, min=%d, sec=%d, yr=%d.\n",
-	     tm.tm_mon, tm.tm_mday, tm.tm_hour, tm.tm_min, tm.tm_sec, tm.tm_year));
+  mutt_debug (3, "is_from(): month=%d, day=%d, hr=%d, min=%d, sec=%d, yr=%d.\n",
+              tm.tm_mon, tm.tm_mday, tm.tm_hour, tm.tm_min, tm.tm_sec, tm.tm_year);
 
   tm.tm_isdst = -1;
 

--- a/getdomain.c
+++ b/getdomain.c
@@ -61,7 +61,7 @@ int getdnsdomainname (char *d, size_t len)
     {
       strfcpy(d, ++p, len);
       ret = 0;
-      dprint(1, (debugfile, "getdnsdomainname(): %s\n", d));
+      mutt_debug (1, "getdnsdomainname(): %s\n", d);
     }
     freeaddrinfo(h);
   }

--- a/gnupgparse.c
+++ b/gnupgparse.c
@@ -139,7 +139,7 @@ static pgp_key_t parse_pub_line (char *buf, int *is_subkey, pgp_key_t k)
   else
     memset (&tmp, 0, sizeof (tmp));
 
-  dprint (2, (debugfile, "parse_pub_line: buf = `%s'\n", buf));
+  mutt_debug (2, "parse_pub_line: buf = `%s'\n", buf);
 
   for (p = buf; p; p = pend)
   {
@@ -156,7 +156,7 @@ static pgp_key_t parse_pub_line (char *buf, int *is_subkey, pgp_key_t k)
     {
       case 1:			/* record type */
       {
-	dprint (2, (debugfile, "record type: %s\n", p));
+        mutt_debug (2, "record type: %s\n", p);
 
 	if (!mutt_strcmp (p, "pub"))
 	  is_pub = 1;
@@ -180,7 +180,7 @@ static pgp_key_t parse_pub_line (char *buf, int *is_subkey, pgp_key_t k)
       }
       case 2:			/* trust info */
       {
-	dprint (2, (debugfile, "trust info: %s\n", p));
+        mutt_debug (2, "trust info: %s\n", p);
 
 	switch (*p)
 	{				/* look only at the first letter */
@@ -214,7 +214,7 @@ static pgp_key_t parse_pub_line (char *buf, int *is_subkey, pgp_key_t k)
       }
       case 3:			/* key length  */
       {
-	dprint (2, (debugfile, "key len: %s\n", p));
+        mutt_debug (2, "key len: %s\n", p);
 
 	if (!(*is_subkey && option (OPTPGPIGNORESUB)) &&
 	    mutt_atos (p, &tmp.keylen) < 0)
@@ -223,7 +223,7 @@ static pgp_key_t parse_pub_line (char *buf, int *is_subkey, pgp_key_t k)
       }
       case 4:			/* pubkey algo */
       {
-	dprint (2, (debugfile, "pubkey algorithm: %s\n", p));
+        mutt_debug (2, "pubkey algorithm: %s\n", p);
 
 	if (!(*is_subkey && option (OPTPGPIGNORESUB)))
 	{
@@ -237,7 +237,7 @@ static pgp_key_t parse_pub_line (char *buf, int *is_subkey, pgp_key_t k)
       }
       case 5:			/* 16 hex digits with the long keyid. */
       {
-	dprint (2, (debugfile, "key id: %s\n", p));
+        mutt_debug (2, "key id: %s\n", p);
 
 	if (!(*is_subkey && option (OPTPGPIGNORESUB)))
 	  mutt_str_replace (&tmp.keyid, p);
@@ -249,7 +249,7 @@ static pgp_key_t parse_pub_line (char *buf, int *is_subkey, pgp_key_t k)
 	char tstr[11];
 	struct tm time;
 
-	dprint (2, (debugfile, "time stamp: %s\n", p));
+	mutt_debug (2, "time stamp: %s\n", p);
 
 	if (!p)
 	  break;
@@ -308,7 +308,7 @@ static pgp_key_t parse_pub_line (char *buf, int *is_subkey, pgp_key_t k)
 	if (!is_uid && (*is_subkey && option (OPTPGPIGNORESUB)))
 	  break;
 
-	dprint (2, (debugfile, "user ID: %s\n", NONULL (p)));
+	mutt_debug (2, "user ID: %s\n", NONULL (p));
 
 	uid = safe_calloc (sizeof (pgp_uid_t), 1);
 	fix_uid (p);
@@ -328,7 +328,7 @@ static pgp_key_t parse_pub_line (char *buf, int *is_subkey, pgp_key_t k)
       case 11:			/* signature class  */
         break;
       case 12:			/* key capabilities */
-	dprint (2, (debugfile, "capabilities info: %s\n", p));
+	mutt_debug (2, "capabilities info: %s\n", p);
 	
 	while(*p)
 	  {
@@ -377,7 +377,7 @@ static pgp_key_t parse_pub_line (char *buf, int *is_subkey, pgp_key_t k)
   return k;
 
 bail:
-  dprint(5,(debugfile,"parse_pub_line: invalid number: '%s'\n", p));
+  mutt_debug (5, "parse_pub_line: invalid number: '%s'\n", p);
   return NULL;
 }
 

--- a/group.c
+++ b/group.c
@@ -44,7 +44,7 @@ group_t *mutt_pattern_group (const char *k)
 
   if (!(p = hash_find (Groups, k)))
   {
-    dprint (2, (debugfile, "mutt_pattern_group: Creating group %s.\n", k));
+    mutt_debug (2, "mutt_pattern_group: Creating group %s.\n", k);
     p = safe_calloc (1, sizeof (group_t));
     p->name = safe_strdup (k);
     hash_insert (Groups, p->name, p, 0);

--- a/handler.c
+++ b/handler.c
@@ -308,8 +308,8 @@ void mutt_decode_base64 (STATE *s, long len, int istext, iconv_t cd)
     {
       /* "i" may be zero if there is trailing whitespace, which is not an error */
       if (i != 0)
-	dprint (2, (debugfile, "%s:%d [mutt_decode_base64()]: "
-	      "didn't get a multiple of 4 chars.\n", __FILE__, __LINE__));
+        mutt_debug (2, "%s:%d [mutt_decode_base64()]: "
+                    "didn't get a multiple of 4 chars.\n", __FILE__, __LINE__);
       break;
     }
 
@@ -1280,7 +1280,8 @@ static int multipart_handler (BODY *a, STATE *s)
     if (rc)
     {
       mutt_error (_("One or more parts of this message could not be displayed"));
-      dprint (1, (debugfile, "Failed on attachment #%d, type %s/%s.\n", count, TYPE(p), NONULL (p->subtype)));
+      mutt_debug (1, "Failed on attachment #%d, type %s/%s.\n",
+                  count, TYPE(p), NONULL (p->subtype));
     }
     
     if ((s->flags & MUTT_REPLYING)
@@ -1630,7 +1631,7 @@ static int run_decode_and_handler (BODY *b, STATE *s, handler_t handler, int pla
      s->fpout = open_memstream (&temp, &tempsize);
      if (!s->fpout) {
        mutt_error (_("Unable to open memory stream!"));
-       dprint (1, (debugfile, "Can't open memory stream.\n"));
+       mutt_debug (1, "Can't open memory stream.\n");
        return -1;
      }
 #else
@@ -1638,7 +1639,7 @@ static int run_decode_and_handler (BODY *b, STATE *s, handler_t handler, int pla
       if ((s->fpout = safe_fopen (tempfile, "w")) == NULL)
       {
         mutt_error (_("Unable to open temporary file!"));
-        dprint (1, (debugfile, "Can't open %s.\n", tempfile));
+        mutt_debug (1, "Can't open %s.\n", tempfile);
         return -1;
       }
 #endif
@@ -1698,7 +1699,8 @@ static int run_decode_and_handler (BODY *b, STATE *s, handler_t handler, int pla
 
     if (rc)
     {
-      dprint (1, (debugfile, "Failed on attachment of type %s/%s.\n", TYPE(b), NONULL (b->subtype)));
+      mutt_debug (1, "Failed on attachment of type %s/%s.\n",
+                  TYPE(b), NONULL (b->subtype));
     }
 
     if (decode)
@@ -1814,8 +1816,8 @@ int mutt_body_handler (BODY *b, STATE *s)
     if (b->encoding != ENC7BIT && b->encoding != ENC8BIT
         && b->encoding != ENCBINARY)
     {
-      dprint (1, (debugfile, "Bad encoding type %d for multipart entity, "
-                  "assuming 7 bit\n", b->encoding));
+      mutt_debug (1, "Bad encoding type %d for multipart entity, "
+                  "assuming 7 bit\n", b->encoding);
       b->encoding = ENC7BIT;
     }
   }
@@ -1869,7 +1871,8 @@ int mutt_body_handler (BODY *b, STATE *s)
   s->flags = oflags | (s->flags & MUTT_FIRSTDONE);
   if (rc)
   {
-    dprint (1, (debugfile, "Bailing on attachment of type %s/%s.\n", TYPE(b), NONULL (b->subtype)));
+    mutt_debug (1, "Bailing on attachment of type %s/%s.\n",
+                TYPE(b), NONULL (b->subtype));
   }
 
   return rc;

--- a/hcache-kc.c
+++ b/hcache-kc.c
@@ -49,7 +49,8 @@ hcache_kyotocabinet_open(const char *path)
   {
 #ifdef DEBUG
     int ecode = kcdbecode (db);
-    dprint (2, (debugfile, "kcdbopen failed for %s: %s (ecode %d)\n", kcdbpath, kcdbemsg (db), ecode));
+    mutt_debug (2, "kcdbopen failed for %s: %s (ecode %d)\n",
+                kcdbpath, kcdbemsg (db), ecode);
 #endif
     kcdbdel(db);
     return NULL;
@@ -105,7 +106,7 @@ hcache_kyotocabinet_close(void **ctx)
   {
 #ifdef DEBUG
     int ecode = kcdbecode (db);
-    dprint (2, (debugfile, "kcdbclose failed: %s (ecode %d)\n", kcdbemsg (db), ecode));
+    mutt_debug (2, "kcdbclose failed: %s (ecode %d)\n", kcdbemsg (db), ecode);
 #endif
   }
   kcdbdel(db);

--- a/hcache-tc.c
+++ b/hcache-tc.c
@@ -39,7 +39,8 @@ hcache_tokyocabinet_open(const char *path)
   {
 #ifdef DEBUG
     int ecode = tcbdbecode (db);
-    dprint (2, (debugfile, "tcbdbopen failed for %s: %s (ecode %d)\n", path, tcbdberrmsg (ecode), ecode));
+    mutt_debug (2, "tcbdbopen failed for %s: %s (ecode %d)\n",
+                path, tcbdberrmsg (ecode), ecode);
 #endif
     tcbdbdel(db);
     return NULL;
@@ -95,7 +96,8 @@ hcache_tokyocabinet_close(void **ctx)
   {
 #ifdef DEBUG
     int ecode = tcbdbecode (db);
-    dprint (2, (debugfile, "tcbdbclose failed: %s (ecode %d)\n", tcbdberrmsg (ecode), ecode));
+    mutt_debug (2, "tcbdbclose failed: %s (ecode %d)\n",
+                tcbdberrmsg (ecode), ecode);
 #endif
   }
   tcbdbdel(db);

--- a/headers.c
+++ b/headers.c
@@ -84,7 +84,7 @@ void mutt_edit_headers (const char *editor,
   stat (path, &st);
   if (mtime == st.st_mtime)
   {
-    dprint (1, (debugfile, "ci_edit_headers(): temp file was not modified.\n"));
+    mutt_debug (1, "ci_edit_headers(): temp file was not modified.\n");
     /* the file has not changed! */
     mutt_unlink (path);
     return;
@@ -306,7 +306,7 @@ void mutt_label_ref_dec(ENVELOPE *env)
       label_delete (label->data);
     }
 
-    dprint(1, (debugfile, "--label %s: %d\n", label->data, count));
+    mutt_debug (1, "--label %s: %d\n", label->data, count);
   }
 }
 
@@ -338,7 +338,7 @@ void mutt_label_ref_inc(ENVELOPE *env)
       hash_insert(Labels, dup_label, (void *) count, 0);
     }
 
-    dprint(1, (debugfile, "++label %s: %d\n", label->data, count));
+    mutt_debug (1, "++label %s: %d\n", label->data, count);
   }
 }
 

--- a/imap/auth.c
+++ b/imap/auth.c
@@ -70,7 +70,7 @@ int imap_authenticate (IMAP_DATA* idata)
       if (! method[0])
 	continue;
       
-      dprint (2, (debugfile, "imap_authenticate: Trying method %s\n", method));
+      mutt_debug (2, "imap_authenticate: Trying method %s\n", method);
       authenticator = imap_authenticators;
 
       while (authenticator->authenticate)
@@ -93,7 +93,7 @@ int imap_authenticate (IMAP_DATA* idata)
   else
   {
     /* Fall back to default: any authenticator */
-    dprint (2, (debugfile, "imap_authenticate: Using any available method.\n"));
+    mutt_debug (2, "imap_authenticate: Using any available method.\n");
     authenticator = imap_authenticators;
 
     while (authenticator->authenticate)

--- a/imap/auth_anon.c
+++ b/imap/auth_anon.c
@@ -50,7 +50,7 @@ imap_auth_res_t imap_auth_anon (IMAP_DATA* idata, const char* method)
 
   if (rc != IMAP_CMD_RESPOND)
   {
-    dprint (1, (debugfile, "Invalid response from server.\n"));
+    mutt_debug (1, "Invalid response from server.\n");
     goto bail;
   }
 
@@ -62,7 +62,7 @@ imap_auth_res_t imap_auth_anon (IMAP_DATA* idata, const char* method)
   
   if (rc != IMAP_CMD_OK)
   {
-    dprint (1, (debugfile, "Error receiving server response.\n"));
+    mutt_debug (1, "Error receiving server response.\n");
     goto bail;
   }
 

--- a/imap/auth_cram.c
+++ b/imap/auth_cram.c
@@ -67,18 +67,18 @@ imap_auth_res_t imap_auth_cram_md5 (IMAP_DATA* idata, const char* method)
   
   if (rc != IMAP_CMD_RESPOND)
   {
-    dprint (1, (debugfile, "Invalid response from server: %s\n", ibuf));
+    mutt_debug (1, "Invalid response from server: %s\n", ibuf);
     goto bail;
   }
 
   if ((len = mutt_from_base64 (obuf, idata->buf + 2)) == -1)
   {
-    dprint (1, (debugfile, "Error decoding base64 response.\n"));
+    mutt_debug (1, "Error decoding base64 response.\n");
     goto bail;
   }
 
   obuf[len] = '\0';
-  dprint (2, (debugfile, "CRAM challenge: %s\n", obuf));
+  mutt_debug (2, "CRAM challenge: %s\n", obuf);
 
   /* The client makes note of the data and then responds with a string
    * consisting of the user name, a space, and a 'digest'. The latter is
@@ -100,7 +100,7 @@ imap_auth_res_t imap_auth_cram_md5 (IMAP_DATA* idata, const char* method)
     hmac_response[4], hmac_response[5], hmac_response[6], hmac_response[7],
     hmac_response[8], hmac_response[9], hmac_response[10], hmac_response[11],
     hmac_response[12], hmac_response[13], hmac_response[14], hmac_response[15]);
-  dprint(2, (debugfile, "CRAM response: %s\n", obuf));
+  mutt_debug (2, "CRAM response: %s\n", obuf);
 
   /* XXX - ibuf must be long enough to store the base64 encoding of obuf, 
    * plus the additional debris
@@ -116,7 +116,7 @@ imap_auth_res_t imap_auth_cram_md5 (IMAP_DATA* idata, const char* method)
 
   if (rc != IMAP_CMD_OK)
   {
-    dprint (1, (debugfile, "Error receiving server response.\n"));
+    mutt_debug (1, "Error receiving server response.\n");
     goto bail;
   }
 

--- a/imap/auth_login.c
+++ b/imap/auth_login.c
@@ -54,8 +54,8 @@ imap_auth_res_t imap_auth_login (IMAP_DATA* idata, const char* method)
    * of 5 or higher */
 
   if (debuglevel < IMAP_LOG_PASS)
-    dprint (2, (debugfile, "Sending LOGIN command for %s...\n",
-      idata->conn->account.user));
+    mutt_debug (2, "Sending LOGIN command for %s...\n",
+                idata->conn->account.user);
 #endif
 
   snprintf (buf, sizeof (buf), "LOGIN %s %s", q_user, q_pass);

--- a/imap/auth_sasl.c
+++ b/imap/auth_sasl.c
@@ -45,8 +45,7 @@ imap_auth_res_t imap_auth_sasl (IMAP_DATA* idata, const char* method)
 
   if (mutt_sasl_client_new (idata->conn, &saslconn) < 0)
   {
-    dprint (1, (debugfile,
-      "imap_auth_sasl: Error allocating SASL connection.\n"));
+    mutt_debug (1, "imap_auth_sasl: Error allocating SASL connection.\n");
     return IMAP_AUTH_FAILURE;
   }
 
@@ -90,9 +89,10 @@ imap_auth_res_t imap_auth_sasl (IMAP_DATA* idata, const char* method)
   if (rc != SASL_OK && rc != SASL_CONTINUE)
   {
     if (method)
-      dprint (2, (debugfile, "imap_auth_sasl: %s unavailable\n", method));
+      mutt_debug (2, "imap_auth_sasl: %s unavailable\n", method);
     else
-      dprint (1, (debugfile, "imap_auth_sasl: Failure starting authentication exchange. No shared mechanisms?\n"));
+      mutt_debug (1, "imap_auth_sasl: Failure starting authentication exchange. "
+                  "No shared mechanisms?\n");
     /* SASL doesn't support LOGIN, so fall back */
 
     return IMAP_AUTH_UNAVAIL;
@@ -110,7 +110,7 @@ imap_auth_res_t imap_auth_sasl (IMAP_DATA* idata, const char* method)
     buf[len++] = ' ';
     if (sasl_encode64 (pc, olen, buf + len, bufsize - len, &olen) != SASL_OK)
     {
-      dprint (1, (debugfile, "imap_auth_sasl: error base64-encoding client response.\n"));
+      mutt_debug (1, "imap_auth_sasl: error base64-encoding client response.\n");
       goto bail;
     }
     client_start = olen = 0;
@@ -148,7 +148,7 @@ imap_auth_res_t imap_auth_sasl (IMAP_DATA* idata, const char* method)
          * include space for the trailing null */
         if (sasl_decode64 (idata->buf+2, len, buf, bufsize - 1, &len) != SASL_OK)
         {
-          dprint (1, (debugfile, "imap_auth_sasl: error base64-decoding server response.\n"));
+          mutt_debug (1, "imap_auth_sasl: error base64-decoding server response.\n");
           goto bail;
         }
       }
@@ -180,7 +180,7 @@ imap_auth_res_t imap_auth_sasl (IMAP_DATA* idata, const char* method)
       }
       if (sasl_encode64 (pc, olen, buf, bufsize, &olen) != SASL_OK)
       {
-	dprint (1, (debugfile, "imap_auth_sasl: error base64-encoding client response.\n"));
+        mutt_debug (1, "imap_auth_sasl: error base64-encoding client response.\n");
 	goto bail;
       }
     }
@@ -195,7 +195,7 @@ imap_auth_res_t imap_auth_sasl (IMAP_DATA* idata, const char* method)
     if (rc < 0)
     {
       mutt_socket_write (idata->conn, "*\r\n");
-      dprint (1, (debugfile, "imap_auth_sasl: sasl_client_step error %d\n",rc));
+      mutt_debug (1, "imap_auth_sasl: sasl_client_step error %d\n", rc);
     }
 	  
     olen = 0;
@@ -221,7 +221,7 @@ imap_auth_res_t imap_auth_sasl (IMAP_DATA* idata, const char* method)
 
   if (method)
   {
-    dprint (2, (debugfile, "imap_auth_sasl: %s failed\n", method));
+    mutt_debug (2, "imap_auth_sasl: %s failed\n", method);
     return IMAP_AUTH_UNAVAIL;
   }
 

--- a/imap/browse.c
+++ b/imap/browse.c
@@ -82,7 +82,7 @@ int imap_browse (char* path, struct browser_state* state)
   if (n)
   {
     int rc;
-    dprint (3, (debugfile, "imap_browse: mbox: %s\n", mbox));
+    mutt_debug (3, "imap_browse: mbox: %s\n", mbox);
 
     /* if our target exists and has inferiors, enter it if we
      * aren't already going to */
@@ -134,7 +134,7 @@ int imap_browse (char* path, struct browser_state* state)
 
       if (showparents)
       {
-	dprint (3, (debugfile, "imap_init_browse: adding parent %s\n", mbox));
+	mutt_debug (3, "imap_init_browse: adding parent %s\n", mbox);
 	imap_add_folder (list.delim, mbox, 1, 0, state, 1);
       }
 
@@ -173,10 +173,10 @@ int imap_browse (char* path, struct browser_state* state)
     state->folder = safe_strdup (buf);
   }
 
-  dprint (3, (debugfile, "imap_browse: Quoting mailbox scan: %s -> ", mbox));
+  mutt_debug (3, "imap_browse: Quoting mailbox scan: %s -> ", mbox);
   snprintf (buf, sizeof (buf), "%s%%", mbox);
   imap_munge_mbox_name (idata, munged_mbox, sizeof (munged_mbox), buf);
-  dprint (3, (debugfile, "%s\n", munged_mbox));
+  mutt_debug (3, "%s\n", munged_mbox);
   snprintf (buf, sizeof (buf), "%s \"\" %s", list_cmd, munged_mbox);
   if (browse_add_list_result (idata, buf, state, 0))
     goto fail;
@@ -212,14 +212,14 @@ int imap_mailbox_create (const char* folder)
 
   if (imap_parse_path (folder, &mx) < 0)
   {
-    dprint (1, (debugfile, "imap_mailbox_create: Bad starting path %s\n",
-      folder));
+    mutt_debug (1, "imap_mailbox_create: Bad starting path %s\n", folder);
     return -1;
   }
 
   if (!(idata = imap_conn_find (&mx.account, MUTT_IMAP_CONN_NONEW)))
   {
-    dprint (1, (debugfile, "imap_mailbox_create: Couldn't find open connection to %s", mx.account.host));
+    mutt_debug (1, "imap_mailbox_create: Couldn't find open connection to %s",
+                mx.account.host);
     goto fail;
   }
   
@@ -266,14 +266,14 @@ int imap_mailbox_rename(const char* mailbox)
 
   if (imap_parse_path (mailbox, &mx) < 0)
   {
-    dprint (1, (debugfile, "imap_mailbox_rename: Bad source mailbox %s\n",
-      mailbox));
+    mutt_debug (1, "imap_mailbox_rename: Bad source mailbox %s\n", mailbox);
     return -1;
   }
 
   if (!(idata = imap_conn_find (&mx.account, MUTT_IMAP_CONN_NONEW)))
   {
-    dprint (1, (debugfile, "imap_mailbox_rename: Couldn't find open connection to %s", mx.account.host));
+    mutt_debug (1, "imap_mailbox_rename: Couldn't find open connection to %s",
+                mx.account.host);
     goto fail;
   }
 
@@ -324,8 +324,8 @@ static int browse_add_list_result (IMAP_DATA* idata, const char* cmd,
 
   if (imap_parse_path (state->folder, &mx))
   {
-    dprint (2, (debugfile,
-      "browse_add_list_result: current folder %s makes no sense\n", state->folder));
+    mutt_debug (2, "browse_add_list_result: current folder %s makes no sense\n",
+                state->folder);
     return -1;
   }
 

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -88,7 +88,7 @@ int imap_access (const char* path, int flags)
 
   if (imap_mboxcache_get (idata, mailbox, 0))
   {
-    dprint (3, (debugfile, "imap_access: found %s in cache\n", mailbox));
+    mutt_debug (3, "imap_access: found %s in cache\n", mailbox);
     return 0;
   }
 
@@ -100,13 +100,13 @@ int imap_access (const char* path, int flags)
     snprintf (buf, sizeof (buf), "STATUS %s (UID-VALIDITY)", mbox);
   else
   {
-    dprint (2, (debugfile, "imap_access: STATUS not supported?\n"));
+    mutt_debug (2, "imap_access: STATUS not supported?\n");
     return -1;
   }
 
   if ((rc = imap_exec (idata, buf, IMAP_CMD_FAIL_OK)) < 0)
   {
-    dprint (1, (debugfile, "imap_access: Can't check STATUS of %s\n", mbox));
+    mutt_debug (1, "imap_access: Can't check STATUS of %s\n", mbox);
     return rc;
   }
 
@@ -206,13 +206,14 @@ int imap_read_literal (FILE* fp, IMAP_DATA* idata, long bytes, progress_t* pbar)
 
   int r = 0;
 
-  dprint (2, (debugfile, "imap_read_literal: reading %ld bytes\n", bytes));
+  mutt_debug (2, "imap_read_literal: reading %ld bytes\n", bytes);
 
   for (pos = 0; pos < bytes; pos++)
   {
     if (mutt_socket_readchar (idata->conn, &c) != 1)
     {
-      dprint (1, (debugfile, "imap_read_literal: error during read, %ld bytes read\n", pos));
+      mutt_debug (1, "imap_read_literal: error during read, %ld bytes read\n",
+                  pos);
       idata->status = IMAP_FATAL;
 
       return -1;
@@ -261,7 +262,7 @@ void imap_expunge_mailbox (IMAP_DATA* idata)
 
     if (h->index == -1)
     {
-      dprint (2, (debugfile, "Expunging message UID %d.\n", HEADER_DATA (h)->uid));
+      mutt_debug (2, "Expunging message UID %d.\n", HEADER_DATA (h)->uid);
 
       h->active = 0;
       idata->ctx->size -= h->content->length;
@@ -376,8 +377,8 @@ IMAP_DATA* imap_conn_find (const ACCOUNT* account, int flags)
       FREE (&idata->capstr);
       new = 1;
       if (idata->conn->ssf)
-	dprint (2, (debugfile, "Communication encrypted at %d bits\n",
-		    idata->conn->ssf));
+        mutt_debug (2, "Communication encrypted at %d bits\n",
+                    idata->conn->ssf);
     }
     else
       mutt_account_unsetpass (&idata->conn->account);
@@ -508,16 +509,14 @@ static char* imap_get_flags (LIST** hflags, char* s)
   /* sanity-check string */
   if (ascii_strncasecmp ("FLAGS", s, 5) != 0)
   {
-    dprint (1, (debugfile, "imap_get_flags: not a FLAGS response: %s\n",
-      s));
+    mutt_debug (1, "imap_get_flags: not a FLAGS response: %s\n", s);
     return NULL;
   }
   s += 5;
   SKIPWS(s);
   if (*s != '(')
   {
-    dprint (1, (debugfile, "imap_get_flags: bogus FLAGS response: %s\n",
-      s));
+    mutt_debug (1, "imap_get_flags: bogus FLAGS response: %s\n", s);
     return NULL;
   }
 
@@ -542,8 +541,7 @@ static char* imap_get_flags (LIST** hflags, char* s)
   /* note bad flags response */
   if (*s != ')')
   {
-    dprint (1, (debugfile,
-      "imap_get_flags: Unterminated FLAGS response: %s\n", s));
+    mutt_debug (1, "imap_get_flags: Unterminated FLAGS response: %s\n", s);
     mutt_free_list (hflags);
 
     return NULL;
@@ -652,7 +650,7 @@ static int imap_open_mailbox (CONTEXT* ctx)
       /* don't override PERMANENTFLAGS */
       if (!idata->flags)
       {
-	dprint (3, (debugfile, "Getting mailbox FLAGS\n"));
+        mutt_debug (3, "Getting mailbox FLAGS\n");
 	if ((pc = imap_get_flags (&(idata->flags), pc)) == NULL)
 	  goto fail;
       }
@@ -660,7 +658,7 @@ static int imap_open_mailbox (CONTEXT* ctx)
     /* PERMANENTFLAGS are massaged to look like FLAGS, then override FLAGS */
     else if (ascii_strncasecmp ("OK [PERMANENTFLAGS", pc, 18) == 0)
     {
-      dprint (3, (debugfile, "Getting mailbox PERMANENTFLAGS\n"));
+      mutt_debug (3, "Getting mailbox PERMANENTFLAGS\n");
       /* safe to call on NULL */
       mutt_free_list (&(idata->flags));
       /* skip "OK [PERMANENT" so syntax is the same as FLAGS */
@@ -671,7 +669,7 @@ static int imap_open_mailbox (CONTEXT* ctx)
     /* save UIDVALIDITY for the header cache */
     else if (ascii_strncasecmp ("OK [UIDVALIDITY", pc, 14) == 0)
     {
-      dprint (3, (debugfile, "Getting mailbox UIDVALIDITY\n"));
+      mutt_debug (3, "Getting mailbox UIDVALIDITY\n");
       pc += 3;
       pc = imap_next_word (pc);
       idata->uid_validity = strtol (pc, NULL, 10);
@@ -679,7 +677,7 @@ static int imap_open_mailbox (CONTEXT* ctx)
     }
     else if (ascii_strncasecmp ("OK [UIDNEXT", pc, 11) == 0)
     {
-      dprint (3, (debugfile, "Getting mailbox UIDNEXT\n"));
+      mutt_debug (3, "Getting mailbox UIDNEXT\n");
       pc += 3;
       pc = imap_next_word (pc);
       idata->uidnext = strtol (pc, NULL, 10);
@@ -714,7 +712,7 @@ static int imap_open_mailbox (CONTEXT* ctx)
   if (!ascii_strncasecmp (imap_get_qualifier (idata->buf), "[READ-ONLY]", 11)  \
   && !mutt_bit_isset (idata->capabilities, ACL))
   {
-    dprint (2, (debugfile, "Mailbox is read-only.\n"));
+    mutt_debug (2, "Mailbox is read-only.\n");
     ctx->readonly = 1;
   }
 
@@ -723,20 +721,20 @@ static int imap_open_mailbox (CONTEXT* ctx)
   if (debuglevel > 2)
   {
     if (!idata->flags)
-      dprint (3, (debugfile, "No folder flags found\n"));
+      mutt_debug (3, "No folder flags found\n");
     else
     {
       LIST* t = idata->flags;
 
-      dprint (3, (debugfile, "Mailbox flags: "));
+      mutt_debug (3, "Mailbox flags: ");
 
       t = t->next;
       while (t)
       {
-        dprint (3, (debugfile, "[%s] ", t->data));
+        mutt_debug (3, "[%s] ", t->data);
         t = t->next;
       }
-      dprint (3, (debugfile, "\n"));
+      mutt_debug (3, "\n");
     }
   }
 #endif
@@ -759,7 +757,7 @@ static int imap_open_mailbox (CONTEXT* ctx)
     goto fail;
   }
 
-  dprint (2, (debugfile, "imap_open_mailbox: msgcount is %d\n", ctx->msgcount));
+  mutt_debug (2, "imap_open_mailbox: msgcount is %d\n", ctx->msgcount);
   FREE (&mx.mbox);
   return 0;
 
@@ -984,7 +982,7 @@ int imap_exec_msgset (IMAP_DATA* idata, const char* pre, const char* post,
 
   if (! (cmd = mutt_buffer_new ()))
   {
-    dprint (1, (debugfile, "imap_exec_msgset: unable to allocate buffer\n"));
+    mutt_debug (1, "imap_exec_msgset: unable to allocate buffer\n");
     return -1;
   }
 
@@ -1181,7 +1179,7 @@ int imap_sync_mailbox (CONTEXT* ctx, int expunge)
 
   if (idata->state < IMAP_SELECTED)
   {
-    dprint (2, (debugfile, "imap_sync_mailbox: no mailbox selected\n"));
+    mutt_debug (2, "imap_sync_mailbox: no mailbox selected\n");
     return -1;
   }
 
@@ -1247,7 +1245,7 @@ int imap_sync_mailbox (CONTEXT* ctx, int expunge)
 	if (!appendctx)
 	  appendctx = mx_open_mailbox (ctx->path, MUTT_APPEND | MUTT_QUIET, NULL);
 	if (!appendctx)
-	  dprint (1, (debugfile, "imap_sync_mailbox: Error opening mailbox in append mode\n"));
+	  mutt_debug (1, "imap_sync_mailbox: Error opening mailbox in append mode\n");
 	else
 	  _mutt_save_message (h, appendctx, 1, 0, 0);
 	h->label_changed = 0;
@@ -1440,13 +1438,13 @@ int imap_check (IMAP_DATA *idata, int force)
     {
       if (imap_cmd_step (idata) != IMAP_CMD_CONTINUE)
       {
-        dprint (1, (debugfile, "Error reading IDLE response\n"));
+        mutt_debug (1, "Error reading IDLE response\n");
         return -1;
       }
     }
     if (result < 0)
     {
-      dprint (1, (debugfile, "Poll failed, disabling IDLE\n"));
+      mutt_debug (1, "Poll failed, disabling IDLE\n");
       mutt_bit_unset (idata->capabilities, IDLE);
     }
   }
@@ -1491,7 +1489,7 @@ static int imap_get_mailbox (const char* path, IMAP_DATA** hidata, char* buf, si
 
   if (imap_parse_path (path, &mx))
   {
-    dprint (1, (debugfile, "imap_get_mailbox: Error parsing %s\n", path));
+    mutt_debug (1, "imap_get_mailbox: Error parsing %s\n", path);
     return -1;
   }
   if (!(*hidata = imap_conn_find (&(mx.account), option (OPTIMAPPASSIVE) ? MUTT_IMAP_CONN_NONEW : 0))
@@ -1553,7 +1551,7 @@ int imap_buffy_check (int force, int check_stats)
     if (!mutt_bit_isset (idata->capabilities, IMAP4REV1) &&
         !mutt_bit_isset (idata->capabilities, STATUS))
     {
-      dprint (2, (debugfile, "Server doesn't support STATUS\n"));
+      mutt_debug (2, "Server doesn't support STATUS\n");
       continue;
     }
 
@@ -1562,7 +1560,7 @@ int imap_buffy_check (int force, int check_stats)
       /* Send commands to previous server. Sorting the buffy list
        * may prevent some infelicitous interleavings */
       if (imap_exec (lastdata, NULL, IMAP_CMD_FAIL_OK) == -1)
-        dprint (1, (debugfile, "Error polling mailboxes\n"));
+        mutt_debug (1, "Error polling mailboxes\n");
 
       lastdata = NULL;
     }
@@ -1580,14 +1578,14 @@ int imap_buffy_check (int force, int check_stats)
 
     if (imap_exec (idata, command, IMAP_CMD_QUEUE) < 0)
     {
-      dprint (1, (debugfile, "Error queueing command\n"));
+      mutt_debug (1, "Error queueing command\n");
       return 0;
     }
   }
 
   if (lastdata && (imap_exec (lastdata, NULL, IMAP_CMD_FAIL_OK) == -1))
   {
-    dprint (1, (debugfile, "Error polling mailboxes\n"));
+    mutt_debug (1, "Error polling mailboxes\n");
     return 0;
   }
 
@@ -1696,8 +1694,8 @@ IMAP_STATUS* imap_mboxcache_get (IMAP_DATA* idata, const char* mbox, int create)
       }
       status->uidvalidity = *(unsigned int *)uidvalidity;
       status->uidnext = uidnext ? *(unsigned int *)uidnext: 0;
-      dprint (3, (debugfile, "mboxcache: hcache uidvalidity %d, uidnext %d\n",
-                  status->uidvalidity, status->uidnext));
+      mutt_debug (3, "mboxcache: hcache uidvalidity %d, uidnext %d\n",
+                  status->uidvalidity, status->uidnext);
     }
     mutt_hcache_free (hc, &uidvalidity);
     mutt_hcache_free (hc, &uidnext);
@@ -1897,7 +1895,7 @@ int imap_subscribe (char *path, int subscribe)
     snprintf (mbox, sizeof (mbox), "%smailboxes \"%s\"",
               subscribe ? "" : "un", path);
     if (mutt_parse_rc_line (mbox, &token, &err))
-      dprint (1, (debugfile, "Error adding subscribed mailbox: %s\n", errstr));
+      mutt_debug (1, "Error adding subscribed mailbox: %s\n", errstr);
     FREE (&token.data);
   }
 
@@ -2101,15 +2099,15 @@ int imap_fast_trash (CONTEXT* ctx, char* dest)
 
   if (imap_parse_path (dest, &mx))
   {
-    dprint (1, (debugfile, "imap_fast_trash: bad destination %s\n", dest));
+    mutt_debug (1, "imap_fast_trash: bad destination %s\n", dest);
     return -1;
   }
 
   /* check that the save-to folder is in the same account */
   if (!mutt_account_match (&(idata->conn->account), &(mx.account)))
   {
-    dprint (3, (debugfile, "imap_fast_trash: %s not same server as %s\n",
-      dest, ctx->path));
+    mutt_debug (3, "imap_fast_trash: %s not same server as %s\n",
+                dest, ctx->path);
     return 1;
   }
 
@@ -2125,20 +2123,20 @@ int imap_fast_trash (CONTEXT* ctx, char* dest)
                            MUTT_TRASH, 0, 0);
     if (rc < 0)
     {
-      dprint (1, (debugfile, "imap_fast_trash: Unable to mark messages as seen\n"));
+      mutt_debug (1, "imap_fast_trash: Unable to mark messages as seen\n");
       goto out;
     }
 
     rc = imap_exec_msgset (idata, "UID COPY", mmbox, MUTT_TRASH, 0, 0);
     if (!rc)
     {
-      dprint (1, (debugfile, "imap_fast_trash: No messages to trash\n"));
+      mutt_debug (1, "imap_fast_trash: No messages to trash\n");
       rc = -1;
       goto out;
     }
     else if (rc < 0)
     {
-      dprint (1, (debugfile, "could not queue copy\n"));
+      mutt_debug (1, "could not queue copy\n");
       goto out;
     }
     else
@@ -2150,13 +2148,13 @@ int imap_fast_trash (CONTEXT* ctx, char* dest)
     {
       if (triedcreate)
       {
-        dprint (1, (debugfile, "Already tried to create mailbox %s\n", mbox));
+        mutt_debug (1, "Already tried to create mailbox %s\n", mbox);
         break;
       }
       /* bail out if command failed for reasons other than nonexistent target */
       if (ascii_strncasecmp (imap_get_qualifier (idata->buf), "[TRYCREATE]", 11))
         break;
-      dprint (3, (debugfile, "imap_fast_trash: server suggests TRYCREATE\n"));
+      mutt_debug (3, "imap_fast_trash: server suggests TRYCREATE\n");
       snprintf (prompt, sizeof (prompt), _("Create %s?"), mbox);
       if (option (OPTCONFIRMCREATE) && mutt_yesorno (prompt, 1) != MUTT_YES)
       {

--- a/imap/message.c
+++ b/imap/message.c
@@ -180,8 +180,8 @@ int imap_read_headers (IMAP_DATA* idata, int msgbegin, int msgend)
 
         if (!h.data->uid)
         {
-          dprint (2, (debugfile, "imap_read_headers: skipping hcache FETCH "
-                      "response for unknown message number %d\n", h.sid));
+          mutt_debug (2, "imap_read_headers: skipping hcache FETCH "
+                      "response for unknown message number %d\n", h.sid);
           mfhrc = -1;
           continue;
         }
@@ -209,7 +209,7 @@ int imap_read_headers (IMAP_DATA* idata, int msgbegin, int msgend)
 	else
         {
 	  /* bad header in the cache, we'll have to refetch. */
-          dprint (3, (debugfile, "bad cache entry at %d, giving up\n", h.sid - 1));
+          mutt_debug (3, "bad cache entry at %d, giving up\n", h.sid - 1);
           imap_free_header_data(&h.data);
           evalhc = 0;
           idx--;
@@ -272,7 +272,7 @@ int imap_read_headers (IMAP_DATA* idata, int msgbegin, int msgend)
 
       if (!ftello (fp))
       {
-        dprint (2, (debugfile, "msg_fetch_header: ignoring fetch response with no body\n"));
+        mutt_debug (2, "msg_fetch_header: ignoring fetch response with no body\n");
         mfhrc = -1;
         msgend--;
         continue;
@@ -284,8 +284,8 @@ int imap_read_headers (IMAP_DATA* idata, int msgbegin, int msgend)
       idx++;
       if (idx > msgend)
       {
-        dprint (1, (debugfile, "imap_read_headers: skipping FETCH response for "
-                    "unknown message number %d\n", h.sid));
+        mutt_debug (1, "imap_read_headers: skipping FETCH response for "
+                    "unknown message number %d\n", h.sid);
         mfhrc = -1;
         idx--;
         continue;
@@ -293,8 +293,7 @@ int imap_read_headers (IMAP_DATA* idata, int msgbegin, int msgend)
       /* May receive FLAGS updates in a separate untagged response (#2935) */
       if (idx < ctx->msgcount)
       {
-	dprint (2, (debugfile, "imap_read_headers: message %d is not new\n",
-		    h.sid));
+        mutt_debug (2, "imap_read_headers: message %d is not new\n", h.sid);
         idx--;
 	continue;
       }
@@ -364,7 +363,7 @@ int imap_read_headers (IMAP_DATA* idata, int msgbegin, int msgend)
           &idata->uid_validity, sizeof (idata->uid_validity));
   if (maxuid && idata->uidnext < maxuid + 1)
   {
-    dprint (2, (debugfile, "Overriding UIDNEXT: %u -> %u\n", idata->uidnext, maxuid + 1));
+    mutt_debug (2, "Overriding UIDNEXT: %u -> %u\n", idata->uidnext, maxuid + 1);
     idata->uidnext = maxuid + 1;
   }
   if (idata->uidnext > 1)
@@ -690,8 +689,7 @@ int imap_append_message (CONTEXT *ctx, MESSAGE *msg)
   {
     char *pc;
 
-    dprint (1, (debugfile, "imap_append_message(): command failed: %s\n",
-		idata->buf));
+    mutt_debug (1, "imap_append_message(): command failed: %s\n", idata->buf);
 
     pc = idata->buf + SEQLEN;
     SKIPWS (pc);
@@ -731,8 +729,7 @@ int imap_append_message (CONTEXT *ctx, MESSAGE *msg)
   {
     char *pc;
 
-    dprint (1, (debugfile, "imap_append_message(): command failed: %s\n",
-		idata->buf));
+    mutt_debug (1, "imap_append_message(): command failed: %s\n", idata->buf);
     pc = idata->buf + SEQLEN;
     SKIPWS (pc);
     pc = imap_next_word (pc);
@@ -772,21 +769,21 @@ int imap_copy_messages (CONTEXT* ctx, HEADER* h, char* dest, int delete)
 
   if (imap_parse_path (dest, &mx))
   {
-    dprint (1, (debugfile, "imap_copy_messages: bad destination %s\n", dest));
+    mutt_debug (1, "imap_copy_messages: bad destination %s\n", dest);
     return -1;
   }
 
   /* check that the save-to folder is in the same account */
   if (!mutt_account_match (&(idata->conn->account), &(mx.account)))
   {
-    dprint (3, (debugfile, "imap_copy_messages: %s not same server as %s\n",
-      dest, ctx->path));
+    mutt_debug (3, "imap_copy_messages: %s not same server as %s\n",
+                dest, ctx->path);
     return 1;
   }
 
   if (h && h->attach_del)
   {
-    dprint (3, (debugfile, "imap_copy_messages: Message contains attachments to be deleted\n"));
+    mutt_debug (3, "imap_copy_messages: Message contains attachments to be deleted\n");
     return 1;
   }
 
@@ -811,7 +808,7 @@ int imap_copy_messages (CONTEXT* ctx, HEADER* h, char* dest, int delete)
       {
         if (ctx->hdrs[n]->tagged && ctx->hdrs[n]->attach_del)
         {
-          dprint (3, (debugfile, "imap_copy_messages: Message contains attachments to be deleted\n"));
+          mutt_debug (3, "imap_copy_messages: Message contains attachments to be deleted\n");
           return 1;
         }
 
@@ -821,7 +818,7 @@ int imap_copy_messages (CONTEXT* ctx, HEADER* h, char* dest, int delete)
           rc = imap_sync_message (idata, ctx->hdrs[n], &sync_cmd, &err_continue);
           if (rc < 0)
           {
-            dprint (1, (debugfile, "imap_copy_messages: could not sync\n"));
+            mutt_debug (1, "imap_copy_messages: could not sync\n");
             goto out;
           }
         }
@@ -830,13 +827,13 @@ int imap_copy_messages (CONTEXT* ctx, HEADER* h, char* dest, int delete)
       rc = imap_exec_msgset (idata, "UID COPY", mmbox, MUTT_TAG, 0, 0);
       if (!rc)
       {
-        dprint (1, (debugfile, "imap_copy_messages: No messages tagged\n"));
+        mutt_debug (1, "imap_copy_messages: No messages tagged\n");
         rc = -1;
         goto out;
       }
       else if (rc < 0)
       {
-        dprint (1, (debugfile, "could not queue copy\n"));
+        mutt_debug (1, "could not queue copy\n");
         goto out;
       }
       else
@@ -852,13 +849,13 @@ int imap_copy_messages (CONTEXT* ctx, HEADER* h, char* dest, int delete)
         rc = imap_sync_message (idata, h, &sync_cmd, &err_continue);
         if (rc < 0)
         {
-          dprint (1, (debugfile, "imap_copy_messages: could not sync\n"));
+          mutt_debug (1, "imap_copy_messages: could not sync\n");
           goto out;
         }
       }
       if ((rc = imap_exec (idata, cmd.data, IMAP_CMD_QUEUE)) < 0)
       {
-        dprint (1, (debugfile, "could not queue copy\n"));
+        mutt_debug (1, "could not queue copy\n");
         goto out;
       }
     }
@@ -869,13 +866,13 @@ int imap_copy_messages (CONTEXT* ctx, HEADER* h, char* dest, int delete)
     {
       if (triedcreate)
       {
-        dprint (1, (debugfile, "Already tried to create mailbox %s\n", mbox));
+        mutt_debug (1, "Already tried to create mailbox %s\n", mbox);
         break;
       }
       /* bail out if command failed for reasons other than nonexistent target */
       if (ascii_strncasecmp (imap_get_qualifier (idata->buf), "[TRYCREATE]", 11))
         break;
-      dprint (3, (debugfile, "imap_copy_messages: server suggests TRYCREATE\n"));
+      mutt_debug (3, "imap_copy_messages: server suggests TRYCREATE\n");
       snprintf (prompt, sizeof (prompt), _("Create %s?"), mbox);
       if (option (OPTCONFIRMCREATE) && mutt_yesorno (prompt, 1) != MUTT_YES)
       {
@@ -1068,7 +1065,7 @@ char* imap_set_flags (IMAP_DATA* idata, HEADER* h, char* s)
   hd = h->data;
   newh.data = hd;
 
-  dprint (2, (debugfile, "imap_fetch_message: parsing FLAGS\n"));
+  mutt_debug (2, "imap_fetch_message: parsing FLAGS\n");
   if ((s = msg_parse_flags (&newh, s)) == NULL)
     return NULL;
 
@@ -1188,7 +1185,7 @@ static int msg_parse_fetch (IMAP_HEADER *h, char *s)
       SKIPWS (s);
       if (*s != '\"')
       {
-        dprint (1, (debugfile, "msg_parse_fetch(): bogus INTERNALDATE entry: %s\n", s));
+        mutt_debug (1, "msg_parse_fetch(): bogus INTERNALDATE entry: %s\n", s);
         return -1;
       }
       s++;
@@ -1238,16 +1235,14 @@ static char* msg_parse_flags (IMAP_HEADER* h, char* s)
   /* sanity-check string */
   if (ascii_strncasecmp ("FLAGS", s, 5) != 0)
   {
-    dprint (1, (debugfile, "msg_parse_flags: not a FLAGS response: %s\n",
-      s));
+    mutt_debug (1, "msg_parse_flags: not a FLAGS response: %s\n", s);
     return NULL;
   }
   s += 5;
   SKIPWS(s);
   if (*s != '(')
   {
-    dprint (1, (debugfile, "msg_parse_flags: bogus FLAGS response: %s\n",
-      s));
+    mutt_debug (1, "msg_parse_flags: bogus FLAGS response: %s\n", s);
     return NULL;
   }
   s++;
@@ -1309,8 +1304,7 @@ static char* msg_parse_flags (IMAP_HEADER* h, char* s)
     s++;
   else
   {
-    dprint (1, (debugfile,
-      "msg_parse_flags: Unterminated FLAGS response: %s\n", s));
+    mutt_debug (1, "msg_parse_flags: Unterminated FLAGS response: %s\n", s);
     return NULL;
   }
 

--- a/imap/util.c
+++ b/imap/util.c
@@ -230,8 +230,7 @@ HEADER* imap_hcache_get (IMAP_DATA* idata, unsigned int uid)
     if (*(unsigned int *)uv == idata->uid_validity)
       h = mutt_hcache_restore (uv);
     else
-      dprint (3, (debugfile, "hcache uidvalidity mismatch: %u",
-                  *(unsigned int *)uv));
+      mutt_debug (3, "hcache uidvalidity mismatch: %u", *(unsigned int *)uv);
     mutt_hcache_free (idata->hcache, &uv);
   }
 
@@ -282,7 +281,7 @@ int imap_parse_path (const char* path, IMAP_MBOX* mx)
       ImapPort = ntohs (service->s_port);
     else
       ImapPort = IMAP_PORT;
-    dprint (3, (debugfile, "Using default IMAP port %d\n", ImapPort));
+    mutt_debug (3, "Using default IMAP port %d\n", ImapPort);
   }
   if (!ImapsPort)
   {
@@ -291,7 +290,7 @@ int imap_parse_path (const char* path, IMAP_MBOX* mx)
       ImapsPort = ntohs (service->s_port);
     else
       ImapsPort = IMAP_SSL_PORT;
-    dprint (3, (debugfile, "Using default IMAPS port %d\n", ImapsPort));
+    mutt_debug (3, "Using default IMAPS port %d\n", ImapsPort);
   }
 
   /* Defaults */
@@ -340,7 +339,7 @@ int imap_parse_path (const char* path, IMAP_MBOX* mx)
 
     if ((n = sscanf (tmp, "%127[^:/]%127s", mx->account.host, tmp)) < 1)
     {
-      dprint (1, (debugfile, "imap_parse_path: NULL host in %s\n", path));
+      mutt_debug (1, "imap_parse_path: NULL host in %s\n", path);
       FREE (&mx->mbox);
       return -1;
     }
@@ -354,7 +353,8 @@ int imap_parse_path (const char* path, IMAP_MBOX* mx)
 	  mx->account.flags |= MUTT_ACCT_SSL;
 	else
 	{
-	  dprint (1, (debugfile, "imap_parse_path: Unknown connection type in %s\n", path));
+	  mutt_debug (1, "imap_parse_path: Unknown connection type in %s\n",
+	              path);
 	  FREE (&mx->mbox);
 	  return -1;
 	}

--- a/init.c
+++ b/init.c
@@ -250,13 +250,13 @@ int mutt_extract_token (BUFFER *dest, BUFFER *tok, int flags)
       } while (pc && *pc != '`');
       if (!pc)
       {
-	dprint (1, (debugfile, "mutt_get_token: mismatched backticks\n"));
+        mutt_debug (1, "mutt_get_token: mismatched backticks\n");
 	return (-1);
       }
       cmd = mutt_substrdup (tok->dptr, pc);
       if ((pid = mutt_create_filter (cmd, NULL, &fp, NULL)) < 0)
       {
-	dprint (1, (debugfile, "mutt_get_token: unable to fork command: %s", cmd));
+        mutt_debug (1, "mutt_get_token: unable to fork command: %s", cmd);
 	FREE (&cmd);
 	return (-1);
       }
@@ -765,10 +765,9 @@ static mbchar_table *parse_mbchar_table (const char *s)
   {
     if (k == (size_t)(-1) || k == (size_t)(-2))
     {
-      dprint (1, (debugfile,
+      mutt_debug (1,
                   "parse_mbchar_table: mbrtowc returned %d converting %s in %s\n",
-                  (k == (size_t)(-1)) ? -1 : -2,
-                  s, t->orig_str));
+                  (k == (size_t)(-1)) ? -1 : -2, s, t->orig_str);
       if (k == (size_t)(-1))
         memset (&mbstate, 0, sizeof (mbstate));
       k = (k == (size_t)(-1)) ? 1 : slen;
@@ -1104,13 +1103,13 @@ static int parse_attach_list (BUFFER *buf, BUFFER *s, LIST **ldata, BUFFER *err)
 
   /* Find the last item in the list that data points to. */
   lastp = NULL;
-  dprint(5, (debugfile, "parse_attach_list: ldata = %p, *ldata = %p\n",
-	      (void *)ldata, (void *)*ldata));
+  mutt_debug (5, "parse_attach_list: ldata = %p, *ldata = %p\n",
+              (void *)ldata, (void *)*ldata);
   for (listp = *ldata; listp; listp = listp->next)
   {
     a = (ATTACH_MATCH *)listp->data;
-    dprint(5, (debugfile, "parse_attach_list: skipping %s/%s\n",
-		a->major, a->minor));
+    mutt_debug (5, "parse_attach_list: skipping %s/%s\n",
+                a->major, a->minor);
     lastp = listp;
   }
 
@@ -1162,8 +1161,8 @@ static int parse_attach_list (BUFFER *buf, BUFFER *s, LIST **ldata, BUFFER *err)
       return -1;
     }
 
-    dprint(5, (debugfile, "parse_attach_list: added %s/%s [%d]\n",
-		a->major, a->minor, a->major_int));
+    mutt_debug (5, "parse_attach_list: added %s/%s [%d]\n",
+                a->major, a->minor, a->major_int);
 
     listp = safe_malloc(sizeof(LIST));
     listp->data = (char *)a;
@@ -1220,12 +1219,12 @@ static int parse_unattach_list (BUFFER *buf, BUFFER *s, LIST **ldata, BUFFER *er
     for(lp = *ldata; lp; )
     {
       a = (ATTACH_MATCH *)lp->data;
-      dprint(5, (debugfile, "parse_unattach_list: check %s/%s [%d] : %s/%s [%d]\n",
-		  a->major, a->minor, a->major_int, tmp, minor, major));
+      mutt_debug (5, "parse_unattach_list: check %s/%s [%d] : %s/%s [%d]\n",
+                  a->major, a->minor, a->major_int, tmp, minor, major);
       if (a->major_int == major && !mutt_strcasecmp(minor, a->minor))
       {
-	dprint(5, (debugfile, "parse_unattach_list: removed %s/%s [%d]\n",
-		    a->major, a->minor, a->major_int));
+        mutt_debug (5, "parse_unattach_list: removed %s/%s [%d]\n",
+                    a->major, a->minor, a->major_int);
 	regfree(&a->minor_rx);
 	FREE(&a->major);
 
@@ -1513,8 +1512,7 @@ static int parse_alias (BUFFER *buf, BUFFER *s, unsigned long data, BUFFER *err)
   }
 
   mutt_extract_token (buf, s, MUTT_TOKEN_QUOTE | MUTT_TOKEN_SPACE | MUTT_TOKEN_SEMICOLON);
-  dprint (3, (debugfile, "parse_alias: Second token is '%s'.\n",
-	      buf->data));
+  mutt_debug (3, "parse_alias: Second token is '%s'.\n", buf->data);
 
   tmp->addr = mutt_parse_adrlist (tmp->addr, buf->data);
 
@@ -1540,11 +1538,9 @@ static int parse_alias (BUFFER *buf, BUFFER *s, unsigned long data, BUFFER *err)
     for (a = tmp->addr; a && a->mailbox; a = a->next)
     {
       if (!a->group)
-	dprint (3, (debugfile, "parse_alias:   %s\n",
-		    a->mailbox));
+        mutt_debug (3, "parse_alias:   %s\n", a->mailbox);
       else
-	dprint (3, (debugfile, "parse_alias:   Group %s\n",
-		    a->mailbox));
+        mutt_debug (3, "parse_alias:   Group %s\n", a->mailbox);
     }
   }
 #endif
@@ -2693,7 +2689,7 @@ static int source_rc (const char *rcfile_path, BUFFER *err)
       }
   }
 
-  dprint(2, (debugfile, "Reading configuration file '%s'.\n", rcfile));
+  mutt_debug (2, "Reading configuration file '%s'.\n", rcfile);
 
   if ((f = mutt_open_read (rcfile, &pid)) == NULL)
   {
@@ -3470,8 +3466,8 @@ static void start_debug (void)
   if ((debugfile = safe_fopen(buf, "w")) != NULL)
   {
     setbuf (debugfile, NULL); /* don't buffer the debugging output! */
-    dprint(1,(debugfile,"NeoMutt/%s (%s) debugging at level %d\n",
-				PACKAGE_VERSION, MUTT_VERSION, debuglevel));
+    mutt_debug (1, "NeoMutt/%s (%s) debugging at level %d\n",
+                PACKAGE_VERSION, MUTT_VERSION, debuglevel);
   }
 }
 #endif
@@ -3965,7 +3961,7 @@ int parse_tag_transforms (BUFFER *b, BUFFER *s, unsigned long data, BUFFER *err)
     /* avoid duplicates */
     tmp = hash_find(TagTransforms, tag);
     if (tmp) {
-      dprint(3,(debugfile,"tag transform '%s' already registered as '%s'\n", tag, tmp));
+      mutt_debug (3, "tag transform '%s' already registered as '%s'\n", tag, tmp);
       FREE(&tag);
       FREE(&transform);
       continue;
@@ -3996,7 +3992,7 @@ int parse_tag_formats (BUFFER *b, BUFFER *s, unsigned long data, BUFFER *err)
     /* avoid duplicates */
     tmp = hash_find(TagFormats, format);
     if (tmp) {
-      dprint(3,(debugfile,"tag format '%s' already registered as '%s'\n", format, tmp));
+      mutt_debug (3, "tag format '%s' already registered as '%s'\n", format, tmp);
       FREE(&tag);
       FREE(&format);
       continue;

--- a/lib.h
+++ b/lib.h
@@ -129,31 +129,16 @@ static inline int is_email_wsp(char c)
 extern void (*mutt_error) (const char *, ...);
 # endif
 
-# ifdef _LIB_C
-#  define MUTT_LIB_WHERE 
-#  define MUTT_LIB_INITVAL(x) = x
-# else
-#  define MUTT_LIB_WHERE extern
-#  define MUTT_LIB_INITVAL(x)
-# endif
-
 void mutt_exit (int);
 
 
-# ifdef DEBUG
-
-MUTT_LIB_WHERE FILE *debugfile MUTT_LIB_INITVAL(0);
-MUTT_LIB_WHERE int debuglevel MUTT_LIB_INITVAL(0);
-
-void mutt_debug (FILE *, const char *, ...);
-
-#  define dprint(N,X) do { if(debuglevel>=N && debugfile) mutt_debug X; } while (0)
-
-# else
-
-#  define dprint(N,X) do { } while (0)
-
-# endif
+#ifdef DEBUG
+extern FILE *debugfile;
+extern int debuglevel;
+void mutt_debug (int level, const char *, ...);
+#else
+#define mutt_debug(...) do { } while (0)
+#endif
 
 
 /* Exit values used in send_msg() */

--- a/mbox.c
+++ b/mbox.c
@@ -147,7 +147,7 @@ int mmdf_parse_mailbox (CONTEXT *ctx)
       if (fgets (buf, sizeof (buf) - 1, ctx->fp) == NULL)
       {
 	/* TODO: memory leak??? */
-	dprint (1, (debugfile, "mmdf_parse_mailbox: unexpected EOF\n"));
+	mutt_debug (1, "mmdf_parse_mailbox: unexpected EOF\n");
 	break;
       }
 
@@ -157,7 +157,7 @@ int mmdf_parse_mailbox (CONTEXT *ctx)
       {
 	if (fseeko (ctx->fp, loc, SEEK_SET) != 0)
 	{
-	  dprint (1, (debugfile, "mmdf_parse_mailbox: fseek() failed\n"));
+	  mutt_debug (1, "mmdf_parse_mailbox: fseek() failed\n");
 	  mutt_error (_("Mailbox is corrupt!"));
 	  return (-1);
 	}
@@ -180,7 +180,7 @@ int mmdf_parse_mailbox (CONTEXT *ctx)
 	      mutt_strcmp (MMDF_SEP, buf) != 0)
 	  {
 	    if (fseeko (ctx->fp, loc, SEEK_SET) != 0)
-	      dprint (1, (debugfile, "mmdf_parse_mailbox: fseek() failed\n"));
+	      mutt_debug (1, "mmdf_parse_mailbox: fseek() failed\n");
 	    hdr->content->length = -1;
 	  }
 	}
@@ -214,7 +214,7 @@ int mmdf_parse_mailbox (CONTEXT *ctx)
     }
     else
     {
-      dprint (1, (debugfile, "mmdf_parse_mailbox: corrupt mailbox!\n"));
+      mutt_debug (1, "mmdf_parse_mailbox: corrupt mailbox!\n");
       mutt_error (_("Mailbox is corrupt!"));
       return (-1);
     }
@@ -338,11 +338,13 @@ int mbox_parse_mailbox (CONTEXT *ctx)
 	      fgets (buf, sizeof (buf), ctx->fp) == NULL ||
 	      mutt_strncmp ("From ", buf, 5) != 0)
 	  {
-	    dprint (1, (debugfile, "mbox_parse_mailbox: bad content-length in message %d (cl=" OFF_T_FMT ")\n", curhdr->index, curhdr->content->length));
-	    dprint (1, (debugfile, "\tLINE: %s", buf));
+	    mutt_debug (1, "mbox_parse_mailbox: bad content-length in message "
+	                "%d (cl=" OFF_T_FMT ")\n",
+	                curhdr->index, curhdr->content->length);
+	    mutt_debug (1, "\tLINE: %s", buf);
 	    if (fseeko (ctx->fp, loc, SEEK_SET) != 0) /* nope, return the previous position */
 	    {
-	      dprint (1, (debugfile, "mbox_parse_mailbox: fseek() failed\n"));
+	      mutt_debug (1, "mbox_parse_mailbox: fseek() failed\n");
 	    }
 	    curhdr->content->length = -1;
 	  }
@@ -366,7 +368,7 @@ int mbox_parse_mailbox (CONTEXT *ctx)
 
 	    /* count the number of lines in this message */
 	    if (fseeko (ctx->fp, loc, SEEK_SET) != 0)
-	      dprint (1, (debugfile, "mbox_parse_mailbox: fseek() failed\n"));
+	      mutt_debug (1, "mbox_parse_mailbox: fseek() failed\n");
 	    while (cl-- > 0)
 	    {
 	      if (fgetc (ctx->fp) == '\n')
@@ -376,7 +378,7 @@ int mbox_parse_mailbox (CONTEXT *ctx)
 
 	  /* return to the offset of the next message separator */
 	  if (fseeko (ctx->fp, tmploc, SEEK_SET) != 0)
-	    dprint (1, (debugfile, "mbox_parse_mailbox: fseek() failed\n"));
+	    mutt_debug (1, "mbox_parse_mailbox: fseek() failed\n");
 	}
       }
 
@@ -717,14 +719,14 @@ static int mbox_check_mailbox (CONTEXT *ctx, int *index_hint)
        * folder.
        */
       if (fseeko (ctx->fp, ctx->size, SEEK_SET) != 0)
-	dprint (1, (debugfile, "mbox_check_mailbox: fseek() failed\n"));
+        mutt_debug (1, "mbox_check_mailbox: fseek() failed\n");
       if (fgets (buffer, sizeof (buffer), ctx->fp) != NULL)
       {
 	if ((ctx->magic == MUTT_MBOX && mutt_strncmp ("From ", buffer, 5) == 0) ||
 	    (ctx->magic == MUTT_MMDF && mutt_strcmp (MMDF_SEP, buffer) == 0))
 	{
 	  if (fseeko (ctx->fp, ctx->size, SEEK_SET) != 0)
-	    dprint (1, (debugfile, "mbox_check_mailbox: fseek() failed\n"));
+	    mutt_debug (1, "mbox_check_mailbox: fseek() failed\n");
 	  if (ctx->magic == MUTT_MBOX)
 	    mbox_parse_mailbox (ctx);
 	  else
@@ -748,7 +750,7 @@ static int mbox_check_mailbox (CONTEXT *ctx, int *index_hint)
       }
       else
       {
-	dprint (1, (debugfile, "mbox_check_mailbox: fgets returned NULL.\n"));
+        mutt_debug (1, "mbox_check_mailbox: fgets returned NULL.\n");
 	modified = 1;
       }
     }
@@ -910,7 +912,7 @@ static int mbox_sync_mailbox (CONTEXT *ctx, int *index_hint)
      */
     mutt_error (_("sync: mbox modified, but no modified messages! (report this bug)"));
     mutt_sleep(5); /* the mutt_error /will/ get cleared! */
-    dprint(1, (debugfile, "mbox_sync_mailbox(): no modified messages.\n"));
+    mutt_debug (1, "mbox_sync_mailbox(): no modified messages.\n");
     unlink (tempfile);
     goto bail;
   }
@@ -1017,7 +1019,7 @@ static int mbox_sync_mailbox (CONTEXT *ctx, int *index_hint)
   if (fclose (fp) != 0)
   {
     fp = NULL;
-    dprint(1, (debugfile, "mbox_sync_mailbox: safe_fclose (&) returned non-zero.\n"));
+    mutt_debug (1, "mbox_sync_mailbox: safe_fclose (&) returned non-zero.\n");
     unlink (tempfile);
     mutt_perror (tempfile);
     mutt_sleep (5);
@@ -1038,7 +1040,7 @@ static int mbox_sync_mailbox (CONTEXT *ctx, int *index_hint)
   {
     mutt_unblock_signals ();
     mx_fastclose_mailbox (ctx);
-    dprint (1, (debugfile, "mbox_sync_mailbox: unable to reopen temp copy of mailbox!\n"));
+    mutt_debug (1, "mbox_sync_mailbox: unable to reopen temp copy of mailbox!\n");
     mutt_perror (tempfile);
     mutt_sleep (5);
     return (-1);
@@ -1050,8 +1052,8 @@ static int mbox_sync_mailbox (CONTEXT *ctx, int *index_hint)
       (ctx->magic == MUTT_MBOX && mutt_strncmp ("From ", buf, 5) != 0) ||
       (ctx->magic == MUTT_MMDF && mutt_strcmp (MMDF_SEP, buf) != 0))
   {
-    dprint (1, (debugfile, "mbox_sync_mailbox: message not in expected position."));
-    dprint (1, (debugfile, "\tLINE: %s\n", buf));
+    mutt_debug (1, "mbox_sync_mailbox: message not in expected position.");
+    mutt_debug (1, "\tLINE: %s\n", buf);
     i = -1;
   }
   else
@@ -1059,7 +1061,7 @@ static int mbox_sync_mailbox (CONTEXT *ctx, int *index_hint)
     if (fseeko (ctx->fp, offset, SEEK_SET) != 0) /* return to proper offset */
     {
       i = -1;
-      dprint (1, (debugfile, "mbox_sync_mailbox: fseek() failed\n"));
+      mutt_debug (1, "mbox_sync_mailbox: fseek() failed\n");
     }
     else
     {
@@ -1079,7 +1081,7 @@ static int mbox_sync_mailbox (CONTEXT *ctx, int *index_hint)
       if (ftruncate (fileno (ctx->fp), ctx->size) != 0)
       {
         i = -1;
-        dprint (1, (debugfile, "mbox_sync_mailbox: ftruncate() failed\n"));
+        mutt_debug (1, "mbox_sync_mailbox: ftruncate() failed\n");
       }
     }
   }

--- a/mh.c
+++ b/mh.c
@@ -233,7 +233,7 @@ static inline mode_t mh_umask (CONTEXT* ctx)
 
   if (stat (ctx->path, &st))
   {
-    dprint (1, (debugfile, "stat failed on %s\n", ctx->path));
+    mutt_debug (1, "stat failed on %s\n", ctx->path);
     return 077;
   }
 
@@ -849,9 +849,8 @@ static int maildir_parse_dir (CONTEXT * ctx, struct maildir ***last,
       continue;
 
     /* FOO - really ignore the return value? */
-    dprint (2,
-	    (debugfile, "%s:%d: queueing %s\n", __FILE__, __LINE__,
-	     de->d_name));
+    mutt_debug (2, "%s:%d: queueing %s\n",
+                __FILE__, __LINE__, de->d_name);
 
     h = mutt_new_header ();
     h->old = is_old;
@@ -901,17 +900,15 @@ static int maildir_add_to_context (CONTEXT * ctx, struct maildir *md)
   while (md)
   {
 
-    dprint (2, (debugfile, "%s:%d maildir_add_to_context(): Considering %s\n",
-		__FILE__, __LINE__, NONULL (md->canon_fname)));
+    mutt_debug (2, "%s:%d maildir_add_to_context(): Considering %s\n",
+                __FILE__, __LINE__, NONULL (md->canon_fname));
 
     if (md->h)
     {
-      dprint (2,
-	      (debugfile,
-	       "%s:%d Adding header structure. Flags: %s%s%s%s%s\n", __FILE__,
-	       __LINE__, md->h->flagged ? "f" : "", md->h->deleted ? "D" : "",
-	       md->h->replied ? "r" : "", md->h->old ? "O" : "",
-	       md->h->read ? "R" : ""));
+      mutt_debug (2, "%s:%d Adding header structure. Flags: %s%s%s%s%s\n",
+                  __FILE__, __LINE__, md->h->flagged ? "f" : "",
+                  md->h->deleted ? "D" : "", md->h->replied ? "r" : "",
+                  md->h->old ? "O" : "", md->h->read ? "R" : "");
       if (ctx->msgcount == ctx->hdrmax)
 	mx_alloc_memory (ctx);
 
@@ -1096,8 +1093,7 @@ static void mh_sort_natural (CONTEXT *ctx, struct maildir **md)
 {
   if (!ctx || !md || !*md || ctx->magic != MUTT_MH || Sort != SORT_ORDER)
     return;
-  dprint (4, (debugfile, "maildir: sorting %s into natural order\n",
-	      ctx->path));
+  mutt_debug (4, "maildir: sorting %s into natural order\n", ctx->path);
   *md = maildir_sort (*md, (size_t) -1, md_cmp_path);
 }
 
@@ -1148,7 +1144,7 @@ static void maildir_delayed_parsing (CONTEXT * ctx, struct maildir **md,
 #define DO_SORT()	do { \
   if (!sort) \
   { \
-    dprint (4, (debugfile, "maildir: need to sort %s by inode\n", ctx->path)); \
+    mutt_debug (4, "maildir: need to sort %s by inode\n", ctx->path); \
     p = maildir_sort (p, (size_t) -1, md_cmp_inode); \
     if (!last) \
       *md = p; \
@@ -1475,8 +1471,8 @@ static int maildir_mh_open_message (CONTEXT *ctx, MESSAGE *msg, int msgno,
   if (!msg->fp)
   {
     mutt_perror (path);
-    dprint (1, (debugfile, "maildir_mh_open_message: fopen: %s: %s (errno %d).\n",
-            path, strerror (errno), errno));
+    mutt_debug (1, "maildir_mh_open_message: fopen: %s: %s (errno %d).\n",
+                path, strerror (errno), errno);
     return -1;
   }
 
@@ -1538,8 +1534,7 @@ static int maildir_open_new_message (MESSAGE * msg, CONTEXT * dest, HEADER * hdr
 	      dest->path, subdir, (long long)time (NULL), mutt_rand64(),
               NONULL (Hostname), suffix);
 
-    dprint (2, (debugfile, "maildir_open_new_message (): Trying %s.\n",
-		path));
+    mutt_debug (2, "maildir_open_new_message (): Trying %s.\n", path);
 
     if ((fd = open (path, O_WRONLY | O_EXCL | O_CREAT, 0666)) == -1)
     {
@@ -1552,7 +1547,7 @@ static int maildir_open_new_message (MESSAGE * msg, CONTEXT * dest, HEADER * hdr
     }
     else
     {
-      dprint (2, (debugfile, "maildir_open_new_message (): Success.\n"));
+      mutt_debug (2, "maildir_open_new_message (): Success.\n");
       msg->path = safe_strdup (path);
       break;
     }
@@ -1625,8 +1620,8 @@ static int _maildir_commit_message (CONTEXT * ctx, MESSAGE * msg, HEADER * hdr)
 	      NONULL (Hostname), suffix);
     snprintf (full, _POSIX_PATH_MAX, "%s/%s", ctx->path, path);
 
-    dprint (2, (debugfile, "_maildir_commit_message (): renaming %s to %s.\n",
-		msg->path, full));
+    mutt_debug (2, "_maildir_commit_message (): renaming %s to %s.\n",
+                msg->path, full);
 
     if (safe_rename (msg->path, full) == 0)
     {
@@ -1879,10 +1874,8 @@ static int maildir_sync_message (CONTEXT * ctx, int msgno)
 
     if ((p = strrchr (h->path, '/')) == NULL)
     {
-      dprint (1,
-	      (debugfile,
-	       "maildir_sync_message: %s: unable to find subdir!\n",
-	       h->path));
+      mutt_debug (1, "maildir_sync_message: %s: unable to find subdir!\n",
+                  h->path);
       return (-1);
     }
     p++;

--- a/mutt_idna.c
+++ b/mutt_idna.c
@@ -125,16 +125,16 @@ static char *intl_to_local (char *orig_user, char *orig_domain, int flags)
 
     if (mutt_convert_string (&reversed_user, Charset, "utf-8", 0) == -1)
     {
-      dprint (1, (debugfile,
+      mutt_debug (1,
                   "intl_to_local: Not reversible. Charset conv to utf-8 failed for user = '%s'.\n",
-                  reversed_user));
+                  reversed_user);
       goto cleanup;
     }
 
     if (ascii_strcasecmp (orig_user, reversed_user))
     {
-      dprint (1, (debugfile, "intl_to_local: Not reversible. orig = '%s', reversed = '%s'.\n",
-                  orig_user, reversed_user));
+      mutt_debug (1, "intl_to_local: Not reversible. orig = '%s', reversed = '%s'.\n",
+                  orig_user, reversed_user);
       goto cleanup;
     }
 
@@ -142,9 +142,9 @@ static char *intl_to_local (char *orig_user, char *orig_domain, int flags)
 
     if (mutt_convert_string (&reversed_domain, Charset, "utf-8", 0) == -1)
     {
-      dprint (1, (debugfile,
+      mutt_debug (1,
                   "intl_to_local: Not reversible. Charset conv to utf-8 failed for domain = '%s'.\n",
-                  reversed_domain));
+                  reversed_domain);
       goto cleanup;
     }
 
@@ -157,9 +157,9 @@ static char *intl_to_local (char *orig_user, char *orig_domain, int flags)
     {
       if (idna_to_ascii_8z (reversed_domain, &tmp, IDNA_ALLOW_UNASSIGNED) != IDNA_SUCCESS)
       {
-        dprint (1, (debugfile,
+        mutt_debug (1,
                     "intl_to_local: Not reversible. idna_to_ascii_8z failed for domain = '%s'.\n",
-                    reversed_domain));
+                    reversed_domain);
         goto cleanup;
       }
       mutt_str_replace (&reversed_domain, tmp);
@@ -168,8 +168,8 @@ static char *intl_to_local (char *orig_user, char *orig_domain, int flags)
 
     if (ascii_strcasecmp (orig_domain, reversed_domain))
     {
-      dprint (1, (debugfile, "intl_to_local: Not reversible. orig = '%s', reversed = '%s'.\n",
-                  orig_domain, reversed_domain));
+      mutt_debug (1, "intl_to_local: Not reversible. orig = '%s', reversed = '%s'.\n",
+                  orig_domain, reversed_domain);
       goto cleanup;
     }
   }

--- a/mutt_notmuch.c
+++ b/mutt_notmuch.c
@@ -179,7 +179,7 @@ static void debug_print_filenames(notmuch_message_t *msg)
        ls && notmuch_filenames_valid(ls);
        notmuch_filenames_move_to_next(ls))
   {
-    dprint(2, (debugfile, "nm: %s: %s\n", id, notmuch_filenames_get(ls)));
+    mutt_debug (2, "nm: %s: %s\n", id, notmuch_filenames_get(ls));
   }
 }
 
@@ -198,7 +198,7 @@ static void debug_print_tags(notmuch_message_t *msg)
        tags && notmuch_tags_valid(tags);
        notmuch_tags_move_to_next(tags))
   {
-    dprint(2, (debugfile, "nm: %s: %s\n", id, notmuch_tags_get(tags)));
+    mutt_debug (2, "nm: %s: %s\n", id, notmuch_tags_get(tags));
   }
 }
 #endif
@@ -326,7 +326,7 @@ static void free_hdrdata(struct nm_hdrdata *data)
   if (!data)
     return;
 
-  dprint(2, (debugfile, "nm: freeing header %p\n", data));
+  mutt_debug (2, "nm: freeing header %p\n", data);
   FREE(&data->folder);
   FREE(&data->tags);
   FREE(&data->tags_transformed);
@@ -341,7 +341,7 @@ static void free_ctxdata(struct nm_ctxdata *data)
   if (!data)
     return;
 
-  dprint(1, (debugfile, "nm: freeing context data %p\n", data));
+  mutt_debug (1, "nm: freeing context data %p\n", data);
 
   if (data->db)
 #ifdef NOTMUCH_API_3
@@ -365,7 +365,7 @@ static struct nm_ctxdata *new_ctxdata(char *uri)
     return NULL;
 
   data = safe_calloc(1, sizeof(struct nm_ctxdata));
-  dprint(1, (debugfile, "nm: initialize context data %p\n", data));
+  mutt_debug (1, "nm: initialize context data %p\n", data);
 
   data->db_limit = NotmuchDBLimit;
 
@@ -402,7 +402,7 @@ static char *header_get_id(HEADER *h)
 static char *header_get_fullpath(HEADER *h, char *buf, size_t bufsz)
 {
   snprintf(buf, bufsz, "%s/%s", nm_header_get_folder(h), h->path);
-  /*dprint(2, (debugfile, "nm: returns fullpath '%s'\n", buf));*/
+  /*mutt_debug (2, "nm: returns fullpath '%s'\n", buf);*/
   return buf;
 }
 
@@ -464,7 +464,7 @@ static bool query_window_check_timebase(const char *timebase)
  */
 static void query_window_reset(void)
 {
-  dprint(2, (debugfile, "query_window_reset ()\n"));
+  mutt_debug (2, "query_window_reset ()\n");
   NotmuchQueryWindowCurrentPosition = 0;
 }
 
@@ -509,7 +509,7 @@ static void query_window_reset(void)
  */
 static bool windowed_query_from_query(const char *query, char *buf, size_t bufsz)
 {
-  dprint(2, (debugfile, "nm: windowed_query_from_query (%s)\n", query));
+  mutt_debug (2, "nm: windowed_query_from_query (%s)\n", query);
 
   int beg = NotmuchQueryWindowDuration * (NotmuchQueryWindowCurrentPosition + 1);
   int end = NotmuchQueryWindowDuration *  NotmuchQueryWindowCurrentPosition;
@@ -530,7 +530,7 @@ static bool windowed_query_from_query(const char *query, char *buf, size_t bufsz
   if (!query_window_check_timebase(NotmuchQueryWindowTimebase))
   {
     mutt_message (_("Invalid nm_query_window_timebase value (valid values are: hour, day, week, month or year)."));
-    dprint(2, (debugfile, "Invalid nm_query_window_timebase value\n"));
+    mutt_debug (2, "Invalid nm_query_window_timebase value\n");
     return false;
   }
 
@@ -541,7 +541,7 @@ static bool windowed_query_from_query(const char *query, char *buf, size_t bufsz
     snprintf(buf, bufsz, "date:%d%s..%d%s and %s",
         beg, NotmuchQueryWindowTimebase, end, NotmuchQueryWindowTimebase, NotmuchQueryWindowCurrentSearch);
 
-  dprint(2, (debugfile, "nm: windowed_query_from_query (%s) -> %s\n", query, buf));
+  mutt_debug (2, "nm: windowed_query_from_query (%s) -> %s\n", query, buf);
 
   return true;
 }
@@ -565,7 +565,7 @@ static bool windowed_query_from_query(const char *query, char *buf, size_t bufsz
  */
 static char *get_query_string(struct nm_ctxdata *data, int window)
 {
-  dprint(2, (debugfile, "nm: get_query_string(%d)\n", window));
+  mutt_debug (2, "nm: get_query_string(%d)\n", window);
 
   struct uri_tag *item;
 
@@ -606,10 +606,10 @@ static char *get_query_string(struct nm_ctxdata *data, int window)
         windowed_query_from_query(data->db_query, buf, sizeof(buf)))
       data->db_query = safe_strdup(buf);
 
-    dprint(2, (debugfile, "nm: query (windowed) '%s'\n", data->db_query));
+    mutt_debug (2, "nm: query (windowed) '%s'\n", data->db_query);
   }
   else
-    dprint(2, (debugfile, "nm: query '%s'\n", data->db_query));
+    mutt_debug (2, "nm: query '%s'\n", data->db_query);
 
   return data->db_query;
 }
@@ -639,7 +639,7 @@ static const char *get_db_filename(struct nm_ctxdata *data)
   if (strncmp(db_filename, "notmuch://", 10) == 0)
     db_filename += 10;
 
-  dprint(2, (debugfile, "nm: db filename '%s'\n", db_filename));
+  mutt_debug (2, "nm: db filename '%s'\n", db_filename);
   return db_filename;
 }
 
@@ -650,8 +650,8 @@ static notmuch_database_t *do_database_open(const char *filename, int writable,
   int ct = 0;
   notmuch_status_t st = NOTMUCH_STATUS_SUCCESS;
 
-  dprint(1, (debugfile, "nm: db open '%s' %s (timeout %d)\n", filename,
-             writable ? "[WRITE]" : "[READ]", NotmuchOpenTimeout));
+  mutt_debug (1, "nm: db open '%s' %s (timeout %d)\n", filename,
+             writable ? "[WRITE]" : "[READ]", NotmuchOpenTimeout);
   do
   {
 #ifdef NOTMUCH_API_3
@@ -702,7 +702,7 @@ static int release_db(struct nm_ctxdata *data)
 {
   if (data && data->db)
   {
-    dprint(1, (debugfile, "nm: db close\n"));
+    mutt_debug (1, "nm: db close\n");
 #ifdef NOTMUCH_API_3
     notmuch_database_destroy(data->db);
 #else
@@ -723,7 +723,7 @@ static int db_trans_begin(struct nm_ctxdata *data)
 
   if (!data->trans)
   {
-    dprint(2, (debugfile, "nm: db trans start\n"));
+    mutt_debug (2, "nm: db trans start\n");
     if (notmuch_database_begin_atomic(data->db))
       return -1;
     data->trans = 1;
@@ -740,7 +740,7 @@ static int db_trans_end(struct nm_ctxdata *data)
 
   if (data->trans)
   {
-    dprint(2, (debugfile, "nm: db trans end\n"));
+    mutt_debug (2, "nm: db trans end\n");
     data->trans = 0;
     if (notmuch_database_end_atomic(data->db))
       return -1;
@@ -763,7 +763,7 @@ static int get_database_mtime(struct nm_ctxdata *data, time_t *mtime)
     return -1;
 
   snprintf(path, sizeof(path), "%s/.notmuch/xapian", get_db_filename(data));
-  dprint(2, (debugfile, "nm: checking '%s' mtime\n", path));
+  mutt_debug (2, "nm: checking '%s' mtime\n", path);
 
   if (stat(path, &st))
     return -1;
@@ -798,7 +798,7 @@ static void apply_exclude_tags(notmuch_query_t *query)
       break;
     *end = '\0';
 
-    dprint(2, (debugfile, "nm: query exclude tag '%s'\n", tag));
+    mutt_debug (2, "nm: query exclude tag '%s'\n", tag);
     notmuch_query_add_tag_exclude(query, tag);
     end = tag = NULL;
   }
@@ -827,7 +827,7 @@ static notmuch_query_t *get_query(struct nm_ctxdata *data, int writable)
 
   apply_exclude_tags(q);
   notmuch_query_set_sort(q, NOTMUCH_SORT_NEWEST_FIRST);
-  dprint(2, (debugfile, "nm: query successfully initialized (%s)\n", str));
+  mutt_debug (2, "nm: query successfully initialized (%s)\n", str);
   return q;
 err:
   if (!is_longrun(data))
@@ -855,7 +855,7 @@ static int update_header_tags(HEADER *h, notmuch_message_t *msg)
   char *tstr = NULL, *ttstr = NULL;
   struct nm_hdrtag *tag_list = NULL, *tmp;
 
-  dprint(2, (debugfile, "nm: tags update requested (%s)\n", data->virtual_id));
+  mutt_debug (2, "nm: tags update requested (%s)\n", data->virtual_id);
 
   for (tags = notmuch_message_get_tags(msg); tags && notmuch_tags_valid(tags);
        notmuch_tags_move_to_next(tags))
@@ -906,7 +906,7 @@ static int update_header_tags(HEADER *h, notmuch_message_t *msg)
   {
     FREE(&tstr);
     FREE(&ttstr);
-    dprint(2, (debugfile, "nm: tags unchanged\n"));
+    mutt_debug (2, "nm: tags unchanged\n");
     return 1;
   }
 
@@ -916,10 +916,10 @@ static int update_header_tags(HEADER *h, notmuch_message_t *msg)
 
   /* new version */
   data->tags = tstr;
-  dprint(2, (debugfile, "nm: new tags: '%s'\n", tstr));
+  mutt_debug (2, "nm: new tags: '%s'\n", tstr);
 
   data->tags_transformed = ttstr;
-  dprint(2, (debugfile, "nm: new tag transforms: '%s'\n", ttstr));
+  mutt_debug (2, "nm: new tag transforms: '%s'\n", ttstr);
 
   return 0;
 }
@@ -929,8 +929,8 @@ static int update_message_path(HEADER *h, const char *path)
   struct nm_hdrdata *data = h->data;
   char *p;
 
-  dprint(2, (debugfile, "nm: path update requested path=%s, (%s)\n", path,
-             data->virtual_id));
+  mutt_debug (2, "nm: path update requested path=%s, (%s)\n", path,
+             data->virtual_id);
 
   p = strrchr(path, '/');
   if (p && ((p - path) > 3) &&
@@ -951,7 +951,7 @@ static int update_message_path(HEADER *h, const char *path)
 
     data->folder = mutt_substrdup(path, p);
 
-    dprint(2, (debugfile, "nm: folder='%s', file='%s'\n", data->folder, h->path));
+    mutt_debug (2, "nm: folder='%s', file='%s'\n", data->folder, h->path);
     return 0;
   }
 
@@ -1018,8 +1018,8 @@ static int init_header(HEADER *h, const char *path, notmuch_message_t *msg)
    */
   ((struct nm_hdrdata *) h->data)->virtual_id = safe_strdup(id);
 
-  dprint(2, (debugfile, "nm: initialize header data: [hdr=%p, data=%p] (%s)\n",
-             h, h->data, id));
+  mutt_debug (2, "nm: initialize header data: [hdr=%p, data=%p] (%s)\n",
+             h, h->data, id);
 
   if (!h->env->message_id)
     h->env->message_id = nm2mutt_message_id(id);
@@ -1106,18 +1106,18 @@ static HEADER *get_mutt_header(CONTEXT *ctx, notmuch_message_t *msg)
   if (!id)
     return NULL;
 
-  dprint(2, (debugfile, "nm: mutt header, id='%s'\n", id));
+  mutt_debug (2, "nm: mutt header, id='%s'\n", id);
 
   if (!ctx->id_hash)
   {
-    dprint(2, (debugfile, "nm: init hash\n"));
+    mutt_debug (2, "nm: init hash\n");
     ctx->id_hash = mutt_make_id_hash(ctx);
     if (!ctx->id_hash)
       return NULL;
   }
 
   mid = nm2mutt_message_id(id);
-  dprint(2, (debugfile, "nm: mutt id='%s'\n", mid));
+  mutt_debug (2, "nm: mutt id='%s'\n", mid);
 
   h = hash_find(ctx->id_hash, mid);
   FREE(&mid);
@@ -1140,8 +1140,8 @@ static void append_message(CONTEXT *ctx, notmuch_query_t *q,
   {
     data->ignmsgcount++;
     progress_update(ctx, q);
-    dprint(2, (debugfile, "nm: ignore id=%s, already in the context\n",
-               notmuch_message_get_message_id(msg)));
+    mutt_debug (2, "nm: ignore id=%s, already in the context\n",
+               notmuch_message_get_message_id(msg));
     return;
   }
 
@@ -1149,12 +1149,12 @@ static void append_message(CONTEXT *ctx, notmuch_query_t *q,
   if (!path)
     return;
 
-  dprint(2, (debugfile, "nm: appending message, i=%d, id=%s, path=%s\n",
-             ctx->msgcount, notmuch_message_get_message_id(msg), path));
+  mutt_debug (2, "nm: appending message, i=%d, id=%s, path=%s\n",
+             ctx->msgcount, notmuch_message_get_message_id(msg), path);
 
   if (ctx->msgcount >= ctx->hdrmax)
   {
-    dprint(2, (debugfile, "nm: allocate mx memory\n"));
+    mutt_debug (2, "nm: allocate mx memory\n");
     mx_alloc_memory(ctx);
   }
   if (access(path, F_OK) == 0)
@@ -1172,7 +1172,7 @@ static void append_message(CONTEXT *ctx, notmuch_query_t *q,
         h = maildir_parse_stream(MUTT_MAILDIR, f, newpath, 0, NULL);
         fclose(f);
 
-        dprint(1, (debugfile, "nm: not up-to-date: %s -> %s\n", path, newpath));
+        mutt_debug (1, "nm: not up-to-date: %s -> %s\n", path, newpath);
       }
     }
     FREE(&folder);
@@ -1180,13 +1180,13 @@ static void append_message(CONTEXT *ctx, notmuch_query_t *q,
 
   if (!h)
   {
-    dprint(1, (debugfile, "nm: failed to parse message: %s\n", path));
+    mutt_debug (1, "nm: failed to parse message: %s\n", path);
     goto done;
   }
   if (init_header(h, newpath ? newpath : path, msg) != 0)
   {
     mutt_free_header(&h);
-    dprint(1, (debugfile, "nm: failed to append header!\n"));
+    mutt_debug (1, "nm: failed to append header!\n");
     goto done;
   }
 
@@ -1203,7 +1203,7 @@ static void append_message(CONTEXT *ctx, notmuch_query_t *q,
 
     if (hd)
     {
-      dprint(1, (debugfile, "nm: remember obsolete path: %s\n", path));
+      mutt_debug (1, "nm: remember obsolete path: %s\n", path);
       hd->oldpath = safe_strdup(path);
     }
   }
@@ -1313,7 +1313,7 @@ static notmuch_message_t *get_nm_message(notmuch_database_t *db, HEADER *hdr)
   notmuch_message_t *msg = NULL;
   char *id = header_get_id(hdr);
 
-  dprint(2, (debugfile, "nm: find message (%s)\n", id));
+  mutt_debug (2, "nm: find message (%s)\n", id);
 
   if (id && db)
     notmuch_database_find_message(db, id, &msg);
@@ -1367,12 +1367,12 @@ static int update_tags(notmuch_message_t *msg, const char *tags)
 
     if (*tag == '-')
     {
-      dprint(1, (debugfile, "nm: remove tag: '%s'\n", tag + 1));
+      mutt_debug (1, "nm: remove tag: '%s'\n", tag + 1);
       notmuch_message_remove_tag(msg, tag + 1);
     }
     else if (*tag == '!')
     {
-      dprint(1, (debugfile, "nm: toggle tag: '%s'\n", tag + 1));
+      mutt_debug (1, "nm: toggle tag: '%s'\n", tag + 1);
       if (nm_message_has_tag (msg, tag + 1))
       {
         notmuch_message_remove_tag (msg, tag + 1);
@@ -1384,7 +1384,7 @@ static int update_tags(notmuch_message_t *msg, const char *tags)
     }
     else
     {
-      dprint(1, (debugfile, "nm: add tag: '%s'\n", (*tag == '+') ? tag + 1 : tag));
+      mutt_debug (1, "nm: add tag: '%s'\n", (*tag == '+') ? tag + 1 : tag);
       notmuch_message_add_tag(msg, (*tag == '+') ? tag + 1 : tag);
     }
     end = tag = NULL;
@@ -1488,7 +1488,7 @@ static int rename_maildir_filename(const char *old, char *newpath, size_t newsz,
 
   if (rename(old, newpath) != 0)
   {
-    dprint(1, (debugfile, "nm: rename(2) failed %s -> %s\n", old, newpath));
+    mutt_debug (1, "nm: rename(2) failed %s -> %s\n", old, newpath);
     return -1;
   }
 
@@ -1503,7 +1503,7 @@ static int remove_filename(struct nm_ctxdata *data, const char *path)
   notmuch_database_t *db = get_db(data, true);
   int trans;
 
-  dprint(2, (debugfile, "nm: remove filename '%s'\n", path));
+  mutt_debug (2, "nm: remove filename '%s'\n", path);
 
   if (!db)
     return -1;
@@ -1522,11 +1522,11 @@ static int remove_filename(struct nm_ctxdata *data, const char *path)
   switch (st)
   {
     case NOTMUCH_STATUS_SUCCESS:
-      dprint(2, (debugfile, "nm: remove success, call unlink\n"));
+      mutt_debug (2, "nm: remove success, call unlink\n");
       unlink(path);
       break;
     case NOTMUCH_STATUS_DUPLICATE_MESSAGE_ID:
-      dprint(2, (debugfile, "nm: remove success (duplicate), call unlink\n"));
+      mutt_debug (2, "nm: remove success (duplicate), call unlink\n");
       unlink(path);
       for (ls = notmuch_message_get_filenames(msg);
            ls && notmuch_filenames_valid(ls);
@@ -1534,14 +1534,14 @@ static int remove_filename(struct nm_ctxdata *data, const char *path)
       {
         path = notmuch_filenames_get(ls);
 
-        dprint(2, (debugfile, "nm: remove duplicate: '%s'\n", path));
+        mutt_debug (2, "nm: remove duplicate: '%s'\n", path);
         unlink(path);
         notmuch_database_remove_message(db, path);
       }
       break;
     default:
-      dprint(1, (debugfile, "nm: failed to remove '%s' [st=%d]\n", path,
-                 (int) st));
+      mutt_debug (1, "nm: failed to remove '%s' [st=%d]\n", path,
+                 (int) st);
       break;
   }
 
@@ -1564,29 +1564,29 @@ static int rename_filename(struct nm_ctxdata *data, const char *old,
   if (!db || !new || !old || (access(new, F_OK) != 0))
     return -1;
 
-  dprint(1, (debugfile, "nm: rename filename, %s -> %s\n", old, new));
+  mutt_debug (1, "nm: rename filename, %s -> %s\n", old, new);
   trans = db_trans_begin(data);
   if (trans < 0)
     return -1;
 
-  dprint(2, (debugfile, "nm: rename: add '%s'\n", new));
+  mutt_debug (2, "nm: rename: add '%s'\n", new);
   st = notmuch_database_add_message(db, new, &msg);
 
   if ((st != NOTMUCH_STATUS_SUCCESS) &&
       (st != NOTMUCH_STATUS_DUPLICATE_MESSAGE_ID))
   {
-    dprint(1, (debugfile, "nm: failed to add '%s' [st=%d]\n", new, (int) st));
+    mutt_debug (1, "nm: failed to add '%s' [st=%d]\n", new, (int) st);
     goto done;
   }
 
-  dprint(2, (debugfile, "nm: rename: rem '%s'\n", old));
+  mutt_debug (2, "nm: rename: rem '%s'\n", old);
   st = notmuch_database_remove_message(db, old);
   switch (st)
   {
     case NOTMUCH_STATUS_SUCCESS:
       break;
     case NOTMUCH_STATUS_DUPLICATE_MESSAGE_ID:
-      dprint(2, (debugfile, "nm: rename: syncing duplicate filename\n"));
+      mutt_debug (2, "nm: rename: syncing duplicate filename\n");
       notmuch_message_destroy(msg);
       msg = NULL;
       notmuch_database_find_message_by_filename(db, new, &msg);
@@ -1601,11 +1601,11 @@ static int rename_filename(struct nm_ctxdata *data, const char *old,
         if (strcmp(new, path) == 0)
           continue;
 
-        dprint(2, (debugfile, "nm: rename: syncing duplicate: %s\n", path));
+        mutt_debug (2, "nm: rename: syncing duplicate: %s\n", path);
 
         if (rename_maildir_filename(path, newpath, sizeof(newpath), h) == 0)
         {
-          dprint(2, (debugfile, "nm: rename dup %s -> %s\n", path, newpath));
+          mutt_debug (2, "nm: rename dup %s -> %s\n", path, newpath);
           notmuch_database_remove_message(db, path);
           notmuch_database_add_message(db, newpath, NULL);
         }
@@ -1616,7 +1616,7 @@ static int rename_filename(struct nm_ctxdata *data, const char *old,
       st = NOTMUCH_STATUS_SUCCESS;
       break;
     default:
-      dprint(1, (debugfile, "nm: failed to remove '%s' [st=%d]\n", old, (int) st));
+      mutt_debug (1, "nm: failed to remove '%s' [st=%d]\n", old, (int) st);
       break;
   }
 
@@ -1651,7 +1651,7 @@ static unsigned count_query(notmuch_database_t *db, const char *qstr)
     res = notmuch_query_count_messages(q);
 #endif
     notmuch_query_destroy(q);
-    dprint(1, (debugfile, "nm: count '%s', result=%d\n", qstr, res));
+    mutt_debug (1, "nm: count '%s', result=%d\n", qstr, res);
   }
   return res;
 }
@@ -1697,7 +1697,7 @@ void nm_longrun_init(CONTEXT *ctx, int writable)
   if (data && get_db(data, writable))
   {
     data->longrun = 1;
-    dprint(2, (debugfile, "nm: long run initialized\n"));
+    mutt_debug (2, "nm: long run initialized\n");
   }
 }
 
@@ -1706,7 +1706,7 @@ void nm_longrun_done(CONTEXT *ctx)
   struct nm_ctxdata *data = get_ctxdata(ctx);
 
   if (data && (release_db(data) == 0))
-    dprint(2, (debugfile, "nm: long run deinitialized\n"));
+    mutt_debug (2, "nm: long run deinitialized\n");
 }
 
 void nm_debug_check(CONTEXT *ctx)
@@ -1717,7 +1717,7 @@ void nm_debug_check(CONTEXT *ctx)
 
   if (data->db)
   {
-    dprint(1, (debugfile, "nm: ERROR: db is open, closing\n"));
+    mutt_debug (1, "nm: ERROR: db is open, closing\n");
     release_db(data);
   }
 }
@@ -1737,9 +1737,9 @@ int nm_read_entire_thread(CONTEXT *ctx, HEADER *h)
   if (!(db = get_db(data, false)) || !(msg = get_nm_message(db, h)))
     goto done;
 
-  dprint(1, (debugfile,
-             "nm: reading entire-thread messages...[current count=%d]\n",
-             ctx->msgcount));
+  mutt_debug (1,
+              "nm: reading entire-thread messages...[current count=%d]\n",
+              ctx->msgcount);
 
   progress_reset(ctx);
   id = notmuch_message_get_thread_id(msg);
@@ -1771,15 +1771,15 @@ done:
     mutt_message(_("No more messages in the thread."));
 
   data->oldmsgcount = 0;
-  dprint(1, (debugfile,
-             "nm: reading entire-thread messages... done [rc=%d, count=%d]\n",
-             rc, ctx->msgcount));
+  mutt_debug (1,
+              "nm: reading entire-thread messages... done [rc=%d, count=%d]\n",
+              rc, ctx->msgcount);
   return rc;
 }
 
 char *nm_uri_from_query(CONTEXT *ctx, char *buf, size_t bufsz)
 {
-  dprint(2, (debugfile, "nm_uri_from_query (%s)\n", buf));
+  mutt_debug (2, "nm_uri_from_query (%s)\n", buf);
   struct nm_ctxdata *data = get_ctxdata(ctx);
   char uri[_POSIX_PATH_MAX + LONG_STRING + 32]; /* path to DB + query + URI "decoration" */
 
@@ -1795,7 +1795,7 @@ char *nm_uri_from_query(CONTEXT *ctx, char *buf, size_t bufsz)
   strncpy(buf, uri, bufsz);
   buf[bufsz - 1] = '\0';
 
-  dprint(1, (debugfile, "nm: uri from query '%s'\n", buf));
+  mutt_debug (1, "nm: uri from query '%s'\n", buf);
   return buf;
 }
 
@@ -1818,7 +1818,7 @@ char *nm_uri_from_query(CONTEXT *ctx, char *buf, size_t bufsz)
  */
 bool nm_normalize_uri(char *new_uri, const char *orig_uri, size_t new_uri_sz)
 {
-  dprint(2, (debugfile, "nm_normalize_uri (%s)\n", orig_uri));
+  mutt_debug (2, "nm_normalize_uri (%s)\n", orig_uri);
   char buf[LONG_STRING];
 
   CONTEXT tmp_ctx;
@@ -1831,33 +1831,33 @@ bool nm_normalize_uri(char *new_uri, const char *orig_uri, size_t new_uri_sz)
   if (url_parse_query(orig_uri, &tmp_ctxdata.db_filename, &tmp_ctxdata.query_items))
   {
     mutt_error(_("failed to parse notmuch uri: %s"), orig_uri);
-    dprint(2, (debugfile, "nm_normalize_uri () -> error #1\n"));
+    mutt_debug (2, "nm_normalize_uri () -> error #1\n");
     return false;
   }
 
-  dprint(2, (debugfile, "nm_normalize_uri #1 () -> db_query: %s\n", tmp_ctxdata.db_query));
+  mutt_debug (2, "nm_normalize_uri #1 () -> db_query: %s\n", tmp_ctxdata.db_query);
 
   if (get_query_string(&tmp_ctxdata, false) == NULL)
   {
     mutt_error(_("failed to parse notmuch uri: %s"), orig_uri);
-    dprint(2, (debugfile, "nm_normalize_uri () -> error #2\n"));
+    mutt_debug (2, "nm_normalize_uri () -> error #2\n");
     return false;
   }
 
-  dprint(2, (debugfile, "nm_normalize_uri #2 () -> db_query: %s\n", tmp_ctxdata.db_query));
+  mutt_debug (2, "nm_normalize_uri #2 () -> db_query: %s\n", tmp_ctxdata.db_query);
 
   strncpy(buf, tmp_ctxdata.db_query, sizeof(buf));
 
   if (nm_uri_from_query(&tmp_ctx, buf, sizeof(buf)) == NULL)
   {
     mutt_error(_("failed to parse notmuch uri: %s"), orig_uri);
-    dprint(2, (debugfile, "nm_normalize_uri () -> error #3\n"));
+    mutt_debug (2, "nm_normalize_uri () -> error #3\n");
     return true;
   }
 
   strncpy(new_uri, buf, new_uri_sz);
 
-  dprint(2, (debugfile, "nm_normalize_uri #3 (%s) -> %s\n", orig_uri, new_uri));
+  mutt_debug (2, "nm_normalize_uri #3 (%s) -> %s\n", orig_uri, new_uri);
   return true;
 }
 
@@ -1875,7 +1875,7 @@ void nm_query_window_forward(void)
   if (NotmuchQueryWindowCurrentPosition != 0)
     NotmuchQueryWindowCurrentPosition -= 1;
 
-  dprint(2, (debugfile, "nm_query_window_forward (%d)\n", NotmuchQueryWindowCurrentPosition));
+  mutt_debug (2, "nm_query_window_forward (%d)\n", NotmuchQueryWindowCurrentPosition);
 }
 
 /**
@@ -1889,7 +1889,7 @@ void nm_query_window_forward(void)
 void nm_query_window_backward(void)
 {
   NotmuchQueryWindowCurrentPosition += 1;
-  dprint(2, (debugfile, "nm_query_window_backward (%d)\n", NotmuchQueryWindowCurrentPosition));
+  mutt_debug (2, "nm_query_window_backward (%d)\n", NotmuchQueryWindowCurrentPosition);
 }
 
 int nm_modify_message_tags(CONTEXT *ctx, HEADER *hdr, char *buf)
@@ -1905,7 +1905,7 @@ int nm_modify_message_tags(CONTEXT *ctx, HEADER *hdr, char *buf)
   if (!(db = get_db(data, true)) || !(msg = get_nm_message(db, hdr)))
     goto done;
 
-  dprint(1, (debugfile, "nm: tags modify: '%s'\n", buf));
+  mutt_debug (1, "nm: tags modify: '%s'\n", buf);
 
   update_tags(msg, buf);
   update_header_flags(ctx, hdr, buf);
@@ -1919,7 +1919,7 @@ done:
     release_db(data);
   if (hdr->changed)
     ctx->mtime = time(NULL);
-  dprint(1, (debugfile, "nm: tags modify done [rc=%d]\n", rc));
+  mutt_debug (1, "nm: tags modify done [rc=%d]\n", rc);
   return rc;
 }
 
@@ -1954,7 +1954,7 @@ int nm_nonctx_get_count(char *path, int *all, int *new)
   notmuch_database_t *db = NULL;
   int rc = -1, dflt = 0;
 
-  dprint(1, (debugfile, "nm: count\n"));
+  mutt_debug (1, "nm: count\n");
 
   if (url_parse_query(path, &db_filename, &query_items))
   {
@@ -2019,13 +2019,13 @@ done:
 #else
     notmuch_database_close(db);
 #endif
-    dprint(1, (debugfile, "nm: count close DB\n"));
+    mutt_debug (1, "nm: count close DB\n");
   }
   if (!dflt)
     FREE(&db_filename);
   url_free_tags(query_items);
 
-  dprint(1, (debugfile, "nm: count done [rc=%d]\n", rc));
+  mutt_debug (1, "nm: count done [rc=%d]\n", rc);
   return rc;
 }
 
@@ -2072,7 +2072,7 @@ int nm_record_message(CONTEXT *ctx, char *path, HEADER *h)
   if (!db)
     return -1;
 
-  dprint(1, (debugfile, "nm: record message: %s\n", path));
+  mutt_debug (1, "nm: record message: %s\n", path);
   trans = db_trans_begin(data);
   if (trans < 0)
     goto done;
@@ -2082,7 +2082,7 @@ int nm_record_message(CONTEXT *ctx, char *path, HEADER *h)
   if ((st != NOTMUCH_STATUS_SUCCESS) &&
       (st != NOTMUCH_STATUS_DUPLICATE_MESSAGE_ID))
   {
-    dprint(1, (debugfile, "nm: failed to add '%s' [st=%d]\n", path, (int) st));
+    mutt_debug (1, "nm: failed to add '%s' [st=%d]\n", path, (int) st);
     goto done;
   }
 
@@ -2121,7 +2121,7 @@ int nm_get_all_tags(CONTEXT *ctx, char **tag_list, int *tag_count)
     goto done;
 
   *tag_count = 0;
-  dprint(1, (debugfile, "nm: get all tags\n"));
+  mutt_debug (1, "nm: get all tags\n");
 
   while (notmuch_tags_valid(tags))
   {
@@ -2141,8 +2141,8 @@ done:
   if (!is_longrun(data))
     release_db(data);
 
-  dprint(1, (debugfile, "nm: get all tags done [rc=%d tag_count=%u]\n", rc,
-             *tag_count));
+  mutt_debug (1, "nm: get all tags done [rc=%d tag_count=%u]\n", rc,
+             *tag_count);
   return rc;
 }
 
@@ -2160,8 +2160,8 @@ static int nm_open_mailbox(CONTEXT *ctx)
   if (!data)
     return -1;
 
-  dprint(1, (debugfile, "nm: reading messages...[current count=%d]\n",
-             ctx->msgcount));
+  mutt_debug (1, "nm: reading messages...[current count=%d]\n",
+             ctx->msgcount);
 
   progress_reset(ctx);
 
@@ -2191,8 +2191,8 @@ static int nm_open_mailbox(CONTEXT *ctx)
   mx_update_context(ctx, ctx->msgcount);
   data->oldmsgcount = 0;
 
-  dprint(1, (debugfile, "nm: reading messages... done [rc=%d, count=%d]\n", rc,
-             ctx->msgcount));
+  mutt_debug (1, "nm: reading messages... done [rc=%d, count=%d]\n", rc,
+             ctx->msgcount);
   return rc;
 }
 
@@ -2232,18 +2232,18 @@ static int nm_check_mailbox(CONTEXT *ctx, int *index_hint)
 
   if (ctx->mtime >= mtime)
   {
-    dprint(2, (debugfile, "nm: check unnecessary (db=%d ctx=%d)\n", mtime,
-               ctx->mtime));
+    mutt_debug (2, "nm: check unnecessary (db=%d ctx=%d)\n", mtime,
+               ctx->mtime);
     return 0;
   }
 
-  dprint(1, (debugfile, "nm: checking (db=%d ctx=%d)\n", mtime, ctx->mtime));
+  mutt_debug (1, "nm: checking (db=%d ctx=%d)\n", mtime, ctx->mtime);
 
   q = get_query(data, false);
   if (!q)
     goto done;
 
-  dprint(1, (debugfile, "nm: start checking (count=%d)\n", ctx->msgcount));
+  mutt_debug (1, "nm: start checking (count=%d)\n", ctx->msgcount);
   data->oldmsgcount = ctx->msgcount;
   data->noprogress = 1;
 
@@ -2326,8 +2326,8 @@ done:
 
   ctx->mtime = time(NULL);
 
-  dprint(1, (debugfile, "nm: ... check done [count=%d, new_flags=%d, occult=%d]\n",
-          ctx->msgcount, new_flags, occult));
+  mutt_debug (1, "nm: ... check done [count=%d, new_flags=%d, occult=%d]\n",
+          ctx->msgcount, new_flags, occult);
 
   return occult ? MUTT_REOPENED : (ctx->msgcount > data->oldmsgcount) ?
                   MUTT_NEW_MAIL :
@@ -2346,7 +2346,7 @@ static int nm_sync_mailbox(CONTEXT *ctx, int *index_hint)
   if (!data)
     return -1;
 
-  dprint(1, (debugfile, "nm: sync start ...\n"));
+  mutt_debug (1, "nm: sync start ...\n");
 
   if (!ctx->quiet)
   {
@@ -2371,7 +2371,7 @@ static int nm_sync_mailbox(CONTEXT *ctx, int *index_hint)
     {
       strncpy(old, hd->oldpath, sizeof(old));
       old[sizeof(old) - 1] = '\0';
-      dprint(2, (debugfile, "nm: fixing obsolete path '%s'\n", old));
+      mutt_debug (2, "nm: fixing obsolete path '%s'\n", old);
     }
     else
       header_get_fullpath(h, old, sizeof(old));
@@ -2411,7 +2411,7 @@ static int nm_sync_mailbox(CONTEXT *ctx, int *index_hint)
   if (changed)
     ctx->mtime = time(NULL);
 
-  dprint(1, (debugfile, "nm: .... sync done [rc=%d]\n", rc));
+  mutt_debug (1, "nm: .... sync done [rc=%d]\n", rc);
   return rc;
 }
 
@@ -2431,7 +2431,7 @@ static int nm_open_message(CONTEXT *ctx, MESSAGE *msg, int msgno)
       ((ctx->magic == MUTT_MAILDIR) || (ctx->magic == MUTT_NOTMUCH)))
     msg->fp = maildir_open_find_message(folder, cur->path, NULL);
 
-  dprint(1, (debugfile, "%s\n", __func__));
+  mutt_debug (1, "%s\n", __func__);
   return 0;
 }
 

--- a/mutt_sasl.c
+++ b/mutt_sasl.c
@@ -36,39 +36,39 @@
 static int getnameinfo_err(int ret)
 {
   int err;
-  dprint (1, (debugfile, "getnameinfo: "));
+  mutt_debug (1, "getnameinfo: ");
   switch(ret)
   {
      case EAI_AGAIN:
-       dprint (1, (debugfile, "The name could not be resolved at this time.  Future attempts may succeed.\n"));
+       mutt_debug (1, "The name could not be resolved at this time.  Future attempts may succeed.\n");
        err=SASL_TRYAGAIN;
        break;
      case EAI_BADFLAGS:
-       dprint (1, (debugfile, "The flags had an invalid value.\n"));
+       mutt_debug (1, "The flags had an invalid value.\n");
        err=SASL_BADPARAM;
        break;
      case EAI_FAIL:
-       dprint (1, (debugfile, "A non-recoverable error occurred.\n"));
+       mutt_debug (1, "A non-recoverable error occurred.\n");
        err=SASL_FAIL;
        break;
      case EAI_FAMILY:
-       dprint (1, (debugfile, "The address family was not recognized or the address length was invalid for the specified family.\n"));
+       mutt_debug (1, "The address family was not recognized or the address length was invalid for the specified family.\n");
        err=SASL_BADPROT;
        break;
      case EAI_MEMORY:
-       dprint (1, (debugfile, "There was a memory allocation failure.\n"));
+       mutt_debug (1, "There was a memory allocation failure.\n");
        err=SASL_NOMEM;
        break;
      case EAI_NONAME:
-       dprint (1, (debugfile, "The name does not resolve for the supplied parameters.  NI_NAMEREQD is set and the host's name cannot be located, or both nodename and servname were null.\n"));
+       mutt_debug (1, "The name does not resolve for the supplied parameters.  NI_NAMEREQD is set and the host's name cannot be located, or both nodename and servname were null.\n");
        err=SASL_FAIL; /* no real equivalent */
        break;
      case EAI_SYSTEM:
-       dprint (1, (debugfile, "A system error occurred.  The error code can be found in errno(%d,%s)).\n",errno,strerror(errno)));
+       mutt_debug (1, "A system error occurred.  The error code can be found in errno(%d,%s)).\n",errno,strerror(errno));
        err=SASL_FAIL; /* no real equivalent */
        break;
      default:
-       dprint (1, (debugfile, "Unknown error %d\n",ret));
+       mutt_debug (1, "Unknown error %d\n",ret);
        err=SASL_FAIL; /* no real equivalent */
        break;
   }
@@ -155,7 +155,7 @@ int mutt_sasl_start (void)
 
   if (rc != SASL_OK)
   {
-    dprint (1, (debugfile, "mutt_sasl_start: libsasl initialisation failed.\n"));
+    mutt_debug (1, "mutt_sasl_start: libsasl initialisation failed.\n");
     return SASL_FAIL;
   }
 
@@ -208,10 +208,10 @@ int mutt_sasl_client_new (CONNECTION* conn, sasl_conn_t** saslconn)
                    IP_PORT_BUFLEN) == SASL_OK)
       plp = iplocalport;
     else
-      dprint (2, (debugfile, "SASL failed to parse local IP address\n"));
+      mutt_debug (2, "SASL failed to parse local IP address\n");
   }
   else
-    dprint (2, (debugfile, "SASL failed to get local IP address\n"));
+    mutt_debug (2, "SASL failed to get local IP address\n");
   
   size = sizeof (remote);
   if (!getpeername (conn->fd, (struct sockaddr *)&remote, &size)){
@@ -219,13 +219,13 @@ int mutt_sasl_client_new (CONNECTION* conn, sasl_conn_t** saslconn)
                    IP_PORT_BUFLEN) == SASL_OK)
       prp = ipremoteport;
     else
-      dprint (2, (debugfile, "SASL failed to parse remote IP address\n"));
+      mutt_debug (2, "SASL failed to parse remote IP address\n");
   }
   else
-    dprint (2, (debugfile, "SASL failed to get remote IP address\n"));
+    mutt_debug (2, "SASL failed to get remote IP address\n");
 
-  dprint (2, (debugfile, "SASL local ip: %s, remote ip:%s\n", NONULL(plp),
-	      NONULL(prp)));
+  mutt_debug (2, "SASL local ip: %s, remote ip:%s\n", NONULL(plp),
+	      NONULL(prp));
   
   rc = sasl_client_new (service, conn->account.host, plp, prp,
     mutt_sasl_get_callbacks (&conn->account), 0, saslconn);
@@ -250,7 +250,7 @@ int mutt_sasl_client_new (CONNECTION* conn, sasl_conn_t** saslconn)
   if (conn->ssf)
   {
     /* I'm not sure this actually has an effect, at least with SASLv2 */
-    dprint (2, (debugfile, "External SSF: %d\n", conn->ssf));
+    mutt_debug (2, "External SSF: %d\n", conn->ssf);
     if (sasl_setprop (*saslconn, SASL_SSF_EXTERNAL, &(conn->ssf)) != SASL_OK)
     {
       mutt_error (_("Error setting SASL external security strength"));
@@ -259,7 +259,7 @@ int mutt_sasl_client_new (CONNECTION* conn, sasl_conn_t** saslconn)
   }
   if (conn->account.user[0])
   {
-    dprint (2, (debugfile, "External authentication name: %s\n", conn->account.user));
+    mutt_debug (2, "External authentication name: %s\n", conn->account.user);
     if (sasl_setprop (*saslconn, SASL_AUTH_EXTERNAL, conn->account.user) != SASL_OK)
     {
       mutt_error (_("Error setting SASL external user name"));
@@ -310,7 +310,7 @@ int mutt_sasl_interact (sasl_interact_t* interaction)
 
   while (interaction->id != SASL_CB_LIST_END)
   {
-    dprint (2, (debugfile, "mutt_sasl_interact: filling in SASL interaction %ld.\n", interaction->id));
+    mutt_debug (2, "mutt_sasl_interact: filling in SASL interaction %ld.\n", interaction->id);
 
     snprintf (prompt, sizeof (prompt), "%s: ", interaction->prompt);
     resp[0] = '\0';
@@ -353,12 +353,12 @@ void mutt_sasl_setup_conn (CONNECTION* conn, sasl_conn_t* saslconn)
   /* get ssf so we know whether we have to (en|de)code read/write */
   sasl_getprop (saslconn, SASL_SSF, &tmp);
   sasldata->ssf = tmp;
-  dprint (3, (debugfile, "SASL protection strength: %u\n", *sasldata->ssf));
+  mutt_debug (3, "SASL protection strength: %u\n", *sasldata->ssf);
   /* Add SASL SSF to transport SSF */
   conn->ssf += *sasldata->ssf;
   sasl_getprop (saslconn, SASL_MAXOUTBUF, &tmp);
   sasldata->pbufsize = tmp;
-  dprint (3, (debugfile, "SASL protection buffer size: %u\n", *sasldata->pbufsize));
+  mutt_debug (3, "SASL protection buffer size: %u\n", *sasldata->pbufsize);
 
   /* clear input buffer */
   sasldata->buf = NULL;
@@ -385,7 +385,7 @@ void mutt_sasl_setup_conn (CONNECTION* conn, sasl_conn_t* saslconn)
 /* mutt_sasl_cb_log: callback to log SASL messages */
 static int mutt_sasl_cb_log (void* context, int priority, const char* message)
 {
-  dprint (priority, (debugfile, "SASL: %s\n", message));
+  mutt_debug (priority, "SASL: %s\n", message);
 
   return SASL_OK;
 }
@@ -411,9 +411,9 @@ static int mutt_sasl_cb_authname (void* context, int id, const char** result,
   if (!account)
     return SASL_BADPARAM;
 
-  dprint (2, (debugfile, "mutt_sasl_cb_authname: getting %s for %s:%u\n",
+  mutt_debug (2, "mutt_sasl_cb_authname: getting %s for %s:%u\n",
 	      id == SASL_CB_AUTHNAME ? "authname" : "user",
-	      account->host, account->port));
+	      account->host, account->port);
 
   if (id == SASL_CB_AUTHNAME)
   {
@@ -443,9 +443,8 @@ static int mutt_sasl_cb_pass (sasl_conn_t* conn, void* context, int id,
   if (!account || !psecret)
     return SASL_BADPARAM;
 
-  dprint (2, (debugfile,
-    "mutt_sasl_cb_pass: getting password for %s@%s:%u\n", account->login,
-    account->host, account->port));
+  mutt_debug (2, "mutt_sasl_cb_pass: getting password for %s@%s:%u\n",
+              account->login, account->host, account->port);
 
   if (mutt_account_getpass (account))
     return SASL_FAIL;
@@ -544,8 +543,8 @@ static int mutt_sasl_conn_read (CONNECTION* conn, char* buf, size_t len)
         &sasldata->blen);
       if (rc != SASL_OK)
       {
-	dprint (1, (debugfile, "SASL decode failed: %s\n",
-          sasl_errstring (rc, NULL, NULL)));
+	mutt_debug (1, "SASL decode failed: %s\n",
+          sasl_errstring (rc, NULL, NULL));
 	goto out;
       }
     }
@@ -591,8 +590,8 @@ static int mutt_sasl_conn_write (CONNECTION* conn, const char* buf,
       rc = sasl_encode (sasldata->saslconn, buf, olen, &pbuf, &plen);
       if (rc != SASL_OK)
       {
-	dprint (1, (debugfile, "SASL encoding failed: %s\n",
-          sasl_errstring (rc, NULL, NULL)));
+	mutt_debug (1, "SASL encoding failed: %s\n",
+          sasl_errstring (rc, NULL, NULL));
 	goto fail;
       }
 

--- a/mutt_socket.c
+++ b/mutt_socket.c
@@ -65,8 +65,8 @@ int mutt_socket_open (CONNECTION* conn)
 
   rc = conn->conn_open (conn);
 
-  dprint (2, (debugfile, "Connected to %s:%d on fd=%d\n",
-	      NONULL (conn->account.host), conn->account.port, conn->fd));
+  mutt_debug (2, "Connected to %s:%d on fd=%d\n",
+	      NONULL (conn->account.host), conn->account.port, conn->fd);
 
   return rc;
 }
@@ -76,7 +76,7 @@ int mutt_socket_close (CONNECTION* conn)
   int rc = -1;
 
   if (conn->fd < 0)
-    dprint (1, (debugfile, "mutt_socket_close: Attempt to close closed connection.\n"));
+    mutt_debug (1, "mutt_socket_close: Attempt to close closed connection.\n");
   else
     rc = conn->conn_close (conn);
 
@@ -92,7 +92,7 @@ int mutt_socket_read (CONNECTION* conn, char* buf, size_t len)
 
   if (conn->fd < 0)
   {
-    dprint (1, (debugfile, "mutt_socket_read: attempt to read from closed connection\n"));
+    mutt_debug (1, "mutt_socket_read: attempt to read from closed connection\n");
     return -1;
   }
 
@@ -114,11 +114,11 @@ int mutt_socket_write_d (CONNECTION *conn, const char *buf, int len, int dbg)
   int rc;
   int sent = 0;
 
-  dprint (dbg, (debugfile,"%d> %s", conn->fd, buf));
+  mutt_debug (dbg, "%d> %s", conn->fd, buf);
 
   if (conn->fd < 0)
   {
-    dprint (1, (debugfile, "mutt_socket_write: attempt to write to closed connection\n"));
+    mutt_debug (1, "mutt_socket_write: attempt to write to closed connection\n");
     return -1;
   }
 
@@ -129,18 +129,16 @@ int mutt_socket_write_d (CONNECTION *conn, const char *buf, int len, int dbg)
   {
     if ((rc = conn->conn_write (conn, buf + sent, len - sent)) < 0)
     {
-      dprint (1, (debugfile,
-                  "mutt_socket_write: error writing (%s), closing socket\n",
-                  strerror(errno)));
+      mutt_debug (1, "mutt_socket_write: error writing (%s), closing socket\n",
+                  strerror(errno));
       mutt_socket_close (conn);
 
       return -1;
     }
 
     if (rc < len - sent)
-      dprint (3, (debugfile,
-                  "mutt_socket_write: short write (%d of %d bytes)\n", rc,
-                  len - sent));
+      mutt_debug (3, "mutt_socket_write: short write (%d of %d bytes)\n",
+                  rc, len - sent);
     
     sent += rc;
   }
@@ -172,7 +170,7 @@ int mutt_socket_readchar (CONNECTION *conn, char *c)
       conn->available = conn->conn_read (conn, conn->inbuf, sizeof (conn->inbuf));
     else
     {
-      dprint (1, (debugfile, "mutt_socket_readchar: attempt to read from closed connection.\n"));
+      mutt_debug (1, "mutt_socket_readchar: attempt to read from closed connection.\n");
       return -1;
     }
     conn->bufpos = 0;
@@ -215,7 +213,7 @@ int mutt_socket_readln_d (char* buf, size_t buflen, CONNECTION* conn, int dbg)
     i--;
   buf[i] = '\0';
 
-  dprint (dbg, (debugfile, "%d< %s\n", conn->fd, buf));
+  mutt_debug (dbg, "%d< %s\n", conn->fd, buf);
   
   /* number of bytes read, not strlen */
   return i + 1;
@@ -323,9 +321,9 @@ static int socket_preconnect (void)
 
   if (mutt_strlen (Preconnect))
   {
-    dprint (2, (debugfile, "Executing preconnect: %s\n", Preconnect));
+    mutt_debug (2, "Executing preconnect: %s\n", Preconnect);
     rc = mutt_system (Preconnect);
-    dprint (2, (debugfile, "Preconnect result: %d\n", rc));
+    mutt_debug (2, "Preconnect result: %d\n", rc);
     if (rc)
     {
       save_errno = errno;
@@ -353,7 +351,7 @@ static int socket_connect (int fd, struct sockaddr* sa)
 #endif
   else
   {
-    dprint (1, (debugfile, "Unknown address family!\n"));
+    mutt_debug (1, "Unknown address family!\n");
     return -1;
   }
   
@@ -367,7 +365,7 @@ static int socket_connect (int fd, struct sockaddr* sa)
   if (connect (fd, sa, sa_size) < 0)
   {
       save_errno = errno;
-      dprint (2, (debugfile, "Connection failed. errno: %d...\n", errno));
+      mutt_debug (2, "Connection failed. errno: %d...\n", errno);
       SigInt = 0;	/* reset in case we caught SIGINTR while in connect() */
   }
 

--- a/mutt_ssl_gnutls.c
+++ b/mutt_ssl_gnutls.c
@@ -232,12 +232,12 @@ static void tls_get_client_cert (CONNECTION* conn)
 
   if (gnutls_x509_crt_init (&clientcrt) < 0)
   {
-    dprint (1, (debugfile, "Failed to init gnutls crt\n"));
+    mutt_debug (1, "Failed to init gnutls crt\n");
     return;
   }
   if (gnutls_x509_crt_import (clientcrt, crtdata, GNUTLS_X509_FMT_DER) < 0)
   {
-    dprint (1, (debugfile, "Failed to import gnutls client crt\n"));
+    mutt_debug (1, "Failed to import gnutls client crt\n");
     goto err_crt;
   }
   /* get length of DN */
@@ -245,16 +245,16 @@ static void tls_get_client_cert (CONNECTION* conn)
   gnutls_x509_crt_get_dn (clientcrt, NULL, &dnlen);
   if (!(dn = calloc (1, dnlen)))
   {
-    dprint (1, (debugfile, "could not allocate DN\n"));
+    mutt_debug (1, "could not allocate DN\n");
     goto err_crt;
   }
   gnutls_x509_crt_get_dn (clientcrt, dn, &dnlen);
-  dprint (2, (debugfile, "client certificate DN: %s\n", dn));
+  mutt_debug (2, "client certificate DN: %s\n", dn);
 
   /* extract CN to use as external user name */
   if (!(cn = strstr (dn, "CN=")))
   {
-    dprint (1, (debugfile, "no CN found in DN\n"));
+    mutt_debug (1, "no CN found in DN\n");
     goto err_dn;
   }
   cn += 3;
@@ -398,7 +398,7 @@ static int tls_negotiate (CONNECTION * conn)
 
   if (SslClientCert)
   {
-    dprint (2, (debugfile, "Using client certificate %s\n", SslClientCert));
+    mutt_debug (2, "Using client certificate %s\n", SslClientCert);
     gnutls_certificate_set_x509_key_file (data->xcred, SslClientCert,
                                           SslClientCert, GNUTLS_X509_FMT_PEM);
   }
@@ -1164,7 +1164,7 @@ static int tls_check_certificate (CONNECTION* conn)
       rc = gnutls_certificate_set_x509_trust_mem (data->xcred, &cert_list[i],
                                                   GNUTLS_X509_FMT_DER);
       if (rc != 1)
-        dprint (1, (debugfile, "error trusting certificate %d: %d\n", i, rc));
+        mutt_debug (1, "error trusting certificate %d: %d\n", i, rc);
 
       certstat = tls_verify_peers (state);
       /* If the cert chain now verifies, and the peer's cert was otherwise

--- a/muttlib.c
+++ b/muttlib.c
@@ -206,8 +206,8 @@ void mutt_free_body (BODY **p)
     {
       if (b->unlink)
 	unlink (b->filename);
-      dprint (1, (debugfile, "mutt_free_body: %sunlinking %s.\n",
-	    b->unlink ? "" : "not ", b->filename));
+      mutt_debug (1, "mutt_free_body: %sunlinking %s.\n",
+                  b->unlink ? "" : "not ", b->filename);
     }
 
     FREE (&b->filename);
@@ -945,11 +945,13 @@ void _mutt_mktemp (char *s, size_t slen, const char *prefix, const char *suffix,
       (int) getuid (), (int) getpid (), mutt_rand64(),
       suffix ? "." : "", NONULL (suffix));
   if (n >= slen)
-    dprint (1, (debugfile, "%s:%d: ERROR: insufficient buffer space to hold temporary filename! slen=%zu but need %zu\n",
-	    src, line, slen, n));
-  dprint (3, (debugfile, "%s:%d: mutt_mktemp returns \"%s\".\n", src, line, s));
+    mutt_debug (1, "%s:%d: ERROR: insufficient buffer space to hold temporary "
+                "filename! slen=%zu but need %zu\n",
+                src, line, slen, n);
+  mutt_debug (3, "%s:%d: mutt_mktemp returns \"%s\".\n", src, line, s);
   if (unlink (s) && errno != ENOENT)
-    dprint (1, (debugfile, "%s:%d: ERROR: unlink(\"%s\"): %s (errno %d)\n", src, line, s, strerror (errno), errno));
+    mutt_debug (1, "%s:%d: ERROR: unlink(\"%s\"): %s (errno %d)\n",
+                src, line, s, strerror (errno), errno);
 }
 
 void mutt_free_alias (ALIAS **p)
@@ -1267,7 +1269,7 @@ void mutt_FormatString (char *dest,		/* output buffer */
       int     i = 0;
 #endif
 
-      dprint(3, (debugfile, "fmtpipe = %s\n", src));
+      mutt_debug (3, "fmtpipe = %s\n", src);
 
       strncpy(srccopy, src, n);
       srccopy[n-1] = '\0';
@@ -1283,11 +1285,11 @@ void mutt_FormatString (char *dest,		/* output buffer */
         char *p;
 
         /* Extract the command name and copy to command line */
-        dprint(3, (debugfile, "fmtpipe +++: %s\n", srcbuf->dptr));
+        mutt_debug (3, "fmtpipe +++: %s\n", srcbuf->dptr);
         if (word->data)
           *word->data = '\0';
         mutt_extract_token(word, srcbuf, 0);
-        dprint(3, (debugfile, "fmtpipe %2d: %s\n", i++, word->data));
+        mutt_debug (3, "fmtpipe %2d: %s\n", i++, word->data);
         mutt_buffer_addch(command, '\'');
         mutt_FormatString(buf, sizeof(buf), 0, cols, word->data, callback, data,
                           flags | MUTT_FORMAT_NOFILTER);
@@ -1306,7 +1308,7 @@ void mutt_FormatString (char *dest,		/* output buffer */
         mutt_buffer_addch(command, ' ');
       } while (MoreArgs(srcbuf));
 
-      dprint(3, (debugfile, "fmtpipe > %s\n", command->data));
+      mutt_debug (3, "fmtpipe > %s\n", command->data);
 
       col -= wlen;	/* reset to passed in value */
       wptr = dest;      /* reset write ptr */
@@ -1319,12 +1321,12 @@ void mutt_FormatString (char *dest,		/* output buffer */
         safe_fclose (&filter);
 	rc = mutt_wait_filter(pid);
 	if (rc != 0)
-	  dprint(1, (debugfile, "format pipe command exited code %d\n", rc));
+	  mutt_debug (1, "format pipe command exited code %d\n", rc);
 	if (n > 0) {
 	  dest[n] = 0;
 	  while ((n > 0) && (dest[n-1] == '\n' || dest[n-1] == '\r'))
 	    dest[--n] = '\0';
-	  dprint(3, (debugfile, "fmtpipe < %s\n", dest));
+	  mutt_debug (3, "fmtpipe < %s\n", dest);
 
 	  /* If the result ends with '%', this indicates that the filter
 	   * generated %-tokens that mutt can expand.  Eliminate the '%'
@@ -1353,7 +1355,8 @@ void mutt_FormatString (char *dest,		/* output buffer */
 	else
 	{
 	  /* read error */
-	  dprint(1, (debugfile, "error reading from fmtpipe: %s (errno=%d)\n", strerror(errno), errno));
+	  mutt_debug (1, "error reading from fmtpipe: %s (errno=%d)\n",
+	              strerror(errno), errno);
 	  *wptr = 0;
 	}
       }
@@ -2126,7 +2129,7 @@ int mutt_match_rx_list (const char *s, RX_LIST *l)
   {
     if (regexec (l->rx->rx, s, (size_t) 0, (regmatch_t *) 0, (int) 0) == 0)
     {
-      dprint (5, (debugfile, "mutt_match_rx_list: %s matches %s\n", s, l->rx->pattern));
+      mutt_debug (5, "mutt_match_rx_list: %s matches %s\n", s, l->rx->pattern);
       return 1;
     }
   }
@@ -2162,8 +2165,8 @@ int mutt_match_spam_list (const char *s, SPAM_LIST *l, char *text, int textsize)
     /* Does this pattern match? */
     if (regexec (l->rx->rx, s, (size_t) l->nmatch, (regmatch_t *) pmatch, (int) 0) == 0)
     {
-      dprint (5, (debugfile, "mutt_match_spam_list: %s matches %s\n", s, l->rx->pattern));
-      dprint (5, (debugfile, "mutt_match_spam_list: %d subs\n", (int)l->rx->rx->re_nsub));
+      mutt_debug (5, "mutt_match_spam_list: %s matches %s\n", s, l->rx->pattern);
+      mutt_debug (5, "mutt_match_spam_list: %d subs\n", (int)l->rx->rx->re_nsub);
 
       /* Copy template into text, with substitutions. */
       for (p = l->template; *p && tlen < textsize - 1;)
@@ -2200,7 +2203,7 @@ int mutt_match_spam_list (const char *s, SPAM_LIST *l, char *text, int textsize)
        * the validity of the text pointer. */
       if (tlen < textsize) {
 	text[tlen] = '\0';
-	dprint (5, (debugfile, "mutt_match_spam_list: \"%s\"\n", text));
+	mutt_debug (5, "mutt_match_spam_list: \"%s\"\n", text);
       }
       return 1;
     }

--- a/mx.c
+++ b/mx.c
@@ -215,7 +215,7 @@ int mx_lock_file (const char *path, int fd, int excl, int dot, int timeout)
   attempt = 0;
   while (fcntl (fd, F_SETLK, &lck) == -1)
   {
-    dprint(1,(debugfile, "mx_lock_file(): fcntl errno %d.\n", errno));
+    mutt_debug (1, "mx_lock_file(): fcntl errno %d.\n", errno);
     if (errno != EAGAIN && errno != EACCES)
     {
       mutt_perror ("fcntl");
@@ -457,8 +457,8 @@ int mx_get_magic (const char *path)
 
   if (stat (path, &st) == -1)
   {
-    dprint (1, (debugfile, "mx_get_magic(): unable to stat %s: %s (errno %d).\n",
-		path, strerror (errno), errno));
+    mutt_debug (1, "mx_get_magic(): unable to stat %s: %s (errno %d).\n",
+                path, strerror (errno), errno);
     return (-1);
   }
 
@@ -504,8 +504,8 @@ int mx_get_magic (const char *path)
   }
   else
   {
-    dprint (1, (debugfile, "mx_get_magic(): unable to open file %s for reading.\n",
-		path));
+    mutt_debug (1, "mx_get_magic(): unable to open file %s for reading.\n",
+                path);
     return (-1);
   }
 
@@ -1306,8 +1306,8 @@ MESSAGE *mx_open_new_message (CONTEXT *dest, HEADER *hdr, int flags)
 
   if (!dest->mx_ops || !dest->mx_ops->open_new_msg)
   {
-      dprint (1, (debugfile, "mx_open_new_message(): function unimplemented for mailbox type %d.\n",
-              dest->magic));
+      mutt_debug (1, "mx_open_new_message(): function unimplemented for mailbox type %d.\n",
+                  dest->magic);
       return NULL;
   }
 
@@ -1358,7 +1358,7 @@ int mx_check_mailbox (CONTEXT *ctx, int *index_hint)
 {
   if (!ctx || !ctx->mx_ops)
   {
-    dprint (1, (debugfile, "mx_check_mailbox: null or invalid context.\n"));
+    mutt_debug (1, "mx_check_mailbox: null or invalid context.\n");
     return -1;
   }
 
@@ -1372,7 +1372,8 @@ MESSAGE *mx_open_message (CONTEXT *ctx, int msgno)
 
   if (!ctx->mx_ops || !ctx->mx_ops->open_msg)
   {
-    dprint (1, (debugfile, "mx_open_message(): function not implemented for mailbox type %d.\n", ctx->magic));
+    mutt_debug (1, "mx_open_message(): function not implemented for mailbox type %d.\n",
+                ctx->magic);
     return NULL;
   }
 
@@ -1392,8 +1393,8 @@ int mx_commit_message (MESSAGE *msg, CONTEXT *ctx)
 
   if (!(msg->write && ctx->append))
   {
-    dprint (1, (debugfile, "mx_commit_message(): msg->write = %d, ctx->append = %d\n",
-		msg->write, ctx->append));
+    mutt_debug (1, "mx_commit_message(): msg->write = %d, ctx->append = %d\n",
+                msg->write, ctx->append);
     return -1;
   }
 
@@ -1412,8 +1413,7 @@ int mx_close_message (CONTEXT *ctx, MESSAGE **msg)
 
   if ((*msg)->path)
   {
-    dprint (1, (debugfile, "mx_close_message (): unlinking %s\n",
-            (*msg)->path));
+    mutt_debug (1, "mx_close_message (): unlinking %s\n", (*msg)->path);
     unlink ((*msg)->path);
     FREE (&(*msg)->path);
   }

--- a/newsrc.c
+++ b/newsrc.c
@@ -113,7 +113,7 @@ void nntp_newsrc_close (NNTP_SERVER *nserv)
   if (!nserv->newsrc_fp)
     return;
 
-  dprint (1, (debugfile, "Unlocking %s\n", nserv->newsrc_file));
+  mutt_debug (1, "Unlocking %s\n", nserv->newsrc_file);
   mx_unlock_file (nserv->newsrc_file, fileno (nserv->newsrc_fp), 0);
   safe_fclose (&nserv->newsrc_fp);
 }
@@ -150,7 +150,7 @@ int nntp_newsrc_parse (NNTP_SERVER *nserv)
   }
 
   /* lock it */
-  dprint (1, (debugfile, "Locking %s\n", nserv->newsrc_file));
+  mutt_debug (1, "Locking %s\n", nserv->newsrc_file);
   if (mx_lock_file (nserv->newsrc_file, fileno (nserv->newsrc_fp), 0, 0, 1))
   {
     safe_fclose (&nserv->newsrc_fp);
@@ -171,7 +171,7 @@ int nntp_newsrc_parse (NNTP_SERVER *nserv)
   nserv->size = sb.st_size;
   nserv->mtime = sb.st_mtime;
   nserv->newsrc_modified = 1;
-  dprint (1, (debugfile, "Parsing %s\n", nserv->newsrc_file));
+  mutt_debug (1, "Parsing %s\n", nserv->newsrc_file);
 
   /* .newsrc has been externally modified or hasn't been loaded yet */
   for (i = 0; i < nserv->groups_num; i++)
@@ -248,7 +248,7 @@ int nntp_newsrc_parse (NNTP_SERVER *nserv)
     nntp_data->newsrc_len = i;
     safe_realloc (&nntp_data->newsrc_ent, i * sizeof (NEWSRC_ENTRY));
     nntp_group_unread_stat (nntp_data);
-    dprint (2, (debugfile, "nntp_newsrc_parse: %s\n", nntp_data->group));
+    mutt_debug (2, "nntp_newsrc_parse: %s\n", nntp_data->group);
   }
   FREE (&line);
   return 1;
@@ -440,7 +440,7 @@ int nntp_newsrc_update (NNTP_SERVER *nserv)
   buf[off] = '\0';
 
   /* newrc being fully rewritten */
-  dprint (1, (debugfile, "Updating %s\n", nserv->newsrc_file));
+  mutt_debug (1, "Updating %s\n", nserv->newsrc_file);
   if (nserv->newsrc_file && update_file (nserv->newsrc_file, buf) == 0)
   {
     struct stat sb;
@@ -541,7 +541,7 @@ static int active_get_cache (NNTP_SERVER *nserv)
   FILE *fp;
 
   cache_expand (file, sizeof (file), &nserv->conn->account, ".active");
-  dprint (1, (debugfile, "Parsing %s\n", file));
+  mutt_debug (1, "Parsing %s\n", file);
   fp = safe_fopen (file, "r");
   if (!fp)
     return -1;
@@ -601,7 +601,7 @@ int nntp_active_save_cache (NNTP_SERVER *nserv)
   }
 
   cache_expand (file, sizeof (file), &nserv->conn->account, ".active");
-  dprint (1, (debugfile, "Updating %s\n", file));
+  mutt_debug (1, "Updating %s\n", file);
   rc = update_file (file, buf);
   FREE (&buf);
   return rc;
@@ -647,8 +647,7 @@ void nntp_hcache_update (NNTP_DATA *nntp_data, header_cache_t *hc)
   hdata = mutt_hcache_fetch_raw (hc, "index", 5);
   if (hdata)
   {
-    dprint (2, (debugfile,
-		"nntp_hcache_update: mutt_hcache_fetch index: %s\n", hdata));
+    mutt_debug (2, "nntp_hcache_update: mutt_hcache_fetch index: %s\n", hdata);
     if (sscanf (hdata, ANUM " " ANUM, &first, &last) == 2)
     {
       old = 1;
@@ -662,8 +661,7 @@ void nntp_hcache_update (NNTP_DATA *nntp_data, header_cache_t *hc)
 	  continue;
 
 	snprintf (buf, sizeof (buf), "%d", current);
-	dprint (2, (debugfile,
-		    "nntp_hcache_update: mutt_hcache_delete %s\n", buf));
+        mutt_debug (2, "nntp_hcache_update: mutt_hcache_delete %s\n", buf);
 	mutt_hcache_delete (hc, buf, strlen(buf));
       }
     }
@@ -676,8 +674,7 @@ void nntp_hcache_update (NNTP_DATA *nntp_data, header_cache_t *hc)
   {
     snprintf (buf, sizeof (buf), "%u %u", nntp_data->firstMessage,
 					  nntp_data->lastMessage);
-    dprint (2, (debugfile,
-		"nntp_hcache_update: mutt_hcache_store index: %s\n", buf));
+    mutt_debug (2, "nntp_hcache_update: mutt_hcache_store index: %s\n", buf);
     mutt_hcache_store_raw (hc, "index", 5, buf, strlen (buf));
   }
 }
@@ -694,7 +691,7 @@ static int nntp_bcache_delete (const char *id, body_cache_t *bcache, void *data)
       anum < nntp_data->firstMessage || anum > nntp_data->lastMessage)
   {
     if (nntp_data)
-      dprint (2, (debugfile, "nntp_bcache_delete: mutt_bcache_del %s\n", id));
+      mutt_debug (2, "nntp_bcache_delete: mutt_bcache_del %s\n", id);
     mutt_bcache_del (bcache, id);
   }
   return 0;
@@ -718,7 +715,7 @@ void nntp_delete_group_cache (NNTP_DATA *nntp_data)
   cache_expand (file, sizeof (file), &nntp_data->nserv->conn->account, file);
   unlink (file);
   nntp_data->lastCached = 0;
-  dprint (2, (debugfile, "nntp_delete_group_cache: %s\n", file));
+  mutt_debug (2, "nntp_delete_group_cache: %s\n", file);
 #endif
 
   if (!nntp_data->bcache)
@@ -726,7 +723,7 @@ void nntp_delete_group_cache (NNTP_DATA *nntp_data)
 			nntp_data->group);
   if (nntp_data->bcache)
   {
-    dprint (2, (debugfile, "nntp_delete_group_cache: %s/*\n", nntp_data->group));
+    mutt_debug (2, "nntp_delete_group_cache: %s/*\n", nntp_data->group);
     mutt_bcache_list (nntp_data->bcache, nntp_bcache_delete, NULL);
     mutt_bcache_close (&nntp_data->bcache);
   }
@@ -793,7 +790,7 @@ void nntp_clear_cache (NNTP_SERVER *nserv)
       if (S_ISDIR (sb.st_mode))
       {
 	rmdir (file);
-	dprint (2, (debugfile, "nntp_clear_cache: %s\n", file));
+	mutt_debug (2, "nntp_clear_cache: %s\n", file);
       }
     }
     closedir (dp);
@@ -1030,8 +1027,8 @@ NNTP_SERVER *nntp_select_server (char *server, int leave_lock)
 		last <= nntp_data->lastMessage)
 	    {
 	      nntp_data->lastCached = last;
-	      dprint (2, (debugfile, "nntp_select_server: %s lastCached=%u\n",
-			  nntp_data->group, last));
+	      mutt_debug (2, "nntp_select_server: %s lastCached=%u\n",
+			  nntp_data->group, last);
 	    }
 	  }
 	  mutt_hcache_free (hc, &hdata);

--- a/nntp.c
+++ b/nntp.c
@@ -342,8 +342,7 @@ static int nntp_auth (NNTP_SERVER *nserv)
       p++;
     }
 
-    dprint (1, (debugfile,
-		"nntp_auth: available methods: %s\n", nserv->authenticators));
+    mutt_debug (1, "nntp_auth: available methods: %s\n", nserv->authenticators);
     a = authenticators;
     while (1)
     {
@@ -375,7 +374,7 @@ static int nntp_auth (NNTP_SERVER *nserv)
 	if (*m != '\0' && *m != ' ')
 	  continue;
       }
-      dprint (1, (debugfile, "nntp_auth: trying method %s\n", method));
+      mutt_debug (1, "nntp_auth: trying method %s\n", method);
 
       /* AUTHINFO USER authentication */
       if (!strcmp (method, "USER"))
@@ -395,8 +394,7 @@ static int nntp_auth (NNTP_SERVER *nserv)
 	{
 #ifdef DEBUG
 	  if (debuglevel < MUTT_SOCK_LOG_FULL)
-	    dprint (MUTT_SOCK_LOG_CMD, (debugfile,
-		    "%d> AUTHINFO PASS *\n", conn->fd));
+	    mutt_debug (MUTT_SOCK_LOG_CMD, "%d> AUTHINFO PASS *\n", conn->fd);
 #endif
 	  snprintf (buf, sizeof (buf), "AUTHINFO PASS %s\r\n",
 		    conn->account.pass);
@@ -427,8 +425,7 @@ static int nntp_auth (NNTP_SERVER *nserv)
 
 	if (mutt_sasl_client_new (conn, &saslconn) < 0)
 	{
-	  dprint (1, (debugfile,
-		  "nntp_auth: error allocating SASL connection.\n"));
+	  mutt_debug (1, "nntp_auth: error allocating SASL connection.\n");
 	  continue;
 	}
 
@@ -443,8 +440,7 @@ static int nntp_auth (NNTP_SERVER *nserv)
 	if (rc != SASL_OK && rc != SASL_CONTINUE)
 	{
 	  sasl_dispose (&saslconn);
-	  dprint (1, (debugfile,
-		  "nntp_auth: error starting SASL authentication exchange.\n"));
+	  mutt_debug (1, "nntp_auth: error starting SASL authentication exchange.\n");
 	  continue;
 	}
 
@@ -468,7 +464,7 @@ static int nntp_auth (NNTP_SERVER *nserv)
 		  *p = '.';
 	      }
 	      *p = '\0';
-	      dprint (1, (debugfile, "SASL> %s\n", tmp));
+	      mutt_debug (1, "SASL> %s\n", tmp);
 	    }
 #endif
 
@@ -478,8 +474,7 @@ static int nntp_auth (NNTP_SERVER *nserv)
 	    if (sasl_encode64 (client_out, client_len,
 		buf + len, sizeof (buf) - len, &len) != SASL_OK)
 	    {
-	      dprint (1, (debugfile,
-		      "nntp_auth: error base64-encoding client response.\n"));
+	      mutt_debug (1, "nntp_auth: error base64-encoding client response.\n");
 	      break;
 	    }
 	  }
@@ -489,10 +484,10 @@ static int nntp_auth (NNTP_SERVER *nserv)
 	  if (debuglevel < MUTT_SOCK_LOG_FULL)
 	  {
 	    if (strchr (buf, ' '))
-	      dprint (MUTT_SOCK_LOG_CMD, (debugfile, "%d> AUTHINFO SASL %s%s\n",
-		      conn->fd, method, client_len ? " sasl_data" : ""));
+	      mutt_debug (MUTT_SOCK_LOG_CMD, "%d> AUTHINFO SASL %s%s\n",
+		      conn->fd, method, client_len ? " sasl_data" : "");
 	    else
-	      dprint (MUTT_SOCK_LOG_CMD, (debugfile, "%d> sasl_data\n", conn->fd));
+	      mutt_debug (MUTT_SOCK_LOG_CMD, "%d> sasl_data\n", conn->fd);
 	  }
 #endif
 	  client_len = 0;
@@ -504,7 +499,7 @@ static int nntp_auth (NNTP_SERVER *nserv)
 	  {
 #ifdef DEBUG
 	    if (debuglevel < MUTT_SOCK_LOG_FULL)
-	      dprint (MUTT_SOCK_LOG_CMD, (debugfile, "%d< %s\n", conn->fd, inbuf));
+	      mutt_debug (MUTT_SOCK_LOG_CMD, "%d< %s\n", conn->fd, inbuf);
 #endif
 	    break;
 	  }
@@ -512,8 +507,8 @@ static int nntp_auth (NNTP_SERVER *nserv)
 	  if (debuglevel < MUTT_SOCK_LOG_FULL)
 	  {
 	    inbuf[3] = '\0';
-	    dprint (MUTT_SOCK_LOG_CMD, (debugfile,
-		    "%d< %s sasl_data\n", conn->fd, inbuf));
+	    mutt_debug (MUTT_SOCK_LOG_CMD, "%d< %s sasl_data\n",
+	                conn->fd, inbuf);
 	  }
 #endif
 
@@ -522,8 +517,7 @@ static int nntp_auth (NNTP_SERVER *nserv)
 	  else if (sasl_decode64 (inbuf + 4, strlen (inbuf + 4),
 		   buf, sizeof (buf) - 1, &len) != SASL_OK)
 	  {
-	    dprint (1, (debugfile,
-		    "nntp_auth: error base64-decoding server response.\n"));
+	    mutt_debug (1, "nntp_auth: error base64-decoding server response.\n");
 	    break;
 	  }
 #ifdef DEBUG
@@ -537,7 +531,7 @@ static int nntp_auth (NNTP_SERVER *nserv)
 		*p = '.';
 	    }
 	    *p = '\0';
-	    dprint (1, (debugfile, "SASL< %s\n", tmp));
+	    mutt_debug (1, "SASL< %s\n", tmp);
 	  }
 #endif
 
@@ -913,7 +907,7 @@ static int fetch_description (char *line, void *data)
   if (nntp_data && mutt_strcmp (desc, nntp_data->desc))
   {
     mutt_str_replace (&nntp_data->desc, desc);
-    dprint (2, (debugfile, "group: %s, desc: %s\n", line, desc));
+    mutt_debug (2, "group: %s, desc: %s\n", line, desc);
   }
   return 0;
 }
@@ -1048,7 +1042,7 @@ static int parse_overview_line (char *line, void *data)
     *field++ = '\0';
   if (sscanf (line, ANUM, &anum) != 1)
     return 0;
-  dprint (2, (debugfile, "parse_overview_line: " ANUM "\n", anum));
+  mutt_debug (2, "parse_overview_line: " ANUM "\n", anum);
 
   /* out of bounds */
   if (anum < fc->first || anum > fc->last)
@@ -1120,8 +1114,7 @@ static int parse_overview_line (char *line, void *data)
     hdata = mutt_hcache_fetch (fc->hc, buf, strlen(buf));
     if (hdata)
     {
-      dprint (2, (debugfile,
-		  "parse_overview_line: mutt_hcache_fetch %s\n", buf));
+      mutt_debug (2, "parse_overview_line: mutt_hcache_fetch %s\n", buf);
       mutt_free_header (&hdr);
       ctx->hdrs[ctx->msgcount] =
       hdr = mutt_hcache_restore (hdata);
@@ -1135,8 +1128,7 @@ static int parse_overview_line (char *line, void *data)
       {
 	if (nntp_data->bcache)
 	{
-	  dprint (2, (debugfile,
-		      "parse_overview_line: mutt_bcache_del %s\n", buf));
+	  mutt_debug (2, "parse_overview_line: mutt_bcache_del %s\n", buf);
 	  mutt_bcache_del (nntp_data->bcache, buf);
 	}
 	save = 0;
@@ -1146,8 +1138,7 @@ static int parse_overview_line (char *line, void *data)
     /* not chached yet, store header */
     else
     {
-      dprint (2, (debugfile,
-		  "parse_overview_line: mutt_hcache_store %s\n", buf));
+      mutt_debug (2, "parse_overview_line: mutt_hcache_store %s\n", buf);
       mutt_hcache_store (fc->hc, buf, strlen(buf), hdr, 0);
     }
   }
@@ -1239,16 +1230,14 @@ static int nntp_fetch_headers (CONTEXT *ctx, void *hc,
 	snprintf (buf, sizeof (buf), "%d", current);
 	if (nntp_data->bcache)
 	{
-	  dprint (2, (debugfile,
-		      "nntp_fetch_headers: mutt_bcache_del %s\n", buf));
+	  mutt_debug (2, "nntp_fetch_headers: mutt_bcache_del %s\n", buf);
 	  mutt_bcache_del (nntp_data->bcache, buf);
 	}
 
 #ifdef USE_HCACHE
 	if (fc.hc)
 	{
-	  dprint (2, (debugfile,
-		      "nntp_fetch_headers: mutt_hcache_delete %s\n", buf));
+	  mutt_debug (2, "nntp_fetch_headers: mutt_hcache_delete %s\n", buf);
 	  mutt_hcache_delete (fc.hc, buf, strlen(buf));
 	}
 #endif
@@ -1285,8 +1274,7 @@ static int nntp_fetch_headers (CONTEXT *ctx, void *hc,
     hdata = mutt_hcache_fetch (fc.hc, buf, strlen(buf));
     if (hdata)
     {
-      dprint (2, (debugfile,
-		  "nntp_fetch_headers: mutt_hcache_fetch %s\n", buf));
+      mutt_debug (2, "nntp_fetch_headers: mutt_hcache_fetch %s\n", buf);
       ctx->hdrs[ctx->msgcount] =
       hdr = mutt_hcache_restore (hdata);
       mutt_hcache_free (fc.hc, &hdata);
@@ -1298,8 +1286,7 @@ static int nntp_fetch_headers (CONTEXT *ctx, void *hc,
 	mutt_free_header (&hdr);
 	if (nntp_data->bcache)
 	{
-	  dprint (2, (debugfile,
-		      "nntp_fetch_headers: mutt_bcache_del %s\n", buf));
+	  mutt_debug (2, "nntp_fetch_headers: mutt_bcache_del %s\n", buf);
 	  mutt_bcache_del (nntp_data->bcache, buf);
 	}
 	continue;
@@ -1361,8 +1348,7 @@ static int nntp_fetch_headers (CONTEXT *ctx, void *hc,
 	if (nntp_data->bcache)
 	{
 	  snprintf (buf, sizeof (buf), "%d", current);
-	  dprint (2, (debugfile,
-		      "nntp_fetch_headers: mutt_bcache_del %s\n", buf));
+	  mutt_debug (2, "nntp_fetch_headers: mutt_bcache_del %s\n", buf);
 	  mutt_bcache_del (nntp_data->bcache, buf);
 	}
 	rc = 0;
@@ -1786,7 +1772,7 @@ int nntp_sync_mailbox (CONTEXT *ctx, int *index_hint)
     snprintf (buf, sizeof (buf), "%d", NHDR (hdr)->article_num);
     if (nntp_data->bcache && hdr->deleted)
     {
-      dprint (2, (debugfile, "nntp_sync_mailbox: mutt_bcache_del %s\n", buf));
+      mutt_debug (2, "nntp_sync_mailbox: mutt_bcache_del %s\n", buf);
       mutt_bcache_del (nntp_data->bcache, buf);
     }
 
@@ -1795,7 +1781,7 @@ int nntp_sync_mailbox (CONTEXT *ctx, int *index_hint)
     {
       if (hdr->deleted && !hdr->read)
 	nntp_data->unread--;
-      dprint (2, (debugfile, "nntp_sync_mailbox: mutt_hcache_store %s\n", buf));
+      mutt_debug (2, "nntp_sync_mailbox: mutt_hcache_store %s\n", buf);
       mutt_hcache_store (hc, buf, strlen(buf), hdr, 0);
     }
 #endif
@@ -1857,7 +1843,7 @@ int nntp_date (NNTP_SERVER *nserv, time_t *now)
       *now = timegm (&tm);
       if (*now >= 0)
       {
-	dprint (1, (debugfile, "nntp_date: server time is %d\n", *now));
+	mutt_debug (1, "nntp_date: server time is %d\n", *now);
 	return 0;
       }
     }
@@ -2045,8 +2031,7 @@ int nntp_check_mailbox (CONTEXT *ctx, int *index_hint)
 	{
 	  int deleted;
 
-	  dprint (2, (debugfile,
-		      "nntp_check_mailbox: mutt_hcache_fetch %s\n", buf));
+	  mutt_debug (2, "nntp_check_mailbox: mutt_hcache_fetch %s\n", buf);
 	  hdr = mutt_hcache_restore (hdata);
 	  mutt_hcache_free (hc, &hdata);
 	  hdr->data = 0;
@@ -2090,8 +2075,7 @@ int nntp_check_mailbox (CONTEXT *ctx, int *index_hint)
       hdata = mutt_hcache_fetch (hc, buf, strlen(buf));
       if (hdata)
       {
-	dprint (2, (debugfile,
-		    "nntp_check_mailbox: mutt_hcache_fetch %s\n", buf));
+	mutt_debug (2, "nntp_check_mailbox: mutt_hcache_fetch %s\n", buf);
 	if (ctx->msgcount >= ctx->hdrmax)
 	  mx_alloc_memory (ctx);
 
@@ -2104,8 +2088,7 @@ int nntp_check_mailbox (CONTEXT *ctx, int *index_hint)
 	  mutt_free_header (&hdr);
 	  if (nntp_data->bcache)
 	  {
-	    dprint (2, (debugfile,
-			"nntp_check_mailbox: mutt_bcache_del %s\n", buf));
+	    mutt_debug (2, "nntp_check_mailbox: mutt_bcache_del %s\n", buf);
 	    mutt_bcache_del (nntp_data->bcache, buf);
 	  }
 	  continue;

--- a/pager.c
+++ b/pager.c
@@ -1150,7 +1150,7 @@ fill_buffer (FILE *f, LOFF_T *last_pos, LOFF_T offset, unsigned char **buf,
       }
       else if (*p == '\033' && *(p+1) == ']' && check_attachment_marker ((char *) p) == 0)
       {
-	dprint (2, (debugfile, "fill_buffer: Seen attachment marker.\n"));
+        mutt_debug (2, "fill_buffer: Seen attachment marker.\n");
 	while (*p++ != '\a')	/* skip pseudo-ANSI sequence */
 	  ;
       }
@@ -1211,8 +1211,8 @@ static int format_line (struct line_t **lineInfo, int n, unsigned char *buf,
     {
       if (k == (size_t)(-1))
         memset(&mbstate, 0, sizeof(mbstate));
-      dprint (1, (debugfile, "%s:%d: mbrtowc returned %d; errno = %d.\n",
-		  __FILE__, __LINE__, k, errno));
+      mutt_debug (1, "%s:%d: mbrtowc returned %d; errno = %d.\n",
+                  __FILE__, __LINE__, k, errno);
       if (col + 4 > wrap_cols)
 	break;
       col += 4;
@@ -1228,12 +1228,12 @@ static int format_line (struct line_t **lineInfo, int n, unsigned char *buf,
     {
       if (wc == 0x200B || wc == 0xFEFF)
       {
-	dprint (3, (debugfile, "skip zero-width character U+%04X\n", (unsigned short)wc));
+        mutt_debug (3, "skip zero-width character U+%04X\n", (unsigned short)wc);
 	continue;
       }
       if (is_display_corrupting_utf8 (wc))
       {
-	dprint (3, (debugfile, "filtered U+%04X\n", (unsigned short)wc));
+        mutt_debug (3, "filtered U+%04X\n", (unsigned short)wc);
 	continue;
       }
     }

--- a/parse.c
+++ b/parse.c
@@ -143,13 +143,13 @@ static PARAMETER *parse_parameters (const char *s)
   const char *p;
   size_t i;
 
-  dprint (2, (debugfile, "parse_parameters: `%s'\n", s));
+  mutt_debug (2, "parse_parameters: `%s'\n", s);
   
   while (*s)
   {
     if ((p = strpbrk (s, "=;")) == NULL)
     {
-      dprint(1, (debugfile, "parse_parameters: malformed parameter: %s\n", s));
+      mutt_debug (1, "parse_parameters: malformed parameter: %s\n", s);
       goto bail;
     }
 
@@ -166,7 +166,7 @@ static PARAMETER *parse_parameters (const char *s)
        */
       if (i == 0)
       {
-	dprint(1, (debugfile, "parse_parameters: missing attribute: %s\n", s));
+        mutt_debug (1, "parse_parameters: missing attribute: %s\n", s);
 	new = NULL;
       }
       else
@@ -222,9 +222,9 @@ static PARAMETER *parse_parameters (const char *s)
       {
 	new->value = safe_strdup (buffer);
 
-	dprint (2, (debugfile, "parse_parameter: `%s' = `%s'\n",
-	      new->attribute ? new->attribute : "",
-	      new->value ? new->value : ""));
+	mutt_debug (2, "parse_parameter: `%s' = `%s'\n",
+	            new->attribute ? new->attribute : "",
+	            new->value ? new->value : "");
 
 	/* Add this parameter to the list */
 	if (head)
@@ -238,7 +238,7 @@ static PARAMETER *parse_parameters (const char *s)
     }
     else
     {
-      dprint (1, (debugfile, "parse_parameters(): parameter with no value: %s\n", s));
+      mutt_debug (1, "parse_parameters(): parameter with no value: %s\n", s);
       s = p;
     }
 
@@ -429,13 +429,14 @@ BODY *mutt_read_mime_header (FILE *fp, int digest)
       c = skip_email_wsp(c + 1);
       if (!*c)
       {
-	dprint (1, (debugfile, "mutt_read_mime_header(): skipping empty header field: %s\n", line));
+        mutt_debug (1, "mutt_read_mime_header(): skipping empty header field: %s\n",
+                    line);
 	continue;
       }
     }
     else
     {
-      dprint (1, (debugfile, "read_mime_header: bogus MIME header: %s\n", line));
+      mutt_debug (1, "read_mime_header: bogus MIME header: %s\n", line);
       break;
     }
 
@@ -811,7 +812,7 @@ time_t mutt_parse_date (const char *s, HEADER *h)
 	  sec = 0;
 	else
 	{
-	  dprint(1, (debugfile, "parse_date: could not process time format: %s\n", t));
+	  mutt_debug (1, "parse_date: could not process time format: %s\n", t);
 	  return(-1);
 	}
 	tm.tm_hour = hour;
@@ -876,7 +877,7 @@ time_t mutt_parse_date (const char *s, HEADER *h)
 
   if (count < 4) /* don't check for missing timezone */
   {
-    dprint(1,(debugfile, "parse_date(): error parsing date format, using received time\n"));
+    mutt_debug (1, "parse_date(): error parsing date format, using received time\n");
     return (-1);
   }
 
@@ -1524,7 +1525,7 @@ ENVELOPE *mutt_read_rfc822_header (FILE *f, HEADER *hdr, short user_hdrs,
 	}
 
 	if (e->spam && e->spam->data)
-          dprint(5, (debugfile, "p822: spam = %s\n", e->spam->data));
+          mutt_debug (5, "p822: spam = %s\n", e->spam->data);
       }
     }
 
@@ -1568,14 +1569,14 @@ ENVELOPE *mutt_read_rfc822_header (FILE *f, HEADER *hdr, short user_hdrs,
 
     if (hdr->received < 0)
     {
-      dprint(1,(debugfile,"read_rfc822_header(): resetting invalid received time to 0\n"));
+      mutt_debug (1, "read_rfc822_header(): resetting invalid received time to 0\n");
       hdr->received = 0;
     }
 
     /* check for missing or invalid date */
     if (hdr->date_sent <= 0)
     {
-      dprint(1,(debugfile,"read_rfc822_header(): no date found, using received time from msg separator\n"));
+      mutt_debug (1, "read_rfc822_header(): no date found, using received time from msg separator\n");
       hdr->date_sent = hdr->received;
     }
   }
@@ -1623,18 +1624,18 @@ static int count_body_parts_check(LIST **checklist, BODY *b, int dflt)
   for (type = *checklist; type; type = type->next)
   {
     a = (ATTACH_MATCH *)type->data;
-    dprint(5, (debugfile, "cbpc: %s %d/%s ?? %s/%s [%d]... ",
-		dflt ? "[OK]   " : "[EXCL] ",
-		b->type, b->subtype, a->major, a->minor, a->major_int));
+    mutt_debug (5, "cbpc: %s %d/%s ?? %s/%s [%d]... ",
+                dflt ? "[OK]   " : "[EXCL] ",
+                b->type, b->subtype, a->major, a->minor, a->major_int);
     if ((a->major_int == TYPEANY || a->major_int == b->type) &&
 	!regexec(&a->minor_rx, b->subtype, 0, NULL, 0))
     {
-      dprint(5, (debugfile, "yes\n"));
+      mutt_debug (5, "yes\n");
       return 1;
     }
     else
     {
-      dprint(5, (debugfile, "no\n"));
+      mutt_debug (5, "no\n");
     }
   }
 
@@ -1659,11 +1660,11 @@ static int count_body_parts (BODY *body, int flags)
     AT_COUNT("default");
     shallrecurse = 0;
 
-    dprint(5, (debugfile, "bp: desc=\"%s\"; fn=\"%s\", type=\"%d/%s\"\n",
-	   bp->description ? bp->description : ("none"),
-	   bp->filename ? bp->filename :
-			bp->d_filename ? bp->d_filename : "(none)",
-	   bp->type, bp->subtype ? bp->subtype : "*"));
+    mutt_debug (5, "bp: desc=\"%s\"; fn=\"%s\", type=\"%d/%s\"\n",
+                bp->description ? bp->description : ("none"),
+                bp->filename ? bp->filename :
+                  bp->d_filename ? bp->d_filename : "(none)",
+                bp->type, bp->subtype ? bp->subtype : "*");
 
     if (bp->type == TYPEMESSAGE)
     {
@@ -1723,18 +1724,18 @@ static int count_body_parts (BODY *body, int flags)
       count++;
     bp->attach_qualifies = shallcount ? 1 : 0;
 
-    dprint(5, (debugfile, "cbp: %p shallcount = %d\n", (void *)bp, shallcount));
+    mutt_debug (5, "cbp: %p shallcount = %d\n", (void *)bp, shallcount);
 
     if (shallrecurse)
     {
-      dprint(5, (debugfile, "cbp: %p pre count = %d\n", (void *)bp, count));
+      mutt_debug (5, "cbp: %p pre count = %d\n", (void *)bp, count);
       bp->attach_count = count_body_parts(bp->parts, flags & ~MUTT_PARTS_TOPLEVEL);
       count += bp->attach_count;
-      dprint(5, (debugfile, "cbp: %p post count = %d\n", (void *)bp, count));
+      mutt_debug (5, "cbp: %p post count = %d\n", (void *)bp, count);
     }
   }
 
-  dprint(5, (debugfile, "bp: return %d\n", count < 0 ? 0 : count));
+  mutt_debug (5, "bp: return %d\n", count < 0 ? 0 : count);
   return count < 0 ? 0 : count;
 }
 

--- a/pattern.c
+++ b/pattern.c
@@ -475,7 +475,7 @@ report_regerror(int regerr, regex_t *preg, BUFFER *err)
   size_t ds = err->dsize;
 
   if (regerror(regerr, preg, err->data, ds) > ds)
-    dprint(2, (debugfile, "warning: buffer too small for regerror\n"));
+    mutt_debug (2, "warning: buffer too small for regerror\n");
   /* The return value is fixed, exists only to shorten code at callsite */
   return RANGE_E_SYNTAX;
 }
@@ -590,7 +590,7 @@ eat_range_by_regexp (pattern_t *pat, BUFFER *s, int kind, BUFFER *err)
   /* Snarf the contents of the two sides of the range. */
   pat->min = scan_range_slot(s, pmatch, pspec->lgrp, RANGE_S_LEFT, kind);
   pat->max = scan_range_slot(s, pmatch, pspec->rgrp, RANGE_S_RIGHT, kind);
-  dprint(1, (debugfile, "pat->min=%d pat->max=%d\n", pat->min, pat->max));
+  mutt_debug (1, "pat->min=%d pat->max=%d\n", pat->min, pat->max);
 
   /* Special case for a bare 0. */
   if ((kind == RANGE_K_BARE) && (pat->min == 0) && (pat->max == 0))

--- a/pgp.c
+++ b/pgp.c
@@ -199,13 +199,12 @@ static int pgp_copy_checksig (FILE *fpin, FILE *fpout)
     {
       if (regexec (PgpGoodSign.rx, line, 0, NULL, 0) == 0)
       {
-	dprint (2, (debugfile, "pgp_copy_checksig: \"%s\" matches regexp.\n",
-		    line));
+        mutt_debug (2, "pgp_copy_checksig: \"%s\" matches regexp.\n", line);
 	rv = 0;
       }
       else
-	dprint (2, (debugfile, "pgp_copy_checksig: \"%s\" doesn't match regexp.\n",
-		    line));
+        mutt_debug (2, "pgp_copy_checksig: \"%s\" doesn't match regexp.\n",
+                    line);
       
       if (strncmp (line, "[GNUPG:] ", 9) == 0)
 	continue;
@@ -216,7 +215,7 @@ static int pgp_copy_checksig (FILE *fpin, FILE *fpout)
   }
   else
   {
-    dprint (2, (debugfile, "pgp_copy_checksig: No pattern.\n"));
+    mutt_debug (2, "pgp_copy_checksig: No pattern.\n");
     mutt_copy_stream (fpin, fpout);
     rv = 1;
   }
@@ -242,20 +241,20 @@ static int pgp_check_decryption_okay (FILE *fpin)
     {
       if (regexec (PgpDecryptionOkay.rx, line, 0, NULL, 0) == 0)
       {
-        dprint (2, (debugfile, "pgp_check_decryption_okay: \"%s\" matches regexp.\n",
-                    line));
+        mutt_debug (2, "pgp_check_decryption_okay: \"%s\" matches regexp.\n",
+                    line);
         rv = 0;
         break;
       }
       else
-        dprint (2, (debugfile, "pgp_check_decryption_okay: \"%s\" doesn't match regexp.\n",
-                    line));
+        mutt_debug (2, "pgp_check_decryption_okay: \"%s\" doesn't match regexp.\n",
+                    line);
     }
     FREE (&line);
   }
   else
   {
-    dprint (2, (debugfile, "pgp_check_decryption_okay: No pattern.\n"));
+    mutt_debug (2, "pgp_check_decryption_okay: No pattern.\n");
     rv = 1;
   }
 
@@ -535,8 +534,8 @@ int pgp_application_pgp_handler (BODY *m, STATE *s)
 	int c;
 	char *expected_charset = gpgcharset && *gpgcharset ? gpgcharset : "utf-8";
 
-	dprint(4,(debugfile,"pgp: recoding inline from [%s] to [%s]\n",
-		  expected_charset, Charset));
+	mutt_debug (4, "pgp: recoding inline from [%s] to [%s]\n",
+	            expected_charset, Charset);
 
 	rewind (pgpout);
 	state_set_prefix (s);
@@ -744,7 +743,7 @@ int pgp_verify_one (BODY *sigbdy, STATE *s, const char *tempfile)
     if ((rv = mutt_wait_filter (thepid)))
       badsig = -1;
     
-     dprint (1, (debugfile, "pgp_verify_one: mutt_wait_filter returned %d.\n", rv));
+     mutt_debug (1, "pgp_verify_one: mutt_wait_filter returned %d.\n", rv);
   }
 
   safe_fclose (&pgperr);
@@ -754,7 +753,7 @@ int pgp_verify_one (BODY *sigbdy, STATE *s, const char *tempfile)
   mutt_unlink (sigfile);
   mutt_unlink (pgperrfile);
 
-  dprint (1, (debugfile, "pgp_verify_one: returning %d.\n", badsig));
+  mutt_debug (1, "pgp_verify_one: returning %d.\n", badsig);
   
   return badsig;
 }

--- a/pgpinvoke.c
+++ b/pgpinvoke.c
@@ -151,7 +151,7 @@ const char *_mutt_fmt_pgp_command (char *dest,
 void mutt_pgp_command (char *d, size_t dlen, struct pgp_command_context *cctx, const char *fmt)
 {
   mutt_FormatString (d, dlen, 0, MuttIndexWindow->cols, NONULL (fmt), _mutt_fmt_pgp_command, (unsigned long) cctx, 0);
-  dprint (2, (debugfile, "mutt_pgp_command: %s\n", d));
+  mutt_debug (2, "mutt_pgp_command: %s\n", d);
 }
 
 /*

--- a/pgpkey.c
+++ b/pgpkey.c
@@ -843,21 +843,20 @@ pgp_key_t pgp_getkeybyaddr (ADDRESS * a, short abilities, pgp_ring_t keyring,
   if (!keys)
     return NULL;
 
-  dprint (5, (debugfile, "pgp_getkeybyaddr: looking for %s <%s>.",
-	      a->personal, a->mailbox));
+  mutt_debug (5, "pgp_getkeybyaddr: looking for %s <%s>.",
+              a->personal, a->mailbox);
 
 
   for (k = keys; k; k = kn)
   {
     kn = k->next;
 
-    dprint (5, (debugfile, "  looking at key: %s\n",
-		pgp_keyid (k)));
+    mutt_debug (5, "  looking at key: %s\n", pgp_keyid (k));
 
     if (abilities && !(k->flags & abilities))
     {
-      dprint (5, (debugfile, "  insufficient abilities: Has %x, want %x\n",
-		  k->flags, abilities));
+      mutt_debug (5, "  insufficient abilities: Has %x, want %x\n",
+                  k->flags, abilities);
       continue;
     }
 
@@ -986,26 +985,26 @@ pgp_key_t pgp_getkeybystr (char *p, short abilities, pgp_ring_t keyring)
 
     match = 0;
 
-    dprint (5, (debugfile, "pgp_getkeybystr: matching \"%s\" against key %s:\n",
-                p, pgp_long_keyid (k)));
+    mutt_debug (5, "pgp_getkeybystr: matching \"%s\" against key %s:\n",
+                p, pgp_long_keyid (k));
 
     if (!*p ||
         (pfcopy && mutt_strcasecmp (pfcopy, k->fingerprint) == 0) ||
         (pl && mutt_strcasecmp (pl, pgp_long_keyid (k)) == 0) ||
         (ps && mutt_strcasecmp (ps, pgp_short_keyid (k)) == 0))
     {
-      dprint (5, (debugfile, "\t\tmatch.\n"));
+      mutt_debug (5, "\t\tmatch.\n");
       match = 1;
     }
     else
     {
       for (a = k->address; a; a = a->next)
       {
-        dprint (5, (debugfile, "pgp_getkeybystr: matching \"%s\" against key %s, \"%s\":\n",
-                    p, pgp_long_keyid (k), NONULL (a->addr)));
+        mutt_debug (5, "pgp_getkeybystr: matching \"%s\" against key %s, \"%s\":\n",
+                    p, pgp_long_keyid (k), NONULL (a->addr));
         if (mutt_stristr (a->addr, p))
         {
-          dprint (5, (debugfile, "\t\tmatch.\n"));
+          mutt_debug (5, "\t\tmatch.\n");
           match = 1;
           break;
         }

--- a/pgpmicalg.c
+++ b/pgpmicalg.c
@@ -87,7 +87,7 @@ static void pgp_dearmor (FILE *in, FILE *out)
   }
   if (r == NULL)
   {
-    dprint (1, (debugfile, "pgp_dearmor: Can't find begin of ASCII armor.\n"));
+    mutt_debug (1, "pgp_dearmor: Can't find begin of ASCII armor.\n");
     return;
   }
 
@@ -100,7 +100,7 @@ static void pgp_dearmor (FILE *in, FILE *out)
   }
   if (r == NULL)
   {
-    dprint (1, (debugfile, "pgp_dearmor: Armor header doesn't end.\n"));
+    mutt_debug (1, "pgp_dearmor: Armor header doesn't end.\n");
     return;
   }
   
@@ -116,19 +116,19 @@ static void pgp_dearmor (FILE *in, FILE *out)
   }
   if (r == NULL)
   {
-    dprint (1, (debugfile, "pgp_dearmor: Can't find end of ASCII armor.\n"));
+    mutt_debug (1, "pgp_dearmor: Can't find end of ASCII armor.\n");
     return;
   }
   
   if ((end = ftello (in) - strlen (line)) < start)
   {
-    dprint (1, (debugfile, "pgp_dearmor: end < start???\n"));
+    mutt_debug (1, "pgp_dearmor: end < start???\n");
     return;
   }
   
   if (fseeko (in, start, SEEK_SET) == -1)
   {
-    dprint (1, (debugfile, "pgp_dearmor: Can't seekto start.\n"));
+    mutt_debug (1, "pgp_dearmor: Can't seekto start.\n");
     return;
   }
 
@@ -140,8 +140,8 @@ static short pgp_mic_from_packet (unsigned char *p, size_t len)
   /* is signature? */
   if ((p[0] & 0x3f) != PT_SIG)
   {
-    dprint (1, (debugfile, "pgp_mic_from_packet: tag = %d, want %d.\n",
-		p[0]&0x3f, PT_SIG));
+    mutt_debug (1, "pgp_mic_from_packet: tag = %d, want %d.\n",
+                p[0]&0x3f, PT_SIG);
     return -1;
   }
   
@@ -153,7 +153,7 @@ static short pgp_mic_from_packet (unsigned char *p, size_t len)
     return (short) p[4];
   else
   {
-    dprint (1, (debugfile, "pgp_mic_from_packet: Bad signature packet.\n"));
+    mutt_debug (1, "pgp_mic_from_packet: Bad signature packet.\n");
     return -1;
   }
 }
@@ -193,7 +193,7 @@ static short pgp_find_hash (const char *fname)
   }
   else
   {
-    dprint (1, (debugfile, "pgp_find_hash: No packet.\n"));
+    mutt_debug (1, "pgp_find_hash: No packet.\n");
   }
   
   bye:

--- a/pop.c
+++ b/pop.c
@@ -90,14 +90,14 @@ static int pop_read_header (POP_DATA *pop_data, HEADER *h)
       {
 	pop_data->cmd_top = 1;
 
-	dprint (1, (debugfile, "pop_read_header: set TOP capability\n"));
+        mutt_debug (1, "pop_read_header: set TOP capability\n");
       }
 
       if (ret == -2)
       {
 	pop_data->cmd_top = 0;
 
-	dprint (1, (debugfile, "pop_read_header: unset TOP capability\n"));
+	mutt_debug (1, "pop_read_header: unset TOP capability\n");
 	snprintf (pop_data->err_msg, sizeof (pop_data->err_msg),
 		_("Command TOP is not supported by server."));
       }
@@ -158,7 +158,7 @@ static int fetch_uidl (char *line, void *data)
 
   if (i == ctx->msgcount)
   {
-    dprint (1, (debugfile, "pop_fetch_headers: new header %d %s\n", index, line));
+    mutt_debug (1, "pop_fetch_headers: new header %d %s\n", index, line);
 
     if (i >= ctx->hdrmax)
       mx_alloc_memory(ctx);
@@ -264,14 +264,14 @@ static int pop_fetch_headers (CONTEXT *ctx)
     {
       pop_data->cmd_uidl = 1;
 
-      dprint (1, (debugfile, "pop_fetch_headers: set UIDL capability\n"));
+      mutt_debug (1, "pop_fetch_headers: set UIDL capability\n");
     }
 
     if (ret == -2 && pop_data->cmd_uidl == 2)
     {
       pop_data->cmd_uidl = 0;
 
-      dprint (1, (debugfile, "pop_fetch_headers: unset UIDL capability\n"));
+      mutt_debug (1, "pop_fetch_headers: unset UIDL capability\n");
       snprintf (pop_data->err_msg, sizeof (pop_data->err_msg),
 	      _("Command UIDL is not supported by server."));
     }
@@ -475,7 +475,7 @@ static void pop_clear_cache (POP_DATA *pop_data)
   if (!pop_data->clear_cache)
     return;
 
-  dprint (1, (debugfile, "pop_clear_cache: delete cached messages\n"));
+  mutt_debug (1, "pop_clear_cache: delete cached messages\n");
 
   for (i = 0; i < POP_CACHE_LEN; i++)
   {

--- a/pop_auth.c
+++ b/pop_auth.c
@@ -51,7 +51,7 @@ static pop_auth_res_t pop_auth_sasl (POP_DATA *pop_data, const char *method)
 
   if (mutt_sasl_client_new (pop_data->conn, &saslconn) < 0)
   {
-    dprint (1, (debugfile, "pop_auth_sasl: Error allocating SASL connection.\n"));
+    mutt_debug (1, "pop_auth_sasl: Error allocating SASL connection.\n");
     return POP_A_FAILURE;
   }
 
@@ -68,7 +68,8 @@ static pop_auth_res_t pop_auth_sasl (POP_DATA *pop_data, const char *method)
 
   if (rc != SASL_OK && rc != SASL_CONTINUE)
   {
-    dprint (1, (debugfile, "pop_auth_sasl: Failure starting authentication exchange. No shared mechanisms?\n"));
+    mutt_debug (1, "pop_auth_sasl: Failure starting authentication exchange. "
+                "No shared mechanisms?\n");
 
     /* SASL doesn't support suggested mechanisms, so fall back */
     return POP_A_UNAVAIL;
@@ -112,7 +113,7 @@ static pop_auth_res_t pop_auth_sasl (POP_DATA *pop_data, const char *method)
     if (!mutt_strncmp (inbuf, "+ ", 2)
         && sasl_decode64 (inbuf+2, strlen (inbuf+2), buf, bufsize - 1, &len) != SASL_OK)
     {
-      dprint (1, (debugfile, "pop_auth_sasl: error base64-decoding server response.\n"));
+      mutt_debug (1, "pop_auth_sasl: error base64-decoding server response.\n");
       goto bail;
     }
 
@@ -146,7 +147,7 @@ static pop_auth_res_t pop_auth_sasl (POP_DATA *pop_data, const char *method)
       }
       if (sasl_encode64 (pc, olen, buf, bufsize, &olen) != SASL_OK)
       {
-	dprint (1, (debugfile, "pop_auth_sasl: error base64-encoding client response.\n"));
+        mutt_debug (1, "pop_auth_sasl: error base64-encoding client response.\n");
 	goto bail;
       }
     }
@@ -266,14 +267,14 @@ static pop_auth_res_t pop_auth_user (POP_DATA *pop_data, const char *method)
     {
       pop_data->cmd_user = 1;
 
-      dprint (1, (debugfile, "pop_auth_user: set USER capability\n"));
+      mutt_debug (1, "pop_auth_user: set USER capability\n");
     }
 
     if (ret == -2)
     {
       pop_data->cmd_user = 0;
 
-      dprint (1, (debugfile, "pop_auth_user: unset USER capability\n"));
+      mutt_debug (1, "pop_auth_user: unset USER capability\n");
       snprintf (pop_data->err_msg, sizeof (pop_data->err_msg),
               _("Command USER is not supported by server."));
     }
@@ -345,7 +346,7 @@ int pop_authenticate (POP_DATA* pop_data)
       comma = strchr (method, ':');
       if (comma)
 	*comma++ = '\0';
-      dprint (2, (debugfile, "pop_authenticate: Trying method %s\n", method));
+      mutt_debug (2, "pop_authenticate: Trying method %s\n", method);
       authenticator = pop_authenticators;
 
       while (authenticator->authenticate)
@@ -386,7 +387,7 @@ int pop_authenticate (POP_DATA* pop_data)
   else
   {
     /* Fall back to default: any authenticator */
-    dprint (2, (debugfile, "pop_authenticate: Using any available method.\n"));
+    mutt_debug (2, "pop_authenticate: Using any available method.\n");
     authenticator = pop_authenticators;
 
     while (authenticator->authenticate)

--- a/pop_lib.c
+++ b/pop_lib.c
@@ -429,7 +429,7 @@ int pop_query_d (POP_DATA *pop_data, char *buf, size_t buflen, char *msg)
     if (msg)
     {
       dbg = MUTT_SOCK_LOG_FULL;
-      dprint (MUTT_SOCK_LOG_CMD, (debugfile, "> %s", msg));
+      mutt_debug (MUTT_SOCK_LOG_CMD, "> %s", msg);
     }
 #endif
 

--- a/postpone.c
+++ b/postpone.c
@@ -92,10 +92,11 @@ int mutt_num_postponed (int force)
       if (newpc >= 0)
       {
 	PostCount = newpc;
-	dprint (3, (debugfile, "mutt_num_postponed: %d postponed IMAP messages found.\n", PostCount));
+        mutt_debug (3, "mutt_num_postponed: %d postponed IMAP messages found.\n",
+                    PostCount);
       }
       else
-	dprint (3, (debugfile, "mutt_num_postponed: using old IMAP postponed count.\n"));
+        mutt_debug (3, "mutt_num_postponed: using old IMAP postponed count.\n");
     }
     return PostCount;
   }

--- a/query.c
+++ b/query.c
@@ -107,7 +107,7 @@ static QUERY *run_query (char *s, int quiet)
 
   if ((thepid = mutt_create_filter (cmd, NULL, &fp, NULL)) < 0)
   {
-    dprint (1, (debugfile, "unable to fork command: %s", cmd));
+    mutt_debug (1, "unable to fork command: %s", cmd);
     return 0;
   }
   if (!quiet)
@@ -145,7 +145,7 @@ static QUERY *run_query (char *s, int quiet)
   safe_fclose (&fp);
   if (mutt_wait_filter (thepid))
   {
-    dprint (1, (debugfile, "Error: %s\n", msg));
+    mutt_debug (1, "Error: %s\n", msg);
     if (!quiet)  mutt_error ("%s", msg);
   }
   else

--- a/recvattach.c
+++ b/recvattach.c
@@ -300,7 +300,8 @@ const char *mutt_attach_fmt (char *dest,
 	  ch = dispchar[aptr->content->disposition];
 	else
 	{
-	  dprint(1, (debugfile, "ERROR: invalid content-disposition %d\n", aptr->content->disposition));
+	  mutt_debug (1, "ERROR: invalid content-disposition %d\n",
+	              aptr->content->disposition);
 	  ch = '!';
 	}
 	snprintf (dest, destlen, "%c", ch);

--- a/rfc1524.c
+++ b/rfc1524.c
@@ -209,7 +209,7 @@ static int rfc1524_mailcap_parse (BODY *a,
       /* ignore comments */
       if (*buf == '#')
 	continue;
-      dprint (2, (debugfile, "mailcap entry: %s\n", buf));
+      mutt_debug (2, "mailcap entry: %s\n", buf);
 
       /* check type */
       ch = get_field (buf);
@@ -236,7 +236,7 @@ static int rfc1524_mailcap_parse (BODY *a,
       {
 	field = ch;
 	ch = get_field (ch);
-	dprint (2, (debugfile, "field: %s\n", field));
+	mutt_debug (2, "field: %s\n", field);
 
 	if (!ascii_strcasecmp (field, "needsterminal"))
 	{
@@ -416,7 +416,7 @@ int rfc1524_mailcap_lookup (BODY *a, char *type, rfc1524_entry *entry, int opt)
     path[x] = '\0';
     mutt_expand_path (path, sizeof (path));
 
-    dprint(2,(debugfile,"Checking mailcap file: %s\n",path));
+    mutt_debug (2, "Checking mailcap file: %s\n",path);
     found = rfc1524_mailcap_parse (a, path, type, entry, opt);
   }
 

--- a/rfc3676.c
+++ b/rfc3676.c
@@ -188,18 +188,18 @@ static void print_flowed_line (char *line, STATE *s, int ql,
   width = quote_width (s, ql);
   last = line[mutt_strlen (line) - 1];
 
-  dprint (4, (debugfile, "f=f: line [%s], width = %ld, spaces = %d\n",
-	      NONULL(line), (long)width, fst->spaces));
+  mutt_debug (4, "f=f: line [%s], width = %ld, spaces = %d\n",
+              NONULL(line), (long)width, fst->spaces);
 
   for (p = (char *)line, words = 0; (p = strsep (&line, " ")) != NULL ; )
   {
-    dprint(4,(debugfile,"f=f: word [%s], width: %d, remaining = [%s]\n",
-	      p, fst->width, line));
+    mutt_debug (4, "f=f: word [%s], width: %d, remaining = [%s]\n",
+                p, fst->width, line);
 
     /* remember number of spaces */
     if (!*p)
     {
-      dprint(4,(debugfile,"f=f: additional space\n"));
+      mutt_debug (4, "f=f: additional space\n");
       fst->spaces++;
       continue;
     }
@@ -216,8 +216,8 @@ static void print_flowed_line (char *line, STATE *s, int ql,
     if (!(!fst->spaces && fst->delsp && last != ' ') &&
 	w < width && w + fst->width + fst->spaces > width)
     {
-      dprint(4,(debugfile,"f=f: break line at %d, %d spaces left\n",
-		fst->width, fst->spaces));
+      mutt_debug (4, "f=f: break line at %d, %d spaces left\n",
+                  fst->width, fst->spaces);
       /* only honor trailing spaces for format=flowed replies */
       if (option(OPTTEXTFLOWED))
 	for ( ; fst->spaces; fst->spaces--)
@@ -271,7 +271,7 @@ int rfc3676_handler (BODY * a, STATE * s)
     fst.delsp = 1;
   }
 
-  dprint (4, (debugfile, "f=f: DelSp: %s\n", delsp ? "yes" : "no"));
+  mutt_debug (4, "f=f: DelSp: %s\n", delsp ? "yes" : "no");
 
   while ((buf = mutt_read_line (buf, &sz, s->fpin, NULL, 0)))
   {
@@ -349,7 +349,7 @@ void rfc3676_space_stuff (HEADER* hdr)
   if (!hdr || !hdr->content || !hdr->content->filename)
     return;
 
-  dprint (2, (debugfile, "f=f: postprocess %s\n", hdr->content->filename));
+  mutt_debug (2, "f=f: postprocess %s\n", hdr->content->filename);
 
   if ((in = safe_fopen (hdr->content->filename, "r")) == NULL)
     return;
@@ -373,8 +373,8 @@ void rfc3676_space_stuff (HEADER* hdr)
         c = buf[len-1];
         buf[len-1] = '\0';
       }
-      dprint (4, (debugfile, "f=f: line %d needs space-stuffing: '%s'\n",
-                  lc, buf));
+      mutt_debug (4, "f=f: line %d needs space-stuffing: '%s'\n",
+                  lc, buf);
       if (len > 0)
         buf[len-1] = c;
 #endif

--- a/send.c
+++ b/send.c
@@ -1421,7 +1421,8 @@ ci_send_message (int flags,		/* send mode */
 
     if (!tempfp)
     {
-      dprint(1,(debugfile, "newsend_message: can't create tempfile %s (errno=%d)\n", msg->content->filename, errno));
+      mutt_debug (1, "newsend_message: can't create tempfile %s (errno=%d)\n",
+                  msg->content->filename, errno);
       mutt_perror (msg->content->filename);
       goto cleanup;
     }
@@ -1443,7 +1444,8 @@ ci_send_message (int flags,		/* send mode */
      */
 
     if (msg->env->from)
-        dprint (5, (debugfile, "ci_send_message: msg->env->from before set_reverse_name: %s\n", msg->env->from->mailbox));
+        mutt_debug (5, "ci_send_message: msg->env->from before set_reverse_name: %s\n",
+                    msg->env->from->mailbox);
     msg->env->from = set_reverse_name (cur->env);
   }
   if (cur && option (OPTREPLYWITHXORIG) && !(flags & (SENDPOSTPONED|SENDRESEND|SENDFORWARD)))
@@ -1462,7 +1464,8 @@ ci_send_message (int flags,		/* send mode */
       msg->env->from = cur->env->x_original_to;
       /* Not more than one from address */
       msg->env->from->next = NULL;
-      dprint (5, (debugfile, "ci_send_message: msg->env->from extracted from X-Original-To: header: %s\n", msg->env->from->mailbox));
+      mutt_debug (5, "ci_send_message: msg->env->from extracted from X-Original-To: header: %s\n",
+                  msg->env->from->mailbox);
     }
   }
 

--- a/sendlib.c
+++ b/sendlib.c
@@ -404,7 +404,7 @@ int mutt_write_mime_header (BODY *a, FILE *f)
     }
     else
     {
-      dprint(1, (debugfile, "ERROR: invalid content-disposition %d\n", a->disposition));
+      mutt_debug (1, "ERROR: invalid content-disposition %d\n", a->disposition);
     }
   }
 
@@ -432,7 +432,7 @@ int mutt_write_mime_body (BODY *a, FILE *f)
     /* First, find the boundary to use */
     if (!(p = mutt_get_parameter ("boundary", a->parameter)))
     {
-      dprint (1, (debugfile, "mutt_write_mime_body(): no boundary parameter found!\n"));
+      mutt_debug (1, "mutt_write_mime_body(): no boundary parameter found!\n");
       mutt_error (_("No boundary parameter found! [report this error]"));
       return (-1);
     }
@@ -462,7 +462,7 @@ int mutt_write_mime_body (BODY *a, FILE *f)
 
   if ((fpin = fopen (a->filename, "r")) == NULL)
   {
-    dprint(1,(debugfile, "write_mime_body: %s no longer exists!\n",a->filename));
+    mutt_debug (1, "write_mime_body: %s no longer exists!\n",a->filename);
     mutt_error (_("%s no longer exists!"), a->filename);
     return -1;
   }
@@ -892,8 +892,8 @@ CONTENT *mutt_get_content_info (const char *fname, BODY *b)
 
   if ((fp = fopen (fname, "r")) == NULL)
   {
-    dprint (1, (debugfile, "mutt_get_content_info: %s: %s (errno %d).\n",
-		fname, strerror (errno), errno));
+    mutt_debug (1, "mutt_get_content_info: %s: %s (errno %d).\n",
+                fname, strerror (errno), errno);
     return (NULL);
   }
 
@@ -979,7 +979,8 @@ int mutt_lookup_mime_type (BODY *att, const char *path)
 	strfcpy (buf, PKGDATADIR"/mime.types", sizeof (buf));
 	break;
       default:
-        dprint (1, (debugfile, "mutt_lookup_mime_type: Internal error, count = %d.\n", count));
+        mutt_debug (1, "mutt_lookup_mime_type: Internal error, count = %d.\n",
+                    count);
 	goto bye;	/* shouldn't happen */
     }
 
@@ -1674,8 +1675,8 @@ static int fold_one_header (FILE *fp, const char *tag, const char *value,
   char buf[HUGE_STRING] = "";
   int first = 1, enc, col = 0, w, l = 0, fold;
 
-  dprint(4,(debugfile,"mwoh: pfx=[%s], tag=[%s], flags=%d value=[%s]\n",
-	    pfx, tag, flags, value));
+  mutt_debug (4, "mwoh: pfx=[%s], tag=[%s], flags=%d value=[%s]\n",
+              pfx, tag, flags, value);
 
   if (tag && *tag && fprintf (fp, "%s%s: ", NONULL (pfx), tag) < 0)
     return -1;
@@ -1697,8 +1698,8 @@ static int fold_one_header (FILE *fp, const char *tag, const char *value,
     w = my_width (buf, col, flags);
     enc = mutt_strncmp (buf, "=?", 2) == 0;
 
-    dprint(5,(debugfile,"mwoh: word=[%s], col=%d, w=%d, next=[0x0%x]\n",
-	      buf, col, w, *next));
+    mutt_debug (5, "mwoh: word=[%s], col=%d, w=%d, next=[0x0%x]\n",
+                buf, col, w, *next);
 
     /* insert a folding \n before the current word's lwsp except for
      * header name, first word on a line (word longer than wrap width)
@@ -1801,16 +1802,15 @@ static int write_one_header (FILE *fp, int pfxw, int max, int wraplen,
   if (!(flags & CH_DISPLAY) && (pfxw + max <= wraplen || is_from))
   {
     valbuf = mutt_substrdup (start, end);
-    dprint(4,(debugfile,"mwoh: buf[%s%s] short enough, "
-	      "max width = %d <= %d\n",
-	      NONULL(pfx), valbuf, max, wraplen));
+    mutt_debug (4, "mwoh: buf[%s%s] short enough, "
+                "max width = %d <= %d\n",
+                NONULL(pfx), valbuf, max, wraplen);
     if (pfx && *pfx)
       if (fputs (pfx, fp) == EOF)
 	return -1;
     if (!(t = strchr (valbuf, ':')))
     {
-      dprint (1, (debugfile, "mwoh: warning: header not in "
-		  "'key: value' format!\n"));
+      mutt_debug (1, "mwoh: warning: header not in 'key: value' format!\n");
       return 0;
     }
     if (print_val (fp, pfx, valbuf, flags, mutt_strlen (pfx)) < 0)
@@ -1825,8 +1825,7 @@ static int write_one_header (FILE *fp, int pfxw, int max, int wraplen,
     t = strchr (start, ':');
     if (!t || t > end)
     {
-      dprint (1, (debugfile, "mwoh: warning: header not in "
-		  "'key: value' format!\n"));
+      mutt_debug (1, "mwoh: warning: header not in 'key: value' format!\n");
       return 0;
     }
     if (is_from)
@@ -1848,9 +1847,8 @@ static int write_one_header (FILE *fp, int pfxw, int max, int wraplen,
 
       valbuf = mutt_substrdup (t, end);
     }
-    dprint(4,(debugfile,"mwoh: buf[%s%s] too long, "
-	      "max width = %d > %d\n",
-	      NONULL(pfx), valbuf, max, wraplen));
+    mutt_debug (4, "mwoh: buf[%s%s] too long, max width = %d > %d\n",
+                NONULL(pfx), valbuf, max, wraplen);
     if (fold_one_header (fp, tagbuf, valbuf, pfx, wraplen, flags) < 0)
       return -1;
     FREE (&tagbuf);
@@ -1889,8 +1887,8 @@ int mutt_write_one_header (FILE *fp, const char *tag, const char *value,
     if (!(flags & CH_DISPLAY) && mutt_strwidth (tag) + 2 + pfxw +
 	mutt_strwidth (v) <= wraplen)
     {
-      dprint(4,(debugfile,"mwoh: buf[%s%s: %s] is short enough\n",
-		NONULL(pfx), tag, v));
+      mutt_debug (4, "mwoh: buf[%s%s: %s] is short enough\n",
+                  NONULL(pfx), tag, v);
       if (fprintf (fp, "%s%s: %s\n", NONULL(pfx), tag, v) <= 0)
 	goto out;
       rc = 0;
@@ -2765,8 +2763,7 @@ ADDRESS *mutt_remove_duplicates (ADDRESS *addr)
 
     if (dup)
     {
-      dprint (2, (debugfile, "mutt_remove_duplicates: Removing %s\n",
-		  addr->mailbox));
+      mutt_debug (2, "mutt_remove_duplicates: Removing %s\n", addr->mailbox);
 
       *last = addr->next;
 
@@ -2813,7 +2810,7 @@ int mutt_write_multiple_fcc (const char *path, HEADER *hdr, const char *msgid,
   strfcpy(fcc_tok, path, sizeof (fcc_tok));
 
   tok = strtok(fcc_tok, ",");
-  dprint(1, (debugfile, "Fcc: initial mailbox = '%s'\n", tok));
+  mutt_debug (1, "Fcc: initial mailbox = '%s'\n", tok);
   /* mutt_expand_path already called above for the first token */
   status = mutt_write_fcc (tok, hdr, msgid, post, fcc, finalpath);
   if (status != 0)
@@ -2825,10 +2822,10 @@ int mutt_write_multiple_fcc (const char *path, HEADER *hdr, const char *msgid,
       continue;
 
     /* Only call mutt_expand_path iff tok has some data */
-    dprint (1, (debugfile, "Fcc: additional mailbox token = '%s'\n", tok));
+    mutt_debug (1, "Fcc: additional mailbox token = '%s'\n", tok);
     strfcpy (fcc_expanded, tok, sizeof (fcc_expanded));
     mutt_expand_path (fcc_expanded, sizeof (fcc_expanded));
-    dprint (1, (debugfile, "     Additional mailbox expanded = '%s'\n", fcc_expanded));
+    mutt_debug (1, "     Additional mailbox expanded = '%s'\n", fcc_expanded);
     status = mutt_write_fcc (fcc_expanded, hdr, msgid, post, fcc, finalpath);
     if (status != 0)
       return status;
@@ -2854,8 +2851,8 @@ int mutt_write_fcc (const char *path, HEADER *hdr, const char *msgid,
 
   if (mx_open_mailbox (path, MUTT_APPEND | MUTT_QUIET, &f) == NULL)
   {
-    dprint (1, (debugfile, "mutt_write_fcc(): unable to open mailbox %s in append-mode, aborting.\n",
-		path));
+    mutt_debug (1, "mutt_write_fcc(): unable to open mailbox %s in append-mode, aborting.\n",
+                path);
     return (-1);
   }
 
@@ -2994,7 +2991,7 @@ int mutt_write_fcc (const char *path, HEADER *hdr, const char *msgid,
     fflush (tempfp);
     if (ferror (tempfp))
     {
-      dprint (1, (debugfile, "mutt_write_fcc(): %s: write failed.\n", tempfile));
+      mutt_debug (1, "mutt_write_fcc(): %s: write failed.\n", tempfile);
       safe_fclose (&tempfp);
       unlink (tempfile);
       mx_commit_message (msg, &f);	/* XXX - really? */

--- a/smime.c
+++ b/smime.c
@@ -301,7 +301,7 @@ static void mutt_smime_command (char *d, size_t dlen,
 {
   mutt_FormatString (d, dlen, 0, MuttIndexWindow->cols, NONULL(fmt), _mutt_fmt_smime_command,
 		    (unsigned long) cctx, 0);
-  dprint (2,(debugfile, "mutt_smime_command: %s\n", d));
+  mutt_debug (2, "mutt_smime_command: %s\n", d);
 }
 
 

--- a/smtp.c
+++ b/smtp.c
@@ -406,7 +406,7 @@ static int smtp_fill_account (ACCOUNT* account)
           SmtpPort = ntohs (service->s_port);
         else
           SmtpPort = SMTP_PORT;
-        dprint (3, (debugfile, "Using default SMTP port %d\n", SmtpPort));
+        mutt_debug (3, "Using default SMTP port %d\n", SmtpPort);
       }
       account->port = SmtpPort;
     }
@@ -528,7 +528,7 @@ static int smtp_auth (CONNECTION* conn)
       if (! method[0])
 	continue;
 
-      dprint (2, (debugfile, "smtp_authenticate: Trying method %s\n", method));
+      mutt_debug (2, "smtp_authenticate: Trying method %s\n", method);
 
       r = smtp_auth_sasl (conn, method);
       
@@ -587,7 +587,7 @@ static int smtp_auth_sasl (CONNECTION* conn, const char* mechlist)
 
   if (rc != SASL_OK && rc != SASL_CONTINUE)
   {
-    dprint (2, (debugfile, "smtp_auth_sasl: %s unavailable\n", mech));
+    mutt_debug (2, "smtp_auth_sasl: %s unavailable\n", mech);
     sasl_dispose (&saslconn);
     return SMTP_AUTH_UNAVAIL;
   }
@@ -605,7 +605,7 @@ static int smtp_auth_sasl (CONNECTION* conn, const char* mechlist)
     if (sasl_encode64 (data, len, buf + mutt_strlen (buf),
                        bufsize - mutt_strlen (buf), &len) != SASL_OK)
     {
-      dprint (1, (debugfile, "smtp_auth_sasl: error base64-encoding client response.\n"));
+      mutt_debug (1, "smtp_auth_sasl: error base64-encoding client response.\n");
       goto fail;
     }
   }
@@ -624,7 +624,7 @@ static int smtp_auth_sasl (CONNECTION* conn, const char* mechlist)
 
     if (sasl_decode64 (buf+4, strlen (buf+4), buf, bufsize - 1, &len) != SASL_OK)
     {
-      dprint (1, (debugfile, "smtp_auth_sasl: error base64-decoding server response.\n"));
+      mutt_debug (1, "smtp_auth_sasl: error base64-decoding server response.\n");
       goto fail;
     }
 
@@ -645,7 +645,7 @@ static int smtp_auth_sasl (CONNECTION* conn, const char* mechlist)
       }
       if (sasl_encode64 (data, len, buf, bufsize, &len) != SASL_OK)
       {
-        dprint (1, (debugfile, "smtp_auth_sasl: error base64-encoding client response.\n"));
+        mutt_debug (1, "smtp_auth_sasl: error base64-encoding client response.\n");
         goto fail;
       }
     }

--- a/snprintf.c
+++ b/snprintf.c
@@ -494,8 +494,8 @@ static void fmtint (char *buffer, size_t *currlen, size_t maxlen,
     spadlen = -spadlen; /* Left Justifty */
 
 #ifdef DEBUG_SNPRINTF
-  dprint (1, (debugfile, "zpad: %d, spad: %d, min: %d, max: %d, place: %d\n",
-      zpadlen, spadlen, min, max, place));
+  mutt_debug (1, "zpad: %d, spad: %d, min: %d, max: %d, place: %d\n",
+              zpadlen, spadlen, min, max, place);
 #endif
 
   /* Spaces */
@@ -623,7 +623,7 @@ static void fmtfp (char *buffer, size_t *currlen, size_t maxlen,
   }
 
 #ifdef DEBUG_SNPRINTF
-  dprint (1, (debugfile, "fmtfp: %f =? %d.%d\n", fvalue, intpart, fracpart));
+  mutt_debug (1, "fmtfp: %f =? %d.%d\n", fvalue, intpart, fracpart);
 #endif
 
   /* Convert integer part */


### PR DESCRIPTION
The dprint macro is error-prone. Any FILE* can be passed to dprint, but
the macro checks that `debugfile` is not NULL (ie. it's open), not the
file pointer it received as parameter. This had also the consequence
that `debugfile` is passed to every call to `dprint`, making lines
unnecessarily long.

This commit replaces calls to `dprint` by direct calls to `mutt_debug`.
It's now hardcoded in this function that it will write in `debugfile`.
Also, remove the MUTT_LIB_WHERE magic.

The substistution has been done with the following command:
   perl -0777 -pi -e 's/dprint[ ]*\((.+?),[ \t\r\n]*\(debugfile,[ ]*(.*?)\)\);/mutt_debug (\1, \2);/igs' *.c imap/*.c
And the code was then slightly ajusted to fix identation and line
length.

Closes #362