### PR TITLE
Fix some problems with autoconf

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -137,21 +137,21 @@ git_ver.h: $(neomutt_SOURCES) $(SUBDIRS)
 install-data-local:
 	$(MKDIR_P) $(DESTDIR)$(sysconfdir)
 	-if test -n "$(SMIMEAUX_TARGET)"; then \
-		$(MKDIR_P) $(DESTDIR)$(libdir)/$(PACKAGE); \
+		$(MKDIR_P) $(DESTDIR)$(exec_prefix)/lib/$(PACKAGE); \
 		for i in $(SMIMEAUX_TARGET); do \
-			$(INSTALL) -m 755 $(srcdir)/$$i $(DESTDIR)$(libdir)/$(PACKAGE); \
+			$(INSTALL) -m 755 $$i $(DESTDIR)$(exec_prefix)/lib/$(PACKAGE); \
 		done \
 	fi
 	-if test -n "$(PGPAUX_TARGET)"; then \
-		$(MKDIR_P) $(DESTDIR)$(libdir)/$(PACKAGE); \
+		$(MKDIR_P) $(DESTDIR)$(exec_prefix)/lib/$(PACKAGE); \
 		for i in $(PGPAUX_TARGET); do \
-			$(INSTALL) -m 755 $$i $(DESTDIR)$(libdir)/$(PACKAGE); \
+			$(INSTALL) -m 755 $$i $(DESTDIR)$(exec_prefix)/lib/$(PACKAGE); \
 		done \
 	fi
 
 uninstall-local:
 	for i in smime_keys $(PGPAUX_TARGET); do \
-		rm -fr $(DESTDIR)$(libdir)/$(PACKAGE)/$$i; \
+		rm -fr $(DESTDIR)$(exec_prefix)/lib/$(PACKAGE)/$$i; \
 	done
 
 distclean-local:

--- a/configure.ac
+++ b/configure.ac
@@ -361,13 +361,13 @@ dnl --- ncurses
 	dnl configure trying to locate curses at /no/include first. The mutual
 	dnl exclusion of slang and curses and the requirement that one (and only
 	dnl one) is chosen could be improved.
-    if test x$with_curses != xyes; then
-        mutt_cv_curses=$withval
-    fi
-    if test x$mutt_cv_curses != x/usr; then
-        LDFLAGS="$LDFLAGS -L${with_curses}/lib"
-        CPPFLAGS="$CPPFLAGS -I${with_curses}/include"
-    fi
+	if test x$with_curses != xyes; then
+		mutt_cv_curses=$withval
+	fi
+	if test x$mutt_cv_curses != x/usr; then
+		LDFLAGS="$LDFLAGS -L${with_curses}/lib"
+		CPPFLAGS="$CPPFLAGS -I${with_curses}/include"
+	fi
 	mutt_cv_curses=/usr
 	AC_CHECK_FUNC(initscr,,[
 		cf_ncurses=""
@@ -843,7 +843,7 @@ AM_GNU_GETTEXT([external])
 
 AM_ICONV
 if test "$am_cv_func_iconv" != yes; then
-    AC_MSG_ERROR([An iconv implementation is required])
+	AC_MSG_ERROR([An iconv implementation is required])
 fi
 
 AC_ARG_WITH(idn, AS_HELP_STRING([--with-idn=@<:@PFX@:>@],[Use GNU libidn for internationalized domain names]),
@@ -858,29 +858,29 @@ AC_ARG_WITH(idn, AS_HELP_STRING([--with-idn=@<:@PFX@:>@],[Use GNU libidn for int
 		[with_idn=auto])
 
 if test "x$with_idn" != "xno"; then
-    dnl Solaris 11 has /usr/include/idn
-    have_stringprep_h=no
-    AC_CHECK_HEADERS([stringprep.h idn/stringprep.h], [
-                have_stringprep_h=yes
-                break])
-    have_idna_h=no
-    AC_CHECK_HEADERS([idna.h idn/idna.h], [
-                have_idna_h=yes
-                break])
+	dnl Solaris 11 has /usr/include/idn
+	have_stringprep_h=no
+	AC_CHECK_HEADERS([stringprep.h idn/stringprep.h], [
+		have_stringprep_h=yes
+		break])
+	have_idna_h=no
+	AC_CHECK_HEADERS([idna.h idn/idna.h], [
+		have_idna_h=yes
+		break])
 
-    AC_SEARCH_LIBS([stringprep_check_version], [idn], [
-        AC_DEFINE([HAVE_LIBIDN], 1, [Define to 1 if you have the GNU idn library])
+	AC_SEARCH_LIBS([stringprep_check_version], [idn], [
+		AC_DEFINE([HAVE_LIBIDN], 1, [Define to 1 if you have the GNU idn library])
 
-        LIBS="$LIBS $LIBICONV"
-        AC_CHECK_FUNCS(idna_to_unicode_utf8_from_utf8 idna_to_unicode_8z8z)
-        AC_CHECK_FUNCS(idna_to_ascii_from_utf8 idna_to_ascii_8z)
-        AC_CHECK_FUNCS(idna_to_ascii_lz idna_to_ascii_from_locale)
-    ])
+		LIBS="$LIBS $LIBICONV"
+		AC_CHECK_FUNCS(idna_to_unicode_utf8_from_utf8 idna_to_unicode_8z8z)
+		AC_CHECK_FUNCS(idna_to_ascii_from_utf8 idna_to_ascii_8z)
+		AC_CHECK_FUNCS(idna_to_ascii_lz idna_to_ascii_from_locale)
+	])
 
-    if test "$with_idn" != auto; then
-        if test $have_stringprep_h = no || test $have_idna_h = no || test $ac_cv_search_stringprep_check_version = no; then
-            AC_MSG_ERROR([IDN was requested, but libidn was not usable on this system])
-        fi
+	if test "$with_idn" != auto; then
+		if test $have_stringprep_h = no || test $have_idna_h = no || test $ac_cv_search_stringprep_check_version = no; then
+			AC_MSG_ERROR([IDN was requested, but libidn was not usable on this system])
+		fi
 	fi
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -357,16 +357,16 @@ main ()
 		[AC_MSG_ERROR(unable to compile.  check config.log)], -lm)
 else
 dnl --- ncurses
-	dnl Plese note that --with-slang=no --with-curses=no will result in
+	dnl Please note that --with-slang=no --with-curses=no will result in
 	dnl configure trying to locate curses at /no/include first. The mutual
 	dnl exclusion of slang and curses and the requirement that one (and only
 	dnl one) is chosen could be improved.
-	if test x$with_curses != xyes; then
+	if test x$with_curses != xyes -a x$with_curses != xno; then
 		mutt_cv_curses=$withval
 	fi
-	if test x$mutt_cv_curses != x/usr; then
-		LDFLAGS="$LDFLAGS -L${with_curses}/lib"
-		CPPFLAGS="$CPPFLAGS -I${with_curses}/include"
+	if test x$mutt_cv_curses != x/usr -a x$mutt_cv_curses != x; then
+		LDFLAGS="$LDFLAGS -L${mutt_cv_curses}/lib"
+		CPPFLAGS="$CPPFLAGS -I${mutt_cv_curses}/include"
 	fi
 	mutt_cv_curses=/usr
 	AC_CHECK_FUNC(initscr,,[

--- a/configure.ac
+++ b/configure.ac
@@ -218,7 +218,7 @@ AS_IF([test x$use_pgp != "xno"], [
 dnl --enable-smime
 AS_IF([test x$use_smime != "xno"], [
 	AC_DEFINE(CRYPT_BACKEND_CLASSIC_SMIME, 1, [Define if you want classic S/MIME support.])
-	SMIMEAUX_TARGET='$(top_srcdir)/contrib/smime_keys'
+	SMIMEAUX_TARGET='$(srcdir)/contrib/smime_keys'
 	build_ncrypt_smime="yes"
 ])
 

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -54,9 +54,9 @@ install-data-local: makedoc-all
 	for f in $(srcdir_DOCFILES); do \
 		$(INSTALL) -m 644 $(srcdir)/$$f $(DESTDIR)$(docdir); \
 	done
-	-$(INSTALL) -m 644 $(srcdir)/manual.txt $(DESTDIR)$(docdir)
+	-$(INSTALL) -m 644 manual.txt $(DESTDIR)$(docdir)
 	-for f in $(HTML_DOCFILES); do \
-		$(INSTALL) -m 644 $(srcdir)/$$f $(DESTDIR)$(docdir); \
+		$(INSTALL) -m 644 $$f $(DESTDIR)$(docdir); \
 	done
 	$(INSTALL) -m 644 neomuttrc $(DESTDIR)$(sysconfdir)/neomuttrc
 	-$(INSTALL) -m 644 $(srcdir)/neomutt-syntax.vim $(DESTDIR)$(docdir)


### PR DESCRIPTION
- 45994318 restore tabs in configure.ac
  No functional changes
- 2d67eab8 fix out-of-tree build
  Make sure the built items in /doc are installed
- 91837478 stop yes/no include dirs
  Stop configure from suggesting '-Iyes/include' or '-Lno/lib'

I tested the last commit using:
- `./configure `
- `./configure --with-curses`
- `./configure --with-curses=yes`
- `./configure --with-curses=no`
- `./configure --with-curses=/usr/local`
- `./configure --without-curses`

