### PR TITLE
build: add -lidn when idn is enabled

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -258,27 +258,6 @@ AS_IF([test x$use_lua = "xyes"], [
 	LIBS="$LIBS $LUA_LIB"
 ])
 
-dnl --enable-notmuch
-AS_IF([test x$use_notmuch = "xyes"], [
-	AC_CHECK_LIB(notmuch, notmuch_database_open, [:],
-		AC_MSG_ERROR([Unable to find Notmuch library]))
-	AC_DEFINE(USE_NOTMUCH,1,[ Define if you want support for the notmuch. ])
-	MUTT_LIB_OBJECTS="$MUTT_LIB_OBJECTS mutt_notmuch.o"
-	LIBS="$LIBS -lnotmuch"
-
-	AC_MSG_CHECKING([for notmuch api version 3])
-	AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
-		[[#include <notmuch.h>]],
-		[[notmuch_database_open("/path", NOTMUCH_DATABASE_MODE_READ_ONLY, (notmuch_database_t**)NULL);]]
-	)], [
-		notmuch_api_3=yes
-		AC_DEFINE([NOTMUCH_API_3], 1, [Define to 1 if you have the notmuch api version 3.])
-	], [
-		notmuch_api_3=no
-	])
-	AC_MSG_RESULT([$notmuch_api_3])
-])
-
 dnl --with-mixmaster
 AS_IF([test "$with_mixmaster" != "no"], [
 	AS_IF([test -x "$with_mixmaster"], [MIXMASTER="$with_mixmaster"], [MIXMASTER="mixmaster"])
@@ -883,6 +862,27 @@ if test "x$with_idn" != "xno"; then
 		fi
 	fi
 fi
+
+dnl --enable-notmuch
+AS_IF([test x$use_notmuch = "xyes"], [
+	AC_CHECK_LIB(notmuch, notmuch_database_open, [:],
+		AC_MSG_ERROR([Unable to find Notmuch library]))
+	AC_DEFINE(USE_NOTMUCH,1,[ Define if you want support for the notmuch. ])
+	MUTT_LIB_OBJECTS="$MUTT_LIB_OBJECTS mutt_notmuch.o"
+	LIBS="$LIBS -lnotmuch"
+
+	AC_MSG_CHECKING([for notmuch api version 3])
+	AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
+		[[#include <notmuch.h>]],
+		[[notmuch_database_open("/path", NOTMUCH_DATABASE_MODE_READ_ONLY, (notmuch_database_t**)NULL);]]
+	)], [
+		notmuch_api_3=yes
+		AC_DEFINE([NOTMUCH_API_3], 1, [Define to 1 if you have the notmuch api version 3.])
+	], [
+		notmuch_api_3=no
+	])
+	AC_MSG_RESULT([$notmuch_api_3])
+])
 
 dnl -- locales --
 AC_CACHE_CHECK([for wchar_t functions], mutt_cv_wc_funcs,


### PR DESCRIPTION
**What does this PR do?**
Add a missing `-lidn` when building with `idn` support to fix neomutt on NixOS.

Neomutt didn't have access to `libidn.so` (during runtime) since it was not specified during linking.

It seems that https://github.com/neomutt/neomutt/commit/abfe0f14d2c98d17a2ce39e14a377782e1aa732d#diff-67e997bcfdac55191033d57a16d1408aL887 introduced that issue and only appeared when I did run the 20170912 release on my NixOS machine.