### PR TITLE
Support for multipart/alternative and multipart/mixed

### DIFF
--- a/body.h
+++ b/body.h
@@ -36,6 +36,7 @@ struct Body
 {
   char *xtype;                  /**< content-type if x-unknown */
   char *subtype;                /**< content-type subtype */
+  char *language;               /**< content-language (RFC8255) */
   struct ParameterList parameter;  /**< parameters of the content-type */
   char *description;            /**< content-description */
   char *form_name;              /**< Content-Disposition form-data name param */

--- a/compose.c
+++ b/compose.c
@@ -1146,6 +1146,7 @@ int mutt_compose_menu(struct Header *msg, char *fcc, size_t fcclen,
             for (int j = i; j < actx->idxlen - 1; j++)
             {
               actx->idx[j] = actx->idx[j + 1];
+              actx->idx[j + 1] = NULL; /* for debug reason */
             }
             actx->idxlen--;
           }
@@ -1159,15 +1160,15 @@ int mutt_compose_menu(struct Header *msg, char *fcc, size_t fcclen,
         group->next = NULL;
         mutt_generate_boundary(&group->parameter);
 
-        struct AttachPtr *gptr = mutt_mem_calloc(1, sizeof(struct AttachPtr));
-        gptr->content = group;
-        update_idx(menu, actx, gptr);
-
         /* if no group desc yet, make one up */
         if (!group->description)
           group->description = mutt_str_strdup("unknown alternative group");
+
+        struct AttachPtr *gptr = mutt_mem_calloc(1, sizeof(struct AttachPtr));
+        gptr->content = group;
+        update_idx(menu, actx, gptr);
       }
-        menu->redraw = 1;
+        menu->redraw = REDRAW_INDEX;
         break;
 
       case OP_COMPOSE_ATTACH_FILE:

--- a/compose.c
+++ b/compose.c
@@ -1102,6 +1102,7 @@ int mutt_compose_menu(struct Header *msg, char *fcc, size_t fcclen,
         struct Body *group = mutt_body_new();
         group->type = TYPEMULTIPART;
         group->subtype = mutt_str_strdup("alternative");
+        group->disposition = DISPINLINE;
 
         struct Body *alts = NULL;
         /* group tagged message into a multipart/alternative */
@@ -1111,6 +1112,7 @@ int mutt_compose_menu(struct Header *msg, char *fcc, size_t fcclen,
           if (bptr->tagged)
           {
             bptr->tagged = false;
+            bptr->disposition = DISPINLINE;
 
             /* for first match, set group desc according to match */
 #define ALTS_TAG "Alternatives for \"%s\""

--- a/compose.c
+++ b/compose.c
@@ -1159,8 +1159,6 @@ int mutt_compose_menu(struct Header *msg, char *fcc, size_t fcclen,
         group->next = NULL;
         mutt_generate_boundary(&group->parameter);
 
-        /* msg->content = NULL; */
-
         struct AttachPtr *gptr = mutt_mem_calloc(1, sizeof(struct AttachPtr));
         gptr->content = group;
         update_idx(menu, actx, gptr);

--- a/compose.c
+++ b/compose.c
@@ -1526,15 +1526,14 @@ int mutt_compose_menu(struct Header *msg, char *fcc, size_t fcclen,
         buf[0] = 0; /* clear buffer first */
         if (CURATTACH->content->language)
           mutt_str_strfcpy(buf, CURATTACH->content->language, sizeof(buf));
-        if ((mutt_get_field("Content-Language: ", buf, sizeof(buf), 0) == 0) &&
-            mutt_mime_valid_language(buf))
+        if (mutt_get_field("Content-Language: ", buf, sizeof(buf), 0) == 0)
         {
           CURATTACH->content->language = mutt_str_strdup(buf);
           menu->redraw = REDRAW_CURRENT | REDRAW_STATUS;
           mutt_clear_error();
         }
         else
-          mutt_error(_("Invalid language, default to none."));
+          mutt_warning(_("Empty Content-Language"));
         mutt_message_hook(NULL, msg, MUTT_SEND2HOOK);
         break;
 

--- a/doc/manual.xml.head
+++ b/doc/manual.xml.head
@@ -9079,6 +9079,22 @@ echo "Sourcing muttrc file" unset confirmappend macro index ,a "&lt;save-message
           See table <xref linkend="tab-attachment-bindings" /> for all
           available functions.
         </para>
+        <para>
+          Mutt includes some primitive ability to compose multipart/alternative
+          parts. In the Compose menu, attach the two (or more) alternatives as
+          usual.  For example, attach "invitation.html" and then
+          "invitation.txt". (You can reorder them using the &lt;move-up&gt; (-)
+          and &lt;move-down&gt; (+) bindings.) Edit the descriptions, if you
+          wish. Then tag the attachments that are alternatives, and press the
+          &lt;group-alternatives&gt; (&amp;) binding to group them together. The
+          separate parts will be replaced by a single new part with the
+          multipart/alternative type. From this point on, the alternatives must
+          be manipulated or deleted as a group.
+        </para>
+        <para>
+          Beware that such messages cannot be postponed. Once two attachments
+          are grouped as alternatives, they must be sent or lost.
+        </para>
       </sect2>
 
       <sect2 id="compose-menu">

--- a/doc/manual.xml.head
+++ b/doc/manual.xml.head
@@ -9079,22 +9079,6 @@ echo "Sourcing muttrc file" unset confirmappend macro index ,a "&lt;save-message
           See table <xref linkend="tab-attachment-bindings" /> for all
           available functions.
         </para>
-        <para>
-          Mutt includes some primitive ability to compose multipart/alternative
-          parts. In the Compose menu, attach the two (or more) alternatives as
-          usual.  For example, attach "invitation.html" and then
-          "invitation.txt". (You can reorder them using the &lt;move-up&gt; (-)
-          and &lt;move-down&gt; (+) bindings.) Edit the descriptions, if you
-          wish. Then tag the attachments that are alternatives, and press the
-          &lt;group-alternatives&gt; (&amp;) binding to group them together. The
-          separate parts will be replaced by a single new part with the
-          multipart/alternative type. From this point on, the alternatives must
-          be manipulated or deleted as a group.
-        </para>
-        <para>
-          Beware that such messages cannot be postponed. Once two attachments
-          are grouped as alternatives, they must be sent or lost.
-        </para>
       </sect2>
 
       <sect2 id="compose-menu">
@@ -9895,54 +9879,225 @@ application/postscript; ps2ascii %s; copiousoutput
 
     <sect1 id="alternative-order">
       <title>MIME Multipart/Alternative</title>
+
       <para>
-        The <literal>multipart/alternative</literal> container type only has
-        child MIME parts which represent the same content in an alternative
-        way. This is often used to send HTML messages which contain an
-        alternative plain text representation.
+        A <literal>multipart/alternative</literal> email has several
+        parts that represent the same content in different formats, such as
+        <literal>text/plain</literal> and <literal>text/html</literal>. This
+        kind of email is heavily used by many modern mail user agents to send
+        HTML messages which contain an alternative plain text representation.
+        You can read and write <literal>multipart/alternative</literal> emails
+        in NeoMutt. 
       </para>
-      <para>
-        NeoMutt has some heuristics for determining which attachment of
-        a <literal>multipart/alternative</literal> type to display:
-      </para>
-      <orderedlist>
-        <listitem>
-          <para>
-            First, NeoMutt will check the <command>alternative_order</command>
-            list to determine if one of the available types is preferred. It
-            consists of a number of MIME types in order, including support for
-            implicit and explicit wildcards. For example:
-          </para>
+
+      <sect2 id="read-alternative-order">
+        <title>Reading Multipart/Alternative Emails</title>
+        <para>
+          NeoMutt has some heuristics for determining which attachment of
+          a <literal>multipart/alternative</literal> type to display:
+        </para>
+        <orderedlist>
+          <listitem>
+            <para>
+              First, NeoMutt will check the <command>alternative_order</command>
+              list to determine if one of the available types is preferred. It
+              consists of a number of MIME types in order, including support for
+              implicit and explicit wildcards. For example:
+            </para>
 
 <screen>
-alternative_order text/enriched text/plain text \
-  application/postscript image/*
+alternative_order text/enriched text/plain text application/postscript image/*
 </screen>
 
-        </listitem>
-        <listitem>
-          <para>
-            Next, NeoMutt will check if any of the types have a defined
-            <link linkend="auto-view"><command>auto_view</command></link>, and
-            use that.
-          </para>
-        </listitem>
-        <listitem>
-          <para>
-            Failing that, NeoMutt will look for any text type.
-          </para>
-        </listitem>
-        <listitem>
-          <para>
-            As a last attempt, NeoMutt will look for any type it knows how to
-            handle.
-          </para>
-        </listitem>
-      </orderedlist>
+          </listitem>
+          <listitem>
+            <para>
+              Next, NeoMutt will check if any of the types have a defined
+              <link linkend="auto-view"><command>auto_view</command></link>, and
+              use that.
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              Failing that, NeoMutt will look for any text type.
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              As a last attempt, NeoMutt will look for any type it knows how to
+              handle.
+            </para>
+          </listitem>
+        </orderedlist>
+        <para>
+          To remove a MIME type from the <command>alternative_order</command>
+          list, use the <command>unalternative_order</command> command.
+        </para>
+      </sect2>
+
+      <sect2 id="compose-alternative-order">
+        <title>Composing Multipart/Alternative Emails</title>
+
+        <para>
+          Noemutt includes some primitive ability to compose multipart/alternative
+          emails:
+        </para>
+        <orderedlist>
+          <listitem>
+            <para>
+              In the Compose menu, attach the two (or more) alternatives as
+              usual. For example, attach "invitation.html" and then "invitation.txt".
+              (You can reorder them using the <literal>&lt;move-up&gt;</literal> (-)
+              and <literal>&lt;move-down&gt;</literal> (+) bindings, and edit the
+              descriptions).
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              Tag the attachments that are alternatives, and press the
+              <command>&lt;group-alternatives&gt;</command> (&amp;) binding to group
+              them together. After this, the separate parts will be replaced by a single
+              new part with the <literal>multipart/alternative</literal> type and the
+              alternatives must be manipulated or deleted as a group.
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              Send the email as usual.
+            </para>
+          </listitem>
+        </orderedlist>
+        <para>
+          If all the attachments have been grouped and form a single
+          <literal>multipart/alternative</literal>, part then this message will be sent
+          as a <literal>multipart/alternative</literal> email, otherwise it will be sent
+          as a <literal>multipart/mixed</literal> email.
+        </para>
+        <para>
+          Note that after grouping, you can't view, edit or break the
+          <literal>multipart/alternative</literal> bundle, because it is in a temporary
+          form. But you can view and edit its primitive part using the
+          <command>&lt;edit&gt;</command> command. When postponing emails or on error
+          (e.g., no recipients address when sending emails) this
+          <literal>multipart/alternative</literal> will be broken apart and need to
+          be tagged and group together again as described above.
+        </para>
+
+        <para>
+          Be aware that when sending a <literal>multipart/alternative</literal> email,
+          you have to manually prepare the alternative parts and attach them. However,
+          you can use Neomutt's macro to perform all the operations needed, such that
+          you can compose a plain text email as usual and turn that into a
+          <literal>multipart/alternative</literal> email in one single command, with
+          one part being <literal>text/plain</literal> and the other
+          <literal>text/html</literal>. An example macro will be the following:
+
+<screen>
+macro compose K "| pandoc -o /tmp/neomutt-alternative.html&lt;enter&gt; \
+    &lt;attach-file&gt;/tmp/neomutt-alternative.html&lt;enter&gt; \
+    &lt;tag-entry&gt;&lt;previous-entry&gt;&lt;tag-entry&gt;&lt;group-alternatives&gt;"
+</screen>
+        </para>
+      </sect2>
+    </sect1>
+
+    <sect1 id="multipart-multilingual">
+      <title>MIME Multipart/Multilingual</title>
+
       <para>
-        To remove a MIME type from the <command>alternative_order</command>
-        list, use the <command>unalternative_order</command> command.
+        Neomutt includes supports for reading and writing <literal>multipart/multilingual</literal>
+        emails. A <literal>multipart/multilingual</literal> email is like a
+        <literal>multipart/alternative</literal> email, except that it comes with parts of
+        different versions of languages instead of appearances. Its format is described by
+        <ulink url="https://tools.ietf.org/html/rfc8255">RFC8255</ulink>.
       </para>
+
+      <sect2 id="read-multipart-multilingual">
+        <title>Reading Multipart/Multilingual Emails</title>
+        <para>
+          Neomutt uses the <literal>$preferred_languages</literal> variable to determine which
+          languages to display when displaying a <literal>multipart/multilingual</literal> email.
+          You can have several preferred languages, separated by <literal>,</literal>
+<screen>
+set preferred_languages="fr,en,de"
+</screen>
+          Neomutt will try to match these strings again the multilingual header in the received
+          emails "by prefix", e.g., <literal>en</literal> will match both <literal>en</literal>
+          and <literal>en_US</literal>.
+        </para>
+
+        <para>
+          If <literal>$preferred_languages</literal> is not set, it default to None, and the
+          first part of the received <literal>multipart/multilingual</literal> email will be
+          displayed.
+        </para>
+      </sect2>
+
+      <sect2 id="compose-multipart-alternative">
+        <title>Composing Multipart/Multilingual Emails</title>
+        <para>
+          The procedures of composing a <literal>multipart/multilingual</literal> email is similar
+          to those in <link linkend="compose-alternative-order">Composing Multipart/Alternative</link>.
+          You have to prepare every part manually or using some scripts, and then tag and group them
+          together into a <literal>multipart/multilingual</literal> bundle before sending it:
+        </para>
+
+        <orderedlist>
+          <listitem>
+            <para>
+              Prepare parts of the multilingual emails.
+            </para>
+          </listitem>
+
+          <listitem>
+            <para>
+              Attach them as attachments.
+            </para>
+          </listitem>
+
+          <listitem>
+            <para>
+              Tag them with <command>&lt;tag-entry&gt;</command>
+            </para>
+          </listitem>
+
+          <listitem>
+            <para>
+              Edit the <literal>Content-Language</literal> header of every attachment with command
+              <command>&lt;edit-language&gt;</command> (default to <literal>Ctrl-L</literal>). This
+              is important, otherwise the recipient of this email will not know the corresponding
+              languages. You can set arbitrary string as <literal>Content-Language</literal>, but it
+              is recommended to set it as some common prefixes such as "en", "zh" and "fr".
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              Group all the tag messages together by <command>&lt;group-multilingual&gt;</command>
+              (default to <literal>^</literal>).
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              Send the email as usual.
+            </para>
+          </listitem>
+
+        </orderedlist>
+
+        <para>
+          As in <link linkend="compose-alternative-order">Composing Multipart/Alternative</link>, you can
+          also use Neomutt's macro and some external scripts to combine these procedure into one.
+        </para>
+
+        <para>
+          Note that after grouping, you can't view, edit or break the
+          <literal>multipart/multilingual</literal> email bundle, because it is in a temporary form.
+          But you can view and edit its primitive part using the <command>&lt;edit&gt;</command>
+          command. When postponing emails or on error (e.g., no recipients address when sending
+          emails) this <literal>multipart/multilingual</literal> will be broken apart and need to
+          be tagged and group together again as described above.
+        </para>
+      </sect2>
     </sect1>
 
     <sect1 id="attachments">

--- a/functions.h
+++ b/functions.h
@@ -436,6 +436,7 @@ const struct Binding OpCompose[] = { /* map: compose */
 #endif
   { "edit-from",             OP_COMPOSE_EDIT_FROM,           "\033f" },
   { "edit-headers",          OP_COMPOSE_EDIT_HEADERS,        "E" },
+  { "edit-language",         OP_COMPOSE_EDIT_LANGUAGE,       "\014" },
   { "edit-message",          OP_COMPOSE_EDIT_MESSAGE,        "e" },
   { "edit-mime",             OP_COMPOSE_EDIT_MIME,           "m" },
 #ifdef USE_NNTP
@@ -452,6 +453,7 @@ const struct Binding OpCompose[] = { /* map: compose */
   { "forget-passphrase",     OP_FORGET_PASSPHRASE,           "\006" },
   { "get-attachment",        OP_COMPOSE_GET_ATTACHMENT,      "G" },
   { "group-alternatives",    OP_COMPOSE_GROUP_ALTS,          "&" },
+  { "group-multilingual",    OP_COMPOSE_GROUP_LINGUAL,       "^" },
   { "ispell",                OP_COMPOSE_ISPELL,              "i" },
 #ifdef MIXMASTER
   { "mix",                   OP_COMPOSE_MIX,                 "M" },

--- a/functions.h
+++ b/functions.h
@@ -451,10 +451,13 @@ const struct Binding OpCompose[] = { /* map: compose */
   { "filter-entry",          OP_FILTER,                      "F" },
   { "forget-passphrase",     OP_FORGET_PASSPHRASE,           "\006" },
   { "get-attachment",        OP_COMPOSE_GET_ATTACHMENT,      "G" },
+  { "group-alternatives",    OP_COMPOSE_GROUP_ALTS,          "&" },
   { "ispell",                OP_COMPOSE_ISPELL,              "i" },
 #ifdef MIXMASTER
   { "mix",                   OP_COMPOSE_MIX,                 "M" },
 #endif
+  { "move-down",             OP_COMPOSE_MOVE_DOWN,           "+" },
+  { "move-up",               OP_COMPOSE_MOVE_UP,             "-" },
   { "new-mime",              OP_COMPOSE_NEW_MIME,            "n" },
   { "pgp-menu",              OP_COMPOSE_PGP_MENU,            "p" },
   { "pipe-entry",            OP_PIPE,                        "|" },

--- a/globals.h
+++ b/globals.h
@@ -236,6 +236,7 @@ WHERE short NntpContext;
 WHERE short MenuContext;
 WHERE short PagerContext;
 WHERE short PagerIndexLines;
+WHERE char *PreferredLanguages;
 WHERE short ReadInc;
 WHERE short ReflowWrap;
 WHERE short SendmailWait;

--- a/handler.c
+++ b/handler.c
@@ -1189,7 +1189,7 @@ static int multilingual_handler(struct Body *a, struct State *s)
   struct Body *b = NULL;
   bool mustfree = false;
   int rc = 0;
-  struct Body *first_multilingual_part = NULL;
+  struct Body *first_part = NULL;
   struct Body *zxx_part = NULL;
   char *lang;
 
@@ -1226,8 +1226,8 @@ static int multilingual_handler(struct Body *a, struct State *s)
     {
       if (mutt_can_decode(b))
       {
-        if (b->language && !first_multilingual_part)
-          first_multilingual_part = b;
+        if (!first_part)
+          first_part = b;
 
         if (b->language && (mutt_str_strcmp("zxx", b->language) == 0))
           zxx_part = b;
@@ -1264,7 +1264,7 @@ static int multilingual_handler(struct Body *a, struct State *s)
     if (zxx_part)
       mutt_body_handler(zxx_part, s);
     else
-      mutt_body_handler(first_multilingual_part, s);
+      mutt_body_handler(first_part, s);
   }
 
   if (mustfree)

--- a/handler.c
+++ b/handler.c
@@ -1178,6 +1178,102 @@ static int alternative_handler(struct Body *a, struct State *s)
 }
 
 /**
+ * multilingual_handler - Parse a multi-lingual email
+ * @param a Body of the email
+ * @param s State for the file containing the email
+ * @retval 0 Always
+ */
+static int multilingual_handler(struct Body *a, struct State *s)
+{
+  struct Body *choice = NULL;
+  struct Body *b = NULL;
+  bool mustfree = false;
+  int rc = 0;
+  struct Body *first_multilingual_part = NULL;
+  struct Body *zxx_part = NULL;
+  char *lang;
+
+  mutt_debug(2, "RFC8255 >> entering in handler multilingual handler\n");
+  if ((a->encoding == ENCBASE64) || (a->encoding == ENCQUOTEDPRINTABLE) ||
+      (a->encoding == ENCUUENCODED))
+  {
+    struct stat st;
+    mustfree = true;
+    fstat(fileno(s->fpin), &st);
+    b = mutt_body_new();
+    b->length = (long) st.st_size;
+    b->parts = mutt_parse_multipart(
+        s->fpin, mutt_param_get(&a->parameter, "boundary"), (long) st.st_size,
+        (mutt_str_strcasecmp("digest", a->subtype) == 0));
+  }
+  else
+    b = a;
+
+  a = b;
+
+  if (a->parts)
+    b = a->parts;
+  else
+    b = a;
+
+  mutt_debug(2, "RFC8255 >> preferred_languages set in config to '%s'\n", PreferredLanguages);
+  char *preferred_languages = mutt_str_strdup(PreferredLanguages);
+  lang = strtok(preferred_languages, ",");
+
+  while (lang)
+  {
+    while (b)
+    {
+      if (mutt_can_decode(b))
+      {
+        if (b->language && !first_multilingual_part)
+          first_multilingual_part = b;
+
+        if (b->language && (mutt_str_strcmp("zxx", b->language) == 0))
+          zxx_part = b;
+
+        mutt_debug(2, "RFC8255 >> comparing configuration preferred_language='%s' to mail part content-language='%s'\n",
+                   lang, b->language);
+        if (lang && b->language && (mutt_str_strcmp(lang, b->language) == 0))
+        {
+          mutt_debug(2, "RFC8255 >> preferred_language='%s' matches content-language='%s' >> part selected to be displayed\n",
+                     lang, b->language);
+          choice = b;
+          break;
+        }
+      }
+
+      b = b->next;
+    }
+
+    if (choice)
+      break;
+
+    lang = strtok(NULL, ",");
+
+    if (a->parts)
+      b = a->parts;
+    else
+      b = a;
+  }
+
+  if (choice)
+    mutt_body_handler(choice, s);
+  else
+  {
+    if (zxx_part)
+      mutt_body_handler(zxx_part, s);
+    else
+      mutt_body_handler(first_multilingual_part, s);
+  }
+
+  if (mustfree)
+    mutt_body_free(&a);
+
+  return rc;
+}
+
+/**
  * message_handler - handles message/rfc822 body parts
  */
 static int message_handler(struct Body *a, struct State *s)
@@ -1902,6 +1998,11 @@ int mutt_body_handler(struct Body *b, struct State *s)
         (mutt_str_strcasecmp("alternative", b->subtype) == 0))
     {
       handler = alternative_handler;
+    }
+    else if ((mutt_str_strcmp("inline", ShowMultipartAlternative) != 0) &&
+             (mutt_str_strcasecmp("multilingual", b->subtype) == 0))
+    {
+      handler = multilingual_handler;
     }
     else if ((WithCrypto != 0) && (mutt_str_strcasecmp("signed", b->subtype) == 0))
     {

--- a/init.h
+++ b/init.h
@@ -2792,6 +2792,12 @@ struct Option MuttVars[] = {
   ** remote machine without having to enter a password.
   */
 #endif /* USE_SOCKET */
+  { "preferred_languages", DT_STRING, R_NONE, &PreferredLanguages, 0 },
+  /*
+  ** .pp
+  ** RFC8255 : user preferred languages to be search in parts and display
+  ** Ex. : set preferred_languages="en,fr,de"
+  */
   { "print",            DT_QUAD, R_NONE, &Print, MUTT_ASKNO },
   /*
   ** .pp

--- a/mutt/mime.c
+++ b/mutt/mime.c
@@ -46,36 +46,6 @@ const int IndexHex[128] = {
     -1,10,11,12, 13,14,15,-1, -1,-1,-1,-1, -1,-1,-1,-1,
     -1,-1,-1,-1, -1,-1,-1,-1, -1,-1,-1,-1, -1,-1,-1,-1
 };
-
-/**
- * BodyLanguages - Common MIME body languages
- */
-const char *const BodyLanguages[] = {
-  "cs-cz",
-  "da", "da-dk",
-  "de", "de-at", "de-ch", "de-de",
-  "el", "el-gr",
-  "en", "en-au", "en-ca", "en-dk", "en-fi", "en-gb", "en-id", "en-ie", "en-il",
-  "en-in", "en-my", "en-no", "en-nz", "en-ph", "en-sg", "en-th", "en-us", "en-ww",
-  "en-xa", "en-za",
-  "es", "es-ar", "es-cl", "es-co", "es-es", "es-la", "es-mx", "es-pr", "es-us",
-  "fi", "fi-fi",
-  "fr", "fr-be", "fr-ca", "fr-ch", "fr-fr", "fr-lu",
-  "he", "he-il",
-  "hu", "hu-hu",
-  "it", "it-it",
-  "ja", "ja-jp",
-  "ko", "ko-kr",
-  "nl", "nl-be", "nl-nl",
-  "no", "no-no",
-  "pl", "pl-pl",
-  "pt", "pt-br", "pt-pt",
-  "ru", "ru-ru",
-  "sl", "sl-sl",
-  "sv", "sv-se",
-  "tr", "tr-tr",
-  "zh", "zh-cn", "zh-hk", "zh-tw",
-};
 // clang-format on
 
 /**
@@ -98,21 +68,3 @@ const char *const BodyEncodings[] = {
  * MimeSpecials - Characters that need special treatment in MIME
  */
 const char MimeSpecials[] = "@.,;:<>[]\\\"()?/= \t";
-
-/**
- * mutt_mime_valid_language - Is it a valid language code?
- * @param lang Language code to check (e.g., en)
- * @retval true Valid language code
- *
- * @note Currently this checking does not strictly adhere to RFC3282 and
- * RFC5646. See #BodyLanguages for all supported languages.
- */
-bool mutt_mime_valid_language(const char *lang)
-{
-  for (size_t i = 0; i < mutt_array_size(BodyLanguages); i++)
-  {
-    if (mutt_str_strcasecmp(lang, BodyLanguages[i]) == 0)
-      return true;
-  }
-  return false;
-}

--- a/mutt/mime.c
+++ b/mutt/mime.c
@@ -27,7 +27,10 @@
  */
 
 #include "config.h"
+#include <stdbool.h>
 #include "mime.h"
+#include "memory.h"
+#include "string2.h"
 
 // clang-format off
 /**
@@ -42,6 +45,36 @@ const int IndexHex[128] = {
     -1,-1,-1,-1, -1,-1,-1,-1, -1,-1,-1,-1, -1,-1,-1,-1,
     -1,10,11,12, 13,14,15,-1, -1,-1,-1,-1, -1,-1,-1,-1,
     -1,-1,-1,-1, -1,-1,-1,-1, -1,-1,-1,-1, -1,-1,-1,-1
+};
+
+/**
+ * BodyLanguages - Common MIME body languages
+ */
+const char *const BodyLanguages[] = {
+  "cs-cz",
+  "da", "da-dk",
+  "de", "de-at", "de-ch", "de-de",
+  "el", "el-gr",
+  "en", "en-au", "en-ca", "en-dk", "en-fi", "en-gb", "en-id", "en-ie", "en-il",
+  "en-in", "en-my", "en-no", "en-nz", "en-ph", "en-sg", "en-th", "en-us", "en-ww",
+  "en-xa", "en-za",
+  "es", "es-ar", "es-cl", "es-co", "es-es", "es-la", "es-mx", "es-pr", "es-us",
+  "fi", "fi-fi",
+  "fr", "fr-be", "fr-ca", "fr-ch", "fr-fr", "fr-lu",
+  "he", "he-il",
+  "hu", "hu-hu",
+  "it", "it-it",
+  "ja", "ja-jp",
+  "ko", "ko-kr",
+  "nl", "nl-be", "nl-nl",
+  "no", "no-no",
+  "pl", "pl-pl",
+  "pt", "pt-br", "pt-pt",
+  "ru", "ru-ru",
+  "sl", "sl-sl",
+  "sv", "sv-se",
+  "tr", "tr-tr",
+  "zh", "zh-cn", "zh-hk", "zh-tw",
 };
 // clang-format on
 
@@ -65,3 +98,21 @@ const char *const BodyEncodings[] = {
  * MimeSpecials - Characters that need special treatment in MIME
  */
 const char MimeSpecials[] = "@.,;:<>[]\\\"()?/= \t";
+
+/**
+ * mutt_mime_valid_language - Is it a valid language code?
+ * @param lang Language code to check (e.g., en)
+ * @retval true Valid language code
+ *
+ * @note Currently this checking does not strictly adhere to RFC3282 and
+ * RFC5646. See #BodyLanguages for all supported languages.
+ */
+bool mutt_mime_valid_language(const char *lang)
+{
+  for (size_t i = 0; i < mutt_array_size(BodyLanguages); i++)
+  {
+    if (mutt_str_strcasecmp(lang, BodyLanguages[i]) == 0)
+      return true;
+  }
+  return false;
+}

--- a/mutt/mime.h
+++ b/mutt/mime.h
@@ -23,6 +23,8 @@
 #ifndef _MUTT_MIME_H
 #define _MUTT_MIME_H
 
+#include <stdbool.h>
+
 /**
  * enum ContentType - Content-Type
  */
@@ -70,7 +72,10 @@ enum ContentDisposition
 extern const int IndexHex[128];
 extern const char *const BodyTypes[];
 extern const char *const BodyEncodings[];
+extern const char *const BodyLanguages[];
 extern const char MimeSpecials[];
+
+bool mutt_mime_valid_language(const char *lang);
 
 #define hexval(c) IndexHex[(unsigned int) (c)]
 

--- a/mutt/mime.h
+++ b/mutt/mime.h
@@ -72,10 +72,7 @@ enum ContentDisposition
 extern const int IndexHex[128];
 extern const char *const BodyTypes[];
 extern const char *const BodyEncodings[];
-extern const char *const BodyLanguages[];
 extern const char MimeSpecials[];
-
-bool mutt_mime_valid_language(const char *lang);
 
 #define hexval(c) IndexHex[(unsigned int) (c)]
 

--- a/opcodes.h
+++ b/opcodes.h
@@ -64,7 +64,10 @@
   _fmt(OP_COMPOSE_EDIT_TO,                N_("edit the TO list")) \
   _fmt(OP_COMPOSE_EDIT_X_COMMENT_TO,      N_("edit the X-Comment-To field")) \
   _fmt(OP_COMPOSE_GET_ATTACHMENT,         N_("get a temporary copy of an attachment")) \
+  _fmt(OP_COMPOSE_GROUP_ALTS,             N_("group tagged attachments as multipart/alternative")) \
   _fmt(OP_COMPOSE_ISPELL,                 N_("run ispell on the message")) \
+  _fmt(OP_COMPOSE_MOVE_DOWN,              N_("move an attachment down in the attachment list")) \
+  _fmt(OP_COMPOSE_MOVE_UP,                N_("move an attachment up in the attachment list")) \
   _fmt(OP_COMPOSE_NEW_MIME,               N_("compose new attachment using mailcap entry")) \
   _fmt(OP_COMPOSE_POSTPONE_MESSAGE,       N_("save this message to send later")) \
   _fmt(OP_COMPOSE_RENAME_ATTACHMENT,      N_("send attachment with a different name")) \

--- a/opcodes.h
+++ b/opcodes.h
@@ -56,6 +56,7 @@
   _fmt(OP_COMPOSE_EDIT_FOLLOWUP_TO,       N_("edit the Followup-To field")) \
   _fmt(OP_COMPOSE_EDIT_FROM,              N_("edit the from field")) \
   _fmt(OP_COMPOSE_EDIT_HEADERS,           N_("edit the message with headers")) \
+  _fmt(OP_COMPOSE_EDIT_LANGUAGE,          N_("edit the Content-Language of the attachment")) \
   _fmt(OP_COMPOSE_EDIT_MESSAGE,           N_("edit the message")) \
   _fmt(OP_COMPOSE_EDIT_MIME,              N_("edit attachment using mailcap entry")) \
   _fmt(OP_COMPOSE_EDIT_NEWSGROUPS,        N_("edit the newsgroups list")) \
@@ -65,6 +66,7 @@
   _fmt(OP_COMPOSE_EDIT_X_COMMENT_TO,      N_("edit the X-Comment-To field")) \
   _fmt(OP_COMPOSE_GET_ATTACHMENT,         N_("get a temporary copy of an attachment")) \
   _fmt(OP_COMPOSE_GROUP_ALTS,             N_("group tagged attachments as multipart/alternative")) \
+  _fmt(OP_COMPOSE_GROUP_LINGUAL,          N_("group tagged attachments as multipart/multilingual")) \
   _fmt(OP_COMPOSE_ISPELL,                 N_("run ispell on the message")) \
   _fmt(OP_COMPOSE_MOVE_DOWN,              N_("move an attachment down in the attachment list")) \
   _fmt(OP_COMPOSE_MOVE_UP,                N_("move an attachment up in the attachment list")) \

--- a/parse.c
+++ b/parse.c
@@ -383,6 +383,20 @@ void mutt_parse_content_type(char *s, struct Body *ct)
   }
 }
 
+/**
+ * mutt_parse_content_language - Read the content's language
+ * @param s  Language string
+ * @param ct Body of the email
+ */
+static void mutt_parse_content_language(char *s, struct Body *ct)
+{
+  if (!s || !ct)
+    return;
+
+  mutt_debug(2, "RFC8255 >> Content-Language set to %s\n", s);
+  ct->language = mutt_str_strdup(s);
+}
+
 static void parse_content_disposition(const char *s, struct Body *ct)
 {
   struct ParameterList parms;
@@ -453,6 +467,8 @@ struct Body *mutt_read_mime_header(FILE *fp, int digest)
     {
       if (mutt_str_strcasecmp("type", line + 8) == 0)
         mutt_parse_content_type(c, p);
+      else if (mutt_str_strcasecmp("language", line + 8) == 0)
+        mutt_parse_content_language(c, p);
       else if (mutt_str_strcasecmp("transfer-encoding", line + 8) == 0)
         p->encoding = mutt_check_encoding(c);
       else if (mutt_str_strcasecmp("disposition", line + 8) == 0)
@@ -796,6 +812,12 @@ int mutt_rfc822_parse_line(struct Envelope *e, struct Header *hdr, char *line,
         {
           if (hdr)
             mutt_parse_content_type(p, hdr->content);
+          matched = 1;
+        }
+        else if (mutt_str_strcasecmp(line + 8, "language") == 0)
+        {
+          if (hdr)
+            mutt_parse_content_language(p, hdr->content);
           matched = 1;
         }
         else if (mutt_str_strcasecmp(line + 8, "transfer-encoding") == 0)

--- a/sendlib.c
+++ b/sendlib.c
@@ -366,7 +366,7 @@ int mutt_write_mime_header(struct Body *a, FILE *f)
     {
       fprintf(f, "Content-Disposition: %s", dispstr[a->disposition]);
 
-      if (a->use_disp)
+      if (a->use_disp && (a->disposition != DISPINLINE))
       {
         char *fn = a->d_filename;
         if (!fn)

--- a/sendlib.c
+++ b/sendlib.c
@@ -355,6 +355,9 @@ int mutt_write_mime_header(struct Body *a, FILE *f)
 
   fputc('\n', f);
 
+  if (a->language)
+    fprintf(f, "Content-Language: %s\n", a->language);
+
   if (a->description)
     fprintf(f, "Content-Description: %s\n", a->description);
 


### PR DESCRIPTION
* **What does this PR do?**

- Allows reordering email attachments.

- Allow joining several attachments as a single `multipart/alternative` attachment.

This is still WIP, mutt segfaults right after sending the email.

This is the work of @oblitium, based on this unattributed patch:
https://github.com/altercation/arch-packages/blob/master/mutt-dgc-hg/dgc.groupalts

* **Are there points in the code the reviewer needs to double check?**

Everything?

* **Does this PR meet the acceptance criteria?** (This is just a reminder for you,
  this section can be removed if you fulfill it.)

   - Documentation created/updated (you have to edit
     [doc/manual.xml.head](https://www.github.com/neomutt/neomutt/blob/master/doc/manual.xml.head)
     for that)

   - All builds are passing

   - Added [doxygen code documentation](https://www.neomutt.org/dev/doxygen)
     [syntax](http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html)

   - Code follows the [style guide](https://www.neomutt.org/dev/coding-style)

* **What are the relevant issue numbers?**

References #587