### PR TITLE
autosetup: delete makedoc on 'make clean'

### DIFF
--- a/doc/Makefile.autosetup
+++ b/doc/Makefile.autosetup
@@ -154,7 +154,7 @@ sortcheck-doc: doc/manual.xml
 all-doc: doc/neomuttrc
 
 clean-doc:
-	$(RM) doc/neomuttrc
+	$(RM) doc/neomuttrc doc/makedoc$(EXEEXT)
 
 install-doc: all-doc
 	$(MKDIR_P) $(DESTDIR)$(sysconfdir)


### PR DESCRIPTION
Now that makedoc is always built, alter the 'make clean' target to delete it.