### PR TITLE
Fix smart wrap in pager without breaking header

### DIFF
--- a/init.h
+++ b/init.h
@@ -4319,7 +4319,7 @@ struct Option MuttVars[] = {
   ** When \fIset\fP, NeoMutt will weed headers when displaying, forwarding,
   ** printing, or replying to messages.
   */
-  { "wrap",             DT_NUMBER,  R_PAGER, UL &Wrap, 0 },
+  { "wrap",             DT_NUMBER,  R_PAGER_FLOW, UL &Wrap, 0 },
   /*
   ** .pp
   ** When set to a positive value, NeoMutt will wrap text at $$wrap characters.

--- a/pager.c
+++ b/pager.c
@@ -1562,8 +1562,8 @@ static int display_line(FILE *f, LOFF_T *last_pos, struct Line **line_info,
   {
     if (cnt < b_read)
     {
-      if (ch != -1 && buf[0] != ' ' && buf[0] != '\t' && buf[cnt] != ' ' &&
-          buf[cnt] != '\t' && buf[cnt] != '\n' && buf[cnt] != '\r')
+      /* Wrap if the line is not part of the header and buf[cnt] is not whitespace */
+      if (ch != -1 && !ISHEADER((*line_info)[n].type) && !ISSPACE(buf[cnt]))
       {
         buf_ptr = buf + ch;
         /* skip trailing blanks */


### PR DESCRIPTION
This commit addresses the issue of smart wrap not working if a line
started with whitespace.

This behavior was a result commit f5e472b where smart wrap was disabled
on lines beginning with a space or tab to prevent headers from having
weird wrapping.

This commit addresses this issue by only applying smart wrapping if the
pager is displaying a message body. This allows smart_wrap to work
inside of a message and preserves what commit f5e472b addressed.

* **Are there points in the code the reviewer needs to double check?**
I'm not the greatest with bitwise operations, but I based my change off of what I saw in pager.c and pager.h. I'm sure I didn't mess up the bitwise operations, but not entirely confident.

* **What are the relevant issue numbers?**
Issue #844 