### PR TITLE
configure: uniformize notmuch and remove dead code

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -65,11 +65,10 @@ EXTRA_mutt_SOURCES = account.c bcache.c bcache.h browser.h compress.c \
 	crypt_gpgme.c crypt_mod_pgp_classic.c crypt_mod_pgp_gpgme.c \
 	crypt_mod_smime_classic.c crypt_mod_smime_gpgme.c dotlock.c \
 	gnupgparse.c hcache.c hcache.h mbyte.h md5.c mutt_idna.c mutt_idna.h \
-	mutt_lua.c mutt_sasl.c mutt_socket.c mutt_ssl.c mutt_ssl_gnutls.c \
+	mutt_lua.c mutt_sasl.c mutt_notmuch.c mutt_socket.c mutt_ssl.c mutt_ssl_gnutls.c \
 	mutt_tunnel.c newsrc.c nntp.c pgp.c pgpinvoke.c pgpkey.c pgplib.c \
 	pgpmicalg.c pgppacket.c pop.c pop_auth.c pop_lib.c remailer.c \
-	remailer.h resize.c sha1.c smime.c smtp.c url.h utf8.c \
-	wcwidth.c
+	remailer.h resize.c sha1.c smime.c smtp.c url.h utf8.c wcwidth.c
 
 EXTRA_DIST = account.h ascii.h attach.h browser.h buffer.h buffy.h ChangeLog \
 	ChangeLog.neomutt ChangeLog.nntp charset.h compress.h config.rpath \
@@ -79,20 +78,15 @@ EXTRA_DIST = account.h ascii.h attach.h browser.h buffer.h buffy.h ChangeLog \
 	hcache_qdbm.c hcache_tc.c hcachever.sh.in history.h init.h keymap.h \
 	lib.h LICENSE.md mailbox.h mapping.h mbyte.h md5.h mime.h mime.types \
 	mutt.h mutt_commands.h mutt_crypt.h mutt_curses.h mutt_idna.h \
-	mutt_lua.h mutt_menu.h mutt_options.h mutt_regex.h mutt_sasl.h \
+	mutt_lua.h mutt_menu.h mutt_notmuch.h mutt_options.h mutt_regex.h mutt_sasl.h \
 	mutt_sasl_plain.h mutt_socket.h mutt_ssl.h mutt_tunnel.h mx.h myvar.h \
 	nntp.h OPS OPS.CRYPT OPS.MIX OPS.NOTMUCH OPS.PGP OPS.SIDEBAR OPS.SMIME \
 	pager.h PATCHES patchlist.sh pgp.h pgpewrap.c pgplib.h pgppacket.h \
 	pop.h protos.h README.md README.SSL remailer.c remailer.h \
-	rfc1524.h rfc2047.h rfc2231.h rfc3676.h rfc822.h sha1.h sidebar.h smime.h \ 
+	rfc1524.h rfc2047.h rfc2231.h rfc3676.h rfc822.h sha1.h sidebar.h smime.h \
 	smime_keys.pl sort.h txt2c.c txt2c.sh UPDATING version.h keymap_alldefs.h
 
 EXTRA_SCRIPTS = smime_keys
-
-if BUILD_NOTMUCH
-mutt_SOURCES += mutt_notmuch.c mutt_notmuch.h
-mutt_LDADD += $(NOTMUCH_LIBS)
-endif
 
 mutt_dotlock_SOURCES = mutt_dotlock.c
 mutt_dotlock_LDADD = $(LIBOBJS)

--- a/configure.ac
+++ b/configure.ac
@@ -290,18 +290,17 @@ AS_IF([test x$enable_lua = "xyes"], [
 	AC_DEFINE(USE_LUA, 1, [Define if you want support for LUA.])
 	MUTT_LIB_OBJECTS="$MUTT_LIB_OBJECTS mutt_lua.o"
 	CPPFLAGS="$CPPFLAGS $LUA_INCLUDE"
-	LIBS="$LIBS $LUA_LIB"
+	MUTTLIBS="$MUTTLIBS $LUA_LIB"
 ])
-AM_CONDITIONAL(BUILD_LUA, test x$enable_lua = xyes)
 
 dnl --enable-notmuch
 AS_IF([test x$use_notmuch = "xyes"], [
-	AC_CHECK_LIB(notmuch, notmuch_database_open,,
+	AC_CHECK_LIB(notmuch, notmuch_database_open, [:],
 		AC_MSG_ERROR([Unable to find Notmuch library]))
 	AC_DEFINE(USE_NOTMUCH,1,[ Define if you want support for the notmuch. ])
-	NOTMUCH_LIBS="-lnotmuch"
+	MUTT_LIB_OBJECTS="$MUTT_LIB_OBJECTS mutt_notmuch.o"
+	MUTTLIBS="$MUTTLIBS -lnotmuch"
 	OPS="$OPS \$(srcdir)/OPS.NOTMUCH"
-	need_notmuch="yes"
 
 	AC_MSG_CHECKING([for notmuch api version 3])
 	AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
@@ -315,7 +314,6 @@ AS_IF([test x$use_notmuch = "xyes"], [
 	])
 	AC_MSG_RESULT([$notmuch_api_3])
 ])
-AM_CONDITIONAL(BUILD_NOTMUCH, test x$need_notmuch = xyes)
 
 dnl --with-mixmaster
 AS_IF([test "$alongwith_mixmaster" != "no"], [
@@ -419,7 +417,7 @@ main ()
 	AC_CHECK_LIB($cf_ncurses, initscr,
 		[MUTTLIBS="$MUTTLIBS -l$cf_ncurses"
 
-		AC_CHECK_LIB($cf_ncurses, tgetent, [], [
+		AC_CHECK_LIB($cf_ncurses, tgetent, [:], [
 			AC_CHECK_LIB(tinfo, tgetent, [MUTTLIBS="$MUTTLIBS -ltinfo"])
 		])
 
@@ -1139,7 +1137,6 @@ AC_SUBST(MUTTLIBS)
 AC_SUBST(MUTT_LIB_OBJECTS)
 AC_SUBST(LIBIMAP)
 AC_SUBST(LIBIMAPDEPS)
-AC_SUBST(NOTMUCH_LIBS)
 
 dnl -- iconv/gettext --
 
@@ -1238,7 +1235,7 @@ if test "x$with_idn" != "xno"; then
 
     AC_SEARCH_LIBS([stringprep_check_version], [idn], [
         AC_DEFINE([HAVE_LIBIDN], 1, [Define to 1 if you have the GNU idn library])
-        MUTTLIBS="$MUTTLIBS $LIBS"
+        MUTTLIBS="$MUTTLIBS -lidn"
 
         LIBS="$LIBS $LIBICONV"
         AC_CHECK_FUNCS(idna_to_unicode_utf8_from_utf8 idna_to_unicode_8z8z)

--- a/hdrline.c
+++ b/hdrline.c
@@ -28,9 +28,6 @@
 #include "mutt_curses.h"
 #include "mutt_idna.h"
 #include "sort.h"
-#ifdef HAVE_ALLOCA_H
-#include <alloca.h>
-#endif
 #ifdef USE_NOTMUCH
 #include "mutt_notmuch.h"
 #endif

--- a/imap/message.c
+++ b/imap/message.c
@@ -26,9 +26,6 @@
 #include "mutt.h"
 #include "bcache.h"
 #include "mx.h"
-#ifdef HAVE_PGP
-#include "pgp.h"
-#endif
 #ifdef USE_HCACHE
 #include "hcache.h"
 #endif
@@ -876,11 +873,6 @@ parsemsg:
   }
 
   h->content->length = ftell(msg->fp) - h->content->offset;
-
-/* This needs to be done in case this is a multipart message */
-#if defined(HAVE_PGP) || defined(HAVE_SMIME)
-  h->security = crypt_query(h->content);
-#endif
 
   mutt_clear_error();
   rewind(msg->fp);

--- a/mutt_ssl_gnutls.c
+++ b/mutt_ssl_gnutls.c
@@ -25,9 +25,6 @@
 #include "mutt_regex.h"
 #include "mutt_socket.h"
 #include "mutt_ssl.h"
-#ifdef HAVE_GNUTLS_OPENSSL_H
-#include <gnutls/openssl.h>
-#endif
 
 /* certificate error bitmap values */
 #define CERTERR_VALID 0

--- a/nntp.c
+++ b/nntp.c
@@ -35,12 +35,6 @@
 #ifdef USE_SSL
 #include "mutt_ssl.h"
 #endif
-#ifdef HAVE_PGP
-#include "pgp.h"
-#endif
-#ifdef HAVE_SMIME
-#include "smime.h"
-#endif
 #ifdef USE_HCACHE
 #include "hcache.h"
 #endif

--- a/version.c
+++ b/version.c
@@ -194,11 +194,7 @@ static struct compile_options comp_opts[] = {
 #else
   { "HAVE_META", 0 },
 #endif
-#ifdef HAVE_REGCOMP
   { "HAVE_REGCOMP", 1 },
-#else
-  { "HAVE_REGCOMP", 0 },
-#endif
 #ifdef HAVE_RESIZETERM
   { "HAVE_RESIZETERM", 1 },
 #else


### PR DESCRIPTION
* What does this PR do?

Cleans up configure.ac to avoid messing with `MUTTLIBS` and `LIBS` in confusing ways, build notmuch the same way as other mutt's components, remove dead code related to configure symbols that are never defined.

* Are there points in the code the reviewer needs to double check?

Making sure that the `HAVE_` symbols are really not defined anywhere and that the changes to configure.ac don't break anything.

* Why was this PR needed?

Improve code readability by removing dead code and uniformize configure.ac and Makefile.am.