### PR TITLE
Fix Issue #849

### DIFF
--- a/mutt_notmuch.c
+++ b/mutt_notmuch.c
@@ -1741,9 +1741,16 @@ char *nm_uri_from_query(struct Context *ctx, char *buf, size_t bufsz)
   int added;
 
   if (data)
-    added = snprintf(uri, sizeof(uri),
-                     "notmuch://%s?type=%s&query=", get_db_filename(data),
-                     query_type_to_string(data->query_type));
+  {
+    if (data->db_limit != 0)
+      added = snprintf(uri, sizeof(uri),
+                       "notmuch://%s?type=%s&limit=%d&query=", get_db_filename(data),
+                       query_type_to_string(data->query_type), data->db_limit);
+    else
+      added = snprintf(uri, sizeof(uri),
+                       "notmuch://%s?type=%s&query=", get_db_filename(data),
+                       query_type_to_string(data->query_type));
+  }
   else if (NmDefaultUri)
     added = snprintf(uri, sizeof(uri), "%s?type=%s&query=", NmDefaultUri,
                      query_type_to_string(string_to_query_type(NmQueryType)));


### PR DESCRIPTION
During notmuch URI creation, the limit= parameter is never added once
parsed. This issue is rectified by checking if db_limit is equal to 0
(the default value) and appending limit= if db_limit != 0.

NeoMutt initializes db_limit with the value of nm_db_limit. If the
limit= parameter is included, db_limit is assigned the value. However,
db_limit is never used after reassignment, resulting in issue #849.

* **What does this PR do?**
Resolves the issue present in #849 where notmuch URI ignores limit= parameter

* **Are there points in the code the reviewer needs to double check?**
Please examine my changes with extra scrutiny.

* **Screenshots (if relevant)**
N/A

* **What are the relevant issue numbers?**
#849 