### PR TITLE
build: allow xsltproc and w3m calls to fail

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -106,7 +106,7 @@ uninstall-local:
 
 check:
 manual.txt: manual.html
-	LC_ALL=C w3m -dump -O UTF8 manual.html > $@ || \
+	-LC_ALL=C w3m -dump -O UTF8 manual.html > $@ || \
 	LC_ALL=C lynx -dump -nolist -with_backspaces -display_charset=us-ascii manual.html > $@ || \
 	LC_ALL=C elinks -dump -no-numbering -no-references manual.html | sed -e 's,\\001, ,g' > $@
 
@@ -115,12 +115,12 @@ Muttrc: $(top_srcdir)/init.h makedoc$(EXEEXT) $(srcdir)/Muttrc.head
 	$(CPP) $(AM_CPPFLAGS) $(DEFS) $(CPPFLAGS) -D_MAKEDOC -C $(top_srcdir)/init.h | ./makedoc$(EXEEXT) -c >> Muttrc
 
 manual.html: manual.xml $(srcdir)/html.xsl $(srcdir)/mutt.xsl $(srcdir)/mutt.css
-	xsltproc --nonet -o $@ $(srcdir)/html.xsl manual.xml
+	-xsltproc --nonet -o $@ $(srcdir)/html.xsl manual.xml
 
 $(CHUNKED_DOCFILES): index.html
 
 index.html: $(srcdir)/chunk.xsl $(srcdir)/mutt.xsl manual.xml $(srcdir)/mutt.css
-	xsltproc --nonet $(srcdir)/chunk.xsl manual.xml > /dev/null 2>&1
+	-xsltproc --nonet $(srcdir)/chunk.xsl manual.xml > /dev/null 2>&1
 
 validate: manual.xml
 	xmllint --noout --noblanks --postvalid $<


### PR DESCRIPTION
* **What does this PR do?**
Fix build issue caused by following commits:
https://github.com/neomutt/neomutt/commit/fce65a1fa5a6a55d58d6810c80c3782d5ec637a3#diff-8d3e8f7411beefc4b162f0d8a5622353L109
https://github.com/neomutt/neomutt/commit/3c3e57dca57cbc8f5c3c84779a77fd60b819b10d#diff-8d3e8f7411beefc4b162f0d8a5622353L126

* **Are there points in the code the reviewer needs to double check?**

* **Why was this PR needed?**
Build failed on OS X 10.6.
See: https://build.macports.org/builders/ports-10.6_i386_legacy-builder/builds/22817
With patch: https://build.macports.org/builders/ports-10.6_i386_legacy-builder/builds/22843
* **What are the relevant issue numbers?**
macports/macports-ports#498