### PR TITLE
devel/issue 774 bcache.h transit to `bool`

### DIFF
--- a/bcache.c
+++ b/bcache.c
@@ -150,13 +150,19 @@ FILE *mutt_bcache_get(struct BodyCache *bcache, const char *id)
   return fp;
 }
 
-FILE *mutt_bcache_put(struct BodyCache *bcache, const char *id, bool tmp)
+FILE *mutt_bcache_put(struct BodyCache *bcache, const char *id)
 {
   char path[LONG_STRING];
   struct stat sb;
 
   if (!id || !*id || !bcache)
     return NULL;
+
+  if (snprintf(path, sizeof(path), "%s%s%s", bcache->path, id, ".tmp") >= sizeof(path))
+  {
+    mutt_error(_("Path too long: %s%s%s"), bcache->path, id, ".tmp");
+    return NULL;
+  }
 
   if (stat(bcache->path, &sb) == 0)
   {
@@ -175,7 +181,6 @@ FILE *mutt_bcache_put(struct BodyCache *bcache, const char *id, bool tmp)
     }
   }
 
-  snprintf(path, sizeof(path), "%s%s%s", bcache->path, id, tmp ? ".tmp" : "");
   mutt_debug(3, "bcache: put: '%s'\n", path);
 
   return safe_fopen(path, "w+");

--- a/bcache.c
+++ b/bcache.c
@@ -150,7 +150,7 @@ FILE *mutt_bcache_get(struct BodyCache *bcache, const char *id)
   return fp;
 }
 
-FILE *mutt_bcache_put(struct BodyCache *bcache, const char *id, int tmp)
+FILE *mutt_bcache_put(struct BodyCache *bcache, const char *id, bool tmp)
 {
   char path[LONG_STRING];
   struct stat sb;

--- a/bcache.h
+++ b/bcache.h
@@ -24,6 +24,7 @@
 #ifndef _MUTT_BCACHE_H
 #define _MUTT_BCACHE_H
 
+#include <stdbool.h>
 #include <stdio.h>
 
 struct Account;
@@ -67,7 +68,7 @@ FILE *mutt_bcache_get(struct BodyCache *bcache, const char *id);
  * @retval FILE* on success
  * @retval NULL on failure
  */
-FILE *mutt_bcache_put(struct BodyCache *bcache, const char *id, int tmp);
+FILE *mutt_bcache_put(struct BodyCache *bcache, const char *id, bool tmp);
 
 /**
  * mutt_bcache_commit - Move a temporary file into the Body Cache

--- a/bcache.h
+++ b/bcache.h
@@ -63,12 +63,13 @@ FILE *mutt_bcache_get(struct BodyCache *bcache, const char *id);
  * mutt_bcache_put - Create a file in the Body Cache
  * @param bcache Body Cache from mutt_bcache_open()
  * @param id     Per-mailbox unique identifier for the message
- * @param tmp    Returned FILE* is in a temporary location
- *               If set, use mutt_bcache_commit to put it into place
  * @retval FILE* on success
  * @retval NULL on failure
+ *
+ * The returned FILE* is in a temporary location.
+ * Use mutt_bcache_commit to put it into place
  */
-FILE *mutt_bcache_put(struct BodyCache *bcache, const char *id, bool tmp);
+FILE *mutt_bcache_put(struct BodyCache *bcache, const char *id);
 
 /**
  * mutt_bcache_commit - Move a temporary file into the Body Cache

--- a/imap/message.c
+++ b/imap/message.c
@@ -109,7 +109,7 @@ static FILE *msg_cache_put(struct ImapData *idata, struct Header *h)
 
   idata->bcache = msg_cache_open(idata);
   snprintf(id, sizeof(id), "%u-%u", idata->uid_validity, HEADER_DATA(h)->uid);
-  return mutt_bcache_put(idata->bcache, id, true);
+  return mutt_bcache_put(idata->bcache, id);
 }
 
 static int msg_cache_commit(struct ImapData *idata, struct Header *h)

--- a/imap/message.c
+++ b/imap/message.c
@@ -109,7 +109,7 @@ static FILE *msg_cache_put(struct ImapData *idata, struct Header *h)
 
   idata->bcache = msg_cache_open(idata);
   snprintf(id, sizeof(id), "%u-%u", idata->uid_validity, HEADER_DATA(h)->uid);
-  return mutt_bcache_put(idata->bcache, id, 1);
+  return mutt_bcache_put(idata->bcache, id, true);
 }
 
 static int msg_cache_commit(struct ImapData *idata, struct Header *h)

--- a/nntp.c
+++ b/nntp.c
@@ -1618,7 +1618,7 @@ static int nntp_open_message(struct Context *ctx, struct Message *msg, int msgno
 
     /* create new cache file */
     mutt_message(fetch_msg);
-    msg->fp = mutt_bcache_put(nntp_data->bcache, article, true);
+    msg->fp = mutt_bcache_put(nntp_data->bcache, article);
     if (!msg->fp)
     {
       mutt_mktemp(buf, sizeof(buf));

--- a/nntp.c
+++ b/nntp.c
@@ -1618,7 +1618,7 @@ static int nntp_open_message(struct Context *ctx, struct Message *msg, int msgno
 
     /* create new cache file */
     mutt_message(fetch_msg);
-    msg->fp = mutt_bcache_put(nntp_data->bcache, article, 1);
+    msg->fp = mutt_bcache_put(nntp_data->bcache, article, true);
     if (!msg->fp)
     {
       mutt_mktemp(buf, sizeof(buf));

--- a/pop.c
+++ b/pop.c
@@ -599,7 +599,7 @@ static int pop_fetch_message(struct Context *ctx, struct Message *msg, int msgno
                        NetInc, h->content->length + h->content->offset - 1);
 
     /* see if we can put in body cache; use our cache as fallback */
-    if (!(msg->fp = mutt_bcache_put(pop_data->bcache, h->data, 1)))
+    if (!(msg->fp = mutt_bcache_put(pop_data->bcache, h->data, true)))
     {
       /* no */
       bcache = 0;

--- a/pop.c
+++ b/pop.c
@@ -599,7 +599,7 @@ static int pop_fetch_message(struct Context *ctx, struct Message *msg, int msgno
                        NetInc, h->content->length + h->content->offset - 1);
 
     /* see if we can put in body cache; use our cache as fallback */
-    if (!(msg->fp = mutt_bcache_put(pop_data->bcache, h->data, true)))
+    if (!(msg->fp = mutt_bcache_put(pop_data->bcache, h->data)))
     {
       /* no */
       bcache = 0;


### PR DESCRIPTION
@neomutt/reviewers 
Next is `bcache.h`. This only affects `mutt_bcache_put()`s `tmp` flag.

Affected files
* `bcache.c` -> `mutt_bcache_put()`
* `bcache.h` -> `mutt_bcache_put();`
* `imap/message.c` -> `msg_cache_put()`
* `nntp.c` -> `nntp_open_message()`
* `pop.c` -> `pop_fetch_message()` -> if can use body cache

* **What does this PR do?**
Refactors bcache.h to make use of `bool`
* **Are there points in the code the reviewer needs to double check?**
Probably not
* **What are the relevant issue numbers?**
#774
* **Further mentions**
`int mutt_bcache_exists()` may return `bool`, as it answers the question: "Does bcache exists? Y/N"