### PR TITLE
Fix Coverity Defects

### DIFF
--- a/addrbook.c
+++ b/addrbook.c
@@ -214,6 +214,8 @@ new_aliases:
         break;
       case OP_GENERIC_SELECT_ENTRY:
         t = menu->current;
+	done = 1;
+	break;
       case OP_EXIT:
 	done = 1;
 	break;

--- a/addrbook.c
+++ b/addrbook.c
@@ -164,6 +164,8 @@ new_aliases:
 
   safe_realloc (&AliasTable, menu->max * sizeof (ALIAS *));
   menu->data = AliasTable;
+  if (!AliasTable)
+    return;
 
   for (i = omax, aliasp = aliases; aliasp; aliasp = aliasp->next, i++)
   {

--- a/alias.c
+++ b/alias.c
@@ -285,7 +285,7 @@ retry_name:
 
   mutt_addrlist_to_local (adr);
 
-  if (adr)
+  if (adr && adr->mailbox)
     strfcpy (buf, adr->mailbox, sizeof (buf));
   else
     buf[0] = 0;

--- a/attach.c
+++ b/attach.c
@@ -729,7 +729,8 @@ int mutt_save_attachment (FILE *fp, BODY *m, char *path, int flags, HEADER *hdr)
       hn->msgno = hdr->msgno; /* required for MH/maildir */
       hn->read = true;
 
-      fseeko (fp, m->offset, SEEK_SET);
+      if (fseeko (fp, m->offset, SEEK_SET) < 0)
+        return -1;
       if (fgets (buf, sizeof (buf), fp) == NULL)
 	return -1;
       if (mx_open_mailbox(path, MUTT_APPEND | MUTT_QUIET, &ctx) == NULL)

--- a/attach.c
+++ b/attach.c
@@ -702,6 +702,9 @@ save_attachment_open (char *path, int flags)
 /* returns 0 on success, -1 on error */
 int mutt_save_attachment (FILE *fp, BODY *m, char *path, int flags, HEADER *hdr)
 {
+  if (!m)
+    return -1;
+
   if (fp)
   {
 
@@ -775,6 +778,9 @@ int mutt_save_attachment (FILE *fp, BODY *m, char *path, int flags, HEADER *hdr)
   }
   else
   {
+    if (!m->filename)
+      return -1;
+
     /* In send mode, just copy file */
 
     FILE *ofp = NULL, *nfp = NULL;

--- a/bcache.c
+++ b/bcache.c
@@ -65,9 +65,13 @@ static int bcache_path(ACCOUNT *account, const char *mailbox,
 
   mutt_encode_path (path, sizeof (path), NONULL (mailbox));
 
+  int plen = mutt_strlen(path);
+  if (plen == 0)
+    return -1;
+
   len = snprintf (dst, dstlen-1, "%s/%s%s%s", MessageCachedir,
 		  host, path,
-		  (*path && path[mutt_strlen (path) - 1] == '/') ? "" : "/");
+		  (*path && path[plen - 1] == '/') ? "" : "/");
 
   mutt_debug (3, "bcache_path: rc: %d, path: '%s'\n", len, dst);
 

--- a/browser.c
+++ b/browser.c
@@ -1755,10 +1755,11 @@ void _mutt_select_file (char *f, size_t flen, int flags, char ***files, int *num
 	}
 
       case OP_TOGGLE_MAILBOXES:
-	buffy = 1 - buffy;
-
       case OP_BROWSER_GOTO_FOLDER:
       case OP_CHECK_NEW:
+        if (i == OP_TOGGLE_MAILBOXES)
+          buffy = 1 - buffy;
+
         if (i == OP_BROWSER_GOTO_FOLDER)
         {
           /* When in mailboxes mode, disables this feature */

--- a/buffer.c
+++ b/buffer.c
@@ -119,14 +119,11 @@ static void mutt_buffer_add (BUFFER* buf, const char* s, size_t len)
   if (!buf || !s)
     return;
 
-  size_t offset;
-
-  if (buf->dptr + len + 1 > buf->data + buf->dsize)
+  if ((buf->dptr + len + 1) > (buf->data + buf->dsize))
   {
-    offset = buf->dptr - buf->data;
-    buf->dsize += len < 128 ? 128 : len + 1;
-    /* suppress compiler aliasing warning */
-    safe_realloc ((void**) (void*) &buf->data, buf->dsize);
+    size_t offset = buf->dptr - buf->data;
+    buf->dsize += (len < 128) ? 128 : len + 1;
+    safe_realloc (&buf->data, buf->dsize);
     buf->dptr = buf->data + offset;
   }
   if (!buf->dptr)

--- a/buffer.c
+++ b/buffer.c
@@ -116,6 +116,9 @@ int mutt_buffer_printf (BUFFER* buf, const char* fmt, ...)
  * the buffer is always null-terminated */
 static void mutt_buffer_add (BUFFER* buf, const char* s, size_t len)
 {
+  if (!buf || !s)
+    return;
+
   size_t offset;
 
   if (buf->dptr + len + 1 > buf->data + buf->dsize)
@@ -126,6 +129,8 @@ static void mutt_buffer_add (BUFFER* buf, const char* s, size_t len)
     safe_realloc ((void**) (void*) &buf->data, buf->dsize);
     buf->dptr = buf->data + offset;
   }
+  if (!buf->dptr)
+    return;
   memcpy (buf->dptr, s, len);
   buf->dptr += len;
   *(buf->dptr) = '\0';
@@ -143,6 +148,9 @@ void mutt_buffer_addch (BUFFER* buf, char c)
 
 int mutt_extract_token (BUFFER *dest, BUFFER *tok, int flags)
 {
+  if (!dest || !tok)
+    return -1;
+
   char		ch;
   char		qc = 0; /* quote char */
   char		*pc;

--- a/buffy.c
+++ b/buffy.c
@@ -602,6 +602,9 @@ int mutt_parse_mailboxes (BUFFER *path, BUFFER *s, unsigned long data, BUFFER *e
 #ifdef USE_NOTMUCH
 int mutt_parse_virtual_mailboxes (BUFFER *path, BUFFER *s, unsigned long data, BUFFER *err)
 {
+  if (!path || !s)
+    return -1;
+
   BUFFY **tmp;
   char buf[_POSIX_PATH_MAX + LONG_STRING + 32];   /* path to DB + query + URI "decoration" */
 

--- a/copy.c
+++ b/copy.c
@@ -64,7 +64,8 @@ mutt_copy_hdr (FILE *in, FILE *out, LOFF_T off_start, LOFF_T off_end, int flags,
     return -1;
 
   if (ftello (in) != off_start)
-    fseeko (in, off_start, SEEK_SET);
+    if (fseeko (in, off_start, SEEK_SET) < 0)
+      return -1;
 
   buf[0] = '\n';
   buf[1] = 0;
@@ -575,7 +576,8 @@ _mutt_copy_message (FILE *fpout, FILE *fpin, HEADER *hdr, BODY *body,
       new_offset = ftello (fpout);
 
       /* Copy the body */
-      fseeko (fpin, body->offset, SEEK_SET);
+      if (fseeko (fpin, body->offset, SEEK_SET) < 0)
+	return -1;
       if (copy_delete_attach (body, fpin, fpout, date))
 	return -1;
 
@@ -678,7 +680,8 @@ _mutt_copy_message (FILE *fpout, FILE *fpin, HEADER *hdr, BODY *body,
     mutt_write_mime_header (cur, fpout);
     fputc ('\n', fpout);
 
-    fseeko (fp, cur->offset, SEEK_SET);
+    if (fseeko (fp, cur->offset, SEEK_SET) < 0)
+      return -1;
     if (mutt_copy_bytes (fp, fpout, cur->length) == -1)
     {
       safe_fclose (&fp);
@@ -690,7 +693,8 @@ _mutt_copy_message (FILE *fpout, FILE *fpin, HEADER *hdr, BODY *body,
   }
   else
   {
-    fseeko (fpin, body->offset, SEEK_SET);
+    if (fseeko (fpin, body->offset, SEEK_SET) < 0)
+      return -1;
     if (flags & MUTT_CM_PREFIX)
     {
       int c;
@@ -760,7 +764,8 @@ _mutt_append_message (CONTEXT *dest, FILE *fpin, CONTEXT *src, HEADER *hdr,
   MESSAGE *msg = NULL;
   int r;
 
-  fseeko (fpin, hdr->offset, SEEK_SET);
+  if (fseeko (fpin, hdr->offset, SEEK_SET) < 0)
+    return -1;
   if (fgets (buf, sizeof (buf), fpin) == NULL)
     return -1;
 

--- a/copy.c
+++ b/copy.c
@@ -774,7 +774,7 @@ _mutt_append_message (CONTEXT *dest, FILE *fpin, CONTEXT *src, HEADER *hdr,
     r = -1;
 
 #ifdef USE_NOTMUCH
-  if (hdr && msg->commited_path && dest->magic == MUTT_MAILDIR && src->magic == MUTT_NOTMUCH)
+  if (msg->commited_path && dest->magic == MUTT_MAILDIR && src->magic == MUTT_NOTMUCH)
 	  nm_update_filename(src, NULL, msg->commited_path, hdr);
 #endif
 

--- a/copy.c
+++ b/copy.c
@@ -60,6 +60,9 @@ mutt_copy_hdr (FILE *in, FILE *out, LOFF_T off_start, LOFF_T off_end, int flags,
   size_t this_one_len = 0;
   int error;
 
+  if (off_start < 0)
+    return -1;
+
   if (ftello (in) != off_start)
     fseeko (in, off_start, SEEK_SET);
 

--- a/copy.c
+++ b/copy.c
@@ -553,12 +553,16 @@ _mutt_copy_message (FILE *fpout, FILE *fpin, HEADER *hdr, BODY *body,
       char date[SHORT_STRING];
 
       mutt_make_date (date, sizeof (date));
-      date[5] = date[mutt_strlen (date) - 1] = '\"';
+      int dlen = mutt_strlen(date);
+      if (dlen == 0)
+        return -1;
+
+      date[5] = '\"';
+      date[dlen - 1] = '\"';
 
       /* Count the number of lines and bytes to be deleted */
       fseeko (fpin, body->offset, SEEK_SET);
-      new_lines = hdr->lines -
-	count_delete_lines (fpin, body, &new_length, mutt_strlen (date));
+      new_lines = hdr->lines - count_delete_lines(fpin, body, &new_length, dlen);
 
       /* Copy the headers */
       if (mutt_copy_header (fpin, hdr, fpout,

--- a/crypt-gpgme.c
+++ b/crypt-gpgme.c
@@ -1141,6 +1141,9 @@ static int show_sig_summary (unsigned long sum,
                               gpgme_ctx_t ctx, gpgme_key_t key, int idx,
                               STATE *s, gpgme_signature_t sig)
 {
+  if (!key)
+    return 1;
+
   int severe = 0;
 
   if ((sum & GPGME_SIGSUM_KEY_REVOKED))
@@ -1676,6 +1679,9 @@ int smime_gpgme_verify_one (BODY *sigbdy, STATE *s, const char *tempfile)
 static BODY *decrypt_part (BODY *a, STATE *s, FILE *fpout, int is_smime,
                            int *r_is_signed)
 {
+  if (!a || !s || !fpout)
+    return NULL;
+
   struct stat info;
   BODY *tattach = NULL;
   int err = 0;

--- a/crypt-gpgme.c
+++ b/crypt-gpgme.c
@@ -2947,7 +2947,7 @@ static const char *crypt_entry_fmt (char *dest,
             }
 	}
       snprintf (fmt, sizeof (fmt), "%%%sc", prefix);
-      snprintf (dest, destlen, fmt, s? *s: 'B');
+      snprintf (dest, destlen, fmt, *s);
       break;
     case 'p':
       snprintf (fmt, sizeof (fmt), "%%%ss", prefix);
@@ -4159,7 +4159,7 @@ static crypt_key_t *crypt_getkeybyaddr (ADDRESS * a, short abilities,
     hints = crypt_add_string_to_hints (hints, a->personal);
 
   if (! oppenc_mode )
-    mutt_message (_("Looking for keys matching \"%s\"..."), a->mailbox);
+    mutt_message (_("Looking for keys matching \"%s\"..."), a ? a->mailbox : "");
   keys = get_candidates (hints, app, (abilities & KEYFLAG_CANSIGN) );
 
   mutt_free_list (&hints);

--- a/crypt-gpgme.c
+++ b/crypt-gpgme.c
@@ -530,7 +530,7 @@ static int data_object_to_stream (gpgme_data_t data, FILE *fp)
       return -1;
     }
 
-  while ((nread = gpgme_data_read (data, buf, sizeof (buf))))
+  while ((nread = gpgme_data_read (data, buf, sizeof (buf))) >= 0)
     {
       /* fixme: we are not really converting CRLF to LF but just
          skipping CR. Doing it correctly needs a more complex logic */
@@ -565,7 +565,7 @@ static char *data_object_to_tempfile (gpgme_data_t data, char *tempf, FILE **ret
   int err;
   char tempfb[_POSIX_PATH_MAX];
   FILE *fp = NULL;
-  size_t nread = 0;
+  ssize_t nread = 0;
 
   if (!tempf)
     {
@@ -584,7 +584,7 @@ static char *data_object_to_tempfile (gpgme_data_t data, char *tempf, FILE **ret
     {
       char buf[4096];
 
-      while ((nread = gpgme_data_read (data, buf, sizeof (buf))))
+      while ((nread = gpgme_data_read (data, buf, sizeof (buf))) >= 0)
         {
           if (fwrite (buf, nread, 1, fp) != 1)
             {

--- a/curs_lib.c
+++ b/curs_lib.c
@@ -765,6 +765,8 @@ int mutt_any_key_to_continue (const char *s)
   int f, ch;
 
   f = open ("/dev/tty", O_RDONLY);
+  if (f < 0)
+    return EOF;
   tcgetattr (f, &t);
   memcpy ((void *)&old, (void *)&t, sizeof(struct termios)); /* save original state */
   t.c_lflag &= ~(ICANON | ECHO);

--- a/curs_lib.c
+++ b/curs_lib.c
@@ -785,7 +785,7 @@ int mutt_any_key_to_continue (const char *s)
   close (f);
   fputs ("\r\n", stdout);
   mutt_clear_error ();
-  return ch;
+  return (ch >= 0) ? ch : EOF;
 }
 
 int mutt_do_pager (const char *banner,

--- a/curs_main.c
+++ b/curs_main.c
@@ -1658,9 +1658,11 @@ int mutt_index_menu (void)
 	break;
 
       case OP_COMPOSE_TO_SENDER:
-
-	mutt_compose_to_sender (tag ? NULL : CURHDR);
-	menu->redraw = REDRAW_FULL;
+        if (Context)
+        {
+          mutt_compose_to_sender (tag ? NULL : CURHDR);
+          menu->redraw = REDRAW_FULL;
+        }
 	break;
 
 	/* --------------------------------------------------------------------
@@ -1775,7 +1777,8 @@ int mutt_index_menu (void)
 #ifdef USE_NOTMUCH
       case OP_MAIN_ENTIRE_THREAD:
       {
-	if (Context->magic != MUTT_NOTMUCH) {
+	if (!Context || (Context->magic != MUTT_NOTMUCH))
+        {
 	  mutt_message (_("No virtual folder, aborting."));
 	  break;
 	}
@@ -1810,7 +1813,7 @@ int mutt_index_menu (void)
       case OP_MAIN_MODIFY_LABELS:
       case OP_MAIN_MODIFY_LABELS_THEN_HIDE:
       {
-	if (Context->magic != MUTT_NOTMUCH) {
+	if (!Context || (Context->magic != MUTT_NOTMUCH)) {
 	  mutt_message (_("No virtual folder, aborting."));
 	  break;
 	}
@@ -1995,7 +1998,7 @@ int mutt_index_menu (void)
 #endif
 #ifdef USE_NOTMUCH
 	else if (op == OP_MAIN_CHANGE_VFOLDER) {
-	  if (Context->magic == MUTT_NOTMUCH) {
+	  if (Context && (Context->magic == MUTT_NOTMUCH)) {
 		  strfcpy(buf, Context->path, sizeof (buf));
 		  mutt_buffy_vfolder (buf, sizeof (buf));
 	  }

--- a/editmsg.c
+++ b/editmsg.c
@@ -176,7 +176,7 @@ static int edit_one_message (CONTEXT *ctx, HEADER *cur)
   if ((rc = mutt_copy_hdr (fp, msg->fp, 0, sb.st_size, CH_NOLEN | cf, NULL)) == 0)
   {
     fputc ('\n', msg->fp);
-    rc = mutt_copy_stream (fp, msg->fp);
+    mutt_copy_stream (fp, msg->fp);
   }
 
   rc = mx_commit_message (msg, &tmpctx);

--- a/handler.c
+++ b/handler.c
@@ -1197,6 +1197,9 @@ static int message_handler (BODY *a, STATE *s)
   int rc = 0;
 
   off_start = ftello (s->fpin);
+  if (off_start < 0)
+    return -1;
+
   if (a->encoding == ENCBASE64 || a->encoding == ENCQUOTEDPRINTABLE ||
       a->encoding == ENCUUENCODED)
   {

--- a/handler.c
+++ b/handler.c
@@ -1790,6 +1790,9 @@ static int malformed_pgp_encrypted_handler (BODY *b, STATE *s)
 
 int mutt_body_handler (BODY *b, STATE *s)
 {
+  if (!b || !s)
+    return -1;
+
   int plaintext = 0;
   handler_t handler = NULL;
   int rc = 0;

--- a/handler.c
+++ b/handler.c
@@ -1059,7 +1059,7 @@ static int alternative_handler (BODY *a, STATE *s)
       btlen = mutt_strlen (t->data);
     }
 
-    if (a && a->parts)
+    if (a->parts)
       b = a->parts;
     else
       b = a;
@@ -1082,7 +1082,7 @@ static int alternative_handler (BODY *a, STATE *s)
   /* Next, look for an autoviewable type */
   if (!choice)
   {
-    if (a && a->parts)
+    if (a->parts)
       b = a->parts;
     else
       b = a;
@@ -1097,7 +1097,7 @@ static int alternative_handler (BODY *a, STATE *s)
   /* Then, look for a text entry */
   if (!choice)
   {
-    if (a && a->parts)
+    if (a->parts)
       b = a->parts;
     else
       b = a;
@@ -1128,7 +1128,7 @@ static int alternative_handler (BODY *a, STATE *s)
   /* Finally, look for other possibilities */
   if (!choice)
   {
-    if (a && a->parts)
+    if (a->parts)
       b = a->parts;
     else
       b = a;
@@ -1156,7 +1156,7 @@ static int alternative_handler (BODY *a, STATE *s)
 
     if (mutt_strcmp ("info", ShowMultipartAlternative) == 0)
     {
-      if (a && a->parts)
+      if (a->parts)
         b = a->parts;
       else
         b = a;

--- a/headers.c
+++ b/headers.c
@@ -281,7 +281,7 @@ int mutt_label_message(HEADER *hdr)
 
   *buf = '\0';
   if (hdr != NULL && hdr->env->x_label != NULL) {
-    strncpy(buf, hdr->env->x_label, LONG_STRING);
+    strfcpy(buf, hdr->env->x_label, sizeof(buf));
   }
 
   if (mutt_get_field("Label: ", buf, sizeof(buf), MUTT_LABEL /* | MUTT_CLEAR */) != 0)

--- a/imap/auth_gss.c
+++ b/imap/auth_gss.c
@@ -56,7 +56,7 @@ static void print_gss_error(OM_uint32 err_maj, OM_uint32 err_min)
 					       &status_string);
 		if (GSS_ERROR(maj_stat))
 			break;
-		strncpy(buf_maj, (char*) status_string.value, sizeof(buf_maj));
+		strfcpy(buf_maj, (char*) status_string.value, sizeof(buf_maj));
 		gss_release_buffer(&min_stat, &status_string);
 
 		maj_stat = gss_display_status (&min_stat,
@@ -67,7 +67,7 @@ static void print_gss_error(OM_uint32 err_maj, OM_uint32 err_min)
 					       &status_string);
 		if (!GSS_ERROR(maj_stat))
 		{
-			strncpy(buf_min, (char*) status_string.value, sizeof(buf_min));
+			strfcpy(buf_min, (char*) status_string.value, sizeof(buf_min));
 			gss_release_buffer(&min_stat, &status_string);
 		}
 	} while (!GSS_ERROR(maj_stat) && msg_ctx != 0);

--- a/imap/auth_gss.c
+++ b/imap/auth_gss.c
@@ -113,10 +113,9 @@ imap_auth_res_t imap_auth_gss (IMAP_DATA* idata, const char* method)
 #ifdef DEBUG
   else if (debuglevel >= 2)
   {
-    maj_stat = gss_display_name (&min_stat, target_name, &request_buf,
-      &mech_name);
+    gss_display_name (&min_stat, target_name, &request_buf, &mech_name);
     mutt_debug (2, "Using service name [%s]\n", (char*) request_buf.value);
-    maj_stat = gss_release_buffer (&min_stat, &request_buf);
+    gss_release_buffer (&min_stat, &request_buf);
   }
 #endif
   /* Acquire initial credentials - without a TGT GSSAPI is UNAVAIL */

--- a/init.c
+++ b/init.c
@@ -2334,6 +2334,10 @@ static int parse_set (BUFFER *tmp, BUFFER *s, unsigned long data, BUFFER *err)
           restore_default (&MuttVars[idx]);
       }
     }
+    else if (idx < 0)
+    {
+      return -1;
+    }
     else if (!myvar && DTYPE (MuttVars[idx].type) == DT_BOOL)
     {
       if (s && *s->dptr == '=')
@@ -2868,6 +2872,8 @@ static int source_rc (const char *rcfile_path, BUFFER *err)
   strfcpy(rcfile, rcfile_path, PATH_MAX);
 
   rcfilelen = mutt_strlen(rcfile);
+  if (rcfilelen == 0)
+    return -1;
 
   if (rcfile[rcfilelen-1] != '|')
   {

--- a/init.c
+++ b/init.c
@@ -2829,7 +2829,7 @@ static int to_absolute_path(char *path, const char *reference)
 
   ref_tmp = safe_strdup(reference);
   dirpath = dirname(ref_tmp); /* get directory name of */
-  strncpy(abs_path, dirpath, PATH_MAX);
+  strfcpy(abs_path, dirpath, PATH_MAX);
   safe_strncat(abs_path, sizeof(abs_path), "/", 1); /* append a / at the end of the path */
 
   FREE(&ref_tmp);
@@ -2865,7 +2865,7 @@ static int source_rc (const char *rcfile_path, BUFFER *err)
 
   pid_t pid;
 
-  strncpy(rcfile, rcfile_path, PATH_MAX);
+  strfcpy(rcfile, rcfile_path, PATH_MAX);
 
   rcfilelen = mutt_strlen(rcfile);
 

--- a/init.c
+++ b/init.c
@@ -4157,6 +4157,9 @@ static int parse_group_context (group_context_t **ctx, BUFFER *buf, BUFFER *s, u
 #ifdef USE_NOTMUCH
 static int parse_tag_transforms (BUFFER *b, BUFFER *s, unsigned long data, BUFFER *err)
 {
+  if (!b || !s)
+    return -1;
+
   char *tmp = NULL;
 
   while (MoreArgs (s))
@@ -4188,6 +4191,9 @@ static int parse_tag_transforms (BUFFER *b, BUFFER *s, unsigned long data, BUFFE
 
 static int parse_tag_formats (BUFFER *b, BUFFER *s, unsigned long data, BUFFER *err)
 {
+  if (!b || !s)
+    return -1;
+
   char *tmp = NULL;
 
   while (MoreArgs (s))

--- a/init.c
+++ b/init.c
@@ -3287,7 +3287,11 @@ int mutt_var_value_complete (char *buffer, size_t len, int pos)
 
     strfcpy (var, pt, sizeof (var));
     /* ignore the trailing '=' when comparing */
-    var[mutt_strlen (var) - 1] = 0;
+    int vlen = mutt_strlen(var);
+    if (vlen == 0)
+      return 0;
+
+    var[vlen - 1] = 0;
     if ((idx = mutt_option_index (var)) == -1)
     {
       if ((myvarval = myvar_get(var)) != NULL)

--- a/init.c
+++ b/init.c
@@ -2303,7 +2303,7 @@ static int parse_set (BUFFER *tmp, BUFFER *s, unsigned long data, BUFFER *err)
 	return -1;
       }
 
-      if (s && *s->dptr == '=')
+      if (*s->dptr == '=')
       {
 	snprintf (err->data, err->dsize, _("value is illegal with reset"));
 	return -1;
@@ -2340,7 +2340,7 @@ static int parse_set (BUFFER *tmp, BUFFER *s, unsigned long data, BUFFER *err)
     }
     else if (!myvar && DTYPE (MuttVars[idx].type) == DT_BOOL)
     {
-      if (s && *s->dptr == '=')
+      if (*s->dptr == '=')
       {
 	if (unset || inv || query)
 	{

--- a/lib.c
+++ b/lib.c
@@ -183,6 +183,8 @@ void safe_realloc (void *ptr, size_t siz)
 
 void safe_free (void *ptr)	/* __SAFE_FREE_CHECKED__ */
 {
+  if (!ptr)
+    return;
   void **p = (void **)ptr;
   if (*p)
   {

--- a/menu.c
+++ b/menu.c
@@ -885,7 +885,7 @@ void mutt_current_menu_redraw ()
 
 static int menu_search (MUTTMENU *menu, int op)
 {
-  int r, wrap = 0;
+  int r = 0, wrap = 0;
   int searchDir;
   regex_t re;
   char buf[SHORT_STRING];
@@ -913,7 +913,10 @@ static int menu_search (MUTTMENU *menu, int op)
   if (op == OP_SEARCH_OPPOSITE)
     searchDir = -searchDir;
 
-  if ((r = REGCOMP (&re, searchBuf, REG_NOSUB | mutt_which_case (searchBuf))) != 0)
+  if (searchBuf)
+    r = REGCOMP (&re, searchBuf, REG_NOSUB | mutt_which_case (searchBuf));
+
+  if (r != 0)
   {
     regerror (r, &re, buf, sizeof (buf));
     mutt_error ("%s", buf);

--- a/mutt_notmuch.c
+++ b/mutt_notmuch.c
@@ -1840,7 +1840,7 @@ bool nm_normalize_uri(char *new_uri, const char *orig_uri, size_t new_uri_sz)
 
   mutt_debug (2, "nm_normalize_uri #2 () -> db_query: %s\n", tmp_ctxdata.db_query);
 
-  strncpy(buf, tmp_ctxdata.db_query, sizeof(buf));
+  strfcpy(buf, tmp_ctxdata.db_query, sizeof(buf));
 
   if (nm_uri_from_query(&tmp_ctx, buf, sizeof(buf)) == NULL)
   {

--- a/mutt_notmuch.c
+++ b/mutt_notmuch.c
@@ -584,6 +584,9 @@ static char *get_query_string(struct nm_ctxdata *data, int window)
       data->db_query = safe_strdup(item->value);
   }
 
+  if (!data->db_query)
+    return NULL;
+
   if (!data->query_type)
     data->query_type = string_to_query_type(NULL);
 

--- a/muttlib.c
+++ b/muttlib.c
@@ -110,6 +110,9 @@ void mutt_adv_mktemp (char *s, size_t l)
 /* create a send-mode duplicate from a receive-mode body */
 int mutt_copy_body (FILE *fp, BODY **tgt, BODY *src)
 {
+  if (!tgt || !src)
+    return -1;
+
   char tmp[_POSIX_PATH_MAX];
   BODY *b = NULL;
 
@@ -1872,12 +1875,17 @@ int state_printf (STATE *s, const char *fmt, ...)
 
 void state_mark_attach (STATE *s)
 {
+  if (!s || !s->fpout)
+    return;
   if ((s->flags & MUTT_DISPLAY) && (mutt_strcmp (Pager, "builtin") == 0))
     state_puts (AttachmentMarker, s);
 }
 
 void state_attach_puts (const char *t, STATE *s)
 {
+  if (!t || !s || !s->fpout)
+    return;
+
   if (*t != '\n') state_mark_attach (s);
   while (*t)
   {

--- a/pager.c
+++ b/pager.c
@@ -1435,7 +1435,8 @@ display_line (FILE *f, LOFF_T *last_pos, struct line_t **lineInfo, int n,
 	(*last)--;
       goto out;
     }
-    regexec ((regex_t *) QuoteRegexp.rx, (char *) fmt, 1, pmatch, 0);
+    if (regexec ((regex_t *) QuoteRegexp.rx, (char *) fmt, 1, pmatch, 0) != 0)
+      goto out;
     (*lineInfo)[n].quote = classify_quote (QuoteList,
 			    (char *) fmt + pmatch[0].rm_so,
 			    pmatch[0].rm_eo - pmatch[0].rm_so,

--- a/parse.c
+++ b/parse.c
@@ -621,7 +621,8 @@ BODY *mutt_parse_multipart (FILE *fp, const char *boundary, LOFF_T end_off, int 
 
 #ifdef SUN_ATTACHMENT
         if (mutt_get_parameter ("content-lines", new->parameter)) {
-	  mutt_atoi (mutt_get_parameter ("content-lines", new->parameter), &lines);
+	  if (mutt_atoi (mutt_get_parameter ("content-lines", new->parameter), &lines) < 0)
+            lines = 0;
 	  for ( ; lines; lines-- )
 	     if (ftello (fp) >= end_off || fgets (buffer, LONG_STRING, fp) == NULL)
 	       break;

--- a/parse.c
+++ b/parse.c
@@ -1346,7 +1346,8 @@ int mutt_parse_rfc822_line (ENVELOPE *e, HEADER *hdr, char *line, char *p, short
 
   done:
 
-  *lastp = last;
+  if (lastp)
+    *lastp = last;
   return matched;
 }
 

--- a/pgp.c
+++ b/pgp.c
@@ -886,7 +886,7 @@ static BODY *pgp_decrypt_part (BODY *a, STATE *s, FILE *fpout, BODY *p)
   if (s->flags & MUTT_DISPLAY)
   {
     rewind (pgperr);
-    if (pgp_copy_checksig (pgperr, s->fpout) == 0 && !rv && p)
+    if (pgp_copy_checksig (pgperr, s->fpout) == 0 && !rv)
       p->goodsig = true;
     else
       p->goodsig = false;

--- a/pgp.c
+++ b/pgp.c
@@ -804,6 +804,9 @@ void pgp_extract_keys_from_attachment_list (FILE *fp, int tag, BODY *top)
 
 static BODY *pgp_decrypt_part (BODY *a, STATE *s, FILE *fpout, BODY *p)
 {
+  if (!a || !s || !fpout || !p)
+    return NULL;
+
   char buf[LONG_STRING];
   FILE *pgpin = NULL, *pgpout = NULL, *pgperr = NULL, *pgptmp = NULL;
   struct stat info;

--- a/pgpinvoke.c
+++ b/pgpinvoke.c
@@ -308,7 +308,8 @@ void pgp_invoke_getkeys (ADDRESS *addr)
 
   if (!isendwin ()) mutt_clear_error ();
 
-  close (devnull);
+  if (devnull >= 0)
+    close (devnull);
 }
 
 pid_t pgp_invoke_export (FILE **pgpin, FILE **pgpout, FILE **pgperr,

--- a/pgpkey.c
+++ b/pgpkey.c
@@ -823,7 +823,7 @@ pgp_key_t pgp_getkeybyaddr (ADDRESS * a, short abilities, pgp_ring_t keyring,
     hints = pgp_add_string_to_hints (hints, a->personal);
 
   if (! oppenc_mode )
-    mutt_message (_("Looking for keys matching \"%s\"..."), a->mailbox);
+    mutt_message (_("Looking for keys matching \"%s\"..."), a ? a->mailbox : "");
   keys = pgp_get_candidates (keyring, hints);
 
   mutt_free_list (&hints);

--- a/pgpmicalg.c
+++ b/pgpmicalg.c
@@ -102,6 +102,8 @@ static void pgp_dearmor (FILE *in, FILE *out)
 
   /* actual data starts here */
   start = ftello (in);
+  if (start < 0)
+    return;
 
   /* find the checksum */
 

--- a/pgppacket.c
+++ b/pgppacket.c
@@ -138,7 +138,7 @@ unsigned char *pgp_read_packet (FILE * fp, size_t * len)
 	  perror ("fread");
 	  goto bail;
 	}
-	material = buf[0] << 24;
+	material = (size_t) buf[0] << 24;
 	material |= buf[1] << 16;
 	material |= buf[2] << 8;
 	material |= buf[3];

--- a/pgppacket.c
+++ b/pgppacket.c
@@ -73,6 +73,8 @@ unsigned char *pgp_read_packet (FILE * fp, size_t * len)
   size_t material;
 
   startpos = ftello (fp);
+  if (startpos < 0)
+    return NULL;
 
   if (!plen)
   {

--- a/pgppacket.c
+++ b/pgppacket.c
@@ -173,7 +173,8 @@ unsigned char *pgp_read_packet (FILE * fp, size_t * len)
       }
 
       case 1:
-      bytes = 2;
+        bytes = 2;
+        /* fall through */
 
       case 2:
       {

--- a/pgppubring.c
+++ b/pgppubring.c
@@ -743,9 +743,11 @@ static pgp_key_t pgp_parse_keyblock (FILE * fp)
 	  break;
 
 	chr = safe_malloc (l);
-	memcpy (chr, buff + 1, l - 1);
-	chr[l - 1] = '\0';
-
+        if (l > 0)
+        {
+          memcpy (chr, buff + 1, l - 1);
+          chr[l - 1] = '\0';
+        }
 
 	*addr = uid = safe_calloc (1, sizeof (pgp_uid_t)); /* XXX */
 	uid->addr = chr;

--- a/pgppubring.c
+++ b/pgppubring.c
@@ -640,7 +640,7 @@ static pgp_key_t pgp_parse_keyblock (FILE * fp)
   unsigned char *buff = NULL;
   unsigned char pt = 0;
   unsigned char last_pt;
-  size_t l;
+  size_t l = 0;
   short err = 0;
 
 #ifdef HAVE_FGETPOS

--- a/pgppubring.c
+++ b/pgppubring.c
@@ -691,7 +691,7 @@ static pgp_key_t pgp_parse_keyblock (FILE * fp)
 	if (pt == PT_SUBKEY || pt == PT_SUBSECKEY)
 	{
 	  p->flags |= KEYFLAG_SUBKEY;
-	  if (p != root)
+	  if (root && (p != root))
 	  {
 	    p->parent  = root;
 	    p->address = pgp_copy_uids (root->address, p);

--- a/pop_lib.c
+++ b/pop_lib.c
@@ -397,8 +397,11 @@ void pop_logout (CONTEXT *ctx)
     if (ret != -1)
     {
       strfcpy (buf, "QUIT\r\n", sizeof (buf));
-      pop_query (pop_data, buf, sizeof (buf));
+      ret = pop_query (pop_data, buf, sizeof (buf));
     }
+
+    if (ret < 0)
+      mutt_debug(1, "Error closing POP connection\n");
 
     mutt_clear_error ();
   }

--- a/recvattach.c
+++ b/recvattach.c
@@ -894,6 +894,7 @@ mutt_attach_display_loop (MUTTMENU *menu, int op, FILE *fp, HEADER *hdr,
       case OP_ATTACH_COLLAPSE:
         if (recv)
           return op;
+        /* fall through */
       default:
 	op = OP_NULL;
     }

--- a/rfc2047.c
+++ b/rfc2047.c
@@ -615,7 +615,7 @@ static int rfc2047_decode_word (char *d, const char *s, size_t len)
   char *charset = NULL;
   int rv = -1;
 
-  pd = d0 = safe_malloc (strlen (s));
+  pd = d0 = safe_malloc (strlen (s) + 1);
 
   for (pp = s; (pp1 = strchr (pp, '?')); pp = pp1 + 1)
   {

--- a/rfc2231.c
+++ b/rfc2231.c
@@ -318,6 +318,7 @@ int rfc2231_encode_string (char **pd)
 				  *pd, strlen (*pd), &d, &dlen)))
   {
     charset = safe_strdup (Charset ? Charset : "unknown-8bit");
+    FREE(&d);
     d = *pd;
     dlen = strlen (d);
   }

--- a/rfc2231.c
+++ b/rfc2231.c
@@ -188,15 +188,12 @@ static void rfc2231_join_continuations (PARAMETER **head,
 	valp = par->value;
     } while (par && (strcmp (par->attribute, attribute) == 0));
 
-    if (value)
-    {
-      if (encoded)
-	mutt_convert_string (&value, charset, Charset, MUTT_ICONV_HOOK_FROM);
-      *head = mutt_new_parameter ();
-      (*head)->attribute = safe_strdup (attribute);
-      (*head)->value = value;
-      head = &(*head)->next;
-    }
+    if (encoded)
+      mutt_convert_string (&value, charset, Charset, MUTT_ICONV_HOOK_FROM);
+    *head = mutt_new_parameter ();
+    (*head)->attribute = safe_strdup (attribute);
+    (*head)->value = value;
+    head = &(*head)->next;
   }
 }
 

--- a/send.c
+++ b/send.c
@@ -287,7 +287,7 @@ static int edit_envelope (ENVELOPE *en, int flags)
       if (ascii_strncasecmp ("subject:", uh->data, 8) == 0)
       {
 	p = skip_email_wsp(uh->data + 8);
-	strncpy (buf, p, sizeof (buf));
+	strfcpy (buf, p, sizeof (buf));
       }
     }
   }

--- a/sendlib.c
+++ b/sendlib.c
@@ -1117,6 +1117,9 @@ void mutt_message_to_7bit (BODY *a, FILE *fp)
     goto cleanup;
   }
 
+  if (!fpin)
+    goto cleanup;
+
   fseeko (fpin, a->offset, SEEK_SET);
   a->parts = mutt_parse_message_rfc822 (fpin, a);
 

--- a/smime.c
+++ b/smime.c
@@ -1221,7 +1221,14 @@ void smime_invoke_import (char *infile, char *mailbox)
 
   buf[0] = '\0';
   if (option (OPTASKCERTLABEL))
-    mutt_get_field (_("Label for certificate: "), buf, sizeof (buf), 0);
+  {
+    if ((mutt_get_field (_("Label for certificate: "), buf, sizeof (buf), 0) != 0) || (buf[0] == 0))
+    {
+      safe_fclose (&fpout);
+      safe_fclose (&fperr);
+      return;
+    }
+  }
 
   mutt_endwin (NULL);
   if ((certfile = smime_extract_certificate(infile)))

--- a/system.c
+++ b/system.c
@@ -91,6 +91,7 @@ int _mutt_system (const char *cmd, int flags)
 #endif
 	  chdir ("/");
 	  act.sa_handler = SIG_DFL;
+          sigemptyset (&act.sa_mask);
 	  sigaction (SIGCHLD, &act, NULL);
 	  break;
 


### PR DESCRIPTION
Here's another batch of preventative fixes.
These address >80 Coverity defects.

They are grouped by type (and better viewed as separate commits):

1. 785959e **strfcpy**
    Replace strncpy with strfcpy to avoid unterminated strings.

2. **add variable** -- add tests to conditionals
    - a331218 **function args**
      Check parameters passed to a function

    - fa7443c **failed function**
      Some functions when they fail return -1.
      This return value is often used as an array index which would cause a buffer underrun.

    - f86fa08 **Context**
      The Context can become NULL without warning

    - 54ac444 **alloc/strdup**
      If alloc is passed 0, or strdup is passed NULL, they can return NULL

    - b6d67a8 **route through code**
      A possible route through the code leads to an invalid variable.

3. c1a457f **remove variable test**
    Remove a few simple tests where the condition is guaranteed to be true.
    There are a few cases where we already know the outcome -- usually due to a previous test.

4. 7287f31 **test functions**
    Test the return value of some functions that could fail.

5. 1af16f5 **tidy switches**
    - Factor out trivial fall throughs
    - Document any other fall throughs

6. 0298ca0 **unused variables**
    Remove unused variables.

7. d390b7e **refactor only**
    Refactor code for clarity -- no functional change.

8. a6dc284 **check for buffer underruns**
    Prevent buffer underruns caused by functions that can return -1.
    Some functions that _could_ return -1 are used as array indices.
    Factor out the function and test the result first.

9. e65462d **fix leaks**
    Fix resource leaks.

10. c429f39 **minor fixes**
    Fix a few minor bugs.

With these changes, the number of defects will drop from 174 to 88.

@neomutt/reviewers please review.