### PR TITLE
include term.h from wherever we find ncurses.h

### DIFF
--- a/curs_main.c
+++ b/curs_main.c
@@ -58,7 +58,7 @@
 #include <ncursesw/term.h>
 #elif defined(HAVE_NCURSES_NCURSES_H)
 #include <ncurses/term.h>
-#elif defined(HAVE_NCURSES_H)
+#else
 #include <term.h>
 #endif
 #ifdef USE_SIDEBAR

--- a/curs_main.c
+++ b/curs_main.c
@@ -54,7 +54,11 @@
 #include "protos.h"
 #include "sort.h"
 #include "thread.h"
-#ifndef USE_SLANG_CURSES
+#ifdef HAVE_NCURSESW_NCURSES_H
+#include <ncursesw/term.h>
+#elif defined(HAVE_NCURSES_NCURSES_H)
+#include <ncurses/term.h>
+#elif defined(HAVE_NCURSES_H)
 #include <term.h>
 #endif
 #ifdef USE_SIDEBAR


### PR DESCRIPTION
Solaris needs `term.h` for `tigetstr()`, but `term.h` doesn't always live in `/usr/include`

The only tests that need to be done are:
- Does Ncurses compile?
- Does Slang compile?

It works in Fedora and Debian, but I'd appreciate feedback for any systems you can test.

/cc @0-wiz-0 