### PR TITLE
Devel/issue 774 attach.h

### DIFF
--- a/attach.h
+++ b/attach.h
@@ -68,28 +68,35 @@ struct AttachCtx
   short body_max;
 };
 
-void mutt_attach_init (struct AttachCtx *actx);
+void mutt_attach_init(struct AttachCtx *actx);
 void mutt_update_tree(struct AttachCtx *actx);
 int mutt_view_attachment(FILE *fp, struct Body *a, int flag, struct Header *hdr,
                          struct AttachCtx *actx);
 
 int mutt_tag_attach(struct Menu *menu, int n, int m);
-int mutt_attach_display_loop (struct Menu *menu, int op, struct Header *hdr,
-                              struct AttachCtx *acvtx, int recv);
+int mutt_attach_display_loop(struct Menu *menu, int op, struct Header *hdr,
+                             struct AttachCtx *acvtx, bool recv);
 
-void mutt_save_attachment_list (struct AttachCtx *actx, FILE *fp, int tag, struct Body *top, struct Header *hdr, struct Menu *menu);
-void mutt_pipe_attachment_list (struct AttachCtx *actx, FILE *fp, int tag, struct Body *top, int filter);
-void mutt_print_attachment_list (struct AttachCtx *actx, FILE *fp, int tag, struct Body *top);
+void mutt_save_attachment_list(struct AttachCtx *actx, FILE *fp, bool tag,
+                               struct Body *top, struct Header *hdr, struct Menu *menu);
+void mutt_pipe_attachment_list(struct AttachCtx *actx, FILE *fp, bool tag,
+                               struct Body *top, bool filter);
+void mutt_print_attachment_list(struct AttachCtx *actx, FILE *fp, bool tag,
+                                struct Body *top);
 
-void mutt_attach_bounce(FILE *fp, struct Header *hdr, struct AttachCtx *actx, struct Body *cur);
-void mutt_attach_resend(FILE *fp, struct Header *hdr, struct AttachCtx *actx, struct Body *cur);
-void mutt_attach_forward(FILE *fp, struct Header *hdr, struct AttachCtx *actx, struct Body *cur, int flags);
-void mutt_attach_reply(FILE *fp, struct Header *hdr, struct AttachCtx *actx, struct Body *cur, int flags);
+void mutt_attach_bounce(FILE *fp, struct Header *hdr, struct AttachCtx *actx,
+                        struct Body *cur);
+void mutt_attach_resend(FILE *fp, struct Header *hdr, struct AttachCtx *actx,
+                        struct Body *cur);
+void mutt_attach_forward(FILE *fp, struct Header *hdr, struct AttachCtx *actx,
+                         struct Body *cur, int flags);
+void mutt_attach_reply(FILE *fp, struct Header *hdr, struct AttachCtx *actx,
+                       struct Body *cur, int flags);
 
-void mutt_actx_add_attach (struct AttachCtx *actx, struct AttachPtr *attach);
-void mutt_actx_add_fp (struct AttachCtx *actx, FILE *new_fp);
-void mutt_actx_add_body (struct AttachCtx *actx, struct Body *new_body);
-void mutt_actx_free_entries (struct AttachCtx *actx);
+void mutt_actx_add_attach(struct AttachCtx *actx, struct AttachPtr *attach);
+void mutt_actx_add_fp(struct AttachCtx *actx, FILE *new_fp);
+void mutt_actx_add_body(struct AttachCtx *actx, struct Body *new_body);
+void mutt_actx_free_entries(struct AttachCtx *actx);
 void mutt_free_attach_context(struct AttachCtx **pactx);
 
 #endif /* _MUTT_ATTACH_H */

--- a/compose.c
+++ b/compose.c
@@ -1473,7 +1473,7 @@ int mutt_compose_menu(struct Header *msg, /* structure for new message */
       case OP_VIEW_ATTACH:
       case OP_DISPLAY_HEADERS:
         CHECK_COUNT;
-        mutt_attach_display_loop(menu, op, NULL, actx, 0);
+        mutt_attach_display_loop(menu, op, NULL, actx, false);
         menu->redraw = REDRAW_FULL;
         /* no send2hook, since this doesn't modify the message */
         break;

--- a/menu.c
+++ b/menu.c
@@ -1099,7 +1099,7 @@ int mutt_menu_loop(struct Menu *menu)
      * the prefix on a timeout (i==-2), but do clear on an abort (i==-1)
      */
     if (menu->tagprefix && i != OP_TAG_PREFIX && i != OP_TAG_PREFIX_COND && i != -2)
-      menu->tagprefix = 0;
+      menu->tagprefix = false;
 
     mutt_curs_set(0);
 
@@ -1135,14 +1135,14 @@ int mutt_menu_loop(struct Menu *menu)
     {
       if (menu->tagprefix)
       {
-        menu->tagprefix = 0;
+        menu->tagprefix = false;
         mutt_window_clearline(menu->messagewin, 0);
         continue;
       }
 
       if (menu->tagged)
       {
-        menu->tagprefix = 1;
+        menu->tagprefix = true;
         continue;
       }
       else if (i == OP_TAG_PREFIX)
@@ -1158,7 +1158,7 @@ int mutt_menu_loop(struct Menu *menu)
       }
     }
     else if (menu->tagged && option(OPT_AUTO_TAG))
-      menu->tagprefix = 1;
+      menu->tagprefix = true;
 
     mutt_curs_set(1);
 

--- a/mutt_menu.h
+++ b/mutt_menu.h
@@ -59,7 +59,7 @@ struct Menu
   int menu;    /**< menu definition for keymap entries. */
   int offset;  /**< row offset within the window to start the index */
   int pagelen; /**< number of entries per screen */
-  int tagprefix;
+  bool tagprefix : 1;
   int is_mailbox_list;
   struct MuttWindow *indexwin;
   struct MuttWindow *statuswin;

--- a/pager.c
+++ b/pager.c
@@ -2862,7 +2862,7 @@ int mutt_pager(const char *banner, const char *fname, int flags, struct Pager *e
       case OP_PIPE:
         CHECK_MODE(IsHeader(extra) || IsAttach(extra));
         if (IsAttach(extra))
-          mutt_pipe_attachment_list(extra->actx, extra->fp, 0, extra->bdy, 0);
+          mutt_pipe_attachment_list(extra->actx, extra->fp, false, extra->bdy, false);
         else
           mutt_pipe_message(extra->hdr);
         break;
@@ -2870,7 +2870,7 @@ int mutt_pager(const char *banner, const char *fname, int flags, struct Pager *e
       case OP_PRINT:
         CHECK_MODE(IsHeader(extra) || IsAttach(extra));
         if (IsAttach(extra))
-          mutt_print_attachment_list(extra->actx, extra->fp, 0, extra->bdy);
+          mutt_print_attachment_list(extra->actx, extra->fp, false, extra->bdy);
         else
           mutt_print_message(extra->hdr);
         break;
@@ -2993,7 +2993,7 @@ int mutt_pager(const char *banner, const char *fname, int flags, struct Pager *e
       case OP_SAVE:
         if (IsAttach(extra))
         {
-          mutt_save_attachment_list(extra->actx, extra->fp, 0, extra->bdy, extra->hdr, NULL);
+          mutt_save_attachment_list(extra->actx, extra->fp, false, extra->bdy, extra->hdr, NULL);
           break;
         }
       /* fall through */

--- a/recvattach.c
+++ b/recvattach.c
@@ -507,7 +507,7 @@ static int query_save_attachment(FILE *fp, struct Body *body,
   return 0;
 }
 
-void mutt_save_attachment_list(struct AttachCtx *actx, FILE *fp, int tag,
+void mutt_save_attachment_list(struct AttachCtx *actx, FILE *fp, bool tag,
                                struct Body *top, struct Header *hdr, struct Menu *menu)
 {
   char buf[_POSIX_PATH_MAX], tfile[_POSIX_PATH_MAX];
@@ -592,7 +592,7 @@ void mutt_save_attachment_list(struct AttachCtx *actx, FILE *fp, int tag,
     mutt_message(_("Attachment saved."));
 }
 
-static void query_pipe_attachment(char *command, FILE *fp, struct Body *body, int filter)
+static void query_pipe_attachment(char *command, FILE *fp, struct Body *body, bool filter)
 {
   char tfile[_POSIX_PATH_MAX];
   char warning[STRING + _POSIX_PATH_MAX];
@@ -653,8 +653,8 @@ static void pipe_attachment(FILE *fp, struct Body *b, struct State *state)
   }
 }
 
-static void pipe_attachment_list(char *command, struct AttachCtx *actx, FILE *fp, int tag,
-                                 struct Body *top, int filter, struct State *state)
+static void pipe_attachment_list(char *command, struct AttachCtx *actx, FILE *fp, bool tag,
+                                 struct Body *top, bool filter, struct State *state)
 {
   int i;
 
@@ -677,15 +677,15 @@ static void pipe_attachment_list(char *command, struct AttachCtx *actx, FILE *fp
   }
 }
 
-void mutt_pipe_attachment_list(struct AttachCtx *actx, FILE *fp, int tag,
-                               struct Body *top, int filter)
+void mutt_pipe_attachment_list(struct AttachCtx *actx, FILE *fp, bool tag,
+                               struct Body *top, bool filter)
 {
   struct State state;
   char buf[SHORT_STRING];
   pid_t thepid;
 
   if (fp)
-    filter = 0; /* sanity check: we can't filter in the recv case yet */
+    filter = false; /* sanity check: we can't filter in the recv case yet */
 
   buf[0] = 0;
   memset(&state, 0, sizeof(struct State));
@@ -712,7 +712,7 @@ void mutt_pipe_attachment_list(struct AttachCtx *actx, FILE *fp, int tag,
     pipe_attachment_list(buf, actx, fp, tag, top, filter, &state);
 }
 
-static int can_print(struct AttachCtx *actx, struct Body *top, int tag)
+static bool can_print(struct AttachCtx *actx, struct Body *top, bool tag)
 {
   char type[STRING];
 
@@ -731,7 +731,7 @@ static int can_print(struct AttachCtx *actx, struct Body *top, int tag)
           if (!mutt_can_decode(top))
           {
             mutt_error(_("I don't know how to print %s attachments!"), type);
-            return 0;
+            return false;
           }
         }
       }
@@ -739,10 +739,10 @@ static int can_print(struct AttachCtx *actx, struct Body *top, int tag)
     if (!tag)
       break;
   }
-  return 1;
+  return true;
 }
 
-static void print_attachment_list(struct AttachCtx *actx, FILE *fp, int tag,
+static void print_attachment_list(struct AttachCtx *actx, FILE *fp, bool tag,
                                   struct Body *top, struct State *state)
 {
   char type[STRING];
@@ -791,7 +791,7 @@ static void print_attachment_list(struct AttachCtx *actx, FILE *fp, int tag,
   }
 }
 
-void mutt_print_attachment_list(struct AttachCtx *actx, FILE *fp, int tag, struct Body *top)
+void mutt_print_attachment_list(struct AttachCtx *actx, FILE *fp, bool tag, struct Body *top)
 {
   struct State state;
 
@@ -870,7 +870,7 @@ static void recvattach_edit_content_type(struct AttachCtx *actx,
 }
 
 int mutt_attach_display_loop(struct Menu *menu, int op, struct Header *hdr,
-                             struct AttachCtx *actx, int recv)
+                             struct AttachCtx *actx, bool recv)
 {
   do
   {
@@ -1157,7 +1157,7 @@ void mutt_view_attachments(struct Header *hdr)
 
       case OP_DISPLAY_HEADERS:
       case OP_VIEW_ATTACH:
-        op = mutt_attach_display_loop(menu, op, hdr, actx, 1);
+        op = mutt_attach_display_loop(menu, op, hdr, actx, true);
         menu->redraw = REDRAW_FULL;
         continue;
 
@@ -1198,7 +1198,7 @@ void mutt_view_attachments(struct Header *hdr)
 
       case OP_PIPE:
         mutt_pipe_attachment_list(actx, CURATTACH->fp, menu->tagprefix,
-                                  CURATTACH->content, 0);
+                                  CURATTACH->content, false);
         break;
 
       case OP_SAVE:

--- a/recvcmd.c
+++ b/recvcmd.c
@@ -58,7 +58,7 @@ static bool check_msg(struct Body *b, bool err)
   return true;
 }
 
-static bool check_all_msg(struct AttachCtx *actx, struct Body *cur, short err)
+static bool check_all_msg(struct AttachCtx *actx, struct Body *cur, bool err)
 {
   if (cur && !check_msg(cur, err))
     return false;
@@ -79,16 +79,16 @@ static bool check_all_msg(struct AttachCtx *actx, struct Body *cur, short err)
 /**
  * check_can_decode - can we decode all tagged attachments?
  */
-static short check_can_decode(struct AttachCtx *actx, struct Body *cur)
+static bool check_can_decode(struct AttachCtx *actx, struct Body *cur)
 {
   if (cur)
     return mutt_can_decode(cur);
 
   for (short i = 0; i < actx->idxlen; i++)
     if (actx->idx[i]->content->tagged && !mutt_can_decode(actx->idx[i]->content))
-      return 0;
+      return false;
 
-  return 1;
+  return true;
 }
 
 static short count_tagged(struct AttachCtx *actx)
@@ -128,7 +128,7 @@ void mutt_attach_bounce(FILE *fp, struct Header *hdr, struct AttachCtx *actx, st
   int ret = 0;
   int p = 0;
 
-  if (!check_all_msg(actx, cur, 1))
+  if (!check_all_msg(actx, cur, true))
     return;
 
   /* one or more messages? */
@@ -242,7 +242,7 @@ void mutt_attach_bounce(FILE *fp, struct Header *hdr, struct AttachCtx *actx, st
  */
 void mutt_attach_resend(FILE *fp, struct Header *hdr, struct AttachCtx *actx, struct Body *cur)
 {
-  if (!check_all_msg(actx, cur, 1))
+  if (!check_all_msg(actx, cur, true))
     return;
 
   if (cur)
@@ -658,7 +658,7 @@ void mutt_attach_forward(FILE *fp, struct Header *hdr, struct AttachCtx *actx,
 {
   short nattach;
 
-  if (check_all_msg(actx, cur, 0))
+  if (check_all_msg(actx, cur, false))
     attach_forward_msgs(fp, hdr, actx, cur, flags);
   else
   {


### PR DESCRIPTION
@neomutt/reviewers 
First PR of hopefully a series ;)
First commits are very granular, later ones are a bit more packed, please
tell which is more appropriate.
If rebasing is needed, e.g. unify more commits, just notify me.

* **What does this PR do?**
Refactors `int -> bool` in `attach.h` and it's deps.
Strips leading space e.g. `foo ()` -> `foo()`, splits too long prototypes to match ~90 chars
* **Are there points in the code the reviewer needs to double check?**
Yes
    * `struct Menu`s `tagprefix` changed from `int` to `bool`.
      I checked all occurrences, and only found boolean uses of it.
    * `static int can_print()` in `recvattach.c` now returns `bool`
    * `static short check_can_decode()` in `recvcmd.c` now returns `bool`
* **What are the relevant issue numbers?**
#774