### PR TITLE
Cleanup "SSL is unavailable" error in mutt_conn_find

### DIFF
--- a/mutt_socket.c
+++ b/mutt_socket.c
@@ -102,8 +102,7 @@ struct Connection *mutt_conn_find(const struct Connection *start, const struct A
       return NULL;
     }
 #else
-    mutt_error(_("SSL is unavailable."));
-    mutt_sleep(2);
+    mutt_error(_("SSL is unavailable, cannot connect to %s"), account->host);
     mutt_socket_free(conn);
 
     return NULL;


### PR DESCRIPTION
- Remove the sleep
- Be more informative about the failed connection

Issue #934
