### PR TITLE
github: improve PR template and CONTRIBUTING.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,21 +1,23 @@
-* What does this PR do?
+* **What does this PR do?**
 
-* Are there points in the code the reviewer needs to double check?
+* **Are there points in the code the reviewer needs to double check?**
 
-* Why was this PR needed?
+* **Why was this PR needed?**
 
-* Screenshots (if relevant)
+* **Screenshots (if relevant)**
 
-* Does this PR meet the acceptance criteria?
+* **Does this PR meet the acceptance criteria?** (This is just a reminder for you,
+  this section can be removed if you fulfill it.)
 
-   - [ ] Documentation created/updated (you have to edit
-     [doc/manual.xml.head](https://www.neomutt.org/guide/) for that)
+   - Documentation created/updated (you have to edit
+     [doc/manual.xml.head](https://www.github.com/neomutt/neomutt/blob/master/doc/manual.xml.head)
+     for that)
 
-   - [ ] All builds are passing
+   - All builds are passing
 
-   - [ ] Added [doxygen code documentation](https://www.neomutt.org/dev/doxygen)
+   - Added [doxygen code documentation](https://www.neomutt.org/dev/doxygen)
      [syntax](http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html)
 
-   - [ ] Code follows the [style guide](https://www.neomutt.org/dev/coding-style)
+   - Code follows the [style guide](https://www.neomutt.org/dev/coding-style)
 
-* What are the relevant issue numbers?
+* **What are the relevant issue numbers?**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,9 +37,9 @@ Tips for writing a good feature request
 Tips for writing good pull requests
 ---------------------------------------
 
-* The first line should be a short (50 chars or less) summary of your commit
-  message. If you can't find a short enough one-line summary, split the commit
-  into multiple ones.
+* The first line should be a short (50 characters or less) summary of your
+  commit message. If you can't find a short enough one-line summary, split the
+  commit into multiple ones.
 
 * Keep one line between the one-line summary and the body.
 
@@ -48,14 +48,14 @@ Tips for writing good pull requests
 
 * your commits should be clear and concise. That means also you shouldn't sum up
   two features or two bug fixes into one commit. If you do, it makes both bug
-  fixes or features harder to understand. Also, don't hesitate
-  to [rewrite](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) the
+  fixes or features harder to understand. Also, don't hesitate to
+  [rewrite](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History) the
   Github history of your development branch.
 
 * Wrap the body of the commit message at around 80 characters.
 
 * if your commit addresses a particular PR, commit or Issue, please say so in
-  your commit. The github documentation
+  your commit. The Github documentation
   ([1](https://help.github.com/articles/autolinked-references-and-urls/)
   and [2](https://help.github.com/articles/closing-issues-via-commit-messages/))
   can help you with that.
@@ -63,6 +63,8 @@ Tips for writing good pull requests
 * Please eliminate any warnings gcc or any other tool produces during the
   compilation stage.
 
+* If your commit addresses only a specific method or a specific file, please say
+  so in your commit.
 
 Thank you for your help!
 


### PR DESCRIPTION
* What does this PR do?

    * PR template:

        * made structural questions bold to contrast it from the actual
  PR description.

        * add note that acceptance criteria can be removed when the PR is
  submitted. Its only meant as a reminder.

        * fixed manual link.

    * CONTRIBUTING.md:

        * ~~removed Note that the first line of git commits should be 50
  characters or less - the consensus seems to not care about that.~~

        * wrap text at 80 characters.

* Why was this PR needed?

    * text boxes to click on are not useful when PR's are submitted (they are mostly empty)
    * ~~Some of the git commits by active contributors exceed 50 characters, therefore I guess the consensus is rather to write clear commit messages than to keep the first line below 50 characters.~~
    * there's no real reason (imho) to keep the acceptance criteria if its fulfilled.
