### PR TITLE
Fix issue #849

### DIFF
--- a/mutt_notmuch.c
+++ b/mutt_notmuch.c
@@ -1801,6 +1801,7 @@ bool nm_normalize_uri(char *new_uri, const char *orig_uri, size_t new_uri_sz)
   char buf[LONG_STRING];
 
   struct Context tmp_ctx;
+  memset(&tmp_ctx, 0, sizeof(tmp_ctx));
   struct NmCtxData *tmp_ctxdata = new_ctxdata(orig_uri);
 
   if (!tmp_ctxdata)

--- a/mutt_notmuch.c
+++ b/mutt_notmuch.c
@@ -334,7 +334,7 @@ static void free_ctxdata(struct NmCtxData *data)
  * A new nm_ctxdata struct is created, then the query is parsed and saved
  * within it.  This should be freed using free_ctxdata().
  */
-static struct NmCtxData *new_ctxdata(char *uri)
+static struct NmCtxData *new_ctxdata(const char *uri)
 {
   struct NmCtxData *data = NULL;
 
@@ -1801,37 +1801,37 @@ bool nm_normalize_uri(char *new_uri, const char *orig_uri, size_t new_uri_sz)
   char buf[LONG_STRING];
 
   struct Context tmp_ctx;
-  struct NmCtxData tmp_ctxdata;
+  struct NmCtxData *tmp_ctxdata = new_ctxdata(orig_uri);
 
-  struct NmCtxData *tmp_data_from_uri = new_ctxdata(strdup(orig_uri));
-
-  if (!tmp_data_from_uri) 
+  if (!tmp_ctxdata)
     return false;
 
-  tmp_ctxdata = *tmp_data_from_uri;
-
   tmp_ctx.magic = MUTT_NOTMUCH;
-  tmp_ctx.data = &tmp_ctxdata;
+  tmp_ctx.data = tmp_ctxdata;
 
-  mutt_debug(2, "nm_normalize_uri #1 () -> db_query: %s\n", tmp_ctxdata.db_query);
+  mutt_debug(2, "nm_normalize_uri #1 () -> db_query: %s\n", tmp_ctxdata->db_query);
 
-  if (get_query_string(&tmp_ctxdata, false) == NULL)
+  if (get_query_string(tmp_ctxdata, false) == NULL)
   {
     mutt_error(_("failed to parse notmuch uri: %s"), orig_uri);
     mutt_debug(2, "nm_normalize_uri () -> error #1\n");
+    FREE(&tmp_ctxdata);
     return false;
   }
 
-  mutt_debug(2, "nm_normalize_uri #2 () -> db_query: %s\n", tmp_ctxdata.db_query);
+  mutt_debug(2, "nm_normalize_uri #2 () -> db_query: %s\n", tmp_ctxdata->db_query);
 
-  strfcpy(buf, tmp_ctxdata.db_query, sizeof(buf));
+  strfcpy(buf, tmp_ctxdata->db_query, sizeof(buf));
 
   if (nm_uri_from_query(&tmp_ctx, buf, sizeof(buf)) == NULL)
   {
     mutt_error(_("failed to parse notmuch uri: %s"), orig_uri);
     mutt_debug(2, "nm_normalize_uri () -> error #2\n");
+    FREE(&tmp_ctxdata);
     return true;
   }
+
+  FREE(&tmp_ctxdata);
 
   strncpy(new_uri, buf, new_uri_sz);
 


### PR DESCRIPTION
nm_uri_from_query() checks if there is a custom limit and includes it
in the URI. This keeps the limit intact after nm_normalize_uri()
terminates. Otherwise, the limit is stored within nm_normalize_uri()'s
temporary NmCtxData struct and lost upon termination.

Additionally, nm_normalize_uri() properly initializes tmp_ctxdata, which
sets the default db_limit value. This ensures db_limit is either
NmDbLimit or the custom limit. My earlier attempt to resolve #849 did
not initialize db_limit and suffered from random db_limit values.

The url_parse_query() check was removed from nm_normalize_uri() as
new_ctxdata() contains the same block of code. Error message numbering
has been updated the reflect the change.

* **What does this PR do?**
Fixes issue #849
* **Are there points in the code the reviewer needs to double check?**
I am unsure if I need to free the NmCtxData struct in nm_normalize_uri(). I had tried using free_ctxdata(), but neomutt would segfault on start. 
* **Screenshots (if relevant)**
N/A
* **What are the relevant issue numbers?**
#849 