### PR TITLE
Avoid "Interrupted system call" IMAP errors

### DIFF
--- a/mutt_socket.c
+++ b/mutt_socket.c
@@ -402,12 +402,7 @@ int raw_socket_read (CONNECTION* conn, char* buf, size_t len)
     mutt_error (_("Error talking to %s (%s)"), conn->account.host,
 		strerror (errno));
     mutt_sleep (2);
-  } else if (errno == EINTR) {
-    rc = -1;
-    mutt_error (_("Error talking to %s (%s)"), conn->account.host,
-               strerror (errno));
-    mutt_sleep (2);
-   }
+  }
   mutt_allow_interrupt (0);
 
   return rc;
@@ -422,11 +417,6 @@ int raw_socket_write (CONNECTION* conn, const char* buf, size_t count)
   {
     mutt_error (_("Error talking to %s (%s)"), conn->account.host,
 		strerror (errno));
-    mutt_sleep (2);
-  } else if (errno == EINTR) {
-    rc = -1;
-    mutt_error (_("Error talking to %s (%s)"), conn->account.host,
-               strerror (errno));
     mutt_sleep (2);
   }
   mutt_allow_interrupt (0);


### PR DESCRIPTION
When trying to use mutt with non-SSL IMAP it intermittently throws 'Error talking to localhost (Interrupted system call)' and closes the mailbox. This fixes neomutt/neomutt#407.