### PR TITLE
fix: crash looking up mime body type

### DIFF
--- a/browser.c
+++ b/browser.c
@@ -1590,6 +1590,8 @@ void _mutt_select_file(char *f, size_t flen, int flags, char ***files, int *numf
               mutt_message(_("Mailbox deleted."));
               init_menu(&state, menu, title, sizeof(title), buffy);
             }
+            else
+              mutt_error(_("Mailbox deletion failed."));
           }
           else
             mutt_message(_("Mailbox not deleted."));

--- a/globals.h
+++ b/globals.h
@@ -346,7 +346,7 @@ WHERE char *NmQueryWindowCurrentSearch;
 #ifdef MAIN_C
 const char *const BodyTypes[] = {
     "x-unknown", "audio",     "application", "image", "message",
-    "model",     "multipart", "text",        "video",
+    "model",     "multipart", "text",        "video", "*",
 };
 const char *const BodyEncodings[] = {
     "x-unknown", "7bit",   "8bit",        "quoted-printable",

--- a/hdrline.c
+++ b/hdrline.c
@@ -173,7 +173,7 @@ static size_t add_index_color(char *buf, size_t buflen, enum FormatFlag flags, c
     buflen -= len;
   }
 
-  if (buflen < 2)
+  if (buflen <= 2)
     return 0;
 
   buf[0] = MUTT_SPECIAL_INDEX;

--- a/imap/command.c
+++ b/imap/command.c
@@ -146,6 +146,7 @@ static void cmd_handle_fatal(struct ImapData *idata)
   if ((idata->state >= IMAP_SELECTED) && (idata->reopen & IMAP_REOPEN_ALLOW))
   {
     mx_fastclose_mailbox(idata->ctx);
+    mutt_socket_close(idata->conn);
     mutt_error(_("Mailbox closed"));
     mutt_sleep(1);
     idata->state = IMAP_DISCONNECTED;

--- a/init.c
+++ b/init.c
@@ -2320,8 +2320,7 @@ static void start_debug(void)
   if ((debugfile = safe_fopen(debugfilename, "w")) != NULL)
   {
     setbuf(debugfile, NULL); /* don't buffer the debugging output! */
-    mutt_debug(1, "NeoMutt/%s debugging at level %d\n", PACKAGE_VERSION,
-               debuglevel);
+    mutt_debug(1, "NeoMutt/%s debugging at level %d\n", PACKAGE_VERSION, debuglevel);
   }
 }
 
@@ -2347,8 +2346,7 @@ static void restart_debug(void)
   }
 
   if (!enable_debug && !disable_debug && debuglevel != DebugLevel)
-    mutt_debug(1, "NeoMutt/%s debugging at level %d\n", PACKAGE_VERSION,
-               DebugLevel);
+    mutt_debug(1, "NeoMutt/%s debugging at level %d\n", PACKAGE_VERSION, DebugLevel);
 
   debuglevel = DebugLevel;
 
@@ -3179,7 +3177,7 @@ static int source_rc(const char *rcfile_path, struct Buffer *err)
   if (rcfilelen == 0)
     return -1;
 
-  ispipe = rcfile[rcfilelen -1] == '|';
+  ispipe = rcfile[rcfilelen - 1] == '|';
 
   if (!ispipe)
   {

--- a/lib/string.c
+++ b/lib/string.c
@@ -62,6 +62,7 @@
 #include <limits.h>
 #include <stdlib.h>
 #include <string.h>
+#include "debug.h"
 #include "memory.h"
 #include "string2.h"
 
@@ -338,10 +339,22 @@ char *mutt_substrdup(const char *begin, const char *end)
   size_t len;
   char *p = NULL;
 
+  if (!begin)
+  {
+    mutt_debug(1, "%s: ERROR: 'begin' is NULL\n", __func__);
+    return NULL;
+  }
+
   if (end)
+  {
+    if (begin > end)
+      return NULL;
     len = end - begin;
+  }
   else
+  {
     len = strlen(begin);
+  }
 
   p = safe_malloc(len + 1);
   memcpy(p, begin, len);

--- a/mh.c
+++ b/mh.c
@@ -2029,6 +2029,7 @@ static int maildir_check_mailbox(struct Context *ctx, int *index_hint)
   bool flags_changed = false; /* message flags were changed in the mailbox */
   struct Maildir *md = NULL;  /* list of messages in the mailbox */
   struct Maildir **last = NULL, *p = NULL;
+  int count = 0;
   struct Hash *fnames = NULL; /* hash table for quickly looking up the base filename
                                    for a maildir message */
   struct MhData *data = mh_data(ctx);
@@ -2066,15 +2067,15 @@ static int maildir_check_mailbox(struct Context *ctx, int *index_hint)
   md = NULL;
   last = &md;
   if (changed & 1)
-    maildir_parse_dir(ctx, &last, "new", NULL, NULL);
+    maildir_parse_dir(ctx, &last, "new", &count, NULL);
   if (changed & 2)
-    maildir_parse_dir(ctx, &last, "cur", NULL, NULL);
+    maildir_parse_dir(ctx, &last, "cur", &count, NULL);
 
   /* we create a hash table keyed off the canonical (sans flags) filename
    * of each message we scanned.  This is used in the loop over the
    * existing messages below to do some correlation.
    */
-  fnames = hash_create(1031, 0);
+  fnames = hash_create(count, 0);
 
   for (p = md; p; p = p->next)
   {
@@ -2181,6 +2182,7 @@ static int mh_check_mailbox(struct Context *ctx, int *index_hint)
   struct Maildir *md = NULL, *p = NULL;
   struct Maildir **last = NULL;
   struct MhSequences mhs;
+  int count = 0;
   struct Hash *fnames = NULL;
   int i;
   struct MhData *data = mh_data(ctx);
@@ -2225,7 +2227,7 @@ static int mh_check_mailbox(struct Context *ctx, int *index_hint)
   md = NULL;
   last = &md;
 
-  maildir_parse_dir(ctx, &last, NULL, NULL, NULL);
+  maildir_parse_dir(ctx, &last, NULL, &count, NULL);
   maildir_delayed_parsing(ctx, &md, NULL);
 
   if (mh_read_sequences(&mhs, ctx->path) < 0)
@@ -2234,7 +2236,7 @@ static int mh_check_mailbox(struct Context *ctx, int *index_hint)
   mhs_free_sequences(&mhs);
 
   /* check for modifications and adjust flags */
-  fnames = hash_create(1031, 0);
+  fnames = hash_create(count, 0);
 
   for (p = md; p; p = p->next)
   {

--- a/mutt_idna.c
+++ b/mutt_idna.c
@@ -57,6 +57,8 @@ static int mbox_to_udomain(const char *mbx, char **user, char **domain)
   char *p = NULL;
 
   mutt_str_replace(&buff, mbx);
+  if (!buff)
+    return -1;
 
   p = strchr(buff, '@');
   if (!p || !p[1])

--- a/pattern.c
+++ b/pattern.c
@@ -729,7 +729,7 @@ static void order_range(struct Pattern *pat)
 }
 
 static int eat_range_by_regex(struct Pattern *pat, struct Buffer *s, int kind,
-                               struct Buffer *err)
+                              struct Buffer *err)
 {
   int regerr;
   regmatch_t pmatch[RANGE_RX_GROUPS];

--- a/po/fr.po
+++ b/po/fr.po
@@ -322,6 +322,9 @@ msgstr "Voulez-vous vraiment supprimer la boîte aux lettres \"%s\" ?"
 msgid "Mailbox deleted."
 msgstr "Boîte aux lettres supprimée."
 
+msgid "Mailbox deletion failed."
+msgstr "La suppression de la boîte aux lettres a échoué."
+
 #: browser.c:1595
 msgid "Mailbox not deleted."
 msgstr "Boîte aux lettres non supprimée."
@@ -1082,12 +1085,10 @@ msgid "Mail not sent: inline PGP can't be used with attachments."
 msgstr "Message non envoyé : PGP en ligne est impossible avec format=flowed."
 
 #: ncrypt/crypt.c:167
-#, fuzzy
 msgid "Inline PGP can't be used with format=flowed.  Revert to PGP/MIME?"
 msgstr "PGP en ligne est impossible avec format=flowed. Utiliser PGP/MIME ?"
 
 #: ncrypt/crypt.c:171
-#, fuzzy
 msgid "Mail not sent: inline PGP can't be used with format=flowed."
 msgstr "Message non envoyé : PGP en ligne est impossible avec format=flowed."
 

--- a/pop.c
+++ b/pop.c
@@ -51,8 +51,8 @@
 #endif
 
 #ifdef USE_HCACHE
-#define HC_FNAME "neomutt"  /* filename for hcache as POP lacks paths */
-#define HC_FEXT "hcache" /* extension for hcache as POP lacks paths */
+#define HC_FNAME "neomutt" /* filename for hcache as POP lacks paths */
+#define HC_FEXT "hcache"   /* extension for hcache as POP lacks paths */
 #endif
 
 /**

--- a/sendlib.c
+++ b/sendlib.c
@@ -1747,7 +1747,7 @@ static int fold_one_header(FILE *fp, const char *tag, const char *value,
   char buf[HUGE_STRING] = "";
   int first = 1, enc, col = 0, w, l = 0, fold;
 
-  mutt_debug(4, "mwoh: pfx=[%s], tag=[%s], flags=%d value=[%s]\n", pfx, tag, flags, value);
+  mutt_debug(4, "mwoh: pfx=[%s], tag=[%s], flags=%d value=[%s]\n", pfx, tag, flags, NONULL(value));
 
   if (tag && *tag && fprintf(fp, "%s%s: ", NONULL(pfx), tag) < 0)
     return -1;
@@ -1923,7 +1923,7 @@ static int write_one_header(FILE *fp, int pfxw, int max, int wraplen, const char
       valbuf = mutt_substrdup(t, end);
     }
     mutt_debug(4, "mwoh: buf[%s%s] too long, max width = %d > %d\n",
-               NONULL(pfx), valbuf, max, wraplen);
+               NONULL(pfx), NONULL(valbuf), max, wraplen);
     if (fold_one_header(fp, tagbuf, valbuf, pfx, wraplen, flags) < 0)
     {
       FREE(&valbuf);


### PR DESCRIPTION
This is a buffer overrun.
The mime type was being looked up in the BodyTypes table, but there wasn't an entry for TYPEANY.

Fixes #784
