### PR TITLE
add %z format string to index_format

### DIFF
--- a/globals.h
+++ b/globals.h
@@ -233,6 +233,11 @@ WHERE short NewsPollTimeout;
 WHERE short NntpContext;
 #endif
 
+#ifdef DEBUG
+WHERE short DebugLevel;
+WHERE char *DebugFile;
+#endif
+
 WHERE short ConnectTimeout;
 WHERE short HistSize;
 WHERE short MenuContext;

--- a/init.h
+++ b/init.h
@@ -651,6 +651,23 @@ struct option_t MuttVars[] = {
   ** rest of the string are expanded in the \fIC\fP locale (that is in US
   ** English).
   */
+#ifdef DEBUG
+  { "debug_level", DT_NUM, R_NONE, UL &DebugLevel, 0 },
+  /*
+  ** .pp
+  ** The debug level. Note: to debug the early startup process (before the
+  ** configuration is loaded), ``-d'' mutt argument must be used.
+  ** debug_level/debug_file are ignored until it's read from the configuration
+  ** file.
+  */
+  { "debug_file", DT_PATH, R_NONE, UL &DebugFile, UL "~/.muttdebug" },
+  /*
+  ** .pp
+  ** The location prefix of the debug file, 0 is append to the debug file
+  ** Old debug files are renamed with the prefix 1, 2, 3 and 4.
+  ** See ``debug_level'' for more detail.
+  */
+#endif
   { "default_hook",     DT_STR,  R_NONE, UL &DefaultHook, UL "~f %s !~P | (~P ~C %s)" },
   /*
   ** .pp

--- a/init.h
+++ b/init.h
@@ -1510,7 +1510,10 @@ struct option_t MuttVars[] = {
   ** .dt %Y .dd ``X-Label:'' field, if present, and \fI(1)\fP not at part of a thread tree,
   **            \fI(2)\fP at the top of a thread, or \fI(3)\fP ``X-Label:'' is different from
   **            preceding message's ``X-Label:''.
-  ** .dt %Z .dd message status flags
+  ** .dt %Z .dd Combined message flags
+  ** .dt %zs .dd message status flags
+  ** .dt %zc .dd message crypto flags
+  ** .dt %zt .dd message tag flags
   ** .dt %{fmt} .dd the date and time of the message is converted to sender's
   **                time zone, and ``fmt'' is expanded by the library function
   **                \fCstrftime(3)\fP; a leading bang disables locales

--- a/lib.c
+++ b/lib.c
@@ -1015,8 +1015,11 @@ const char *mutt_strsysexit(int e)
 }
 
 #ifdef DEBUG
+char debugfilename[_POSIX_PATH_MAX];
 FILE *debugfile;
 int debuglevel;
+char *debugfile_cmdline = NULL;
+int debuglevel_cmdline;
 
 void mutt_debug(int level, const char *fmt, ...)
 {

--- a/lib.h
+++ b/lib.h
@@ -114,8 +114,11 @@ void mutt_exit(int);
 
 
 #ifdef DEBUG
+extern char debugfilename[_POSIX_PATH_MAX];
 extern FILE *debugfile;
 extern int debuglevel;
+extern char *debugfile_cmdline;
+extern int debuglevel_cmdline;
 void mutt_debug(int level, const char *fmt, ...);
 #else
 #define mutt_debug(...) do { } while (0)

--- a/main.c
+++ b/main.c
@@ -252,9 +252,10 @@ int main(int argc, char **argv, char **environ)
 
 #ifdef USE_NNTP
     if ((i = getopt(argc, argv,
-                    "+A:a:Bb:F:f:c:Dd:Ee:g:GH:s:i:hm:npQ:RSvxyzZ")) != EOF)
+                    "+A:a:Bb:F:f:c:Dd:l:Ee:g:GH:s:i:hm:npQ:RSvxyzZ")) != EOF)
 #else
-    if ((i = getopt(argc, argv, "+A:a:Bb:F:f:c:Dd:Ee:H:s:i:hm:npQ:RSvxyzZ")) != EOF)
+    if ((i = getopt(argc, argv,
+                    "+A:a:Bb:F:f:c:Dd:l:Ee:H:s:i:hm:npQ:RSvxyzZ")) != EOF)
 #endif
       switch (i)
       {
@@ -297,14 +298,14 @@ int main(int argc, char **argv, char **environ)
 
         case 'd':
 #ifdef DEBUG
-          if (mutt_atoi(optarg, &debuglevel) < 0 || debuglevel <= 0)
+          if (mutt_atoi(optarg, &debuglevel_cmdline) < 0 || debuglevel_cmdline <= 0)
           {
             fprintf(stderr, _("Error: value '%s' is invalid for -d.\n"), optarg);
             return 1;
           }
-          printf(_("Debugging at level %d.\n"), debuglevel);
+          printf(_("Debugging at level %d.\n"), debuglevel_cmdline);
 #else
-          printf(_("DEBUG was not defined during compilation.  Ignored.\n"));
+          printf(_("DEBUG was not defined during compilation. -d Ignored.\n"));
 #endif
           break;
 
@@ -322,6 +323,15 @@ int main(int argc, char **argv, char **environ)
 
         case 'i':
           includeFile = optarg;
+          break;
+
+        case 'l':
+#ifdef DEBUG
+          debugfile_cmdline = optarg;
+          printf(_("Debugging at file %s.\n"), debugfile_cmdline);
+#else
+          printf(_("DEBUG was not defined during compilation. -l Ignored.\n"));
+#endif
           break;
 
         case 'm':


### PR DESCRIPTION
The %Z format string consists of three columns. Add %z which only
consists of 2 columns, sacrificing the middle column. The cost here is
to omit sign and crypto flags, but not everybody cares for that.
Delete flags have been merged into the first column.

Signed-off-by: Stefan Assmann <sassmann@kpanic.de>

* What does this PR do?
Add %z which only consists of 2 columns to index_format.

* Are there points in the code the reviewer needs to double check?
Check hdr_format_str()

* Why was this PR needed?
Allows to have 2 column message status flags.

* Screenshots (if relevant)

* Does this PR meet the acceptance criteria?

   - [ ] Documentation created/updated (you have to edit
     [doc/manual.xml.head](https://www.neomutt.org/guide/) for that)
     Patch docs in init.h, should be enough?

   - [ ] All builds are passing
     How can I test this? Did a local build.

   - [ ] Added [doxygen code documentation](https://www.neomutt.org/dev/doxygen)
     [syntax](http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html)
     Not required

   - [ ] Code follows the [style guide](https://www.neomutt.org/dev/coding-style)
      I sure hope so. :)

* What are the relevant issue numbers?
