### PR TITLE
pager: index must be rebuild when check mailbox returns MUTT_REOPENED

### DIFF
--- a/pager.c
+++ b/pager.c
@@ -2231,7 +2231,10 @@ int mutt_pager(const char *banner, const char *fname, int flags, struct Pager *e
               break;
             }
           }
+        }
 
+        if ((check == MUTT_NEW_MAIL) || (check == MUTT_REOPENED))
+        {
           if (rd.index && Context)
           {
             /* After the mailbox has been updated,
@@ -2247,7 +2250,9 @@ int mutt_pager(const char *banner, const char *fname, int flags, struct Pager *e
             rd.index->max = Context->vcount;
 
             /* If these header pointers don't match, then our email may have
-             * been deleted.  Make the pointer safe, then leave the pager */
+             * been deleted.  Make the pointer safe, then leave the pager.
+             * This have a unpleasant behaviour to close the pager even the
+             * deleted message is not the opened one, but at least it's safe. */
             if (extra->hdr != Context->hdrs[Context->v2r[rd.index->current]])
             {
               extra->hdr = Context->hdrs[Context->v2r[rd.index->current]];


### PR DESCRIPTION
When we call mx_check_mailbox() and something change
header in Context->hdrs may have been updated.

In case of MUTT_NEW_MAIL, the page rebuild the index, and fixup
rd.index->current/max and extra->hdr. If the extra->hdr change
like when an above the opened one, or the selected one, is deleted, the
pager is closed.

In case of MUTT_REOPENED we do nothing. Making rd.index->current/max
wrong and extra->hdr perhaps pointing to something that doesn't exist
anymore.

This change makes the MUTT_REOPENED behavior similar to MUTT_NEW_MAIL.

Note that we this the pager have good change to be closed with the
mailbox is modified externally, just like the current MUTT_NEW_MAIL
behavior.

Closes #796