### PR TITLE
build: change gpgme requirement back to 1.1.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -245,8 +245,9 @@ dnl == Declare all the checks and code for options / features below this line ==
 dnl --enable-gpgme
 AS_IF([test x$use_gpgme = "xyes"], [
 	ifdef([AM_PATH_GPGME], [
-		AM_PATH_GPGME(1.2.0, [
+		AM_PATH_GPGME(1.1.0, [
 			AC_DEFINE(CRYPT_BACKEND_GPGME, 1, [GPGME support])
+			AC_CHECK_FUNCS([gpgme_op_export_keys])
 			MUTT_LIB_OBJECTS="$MUTT_LIB_OBJECTS crypt_gpgme.o \
 			crypt_mod_pgp_gpgme.o crypt_mod_smime_gpgme.o"
 		], [gpgme_found=no])

--- a/crypt_gpgme.c
+++ b/crypt_gpgme.c
@@ -4468,6 +4468,7 @@ char *smime_gpgme_findkeys(ADDRESS *adrlist, int oppenc_mode)
   return find_keys(adrlist, APPLICATION_SMIME, oppenc_mode);
 }
 
+#ifdef HAVE_GPGME_OP_EXPORT_KEYS
 BODY *pgp_gpgme_make_key_attachment(char *tempf)
 {
   crypt_key_t *key = NULL;
@@ -4527,6 +4528,7 @@ bail:
 
   return att;
 }
+#endif
 
 /*
  * Implementation of `init'.

--- a/crypt_mod_pgp_gpgme.c
+++ b/crypt_mod_pgp_gpgme.c
@@ -89,10 +89,12 @@ static BODY *crypt_mod_pgp_encrypt_message(BODY *a, char *keylist, int sign)
   return pgp_gpgme_encrypt_message(a, keylist, sign);
 }
 
+#ifdef HAVE_GPGME_OP_EXPORT_KEYS
 static BODY *crypt_mod_pgp_make_key_attachment(char *tempf)
 {
   return pgp_gpgme_make_key_attachment(tempf);
 }
+#endif
 
 static void crypt_mod_pgp_set_sender(const char *sender)
 {
@@ -110,7 +112,11 @@ struct crypt_module_specs crypt_mod_pgp_gpgme = {
 
         /* PGP specific.  */
         crypt_mod_pgp_encrypt_message,
+#ifdef HAVE_GPGME_OP_EXPORT_KEYS
         crypt_mod_pgp_make_key_attachment,
+#else
+        NULL,
+#endif
         crypt_mod_pgp_check_traditional, NULL, /* pgp_traditional_encryptsign  */
         NULL,                                  /* pgp_invoke_getkeys  */
         crypt_mod_pgp_invoke_import, NULL, /* pgp_extract_keys_from_attachment_list  */


### PR DESCRIPTION
RHEL6 is still using GPGME 1.1.8, which doesn't have the function
`gpgme_op_export_keys`.  Revert the GPGME requirement to 1.1.0 and put
back the #ifdef's around the missing function.

Note: The improvements to `configure.ac` are still there.

@neomutt/reviewers Please review