### PR TITLE
Add chmod like functions to mutt/file.[hc]

### DIFF
--- a/attach.c
+++ b/attach.c
@@ -453,7 +453,7 @@ int mutt_view_attachment(FILE *fp, struct Body *a, int flag, struct Header *hdr,
       FREE(&fname);
       if (mutt_save_attachment(fp, a, tempfile, 0, NULL) == -1)
         goto return_error;
-      chmod(tempfile, 0400);
+      mutt_file_chmod(tempfile, S_IRUSR);
     }
 
     use_pipe = rfc1524_expand_command(a, tempfile, type, command, sizeof(command));
@@ -631,7 +631,7 @@ return_error:
   if (fp && tempfile[0])
   {
     /* Restore write permission so mutt_file_unlink can open the file for writing */
-    chmod(tempfile, 0600);
+    mutt_file_chmod_add(tempfile, S_IWUSR);
     mutt_file_unlink(tempfile);
   }
   else if (unlink_tempfile)

--- a/editmsg.c
+++ b/editmsg.c
@@ -120,10 +120,10 @@ static int edit_or_view_one_message(bool edit, struct Context *ctx, struct Heade
     goto bail;
   }
 
-  /* remove write permissions */
   if (!edit)
   {
-    rc = chmod(tmp, sb.st_mode & ~(S_IWUSR | S_IWGRP | S_IWOTH));
+    /* remove write permissions */
+    rc = mutt_file_chmod_rm_stat(tmp, S_IWUSR | S_IWGRP | S_IWOTH, &sb);
     if (rc == -1)
     {
       mutt_debug(1, "Could not remove write permissions of %s: %s", tmp, strerror(errno));

--- a/mutt/file.h
+++ b/mutt/file.h
@@ -35,6 +35,11 @@ struct stat;
 
 const char *mutt_file_basename(const char *f);
 int         mutt_file_check_empty(const char *path);
+int         mutt_file_chmod(const char *path, mode_t mode);
+int         mutt_file_chmod_add(const char *path, mode_t mode);
+int         mutt_file_chmod_add_stat(const char *path, mode_t mode, struct stat *st);
+int         mutt_file_chmod_rm(const char *path, mode_t mode);
+int         mutt_file_chmod_rm_stat(const char *path, mode_t mode, struct stat *st);
 char *      mutt_file_concatn_path(char *dst, size_t dstlen, const char *dir, size_t dirlen, const char *fname, size_t fnamelen);
 char *      mutt_file_concat_path(char *d, const char *dir, const char *fname, size_t l);
 int         mutt_file_copy_bytes(FILE *in, FILE *out, size_t size);


### PR DESCRIPTION
As discussed in pull-request #948 this implements three functions to set, add, and remove file permissions.

**Notes**

* I followed flatcap's naming convention for the functions as suggested in #948.

* `mutt_file_chmod()` is really just a `chmod()`. I added it anyway to have a complete API in `file.c`.

* I copied the approach of `mutt_file_decrease_mtime()` and gave `mutt_file_chmod_add/remove()` an optional parameter `struct stat sb` through which the caller can pass the `struct stat` for the file. Theoretically this saves a systemcall, although I doubt its usefulness.

* I converted the three calls of `chmod()` to the new functions. Please double check that the use of `mutt_file_chmod_add/remove()` is correct and shouldn't be `mutt_file_chmod()`.

* I tested the code by saving an attachment and comparing its permissions which a vanilla neomutt's saved attachment. They are the same (`rw-------`). Don't know if there are any other tests to perform (in particular how to test the error branch with `mutt_file_chmod_add()`).