### PR TITLE
Encode URIs created with nm_uri_from_query

### DIFF
--- a/mutt_notmuch.c
+++ b/mutt_notmuch.c
@@ -1841,15 +1841,24 @@ char *nm_uri_from_query(struct Context *ctx, char *buf, size_t bufsz)
   mutt_debug(2, "nm_uri_from_query (%s)\n", buf);
   struct NmCtxData *data = get_ctxdata(ctx);
   char uri[_POSIX_PATH_MAX + LONG_STRING + 32]; /* path to DB + query + URI "decoration" */
+  int added;
 
   if (data)
-    snprintf(uri, sizeof(uri), "notmuch://%s?query=%s", get_db_filename(data), buf);
+    added = snprintf(uri, sizeof(uri), "notmuch://%s?query=", get_db_filename(data));
   else if (NotmuchDefaultUri)
-    snprintf(uri, sizeof(uri), "%s?query=%s", NotmuchDefaultUri, buf);
+    added = snprintf(uri, sizeof(uri), "%s?query=", NotmuchDefaultUri);
   else if (Maildir)
-    snprintf(uri, sizeof(uri), "notmuch://%s?query=%s", Maildir, buf);
+    added = snprintf(uri, sizeof(uri), "notmuch://%s?query=", Maildir);
   else
     return NULL;
+
+  if (added >= sizeof(uri))
+  {
+    // snprintf output was truncated, so can't create URI
+    return NULL;
+  }
+
+  url_pct_encode(&uri[added], sizeof(uri) - added, buf);
 
   strncpy(buf, uri, bufsz);
   buf[bufsz - 1] = '\0';

--- a/url.c
+++ b/url.c
@@ -186,7 +186,7 @@ int url_parse_ciss(struct CissUrl *ciss, char *src)
   return ciss_parse_userhost(ciss, tmp);
 }
 
-static void url_pct_encode(char *dst, size_t l, const char *src)
+void url_pct_encode(char *dst, size_t l, const char *src)
 {
   static const char *alph = "0123456789ABCDEF";
 
@@ -194,7 +194,7 @@ static void url_pct_encode(char *dst, size_t l, const char *src)
   l--;
   while (src && *src && l)
   {
-    if (strchr("/:%", *src) && l > 3)
+    if (strchr("/:&%", *src) && l > 3)
     {
       *dst++ = '%';
       *dst++ = alph[(*src >> 4) & 0xf];

--- a/url.h
+++ b/url.h
@@ -67,5 +67,6 @@ int url_parse_ciss(struct CissUrl *ciss, char *src);
 int url_ciss_tostring(struct CissUrl *ciss, char *dest, size_t len, int flags);
 int url_parse_mailto(struct Envelope *e, char **body, const char *src);
 int url_pct_decode(char *s);
+void url_pct_encode(char *dest, size_t len, const char *src);
 
 #endif /* _MUTT_URL_H */


### PR DESCRIPTION
* **What does this PR do?**

Encodes URIs created in nm_uri_from_query using url_pct_encode. This means url_pct_encode is no longer static. This violates the coding style, as this function is now global but doesn't start with 'mutt_'. However, leaving 'mutt_' off seems to be consistent with the other url functions. Can change this if desired.

* **Are there points in the code the reviewer needs to double check?**

`url_pct_encode` now also encodes ampersands (`&`s). As `url_pct_encode` is only used in two other places, where it encodes either usernames or passwords, this seems valid.

* **What are the relevant issue numbers?**

Addresses issue #603 