### PR TITLE
Move definition of conn/globals.h back into globals.h

### DIFF
--- a/conn/conn_globals.c
+++ b/conn/conn_globals.c
@@ -40,6 +40,7 @@
 
 #include "config.h"
 
+#if 0
 short ConnectTimeout; /**< Config: $connect_timeout */
 
 #ifdef USE_SSL
@@ -57,3 +58,4 @@ short SslMinDhPrimeBits;           /**< Config: $ssl_min_dh_prime_bits */
 const char *Preconnect; /**< Config: $preconnect */
 const char *Tunnel;     /**< Config: $tunnel */
 #endif                  /* USE_SOCKET */
+#endif

--- a/globals.h
+++ b/globals.h
@@ -326,6 +326,26 @@ WHERE int NmQueryWindowCurrentPosition;
 WHERE char *NmQueryWindowCurrentSearch;
 #endif
 
+#if 1
+WHERE short ConnectTimeout;
+
+#ifdef USE_SSL
+WHERE const char *CertificateFile;
+WHERE const char *EntropyFile;
+WHERE const char *SslCiphers;
+WHERE const char *SslClientCert;
+#ifdef USE_SSL_GNUTLS
+WHERE const char *SslCaCertificatesFile;
+WHERE short SslMinDhPrimeBits;
+#endif
+#endif
+
+#ifdef USE_SOCKET
+WHERE const char *Preconnect;
+WHERE const char *Tunnel;
+#endif
+#endif
+
 #ifdef MAIN_C
 const char *const BodyTypes[] = {
     "x-unknown", "audio",     "application", "image", "message",


### PR DESCRIPTION
Fixed #907

This is a quick and dirty fix to make sure the linker sees the definitions of objects defined in the libraries. A nicer and longer-term solution might involve the use of the `-whole-archive` (respectively `-all_load`on OSX) linker flags, but this requires more investigation.