### PR TITLE
If set, use -D_FILE_OFFSET_BITS=64 when checking for GPGMe

### DIFF
--- a/auto.def
+++ b/auto.def
@@ -225,6 +225,7 @@ if {1} {
   cc-with [list -cflags [get-define CFLAGS]]
 
   # Large file support
+  cc-check-lfs
   cc-with {-includes sys/types.h} {
     if {[cc-check-sizeof off_t] eq {8}} {
       define OFF_T_FMT {"%" PRId64}
@@ -319,11 +320,17 @@ if {[get-define want-full-doc]} {define MAKEDOC_FULL}
 ###############################################################################
 # GPGME
 if {[get-define want-gpgme]} {
-  if {![check-inc-and-lib gpgme [opt-val with-gpgme $prefix] \
-                          gpgme.h gpgme_new gpgme]} {
-    user-error "Unable to find GPGME"
+  set gpgme_cflags {}
+  if {[is-defined _FILE_OFFSET_BITS]} {
+    set gpgme_cflags -D_FILE_OFFSET_BITS=[get-define _FILE_OFFSET_BITS]
   }
-  cc-check-functions gpgme_op_export_keys
+  cc-with [list -cflags $gpgme_cflags] {
+    if {![check-inc-and-lib gpgme [opt-val with-gpgme $prefix] \
+                            gpgme.h gpgme_new gpgme]} {
+      user-error "Unable to find GPGME"
+    }
+    cc-check-functions gpgme_op_export_keys
+  }
   define CRYPT_BACKEND_GPGME
 }
 

--- a/auto.def
+++ b/auto.def
@@ -225,15 +225,12 @@ if {1} {
   cc-with [list -cflags [get-define CFLAGS]]
 
   # Large file support
-  cc-check-lfs
-  cc-with {-includes sys/types.h} {
-    if {[cc-check-sizeof off_t] eq {8}} {
-      define OFF_T_FMT {"%" PRId64}
-    } else {
-      define OFF_T_FMT {"%" PRId32}
-    }
-    define LOFF_T off_t
+  if {[cc-check-lfs]} {
+    define OFF_T_FMT {"%" PRId64}
+  } else {
+    define OFF_T_FMT {"%" PRId32}
   }
+  define LOFF_T off_t
 
   # Let's always use volatile for sig_atomic_t
   cc-check-includes signal.h


### PR DESCRIPTION
Issue #826

* **What does this PR do?**

GPGMe gets configured a bit differently depending on whether LFS needs the `_FILE_OFFSET_BITS=64` define. This commit reinstates `cc-check-lfs` that might define  `_FILE_OFFSET_BITS`, and if defined, adds it to `CFLAGS` when checking for GPGMe