### PR TITLE
Trivial code fixes

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1050,7 +1050,7 @@
   - Sidebar's inbox occasionally shows zero/wrong value
   - Fix crash opening a second compressed mailbox
 * Config
-  - Look for /etc/NeoMuttrc and ~/.neomuttrc
+  - Look for /etc/neomuttrc and ~/.neomuttrc
 * Docs
   - Fix broken links, typos
   - Update project link

--- a/hdrline.c
+++ b/hdrline.c
@@ -846,7 +846,7 @@ static const char *hdr_format_str(char *dest, size_t destlen, size_t col, int co
         optional = 0;
       break;
 
-    case 'g':;
+    case 'g':
       tags = driver_tags_get_transformed(&hdr->tags);
       if (!optional)
       {
@@ -913,7 +913,7 @@ static const char *hdr_format_str(char *dest, size_t destlen, size_t col, int co
                     hdr->env->message_id ? hdr->env->message_id : "<no.id>");
       break;
 
-    case 'J':;
+    case 'J':
       tags = driver_tags_get_transformed(&hdr->tags);
       if (tags)
       {

--- a/imap/util.c
+++ b/imap/util.c
@@ -637,7 +637,7 @@ int imap_get_literal_count(const char *buf, long *bytes)
 }
 
 /**
- * imap_get_qualifier - Get the qualifier from a tagged reponse
+ * imap_get_qualifier - Get the qualifier from a tagged response
  *
  * In a tagged response, skip tag and status for the qualifier message. Used by
  * imap_copy_message for TRYCREATE

--- a/keymap.c
+++ b/keymap.c
@@ -1093,7 +1093,7 @@ int mutt_parse_bind(struct Buffer *buf, struct Buffer *s, unsigned long data,
   char *key = NULL;
   int menu[sizeof(Menus) / sizeof(struct Mapping) - 1], r = 0, nummenus;
 
-  key = parse_keymap(menu, s, sizeof(menu) / sizeof(menu[0]), &nummenus, err);
+  key = parse_keymap(menu, s, mutt_array_size(menu), &nummenus, err);
   if (!key)
     return -1;
 
@@ -1151,7 +1151,7 @@ int mutt_parse_macro(struct Buffer *buf, struct Buffer *s, unsigned long data,
   char *seq = NULL;
   char *key = NULL;
 
-  key = parse_keymap(menu, s, sizeof(menu) / sizeof(menu[0]), &nummenus, err);
+  key = parse_keymap(menu, s, mutt_array_size(menu), &nummenus, err);
   if (!key)
     return -1;
 
@@ -1230,7 +1230,7 @@ int mutt_parse_exec(struct Buffer *buf, struct Buffer *s, unsigned long data,
       return -1;
     }
     nops++;
-  } while (MoreArgs(s) && nops < sizeof(ops) / sizeof(ops[0]));
+  } while (MoreArgs(s) && nops < mutt_array_size(ops));
 
   while (nops)
     mutt_push_macro_event(0, ops[--nops]);

--- a/lib/lib.h
+++ b/lib/lib.h
@@ -56,7 +56,6 @@
 #include "mapping.h"
 #include "md5.h"
 #include "memory.h"
-#include "memory.h"
 #include "message.h"
 #include "sha1.h"
 #include "string2.h"

--- a/mh.c
+++ b/mh.c
@@ -585,7 +585,7 @@ static void mh_sequences_add_one(struct Context *ctx, int n, short unseen,
   char seq_flagged[STRING];
 
   char *buff = NULL;
-  int line;
+  int line = 0;
   size_t sz;
 
   if (mh_mkstemp(ctx, &nfp, &tmpfname) == -1)

--- a/mutt_notmuch.c
+++ b/mutt_notmuch.c
@@ -1620,7 +1620,7 @@ done:
   return rc;
 }
 
-static unsigned count_query(notmuch_database_t *db, const char *qstr)
+static unsigned int count_query(notmuch_database_t *db, const char *qstr)
 {
   unsigned res = 0;
   notmuch_query_t *q = notmuch_query_create(db, qstr);

--- a/pager.c
+++ b/pager.c
@@ -1148,7 +1148,7 @@ static int fill_buffer(FILE *f, LOFF_T *last_pos, LOFF_T offset, unsigned char *
 {
   unsigned char *p = NULL, *q = NULL;
   static int b_read;
-  int l;
+  int l = 0;
 
   if (*buf_ready == 0)
   {


### PR DESCRIPTION
* 6fecb921 minor code fixes
  - Fix typos
  - Fix function prototype
  - Remove spurious semicolons
  - Remove duplicate #include

* e511a0bb use mutt_array_size()

* 7b258d98 refactor out O_NOFOLLOW
  O_NOFOLLOW is part of POSIX:2008 which isn't required for NeoMutt.
  This refactoring streamlines the code.

* 150febe9 initialise variables
  These variables were passed uninitialised to a function which increments them.
  Discovered by Coverity after the 'if-assign' commits.