### PR TITLE
Notmuch: Fixed modify-labels command on folders

### DIFF
--- a/curs_main.c
+++ b/curs_main.c
@@ -1801,11 +1801,13 @@ int mutt_index_menu (void)
       case OP_MAIN_MODIFY_LABELS:
       case OP_MAIN_MODIFY_LABELS_THEN_HIDE:
       {
-	if (Context->magic != MUTT_NOTMUCH) {
-	  mutt_message (_("No virtual folder, aborting."));
-	  break;
-	}
-	CHECK_MSGCOUNT;
+        if (Context->magic != MUTT_NOTMUCH) {
+          // remove remaining arguments
+          mutt_get_field ("", buf, sizeof(buf), MUTT_NM_TAG);
+          mutt_error (_("No virtual folder, aborting."));
+          break;
+        }
+        CHECK_MSGCOUNT;
         CHECK_VISIBLE;
 	*buf = '\0';
 	if (mutt_get_field ("Add/remove labels: ", buf, sizeof (buf), MUTT_NM_TAG) || !*buf)


### PR DESCRIPTION
When calling `<modify-labels>` on non-virtual folders with the toggle
operator ("!") the notmuch code would break early and leave the rest of
the arguments within the input buffer. Mutt would then interpret the "!"
as OP_SHELL_ESCAPE and pass the label to /bin/sh.

To fix this behaviour two changes have been made:

- When not within a virtual folder the error will now be displayed using
  `mutt_error` which causes mutt to stop executing the current macro.
  Without this change other instructions in the macro would be called.
  e.g. causing the ui to change, reload of inboxes etc.

- Remaining arguments in the for the \<modify-labels\> command will be
  discarded.