### PR TITLE
use w3m as default for generating UTF8 manual.txt

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -127,8 +127,8 @@ uninstall-local:
 
 check:
 manual.txt: manual.html
-	-LC_ALL=C lynx -dump -nolist -with_backspaces -display_charset=us-ascii manual.html > $@ || \
-	LC_ALL=C w3m -dump manual.html > $@ || \
+	-LC_ALL=C w3m -dump -O UTF8 manual.html > $@ || \
+	LC_ALL=C lynx -dump -nolist -with_backspaces -display_charset=us-ascii manual.html > $@ || \
 	LC_ALL=C elinks -dump -no-numbering -no-references manual.html | sed -e 's,\\001, ,g' > $@
 
 Muttrc: stamp-doc-rc


### PR DESCRIPTION
The input for manual.txt is manual.html which is UTF8 encoded. Now
forcing manual.txt to be ascii leads to all sorts of "?" in the ascii
file, which is not nice. If we have UTF8 input we should also use UTF8
for the output.
Moved w3m to be the default to generate UTF8 manual.txt. If you prefer
manual.txt to be ascii the fallbacks lynx or elinks will still produce
plain ascii.

Signed-off-by: Stefan Assmann <sassmann@kpanic.de>

* Does this PR meet the acceptance criteria?

   - [ ] Documentation created/updated (you have to edit
     [doc/manual.xml.head](https://www.neomutt.org/guide/) for that)

   - [ ] All builds are passing

   - [ ] Added [doxygen code documentation](https://www.neomutt.org/dev/doxygen)
     [syntax](http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html)

   - [ ] Code follows the [style guide](https://www.neomutt.org/dev/coding-style)