### PR TITLE
fix: overflow in mutt_mktime()

### DIFF
--- a/from.c
+++ b/from.c
@@ -134,6 +134,8 @@ int is_from(const char *s, char *path, size_t pathlen, time_t *tp)
     return 0;
   if (sscanf(s, "%d", &tm.tm_mday) != 1)
     return 0;
+  if ((tm.tm_mday < 1) || (tm.tm_mday > 31))
+    return 0;
 
   /* time */
   s = next_word(s);
@@ -146,6 +148,10 @@ int is_from(const char *s, char *path, size_t pathlen, time_t *tp)
   else if (sscanf(s, "%d:%d", &tm.tm_hour, &tm.tm_min) == 2)
     tm.tm_sec = 0;
   else
+    return 0;
+
+  if ((tm.tm_hour < 0) || (tm.tm_hour > 23) || (tm.tm_min < 0) ||
+      (tm.tm_min > 59) || (tm.tm_sec < 0) || (tm.tm_sec > 60))
     return 0;
 
   s = next_word(s);
@@ -173,6 +179,8 @@ int is_from(const char *s, char *path, size_t pathlen, time_t *tp)
 
   /* year */
   if (sscanf(s, "%d", &yr) != 1)
+    return 0;
+  if ((yr < 0) || (yr > 9999))
     return 0;
   tm.tm_year = yr > 1900 ? yr - 1900 : (yr < 70 ? yr + 100 : yr);
 

--- a/lib/date.c
+++ b/lib/date.c
@@ -54,8 +54,10 @@
 
 /* theoretically time_t can be float but it is integer on most (if not all) systems */
 #define TIME_T_MAX ((((time_t) 1 << (sizeof(time_t) * 8 - 2)) - 1) * 2 + 1)
+#define TIME_T_MIN (-TIME_T_MAX - 1)
 #define TM_YEAR_MAX                                                            \
   (1970 + (((((TIME_T_MAX - 59) / 60) - 59) / 60) - 23) / 24 / 366)
+#define TM_YEAR_MIN (1970 - (TM_YEAR_MAX - 1970) - 1)
 
 /**
  * Weekdays - Day of the week (abbreviated)
@@ -247,8 +249,10 @@ time_t mutt_mktime(struct tm *t, int local)
 
   /* Prevent an integer overflow.
    * The time_t cast is an attempt to silence a clang range warning. */
-  if ((time_t) t->tm_year > TM_YEAR_MAX)
+  if ((time_t) t->tm_year > (TM_YEAR_MAX - 1900))
     return TIME_T_MAX;
+  if ((time_t) t->tm_year < (TM_YEAR_MIN - 1900))
+    return TIME_T_MIN;
 
   /* Compute the number of days since January 1 in the same year */
   g = AccumDaysPerMonth[t->tm_mon % 12];

--- a/lib/date.c
+++ b/lib/date.c
@@ -254,6 +254,14 @@ time_t mutt_mktime(struct tm *t, int local)
   if ((time_t) t->tm_year < (TM_YEAR_MIN - 1900))
     return TIME_T_MIN;
 
+  if ((t->tm_mday < 1) || (t->tm_mday > 31))
+    return TIME_T_MIN;
+  if ((t->tm_hour < 0) || (t->tm_hour > 23) || (t->tm_min < 0) ||
+      (t->tm_min > 59) || (t->tm_sec < 0) || (t->tm_sec > 60))
+    return TIME_T_MIN;
+  if (t->tm_year > 9999)
+    return TIME_T_MAX;
+
   /* Compute the number of days since January 1 in the same year */
   g = AccumDaysPerMonth[t->tm_mon % 12];
 
@@ -479,13 +487,15 @@ time_t mutt_parse_date(const char *s, struct Tz *tz_out)
 
       case 1: /* month of the year */
         i = mutt_check_month(t);
-        if (i < 0)
+        if ((i < 0) || (i > 11))
           return -1;
         tm.tm_mon = i;
         break;
 
       case 2: /* year */
         if ((mutt_atoi(t, &tm.tm_year) < 0) || (tm.tm_year < 0))
+          return -1;
+        if ((tm.tm_year < 0) || (tm.tm_year > 9999))
           return -1;
         if (tm.tm_year < 50)
           tm.tm_year += 100;
@@ -503,6 +513,9 @@ time_t mutt_parse_date(const char *s, struct Tz *tz_out)
           mutt_debug(1, "parse_date: could not process time format: %s\n", t);
           return -1;
         }
+        if ((hour < 0) || (hour > 23) || (min < 0) ||
+            (min > 59) || (sec < 0) || (sec > 60))
+          return -1;
         tm.tm_hour = hour;
         tm.tm_min = min;
         tm.tm_sec = sec;


### PR DESCRIPTION
mutt_mktime() can overflow when used on 32-bit arches.
This was due to a bogus comparision.

Now, extreme future dates will be interpreted as 2038-01-19.

Fixes #794