### PR TITLE
Don't start function names with an underscore

### DIFF
--- a/attach.c
+++ b/attach.c
@@ -795,7 +795,7 @@ int mutt_save_attachment(FILE *fp, struct Body *m, char *path, int flags, struct
       if (ctx.magic == MUTT_MBOX || ctx.magic == MUTT_MMDF)
         chflags = CH_FROM | CH_UPDATE_LEN;
       chflags |= (ctx.magic == MUTT_MAILDIR ? CH_NOSTATUS : CH_UPDATE);
-      if (mutt_copy_message(msg->fp, fp, hn, hn->content, 0, chflags) == 0 &&
+      if (mutt_copy_message_fp(msg->fp, fp, hn, 0, chflags) == 0 &&
           mx_commit_message(msg, &ctx) == 0)
         r = 0;
       else

--- a/attach.c
+++ b/attach.c
@@ -795,7 +795,7 @@ int mutt_save_attachment(FILE *fp, struct Body *m, char *path, int flags, struct
       if (ctx.magic == MUTT_MBOX || ctx.magic == MUTT_MMDF)
         chflags = CH_FROM | CH_UPDATE_LEN;
       chflags |= (ctx.magic == MUTT_MAILDIR ? CH_NOSTATUS : CH_UPDATE);
-      if (_mutt_copy_message(msg->fp, fp, hn, hn->content, 0, chflags) == 0 &&
+      if (mutt_copy_message(msg->fp, fp, hn, hn->content, 0, chflags) == 0 &&
           mx_commit_message(msg, &ctx) == 0)
         r = 0;
       else

--- a/browser.c
+++ b/browser.c
@@ -1066,7 +1066,7 @@ void mutt_browser_select_dir(char *f)
   mutt_get_parent_path(LastDir, OldLastDir, sizeof(LastDir));
 }
 
-void _mutt_select_file(char *f, size_t flen, int flags, char ***files, int *numfiles)
+void mutt_select_file(char *f, size_t flen, int flags, char ***files, int *numfiles)
 {
   char buf[_POSIX_PATH_MAX];
   char prefix[_POSIX_PATH_MAX] = "";

--- a/color.c
+++ b/color.c
@@ -484,14 +484,14 @@ static void do_uncolor(struct Buffer *buf, struct Buffer *s,
 }
 
 /**
- * _mutt_parse_uncolor - Parse an 'uncolor' command
+ * parse_uncolor - Parse an 'uncolor' command
  *
  * usage:
  * * uncolor index pattern [pattern...]
  * * unmono  index pattern [pattern...]
  */
-static int _mutt_parse_uncolor(struct Buffer *buf, struct Buffer *s, unsigned long data,
-                               struct Buffer *err, short parse_uncolor)
+static int parse_uncolor(struct Buffer *buf, struct Buffer *s, unsigned long data,
+                         struct Buffer *err, short parse_uncolor)
 {
   int object = 0, do_cache = 0;
 
@@ -581,7 +581,7 @@ static int _mutt_parse_uncolor(struct Buffer *buf, struct Buffer *s, unsigned lo
 int mutt_parse_uncolor(struct Buffer *buf, struct Buffer *s, unsigned long data,
                        struct Buffer *err)
 {
-  return _mutt_parse_uncolor(buf, s, data, err, 1);
+  return parse_uncolor(buf, s, data, err, 1);
 }
 
 #endif
@@ -589,7 +589,7 @@ int mutt_parse_uncolor(struct Buffer *buf, struct Buffer *s, unsigned long data,
 int mutt_parse_unmono(struct Buffer *buf, struct Buffer *s, unsigned long data,
                       struct Buffer *err)
 {
-  return _mutt_parse_uncolor(buf, s, data, err, 0);
+  return parse_uncolor(buf, s, data, err, 0);
 }
 
 static int add_pattern(struct ColorLineHead *top, const char *s, int sensitive, int fg,
@@ -814,13 +814,13 @@ static int fgbgattr_to_color(int fg, int bg, int attr)
 }
 
 /**
- * _mutt_parse_color - Parse a "color" command
+ * parse_color - Parse a "color" command
  *
  * usage: color OBJECT FG BG [ REGEX ]
  *        mono  OBJECT ATTR [ REGEX ]
  */
-static int _mutt_parse_color(struct Buffer *buf, struct Buffer *s, struct Buffer *err,
-                             parser_callback_t callback, bool dry_run)
+static int parse_color(struct Buffer *buf, struct Buffer *s, struct Buffer *err,
+                       parser_callback_t callback, bool dry_run)
 {
   int object = 0, attr = 0, fg = 0, bg = 0, q_level = 0;
   int r = 0, match = 0;
@@ -980,7 +980,7 @@ int mutt_parse_color(struct Buffer *buff, struct Buffer *s, unsigned long data,
   if (option(OPT_NO_CURSES) || !has_colors())
     dry_run = true;
 
-  return _mutt_parse_color(buff, s, err, parse_color_pair, dry_run);
+  return parse_color(buff, s, err, parse_color_pair, dry_run);
 }
 
 #endif
@@ -998,5 +998,5 @@ int mutt_parse_mono(struct Buffer *buff, struct Buffer *s, unsigned long data,
     dry_run = true;
 #endif
 
-  return _mutt_parse_color(buff, s, err, parse_attr_spec, dry_run);
+  return parse_color(buff, s, err, parse_attr_spec, dry_run);
 }

--- a/commands.c
+++ b/commands.c
@@ -167,7 +167,7 @@ int mutt_display_message(struct Header *cur)
   if (Context->magic == MUTT_NOTMUCH)
     chflags |= CH_VIRTUAL;
 #endif
-  res = mutt_open_copy_message(fpout, Context, cur, cmflags, chflags);
+  res = mutt_copy_message_ctx(fpout, Context, cur, cmflags, chflags);
 
   if ((safe_fclose(&fpout) != 0 && errno != EPIPE) || res < 0)
   {
@@ -384,7 +384,7 @@ static void pipe_msg(struct Header *h, FILE *fp, int decode, int print)
   if (decode)
     mutt_parse_mime_message(Context, h);
 
-  mutt_open_copy_message(fp, Context, h, cmflags, chflags);
+  mutt_copy_message_ctx(fp, Context, h, cmflags, chflags);
 }
 
 /**

--- a/commands.c
+++ b/commands.c
@@ -388,12 +388,12 @@ static void pipe_msg(struct Header *h, FILE *fp, int decode, int print)
 }
 
 /**
- * _mutt_pipe_message - Pipe message to a command
+ * pipe_message - Pipe message to a command
  *
  * The following code is shared between printing and piping.
  */
-static int _mutt_pipe_message(struct Header *h, char *cmd, int decode,
-                              int print, int split, char *sep)
+static int pipe_message(struct Header *h, char *cmd, int decode, int print,
+                        int split, char *sep)
 {
   int rc = 0;
   pid_t thepid;
@@ -513,7 +513,7 @@ void mutt_pipe_message(struct Header *h)
     return;
 
   mutt_expand_path(buffer, sizeof(buffer));
-  _mutt_pipe_message(h, buffer, option(OPT_PIPE_DECODE), 0, option(OPT_PIPE_SPLIT), PipeSep);
+  pipe_message(h, buffer, option(OPT_PIPE_DECODE), 0, option(OPT_PIPE_SPLIT), PipeSep);
 }
 
 void mutt_print_message(struct Header *h)
@@ -528,8 +528,8 @@ void mutt_print_message(struct Header *h)
                        h ? _("Print message?") : _("Print tagged messages?")) != MUTT_YES)
     return;
 
-  if (_mutt_pipe_message(h, PrintCommand, option(OPT_PRINT_DECODE), 1,
-                         option(OPT_PRINT_SPLIT), "\f") == 0)
+  if (pipe_message(h, PrintCommand, option(OPT_PRINT_DECODE), 1,
+                   option(OPT_PRINT_SPLIT), "\f") == 0)
     mutt_message(h ? _("Message printed") : _("Messages printed"));
   else
     mutt_message(h ? _("Message could not be printed") :
@@ -1053,7 +1053,7 @@ int mutt_edit_content_type(struct Header *h, struct Body *b, FILE *fp)
   return structure_changed;
 }
 
-static int _mutt_check_traditional_pgp(struct Header *h, int *redraw)
+static int check_traditional_pgp(struct Header *h, int *redraw)
 {
   struct Message *msg = NULL;
   int rv = 0;
@@ -1080,14 +1080,14 @@ int mutt_check_traditional_pgp(struct Header *h, int *redraw)
 {
   int rv = 0;
   if (h && !(h->security & PGP_TRADITIONAL_CHECKED))
-    rv = _mutt_check_traditional_pgp(h, redraw);
+    rv = check_traditional_pgp(h, redraw);
   else
   {
     for (int i = 0; i < Context->msgcount; i++)
     {
       if (message_is_tagged(Context, i) && !(Context->hdrs[i]->security & PGP_TRADITIONAL_CHECKED))
       {
-        rv = _mutt_check_traditional_pgp(Context->hdrs[i], redraw) || rv;
+        rv = check_traditional_pgp(Context->hdrs[i], redraw) || rv;
       }
     }
   }

--- a/compose.c
+++ b/compose.c
@@ -1017,8 +1017,8 @@ int mutt_compose_menu(struct Header *msg, /* structure for new message */
         numfiles = 0;
         files = NULL;
 
-        if (_mutt_enter_fname(prompt, fname, sizeof(fname), 0, 1, &files,
-                              &numfiles, MUTT_SEL_MULTI) == -1 ||
+        if (mutt_enter_fname_full(prompt, fname, sizeof(fname), 0, 1, &files,
+                                  &numfiles, MUTT_SEL_MULTI) == -1 ||
             *fname == '\0')
           break;
 

--- a/copy.c
+++ b/copy.c
@@ -523,7 +523,7 @@ static int count_delete_lines(FILE *fp, struct Body *b, LOFF_T *length, size_t d
 }
 
 /**
- * mutt_copy_message - make a copy of a message
+ * mutt_copy_message_fp - make a copy of a message from a FILE pointer
  * @param fpout   Where to write output
  * @param fpin    Where to get input
  * @param hdr     Header of message being copied
@@ -540,9 +540,10 @@ static int count_delete_lines(FILE *fp, struct Body *b, LOFF_T *length, size_t d
  * * #MUTT_CM_DECODE_PGP used for decoding PGP messages
  * * #MUTT_CM_CHARCONV   perform character set conversion
  */
-int mutt_copy_message(FILE *fpout, FILE *fpin, struct Header *hdr,
-                      struct Body *body, int flags, int chflags)
+int mutt_copy_message_fp(FILE *fpout, FILE *fpin, struct Header *hdr, int flags,
+                      int chflags)
 {
+  struct Body *body = hdr->content;
   char prefix[SHORT_STRING];
   struct State s;
   LOFF_T new_offset = -1;
@@ -743,13 +744,13 @@ int mutt_copy_message(FILE *fpout, FILE *fpin, struct Header *hdr,
 }
 
 /**
- * mutt_open_copy_message - Copy a message
+ * mutt_copy_message_ctx - Copy a message from a Context
  *
  * should be made to return -1 on fatal errors, and 1 on non-fatal errors
  * like partial decode, where it is worth displaying as much as possible
  */
-int mutt_open_copy_message(FILE *fpout, struct Context *src, struct Header *hdr,
-                           int flags, int chflags)
+int mutt_copy_message_ctx(FILE *fpout, struct Context *src, struct Header *hdr,
+                          int flags, int chflags)
 {
   struct Message *msg = NULL;
   int r;
@@ -757,7 +758,7 @@ int mutt_open_copy_message(FILE *fpout, struct Context *src, struct Header *hdr,
   msg = mx_open_message(src, hdr->msgno);
   if (!msg)
     return -1;
-  if ((r = mutt_copy_message(fpout, msg->fp, hdr, hdr->content, flags, chflags)) == 0 &&
+  if ((r = mutt_copy_message_fp(fpout, msg->fp, hdr, flags, chflags)) == 0 &&
       (ferror(fpout) || feof(fpout)))
   {
     mutt_debug(1, "mutt_copy_message failed to detect EOF!\n");
@@ -780,7 +781,7 @@ int mutt_open_copy_message(FILE *fpout, struct Context *src, struct Header *hdr,
  * @retval -1 on error
  */
 static int append_message(struct Context *dest, FILE *fpin, struct Context *src,
-                          struct Header *hdr, struct Body *body, int flags, int chflags)
+                          struct Header *hdr, int flags, int chflags)
 {
   char buf[STRING];
   struct Message *msg = NULL;
@@ -797,7 +798,7 @@ static int append_message(struct Context *dest, FILE *fpin, struct Context *src,
   if (dest->magic == MUTT_MBOX || dest->magic == MUTT_MMDF)
     chflags |= CH_FROM | CH_FORCE_FROM;
   chflags |= (dest->magic == MUTT_MAILDIR ? CH_NOSTATUS : CH_UPDATE);
-  r = mutt_copy_message(msg->fp, fpin, hdr, body, flags, chflags);
+  r = mutt_copy_message_fp(msg->fp, fpin, hdr, flags, chflags);
   if (mx_commit_message(msg, dest) != 0)
     r = -1;
 
@@ -819,7 +820,7 @@ int mutt_append_message(struct Context *dest, struct Context *src,
   msg = mx_open_message(src, hdr->msgno);
   if (!msg)
     return -1;
-  r = append_message(dest, msg->fp, src, hdr, hdr->content, cmflags, chflags);
+  r = append_message(dest, msg->fp, src, hdr, cmflags, chflags);
   mx_close_message(src, &msg);
   return r;
 }

--- a/copy.c
+++ b/copy.c
@@ -768,7 +768,7 @@ int mutt_copy_message(FILE *fpout, struct Context *src, struct Header *hdr,
 }
 
 /**
- * _mutt_append_message - appends a copy of the given message to a mailbox
+ * append_message - appends a copy of the given message to a mailbox
  * @param dest    destination mailbox
  * @param fpin    where to get input
  * @param src     source mailbox
@@ -779,9 +779,8 @@ int mutt_copy_message(FILE *fpout, struct Context *src, struct Header *hdr,
  * @retval 0 on success
  * @retval -1 on error
  */
-static int _mutt_append_message(struct Context *dest, FILE *fpin,
-                                struct Context *src, struct Header *hdr,
-                                struct Body *body, int flags, int chflags)
+static int append_message(struct Context *dest, FILE *fpin, struct Context *src,
+                          struct Header *hdr, struct Body *body, int flags, int chflags)
 {
   char buf[STRING];
   struct Message *msg = NULL;
@@ -820,7 +819,7 @@ int mutt_append_message(struct Context *dest, struct Context *src,
   msg = mx_open_message(src, hdr->msgno);
   if (!msg)
     return -1;
-  r = _mutt_append_message(dest, msg->fp, src, hdr, hdr->content, cmflags, chflags);
+  r = append_message(dest, msg->fp, src, hdr, hdr->content, cmflags, chflags);
   mx_close_message(src, &msg);
   return r;
 }

--- a/copy.c
+++ b/copy.c
@@ -523,7 +523,7 @@ static int count_delete_lines(FILE *fp, struct Body *b, LOFF_T *length, size_t d
 }
 
 /**
- * _mutt_copy_message - make a copy of a message
+ * mutt_copy_message - make a copy of a message
  * @param fpout   Where to write output
  * @param fpin    Where to get input
  * @param hdr     Header of message being copied
@@ -540,8 +540,8 @@ static int count_delete_lines(FILE *fp, struct Body *b, LOFF_T *length, size_t d
  * * #MUTT_CM_DECODE_PGP used for decoding PGP messages
  * * #MUTT_CM_CHARCONV   perform character set conversion
  */
-int _mutt_copy_message(FILE *fpout, FILE *fpin, struct Header *hdr,
-                       struct Body *body, int flags, int chflags)
+int mutt_copy_message(FILE *fpout, FILE *fpin, struct Header *hdr,
+                      struct Body *body, int flags, int chflags)
 {
   char prefix[SHORT_STRING];
   struct State s;
@@ -553,7 +553,7 @@ int _mutt_copy_message(FILE *fpout, FILE *fpin, struct Header *hdr,
     if (option(OPT_TEXT_FLOWED))
       strfcpy(prefix, ">", sizeof(prefix));
     else
-      _mutt_make_string(prefix, sizeof(prefix), NONULL(IndentString), Context, hdr, 0);
+      mutt_make_string_flags(prefix, sizeof(prefix), NONULL(IndentString), Context, hdr, 0);
   }
 
   if (hdr->xlabel_changed)
@@ -743,13 +743,13 @@ int _mutt_copy_message(FILE *fpout, FILE *fpin, struct Header *hdr,
 }
 
 /**
- * mutt_copy_message - Copy a message
+ * mutt_open_copy_message - Copy a message
  *
  * should be made to return -1 on fatal errors, and 1 on non-fatal errors
  * like partial decode, where it is worth displaying as much as possible
  */
-int mutt_copy_message(FILE *fpout, struct Context *src, struct Header *hdr,
-                      int flags, int chflags)
+int mutt_open_copy_message(FILE *fpout, struct Context *src, struct Header *hdr,
+                           int flags, int chflags)
 {
   struct Message *msg = NULL;
   int r;
@@ -757,10 +757,10 @@ int mutt_copy_message(FILE *fpout, struct Context *src, struct Header *hdr,
   msg = mx_open_message(src, hdr->msgno);
   if (!msg)
     return -1;
-  if ((r = _mutt_copy_message(fpout, msg->fp, hdr, hdr->content, flags, chflags)) == 0 &&
+  if ((r = mutt_copy_message(fpout, msg->fp, hdr, hdr->content, flags, chflags)) == 0 &&
       (ferror(fpout) || feof(fpout)))
   {
-    mutt_debug(1, "_mutt_copy_message failed to detect EOF!\n");
+    mutt_debug(1, "mutt_copy_message failed to detect EOF!\n");
     r = -1;
   }
   mx_close_message(src, &msg);
@@ -774,7 +774,7 @@ int mutt_copy_message(FILE *fpout, struct Context *src, struct Header *hdr,
  * @param src     source mailbox
  * @param hdr     message being copied
  * @param body    structure of message being copied
- * @param flags   mutt_copy_message() flags
+ * @param flags   mutt_open_copy_message() flags
  * @param chflags mutt_copy_header() flags
  * @retval 0 on success
  * @retval -1 on error
@@ -797,7 +797,7 @@ static int append_message(struct Context *dest, FILE *fpin, struct Context *src,
   if (dest->magic == MUTT_MBOX || dest->magic == MUTT_MMDF)
     chflags |= CH_FROM | CH_FORCE_FROM;
   chflags |= (dest->magic == MUTT_MAILDIR ? CH_NOSTATUS : CH_UPDATE);
-  r = _mutt_copy_message(msg->fp, fpin, hdr, body, flags, chflags);
+  r = mutt_copy_message(msg->fp, fpin, hdr, body, flags, chflags);
   if (mx_commit_message(msg, dest) != 0)
     r = -1;
 

--- a/copy.h
+++ b/copy.h
@@ -72,10 +72,8 @@ int mutt_copy_hdr(FILE *in, FILE *out, LOFF_T off_start, LOFF_T off_end,
 
 int mutt_copy_header(FILE *in, struct Header *h, FILE *out, int flags, const char *prefix);
 
-int mutt_copy_message(FILE *fpout, FILE *fpin, struct Header *hdr, struct Body *body,
-                       int flags, int chflags);
-
-int mutt_open_copy_message(FILE *fpout, struct Context *src, struct Header *hdr, int flags, int chflags);
+int mutt_copy_message_fp (FILE *fpout, FILE *fpin,          struct Header *hdr, int flags, int chflags);
+int mutt_copy_message_ctx(FILE *fpout, struct Context *src, struct Header *hdr, int flags, int chflags);
 
 int mutt_append_message(struct Context *dest, struct Context *src, struct Header *hdr, int cmflags, int chflags);
 

--- a/copy.h
+++ b/copy.h
@@ -29,7 +29,7 @@ struct Body;
 struct Header;
 struct Context;
 
-/**< flags to _mutt_copy_message */
+/**< flags to mutt_copy_message */
 #define MUTT_CM_NOHEADER     (1 << 0) /**< don't copy the message header */
 #define MUTT_CM_PREFIX       (1 << 1) /**< quote the message */
 #define MUTT_CM_DECODE       (1 << 2) /**< decode the message body into text/plain */
@@ -72,10 +72,10 @@ int mutt_copy_hdr(FILE *in, FILE *out, LOFF_T off_start, LOFF_T off_end,
 
 int mutt_copy_header(FILE *in, struct Header *h, FILE *out, int flags, const char *prefix);
 
-int _mutt_copy_message(FILE *fpout, FILE *fpin, struct Header *hdr, struct Body *body,
+int mutt_copy_message(FILE *fpout, FILE *fpin, struct Header *hdr, struct Body *body,
                        int flags, int chflags);
 
-int mutt_copy_message(FILE *fpout, struct Context *src, struct Header *hdr, int flags, int chflags);
+int mutt_open_copy_message(FILE *fpout, struct Context *src, struct Header *hdr, int flags, int chflags);
 
 int mutt_append_message(struct Context *dest, struct Context *src, struct Header *hdr, int cmflags, int chflags);
 

--- a/curs_lib.c
+++ b/curs_lib.c
@@ -176,8 +176,8 @@ struct Event mutt_getch(void)
   return (ch == ctrl('G') ? err : ret);
 }
 
-int _mutt_get_field(const char *field, char *buf, size_t buflen, int complete,
-                    int multiple, char ***files, int *numfiles)
+int mutt_get_field_full(const char *field, char *buf, size_t buflen,
+                        int complete, int multiple, char ***files, int *numfiles)
 {
   int ret;
   int x;
@@ -201,7 +201,7 @@ int _mutt_get_field(const char *field, char *buf, size_t buflen, int complete,
     NORMAL_COLOR;
     mutt_refresh();
     mutt_window_getyx(MuttMessageWindow, NULL, &x);
-    ret = _mutt_enter_string(buf, buflen, x, complete, multiple, files, numfiles, es);
+    ret = mutt_enter_string_full(buf, buflen, x, complete, multiple, files, numfiles, es);
   } while (ret == 1);
   mutt_window_clearline(MuttMessageWindow, 0);
   mutt_free_enter_state(&es);
@@ -896,8 +896,8 @@ int mutt_do_pager(const char *banner, const char *tempfile, int do_color, struct
   return rc;
 }
 
-int _mutt_enter_fname(const char *prompt, char *buf, size_t blen, int buffy,
-                      int multiple, char ***files, int *numfiles, int flags)
+int mutt_enter_fname_full(const char *prompt, char *buf, size_t blen, int buffy,
+                          int multiple, char ***files, int *numfiles, int flags)
 {
   struct Event ch;
 
@@ -927,7 +927,7 @@ int _mutt_enter_fname(const char *prompt, char *buf, size_t blen, int buffy,
       flags |= MUTT_SEL_MULTI;
     if (buffy)
       flags |= MUTT_SEL_BUFFY;
-    _mutt_select_file(buf, blen, flags, files, numfiles);
+    mutt_select_file(buf, blen, flags, files, numfiles);
   }
   else
   {
@@ -935,8 +935,8 @@ int _mutt_enter_fname(const char *prompt, char *buf, size_t blen, int buffy,
 
     sprintf(pc, "%s: ", prompt);
     mutt_unget_event(ch.op ? 0 : ch.ch, ch.op ? ch.op : 0);
-    if (_mutt_get_field(pc, buf, blen, (buffy ? MUTT_EFILE : MUTT_FILE) | MUTT_CLEAR,
-                        multiple, files, numfiles) != 0)
+    if (mutt_get_field_full(pc, buf, blen, (buffy ? MUTT_EFILE : MUTT_FILE) | MUTT_CLEAR,
+                            multiple, files, numfiles) != 0)
       buf[0] = '\0';
     FREE(&pc);
 #ifdef USE_NOTMUCH

--- a/curs_main.c
+++ b/curs_main.c
@@ -655,7 +655,7 @@ void index_make_entry(char *s, size_t l, struct Menu *menu, int num)
     }
   }
 
-  _mutt_make_string(s, l, NONULL(IndexFormat), Context, h, flag);
+  mutt_make_string_flags(s, l, NONULL(IndexFormat), Context, h, flag);
 }
 
 int index_color(int index_no)

--- a/enter.c
+++ b/enter.c
@@ -40,7 +40,7 @@
 #include "protos.h"
 
 /**
- * enum RedrawFlags - redraw flags for mutt_enter_string()
+ * enum RedrawFlags - redraw flags for mutt_enter_string_full()
  */
 enum RedrawFlags
 {
@@ -251,14 +251,14 @@ int mutt_enter_string(char *buf, size_t buflen, int col, int flags)
       clearok(stdscr, TRUE);
     }
 #endif
-    rv = _mutt_enter_string(buf, buflen, col, flags, 0, NULL, NULL, es);
+    rv = mutt_enter_string_full(buf, buflen, col, flags, 0, NULL, NULL, es);
   } while (rv == 1);
   mutt_free_enter_state(&es);
   return rv;
 }
 
 /**
- * _mutt_enter_string - Ask the user for a string
+ * mutt_enter_string_full - Ask the user for a string
  * @param[in]  buf      Buffer to store the string
  * @param[in]  buflen   Buffer length
  * @param[in]  col      Initial cursor position
@@ -271,8 +271,8 @@ int mutt_enter_string(char *buf, size_t buflen, int col, int flags)
  * @retval 0  if input was given
  * @retval -1 if abort
  */
-int _mutt_enter_string(char *buf, size_t buflen, int col, int flags, int multiple,
-                       char ***files, int *numfiles, struct EnterState *state)
+int mutt_enter_string_full(char *buf, size_t buflen, int col, int flags, int multiple,
+                      char ***files, int *numfiles, struct EnterState *state)
 {
   int width = MuttMessageWindow->cols - col - 1;
   int redraw;
@@ -591,7 +591,8 @@ int _mutt_enter_string(char *buf, size_t buflen, int col, int flags, int multipl
             if (tempbuf && templen == state->lastchar - i &&
                 !memcmp(tempbuf, state->wbuf + i, (state->lastchar - i) * sizeof(wchar_t)))
             {
-              mutt_select_file(buf, buflen, (flags & MUTT_EFILE) ? MUTT_SEL_FOLDER : 0);
+              mutt_select_file(buf, buflen,
+                               (flags & MUTT_EFILE) ? MUTT_SEL_FOLDER : 0, NULL, NULL);
               if (*buf)
                 replace_part(state, i, buf);
               rv = 1;
@@ -698,10 +699,10 @@ int _mutt_enter_string(char *buf, size_t buflen, int col, int flags, int multipl
                 (tempbuf && templen == state->lastchar &&
                  !memcmp(tempbuf, state->wbuf, state->lastchar * sizeof(wchar_t))))
             {
-              _mutt_select_file(buf, buflen,
-                                ((flags & MUTT_EFILE) ? MUTT_SEL_FOLDER : 0) |
-                                    (multiple ? MUTT_SEL_MULTI : 0),
-                                files, numfiles);
+              mutt_select_file(buf, buflen,
+                               ((flags & MUTT_EFILE) ? MUTT_SEL_FOLDER : 0) |
+                                   (multiple ? MUTT_SEL_MULTI : 0),
+                               files, numfiles);
               if (*buf)
               {
                 mutt_pretty_mailbox(buf, buflen);

--- a/flags.c
+++ b/flags.c
@@ -36,7 +36,7 @@
 #include "sort.h"
 #include "thread.h"
 
-void _mutt_set_flag(struct Context *ctx, struct Header *h, int flag, int bf, int upd_ctx)
+void mutt_set_flag_update(struct Context *ctx, struct Header *h, int flag, int bf, int upd_ctx)
 {
   if (!ctx || !h)
     return;

--- a/hdrline.c
+++ b/hdrline.c
@@ -1385,8 +1385,8 @@ static const char *hdr_format_str(char *dest, size_t destlen, size_t col, int co
   return src;
 }
 
-void _mutt_make_string(char *dest, size_t destlen, const char *s,
-                       struct Context *ctx, struct Header *hdr, enum FormatFlag flags)
+void mutt_make_string_flags(char *dest, size_t destlen, const char *s,
+                            struct Context *ctx, struct Header *hdr, enum FormatFlag flags)
 {
   struct HdrFormatInfo hfi;
 

--- a/hook.c
+++ b/hook.c
@@ -500,7 +500,7 @@ void mutt_select_fcc(char *path, size_t pathlen, struct Header *hdr)
   mutt_pretty_mailbox(path, pathlen);
 }
 
-static char *_mutt_string_hook(const char *match, int hook)
+static char *string_hook(const char *match, int hook)
 {
   struct Hook *tmp = NULL;
 
@@ -513,7 +513,7 @@ static char *_mutt_string_hook(const char *match, int hook)
   return NULL;
 }
 
-static void _mutt_list_hook(struct ListHead *matches, const char *match, int hook)
+static void list_hook(struct ListHead *matches, const char *match, int hook)
 {
   struct Hook *tmp = NULL;
 
@@ -527,17 +527,17 @@ static void _mutt_list_hook(struct ListHead *matches, const char *match, int hoo
 
 char *mutt_charset_hook(const char *chs)
 {
-  return _mutt_string_hook(chs, MUTT_CHARSETHOOK);
+  return string_hook(chs, MUTT_CHARSETHOOK);
 }
 
 char *mutt_iconv_hook(const char *chs)
 {
-  return _mutt_string_hook(chs, MUTT_ICONVHOOK);
+  return string_hook(chs, MUTT_ICONVHOOK);
 }
 
 void mutt_crypt_hook(struct ListHead *list, struct Address *adr)
 {
-  _mutt_list_hook(list, adr->mailbox, MUTT_CRYPTHOOK);
+  list_hook(list, adr->mailbox, MUTT_CRYPTHOOK);
 }
 
 #ifdef USE_SOCKET

--- a/hook.c
+++ b/hook.c
@@ -121,7 +121,7 @@ int mutt_parse_hook(struct Buffer *buf, struct Buffer *s, unsigned long data,
     }
 
     strfcpy(path, pattern.data, sizeof(path));
-    _mutt_expand_path(path, sizeof(path), 1);
+    mutt_expand_path_regex(path, sizeof(path), 1);
 
     /* Check for other mailbox shortcuts that expand to the empty string.
      * This is likely a mistake too */

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -2485,7 +2485,7 @@ int imap_sync_mailbox(struct Context *ctx, int expunge)
           mutt_debug(
               1, "imap_sync_mailbox: Error opening mailbox in append mode\n");
         else
-          _mutt_save_message(h, appendctx, 1, 0, 0);
+          mutt_save_message_ctx(h, 1, 0, 0, appendctx);
         h->xlabel_changed = false;
       }
     }

--- a/init.c
+++ b/init.c
@@ -1149,7 +1149,7 @@ static int parse_unstailq(struct Buffer *buf, struct Buffer *s,
   return 0;
 }
 
-static void _alternates_clean(void)
+static void alternates_clean(void)
 {
   if (Context && Context->msgcount)
   {
@@ -1163,7 +1163,7 @@ static int parse_alternates(struct Buffer *buf, struct Buffer *s,
 {
   struct GroupContext *gc = NULL;
 
-  _alternates_clean();
+  alternates_clean();
 
   do
   {
@@ -1192,7 +1192,7 @@ bail:
 static int parse_unalternates(struct Buffer *buf, struct Buffer *s,
                               unsigned long data, struct Buffer *err)
 {
-  _alternates_clean();
+  alternates_clean();
   do
   {
     mutt_extract_token(buf, s, 0);
@@ -1528,9 +1528,9 @@ bail:
 }
 
 /**
- * _attachments_clean - always wise to do what someone else did before
+ * attachments_clean - always wise to do what someone else did before
  */
-static void _attachments_clean(void)
+static void attachments_clean(void)
 {
   if (Context && Context->msgcount)
   {
@@ -1601,7 +1601,7 @@ static int parse_attach_list(struct Buffer *buf, struct Buffer *s,
     mutt_list_insert_tail(head, (char *) a);
   } while (MoreArgs(s));
 
-  _attachments_clean();
+  attachments_clean();
   return 0;
 }
 
@@ -1657,7 +1657,7 @@ static int parse_unattach_list(struct Buffer *buf, struct Buffer *s,
   } while (MoreArgs(s));
 
   FREE(&tmp);
-  _attachments_clean();
+  attachments_clean();
   return 0;
 }
 

--- a/main.c
+++ b/main.c
@@ -882,7 +882,7 @@ int main(int argc, char **argv, char **env)
         exit(1);
       }
       folder[0] = 0;
-      mutt_select_file(folder, sizeof(folder), MUTT_SEL_FOLDER | MUTT_SEL_BUFFY);
+      mutt_select_file(folder, sizeof(folder), MUTT_SEL_FOLDER | MUTT_SEL_BUFFY, NULL, NULL);
       if (!folder[0])
       {
         mutt_endwin(NULL);

--- a/mbox.c
+++ b/mbox.c
@@ -1167,7 +1167,7 @@ static int mbox_sync_mailbox(struct Context *ctx, int *index_hint)
        */
       newOffset[i - first].hdr = ftello(fp) + offset;
 
-      if (mutt_open_copy_message(fp, ctx, ctx->hdrs[i], MUTT_CM_UPDATE,
+      if (mutt_copy_message_ctx(fp, ctx, ctx->hdrs[i], MUTT_CM_UPDATE,
                                  CH_FROM | CH_UPDATE | CH_UPDATE_LEN) != 0)
       {
         mutt_perror(tempfile);

--- a/mbox.c
+++ b/mbox.c
@@ -1167,8 +1167,8 @@ static int mbox_sync_mailbox(struct Context *ctx, int *index_hint)
        */
       newOffset[i - first].hdr = ftello(fp) + offset;
 
-      if (mutt_copy_message(fp, ctx, ctx->hdrs[i], MUTT_CM_UPDATE,
-                            CH_FROM | CH_UPDATE | CH_UPDATE_LEN) != 0)
+      if (mutt_open_copy_message(fp, ctx, ctx->hdrs[i], MUTT_CM_UPDATE,
+                                 CH_FROM | CH_UPDATE | CH_UPDATE_LEN) != 0)
       {
         mutt_perror(tempfile);
         mutt_sleep(5);

--- a/mh.c
+++ b/mh.c
@@ -1767,7 +1767,7 @@ static int mh_rewrite_message(struct Context *ctx, int msgno)
   if (!dest)
     return -1;
 
-  rc = mutt_copy_message(dest->fp, ctx, h, MUTT_CM_UPDATE, CH_UPDATE | CH_UPDATE_LEN);
+  rc = mutt_open_copy_message(dest->fp, ctx, h, MUTT_CM_UPDATE, CH_UPDATE | CH_UPDATE_LEN);
   if (rc == 0)
   {
     snprintf(oldpath, _POSIX_PATH_MAX, "%s/%s", ctx->path, h->path);

--- a/mh.c
+++ b/mh.c
@@ -1767,7 +1767,7 @@ static int mh_rewrite_message(struct Context *ctx, int msgno)
   if (!dest)
     return -1;
 
-  rc = mutt_open_copy_message(dest->fp, ctx, h, MUTT_CM_UPDATE, CH_UPDATE | CH_UPDATE_LEN);
+  rc = mutt_copy_message_ctx(dest->fp, ctx, h, MUTT_CM_UPDATE, CH_UPDATE | CH_UPDATE_LEN);
   if (rc == 0)
   {
     snprintf(oldpath, _POSIX_PATH_MAX, "%s/%s", ctx->path, h->path);

--- a/mutt.h
+++ b/mutt.h
@@ -57,7 +57,7 @@ struct Mapping;
 #define fgetc fgetc_unlocked
 #endif
 
-/* flags for mutt_enter_string() */
+/* flags for mutt_enter_string_full() */
 #define MUTT_ALIAS    (1 << 0)  /**< do alias "completion" by calling up the alias-menu */
 #define MUTT_FILE     (1 << 1)  /**< do file completion */
 #define MUTT_EFILE    (1 << 2)  /**< do file completion, plus incoming folders */
@@ -293,7 +293,7 @@ enum QuadOptionVars
 /* flags for mutt_compose_menu() */
 #define MUTT_COMPOSE_NOFREEHEADER (1 << 0)
 
-/* flags to _mutt_select_file() */
+/* flags to mutt_select_file() */
 #define MUTT_SEL_BUFFY   (1 << 0)
 #define MUTT_SEL_MULTI   (1 << 1)
 #define MUTT_SEL_FOLDER  (1 << 2)

--- a/muttlib.c
+++ b/muttlib.c
@@ -187,10 +187,10 @@ bool mutt_matches_ignore(const char *s)
 
 char *mutt_expand_path(char *s, size_t slen)
 {
-  return _mutt_expand_path(s, slen, 0);
+  return mutt_expand_path_regex(s, slen, 0);
 }
 
-char *_mutt_expand_path(char *s, size_t slen, int regex)
+char *mutt_expand_path_regex(char *s, size_t slen, int regex)
 {
   char p[_POSIX_PATH_MAX] = "";
   char q[_POSIX_PATH_MAX] = "";
@@ -528,8 +528,8 @@ uint64_t mutt_rand64(void)
   return ret;
 }
 
-void _mutt_mktemp(char *s, size_t slen, const char *prefix, const char *suffix,
-                  const char *src, int line)
+void mutt_mktemp_full(char *s, size_t slen, const char *prefix,
+                      const char *suffix, const char *src, int line)
 {
   size_t n = snprintf(s, slen, "%s/%s-%s-%d-%d-%" PRIu64 "%s%s", NONULL(Tmpdir),
                       NONULL(prefix), NONULL(ShortHostname), (int) getuid(),

--- a/ncrypt/crypt.c
+++ b/ncrypt/crypt.c
@@ -724,7 +724,7 @@ void crypt_extract_keys_from_messages(struct Header *h)
 
       if ((WithCrypto & APPLICATION_PGP) && (hi->security & APPLICATION_PGP))
       {
-        mutt_copy_message(fpout, Context, hi, MUTT_CM_DECODE | MUTT_CM_CHARCONV, 0);
+        mutt_open_copy_message(fpout, Context, hi, MUTT_CM_DECODE | MUTT_CM_CHARCONV, 0);
         fflush(fpout);
 
         mutt_endwin(_("Trying to extract PGP keys...\n"));
@@ -734,11 +734,11 @@ void crypt_extract_keys_from_messages(struct Header *h)
       if ((WithCrypto & APPLICATION_SMIME) && (hi->security & APPLICATION_SMIME))
       {
         if (hi->security & ENCRYPT)
-          mutt_copy_message(fpout, Context, hi,
-                            MUTT_CM_NOHEADER | MUTT_CM_DECODE_CRYPT | MUTT_CM_DECODE_SMIME,
-                            0);
+          mutt_open_copy_message(fpout, Context, hi,
+                                 MUTT_CM_NOHEADER | MUTT_CM_DECODE_CRYPT | MUTT_CM_DECODE_SMIME,
+                                 0);
         else
-          mutt_copy_message(fpout, Context, hi, 0, 0);
+          mutt_open_copy_message(fpout, Context, hi, 0, 0);
         fflush(fpout);
 
         if (hi->env->from)
@@ -764,7 +764,7 @@ void crypt_extract_keys_from_messages(struct Header *h)
     {
       if ((WithCrypto & APPLICATION_PGP) && (h->security & APPLICATION_PGP))
       {
-        mutt_copy_message(fpout, Context, h, MUTT_CM_DECODE | MUTT_CM_CHARCONV, 0);
+        mutt_open_copy_message(fpout, Context, h, MUTT_CM_DECODE | MUTT_CM_CHARCONV, 0);
         fflush(fpout);
         mutt_endwin(_("Trying to extract PGP keys...\n"));
         crypt_pgp_invoke_import(tempfname);
@@ -773,11 +773,11 @@ void crypt_extract_keys_from_messages(struct Header *h)
       if ((WithCrypto & APPLICATION_SMIME) && (h->security & APPLICATION_SMIME))
       {
         if (h->security & ENCRYPT)
-          mutt_copy_message(fpout, Context, h,
-                            MUTT_CM_NOHEADER | MUTT_CM_DECODE_CRYPT | MUTT_CM_DECODE_SMIME,
-                            0);
+          mutt_open_copy_message(fpout, Context, h,
+                                 MUTT_CM_NOHEADER | MUTT_CM_DECODE_CRYPT | MUTT_CM_DECODE_SMIME,
+                                 0);
         else
-          mutt_copy_message(fpout, Context, h, 0, 0);
+          mutt_open_copy_message(fpout, Context, h, 0, 0);
 
         fflush(fpout);
         if (h->env->from)

--- a/ncrypt/crypt.c
+++ b/ncrypt/crypt.c
@@ -724,7 +724,7 @@ void crypt_extract_keys_from_messages(struct Header *h)
 
       if ((WithCrypto & APPLICATION_PGP) && (hi->security & APPLICATION_PGP))
       {
-        mutt_open_copy_message(fpout, Context, hi, MUTT_CM_DECODE | MUTT_CM_CHARCONV, 0);
+        mutt_copy_message_ctx(fpout, Context, hi, MUTT_CM_DECODE | MUTT_CM_CHARCONV, 0);
         fflush(fpout);
 
         mutt_endwin(_("Trying to extract PGP keys...\n"));
@@ -734,11 +734,11 @@ void crypt_extract_keys_from_messages(struct Header *h)
       if ((WithCrypto & APPLICATION_SMIME) && (hi->security & APPLICATION_SMIME))
       {
         if (hi->security & ENCRYPT)
-          mutt_open_copy_message(fpout, Context, hi,
-                                 MUTT_CM_NOHEADER | MUTT_CM_DECODE_CRYPT | MUTT_CM_DECODE_SMIME,
-                                 0);
+          mutt_copy_message_ctx(fpout, Context, hi,
+                                MUTT_CM_NOHEADER | MUTT_CM_DECODE_CRYPT | MUTT_CM_DECODE_SMIME,
+                                0);
         else
-          mutt_open_copy_message(fpout, Context, hi, 0, 0);
+          mutt_copy_message_ctx(fpout, Context, hi, 0, 0);
         fflush(fpout);
 
         if (hi->env->from)
@@ -764,7 +764,7 @@ void crypt_extract_keys_from_messages(struct Header *h)
     {
       if ((WithCrypto & APPLICATION_PGP) && (h->security & APPLICATION_PGP))
       {
-        mutt_open_copy_message(fpout, Context, h, MUTT_CM_DECODE | MUTT_CM_CHARCONV, 0);
+        mutt_copy_message_ctx(fpout, Context, h, MUTT_CM_DECODE | MUTT_CM_CHARCONV, 0);
         fflush(fpout);
         mutt_endwin(_("Trying to extract PGP keys...\n"));
         crypt_pgp_invoke_import(tempfname);
@@ -773,11 +773,11 @@ void crypt_extract_keys_from_messages(struct Header *h)
       if ((WithCrypto & APPLICATION_SMIME) && (h->security & APPLICATION_SMIME))
       {
         if (h->security & ENCRYPT)
-          mutt_open_copy_message(fpout, Context, h,
-                                 MUTT_CM_NOHEADER | MUTT_CM_DECODE_CRYPT | MUTT_CM_DECODE_SMIME,
-                                 0);
+          mutt_copy_message_ctx(fpout, Context, h,
+                                MUTT_CM_NOHEADER | MUTT_CM_DECODE_CRYPT | MUTT_CM_DECODE_SMIME,
+                                0);
         else
-          mutt_open_copy_message(fpout, Context, h, 0, 0);
+          mutt_copy_message_ctx(fpout, Context, h, 0, 0);
 
         fflush(fpout);
         if (h->env->from)

--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -3112,9 +3112,9 @@ static void crypt_entry(char *s, size_t l, struct Menu *menu, int num)
 }
 
 /**
- * _crypt_compare_address - Compare Key addresses and IDs for sorting
+ * compare_key_address - Compare Key addresses and IDs for sorting
  */
-static int _crypt_compare_address(const void *a, const void *b)
+static int compare_key_address(const void *a, const void *b)
 {
   struct CryptKeyInfo **s = (struct CryptKeyInfo **) a;
   struct CryptKeyInfo **t = (struct CryptKeyInfo **) b;
@@ -3128,14 +3128,14 @@ static int _crypt_compare_address(const void *a, const void *b)
 
 static int crypt_compare_address(const void *a, const void *b)
 {
-  return ((PgpSortKeys & SORT_REVERSE) ? !_crypt_compare_address(a, b) :
-                                         _crypt_compare_address(a, b));
+  return ((PgpSortKeys & SORT_REVERSE) ? !compare_key_address(a, b) :
+                                         compare_key_address(a, b));
 }
 
 /**
- * _crypt_compare_keyid - Compare Key IDs and addresses for sorting
+ * compare_keyid - Compare Key IDs and addresses for sorting
  */
-static int _crypt_compare_keyid(const void *a, const void *b)
+static int compare_keyid(const void *a, const void *b)
 {
   struct CryptKeyInfo **s = (struct CryptKeyInfo **) a;
   struct CryptKeyInfo **t = (struct CryptKeyInfo **) b;
@@ -3149,14 +3149,13 @@ static int _crypt_compare_keyid(const void *a, const void *b)
 
 static int crypt_compare_keyid(const void *a, const void *b)
 {
-  return ((PgpSortKeys & SORT_REVERSE) ? !_crypt_compare_keyid(a, b) :
-                                         _crypt_compare_keyid(a, b));
+  return ((PgpSortKeys & SORT_REVERSE) ? !compare_keyid(a, b) : compare_keyid(a, b));
 }
 
 /**
- * _crypt_compare_date - Compare Key creation dates and addresses for sorting
+ * compare_key_date - Compare Key creation dates and addresses for sorting
  */
-static int _crypt_compare_date(const void *a, const void *b)
+static int compare_key_date(const void *a, const void *b)
 {
   struct CryptKeyInfo **s = (struct CryptKeyInfo **) a;
   struct CryptKeyInfo **t = (struct CryptKeyInfo **) b;
@@ -3177,17 +3176,16 @@ static int _crypt_compare_date(const void *a, const void *b)
 
 static int crypt_compare_date(const void *a, const void *b)
 {
-  return ((PgpSortKeys & SORT_REVERSE) ? !_crypt_compare_date(a, b) :
-                                         _crypt_compare_date(a, b));
+  return ((PgpSortKeys & SORT_REVERSE) ? !compare_key_date(a, b) : compare_key_date(a, b));
 }
 
 /**
- * _crypt_compare_trust - Compare the trust of keys for sorting
+ * compare_key_trust - Compare the trust of keys for sorting
  *
  * Compare two trust values, the key length, the creation dates. the addresses
  * and the key IDs.
  */
-static int _crypt_compare_trust(const void *a, const void *b)
+static int compare_key_trust(const void *a, const void *b)
 {
   struct CryptKeyInfo **s = (struct CryptKeyInfo **) a;
   struct CryptKeyInfo **t = (struct CryptKeyInfo **) b;
@@ -3225,8 +3223,8 @@ static int _crypt_compare_trust(const void *a, const void *b)
 
 static int crypt_compare_trust(const void *a, const void *b)
 {
-  return ((PgpSortKeys & SORT_REVERSE) ? !_crypt_compare_trust(a, b) :
-                                         _crypt_compare_trust(a, b));
+  return ((PgpSortKeys & SORT_REVERSE) ? !compare_key_trust(a, b) :
+                                         compare_key_trust(a, b));
 }
 
 /**

--- a/ncrypt/pgp.c
+++ b/ncrypt/pgp.c
@@ -120,7 +120,7 @@ bool pgp_use_gpg_agent(void)
   return true;
 }
 
-static struct PgpKeyInfo *_pgp_parent(struct PgpKeyInfo *k)
+static struct PgpKeyInfo *key_parent(struct PgpKeyInfo *k)
 {
   if ((k->flags & KEYFLAG_SUBKEY) && k->parent && option(OPT_PGP_IGNORE_SUBKEYS))
     k = k->parent;
@@ -130,21 +130,21 @@ static struct PgpKeyInfo *_pgp_parent(struct PgpKeyInfo *k)
 
 char *pgp_long_keyid(struct PgpKeyInfo *k)
 {
-  k = _pgp_parent(k);
+  k = key_parent(k);
 
   return k->keyid;
 }
 
 char *pgp_short_keyid(struct PgpKeyInfo *k)
 {
-  k = _pgp_parent(k);
+  k = key_parent(k);
 
   return k->keyid + 8;
 }
 
 char *pgp_keyid(struct PgpKeyInfo *k)
 {
-  k = _pgp_parent(k);
+  k = key_parent(k);
 
   return _pgp_keyid(k);
 }
@@ -159,7 +159,7 @@ char *_pgp_keyid(struct PgpKeyInfo *k)
 
 static char *pgp_fingerprint(struct PgpKeyInfo *k)
 {
-  k = _pgp_parent(k);
+  k = key_parent(k);
 
   return k->fingerprint;
 }

--- a/ncrypt/pgp.c
+++ b/ncrypt/pgp.c
@@ -142,19 +142,19 @@ char *pgp_short_keyid(struct PgpKeyInfo *k)
   return k->keyid + 8;
 }
 
-char *pgp_keyid(struct PgpKeyInfo *k)
-{
-  k = key_parent(k);
-
-  return _pgp_keyid(k);
-}
-
-char *_pgp_keyid(struct PgpKeyInfo *k)
+char *pgp_this_keyid(struct PgpKeyInfo *k)
 {
   if (option(OPT_PGP_LONG_IDS))
     return k->keyid;
   else
     return (k->keyid + 8);
+}
+
+char *pgp_keyid(struct PgpKeyInfo *k)
+{
+  k = key_parent(k);
+
+  return pgp_this_keyid(k);
 }
 
 static char *pgp_fingerprint(struct PgpKeyInfo *k)

--- a/ncrypt/pgp.h
+++ b/ncrypt/pgp.h
@@ -42,8 +42,8 @@ bool pgp_use_gpg_agent(void);
 
 int pgp_check_traditional(FILE *fp, struct Body *b, int tagged_only);
 
-char *_pgp_keyid(struct PgpKeyInfo *);
-char *pgp_keyid(struct PgpKeyInfo *);
+char *pgp_this_keyid(struct PgpKeyInfo *k);
+char *pgp_keyid(struct PgpKeyInfo *k);
 char *pgp_short_keyid(struct PgpKeyInfo * k);
 char *pgp_long_keyid(struct PgpKeyInfo * k);
 char *pgp_fpr_or_lkeyid(struct PgpKeyInfo * k);

--- a/ncrypt/pgpinvoke.c
+++ b/ncrypt/pgpinvoke.c
@@ -57,11 +57,10 @@ struct PgpCommandContext
   const char *ids;       /**< %r */
 };
 
-static const char *_mutt_fmt_pgp_command(char *dest, size_t destlen, size_t col,
-                                         int cols, char op, const char *src,
-                                         const char *prefix, const char *ifstring,
-                                         const char *elsestring,
-                                         unsigned long data, enum FormatFlag flags)
+static const char *fmt_pgp_command(char *dest, size_t destlen, size_t col, int cols,
+                                   char op, const char *src, const char *prefix,
+                                   const char *ifstring, const char *elsestring,
+                                   unsigned long data, enum FormatFlag flags)
 {
   char fmt[16];
   struct PgpCommandContext *cctx = (struct PgpCommandContext *) data;
@@ -136,10 +135,9 @@ static const char *_mutt_fmt_pgp_command(char *dest, size_t destlen, size_t col,
   }
 
   if (optional)
-    mutt_expando_format(dest, destlen, col, cols, ifstring, _mutt_fmt_pgp_command, data, 0);
+    mutt_expando_format(dest, destlen, col, cols, ifstring, fmt_pgp_command, data, 0);
   else if (flags & MUTT_FORMAT_OPTIONAL)
-    mutt_expando_format(dest, destlen, col, cols, elsestring,
-                        _mutt_fmt_pgp_command, data, 0);
+    mutt_expando_format(dest, destlen, col, cols, elsestring, fmt_pgp_command, data, 0);
 
   return src;
 }
@@ -148,7 +146,7 @@ static void mutt_pgp_command(char *d, size_t dlen,
                              struct PgpCommandContext *cctx, const char *fmt)
 {
   mutt_expando_format(d, dlen, 0, MuttIndexWindow->cols, NONULL(fmt),
-                      _mutt_fmt_pgp_command, (unsigned long) cctx, 0);
+                      fmt_pgp_command, (unsigned long) cctx, 0);
   mutt_debug(2, "mutt_pgp_command: %s\n", d);
 }
 

--- a/ncrypt/pgpkey.c
+++ b/ncrypt/pgpkey.c
@@ -307,7 +307,7 @@ static void pgp_entry(char *s, size_t l, struct Menu *menu, int num)
                       pgp_entry_fmt, (unsigned long) &entry, MUTT_FORMAT_ARROWCURSOR);
 }
 
-static int _pgp_compare_address(const void *a, const void *b)
+static int compare_key_address(const void *a, const void *b)
 {
   int r;
 
@@ -323,11 +323,11 @@ static int _pgp_compare_address(const void *a, const void *b)
 
 static int pgp_compare_address(const void *a, const void *b)
 {
-  return ((PgpSortKeys & SORT_REVERSE) ? !_pgp_compare_address(a, b) :
-                                         _pgp_compare_address(a, b));
+  return ((PgpSortKeys & SORT_REVERSE) ? !compare_key_address(a, b) :
+                                         compare_key_address(a, b));
 }
 
-static int _pgp_compare_keyid(const void *a, const void *b)
+static int compare_keyid(const void *a, const void *b)
 {
   int r;
 
@@ -342,11 +342,10 @@ static int _pgp_compare_keyid(const void *a, const void *b)
 
 static int pgp_compare_keyid(const void *a, const void *b)
 {
-  return ((PgpSortKeys & SORT_REVERSE) ? !_pgp_compare_keyid(a, b) :
-                                         _pgp_compare_keyid(a, b));
+  return ((PgpSortKeys & SORT_REVERSE) ? !compare_keyid(a, b) : compare_keyid(a, b));
 }
 
-static int _pgp_compare_date(const void *a, const void *b)
+static int compare_key_date(const void *a, const void *b)
 {
   int r;
   struct PgpUid **s = (struct PgpUid **) a;
@@ -359,11 +358,10 @@ static int _pgp_compare_date(const void *a, const void *b)
 
 static int pgp_compare_date(const void *a, const void *b)
 {
-  return ((PgpSortKeys & SORT_REVERSE) ? !_pgp_compare_date(a, b) :
-                                         _pgp_compare_date(a, b));
+  return ((PgpSortKeys & SORT_REVERSE) ? !compare_key_date(a, b) : compare_key_date(a, b));
 }
 
-static int _pgp_compare_trust(const void *a, const void *b)
+static int compare_key_trust(const void *a, const void *b)
 {
   int r;
 
@@ -387,8 +385,8 @@ static int _pgp_compare_trust(const void *a, const void *b)
 
 static int pgp_compare_trust(const void *a, const void *b)
 {
-  return ((PgpSortKeys & SORT_REVERSE) ? !_pgp_compare_trust(a, b) :
-                                         _pgp_compare_trust(a, b));
+  return ((PgpSortKeys & SORT_REVERSE) ? !compare_key_trust(a, b) :
+                                         compare_key_trust(a, b));
 }
 
 static bool pgp_key_is_valid(struct PgpKeyInfo *k)

--- a/ncrypt/pgpkey.c
+++ b/ncrypt/pgpkey.c
@@ -232,7 +232,7 @@ static const char *pgp_entry_fmt(char *dest, size_t destlen, size_t col, int col
       if (!optional)
       {
         snprintf(fmt, sizeof(fmt), "%%%ss", prefix);
-        snprintf(dest, destlen, fmt, _pgp_keyid(key));
+        snprintf(dest, destlen, fmt, pgp_this_keyid(key));
       }
       break;
     case 'u':

--- a/ncrypt/pgplib.c
+++ b/ncrypt/pgplib.c
@@ -139,7 +139,7 @@ struct PgpUid *pgp_copy_uids(struct PgpUid *up, struct PgpKeyInfo *parent)
   return l;
 }
 
-static void _pgp_free_key(struct PgpKeyInfo **kpp)
+static void free_key(struct PgpKeyInfo **kpp)
 {
   struct PgpKeyInfo *kp = NULL;
 
@@ -205,12 +205,12 @@ void pgp_free_key(struct PgpKeyInfo **kpp)
     for (q = p->next; q && q->parent == p; q = r)
     {
       r = q->next;
-      _pgp_free_key(&q);
+      free_key(&q);
     }
     if (p->parent)
-      _pgp_free_key(&p->parent);
+      free_key(&p->parent);
 
-    _pgp_free_key(&p);
+    free_key(&p);
   }
 
   *kpp = NULL;

--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -155,15 +155,14 @@ int smime_valid_passphrase(void)
  */
 
 /**
- * _mutt_fmt_smime_command - Format an SMIME command
+ * fmt_smime_command - Format an SMIME command
  *
  * This is almost identical to pgp's invoking interface.
  */
-static const char *_mutt_fmt_smime_command(char *dest, size_t destlen, size_t col,
-                                           int cols, char op, const char *src,
-                                           const char *prefix, const char *ifstring,
-                                           const char *elsestring,
-                                           unsigned long data, enum FormatFlag flags)
+static const char *fmt_smime_command(char *dest, size_t destlen, size_t col, int cols,
+                                     char op, const char *src, const char *prefix,
+                                     const char *ifstring, const char *elsestring,
+                                     unsigned long data, enum FormatFlag flags)
 {
   char fmt[16];
   struct SmimeCommandContext *cctx = (struct SmimeCommandContext *) data;
@@ -286,11 +285,9 @@ static const char *_mutt_fmt_smime_command(char *dest, size_t destlen, size_t co
   }
 
   if (optional)
-    mutt_expando_format(dest, destlen, col, cols, ifstring,
-                        _mutt_fmt_smime_command, data, 0);
+    mutt_expando_format(dest, destlen, col, cols, ifstring, fmt_smime_command, data, 0);
   else if (flags & MUTT_FORMAT_OPTIONAL)
-    mutt_expando_format(dest, destlen, col, cols, elsestring,
-                        _mutt_fmt_smime_command, data, 0);
+    mutt_expando_format(dest, destlen, col, cols, elsestring, fmt_smime_command, data, 0);
 
   return src;
 }
@@ -299,7 +296,7 @@ static void smime_command(char *d, size_t dlen,
                           struct SmimeCommandContext *cctx, const char *fmt)
 {
   mutt_expando_format(d, dlen, 0, MuttIndexWindow->cols, NONULL(fmt),
-                      _mutt_fmt_smime_command, (unsigned long) cctx, 0);
+                      fmt_smime_command, (unsigned long) cctx, 0);
   mutt_debug(2, "smime_command: %s\n", d);
 }
 
@@ -762,12 +759,12 @@ static struct SmimeKey *smime_ask_for_key(char *prompt, short abilities, short p
 }
 
 /**
- * _smime_getkeys - Get the keys for a mailbox
+ * getkeys - Get the keys for a mailbox
  *
  * This sets the '*ToUse' variables for an upcoming decryption, where the
  * required key is different from SmimeDefaultKey.
  */
-static void _smime_getkeys(char *mailbox)
+static void getkeys(char *mailbox)
 {
   struct SmimeKey *key = NULL;
   char *k = NULL;
@@ -840,17 +837,17 @@ void smime_getkeys(struct Envelope *env)
     if (mutt_addr_is_user(t))
     {
       found = true;
-      _smime_getkeys(t->mailbox);
+      getkeys(t->mailbox);
     }
   for (t = env->cc; !found && t; t = t->next)
     if (mutt_addr_is_user(t))
     {
       found = true;
-      _smime_getkeys(t->mailbox);
+      getkeys(t->mailbox);
     }
   if (!found && (t = mutt_default_from()))
   {
-    _smime_getkeys(t->mailbox);
+    getkeys(t->mailbox);
     rfc822_free_address(&t);
   }
 }

--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -1250,10 +1250,10 @@ int smime_verify_sender(struct Header *h)
   }
 
   if (h->security & ENCRYPT)
-    mutt_copy_message(fpout, Context, h, MUTT_CM_DECODE_CRYPT & MUTT_CM_DECODE_SMIME,
-                      CH_MIME | CH_WEED | CH_NONEWLINE);
+    mutt_open_copy_message(fpout, Context, h, MUTT_CM_DECODE_CRYPT & MUTT_CM_DECODE_SMIME,
+                           CH_MIME | CH_WEED | CH_NONEWLINE);
   else
-    mutt_copy_message(fpout, Context, h, 0, 0);
+    mutt_open_copy_message(fpout, Context, h, 0, 0);
 
   fflush(fpout);
   safe_fclose(&fpout);

--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -1250,10 +1250,10 @@ int smime_verify_sender(struct Header *h)
   }
 
   if (h->security & ENCRYPT)
-    mutt_open_copy_message(fpout, Context, h, MUTT_CM_DECODE_CRYPT & MUTT_CM_DECODE_SMIME,
-                           CH_MIME | CH_WEED | CH_NONEWLINE);
+    mutt_copy_message_ctx(fpout, Context, h, MUTT_CM_DECODE_CRYPT & MUTT_CM_DECODE_SMIME,
+                          CH_MIME | CH_WEED | CH_NONEWLINE);
   else
-    mutt_open_copy_message(fpout, Context, h, 0, 0);
+    mutt_copy_message_ctx(fpout, Context, h, 0, 0);
 
   fflush(fpout);
   safe_fclose(&fpout);

--- a/postpone.c
+++ b/postpone.c
@@ -176,7 +176,8 @@ static void post_entry(char *s, size_t slen, struct Menu *menu, int entry)
 {
   struct Context *ctx = (struct Context *) menu->data;
 
-  _mutt_make_string(s, slen, NONULL(IndexFormat), ctx, ctx->hdrs[entry], MUTT_FORMAT_ARROWCURSOR);
+  mutt_make_string_flags(s, slen, NONULL(IndexFormat), ctx, ctx->hdrs[entry],
+                         MUTT_FORMAT_ARROWCURSOR);
 }
 
 static struct Header *select_msg(void)

--- a/protos.h
+++ b/protos.h
@@ -53,8 +53,8 @@ struct ListHead;
 struct stat;
 struct passwd;
 
-#define mutt_make_string(A, B, C, D, E) _mutt_make_string(A, B, C, D, E, 0)
-void _mutt_make_string(char *dest, size_t destlen, const char *s, struct Context *ctx,
+#define mutt_make_string(A, B, C, D, E) mutt_make_string_flags(A, B, C, D, E, 0)
+void mutt_make_string_flags(char *dest, size_t destlen, const char *s, struct Context *ctx,
                        struct Header *hdr, enum FormatFlag flags);
 
 /**
@@ -128,7 +128,7 @@ const char *mutt_attach_fmt(char *dest, size_t destlen, size_t col, int cols,
 char *mutt_charset_hook(const char *chs);
 char *mutt_iconv_hook(const char *chs);
 char *mutt_expand_path(char *s, size_t slen);
-char *_mutt_expand_path(char *s, size_t slen, int regex);
+char *mutt_expand_path_regex(char *s, size_t slen, int regex);
 char *mutt_find_hook(int type, const char *pat);
 char *mutt_gecos_name(char *dest, size_t destlen, struct passwd *pw);
 char *mutt_get_body_charset(char *d, size_t dlen, struct Body *b);
@@ -203,10 +203,9 @@ void mutt_make_help(char *d, size_t dlen, const char *txt, int menu, int op);
 void mutt_make_misc_reply_headers(struct Envelope *env, struct Context *ctx, struct Header *cur, struct Envelope *curenv);
 void mutt_make_post_indent(struct Context *ctx, struct Header *cur, FILE *out);
 void mutt_message_to_7bit(struct Body *a, FILE *fp);
+void mutt_mktemp_full(char *s, size_t slen, const char *prefix, const char *suffix, const char *src, int line);
+#define mutt_mktemp_pfx_sfx(a, b, c, d) mutt_mktemp_full(a, b, c, d, __FILE__, __LINE__)
 #define mutt_mktemp(a, b) mutt_mktemp_pfx_sfx(a, b, "neomutt", NULL)
-#define mutt_mktemp_pfx_sfx(a, b, c, d) _mutt_mktemp(a, b, c, d, __FILE__, __LINE__)
-void _mutt_mktemp(char *s, size_t slen, const char *prefix, const char *suffix,
-                  const char *src, int line);
 void mutt_paddstr(int n, const char *s);
 void mutt_parse_mime_message(struct Context *ctx, struct Header *cur);
 void mutt_parse_part(FILE *fp, struct Body *b);
@@ -223,11 +222,10 @@ void mutt_safe_path(char *s, size_t l, struct Address *a);
 void mutt_save_path(char *d, size_t dsize, struct Address *a);
 void mutt_score_message(struct Context *ctx, struct Header *hdr, int upd_ctx);
 void mutt_select_fcc(char *path, size_t pathlen, struct Header *hdr);
-#define mutt_select_file(A, B, C) _mutt_select_file(A, B, C, NULL, NULL)
-void _mutt_select_file(char *f, size_t flen, int flags, char ***files, int *numfiles);
+void mutt_select_file(char *f, size_t flen, int flags, char ***files, int *numfiles);
 void mutt_message_hook(struct Context *ctx, struct Header *hdr, int type);
-void _mutt_set_flag(struct Context *ctx, struct Header *h, int flag, int bf, int upd_ctx);
-#define mutt_set_flag(a, b, c, d) _mutt_set_flag(a, b, c, d, 1)
+void mutt_set_flag_update(struct Context *ctx, struct Header *h, int flag, int bf, int upd_ctx);
+#define mutt_set_flag(a, b, c, d) mutt_set_flag_update(a, b, c, d, 1)
 void mutt_set_followup_to(struct Envelope *e);
 void mutt_shell_escape(void);
 void mutt_show_error(void);
@@ -281,15 +279,15 @@ int mutt_chscmp(const char *s, const char *chs);
 int mutt_prepare_template(FILE *fp, struct Context *ctx, struct Header *newhdr, struct Header *hdr, short resend);
 int mutt_resend_message(FILE *fp, struct Context *ctx, struct Header *cur);
 int mutt_compose_to_sender(struct Header *hdr);
-#define mutt_enter_fname(A, B, C, D) _mutt_enter_fname(A, B, C, D, 0, NULL, NULL, 0)
-#define mutt_enter_vfolder(A, B, C, D) _mutt_enter_fname(A, B, C, D, 0, NULL, NULL, MUTT_SEL_VFOLDER)
-int _mutt_enter_fname(const char *prompt, char *buf, size_t blen, int buffy,
+#define mutt_enter_fname(A, B, C, D)   mutt_enter_fname_full(A, B, C, D, 0, NULL, NULL, 0)
+#define mutt_enter_vfolder(A, B, C, D) mutt_enter_fname_full(A, B, C, D, 0, NULL, NULL, MUTT_SEL_VFOLDER)
+int mutt_enter_fname_full(const char *prompt, char *buf, size_t blen, int buffy,
                       int multiple, char ***files, int *numfiles, int flags);
 int mutt_enter_string(char *buf, size_t buflen, int col, int flags);
-int _mutt_enter_string(char *buf, size_t buflen, int col, int flags, int multiple,
+int mutt_enter_string_full(char *buf, size_t buflen, int col, int flags, int multiple,
                        char ***files, int *numfiles, struct EnterState *state);
-#define mutt_get_field(A, B, C, D) _mutt_get_field(A, B, C, D, 0, NULL, NULL)
-int _mutt_get_field(const char *field, char *buf, size_t buflen, int complete,
+#define mutt_get_field(A, B, C, D) mutt_get_field_full(A, B, C, D, 0, NULL, NULL)
+int mutt_get_field_full(const char *field, char *buf, size_t buflen, int complete,
                     int multiple, char ***files, int *numfiles);
 int mutt_get_hook_type(const char *name);
 int mutt_get_field_unbuffered(char *msg, char *buf, size_t buflen, int flags);
@@ -332,7 +330,7 @@ int mutt_print_attachment(FILE *fp, struct Body *a);
 int mutt_query_complete(char *buf, size_t buflen);
 int mutt_query_variables(struct ListHead *queries);
 int mutt_save_attachment(FILE *fp, struct Body *m, char *path, int flags, struct Header *hdr);
-int _mutt_save_message(struct Header *h, struct Context *ctx, int delete, int decode, int decrypt);
+int mutt_save_message_ctx(struct Header *h, int delete, int decode, int decrypt, struct Context *ctx);
 int mutt_save_message(struct Header *h, int delete, int decode, int decrypt);
 #ifdef USE_SMTP
 int mutt_smtp_send(const struct Address *from, const struct Address *to, const struct Address *cc,

--- a/recvattach.c
+++ b/recvattach.c
@@ -210,8 +210,9 @@ const char *mutt_attach_fmt(char *dest, size_t destlen, size_t col, int cols,
             MessageFormat && aptr->content->hdr)
         {
           char s[SHORT_STRING];
-          _mutt_make_string(s, sizeof(s), MessageFormat, NULL, aptr->content->hdr,
-                            MUTT_FORMAT_FORCESUBJ | MUTT_FORMAT_MAKEPRINT | MUTT_FORMAT_ARROWCURSOR);
+          mutt_make_string_flags(
+              s, sizeof(s), MessageFormat, NULL, aptr->content->hdr,
+              MUTT_FORMAT_FORCESUBJ | MUTT_FORMAT_MAKEPRINT | MUTT_FORMAT_ARROWCURSOR);
           if (*s)
           {
             mutt_format_s(dest, destlen, prefix, s);

--- a/recvcmd.c
+++ b/recvcmd.c
@@ -617,7 +617,7 @@ static void attach_forward_msgs(FILE *fp, struct Header *hdr,
     if (cur)
     {
       mutt_forward_intro(Context, cur->hdr, tmpfp);
-      mutt_copy_message(tmpfp, fp, cur->hdr, cur->hdr->content, cmflags, chflags);
+      mutt_copy_message_fp(tmpfp, fp, cur->hdr, cmflags, chflags);
       mutt_forward_trailer(Context, cur->hdr, tmpfp);
     }
     else
@@ -627,8 +627,8 @@ static void attach_forward_msgs(FILE *fp, struct Header *hdr,
         if (actx->idx[i]->content->tagged)
         {
           mutt_forward_intro(Context, actx->idx[i]->content->hdr, tmpfp);
-          mutt_copy_message(tmpfp, actx->idx[i]->fp, actx->idx[i]->content->hdr,
-                            actx->idx[i]->content->hdr->content, cmflags, chflags);
+          mutt_copy_message_fp(tmpfp, actx->idx[i]->fp,
+                               actx->idx[i]->content->hdr, cmflags, chflags);
           mutt_forward_trailer(Context, actx->idx[i]->content->hdr, tmpfp);
         }
       }
@@ -785,7 +785,7 @@ static void attach_include_reply(FILE *fp, FILE *tmpfp, struct Header *cur, int 
     cmflags |= MUTT_CM_WEED;
   }
 
-  mutt_copy_message(tmpfp, fp, cur, cur->content, cmflags, chflags);
+  mutt_copy_message_fp(tmpfp, fp, cur, cmflags, chflags);
   mutt_make_post_indent(Context, cur, tmpfp);
 }
 

--- a/recvcmd.c
+++ b/recvcmd.c
@@ -341,7 +341,7 @@ static void include_header(int quote, FILE *ifp, struct Header *hdr, FILE *ofp, 
     if (_prefix)
       strfcpy(prefix, _prefix, sizeof(prefix));
     else if (!option(OPT_TEXT_FLOWED))
-      _mutt_make_string(prefix, sizeof(prefix), NONULL(IndentString), Context, hdr, 0);
+      mutt_make_string_flags(prefix, sizeof(prefix), NONULL(IndentString), Context, hdr, 0);
     else
       strfcpy(prefix, ">", sizeof(prefix));
 
@@ -433,8 +433,8 @@ static void attach_forward_bodies(FILE *fp, struct Header *hdr, struct AttachCtx
   if (option(OPT_FORWARD_QUOTE))
   {
     if (!option(OPT_TEXT_FLOWED))
-      _mutt_make_string(prefix, sizeof(prefix), NONULL(IndentString), Context,
-                        parent_hdr, 0);
+      mutt_make_string_flags(prefix, sizeof(prefix), NONULL(IndentString),
+                             Context, parent_hdr, 0);
     else
       strfcpy(prefix, ">", sizeof(prefix));
   }
@@ -617,7 +617,7 @@ static void attach_forward_msgs(FILE *fp, struct Header *hdr,
     if (cur)
     {
       mutt_forward_intro(Context, cur->hdr, tmpfp);
-      _mutt_copy_message(tmpfp, fp, cur->hdr, cur->hdr->content, cmflags, chflags);
+      mutt_copy_message(tmpfp, fp, cur->hdr, cur->hdr->content, cmflags, chflags);
       mutt_forward_trailer(Context, cur->hdr, tmpfp);
     }
     else
@@ -627,8 +627,8 @@ static void attach_forward_msgs(FILE *fp, struct Header *hdr,
         if (actx->idx[i]->content->tagged)
         {
           mutt_forward_intro(Context, actx->idx[i]->content->hdr, tmpfp);
-          _mutt_copy_message(tmpfp, actx->idx[i]->fp, actx->idx[i]->content->hdr,
-                             actx->idx[i]->content->hdr->content, cmflags, chflags);
+          mutt_copy_message(tmpfp, actx->idx[i]->fp, actx->idx[i]->content->hdr,
+                            actx->idx[i]->content->hdr->content, cmflags, chflags);
           mutt_forward_trailer(Context, actx->idx[i]->content->hdr, tmpfp);
         }
       }
@@ -785,7 +785,7 @@ static void attach_include_reply(FILE *fp, FILE *tmpfp, struct Header *cur, int 
     cmflags |= MUTT_CM_WEED;
   }
 
-  _mutt_copy_message(tmpfp, fp, cur, cur->content, cmflags, chflags);
+  mutt_copy_message(tmpfp, fp, cur, cur->content, cmflags, chflags);
   mutt_make_post_indent(Context, cur, tmpfp);
 }
 
@@ -882,8 +882,8 @@ void mutt_attach_reply(FILE *fp, struct Header *hdr, struct AttachCtx *actx,
     st.fpout = tmpfp;
 
     if (!option(OPT_TEXT_FLOWED))
-      _mutt_make_string(prefix, sizeof(prefix), NONULL(IndentString), Context,
-                        parent_hdr, 0);
+      mutt_make_string_flags(prefix, sizeof(prefix), NONULL(IndentString),
+                             Context, parent_hdr, 0);
     else
       strfcpy(prefix, ">", sizeof(prefix));
 

--- a/rfc2047.c
+++ b/rfc2047.c
@@ -611,7 +611,7 @@ static int rfc2047_encode(ICONV_CONST char *d, size_t dlen, int col, const char 
   return ret;
 }
 
-void _rfc2047_encode_string(char **pd, int encode_specials, int col)
+void rfc2047_encode_string(char **pd, int encode_specials, int col)
 {
   char *e = NULL;
   size_t elen;
@@ -639,9 +639,9 @@ void rfc2047_encode_adrlist(struct Address *addr, const char *tag)
   while (ptr)
   {
     if (ptr->personal)
-      _rfc2047_encode_string(&ptr->personal, 1, col);
+      rfc2047_encode_string(&ptr->personal, 1, col);
     else if (ptr->group && ptr->mailbox)
-      _rfc2047_encode_string(&ptr->mailbox, 1, col);
+      rfc2047_encode_string(&ptr->mailbox, 1, col);
     ptr = ptr->next;
   }
 }

--- a/rfc2047.h
+++ b/rfc2047.h
@@ -31,10 +31,10 @@ char *mutt_choose_charset(const char *fromcode, const char *charsets, char *u,
                           size_t ulen, char **d, size_t *dlen);
 int convert_nonmime_string(char **ps);
 
-void _rfc2047_encode_string(char **pd, int encode_specials, int col);
+void rfc2047_encode_string(char **pd, int encode_specials, int col);
 void rfc2047_encode_adrlist(struct Address *addr, const char *tag);
 
-#define rfc2047_encode_string(a) _rfc2047_encode_string(a, 0, 32);
+#define rfc2047_encode_string32(a) rfc2047_encode_string(a, 0, 32);
 
 void rfc2047_decode(char **pd);
 void rfc2047_decode_adrlist(struct Address *a);

--- a/score.c
+++ b/score.c
@@ -162,11 +162,11 @@ void mutt_score_message(struct Context *ctx, struct Header *hdr, int upd_ctx)
     hdr->score = 0;
 
   if (hdr->score <= ScoreThresholdDelete)
-    _mutt_set_flag(ctx, hdr, MUTT_DELETE, 1, upd_ctx);
+    mutt_set_flag_update(ctx, hdr, MUTT_DELETE, 1, upd_ctx);
   if (hdr->score <= ScoreThresholdRead)
-    _mutt_set_flag(ctx, hdr, MUTT_READ, 1, upd_ctx);
+    mutt_set_flag_update(ctx, hdr, MUTT_READ, 1, upd_ctx);
   if (hdr->score >= ScoreThresholdFlag)
-    _mutt_set_flag(ctx, hdr, MUTT_FLAG, 1, upd_ctx);
+    mutt_set_flag_update(ctx, hdr, MUTT_FLAG, 1, upd_ctx);
 }
 
 int mutt_parse_unscore(struct Buffer *buf, struct Buffer *s, unsigned long data,

--- a/send.c
+++ b/send.c
@@ -468,7 +468,7 @@ static int include_forward(struct Context *ctx, struct Header *cur, FILE *out)
    * rather than send action */
   chflags |= CH_DISPLAY;
 
-  mutt_copy_message(out, ctx, cur, cmflags, chflags);
+  mutt_open_copy_message(out, ctx, cur, cmflags, chflags);
   mutt_forward_trailer(ctx, cur, out);
   return 0;
 }
@@ -522,7 +522,7 @@ static int include_reply(struct Context *ctx, struct Header *cur, FILE *out)
     cmflags |= MUTT_CM_WEED;
   }
 
-  mutt_copy_message(out, ctx, cur, cmflags, chflags);
+  mutt_open_copy_message(out, ctx, cur, cmflags, chflags);
 
   mutt_make_post_indent(ctx, cur, out);
 
@@ -1157,7 +1157,7 @@ void mutt_encode_descriptions(struct Body *b, short recurse)
   {
     if (t->description)
     {
-      rfc2047_encode_string(&t->description);
+      rfc2047_encode_string32(&t->description);
     }
     if (recurse && t->parts)
       mutt_encode_descriptions(t->parts, recurse);

--- a/send.c
+++ b/send.c
@@ -468,7 +468,7 @@ static int include_forward(struct Context *ctx, struct Header *cur, FILE *out)
    * rather than send action */
   chflags |= CH_DISPLAY;
 
-  mutt_open_copy_message(out, ctx, cur, cmflags, chflags);
+  mutt_copy_message_ctx(out, ctx, cur, cmflags, chflags);
   mutt_forward_trailer(ctx, cur, out);
   return 0;
 }
@@ -522,7 +522,7 @@ static int include_reply(struct Context *ctx, struct Header *cur, FILE *out)
     cmflags |= MUTT_CM_WEED;
   }
 
-  mutt_open_copy_message(out, ctx, cur, cmflags, chflags);
+  mutt_copy_message_ctx(out, ctx, cur, cmflags, chflags);
 
   mutt_make_post_indent(ctx, cur, out);
 

--- a/sendlib.c
+++ b/sendlib.c
@@ -1415,7 +1415,7 @@ struct Body *mutt_make_message_attach(struct Context *ctx, struct Header *hdr, i
     }
   }
 
-  mutt_open_copy_message(fp, ctx, hdr, cmflags, chflags);
+  mutt_copy_message_ctx(fp, ctx, hdr, cmflags, chflags);
 
   fflush(fp);
   rewind(fp);

--- a/sendlib.c
+++ b/sendlib.c
@@ -2748,8 +2748,8 @@ void mutt_unprepare_envelope(struct Envelope *env)
   rfc2047_decode(&env->subject);
 }
 
-static int _mutt_bounce_message(FILE *fp, struct Header *h, struct Address *to,
-                                const char *resent_from, struct Address *env_from)
+static int bounce_message(FILE *fp, struct Header *h, struct Address *to,
+                          const char *resent_from, struct Address *env_from)
 {
   int ret = 0;
   FILE *f = NULL;
@@ -2761,7 +2761,7 @@ static int _mutt_bounce_message(FILE *fp, struct Header *h, struct Address *to,
     /* Try to bounce each message out, aborting if we get any failures. */
     for (int i = 0; i < Context->msgcount; i++)
       if (message_is_tagged(Context, i))
-        ret |= _mutt_bounce_message(fp, Context->hdrs[i], to, resent_from, env_from);
+        ret |= bounce_message(fp, Context->hdrs[i], to, resent_from, env_from);
     return ret;
   }
 
@@ -2859,7 +2859,7 @@ int mutt_bounce_message(FILE *fp, struct Header *h, struct Address *to)
   resent_to = rfc822_cpy_adr(to, 0);
   rfc2047_encode_adrlist(resent_to, "Resent-To");
 
-  ret = _mutt_bounce_message(fp, h, resent_to, resent_from, from);
+  ret = bounce_message(fp, h, resent_to, resent_from, from);
 
   rfc822_free_address(&resent_to);
   rfc822_free_address(&from);

--- a/sendlib.c
+++ b/sendlib.c
@@ -1415,7 +1415,7 @@ struct Body *mutt_make_message_attach(struct Context *ctx, struct Header *hdr, i
     }
   }
 
-  mutt_copy_message(fp, ctx, hdr, cmflags, chflags);
+  mutt_open_copy_message(fp, ctx, hdr, cmflags, chflags);
 
   fflush(fp);
   rewind(fp);
@@ -2247,7 +2247,7 @@ static void encode_headers(struct ListHead *h)
     if (!tmp)
       continue;
 
-    rfc2047_encode_string(&tmp);
+    rfc2047_encode_string32(&tmp);
     safe_realloc(&np->data, mutt_strlen(np->data) + 2 + mutt_strlen(tmp) + 1);
 
     sprintf(np->data + i, ": %s", NONULL(tmp));
@@ -2724,7 +2724,7 @@ void mutt_prepare_envelope(struct Envelope *env, int final)
     if (!option(OPT_NEWS_SEND) || option(OPT_MIME_SUBJECT))
 #endif
     {
-      rfc2047_encode_string(&env->subject);
+      rfc2047_encode_string32(&env->subject);
     }
   encode_headers(&env->userhdrs);
 }

--- a/status.c
+++ b/status.c
@@ -45,9 +45,8 @@ static char *get_sort_str(char *buf, size_t buflen, int method)
   return buf;
 }
 
-static void _menu_status_line(char *buf, size_t buflen, size_t col, int cols,
-                              struct Menu *menu, const char *p);
-
+static void status_line(char *buf, size_t buflen, size_t col, int cols,
+                        struct Menu *menu, const char *p);
 /**
  * status_format_str - Format a string for the status bar
  *
@@ -317,15 +316,15 @@ static const char *status_format_str(char *buf, size_t buflen, size_t col, int c
   }
 
   if (optional)
-    _menu_status_line(buf, buflen, col, cols, menu, ifstring);
+    status_line(buf, buflen, col, cols, menu, ifstring);
   else if (flags & MUTT_FORMAT_OPTIONAL)
-    _menu_status_line(buf, buflen, col, cols, menu, elsestring);
+    status_line(buf, buflen, col, cols, menu, elsestring);
 
   return src;
 }
 
-static void _menu_status_line(char *buf, size_t buflen, size_t col, int cols,
-                              struct Menu *menu, const char *p)
+static void status_line(char *buf, size_t buflen, size_t col, int cols,
+                        struct Menu *menu, const char *p)
 {
   mutt_expando_format(buf, buflen, col, cols, p, status_format_str,
                       (unsigned long) menu, 0);

--- a/thread.c
+++ b/thread.c
@@ -1052,13 +1052,13 @@ static struct Header *find_virtual(struct MuttThread *cur, int reverse)
 }
 
 /**
- * _mutt_aside_thread - Find the next/previous (sub)thread
+ * mutt_aside_thread - Find the next/previous (sub)thread
  * @param hdr        Search from this message
  * @param dir        Direction to search: 'true' forwards, 'false' backwards
  * @param subthreads Search subthreads: 'true' subthread, 'false' not
  * @retval n Index into the virtual email table
  */
-int _mutt_aside_thread(struct Header *hdr, short dir, short subthreads)
+int mutt_aside_thread(struct Header *hdr, short dir, short subthreads)
 {
   struct MuttThread *cur = NULL;
   struct Header *tmp = NULL;
@@ -1177,7 +1177,7 @@ void mutt_set_virtual(struct Context *ctx)
   }
 }
 
-int _mutt_traverse_thread(struct Context *ctx, struct Header *cur, int flag)
+int mutt_traverse_thread(struct Context *ctx, struct Header *cur, int flag)
 {
   struct MuttThread *thread = NULL, *top = NULL;
   struct Header *roothdr = NULL;

--- a/thread.h
+++ b/thread.h
@@ -49,19 +49,19 @@ struct MuttThread
   struct Header *sort_key;
 };
 
-int _mutt_aside_thread(struct Header *hdr, short dir, short subthreads);
-#define mutt_next_thread(x)        _mutt_aside_thread(x, 1, 0)
-#define mutt_previous_thread(x)    _mutt_aside_thread(x, 0, 0)
-#define mutt_next_subthread(x)     _mutt_aside_thread(x, 1, 1)
-#define mutt_previous_subthread(x) _mutt_aside_thread(x, 0, 1)
+int mutt_aside_thread(struct Header *hdr, short dir, short subthreads);
+#define mutt_next_thread(x)        mutt_aside_thread(x, 1, 0)
+#define mutt_previous_thread(x)    mutt_aside_thread(x, 0, 0)
+#define mutt_next_subthread(x)     mutt_aside_thread(x, 1, 1)
+#define mutt_previous_subthread(x) mutt_aside_thread(x, 0, 1)
 
-int _mutt_traverse_thread(struct Context *ctx, struct Header *cur, int flag);
-#define mutt_collapse_thread(x, y)         _mutt_traverse_thread(x, y, MUTT_THREAD_COLLAPSE)
-#define mutt_uncollapse_thread(x, y)       _mutt_traverse_thread(x, y, MUTT_THREAD_UNCOLLAPSE)
-#define mutt_get_hidden(x, y)              _mutt_traverse_thread(x, y, MUTT_THREAD_GET_HIDDEN)
-#define mutt_thread_contains_unread(x, y)  _mutt_traverse_thread(x, y, MUTT_THREAD_UNREAD)
-#define mutt_thread_contains_flagged(x, y) _mutt_traverse_thread(x, y, MUTT_THREAD_FLAGGED)
-#define mutt_thread_next_unread(x, y)      _mutt_traverse_thread(x, y, MUTT_THREAD_NEXT_UNREAD)
+int mutt_traverse_thread(struct Context *ctx, struct Header *cur, int flag);
+#define mutt_collapse_thread(x, y)         mutt_traverse_thread(x, y, MUTT_THREAD_COLLAPSE)
+#define mutt_uncollapse_thread(x, y)       mutt_traverse_thread(x, y, MUTT_THREAD_UNCOLLAPSE)
+#define mutt_get_hidden(x, y)              mutt_traverse_thread(x, y, MUTT_THREAD_GET_HIDDEN)
+#define mutt_thread_contains_unread(x, y)  mutt_traverse_thread(x, y, MUTT_THREAD_UNREAD)
+#define mutt_thread_contains_flagged(x, y) mutt_traverse_thread(x, y, MUTT_THREAD_FLAGGED)
+#define mutt_thread_next_unread(x, y)      mutt_traverse_thread(x, y, MUTT_THREAD_NEXT_UNREAD)
 
 void mutt_break_thread(struct Header *hdr);
 int mutt_link_threads(struct Header *cur, struct Header *last, struct Context *ctx);


### PR DESCRIPTION
- 9f540482f rename static functions
- 7e347662d rename public functions

One function has had its parameters reordered (to match another function).
Otherwise, there are no code changes.

##  Static Functions
Most of their names have been simplified by stripping leading components.

| Old Name                    | New Name              |
| :-------------------------- | :-------------------- |
| _alternates_clean           | alternates_clean      |
| _attachments_clean          | attachments_clean     |
| _crypt_compare_address      | compare_key_address   |
| _crypt_compare_date         | compare_key_date      |
| _crypt_compare_keyid        | compare_keyid         |
| _crypt_compare_trust        | compare_key_trust     |
| _handle_error               | handle_error          |
| _handle_panic               | handle_panic          |
| _lua_expose_command         | lua_expose_command    |
| _lua_init                   | lua_init              |
| _lua_mutt_call              | lua_mutt_call         |
| _lua_mutt_enter             | lua_mutt_enter        |
| _lua_mutt_error             | lua_mutt_error        |
| _lua_mutt_get               | lua_mutt_get          |
| _lua_mutt_message           | lua_mutt_message      |
| _lua_mutt_set               | lua_mutt_set          |
| _maildir_commit_message     | md_commit_message     |
| _maildir_open_find_message  | md_open_find_message  |
| _menu_status_line           | status_line           |
| _mh_commit_message          | mh_commit_msg         |
| _mutt_append_message        | append_message        |
| _mutt_bounce_message        | bounce_message        |
| _mutt_check_traditional_pgp | check_traditional_pgp |
| _mutt_fmt_smime_command     | fmt_smime_command     |
| _mutt_list_hook             | list_hook             |
| _mutt_parse_color           | parse_color           |
| _mutt_parse_uncolor         | parse_uncolor         |
| _mutt_pipe_message          | pipe_message          |
| _mutt_string_hook           | string_hook           |
| _pgp_compare_address        | compare_key_address   |
| _pgp_compare_date           | compare_key_date      |
| _pgp_compare_keyid          | compare_keyid         |
| _pgp_compare_trust          | compare_key_trust     |
| _pgp_free_key               | free_key              |
| _pgp_parent                 | key_parent            |
| _smime_getkeys              | getkeys               |

## Public Functions
Some have just had their leading `_` stripped.
The others have been renamed to distinguish them from similarly named functions.
e.g.  Suffix describing extra parameter.

| Old Name               | New Name                 |
| :--------------------- | :----------------------- |
| mutt_copy_message      | mutt_open_copy_message   |
| rfc2047_encode_string  | rfc2047_encode_string32  |
| _mutt_aside_thread     | mutt_aside_thread        |
| _mutt_copy_message     | mutt_copy_message        |
| _mutt_enter_fname      | mutt_enter_fname_full    |
| _mutt_enter_string     | mutt_enter_string_full   |
| _mutt_expand_path      | mutt_expand_path_regex   |
| _mutt_get_field        | mutt_get_field_full      |
| _mutt_make_string      | mutt_make_string_flags   |
| _mutt_mktemp           | mutt_mktemp_full         |
| _mutt_save_message     | mutt_save_message_ctx    |
| _mutt_select_file      | mutt_select_file         |
| _mutt_set_flag         | mutt_set_flag_update     |
| _mutt_traverse_thread  | mutt_traverse_thread     |
| _pgp_keyid             | pgp_this_keyid           |
| _rfc2047_encode_string | rfc2047_encode_string    |

I'm happy to change any of the names.  (naming is hard :-)