### PR TITLE
build: --enable-everything includes lua

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -246,12 +246,12 @@ AC_DEFINE(SUN_ATTACHMENT,1,[ Define to enable Sun mailtool attachments support. 
 
 dnl --enable-lua
 AS_IF([test x$use_lua = "xyes"], [
-	AX_PROG_LUA([5.2],[],:,enable_lua=no)
-	AX_LUA_HEADERS(:,enable_lua=no)
-	AX_LUA_LIBS(:,enable_lua=no)
+	AX_PROG_LUA([5.2],[],:,use_lua=no)
+	AX_LUA_HEADERS(:,use_lua=no)
+	AX_LUA_LIBS(:,use_lua=no)
 ])
 
-AS_IF([test x$enable_lua = "xyes"], [
+AS_IF([test x$use_lua = "xyes"], [
 	AC_DEFINE(USE_LUA, 1, [Define if you want support for LUA.])
 	MUTT_LIB_OBJECTS="$MUTT_LIB_OBJECTS mutt_lua.o"
 	CPPFLAGS="$CPPFLAGS $LUA_INCLUDE"


### PR DESCRIPTION
With autoconf, `./configure --enable-everything` should include lua.
configure's summary says it does, but `config.h` disagrees.

Tested with:
- `./configure`
- `./configure --enable-lua`
- `./configure --disable-lua`
- `./configure --enable-everything`

Thanks to @tycho for the fix.

Fixes #855
