### PR TITLE
Add an option to show multipart/alternative

### DIFF
--- a/globals.h
+++ b/globals.h
@@ -135,6 +135,7 @@ WHERE short SearchContext;
 WHERE char *SendCharset;
 WHERE char *Sendmail;
 WHERE char *Shell;
+WHERE char *ShowMultipartAlternative;
 #ifdef USE_SIDEBAR
 WHERE char *SidebarDelimChars;
 WHERE char *SidebarDividerChar;

--- a/init.c
+++ b/init.c
@@ -1978,6 +1978,13 @@ static int check_charset (struct option_t *opt, const char *val)
   return rc;
 }
 
+static bool valid_show_multipart_alternative(const char *val)
+{
+  return ((mutt_strcmp(val, "inline") == 0) ||
+          (mutt_strcmp(val, "info") == 0) ||
+          (val == NULL) || (*val == 0));
+}
+
 static int parse_setenv(BUFFER *tmp, BUFFER *s, unsigned long data, BUFFER *err)
 {
   int query, unset, len;
@@ -2342,6 +2349,14 @@ static int parse_set (BUFFER *tmp, BUFFER *s, unsigned long data, BUFFER *err)
 	  *((char **) MuttVars[idx].data) = safe_strdup (tmp->data);
 	  if (mutt_strcmp (MuttVars[idx].option, "charset") == 0)
 	    mutt_set_charset (Charset);
+
+          if ((mutt_strcmp (MuttVars[idx].option, "show_multipart_alternative") == 0) &&
+              !valid_show_multipart_alternative(tmp->data))
+          {
+            snprintf (err->data, err->dsize, _("Invalid value for option %s: \"%s\""),
+                      MuttVars[idx].option, tmp->data);
+            return -1;
+          }
         }
         else if (DTYPE (MuttVars[idx].type) == DT_MBCHARTBL)
         {

--- a/init.h
+++ b/init.h
@@ -1273,6 +1273,14 @@ struct option_t MuttVars[] = {
   ** function; \fC<group-reply>\fP will reply to both the sender and the
   ** list.
   */
+  { "show_multipart_alternative", DT_STR, R_NONE, UL &ShowMultipartAlternative, 0 },
+  /*
+  ** .pp
+  ** When \fIset\fP to \fCinfo\fP, the multipart/alternative information is shown.
+  ** When \fIset\fP to \fCinline\fP, all of the alternatives are displayed.
+  ** When not set, the default behavior is to show only the chosen alternative.
+  ** .pp
+  */
 #ifdef USE_IMAP
   { "imap_authenticators", DT_STR, R_NONE, UL &ImapAuthenticators, UL 0 },
   /*


### PR DESCRIPTION
This pull request adds an option to ignore the multipart/alternative flag in emails. The reason for that is that there exist a lot of mailers that misuse that flag and doesn't have the same contents in the "alternative" part. 

Thus, clients that make the "wrong" choice in the alternative will see unhelpful or incomplete data and may miss important informations if he doesn't think to look at the attachment part.

NB: Is the documentation automatically generated from the comments?