### PR TITLE
Deprecation: changed called function in mutt_sasl.c

### DIFF
--- a/mutt_sasl.c
+++ b/mutt_sasl.c
@@ -631,7 +631,13 @@ void mutt_sasl_setup_conn(struct Connection *conn, sasl_conn_t *saslconn)
   conn->conn_poll = mutt_sasl_conn_poll;
 }
 
+/*
+ * mutt_sasl_done - Invoke when processing is complete.
+ * This is a cleanup function, used to free all memory used by the library. 
+ * Invoke when processing is complete.
+ */
 void mutt_sasl_done(void)
 {
-  sasl_done();
+  /* As we never use the server-side, the silently ignore the return value */
+  sasl_client_done();
 }


### PR DESCRIPTION
* **What does this PR do?**
Changes sasl_done() to sasl_client_done(), as former is deprecated now.
* **Are there points in the code the reviewer needs to double check?**
no
* **What are the relevant issue numbers?**
#841 