### PR TITLE
fix: Garbage in chdir prompt due to unescaped string

### DIFF
--- a/browser.c
+++ b/browser.c
@@ -1577,9 +1577,12 @@ void _mutt_select_file (char *f, size_t flen, int flags, char ***files, int *num
 #endif
 	{
 	  /* add '/' at the end of the directory name if not already there */
-	  int len=mutt_strlen(LastDir);
-	  if (len && LastDir[len-1] != '/' && sizeof (buf) > len)
-	    buf[len]='/';
+	  int len = mutt_strlen(buf);
+	  if ((len > 0) && (buf[len - 1] != '/') && (sizeof(buf) > (len + 1)))
+	  {
+	    buf[len] = '/';
+	    buf[len + 1] = '\0';
+	  }
 	}
 
 	if (mutt_get_field (_("Chdir to: "), buf, sizeof (buf), MUTT_FILE) == 0 &&


### PR DESCRIPTION
I upgraded one of my stable systems to stretch and noticed that when
changing the directory with 'c', there was some garbage at the end of
the string in the prompt. I've not noticed that before on my main
amd64 system, but this stable system is i386, so different alignment
and word size that can affect this kind of thing.

I tracked it down to an unescaped string handling.

Debian [BTS#857433](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=857433)