### PR TITLE
Define NCURSES_WIDECHAR to require wide-char support from ncurses

### DIFF
--- a/auto.def
+++ b/auto.def
@@ -460,6 +460,7 @@ if {[get-define want-fmemopen]} {
 # Ncurses / S-Lang
 switch [opt-val with-ui ncurses] {
   ncurses {
+    define-append CFLAGS -DNCURSES_WIDECHAR
     # Locate the library defining waddnwstr()
     set ncurses_prefix [opt-val with-ncurses $prefix]
     cc-with [list -libs -L$ncurses_prefix/lib] {

--- a/configure.ac
+++ b/configure.ac
@@ -409,6 +409,7 @@ dnl --- ncurses
 		MUTT_LIB_OBJECTS="$MUTT_LIB_OBJECTS resize.o"
 	fi
 	AC_CHECK_FUNCS([use_extended_names])
+	CPPFLAGS="$CPPFLAGS -DNCURSES_WIDECHAR"
 fi
 
 AC_HEADER_STDC


### PR DESCRIPTION
See https://lists.gnu.org/archive/html/qemu-devel/2017-06/msg00634.html for a discussion.

This might be a solution for #589.
