### PR TITLE
Fix latest coverity issues

### DIFF
--- a/ncrypt/crypt.c
+++ b/ncrypt/crypt.c
@@ -182,7 +182,7 @@ int mutt_protect(struct Header *msg, char *keylist)
   {
     /* Set sender (necessary for e.g. PKA).  */
     const char *mailbox = NULL;
-    const struct Address *from = msg->env->from;
+    struct Address *from = msg->env->from;
 
     if (!from)
       from = mutt_default_from();
@@ -197,7 +197,7 @@ int mutt_protect(struct Header *msg, char *keylist)
       crypt_pgp_set_sender(mailbox);
 
     if (!msg->env->from)
-      FREE(&from);
+      rfc822_free_address(&from);
   }
 
   if (msg->security & SIGN)

--- a/ncrypt/crypt.c
+++ b/ncrypt/crypt.c
@@ -195,6 +195,9 @@ int mutt_protect(struct Header *msg, char *keylist)
       crypt_smime_set_sender(mailbox);
     else if ((WithCrypto & APPLICATION_PGP) && (msg->security & APPLICATION_PGP))
       crypt_pgp_set_sender(mailbox);
+
+    if (!msg->env->from)
+      FREE(&from);
   }
 
   if (msg->security & SIGN)

--- a/nntp.c
+++ b/nntp.c
@@ -740,7 +740,7 @@ int nntp_open_connection(struct NntpServer *nserv)
 static int nntp_query(struct NntpData *nntp_data, char *line, size_t linelen)
 {
   struct NntpServer *nserv = nntp_data->nserv;
-  char buf[LONG_STRING];
+  char buf[LONG_STRING] = {0};
 
   if (nserv->status == NNTP_BYE)
     return -1;

--- a/parse.c
+++ b/parse.c
@@ -1412,8 +1412,11 @@ struct Envelope *mutt_read_rfc822_header(FILE *f, struct Header *hdr,
     }
   }
 
-  while ((loc = ftello(f)), *(line = mutt_read_rfc822_line(f, line, &linelen)) != 0)
+  while ((loc = ftello(f)) != -1)
   {
+    line = mutt_read_rfc822_line(f, line, &linelen);
+    if (*line == '\0')
+      break;
     if ((p = strpbrk(line, ": \t")) == NULL || *p != ':')
     {
       char return_path[LONG_STRING];


### PR DESCRIPTION
ncrypt/crypt.c
CID 170494:  Resource leaks  (RESOURCE_LEAK)
Variable "from" going out of scope leaks the storage it points to.

nntp.c
CID 170495:  Uninitialized variables  (UNINIT)
Declaring variable "buf" without initializer.

parse.c
CID 76957:  Error handling issues  (NEGATIVE_RETURNS)
"loc" is passed to a parameter that cannot be negative.

@neomutt/reviewers please review.