### PR TITLE
trim trailing slash from completed dirs

### DIFF
--- a/addrbook.c
+++ b/addrbook.c
@@ -65,7 +65,7 @@ static const char *alias_format_str(char *dest, size_t destlen, size_t col, int 
       mutt_format_s(dest, destlen, fmt, alias->name);
       break;
     case 'r':
-      adr[0] = 0;
+      adr[0] = '\0';
       rfc822_write_address(adr, sizeof(adr), alias->addr, 1);
       snprintf(tmp, sizeof(tmp), "%%%ss", fmt);
       snprintf(dest, destlen, tmp, adr);
@@ -76,7 +76,7 @@ static const char *alias_format_str(char *dest, size_t destlen, size_t col, int 
       break;
     case 't':
       dest[0] = alias->tagged ? '*' : ' ';
-      dest[1] = 0;
+      dest[1] = '\0';
       break;
   }
 

--- a/alias.c
+++ b/alias.c
@@ -279,7 +279,7 @@ int check_alias_name(const char *s, char *dest, size_t destlen)
     }
   }
   if (!dry)
-    *dest = 0;
+    *dest = '\0';
   return rv;
 }
 
@@ -305,7 +305,7 @@ void mutt_create_alias(struct Envelope *cur, struct Address *iadr)
   {
     strfcpy(tmp, adr->mailbox, sizeof(tmp));
     if ((pc = strchr(tmp, '@')))
-      *pc = 0;
+      *pc = '\0';
   }
   else
     tmp[0] = '\0';
@@ -346,7 +346,7 @@ retry_name:
   if (adr && adr->mailbox)
     strfcpy(buf, adr->mailbox, sizeof(buf));
   else
-    buf[0] = 0;
+    buf[0] = '\0';
 
   mutt_addrlist_to_intl(adr, NULL);
 
@@ -371,7 +371,7 @@ retry_name:
   if (adr && adr->personal && !mutt_is_mail_list(adr))
     strfcpy(buf, adr->personal, sizeof(buf));
   else
-    buf[0] = 0;
+    buf[0] = '\0';
 
   if (mutt_get_field(_("Personal name: "), buf, sizeof(buf), 0) != 0)
   {
@@ -380,7 +380,7 @@ retry_name:
   }
   new->addr->personal = safe_strdup(buf);
 
-  buf[0] = 0;
+  buf[0] = '\0';
   rfc822_write_address(buf, sizeof(buf), new->addr, 1);
   snprintf(prompt, sizeof(prompt), _("[%s = %s] Accept?"), new->name, buf);
   if (mutt_yesorno(prompt, MUTT_YES) != MUTT_YES)
@@ -431,7 +431,7 @@ retry_name:
       strfcpy(buf, new->name, sizeof(buf));
     recode_buf(buf, sizeof(buf));
     fprintf(rc, "alias %s ", buf);
-    buf[0] = 0;
+    buf[0] = '\0';
     rfc822_write_address(buf, sizeof(buf), new->addr, 0);
     recode_buf(buf, sizeof(buf));
     write_safe_address(rc, buf);
@@ -530,7 +530,7 @@ int mutt_alias_complete(char *s, size_t buflen)
         {
           for (i = 0; a->name[i] && a->name[i] == bestname[i]; i++)
             ;
-          bestname[i] = 0;
+          bestname[i] = '\0';
         }
       }
       a = a->next;
@@ -567,7 +567,7 @@ int mutt_alias_complete(char *s, size_t buflen)
     }
   }
 
-  bestname[0] = 0;
+  bestname[0] = '\0';
   mutt_alias_menu(bestname, sizeof(bestname), a_list ? a_list : Aliases);
   if (bestname[0] != 0)
     strfcpy(s, bestname, buflen);

--- a/buffy.c
+++ b/buffy.c
@@ -748,7 +748,7 @@ int mutt_buffy_list(void)
 
   int have_unnotified = BuffyNotify;
 
-  buffylist[0] = 0;
+  buffylist[0] = '\0';
   pos += strlen(strncat(buffylist, _("New mail in "), sizeof(buffylist) - 1 - pos));
   for (b = Incoming; b; b = b->next)
   {

--- a/charset.c
+++ b/charset.c
@@ -231,7 +231,7 @@ void mutt_canonical_charset(char *dest, size_t dlen, const char *name)
 
   strfcpy(in, name, sizeof(in));
   if ((ext = strchr(in, '/')))
-    *ext++ = 0;
+    *ext++ = '\0';
 
   if ((mutt_strcasecmp(in, "utf-8") == 0) || (mutt_strcasecmp(in, "utf8") == 0))
   {

--- a/commands.c
+++ b/commands.c
@@ -801,8 +801,13 @@ int mutt_save_message(struct Header *h, int delete, int decode, int decrypt)
   if (mutt_enter_fname(prompt, buf, sizeof(buf), 0) == -1)
     return -1;
 
-  if (!buf[0])
+  size_t pathlen = strlen(buf);
+  if (pathlen == 0)
     return -1;
+
+  /* Trim any trailing '/' */
+  if (buf[pathlen - 1] == '/')
+    buf[pathlen - 1] = '\0';
 
   /* This is an undocumented feature of ELM pointed out to me by Felix von
    * Leitner <leitner@prz.fu-berlin.de>
@@ -811,15 +816,6 @@ int mutt_save_message(struct Header *h, int delete, int decode, int decrypt)
     strfcpy(buf, LastSaveFolder, sizeof(buf));
   else
     strfcpy(LastSaveFolder, buf, sizeof(LastSaveFolder));
-
-  /* check if path is a filename by comparing last character
-   * (mboxes need filenames, not directories)
-   */
-  if (DefaultMagic == MUTT_MBOX && buf[strlen(buf) - 1] == '/')
-  {
-    mutt_error(_("'%s' is a directory, need a filename for mbox."), buf);
-    return -1;
-  }
 
   mutt_expand_path(buf, sizeof(buf));
 

--- a/commands.c
+++ b/commands.c
@@ -313,7 +313,7 @@ void ci_bounce_message(struct Header *h)
     return;
   }
 
-  buf[0] = 0;
+  buf[0] = '\0';
   rfc822_write_address(buf, sizeof(buf), adr, 1);
 
 #define EXTRA_SPACE (15 + 7 + 2)
@@ -497,7 +497,7 @@ void mutt_pipe_message(struct Header *h)
 {
   char buffer[LONG_STRING];
 
-  buffer[0] = 0;
+  buffer[0] = '\0';
   if (mutt_get_field(_("Pipe to command: "), buffer, sizeof(buffer), MUTT_CMD) != 0 ||
       !buffer[0])
     return;
@@ -602,7 +602,7 @@ void mutt_shell_escape(void)
 {
   char buf[LONG_STRING];
 
-  buf[0] = 0;
+  buf[0] = '\0';
   if (mutt_get_field(_("Shell command: "), buf, sizeof(buf), MUTT_CMD) == 0)
   {
     if (!buf[0] && Shell)
@@ -628,7 +628,7 @@ void mutt_enter_command(void)
   char buffer[LONG_STRING];
   int r;
 
-  buffer[0] = 0;
+  buffer[0] = '\0';
   if (mutt_get_field(":", buffer, sizeof(buffer), MUTT_COMMAND) != 0 || !buffer[0])
     return;
   mutt_buffer_init(&err);
@@ -669,7 +669,7 @@ void mutt_display_address(struct Envelope *env)
    * software.
    */
 
-  buf[0] = 0;
+  buf[0] = '\0';
   rfc822_write_address(buf, sizeof(buf), adr, 0);
   mutt_message("%s: %s", pfx, buf);
 }

--- a/complete.c
+++ b/complete.c
@@ -103,11 +103,11 @@ int mutt_complete(char *s, size_t slen)
           {
             if (filepart[i] != nntp_data->group[i])
             {
-              filepart[i] = 0;
+              filepart[i] = '\0';
               break;
             }
           }
-          filepart[i] = 0;
+          filepart[i] = '\0';
         }
         else
         {
@@ -143,7 +143,7 @@ int mutt_complete(char *s, size_t slen)
   if (*s == '=' || *s == '+' || *s == '!')
   {
     dirpart[0] = *s;
-    dirpart[1] = 0;
+    dirpart[1] = '\0';
     if (*s == '!')
       strfcpy(exp_dirpart, NONULL(SpoolFile), sizeof(exp_dirpart));
     else
@@ -172,7 +172,7 @@ int mutt_complete(char *s, size_t slen)
       {
         p = s + 1;
         strfcpy(dirpart, "/", sizeof(dirpart));
-        exp_dirpart[0] = 0;
+        exp_dirpart[0] = '\0';
         strfcpy(filepart, p, sizeof(filepart));
         dirp = opendir(dirpart);
       }
@@ -188,7 +188,7 @@ int mutt_complete(char *s, size_t slen)
     else
     {
       /* no directory name, so assume current directory. */
-      dirpart[0] = 0;
+      dirpart[0] = '\0';
       strfcpy(filepart, s, sizeof(filepart));
       dirp = opendir(".");
     }
@@ -228,11 +228,11 @@ int mutt_complete(char *s, size_t slen)
         {
           if (filepart[i] != de->d_name[i])
           {
-            filepart[i] = 0;
+            filepart[i] = '\0';
             break;
           }
         }
-        filepart[i] = 0;
+        filepart[i] = '\0';
       }
       else
       {

--- a/copy.c
+++ b/copy.c
@@ -83,7 +83,7 @@ int mutt_copy_hdr(FILE *in, FILE *out, LOFF_T off_start, LOFF_T off_end,
       return -1;
 
   buf[0] = '\n';
-  buf[1] = 0;
+  buf[1] = '\0';
 
   if ((flags & (CH_REORDER | CH_WEED | CH_MIME | CH_DECODE | CH_PREFIX | CH_WEED_DELIVERED)) == 0)
   {
@@ -194,7 +194,7 @@ int mutt_copy_hdr(FILE *in, FILE *out, LOFF_T off_start, LOFF_T off_end,
               (this_one[this_one_len - 1] == '\n'))
           {
             this_one[this_one_len - 2] = '\n';
-            this_one[this_one_len - 1] = 0;
+            this_one[this_one_len - 1] = '\0';
           }
         }
 

--- a/curs_lib.c
+++ b/curs_lib.c
@@ -262,7 +262,7 @@ int mutt_yesorno(const char *msg, int def)
   int reno_ok;
   char answer[2];
 
-  answer[1] = 0;
+  answer[1] = '\0';
 
   reyes_ok = (expr = nl_langinfo(YESEXPR)) && expr[0] == '^' &&
              !REGCOMP(&reyes, expr, REG_NOSUB);
@@ -532,7 +532,7 @@ static void message_bar(int percent, const char *fmt, ...)
       int off = mutt_wstr_trunc(buf2, sizeof(buf2), w, NULL);
 
       ch = buf2[off];
-      buf2[off] = 0;
+      buf2[off] = '\0';
       SETCOLOR(MT_COLOR_PROGRESS);
       addstr(buf2);
       buf2[off] = ch;
@@ -916,7 +916,7 @@ int _mutt_enter_fname(const char *prompt, char *buf, size_t blen, int buffy,
   else if (ch.ch == '?')
   {
     mutt_refresh();
-    buf[0] = 0;
+    buf[0] = '\0';
 
     if (!flags)
       flags = MUTT_SEL_FOLDER;
@@ -934,7 +934,7 @@ int _mutt_enter_fname(const char *prompt, char *buf, size_t blen, int buffy,
     mutt_unget_event(ch.op ? 0 : ch.ch, ch.op ? ch.op : 0);
     if (_mutt_get_field(pc, buf, blen, (buffy ? MUTT_EFILE : MUTT_FILE) | MUTT_CLEAR,
                         multiple, files, numfiles) != 0)
-      buf[0] = 0;
+      buf[0] = '\0';
     FREE(&pc);
 #ifdef USE_NOTMUCH
     if ((flags & MUTT_SEL_VFOLDER) && buf[0] && (strncmp(buf, "notmuch://", 10) != 0))

--- a/curs_main.c
+++ b/curs_main.c
@@ -56,7 +56,11 @@
 #include "protos.h"
 #include "sort.h"
 #include "thread.h"
-#ifndef USE_SLANG_CURSES
+#ifdef HAVE_NCURSESW_NCURSES_H
+#include <ncursesw/term.h>
+#elif defined(HAVE_NCURSES_NCURSES_H)
+#include <ncurses/term.h>
+#else
 #include <term.h>
 #endif
 #ifdef USE_SIDEBAR

--- a/doc/makedoc.c
+++ b/doc/makedoc.c
@@ -141,7 +141,7 @@ static char *get_token(char *d, size_t l, char *s)
       fprintf(stderr, "%s: found single character token `%c'.\n", Progname, *s);
     }
     d[0] = *s++;
-    d[1] = 0;
+    d[1] = '\0';
     return s;
   }
 
@@ -925,7 +925,7 @@ static int handle_docline(char *l, FILE *out, int docstat)
 
         docstat = commit_buff(buff, &d, out, docstat);
         save = *s;
-        *s = 0;
+        *s = '\0';
         print_ref(out, output_dollar, ref);
         *s = save;
         s--;

--- a/edit.c
+++ b/edit.c
@@ -80,7 +80,7 @@ static char **be_snarf_data(FILE *f, char **buf, int *bufmax, int *buflen,
   char *p = tmp;
   int tmplen = sizeof(tmp);
 
-  tmp[sizeof(tmp) - 1] = 0;
+  tmp[sizeof(tmp) - 1] = '\0';
   if (prefix)
   {
     strfcpy(tmp, NONULL(Prefix), sizeof(tmp));
@@ -212,7 +212,7 @@ static void be_print_header(struct Envelope *env)
   if (env->to)
   {
     addstr("To: ");
-    tmp[0] = 0;
+    tmp[0] = '\0';
     rfc822_write_address(tmp, sizeof(tmp), env->to, 1);
     addstr(tmp);
     addch('\n');
@@ -220,7 +220,7 @@ static void be_print_header(struct Envelope *env)
   if (env->cc)
   {
     addstr("Cc: ");
-    tmp[0] = 0;
+    tmp[0] = '\0';
     rfc822_write_address(tmp, sizeof(tmp), env->cc, 1);
     addstr(tmp);
     addch('\n');
@@ -228,7 +228,7 @@ static void be_print_header(struct Envelope *env)
   if (env->bcc)
   {
     addstr("Bcc: ");
-    tmp[0] = 0;
+    tmp[0] = '\0';
     rfc822_write_address(tmp, sizeof(tmp), env->bcc, 1);
     addstr(tmp);
     addch('\n');
@@ -254,7 +254,7 @@ static void be_edit_header(struct Envelope *e, int force)
   mutt_window_move(MuttMessageWindow, 0, 0);
 
   addstr("To: ");
-  tmp[0] = 0;
+  tmp[0] = '\0';
   mutt_addrlist_to_local(e->to);
   rfc822_write_address(tmp, sizeof(tmp), e->to, 0);
   if (!e->to || force)
@@ -265,7 +265,7 @@ static void be_edit_header(struct Envelope *e, int force)
       e->to = mutt_parse_adrlist(e->to, tmp);
       e->to = mutt_expand_aliases(e->to);
       mutt_addrlist_to_intl(e->to, NULL); /* XXX - IDNA error reporting? */
-      tmp[0] = 0;
+      tmp[0] = '\0';
       rfc822_write_address(tmp, sizeof(tmp), e->to, 1);
       mutt_window_mvaddstr(MuttMessageWindow, 0, 4, tmp);
     }
@@ -289,7 +289,7 @@ static void be_edit_header(struct Envelope *e, int force)
   if ((!e->cc && option(OPT_ASK_CC)) || force)
   {
     addstr("Cc: ");
-    tmp[0] = 0;
+    tmp[0] = '\0';
     mutt_addrlist_to_local(e->cc);
     rfc822_write_address(tmp, sizeof(tmp), e->cc, 0);
     if (mutt_enter_string(tmp, sizeof(tmp), 4, 0) == 0)
@@ -297,7 +297,7 @@ static void be_edit_header(struct Envelope *e, int force)
       rfc822_free_address(&e->cc);
       e->cc = mutt_parse_adrlist(e->cc, tmp);
       e->cc = mutt_expand_aliases(e->cc);
-      tmp[0] = 0;
+      tmp[0] = '\0';
       mutt_addrlist_to_intl(e->cc, NULL);
       rfc822_write_address(tmp, sizeof(tmp), e->cc, 1);
       mutt_window_mvaddstr(MuttMessageWindow, 0, 4, tmp);
@@ -310,7 +310,7 @@ static void be_edit_header(struct Envelope *e, int force)
   if (option(OPT_ASK_BCC) || force)
   {
     addstr("Bcc: ");
-    tmp[0] = 0;
+    tmp[0] = '\0';
     mutt_addrlist_to_local(e->bcc);
     rfc822_write_address(tmp, sizeof(tmp), e->bcc, 0);
     if (mutt_enter_string(tmp, sizeof(tmp), 5, 0) == 0)
@@ -319,7 +319,7 @@ static void be_edit_header(struct Envelope *e, int force)
       e->bcc = mutt_parse_adrlist(e->bcc, tmp);
       e->bcc = mutt_expand_aliases(e->bcc);
       mutt_addrlist_to_intl(e->bcc, NULL);
-      tmp[0] = 0;
+      tmp[0] = '\0';
       rfc822_write_address(tmp, sizeof(tmp), e->bcc, 1);
       mutt_window_mvaddstr(MuttMessageWindow, 0, 5, tmp);
     }
@@ -346,12 +346,12 @@ int mutt_builtin_editor(const char *path, struct Header *msg, struct Header *cur
 
   buf = be_snarf_file(path, buf, &bufmax, &buflen, 0);
 
-  tmp[0] = 0;
+  tmp[0] = '\0';
   while (!done)
   {
     if (mutt_enter_string(tmp, sizeof(tmp), 0, 0) == -1)
     {
-      tmp[0] = 0;
+      tmp[0] = '\0';
       continue;
     }
     addch('\n');
@@ -361,7 +361,7 @@ int mutt_builtin_editor(const char *path, struct Header *msg, struct Header *cur
       /* remove trailing whitespace from the line */
       p = tmp + mutt_strlen(tmp) - 1;
       while (p >= tmp && ISSPACE(*p))
-        *p-- = 0;
+        *p-- = '\0';
 
       p = tmp + 2;
       SKIPWS(p);
@@ -440,7 +440,7 @@ int mutt_builtin_editor(const char *path, struct Header *msg, struct Header *cur
           {
             buflen--;
             strfcpy(tmp, buf[buflen], sizeof(tmp));
-            tmp[mutt_strlen(tmp) - 1] = 0;
+            tmp[mutt_strlen(tmp) - 1] = '\0';
             FREE(&buf[buflen]);
             buf[buflen] = NULL;
             continue;
@@ -497,7 +497,7 @@ int mutt_builtin_editor(const char *path, struct Header *msg, struct Header *cur
       buf[buflen++] = safe_strdup(tmp[1] == '~' ? tmp + 1 : tmp);
     }
 
-    tmp[0] = 0;
+    tmp[0] = '\0';
   }
 
   if (!abort)

--- a/from.c
+++ b/from.c
@@ -41,7 +41,7 @@ int is_from(const char *s, char *path, size_t pathlen, time_t *tp)
   int yr;
 
   if (path)
-    *path = 0;
+    *path = '\0';
 
   if (mutt_strncmp("From ", s, 5) != 0)
     return 0;
@@ -93,7 +93,7 @@ int is_from(const char *s, char *path, size_t pathlen, time_t *tp)
       if (len + 1 > pathlen)
         len = pathlen - 1;
       memcpy(path, s, len);
-      path[len] = 0;
+      path[len] = '\0';
       mutt_debug(3, "is_from(): got return path: %s\n", path);
     }
 

--- a/handler.c
+++ b/handler.c
@@ -290,7 +290,7 @@ static void decode_quoted(struct State *s, long len, int istext, iconv_t cd)
     {
       while (linelen > 0 && ISSPACE(line[linelen - 1]))
         linelen--;
-      line[linelen] = 0;
+      line[linelen] = '\0';
     }
 
     /* decode and do character set conversion */
@@ -310,7 +310,7 @@ void mutt_decode_base64(struct State *s, long len, int istext, iconv_t cd)
   char bufi[BUFI_SIZE];
   size_t l = 0;
 
-  buf[4] = 0;
+  buf[4] = '\0';
 
   if (istext)
     state_set_prefix(s);
@@ -1667,7 +1667,7 @@ static int text_plain_handler(struct Body *b, struct State *s)
     {
       l = mutt_strlen(buf);
       while (l > 0 && buf[l - 1] == ' ')
-        buf[--l] = 0;
+        buf[--l] = '\0';
     }
     if (s->prefix)
       state_puts(s->prefix, s);

--- a/hcache/hcache.c
+++ b/hcache/hcache.c
@@ -555,7 +555,7 @@ static bool create_hcache_dir(const char *path)
   if (!p)
     return true;
 
-  *p = 0;
+  *p = '\0';
   if (mutt_mkdir(dir, S_IRWXU | S_IRWXG | S_IRWXO) == 0)
     return true;
 

--- a/headers.c
+++ b/headers.c
@@ -185,7 +185,7 @@ void mutt_edit_headers(const char *editor, const char *body, struct Header *msg,
             path[l++] = *p;
         }
         p = skip_email_wsp(p);
-        path[l] = 0;
+        path[l] = '\0';
 
         mutt_expand_path(path, sizeof(path));
         if ((body2 = mutt_make_file_attach(path)))

--- a/help.c
+++ b/help.c
@@ -72,7 +72,7 @@ void mutt_make_help(char *d, size_t dlen, const char *txt, int menu, int op)
       km_expand_key(buf, sizeof(buf), km_find_func(MENU_GENERIC, op)))
     snprintf(d, dlen, "%s:%s", buf, txt);
   else
-    d[0] = 0;
+    d[0] = '\0';
 }
 
 char *mutt_compile_help(char *buf, size_t buflen, int menu, const struct Mapping *items)

--- a/hook.c
+++ b/hook.c
@@ -452,7 +452,7 @@ static int addr_hook(char *path, size_t pathlen, int type, struct Context *ctx,
 
 void mutt_default_save(char *path, size_t pathlen, struct Header *hdr)
 {
-  *path = 0;
+  *path = '\0';
   if (addr_hook(path, pathlen, MUTT_SAVEHOOK, Context, hdr) != 0)
   {
     char tmp[_POSIX_PATH_MAX];

--- a/imap/auth_gss.c
+++ b/imap/auth_gss.c
@@ -237,7 +237,7 @@ enum ImapAuthRes imap_auth_gss(struct ImapData *idata, const char *method)
   }
 
   /* we don't care about buffer size if we don't wrap content. But here it is */
-  ((char *) send_token.value)[0] = 0;
+  ((char *) send_token.value)[0] = '\0';
   buf_size = ntohl(*((long *) send_token.value));
   gss_release_buffer(&min_stat, &send_token);
   mutt_debug(2, "Unwrapped security level flags: %c%c%c\n",

--- a/imap/message.c
+++ b/imap/message.c
@@ -272,7 +272,7 @@ static int msg_parse_fetch(struct ImapHeader *h, char *s)
       if (*s != '\"')
         return -1;
       s++; /* skip past the trailing " */
-      *ptmp = 0;
+      *ptmp = '\0';
       h->received = imap_parse_date(tmp);
     }
     else if (mutt_strncasecmp("RFC822.SIZE", s, 11) == 0)
@@ -282,7 +282,7 @@ static int msg_parse_fetch(struct ImapHeader *h, char *s)
       ptmp = tmp;
       while (isdigit((unsigned char) *s))
         *ptmp++ = *s++;
-      *ptmp = 0;
+      *ptmp = '\0';
       h->content_length = atoi(tmp);
     }
     else if ((mutt_strncasecmp("BODY", s, 4) == 0) ||

--- a/imap/util.c
+++ b/imap/util.c
@@ -627,7 +627,7 @@ int imap_get_literal_count(const char *buf, long *bytes)
   pn = pc;
   while (isdigit((unsigned char) *pc))
     pc++;
-  *pc = 0;
+  *pc = '\0';
   *bytes = atoi(pn);
 
   return 0;
@@ -795,7 +795,7 @@ void imap_quote_string(char *dest, size_t dlen, const char *src)
     }
   }
   *pt++ = '"';
-  *pt = 0;
+  *pt = '\0';
 }
 
 /**
@@ -871,17 +871,17 @@ int imap_wordcasecmp(const char *a, const char *b)
   char *s = (char *) b;
   int i;
 
-  tmp[SHORT_STRING - 1] = 0;
+  tmp[SHORT_STRING - 1] = '\0';
   for (i = 0; i < SHORT_STRING - 2; i++, s++)
   {
     if (!*s || ISSPACE(*s))
     {
-      tmp[i] = 0;
+      tmp[i] = '\0';
       break;
     }
     tmp[i] = *s;
   }
-  tmp[i + 1] = 0;
+  tmp[i + 1] = '\0';
 
   return mutt_strcasecmp(a, tmp);
 }

--- a/init.c
+++ b/init.c
@@ -2254,7 +2254,7 @@ static void pretty_var(char *dst, size_t len, const char *option, const char *va
   p += escape_string(p, len - (p - dst) + 1, val); /* \0 terminate it */
   if (p - dst < len)
     *p++ = '"';
-  *p = 0;
+  *p = '\0';
 }
 
 static int check_charset(struct Option *opt, const char *val)
@@ -3432,7 +3432,7 @@ static void candidate(char *dest, char *try, const char *src, int len)
     {
       for (l = 0; src[l] && src[l] == dest[l]; l++)
         ;
-      dest[l] = 0;
+      dest[l] = '\0';
     }
   }
 }
@@ -3637,7 +3637,7 @@ int mutt_var_value_complete(char *buffer, size_t len, int pos)
     if (vlen == 0)
       return 0;
 
-    var[vlen - 1] = 0;
+    var[vlen - 1] = '\0';
     if ((idx = mutt_option_index(var)) == -1)
     {
       if ((myvarval = myvar_get(var)) != NULL)

--- a/keymap.c
+++ b/keymap.c
@@ -625,7 +625,7 @@ static const char *km_keyname(int c)
     {
       buf[0] = '^';
       buf[1] = (c + '@') & 0x7f;
-      buf[2] = 0;
+      buf[2] = '\0';
     }
     else
       snprintf(buf, sizeof(buf), "\\%d%d%d", c >> 6, (c >> 3) & 7, c & 7);

--- a/lib/date.c
+++ b/lib/date.c
@@ -202,7 +202,7 @@ static const char *uncomment_timezone(char *buf, size_t buflen, const char *tz)
   if (len > (buflen - 1))
     len = buflen - 1;
   memcpy(buf, tz, len);
-  buf[len] = 0;
+  buf[len] = '\0';
   return buf;
 }
 

--- a/lib/file.c
+++ b/lib/file.c
@@ -656,9 +656,9 @@ char *mutt_read_line(char *s, size_t *size, FILE *fp, int *line, int flags)
         (*line)++;
       if (flags & MUTT_EOL)
         return s;
-      *ch = 0;
+      *ch = '\0';
       if ((ch > s) && (*(ch - 1) == '\r'))
-        *--ch = 0;
+        *--ch = '\0';
       if (!(flags & MUTT_CONT) || (ch == s) || (*(ch - 1) != '\\'))
         return s;
       offset = ch - s - 1;
@@ -768,7 +768,7 @@ char *mutt_concatn_path(char *dst, size_t dstlen, const char *dir,
      * It doesn't appear that the return value is actually checked anywhere mutt_concat_path()
      * is called, so we should just copy set dst to nul and let the calling function fail later.
      */
-    dst[0] = 0; /* safe since we bail out early if dstlen == 0 */
+    dst[0] = '\0'; /* safe since we bail out early if dstlen == 0 */
     return NULL;
   }
 
@@ -784,7 +784,7 @@ char *mutt_concatn_path(char *dst, size_t dstlen, const char *dir,
     memcpy(dst + offset, fname, fnamelen);
     offset += fnamelen;
   }
-  dst[offset] = 0;
+  dst[offset] = '\0';
   return dst;
 }
 

--- a/lib/string.c
+++ b/lib/string.c
@@ -319,7 +319,7 @@ char *mutt_substrcpy(char *dest, const char *begin, const char *end, size_t dest
   if (len > (destlen - 1))
     len = destlen - 1;
   memcpy(dest, begin, len);
-  dest[len] = 0;
+  dest[len] = '\0';
   return dest;
 }
 
@@ -345,7 +345,7 @@ char *mutt_substrdup(const char *begin, const char *end)
 
   p = safe_malloc(len + 1);
   memcpy(p, begin, len);
-  p[len] = 0;
+  p[len] = '\0';
   return p;
 }
 
@@ -477,7 +477,7 @@ void mutt_remove_trailing_ws(char *s)
   char *p = NULL;
 
   for (p = s + mutt_strlen(s) - 1; p >= s && ISSPACE(*p); p--)
-    *p = 0;
+    *p = '\0';
 }
 
 /**
@@ -625,7 +625,7 @@ void rfc822_dequote_comment(char *s)
       w++;
     }
   }
-  *w = 0;
+  *w = '\0';
 }
 
 /**

--- a/mbox.c
+++ b/mbox.c
@@ -119,7 +119,7 @@ static int mmdf_parse_mailbox(struct Context *ctx)
   ctx->mtime = sb.st_mtime;
   ctx->size = sb.st_size;
 
-  buf[sizeof(buf) - 1] = 0;
+  buf[sizeof(buf) - 1] = '\0';
 
   if (!ctx->quiet)
   {
@@ -158,7 +158,7 @@ static int mmdf_parse_mailbox(struct Context *ctx)
         break;
       }
 
-      return_path[0] = 0;
+      return_path[0] = '\0';
 
       if (!is_from(buf, return_path, sizeof(return_path), &t))
       {

--- a/menu.c
+++ b/menu.c
@@ -290,7 +290,7 @@ static void menu_pad_string(struct Menu *menu, char *s, size_t n)
   int cols = menu->indexwin->cols - shift;
 
   mutt_simple_format(s, n, cols, cols, FMT_LEFT, ' ', scratch, mutt_strlen(scratch), 1);
-  s[n - 1] = 0;
+  s[n - 1] = '\0';
   FREE(&scratch);
 }
 
@@ -535,7 +535,7 @@ static void menu_jump(struct Menu *menu)
   if (menu->max)
   {
     mutt_unget_event(LastKey, 0);
-    buf[0] = 0;
+    buf[0] = '\0';
     if (mutt_get_field(_("Jump to: "), buf, sizeof(buf), 0) == 0 && buf[0])
     {
       if (mutt_atoi(buf, &n) == 0 && n > 0 && n < menu->max + 1)

--- a/mh.c
+++ b/mh.c
@@ -1854,7 +1854,7 @@ static int maildir_sync_message(struct Context *ctx, int msgno)
 
     /* kill the previous flags */
     if ((p = strchr(newpath, ':')) != NULL)
-      *p = 0;
+      *p = '\0';
 
     maildir_flags(suffix, sizeof(suffix), h);
 

--- a/mutt_sasl.h
+++ b/mutt_sasl.h
@@ -26,6 +26,7 @@
 #define _MUTT_SASL_H
 
 #include <stddef.h>
+#include <time.h>
 #include <sasl/sasl.h>
 
 struct Connection;


### PR DESCRIPTION
When saving a email, selecting a maildir directory should override the setting of $mbox_type.

- default mailbox (`$mbox_type`) is set to `mbox`
- save an email to a **Maildir** directory with a trailing '/'

Before #551, NeoMutt would do the "right thing" and safe it in Maildir format.
Since, it complains: '=bar/' is a directory, need a filename for mbox.

By trimming the trailing '/' from the completed name, means:
- maildirs are selected correctly
- non-existent paths respect `$mbox_type`

Fixes #719

