### PR TITLE
Sort the folders list when browsing an IMAP server

### DIFF
--- a/browser.c
+++ b/browser.c
@@ -1122,9 +1122,10 @@ void _mutt_select_file(char *f, size_t flen, int flags, char ***files, int *numf
       init_state(&state, NULL);
       state.imap_browse = true;
       if (!imap_browse(f, &state))
+      {
         strfcpy(LastDir, state.folder, sizeof(LastDir));
-      else
         browser_sort(&state);
+      }
     }
     else
     {


### PR DESCRIPTION
Issue #803

* **Are there points in the code the reviewer needs to double check?**

I don't remember why I put that call to `browser_sort` inside the else branch, which would mean it's called on an undefined `state` variable. Probably just an oversight not backed by any particular logic. Does anybody have an idea? ;)