### PR TITLE
bool: include missing stdbool.h header in mutt_options.h

### DIFF
--- a/mutt_options.h
+++ b/mutt_options.h
@@ -24,6 +24,7 @@
 #define _MUTT_OPTIONS_H
 
 #include <stddef.h>
+#include <stdbool.h>
 
 struct Buffer;
 


### PR DESCRIPTION
* **What does this PR do?**
adds `#include <stdbool.h>` to satisfy the use of `bool` of return value of
`mutt_option_get()` in `mutt_options.h`.
* **Are there points in the code the reviewer needs to double check?**
Currently everybody who uses `mutt_options.h` already includes `stdbool.h`.
* **What are the relevant issue numbers?**
#774 