### PR TITLE
Reverts making AliasFile into a list_t

### DIFF
--- a/alias.c
+++ b/alias.c
@@ -344,53 +344,49 @@ retry_name:
   else
     Aliases = new;
 
-  for (LIST *AliasFile = AliasFiles; AliasFile != NULL;
-      AliasFile = AliasFile->next)
+  strfcpy (buf, NONULL (AliasFile), sizeof (buf));
+  if (mutt_get_field (_("Save to file: "), buf, sizeof (buf), MUTT_FILE) != 0)
+    return;
+  mutt_expand_path (buf, sizeof (buf));
+  if ((rc = fopen (buf, "a+")))
   {
-    strfcpy(buf, NONULL(AliasFile->data), sizeof(buf));
-    if (mutt_get_field(_("Save to file: "), buf, sizeof(buf), MUTT_FILE) != 0)
-      return;
-    mutt_expand_path(buf, sizeof(buf));
-    if ((rc = fopen(buf, "a+")))
+    /* terminate existing file with \n if necessary */
+    if (fseek (rc, 0, SEEK_END))
+      goto fseek_err;
+    if (ftell(rc) > 0)
     {
-      /* terminate existing file with \n if necessary */
-      if (fseek(rc, 0, SEEK_END))
-        goto fseek_err;
-      if (ftell(rc) > 0)
+      if (fseek (rc, -1, SEEK_CUR) < 0)
+	goto fseek_err;
+      if (fread(buf, 1, 1, rc) != 1)
       {
-        if (fseek(rc, -1, SEEK_CUR) < 0)
-          goto fseek_err;
-        if (fread(buf, 1, 1, rc) != 1)
-        {
-          mutt_perror(_("Error reading alias file"));
-          safe_fclose(&rc);
-          return;
-        }
-        if (fseek(rc, 0, SEEK_END) < 0)
-          goto fseek_err;
-        if (buf[0] != '\n')
-          fputc('\n', rc);
+	mutt_perror (_("Error reading alias file"));
+	safe_fclose (&rc);
+	return;
       }
-
-      if (mutt_check_alias_name(new->name, NULL, 0))
-        mutt_quote_filename(buf, sizeof(buf), new->name);
-      else
-        strfcpy(buf, new->name, sizeof(buf));
-      recode_buf(buf, sizeof(buf));
-      fprintf(rc, "alias %s ", buf);
-      buf[0] = 0;
-      rfc822_write_address(buf, sizeof(buf), new->addr, 0);
-      recode_buf(buf, sizeof(buf));
-      write_safe_address(rc, buf);
-      fputc('\n', rc);
-      if (safe_fsync_close(&rc) != 0)
-        mutt_message("Trouble adding alias: %s.", strerror(errno));
-      else
-        mutt_message(_("Alias added."));
+      if (fseek (rc, 0, SEEK_END) < 0)
+	goto fseek_err;
+      if (buf[0] != '\n')
+	fputc ('\n', rc);
     }
+
+    if (mutt_check_alias_name (new->name, NULL, 0))
+      mutt_quote_filename (buf, sizeof (buf), new->name);
     else
-      mutt_perror(buf);
+      strfcpy (buf, new->name, sizeof (buf));
+    recode_buf (buf, sizeof (buf));
+    fprintf (rc, "alias %s ", buf);
+    buf[0] = 0;
+    rfc822_write_address (buf, sizeof (buf), new->addr, 0);
+    recode_buf (buf, sizeof (buf));
+    write_safe_address (rc, buf);
+    fputc ('\n', rc);
+    if (safe_fsync_close(&rc) != 0)
+      mutt_message ("Trouble adding alias: %s.", strerror(errno));
+    else
+      mutt_message (_("Alias added."));
   }
+  else
+    mutt_perror (buf);
 
   return;
   

--- a/globals.h
+++ b/globals.h
@@ -31,7 +31,7 @@ WHERE char *MuttDotlock;
 WHERE ADDRESS *EnvFrom;
 WHERE ADDRESS *From;
 
-WHERE LIST *AliasFiles;
+WHERE char *AliasFile;
 WHERE char *AliasFmt;
 WHERE char *AssumedCharset;
 WHERE char *AttachSep;

--- a/init.c
+++ b/init.c
@@ -3807,10 +3807,10 @@ void mutt_init (int skip_sys_rc, LIST *commands)
     }
   }
 
-  if (Muttrc)
+  if (Muttrc && Muttrc->data)
   {
-    FREE (&AliasFiles);
-    AliasFiles = mutt_copy_list(Muttrc);
+    FREE (&AliasFile);
+    AliasFile = safe_strdup (Muttrc->data);
   }
 
   /* Process the global rc file if it exists and the user hasn't explicity

--- a/init.h
+++ b/init.h
@@ -123,7 +123,7 @@ struct option_t MuttVars[] = {
   ** check only happens after the \fIfirst\fP edit of the file).  When set
   ** to \fIno\fP, composition will never be aborted.
   */
-  { "alias_file",	DT_PATH, R_NONE, UL &AliasFiles, UL "~/.muttrc" },
+  { "alias_file",	DT_PATH, R_NONE, UL &AliasFile, UL "~/.muttrc" },
   /*
   ** .pp
   ** The default file in which to save aliases created by the


### PR DESCRIPTION
Uses the first loaded muttrc file as default for alias file.

This partially reverts commit 83f7558efab3dcd7b7e227a727ef95f711363f50.

fixes #378

Signed-off-by: Guyzmo <guyzmo+github+pub@m0g.net>