### PR TITLE
unbind mappings before overwriting in vim-keys

### DIFF
--- a/contrib/vim-keys/vim-keys.rc
+++ b/contrib/vim-keys/vim-keys.rc
@@ -3,8 +3,10 @@
 #------------------------------------------------------------
 
 # Moving around
+bind attach,browser,index       g   noop
 bind attach,browser,index       gg  first-entry
 bind attach,browser,index       G   last-entry
+bind pager                      g  noop
 bind pager                      gg  top
 bind pager                      G   bottom
 bind pager                      k   previous-line
@@ -20,6 +22,7 @@ bind browser,pager              \Cy previous-line
 bind index                      \Ce next-line
 bind index                      \Cy previous-line
 
+bind pager,index                d   noop
 bind pager,index                dd  delete-message
 
 # Mail & Reply


### PR DESCRIPTION
* **What does this PR do?**

Sets mappings to `noop` before overwriting them to prevent warnings.

* **Are there points in the code the reviewer needs to double check?**

No.

* **Why was this PR needed?**

Changes to key bindings in release 2017-06-02.

* **What are the relevant issue numbers?**

#583 
