### PR TITLE
call the folder-hook before saving to $record

### DIFF
--- a/hook.c
+++ b/hook.c
@@ -329,7 +329,7 @@ int mutt_parse_unhook(struct Buffer *buf, struct Buffer *s, unsigned long data,
   return 0;
 }
 
-void mutt_folder_hook(char *path)
+void mutt_folder_hook(const char *path)
 {
   struct Hook *tmp = NULL;
   struct Buffer err, token;

--- a/protos.h
+++ b/protos.h
@@ -183,7 +183,7 @@ void mutt_enter_command(void);
 void mutt_expand_file_fmt(char *dest, size_t destlen, const char *fmt, const char *src);
 void mutt_expand_fmt(char *dest, size_t destlen, const char *fmt, const char *src);
 void mutt_fix_reply_recipients(struct Envelope *env);
-void mutt_folder_hook(char *path);
+void mutt_folder_hook(const char *path);
 void mutt_simple_format(char *dest, size_t destlen, int min_width, int max_width, int justify,
                         char m_pad_char, const char *s, size_t n, int arboreal);
 void mutt_format_s(char *dest, size_t destlen, const char *prefix, const char *s);

--- a/sendlib.c
+++ b/sendlib.c
@@ -2982,6 +2982,7 @@ int mutt_write_fcc(const char *path, struct Header *hdr, const char *msgid,
   if (post)
     set_noconv_flags(hdr->content, 1);
 
+  mutt_folder_hook(path);
   if (mx_open_mailbox(path, MUTT_APPEND | MUTT_QUIET, &f) == NULL)
   {
     mutt_debug(1, "mutt_write_fcc(): unable to open mailbox %s in append-mode, "


### PR DESCRIPTION
cli neomutt asks for a password when sending because the `folder-hook` isn't executed for the `$record` mailbox.

This problem was discovered in #877.
Thanks to @lrosenman for his help debugging.

Setup:
- IMAP server
- 'sent' mailbox
- Password that's set using a folder-hook

Here's a minimal config.
```
set smtp_url="smtp://example.com"
set folder="imaps://USER@example.org"
set record="=SENT"
set imap_check_subscribed=yes
set from = "flatcap"
set realname = "Richard Russon"
set spoolfile = "=INBOX"
folder-hook "imaps://USER@example.com" set imap_pass="PASSWORD"
```

Test, by sending an email from the command line:

```
neomutt -n -F test.rc user@example.com
```

Actions:
- Follow the prompts to the compose email
- Hit <kbd>y</kbd> to send the mail

Result:
- A prompt for the password

Expected behaviour:
- `folder-hook` is run
- No prompt for a password
- Email saved to `$record` folder
