### PR TITLE
Use bundled wcscasecmp if an implementation is not found in libc

### DIFF
--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -67,6 +67,10 @@ NEOMUTTOBJS=	account.o addrbook.o alias.o attach.o bcache.o body.o \
 		smtp.o sort.o state.o status.o system.o thread.o url.o \
 		version.o
 
+@if HAVE_WCSCASECMP
+@else
+NEOMUTTOBJS+=	wcscasecmp.o
+@endif
 @if HAVE_RESIZETERM
 NEOMUTTOBJS+=	resize.o
 @endif

--- a/auto.def
+++ b/auto.def
@@ -258,7 +258,8 @@ if {1} {
     iswblank \
     mkdtemp \
     strsep \
-    vasprintf
+    vasprintf \
+    wcscasecmp
 
   cc-check-function-in-lib gethostent nsl
   cc-check-function-in-lib setsockopt socket


### PR DESCRIPTION
Issue #879
