### PR TITLE
Introduce GPG config file changes to accomodate gpg 2.1

### DIFF
--- a/contrib/gpg.rc
+++ b/contrib/gpg.rc
@@ -2,7 +2,13 @@
 #
 # Command formats for gpg.
 #
-# This version uses gpg-2comp from
+# Version notes:
+#
+#   GPG 2.1 introduces the option "--pinentry-mode", which requires
+#   the "loopback" argument in instances where "--passphrase-fd" is
+#   used.
+#
+# The gpg-2comp found in some comments comes from
 #   http://70t.de/download/gpg-2comp.tar.gz
 #
 # %p    The empty string when no passphrase is needed,
@@ -29,58 +35,72 @@
 # breaking PGP/MIME.
 
 # decode application/pgp
-set pgp_decode_command="gpg --status-fd=2 %?p?--passphrase-fd 0? --no-verbose --quiet --batch --output - %f"
+#
+set pgp_decode_command="gpg --status-fd=2 %?p?--pinentry-mode loopback --passphrase-fd 0? --no-verbose --quiet --batch --output - %f"
 
-# verify a pgp/mime signature
+# Verify a signature
+#
 set pgp_verify_command="gpg --status-fd=2 --no-verbose --quiet --batch --output - --verify %s %f"
 
-# decrypt a pgp/mime attachment
-set pgp_decrypt_command="gpg --status-fd=2 %?p?--passphrase-fd 0? --no-verbose --quiet --batch --output - %f"
+# Decrypt an attachment
+#
+set pgp_decrypt_command="gpg --status-fd=2 %?p?--pinentry-mode loopback --passphrase-fd 0? --no-verbose --quiet --batch --output - --decrypt %f"
 
-# create a pgp/mime signed attachment
+# Create a PGP/MIME signed attachment
+#
 # set pgp_sign_command="gpg-2comp --comment '' --no-verbose --batch --output - %?p?--passphrase-fd 0? --armor --detach-sign --textmode %?a?-u %a? %f"
-set pgp_sign_command="gpg --no-verbose --batch --quiet --output - %?p?--passphrase-fd 0? --armor --detach-sign --textmode %?a?-u %a? %f"
+#
+set pgp_sign_command="gpg %?p?--pinentry-mode loopback --passphrase-fd 0? --no-verbose --batch --quiet --output - --armor --textmode %?a?--local-user %a? --detach-sign %f"
 
-# create a application/pgp signed (old-style) message
+# Create a application/pgp inline signed message.  This style is obsolete but still needed for Hushmail recipients and some MUAs.
+#
 # set pgp_clearsign_command="gpg-2comp --comment '' --no-verbose --batch --output - %?p?--passphrase-fd 0? --armor --textmode --clearsign %?a?-u %a? %f"
-set pgp_clearsign_command="gpg --no-verbose --batch --quiet --output - %?p?--passphrase-fd 0? --armor --textmode --clearsign %?a?-u %a? %f"
+#
+set pgp_clearsign_command="gpg %?p?--pinentry-mode loopback --passphrase-fd 0? --no-verbose --batch --quiet --output - --armor --textmode %?a?--local-user %a? --clearsign %f"
 
-# create a pgp/mime encrypted attachment
+# Create an encrypted attachment (note that some users include the --always-trust option here)
+#
 # set pgp_encrypt_only_command="/usr/lib/neomutt/pgpewrap gpg-2comp -v --batch --output - --encrypt --textmode --armor --always-trust -- -r %r -- %f"
-set pgp_encrypt_only_command="/usr/lib/neomutt/pgpewrap gpg --batch --quiet --no-verbose --output - --encrypt --textmode --armor --always-trust -- -r %r -- %f"
+#
+set pgp_encrypt_only_command="/usr/lib/neomutt/pgpewrap gpg --batch --quiet --no-verbose --output - --textmode --armor -- --recipient %r -- --encrypt %f"
 
-# create a pgp/mime encrypted and signed attachment
+# Create an encrypted and signed attachment (note that some users include the --always-trust option here)
+# 
 # set pgp_encrypt_sign_command="/usr/lib/neomutt/pgpewrap gpg-2comp %?p?--passphrase-fd 0? -v --batch --output - --encrypt --sign %?a?-u %a? --armor --always-trust -- -r %r -- %f"
-set pgp_encrypt_sign_command="/usr/lib/neomutt/pgpewrap gpg %?p?--passphrase-fd 0? --batch --quiet --no-verbose --textmode --output - --encrypt --sign %?a?-u %a? --armor --always-trust -- -r %r -- %f"
+#
+set pgp_encrypt_sign_command="/usr/lib/neomutt/pgpewrap gpg %?p?--pinentry-mode loopback --passphrase-fd 0? --batch --quiet --no-verbose --textmode --output - %?a?--local-user %a? --armor -- --recipient %r -- --sign --encrypt %f"
 
-# import a key into the public key ring
+# Import a key into the public key ring
+#
 set pgp_import_command="gpg --no-verbose --import %f"
 
-# export a key from the public key ring
-set pgp_export_command="gpg --no-verbose --export --armor %r"
+# Export a key from the public key ring
+#
+set pgp_export_command="gpg --no-verbose --armor --export %r"
 
-# verify a key
+# Verify a key
+#
 set pgp_verify_key_command="gpg --verbose --batch --fingerprint --check-sigs %r"
 
-# read in the public key ring
-set pgp_list_pubring_command="gpg --no-verbose --batch --quiet --with-colons --with-fingerprint --with-fingerprint --list-keys %r"
+# Read in the public key ring
+#
+set pgp_list_pubring_command="gpg --no-verbose --batch --quiet --with-colons --with-fingerprint --with-fingerprint --list-keys %r" 
 
-# read in the secret key ring
-set pgp_list_secring_command="gpg --no-verbose --batch --quiet --with-colons --with-fingerprint --with-fingerprint --list-secret-keys %r"
+# Read in the secret key ring
+#
+set pgp_list_secring_command="gpg --no-verbose --batch --quiet --with-colons --with-fingerprint --with-fingerprint --list-secret-keys %r" 
 
-# fetch keys
+# Fetch keys
 # set pgp_getkeys_command="pkspxycwrap %r"
 
 # pattern for good signature - may need to be adapted to locale!
-
-# set pgp_good_sign="^gpgv?: Good signature from "
-
 # OK, here's a version which uses gnupg's message catalog:
+# set pgp_good_sign="^gpgv?: Good signature from"
 # set pgp_good_sign="`gettext -d gnupg -s 'Good signature from "' | tr -d '"'`"
-
-# This version uses --status-fd messages
+#
+# Output pattern to indicate a valid signature using --status-fd messages
 set pgp_good_sign="^\\[GNUPG:\\] GOODSIG"
 
-# pattern to verify a decryption occurred
+# Output pattern to verify a decryption occurred
 set pgp_decryption_okay="^\\[GNUPG:\\] DECRYPTION_OKAY"
 


### PR DESCRIPTION
* **What does this PR do?**
 * renames `gpg.rc` to `gpg2.rc`
 * introduces `gpg2_1.rc` which brings in a parameter that does not exist in older GPG versions
 * places gpg commands at the end of the commandline, as required by the (often unenforced) syntax rules
 * remove use of `--always-trust` in the new version (on the advice of GPG folks)
 * ultimately fixes bug https://github.com/neomutt/neomutt/issues/944

* **Are there points in the code the reviewer needs to double check?**
I didn't do any testing on the removal of `--always-trust`.

* **Does this PR meet the acceptance criteria?**
I think so.  I do not believe this change requires any of the following.

   - Documentation created/updated (you have to edit
     [doc/manual.xml.head](https://www.github.com/neomutt/neomutt/blob/master/doc/manual.xml.head)
     for that)

   - All builds are passing

   - Added [doxygen code documentation](https://www.neomutt.org/dev/doxygen)
     [syntax](http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html)

   - Code follows the [style guide](https://www.neomutt.org/dev/coding-style)

* **What are the relevant issue numbers?**
https://github.com/neomutt/neomutt/issues/944
