### PR TITLE
A couple of fixes for the GMail searching

### DIFF
--- a/imap/command.c
+++ b/imap/command.c
@@ -67,11 +67,14 @@
 
 /**
  * Capabilities - Server capabilties strings that we understand
+ *
+ * @note This must be kept in the same order as ImapCaps.
  */
 static const char *const Capabilities[] = {
-  "IMAP4",         "IMAP4rev1",   "STATUS",         "ACL",      "NAMESPACE",
-  "AUTH=CRAM-MD5", "AUTH=GSSAPI", "AUTH=ANONYMOUS", "STARTTLS", "LOGINDISABLED",
-  "IDLE",          "SASL-IR",     "X-GM-EXT1",      "ENABLE",   NULL,
+  "IMAP4",     "IMAP4rev1",     "STATUS",      "ACL",
+  "NAMESPACE", "AUTH=CRAM-MD5", "AUTH=GSSAPI", "AUTH=ANONYMOUS",
+  "STARTTLS",  "LOGINDISABLED", "IDLE",        "SASL-IR",
+  "ENABLE",    "X-GM-EXT1",     NULL,
 };
 
 /**

--- a/imap/command.c
+++ b/imap/command.c
@@ -69,30 +69,14 @@
  * Capabilities - Server capabilties strings that we understand
  *
  * @note This must be kept in the same order as ImapCaps.
+ *
+ * @note Gmail documents one string but use another, so we support both.
  */
 static const char *const Capabilities[] = {
   "IMAP4",     "IMAP4rev1",     "STATUS",      "ACL",
   "NAMESPACE", "AUTH=CRAM-MD5", "AUTH=GSSAPI", "AUTH=ANONYMOUS",
   "STARTTLS",  "LOGINDISABLED", "IDLE",        "SASL-IR",
-  "ENABLE",    "X-GM-EXT1",     NULL,
-};
-
-/**
- * struct CapabilityAlias - Alternative names for capabilities
- */
-struct CapabilityAlias
-{
-  char *name;
-  unsigned int value;
-};
-
-/**
- * CapabilityAliases - Alternate capability strings (for compatibility)
- */
-static struct CapabilityAlias CapabilityAliases[] = {
-  /* Gmail documents one string but use another.  Support both. */
-  { "X-GM-EXT-1", X_GM_EXT1 },
-  { NULL, 0 },
+  "ENABLE",    "X-GM-EXT1",     "X-GM-EXT-1",  NULL,
 };
 
 /**
@@ -387,7 +371,6 @@ static void cmd_parse_fetch(struct ImapData *idata, char *s)
  */
 static void cmd_parse_capability(struct ImapData *idata, char *s)
 {
-  bool found;
   char *bracket = NULL;
 
   mutt_debug(3, "Handling CAPABILITY\n");
@@ -402,28 +385,13 @@ static void cmd_parse_capability(struct ImapData *idata, char *s)
 
   while (*s)
   {
-    found = false;
     for (int i = 0; i < CAPMAX; i++)
     {
       if (imap_wordcasecmp(Capabilities[i], s) == 0)
       {
         mutt_bit_set(idata->capabilities, i);
         mutt_debug(4, " Found capability \"%s\": %d\n", Capabilities[i], i);
-        found = true;
         break;
-      }
-    }
-    if (!found)
-    {
-      for (int i = 0; CapabilityAliases[i].name != NULL; i++)
-      {
-        if (imap_wordcasecmp(CapabilityAliases[i].name, s) == 0)
-        {
-          mutt_bit_set(idata->capabilities, CapabilityAliases[i].value);
-          mutt_debug(4, " Found capability \"%s\": %d\n",
-                     CapabilityAliases[i].name, CapabilityAliases[i].value);
-          break;
-        }
       }
     }
     s = imap_next_word(s);

--- a/imap/imap_private.h
+++ b/imap/imap_private.h
@@ -117,6 +117,8 @@ enum ImapNamespace
 
 /**
  * enum ImapCaps - Capabilities we are interested in
+ *
+ * @note This must be kept in the same order as Capabilities.
  */
 enum ImapCaps
 {

--- a/imap/imap_private.h
+++ b/imap/imap_private.h
@@ -136,6 +136,7 @@ enum ImapCaps
   SASL_IR,       /**< SASL initial response draft */
   ENABLE,        /**< RFC5161 */
   X_GM_EXT1,     /**< https://developers.google.com/gmail/imap/imap-extensions */
+  X_GM_ALT1 = X_GM_EXT1, /**< Alternative capability string */
 
   CAPMAX
 };


### PR DESCRIPTION
- 5ce778544 bug: imap gmail search

The order of strings in Capabilities should match the enums in ImapCaps.

- 9c179f960 fix: drop capability aliases

`CapabilityAliases` was a list of alternative names (just one) for IMAP capability strings.  This isn't necessary.  We can put the strings in `Capabilities` and fix the enumeration.

```c
enum ImapCaps
{   
  ...
  X_GM_EXT1,
  X_GM_ALT1 = X_GM_EXT1,
  ...
};  
``` 