### PR TITLE
small changes (mostly coverity inspired)

### DIFF
--- a/attach.c
+++ b/attach.c
@@ -530,7 +530,11 @@ int mutt_view_attachment(FILE *fp, struct Body *a, int flag, struct Header *hdr,
     else
     {
       /* interactive command */
-      if (mutt_system(command) || (entry->needsterminal && option(OPT_WAIT_KEY)))
+      int rc = mutt_system(command);
+      if (rc == -1)
+        mutt_debug(1, "Error running \"%s\"!", command);
+
+      if ((rc != 0) || (entry->needsterminal && option(OPT_WAIT_KEY)))
         mutt_any_key_to_continue(NULL);
     }
   }
@@ -1050,7 +1054,11 @@ int mutt_print_attachment(FILE *fp, struct Body *a)
     }
     else
     {
-      if (mutt_system(command) || option(OPT_WAIT_KEY))
+      int rc = mutt_system(command);
+      if (rc == -1)
+        mutt_debug(1, "Error running \"%s\"!", command);
+
+      if ((rc != 0) || option(OPT_WAIT_KEY))
         mutt_any_key_to_continue(NULL);
     }
 

--- a/attach.c
+++ b/attach.c
@@ -179,6 +179,7 @@ int mutt_compose_attachment(struct Body *a)
             /* Remove headers by copying out data to another file, then
              * copying the file back */
             fseeko(fp, b->offset, SEEK_SET);
+            mutt_free_body(&b);
             mutt_mktemp(tempfile, sizeof(tempfile));
             tfp = safe_fopen(tempfile, "w");
             if (!tfp)
@@ -195,8 +196,6 @@ int mutt_compose_attachment(struct Body *a)
               mutt_perror(_("Failure to rename file."));
               goto bailout;
             }
-
-            mutt_free_body(&b);
           }
         }
       }

--- a/attach.c
+++ b/attach.c
@@ -751,8 +751,13 @@ static FILE *save_attachment_open(char *path, int flags)
 
 /**
  * mutt_save_attachment - Save an attachment
- * @retval 0 on success
- * @retval -1 on error
+ * @param fp    Source file stream. Can be NULL
+ * @param m     Email Body
+ * @param path  Where to save the attachment
+ * @param flags Flags, e.g. #MUTT_SAVE_APPEND
+ * @param hdr   Message header for the current message. Can be NULL
+ * @retval  0 Success
+ * @retval -1 Error
  */
 int mutt_save_attachment(FILE *fp, struct Body *m, char *path, int flags, struct Header *hdr)
 {
@@ -1010,8 +1015,8 @@ int mutt_print_attachment(FILE *fp, struct Body *a)
     }
 
     /* in recv mode, save file to newfile first */
-    if (fp)
-      mutt_save_attachment(fp, a, newfile, 0, NULL);
+    if (fp && (mutt_save_attachment(fp, a, newfile, 0, NULL) != 0))
+      return 0;
 
     strfcpy(command, entry->printcommand, sizeof(command));
     piped = rfc1524_expand_command(a, newfile, type, command, sizeof(command));

--- a/browser.c
+++ b/browser.c
@@ -2003,7 +2003,7 @@ void mutt_select_file(char *f, size_t flen, int flags, char ***files, int *numfi
             }
 
             err = REGCOMP(&rx, s, REG_NOSUB);
-            if (err)
+            if (err != 0)
             {
               regerror(err, &rx, buf, sizeof(buf));
               regfree(&rx);

--- a/browser.c
+++ b/browser.c
@@ -1982,7 +1982,8 @@ void mutt_select_file(char *f, size_t flen, int flags, char ***files, int *numfi
         if (option(OPT_NEWS))
         {
           struct NntpServer *nserv = CurrentNewsSrv;
-          regex_t *rx = safe_malloc(sizeof(regex_t));
+          regex_t rx;
+          memset(&rx, 0, sizeof(rx));
           char *s = buf;
           int rc, j = menu->current;
 
@@ -1998,16 +1999,14 @@ void mutt_select_file(char *f, size_t flen, int flags, char ***files, int *numfi
               snprintf(tmp, sizeof(tmp), _("Unsubscribe pattern: "));
             if (mutt_get_field(tmp, buf, sizeof(buf), 0) != 0 || !buf[0])
             {
-              FREE(&rx);
               break;
             }
 
-            err = REGCOMP(rx, s, REG_NOSUB);
+            err = REGCOMP(&rx, s, REG_NOSUB);
             if (err)
             {
-              regerror(err, rx, buf, sizeof(buf));
-              regfree(rx);
-              FREE(&rx);
+              regerror(err, &rx, buf, sizeof(buf));
+              regfree(&rx);
               mutt_error("%s", buf);
               break;
             }
@@ -2029,7 +2028,7 @@ void mutt_select_file(char *f, size_t flen, int flags, char ***files, int *numfi
             struct FolderFile *ff = &state.entry[j];
 
             if (i == OP_BROWSER_SUBSCRIBE || i == OP_BROWSER_UNSUBSCRIBE ||
-                regexec(rx, ff->name, 0, NULL, 0) == 0)
+                regexec(&rx, ff->name, 0, NULL, 0) == 0)
             {
               if (i == OP_BROWSER_SUBSCRIBE || i == OP_SUBSCRIBE_PATTERN)
                 mutt_newsgroup_subscribe(nserv, ff->name);
@@ -2051,7 +2050,7 @@ void mutt_select_file(char *f, size_t flen, int flags, char ***files, int *numfi
               struct NntpData *nntp_data = nserv->groups_list[k];
               if (nntp_data && nntp_data->group && !nntp_data->subscribed)
               {
-                if (regexec(rx, nntp_data->group, 0, NULL, 0) == 0)
+                if (regexec(&rx, nntp_data->group, 0, NULL, 0) == 0)
                 {
                   mutt_newsgroup_subscribe(nserv, nntp_data->group);
                   add_folder(menu, &state, nntp_data->group, NULL, NULL, NULL, nntp_data);
@@ -2066,8 +2065,7 @@ void mutt_select_file(char *f, size_t flen, int flags, char ***files, int *numfi
           nntp_clear_cache(nserv);
           nntp_newsrc_close(nserv);
           if (i != OP_BROWSER_SUBSCRIBE && i != OP_BROWSER_UNSUBSCRIBE)
-            regfree(rx);
-          FREE(&rx);
+            regfree(&rx);
         }
 #ifdef USE_IMAP
         else

--- a/commands.c
+++ b/commands.c
@@ -622,7 +622,11 @@ void mutt_shell_escape(void)
       mutt_window_clearline(MuttMessageWindow, 0);
       mutt_endwin(NULL);
       fflush(stdout);
-      if (mutt_system(buf) != 0 || option(OPT_WAIT_KEY))
+      int rc = mutt_system(buf);
+      if (rc == -1)
+        mutt_debug(1, "Error running \"%s\"!", buf);
+
+      if ((rc != 0) || option(OPT_WAIT_KEY))
         mutt_any_key_to_continue(NULL);
       mutt_buffy_check(true);
     }

--- a/conn/sasl.c
+++ b/conn/sasl.c
@@ -244,13 +244,13 @@ static int mutt_sasl_cb_authname(void *context, int id, const char **result, uns
 
   if (id == SASL_CB_AUTHNAME)
   {
-    if (mutt_account_getlogin(account))
+    if (mutt_account_getlogin(account) < 0)
       return SASL_FAIL;
     *result = account->login;
   }
   else
   {
-    if (mutt_account_getuser(account))
+    if (mutt_account_getuser(account) < 0)
       return SASL_FAIL;
     *result = account->user;
   }
@@ -280,7 +280,7 @@ static int mutt_sasl_cb_pass(sasl_conn_t *conn, void *context, int id, sasl_secr
   mutt_debug(2, "mutt_sasl_cb_pass: getting password for %s@%s:%u\n",
              account->login, account->host, account->port);
 
-  if (mutt_account_getpass(account))
+  if (mutt_account_getpass(account) < 0)
     return SASL_FAIL;
 
   len = strlen(account->pass);

--- a/conn/socket.c
+++ b/conn/socket.c
@@ -87,7 +87,7 @@ static int socket_preconnect(void)
     mutt_debug(2, "Executing preconnect: %s\n", Preconnect);
     rc = mutt_system(Preconnect);
     mutt_debug(2, "Preconnect result: %d\n", rc);
-    if (rc)
+    if (rc != 0)
     {
       save_errno = errno;
       mutt_perror(_("Preconnect command failed."));

--- a/conn/ssl.c
+++ b/conn/ssl.c
@@ -360,13 +360,13 @@ static int ssl_passwd_cb(char *buf, int size, int rwflag, void *userdata)
 {
   struct Account *account = (struct Account *) userdata;
 
-  if (mutt_account_getuser(account))
+  if (mutt_account_getuser(account) < 0)
     return 0;
 
   mutt_debug(2, "ssl_passwd_cb: getting password for %s@%s:%u\n", account->user,
              account->host, account->port);
 
-  if (mutt_account_getpass(account))
+  if (mutt_account_getpass(account) < 0)
     return 0;
 
   return snprintf(buf, size, "%s", account->pass);
@@ -710,7 +710,8 @@ static void ssl_get_client_cert(struct SslSockData *ssldata, struct Connection *
     SSL_CTX_use_PrivateKey_file(ssldata->ctx, SslClientCert, SSL_FILETYPE_PEM);
 
     /* if we are using a client cert, SASL may expect an external auth name */
-    mutt_account_getuser(&conn->account);
+    if (mutt_account_getuser(&conn->account) < 0)
+      mutt_debug(1, "Couldn't get user info\n");
   }
 }
 

--- a/conn/ssl.c
+++ b/conn/ssl.c
@@ -971,7 +971,7 @@ static int interactive_check_cert(X509 *cert, int idx, int len, SSL *ssl, int al
   struct Menu *menu = mutt_new_menu(MENU_GENERIC);
   int done, row;
   FILE *fp = NULL;
-  int allow_skip = 0;
+  int ALLOW_SKIP = 0; /**< All caps tells Coverity that this is effectively a preproc condition */
 
   mutt_push_current_menu(menu);
 
@@ -1019,7 +1019,7 @@ static int interactive_check_cert(X509 *cert, int idx, int len, SSL *ssl, int al
 /* The leaf/host certificate can't be skipped. */
 #ifdef HAVE_SSL_PARTIAL_CHAIN
   if ((idx != 0) && (option(OPT_SSL_VERIFY_PARTIAL_CHAINS)))
-    allow_skip = 1;
+    ALLOW_SKIP = 1;
 #endif
 
   /* Inside ssl_verify_callback(), this function is guarded by a call to
@@ -1039,14 +1039,14 @@ static int interactive_check_cert(X509 *cert, int idx, int len, SSL *ssl, int al
   menu->keys = _("roas");
   if (allow_always)
   {
-    if (allow_skip)
+    if (ALLOW_SKIP)
       menu->prompt = _("(r)eject, accept (o)nce, (a)ccept always, (s)kip");
     else
       menu->prompt = _("(r)eject, accept (o)nce, (a)ccept always");
   }
   else
   {
-    if (allow_skip)
+    if (ALLOW_SKIP)
       menu->prompt = _("(r)eject, accept (o)nce, (s)kip");
     else
       menu->prompt = _("(r)eject, accept (o)nce");
@@ -1097,7 +1097,7 @@ static int interactive_check_cert(X509 *cert, int idx, int len, SSL *ssl, int al
         ssl_cache_trusted_cert(cert);
         break;
       case OP_MAX + 4: /* skip */
-        if (!allow_skip)
+        if (!ALLOW_SKIP)
           break;
         done = 2;
         SSL_set_ex_data(ssl, SkipModeExDataIndex, &SkipModeExDataIndex);

--- a/conn/ssl.c
+++ b/conn/ssl.c
@@ -587,7 +587,7 @@ static bool hostname_match(const char *hostname, const char *certname)
 }
 
 /**
- * ssl_init - Initialist the SSL library
+ * ssl_init - Initialise the SSL library
  * @retval  0 Success
  * @retval -1 Error
  *

--- a/conn/ssl_gnutls.c
+++ b/conn/ssl_gnutls.c
@@ -1013,7 +1013,8 @@ static void tls_get_client_cert(struct Connection *conn)
     *cnend = '\0';
 
   /* if we are using a client cert, SASL may expect an external auth name */
-  mutt_account_getuser(&conn->account);
+  if (mutt_account_getuser(&conn->account) < 0)
+    mutt_debug(1, "Couldn't get user info\n");
 
 err_dn:
   FREE(&dn);

--- a/conn/tunnel.c
+++ b/conn/tunnel.c
@@ -241,7 +241,7 @@ static int tunnel_socket_poll(struct Connection *conn, time_t wait_secs)
 
 /**
  * mutt_tunnel_socket_setup - setups tunnel connection functions.
- * @param conn Connection to asign functions to
+ * @param conn Connection to assign functions to
  *
  * Assign tunnel socket functions to the Connection conn.
  */

--- a/curs_lib.c
+++ b/curs_lib.c
@@ -1343,7 +1343,7 @@ void mutt_paddstr(int n, const char *s)
 
 /**
  * mutt_wstr_trunc - Work out how to truncate a widechar string
- * @param[in]  src    String to measute
+ * @param[in]  src    String to measure
  * @param[in]  maxlen Maximum length of string in bytes
  * @param[in]  maxwid Maximum width in screen columns
  * @param[out] width  Save the truncated screen column width

--- a/curs_lib.c
+++ b/curs_lib.c
@@ -266,10 +266,10 @@ int mutt_yesorno(const char *msg, int def)
 
   answer[1] = '\0';
 
-  reyes_ok = (expr = nl_langinfo(YESEXPR)) && expr[0] == '^' &&
-             !REGCOMP(&reyes, expr, REG_NOSUB);
-  reno_ok = (expr = nl_langinfo(NOEXPR)) && expr[0] == '^' &&
-            !REGCOMP(&reno, expr, REG_NOSUB);
+  reyes_ok = (expr = nl_langinfo(YESEXPR)) && (expr[0] == '^') &&
+             (REGCOMP(&reyes, expr, REG_NOSUB) == 0);
+  reno_ok = (expr = nl_langinfo(NOEXPR)) && (expr[0] == '^') &&
+            (REGCOMP(&reno, expr, REG_NOSUB) == 0);
 
   /*
    * In order to prevent the default answer to the question to wrapped

--- a/curs_lib.c
+++ b/curs_lib.c
@@ -233,7 +233,7 @@ void mutt_edit_file(const char *editor, const char *data)
 
   mutt_endwin(NULL);
   mutt_expand_file_fmt(cmd, sizeof(cmd), editor, data);
-  if (mutt_system(cmd))
+  if (mutt_system(cmd) != 0)
   {
     mutt_error(_("Error running \"%s\"!"), cmd);
     mutt_sleep(2);

--- a/curs_main.c
+++ b/curs_main.c
@@ -1007,7 +1007,8 @@ int mutt_index_menu(void)
               {
                 char cmd[LONG_STRING];
                 menu_status_line(cmd, sizeof(cmd), menu, NONULL(NewMailCommand));
-                mutt_system(cmd);
+                if (mutt_system(cmd) != 0)
+                  mutt_error(_("Error running \"%s\"!"), cmd);
               }
               break;
             }
@@ -1049,7 +1050,8 @@ int mutt_index_menu(void)
           {
             char cmd[LONG_STRING];
             menu_status_line(cmd, sizeof(cmd), menu, NONULL(NewMailCommand));
-            mutt_system(cmd);
+            if (mutt_system(cmd) != 0)
+              mutt_error(_("Error running \"%s\"!"), cmd);
           }
         }
       }

--- a/hcache/hcache.c
+++ b/hcache/hcache.c
@@ -587,7 +587,7 @@ static bool create_hcache_dir(const char *path)
  * If @a path exists and is a directory, it is used.
  * If @a path has a trailing '/' it is assumed to be a directory.
  * If ICONV isn't being used, then a suffix is added to the path, e.g. '-utf-8'.
- * Otherise @a path is assumed to be a file.
+ * Otherwise @a path is assumed to be a file.
  */
 static const char *hcache_per_folder(const char *path, const char *folder, hcache_namer_t namer)
 {

--- a/hcache/qdbm.c
+++ b/hcache/qdbm.c
@@ -68,7 +68,7 @@ static int hcache_qdbm_store(void *ctx, const char *key, size_t keylen, void *da
     return -1;
 
   VILLA *db = ctx;
-  /* Not sure if dbecode is reset on success, so better to explicitely return 0
+  /* Not sure if dbecode is reset on success, so better to explicitly return 0
    * on success */
   bool success = vlput(db, key, keylen, data, dlen, VL_DOVER);
   return success ? 0 : dpecode ? dpecode : -1;
@@ -80,7 +80,7 @@ static int hcache_qdbm_delete(void *ctx, const char *key, size_t keylen)
     return -1;
 
   VILLA *db = ctx;
-  /* Not sure if dbecode is reset on success, so better to explicitely return 0
+  /* Not sure if dbecode is reset on success, so better to explicitly return 0
    * on success */
   bool success = vlout(db, key, keylen);
   return success ? 0 : dpecode ? dpecode : -1;

--- a/imap/auth_anon.c
+++ b/imap/auth_anon.c
@@ -56,7 +56,7 @@ enum ImapAuthRes imap_auth_anon(struct ImapData *idata, const char *method)
   if (!mutt_bit_isset(idata->capabilities, AUTH_ANON))
     return IMAP_AUTH_UNAVAIL;
 
-  if (mutt_account_getuser(&idata->conn->account))
+  if (mutt_account_getuser(&idata->conn->account) < 0)
     return IMAP_AUTH_FAILURE;
 
   if (idata->conn->account.user[0] != '\0')

--- a/imap/auth_cram.c
+++ b/imap/auth_cram.c
@@ -117,9 +117,9 @@ enum ImapAuthRes imap_auth_cram_md5(struct ImapData *idata, const char *method)
   mutt_message(_("Authenticating (CRAM-MD5)..."));
 
   /* get auth info */
-  if (mutt_account_getlogin(&idata->conn->account))
+  if (mutt_account_getlogin(&idata->conn->account) < 0)
     return IMAP_AUTH_FAILURE;
-  if (mutt_account_getpass(&idata->conn->account))
+  if (mutt_account_getpass(&idata->conn->account) < 0)
     return IMAP_AUTH_FAILURE;
 
   imap_cmd_start(idata, "AUTHENTICATE CRAM-MD5");

--- a/imap/auth_gss.c
+++ b/imap/auth_gss.c
@@ -118,7 +118,7 @@ enum ImapAuthRes imap_auth_gss(struct ImapData *idata, const char *method)
   if (!mutt_bit_isset(idata->capabilities, AGSSAPI))
     return IMAP_AUTH_UNAVAIL;
 
-  if (mutt_account_getuser(&idata->conn->account))
+  if (mutt_account_getuser(&idata->conn->account) < 0)
     return IMAP_AUTH_FAILURE;
 
   /* get an IMAP service ticket for the server */

--- a/imap/auth_login.c
+++ b/imap/auth_login.c
@@ -61,9 +61,9 @@ enum ImapAuthRes imap_auth_login(struct ImapData *idata, const char *method)
     return IMAP_AUTH_UNAVAIL;
   }
 
-  if (mutt_account_getuser(&idata->conn->account))
+  if (mutt_account_getuser(&idata->conn->account) < 0)
     return IMAP_AUTH_FAILURE;
-  if (mutt_account_getpass(&idata->conn->account))
+  if (mutt_account_getpass(&idata->conn->account) < 0)
     return IMAP_AUTH_FAILURE;
 
   mutt_message(_("Logging in..."));

--- a/imap/auth_plain.c
+++ b/imap/auth_plain.c
@@ -53,9 +53,9 @@ enum ImapAuthRes imap_auth_plain(struct ImapData *idata, const char *method)
   enum ImapAuthRes res = IMAP_AUTH_SUCCESS;
   char buf[STRING];
 
-  if (mutt_account_getuser(&idata->conn->account))
+  if (mutt_account_getuser(&idata->conn->account) < 0)
     return IMAP_AUTH_FAILURE;
-  if (mutt_account_getpass(&idata->conn->account))
+  if (mutt_account_getpass(&idata->conn->account) < 0)
     return IMAP_AUTH_FAILURE;
 
   mutt_message(_("Logging in..."));

--- a/imap/auth_sasl.c
+++ b/imap/auth_sasl.c
@@ -82,7 +82,7 @@ enum ImapAuthRes imap_auth_sasl(struct ImapData *idata, const char *method)
      * 2. attempt sasl_client_start with only "AUTH=ANONYMOUS" capability
      * 3. if sasl_client_start fails, fall through... */
 
-    if (mutt_account_getuser(&idata->conn->account))
+    if (mutt_account_getuser(&idata->conn->account) < 0)
       return IMAP_AUTH_FAILURE;
 
     if (mutt_bit_isset(idata->capabilities, AUTH_ANON) &&

--- a/imap/command.c
+++ b/imap/command.c
@@ -66,7 +66,7 @@
 #define IMAP_CMD_BUFSIZE 512
 
 /**
- * Capabilities - Server capabilties strings that we understand
+ * Capabilities - Server capabilities strings that we understand
  *
  * @note This must be kept in the same order as ImapCaps.
  *

--- a/imap/message.c
+++ b/imap/message.c
@@ -1223,7 +1223,7 @@ int imap_close_message(struct Context *ctx, struct Message *msg)
  * @param ctx Context
  * @param msg Email info
  * @retval 0   Success
- * @retval EOF fclose() failured, see errno
+ * @retval EOF fclose() failed, see errno
  * @retval -1  Failure
  */
 int imap_commit_message(struct Context *ctx, struct Message *msg)

--- a/init.c
+++ b/init.c
@@ -1588,7 +1588,7 @@ static int parse_attach_list(struct Buffer *buf, struct Buffer *s,
 
     FREE(&tmpminor);
 
-    if (ret)
+    if (ret != 0)
     {
       regerror(ret, &a->minor_regex, err->data, err->dsize);
       FREE(&a->major);

--- a/init.h
+++ b/init.h
@@ -3939,7 +3939,7 @@ struct Option MuttVars[] = {
   { "ssl_ciphers", DT_STRING, R_NONE, UL &SslCiphers, UL 0 },
   /*
   ** .pp
-  ** Contains a colon-seperated list of ciphers to use when using SSL.
+  ** Contains a colon-separated list of ciphers to use when using SSL.
   ** For OpenSSL, see ciphers(1) for the syntax of the string.
   ** .pp
   ** For GnuTLS, this option will be used in place of "NORMAL" at the

--- a/lib/file.c
+++ b/lib/file.c
@@ -111,7 +111,7 @@ static bool compare_stat(struct stat *osb, struct stat *nsb)
  * @param nflen   Length of new filename
  * @param newdir  New directory name
  * @param ndlen   Length of new directory name
- * @retval  0 Succes 0 Success
+ * @retval  0 Success
  * @retval -1 Error
  */
 static int mkwrapdir(const char *path, char *newfile, size_t nflen, char *newdir, size_t ndlen)

--- a/lib/string.c
+++ b/lib/string.c
@@ -252,8 +252,8 @@ void mutt_str_replace(char **p, const char *s)
 }
 
 /**
- * mutt_str_append_item - Add string to another seprated by sep
- * @param str String appened
+ * mutt_str_append_item - Add string to another separated by sep
+ * @param str  String appended
  * @param item String to append
  * @param sep separator between string item
  *

--- a/mutt_account.c
+++ b/mutt_account.c
@@ -32,7 +32,10 @@
 #include "url.h"
 
 /**
- * mutt_account_match - compare account info (host/port/user)
+ * mutt_account_match - Compare account info (host/port/user)
+ * @param a1 First Account
+ * @param a2 Second Account
+ * @retval 0 Accounts match
  */
 int mutt_account_match(const struct Account *a1, const struct Account *a2)
 {
@@ -78,7 +81,11 @@ int mutt_account_match(const struct Account *a1, const struct Account *a2)
 }
 
 /**
- * mutt_account_fromurl - fill account with information from url
+ * mutt_account_fromurl - Fill Account with information from url
+ * @param account Account to fill
+ * @param url     Url to parse
+ * @retval  0 Success
+ * @retval -1 Error
  */
 int mutt_account_fromurl(struct Account *account, struct Url *url)
 {
@@ -108,7 +115,9 @@ int mutt_account_fromurl(struct Account *account, struct Url *url)
 }
 
 /**
- * mutt_account_tourl - fill URL with info from account
+ * mutt_account_tourl - Fill URL with info from account
+ * @param account Source Account
+ * @param url     Url to fill
  *
  * The URL information is a set of pointers into account - don't free or edit
  * account until you've finished with url (make a copy of account if you need
@@ -172,7 +181,10 @@ void mutt_account_tourl(struct Account *account, struct Url *url)
 }
 
 /**
- * mutt_account_getuser - retrieve username into Account, if necessary
+ * mutt_account_getuser - Retrieve username into Account, if necessary
+ * @param account Account to fill
+ * @retval  0 Success
+ * @retval -1 Failure
  */
 int mutt_account_getuser(struct Account *account)
 {
@@ -210,6 +222,12 @@ int mutt_account_getuser(struct Account *account)
   return 0;
 }
 
+/**
+ * mutt_account_getlogin - Retrieve login info into Account, if necessary
+ * @param account Account to fill
+ * @retval  0 Success
+ * @retval -1 Failure
+ */
 int mutt_account_getlogin(struct Account *account)
 {
   /* already set */
@@ -228,17 +246,26 @@ int mutt_account_getlogin(struct Account *account)
 
   if (!(account->flags & MUTT_ACCT_LOGIN))
   {
-    mutt_account_getuser(account);
-    strfcpy(account->login, account->user, sizeof(account->login));
+    if (mutt_account_getuser(account) == 0)
+    {
+      strfcpy(account->login, account->user, sizeof(account->login));
+      account->flags |= MUTT_ACCT_LOGIN;
+    }
+    else
+    {
+      mutt_debug(1, "Couldn't get user info\n");
+      return -1;
+    }
   }
-
-  account->flags |= MUTT_ACCT_LOGIN;
 
   return 0;
 }
 
 /**
- * mutt_account_getpass - fetch password into Account, if necessary
+ * mutt_account_getpass - Fetch password into Account, if necessary
+ * @param account Account to fill
+ * @retval  0 Success
+ * @retval -1 Failure
  */
 int mutt_account_getpass(struct Account *account)
 {
@@ -279,6 +306,10 @@ int mutt_account_getpass(struct Account *account)
   return 0;
 }
 
+/**
+ * mutt_account_unsetpass - Unset Account's password
+ * @param account Account to modify
+ */
 void mutt_account_unsetpass(struct Account *account)
 {
   account->flags &= ~MUTT_ACCT_PASS;

--- a/mutt_account.h
+++ b/mutt_account.h
@@ -42,11 +42,11 @@ enum AccountType
 };
 
 /* account flags */
-#define MUTT_ACCT_PORT (1 << 0)
-#define MUTT_ACCT_USER (1 << 1)
+#define MUTT_ACCT_PORT  (1 << 0)
+#define MUTT_ACCT_USER  (1 << 1)
 #define MUTT_ACCT_LOGIN (1 << 2)
-#define MUTT_ACCT_PASS (1 << 3)
-#define MUTT_ACCT_SSL (1 << 4)
+#define MUTT_ACCT_PASS  (1 << 3)
+#define MUTT_ACCT_SSL   (1 << 4)
 
 int mutt_account_match(const struct Account *a1, const struct Account *m2);
 int mutt_account_fromurl(struct Account *account, struct Url *url);

--- a/mutt_regex.h
+++ b/mutt_regex.h
@@ -37,7 +37,22 @@
 #define REG_WORDS 0
 #endif
 
+/**
+ * REGCOMP - Compile a regular expression
+ * @param X regex_t struct to fill
+ * @param Y Regular expression string
+ * @param Z Flags
+ * @retval   0 Success
+ * @retval num Failure, e.g. REG_BADPAT
+ */
 #define REGCOMP(X, Y, Z) regcomp(X, Y, REG_WORDS | REG_EXTENDED | (Z))
+/**
+ * REGEXEC - Perform a regular expression comparison
+ * @param X regex_t containing compiled regular expression
+ * @param Y String to compare
+ * @retval 0           Success
+ * @retval REG_NOMATCH Failure
+ */
 #define REGEXEC(X, Y) regexec(&X, Y, (size_t) 0, (regmatch_t *) 0, (int) 0)
 
 /**

--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -382,6 +382,9 @@ static bool crypt_key_is_valid(struct CryptKeyInfo *k)
  */
 static int crypt_id_is_strong(struct CryptKeyInfo *key)
 {
+  if (!key)
+    return 0;
+
   unsigned int is_strong = 0;
 
   if ((key->flags & KEYFLAG_ISX509))
@@ -411,6 +414,9 @@ static int crypt_id_is_strong(struct CryptKeyInfo *key)
  */
 static int crypt_id_is_valid(struct CryptKeyInfo *key)
 {
+  if (!key)
+    return 0;
+
   return !(key->flags & KEYFLAG_CANTUSE);
 }
 
@@ -431,13 +437,20 @@ static int crypt_id_matches_addr(struct Address *addr, struct Address *u_addr,
   if (crypt_id_is_strong(key))
     rv |= CRYPT_KV_STRONGID;
 
-  if (addr->mailbox && u_addr->mailbox &&
-      (mutt_strcasecmp(addr->mailbox, u_addr->mailbox) == 0))
-    rv |= CRYPT_KV_ADDR;
+  if (addr && u_addr)
+  {
+    if (addr->mailbox && u_addr->mailbox &&
+        (mutt_strcasecmp(addr->mailbox, u_addr->mailbox) == 0))
+    {
+      rv |= CRYPT_KV_ADDR;
+    }
 
-  if (addr->personal && u_addr->personal &&
-      (mutt_strcasecmp(addr->personal, u_addr->personal) == 0))
-    rv |= CRYPT_KV_STRING;
+    if (addr->personal && u_addr->personal &&
+        (mutt_strcasecmp(addr->personal, u_addr->personal) == 0))
+    {
+      rv |= CRYPT_KV_STRING;
+    }
+  }
 
   return rv;
 }

--- a/ncrypt/pgpinvoke.c
+++ b/ncrypt/pgpinvoke.c
@@ -250,7 +250,8 @@ void pgp_invoke_import(const char *fname)
   cctx.signas = PgpSignAs;
 
   mutt_pgp_command(cmd, sizeof(cmd), &cctx, PgpImportCommand);
-  mutt_system(cmd);
+  if (mutt_system(cmd) != 0)
+    mutt_debug(1, "Error running \"%s\"!", cmd);
 }
 
 void pgp_invoke_getkeys(struct Address *addr)
@@ -288,7 +289,8 @@ void pgp_invoke_getkeys(struct Address *addr)
   if (!isendwin())
     mutt_message(_("Fetching PGP key..."));
 
-  mutt_system(cmd);
+  if (mutt_system(cmd) != 0)
+    mutt_debug(1, "Error running \"%s\"!", cmd);
 
   if (!isendwin())
     mutt_clear_error();

--- a/nntp.c
+++ b/nntp.c
@@ -313,8 +313,8 @@ static int nntp_auth(struct NntpServer *nserv)
   while (true)
   {
     /* get login and password */
-    if (mutt_account_getuser(&conn->account) || !conn->account.user[0] ||
-        mutt_account_getpass(&conn->account) || !conn->account.pass[0])
+    if ((mutt_account_getuser(&conn->account) < 0) || (conn->account.user[0] == '\0') ||
+        (mutt_account_getpass(&conn->account) < 0) || (conn->account.pass[0] == '\0'))
       break;
 
     /* get list of authenticators */

--- a/opcodes.h
+++ b/opcodes.h
@@ -1,6 +1,6 @@
 /**
  * @file
- * GUI display the mailboxes in a side panel
+ * All user-callable functions
  *
  * @authors
  * Copyright (C) 2017 Damien Riegel <damien.riegel@gmail.com>
@@ -234,8 +234,8 @@
   _fmt(OP_MAIN_SHOW_LIMIT,                N_("show currently active limit pattern")) \
   _fmt(OP_MAIN_COLLAPSE_THREAD,           N_("collapse/uncollapse current thread")) \
   _fmt(OP_MAIN_COLLAPSE_ALL,              N_("collapse/uncollapse all threads")) \
-  _fmt(OP_MAIN_MODIFY_TAGS,             N_("modify (notmuch/imap) tags")) \
-  _fmt(OP_MAIN_MODIFY_TAGS_THEN_HIDE,   N_("modify (notmuch/imap) tags and then hide message")) \
+  _fmt(OP_MAIN_MODIFY_TAGS,               N_("modify (notmuch/imap) tags")) \
+  _fmt(OP_MAIN_MODIFY_TAGS_THEN_HIDE,     N_("modify (notmuch/imap) tags and then hide message")) \
 
 #define OPS_CRYPT(_fmt) \
   _fmt(OP_DECRYPT_SAVE,                   N_("make decrypted copy and delete")) \

--- a/pager.c
+++ b/pager.c
@@ -2234,7 +2234,8 @@ int mutt_pager(const char *banner, const char *fname, int flags, struct Pager *e
         {
           char cmd[LONG_STRING];
           menu_status_line(cmd, sizeof(cmd), rd.index, NONULL(NewMailCommand));
-          mutt_system(cmd);
+          if (mutt_system(cmd) != 0)
+            mutt_error(_("Error running \"%s\"!"), cmd);
         }
       }
     }

--- a/pattern.c
+++ b/pattern.c
@@ -114,7 +114,7 @@ static bool eat_regex(struct Pattern *pat, struct Buffer *s, struct Buffer *err)
     pat->p.regex = safe_malloc(sizeof(regex_t));
     r = REGCOMP(pat->p.regex, buf.data,
                 REG_NEWLINE | REG_NOSUB | mutt_which_case(buf.data));
-    if (r)
+    if (r != 0)
     {
       regerror(r, pat->p.regex, errmsg, sizeof(errmsg));
       mutt_buffer_printf(err, "'%s': %s", buf.data, errmsg);

--- a/pop_auth.c
+++ b/pop_auth.c
@@ -343,8 +343,8 @@ int pop_authenticate(struct PopData *pop_data)
   int attempts = 0;
   int ret = POP_A_UNAVAIL;
 
-  if (mutt_account_getuser(acct) || !acct->user[0] ||
-      mutt_account_getpass(acct) || !acct->pass[0])
+  if ((mutt_account_getuser(acct) < 0) || (acct->user[0] == '\0') ||
+      (mutt_account_getpass(acct) < 0) || (acct->pass[0] == '\0'))
     return -3;
 
   if (PopAuthenticators && *PopAuthenticators)

--- a/remailer.c
+++ b/remailer.c
@@ -48,7 +48,7 @@
 #include "rfc822.h"
 
 /**
- * struct Coord - Screen coordindates
+ * struct Coord - Screen coordinates
  */
 struct Coord
 {

--- a/remailer.c
+++ b/remailer.c
@@ -735,7 +735,8 @@ int mix_send_message(struct ListHead *chain, const char *tempfile)
   if (!option(OPT_NO_CURSES))
     mutt_endwin(NULL);
 
-  if ((i = mutt_system(cmd)))
+  i = mutt_system(cmd);
+  if (i != 0)
   {
     fprintf(stderr, _("Error sending message, child exited %d.\n"), i);
     if (!option(OPT_NO_CURSES))

--- a/rfc1524.c
+++ b/rfc1524.c
@@ -302,7 +302,7 @@ static int rfc1524_mailcap_parse(struct Body *a, char *filename, char *type,
             len = mutt_strlen(test_command) + STRING;
             safe_realloc(&test_command, len);
             rfc1524_expand_command(a, a->filename, type, test_command, len);
-            if (mutt_system(test_command))
+            if (mutt_system(test_command) != 0)
             {
               /* a non-zero exit code means test failed */
               found = false;

--- a/rfc1524.c
+++ b/rfc1524.c
@@ -389,7 +389,7 @@ void rfc1524_free_entry(struct Rfc1524MailcapEntry **entry)
  * @param type   Text type in "type/subtype" format
  * @param entry  struct Rfc1524MailcapEntry to populate with results
  * @param opt    Type of mailcap entry to lookup
- * @retval 1 on success. If *entry is not NULL it poplates it with the mailcap entry
+ * @retval 1 on success. If *entry is not NULL it populates it with the mailcap entry
  * @retval 0 if no matching entry is found
  *
  * opt can be one of: #MUTT_EDIT, #MUTT_COMPOSE, #MUTT_PRINT, #MUTT_AUTOVIEW

--- a/sendlib.c
+++ b/sendlib.c
@@ -2942,6 +2942,9 @@ int mutt_write_multiple_fcc(const char *path, struct Header *hdr, const char *ms
   strfcpy(fcc_tok, path, sizeof(fcc_tok));
 
   tok = strtok(fcc_tok, ",");
+  if (!tok)
+    return -1;
+
   mutt_debug(1, "Fcc: initial mailbox = '%s'\n", tok);
   /* mutt_expand_path already called above for the first token */
   status = mutt_write_fcc(tok, hdr, msgid, post, fcc, finalpath);

--- a/smtp.c
+++ b/smtp.c
@@ -535,7 +535,8 @@ static int smtp_auth_plain(struct Connection *conn)
     if (mutt_strncasecmp(method, "plain", 5) == 0)
     {
       /* Get username and password. Bail out of any cannot be retrieved. */
-      if (mutt_account_getuser(&conn->account) || mutt_account_getpass(&conn->account))
+      if ((mutt_account_getuser(&conn->account) < 0) ||
+          (mutt_account_getpass(&conn->account) < 0))
       {
         goto error;
       }

--- a/system.c
+++ b/system.c
@@ -33,6 +33,16 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 
+/**
+ * mutt_system - Run an external command
+ * @param cmd Command and argments
+ * @retval -1  Error
+ * @retval >=0 Success (command's return code)
+ *
+ * Fork and run an external command with arguments.
+ *
+ * @note This function won't return until the command finishes.
+ */
 int mutt_system(const char *cmd)
 {
   int rc = -1;


### PR DESCRIPTION
Lots of fairly simple changes.

- 0f55efa50 fix typos
- 706e3a7c0 fix leak in mutt_select_file()
- 5ab1c1c50 fix leak in mutt_compose_attachment()
- 2b7c87b7a highlight preproc-like variable
  Rename a variable to CAPS which we use like a preprocessor condition
- 1473ef364 add pointer checks to gpgme

Make sure we check the return value from functions (and document those functions):
- 122c38f33 check retval of REGCOMP()
- 09abd3d14 check retval of strtok()
- a4734be2f check retval of mutt_save_attachment()
- 6614c958f check retval of mutt_account_get{user,pass,login}()
- 31df1c24a check retval of mutt_system()
