### PR TITLE
Abort when message is empty

### DIFF
--- a/send.c
+++ b/send.c
@@ -1662,7 +1662,7 @@ ci_send_message (int flags,		/* send mode */
       if (stat (msg->content->filename, &st) == 0)
       {
 	/* if the file was not modified, bail out now */
-	if (mtime == st.st_mtime && !msg->content->next &&
+	if ((mtime == st.st_mtime || st.st_size == 0) && !msg->content->next &&
 	    query_quadoption (OPT_ABORT, _("Abort unmodified message?")) == MUTT_YES)
 	{
 	  mutt_message (_("Aborted unmodified message."));


### PR DESCRIPTION
When the message to send is empty, this doesn't really make sense to
show the composer. We should return directly to the index.

Closes #191
