### PR TITLE
Fixes when using colors

### DIFF
--- a/color.c
+++ b/color.c
@@ -426,11 +426,7 @@ static int parse_color_name(const char *s, int *col, int *attr, int is_fg, struc
 
   if (is_bright)
   {
-    if (is_fg)
-    {
-      *attr |= A_BOLD;
-    }
-    else if (COLORS < 16)
+    if (COLORS < 16)
     {
       /* A_BLINK turns the background color brite on some terms */
       *attr |= A_BLINK;


### PR DESCRIPTION
This PR fixes some colors misbehavior:
 * [**merged**] the background color of the "tree" element, used to display mail threads is meaning less, because it mixes with the background color of the indexes subject in unexpected ways (and this latter background color is variable). It is better to create new color pairs dynamically, using the fixed "tree" foreground color, and whatever background color the "tree" element is supposed to use for a given message.

  * [**workaround found**] the color having "bright" in its color name should not always have the bold attribute, because some colors schemes like solarized don't have the notion of color "brightness", which just represents of position in the color palette.

 * [**merged**] the flags modifications in a collapsed sub-tree should modify the root message of the tree **last**, because some color patterns updates that immediately follows, may take into account the status of the other hidden messages in this collapsed sub-tree, for example `~v~(~D)`

