### PR TITLE
imap: Fix mx.mbox leak in imap_get_parent_path

### DIFF
--- a/imap/util.c
+++ b/imap/util.c
@@ -166,6 +166,7 @@ void imap_get_parent_path(char *output, const char *path, size_t olen)
 
   /* Returns a fully qualified IMAP url */
   imap_qualify_path(output, olen, &mx, mbox);
+  FREE(&mx.mbox);
 }
 
 /**


### PR DESCRIPTION
valgrind reports a memory leak in imap_get_parent_path due to no
free'ing mx.mbox. As described in imap_parse_path, the callee should
free mx.mbox.

Valgrind output:
```==24227== 13 bytes in 1 blocks are definitely lost in loss record 154 of 953
==24227==    at 0x4C2CE5F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==24227==    by 0x1DE1AF: safe_malloc (memory.c:113)
==24227==    by 0x1DE683: safe_strdup (string.c:175)
==24227==    by 0x1D7B19: imap_parse_path (util.c:332)
==24227==    by 0x1D84E6: imap_get_parent_path (util.c:148)
==24227==    by 0x144619: mutt_index_menu (curs_main.c:2046)
==24227==    by 0x120B68: main (main.c:936)
```