### PR TITLE
Fix dubious use macro for _() / gettext()

### DIFF
--- a/addrbook.c
+++ b/addrbook.c
@@ -142,7 +142,7 @@ void mutt_alias_menu (char *buf, size_t buflen, ALIAS *aliases)
   
   if (!aliases)
   {
-    mutt_error _("You have no aliases!");
+    mutt_error (_("You have no aliases!"));
     return;
   }
   

--- a/alias.c
+++ b/alias.c
@@ -264,7 +264,7 @@ retry_name:
   /* check to see if the user already has an alias defined */
   if (mutt_lookup_alias (buf))
   {
-    mutt_error _("You already have an alias defined with that name!");
+    mutt_error (_("You already have an alias defined with that name!"));
     return;
   }
   

--- a/attach.c
+++ b/attach.c
@@ -123,7 +123,7 @@ int mutt_compose_attachment (BODY *a)
 				      command, sizeof (command)))
       {
 	/* For now, editing requires a file, no piping */
-	mutt_error _("Mailcap compose entry requires %%s");
+	mutt_error (_("Mailcap compose entry requires %%s"));
       }
       else
       {
@@ -141,7 +141,7 @@ int mutt_compose_attachment (BODY *a)
 
 	  if ((fp = safe_fopen (a->filename, "r")) == NULL)
 	  {
-	    mutt_perror _("Failure to open file to parse headers.");
+	    mutt_perror (_("Failure to open file to parse headers."));
 	    goto bailout;
 	  }
 
@@ -172,7 +172,7 @@ int mutt_compose_attachment (BODY *a)
 	    mutt_mktemp (tempfile, sizeof (tempfile));
 	    if ((tfp = safe_fopen (tempfile, "w")) == NULL)
 	    {
-	      mutt_perror _("Failure to open file to strip headers.");
+	      mutt_perror (_("Failure to open file to strip headers."));
 	      goto bailout;
 	    }
 	    mutt_copy_stream (fp, tfp);
@@ -181,7 +181,7 @@ int mutt_compose_attachment (BODY *a)
 	    mutt_unlink (a->filename);  
 	    if (mutt_rename_file (tempfile, a->filename) != 0) 
 	    {
-	      mutt_perror _("Failure to rename file.");
+	      mutt_perror (_("Failure to rename file."));
 	      goto bailout;
 	    }
 
@@ -255,7 +255,7 @@ int mutt_edit_attachment (BODY *a)
 				      command, sizeof (command)))
       {
 	/* For now, editing requires a file, no piping */
-	mutt_error _("Mailcap Edit entry requires %%s");
+	mutt_error (_("Mailcap Edit entry requires %%s"));
         goto bailout;
       }
       else
@@ -363,7 +363,7 @@ int mutt_view_attachment (FILE *fp, BODY *a, int flag, HEADER *hdr,
       {
 	/* fallback to view as text */
 	rfc1524_free_entry (&entry);
-	mutt_error _("No matching mailcap entry found.  Viewing as text.");
+	mutt_error (_("No matching mailcap entry found.  Viewing as text."));
 	flag = MUTT_AS_TEXT;
 	use_mailcap = 0;
       }
@@ -376,7 +376,7 @@ int mutt_view_attachment (FILE *fp, BODY *a, int flag, HEADER *hdr,
   {
     if (!entry->command)
     {
-      mutt_error _("MIME type not defined.  Cannot view attachment.");
+      mutt_error (_("MIME type not defined.  Cannot view attachment."));
       goto return_error;
     }
     strfcpy (command, entry->command, sizeof (command));
@@ -466,7 +466,7 @@ int mutt_view_attachment (FILE *fp, BODY *a, int flag, HEADER *hdr,
 	if(tempfd != -1)
 	  close(tempfd);
 
-	mutt_error _("Cannot create filter");
+	mutt_error (_("Cannot create filter"));
 	goto return_error;
       }
 
@@ -630,7 +630,7 @@ int mutt_pipe_attachment (FILE *fp, BODY *b, const char *path, char *outfile)
 
     if (thepid < 0)
     {
-      mutt_perror _("Can't create filter");
+      mutt_perror (_("Can't create filter"));
       goto bail;
     }
     
@@ -662,7 +662,7 @@ int mutt_pipe_attachment (FILE *fp, BODY *b, const char *path, char *outfile)
 
     if (thepid < 0)
     {
-      mutt_perror _("Can't create filter");
+      mutt_perror (_("Can't create filter"));
       safe_fclose (&ifp);
       goto bail;
     }
@@ -796,7 +796,7 @@ int mutt_save_attachment (FILE *fp, BODY *m, char *path, int flags, HEADER *hdr)
 
     if (mutt_copy_stream (ofp, nfp) == -1)
     {
-      mutt_error _("Write fault!");
+      mutt_error (_("Write fault!"));
       safe_fclose (&ofp);
       safe_fclose (&nfp);
       return (-1);
@@ -965,7 +965,7 @@ int mutt_print_attachment (FILE *fp, BODY *a)
 
       if ((thepid = mutt_create_filter (command, &fpout, NULL, NULL)) < 0)
       {
-	mutt_perror _("Can't create filter");
+	mutt_perror (_("Can't create filter"));
 	rfc1524_free_entry (&entry);
 	safe_fclose (&ifp);
 	return 0;
@@ -1023,7 +1023,7 @@ int mutt_print_attachment (FILE *fp, BODY *a)
       mutt_endwin (NULL);
       if ((thepid = mutt_create_filter (NONULL(PrintCmd), &fpout, NULL, NULL)) < 0)
       {
-	mutt_perror _("Can't create filter");
+	mutt_perror (_("Can't create filter"));
 	goto bail0;
       }
 
@@ -1046,7 +1046,7 @@ int mutt_print_attachment (FILE *fp, BODY *a)
   }
   else
   {
-    mutt_error _("I don't know how to print that!");
+    mutt_error (_("I don't know how to print that!"));
     return 0;
   }
 }

--- a/browser.c
+++ b/browser.c
@@ -1000,7 +1000,7 @@ static int file_tag (MUTTMENU *menu, int n, int m)
   int ot;
   if (S_ISDIR (ff->mode) || (S_ISLNK (ff->mode) && link_is_dir (LastDir, ff->name)))
   {
-    mutt_error _("Can't attach a directory!");
+    mutt_error (_("Can't attach a directory!"));
     return 0;
   }
   
@@ -1279,7 +1279,7 @@ void _mutt_select_file (char *f, size_t flen, int flags, char ***files, int *num
 
 	if (!state.entrylen)
 	{
-	  mutt_error _("No files match the file mask");
+	  mutt_error (_("No files match the file mask"));
 	  break;
 	}
 
@@ -1537,7 +1537,7 @@ void _mutt_select_file (char *f, size_t flen, int flags, char ***files, int *num
 	  imap_parse_path (state.entry[nentry].name, &mx);
 	  if (!mx.mbox)
 	  {
-	    mutt_error _("Cannot delete root folder");
+	    mutt_error (_("Cannot delete root folder"));
 	    break;
 	  }
 	  snprintf (msg, sizeof (msg), _("Really delete mailbox \"%s\"?"),
@@ -1556,13 +1556,13 @@ void _mutt_select_file (char *f, size_t flen, int flags, char ***files, int *num
               memset (&state.entry[state.entrylen - 1], 0,
                       sizeof (struct folder_file));
 	      state.entrylen--;
-	      mutt_message _("Mailbox deleted.");
+	      mutt_message (_("Mailbox deleted."));
 	      init_menu (&state, menu, title, sizeof (title), buffy);
 	      MAYBE_REDRAW (menu->redraw);
 	    }
 	  }
 	  else
-	    mutt_message _("Mailbox not deleted.");
+	    mutt_message (_("Mailbox not deleted."));
 	  FREE (&mx.mbox);
         }
         break;
@@ -1624,7 +1624,7 @@ void _mutt_select_file (char *f, size_t flen, int flags, char ***files, int *num
 		  strfcpy (LastDir, buf, sizeof (LastDir));
 		else
 		{
-		  mutt_error _("Error scanning directory.");
+		  mutt_error (_("Error scanning directory."));
 		  if (examine_directory (menu, &state, LastDir, prefix) == -1)
 		  {
 		    mutt_menuDestroy (&menu);
@@ -1696,14 +1696,14 @@ void _mutt_select_file (char *f, size_t flen, int flags, char ***files, int *num
 	      init_menu (&state, menu, title, sizeof (title), buffy);
 	    else
 	    {
-	      mutt_error _("Error scanning directory.");
+	      mutt_error (_("Error scanning directory."));
 	      mutt_menuDestroy (&menu);
 	      goto bail;
 	    }
 	    killPrefix = 0;
 	    if (!state.entrylen)
 	    {
-	      mutt_error _("No files match the file mask");
+	      mutt_error (_("No files match the file mask"));
 	      break;
 	    }
 	  }
@@ -1842,7 +1842,7 @@ void _mutt_select_file (char *f, size_t flen, int flags, char ***files, int *num
       case OP_BROWSER_VIEW_FILE:
 	if (!state.entrylen)
 	{
-	  mutt_error _("No files match the file mask");
+	  mutt_error (_("No files match the file mask"));
 	  break;
 	}
 
@@ -1860,7 +1860,7 @@ void _mutt_select_file (char *f, size_t flen, int flags, char ***files, int *num
 	    (S_ISLNK (state.entry[menu->current].mode) &&
 	    link_is_dir (LastDir, state.entry[menu->current].name)))
 	{
-	  mutt_error _("Can't view a directory");
+	  mutt_error (_("Can't view a directory"));
 	  break;
 	} 
 	else
@@ -1877,7 +1877,7 @@ void _mutt_select_file (char *f, size_t flen, int flags, char ***files, int *num
 	    menu->redraw = REDRAW_FULL;
 	  }
 	  else
-	    mutt_error _("Error trying to view file");
+	    mutt_error (_("Error trying to view file"));
 	}
 	break;
 

--- a/commands.c
+++ b/commands.c
@@ -117,7 +117,7 @@ int mutt_display_message (HEADER *cur)
   mutt_mktemp (tempfile, sizeof (tempfile));
   if ((fpout = safe_fopen (tempfile, "w")) == NULL)
   {
-    mutt_error _("Could not create temporary file!");
+    mutt_error (_("Could not create temporary file!"));
     return (0);
   }
 
@@ -197,14 +197,14 @@ int mutt_display_message (HEADER *cur)
       if (cur->security & GOODSIGN)
       {
 	if (!crypt_smime_verify_sender(cur))
-	  mutt_message ( _("S/MIME signature successfully verified."));
+	  mutt_message (_("S/MIME signature successfully verified."));
 	else
-	  mutt_error ( _("S/MIME certificate owner does not match sender."));
+	  mutt_error (_("S/MIME certificate owner does not match sender."));
       }
       else if (cur->security & PARTSIGN)
 	mutt_message (_("Warning: Part of this message has not been signed."));
       else if (cur->security & SIGN || cur->security & BADSIGN)
-	mutt_error ( _("S/MIME signature could NOT be verified."));
+	mutt_error (_("S/MIME signature could NOT be verified."));
     }
 
     if (WithCrypto 
@@ -239,7 +239,7 @@ int mutt_display_message (HEADER *cur)
       mutt_set_flag (Context, cur, MUTT_READ, 1);
     if (r != -1 && option (OPTPROMPTAFTER))
     {
-      mutt_unget_event (mutt_any_key_to_continue _("Command: "), 0);
+      mutt_unget_event (mutt_any_key_to_continue(_("Command: ")), 0);
       rc = km_dokey (MENU_PAGER);
     }
     else
@@ -264,7 +264,7 @@ void ci_bounce_message (HEADER *h, int *redraw)
   {
     if (!h->env->from)
     {
-      mutt_error _("Warning: message contains no From: header");
+      mutt_error (_("Warning: message contains no From: header"));
       mutt_sleep (2);
     }
   }
@@ -274,7 +274,7 @@ void ci_bounce_message (HEADER *h, int *redraw)
     {
       if (Context->hdrs[rc]->tagged && !Context->hdrs[rc]->env->from)
       {
-	mutt_error _("Warning: message contains no From: header");
+	mutt_error (_("Warning: message contains no From: header"));
 	mutt_sleep (2);
 	break;
       }
@@ -299,7 +299,7 @@ void ci_bounce_message (HEADER *h, int *redraw)
 
   if (!(adr = mutt_parse_adrlist (adr, buf)))
   {
-    mutt_error _("Error parsing address!");
+    mutt_error (_("Error parsing address!"));
     return;
   }
 
@@ -421,7 +421,7 @@ static int _mutt_pipe_message (HEADER *h, char *cmd,
 
     if ((thepid = mutt_create_filter (cmd, &fpout, NULL, NULL)) < 0)
     {
-      mutt_perror _("Can't create filter process");
+      mutt_perror (_("Can't create filter process"));
       return 1;
     }
       
@@ -455,7 +455,7 @@ static int _mutt_pipe_message (HEADER *h, char *cmd,
 	  mutt_endwin (NULL);
 	  if ((thepid = mutt_create_filter (cmd, &fpout, NULL, NULL)) < 0)
 	  {
-	    mutt_perror _("Can't create filter process");
+	    mutt_perror (_("Can't create filter process"));
 	    return 1;
 	  }
           pipe_msg (Context->hdrs[Context->v2r[i]], fpout, decode, print);
@@ -472,7 +472,7 @@ static int _mutt_pipe_message (HEADER *h, char *cmd,
       mutt_endwin (NULL);
       if ((thepid = mutt_create_filter (cmd, &fpout, NULL, NULL)) < 0)
       {
-	mutt_perror _("Can't create filter process");
+	mutt_perror (_("Can't create filter process"));
 	return 1;
       }
       for (i = 0; i < Context->vcount; i++)

--- a/compose.c
+++ b/compose.c
@@ -214,7 +214,7 @@ static void redraw_mix_line (LIST *chain)
 
   if (!chain)
   {
-    addstr ("<no chain defined>");
+    addstr (_("<no chain defined>"));
     mutt_window_clrtoeol (MuttIndexWindow);
     return;
   }

--- a/compose.c
+++ b/compose.c
@@ -51,7 +51,7 @@
 
 static const char* There_are_no_attachments = N_("There are no attachments.");
 
-#define CHECK_COUNT if (idxlen == 0) { mutt_error _(There_are_no_attachments); break; }
+#define CHECK_COUNT if (idxlen == 0) { mutt_error(_(There_are_no_attachments)); break; }
 
 
 
@@ -371,7 +371,7 @@ static int delete_attachment (MUTTMENU *menu, short *idxlen, int x)
 
   if (x == 0 && menu->max == 1)
   {
-    mutt_error _("You may not delete the only attachment.");
+    mutt_error (_("You may not delete the only attachment."));
     idx[x]->content->tagged = 0;
     return (-1);
   }
@@ -835,7 +835,7 @@ int mutt_compose_menu (HEADER *msg,   /* structure for new message */
 
 	  error = 0;
 	  if (numfiles > 1)
-	    mutt_message _("Attaching selected files...");
+	    mutt_message (_("Attaching selected files..."));
 	  for (i = 0; i < numfiles; i++)
 	  {
 	    char *att = files[i];
@@ -930,7 +930,7 @@ int mutt_compose_menu (HEADER *msg,   /* structure for new message */
 	  {
 	    mx_close_mailbox (ctx, NULL);
 	    FREE (&ctx);
-	    mutt_error _("No messages in that folder.");
+	    mutt_error (_("No messages in that folder."));
 	    break;
 	  }
 
@@ -939,7 +939,7 @@ int mutt_compose_menu (HEADER *msg,   /* structure for new message */
 	  
 	  Context = ctx;
 	  set_option(OPTATTACHMSG);
-	  mutt_message _("Tag the messages you want to attach!");
+	  mutt_message (_("Tag the messages you want to attach!"));
 	  close = mutt_index_menu ();
 	  unset_option(OPTATTACHMSG);
 
@@ -971,7 +971,7 @@ int mutt_compose_menu (HEADER *msg,   /* structure for new message */
 		update_idx (menu, idx, idxlen++);
 	      else
 	      {
-		mutt_error _("Unable to attach!");
+		mutt_error (_("Unable to attach!"));
 		FREE (&idx[idxlen]);
 	      }
 	    }
@@ -1104,7 +1104,7 @@ int mutt_compose_menu (HEADER *msg,   /* structure for new message */
 	    mutt_clear_error();
 	  }
 	  else
-	    mutt_error _("Invalid encoding.");
+	    mutt_error (_("Invalid encoding."));
 	}
         mutt_message_hook (NULL, msg, MUTT_SEND2HOOK);
         break;
@@ -1258,7 +1258,7 @@ int mutt_compose_menu (HEADER *msg,   /* structure for new message */
 
 	  if (!(p = strchr (type, '/')))
 	  {
-	    mutt_error _("Content-Type is of the form base/sub");
+	    mutt_error (_("Content-Type is of the form base/sub"));
 	    continue;
 	  }
 	  *p++ = 0;
@@ -1285,7 +1285,7 @@ int mutt_compose_menu (HEADER *msg,   /* structure for new message */
 
 	  if ((idx[idxlen]->content = mutt_make_file_attach (fname)) == NULL)
 	  {
-	    mutt_error _("What we have here is a failure to make an attachment");
+	    mutt_error (_("What we have here is a failure to make an attachment"));
 	    continue;
 	  }
 	  update_idx (menu, idx, idxlen++);
@@ -1422,7 +1422,7 @@ int mutt_compose_menu (HEADER *msg,   /* structure for new message */
          if (mutt_write_fcc (fname, msg, NULL, 0, NULL, NULL) < 0)
            msg->content = mutt_remove_multipart (msg->content);
          else
-           mutt_message _("Message written.");
+           mutt_message (_("Message written."));
        }
        break;
 

--- a/crypt-gpgme.c
+++ b/crypt-gpgme.c
@@ -586,7 +586,7 @@ static char *data_object_to_tempfile (gpgme_data_t data, char *tempf, FILE **ret
     }
   if ((fp = safe_fopen (tempf, tempf == tempfb ? "w+" : "a+")) == NULL)
     {
-      mutt_perror _("Can't create temporary file");
+      mutt_perror (_("Can't create temporary file"));
       return NULL;
     }
 
@@ -2657,11 +2657,11 @@ int pgp_gpgme_encrypted_handler (BODY *a, STATE *s)
         }
 
       mutt_free_body (&tattach);
-      mutt_message _("PGP message successfully decrypted.");
+      mutt_message (_("PGP message successfully decrypted."));
     }
   else
     {
-      mutt_error _("Could not decrypt PGP message");
+      mutt_error (_("Could not decrypt PGP message"));
       mutt_sleep (2);
       rc = -1;
     }
@@ -3643,10 +3643,10 @@ verify_key (crypt_key_t *key)
   mutt_mktemp (tempfile, sizeof (tempfile));
   if (!(fp = safe_fopen (tempfile, "w")))
     {
-      mutt_perror _("Can't create temporary file");
+      mutt_perror (_("Can't create temporary file"));
       return;
     }
-  mutt_message _("Collecting data...");
+  mutt_message (_("Collecting data..."));
 
   print_key_info (key->kobj, fp);
 
@@ -3992,7 +3992,7 @@ static crypt_key_t *crypt_select_key (crypt_key_t *keys,
 
   if (!i && unusable)
     {
-      mutt_error _("All matching keys are marked expired/revoked.");
+      mutt_error (_("All matching keys are marked expired/revoked."));
       mutt_sleep (1);
       return NULL;
     }
@@ -4086,8 +4086,8 @@ static crypt_key_t *crypt_select_key (crypt_key_t *keys,
             {
             if (!crypt_key_is_valid (key_table[menu->current]))
               {
-                mutt_error _("This key can't be used: "
-                             "expired/disabled/revoked.");
+                mutt_error(_("This key can't be used: "
+                             "expired/disabled/revoked."));
                 break;
               }
             }

--- a/crypt-gpgme.c
+++ b/crypt-gpgme.c
@@ -554,7 +554,7 @@ static int data_object_to_stream (gpgme_data_t data, FILE *fp)
 
      if (ferror (fp))
        {
-         mutt_perror ("[tempfile]");
+         mutt_perror (_("[tempfile]"));
          return -1;
        }
     }

--- a/crypt.c
+++ b/crypt.c
@@ -84,7 +84,7 @@ void crypt_forget_passphrase (void)
     crypt_smime_void_passphrase ();
 
   if (WithCrypto)
-    mutt_message _("Passphrase(s) forgotten.");
+    mutt_message(_("Passphrase(s) forgotten."));
 }
 
 
@@ -148,14 +148,14 @@ int mutt_protect (HEADER *msg, char *keylist)
       if (query_quadoption (OPT_PGPMIMEAUTO,
           _("Inline PGP can't be used with attachments.  Revert to PGP/MIME?")) != MUTT_YES)
       {
-        mutt_error _("Mail not sent: inline PGP can't be used with attachments.");
+        mutt_error (_("Mail not sent: inline PGP can't be used with attachments."));
         return -1;
       }
     }
     else
     {
       /* they really want to send it inline... go for it */
-      if (!isendwin ()) mutt_endwin _("Invoking PGP...");
+      if (!isendwin ()) mutt_endwin(_("Invoking PGP..."));
       pbody = crypt_pgp_traditional_encryptsign (msg->content, flags, keylist);
       if (pbody)
       {
@@ -166,7 +166,7 @@ int mutt_protect (HEADER *msg, char *keylist)
       /* otherwise inline won't work...ask for revert */
       if (query_quadoption (OPT_PGPMIMEAUTO, _("Message can't be sent inline.  Revert to using PGP/MIME?")) != MUTT_YES)
       {
-        mutt_error _("Mail not sent.");
+        mutt_error (_("Mail not sent."));
         return -1;
       }
     }

--- a/cryptglue.c
+++ b/cryptglue.c
@@ -107,9 +107,9 @@ void crypt_init (void)
 void crypt_invoke_message (int type)
 {
   if ((WithCrypto & APPLICATION_PGP) && (type & APPLICATION_PGP))
-    mutt_message _("Invoking PGP...");
+    mutt_message (_("Invoking PGP..."));
   else if ((WithCrypto & APPLICATION_SMIME) && (type & APPLICATION_SMIME))
-    mutt_message _("Invoking S/MIME...");
+    mutt_message (_("Invoking S/MIME..."));
 }
 
 

--- a/curs_main.c
+++ b/curs_main.c
@@ -72,27 +72,27 @@ static const char *No_visible = N_("No visible messages.");
 #define CHECK_IN_MAILBOX if (!Context) \
 	{ \
 		mutt_flushinp (); \
-		mutt_error _(No_mailbox_is_open); \
+		mutt_error(_(No_mailbox_is_open)); \
 		break; \
 	}
 
 #define CHECK_MSGCOUNT if (!Context) \
 	{ \
 	  	mutt_flushinp (); \
-		mutt_error _(No_mailbox_is_open); \
+		mutt_error(_(No_mailbox_is_open)); \
 		break; \
 	} \
 	else if (!Context->msgcount) \
 	{ \
 	  	mutt_flushinp (); \
-		mutt_error _(There_are_no_messages); \
+		mutt_error(_(There_are_no_messages)); \
 		break; \
 	}
 
 #define CHECK_VISIBLE if (Context && menu->current >= Context->vcount) \
   	{\
 	  	mutt_flushinp (); \
-	  	mutt_error _(No_visible); \
+	  	mutt_error(_(No_visible)); \
 	  	break; \
 	}
 
@@ -100,7 +100,7 @@ static const char *No_visible = N_("No visible messages.");
 #define CHECK_READONLY if (Context->readonly) \
 			{ \
 			  	mutt_flushinp (); \
-				mutt_error _(Mailbox_is_read_only); \
+				mutt_error(_(Mailbox_is_read_only)); \
 				break; \
 			}
 
@@ -115,7 +115,7 @@ static const char *No_visible = N_("No visible messages.");
 #define CHECK_ATTACH if(option(OPTATTACHMSG)) \
 		     {\
 			mutt_flushinp (); \
-			mutt_error _(Function_not_permitted_in_attach_message_mode); \
+			mutt_error(_(Function_not_permitted_in_attach_message_mode)); \
 			break; \
 		     }
 
@@ -417,19 +417,19 @@ static int mx_toggle_write (CONTEXT *ctx)
 
   if (ctx->readonly)
   {
-    mutt_error _("Cannot toggle write on a readonly mailbox!");
+    mutt_error (_("Cannot toggle write on a readonly mailbox!"));
     return -1;
   }
 
   if (ctx->dontwrite)
   {
     ctx->dontwrite = 0;
-    mutt_message _("Changes to folder will be written on folder exit.");
+    mutt_message (_("Changes to folder will be written on folder exit."));
   }
   else
   {
     ctx->dontwrite = 1;
-    mutt_message _("Changes to folder will not be written.");
+    mutt_message (_("Changes to folder will not be written."));
   }
 
   return 0;
@@ -908,7 +908,7 @@ int mutt_index_menu (void)
       {
 	/* notify the user of new mail */
 	if (check == MUTT_REOPENED)
-	  mutt_error _("Mailbox was externally modified.  Flags may be wrong.");
+	  mutt_error (_("Mailbox was externally modified.  Flags may be wrong."));
 	else if (check == MUTT_NEW_MAIL)
 	{
 	  for (i = oldcount; i < Context->msgcount; i++)
@@ -928,7 +928,7 @@ int mutt_index_menu (void)
 	    }
 	  }
 	} else if (check == MUTT_FLAGS)
-	  mutt_message _("Mailbox was externally modified.");
+	  mutt_message (_("Mailbox was externally modified."));
 
 	/* avoid the message being overwritten by buffy */
 	do_buffy_notify = 0;
@@ -1069,13 +1069,13 @@ int mutt_index_menu (void)
       {
 	if (!Context)
 	{
-	  mutt_error _("No mailbox is open.");
+	  mutt_error (_("No mailbox is open."));
 	  continue;
 	}
 
 	if (!Context->tagged)
 	{
-	  mutt_error _("No tagged messages.");
+	  mutt_error (_("No tagged messages."));
 	  continue;
 	}
 	tag = 1;
@@ -1099,14 +1099,14 @@ int mutt_index_menu (void)
       {
 	if (!Context)
 	{
-	  mutt_error _("No mailbox is open.");
+	  mutt_error (_("No mailbox is open."));
 	  continue;
 	}
 
 	if (!Context->tagged)
 	{
 	  mutt_flush_macro_to_endcond ();
-	  mutt_message  _("Nothing to do.");
+	  mutt_message  (_("Nothing to do."));
 	  continue;
 	}
 	tag = 1;
@@ -1389,7 +1389,7 @@ int mutt_index_menu (void)
 
 	if (mutt_atoi (buf, &i) < 0)
 	{
-	  mutt_error _("Argument must be a message number.");
+	  mutt_error (_("Argument must be a message number."));
 	  break;
 	}
 
@@ -1421,10 +1421,10 @@ int mutt_index_menu (void)
 	    menu->redraw = REDRAW_MOTION;
 	  }
 	  else
-	    mutt_error _("That message is not visible.");
+	    mutt_error (_("That message is not visible."));
 	}
 	else
-	  mutt_error _("Invalid message number.");
+	  mutt_error (_("Invalid message number."));
 
 	break;
 
@@ -1463,7 +1463,7 @@ int mutt_index_menu (void)
       case OP_MAIN_SHOW_LIMIT:
 	CHECK_IN_MAILBOX;
 	if (!Context->pattern)
-	   mutt_message _("No limit pattern is in effect.");
+	   mutt_message (_("No limit pattern is in effect."));
 	else
 	{
 	   char buf[STRING];
@@ -1525,7 +1525,7 @@ int mutt_index_menu (void)
 	  menu->redraw = REDRAW_FULL;
 	}
         if (Context->pattern)
-	  mutt_message _("To view all messages, limit to \"all\".");
+	  mutt_message (_("To view all messages, limit to \"all\"."));
 	break;
 
       case OP_QUIT:
@@ -1681,7 +1681,7 @@ int mutt_index_menu (void)
 	  FREE (&Context);
 	}
 	imap_logout_all();
-	mutt_message _("Logged out of IMAP servers.");
+	mutt_message (_("Logged out of IMAP servers."));
 	set_option (OPTSEARCHINVALID);
 	menu->redraw = REDRAW_FULL;
 	break;
@@ -1973,7 +1973,7 @@ int mutt_index_menu (void)
 	  mutt_buffy (buf, sizeof (buf));
 	  if (!buf[0])
 	  {
-	    mutt_error _("No mailboxes have new mail");
+	    mutt_error (_("No mailboxes have new mail"));
 	    break;
 	  }
 	}
@@ -2126,7 +2126,7 @@ int mutt_index_menu (void)
 	CHECK_ACL(MUTT_ACL_WRITE, _("Cannot break thread"));
 
         if ((Sort & SORT_MASK) != SORT_THREADS)
-	  mutt_error _("Threading is not enabled.");
+	  mutt_error (_("Threading is not enabled."));
 	else if (CURHDR->env->in_reply_to || CURHDR->env->references)
 	{
 	  {
@@ -2138,7 +2138,7 @@ int mutt_index_menu (void)
 	  }
 
 	  Context->changed = 1;
-	  mutt_message _("Thread broken");
+	  mutt_message (_("Thread broken"));
 
 	  if (menu->menu == MENU_PAGER)
 	  {
@@ -2149,7 +2149,7 @@ int mutt_index_menu (void)
 	    menu->redraw |= REDRAW_INDEX;
 	}
 	else
-	  mutt_error _("Thread cannot be broken, message is not part of a thread");
+	  mutt_error (_("Thread cannot be broken, message is not part of a thread"));
 
 	break;
 
@@ -2162,11 +2162,11 @@ int mutt_index_menu (void)
 	CHECK_ACL(MUTT_ACL_WRITE, _("Cannot link threads"));
 
         if ((Sort & SORT_MASK) != SORT_THREADS)
-	  mutt_error _("Threading is not enabled.");
+	  mutt_error (_("Threading is not enabled."));
 	else if (!CURHDR->env->message_id)
-	  mutt_error _("No Message-ID: header available to link thread");
+	  mutt_error (_("No Message-ID: header available to link thread"));
 	else if (!tag && (!Context->last_tag || !Context->last_tag->tagged))
-	  mutt_error _("First, please tag a message to be linked here");
+	  mutt_error (_("First, please tag a message to be linked here"));
 	else
 	{
 	  HEADER *oldcur = CURHDR;
@@ -2178,10 +2178,10 @@ int mutt_index_menu (void)
 	    menu->current = oldcur->virtual;
 
 	    Context->changed = 1;
-	    mutt_message _("Threads linked");
+	    mutt_message (_("Threads linked"));
 	  }
 	  else
-	    mutt_error _("No thread linked");
+	    mutt_error (_("No thread linked"));
 	}
 
 	if (menu->menu == MENU_PAGER)
@@ -2217,14 +2217,14 @@ int mutt_index_menu (void)
 	if (menu->current >= Context->vcount - 1)
 	{
 	  if (menu->menu == MENU_MAIN)
-	    mutt_error _("You are on the last message.");
+	    mutt_error (_("You are on the last message."));
 	  break;
 	}
 	if ((menu->current = ci_next_undeleted (menu->current)) == -1)
 	{
 	  menu->current = menu->oldcurrent;
 	  if (menu->menu == MENU_MAIN)
-	    mutt_error _("No undeleted messages.");
+	    mutt_error (_("No undeleted messages."));
 	}
 	else if (menu->menu == MENU_PAGER)
 	{
@@ -2242,7 +2242,7 @@ int mutt_index_menu (void)
 	if (menu->current >= Context->vcount - 1)
 	{
 	  if (menu->menu == MENU_MAIN)
-	    mutt_error _("You are on the last message.");
+	    mutt_error (_("You are on the last message."));
 	  break;
 	}
 	menu->current++;
@@ -2261,14 +2261,14 @@ int mutt_index_menu (void)
         CHECK_VISIBLE;
 	if (menu->current < 1)
 	{
-	  mutt_error _("You are on the first message.");
+	  mutt_error (_("You are on the first message."));
 	  break;
 	}
 	if ((menu->current = ci_previous_undeleted (menu->current)) == -1)
 	{
 	  menu->current = menu->oldcurrent;
 	  if (menu->menu == MENU_MAIN)
-	    mutt_error _("No undeleted messages.");
+	    mutt_error (_("No undeleted messages."));
 	}
 	else if (menu->menu == MENU_PAGER)
 	{
@@ -2285,7 +2285,7 @@ int mutt_index_menu (void)
         CHECK_VISIBLE;
 	if (menu->current < 1)
 	{
-	  if (menu->menu == MENU_MAIN) mutt_error _("You are on the first message.");
+	  if (menu->menu == MENU_MAIN) mutt_error (_("You are on the first message."));
 	  break;
 	}
 	menu->current--;
@@ -2360,7 +2360,7 @@ int mutt_index_menu (void)
 	    i++;
 	    if (i > Context->vcount - 1)
 	    {
-	      mutt_message _("Search wrapped to top.");
+	      mutt_message (_("Search wrapped to top."));
 	      i = 0;
 	    }
 	  }
@@ -2369,7 +2369,7 @@ int mutt_index_menu (void)
 	    i--;
 	    if (i < 0)
 	    {
-	      mutt_message _("Search wrapped to bottom.");
+	      mutt_message (_("Search wrapped to bottom."));
 	      i = Context->vcount - 1;
 	    }
 	  }
@@ -2555,9 +2555,9 @@ int mutt_index_menu (void)
 	{
 	  menu->current = menu->oldcurrent;
 	  if (op == OP_MAIN_NEXT_THREAD || op == OP_MAIN_NEXT_SUBTHREAD)
-	    mutt_error _("No more threads.");
+	    mutt_error (_("No more threads."));
 	  else
-	    mutt_error _("You are on the first thread.");
+	    mutt_error (_("You are on the first thread."));
 	}
 	else if (menu->menu == MENU_PAGER)
 	{
@@ -2622,7 +2622,7 @@ int mutt_index_menu (void)
 
         if ((Sort & SORT_MASK) != SORT_THREADS)
         {
-	  mutt_error _("Threading is not enabled.");
+	  mutt_error (_("Threading is not enabled."));
 	  break;
 	}
 
@@ -2640,7 +2640,7 @@ int mutt_index_menu (void)
 	}
 	else
 	{
-	  mutt_error _("Thread contains unread messages.");
+	  mutt_error (_("Thread contains unread messages."));
 	  break;
 	}
 

--- a/flags.c
+++ b/flags.c
@@ -302,7 +302,7 @@ int mutt_thread_set_flag (HEADER *hdr, int flag, int bf, int subthread)
   
   if ((Sort & SORT_MASK) != SORT_THREADS)
   {
-    mutt_error _("Threading is not enabled.");
+    mutt_error (_("Threading is not enabled."));
     return (-1);
   }
 

--- a/handler.c
+++ b/handler.c
@@ -1360,7 +1360,7 @@ static int autoview_handler (BODY *a, STATE *s)
 
     if (thepid < 0)
     {
-      mutt_perror _("Can't create filter");
+      mutt_perror (_("Can't create filter"));
       if (s->flags & MUTT_DISPLAY)
       {
 	state_mark_attach (s);
@@ -1637,7 +1637,7 @@ static int run_decode_and_handler (BODY *b, STATE *s, handler_t handler, int pla
       mutt_mktemp (tempfile, sizeof (tempfile));
       if ((s->fpout = safe_fopen (tempfile, "w")) == NULL)
       {
-        mutt_error _("Unable to open temporary file!");
+        mutt_error (_("Unable to open temporary file!"));
         dprint (1, (debugfile, "Can't open %s.\n", tempfile));
         return -1;
       }
@@ -1799,7 +1799,7 @@ int mutt_body_handler (BODY *b, STATE *s)
       p = mutt_get_parameter ("protocol", b->parameter);
 
       if (!p)
-        mutt_error _("Error: multipart/signed has no protocol.");
+        mutt_error (_("Error: multipart/signed has no protocol."));
       else if (s->flags & MUTT_VERIFY)
 	handler = mutt_signed_handler;
     }

--- a/handler.c
+++ b/handler.c
@@ -1677,7 +1677,7 @@ static int run_decode_and_handler (BODY *b, STATE *s, handler_t handler, int pla
         s->fpin = safe_fopen ("/dev/null", "r");
       }
       if (!s->fpin) {
-        mutt_perror ("failed to re-open memstream!");
+        mutt_perror (_("failed to re-open memstream!"));
         return -1;
       }
 #else

--- a/imap/auth_anon.c
+++ b/imap/auth_anon.c
@@ -40,7 +40,7 @@ imap_auth_res_t imap_auth_anon (IMAP_DATA* idata, const char* method)
   if (idata->conn->account.user[0] != '\0')
     return IMAP_AUTH_UNAVAIL;
 
-  mutt_message _("Authenticating (anonymous)...");
+  mutt_message (_("Authenticating (anonymous)..."));
 
   imap_cmd_start (idata, "AUTHENTICATE ANONYMOUS");
 
@@ -70,7 +70,7 @@ imap_auth_res_t imap_auth_anon (IMAP_DATA* idata, const char* method)
     return IMAP_AUTH_SUCCESS;
 
  bail:
-  mutt_error _("Anonymous authentication failed.");
+  mutt_error (_("Anonymous authentication failed."));
   mutt_sleep (2);
   return IMAP_AUTH_FAILURE;
 }

--- a/imap/auth_cram.c
+++ b/imap/auth_cram.c
@@ -45,7 +45,7 @@ imap_auth_res_t imap_auth_cram_md5 (IMAP_DATA* idata, const char* method)
   if (!mutt_bit_isset (idata->capabilities, ACRAM_MD5))
     return IMAP_AUTH_UNAVAIL;
 
-  mutt_message _("Authenticating (CRAM-MD5)...");
+  mutt_message (_("Authenticating (CRAM-MD5)..."));
 
   /* get auth info */
   if (mutt_account_getlogin (&idata->conn->account))
@@ -124,7 +124,7 @@ imap_auth_res_t imap_auth_cram_md5 (IMAP_DATA* idata, const char* method)
     return IMAP_AUTH_SUCCESS;
 
  bail:
-  mutt_error _("CRAM-MD5 authentication failed.");
+  mutt_error (_("CRAM-MD5 authentication failed."));
   mutt_sleep (2);
   return IMAP_AUTH_FAILURE;
 }

--- a/imap/auth_gss.c
+++ b/imap/auth_gss.c
@@ -142,7 +142,7 @@ imap_auth_res_t imap_auth_gss (IMAP_DATA* idata, const char* method)
   }
 
   /* now begin login */
-  mutt_message _("Authenticating (GSSAPI)...");
+  mutt_message (_("Authenticating (GSSAPI)..."));
 
   imap_cmd_start (idata, "AUTHENTICATE GSSAPI");
 
@@ -309,7 +309,7 @@ imap_auth_res_t imap_auth_gss (IMAP_DATA* idata, const char* method)
   while (rc == IMAP_CMD_CONTINUE);
 
  bail:
-  mutt_error _("GSSAPI authentication failed.");
+  mutt_error (_("GSSAPI authentication failed."));
   mutt_sleep (2);
   return IMAP_AUTH_FAILURE;
 }

--- a/imap/auth_login.c
+++ b/imap/auth_login.c
@@ -35,7 +35,7 @@ imap_auth_res_t imap_auth_login (IMAP_DATA* idata, const char* method)
 
   if (mutt_bit_isset (idata->capabilities, LOGINDISABLED))
   {
-    mutt_message _("LOGIN disabled on this server.");
+    mutt_message (_("LOGIN disabled on this server."));
     return IMAP_AUTH_UNAVAIL;
   }
 
@@ -44,7 +44,7 @@ imap_auth_res_t imap_auth_login (IMAP_DATA* idata, const char* method)
   if (mutt_account_getpass (&idata->conn->account))
     return IMAP_AUTH_FAILURE;
 
-  mutt_message _("Logging in...");
+  mutt_message (_("Logging in..."));
 
   imap_quote_string (q_user, sizeof (q_user), idata->conn->account.user);
   imap_quote_string (q_pass, sizeof (q_pass), idata->conn->account.pass);
@@ -67,7 +67,7 @@ imap_auth_res_t imap_auth_login (IMAP_DATA* idata, const char* method)
     return IMAP_AUTH_SUCCESS;
   }
 
-  mutt_error _("Login failed.");
+  mutt_error (_("Login failed."));
   mutt_sleep (2);
   return IMAP_AUTH_FAILURE;
 }

--- a/imap/auth_plain.c
+++ b/imap/auth_plain.c
@@ -40,7 +40,7 @@ imap_auth_res_t imap_auth_plain(IMAP_DATA *idata, const char *method)
   if (mutt_account_getpass(&idata->conn->account))
     return IMAP_AUTH_FAILURE;
 
-  mutt_message _("Logging in...");
+  mutt_message(_("Logging in..."));
 
   mutt_sasl_plain_msg(buf, STRING, "AUTHENTICATE PLAIN",
                       idata->conn->account.user, idata->conn->account.user,
@@ -57,7 +57,7 @@ imap_auth_res_t imap_auth_plain(IMAP_DATA *idata, const char *method)
   }
   else if (rc == IMAP_CMD_NO)
   {
-    mutt_error _("Login failed.");
+    mutt_error(_("Login failed."));
     mutt_sleep(2);
     res = IMAP_AUTH_FAILURE;
   }

--- a/imap/auth_sasl.c
+++ b/imap/auth_sasl.c
@@ -225,7 +225,7 @@ imap_auth_res_t imap_auth_sasl (IMAP_DATA* idata, const char* method)
     return IMAP_AUTH_UNAVAIL;
   }
 
-  mutt_error _("SASL authentication failed.");
+  mutt_error (_("SASL authentication failed."));
   mutt_sleep(2);
 
   return IMAP_AUTH_FAILURE;

--- a/imap/browse.c
+++ b/imap/browse.c
@@ -65,7 +65,7 @@ int imap_browse (char* path, struct browser_state* state)
   if (!(idata = imap_conn_find (&(mx.account), 0)))
     goto fail;
 
-  mutt_message _("Getting folder list...");
+  mutt_message (_("Getting folder list..."));
 
   /* skip check for parents when at the root */
   if (mx.mbox && mx.mbox[0] != '\0')
@@ -183,7 +183,7 @@ int imap_browse (char* path, struct browser_state* state)
 
   if (!state->entrylen)
   {
-    mutt_error _("No such folder");
+    mutt_error (_("No such folder"));
     goto fail;
   }
 
@@ -246,7 +246,7 @@ int imap_mailbox_create (const char* folder)
   if (imap_create_mailbox (idata, buf) < 0)
     goto fail;
 
-  mutt_message _("Mailbox created.");
+  mutt_message (_("Mailbox created."));
   mutt_sleep (0);
 
   FREE (&mx.mbox);
@@ -279,7 +279,7 @@ int imap_mailbox_rename(const char* mailbox)
 
   if (!mx.mbox)
   {
-    mutt_error _("Cannot rename root folder");
+    mutt_error (_("Cannot rename root folder"));
     goto fail;
   }
 

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -456,7 +456,7 @@ int imap_open_connection (IMAP_DATA* idata)
 
     if (option(OPTSSLFORCETLS) && ! idata->conn->ssf)
     {
-      mutt_error _("Encrypted connection unavailable");
+      mutt_error (_("Encrypted connection unavailable"));
       mutt_sleep (1);
       goto err_close_conn;
     }
@@ -754,7 +754,7 @@ static int imap_open_mailbox (CONTEXT* ctx)
 
   if (count && (imap_read_headers (idata, 0, count-1) < 0))
   {
-    mutt_error _("Error opening mailbox");
+    mutt_error (_("Error opening mailbox"));
     mutt_sleep (1);
     goto fail;
   }
@@ -1306,7 +1306,7 @@ int imap_sync_mailbox (CONTEXT* ctx, int expunge)
       }
     }
     else
-      mutt_error _("Error saving flags");
+      mutt_error (_("Error saving flags"));
     rc = -1;
     goto out;
   }
@@ -1329,7 +1329,7 @@ int imap_sync_mailbox (CONTEXT* ctx, int expunge)
   if (expunge && !(ctx->closing) &&
       mutt_bit_isset(ctx->rights, MUTT_ACL_DELETE))
   {
-    mutt_message _("Expunging messages from server...");
+    mutt_message (_("Expunging messages from server..."));
     /* Set expunge bit so we don't get spurious reopened messages */
     idata->reopen |= IMAP_EXPUNGE_EXPECTED;
     if (imap_exec (idata, "EXPUNGE", 0) != 0)

--- a/imap/message.c
+++ b/imap/message.c
@@ -95,7 +95,7 @@ int imap_read_headers (IMAP_DATA* idata, int msgbegin, int msgend)
   }
   else
   {	/* Unable to fetch headers for lower versions */
-    mutt_error _("Unable to fetch headers from this IMAP server version.");
+    mutt_error (_("Unable to fetch headers from this IMAP server version."));
     mutt_sleep (2);	/* pause a moment to let the user see the error */
     goto error_out_0;
   }
@@ -443,7 +443,7 @@ int imap_fetch_message (CONTEXT *ctx, MESSAGE *msg, int msgno)
   }
 
   if (!isendwin())
-    mutt_message _("Fetching message...");
+    mutt_message (_("Fetching message..."));
 
   if (!(msg->fp = msg_cache_put (idata, h)))
   {

--- a/init.c
+++ b/init.c
@@ -1284,7 +1284,7 @@ static int parse_attachments (BUFFER *buf, BUFFER *s, unsigned long data, BUFFER
   if (op == '?') {
     mutt_endwin (NULL);
     fflush (stdout);
-    printf("\nCurrent attachments settings:\n\n");
+    printf(_("\nCurrent attachments settings:\n\n"));
     print_attach_list(AttachAllow,   '+', "A");
     print_attach_list(AttachExclude, '-', "A");
     print_attach_list(InlineAllow,   '+', "I");

--- a/keymap.c
+++ b/keymap.c
@@ -533,14 +533,14 @@ int km_dokey (int menu)
 
       if (option (OPTIGNOREMACROEVENTS))
       {
-	mutt_error _("Macros are currently disabled.");
+	mutt_error (_("Macros are currently disabled."));
 	return -1;
       }
 
       if (n++ == 10)
       {
 	mutt_flushinp ();
-	mutt_error _("Macro loop detected.");
+	mutt_error (_("Macro loop detected."));
 	return -1;
       }
 
@@ -846,7 +846,7 @@ void km_error_key (int menu)
   
   if(!(km_expand_key(buf, sizeof(buf), key)))
   {
-    mutt_error _("Key is not bound.");
+    mutt_error (_("Key is not bound."));
     return;
   }
 
@@ -854,7 +854,7 @@ void km_error_key (int menu)
   tokenize_unget_string (buf);
   if (km_dokey (menu) != OP_HELP)
   {
-    mutt_error _("Key is not bound.");
+    mutt_error (_("Key is not bound."));
     return;
   }
 

--- a/lib.c
+++ b/lib.c
@@ -128,14 +128,14 @@ void *safe_calloc (size_t nmemb, size_t size)
 
   if (((size_t) -1) / nmemb <= size)
   {
-    mutt_error _("Integer overflow -- can't allocate memory!");
+    mutt_error (_("Integer overflow -- can't allocate memory!"));
     sleep (1);
     mutt_exit (1);
   }
   
   if (!(p = calloc (nmemb, size)))
   {
-    mutt_error _("Out of memory!");
+    mutt_error (_("Out of memory!"));
     sleep (1);
     mutt_exit (1);
   }
@@ -150,7 +150,7 @@ void *safe_malloc (size_t siz)
     return 0;
   if ((p = (void *) malloc (siz)) == 0)	/* __MEM_CHECKED__ */
   {
-    mutt_error _("Out of memory!");
+    mutt_error (_("Out of memory!"));
     sleep (1);
     mutt_exit (1);
   }
@@ -182,7 +182,7 @@ void safe_realloc (void *ptr, size_t siz)
 
   if (!r)
   {
-    mutt_error _("Out of memory!");
+    mutt_error (_("Out of memory!"));
     sleep (1);
     mutt_exit (1);
   }

--- a/lib.h
+++ b/lib.h
@@ -44,7 +44,7 @@
 
 # ifdef ENABLE_NLS
 #  include <libintl.h>
-# define _(a) (gettext (a))
+# define _(a) gettext (a)
 #  ifdef gettext_noop
 #   define N_(a) gettext_noop (a)
 #  else

--- a/main.c
+++ b/main.c
@@ -82,7 +82,7 @@ static void mutt_usage (void)
 {
   puts (mutt_make_version ());
 
-  puts _(
+  puts (_(
 "usage: mutt [<options>] [-z] [-f <file> | -yZ]\n\
        mutt [<options>] [-Ex] [-Hi <file>] [-s <subj>] [-bc <addr>] [-a <file> [...] --] <addr> [...]\n\
        mutt [<options>] [-x] [-s <subj>] [-bc <addr>] [-a <file> [...] --] <addr> [...] < message\n\
@@ -90,9 +90,9 @@ static void mutt_usage (void)
        mutt [<options>] -A <alias> [...]\n\
        mutt [<options>] -Q <query> [...]\n\
        mutt [<options>] -D [-S]\n\
-       mutt -v[v]\n");
+       mutt -v[v]\n"));
 
-  puts _("\
+  puts (_("\
 options:\n\
   -A <alias>\texpand the given alias\n\
   -a <file> [...] --\tattach file(s) to the message\n\
@@ -100,11 +100,11 @@ options:\n\
   -b <address>\tspecify a blind carbon-copy (BCC) address\n\
   -c <address>\tspecify a carbon-copy (CC) address\n\
   -D\t\tprint the value of all variables to stdout\n\
-  -D -S\t\tlike -D, but hide the value of sensitive variables");
+  -D -S\t\tlike -D, but hide the value of sensitive variables"));
 #if DEBUG
-  puts _("  -d <level>\tlog debugging output to ~/.muttdebug0");
+  puts (_("  -d <level>\tlog debugging output to ~/.muttdebug0"));
 #endif
-  puts _(
+  puts (_(
 "  -E\t\tedit the draft (-H) or include (-i) file\n\
   -e <command>\tspecify a command to be executed after initialization\n\
   -f <file>\tspecify which mailbox to read\n\
@@ -115,9 +115,9 @@ options:\n\
   -i <file>\tspecify a file which Mutt should include in the body\n\
   -m <type>\tspecify a default mailbox type\n\
   -n\t\tcauses Mutt not to read the system Muttrc\n\
-  -p\t\trecall a postponed message");
+  -p\t\trecall a postponed message"));
   
-  puts _("\
+  puts (_("\
   -Q <variable>\tquery a configuration variable\n\
   -R\t\topen mailbox in read-only mode\n\
   -s <subj>\tspecify a subject (must be in quotes if it has spaces)\n\
@@ -126,7 +126,7 @@ options:\n\
   -y\t\tselect a mailbox specified in your `mailboxes' list\n\
   -z\t\texit immediately if there are no messages in the mailbox\n\
   -Z\t\topen the first folder with new message, exit immediately if none\n\
-  -h\t\tthis help message");
+  -h\t\tthis help message"));
 
   exit (0);
 }
@@ -149,7 +149,7 @@ static void start_curses (void)
 #endif
   if (initscr () == NULL)
   {
-    puts _("Error initializing terminal.");
+    puts (_("Error initializing terminal."));
     exit (1);
   }
 #if 1 /* USE_SLANG_CURSES  - commenting out suggested in #455. */
@@ -312,7 +312,7 @@ int main (int argc, char **argv, char **environ)
 	}
 	printf (_("Debugging at level %d.\n"), debuglevel);
 #else
-	printf _("DEBUG was not defined during compilation.  Ignored.\n");
+	printf (_("DEBUG was not defined during compilation.  Ignored.\n"));
 #endif
 	break;
 
@@ -508,7 +508,7 @@ int main (int argc, char **argv, char **environ)
       if (mutt_yesorno (msg, MUTT_YES) == MUTT_YES)
       {
 	if (mkdir (fpath, 0700) == -1 && errno != EEXIST)
-	  mutt_error ( _("Can't create %s: %s."), Maildir, strerror (errno));
+	  mutt_error (_("Can't create %s: %s."), Maildir, strerror (errno));
       }
     }
   }
@@ -820,7 +820,7 @@ int main (int argc, char **argv, char **environ)
     {
       if (!mutt_buffy_check (0))
       {
-	mutt_endwin _("No mailbox with new mail.");
+	mutt_endwin (_("No mailbox with new mail."));
 	exit (1);
       }
       folder[0] = 0;
@@ -841,7 +841,7 @@ int main (int argc, char **argv, char **environ)
       else
 #endif
       if (!Incoming) {
-	mutt_endwin _("No incoming mailboxes defined.");
+	mutt_endwin (_("No incoming mailboxes defined."));
 	exit (1);
       }
       folder[0] = 0;
@@ -884,7 +884,7 @@ int main (int argc, char **argv, char **environ)
 	  mutt_endwin (strerror (errno));
 	  exit (1);
 	case 1:
-	  mutt_endwin _("Mailbox is empty.");
+	  mutt_endwin (_("Mailbox is empty."));
 	  exit (1);
       }
     }

--- a/mbox.c
+++ b/mbox.c
@@ -158,7 +158,7 @@ int mmdf_parse_mailbox (CONTEXT *ctx)
 	if (fseeko (ctx->fp, loc, SEEK_SET) != 0)
 	{
 	  dprint (1, (debugfile, "mmdf_parse_mailbox: fseek() failed\n"));
-	  mutt_error _("Mailbox is corrupt!");
+	  mutt_error (_("Mailbox is corrupt!"));
 	  return (-1);
 	}
       } 
@@ -215,7 +215,7 @@ int mmdf_parse_mailbox (CONTEXT *ctx)
     else
     {
       dprint (1, (debugfile, "mmdf_parse_mailbox: corrupt mailbox!\n"));
-      mutt_error _("Mailbox is corrupt!");
+      mutt_error (_("Mailbox is corrupt!"));
       return (-1);
     }
   }
@@ -519,7 +519,7 @@ static int mbox_commit_message (CONTEXT *ctx, MESSAGE *msg)
   if ((fflush (msg->fp) == EOF) ||
       (fsync (fileno (msg->fp)) == -1))
   {
-    mutt_perror _("Can't write message");
+    mutt_perror (_("Can't write message"));
     return -1;
   }
 
@@ -534,7 +534,7 @@ static int mmdf_commit_message (CONTEXT *ctx, MESSAGE *msg)
   if ((fflush (msg->fp) == EOF) ||
       (fsync (fileno (msg->fp)) == -1))
   {
-    mutt_perror _("Can't write message");
+    mutt_perror (_("Can't write message"));
     return -1;
   }
 
@@ -774,7 +774,7 @@ static int mbox_check_mailbox (CONTEXT *ctx, int *index_hint)
   mbox_unlock_mailbox (ctx);
   mx_fastclose_mailbox (ctx);
   mutt_unblock_signals ();
-  mutt_error _("Mailbox was corrupted!");
+  mutt_error (_("Mailbox was corrupted!"));
   return (-1);
 }
 
@@ -856,7 +856,7 @@ static int mbox_sync_mailbox (CONTEXT *ctx, int *index_hint)
   if ((ctx->fp = freopen (ctx->path, "r+", ctx->fp)) == NULL)
   {
     mx_fastclose_mailbox (ctx);
-    mutt_error _("Fatal error!  Could not reopen mailbox!");
+    mutt_error (_("Fatal error!  Could not reopen mailbox!"));
     return (-1);
   }
 
@@ -865,7 +865,7 @@ static int mbox_sync_mailbox (CONTEXT *ctx, int *index_hint)
   if (mbox_lock_mailbox (ctx, 1, 1) == -1)
   {
     mutt_unblock_signals ();
-    mutt_error _("Unable to lock mailbox!");
+    mutt_error (_("Unable to lock mailbox!"));
     goto bail;
   }
 
@@ -891,7 +891,7 @@ static int mbox_sync_mailbox (CONTEXT *ctx, int *index_hint)
       close (i);
       unlink (tempfile);
     }
-    mutt_error _("Could not create temporary file!");
+    mutt_error (_("Could not create temporary file!"));
     mutt_sleep (5);
     goto bail;
   }
@@ -908,7 +908,7 @@ static int mbox_sync_mailbox (CONTEXT *ctx, int *index_hint)
      * messages were found to be changed or deleted.  This should
      * never happen, is we presume it is a bug in mutt.
      */
-    mutt_error _("sync: mbox modified, but no modified messages! (report this bug)");
+    mutt_error (_("sync: mbox modified, but no modified messages! (report this bug)"));
     mutt_sleep(5); /* the mutt_error /will/ get cleared! */
     dprint(1, (debugfile, "mbox_sync_mailbox(): no modified messages.\n"));
     unlink (tempfile);
@@ -1067,7 +1067,7 @@ static int mbox_sync_mailbox (CONTEXT *ctx, int *index_hint)
        * change/deleted message
        */
       if (!ctx->quiet)
-	mutt_message _("Committing changes...");
+	mutt_message (_("Committing changes..."));
       i = mutt_copy_stream (fp, ctx->fp);
 
       if (ferror (ctx->fp))
@@ -1116,7 +1116,7 @@ static int mbox_sync_mailbox (CONTEXT *ctx, int *index_hint)
     unlink (tempfile);
     mutt_unblock_signals ();
     mx_fastclose_mailbox (ctx);
-    mutt_error _("Fatal error!  Could not reopen mailbox!");
+    mutt_error (_("Fatal error!  Could not reopen mailbox!"));
     return (-1);
   }
 
@@ -1171,7 +1171,7 @@ bail:  /* Come here in case of disaster */
 
   if ((ctx->fp = freopen (ctx->path, "r", ctx->fp)) == NULL)
   {
-    mutt_error _("Could not reopen mailbox!");
+    mutt_error (_("Could not reopen mailbox!"));
     mx_fastclose_mailbox (ctx);
     return (-1);
   }
@@ -1198,7 +1198,7 @@ int mutt_reopen_mailbox (CONTEXT *ctx, int *index_hint)
   ctx->quiet = 1;
   
   if (!ctx->quiet)
-    mutt_message _("Reopening mailbox...");
+    mutt_message (_("Reopening mailbox..."));
   
   /* our heuristics require the old mailbox to be unsorted */
   if (Sort != SORT_ORDER)

--- a/menu.c
+++ b/menu.c
@@ -501,11 +501,11 @@ void menu_jump (MUTTMENU *menu)
 	menu->redraw = REDRAW_MOTION;
       }
       else
-	mutt_error _("Invalid index number.");
+	mutt_error (_("Invalid index number."));
     }
   }
   else
-    mutt_error _("No entries.");
+    mutt_error (_("No entries."));
 }
 
 void menu_next_line (MUTTMENU *menu)
@@ -523,10 +523,10 @@ void menu_next_line (MUTTMENU *menu)
       menu->redraw = REDRAW_INDEX;
     }
     else
-      mutt_error _("You cannot scroll down farther.");
+      mutt_error (_("You cannot scroll down farther."));
   }
   else
-    mutt_error _("No entries.");
+    mutt_error (_("No entries."));
 }
 
 void menu_prev_line (MUTTMENU *menu)
@@ -541,7 +541,7 @@ void menu_prev_line (MUTTMENU *menu)
     menu->redraw = REDRAW_INDEX;
   }
   else
-    mutt_error _("You cannot scroll up farther.");
+    mutt_error (_("You cannot scroll up farther."));
 }
 
 /* 
@@ -591,7 +591,7 @@ static void menu_length_jump (MUTTMENU *menu, int jumplen)
     menu->current = MAX (menu->current, 0);
   }
   else
-    mutt_error _("No entries.");
+    mutt_error (_("No entries."));
 }
 #undef DIRECTION
 
@@ -634,7 +634,7 @@ void menu_bottom_page (MUTTMENU *menu)
     menu->redraw = REDRAW_MOTION;
   }
   else
-    mutt_error _("No entries.");
+    mutt_error (_("No entries."));
 }
 
 void menu_middle_page (MUTTMENU *menu)
@@ -650,7 +650,7 @@ void menu_middle_page (MUTTMENU *menu)
     menu->redraw = REDRAW_MOTION;
   }
   else
-    mutt_error _("No entries.");
+    mutt_error (_("No entries."));
 }
 
 void menu_first_entry (MUTTMENU *menu)
@@ -661,7 +661,7 @@ void menu_first_entry (MUTTMENU *menu)
     menu->redraw = REDRAW_MOTION;
   }
   else
-    mutt_error _("No entries.");
+    mutt_error (_("No entries."));
 }
 
 void menu_last_entry (MUTTMENU *menu)
@@ -672,7 +672,7 @@ void menu_last_entry (MUTTMENU *menu)
     menu->redraw = REDRAW_MOTION;
   }
   else
-    mutt_error _("No entries.");
+    mutt_error (_("No entries."));
 }
 
 void menu_current_top (MUTTMENU *menu)
@@ -683,7 +683,7 @@ void menu_current_top (MUTTMENU *menu)
     menu->redraw = REDRAW_INDEX;
   }
   else
-    mutt_error _("No entries.");
+    mutt_error (_("No entries."));
 }
 
 void menu_current_middle (MUTTMENU *menu)
@@ -696,7 +696,7 @@ void menu_current_middle (MUTTMENU *menu)
     menu->redraw = REDRAW_INDEX;
   }
   else
-    mutt_error _("No entries.");
+    mutt_error (_("No entries."));
 }
 
 void menu_current_bottom (MUTTMENU *menu)
@@ -709,7 +709,7 @@ void menu_current_bottom (MUTTMENU *menu)
     menu->redraw = REDRAW_INDEX;
   }
   else
-    mutt_error _("No entries.");
+    mutt_error (_("No entries."));
 }
 
 static void menu_next_entry (MUTTMENU *menu)
@@ -720,7 +720,7 @@ static void menu_next_entry (MUTTMENU *menu)
     menu->redraw = REDRAW_MOTION;
   }
   else
-    mutt_error _("You are on the last entry.");
+    mutt_error (_("You are on the last entry."));
 }
 
 static void menu_prev_entry (MUTTMENU *menu)
@@ -731,7 +731,7 @@ static void menu_prev_entry (MUTTMENU *menu)
     menu->redraw = REDRAW_MOTION;
   }
   else
-    mutt_error _("You are on the first entry.");
+    mutt_error (_("You are on the first entry."));
 }
 
 static int default_color (int i)
@@ -853,7 +853,7 @@ search_next:
     goto search_next;
   }
   regfree (&re);
-  mutt_error _("Not found.");
+  mutt_error (_("Not found."));
   return (-1);
 }
 
@@ -993,13 +993,13 @@ int mutt_menuLoop (MUTTMENU *menu)
       }
       else if (i == OP_TAG_PREFIX)
       {
-	mutt_error _("No tagged entries.");
+	mutt_error (_("No tagged entries."));
 	i = -1;
       }
       else /* None tagged, OP_TAG_PREFIX_COND */
       {
 	mutt_flush_macro_to_endcond ();
-	mutt_message _("Nothing to do.");
+	mutt_message (_("Nothing to do."));
 	i = -1;
       }
     }
@@ -1093,12 +1093,12 @@ int mutt_menuLoop (MUTTMENU *menu)
 	    menu->current = menu->oldcurrent;
 	}
 	else
-	  mutt_error _("Search is not implemented for this menu.");
+	  mutt_error (_("Search is not implemented for this menu."));
 	break;
 
       case OP_JUMP:
 	if (menu->dialog)
-	  mutt_error _("Jumping is not implemented for dialogs.");
+	  mutt_error (_("Jumping is not implemented for dialogs."));
 	else
 	  menu_jump (menu);
 	break;
@@ -1136,10 +1136,10 @@ int mutt_menuLoop (MUTTMENU *menu)
 	      menu->redraw = REDRAW_CURRENT;
 	  }
 	  else
-	    mutt_error _("No entries.");
+	    mutt_error (_("No entries."));
 	}
 	else
-	  mutt_error _("Tagging is not supported.");
+	  mutt_error (_("Tagging is not supported."));
 	break;
 
       case OP_SHELL_ESCAPE:

--- a/mutt_socket.c
+++ b/mutt_socket.c
@@ -297,7 +297,7 @@ CONNECTION* mutt_conn_find (const CONNECTION* start, const ACCOUNT* account)
       return NULL;
     }
 #else
-    mutt_error _("SSL is unavailable.");
+    mutt_error (_("SSL is unavailable."));
     mutt_sleep (2);
     mutt_socket_free (conn);
 

--- a/muttlib.c
+++ b/muttlib.c
@@ -1742,7 +1742,7 @@ int mutt_save_confirm (const char *s, struct stat *st)
 #ifdef USE_POP
   if (magic == MUTT_POP)
   {
-    mutt_error _("Can't save message to POP mailbox.");
+    mutt_error (_("Can't save message to POP mailbox."));
     return 1;
   }
 #endif

--- a/mx.c
+++ b/mx.c
@@ -176,7 +176,7 @@ retry_lock:
     } 
     else
     {
-      mutt_error ( _("Can't dotlock %s.\n"), path);
+      mutt_error (_("Can't dotlock %s.\n"), path);
     }
   }
   return (r == DL_EX_OK ? 0 : -1);
@@ -232,7 +232,7 @@ int mx_lock_file (const char *path, int fd, int excl, int dot, int timeout)
     if (prev_sb.st_size == sb.st_size && ++count >= (timeout?MAXLOCKATTEMPT:0))
     {
       if (timeout)
-	mutt_error _("Timeout exceeded while attempting fcntl lock!");
+	mutt_error (_("Timeout exceeded while attempting fcntl lock!"));
       return -1;
     }
 
@@ -265,7 +265,7 @@ int mx_lock_file (const char *path, int fd, int excl, int dot, int timeout)
     if (prev_sb.st_size == sb.st_size && ++count >= (timeout?MAXLOCKATTEMPT:0))
     {
       if (timeout)
-	mutt_error _("Timeout exceeded while attempting flock lock!");
+	mutt_error (_("Timeout exceeded while attempting flock lock!"));
       r = -1;
       break;
     }
@@ -783,7 +783,7 @@ static int trash_append (CONTEXT *ctx)
     set_option (OPTCONFIRMAPPEND);
   if (rc != 0)
   {
-    mutt_error _("message(s) not deleted");
+    mutt_error (_("message(s) not deleted"));
     return -1;
   }
 
@@ -816,7 +816,7 @@ static int trash_append (CONTEXT *ctx)
   }
   else
   {
-    mutt_error _("Can't open trash folder");
+    mutt_error (_("Can't open trash folder"));
     return -1;
   }
 
@@ -997,7 +997,7 @@ int mx_close_mailbox (CONTEXT *ctx, int *index_hint)
   else if (!ctx->changed && ctx->deleted == 0)
   {
     if (!ctx->quiet)
-      mutt_message _("Mailbox is unchanged.");
+      mutt_message (_("Mailbox is unchanged."));
     if (ctx->magic == MUTT_MBOX || ctx->magic == MUTT_MMDF)
       mbox_reset_atime (ctx, NULL);
     mx_fastclose_mailbox (ctx);
@@ -1190,14 +1190,14 @@ int mx_sync_mailbox (CONTEXT *ctx, int *index_hint)
   }
   else if (ctx->readonly)
   {
-    mutt_error _("Mailbox is read-only.");
+    mutt_error (_("Mailbox is read-only."));
     return -1;
   }
 
   if (!ctx->changed && !ctx->deleted)
   {
     if (!ctx->quiet)
-      mutt_message _("Mailbox is unchanged.");
+      mutt_message (_("Mailbox is unchanged."));
     return (0);
   }
 
@@ -1252,7 +1252,7 @@ int mx_sync_mailbox (CONTEXT *ctx, int *index_hint)
     if (ctx->magic == MUTT_IMAP && !purge)
     {
       if (!ctx->quiet)
-        mutt_message _("Mailbox checkpointed.");
+        mutt_message (_("Mailbox checkpointed."));
     }
     else
 #endif
@@ -1430,7 +1430,7 @@ void mx_alloc_memory (CONTEXT *ctx)
   
   if ((ctx->hdrmax + 25) * s < ctx->hdrmax * s)
   {
-    mutt_error _("Integer overflow -- can't allocate memory.");
+    mutt_error (_("Integer overflow -- can't allocate memory."));
     sleep (1);
     mutt_exit (1);
   }

--- a/nntp.c
+++ b/nntp.c
@@ -2190,7 +2190,7 @@ int nntp_check_new_groups (NNTP_SERVER *nserv)
   time_t now;
   struct tm *tm;
   char buf[LONG_STRING];
-  char *msg = _("Checking for new newsgroups...");
+  char *msg = (_("Checking for new newsgroups..."));
   unsigned int i;
   int rc, update_active = false;
 

--- a/pager.c
+++ b/pager.c
@@ -62,21 +62,21 @@ static HEADER *OldHdr = NULL;
 #define CHECK_MODE(x)	if (!(x)) \
 			{ \
 			  	mutt_flushinp (); \
-				mutt_error _(Not_available_in_this_menu); \
+				mutt_error(_(Not_available_in_this_menu)); \
 				break; \
 			}
 
 #define CHECK_READONLY	if (!Context || Context->readonly) \
 			{ \
 				mutt_flushinp (); \
-				mutt_error _(Mailbox_is_read_only);	\
+				mutt_error(_(Mailbox_is_read_only));	\
 				break; \
 			}
 
 #define CHECK_ATTACH if(option(OPTATTACHMSG)) \
 		     {\
 			mutt_flushinp (); \
-			mutt_error _(Function_not_permitted_in_attach_message_mode); \
+			mutt_error(_(Function_not_permitted_in_attach_message_mode)); \
 			break; \
 		     }
 
@@ -2190,7 +2190,7 @@ mutt_pager (const char *banner, const char *fname, int flags, pager_t *extra)
 	else if (option (OPTPAGERSTOP))
 	{
 	  /* emulate "less -q" and don't go on to the next message. */
-	  mutt_error _("Bottom of message is shown.");
+	  mutt_error (_("Bottom of message is shown."));
 	}
 	else
 	{
@@ -2206,7 +2206,7 @@ mutt_pager (const char *banner, const char *fname, int flags, pager_t *extra)
 	  topline = upNLines (pager_window->rows-PagerContext, lineInfo, topline, hideQuoted);
 	}
 	else
-	  mutt_error _("Top of message is shown.");
+	  mutt_error (_("Top of message is shown."));
 	break;
 
       case OP_NEXT_LINE:
@@ -2221,28 +2221,28 @@ mutt_pager (const char *banner, const char *fname, int flags, pager_t *extra)
 	  }
 	}
 	else
-	  mutt_error _("Bottom of message is shown.");
+	  mutt_error (_("Bottom of message is shown."));
 	break;
 
       case OP_PREV_LINE:
 	if (topline)
 	  topline = upNLines (1, lineInfo, topline, hideQuoted);
 	else
-	  mutt_error _("Top of message is shown.");
+	  mutt_error (_("Top of message is shown."));
 	break;
 
       case OP_PAGER_TOP:
         if (topline)
 	  topline = 0;
       	else
-	  mutt_error _("Top of message is shown.");
+	  mutt_error (_("Top of message is shown."));
 	break;
 
       case OP_HALF_UP:
 	if (topline)
 	  topline = upNLines (pager_window->rows/2, lineInfo, topline, hideQuoted);
 	else
-	  mutt_error _("Top of message is shown.");
+	  mutt_error (_("Top of message is shown."));
 	break;
 
       case OP_HALF_DOWN:
@@ -2253,7 +2253,7 @@ mutt_pager (const char *banner, const char *fname, int flags, pager_t *extra)
 	else if (option (OPTPAGERSTOP))
 	{
 	  /* emulate "less -q" and don't go on to the next message. */
-	  mutt_error _("Bottom of message is shown.");
+	  mutt_error (_("Bottom of message is shown."));
 	}
 	else
 	{
@@ -2289,10 +2289,10 @@ search_next:
 	    if (i < lastLine)
 	      topline = i;
 	    else if (wrapped || !option (OPTWRAPSEARCH))
-	      mutt_error _("Not found.");
+	      mutt_error (_("Not found."));
 	    else
 	    {
-	      mutt_message _("Search wrapped to top.");
+	      mutt_message (_("Search wrapped to top."));
 	      wrapped = 1;
 	      goto search_next;
 	    }
@@ -2311,10 +2311,10 @@ search_next:
 	    if (i >= 0)
 	      topline = i;
 	    else if (wrapped || !option (OPTWRAPSEARCH))
-	      mutt_error _("Not found.");
+	      mutt_error (_("Not found."));
 	    else
 	    {
-	      mutt_message _("Search wrapped to bottom.");
+	      mutt_message (_("Search wrapped to bottom."));
 	      wrapped = 1;
 	      goto search_next;
 	    }
@@ -2431,7 +2431,7 @@ search_next:
 	  if (lineInfo[topline].search_cnt == 0)
 	  {
 	    SearchFlag = 0;
-	    mutt_error _("Not found.");
+	    mutt_error (_("Not found."));
 	  }
 	  else
 	  {
@@ -2467,7 +2467,7 @@ search_next:
 	  InHelp = 0;
 	}
 	else
-	  mutt_error _("Help is currently being shown.");
+	  mutt_error (_("Help is currently being shown."));
 	break;
 
       case OP_PAGER_HIDE_QUOTED:
@@ -2511,7 +2511,7 @@ search_next:
 
 	  if (dretval < 0)
 	  {
-	    mutt_error _("No more quoted text.");
+	    mutt_error (_("No more quoted text."));
 	    break;
 	  }
 
@@ -2524,7 +2524,7 @@ search_next:
 
 	  if (dretval < 0)
 	  {
-	    mutt_error _("No more unquoted text after quoted text.");
+	    mutt_error (_("No more unquoted text after quoted text."));
 	    break;	  
 	  }
 	  topline = new_topline;
@@ -2544,7 +2544,7 @@ search_next:
 	  topline = upNLines (pager_window->rows, lineInfo, lastLine, hideQuoted);
 	}
 	else
-	  mutt_error _("Bottom of message is shown.");
+	  mutt_error (_("Bottom of message is shown."));
 	break;
 
       case OP_REDRAW:

--- a/parse.c
+++ b/parse.c
@@ -585,7 +585,7 @@ BODY *mutt_parse_multipart (FILE *fp, const char *boundary, LOFF_T end_off, int 
 
   if (!boundary)
   {
-    mutt_error _("multipart message has no boundary parameter!");
+    mutt_error (_("multipart message has no boundary parameter!"));
     return (NULL);
   }
 

--- a/pattern.c
+++ b/pattern.c
@@ -1764,7 +1764,7 @@ int mutt_pattern_func (int op, char *prompt)
   if (mutt_get_field (prompt, buf, sizeof (buf), MUTT_PATTERN | MUTT_CLEAR) != 0 || !buf[0])
     return (-1);
 
-  mutt_message _("Compiling search pattern...");
+  mutt_message (_("Compiling search pattern..."));
   
   simple = safe_strdup (buf);
   mutt_check_simple (buf, sizeof (buf), NONULL (SimpleSearch));
@@ -1854,7 +1854,7 @@ int mutt_pattern_func (int op, char *prompt)
       mutt_pattern_free (&Context->limit_pattern);
 
     if (Context->msgcount && !Context->vcount)
-      mutt_error _("No messages matched criteria.");
+      mutt_error (_("No messages matched criteria."));
 
     /* record new limit pattern, unless match all */
     if (mutt_strcmp (buf, "~A") != 0)
@@ -1906,7 +1906,7 @@ int mutt_search_command (int cur, int op)
       mutt_buffer_init (&err);
       set_option (OPTSEARCHINVALID);
       strfcpy (LastSearch, buf, sizeof (LastSearch));
-      mutt_message _("Compiling search pattern...");
+      mutt_message (_("Compiling search pattern..."));
       mutt_pattern_free (&SearchPattern);
       err.dsize = STRING;
       err.data = safe_malloc (err.dsize);
@@ -1949,7 +1949,7 @@ int mutt_search_command (int cur, int op)
         msg = _("Search wrapped to top.");
       else 
       {
-        mutt_message _("Search hit bottom without finding match");
+        mutt_message (_("Search hit bottom without finding match"));
 	return (-1);
       }
     }
@@ -1960,7 +1960,7 @@ int mutt_search_command (int cur, int op)
         msg = _("Search wrapped to bottom.");
       else 
       {
-        mutt_message _("Search hit top without finding match");
+        mutt_message (_("Search hit top without finding match"));
 	return (-1);
       }
     }
@@ -1992,7 +1992,7 @@ int mutt_search_command (int cur, int op)
 
     if (SigInt)
     {
-      mutt_error _("Search interrupted.");
+      mutt_error (_("Search interrupted."));
       SigInt = 0;
       return (-1);
     }
@@ -2000,6 +2000,6 @@ int mutt_search_command (int cur, int op)
     i += incr;
   }
 
-  mutt_error _("Not found.");
+  mutt_error (_("Not found."));
   return (-1);
 }

--- a/pattern.c
+++ b/pattern.c
@@ -183,7 +183,7 @@ msg_search (CONTEXT *ctx, pattern_t* pat, int msgno)
 #ifdef USE_FMEMOPEN
       s.fpout = open_memstream (&temp, &tempsize);
       if (!s.fpout) {
-	mutt_perror ("Error opening memstream");
+	mutt_perror (_("Error opening memstream"));
 	return 0;
       }
 #else
@@ -229,13 +229,13 @@ msg_search (CONTEXT *ctx, pattern_t* pat, int msgno)
       if (tempsize) {
         fp = fmemopen (temp, tempsize, "r");
         if (!fp) {
-          mutt_perror ("Error re-opening memstream");
+          mutt_perror (_("Error re-opening memstream"));
           return 0;
         }
       } else { /* fmemopen cannot handle empty buffers */
         fp = safe_fopen ("/dev/null", "r");
         if (!fp) {
-          mutt_perror ("Error opening /dev/null");
+          mutt_perror (_("Error opening /dev/null"));
           return 0;
         }
       }

--- a/pgp.c
+++ b/pgp.c
@@ -102,7 +102,7 @@ int pgp_valid_passphrase (void)
 void pgp_forget_passphrase (void)
 {
   pgp_void_passphrase ();
-  mutt_message _("PGP passphrase forgotten.");
+  mutt_message (_("PGP passphrase forgotten."));
 }
 
 int pgp_use_gpg_agent (void)
@@ -502,7 +502,7 @@ int pgp_application_pgp_handler (BODY *m, STATE *s)
 	
 	if (could_not_decrypt && !(s->flags & MUTT_DISPLAY))
 	{
-          mutt_error _("Could not decrypt PGP message");
+          mutt_error (_("Could not decrypt PGP message"));
 	  mutt_sleep (1);
 	  rc = -1;
 	  goto out;
@@ -565,9 +565,9 @@ int pgp_application_pgp_handler (BODY *m, STATE *s)
         {
 	  state_attach_puts (_("[-- END PGP MESSAGE --]\n"), s);
 	  if (could_not_decrypt)
-	    mutt_error _("Could not decrypt PGP message");
+	    mutt_error (_("Could not decrypt PGP message"));
 	  else
-	    mutt_message _("PGP message successfully decrypted.");
+	    mutt_message (_("PGP message successfully decrypted."));
         }
 	else if (pgp_keyblock)
 	  state_attach_puts (_("[-- END PGP PUBLIC KEY BLOCK --]\n"), s);
@@ -857,7 +857,7 @@ void pgp_extract_keys_from_attachment_list (FILE *fp, int tag, BODY *top)
 {
   if(!fp)
   {
-    mutt_error _("Internal error.  Please submit a bug report.");
+    mutt_error (_("Internal error.  Please submit a bug report."));
     return;
   }
 
@@ -949,7 +949,7 @@ BODY *pgp_decrypt_part (BODY *a, STATE *s, FILE *fpout, BODY *p)
   rewind (pgperr);
   if (pgp_check_decryption_okay (pgperr) < 0)
   {
-    mutt_error _("Decryption failed");
+    mutt_error (_("Decryption failed"));
     pgp_void_passphrase ();
     return NULL;
   }
@@ -973,7 +973,7 @@ BODY *pgp_decrypt_part (BODY *a, STATE *s, FILE *fpout, BODY *p)
 
   if (fgetc (fpout) == EOF)
   {
-    mutt_error _("Decryption failed");
+    mutt_error (_("Decryption failed"));
     pgp_void_passphrase ();
     return NULL;
   }
@@ -1122,11 +1122,11 @@ int pgp_encrypted_handler (BODY *a, STATE *s)
 
     mutt_free_body (&tattach);
     /* clear 'Invoking...' message, since there's no error */
-    mutt_message _("PGP message successfully decrypted.");
+    mutt_message (_("PGP message successfully decrypted."));
   }
   else
   {
-    mutt_error _("Could not decrypt PGP message");
+    mutt_error (_("Could not decrypt PGP message"));
     mutt_sleep (2);
     /* void the passphrase, even if it's not necessarily the problem */
     pgp_void_passphrase ();
@@ -1179,7 +1179,7 @@ BODY *pgp_sign_message (BODY *a)
   if ((thepid = pgp_invoke_sign (&pgpin, &pgpout, &pgperr,
 				 -1, -1, -1, signedfile)) == -1)
   {
-    mutt_perror _("Can't open PGP subprocess!");
+    mutt_perror (_("Can't open PGP subprocess!"));
     safe_fclose (&fp);
     unlink(sigfile);
     unlink(signedfile);
@@ -1613,7 +1613,7 @@ BODY *pgp_traditional_encryptsign (BODY *a, int flags, char *keylist)
 					-1, fileno (pgpout), fileno (pgperr),
 					pgpinfile, keylist, flags)) == -1)
   {
-    mutt_perror _("Can't invoke PGP");
+    mutt_perror (_("Can't invoke PGP"));
     safe_fclose (&pgpout);
     safe_fclose (&pgperr);
     mutt_unlink (pgpinfile);

--- a/pgpinvoke.c
+++ b/pgpinvoke.c
@@ -307,7 +307,7 @@ void pgp_invoke_getkeys (ADDRESS *addr)
 
   devnull = open ("/dev/null", O_RDWR);
 
-  if (!isendwin ()) mutt_message  _("Fetching PGP key...");
+  if (!isendwin ()) mutt_message  (_("Fetching PGP key..."));
 
   mutt_system (cmd);
 

--- a/pgpkey.c
+++ b/pgpkey.c
@@ -488,7 +488,7 @@ static pgp_key_t pgp_select_key (pgp_key_t keys,
 
   if (!i && unusable)
   {
-    mutt_error _("All matching keys are expired, revoked, or disabled.");
+    mutt_error (_("All matching keys are expired, revoked, or disabled."));
     mutt_sleep (1);
     return NULL;
   }
@@ -550,17 +550,17 @@ static pgp_key_t pgp_select_key (pgp_key_t keys,
       mutt_mktemp (tempfile, sizeof (tempfile));
       if ((devnull = fopen ("/dev/null", "w")) == NULL)	/* __FOPEN_CHECKED__ */
       {
-	mutt_perror _("Can't open /dev/null");
+	mutt_perror (_("Can't open /dev/null"));
 	break;
       }
       if ((fp = safe_fopen (tempfile, "w")) == NULL)
       {
 	safe_fclose (&devnull);
-	mutt_perror _("Can't create temporary file");
+	mutt_perror (_("Can't create temporary file"));
 	break;
       }
 
-      mutt_message _("Invoking PGP...");
+      mutt_message (_("Invoking PGP..."));
 
       snprintf (tmpbuf, sizeof (tmpbuf), "0x%s",
           pgp_fpr_or_lkeyid (pgp_principal_key (KeyTable[menu->current]->parent)));
@@ -568,7 +568,7 @@ static pgp_key_t pgp_select_key (pgp_key_t keys,
       if ((thepid = pgp_invoke_verify_key (NULL, NULL, NULL, -1,
 		    fileno (fp), fileno (devnull), tmpbuf)) == -1)
       {
-	mutt_perror _("Can't create filter");
+	mutt_perror (_("Can't create filter"));
 	unlink (tempfile);
 	safe_fclose (&fp);
 	safe_fclose (&devnull);
@@ -598,7 +598,7 @@ static pgp_key_t pgp_select_key (pgp_key_t keys,
       if (option (OPTPGPCHECKTRUST))
 	if (!pgp_key_is_valid (KeyTable[menu->current]->parent))
 	{
-	  mutt_error _("This key can't be used: expired/disabled/revoked.");
+	  mutt_error (_("This key can't be used: expired/disabled/revoked."));
 	  break;
 	}
 
@@ -737,27 +737,27 @@ BODY *pgp_make_key_attachment (char *tempf)
 
   if ((tempfp = safe_fopen (tempf, tempf == tempfb ? "w" : "a")) == NULL)
   {
-    mutt_perror _("Can't create temporary file");
+    mutt_perror (_("Can't create temporary file"));
     return NULL;
   }
 
   if ((devnull = fopen ("/dev/null", "w")) == NULL)	/* __FOPEN_CHECKED__ */
   {
-    mutt_perror _("Can't open /dev/null");
+    mutt_perror (_("Can't open /dev/null"));
     safe_fclose (&tempfp);
     if (tempf == tempfb)
       unlink (tempf);
     return NULL;
   }
 
-  mutt_message _("Invoking PGP...");
+  mutt_message (_("Invoking PGP..."));
 
 
   if ((thepid = 
        pgp_invoke_export (NULL, NULL, NULL, -1,
 			   fileno (tempfp), fileno (devnull), tmp)) == -1)
   {
-    mutt_perror _("Can't create filter");
+    mutt_perror (_("Can't create filter"));
     unlink (tempf);
     safe_fclose (&tempfp);
     safe_fclose (&devnull);

--- a/pop.c
+++ b/pop.c
@@ -126,7 +126,7 @@ static int pop_read_header (POP_DATA *pop_data, HEADER *h)
     }
     case -3:
     {
-      mutt_error _("Can't write header to temporary file!");
+      mutt_error (_("Can't write header to temporary file!"));
       break;
     }
   }
@@ -452,7 +452,7 @@ static int pop_open_mailbox (CONTEXT *ctx)
 
     ctx->size = pop_data->size;
 
-    mutt_message _("Fetching list of messages...");
+    mutt_message (_("Fetching list of messages..."));
 
     ret = pop_fetch_headers (ctx);
 
@@ -565,7 +565,7 @@ static int pop_fetch_message (CONTEXT* ctx, MESSAGE* msg, int msgno)
     /* verify that massage index is correct */
     if (h->refno < 0)
     {
-      mutt_error _("The message index is incorrect. Try reopening the mailbox.");
+      mutt_error (_("The message index is incorrect. Try reopening the mailbox."));
       mutt_sleep (2);
       return -1;
     }
@@ -610,7 +610,7 @@ static int pop_fetch_message (CONTEXT* ctx, MESSAGE* msg, int msgno)
 
     if (ret == -3)
     {
-      mutt_error _("Can't write message to temporary file!");
+      mutt_error (_("Can't write message to temporary file!"));
       mutt_sleep (2);
       return -1;
     }
@@ -760,7 +760,7 @@ static int pop_check_mailbox (CONTEXT *ctx, int *index_hint)
 
   ctx->size = pop_data->size;
 
-  mutt_message _("Checking for new messages...");
+  mutt_message (_("Checking for new messages..."));
 
   ret = pop_fetch_headers (ctx);
   pop_clear_cache (pop_data);
@@ -789,7 +789,7 @@ void pop_fetch_mail (void)
 
   if (!PopHost)
   {
-    mutt_error _("POP host is not defined.");
+    mutt_error (_("POP host is not defined."));
     return;
   }
 
@@ -825,7 +825,7 @@ void pop_fetch_mail (void)
 
   conn->data = pop_data;
 
-  mutt_message _("Checking for new messages...");
+  mutt_message (_("Checking for new messages..."));
 
   /* find out how many messages are in the mailbox. */
   strfcpy (buffer, "STAT\r\n", sizeof (buffer));
@@ -853,7 +853,7 @@ void pop_fetch_mail (void)
 
   if (msgs <= last)
   {
-    mutt_message _("No new mail in POP mailbox.");
+    mutt_message (_("No new mail in POP mailbox."));
     goto finish;
   }
 
@@ -904,7 +904,7 @@ void pop_fetch_mail (void)
     }
     if (ret == -3)
     {
-      mutt_error _("Error while writing mailbox!");
+      mutt_error (_("Error while writing mailbox!"));
       break;
     }
 
@@ -931,7 +931,7 @@ finish:
   return;
 
 fail:
-  mutt_error _("Server closed connection!");
+  mutt_error (_("Server closed connection!"));
   mutt_socket_close (conn);
   FREE (&pop_data);
 }

--- a/pop_auth.c
+++ b/pop_auth.c
@@ -80,7 +80,7 @@ static pop_auth_res_t pop_auth_sasl (POP_DATA *pop_data, const char *method)
    */
   client_start = olen;
 
-  mutt_message _("Authenticating (SASL)...");
+  mutt_message (_("Authenticating (SASL)..."));
 
   bufsize = ((olen * 2) > LONG_STRING) ? (olen * 2) : LONG_STRING;
   buf = safe_malloc (bufsize);
@@ -177,7 +177,7 @@ bail:
   }
 
   FREE (&buf);
-  mutt_error _("SASL authentication failed.");
+  mutt_error (_("SASL authentication failed."));
   mutt_sleep (2);
 
   return POP_A_FAILURE;
@@ -212,12 +212,12 @@ static pop_auth_res_t pop_auth_apop (POP_DATA *pop_data, const char *method)
 
   if (rfc822_valid_msgid (pop_data->timestamp) < 0)
   {
-    mutt_error _("POP timestamp is invalid!");
+    mutt_error (_("POP timestamp is invalid!"));
     mutt_sleep (2);
     return POP_A_UNAVAIL;
   }
 
-  mutt_message _("Authenticating (APOP)...");
+  mutt_message (_("Authenticating (APOP)..."));
 
   /* Compute the authentication hash to send to the server */
   md5_init_ctx (&ctx);
@@ -240,7 +240,7 @@ static pop_auth_res_t pop_auth_apop (POP_DATA *pop_data, const char *method)
       return POP_A_SOCKET;
   }
 
-  mutt_error _("APOP authentication failed.");
+  mutt_error (_("APOP authentication failed."));
   mutt_sleep (2);
 
   return POP_A_FAILURE;
@@ -255,7 +255,7 @@ static pop_auth_res_t pop_auth_user (POP_DATA *pop_data, const char *method)
   if (!pop_data->cmd_user)
     return POP_A_UNAVAIL;
 
-  mutt_message _("Logging in...");
+  mutt_message (_("Logging in..."));
 
   snprintf (buf, sizeof (buf), "USER %s\r\n", pop_data->conn->account.user);
   ret = pop_query (pop_data, buf, sizeof (buf));

--- a/pop_lib.c
+++ b/pop_lib.c
@@ -333,7 +333,7 @@ int pop_open_connection (POP_DATA *pop_data)
 
   if (option(OPTSSLFORCETLS) && !pop_data->conn->ssf)
   {
-    mutt_error _("Encrypted connection unavailable");
+    mutt_error (_("Encrypted connection unavailable"));
     mutt_sleep (1);
     return -2;
   }
@@ -375,7 +375,7 @@ int pop_open_connection (POP_DATA *pop_data)
 
 err_conn:
   pop_data->status = POP_DISCONNECTED;
-  mutt_error _("Server closed connection!");
+  mutt_error (_("Server closed connection!"));
   mutt_sleep (2);
   return -1;
 }
@@ -389,7 +389,7 @@ void pop_logout (CONTEXT *ctx)
 
   if (pop_data->status == POP_CONNECTED)
   {
-    mutt_message _("Closing connection to POP server...");
+    mutt_message (_("Closing connection to POP server..."));
 
     if (ctx->readonly)
     {

--- a/postpone.c
+++ b/postpone.c
@@ -254,7 +254,7 @@ int mutt_get_postponed (CONTEXT *ctx, HEADER *hdr, HEADER **cur, char *fcc, size
   if ((PostContext = mx_open_mailbox (Postponed, MUTT_NOSORT, NULL)) == NULL)
   {
     PostCount = 0;
-    mutt_error _("No postponed messages.");
+    mutt_error (_("No postponed messages."));
     return (-1);
   }
 
@@ -263,7 +263,7 @@ int mutt_get_postponed (CONTEXT *ctx, HEADER *hdr, HEADER **cur, char *fcc, size
     PostCount = 0;
     mx_close_mailbox (PostContext, NULL);
     FREE (&PostContext);
-    mutt_error _("No postponed messages.");
+    mutt_error (_("No postponed messages."));
     return (-1);
   }
 
@@ -465,7 +465,7 @@ int mutt_parse_crypt_hdr (const char *p, int set_empty_signas, int crypt_app)
 
           if (*p!='>')
           {
-            mutt_error _("Illegal crypto header");
+            mutt_error (_("Illegal crypto header"));
             return 0;
           }
         }
@@ -486,7 +486,7 @@ int mutt_parse_crypt_hdr (const char *p, int set_empty_signas, int crypt_app)
 	    ;
 	  if(*p != '>')
 	  {
-	    mutt_error _("Illegal crypto header");
+	    mutt_error (_("Illegal crypto header"));
 	    return 0;
 	  }
 	}
@@ -506,7 +506,7 @@ int mutt_parse_crypt_hdr (const char *p, int set_empty_signas, int crypt_app)
 
 	  if(*p != '>')
 	  {
-	    mutt_error _("Illegal S/MIME header");
+	    mutt_error (_("Illegal S/MIME header"));
 	    return 0;
 	  }
 	}
@@ -520,7 +520,7 @@ int mutt_parse_crypt_hdr (const char *p, int set_empty_signas, int crypt_app)
 	break;
 
       default:
-        mutt_error _("Illegal crypto header");
+        mutt_error (_("Illegal crypto header"));
         return 0;
     }
 
@@ -603,7 +603,7 @@ int mutt_prepare_template (FILE *fp, CONTEXT *ctx, HEADER *newhdr, HEADER *hdr,
     if (!crypt_valid_passphrase (sec_type))
       goto err;
 
-    mutt_message _("Decrypting message...");
+    mutt_message (_("Decrypting message..."));
     if ((crypt_pgp_decrypt_mime (fp, &bfp, newhdr->content, &b) == -1)
 	|| b == NULL)
     {
@@ -611,7 +611,7 @@ int mutt_prepare_template (FILE *fp, CONTEXT *ctx, HEADER *newhdr, HEADER *hdr,
       mx_close_message (ctx, &msg);
       mutt_free_envelope (&newhdr->env);
       mutt_free_body (&newhdr->content);
-      mutt_error _("Decryption failed.");
+      mutt_error (_("Decryption failed."));
       return -1;
     }
 

--- a/query.c
+++ b/query.c
@@ -111,7 +111,7 @@ static QUERY *run_query (char *s, int quiet)
     return 0;
   }
   if (!quiet)
-    mutt_message _("Waiting for response...");
+    mutt_message (_("Waiting for response..."));
   fgets (msg, sizeof (msg), fp);
   if ((p = strrchr (msg, '\n')))
     *p = '\0';
@@ -262,7 +262,7 @@ int mutt_query_complete (char *buf, size_t buflen)
 
   if (!QueryCmd)
   {
-    mutt_error _("Query command not defined.");
+    mutt_error (_("Query command not defined."));
     return 0;
   }
 
@@ -291,7 +291,7 @@ void mutt_query_menu (char *buf, size_t buflen)
 {
   if (!QueryCmd)
   {
-    mutt_error _("Query command not defined.");
+    mutt_error (_("Query command not defined."));
     return;
   }
 

--- a/recvattach.c
+++ b/recvattach.c
@@ -45,7 +45,7 @@ static const char *Mailbox_is_read_only = N_("Mailbox is read-only.");
 #define CHECK_READONLY if (Context->readonly) \
 {\
     mutt_flushinp (); \
-    mutt_error _(Mailbox_is_read_only); \
+    mutt_error(_(Mailbox_is_read_only)); \
     break; \
 }
 
@@ -498,10 +498,10 @@ static int mutt_query_save_attachment (FILE *fp, BODY *body, HEADER *hdr, char *
       }
     }
     
-    mutt_message _("Saving...");
+    mutt_message (_("Saving..."));
     if (mutt_save_attachment (fp, body, tfile, append, (hdr || !is_message) ? hdr : body->hdr) == 0)
     {
-      mutt_message _("Attachment saved.");
+      mutt_message (_("Attachment saved."));
       return 0;
     }
     else
@@ -592,7 +592,7 @@ void mutt_save_attachment_list (FILE *fp, int tag, BODY *top, HEADER *hdr, MUTTM
   }
   
   if (!option (OPTATTACHSPLIT) && (rc == 0))
-    mutt_message _("Attachment saved.");
+    mutt_message (_("Attachment saved."));
 }
 
 static void
@@ -622,7 +622,7 @@ mutt_query_pipe_attachment (char *command, FILE *fp, BODY *body, int filter)
       mutt_unlink (body->filename);
       mutt_rename_file (tfile, body->filename);
       mutt_update_encoding (body);
-      mutt_message _("Attachment filtered.");
+      mutt_message (_("Attachment filtered."));
     }
   }
   else
@@ -945,7 +945,7 @@ static const char *Function_not_permitted = N_("Function not permitted in attach
 #define CHECK_ATTACH if(option(OPTATTACHMSG)) \
 		     {\
 			mutt_flushinp (); \
-			mutt_error _(Function_not_permitted); \
+			mutt_error(_(Function_not_permitted)); \
 			break; \
 		     }
 
@@ -1025,7 +1025,7 @@ void mutt_view_attachments (HEADER *hdr)
     if (need_secured && !secured)
     {
       mx_close_message (Context, &msg);
-      mutt_error _("Can't decrypt encrypted message!");
+      mutt_error (_("Can't decrypt encrypted message!"));
       return;
     }
   }
@@ -1075,7 +1075,7 @@ void mutt_view_attachments (HEADER *hdr)
       case OP_ATTACH_COLLAPSE:
         if (!idx[menu->current]->content->parts)
         {
-	  mutt_error _("There are no subparts to show!");
+	  mutt_error (_("There are no subparts to show!"));
 	  break;
 	}
         if (!idx[menu->current]->content->collapsed)
@@ -1136,7 +1136,7 @@ void mutt_view_attachments (HEADER *hdr)
 	if (Context->magic == MUTT_POP)
 	{
 	  mutt_flushinp ();
-	  mutt_error _("Can't delete attachment from POP server.");
+	  mutt_error (_("Can't delete attachment from POP server."));
 	  break;
 	}
 #endif
@@ -1152,14 +1152,14 @@ void mutt_view_attachments (HEADER *hdr)
 
         if (WithCrypto && (hdr->security & ENCRYPT))
         {
-          mutt_message _(
-            "Deletion of attachments from encrypted messages is unsupported.");
+          mutt_message(_(
+            "Deletion of attachments from encrypted messages is unsupported."));
           break;
         }
         if (WithCrypto && (hdr->security & (SIGN | PARTSIGN)))
         {
-          mutt_message _(
-            "Deletion of attachments from signed messages may invalidate the signature.");
+          mutt_message(_(
+            "Deletion of attachments from signed messages may invalidate the signature."));
         }
         if (!menu->tagprefix)
         {
@@ -1175,8 +1175,8 @@ void mutt_view_attachments (HEADER *hdr)
               menu->redraw = REDRAW_CURRENT;
           }
           else
-            mutt_message _(
-              "Only deletion of multipart attachments is supported.");
+            mutt_message(_(
+              "Only deletion of multipart attachments is supported."));
         }
         else
         {
@@ -1192,8 +1192,8 @@ void mutt_view_attachments (HEADER *hdr)
                 menu->redraw = REDRAW_INDEX;
               }
               else
-                mutt_message _(
-                  "Only deletion of multipart attachments is supported.");
+                mutt_message(_(
+                  "Only deletion of multipart attachments is supported."));
             }
           }
         }

--- a/recvcmd.c
+++ b/recvcmd.c
@@ -40,7 +40,7 @@ static short check_msg (BODY * b, short err)
   if (!mutt_is_message_type (b->type, b->subtype))
   {
     if (err)
-      mutt_error _("You may only bounce message/rfc822 parts.");
+      mutt_error (_("You may only bounce message/rfc822 parts."));
     return -1;
   }
   return 0;
@@ -145,7 +145,7 @@ void mutt_attach_bounce (FILE * fp, HEADER * hdr,
   {
     if (!cur->hdr->env->from)
     {
-      mutt_error _("Warning: message contains no From: header");
+      mutt_error (_("Warning: message contains no From: header"));
       mutt_sleep (2);
       mutt_clear_error ();
     }
@@ -158,7 +158,7 @@ void mutt_attach_bounce (FILE * fp, HEADER * hdr,
       {
 	if (!idx[i]->content->hdr->env->from)
 	{
-	  mutt_error _("Warning: message contains no From: header");
+	  mutt_error (_("Warning: message contains no From: header"));
 	  mutt_sleep (2);
 	  mutt_clear_error ();
 	  break;
@@ -179,7 +179,7 @@ void mutt_attach_bounce (FILE * fp, HEADER * hdr,
 
   if (!(adr = rfc822_parse_adrlist (adr, buf)))
   {
-    mutt_error _("Error parsing address!");
+    mutt_error (_("Error parsing address!"));
     return;
   }
 
@@ -749,7 +749,7 @@ attach_reply_envelope_defaults (ENVELOPE *env, ATTACHPTR **idx, short idxlen,
 
   if (curenv == NULL  ||  curhdr == NULL)
   {
-    mutt_error _("Can't find any tagged messages.");
+    mutt_error (_("Can't find any tagged messages."));
     return -1;
   }
 

--- a/remailer.c
+++ b/remailer.c
@@ -161,7 +161,7 @@ static REMAILER **mix_type2_list (size_t *l)
   /* first, generate the "random" remailer */
   
   p = mix_new_remailer ();
-  p->shortname = safe_strdup ("<random>");
+  p->shortname = safe_strdup (_("<random>"));
   mix_add_entry (&type2_list, p, &slots, &used);
   
   while (fgets (line, sizeof (line), fp))

--- a/remailer.c
+++ b/remailer.c
@@ -509,7 +509,7 @@ void mix_make_chain (LIST **chainp, int *redraw)
 
   if (!(type2_list = mix_type2_list (&ttll)))
   {
-    mutt_error _("Can't get mixmaster's type2.list!");
+    mutt_error (_("Can't get mixmaster's type2.list!"));
     return;
   }
 
@@ -593,7 +593,7 @@ void mix_make_chain (LIST **chainp, int *redraw)
 	if (chain->cl && chain->ch[chain->cl - 1] && 
 	    (type2_list[chain->ch[chain->cl-1]]->caps & MIX_CAP_MIDDLEMAN))
 	{
-	  mutt_error ( _("Error: %s can't be used as the final remailer of a chain."),
+	  mutt_error (_("Error: %s can't be used as the final remailer of a chain."),
 		    type2_list[chain->ch[chain->cl - 1]]->shortname);
 	}
 	else
@@ -623,7 +623,7 @@ void mix_make_chain (LIST **chainp, int *redraw)
 	  c_redraw = 1;
 	}
 	else
-	  mutt_error ( _("Mixmaster chains are limited to %d elements."),
+	  mutt_error (_("Mixmaster chains are limited to %d elements."),
 		    MAXMIXES);
 	
 	break;
@@ -646,7 +646,7 @@ void mix_make_chain (LIST **chainp, int *redraw)
 	}
 	else
 	{
-	  mutt_error _("The remailer chain is already empty.");
+	  mutt_error (_("The remailer chain is already empty."));
 	}
 	break;
       }
@@ -656,7 +656,7 @@ void mix_make_chain (LIST **chainp, int *redraw)
 	if (c_cur) 
 	  c_cur--;
 	else
-	  mutt_error _("You already have the first chain element selected.");
+	  mutt_error (_("You already have the first chain element selected."));
 	
 	break;
       }
@@ -666,7 +666,7 @@ void mix_make_chain (LIST **chainp, int *redraw)
 	if (chain->cl && c_cur < chain->cl - 1)
 	  c_cur++;
 	else
-	  mutt_error _("You already have the last chain element selected.");
+	  mutt_error (_("You already have the last chain element selected."));
 	
 	break;
       }
@@ -705,7 +705,7 @@ int mix_check_message (HEADER *msg)
   
   if (msg->env->cc || msg->env->bcc)
   {
-    mutt_error _("Mixmaster doesn't accept Cc or Bcc headers.");
+    mutt_error (_("Mixmaster doesn't accept Cc or Bcc headers."));
     return -1;
   }
 
@@ -729,7 +729,7 @@ int mix_check_message (HEADER *msg)
     
     if (!(fqdn = mutt_fqdn (1)))
     {
-      mutt_error _("Please set the hostname variable to a proper value when using mixmaster!");
+      mutt_error (_("Please set the hostname variable to a proper value when using mixmaster!"));
       return (-1);
     }
   
@@ -767,7 +767,7 @@ int mix_send_message (LIST *chain, const char *tempfile)
     if (!option (OPTNOCURSES))
     {
       mutt_any_key_to_continue (NULL);
-      mutt_error _("Error sending message.");
+      mutt_error (_("Error sending message."));
     }
   }
 

--- a/rfc1524.c
+++ b/rfc1524.c
@@ -393,7 +393,7 @@ int rfc1524_mailcap_lookup (BODY *a, char *type, rfc1524_entry *entry, int opt)
    */
   if (!curr || !*curr)
   {
-    mutt_error _("No mailcap path specified");
+    mutt_error (_("No mailcap path specified"));
     return 0;
   }
 

--- a/safe_asprintf.c
+++ b/safe_asprintf.c
@@ -39,7 +39,7 @@ int safe_asprintf (char **strp, const char *fmt, ...)
    */
   if (n < 0)
   {
-    mutt_error _("Out of memory!");
+    mutt_error (_("Out of memory!"));
     sleep (1);
     mutt_exit (1);
   }

--- a/send.c
+++ b/send.c
@@ -297,7 +297,7 @@ static int edit_envelope (ENVELOPE *en, int flags)
   if (mutt_get_field ("Subject: ", buf, sizeof (buf), 0) != 0 ||
       (!buf[0] && query_quadoption (OPT_SUBJECT, _("No subject, abort?")) != MUTT_NO))
   {
-    mutt_message _("No subject, aborting.");
+    mutt_message (_("No subject, aborting."));
     return (-1);
   }
   mutt_str_replace (&en->subject, buf);
@@ -767,7 +767,7 @@ envelope_defaults (ENVELOPE *env, CONTEXT *ctx, HEADER *cur, int flags)
       /* This could happen if the user tagged some messages and then did
        * a limit such that none of the tagged message are visible.
        */
-      mutt_error _("No tagged messages are visible!");
+      mutt_error (_("No tagged messages are visible!"));
       return (-1);
     }
   }
@@ -802,7 +802,7 @@ envelope_defaults (ENVELOPE *env, CONTEXT *ctx, HEADER *cur, int flags)
 
     if ((flags & SENDLISTREPLY) && !env->to)
     {
-      mutt_error _("No mailing lists found!");
+      mutt_error (_("No mailing lists found!"));
       return (-1);
     }
 
@@ -837,7 +837,7 @@ generate_body (FILE *tempfp,	/* stream for outgoing message */
 
     if (i == MUTT_YES)
     {
-      mutt_message _("Including quoted message...");
+      mutt_message (_("Including quoted message..."));
       if (!cur)
       {
 	for (i = 0; i < ctx->vcount; i++)
@@ -847,7 +847,7 @@ generate_body (FILE *tempfp,	/* stream for outgoing message */
 	  {
 	    if (include_reply (ctx, h, tempfp) == -1)
 	    {
-	      mutt_error _("Could not include all requested messages!");
+	      mutt_error (_("Could not include all requested messages!"));
 	      return (-1);
 	    }
 	    fputc ('\n', tempfp);
@@ -865,7 +865,7 @@ generate_body (FILE *tempfp,	/* stream for outgoing message */
     {
       BODY *last = msg->content;
 
-      mutt_message _("Preparing forwarded message...");
+      mutt_message (_("Preparing forwarded message..."));
       
       while (last && last->next)
 	last = last->next;
@@ -1658,7 +1658,7 @@ ci_send_message (int flags,		/* send mode */
 	if (mtime == st.st_mtime && !msg->content->next &&
 	    query_quadoption (OPT_ABORT, _("Abort unmodified message?")) == MUTT_YES)
 	{
-	  mutt_message _("Aborted unmodified message.");
+	  mutt_message (_("Aborted unmodified message."));
 	  goto cleanup;
 	}
       }
@@ -1795,7 +1795,7 @@ main_loop:
 	mutt_message (_("Article not posted."));
       else
 #endif
-      mutt_message _("Mail not sent.");
+      mutt_message (_("Mail not sent."));
       goto cleanup;
     }
     else if (i == 1)
@@ -1846,7 +1846,7 @@ main_loop:
 	goto main_loop;
       }
       mutt_update_num_postponed ();
-      mutt_message _("Message postponed.");
+      mutt_message (_("Message postponed."));
       rv = 1;
       goto cleanup;
     }
@@ -1860,12 +1860,12 @@ main_loop:
   {
     if (! (flags & SENDBATCH))
     {
-      mutt_error _("No recipients are specified!");
+      mutt_error (_("No recipients are specified!"));
       goto main_loop;
     }
     else
     {
-      puts _("No recipients were specified.");
+      puts (_("No recipients were specified."));
       goto cleanup;
     }
   }
@@ -1885,7 +1885,7 @@ main_loop:
   {
     /* if the abort is automatic, print an error message */
     if (quadoption (OPT_SUBJECT) == MUTT_YES)
-      mutt_error _("No subject specified.");
+      mutt_error (_("No subject specified."));
     goto main_loop;
   }
 #ifdef USE_NNTP
@@ -1974,7 +1974,7 @@ main_loop:
   }
 
   if (!option (OPTNOCURSES) && !(flags & SENDMAILX))
-    mutt_message _("Sending message...");
+    mutt_message (_("Sending message..."));
 
   mutt_prepare_envelope (msg->env, 1);
 
@@ -2118,7 +2118,7 @@ full_fcc:
     }
     else
     {
-      puts _("Could not send the message.");
+      puts (_("Could not send the message."));
       goto cleanup;
     }
   }

--- a/sendlib.c
+++ b/sendlib.c
@@ -433,7 +433,7 @@ int mutt_write_mime_body (BODY *a, FILE *f)
     if (!(p = mutt_get_parameter ("boundary", a->parameter)))
     {
       dprint (1, (debugfile, "mutt_write_mime_body(): no boundary parameter found!\n"));
-      mutt_error _("No boundary parameter found! [report this error]");
+      mutt_error (_("No boundary parameter found! [report this error]"));
       return (-1);
     }
     strfcpy (boundary, p, sizeof (boundary));

--- a/smime.c
+++ b/smime.c
@@ -1464,7 +1464,7 @@ BODY *smime_build_smime_entity (BODY *a, char *certlist)
   if (empty)
   {
     /* fatal error while trying to encrypt message */
-    if (!err) mutt_any_key_to_continue _("No output from OpenSSL...");
+    if (!err) mutt_any_key_to_continue (_("No output from OpenSSL..."));
     mutt_unlink (tempfile);
     return (NULL);
   }
@@ -1531,7 +1531,7 @@ BODY *smime_sign_message (BODY *a )
 
   if (!SmimeDefaultKey)
   {
-    mutt_error _("Can't sign: No key specified. Use Sign As.");
+    mutt_error (_("Can't sign: No key specified. Use Sign As."));
     return NULL;
   }
 
@@ -1583,7 +1583,7 @@ BODY *smime_sign_message (BODY *a )
   if ((thepid = smime_invoke_sign (&smimein, NULL, &smimeerr,
 				 -1, fileno (smimeout), -1, filetosign)) == -1)
   {
-    mutt_perror _("Can't open OpenSSL subprocess!");
+    mutt_perror (_("Can't open OpenSSL subprocess!"));
     safe_fclose (&smimeout);
     mutt_unlink (signedfile);
     mutt_unlink (filetosign);
@@ -1621,7 +1621,7 @@ BODY *smime_sign_message (BODY *a )
 
   if (empty)
   {
-    mutt_any_key_to_continue _("No output from OpenSSL...");
+    mutt_any_key_to_continue (_("No output from OpenSSL..."));
     mutt_unlink (signedfile);
     return (NULL); /* fatal error while signing */
   }

--- a/sort.c
+++ b/sort.c
@@ -322,7 +322,7 @@ void mutt_sort_headers (CONTEXT *ctx, int init)
   }
 
   if (!ctx->quiet)
-    mutt_message _("Sorting mailbox...");
+    mutt_message (_("Sorting mailbox..."));
 
   if (option (OPTNEEDRESCORE) && option (OPTSCORE))
   {
@@ -359,7 +359,7 @@ void mutt_sort_headers (CONTEXT *ctx, int init)
   else if ((sortfunc = mutt_get_sort_func (Sort)) == NULL ||
 	   (AuxSort = mutt_get_sort_func (SortAux)) == NULL)
   {
-    mutt_error _("Could not find sorting function! [report this bug]");
+    mutt_error (_("Could not find sorting function! [report this bug]"));
     mutt_sleep (1);
     return;
   }

--- a/thread.c
+++ b/thread.c
@@ -1028,7 +1028,7 @@ int _mutt_aside_thread (HEADER *hdr, short dir, short subthreads)
 
   if ((Sort & SORT_MASK) != SORT_THREADS)
   {
-    mutt_error _("Threading is not enabled.");
+    mutt_error (_("Threading is not enabled."));
     return (hdr->virtual);
   }
 
@@ -1084,7 +1084,7 @@ int mutt_parent_message (CONTEXT *ctx, HEADER *hdr, int find_root)
 
   if ((Sort & SORT_MASK) != SORT_THREADS)
   {
-    mutt_error _("Threading is not enabled.");
+    mutt_error (_("Threading is not enabled."));
     return (hdr->virtual);
   }
 


### PR DESCRIPTION
This PR supercedes #266 (Internationalize strings).

The gettext macro `_()` was pooly defined which led to some bad practices.
Note the missing `()`s in this:
```
mutt_message _("string")
```

@alok used some scripting skills to fix the problems, but it left a LOT of false positives.
This PR has filtered out the stuff that wasn't needed.

The first commit (LARGE) fixes `function _("string");` to `function(_("string"));`
The second commit (small) adds some missing translation markers.

Thanks @alok it's saved me a lot of time.

@neomutt/reviewers Please review