### PR TITLE
spacing: Align function prototypes in init.h

### DIFF
--- a/init.h
+++ b/init.h
@@ -4514,12 +4514,12 @@ const struct Mapping SortSidebarMethods[] = {
 
 /* functions used to parse commands in a rc file */
 
-static int parse_stailq(struct Buffer *buf, struct Buffer *s, unsigned long data,
-                      struct Buffer *err);
+static int parse_stailq(struct Buffer *buf, struct Buffer *s,
+                        unsigned long data, struct Buffer *err);
 static int parse_spam_list(struct Buffer *buf, struct Buffer *s,
                            unsigned long data, struct Buffer *err);
 static int parse_unstailq(struct Buffer *buf, struct Buffer *s,
-                        unsigned long data, struct Buffer *err);
+                          unsigned long data, struct Buffer *err);
 #ifdef USE_SIDEBAR
 static int parse_path_list(struct Buffer *buf, struct Buffer *s,
                            unsigned long data, struct Buffer *err);
@@ -4527,29 +4527,29 @@ static int parse_path_unlist(struct Buffer *buf, struct Buffer *s,
                              unsigned long data, struct Buffer *err);
 #endif
 
-static int parse_group(struct Buffer *buf, struct Buffer *s, unsigned long data,
-                       struct Buffer *err);
+static int parse_group(struct Buffer *buf, struct Buffer *s,
+                       unsigned long data, struct Buffer *err);
 
-static int parse_lists(struct Buffer *buf, struct Buffer *s, unsigned long data,
-                       struct Buffer *err);
+static int parse_lists(struct Buffer *buf, struct Buffer *s,
+                       unsigned long data, struct Buffer *err);
 static int parse_unlists(struct Buffer *buf, struct Buffer *s,
                          unsigned long data, struct Buffer *err);
-static int parse_alias(struct Buffer *buf, struct Buffer *s, unsigned long data,
-                       struct Buffer *err);
+static int parse_alias(struct Buffer *buf, struct Buffer *s,
+                       unsigned long data, struct Buffer *err);
 static int parse_unalias(struct Buffer *buf, struct Buffer *s,
                          unsigned long data, struct Buffer *err);
 static int finish_source(struct Buffer *buf, struct Buffer *s,
                          unsigned long data, struct Buffer *err);
-static int parse_ifdef(struct Buffer *buf, struct Buffer *s, unsigned long data,
-                       struct Buffer *err);
+static int parse_ifdef(struct Buffer *buf, struct Buffer *s,
+                       unsigned long data, struct Buffer *err);
 static int parse_ignore(struct Buffer *buf, struct Buffer *s,
                         unsigned long data, struct Buffer *err);
 static int parse_unignore(struct Buffer *buf, struct Buffer *s,
                           unsigned long data, struct Buffer *err);
 static int parse_source(struct Buffer *buf, struct Buffer *token,
                         unsigned long data, struct Buffer *err);
-static int parse_set(struct Buffer *buf, struct Buffer *s, unsigned long data,
-                     struct Buffer *err);
+static int parse_set(struct Buffer *buf, struct Buffer *s,
+                     unsigned long data, struct Buffer *err);
 static int parse_setenv(struct Buffer *buf, struct Buffer *s,
                         unsigned long data, struct Buffer *err);
 static int parse_my_hdr(struct Buffer *buf, struct Buffer *s,
@@ -4573,9 +4573,8 @@ static int parse_subjectrx_list(struct Buffer *buf, struct Buffer *s,
                                 unsigned long data, struct Buffer *err);
 static int parse_unsubjectrx_list(struct Buffer *buf, struct Buffer *s,
                                   unsigned long data, struct Buffer *err);
-static int parse_alternates(struct Buffer *buf, struct Buffer *s, unsigned long data,
-
-                            struct Buffer *err);
+static int parse_alternates(struct Buffer *buf, struct Buffer *s,
+                            unsigned long data, struct Buffer *err);
 static int parse_unalternates(struct Buffer *buf, struct Buffer *s,
                               unsigned long data, struct Buffer *err);
 
@@ -4592,9 +4591,9 @@ static int parse_tag_formats(struct Buffer *buf, struct Buffer *s,
 
 #ifdef USE_IMAP
 static int parse_subscribe_to(struct Buffer *buf, struct Buffer *s,
-                                unsigned long data, struct Buffer *err);
+                              unsigned long data, struct Buffer *err);
 static int parse_unsubscribe_from(struct Buffer *buf, struct Buffer *s,
-                                unsigned long data, struct Buffer *err);
+                                  unsigned long data, struct Buffer *err);
 #endif
 
 const struct Command Commands[] = {

--- a/init.h
+++ b/init.h
@@ -4513,88 +4513,48 @@ const struct Mapping SortSidebarMethods[] = {
 };
 
 /* functions used to parse commands in a rc file */
-
-static int parse_stailq(struct Buffer *buf, struct Buffer *s,
-                        unsigned long data, struct Buffer *err);
-static int parse_spam_list(struct Buffer *buf, struct Buffer *s,
-                           unsigned long data, struct Buffer *err);
-static int parse_unstailq(struct Buffer *buf, struct Buffer *s,
-                          unsigned long data, struct Buffer *err);
-#ifdef USE_SIDEBAR
-static int parse_path_list(struct Buffer *buf, struct Buffer *s,
-                           unsigned long data, struct Buffer *err);
-static int parse_path_unlist(struct Buffer *buf, struct Buffer *s,
-                             unsigned long data, struct Buffer *err);
-#endif
-
-static int parse_group(struct Buffer *buf, struct Buffer *s,
-                       unsigned long data, struct Buffer *err);
-
-static int parse_lists(struct Buffer *buf, struct Buffer *s,
-                       unsigned long data, struct Buffer *err);
-static int parse_unlists(struct Buffer *buf, struct Buffer *s,
-                         unsigned long data, struct Buffer *err);
-static int parse_alias(struct Buffer *buf, struct Buffer *s,
-                       unsigned long data, struct Buffer *err);
-static int parse_unalias(struct Buffer *buf, struct Buffer *s,
-                         unsigned long data, struct Buffer *err);
-static int finish_source(struct Buffer *buf, struct Buffer *s,
-                         unsigned long data, struct Buffer *err);
-static int parse_ifdef(struct Buffer *buf, struct Buffer *s,
-                       unsigned long data, struct Buffer *err);
-static int parse_ignore(struct Buffer *buf, struct Buffer *s,
-                        unsigned long data, struct Buffer *err);
-static int parse_unignore(struct Buffer *buf, struct Buffer *s,
-                          unsigned long data, struct Buffer *err);
-static int parse_source(struct Buffer *buf, struct Buffer *token,
-                        unsigned long data, struct Buffer *err);
-static int parse_set(struct Buffer *buf, struct Buffer *s,
-                     unsigned long data, struct Buffer *err);
-static int parse_setenv(struct Buffer *buf, struct Buffer *s,
-                        unsigned long data, struct Buffer *err);
-static int parse_my_hdr(struct Buffer *buf, struct Buffer *s,
-                        unsigned long data, struct Buffer *err);
-static int parse_unmy_hdr(struct Buffer *buf, struct Buffer *s,
-                          unsigned long data, struct Buffer *err);
-static int parse_subscribe(struct Buffer *buf, struct Buffer *s,
-                           unsigned long data, struct Buffer *err);
-static int parse_unsubscribe(struct Buffer *buf, struct Buffer *s,
-                             unsigned long data, struct Buffer *err);
-static int parse_attachments(struct Buffer *buf, struct Buffer *s,
-                             unsigned long data, struct Buffer *err);
-static int parse_unattachments(struct Buffer *buf, struct Buffer *s,
-                               unsigned long data, struct Buffer *err);
-
-static int parse_replace_list(struct Buffer *buf, struct Buffer *s,
-                              unsigned long data, struct Buffer *err);
-static int parse_unreplace_list(struct Buffer *buf, struct Buffer *s,
-                                unsigned long data, struct Buffer *err);
-static int parse_subjectrx_list(struct Buffer *buf, struct Buffer *s,
-                                unsigned long data, struct Buffer *err);
-static int parse_unsubjectrx_list(struct Buffer *buf, struct Buffer *s,
-                                  unsigned long data, struct Buffer *err);
-static int parse_alternates(struct Buffer *buf, struct Buffer *s,
-                            unsigned long data, struct Buffer *err);
-static int parse_unalternates(struct Buffer *buf, struct Buffer *s,
-                              unsigned long data, struct Buffer *err);
-
-/* Parse -group arguments */
-static int parse_group_context(struct GroupContext **ctx, struct Buffer *buf,
-                               struct Buffer *s, unsigned long data, struct Buffer *err);
-
-#ifdef USE_NOTMUCH
-static int parse_tag_transforms(struct Buffer *buf, struct Buffer *s,
-                                unsigned long data, struct Buffer *err);
-static int parse_tag_formats(struct Buffer *buf, struct Buffer *s,
-                             unsigned long data, struct Buffer *err);
-#endif
-
+static int finish_source         (struct Buffer *buf, struct Buffer *s, unsigned long data, struct Buffer *err);
+static int parse_alias           (struct Buffer *buf, struct Buffer *s, unsigned long data, struct Buffer *err);
+static int parse_alternates      (struct Buffer *buf, struct Buffer *s, unsigned long data, struct Buffer *err);
+static int parse_attachments     (struct Buffer *buf, struct Buffer *s, unsigned long data, struct Buffer *err);
+static int parse_group           (struct Buffer *buf, struct Buffer *s, unsigned long data, struct Buffer *err);
+static int parse_ifdef           (struct Buffer *buf, struct Buffer *s, unsigned long data, struct Buffer *err);
+static int parse_ignore          (struct Buffer *buf, struct Buffer *s, unsigned long data, struct Buffer *err);
+static int parse_lists           (struct Buffer *buf, struct Buffer *s, unsigned long data, struct Buffer *err);
+static int parse_my_hdr          (struct Buffer *buf, struct Buffer *s, unsigned long data, struct Buffer *err);
+static int parse_replace_list    (struct Buffer *buf, struct Buffer *s, unsigned long data, struct Buffer *err);
+static int parse_set             (struct Buffer *buf, struct Buffer *s, unsigned long data, struct Buffer *err);
+static int parse_setenv          (struct Buffer *buf, struct Buffer *s, unsigned long data, struct Buffer *err);
+static int parse_source          (struct Buffer *buf, struct Buffer *s, unsigned long data, struct Buffer *err);
+static int parse_spam_list       (struct Buffer *buf, struct Buffer *s, unsigned long data, struct Buffer *err);
+static int parse_stailq          (struct Buffer *buf, struct Buffer *s, unsigned long data, struct Buffer *err);
+static int parse_subjectrx_list  (struct Buffer *buf, struct Buffer *s, unsigned long data, struct Buffer *err);
+static int parse_subscribe       (struct Buffer *buf, struct Buffer *s, unsigned long data, struct Buffer *err);
+static int parse_unalias         (struct Buffer *buf, struct Buffer *s, unsigned long data, struct Buffer *err);
+static int parse_unalternates    (struct Buffer *buf, struct Buffer *s, unsigned long data, struct Buffer *err);
+static int parse_unattachments   (struct Buffer *buf, struct Buffer *s, unsigned long data, struct Buffer *err);
+static int parse_unignore        (struct Buffer *buf, struct Buffer *s, unsigned long data, struct Buffer *err);
+static int parse_unlists         (struct Buffer *buf, struct Buffer *s, unsigned long data, struct Buffer *err);
+static int parse_unmy_hdr        (struct Buffer *buf, struct Buffer *s, unsigned long data, struct Buffer *err);
+static int parse_unreplace_list  (struct Buffer *buf, struct Buffer *s, unsigned long data, struct Buffer *err);
+static int parse_unstailq        (struct Buffer *buf, struct Buffer *s, unsigned long data, struct Buffer *err);
+static int parse_unsubjectrx_list(struct Buffer *buf, struct Buffer *s, unsigned long data, struct Buffer *err);
+static int parse_unsubscribe     (struct Buffer *buf, struct Buffer *s, unsigned long data, struct Buffer *err);
 #ifdef USE_IMAP
-static int parse_subscribe_to(struct Buffer *buf, struct Buffer *s,
-                              unsigned long data, struct Buffer *err);
-static int parse_unsubscribe_from(struct Buffer *buf, struct Buffer *s,
-                                  unsigned long data, struct Buffer *err);
+static int parse_subscribe_to    (struct Buffer *buf, struct Buffer *s, unsigned long data, struct Buffer *err);
+static int parse_unsubscribe_from(struct Buffer *buf, struct Buffer *s, unsigned long data, struct Buffer *err);
 #endif
+#ifdef USE_NOTMUCH
+static int parse_tag_formats     (struct Buffer *buf, struct Buffer *s, unsigned long data, struct Buffer *err);
+static int parse_tag_transforms  (struct Buffer *buf, struct Buffer *s, unsigned long data, struct Buffer *err);
+#endif
+#ifdef USE_SIDEBAR
+static int parse_path_list       (struct Buffer *buf, struct Buffer *s, unsigned long data, struct Buffer *err);
+static int parse_path_unlist     (struct Buffer *buf, struct Buffer *s, unsigned long data, struct Buffer *err);
+#endif
+/* Parse -group arguments */
+static int parse_group_context   (struct GroupContext **ctx,
+                                  struct Buffer *buf, struct Buffer *s, unsigned long data, struct Buffer *err);
 
 const struct Command Commands[] = {
 #ifdef USE_SOCKET


### PR DESCRIPTION
* **What does this PR do?**
Aligns all function prototypes of commands to make it more consistent.
* **Are there points in the code the reviewer needs to double check?**
No
* **What are the relevant issue numbers?**
None
* **Further proposal**
It may be nicer to break the Coding-Style-Rule "No space between function name and `(`" here,
as all prototypes only differ in the function name. It also fits, as all `struct`s and `#def`s are nicely aligned.