### PR TITLE
split up 'if' statements that assign and test (3)

### DIFF
--- a/attach.c
+++ b/attach.c
@@ -653,11 +653,14 @@ int mutt_pipe_attachment(FILE *fp, struct Body *b, const char *path, char *outfi
   int rv = 0;
 
   if (outfile && *outfile)
-    if ((out = safe_open(outfile, O_CREAT | O_EXCL | O_WRONLY)) < 0)
+  {
+    out = safe_open(outfile, O_CREAT | O_EXCL | O_WRONLY);
+    if (out < 0)
     {
       mutt_perror("open");
       return 0;
     }
+  }
 
   mutt_endwin(NULL);
 
@@ -1029,7 +1032,8 @@ int mutt_print_attachment(FILE *fp, struct Body *a)
         return 0;
       }
 
-      if ((thepid = mutt_create_filter(command, &fpout, NULL, NULL)) < 0)
+      thepid = mutt_create_filter(command, &fpout, NULL, NULL);
+      if (thepid < 0)
       {
         mutt_perror(_("Can't create filter"));
         rfc1524_free_entry(&entry);
@@ -1086,7 +1090,8 @@ int mutt_print_attachment(FILE *fp, struct Body *a)
       mutt_debug(2, "successfully opened %s read-only\n", newfile);
 
       mutt_endwin(NULL);
-      if ((thepid = mutt_create_filter(NONULL(PrintCommand), &fpout, NULL, NULL)) < 0)
+      thepid = mutt_create_filter(NONULL(PrintCommand), &fpout, NULL, NULL);
+      if (thepid < 0)
       {
         mutt_perror(_("Can't create filter"));
         goto bail0;

--- a/commands.c
+++ b/commands.c
@@ -411,7 +411,8 @@ static int _mutt_pipe_message(struct Header *h, char *cmd, int decode,
     }
     mutt_endwin(NULL);
 
-    if ((thepid = mutt_create_filter(cmd, &fpout, NULL, NULL)) < 0)
+    thepid = mutt_create_filter(cmd, &fpout, NULL, NULL);
+    if (thepid < 0)
     {
       mutt_perror(_("Can't create filter process"));
       return 1;
@@ -447,7 +448,8 @@ static int _mutt_pipe_message(struct Header *h, char *cmd, int decode,
         {
           mutt_message_hook(Context, Context->hdrs[Context->v2r[i]], MUTT_MESSAGEHOOK);
           mutt_endwin(NULL);
-          if ((thepid = mutt_create_filter(cmd, &fpout, NULL, NULL)) < 0)
+          thepid = mutt_create_filter(cmd, &fpout, NULL, NULL);
+          if (thepid < 0)
           {
             mutt_perror(_("Can't create filter process"));
             return 1;
@@ -467,7 +469,8 @@ static int _mutt_pipe_message(struct Header *h, char *cmd, int decode,
     else
     {
       mutt_endwin(NULL);
-      if ((thepid = mutt_create_filter(cmd, &fpout, NULL, NULL)) < 0)
+      thepid = mutt_create_filter(cmd, &fpout, NULL, NULL);
+      if (thepid < 0)
       {
         mutt_perror(_("Can't create filter process"));
         return 1;

--- a/curs_main.c
+++ b/curs_main.c
@@ -977,7 +977,8 @@ int mutt_index_menu(void)
               CURHDR->index :
               0;
 
-      if ((check = mx_check_mailbox(Context, &index_hint)) < 0)
+      check = mx_check_mailbox(Context, &index_hint);
+      if (check < 0)
       {
         if (!Context->path)
         {
@@ -2163,7 +2164,8 @@ int mutt_index_menu(void)
          * set CurrentMenu incorrectly when we return back to the index menu. */
         menu->menu = MENU_MAIN;
 
-        if ((op = mutt_display_message(CURHDR)) < 0)
+        op = mutt_display_message(CURHDR);
+        if (op < 0)
         {
           unset_option(OPT_NEED_RESORT);
           break;
@@ -2658,7 +2660,8 @@ int mutt_index_menu(void)
         CHECK_MSGCOUNT;
         CHECK_VISIBLE;
 
-        if ((menu->current = mutt_parent_message(Context, CURHDR, op == OP_MAIN_ROOT_MESSAGE)) < 0)
+        menu->current = mutt_parent_message(Context, CURHDR, op == OP_MAIN_ROOT_MESSAGE);
+        if (menu->current < 0)
         {
           menu->current = menu->oldcurrent;
         }

--- a/enter.c
+++ b/enter.c
@@ -350,7 +350,8 @@ int _mutt_enter_string(char *buf, size_t buflen, int col, int flags, int multipl
     }
     mutt_refresh();
 
-    if ((ch = km_dokey(MENU_EDITOR)) < 0)
+    ch = km_dokey(MENU_EDITOR);
+    if (ch < 0)
     {
       rv = (SigWinch && ch == -2) ? 1 : -1;
       goto bye;

--- a/from.c
+++ b/from.c
@@ -125,7 +125,8 @@ int is_from(const char *s, char *path, size_t pathlen, time_t *tp)
   }
 
   /* now we should be on the month. */
-  if ((tm.tm_mon = mutt_check_month(s)) < 0)
+  tm.tm_mon = mutt_check_month(s);
+  if (tm.tm_mon < 0)
     return 0;
 
   /* day */

--- a/imap/command.c
+++ b/imap/command.c
@@ -1047,7 +1047,8 @@ int imap_exec(struct ImapData *idata, const char *cmdstr, int flags)
 {
   int rc;
 
-  if ((rc = cmd_start(idata, cmdstr, flags)) < 0)
+  rc = cmd_start(idata, cmdstr, flags);
+  if (rc < 0)
   {
     cmd_handle_fatal(idata);
     return -1;

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -125,7 +125,8 @@ int imap_access(const char *path)
     return -1;
   }
 
-  if ((rc = imap_exec(idata, buf, IMAP_CMD_FAIL_OK)) < 0)
+  rc = imap_exec(idata, buf, IMAP_CMD_FAIL_OK);
+  if (rc < 0)
   {
     mutt_debug(1, "imap_access: Can't check STATUS of %s\n", mbox);
     return rc;
@@ -1257,12 +1258,14 @@ static int sync_helper(struct ImapData *idata, int right, int flag, const char *
     return 0;
 
   snprintf(buf, sizeof(buf), "+FLAGS.SILENT (%s)", name);
-  if ((rc = imap_exec_msgset(idata, "UID STORE", buf, flag, 1, 0)) < 0)
+  rc = imap_exec_msgset(idata, "UID STORE", buf, flag, 1, 0);
+  if (rc < 0)
     return rc;
   count += rc;
 
   buf[0] = '-';
-  if ((rc = imap_exec_msgset(idata, "UID STORE", buf, flag, 1, 1)) < 0)
+  rc = imap_exec_msgset(idata, "UID STORE", buf, flag, 1, 1);
+  if (rc < 0)
     return rc;
   count += rc;
 
@@ -2096,7 +2099,8 @@ static int imap_compile_search(struct Context *ctx, const struct Pattern *pat,
   {
     int clauses;
 
-    if ((clauses = do_search(pat->child, 1)) > 0)
+    clauses = do_search(pat->child, 1);
+    if (clauses > 0)
     {
       const struct Pattern *clause = pat->child;
 

--- a/imap/message.c
+++ b/imap/message.c
@@ -594,7 +594,8 @@ int imap_read_headers(struct ImapData *idata, unsigned int msn_begin, unsigned i
         if (rc != IMAP_CMD_CONTINUE)
           break;
 
-        if ((mfhrc = msg_fetch_header(ctx, &h, idata->buf, NULL)) < 0)
+        mfhrc = msg_fetch_header(ctx, &h, idata->buf, NULL);
+        if (mfhrc < 0)
           continue;
 
         if (!h.data->uid)
@@ -712,7 +713,8 @@ int imap_read_headers(struct ImapData *idata, unsigned int msn_begin, unsigned i
         if (rc != IMAP_CMD_CONTINUE)
           break;
 
-        if ((mfhrc = msg_fetch_header(ctx, &h, idata->buf, fp)) < 0)
+        mfhrc = msg_fetch_header(ctx, &h, idata->buf, fp);
+        if (mfhrc < 0)
           continue;
 
         if (!ftello(fp))
@@ -1321,7 +1323,8 @@ int imap_copy_messages(struct Context *ctx, struct Header *h, char *dest, int de
           goto out;
         }
       }
-      if ((rc = imap_exec(idata, cmd.data, IMAP_CMD_QUEUE)) < 0)
+      rc = imap_exec(idata, cmd.data, IMAP_CMD_QUEUE);
+      if (rc < 0)
       {
         mutt_debug(1, "could not queue copy\n");
         goto out;

--- a/imap/util.c
+++ b/imap/util.c
@@ -359,7 +359,8 @@ int imap_parse_path(const char *path, struct ImapMbox *mx)
       mx->account.flags |= MUTT_ACCT_USER;
     }
 
-    if ((n = sscanf(tmp, "%127[^:/]%127s", mx->account.host, tmp)) < 1)
+    n = sscanf(tmp, "%127[^:/]%127s", mx->account.host, tmp);
+    if (n < 1)
     {
       mutt_debug(1, "imap_parse_path: NULL host in %s\n", path);
       FREE(&mx->mbox);

--- a/init.c
+++ b/init.c
@@ -620,7 +620,8 @@ int mutt_extract_token(struct Buffer *dest, struct Buffer *tok, int flags)
         return -1;
       }
       cmd = mutt_substrdup(tok->dptr, pc);
-      if ((pid = mutt_create_filter(cmd, NULL, &fp, NULL)) < 0)
+      pid = mutt_create_filter(cmd, NULL, &fp, NULL);
+      if (pid < 0)
       {
         mutt_debug(1, "mutt_get_token: unable to fork command: %s\n", cmd);
         FREE(&cmd);

--- a/keymap.c
+++ b/keymap.c
@@ -396,7 +396,8 @@ static void generic_tokenize_push_string(char *s, void (*generic_push)(int, int)
         ;
       if (pp >= s)
       {
-        if ((i = parse_fkey(pp)) > 0)
+        i = parse_fkey(pp);
+        if (i > 0)
         {
           generic_push(KEY_F(i), 0);
           p = pp - 1;

--- a/mutt_socket.c
+++ b/mutt_socket.c
@@ -122,7 +122,8 @@ int mutt_socket_write_d(struct Connection *conn, const char *buf, int len, int d
 
   while (sent < len)
   {
-    if ((rc = conn->conn_write(conn, buf + sent, len - sent)) < 0)
+    rc = conn->conn_write(conn, buf + sent, len - sent);
+    if (rc < 0)
     {
       mutt_debug(1, "mutt_socket_write: error writing (%s), closing socket\n",
                  strerror(errno));

--- a/mutt_ssl.c
+++ b/mutt_ssl.c
@@ -293,7 +293,8 @@ static void ssl_dprint_err_stack(void)
   if (!bio)
     return;
   ERR_print_errors(bio);
-  if ((buflen = BIO_get_mem_data(bio, &buf)) > 0)
+  buflen = BIO_get_mem_data(bio, &buf);
+  if (buflen > 0)
   {
     output = safe_malloc(buflen + 1);
     memcpy(output, buf, buflen);

--- a/mutt_ssl_gnutls.c
+++ b/mutt_ssl_gnutls.c
@@ -966,7 +966,8 @@ static int tls_set_priority(struct TlsSockData *data)
     return -1;
   }
 
-  if ((err = gnutls_priority_set_direct(data->state, priority, NULL)) < 0)
+  err = gnutls_priority_set_direct(data->state, priority, NULL);
+  if (err < 0)
   {
     mutt_error("gnutls_priority_set_direct(%s): %s", priority, gnutls_strerror(err));
     mutt_sleep(2);

--- a/muttlib.c
+++ b/muttlib.c
@@ -1242,7 +1242,8 @@ void mutt_expando_format(char *dest, size_t destlen, size_t col, int cols,
          * %*X: right justify to EOL, right takes precedence */
         int soft = ch == '*';
         int pl, pw;
-        if ((pl = mutt_charlen(src, &pw)) <= 0)
+        pl = mutt_charlen(src, &pw);
+        if (pl <= 0)
           pl = pw = 1;
 
         /* see if there's room to add content, else ignore */
@@ -1316,7 +1317,8 @@ void mutt_expando_format(char *dest, size_t destlen, size_t col, int cols,
       {
         /* pad to EOL */
         int pl, pw, c;
-        if ((pl = mutt_charlen(src, &pw)) <= 0)
+        pl = mutt_charlen(src, &pw);
+        if (pl <= 0)
           pl = pw = 1;
 
         /* see if there's room to add content, else ignore */
@@ -1409,7 +1411,8 @@ void mutt_expando_format(char *dest, size_t destlen, size_t col, int cols,
     {
       int tmp, w;
       /* in case of error, simply copy byte */
-      if ((tmp = mutt_charlen(src, &w)) < 0)
+      tmp = mutt_charlen(src, &w);
+      if (tmp < 0)
         tmp = w = 1;
       if (tmp > 0 && wlen + tmp < destlen)
       {

--- a/ncrypt/pgpmicalg.c
+++ b/ncrypt/pgpmicalg.c
@@ -114,7 +114,8 @@ static void pgp_dearmor(FILE *in, FILE *out)
     return;
   }
 
-  if ((end = ftello(in) - strlen(line)) < start)
+  end = ftello(in) - strlen(line);
+  if (end < start)
   {
     mutt_debug(1, "pgp_dearmor: end < start???\n");
     return;

--- a/parse.c
+++ b/parse.c
@@ -810,7 +810,8 @@ int mutt_parse_rfc822_line(struct Envelope *e, struct Header *hdr, char *line,
         {
           if (hdr)
           {
-            if ((hdr->content->length = atol(p)) < 0)
+            hdr->content->length = atol(p);
+            if (hdr->content->length < 0)
               hdr->content->length = -1;
           }
           matched = 1;

--- a/query.c
+++ b/query.c
@@ -127,7 +127,8 @@ static struct Query *run_query(char *s, int quiet)
 
   mutt_expand_file_fmt(cmd, sizeof(cmd), QueryCommand, s);
 
-  if ((thepid = mutt_create_filter(cmd, NULL, &fp, NULL)) < 0)
+  thepid = mutt_create_filter(cmd, NULL, &fp, NULL);
+  if (thepid < 0)
   {
     mutt_debug(1, "unable to fork command: %s\n", cmd);
     return 0;

--- a/send.c
+++ b/send.c
@@ -1371,7 +1371,8 @@ int ci_send_message(int flags, struct Header *msg, char *tempfile,
 
     if (flags == SENDPOSTPONED)
     {
-      if ((flags = mutt_get_postponed(ctx, msg, &cur, fcc, sizeof(fcc))) < 0)
+      flags = mutt_get_postponed(ctx, msg, &cur, fcc, sizeof(fcc));
+      if (flags < 0)
         goto cleanup;
 #ifdef USE_NNTP
       /*

--- a/sendlib.c
+++ b/sendlib.c
@@ -1445,7 +1445,8 @@ static void run_mime_type_query(struct Body *att)
 
   mutt_expand_file_fmt(cmd, sizeof(cmd), MimeTypeQueryCommand, att->filename);
 
-  if ((thepid = mutt_create_filter(cmd, NULL, &fp, &fperr)) < 0)
+  thepid = mutt_create_filter(cmd, NULL, &fp, &fperr);
+  if (thepid < 0)
   {
     mutt_error(_("Error running \"%s\"!"), cmd);
     return;
@@ -2012,7 +2013,8 @@ int mutt_write_one_header(FILE *fp, const char *tag, const char *value,
     /* find maximum line width in current header */
     if (p)
       *p = 0;
-    if ((w = my_width(line, 0, flags)) > max)
+    w = my_width(line, 0, flags);
+    if (w > max)
       max = w;
     if (p)
       *p = '\n';

--- a/smtp.c
+++ b/smtp.c
@@ -411,7 +411,8 @@ static int smtp_auth_sasl(struct Connection *conn, const char *mechlist)
   {
     if (mutt_socket_write(conn, buf) < 0)
       goto fail;
-    if ((rc = mutt_socket_readln(buf, bufsize, conn)) < 0)
+    rc = mutt_socket_readln(buf, bufsize, conn);
+    if (rc < 0)
       goto fail;
     if (!valid_smtp_code(buf, rc, &rc))
       goto fail;

--- a/state.c
+++ b/state.c
@@ -56,7 +56,8 @@ static int state_putwc(wchar_t wc, struct State *s)
   char mb[MB_LEN_MAX] = "";
   int rc;
 
-  if ((rc = wcrtomb(mb, wc, NULL)) < 0)
+  rc = wcrtomb(mb, wc, NULL);
+  if (rc < 0)
     return rc;
   if (fputs(mb, s->fpout) == EOF)
     return -1;


### PR DESCRIPTION
A final batch of 36 changes.  Those `if` statements with an assignment and a comparision.

---

Split 'if' statements that combine an assignment with a test.
e.g. from:
```c
if ((rc = mutt_socket_readln(buf, bufsize, conn)) < 0)
```
To:
```c
rc = mutt_socket_readln(buf, bufsize, conn);
if (rc < 0)
```
This makes the statements a little easier to read and debug.