### PR TITLE
Use safe_calloc to initialize memory, simplify size_t overflow check

### DIFF
--- a/hcache/lmdb.c
+++ b/hcache/lmdb.c
@@ -108,9 +108,7 @@ static void *hcache_lmdb_open(const char *path)
 {
   int rc;
 
-  struct HcacheLmdbCtx *ctx = safe_malloc(sizeof(struct HcacheLmdbCtx));
-  ctx->txn = NULL;
-  ctx->db = 0;
+  struct HcacheLmdbCtx *ctx = safe_calloc(1, sizeof(struct HcacheLmdbCtx));
 
   rc = mdb_env_create(&ctx->env);
   if (rc != MDB_SUCCESS)

--- a/lib/memory.c
+++ b/lib/memory.c
@@ -37,6 +37,7 @@
  */
 
 #include "config.h"
+#include <stdint.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include "memory.h"
@@ -61,7 +62,7 @@ void *safe_calloc(size_t nmemb, size_t size)
   if (!nmemb || !size)
     return NULL;
 
-  if (((size_t) -1) / nmemb <= size)
+  if (nmemb > (SIZE_MAX / size))
   {
     mutt_error(_("Integer overflow -- can't allocate memory!"));
     sleep(1);


### PR DESCRIPTION
* **What does this PR do?**

  * Minor change in LMDB hcache driver to use `safe_calloc` instead of initializing the memory manually
  * Simplify `safe_calloc`'s check for `size_t` overflow