### PR TITLE
tags: Show fake header for all backends

### DIFF
--- a/copy.c
+++ b/copy.c
@@ -456,16 +456,16 @@ int mutt_copy_header(FILE *in, struct Header *h, FILE *out, int flags, const cha
       fputs(buf, out);
       fputc('\n', out);
     }
-    char *tags = driver_tags_get(&h->tags);
-    if (tags && !(option(OPT_WEED) && mutt_matches_ignore("tags")))
-    {
-      fputs("Tags: ", out);
-      fputs(tags, out);
-      fputc('\n', out);
-    }
-    FREE(&tags);
   }
 #endif
+  char *tags = driver_tags_get(&h->tags);
+  if (tags && !(option(OPT_WEED) && mutt_matches_ignore("tags")))
+  {
+    fputs("Tags: ", out);
+    fputs(tags, out);
+    fputc('\n', out);
+  }
+  FREE(&tags);
 
   if (flags & CH_UPDATE_LABEL)
   {


### PR DESCRIPTION

Tag header was shown with Notmuch but not with Imap. This change enables it for all backends.

Closes #864
