### PR TITLE
tags: always pass correct buffer length

### DIFF
--- a/curs_main.c
+++ b/curs_main.c
@@ -1867,7 +1867,7 @@ int mutt_index_menu(void)
         CHECK_VISIBLE;
         CHECK_READONLY;
 
-        rc = hdr_tags_editor(Context, tag ? NULL : hdr_tags_get_with_hidden(CURHDR), buf);
+        rc = hdr_tags_editor(Context, tag ? NULL : hdr_tags_get_with_hidden(CURHDR), buf, sizeof(buf));
         if (rc < 0)
           break;
         else if (rc == 0)

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -1249,7 +1249,7 @@ static int sync_helper(struct ImapData *idata, int right, int flag, const char *
  * @retval 0: no valid user input
  * @retval 1: buf set
  */
-static int imap_edit_message_tags(struct Context *ctx, const char *tags, char *buf)
+static int imap_edit_message_tags(struct Context *ctx, const char *tags, char *buf, size_t buflen)
 {
   char *new = NULL;
   char *checker = NULL;
@@ -1264,9 +1264,9 @@ static int imap_edit_message_tags(struct Context *ctx, const char *tags, char *b
 
   *buf = '\0';
   if (tags)
-    strncpy(buf, tags, LONG_STRING);
+    strncpy(buf, tags, buflen);
 
-  if (mutt_get_field("Keywords: ", buf, LONG_STRING, 0) != 0)
+  if (mutt_get_field("Keywords: ", buf, buflen, 0) != 0)
     return -1;
 
   /* each keyword must be atom defined by rfc822 as:

--- a/mutt_notmuch.c
+++ b/mutt_notmuch.c
@@ -1847,10 +1847,10 @@ void nm_query_window_backward(void)
   mutt_debug(2, "nm_query_window_backward (%d)\n", NmQueryWindowCurrentPosition);
 }
 
-static int nm_edit_message_tags(struct Context *ctx, const char *tags, char *buf)
+static int nm_edit_message_tags(struct Context *ctx, const char *tags, char *buf, size_t buflen)
 {
   *buf = '\0';
-  return (mutt_get_field("Add/remove labels: ", buf, sizeof(buf), MUTT_NM_TAG) || !*buf);
+  return (mutt_get_field("Add/remove labels: ", buf, buflen, MUTT_NM_TAG) || !*buf);
 }
 
 static int nm_commit_message_tags(struct Context *ctx, struct Header *hdr, char *buf)

--- a/mutt_tags.c
+++ b/mutt_tags.c
@@ -224,10 +224,10 @@ int hdr_tags_replace(struct Header *h, char *tags)
   return 1;
 }
 
-int hdr_tags_editor(struct Context *ctx, const char *tags, char *buf)
+int hdr_tags_editor(struct Context *ctx, const char *tags, char *buf, size_t buflen)
 {
   if (ctx->mx_ops->edit_msg_tags)
-    return ctx->mx_ops->edit_msg_tags(ctx, tags, buf);
+    return ctx->mx_ops->edit_msg_tags(ctx, tags, buf, buflen);
 
   mutt_message(_("Folder doesn't support tagging, aborting."));
   return -1;

--- a/mutt_tags.h
+++ b/mutt_tags.h
@@ -66,7 +66,7 @@ const char *hdr_tags_get_transformed_for(char *name, struct Header *h);
 void hdr_tags_init(struct Header *h);
 void hdr_tags_add(struct Header *h, char *new_tag);
 int hdr_tags_replace(struct Header *h, char *tags);
-int hdr_tags_editor(struct Context *ctx, const char *tags, char *buf);
+int hdr_tags_editor(struct Context *ctx, const char *tags, char *buf, size_t buflen);
 int hdr_tags_commit(struct Context *ctx, struct Header *h, char *tags);
 
 #endif /* _MUTT_TAG_H */

--- a/mx.h
+++ b/mx.h
@@ -63,7 +63,7 @@ struct MxOps
   int (*close_msg)(struct Context *ctx, struct Message *msg);
   int (*commit_msg)(struct Context *ctx, struct Message *msg);
   int (*open_new_msg)(struct Message *msg, struct Context *ctx, struct Header *hdr);
-  int (*edit_msg_tags)(struct Context *ctx, const char *tags, char *buf);
+  int (*edit_msg_tags)(struct Context *ctx, const char *tags, char *buf, size_t buflen);
   int (*commit_msg_tags)(struct Context *msg, struct Header *hdr, char *buf);
 };
 


### PR DESCRIPTION
In notmuch editor we was passing sizeof(buf) with buf a char* with an
unknown allocated size.

In imap, we have assumed/hardcoded LONGSTRING. That's true, but we
should not do that.

edit_msg_tags() now takes the buflen as parameter so the root caller
can pass the size of the buffer.