### PR TITLE
Don't clear the macro buffer during startup

### DIFF
--- a/curs_main.c
+++ b/curs_main.c
@@ -946,6 +946,12 @@ int mutt_index_menu(void)
     menu->redraw = REDRAW_FULL;
   }
 
+  /* On SIGWINCH, we clear the input buffer and redraw the screen.
+   * We don't want this to happening the first time we enter the loop.
+   * The startup hook puts commands into the keyboard buffer which we don't
+   * want to lose. */
+  SigWinch = 0;
+
   while (true)
   {
     /* Clear the tag prefix unless we just started it.  Don't clear


### PR DESCRIPTION
The **normal sequence** of events is this:
      
1. Startup
1. Folder hook is executed, causing:
   1. OP_MAIN_COLLAPSE_ALL to be put in macro buffer 
1. Mailbox is opened
1. mutt_index_menu() starts
   1. No SigWinch has occurred
   1. km_do_key() called
   1. OP_MAIN_COLLAPSE_ALL is performed

A **broken sequence** of events is this:

1. Startup
1. Folder hook is executed, causing:
   1. OP_MAIN_COLLAPSE_ALL to be put in macro buffer 
1. Mailbox is opened, during which
   1. SIGWINCH occurs (SigWinch = 1)
1. mutt_index_menu() starts
   1. A SigWinch HAS occurred, causing
       1. mutt_flushinp() to called
       1. the macro buffer to be emptied
   1. km_do_key() called
   1. nothing is returned
