### PR TITLE
fix gpgme S/MIME non-detached signature handling

### DIFF
--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -1705,6 +1705,9 @@ restart:
       {
         maybe_signed = true;
         gpgme_data_release(plaintext);
+        /* gpgsm ends the session after an error; restart it */
+        gpgme_release(ctx);
+        ctx = create_gpgme_context(is_smime);
         goto restart;
       }
     }


### PR DESCRIPTION
- gpgsm ends the session after the decrypt error, so restart gpgsm when retrying with "maybe_signed".
- evolution sends encrypted + signed S/MIME mails with non-detached signatures
