### PR TITLE
Fix resource leaks on error paths (coverity)

### DIFF
--- a/attach.c
+++ b/attach.c
@@ -47,13 +47,13 @@ int mutt_get_tmp_attachment (BODY *a)
 {
   char type[STRING];
   char tempfile[_POSIX_PATH_MAX];
-  rfc1524_entry *entry = rfc1524_new_entry();
   FILE *fpin = NULL, *fpout = NULL;
   struct stat st;
   
   if(a->unlink)
     return 0;
 
+  rfc1524_entry *entry = rfc1524_new_entry();
   snprintf(type, sizeof(type), "%s/%s", TYPE(a), a->subtype);
   rfc1524_mailcap_lookup(a, type, entry, 0);
   rfc1524_expand_filename(entry->nametemplate, a->filename, 

--- a/crypt-gpgme.c
+++ b/crypt-gpgme.c
@@ -2511,7 +2511,7 @@ int pgp_gpgme_application_handler (BODY *m, STATE *s)
                   tmpfname = data_object_to_tempfile (plaintext, NULL, &pgpout);
                   if (!tmpfname)
                     {
-                      pgpout = NULL;
+                      safe_fclose (&pgpout);
                       state_puts (_("Error: copy data failed\n"), s);
                     }
                   else

--- a/crypt-gpgme.c
+++ b/crypt-gpgme.c
@@ -2309,11 +2309,14 @@ static void copy_clearsigned (gpgme_data_t data, STATE *s, char *charset)
   short complete, armor_header;
   FGETCONV *fc;
   char *fname;
-  FILE *fp;
+  FILE *fp = NULL;
 
   fname = data_object_to_tempfile (data, NULL, &fp);
   if (!fname)
+  {
+    safe_fclose (&fp);
     return;
+  }
   unlink (fname);
   FREE (&fname);
 

--- a/edit.c
+++ b/edit.c
@@ -441,7 +441,7 @@ int mutt_builtin_editor (const char *path, HEADER *msg, HEADER *cur)
 	case 'v':
 	  if (be_barf_file (path, buf, buflen) == 0)
 	  {
-	    char *tag, *err;
+            char *tag = NULL, *err = NULL;
 	    be_free_memory (buf, buflen);
 	    buf = NULL;
 	    bufmax = buflen = 0;
@@ -452,6 +452,8 @@ int mutt_builtin_editor (const char *path, HEADER *msg, HEADER *cur)
 	      mutt_edit_headers (NONULL(Visual), path, msg, NULL, 0);
 	      if (mutt_env_to_intl (msg->env, &tag, &err))
 		printw (_("Bad IDN in %s: '%s'\n"), tag, err);
+              /* tag is a statically allocated string and should not be freed */
+              FREE(&err);
 	    }
 	    else
 	      mutt_edit_file (NONULL(Visual), path);

--- a/init.c
+++ b/init.c
@@ -1617,6 +1617,7 @@ static int parse_alias (BUFFER *buf, BUFFER *s, unsigned long data, BUFFER *err)
   {
     snprintf (err->data, err->dsize, _("Warning: Bad IDN '%s' in alias '%s'.\n"),
 	      estr, tmp->name);
+    FREE(&estr);
     goto bail;
   }
 

--- a/init.c
+++ b/init.c
@@ -1154,6 +1154,7 @@ static int parse_group (BUFFER *buf, BUFFER *s, unsigned long data, BUFFER *err)
 	    snprintf (err->data, err->dsize, _("%sgroup: warning: bad IDN '%s'.\n"),
 		      data == 1 ? "un" : "", estr);
             rfc822_free_address (&addr);
+            FREE(&estr);
 	    goto bail;
 	  }
 	  if (data == MUTT_GROUP)

--- a/init.c
+++ b/init.c
@@ -1282,13 +1282,14 @@ static int parse_unattach_list (BUFFER *buf, BUFFER *s, LIST **ldata, BUFFER *er
 {
   ATTACH_MATCH *a;
   LIST *lp, *lastp, *newlp;
-  char *tmp;
+  char *tmp = NULL;
   int major;
   char *minor;
 
   do
   {
     mutt_extract_token (buf, s, 0);
+    FREE(&tmp);
 
     if (!ascii_strcasecmp(buf->data, "any"))
       tmp = safe_strdup("*/.*");

--- a/init.c
+++ b/init.c
@@ -3900,7 +3900,10 @@ void mutt_init (int skip_sys_rc, LIST *commands)
 
     char *config = mutt_find_cfg (Homedir, xdg_cfg_home);
     if (config)
+    {
       Muttrc = mutt_add_list (Muttrc, config);
+      FREE(&config);
+    }
   }
   else
   {

--- a/init.c
+++ b/init.c
@@ -1153,6 +1153,7 @@ static int parse_group (BUFFER *buf, BUFFER *s, unsigned long data, BUFFER *err)
 	  { 
 	    snprintf (err->data, err->dsize, _("%sgroup: warning: bad IDN '%s'.\n"),
 		      data == 1 ? "un" : "", estr);
+            rfc822_free_address (&addr);
 	    goto bail;
 	  }
 	  if (data == MUTT_GROUP)

--- a/mbox.c
+++ b/mbox.c
@@ -1043,6 +1043,7 @@ static int mbox_sync_mailbox (CONTEXT *ctx, int *index_hint)
     mutt_debug (1, "mbox_sync_mailbox: unable to reopen temp copy of mailbox!\n");
     mutt_perror (tempfile);
     mutt_sleep (5);
+    FREE (&newOffset);
     return (-1);
   }
 
@@ -1106,6 +1107,7 @@ static int mbox_sync_mailbox (CONTEXT *ctx, int *index_hint)
     mutt_pretty_mailbox (savefile, sizeof (savefile));
     mutt_error (_("Write failed!  Saved partial mailbox to %s"), savefile);
     mutt_sleep (5);
+    FREE (&newOffset);
     return (-1);
   }
 
@@ -1119,6 +1121,7 @@ static int mbox_sync_mailbox (CONTEXT *ctx, int *index_hint)
     mutt_unblock_signals ();
     mx_fastclose_mailbox (ctx);
     mutt_error (_("Fatal error!  Could not reopen mailbox!"));
+    FREE (&newOffset);
     return (-1);
   }
 

--- a/mbox.c
+++ b/mbox.c
@@ -1044,6 +1044,7 @@ static int mbox_sync_mailbox (CONTEXT *ctx, int *index_hint)
     mutt_perror (tempfile);
     mutt_sleep (5);
     FREE (&newOffset);
+    FREE (&oldOffset);
     return (-1);
   }
 
@@ -1108,6 +1109,7 @@ static int mbox_sync_mailbox (CONTEXT *ctx, int *index_hint)
     mutt_error (_("Write failed!  Saved partial mailbox to %s"), savefile);
     mutt_sleep (5);
     FREE (&newOffset);
+    FREE (&oldOffset);
     return (-1);
   }
 
@@ -1122,6 +1124,7 @@ static int mbox_sync_mailbox (CONTEXT *ctx, int *index_hint)
     mx_fastclose_mailbox (ctx);
     mutt_error (_("Fatal error!  Could not reopen mailbox!"));
     FREE (&newOffset);
+    FREE (&oldOffset);
     return (-1);
   }
 

--- a/pgp.c
+++ b/pgp.c
@@ -1443,6 +1443,7 @@ BODY *pgp_encrypt_message (BODY *a, char *keylist, int sign)
 				    fileno (fpout), fileno (pgperr),
 				    pgpinfile, keylist, sign)) == -1)
   {
+    safe_fclose (&fpout);
     safe_fclose (&pgperr);
     unlink(pgpinfile);
     return (NULL);

--- a/pgp.c
+++ b/pgp.c
@@ -395,6 +395,7 @@ int pgp_application_pgp_handler (BODY *m, STATE *s)
       if ((tmpfp = safe_fopen (tmpfname, "w+")) == NULL)
       {
 	mutt_perror (tmpfname);
+        FREE(&gpgcharset);
 	return -1;
       }
       
@@ -416,6 +417,7 @@ int pgp_application_pgp_handler (BODY *m, STATE *s)
 	if (mutt_strncmp ("Charset: ", buf, 9) == 0)
 	{
 	  size_t l = 0;
+          FREE(&gpgcharset);
 	  gpgcharset = safe_strdup (buf + 9);
 	  if ((l = mutt_strlen (gpgcharset)) > 0 && gpgcharset[l-1] == '\n')
 	    gpgcharset[l-1] = 0;
@@ -435,6 +437,7 @@ int pgp_application_pgp_handler (BODY *m, STATE *s)
 	{
 	  mutt_perror (outfile);
           safe_fclose (&tmpfp);
+          FREE(&gpgcharset);
 	  return -1;
 	}
 	

--- a/pgp.c
+++ b/pgp.c
@@ -434,6 +434,7 @@ int pgp_application_pgp_handler (BODY *m, STATE *s)
 	if ((pgpout = safe_fopen (outfile, "w+")) == NULL)
 	{
 	  mutt_perror (outfile);
+          safe_fclose (&tmpfp);
 	  return -1;
 	}
 	

--- a/query.c
+++ b/query.c
@@ -441,6 +441,7 @@ static void query_menu (char *buf, size_t buflen, QUERY *results, int retbuf)
 	      }
 
 	    mutt_create_alias (NULL, naddr);
+            rfc822_free_address (&naddr);
 	  }
 	  else
 	  {

--- a/recvcmd.c
+++ b/recvcmd.c
@@ -439,6 +439,7 @@ static void attach_forward_bodies (FILE * fp, HEADER * hdr,
   if ((tmpfp = safe_fopen (tmpbody, "w")) == NULL)
   {
     mutt_error (_("Can't open temporary file %s."), tmpbody);
+    mutt_free_header (&tmphdr);
     return;
   }
 

--- a/send.c
+++ b/send.c
@@ -1196,7 +1196,10 @@ int mutt_resend_message (FILE *fp, CONTEXT *ctx, HEADER *cur)
   HEADER *msg = mutt_new_header ();
   
   if (mutt_prepare_template (fp, ctx, msg, cur, 1) < 0)
+  {
+    mutt_free_header (&msg);
     return -1;
+  }
 
   if (WithCrypto)
   {

--- a/sendlib.c
+++ b/sendlib.c
@@ -1798,11 +1798,18 @@ static int write_one_header (FILE *fp, int pfxw, int max, int wraplen,
                 "max width = %d <= %d\n",
                 NONULL(pfx), valbuf, max, wraplen);
     if (pfx && *pfx)
+    {
       if (fputs (pfx, fp) == EOF)
+      {
+        FREE (&valbuf);
 	return -1;
+      }
+    }
+
     if (!(t = strchr (valbuf, ':')))
     {
       mutt_debug (1, "mwoh: warning: header not in 'key: value' format!\n");
+      FREE (&valbuf);
       return 0;
     }
     if (print_val (fp, pfx, valbuf, flags, mutt_strlen (pfx)) < 0)
@@ -1842,7 +1849,10 @@ static int write_one_header (FILE *fp, int pfxw, int max, int wraplen,
     mutt_debug (4, "mwoh: buf[%s%s] too long, max width = %d > %d\n",
                 NONULL(pfx), valbuf, max, wraplen);
     if (fold_one_header (fp, tagbuf, valbuf, pfx, wraplen, flags) < 0)
+    {
+      FREE (&valbuf);
       return -1;
+    }
     FREE (&tagbuf);
     FREE (&valbuf);
   }

--- a/sendlib.c
+++ b/sendlib.c
@@ -2871,6 +2871,7 @@ int mutt_write_fcc (const char *path, HEADER *hdr, const char *msgid,
     onm_flags |= MUTT_SET_DRAFT;
   if ((msg = mx_open_new_message (&f, hdr, onm_flags)) == NULL)
   {
+    safe_fclose(&tempfp);
     mx_close_mailbox (&f, NULL);
     return (-1);
   }

--- a/sendlib.c
+++ b/sendlib.c
@@ -1851,6 +1851,7 @@ static int write_one_header (FILE *fp, int pfxw, int max, int wraplen,
     if (fold_one_header (fp, tagbuf, valbuf, pfx, wraplen, flags) < 0)
     {
       FREE (&valbuf);
+      FREE (&tagbuf);
       return -1;
     }
     FREE (&tagbuf);

--- a/smime.c
+++ b/smime.c
@@ -1434,6 +1434,7 @@ BODY *smime_build_smime_entity (BODY *a, char *certlist)
     safe_fclose (&smimeerr);
     mutt_unlink (smimeinfile);
     mutt_unlink (certfile);
+    safe_fclose (&fpout);
     return (NULL);
   }
 

--- a/smime.c
+++ b/smime.c
@@ -1842,7 +1842,7 @@ static BODY *smime_handle_entity (BODY *m, STATE *s, FILE *outFile)
   if ((smimeerr = safe_fopen (errfile, "w+")) == NULL)
   {
     mutt_perror (errfile);
-    safe_fclose (&smimeout); smimeout = NULL;
+    safe_fclose (&smimeout);
     return NULL;
   }
   mutt_unlink (errfile);
@@ -1852,8 +1852,8 @@ static BODY *smime_handle_entity (BODY *m, STATE *s, FILE *outFile)
   if ((tmpfp = safe_fopen (tmpfname, "w+")) == NULL)
   {
     mutt_perror (tmpfname);
-    safe_fclose (&smimeout); smimeout = NULL;
-    safe_fclose (&smimeerr); smimeerr = NULL;
+    safe_fclose (&smimeout);
+    safe_fclose (&smimeerr);
     return NULL;
   }
 
@@ -1868,10 +1868,11 @@ static BODY *smime_handle_entity (BODY *m, STATE *s, FILE *outFile)
       (thepid = smime_invoke_decrypt (&smimein, NULL, NULL, -1,
 				      fileno (smimeout),  fileno (smimeerr), tmpfname)) == -1)
   {
-    safe_fclose (&smimeout); smimeout = NULL;
+    safe_fclose (&smimeout);
     mutt_unlink (tmpfname);
     if (s->flags & MUTT_DISPLAY)
       state_attach_puts (_("[-- Error: unable to create OpenSSL subprocess! --]\n"), s);
+    safe_fclose (&smimeerr);
     return NULL;
   }
   else if ((type & SIGNOPAQUE) &&
@@ -1879,10 +1880,11 @@ static BODY *smime_handle_entity (BODY *m, STATE *s, FILE *outFile)
 					  fileno (smimeout), fileno (smimeerr), NULL,
 					  tmpfname, SIGNOPAQUE)) == -1)
   {
-    safe_fclose (&smimeout); smimeout = NULL;
+    safe_fclose (&smimeout);
     mutt_unlink (tmpfname);
     if (s->flags & MUTT_DISPLAY)
       state_attach_puts (_("[-- Error: unable to create OpenSSL subprocess! --]\n"), s);
+    safe_fclose (&smimeerr);
     return NULL;
   }
 
@@ -1934,7 +1936,8 @@ static BODY *smime_handle_entity (BODY *m, STATE *s, FILE *outFile)
       if ((fpout = safe_fopen (tmptmpfname, "w+")) == NULL)
       {
 	mutt_perror(tmptmpfname);
-	safe_fclose (&smimeout); smimeout = NULL;
+        safe_fclose (&smimeout);
+        safe_fclose (&smimeerr);
 	return NULL;
       }
     }


### PR DESCRIPTION
There are about 25 small changes to prevent resource leaks.

As an experiment, I've made two commits:
1. Fix leaks and add CID comments (d0699e9)
2. Remove the CID comments

If you'd like to reference the Coverity Defect ID you can look at just the first commit: d0699e9
The commits will be squashed before merging.

Coverity reports that the changes are successful :-)

@neomutt/reviewers Please Review.
