### PR TITLE
Lists, queues, and the like - 1

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -91,7 +91,7 @@ EXTRA_DIST = account.h attach.h bcache.h browser.h buffy.h \
 	mutt_options.h mutt_regex.h mutt_sasl.h mutt_sasl_plain.h \
 	mutt_socket.h mutt_ssl.h mutt_tunnel.h mx.h myvar.h nntp.h OPS \
 	OPS.CRYPT OPS.MIX OPS.NOTMUCH OPS.PGP OPS.SIDEBAR OPS.SMIME pager.h \
-	pgpewrap.c pop.h protos.h README.md README.SSL remailer.c remailer.h \
+	pgpewrap.c pop.h protos.h queue.h README.md README.SSL remailer.c remailer.h \
 	rfc1524.h rfc2047.h rfc2231.h rfc3676.h rfc822.h sidebar.h \
 	sort.h txt2c.c txt2c.sh version.h \
 	keymap_alldefs.h

--- a/alias.c
+++ b/alias.c
@@ -54,7 +54,7 @@ struct Address *mutt_lookup_alias(const char *s)
   return NULL; /* no such alias */
 }
 
-static struct Address *expand_aliases_r(struct Address *a, struct STailQHead *expn)
+static struct Address *expand_aliases_r(struct Address *a, struct ListHead *expn)
 {
   struct Address *head = NULL, *last = NULL, *t = NULL, *w = NULL;
   bool i;
@@ -69,7 +69,7 @@ static struct Address *expand_aliases_r(struct Address *a, struct STailQHead *ex
       if (t)
       {
         i = false;
-        struct STailQNode *np = NULL;
+        struct ListNode *np;
         STAILQ_FOREACH(np, expn, entries)
         {
           if (mutt_strcmp(a->mailbox, np->data) == 0) /* alias already found */
@@ -82,7 +82,7 @@ static struct Address *expand_aliases_r(struct Address *a, struct STailQHead *ex
 
         if (!i)
         {
-          mutt_stailq_insert_head(expn, safe_strdup(a->mailbox));
+          mutt_list_insert_head(expn, safe_strdup(a->mailbox));
           w = rfc822_cpy_adr(t, 0);
           w = expand_aliases_r(w, expn);
           if (head)
@@ -135,11 +135,11 @@ static struct Address *expand_aliases_r(struct Address *a, struct STailQHead *ex
 struct Address *mutt_expand_aliases(struct Address *a)
 {
   struct Address *t = NULL;
-  struct STailQHead expn; /* previously expanded aliases to avoid loops */
+  struct ListHead expn; /* previously expanded aliases to avoid loops */
 
   STAILQ_INIT(&expn);
   t = expand_aliases_r(a, &expn);
-  mutt_stailq_free(&expn);
+  mutt_list_free(&expn);
   return (mutt_remove_duplicates(t));
 }
 

--- a/alias.c
+++ b/alias.c
@@ -54,10 +54,9 @@ struct Address *mutt_lookup_alias(const char *s)
   return NULL; /* no such alias */
 }
 
-static struct Address *expand_aliases_r(struct Address *a, struct List **expn)
+static struct Address *expand_aliases_r(struct Address *a, struct STailQHead *expn)
 {
   struct Address *head = NULL, *last = NULL, *t = NULL, *w = NULL;
-  struct List *u = NULL;
   bool i;
   const char *fqdn = NULL;
 
@@ -70,9 +69,10 @@ static struct Address *expand_aliases_r(struct Address *a, struct List **expn)
       if (t)
       {
         i = false;
-        for (u = *expn; u; u = u->next)
+        struct STailQNode *np = NULL;
+        STAILQ_FOREACH(np, expn, entries)
         {
-          if (mutt_strcmp(a->mailbox, u->data) == 0) /* alias already found */
+          if (mutt_strcmp(a->mailbox, np->data) == 0) /* alias already found */
           {
             mutt_debug(1, "expand_aliases_r(): loop in alias found for '%s'\n", a->mailbox);
             i = true;
@@ -82,10 +82,7 @@ static struct Address *expand_aliases_r(struct Address *a, struct List **expn)
 
         if (!i)
         {
-          u = safe_malloc(sizeof(struct List));
-          u->data = safe_strdup(a->mailbox);
-          u->next = *expn;
-          *expn = u;
+          mutt_stailq_insert_head(expn, safe_strdup(a->mailbox));
           w = rfc822_cpy_adr(t, 0);
           w = expand_aliases_r(w, expn);
           if (head)
@@ -138,10 +135,11 @@ static struct Address *expand_aliases_r(struct Address *a, struct List **expn)
 struct Address *mutt_expand_aliases(struct Address *a)
 {
   struct Address *t = NULL;
-  struct List *expn = NULL; /* previously expanded aliases to avoid loops */
+  struct STailQHead expn; /* previously expanded aliases to avoid loops */
 
+  STAILQ_INIT(&expn);
   t = expand_aliases_r(a, &expn);
-  mutt_free_list(&expn);
+  mutt_stailq_free(&expn);
   return (mutt_remove_duplicates(t));
 }
 

--- a/attach.c
+++ b/attach.c
@@ -307,15 +307,15 @@ bailout:
  */
 void mutt_check_lookup_list(struct Body *b, char *type, int len)
 {
-  struct List *t = MimeLookupList;
   int i;
 
-  for (; t; t = t->next)
+  struct STailQNode *np;
+  STAILQ_FOREACH(np, &MimeLookupList, entries)
   {
-    i = mutt_strlen(t->data) - 1;
-    if ((i > 0 && t->data[i - 1] == '/' && t->data[i] == '*' &&
-         (mutt_strncasecmp(type, t->data, i) == 0)) ||
-        (mutt_strcasecmp(type, t->data) == 0))
+    i = mutt_strlen(np->data) - 1;
+    if ((i > 0 && np->data[i - 1] == '/' && np->data[i] == '*' &&
+         (mutt_strncasecmp(type, np->data, i) == 0)) ||
+        (mutt_strcasecmp(type, np->data) == 0))
     {
       struct Body tmp = { 0 };
       int n;

--- a/attach.c
+++ b/attach.c
@@ -309,7 +309,7 @@ void mutt_check_lookup_list(struct Body *b, char *type, int len)
 {
   int i;
 
-  struct STailQNode *np;
+  struct ListNode *np;
   STAILQ_FOREACH(np, &MimeLookupList, entries)
   {
     i = mutt_strlen(np->data) - 1;

--- a/compose.c
+++ b/compose.c
@@ -318,7 +318,7 @@ static void redraw_crypt_lines(struct Header *msg)
 
 #ifdef MIXMASTER
 
-static void redraw_mix_line(struct STailQHead *chain)
+static void redraw_mix_line(struct ListHead *chain)
 {
   char *t = NULL;
 
@@ -335,7 +335,7 @@ static void redraw_mix_line(struct STailQHead *chain)
   }
 
   int c = 12;
-  struct STailQNode *np;
+  struct ListNode *np;
   STAILQ_FOREACH(np, chain, entries)
   {
     t = np->data;

--- a/copy.c
+++ b/copy.c
@@ -156,7 +156,7 @@ int mutt_copy_hdr(FILE *in, FILE *out, LOFF_T off_start, LOFF_T off_end,
    */
   if (flags & CH_REORDER)
   {
-    struct STailQNode *np;
+    struct ListNode *np;
     STAILQ_FOREACH(np, &HeaderOrderList, entries)
     {
       mutt_debug(3, "Reorder list: %s\n", np->data);
@@ -251,7 +251,7 @@ int mutt_copy_hdr(FILE *in, FILE *out, LOFF_T off_start, LOFF_T off_end,
       /* Find x -- the array entry where this header is to be saved */
       if (flags & CH_REORDER)
       {
-        struct STailQNode *np;
+        struct ListNode *np;
         x = 0;
         STAILQ_FOREACH(np, &HeaderOrderList, entries)
         {
@@ -403,7 +403,7 @@ int mutt_copy_header(FILE *in, struct Header *h, FILE *out, int flags, const cha
   if ((flags & CH_UPDATE_IRT) && !STAILQ_EMPTY(&h->env->in_reply_to))
   {
     fputs("In-Reply-To:", out);
-    struct STailQNode *np;
+    struct ListNode *np;
     STAILQ_FOREACH(np, &h->env->in_reply_to, entries)
     {
       fputc(' ', out);

--- a/copy.c
+++ b/copy.c
@@ -68,7 +68,6 @@ int mutt_copy_hdr(FILE *in, FILE *out, LOFF_T off_start, LOFF_T off_end,
   bool ignore = false;
   char buf[LONG_STRING]; /* should be long enough to get most fields in one pass */
   char *nl = NULL;
-  struct List *t = NULL;
   char **headers = NULL;
   int hdr_count;
   int x;
@@ -157,9 +156,10 @@ int mutt_copy_hdr(FILE *in, FILE *out, LOFF_T off_start, LOFF_T off_end,
    */
   if (flags & CH_REORDER)
   {
-    for (t = HeaderOrderList; t; t = t->next)
+    struct STailQNode *np;
+    STAILQ_FOREACH(np, &HeaderOrderList, entries)
     {
-      mutt_debug(3, "Reorder list: %s\n", t->data);
+      mutt_debug(3, "Reorder list: %s\n", np->data);
       hdr_count++;
     }
   }
@@ -251,11 +251,14 @@ int mutt_copy_hdr(FILE *in, FILE *out, LOFF_T off_start, LOFF_T off_end,
       /* Find x -- the array entry where this header is to be saved */
       if (flags & CH_REORDER)
       {
-        for (t = HeaderOrderList, x = 0; (t); t = t->next, x++)
+        struct STailQNode *np;
+        x = 0;
+        STAILQ_FOREACH(np, &HeaderOrderList, entries)
         {
-          if (mutt_strncasecmp(buf, t->data, mutt_strlen(t->data)) == 0)
+          ++x;
+          if (mutt_strncasecmp(buf, np->data, mutt_strlen(np->data)) == 0)
           {
-            mutt_debug(2, "Reorder: %s matches %s\n", t->data, buf);
+            mutt_debug(2, "Reorder: %s matches %s\n", np->data, buf);
             break;
           }
         }

--- a/copy.c
+++ b/copy.c
@@ -397,22 +397,22 @@ int mutt_copy_header(FILE *in, struct Header *h, FILE *out, int flags, const cha
     fputc('\n', out);
   }
 
-  if ((flags & CH_UPDATE_IRT) && h->env->in_reply_to)
+  if ((flags & CH_UPDATE_IRT) && !STAILQ_EMPTY(&h->env->in_reply_to))
   {
-    struct List *listp = h->env->in_reply_to;
     fputs("In-Reply-To:", out);
-    for (; listp; listp = listp->next)
+    struct STailQNode *np;
+    STAILQ_FOREACH(np, &h->env->in_reply_to, entries)
     {
       fputc(' ', out);
-      fputs(listp->data, out);
+      fputs(np->data, out);
     }
     fputc('\n', out);
   }
 
-  if ((flags & CH_UPDATE_REFS) && h->env->references)
+  if ((flags & CH_UPDATE_REFS) && !STAILQ_EMPTY(&h->env->references))
   {
     fputs("References:", out);
-    mutt_write_references(h->env->references, out, 0);
+    mutt_write_references(&h->env->references, out, 0);
     fputc('\n', out);
   }
 

--- a/curs_main.c
+++ b/curs_main.c
@@ -1318,7 +1318,7 @@ int mutt_index_menu(void)
           /* trying to find msgid of the root message */
           if (op == OP_RECONSTRUCT_THREAD)
           {
-            struct STailQNode *ref;
+            struct ListNode *ref;
             STAILQ_FOREACH(ref, &CURHDR->env->references, entries)
             {
               if (hash_find(Context->id_hash, ref->data) == NULL)

--- a/curs_main.c
+++ b/curs_main.c
@@ -1246,13 +1246,12 @@ int mutt_index_menu(void)
           }
           else
           {
-            struct List *ref = CURHDR->env->references;
-            if (!ref)
+            if (STAILQ_EMPTY(&CURHDR->env->references))
             {
               mutt_error(_("Article has no parent reference."));
               break;
             }
-            strfcpy(buf, ref->data, sizeof(buf));
+            strfcpy(buf, STAILQ_FIRST(&CURHDR->env->references)->data, sizeof(buf));
           }
           if (!Context->id_hash)
             Context->id_hash = mutt_make_id_hash(Context);
@@ -1319,8 +1318,8 @@ int mutt_index_menu(void)
           /* trying to find msgid of the root message */
           if (op == OP_RECONSTRUCT_THREAD)
           {
-            struct List *ref = CURHDR->env->references;
-            while (ref)
+            struct STailQNode *ref;
+            STAILQ_FOREACH(ref, &CURHDR->env->references, entries)
             {
               if (hash_find(Context->id_hash, ref->data) == NULL)
               {
@@ -1330,9 +1329,8 @@ int mutt_index_menu(void)
               }
 
               /* the last msgid in References is the root message */
-              if (!ref->next)
+              if (!STAILQ_NEXT(ref, entries))
                 strfcpy(buf, ref->data, sizeof(buf));
-              ref = ref->next;
             }
           }
 
@@ -2191,7 +2189,8 @@ int mutt_index_menu(void)
 
         if ((Sort & SORT_MASK) != SORT_THREADS)
           mutt_error(_("Threading is not enabled."));
-        else if (CURHDR->env->in_reply_to || CURHDR->env->references)
+        else if (!STAILQ_EMPTY(&CURHDR->env->in_reply_to) ||
+                 !STAILQ_EMPTY(&CURHDR->env->references))
         {
           {
             struct Header *oldcur = CURHDR;

--- a/envelope.h
+++ b/envelope.h
@@ -57,9 +57,9 @@ struct Envelope
   char *x_comment_to;
 #endif
   struct Buffer *spam;
-  struct STailQHead references;  /**< message references (in reverse order) */
-  struct STailQHead in_reply_to; /**< in-reply-to header content */
-  struct STailQHead userhdrs;    /**< user defined headers */
+  struct ListHead references;  /**< message references (in reverse order) */
+  struct ListHead in_reply_to; /**< in-reply-to header content */
+  struct ListHead userhdrs;    /**< user defined headers */
   int kwtypes;
 
   bool irt_changed : 1;  /**< In-Reply-To changed to link/break threads */

--- a/envelope.h
+++ b/envelope.h
@@ -25,6 +25,7 @@
 
 #include <stdbool.h>
 #include "lib/lib.h"
+#include "list.h"
 
 /**
  * struct Envelope - The header of an email
@@ -56,8 +57,8 @@ struct Envelope
   char *x_comment_to;
 #endif
   struct Buffer *spam;
-  struct List *references;  /**< message references (in reverse order) */
-  struct List *in_reply_to; /**< in-reply-to header content */
+  struct STailQHead references;  /**< message references (in reverse order) */
+  struct STailQHead in_reply_to; /**< in-reply-to header content */
   struct List *userhdrs;    /**< user defined headers */
   int kwtypes;
 
@@ -67,7 +68,10 @@ struct Envelope
 
 static inline struct Envelope *mutt_new_envelope(void)
 {
-  return safe_calloc(1, sizeof(struct Envelope));
+  struct Envelope *e = safe_calloc(1, sizeof(struct Envelope));
+  STAILQ_INIT(&e->references);
+  STAILQ_INIT(&e->in_reply_to);
+  return e;
 }
 
 #endif /* _MUTT_ENVELOPE_H */

--- a/envelope.h
+++ b/envelope.h
@@ -59,7 +59,7 @@ struct Envelope
   struct Buffer *spam;
   struct STailQHead references;  /**< message references (in reverse order) */
   struct STailQHead in_reply_to; /**< in-reply-to header content */
-  struct List *userhdrs;    /**< user defined headers */
+  struct STailQHead userhdrs;    /**< user defined headers */
   int kwtypes;
 
   bool irt_changed : 1;  /**< In-Reply-To changed to link/break threads */
@@ -71,6 +71,7 @@ static inline struct Envelope *mutt_new_envelope(void)
   struct Envelope *e = safe_calloc(1, sizeof(struct Envelope));
   STAILQ_INIT(&e->references);
   STAILQ_INIT(&e->in_reply_to);
+  STAILQ_INIT(&e->userhdrs);
   return e;
 }
 

--- a/globals.h
+++ b/globals.h
@@ -208,11 +208,11 @@ WHERE struct STailQHead AttachAllow INITVAL(STAILQ_HEAD_INITIALIZER(AttachAllow)
 WHERE struct STailQHead AttachExclude INITVAL(STAILQ_HEAD_INITIALIZER(AttachExclude));
 WHERE struct STailQHead InlineAllow INITVAL(STAILQ_HEAD_INITIALIZER(InlineAllow));
 WHERE struct STailQHead InlineExclude INITVAL(STAILQ_HEAD_INITIALIZER(InlineExclude));
-WHERE struct List *HeaderOrderList;
-WHERE struct List *Ignore;
+WHERE struct STailQHead HeaderOrderList INITVAL(STAILQ_HEAD_INITIALIZER(HeaderOrderList));
+WHERE struct STailQHead Ignore INITVAL(STAILQ_HEAD_INITIALIZER(Ignore));
 WHERE struct List *MailToAllow;
 WHERE struct List *MimeLookupList;
-WHERE struct List *UnIgnore;
+WHERE struct STailQHead UnIgnore INITVAL(STAILQ_HEAD_INITIALIZER(UnIgnore));
 
 WHERE struct RxList *Alternates;
 WHERE struct RxList *UnAlternates;

--- a/globals.h
+++ b/globals.h
@@ -202,7 +202,7 @@ WHERE struct Hash *TagTransforms;
 WHERE struct Hash *TagFormats;
 #endif
 
-WHERE struct List *AutoViewList;
+WHERE struct STailQHead AutoViewList INITVAL(STAILQ_HEAD_INITIALIZER(AutoViewList));
 WHERE struct List *AlternativeOrderList;
 WHERE struct List *AttachAllow;
 WHERE struct List *AttachExclude;

--- a/globals.h
+++ b/globals.h
@@ -115,7 +115,7 @@ WHERE char *Mixmaster;
 WHERE char *MixEntryFormat;
 #endif
 
-WHERE struct STailQHead Muttrc INITVAL(STAILQ_HEAD_INITIALIZER(Muttrc));
+WHERE struct ListHead Muttrc INITVAL(STAILQ_HEAD_INITIALIZER(Muttrc));
 #ifdef USE_NNTP
 WHERE char *GroupFormat;
 WHERE char *Inews;
@@ -202,17 +202,17 @@ WHERE struct Hash *TagTransforms;
 WHERE struct Hash *TagFormats;
 #endif
 
-WHERE struct STailQHead AutoViewList INITVAL(STAILQ_HEAD_INITIALIZER(AutoViewList));
-WHERE struct STailQHead AlternativeOrderList INITVAL(STAILQ_HEAD_INITIALIZER(AlternativeOrderList));
-WHERE struct STailQHead AttachAllow INITVAL(STAILQ_HEAD_INITIALIZER(AttachAllow));
-WHERE struct STailQHead AttachExclude INITVAL(STAILQ_HEAD_INITIALIZER(AttachExclude));
-WHERE struct STailQHead InlineAllow INITVAL(STAILQ_HEAD_INITIALIZER(InlineAllow));
-WHERE struct STailQHead InlineExclude INITVAL(STAILQ_HEAD_INITIALIZER(InlineExclude));
-WHERE struct STailQHead HeaderOrderList INITVAL(STAILQ_HEAD_INITIALIZER(HeaderOrderList));
-WHERE struct STailQHead Ignore INITVAL(STAILQ_HEAD_INITIALIZER(Ignore));
-WHERE struct STailQHead MailToAllow INITVAL(STAILQ_HEAD_INITIALIZER(MailToAllow));
-WHERE struct STailQHead MimeLookupList INITVAL(STAILQ_HEAD_INITIALIZER(MimeLookupList));
-WHERE struct STailQHead UnIgnore INITVAL(STAILQ_HEAD_INITIALIZER(UnIgnore));
+WHERE struct ListHead AutoViewList INITVAL(STAILQ_HEAD_INITIALIZER(AutoViewList));
+WHERE struct ListHead AlternativeOrderList INITVAL(STAILQ_HEAD_INITIALIZER(AlternativeOrderList));
+WHERE struct ListHead AttachAllow INITVAL(STAILQ_HEAD_INITIALIZER(AttachAllow));
+WHERE struct ListHead AttachExclude INITVAL(STAILQ_HEAD_INITIALIZER(AttachExclude));
+WHERE struct ListHead InlineAllow INITVAL(STAILQ_HEAD_INITIALIZER(InlineAllow));
+WHERE struct ListHead InlineExclude INITVAL(STAILQ_HEAD_INITIALIZER(InlineExclude));
+WHERE struct ListHead HeaderOrderList INITVAL(STAILQ_HEAD_INITIALIZER(HeaderOrderList));
+WHERE struct ListHead Ignore INITVAL(STAILQ_HEAD_INITIALIZER(Ignore));
+WHERE struct ListHead MailToAllow INITVAL(STAILQ_HEAD_INITIALIZER(MailToAllow));
+WHERE struct ListHead MimeLookupList INITVAL(STAILQ_HEAD_INITIALIZER(MimeLookupList));
+WHERE struct ListHead UnIgnore INITVAL(STAILQ_HEAD_INITIALIZER(UnIgnore));
 
 WHERE struct RxList *Alternates;
 WHERE struct RxList *UnAlternates;
@@ -266,7 +266,7 @@ WHERE short ScoreThresholdFlag;
 
 #ifdef USE_SIDEBAR
 WHERE short SidebarWidth;
-WHERE struct STailQHead SidebarWhitelist INITVAL(STAILQ_HEAD_INITIALIZER(SidebarWhitelist));
+WHERE struct ListHead SidebarWhitelist INITVAL(STAILQ_HEAD_INITIALIZER(SidebarWhitelist));
 #endif
 
 #ifdef USE_IMAP
@@ -283,7 +283,7 @@ WHERE SIG_ATOMIC_VOLATILE_T SigWinch;
 WHERE int CurrentMenu;
 
 WHERE struct Alias *Aliases;
-WHERE struct STailQHead UserHeader INITVAL(STAILQ_HEAD_INITIALIZER(UserHeader));
+WHERE struct ListHead UserHeader INITVAL(STAILQ_HEAD_INITIALIZER(UserHeader));
 
 /* -- formerly in pgp.h -- */
 WHERE struct Regex PgpGoodSign;

--- a/globals.h
+++ b/globals.h
@@ -203,11 +203,11 @@ WHERE struct Hash *TagFormats;
 #endif
 
 WHERE struct STailQHead AutoViewList INITVAL(STAILQ_HEAD_INITIALIZER(AutoViewList));
-WHERE struct List *AlternativeOrderList;
-WHERE struct List *AttachAllow;
-WHERE struct List *AttachExclude;
-WHERE struct List *InlineAllow;
-WHERE struct List *InlineExclude;
+WHERE struct STailQHead AlternativeOrderList INITVAL(STAILQ_HEAD_INITIALIZER(AlternativeOrderList));
+WHERE struct STailQHead AttachAllow INITVAL(STAILQ_HEAD_INITIALIZER(AttachAllow));
+WHERE struct STailQHead AttachExclude INITVAL(STAILQ_HEAD_INITIALIZER(AttachExclude));
+WHERE struct STailQHead InlineAllow INITVAL(STAILQ_HEAD_INITIALIZER(InlineAllow));
+WHERE struct STailQHead InlineExclude INITVAL(STAILQ_HEAD_INITIALIZER(InlineExclude));
 WHERE struct List *HeaderOrderList;
 WHERE struct List *Ignore;
 WHERE struct List *MailToAllow;

--- a/globals.h
+++ b/globals.h
@@ -115,7 +115,7 @@ WHERE char *Mixmaster;
 WHERE char *MixEntryFormat;
 #endif
 
-WHERE struct List *Muttrc;
+WHERE struct STailQHead Muttrc INITVAL(STAILQ_HEAD_INITIALIZER(Muttrc));
 #ifdef USE_NNTP
 WHERE char *GroupFormat;
 WHERE char *Inews;

--- a/globals.h
+++ b/globals.h
@@ -210,8 +210,8 @@ WHERE struct STailQHead InlineAllow INITVAL(STAILQ_HEAD_INITIALIZER(InlineAllow)
 WHERE struct STailQHead InlineExclude INITVAL(STAILQ_HEAD_INITIALIZER(InlineExclude));
 WHERE struct STailQHead HeaderOrderList INITVAL(STAILQ_HEAD_INITIALIZER(HeaderOrderList));
 WHERE struct STailQHead Ignore INITVAL(STAILQ_HEAD_INITIALIZER(Ignore));
-WHERE struct List *MailToAllow;
-WHERE struct List *MimeLookupList;
+WHERE struct STailQHead MailToAllow INITVAL(STAILQ_HEAD_INITIALIZER(MailToAllow));
+WHERE struct STailQHead MimeLookupList INITVAL(STAILQ_HEAD_INITIALIZER(MimeLookupList));
 WHERE struct STailQHead UnIgnore INITVAL(STAILQ_HEAD_INITIALIZER(UnIgnore));
 
 WHERE struct RxList *Alternates;
@@ -266,7 +266,7 @@ WHERE short ScoreThresholdFlag;
 
 #ifdef USE_SIDEBAR
 WHERE short SidebarWidth;
-WHERE struct List *SidebarWhitelist;
+WHERE struct STailQHead SidebarWhitelist INITVAL(STAILQ_HEAD_INITIALIZER(SidebarWhitelist));
 #endif
 
 #ifdef USE_IMAP

--- a/globals.h
+++ b/globals.h
@@ -25,6 +25,7 @@
 
 #include <signal.h>
 #include "lib/lib.h"
+#include "list.h"
 #include "where.h"
 #include "mutt_regex.h"
 
@@ -282,7 +283,7 @@ WHERE SIG_ATOMIC_VOLATILE_T SigWinch;
 WHERE int CurrentMenu;
 
 WHERE struct Alias *Aliases;
-WHERE struct List *UserHeader;
+WHERE struct STailQHead UserHeader INITVAL(STAILQ_HEAD_INITIALIZER(UserHeader));
 
 /* -- formerly in pgp.h -- */
 WHERE struct Regex PgpGoodSign;

--- a/handler.c
+++ b/handler.c
@@ -1017,7 +1017,7 @@ static int is_autoview(struct Body *b)
   {
     /* determine if this type is on the user's auto_view list */
     mutt_check_lookup_list(b, type, sizeof(type));
-    struct STailQNode *np;
+    struct ListNode *np;
     STAILQ_FOREACH(np, &AutoViewList, entries)
     {
       int i = mutt_strlen(np->data) - 1;
@@ -1073,7 +1073,7 @@ static int alternative_handler(struct Body *a, struct State *s)
   a = b;
 
   /* First, search list of preferred types */
-  struct STailQNode *np;
+  struct ListNode *np;
   STAILQ_FOREACH(np, &AlternativeOrderList, entries)
   {
     char *c = NULL;

--- a/handler.c
+++ b/handler.c
@@ -1016,16 +1016,18 @@ static int is_autoview(struct Body *b)
   else
   {
     /* determine if this type is on the user's auto_view list */
-    struct List *t = AutoViewList;
-
     mutt_check_lookup_list(b, type, sizeof(type));
-    for (; t; t = t->next)
+    struct STailQNode *np;
+    STAILQ_FOREACH(np, &AutoViewList, entries)
     {
-      int i = mutt_strlen(t->data) - 1;
-      if ((i > 0 && t->data[i - 1] == '/' && t->data[i] == '*' &&
-           (mutt_strncasecmp(type, t->data, i) == 0)) ||
-          (mutt_strcasecmp(type, t->data) == 0))
+      int i = mutt_strlen(np->data) - 1;
+      if ((i > 0 && np->data[i - 1] == '/' && np->data[i] == '*' &&
+           (mutt_strncasecmp(type, np->data, i) == 0)) ||
+          (mutt_strcasecmp(type, np->data) == 0))
+      {
         is_av = 1;
+        break;
+      }
     }
 
     if (is_mmnoask(type))

--- a/handler.c
+++ b/handler.c
@@ -1051,7 +1051,6 @@ static int alternative_handler(struct Body *a, struct State *s)
 {
   struct Body *choice = NULL;
   struct Body *b = NULL;
-  struct List *t = NULL;
   int type = 0;
   bool mustfree = false;
   int rc = 0;
@@ -1074,23 +1073,23 @@ static int alternative_handler(struct Body *a, struct State *s)
   a = b;
 
   /* First, search list of preferred types */
-  t = AlternativeOrderList;
-  while (t && !choice)
+  struct STailQNode *np;
+  STAILQ_FOREACH(np, &AlternativeOrderList, entries)
   {
     char *c = NULL;
     int btlen; /* length of basetype */
     bool wild; /* do we have a wildcard to match all subtypes? */
 
-    c = strchr(t->data, '/');
+    c = strchr(np->data, '/');
     if (c)
     {
       wild = (c[1] == '*' && c[2] == 0);
-      btlen = c - t->data;
+      btlen = c - np->data;
     }
     else
     {
       wild = true;
-      btlen = mutt_strlen(t->data);
+      btlen = mutt_strlen(np->data);
     }
 
     if (a->parts)
@@ -1100,17 +1099,19 @@ static int alternative_handler(struct Body *a, struct State *s)
     while (b)
     {
       const char *bt = TYPE(b);
-      if ((mutt_strncasecmp(bt, t->data, btlen) == 0) && (bt[btlen] == 0))
+      if ((mutt_strncasecmp(bt, np->data, btlen) == 0) && (bt[btlen] == 0))
       {
         /* the basetype matches */
-        if (wild || (mutt_strcasecmp(t->data + btlen + 1, b->subtype) == 0))
+        if (wild || (mutt_strcasecmp(np->data + btlen + 1, b->subtype) == 0))
         {
           choice = b;
         }
       }
       b = b->next;
     }
-    t = t->next;
+
+    if (choice)
+      break;
   }
 
   /* Next, look for an autoviewable type */

--- a/hcache/hcache.c
+++ b/hcache/hcache.c
@@ -314,9 +314,8 @@ static void restore_stailq(struct STailQHead *l, const unsigned char *d, int *of
   struct STailQNode *np;
   while (counter)
   {
-    np = safe_malloc(sizeof(struct STailQNode));
+    np = mutt_stailq_insert_tail(l, NULL);
     restore_char(&np->data, d, off, convert);
-    STAILQ_INSERT_TAIL(l, np, entries);
     counter--;
   }
 }

--- a/hcache/hcache.c
+++ b/hcache/hcache.c
@@ -286,14 +286,14 @@ static void restore_address(struct Address **a, const unsigned char *d, int *off
   *a = NULL;
 }
 
-static unsigned char *dump_stailq(struct STailQHead *l, unsigned char *d, int *off, int convert)
+static unsigned char *dump_stailq(struct ListHead *l, unsigned char *d, int *off, int convert)
 {
   unsigned int counter = 0;
   unsigned int start_off = *off;
 
   d = dump_int(0xdeadbeef, d, off);
 
-  struct STailQNode *np;
+  struct ListNode *np;
   STAILQ_FOREACH(np, l, entries)
   {
     d = dump_char(np->data, d, off, convert);
@@ -305,16 +305,16 @@ static unsigned char *dump_stailq(struct STailQHead *l, unsigned char *d, int *o
   return d;
 }
 
-static void restore_stailq(struct STailQHead *l, const unsigned char *d, int *off, int convert)
+static void restore_stailq(struct ListHead *l, const unsigned char *d, int *off, int convert)
 {
   unsigned int counter;
 
   restore_int(&counter, d, off);
 
-  struct STailQNode *np;
+  struct ListNode *np;
   while (counter)
   {
-    np = mutt_stailq_insert_tail(l, NULL);
+    np = mutt_list_insert_tail(l, NULL);
     restore_char(&np->data, d, off, convert);
     counter--;
   }

--- a/hcache/hcache.c
+++ b/hcache/hcache.c
@@ -686,7 +686,7 @@ static void *hcache_dump(header_cache_t *h, struct Header *header, int *off,
   nh.tree = NULL;
   nh.thread = NULL;
 #ifdef MIXMASTER
-  nh.chain = NULL;
+  STAILQ_INIT(&nh.chain);
 #endif
 #if defined(USE_POP) || defined(USE_IMAP)
   nh.data = NULL;

--- a/hcache/hcachever.sh
+++ b/hcache/hcachever.sh
@@ -46,7 +46,7 @@ getstruct () {
   done
 
   case $STRUCT in
-    Address|STailQNode|STailQHead|Buffer|Parameter|Body|Envelope|Header)
+    Address|ListNode|Buffer|Parameter|Body|Envelope|Header)
       BODY=`cleanbody "$BODY"`
       echo "$STRUCT: $BODY"
     ;;

--- a/hcache/hcachever.sh
+++ b/hcache/hcachever.sh
@@ -46,7 +46,7 @@ getstruct () {
   done
 
   case $STRUCT in
-    Address|List|Buffer|Parameter|Body|Envelope|Header)
+    Address|STailQNode|STailQHead|Buffer|Parameter|Body|Envelope|Header)
       BODY=`cleanbody "$BODY"`
       echo "$STRUCT: $BODY"
     ;;

--- a/header.h
+++ b/header.h
@@ -26,6 +26,8 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <time.h>
+#include "lib/lib.h"
+#include "list.h"
 
 /**
  * struct Header - The header/envelope of an email
@@ -99,7 +101,7 @@ struct Header
   short attach_total;
 
 #ifdef MIXMASTER
-  struct List *chain;
+  struct STailQHead chain;
 #endif
 
 #ifdef USE_POP
@@ -116,7 +118,11 @@ struct Header
 
 static inline struct Header *mutt_new_header(void)
 {
-  return safe_calloc(1, sizeof(struct Header));
+  struct Header *h = safe_calloc(1, sizeof(struct Header));
+#ifdef MIXMASTER
+  STAILQ_INIT(&h->chain);
+#endif
+  return h;
 }
 
 #endif /* _MUTT_HEADER_H */

--- a/header.h
+++ b/header.h
@@ -101,7 +101,7 @@ struct Header
   short attach_total;
 
 #ifdef MIXMASTER
-  struct STailQHead chain;
+  struct ListHead chain;
 #endif
 
 #ifdef USE_POP

--- a/headers.c
+++ b/headers.c
@@ -130,15 +130,15 @@ void mutt_edit_headers(const char *editor, const char *body, struct Header *msg,
 #ifdef USE_NNTP
   if (!option(OPT_NEWS_SEND))
 #endif
-    if (msg->env->in_reply_to &&
-        (!n->in_reply_to ||
-         (mutt_strcmp(n->in_reply_to->data, msg->env->in_reply_to->data) != 0)))
-      mutt_free_list(&msg->env->references);
+    if (!STAILQ_EMPTY(&msg->env->in_reply_to) &&
+        (STAILQ_EMPTY(&n->in_reply_to) ||
+         (mutt_strcmp(STAILQ_FIRST(&n->in_reply_to)->data,
+                      STAILQ_FIRST(&msg->env->in_reply_to)->data) != 0)))
+      mutt_free_stailq(&msg->env->references);
 
   /* restore old info. */
-  mutt_free_list(&n->references);
-  n->references = msg->env->references;
-  msg->env->references = NULL;
+  mutt_free_stailq(&n->references);
+  STAILQ_SWAP(&n->references, &msg->env->references, STailQNode);
 
   mutt_free_envelope(&msg->env);
   msg->env = n;

--- a/headers.c
+++ b/headers.c
@@ -98,7 +98,7 @@ void mutt_edit_headers(const char *editor, const char *body, struct Header *msg,
   }
 
   mutt_unlink(body);
-  mutt_stailq_free(&msg->env->userhdrs);
+  mutt_list_free(&msg->env->userhdrs);
 
   /* Read the temp file back in */
   if ((ifp = fopen(path, "r")) == NULL)
@@ -133,11 +133,11 @@ void mutt_edit_headers(const char *editor, const char *body, struct Header *msg,
         (STAILQ_EMPTY(&n->in_reply_to) ||
          (mutt_strcmp(STAILQ_FIRST(&n->in_reply_to)->data,
                       STAILQ_FIRST(&msg->env->in_reply_to)->data) != 0)))
-      mutt_stailq_free(&msg->env->references);
+      mutt_list_free(&msg->env->references);
 
   /* restore old info. */
-  mutt_stailq_free(&n->references);
-  STAILQ_SWAP(&n->references, &msg->env->references, STailQNode);
+  mutt_list_free(&n->references);
+  STAILQ_SWAP(&n->references, &msg->env->references, ListNode);
 
   mutt_free_envelope(&msg->env);
   msg->env = n;
@@ -149,7 +149,7 @@ void mutt_edit_headers(const char *editor, const char *body, struct Header *msg,
    * fcc: or attach: or pgp: was specified
    */
 
-  struct STailQNode *np, *tmp;
+  struct ListNode *np, *tmp;
   STAILQ_FOREACH_SAFE(np, &msg->env->userhdrs, entries, tmp)
   {
     keep = true;
@@ -214,7 +214,7 @@ void mutt_edit_headers(const char *editor, const char *body, struct Header *msg,
 
     if (!keep)
     {
-      STAILQ_REMOVE(&msg->env->userhdrs, np, STailQNode, entries);
+      STAILQ_REMOVE(&msg->env->userhdrs, np, ListNode, entries);
       FREE(&np->data);
       FREE(&np);
     }

--- a/headers.c
+++ b/headers.c
@@ -98,7 +98,7 @@ void mutt_edit_headers(const char *editor, const char *body, struct Header *msg,
   }
 
   mutt_unlink(body);
-  mutt_free_stailq(&msg->env->userhdrs);
+  mutt_stailq_free(&msg->env->userhdrs);
 
   /* Read the temp file back in */
   if ((ifp = fopen(path, "r")) == NULL)
@@ -133,10 +133,10 @@ void mutt_edit_headers(const char *editor, const char *body, struct Header *msg,
         (STAILQ_EMPTY(&n->in_reply_to) ||
          (mutt_strcmp(STAILQ_FIRST(&n->in_reply_to)->data,
                       STAILQ_FIRST(&msg->env->in_reply_to)->data) != 0)))
-      mutt_free_stailq(&msg->env->references);
+      mutt_stailq_free(&msg->env->references);
 
   /* restore old info. */
-  mutt_free_stailq(&n->references);
+  mutt_stailq_free(&n->references);
   STAILQ_SWAP(&n->references, &msg->env->references, STailQNode);
 
   mutt_free_envelope(&msg->env);

--- a/hook.c
+++ b/hook.c
@@ -530,18 +530,16 @@ static char *_mutt_string_hook(const char *match, int hook)
   return NULL;
 }
 
-static struct List *_mutt_list_hook(const char *match, int hook)
+static void _mutt_list_hook(struct STailQHead *matches, const char *match, int hook)
 {
   struct Hook *tmp = Hooks;
-  struct List *matches = NULL;
 
   for (; tmp; tmp = tmp->next)
   {
     if ((tmp->type & hook) &&
         ((match && regexec(tmp->rx.rx, match, 0, NULL, 0) == 0) ^ tmp->rx.not))
-      matches = mutt_add_list(matches, tmp->command);
+      mutt_stailq_insert_tail(matches, safe_strdup(tmp->command));
   }
-  return matches;
 }
 
 char *mutt_charset_hook(const char *chs)
@@ -554,9 +552,9 @@ char *mutt_iconv_hook(const char *chs)
   return _mutt_string_hook(chs, MUTT_ICONVHOOK);
 }
 
-struct List *mutt_crypt_hook(struct Address *adr)
+void mutt_crypt_hook(struct STailQHead *list, struct Address *adr)
 {
-  return _mutt_list_hook(adr->mailbox, MUTT_CRYPTHOOK);
+  _mutt_list_hook(list, adr->mailbox, MUTT_CRYPTHOOK);
 }
 
 #ifdef USE_SOCKET

--- a/hook.c
+++ b/hook.c
@@ -50,16 +50,17 @@
 /**
  * struct Hook - A list of user hooks
  */
+TAILQ_HEAD(HookHead, Hook);
 struct Hook
 {
   int type;                /**< hook type */
   struct Regex rx;         /**< regular expression */
   char *command;           /**< filename, command or pattern to execute */
   struct Pattern *pattern; /**< used for fcc,save,send-hook */
-  struct Hook *next;
+  TAILQ_ENTRY(Hook) entries;
 };
 
-static struct Hook *Hooks = NULL;
+static struct HookHead Hooks = TAILQ_HEAD_INITIALIZER(Hooks);
 
 static int current_hook_type = 0;
 
@@ -175,7 +176,7 @@ int mutt_parse_hook(struct Buffer *buf, struct Buffer *s, unsigned long data,
   }
 
   /* check to make sure that a matching hook doesn't already exist */
-  for (ptr = Hooks; ptr; ptr = ptr->next)
+  TAILQ_FOREACH(ptr, &Hooks, entries)
   {
     if (data & MUTT_GLOBALHOOK)
     {
@@ -216,8 +217,6 @@ int mutt_parse_hook(struct Buffer *buf, struct Buffer *s, unsigned long data,
         return 0;
       }
     }
-    if (!ptr->next)
-      break;
   }
 
   if (data & (MUTT_SENDHOOK | MUTT_SEND2HOOK | MUTT_SAVEHOOK | MUTT_FCCHOOK |
@@ -246,19 +245,14 @@ int mutt_parse_hook(struct Buffer *buf, struct Buffer *s, unsigned long data,
     }
   }
 
-  if (ptr)
-  {
-    ptr->next = safe_calloc(1, sizeof(struct Hook));
-    ptr = ptr->next;
-  }
-  else
-    Hooks = ptr = safe_calloc(1, sizeof(struct Hook));
+  ptr = safe_calloc(1, sizeof(struct Hook));
   ptr->type = data;
   ptr->command = command.data;
   ptr->pattern = pat;
   ptr->rx.pattern = pattern.data;
   ptr->rx.rx = rx;
   ptr->rx.not = not;
+  TAILQ_INSERT_TAIL(&Hooks, ptr, entries);
   return 0;
 
 error:
@@ -289,26 +283,15 @@ static void delete_hook(struct Hook *h)
 static void delete_hooks(int type)
 {
   struct Hook *h = NULL;
-  struct Hook *prev = NULL;
+  struct Hook *tmp = NULL;
 
-  while (h = Hooks, h && (type == 0 || type == h->type))
+  TAILQ_FOREACH_SAFE(h, &Hooks, entries, tmp)
   {
-    Hooks = h->next;
-    delete_hook(h);
-  }
-
-  prev = h; /* Unused assignment to avoid compiler warnings */
-
-  while (h)
-  {
-    if (type == h->type)
+    if (type == 0 || type == h->type)
     {
-      prev->next = h->next;
+      TAILQ_REMOVE(&Hooks, h, entries);
       delete_hook(h);
     }
-    else
-      prev = h;
-    h = prev->next;
   }
 }
 
@@ -351,7 +334,7 @@ int mutt_parse_unhook(struct Buffer *buf, struct Buffer *s, unsigned long data,
 
 void mutt_folder_hook(char *path)
 {
-  struct Hook *tmp = Hooks;
+  struct Hook *tmp = NULL;
   struct Buffer err, token;
 
   current_hook_type = MUTT_FOLDERHOOK;
@@ -360,7 +343,7 @@ void mutt_folder_hook(char *path)
   err.dsize = STRING;
   err.data = safe_malloc(err.dsize);
   mutt_buffer_init(&token);
-  for (; tmp; tmp = tmp->next)
+  TAILQ_FOREACH(tmp, &Hooks, entries)
   {
     if (!tmp->command)
       continue;
@@ -390,14 +373,16 @@ void mutt_folder_hook(char *path)
 
 char *mutt_find_hook(int type, const char *pat)
 {
-  struct Hook *tmp = Hooks;
+  struct Hook *tmp = NULL;
 
-  for (; tmp; tmp = tmp->next)
+  TAILQ_FOREACH(tmp, &Hooks, entries)
+  {
     if (tmp->type & type)
     {
       if (regexec(tmp->rx.rx, pat, 0, NULL, 0) == 0)
         return tmp->command;
     }
+  }
   return NULL;
 }
 
@@ -414,7 +399,7 @@ void mutt_message_hook(struct Context *ctx, struct Header *hdr, int type)
   err.data = safe_malloc(err.dsize);
   mutt_buffer_init(&token);
   memset(&cache, 0, sizeof(cache));
-  for (hook = Hooks; hook; hook = hook->next)
+  TAILQ_FOREACH(hook, &Hooks, entries)
   {
     if (!hook->command)
       continue;
@@ -451,7 +436,7 @@ static int addr_hook(char *path, size_t pathlen, int type, struct Context *ctx,
 
   memset(&cache, 0, sizeof(cache));
   /* determine if a matching hook exists */
-  for (hook = Hooks; hook; hook = hook->next)
+  TAILQ_FOREACH(hook, &Hooks, entries)
   {
     if (!hook->command)
       continue;
@@ -519,9 +504,9 @@ void mutt_select_fcc(char *path, size_t pathlen, struct Header *hdr)
 
 static char *_mutt_string_hook(const char *match, int hook)
 {
-  struct Hook *tmp = Hooks;
+  struct Hook *tmp = NULL;
 
-  for (; tmp; tmp = tmp->next)
+  TAILQ_FOREACH(tmp, &Hooks, entries)
   {
     if ((tmp->type & hook) &&
         ((match && regexec(tmp->rx.rx, match, 0, NULL, 0) == 0) ^ tmp->rx.not))
@@ -532,9 +517,9 @@ static char *_mutt_string_hook(const char *match, int hook)
 
 static void _mutt_list_hook(struct STailQHead *matches, const char *match, int hook)
 {
-  struct Hook *tmp = Hooks;
+  struct Hook *tmp = NULL;
 
-  for (; tmp; tmp = tmp->next)
+  TAILQ_FOREACH(tmp, &Hooks, entries)
   {
     if ((tmp->type & hook) &&
         ((match && regexec(tmp->rx.rx, match, 0, NULL, 0) == 0) ^ tmp->rx.not))
@@ -577,7 +562,7 @@ void mutt_account_hook(const char *url)
   err.data = safe_malloc(err.dsize);
   mutt_buffer_init(&token);
 
-  for (hook = Hooks; hook; hook = hook->next)
+  TAILQ_FOREACH(hook, &Hooks, entries)
   {
     if (!(hook->command && (hook->type & MUTT_ACCOUNTHOOK)))
       continue;
@@ -617,7 +602,7 @@ void mutt_timeout_hook(void)
   err.dsize = sizeof(buf);
   mutt_buffer_init(&token);
 
-  for (hook = Hooks; hook; hook = hook->next)
+  TAILQ_FOREACH(hook, &Hooks, entries)
   {
     if (!(hook->command && (hook->type & MUTT_TIMEOUTHOOK)))
       continue;
@@ -652,7 +637,7 @@ void mutt_startup_shutdown_hook(int type)
   err.dsize = sizeof(buf);
   mutt_buffer_init(&token);
 
-  for (hook = Hooks; hook; hook = hook->next)
+  TAILQ_FOREACH(hook, &Hooks, entries)
   {
     if (!(hook->command && (hook->type & type)))
       continue;

--- a/hook.c
+++ b/hook.c
@@ -513,7 +513,7 @@ static char *_mutt_string_hook(const char *match, int hook)
   return NULL;
 }
 
-static void _mutt_list_hook(struct STailQHead *matches, const char *match, int hook)
+static void _mutt_list_hook(struct ListHead *matches, const char *match, int hook)
 {
   struct Hook *tmp = NULL;
 
@@ -521,7 +521,7 @@ static void _mutt_list_hook(struct STailQHead *matches, const char *match, int h
   {
     if ((tmp->type & hook) &&
         ((match && regexec(tmp->rx.rx, match, 0, NULL, 0) == 0) ^ tmp->rx.not))
-      mutt_stailq_insert_tail(matches, safe_strdup(tmp->command));
+      mutt_list_insert_tail(matches, safe_strdup(tmp->command));
   }
 }
 
@@ -535,7 +535,7 @@ char *mutt_iconv_hook(const char *chs)
   return _mutt_string_hook(chs, MUTT_ICONVHOOK);
 }
 
-void mutt_crypt_hook(struct STailQHead *list, struct Address *adr)
+void mutt_crypt_hook(struct ListHead *list, struct Address *adr)
 {
   _mutt_list_hook(list, adr->mailbox, MUTT_CRYPTHOOK);
 }

--- a/hook.c
+++ b/hook.c
@@ -50,7 +50,7 @@
 /**
  * struct Hook - A list of user hooks
  */
-TAILQ_HEAD(HookHead, Hook);
+static TAILQ_HEAD(HookHead, Hook) Hooks = TAILQ_HEAD_INITIALIZER(Hooks);
 struct Hook
 {
   int type;                /**< hook type */
@@ -59,8 +59,6 @@ struct Hook
   struct Pattern *pattern; /**< used for fcc,save,send-hook */
   TAILQ_ENTRY(Hook) entries;
 };
-
-static struct HookHead Hooks = TAILQ_HEAD_INITIALIZER(Hooks);
 
 static int current_hook_type = 0;
 

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -65,7 +65,7 @@
 #endif
 
 /* imap forward declarations */
-static char *imap_get_flags(struct List **hflags, char *s);
+static char *imap_get_flags(struct STailQHead *hflags, char *s);
 static int imap_check_capabilities(struct ImapData *idata);
 static void imap_set_flag(struct ImapData *idata, int aclbit, int flag,
                           const char *str, char *flags, size_t flsize);
@@ -547,9 +547,8 @@ void imap_close_connection(struct ImapData *idata)
  *
  * return stream following FLAGS response
  */
-static char *imap_get_flags(struct List **hflags, char *s)
+static char *imap_get_flags(struct STailQHead *hflags, char *s)
 {
-  struct List *flags = NULL;
   char *flag_word = NULL;
   char ctmp;
 
@@ -567,10 +566,7 @@ static char *imap_get_flags(struct List **hflags, char *s)
     return NULL;
   }
 
-  /* create list, update caller's flags handle */
-  flags = mutt_new_list();
-  *hflags = flags;
-
+  /* update caller's flags handle */
   while (*s && *s != ')')
   {
     s++;
@@ -581,7 +577,7 @@ static char *imap_get_flags(struct List **hflags, char *s)
     ctmp = *s;
     *s = '\0';
     if (*flag_word)
-      mutt_add_list(flags, flag_word);
+      mutt_stailq_insert_tail(hflags, safe_strdup(flag_word));
     *s = ctmp;
   }
 
@@ -589,7 +585,7 @@ static char *imap_get_flags(struct List **hflags, char *s)
   if (*s != ')')
   {
     mutt_debug(1, "imap_get_flags: Unterminated FLAGS response: %s\n", s);
-    mutt_free_list(hflags);
+    mutt_stailq_free(hflags);
 
     return NULL;
   }
@@ -696,10 +692,10 @@ static int imap_open_mailbox(struct Context *ctx)
     if (mutt_strncasecmp("FLAGS", pc, 5) == 0)
     {
       /* don't override PERMANENTFLAGS */
-      if (!idata->flags)
+      if (STAILQ_EMPTY(&idata->flags))
       {
         mutt_debug(3, "Getting mailbox FLAGS\n");
-        if ((pc = imap_get_flags(&(idata->flags), pc)) == NULL)
+        if ((pc = imap_get_flags(&idata->flags, pc)) == NULL)
           goto fail;
       }
     }
@@ -708,7 +704,7 @@ static int imap_open_mailbox(struct Context *ctx)
     {
       mutt_debug(3, "Getting mailbox PERMANENTFLAGS\n");
       /* safe to call on NULL */
-      mutt_free_list(&(idata->flags));
+      mutt_stailq_free(&idata->flags);
       /* skip "OK [PERMANENT" so syntax is the same as FLAGS */
       pc += 13;
       if ((pc = imap_get_flags(&(idata->flags), pc)) == NULL)
@@ -767,19 +763,15 @@ static int imap_open_mailbox(struct Context *ctx)
   /* dump the mailbox flags we've found */
   if (debuglevel > 2)
   {
-    if (!idata->flags)
+    if (STAILQ_EMPTY(&idata->flags))
       mutt_debug(3, "No folder flags found\n");
     else
     {
-      struct List *t = idata->flags;
-
       mutt_debug(3, "Mailbox flags: ");
-
-      t = t->next;
-      while (t)
+      struct STailQNode *np;
+      STAILQ_FOREACH(np, &idata->flags, entries)
       {
-        mutt_debug(3, "[%s] ", t->data);
-        t = t->next;
+        mutt_debug(3, "[%s] ", np->data);
       }
       mutt_debug(3, "\n");
     }
@@ -901,7 +893,7 @@ static void imap_set_flag(struct ImapData *idata, int aclbit, int flag,
                           const char *str, char *flags, size_t flsize)
 {
   if (mutt_bit_isset(idata->ctx->rights, aclbit))
-    if (flag && imap_has_flag(idata->flags, str))
+    if (flag && imap_has_flag(&idata->flags, str))
       safe_strcat(flags, flsize, str);
 }
 
@@ -912,21 +904,19 @@ static void imap_set_flag(struct ImapData *idata, int aclbit, int flag,
  * Do a caseless comparison of the flag against a flag list, return true if
  * found or flag list has '\*'.
  */
-bool imap_has_flag(struct List *flag_list, const char *flag)
+bool imap_has_flag(struct STailQHead *flag_list, const char *flag)
 {
-  if (!flag_list)
+  if (STAILQ_EMPTY(flag_list))
     return false;
 
-  flag_list = flag_list->next;
-  while (flag_list)
+  struct STailQNode *np;
+  STAILQ_FOREACH(np, flag_list, entries)
   {
-    if (mutt_strncasecmp(flag_list->data, flag, strlen(flag_list->data)) == 0)
+    if (mutt_strncasecmp(np->data, flag, strlen(np->data)) == 0)
       return true;
 
-    if (mutt_strncmp(flag_list->data, "\\*", strlen(flag_list->data)) == 0)
+    if (mutt_strncmp(np->data, "\\*", strlen(np->data)) == 0)
       return true;
-
-    flag_list = flag_list->next;
   }
 
   return false;
@@ -1154,7 +1144,7 @@ int imap_sync_message(struct ImapData *idata, struct Header *hdr,
 
   /* now make sure we don't lose custom tags */
   if (mutt_bit_isset(idata->ctx->rights, MUTT_ACL_WRITE))
-    imap_add_keywords(flags, hdr, idata->flags, sizeof(flags));
+    imap_add_keywords(flags, hdr, &idata->flags, sizeof(flags));
 
   mutt_remove_trailing_ws(flags);
 
@@ -1209,7 +1199,7 @@ static int sync_helper(struct ImapData *idata, int right, int flag, const char *
   if (!mutt_bit_isset(idata->ctx->rights, right))
     return 0;
 
-  if (right == MUTT_ACL_WRITE && !imap_has_flag(idata->flags, name))
+  if (right == MUTT_ACL_WRITE && !imap_has_flag(&idata->flags, name))
     return 0;
 
   snprintf(buf, sizeof(buf), "+FLAGS.SILENT (%s)", name);
@@ -1459,7 +1449,7 @@ int imap_close_mailbox(struct Context *ctx)
 
     idata->reopen &= IMAP_REOPEN_ALLOW;
     FREE(&(idata->mailbox));
-    mutt_free_list(&idata->flags);
+    mutt_stailq_free(&idata->flags);
     idata->ctx = NULL;
 
     hash_destroy(&idata->uid_hash, NULL);
@@ -1748,18 +1738,17 @@ int imap_status(char *path, int queue)
  */
 struct ImapStatus *imap_mboxcache_get(struct ImapData *idata, const char *mbox, int create)
 {
-  struct List *cur = NULL;
   struct ImapStatus *status = NULL;
-  struct ImapStatus scache;
 #ifdef USE_HCACHE
   header_cache_t *hc = NULL;
   void *uidvalidity = NULL;
   void *uidnext = NULL;
 #endif
 
-  for (cur = idata->mboxcache; cur; cur = cur->next)
+  struct STailQNode *np;
+  STAILQ_FOREACH(np, &idata->mboxcache, entries)
   {
-    status = (struct ImapStatus *) cur->data;
+    status = (struct ImapStatus *) np->data;
 
     if (imap_mxcmp(mbox, status->name) == 0)
       return status;
@@ -1769,9 +1758,9 @@ struct ImapStatus *imap_mboxcache_get(struct ImapData *idata, const char *mbox, 
   /* lame */
   if (create)
   {
-    memset(&scache, 0, sizeof(scache));
-    scache.name = (char *) mbox;
-    idata->mboxcache = mutt_add_list_n(idata->mboxcache, &scache, sizeof(scache));
+    struct ImapStatus *scache = safe_calloc(1, sizeof(struct ImapStatus));
+    scache->name = (char *) mbox;
+    mutt_stailq_insert_tail(&idata->mboxcache, (char *)scache);
     status = imap_mboxcache_get(idata, mbox, 0);
     status->name = safe_strdup(mbox);
   }
@@ -1807,17 +1796,16 @@ struct ImapStatus *imap_mboxcache_get(struct ImapData *idata, const char *mbox, 
 
 void imap_mboxcache_free(struct ImapData *idata)
 {
-  struct List *cur = NULL;
   struct ImapStatus *status = NULL;
 
-  for (cur = idata->mboxcache; cur; cur = cur->next)
+  struct STailQNode *np;
+  STAILQ_FOREACH(np, &idata->mboxcache, entries)
   {
-    status = (struct ImapStatus *) cur->data;
-
+    status = (struct ImapStatus *) np->data;
     FREE(&status->name);
   }
 
-  mutt_free_list(&idata->mboxcache);
+  mutt_stailq_free(&idata->mboxcache);
 }
 
 /**

--- a/imap/imap_private.h
+++ b/imap/imap_private.h
@@ -238,7 +238,7 @@ struct ImapData
   struct Buffer *cmdbuf;
 
   /* cache ImapStatus of visited mailboxes */
-  struct STailQHead mboxcache;
+  struct ListHead mboxcache;
 
   /* The following data is all specific to the currently SELECTED mbox */
   char delim;
@@ -257,7 +257,7 @@ struct ImapData
   struct BodyCache *bcache;
 
   /* all folder flags - system flags AND keywords */
-  struct STailQHead flags;
+  struct ListHead flags;
 #ifdef USE_HCACHE
   header_cache_t *hcache;
 #endif
@@ -280,7 +280,7 @@ int imap_read_literal(FILE *fp, struct ImapData *idata, long bytes, struct Progr
 void imap_expunge_mailbox(struct ImapData *idata);
 void imap_logout(struct ImapData **idata);
 int imap_sync_message(struct ImapData *idata, struct Header *hdr, struct Buffer *cmd, int *err_continue);
-bool imap_has_flag(struct STailQHead *flag_list, const char *flag);
+bool imap_has_flag(struct ListHead *flag_list, const char *flag);
 
 /* auth.c */
 int imap_authenticate(struct ImapData *idata);
@@ -295,7 +295,7 @@ int imap_exec(struct ImapData *idata, const char *cmd, int flags);
 int imap_cmd_idle(struct ImapData *idata);
 
 /* message.c */
-void imap_add_keywords(char *s, struct Header *keywords, struct STailQHead *mailbox_flags, size_t slen);
+void imap_add_keywords(char *s, struct Header *keywords, struct ListHead *mailbox_flags, size_t slen);
 void imap_free_header_data(struct ImapHeaderData **data);
 int imap_read_headers(struct ImapData *idata, unsigned int msn_begin, unsigned int msn_end);
 char *imap_set_flags(struct ImapData *idata, struct Header *h, char *s);

--- a/imap/imap_private.h
+++ b/imap/imap_private.h
@@ -30,6 +30,7 @@
 #ifdef USE_HCACHE
 #include "hcache/hcache.h"
 #endif
+#include "list.h"
 
 struct Account;
 struct Buffer;
@@ -37,7 +38,6 @@ struct Context;
 struct Header;
 struct ImapHeaderData;
 struct ImapMbox;
-struct List;
 struct Message;
 struct Progress;
 
@@ -238,7 +238,7 @@ struct ImapData
   struct Buffer *cmdbuf;
 
   /* cache ImapStatus of visited mailboxes */
-  struct List *mboxcache;
+  struct STailQHead mboxcache;
 
   /* The following data is all specific to the currently SELECTED mbox */
   char delim;
@@ -257,7 +257,7 @@ struct ImapData
   struct BodyCache *bcache;
 
   /* all folder flags - system flags AND keywords */
-  struct List *flags;
+  struct STailQHead flags;
 #ifdef USE_HCACHE
   header_cache_t *hcache;
 #endif
@@ -280,7 +280,7 @@ int imap_read_literal(FILE *fp, struct ImapData *idata, long bytes, struct Progr
 void imap_expunge_mailbox(struct ImapData *idata);
 void imap_logout(struct ImapData **idata);
 int imap_sync_message(struct ImapData *idata, struct Header *hdr, struct Buffer *cmd, int *err_continue);
-bool imap_has_flag(struct List *flag_list, const char *flag);
+bool imap_has_flag(struct STailQHead *flag_list, const char *flag);
 
 /* auth.c */
 int imap_authenticate(struct ImapData *idata);
@@ -295,7 +295,7 @@ int imap_exec(struct ImapData *idata, const char *cmd, int flags);
 int imap_cmd_idle(struct ImapData *idata);
 
 /* message.c */
-void imap_add_keywords(char *s, struct Header *keywords, struct List *mailbox_flags, size_t slen);
+void imap_add_keywords(char *s, struct Header *keywords, struct STailQHead *mailbox_flags, size_t slen);
 void imap_free_header_data(struct ImapHeaderData **data);
 int imap_read_headers(struct ImapData *idata, unsigned int msn_begin, unsigned int msn_end);
 char *imap_set_flags(struct ImapData *idata, struct Header *h, char *s);

--- a/imap/message.c
+++ b/imap/message.c
@@ -162,7 +162,7 @@ static char *msg_parse_flags(struct ImapHeader *h, char *s)
   }
   s++;
 
-  mutt_stailq_free(&hd->keywords);
+  mutt_list_free(&hd->keywords);
   hd->deleted = hd->flagged = hd->replied = hd->read = hd->old = false;
 
   /* start parsing */
@@ -205,7 +205,7 @@ static char *msg_parse_flags(struct ImapHeader *h, char *s)
         s++;
       ctmp = *s;
       *s = '\0';
-      mutt_stailq_insert_tail(&hd->keywords, safe_strdup(flag_word));
+      mutt_list_insert_tail(&hd->keywords, safe_strdup(flag_word));
       *s = ctmp;
     }
     SKIPWS(s);
@@ -1397,14 +1397,14 @@ int imap_cache_clean(struct ImapData *idata)
  *
  * If the tags appear in the folder flags list. Why wouldn't they?
  */
-void imap_add_keywords(char *s, struct Header *h, struct STailQHead *mailbox_flags, size_t slen)
+void imap_add_keywords(char *s, struct Header *h, struct ListHead *mailbox_flags, size_t slen)
 {
-  struct STailQHead *keywords = &HEADER_DATA(h)->keywords;
+  struct ListHead *keywords = &HEADER_DATA(h)->keywords;
 
   if (STAILQ_EMPTY(mailbox_flags) || !HEADER_DATA(h) || STAILQ_EMPTY(keywords))
     return;
 
-  struct STailQNode *np;
+  struct ListNode *np;
   STAILQ_FOREACH(np, keywords, entries)
   {
     if (imap_has_flag(mailbox_flags, np->data))
@@ -1423,7 +1423,7 @@ void imap_free_header_data(struct ImapHeaderData **data)
   if (*data)
   {
     /* this should be safe even if the list wasn't used */
-    mutt_stailq_free(&(*data)->keywords);
+    mutt_list_free(&(*data)->keywords);
     FREE(data);
   }
 }

--- a/imap/message.c
+++ b/imap/message.c
@@ -53,6 +53,13 @@
 #include "hcache/hcache.h"
 #endif
 
+static struct ImapHeaderData* imap_new_header_data(void)
+{
+    struct ImapHeaderData *d = safe_calloc(1, sizeof(struct ImapHeaderData));
+    STAILQ_INIT(&d->keywords);
+    return d;
+}
+
 static void imap_update_context(struct ImapData *idata, int oldmsgcount)
 {
   struct Context *ctx = NULL;
@@ -155,7 +162,7 @@ static char *msg_parse_flags(struct ImapHeader *h, char *s)
   }
   s++;
 
-  mutt_free_list(&hd->keywords);
+  mutt_stailq_free(&hd->keywords);
   hd->deleted = hd->flagged = hd->replied = hd->read = hd->old = false;
 
   /* start parsing */
@@ -194,14 +201,11 @@ static char *msg_parse_flags(struct ImapHeader *h, char *s)
       char ctmp;
       char *flag_word = s;
 
-      if (!hd->keywords)
-        hd->keywords = mutt_new_list();
-
       while (*s && !ISSPACE(*s) && *s != ')')
         s++;
       ctmp = *s;
       *s = '\0';
-      mutt_add_list(hd->keywords, flag_word);
+      mutt_stailq_insert_tail(&hd->keywords, safe_strdup(flag_word));
       *s = ctmp;
     }
     SKIPWS(s);
@@ -570,7 +574,7 @@ int imap_read_headers(struct ImapData *idata, unsigned int msn_begin, unsigned i
       mutt_progress_update(&progress, msgno, -1);
 
       memset(&h, 0, sizeof(h));
-      h.data = safe_calloc(1, sizeof(struct ImapHeaderData));
+      h.data = imap_new_header_data();
       do
       {
         rc = imap_cmd_step(idata);
@@ -681,7 +685,7 @@ int imap_read_headers(struct ImapData *idata, unsigned int msn_begin, unsigned i
 
       rewind(fp);
       memset(&h, 0, sizeof(h));
-      h.data = safe_calloc(1, sizeof(struct ImapHeaderData));
+      h.data = imap_new_header_data();
 
       /* this DO loop does two things:
        * 1. handles untagged messages, so we can try again on the same msg
@@ -1393,23 +1397,21 @@ int imap_cache_clean(struct ImapData *idata)
  *
  * If the tags appear in the folder flags list. Why wouldn't they?
  */
-void imap_add_keywords(char *s, struct Header *h, struct List *mailbox_flags, size_t slen)
+void imap_add_keywords(char *s, struct Header *h, struct STailQHead *mailbox_flags, size_t slen)
 {
-  struct List *keywords = NULL;
+  struct STailQHead *keywords = &HEADER_DATA(h)->keywords;
 
-  if (!mailbox_flags || !HEADER_DATA(h) || !HEADER_DATA(h)->keywords)
+  if (STAILQ_EMPTY(mailbox_flags) || !HEADER_DATA(h) || STAILQ_EMPTY(keywords))
     return;
 
-  keywords = HEADER_DATA(h)->keywords->next;
-
-  while (keywords)
+  struct STailQNode *np;
+  STAILQ_FOREACH(np, keywords, entries)
   {
-    if (imap_has_flag(mailbox_flags, keywords->data))
+    if (imap_has_flag(mailbox_flags, np->data))
     {
-      safe_strcat(s, slen, keywords->data);
+      safe_strcat(s, slen, np->data);
       safe_strcat(s, slen, " ");
     }
-    keywords = keywords->next;
   }
 }
 
@@ -1421,7 +1423,7 @@ void imap_free_header_data(struct ImapHeaderData **data)
   if (*data)
   {
     /* this should be safe even if the list wasn't used */
-    mutt_free_list(&((*data)->keywords));
+    mutt_stailq_free(&(*data)->keywords);
     FREE(data);
   }
 }

--- a/imap/message.h
+++ b/imap/message.h
@@ -26,6 +26,7 @@
 
 #include <stdbool.h>
 #include <time.h>
+#include "list.h"
 
 /**
  * struct ImapHeaderData - IMAP-specific header data
@@ -46,7 +47,7 @@ struct ImapHeaderData
 
   unsigned int uid; /**< 32-bit Message UID */
   unsigned int msn; /**< Message Sequence Number */
-  struct List *keywords;
+  struct STailQHead keywords;
 };
 
 /**

--- a/imap/message.h
+++ b/imap/message.h
@@ -47,7 +47,7 @@ struct ImapHeaderData
 
   unsigned int uid; /**< 32-bit Message UID */
   unsigned int msn; /**< Message Sequence Number */
-  struct STailQHead keywords;
+  struct ListHead keywords;
 };
 
 /**

--- a/imap/util.c
+++ b/imap/util.c
@@ -517,6 +517,9 @@ struct ImapData *imap_new_idata(void)
     FREE(&idata);
   }
 
+  STAILQ_INIT(&idata->flags);
+  STAILQ_INIT(&idata->mboxcache);
+
   return idata;
 }
 
@@ -529,7 +532,7 @@ void imap_free_idata(struct ImapData **idata)
     return;
 
   FREE(&(*idata)->capstr);
-  mutt_free_list(&(*idata)->flags);
+  mutt_stailq_free(&(*idata)->flags);
   imap_mboxcache_free(*idata);
   mutt_buffer_free(&(*idata)->cmdbuf);
   FREE(&(*idata)->buf);

--- a/imap/util.c
+++ b/imap/util.c
@@ -532,7 +532,7 @@ void imap_free_idata(struct ImapData **idata)
     return;
 
   FREE(&(*idata)->capstr);
-  mutt_stailq_free(&(*idata)->flags);
+  mutt_list_free(&(*idata)->flags);
   imap_mboxcache_free(*idata);
   mutt_buffer_free(&(*idata)->cmdbuf);
   FREE(&(*idata)->buf);

--- a/init.c
+++ b/init.c
@@ -3936,10 +3936,8 @@ int var_to_string(int idx, char *val, size_t len)
 /**
  * mutt_query_variables - Implement the -Q command line flag
  */
-int mutt_query_variables(struct List *queries)
+int mutt_query_variables(struct STailQHead *queries)
 {
-  struct List *p = NULL;
-
   char command[STRING];
 
   struct Buffer err, token;
@@ -3950,9 +3948,10 @@ int mutt_query_variables(struct List *queries)
   err.dsize = STRING;
   err.data = safe_malloc(err.dsize);
 
-  for (p = queries; p; p = p->next)
+  struct STailQNode *np;
+  STAILQ_FOREACH(np, queries, entries)
   {
-    snprintf(command, sizeof(command), "set ?%s\n", p->data);
+    snprintf(command, sizeof(command), "set ?%s\n", np->data);
     if (mutt_parse_rc_line(command, &token, &err) == -1)
     {
       fprintf(stderr, "%s\n", err.data);
@@ -4029,7 +4028,7 @@ int mutt_getvaluebyname(const char *name, const struct Mapping *map)
   return -1;
 }
 
-static int execute_commands(struct List *p)
+static int execute_commands(struct STailQHead *p)
 {
   struct Buffer err, token;
 
@@ -4037,9 +4036,10 @@ static int execute_commands(struct List *p)
   err.dsize = STRING;
   err.data = safe_malloc(err.dsize);
   mutt_buffer_init(&token);
-  for (; p; p = p->next)
+  struct STailQNode *np;
+  STAILQ_FOREACH(np, p, entries)
   {
-    if (mutt_parse_rc_line(p->data, &token, &err) == -1)
+    if (mutt_parse_rc_line(np->data, &token, &err) == -1)
     {
       fprintf(stderr, _("Error in command line: %s\n"), err.data);
       FREE(&token.data);
@@ -4091,7 +4091,7 @@ static char *find_cfg(const char *home, const char *xdg_cfg_home)
   return NULL;
 }
 
-void mutt_init(int skip_sys_rc, struct List *commands)
+void mutt_init(int skip_sys_rc, struct STailQHead *commands)
 {
   struct passwd *pw = NULL;
   struct utsname utsname;

--- a/init.c
+++ b/init.c
@@ -1770,7 +1770,7 @@ static int parse_attachments(struct Buffer *buf, struct Buffer *s,
                              unsigned long data, struct Buffer *err)
 {
   char op, *category = NULL;
-  struct STailQHead *headp = NULL;
+  struct STailQHead *head = NULL;
 
   mutt_extract_token(buf, s, 0);
   if (!buf->data || *buf->data == '\0')
@@ -1803,16 +1803,16 @@ static int parse_attachments(struct Buffer *buf, struct Buffer *s,
   if (mutt_strncasecmp(category, "attachment", strlen(category)) == 0)
   {
     if (op == '+')
-      headp = &AttachAllow;
+      head = &AttachAllow;
     else
-      headp = &AttachExclude;
+      head = &AttachExclude;
   }
   else if (mutt_strncasecmp(category, "inline", strlen(category)) == 0)
   {
     if (op == '+')
-      headp = &InlineAllow;
+      head = &InlineAllow;
     else
-      headp = &InlineExclude;
+      head = &InlineExclude;
   }
   else
   {
@@ -1820,7 +1820,7 @@ static int parse_attachments(struct Buffer *buf, struct Buffer *s,
     return -1;
   }
 
-  return parse_attach_list(buf, s, headp, err);
+  return parse_attach_list(buf, s, head, err);
 }
 
 static int parse_unattachments(struct Buffer *buf, struct Buffer *s,

--- a/init.h
+++ b/init.h
@@ -4493,9 +4493,13 @@ const struct Mapping SortSidebarMethods[] = {
 
 static int parse_list(struct Buffer *buf, struct Buffer *s, unsigned long data,
                       struct Buffer *err);
+static int parse_stailq(struct Buffer *buf, struct Buffer *s, unsigned long data,
+                      struct Buffer *err);
 static int parse_spam_list(struct Buffer *buf, struct Buffer *s,
                            unsigned long data, struct Buffer *err);
 static int parse_unlist(struct Buffer *buf, struct Buffer *s,
+                        unsigned long data, struct Buffer *err);
+static int parse_unstailq(struct Buffer *buf, struct Buffer *s,
                         unsigned long data, struct Buffer *err);
 #ifdef USE_SIDEBAR
 static int parse_path_list(struct Buffer *buf, struct Buffer *s,
@@ -4576,7 +4580,7 @@ const struct Command Commands[] = {
   { "alias",            parse_alias,            0 },
   { "attachments",      parse_attachments,      0 },
   { "unattachments",parse_unattachments,0 },
-  { "auto_view",        parse_list,             UL &AutoViewList },
+  { "auto_view",        parse_stailq,           UL &AutoViewList },
   { "alternative_order",        parse_list,     UL &AlternativeOrderList },
   { "bind",             mutt_parse_bind,        0 },
   { "charset-hook",     mutt_parse_hook,        MUTT_CHARSETHOOK },
@@ -4650,7 +4654,7 @@ const struct Command Commands[] = {
   { "toggle",           parse_set,              MUTT_SET_INV },
   { "unalias",          parse_unalias,          0 },
   { "unalternative_order",parse_unlist,         UL &AlternativeOrderList },
-  { "unauto_view",      parse_unlist,           UL &AutoViewList },
+  { "unauto_view",      parse_unstailq,         UL &AutoViewList },
   { "unhdr_order",      parse_unlist,           UL &HeaderOrderList },
   { "unhook",           mutt_parse_unhook,      0 },
   { "unignore",         parse_unignore,         0 },

--- a/init.h
+++ b/init.h
@@ -4581,7 +4581,7 @@ const struct Command Commands[] = {
   { "attachments",      parse_attachments,      0 },
   { "unattachments",parse_unattachments,0 },
   { "auto_view",        parse_stailq,           UL &AutoViewList },
-  { "alternative_order",        parse_list,     UL &AlternativeOrderList },
+  { "alternative_order",parse_stailq,           UL &AlternativeOrderList },
   { "bind",             mutt_parse_bind,        0 },
   { "charset-hook",     mutt_parse_hook,        MUTT_CHARSETHOOK },
 #ifdef HAVE_COLOR
@@ -4653,7 +4653,7 @@ const struct Command Commands[] = {
   { "timeout-hook",     mutt_parse_hook,        MUTT_TIMEOUTHOOK | MUTT_GLOBALHOOK },
   { "toggle",           parse_set,              MUTT_SET_INV },
   { "unalias",          parse_unalias,          0 },
-  { "unalternative_order",parse_unlist,         UL &AlternativeOrderList },
+  { "unalternative_order",parse_unstailq,       UL &AlternativeOrderList },
   { "unauto_view",      parse_unstailq,         UL &AutoViewList },
   { "unhdr_order",      parse_unlist,           UL &HeaderOrderList },
   { "unhook",           mutt_parse_unhook,      0 },

--- a/init.h
+++ b/init.h
@@ -4491,14 +4491,10 @@ const struct Mapping SortSidebarMethods[] = {
 
 /* functions used to parse commands in a rc file */
 
-static int parse_list(struct Buffer *buf, struct Buffer *s, unsigned long data,
-                      struct Buffer *err);
 static int parse_stailq(struct Buffer *buf, struct Buffer *s, unsigned long data,
                       struct Buffer *err);
 static int parse_spam_list(struct Buffer *buf, struct Buffer *s,
                            unsigned long data, struct Buffer *err);
-static int parse_unlist(struct Buffer *buf, struct Buffer *s,
-                        unsigned long data, struct Buffer *err);
 static int parse_unstailq(struct Buffer *buf, struct Buffer *s,
                         unsigned long data, struct Buffer *err);
 #ifdef USE_SIDEBAR
@@ -4619,12 +4615,12 @@ const struct Command Commands[] = {
   { "tag-transforms",   parse_tag_transforms,   0 },
   { "tag-formats",      parse_tag_formats,      0 },
 #endif
-  { "mailto_allow",     parse_list,             UL &MailToAllow },
-  { "unmailto_allow",   parse_unlist,           UL &MailToAllow },
+  { "mailto_allow",     parse_stailq,           UL &MailToAllow },
+  { "unmailto_allow",   parse_unstailq,         UL &MailToAllow },
   { "message-hook",     mutt_parse_hook,        MUTT_MESSAGEHOOK },
   { "mbox-hook",        mutt_parse_hook,        MUTT_MBOXHOOK },
-  { "mime_lookup",      parse_list,     UL &MimeLookupList },
-  { "unmime_lookup",    parse_unlist,   UL &MimeLookupList },
+  { "mime_lookup",      parse_stailq,           UL &MimeLookupList },
+  { "unmime_lookup",    parse_unstailq,         UL &MimeLookupList },
   { "mono",             mutt_parse_mono,        0 },
   { "my_hdr",           parse_my_hdr,           0 },
   { "pgp-hook",         mutt_parse_hook,        MUTT_CRYPTHOOK },

--- a/init.h
+++ b/init.h
@@ -4599,7 +4599,7 @@ const struct Command Commands[] = {
 #endif
   { "group",            parse_group,            MUTT_GROUP },
   { "ungroup",          parse_group,            MUTT_UNGROUP },
-  { "hdr_order",        parse_list,             UL &HeaderOrderList },
+  { "hdr_order",        parse_stailq,           UL &HeaderOrderList },
   { "ifdef",            parse_ifdef,            0 },
   { "ifndef",           parse_ifdef,            1 },
   { "finish",           finish_source,          0 },
@@ -4655,7 +4655,7 @@ const struct Command Commands[] = {
   { "unalias",          parse_unalias,          0 },
   { "unalternative_order",parse_unstailq,       UL &AlternativeOrderList },
   { "unauto_view",      parse_unstailq,         UL &AutoViewList },
-  { "unhdr_order",      parse_unlist,           UL &HeaderOrderList },
+  { "unhdr_order",      parse_unstailq,         UL &HeaderOrderList },
   { "unhook",           mutt_parse_unhook,      0 },
   { "unignore",         parse_unignore,         0 },
   { "unlists",          parse_unlists,          0 },

--- a/list.h
+++ b/list.h
@@ -94,6 +94,10 @@ static inline void mutt_stailq_free(struct STailQHead *h)
   STAILQ_INIT(h);
 }
 
+/**
+ * mutt_stailq_match - Is the string in the list
+ * @return true if the header contained in "s" is in list "h"
+ */
 static inline bool mutt_stailq_match(const char *s, struct STailQHead *h)
 {
   struct STailQNode *np;

--- a/list.h
+++ b/list.h
@@ -23,6 +23,8 @@
 #ifndef _MUTT_LIST_H
 #define _MUTT_LIST_H
 
+#include <string.h>
+
 /**
  * struct List - Singly-linked List type
  */
@@ -90,6 +92,17 @@ static inline void mutt_stailq_free(struct STailQHead *h)
       np = next;
   }
   STAILQ_INIT(h);
+}
+
+static inline bool mutt_stailq_match(const char *s, struct STailQHead *h)
+{
+  struct STailQNode *np;
+  STAILQ_FOREACH(np, h, entries)
+  {
+    if (*np->data == '*' || mutt_strncasecmp(s, np->data, strlen(np->data)) == 0)
+      return true;
+  }
+  return false;
 }
 
 #endif /* _MUTT_LIST_H */

--- a/list.h
+++ b/list.h
@@ -24,6 +24,7 @@
 #define _MUTT_LIST_H
 
 #include <string.h>
+#include "lib/lib.h"
 
 /**
  * struct List - Singly-linked List type
@@ -94,10 +95,6 @@ static inline void mutt_stailq_free(struct STailQHead *h)
   STAILQ_INIT(h);
 }
 
-/**
- * mutt_stailq_match - Is the string in the list
- * @return true if the header contained in "s" is in list "h"
- */
 static inline bool mutt_stailq_match(const char *s, struct STailQHead *h)
 {
   struct STailQNode *np;

--- a/list.h
+++ b/list.h
@@ -27,20 +27,6 @@
 #include "lib/lib.h"
 
 /**
- * struct List - Singly-linked List type
- */
-struct List
-{
-  char *data;
-  struct List *next;
-};
-
-static inline struct List *mutt_new_list(void)
-{
-  return safe_calloc(1, sizeof(struct List));
-}
-
-/**
  * New implementation using macros from queue.h
  */
 
@@ -53,7 +39,8 @@ struct STailQNode
     STAILQ_ENTRY(STailQNode) entries;
 };
 
-static inline struct STailQNode* mutt_stailq_insert_head(struct STailQHead *h, char *s)
+static inline struct STailQNode* mutt_stailq_insert_head(struct STailQHead *h,
+                                                         char *s)
 {
   struct STailQNode *np = safe_calloc(1, sizeof(struct STailQNode));
   np->data = s;
@@ -61,11 +48,22 @@ static inline struct STailQNode* mutt_stailq_insert_head(struct STailQHead *h, c
   return np;
 }
 
-static inline struct STailQNode* mutt_stailq_insert_tail(struct STailQHead *h, char * s)
+static inline struct STailQNode* mutt_stailq_insert_tail(struct STailQHead *h,
+                                                         char *s)
 {
   struct STailQNode *np = safe_calloc(1, sizeof(struct STailQNode));
   np->data = s;
   STAILQ_INSERT_TAIL(h, np, entries);
+  return np;
+}
+
+static inline struct STailQNode* mutt_stailq_insert_after(struct STailQHead *h,
+                                                          struct STailQNode *n,
+                                                          char *s)
+{
+  struct STailQNode *np = safe_calloc(1, sizeof(struct STailQNode));
+  np->data = s;
+  STAILQ_INSERT_AFTER(h, n, np, entries);
   return np;
 }
 
@@ -95,6 +93,22 @@ static inline void mutt_stailq_free(struct STailQHead *h)
   STAILQ_INIT(h);
 }
 
+static inline void mutt_stailq_clear(struct STailQHead *h)
+{
+  struct STailQNode *np = STAILQ_FIRST(h), *next = NULL;
+  while (np)
+  {
+      next = STAILQ_NEXT(np, entries);
+      FREE(&np);
+      np = next;
+  }
+  STAILQ_INIT(h);
+}
+
+/**
+ * mutt_stailq_match - Is the string in the list
+ * @return true if the header contained in "s" is in list "h"
+ */
 static inline bool mutt_stailq_match(const char *s, struct STailQHead *h)
 {
   struct STailQNode *np;

--- a/list.h
+++ b/list.h
@@ -32,44 +32,45 @@
 
 #include "queue.h"
 
-STAILQ_HEAD(STailQHead, STailQNode);
-struct STailQNode
+STAILQ_HEAD(ListHead, ListNode);
+struct ListNode
 {
     char *data;
-    STAILQ_ENTRY(STailQNode) entries;
+    STAILQ_ENTRY(ListNode) entries;
 };
 
-static inline struct STailQNode* mutt_stailq_insert_head(struct STailQHead *h,
-                                                         char *s)
+static inline struct ListNode* mutt_list_insert_head(struct ListHead *h,
+                                                     char *s)
 {
-  struct STailQNode *np = safe_calloc(1, sizeof(struct STailQNode));
+  struct ListNode *np = safe_calloc(1, sizeof(struct ListNode));
   np->data = s;
   STAILQ_INSERT_HEAD(h, np, entries);
   return np;
 }
 
-static inline struct STailQNode* mutt_stailq_insert_tail(struct STailQHead *h,
-                                                         char *s)
+static inline struct ListNode* mutt_list_insert_tail(struct ListHead *h,
+                                                     char *s)
 {
-  struct STailQNode *np = safe_calloc(1, sizeof(struct STailQNode));
+  struct ListNode *np = safe_calloc(1, sizeof(struct ListNode));
   np->data = s;
   STAILQ_INSERT_TAIL(h, np, entries);
   return np;
 }
 
-static inline struct STailQNode* mutt_stailq_insert_after(struct STailQHead *h,
-                                                          struct STailQNode *n,
-                                                          char *s)
+static inline struct ListNode* mutt_list_insert_after(struct ListHead *h,
+                                                      struct ListNode *n,
+                                                      char *s)
 {
-  struct STailQNode *np = safe_calloc(1, sizeof(struct STailQNode));
+  struct ListNode *np = safe_calloc(1, sizeof(struct ListNode));
   np->data = s;
   STAILQ_INSERT_AFTER(h, n, np, entries);
   return np;
 }
 
-static inline struct STailQNode *mutt_stailq_find(struct STailQHead *h, const char *data)
+static inline struct ListNode *mutt_list_find(struct ListHead *h,
+                                              const char *data)
 {
-  struct STailQNode *np = NULL;
+  struct ListNode *np;
   STAILQ_FOREACH(np, h, entries)
   {
     if (np->data == data || mutt_strcmp(np->data, data) == 0)
@@ -80,9 +81,9 @@ static inline struct STailQNode *mutt_stailq_find(struct STailQHead *h, const ch
   return NULL;
 }
 
-static inline void mutt_stailq_free(struct STailQHead *h)
+static inline void mutt_list_free(struct ListHead *h)
 {
-  struct STailQNode *np = STAILQ_FIRST(h), *next = NULL;
+  struct ListNode *np = STAILQ_FIRST(h), *next = NULL;
   while (np)
   {
       next = STAILQ_NEXT(np, entries);
@@ -93,9 +94,9 @@ static inline void mutt_stailq_free(struct STailQHead *h)
   STAILQ_INIT(h);
 }
 
-static inline void mutt_stailq_clear(struct STailQHead *h)
+static inline void mutt_list_clear(struct ListHead *h)
 {
-  struct STailQNode *np = STAILQ_FIRST(h), *next = NULL;
+  struct ListNode *np = STAILQ_FIRST(h), *next = NULL;
   while (np)
   {
       next = STAILQ_NEXT(np, entries);
@@ -106,12 +107,12 @@ static inline void mutt_stailq_clear(struct STailQHead *h)
 }
 
 /**
- * mutt_stailq_match - Is the string in the list
+ * mutt_list_match - Is the string in the list
  * @return true if the header contained in "s" is in list "h"
  */
-static inline bool mutt_stailq_match(const char *s, struct STailQHead *h)
+static inline bool mutt_list_match(const char *s, struct ListHead *h)
 {
-  struct STailQNode *np;
+  struct ListNode *np;
   STAILQ_FOREACH(np, h, entries)
   {
     if (*np->data == '*' || mutt_strncasecmp(s, np->data, strlen(np->data)) == 0)

--- a/list.h
+++ b/list.h
@@ -50,4 +50,46 @@ struct STailQNode
     STAILQ_ENTRY(STailQNode) entries;
 };
 
+static inline struct STailQNode* mutt_stailq_insert_head(struct STailQHead *h, char *s)
+{
+  struct STailQNode *np = safe_calloc(1, sizeof(struct STailQNode));
+  np->data = s;
+  STAILQ_INSERT_HEAD(h, np, entries);
+  return np;
+}
+
+static inline struct STailQNode* mutt_stailq_insert_tail(struct STailQHead *h, char * s)
+{
+  struct STailQNode *np = safe_calloc(1, sizeof(struct STailQNode));
+  np->data = s;
+  STAILQ_INSERT_TAIL(h, np, entries);
+  return np;
+}
+
+static inline struct STailQNode *mutt_stailq_find(struct STailQHead *h, const char *data)
+{
+  struct STailQNode *np = NULL;
+  STAILQ_FOREACH(np, h, entries)
+  {
+    if (np->data == data || mutt_strcmp(np->data, data) == 0)
+    {
+      return np;
+    }
+  }
+  return NULL;
+}
+
+static inline void mutt_stailq_free(struct STailQHead *h)
+{
+  struct STailQNode *np = STAILQ_FIRST(h), *next = NULL;
+  while (np)
+  {
+      next = STAILQ_NEXT(np, entries);
+      FREE(&np->data);
+      FREE(&np);
+      np = next;
+  }
+  STAILQ_INIT(h);
+}
+
 #endif /* _MUTT_LIST_H */

--- a/list.h
+++ b/list.h
@@ -37,4 +37,17 @@ static inline struct List *mutt_new_list(void)
   return safe_calloc(1, sizeof(struct List));
 }
 
+/**
+ * New implementation using macros from queue.h
+ */
+
+#include "queue.h"
+
+STAILQ_HEAD(STailQHead, STailQNode);
+struct STailQNode
+{
+    char *data;
+    STAILQ_ENTRY(STailQNode) entries;
+};
+
 #endif /* _MUTT_LIST_H */

--- a/main.c
+++ b/main.c
@@ -195,10 +195,10 @@ int main(int argc, char **argv, char **env)
   char *draftFile = NULL;
   char *newMagic = NULL;
   struct Header *msg = NULL;
-  struct List *attach = NULL;
-  struct List *commands = NULL;
-  struct List *queries = NULL;
-  struct List *alias_queries = NULL;
+  struct STailQHead attach = STAILQ_HEAD_INITIALIZER(attach);
+  struct STailQHead commands = STAILQ_HEAD_INITIALIZER(commands);
+  struct STailQHead queries = STAILQ_HEAD_INITIALIZER(queries);
+  struct STailQHead alias_queries = STAILQ_HEAD_INITIALIZER(alias_queries);
   int sendflags = 0;
   int flags = 0;
   int version = 0;
@@ -270,8 +270,8 @@ int main(int argc, char **argv, char **env)
       }
 
       /* non-option, either an attachment or address */
-      if (attach)
-        attach = mutt_add_list(attach, argv[optind]);
+      if (!STAILQ_EMPTY(&attach))
+        mutt_stailq_insert_tail(&attach, safe_strdup(argv[optind]));
       else
         argv[nargc++] = argv[optind];
     }
@@ -282,10 +282,10 @@ int main(int argc, char **argv, char **env)
       switch (i)
       {
         case 'A':
-          alias_queries = mutt_add_list(alias_queries, optarg);
+          mutt_stailq_insert_tail(&alias_queries, safe_strdup(optarg));
           break;
         case 'a':
-          attach = mutt_add_list(attach, optarg);
+          mutt_stailq_insert_tail(&attach, safe_strdup(optarg));
           break;
 
         case 'F':
@@ -337,7 +337,7 @@ int main(int argc, char **argv, char **env)
           break;
 
         case 'e':
-          commands = mutt_add_list(commands, optarg);
+          mutt_stailq_insert_tail(&commands, safe_strdup(optarg));
           break;
 
         case 'H':
@@ -371,7 +371,7 @@ int main(int argc, char **argv, char **env)
           break;
 
         case 'Q':
-          queries = mutt_add_list(queries, optarg);
+          mutt_stailq_insert_tail(&queries, safe_strdup(optarg));
           break;
 
         case 'R':
@@ -404,7 +404,7 @@ int main(int argc, char **argv, char **env)
           char buf[LONG_STRING];
 
           snprintf(buf, sizeof(buf), "set news_server=%s", optarg);
-          commands = mutt_add_list(commands, buf);
+          mutt_stailq_insert_tail(&commands, safe_strdup(buf));
         }
 
         case 'G': /* List of newsgroups */
@@ -444,7 +444,8 @@ int main(int argc, char **argv, char **env)
   }
 
   /* Check for a batch send. */
-  if (!isatty(0) || queries || alias_queries || dump_variables || batch_mode)
+  if (!isatty(0) || !STAILQ_EMPTY(&queries) || !STAILQ_EMPTY(&alias_queries) ||
+      dump_variables || batch_mode)
   {
     set_option(OPT_NO_CURSES);
     sendflags = SENDBATCH;
@@ -465,8 +466,8 @@ int main(int argc, char **argv, char **env)
   }
 
   /* set defaults and read init files */
-  mutt_init(flags & MUTT_NOSYSRC, commands);
-  mutt_free_list(&commands);
+  mutt_init(flags & MUTT_NOSYSRC, &commands);
+  mutt_stailq_free(&commands);
 
   /* Initialize crypto backends.  */
   crypt_init();
@@ -474,24 +475,25 @@ int main(int argc, char **argv, char **env)
   if (newMagic)
     mx_set_magic(newMagic);
 
-  if (queries)
+  if (!STAILQ_EMPTY(&queries))
   {
     for (; optind < argc; optind++)
-      queries = mutt_add_list(queries, argv[optind]);
-    return mutt_query_variables(queries);
+      mutt_stailq_insert_tail(&queries, safe_strdup(argv[optind]));
+    return mutt_query_variables(&queries);
   }
   if (dump_variables)
     return mutt_dump_variables(hide_sensitive);
 
-  if (alias_queries)
+  if (!STAILQ_EMPTY(&alias_queries))
   {
     int rv = 0;
     struct Address *a = NULL;
     for (; optind < argc; optind++)
-      alias_queries = mutt_add_list(alias_queries, argv[optind]);
-    for (; alias_queries; alias_queries = alias_queries->next)
+      mutt_stailq_insert_tail(&alias_queries, safe_strdup(argv[optind]));
+    struct STailQNode *np;
+    STAILQ_FOREACH(np, &alias_queries, entries)
     {
-      if ((a = mutt_lookup_alias(alias_queries->data)))
+      if ((a = mutt_lookup_alias(np->data)))
       {
         /* output in machine-readable form */
         mutt_addrlist_to_intl(a, NULL);
@@ -500,9 +502,10 @@ int main(int argc, char **argv, char **env)
       else
       {
         rv = 1;
-        printf("%s\n", alias_queries->data);
+        printf("%s\n", np->data);
       }
     }
+    mutt_stailq_free(&alias_queries);
     return rv;
   }
 
@@ -553,7 +556,8 @@ int main(int argc, char **argv, char **env)
     mutt_free_windows();
     mutt_endwin(NULL);
   }
-  else if (subject || msg || sendflags || draftFile || includeFile || attach || optind < argc)
+  else if (subject || msg || sendflags || draftFile || includeFile ||
+          !STAILQ_EMPTY(&attach) || optind < argc)
   {
     FILE *fin = NULL;
     FILE *fout = NULL;
@@ -746,34 +750,33 @@ int main(int argc, char **argv, char **env)
 
     FREE(&bodytext);
 
-    if (attach)
+    if (!STAILQ_EMPTY(&attach))
     {
-      struct List *t = attach;
       struct Body *a = msg->content;
 
       while (a && a->next)
         a = a->next;
 
-      while (t)
+      struct STailQNode *np;
+      STAILQ_FOREACH(np, &attach, entries)
       {
         if (a)
         {
-          a->next = mutt_make_file_attach(t->data);
+          a->next = mutt_make_file_attach(np->data);
           a = a->next;
         }
         else
-          msg->content = a = mutt_make_file_attach(t->data);
+          msg->content = a = mutt_make_file_attach(np->data);
         if (!a)
         {
           if (!option(OPT_NO_CURSES))
             mutt_endwin(NULL);
-          fprintf(stderr, _("%s: unable to attach file.\n"), t->data);
-          mutt_free_list(&attach);
+          fprintf(stderr, _("%s: unable to attach file.\n"), np->data);
+          mutt_stailq_free(&attach);
           exit(1);
         }
-        t = t->next;
       }
-      mutt_free_list(&attach);
+      mutt_stailq_free(&attach);
     }
 
     rv = ci_send_message(sendflags, msg, bodyfile, NULL, NULL);

--- a/main.c
+++ b/main.c
@@ -290,7 +290,7 @@ int main(int argc, char **argv, char **env)
 
         case 'F':
           /* mutt_str_replace (&Muttrc, optarg); */
-          Muttrc = mutt_add_list(Muttrc, optarg);
+          mutt_stailq_insert_tail(&Muttrc, safe_strdup(optarg));
           break;
 
         case 'f':

--- a/mbox.c
+++ b/mbox.c
@@ -575,10 +575,10 @@ static int strict_addrcmp(const struct Address *a, const struct Address *b)
   return 1;
 }
 
-static int strict_cmp_stailq(const struct STailQHead *ah, const struct STailQHead *bh)
+static int strict_cmp_stailq(const struct ListHead *ah, const struct ListHead *bh)
 {
-  struct STailQNode *a = STAILQ_FIRST(ah);
-  struct STailQNode *b = STAILQ_FIRST(bh);
+  struct ListNode *a = STAILQ_FIRST(ah);
+  struct ListNode *b = STAILQ_FIRST(bh);
 
   while (a && b)
   {

--- a/mbox.c
+++ b/mbox.c
@@ -575,15 +575,18 @@ static int strict_addrcmp(const struct Address *a, const struct Address *b)
   return 1;
 }
 
-static int strict_cmp_lists(const struct List *a, const struct List *b)
+static int strict_cmp_stailq(const struct STailQHead *ah, const struct STailQHead *bh)
 {
+  struct STailQNode *a = STAILQ_FIRST(ah);
+  struct STailQNode *b = STAILQ_FIRST(bh);
+
   while (a && b)
   {
     if (mutt_strcmp(a->data, b->data) != 0)
       return 0;
 
-    a = a->next;
-    b = b->next;
+    a = STAILQ_NEXT(a, entries);
+    b = STAILQ_NEXT(b, entries);
   }
   if (a || b)
     return 0;
@@ -597,7 +600,7 @@ static int strict_cmp_envelopes(const struct Envelope *e1, const struct Envelope
   {
     if ((mutt_strcmp(e1->message_id, e2->message_id) != 0) ||
         (mutt_strcmp(e1->subject, e2->subject) != 0) ||
-        !strict_cmp_lists(e1->references, e2->references) ||
+        !strict_cmp_stailq(&e1->references, &e2->references) ||
         !strict_addrcmp(e1->from, e2->from) || !strict_addrcmp(e1->sender, e2->sender) ||
         !strict_addrcmp(e1->reply_to, e2->reply_to) ||
         !strict_addrcmp(e1->to, e2->to) || !strict_addrcmp(e1->cc, e2->cc) ||

--- a/mutt.h
+++ b/mutt.h
@@ -30,7 +30,6 @@
 #include <stddef.h>
 #include <stdio.h>
 
-struct List;
 struct ReplaceList;
 struct RxList;
 struct State;
@@ -313,15 +312,11 @@ enum QuadOptionVars
 #define MUTT_X_MOZILLA_KEYS (1 << 2) /**< tbird */
 #define MUTT_KEYWORDS       (1 << 3) /**< rfc2822 */
 
-void mutt_free_list(struct List **list);
 void mutt_free_rx_list(struct RxList **list);
 void mutt_free_replace_list(struct ReplaceList **list);
 int mutt_matches_ignore(const char *s);
 
 /* add an element to a list */
-struct List *mutt_add_list(struct List *head, const char *data);
-struct List *mutt_add_list_n(struct List *head, const void *data, size_t len);
-struct List *mutt_find_list(struct List *l, const char *data);
 int mutt_remove_from_rx_list(struct RxList **l, const char *str);
 
 void mutt_init(int skip_sys_rc, struct STailQHead *commands);

--- a/mutt.h
+++ b/mutt.h
@@ -34,6 +34,7 @@ struct List;
 struct ReplaceList;
 struct RxList;
 struct State;
+struct STailQHead;
 
 /* On OS X 10.5.x, wide char functions are inlined by default breaking
  * --without-wc-funcs compilation
@@ -313,9 +314,9 @@ enum QuadOptionVars
 #define MUTT_KEYWORDS       (1 << 3) /**< rfc2822 */
 
 void mutt_free_list(struct List **list);
+void mutt_free_stailq(struct STailQHead *list);
 void mutt_free_rx_list(struct RxList **list);
 void mutt_free_replace_list(struct ReplaceList **list);
-struct List *mutt_copy_list(struct List *p);
 int mutt_matches_ignore(const char *s);
 bool mutt_matches_list(const char *s, struct List *t);
 
@@ -323,6 +324,7 @@ bool mutt_matches_list(const char *s, struct List *t);
 struct List *mutt_add_list(struct List *head, const char *data);
 struct List *mutt_add_list_n(struct List *head, const void *data, size_t len);
 struct List *mutt_find_list(struct List *l, const char *data);
+struct STailQNode *mutt_find_stailq(struct STailQHead *h, const char *data);
 int mutt_remove_from_rx_list(struct RxList **l, const char *str);
 
 /* handle stack */

--- a/mutt.h
+++ b/mutt.h
@@ -324,7 +324,7 @@ struct List *mutt_add_list_n(struct List *head, const void *data, size_t len);
 struct List *mutt_find_list(struct List *l, const char *data);
 int mutt_remove_from_rx_list(struct RxList **l, const char *str);
 
-void mutt_init(int skip_sys_rc, struct List *commands);
+void mutt_init(int skip_sys_rc, struct STailQHead *commands);
 
 /* flag to mutt_pattern_comp() */
 #define MUTT_FULL_MSG (1 << 0) /* enable body and header matching */

--- a/mutt.h
+++ b/mutt.h
@@ -314,7 +314,6 @@ enum QuadOptionVars
 #define MUTT_KEYWORDS       (1 << 3) /**< rfc2822 */
 
 void mutt_free_list(struct List **list);
-void mutt_free_stailq(struct STailQHead *list);
 void mutt_free_rx_list(struct RxList **list);
 void mutt_free_replace_list(struct ReplaceList **list);
 int mutt_matches_ignore(const char *s);
@@ -324,7 +323,6 @@ bool mutt_matches_list(const char *s, struct List *t);
 struct List *mutt_add_list(struct List *head, const char *data);
 struct List *mutt_add_list_n(struct List *head, const void *data, size_t len);
 struct List *mutt_find_list(struct List *l, const char *data);
-struct STailQNode *mutt_find_stailq(struct STailQHead *h, const char *data);
 int mutt_remove_from_rx_list(struct RxList **l, const char *str);
 
 void mutt_init(int skip_sys_rc, struct List *commands);

--- a/mutt.h
+++ b/mutt.h
@@ -317,7 +317,6 @@ void mutt_free_list(struct List **list);
 void mutt_free_rx_list(struct RxList **list);
 void mutt_free_replace_list(struct ReplaceList **list);
 int mutt_matches_ignore(const char *s);
-bool mutt_matches_list(const char *s, struct List *t);
 
 /* add an element to a list */
 struct List *mutt_add_list(struct List *head, const char *data);

--- a/mutt.h
+++ b/mutt.h
@@ -33,7 +33,7 @@
 struct ReplaceList;
 struct RxList;
 struct State;
-struct STailQHead;
+struct ListHead;
 
 /* On OS X 10.5.x, wide char functions are inlined by default breaking
  * --without-wc-funcs compilation
@@ -319,7 +319,7 @@ int mutt_matches_ignore(const char *s);
 /* add an element to a list */
 int mutt_remove_from_rx_list(struct RxList **l, const char *str);
 
-void mutt_init(int skip_sys_rc, struct STailQHead *commands);
+void mutt_init(int skip_sys_rc, struct ListHead *commands);
 
 /* flag to mutt_pattern_comp() */
 #define MUTT_FULL_MSG (1 << 0) /* enable body and header matching */

--- a/mutt.h
+++ b/mutt.h
@@ -327,11 +327,6 @@ struct List *mutt_find_list(struct List *l, const char *data);
 struct STailQNode *mutt_find_stailq(struct STailQHead *h, const char *data);
 int mutt_remove_from_rx_list(struct RxList **l, const char *str);
 
-/* handle stack */
-void mutt_push_list(struct List **head, const char *data);
-bool mutt_pop_list(struct List **head);
-const char *mutt_front_list(struct List *head);
-
 void mutt_init(int skip_sys_rc, struct List *commands);
 
 /* flag to mutt_pattern_comp() */

--- a/muttlib.c
+++ b/muttlib.c
@@ -359,23 +359,9 @@ void mutt_free_header(struct Header **h)
 }
 
 /**
- * mutt_matches_list - Is the string in the list
- * @retval true if the header contained in "s" is in list "t"
- */
-bool mutt_matches_list(const char *s, struct List *t)
-{
-  for (; t; t = t->next)
-  {
-    if ((mutt_strncasecmp(s, t->data, mutt_strlen(t->data)) == 0) || *t->data == '*')
-      return true;
-  }
-  return false;
-}
-
-/**
  * mutt_matches_ignore - Does the string match the ignore list
  *
- * checks Ignore and UnIgnore using mutt_matches_list
+ * checks Ignore and UnIgnore using mutt_stailq_match
  */
 int mutt_matches_ignore(const char *s)
 {

--- a/muttlib.c
+++ b/muttlib.c
@@ -244,49 +244,6 @@ void mutt_free_body(struct Body **p)
   *p = 0;
 }
 
-struct List *mutt_add_list(struct List *head, const char *data)
-{
-  size_t len = mutt_strlen(data);
-
-  return mutt_add_list_n(head, data, len ? len + 1 : 0);
-}
-
-struct List *mutt_add_list_n(struct List *head, const void *data, size_t len)
-{
-  struct List *tmp = NULL;
-
-  for (tmp = head; tmp && tmp->next; tmp = tmp->next)
-    ;
-  if (tmp)
-  {
-    tmp->next = safe_malloc(sizeof(struct List));
-    tmp = tmp->next;
-  }
-  else
-    head = tmp = safe_malloc(sizeof(struct List));
-
-  tmp->data = safe_malloc(len);
-  if (len)
-    memcpy(tmp->data, data, len);
-  tmp->next = NULL;
-  return head;
-}
-
-struct List *mutt_find_list(struct List *l, const char *data)
-{
-  struct List *p = l;
-
-  while (p)
-  {
-    if (data == p->data)
-      return p;
-    if (data && p->data && (mutt_strcmp(p->data, data) == 0))
-      return p;
-    p = p->next;
-  }
-  return NULL;
-}
-
 int mutt_remove_from_rx_list(struct RxList **l, const char *str)
 {
   struct RxList *p = NULL, *last = NULL;
@@ -321,21 +278,6 @@ int mutt_remove_from_rx_list(struct RxList **l, const char *str)
     }
   }
   return rv;
-}
-
-void mutt_free_list(struct List **list)
-{
-  struct List *p = NULL;
-
-  if (!list)
-    return;
-  while (*list)
-  {
-    p = *list;
-    *list = (*list)->next;
-    FREE(&p->data);
-    FREE(&p);
-  }
 }
 
 void mutt_free_header(struct Header **h)

--- a/muttlib.c
+++ b/muttlib.c
@@ -379,7 +379,7 @@ bool mutt_matches_list(const char *s, struct List *t)
  */
 int mutt_matches_ignore(const char *s)
 {
-  return mutt_matches_list(s, Ignore) && !mutt_matches_list(s, UnIgnore);
+  return mutt_stailq_match(s, &Ignore) && !mutt_stailq_match(s, &UnIgnore);
 }
 
 char *mutt_expand_path(char *s, size_t slen)

--- a/muttlib.c
+++ b/muttlib.c
@@ -287,19 +287,6 @@ struct List *mutt_find_list(struct List *l, const char *data)
   return NULL;
 }
 
-struct STailQNode *mutt_find_stailq(struct STailQHead *h, const char *data)
-{
-  struct STailQNode *np = NULL;
-  STAILQ_FOREACH(np, h, entries)
-  {
-    if (np->data == data)
-      return np;
-    if (data && np->data && (mutt_strcmp(np->data, data) == 0))
-      return np;
-  }
-  return NULL;
-}
-
 int mutt_remove_from_rx_list(struct RxList **l, const char *str)
 {
   struct RxList *p = NULL, *last = NULL;
@@ -351,18 +338,6 @@ void mutt_free_list(struct List **list)
   }
 }
 
-void mutt_free_stailq(struct STailQHead *h)
-{
-    struct STailQNode *np = NULL;
-    while (!STAILQ_EMPTY(h))
-    {
-        np = STAILQ_FIRST(h);
-        STAILQ_REMOVE_HEAD(h, entries);
-        FREE(&np->data);
-        FREE(&np);
-    }
-}
-
 void mutt_free_header(struct Header **h)
 {
   if (!h || !*h)
@@ -373,7 +348,7 @@ void mutt_free_header(struct Header **h)
   FREE(&(*h)->tree);
   FREE(&(*h)->path);
 #ifdef MIXMASTER
-  mutt_free_stailq(&(*h)->chain);
+  mutt_stailq_free(&(*h)->chain);
 #endif
 #if defined(USE_POP) || defined(USE_IMAP) || defined(USE_NNTP) || defined(USE_NOTMUCH)
   if ((*h)->free_cb)
@@ -716,9 +691,9 @@ void mutt_free_envelope(struct Envelope **p)
 
   mutt_buffer_free(&(*p)->spam);
 
-  mutt_free_stailq(&(*p)->references);
-  mutt_free_stailq(&(*p)->in_reply_to);
-  mutt_free_stailq(&(*p)->userhdrs);
+  mutt_stailq_free(&(*p)->references);
+  mutt_stailq_free(&(*p)->in_reply_to);
+  mutt_stailq_free(&(*p)->userhdrs);
   FREE(p);
 }
 
@@ -781,7 +756,7 @@ void mutt_merge_envelopes(struct Envelope *base, struct Envelope **extra)
   /* spam and user headers should never be hashed, and the new envelope may
     * have better values. Use new versions regardless. */
   mutt_buffer_free(&base->spam);
-  mutt_free_stailq(&base->userhdrs);
+  mutt_stailq_free(&base->userhdrs);
   MOVE_ELEM(spam);
   MOVE_STAILQ(userhdrs);
 #undef MOVE_ELEM

--- a/muttlib.c
+++ b/muttlib.c
@@ -745,7 +745,7 @@ void mutt_free_envelope(struct Envelope **p)
 
   mutt_free_stailq(&(*p)->references);
   mutt_free_stailq(&(*p)->in_reply_to);
-  mutt_free_list(&(*p)->userhdrs);
+  mutt_free_stailq(&(*p)->userhdrs);
   FREE(p);
 }
 
@@ -808,9 +808,9 @@ void mutt_merge_envelopes(struct Envelope *base, struct Envelope **extra)
   /* spam and user headers should never be hashed, and the new envelope may
     * have better values. Use new versions regardless. */
   mutt_buffer_free(&base->spam);
-  mutt_free_list(&base->userhdrs);
+  mutt_free_stailq(&base->userhdrs);
   MOVE_ELEM(spam);
-  MOVE_ELEM(userhdrs);
+  MOVE_STAILQ(userhdrs);
 #undef MOVE_ELEM
 
   mutt_free_envelope(extra);

--- a/muttlib.c
+++ b/muttlib.c
@@ -400,7 +400,7 @@ void mutt_free_header(struct Header **h)
   FREE(&(*h)->tree);
   FREE(&(*h)->path);
 #ifdef MIXMASTER
-  mutt_free_list(&(*h)->chain);
+  mutt_free_stailq(&(*h)->chain);
 #endif
 #if defined(USE_POP) || defined(USE_IMAP) || defined(USE_NNTP) || defined(USE_NOTMUCH)
   if ((*h)->free_cb)

--- a/muttlib.c
+++ b/muttlib.c
@@ -290,7 +290,7 @@ void mutt_free_header(struct Header **h)
   FREE(&(*h)->tree);
   FREE(&(*h)->path);
 #ifdef MIXMASTER
-  mutt_stailq_free(&(*h)->chain);
+  mutt_list_free(&(*h)->chain);
 #endif
 #if defined(USE_POP) || defined(USE_IMAP) || defined(USE_NNTP) || defined(USE_NOTMUCH)
   if ((*h)->free_cb)
@@ -303,11 +303,11 @@ void mutt_free_header(struct Header **h)
 /**
  * mutt_matches_ignore - Does the string match the ignore list
  *
- * checks Ignore and UnIgnore using mutt_stailq_match
+ * checks Ignore and UnIgnore using mutt_list_match
  */
 int mutt_matches_ignore(const char *s)
 {
-  return mutt_stailq_match(s, &Ignore) && !mutt_stailq_match(s, &UnIgnore);
+  return mutt_list_match(s, &Ignore) && !mutt_list_match(s, &UnIgnore);
 }
 
 char *mutt_expand_path(char *s, size_t slen)
@@ -619,9 +619,9 @@ void mutt_free_envelope(struct Envelope **p)
 
   mutt_buffer_free(&(*p)->spam);
 
-  mutt_stailq_free(&(*p)->references);
-  mutt_stailq_free(&(*p)->in_reply_to);
-  mutt_stailq_free(&(*p)->userhdrs);
+  mutt_list_free(&(*p)->references);
+  mutt_list_free(&(*p)->in_reply_to);
+  mutt_list_free(&(*p)->userhdrs);
   FREE(p);
 }
 
@@ -645,7 +645,7 @@ void mutt_merge_envelopes(struct Envelope *base, struct Envelope **extra)
 #define MOVE_STAILQ(h)                                                         \
   if (STAILQ_EMPTY(&base->h))                                                  \
   {                                                                            \
-    STAILQ_SWAP(&base->h, &((*extra))->h, STailQNode);                         \
+    STAILQ_SWAP(&base->h, &((*extra))->h, ListNode);                         \
   }
 
   MOVE_ELEM(return_path);
@@ -684,7 +684,7 @@ void mutt_merge_envelopes(struct Envelope *base, struct Envelope **extra)
   /* spam and user headers should never be hashed, and the new envelope may
     * have better values. Use new versions regardless. */
   mutt_buffer_free(&base->spam);
-  mutt_stailq_free(&base->userhdrs);
+  mutt_list_free(&base->userhdrs);
   MOVE_ELEM(spam);
   MOVE_STAILQ(userhdrs);
 #undef MOVE_ELEM

--- a/muttlib.c
+++ b/muttlib.c
@@ -300,33 +300,6 @@ struct STailQNode *mutt_find_stailq(struct STailQHead *h, const char *data)
   return NULL;
 }
 
-void mutt_push_list(struct List **head, const char *data)
-{
-  struct List *tmp = NULL;
-  tmp = safe_malloc(sizeof(struct List));
-  tmp->data = safe_strdup(data);
-  tmp->next = *head;
-  *head = tmp;
-}
-
-bool mutt_pop_list(struct List **head)
-{
-  struct List *elt = *head;
-  if (!elt)
-    return false;
-  *head = elt->next;
-  FREE(&elt->data);
-  FREE(&elt);
-  return true;
-}
-
-const char *mutt_front_list(struct List *head)
-{
-  if (!head || !head->data)
-    return "";
-  return head->data;
-}
-
 int mutt_remove_from_rx_list(struct RxList **l, const char *str)
 {
   struct RxList *p = NULL, *last = NULL;

--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -3862,14 +3862,14 @@ leave:
  *
  * We need to convert spaces in an item into a '+' and '%' into "%25".
  */
-static char *list_to_pattern(struct STailQHead *list)
+static char *list_to_pattern(struct ListHead *list)
 {
   char *pattern = NULL, *p = NULL;
   const char *s = NULL;
   size_t n;
 
   n = 0;
-  struct STailQNode *np;
+  struct ListNode *np;
   STAILQ_FOREACH(np, list, entries)
   {
     for (s = np->data; *s; s++)
@@ -3919,7 +3919,7 @@ static char *list_to_pattern(struct STailQHead *list)
  *
  * Select by looking at the HINTS list.
  */
-static struct CryptKeyInfo *get_candidates(struct STailQHead *hints, unsigned int app, int secret)
+static struct CryptKeyInfo *get_candidates(struct ListHead *hints, unsigned int app, int secret)
 {
   struct CryptKeyInfo *db = NULL, *k = NULL, **kend = NULL;
   char *pattern = NULL;
@@ -3951,7 +3951,7 @@ static struct CryptKeyInfo *get_candidates(struct STailQHead *hints, unsigned in
          escaped pappert but simple strings passed in an array to the
          keylist_ext_start function. */
     size_t n = 0;
-    struct STailQNode *np;
+    struct ListNode *np;
     STAILQ_FOREACH(np, hints, entries)
     {
       if (np->data && *np->data)
@@ -4069,7 +4069,7 @@ static struct CryptKeyInfo *get_candidates(struct STailQHead *hints, unsigned in
  *
  * This list is later used to match addresses.
  */
-static void crypt_add_string_to_hints(struct STailQHead *hints, const char *str)
+static void crypt_add_string_to_hints(struct ListHead *hints, const char *str)
 {
   char *scratch = NULL;
   char *t = NULL;
@@ -4080,7 +4080,7 @@ static void crypt_add_string_to_hints(struct STailQHead *hints, const char *str)
   for (t = strtok(scratch, " ,.:\"()<>\n"); t; t = strtok(NULL, " ,.:\"()<>\n"))
   {
     if (strlen(t) > 3)
-      mutt_stailq_insert_tail(hints, safe_strdup(t));
+      mutt_list_insert_tail(hints, safe_strdup(t));
   }
 
   FREE(&scratch);
@@ -4293,7 +4293,7 @@ static struct CryptKeyInfo *crypt_getkeybyaddr(struct Address *a,
                                                int *forced_valid, bool oppenc_mode)
 {
   struct Address *r = NULL, *p = NULL;
-  struct STailQHead hints = STAILQ_HEAD_INITIALIZER(hints);
+  struct ListHead hints = STAILQ_HEAD_INITIALIZER(hints);
 
   int multi = false;
   int this_key_has_strong = false;
@@ -4317,7 +4317,7 @@ static struct CryptKeyInfo *crypt_getkeybyaddr(struct Address *a,
     mutt_message(_("Looking for keys matching \"%s\"..."), a ? a->mailbox : "");
   keys = get_candidates(&hints, app, (abilities & KEYFLAG_CANSIGN));
 
-  mutt_stailq_free(&hints);
+  mutt_list_free(&hints);
 
   if (!keys)
     return NULL;
@@ -4417,7 +4417,7 @@ static struct CryptKeyInfo *crypt_getkeybyaddr(struct Address *a,
 static struct CryptKeyInfo *crypt_getkeybystr(char *p, short abilities,
                                               unsigned int app, int *forced_valid)
 {
-  struct STailQHead hints = STAILQ_HEAD_INITIALIZER(hints);
+  struct ListHead hints = STAILQ_HEAD_INITIALIZER(hints);
   struct CryptKeyInfo *keys = NULL;
   struct CryptKeyInfo *matches = NULL;
   struct CryptKeyInfo **matches_endp = &matches;
@@ -4431,7 +4431,7 @@ static struct CryptKeyInfo *crypt_getkeybystr(char *p, short abilities,
   pfcopy = crypt_get_fingerprint_or_id(p, &phint, &pl, &ps);
   crypt_add_string_to_hints(&hints, phint);
   keys = get_candidates(&hints, app, (abilities & KEYFLAG_CANSIGN));
-  mutt_stailq_free(&hints);
+  mutt_list_free(&hints);
 
   if (!keys)
   {
@@ -4550,8 +4550,8 @@ static struct CryptKeyInfo *crypt_ask_for_key(char *tag, char *whatfor, short ab
  */
 static char *find_keys(struct Address *adrlist, unsigned int app, int oppenc_mode)
 {
-  struct STailQHead crypt_hook_list = STAILQ_HEAD_INITIALIZER(crypt_hook_list);
-  struct STailQNode *crypt_hook = NULL;
+  struct ListHead crypt_hook_list = STAILQ_HEAD_INITIALIZER(crypt_hook_list);
+  struct ListNode *crypt_hook = NULL;
   char *crypt_hook_val = NULL;
   const char *keyID = NULL;
   char *keylist = NULL, *t = NULL;
@@ -4622,7 +4622,7 @@ static char *find_keys(struct Address *adrlist, unsigned int app, int oppenc_mod
         {
           FREE(&keylist);
           rfc822_free_address(&addr);
-          mutt_stailq_free(&crypt_hook_list);
+          mutt_list_free(&crypt_hook_list);
           return NULL;
         }
       }
@@ -4643,7 +4643,7 @@ static char *find_keys(struct Address *adrlist, unsigned int app, int oppenc_mod
       {
         FREE(&keylist);
         rfc822_free_address(&addr);
-        mutt_stailq_free(&crypt_hook_list);
+        mutt_list_free(&crypt_hook_list);
         return NULL;
       }
 
@@ -4666,7 +4666,7 @@ static char *find_keys(struct Address *adrlist, unsigned int app, int oppenc_mod
 
     } while (crypt_hook);
 
-    mutt_stailq_free(&crypt_hook_list);
+    mutt_list_free(&crypt_hook_list);
   }
   return keylist;
 }

--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -3858,21 +3858,21 @@ leave:
  */
 
 /**
- * list_to_pattern - Convert List to GPGME-compatible pattern
+ * list_to_pattern - Convert STailQ to GPGME-compatible pattern
  *
  * We need to convert spaces in an item into a '+' and '%' into "%25".
  */
-static char *list_to_pattern(struct List *list)
+static char *list_to_pattern(struct STailQHead *list)
 {
-  struct List *l = NULL;
   char *pattern = NULL, *p = NULL;
   const char *s = NULL;
   size_t n;
 
   n = 0;
-  for (l = list; l; l = l->next)
+  struct STailQNode *np;
+  STAILQ_FOREACH(np, list, entries)
   {
-    for (s = l->data; *s; s++)
+    for (s = np->data; *s; s++)
     {
       if (*s == '%' || *s == '+')
         n += 2;
@@ -3882,14 +3882,14 @@ static char *list_to_pattern(struct List *list)
   }
   n++; /* make sure to allocate at least one byte */
   pattern = p = safe_calloc(1, n);
-  for (l = list; l; l = l->next)
+  STAILQ_FOREACH(np, list, entries)
   {
-    s = l->data;
+    s = np->data;
     if (*s)
     {
-      if (l != list)
+      if (np != STAILQ_FIRST(list))
         *p++ = ' ';
-      for (s = l->data; *s; s++)
+      for (s = np->data; *s; s++)
       {
         if (*s == '%')
         {
@@ -3919,7 +3919,7 @@ static char *list_to_pattern(struct List *list)
  *
  * Select by looking at the HINTS list.
  */
-static struct CryptKeyInfo *get_candidates(struct List *hints, unsigned int app, int secret)
+static struct CryptKeyInfo *get_candidates(struct STailQHead *hints, unsigned int app, int secret)
 {
   struct CryptKeyInfo *db = NULL, *k = NULL, **kend = NULL;
   char *pattern = NULL;
@@ -3950,23 +3950,22 @@ static struct CryptKeyInfo *get_candidates(struct List *hints, unsigned int app,
          depending on the protocol.  For gpg we don't need percent
          escaped pappert but simple strings passed in an array to the
          keylist_ext_start function. */
-    struct List *l = NULL;
-    size_t n;
-    char **patarr = NULL;
-
-    for (l = hints, n = 0; l; l = l->next)
+    size_t n = 0;
+    struct STailQNode *np;
+    STAILQ_FOREACH(np, hints, entries)
     {
-      if (l->data && *l->data)
+      if (np->data && *np->data)
         n++;
     }
     if (!n)
       goto no_pgphints;
 
-    patarr = safe_calloc(n + 1, sizeof(*patarr));
-    for (l = hints, n = 0; l; l = l->next)
+    char **patarr = safe_calloc(n + 1, sizeof(*patarr));
+    n = 0;
+    STAILQ_FOREACH(np, hints, entries)
     {
-      if (l->data && *l->data)
-        patarr[n++] = safe_strdup(l->data);
+      if (np->data && *np->data)
+        patarr[n++] = safe_strdup(np->data);
     }
     patarr[n] = NULL;
     err = gpgme_op_keylist_ext_start(ctx, (const char **) patarr, secret, 0);
@@ -4070,22 +4069,21 @@ static struct CryptKeyInfo *get_candidates(struct List *hints, unsigned int app,
  *
  * This list is later used to match addresses.
  */
-static struct List *crypt_add_string_to_hints(struct List *hints, const char *str)
+static void crypt_add_string_to_hints(struct STailQHead *hints, const char *str)
 {
   char *scratch = NULL;
   char *t = NULL;
 
   if ((scratch = safe_strdup(str)) == NULL)
-    return hints;
+    return;
 
   for (t = strtok(scratch, " ,.:\"()<>\n"); t; t = strtok(NULL, " ,.:\"()<>\n"))
   {
     if (strlen(t) > 3)
-      hints = mutt_add_list(hints, t);
+      mutt_stailq_insert_tail(hints, safe_strdup(t));
   }
 
   FREE(&scratch);
-  return hints;
 }
 
 /**
@@ -4295,7 +4293,7 @@ static struct CryptKeyInfo *crypt_getkeybyaddr(struct Address *a,
                                                int *forced_valid, bool oppenc_mode)
 {
   struct Address *r = NULL, *p = NULL;
-  struct List *hints = NULL;
+  struct STailQHead hints = STAILQ_HEAD_INITIALIZER(hints);
 
   int multi = false;
   int this_key_has_strong = false;
@@ -4311,15 +4309,15 @@ static struct CryptKeyInfo *crypt_getkeybyaddr(struct Address *a,
   *forced_valid = 0;
 
   if (a && a->mailbox)
-    hints = crypt_add_string_to_hints(hints, a->mailbox);
+    crypt_add_string_to_hints(&hints, a->mailbox);
   if (a && a->personal)
-    hints = crypt_add_string_to_hints(hints, a->personal);
+    crypt_add_string_to_hints(&hints, a->personal);
 
   if (!oppenc_mode)
     mutt_message(_("Looking for keys matching \"%s\"..."), a ? a->mailbox : "");
-  keys = get_candidates(hints, app, (abilities & KEYFLAG_CANSIGN));
+  keys = get_candidates(&hints, app, (abilities & KEYFLAG_CANSIGN));
 
-  mutt_free_list(&hints);
+  mutt_stailq_free(&hints);
 
   if (!keys)
     return NULL;
@@ -4419,7 +4417,7 @@ static struct CryptKeyInfo *crypt_getkeybyaddr(struct Address *a,
 static struct CryptKeyInfo *crypt_getkeybystr(char *p, short abilities,
                                               unsigned int app, int *forced_valid)
 {
-  struct List *hints = NULL;
+  struct STailQHead hints = STAILQ_HEAD_INITIALIZER(hints);
   struct CryptKeyInfo *keys = NULL;
   struct CryptKeyInfo *matches = NULL;
   struct CryptKeyInfo **matches_endp = &matches;
@@ -4431,9 +4429,9 @@ static struct CryptKeyInfo *crypt_getkeybystr(char *p, short abilities,
   *forced_valid = 0;
 
   pfcopy = crypt_get_fingerprint_or_id(p, &phint, &pl, &ps);
-  hints = crypt_add_string_to_hints(hints, phint);
-  keys = get_candidates(hints, app, (abilities & KEYFLAG_CANSIGN));
-  mutt_free_list(&hints);
+  crypt_add_string_to_hints(&hints, phint);
+  keys = get_candidates(&hints, app, (abilities & KEYFLAG_CANSIGN));
+  mutt_stailq_free(&hints);
 
   if (!keys)
   {
@@ -4552,7 +4550,8 @@ static struct CryptKeyInfo *crypt_ask_for_key(char *tag, char *whatfor, short ab
  */
 static char *find_keys(struct Address *adrlist, unsigned int app, int oppenc_mode)
 {
-  struct List *crypt_hook_list = NULL, *crypt_hook = NULL;
+  struct STailQHead crypt_hook_list = STAILQ_HEAD_INITIALIZER(crypt_hook_list);
+  struct STailQNode *crypt_hook = NULL;
   char *crypt_hook_val = NULL;
   const char *keyID = NULL;
   char *keylist = NULL, *t = NULL;
@@ -4570,7 +4569,8 @@ static char *find_keys(struct Address *adrlist, unsigned int app, int oppenc_mod
   for (p = adrlist; p; p = p->next)
   {
     key_selected = false;
-    crypt_hook_list = crypt_hook = mutt_crypt_hook(p);
+    mutt_crypt_hook(&crypt_hook_list, p);
+    crypt_hook = STAILQ_FIRST(&crypt_hook_list);
     do
     {
       q = p;
@@ -4612,9 +4612,9 @@ static char *find_keys(struct Address *adrlist, unsigned int app, int oppenc_mod
         }
         else if (r == MUTT_NO)
         {
-          if (key_selected || crypt_hook->next)
+          if (key_selected || STAILQ_NEXT(crypt_hook, entries))
           {
-            crypt_hook = crypt_hook->next;
+            crypt_hook = STAILQ_NEXT(crypt_hook, entries);
             continue;
           }
         }
@@ -4622,7 +4622,7 @@ static char *find_keys(struct Address *adrlist, unsigned int app, int oppenc_mod
         {
           FREE(&keylist);
           rfc822_free_address(&addr);
-          mutt_free_list(&crypt_hook_list);
+          mutt_stailq_free(&crypt_hook_list);
           return NULL;
         }
       }
@@ -4643,7 +4643,7 @@ static char *find_keys(struct Address *adrlist, unsigned int app, int oppenc_mod
       {
         FREE(&keylist);
         rfc822_free_address(&addr);
-        mutt_free_list(&crypt_hook_list);
+        mutt_stailq_free(&crypt_hook_list);
         return NULL;
       }
 
@@ -4662,11 +4662,11 @@ static char *find_keys(struct Address *adrlist, unsigned int app, int oppenc_mod
       rfc822_free_address(&addr);
 
       if (crypt_hook)
-        crypt_hook = crypt_hook->next;
+        crypt_hook = STAILQ_NEXT(crypt_hook, entries);
 
     } while (crypt_hook);
 
-    mutt_free_list(&crypt_hook_list);
+    mutt_stailq_free(&crypt_hook_list);
   }
   return keylist;
 }

--- a/ncrypt/gnupgparse.c
+++ b/ncrypt/gnupgparse.c
@@ -381,7 +381,7 @@ bail:
   return NULL;
 }
 
-struct PgpKeyInfo *pgp_get_candidates(enum PgpRing keyring, struct List *hints)
+struct PgpKeyInfo *pgp_get_candidates(enum PgpRing keyring, struct STailQHead *hints)
 {
   FILE *fp = NULL;
   pid_t thepid;

--- a/ncrypt/gnupgparse.c
+++ b/ncrypt/gnupgparse.c
@@ -381,7 +381,7 @@ bail:
   return NULL;
 }
 
-struct PgpKeyInfo *pgp_get_candidates(enum PgpRing keyring, struct STailQHead *hints)
+struct PgpKeyInfo *pgp_get_candidates(enum PgpRing keyring, struct ListHead *hints)
 {
   FILE *fp = NULL;
   pid_t thepid;

--- a/ncrypt/gnupgparse.h
+++ b/ncrypt/gnupgparse.h
@@ -25,8 +25,8 @@
 
 #include "pgpkey.h"
 
-struct STailQHead;
+struct ListHead;
 
-struct PgpKeyInfo * pgp_get_candidates(enum PgpRing keyring, struct STailQHead *hints);
+struct PgpKeyInfo * pgp_get_candidates(enum PgpRing keyring, struct ListHead *hints);
 
 #endif /* _NCRYPT_GNUPGPARSE_H */

--- a/ncrypt/gnupgparse.h
+++ b/ncrypt/gnupgparse.h
@@ -25,8 +25,8 @@
 
 #include "pgpkey.h"
 
-struct List;
+struct STailQHead;
 
-struct PgpKeyInfo * pgp_get_candidates(enum PgpRing keyring, struct List *hints);
+struct PgpKeyInfo * pgp_get_candidates(enum PgpRing keyring, struct STailQHead *hints);
 
 #endif /* _NCRYPT_GNUPGPARSE_H */

--- a/ncrypt/pgp.c
+++ b/ncrypt/pgp.c
@@ -1219,8 +1219,8 @@ struct Body *pgp_sign_message(struct Body *a)
  */
 char *pgp_find_keys(struct Address *adrlist, int oppenc_mode)
 {
-  struct STailQHead crypt_hook_list = STAILQ_HEAD_INITIALIZER(crypt_hook_list);
-  struct STailQNode *crypt_hook = NULL;
+  struct ListHead crypt_hook_list = STAILQ_HEAD_INITIALIZER(crypt_hook_list);
+  struct ListNode *crypt_hook = NULL;
   char *keyID = NULL, *keylist = NULL;
   size_t keylist_size = 0;
   size_t keylist_used = 0;
@@ -1285,7 +1285,7 @@ char *pgp_find_keys(struct Address *adrlist, int oppenc_mode)
         {
           FREE(&keylist);
           rfc822_free_address(&addr);
-          mutt_stailq_free(&crypt_hook_list);
+          mutt_list_free(&crypt_hook_list);
           return NULL;
         }
       }
@@ -1306,7 +1306,7 @@ char *pgp_find_keys(struct Address *adrlist, int oppenc_mode)
       {
         FREE(&keylist);
         rfc822_free_address(&addr);
-        mutt_stailq_free(&crypt_hook_list);
+        mutt_list_free(&crypt_hook_list);
         return NULL;
       }
 
@@ -1328,7 +1328,7 @@ char *pgp_find_keys(struct Address *adrlist, int oppenc_mode)
 
     } while (crypt_hook);
 
-    mutt_stailq_free(&crypt_hook_list);
+    mutt_list_free(&crypt_hook_list);
   }
   return keylist;
 }

--- a/ncrypt/pgp.h
+++ b/ncrypt/pgp.h
@@ -35,7 +35,6 @@
 struct Address;
 struct Body;
 struct Header;
-struct List;
 struct PgpKeyInfo;
 struct State;
 

--- a/ncrypt/pgpinvoke.c
+++ b/ncrypt/pgpinvoke.c
@@ -315,7 +315,7 @@ pid_t pgp_invoke_verify_key(FILE **pgpin, FILE **pgpout, FILE **pgperr, int pgpi
 
 pid_t pgp_invoke_list_keys(FILE **pgpin, FILE **pgpout, FILE **pgperr,
                            int pgpinfd, int pgpoutfd, int pgperrfd,
-                          enum PgpRing keyring, struct STailQHead *hints)
+                          enum PgpRing keyring, struct ListHead *hints)
 {
   char uids[HUGE_STRING];
   char tmpuids[HUGE_STRING];
@@ -323,7 +323,7 @@ pid_t pgp_invoke_list_keys(FILE **pgpin, FILE **pgpout, FILE **pgperr,
 
   *uids = '\0';
 
-  struct STailQNode *np;
+  struct ListNode *np;
   STAILQ_FOREACH(np, hints, entries)
   {
     mutt_quote_filename(quoted, sizeof(quoted), (char *) np->data);

--- a/ncrypt/pgpinvoke.c
+++ b/ncrypt/pgpinvoke.c
@@ -315,7 +315,7 @@ pid_t pgp_invoke_verify_key(FILE **pgpin, FILE **pgpout, FILE **pgperr, int pgpi
 
 pid_t pgp_invoke_list_keys(FILE **pgpin, FILE **pgpout, FILE **pgperr,
                            int pgpinfd, int pgpoutfd, int pgperrfd,
-                           enum PgpRing keyring, struct List *hints)
+                          enum PgpRing keyring, struct STailQHead *hints)
 {
   char uids[HUGE_STRING];
   char tmpuids[HUGE_STRING];
@@ -323,9 +323,10 @@ pid_t pgp_invoke_list_keys(FILE **pgpin, FILE **pgpout, FILE **pgperr,
 
   *uids = '\0';
 
-  for (; hints; hints = hints->next)
+  struct STailQNode *np;
+  STAILQ_FOREACH(np, hints, entries)
   {
-    mutt_quote_filename(quoted, sizeof(quoted), (char *) hints->data);
+    mutt_quote_filename(quoted, sizeof(quoted), (char *) np->data);
     snprintf(tmpuids, sizeof(tmpuids), "%s %s", uids, quoted);
     strcpy(uids, tmpuids);
   }

--- a/ncrypt/pgpinvoke.h
+++ b/ncrypt/pgpinvoke.h
@@ -28,7 +28,7 @@
 #include "pgpkey.h"
 
 struct Address;
-struct STailQHead;
+struct ListHead;
 
 /* The PGP invocation interface */
 
@@ -52,7 +52,7 @@ pid_t pgp_invoke_verify_key(FILE **pgpin, FILE **pgpout, FILE **pgperr, int pgpi
                             int pgpoutfd, int pgperrfd, const char *uids);
 pid_t pgp_invoke_list_keys(FILE **pgpin, FILE **pgpout, FILE **pgperr, int pgpinfd,
                            int pgpoutfd, int pgperrfd, enum PgpRing keyring,
-                           struct STailQHead *hints);
+                           struct ListHead *hints);
 pid_t pgp_invoke_traditional(FILE **pgpin, FILE **pgpout, FILE **pgperr,
                              int pgpinfd, int pgpoutfd, int pgperrfd,
                              const char *fname, const char *uids, int flags);

--- a/ncrypt/pgpinvoke.h
+++ b/ncrypt/pgpinvoke.h
@@ -28,7 +28,7 @@
 #include "pgpkey.h"
 
 struct Address;
-struct List;
+struct STailQHead;
 
 /* The PGP invocation interface */
 
@@ -51,7 +51,8 @@ pid_t pgp_invoke_export(FILE **pgpin, FILE **pgpout, FILE **pgperr, int pgpinfd,
 pid_t pgp_invoke_verify_key(FILE **pgpin, FILE **pgpout, FILE **pgperr, int pgpinfd,
                             int pgpoutfd, int pgperrfd, const char *uids);
 pid_t pgp_invoke_list_keys(FILE **pgpin, FILE **pgpout, FILE **pgperr, int pgpinfd,
-                           int pgpoutfd, int pgperrfd, enum PgpRing keyring, struct List *hints);
+                           int pgpoutfd, int pgperrfd, enum PgpRing keyring,
+                           struct STailQHead *hints);
 pid_t pgp_invoke_traditional(FILE **pgpin, FILE **pgpout, FILE **pgperr,
                              int pgpinfd, int pgpoutfd, int pgperrfd,
                              const char *fname, const char *uids, int flags);

--- a/ncrypt/pgpkey.c
+++ b/ncrypt/pgpkey.c
@@ -44,6 +44,7 @@
 #include "keymap.h"
 #include "keymap_defs.h"
 #include "lib/lib.h"
+#include "list.h"
 #include "mime.h"
 #include "mutt_curses.h"
 #include "mutt_menu.h"
@@ -56,8 +57,6 @@
 #include "protos.h"
 #include "rfc822.h"
 #include "sort.h"
-
-struct List;
 
 /**
  * struct PgpCache - List of cached PGP keys
@@ -785,22 +784,21 @@ struct Body *pgp_make_key_attachment(char *tempf)
   return att;
 }
 
-static struct List *pgp_add_string_to_hints(struct List *hints, const char *str)
+static void pgp_add_string_to_hints(struct STailQHead *hints, const char *str)
 {
   char *scratch = NULL;
   char *t = NULL;
 
   if ((scratch = safe_strdup(str)) == NULL)
-    return hints;
+    return;
 
   for (t = strtok(scratch, " ,.:\"()<>\n"); t; t = strtok(NULL, " ,.:\"()<>\n"))
   {
     if (strlen(t) > 3)
-      hints = mutt_add_list(hints, t);
+      mutt_stailq_insert_tail(hints, safe_strdup(t));
   }
 
   FREE(&scratch);
-  return hints;
 }
 
 static struct PgpKeyInfo **pgp_get_lastp(struct PgpKeyInfo *p)
@@ -816,7 +814,7 @@ struct PgpKeyInfo *pgp_getkeybyaddr(struct Address *a, short abilities,
                                     enum PgpRing keyring, int oppenc_mode)
 {
   struct Address *r = NULL, *p = NULL;
-  struct List *hints = NULL;
+  struct STailQHead hints = STAILQ_HEAD_INITIALIZER(hints);
 
   bool multi = false;
 
@@ -828,15 +826,15 @@ struct PgpKeyInfo *pgp_getkeybyaddr(struct Address *a, short abilities,
   struct PgpUid *q = NULL;
 
   if (a && a->mailbox)
-    hints = pgp_add_string_to_hints(hints, a->mailbox);
+    pgp_add_string_to_hints(&hints, a->mailbox);
   if (a && a->personal)
-    hints = pgp_add_string_to_hints(hints, a->personal);
+    pgp_add_string_to_hints(&hints, a->personal);
 
   if (!oppenc_mode)
     mutt_message(_("Looking for keys matching \"%s\"..."), a ? a->mailbox : "");
-  keys = pgp_get_candidates(keyring, hints);
+  keys = pgp_get_candidates(keyring, &hints);
 
-  mutt_free_list(&hints);
+  mutt_stailq_free(&hints);
 
   if (!keys)
     return NULL;
@@ -942,7 +940,7 @@ struct PgpKeyInfo *pgp_getkeybyaddr(struct Address *a, short abilities,
 
 struct PgpKeyInfo *pgp_getkeybystr(char *p, short abilities, enum PgpRing keyring)
 {
-  struct List *hints = NULL;
+  struct STailQHead hints = STAILQ_HEAD_INITIALIZER(hints);
   struct PgpKeyInfo *keys = NULL;
   struct PgpKeyInfo *matches = NULL;
   struct PgpKeyInfo **last = &matches;
@@ -957,9 +955,9 @@ struct PgpKeyInfo *pgp_getkeybystr(char *p, short abilities, enum PgpRing keyrin
   mutt_message(_("Looking for keys matching \"%s\"..."), p);
 
   pfcopy = crypt_get_fingerprint_or_id(p, &phint, &pl, &ps);
-  hints = pgp_add_string_to_hints(hints, phint);
-  keys = pgp_get_candidates(keyring, hints);
-  mutt_free_list(&hints);
+  pgp_add_string_to_hints(&hints, phint);
+  keys = pgp_get_candidates(keyring, &hints);
+  mutt_stailq_free(&hints);
 
   if (!keys)
     goto out;

--- a/ncrypt/pgpkey.c
+++ b/ncrypt/pgpkey.c
@@ -784,7 +784,7 @@ struct Body *pgp_make_key_attachment(char *tempf)
   return att;
 }
 
-static void pgp_add_string_to_hints(struct STailQHead *hints, const char *str)
+static void pgp_add_string_to_hints(struct ListHead *hints, const char *str)
 {
   char *scratch = NULL;
   char *t = NULL;
@@ -795,7 +795,7 @@ static void pgp_add_string_to_hints(struct STailQHead *hints, const char *str)
   for (t = strtok(scratch, " ,.:\"()<>\n"); t; t = strtok(NULL, " ,.:\"()<>\n"))
   {
     if (strlen(t) > 3)
-      mutt_stailq_insert_tail(hints, safe_strdup(t));
+      mutt_list_insert_tail(hints, safe_strdup(t));
   }
 
   FREE(&scratch);
@@ -814,7 +814,7 @@ struct PgpKeyInfo *pgp_getkeybyaddr(struct Address *a, short abilities,
                                     enum PgpRing keyring, int oppenc_mode)
 {
   struct Address *r = NULL, *p = NULL;
-  struct STailQHead hints = STAILQ_HEAD_INITIALIZER(hints);
+  struct ListHead hints = STAILQ_HEAD_INITIALIZER(hints);
 
   bool multi = false;
 
@@ -834,7 +834,7 @@ struct PgpKeyInfo *pgp_getkeybyaddr(struct Address *a, short abilities,
     mutt_message(_("Looking for keys matching \"%s\"..."), a ? a->mailbox : "");
   keys = pgp_get_candidates(keyring, &hints);
 
-  mutt_stailq_free(&hints);
+  mutt_list_free(&hints);
 
   if (!keys)
     return NULL;
@@ -940,7 +940,7 @@ struct PgpKeyInfo *pgp_getkeybyaddr(struct Address *a, short abilities,
 
 struct PgpKeyInfo *pgp_getkeybystr(char *p, short abilities, enum PgpRing keyring)
 {
-  struct STailQHead hints = STAILQ_HEAD_INITIALIZER(hints);
+  struct ListHead hints = STAILQ_HEAD_INITIALIZER(hints);
   struct PgpKeyInfo *keys = NULL;
   struct PgpKeyInfo *matches = NULL;
   struct PgpKeyInfo **last = &matches;
@@ -957,7 +957,7 @@ struct PgpKeyInfo *pgp_getkeybystr(char *p, short abilities, enum PgpRing keyrin
   pfcopy = crypt_get_fingerprint_or_id(p, &phint, &pl, &ps);
   pgp_add_string_to_hints(&hints, phint);
   keys = pgp_get_candidates(keyring, &hints);
-  mutt_stailq_free(&hints);
+  mutt_list_free(&hints);
 
   if (!keys)
     goto out;

--- a/parse.c
+++ b/parse.c
@@ -114,14 +114,14 @@ char *mutt_read_rfc822_line(FILE *f, char *line, size_t *linelen)
   /* not reached */
 }
 
-static void parse_references(struct STailQHead *head, char *s)
+static void parse_references(struct ListHead *head, char *s)
 {
   char *m = NULL;
   const char *sp = NULL;
 
   while ((m = mutt_extract_message_id(s, &sp)))
   {
-    mutt_stailq_insert_head(head, m);
+    mutt_list_insert_head(head, m);
     s = NULL;
   }
 }
@@ -1095,7 +1095,7 @@ int mutt_parse_rfc822_line(struct Envelope *e, struct Header *hdr, char *line,
     case 'i':
       if (mutt_strcasecmp(line + 1, "n-reply-to") == 0)
       {
-        mutt_stailq_free(&e->in_reply_to);
+        mutt_list_free(&e->in_reply_to);
         parse_references(&e->in_reply_to, p);
         matched = 1;
       }
@@ -1196,7 +1196,7 @@ int mutt_parse_rfc822_line(struct Envelope *e, struct Header *hdr, char *line,
     case 'r':
       if (mutt_strcasecmp(line + 1, "eferences") == 0)
       {
-        mutt_stailq_free(&e->references);
+        mutt_list_free(&e->references);
         parse_references(&e->references, p);
         matched = 1;
       }
@@ -1338,7 +1338,7 @@ int mutt_parse_rfc822_line(struct Envelope *e, struct Header *hdr, char *line,
 
     if (!(weed && option(OPT_WEED) && mutt_matches_ignore(line)))
     {
-      struct STailQNode *np = mutt_stailq_insert_tail(&e->userhdrs, safe_strdup(line));
+      struct ListNode *np = mutt_list_insert_tail(&e->userhdrs, safe_strdup(line));
       if (do_2047)
         rfc2047_decode(&np->data);
     }
@@ -1538,7 +1538,7 @@ struct Address *mutt_parse_adrlist(struct Address *p, const char *s)
 /**
  * count_body_parts_check - Compares mime types to the ok and except lists
  */
-static bool count_body_parts_check(struct STailQHead *checklist, struct Body *b, bool dflt)
+static bool count_body_parts_check(struct ListHead *checklist, struct Body *b, bool dflt)
 {
   struct AttachMatch *a = NULL;
 
@@ -1548,7 +1548,7 @@ static bool count_body_parts_check(struct STailQHead *checklist, struct Body *b,
     return false;
   }
 
-  struct STailQNode *np;
+  struct ListNode *np;
   STAILQ_FOREACH(np, checklist, entries)
   {
     a = (struct AttachMatch *) np->data;

--- a/parse.c
+++ b/parse.c
@@ -116,17 +116,13 @@ char *mutt_read_rfc822_line(FILE *f, char *line, size_t *linelen)
 
 static void parse_references(struct STailQHead *head, char *s)
 {
-  struct STailQNode *np = NULL;
   char *m = NULL;
   const char *sp = NULL;
 
-  m = mutt_extract_message_id(s, &sp);
-  while (m)
+  while ((m = mutt_extract_message_id(s, &sp)))
   {
-    np  = safe_malloc(sizeof(struct STailQNode));
-    np->data = m;
-    STAILQ_INSERT_HEAD(head, np, entries);
-    m = mutt_extract_message_id(NULL, &sp);
+    mutt_stailq_insert_head(head, m);
+    s = NULL;
   }
 }
 
@@ -1099,7 +1095,7 @@ int mutt_parse_rfc822_line(struct Envelope *e, struct Header *hdr, char *line,
     case 'i':
       if (mutt_strcasecmp(line + 1, "n-reply-to") == 0)
       {
-        mutt_free_stailq(&e->in_reply_to);
+        mutt_stailq_free(&e->in_reply_to);
         parse_references(&e->in_reply_to, p);
         matched = 1;
       }
@@ -1200,7 +1196,7 @@ int mutt_parse_rfc822_line(struct Envelope *e, struct Header *hdr, char *line,
     case 'r':
       if (mutt_strcasecmp(line + 1, "eferences") == 0)
       {
-        mutt_free_stailq(&e->references);
+        mutt_stailq_free(&e->references);
         parse_references(&e->references, p);
         matched = 1;
       }
@@ -1342,9 +1338,7 @@ int mutt_parse_rfc822_line(struct Envelope *e, struct Header *hdr, char *line,
 
     if (!(weed && option(OPT_WEED) && mutt_matches_ignore(line)))
     {
-      struct STailQNode *np = calloc(1, sizeof(struct STailQNode));
-      np->data = safe_strdup(line);
-      STAILQ_INSERT_TAIL(&e->userhdrs, np, entries);
+      struct STailQNode *np = mutt_stailq_insert_tail(&e->userhdrs, safe_strdup(line));
       if (do_2047)
         rfc2047_decode(&np->data);
     }

--- a/pattern.c
+++ b/pattern.c
@@ -1398,9 +1398,9 @@ static int match_adrlist(struct Pattern *pat, int match_personal, int n, ...)
   return pat->alladdr; /* No matches, or all matches if alladdr */
 }
 
-static bool match_reference(struct Pattern *pat, struct STailQHead *refs)
+static bool match_reference(struct Pattern *pat, struct ListHead *refs)
 {
-  struct STailQNode *np = NULL;
+  struct ListNode *np;
   STAILQ_FOREACH(np, refs, entries)
   {
     if (patmatch(pat, np->data) == 0)

--- a/postpone.c
+++ b/postpone.c
@@ -369,12 +369,15 @@ int mutt_get_postponed(struct Context *ctx, struct Header *hdr,
     else if (mutt_strncmp("X-Mutt-Mix:", np->data, 11) == 0)
     {
       char *t = NULL;
-      mutt_free_list(&hdr->chain);
+      mutt_free_stailq(&hdr->chain);
 
       t = strtok(np->data + 11, " \t\n");
+      struct STailQNode *n;
       while (t)
       {
-        hdr->chain = mutt_add_list(hdr->chain, t);
+        n = safe_calloc(1, sizeof(struct STailQNode));
+        n->data = safe_strdup(t);
+        STAILQ_INSERT_TAIL(&hdr->chain, n, entries);
         t = strtok(NULL, " \t\n");
       }
     }

--- a/postpone.c
+++ b/postpone.c
@@ -369,15 +369,12 @@ int mutt_get_postponed(struct Context *ctx, struct Header *hdr,
     else if (mutt_strncmp("X-Mutt-Mix:", np->data, 11) == 0)
     {
       char *t = NULL;
-      mutt_free_stailq(&hdr->chain);
+      mutt_stailq_free(&hdr->chain);
 
       t = strtok(np->data + 11, " \t\n");
-      struct STailQNode *n;
       while (t)
       {
-        n = safe_calloc(1, sizeof(struct STailQNode));
-        n->data = safe_strdup(t);
-        STAILQ_INSERT_TAIL(&hdr->chain, n, entries);
+        mutt_stailq_insert_tail(&hdr->chain, safe_strdup(t));
         t = strtok(NULL, " \t\n");
       }
     }

--- a/postpone.c
+++ b/postpone.c
@@ -319,7 +319,7 @@ int mutt_get_postponed(struct Context *ctx, struct Header *hdr,
 
   FREE(&PostContext);
 
-  struct STailQNode *np, *tmp;
+  struct ListNode *np, *tmp;
   STAILQ_FOREACH_SAFE(np, &hdr->env->userhdrs, entries, tmp)
   {
     if (mutt_strncasecmp("X-Mutt-References:", np->data, 18) == 0)
@@ -369,12 +369,12 @@ int mutt_get_postponed(struct Context *ctx, struct Header *hdr,
     else if (mutt_strncmp("X-Mutt-Mix:", np->data, 11) == 0)
     {
       char *t = NULL;
-      mutt_stailq_free(&hdr->chain);
+      mutt_list_free(&hdr->chain);
 
       t = strtok(np->data + 11, " \t\n");
       while (t)
       {
-        mutt_stailq_insert_tail(&hdr->chain, safe_strdup(t));
+        mutt_list_insert_tail(&hdr->chain, safe_strdup(t));
         t = strtok(NULL, " \t\n");
       }
     }
@@ -387,7 +387,7 @@ int mutt_get_postponed(struct Context *ctx, struct Header *hdr,
     }
 
     // remove the header
-    STAILQ_REMOVE(&hdr->env->userhdrs, np, STailQNode, entries);
+    STAILQ_REMOVE(&hdr->env->userhdrs, np, ListNode, entries);
     FREE(&np->data);
     FREE(&np);
   }

--- a/postpone.c
+++ b/postpone.c
@@ -263,9 +263,6 @@ int mutt_get_postponed(struct Context *ctx, struct Header *hdr,
 {
   struct Header *h = NULL;
   int code = SENDPOSTPONED;
-  struct List *tmp = NULL;
-  struct List *last = NULL;
-  struct List *next = NULL;
   const char *p = NULL;
   int opt_delete;
 
@@ -322,47 +319,29 @@ int mutt_get_postponed(struct Context *ctx, struct Header *hdr,
 
   FREE(&PostContext);
 
-  for (tmp = hdr->env->userhdrs; tmp;)
+  struct STailQNode *np, *tmp;
+  STAILQ_FOREACH_SAFE(np, &hdr->env->userhdrs, entries, tmp)
   {
-    if (mutt_strncasecmp("X-Mutt-References:", tmp->data, 18) == 0)
+    if (mutt_strncasecmp("X-Mutt-References:", np->data, 18) == 0)
     {
       if (ctx)
       {
         /* if a mailbox is currently open, look to see if the original message
            the user attempted to reply to is in this mailbox */
-        p = skip_email_wsp(tmp->data + 18);
+        p = skip_email_wsp(np->data + 18);
         if (!ctx->id_hash)
           ctx->id_hash = mutt_make_id_hash(ctx);
         *cur = hash_find(ctx->id_hash, p);
       }
-
-      /* Remove the X-Mutt-References: header field. */
-      next = tmp->next;
-      if (last)
-        last->next = tmp->next;
-      else
-        hdr->env->userhdrs = tmp->next;
-      tmp->next = NULL;
-      mutt_free_list(&tmp);
-      tmp = next;
       if (*cur)
         code |= SENDREPLY;
     }
-    else if (mutt_strncasecmp("X-Mutt-Fcc:", tmp->data, 11) == 0)
+    else if (mutt_strncasecmp("X-Mutt-Fcc:", np->data, 11) == 0)
     {
-      p = skip_email_wsp(tmp->data + 11);
+      p = skip_email_wsp(np->data + 11);
       strfcpy(fcc, p, fcclen);
       mutt_pretty_mailbox(fcc, fcclen);
 
-      /* remove the X-Mutt-Fcc: header field */
-      next = tmp->next;
-      if (last)
-        last->next = tmp->next;
-      else
-        hdr->env->userhdrs = tmp->next;
-      tmp->next = NULL;
-      mutt_free_list(&tmp);
-      tmp = next;
       /* note that x-mutt-fcc was present.  we do this because we want to add a
       * default fcc if the header was missing, but preserve the request of the
       * user to not make a copy if the header field is present, but empty.
@@ -371,70 +350,46 @@ int mutt_get_postponed(struct Context *ctx, struct Header *hdr,
       code |= SENDPOSTPONEDFCC;
     }
     else if ((WithCrypto & APPLICATION_PGP) &&
-             ((mutt_strncmp("Pgp:", tmp->data, 4) == 0) /* this is generated
-                                                       * by old mutt versions
-                                                       */
-              || (mutt_strncmp("X-Mutt-PGP:", tmp->data, 11) == 0)))
+             ((mutt_strncmp("Pgp:", np->data, 4) == 0) /* this is generated
+                                                        * by old mutt versions
+                                                        */
+              || (mutt_strncmp("X-Mutt-PGP:", np->data, 11) == 0)))
     {
-      hdr->security = mutt_parse_crypt_hdr(strchr(tmp->data, ':') + 1, 1, APPLICATION_PGP);
+      hdr->security = mutt_parse_crypt_hdr(strchr(np->data, ':') + 1, 1, APPLICATION_PGP);
       hdr->security |= APPLICATION_PGP;
-
-      /* remove the pgp field */
-      next = tmp->next;
-      if (last)
-        last->next = tmp->next;
-      else
-        hdr->env->userhdrs = tmp->next;
-      tmp->next = NULL;
-      mutt_free_list(&tmp);
-      tmp = next;
     }
     else if ((WithCrypto & APPLICATION_SMIME) &&
-             (mutt_strncmp("X-Mutt-SMIME:", tmp->data, 13) == 0))
+             (mutt_strncmp("X-Mutt-SMIME:", np->data, 13) == 0))
     {
-      hdr->security = mutt_parse_crypt_hdr(strchr(tmp->data, ':') + 1, 1, APPLICATION_SMIME);
+      hdr->security = mutt_parse_crypt_hdr(strchr(np->data, ':') + 1, 1, APPLICATION_SMIME);
       hdr->security |= APPLICATION_SMIME;
-
-      /* remove the smime field */
-      next = tmp->next;
-      if (last)
-        last->next = tmp->next;
-      else
-        hdr->env->userhdrs = tmp->next;
-      tmp->next = NULL;
-      mutt_free_list(&tmp);
-      tmp = next;
     }
 
 #ifdef MIXMASTER
-    else if (mutt_strncmp("X-Mutt-Mix:", tmp->data, 11) == 0)
+    else if (mutt_strncmp("X-Mutt-Mix:", np->data, 11) == 0)
     {
       char *t = NULL;
       mutt_free_list(&hdr->chain);
 
-      t = strtok(tmp->data + 11, " \t\n");
+      t = strtok(np->data + 11, " \t\n");
       while (t)
       {
         hdr->chain = mutt_add_list(hdr->chain, t);
         t = strtok(NULL, " \t\n");
       }
-
-      next = tmp->next;
-      if (last)
-        last->next = tmp->next;
-      else
-        hdr->env->userhdrs = tmp->next;
-      tmp->next = NULL;
-      mutt_free_list(&tmp);
-      tmp = next;
     }
 #endif
 
     else
     {
-      last = tmp;
-      tmp = tmp->next;
+      // skip header removal
+      continue;
     }
+
+    // remove the header
+    STAILQ_REMOVE(&hdr->env->userhdrs, np, STailQNode, entries);
+    FREE(&np->data);
+    FREE(&np);
   }
 
   if (option(OPT_CRYPT_OPPORTUNISTIC_ENCRYPT))

--- a/protos.h
+++ b/protos.h
@@ -48,7 +48,7 @@ struct Regex;
 struct ReplaceList;
 struct RxList;
 struct State;
-struct STailQHead;
+struct ListHead;
 
 struct stat;
 struct passwd;
@@ -137,7 +137,7 @@ char *_mutt_expand_path(char *s, size_t slen, int rx);
 char *mutt_find_hook(int type, const char *pat);
 char *mutt_gecos_name(char *dest, size_t destlen, struct passwd *pw);
 char *mutt_get_body_charset(char *d, size_t dlen, struct Body *b);
-void mutt_crypt_hook(struct STailQHead *list, struct Address *adr);
+void mutt_crypt_hook(struct ListHead *list, struct Address *adr);
 void mutt_timeout_hook(void);
 void mutt_startup_shutdown_hook(int type);
 int mutt_set_xdg_path(enum XdgType type, char *buf, size_t bufsize);
@@ -342,7 +342,7 @@ int mutt_parse_unhook(struct Buffer *buf, struct Buffer *s, unsigned long data, 
 int mutt_pipe_attachment(FILE *fp, struct Body *b, const char *path, char *outfile);
 int mutt_print_attachment(FILE *fp, struct Body *a);
 int mutt_query_complete(char *buf, size_t buflen);
-int mutt_query_variables(struct STailQHead *queries);
+int mutt_query_variables(struct ListHead *queries);
 int mutt_save_attachment(FILE *fp, struct Body *m, char *path, int flags, struct Header *hdr);
 int _mutt_save_message(struct Header *h, struct Context *ctx, int delete, int decode, int decrypt);
 int mutt_save_message(struct Header *h, int delete, int decode, int decrypt);
@@ -366,7 +366,7 @@ int mutt_write_mime_header(struct Body *a, FILE *f);
 int mutt_write_one_header(FILE *fp, const char *tag, const char *value,
                           const char *pfx, int wraplen, int flags);
 int mutt_write_rfc822_header(FILE *fp, struct Envelope *env, struct Body *attach, int mode, int privacy);
-void mutt_write_references(const struct STailQHead *r, FILE *f, size_t trim);
+void mutt_write_references(const struct ListHead *r, FILE *f, size_t trim);
 int mutt_yesorno(const char *msg, int def);
 void mutt_set_header_color(struct Context *ctx, struct Header *curhdr);
 void mutt_sleep(short s);

--- a/protos.h
+++ b/protos.h
@@ -49,6 +49,7 @@ struct Regex;
 struct ReplaceList;
 struct RxList;
 struct State;
+struct STailQHead;
 
 struct stat;
 struct passwd;
@@ -149,8 +150,7 @@ const char *mutt_fqdn(short may_hide_host);
 struct Regex *mutt_compile_regexp(const char *s, int flags);
 
 void mutt_account_hook(const char *url);
-void mutt_add_to_reference_headers(struct Envelope *env, struct Envelope *curenv, struct List ***pp,
-                                   struct List ***qq);
+void mutt_add_to_reference_headers(struct Envelope *env, struct Envelope *curenv);
 void mutt_adv_mktemp(char *s, size_t l);
 void mutt_alias_menu(char *buf, size_t buflen, struct Alias *aliases);
 void mutt_allow_interrupt(int disposition);
@@ -367,7 +367,7 @@ int mutt_write_mime_header(struct Body *a, FILE *f);
 int mutt_write_one_header(FILE *fp, const char *tag, const char *value,
                           const char *pfx, int wraplen, int flags);
 int mutt_write_rfc822_header(FILE *fp, struct Envelope *env, struct Body *attach, int mode, int privacy);
-void mutt_write_references(struct List *r, FILE *f, int trim);
+void mutt_write_references(const struct STailQHead *r, FILE *f, size_t trim);
 int mutt_yesorno(const char *msg, int def);
 void mutt_set_header_color(struct Context *ctx, struct Header *curhdr);
 void mutt_sleep(short s);

--- a/protos.h
+++ b/protos.h
@@ -138,7 +138,7 @@ char *_mutt_expand_path(char *s, size_t slen, int rx);
 char *mutt_find_hook(int type, const char *pat);
 char *mutt_gecos_name(char *dest, size_t destlen, struct passwd *pw);
 char *mutt_get_body_charset(char *d, size_t dlen, struct Body *b);
-struct List *mutt_crypt_hook(struct Address *adr);
+void mutt_crypt_hook(struct STailQHead *list, struct Address *adr);
 void mutt_timeout_hook(void);
 void mutt_startup_shutdown_hook(int type);
 int mutt_set_xdg_path(enum XdgType type, char *buf, size_t bufsize);

--- a/protos.h
+++ b/protos.h
@@ -43,7 +43,6 @@ struct Context;
 struct EnterState;
 struct Envelope;
 struct Header;
-struct List;
 struct Parameter;
 struct Regex;
 struct ReplaceList;
@@ -343,7 +342,7 @@ int mutt_parse_unhook(struct Buffer *buf, struct Buffer *s, unsigned long data, 
 int mutt_pipe_attachment(FILE *fp, struct Body *b, const char *path, char *outfile);
 int mutt_print_attachment(FILE *fp, struct Body *a);
 int mutt_query_complete(char *buf, size_t buflen);
-int mutt_query_variables(struct List *queries);
+int mutt_query_variables(struct STailQHead *queries);
 int mutt_save_attachment(FILE *fp, struct Body *m, char *path, int flags, struct Header *hdr);
 int _mutt_save_message(struct Header *h, struct Context *ctx, int delete, int decode, int decrypt);
 int mutt_save_message(struct Header *h, int delete, int decode, int decrypt);

--- a/protos.h
+++ b/protos.h
@@ -336,7 +336,7 @@ int mutt_parse_unmono(struct Buffer *buf, struct Buffer *s, unsigned long data, 
 int mutt_parse_push(struct Buffer *buf, struct Buffer *s, unsigned long data, struct Buffer *err);
 int mutt_parse_rc_line(/* const */ char *line, struct Buffer *token, struct Buffer *err);
 int mutt_parse_rfc822_line(struct Envelope *e, struct Header *hdr, char *line, char *p,
-                           short user_hdrs, short weed, short do_2047, struct List **lastp);
+                           short user_hdrs, short weed, short do_2047);
 int mutt_parse_score(struct Buffer *buf, struct Buffer *s, unsigned long data, struct Buffer *err);
 int mutt_parse_unscore(struct Buffer *buf, struct Buffer *s, unsigned long data, struct Buffer *err);
 int mutt_parse_unhook(struct Buffer *buf, struct Buffer *s, unsigned long data, struct Buffer *err);

--- a/queue.h
+++ b/queue.h
@@ -1,0 +1,858 @@
+/*-
+ * Copyright (c) 1991, 1993
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *	@(#)queue.h	8.5 (Berkeley) 8/20/94
+ * $FreeBSD: head/sys/sys/queue.h 314436 2017-02-28 23:42:47Z imp $
+ */
+
+#ifndef _SYS_QUEUE_H_
+#define	_SYS_QUEUE_H_
+
+#include <sys/cdefs.h>
+
+/*
+ * This file defines four types of data structures: singly-linked lists,
+ * singly-linked tail queues, lists and tail queues.
+ *
+ * A singly-linked list is headed by a single forward pointer. The elements
+ * are singly linked for minimum space and pointer manipulation overhead at
+ * the expense of O(n) removal for arbitrary elements. New elements can be
+ * added to the list after an existing element or at the head of the list.
+ * Elements being removed from the head of the list should use the explicit
+ * macro for this purpose for optimum efficiency. A singly-linked list may
+ * only be traversed in the forward direction.  Singly-linked lists are ideal
+ * for applications with large datasets and few or no removals or for
+ * implementing a LIFO queue.
+ *
+ * A singly-linked tail queue is headed by a pair of pointers, one to the
+ * head of the list and the other to the tail of the list. The elements are
+ * singly linked for minimum space and pointer manipulation overhead at the
+ * expense of O(n) removal for arbitrary elements. New elements can be added
+ * to the list after an existing element, at the head of the list, or at the
+ * end of the list. Elements being removed from the head of the tail queue
+ * should use the explicit macro for this purpose for optimum efficiency.
+ * A singly-linked tail queue may only be traversed in the forward direction.
+ * Singly-linked tail queues are ideal for applications with large datasets
+ * and few or no removals or for implementing a FIFO queue.
+ *
+ * A list is headed by a single forward pointer (or an array of forward
+ * pointers for a hash table header). The elements are doubly linked
+ * so that an arbitrary element can be removed without a need to
+ * traverse the list. New elements can be added to the list before
+ * or after an existing element or at the head of the list. A list
+ * may be traversed in either direction.
+ *
+ * A tail queue is headed by a pair of pointers, one to the head of the
+ * list and the other to the tail of the list. The elements are doubly
+ * linked so that an arbitrary element can be removed without a need to
+ * traverse the list. New elements can be added to the list before or
+ * after an existing element, at the head of the list, or at the end of
+ * the list. A tail queue may be traversed in either direction.
+ *
+ * For details on the use of these macros, see the queue(3) manual page.
+ *
+ * Below is a summary of implemented functions where:
+ *  +  means the macro is available
+ *  -  means the macro is not available
+ *  s  means the macro is available but is slow (runs in O(n) time)
+ *
+ *				SLIST	LIST	STAILQ	TAILQ
+ * _HEAD			+	+	+	+
+ * _CLASS_HEAD			+	+	+	+
+ * _HEAD_INITIALIZER		+	+	+	+
+ * _ENTRY			+	+	+	+
+ * _CLASS_ENTRY			+	+	+	+
+ * _INIT			+	+	+	+
+ * _EMPTY			+	+	+	+
+ * _FIRST			+	+	+	+
+ * _NEXT			+	+	+	+
+ * _PREV			-	+	-	+
+ * _LAST			-	-	+	+
+ * _FOREACH			+	+	+	+
+ * _FOREACH_FROM		+	+	+	+
+ * _FOREACH_SAFE		+	+	+	+
+ * _FOREACH_FROM_SAFE		+	+	+	+
+ * _FOREACH_REVERSE		-	-	-	+
+ * _FOREACH_REVERSE_FROM	-	-	-	+
+ * _FOREACH_REVERSE_SAFE	-	-	-	+
+ * _FOREACH_REVERSE_FROM_SAFE	-	-	-	+
+ * _INSERT_HEAD			+	+	+	+
+ * _INSERT_BEFORE		-	+	-	+
+ * _INSERT_AFTER		+	+	+	+
+ * _INSERT_TAIL			-	-	+	+
+ * _CONCAT			s	s	+	+
+ * _REMOVE_AFTER		+	-	+	-
+ * _REMOVE_HEAD			+	-	+	-
+ * _REMOVE			s	+	s	+
+ * _SWAP			+	+	+	+
+ *
+ */
+#ifdef QUEUE_MACRO_DEBUG
+#warn Use QUEUE_MACRO_DEBUG_TRACE and/or QUEUE_MACRO_DEBUG_TRASH
+#define	QUEUE_MACRO_DEBUG_TRACE
+#define	QUEUE_MACRO_DEBUG_TRASH
+#endif
+
+#ifdef QUEUE_MACRO_DEBUG_TRACE
+/* Store the last 2 places the queue element or head was altered */
+struct qm_trace {
+	unsigned long	 lastline;
+	unsigned long	 prevline;
+	const char	*lastfile;
+	const char	*prevfile;
+};
+
+#define	TRACEBUF	struct qm_trace trace;
+#define	TRACEBUF_INITIALIZER	{ __LINE__, 0, __FILE__, NULL } ,
+
+#define	QMD_TRACE_HEAD(head) do {					\
+	(head)->trace.prevline = (head)->trace.lastline;		\
+	(head)->trace.prevfile = (head)->trace.lastfile;		\
+	(head)->trace.lastline = __LINE__;				\
+	(head)->trace.lastfile = __FILE__;				\
+} while (0)
+
+#define	QMD_TRACE_ELEM(elem) do {					\
+	(elem)->trace.prevline = (elem)->trace.lastline;		\
+	(elem)->trace.prevfile = (elem)->trace.lastfile;		\
+	(elem)->trace.lastline = __LINE__;				\
+	(elem)->trace.lastfile = __FILE__;				\
+} while (0)
+
+#else	/* !QUEUE_MACRO_DEBUG_TRACE */
+#define	QMD_TRACE_ELEM(elem)
+#define	QMD_TRACE_HEAD(head)
+#define	TRACEBUF
+#define	TRACEBUF_INITIALIZER
+#endif	/* QUEUE_MACRO_DEBUG_TRACE */
+
+#ifdef QUEUE_MACRO_DEBUG_TRASH
+#define	TRASHIT(x)		do {(x) = (void *)-1;} while (0)
+#define	QMD_IS_TRASHED(x)	((x) == (void *)(intptr_t)-1)
+#else	/* !QUEUE_MACRO_DEBUG_TRASH */
+#define	TRASHIT(x)
+#define	QMD_IS_TRASHED(x)	0
+#endif	/* QUEUE_MACRO_DEBUG_TRASH */
+
+#if defined(QUEUE_MACRO_DEBUG_TRACE) || defined(QUEUE_MACRO_DEBUG_TRASH)
+#define	QMD_SAVELINK(name, link)	void **name = (void *)&(link)
+#else	/* !QUEUE_MACRO_DEBUG_TRACE && !QUEUE_MACRO_DEBUG_TRASH */
+#define	QMD_SAVELINK(name, link)
+#endif	/* QUEUE_MACRO_DEBUG_TRACE || QUEUE_MACRO_DEBUG_TRASH */
+
+#ifdef __cplusplus
+/*
+ * In C++ there can be structure lists and class lists:
+ */
+#define	QUEUE_TYPEOF(type) type
+#else
+#define	QUEUE_TYPEOF(type) struct type
+#endif
+
+/*
+ * Singly-linked List declarations.
+ */
+#define	SLIST_HEAD(name, type)						\
+struct name {								\
+	struct type *slh_first;	/* first element */			\
+}
+
+#define	SLIST_CLASS_HEAD(name, type)					\
+struct name {								\
+	class type *slh_first;	/* first element */			\
+}
+
+#define	SLIST_HEAD_INITIALIZER(head)					\
+	{ NULL }
+
+#define	SLIST_ENTRY(type)						\
+struct {								\
+	struct type *sle_next;	/* next element */			\
+}
+
+#define	SLIST_CLASS_ENTRY(type)						\
+struct {								\
+	class type *sle_next;		/* next element */		\
+}
+
+/*
+ * Singly-linked List functions.
+ */
+#if (defined(_KERNEL) && defined(INVARIANTS))
+#define	QMD_SLIST_CHECK_PREVPTR(prevp, elm) do {			\
+	if (*(prevp) != (elm))						\
+		panic("Bad prevptr *(%p) == %p != %p",			\
+		    (prevp), *(prevp), (elm));				\
+} while (0)
+#else
+#define	QMD_SLIST_CHECK_PREVPTR(prevp, elm)
+#endif
+
+#define SLIST_CONCAT(head1, head2, type, field) do {			\
+	QUEUE_TYPEOF(type) *curelm = SLIST_FIRST(head1);		\
+	if (curelm == NULL) {						\
+		if ((SLIST_FIRST(head1) = SLIST_FIRST(head2)) != NULL)	\
+			SLIST_INIT(head2);				\
+	} else if (SLIST_FIRST(head2) != NULL) {			\
+		while (SLIST_NEXT(curelm, field) != NULL)		\
+			curelm = SLIST_NEXT(curelm, field);		\
+		SLIST_NEXT(curelm, field) = SLIST_FIRST(head2);		\
+		SLIST_INIT(head2);					\
+	}								\
+} while (0)
+
+#define	SLIST_EMPTY(head)	((head)->slh_first == NULL)
+
+#define	SLIST_FIRST(head)	((head)->slh_first)
+
+#define	SLIST_FOREACH(var, head, field)					\
+	for ((var) = SLIST_FIRST((head));				\
+	    (var);							\
+	    (var) = SLIST_NEXT((var), field))
+
+#define	SLIST_FOREACH_FROM(var, head, field)				\
+	for ((var) = ((var) ? (var) : SLIST_FIRST((head)));		\
+	    (var);							\
+	    (var) = SLIST_NEXT((var), field))
+
+#define	SLIST_FOREACH_SAFE(var, head, field, tvar)			\
+	for ((var) = SLIST_FIRST((head));				\
+	    (var) && ((tvar) = SLIST_NEXT((var), field), 1);		\
+	    (var) = (tvar))
+
+#define	SLIST_FOREACH_FROM_SAFE(var, head, field, tvar)			\
+	for ((var) = ((var) ? (var) : SLIST_FIRST((head)));		\
+	    (var) && ((tvar) = SLIST_NEXT((var), field), 1);		\
+	    (var) = (tvar))
+
+#define	SLIST_FOREACH_PREVPTR(var, varp, head, field)			\
+	for ((varp) = &SLIST_FIRST((head));				\
+	    ((var) = *(varp)) != NULL;					\
+	    (varp) = &SLIST_NEXT((var), field))
+
+#define	SLIST_INIT(head) do {						\
+	SLIST_FIRST((head)) = NULL;					\
+} while (0)
+
+#define	SLIST_INSERT_AFTER(slistelm, elm, field) do {			\
+	SLIST_NEXT((elm), field) = SLIST_NEXT((slistelm), field);	\
+	SLIST_NEXT((slistelm), field) = (elm);				\
+} while (0)
+
+#define	SLIST_INSERT_HEAD(head, elm, field) do {			\
+	SLIST_NEXT((elm), field) = SLIST_FIRST((head));			\
+	SLIST_FIRST((head)) = (elm);					\
+} while (0)
+
+#define	SLIST_NEXT(elm, field)	((elm)->field.sle_next)
+
+#define	SLIST_REMOVE(head, elm, type, field) do {			\
+	QMD_SAVELINK(oldnext, (elm)->field.sle_next);			\
+	if (SLIST_FIRST((head)) == (elm)) {				\
+		SLIST_REMOVE_HEAD((head), field);			\
+	}								\
+	else {								\
+		QUEUE_TYPEOF(type) *curelm = SLIST_FIRST(head);		\
+		while (SLIST_NEXT(curelm, field) != (elm))		\
+			curelm = SLIST_NEXT(curelm, field);		\
+		SLIST_REMOVE_AFTER(curelm, field);			\
+	}								\
+	TRASHIT(*oldnext);						\
+} while (0)
+
+#define SLIST_REMOVE_AFTER(elm, field) do {				\
+	SLIST_NEXT(elm, field) =					\
+	    SLIST_NEXT(SLIST_NEXT(elm, field), field);			\
+} while (0)
+
+#define	SLIST_REMOVE_HEAD(head, field) do {				\
+	SLIST_FIRST((head)) = SLIST_NEXT(SLIST_FIRST((head)), field);	\
+} while (0)
+
+#define	SLIST_REMOVE_PREVPTR(prevp, elm, field) do {			\
+	QMD_SLIST_CHECK_PREVPTR(prevp, elm);				\
+	*(prevp) = SLIST_NEXT(elm, field);				\
+	TRASHIT((elm)->field.sle_next);					\
+} while (0)
+
+#define SLIST_SWAP(head1, head2, type) do {				\
+	QUEUE_TYPEOF(type) *swap_first = SLIST_FIRST(head1);		\
+	SLIST_FIRST(head1) = SLIST_FIRST(head2);			\
+	SLIST_FIRST(head2) = swap_first;				\
+} while (0)
+
+/*
+ * Singly-linked Tail queue declarations.
+ */
+#define	STAILQ_HEAD(name, type)						\
+struct name {								\
+	struct type *stqh_first;/* first element */			\
+	struct type **stqh_last;/* addr of last next element */		\
+}
+
+#define	STAILQ_CLASS_HEAD(name, type)					\
+struct name {								\
+	class type *stqh_first;	/* first element */			\
+	class type **stqh_last;	/* addr of last next element */		\
+}
+
+#define	STAILQ_HEAD_INITIALIZER(head)					\
+	{ NULL, &(head).stqh_first }
+
+#define	STAILQ_ENTRY(type)						\
+struct {								\
+	struct type *stqe_next;	/* next element */			\
+}
+
+#define	STAILQ_CLASS_ENTRY(type)					\
+struct {								\
+	class type *stqe_next;	/* next element */			\
+}
+
+/*
+ * Singly-linked Tail queue functions.
+ */
+#define	STAILQ_CONCAT(head1, head2) do {				\
+	if (!STAILQ_EMPTY((head2))) {					\
+		*(head1)->stqh_last = (head2)->stqh_first;		\
+		(head1)->stqh_last = (head2)->stqh_last;		\
+		STAILQ_INIT((head2));					\
+	}								\
+} while (0)
+
+#define	STAILQ_EMPTY(head)	((head)->stqh_first == NULL)
+
+#define	STAILQ_FIRST(head)	((head)->stqh_first)
+
+#define	STAILQ_FOREACH(var, head, field)				\
+	for((var) = STAILQ_FIRST((head));				\
+	   (var);							\
+	   (var) = STAILQ_NEXT((var), field))
+
+#define	STAILQ_FOREACH_FROM(var, head, field)				\
+	for ((var) = ((var) ? (var) : STAILQ_FIRST((head)));		\
+	   (var);							\
+	   (var) = STAILQ_NEXT((var), field))
+
+#define	STAILQ_FOREACH_SAFE(var, head, field, tvar)			\
+	for ((var) = STAILQ_FIRST((head));				\
+	    (var) && ((tvar) = STAILQ_NEXT((var), field), 1);		\
+	    (var) = (tvar))
+
+#define	STAILQ_FOREACH_FROM_SAFE(var, head, field, tvar)		\
+	for ((var) = ((var) ? (var) : STAILQ_FIRST((head)));		\
+	    (var) && ((tvar) = STAILQ_NEXT((var), field), 1);		\
+	    (var) = (tvar))
+
+#define	STAILQ_INIT(head) do {						\
+	STAILQ_FIRST((head)) = NULL;					\
+	(head)->stqh_last = &STAILQ_FIRST((head));			\
+} while (0)
+
+#define	STAILQ_INSERT_AFTER(head, tqelm, elm, field) do {		\
+	if ((STAILQ_NEXT((elm), field) = STAILQ_NEXT((tqelm), field)) == NULL)\
+		(head)->stqh_last = &STAILQ_NEXT((elm), field);		\
+	STAILQ_NEXT((tqelm), field) = (elm);				\
+} while (0)
+
+#define	STAILQ_INSERT_HEAD(head, elm, field) do {			\
+	if ((STAILQ_NEXT((elm), field) = STAILQ_FIRST((head))) == NULL)	\
+		(head)->stqh_last = &STAILQ_NEXT((elm), field);		\
+	STAILQ_FIRST((head)) = (elm);					\
+} while (0)
+
+#define	STAILQ_INSERT_TAIL(head, elm, field) do {			\
+	STAILQ_NEXT((elm), field) = NULL;				\
+	*(head)->stqh_last = (elm);					\
+	(head)->stqh_last = &STAILQ_NEXT((elm), field);			\
+} while (0)
+
+#define	STAILQ_LAST(head, type, field)				\
+	(STAILQ_EMPTY((head)) ? NULL :				\
+	    __containerof((head)->stqh_last,			\
+	    QUEUE_TYPEOF(type), field.stqe_next))
+
+#define	STAILQ_NEXT(elm, field)	((elm)->field.stqe_next)
+
+#define	STAILQ_REMOVE(head, elm, type, field) do {			\
+	QMD_SAVELINK(oldnext, (elm)->field.stqe_next);			\
+	if (STAILQ_FIRST((head)) == (elm)) {				\
+		STAILQ_REMOVE_HEAD((head), field);			\
+	}								\
+	else {								\
+		QUEUE_TYPEOF(type) *curelm = STAILQ_FIRST(head);	\
+		while (STAILQ_NEXT(curelm, field) != (elm))		\
+			curelm = STAILQ_NEXT(curelm, field);		\
+		STAILQ_REMOVE_AFTER(head, curelm, field);		\
+	}								\
+	TRASHIT(*oldnext);						\
+} while (0)
+
+#define STAILQ_REMOVE_AFTER(head, elm, field) do {			\
+	if ((STAILQ_NEXT(elm, field) =					\
+	     STAILQ_NEXT(STAILQ_NEXT(elm, field), field)) == NULL)	\
+		(head)->stqh_last = &STAILQ_NEXT((elm), field);		\
+} while (0)
+
+#define	STAILQ_REMOVE_HEAD(head, field) do {				\
+	if ((STAILQ_FIRST((head)) =					\
+	     STAILQ_NEXT(STAILQ_FIRST((head)), field)) == NULL)		\
+		(head)->stqh_last = &STAILQ_FIRST((head));		\
+} while (0)
+
+#define STAILQ_SWAP(head1, head2, type) do {				\
+	QUEUE_TYPEOF(type) *swap_first = STAILQ_FIRST(head1);		\
+	QUEUE_TYPEOF(type) **swap_last = (head1)->stqh_last;		\
+	STAILQ_FIRST(head1) = STAILQ_FIRST(head2);			\
+	(head1)->stqh_last = (head2)->stqh_last;			\
+	STAILQ_FIRST(head2) = swap_first;				\
+	(head2)->stqh_last = swap_last;					\
+	if (STAILQ_EMPTY(head1))					\
+		(head1)->stqh_last = &STAILQ_FIRST(head1);		\
+	if (STAILQ_EMPTY(head2))					\
+		(head2)->stqh_last = &STAILQ_FIRST(head2);		\
+} while (0)
+
+
+/*
+ * List declarations.
+ */
+#define	LIST_HEAD(name, type)						\
+struct name {								\
+	struct type *lh_first;	/* first element */			\
+}
+
+#define	LIST_CLASS_HEAD(name, type)					\
+struct name {								\
+	class type *lh_first;	/* first element */			\
+}
+
+#define	LIST_HEAD_INITIALIZER(head)					\
+	{ NULL }
+
+#define	LIST_ENTRY(type)						\
+struct {								\
+	struct type *le_next;	/* next element */			\
+	struct type **le_prev;	/* address of previous next element */	\
+}
+
+#define	LIST_CLASS_ENTRY(type)						\
+struct {								\
+	class type *le_next;	/* next element */			\
+	class type **le_prev;	/* address of previous next element */	\
+}
+
+/*
+ * List functions.
+ */
+
+#if (defined(_KERNEL) && defined(INVARIANTS))
+/*
+ * QMD_LIST_CHECK_HEAD(LIST_HEAD *head, LIST_ENTRY NAME)
+ *
+ * If the list is non-empty, validates that the first element of the list
+ * points back at 'head.'
+ */
+#define	QMD_LIST_CHECK_HEAD(head, field) do {				\
+	if (LIST_FIRST((head)) != NULL &&				\
+	    LIST_FIRST((head))->field.le_prev !=			\
+	     &LIST_FIRST((head)))					\
+		panic("Bad list head %p first->prev != head", (head));	\
+} while (0)
+
+/*
+ * QMD_LIST_CHECK_NEXT(TYPE *elm, LIST_ENTRY NAME)
+ *
+ * If an element follows 'elm' in the list, validates that the next element
+ * points back at 'elm.'
+ */
+#define	QMD_LIST_CHECK_NEXT(elm, field) do {				\
+	if (LIST_NEXT((elm), field) != NULL &&				\
+	    LIST_NEXT((elm), field)->field.le_prev !=			\
+	     &((elm)->field.le_next))					\
+	     	panic("Bad link elm %p next->prev != elm", (elm));	\
+} while (0)
+
+/*
+ * QMD_LIST_CHECK_PREV(TYPE *elm, LIST_ENTRY NAME)
+ *
+ * Validates that the previous element (or head of the list) points to 'elm.'
+ */
+#define	QMD_LIST_CHECK_PREV(elm, field) do {				\
+	if (*(elm)->field.le_prev != (elm))				\
+		panic("Bad link elm %p prev->next != elm", (elm));	\
+} while (0)
+#else
+#define	QMD_LIST_CHECK_HEAD(head, field)
+#define	QMD_LIST_CHECK_NEXT(elm, field)
+#define	QMD_LIST_CHECK_PREV(elm, field)
+#endif /* (_KERNEL && INVARIANTS) */
+
+#define LIST_CONCAT(head1, head2, type, field) do {			      \
+	QUEUE_TYPEOF(type) *curelm = LIST_FIRST(head1);			      \
+	if (curelm == NULL) {						      \
+		if ((LIST_FIRST(head1) = LIST_FIRST(head2)) != NULL) {	      \
+			LIST_FIRST(head2)->field.le_prev =		      \
+			    &LIST_FIRST((head1));			      \
+			LIST_INIT(head2);				      \
+		}							      \
+	} else if (LIST_FIRST(head2) != NULL) {				      \
+		while (LIST_NEXT(curelm, field) != NULL)		      \
+			curelm = LIST_NEXT(curelm, field);		      \
+		LIST_NEXT(curelm, field) = LIST_FIRST(head2);		      \
+		LIST_FIRST(head2)->field.le_prev = &LIST_NEXT(curelm, field); \
+		LIST_INIT(head2);					      \
+	}								      \
+} while (0)
+
+#define	LIST_EMPTY(head)	((head)->lh_first == NULL)
+
+#define	LIST_FIRST(head)	((head)->lh_first)
+
+#define	LIST_FOREACH(var, head, field)					\
+	for ((var) = LIST_FIRST((head));				\
+	    (var);							\
+	    (var) = LIST_NEXT((var), field))
+
+#define	LIST_FOREACH_FROM(var, head, field)				\
+	for ((var) = ((var) ? (var) : LIST_FIRST((head)));		\
+	    (var);							\
+	    (var) = LIST_NEXT((var), field))
+
+#define	LIST_FOREACH_SAFE(var, head, field, tvar)			\
+	for ((var) = LIST_FIRST((head));				\
+	    (var) && ((tvar) = LIST_NEXT((var), field), 1);		\
+	    (var) = (tvar))
+
+#define	LIST_FOREACH_FROM_SAFE(var, head, field, tvar)			\
+	for ((var) = ((var) ? (var) : LIST_FIRST((head)));		\
+	    (var) && ((tvar) = LIST_NEXT((var), field), 1);		\
+	    (var) = (tvar))
+
+#define	LIST_INIT(head) do {						\
+	LIST_FIRST((head)) = NULL;					\
+} while (0)
+
+#define	LIST_INSERT_AFTER(listelm, elm, field) do {			\
+	QMD_LIST_CHECK_NEXT(listelm, field);				\
+	if ((LIST_NEXT((elm), field) = LIST_NEXT((listelm), field)) != NULL)\
+		LIST_NEXT((listelm), field)->field.le_prev =		\
+		    &LIST_NEXT((elm), field);				\
+	LIST_NEXT((listelm), field) = (elm);				\
+	(elm)->field.le_prev = &LIST_NEXT((listelm), field);		\
+} while (0)
+
+#define	LIST_INSERT_BEFORE(listelm, elm, field) do {			\
+	QMD_LIST_CHECK_PREV(listelm, field);				\
+	(elm)->field.le_prev = (listelm)->field.le_prev;		\
+	LIST_NEXT((elm), field) = (listelm);				\
+	*(listelm)->field.le_prev = (elm);				\
+	(listelm)->field.le_prev = &LIST_NEXT((elm), field);		\
+} while (0)
+
+#define	LIST_INSERT_HEAD(head, elm, field) do {				\
+	QMD_LIST_CHECK_HEAD((head), field);				\
+	if ((LIST_NEXT((elm), field) = LIST_FIRST((head))) != NULL)	\
+		LIST_FIRST((head))->field.le_prev = &LIST_NEXT((elm), field);\
+	LIST_FIRST((head)) = (elm);					\
+	(elm)->field.le_prev = &LIST_FIRST((head));			\
+} while (0)
+
+#define	LIST_NEXT(elm, field)	((elm)->field.le_next)
+
+#define	LIST_PREV(elm, head, type, field)			\
+	((elm)->field.le_prev == &LIST_FIRST((head)) ? NULL :	\
+	    __containerof((elm)->field.le_prev,			\
+	    QUEUE_TYPEOF(type), field.le_next))
+
+#define	LIST_REMOVE(elm, field) do {					\
+	QMD_SAVELINK(oldnext, (elm)->field.le_next);			\
+	QMD_SAVELINK(oldprev, (elm)->field.le_prev);			\
+	QMD_LIST_CHECK_NEXT(elm, field);				\
+	QMD_LIST_CHECK_PREV(elm, field);				\
+	if (LIST_NEXT((elm), field) != NULL)				\
+		LIST_NEXT((elm), field)->field.le_prev = 		\
+		    (elm)->field.le_prev;				\
+	*(elm)->field.le_prev = LIST_NEXT((elm), field);		\
+	TRASHIT(*oldnext);						\
+	TRASHIT(*oldprev);						\
+} while (0)
+
+#define LIST_SWAP(head1, head2, type, field) do {			\
+	QUEUE_TYPEOF(type) *swap_tmp = LIST_FIRST(head1);		\
+	LIST_FIRST((head1)) = LIST_FIRST((head2));			\
+	LIST_FIRST((head2)) = swap_tmp;					\
+	if ((swap_tmp = LIST_FIRST((head1))) != NULL)			\
+		swap_tmp->field.le_prev = &LIST_FIRST((head1));		\
+	if ((swap_tmp = LIST_FIRST((head2))) != NULL)			\
+		swap_tmp->field.le_prev = &LIST_FIRST((head2));		\
+} while (0)
+
+/*
+ * Tail queue declarations.
+ */
+#define	TAILQ_HEAD(name, type)						\
+struct name {								\
+	struct type *tqh_first;	/* first element */			\
+	struct type **tqh_last;	/* addr of last next element */		\
+	TRACEBUF							\
+}
+
+#define	TAILQ_CLASS_HEAD(name, type)					\
+struct name {								\
+	class type *tqh_first;	/* first element */			\
+	class type **tqh_last;	/* addr of last next element */		\
+	TRACEBUF							\
+}
+
+#define	TAILQ_HEAD_INITIALIZER(head)					\
+	{ NULL, &(head).tqh_first, TRACEBUF_INITIALIZER }
+
+#define	TAILQ_ENTRY(type)						\
+struct {								\
+	struct type *tqe_next;	/* next element */			\
+	struct type **tqe_prev;	/* address of previous next element */	\
+	TRACEBUF							\
+}
+
+#define	TAILQ_CLASS_ENTRY(type)						\
+struct {								\
+	class type *tqe_next;	/* next element */			\
+	class type **tqe_prev;	/* address of previous next element */	\
+	TRACEBUF							\
+}
+
+/*
+ * Tail queue functions.
+ */
+#if (defined(_KERNEL) && defined(INVARIANTS))
+/*
+ * QMD_TAILQ_CHECK_HEAD(TAILQ_HEAD *head, TAILQ_ENTRY NAME)
+ *
+ * If the tailq is non-empty, validates that the first element of the tailq
+ * points back at 'head.'
+ */
+#define	QMD_TAILQ_CHECK_HEAD(head, field) do {				\
+	if (!TAILQ_EMPTY(head) &&					\
+	    TAILQ_FIRST((head))->field.tqe_prev !=			\
+	     &TAILQ_FIRST((head)))					\
+		panic("Bad tailq head %p first->prev != head", (head));	\
+} while (0)
+
+/*
+ * QMD_TAILQ_CHECK_TAIL(TAILQ_HEAD *head, TAILQ_ENTRY NAME)
+ *
+ * Validates that the tail of the tailq is a pointer to pointer to NULL.
+ */
+#define	QMD_TAILQ_CHECK_TAIL(head, field) do {				\
+	if (*(head)->tqh_last != NULL)					\
+	    	panic("Bad tailq NEXT(%p->tqh_last) != NULL", (head)); 	\
+} while (0)
+
+/*
+ * QMD_TAILQ_CHECK_NEXT(TYPE *elm, TAILQ_ENTRY NAME)
+ *
+ * If an element follows 'elm' in the tailq, validates that the next element
+ * points back at 'elm.'
+ */
+#define	QMD_TAILQ_CHECK_NEXT(elm, field) do {				\
+	if (TAILQ_NEXT((elm), field) != NULL &&				\
+	    TAILQ_NEXT((elm), field)->field.tqe_prev !=			\
+	     &((elm)->field.tqe_next))					\
+		panic("Bad link elm %p next->prev != elm", (elm));	\
+} while (0)
+
+/*
+ * QMD_TAILQ_CHECK_PREV(TYPE *elm, TAILQ_ENTRY NAME)
+ *
+ * Validates that the previous element (or head of the tailq) points to 'elm.'
+ */
+#define	QMD_TAILQ_CHECK_PREV(elm, field) do {				\
+	if (*(elm)->field.tqe_prev != (elm))				\
+		panic("Bad link elm %p prev->next != elm", (elm));	\
+} while (0)
+#else
+#define	QMD_TAILQ_CHECK_HEAD(head, field)
+#define	QMD_TAILQ_CHECK_TAIL(head, headname)
+#define	QMD_TAILQ_CHECK_NEXT(elm, field)
+#define	QMD_TAILQ_CHECK_PREV(elm, field)
+#endif /* (_KERNEL && INVARIANTS) */
+
+#define	TAILQ_CONCAT(head1, head2, field) do {				\
+	if (!TAILQ_EMPTY(head2)) {					\
+		*(head1)->tqh_last = (head2)->tqh_first;		\
+		(head2)->tqh_first->field.tqe_prev = (head1)->tqh_last;	\
+		(head1)->tqh_last = (head2)->tqh_last;			\
+		TAILQ_INIT((head2));					\
+		QMD_TRACE_HEAD(head1);					\
+		QMD_TRACE_HEAD(head2);					\
+	}								\
+} while (0)
+
+#define	TAILQ_EMPTY(head)	((head)->tqh_first == NULL)
+
+#define	TAILQ_FIRST(head)	((head)->tqh_first)
+
+#define	TAILQ_FOREACH(var, head, field)					\
+	for ((var) = TAILQ_FIRST((head));				\
+	    (var);							\
+	    (var) = TAILQ_NEXT((var), field))
+
+#define	TAILQ_FOREACH_FROM(var, head, field)				\
+	for ((var) = ((var) ? (var) : TAILQ_FIRST((head)));		\
+	    (var);							\
+	    (var) = TAILQ_NEXT((var), field))
+
+#define	TAILQ_FOREACH_SAFE(var, head, field, tvar)			\
+	for ((var) = TAILQ_FIRST((head));				\
+	    (var) && ((tvar) = TAILQ_NEXT((var), field), 1);		\
+	    (var) = (tvar))
+
+#define	TAILQ_FOREACH_FROM_SAFE(var, head, field, tvar)			\
+	for ((var) = ((var) ? (var) : TAILQ_FIRST((head)));		\
+	    (var) && ((tvar) = TAILQ_NEXT((var), field), 1);		\
+	    (var) = (tvar))
+
+#define	TAILQ_FOREACH_REVERSE(var, head, headname, field)		\
+	for ((var) = TAILQ_LAST((head), headname);			\
+	    (var);							\
+	    (var) = TAILQ_PREV((var), headname, field))
+
+#define	TAILQ_FOREACH_REVERSE_FROM(var, head, headname, field)		\
+	for ((var) = ((var) ? (var) : TAILQ_LAST((head), headname));	\
+	    (var);							\
+	    (var) = TAILQ_PREV((var), headname, field))
+
+#define	TAILQ_FOREACH_REVERSE_SAFE(var, head, headname, field, tvar)	\
+	for ((var) = TAILQ_LAST((head), headname);			\
+	    (var) && ((tvar) = TAILQ_PREV((var), headname, field), 1);	\
+	    (var) = (tvar))
+
+#define	TAILQ_FOREACH_REVERSE_FROM_SAFE(var, head, headname, field, tvar) \
+	for ((var) = ((var) ? (var) : TAILQ_LAST((head), headname));	\
+	    (var) && ((tvar) = TAILQ_PREV((var), headname, field), 1);	\
+	    (var) = (tvar))
+
+#define	TAILQ_INIT(head) do {						\
+	TAILQ_FIRST((head)) = NULL;					\
+	(head)->tqh_last = &TAILQ_FIRST((head));			\
+	QMD_TRACE_HEAD(head);						\
+} while (0)
+
+#define	TAILQ_INSERT_AFTER(head, listelm, elm, field) do {		\
+	QMD_TAILQ_CHECK_NEXT(listelm, field);				\
+	if ((TAILQ_NEXT((elm), field) = TAILQ_NEXT((listelm), field)) != NULL)\
+		TAILQ_NEXT((elm), field)->field.tqe_prev = 		\
+		    &TAILQ_NEXT((elm), field);				\
+	else {								\
+		(head)->tqh_last = &TAILQ_NEXT((elm), field);		\
+		QMD_TRACE_HEAD(head);					\
+	}								\
+	TAILQ_NEXT((listelm), field) = (elm);				\
+	(elm)->field.tqe_prev = &TAILQ_NEXT((listelm), field);		\
+	QMD_TRACE_ELEM(&(elm)->field);					\
+	QMD_TRACE_ELEM(&(listelm)->field);				\
+} while (0)
+
+#define	TAILQ_INSERT_BEFORE(listelm, elm, field) do {			\
+	QMD_TAILQ_CHECK_PREV(listelm, field);				\
+	(elm)->field.tqe_prev = (listelm)->field.tqe_prev;		\
+	TAILQ_NEXT((elm), field) = (listelm);				\
+	*(listelm)->field.tqe_prev = (elm);				\
+	(listelm)->field.tqe_prev = &TAILQ_NEXT((elm), field);		\
+	QMD_TRACE_ELEM(&(elm)->field);					\
+	QMD_TRACE_ELEM(&(listelm)->field);				\
+} while (0)
+
+#define	TAILQ_INSERT_HEAD(head, elm, field) do {			\
+	QMD_TAILQ_CHECK_HEAD(head, field);				\
+	if ((TAILQ_NEXT((elm), field) = TAILQ_FIRST((head))) != NULL)	\
+		TAILQ_FIRST((head))->field.tqe_prev =			\
+		    &TAILQ_NEXT((elm), field);				\
+	else								\
+		(head)->tqh_last = &TAILQ_NEXT((elm), field);		\
+	TAILQ_FIRST((head)) = (elm);					\
+	(elm)->field.tqe_prev = &TAILQ_FIRST((head));			\
+	QMD_TRACE_HEAD(head);						\
+	QMD_TRACE_ELEM(&(elm)->field);					\
+} while (0)
+
+#define	TAILQ_INSERT_TAIL(head, elm, field) do {			\
+	QMD_TAILQ_CHECK_TAIL(head, field);				\
+	TAILQ_NEXT((elm), field) = NULL;				\
+	(elm)->field.tqe_prev = (head)->tqh_last;			\
+	*(head)->tqh_last = (elm);					\
+	(head)->tqh_last = &TAILQ_NEXT((elm), field);			\
+	QMD_TRACE_HEAD(head);						\
+	QMD_TRACE_ELEM(&(elm)->field);					\
+} while (0)
+
+#define	TAILQ_LAST(head, headname)					\
+	(*(((struct headname *)((head)->tqh_last))->tqh_last))
+
+#define	TAILQ_NEXT(elm, field) ((elm)->field.tqe_next)
+
+#define	TAILQ_PREV(elm, headname, field)				\
+	(*(((struct headname *)((elm)->field.tqe_prev))->tqh_last))
+
+#define	TAILQ_REMOVE(head, elm, field) do {				\
+	QMD_SAVELINK(oldnext, (elm)->field.tqe_next);			\
+	QMD_SAVELINK(oldprev, (elm)->field.tqe_prev);			\
+	QMD_TAILQ_CHECK_NEXT(elm, field);				\
+	QMD_TAILQ_CHECK_PREV(elm, field);				\
+	if ((TAILQ_NEXT((elm), field)) != NULL)				\
+		TAILQ_NEXT((elm), field)->field.tqe_prev = 		\
+		    (elm)->field.tqe_prev;				\
+	else {								\
+		(head)->tqh_last = (elm)->field.tqe_prev;		\
+		QMD_TRACE_HEAD(head);					\
+	}								\
+	*(elm)->field.tqe_prev = TAILQ_NEXT((elm), field);		\
+	TRASHIT(*oldnext);						\
+	TRASHIT(*oldprev);						\
+	QMD_TRACE_ELEM(&(elm)->field);					\
+} while (0)
+
+#define TAILQ_SWAP(head1, head2, type, field) do {			\
+	QUEUE_TYPEOF(type) *swap_first = (head1)->tqh_first;		\
+	QUEUE_TYPEOF(type) **swap_last = (head1)->tqh_last;		\
+	(head1)->tqh_first = (head2)->tqh_first;			\
+	(head1)->tqh_last = (head2)->tqh_last;				\
+	(head2)->tqh_first = swap_first;				\
+	(head2)->tqh_last = swap_last;					\
+	if ((swap_first = (head1)->tqh_first) != NULL)			\
+		swap_first->field.tqe_prev = &(head1)->tqh_first;	\
+	else								\
+		(head1)->tqh_last = &(head1)->tqh_first;		\
+	if ((swap_first = (head2)->tqh_first) != NULL)			\
+		swap_first->field.tqe_prev = &(head2)->tqh_first;	\
+	else								\
+		(head2)->tqh_last = &(head2)->tqh_first;		\
+} while (0)
+
+#endif /* !_SYS_QUEUE_H_ */

--- a/recvcmd.c
+++ b/recvcmd.c
@@ -741,15 +741,13 @@ static int attach_reply_envelope_defaults(struct Envelope *env, struct AttachPtr
   mutt_make_misc_reply_headers(env, Context, curhdr, curenv);
 
   if (parent)
-    mutt_add_to_reference_headers(env, curenv, NULL, NULL);
+    mutt_add_to_reference_headers(env, curenv);
   else
   {
-    struct List **p = NULL, **q = NULL;
-
     for (short i = 0; i < idxlen; i++)
     {
       if (idx[i]->content->tagged)
-        mutt_add_to_reference_headers(env, idx[i]->content->hdr->env, &p, &q);
+        mutt_add_to_reference_headers(env, idx[i]->content->hdr->env);
     }
   }
 

--- a/remailer.c
+++ b/remailer.c
@@ -452,7 +452,7 @@ static const struct Mapping RemailerHelp[] = {
   { N_("OK"), OP_MIX_USE },        { NULL, 0 },
 };
 
-void mix_make_chain(struct STailQHead *chainhead)
+void mix_make_chain(struct ListHead *chainhead)
 {
   struct MixChain *chain = NULL;
   int c_cur = 0, c_old = 0;
@@ -479,12 +479,12 @@ void mix_make_chain(struct STailQHead *chainhead)
 
   chain = safe_calloc(1, sizeof(struct MixChain));
 
-  struct STailQNode *p;
+  struct ListNode *p;
   STAILQ_FOREACH(p, chainhead, entries)
   {
     mix_chain_add(chain, p->data, type2_list);
   }
-  mutt_stailq_free(chainhead);
+  mutt_list_free(chainhead);
 
   /* safety check */
   for (i = 0; i < chain->cl; i++)
@@ -653,7 +653,7 @@ void mix_make_chain(struct STailQHead *chainhead)
       else
         t = "*";
 
-      mutt_stailq_insert_tail(chainhead, safe_strdup(t));
+      mutt_list_insert_tail(chainhead, safe_strdup(t));
     }
   }
 
@@ -710,7 +710,7 @@ int mix_check_message(struct Header *msg)
   return 0;
 }
 
-int mix_send_message(struct STailQHead *chain, const char *tempfile)
+int mix_send_message(struct ListHead *chain, const char *tempfile)
 {
   char cmd[HUGE_STRING];
   char tmp[HUGE_STRING];
@@ -719,7 +719,7 @@ int mix_send_message(struct STailQHead *chain, const char *tempfile)
 
   snprintf(cmd, sizeof(cmd), "cat %s | %s -m ", tempfile, Mixmaster);
 
-  struct STailQNode *np;
+  struct ListNode *np;
   STAILQ_FOREACH(np, chain, entries)
   {
     strfcpy(tmp, cmd, sizeof(tmp));

--- a/remailer.c
+++ b/remailer.c
@@ -484,7 +484,7 @@ void mix_make_chain(struct STailQHead *chainhead)
   {
     mix_chain_add(chain, p->data, type2_list);
   }
-  mutt_free_stailq(chainhead);
+  mutt_stailq_free(chainhead);
 
   /* safety check */
   for (i = 0; i < chain->cl; i++)
@@ -646,7 +646,6 @@ void mix_make_chain(struct STailQHead *chainhead)
 
   if (chain->cl)
   {
-    struct STailQNode *n = NULL;
     for (i = 0; i < chain->cl; i++)
     {
       if ((j = chain->ch[i]))
@@ -654,9 +653,7 @@ void mix_make_chain(struct STailQHead *chainhead)
       else
         t = "*";
 
-      n = safe_calloc(1, sizeof(struct STailQNode));
-      n->data = safe_strdup(t);
-      STAILQ_INSERT_TAIL(chainhead, n, entries);
+      mutt_stailq_insert_tail(chainhead, safe_strdup(t));
     }
   }
 

--- a/remailer.h
+++ b/remailer.h
@@ -29,7 +29,7 @@
 
 #include <stddef.h>
 
-struct STailQHead;
+struct ListHead;
 struct Header;
 
 #ifdef MIXMASTER
@@ -64,9 +64,9 @@ struct MixChain
   int ch[MAXMIXES];
 };
 
-int mix_send_message(struct STailQHead *chain, const char *tempfile);
+int mix_send_message(struct ListHead *chain, const char *tempfile);
 int mix_check_message(struct Header *msg);
-void mix_make_chain(struct STailQHead *chain);
+void mix_make_chain(struct ListHead *chain);
 
 #endif /* MIXMASTER */
 

--- a/remailer.h
+++ b/remailer.h
@@ -29,7 +29,7 @@
 
 #include <stddef.h>
 
-struct List;
+struct STailQHead;
 struct Header;
 
 #ifdef MIXMASTER
@@ -64,9 +64,9 @@ struct MixChain
   int ch[MAXMIXES];
 };
 
-int mix_send_message(struct List *chain, const char *tempfile);
+int mix_send_message(struct STailQHead *chain, const char *tempfile);
 int mix_check_message(struct Header *msg);
-void mix_make_chain(struct List **chainp);
+void mix_make_chain(struct STailQHead *chain);
 
 #endif /* MIXMASTER */
 

--- a/send.c
+++ b/send.c
@@ -364,11 +364,6 @@ static void process_user_recips(struct Envelope *env)
 static void process_user_header(struct Envelope *env)
 {
   struct List *uh = UserHeader;
-  struct List *last = env->userhdrs;
-
-  if (last)
-    while (last->next)
-      last = last->next;
 
   for (; uh; uh = uh->next)
   {
@@ -406,14 +401,9 @@ static void process_user_header(struct Envelope *env)
              (mutt_strncasecmp("subject:", uh->data, 8) != 0) &&
              (mutt_strncasecmp("return-path:", uh->data, 12) != 0))
     {
-      if (last)
-      {
-        last->next = mutt_new_list();
-        last = last->next;
-      }
-      else
-        last = env->userhdrs = mutt_new_list();
-      last->data = safe_strdup(uh->data);
+      struct STailQNode *np = safe_calloc(1, sizeof(struct STailQNode));
+      np->data = safe_strdup(uh->data);
+      STAILQ_INSERT_TAIL(&env->userhdrs, np, entries);
     }
   }
 }

--- a/send.c
+++ b/send.c
@@ -250,7 +250,6 @@ static int edit_address(struct Address **a, /* const */ char *field)
 static int edit_envelope(struct Envelope *en, int flags)
 {
   char buf[HUGE_STRING];
-  struct List *uh = UserHeader;
 
 #ifdef USE_NNTP
   if (option(OPT_NEWS_SEND))
@@ -309,7 +308,8 @@ static int edit_envelope(struct Envelope *en, int flags)
     const char *p = NULL;
 
     buf[0] = 0;
-    for (; uh; uh = uh->next)
+    struct STailQNode *uh;
+    STAILQ_FOREACH(uh, &UserHeader, entries)
     {
       if (mutt_strncasecmp("subject:", uh->data, 8) == 0)
       {
@@ -340,9 +340,8 @@ static char *nntp_get_header(const char *s)
 
 static void process_user_recips(struct Envelope *env)
 {
-  struct List *uh = UserHeader;
-
-  for (; uh; uh = uh->next)
+  struct STailQNode *uh;
+  STAILQ_FOREACH(uh, &UserHeader, entries)
   {
     if (mutt_strncasecmp("to:", uh->data, 3) == 0)
       env->to = rfc822_parse_adrlist(env->to, uh->data + 3);
@@ -363,9 +362,8 @@ static void process_user_recips(struct Envelope *env)
 
 static void process_user_header(struct Envelope *env)
 {
-  struct List *uh = UserHeader;
-
-  for (; uh; uh = uh->next)
+  struct STailQNode *uh;
+  STAILQ_FOREACH(uh, &UserHeader, entries)
   {
     if (mutt_strncasecmp("from:", uh->data, 5) == 0)
     {

--- a/send.c
+++ b/send.c
@@ -1103,7 +1103,7 @@ static int send_message(struct Header *msg)
     unset_option(OPT_WRITE_BCC);
 #endif
 #ifdef MIXMASTER
-  mutt_write_rfc822_header(tempfp, msg->env, msg->content, 0, msg->chain ? 1 : 0);
+  mutt_write_rfc822_header(tempfp, msg->env, msg->content, 0, !STAILQ_EMPTY(&msg->chain));
 #endif
 #ifndef MIXMASTER
   mutt_write_rfc822_header(tempfp, msg->env, msg->content, 0, 0);
@@ -1130,8 +1130,8 @@ static int send_message(struct Header *msg)
   }
 
 #ifdef MIXMASTER
-  if (msg->chain)
-    return mix_send_message(msg->chain, tempfile);
+  if (!STAILQ_EMPTY(&msg->chain))
+    return mix_send_message(&msg->chain, tempfile);
 #endif
 
 #ifdef USE_SMTP

--- a/send.c
+++ b/send.c
@@ -308,7 +308,7 @@ static int edit_envelope(struct Envelope *en, int flags)
     const char *p = NULL;
 
     buf[0] = 0;
-    struct STailQNode *uh;
+    struct ListNode *uh;
     STAILQ_FOREACH(uh, &UserHeader, entries)
     {
       if (mutt_strncasecmp("subject:", uh->data, 8) == 0)
@@ -340,7 +340,7 @@ static char *nntp_get_header(const char *s)
 
 static void process_user_recips(struct Envelope *env)
 {
-  struct STailQNode *uh;
+  struct ListNode *uh;
   STAILQ_FOREACH(uh, &UserHeader, entries)
   {
     if (mutt_strncasecmp("to:", uh->data, 3) == 0)
@@ -362,7 +362,7 @@ static void process_user_recips(struct Envelope *env)
 
 static void process_user_header(struct Envelope *env)
 {
-  struct STailQNode *uh;
+  struct ListNode *uh;
   STAILQ_FOREACH(uh, &UserHeader, entries)
   {
     if (mutt_strncasecmp("from:", uh->data, 5) == 0)
@@ -399,7 +399,7 @@ static void process_user_header(struct Envelope *env)
              (mutt_strncasecmp("subject:", uh->data, 8) != 0) &&
              (mutt_strncasecmp("return-path:", uh->data, 12) != 0))
     {
-      mutt_stailq_insert_tail(&env->userhdrs, safe_strdup(uh->data));
+      mutt_list_insert_tail(&env->userhdrs, safe_strdup(uh->data));
     }
   }
 }
@@ -641,23 +641,23 @@ int mutt_fetch_recips(struct Envelope *out, struct Envelope *in, int flags)
   return 0;
 }
 
-static void add_references(struct STailQHead *head, struct Envelope *e)
+static void add_references(struct ListHead *head, struct Envelope *e)
 {
-  struct STailQHead *src;
-  struct STailQNode *np;
+  struct ListHead *src;
+  struct ListNode *np;
 
   src = !STAILQ_EMPTY(&e->references) ? &e->references : &e->in_reply_to;
   STAILQ_FOREACH(np, src, entries)
   {
-    mutt_stailq_insert_tail(head, safe_strdup(np->data));
+    mutt_list_insert_tail(head, safe_strdup(np->data));
   }
 }
 
-static void add_message_id(struct STailQHead *head, struct Envelope *e)
+static void add_message_id(struct ListHead *head, struct Envelope *e)
 {
   if (e->message_id)
   {
-    mutt_stailq_insert_head(head, safe_strdup(e->message_id));
+    mutt_list_insert_head(head, safe_strdup(e->message_id));
   }
 }
 
@@ -751,7 +751,7 @@ static void make_reference_headers(struct Envelope *curenv,
      discouraged by RfC2822, sect. 3.6.4 */
   if (ctx->tagged > 0 && !STAILQ_EMPTY(&env->in_reply_to) &&
       STAILQ_NEXT(STAILQ_FIRST(&env->in_reply_to), entries))
-    mutt_stailq_free(&env->references);
+    mutt_list_free(&env->references);
 }
 
 static int envelope_defaults(struct Envelope *env, struct Context *ctx,
@@ -1249,8 +1249,8 @@ static int is_reply(struct Header *reply, struct Header *orig)
 {
   if (!reply || !reply->env || !orig || !orig->env)
     return 0;
-  return mutt_stailq_find(&orig->env->references, reply->env->message_id) ||
-         mutt_stailq_find(&orig->env->in_reply_to, reply->env->message_id);
+  return mutt_list_find(&orig->env->references, reply->env->message_id) ||
+         mutt_list_find(&orig->env->in_reply_to, reply->env->message_id);
 }
 
 static int has_recips(struct Address *a)

--- a/send.c
+++ b/send.c
@@ -399,9 +399,7 @@ static void process_user_header(struct Envelope *env)
              (mutt_strncasecmp("subject:", uh->data, 8) != 0) &&
              (mutt_strncasecmp("return-path:", uh->data, 12) != 0))
     {
-      struct STailQNode *np = safe_calloc(1, sizeof(struct STailQNode));
-      np->data = safe_strdup(uh->data);
-      STAILQ_INSERT_TAIL(&env->userhdrs, np, entries);
+      mutt_stailq_insert_tail(&env->userhdrs, safe_strdup(uh->data));
     }
   }
 }
@@ -646,14 +644,12 @@ int mutt_fetch_recips(struct Envelope *out, struct Envelope *in, int flags)
 static void add_references(struct STailQHead *head, struct Envelope *e)
 {
   struct STailQHead *src;
-  struct STailQNode *np, *new;
+  struct STailQNode *np;
 
   src = !STAILQ_EMPTY(&e->references) ? &e->references : &e->in_reply_to;
   STAILQ_FOREACH(np, src, entries)
   {
-    new = safe_calloc(1, sizeof(struct STailQNode));
-    new->data = safe_strdup(np->data);
-    STAILQ_INSERT_TAIL(head, new, entries);
+    mutt_stailq_insert_tail(head, safe_strdup(np->data));
   }
 }
 
@@ -661,9 +657,7 @@ static void add_message_id(struct STailQHead *head, struct Envelope *e)
 {
   if (e->message_id)
   {
-    struct STailQNode *new = safe_calloc(1, sizeof(struct STailQNode));
-    new->data = safe_strdup(e->message_id);
-    STAILQ_INSERT_HEAD(head, new, entries);
+    mutt_stailq_insert_head(head, safe_strdup(e->message_id));
   }
 }
 
@@ -757,7 +751,7 @@ static void make_reference_headers(struct Envelope *curenv,
      discouraged by RfC2822, sect. 3.6.4 */
   if (ctx->tagged > 0 && !STAILQ_EMPTY(&env->in_reply_to) &&
       STAILQ_NEXT(STAILQ_FIRST(&env->in_reply_to), entries))
-    mutt_free_stailq(&env->references);
+    mutt_stailq_free(&env->references);
 }
 
 static int envelope_defaults(struct Envelope *env, struct Context *ctx,
@@ -1255,8 +1249,8 @@ static int is_reply(struct Header *reply, struct Header *orig)
 {
   if (!reply || !reply->env || !orig || !orig->env)
     return 0;
-  return mutt_find_stailq(&orig->env->references, reply->env->message_id) ||
-         mutt_find_stailq(&orig->env->in_reply_to, reply->env->message_id);
+  return mutt_stailq_find(&orig->env->references, reply->env->message_id) ||
+         mutt_stailq_find(&orig->env->in_reply_to, reply->env->message_id);
 }
 
 static int has_recips(struct Address *a)

--- a/sendlib.c
+++ b/sendlib.c
@@ -3024,13 +3024,14 @@ int mutt_write_fcc(const char *path, struct Header *hdr, const char *msgid,
    * chain, save that information
    */
 
-  if (post && hdr->chain && hdr->chain)
+  if (post && !STAILQ_EMPTY(&hdr->chain))
   {
-    struct List *p = NULL;
-
     fputs("X-Mutt-Mix:", msg->fp);
-    for (p = hdr->chain; p; p = p->next)
+    struct STailQNode *p;
+    STAILQ_FOREACH(p, &hdr->chain, entries)
+    {
       fprintf(msg->fp, " %s", (char *) p->data);
+    }
 
     fputc('\n', msg->fp);
   }

--- a/sendlib.c
+++ b/sendlib.c
@@ -1586,9 +1586,9 @@ void mutt_write_address_list(struct Address *adr, FILE *fp, int linelen, int dis
  * need to write the list in reverse because they are stored in reverse order
  * when parsed to speed up threading
  */
-void mutt_write_references(const struct STailQHead *r, FILE *f, size_t trim)
+void mutt_write_references(const struct ListHead *r, FILE *f, size_t trim)
 {
-  struct STailQNode *np;
+  struct ListNode *np;
   size_t length = 0;
 
   STAILQ_FOREACH(np, r, entries)
@@ -1597,7 +1597,7 @@ void mutt_write_references(const struct STailQHead *r, FILE *f, size_t trim)
       break;
   }
 
-  struct STailQNode **ref = safe_calloc(length, sizeof(struct STailQNode*));
+  struct ListNode **ref = safe_calloc(length, sizeof(struct ListNode*));
 
   // store in reverse order
   STAILQ_FOREACH(np, r, entries)
@@ -2123,7 +2123,7 @@ int mutt_write_rfc822_header(FILE *fp, struct Envelope *env,
   }
 
   /* Add any user defined headers */
-  struct STailQNode *tmp;
+  struct ListNode *tmp;
   STAILQ_FOREACH(tmp, &env->userhdrs, entries)
   {
     if ((p = strchr(tmp->data, ':')))
@@ -2164,13 +2164,13 @@ int mutt_write_rfc822_header(FILE *fp, struct Envelope *env,
   return (ferror(fp) == 0 ? 0 : -1);
 }
 
-static void encode_headers(struct STailQHead *h)
+static void encode_headers(struct ListHead *h)
 {
   char *tmp = NULL;
   char *p = NULL;
   int i;
 
-  struct STailQNode *np;
+  struct ListNode *np;
   STAILQ_FOREACH(np, h, entries)
   {
     if (!(p = strchr(np->data, ':')))
@@ -2663,7 +2663,7 @@ void mutt_prepare_envelope(struct Envelope *env, int final)
 
 void mutt_unprepare_envelope(struct Envelope *env)
 {
-  struct STailQNode *item;
+  struct ListNode *item;
   STAILQ_FOREACH(item, &env->userhdrs, entries)
   {
     rfc2047_decode(&item->data);
@@ -3027,7 +3027,7 @@ int mutt_write_fcc(const char *path, struct Header *hdr, const char *msgid,
   if (post && !STAILQ_EMPTY(&hdr->chain))
   {
     fputs("X-Mutt-Mix:", msg->fp);
-    struct STailQNode *p;
+    struct ListNode *p;
     STAILQ_FOREACH(p, &hdr->chain, entries)
     {
       fprintf(msg->fp, " %s", (char *) p->data);

--- a/sidebar.c
+++ b/sidebar.c
@@ -369,8 +369,8 @@ static void update_entries_visibility(void)
       /* Spool directory */
       continue;
 
-    if (mutt_find_list(SidebarWhitelist, sbe->buffy->path) ||
-        mutt_find_list(SidebarWhitelist, sbe->buffy->desc))
+    if (mutt_stailq_find(&SidebarWhitelist, sbe->buffy->path) ||
+        mutt_stailq_find(&SidebarWhitelist, sbe->buffy->desc))
       /* Explicitly asked to be visible */
       continue;
 

--- a/sidebar.c
+++ b/sidebar.c
@@ -369,8 +369,8 @@ static void update_entries_visibility(void)
       /* Spool directory */
       continue;
 
-    if (mutt_stailq_find(&SidebarWhitelist, sbe->buffy->path) ||
-        mutt_stailq_find(&SidebarWhitelist, sbe->buffy->desc))
+    if (mutt_list_find(&SidebarWhitelist, sbe->buffy->path) ||
+        mutt_list_find(&SidebarWhitelist, sbe->buffy->desc))
       /* Explicitly asked to be visible */
       continue;
 

--- a/thread.c
+++ b/thread.c
@@ -1457,8 +1457,8 @@ static void clean_references(struct MuttThread *brk, struct MuttThread *cur)
 
 void mutt_break_thread(struct Header *hdr)
 {
-  mutt_free_stailq(&hdr->env->in_reply_to);
-  mutt_free_stailq(&hdr->env->references);
+  mutt_stailq_free(&hdr->env->in_reply_to);
+  mutt_stailq_free(&hdr->env->references);
   hdr->env->irt_changed = hdr->env->refs_changed = hdr->changed = true;
 
   clean_references(hdr->thread, hdr->thread->child);
@@ -1470,12 +1470,7 @@ static bool link_threads(struct Header *parent, struct Header *child, struct Con
     return false;
 
   mutt_break_thread(child);
-
-  STAILQ_INIT(&child->env->in_reply_to);
-  struct STailQNode *new = safe_calloc(1, sizeof(struct STailQNode));
-  new->data = safe_strdup(parent->env->message_id);
-  STAILQ_INSERT_HEAD(&child->env->in_reply_to, new, entries);
-
+  mutt_stailq_insert_head(&child->env->in_reply_to, safe_strdup(parent->env->message_id));
   mutt_set_flag(ctx, child, MUTT_TAG, 0);
 
   child->env->irt_changed = child->changed = true;

--- a/thread.c
+++ b/thread.c
@@ -373,12 +373,11 @@ void mutt_draw_tree(struct Context *ctx)
  * most immediate existing descendants.  we also note the earliest
  * date on any of the parents and put it in *dateptr.
  */
-static struct List *make_subject_list(struct MuttThread *cur, time_t *dateptr)
+static void make_subject_list(struct STailQHead *subjects, struct MuttThread *cur, time_t *dateptr)
 {
   struct MuttThread *start = cur;
   struct Envelope *env = NULL;
   time_t thisdate;
-  struct List *curlist = NULL, *oldlist = NULL, *newlist = NULL, *subjects = NULL;
   int rc = 0;
 
   while (true)
@@ -397,28 +396,17 @@ static struct List *make_subject_list(struct MuttThread *cur, time_t *dateptr)
     env = cur->message->env;
     if (env->real_subj && ((env->real_subj != env->subject) || (!option(OPT_SORT_RE))))
     {
-      for (curlist = subjects, oldlist = NULL; curlist;
-           oldlist = curlist, curlist = curlist->next)
+      struct STailQNode *np;
+      STAILQ_FOREACH(np, subjects, entries)
       {
-        rc = mutt_strcmp(env->real_subj, curlist->data);
+        rc = mutt_strcmp(env->real_subj, np->data);
         if (rc >= 0)
           break;
       }
-      if (!curlist || rc > 0)
-      {
-        newlist = safe_calloc(1, sizeof(struct List));
-        newlist->data = env->real_subj;
-        if (oldlist)
-        {
-          newlist->next = oldlist->next;
-          oldlist->next = newlist;
-        }
-        else
-        {
-          newlist->next = subjects;
-          subjects = newlist;
-        }
-      }
+      if (!np)
+          mutt_stailq_insert_head(subjects, env->real_subj);
+      else if (rc > 0)
+          mutt_stailq_insert_after(subjects, np, env->real_subj);
     }
 
     while (!cur->next && cur != start)
@@ -429,8 +417,6 @@ static struct List *make_subject_list(struct MuttThread *cur, time_t *dateptr)
       break;
     cur = cur->next;
   }
-
-  return subjects;
 }
 
 /**
@@ -443,14 +429,15 @@ static struct MuttThread *find_subject(struct Context *ctx, struct MuttThread *c
 {
   struct HashElem *ptr = NULL;
   struct MuttThread *tmp = NULL, *last = NULL;
-  struct List *subjects = NULL, *oldlist = NULL;
+  struct STailQHead subjects = STAILQ_HEAD_INITIALIZER(subjects);
   time_t date = 0;
 
-  subjects = make_subject_list(cur, &date);
+  make_subject_list(&subjects, cur, &date);
 
-  while (subjects)
+  struct STailQNode *np;
+  STAILQ_FOREACH(np, &subjects, entries)
   {
-    for (ptr = hash_find_bucket(ctx->subj_hash, subjects->data); ptr; ptr = ptr->next)
+    for (ptr = hash_find_bucket(ctx->subj_hash, np->data); ptr; ptr = ptr->next)
     {
       tmp = ((struct Header *) ptr->data)->thread;
       if (tmp != cur &&                    /* don't match the same message */
@@ -463,16 +450,14 @@ static struct MuttThread *find_subject(struct Context *ctx, struct MuttThread *c
                          (last->message->received < tmp->message->received) :
                          (last->message->date_sent < tmp->message->date_sent))) &&
           tmp->message->env->real_subj &&
-          (mutt_strcmp(subjects->data, tmp->message->env->real_subj) == 0))
+          (mutt_strcmp(np->data, tmp->message->env->real_subj) == 0))
       {
         last = tmp; /* best match so far */
       }
     }
-
-    oldlist = subjects;
-    subjects = subjects->next;
-    FREE(&oldlist);
   }
+
+  mutt_stailq_clear(&subjects);
   return last;
 }
 

--- a/url.c
+++ b/url.c
@@ -313,7 +313,7 @@ int url_parse_mailto(struct Envelope *e, char **body, const char *src)
      * choose to create a message with only a subset of the headers given in
      * the URL.
      */
-    if (mutt_matches_list(tag, MailToAllow))
+    if (mutt_stailq_match(tag, &MailToAllow))
     {
       if (mutt_strcasecmp(tag, "body") == 0)
       {

--- a/url.c
+++ b/url.c
@@ -273,8 +273,6 @@ int url_parse_mailto(struct Envelope *e, char **body, const char *src)
 
   int rc = -1;
 
-  struct List *last = NULL;
-
   if (!(t = strchr(src, ':')))
     return -1;
 
@@ -330,7 +328,7 @@ int url_parse_mailto(struct Envelope *e, char **body, const char *src)
         safe_asprintf(&scratch, "%s: %s", tag, value);
         scratch[taglen] = 0; /* overwrite the colon as mutt_parse_rfc822_line expects */
         value = skip_email_wsp(&scratch[taglen + 1]);
-        mutt_parse_rfc822_line(e, NULL, scratch, value, 1, 0, 1, &last);
+        mutt_parse_rfc822_line(e, NULL, scratch, value, 1, 0, 1);
         FREE(&scratch);
       }
     }

--- a/url.c
+++ b/url.c
@@ -313,7 +313,7 @@ int url_parse_mailto(struct Envelope *e, char **body, const char *src)
      * choose to create a message with only a subset of the headers given in
      * the URL.
      */
-    if (mutt_stailq_match(tag, &MailToAllow))
+    if (mutt_list_match(tag, &MailToAllow))
     {
       if (mutt_strcasecmp(tag, "body") == 0)
       {


### PR DESCRIPTION
* **What does this PR do?**

This PR is a first step in using established best practices for data structures and algorithms. This first series of commits replace the singly-linked list formerly implemented by `struct List` with a singly-linked tail queue represented by `struct ListHead` and `struct ListNode`, implemented using the macros from FreeBSD's queue.h.

This allows for the removal of error prone hand written algorithms such as raw loops, search, insertion, and removal.

* **Are there points in the code the reviewer needs to double check?**

Some algorithms have been greatly simplified. Corner cases might have been overlooked.

- cbe2066 Datastructures #1 - PoC of standardizing a couple of fields
- 52e5335 Add queue.h to EXTRA_DIST
- 79868b1 Convert userhdrs to STailQ
- 6ca73a5 Convert mix chain to STailQ
- ce48de7 HCache now depends on tailq structures instead of List
- 3ce9c4b Convert UserHeader to STailQ
- 4399aa9 Convert MuttrcStack to STailQ
- 92e2868 Convert AutoViewList to STailQ
- 80792f5 Convert Muttrc to STailQ, start to gather common algos in list.h
- 83c2161 Convert AlternativeOrderList and (Attach|Inline)(Allow|Exclude) to STailQ
- 97a20d1 Be consistent on variable names
- d9ff90d Convert HeaderOrderList and (Un)?Ignore to STailQ
- 8ebf6f1 Convert MailtoAllow, MimeLookupList and SidebarWhitelist to STailQ
- 67e5fad Remove unused functions
- 35a686f Convert List to STailQ in imap code
- d8d94cc Convert List to STailQ in ncrypt code
- 6bfeb57 Convert Hooks to TAILQ
- 0fcd033 More idiomatic definition of HookHead
- 3452af7 Convert remaining List structures to STailQ in main.c
- 18d9e0e Convert last List instances to STailQ, kill List definition
- 1b98b31 Restore naming sanity: s/STailQ/List/g

See #374.