### PR TITLE
Fixes for endianness detection

### DIFF
--- a/auto.def
+++ b/auto.def
@@ -224,6 +224,9 @@ if {1} {
 
   # Endianess
   cc-check-endian
+  if {[have-feature BIG_ENDIAN]} {
+    define WORDS_BIGENDIAN
+  }
 
   # Large file support
   if {[cc-check-lfs]} {
@@ -823,6 +826,7 @@ set auto_rep {
   SUN_ATTACHMENT
   SYSCONFDIR
   USE_*
+  WORDS_BIGENDIAN
 }
 set bare_rep {
   ICONV_CONST

--- a/auto.def
+++ b/auto.def
@@ -222,7 +222,7 @@ if {1} {
   }
   cc-with [list -cflags [get-define CFLAGS]]
 
-  # Endianess
+  # Endianness
   cc-check-endian
   if {[have-feature BIG_ENDIAN]} {
     define WORDS_BIGENDIAN

--- a/auto.def
+++ b/auto.def
@@ -202,9 +202,6 @@ if {1} {
     }
   }
 
-  # Endianess
-  cc-check-endian
-
   # GCC-specifc CFLAGS
   if {![catch {exec [get-define CC] --version} res]} {
     if {[regexp -nocase gcc $res]} {
@@ -224,6 +221,9 @@ if {1} {
     define-append CFLAGS -D__EXTENSIONS__
   }
   cc-with [list -cflags [get-define CFLAGS]]
+
+  # Endianess
+  cc-check-endian
 
   # Large file support
   if {[cc-check-lfs]} {


### PR DESCRIPTION
GNU/Linux does not seem to define BYTE_ORDER in vanilla c99 mode.

Issue #883
