### PR TITLE
Fixes missing failure return of notmuch msg open


### DIFF
--- a/mutt_notmuch.c
+++ b/mutt_notmuch.c
@@ -2430,7 +2430,7 @@ static int nm_open_message(CONTEXT *ctx, MESSAGE *msg, int msgno)
     msg->fp = maildir_open_find_message(folder, cur->path, NULL);
 
   mutt_debug (1, "%s\n", __func__);
-  return 0;
+  return !msg->fp;
 }
 
 static int nm_close_message(CONTEXT *ctx, MESSAGE *msg)


### PR DESCRIPTION


When calling the `mx_ops->open_msg()` method of the notmuch
implementation, if the message failed to open, it is not reported to the
user interface. This patch returns a non-zero value that will prevent a
crash.

fixes #308

