### PR TITLE
trivial code fixes/changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ autosetup/jimsh0
 # Ignore directories
 **/.deps/
 **/*.Po
+**/*.Tpo
 autom4te.cache/
 .build-aux/
 

--- a/addrbook.c
+++ b/addrbook.c
@@ -168,8 +168,8 @@ new_aliases:
   /* count the number of aliases */
   for (aliasp = aliases; aliasp; aliasp = aliasp->next)
   {
-    aliasp->self->del = false;
-    aliasp->self->tagged = false;
+    aliasp->del = false;
+    aliasp->tagged = false;
     menu->max++;
   }
 
@@ -180,7 +180,7 @@ new_aliases:
 
   for (i = omax, aliasp = aliases; aliasp; aliasp = aliasp->next, i++)
   {
-    AliasTable[i] = aliasp->self;
+    AliasTable[i] = aliasp;
     aliases = aliasp;
   }
 
@@ -215,7 +215,7 @@ new_aliases:
         }
         else
         {
-          AliasTable[menu->current]->self->del = (op == OP_DELETE);
+          AliasTable[menu->current]->del = (op == OP_DELETE);
           menu->redraw |= REDRAW_CURRENT;
           if (option(OPT_RESOLVE) && menu->current < menu->max - 1)
           {

--- a/alias.c
+++ b/alias.c
@@ -337,7 +337,6 @@ retry_name:
   }
 
   new = safe_calloc(1, sizeof(struct Alias));
-  new->self = new;
   new->name = safe_strdup(buf);
 
   mutt_addrlist_to_local(adr);

--- a/alias.h
+++ b/alias.h
@@ -33,7 +33,6 @@ struct Address;
  */
 struct Alias
 {
-  struct Alias *self; /* XXX - ugly hack */
   char *name;
   struct Address *addr;
   struct Alias *next;

--- a/conn/sasl.c
+++ b/conn/sasl.c
@@ -726,7 +726,7 @@ void mutt_sasl_setup_conn(struct Connection *conn, sasl_conn_t *saslconn)
 /*
  * mutt_sasl_done - Invoke when processing is complete.
  *
- * This is a cleanup function, used to free all memory used by the library. 
+ * This is a cleanup function, used to free all memory used by the library.
  * Invoke when processing is complete.
  */
 void mutt_sasl_done(void)

--- a/conn/sasl.c
+++ b/conn/sasl.c
@@ -138,7 +138,8 @@ static int getnameinfo_err(int ret)
  *
  * utility function, copied from sasl2 sample code
  */
-static int iptostring(const struct sockaddr *addr, socklen_t addrlen, char *out, unsigned outlen)
+static int iptostring(const struct sockaddr *addr, socklen_t addrlen, char *out,
+                      unsigned int outlen)
 {
   char hbuf[NI_MAXHOST], pbuf[NI_MAXSERV];
   int ret;
@@ -223,7 +224,7 @@ static int mutt_sasl_start(void)
  * @param[out] len     Length of result
  * @retval int SASL error code, e.g. SASL_FAIL
  */
-static int mutt_sasl_cb_authname(void *context, int id, const char **result, unsigned *len)
+static int mutt_sasl_cb_authname(void *context, int id, const char **result, unsigned int *len)
 {
   struct Account *account = (struct Account *) context;
 

--- a/conn/tunnel.c
+++ b/conn/tunnel.c
@@ -22,7 +22,7 @@
  */
 
 /**
- * @page conn_tunnel Support for network tunnelling 
+ * @page conn_tunnel Support for network tunnelling
  *
  * Support for network tunnelling
  *

--- a/copy.c
+++ b/copy.c
@@ -1029,7 +1029,7 @@ static int address_header_decode(char **h)
     if (cur->personal)
       rfc822_dequote_comment(cur->personal);
 
-  /* angle brackets for return path are mandated by RfC5322,
+  /* angle brackets for return path are mandated by RFC5322,
    * so leave Return-Path as-is */
   if (rp)
     *h = safe_strdup(s);

--- a/doc/manual.xml.head
+++ b/doc/manual.xml.head
@@ -2728,7 +2728,7 @@ color sidebar_divider   color8  default
           specifically it does not add the trailing spaces.</para>
           <para>After editing the initial message text and before entering the
           compose menu, NeoMutt properly space-stuffs the message.
-          <emphasis>Space-stuffing</emphasis> is required by RfC3676 defining
+          <emphasis>Space-stuffing</emphasis> is required by RFC3676 defining
           <literal>format=flowed</literal> and means to prepend a space
           to:</para>
           <itemizedlist>
@@ -14796,7 +14796,7 @@ bind index D purge-message
       <para>NeoMutt in many places has to rely on external applications or for
       convenience supports mechanisms involving external applications.</para>
       <para>One of these is the
-      <literal>mailcap</literal> mechanism as defined by RfC1524. Details about
+      <literal>mailcap</literal> mechanism as defined by RFC1524. Details about
       a secure use of the mailcap mechanisms is given in
       <xref linkend="secure-mailcap" />.</para>
       <para>Besides the mailcap mechanism, NeoMutt uses a number of other external

--- a/doc/neomutt.pwl
+++ b/doc/neomutt.pwl
@@ -272,7 +272,7 @@ ispell
 png
 NTLM
 clearsign
-RfC
+RFC
 rfc
 syntaxes
 untag

--- a/handler.c
+++ b/handler.c
@@ -217,7 +217,7 @@ static void qp_decode_line(char *dest, char *src, size_t *l, int last)
   {
     /* neither \r nor \n as part of line-terminating CRLF
      * may be qp-encoded, so remove \r and \n-terminate;
-     * see RfC2045, sect. 6.7, (1): General 8bit representation */
+     * see RFC2045, sect. 6.7, (1): General 8bit representation */
     if (kind == 0 && c == '\r')
       *(d - 1) = '\n';
     else

--- a/hcache/hcache.c
+++ b/hcache/hcache.c
@@ -170,8 +170,8 @@ static void restore_int(unsigned int *i, const unsigned char *d, int *off)
 
 static inline bool is_ascii(const char *p, size_t len)
 {
-  register const char *s = p;
-  while (s && (unsigned) (s - p) < len)
+  const char *s = p;
+  while (s && (unsigned int) (s - p) < len)
   {
     if ((*s & 0x80) != 0)
       return false;

--- a/init.c
+++ b/init.c
@@ -1916,7 +1916,6 @@ static int parse_alias(struct Buffer *buf, struct Buffer *s, unsigned long data,
   {
     /* create a new alias */
     tmp = safe_calloc(1, sizeof(struct Alias));
-    tmp->self = tmp;
     tmp->name = safe_strdup(buf->data);
     /* give the main addressbook code a chance */
     if (CurrentMenu == MENU_ALIAS)

--- a/main.c
+++ b/main.c
@@ -51,6 +51,7 @@
 #include "mailbox.h"
 #include "mutt_curses.h"
 #include "mutt_idna.h"
+#include "mutt_menu.h"
 #include "mutt_regex.h"
 #include "mutt_socket.h"
 #include "ncrypt/ncrypt.h"

--- a/mbyte.c
+++ b/mbyte.c
@@ -4,6 +4,7 @@
  *
  * @authors
  * Copyright (C) 2000 Edmund Grimley Evans <edmundo@rano.org>
+ * Copyright (C) 2000 Takashi Takizawa <taki@luna.email.ne.jp>
  *
  * @copyright
  * This program is free software: you can redistribute it and/or modify it under
@@ -18,10 +19,6 @@
  *
  * You should have received a copy of the GNU General Public License along with
  * this program.  If not, see <http://www.gnu.org/licenses/>.
- */
-
-/*
- * Japanese support by TAKIZAWA Takashi <taki@luna.email.ne.jp>.
  */
 
 #include "config.h"

--- a/mbyte.h
+++ b/mbyte.h
@@ -3,6 +3,8 @@
  * Convert strings between multibyte and utf8 encodings
  *
  * @authors
+ * Copyright (C) 2000 Edmund Grimley Evans <edmundo@rano.org>
+ *
  * @copyright
  * This program is free software: you can redistribute it and/or modify it under
  * the terms of the GNU General Public License as published by the Free Software

--- a/mh.c
+++ b/mh.c
@@ -75,7 +75,7 @@ struct Maildir
 {
   struct Header *h;
   char *canon_fname;
-  unsigned header_parsed : 1;
+  bool header_parsed : 1;
   ino_t inode;
   struct Maildir *next;
 };

--- a/mutt_notmuch.c
+++ b/mutt_notmuch.c
@@ -925,7 +925,7 @@ static void progress_update(struct Context *ctx, notmuch_query_t *q)
 
   if (!data->progress_ready && q)
   {
-    unsigned count;
+    unsigned int count;
     static char msg[STRING];
     snprintf(msg, sizeof(msg), _("Reading messages..."));
 
@@ -1513,7 +1513,7 @@ done:
 
 static unsigned int count_query(notmuch_database_t *db, const char *qstr)
 {
-  unsigned res = 0;
+  unsigned int res = 0;
   notmuch_query_t *q = notmuch_query_create(db, qstr);
 
   if (q)

--- a/ncrypt/crypt.c
+++ b/ncrypt/crypt.c
@@ -713,38 +713,38 @@ void crypt_extract_keys_from_messages(struct Header *h)
       if (!message_is_tagged(Context, i))
         continue;
 
-      struct Header *h = Context->hdrs[i];
+      struct Header *hi = Context->hdrs[i];
 
-      mutt_parse_mime_message(Context, h);
-      if (h->security & ENCRYPT && !crypt_valid_passphrase(h->security))
+      mutt_parse_mime_message(Context, hi);
+      if (hi->security & ENCRYPT && !crypt_valid_passphrase(hi->security))
       {
         safe_fclose(&fpout);
         break;
       }
 
-      if ((WithCrypto & APPLICATION_PGP) && (h->security & APPLICATION_PGP))
+      if ((WithCrypto & APPLICATION_PGP) && (hi->security & APPLICATION_PGP))
       {
-        mutt_copy_message(fpout, Context, h, MUTT_CM_DECODE | MUTT_CM_CHARCONV, 0);
+        mutt_copy_message(fpout, Context, hi, MUTT_CM_DECODE | MUTT_CM_CHARCONV, 0);
         fflush(fpout);
 
         mutt_endwin(_("Trying to extract PGP keys...\n"));
         crypt_pgp_invoke_import(tempfname);
       }
 
-      if ((WithCrypto & APPLICATION_SMIME) && (h->security & APPLICATION_SMIME))
+      if ((WithCrypto & APPLICATION_SMIME) && (hi->security & APPLICATION_SMIME))
       {
-        if (h->security & ENCRYPT)
-          mutt_copy_message(fpout, Context, h,
+        if (hi->security & ENCRYPT)
+          mutt_copy_message(fpout, Context, hi,
                             MUTT_CM_NOHEADER | MUTT_CM_DECODE_CRYPT | MUTT_CM_DECODE_SMIME,
                             0);
         else
-          mutt_copy_message(fpout, Context, h, 0, 0);
+          mutt_copy_message(fpout, Context, hi, 0, 0);
         fflush(fpout);
 
-        if (h->env->from)
-          tmp = mutt_expand_aliases(h->env->from);
-        else if (h->env->sender)
-          tmp = mutt_expand_aliases(h->env->sender);
+        if (hi->env->from)
+          tmp = mutt_expand_aliases(hi->env->from);
+        else if (hi->env->sender)
+          tmp = mutt_expand_aliases(hi->env->sender);
         mbox = tmp ? tmp->mailbox : NULL;
         if (mbox)
         {

--- a/ncrypt/pgp.c
+++ b/ncrypt/pgp.c
@@ -414,7 +414,7 @@ int pgp_application_pgp_handler(struct Body *m, struct State *s)
             (!needpass && ((mutt_strcmp("-----END PGP SIGNATURE-----\n", buf) == 0) ||
                            (mutt_strcmp("-----END PGP PUBLIC KEY BLOCK-----\n", buf) == 0))))
           break;
-        /* remember optional Charset: armor header as defined by RfC4880 */
+        /* remember optional Charset: armor header as defined by RFC4880 */
         if (mutt_strncmp("Charset: ", buf, 9) == 0)
         {
           size_t l = 0;

--- a/newsrc.c
+++ b/newsrc.c
@@ -460,20 +460,20 @@ int nntp_newsrc_update(struct NntpServer *nserv)
     off += strlen(buf + off);
 
     /* write entries */
-    for (unsigned int i = 0; i < nntp_data->newsrc_len; i++)
+    for (unsigned int j = 0; j < nntp_data->newsrc_len; j++)
     {
       if (off + LONG_STRING > buflen)
       {
         buflen *= 2;
         safe_realloc(&buf, buflen);
       }
-      if (i)
+      if (j)
         buf[off++] = ',';
-      if (nntp_data->newsrc_ent[i].first == nntp_data->newsrc_ent[i].last)
-        snprintf(buf + off, buflen - off, "%d", nntp_data->newsrc_ent[i].first);
-      else if (nntp_data->newsrc_ent[i].first < nntp_data->newsrc_ent[i].last)
+      if (nntp_data->newsrc_ent[j].first == nntp_data->newsrc_ent[j].last)
+        snprintf(buf + off, buflen - off, "%d", nntp_data->newsrc_ent[j].first);
+      else if (nntp_data->newsrc_ent[j].first < nntp_data->newsrc_ent[j].last)
         snprintf(buf + off, buflen - off, "%d-%d",
-                 nntp_data->newsrc_ent[i].first, nntp_data->newsrc_ent[i].last);
+                 nntp_data->newsrc_ent[j].first, nntp_data->newsrc_ent[j].last);
       off += strlen(buf + off);
     }
     buf[off++] = '\n';

--- a/pager.c
+++ b/pager.c
@@ -1847,7 +1847,6 @@ static void pager_menu_redraw(struct Menu *pager_menu)
 
       NORMAL_COLOR;
       rd->index->pagelen = rd->index_window->rows;
-      ;
 
       /* some fudge to work out whereabouts the indicator should go */
       if (rd->index->current - rd->indicator < 0)

--- a/pager.c
+++ b/pager.c
@@ -2086,10 +2086,10 @@ int mutt_pager(const char *banner, const char *fname, int flags, struct Pager *e
     mutt_set_flag(Context, extra->hdr, MUTT_READ, 1);
   }
 
-  rd.line_info = safe_malloc(sizeof(struct Line) * (rd.max_line = LINES));
+  rd.max_line = LINES; /* number of lines on screen, from curses */
+  rd.line_info = safe_calloc(rd.max_line, sizeof(struct Line));
   for (i = 0; i < rd.max_line; i++)
   {
-    memset(&rd.line_info[i], 0, sizeof(struct Line));
     rd.line_info[i].type = -1;
     rd.line_info[i].search_cnt = -1;
     rd.line_info[i].syntax = safe_malloc(sizeof(struct Syntax));

--- a/pattern.c
+++ b/pattern.c
@@ -1771,9 +1771,9 @@ int mutt_pattern_exec(struct Pattern *pat, enum PatternExecFlag flags,
     case MUTT_BROKEN:
       return (pat->not ^ (h->thread && h->thread->fake_thread));
 #ifdef USE_NNTP
+    case MUTT_NEWSGROUPS:
       if (!h->env)
         return 0;
-    case MUTT_NEWSGROUPS:
       return (pat->not ^ (h->env->newsgroups && patmatch(pat, h->env->newsgroups) == 0));
 #endif
   }

--- a/protos.h
+++ b/protos.h
@@ -234,7 +234,6 @@ void mutt_show_error(void);
 void mutt_signal_init(void);
 void mutt_stamp_attachment(struct Body *a);
 void mutt_tag_set_flag(int flag, int bf);
-bool mutt_ts_capability(void);
 void mutt_unblock_signals(void);
 void mutt_unblock_signals_system(int catch);
 void mutt_update_encoding(struct Body *a);
@@ -259,7 +258,6 @@ int mutt_change_flag(struct Header *h, int bf);
 int mutt_check_encoding(const char *c);
 
 int mutt_check_mime_type(const char *s);
-int mutt_check_month(const char *s);
 int mutt_check_overwrite(const char *attname, const char *path, char *fname,
                          size_t flen, int *append, char **directory);
 int mutt_check_traditional_pgp(struct Header *h, int *redraw);
@@ -371,9 +369,6 @@ uint32_t mutt_rand32(void);
 uint64_t mutt_rand64(void);
 
 struct Address *alias_reverse_lookup(struct Address *a);
-
-/* utf8.c */
-int mutt_wctoutf8(char *s, unsigned int c, size_t buflen);
 
 #ifdef LOCALES_HACK
 #define IsPrint(c) (isprint((unsigned char) (c)) || ((unsigned char) (c) >= 0xa0))

--- a/rfc3676.c
+++ b/rfc3676.c
@@ -276,7 +276,7 @@ int rfc3676_handler(struct Body *a, struct State *s)
 
   memset(&fst, 0, sizeof(fst));
 
-  /* respect DelSp of RfC3676 only with f=f parts */
+  /* respect DelSp of RFC3676 only with f=f parts */
   if ((t = (char *) mutt_get_parameter("delsp", a->parameter)))
   {
     delsp = mutt_strlen(t) == 3 && (mutt_strncasecmp(t, "yes", 3) == 0);

--- a/send.c
+++ b/send.c
@@ -750,7 +750,7 @@ static void make_reference_headers(struct Envelope *curenv,
 
   /* if there's more than entry in In-Reply-To (i.e. message has
      multiple parents), don't generate a References: header as it's
-     discouraged by RfC2822, sect. 3.6.4 */
+     discouraged by RFC2822, sect. 3.6.4 */
   if (ctx->tagged > 0 && !STAILQ_EMPTY(&env->in_reply_to) &&
       STAILQ_NEXT(STAILQ_FIRST(&env->in_reply_to), entries))
     mutt_list_free(&env->references);

--- a/sendlib.c
+++ b/sendlib.c
@@ -1734,7 +1734,7 @@ static int print_val(FILE *fp, const char *pfx, const char *value, int flags, si
     if (fputc(*value, fp) == EOF)
       return -1;
     /* corner-case: break words longer than 998 chars by force,
-     * mandated by RfC5322 */
+     * mandated by RFC5322 */
     if (!(flags & CH_DISPLAY) && ++col >= 998)
     {
       if (fputs("\n ", fp) < 0)


### PR DESCRIPTION
All these changes are small and simple.

- 9300ff9bb move test to the right place
- 48908f241 Remove unnecessary semicolon
- f0404ff60 build: fix shadow variable warning
- b6bfab9bc refactor malloc/calloc
- 9c6eaff7d ignore temporary build files
- fb086fb1a fix copyright messages
- 574826250 fix plain unsigned
- 14b2a1b2c unused prototypes, whitespace
- 6b8388608 Standardise spelling s/RfC/RFC/
- ed750e21f alias drop self
  I cannot see a need for the `self` pointer in the current code.
  I haven't investigated if it was ever needed.