### PR TITLE
Unused parameters

### DIFF
--- a/attach.h
+++ b/attach.h
@@ -87,8 +87,7 @@ void mutt_pipe_attachment_list(struct AttachCtx *actx, FILE *fp, bool tag,
 void mutt_print_attachment_list(struct AttachCtx *actx, FILE *fp, bool tag,
                                 struct Body *top);
 
-void mutt_attach_bounce(FILE *fp, struct Header *hdr, struct AttachCtx *actx,
-                        struct Body *cur);
+void mutt_attach_bounce(FILE *fp, struct AttachCtx *actx, struct Body *cur);
 void mutt_attach_resend(FILE *fp, struct Header *hdr, struct AttachCtx *actx,
                         struct Body *cur);
 void mutt_attach_forward(FILE *fp, struct Header *hdr, struct AttachCtx *actx,

--- a/attach.h
+++ b/attach.h
@@ -88,8 +88,7 @@ void mutt_print_attachment_list(struct AttachCtx *actx, FILE *fp, bool tag,
                                 struct Body *top);
 
 void mutt_attach_bounce(FILE *fp, struct AttachCtx *actx, struct Body *cur);
-void mutt_attach_resend(FILE *fp, struct Header *hdr, struct AttachCtx *actx,
-                        struct Body *cur);
+void mutt_attach_resend(FILE *fp, struct AttachCtx *actx, struct Body *cur);
 void mutt_attach_forward(FILE *fp, struct Header *hdr, struct AttachCtx *actx,
                          struct Body *cur, int flags);
 void mutt_attach_reply(FILE *fp, struct Header *hdr, struct AttachCtx *actx,

--- a/buffy.c
+++ b/buffy.c
@@ -726,7 +726,7 @@ int mutt_buffy_check(bool force)
   BuffyNotify = 0;
 
 #ifdef USE_IMAP
-  BuffyCount += imap_buffy_check(force, check_stats);
+  BuffyCount += imap_buffy_check(check_stats);
 #endif
 
   /* check device ID and serial number instead of comparing paths */

--- a/compress.c
+++ b/compress.c
@@ -128,7 +128,7 @@ static void unlock_realpath(struct Context *ctx)
   if (!ci->locked)
     return;
 
-  mutt_file_unlock(ctx->realpath, fileno(ci->lockfp));
+  mutt_file_unlock(fileno(ci->lockfp));
 
   ci->locked = 0;
   mutt_file_fclose(&ci->lockfp);

--- a/compress.c
+++ b/compress.c
@@ -96,7 +96,7 @@ static int lock_realpath(struct Context *ctx, int excl)
     return 0;
   }
 
-  int r = mutt_file_lock(ctx->realpath, fileno(ci->lockfp), excl, 1);
+  int r = mutt_file_lock(fileno(ci->lockfp), excl, 1);
 
   if (r == 0)
     ci->locked = 1;

--- a/curs_main.c
+++ b/curs_main.c
@@ -435,8 +435,8 @@ void update_index(struct Menu *menu, struct Context *ctx, int check, int oldcoun
     menu->current = ci_first_message();
 }
 
-static int main_change_folder(struct Menu *menu, int op, char *buf, size_t bufsz,
-                              int *oldcount, int *index_hint, int flags)
+static int main_change_folder(struct Menu *menu, int op, char *buf,
+                              size_t bufsz, int *oldcount, int *index_hint)
 {
 #ifdef USE_NNTP
   if (option(OPT_NEWS))
@@ -1978,7 +1978,7 @@ int mutt_index_menu(void)
         if (!nm_uri_from_query(Context, buf, sizeof(buf)))
           mutt_message(_("Failed to create query, aborting."));
         else
-          main_change_folder(menu, op, buf, sizeof(buf), &oldcount, &index_hint, 0);
+          main_change_folder(menu, op, buf, sizeof(buf), &oldcount, &index_hint);
         break;
 
       case OP_MAIN_WINDOWED_VFOLDER_BACKWARD:
@@ -1998,7 +1998,7 @@ int mutt_index_menu(void)
         if (!nm_uri_from_query(Context, buf, sizeof(buf)))
           mutt_message(_("Failed to create query, aborting."));
         else
-          main_change_folder(menu, op, buf, sizeof(buf), &oldcount, &index_hint, 0);
+          main_change_folder(menu, op, buf, sizeof(buf), &oldcount, &index_hint);
         break;
 
       case OP_MAIN_WINDOWED_VFOLDER_FORWARD:
@@ -2019,7 +2019,7 @@ int mutt_index_menu(void)
         else
         {
           mutt_debug(2, "nm: + windowed query (%s)\n", buf);
-          main_change_folder(menu, op, buf, sizeof(buf), &oldcount, &index_hint, 0);
+          main_change_folder(menu, op, buf, sizeof(buf), &oldcount, &index_hint);
         }
         break;
 
@@ -2142,7 +2142,7 @@ int mutt_index_menu(void)
           }
         }
 
-        main_change_folder(menu, op, buf, sizeof(buf), &oldcount, &index_hint, flags);
+        main_change_folder(menu, op, buf, sizeof(buf), &oldcount, &index_hint);
 #ifdef USE_NNTP
         /* mutt_buffy_check() must be done with mail-reader mode! */
         menu->help = mutt_compile_help(

--- a/enter.c
+++ b/enter.c
@@ -623,7 +623,7 @@ int mutt_enter_string_full(char *buf, size_t buflen, int col, int flags, int mul
           {
             mutt_mb_wcstombs(buf, buflen, state->wbuf, state->curpos);
             i = strlen(buf);
-            if (!mutt_nm_tag_complete(buf, buflen, i, state->tabs))
+            if (!mutt_nm_tag_complete(buf, buflen, state->tabs))
               BEEP();
 
             replace_part(state, 0, buf);

--- a/hcache/bdb.c
+++ b/hcache/bdb.c
@@ -91,7 +91,7 @@ static void *hcache_bdb_open(const char *path)
     return NULL;
   }
 
-  if (mutt_file_lock(ctx->lockfile, ctx->fd, 1, 5))
+  if (mutt_file_lock(ctx->fd, 1, 5))
     goto fail_close;
 
   ret = db_env_create(&ctx->env, 0);

--- a/hcache/bdb.c
+++ b/hcache/bdb.c
@@ -124,7 +124,7 @@ fail_db:
 fail_env:
   ctx->env->close(ctx->env, 0);
 fail_unlock:
-  mutt_file_unlock(ctx->lockfile, ctx->fd);
+  mutt_file_unlock(ctx->fd);
 fail_close:
   close(ctx->fd);
   unlink(ctx->lockfile);
@@ -199,7 +199,7 @@ static void hcache_bdb_close(void **vctx)
 
   ctx->db->close(ctx->db, 0);
   ctx->env->close(ctx->env, 0);
-  mutt_file_unlock(ctx->lockfile, ctx->fd);
+  mutt_file_unlock(ctx->fd);
   close(ctx->fd);
   unlink(ctx->lockfile);
   FREE(vctx);

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -1472,7 +1472,7 @@ int imap_check(struct ImapData *idata, int force)
  * batch the commands and save on round trips. Returns number of mailboxes with
  * new mail.
  */
-int imap_buffy_check(int force, int check_stats)
+int imap_buffy_check(int check_stats)
 {
   struct ImapData *idata = NULL;
   struct ImapData *lastdata = NULL;

--- a/imap/imap.h
+++ b/imap/imap.h
@@ -68,7 +68,7 @@ int imap_access(const char *path);
 int imap_check_mailbox(struct Context *ctx, int force);
 int imap_delete_mailbox(struct Context *ctx, struct ImapMbox *mx);
 int imap_sync_mailbox(struct Context *ctx, int expunge);
-int imap_buffy_check(int force, int check_stats);
+int imap_buffy_check(int check_stats);
 int imap_status(char *path, int queue);
 int imap_search(struct Context *ctx, const struct Pattern *pat);
 int imap_subscribe(char *path, bool subscribe);

--- a/init.c
+++ b/init.c
@@ -3737,7 +3737,7 @@ bool mutt_nm_query_complete(char *buffer, size_t len, int pos, int numtabs)
  *
  * Complete the nearest "+" or "-" -prefixed string previous to pos.
  */
-bool mutt_nm_tag_complete(char *buffer, size_t len, int pos, int numtabs)
+bool mutt_nm_tag_complete(char *buffer, size_t len, int numtabs)
 {
   if (!buffer)
     return false;

--- a/mbox.c
+++ b/mbox.c
@@ -92,7 +92,7 @@ static void mbox_unlock_mailbox(struct Context *ctx)
   {
     fflush(ctx->fp);
 
-    mutt_file_unlock(ctx->path, fileno(ctx->fp));
+    mutt_file_unlock(fileno(ctx->fp));
     ctx->locked = false;
   }
 }
@@ -496,7 +496,7 @@ static int mbox_close_mailbox(struct Context *ctx)
 
   if (ctx->append)
   {
-    mutt_file_unlock(ctx->path, fileno(ctx->fp));
+    mutt_file_unlock(fileno(ctx->fp));
     mutt_sig_unblock();
   }
 

--- a/mbox.c
+++ b/mbox.c
@@ -74,7 +74,7 @@ static int mbox_lock_mailbox(struct Context *ctx, int excl, int retry)
 {
   int r;
 
-  r = mutt_file_lock(ctx->path, fileno(ctx->fp), excl, retry);
+  r = mutt_file_lock(fileno(ctx->fp), excl, retry);
   if (r == 0)
     ctx->locked = true;
   else if (retry && !excl)

--- a/mutt/file.c
+++ b/mutt/file.c
@@ -1089,7 +1089,6 @@ int mutt_file_chmod_rm_stat(const char *path, mode_t mode, struct stat *st)
 
 /**
  * mutt_file_lock - (try to) lock a file
- * @param path    Path to file
  * @param fd      File descriptor to file
  * @param excl    If set, try to lock exclusively
  * @param timeout Retry after this time
@@ -1101,7 +1100,7 @@ int mutt_file_chmod_rm_stat(const char *path, mode_t mode, struct stat *st)
  *
  * Use mutt_file_unlock() to unlock the file.
  */
-int mutt_file_lock(const char *path, int fd, int excl, int timeout)
+int mutt_file_lock(int fd, int excl, int timeout)
 {
 #if defined(USE_FCNTL) || defined(USE_FLOCK)
   int count;
@@ -1236,7 +1235,7 @@ void mutt_file_unlink_empty(const char *path)
   if (fd == -1)
     return;
 
-  if (mutt_file_lock(path, fd, 1, 1) == -1)
+  if (mutt_file_lock(fd, 1, 1) == -1)
   {
     close(fd);
     return;

--- a/mutt/file.c
+++ b/mutt/file.c
@@ -1200,11 +1200,10 @@ int mutt_file_lock(int fd, int excl, int timeout)
 
 /**
  * mutt_file_unlock - Unlock a file previously locked by mutt_file_lock()
- * @param path Path to file
- * @param fd   File descriptor to file
+ * @param fd File descriptor to file
  * @retval 0 Always
  */
-int mutt_file_unlock(const char *path, int fd)
+int mutt_file_unlock(int fd)
 {
 #ifdef USE_FCNTL
   struct flock unlockit = { F_UNLCK, 0, 0, 0, 0 };
@@ -1244,7 +1243,7 @@ void mutt_file_unlink_empty(const char *path)
   if (fstat(fd, &sb) == 0 && sb.st_size == 0)
     unlink(path);
 
-  mutt_file_unlock(path, fd);
+  mutt_file_unlock(fd);
   close(fd);
 }
 

--- a/mutt/file.h
+++ b/mutt/file.h
@@ -49,7 +49,7 @@ const char *mutt_file_dirname(const char *p);
 int         mutt_file_fclose(FILE **f);
 FILE *      mutt_file_fopen(const char *path, const char *mode);
 int         mutt_file_fsync_close(FILE **f);
-int         mutt_file_lock(const char *path, int fd, int excl, int timeout);
+int         mutt_file_lock(int fd, int excl, int timeout);
 int         mutt_file_mkdir(const char *path, mode_t mode);
 int         mutt_file_open(const char *path, int flags);
 size_t      mutt_file_quote_filename(char *d, size_t l, const char *f);

--- a/mutt/file.h
+++ b/mutt/file.h
@@ -66,6 +66,6 @@ int         mutt_file_to_absolute_path(char *path, const char *reference);
 void        mutt_file_touch_atime(int f);
 void        mutt_file_unlink(const char *s);
 void        mutt_file_unlink_empty(const char *path);
-int         mutt_file_unlock(const char *path, int fd);
+int         mutt_file_unlock(int fd);
 
 #endif /* _MUTT_FILE_H */

--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -5034,7 +5034,7 @@ int smime_gpgme_send_menu(struct Header *msg)
   return gpgme_send_menu(msg, 1);
 }
 
-static int verify_sender(struct Header *h, gpgme_protocol_t protocol)
+static int verify_sender(struct Header *h)
 {
   struct Address *sender = NULL;
   unsigned int rc = 1;
@@ -5114,7 +5114,7 @@ static int verify_sender(struct Header *h, gpgme_protocol_t protocol)
 
 int smime_gpgme_verify_sender(struct Header *h)
 {
-  return verify_sender(h, GPGME_PROTOCOL_CMS);
+  return verify_sender(h);
 }
 
 void mutt_gpgme_set_sender(const char *sender)

--- a/newsrc.c
+++ b/newsrc.c
@@ -188,7 +188,7 @@ int nntp_newsrc_parse(struct NntpServer *nserv)
 
   /* lock it */
   mutt_debug(1, "Locking %s\n", nserv->newsrc_file);
-  if (mutt_file_lock(nserv->newsrc_file, fileno(nserv->newsrc_fp), 0, 1))
+  if (mutt_file_lock(fileno(nserv->newsrc_fp), 0, 1))
   {
     mutt_file_fclose(&nserv->newsrc_fp);
     return -1;

--- a/newsrc.c
+++ b/newsrc.c
@@ -124,7 +124,7 @@ void nntp_newsrc_close(struct NntpServer *nserv)
     return;
 
   mutt_debug(1, "Unlocking %s\n", nserv->newsrc_file);
-  mutt_file_unlock(nserv->newsrc_file, fileno(nserv->newsrc_fp));
+  mutt_file_unlock(fileno(nserv->newsrc_fp));
   mutt_file_fclose(&nserv->newsrc_fp);
 }
 

--- a/pager.c
+++ b/pager.c
@@ -2719,7 +2719,7 @@ int mutt_pager(const char *banner, const char *fname, int flags, struct Pager *e
         CHECK_MODE(IsHeader(extra) || IsMsgAttach(extra))
         CHECK_ATTACH;
         if (IsMsgAttach(extra))
-          mutt_attach_resend(extra->fp, extra->hdr, extra->actx, extra->bdy);
+          mutt_attach_resend(extra->fp, extra->actx, extra->bdy);
         else
           mutt_resend_message(NULL, extra->ctx, extra->hdr);
         pager_menu->redraw = REDRAW_FULL;

--- a/pager.c
+++ b/pager.c
@@ -2710,7 +2710,7 @@ int mutt_pager(const char *banner, const char *fname, int flags, struct Pager *e
         CHECK_MODE(IsHeader(extra) || IsMsgAttach(extra))
         CHECK_ATTACH;
         if (IsMsgAttach(extra))
-          mutt_attach_bounce(extra->fp, extra->hdr, extra->actx, extra->bdy);
+          mutt_attach_bounce(extra->fp, extra->actx, extra->bdy);
         else
           ci_bounce_message(extra->hdr);
         break;

--- a/protos.h
+++ b/protos.h
@@ -196,7 +196,7 @@ void mutt_check_lookup_list(struct Body *b, char *type, int len);
 void mutt_make_attribution(struct Context *ctx, struct Header *cur, FILE *out);
 void mutt_make_forward_subject(struct Envelope *env, struct Context *ctx, struct Header *cur);
 void mutt_make_help(char *d, size_t dlen, const char *txt, int menu, int op);
-void mutt_make_misc_reply_headers(struct Envelope *env, struct Context *ctx, struct Header *cur, struct Envelope *curenv);
+void mutt_make_misc_reply_headers(struct Envelope *env, struct Envelope *curenv);
 void mutt_make_post_indent(struct Context *ctx, struct Header *cur, FILE *out);
 void mutt_message_to_7bit(struct Body *a, FILE *fp);
 void mutt_mktemp_full(char *s, size_t slen, const char *prefix, const char *suffix, const char *src, int line);

--- a/protos.h
+++ b/protos.h
@@ -257,7 +257,7 @@ int mutt_command_complete(char *buffer, size_t len, int pos, int numtabs);
 int mutt_var_value_complete(char *buffer, size_t len, int pos);
 #ifdef USE_NOTMUCH
 bool mutt_nm_query_complete(char *buffer, size_t len, int pos, int numtabs);
-bool mutt_nm_tag_complete(char *buffer, size_t len, int pos, int numtabs);
+bool mutt_nm_tag_complete(char *buffer, size_t len, int numtabs);
 #endif
 int mutt_complete(char *s, size_t slen);
 int mutt_compose_attachment(struct Body *a);

--- a/recvattach.c
+++ b/recvattach.c
@@ -1357,7 +1357,7 @@ void mutt_view_attachments(struct Header *hdr)
 
       case OP_BOUNCE_MESSAGE:
         CHECK_ATTACH;
-        mutt_attach_bounce(CURATTACH->fp, hdr, actx,
+        mutt_attach_bounce(CURATTACH->fp, actx,
                            menu->tagprefix ? NULL : CURATTACH->content);
         menu->redraw = REDRAW_FULL;
         break;

--- a/recvattach.c
+++ b/recvattach.c
@@ -1350,7 +1350,7 @@ void mutt_view_attachments(struct Header *hdr)
 
       case OP_RESEND:
         CHECK_ATTACH;
-        mutt_attach_resend(CURATTACH->fp, hdr, actx,
+        mutt_attach_resend(CURATTACH->fp, actx,
                            menu->tagprefix ? NULL : CURATTACH->content);
         menu->redraw = REDRAW_FULL;
         break;

--- a/recvcmd.c
+++ b/recvcmd.c
@@ -119,7 +119,7 @@ static short count_tagged_children(struct AttachCtx *actx, short i)
 /**
  * mutt_attach_bounce - Bounce function, from the attachment menu
  */
-void mutt_attach_bounce(FILE *fp, struct Header *hdr, struct AttachCtx *actx, struct Body *cur)
+void mutt_attach_bounce(FILE *fp, struct AttachCtx *actx, struct Body *cur)
 {
   char prompt[STRING];
   char buf[HUGE_STRING];

--- a/recvcmd.c
+++ b/recvcmd.c
@@ -762,7 +762,7 @@ static int attach_reply_envelope_defaults(struct Envelope *env, struct AttachCtx
 
     mutt_fix_reply_recipients(env);
   }
-  mutt_make_misc_reply_headers(env, Context, curhdr, curenv);
+  mutt_make_misc_reply_headers(env, curenv);
 
   if (parent)
     mutt_add_to_reference_headers(env, curenv);

--- a/recvcmd.c
+++ b/recvcmd.c
@@ -377,7 +377,7 @@ static struct Body **copy_problematic_attachments(struct Body **last,
  * (non-message types)
  */
 static void attach_forward_bodies(FILE *fp, struct Header *hdr, struct AttachCtx *actx,
-                                  struct Body *cur, short nattach, int flags)
+                                  struct Body *cur, short nattach)
 {
   bool mime_fwd_all = false;
   bool mime_fwd_any = true;
@@ -674,7 +674,7 @@ void mutt_attach_forward(FILE *fp, struct Header *hdr, struct AttachCtx *actx,
   else
   {
     nattach = count_tagged(actx);
-    attach_forward_bodies(fp, hdr, actx, cur, nattach, flags);
+    attach_forward_bodies(fp, hdr, actx, cur, nattach);
   }
 }
 

--- a/recvcmd.c
+++ b/recvcmd.c
@@ -781,7 +781,7 @@ static int attach_reply_envelope_defaults(struct Envelope *env, struct AttachCtx
 /**
  * attach_include_reply - This is _very_ similar to send.c's include_reply()
  */
-static void attach_include_reply(FILE *fp, FILE *tmpfp, struct Header *cur, int flags)
+static void attach_include_reply(FILE *fp, FILE *tmpfp, struct Header *cur)
 {
   int cmflags = MUTT_CM_PREFIX | MUTT_CM_DECODE | MUTT_CM_CHARCONV;
   int chflags = CH_DECODE;
@@ -875,13 +875,13 @@ void mutt_attach_reply(FILE *fp, struct Header *hdr, struct AttachCtx *actx,
   if (!parent_hdr)
   {
     if (cur)
-      attach_include_reply(fp, tmpfp, cur->hdr, flags);
+      attach_include_reply(fp, tmpfp, cur->hdr);
     else
     {
       for (short i = 0; i < actx->idxlen; i++)
       {
         if (actx->idx[i]->content->tagged)
-          attach_include_reply(actx->idx[i]->fp, tmpfp, actx->idx[i]->content->hdr, flags);
+          attach_include_reply(actx->idx[i]->fp, tmpfp, actx->idx[i]->content->hdr);
       }
     }
   }

--- a/recvcmd.c
+++ b/recvcmd.c
@@ -556,8 +556,7 @@ bail:
  * relies on a context structure to find messages, while, on the attachment
  * menu, messages are referenced through the attachment index.
  */
-static void attach_forward_msgs(FILE *fp, struct Header *hdr,
-                                struct AttachCtx *actx, struct Body *cur, int flags)
+static void attach_forward_msgs(FILE *fp, struct AttachCtx *actx, struct Body *cur, int flags)
 {
   struct Header *curhdr = NULL;
   struct Header *tmphdr = NULL;
@@ -670,7 +669,7 @@ void mutt_attach_forward(FILE *fp, struct Header *hdr, struct AttachCtx *actx,
   short nattach;
 
   if (check_all_msg(actx, cur, false))
-    attach_forward_msgs(fp, hdr, actx, cur, flags);
+    attach_forward_msgs(fp, actx, cur, flags);
   else
   {
     nattach = count_tagged(actx);

--- a/recvcmd.c
+++ b/recvcmd.c
@@ -241,7 +241,7 @@ void mutt_attach_bounce(FILE *fp, struct AttachCtx *actx, struct Body *cur)
 /**
  * mutt_attach_resend - resend-message, from the attachment menu
  */
-void mutt_attach_resend(FILE *fp, struct Header *hdr, struct AttachCtx *actx, struct Body *cur)
+void mutt_attach_resend(FILE *fp, struct AttachCtx *actx, struct Body *cur)
 {
   if (!check_all_msg(actx, cur, true))
     return;

--- a/send.c
+++ b/send.c
@@ -709,8 +709,7 @@ void mutt_make_forward_subject(struct Envelope *env, struct Context *ctx, struct
   mutt_str_replace(&env->subject, buffer);
 }
 
-void mutt_make_misc_reply_headers(struct Envelope *env, struct Context *ctx,
-                                  struct Header *cur, struct Envelope *curenv)
+void mutt_make_misc_reply_headers(struct Envelope *env, struct Envelope *curenv)
 {
   if (!env || !curenv)
     return;
@@ -835,7 +834,7 @@ static int envelope_defaults(struct Envelope *env, struct Context *ctx,
       return -1;
     }
 
-    mutt_make_misc_reply_headers(env, ctx, cur, curenv);
+    mutt_make_misc_reply_headers(env, curenv);
     make_reference_headers(tag ? NULL : curenv, env, ctx);
   }
   else if (flags & SENDFORWARD)

--- a/sendlib.c
+++ b/sendlib.c
@@ -298,7 +298,7 @@ static void encode_base64(FGETCONV *fc, FILE *fout, int istext)
   fputc('\n', fout);
 }
 
-static void encode_8bit(FGETCONV *fc, FILE *fout, int istext)
+static void encode_8bit(FGETCONV *fc, FILE *fout)
 {
   int ch;
 
@@ -488,7 +488,7 @@ int mutt_write_mime_body(struct Body *a, FILE *f)
   else if (a->encoding == ENCBASE64)
     encode_base64(fc, f, write_as_text_part(a));
   else if (a->type == TYPETEXT && (!a->noconv))
-    encode_8bit(fc, f, write_as_text_part(a));
+    encode_8bit(fc, f);
   else
     mutt_file_copy_stream(fpin, f);
   mutt_sig_allow_interrupt(0);


### PR DESCRIPTION
### Unused

These 13 functions have unused parameters.
I suggest we remove them (and add them back _if_ we ever need them).
They're in separate commits for ease of review; I'll squash them all before merging.

| Commit   | File                 | Function(argument)                    |
| :------- | :------------------- | :------------------------------------ |
| 99a1c25d | curs_main.c          | main_change_folder(flags)             |
| ea00c482 | imap/imap.c          | imap_buffy_check(force)               |
| 58c295e6 | init.c               | mutt_nm_tag_complete(pos)             |
| fcbf897c | mutt/file.c          | mutt_file_lock(path)                  |
| 1b4ee25b | mutt/file.c          | mutt_file_unlock(path)                |
| 2c0e95df | ncrypt/crypt_gpgme.c | verify_sender(protocol)               |
| 31dbecf9 | recvcmd.c            | attach_forward_bodies(flags)          |
| e504ea0c | recvcmd.c            | attach_forward_msgs(hdr)              |
| 6aab5181 | recvcmd.c            | attach_include_reply(flags)           |
| 460cfff0 | recvcmd.c            | mutt_attach_bounce(hdr)               |
| 32ce5a51 | recvcmd.c            | mutt_attach_resend(hdr)               |
| b5038b6b | send.c               | mutt_make_misc_reply_headers(hdr,ctx) |
| 13df4039 | sendlib.c            | encode_8bit(istext)                   |

### Macro

I'd like to add a macro to wrap all the other unused parameters.
They are common in various APIs: string formatting, hcache, etc.
With the macro in place, we can enable the compiler option: `-Wunused-parameter` to catch any new unused parameters.

```c
#define UNUSED(x) UNUSED_ ## x __attribute__((__unused__))
```