### PR TITLE
make modify-labels-then-hide hide or unhide

### DIFF
--- a/curs_main.c
+++ b/curs_main.c
@@ -1864,9 +1864,12 @@ int mutt_index_menu(void)
               if (!Context->quiet)
                 mutt_progress_update(&progress, ++px, -1);
               nm_modify_message_tags(Context, Context->hdrs[Context->v2r[j]], buf);
+
+              bool still_queried =
+                  nm_message_is_still_queried(Context, Context->hdrs[Context->v2r[j]]);
               if (op == OP_MAIN_MODIFY_LABELS_THEN_HIDE)
               {
-                Context->hdrs[Context->v2r[j]]->quasi_deleted = true;
+                Context->hdrs[Context->v2r[j]]->quasi_deleted = !still_queried;
                 Context->changed = true;
               }
             }
@@ -1883,7 +1886,8 @@ int mutt_index_menu(void)
           }
           if (op == OP_MAIN_MODIFY_LABELS_THEN_HIDE)
           {
-            CURHDR->quasi_deleted = true;
+            bool still_queried = nm_message_is_still_queried(Context, CURHDR);
+            CURHDR->quasi_deleted = !still_queried;
             Context->changed = true;
           }
           if (menu->menu == MENU_PAGER)

--- a/mutt_notmuch.h
+++ b/mutt_notmuch.h
@@ -32,6 +32,7 @@ int nm_update_filename(struct Context *ctx, const char *old, const char *new, st
 bool nm_normalize_uri(char *new_uri, const char *orig_uri, size_t new_uri_sz);
 char *nm_uri_from_query(struct Context *ctx, char *buf, size_t bufsz);
 int nm_modify_message_tags(struct Context *ctx, struct Header *hdr, char *buf);
+bool nm_message_is_still_queried(struct Context *ctx, struct Header *hdr);
 
 void nm_query_window_backward(void);
 void nm_query_window_forward(void);


### PR DESCRIPTION
If the message is no longer in the current query after modifying
the label it will be hidden as before, but if it is in the current
query (again), it will be unhidden.

Related to #601