### PR TITLE
attachment/pager: Use mailcap for test/* except plain

### DIFF
--- a/handler.c
+++ b/handler.c
@@ -1823,7 +1823,7 @@ int mutt_body_handler (BODY *b, STATE *s)
     else if (ascii_strcasecmp ("enriched", b->subtype) == 0)
       handler = text_enriched_handler;
     else /* text body type without a handler */
-      plaintext = 1;
+      plaintext = 0;
   }
   else if (b->type == TYPEMESSAGE)
   {

--- a/muttlib.c
+++ b/muttlib.c
@@ -734,10 +734,9 @@ int mutt_needs_mailcap (BODY *m)
   switch (m->type)
   {
     case TYPETEXT:
-      /* we can display any text, overridable by auto_view */
-      return 0;
+      if (!ascii_strcasecmp ("plain", m->subtype))
+        return 0;
       break;
-
     case TYPEAPPLICATION:
       if((WithCrypto & APPLICATION_PGP) && mutt_is_application_pgp(m))
 	return 0;


### PR DESCRIPTION
This change makes attachment view using mailcap for everything
not text/plain.

And in pager, don't assume text/* are human readable except text/plain.
This can still be overridable with auto_view.

Closes #430