### PR TITLE
docs: compressed and nntp features are now always built

### DIFF
--- a/doc/manual.xml.head
+++ b/doc/manual.xml.head
@@ -9973,12 +9973,6 @@ close-hook  '\.gpg$' "gpg --encrypt --recipient YourGpgUserIdOrKeyId &lt; '%t' &
         <itemizedlist>
           <listitem>
             <para>
-              <link linkend="compile-time-features">Compile-Time
-              Features</link>
-            </para>
-          </listitem>
-          <listitem>
-            <para>
               <link linkend="regex">Regular Expressions</link>
             </para>
           </listitem>
@@ -12396,18 +12390,6 @@ bind index \CG get-message
 <emphasis role="comment"># --------------------------------------------------------------------------
 # vim: syntax=neomuttrc</emphasis>
 </screen>
-      </sect2>
-
-      <sect2 id="nntp-see-also">
-        <title>See Also</title>
-        <itemizedlist>
-          <listitem>
-            <para>
-              <link linkend="compile-time-features">Compile-Time
-              Features</link>
-            </para>
-          </listitem>
-        </itemizedlist>
       </sect2>
 
       <sect2 id="nntp-known-bugs">


### PR DESCRIPTION
* **What does this PR do?**
docs cleanup after [NeoMutt 2017-06-02](https://github.com/neomutt/neomutt/releases/tag/neomutt-20170602):
> Six features are now "always built" as part of NeoMutt: sidebar, imap, pop, smtp, compressed, nntp.
These features have no build dependencies and don't add much to the size.

@neomutt/reviewers please review.