### PR TITLE
index_format: add support of %K

### DIFF
--- a/hdrline.c
+++ b/hdrline.c
@@ -422,7 +422,7 @@ static char *apply_subject_mods (ENVELOPE *env)
 /* %a = address of author
  * %A = reply-to address (if present; otherwise: address of author
  * %b = filename of the originating folder
- * %B = the list to which the letter was sent
+ * %B = the list to which the letter was sent, or else the folder name (%b).
  * %c = size of message in bytes
  * %C = current message number
  * %d = date and time of message using $date_format and sender's timezone
@@ -435,6 +435,7 @@ static char *apply_subject_mods (ENVELOPE *env)
  * %g = message labels (e.g. notmuch tags)
  * %i = message-id
  * %I = initials of author
+ * %K = the list to which the letter was sent (if any; otherwise: empty)
  * %l = number of lines in the message
  * %L = like %F, except `lists' are displayed first
  * %m = number of messages in the mailbox
@@ -526,6 +527,7 @@ hdr_format_str (char *dest,
       break;
 
     case 'B':
+    case 'K':
       if (!first_mailing_list (dest, destlen, hdr->env->to) &&
 	  !first_mailing_list (dest, destlen, hdr->env->cc))
 	dest[0] = 0;
@@ -534,6 +536,13 @@ hdr_format_str (char *dest,
 	strfcpy (buf2, dest, sizeof(buf2));
 	mutt_format_s (dest, destlen, prefix, buf2);
 	break;
+      }
+      if (op == 'K')
+      {
+        if (optional)
+          optional = 0;
+        /* break if 'K' returns nothing */
+        break;
       }
       /* fall through if 'B' returns nothing */
 

--- a/init.h
+++ b/init.h
@@ -1487,6 +1487,7 @@ struct option_t MuttVars[] = {
   ** .dt %g .dd message labels (e.g. notmuch tags)
   ** .dt %H .dd spam attribute(s) of this message
   ** .dt %i .dd message-id of the current message
+  ** .dt %K .dd the list to which the letter was sent (if any; otherwise: empty).
   ** .dt %l .dd number of lines in the message (does not work with maildir,
   **            mh, and possibly IMAP folders)
   ** .dt %L .dd If an address in the ``To:'' or ``Cc:'' header field matches an address


### PR DESCRIPTION
* What does this PR do?

This PR adds a new sequence `%K` to `$index_format`.
It returns the list to which the letter was sent. But unlike `%B`, `%K` will remain empty if no list is present. The sequence supports conditional formatting (`%?K?...`).

* Are there points in the code the reviewer needs to double check?

* Why was this PR needed?

This PR allows the user to create a column dedicated to list name (_if any_) in `$index_format`.

* Screenshots (if relevant)

The following screenshot uses:
```
$index_format = "%4C (%4c) %Z %?GI?%GI& ? %[%d/%b]  %-20.19F %?K?%15.14K&               ? %?M?(%3M)&     ? %?X?¤& ? %s %> %?g?%g?"
```

![2017-03-04-204630_1920x2160](https://cloud.githubusercontent.com/assets/226063/23581837/4c09bbce-011d-11e7-8535-d56fcca52970.png)

* Does this PR meet the acceptance criteria?

   - [x] Documentation created/updated (you have to edit
     [doc/manual.xml.head](https://www.neomutt.org/guide/) for that)

   - [ ] All builds are passing

   - [x] Code follows the [style guide](https://www.neomutt.org/dev/coding-style)

* What are the relevant issue numbers?

_N/A_