### PR TITLE
Refactor: Remove unused return type

### DIFF
--- a/mutt_tunnel.c
+++ b/mutt_tunnel.c
@@ -189,13 +189,17 @@ static int tunnel_socket_poll(struct Connection *conn, time_t wait_secs)
   return rc;
 }
 
-int mutt_tunnel_socket_setup(struct Connection *conn)
+/**
+ * mutt_tunnel_socket_setup - setups tunnel connection functions.
+ * @param conn Connection to asign functions to
+ *
+ * Assign tunnel socket functions to the Connection conn.
+ */
+void mutt_tunnel_socket_setup(struct Connection *conn)
 {
   conn->conn_open = tunnel_socket_open;
   conn->conn_close = tunnel_socket_close;
   conn->conn_read = tunnel_socket_read;
   conn->conn_write = tunnel_socket_write;
   conn->conn_poll = tunnel_socket_poll;
-
-  return 0;
 }

--- a/mutt_tunnel.h
+++ b/mutt_tunnel.h
@@ -23,6 +23,6 @@
 
 struct Connection;
 
-int mutt_tunnel_socket_setup(struct Connection *conn);
+void mutt_tunnel_socket_setup(struct Connection *conn);
 
 #endif /* _MUTT_TUNNEL_H */


### PR DESCRIPTION
@neomutt/reviewers 
next up is `mutt_tunnel.h`
* **What does this PR do?**
Changes the return type of `mutt_tunnel_socket_setup()` from `int` -> `void` as
it always returned `0`.
Added documentation.
* **Are there points in the code the reviewer needs to double check?**
No, it only gets called once, without using the return type

