### PR TITLE
Boolification of functions

### DIFF
--- a/account.c
+++ b/account.c
@@ -156,13 +156,13 @@ void mutt_account_tourl (ACCOUNT* account, ciss_url_t* url)
 }
 
 /* mutt_account_getuser: retrieve username into ACCOUNT, if necessary */
-int mutt_account_getuser (ACCOUNT* account)
+bool mutt_account_getuser (ACCOUNT* account)
 {
   char prompt[SHORT_STRING];
 
   /* already set */
   if (account->flags & MUTT_ACCT_USER)
-    return 0;
+    return true;
 #ifdef USE_IMAP
   else if ((account->type == MUTT_ACCT_TYPE_IMAP) && ImapUser)
     strfcpy (account->user, ImapUser, sizeof (account->user));
@@ -176,7 +176,7 @@ int mutt_account_getuser (ACCOUNT* account)
     strfcpy (account->user, NntpUser, sizeof (account->user));
 #endif
   else if (option (OPTNOCURSES))
-    return -1;
+    return false;
   /* prompt (defaults to unix username), copy into account->user */
   else
   {
@@ -184,12 +184,12 @@ int mutt_account_getuser (ACCOUNT* account)
     snprintf (prompt, sizeof (prompt), _("Username at %s: "), account->host);
     strfcpy (account->user, NONULL (Username), sizeof (account->user));
     if (mutt_get_field_unbuffered (prompt, account->user, sizeof (account->user), 0))
-      return -1;
+      return false;
   }
 
   account->flags |= MUTT_ACCT_USER;
 
-  return 0;
+  return true;
 }
 
 int mutt_account_getlogin (ACCOUNT* account)

--- a/account.c
+++ b/account.c
@@ -220,12 +220,12 @@ int mutt_account_getlogin (ACCOUNT* account)
 }
 
 /* mutt_account_getpass: fetch password into ACCOUNT, if necessary */
-int mutt_account_getpass (ACCOUNT* account)
+bool mutt_account_getpass (ACCOUNT* account)
 {
   char prompt[SHORT_STRING];
 
   if (account->flags & MUTT_ACCT_PASS)
-    return 0;
+    return true;
 #ifdef USE_IMAP
   else if ((account->type == MUTT_ACCT_TYPE_IMAP) && ImapPass)
     strfcpy (account->pass, ImapPass, sizeof (account->pass));
@@ -243,7 +243,7 @@ int mutt_account_getpass (ACCOUNT* account)
     strfcpy (account->pass, NntpPass, sizeof (account->pass));
 #endif
   else if (option (OPTNOCURSES))
-    return -1;
+    return false;
   else
   {
     snprintf (prompt, sizeof (prompt), _("Password for %s@%s: "),
@@ -251,12 +251,12 @@ int mutt_account_getpass (ACCOUNT* account)
               account->host);
     account->pass[0] = '\0';
     if (mutt_get_password (prompt, account->pass, sizeof (account->pass)))
-      return -1;
+      return false;
   }
 
   account->flags |= MUTT_ACCT_PASS;
 
-  return 0;
+  return true;
 }
 
 void mutt_account_unsetpass (ACCOUNT* account)

--- a/account.h
+++ b/account.h
@@ -55,7 +55,7 @@ int mutt_account_fromurl (ACCOUNT* account, ciss_url_t* url);
 void mutt_account_tourl (ACCOUNT* account, ciss_url_t* url);
 int mutt_account_getuser (ACCOUNT* account);
 int mutt_account_getlogin (ACCOUNT* account);
-int mutt_account_getpass (ACCOUNT* account);
+bool mutt_account_getpass (ACCOUNT* account);
 void mutt_account_unsetpass (ACCOUNT* account);
 
 #endif /* _MUTT_ACCOUNT_H */

--- a/account.h
+++ b/account.h
@@ -53,7 +53,7 @@ typedef struct
 int mutt_account_match (const ACCOUNT* a1, const ACCOUNT* m2);
 int mutt_account_fromurl (ACCOUNT* account, ciss_url_t* url);
 void mutt_account_tourl (ACCOUNT* account, ciss_url_t* url);
-int mutt_account_getuser (ACCOUNT* account);
+bool mutt_account_getuser (ACCOUNT* account);
 int mutt_account_getlogin (ACCOUNT* account);
 bool mutt_account_getpass (ACCOUNT* account);
 void mutt_account_unsetpass (ACCOUNT* account);

--- a/alias.c
+++ b/alias.c
@@ -610,7 +610,7 @@ static int string_is_address(const char *str, const char *u, const char *d)
 }
 
 /* returns true if the given address belongs to the user. */
-int mutt_addr_is_user (ADDRESS *addr)
+bool mutt_addr_is_user (ADDRESS *addr)
 {
   const char *fqdn = NULL;
 
@@ -618,46 +618,46 @@ int mutt_addr_is_user (ADDRESS *addr)
   if (!addr)
   {
     mutt_debug (5, "mutt_addr_is_user: yes, NULL address\n");
-    return 1;
+    return true;
   }
   if (!addr->mailbox)
   {
     mutt_debug (5, "mutt_addr_is_user: no, no mailbox\n");
-    return 0;
+    return false;
   }
 
   if (ascii_strcasecmp (addr->mailbox, Username) == 0)
   {
     mutt_debug (5, "mutt_addr_is_user: yes, %s = %s\n",
                 addr->mailbox, Username);
-    return 1;
+    return true;
   }
   if (string_is_address(addr->mailbox, Username, Hostname))
   {
     mutt_debug (5, "mutt_addr_is_user: yes, %s = %s @ %s \n",
                 addr->mailbox, Username, Hostname);
-    return 1;
+    return true;
   }
   fqdn = mutt_fqdn (0);
   if (string_is_address(addr->mailbox, Username, fqdn))
   {
     mutt_debug (5, "mutt_addr_is_user: yes, %s = %s @ %s \n",
                 addr->mailbox, Username, NONULL(fqdn));
-    return 1;
+    return true;
   }
   fqdn = mutt_fqdn (1);
   if (string_is_address(addr->mailbox, Username, fqdn))
   {
     mutt_debug (5, "mutt_addr_is_user: yes, %s = %s @ %s \n",
                 addr->mailbox, Username, NONULL(fqdn));
-    return 1;
+    return true;
   }
 
   if (From && (ascii_strcasecmp (From->mailbox, addr->mailbox) == 0))
   {
     mutt_debug (5, "mutt_addr_is_user: yes, %s = %s\n",
                 addr->mailbox, From->mailbox);
-    return 1;
+    return true;
   }
 
   if (mutt_match_rx_list (addr->mailbox, Alternates))
@@ -668,9 +668,9 @@ int mutt_addr_is_user (ADDRESS *addr)
       mutt_debug (5, "mutt_addr_is_user: but, %s matched by unalternates.\n",
                   addr->mailbox);
     else
-      return 1;
+      return true;
   }
 
   mutt_debug (5, "mutt_addr_is_user: no, all failed.\n");
-  return 0;
+  return false;
 }

--- a/bcache.c
+++ b/bcache.c
@@ -38,7 +38,7 @@ struct body_cache {
   size_t pathlen;
 };
 
-static int bcache_path(ACCOUNT *account, const char *mailbox,
+static bool bcache_path(ACCOUNT *account, const char *mailbox,
 		       char *dst, size_t dstlen)
 {
   char host[STRING];
@@ -47,7 +47,7 @@ static int bcache_path(ACCOUNT *account, const char *mailbox,
   int len;
 
   if (!account || !MessageCachedir || !*MessageCachedir || !dst || !dstlen)
-    return -1;
+    return false;
 
   /* make up a ciss_url_t we can turn into a string */
   memset (&url, 0, sizeof (ciss_url_t));
@@ -60,7 +60,7 @@ static int bcache_path(ACCOUNT *account, const char *mailbox,
   if (url_ciss_tostring (&url, host, sizeof (host), U_PATH) < 0)
   {
     mutt_debug (1, "bcache_path: URL to string failed\n");
-    return -1;
+    return false;
   }
 
   mutt_encode_path (path, sizeof (path), NONULL (mailbox));
@@ -72,11 +72,11 @@ static int bcache_path(ACCOUNT *account, const char *mailbox,
   mutt_debug (3, "bcache_path: rc: %d, path: '%s'\n", len, dst);
 
   if (len < 0 || len >= dstlen-1)
-    return -1;
+    return false;
 
   mutt_debug (3, "bcache_path: directory: '%s'\n", dst);
 
-  return 0;
+  return true;
 }
 
 body_cache_t *mutt_bcache_open (ACCOUNT *account, const char *mailbox)
@@ -87,8 +87,8 @@ body_cache_t *mutt_bcache_open (ACCOUNT *account, const char *mailbox)
     goto bail;
 
   bcache = safe_calloc (1, sizeof (struct body_cache));
-  if (bcache_path (account, mailbox, bcache->path,
-		   sizeof (bcache->path)) < 0)
+  if (!bcache_path (account, mailbox, bcache->path,
+		   sizeof (bcache->path)))
     goto bail;
   bcache->pathlen = mutt_strlen (bcache->path);
 

--- a/compose.c
+++ b/compose.c
@@ -234,7 +234,7 @@ static void redraw_mix_line (LIST *chain)
 }
 #endif /* MIXMASTER */
 
-static int
+static bool
 check_attachments(ATTACHPTR **idx, short idxlen)
 {
   int i, r;
@@ -249,7 +249,7 @@ check_attachments(ATTACHPTR **idx, short idxlen)
       mutt_pretty_mailbox(pretty, sizeof (pretty));
       mutt_error(_("%s [#%d] no longer exists!"),
 		 pretty, i+1);
-      return -1;
+      return false;
     }
 
     if(idx[i]->content->stamp < st.st_mtime)
@@ -261,11 +261,11 @@ check_attachments(ATTACHPTR **idx, short idxlen)
       if((r = mutt_yesorno(msg, MUTT_YES)) == MUTT_YES)
 	mutt_update_encoding(idx[i]->content);
       else if(r == MUTT_ABORT)
-	return -1;
+	return false;
     }
   }
 
-  return 0;
+  return true;
 }
 
 static void draw_envelope_addr (int line, ADDRESS *addr)
@@ -1142,7 +1142,7 @@ int mutt_compose_menu (HEADER *msg,   /* structure for new message */
 	 * users an opportunity to change settings from the ":" prompt.
 	 */
 
-        if(check_attachments(idx, idxlen) != 0)
+        if (!check_attachments(idx, idxlen))
         {
 	  menu->redraw = REDRAW_FULL;
 	  break;
@@ -1395,7 +1395,7 @@ int mutt_compose_menu (HEADER *msg,   /* structure for new message */
 
       case OP_COMPOSE_POSTPONE_MESSAGE:
 
-        if(check_attachments(idx, idxlen) != 0)
+        if (!check_attachments(idx, idxlen))
         {
 	  menu->redraw = REDRAW_FULL;
 	  break;

--- a/curs_main.c
+++ b/curs_main.c
@@ -409,7 +409,7 @@ void update_index (MUTTMENU *menu, CONTEXT *ctx, int check,
 
 }
 
-static int main_change_folder(MUTTMENU *menu, int op, char *buf, size_t bufsz,
+static bool main_change_folder(MUTTMENU *menu, int op, char *buf, size_t bufsz,
 			  int *oldcount, int *index_hint, int flags)
 {
 #ifdef USE_NNTP
@@ -424,7 +424,7 @@ static int main_change_folder(MUTTMENU *menu, int op, char *buf, size_t bufsz,
   if (mx_get_magic (buf) <= 0)
   {
     mutt_error (_("%s is not a mailbox."), buf);
-    return -1;
+    return false;
   }
   mutt_str_replace (&CurrentFolder, buf);
 
@@ -451,7 +451,7 @@ static int main_change_folder(MUTTMENU *menu, int op, char *buf, size_t bufsz,
 
       set_option (OPTSEARCHINVALID);
       menu->redraw = REDRAW_INDEX | REDRAW_STATUS;
-      return 0;
+      return true;
     }
     FREE (&Context);
   }
@@ -489,7 +489,7 @@ static int main_change_folder(MUTTMENU *menu, int op, char *buf, size_t bufsz,
   menu->redraw = REDRAW_FULL;
   set_option (OPTSEARCHINVALID);
 
-  return 0;
+  return true;
 }
 
 

--- a/curs_main.c
+++ b/curs_main.c
@@ -246,15 +246,15 @@ static int ci_first_message (void)
 }
 
 /* This should be in mx.c, but it only gets used here. */
-static int mx_toggle_write (CONTEXT *ctx)
+static bool mx_toggle_write (CONTEXT *ctx)
 {
   if (!ctx)
-    return -1;
+    return false;
 
   if (ctx->readonly)
   {
     mutt_error (_("Cannot toggle write on a readonly mailbox!"));
-    return -1;
+    return false;
   }
 
   if (ctx->dontwrite)
@@ -268,7 +268,7 @@ static int mx_toggle_write (CONTEXT *ctx)
     mutt_message (_("Changes to folder will not be written."));
   }
 
-  return 0;
+  return true;
 }
 
 static void resort_index (MUTTMENU *menu)
@@ -2534,7 +2534,7 @@ int mutt_index_menu (void)
       case OP_TOGGLE_WRITE:
 
 	CHECK_IN_MAILBOX;
-	if (mx_toggle_write (Context) == 0)
+	if (mx_toggle_write (Context))
 	  menu->redraw |= REDRAW_STATUS;
 	break;
 

--- a/from.c
+++ b/from.c
@@ -40,16 +40,16 @@ int mutt_check_month (const char *s)
   return -1; /* error */
 }
 
-static int is_day_name (const char *s)
+static bool is_day_name (const char *s)
 {
   int i;
 
   if ((strlen (s) < 3) || !*(s + 3) || !ISSPACE (*(s+3)))
-    return 0;
+    return false;
   for (i=0; i<7; i++)
     if (mutt_strncasecmp (s, Weekdays[i], 3) == 0)
-      return 1;
-  return 0;
+      return true;
+  return false;
 }
 
 /*

--- a/hdrline.c
+++ b/hdrline.c
@@ -205,7 +205,7 @@ static void make_from (ENVELOPE *env, char *buf, size_t len, int do_lists)
   if (!env || !buf)
     return;
 
-  int me;
+  bool me;
   enum FieldType disp;
   ADDRESS *name = NULL;
 
@@ -253,7 +253,7 @@ static void make_from_addr (ENVELOPE *hdr, char *buf, size_t len, int do_lists)
   if (!hdr || !buf)
     return;
 
-  int me = mutt_addr_is_user (hdr->from);
+  bool me = mutt_addr_is_user (hdr->from);
 
   if (do_lists || me)
   {

--- a/hdrline.c
+++ b/hdrline.c
@@ -273,12 +273,12 @@ static void make_from_addr (ENVELOPE *hdr, char *buf, size_t len, int do_lists)
     *buf = 0;
 }
 
-static int user_in_addr (ADDRESS *a)
+static bool user_in_addr (ADDRESS *a)
 {
   for (; a; a = a->next)
     if (mutt_addr_is_user (a))
-      return 1;
-  return 0;
+      return true;
+  return false;
 }
 
 /* Return values:

--- a/hook.c
+++ b/hook.c
@@ -441,7 +441,7 @@ void mutt_default_save (char *path, size_t pathlen, HEADER *hdr)
     char tmp[_POSIX_PATH_MAX];
     ADDRESS *adr = NULL;
     ENVELOPE *env = hdr->env;
-    int fromMe = mutt_addr_is_user (env->from);
+    bool fromMe = mutt_addr_is_user (env->from);
 
     if (!fromMe && env->reply_to && env->reply_to->mailbox)
       adr = env->reply_to;

--- a/imap/auth_anon.c
+++ b/imap/auth_anon.c
@@ -31,7 +31,7 @@ imap_auth_res_t imap_auth_anon (IMAP_DATA* idata, const char* method)
   if (!mutt_bit_isset (idata->capabilities, AUTH_ANON))
     return IMAP_AUTH_UNAVAIL;
 
-  if (mutt_account_getuser (&idata->conn->account))
+  if (!mutt_account_getuser (&idata->conn->account))
     return IMAP_AUTH_FAILURE;
 
   if (idata->conn->account.user[0] != '\0')

--- a/imap/auth_cram.c
+++ b/imap/auth_cram.c
@@ -47,7 +47,7 @@ imap_auth_res_t imap_auth_cram_md5 (IMAP_DATA* idata, const char* method)
   /* get auth info */
   if (mutt_account_getlogin (&idata->conn->account))
     return IMAP_AUTH_FAILURE;
-  if (mutt_account_getpass (&idata->conn->account))
+  if (!mutt_account_getpass (&idata->conn->account))
     return IMAP_AUTH_FAILURE;
 
   imap_cmd_start (idata, "AUTHENTICATE CRAM-MD5");

--- a/imap/auth_gss.c
+++ b/imap/auth_gss.c
@@ -96,7 +96,7 @@ imap_auth_res_t imap_auth_gss (IMAP_DATA* idata, const char* method)
   if (!mutt_bit_isset (idata->capabilities, AGSSAPI))
     return IMAP_AUTH_UNAVAIL;
 
-  if (mutt_account_getuser (&idata->conn->account))
+  if (!mutt_account_getuser (&idata->conn->account))
     return IMAP_AUTH_FAILURE;
 
   /* get an IMAP service ticket for the server */

--- a/imap/auth_login.c
+++ b/imap/auth_login.c
@@ -38,7 +38,7 @@ imap_auth_res_t imap_auth_login (IMAP_DATA* idata, const char* method)
 
   if (mutt_account_getuser (&idata->conn->account))
     return IMAP_AUTH_FAILURE;
-  if (mutt_account_getpass (&idata->conn->account))
+  if (!mutt_account_getpass (&idata->conn->account))
     return IMAP_AUTH_FAILURE;
 
   mutt_message (_("Logging in..."));

--- a/imap/auth_login.c
+++ b/imap/auth_login.c
@@ -36,7 +36,7 @@ imap_auth_res_t imap_auth_login (IMAP_DATA* idata, const char* method)
     return IMAP_AUTH_UNAVAIL;
   }
 
-  if (mutt_account_getuser (&idata->conn->account))
+  if (!mutt_account_getuser (&idata->conn->account))
     return IMAP_AUTH_FAILURE;
   if (!mutt_account_getpass (&idata->conn->account))
     return IMAP_AUTH_FAILURE;

--- a/imap/auth_plain.c
+++ b/imap/auth_plain.c
@@ -34,7 +34,7 @@ imap_auth_res_t imap_auth_plain(IMAP_DATA *idata, const char *method)
 
   if (mutt_account_getuser(&idata->conn->account))
     return IMAP_AUTH_FAILURE;
-  if (mutt_account_getpass(&idata->conn->account))
+  if (!mutt_account_getpass(&idata->conn->account))
     return IMAP_AUTH_FAILURE;
 
   mutt_message(_("Logging in..."));

--- a/imap/auth_plain.c
+++ b/imap/auth_plain.c
@@ -32,7 +32,7 @@ imap_auth_res_t imap_auth_plain(IMAP_DATA *idata, const char *method)
   imap_auth_res_t res = IMAP_AUTH_SUCCESS;
   char buf[STRING];
 
-  if (mutt_account_getuser(&idata->conn->account))
+  if (!mutt_account_getuser(&idata->conn->account))
     return IMAP_AUTH_FAILURE;
   if (!mutt_account_getpass(&idata->conn->account))
     return IMAP_AUTH_FAILURE;

--- a/imap/auth_sasl.c
+++ b/imap/auth_sasl.c
@@ -58,7 +58,7 @@ imap_auth_res_t imap_auth_sasl (IMAP_DATA* idata, const char* method)
      * 2. attempt sasl_client_start with only "AUTH=ANONYMOUS" capability
      * 3. if sasl_client_start fails, fall through... */
 
-    if (mutt_account_getuser (&idata->conn->account))
+    if (!mutt_account_getuser (&idata->conn->account))
       return IMAP_AUTH_FAILURE;
 
     if (mutt_bit_isset (idata->capabilities, AUTH_ANON) &&

--- a/imap/command.c
+++ b/imap/command.c
@@ -51,12 +51,12 @@ static const char * const Capabilities[] = {
   NULL
 };
 
-static int cmd_queue_full (IMAP_DATA* idata)
+static bool cmd_queue_full (IMAP_DATA* idata)
 {
   if ((idata->nextcmd + 1) % idata->cmdslots == idata->lastcmd)
-    return 1;
+    return true;
 
-  return 0;
+  return false;
 }
 
 /* sets up a new command control block and adds it to the queue.

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -850,25 +850,25 @@ static void imap_set_flag (IMAP_DATA* idata, int aclbit, int flag,
 }
 
 /* imap_has_flag: do a caseless comparison of the flag against a flag list,
-*   return 1 if found or flag list has '\*', 0 otherwise */
-int imap_has_flag (LIST* flag_list, const char* flag)
+*   return true if found or flag list has '\*', false otherwise */
+bool imap_has_flag (LIST* flag_list, const char* flag)
 {
   if (!flag_list)
-    return 0;
+    return false;
 
   flag_list = flag_list->next;
   while (flag_list)
   {
     if (ascii_strncasecmp (flag_list->data, flag, strlen (flag_list->data)) == 0)
-      return 1;
+      return true;
 
     if (ascii_strncmp (flag_list->data, "\\*", strlen (flag_list->data)) == 0)
-      return 1;
+      return true;
 
     flag_list = flag_list->next;
   }
 
-  return 0;
+  return false;
 }
 
 /* Note: headers must be in SORT_ORDER. See imap_exec_msgset for args.

--- a/imap/imap_private.h
+++ b/imap/imap_private.h
@@ -245,7 +245,7 @@ int imap_read_literal(FILE *fp, IMAP_DATA *idata, long bytes,
 void imap_expunge_mailbox(IMAP_DATA *idata);
 void imap_logout(IMAP_DATA **idata);
 int imap_sync_message(IMAP_DATA *idata, HEADER *hdr, BUFFER *cmd, int *err_continue);
-int imap_has_flag(LIST *flag_list, const char *flag);
+bool imap_has_flag(LIST *flag_list, const char *flag);
 
 /* auth.c */
 int imap_authenticate (IMAP_DATA* idata);

--- a/init.c
+++ b/init.c
@@ -653,7 +653,7 @@ static REPLACE_LIST *new_replace_list(void)
   return safe_calloc (1, sizeof (REPLACE_LIST));
 }
 
-static int add_to_replace_list (REPLACE_LIST **list, const char *pat, const char *templ, BUFFER *err)
+static bool add_to_replace_list (REPLACE_LIST **list, const char *pat, const char *templ, BUFFER *err)
 {
   REPLACE_LIST *t = NULL, *last = NULL;
   REGEXP *rx = NULL;
@@ -661,12 +661,12 @@ static int add_to_replace_list (REPLACE_LIST **list, const char *pat, const char
   const char *p = NULL;
 
   if (!pat || !*pat || !templ)
-    return 0;
+    return true;
 
   if (!(rx = mutt_compile_regexp (pat, REG_ICASE)))
   {
     snprintf (err->data, err->dsize, _("Bad regexp: %s"), pat);
-    return -1;
+    return false;
   }
 
   /* check to make sure the item is not already on this list */
@@ -728,12 +728,12 @@ static int add_to_replace_list (REPLACE_LIST **list, const char *pat, const char
     snprintf (err->data, err->dsize, _("Not enough subexpressions for "
                                        "template"));
     remove_from_replace_list(list, pat);
-    return -1;
+    return false;
   }
 
   t->nmatch++;         /* match 0 is always the whole expr */
 
-  return 0;
+  return true;
 }
 
 
@@ -1010,7 +1010,7 @@ static int parse_replace_list (BUFFER *buf, BUFFER *s, unsigned long data, BUFFE
   }
   mutt_extract_token(&templ, s, 0);
 
-  if (add_to_replace_list(list, buf->data, templ.data, err) != 0) {
+  if (!add_to_replace_list(list, buf->data, templ.data, err)) {
     FREE(&templ.data);
     return -1;
   }
@@ -1105,7 +1105,7 @@ static int parse_spam_list (BUFFER *buf, BUFFER *s, unsigned long data, BUFFER *
       mutt_extract_token (&templ, s, 0);
 
       /* Add to the spam list. */
-      if (add_to_replace_list (&SpamList, buf->data, templ.data, err) != 0) {
+      if (!add_to_replace_list (&SpamList, buf->data, templ.data, err)) {
 	  FREE(&templ.data);
           return -1;
       }

--- a/lib.c
+++ b/lib.c
@@ -556,7 +556,7 @@ int safe_rename (const char *src, const char *target)
 
 
 /* Create a temporary directory next to a file name */
-static int mkwrapdir (const char *path, char *newfile, size_t nflen,
+static bool mkwrapdir (const char *path, char *newfile, size_t nflen,
 		    char *newdir, size_t ndlen)
 {
   const char *basename = NULL;
@@ -580,16 +580,16 @@ static int mkwrapdir (const char *path, char *newfile, size_t nflen,
   if (mkdtemp(newdir) == NULL)
   {
       mutt_debug (1, "mkwrapdir: mkdtemp() failed\n");
-      return -1;
+      return false;
   }
 
   if (snprintf (newfile, nflen, "%s/%s", newdir, NONULL(basename)) >= nflen)
   {
       rmdir(newdir);
       mutt_debug (1, "mkwrapdir: string was truncated\n");
-      return -1;
+      return false;
   }
-  return 0;
+  return true;
 }
 
 /* remove a directory and everything under it */
@@ -652,8 +652,8 @@ int safe_open (const char *path, int flags)
     char safe_file[_POSIX_PATH_MAX];
     char safe_dir[_POSIX_PATH_MAX];
 
-    if (mkwrapdir (path, safe_file, sizeof (safe_file),
-			safe_dir, sizeof (safe_dir)) == -1)
+    if (!mkwrapdir (path, safe_file, sizeof (safe_file),
+			safe_dir, sizeof (safe_dir)))
       return -1;
 
     if ((fd = open (safe_file, flags, 0600)) < 0)

--- a/menu.c
+++ b/menu.c
@@ -964,7 +964,7 @@ static int menu_dialog_translate_op (int i)
   return i;
 }
 
-static int menu_dialog_dokey (MUTTMENU *menu, int *ip)
+static bool menu_dialog_dokey (MUTTMENU *menu, int *ip)
 {
   event_t ch;
   char *p = NULL;
@@ -974,18 +974,18 @@ static int menu_dialog_dokey (MUTTMENU *menu, int *ip)
   if (ch.ch < 0)
   {
     *ip = -1;
-    return 0;
+    return true;
   }
 
   if (ch.ch && (p = strchr (menu->keys, ch.ch)))
   {
     *ip = OP_MAX + (p - menu->keys + 1);
-    return 0;
+    return true;
   }
   else
   {
     mutt_unget_event (ch.op ? 0 : ch.ch, ch.op ? ch.op : 0);
-    return -1;
+    return false;
   }
 }
 
@@ -1071,7 +1071,7 @@ int mutt_menu_loop (MUTTMENU *menu)
     mutt_refresh ();
 
     /* try to catch dialog keys before ops */
-    if (menu->dialog && menu_dialog_dokey (menu, &i) == 0)
+    if (menu->dialog && menu_dialog_dokey (menu, &i))
       return i;
 
     i = km_dokey (menu->menu);

--- a/mh.c
+++ b/mh.c
@@ -257,14 +257,14 @@ static int mh_already_notified(BUFFY *b, int msgno)
  * digits.  Deleted message get moved to a filename with a comma before
  * it.
  */
-static int mh_valid_message (const char *s)
+static bool mh_valid_message (const char *s)
 {
   for (; *s; s++)
   {
     if (!isdigit ((unsigned char) *s))
-      return 0;
+      return false;
   }
-  return 1;
+  return true;
 }
 
 /* Checks new mail for a mh mailbox.

--- a/mutt_notmuch.c
+++ b/mutt_notmuch.c
@@ -842,7 +842,7 @@ static void append_str_item(char **str, const char *item, int sep)
   memcpy(p, item, sz + 1);
 }
 
-static int update_header_tags(HEADER *h, notmuch_message_t *msg)
+static bool update_header_tags(HEADER *h, notmuch_message_t *msg)
 {
   struct nm_hdrdata *data = h->data;
   notmuch_tags_t *tags = NULL;
@@ -901,7 +901,7 @@ static int update_header_tags(HEADER *h, notmuch_message_t *msg)
     FREE(&tstr);
     FREE(&ttstr);
     mutt_debug (2, "nm: tags unchanged\n");
-    return 1;
+    return false;
   }
 
   /* free old version */
@@ -915,7 +915,7 @@ static int update_header_tags(HEADER *h, notmuch_message_t *msg)
   data->tags_transformed = ttstr;
   mutt_debug (2, "nm: new tag transforms: '%s'\n", ttstr);
 
-  return 0;
+  return true;
 }
 
 static int update_message_path(HEADER *h, const char *path)
@@ -2298,7 +2298,7 @@ static int nm_check_mailbox(CONTEXT *ctx, int *index_hint)
       maildir_update_flags(ctx, h, &tmp);
     }
 
-    if (update_header_tags(h, m) == 0)
+    if (update_header_tags(h, m))
       new_flags++;
 
     notmuch_message_destroy(m);

--- a/mutt_notmuch.c
+++ b/mutt_notmuch.c
@@ -692,7 +692,7 @@ static notmuch_database_t *get_db(struct nm_ctxdata *data, int writable)
   return data->db;
 }
 
-static int release_db(struct nm_ctxdata *data)
+static bool release_db(struct nm_ctxdata *data)
 {
   if (data && data->db)
   {
@@ -704,10 +704,10 @@ static int release_db(struct nm_ctxdata *data)
 #endif
     data->db = NULL;
     data->longrun = false;
-    return 0;
+    return true;
   }
 
-  return -1;
+  return false;
 }
 
 static int db_trans_begin(struct nm_ctxdata *data)
@@ -1699,7 +1699,7 @@ void nm_longrun_done(CONTEXT *ctx)
 {
   struct nm_ctxdata *data = get_ctxdata(ctx);
 
-  if (data && (release_db(data) == 0))
+  if (data && release_db(data))
     mutt_debug (2, "nm: long run deinitialized\n");
 }
 

--- a/mutt_notmuch.c
+++ b/mutt_notmuch.c
@@ -1489,7 +1489,7 @@ static int rename_maildir_filename(const char *old, char *newpath, size_t newsz,
   return 0;
 }
 
-static int remove_filename(struct nm_ctxdata *data, const char *path)
+static bool remove_filename(struct nm_ctxdata *data, const char *path)
 {
   notmuch_status_t st;
   notmuch_filenames_t *ls = NULL;
@@ -1500,13 +1500,13 @@ static int remove_filename(struct nm_ctxdata *data, const char *path)
   mutt_debug (2, "nm: remove filename '%s'\n", path);
 
   if (!db)
-    return -1;
+    return false;
   st = notmuch_database_find_message_by_filename(db, path, &msg);
   if (st || !msg)
-    return -1;
+    return false;
   trans = db_trans_begin(data);
   if (trans < 0)
-    return -1;
+    return false;
 
   /*
    * note that unlink() is probably unnecessary here, it's already removed
@@ -1542,7 +1542,7 @@ static int remove_filename(struct nm_ctxdata *data, const char *path)
   notmuch_message_destroy(msg);
   if (trans)
     db_trans_end(data);
-  return 0;
+  return true;
 }
 
 static int rename_filename(struct nm_ctxdata *data, const char *old,
@@ -2392,7 +2392,7 @@ static int nm_sync_mailbox(CONTEXT *ctx, int *index_hint)
 
     if (h->deleted || (strcmp(old, new) != 0))
     {
-      if (h->deleted && (remove_filename(data, old) == 0))
+      if (h->deleted && remove_filename(data, old))
         changed = 1;
       else if (*new && *old && (rename_filename(data, old, new, h) == 0))
         changed = 1;

--- a/mutt_notmuch.c
+++ b/mutt_notmuch.c
@@ -748,24 +748,24 @@ static int is_longrun(struct nm_ctxdata *data)
   return data && data->longrun;
 }
 
-static int get_database_mtime(struct nm_ctxdata *data, time_t *mtime)
+static bool get_database_mtime(struct nm_ctxdata *data, time_t *mtime)
 {
   char path[_POSIX_PATH_MAX];
   struct stat st;
 
   if (!data)
-    return -1;
+    return false;
 
   snprintf(path, sizeof(path), "%s/.notmuch/xapian", get_db_filename(data));
   mutt_debug (2, "nm: checking '%s' mtime\n", path);
 
   if (stat(path, &st))
-    return -1;
+    return false;
 
   if (mtime)
     *mtime = st.st_mtime;
 
-  return 0;
+  return true;
 }
 
 static void apply_exclude_tags(notmuch_query_t *query)
@@ -2225,7 +2225,7 @@ static int nm_check_mailbox(CONTEXT *ctx, int *index_hint)
   notmuch_messages_t *msgs = NULL;
   int i, limit, occult = 0, new_flags = 0;
 
-  if (!data || (get_database_mtime(data, &mtime) != 0))
+  if (!data || !get_database_mtime(data, &mtime))
     return -1;
 
   if (ctx->mtime >= mtime)

--- a/mutt_notmuch.c
+++ b/mutt_notmuch.c
@@ -1332,13 +1332,13 @@ static bool nm_message_has_tag(notmuch_message_t *msg, char *tag)
   return false;
 }
 
-static int update_tags(notmuch_message_t *msg, const char *tags)
+static bool update_tags(notmuch_message_t *msg, const char *tags)
 {
   char *tag = NULL, *end = NULL, *p = NULL;
   char *buf = safe_strdup(tags);
 
   if (!buf)
-    return -1;
+    return false;
 
   notmuch_message_freeze(msg);
 
@@ -1386,7 +1386,7 @@ static int update_tags(notmuch_message_t *msg, const char *tags)
 
   notmuch_message_thaw(msg);
   FREE(&buf);
-  return 0;
+  return true;
 }
 
 static int update_header_flags(CONTEXT *ctx, HEADER *hdr, const char *tags)

--- a/mutt_sasl.c
+++ b/mutt_sasl.c
@@ -203,7 +203,7 @@ static int mutt_sasl_cb_pass (sasl_conn_t* conn, void* context, int id,
   mutt_debug (2, "mutt_sasl_cb_pass: getting password for %s@%s:%u\n",
               account->login, account->host, account->port);
 
-  if (mutt_account_getpass (account))
+  if (!mutt_account_getpass (account))
     return SASL_FAIL;
 
   len = strlen (account->pass);

--- a/mutt_sasl.c
+++ b/mutt_sasl.c
@@ -180,7 +180,7 @@ static int mutt_sasl_cb_authname (void* context, int id, const char** result,
   }
   else
   {
-    if (mutt_account_getuser (account))
+    if (!mutt_account_getuser (account))
       return SASL_FAIL;
     *result = account->user;
   }

--- a/mutt_ssl.c
+++ b/mutt_ssl.c
@@ -412,7 +412,7 @@ static bool check_certificate_expiration (X509 *peercert, bool silent)
 }
 
 /* port to mutt from msmtp's tls.c */
-static int hostname_match (const char *hostname, const char *certname)
+static bool hostname_match (const char *hostname, const char *certname)
 {
   const char *cmp1 = NULL, *cmp2 = NULL;
 
@@ -422,7 +422,7 @@ static int hostname_match (const char *hostname, const char *certname)
     cmp2 = strchr(hostname, '.');
     if (!cmp2)
     {
-      return 0;
+      return false;
     }
     else
     {
@@ -437,15 +437,15 @@ static int hostname_match (const char *hostname, const char *certname)
 
   if (*cmp1 == '\0' || *cmp2 == '\0')
   {
-    return 0;
+    return false;
   }
 
   if (strcasecmp(cmp1, cmp2) != 0)
   {
-    return 0;
+    return false;
   }
 
-  return 1;
+  return true;
 }
 
 /*
@@ -640,7 +640,7 @@ static int check_host (X509 *x509cert, const char *hostname, char *err, size_t e
   int subj_alt_names_count;
   GENERAL_NAME *subj_alt_name = NULL;
   /* did we find a name matching hostname? */
-  int match_found;
+  bool match_found;
 
   /* Check if 'hostname' matches the one of the subjectAltName extensions of
    * type DNS or the Common Name (CN). */

--- a/mutt_ssl.c
+++ b/mutt_ssl.c
@@ -273,7 +273,7 @@ static int ssl_passwd_cb(char *buf, int size, int rwflag, void *userdata)
 {
   ACCOUNT *account = (ACCOUNT*)userdata;
 
-  if (mutt_account_getuser (account))
+  if (!mutt_account_getuser (account))
     return 0;
 
   mutt_debug (2, "ssl_passwd_cb: getting password for %s@%s:%u\n",

--- a/mutt_ssl.c
+++ b/mutt_ssl.c
@@ -382,7 +382,7 @@ static int compare_certificates (X509 *cert, X509 *peercert,
   return 0;
 }
 
-static int check_certificate_expiration (X509 *peercert, int silent)
+static bool check_certificate_expiration (X509 *peercert, bool silent)
 {
   if (option (OPTSSLVERIFYDATES) != MUTT_NO)
   {
@@ -394,7 +394,7 @@ static int check_certificate_expiration (X509 *peercert, int silent)
         mutt_error (_("Server certificate is not yet valid"));
         mutt_sleep (2);
       }
-      return 0;
+      return false;
     }
     if (X509_cmp_current_time (X509_get_notAfter (peercert)) <= 0)
     {
@@ -404,11 +404,11 @@ static int check_certificate_expiration (X509 *peercert, int silent)
         mutt_error (_("Server certificate has expired"));
         mutt_sleep (2);
       }
-      return 0;
+      return false;
     }
   }
 
-  return 1;
+  return true;
 }
 
 /* port to mutt from msmtp's tls.c */
@@ -610,7 +610,7 @@ static int check_certificate_file (X509 *peercert)
   while (PEM_read_X509 (fp, &cert, NULL, NULL) != NULL)
   {
     if ((compare_certificates (cert, peercert, peermd, peermdlen) == 0) &&
-        check_certificate_expiration (cert, 1))
+        check_certificate_expiration (cert, true))
     {
       pass = 1;
       break;
@@ -732,7 +732,7 @@ out:
 
 static int check_certificate_by_digest (X509 *peercert)
 {
-  return check_certificate_expiration (peercert, 0) &&
+  return check_certificate_expiration (peercert, false) &&
     check_certificate_file (peercert);
 }
 
@@ -822,7 +822,7 @@ static int interactive_check_cert (X509 *cert, int idx, int len, SSL *ssl, int a
    */
   allow_always = allow_always &&
                  SslCertFile &&
-                 check_certificate_expiration (cert, 1);
+                 check_certificate_expiration (cert, true);
 
   /* L10N:
    * These four letters correspond to the choices in the next four strings:

--- a/mutt_ssl.c
+++ b/mutt_ssl.c
@@ -458,13 +458,13 @@ static bool hostname_match (const char *hostname, const char *certname)
  * versions also. (That's the reason for the ugly #ifdefs and macros,
  * otherwise I could have simply #ifdef'd the whole ssl_init funcion)
  */
-static int ssl_init (void)
+static bool ssl_init (void)
 {
   char path[_POSIX_PATH_MAX];
   static unsigned char init_complete = 0;
 
   if (init_complete)
-    return 0;
+    return true;
 
   if (! HAVE_ENTROPY())
   {
@@ -487,7 +487,7 @@ static int ssl_init (void)
     {
       mutt_error (_("Failed to find enough entropy on your system"));
       mutt_sleep (2);
-      return -1;
+      return false;
     }
   }
 
@@ -496,7 +496,7 @@ static int ssl_init (void)
   SSL_load_error_strings();
   SSL_library_init();
   init_complete = 1;
-  return 0;
+  return true;
 }
 
 static int ssl_socket_read (CONNECTION* conn, char* buf, size_t len)
@@ -1193,7 +1193,7 @@ int mutt_ssl_starttls (CONNECTION* conn)
   int maxbits;
   long ssl_options = 0;
 
-  if (ssl_init())
+  if (!ssl_init())
     goto bail;
 
   ssldata = safe_calloc (1, sizeof (sslsockdata));
@@ -1302,7 +1302,7 @@ int mutt_ssl_starttls (CONNECTION* conn)
 
 int mutt_ssl_socket_setup (CONNECTION * conn)
 {
-  if (ssl_init() < 0)
+  if (!ssl_init())
   {
     conn->conn_open = ssl_socket_open_err;
     return -1;

--- a/mutt_ssl.c
+++ b/mutt_ssl.c
@@ -279,7 +279,7 @@ static int ssl_passwd_cb(char *buf, int size, int rwflag, void *userdata)
   mutt_debug (2, "ssl_passwd_cb: getting password for %s@%s:%u\n",
               account->user, account->host, account->port);
 
-  if (mutt_account_getpass (account))
+  if (!mutt_account_getpass (account))
     return 0;
 
   return snprintf(buf, size, "%s", account->pass);

--- a/muttlib.c
+++ b/muttlib.c
@@ -692,27 +692,27 @@ void mutt_delete_parameter (const char *attribute, PARAMETER **p)
 }
 
 /* returns 1 if Mutt can't display this type of data, 0 otherwise */
-int mutt_needs_mailcap (BODY *m)
+bool mutt_needs_mailcap (BODY *m)
 {
   switch (m->type)
   {
     case TYPETEXT:
       if (ascii_strcasecmp ("plain", m->subtype) == 0)
-        return 0;
+        return false;
       break;
     case TYPEAPPLICATION:
       if((WithCrypto & APPLICATION_PGP) && mutt_is_application_pgp(m))
-	return 0;
+	return false;
       if((WithCrypto & APPLICATION_SMIME) && mutt_is_application_smime(m))
-	return 0;
+	return false;
       break;
 
     case TYPEMULTIPART:
     case TYPEMESSAGE:
-      return 0;
+      return false;
   }
 
-  return 1;
+  return true;
 }
 
 bool mutt_is_text_part (BODY *b)

--- a/nntp.c
+++ b/nntp.c
@@ -313,7 +313,7 @@ static int nntp_auth (NNTP_SERVER *nserv)
   while (1)
   {
     /* get login and password */
-    if (mutt_account_getuser (&conn->account) || !conn->account.user[0] ||
+    if (!mutt_account_getuser (&conn->account) || !conn->account.user[0] ||
 	!mutt_account_getpass (&conn->account) || !conn->account.pass[0])
       break;
 

--- a/nntp.c
+++ b/nntp.c
@@ -314,7 +314,7 @@ static int nntp_auth (NNTP_SERVER *nserv)
   {
     /* get login and password */
     if (mutt_account_getuser (&conn->account) || !conn->account.user[0] ||
-	mutt_account_getpass (&conn->account) || !conn->account.pass[0])
+	!mutt_account_getpass (&conn->account) || !conn->account.pass[0])
       break;
 
     /* get list of authenticators */

--- a/parse.c
+++ b/parse.c
@@ -1543,7 +1543,7 @@ ADDRESS *mutt_parse_adrlist (ADDRESS *p, const char *s)
 }
 
 /* Compares mime types to the ok and except lists */
-static int count_body_parts_check(LIST **checklist, BODY *b, int dflt)
+static bool count_body_parts_check(LIST **checklist, BODY *b, bool dflt)
 {
   LIST *type = NULL;
   ATTACH_MATCH *a = NULL;
@@ -1551,7 +1551,7 @@ static int count_body_parts_check(LIST **checklist, BODY *b, int dflt)
   /* If list is null, use default behavior. */
   if (! *checklist)
   {
-    return 0;
+    return false;
   }
 
   for (type = *checklist; type; type = type->next)
@@ -1565,7 +1565,7 @@ static int count_body_parts_check(LIST **checklist, BODY *b, int dflt)
         (!b->subtype || !regexec(&a->minor_rx, b->subtype, 0, NULL, 0)))
     {
       mutt_debug (5, "yes\n");
-      return 1;
+      return true;
     }
     else
     {
@@ -1573,7 +1573,7 @@ static int count_body_parts_check(LIST **checklist, BODY *b, int dflt)
     }
   }
 
-  return 0;
+  return false;
 }
 
 #define AT_COUNT(why)   { shallcount = true; }
@@ -1640,16 +1640,16 @@ static int count_body_parts (BODY *body, int flags)
 
       if (bp->disposition == DISPATTACH)
       {
-        if (!count_body_parts_check(&AttachAllow, bp, 1))
+        if (!count_body_parts_check(&AttachAllow, bp, true))
 	  AT_NOCOUNT("attach not allowed");
-        if (count_body_parts_check(&AttachExclude, bp, 0))
+        if (count_body_parts_check(&AttachExclude, bp, false))
 	  AT_NOCOUNT("attach excluded");
       }
       else
       {
-        if (!count_body_parts_check(&InlineAllow, bp, 1))
+        if (!count_body_parts_check(&InlineAllow, bp, true))
 	  AT_NOCOUNT("inline not allowed");
-        if (count_body_parts_check(&InlineExclude, bp, 0))
+        if (count_body_parts_check(&InlineExclude, bp, false))
 	  AT_NOCOUNT("excluded");
       }
     }

--- a/pgp.c
+++ b/pgp.c
@@ -95,18 +95,18 @@ int pgp_valid_passphrase (void)
   return 0;
 }
 
-int pgp_use_gpg_agent (void)
+bool pgp_use_gpg_agent (void)
 {
   char *tty = NULL;
 
   /* GnuPG 2.1 no longer exports GPG_AGENT_INFO */
   if (!option (OPTUSEGPGAGENT))
-    return 0;
+    return false;
 
   if ((tty = ttyname(0)))
     setenv("GPG_TTY", tty, 0);
 
-  return 1;
+  return true;
 }
 
 static pgp_key_t _pgp_parent(pgp_key_t k)

--- a/pgp.h
+++ b/pgp.h
@@ -28,7 +28,7 @@
 
 /* prototypes */
 
-int pgp_use_gpg_agent(void);
+bool pgp_use_gpg_agent(void);
 
 int pgp_check_traditional(FILE *fp, BODY *b, int tagged_only);
 BODY *pgp_make_key_attachment(char *tempf);

--- a/pop_auth.c
+++ b/pop_auth.c
@@ -328,7 +328,7 @@ int pop_authenticate (POP_DATA* pop_data)
   int attempts = 0;
   int ret = POP_A_UNAVAIL;
 
-  if (mutt_account_getuser (acct) || !acct->user[0] ||
+  if (!mutt_account_getuser (acct) || !acct->user[0] ||
       !mutt_account_getpass (acct) || !acct->pass[0])
     return -3;
 

--- a/pop_auth.c
+++ b/pop_auth.c
@@ -329,7 +329,7 @@ int pop_authenticate (POP_DATA* pop_data)
   int ret = POP_A_UNAVAIL;
 
   if (mutt_account_getuser (acct) || !acct->user[0] ||
-      mutt_account_getpass (acct) || !acct->pass[0])
+      !mutt_account_getpass (acct) || !acct->pass[0])
     return -3;
 
   if (PopAuthenticators && *PopAuthenticators)

--- a/protos.h
+++ b/protos.h
@@ -273,7 +273,7 @@ void mutt_view_attachments(HEADER *hdr);
 void mutt_write_address_list(ADDRESS *adr, FILE *fp, int linelen, int display);
 void mutt_set_virtual(CONTEXT *ctx);
 int mutt_add_to_rx_list(RX_LIST **list, const char *s, int flags, BUFFER *err);
-int mutt_addr_is_user(ADDRESS *addr);
+bool mutt_addr_is_user(ADDRESS *addr);
 int mutt_addwch(wchar_t wc);
 int mutt_alias_complete(char *s, size_t buflen);
 void mutt_alias_add_reverse(ALIAS *t);

--- a/protos.h
+++ b/protos.h
@@ -346,7 +346,7 @@ bool mutt_match_rx_list(const char *s, RX_LIST *l);
 int mutt_match_spam_list(const char *s, REPLACE_LIST *l, char *text, int textsize);
 int mutt_messages_in_thread(CONTEXT *ctx, HEADER *hdr, int flag);
 int mutt_multi_choice(char *prompt, char *letters);
-int mutt_needs_mailcap(BODY *m);
+bool mutt_needs_mailcap(BODY *m);
 int mutt_num_postponed(int force);
 int mutt_parse_bind(BUFFER *buf, BUFFER *s, unsigned long data, BUFFER *err);
 int mutt_parse_exec(BUFFER *buf, BUFFER *s, unsigned long data, BUFFER *err);

--- a/recvattach.c
+++ b/recvattach.c
@@ -428,7 +428,7 @@ static void prepend_curdir (char *dst, size_t dstlen)
   dst[l + 2] = 0;
 }
 
-static int query_save_attachment (FILE *fp, BODY *body, HEADER *hdr, char **directory)
+static bool query_save_attachment (FILE *fp, BODY *body, HEADER *hdr, char **directory)
 {
   char *prompt = NULL;
   char buf[_POSIX_PATH_MAX], tfile[_POSIX_PATH_MAX];
@@ -460,7 +460,7 @@ static int query_save_attachment (FILE *fp, BODY *body, HEADER *hdr, char **dire
 	|| !buf[0])
     {
       mutt_clear_error ();
-      return -1;
+      return false;
     }
 
     prompt = NULL;
@@ -483,13 +483,13 @@ static int query_save_attachment (FILE *fp, BODY *body, HEADER *hdr, char **dire
 	continue;
       }
       else if (rc == -1)
-	return -1;
+	return false;
       strfcpy(tfile, buf, sizeof(tfile));
     }
     else
     {
       if ((rc = mutt_check_overwrite (body->filename, buf, tfile, sizeof (tfile), &append, directory)) == -1)
-	return -1;
+	return false;
       else if (rc == 1)
       {
 	prompt = _("Save to file: ");
@@ -501,7 +501,7 @@ static int query_save_attachment (FILE *fp, BODY *body, HEADER *hdr, char **dire
     if (mutt_save_attachment (fp, body, tfile, append, (hdr || !is_message) ? hdr : body->hdr) == 0)
     {
       mutt_message (_("Attachment saved."));
-      return 0;
+      return true;
     }
     else
     {
@@ -509,7 +509,7 @@ static int query_save_attachment (FILE *fp, BODY *body, HEADER *hdr, char **dire
       continue;
     }
   }
-  return 0;
+  return true;
 }
 
 void mutt_save_attachment_list (FILE *fp, int tag, BODY *top, HEADER *hdr, MUTTMENU *menu)
@@ -570,7 +570,7 @@ void mutt_save_attachment_list (FILE *fp, int tag, BODY *top, HEADER *hdr, MUTTM
 
 	  menu_redraw (menu);
 	}
-	if (query_save_attachment (fp, top, hdr, &directory) == -1)
+	if (!query_save_attachment (fp, top, hdr, &directory))
 	  break;
       }
     }

--- a/recvcmd.c
+++ b/recvcmd.c
@@ -28,15 +28,15 @@
 /* some helper functions to verify that we are exclusively operating
  * on message/rfc822 attachments
  */
-static short check_msg (BODY * b, short err)
+static bool check_msg (BODY * b, bool err)
 {
   if (!mutt_is_message_type (b->type, b->subtype))
   {
     if (err)
       mutt_error (_("You may only bounce message/rfc822 parts."));
-    return -1;
+    return false;
   }
-  return 0;
+  return true;
 }
 
 static bool check_all_msg (ATTACHPTR ** idx, short idxlen,
@@ -44,7 +44,7 @@ static bool check_all_msg (ATTACHPTR ** idx, short idxlen,
 {
   short i;
 
-  if (cur && check_msg (cur, err) == -1)
+  if (cur && !check_msg (cur, err))
     return false;
   else if (!cur)
   {
@@ -52,7 +52,7 @@ static bool check_all_msg (ATTACHPTR ** idx, short idxlen,
     {
       if (idx[i]->content->tagged)
       {
-	if (check_msg (idx[i]->content, err) == -1)
+	if (!check_msg (idx[i]->content, err))
 	  return false;
       }
     }

--- a/recvcmd.c
+++ b/recvcmd.c
@@ -39,13 +39,13 @@ static short check_msg (BODY * b, short err)
   return 0;
 }
 
-static short check_all_msg (ATTACHPTR ** idx, short idxlen,
-			    BODY * cur, short err)
+static bool check_all_msg (ATTACHPTR ** idx, short idxlen,
+			    BODY * cur, bool err)
 {
   short i;
 
   if (cur && check_msg (cur, err) == -1)
-    return -1;
+    return false;
   else if (!cur)
   {
     for (i = 0; i < idxlen; i++)
@@ -53,11 +53,11 @@ static short check_all_msg (ATTACHPTR ** idx, short idxlen,
       if (idx[i]->content->tagged)
       {
 	if (check_msg (idx[i]->content, err) == -1)
-	  return -1;
+	  return false;
       }
     }
   }
-  return 0;
+  return true;
 }
 
 
@@ -123,7 +123,7 @@ void mutt_attach_bounce (FILE * fp, HEADER * hdr,
   int ret = 0;
   int p   = 0;
 
-  if (check_all_msg (idx, idxlen, cur, 1) == -1)
+  if (!check_all_msg (idx, idxlen, cur, true))
     return;
 
   /* one or more messages? */
@@ -244,7 +244,7 @@ void mutt_attach_resend (FILE * fp, HEADER * hdr, ATTACHPTR ** idx,
 {
   short i;
 
-  if (check_all_msg (idx, idxlen, cur, 1) == -1)
+  if (!check_all_msg (idx, idxlen, cur, true))
     return;
 
   if (cur)
@@ -673,7 +673,7 @@ void mutt_attach_forward (FILE * fp, HEADER * hdr,
   short nattach;
 
 
-  if (check_all_msg (idx, idxlen, cur, 0) == 0)
+  if (check_all_msg (idx, idxlen, cur, false))
     attach_forward_msgs (fp, hdr, idx, idxlen, cur, flags);
   else
   {
@@ -833,7 +833,7 @@ void mutt_attach_reply (FILE * fp, HEADER * hdr,
     unset_option (OPTNEWSSEND);
 #endif
 
-  if (check_all_msg (idx, idxlen, cur, 0) == -1)
+  if (!check_all_msg (idx, idxlen, cur, false))
   {
     nattach = count_tagged (idx, idxlen);
     if ((parent = find_parent (idx, idxlen, cur, nattach)) == NULL)

--- a/remailer.c
+++ b/remailer.c
@@ -422,18 +422,18 @@ static void mix_entry (char *b, size_t blen, MUTTMENU *menu, int num)
 		     (unsigned long) type2_list[num], MUTT_FORMAT_ARROWCURSOR);
 }
 
-static int mix_chain_add (MIXCHAIN *chain, const char *s,
+static bool mix_chain_add (MIXCHAIN *chain, const char *s,
 			  REMAILER **type2_list)
 {
   int i;
 
   if (chain->cl >= MAXMIXES)
-    return -1;
+    return false;
 
   if ((mutt_strcmp (s, "0") == 0) || (ascii_strcasecmp (s, "<random>") == 0))
   {
     chain->ch[chain->cl++] = 0;
-    return 0;
+    return true;
   }
 
   for (i = 0; type2_list[i]; i++)
@@ -441,7 +441,7 @@ static int mix_chain_add (MIXCHAIN *chain, const char *s,
     if (ascii_strcasecmp (s, type2_list[i]->shortname) == 0)
     {
       chain->ch[chain->cl++] = i;
-      return 0;
+      return true;
     }
   }
 
@@ -450,7 +450,7 @@ static int mix_chain_add (MIXCHAIN *chain, const char *s,
   if (!type2_list[i])
     chain->ch[chain->cl++] = 0;
 
-  return 0;
+  return true;
 }
 
 static const struct mapping_t RemailerHelp[] =

--- a/rfc3676.c
+++ b/rfc3676.c
@@ -78,22 +78,22 @@ static int space_quotes (STATE *s)
  * as opposed to
  *    >>>foo
  */
-static int add_quote_suffix (STATE *s, int ql)
+static bool add_quote_suffix (STATE *s, int ql)
 {
   if (s->flags & MUTT_REPLYING)
-    return 0;
+    return false;
 
   if (space_quotes (s))
-    return 0;
+    return false;
 
   if (!ql && !s->prefix)
-    return 0;
+    return false;
 
   /* The prefix will add its own space */
   if (!option (OPTTEXTFLOWED) && !ql && s->prefix)
-    return 0;
+    return false;
 
-  return 1;
+  return true;
 }
 
 static size_t print_indent (int ql, STATE *s, int add_suffix)

--- a/sidebar.c
+++ b/sidebar.c
@@ -430,25 +430,25 @@ static void sort_entries (void)
  * select_next - Selects the next unhidden mailbox
  *
  * Returns:
- *      1: Success
- *      0: Failure
+ *      true: Success
+ *      false: Failure
  */
-static int select_next (void)
+static bool select_next (void)
 {
   int entry = HilIndex;
 
   if (!EntryCount || HilIndex < 0)
-    return 0;
+    return false;
 
   do
   {
     entry++;
     if (entry == EntryCount)
-      return 0;
+      return false;
   } while (Entries[entry]->is_hidden);
 
   HilIndex = entry;
-  return 1;
+  return true;
 }
 
 /**

--- a/sidebar.c
+++ b/sidebar.c
@@ -490,25 +490,25 @@ static int select_next_new (void)
  * select_prev - Selects the previous unhidden mailbox
  *
  * Returns:
- *      1: Success
- *      0: Failure
+ *      true: Success
+ *      false: Failure
  */
-static int select_prev (void)
+static bool select_prev (void)
 {
   int entry = HilIndex;
 
   if (!EntryCount || HilIndex < 0)
-    return 0;
+    return false;
 
   do
   {
     entry--;
     if (entry < 0)
-      return 0;
+      return false;
   } while (Entries[entry]->is_hidden);
 
   HilIndex = entry;
-  return 1;
+  return true;
 }
 
 /**

--- a/smtp.c
+++ b/smtp.c
@@ -264,7 +264,7 @@ static bool addresses_use_unicode(const ADDRESS* a)
 }
 
 
-static int smtp_fill_account (ACCOUNT* account)
+static bool smtp_fill_account (ACCOUNT* account)
 {
   static unsigned short SmtpPort = 0;
 
@@ -284,7 +284,7 @@ static int smtp_fill_account (ACCOUNT* account)
     FREE (&urlstr);
     mutt_error (_("Invalid SMTP URL: %s"), SmtpUrl);
     mutt_sleep (1);
-    return -1;
+    return false;
   }
   FREE (&urlstr);
 
@@ -310,7 +310,7 @@ static int smtp_fill_account (ACCOUNT* account)
     }
   }
 
-  return 0;
+  return true;
 }
 
 static int smtp_helo (CONNECTION* conn)
@@ -643,7 +643,7 @@ mutt_smtp_send (const ADDRESS* from, const ADDRESS* to, const ADDRESS* cc,
     return -1;
   }
 
-  if (smtp_fill_account (&account) < 0)
+  if (!smtp_fill_account (&account))
     return ret;
 
   if (!(conn = mutt_conn_find (NULL, &account)))

--- a/smtp.c
+++ b/smtp.c
@@ -524,7 +524,7 @@ static int smtp_auth_plain(CONNECTION* conn)
     {
       /* Get username and password. Bail out of any cannot be retrieved. */
       if (mutt_account_getuser(&conn->account) ||
-          mutt_account_getpass(&conn->account))
+          !mutt_account_getpass(&conn->account))
       {
         goto error;
       }

--- a/smtp.c
+++ b/smtp.c
@@ -252,15 +252,15 @@ static int address_uses_unicode(const char *a)
 /* Returns 1 if any address in a contains at least one 8-bit
  * character, 0 if none do.
  */
-static int addresses_use_unicode(const ADDRESS* a)
+static bool addresses_use_unicode(const ADDRESS* a)
 {
   while (a)
   {
     if(a->mailbox && !a->group && address_uses_unicode(a->mailbox))
-      return 1;
+      return true;
     a = a->next;
   }
-  return 0;
+  return false;
 }
 
 

--- a/smtp.c
+++ b/smtp.c
@@ -69,19 +69,19 @@ static int Esmtp = 0;
 static char* AuthMechs = NULL;
 static unsigned char Capabilities[(CAPMAX + 7)/ 8];
 
-static int smtp_code (char *buf, size_t len, int *n)
+static bool smtp_code (char *buf, size_t len, int *n)
 {
   char code[4];
 
   if (len < 4)
-    return -1;
+    return false;
   code[0] = buf[0];
   code[1] = buf[1];
   code[2] = buf[2];
   code[3] = 0;
   if (mutt_atoi (code, n) < 0)
-    return -1;
-  return 0;
+    return false;
+  return true;
 }
 
 /* Reads a command response from the SMTP server.
@@ -117,7 +117,7 @@ smtp_get_resp (CONNECTION * conn)
     else if (ascii_strncasecmp ("SMTPUTF8", buf + 4, 8) == 0)
       mutt_bit_set (Capabilities, SMTPUTF8);
 
-    if (smtp_code (buf, n, &n) < 0)
+    if (!smtp_code (buf, n, &n))
       return smtp_err_code;
 
   } while (buf[3] == '-');
@@ -398,7 +398,7 @@ static int smtp_auth_sasl (CONNECTION* conn, const char* mechlist)
       goto fail;
     if ((rc = mutt_socket_readln (buf, bufsize, conn)) < 0)
       goto fail;
-    if (smtp_code (buf, rc, &rc) < 0)
+    if (!smtp_code (buf, rc, &rc))
       goto fail;
 
     if (rc != smtp_ready)

--- a/smtp.c
+++ b/smtp.c
@@ -523,7 +523,7 @@ static int smtp_auth_plain(CONNECTION* conn)
     if (ascii_strncasecmp(method, "plain", 5) == 0)
     {
       /* Get username and password. Bail out of any cannot be retrieved. */
-      if (mutt_account_getuser(&conn->account) ||
+      if (!mutt_account_getuser(&conn->account) ||
           !mutt_account_getpass(&conn->account))
       {
         goto error;


### PR DESCRIPTION
Fixes #492 (part of)

Sets 20-25 contain 38 functions that are suitable for boolification.
For each function:
- Prototype updated
- Return values boolified
- Function parameters boolified
- Function callers checked
- Caller local variables boolified

1. bee6996 **add_quote_suffix**
2. c78dee3 **addresses_use_unicode**
3. 09d39aa **add_to_replace_list**
4. 0c0dd88 **bcache_path**
5. 1c3ba78 **check_all_msg**
6. 1f2ec5e **check_attachments**
7. c4014e4 **check_certificate_expiration**
8. 5957e48 **check_msg**
9. 758a3fe **cmd_queue_full**
10. e0fdb67 **count_body_parts_check**
11. 0e8fa6d **get_database_mtime**
12. 761b2f6 **hostname_match**
13. 11f8893 **imap_check_capabilities**
14. e0926c4 **imap_get_mailbox**
15. ba6914d **imap_has_flag**
16. 66e389a **is_day_name**
17. 3eb48fe **main_change_folder**
18. 26728cc **menu_dialog_dokey**
19. 615285e **mh_valid_message**
20. 185f76f **mix_chain_add**
21. ac0d175 **mkwrapdir**
22. 08b3848 **mutt_account_getpass**
23. 57f28c2 **mutt_account_getuser**
24. 53e75d1 **mutt_addr_is_user**
25. 4d4dfc9 **mutt_needs_mailcap**
26. b8c1611 **mx_toggle_write**
27. bc9d3ff **pgp_use_gpg_agent**
28. 8185a0f **query_save_attachment**
29. ba54e09 **release_db**
30. 95e58b2 **remove_filename**
31. 8e7f4a5 **select_next**
32. 52ee0d4 **select_prev**
33. 448a5f4 **smtp_code**
34. eccd5d9 **smtp_fill_account**
35. 9ca695d **ssl_init**
36. 7606294 **update_header_tags**
37. f0e08bb **update_tags**
38. de99177 **user_in_addr**

While 38 commits will make my stats look good, I'll squash them when merging :-)

@neomutt/reviewers Please review.