### PR TITLE
display_filter: Don't output escape sequences

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -146,6 +146,7 @@ int mutt_display_message(struct Header *cur)
       unlink(tempfile);
       return 0;
     }
+    cmflags |= MUTT_CM_DISPLAY_FILTER;
   }
 
   if (!Pager || (mutt_strcmp(Pager, "builtin") == 0))

--- a/copy.c
+++ b/copy.c
@@ -655,6 +655,8 @@ int _mutt_copy_message(FILE *fpout, FILE *fpin, struct Header *hdr,
       s.prefix = prefix;
     if (flags & MUTT_CM_DISPLAY)
       s.flags |= MUTT_DISPLAY;
+    if (flags & MUTT_CM_DISPLAY_FILTER)
+      s.flags |= MUTT_DISPLAY_FILTER;
     if (flags & MUTT_CM_PRINTING)
       s.flags |= MUTT_PRINTING;
     if (flags & MUTT_CM_WEED)

--- a/copy.h
+++ b/copy.h
@@ -43,6 +43,7 @@ struct Context;
 #define MUTT_CM_DECODE_SMIME (1 << 10) /**< used for decoding S/MIME messages */
 #define MUTT_CM_DECODE_CRYPT (MUTT_CM_DECODE_PGP | MUTT_CM_DECODE_SMIME)
 #define MUTT_CM_VERIFY       (1 << 11) /**< do signature verification */
+#define MUTT_CM_DISPLAY_FILTER (1 << 12) /**< output being passed through an external filter */
 
 /* flags for mutt_copy_header() */
 #define CH_UPDATE         (1 << 0)  /**< update the status and x-status fields? */

--- a/state.c
+++ b/state.c
@@ -31,6 +31,8 @@ void state_mark_attach(struct State *s)
 {
   if (!s || !s->fpout)
     return;
+  if (s->flags & MUTT_DISPLAY_FILTER)
+    return;
   if ((s->flags & MUTT_DISPLAY) && (mutt_strcmp(Pager, "builtin") == 0))
     state_puts(AttachmentMarker, s);
 }

--- a/state.h
+++ b/state.h
@@ -46,6 +46,7 @@ struct State
 #define MUTT_PRINTING      (1 << 5) /**< are we printing? - MUTT_DISPLAY "light" */
 #define MUTT_REPLYING      (1 << 6) /**< are we replying? */
 #define MUTT_FIRSTDONE     (1 << 7) /**< the first attachment has been done */
+#define MUTT_DISPLAY_FILTER (1 << 8) /**< output being passed through an external filter */
 
 #define state_set_prefix(s) ((s)->flags |= MUTT_PENDINGPREFIX)
 #define state_reset_prefix(s) ((s)->flags &= ~MUTT_PENDINGPREFIX)


### PR DESCRIPTION
When NeoMutt opens a signed/encrypted message, it adds some lines to the
display, e.g.

    [-- PGP output follows ... --]

In order to be able to colour them, it adds a marker to the beginning of the line -- `<esc>]9;XXX<bel>` -- where "XXX" is a random 64-bit number.
This marker means that other strings in the body of the email will never match.

Unfortunately, this escape sequence will be visible to the `display_filter` command.

issue #897

---


Normally, NeoMutt processes the email, writing it to a temporary file.  That file is displayed in the pager.
When `$display_filter` is set, it invisibly inserts the filter into the processing.

    Process email -> filter -> temp file -> pager

https://github.com/neomutt/neomutt/blob/3a6f8fbc8de5d309c2ea556817889714d2e8c0f6/init.c#L4075-L4076

https://github.com/neomutt/neomutt/blob/3a6f8fbc8de5d309c2ea556817889714d2e8c0f6/pager.c#L828-L829

This PR adds a new flag to the `struct State` which gets passed down through many code layers.
The backtrace looks something like:
```
#1 mutt_index_menu()
#2 mutt_display_message()
#3 mutt_copy_message()
#4 _mutt_copy_message()
#5 mutt_body_handler()
#6 handler = mutt_signed_handler
#7 run_decode_and_handler()
#8 handler() -> mutt_signed_handler()
.. many pgp functions
#11 state_mark_attach()
#12 state_puts(AttachmentMarker, s);
```