### PR TITLE
curs_lib.c: _mutt_enter_fname fix

### DIFF
--- a/color.c
+++ b/color.c
@@ -347,14 +347,6 @@ int mutt_combine_color(int fg_attr, int bg_attr)
   mutt_lookup_color(bg_attr, NULL, &bg);
   if ((fg == COLOR_DEFAULT) && (bg == COLOR_DEFAULT))
     return A_NORMAL;
-#ifdef HAVE_USE_DEFAULT_COLORS
-  if (!option(OPT_NO_CURSES) && has_colors() &&
-      ((fg == COLOR_DEFAULT) || (bg == COLOR_DEFAULT)) && use_default_colors() != OK)
-  {
-    mutt_error(_("default colors not supported."));
-    return A_NORMAL;
-  }
-#endif
   return mutt_alloc_color(fg, bg);
 }
 
@@ -887,7 +879,13 @@ static int _mutt_parse_color(struct Buffer *buf, struct Buffer *s, struct Buffer
 #ifdef HAVE_USE_DEFAULT_COLORS
   if (!option(OPT_NO_CURSES) && has_colors()
       /* delay use_default_colors() until needed, since it initializes things */
-      && (fg == COLOR_DEFAULT || bg == COLOR_DEFAULT) && use_default_colors() != OK)
+      && (fg == COLOR_DEFAULT || bg == COLOR_DEFAULT || object == MT_COLOR_TREE)
+      && use_default_colors() != OK)
+      /* the case of the tree object is special, because a non-default
+       * fg color of the tree element may be combined dynamically with
+       * the default bg color of an index line, not necessarily defined in
+       * a rc file.
+       */
   {
     strfcpy(err->data, _("default colors not supported"), err->dsize);
     return -1;

--- a/curs_lib.c
+++ b/curs_lib.c
@@ -915,7 +915,9 @@ int _mutt_enter_fname(const char *prompt, char *buf, size_t blen, int buffy,
   {
     mutt_refresh();
     buf[0] = 0;
-    flags = MUTT_SEL_FOLDER;
+
+    if (!flags)
+      flags = MUTT_SEL_FOLDER;
     if (multiple)
       flags |= MUTT_SEL_MULTI;
     if (buffy)


### PR DESCRIPTION
#_mutt_enter_fname: verify that flag is not zero

The flag argument in the _mutt_enter_fname function might not be                                                                                                                          
zero (e.g. in the definition of the mutt_enter_vfolder function, see                                                                                                                      
protos.h:297).                                                                                                                                                                            
                                                                                                                                                                                              
This fixes issue #707, the issue was introduced in 43b949fbafe2e08c0cb90e5bc39a730201b8a0c4