### PR TITLE
docs: fix references in INSTALL

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -45,8 +45,6 @@ systems:
 
 - For building the manual, mutt needs the DocBook XSL stylesheets
   as well as the DocBook DTD as of version 4.2 installed locally.
-  For details, please see the section "Generating Mutt Documentation
-  From Source" in doc/devel-notes.txt.
 
 
 Installation


### PR DESCRIPTION
In doc/, there is no file named devel-note.txt.Actually, this is  harmless.As @flatcap  said, we have't modify the INSTALL file yet.

* **What does this PR do?**
It's aim to fix a doc bug.But it is only a small reference missing.
* **Are there points in the code the reviewer needs to double check?**
It is such small fix even i hesitate to pull request.I appreciate @flatcap help me to improve the commet
* **Why was this PR needed?**
Actually, i fix a reference missing in INSTALL, and i hope i can continue to improve it.
* **Screenshots (if relevant)**
Details is displayed in my comment.
* **Does this PR meet the acceptance criteria?** (This is just a reminder for you,
  this section can be removed if you fulfill it.)

   - Documentation created/updated (you have to edit
     [doc/manual.xml.head](https://www.github.com/neomutt/neomutt/blob/master/doc/manual.xml.head)
     for that)

   - All builds are passing

   - Added [doxygen code documentation](https://www.neomutt.org/dev/doxygen)
     [syntax](http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html)

   - Code follows the [style guide](https://www.neomutt.org/dev/coding-style)

* **What are the relevant issue numbers?**
