### PR TITLE
Only include libintl.h if ENABLE_NLS is defined

### DIFF
--- a/alias.c
+++ b/alias.c
@@ -23,7 +23,9 @@
 #include "config.h"
 #include <stddef.h>
 #include <errno.h>
+#ifdef ENABLE_NLS
 #include <libintl.h>
+#endif
 #include <pwd.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/browser.c
+++ b/browser.c
@@ -25,7 +25,9 @@
 #include <dirent.h>
 #include <errno.h>
 #include <grp.h>
+#ifdef ENABLE_NLS
 #include <libintl.h>
+#endif
 #include <limits.h>
 #include <locale.h>
 #include <pwd.h>

--- a/commands.c
+++ b/commands.c
@@ -24,7 +24,9 @@
 #include "config.h"
 #include <errno.h>
 #include <fcntl.h>
+#ifdef ENABLE_NLS
 #include <libintl.h>
+#endif
 #include <limits.h>
 #include <stdbool.h>
 #include <stdio.h>

--- a/compose.c
+++ b/compose.c
@@ -23,7 +23,9 @@
 
 #include "config.h"
 #include <errno.h>
+#ifdef ENABLE_NLS
 #include <libintl.h>
+#endif
 #include <limits.h>
 #include <stdbool.h>
 #include <stdio.h>

--- a/curs_lib.c
+++ b/curs_lib.c
@@ -27,7 +27,9 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <langinfo.h>
+#ifdef ENABLE_NLS
 #include <libintl.h>
+#endif
 #include <limits.h>
 #include <regex.h>
 #include <stdarg.h>

--- a/curs_main.c
+++ b/curs_main.c
@@ -23,7 +23,9 @@
 #include "config.h"
 #include <assert.h>
 #include <ctype.h>
+#ifdef ENABLE_NLS
 #include <libintl.h>
+#endif
 #include <regex.h>
 #include <stdbool.h>
 #include <stdio.h>

--- a/edit.c
+++ b/edit.c
@@ -25,7 +25,9 @@
 #include "config.h"
 #include <ctype.h>
 #include <errno.h>
+#ifdef ENABLE_NLS
 #include <libintl.h>
+#endif
 #include <locale.h>
 #include <stdbool.h>
 #include <stdio.h>

--- a/handler.c
+++ b/handler.c
@@ -24,7 +24,9 @@
 #include <stddef.h>
 #include <ctype.h>
 #include <iconv.h>
+#ifdef ENABLE_NLS
 #include <libintl.h>
+#endif
 #include <limits.h>
 #include <stdbool.h>
 #include <stdio.h>

--- a/imap/browse.c
+++ b/imap/browse.c
@@ -24,7 +24,9 @@
 /* Mutt browser support routines */
 
 #include "config.h"
+#ifdef ENABLE_NLS
 #include <libintl.h>
+#endif
 #include <regex.h>
 #include <stdbool.h>
 #include <stdio.h>

--- a/main.c
+++ b/main.c
@@ -26,7 +26,9 @@
 
 #include "config.h"
 #include <errno.h>
+#ifdef ENABLE_NLS
 #include <libintl.h>
+#endif
 #include <limits.h>
 #include <locale.h>
 #include <stdbool.h>

--- a/menu.c
+++ b/menu.c
@@ -22,7 +22,9 @@
 
 #include "config.h"
 #include <stddef.h>
+#ifdef ENABLE_NLS
 #include <libintl.h>
+#endif
 #include <regex.h>
 #include <stdbool.h>
 #include <stdio.h>

--- a/muttlib.c
+++ b/muttlib.c
@@ -27,7 +27,9 @@
 #include <errno.h>
 #include <inttypes.h>
 #include <libgen.h>
+#ifdef ENABLE_NLS
 #include <libintl.h>
+#endif
 #include <limits.h>
 #include <pwd.h>
 #include <regex.h>

--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -33,7 +33,9 @@
 #include <gpg-error.h>
 #include <gpgme.h>
 #include <langinfo.h>
+#ifdef ENABLE_NLS
 #include <libintl.h>
+#endif
 #include <limits.h>
 #include <locale.h>
 #include <stdbool.h>

--- a/ncrypt/pgp.c
+++ b/ncrypt/pgp.c
@@ -31,7 +31,9 @@
  */
 
 #include "config.h"
+#ifdef ENABLE_NLS
 #include <libintl.h>
+#endif
 #include <limits.h>
 #include <regex.h>
 #include <stdbool.h>

--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -23,7 +23,9 @@
  */
 
 #include "config.h"
+#ifdef ENABLE_NLS
 #include <libintl.h>
+#endif
 #include <limits.h>
 #include <stdbool.h>
 #include <stdio.h>

--- a/pager.c
+++ b/pager.c
@@ -25,7 +25,9 @@
 #include <ctype.h>
 #include <errno.h>
 #include <inttypes.h>
+#ifdef ENABLE_NLS
 #include <libintl.h>
+#endif
 #include <limits.h>
 #include <regex.h>
 #include <stdbool.h>

--- a/pattern.c
+++ b/pattern.c
@@ -23,7 +23,9 @@
 #include "config.h"
 #include <stddef.h>
 #include <ctype.h>
+#ifdef ENABLE_NLS
 #include <libintl.h>
+#endif
 #include <limits.h>
 #include <regex.h>
 #include <stdarg.h>

--- a/query.c
+++ b/query.c
@@ -21,7 +21,9 @@
  */
 
 #include "config.h"
+#ifdef ENABLE_NLS
 #include <libintl.h>
+#endif
 #include <limits.h>
 #include <regex.h>
 #include <stdbool.h>

--- a/recvattach.c
+++ b/recvattach.c
@@ -22,7 +22,9 @@
  */
 
 #include "config.h"
+#ifdef ENABLE_NLS
 #include <libintl.h>
+#endif
 #include <limits.h>
 #include <stdbool.h>
 #include <stdio.h>


### PR DESCRIPTION
This fixes a compilation error because of missing libintl.h on systems
without gettext.