### PR TITLE
Fix truncated formating

### DIFF
--- a/curs_lib.c
+++ b/curs_lib.c
@@ -1199,7 +1199,7 @@ void mutt_simple_format(char *dest, size_t destlen, int min_width, int max_width
     if (w >= 0)
     {
       if (w > max_width || (k2 = wcrtomb(scratch, wc, &mbstate2)) > destlen)
-        break;
+        continue;
       min_width -= w;
       max_width -= w;
       strncpy(p, scratch, k2);


### PR DESCRIPTION
This patch fixes the leak of index line attributes on the next line due to the truncation of the output buffer based on terminal number of columns, that forgets to include escape sequence from the end of the input buffer (#664). Characters from an escape sequence have w=0, so they'll continue to be added to the output buffer.