### PR TITLE
notmuch: drop VirtIncoming

### DIFF
--- a/browser.c
+++ b/browser.c
@@ -738,10 +738,10 @@ static int examine_directory(struct Menu *menu, struct BrowserState *state,
 #ifdef USE_NOTMUCH
 static int examine_vfolders(struct Menu *menu, struct BrowserState *state)
 {
-  struct Buffy *tmp = VirtIncoming;
-
-  if (!VirtIncoming)
+  struct Buffy *tmp = Incoming;
+  if (!tmp)
     return -1;
+
   mutt_buffy_check(false);
 
   init_state(state, menu);

--- a/buffy.c
+++ b/buffy.c
@@ -456,13 +456,12 @@ static struct Buffy *buffy_get(const char *path)
 void mutt_buffy_cleanup(const char *buf, struct stat *st)
 {
   struct utimbuf ut;
-  struct Buffy *tmp = NULL;
 
   if (option(OPTCHECKMBOXSIZE))
   {
-    tmp = mutt_find_mailbox(buf);
-    if (tmp && !tmp->new)
-      mutt_update_mailbox(tmp);
+    struct Buffy *b = mutt_find_mailbox(buf);
+    if (b && !b->new)
+      mutt_update_mailbox(b);
   }
   else
   {
@@ -480,20 +479,19 @@ void mutt_buffy_cleanup(const char *buf, struct stat *st)
 
 struct Buffy *mutt_find_mailbox(const char *path)
 {
-  struct Buffy *tmp = NULL;
   struct stat sb;
   struct stat tmp_sb;
 
   if (stat(path, &sb) != 0)
     return NULL;
 
-  for (tmp = Incoming; tmp; tmp = tmp->next)
+  for (struct Buffy *b = Incoming; b; b = b->next)
   {
-    if (stat(tmp->path, &tmp_sb) == 0 && sb.st_dev == tmp_sb.st_dev &&
+    if (stat(b->path, &tmp_sb) == 0 && sb.st_dev == tmp_sb.st_dev &&
         sb.st_ino == tmp_sb.st_ino)
-      break;
+      return b;
   }
-  return tmp;
+  return NULL;
 }
 
 void mutt_update_mailbox(struct Buffy *b)
@@ -513,7 +511,7 @@ void mutt_update_mailbox(struct Buffy *b)
 int mutt_parse_mailboxes(struct Buffer *path, struct Buffer *s,
                          unsigned long data, struct Buffer *err)
 {
-  struct Buffy **tmp = NULL, *tmp1 = NULL;
+  struct Buffy **b = NULL, *tmp1 = NULL;
   char buf[_POSIX_PATH_MAX];
   struct stat sb;
   char f1[PATH_MAX];
@@ -526,14 +524,14 @@ int mutt_parse_mailboxes(struct Buffer *path, struct Buffer *s,
 
     if (data == MUTT_UNMAILBOXES && (mutt_strcmp(buf, "*") == 0))
     {
-      for (tmp = &Incoming; *tmp;)
+      for (b = &Incoming; *b;)
       {
-        tmp1 = (*tmp)->next;
+        tmp1 = (*b)->next;
 #ifdef USE_SIDEBAR
-        mutt_sb_notify_mailbox(*tmp, 0);
+        mutt_sb_notify_mailbox(*b, 0);
 #endif
-        buffy_free(tmp);
-        *tmp = tmp1;
+        buffy_free(b);
+        *b = tmp1;
       }
       return 0;
     }
@@ -546,53 +544,53 @@ int mutt_parse_mailboxes(struct Buffer *path, struct Buffer *s,
 
     /* avoid duplicates */
     p = realpath(buf, f1);
-    for (tmp = &Incoming; *tmp; tmp = &((*tmp)->next))
+    for (b = &Incoming; *b; b = &((*b)->next))
     {
-      if (mutt_strcmp(p ? p : buf, (*tmp)->realpath) == 0)
+      if (mutt_strcmp(p ? p : buf, (*b)->realpath) == 0)
       {
-        mutt_debug(3, "mailbox '%s' already registered as '%s'\n", buf, (*tmp)->path);
+        mutt_debug(3, "mailbox '%s' already registered as '%s'\n", buf, (*b)->path);
         break;
       }
     }
 
     if (data == MUTT_UNMAILBOXES)
     {
-      if (*tmp)
+      if (*b)
       {
-        tmp1 = (*tmp)->next;
+        tmp1 = (*b)->next;
 #ifdef USE_SIDEBAR
-        mutt_sb_notify_mailbox(*tmp, 0);
+        mutt_sb_notify_mailbox(*b, 0);
 #endif
-        buffy_free(tmp);
-        *tmp = tmp1;
+        buffy_free(b);
+        *b = tmp1;
       }
       continue;
     }
 
-    if (!*tmp)
+    if (!*b)
     {
-      *tmp = buffy_new(buf);
+      *b = buffy_new(buf);
 #ifdef USE_SIDEBAR
-      mutt_sb_notify_mailbox(*tmp, 1);
+      mutt_sb_notify_mailbox(*b, 1);
 #endif
     }
 
-    (*tmp)->new = false;
-    (*tmp)->notified = true;
-    (*tmp)->newly_created = false;
+    (*b)->new = false;
+    (*b)->notified = true;
+    (*b)->newly_created = false;
 
     /* for check_mbox_size, it is important that if the folder is new (tested by
      * reading it), the size is set to 0 so that later when we check we see
      * that it increased .  without check_mbox_size we probably don't care.
      */
-    if (option(OPTCHECKMBOXSIZE) && stat((*tmp)->path, &sb) == 0 &&
-        !test_new_folder((*tmp)->path))
+    if (option(OPTCHECKMBOXSIZE) && stat((*b)->path, &sb) == 0 &&
+        !test_new_folder((*b)->path))
     {
       /* some systems out there don't have an off_t type */
-      (*tmp)->size = (off_t) sb.st_size;
+      (*b)->size = (off_t) sb.st_size;
     }
     else
-      (*tmp)->size = 0;
+      (*b)->size = 0;
   }
   return 0;
 }
@@ -604,7 +602,7 @@ int mutt_parse_virtual_mailboxes(struct Buffer *path, struct Buffer *s,
   if (!path || !s)
     return -1;
 
-  struct Buffy **tmp = NULL;
+  struct Buffy **b = NULL;
   char buf[_POSIX_PATH_MAX + LONG_STRING + 32]; /* path to DB + query + URI "decoration" */
 
   while (MoreArgs(s))
@@ -628,27 +626,27 @@ int mutt_parse_virtual_mailboxes(struct Buffer *path, struct Buffer *s,
     }
 
     /* avoid duplicates */
-    for (tmp = &VirtIncoming; *tmp; tmp = &((*tmp)->next))
+    for (b = &VirtIncoming; *b; b = &((*b)->next))
     {
-      if (mutt_strcmp(buf, (*tmp)->path) == 0)
+      if (mutt_strcmp(buf, (*b)->path) == 0)
       {
         mutt_debug(3, "virtual mailbox '%s' already registered as '%s'\n", buf,
-                   (*tmp)->path);
+                   (*b)->path);
         break;
       }
     }
 
-    if (!*tmp)
-      *tmp = buffy_new(buf);
+    if (!*b)
+      *b = buffy_new(buf);
 
-    (*tmp)->magic = MUTT_NOTMUCH;
-    (*tmp)->new = false;
-    (*tmp)->notified = true;
-    (*tmp)->newly_created = false;
-    (*tmp)->size = 0;
-    (*tmp)->desc = desc;
+    (*b)->magic = MUTT_NOTMUCH;
+    (*b)->new = false;
+    (*b)->notified = true;
+    (*b)->newly_created = false;
+    (*b)->size = 0;
+    (*b)->desc = desc;
 #ifdef USE_SIDEBAR
-    mutt_sb_notify_mailbox(*tmp, 1);
+    mutt_sb_notify_mailbox(*b, 1);
 #endif
   }
 #ifdef USE_SIDEBAR
@@ -660,7 +658,7 @@ int mutt_parse_virtual_mailboxes(struct Buffer *path, struct Buffer *s,
 int mutt_parse_unvirtual_mailboxes(struct Buffer *path, struct Buffer *s,
                                    unsigned long data, struct Buffer *err)
 {
-  struct Buffy **tmp = NULL, *tmp1 = NULL;
+  struct Buffy **b = NULL, *tmp1 = NULL;
 
   while (MoreArgs(s))
   {
@@ -668,14 +666,14 @@ int mutt_parse_unvirtual_mailboxes(struct Buffer *path, struct Buffer *s,
 
     if (mutt_strcmp(path->data, "*") == 0)
     {
-      for (tmp = &VirtIncoming; *tmp;)
+      for (b = &VirtIncoming; *b;)
       {
-        tmp1 = (*tmp)->next;
+        tmp1 = (*b)->next;
 #ifdef USE_SIDEBAR
-        mutt_sb_notify_mailbox(*tmp, 0);
+        mutt_sb_notify_mailbox(*b, 0);
 #endif
-        buffy_free(tmp);
-        *tmp = tmp1;
+        buffy_free(b);
+        *b = tmp1;
       }
 #ifdef USE_SIDEBAR
       mutt_sb_draw();
@@ -683,17 +681,17 @@ int mutt_parse_unvirtual_mailboxes(struct Buffer *path, struct Buffer *s,
       return 0;
     }
 
-    for (tmp = &VirtIncoming; *tmp; tmp = &((*tmp)->next))
+    for (b = &VirtIncoming; *b; b = &((*b)->next))
     {
-      if ((mutt_strcasecmp(path->data, (*tmp)->path) == 0) ||
-          (mutt_strcasecmp(path->data, (*tmp)->desc) == 0))
+      if ((mutt_strcasecmp(path->data, (*b)->path) == 0) ||
+          (mutt_strcasecmp(path->data, (*b)->desc) == 0))
       {
-        tmp1 = (*tmp)->next;
+        tmp1 = (*b)->next;
 #ifdef USE_SIDEBAR
-        mutt_sb_notify_mailbox(*tmp, 0);
+        mutt_sb_notify_mailbox(*b, 0);
 #endif
-        buffy_free(tmp);
-        *tmp = tmp1;
+        buffy_free(b);
+        *b = tmp1;
         break;
       }
     }
@@ -711,7 +709,6 @@ int mutt_parse_unvirtual_mailboxes(struct Buffer *path, struct Buffer *s,
  */
 int mutt_buffy_check(bool force)
 {
-  struct Buffy *tmp = NULL;
   struct stat contex_sb;
   time_t t;
   bool check_stats = false;
@@ -761,12 +758,12 @@ int mutt_buffy_check(bool force)
     contex_sb.st_ino = 0;
   }
 
-  for (tmp = Incoming; tmp; tmp = tmp->next)
-    buffy_check(tmp, &contex_sb, check_stats);
+  for (struct Buffy *b = Incoming; b; b = b->next)
+    buffy_check(b, &contex_sb, check_stats);
 
 #ifdef USE_NOTMUCH
-  for (tmp = VirtIncoming; tmp; tmp = tmp->next)
-    buffy_check(tmp, &contex_sb, check_stats);
+  for (struct Buffy *b = VirtIncoming; b; b = b->next)
+    buffy_check(b, &contex_sb, check_stats);
 #endif
 
   BuffyDoneTime = BuffyTime;
@@ -775,7 +772,7 @@ int mutt_buffy_check(bool force)
 
 int mutt_buffy_list(void)
 {
-  struct Buffy *tmp = NULL;
+  struct Buffy *b = NULL;
   char path[_POSIX_PATH_MAX];
   char buffylist[2 * STRING];
   size_t pos = 0;
@@ -785,13 +782,13 @@ int mutt_buffy_list(void)
 
   buffylist[0] = 0;
   pos += strlen(strncat(buffylist, _("New mail in "), sizeof(buffylist) - 1 - pos));
-  for (tmp = Incoming; tmp; tmp = tmp->next)
+  for (b = Incoming; b; b = b->next)
   {
     /* Is there new mail in this mailbox? */
-    if (!tmp->new || (have_unnotified && tmp->notified))
+    if (!b->new || (have_unnotified && b->notified))
       continue;
 
-    strfcpy(path, tmp->path, sizeof(path));
+    strfcpy(path, b->path, sizeof(path));
     mutt_pretty_mailbox(path, sizeof(path));
 
     if (!first && (MuttMessageWindow->cols >= 7) &&
@@ -802,16 +799,16 @@ int mutt_buffy_list(void)
       pos += strlen(strncat(buffylist + pos, ", ", sizeof(buffylist) - 1 - pos));
 
     /* Prepend an asterisk to mailboxes not already notified */
-    if (!tmp->notified)
+    if (!b->notified)
     {
       /* pos += strlen (strncat(buffylist + pos, "*", sizeof(buffylist)-1-pos)); */
-      tmp->notified = true;
+      b->notified = true;
       BuffyNotify--;
     }
     pos += strlen(strncat(buffylist + pos, path, sizeof(buffylist) - 1 - pos));
     first = 0;
   }
-  if (!first && tmp)
+  if (!first && b)
   {
     strncat(buffylist + pos, ", ...", sizeof(buffylist) - 1 - pos);
   }
@@ -856,7 +853,6 @@ int mutt_buffy_notify(void)
  */
 void mutt_buffy(char *s, size_t slen)
 {
-  struct Buffy *tmp = Incoming;
   int pass, found = 0;
 
   mutt_expand_path(s, slen);
@@ -864,18 +860,20 @@ void mutt_buffy(char *s, size_t slen)
   if (mutt_buffy_check(false))
   {
     for (pass = 0; pass < 2; pass++)
-      for (tmp = Incoming; tmp; tmp = tmp->next)
+    {
+      for (struct Buffy *b = Incoming; b; b = b->next)
       {
-        mutt_expand_path(tmp->path, sizeof(tmp->path));
-        if ((found || pass) && tmp->new)
+        mutt_expand_path(b->path, sizeof(b->path));
+        if ((found || pass) && b->new)
         {
-          strfcpy(s, tmp->path, slen);
+          strfcpy(s, b->path, slen);
           mutt_pretty_mailbox(s, slen);
           return;
         }
-        if (mutt_strcmp(s, tmp->path) == 0)
+        if (mutt_strcmp(s, b->path) == 0)
           found = 1;
       }
+    }
 
     mutt_buffy_check(true); /* buffy was wrong - resync things */
   }
@@ -887,22 +885,21 @@ void mutt_buffy(char *s, size_t slen)
 #ifdef USE_NOTMUCH
 void mutt_buffy_vfolder(char *s, size_t slen)
 {
-  struct Buffy *tmp = NULL;
-  int pass, found = 0;
+  bool found = false;
 
   if (mutt_buffy_check(false))
   {
-    for (pass = 0; pass < 2; pass++)
+    for (int pass = 0; pass < 2; pass++)
     {
-      for (tmp = VirtIncoming; tmp; tmp = tmp->next)
+      for (struct Buffy *b = VirtIncoming; b; b = b->next)
       {
-        if ((found || pass) && tmp->new)
+        if ((found || pass) && b->new)
         {
-          strfcpy(s, tmp->desc, slen);
+          strfcpy(s, b->desc, slen);
           return;
         }
-        if (mutt_strcmp(s, tmp->path) == 0)
-          found = 1;
+        if (mutt_strcmp(s, b->path) == 0)
+          found = true;
       }
     }
 

--- a/buffy.h
+++ b/buffy.h
@@ -26,10 +26,6 @@
 
 struct stat;
 
-/* parameter to mutt_parse_mailboxes */
-#define MUTT_MAILBOXES   1
-#define MUTT_UNMAILBOXES 2
-
 struct Buffy
 {
   char path[_POSIX_PATH_MAX];

--- a/buffy.h
+++ b/buffy.h
@@ -26,6 +26,10 @@
 
 struct stat;
 
+/* parameter to mutt_parse_mailboxes */
+#define MUTT_NAMED   1
+#define MUTT_VIRTUAL 2
+
 struct Buffy
 {
   char path[_POSIX_PATH_MAX];
@@ -53,7 +57,6 @@ WHERE short BuffyTimeout INITVAL(3);
 WHERE short BuffyCheckStatsInterval INITVAL(60);
 
 #ifdef USE_NOTMUCH
-WHERE struct Buffy *VirtIncoming INITVAL(0);
 void mutt_buffy_vfolder(char *s, size_t slen);
 #endif
 

--- a/init.c
+++ b/init.c
@@ -64,6 +64,7 @@
 #include "options.h"
 #include "pattern.h"
 #include "rfc822.h"
+#include "sidebar.h"
 #include "version.h"
 #ifdef USE_NOTMUCH
 #include "mutt_notmuch.h"
@@ -4281,8 +4282,19 @@ void mutt_init(int skip_sys_rc, struct List *commands)
   mutt_read_histfile();
 
 #ifdef USE_NOTMUCH
-  if (option(OPTVIRTSPOOLFILE) && VirtIncoming)
-    mutt_str_replace(&Spoolfile, VirtIncoming->path);
+  if (option(OPTVIRTSPOOLFILE))
+  {
+    /* Find the first virtual folder and open it */
+    for (struct Buffy *b = Incoming; b; b = b->next)
+    {
+      if (b->magic == MUTT_NOTMUCH)
+      {
+        mutt_str_replace(&Spoolfile, b->path);
+        mutt_sb_toggle_virtual();
+        break;
+      }
+    }
+  }
 #endif
 
   FREE(&err.data);

--- a/init.h
+++ b/init.h
@@ -4566,8 +4566,8 @@ const struct Command Commands[] = {
   { "lua-source",       mutt_lua_source_file,   0 },
 #endif
   { "macro",            mutt_parse_macro,       0 },
-  { "mailboxes",        mutt_parse_mailboxes,   MUTT_MAILBOXES },
-  { "unmailboxes",      mutt_parse_mailboxes,   MUTT_UNMAILBOXES },
+  { "mailboxes",        mutt_parse_mailboxes,   0 },
+  { "unmailboxes",      mutt_parse_unmailboxes, 0 },
 #ifdef USE_NOTMUCH
   { "virtual-mailboxes",mutt_parse_virtual_mailboxes, 0 },
   { "unvirtual-mailboxes",mutt_parse_unvirtual_mailboxes, 0 },

--- a/init.h
+++ b/init.h
@@ -4569,8 +4569,8 @@ const struct Command Commands[] = {
   { "mailboxes",        mutt_parse_mailboxes,   0 },
   { "unmailboxes",      mutt_parse_unmailboxes, 0 },
 #ifdef USE_NOTMUCH
-  { "virtual-mailboxes",mutt_parse_virtual_mailboxes, 0 },
-  { "unvirtual-mailboxes",mutt_parse_unvirtual_mailboxes, 0 },
+  { "virtual-mailboxes",mutt_parse_mailboxes,   MUTT_VIRTUAL | MUTT_NAMED },
+  { "unvirtual-mailboxes",mutt_parse_unmailboxes, MUTT_VIRTUAL },
   { "tag-transforms",   parse_tag_transforms,   0 },
   { "tag-formats",      parse_tag_formats,      0 },
 #endif

--- a/mutt_notmuch.c
+++ b/mutt_notmuch.c
@@ -2008,29 +2008,27 @@ done:
 
 char *nm_get_description(struct Context *ctx)
 {
-  struct Buffy *p = NULL;
-
-  for (p = VirtIncoming; p; p = p->next)
-    if (p->desc && (strcmp(p->path, ctx->path) == 0))
-      return p->desc;
+  for (struct Buffy *b = VirtIncoming; b; b = b->next)
+    if (b->desc && (strcmp(b->path, ctx->path) == 0))
+      return b->desc;
 
   return NULL;
 }
 
 int nm_description_to_path(const char *desc, char *buf, size_t bufsz)
 {
-  struct Buffy *p = NULL;
-
   if (!desc || !buf || !bufsz)
     return -EINVAL;
 
-  for (p = VirtIncoming; p; p = p->next)
-    if (p->desc && (strcmp(desc, p->desc) == 0))
+  for (struct Buffy *b = VirtIncoming; b; b = b->next)
+  {
+    if (b->desc && (strcmp(desc, b->desc) == 0))
     {
-      strncpy(buf, p->path, bufsz);
+      strncpy(buf, b->path, bufsz);
       buf[bufsz - 1] = '\0';
       return 0;
     }
+  }
 
   return -1;
 }

--- a/mutt_notmuch.c
+++ b/mutt_notmuch.c
@@ -2008,7 +2008,7 @@ done:
 
 char *nm_get_description(struct Context *ctx)
 {
-  for (struct Buffy *b = VirtIncoming; b; b = b->next)
+  for (struct Buffy *b = Incoming; b; b = b->next)
     if (b->desc && (strcmp(b->path, ctx->path) == 0))
       return b->desc;
 
@@ -2020,9 +2020,9 @@ int nm_description_to_path(const char *desc, char *buf, size_t bufsz)
   if (!desc || !buf || !bufsz)
     return -EINVAL;
 
-  for (struct Buffy *b = VirtIncoming; b; b = b->next)
+  for (struct Buffy *b = Incoming; b; b = b->next)
   {
-    if (b->desc && (strcmp(desc, b->desc) == 0))
+    if ((b->magic != MUTT_NOTMUCH) && b->desc && (strcmp(desc, b->desc) == 0))
     {
       strncpy(buf, b->path, bufsz);
       buf[bufsz - 1] = '\0';

--- a/protos.h
+++ b/protos.h
@@ -328,6 +328,7 @@ int mutt_parse_uncolor(struct Buffer *buf, struct Buffer *s, unsigned long data,
 int mutt_parse_hook(struct Buffer *buf, struct Buffer *s, unsigned long data, struct Buffer *err);
 int mutt_parse_macro(struct Buffer *buf, struct Buffer *s, unsigned long data, struct Buffer *err);
 int mutt_parse_mailboxes(struct Buffer *path, struct Buffer *s, unsigned long data, struct Buffer *err);
+int mutt_parse_unmailboxes(struct Buffer *path, struct Buffer *s, unsigned long data, struct Buffer *err);
 int mutt_parse_mono(struct Buffer *buff, struct Buffer *s, unsigned long data, struct Buffer *err);
 int mutt_parse_unmono(struct Buffer *buf, struct Buffer *s, unsigned long data, struct Buffer *err);
 int mutt_parse_push(struct Buffer *buf, struct Buffer *s, unsigned long data, struct Buffer *err);

--- a/protos.h
+++ b/protos.h
@@ -81,7 +81,6 @@ void mutt_set_parameter(const char *attribute, const char *value, struct Paramet
 
 #ifdef USE_NOTMUCH
 int mutt_parse_virtual_mailboxes(struct Buffer *path, struct Buffer *s, unsigned long data, struct Buffer *err);
-int mutt_parse_unvirtual_mailboxes(struct Buffer *path, struct Buffer *s, unsigned long data, struct Buffer *err);
 #endif
 
 FILE *mutt_open_read(const char *path, pid_t *thepid);

--- a/sidebar.c
+++ b/sidebar.c
@@ -73,38 +73,9 @@ enum div_type
 
 enum sb_src
 {
-  SB_SRC_NONE = 0,
   SB_SRC_INCOMING,
   SB_SRC_VIRT,
-} sidebar_source = SB_SRC_NONE;
-
-static struct Buffy *get_incoming(void)
-{
-  switch (sidebar_source)
-  {
-    case SB_SRC_NONE:
-      sidebar_source = SB_SRC_INCOMING;
-
-#ifdef USE_NOTMUCH
-      if (option(OPTVIRTSPOOLFILE) && VirtIncoming)
-      {
-        sidebar_source = SB_SRC_VIRT;
-        return VirtIncoming;
-      }
-      break;
-    case SB_SRC_VIRT:
-      if (VirtIncoming)
-      {
-        return VirtIncoming;
-      }
-      break;
-#endif
-    case SB_SRC_INCOMING:
-      break;
-  }
-
-  return Incoming; /* default */
-}
+} sidebar_source = SB_SRC_INCOMING;
 
 /**
  * cb_format_str - Create the string to show in the sidebar
@@ -361,6 +332,15 @@ static void update_entries_visibility(void)
 
     sbe->is_hidden = false;
 
+#ifdef USE_NOTMUCH
+    if (((sbe->buffy->magic != MUTT_NOTMUCH) && (sidebar_source == SB_SRC_VIRT)) ||
+        ((sbe->buffy->magic == MUTT_NOTMUCH) && (sidebar_source == SB_SRC_INCOMING)))
+    {
+      sbe->is_hidden = true;
+      continue;
+    }
+#endif
+
     if (!new_only)
       continue;
 
@@ -386,7 +366,7 @@ static void update_entries_visibility(void)
  */
 static void unsort_entries(void)
 {
-  struct Buffy *cur = get_incoming();
+  struct Buffy *cur = Incoming;
   int i = 0, j;
   struct SbEntry *tmp = NULL;
 
@@ -909,7 +889,11 @@ static void draw_sidebar(int num_rows, int num_cols, int div_width)
     else
       sidebar_folder_name = b->path + maildir_is_prefix * (maildirlen + 1);
 
-    if (maildir_is_prefix && option(OPTSIDEBARFOLDERINDENT))
+    if (b->desc)
+    {
+      sidebar_folder_name = b->desc;
+    }
+    else if (maildir_is_prefix && option(OPTSIDEBARFOLDERINDENT))
     {
       const char *tmp_folder_name = NULL;
       int lastsep = 0;
@@ -936,12 +920,6 @@ static void draw_sidebar(int num_rows, int num_cols, int div_width)
         safe_strcat(sidebar_folder_name, sfn_len, tmp_folder_name);
       }
     }
-#ifdef USE_NOTMUCH
-    else if (b->magic == MUTT_NOTMUCH)
-    {
-      sidebar_folder_name = b->desc;
-    }
-#endif
     char str[STRING];
     make_sidebar_entry(str, sizeof(str), w, sidebar_folder_name, entry);
     printw("%s", str);
@@ -979,17 +957,14 @@ void mutt_sb_draw(void)
   int div_width = draw_divider(num_rows, num_cols);
 
   if (!Entries)
-    for (struct Buffy *b = get_incoming(); b; b = b->next)
+    for (struct Buffy *b = Incoming; b; b = b->next)
       mutt_sb_notify_mailbox(b, 1);
 
-  if (!get_incoming())
+  if (!prepare_sidebar(num_rows))
   {
     fill_empty_space(0, num_rows, div_width, num_cols - div_width);
     return;
   }
-
-  if (!prepare_sidebar(num_rows))
-    return;
 
   draw_sidebar(num_rows, num_cols, div_width);
   move(y, x);
@@ -1061,7 +1036,7 @@ void mutt_sb_set_buffystats(const struct Context *ctx)
 {
   /* Even if the sidebar's hidden,
    * we should take note of the new data. */
-  struct Buffy *b = get_incoming();
+  struct Buffy *b = Incoming;
   if (!ctx || !b)
     return;
 
@@ -1136,9 +1111,6 @@ void mutt_sb_notify_mailbox(struct Buffy *b, int created)
   if (!b)
     return;
 
-  if (sidebar_source == SB_SRC_NONE)
-    return;
-
   /* Any new/deleted mailboxes will cause a refresh.  As long as
    * they're valid, our pointers will be updated in prepare_sidebar() */
 
@@ -1194,11 +1166,8 @@ void mutt_sb_notify_mailbox(struct Buffy *b, int created)
  */
 void mutt_sb_toggle_virtual(void)
 {
-  if (sidebar_source == -1)
-    get_incoming();
-
 #ifdef USE_NOTMUCH
-  if ((sidebar_source == SB_SRC_INCOMING) && VirtIncoming)
+  if (sidebar_source == SB_SRC_INCOMING)
     sidebar_source = SB_SRC_VIRT;
   else
 #endif
@@ -1209,13 +1178,19 @@ void mutt_sb_toggle_virtual(void)
   HilIndex = -1;
   BotIndex = -1;
 
-  struct Buffy *b = NULL;
-
+  /* First clear all the sidebar entries */
   EntryCount = 0;
   FREE(&Entries);
   EntryLen = 0;
-  for (b = get_incoming(); b; b = b->next)
-    mutt_sb_notify_mailbox(b, 1);
+  for (struct Buffy *b = Incoming; b; b = b->next)
+  {
+    /* and reintroduce the ones that are visible */
+    if (((b->magic == MUTT_NOTMUCH) && (sidebar_source == SB_SRC_VIRT)) ||
+        ((b->magic != MUTT_NOTMUCH) && (sidebar_source == SB_SRC_INCOMING)))
+    {
+      mutt_sb_notify_mailbox(b, true);
+    }
+  }
 
   mutt_set_current_menu_redraw(REDRAW_SIDEBAR);
 }

--- a/sidebar.c
+++ b/sidebar.c
@@ -51,7 +51,7 @@ struct SbEntry
 {
   char box[STRING]; /* formatted mailbox name */
   struct Buffy *buffy;
-  short is_hidden;
+  bool is_hidden;
 };
 
 static int EntryCount = 0;
@@ -71,13 +71,12 @@ enum div_type
   SB_DIV_UTF8
 };
 
-enum
+enum sb_src
 {
   SB_SRC_NONE = 0,
+  SB_SRC_INCOMING,
   SB_SRC_VIRT,
-  SB_SRC_INCOMING
-};
-static int sidebar_source = SB_SRC_NONE;
+} sidebar_source = SB_SRC_NONE;
 
 static struct Buffy *get_incoming(void)
 {
@@ -360,7 +359,7 @@ static void update_entries_visibility(void)
   {
     sbe = Entries[i];
 
-    sbe->is_hidden = 0;
+    sbe->is_hidden = false;
 
     if (!new_only)
       continue;
@@ -378,7 +377,7 @@ static void update_entries_visibility(void)
       /* Explicitly asked to be visible */
       continue;
 
-    sbe->is_hidden = 1;
+    sbe->is_hidden = true;
   }
 }
 
@@ -979,9 +978,8 @@ void mutt_sb_draw(void)
 
   int div_width = draw_divider(num_rows, num_cols);
 
-  struct Buffy *b = NULL;
   if (!Entries)
-    for (b = get_incoming(); b; b = b->next)
+    for (struct Buffy *b = get_incoming(); b; b = b->next)
       mutt_sb_notify_mailbox(b, 1);
 
   if (!get_incoming())


### PR DESCRIPTION
NotMuch kept its mailboxes in a separate list, `VirtIncoming` rather than `Incoming`.
This lead to some code duplication and complex logic in the sidebar.

1. be36e9f tidy some buffy code
2. c58c838 split mutt_parse_mailboxes into mutt_parse_unmailboxes
3. 5dca538 drop VirtIncoming

From a user's point-of-view nothing has changed, you still use `<sidebar-toggle-virtual>` to switch between normal and virtual mailboxes.  (For now)

I've tested:
- adding normal mailboxes
- removing a single normal mailbox by shortcut `=mailbox`
- removing a single normal mailbox by path `/home/user/mail/mailbox`
- removing all normal mailboxes `*`
- adding virtual mailboxes
- removing a single virtual mailbox by description `neomutt`
- removing a single virtual mailbox by short path `notmuch://?query=neomutt`
- removing a single virtual mailbox by canonical path `notmuch:///home/user/mail/linode?query=neomutt`
- removing all virtual mailboxes `*`

... but I could do with a NotMuch expert giving it a try.

---

This is step one.  What comes next is open to discussion...

I'd like to see a fake mailbox used as a container for the virtual mailboxes.
This mailbox would live in a unified sidebar.