### PR TITLE
contrib: Add guix-neomutt.scm.

### DIFF
--- a/contrib/guix-neomutt.scm
+++ b/contrib/guix-neomutt.scm
@@ -1,0 +1,49 @@
+;;; Copyright (C) 2017 ng0 <ng0@infotropique.org>
+;;;
+;;; This program is free software: you can redistribute it and/or modify it under
+;;; the terms of the GNU General Public License as published by the Free Software
+;;; Foundation, either version 2 of the License, or (at your option) any later
+;;; version.
+;;;
+;;; This program is distributed in the hope that it will be useful, but WITHOUT
+;;; ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+;;; FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+;;; details.
+;;;
+;;; You should have received a copy of the GNU General Public License along with
+;;; this program.  If not, see <http://www.gnu.org/licenses/>.
+;;;
+;;; How to use this file.
+;;; Building neomutt from within the git checkout, skipping the hash check:
+;;; cd contrib
+;;; guix build -f guix-neomutt.scm
+
+(use-modules
+ (ice-9 popen)
+ (ice-9 match)
+ (ice-9 rdelim)
+ (guix packages)
+ (guix build-system gnu)
+ (guix gexp)
+ ((guix build utils) #:select (with-directory-excursion))
+ (gnu packages)
+ (gnu packages base)
+ (gnu packages autotools)
+ (gnu packages mail)
+ (gnu packages gettext))
+
+(define %source-dir (canonicalize-path ".."))
+
+(define-public neomutt-git
+  (package
+    (inherit neomutt)
+    (name "neomutt-git")
+    (version (string-append (package-version neomutt) "-git"))
+    (source
+     (local-file %source-dir
+                 #:recursive? #t))
+    (native-inputs
+      `(("gettext-minimal" ,gettext-minimal)
+        ,@(package-native-inputs neomutt)))))
+
+neomutt-git


### PR DESCRIPTION
* **What does this PR do?**

guix-neomutt.scm can be used to build the git checkout of neomutt at HEAD without hash checking in the build environment of GNU Guix. This is similar to what other software packages already do, like Mediagoblin, GNUnet, etc. There's no formalized way how to do it yet, but it helps with development on those platforms.

* **Are there points in the code the reviewer needs to double check?**

* **Screenshots (if relevant)**

* **Does this PR meet the acceptance criteria?** (This is just a reminder for you,
  this section can be removed if you fulfill it.)

   - Documentation created/updated (you have to edit
     [doc/manual.xml.head](https://www.github.com/neomutt/neomutt/blob/master/doc/manual.xml.head)
     for that)

   - All builds are passing

   - Added [doxygen code documentation](https://www.neomutt.org/dev/doxygen)
     [syntax](http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html)

   - Code follows the [style guide](https://www.neomutt.org/dev/coding-style)

* **What are the relevant issue numbers?**
