### PR TITLE
keyword: remove doc menu entry

### DIFF
--- a/doc/manual.xml.head
+++ b/doc/manual.xml.head
@@ -11218,11 +11218,6 @@ color index_size cyan default
               <link linkend="status-color">Status-Color feature</link>
             </para>
           </listitem>
-          <listitem>
-            <para>
-              <link linkend="keywords">Keywords feature</link>
-            </para>
-          </listitem>
         </itemizedlist>
       </sect2>
 


### PR DESCRIPTION
We remove keyword dead code in 5c600997cd0e028a237fe6847ddffa1f2c340ea6.

This change removes the memu entry in the doc.

Closes #836