### PR TITLE
doc: fix spaces in NNTP part of the manual

### DIFF
--- a/doc/manual.xml.head
+++ b/doc/manual.xml.head
@@ -94,7 +94,7 @@
       <title>Typographical Conventions</title>
       <para>This section lists typographical conventions followed throughout
       this manual. See table
-      <xref linkend="tab-typo" />for typographical conventions for special
+      <xref linkend="tab-typo" /> for typographical conventions for special
       terms.</para>
 
       <table id="tab-typo">
@@ -237,7 +237,7 @@
       <para>Besides an interactive mode, Mutt can also be used as a
       command-line tool only send messages. It also supports a
       <literal>mailx(1)</literal>-compatible interface, see
-      <xref linkend="tab-commandline-options" />for a complete list of
+      <xref linkend="tab-commandline-options" /> for a complete list of
       command-line options.</para>
     </sect1>
 
@@ -337,7 +337,7 @@ Seas          1/7|  4    ! Feb 28  Summer Jackson   (264)  Lemon
         <sect3 id="intro-sidebar-navigation">
           <title>Navigation</title>
           <para>The Sidebar adds some new
-          <link linkend="sidebar-functions">functions</link>to Mutt.</para>
+          <link linkend="sidebar-functions">functions</link> to Mutt.</para>
           <para>The user pressed the
           <quote>c</quote>key to
           <literal>&lt;change-folder&gt;</literal>to the
@@ -557,7 +557,7 @@ set sidebar_divider_char = '│'          <emphasis role="comment"># Pretty line
             <para>
             <literal>$sidebar_format</literal>allows you to customize the
             Sidebar display. For an introduction, read
-            <link linkend="index-format">format strings</link>including the
+            <link linkend="index-format">format strings</link> including the
             section about
             <link linkend="formatstrings-conditionals">
             conditionals</link>.</para>
@@ -1038,8 +1038,8 @@ color sidebar_divider   color8  default
       <title>Moving Around in Menus</title>
       <para>The most important navigation keys common to line- or entry-based
       menus are shown in
-      <xref linkend="tab-keys-nav-line" />and in
-      <xref linkend="tab-keys-nav-page" />for page-based menus.</para>
+      <xref linkend="tab-keys-nav-line" /> and in
+      <xref linkend="tab-keys-nav-page" /> for page-based menus.</para>
 
       <table id="tab-keys-nav-line">
         <title>Most common navigation keys in entry-based menus</title>
@@ -1178,7 +1178,7 @@ color sidebar_divider   color8  default
         <para>Mutt has a built-in line editor for inputting text, e.g. email
         addresses or filenames. The keys used to manipulate text input are very
         similar to those of Emacs. See
-        <xref linkend="tab-keys-editor" />for a full reference of available
+        <xref linkend="tab-keys-editor" /> for a full reference of available
         functions, their default key bindings, and short descriptions.</para>
 
         <table id="tab-keys-editor">
@@ -1359,9 +1359,9 @@ color sidebar_divider   color8  default
         <title>History</title>
         <para>Mutt maintains a history for the built-in editor. The number of
         items is controlled by the
-        <link linkend="history">$history</link>variable and can be made
+        <link linkend="history">$history</link> variable and can be made
         persistent using an external file specified using
-        <link linkend="history-file">$history_file</link>and
+        <link linkend="history-file">$history_file</link> and
         <link linkend="save-history">$save_history</link>. You may cycle
         through them at an editor prompt by using the
         <literal>&lt;history-up&gt;</literal>and/or
@@ -1393,7 +1393,7 @@ color sidebar_divider   color8  default
         </itemizedlist>
         <para>Mutt automatically filters out consecutively repeated items from
         the history. If
-        <link linkend="history-remove-dups">$history_remove_dups</link>is set,
+        <link linkend="history-remove-dups">$history_remove_dups</link> is set,
         all repeated items are removed from the history. It also mimics the
         behavior of some shells by ignoring items starting with a space. The
         latter feature can be useful in macros to not clobber the history's
@@ -1418,7 +1418,7 @@ color sidebar_divider   color8  default
         index are shown in
         <xref linkend="tab-key-index" />. How messages are presented in the
         index menu can be customized using the
-        <link linkend="index-format">$index_format</link>variable.</para>
+        <link linkend="index-format">$index_format</link> variable.</para>
 
         <table id="tab-key-index">
           <title>Most common message index keys</title>
@@ -1553,16 +1553,16 @@ color sidebar_divider   color8  default
         summary of the disposition of each message is printed beside the
         message number. Zero or more of the
         <quote>flags</quote>in
-        <xref linkend="tab-msg-status-flags" />may appear, some of which can be
+        <xref linkend="tab-msg-status-flags" /> may appear, some of which can be
         turned on or off using these functions:
         <literal>&lt;set-flag&gt;</literal>and
         <literal>&lt;clear-flag&gt;</literal>bound by default to
         <quote>w</quote>and
         <quote>W</quote>respectively.</para>
         <para>Furthermore, the flags in
-        <xref linkend="tab-msg-recip-flags" />reflect who the message is
+        <xref linkend="tab-msg-recip-flags" /> reflect who the message is
         addressed to. They can be customized with the
-        <link linkend="to-chars">$to_chars</link>variable.</para>
+        <link linkend="to-chars">$to_chars</link> variable.</para>
 
         <table id="tab-msg-status-flags">
           <title>Message status flags</title>
@@ -1672,7 +1672,7 @@ color sidebar_divider   color8  default
         <para>By default, Mutt uses its built-in pager to display the contents
         of messages (an external pager such as
         <literal>less(1)</literal>can be configured, see
-        <link linkend="pager">$pager</link>variable). The pager is very similar
+        <link linkend="pager">$pager</link> variable). The pager is very similar
         to the Unix program
         <literal>less(1)</literal>though not nearly as featureful.</para>
 
@@ -1748,7 +1748,7 @@ color sidebar_divider   color8  default
         <quote>_</quote>for denoting underline. Mutt will attempt to display
         these in bold and underline respectively if your terminal supports
         them. If not, you can use the bold and underline
-        <link linkend="color">color</link>objects to specify a
+        <link linkend="color">color</link> objects to specify a
         <command>color</command>or mono attribute for them.</para>
         <para>Additionally, the internal pager supports the ANSI escape
         sequences for character attributes. Mutt translates them into the
@@ -1858,7 +1858,7 @@ color sidebar_divider   color8  default
         <para>Mutt uses these attributes for handling
         <literal>text/enriched</literal>messages, and they can also be used by
         an external
-        <link linkend="auto-view">autoview</link>script for highlighting
+        <link linkend="auto-view">autoview</link> script for highlighting
         purposes.</para>
         <note>
           <para>If you change the colors for your display, for example by
@@ -1868,7 +1868,7 @@ color sidebar_divider   color8  default
         <note>
           <para>Note that the search commands in the pager take regular
           expressions, which are not quite the same as the more complex
-          <link linkend="patterns">patterns</link>used by the search command in
+          <link linkend="patterns">patterns</link> used by the search command in
           the index. This is because patterns are used to select messages by
           criteria whereas the pager already displays a selected
           message.</para>
@@ -1883,7 +1883,7 @@ color sidebar_divider   color8  default
         extremely useful in mailing lists where different parts of the
         discussion diverge. Mutt displays threads as a tree structure.</para>
         <para>In Mutt, when a mailbox is
-        <link linkend="sort">sorted</link>by
+        <link linkend="sort">sorted</link> by
         <emphasis>threads</emphasis>, there are a few additional functions
         available in the
         <emphasis>index</emphasis>and
@@ -2009,7 +2009,7 @@ color sidebar_divider   color8  default
         <link linkend="index-format">$index_format</link>. For example, you
         could use
         <quote>%?M?(#%03M)&amp;(%4l)?</quote>in
-        <link linkend="index-format">$index_format</link>to optionally display
+        <link linkend="index-format">$index_format</link> to optionally display
         the number of hidden messages if the thread is collapsed. The
         <literal>
         %?&lt;char&gt;?&lt;if-part&gt;&amp;&lt;else-part&gt;?</literal>syntax
@@ -2019,7 +2019,7 @@ color sidebar_divider   color8  default
         <para>Technically, every reply should contain a list of its parent
         messages in the thread tree, but not all do. In these cases, Mutt
         groups them by subject which can be controlled using the
-        <link linkend="strict-threads">$strict_threads</link>variable.</para>
+        <link linkend="strict-threads">$strict_threads</link> variable.</para>
       </sect2>
 
       <sect2 id="reading-misc">
@@ -2039,11 +2039,11 @@ color sidebar_divider   color8  default
               <link linkend="alias">
                 <command>alias</command>
               </link>command is added to the file specified by the
-              <link linkend="alias-file">$alias_file</link>variable for future
+              <link linkend="alias-file">$alias_file</link> variable for future
               use</para>
               <note>
                 <para>Mutt does not read the
-                <link linkend="alias-file">$alias_file</link>upon startup so
+                <link linkend="alias-file">$alias_file</link> upon startup so
                 you must explicitly
                 <link linkend="source">
                   <command>source</command>
@@ -2109,7 +2109,7 @@ color sidebar_divider   color8  default
               <para>This command is used to execute any command you would
               normally put in a configuration file. A common use is to check
               the settings of variables, or in conjunction with
-              <link linkend="macro">macros</link>to change settings on the
+              <link linkend="macro">macros</link> to change settings on the
               fly.</para>
             </listitem>
           </varlistentry>
@@ -2141,10 +2141,10 @@ color sidebar_divider   color8  default
               addresses which match the regular expressions given by the
               <link linkend="lists">
               <command>lists</command>or
-              <command>subscribe</command></link>commands, but also honor any
+              <command>subscribe</command></link> commands, but also honor any
               <literal>Mail-Followup-To</literal>header(s) if the
               <link linkend="honor-followup-to">
-              $honor_followup_to</link>configuration variable is set. In
+              $honor_followup_to</link> configuration variable is set. In
               addition, the
               <literal>List-Post</literal>header field is examined for
               <literal>mailto:</literal>URLs specifying a mailing list address.
@@ -2162,8 +2162,8 @@ color sidebar_divider   color8  default
               tagged message(s) to it. The variables
               <link linkend="pipe-decode">$pipe_decode</link>,
               <link linkend="pipe-split">$pipe_split</link>,
-              <link linkend="pipe-sep">$pipe_sep</link>and
-              <link linkend="wait-key">$wait_key</link>control the exact
+              <link linkend="pipe-sep">$pipe_sep</link> and
+              <link linkend="wait-key">$wait_key</link> control the exact
               behavior of this function.</para>
             </listitem>
           </varlistentry>
@@ -2177,7 +2177,7 @@ color sidebar_divider   color8  default
               arbitrary folders". It can conveniently be used to forward MIME
               messages while preserving the original mail structure. Note that
               the amount of headers included here depends on the value of the
-              <link linkend="weed">$weed</link>variable.</para>
+              <link linkend="weed">$weed</link> variable.</para>
               <para>This function is also available from the attachment menu.
               You can use this to easily resend a message which was included
               with a bounce message as a
@@ -2190,7 +2190,7 @@ color sidebar_divider   color8  default
             <anchor id="shell-escape" />(default: !)</term>
             <listitem>
               <para>Asks for an external Unix command and executes it. The
-              <link linkend="wait-key">$wait_key</link>can be used to control
+              <link linkend="wait-key">$wait_key</link> can be used to control
               whether Mutt will wait for a key to be pressed when the command
               returns (presumably to let the user read the output of the
               command), based on the return status of the named command. If no
@@ -2203,7 +2203,7 @@ color sidebar_divider   color8  default
             <anchor id="toggle-quoted" />(default: T)</term>
             <listitem>
               <para>The pager uses the
-              <link linkend="quote-regexp">$quote_regexp</link>variable to
+              <link linkend="quote-regexp">$quote_regexp</link> variable to
               detect quoted text when displaying the body of the message. This
               function toggles the display of the quoted material in the
               message. It is particularly useful when being interested in just
@@ -2231,7 +2231,7 @@ color sidebar_divider   color8  default
       <sect2 id="sending-intro">
         <title>Introduction</title>
         <para>The bindings shown in
-        <xref linkend="tab-key-send" />are available in the
+        <xref linkend="tab-key-send" /> are available in the
         <emphasis>index</emphasis>and
         <emphasis>pager</emphasis>to start a new message.</para>
 
@@ -2322,7 +2322,7 @@ color sidebar_divider   color8  default
         <link linkend="autoedit">$autoedit</link>,
         <link linkend="bounce">$bounce</link>,
         <link linkend="fast-reply">$fast_reply</link>, and
-        <link linkend="include">$include</link>for changing how and if Mutt
+        <link linkend="include">$include</link> for changing how and if Mutt
         asks these questions.</para>
         <para>When replying, Mutt fills these fields with proper values
         depending on the reply type. The types of replying supported
@@ -2349,30 +2349,30 @@ color sidebar_divider   color8  default
             <listitem>
               <para>Reply to all mailing list addresses found, either specified
               via configuration or auto-detected. See
-              <xref linkend="lists" />for details.</para>
+              <xref linkend="lists" /> for details.</para>
             </listitem>
           </varlistentry>
         </variablelist>
         <para>After getting recipients for new messages, forwards or replies,
         Mutt will then automatically start your
-        <link linkend="editor">$editor</link>on the message body. If the
-        <link linkend="edit-headers">$edit_headers</link>variable is set, the
+        <link linkend="editor">$editor</link> on the message body. If the
+        <link linkend="edit-headers">$edit_headers</link> variable is set, the
         headers will be at the top of the message in your editor; the message
         body should start on a new line after the existing blank line at the
         end of headers. Any messages you are replying to will be added in sort
         order to the message, with appropriate
         <link linkend="attribution">$attribution</link>,
-        <link linkend="indent-string">$indent_string</link>and
+        <link linkend="indent-string">$indent_string</link> and
         <link linkend="post-indent-string">$post_indent_string</link>. When
         forwarding a message, if the
-        <link linkend="mime-forward">$mime_forward</link>variable is unset, a
+        <link linkend="mime-forward">$mime_forward</link> variable is unset, a
         copy of the forwarded message will be included. If you have specified a
         <link linkend="signature">$signature</link>, it will be appended to the
         message.</para>
         <para>Once you have finished editing the body of your mail message, you
         are returned to the
         <emphasis>compose</emphasis>menu providing the functions shown in
-        <xref linkend="tab-func-compose" />to modify, send or postpone the
+        <xref linkend="tab-func-compose" /> to modify, send or postpone the
         message.</para>
 
         <table id="tab-func-compose">
@@ -2539,7 +2539,7 @@ color sidebar_divider   color8  default
           <para>Note that certain operations like composing a new mail,
           replying, forwarding, etc. are not permitted when you are in that
           folder. The %r in
-          <link linkend="status-format">$status_format</link>will change to a
+          <link linkend="status-format">$status_format</link> will change to a
           <quote>A</quote>to indicate that you are in attach-message
           mode.</para>
         </note>
@@ -2548,7 +2548,7 @@ color sidebar_divider   color8  default
       <sect2 id="edit-header">
         <title>Editing the Message Header</title>
         <para>When editing the header because of
-        <link linkend="edit-headers">$edit_headers</link>being set, there are a
+        <link linkend="edit-headers">$edit_headers</link> being set, there are a
         several pseudo headers available which will not be included in sent
         messages but trigger special Mutt behavior.</para>
 
@@ -2595,7 +2595,7 @@ color sidebar_divider   color8  default
           <quote>E</quote>selects encryption,
           <quote>S</quote>selects signing and
           <quote>S&lt;id&gt;</quote>selects signing with the given key, setting
-          <link linkend="pgp-sign-as">$pgp_sign_as</link>permanently. The
+          <link linkend="pgp-sign-as">$pgp_sign_as</link> permanently. The
           selection can later be changed in the compose menu.</para>
         </sect3>
 
@@ -2724,7 +2724,7 @@ color sidebar_divider   color8  default
           <para>Mutt only supports setting the required
           <literal>format=flowed</literal>MIME parameter on outgoing messages
           if the
-          <link linkend="text-flowed">$text_flowed</link>variable is set,
+          <link linkend="text-flowed">$text_flowed</link> variable is set,
           specifically it does not add the trailing spaces.</para>
           <para>After editing the initial message text and before entering the
           compose menu, Mutt properly space-stuffs the message.
@@ -2784,7 +2784,7 @@ color sidebar_divider   color8  default
           replying to
           <literal>format=flowed</literal>messages. In order to take advantage
           of these,
-          <link linkend="reflow-text">$reflow_text</link>must be set.</para>
+          <link linkend="reflow-text">$reflow_text</link> must be set.</para>
           <itemizedlist>
             <listitem>
               <para>Paragraphs are automatically reflowed and wrapped at a
@@ -2796,14 +2796,14 @@ color sidebar_divider   color8  default
               <literal>format=flowed</literal>messages can be difficult to
               read, and doesn't intermix well with non-flowed replies. Setting
               <link linkend="reflow-space-quotes">
-              $reflow_space_quotes</link>adds spaces after each level of
+              $reflow_space_quotes</link> adds spaces after each level of
               quoting when in the pager and replying in a non-flowed format
               (i.e. with
-              <link linkend="text-flowed">$text_flowed</link>unset).</para>
+              <link linkend="text-flowed">$text_flowed</link> unset).</para>
             </listitem>
             <listitem>
               <para>If
-              <link linkend="reflow-space-quotes">$reflow_space_quotes</link>is
+              <link linkend="reflow-space-quotes">$reflow_space_quotes</link> is
               unset, mutt will still add one trailing space after all the
               quotes in the pager (but not when replying).</para>
             </listitem>
@@ -2827,22 +2827,22 @@ color sidebar_divider   color8  default
       <para>Forwarding can be done by including the original message in the new
       message's body (surrounded by indicating lines) or including it as a MIME
       attachment, depending on the value of the
-      <link linkend="mime-forward">$mime_forward</link>variable. Decoding of
+      <link linkend="mime-forward">$mime_forward</link> variable. Decoding of
       attachments, like in the pager, can be controlled by the
-      <link linkend="forward-decode">$forward_decode</link>and
-      <link linkend="mime-forward-decode">$mime_forward_decode</link>variables,
+      <link linkend="forward-decode">$forward_decode</link> and
+      <link linkend="mime-forward-decode">$mime_forward_decode</link> variables,
       respectively. The desired forwarding format may depend on the content,
       therefore
-      <link linkend="mime-forward">$mime_forward</link>is a quadoption which,
+      <link linkend="mime-forward">$mime_forward</link> is a quadoption which,
       for example, can be set to
       <quote>ask-no</quote>.</para>
       <para>The inclusion of headers is controlled by the current setting of
       the
-      <link linkend="weed">$weed</link>variable, unless
-      <link linkend="mime-forward">$mime_forward</link>is set.</para>
+      <link linkend="weed">$weed</link> variable, unless
+      <link linkend="mime-forward">$mime_forward</link> is set.</para>
       <para>By default a forwarded message does not reference the messages it
       contains. When
-      <link linkend="forward-references">$forward_references</link>is set, a
+      <link linkend="forward-references">$forward_references</link> is set, a
       forwarded message includes the
       <quote>In-Reply-To:</quote>and
       <quote>References:</quote>headers, just like a reply would. Hence the
@@ -2859,7 +2859,7 @@ color sidebar_divider   color8  default
       <literal>&lt;postpone-message&gt;</literal>function is used in the
       <emphasis>compose</emphasis>menu, the body of your message and
       attachments are stored in the mailbox specified by the
-      <link linkend="postponed">$postponed</link>variable. This means that you
+      <link linkend="postponed">$postponed</link> variable. This means that you
       can recall the message even if you exit Mutt and then restart it at a
       later time.</para>
       <para>Once a message is postponed, there are several ways to resume it.
@@ -2877,7 +2877,7 @@ color sidebar_divider   color8  default
         to for the status of the message to be updated.</para>
       </note>
       <para>See also the
-      <link linkend="postpone">$postpone</link>quad-option.</para>
+      <link linkend="postpone">$postpone</link> quad-option.</para>
     </sect1>
   </chapter>
 
@@ -3152,7 +3152,7 @@ over several lines"
       <quote>sent_on_kremvax</quote>if the environment variable
       <literal>$HOSTNAME</literal>is set to
       <quote>kremvax.</quote>(See
-      <link linkend="record">$record</link>for details.)</para>
+      <link linkend="record">$record</link> for details.)</para>
       <para>Mutt expands the variable when it is assigned, not when it is used.
       If the value of a variable on the right-hand side of an assignment
       changes after the assignment, the variable on the left-hand side will not
@@ -3162,12 +3162,12 @@ over several lines"
       <link linkend="commands">command reference</link>.</para>
       <para>All configuration files are expected to be in the current locale as
       specified by the
-      <link linkend="charset">$charset</link>variable which doesn't have a
+      <link linkend="charset">$charset</link> variable which doesn't have a
       default value since it's determined by Mutt at startup. If a
       configuration file is not encoded in the same character set the
-      <link linkend="config-charset">$config_charset</link>variable should be
+      <link linkend="config-charset">$config_charset</link> variable should be
       used: all lines starting with the next are recoded from
-      <link linkend="config-charset">$config_charset</link>to
+      <link linkend="config-charset">$config_charset</link> to
       <link linkend="charset">$charset</link>.</para>
       <para>This mechanism should be avoided if possible as it has the
       following implications:</para>
@@ -3175,13 +3175,13 @@ over several lines"
         <listitem>
           <para>These variables should be set early in a configuration file
           with
-          <link linkend="charset">$charset</link>preceding
-          <link linkend="config-charset">$config_charset</link>so Mutt knows
+          <link linkend="charset">$charset</link> preceding
+          <link linkend="config-charset">$config_charset</link> so Mutt knows
           what character set to convert to.</para>
         </listitem>
         <listitem>
           <para>If
-          <link linkend="config-charset">$config_charset</link>is set, it
+          <link linkend="config-charset">$config_charset</link> is set, it
           should be set in each configuration file because the value is global
           and
           <emphasis>not</emphasis>per configuration file.</para>
@@ -3238,7 +3238,7 @@ over several lines"
       <para>Mutt supports grouping addresses logically into named groups. An
       address or address pattern can appear in several groups at the same time.
       These groups can be used in
-      <link linkend="patterns">patterns</link>(for searching, limiting and
+      <link linkend="patterns">patterns</link> (for searching, limiting and
       tagging) and in hooks by using group patterns. This can be useful to
       classify mail and take certain actions depending on in what groups the
       message is. For example, the mutt user's mailing list would fit into the
@@ -3364,7 +3364,7 @@ alias theguys manny, moe, jack
       <link linkend="create-alias">
         <literal>&lt;create-alias&gt;</literal>
       </link>function can use only one file, the one pointed to by the
-      <link linkend="alias-file">$alias_file</link>variable (which is
+      <link linkend="alias-file">$alias_file</link> variable (which is
       <literal>~/.muttrc</literal>by default). This file is not special either,
       in the sense that Mutt will happily append aliases to any file, but in
       order for the new aliases to take effect you need to explicitly
@@ -3384,7 +3384,7 @@ set alias_file=~/.mail_aliases
       <emphasis>To:</emphasis>or
       <emphasis>Cc:</emphasis>prompt. You can also enter aliases in your editor
       at the appropriate headers if you have the
-      <link linkend="edit-headers">$edit_headers</link>variable set.</para>
+      <link linkend="edit-headers">$edit_headers</link> variable set.</para>
       <para>In addition, at the various address prompts, you can use the tab
       character to expand a partial alias to the full alias. If there are
       multiple matches, Mutt will bring up a menu with the matching aliases. In
@@ -3744,13 +3744,13 @@ bind index gg first-entry</screen>
       the
       <literal>.muttrc</literal>.</para>
       <para>The regexp parameter has
-      <link linkend="shortcuts">mailbox shortcut</link>expansion performed on
+      <link linkend="shortcuts">mailbox shortcut</link> expansion performed on
       the first character. See
-      <xref linkend="mailbox-hook" />for more details.</para>
+      <xref linkend="mailbox-hook" /> for more details.</para>
       <note>
         <para>If you use the
         <quote>!</quote>shortcut for
-        <link linkend="spoolfile">$spoolfile</link>at the beginning of the
+        <link linkend="spoolfile">$spoolfile</link> at the beginning of the
         pattern, you must place it inside of double or single quotes in order
         to distinguish it from the logical
         <emphasis>not</emphasis>operator for the expression.</para>
@@ -3773,12 +3773,12 @@ bind index gg first-entry</screen>
       <note>
         <para>The keyboard buffer will not be processed until after all hooks
         are run; multiple
-        <link linkend="push">push</link>or
-        <link linkend="exec">exec</link>commands will end up being processed in
+        <link linkend="push">push</link> or
+        <link linkend="exec">exec</link> commands will end up being processed in
         reverse order.</para>
       </note>
       <para>The following example will set the
-      <link linkend="sort">sort</link>variable to
+      <link linkend="sort">sort</link> variable to
       <literal>date-sent</literal>for all folders but to
       <literal>threads</literal>for all folders containing
       <quote>mutt</quote>in their name.</para>
@@ -3818,14 +3818,14 @@ folder-hook mutt "set sort=threads"
       a single key or fewer keys.</para>
       <para>
       <emphasis>menu</emphasis>is the
-      <link linkend="maps">map</link>which the macro will be bound in. Multiple
+      <link linkend="maps">map</link> which the macro will be bound in. Multiple
       maps may be specified by separating multiple menu arguments by commas.
       Whitespace may not be used in between the menu arguments and the commas
       separating them.</para>
       <para>
       <emphasis>key</emphasis>and
       <emphasis>sequence</emphasis>are expanded by the same rules as the
-      <link linkend="bind">key bindings</link>with some additions. The first is
+      <link linkend="bind">key bindings</link> with some additions. The first is
       that control characters in
       <emphasis>sequence</emphasis>can also be specified as
       <emphasis>^x</emphasis>. In order to get a caret (
@@ -3946,7 +3946,7 @@ folder-hook mutt "set sort=threads"
       server-side searches (=b, =B, =h) are not supported for color index
       patterns.</para>
       <para>When
-      <link linkend="header-color-partial">$header_color_partial</link>is unset
+      <link linkend="header-color-partial">$header_color_partial</link> is unset
       (the default), a
       <emphasis>header</emphasis>matched by
       <emphasis>regexp</emphasis>will have color applied to the entire header.
@@ -4014,14 +4014,14 @@ folder-hook mutt "set sort=threads"
         </listitem>
         <listitem>
           <para>
-          <link linkend="progress">progress</link>(visual progress bar)</para>
+          <link linkend="progress">progress</link> (visual progress bar)</para>
         </listitem>
         <listitem>
           <para>prompt</para>
         </listitem>
         <listitem>
           <para>quoted (text matching
-          <link linkend="quote-regexp">$quote_regexp</link>in the body of a
+          <link linkend="quote-regexp">$quote_regexp</link> in the body of a
           message)</para>
         </listitem>
         <listitem>
@@ -4281,7 +4281,7 @@ export COLORFGBG
         <title>Header Display</title>
         <para>When displaying a message in the pager, Mutt folds long header
         lines at
-        <link linkend="wrap">$wrap</link>columns. Though there're precise rules
+        <link linkend="wrap">$wrap</link> columns. Though there're precise rules
         about where to break and how, Mutt always folds headers using a tab for
         readability. (Note that the sending side is not affected by this, Mutt
         tries to implement standards compliant folding.)</para>
@@ -4521,7 +4521,7 @@ unignore posted-to:
         not supported by all mail user agents. Adding it is not bullet-proof
         against receiving personal CCs of list messages. Also note that the
         generation of the Mail-Followup-To header is controlled by the
-        <link linkend="followup-to">$followup_to</link>configuration variable
+        <link linkend="followup-to">$followup_to</link> configuration variable
         since it's common practice on some mailing lists to send Cc upon
         replies (which is more a group- than a list-reply).</para>
       </note>
@@ -4556,7 +4556,7 @@ unignore posted-to:
       <para>The
       <literal>-group</literal>flag adds all of the subsequent regular
       expressions to the named
-      <link linkend="addrgroup">address group</link>in addition to adding to
+      <link linkend="addrgroup">address group</link> in addition to adding to
       the specified address list.</para>
       <para>The
       <quote>unlists</quote>command is used to remove a token from the list of
@@ -4587,11 +4587,11 @@ unignore posted-to:
       <emphasis>mailbox</emphasis>specifies where mail should be saved when
       read.</para>
       <para>The regexp parameter has
-      <link linkend="shortcuts">mailbox shortcut</link>expansion performed on
+      <link linkend="shortcuts">mailbox shortcut</link> expansion performed on
       the first character. See
-      <xref linkend="mailbox-hook" />for more details.</para>
-      <para>Note that execution of mbox-hooks is dependent on the 
-      <link linkend="move">$move</link>configuration variable. If set to 
+      <xref linkend="mailbox-hook" /> for more details.</para>
+      <para>Note that execution of mbox-hooks is dependent on the
+      <link linkend="move">$move</link> configuration variable. If set to
       <quote>no</quote>(the default), mbox-hooks will not be executed.</para>
       <para>Unlike some of the other
       <emphasis>hook</emphasis>commands, only the
@@ -4629,11 +4629,11 @@ unignore posted-to:
       <emphasis>folder</emphasis>can also be a POP/IMAP folder URL. The URL
       syntax is described in
       <xref linkend="url-syntax" />, POP and IMAP are described in
-      <xref linkend="pop" />and
-      <xref linkend="imap" />respectively.</para>
+      <xref linkend="pop" /> and
+      <xref linkend="imap" /> respectively.</para>
       <para>Mutt provides a number of advanced features for handling (possibly
       many) folders and new mail within them, please refer to
-      <xref linkend="new-mail" />for details (including in what situations and
+      <xref linkend="new-mail" /> for details (including in what situations and
       how often Mutt checks for new mail).</para>
       <para>The
       <quote>unmailboxes</quote>command is used to remove a token from the list
@@ -4643,11 +4643,11 @@ unignore posted-to:
         <para>The folders in the
         <command>mailboxes</command>command are resolved when the command is
         executed, so if these names contain
-        <link linkend="shortcuts">shortcut characters</link>(such as
+        <link linkend="shortcuts">shortcut characters</link> (such as
         <quote>=</quote>and
         <quote>!</quote>), any variable definition that affects these
         characters (like
-        <link linkend="folder">$folder</link>and
+        <link linkend="folder">$folder</link> and
         <link linkend="spoolfile">$spoolfile</link>) should be set before the
         <command>mailboxes</command>command. If none of these shortcuts are
         used, a local path should be absolute as otherwise Mutt tries to find
@@ -4678,11 +4678,11 @@ unignore posted-to:
       <command>my_hdr</command>command allows you to create your own header
       fields which will be added to every message you send and appear in the
       editor if
-      <link linkend="edit-headers">$edit_headers</link>is set.</para>
+      <link linkend="edit-headers">$edit_headers</link> is set.</para>
       <para>For example, if you would like to add an
       <quote>Organization:</quote>header field to all of your outgoing
       messages, you can put the command something like shown in
-      <xref linkend="ex-my-hdr" />in your
+      <xref linkend="ex-my-hdr" /> in your
       <literal>.muttrc</literal>.</para>
       <example id="ex-my-hdr">
         <title>Defining custom headers</title>
@@ -4696,7 +4696,7 @@ unignore posted-to:
       </note>
       <para>If you would like to add a header field to a single message, you
       should either set the
-      <link linkend="edit-headers">$edit_headers</link>variable, or use the
+      <link linkend="edit-headers">$edit_headers</link> variable, or use the
       <literal>&lt;edit-headers&gt;</literal>function (default:
       <quote>E</quote>) in the compose menu so that you can edit the header of
       your message along with the body.</para>
@@ -4726,11 +4726,11 @@ unignore posted-to:
       <emphasis>mailbox</emphasis>will be used as the default if the message
       matches
       <emphasis>pattern</emphasis>, see
-      <xref linkend="pattern-hook" />for information on the exact
+      <xref linkend="pattern-hook" /> for information on the exact
       format.</para>
       <para>To provide more flexibility and good defaults, Mutt applies the
       expandos of
-      <link linkend="index-format">$index_format</link>to
+      <link linkend="index-format">$index_format</link> to
       <emphasis>mailbox</emphasis>after it was expanded.</para>
       <example id="ex-save-hook-exando">
         <title>Using %-expandos in
@@ -4768,13 +4768,13 @@ save-hook aol\\.com$ +spam
       <emphasis>pattern</emphasis>and uses
       <emphasis>mailbox</emphasis>as the default Fcc: mailbox. If no match is
       found the message will be saved to
-      <link linkend="record">$record</link>mailbox.</para>
+      <link linkend="record">$record</link> mailbox.</para>
       <para>To provide more flexibility and good defaults, Mutt applies the
       expandos of
-      <link linkend="index-format">$index_format</link>to
+      <link linkend="index-format">$index_format</link> to
       <emphasis>mailbox</emphasis>after it was expanded.</para>
       <para>See
-      <xref linkend="pattern-hook" />for information on the exact format of
+      <xref linkend="pattern-hook" /> for information on the exact format of
       <emphasis>pattern</emphasis>.</para>
       <screen>fcc-hook [@.]aol\\.com$ +spammers</screen>
       <para>...will save a copy of all messages going to the aol.com domain to
@@ -4839,7 +4839,7 @@ save-hook aol\\.com$ +spam
       <para>These commands can be used to execute arbitrary configuration
       commands based upon recipients of the message.
       <emphasis>pattern</emphasis>is used to match the message, see
-      <xref linkend="pattern-hook" />for details.
+      <xref linkend="pattern-hook" /> for details.
       <emphasis>command</emphasis>is executed when
       <emphasis>pattern</emphasis>matches.</para>
       <para>
@@ -4870,7 +4870,7 @@ save-hook aol\\.com$ +spam
       <command>send2-hook</command>is executed after
       <command>send-hook</command>, and can, e.g., be used to set parameters
       such as the
-      <link linkend="sendmail">$sendmail</link>variable depending on the
+      <link linkend="sendmail">$sendmail</link> variable depending on the
       message's sender address.</para>
       <para>For each type of
       <command>send-hook</command>or
@@ -4884,7 +4884,7 @@ save-hook aol\\.com$ +spam
       <para>Another typical use for this command is to change the values of the
       <link linkend="attribution">$attribution</link>,
       <link linkend="attribution-locale">$attribution_locale</link>, and
-      <link linkend="signature">$signature</link>variables in order to change
+      <link linkend="signature">$signature</link> variables in order to change
       the language of the attributions and signatures based upon the
       recipients.</para>
       <note>
@@ -4893,7 +4893,7 @@ save-hook aol\\.com$ +spam
         initial list of recipients. Adding a recipient after replying or
         editing the message will not cause any
         <command>send-hook</command>to be executed, similarly if
-        <link linkend="autoedit">$autoedit</link>is set (as then the initial
+        <link linkend="autoedit">$autoedit</link> is set (as then the initial
         list of recipients is empty). Also note that
         <link linkend="my-hdr">
           <command>my_hdr</command>
@@ -4925,7 +4925,7 @@ save-hook aol\\.com$ +spam
       specified in the
       <literal>.muttrc</literal>.</para>
       <para>See
-      <xref linkend="pattern-hook" />for information on the exact format of
+      <xref linkend="pattern-hook" /> for information on the exact format of
       <emphasis>pattern</emphasis>.</para>
       <para>Example:</para>
       <screen>
@@ -4957,7 +4957,7 @@ message-hook '~f freshmeat-news' 'set pager="less \"+/^  subject: .*\""'
       multiple matching crypt-hooks result in the use of multiple keyids for a
       recipient. During key selection, Mutt will confirm whether each
       crypt-hook is to be used (unless the
-      <link linkend="crypt-confirmhook">$crypt_confirmhook</link>option is
+      <link linkend="crypt-confirmhook">$crypt_confirmhook</link> option is
       unset). If all crypt-hooks for a recipient are declined, Mutt will use
       the original recipient address for key selection instead.</para>
       <para>The meaning of
@@ -4978,10 +4978,10 @@ message-hook '~f freshmeat-news' 'set pager="less \"+/^  subject: .*\""'
       <para>This command adds the named string to the beginning of the keyboard
       buffer. The string may contain control characters, key names and function
       names like the sequence string in the
-      <link linkend="macro">macro</link>command. You may use it to
+      <link linkend="macro">macro</link> command. You may use it to
       automatically run a sequence of commands at startup, or when entering
       certain folders. For example,
-      <xref linkend="ex-folder-hook-push" />shows how to automatically collapse
+      <xref linkend="ex-folder-hook-push" /> shows how to automatically collapse
       all threads when entering a folder.</para>
       <example id="ex-folder-hook-push">
         <title>Embedding
@@ -5060,7 +5060,7 @@ message-hook '~f freshmeat-news' 'set pager="less \"+/^  subject: .*\""'
       <emphasis>value</emphasis>to a message's score if
       <emphasis>pattern</emphasis>matches it.
       <emphasis>pattern</emphasis>is a string in the format described in the
-      <link linkend="patterns">patterns</link>section (note: For efficiency
+      <link linkend="patterns">patterns</link> section (note: For efficiency
       reasons, patterns which scan information not available in the index, such
       as
       <literal>~b</literal>,
@@ -5082,9 +5082,9 @@ message-hook '~f freshmeat-news' 'set pager="less \"+/^  subject: .*\""'
       score entries.</para>
 
       <para>Scoring occurs as the messages are read in, before the mailbox is
-      sorted. Because of this, patterns which depend on threading, such as 
-      <emphasis>~=</emphasis>, 
-      <emphasis>~$</emphasis>, and 
+      sorted. Because of this, patterns which depend on threading, such as
+      <emphasis>~=</emphasis>,
+      <emphasis>~$</emphasis>, and
       <emphasis>~()</emphasis>, will not work by default. A workaround is to push
       the scoring command in a folder hook. This will cause the mailbox to be
       rescored after it is opened and input starts being processed:</para>
@@ -5124,7 +5124,7 @@ folder-hook . 'push "&lt;enter-command&gt;score ~= 10&lt;enter&gt;"'
       determined by the external filter. You also can display the spam
       attributes in your index display using the
       <literal>%H</literal>selector in the
-      <link linkend="index-format">$index_format</link>variable. (Tip: try
+      <link linkend="index-format">$index_format</link> variable. (Tip: try
       <literal>%?H?[%H] ?</literal>to display spam tags only when they are
       defined for a given message.)</para>
       <para>Your first step is to define your external filter's spam patterns
@@ -5149,16 +5149,16 @@ folder-hook . 'push "&lt;enter-command&gt;score ~= 10&lt;enter&gt;"'
       <para>To match spam tags, mutt needs the corresponding header information
       which is always the case for local and POP folders but not for IMAP in
       the default configuration. Depending on the spam header to be analyzed,
-      <link linkend="imap-headers">$imap_headers</link>may need to be
+      <link linkend="imap-headers">$imap_headers</link> may need to be
       adjusted.</para>
       <para>If you're using multiple spam filters, a message can have more than
       one spam-related header. You can define
       <command>spam</command>patterns for each filter you use. If a message
       matches two or more of these patterns, and the
-      <link linkend="spam-separator">$spam_separator</link>variable is set to a
+      <link linkend="spam-separator">$spam_separator</link> variable is set to a
       string, then the message's spam tag will consist of all the
       <emphasis>format</emphasis>strings joined together, with the value of
-      <link linkend="spam-separator">$spam_separator</link>separating
+      <link linkend="spam-separator">$spam_separator</link> separating
       them.</para>
       <para>For example, suppose one uses DCC, SpamAssassin, and PureMessage,
       then the configuration might look like in
@@ -5181,14 +5181,14 @@ set spam_separator=", "
       case,
       <quote>Fuz2</quote>.)</para>
       <para>If the
-      <link linkend="spam-separator">$spam_separator</link>variable is unset,
+      <link linkend="spam-separator">$spam_separator</link> variable is unset,
       then each spam pattern match supersedes the previous one. Instead of
       getting joined
       <emphasis>format</emphasis>strings, you'll get only the last one to
       match.</para>
       <para>The spam tag is what will be displayed in the index when you use
       <literal>%H</literal>in the
-      <link linkend="index-format">$index_format</link>variable. It's also the
+      <link linkend="index-format">$index_format</link> variable. It's also the
       string that the
       <literal>~H</literal>pattern-matching expression matches against for
       <literal>&lt;search&gt;</literal>and
@@ -5306,7 +5306,7 @@ set spam_separator=", "
             <term>regular expression</term>
             <listitem>
               <para>A regular expression, see
-              <xref linkend="regexp" />for an introduction.</para>
+              <xref linkend="regexp" /> for an introduction.</para>
             </listitem>
           </varlistentry>
           <varlistentry>
@@ -5334,7 +5334,7 @@ set spam_separator=", "
             <term>user-defined</term>
             <listitem>
               <para>Arbitrary text, see
-              <xref linkend="set-myvar" />for details.</para>
+              <xref linkend="set-myvar" /> for details.</para>
             </listitem>
           </varlistentry>
         </variablelist>
@@ -5456,7 +5456,7 @@ set spam_separator=", "
         <sect3 id="set-myvar-intro">
           <title>Introduction</title>
           <para>Along with the variables listed in the
-          <link linkend="variables">Configuration variables</link>section, Mutt
+          <link linkend="variables">Configuration variables</link> section, Mutt
           supports user-defined variables with names starting with
           <literal>my_</literal>as in, for example,
           <literal>my_cfgdir</literal>.</para>
@@ -5468,7 +5468,7 @@ set spam_separator=", "
           <command>reset</command>commands remove the variable entirely.</para>
           <para>Since user-defined variables are expanded in the same way that
           environment variables are (except for the
-          <link linkend="shell-escape">shell-escape</link>command and backtick
+          <link linkend="shell-escape">shell-escape</link> command and backtick
           expansion), this feature can be used to make configuration files more
           readable.</para>
         </sect3>
@@ -5493,11 +5493,11 @@ source $my_cfgdir/macros
           <para>A custom variable can also be used in macros to backup the
           current value of another variable. In the following example, the
           value of the
-          <link linkend="delete">$delete</link>is changed temporarily while its
+          <link linkend="delete">$delete</link> is changed temporarily while its
           original value is saved as
           <literal>my_delete</literal>. After the macro has executed all
           commands, the original value of
-          <link linkend="delete">$delete</link>is restored.</para>
+          <link linkend="delete">$delete</link> is restored.</para>
           <example id="ex-myvar2">
             <title>Using user-defined variables for backing up other config
             option values</title>
@@ -5513,10 +5513,10 @@ macro pager ,x '\
           configuration file(s), the value of
           <literal>$my_delete</literal>in the last example would be the value
           of
-          <link linkend="delete">$delete</link>exactly as it was at that point
+          <link linkend="delete">$delete</link> exactly as it was at that point
           during parsing the configuration file. If another statement would
           change the value for
-          <link linkend="delete">$delete</link>later in the same or another
+          <link linkend="delete">$delete</link> later in the same or another
           file, it would have no effect on
           <literal>$my_delete</literal>. However, the expansion can be deferred
           to runtime, as shown in the next example, when escaping the dollar
@@ -5549,7 +5549,7 @@ macro pager &lt;PageDown&gt; "\
         given that its content is valid for the target. This also counts for
         custom variables which are of type string. In case of parsing errors,
         Mutt will print error messages.
-        <xref linkend="ex-myvar4" />demonstrates type conversions.</para>
+        <xref linkend="ex-myvar4" /> demonstrates type conversions.</para>
         <example id="ex-myvar4">
           <title>Type conversions using variables</title>
           <screen>
@@ -5649,7 +5649,7 @@ mailboxes $my_mx +mailbox3</screen>
         <para>The most basic format string element is a percent symbol followed
         by another character. For example,
         <literal>%s</literal>represents a message's Subject: header in the
-        <link linkend="index-format">$index_format</link>variable. The
+        <link linkend="index-format">$index_format</link> variable. The
         <quote>expandos</quote>available are documented with each format
         variable, but there are general modifiers available with all formatting
         expandos, too. Those are our concern here.</para>
@@ -5729,7 +5729,7 @@ mailboxes $my_mx +mailbox3</screen>
 %&lt;x?%&lt;y?%&lt;z?xyz&amp;xy&gt;&amp;x&gt;&amp;none&gt;
 </screen>
         <para>For more examples, see
-        <xref linkend="nested-if" /></para>
+        <xref linkend="nested-if" /> </para>
       </sect2>
 
       <sect2 id="formatstrings-filters">
@@ -5756,7 +5756,7 @@ mailboxes $my_mx +mailbox3</screen>
         <literal>mutt_xtitle</literal>script installed in the
         <literal>samples</literal>subdirectory of the Mutt documentation: it
         can be used as filter for
-        <link linkend="status-format">$status_format</link>to set the current
+        <link linkend="status-format">$status_format</link> to set the current
         terminal's title, if supported.</para>
       </sect2>
 
@@ -5943,7 +5943,7 @@ mailboxes $my_mx +mailbox3</screen>
     <sect1 id="regexp">
       <title>Regular Expressions</title>
       <para>All string patterns in Mutt including those in more complex
-      <link linkend="patterns">patterns</link>must be specified using regular
+      <link linkend="patterns">patterns</link> must be specified using regular
       expressions (regexp) in the
       <quote>POSIX extended</quote>syntax (which is more or less the syntax
       used by egrep and GNU awk). For your convenience, we have included below
@@ -5964,7 +5964,7 @@ mailboxes $my_mx +mailbox3</screen>
         <para>The regular expression can be enclosed/delimited by either " or '
         which is useful if the regular expression includes a white-space
         character. See
-        <xref linkend="muttrc-syntax" />for more information on " and '
+        <xref linkend="muttrc-syntax" /> for more information on " and '
         delimiter processing. To match a literal " or ' you must preface it
         with \ (backslash).</para>
       </note>
@@ -5999,7 +5999,7 @@ mailboxes $my_mx +mailbox3</screen>
       <quote>[:</quote>, a keyword denoting the class, and
       <quote>:]</quote>. The following classes are defined by the POSIX
       standard in
-      <xref linkend="posix-regex-char-classes" /></para>
+      <xref linkend="posix-regex-char-classes" /> </para>
 
       <table id="posix-regex-char-classes">
         <title>POSIX regular expression character classes</title>
@@ -6251,7 +6251,7 @@ mailboxes $my_mx +mailbox3</screen>
         <literal>limit</literal>,
         <literal>tag-pattern</literal>,
         <literal>delete-pattern</literal>, etc.).
-        <xref linkend="tab-patterns" />shows several ways to select
+        <xref linkend="tab-patterns" /> shows several ways to select
         messages.</para>
 
         <table id="tab-patterns">
@@ -6609,7 +6609,7 @@ mailboxes $my_mx +mailbox3</screen>
         <para>***) The message number ranges (introduced by
         <literal>~m</literal>) are even more general and powerful than the
         other types of ranges. Read on and see
-        <xref linkend="message-ranges" />below.</para>
+        <xref linkend="message-ranges" /> below.</para>
         <para>Special attention has to be paid when using regular expressions
         inside of patterns. Specifically, Mutt's parser for these patterns will
         strip one level of backslash (
@@ -6896,7 +6896,7 @@ mailboxes $my_mx +mailbox3</screen>
         </table>
         <para>The second type of simple search is to build a complex search
         pattern using
-        <link linkend="simple-search">$simple_search</link>as a template. Mutt
+        <link linkend="simple-search">$simple_search</link> as a template. Mutt
         will insert your query properly quoted and search for the composed
         complex query.</para>
       </sect2>
@@ -7053,7 +7053,7 @@ mailboxes $my_mx +mailbox3</screen>
             <para>All dates used when searching are relative to the
             <emphasis>local</emphasis>time zone, so unless you change the
             setting of your
-            <link linkend="index-format">$index_format</link>to include a
+            <link linkend="index-format">$index_format</link> to include a
             <literal>%[...]</literal>format, these are
             <emphasis>not</emphasis>the dates shown in the main index.</para>
           </note>
@@ -7074,7 +7074,7 @@ mailboxes $my_mx +mailbox3</screen>
       that returns you to the current message by searching for its Message-ID.
       You can choose a different prefix by setting the
       <link linkend="mark-macro-prefix">
-      $mark_macro_prefix</link>variable.)</para>
+      $mark_macro_prefix</link> variable.)</para>
     </sect1>
 
     <sect1 id="tags">
@@ -7089,7 +7089,7 @@ mailboxes $my_mx +mailbox3</screen>
       by hand using the
       <literal>&lt;tag-message&gt;</literal>function, which is bound to
       <quote>t</quote>by default. See
-      <link linkend="patterns">patterns</link>for Mutt's pattern matching
+      <link linkend="patterns">patterns</link> for Mutt's pattern matching
       syntax.</para>
       <para>Once you have tagged the desired messages, you can use the
       <quote>tag-prefix</quote>operator, which is the
@@ -7097,13 +7097,13 @@ mailboxes $my_mx +mailbox3</screen>
       <quote>tag-prefix</quote>operator is used, the
       <emphasis>next</emphasis>operation will be applied to all tagged messages
       if that operation can be used in that manner. If the
-      <link linkend="auto-tag">$auto_tag</link>variable is set, the next
+      <link linkend="auto-tag">$auto_tag</link> variable is set, the next
       operation applies to the tagged messages automatically, without requiring
       the
       <quote>tag-prefix</quote>.</para>
       <para>In
       <link linkend="macro">
-      <command>macro</command>s</link>or
+      <command>macro</command>s</link> or
       <link linkend="push">
         <command>push</command>
       </link>commands, you can use the
@@ -7125,8 +7125,8 @@ mailboxes $my_mx +mailbox3</screen>
       upon which mailbox you are reading, or to whom you are sending mail. In
       the Mutt world, a
       <emphasis>hook</emphasis>consists of a
-      <link linkend="regexp">regular expression</link>or
-      <link linkend="patterns">pattern</link>along with a configuration
+      <link linkend="regexp">regular expression</link> or
+      <link linkend="patterns">pattern</link> along with a configuration
       option/command. See:
       <itemizedlist>
         <listitem>
@@ -7260,8 +7260,8 @@ send-hook ~C'^b@b\.b$' my_hdr from: c@c.c
       </example>
       <para>In
       <xref linkend="ex-default-hook" />, by default the value of
-      <link linkend="from">$from</link>and
-      <link linkend="realname">$realname</link>is not overridden. When sending
+      <link linkend="from">$from</link> and
+      <link linkend="realname">$realname</link> is not overridden. When sending
       messages either To: or Cc: to
       <literal>&lt;b@b.b&gt;</literal>, the From: header is changed to
       <literal>&lt;c@c.c&gt;</literal>.</para>
@@ -7276,12 +7276,12 @@ send-hook ~C'^b@b\.b$' my_hdr from: c@c.c
         <command>save-hook</command>,
         <command>fcc-hook</command>) are evaluated in a slightly different
         manner. For the other types of hooks, a
-        <link linkend="regexp">regular expression</link>is sufficient. But in
+        <link linkend="regexp">regular expression</link> is sufficient. But in
         dealing with messages a finer grain of control is needed for matching
         since for different purposes you want to match different
         criteria.</para>
         <para>Mutt allows the use of the
-        <link linkend="patterns">search pattern</link>language for matching
+        <link linkend="patterns">search pattern</link> language for matching
         messages in hook commands. This works in exactly the same way as it
         would when
         <emphasis>limiting</emphasis>or
@@ -7299,9 +7299,9 @@ send-hook ~C'^b@b\.b$' my_hdr from: c@c.c
         <emphasis>regular expression</emphasis>like the other hooks, in which
         case Mutt will translate your pattern into the full language, using the
         translation specified by the
-        <link linkend="default-hook">$default_hook</link>variable. The pattern
+        <link linkend="default-hook">$default_hook</link> variable. The pattern
         is translated at the time the hook is declared, so the value of
-        <link linkend="default-hook">$default_hook</link>that is in effect at
+        <link linkend="default-hook">$default_hook</link> that is in effect at
         that time will be used.</para>
       </sect2>
 
@@ -7310,8 +7310,8 @@ send-hook ~C'^b@b\.b$' my_hdr from: c@c.c
         <para>Hooks that match against mailboxes (
         <command>folder-hook</command>,
         <command>mbox-hook</command>) apply both
-        <link linkend="regexp">regular expression</link>syntax as well as
-        <link linkend="shortcuts">mailbox shortcut</link>expansion on the
+        <link linkend="regexp">regular expression</link> syntax as well as
+        <link linkend="shortcuts">mailbox shortcut</link> expansion on the
         regexp parameter. There is some overlap between these, so special
         attention should be paid to the first character of the regexp.</para>
         <screen>
@@ -7359,7 +7359,7 @@ setenv ?LESS
       <para>Mutt supports connecting to external directory databases such as
       LDAP, ph/qi, bbdb, or NIS through a wrapper script which connects to Mutt
       using a simple interface. Using the
-      <link linkend="query-command">$query_command</link>variable, you specify
+      <link linkend="query-command">$query_command</link> variable, you specify
       the wrapper command to use. For example:</para>
       <screen>set query_command = "mutt_ldap_query.pl %s"</screen>
       <para>The wrapper script should accept the query on the command-line. It
@@ -7400,7 +7400,7 @@ roessler@does-not-exist.org        Thomas Roessler mutt pgp
       formats: mbox, MMDF, MH and Maildir. The mailbox type is auto detected,
       so there is no need to use a flag for different mailbox types. When
       creating new mailboxes, Mutt uses the default specified with the
-      <link linkend="mbox-type">$mbox_type</link>variable. A short description
+      <link linkend="mbox-type">$mbox_type</link> variable. A short description
       of the formats follows.</para>
       <para>
       <emphasis>mbox</emphasis>. This is a widely used mailbox format for UNIX.
@@ -7437,7 +7437,7 @@ roessler@does-not-exist.org        Thomas Roessler mutt pgp
       corruption is less likely to occur than with mbox/mmdf. It's usually
       slower to open compared to mbox/mmdf since many small files have to be
       read (Mutt provides
-      <xref linkend="header-caching" />to greatly speed this process up).
+      <xref linkend="header-caching" /> to greatly speed this process up).
       Depending on the environment, MH is not very disk-space efficient.</para>
       <para>
       <emphasis>Maildir</emphasis>. The newest of the mailbox formats, used by
@@ -7478,7 +7478,7 @@ roessler@does-not-exist.org        Thomas Roessler mutt pgp
                 <literal>!</literal>
               </entry>
               <entry>your
-              <link linkend="spoolfile">$spoolfile</link>(incoming)
+              <link linkend="spoolfile">$spoolfile</link> (incoming)
               mailbox</entry>
             </row>
             <row>
@@ -7486,14 +7486,14 @@ roessler@does-not-exist.org        Thomas Roessler mutt pgp
                 <literal>&gt;</literal>
               </entry>
               <entry>your
-              <link linkend="mbox">$mbox</link>file</entry>
+              <link linkend="mbox">$mbox</link> file</entry>
             </row>
             <row>
               <entry>
                 <literal>&lt;</literal>
               </entry>
               <entry>your
-              <link linkend="record">$record</link>file</entry>
+              <link linkend="record">$record</link> file</entry>
             </row>
             <row>
               <entry>
@@ -7518,14 +7518,14 @@ roessler@does-not-exist.org        Thomas Roessler mutt pgp
               <literal>=</literal>or
               <literal>+</literal></entry>
               <entry>your
-              <link linkend="folder">$folder</link>directory</entry>
+              <link linkend="folder">$folder</link> directory</entry>
             </row>
             <row>
               <entry>
                 <emphasis>@alias</emphasis>
               </entry>
               <entry>to the
-              <link linkend="save-hook">default save folder</link>as determined
+              <link linkend="save-hook">default save folder</link> as determined
               by the address of the alias</entry>
             </row>
           </tbody>
@@ -7550,14 +7550,14 @@ roessler@does-not-exist.org        Thomas Roessler mutt pgp
       the use of the
       <link linkend="lists">
       <command>lists</command>and
-      <command>subscribe</command></link>commands in your
+      <command>subscribe</command></link> commands in your
       <literal>.muttrc</literal>.</para>
       <para>Now that Mutt knows what your mailing lists are, it can do several
       things, the first of which is the ability to show the name of a list
       through which you received a message (i.e., of a subscribed list) in the
       <emphasis>index</emphasis>menu display. This is useful to distinguish
       between personal and list mail in the same mailbox. In the
-      <link linkend="index-format">$index_format</link>variable, the expando
+      <link linkend="index-format">$index_format</link> variable, the expando
       <quote>%L</quote>will print the string
       <quote>To &lt;list&gt;</quote>when
       <quote>list</quote>appears in the
@@ -7583,7 +7583,7 @@ roessler@does-not-exist.org        Thomas Roessler mutt pgp
       <literal>Mail-Followup-To</literal>header. When you send a message to a
       list of recipients which includes one or several subscribed mailing
       lists, and if the
-      <link linkend="followup-to">$followup_to</link>option is set, Mutt will
+      <link linkend="followup-to">$followup_to</link> option is set, Mutt will
       generate a Mail-Followup-To header which contains all the recipients to
       whom you send this message, but not your address. This indicates that
       group-replies or list-replies (also known as
@@ -7595,9 +7595,9 @@ roessler@does-not-exist.org        Thomas Roessler mutt pgp
       has a
       <literal>Mail-Followup-To</literal>header, Mutt will respect this header
       if the
-      <link linkend="honor-followup-to">$honor_followup_to</link>configuration
+      <link linkend="honor-followup-to">$honor_followup_to</link> configuration
       variable is set. Using
-      <link linkend="list-reply">list-reply</link>will in this case also make
+      <link linkend="list-reply">list-reply</link> will in this case also make
       sure that the reply goes to the mailing list, even if it's not specified
       in the list of recipients in the
       <literal>Mail-Followup-To</literal>.</para>
@@ -7613,7 +7613,7 @@ roessler@does-not-exist.org        Thomas Roessler mutt pgp
       when trying to reply directly to the author in private, since most mail
       clients will automatically reply to the address given in the
       <quote>Reply-To</quote>field. Mutt uses the
-      <link linkend="reply-to">$reply_to</link>variable to help decide which
+      <link linkend="reply-to">$reply_to</link> variable to help decide which
       address to use. If set to
       <emphasis>ask-yes</emphasis>or
       <emphasis>ask-no</emphasis>, you will be prompted as to whether or not
@@ -7631,7 +7631,7 @@ roessler@does-not-exist.org        Thomas Roessler mutt pgp
       (TAB, by default) will perform completion against all labels currently in
       use.</para>
       <para>Lastly, Mutt has the ability to
-      <link linkend="sort">sort</link>the mailbox into
+      <link linkend="sort">sort</link> the mailbox into
       <link linkend="threads">threads</link>. A thread is a group of messages
       which all relate to the same subject. This is usually organized into a
       tree-like structure where a message and all of its replies are
@@ -7709,11 +7709,11 @@ roessler@does-not-exist.org        Thomas Roessler mutt pgp
       <literal>Keywords</literal>, or
       <literal>X-Label:</literal>. Keywords will be saved to whichever header
       was in use by the message the keyword was read from. If
-      <link linkend="keywords-standard">$keywords_standard</link>is set,
+      <link linkend="keywords-standard">$keywords_standard</link> is set,
       keywords will be saved without exception to the standard
       <literal>Keywords:</literal>header. (If both are set, both will be used;
       if both are unset, legacy headers are used.) Additionally,
-      <link linkend="xlabel-delimiter">$xlabel_delimiter</link>is used to
+      <link linkend="xlabel-delimiter">$xlabel_delimiter</link> is used to
       format the X-Label: header on saves.</para>
       <para>To migrate completely to the new standard, unset
       <literal>$keywords_legacy</literal>and set
@@ -7760,7 +7760,7 @@ roessler@does-not-exist.org        Thomas Roessler mutt pgp
       subject to be replaced with the
       <quote>replacement</quote>value. The replacement is subject to
       substitutions in the same way as for the
-      <link linkend="spam">spam</link>command:
+      <link linkend="spam">spam</link> command:
       <literal>%L</literal>for the text to the left of the match,
       <literal>%R</literal>for text to the right of the match, and
       <literal>%1</literal>for the first subgroup in the match (etc). If you
@@ -7795,7 +7795,7 @@ subjectrx '\[[^\]]*\]:? *' '%L%R'
       <title>New Mail Detection</title>
       <para>Mutt supports setups with multiple folders, allowing all of them to
       be monitored for new mail (see
-      <xref linkend="mailboxes" />for details).</para>
+      <xref linkend="mailboxes" /> for details).</para>
 
       <sect2 id="new-mail-formats">
         <title>How New Mail Detection Works</title>
@@ -7819,7 +7819,7 @@ subjectrx '\[[^\]]*\]:? *' '%L%R'
         </note>
         <para>In cases where new mail detection for Mbox or Mmdf folders
         appears to be unreliable, the
-        <link linkend="check-mbox-size">$check_mbox_size</link>option can be
+        <link linkend="check-mbox-size">$check_mbox_size</link> option can be
         used to make Mutt track and consult file sizes for new mail detection
         instead which won't work for size-neutral changes.</para>
         <para>New mail for Maildir is assumed if there is one message in the
@@ -7829,7 +7829,7 @@ subjectrx '\[[^\]]*\]:? *' '%L%R'
         in the
         <quote>unseen</quote>sequence as specified by
         <link linkend="mh-seq-unseen">$mh_seq_unseen</link>. Optionally,
-        <link linkend="new-mail-command">$new_mail_command</link>can be
+        <link linkend="new-mail-command">$new_mail_command</link> can be
         configured to execute an external program every time new mail is
         detected in the current inbox.</para>
         <para>Mutt does not poll POP3 folders for new mail, it only
@@ -7837,10 +7837,10 @@ subjectrx '\[[^\]]*\]:? *' '%L%R'
         folder).</para>
         <para>For IMAP, by default Mutt uses recent message counts provided by
         the server to detect new mail. If the
-        <link linkend="imap-idle">$imap_idle</link>option is set, it'll use the
+        <link linkend="imap-idle">$imap_idle</link> option is set, it'll use the
         IMAP IDLE extension if advertised by the server.</para>
         <para>The
-        <link linkend="mail-check-recent">$mail_check_recent</link>option
+        <link linkend="mail-check-recent">$mail_check_recent</link> option
         changes whether Mutt will notify you of new mail in an already visited
         mailbox. When set (the default) it will only notify you of new mail
         received since the last time you opened the mailbox. When unset, Mutt
@@ -7854,8 +7854,8 @@ subjectrx '\[[^\]]*\]:? *' '%L%R'
         new mail in all folders which have been configured via the
         <command>mailboxes</command>command. The interval depends on the folder
         type: for local/IMAP folders it consults
-        <link linkend="mail-check">$mail_check</link>and
-        <link linkend="pop-checkinterval">$pop_checkinterval</link>for POP
+        <link linkend="mail-check">$mail_check</link> and
+        <link linkend="pop-checkinterval">$pop_checkinterval</link> for POP
         folders.</para>
         <para>Outside the index menu the directory browser supports checking
         for new mail using the
@@ -7873,7 +7873,7 @@ subjectrx '\[[^\]]*\]:? *' '%L%R'
         mail in the command line at the bottom of the screen.</para>
         <para>For the index, by default Mutt displays the number of mailboxes
         with new mail in the status bar, please refer to the
-        <link linkend="status-format">$status_format</link>variable for
+        <link linkend="status-format">$status_format</link> variable for
         details.</para>
         <para>When changing folders, Mutt fills the prompt with the first
         folder from the mailboxes list containing new mail (if any), pressing
@@ -7886,7 +7886,7 @@ subjectrx '\[[^\]]*\]:? *' '%L%R'
       <sect2 id="calc-mailbox-counts">
         <title>Calculating Mailbox Message Counts</title>
         <para>If
-        <link linkend="mail-check-stats">$mail_check_stats</link>is set, Mutt
+        <link linkend="mail-check-stats">$mail_check_stats</link> is set, Mutt
         will periodically calculate the unread, flagged, and total message
         counts for each mailbox watched by the
         <command>mailboxes</command>command. This calculation takes place at
@@ -7922,7 +7922,7 @@ subjectrx '\[[^\]]*\]:? *' '%L%R'
         using the
         <literal>&lt;tag-prefix&gt;</literal>command (
         <quote>;</quote>) or the
-        <link linkend="auto-tag">$auto_tag</link>option.</para>
+        <link linkend="auto-tag">$auto_tag</link> option.</para>
       </sect2>
 
       <sect2 id="break-threads">
@@ -7945,13 +7945,13 @@ subjectrx '\[[^\]]*\]:? *' '%L%R'
       thought of as
       <quote>return receipts.</quote></para>
       <para>To support DSN, there are two variables.
-      <link linkend="dsn-notify">$dsn_notify</link>is used to request receipts
+      <link linkend="dsn-notify">$dsn_notify</link> is used to request receipts
       for different results (such as failed message, message delivered, etc.).
-      <link linkend="dsn-return">$dsn_return</link>requests how much of your
+      <link linkend="dsn-return">$dsn_return</link> requests how much of your
       message should be returned with the receipt (headers or full
       message).</para>
       <para>When using
-      <link linkend="sendmail">$sendmail</link>for mail delivery, you need to
+      <link linkend="sendmail">$sendmail</link> for mail delivery, you need to
       use either Berkeley sendmail 8.8.x (or greater) a MTA supporting DSN
       command line options compatible to Sendmail: The -N and -R options can be
       used by the mail client to make requests as to what type of status
@@ -8005,7 +8005,7 @@ macro pager \cb |urlview\n
             present either, Mutt takes the user's mailbox in the mailspool as
             determined at compile-time (which may also reside in the home
             directory). The
-            <link linkend="spoolfile">$spoolfile</link>setting overrides this
+            <link linkend="spoolfile">$spoolfile</link> setting overrides this
             selection. Highest priority has the mailbox given with the
             <literal>-f</literal>command line option.</para>
           </listitem>
@@ -8123,7 +8123,7 @@ macro pager \cb |urlview\n
         <literal>&lt;forward&gt;</literal>functions) to attachments of type
         <literal>message/rfc822</literal>.</para>
         <para>See table
-        <xref linkend="tab-attachment-bindings" />for all available
+        <xref linkend="tab-attachment-bindings" /> for all available
         functions.</para>
       </sect2>
 
@@ -8156,7 +8156,7 @@ macro pager \cb |urlview\n
         <literal>&lt;rename-file&gt;</literal>command (default: R). The final
         field is the description of the attachment, and can be changed with the
         <literal>&lt;edit-description&gt;</literal>command (default: d). See
-        <link linkend="attach-format">$attach_format</link>for a full list of
+        <link linkend="attach-format">$attach_format</link> for a full list of
         available expandos to format this display to your needs.</para>
       </sect2>
     </sect1>
@@ -8204,7 +8204,7 @@ audio/x-aiff                    aif aifc aiff
       that Mutt assigns to an attachment by using the
       <literal>&lt;edit-type&gt;</literal>command from the compose menu
       (default: ^T), see
-      <xref linkend="supported-mime-types" />for supported major types. Mutt
+      <xref linkend="supported-mime-types" /> for supported major types. Mutt
       recognizes all of these if the appropriate entry is found in the
       <literal>mime.types</literal>file. Non-recognized mime types should only
       be used if the recipient of the message is likely to be expecting such
@@ -8431,7 +8431,7 @@ text/*; more
         <literal>%s</literal>syntaxes properly, and avoids risky characters by
         substituting them, see the
         <link linkend="mailcap-sanitize">
-        $mailcap_sanitize</link>variable.</para>
+        $mailcap_sanitize</link> variable.</para>
         <para>Although Mutt's procedures to invoke programs with mailcap seem
         to be safe, there are other applications parsing mailcap, maybe taking
         less care of it. Therefore you should pay attention to the following
@@ -8503,11 +8503,11 @@ text/test-mailcap-bug; cat %s; copiousoutput; test=charset=%{charset} \
                   <command>auto_view</command>
                 </link>, in order to decide whether it should honor the setting
                 of the
-                <link linkend="wait-key">$wait_key</link>variable or not. When
+                <link linkend="wait-key">$wait_key</link> variable or not. When
                 an attachment is viewed using an interactive program, and the
                 corresponding mailcap entry has a
                 <emphasis>needsterminal</emphasis>flag, Mutt will use
-                <link linkend="wait-key">$wait_key</link>and the exit status of
+                <link linkend="wait-key">$wait_key</link> and the exit status of
                 the program to decide if it will ask you to press a key after
                 the external program has exited. In all other situations it
                 will not prompt you for a key.</para>
@@ -8547,7 +8547,7 @@ text/test-mailcap-bug; cat %s; copiousoutput; test=charset=%{charset} \
                 MIME type. Mutt supports this from the compose menu, and also
                 uses it to compose new attachments. Mutt will default to the
                 defined
-                <link linkend="editor">$editor</link>for text
+                <link linkend="editor">$editor</link> for text
                 attachments.</para>
               </listitem>
             </varlistentry>
@@ -8872,7 +8872,7 @@ alternative_order text/enriched text/plain text \
       especially for remote mail folders such as IMAP because all messages have
       to be downloaded first regardless whether the user really wants to view
       them or not though using
-      <xref linkend="body-caching" />usually means to download the message just
+      <xref linkend="body-caching" /> usually means to download the message just
       once.</para>
       <para>The syntax is:</para>
       <cmdsynopsis>
@@ -9139,16 +9139,16 @@ smtp://user@host:587/
       <para>Remote POP3 servers can be accessed using URLs with the
       <literal>pop</literal>protocol for unencrypted and
       <literal>pops</literal>for encrypted communication, see
-      <xref linkend="url-syntax" />for details.</para>
+      <xref linkend="url-syntax" /> for details.</para>
       <para>Polling for new mail is more expensive over POP3 than locally. For
       this reason the frequency at which Mutt will check for mail remotely can
       be controlled by the
-      <link linkend="pop-checkinterval">$pop_checkinterval</link>variable,
+      <link linkend="pop-checkinterval">$pop_checkinterval</link> variable,
       which defaults to every 60 seconds.</para>
       <para>POP is read-only which doesn't allow for some features like editing
       messages or changing flags. However, using
-      <xref linkend="header-caching" />and
-      <xref linkend="body-caching" />Mutt simulates the new/old/read flags as
+      <xref linkend="header-caching" /> and
+      <xref linkend="body-caching" /> Mutt simulates the new/old/read flags as
       well as flagged and replied. Mutt applies some logic on top of remote
       messages but cannot change them so that modifications of flags are lost
       when messages are downloaded from the POP server (either by Mutt or other
@@ -9177,7 +9177,7 @@ smtp://user@host:587/
       folders located on a remote IMAP server.</para>
       <para>You can access the remote inbox by selecting the folder by its URL
       (see
-      <xref linkend="url-syntax" />for details) using the
+      <xref linkend="url-syntax" /> for details) using the
       <literal>imap</literal>or
       <literal>imaps</literal>protocol. Alternatively, a pine-compatible
       notation is also supported, i.e.
@@ -9191,11 +9191,11 @@ smtp://user@host:587/
       look at only the folders you are subscribed to, or all folders with the
       <emphasis>toggle-subscribed</emphasis>command. See also the
       <link linkend="imap-list-subscribed">
-      $imap_list_subscribed</link>variable.</para>
+      $imap_list_subscribed</link> variable.</para>
       <para>Polling for new mail on an IMAP server can cause noticeable delays.
       So, you'll want to carefully tune the
-      <link linkend="mail-check">$mail_check</link>and
-      <link linkend="timeout">$timeout</link>variables. Reasonable values
+      <link linkend="mail-check">$mail_check</link> and
+      <link linkend="timeout">$timeout</link> variables. Reasonable values
       are:</para>
       <screen>
 set mail_check=90
@@ -9272,7 +9272,7 @@ set timeout=15
         <itemizedlist>
           <listitem>
             <para>
-            <link linkend="imap-user">$imap_user</link>- controls the username
+            <link linkend="imap-user">$imap_user</link> - controls the username
             under which you request authentication on the IMAP server, for all
             authenticators. This is overridden by an explicit username in the
             mailbox path (i.e. by using a mailbox name of the form
@@ -9280,13 +9280,13 @@ set timeout=15
           </listitem>
           <listitem>
             <para>
-            <link linkend="imap-pass">$imap_pass</link>- a password which you
+            <link linkend="imap-pass">$imap_pass</link> - a password which you
             may preset, used by all authentication methods where a password is
             needed.</para>
           </listitem>
           <listitem>
             <para>
-            <link linkend="imap-authenticators">$imap_authenticators</link>- a
+            <link linkend="imap-authenticators">$imap_authenticators</link> - a
             colon-delimited list of IMAP authentication methods to try, in the
             order you wish to try them. If specified, this overrides Mutt's
             default (attempt everything, in the order listed above).</para>
@@ -9302,7 +9302,7 @@ set timeout=15
       was configured and built with
       <literal>--enable-smtp</literal>.</para>
       <para>If the configuration variable
-      <link linkend="smtp-url">$smtp_url</link>is set, Mutt will contact the
+      <link linkend="smtp-url">$smtp_url</link> is set, Mutt will contact the
       given SMTP server to deliver messages; if it is unset, Mutt will use the
       program specified by
       <link linkend="sendmail">$sendmail</link>.</para>
@@ -9312,7 +9312,7 @@ set timeout=15
       <literal>smtps</literal>protocol using SSL or TLS) as well as SMTP
       authentication using SASL. The authentication mechanisms for SASL are
       specified in
-      <link linkend="smtp-authenticators">$smtp_authenticators</link>defaulting
+      <link linkend="smtp-authenticators">$smtp_authenticators</link> defaulting
       to an empty list which makes Mutt try all available methods from
       most-secure to least-secure.</para>
     </sect1>
@@ -9357,7 +9357,7 @@ account-hook imap://host2/ 'set tunnel="ssh host2 /usr/libexec/imapd"'
 account-hook smtp://user@host3/ 'set tunnel="ssh host3 /usr/libexec/smtpd"'
 </screen>
       <para>To manage multiple accounts with, for example, different values of
-      <link linkend="record">$record</link>or sender addresses,
+      <link linkend="record">$record</link> or sender addresses,
       <link linkend="folder-hook">
         <command>folder-hook</command>
       </link>has to be be used together with the
@@ -9374,7 +9374,7 @@ folder-hook imap://user@host2/ 'set folder=imap://host2/ ; set record=+INBOX/Sen
 </screen>
       </example>
       <para>In example
-      <xref linkend="ex-multiaccount" />the folders are defined using
+      <xref linkend="ex-multiaccount" /> the folders are defined using
       <link linkend="mailboxes">
         <command>mailboxes</command>
       </link>so Mutt polls them for new mail. Each
@@ -9382,18 +9382,18 @@ folder-hook imap://user@host2/ 'set folder=imap://host2/ ; set record=+INBOX/Sen
         <command>folder-hook</command>
       </link>triggers when one mailbox below each IMAP account is opened and
       sets
-      <link linkend="folder">$folder</link>to the account's root folder. Next,
+      <link linkend="folder">$folder</link> to the account's root folder. Next,
       it sets
-      <link linkend="record">$record</link>to the
+      <link linkend="record">$record</link> to the
       <emphasis>INBOX/Sent</emphasis>folder below the newly set
       <link linkend="folder">$folder</link>. Please notice that the value the
       <quote>+</quote>
-      <link linkend="shortcuts">mailbox shortcut</link>refers to depends on the
+      <link linkend="shortcuts">mailbox shortcut</link> refers to depends on the
       <emphasis>current</emphasis>value of
-      <link linkend="folder">$folder</link>and therefore has to be set
+      <link linkend="folder">$folder</link> and therefore has to be set
       separately per account. Setting other values like
-      <link linkend="from">$from</link>or
-      <link linkend="signature">$signature</link>is analogous to setting
+      <link linkend="from">$from</link> or
+      <link linkend="signature">$signature</link> is analogous to setting
       <link linkend="record">$record</link>.</para>
     </sect1>
 
@@ -9425,13 +9425,13 @@ folder-hook imap://user@host2/ 'set folder=imap://host2/ ; set record=+INBOX/Sen
         tokyocabinet, kyotocabinet, qdbm, gdbm, lmdb or bdb must be
         present.</para>
         <para>If enabled,
-        <link linkend="header-cache">$header_cache</link>can be used to either
+        <link linkend="header-cache">$header_cache</link> can be used to either
         point to a file or a directory. If set to point to a file, one database
         file for all folders will be used (which may result in lower
         performance), but one file per folder if it points to a
         directory.</para>
         <para>Additionally,
-        <link linkend="header-cache-backend">$header_cache_backend</link>can be
+        <link linkend="header-cache-backend">$header_cache_backend</link> can be
         used to specify which backend to use. The list of available backends
         can be specified at configure time with a set of --with-&lt;backend&gt;
         options. Currently, the following backends are supported: tokyocabinet,
@@ -9448,7 +9448,7 @@ folder-hook imap://user@host2/ 'set folder=imap://host2/ ; set record=+INBOX/Sen
         POP and IMAP folders because messages usually have to be downloaded
         only once.</para>
         <para>For configuration, the variable
-        <link linkend="message-cachedir">$message_cachedir</link>must point to
+        <link linkend="message-cachedir">$message_cachedir</link> must point to
         a directory. There, Mutt will create a hierarchy of subdirectories
         named like the account and mailbox path the cache is for.</para>
       </sect2>
@@ -9456,8 +9456,8 @@ folder-hook imap://user@host2/ 'set folder=imap://host2/ ; set record=+INBOX/Sen
       <sect2 id="cache-dirs">
         <title>Cache Directories</title>
         <para>For using both, header and body caching,
-        <link linkend="header-cache">$header_cache</link>and
-        <link linkend="message-cachedir">$message_cachedir</link>can be safely
+        <link linkend="header-cache">$header_cache</link> and
+        <link linkend="message-cachedir">$message_cachedir</link> can be safely
         set to the same value.</para>
         <para>In a header or body cache directory, Mutt creates a directory
         hierarchy named like:
@@ -9482,7 +9482,7 @@ folder-hook imap://user@host2/ 'set folder=imap://host2/ ; set record=+INBOX/Sen
         disk space freed by removing messages is re-used.</para>
         <para>For body caches, Mutt can keep the local cache in sync with the
         remote mailbox if the
-        <link linkend="message-cache-clean">$message_cache_clean</link>variable
+        <link linkend="message-cache-clean">$message_cache_clean</link> variable
         is set. Cleaning means to remove messages from the cache which are no
         longer present in the mailbox which only happens when other mail
         clients or instances of Mutt using a different body cache location
@@ -9999,7 +9999,7 @@ bind index,pager @ compose-to-sender
           <title>Security</title>
           <para>Encrypted files are decrypted into temporary files which are
           stored in the
-          <link linkend="tmpdir">$tmpdir</link>directory. This could be a
+          <link linkend="tmpdir">$tmpdir</link> directory. This could be a
           security risk.</para>
         </sect3>
       </sect2>
@@ -10134,7 +10134,7 @@ close-hook  '\.gpg$' "gpg --encrypt --recipient YourGpgUserIdOrKeyId &lt; '%t' &
         <title>Introduction</title>
         <para>The
         <quote>Conditional Dates</quote>feature allows you to construct
-        <link linkend="index-format">$index_format</link>expressions based on
+        <link linkend="index-format">$index_format</link> expressions based on
         the age of the email.</para>
         <para>Mutt's default
         <literal>$index_format</literal>displays email dates in the form:
@@ -10523,7 +10523,7 @@ set index_format='%4C %Z %&lt;[y?%&lt;[m?%&lt;[d?%[%H:%M ]&amp;%[%a %d]&gt;&amp;
         <link linkend="fcc-clear">$fcc_clear</link>.</para>
         <para>A better option is to enable
         <link linkend="smime-encrypt-self">$smime_encrypt_self</link>, then set
-        <link linkend="smime-default-key">$smime_default_key</link>to your
+        <link linkend="smime-default-key">$smime_default_key</link> to your
         personal S/MIME key id.</para>
         <screen>
 set smime_encrypt_self = yes
@@ -10531,7 +10531,7 @@ set smime_default_key  = bb345e23.0
 </screen>
         <para>Or, if you use PGP,
         <link linkend="pgp-encrypt-self">$pgp_encrypt_self</link>, then set
-        <link linkend="pgp-sign-as">$pgp_sign_as</link>to your personal PGP key
+        <link linkend="pgp-sign-as">$pgp_sign_as</link> to your personal PGP key
         id.</para>
         <screen>
 set pgp_encrypt_self = yes
@@ -10645,7 +10645,7 @@ set pgp_encrypt_self = "no"
         <para>This feature changes a few places where Mutt creates temporary
         files. It replaces them with in-memory buffers. This should improve the
         performance when searching the header or body using the
-        <link linkend="thorough-search">$thorough_search</link>option.</para>
+        <link linkend="thorough-search">$thorough_search</link> option.</para>
         <para>There are no user-configurable parts.</para>
         <para>This feature depends on
         <literal>open_memstream()</literal>and
@@ -10992,7 +10992,7 @@ finish                                  <emphasis role="comment"># Finish readin
         <para>Here a symbol can be a
         <link linkend="variables">$variable</link>,
         <link linkend="functions">&lt;function&gt;</link>,
-        <link linkend="commands">command</link>or compile-time symbol, such as
+        <link linkend="commands">command</link> or compile-time symbol, such as
         <quote>imap</quote>.</para>
         <para>A list of compile-time symbols can be seen in the output of the
         command <screen>mutt -v</screen> (in the <quote>Compile options</quote>
@@ -11340,7 +11340,7 @@ color index_size cyan default
         initials.</para>
         <para>The index panel displays a list of emails. Its layout is
         controlled by the
-        <link linkend="index-format">$index_format</link>variable. Using this
+        <link linkend="index-format">$index_format</link> variable. Using this
         expando saves space in the index panel. This can be useful if you are
         regularly working with a small set of people.</para>
       </sect2>
@@ -11349,7 +11349,7 @@ color index_size cyan default
         <title>Variables</title>
         <para>This feature has no config of its own. It adds an expando which
         can be used in the
-        <link linkend="index-format">$index_format</link>variable.</para>
+        <link linkend="index-format">$index_format</link> variable.</para>
       </sect2>
 
       <sect2 id="initials-muttrc">
@@ -12194,22 +12194,22 @@ set new_mail_command = ""
         <title>Introduction</title>
         <para>Reading news via NNTP</para>
         <para>If Mutt is compiled with the
-        <emphasis>--enable-nntp</emphasis>option, it can read from a news
+        <emphasis>--enable-nntp</emphasis> option, it can read from a news
         server using NNTP.</para>
         <para>The default news server can be obtained from the
-        <literal>$NNTPSERVER</literal>environment variable or from the
-        <literal>/etc/nntpserver</literal>file. Like in other news readers,
+        <literal>$NNTPSERVER</literal> environment variable or from the
+        <literal>/etc/nntpserver</literal> file. Like in other news readers,
         information about the subscribed newsgroups is saved in the file
         specified by the
-        <link linkend="newsrc">$newsrc</link>variable. You can open a newsgroup
+        <link linkend="newsrc">$newsrc</link> variable. You can open a newsgroup
         with the function
         <literal>&lt;change-newsgroup&gt;</literal></para>
         <para>The variable
-        <link linkend="news-cache-dir">$news_cache_dir</link>can be used to
+        <link linkend="news-cache-dir">$news_cache_dir</link> can be used to
         point to a directory. Mutt will create a hierarchy of subdirectories
         named like the account and newsgroup the cache is for. The hierarchy is
         also used to store header cache if Mutt was compiled with
-        <link linkend="header-caching">header cache</link>support.</para>
+        <link linkend="header-caching">header cache</link> support.</para>
       </sect2>
 
       <sect2 id="nntp-variables">
@@ -12855,7 +12855,7 @@ virtual-mailboxes "My INBOX" "notmuch://?query=tag:inbox"
           <para>For an explanation of
           <quote>soft-fill</quote>, see the
           <link linkend="index-format">
-          $index_format</link>documentation.</para>
+          $index_format</link> documentation.</para>
           <para>* = can be optionally printed if nonzero</para>
         </sect3>
       </sect2>
@@ -14033,7 +14033,7 @@ set sort_browser="reverse-size"
         </cmdsynopsis>
         <para>This command specifies mailboxes that will always be displayed in
         the sidebar, even if
-        <link linkend="sidebar-new-mail-only">$sidebar_new_mail_only</link>is
+        <link linkend="sidebar-new-mail-only">$sidebar_new_mail_only</link> is
         set and the mailbox does not contain new mail.</para>
         <para>The
         <quote>unsidebar_whitelist</quote>command is used to remove a mailbox
@@ -14715,21 +14715,21 @@ color status brightwhite default 'Mutt: ([^ ]+)' 1
         <para>In Mutt, when you
         <quote>delete</quote>an email it is first marked deleted. The email
         isn't really gone until
-        <link linkend="index-map">&lt;sync-mailbox&gt;</link>is called. This
+        <link linkend="index-map">&lt;sync-mailbox&gt;</link> is called. This
         happens when the user leaves the folder, or the function is called
         manually.</para>
         <para>After
         <literal>&lt;sync-mailbox&gt;</literal>has been called the email is
         gone forever.</para>
         <para>The
-        <link linkend="trash">$trash</link>variable defines a folder in which
+        <link linkend="trash">$trash</link> variable defines a folder in which
         to keep old emails. As before, first you mark emails for deletion. When
         &lt;sync-mailbox&gt; is called the emails are moved to the trash
         folder.</para>
         <para>The
         <literal>$trash</literal>path can be either a full directory, or be
         relative to the
-        <link linkend="folder">$folder</link>variable, like the
+        <link linkend="folder">$folder</link> variable, like the
         <literal>mailboxes</literal>command.</para>
         <note>
           <para>Emails deleted from the trash folder are gone forever.</para>
@@ -14877,7 +14877,7 @@ bind index D purge-message
       by other users and maybe even readable in case of misconfiguration. Also,
       a different location for these files may be desired which can be changed
       via the
-      <link linkend="tmpdir">$tmpdir</link>variable.</para>
+      <link linkend="tmpdir">$tmpdir</link> variable.</para>
     </sect1>
 
     <sect1 id="security-leaks">
@@ -14893,7 +14893,7 @@ bind index D purge-message
         mutt session, others can make assumptions about your mailing habits
         depending on the number of messages sent. If this is not desired, the
         header can be manually provided using
-        <link linkend="edit-headers">$edit_headers</link>(though not
+        <link linkend="edit-headers">$edit_headers</link> (though not
         recommended).</para>
       </sect2>
 
@@ -14907,7 +14907,7 @@ bind index D purge-message
         files using
         <link linkend="attach-header">the Attach: pseudoheader</link>. This may
         be problematic if the
-        <link linkend="edit-headers">$edit-headers</link>variable is
+        <link linkend="edit-headers">$edit-headers</link> variable is
         <emphasis>unset</emphasis>, i.e. the user doesn't want to see header
         fields while editing the message and doesn't pay enough attention to
         the compose menu's listing of attachments.</para>
@@ -14962,14 +14962,14 @@ bind index D purge-message
         </listitem>
         <listitem>
           <para>Mutt provides the
-          <link linkend="read-inc">$read_inc</link>and
-          <link linkend="write-inc">$write_inc</link>variables to specify at
+          <link linkend="read-inc">$read_inc</link> and
+          <link linkend="write-inc">$write_inc</link> variables to specify at
           which rate to update progress counters. If these values are too low,
           Mutt may spend more time on updating the progress counter than it
           spends on actually reading/writing folders.</para>
           <para>For example, when opening a maildir folder with a few thousand
           messages, the default value for
-          <link linkend="read-inc">$read_inc</link>may be too low. It can be
+          <link linkend="read-inc">$read_inc</link> may be too low. It can be
           tuned on on a folder-basis using
           <link linkend="folder-hook">
           <command>folder-hook</command>s</link>:</para>
@@ -14988,7 +14988,7 @@ folder-hook ^pop 'set read_inc=1'</screen>
       desirable as they produce either too few or too much progress updates.
       Thus, Mutt allows to limit the number of progress updates per second
       it'll actually send to the terminal using the
-      <link linkend="time-inc">$time_inc</link>variable.</para>
+      <link linkend="time-inc">$time_inc</link> variable.</para>
     </sect1>
 
     <sect1 id="tuning-messages">
@@ -14999,7 +14999,7 @@ folder-hook ^pop 'set read_inc=1'</screen>
       will be gone for the next session.)</para>
       <para>To improve performance and permanently cache whole messages, please
       refer to Mutt's so-called
-      <link linkend="body-caching">body caching</link>for details.</para>
+      <link linkend="body-caching">body caching</link> for details.</para>
     </sect1>
 
     <sect1 id="tuning-search">

--- a/doc/manual.xml.tail
+++ b/doc/manual.xml.tail
@@ -6,7 +6,7 @@
     mapping in which they are available. The default key setting is given, and
     an explanation of what the function does. The key bindings of these
     functions can be changed with the
-    <link linkend="bind">bind</link>command.</para>
+    <link linkend="bind">bind</link> command.</para>
 
 __print_map(generic)
 __print_map(index)


### PR DESCRIPTION
* **What does this PR do?**

    fixes some spaces in the manual. thanks to Bo YU <tsu.yubo@gmail.com> for reporting this on the
neomutt-devel mailinglist.


@neomutt/reviewers please review.