### PR TITLE
restore ~/.config/mutt to config search path

### DIFF
--- a/doc/manual.xml.head
+++ b/doc/manual.xml.head
@@ -2898,9 +2898,6 @@ color sidebar_divider   color8  default
         <tgroup cols="1">
           <tbody>
             <row>
-              <entry>neomuttrc-20170912</entry>
-            </row>
-            <row>
               <entry>neomuttrc</entry>
             </row>
             <row>
@@ -2939,10 +2936,6 @@ color sidebar_divider   color8  default
             </thead>
             <tbody>
               <row>
-                <entry>/etc/xdg/neomutt/neomuttrc-20170912</entry>
-                <entry>NeoMutt release version</entry>
-              </row>
-              <row>
                 <entry>/etc/xdg/neomutt/neomuttrc</entry>
               </row>
               <row>
@@ -2950,19 +2943,11 @@ color sidebar_divider   color8  default
                 <entry>Note the case of the filename</entry>
               </row>
               <row>
-                <entry>/etc/neomuttrc-20170912</entry>
-                <entry>NeoMutt release version</entry>
-              </row>
-              <row>
                 <entry>/etc/neomuttrc</entry>
               </row>
               <row>
                 <entry>/etc/Muttrc</entry>
                 <entry>Note the case of the filename</entry>
-              </row>
-              <row>
-                <entry>/usr/share/neomutt/neomuttrc-20170912</entry>
-                <entry>NeoMutt release version</entry>
               </row>
               <row>
                 <entry>/usr/share/neomutt/neomuttrc</entry>
@@ -2983,7 +2968,7 @@ color sidebar_divider   color8  default
         <literal>XDG_CONFIG_HOME</literal> environment variable, which defaults
         to
         <literal>~/.config/neomutt</literal>. Next, it looks in
-        <literal>~</literal>(your home directory). Finally, it tries
+        <literal>~</literal> (your home directory). Finally, it tries
         <literal>~/.neomutt</literal>.</para>
         <para>You may specify your own location for the user config file using
         the
@@ -2994,18 +2979,13 @@ color sidebar_divider   color8  default
 
         <table id="neomuttrc-user-files">
           <title>NeoMutt user config file locations</title>
-          <tgroup cols="2">
+          <tgroup cols="1">
             <thead>
               <row>
                 <entry>File Location</entry>
-                <entry>Notes</entry>
               </row>
             </thead>
             <tbody>
-              <row>
-                <entry>~/.config/neomutt/neomuttrc-20170912</entry>
-                <entry>NeoMutt release version</entry>
-              </row>
               <row>
                 <entry>~/.config/neomutt/neomuttrc</entry>
               </row>
@@ -3013,8 +2993,10 @@ color sidebar_divider   color8  default
                 <entry>~/.config/neomutt/muttrc</entry>
               </row>
               <row>
-                <entry>~/.neomutt/neomuttrc-20170912</entry>
-                <entry>NeoMutt release version</entry>
+                <entry>~/.config/mutt/neomuttrc</entry>
+              </row>
+              <row>
+                <entry>~/.config/mutt/muttrc</entry>
               </row>
               <row>
                 <entry>~/.neomutt/neomuttrc</entry>
@@ -3023,18 +3005,10 @@ color sidebar_divider   color8  default
                 <entry>~/.neomutt/muttrc</entry>
               </row>
               <row>
-                <entry>~/.mutt/neomuttrc-20170912</entry>
-                <entry>NeoMutt release version</entry>
-              </row>
-              <row>
                 <entry>~/.mutt/neomuttrc</entry>
               </row>
               <row>
                 <entry>~/.mutt/muttrc</entry>
-              </row>
-              <row>
-                <entry>~/.neomuttrc-20170912</entry>
-                <entry>NeoMutt release version</entry>
               </row>
               <row>
                 <entry>~/.neomuttrc</entry>

--- a/init.c
+++ b/init.c
@@ -4042,34 +4042,24 @@ static int execute_commands(struct ListHead *p)
 static char *find_cfg(const char *home, const char *xdg_cfg_home)
 {
   const char *names[] = {
-    "neomuttrc-" PACKAGE_VERSION, "neomuttrc", "muttrc", NULL,
+    "neomuttrc", "muttrc", NULL,
   };
 
   const char *locations[][2] = {
-    {
-        xdg_cfg_home, "neomutt/",
-    },
-    {
-        home, ".neomutt/",
-    },
-    {
-        home, ".mutt/",
-    },
-    {
-        home, ".",
-    },
-    {
-        NULL, NULL,
-    },
+    { xdg_cfg_home, "neomutt/" },
+    { xdg_cfg_home, "mutt/" },
+    { home, ".neomutt/" },
+    { home, ".mutt/" },
+    { home, "." },
+    { NULL, NULL },
   };
+
   for (int i = 0; locations[i][0] || locations[i][1]; i++)
   {
-    int j;
-
     if (!locations[i][0])
       continue;
 
-    for (j = 0; names[j]; j++)
+    for (int j = 0; names[j]; j++)
     {
       char buffer[STRING];
 
@@ -4384,19 +4374,11 @@ void mutt_init(int skip_sys_rc, struct ListHead *commands)
       if (mutt_set_xdg_path(XDG_CONFIG_DIRS, buffer, sizeof(buffer)))
         break;
 
-      snprintf(buffer, sizeof(buffer), "%s/neomuttrc-%s", SYSCONFDIR, PACKAGE_VERSION);
-      if (access(buffer, F_OK) == 0)
-        break;
-
       snprintf(buffer, sizeof(buffer), "%s/neomuttrc", SYSCONFDIR);
       if (access(buffer, F_OK) == 0)
         break;
 
       snprintf(buffer, sizeof(buffer), "%s/Muttrc", SYSCONFDIR);
-      if (access(buffer, F_OK) == 0)
-        break;
-
-      snprintf(buffer, sizeof(buffer), "%s/neomuttrc-%s", PKGDATADIR, PACKAGE_VERSION);
       if (access(buffer, F_OK) == 0)
         break;
 

--- a/muttlib.c
+++ b/muttlib.c
@@ -1758,15 +1758,6 @@ int mutt_set_xdg_path(enum XdgType type, char *buf, size_t bufsize)
 
   while ((token = strsep(&xdg, ":")))
   {
-    if (snprintf(buf, bufsize, "%s/%s/neomuttrc-%s", token, PACKAGE, PACKAGE_VERSION) < 0)
-      continue;
-    mutt_expand_path(buf, bufsize);
-    if (access(buf, F_OK) == 0)
-    {
-      rc = 1;
-      break;
-    }
-
     if (snprintf(buf, bufsize, "%s/%s/neomuttrc", token, PACKAGE) < 0)
       continue;
     mutt_expand_path(buf, bufsize);


### PR DESCRIPTION
Some people are still using this dir.
It will be deprecated in the future.

Also, drop the dated/versioned config files.
Nobody was using them.

    ~/.mutt/neomutt-20170912

* **What does this PR do?**

* **Are there points in the code the reviewer needs to double check?**

* **Screenshots (if relevant)**

* **Does this PR meet the acceptance criteria?** (This is just a reminder for you,
  this section can be removed if you fulfill it.)

   - Documentation created/updated (you have to edit
     [doc/manual.xml.head](https://www.github.com/neomutt/neomutt/blob/master/doc/manual.xml.head)
     for that)

   - All builds are passing

   - Added [doxygen code documentation](https://www.neomutt.org/dev/doxygen)
     [syntax](http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html)

   - Code follows the [style guide](https://www.neomutt.org/dev/coding-style)

* **What are the relevant issue numbers?**
