### PR TITLE
editorconfig: support for new files, fix whitespace

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,18 +4,18 @@ root = true
 end_of_line = lf
 insert_final_newline = true
 charset = utf8
-trim_trailing_whitespace = true
+trim_trailing_whitespace = false
 
-[*.{c,h}]
+# those two settings may be overwritten below.
 indent_size = 2
 indent_style = space
 
+
+
 [ChangeLog.neomutt]
-indent_style = space
 indent_size = 1
 
 
-[configure]
-indent_size = 2
-indent_style = space
-
+[{[mM]akefile*,*.am}]
+indent_size = 4
+indent_style = tab


### PR DESCRIPTION
* Our code contains a lot of whitespace issues, so every commit is
  polluted by whitespace changes with the current editorconfig. However, i'm not sure whether disabling `trim_trailing_whitespace` is the best way to go until the codebase has been formatted with clang-format (which will also fix trailing whitespace)

* Add support for Makefile.am, xml, vim and yml files.

@flatcap what do you think?