### PR TITLE
make +DEBUG persistent

### DIFF
--- a/auto.def
+++ b/auto.def
@@ -27,7 +27,6 @@ options {
   with-ncurses:path         => "Location of ncurses"
   with-slang:path           => "Location of S-Lang"
 # Features w/o 3rd party dependencies
-  logging=0                 => "Enable debug logging"
   doc=1                     => "Disable building the documentation"
   full-doc=0                => "Build the full documentation set"
   docdir:path               => "Documentation root"
@@ -96,7 +95,7 @@ if {1} {
   # Keep sorted, please.
   foreach opt {
     bdb doc everything fcntl flock fmemopen full-doc gdbm gnutls gpgme gss
-    homespool idn kyotocabinet lmdb locales-fix logging lua mixmaster nls
+    homespool idn kyotocabinet lmdb locales-fix lua mixmaster nls
     notmuch pgp qdbm sasl smime ssl tokyocabinet
   } {
     define want-$opt [opt-bool $opt]
@@ -304,10 +303,6 @@ if {[get-define want-everything]} {
 } else {
   set conf_options "$::argv"
 }
-
-###############################################################################
-# Debug
-if {[get-define want-logging]} {define DEBUG}
 
 ###############################################################################
 # flock(1)
@@ -826,7 +821,6 @@ set auto_rep {
   BINDIR
   BUILD_DOC
   CRYPT_*
-  DEBUG
   DOMAIN
   ENABLE_*
   HAVE_*

--- a/configure.ac
+++ b/configure.ac
@@ -591,12 +591,6 @@ AM_CONDITIONAL(USE_SASL, test x$need_sasl = xyes)
 
 dnl -- end socket --
 
-AC_ARG_ENABLE(debug, AS_HELP_STRING([--enable-debug],[Enable debugging support]),
-	[ if test x$enableval = xyes; then
-		AC_DEFINE(DEBUG,1,[ Define to enable debugging info. ])
-	fi
-])
-
 AC_ARG_ENABLE(flock, AS_HELP_STRING([--enable-flock],[Use flock() to lock files]),
 	[if test $enableval = yes; then
 		AC_DEFINE(USE_FLOCK,1, [ Define to use flock() to lock mailboxes. ])

--- a/conn/ssl.c
+++ b/conn/ssl.c
@@ -130,9 +130,7 @@ static int ssl_load_certificates(SSL_CTX *ctx)
   X509 *cert = NULL;
   X509_STORE *store = NULL;
   int rc = 1;
-#ifdef DEBUG
   char buf[STRING];
-#endif
 
   mutt_debug(2, "loading trusted certificates\n");
   store = SSL_CTX_get_cert_store(ctx);
@@ -265,7 +263,7 @@ static void ssl_err(struct SslSockData *data, int err)
       data->isopen = 0;
       break;
   }
-#ifdef DEBUG
+
   const char *errmsg = NULL;
   unsigned long sslerr;
 
@@ -315,15 +313,13 @@ static void ssl_err(struct SslSockData *data, int err)
   }
 
   mutt_debug(1, "SSL error: %s\n", errmsg);
-#endif
 }
 
 /**
- * ssl_dprint_err_stack - Dump the SSL error stack (DEBUG only)
+ * ssl_dprint_err_stack - Dump the SSL error stack
  */
 static void ssl_dprint_err_stack(void)
 {
-#ifdef DEBUG
   BIO *bio = NULL;
   char *buf = NULL;
   long buflen;
@@ -343,7 +339,6 @@ static void ssl_dprint_err_stack(void)
     FREE(&output);
   }
   BIO_free(bio);
-#endif
 }
 
 /**
@@ -1223,14 +1218,10 @@ static int ssl_verify_callback(int preverify_ok, X509_STORE_CTX *ctx)
       return 1;
     }
 
-#ifdef DEBUG
     /* log verification error */
-    {
-      int err = X509_STORE_CTX_get_error(ctx);
-      snprintf(buf, sizeof(buf), "%s (%d)", X509_verify_cert_error_string(err), err);
-      mutt_debug(2, "X509_verify_cert: %s\n", buf);
-    }
-#endif
+    int err = X509_STORE_CTX_get_error(ctx);
+    snprintf(buf, sizeof(buf), "%s (%d)", X509_verify_cert_error_string(err), err);
+    mutt_debug(2, "X509_verify_cert: %s\n", buf);
 
     /* prompt user */
     return interactive_check_cert(cert, pos, len, ssl, 1);

--- a/copy.c
+++ b/copy.c
@@ -611,18 +611,13 @@ int mutt_copy_message_fp(FILE *fpout, FILE *fpin, struct Header *hdr, int flags,
       if (copy_delete_attach(body, fpin, fpout, date))
         return -1;
 
-#ifdef DEBUG
+      LOFF_T fail = ((ftello(fpout) - new_offset) - new_length);
+      if (fail)
       {
-        LOFF_T fail = ((ftello(fpout) - new_offset) - new_length);
-
-        if (fail)
-        {
-          mutt_error("The length calculation was wrong by %ld bytes", fail);
-          new_length += fail;
-          mutt_sleep(1);
-        }
+        mutt_error("The length calculation was wrong by %ld bytes", fail);
+        new_length += fail;
+        mutt_sleep(1);
       }
-#endif
 
       /* Update original message if we are sync'ing a mailfolder */
       if (flags & MUTT_CM_UPDATE)

--- a/globals.h
+++ b/globals.h
@@ -222,10 +222,8 @@ WHERE short NntpPoll;
 WHERE short NntpContext;
 #endif
 
-#ifdef DEBUG
 WHERE short DebugLevel;
 WHERE char *DebugFile;
-#endif
 
 WHERE short History;
 WHERE short MenuContext;

--- a/hcache/kc.c
+++ b/hcache/kc.c
@@ -59,10 +59,8 @@ static void *hcache_kyotocabinet_open(const char *path)
     return db;
   else
   {
-#ifdef DEBUG
     int ecode = kcdbecode(db);
     mutt_debug(2, "kcdbopen failed for %s: %s (ecode %d)\n", kcdbpath, kcdbemsg(db), ecode);
-#endif
     kcdbdel(db);
     return NULL;
   }
@@ -122,10 +120,8 @@ static void hcache_kyotocabinet_close(void **ctx)
   KCDB *db = *ctx;
   if (!kcdbclose(db))
   {
-#ifdef DEBUG
     int ecode = kcdbecode(db);
     mutt_debug(2, "kcdbclose failed: %s (ecode %d)\n", kcdbemsg(db), ecode);
-#endif
   }
   kcdbdel(db);
 }

--- a/hcache/tc.c
+++ b/hcache/tc.c
@@ -49,11 +49,9 @@ static void *hcache_tokyocabinet_open(const char *path)
     return db;
   else
   {
-#ifdef DEBUG
     int ecode = tcbdbecode(db);
     mutt_debug(2, "tcbdbopen failed for %s: %s (ecode %d)\n", path,
                tcbdberrmsg(ecode), ecode);
-#endif
     tcbdbdel(db);
     return NULL;
   }
@@ -112,10 +110,8 @@ static void hcache_tokyocabinet_close(void **ctx)
   TCBDB *db = *ctx;
   if (!tcbdbclose(db))
   {
-#ifdef DEBUG
     int ecode = tcbdbecode(db);
     mutt_debug(2, "tcbdbclose failed: %s (ecode %d)\n", tcbdberrmsg(ecode), ecode);
-#endif
   }
   tcbdbdel(db);
 }

--- a/imap/auth_gss.c
+++ b/imap/auth_gss.c
@@ -104,10 +104,8 @@ enum ImapAuthRes imap_auth_gss(struct ImapData *idata, const char *method)
   gss_buffer_t sec_token;
   gss_name_t target_name;
   gss_ctx_id_t context;
-#ifdef DEBUG
   gss_OID mech_name;
   char server_conf_flags;
-#endif
   gss_qop_t quality;
   int cflags;
   OM_uint32 maj_stat, min_stat;
@@ -131,14 +129,12 @@ enum ImapAuthRes imap_auth_gss(struct ImapData *idata, const char *method)
     mutt_debug(2, "Couldn't get service name for [%s]\n", buf1);
     return IMAP_AUTH_UNAVAIL;
   }
-#ifdef DEBUG
   else if (debuglevel >= 2)
   {
     gss_display_name(&min_stat, target_name, &request_buf, &mech_name);
     mutt_debug(2, "Using service name [%s]\n", (char *) request_buf.value);
     gss_release_buffer(&min_stat, &request_buf);
   }
-#endif
   /* Acquire initial credentials - without a TGT GSSAPI is UNAVAIL */
   sec_token = GSS_C_NO_BUFFER;
   context = GSS_C_NO_CONTEXT;
@@ -244,9 +240,7 @@ enum ImapAuthRes imap_auth_gss(struct ImapData *idata, const char *method)
   mutt_debug(2, "Credential exchange complete\n");
 
 /* first octet is security levels supported. We want NONE */
-#ifdef DEBUG
   server_conf_flags = ((char *) send_token.value)[0];
-#endif
   if (!(((char *) send_token.value)[0] & GSS_AUTH_P_NONE))
   {
     mutt_debug(2, "Server requires integrity or privacy\n");

--- a/imap/auth_login.c
+++ b/imap/auth_login.c
@@ -71,13 +71,11 @@ enum ImapAuthRes imap_auth_login(struct ImapData *idata, const char *method)
   imap_quote_string(q_user, sizeof(q_user), idata->conn->account.user);
   imap_quote_string(q_pass, sizeof(q_pass), idata->conn->account.pass);
 
-#ifdef DEBUG
   /* don't print the password unless we're at the ungodly debugging level
    * of 5 or higher */
 
   if (debuglevel < IMAP_LOG_PASS)
     mutt_debug(2, "Sending LOGIN command for %s...\n", idata->conn->account.user);
-#endif
 
   snprintf(buf, sizeof(buf), "LOGIN %s %s", q_user, q_pass);
   rc = imap_exec(idata, buf, IMAP_CMD_FAIL_OK | IMAP_CMD_PASS);

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -849,10 +849,8 @@ int imap_read_literal(FILE *fp, struct ImapData *idata, long bytes, struct Progr
 
     if (pbar && !(pos % 1024))
       mutt_progress_update(pbar, pos, -1);
-#ifdef DEBUG
     if (debuglevel >= IMAP_LOG_LTRL)
       fputc(c, debugfile);
-#endif
   }
 
   return 0;
@@ -2190,7 +2188,6 @@ static int imap_open_mailbox(struct Context *ctx)
     ctx->readonly = true;
   }
 
-#ifdef DEBUG
   /* dump the mailbox flags we've found */
   if (debuglevel > 2)
   {
@@ -2210,7 +2207,6 @@ static int imap_open_mailbox(struct Context *ctx)
       FREE(&flag_buffer.data);
     }
   }
-#endif
 
   if (!(mutt_bit_isset(idata->ctx->rights, MUTT_ACL_DELETE) ||
         mutt_bit_isset(idata->ctx->rights, MUTT_ACL_SEEN) ||

--- a/init.c
+++ b/init.c
@@ -1958,7 +1958,6 @@ static int parse_alias(struct Buffer *buf, struct Buffer *s, unsigned long data,
   mutt_group_context_add_adrlist(gc, tmp->addr);
   mutt_alias_add_reverse(tmp);
 
-#ifdef DEBUG
   if (debuglevel >= 2)
   {
     /* A group is terminated with an empty address, so check a->mailbox */
@@ -1970,7 +1969,6 @@ static int parse_alias(struct Buffer *buf, struct Buffer *s, unsigned long data,
         mutt_debug(3, "  Group %s\n", a->mailbox);
     }
   }
-#endif
   mutt_group_context_destroy(&gc);
   return 0;
 
@@ -2102,11 +2100,9 @@ static void restore_default(struct Option *p)
     case DT_PATH:
       FREE((char **) p->data);
       char *init = NULL;
-#ifdef DEBUG
       if (mutt_str_strcmp(p->option, "debug_file") == 0 && debugfile_cmdline)
         init = debugfile_cmdline;
       else
-#endif
         init = (char *) p->init;
       if (init)
       {
@@ -2133,11 +2129,9 @@ static void restore_default(struct Option *p)
     case DT_NUMBER:
     case DT_SORT:
     case DT_MAGIC:
-#ifdef DEBUG
       if (mutt_str_strcmp(p->option, "debug_level") == 0 && debuglevel_cmdline)
         *((short *) p->data) = debuglevel_cmdline;
       else
-#endif
         *((short *) p->data) = p->init;
       break;
     case DT_REGEX:
@@ -2304,7 +2298,6 @@ char **mutt_envlist(void)
   return envlist;
 }
 
-#ifdef DEBUG
 /**
  * start_debug - prepare the debugging file
  *
@@ -2365,7 +2358,6 @@ static void restart_debug(void)
   if (enable_debug || (file_changed && debuglevel > 0))
     start_debug();
 }
-#endif
 
 /* mutt_envlist_set - Helper function for parse_setenv()
  * @param name      Name of the environment variable
@@ -2730,14 +2722,11 @@ static int parse_set(struct Buffer *tmp, struct Buffer *s, unsigned long data,
         }
         else if (DTYPE(MuttVars[idx].type) == DT_PATH)
         {
-#ifdef DEBUG
           if (mutt_str_strcmp(MuttVars[idx].option, "debug_file") == 0 && debugfile_cmdline)
           {
-            mutt_message(_("set debug_file ignored, it have been overridden "
-                           "with cmdline"));
+            mutt_message(_("set debug_file ignored, it has been overridden by the cmdline"));
             break;
           }
-#endif
           /* MuttVars[idx].data is already 'char**' (or some 'void**') or...
            * so cast to 'void*' is okay */
           FREE((void *) MuttVars[idx].data);
@@ -2745,10 +2734,8 @@ static int parse_set(struct Buffer *tmp, struct Buffer *s, unsigned long data,
           mutt_str_strfcpy(scratch, tmp->data, sizeof(scratch));
           mutt_expand_path(scratch, sizeof(scratch));
           *((char **) MuttVars[idx].data) = mutt_str_strdup(scratch);
-#ifdef DEBUG
           if (mutt_str_strcmp(MuttVars[idx].option, "debug_file") == 0)
             restart_debug();
-#endif
         }
         else if (DTYPE(MuttVars[idx].type) == DT_STRING)
         {
@@ -2904,14 +2891,11 @@ static int parse_set(struct Buffer *tmp, struct Buffer *s, unsigned long data,
         r = -1;
         break;
       }
-#ifdef DEBUG
       else if (mutt_str_strcmp(MuttVars[idx].option, "debug_level") == 0 && debuglevel_cmdline)
       {
-        mutt_message(
-            _("set debug_level ignored, it have been overridden with cmdline"));
+        mutt_message(_("set debug_level ignored, it has been overridden by the cmdline"));
         break;
       }
-#endif
       else
         *ptr = val;
 
@@ -2922,14 +2906,12 @@ static int parse_set(struct Buffer *tmp, struct Buffer *s, unsigned long data,
           *ptr = 0;
         mutt_init_history();
       }
-#ifdef DEBUG
       else if (mutt_str_strcmp(MuttVars[idx].option, "debug_level") == 0)
       {
         if (*ptr < 0)
           *ptr = 0;
         restart_debug();
       }
-#endif
       else if (mutt_str_strcmp(MuttVars[idx].option, "pager_index_lines") == 0)
       {
         if (*ptr < 0)
@@ -4079,7 +4061,6 @@ void mutt_init(int skip_sys_rc, struct ListHead *commands)
     Shell = mutt_str_strdup((p = getenv("SHELL")) ? p : "/bin/sh");
   }
 
-#ifdef DEBUG
   /* Start up debugging mode if requested from cmdline */
   if (debuglevel_cmdline > 0)
   {
@@ -4096,7 +4077,6 @@ void mutt_init(int skip_sys_rc, struct ListHead *commands)
     }
     start_debug();
   }
-#endif
 
   /* And about the host... */
 

--- a/init.h
+++ b/init.h
@@ -671,7 +671,6 @@ struct Option MuttVars[] = {
   ** rest of the string are expanded in the \fIC\fP locale (that is in US
   ** English).
   */
-#ifdef DEBUG
   { "debug_level", DT_NUMBER, R_NONE, UL &DebugLevel, 0 },
   /*
   ** .pp
@@ -687,7 +686,6 @@ struct Option MuttVars[] = {
   ** Old debug files are renamed with the prefix 1, 2, 3 and 4.
   ** See ``debug_level'' for more detail.
   */
-#endif
   { "default_hook",     DT_STRING,  R_NONE, UL &DefaultHook, UL "~f %s !~P | (~P ~C %s)" },
   /*
   ** .pp

--- a/main.c
+++ b/main.c
@@ -101,9 +101,7 @@ static void usage(void)
          "  -D            print the value of all variables to stdout\n"
          "  -D -S         like -D, but hide the value of sensitive variables\n"
          "  -B            run in batch mode (do not start the ncurses UI)"));
-#ifdef DEBUG
   puts(_("  -d <level>    log debugging output to ~/.neomuttdebug0"));
-#endif
   puts(_(
          "  -E            edit the draft (-H) or include (-i) file\n"
          "  -e <command>  specify a command to be executed after initialization\n"
@@ -318,17 +316,12 @@ int main(int argc, char **argv, char **env)
           break;
 
         case 'd':
-#ifdef DEBUG
           if (mutt_str_atoi(optarg, &debuglevel_cmdline) < 0 || debuglevel_cmdline <= 0)
           {
             fprintf(stderr, _("Error: value '%s' is invalid for -d.\n"), optarg);
             return 1;
           }
           printf(_("Debugging at level %d.\n"), debuglevel_cmdline);
-#else
-          printf("%s",
-                 _("DEBUG was not defined during compilation. -d Ignored.\n"));
-#endif
           break;
 
         case 'E':
@@ -348,12 +341,8 @@ int main(int argc, char **argv, char **env)
           break;
 
         case 'l':
-#ifdef DEBUG
           debugfile_cmdline = optarg;
           printf(_("Debugging at file %s.\n"), debugfile_cmdline);
-#else
-          printf(_("DEBUG was not defined during compilation. -l Ignored.\n"));
-#endif
           break;
 
         case 'm':

--- a/mutt.h
+++ b/mutt.h
@@ -345,12 +345,10 @@ const char *mutt_str_sysexit(int e);
 
 char *mutt_compile_help(char *buf, size_t buflen, int menu, const struct Mapping *items);
 
-#ifdef DEBUG
 extern char debugfilename[_POSIX_PATH_MAX];
 extern FILE *debugfile;
 extern int debuglevel;
 extern char *debugfile_cmdline;
 extern int debuglevel_cmdline;
-#endif
 
 #endif /* _MUTT_H */

--- a/mutt/debug.h
+++ b/mutt/debug.h
@@ -23,11 +23,7 @@
 #ifndef _MUTT_DEBUG_H
 #define _MUTT_DEBUG_H
 
-#ifdef DEBUG
 int mutt_debug_real(const char *function, const char *file, int line, int level, ...);
 #define mutt_debug(LEVEL, ...) mutt_debug_real(__func__, __FILE__, __LINE__, LEVEL, __VA_ARGS__)
-#else
-#define mutt_debug(...) do { } while (0)
-#endif
 
 #endif /* _MUTT_DEBUG_H */

--- a/mutt_notmuch.c
+++ b/mutt_notmuch.c
@@ -689,9 +689,7 @@ err:
 
 static int update_header_tags(struct Header *h, notmuch_message_t *msg)
 {
-#ifdef DEBUG
   struct NmHdrData *data = h->data;
-#endif
   notmuch_tags_t *tags = NULL;
   char *new_tags = NULL;
   char *old_tags = NULL;

--- a/muttlib.c
+++ b/muttlib.c
@@ -930,9 +930,7 @@ void mutt_expando_format(char *buf, size_t buflen, size_t col, int cols, const c
     {
       struct Buffer *srcbuf = NULL, *word = NULL, *command = NULL;
       char srccopy[LONG_STRING];
-#ifdef DEBUG
       int i = 0;
-#endif
 
       mutt_debug(3, "fmtpipe = %s\n", src);
 
@@ -1782,7 +1780,6 @@ void mutt_get_parent_path(char *output, char *path, size_t olen)
   }
 }
 
-#ifdef DEBUG
 char debugfilename[_POSIX_PATH_MAX];
 FILE *debugfile = NULL;
 int debuglevel;
@@ -1813,7 +1810,6 @@ int mutt_debug_real(const char *function, const char *file, int line, int level,
   va_end(ap);
   return ret;
 }
-#endif
 
 /**
  * mutt_inbox_cmp - do two folders share the same path and one is an inbox

--- a/ncrypt/crypt.c
+++ b/ncrypt/crypt.c
@@ -92,8 +92,7 @@ void crypt_forget_passphrase(void)
     mutt_message(_("Passphrase(s) forgotten."));
 }
 
-#if (!defined(DEBUG))
-
+#ifndef DEBUG
 #include <sys/resource.h>
 static void disable_coredumps(void)
 {
@@ -106,7 +105,6 @@ static void disable_coredumps(void)
     done = true;
   }
 }
-
 #endif
 
 /**
@@ -116,7 +114,7 @@ int crypt_valid_passphrase(int flags)
 {
   int rc = 0;
 
-#if !defined(DEBUG)
+#ifndef DEBUG
   disable_coredumps();
 #endif
 

--- a/nntp.c
+++ b/nntp.c
@@ -406,10 +406,8 @@ static int nntp_auth(struct NntpServer *nserv)
         /* username accepted, sending password */
         if (mutt_str_strncmp("381", buf, 3) == 0)
         {
-#ifdef DEBUG
           if (debuglevel < MUTT_SOCK_LOG_FULL)
             mutt_debug(MUTT_SOCK_LOG_CMD, "%d> AUTHINFO PASS *\n", conn->fd);
-#endif
           snprintf(buf, sizeof(buf), "AUTHINFO PASS %s\r\n", conn->account.pass);
           if (mutt_socket_write_d(conn, buf, -1, MUTT_SOCK_LOG_FULL) < 0 ||
               mutt_socket_readln(buf, sizeof(buf), conn) < 0)
@@ -468,7 +466,6 @@ static int nntp_auth(struct NntpServer *nserv)
           /* send out client response */
           if (client_len)
           {
-#ifdef DEBUG
             if (debuglevel >= MUTT_SOCK_LOG_FULL)
             {
               char tmp[LONG_STRING];
@@ -481,7 +478,6 @@ static int nntp_auth(struct NntpServer *nserv)
               *p = '\0';
               mutt_debug(1, "SASL> %s\n", tmp);
             }
-#endif
 
             if (*buf)
               mutt_str_strcat(buf, sizeof(buf), " ");
@@ -495,7 +491,6 @@ static int nntp_auth(struct NntpServer *nserv)
           }
 
           mutt_str_strcat(buf, sizeof(buf), "\r\n");
-#ifdef DEBUG
           if (debuglevel < MUTT_SOCK_LOG_FULL)
           {
             if (strchr(buf, ' '))
@@ -504,7 +499,6 @@ static int nntp_auth(struct NntpServer *nserv)
             else
               mutt_debug(MUTT_SOCK_LOG_CMD, "%d> sasl_data\n", conn->fd);
           }
-#endif
           client_len = 0;
           if (mutt_socket_write_d(conn, buf, -1, MUTT_SOCK_LOG_FULL) < 0 ||
               mutt_socket_readln_d(inbuf, sizeof(inbuf), conn, MUTT_SOCK_LOG_FULL) < 0)
@@ -514,19 +508,15 @@ static int nntp_auth(struct NntpServer *nserv)
           if ((mutt_str_strncmp(inbuf, "283 ", 4) != 0) &&
               (mutt_str_strncmp(inbuf, "383 ", 4) != 0))
           {
-#ifdef DEBUG
             if (debuglevel < MUTT_SOCK_LOG_FULL)
               mutt_debug(MUTT_SOCK_LOG_CMD, "%d< %s\n", conn->fd, inbuf);
-#endif
             break;
           }
-#ifdef DEBUG
           if (debuglevel < MUTT_SOCK_LOG_FULL)
           {
             inbuf[3] = '\0';
             mutt_debug(MUTT_SOCK_LOG_CMD, "%d< %s sasl_data\n", conn->fd, inbuf);
           }
-#endif
 
           if (strcmp("=", inbuf + 4) == 0)
             len = 0;
@@ -536,7 +526,6 @@ static int nntp_auth(struct NntpServer *nserv)
             mutt_debug(1, "error base64-decoding server response.\n");
             break;
           }
-#ifdef DEBUG
           else if (debuglevel >= MUTT_SOCK_LOG_FULL)
           {
             char tmp[LONG_STRING];
@@ -549,7 +538,6 @@ static int nntp_auth(struct NntpServer *nserv)
             *p = '\0';
             mutt_debug(1, "SASL< %s\n", tmp);
           }
-#endif
 
           while (true)
           {

--- a/pop_auth.c
+++ b/pop_auth.c
@@ -295,10 +295,8 @@ static enum PopAuthRes pop_auth_user(struct PopData *pop_data, const char *metho
   {
     snprintf(buf, sizeof(buf), "PASS %s\r\n", pop_data->conn->account.pass);
     ret = pop_query_d(pop_data, buf, sizeof(buf),
-#ifdef DEBUG
                       /* don't print the password unless we're at the ungodly debugging level */
                       debuglevel < MUTT_SOCK_LOG_FULL ? "PASS *\r\n" :
-#endif
                                                         NULL);
   }
 

--- a/pop_lib.c
+++ b/pop_lib.c
@@ -469,14 +469,12 @@ int pop_query_d(struct PopData *pop_data, char *buf, size_t buflen, char *msg)
   if (pop_data->status != POP_CONNECTED)
     return -1;
 
-#ifdef DEBUG
   /* print msg instead of real command */
   if (msg)
   {
     dbg = MUTT_SOCK_LOG_FULL;
     mutt_debug(MUTT_SOCK_LOG_CMD, "> %s", msg);
   }
-#endif
 
   mutt_socket_write_d(pop_data->conn, buf, -1, dbg);
 

--- a/rfc3676.c
+++ b/rfc3676.c
@@ -351,11 +351,9 @@ int rfc3676_handler(struct Body *a, struct State *s)
  */
 void rfc3676_space_stuff(struct Header *hdr)
 {
-#ifdef DEBUG
   int lc = 0;
   size_t len = 0;
   unsigned char c = '\0';
-#endif
   FILE *in = NULL, *out = NULL;
   char buf[LONG_STRING];
   char tmpfile[_POSIX_PATH_MAX];
@@ -382,7 +380,6 @@ void rfc3676_space_stuff(struct Header *hdr)
     if ((mutt_str_strncmp("From ", buf, 5) == 0) || buf[0] == ' ')
     {
       fputc(' ', out);
-#ifdef DEBUG
       lc++;
       len = mutt_str_strlen(buf);
       if (len > 0)
@@ -393,7 +390,6 @@ void rfc3676_space_stuff(struct Header *hdr)
       mutt_debug(4, "f=f: line %d needs space-stuffing: '%s'\n", lc, buf);
       if (len > 0)
         buf[len - 1] = c;
-#endif
     }
     fputs(buf, out);
   }

--- a/version.c
+++ b/version.c
@@ -109,6 +109,7 @@ static struct CompileOptions comp_opts_default[] = {
   { "compose_to_sender", 1 },
   { "compress", 1 },
   { "cond_date", 1 },
+  { "debug", 1 },
   { "encrypt_to_self", 1 },
   { "forgotten_attachments", 1 },
   { "forwref", 1 },
@@ -152,11 +153,6 @@ static struct CompileOptions comp_opts[] = {
   { "curs_set", 1 },
 #else
   { "curs_set", 0 },
-#endif
-#ifdef DEBUG
-  { "debug", 1 },
-#else
-  { "debug", 0 },
 #endif
 #ifdef USE_FCNTL
   { "fcntl", 1 },


### PR DESCRIPTION
* **What does this PR do?**

    * removes `--enable-debug` compile option
    * remove `#define` DEBUG and corresponding `#ifdef`. This is fine IMHO, because debugging code usually doesn't need to be refactored. Or more precisely: "making a tighter integration into the sidebar easier" was a reason to not touch `#ifdef` of e.g. IMAP. This doesn't apply to `DEBUG`.
    * non-debug being the default is **not** changed.

* **Are there points in the code the reviewer needs to double check?**

    * [imap/auth_gss.c](https://github.com/neomutt/neomutt/compare/master...devel/persistent-debug#diff-092fac0ebe696f5a8bd7856d7fba9621R82)
    * [rfc3676.c](https://github.com/neomutt/neomutt/compare/master...devel/persistent-debug#diff-f0eb956c12d2e70484cf45af91dc0f5fR354)
    * [imap/auth_gss.c](https://github.com/neomutt/neomutt/compare/master...devel/persistent-debug#diff-092fac0ebe696f5a8bd7856d7fba9621R220)
    the above are variables where its not obvious that their purpose is for debugging. I agree that the `#ifdef` around these places makes the purpose clearer as with comments. However, i the removal of `#ifdef DEBUG` is still more "lean" in the other places. Therefore, I'm unsure what to do here, if commenting `// debug ` is really good.

* **What are the relevant issue numbers?**

#552 #389 

* **further TODO:**

    * update translations (i guess? i'm not sure)
    * update documentation

@neomutt/reviewers please review.