### PR TITLE
Release KyotoCabinet data with kcfree()

### DIFF
--- a/hcache-kc.c
+++ b/hcache-kc.c
@@ -71,7 +71,8 @@ hcache_kyotocabinet_fetch(void *ctx, const char *key, size_t keylen)
 static void
 hcache_kyotocabinet_free(void *vctx, void **data)
 {
-    FREE(data); /* __FREE_CHECKED__ */
+    kcfree(*data);
+    *data = NULL;
 }
 
 static int


### PR DESCRIPTION
Obtained from https://dev.mutt.org/hg/mutt/rev/09bb4a62ceb1

Closes #383