### PR TITLE
remove --enable-mailtool configure option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -221,6 +221,7 @@ AC_DEFINE(USE_SIDEBAR, 1, [Define if you want support for the sidebar.])
 AC_DEFINE(USE_SMTP, 1, [Include internal SMTP relay support])
 AC_DEFINE(USE_SOCKET,1,
 	[ Include code for socket support. Set automatically if you enable POP3 or IMAP ])
+AC_DEFINE(SUN_ATTACHMENT,1,[ Define to enable Sun mailtool attachments support. ])
 
 dnl --enable-lua
 AS_IF([test x$use_lua = "xyes"], [
@@ -635,11 +636,6 @@ AC_ARG_ENABLE(nfs-fix, AS_HELP_STRING([--enable-nfs-fix],[Work around an NFS wit
 			[Define if you have problems with mutt not detecting
 			new/old mailboxes over NFS.  Some NFS implementations
 			incorrectly cache the attributes of small files.])
-	fi])
-
-AC_ARG_ENABLE(mailtool, AS_HELP_STRING([--enable-mailtool],[Enable Sun mailtool attachments support]),
-	[if test x$enableval = xyes; then
-		AC_DEFINE(SUN_ATTACHMENT,1,[ Define to enable Sun mailtool attachments support. ])
 	fi])
 
 AC_ARG_ENABLE(locales-fix, AS_HELP_STRING([--enable-locales-fix],[The result of isprint() is unreliable]),

--- a/version.c
+++ b/version.c
@@ -282,8 +282,6 @@ static struct compile_options comp_opts[] = {
   { "status_color", 1 },
 #ifdef SUN_ATTACHMENT
   { "sun_attachment", 1 },
-#else
-  { "sun_attachment", 0 },
 #endif
   { "timeout", 1 },
   { "tls_sni", 1 },


### PR DESCRIPTION
* **What does this PR do?** Completely removes the `--enable-mailtool` configure flag.


* **Why was this PR needed?** It looks legacy. However I have not found much evidence about its legacy - still i doubt the contrary.

* **What are the relevant issue numbers?** #389 

@neomutt/reviewers please review.