### PR TITLE
fix: crash using uncolor

### DIFF
--- a/color.c
+++ b/color.c
@@ -470,7 +470,7 @@ static void do_uncolor(struct Buffer *buf, struct Buffer *s,
           {
             *do_cache = 1;
           }
-          mutt_debug(1, "Freeing pattern \"%s\" from ColorList\n", tmp->pattern);
+          mutt_debug(1, "Freeing pattern \"%s\" from ColorList\n", buf->data);
           if (tmp)
             STAILQ_REMOVE_AFTER(cl, tmp, entries);
           else


### PR DESCRIPTION
Using 'uncolor' on the last 'color' added would cause a crash,
because `tmp` isn't defined the first time through the loop.

e.g.
```
color index red yellow ~U; uncolor index ~U
```

This also fixes the two new coverity bugs.