### PR TITLE
Fix includes for mutt_md5

### DIFF
--- a/hcache/mutt_md5.c
+++ b/hcache/mutt_md5.c
@@ -32,7 +32,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <string.h>
-#include "lib/lib.h"
+#include "lib/md5.h"
 
 /* local md5 equivalent for header cache versioning */
 int main(void)


### PR DESCRIPTION
Fixes #706

Including `lib/lib.h` means we bring in dependency on gettext.
