### PR TITLE
fix actions on tagged messages

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -432,11 +432,11 @@ static int _mutt_pipe_message(struct Header *h, char *cmd, int decode,
       for (int i = 0; i < Context->msgcount; i++)
         if (message_is_tagged(Context, i))
         {
-          mutt_message_hook(Context, Context->hdrs[i], MUTT_MESSAGEHOOK);
-          mutt_parse_mime_message(Context, Context->hdrs[i]);
-          if (Context->hdrs[i]->security & ENCRYPT &&
-              !crypt_valid_passphrase(Context->hdrs[i]->security))
-            return 1;
+        mutt_message_hook(Context, Context->hdrs[i], MUTT_MESSAGEHOOK);
+        mutt_parse_mime_message(Context, Context->hdrs[i]);
+        if (Context->hdrs[i]->security & ENCRYPT &&
+            !crypt_valid_passphrase(Context->hdrs[i]->security))
+          return 1;
         }
     }
 
@@ -446,23 +446,23 @@ static int _mutt_pipe_message(struct Header *h, char *cmd, int decode,
       {
         if (message_is_tagged(Context, i))
         {
-          mutt_message_hook(Context, Context->hdrs[i], MUTT_MESSAGEHOOK);
-          mutt_endwin(NULL);
-          thepid = mutt_create_filter(cmd, &fpout, NULL, NULL);
-          if (thepid < 0)
-          {
-            mutt_perror(_("Can't create filter process"));
-            return 1;
-          }
-          set_option(OPT_KEEP_QUIET);
-          pipe_msg(Context->hdrs[i], fpout, decode, print);
-          /* add the message separator */
-          if (sep)
-            fputs(sep, fpout);
-          safe_fclose(&fpout);
-          if (mutt_wait_filter(thepid) != 0)
-            rc = 1;
-          unset_option(OPT_KEEP_QUIET);
+        mutt_message_hook(Context, Context->hdrs[i], MUTT_MESSAGEHOOK);
+        mutt_endwin(NULL);
+        thepid = mutt_create_filter(cmd, &fpout, NULL, NULL);
+        if (thepid < 0)
+        {
+          mutt_perror(_("Can't create filter process"));
+          return 1;
+        }
+        set_option(OPT_KEEP_QUIET);
+        pipe_msg(Context->hdrs[i], fpout, decode, print);
+        /* add the message separator */
+        if (sep)
+          fputs(sep, fpout);
+        safe_fclose(&fpout);
+        if (mutt_wait_filter(thepid) != 0)
+          rc = 1;
+        unset_option(OPT_KEEP_QUIET);
         }
       }
     }
@@ -480,11 +480,11 @@ static int _mutt_pipe_message(struct Header *h, char *cmd, int decode,
       {
         if (message_is_tagged(Context, i))
         {
-          mutt_message_hook(Context, Context->hdrs[i], MUTT_MESSAGEHOOK);
-          pipe_msg(Context->hdrs[i], fpout, decode, print);
-          /* add the message separator */
-          if (sep)
-            fputs(sep, fpout);
+        mutt_message_hook(Context, Context->hdrs[i], MUTT_MESSAGEHOOK);
+        pipe_msg(Context->hdrs[i], fpout, decode, print);
+        /* add the message separator */
+        if (sep)
+          fputs(sep, fpout);
         }
       }
       safe_fclose(&fpout);
@@ -896,20 +896,19 @@ int mutt_save_message(struct Header *h, int delete, int decode, int decrypt)
       {
         if (message_is_tagged(Context, i))
         {
-          mutt_message_hook(Context, Context->hdrs[i], MUTT_MESSAGEHOOK);
-          if ((rc = _mutt_save_message(Context->hdrs[i], &ctx,
-                                      delete, decode, decrypt) != 0))
-            break;
+        mutt_message_hook(Context, Context->hdrs[i], MUTT_MESSAGEHOOK);
+        if ((rc = _mutt_save_message(Context->hdrs[i], &ctx, delete, decode, decrypt) != 0))
+          break;
 #ifdef USE_COMPRESSED
-          if (cm)
-          {
-            struct Header *h2 = Context->hdrs[i];
-            cm->msg_count++;
-            if (!h2->read)
-              cm->msg_unread++;
-            if (h2->flagged)
-              cm->msg_flagged++;
-          }
+        if (cm)
+        {
+          struct Header *h2 = Context->hdrs[i];
+          cm->msg_count++;
+          if (!h2->read)
+            cm->msg_unread++;
+          if (h2->flagged)
+            cm->msg_flagged++;
+        }
 #endif
         }
       }

--- a/compose.c
+++ b/compose.c
@@ -1057,7 +1057,6 @@ int mutt_compose_menu(struct Header *msg, /* structure for new message */
 #endif
       {
         char *prompt = NULL;
-        struct Header *h = NULL;
 
         fname[0] = 0;
         prompt = _("Open mailbox to attach message from");
@@ -1149,11 +1148,10 @@ int mutt_compose_menu(struct Header *msg, /* structure for new message */
 
         for (i = 0; i < Context->msgcount; i++)
         {
-          h = Context->hdrs[i];
-          if (h->tagged)
+          if (message_is_tagged(Context, i))
           {
             new = (struct AttachPtr *) safe_calloc(1, sizeof(struct AttachPtr));
-            new->content = mutt_make_message_attach(Context, h, 1);
+            new->content = mutt_make_message_attach(Context, Context->hdrs[i], 1);
             if (new->content)
               update_idx(menu, actx, new);
             else

--- a/compose.c
+++ b/compose.c
@@ -1150,15 +1150,15 @@ int mutt_compose_menu(struct Header *msg, /* structure for new message */
         {
           if (message_is_tagged(Context, i))
           {
-            new = (struct AttachPtr *) safe_calloc(1, sizeof(struct AttachPtr));
-            new->content = mutt_make_message_attach(Context, Context->hdrs[i], 1);
-            if (new->content)
-              update_idx(menu, actx, new);
-            else
-            {
-              mutt_error(_("Unable to attach!"));
-              FREE(&new);
-            }
+          new = (struct AttachPtr *) safe_calloc(1, sizeof(struct AttachPtr));
+          new->content = mutt_make_message_attach(Context, Context->hdrs[i], 1);
+          if (new->content != NULL)
+            update_idx(menu, actx, new);
+          else
+          {
+            mutt_error(_("Unable to attach!"));
+            FREE(&new);
+          }
           }
         }
         menu->redraw |= REDRAW_FULL;

--- a/compose.c
+++ b/compose.c
@@ -1148,8 +1148,9 @@ int mutt_compose_menu(struct Header *msg, /* structure for new message */
 
         for (i = 0; i < Context->msgcount; i++)
         {
-          if (message_is_tagged(Context, i))
-          {
+          if (!message_is_tagged(Context, i))
+            continue;
+
           new = (struct AttachPtr *) safe_calloc(1, sizeof(struct AttachPtr));
           new->content = mutt_make_message_attach(Context, Context->hdrs[i], 1);
           if (new->content != NULL)
@@ -1158,7 +1159,6 @@ int mutt_compose_menu(struct Header *msg, /* structure for new message */
           {
             mutt_error(_("Unable to attach!"));
             FREE(&new);
-          }
           }
         }
         menu->redraw |= REDRAW_FULL;

--- a/curs_lib.c
+++ b/curs_lib.c
@@ -43,8 +43,10 @@
 #include <wchar.h>
 #include "lib/lib.h"
 #include "mutt.h"
+#include "context.h"
 #include "enter_state.h"
 #include "globals.h"
+#include "header.h"
 #include "mbyte.h"
 #include "mutt_curses.h"
 #include "mutt_menu.h"
@@ -1460,4 +1462,33 @@ int mutt_strwidth(const char *s)
     w += wcwidth(wc);
   }
   return w;
+}
+
+/**
+ * message_is_visible - Is a message in the index within limit
+ * @param ctx   Open mailbox
+ * @param index Message ID (index into `ctx->hdrs[]`
+ * @retval bool True if the message is within limit
+ *
+ * If no limit is in effect, all the messages are visible.
+ */
+bool message_is_visible(struct Context *ctx, int index)
+{
+  if (!ctx || !ctx->hdrs || (index >= ctx->msgcount))
+    return false;
+
+  return !ctx->pattern || ctx->hdrs[index]->limited;
+}
+
+/**
+ * message_is_tagged - Is a message in the index tagged (and within limit)
+ * @param ctx   Open mailbox
+ * @param index Message ID (index into `ctx->hdrs[]`
+ * @retval bool True if the message is both tagged and within limit
+ *
+ * If a limit is in effect, the message must be visible within it.
+ */
+bool message_is_tagged(struct Context *ctx, int index)
+{
+  return message_is_visible(ctx, index) && ctx->hdrs[index]->tagged;
 }

--- a/curs_main.c
+++ b/curs_main.c
@@ -1631,8 +1631,9 @@ int mutt_index_menu(void)
         CHECK_VISIBLE;
         if (tag && !option(OPT_AUTO_TAG))
         {
-          for (j = 0; j < Context->vcount; j++)
-            mutt_set_flag(Context, Context->hdrs[Context->v2r[j]], MUTT_TAG, 0);
+          for (j = 0; j < Context->msgcount; j++)
+            if (message_is_visible(Context, j))
+              mutt_set_flag(Context, Context->hdrs[j], MUTT_TAG, 0);
           menu->redraw |= REDRAW_STATUS | REDRAW_INDEX;
         }
         else
@@ -1791,11 +1792,11 @@ int mutt_index_menu(void)
         CHECK_VISIBLE;
         if (tag)
         {
-          for (j = 0; j < Context->vcount; j++)
+          for (j = 0; j < Context->msgcount; j++)
           {
-            if (Context->hdrs[Context->v2r[j]]->tagged)
+            if (message_is_tagged(Context, j))
             {
-              Context->hdrs[Context->v2r[j]]->quasi_deleted = true;
+              Context->hdrs[j]->quasi_deleted = true;
               Context->changed = true;
             }
           }
@@ -1887,22 +1888,22 @@ int mutt_index_menu(void)
           if (Context->magic == MUTT_NOTMUCH)
             nm_longrun_init(Context, true);
 #endif
-          for (px = 0, j = 0; j < Context->vcount; j++)
+          for (px = 0, j = 0; j < Context->msgcount; j++)
           {
-            if (Context->hdrs[Context->v2r[j]]->tagged)
+            if (message_is_tagged(Context, j))
             {
               if (!Context->quiet)
                 mutt_progress_update(&progress, ++px, -1);
-              mx_tags_commit(Context, Context->hdrs[Context->v2r[j]], buf);
+              mx_tags_commit(Context, Context->hdrs[j], buf);
               if (op == OP_MAIN_MODIFY_TAGS_THEN_HIDE)
               {
                 bool still_queried = false;
 #ifdef USE_NOTMUCH
                 if (Context->magic == MUTT_NOTMUCH)
                   still_queried = nm_message_is_still_queried(
-                      Context, Context->hdrs[Context->v2r[j]]);
+                      Context, Context->hdrs[j]);
 #endif
-                Context->hdrs[Context->v2r[j]]->quasi_deleted = !still_queried;
+                Context->hdrs[j]->quasi_deleted = !still_queried;
                 Context->changed = true;
               }
             }
@@ -2527,11 +2528,11 @@ int mutt_index_menu(void)
 
         if (tag)
         {
-          for (j = 0; j < Context->vcount; j++)
+          for (j = 0; j < Context->msgcount; j++)
           {
-            if (Context->hdrs[Context->v2r[j]]->tagged)
-              mutt_set_flag(Context, Context->hdrs[Context->v2r[j]], MUTT_FLAG,
-                            !Context->hdrs[Context->v2r[j]]->flagged);
+            if (message_is_tagged(Context, j))
+              mutt_set_flag(Context, Context->hdrs[j], MUTT_FLAG,
+                            !Context->hdrs[j]->flagged);
           }
 
           menu->redraw |= REDRAW_INDEX;
@@ -2566,15 +2567,15 @@ int mutt_index_menu(void)
 
         if (tag)
         {
-          for (j = 0; j < Context->vcount; j++)
+          for (j = 0; j < Context->msgcount; j++)
           {
-            if (Context->hdrs[Context->v2r[j]]->tagged)
+            if (message_is_tagged(Context, j))
             {
-              if (Context->hdrs[Context->v2r[j]]->read ||
-                  Context->hdrs[Context->v2r[j]]->old)
-                mutt_set_flag(Context, Context->hdrs[Context->v2r[j]], MUTT_NEW, 1);
+              if (Context->hdrs[j]->read ||
+                  Context->hdrs[j]->old)
+                mutt_set_flag(Context, Context->hdrs[j], MUTT_NEW, 1);
               else
-                mutt_set_flag(Context, Context->hdrs[Context->v2r[j]], MUTT_READ, 1);
+                mutt_set_flag(Context, Context->hdrs[j], MUTT_READ, 1);
             }
           }
           menu->redraw |= REDRAW_STATUS | REDRAW_INDEX;
@@ -3107,10 +3108,10 @@ int mutt_index_menu(void)
 
         if (tag)
         {
-          for (j = 0; j < Context->vcount; j++)
+          for (j = 0; j < Context->msgcount; j++)
           {
-            if (Context->hdrs[Context->v2r[j]]->tagged)
-              mutt_resend_message(NULL, Context, Context->hdrs[Context->v2r[j]]);
+            if (message_is_tagged(Context, j))
+              mutt_resend_message(NULL, Context, Context->hdrs[j]);
           }
         }
         else

--- a/curs_main.c
+++ b/curs_main.c
@@ -1890,8 +1890,9 @@ int mutt_index_menu(void)
 #endif
           for (px = 0, j = 0; j < Context->msgcount; j++)
           {
-            if (message_is_tagged(Context, j))
-            {
+            if (!message_is_tagged(Context, j))
+              continue;
+
             if (!Context->quiet)
               mutt_progress_update(&progress, ++px, -1);
             mx_tags_commit(Context, Context->hdrs[j], buf);
@@ -1904,7 +1905,6 @@ int mutt_index_menu(void)
 #endif
               Context->hdrs[j]->quasi_deleted = !still_queried;
               Context->changed = true;
-            }
             }
           }
 #ifdef USE_NOTMUCH
@@ -2568,13 +2568,13 @@ int mutt_index_menu(void)
         {
           for (j = 0; j < Context->msgcount; j++)
           {
-            if (message_is_tagged(Context, j))
-            {
+            if (!message_is_tagged(Context, j))
+              continue;
+
             if (Context->hdrs[j]->read || Context->hdrs[j]->old)
               mutt_set_flag(Context, Context->hdrs[j], MUTT_NEW, 1);
             else
               mutt_set_flag(Context, Context->hdrs[j], MUTT_READ, 1);
-            }
           }
           menu->redraw |= REDRAW_STATUS | REDRAW_INDEX;
         }

--- a/curs_main.c
+++ b/curs_main.c
@@ -1892,20 +1892,19 @@ int mutt_index_menu(void)
           {
             if (message_is_tagged(Context, j))
             {
-              if (!Context->quiet)
-                mutt_progress_update(&progress, ++px, -1);
-              mx_tags_commit(Context, Context->hdrs[j], buf);
-              if (op == OP_MAIN_MODIFY_TAGS_THEN_HIDE)
-              {
-                bool still_queried = false;
+            if (!Context->quiet)
+              mutt_progress_update(&progress, ++px, -1);
+            mx_tags_commit(Context, Context->hdrs[j], buf);
+            if (op == OP_MAIN_MODIFY_TAGS_THEN_HIDE)
+            {
+              bool still_queried = false;
 #ifdef USE_NOTMUCH
-                if (Context->magic == MUTT_NOTMUCH)
-                  still_queried = nm_message_is_still_queried(
-                      Context, Context->hdrs[j]);
+              if (Context->magic == MUTT_NOTMUCH)
+                still_queried = nm_message_is_still_queried(Context, Context->hdrs[j]);
 #endif
-                Context->hdrs[j]->quasi_deleted = !still_queried;
-                Context->changed = true;
-              }
+              Context->hdrs[j]->quasi_deleted = !still_queried;
+              Context->changed = true;
+            }
             }
           }
 #ifdef USE_NOTMUCH
@@ -2571,11 +2570,10 @@ int mutt_index_menu(void)
           {
             if (message_is_tagged(Context, j))
             {
-              if (Context->hdrs[j]->read ||
-                  Context->hdrs[j]->old)
-                mutt_set_flag(Context, Context->hdrs[j], MUTT_NEW, 1);
-              else
-                mutt_set_flag(Context, Context->hdrs[j], MUTT_READ, 1);
+            if (Context->hdrs[j]->read || Context->hdrs[j]->old)
+              mutt_set_flag(Context, Context->hdrs[j], MUTT_NEW, 1);
+            else
+              mutt_set_flag(Context, Context->hdrs[j], MUTT_READ, 1);
             }
           }
           menu->redraw |= REDRAW_STATUS | REDRAW_INDEX;

--- a/editmsg.c
+++ b/editmsg.c
@@ -226,12 +226,11 @@ int mutt_edit_message(struct Context *ctx, struct Header *hdr)
   if (hdr)
     return edit_one_message(ctx, hdr);
 
-  for (int i = 0; i < ctx->vcount; i++)
+  for (int i = 0; i < ctx->msgcount; i++)
   {
-    int j = ctx->v2r[i];
-    if (ctx->hdrs[j]->tagged)
+    if (message_is_tagged(ctx, i))
     {
-      if (edit_one_message(ctx, ctx->hdrs[j]) == -1)
+      if (edit_one_message(ctx, ctx->hdrs[i]) == -1)
         return -1;
     }
   }

--- a/editmsg.c
+++ b/editmsg.c
@@ -228,11 +228,11 @@ int mutt_edit_message(struct Context *ctx, struct Header *hdr)
 
   for (int i = 0; i < ctx->msgcount; i++)
   {
-    if (message_is_tagged(ctx, i))
-    {
+    if (!message_is_tagged(ctx, i))
+      continue;
+
     if (edit_one_message(ctx, ctx->hdrs[i]) == -1)
       return -1;
-    }
   }
 
   return 0;

--- a/editmsg.c
+++ b/editmsg.c
@@ -230,8 +230,8 @@ int mutt_edit_message(struct Context *ctx, struct Header *hdr)
   {
     if (message_is_tagged(ctx, i))
     {
-      if (edit_one_message(ctx, ctx->hdrs[i]) == -1)
-        return -1;
+    if (edit_one_message(ctx, ctx->hdrs[i]) == -1)
+      return -1;
     }
   }
 

--- a/flags.c
+++ b/flags.c
@@ -334,9 +334,9 @@ void _mutt_set_flag(struct Context *ctx, struct Header *h, int flag, int bf, int
  */
 void mutt_tag_set_flag(int flag, int bf)
 {
-  for (int i = 0; i < Context->vcount; i++)
-    if (Context->hdrs[Context->v2r[i]]->tagged)
-      mutt_set_flag(Context, Context->hdrs[Context->v2r[i]], flag, bf);
+  for (int i = 0; i < Context->msgcount; i++)
+    if (message_is_tagged(Context, i))
+      mutt_set_flag(Context, Context->hdrs[i], flag, bf);
 }
 
 int mutt_thread_set_flag(struct Header *hdr, int flag, int bf, int subthread)

--- a/headers.c
+++ b/headers.c
@@ -317,13 +317,13 @@ int mutt_label_message(struct Header *hdr)
     {
       if (message_is_tagged(Context, i))
       {
-        struct Header *h = Context->hdrs[i];
-        if (label_message(Context, h, new))
-        {
-          changed++;
-          mutt_set_flag(Context, h, MUTT_TAG, 0);
-          /* mutt_set_flag re-evals the header color */
-        }
+      struct Header *h = Context->hdrs[i];
+      if (label_message(Context, h, new))
+      {
+        changed++;
+        mutt_set_flag(Context, h, MUTT_TAG, 0);
+        /* mutt_set_flag re-evals the header color */
+      }
       }
     }
   }

--- a/headers.c
+++ b/headers.c
@@ -315,15 +315,15 @@ int mutt_label_message(struct Header *hdr)
   {
     for (int i = 0; i < Context->msgcount; ++i)
     {
-      if (message_is_tagged(Context, i))
-      {
+      if (!message_is_tagged(Context, i))
+        continue;
+
       struct Header *h = Context->hdrs[i];
       if (label_message(Context, h, new))
       {
         changed++;
         mutt_set_flag(Context, h, MUTT_TAG, 0);
         /* mutt_set_flag re-evals the header color */
-      }
       }
     }
   }

--- a/headers.c
+++ b/headers.c
@@ -313,16 +313,18 @@ int mutt_label_message(struct Header *hdr)
   }
   else
   {
-#define HDR_OF(index) Context->hdrs[Context->v2r[(index)]]
-    for (int i = 0; i < Context->vcount; ++i)
+    for (int i = 0; i < Context->msgcount; ++i)
     {
-      if (HDR_OF(i)->tagged)
-        if (label_message(Context, HDR_OF(i), new))
+      if (message_is_tagged(Context, i))
+      {
+        struct Header *h = Context->hdrs[i];
+        if (label_message(Context, h, new))
         {
           changed++;
-          mutt_set_flag(Context, HDR_OF(i), MUTT_TAG, 0);
+          mutt_set_flag(Context, h, MUTT_TAG, 0);
           /* mutt_set_flag re-evals the header color */
         }
+      }
     }
   }
 

--- a/imap/message.c
+++ b/imap/message.c
@@ -1275,14 +1275,17 @@ int imap_copy_messages(struct Context *ctx, struct Header *h, char *dest, int de
        * remainder. */
       for (int i = 0; i < ctx->msgcount; i++)
       {
-        if (message_is_tagged(ctx, i) && ctx->hdrs[i]->attach_del)
+        if (!message_is_tagged(ctx, i))
+          continue;
+
+        if (ctx->hdrs[i]->attach_del)
         {
           mutt_debug(3, "imap_copy_messages: Message contains attachments to "
                         "be deleted\n");
           return 1;
         }
 
-        if (message_is_tagged(ctx, i) && ctx->hdrs[i]->active && ctx->hdrs[i]->changed)
+        if (ctx->hdrs[i]->active && ctx->hdrs[i]->changed)
         {
           rc = imap_sync_message_for_copy(idata, ctx->hdrs[i], &sync_cmd, &err_continue);
           if (rc < 0)
@@ -1368,13 +1371,13 @@ int imap_copy_messages(struct Context *ctx, struct Header *h, char *dest, int de
     {
       for (int i = 0; i < ctx->msgcount; i++)
       {
-        if (message_is_tagged(ctx, i))
-        {
+        if (!message_is_tagged(ctx, i))
+          continue;
+
         mutt_set_flag(ctx, ctx->hdrs[i], MUTT_DELETE, 1);
         mutt_set_flag(ctx, ctx->hdrs[i], MUTT_PURGE, 1);
         if (option(OPT_DELETE_UNTAG))
           mutt_set_flag(ctx, ctx->hdrs[i], MUTT_TAG, 0);
-        }
       }
     }
     else

--- a/imap/message.c
+++ b/imap/message.c
@@ -1275,14 +1275,14 @@ int imap_copy_messages(struct Context *ctx, struct Header *h, char *dest, int de
        * remainder. */
       for (int i = 0; i < ctx->msgcount; i++)
       {
-        if (ctx->hdrs[i]->tagged && ctx->hdrs[i]->attach_del)
+        if (message_is_tagged(ctx, i) && ctx->hdrs[i]->attach_del)
         {
           mutt_debug(3, "imap_copy_messages: Message contains attachments to "
                         "be deleted\n");
           return 1;
         }
 
-        if (ctx->hdrs[i]->tagged && ctx->hdrs[i]->active && ctx->hdrs[i]->changed)
+        if (message_is_tagged(ctx, i) && ctx->hdrs[i]->active && ctx->hdrs[i]->changed)
         {
           rc = imap_sync_message_for_copy(idata, ctx->hdrs[i], &sync_cmd, &err_continue);
           if (rc < 0)
@@ -1368,7 +1368,7 @@ int imap_copy_messages(struct Context *ctx, struct Header *h, char *dest, int de
     {
       for (int i = 0; i < ctx->msgcount; i++)
       {
-        if (ctx->hdrs[i]->tagged)
+        if (message_is_tagged(ctx, i))
         {
           mutt_set_flag(ctx, ctx->hdrs[i], MUTT_DELETE, 1);
           mutt_set_flag(ctx, ctx->hdrs[i], MUTT_PURGE, 1);

--- a/imap/message.c
+++ b/imap/message.c
@@ -1370,10 +1370,10 @@ int imap_copy_messages(struct Context *ctx, struct Header *h, char *dest, int de
       {
         if (message_is_tagged(ctx, i))
         {
-          mutt_set_flag(ctx, ctx->hdrs[i], MUTT_DELETE, 1);
-          mutt_set_flag(ctx, ctx->hdrs[i], MUTT_PURGE, 1);
-          if (option(OPT_DELETE_UNTAG))
-            mutt_set_flag(ctx, ctx->hdrs[i], MUTT_TAG, 0);
+        mutt_set_flag(ctx, ctx->hdrs[i], MUTT_DELETE, 1);
+        mutt_set_flag(ctx, ctx->hdrs[i], MUTT_PURGE, 1);
+        if (option(OPT_DELETE_UNTAG))
+          mutt_set_flag(ctx, ctx->hdrs[i], MUTT_TAG, 0);
         }
       }
     }

--- a/ncrypt/crypt.c
+++ b/ncrypt/crypt.c
@@ -710,8 +710,9 @@ void crypt_extract_keys_from_messages(struct Header *h)
   {
     for (int i = 0; i < Context->msgcount; i++)
     {
-      if (message_is_tagged(Context, i))
-      {
+      if (!message_is_tagged(Context, i))
+        continue;
+
       struct Header *h = Context->hdrs[i];
 
       mutt_parse_mime_message(Context, h);
@@ -754,7 +755,6 @@ void crypt_extract_keys_from_messages(struct Header *h)
       }
 
       rewind(fpout);
-      }
     }
   }
   else

--- a/ncrypt/crypt.c
+++ b/ncrypt/crypt.c
@@ -708,22 +708,24 @@ void crypt_extract_keys_from_messages(struct Header *h)
 
   if (!h)
   {
-    for (int i = 0; i < Context->vcount; i++)
+    for (int i = 0; i < Context->msgcount; i++)
     {
-      if (Context->hdrs[Context->v2r[i]]->tagged)
+      if (message_is_tagged(Context, i))
       {
-        mutt_parse_mime_message(Context, Context->hdrs[Context->v2r[i]]);
-        if (Context->hdrs[Context->v2r[i]]->security & ENCRYPT &&
-            !crypt_valid_passphrase(Context->hdrs[Context->v2r[i]]->security))
+        struct Header *h = Context->hdrs[i];
+
+        mutt_parse_mime_message(Context, h);
+        if (h->security & ENCRYPT &&
+            !crypt_valid_passphrase(h->security))
         {
           safe_fclose(&fpout);
           break;
         }
 
         if ((WithCrypto & APPLICATION_PGP) &&
-            (Context->hdrs[Context->v2r[i]]->security & APPLICATION_PGP))
+            (h->security & APPLICATION_PGP))
         {
-          mutt_copy_message(fpout, Context, Context->hdrs[Context->v2r[i]],
+          mutt_copy_message(fpout, Context, h,
                             MUTT_CM_DECODE | MUTT_CM_CHARCONV, 0);
           fflush(fpout);
 
@@ -732,20 +734,20 @@ void crypt_extract_keys_from_messages(struct Header *h)
         }
 
         if ((WithCrypto & APPLICATION_SMIME) &&
-            (Context->hdrs[Context->v2r[i]]->security & APPLICATION_SMIME))
+            (h->security & APPLICATION_SMIME))
         {
-          if (Context->hdrs[Context->v2r[i]]->security & ENCRYPT)
-            mutt_copy_message(fpout, Context, Context->hdrs[Context->v2r[i]],
+          if (h->security & ENCRYPT)
+            mutt_copy_message(fpout, Context, h,
                               MUTT_CM_NOHEADER | MUTT_CM_DECODE_CRYPT | MUTT_CM_DECODE_SMIME,
                               0);
           else
-            mutt_copy_message(fpout, Context, Context->hdrs[Context->v2r[i]], 0, 0);
+            mutt_copy_message(fpout, Context, h, 0, 0);
           fflush(fpout);
 
-          if (Context->hdrs[Context->v2r[i]]->env->from)
-            tmp = mutt_expand_aliases(Context->hdrs[Context->v2r[i]]->env->from);
-          else if (Context->hdrs[Context->v2r[i]]->env->sender)
-            tmp = mutt_expand_aliases(Context->hdrs[Context->v2r[i]]->env->sender);
+          if (h->env->from)
+            tmp = mutt_expand_aliases(h->env->from);
+          else if (h->env->sender)
+            tmp = mutt_expand_aliases(h->env->sender);
           mbox = tmp ? tmp->mailbox : NULL;
           if (mbox)
           {

--- a/ncrypt/crypt.c
+++ b/ncrypt/crypt.c
@@ -712,52 +712,48 @@ void crypt_extract_keys_from_messages(struct Header *h)
     {
       if (message_is_tagged(Context, i))
       {
-        struct Header *h = Context->hdrs[i];
+      struct Header *h = Context->hdrs[i];
 
-        mutt_parse_mime_message(Context, h);
-        if (h->security & ENCRYPT &&
-            !crypt_valid_passphrase(h->security))
-        {
-          safe_fclose(&fpout);
-          break;
-        }
+      mutt_parse_mime_message(Context, h);
+      if (h->security & ENCRYPT && !crypt_valid_passphrase(h->security))
+      {
+        safe_fclose(&fpout);
+        break;
+      }
 
-        if ((WithCrypto & APPLICATION_PGP) &&
-            (h->security & APPLICATION_PGP))
-        {
+      if ((WithCrypto & APPLICATION_PGP) && (h->security & APPLICATION_PGP))
+      {
+        mutt_copy_message(fpout, Context, h, MUTT_CM_DECODE | MUTT_CM_CHARCONV, 0);
+        fflush(fpout);
+
+        mutt_endwin(_("Trying to extract PGP keys...\n"));
+        crypt_pgp_invoke_import(tempfname);
+      }
+
+      if ((WithCrypto & APPLICATION_SMIME) && (h->security & APPLICATION_SMIME))
+      {
+        if (h->security & ENCRYPT)
           mutt_copy_message(fpout, Context, h,
-                            MUTT_CM_DECODE | MUTT_CM_CHARCONV, 0);
-          fflush(fpout);
+                            MUTT_CM_NOHEADER | MUTT_CM_DECODE_CRYPT | MUTT_CM_DECODE_SMIME,
+                            0);
+        else
+          mutt_copy_message(fpout, Context, h, 0, 0);
+        fflush(fpout);
 
-          mutt_endwin(_("Trying to extract PGP keys...\n"));
-          crypt_pgp_invoke_import(tempfname);
-        }
-
-        if ((WithCrypto & APPLICATION_SMIME) &&
-            (h->security & APPLICATION_SMIME))
+        if (h->env->from)
+          tmp = mutt_expand_aliases(h->env->from);
+        else if (h->env->sender)
+          tmp = mutt_expand_aliases(h->env->sender);
+        mbox = tmp ? tmp->mailbox : NULL;
+        if (mbox)
         {
-          if (h->security & ENCRYPT)
-            mutt_copy_message(fpout, Context, h,
-                              MUTT_CM_NOHEADER | MUTT_CM_DECODE_CRYPT | MUTT_CM_DECODE_SMIME,
-                              0);
-          else
-            mutt_copy_message(fpout, Context, h, 0, 0);
-          fflush(fpout);
-
-          if (h->env->from)
-            tmp = mutt_expand_aliases(h->env->from);
-          else if (h->env->sender)
-            tmp = mutt_expand_aliases(h->env->sender);
-          mbox = tmp ? tmp->mailbox : NULL;
-          if (mbox)
-          {
-            mutt_endwin(_("Trying to extract S/MIME certificates...\n"));
-            crypt_smime_invoke_import(tempfname, mbox);
-            tmp = NULL;
-          }
+          mutt_endwin(_("Trying to extract S/MIME certificates...\n"));
+          crypt_smime_invoke_import(tempfname, mbox);
+          tmp = NULL;
         }
+      }
 
-        rewind(fpout);
+      rewind(fpout);
       }
     }
   }

--- a/protos.h
+++ b/protos.h
@@ -397,4 +397,7 @@ int ci_send_message(int flags, struct Header *msg, char *tempfile, struct Contex
 int wcscasecmp(const wchar_t *a, const wchar_t *b);
 #endif
 
+bool message_is_tagged(struct Context *ctx, int index);
+bool message_is_visible(struct Context *ctx, int index);
+
 #endif /* _MUTT_PROTOS_H */

--- a/send.c
+++ b/send.c
@@ -768,9 +768,9 @@ static int envelope_defaults(struct Envelope *env, struct Context *ctx,
     for (int i = 0; i < ctx->msgcount; i++)
       if (message_is_tagged(ctx, i))
       {
-        cur = ctx->hdrs[i];
-        curenv = cur->env;
-        break;
+      cur = ctx->hdrs[i];
+      curenv = cur->env;
+      break;
       }
 
     if (!cur)
@@ -860,12 +860,12 @@ static int generate_body(FILE *tempfp, struct Header *msg, int flags,
         {
           if (message_is_tagged(ctx, i))
           {
-            if (include_reply(ctx, ctx->hdrs[i], tempfp) == -1)
-            {
-              mutt_error(_("Could not include all requested messages!"));
-              return -1;
-            }
-            fputc('\n', tempfp);
+          if (include_reply(ctx, ctx->hdrs[i], tempfp) == -1)
+          {
+            mutt_error(_("Could not include all requested messages!"));
+            return -1;
+          }
+          fputc('\n', tempfp);
           }
         }
       }
@@ -899,14 +899,14 @@ static int generate_body(FILE *tempfp, struct Header *msg, int flags,
         {
           if (message_is_tagged(ctx, i))
           {
-            tmp = mutt_make_message_attach(ctx, ctx->hdrs[i], 0);
-            if (last)
-            {
-              last->next = tmp;
-              last = tmp;
-            }
-            else
-              last = msg->content = tmp;
+          tmp = mutt_make_message_attach(ctx, ctx->hdrs[i], 0);
+          if (last)
+          {
+            last->next = tmp;
+            last = tmp;
+          }
+          else
+            last = msg->content = tmp;
           }
         }
       }
@@ -2186,8 +2186,7 @@ int ci_send_message(int flags, struct Header *msg, char *tempfile,
     {
       for (i = 0; i < ctx->msgcount; i++)
         if (message_is_tagged(ctx, i))
-          mutt_set_flag(ctx, ctx->hdrs[i], MUTT_REPLIED,
-                        is_reply(ctx->hdrs[i], msg));
+          mutt_set_flag(ctx, ctx->hdrs[i], MUTT_REPLIED, is_reply(ctx->hdrs[i], msg));
     }
   }
 

--- a/send.c
+++ b/send.c
@@ -739,12 +739,10 @@ static void make_reference_headers(struct Envelope *curenv,
 
   if (!curenv)
   {
-    struct Header *h = NULL;
-    for (int i = 0; i < ctx->vcount; i++)
+    for (int i = 0; i < ctx->msgcount; i++)
     {
-      h = ctx->hdrs[ctx->v2r[i]];
-      if (h->tagged)
-        mutt_add_to_reference_headers(env, h->env);
+      if (message_is_tagged(ctx, i))
+        mutt_add_to_reference_headers(env, ctx->hdrs[i]->env);
     }
   }
   else
@@ -767,10 +765,10 @@ static int envelope_defaults(struct Envelope *env, struct Context *ctx,
   if (!cur)
   {
     tag = true;
-    for (int i = 0; i < ctx->vcount; i++)
-      if (ctx->hdrs[ctx->v2r[i]]->tagged)
+    for (int i = 0; i < ctx->msgcount; i++)
+      if (message_is_tagged(ctx, i))
       {
-        cur = ctx->hdrs[ctx->v2r[i]];
+        cur = ctx->hdrs[i];
         curenv = cur->env;
         break;
       }
@@ -803,12 +801,9 @@ static int envelope_defaults(struct Envelope *env, struct Context *ctx,
 #endif
         if (tag)
     {
-      struct Header *h = NULL;
-
-      for (int i = 0; i < ctx->vcount; i++)
+      for (int i = 0; i < ctx->msgcount; i++)
       {
-        h = ctx->hdrs[ctx->v2r[i]];
-        if (h->tagged && mutt_fetch_recips(env, h->env, flags) == -1)
+        if (message_is_tagged(ctx, i) && (mutt_fetch_recips(env, ctx->hdrs[i]->env, flags) == -1))
           return -1;
       }
     }
@@ -848,7 +843,6 @@ static int generate_body(FILE *tempfp, struct Header *msg, int flags,
                          struct Context *ctx, struct Header *cur)
 {
   int i;
-  struct Header *h = NULL;
   struct Body *tmp = NULL;
 
   if (flags & SENDREPLY)
@@ -862,12 +856,11 @@ static int generate_body(FILE *tempfp, struct Header *msg, int flags,
       mutt_message(_("Including quoted message..."));
       if (!cur)
       {
-        for (i = 0; i < ctx->vcount; i++)
+        for (i = 0; i < ctx->msgcount; i++)
         {
-          h = ctx->hdrs[ctx->v2r[i]];
-          if (h->tagged)
+          if (message_is_tagged(ctx, i))
           {
-            if (include_reply(ctx, h, tempfp) == -1)
+            if (include_reply(ctx, ctx->hdrs[i], tempfp) == -1)
             {
               mutt_error(_("Could not include all requested messages!"));
               return -1;
@@ -902,11 +895,11 @@ static int generate_body(FILE *tempfp, struct Header *msg, int flags,
       }
       else
       {
-        for (i = 0; i < ctx->vcount; i++)
+        for (i = 0; i < ctx->msgcount; i++)
         {
-          if (ctx->hdrs[ctx->v2r[i]]->tagged)
+          if (message_is_tagged(ctx, i))
           {
-            tmp = mutt_make_message_attach(ctx, ctx->hdrs[ctx->v2r[i]], 0);
+            tmp = mutt_make_message_attach(ctx, ctx->hdrs[i], 0);
             if (last)
             {
               last->next = tmp;
@@ -923,9 +916,9 @@ static int generate_body(FILE *tempfp, struct Header *msg, int flags,
       if (cur)
         include_forward(ctx, cur, tempfp);
       else
-        for (i = 0; i < ctx->vcount; i++)
-          if (ctx->hdrs[ctx->v2r[i]]->tagged)
-            include_forward(ctx, ctx->hdrs[ctx->v2r[i]], tempfp);
+        for (i = 0; i < ctx->msgcount; i++)
+          if (message_is_tagged(ctx, i))
+            include_forward(ctx, ctx->hdrs[i], tempfp);
     }
     else if (i == -1)
       return -1;
@@ -1201,11 +1194,10 @@ int mutt_compose_to_sender(struct Header *hdr)
   msg->env = mutt_new_envelope();
   if (!hdr)
   {
-    for (int i = 0; i < Context->vcount; i++)
+    for (int i = 0; i < Context->msgcount; i++)
     {
-      hdr = Context->hdrs[Context->v2r[(i)]];
-      if (hdr->tagged)
-        rfc822_append(&msg->env->to, hdr->env->from, 0);
+      if (message_is_tagged(Context, i))
+        rfc822_append(&msg->env->to, Context->hdrs[i]->env->from, 0);
     }
   }
   else
@@ -2192,10 +2184,10 @@ int ci_send_message(int flags, struct Header *msg, char *tempfile,
       mutt_set_flag(ctx, cur, MUTT_REPLIED, is_reply(cur, msg));
     else if (!(flags & SENDPOSTPONED) && ctx && ctx->tagged)
     {
-      for (i = 0; i < ctx->vcount; i++)
-        if (ctx->hdrs[ctx->v2r[i]]->tagged)
-          mutt_set_flag(ctx, ctx->hdrs[ctx->v2r[i]], MUTT_REPLIED,
-                        is_reply(ctx->hdrs[ctx->v2r[i]], msg));
+      for (i = 0; i < ctx->msgcount; i++)
+        if (message_is_tagged(ctx, i))
+          mutt_set_flag(ctx, ctx->hdrs[i], MUTT_REPLIED,
+                        is_reply(ctx->hdrs[i], msg));
     }
   }
 

--- a/sendlib.c
+++ b/sendlib.c
@@ -2759,7 +2759,7 @@ static int _mutt_bounce_message(FILE *fp, struct Header *h, struct Address *to,
   {
     /* Try to bounce each message out, aborting if we get any failures. */
     for (int i = 0; i < Context->msgcount; i++)
-      if (Context->hdrs[i]->tagged)
+      if (message_is_tagged(Context, i))
         ret |= _mutt_bounce_message(fp, Context->hdrs[i], to, resent_from, env_from);
     return ret;
   }

--- a/thread.c
+++ b/thread.c
@@ -1472,9 +1472,9 @@ int mutt_link_threads(struct Header *cur, struct Header *last, struct Context *c
 
   if (!last)
   {
-    for (int i = 0; i < ctx->vcount; i++)
-      if (ctx->hdrs[Context->v2r[i]]->tagged)
-        changed |= link_threads(cur, ctx->hdrs[Context->v2r[i]], ctx);
+    for (int i = 0; i < ctx->msgcount; i++)
+      if (message_is_tagged(ctx, i))
+        changed |= link_threads(cur, ctx->hdrs[i], ctx);
   }
   else
     changed = link_threads(cur, last, ctx);


### PR DESCRIPTION
Many actions aren't performed on all tagged messages if the messages are within a collapsed thread.

Fixes #697

### Overview

The `Context` has two lists of emails:

- `struct Header **hdrs`
  A list of all emails
- `int v2r []`
  A lookup table of **visible** emails (what's seen in the index)

An email may be invisible if it's in a collapsed thread,
or if it doesn't match a `limit` pattern.

### Bug

Actions aren't being applied to tagged, but collapsed, threads.
e.g.

- \<tag-thread\>\<collapse-thread\>\<tag-prefix\>\<flag-message\>
- Expected action: all the emails in the thread are flagged
- Actual action: only the parent email is flagged

A closer inspection showed the problem to be widespread.
The incorrect code was looping through the `v2r` table of visible emails looking
for those that were tagged.

### Tests

1. Threads open, Tag a thread, Perform an action
   Result: Action is performed on every email in the thread
1. Threads closed, Tag a thread, Perform an action
   Result: Action is performed on every email in the thread
1. Threads open, Tag everything, Limit to a single thread, Perform an action
   Result: Action is performed on every email in the thread, but nothing else

### Fix

My first attempt at a fix, changed the code to loop through `hdrs` looking for
tagged emails.  This suffered from a different problem -- it applied functions
to tagged emails that were outside the limit pattern.

Now, the checks have been factored out into a new function `bool message_is_tagged()`
If the message is tagged **and** within the current limit (if applicable).

### Results

There are thirty changes to twenty functions.
I suspect this broken code has been cut'n'pasted for a long time.

Functions/actions that acted on messages outside of the limit pattern:

- ci_bounce_message
- imap_copy_messages * 2
- mutt_compose_menu (attach-message)
- mutt_index_menu (modify-tags)
- _mutt_bounce_message

Functions/actions that didn't act on collapsed threads:

- crypt_extract_keys_from_messages
- make_reference_headers
- mutt_check_traditional_pgp
- mutt_edit_message
- mutt_index_menu (flag-message)
- mutt_index_menu (quasi-delete)
- mutt_index_menu (resend-message)
- mutt_index_menu (tag-tag)
- mutt_index_menu (toggle-new)
- mutt_label_message
- mutt_link_threads
- mutt_save_message
- mutt_save_message
- _mutt_pipe_message * 3
- _mutt_set_flag
