### PR TITLE
[WIP] use ~/.mutt/log/$pid-$date by default as log file

### DIFF
--- a/globals.h
+++ b/globals.h
@@ -235,6 +235,7 @@ WHERE short NntpContext;
 #endif
 
 WHERE short DebugLevel;
+WHERE char *DebugDir;
 WHERE char *DebugFile;
 
 WHERE short MenuContext;

--- a/init.c
+++ b/init.c
@@ -32,6 +32,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
+#include <sys/types.h>
 #include <sys/utsname.h>
 #include <unistd.h>
 #include <wchar.h>
@@ -64,6 +65,8 @@
 #ifdef USE_IMAP
 #include "imap/imap.h" /* for imap_subscribe() */
 #endif
+
+static char *saved_DebugFileFormat;
 
 #define CHECK_PAGER                                                                  \
   if ((CurrentMenu == MENU_PAGER) && (idx >= 0) && (MuttVars[idx].flags & R_RESORT)) \
@@ -2078,23 +2081,56 @@ char **mutt_envlist(void)
  */
 static void start_debug(void)
 {
-  if (!DebugFile)
-    return;
+  struct stat s;
+  int does_path_exist = stat(DebugDir, &s);
 
-  char buf[_POSIX_PATH_MAX];
-
-  /* rotate the old debug logs */
-  for (int i = 3; i >= 0; i--)
+  if (does_path_exist != 0)
   {
-    snprintf(debugfilename, sizeof(debugfilename), "%s%d", DebugFile, i);
-    snprintf(buf, sizeof(buf), "%s%d", DebugFile, i + 1);
+    // iterate though the directory tree to create every folder
+    for (int i = 0; DebugDir[i] != '\0'; i++)
+    {
+      if (DebugDir[i] == '/')
+      {
+        // temporary replacement
+        DebugDir[i] = '\0';
 
-    mutt_expand_path(debugfilename, sizeof(debugfilename));
-    mutt_expand_path(buf, sizeof(buf));
-    rename(debugfilename, buf);
+        mkdir(DebugDir, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
+        DebugDir[i] = '/';
+
+      }
+    }
   }
 
-  debugfile = mutt_file_fopen(debugfilename, "w");
+  char buf[_POSIX_PATH_MAX] = {0};
+
+  time_t t;
+  t = time(NULL);
+
+  struct tm *creation_time = localtime(&t);
+
+  // filename should consist of
+  //  - path
+  //  - current time
+  //  - pid of current program.
+  snprintf(buf, sizeof(buf), "%s", DebugDir);
+
+  int pid = (int) getpid();
+  snprintf(buf + strlen(buf), sizeof(buf), "pid%d-", pid);
+
+  // append to existing part
+  strftime(buf + strlen(buf), sizeof(buf), DebugFile, creation_time);
+
+
+  // save the current name of the DebugFile, to test later if it has changed.
+  // static is needed, because restart_debug needs to read the value later.
+  //
+  // save the current format of DebugFile.
+  // --> PID stays always the same
+  // --> creation_time only changes if a new debugfile is used.
+  //
+  saved_DebugFileFormat = DebugFile;
+
+  debugfile = mutt_file_fopen(buf, "w");
   if (debugfile)
   {
     setbuf(debugfile, NULL); /* don't buffer the debugging output! */
@@ -2105,7 +2141,7 @@ static void start_debug(void)
 /**
  * restart_debug - reload the debugging configuration
  *
- * This method closes the old debug file is debug was enabled,
+ * This method closes the old debug file if debug was enabled,
  * then reconfigure the debugging system from the configuration options
  * and start a new debug file if debug is enabled
  */
@@ -2114,8 +2150,8 @@ static void restart_debug(void)
   bool disable_debug = (debuglevel > 0 && DebugLevel == 0);
   bool enable_debug = (debuglevel == 0 && DebugLevel > 0);
   bool file_changed =
-      ((mutt_str_strlen(debugfilename) - 1) != mutt_str_strlen(DebugFile) ||
-       mutt_str_strncmp(debugfilename, DebugFile, mutt_str_strlen(debugfilename) - 1));
+      ((mutt_str_strlen(saved_DebugFileFormat)) != mutt_str_strlen(DebugFile) ||
+       mutt_str_strcmp(saved_DebugFileFormat, DebugFile));
 
   if (disable_debug || file_changed)
   {

--- a/init.h
+++ b/init.h
@@ -672,12 +672,18 @@ struct Option MuttVars[] = {
   ** debug_level/debug_file are ignored until it's read from the configuration
   ** file.
   */
-  { "debug_file", DT_PATH, R_NONE, UL &DebugFile, UL "~/.neomuttdebug" },
+  { "debug_dir", DT_PATH, R_NONE, UL &DebugDir, UL "~/.neomutt/log/" },
   /*
   ** .pp
-  ** The location prefix of the debug file, 0 is append to the debug file
-  ** Old debug files are renamed with the prefix 1, 2, 3 and 4.
-  ** See ``debug_level'' for more detail.
+  ** The location to save all debug files, whose format is controlled by
+  ** ``debug_file''.
+  */
+  { "debug_file", DT_PATH, R_NONE, UL &DebugFile, UL "%F_-_%R.log" },
+  /*
+  ** .pp
+  ** The filename of the debug file. It uses per default the ISO 8601 date format
+  ** (%Y-%m-%d).
+  ** See ``debug_level'' and ``debug_dir'' for more detail.
   */
   { "default_hook",     DT_STRING,  R_NONE, UL &DefaultHook, UL "~f %s !~P | (~P ~C %s)" },
   /*

--- a/mutt.h
+++ b/mutt.h
@@ -294,7 +294,6 @@ const char *mutt_str_sysexit(int e);
 
 char *mutt_compile_help(char *buf, size_t buflen, int menu, const struct Mapping *items);
 
-extern char debugfilename[_POSIX_PATH_MAX];
 extern FILE *debugfile;
 extern int debuglevel;
 extern char *debugfile_cmdline;


### PR DESCRIPTION
* **What does this PR do?**

    * add new config variable `debug_dir`, which defaults to `~/.mutt/log`
    * create directory tree of `debug_dir` if it doesn't exist
    * use the pid of the current process and the current date as default for the log filename.

* **What are the relevant issue numbers?**

    * part of #625 


*  **TODO**

    * fix `restart_debug`
        * When debug_file is changed, start_debug() is not executed.
    * fix documentation.