### PR TITLE
Add alternate types information in viewer

### DIFF
--- a/handler.c
+++ b/handler.c
@@ -1004,6 +1004,8 @@ static int alternative_handler (BODY *a, STATE *s)
   int type = 0;
   int mustfree = 0;
   int rc = 0;
+  char length[5];
+  int count = 0;
 
   if (a->encoding == ENCBASE64 || a->encoding == ENCQUOTEDPRINTABLE ||
       a->encoding == ENCUUENCODED)
@@ -1130,7 +1132,31 @@ static int alternative_handler (BODY *a, STATE *s)
       fseeko (s->fpin, choice->hdr_offset, 0);
       mutt_copy_bytes(s->fpin, s->fpout, choice->offset-choice->hdr_offset);
     }
+
+    mutt_pretty_size (length, sizeof (length), choice->length);
+    state_mark_attach (s);
+    state_printf (s, _("[-- Type: %s/%s, Encoding: %s, Size: %s --]\n"),
+                  TYPE (choice), choice->subtype, ENCODING (choice->encoding), length);
     mutt_body_handler (choice, s);
+
+    if (a && a->parts)
+      b = a->parts;
+    else
+      b = a;
+    while (b)
+    {
+      if (choice != b) {
+        count += 1;
+        mutt_pretty_size (length, sizeof (length), b->length);
+        if (count == 1)
+          state_putc ('\n', s);
+
+        state_mark_attach (s);
+        state_printf (s, _("[-- Alternative Type #%d %s/%s, Encoding: %s, Size: %s --]\n"),
+                      count, TYPE (b), b->subtype, ENCODING (b->encoding), length);
+      }
+      b = b->next;
+    }
   }
   else if (s->flags & MUTT_DISPLAY)
   {


### PR DESCRIPTION
This MR adds informations about alternates when viewing an email:

- First, it show which content type we're reading in the alternates
- Also, it shows the other available alternates

![2017-02-10_23_21_03](https://cloud.githubusercontent.com/assets/510202/22846617/9c2497aa-efe8-11e6-8bdf-fda2e1ac8afc.png)

Please comment on the wording/style

This came from discussions in https://github.com/neomutt/neomutt/pull/390 but is independent

cc @d-k-c 