### PR TITLE
Wrap dirname(3) inside a mutt_dirname() function

### DIFF
--- a/init.c
+++ b/init.c
@@ -25,7 +25,6 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <inttypes.h>
-#include <libgen.h>
 #include <limits.h>
 #include <pwd.h>
 #include <regex.h>
@@ -3116,7 +3115,7 @@ static struct ListHead MuttrcStack = STAILQ_HEAD_INITIALIZER(MuttrcStack);
  */
 static int to_absolute_path(char *path, const char *reference)
 {
-  char *ref_tmp = NULL, *dirpath = NULL;
+  const char *dirpath = NULL;
   char abs_path[PATH_MAX];
   int path_len;
 
@@ -3126,12 +3125,10 @@ static int to_absolute_path(char *path, const char *reference)
     return true;
   }
 
-  ref_tmp = safe_strdup(reference);
-  dirpath = dirname(ref_tmp); /* get directory name of */
+  dirpath = mutt_dirname(reference);
   strfcpy(abs_path, dirpath, PATH_MAX);
   safe_strncat(abs_path, sizeof(abs_path), "/", 1); /* append a / at the end of the path */
 
-  FREE(&ref_tmp);
   path_len = PATH_MAX - strlen(path);
 
   safe_strncat(abs_path, sizeof(abs_path), path, path_len > 0 ? path_len : 0);

--- a/lib/file.c
+++ b/lib/file.c
@@ -33,6 +33,7 @@
  * | mutt_copy_bytes()         | Copy some content from one file to another
  * | mutt_copy_stream()        | Copy the contents of one file into another
  * | mutt_decrease_mtime()     | Decrease a file's modification time by 1 second
+ * | mutt_dirname()            | Return a path up to, but not including, the final '/'
  * | mutt_lock_file()          | (try to) lock a file
  * | mutt_mkdir()              | Recursively create directories
  * | mutt_quote_filename()     | Quote a filename to survive the shell's quoting rules
@@ -58,6 +59,7 @@
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <libgen.h>
 #include <limits.h>
 #include <stdbool.h>
 #include <stdio.h>
@@ -910,6 +912,23 @@ time_t mutt_decrease_mtime(const char *f, struct stat *st)
   }
 
   return mtime;
+}
+
+/**
+ * mutt_dirname - Return a path up to, but not including, the final '/'.
+ *
+ * Unlike the IEEE Std 1003.1-2001 specification of dirname(3), this
+ * implementation does not modify its parameter, so callers need not manually
+ * copy their paths into a modifiable buffer prior to calling this function.
+ *
+ * @param  p    Path
+ * @retval ptr  The directory containing p
+ */
+const char *mutt_dirname(const char *p)
+{
+  static char buf[_POSIX_PATH_MAX];
+  strncpy(buf, p, sizeof(buf)-1);
+  return dirname(buf);
 }
 
 /**

--- a/lib/file.c
+++ b/lib/file.c
@@ -915,19 +915,20 @@ time_t mutt_decrease_mtime(const char *f, struct stat *st)
 }
 
 /**
- * mutt_dirname - Return a path up to, but not including, the final '/'.
+ * mutt_dirname - Return a path up to, but not including, the final '/'
+ * @param  p    Path
+ * @retval ptr  The directory containing p
  *
  * Unlike the IEEE Std 1003.1-2001 specification of dirname(3), this
  * implementation does not modify its parameter, so callers need not manually
  * copy their paths into a modifiable buffer prior to calling this function.
  *
- * @param  p    Path
- * @retval ptr  The directory containing p
+ * mutt_dirname() returns a static string which must not be free()'d.
  */
 const char *mutt_dirname(const char *p)
 {
   static char buf[_POSIX_PATH_MAX];
-  strncpy(buf, p, sizeof(buf)-1);
+  strfcpy(buf, p, sizeof(buf));
   return dirname(buf);
 }
 

--- a/lib/file.h
+++ b/lib/file.h
@@ -39,6 +39,7 @@ char *      mutt_concat_path(char *d, const char *dir, const char *fname, size_t
 int         mutt_copy_bytes(FILE *in, FILE *out, size_t size);
 int         mutt_copy_stream(FILE *fin, FILE *fout);
 time_t      mutt_decrease_mtime(const char *f, struct stat *st);
+const char *mutt_dirname(const char *p);
 int         mutt_lock_file(const char *path, int fd, int excl, int timeout);
 int         mutt_mkdir(const char *path, mode_t mode);
 size_t      mutt_quote_filename(char *d, size_t l, const char *f);

--- a/muttlib.c
+++ b/muttlib.c
@@ -26,7 +26,6 @@
 #include <ctype.h>
 #include <errno.h>
 #include <inttypes.h>
-#include <libgen.h>
 #ifdef ENABLE_NLS
 #include <libintl.h>
 #endif
@@ -1544,10 +1543,8 @@ int mutt_save_confirm(const char *s, struct stat *st)
       /* user confirmed with MUTT_YES or set OPT_CONFIRMCREATE */
       if (ret == 0)
       {
-        strncpy(tmp, s, sizeof(tmp) - 1);
-
         /* create dir recursively */
-        if (mutt_mkdir(dirname(tmp), S_IRWXU) == -1)
+        if (mutt_mkdir(mutt_dirname(s), S_IRWXU) == -1)
         {
           /* report failure & abort */
           mutt_perror(s);


### PR DESCRIPTION
This new function, opposite to the original dirname(3), does not modify its argument and can be passed a const char * argument. This means that callers mustn't copy their strings before calling dirname anymore.
