### PR TITLE
split up 'if' statements that assign and test

### DIFF
--- a/alias.c
+++ b/alias.c
@@ -358,7 +358,8 @@ retry_name:
       return;
     }
 
-    if ((new->addr = rfc822_parse_adrlist(new->addr, buf)) == NULL)
+    new->addr = rfc822_parse_adrlist(new->addr, buf);
+    if (!new->addr)
       BEEP();
     if (mutt_addrlist_to_intl(new->addr, &err))
     {

--- a/attach.c
+++ b/attach.c
@@ -138,7 +138,8 @@ int mutt_compose_attachment(struct Body *a)
         int r;
 
         mutt_endwin(NULL);
-        if ((r = mutt_system(command)) == -1)
+        r = mutt_system(command);
+        if (r == -1)
           mutt_error(_("Error running \"%s\"!"), command);
 
         if (r != -1 && entry->composetypecommand)
@@ -147,7 +148,8 @@ int mutt_compose_attachment(struct Body *a)
           FILE *fp = NULL, *tfp = NULL;
           char tempfile[_POSIX_PATH_MAX];
 
-          if ((fp = safe_fopen(a->filename, "r")) == NULL)
+          fp = safe_fopen(a->filename, "r");
+          if (!fp)
           {
             mutt_perror(_("Failure to open file to parse headers."));
             goto bailout;
@@ -179,7 +181,8 @@ int mutt_compose_attachment(struct Body *a)
              * copying the file back */
             fseeko(fp, b->offset, SEEK_SET);
             mutt_mktemp(tempfile, sizeof(tempfile));
-            if ((tfp = safe_fopen(tempfile, "w")) == NULL)
+            tfp = safe_fopen(tempfile, "w");
+            if (!tfp)
             {
               mutt_perror(_("Failure to open file to strip headers."));
               goto bailout;
@@ -320,7 +323,8 @@ void mutt_check_lookup_list(struct Body *b, char *type, int len)
     {
       struct Body tmp = { 0 };
       int n;
-      if ((n = mutt_lookup_mime_type(&tmp, b->filename)) != TYPEOTHER)
+      n = mutt_lookup_mime_type(&tmp, b->filename);
+      if (n != TYPEOTHER)
       {
         snprintf(type, len, "%s/%s",
                  n == TYPEAUDIO ?
@@ -688,7 +692,8 @@ int mutt_pipe_attachment(FILE *fp, struct Body *b, const char *path, char *outfi
 
     FILE *ifp = NULL, *ofp = NULL;
 
-    if ((ifp = fopen(b->filename, "r")) == NULL)
+    ifp = fopen(b->filename, "r");
+    if (!ifp)
     {
       mutt_perror("fopen");
       if (outfile && *outfile)
@@ -780,7 +785,8 @@ int mutt_save_attachment(FILE *fp, struct Body *m, char *path, int flags, struct
         return -1;
       if (mx_open_mailbox(path, MUTT_APPEND | MUTT_QUIET, &ctx) == NULL)
         return -1;
-      if ((msg = mx_open_new_message(&ctx, hn, is_from(buf, NULL, 0, NULL) ? 0 : MUTT_ADD_FROM)) == NULL)
+      msg = mx_open_new_message(&ctx, hn, is_from(buf, NULL, 0, NULL) ? 0 : MUTT_ADD_FROM);
+      if (!msg)
       {
         mx_close_mailbox(&ctx, NULL);
         return -1;
@@ -805,7 +811,8 @@ int mutt_save_attachment(FILE *fp, struct Body *m, char *path, int flags, struct
       struct State s;
 
       memset(&s, 0, sizeof(s));
-      if ((s.fpout = save_attachment_open(path, flags)) == NULL)
+      s.fpout = save_attachment_open(path, flags);
+      if (!s.fpout)
       {
         mutt_perror("fopen");
         mutt_sleep(2);
@@ -831,13 +838,15 @@ int mutt_save_attachment(FILE *fp, struct Body *m, char *path, int flags, struct
 
     FILE *ofp = NULL, *nfp = NULL;
 
-    if ((ofp = fopen(m->filename, "r")) == NULL)
+    ofp = fopen(m->filename, "r");
+    if (!ofp)
     {
       mutt_perror("fopen");
       return -1;
     }
 
-    if ((nfp = save_attachment_open(path, flags)) == NULL)
+    nfp = save_attachment_open(path, flags);
+    if (!nfp)
     {
       mutt_perror("fopen");
       safe_fclose(&ofp);
@@ -904,7 +913,8 @@ int mutt_decode_save_attachment(FILE *fp, struct Body *m, char *path, int displa
       return -1;
     }
 
-    if ((s.fpin = fopen(m->filename, "r")) == NULL)
+    s.fpin = fopen(m->filename, "r");
+    if (!s.fpin)
     {
       mutt_perror("fopen");
       return -1;
@@ -1011,7 +1021,8 @@ int mutt_print_attachment(FILE *fp, struct Body *a)
     /* interactive program */
     if (piped)
     {
-      if ((ifp = fopen(newfile, "r")) == NULL)
+      ifp = fopen(newfile, "r");
+      if (!ifp)
       {
         mutt_perror("fopen");
         rfc1524_free_entry(&entry);
@@ -1065,7 +1076,8 @@ int mutt_print_attachment(FILE *fp, struct Body *a)
     {
       mutt_debug(2, "successfully decoded %s type attachment to %s\n", type, newfile);
 
-      if ((ifp = fopen(newfile, "r")) == NULL)
+      ifp = fopen(newfile, "r");
+      if (!ifp)
       {
         mutt_perror("fopen");
         goto bail0;

--- a/browser.c
+++ b/browser.c
@@ -716,7 +716,8 @@ static int examine_directory(struct Menu *menu, struct BrowserState *state,
 
     mutt_buffy_check(false);
 
-    if ((dp = opendir(d)) == NULL)
+    dp = opendir(d);
+    if (!dp)
     {
       mutt_perror(d);
       return -1;
@@ -1696,7 +1697,8 @@ void _mutt_select_file(char *f, size_t flen, int flags, char ***files, int *numf
             not = 1;
           }
 
-          if ((err = REGCOMP(rx, s, REG_NOSUB)) != 0)
+          err = REGCOMP(rx, s, REG_NOSUB);
+          if (err != 0)
           {
             regerror(err, rx, buf, sizeof(buf));
             FREE(&rx);

--- a/buffy.c
+++ b/buffy.c
@@ -215,7 +215,8 @@ static int buffy_maildir_check_dir(struct Buffy *mailbox, const char *dir_name,
   if (!(check_new || check_stats))
     return rc;
 
-  if ((dirp = opendir(path)) == NULL)
+  dirp = opendir(path);
+  if (!dirp)
   {
     mailbox->magic = 0;
     return 0;

--- a/charset.c
+++ b/charset.c
@@ -348,7 +348,8 @@ iconv_t mutt_iconv_open(const char *tocode, const char *fromcode, int flags)
   fromcode2 = (fromcode2) ? fromcode2 : fromcode1;
 
   /* call system iconv with names it appreciates */
-  if ((cd = iconv_open(tocode2, fromcode2)) != (iconv_t) -1)
+  cd = iconv_open(tocode2, fromcode2);
+  if (cd != (iconv_t) -1)
     return cd;
 
   return (iconv_t) -1;
@@ -551,7 +552,8 @@ char *fgetconvs(char *buf, size_t l, FGETCONV *_fc)
 
   for (r = 0; r + 1 < l;)
   {
-    if ((c = fgetconv(_fc)) == EOF)
+    c = fgetconv(_fc);
+    if (c == EOF)
       break;
     buf[r++] = (char) c;
     if (c == '\n')
@@ -642,7 +644,8 @@ bool mutt_check_charset(const char *s, bool strict)
         return true;
     }
 
-  if ((cd = mutt_iconv_open(s, s, 0)) != (iconv_t)(-1))
+  cd = mutt_iconv_open(s, s, 0);
+  if (cd != (iconv_t)(-1))
   {
     iconv_close(cd);
     return true;

--- a/charset.c
+++ b/charset.c
@@ -214,7 +214,8 @@ void mutt_set_langinfo_charset(void)
   mutt_canonical_charset(buff2, sizeof(buff2), buff);
 
   /* finally, set $charset */
-  if (!(Charset = safe_strdup(buff2)))
+  Charset = safe_strdup(buff2);
+  if (!Charset)
     Charset = safe_strdup("iso-8859-1");
 }
 

--- a/color.c
+++ b/color.c
@@ -497,7 +497,8 @@ static int _mutt_parse_uncolor(struct Buffer *buf, struct Buffer *s, unsigned lo
 
   mutt_extract_token(buf, s, 0);
 
-  if ((object = mutt_getvaluebyname(buf->data, Fields)) == -1)
+  object = mutt_getvaluebyname(buf->data, Fields);
+  if (object == -1)
   {
     snprintf(err->data, err->dsize, _("%s: no such object"), buf->data);
     return -1;
@@ -642,7 +643,8 @@ static int add_pattern(struct ColorLineHead *top, const char *s, int sensitive, 
     {
       strfcpy(buf, NONULL(s), sizeof(buf));
       mutt_check_simple(buf, sizeof(buf), NONULL(SimpleSearch));
-      if ((tmp->color_pattern = mutt_pattern_comp(buf, MUTT_FULL_MSG, err)) == NULL)
+      tmp->color_pattern = mutt_pattern_comp(buf, MUTT_FULL_MSG, err);
+      if (!tmp->color_pattern)
       {
         free_color_line(tmp, 1);
         return -1;
@@ -713,7 +715,8 @@ static int parse_object(struct Buffer *buf, struct Buffer *s, int *o, int *ql,
 
     mutt_extract_token(buf, s, 0);
 
-    if ((*o = mutt_getvaluebyname(buf->data, ComposeFields)) == -1)
+    *o = mutt_getvaluebyname(buf->data, ComposeFields);
+    if (*o == -1)
     {
       snprintf(err->data, err->dsize, _("%s: no such object"), buf->data);
       return (-1);

--- a/commands.c
+++ b/commands.c
@@ -299,7 +299,8 @@ void ci_bounce_message(struct Header *h)
   if (rc || !buf[0])
     return;
 
-  if (!(adr = mutt_parse_adrlist(adr, buf)))
+  adr = mutt_parse_adrlist(adr, buf);
+  if (!adr)
   {
     mutt_error(_("Error parsing address!"));
     return;

--- a/commands.c
+++ b/commands.c
@@ -126,7 +126,8 @@ int mutt_display_message(struct Header *cur)
   }
 
   mutt_mktemp(tempfile, sizeof(tempfile));
-  if ((fpout = safe_fopen(tempfile, "w")) == NULL)
+  fpout = safe_fopen(tempfile, "w");
+  if (!fpout)
   {
     mutt_error(_("Could not create temporary file!"));
     return 0;
@@ -237,7 +238,8 @@ int mutt_display_message(struct Header *cur)
 
     mutt_endwin(NULL);
     snprintf(buf, sizeof(buf), "%s %s", NONULL(Pager), tempfile);
-    if ((r = mutt_system(buf)) == -1)
+    r = mutt_system(buf);
+    if (r == -1)
       mutt_error(_("Error running \"%s\"!"), buf);
     unlink(tempfile);
     if (!option(OPT_NO_CURSES))
@@ -725,7 +727,8 @@ int _mutt_save_message(struct Header *h, struct Context *ctx, int delete, int de
   if (decode || decrypt)
     mutt_parse_mime_message(Context, h);
 
-  if ((rc = mutt_append_message(ctx, Context, h, cmflags, chflags)) != 0)
+  rc = mutt_append_message(ctx, Context, h, cmflags, chflags);
+  if (rc != 0)
     return rc;
 
   if (delete)
@@ -994,7 +997,8 @@ int mutt_edit_content_type(struct Header *h, struct Body *b, FILE *fp)
     int r;
     snprintf(tmp, sizeof(tmp), _("Convert to %s upon sending?"),
              mutt_get_parameter("charset", b->parameter));
-    if ((r = mutt_yesorno(tmp, !b->noconv)) != MUTT_ABORT)
+    r = mutt_yesorno(tmp, !b->noconv);
+    if (r != MUTT_ABORT)
       b->noconv = (r == MUTT_NO);
   }
 
@@ -1051,7 +1055,8 @@ static int _mutt_check_traditional_pgp(struct Header *h, int *redraw)
   h->security |= PGP_TRADITIONAL_CHECKED;
 
   mutt_parse_mime_message(Context, h);
-  if ((msg = mx_open_message(Context, h->msgno)) == NULL)
+  msg = mx_open_message(Context, h->msgno);
+  if (!msg)
     return 0;
   if (crypt_pgp_check_traditional(msg->fp, h->content, 0))
   {

--- a/complete.c
+++ b/complete.c
@@ -205,7 +205,8 @@ int mutt_complete(char *s, size_t slen)
    * special case to handle when there is no filepart yet.  find the first
    * file/directory which is not ``.'' or ``..''
    */
-  if ((len = mutt_strlen(filepart)) == 0)
+  len = mutt_strlen(filepart);
+  if (len == 0)
   {
     while ((de = readdir(dirp)) != NULL)
     {

--- a/compose.c
+++ b/compose.c
@@ -1068,7 +1068,8 @@ int mutt_compose_menu(struct Header *msg, /* structure for new message */
         unset_option(OPT_NEWS);
         if (op == OP_COMPOSE_ATTACH_NEWS_MESSAGE)
         {
-          if (!(CurrentNewsSrv = nntp_select_server(NewsServer, 0)))
+          CurrentNewsSrv = nntp_select_server(NewsServer, 0);
+          if (!CurrentNewsSrv)
             break;
 
           prompt = _("Open newsgroup to attach message from");
@@ -1417,7 +1418,8 @@ int mutt_compose_menu(struct Header *msg, /* structure for new message */
         if (mutt_get_field("Content-Type: ", type, sizeof(type), 0) != 0 || !type[0])
           continue;
 
-        if (!(p = strchr(type, '/')))
+        p = strchr(type, '/');
+        if (!p)
         {
           mutt_error(_("Content-Type is of the form base/sub"));
           continue;
@@ -1431,7 +1433,8 @@ int mutt_compose_menu(struct Header *msg, /* structure for new message */
         }
         new = (struct AttachPtr *) safe_calloc(1, sizeof(struct AttachPtr));
         /* Touch the file */
-        if (!(fp = safe_fopen(fname, "w")))
+        fp = safe_fopen(fname, "w");
+        if (!fp)
         {
           mutt_error(_("Can't create file %s"), fname);
           FREE(&new);

--- a/compose.c
+++ b/compose.c
@@ -379,7 +379,8 @@ static int check_attachments(struct AttachCtx *actx)
       mutt_pretty_mailbox(pretty, sizeof(pretty));
       snprintf(msg, sizeof(msg), _("%s [#%d] modified. Update encoding?"), pretty, i + 1);
 
-      if ((r = mutt_yesorno(msg, MUTT_YES)) == MUTT_YES)
+      r = mutt_yesorno(msg, MUTT_YES);
+      if (r == MUTT_YES)
         mutt_update_encoding(actx->idx[i]->content);
       else if (r == MUTT_ABORT)
         return -1;
@@ -994,7 +995,8 @@ int mutt_compose_menu(struct Header *msg, /* structure for new message */
         if (!(WithCrypto & APPLICATION_PGP))
           break;
         new = safe_calloc(1, sizeof(struct AttachPtr));
-        if ((new->content = crypt_pgp_make_key_attachment(NULL)) != NULL)
+        new->content = crypt_pgp_make_key_attachment(NULL);
+        if (new->content)
         {
           update_idx(menu, actx, new);
           menu->redraw |= REDRAW_INDEX;
@@ -1421,7 +1423,8 @@ int mutt_compose_menu(struct Header *msg, /* structure for new message */
           continue;
         }
         *p++ = 0;
-        if ((itype = mutt_check_mime_type(type)) == TYPEOTHER)
+        itype = mutt_check_mime_type(type);
+        if (itype == TYPEOTHER)
         {
           mutt_error(_("Unknown Content-Type %s"), type);
           continue;
@@ -1436,7 +1439,8 @@ int mutt_compose_menu(struct Header *msg, /* structure for new message */
         }
         safe_fclose(&fp);
 
-        if ((new->content = mutt_make_file_attach(fname)) == NULL)
+        new->content = mutt_make_file_attach(fname);
+        if (!new->content)
         {
           mutt_error(_("What we have here is a failure to make an attachment"));
           FREE(&new);
@@ -1501,7 +1505,8 @@ int mutt_compose_menu(struct Header *msg, /* structure for new message */
         break;
 
       case OP_EXIT:
-        if ((i = query_quadoption(OPT_POSTPONE, _("Postpone this message?"))) == MUTT_NO)
+        i = query_quadoption(OPT_POSTPONE, _("Postpone this message?"));
+        if (i == MUTT_NO)
         {
           for (i = 0; i < actx->idxlen; i++)
             if (actx->idx[i]->unowned)

--- a/compress.c
+++ b/compress.c
@@ -160,7 +160,8 @@ static int setup_paths(struct Context *ctx)
   mutt_mktemp(tmppath, sizeof(tmppath));
   ctx->path = safe_strdup(tmppath);
 
-  if ((tmpfp = safe_fopen(ctx->path, "w")) == NULL)
+  tmpfp = safe_fopen(ctx->path, "w");
+  if (!tmpfp)
     return -1;
 
   safe_fclose(&tmpfp);

--- a/copy.c
+++ b/copy.c
@@ -755,7 +755,8 @@ int mutt_copy_message(FILE *fpout, struct Context *src, struct Header *hdr,
   struct Message *msg = NULL;
   int r;
 
-  if ((msg = mx_open_message(src, hdr->msgno)) == NULL)
+  msg = mx_open_message(src, hdr->msgno);
+  if (!msg)
     return -1;
   if ((r = _mutt_copy_message(fpout, msg->fp, hdr, hdr->content, flags, chflags)) == 0 &&
       (ferror(fpout) || feof(fpout)))
@@ -792,7 +793,8 @@ static int _mutt_append_message(struct Context *dest, FILE *fpin,
   if (fgets(buf, sizeof(buf), fpin) == NULL)
     return -1;
 
-  if ((msg = mx_open_new_message(dest, hdr, is_from(buf, NULL, 0, NULL) ? 0 : MUTT_ADD_FROM)) == NULL)
+  msg = mx_open_new_message(dest, hdr, is_from(buf, NULL, 0, NULL) ? 0 : MUTT_ADD_FROM);
+  if (!msg)
     return -1;
   if (dest->magic == MUTT_MBOX || dest->magic == MUTT_MMDF)
     chflags |= CH_FROM | CH_FORCE_FROM;
@@ -816,7 +818,8 @@ int mutt_append_message(struct Context *dest, struct Context *src,
   struct Message *msg = NULL;
   int r;
 
-  if ((msg = mx_open_message(src, hdr->msgno)) == NULL)
+  msg = mx_open_message(src, hdr->msgno);
+  if (!msg)
     return -1;
   r = _mutt_append_message(dest, msg->fp, src, hdr, hdr->content, cmflags, chflags);
   mx_close_message(src, &msg);
@@ -1017,7 +1020,8 @@ static int address_header_decode(char **h)
       return 0;
   }
 
-  if ((a = rfc822_parse_adrlist(a, s + l)) == NULL)
+  a = rfc822_parse_adrlist(a, s + l);
+  if (!a)
     return 0;
 
   mutt_addrlist_to_local(a);

--- a/curs_lib.c
+++ b/curs_lib.c
@@ -740,7 +740,8 @@ int mutt_window_mvprintw(struct MuttWindow *win, int row, int col, const char *f
   va_list ap;
   int rv;
 
-  if ((rv = mutt_window_move(win, row, col)) != ERR)
+  rv = mutt_window_move(win, row, col);
+  if (rv != ERR)
   {
     va_start(ap, fmt);
     rv = vw_printw(stdscr, fmt, ap);

--- a/curs_main.c
+++ b/curs_main.c
@@ -467,7 +467,8 @@ static int main_change_folder(struct Menu *menu, int op, char *buf, size_t bufsz
       new_last_folder = safe_strdup(Context->path);
     *oldcount = Context ? Context->msgcount : 0;
 
-    if ((check = mx_close_mailbox(Context, index_hint)) != 0)
+    check = mx_close_mailbox(Context, index_hint);
+    if (check != 0)
     {
       if (check == MUTT_NEW_MAIL || check == MUTT_REOPENED)
         update_index(menu, Context, check, *oldcount, *index_hint);
@@ -1034,7 +1035,8 @@ int mutt_index_menu(void)
     {
       /* check for new mail in the incoming folders */
       oldcount = newcount;
-      if ((newcount = mutt_buffy_check(false)) != oldcount)
+      newcount = mutt_buffy_check(false);
+      if (newcount != oldcount)
         menu->redraw |= REDRAW_STATUS;
       if (do_buffy_notify)
       {
@@ -1597,7 +1599,8 @@ int mutt_index_menu(void)
 
         CHECK_MSGCOUNT;
         CHECK_VISIBLE;
-        if ((menu->current = mutt_search_command(menu->current, op)) == -1)
+        menu->current = mutt_search_command(menu->current, op);
+        if (menu->current == -1)
           menu->current = menu->oldcurrent;
         else
           menu->redraw = REDRAW_MOTION;
@@ -1744,7 +1747,8 @@ int mutt_index_menu(void)
               newhdr = Context->hdrs[Context->v2r[newidx]];
           }
 
-          if ((check = mx_sync_mailbox(Context, &index_hint)) == 0)
+          check = mx_sync_mailbox(Context, &index_hint);
+          if (check == 0)
           {
             if (newhdr && Context->vcount != ovc)
               for (j = 0; j < Context->vcount; j++)
@@ -1928,7 +1932,8 @@ int mutt_index_menu(void)
           }
           if (option(OPT_RESOLVE))
           {
-            if ((menu->current = ci_next_undeleted(menu->current)) == -1)
+            menu->current = ci_next_undeleted(menu->current);
+            if (menu->current == -1)
             {
               menu->current = menu->oldcurrent;
               menu->redraw = REDRAW_CURRENT;
@@ -2298,7 +2303,8 @@ int mutt_index_menu(void)
             mutt_error(_("You are on the last message."));
           break;
         }
-        if ((menu->current = ci_next_undeleted(menu->current)) == -1)
+        menu->current = ci_next_undeleted(menu->current);
+        if (menu->current == -1)
         {
           menu->current = menu->oldcurrent;
           if (menu->menu == MENU_MAIN)
@@ -2342,7 +2348,8 @@ int mutt_index_menu(void)
           mutt_error(_("You are on the first message."));
           break;
         }
-        if ((menu->current = ci_previous_undeleted(menu->current)) == -1)
+        menu->current = ci_previous_undeleted(menu->current);
+        if (menu->current == -1)
         {
           menu->current = menu->oldcurrent;
           if (menu->menu == MENU_MAIN)
@@ -2399,7 +2406,8 @@ int mutt_index_menu(void)
             menu->redraw |= REDRAW_INDEX;
           else if (option(OPT_RESOLVE))
           {
-            if ((menu->current = ci_next_undeleted(menu->current)) == -1)
+            menu->current = ci_next_undeleted(menu->current);
+            if (menu->current == -1)
             {
               menu->current = menu->oldcurrent;
               menu->redraw |= REDRAW_CURRENT;
@@ -2532,7 +2540,8 @@ int mutt_index_menu(void)
           mutt_set_flag(Context, CURHDR, MUTT_FLAG, !CURHDR->flagged);
           if (option(OPT_RESOLVE))
           {
-            if ((menu->current = ci_next_undeleted(menu->current)) == -1)
+            menu->current = ci_next_undeleted(menu->current);
+            if (menu->current == -1)
             {
               menu->current = menu->oldcurrent;
               menu->redraw |= REDRAW_CURRENT;
@@ -2578,7 +2587,8 @@ int mutt_index_menu(void)
 
           if (option(OPT_RESOLVE))
           {
-            if ((menu->current = ci_next_undeleted(menu->current)) == -1)
+            menu->current = ci_next_undeleted(menu->current);
+            if (menu->current == -1)
             {
               menu->current = menu->oldcurrent;
               menu->redraw |= REDRAW_CURRENT;
@@ -2676,7 +2686,8 @@ int mutt_index_menu(void)
             menu->redraw |= REDRAW_INDEX;
           else if (option(OPT_RESOLVE))
           {
-            if ((menu->current = ci_next_undeleted(menu->current)) == -1)
+            menu->current = ci_next_undeleted(menu->current);
+            if (menu->current == -1)
             {
               menu->current = menu->oldcurrent;
               menu->redraw |= REDRAW_CURRENT;
@@ -2781,7 +2792,8 @@ int mutt_index_menu(void)
             mutt_set_flag(Context, CURHDR, MUTT_TAG, 0);
           if (option(OPT_RESOLVE))
           {
-            if ((menu->current = ci_next_undeleted(menu->current)) == -1)
+            menu->current = ci_next_undeleted(menu->current);
+            if (menu->current == -1)
             {
               menu->current = menu->oldcurrent;
               menu->redraw |= REDRAW_CURRENT;

--- a/doc/makedoc.c
+++ b/doc/makedoc.c
@@ -1262,21 +1262,25 @@ static void handle_confline(char *s, FILE *out)
   /* xxx - put this into an actual state machine? */
 
   /* variable name */
-  if (!(s = get_token(varname, sizeof(varname), s)))
+  s = get_token(varname, sizeof(varname), s);
+  if (!s)
     return;
 
   /* comma */
-  if (!(s = get_token(buff, sizeof(buff), s)))
+  s = get_token(buff, sizeof(buff), s);
+  if (!s)
     return;
 
   /* type */
-  if (!(s = get_token(buff, sizeof(buff), s)))
+  s = get_token(buff, sizeof(buff), s);
+  if (!s)
     return;
 
   type = buff2type(buff);
 
   /* possibly a "|" or comma */
-  if (!(s = get_token(buff, sizeof(buff), s)))
+  s = get_token(buff, sizeof(buff), s);
+  if (!s)
     return;
 
   if (strcmp(buff, "|") == 0)
@@ -1284,9 +1288,11 @@ static void handle_confline(char *s, FILE *out)
     if (Debug)
       fprintf(stderr, "%s: Expecting <subtype> <comma>.\n", Progname);
     /* ignore subtype and comma */
-    if (!(s = get_token(buff, sizeof(buff), s)))
+    s = get_token(buff, sizeof(buff), s);
+    if (!s)
       return;
-    if (!(s = get_token(buff, sizeof(buff), s)))
+    s = get_token(buff, sizeof(buff), s);
+    if (!s)
       return;
   }
 
@@ -1294,34 +1300,42 @@ static void handle_confline(char *s, FILE *out)
 
   while (true)
   {
-    if (!(s = get_token(buff, sizeof(buff), s)))
+    s = get_token(buff, sizeof(buff), s);
+    if (!s)
       return;
     if (strcmp(buff, ",") == 0)
       break;
   }
 
   /* option name or UL &address */
-  if (!(s = get_token(buff, sizeof(buff), s)))
+  s = get_token(buff, sizeof(buff), s);
+  if (!s)
     return;
   if (strcmp(buff, "UL") == 0)
-    if (!(s = get_token(buff, sizeof(buff), s)))
+  {
+    s = get_token(buff, sizeof(buff), s);
+    if (!s)
       return;
+  }
 
   /* comma */
-  if (!(s = get_token(buff, sizeof(buff), s)))
+  s = get_token(buff, sizeof(buff), s);
+  if (!s)
     return;
 
   if (Debug)
     fprintf(stderr, "%s: Expecting default value.\n", Progname);
 
   /* <default value> or UL <default value> */
-  if (!(s = get_token(buff, sizeof(buff), s)))
+  s = get_token(buff, sizeof(buff), s);
+  if (!s)
     return;
   if (strcmp(buff, "UL") == 0)
   {
     if (Debug)
       fprintf(stderr, "%s: Skipping UL.\n", Progname);
-    if (!(s = get_token(buff, sizeof(buff), s)))
+    s = get_token(buff, sizeof(buff), s);
+    if (!s)
       return;
   }
 
@@ -1362,7 +1376,8 @@ static void makedoc(FILE *in, FILE *out)
     else
       *p = '\0';
 
-    if (!(p = get_token(token, sizeof(token), buffer)))
+    p = get_token(token, sizeof(token), buffer);
+    if (!p)
       continue;
 
     if (Debug)

--- a/doc/makedoc.c
+++ b/doc/makedoc.c
@@ -1351,7 +1351,8 @@ static void makedoc(FILE *in, FILE *out)
   while ((fgets(buffer, sizeof(buffer), in)))
   {
     line++;
-    if ((p = strchr(buffer, '\n')) == NULL)
+    p = strchr(buffer, '\n');
+    if (!p)
     {
       fprintf(stderr, "%s: Line %d too long.  Ask a wizard to enlarge\n"
                       "%s: my buffer size.\n",
@@ -1424,7 +1425,8 @@ int main(int argc, char *argv[])
 
   if (optind != argc)
   {
-    if ((f = fopen(argv[optind], "r")) == NULL)
+    f = fopen(argv[optind], "r");
+    if (!f)
     {
       fprintf(stderr, "%s: Can't open %s (%s).\n", Progname, argv[optind], strerror(errno));
       exit(1);

--- a/edit.c
+++ b/edit.c
@@ -137,7 +137,8 @@ static int be_barf_file(const char *path, char **buf, int buflen)
 {
   FILE *f = NULL;
 
-  if ((f = fopen(path, "w")) == NULL)
+  f = fopen(path, "w");
+  if (!f)
   {
     addstr(strerror(errno));
     addch('\n');

--- a/editmsg.c
+++ b/editmsg.c
@@ -99,7 +99,8 @@ static int edit_one_message(struct Context *ctx, struct Header *cur)
     goto bail;
   }
 
-  if ((rc = stat(tmp, &sb)) == -1)
+  rc = stat(tmp, &sb);
+  if (rc == -1)
   {
     mutt_error(_("Can't stat %s: %s"), tmp, strerror(errno));
     goto bail;
@@ -121,7 +122,8 @@ static int edit_one_message(struct Context *ctx, struct Header *cur)
 
   mutt_edit_file(NONULL(Editor), tmp);
 
-  if ((rc = stat(tmp, &sb)) == -1)
+  rc = stat(tmp, &sb);
+  if (rc == -1)
   {
     mutt_error(_("Can't stat %s: %s"), tmp, strerror(errno));
     goto bail;
@@ -141,7 +143,8 @@ static int edit_one_message(struct Context *ctx, struct Header *cur)
     goto bail;
   }
 
-  if ((fp = fopen(tmp, "r")) == NULL)
+  fp = fopen(tmp, "r");
+  if (!fp)
   {
     rc = -1;
     mutt_error(_("Can't open message file: %s"), strerror(errno));
@@ -184,7 +187,8 @@ static int edit_one_message(struct Context *ctx, struct Header *cur)
     goto bail;
   }
 
-  if ((rc = mutt_copy_hdr(fp, msg->fp, 0, sb.st_size, CH_NOLEN | cf, NULL)) == 0)
+  rc = mutt_copy_hdr(fp, msg->fp, 0, sb.st_size, CH_NOLEN | cf, NULL);
+  if (rc == 0)
   {
     fputc('\n', msg->fp);
     mutt_copy_stream(fp, msg->fp);

--- a/filter.c
+++ b/filter.c
@@ -100,7 +100,8 @@ pid_t mutt_create_filter_fd(const char *cmd, FILE **in, FILE **out, FILE **err,
 
   mutt_block_signals_system();
 
-  if ((thepid = fork()) == 0)
+  thepid = fork();
+  if (thepid == 0)
   {
     mutt_unblock_signals_system(0);
 

--- a/flags.c
+++ b/flags.c
@@ -357,7 +357,8 @@ int mutt_thread_set_flag(struct Header *hdr, int flag, int bf, int subthread)
   if (cur->message && cur != hdr->thread)
     mutt_set_flag(Context, cur->message, flag, bf);
 
-  if ((cur = cur->child) == NULL)
+  cur = cur->child;
+  if (!cur)
     goto done;
 
   while (true)

--- a/group.c
+++ b/group.c
@@ -39,7 +39,8 @@ struct Group *mutt_pattern_group(const char *k)
   if (!k)
     return 0;
 
-  if (!(p = hash_find(Groups, k)))
+  p = hash_find(Groups, k);
+  if (!p)
   {
     mutt_debug(2, "mutt_pattern_group: Creating group %s.\n", k);
     p = safe_calloc(1, sizeof(struct Group));

--- a/handler.c
+++ b/handler.c
@@ -144,7 +144,8 @@ static void decode_xbit(struct State *s, long len, int istext, iconv_t cd)
     {
       if (c == '\r' && len)
       {
-        if ((ch = fgetc(s->fpin)) == '\n')
+        ch = fgetc(s->fpin);
+        if (ch == '\n')
         {
           c = ch;
           len--;
@@ -319,7 +320,8 @@ void mutt_decode_base64(struct State *s, long len, int istext, iconv_t cd)
   {
     for (i = 0; i < 4 && len > 0; len--)
     {
-      if ((ch = fgetc(s->fpin)) == EOF)
+      ch = fgetc(s->fpin);
+      if (ch == EOF)
         break;
       if (ch >= 0 && ch < 128 && (base64val(ch) != -1 || ch == '='))
         buf[i++] = ch;
@@ -970,7 +972,8 @@ static int is_mmnoask(const char *buf)
 
     while ((p = strtok(p, ",")) != NULL)
     {
-      if ((q = strrchr(p, '/')) != NULL)
+      q = strrchr(p, '/');
+      if (q)
       {
         if (*(q + 1) == '*')
         {
@@ -1415,7 +1418,8 @@ static int autoview_handler(struct Body *a, struct State *s)
       mutt_message(_("Invoking autoview command: %s"), command);
     }
 
-    if ((fpin = safe_fopen(tempfile, "w+")) == NULL)
+    fpin = safe_fopen(tempfile, "w+");
+    if (!fpin)
     {
       mutt_perror("fopen");
       rfc1524_free_entry(&entry);
@@ -1723,7 +1727,8 @@ static int run_decode_and_handler(struct Body *b, struct State *s,
       }
 #else
       mutt_mktemp(tempfile, sizeof(tempfile));
-      if ((s->fpout = safe_fopen(tempfile, "w")) == NULL)
+      s->fpout = safe_fopen(tempfile, "w");
+      if (!s->fpout)
       {
         mutt_error(_("Unable to open temporary file!"));
         mutt_debug(1, "Can't open %s.\n", tempfile);

--- a/headers.c
+++ b/headers.c
@@ -56,7 +56,8 @@ void mutt_edit_headers(const char *editor, const char *body, struct Header *msg,
   struct stat st;
 
   mutt_mktemp(path, sizeof(path));
-  if ((ofp = safe_fopen(path, "w")) == NULL)
+  ofp = safe_fopen(path, "w");
+  if (!ofp)
   {
     mutt_perror(path);
     return;
@@ -67,7 +68,8 @@ void mutt_edit_headers(const char *editor, const char *body, struct Header *msg,
   fputc('\n', ofp); /* tie off the header. */
 
   /* now copy the body of the message. */
-  if ((ifp = fopen(body, "r")) == NULL)
+  ifp = fopen(body, "r");
+  if (!ifp)
   {
     mutt_perror(body);
     safe_fclose(&ofp);
@@ -101,13 +103,15 @@ void mutt_edit_headers(const char *editor, const char *body, struct Header *msg,
   mutt_list_free(&msg->env->userhdrs);
 
   /* Read the temp file back in */
-  if ((ifp = fopen(path, "r")) == NULL)
+  ifp = fopen(path, "r");
+  if (!ifp)
   {
     mutt_perror(path);
     return;
   }
 
-  if ((ofp = safe_fopen(body, "w")) == NULL)
+  ofp = safe_fopen(body, "w");
+  if (!ofp)
   {
     /* intentionally leak a possible temporary file here */
     safe_fclose(&ifp);

--- a/help.c
+++ b/help.c
@@ -358,7 +358,8 @@ void mutt_help(int menu)
 
   do
   {
-    if ((f = safe_fopen(t, "w")) == NULL)
+    f = safe_fopen(t, "w");
+    if (!f)
     {
       mutt_perror(t);
       return;

--- a/history.c
+++ b/history.c
@@ -120,7 +120,8 @@ void mutt_read_histfile(void)
   char *linebuf = NULL, *p = NULL;
   size_t buflen;
 
-  if ((f = fopen(HistoryFile, "r")) == NULL)
+  f = fopen(HistoryFile, "r");
+  if (!f)
     return;
 
   while ((linebuf = mutt_read_line(linebuf, &buflen, f, &line, 0)) != NULL)
@@ -200,7 +201,8 @@ static void shrink_histfile(void)
   bool regen_file = false;
   struct Hash *dup_hashes[HC_LAST] = { 0 };
 
-  if ((f = fopen(HistoryFile, "r")) == NULL)
+  f = fopen(HistoryFile, "r");
+  if (!f)
     return;
 
   if (option(OPT_HISTORY_REMOVE_DUPS))
@@ -240,7 +242,8 @@ static void shrink_histfile(void)
   if (regen_file)
   {
     mutt_mktemp(tmpfname, sizeof(tmpfname));
-    if ((tmp = safe_fopen(tmpfname, "w+")) == NULL)
+    tmp = safe_fopen(tmpfname, "w+");
+    if (!tmp)
     {
       mutt_perror(tmpfname);
       goto cleanup;
@@ -295,7 +298,8 @@ static void save_history(enum HistoryClass hclass, const char *s)
   if (!s || !*s) /* This shouldn't happen, but it's safer. */
     return;
 
-  if ((f = fopen(HistoryFile, "a")) == NULL)
+  f = fopen(HistoryFile, "a");
+  if (!f)
   {
     mutt_perror("fopen");
     return;

--- a/imap/auth_cram.c
+++ b/imap/auth_cram.c
@@ -79,7 +79,8 @@ enum ImapAuthRes imap_auth_cram_md5(struct ImapData *idata, const char *method)
     goto bail;
   }
 
-  if ((len = mutt_from_base64(obuf, idata->buf + 2)) == -1)
+  len = mutt_from_base64(obuf, idata->buf + 2);
+  if (len == -1)
   {
     mutt_debug(1, "Error decoding base64 response.\n");
     goto bail;

--- a/imap/browse.c
+++ b/imap/browse.c
@@ -195,7 +195,8 @@ int imap_browse(char *path, struct BrowserState *state)
   unset_option(OPT_IMAP_CHECK_SUBSCRIBED);
   strfcpy(list_cmd, option(OPT_IMAP_LIST_SUBSCRIBED) ? "LSUB" : "LIST", sizeof(list_cmd));
 
-  if (!(idata = imap_conn_find(&(mx.account), 0)))
+  idata = imap_conn_find(&(mx.account), 0);
+  if (!idata)
     goto fail;
 
   mutt_message(_("Getting folder list..."));
@@ -352,7 +353,8 @@ int imap_mailbox_create(const char *folder)
     return -1;
   }
 
-  if (!(idata = imap_conn_find(&mx.account, MUTT_IMAP_CONN_NONEW)))
+  idata = imap_conn_find(&mx.account, MUTT_IMAP_CONN_NONEW);
+  if (!idata)
   {
     mutt_debug(1, "imap_mailbox_create: Couldn't find open connection to %s\n",
                mx.account.host);
@@ -406,7 +408,8 @@ int imap_mailbox_rename(const char *mailbox)
     return -1;
   }
 
-  if (!(idata = imap_conn_find(&mx.account, MUTT_IMAP_CONN_NONEW)))
+  idata = imap_conn_find(&mx.account, MUTT_IMAP_CONN_NONEW);
+  if (!idata)
   {
     mutt_debug(1, "imap_mailbox_rename: Couldn't find open connection to %s\n",
                mx.account.host);

--- a/imap/command.c
+++ b/imap/command.c
@@ -127,7 +127,8 @@ static int cmd_queue(struct ImapData *idata, const char *cmdstr, int flags)
       return rc;
   }
 
-  if (!(cmd = cmd_new(idata)))
+  cmd = cmd_new(idata);
+  if (!cmd)
     return IMAP_CMD_BAD;
 
   if (mutt_buffer_printf(idata->cmdbuf, "%s %s\r\n", cmd->seq, cmdstr) < 0)

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -493,7 +493,8 @@ int imap_open_connection(struct ImapData *idata)
         goto err_close_conn;
       if (rc == MUTT_YES)
       {
-        if ((rc = imap_exec(idata, "STARTTLS", IMAP_CMD_FAIL_OK)) == -1)
+        rc = imap_exec(idata, "STARTTLS", IMAP_CMD_FAIL_OK);
+        if (rc == -1)
           goto bail;
         if (rc != -2)
         {
@@ -696,7 +697,8 @@ static int imap_open_mailbox(struct Context *ctx)
   {
     char *pc = NULL;
 
-    if ((rc = imap_cmd_step(idata)) != IMAP_CMD_CONTINUE)
+    rc = imap_cmd_step(idata);
+    if (rc != IMAP_CMD_CONTINUE)
       break;
 
     pc = idata->buf + 2;
@@ -709,7 +711,8 @@ static int imap_open_mailbox(struct Context *ctx)
       if (STAILQ_EMPTY(&idata->flags))
       {
         mutt_debug(3, "Getting mailbox FLAGS\n");
-        if ((pc = imap_get_flags(&idata->flags, pc)) == NULL)
+        pc = imap_get_flags(&idata->flags, pc);
+        if (!pc)
           goto fail;
       }
     }
@@ -721,7 +724,8 @@ static int imap_open_mailbox(struct Context *ctx)
       mutt_list_free(&idata->flags);
       /* skip "OK [PERMANENT" so syntax is the same as FLAGS */
       pc += 13;
-      if ((pc = imap_get_flags(&(idata->flags), pc)) == NULL)
+      pc = imap_get_flags(&(idata->flags), pc);
+      if (!pc)
         goto fail;
     }
     /* save UIDVALIDITY for the header cache */
@@ -849,7 +853,8 @@ static int imap_open_mailbox_append(struct Context *ctx, int flags)
     strfcpy(mailbox, "INBOX", sizeof(mailbox));
   FREE(&mx.mbox);
 
-  if ((rc = imap_access(ctx->path)) == 0)
+  rc = imap_access(ctx->path);
+  if (rc == 0)
     return 0;
 
   if (rc == -1)
@@ -889,7 +894,8 @@ static int imap_open_new_message(struct Message *msg, struct Context *dest, stru
   char tmp[_POSIX_PATH_MAX];
 
   mutt_mktemp(tmp, sizeof(tmp));
-  if ((msg->fp = safe_fopen(tmp, "w")) == NULL)
+  msg->fp = safe_fopen(tmp, "w");
+  if (!msg->fp)
   {
     mutt_perror(tmp);
     return -1;
@@ -1460,7 +1466,8 @@ int imap_sync_mailbox(struct Context *ctx, int expunge)
    * to be changed. */
   imap_allow_reopen(ctx);
 
-  if ((rc = imap_check(idata, 0)) != 0)
+  rc = imap_check(idata, 0);
+  if (rc != 0)
     return rc;
 
   /* if we are expunging anyway, we can do deleted messages very quickly... */

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -88,7 +88,8 @@ int imap_access(const char *path)
   if (imap_parse_path(path, &mx))
     return -1;
 
-  if (!(idata = imap_conn_find(&mx.account, option(OPT_IMAP_PASSIVE) ? MUTT_IMAP_CONN_NONEW : 0)))
+  idata = imap_conn_find(&mx.account, option(OPT_IMAP_PASSIVE) ? MUTT_IMAP_CONN_NONEW : 0);
+  if (!idata)
   {
     FREE(&mx.mbox);
     return -1;
@@ -173,7 +174,8 @@ int imap_delete_mailbox(struct Context *ctx, struct ImapMbox *mx)
 
   if (!ctx || !ctx->data)
   {
-    if (!(idata = imap_conn_find(&mx->account, option(OPT_IMAP_PASSIVE) ? MUTT_IMAP_CONN_NONEW : 0)))
+    idata = imap_conn_find(&mx->account, option(OPT_IMAP_PASSIVE) ? MUTT_IMAP_CONN_NONEW : 0);
+    if (!idata)
     {
       FREE(&mx->mbox);
       return -1;
@@ -414,7 +416,8 @@ struct ImapData *imap_conn_find(const struct Account *account, int flags)
   if (!idata)
   {
     /* The current connection is a new connection */
-    if (!(idata = imap_new_idata()))
+    idata = imap_new_idata();
+    if (!idata)
     {
       mutt_socket_free(conn);
       return NULL;
@@ -627,7 +630,8 @@ static int imap_open_mailbox(struct Context *ctx)
   }
 
   /* we require a connection which isn't currently in IMAP_SELECTED state */
-  if (!(idata = imap_conn_find(&(mx.account), MUTT_IMAP_CONN_NOSELECT)))
+  idata = imap_conn_find(&(mx.account), MUTT_IMAP_CONN_NOSELECT);
+  if (!idata)
     goto fail_noidata;
   if (idata->state < IMAP_AUTHENTICATED)
     goto fail;
@@ -840,7 +844,8 @@ static int imap_open_mailbox_append(struct Context *ctx, int flags)
   /* in APPEND mode, we appear to hijack an existing IMAP connection -
    * ctx is brand new and mostly empty */
 
-  if (!(idata = imap_conn_find(&(mx.account), 0)))
+  idata = imap_conn_find(&(mx.account), 0);
+  if (!idata)
   {
     FREE(&mx.mbox);
     return -1;
@@ -1056,7 +1061,8 @@ int imap_exec_msgset(struct ImapData *idata, const char *pre, const char *post,
   int rc;
   int count = 0;
 
-  if (!(cmd = mutt_buffer_new()))
+  cmd = mutt_buffer_new();
+  if (!cmd)
   {
     mutt_debug(1, "imap_exec_msgset: unable to allocate buffer\n");
     return -1;
@@ -1381,7 +1387,8 @@ static int imap_commit_message_tags(struct Context *ctx, struct Header *h, char 
   /* Remove old custom flags */
   if (HEADER_DATA(h)->flags_remote)
   {
-    if (!(cmd = mutt_buffer_new()))
+    cmd = mutt_buffer_new();
+    if (!cmd)
     {
       mutt_debug(1, "imap_commit_message_tags: unable to allocate buffer\n");
       return -1;
@@ -1408,7 +1415,8 @@ static int imap_commit_message_tags(struct Context *ctx, struct Header *h, char 
   /* Add new custom flags */
   if (tags)
   {
-    if (!(cmd = mutt_buffer_new()))
+    cmd = mutt_buffer_new();
+    if (!cmd)
     {
       mutt_debug(1, "imap_commit_message_tags: fail to remove old flags\n");
       return -1;
@@ -2125,7 +2133,8 @@ static int imap_compile_search(struct Context *ctx, const struct Pattern *pat,
         mutt_buffer_addstr(buf, "HEADER ");
 
         /* extract header name */
-        if (!(delim = strchr(pat->p.str, ':')))
+        delim = strchr(pat->p.str, ':');
+        if (!delim)
         {
           mutt_error(_("Header search without header name: %s"), pat->p.str);
           return -1;
@@ -2212,7 +2221,8 @@ int imap_subscribe(char *path, int subscribe)
     mutt_error(_("Bad mailbox name"));
     return -1;
   }
-  if (!(idata = imap_conn_find(&(mx.account), 0)))
+  idata = imap_conn_find(&(mx.account), 0);
+  if (!idata)
     goto fail;
 
   imap_fix_path(idata, mx.mbox, buf, sizeof(buf));
@@ -2359,7 +2369,8 @@ int imap_complete(char *dest, size_t dlen, char *path)
 
   /* don't open a new socket just for completion. Instead complete over
    * known mailboxes/hooks/etc */
-  if (!(idata = imap_conn_find(&(mx.account), MUTT_IMAP_CONN_NONEW)))
+  idata = imap_conn_find(&(mx.account), MUTT_IMAP_CONN_NONEW);
+  if (!idata)
   {
     FREE(&mx.mbox);
     strfcpy(dest, path, dlen);

--- a/imap/message.c
+++ b/imap/message.c
@@ -255,7 +255,8 @@ static int msg_parse_fetch(struct ImapHeader *h, char *s)
 
     if (mutt_strncasecmp("FLAGS", s, 5) == 0)
     {
-      if ((s = msg_parse_flags(h, s)) == NULL)
+      s = msg_parse_flags(h, s);
+      if (!s)
         return -1;
     }
     else if (mutt_strncasecmp("UID", s, 3) == 0)
@@ -932,7 +933,8 @@ int imap_fetch_message(struct Context *ctx, struct Message *msg, int msgno)
   imap_cmd_start(idata, buf);
   do
   {
-    if ((rc = imap_cmd_step(idata)) != IMAP_CMD_CONTINUE)
+    rc = imap_cmd_step(idata);
+    if (rc != IMAP_CMD_CONTINUE)
       break;
 
     pc = idata->buf;
@@ -972,7 +974,8 @@ int imap_fetch_message(struct Context *ctx, struct Message *msg, int msgno)
                                 output_progress ? &progressbar : NULL) < 0)
             goto bail;
           /* pick up trailing line */
-          if ((rc = imap_cmd_step(idata)) != IMAP_CMD_CONTINUE)
+          rc = imap_cmd_step(idata);
+          if (rc != IMAP_CMD_CONTINUE)
             goto bail;
           pc = idata->buf;
 
@@ -984,7 +987,8 @@ int imap_fetch_message(struct Context *ctx, struct Message *msg, int msgno)
          * incrementally update flags later, this won't stop us syncing */
         else if ((mutt_strncasecmp("FLAGS", pc, 5) == 0) && !h->changed)
         {
-          if ((pc = imap_set_flags(idata, h, pc, NULL)) == NULL)
+          pc = imap_set_flags(idata, h, pc, NULL);
+          if (!pc)
             goto bail;
         }
       }
@@ -1099,7 +1103,8 @@ int imap_append_message(struct Context *ctx, struct Message *msg)
   if (!*mailbox)
     strfcpy(mailbox, "INBOX", sizeof(mailbox));
 
-  if ((fp = fopen(msg->path, "r")) == NULL)
+  fp = fopen(msg->path, "r");
+  if (!fp)
   {
     mutt_perror(msg->path);
     goto fail;
@@ -1477,7 +1482,8 @@ char *imap_set_flags(struct ImapData *idata, struct Header *h, char *s, int *ser
   memcpy(&old_hd, hd, sizeof(old_hd));
 
   mutt_debug(2, "imap_set_flags: parsing FLAGS\n");
-  if ((s = msg_parse_flags(&newh, s)) == NULL)
+  s = msg_parse_flags(&newh, s);
+  if (!s)
     return NULL;
 
   /* Update tags system */

--- a/imap/message.c
+++ b/imap/message.c
@@ -345,7 +345,8 @@ static int msg_fetch_header(struct Context *ctx, struct ImapHeader *h, char *buf
     return rc;
 
   rc = -2; /* we've got a FETCH response, for better or worse */
-  if (!(buf = strchr(buf, '(')))
+  buf = strchr(buf, '(');
+  if (!buf)
     return rc;
   buf++;
 
@@ -534,7 +535,8 @@ int imap_read_headers(struct ImapData *idata, unsigned int msn_begin, unsigned i
   /* instead of downloading all headers and then parsing them, we parse them
    * as they come in. */
   mutt_mktemp(tempfile, sizeof(tempfile));
-  if (!(fp = safe_fopen(tempfile, "w+")))
+  fp = safe_fopen(tempfile, "w+");
+  if (!fp)
   {
     mutt_error(_("Could not create temporary file %s"), tempfile);
     mutt_sleep(2);
@@ -908,12 +910,14 @@ int imap_fetch_message(struct Context *ctx, struct Message *msg, int msgno)
   if (output_progress)
     mutt_message(_("Fetching message..."));
 
-  if (!(msg->fp = msg_cache_put(idata, h)))
+  msg->fp = msg_cache_put(idata, h);
+  if (!msg->fp)
   {
     cache->uid = HEADER_DATA(h)->uid;
     mutt_mktemp(path, sizeof(path));
     cache->path = safe_strdup(path);
-    if (!(msg->fp = safe_fopen(path, "w+")))
+    msg->fp = safe_fopen(path, "w+");
+    if (!msg->fp)
     {
       FREE(&cache->path);
       return -1;

--- a/imap/util.c
+++ b/imap/util.c
@@ -507,11 +507,13 @@ struct ImapData *imap_new_idata(void)
 {
   struct ImapData *idata = safe_calloc(1, sizeof(struct ImapData));
 
-  if (!(idata->cmdbuf = mutt_buffer_new()))
+  idata->cmdbuf = mutt_buffer_new();
+  if (!idata->cmdbuf)
     FREE(&idata);
 
   idata->cmdslots = ImapPipelineDepth + 2;
-  if (!(idata->cmds = safe_calloc(idata->cmdslots, sizeof(*idata->cmds))))
+  idata->cmds = safe_calloc(idata->cmdslots, sizeof(*idata->cmds));
+  if (!idata->cmds)
   {
     mutt_buffer_free(&idata->cmdbuf);
     FREE(&idata);

--- a/init.c
+++ b/init.c
@@ -170,7 +170,8 @@ static int parse_regex(int idx, struct Buffer *tmp, struct Buffer *err)
     }
 
     rx = safe_malloc(sizeof(regex_t));
-    if ((e = REGCOMP(rx, p, flags)) != 0)
+    e = REGCOMP(rx, p, flags);
+    if (e != 0)
     {
       regerror(e, rx, err->data, err->dsize);
       FREE(&rx);
@@ -352,7 +353,8 @@ static int parse_sort(short *val, const char *s, const struct Mapping *map, stru
     flags |= SORT_LAST;
   }
 
-  if ((i = mutt_getvaluebyname(s, map)) == -1)
+  i = mutt_getvaluebyname(s, map);
+  if (i == -1)
   {
     snprintf(err->data, err->dsize, _("%s: unknown sorting method"), s);
     return -1;
@@ -1489,7 +1491,8 @@ static int parse_group(struct Buffer *buf, struct Buffer *s, unsigned long data,
           break;
 
         case GS_ADDR:
-          if ((addr = mutt_parse_adrlist(NULL, buf->data)) == NULL)
+          addr = mutt_parse_adrlist(NULL, buf->data);
+          if (!addr)
             goto bail;
           if (mutt_addrlist_to_intl(addr, &estr))
           {
@@ -2311,7 +2314,8 @@ static void start_debug(void)
     rename(debugfilename, buf);
   }
 
-  if ((debugfile = safe_fopen(debugfilename, "w")) != NULL)
+  debugfile = safe_fopen(debugfilename, "w");
+  if (debugfile)
   {
     setbuf(debugfile, NULL); /* don't buffer the debugging output! */
     mutt_debug(1, "NeoMutt/%s debugging at level %d\n", PACKAGE_VERSION, debuglevel);
@@ -3200,7 +3204,8 @@ static int source_rc(const char *rcfile_path, struct Buffer *err)
 
   mutt_debug(2, "Reading configuration file '%s'.\n", rcfile);
 
-  if ((f = mutt_open_read(rcfile, &pid)) == NULL)
+  f = mutt_open_read(rcfile, &pid);
+  if (!f)
   {
     snprintf(err->data, err->dsize, "%s: %s", rcfile, strerror(errno));
     return -1;
@@ -3632,9 +3637,11 @@ int mutt_var_value_complete(char *buffer, size_t len, int pos)
       return 0;
 
     var[vlen - 1] = '\0';
-    if ((idx = mutt_option_index(var)) == -1)
+    idx = mutt_option_index(var);
+    if (idx == -1)
     {
-      if ((myvarval = myvar_get(var)) != NULL)
+      myvarval = myvar_get(var);
+      if (myvarval)
       {
         pretty_var(pt, len - (pt - buffer), var, myvarval);
         return 1;
@@ -4228,7 +4235,8 @@ void mutt_init(int skip_sys_rc, struct ListHead *commands)
   Editor = safe_strdup(p);
   Visual = safe_strdup(p);
 
-  if ((p = getenv("REPLYTO")) != NULL)
+  p = getenv("REPLYTO");
+  if (p)
   {
     struct Buffer buf, token;
 
@@ -4243,7 +4251,8 @@ void mutt_init(int skip_sys_rc, struct ListHead *commands)
     FREE(&token.data);
   }
 
-  if ((p = getenv("EMAIL")) != NULL)
+  p = getenv("EMAIL");
+  if (p)
     From = rfc822_parse_adrlist(NULL, p);
 
   mutt_set_langinfo_charset();

--- a/init.c
+++ b/init.c
@@ -781,7 +781,8 @@ int mutt_add_to_regex_list(struct RegexList **list, const char *s, int flags,
   if (!s || !*s)
     return 0;
 
-  if (!(rx = mutt_compile_regex(s, flags)))
+  rx = mutt_compile_regex(s, flags);
+  if (!rx)
   {
     snprintf(err->data, err->dsize, "Bad regex: %s\n", s);
     return -1;
@@ -871,7 +872,8 @@ static int add_to_replace_list(struct ReplaceList **list, const char *pat,
   if (!pat || !*pat || !templ)
     return 0;
 
-  if (!(rx = mutt_compile_regex(pat, REG_ICASE)))
+  rx = mutt_compile_regex(pat, REG_ICASE);
+  if (!rx)
   {
     snprintf(err->data, err->dsize, _("Bad regex: %s"), pat);
     return -1;

--- a/keymap.c
+++ b/keymap.c
@@ -202,7 +202,8 @@ static int parsekeys(const char *str, keycode_t *d, int max)
       c = *t;
       *t = '\0';
 
-      if ((n = mutt_getvaluebyname(s, KeyNames)) != -1)
+      n = mutt_getvaluebyname(s, KeyNames);
+      if (n != -1)
       {
         s = t;
         *d = n;
@@ -1090,7 +1091,8 @@ int mutt_parse_bind(struct Buffer *buf, struct Buffer *s, unsigned long data,
   char *key = NULL;
   int menu[sizeof(Menus) / sizeof(struct Mapping) - 1], r = 0, nummenus;
 
-  if ((key = parse_keymap(menu, s, sizeof(menu) / sizeof(menu[0]), &nummenus, err)) == NULL)
+  key = parse_keymap(menu, s, sizeof(menu) / sizeof(menu[0]), &nummenus, err);
+  if (!key)
     return -1;
 
   /* function to execute */
@@ -1147,7 +1149,8 @@ int mutt_parse_macro(struct Buffer *buf, struct Buffer *s, unsigned long data,
   char *seq = NULL;
   char *key = NULL;
 
-  if ((key = parse_keymap(menu, s, sizeof(menu) / sizeof(menu[0]), &nummenus, err)) == NULL)
+  key = parse_keymap(menu, s, sizeof(menu) / sizeof(menu[0]), &nummenus, err);
+  if (!key)
     return -1;
 
   mutt_extract_token(buf, s, MUTT_TOKEN_CONDENSE);

--- a/lib/date.c
+++ b/lib/date.c
@@ -560,7 +560,8 @@ time_t mutt_parse_date(const char *s, struct Tz *tz_out)
           /* ad hoc support for the European MET (now officially CET) TZ */
           if (mutt_strcasecmp(t, "MET") == 0)
           {
-            if ((t = strtok(NULL, " \t")) != NULL)
+            t = strtok(NULL, " \t");
+            if (t)
             {
               if (mutt_strcasecmp(t, "DST") == 0)
                 zhours++;

--- a/lib/file.c
+++ b/lib/file.c
@@ -650,7 +650,8 @@ char *mutt_read_line(char *s, size_t *size, FILE *fp, int *line, int flags)
       FREE(&s);
       return NULL;
     }
-    if ((ch = strchr(s + offset, '\n')) != NULL)
+    ch = strchr(s + offset, '\n');
+    if (ch)
     {
       if (line)
         (*line)++;

--- a/main.c
+++ b/main.c
@@ -632,7 +632,8 @@ int main(int argc, char **argv, char **env)
         {
           strfcpy(expanded_infile, infile, sizeof(expanded_infile));
           mutt_expand_path(expanded_infile, sizeof(expanded_infile));
-          if ((fin = fopen(expanded_infile, "r")) == NULL)
+          fin = fopen(expanded_infile, "r");
+          if (!fin)
           {
             if (!option(OPT_NO_CURSES))
               mutt_endwin(NULL);
@@ -651,7 +652,8 @@ int main(int argc, char **argv, char **env)
         mutt_mktemp(buf, sizeof(buf));
         tempfile = safe_strdup(buf);
 
-        if ((fout = safe_fopen(tempfile, "w")) == NULL)
+        fout = safe_fopen(tempfile, "w");
+        if (!fout)
         {
           if (!option(OPT_NO_CURSES))
             mutt_endwin(NULL);
@@ -670,7 +672,8 @@ int main(int argc, char **argv, char **env)
           fputs(bodytext, fout);
         safe_fclose(&fout);
 
-        if ((fin = fopen(tempfile, "r")) == NULL)
+        fin = fopen(tempfile, "r");
+        if (!fin)
         {
           if (!option(OPT_NO_CURSES))
             mutt_endwin(NULL);
@@ -796,7 +799,8 @@ int main(int argc, char **argv, char **env)
           perror(expanded_infile);
           exit(1);
         }
-        if ((fout = safe_fopen(expanded_infile, "a")) == NULL)
+        fout = safe_fopen(expanded_infile, "a");
+        if (!fout)
         {
           if (!option(OPT_NO_CURSES))
             mutt_endwin(NULL);

--- a/main.c
+++ b/main.c
@@ -869,7 +869,8 @@ int main(int argc, char **argv, char **env)
       if (flags & MUTT_NEWS)
       {
         set_option(OPT_NEWS);
-        if (!(CurrentNewsSrv = nntp_select_server(NewsServer, 0)))
+        CurrentNewsSrv = nntp_select_server(NewsServer, 0);
+        if (!CurrentNewsSrv)
         {
           mutt_endwin(ErrorBuf);
           exit(1);

--- a/mbox.c
+++ b/mbox.c
@@ -611,7 +611,7 @@ static int strict_cmp_envelopes(const struct Envelope *e1, const struct Envelope
   }
   else
   {
-    if (e1 == NULL && e2 == NULL)
+    if (!e1 && !e2)
       return 1;
     else
       return 0;
@@ -665,7 +665,7 @@ int mbox_strict_cmp_headers(const struct Header *h1, const struct Header *h2)
   }
   else
   {
-    if (h1 == NULL && h2 == NULL)
+    if (!h1 && !h2)
       return 1;
     else
       return 0;
@@ -743,7 +743,8 @@ static int reopen_mailbox(struct Context *ctx, int *index_hint)
     case MUTT_MMDF:
       cmp_headers = mbox_strict_cmp_headers;
       safe_fclose(&ctx->fp);
-      if (!(ctx->fp = safe_fopen(ctx->path, "r")))
+      ctx->fp = safe_fopen(ctx->path, "r");
+      if (!ctx->fp)
         rc = -1;
       else
         rc = ((ctx->magic == MUTT_MBOX) ? mbox_parse_mailbox : mmdf_parse_mailbox)(ctx);

--- a/mbox.c
+++ b/mbox.c
@@ -75,7 +75,8 @@ static int mbox_lock_mailbox(struct Context *ctx, int excl, int retry)
 {
   int r;
 
-  if ((r = mutt_lock_file(ctx->path, fileno(ctx->fp), excl, retry)) == 0)
+  r = mutt_lock_file(ctx->path, fileno(ctx->fp), excl, retry);
+  if (r == 0)
     ctx->locked = true;
   else if (retry && !excl)
   {
@@ -440,7 +441,8 @@ static int mbox_open_mailbox(struct Context *ctx)
 {
   int rc;
 
-  if ((ctx->fp = fopen(ctx->path, "r")) == NULL)
+  ctx->fp = fopen(ctx->path, "r");
+  if (!ctx->fp)
   {
     mutt_perror(ctx->path);
     return -1;
@@ -1043,7 +1045,8 @@ static int mbox_sync_mailbox(struct Context *ctx, int *index_hint)
   /* need to open the file for writing in such a way that it does not truncate
    * the file, so use read-write mode.
    */
-  if ((ctx->fp = freopen(ctx->path, "r+", ctx->fp)) == NULL)
+  ctx->fp = freopen(ctx->path, "r+", ctx->fp);
+  if (!ctx->fp)
   {
     mx_fastclose_mailbox(ctx);
     mutt_error(_("Fatal error!  Could not reopen mailbox!"));
@@ -1225,7 +1228,8 @@ static int mbox_sync_mailbox(struct Context *ctx, int *index_hint)
     goto bail;
   }
 
-  if ((fp = fopen(tempfile, "r")) == NULL)
+  fp = fopen(tempfile, "r");
+  if (!fp)
   {
     mutt_unblock_signals();
     mx_fastclose_mailbox(ctx);
@@ -1307,7 +1311,8 @@ static int mbox_sync_mailbox(struct Context *ctx, int *index_hint)
   mbox_reset_atime(ctx, &statbuf);
 
   /* reopen the mailbox in read-only mode */
-  if ((ctx->fp = fopen(ctx->path, "r")) == NULL)
+  ctx->fp = fopen(ctx->path, "r");
+  if (!ctx->fp)
   {
     unlink(tempfile);
     mutt_unblock_signals();
@@ -1367,7 +1372,8 @@ bail: /* Come here in case of disaster */
   FREE(&newOffset);
   FREE(&oldOffset);
 
-  if ((ctx->fp = freopen(ctx->path, "r", ctx->fp)) == NULL)
+  ctx->fp = freopen(ctx->path, "r", ctx->fp);
+  if (!ctx->fp)
   {
     mutt_error(_("Could not reopen mailbox!"));
     mx_fastclose_mailbox(ctx);

--- a/mbyte.c
+++ b/mbyte.c
@@ -86,7 +86,8 @@ int mutt_filter_unprintable(char **s)
   char *p = *s;
   mbstate_t mbstate1, mbstate2;
 
-  if (!(b = mutt_buffer_new()))
+  b = mutt_buffer_new();
+  if (!b)
     return -1;
   memset(&mbstate1, 0, sizeof(mbstate1));
   memset(&mbstate2, 0, sizeof(mbstate2));

--- a/menu.c
+++ b/menu.c
@@ -1241,7 +1241,8 @@ int mutt_menu_loop(struct Menu *menu)
         if (menu->search && !menu->dialog) /* Searching dialogs won't work */
         {
           menu->oldcurrent = menu->current;
-          if ((menu->current = menu_search(menu, i)) != -1)
+          menu->current = menu_search(menu, i);
+          if (menu->current != -1)
             menu->redraw = REDRAW_MOTION;
           else
             menu->current = menu->oldcurrent;

--- a/mh.c
+++ b/mh.c
@@ -178,12 +178,14 @@ static int mh_read_sequences(struct MhSequences *mhs, const char *path)
   char pathname[_POSIX_PATH_MAX];
   snprintf(pathname, sizeof(pathname), "%s/.mh_sequences", path);
 
-  if (!(fp = fopen(pathname, "r")))
+  fp = fopen(pathname, "r");
+  if (!fp)
     return 0; /* yes, ask callers to silently ignore the error */
 
   while ((buff = mutt_read_line(buff, &sz, fp, &line, 0)))
   {
-    if (!(t = strtok(buff, " \t:")))
+    t = strtok(buff, " \t:");
+    if (!t)
       continue;
 
     if (mutt_strcmp(t, MhSeqUnseen) == 0)

--- a/mutt_socket.c
+++ b/mutt_socket.c
@@ -327,7 +327,8 @@ int raw_socket_read(struct Connection *conn, char *buf, size_t len)
   int rc;
 
   mutt_allow_interrupt(1);
-  if ((rc = read(conn->fd, buf, len)) == -1)
+  rc = read(conn->fd, buf, len);
+  if (rc == -1)
   {
     mutt_error(_("Error talking to %s (%s)"), conn->account.host, strerror(errno));
     mutt_sleep(2);
@@ -351,7 +352,8 @@ int raw_socket_write(struct Connection *conn, const char *buf, size_t count)
   int rc;
 
   mutt_allow_interrupt(1);
-  if ((rc = write(conn->fd, buf, count)) == -1)
+  rc = write(conn->fd, buf, count);
+  if (rc == -1)
   {
     mutt_error(_("Error talking to %s (%s)"), conn->account.host, strerror(errno));
     mutt_sleep(2);
@@ -520,7 +522,8 @@ int raw_socket_open(struct Connection *conn)
     fd = socket(cur->ai_family, cur->ai_socktype, cur->ai_protocol);
     if (fd >= 0)
     {
-      if ((rc = socket_connect(fd, cur->ai_addr)) == 0)
+      rc = socket_connect(fd, cur->ai_addr);
+      if (rc == 0)
       {
         fcntl(fd, F_SETFD, FD_CLOEXEC);
         conn->fd = fd;
@@ -580,7 +583,8 @@ int raw_socket_open(struct Connection *conn)
 
     if (fd >= 0)
     {
-      if ((rc = socket_connect(fd, (struct sockaddr *) &sin)) == 0)
+      rc = socket_connect(fd, (struct sockaddr *) &sin);
+      if (rc == 0)
       {
         fcntl(fd, F_SETFD, FD_CLOEXEC);
         conn->fd = fd;

--- a/mutt_ssl.c
+++ b/mutt_ssl.c
@@ -121,7 +121,8 @@ static int ssl_load_certificates(SSL_CTX *ctx)
     SSL_CTX_set_cert_store(ctx, store);
   }
 
-  if ((fp = fopen(CertificateFile, "rt")) == NULL)
+  fp = fopen(CertificateFile, "rt");
+  if (!fp)
     return 0;
 
   while (NULL != PEM_read_X509(fp, &cert, NULL, NULL))
@@ -632,7 +633,8 @@ static int check_certificate_file(X509 *peercert)
   if (!CertificateFile)
     return 0;
 
-  if ((fp = fopen(CertificateFile, "rt")) == NULL)
+  fp = fopen(CertificateFile, "rt");
+  if (!fp)
     return 0;
 
   if (!X509_digest(peercert, EVP_sha256(), peermd, &peermdlen))
@@ -1074,7 +1076,8 @@ static int ssl_negotiate(struct Connection *conn, struct SslSockData *ssldata)
   int err;
   const char *errmsg = NULL;
 
-  if ((HostExDataIndex = SSL_get_ex_new_index(0, "host", NULL, NULL, NULL)) == -1)
+  HostExDataIndex = SSL_get_ex_new_index(0, "host", NULL, NULL, NULL);
+  if (HostExDataIndex == -1)
   {
     mutt_debug(1, "failed to get index for application specific data\n");
     return -1;
@@ -1086,7 +1089,8 @@ static int ssl_negotiate(struct Connection *conn, struct SslSockData *ssldata)
     return -1;
   }
 
-  if ((SkipModeExDataIndex = SSL_get_ex_new_index(0, "skip", NULL, NULL, NULL)) == -1)
+  SkipModeExDataIndex = SSL_get_ex_new_index(0, "skip", NULL, NULL, NULL);
+  if (SkipModeExDataIndex == -1)
   {
     mutt_debug(1, "failed to get index for application specific data\n");
     return -1;
@@ -1112,7 +1116,8 @@ static int ssl_negotiate(struct Connection *conn, struct SslSockData *ssldata)
 
   ERR_clear_error();
 
-  if ((err = SSL_connect(ssldata->ssl)) != 1)
+  err = SSL_connect(ssldata->ssl);
+  if (err != 1)
   {
     switch (SSL_get_error(ssldata->ssl, err))
     {

--- a/mutt_ssl.c
+++ b/mutt_ssl.c
@@ -289,7 +289,8 @@ static void ssl_dprint_err_stack(void)
   long buflen;
   char *output = NULL;
 
-  if (!(bio = BIO_new(BIO_s_mem())))
+  bio = BIO_new(BIO_s_mem());
+  if (!bio)
     return;
   ERR_print_errors(bio);
   if ((buflen = BIO_get_mem_data(bio, &buf)) > 0)
@@ -718,7 +719,8 @@ static int check_host(X509 *x509cert, const char *hostname, char *err, size_t er
   if (!match_found)
   {
     /* Try the common name */
-    if (!(x509_subject = X509_get_subject_name(x509cert)))
+    x509_subject = X509_get_subject_name(x509cert);
+    if (!x509_subject)
     {
       if (err && errlen)
         strfcpy(err, _("cannot get certificate subject"), errlen);
@@ -960,13 +962,15 @@ static int ssl_verify_callback(int preverify_ok, X509_STORE_CTX *ctx)
   unsigned int last_cert_mdlen;
 #endif
 
-  if (!(ssl = X509_STORE_CTX_get_ex_data(ctx, SSL_get_ex_data_X509_STORE_CTX_idx())))
+  ssl = X509_STORE_CTX_get_ex_data(ctx, SSL_get_ex_data_X509_STORE_CTX_idx());
+  if (!ssl)
   {
     mutt_debug(1, "ssl_verify_callback: failed to retrieve SSL structure from "
                   "X509_STORE_CTX\n");
     return 0;
   }
-  if (!(host = SSL_get_ex_data(ssl, HostExDataIndex)))
+  host = SSL_get_ex_data(ssl, HostExDataIndex);
+  if (!host)
   {
     mutt_debug(1, "ssl_verify_callback: failed to retrieve hostname from SSL "
                   "structure\n");
@@ -1151,7 +1155,8 @@ static int ssl_socket_open(struct Connection *conn)
   data = safe_calloc(1, sizeof(struct SslSockData));
   conn->sockdata = data;
 
-  if (!(data->ctx = SSL_CTX_new(SSLv23_client_method())))
+  data->ctx = SSL_CTX_new(SSLv23_client_method());
+  if (!data->ctx)
   {
     /* L10N: an SSL context is a data structure returned by the OpenSSL
              function SSL_CTX_new().  In this case it returned NULL: an
@@ -1255,7 +1260,8 @@ int mutt_ssl_starttls(struct Connection *conn)
    * TLSv1_client_method gives us explicitly TLSv1.0, not 1.1 or 1.2 (True as
    * of OpenSSL 1.0.1c)
    */
-  if (!(ssldata->ctx = SSL_CTX_new(SSLv23_client_method())))
+  ssldata->ctx = SSL_CTX_new(SSLv23_client_method());
+  if (!ssldata->ctx)
   {
     mutt_debug(1, "mutt_ssl_starttls: Error allocating SSL_CTX\n");
     goto bail_ssldata;
@@ -1314,7 +1320,8 @@ int mutt_ssl_starttls(struct Connection *conn)
     mutt_sleep(2);
   }
 
-  if (!(ssldata->ssl = SSL_new(ssldata->ctx)))
+  ssldata->ssl = SSL_new(ssldata->ctx);
+  if (!ssldata->ssl)
   {
     mutt_debug(1, "mutt_ssl_starttls: Error allocating SSL\n");
     goto bail_ctx;

--- a/mutt_ssl_gnutls.c
+++ b/mutt_ssl_gnutls.c
@@ -874,7 +874,8 @@ static void tls_get_client_cert(struct Connection *conn)
   size_t dnlen;
 
   /* get our cert CN if we have one */
-  if (!(crtdata = gnutls_certificate_get_ours(data->state)))
+  crtdata = gnutls_certificate_get_ours(data->state);
+  if (!crtdata)
     return;
 
   if (gnutls_x509_crt_init(&clientcrt) < 0)
@@ -890,7 +891,8 @@ static void tls_get_client_cert(struct Connection *conn)
   /* get length of DN */
   dnlen = 0;
   gnutls_x509_crt_get_dn(clientcrt, NULL, &dnlen);
-  if (!(dn = calloc(1, dnlen)))
+  dn = calloc(1, dnlen);
+  if (!dn)
   {
     mutt_debug(1, "could not allocate DN\n");
     goto err_crt;
@@ -899,7 +901,8 @@ static void tls_get_client_cert(struct Connection *conn)
   mutt_debug(2, "client certificate DN: %s\n", dn);
 
   /* extract CN to use as external user name */
-  if (!(cn = strstr(dn, "CN=")))
+  cn = strstr(dn, "CN=");
+  if (!cn)
   {
     mutt_debug(1, "no CN found in DN\n");
     goto err_dn;

--- a/mutt_tunnel.c
+++ b/mutt_tunnel.c
@@ -61,13 +61,15 @@ static int tunnel_socket_open(struct Connection *conn)
 
   mutt_message(_("Connecting with \"%s\"..."), Tunnel);
 
-  if ((rc = pipe(pin)) == -1)
+  rc = pipe(pin);
+  if (rc == -1)
   {
     mutt_perror("pipe");
     FREE(&conn->sockdata);
     return -1;
   }
-  if ((rc = pipe(pout)) == -1)
+  rc = pipe(pout);
+  if (rc == -1)
   {
     mutt_perror("pipe");
     close(pin[0]);
@@ -77,7 +79,8 @@ static int tunnel_socket_open(struct Connection *conn)
   }
 
   mutt_block_signals_system();
-  if ((pid = fork()) == 0)
+  pid = fork();
+  if (pid == 0)
   {
     mutt_unblock_signals_system(0);
     devnull = open("/dev/null", O_RDWR);

--- a/muttlib.c
+++ b/muttlib.c
@@ -110,7 +110,8 @@ void mutt_adv_mktemp(char *s, size_t l)
     if (lstat(s, &sb) == -1 && errno == ENOENT)
       return;
 
-    if ((suffix = strrchr(prefix, '.')) != NULL)
+    suffix = strrchr(prefix, '.');
+    if (suffix)
     {
       *suffix = 0;
       suffix++;
@@ -1012,7 +1013,8 @@ void mutt_expando_format(char *dest, size_t destlen, size_t col, int cols,
       col -= wlen; /* reset to passed in value */
       wptr = dest; /* reset write ptr */
       wlen = ((flags & MUTT_FORMAT_ARROWCURSOR) && option(OPT_ARROW_CURSOR)) ? 3 : 0;
-      if ((pid = mutt_create_filter(command->data, NULL, &filter, NULL)) != -1)
+      pid = mutt_create_filter(command->data, NULL, &filter, NULL);
+      if (pid != -1)
       {
         int rc;
 
@@ -1495,7 +1497,8 @@ int mutt_save_confirm(const char *s, struct stat *st)
     if (option(OPT_CONFIRMAPPEND))
     {
       snprintf(tmp, sizeof(tmp), _("Append messages to %s?"), s);
-      if ((rc = mutt_yesorno(tmp, MUTT_YES)) == MUTT_NO)
+      rc = mutt_yesorno(tmp, MUTT_YES);
+      if (rc == MUTT_NO)
         ret = 1;
       else if (rc == MUTT_ABORT)
         ret = -1;
@@ -1529,7 +1532,8 @@ int mutt_save_confirm(const char *s, struct stat *st)
       if (option(OPT_CONFIRMCREATE))
       {
         snprintf(tmp, sizeof(tmp), _("Create %s?"), s);
-        if ((rc = mutt_yesorno(tmp, MUTT_YES)) == MUTT_NO)
+        rc = mutt_yesorno(tmp, MUTT_YES);
+        if (rc == MUTT_NO)
           ret = 1;
         else if (rc == MUTT_ABORT)
           ret = -1;

--- a/mx.c
+++ b/mx.c
@@ -710,7 +710,8 @@ int mx_close_mailbox(struct Context *ctx, int *index_hint)
     {
       mutt_expand_path(mbox, sizeof(mbox));
       snprintf(buf, sizeof(buf), _("Move read messages to %s?"), mbox);
-      if ((move_messages = query_quadoption(OPT_MOVE, buf)) == MUTT_ABORT)
+      move_messages = query_quadoption(OPT_MOVE, buf);
+      if (move_messages == MUTT_ABORT)
       {
         ctx->closing = false;
         return -1;
@@ -728,7 +729,8 @@ int mx_close_mailbox(struct Context *ctx, int *index_hint)
              ctx->deleted == 1 ? _("Purge %d deleted message?") :
                                  _("Purge %d deleted messages?"),
              ctx->deleted);
-    if ((purge = query_quadoption(OPT_DELETE, buf)) == MUTT_ABORT)
+    purge = query_quadoption(OPT_DELETE, buf);
+    if (purge == MUTT_ABORT)
     {
       ctx->closing = false;
       return -1;
@@ -828,7 +830,8 @@ int mx_close_mailbox(struct Context *ctx, int *index_hint)
   /* allow IMAP to preserve the deleted flag across sessions */
   if (ctx->magic == MUTT_IMAP)
   {
-    if ((check = imap_sync_mailbox(ctx, purge)) != 0)
+    check = imap_sync_mailbox(ctx, purge);
+    if (check != 0)
     {
       ctx->closing = false;
       return check;
@@ -849,7 +852,8 @@ int mx_close_mailbox(struct Context *ctx, int *index_hint)
 
     if (ctx->changed || ctx->deleted)
     {
-      if ((check = sync_mailbox(ctx, index_hint)) != 0)
+      check = sync_mailbox(ctx, index_hint);
+      if (check != 0)
       {
         ctx->closing = false;
         return check;
@@ -1023,7 +1027,8 @@ int mx_sync_mailbox(struct Context *ctx, int *index_hint)
              ctx->deleted == 1 ? _("Purge %d deleted message?") :
                                  _("Purge %d deleted messages?"),
              ctx->deleted);
-    if ((purge = query_quadoption(OPT_DELETE, buf)) == MUTT_ABORT)
+    purge = query_quadoption(OPT_DELETE, buf);
+    if (purge == MUTT_ABORT)
       return -1;
     else if (purge == MUTT_NO)
     {

--- a/mx.c
+++ b/mx.c
@@ -424,7 +424,8 @@ struct Context *mx_open_mailbox(const char *path, int flags, struct Context *pct
       FREE(&ctx);
     return NULL;
   }
-  if (!(ctx->realpath = realpath(ctx->path, NULL)))
+  ctx->realpath = realpath(ctx->path, NULL);
+  if (!ctx->realpath)
     ctx->realpath = safe_strdup(ctx->path);
 
   ctx->msgnotreadyet = -1;

--- a/ncrypt/crypt.c
+++ b/ncrypt/crypt.c
@@ -231,7 +231,8 @@ int mutt_protect(struct Header *msg, char *keylist)
   {
     if ((WithCrypto & APPLICATION_SMIME) && (msg->security & APPLICATION_SMIME))
     {
-      if (!(tmp_pbody = crypt_smime_sign_message(msg->content)))
+      tmp_pbody = crypt_smime_sign_message(msg->content);
+      if (!tmp_pbody)
         return -1;
       pbody = tmp_smime_pbody = tmp_pbody;
     }
@@ -239,7 +240,8 @@ int mutt_protect(struct Header *msg, char *keylist)
     if ((WithCrypto & APPLICATION_PGP) && (msg->security & APPLICATION_PGP) &&
         (!(flags & ENCRYPT) || option(OPT_PGP_RETAINABLE_SIGS)))
     {
-      if (!(tmp_pbody = crypt_pgp_sign_message(msg->content)))
+      tmp_pbody = crypt_pgp_sign_message(msg->content);
+      if (!tmp_pbody)
         return -1;
 
       flags &= ~SIGN;
@@ -317,7 +319,8 @@ int mutt_is_multipart_signed(struct Body *b)
       (mutt_strcasecmp(b->subtype, "signed") != 0))
     return 0;
 
-  if (!(p = mutt_get_parameter("protocol", b->parameter)))
+  p = mutt_get_parameter("protocol", b->parameter);
+  if (!p)
     return 0;
 
   if (!(mutt_strcasecmp(p, "multipart/mixed") != 0))
@@ -614,7 +617,8 @@ int crypt_write_signed(struct Body *a, struct State *s, const char *tempfile)
   if (!WithCrypto)
     return -1;
 
-  if (!(fp = safe_fopen(tempfile, "w")))
+  fp = safe_fopen(tempfile, "w");
+  if (!fp)
   {
     mutt_perror(tempfile);
     return -1;
@@ -692,7 +696,8 @@ void crypt_extract_keys_from_messages(struct Header *h)
     return;
 
   mutt_mktemp(tempfname, sizeof(tempfname));
-  if (!(fpout = safe_fopen(tempfname, "w")))
+  fpout = safe_fopen(tempfname, "w");
+  if (!fpout)
   {
     mutt_perror(tempfname);
     return;

--- a/ncrypt/crypt.c
+++ b/ncrypt/crypt.c
@@ -625,7 +625,8 @@ int crypt_write_signed(struct Body *a, struct State *s, const char *tempfile)
   hadcr = false;
   while (bytes > 0)
   {
-    if ((c = fgetc(s->fpin)) == EOF)
+    c = fgetc(s->fpin);
+    if (c == EOF)
       break;
 
     bytes--;
@@ -840,7 +841,8 @@ int crypt_get_keys(struct Header *msg, char **keylist, int oppenc_mode)
   {
     if ((WithCrypto & APPLICATION_PGP) && (msg->security & APPLICATION_PGP))
     {
-      if ((*keylist = crypt_pgp_findkeys(adrlist, oppenc_mode)) == NULL)
+      *keylist = crypt_pgp_findkeys(adrlist, oppenc_mode);
+      if (!*keylist)
       {
         rfc822_free_address(&adrlist);
         return -1;
@@ -851,7 +853,8 @@ int crypt_get_keys(struct Header *msg, char **keylist, int oppenc_mode)
     }
     if ((WithCrypto & APPLICATION_SMIME) && (msg->security & APPLICATION_SMIME))
     {
-      if ((*keylist = crypt_smime_findkeys(adrlist, oppenc_mode)) == NULL)
+      *keylist = crypt_smime_findkeys(adrlist, oppenc_mode);
+      if (!*keylist)
       {
         rfc822_free_address(&adrlist);
         return -1;

--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -648,7 +648,8 @@ static char *data_object_to_tempfile(gpgme_data_t data, char *tempf, FILE **ret_
     mutt_mktemp(tempfb, sizeof(tempfb));
     tempf = tempfb;
   }
-  if ((fp = safe_fopen(tempf, tempf == tempfb ? "w+" : "a+")) == NULL)
+  fp = safe_fopen(tempf, tempf == tempfb ? "w+" : "a+");
+  if (!fp)
   {
     mutt_perror(_("Can't create temporary file"));
     return NULL;
@@ -1961,7 +1962,8 @@ int pgp_gpgme_decrypt_mime(FILE *fpin, FILE **fpout, struct Body *b, struct Body
     saved_length = b->length;
 
     mutt_mktemp(tempfile, sizeof(tempfile));
-    if ((decoded_fp = safe_fopen(tempfile, "w+")) == NULL)
+    decoded_fp = safe_fopen(tempfile, "w+");
+    if (!decoded_fp)
     {
       mutt_perror(tempfile);
       return -1;
@@ -1990,7 +1992,8 @@ int pgp_gpgme_decrypt_mime(FILE *fpin, FILE **fpout, struct Body *b, struct Body
   }
   unlink(tempfile);
 
-  if ((*cur = decrypt_part(b, &s, *fpout, 0, &is_signed)) == NULL)
+  *cur = decrypt_part(b, &s, *fpout, 0, &is_signed);
+  if (!*cur)
     rv = -1;
   rewind(*fpout);
   if (is_signed > 0)
@@ -2155,7 +2158,8 @@ static int pgp_gpgme_extract_keys(gpgme_data_t keydata, FILE **fp, int dryrun)
   int rc = -1;
   time_t tt;
 
-  if ((err = gpgme_new(&tmpctx)) != GPG_ERR_NO_ERROR)
+  err = gpgme_new(&tmpctx);
+  if (err != GPG_ERR_NO_ERROR)
   {
     mutt_debug(1, "Error creating GPGME context\n");
     return rc;
@@ -2188,7 +2192,8 @@ static int pgp_gpgme_extract_keys(gpgme_data_t keydata, FILE **fp, int dryrun)
     }
   }
 
-  if ((err = gpgme_op_import(tmpctx, keydata)) != GPG_ERR_NO_ERROR)
+  err = gpgme_op_import(tmpctx, keydata);
+  if (err != GPG_ERR_NO_ERROR)
   {
     mutt_debug(1, "Error importing key\n");
     goto err_tmpdir;
@@ -2302,7 +2307,8 @@ static int pgp_check_traditional_one_body(FILE *fp, struct Body *b)
     return 0;
   }
 
-  if ((tfp = fopen(tempfile, "r")) == NULL)
+  tfp = fopen(tempfile, "r");
+  if (!tfp)
   {
     unlink(tempfile);
     return 0;
@@ -2372,7 +2378,8 @@ void pgp_gpgme_invoke_import(const char *fname)
   /* Note that the stream, "in", needs to be kept open while the keydata
    * is used.
    */
-  if ((err = gpgme_data_new_from_stream(&keydata, in)) != GPG_ERR_NO_ERROR)
+  err = gpgme_data_new_from_stream(&keydata, in);
+  if (err != GPG_ERR_NO_ERROR)
   {
     safe_fclose(&in);
     mutt_error(_("error allocating data object: %s\n"), gpgme_strerror(err));
@@ -4076,7 +4083,8 @@ static void crypt_add_string_to_hints(struct ListHead *hints, const char *str)
   char *scratch = NULL;
   char *t = NULL;
 
-  if ((scratch = safe_strdup(str)) == NULL)
+  scratch = safe_strdup(str);
+  if (!scratch)
     return;
 
   for (t = strtok(scratch, " ,.:\"()<>\n"); t; t = strtok(NULL, " ,.:\"()<>\n"))

--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -1984,7 +1984,8 @@ int pgp_gpgme_decrypt_mime(FILE *fpin, FILE **fpout, struct Body *b, struct Body
   }
 
   mutt_mktemp(tempfile, sizeof(tempfile));
-  if (!(*fpout = safe_fopen(tempfile, "w+")))
+  *fpout = safe_fopen(tempfile, "w+");
+  if (!*fpout)
   {
     mutt_perror(tempfile);
     rv = -1;
@@ -2045,7 +2046,8 @@ int smime_gpgme_decrypt_mime(FILE *fpin, FILE **fpout, struct Body *b, struct Bo
   s.fpin = fpin;
   fseeko(s.fpin, b->offset, SEEK_SET);
   mutt_mktemp(tempfile, sizeof(tempfile));
-  if (!(tmpfp = safe_fopen(tempfile, "w+")))
+  tmpfp = safe_fopen(tempfile, "w+");
+  if (!tmpfp)
   {
     mutt_perror(tempfile);
     return -1;
@@ -2063,7 +2065,8 @@ int smime_gpgme_decrypt_mime(FILE *fpin, FILE **fpout, struct Body *b, struct Bo
   s.fpin = tmpfp;
   s.fpout = 0;
   mutt_mktemp(tempfile, sizeof(tempfile));
-  if (!(*fpout = safe_fopen(tempfile, "w+")))
+  *fpout = safe_fopen(tempfile, "w+");
+  if (!*fpout)
   {
     mutt_perror(tempfile);
     return -1;
@@ -2099,7 +2102,8 @@ int smime_gpgme_decrypt_mime(FILE *fpin, FILE **fpout, struct Body *b, struct Bo
     s.fpin = *fpout;
     fseeko(s.fpin, bb->offset, SEEK_SET);
     mutt_mktemp(tempfile, sizeof(tempfile));
-    if (!(tmpfp = safe_fopen(tempfile, "w+")))
+    tmpfp = safe_fopen(tempfile, "w+");
+    if (!tmpfp)
     {
       mutt_perror(tempfile);
       return -1;
@@ -2118,7 +2122,8 @@ int smime_gpgme_decrypt_mime(FILE *fpin, FILE **fpout, struct Body *b, struct Bo
     s.fpin = tmpfp;
     s.fpout = 0;
     mutt_mktemp(tempfile, sizeof(tempfile));
-    if (!(*fpout = safe_fopen(tempfile, "w+")))
+    *fpout = safe_fopen(tempfile, "w+");
+    if (!*fpout)
     {
       mutt_perror(tempfile);
       return -1;
@@ -2373,7 +2378,8 @@ void pgp_gpgme_invoke_import(const char *fname)
   FILE *in = NULL;
   FILE *out = NULL;
 
-  if (!(in = safe_fopen(fname, "r")))
+  in = safe_fopen(fname, "r");
+  if (!in)
     return;
   /* Note that the stream, "in", needs to be kept open while the keydata
    * is used.
@@ -2731,7 +2737,8 @@ int pgp_gpgme_encrypted_handler(struct Body *a, struct State *s)
   mutt_debug(2, "Entering pgp_encrypted handler\n");
 
   mutt_mktemp(tempfile, sizeof(tempfile));
-  if (!(fpout = safe_fopen(tempfile, "w+")))
+  fpout = safe_fopen(tempfile, "w+");
+  if (!fpout)
   {
     if (s->flags & MUTT_DISPLAY)
       state_attach_puts(_("[-- Error: could not create temporary file! "
@@ -2808,7 +2815,8 @@ int smime_gpgme_application_handler(struct Body *a, struct State *s)
 
   a->warnsig = false;
   mutt_mktemp(tempfile, sizeof(tempfile));
-  if (!(fpout = safe_fopen(tempfile, "w+")))
+  fpout = safe_fopen(tempfile, "w+");
+  if (!fpout)
   {
     if (s->flags & MUTT_DISPLAY)
       state_attach_puts(_("[-- Error: could not create temporary file! "
@@ -2842,7 +2850,8 @@ int smime_gpgme_application_handler(struct Body *a, struct State *s)
        */
     if (mutt_is_multipart_signed(tattach) && !tattach->next)
     {
-      if (!(a->goodsig = tattach->goodsig))
+      a->goodsig = tattach->goodsig;
+      if (!a->goodsig)
         a->warnsig = tattach->warnsig;
     }
     else if (tattach->goodsig)
@@ -3488,19 +3497,22 @@ static unsigned int key_check_cap(gpgme_key_t key, enum KeyCap cap)
   switch (cap)
   {
     case KEY_CAP_CAN_ENCRYPT:
-      if (!(ret = key->can_encrypt))
+      ret = key->can_encrypt;
+      if (ret == 0)
         for (subkey = key->subkeys; subkey; subkey = subkey->next)
           if ((ret = subkey->can_encrypt))
             break;
       break;
     case KEY_CAP_CAN_SIGN:
-      if (!(ret = key->can_sign))
+      ret = key->can_sign;
+      if (ret == 0)
         for (subkey = key->subkeys; subkey; subkey = subkey->next)
           if ((ret = subkey->can_sign))
             break;
       break;
     case KEY_CAP_CAN_CERTIFY:
-      if (!(ret = key->can_certify))
+      ret = key->can_certify;
+      if (ret == 0)
         for (subkey = key->subkeys; subkey; subkey = subkey->next)
           if ((ret = subkey->can_certify))
             break;
@@ -3809,7 +3821,8 @@ static void verify_key(struct CryptKeyInfo *key)
   int maxdepth = 100;
 
   mutt_mktemp(tempfile, sizeof(tempfile));
-  if (!(fp = safe_fopen(tempfile, "w")))
+  fp = safe_fopen(tempfile, "w");
+  if (!fp)
   {
     mutt_perror(_("Can't create temporary file"));
     return;

--- a/ncrypt/gnupgparse.c
+++ b/ncrypt/gnupgparse.c
@@ -390,7 +390,8 @@ struct PgpKeyInfo *pgp_get_candidates(enum PgpRing keyring, struct ListHead *hin
   int is_sub;
   int devnull;
 
-  if ((devnull = open("/dev/null", O_RDWR)) == -1)
+  devnull = open("/dev/null", O_RDWR);
+  if (devnull == -1)
     return NULL;
 
   mutt_str_replace(&_chs, Charset);

--- a/ncrypt/gnupgparse.c
+++ b/ncrypt/gnupgparse.c
@@ -407,7 +407,8 @@ struct PgpKeyInfo *pgp_get_candidates(enum PgpRing keyring, struct ListHead *hin
   k = NULL;
   while (fgets(buf, sizeof(buf) - 1, fp))
   {
-    if (!(kk = parse_pub_line(buf, &is_sub, k)))
+    kk = parse_pub_line(buf, &is_sub, k);
+    if (!kk)
       continue;
 
     /* Only append kk to the list if it's new. */

--- a/ncrypt/pgp.c
+++ b/ncrypt/pgp.c
@@ -713,7 +713,8 @@ int pgp_verify_one(struct Body *sigbdy, struct State *s, const char *tempfile)
 
   snprintf(sigfile, sizeof(sigfile), "%s.asc", tempfile);
 
-  if (!(fp = safe_fopen(sigfile, "w")))
+  fp = safe_fopen(sigfile, "w");
+  if (!fp)
   {
     mutt_perror(sigfile);
     return -1;
@@ -724,7 +725,8 @@ int pgp_verify_one(struct Body *sigbdy, struct State *s, const char *tempfile)
   safe_fclose(&fp);
 
   mutt_mktemp(pgperrfile, sizeof(pgperrfile));
-  if (!(pgperr = safe_fopen(pgperrfile, "w+")))
+  pgperr = safe_fopen(pgperrfile, "w+");
+  if (!pgperr)
   {
     mutt_perror(pgperrfile);
     unlink(sigfile);
@@ -774,7 +776,8 @@ static void pgp_extract_keys_from_attachment(FILE *fp, struct Body *top)
   char tempfname[_POSIX_PATH_MAX];
 
   mutt_mktemp(tempfname, sizeof(tempfname));
-  if (!(tempfp = safe_fopen(tempfname, "w")))
+  tempfp = safe_fopen(tempfname, "w");
+  if (!tempfp)
   {
     mutt_perror(tempfname);
     return;

--- a/ncrypt/pgp.c
+++ b/ncrypt/pgp.c
@@ -394,7 +394,8 @@ int pgp_application_pgp_handler(struct Body *m, struct State *s)
 
       /* Copy PGP material to temporary file */
       mutt_mktemp(tmpfname, sizeof(tmpfname));
-      if ((tmpfp = safe_fopen(tmpfname, "w+")) == NULL)
+      tmpfp = safe_fopen(tmpfname, "w+");
+      if (!tmpfp)
       {
         mutt_perror(tmpfname);
         FREE(&gpgcharset);
@@ -434,7 +435,8 @@ int pgp_application_pgp_handler(struct Body *m, struct State *s)
       if (!clearsign || (s->flags & MUTT_VERIFY))
       {
         mutt_mktemp(outfile, sizeof(outfile));
-        if ((pgpout = safe_fopen(outfile, "w+")) == NULL)
+        pgpout = safe_fopen(outfile, "w+");
+        if (!pgpout)
         {
           mutt_perror(outfile);
           safe_fclose(&tmpfp);
@@ -640,7 +642,8 @@ static int pgp_check_traditional_one_body(FILE *fp, struct Body *b)
     return 0;
   }
 
-  if ((tfp = fopen(tempfile, "r")) == NULL)
+  tfp = fopen(tempfile, "r");
+  if (!tfp)
   {
     unlink(tempfile);
     return 0;
@@ -832,7 +835,8 @@ static struct Body *pgp_decrypt_part(struct Body *a, struct State *s,
   int rv;
 
   mutt_mktemp(pgperrfile, sizeof(pgperrfile));
-  if ((pgperr = safe_fopen(pgperrfile, "w+")) == NULL)
+  pgperr = safe_fopen(pgperrfile, "w+");
+  if (!pgperr)
   {
     mutt_perror(pgperrfile);
     return NULL;
@@ -840,7 +844,8 @@ static struct Body *pgp_decrypt_part(struct Body *a, struct State *s,
   unlink(pgperrfile);
 
   mutt_mktemp(pgptmpfile, sizeof(pgptmpfile));
-  if ((pgptmp = safe_fopen(pgptmpfile, "w")) == NULL)
+  pgptmp = safe_fopen(pgptmpfile, "w");
+  if (!pgptmp)
   {
     mutt_perror(pgptmpfile);
     safe_fclose(&pgperr);
@@ -925,7 +930,8 @@ static struct Body *pgp_decrypt_part(struct Body *a, struct State *s,
 
   rewind(fpout);
 
-  if ((tattach = mutt_read_mime_header(fpout, 0)) != NULL)
+  tattach = mutt_read_mime_header(fpout, 0);
+  if (tattach)
   {
     /*
      * Need to set the length of this body part.
@@ -973,7 +979,8 @@ int pgp_decrypt_mime(FILE *fpin, FILE **fpout, struct Body *b, struct Body **cur
     saved_length = b->length;
 
     mutt_mktemp(tempfile, sizeof(tempfile));
-    if ((decoded_fp = safe_fopen(tempfile, "w+")) == NULL)
+    decoded_fp = safe_fopen(tempfile, "w+");
+    if (!decoded_fp)
     {
       mutt_perror(tempfile);
       return -1;
@@ -994,7 +1001,8 @@ int pgp_decrypt_mime(FILE *fpin, FILE **fpout, struct Body *b, struct Body **cur
   }
 
   mutt_mktemp(tempfile, sizeof(tempfile));
-  if ((*fpout = safe_fopen(tempfile, "w+")) == NULL)
+  *fpout = safe_fopen(tempfile, "w+");
+  if (!*fpout)
   {
     mutt_perror(tempfile);
     rv = -1;
@@ -1002,7 +1010,8 @@ int pgp_decrypt_mime(FILE *fpin, FILE **fpout, struct Body *b, struct Body **cur
   }
   unlink(tempfile);
 
-  if ((*cur = pgp_decrypt_part(b, &s, *fpout, p)) == NULL)
+  *cur = pgp_decrypt_part(b, &s, *fpout, p);
+  if (!*cur)
     rv = -1;
   rewind(*fpout);
 
@@ -1032,7 +1041,8 @@ int pgp_encrypted_handler(struct Body *a, struct State *s)
   int rc = 0;
 
   mutt_mktemp(tempfile, sizeof(tempfile));
-  if ((fpout = safe_fopen(tempfile, "w+")) == NULL)
+  fpout = safe_fopen(tempfile, "w+");
+  if (!fpout)
   {
     if (s->flags & MUTT_DISPLAY)
       state_attach_puts(_("[-- Error: could not create temporary file! --]\n"), s);
@@ -1042,7 +1052,8 @@ int pgp_encrypted_handler(struct Body *a, struct State *s)
   if (s->flags & MUTT_DISPLAY)
     crypt_current_time(s, "PGP");
 
-  if ((tattach = pgp_decrypt_part(a, s, fpout, a)) != NULL)
+  tattach = pgp_decrypt_part(a, s, fpout, a);
+  if (tattach)
   {
     if (s->flags & MUTT_DISPLAY)
       state_attach_puts(
@@ -1105,13 +1116,15 @@ struct Body *pgp_sign_message(struct Body *a)
   convert_to_7bit(a); /* Signed data _must_ be in 7-bit format. */
 
   mutt_mktemp(sigfile, sizeof(sigfile));
-  if ((fp = safe_fopen(sigfile, "w")) == NULL)
+  fp = safe_fopen(sigfile, "w");
+  if (!fp)
   {
     return NULL;
   }
 
   mutt_mktemp(signedfile, sizeof(signedfile));
-  if ((sfp = safe_fopen(signedfile, "w")) == NULL)
+  sfp = safe_fopen(signedfile, "w");
+  if (!sfp)
   {
     mutt_perror(signedfile);
     safe_fclose(&fp);
@@ -1124,7 +1137,8 @@ struct Body *pgp_sign_message(struct Body *a)
   mutt_write_mime_body(a, sfp);
   safe_fclose(&sfp);
 
-  if ((thepid = pgp_invoke_sign(&pgpin, &pgpout, &pgperr, -1, -1, -1, signedfile)) == -1)
+  thepid = pgp_invoke_sign(&pgpin, &pgpout, &pgperr, -1, -1, -1, signedfile);
+  if (thepid == -1)
   {
     mutt_perror(_("Can't open PGP subprocess!"));
     safe_fclose(&fp);
@@ -1353,14 +1367,16 @@ struct Body *pgp_encrypt_message(struct Body *a, char *keylist, int sign)
   pid_t thepid;
 
   mutt_mktemp(tempfile, sizeof(tempfile));
-  if ((fpout = safe_fopen(tempfile, "w+")) == NULL)
+  fpout = safe_fopen(tempfile, "w+");
+  if (!fpout)
   {
     mutt_perror(tempfile);
     return NULL;
   }
 
   mutt_mktemp(pgperrfile, sizeof(pgperrfile));
-  if ((pgperr = safe_fopen(pgperrfile, "w+")) == NULL)
+  pgperr = safe_fopen(pgperrfile, "w+");
+  if (!pgperr)
   {
     mutt_perror(pgperrfile);
     unlink(tempfile);
@@ -1370,7 +1386,8 @@ struct Body *pgp_encrypt_message(struct Body *a, char *keylist, int sign)
   unlink(pgperrfile);
 
   mutt_mktemp(pgpinfile, sizeof(pgpinfile));
-  if ((fptmp = safe_fopen(pgpinfile, "w")) == NULL)
+  fptmp = safe_fopen(pgpinfile, "w");
+  if (!fptmp)
   {
     mutt_perror(pgpinfile);
     unlink(tempfile);
@@ -1492,14 +1509,16 @@ struct Body *pgp_traditional_encryptsign(struct Body *a, int flags, char *keylis
   if (mutt_strcasecmp(a->subtype, "plain") != 0)
     return NULL;
 
-  if ((fp = fopen(a->filename, "r")) == NULL)
+  fp = fopen(a->filename, "r");
+  if (!fp)
   {
     mutt_perror(a->filename);
     return NULL;
   }
 
   mutt_mktemp(pgpinfile, sizeof(pgpinfile));
-  if ((pgpin = safe_fopen(pgpinfile, "w")) == NULL)
+  pgpin = safe_fopen(pgpinfile, "w");
+  if (!pgpin)
   {
     mutt_perror(pgpinfile);
     safe_fclose(&fp);

--- a/ncrypt/pgpkey.c
+++ b/ncrypt/pgpkey.c
@@ -556,12 +556,14 @@ static struct PgpKeyInfo *pgp_select_key(struct PgpKeyInfo *keys,
       case OP_VERIFY_KEY:
 
         mutt_mktemp(tempfile, sizeof(tempfile));
-        if ((devnull = fopen("/dev/null", "w")) == NULL)
+        devnull = fopen("/dev/null", "w");
+        if (!devnull)
         {
           mutt_perror(_("Can't open /dev/null"));
           break;
         }
-        if ((fp = safe_fopen(tempfile, "w")) == NULL)
+        fp = safe_fopen(tempfile, "w");
+        if (!fp)
         {
           safe_fclose(&devnull);
           mutt_perror(_("Can't create temporary file"));
@@ -737,13 +739,15 @@ struct Body *pgp_make_key_attachment(char *tempf)
     tempf = tempfb;
   }
 
-  if ((tempfp = safe_fopen(tempf, tempf == tempfb ? "w" : "a")) == NULL)
+  tempfp = safe_fopen(tempf, tempf == tempfb ? "w" : "a");
+  if (!tempfp)
   {
     mutt_perror(_("Can't create temporary file"));
     return NULL;
   }
 
-  if ((devnull = fopen("/dev/null", "w")) == NULL)
+  devnull = fopen("/dev/null", "w");
+  if (!devnull)
   {
     mutt_perror(_("Can't open /dev/null"));
     safe_fclose(&tempfp);
@@ -790,7 +794,8 @@ static void pgp_add_string_to_hints(struct ListHead *hints, const char *str)
   char *scratch = NULL;
   char *t = NULL;
 
-  if ((scratch = safe_strdup(str)) == NULL)
+  scratch = safe_strdup(str);
+  if (!scratch)
     return;
 
   for (t = strtok(scratch, " ,.:\"()<>\n"); t; t = strtok(NULL, " ,.:\"()<>\n"))

--- a/ncrypt/pgpmicalg.c
+++ b/ncrypt/pgpmicalg.c
@@ -164,14 +164,16 @@ static short pgp_find_hash(const char *fname)
   short rv = -1;
 
   mutt_mktemp(tempfile, sizeof(tempfile));
-  if ((out = safe_fopen(tempfile, "w+")) == NULL)
+  out = safe_fopen(tempfile, "w+");
+  if (!out)
   {
     mutt_perror(tempfile);
     goto bye;
   }
   unlink(tempfile);
 
-  if ((in = fopen(fname, "r")) == NULL)
+  in = fopen(fname, "r");
+  if (!in)
   {
     mutt_perror(fname);
     goto bye;
@@ -180,7 +182,8 @@ static short pgp_find_hash(const char *fname)
   pgp_dearmor(in, out);
   rewind(out);
 
-  if ((p = pgp_read_packet(out, &l)) != NULL)
+  p = pgp_read_packet(out, &l);
+  if (p)
   {
     rv = pgp_mic_from_packet(p, l);
   }

--- a/ncrypt/pgppacket.c
+++ b/ncrypt/pgppacket.c
@@ -40,7 +40,8 @@ static int read_material(size_t material, size_t *used, FILE *fp)
 
     nplen = *used + material + CHUNKSIZE;
 
-    if (!(p = realloc(pbuf, nplen)))
+    p = realloc(pbuf, nplen);
+    if (!p)
     {
       perror("realloc");
       return -1;

--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -1245,7 +1245,8 @@ int smime_verify_sender(struct Header *h)
   int retval = 1;
 
   mutt_mktemp(tempfname, sizeof(tempfname));
-  if (!(fpout = safe_fopen(tempfname, "w")))
+  fpout = safe_fopen(tempfname, "w");
+  if (!fpout)
   {
     mutt_perror(tempfname);
     return 1;
@@ -1677,7 +1678,8 @@ int smime_verify_one(struct Body *sigbdy, struct State *s, const char *tempfile)
   sigbdy->type = origType;
 
   mutt_mktemp(smimeerrfile, sizeof(smimeerrfile));
-  if (!(smimeerr = safe_fopen(smimeerrfile, "w+")))
+  smimeerr = safe_fopen(smimeerrfile, "w+");
+  if (!smimeerr)
   {
     mutt_perror(smimeerrfile);
     mutt_unlink(signedfile);
@@ -1989,7 +1991,8 @@ int smime_decrypt_mime(FILE *fpin, FILE **fpout, struct Body *b, struct Body **c
   }
   mutt_unlink(tempfile);
 
-  if (!(*cur = smime_handle_entity(b, &s, *fpout)))
+  *cur = smime_handle_entity(b, &s, *fpout);
+  if (!*cur)
   {
     rv = -1;
     goto bail;

--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -575,7 +575,8 @@ static struct SmimeKey *smime_get_candidates(char *search, short public)
   snprintf(index_file, sizeof(index_file), "%s/.index",
            public ? NONULL(SmimeCertificates) : NONULL(SmimeKeys));
 
-  if ((fp = safe_fopen(index_file, "r")) == NULL)
+  fp = safe_fopen(index_file, "r");
+  if (!fp)
   {
     mutt_perror(index_file);
     return NULL;
@@ -911,7 +912,8 @@ static int smime_handle_cert_email(char *certificate, char *mailbox, int copy,
   size_t len = 0;
 
   mutt_mktemp(tmpfname, sizeof(tmpfname));
-  if ((fperr = safe_fopen(tmpfname, "w+")) == NULL)
+  fperr = safe_fopen(tmpfname, "w+");
+  if (!fperr)
   {
     mutt_perror(tmpfname);
     return 1;
@@ -919,7 +921,8 @@ static int smime_handle_cert_email(char *certificate, char *mailbox, int copy,
   mutt_unlink(tmpfname);
 
   mutt_mktemp(tmpfname, sizeof(tmpfname));
-  if ((fpout = safe_fopen(tmpfname, "w+")) == NULL)
+  fpout = safe_fopen(tmpfname, "w+");
+  if (!fpout)
   {
     safe_fclose(&fperr);
     mutt_perror(tmpfname);
@@ -1003,7 +1006,8 @@ static char *smime_extract_certificate(char *infile)
   int empty;
 
   mutt_mktemp(tmpfname, sizeof(tmpfname));
-  if ((fperr = safe_fopen(tmpfname, "w+")) == NULL)
+  fperr = safe_fopen(tmpfname, "w+");
+  if (!fperr)
   {
     mutt_perror(tmpfname);
     return NULL;
@@ -1011,7 +1015,8 @@ static char *smime_extract_certificate(char *infile)
   mutt_unlink(tmpfname);
 
   mutt_mktemp(pk7out, sizeof(pk7out));
-  if ((fpout = safe_fopen(pk7out, "w+")) == NULL)
+  fpout = safe_fopen(pk7out, "w+");
+  if (!fpout)
   {
     safe_fclose(&fperr);
     mutt_perror(pk7out);
@@ -1050,7 +1055,8 @@ static char *smime_extract_certificate(char *infile)
 
   safe_fclose(&fpout);
   mutt_mktemp(certfile, sizeof(certfile));
-  if ((fpout = safe_fopen(certfile, "w+")) == NULL)
+  fpout = safe_fopen(certfile, "w+");
+  if (!fpout)
   {
     safe_fclose(&fperr);
     mutt_unlink(pk7out);
@@ -1104,7 +1110,8 @@ static char *smime_extract_signer_certificate(char *infile)
   int empty;
 
   mutt_mktemp(tmpfname, sizeof(tmpfname));
-  if ((fperr = safe_fopen(tmpfname, "w+")) == NULL)
+  fperr = safe_fopen(tmpfname, "w+");
+  if (!fperr)
   {
     mutt_perror(tmpfname);
     return NULL;
@@ -1112,7 +1119,8 @@ static char *smime_extract_signer_certificate(char *infile)
   mutt_unlink(tmpfname);
 
   mutt_mktemp(certfile, sizeof(certfile));
-  if ((fpout = safe_fopen(certfile, "w+")) == NULL)
+  fpout = safe_fopen(certfile, "w+");
+  if (!fpout)
   {
     safe_fclose(&fperr);
     mutt_perror(certfile);
@@ -1166,7 +1174,8 @@ void smime_invoke_import(char *infile, char *mailbox)
   pid_t thepid = -1;
 
   mutt_mktemp(tmpfname, sizeof(tmpfname));
-  if ((fperr = safe_fopen(tmpfname, "w+")) == NULL)
+  fperr = safe_fopen(tmpfname, "w+");
+  if (!fperr)
   {
     mutt_perror(tmpfname);
     return;
@@ -1174,7 +1183,8 @@ void smime_invoke_import(char *infile, char *mailbox)
   mutt_unlink(tmpfname);
 
   mutt_mktemp(tmpfname, sizeof(tmpfname));
-  if ((fpout = safe_fopen(tmpfname, "w+")) == NULL)
+  fpout = safe_fopen(tmpfname, "w+");
+  if (!fpout)
   {
     safe_fclose(&fperr);
     mutt_perror(tmpfname);
@@ -1319,14 +1329,16 @@ struct Body *smime_build_smime_entity(struct Body *a, char *certlist)
   pid_t thepid;
 
   mutt_mktemp(tempfile, sizeof(tempfile));
-  if ((fpout = safe_fopen(tempfile, "w+")) == NULL)
+  fpout = safe_fopen(tempfile, "w+");
+  if (!fpout)
   {
     mutt_perror(tempfile);
     return NULL;
   }
 
   mutt_mktemp(smimeerrfile, sizeof(smimeerrfile));
-  if ((smimeerr = safe_fopen(smimeerrfile, "w+")) == NULL)
+  smimeerr = safe_fopen(smimeerrfile, "w+");
+  if (!smimeerr)
   {
     mutt_perror(smimeerrfile);
     safe_fclose(&fpout);
@@ -1336,7 +1348,8 @@ struct Body *smime_build_smime_entity(struct Body *a, char *certlist)
   mutt_unlink(smimeerrfile);
 
   mutt_mktemp(smimeinfile, sizeof(smimeinfile));
-  if ((fptmp = safe_fopen(smimeinfile, "w+")) == NULL)
+  fptmp = safe_fopen(smimeinfile, "w+");
+  if (!fptmp)
   {
     mutt_perror(smimeinfile);
     mutt_unlink(tempfile);
@@ -1478,14 +1491,16 @@ struct Body *smime_sign_message(struct Body *a)
   convert_to_7bit(a); /* Signed data _must_ be in 7-bit format. */
 
   mutt_mktemp(filetosign, sizeof(filetosign));
-  if ((sfp = safe_fopen(filetosign, "w+")) == NULL)
+  sfp = safe_fopen(filetosign, "w+");
+  if (!sfp)
   {
     mutt_perror(filetosign);
     return NULL;
   }
 
   mutt_mktemp(signedfile, sizeof(signedfile));
-  if ((smimeout = safe_fopen(signedfile, "w+")) == NULL)
+  smimeout = safe_fopen(signedfile, "w+");
+  if (!smimeout)
   {
     mutt_perror(signedfile);
     safe_fclose(&sfp);
@@ -1627,7 +1642,8 @@ int smime_verify_one(struct Body *sigbdy, struct State *s, const char *tempfile)
 
   /* decode to a tempfile, saving the original destination */
   fp = s->fpout;
-  if ((s->fpout = safe_fopen(signedfile, "w")) == NULL)
+  s->fpout = safe_fopen(signedfile, "w");
+  if (!s->fpout)
   {
     mutt_perror(signedfile);
     return -1;
@@ -1739,14 +1755,16 @@ static struct Body *smime_handle_entity(struct Body *m, struct State *s, FILE *o
     return NULL;
 
   mutt_mktemp(outfile, sizeof(outfile));
-  if ((smimeout = safe_fopen(outfile, "w+")) == NULL)
+  smimeout = safe_fopen(outfile, "w+");
+  if (!smimeout)
   {
     mutt_perror(outfile);
     return NULL;
   }
 
   mutt_mktemp(errfile, sizeof(errfile));
-  if ((smimeerr = safe_fopen(errfile, "w+")) == NULL)
+  smimeerr = safe_fopen(errfile, "w+");
+  if (!smimeerr)
   {
     mutt_perror(errfile);
     safe_fclose(&smimeout);
@@ -1755,7 +1773,8 @@ static struct Body *smime_handle_entity(struct Body *m, struct State *s, FILE *o
   mutt_unlink(errfile);
 
   mutt_mktemp(tmpfname, sizeof(tmpfname));
-  if ((tmpfp = safe_fopen(tmpfname, "w+")) == NULL)
+  tmpfp = safe_fopen(tmpfname, "w+");
+  if (!tmpfp)
   {
     mutt_perror(tmpfname);
     safe_fclose(&smimeout);
@@ -1813,7 +1832,8 @@ static struct Body *smime_handle_entity(struct Body *m, struct State *s, FILE *o
     fflush(smimeerr);
     rewind(smimeerr);
 
-    if ((c = fgetc(smimeerr)) != EOF)
+    c = fgetc(smimeerr);
+    if (c != EOF)
     {
       ungetc(c, smimeerr);
 
@@ -1840,7 +1860,8 @@ static struct Body *smime_handle_entity(struct Body *m, struct State *s, FILE *o
     else
     {
       mutt_mktemp(tmptmpfname, sizeof(tmptmpfname));
-      if ((fpout = safe_fopen(tmptmpfname, "w+")) == NULL)
+      fpout = safe_fopen(tmptmpfname, "w+");
+      if (!fpout)
       {
         mutt_perror(tmptmpfname);
         safe_fclose(&smimeout);
@@ -1861,7 +1882,8 @@ static struct Body *smime_handle_entity(struct Body *m, struct State *s, FILE *o
     fflush(fpout);
     rewind(fpout);
 
-    if ((p = mutt_read_mime_header(fpout, 0)) != NULL)
+    p = mutt_read_mime_header(fpout, 0);
+    if (p)
     {
       fstat(fileno(fpout), &info);
       p->length = info.st_size - p->offset;
@@ -1940,7 +1962,8 @@ int smime_decrypt_mime(FILE *fpin, FILE **fpout, struct Body *b, struct Body **c
   fseeko(s.fpin, b->offset, SEEK_SET);
 
   mutt_mktemp(tempfile, sizeof(tempfile));
-  if ((tmpfp = safe_fopen(tempfile, "w+")) == NULL)
+  tmpfp = safe_fopen(tempfile, "w+");
+  if (!tmpfp)
   {
     mutt_perror(tempfile);
     return -1;
@@ -1957,7 +1980,8 @@ int smime_decrypt_mime(FILE *fpin, FILE **fpout, struct Body *b, struct Body **c
   s.fpout = 0;
 
   mutt_mktemp(tempfile, sizeof(tempfile));
-  if ((*fpout = safe_fopen(tempfile, "w+")) == NULL)
+  *fpout = safe_fopen(tempfile, "w+");
+  if (!*fpout)
   {
     mutt_perror(tempfile);
     rv = -1;

--- a/pager.c
+++ b/pager.c
@@ -1154,7 +1154,8 @@ static int fill_buffer(FILE *f, LOFF_T *last_pos, LOFF_T offset, unsigned char *
   {
     if (offset != *last_pos)
       fseeko(f, offset, SEEK_SET);
-    if ((*buf = (unsigned char *) mutt_read_line((char *) *buf, blen, f, &l, MUTT_EOL)) == NULL)
+    *buf = (unsigned char *) mutt_read_line((char *) *buf, blen, f, &l, MUTT_EOL);
+    if (!*buf)
     {
       fmt[0] = 0;
       return -1;
@@ -2063,7 +2064,8 @@ int mutt_pager(const char *banner, const char *fname, int flags, struct Pager *e
   rd.searchbuf = searchbuf;
   rd.has_types = (IsHeader(extra) || (flags & MUTT_SHOWCOLOR)) ? MUTT_TYPES : 0; /* main message or rfc822 attachment */
 
-  if ((rd.fp = fopen(fname, "r")) == NULL)
+  rd.fp = fopen(fname, "r");
+  if (!rd.fp)
   {
     mutt_perror(fname);
     return -1;

--- a/parse.c
+++ b/parse.c
@@ -159,7 +159,8 @@ static struct Parameter *parse_parameters(const char *s)
 
   while (*s)
   {
-    if ((p = strpbrk(s, "=;")) == NULL)
+    p = strpbrk(s, "=;");
+    if (!p)
     {
       mutt_debug(1, "parse_parameters: malformed parameter: %s\n", s);
       goto bail;
@@ -310,7 +311,8 @@ void mutt_parse_content_type(char *s, struct Body *ct)
   mutt_free_parameter(&ct->parameter);
 
   /* First extract any existing parameters */
-  if ((pc = strchr(s, ';')) != NULL)
+  pc = strchr(s, ';');
+  if (pc)
   {
     *pc++ = 0;
     while (*pc && ISSPACE(*pc))
@@ -400,7 +402,8 @@ static void parse_content_disposition(const char *s, struct Body *ct)
     ct->disposition = DISPATTACH;
 
   /* Check to see if a default filename was given */
-  if ((s = strchr(s, ';')) != NULL)
+  s = strchr(s, ';');
+  if (s)
   {
     s = skip_email_wsp(s + 1);
     if ((s = mutt_get_parameter("filename", (parms = parse_parameters(s)))))
@@ -1297,7 +1300,8 @@ struct Address *mutt_parse_adrlist(struct Address *p, const char *s)
   const char *q = NULL;
 
   /* check for a simple whitespace separated list of addresses */
-  if ((q = strpbrk(s, "\"<>():;,\\")) == NULL)
+  q = strpbrk(s, "\"<>():;,\\");
+  if (!q)
   {
     char tmp[HUGE_STRING];
     char *r = NULL;

--- a/parse.c
+++ b/parse.c
@@ -381,7 +381,8 @@ void mutt_parse_content_type(char *s, struct Body *ct)
   /* Default character set for text types. */
   if (ct->type == TYPETEXT)
   {
-    if (!(pc = mutt_get_parameter("charset", ct->parameter)))
+    pc = mutt_get_parameter("charset", ct->parameter);
+    if (!pc)
       mutt_set_parameter("charset",
                          (AssumedCharset && *AssumedCharset) ?
                              (const char *) mutt_get_default_charset() :
@@ -909,7 +910,8 @@ int mutt_parse_rfc822_line(struct Envelope *e, struct Header *hdr, char *line,
           for (beg = strchr(p, '<'); beg; beg = strchr(end, ','))
           {
             beg++;
-            if (!(end = strchr(beg, '>')))
+            end = strchr(beg, '>');
+            if (!end)
               break;
 
             /* Take the first mailto URL */

--- a/pattern.c
+++ b/pattern.c
@@ -484,7 +484,8 @@ static bool eat_date(struct Pattern *pat, struct Buffer *s, struct Buffer *err)
     if (isdigit((unsigned char) *pc))
     {
       /* minimum date specified */
-      if ((pc = get_date(pc, &min, err)) == NULL)
+      pc = get_date(pc, &min, err);
+      if (!pc)
       {
         FREE(&buffer.data);
         return false;
@@ -940,7 +941,8 @@ static int msg_search(struct Context *ctx, struct Pattern *pat, int msgno)
   struct stat st;
 #endif
 
-  if ((msg = mx_open_message(ctx, msgno)) != NULL)
+  msg = mx_open_message(ctx, msgno);
+  if (msg)
   {
     if (option(OPT_THOROUGH_SEARCH))
     {
@@ -957,7 +959,8 @@ static int msg_search(struct Context *ctx, struct Pattern *pat, int msgno)
       }
 #else
       mutt_mktemp(tempfile, sizeof(tempfile));
-      if ((s.fpout = safe_fopen(tempfile, "w+")) == NULL)
+      s.fpout = safe_fopen(tempfile, "w+");
+      if (!s.fpout)
       {
         mutt_perror(tempfile);
         return 0;
@@ -1235,7 +1238,8 @@ struct Pattern *mutt_pattern_comp(/* const */ char *s, int flags, struct Buffer 
           isalias = false;
           /* compile the sub-expression */
           buf = mutt_substrdup(ps.dptr + 1, p);
-          if ((tmp2 = mutt_pattern_comp(buf, flags, err)) == NULL)
+          tmp2 = mutt_pattern_comp(buf, flags, err);
+          if (!tmp2)
           {
             FREE(&buf);
             mutt_pattern_free(&curlist);
@@ -1274,7 +1278,8 @@ struct Pattern *mutt_pattern_comp(/* const */ char *s, int flags, struct Buffer 
         last = tmp;
 
         ps.dptr++; /* move past the ~ */
-        if ((entry = lookup_tag(*ps.dptr)) == NULL)
+        entry = lookup_tag(*ps.dptr);
+        if (!entry)
         {
           snprintf(err->data, err->dsize, _("%c: invalid pattern modifier"), *ps.dptr);
           mutt_pattern_free(&curlist);
@@ -1317,7 +1322,8 @@ struct Pattern *mutt_pattern_comp(/* const */ char *s, int flags, struct Buffer 
         }
         /* compile the sub-expression */
         buf = mutt_substrdup(ps.dptr + 1, p);
-        if ((tmp = mutt_pattern_comp(buf, flags, err)) == NULL)
+        tmp = mutt_pattern_comp(buf, flags, err);
+        if (!tmp)
         {
           FREE(&buf);
           mutt_pattern_free(&curlist);
@@ -1895,7 +1901,8 @@ int mutt_pattern_func(int op, char *prompt)
   mutt_buffer_init(&err);
   err.dsize = STRING;
   err.data = safe_malloc(err.dsize);
-  if ((pat = mutt_pattern_comp(buf, MUTT_FULL_MSG, &err)) == NULL)
+  pat = mutt_pattern_comp(buf, MUTT_FULL_MSG, &err);
+  if (!pat)
   {
     FREE(&simple);
     mutt_error("%s", err.data);
@@ -2029,7 +2036,8 @@ int mutt_search_command(int cur, int op)
       mutt_pattern_free(&SearchPattern);
       err.dsize = STRING;
       err.data = safe_malloc(err.dsize);
-      if ((SearchPattern = mutt_pattern_comp(temp, MUTT_FULL_MSG, &err)) == NULL)
+      SearchPattern = mutt_pattern_comp(temp, MUTT_FULL_MSG, &err);
+      if (!SearchPattern)
       {
         mutt_error("%s", err.data);
         FREE(&err.data);

--- a/pgppubring.c
+++ b/pgppubring.c
@@ -652,7 +652,8 @@ static struct PgpKeyInfo *pgp_parse_keyblock(FILE *fp)
       case PT_SUBKEY:
       case PT_SUBSECKEY:
       {
-        if (!(*last = p = pgp_parse_keyinfo(buff, l)))
+        *last = p = pgp_parse_keyinfo(buff, l);
+        if (!*last)
         {
           err = 1;
           break;

--- a/pgppubring.c
+++ b/pgppubring.c
@@ -768,7 +768,8 @@ static void pgpring_find_candidates(char *ringfile, const char *hints[], int nhi
 
   short err = 0;
 
-  if ((rfp = fopen(ringfile, "r")) == NULL)
+  rfp = fopen(ringfile, "r");
+  if (!rfp)
   {
     char *error_buf = NULL;
     size_t error_buf_len;
@@ -810,7 +811,8 @@ static void pgpring_find_candidates(char *ringfile, const char *hints[], int nhi
 
         /* Not bailing out here would lead us into an endless loop. */
 
-        if ((p = pgp_parse_keyblock(rfp)) == NULL)
+        p = pgp_parse_keyblock(rfp);
+        if (!p)
           err = 1;
 
         pgpring_dump_keyblock(p);

--- a/pop.c
+++ b/pop.c
@@ -725,7 +725,8 @@ static int pop_sync_mailbox(struct Context *ctx, int *index_hint)
         if (!ctx->quiet)
           mutt_progress_update(&progress, j, -1);
         snprintf(buf, sizeof(buf), "DELE %d\r\n", ctx->hdrs[i]->refno);
-        if ((ret = pop_query(pop_data, buf, sizeof(buf))) == 0)
+        ret = pop_query(pop_data, buf, sizeof(buf));
+        if (ret == 0)
         {
           mutt_bcache_del(pop_data->bcache, ctx->hdrs[i]->data);
 #ifdef USE_HCACHE
@@ -900,7 +901,8 @@ void pop_fetch_mail(void)
 
   for (int i = last + 1; i <= msgs; i++)
   {
-    if ((msg = mx_open_new_message(&ctx, NULL, MUTT_ADD_FROM)) == NULL)
+    msg = mx_open_new_message(&ctx, NULL, MUTT_ADD_FROM);
+    if (!msg)
       ret = -3;
     else
     {

--- a/pop.c
+++ b/pop.c
@@ -87,7 +87,8 @@ static int pop_read_header(struct PopData *pop_data, struct Header *h)
   char tempfile[_POSIX_PATH_MAX];
 
   mutt_mktemp(tempfile, sizeof(tempfile));
-  if (!(f = safe_fopen(tempfile, "w+")))
+  f = safe_fopen(tempfile, "w+");
+  if (!f)
   {
     mutt_perror(tempfile);
     return -3;
@@ -201,9 +202,11 @@ static int msg_cache_check(const char *id, struct BodyCache *bcache, void *data)
   struct Context *ctx = NULL;
   struct PopData *pop_data = NULL;
 
-  if (!(ctx = (struct Context *) data))
+  ctx = (struct Context *) data;
+  if (!ctx)
     return -1;
-  if (!(pop_data = (struct PopData *) ctx->data))
+  pop_data = (struct PopData *) ctx->data;
+  if (!pop_data)
     return -1;
 
 #ifdef USE_HCACHE
@@ -599,12 +602,14 @@ static int pop_fetch_message(struct Context *ctx, struct Message *msg, int msgno
                        NetInc, h->content->length + h->content->offset - 1);
 
     /* see if we can put in body cache; use our cache as fallback */
-    if (!(msg->fp = mutt_bcache_put(pop_data->bcache, h->data)))
+    msg->fp = mutt_bcache_put(pop_data->bcache, h->data);
+    if (!msg->fp)
     {
       /* no */
       bcache = 0;
       mutt_mktemp(path, sizeof(path));
-      if (!(msg->fp = safe_fopen(path, "w+")))
+      msg->fp = safe_fopen(path, "w+");
+      if (!msg->fp)
       {
         mutt_perror(path);
         mutt_sleep(2);

--- a/postpone.c
+++ b/postpone.c
@@ -268,7 +268,8 @@ int mutt_get_postponed(struct Context *ctx, struct Header *hdr,
   if (!Postponed)
     return -1;
 
-  if ((PostContext = mx_open_mailbox(Postponed, MUTT_NOSORT, NULL)) == NULL)
+  PostContext = mx_open_mailbox(Postponed, MUTT_NOSORT, NULL);
+  if (!PostContext)
   {
     PostCount = 0;
     mutt_error(_("No postponed messages."));
@@ -659,7 +660,8 @@ int mutt_prepare_template(FILE *fp, struct Context *ctx, struct Header *newhdr,
     }
 
     mutt_adv_mktemp(file, sizeof(file));
-    if ((s.fpout = safe_fopen(file, "w")) == NULL)
+    s.fpout = safe_fopen(file, "w");
+    if (!s.fpout)
       goto bail;
 
     if ((WithCrypto & APPLICATION_PGP) &&

--- a/query.c
+++ b/query.c
@@ -82,7 +82,8 @@ static struct Address *result_to_addr(struct Query *r)
 {
   static struct Address *tmp = NULL;
 
-  if (!(tmp = rfc822_cpy_adr(r->addr, 0)))
+  tmp = rfc822_cpy_adr(r->addr, 0);
+  if (!tmp)
     return NULL;
 
   if (!tmp->next && !tmp->personal)

--- a/recvattach.c
+++ b/recvattach.c
@@ -470,7 +470,8 @@ static int query_save_attachment(FILE *fp, struct Body *body,
       struct stat st;
 
       /* check to make sure that this file is really the one the user wants */
-      if ((rc = mutt_save_confirm(buf, &st)) == 1)
+      rc = mutt_save_confirm(buf, &st);
+      if (rc == 1)
       {
         prompt = _("Save to file: ");
         continue;
@@ -641,7 +642,8 @@ static void pipe_attachment(FILE *fp, struct Body *b, struct State *state)
   }
   else
   {
-    if ((ifp = fopen(b->filename, "r")) == NULL)
+    ifp = fopen(b->filename, "r");
+    if (!ifp)
     {
       mutt_perror("fopen");
       return;
@@ -770,7 +772,8 @@ static void print_attachment_list(struct AttachCtx *actx, FILE *fp, bool tag,
           mutt_mktemp(newfile, sizeof(newfile));
           if (mutt_decode_save_attachment(fp, top, newfile, MUTT_PRINTING, 0) == 0)
           {
-            if ((ifp = fopen(newfile, "r")) != NULL)
+            ifp = fopen(newfile, "r");
+            if (ifp)
             {
               mutt_copy_stream(ifp, state->fpout);
               safe_fclose(&ifp);
@@ -1121,7 +1124,8 @@ void mutt_view_attachments(struct Header *hdr)
 
   mutt_message_hook(Context, hdr, MUTT_MESSAGEHOOK);
 
-  if ((msg = mx_open_message(Context, hdr->msgno)) == NULL)
+  msg = mx_open_message(Context, hdr->msgno);
+  if (!msg)
     return;
 
   menu = mutt_new_menu(MENU_ATTACH);

--- a/recvcmd.c
+++ b/recvcmd.c
@@ -171,7 +171,8 @@ void mutt_attach_bounce(FILE *fp, struct Header *hdr, struct AttachCtx *actx, st
   if (mutt_get_field(prompt, buf, sizeof(buf), MUTT_ALIAS) || buf[0] == '\0')
     return;
 
-  if (!(adr = rfc822_parse_adrlist(adr, buf)))
+  adr = rfc822_parse_adrlist(adr, buf);
+  if (!adr)
   {
     mutt_error(_("Error parsing address!"));
     return;
@@ -589,7 +590,8 @@ static void attach_forward_msgs(FILE *fp, struct Header *hdr,
     /* no MIME encapsulation */
 
     mutt_mktemp(tmpbody, sizeof(tmpbody));
-    if (!(tmpfp = safe_fopen(tmpbody, "w")))
+    tmpfp = safe_fopen(tmpbody, "w");
+    if (!tmpfp)
     {
       mutt_error(_("Can't create %s."), tmpbody);
       mutt_free_header(&tmphdr);
@@ -709,7 +711,7 @@ static int attach_reply_envelope_defaults(struct Envelope *env, struct AttachCtx
     curhdr = parent;
   }
 
-  if (curenv == NULL || curhdr == NULL)
+  if (!curenv || !curhdr)
   {
     mutt_error(_("Can't find any tagged messages."));
     return -1;

--- a/recvcmd.c
+++ b/recvcmd.c
@@ -417,7 +417,8 @@ static void attach_forward_bodies(FILE *fp, struct Header *hdr, struct AttachCtx
   mutt_make_forward_subject(tmphdr->env, Context, parent_hdr);
 
   mutt_mktemp(tmpbody, sizeof(tmpbody));
-  if ((tmpfp = safe_fopen(tmpbody, "w")) == NULL)
+  tmpfp = safe_fopen(tmpbody, "w");
+  if (!tmpfp)
   {
     mutt_error(_("Can't open temporary file %s."), tmpbody);
     mutt_free_header(&tmphdr);
@@ -814,7 +815,8 @@ void mutt_attach_reply(FILE *fp, struct Header *hdr, struct AttachCtx *actx,
   if (!check_all_msg(actx, cur, false))
   {
     nattach = count_tagged(actx);
-    if ((parent = find_parent(actx, cur, nattach)) != NULL)
+    parent = find_parent(actx, cur, nattach);
+    if (parent)
     {
       parent_hdr = parent->content->hdr;
       parent_fp = parent->fp;
@@ -849,7 +851,8 @@ void mutt_attach_reply(FILE *fp, struct Header *hdr, struct AttachCtx *actx,
   }
 
   mutt_mktemp(tmpbody, sizeof(tmpbody));
-  if ((tmpfp = safe_fopen(tmpbody, "w")) == NULL)
+  tmpfp = safe_fopen(tmpbody, "w");
+  if (!tmpfp)
   {
     mutt_error(_("Can't create %s."), tmpbody);
     mutt_free_header(&tmphdr);

--- a/remailer.c
+++ b/remailer.c
@@ -142,12 +142,14 @@ static struct Remailer **mix_type2_list(size_t *l)
   if (!l)
     return NULL;
 
-  if ((devnull = open("/dev/null", O_RDWR)) == -1)
+  devnull = open("/dev/null", O_RDWR);
+  if (devnull == -1)
     return NULL;
 
   snprintf(cmd, sizeof(cmd), "%s -T", Mixmaster);
 
-  if ((mm_pid = mutt_create_filter_fd(cmd, NULL, &fp, NULL, devnull, -1, devnull)) == -1)
+  mm_pid = mutt_create_filter_fd(cmd, NULL, &fp, NULL, devnull, -1, devnull);
+  if (mm_pid == -1)
   {
     close(devnull);
     return NULL;

--- a/remailer.c
+++ b/remailer.c
@@ -165,25 +165,30 @@ static struct Remailer **mix_type2_list(size_t *l)
   {
     p = mix_new_remailer();
 
-    if (!(t = strtok(line, " \t\n")))
+    t = strtok(line, " \t\n");
+    if (!t)
       goto problem;
 
     p->shortname = safe_strdup(t);
 
-    if (!(t = strtok(NULL, " \t\n")))
+    t = strtok(NULL, " \t\n");
+    if (!t)
       goto problem;
 
     p->addr = safe_strdup(t);
 
-    if (!(t = strtok(NULL, " \t\n")))
+    t = strtok(NULL, " \t\n");
+    if (!t)
       goto problem;
 
-    if (!(t = strtok(NULL, " \t\n")))
+    t = strtok(NULL, " \t\n");
+    if (!t)
       goto problem;
 
     p->ver = safe_strdup(t);
 
-    if (!(t = strtok(NULL, " \t\n")))
+    t = strtok(NULL, " \t\n");
+    if (!t)
       goto problem;
 
     p->caps = mix_get_caps(t);
@@ -470,7 +475,8 @@ void mix_make_chain(struct ListHead *chainhead)
   int j;
   char *t = NULL;
 
-  if (!(type2_list = mix_type2_list(&ttll)))
+  type2_list = mix_type2_list(&ttll);
+  if (!type2_list)
   {
     mutt_error(_("Can't get mixmaster's type2.list!"));
     return;
@@ -692,7 +698,8 @@ int mix_check_message(struct Header *msg)
 
   if (need_hostname)
   {
-    if (!(fqdn = mutt_fqdn(1)))
+    fqdn = mutt_fqdn(1);
+    if (!fqdn)
     {
       mutt_error(_("Please set the hostname variable to a proper value when "
                    "using mixmaster!"));

--- a/resize.c
+++ b/resize.c
@@ -50,7 +50,8 @@ void mutt_resize_screen(void)
 
   SLtt_Screen_Rows = -1;
   SLtt_Screen_Cols = -1;
-  if ((fd = open("/dev/tty", O_RDONLY)) != -1)
+  fd = open("/dev/tty", O_RDONLY);
+  if (fd != -1)
   {
     if (ioctl(fd, TIOCGWINSZ, &w) != -1)
     {

--- a/rfc1524.c
+++ b/rfc1524.c
@@ -202,11 +202,13 @@ static int rfc1524_mailcap_parse(struct Body *a, char *filename, char *type,
    */
 
   /* find length of basetype */
-  if ((ch = strchr(type, '/')) == NULL)
+  ch = strchr(type, '/');
+  if (!ch)
     return false;
   btlen = ch - type;
 
-  if ((fp = fopen(filename, "r")) != NULL)
+  fp = fopen(filename, "r");
+  if (fp)
   {
     while (!found && (buf = mutt_read_line(buf, &buflen, fp, &line, MUTT_CONT)) != NULL)
     {
@@ -592,9 +594,11 @@ int mutt_rename_file(char *oldfile, char *newfile)
     return 1;
   if (access(newfile, F_OK) == 0)
     return 2;
-  if ((ofp = fopen(oldfile, "r")) == NULL)
+  ofp = fopen(oldfile, "r");
+  if (!ofp)
     return 3;
-  if ((nfp = safe_fopen(newfile, "w")) == NULL)
+  nfp = safe_fopen(newfile, "w");
+  if (!nfp)
   {
     safe_fclose(&ofp);
     return 3;

--- a/rfc2047.c
+++ b/rfc2047.c
@@ -802,7 +802,8 @@ void rfc2047_decode(char **pd)
 
   while (*s && dlen > 0)
   {
-    if (!(p = find_encoded_word(s, &q)))
+    p = find_encoded_word(s, &q);
+    if (!p)
     {
       /* no encoded words */
       if (option(OPT_IGNORE_LINEAR_WHITE_SPACE))

--- a/rfc2047.c
+++ b/rfc2047.c
@@ -858,7 +858,8 @@ void rfc2047_decode(char **pd)
           s += m;
         }
 
-        if ((m = n - lwsrlen(s, n)) != 0)
+        m = n - lwsrlen(s, n);
+        if (m != 0)
         {
           if (m > dlen)
             m = dlen;

--- a/rfc2231.c
+++ b/rfc2231.c
@@ -79,7 +79,8 @@ static char *rfc2231_get_charset(char *value, char *charset, size_t chslen)
 {
   char *t = NULL, *u = NULL;
 
-  if (!(t = strchr(value, '\'')))
+  t = strchr(value, '\'');
+  if (!t)
   {
     charset[0] = '\0';
     return value;
@@ -232,7 +233,8 @@ void rfc2231_decode_parameters(struct Parameter **headp)
   {
     q = p->next;
 
-    if (!(s = strchr(p->attribute, '*')))
+    s = strchr(p->attribute, '*');
+    if (!s)
     {
       /*
        * Using RFC2047 encoding in MIME parameters is explicitly

--- a/rfc3676.c
+++ b/rfc3676.c
@@ -365,11 +365,13 @@ void rfc3676_space_stuff(struct Header *hdr)
 
   mutt_debug(2, "f=f: postprocess %s\n", hdr->content->filename);
 
-  if ((in = safe_fopen(hdr->content->filename, "r")) == NULL)
+  in = safe_fopen(hdr->content->filename, "r");
+  if (!in)
     return;
 
   mutt_mktemp(tmpfile, sizeof(tmpfile));
-  if ((out = safe_fopen(tmpfile, "w+")) == NULL)
+  out = safe_fopen(tmpfile, "w+");
+  if (!out)
   {
     safe_fclose(&in);
     return;

--- a/rfc822.c
+++ b/rfc822.c
@@ -353,7 +353,8 @@ struct Address *rfc822_parse_adrlist(struct Address *top, const char *s)
     {
       if (commentlen && commentlen < sizeof(comment) - 1)
         comment[commentlen++] = ' ';
-      if ((ps = next_token(s, comment, &commentlen, sizeof(comment) - 1)) == NULL)
+      ps = next_token(s, comment, &commentlen, sizeof(comment) - 1);
+      if (!ps)
       {
         rfc822_free_address(&top);
         return NULL;
@@ -364,7 +365,8 @@ struct Address *rfc822_parse_adrlist(struct Address *top, const char *s)
     {
       if (phraselen && phraselen < sizeof(phrase) - 1)
         phrase[phraselen++] = ' ';
-      if ((ps = parse_quote(s + 1, phrase, &phraselen, sizeof(phrase) - 1)) == NULL)
+      ps = parse_quote(s + 1, phrase, &phraselen, sizeof(phrase) - 1);
+      if (!ps)
       {
         rfc822_free_address(&top);
         return NULL;
@@ -419,7 +421,8 @@ struct Address *rfc822_parse_adrlist(struct Address *top, const char *s)
       cur = rfc822_new_address();
       if (phraselen)
         cur->personal = safe_strdup(phrase);
-      if ((ps = parse_route_addr(s + 1, comment, &commentlen, sizeof(comment) - 1, cur)) == NULL)
+      ps = parse_route_addr(s + 1, comment, &commentlen, sizeof(comment) - 1, cur);
+      if (!ps)
       {
         rfc822_free_address(&top);
         rfc822_free_address(&cur);
@@ -440,7 +443,8 @@ struct Address *rfc822_parse_adrlist(struct Address *top, const char *s)
     {
       if (phraselen && phraselen < sizeof(phrase) - 1 && ws_pending)
         phrase[phraselen++] = ' ';
-      if ((ps = next_token(s, phrase, &phraselen, sizeof(phrase) - 1)) == NULL)
+      ps = next_token(s, phrase, &phraselen, sizeof(phrase) - 1);
+      if (!ps)
       {
         rfc822_free_address(&top);
         return NULL;

--- a/score.c
+++ b/score.c
@@ -103,7 +103,8 @@ int mutt_parse_score(struct Buffer *buf, struct Buffer *s, unsigned long data,
       break;
   if (!ptr)
   {
-    if ((pat = mutt_pattern_comp(pattern, 0, err)) == NULL)
+    pat = mutt_pattern_comp(pattern, 0, err);
+    if (!pat)
     {
       FREE(&pattern);
       return -1;

--- a/send.c
+++ b/send.c
@@ -236,7 +236,8 @@ static int edit_address(struct Address **a, /* const */ char *field)
       return -1;
     rfc822_free_address(a);
     *a = mutt_expand_aliases(mutt_parse_adrlist(NULL, buf));
-    if ((idna_ok = mutt_addrlist_to_intl(*a, &err)) != 0)
+    idna_ok = mutt_addrlist_to_intl(*a, &err);
+    if (idna_ok != 0)
     {
       mutt_error(_("Error: '%s' is a bad IDN."), err);
       mutt_refresh();
@@ -615,7 +616,8 @@ int mutt_fetch_recips(struct Envelope *out, struct Envelope *in, int flags)
              in->mail_followup_to->mailbox,
              in->mail_followup_to->next ? ",..." : "");
 
-    if ((hmfupto = query_quadoption(OPT_HONOR_FOLLOWUP_TO, prompt)) == MUTT_ABORT)
+    hmfupto = query_quadoption(OPT_HONOR_FOLLOWUP_TO, prompt);
+    if (hmfupto == MUTT_ABORT)
       return -1;
   }
 
@@ -852,7 +854,8 @@ static int generate_body(FILE *tempfp, struct Header *msg, int flags,
 
   if (flags & SENDREPLY)
   {
-    if ((i = query_quadoption(OPT_INCLUDE, _("Include message in reply?"))) == MUTT_ABORT)
+    i = query_quadoption(OPT_INCLUDE, _("Include message in reply?"));
+    if (i == MUTT_ABORT)
       return -1;
 
     if (i == MUTT_YES)
@@ -880,7 +883,8 @@ static int generate_body(FILE *tempfp, struct Header *msg, int flags,
   }
   else if (flags & SENDFORWARD)
   {
-    if ((i = query_quadoption(OPT_MIME_FORWARD, _("Forward as attachment?"))) == MUTT_YES)
+    i = query_quadoption(OPT_MIME_FORWARD, _("Forward as attachment?"));
+    if (i == MUTT_YES)
     {
       struct Body *last = msg->content;
 
@@ -1088,7 +1092,8 @@ static int send_message(struct Header *msg)
 
   /* Write out the message in MIME form. */
   mutt_mktemp(tempfile, sizeof(tempfile));
-  if ((tempfp = safe_fopen(tempfile, "w")) == NULL)
+  tempfp = safe_fopen(tempfile, "w");
+  if (!tempfp)
     return -1;
 
 #ifdef USE_SMTP
@@ -1178,7 +1183,8 @@ static void fix_end_of_file(const char *data)
 {
   FILE *fp = NULL;
 
-  if ((fp = safe_fopen(data, "a+")) == NULL)
+  fp = safe_fopen(data, "a+");
+  if (!fp)
     return;
   if (fseek(fp, -1, SEEK_END) >= 0)
   {
@@ -1338,7 +1344,8 @@ int ci_send_message(int flags, struct Header *msg, char *tempfile,
     /* If the user is composing a new message, check to see if there
      * are any postponed messages first.
      */
-    if ((i = query_quadoption(OPT_RECALL, _("Recall postponed message?"))) == MUTT_ABORT)
+    i = query_quadoption(OPT_RECALL, _("Recall postponed message?"));
+    if (i == MUTT_ABORT)
       return rv;
 
     if (i == MUTT_YES)
@@ -1386,7 +1393,8 @@ int ci_send_message(int flags, struct Header *msg, char *tempfile,
 
     if (flags & (SENDPOSTPONED | SENDRESEND))
     {
-      if ((tempfp = safe_fopen(msg->content->filename, "a+")) == NULL)
+      tempfp = safe_fopen(msg->content->filename, "a+");
+      if (!tempfp)
       {
         mutt_perror(msg->content->filename);
         goto cleanup;

--- a/send.c
+++ b/send.c
@@ -1425,7 +1425,8 @@ int ci_send_message(int flags, struct Header *msg, char *tempfile,
       pbody->next = msg->content; /* don't kill command-line attachments */
       msg->content = pbody;
 
-      if (!(ctype = safe_strdup(ContentType)))
+      ctype = safe_strdup(ContentType);
+      if (!ctype)
         ctype = safe_strdup("text/plain");
       mutt_parse_content_type(ctype, msg->content);
       FREE(&ctype);

--- a/sendlib.c
+++ b/sendlib.c
@@ -384,7 +384,8 @@ int mutt_write_mime_header(struct Body *a, FILE *f)
 
       if (a->use_disp)
       {
-        if (!(fn = a->d_filename))
+        fn = a->d_filename;
+        if (!fn)
           fn = a->filename;
 
         if (fn)
@@ -436,7 +437,8 @@ int mutt_write_mime_body(struct Body *a, FILE *f)
   if (a->type == TYPEMULTIPART)
   {
     /* First, find the boundary to use */
-    if (!(p = mutt_get_parameter("boundary", a->parameter)))
+    p = mutt_get_parameter("boundary", a->parameter);
+    if (!p)
     {
       mutt_debug(1, "mutt_write_mime_body(): no boundary parameter found!\n");
       mutt_error(_("No boundary parameter found! [report this error]"));
@@ -1194,7 +1196,8 @@ void mutt_message_to_7bit(struct Body *a, FILE *fp)
   }
 
   mutt_mktemp(temp, sizeof(temp));
-  if (!(fpout = safe_fopen(temp, "w+")))
+  fpout = safe_fopen(temp, "w+");
+  if (!fpout)
   {
     mutt_perror("fopen");
     goto cleanup;
@@ -1900,7 +1903,8 @@ static int write_one_header(FILE *fp, int pfxw, int max, int wraplen, const char
       }
     }
 
-    if (!(t = strchr(valbuf, ':')))
+    t = strchr(valbuf, ':');
+    if (!t)
     {
       mutt_debug(1, "mwoh: warning: header not in 'key: value' format!\n");
       FREE(&valbuf);
@@ -2230,7 +2234,8 @@ static void encode_headers(struct ListHead *h)
   struct ListNode *np;
   STAILQ_FOREACH(np, h, entries)
   {
-    if (!(p = strchr(np->data, ':')))
+    p = strchr(np->data, ':');
+    if (!p)
       continue;
 
     i = p - np->data;
@@ -2286,7 +2291,8 @@ static char *gen_msgid(void)
   rndid[MUTT_RANDTAG_LEN] = 0;
   now = time(NULL);
   tm = gmtime(&now);
-  if (!(fqdn = mutt_fqdn(0)))
+  fqdn = mutt_fqdn(0);
+  if (!fqdn)
     fqdn = NONULL(ShortHostname);
 
   snprintf(buf, sizeof(buf), "<%d%02d%02d%02d%02d%02d.%s@%s>", tm->tm_year + 1900,

--- a/sendlib.c
+++ b/sendlib.c
@@ -465,7 +465,8 @@ int mutt_write_mime_body(struct Body *a, FILE *f)
     return 0;
   }
 
-  if ((fpin = fopen(a->filename, "r")) == NULL)
+  fpin = fopen(a->filename, "r");
+  if (!fpin)
   {
     mutt_debug(1, "write_mime_body: %s no longer exists!\n", a->filename);
     mutt_error(_("%s no longer exists!"), a->filename);
@@ -835,7 +836,8 @@ static size_t convert_file_from_to(FILE *file, const char *fromcodes, const char
   ncodes = 0;
   for (c = tocodes; c; c = c1 ? c1 + 1 : 0)
   {
-    if ((c1 = strchr(c, ':')) == c)
+    c1 = strchr(c, ':');
+    if (c1 == c)
       continue;
     ncodes++;
   }
@@ -844,7 +846,8 @@ static size_t convert_file_from_to(FILE *file, const char *fromcodes, const char
   tcode = safe_malloc(ncodes * sizeof(char *));
   for (c = tocodes, i = 0; c; c = c1 ? c1 + 1 : 0, i++)
   {
-    if ((c1 = strchr(c, ':')) == c)
+    c1 = strchr(c, ':');
+    if (c1 == c)
       continue;
     tcode[i] = mutt_substrdup(c, c1);
   }
@@ -855,7 +858,8 @@ static size_t convert_file_from_to(FILE *file, const char *fromcodes, const char
     /* Try each fromcode in turn */
     for (c = fromcodes; c; c = c1 ? c1 + 1 : 0)
     {
-      if ((c1 = strchr(c, ':')) == c)
+      c1 = strchr(c, ':');
+      if (c1 == c)
         continue;
       fcode = mutt_substrdup(c, c1);
 
@@ -923,7 +927,8 @@ struct Content *mutt_get_content_info(const char *fname, struct Body *b)
     return NULL;
   }
 
-  if ((fp = fopen(fname, "r")) == NULL)
+  fp = fopen(fname, "r");
+  if (!fp)
   {
     mutt_debug(1, "mutt_get_content_info: %s: %s (errno %d).\n", fname,
                strerror(errno), errno);
@@ -1030,7 +1035,8 @@ int mutt_lookup_mime_type(struct Body *att, const char *path)
         goto bye; /* shouldn't happen */
     }
 
-    if ((f = fopen(buf, "r")) != NULL)
+    f = fopen(buf, "r");
+    if (f)
     {
       found_mimetypes = true;
 
@@ -1045,7 +1051,8 @@ int mutt_lookup_mime_type(struct Body *att, const char *path)
         SKIPWS(ct);
 
         /* position on the next field in this line */
-        if ((p = strpbrk(ct, " \t")) == NULL)
+        p = strpbrk(ct, " \t");
+        if (!p)
           continue;
         *p++ = 0;
         SKIPWS(p);
@@ -1061,7 +1068,8 @@ int mutt_lookup_mime_type(struct Body *att, const char *path)
           {
             /* get the content-type */
 
-            if ((p = strchr(ct, '/')) == NULL)
+            p = strchr(ct, '/');
+            if (!p)
             {
               /* malformed line, just skip it. */
               break;
@@ -1073,7 +1081,8 @@ int mutt_lookup_mime_type(struct Body *att, const char *path)
 
             mutt_substrcpy(subtype, p, q, sizeof(subtype));
 
-            if ((type = mutt_check_mime_type(ct)) == TYPEOTHER)
+            type = mutt_check_mime_type(ct);
+            if (type == TYPEOTHER)
               strfcpy(xtype, ct, sizeof(xtype));
 
             cur_sze = sze;
@@ -1129,7 +1138,8 @@ static void transform_to_7bit(struct Body *a, FILE *fpin)
       a->force_charset = true;
 
       mutt_mktemp(buff, sizeof(buff));
-      if ((s.fpout = safe_fopen(buff, "w")) == NULL)
+      s.fpout = safe_fopen(buff, "w");
+      if (!s.fpout)
       {
         mutt_perror("fopen");
         return;
@@ -1320,7 +1330,8 @@ void mutt_update_encoding(struct Body *a)
   if (!a->force_charset && !a->noconv)
     mutt_delete_parameter("charset", &a->parameter);
 
-  if ((info = mutt_get_content_info(a->filename, a)) == NULL)
+  info = mutt_get_content_info(a->filename, a);
+  if (!info)
     return;
 
   set_encoding(a, info);
@@ -1349,7 +1360,8 @@ struct Body *mutt_make_message_attach(struct Context *ctx, struct Header *hdr, i
   }
 
   mutt_mktemp(buffer, sizeof(buffer));
-  if ((fp = safe_fopen(buffer, "w+")) == NULL)
+  fp = safe_fopen(buffer, "w+");
+  if (!fp)
     return NULL;
 
   body = mutt_new_body();
@@ -1436,7 +1448,8 @@ static void run_mime_type_query(struct Body *att)
     return;
   }
 
-  if ((buf = mutt_read_line(buf, &buflen, fp, &dummy, 0)) != NULL)
+  buf = mutt_read_line(buf, &buflen, fp, &dummy, 0);
+  if (buf)
   {
     if (strchr(buf, '/'))
       mutt_parse_content_type(buf, att);
@@ -1469,7 +1482,8 @@ struct Body *mutt_make_file_attach(const char *path)
       !option(OPT_MIME_TYPE_QUERY_FIRST))
     run_mime_type_query(att);
 
-  if ((info = mutt_get_content_info(path, att)) == NULL)
+  info = mutt_get_content_info(path, att);
+  if (!info)
   {
     mutt_free_body(&att);
     return NULL;
@@ -2316,7 +2330,8 @@ static int send_msg(const char *path, char **args, const char *msg, char **tempf
     *tempfile = safe_strdup(tmp);
   }
 
-  if ((pid = fork()) == 0)
+  pid = fork();
+  if (pid == 0)
   {
     struct sigaction act, oldalrm;
 
@@ -2345,7 +2360,8 @@ static int send_msg(const char *path, char **args, const char *msg, char **tempf
 #endif
 
     /* now the second fork() */
-    if ((pid = fork()) == 0)
+    pid = fork();
+    if (pid == 0)
     {
       /* "msg" will be opened as stdin */
       if (open(msg, O_RDONLY, 0) < 0)
@@ -2749,7 +2765,8 @@ static int _mutt_bounce_message(FILE *fp, struct Header *h, struct Address *to,
     fp = msg->fp;
 
   mutt_mktemp(tempfile, sizeof(tempfile));
-  if ((f = safe_fopen(tempfile, "w")) != NULL)
+  f = safe_fopen(tempfile, "w");
+  if (f)
   {
     int ch_flags = CH_XMIT | CH_NONEWLINE | CH_NOQFROM;
     char *msgid_str = NULL;
@@ -2971,7 +2988,8 @@ int mutt_write_fcc(const char *path, struct Header *hdr, const char *msgid,
   if (f.magic == MUTT_MMDF || f.magic == MUTT_MBOX)
   {
     mutt_mktemp(tempfile, sizeof(tempfile));
-    if ((tempfp = safe_fopen(tempfile, "w+")) == NULL)
+    tempfp = safe_fopen(tempfile, "w+");
+    if (!tempfp)
     {
       mutt_perror(tempfile);
       mx_close_mailbox(&f, NULL);
@@ -2986,7 +3004,8 @@ int mutt_write_fcc(const char *path, struct Header *hdr, const char *msgid,
   onm_flags = MUTT_ADD_FROM;
   if (post)
     onm_flags |= MUTT_SET_DRAFT;
-  if ((msg = mx_open_new_message(&f, hdr, onm_flags)) == NULL)
+  msg = mx_open_new_message(&f, hdr, onm_flags);
+  if (!msg)
   {
     safe_fclose(&tempfp);
     mx_close_mailbox(&f, NULL);

--- a/smtp.c
+++ b/smtp.c
@@ -345,7 +345,8 @@ static int smtp_helo(struct Connection *conn)
 #endif
   }
 
-  if (!(fqdn = mutt_fqdn(0)))
+  fqdn = mutt_fqdn(0);
+  if (!fqdn)
     fqdn = NONULL(ShortHostname);
 
   snprintf(buf, sizeof(buf), "%s %s\r\n", Esmtp ? "EHLO" : "HELO", fqdn);
@@ -659,7 +660,8 @@ int mutt_smtp_send(const struct Address *from, const struct Address *to,
   if (smtp_fill_account(&account) < 0)
     return ret;
 
-  if (!(conn = mutt_conn_find(NULL, &account)))
+  conn = mutt_conn_find(NULL, &account);
+  if (!conn)
     return -1;
 
   Esmtp = eightbit;

--- a/system.c
+++ b/system.c
@@ -57,7 +57,8 @@ int mutt_system(const char *cmd)
   sigaction(SIGTSTP, &act, &oldtstp);
   sigaction(SIGCONT, &act, &oldcont);
 
-  if ((thepid = fork()) == 0)
+  thepid = fork();
+  if (thepid == 0)
   {
     act.sa_flags = 0;
 

--- a/thread.c
+++ b/thread.c
@@ -541,7 +541,8 @@ static void pseudo_threads(struct Context *ctx)
   {
     cur = tree;
     tree = tree->next;
-    if ((parent = find_subject(ctx, cur)) != NULL)
+    parent = find_subject(ctx, cur);
+    if (parent)
     {
       cur->fake_thread = true;
       unlink_message(&top, cur);
@@ -920,7 +921,8 @@ void mutt_sort_threads(struct Context *ctx, int init)
       if (using_refs == 0)
       {
         /* look at the beginning of in-reply-to: */
-        if ((ref = STAILQ_FIRST(&cur->env->in_reply_to)) != NULL)
+        ref = STAILQ_FIRST(&cur->env->in_reply_to);
+        if (ref)
           using_refs = 1;
         else
         {
@@ -954,7 +956,8 @@ void mutt_sort_threads(struct Context *ctx, int init)
       if (!ref)
         break;
 
-      if ((new = hash_find(ctx->thread_hash, ref->data)) == NULL)
+      new = hash_find(ctx->thread_hash, ref->data);
+      if (!new)
       {
         new = safe_calloc(1, sizeof(struct MuttThread));
         hash_insert(ctx->thread_hash, ref->data, new);
@@ -1014,7 +1017,8 @@ static struct Header *find_virtual(struct MuttThread *cur, int reverse)
     return cur->message;
 
   top = cur;
-  if ((cur = cur->child) == NULL)
+  cur = cur->child;
+  if (!cur)
     return NULL;
 
   while (reverse && cur->next)
@@ -1128,7 +1132,8 @@ int mutt_parent_message(struct Context *ctx, struct Header *hdr, int find_root)
 
   for (thread = hdr->thread->parent; thread; thread = thread->parent)
   {
-    if ((hdr = thread->message) != NULL)
+    hdr = thread->message;
+    if (hdr)
     {
       parent = hdr;
       if (!find_root)

--- a/url.c
+++ b/url.c
@@ -90,7 +90,8 @@ enum UrlScheme url_check_scheme(const char *s)
   for (t = sbuf; *t; t++)
     *t = tolower(*t);
 
-  if ((i = mutt_getvaluebyname(sbuf, UrlMap)) == -1)
+  i = mutt_getvaluebyname(sbuf, UrlMap);
+  if (i == -1)
     return U_UNKNOWN;
   else
     return (enum UrlScheme) i;
@@ -174,7 +175,8 @@ int url_parse(struct Url *u, char *src)
 {
   char *tmp = NULL;
 
-  if ((u->scheme = url_check_scheme(src)) == U_UNKNOWN)
+  u->scheme = url_check_scheme(src);
+  if (u->scheme == U_UNKNOWN)
     return -1;
 
   tmp = strchr(src, ':') + 1;
@@ -273,7 +275,8 @@ int url_parse_mailto(struct Envelope *e, char **body, const char *src)
     return -1;
 
   /* copy string for safe use of strtok() */
-  if ((tmp = safe_strdup(t + 1)) == NULL)
+  tmp = safe_strdup(t + 1);
+  if (!tmp)
     return -1;
 
   if ((headers = strchr(tmp, '?')))

--- a/url.c
+++ b/url.c
@@ -271,7 +271,8 @@ int url_parse_mailto(struct Envelope *e, char **body, const char *src)
 
   int rc = -1;
 
-  if (!(t = strchr(src, ':')))
+  t = strchr(src, ':');
+  if (!t)
     return -1;
 
   /* copy string for safe use of strtok() */


### PR DESCRIPTION
This commit was made quickly with vim, but checked carefully by hand.
I think it makes the statements a little easier to read and debug.

It splits up 292 `if` statements of the form:
```c
if ((pc = imap_get_flags(&(idata->flags), pc)) == NULL)
```
into:
```c
pc = imap_get_flags(&(idata->flags), pc);
if (!pc)
```

<sub>This is part of flatcap's therapeutic coding regime</sub>