### PR TITLE
Fix memory leaks in pgpewrap

### DIFF
--- a/pgpewrap.c
+++ b/pgpewrap.c
@@ -47,6 +47,7 @@ int main(int argc, char **argv)
       i += 2;
       if (i > argc)
       {
+        free(opts);
         print_usage(argv[0]);
       }
       pfx = argv[i - 1];
@@ -59,5 +60,6 @@ int main(int argc, char **argv)
 
   execvp(opts[0], opts);
   perror(argv[0]);
+  free(opts);
   return 2;
 }

--- a/pgpewrap.c
+++ b/pgpewrap.c
@@ -24,7 +24,7 @@ int main(int argc, char **argv)
   char **opts = NULL, **opt = NULL, *pfx = NULL;
   int i;
 
-  if (argc <= 1)
+  if (argc < 2)
   {
     print_usage(argv[0]);
   }
@@ -34,12 +34,6 @@ int main(int argc, char **argv)
   {
     perror(argv[0]);
     exit(2);
-  }
-
-  if (argc < 2)
-  {
-    fprintf(stderr, "Command line usage: %s [flags] -- prefix [recipients]\n", argv[0]);
-    return 1;
   }
 
   opt = opts;


### PR DESCRIPTION
Although the wrapper probably won't cause a real memory leak, cleaning up all allocated memory when exiting could save time spend on debugging memory leaks. Apart from fixing a leak this also leads a small refactoring of the duplicate argc check.