### PR TITLE
bool: convert struct member in mutt_regex.h

### DIFF
--- a/init.c
+++ b/init.c
@@ -2153,7 +2153,7 @@ static void restore_default(struct Option *p)
         if ((mutt_strcmp(p->option, "mask") == 0) && *s == '!')
         {
           s++;
-          pp->not = 1;
+          pp->not = true;
         }
         retval = REGCOMP(pp->regex, s, flags);
         if (retval != 0)

--- a/mutt_regex.h
+++ b/mutt_regex.h
@@ -47,7 +47,7 @@ struct Regex
 {
   char *pattern;  /**< printable version */
   regex_t *regex; /**< compiled expression */
-  int not;        /**< do not match */
+  bool not : 1;   /**< do not match */
 };
 
 /**


### PR DESCRIPTION
@neomutt/reviewers 
next up is `mutt_regex.h`


* **What does this PR do?**
changes `struct Regex`s not member to `bool`

Affected
* struct Regex
* restore_default()

* **Are there points in the code the reviewer needs to double check?**
no
* **What are the relevant issue numbers?**
#774 