### PR TITLE
Add UNUSED macro for parameters

### DIFF
--- a/addrbook.c
+++ b/addrbook.c
@@ -71,10 +71,11 @@ static const struct Mapping AliasHelp[] = {
  * | \%r     | Address which alias expands to
  * | \%t     | Character which indicates if the alias is tagged for inclusion
  */
-static const char *alias_format_str(char *buf, size_t buflen, size_t col, int cols,
-                                    char op, const char *src, const char *prec,
-                                    const char *if_str, const char *else_str,
-                                    unsigned long data, enum FormatFlag flags)
+static const char *alias_format_str(char *buf, size_t buflen, size_t UNUSED(col),
+                                    int UNUSED(cols), char op, const char *src,
+                                    const char *prec, const char *UNUSED(if_str),
+                                    const char *UNUSED(else_str), unsigned long data,
+                                    enum FormatFlag UNUSED(flags))
 {
   char fmt[SHORT_STRING], addr[SHORT_STRING];
   struct Alias *alias = (struct Alias *) data;

--- a/auto.def
+++ b/auto.def
@@ -207,6 +207,8 @@ if {1} {
   if {![catch {exec [get-define CC] --version} res]} {
     if {[regexp -nocase gcc $res]} {
       define-append CFLAGS "-fno-delete-null-pointer-checks"
+      define-append CFLAGS "-Wunused-parameter"
+      define-append CFLAGS "-Wshadow"
     }
   }
 

--- a/buffy.c
+++ b/buffy.c
@@ -543,7 +543,7 @@ void mutt_update_mailbox(struct Buffy *b)
 }
 
 int mutt_parse_mailboxes(struct Buffer *path, struct Buffer *s,
-                         unsigned long data, struct Buffer *err)
+                         unsigned long data, struct Buffer *UNUSED(err))
 {
   struct Buffy **b = NULL;
   char buf[_POSIX_PATH_MAX];
@@ -634,7 +634,7 @@ int mutt_parse_mailboxes(struct Buffer *path, struct Buffer *s,
 }
 
 int mutt_parse_unmailboxes(struct Buffer *path, struct Buffer *s,
-                           unsigned long data, struct Buffer *err)
+                           unsigned long data, struct Buffer *UNUSED(err))
 {
   char buf[_POSIX_PATH_MAX];
   bool clear_all = false;

--- a/color.c
+++ b/color.c
@@ -488,8 +488,8 @@ static void do_uncolor(struct Buffer *buf, struct Buffer *s,
  * * uncolor index pattern [pattern...]
  * * unmono  index pattern [pattern...]
  */
-static int parse_uncolor(struct Buffer *buf, struct Buffer *s, unsigned long data,
-                         struct Buffer *err, short parse_uncolor)
+static int parse_uncolor(struct Buffer *buf, struct Buffer *s,
+                         unsigned long UNUSED(data), struct Buffer *err, short parse_uncolor)
 {
   int object = 0, do_cache = 0;
 
@@ -980,8 +980,8 @@ static int parse_color(struct Buffer *buf, struct Buffer *s, struct Buffer *err,
 
 #ifdef HAVE_COLOR
 
-int mutt_parse_color(struct Buffer *buf, struct Buffer *s, unsigned long data,
-                     struct Buffer *err)
+int mutt_parse_color(struct Buffer *buf, struct Buffer *s,
+                     unsigned long UNUSED(data), struct Buffer *err)
 {
   bool dry_run = false;
 
@@ -993,8 +993,8 @@ int mutt_parse_color(struct Buffer *buf, struct Buffer *s, unsigned long data,
 
 #endif
 
-int mutt_parse_mono(struct Buffer *buf, struct Buffer *s, unsigned long data,
-                    struct Buffer *err)
+int mutt_parse_mono(struct Buffer *buf, struct Buffer *s,
+                    unsigned long UNUSED(data), struct Buffer *err)
 {
   bool dry_run = false;
 

--- a/compress.c
+++ b/compress.c
@@ -349,10 +349,11 @@ static char *escape_path(char *src)
  * | \%f     | Compressed file
  * | \%t     | Plaintext, temporary file
  */
-static const char *compress_format_str(char *buf, size_t buflen, size_t col, int cols,
-                                       char op, const char *src, const char *prec,
-                                       const char *if_str, const char *else_str,
-                                       unsigned long data, enum FormatFlag flags)
+static const char *
+compress_format_str(char *buf, size_t buflen, size_t UNUSED(col), int UNUSED(cols),
+                    char op, const char *src, const char *UNUSED(prec),
+                    const char *UNUSED(if_str), const char *UNUSED(else_str),
+                    unsigned long data, enum FormatFlag UNUSED(flags))
 {
   if (!buf || (data == 0))
     return src;

--- a/conn/sasl.c
+++ b/conn/sasl.c
@@ -171,7 +171,7 @@ static int iptostring(const struct sockaddr *addr, socklen_t addrlen, char *out,
  * @param message  Message
  * @retval int SASL_OK, always
  */
-static int mutt_sasl_cb_log(void *UNUSED(context), int priority, const char *message)
+static int mutt_sasl_cb_log(void *UNUSED(context), int CONDIT(priority), const char *CONDIT(message))
 {
   mutt_debug(priority, "SASL: %s\n", message);
 

--- a/conn/sasl.c
+++ b/conn/sasl.c
@@ -171,7 +171,7 @@ static int iptostring(const struct sockaddr *addr, socklen_t addrlen, char *out,
  * @param message  Message
  * @retval int SASL_OK, always
  */
-static int mutt_sasl_cb_log(void *context, int priority, const char *message)
+static int mutt_sasl_cb_log(void *UNUSED(context), int priority, const char *message)
 {
   mutt_debug(priority, "SASL: %s\n", message);
 
@@ -268,7 +268,8 @@ static int mutt_sasl_cb_authname(void *context, int id, const char **result, uns
  * @param[out] psecret SASL secret
  * @retval int SASL error code, e.g SASL_FAIL
  */
-static int mutt_sasl_cb_pass(sasl_conn_t *conn, void *context, int id, sasl_secret_t **psecret)
+static int mutt_sasl_cb_pass(sasl_conn_t *UNUSED(conn), void *context,
+                             int UNUSED(id), sasl_secret_t **psecret)
 {
   struct Account *account = (struct Account *) context;
   int len;

--- a/conn/socket.c
+++ b/conn/socket.c
@@ -201,7 +201,7 @@ int mutt_socket_close(struct Connection *conn)
  * @retval >0 Number of bytes written
  * @retval -1 Error
  */
-int mutt_socket_write_d(struct Connection *conn, const char *buf, int len, int dbg)
+int mutt_socket_write_d(struct Connection *conn, const char *buf, int len, int CONDIT(dbg))
 {
   int rc;
   int sent = 0;
@@ -300,7 +300,7 @@ int mutt_socket_readchar(struct Connection *conn, char *c)
  * @retval >0 Success, number of bytes read
  * @retval -1 Error
  */
-int mutt_socket_readln_d(char *buf, size_t buflen, struct Connection *conn, int dbg)
+int mutt_socket_readln_d(char *buf, size_t buflen, struct Connection *conn, int CONDIT(dbg))
 {
   char ch;
   int i;

--- a/conn/ssl.c
+++ b/conn/ssl.c
@@ -349,7 +349,7 @@ static void ssl_dprint_err_stack(void)
  * @retval >0 Success, number of chars written to buf
  * @retval  0 Error
  */
-static int ssl_passwd_cb(char *buf, int size, int rwflag, void *userdata)
+static int ssl_passwd_cb(char *buf, int size, int UNUSED(rwflag), void *userdata)
 {
   struct Account *account = (struct Account *) userdata;
 
@@ -370,7 +370,7 @@ static int ssl_passwd_cb(char *buf, int size, int rwflag, void *userdata)
  * @param conn Connection to a server
  * @retval -1 Always
  */
-static int ssl_socket_open_err(struct Connection *conn)
+static int ssl_socket_open_err(struct Connection *UNUSED(conn))
 {
   mutt_error(_("SSL disabled due to the lack of entropy"));
   mutt_sleep(2);

--- a/copy.c
+++ b/copy.c
@@ -784,7 +784,7 @@ int mutt_copy_message_ctx(FILE *fpout, struct Context *src, struct Header *hdr,
  * @retval 0 on success
  * @retval -1 on error
  */
-static int append_message(struct Context *dest, FILE *fpin, struct Context *src,
+static int append_message(struct Context *dest, FILE *fpin, struct Context *CONDIT(src),
                           struct Header *hdr, int flags, int chflags)
 {
   char buf[STRING];

--- a/handler.c
+++ b/handler.c
@@ -1615,7 +1615,7 @@ void mutt_decode_attachment(struct Body *b, struct State *s)
  * all trailing spaces to improve interoperability; if $text_flowed is unset,
  * simply verbatim copy input
  */
-static int text_plain_handler(struct Body *b, struct State *s)
+static int text_plain_handler(struct Body *UNUSED(b), struct State *s)
 {
   char *buf = NULL;
   size_t l = 0, sz = 0;

--- a/hcache/bdb.c
+++ b/hcache/bdb.c
@@ -151,7 +151,7 @@ static void *hcache_bdb_fetch(void *vctx, const char *key, size_t keylen)
   return data.data;
 }
 
-static void hcache_bdb_free(void *vctx, void **data)
+static void hcache_bdb_free(void *UNUSED(vctx), void **data)
 {
   FREE(data);
 }

--- a/hcache/gdbm.c
+++ b/hcache/gdbm.c
@@ -67,7 +67,7 @@ static void *hcache_gdbm_fetch(void *ctx, const char *key, size_t keylen)
   return data.dptr;
 }
 
-static void hcache_gdbm_free(void *vctx, void **data)
+static void hcache_gdbm_free(void *UNUSED(vctx), void **data)
 {
   FREE(data);
 }

--- a/hcache/kc.c
+++ b/hcache/kc.c
@@ -76,7 +76,7 @@ static void *hcache_kyotocabinet_fetch(void *ctx, const char *key, size_t keylen
   return kcdbget(db, key, keylen, &sp);
 }
 
-static void hcache_kyotocabinet_free(void *vctx, void **data)
+static void hcache_kyotocabinet_free(void *UNUSED(vctx), void **data)
 {
   kcfree(*data);
   *data = NULL;

--- a/hcache/lmdb.c
+++ b/hcache/lmdb.c
@@ -191,7 +191,7 @@ static void *hcache_lmdb_fetch(void *vctx, const char *key, size_t keylen)
   return data.mv_data;
 }
 
-static void hcache_lmdb_free(void *vctx, void **data)
+static void hcache_lmdb_free(void *UNUSED(vctx), void **UNUSED(data))
 {
   /* LMDB data is owned by the database */
 }

--- a/hcache/qdbm.c
+++ b/hcache/qdbm.c
@@ -56,7 +56,7 @@ static void *hcache_qdbm_fetch(void *ctx, const char *key, size_t keylen)
   return vlget(db, key, keylen, NULL);
 }
 
-static void hcache_qdbm_free(void *ctx, void **data)
+static void hcache_qdbm_free(void *UNUSED(ctx), void **data)
 {
   FREE(data);
 }

--- a/hcache/tc.c
+++ b/hcache/tc.c
@@ -67,7 +67,7 @@ static void *hcache_tokyocabinet_fetch(void *ctx, const char *key, size_t keylen
   return tcbdbget(db, key, keylen, &sp);
 }
 
-static void hcache_tokyocabinet_free(void *ctx, void **data)
+static void hcache_tokyocabinet_free(void *UNUSED(ctx), void **data)
 {
   FREE(data);
 }

--- a/hook.c
+++ b/hook.c
@@ -59,8 +59,8 @@ static TAILQ_HEAD(HookHead, Hook) Hooks = TAILQ_HEAD_INITIALIZER(Hooks);
 
 static int current_hook_type = 0;
 
-int mutt_parse_hook(struct Buffer *buf, struct Buffer *s, unsigned long data,
-                    struct Buffer *err)
+int mutt_parse_hook(struct Buffer *UNUSED(buf), struct Buffer *s,
+                    unsigned long data, struct Buffer *err)
 {
   struct Hook *ptr = NULL;
   struct Buffer command, pattern;
@@ -299,8 +299,8 @@ static void delete_hooks(int type)
   }
 }
 
-int mutt_parse_unhook(struct Buffer *buf, struct Buffer *s, unsigned long data,
-                      struct Buffer *err)
+int mutt_parse_unhook(struct Buffer *buf, struct Buffer *s,
+                      unsigned long UNUSED(data), struct Buffer *err)
 {
   while (MoreArgs(s))
   {

--- a/imap/auth_anon.c
+++ b/imap/auth_anon.c
@@ -49,7 +49,7 @@
  *
  * this is basically a stripped-down version of the cram-md5 method.
  */
-enum ImapAuthRes imap_auth_anon(struct ImapData *idata, const char *method)
+enum ImapAuthRes imap_auth_anon(struct ImapData *idata, const char *UNUSED(method))
 {
   int rc;
 

--- a/imap/auth_cram.c
+++ b/imap/auth_cram.c
@@ -103,7 +103,7 @@ static void hmac_md5(const char *password, char *challenge, unsigned char *respo
  * @param method Name of this authentication method
  * @retval enum Result, e.g. #IMAP_AUTH_SUCCESS
  */
-enum ImapAuthRes imap_auth_cram_md5(struct ImapData *idata, const char *method)
+enum ImapAuthRes imap_auth_cram_md5(struct ImapData *idata, const char *UNUSED(method))
 {
   char ibuf[LONG_STRING * 2], obuf[LONG_STRING];
   unsigned char hmac_response[MD5_DIGEST_LEN];

--- a/imap/auth_gss.c
+++ b/imap/auth_gss.c
@@ -98,7 +98,7 @@ static void print_gss_error(OM_uint32 err_maj, OM_uint32 err_min)
  * @param method Name of this authentication method
  * @retval enum Result, e.g. #IMAP_AUTH_SUCCESS
  */
-enum ImapAuthRes imap_auth_gss(struct ImapData *idata, const char *method)
+enum ImapAuthRes imap_auth_gss(struct ImapData *idata, const char *UNUSED(method))
 {
   gss_buffer_desc request_buf, send_token;
   gss_buffer_t sec_token;

--- a/imap/auth_login.c
+++ b/imap/auth_login.c
@@ -49,7 +49,7 @@
  * @param method Name of this authentication method
  * @retval enum Result, e.g. #IMAP_AUTH_SUCCESS
  */
-enum ImapAuthRes imap_auth_login(struct ImapData *idata, const char *method)
+enum ImapAuthRes imap_auth_login(struct ImapData *idata, const char *UNUSED(method))
 {
   char q_user[SHORT_STRING], q_pass[SHORT_STRING];
   char buf[STRING];

--- a/imap/auth_plain.c
+++ b/imap/auth_plain.c
@@ -47,7 +47,7 @@
  * @param method Name of this authentication method
  * @retval enum Result, e.g. #IMAP_AUTH_SUCCESS
  */
-enum ImapAuthRes imap_auth_plain(struct ImapData *idata, const char *method)
+enum ImapAuthRes imap_auth_plain(struct ImapData *idata, const char *UNUSED(method))
 {
   int rc;
   enum ImapAuthRes res = IMAP_AUTH_SUCCESS;

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -2248,7 +2248,7 @@ fail_noidata:
  * @retval  0 Success
  * @retval -1 Failure
  */
-static int imap_open_mailbox_append(struct Context *ctx, int flags)
+static int imap_open_mailbox_append(struct Context *ctx, int UNUSED(flags))
 {
   struct ImapData *idata = NULL;
   char buf[LONG_STRING];
@@ -2367,7 +2367,8 @@ static int imap_close_mailbox(struct Context *ctx)
  * @retval  0 Success
  * @retval -1 Failure
  */
-static int imap_open_new_message(struct Message *msg, struct Context *dest, struct Header *hdr)
+static int imap_open_new_message(struct Message *msg, struct Context *UNUSED(dest),
+                                 struct Header *UNUSED(hdr))
 {
   char tmp[_POSIX_PATH_MAX];
 

--- a/imap/message.c
+++ b/imap/message.c
@@ -1223,7 +1223,7 @@ bail:
  * @retval 0   Success
  * @retval EOF Failure, see errno
  */
-int imap_close_message(struct Context *ctx, struct Message *msg)
+int imap_close_message(struct Context *UNUSED(ctx), struct Message *msg)
 {
   return mutt_file_fclose(&msg->fp);
 }

--- a/init.c
+++ b/init.c
@@ -754,8 +754,8 @@ static void add_to_stailq(struct ListHead *head, const char *str)
  *
  * If the 'finish' command is found, we should stop reading the current file.
  */
-static int finish_source(struct Buffer *tmp, struct Buffer *s,
-                         unsigned long data, struct Buffer *err)
+static int finish_source(struct Buffer *UNUSED(tmp), struct Buffer *s,
+                         unsigned long UNUSED(data), struct Buffer *err)
 {
   if (MoreArgs(s))
   {
@@ -887,7 +887,7 @@ static void remove_from_stailq(struct ListHead *head, const char *str)
 }
 
 static int parse_unignore(struct Buffer *buf, struct Buffer *s,
-                          unsigned long data, struct Buffer *err)
+                          unsigned long UNUSED(data), struct Buffer *UNUSED(err))
 {
   do
   {
@@ -904,7 +904,7 @@ static int parse_unignore(struct Buffer *buf, struct Buffer *s,
 }
 
 static int parse_ignore(struct Buffer *buf, struct Buffer *s,
-                        unsigned long data, struct Buffer *err)
+                        unsigned long UNUSED(data), struct Buffer *UNUSED(err))
 {
   do
   {
@@ -917,7 +917,7 @@ static int parse_ignore(struct Buffer *buf, struct Buffer *s,
 }
 
 static int parse_stailq(struct Buffer *buf, struct Buffer *s,
-                        unsigned long data, struct Buffer *err)
+                        unsigned long data, struct Buffer *UNUSED(err))
 {
   do
   {
@@ -929,7 +929,7 @@ static int parse_stailq(struct Buffer *buf, struct Buffer *s,
 }
 
 static int parse_unstailq(struct Buffer *buf, struct Buffer *s,
-                          unsigned long data, struct Buffer *err)
+                          unsigned long data, struct Buffer *UNUSED(err))
 {
   do
   {
@@ -989,7 +989,7 @@ bail:
 }
 
 static int parse_unalternates(struct Buffer *buf, struct Buffer *s,
-                              unsigned long data, struct Buffer *err)
+                              unsigned long UNUSED(data), struct Buffer *err)
 {
   alternates_clean();
   do
@@ -1175,7 +1175,7 @@ static int parse_spam_list(struct Buffer *buf, struct Buffer *s,
 
 #ifdef USE_SIDEBAR
 static int parse_path_list(struct Buffer *buf, struct Buffer *s,
-                           unsigned long data, struct Buffer *err)
+                           unsigned long data, struct Buffer *UNUSED(err))
 {
   char path[_POSIX_PATH_MAX];
 
@@ -1191,7 +1191,7 @@ static int parse_path_list(struct Buffer *buf, struct Buffer *s,
 }
 
 static int parse_path_unlist(struct Buffer *buf, struct Buffer *s,
-                             unsigned long data, struct Buffer *err)
+                             unsigned long data, struct Buffer *UNUSED(err))
 {
   char path[_POSIX_PATH_MAX];
 
@@ -1412,7 +1412,7 @@ static int parse_attach_list(struct Buffer *buf, struct Buffer *s,
 }
 
 static int parse_unattach_list(struct Buffer *buf, struct Buffer *s,
-                               struct ListHead *head, struct Buffer *err)
+                               struct ListHead *head, struct Buffer *UNUSED(err))
 {
   struct AttachMatch *a = NULL;
   char *tmp = NULL;
@@ -1481,7 +1481,7 @@ static int print_attach_list(struct ListHead *h, char op, char *name)
 }
 
 static int parse_attachments(struct Buffer *buf, struct Buffer *s,
-                             unsigned long data, struct Buffer *err)
+                             unsigned long UNUSED(data), struct Buffer *err)
 {
   char op, *category = NULL;
   struct ListHead *head = NULL;
@@ -1538,7 +1538,7 @@ static int parse_attachments(struct Buffer *buf, struct Buffer *s,
 }
 
 static int parse_unattachments(struct Buffer *buf, struct Buffer *s,
-                               unsigned long data, struct Buffer *err)
+                               unsigned long UNUSED(data), struct Buffer *err)
 {
   char op, *p = NULL;
   struct ListHead *head = NULL;
@@ -1581,7 +1581,7 @@ static int parse_unattachments(struct Buffer *buf, struct Buffer *s,
 }
 
 static int parse_unlists(struct Buffer *buf, struct Buffer *s,
-                         unsigned long data, struct Buffer *err)
+                         unsigned long UNUSED(data), struct Buffer *err)
 {
   do
   {
@@ -1631,7 +1631,7 @@ bail:
 }
 
 static int parse_unsubscribe(struct Buffer *buf, struct Buffer *s,
-                             unsigned long data, struct Buffer *err)
+                             unsigned long UNUSED(data), struct Buffer *err)
 {
   do
   {
@@ -1649,7 +1649,7 @@ static int parse_unsubscribe(struct Buffer *buf, struct Buffer *s,
 }
 
 static int parse_unalias(struct Buffer *buf, struct Buffer *s,
-                         unsigned long data, struct Buffer *err)
+                         unsigned long UNUSED(data), struct Buffer *UNUSED(err))
 {
   struct Alias *tmp = NULL, *last = NULL;
 
@@ -1782,7 +1782,7 @@ bail:
 }
 
 static int parse_unmy_hdr(struct Buffer *buf, struct Buffer *s,
-                          unsigned long data, struct Buffer *err)
+                          unsigned long UNUSED(data), struct Buffer *UNUSED(err))
 {
   struct ListNode *np, *tmp;
   size_t l;
@@ -1814,7 +1814,7 @@ static int parse_unmy_hdr(struct Buffer *buf, struct Buffer *s,
 }
 
 static int parse_my_hdr(struct Buffer *buf, struct Buffer *s,
-                        unsigned long data, struct Buffer *err)
+                        unsigned long UNUSED(data), struct Buffer *err)
 {
   struct ListNode *n = NULL;
   size_t keylen;
@@ -3027,7 +3027,7 @@ static int source_rc(const char *rcfile_path, struct Buffer *err)
 #undef MAXERRS
 
 static int parse_source(struct Buffer *tmp, struct Buffer *token,
-                        unsigned long data, struct Buffer *err)
+                        unsigned long UNUSED(data), struct Buffer *err)
 {
   char path[_POSIX_PATH_MAX];
 
@@ -4182,7 +4182,8 @@ int mutt_get_hook_type(const char *name)
 }
 
 static int parse_group_context(struct GroupContext **ctx, struct Buffer *buf,
-                               struct Buffer *s, unsigned long data, struct Buffer *err)
+                               struct Buffer *s, unsigned long UNUSED(data),
+                               struct Buffer *err)
 {
   while (mutt_str_strcasecmp(buf->data, "-group") == 0)
   {
@@ -4213,7 +4214,7 @@ bail:
 }
 
 static int parse_tag_transforms(struct Buffer *b, struct Buffer *s,
-                                unsigned long data, struct Buffer *err)
+                                unsigned long UNUSED(data), struct Buffer *UNUSED(err))
 {
   if (!b || !s)
     return -1;
@@ -4249,7 +4250,7 @@ static int parse_tag_transforms(struct Buffer *b, struct Buffer *s,
 }
 
 static int parse_tag_formats(struct Buffer *b, struct Buffer *s,
-                             unsigned long data, struct Buffer *err)
+                             unsigned long UNUSED(data), struct Buffer *UNUSED(err))
 {
   if (!b || !s)
     return -1;
@@ -4299,7 +4300,7 @@ static int parse_tag_formats(struct Buffer *b, struct Buffer *s,
  * Use it as follows: subscribe-to =folder
  */
 static int parse_subscribe_to(struct Buffer *b, struct Buffer *s,
-                              unsigned long data, struct Buffer *err)
+                              unsigned long UNUSED(data), struct Buffer *err)
 {
   if (!b || !s || !err)
     return -1;
@@ -4355,7 +4356,7 @@ static int parse_subscribe_to(struct Buffer *b, struct Buffer *s,
  * Use it as follows: unsubscribe-from =folder
  */
 static int parse_unsubscribe_from(struct Buffer *b, struct Buffer *s,
-                                  unsigned long data, struct Buffer *err)
+                                  unsigned long UNUSED(data), struct Buffer *err)
 {
   if (!b || !s || !err)
     return -1;

--- a/keymap.c
+++ b/keymap.c
@@ -956,8 +956,8 @@ void km_error_key(int menu)
   return;
 }
 
-int mutt_parse_push(struct Buffer *buf, struct Buffer *s, unsigned long data,
-                    struct Buffer *err)
+int mutt_parse_push(struct Buffer *buf, struct Buffer *s,
+                    unsigned long UNUSED(data), struct Buffer *err)
 {
   int r = 0;
 
@@ -1095,8 +1095,8 @@ const struct Binding *km_get_table(int menu)
  *
  * bind menu-name `<key_sequence>` function-name
  */
-int mutt_parse_bind(struct Buffer *buf, struct Buffer *s, unsigned long data,
-                    struct Buffer *err)
+int mutt_parse_bind(struct Buffer *buf, struct Buffer *s,
+                    unsigned long UNUSED(data), struct Buffer *err)
 {
   const struct Binding *bindings = NULL;
   char *key = NULL;
@@ -1153,8 +1153,8 @@ int mutt_parse_bind(struct Buffer *buf, struct Buffer *s, unsigned long data,
  *
  * macro `<menu>` `<key>` `<macro>` `<description>`
  */
-int mutt_parse_macro(struct Buffer *buf, struct Buffer *s, unsigned long data,
-                     struct Buffer *err)
+int mutt_parse_macro(struct Buffer *buf, struct Buffer *s,
+                     unsigned long UNUSED(data), struct Buffer *err)
 {
   int menu[sizeof(Menus) / sizeof(struct Mapping) - 1], r = -1, nummenus;
   char *seq = NULL;
@@ -1206,8 +1206,8 @@ int mutt_parse_macro(struct Buffer *buf, struct Buffer *s, unsigned long data,
 /**
  * mutt_parse_exec - exec function-name
  */
-int mutt_parse_exec(struct Buffer *buf, struct Buffer *s, unsigned long data,
-                    struct Buffer *err)
+int mutt_parse_exec(struct Buffer *buf, struct Buffer *s,
+                    unsigned long UNUSED(data), struct Buffer *err)
 {
   int ops[128];
   int nops = 0;

--- a/mbox.c
+++ b/mbox.c
@@ -503,21 +503,21 @@ static int mbox_close_mailbox(struct Context *ctx)
   return 0;
 }
 
-static int mbox_open_message(struct Context *ctx, struct Message *msg, int msgno)
+static int mbox_open_message(struct Context *ctx, struct Message *msg, int UNUSED(msgno))
 {
   msg->fp = ctx->fp;
 
   return 0;
 }
 
-static int mbox_close_message(struct Context *ctx, struct Message *msg)
+static int mbox_close_message(struct Context *UNUSED(ctx), struct Message *msg)
 {
   msg->fp = NULL;
 
   return 0;
 }
 
-static int mbox_commit_message(struct Context *ctx, struct Message *msg)
+static int mbox_commit_message(struct Context *UNUSED(ctx), struct Message *msg)
 {
   if (fputc('\n', msg->fp) == EOF)
     return -1;
@@ -531,7 +531,7 @@ static int mbox_commit_message(struct Context *ctx, struct Message *msg)
   return 0;
 }
 
-static int mmdf_commit_message(struct Context *ctx, struct Message *msg)
+static int mmdf_commit_message(struct Context *UNUSED(ctx), struct Message *msg)
 {
   if (fputs(MMDF_SEP, msg->fp) == EOF)
     return -1;
@@ -545,7 +545,8 @@ static int mmdf_commit_message(struct Context *ctx, struct Message *msg)
   return 0;
 }
 
-static int mbox_open_new_message(struct Message *msg, struct Context *dest, struct Header *hdr)
+static int mbox_open_new_message(struct Message *msg, struct Context *dest,
+                                 struct Header *UNUSED(hdr))
 {
   msg->fp = dest->fp;
   return 0;

--- a/menu.c
+++ b/menu.c
@@ -784,7 +784,7 @@ static void menu_prev_entry(struct Menu *menu)
     mutt_error(_("You are on the first entry."));
 }
 
-static int default_color(int i)
+static int default_color(int UNUSED(i))
 {
   return ColorDefs[MT_COLOR_NORMAL];
 }

--- a/mh.c
+++ b/mh.c
@@ -1420,7 +1420,8 @@ static int mh_open_mailbox_append(struct Context *ctx, int flags)
  * Open a new (temporary) message in an MH folder.
  */
 
-static int mh_open_new_message(struct Message *msg, struct Context *dest, struct Header *hdr)
+static int mh_open_new_message(struct Message *msg, struct Context *dest,
+                               struct Header *UNUSED(hdr))
 {
   return mh_mkstemp(dest, &msg->fp, &msg->path);
 }
@@ -1487,7 +1488,7 @@ static int mh_open_message(struct Context *ctx, struct Message *msg, int msgno)
   return maildir_mh_open_message(ctx, msg, msgno, 0);
 }
 
-static int mh_close_message(struct Context *ctx, struct Message *msg)
+static int mh_close_message(struct Context *UNUSED(ctx), struct Message *msg)
 {
   return mutt_file_fclose(&msg->fp);
 }

--- a/mutt/debug.c
+++ b/mutt/debug.c
@@ -33,6 +33,7 @@
 #include "config.h"
 #include <stdarg.h>
 #include <stdio.h>
+#include "debug.h"
 
 /**
  * mutt_debug_real - Output some debugging information
@@ -45,7 +46,8 @@
  * This stub function ignores the logging level and outputs all information to
  * stderr.
  */
-int mutt_debug_real(const char *function, const char *file, int line, int level, ...)
+int mutt_debug_real(const char *UNUSED(function), const char *UNUSED(file),
+                    int UNUSED(line), int level, ...)
 {
   va_list ap;
   va_start(ap, level);

--- a/mutt/debug.h
+++ b/mutt/debug.h
@@ -29,4 +29,7 @@ int mutt_debug_real(const char *function, const char *file, int line, int level,
 /* Mark unused parameters in API functions */
 #define UNUSED(x) UNUSED_ ## x __attribute__((__unused__))
 
+/* Mark conditional parameters, i.e. only used in #ifdef clauses */
+#define CONDIT(x) x __attribute__((__unused__))
+
 #endif /* _MUTT_DEBUG_H */

--- a/mutt/debug.h
+++ b/mutt/debug.h
@@ -26,4 +26,7 @@
 int mutt_debug_real(const char *function, const char *file, int line, int level, ...);
 #define mutt_debug(LEVEL, ...) mutt_debug_real(__func__, __FILE__, __LINE__, LEVEL, __VA_ARGS__)
 
+/* Mark unused parameters in API functions */
+#define UNUSED(x) UNUSED_ ## x __attribute__((__unused__))
+
 #endif /* _MUTT_DEBUG_H */

--- a/mutt/file.c
+++ b/mutt/file.c
@@ -1103,7 +1103,7 @@ int mutt_file_chmod_rm_stat(const char *path, mode_t mode, struct stat *st)
  *
  * Use mutt_file_unlock() to unlock the file.
  */
-int mutt_file_lock(int fd, int excl, int timeout)
+int mutt_file_lock(int CONDIT(fd), int CONDIT(excl), int CONDIT(timeout))
 {
 #if defined(USE_FCNTL) || defined(USE_FLOCK)
   int count;
@@ -1206,7 +1206,7 @@ int mutt_file_lock(int fd, int excl, int timeout)
  * @param fd File descriptor to file
  * @retval 0 Always
  */
-int mutt_file_unlock(int fd)
+int mutt_file_unlock(int CONDIT(fd))
 {
 #ifdef USE_FCNTL
   struct flock unlockit = { F_UNLCK, 0, 0, 0, 0 };

--- a/mutt/signal.c
+++ b/mutt/signal.c
@@ -44,6 +44,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include "debug.h"
 #include "message.h"
 #include "signal2.h"
 
@@ -64,7 +65,7 @@ static sig_handler_t exit_handler = mutt_sig_exit_handler;
  * Useful for signals that we can't ignore,
  * or don't want to do anything with.
  */
-void mutt_sig_empty_handler(int sig)
+void mutt_sig_empty_handler(int UNUSED(sig))
 {
 }
 

--- a/mutt_lua.c
+++ b/mutt_lua.c
@@ -386,7 +386,7 @@ static bool lua_init(lua_State **l)
 
 lua_State *Lua = NULL;
 
-int mutt_lua_parse(struct Buffer *tmp, struct Buffer *s,
+int mutt_lua_parse(struct Buffer *CONDIT(tmp), struct Buffer *s,
                    unsigned long UNUSED(data), struct Buffer *err)
 {
   lua_init(&Lua);

--- a/mutt_lua.c
+++ b/mutt_lua.c
@@ -386,7 +386,8 @@ static bool lua_init(lua_State **l)
 
 lua_State *Lua = NULL;
 
-int mutt_lua_parse(struct Buffer *tmp, struct Buffer *s, unsigned long data, struct Buffer *err)
+int mutt_lua_parse(struct Buffer *tmp, struct Buffer *s,
+                   unsigned long UNUSED(data), struct Buffer *err)
 {
   lua_init(&Lua);
   mutt_debug(2, " * mutt_lua_parse(%s)\n", tmp->data);
@@ -404,7 +405,7 @@ int mutt_lua_parse(struct Buffer *tmp, struct Buffer *s, unsigned long data, str
 }
 
 int mutt_lua_source_file(struct Buffer *tmp, struct Buffer *s,
-                         unsigned long data, struct Buffer *err)
+                         unsigned long UNUSED(data), struct Buffer *err)
 {
   mutt_debug(2, " * mutt_lua_source()\n");
 

--- a/mutt_notmuch.c
+++ b/mutt_notmuch.c
@@ -1731,7 +1731,8 @@ void nm_query_window_backward(void)
  * @retval 0: no valid user input
  * @retval 1: buf set
  */
-static int nm_edit_message_tags(struct Context *ctx, const char *tags, char *buf, size_t buflen)
+static int nm_edit_message_tags(struct Context *UNUSED(ctx),
+                                const char *UNUSED(tags), char *buf, size_t buflen)
 {
   *buf = '\0';
   if (mutt_get_field("Add/remove labels: ", buf, buflen, MUTT_NM_TAG) != 0)
@@ -2158,7 +2159,7 @@ static int nm_close_mailbox(struct Context *ctx)
  * @retval #MUTT_REOPENED - mailbox closed and reopened
  * @retval #MUTT_FLAGS - flags have changed
  */
-static int nm_check_mailbox(struct Context *ctx, int *index_hint)
+static int nm_check_mailbox(struct Context *ctx, int *UNUSED(index_hint))
 {
   struct NmCtxData *data = get_ctxdata(ctx);
   time_t mtime = 0;
@@ -2281,7 +2282,7 @@ done:
  * @param ctx        A mailbox CONTEXT
  * @param index_hint Remember our place in the index
  */
-static int nm_sync_mailbox(struct Context *ctx, int *index_hint)
+static int nm_sync_mailbox(struct Context *ctx, int *UNUSED(index_hint))
 {
   struct NmCtxData *data = get_ctxdata(ctx);
   int rc = 0;
@@ -2398,7 +2399,7 @@ static int nm_open_message(struct Context *ctx, struct Message *msg, int msgno)
  * @retval 0 Success
  * @retval 1 Error
  */
-static int nm_close_message(struct Context *ctx, struct Message *msg)
+static int nm_close_message(struct Context *UNUSED(ctx), struct Message *msg)
 {
   if (!msg)
     return 1;
@@ -2406,7 +2407,7 @@ static int nm_close_message(struct Context *ctx, struct Message *msg)
   return 0;
 }
 
-static int nm_commit_message(struct Context *ctx, struct Message *msg)
+static int nm_commit_message(struct Context *UNUSED(ctx), struct Message *UNUSED(msg))
 {
   mutt_error(_("Can't write to virtual folder."));
   return -1;

--- a/muttlib.c
+++ b/muttlib.c
@@ -1509,7 +1509,8 @@ int debuglevel;
 char *debugfile_cmdline = NULL;
 int debuglevel_cmdline;
 
-int mutt_debug_real(const char *function, const char *file, int line, int level, ...)
+int mutt_debug_real(const char *function, const char *UNUSED(file),
+                    int UNUSED(line), int level, ...)
 {
   va_list ap;
   time_t now = time(NULL);

--- a/muttlib.c
+++ b/muttlib.c
@@ -468,7 +468,7 @@ uint64_t mutt_rand64(void)
 }
 
 void mutt_mktemp_full(char *s, size_t slen, const char *prefix,
-                      const char *suffix, const char *src, int line)
+                      const char *suffix, const char *CONDIT(src), int CONDIT(line))
 {
   size_t n = snprintf(s, slen, "%s/%s-%s-%d-%d-%" PRIu64 "%s%s", NONULL(Tmpdir),
                       NONULL(prefix), NONULL(ShortHostname), (int) getuid(),

--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -1178,7 +1178,7 @@ static char *smime_extract_signer_certificate(char *infile)
 /**
  * smime_invoke_import - Add a certificate and update index file (externally)
  */
-void smime_invoke_import(char *infile, char *mailbox)
+void smime_invoke_import(char *infile, char *UNUSED(mailbox))
 {
   char tmpfname[_POSIX_PATH_MAX], *certfile = NULL, buf[STRING];
   FILE *smimein = NULL, *fpout = NULL, *fperr = NULL;

--- a/newsrc.c
+++ b/newsrc.c
@@ -115,7 +115,7 @@ void nntp_data_free(void *data)
   FREE(&data);
 }
 
-void nntp_hash_destructor(int type, void *obj, intptr_t data)
+void nntp_hash_destructor(int UNUSED(type), void *obj, intptr_t UNUSED(data))
 {
   nntp_data_free(obj);
 }

--- a/newsrc.c
+++ b/newsrc.c
@@ -888,9 +888,10 @@ void nntp_clear_cache(struct NntpServer *nserv)
  * | \%S     | Url schema
  * | \%u     | Username
  */
-const char *nntp_format_str(char *buf, size_t buflen, size_t col, int cols, char op,
-                            const char *src, const char *prec, const char *if_str,
-                            const char *else_str, unsigned long data, enum FormatFlag flags)
+const char *nntp_format_str(char *buf, size_t buflen, size_t UNUSED(col),
+                            int UNUSED(cols), char op, const char *src, const char *prec,
+                            const char *UNUSED(if_str), const char *UNUSED(else_str),
+                            unsigned long data, enum FormatFlag UNUSED(flags))
 {
   struct NntpServer *nserv = (struct NntpServer *) data;
   struct Account *acct = &nserv->conn->account;

--- a/nntp.c
+++ b/nntp.c
@@ -1221,7 +1221,7 @@ static int parse_overview_line(char *line, void *data)
 /**
  * nntp_fetch_headers - Fetch headers
  */
-static int nntp_fetch_headers(struct Context *ctx, void *hc, anum_t first,
+static int nntp_fetch_headers(struct Context *ctx, void *CONDIT(hc), anum_t first,
                               anum_t last, int restore)
 {
   struct NntpData *nntp_data = ctx->data;

--- a/nntp.c
+++ b/nntp.c
@@ -1717,7 +1717,7 @@ static int nntp_open_message(struct Context *ctx, struct Message *msg, int msgno
 /**
  * nntp_close_message - Close message
  */
-static int nntp_close_message(struct Context *ctx, struct Message *msg)
+static int nntp_close_message(struct Context *UNUSED(ctx), struct Message *msg)
 {
   return mutt_file_fclose(&msg->fp);
 }
@@ -2068,7 +2068,7 @@ static int check_mailbox(struct Context *ctx)
  * @retval  0             No change
  * @retval -1             Lost connection
  */
-static int nntp_check_mailbox(struct Context *ctx, int *index_hint)
+static int nntp_check_mailbox(struct Context *ctx, int *UNUSED(index_hint))
 {
   int ret = check_mailbox(ctx);
   if (ret == 0)
@@ -2083,7 +2083,7 @@ static int nntp_check_mailbox(struct Context *ctx, int *index_hint)
 /**
  * nntp_sync_mailbox - Save changes to .newsrc and cache
  */
-static int nntp_sync_mailbox(struct Context *ctx, int *index_hint)
+static int nntp_sync_mailbox(struct Context *ctx, int *UNUSED(index_hint))
 {
   struct NntpData *nntp_data = ctx->data;
   int rc;

--- a/parse.c
+++ b/parse.c
@@ -1306,7 +1306,7 @@ struct Envelope *mutt_read_rfc822_header(FILE *f, struct Header *hdr,
 /**
  * count_body_parts_check - Compares mime types to the ok and except lists
  */
-static bool count_body_parts_check(struct ListHead *checklist, struct Body *b, bool dflt)
+static bool count_body_parts_check(struct ListHead *checklist, struct Body *b, bool CONDIT(dflt))
 {
   struct AttachMatch *a = NULL;
 

--- a/pattern.c
+++ b/pattern.c
@@ -533,7 +533,7 @@ static bool eat_date(struct Pattern *pat, struct Buffer *s, struct Buffer *err)
   return true;
 }
 
-static bool eat_range(struct Pattern *pat, struct Buffer *s, struct Buffer *err)
+static bool eat_range(struct Pattern *pat, struct Buffer *s, struct Buffer *UNUSED(err))
 {
   char *tmp = NULL;
   bool do_exclusive = false;

--- a/pop.c
+++ b/pop.c
@@ -695,7 +695,7 @@ static int pop_fetch_message(struct Context *ctx, struct Message *msg, int msgno
   return 0;
 }
 
-static int pop_close_message(struct Context *ctx, struct Message *msg)
+static int pop_close_message(struct Context *UNUSED(ctx), struct Message *msg)
 {
   return mutt_file_fclose(&msg->fp);
 }
@@ -703,7 +703,7 @@ static int pop_close_message(struct Context *ctx, struct Message *msg)
 /**
  * pop_sync_mailbox - update POP mailbox, delete messages from server
  */
-static int pop_sync_mailbox(struct Context *ctx, int *index_hint)
+static int pop_sync_mailbox(struct Context *ctx, int *UNUSED(index_hint))
 {
   int i, j, ret = 0;
   char buf[LONG_STRING];
@@ -784,7 +784,7 @@ static int pop_sync_mailbox(struct Context *ctx, int *index_hint)
 /**
  * pop_check_mailbox - Check for new messages and fetch headers
  */
-static int pop_check_mailbox(struct Context *ctx, int *index_hint)
+static int pop_check_mailbox(struct Context *ctx, int *UNUSED(index_hint))
 {
   int ret;
   struct PopData *pop_data = (struct PopData *) ctx->data;

--- a/pop_auth.c
+++ b/pop_auth.c
@@ -212,7 +212,7 @@ void pop_apop_timestamp(struct PopData *pop_data, char *buf)
 /**
  * pop_auth_apop - APOP authenticator
  */
-static enum PopAuthRes pop_auth_apop(struct PopData *pop_data, const char *method)
+static enum PopAuthRes pop_auth_apop(struct PopData *pop_data, const char *UNUSED(method))
 {
   struct Md5Ctx ctx;
   unsigned char digest[16];
@@ -258,7 +258,7 @@ static enum PopAuthRes pop_auth_apop(struct PopData *pop_data, const char *metho
 /**
  * pop_auth_user - USER authenticator
  */
-static enum PopAuthRes pop_auth_user(struct PopData *pop_data, const char *method)
+static enum PopAuthRes pop_auth_user(struct PopData *pop_data, const char *UNUSED(method))
 {
   char buf[LONG_STRING];
   int ret;

--- a/pop_lib.c
+++ b/pop_lib.c
@@ -461,7 +461,7 @@ void pop_logout(struct Context *ctx)
  * @retval -1 Connection lost
  * @retval -2 Invalid command or execution error
 */
-int pop_query_d(struct PopData *pop_data, char *buf, size_t buflen, char *msg)
+int pop_query_d(struct PopData *pop_data, char *buf, size_t buflen, char *CONDIT(msg))
 {
   int dbg = MUTT_SOCK_LOG_CMD;
   char *c = NULL;

--- a/score.c
+++ b/score.c
@@ -74,8 +74,8 @@ void mutt_check_rescore(struct Context *ctx)
   OPT_NEED_RESCORE = false;
 }
 
-int mutt_parse_score(struct Buffer *buf, struct Buffer *s, unsigned long data,
-                     struct Buffer *err)
+int mutt_parse_score(struct Buffer *buf, struct Buffer *s,
+                     unsigned long UNUSED(data), struct Buffer *err)
 {
   struct Score *ptr = NULL, *last = NULL;
   char *pattern = NULL, *pc = NULL;
@@ -170,8 +170,8 @@ void mutt_score_message(struct Context *ctx, struct Header *hdr, int upd_ctx)
     mutt_set_flag_update(ctx, hdr, MUTT_FLAG, 1, upd_ctx);
 }
 
-int mutt_parse_unscore(struct Buffer *buf, struct Buffer *s, unsigned long data,
-                       struct Buffer *err)
+int mutt_parse_unscore(struct Buffer *buf, struct Buffer *s,
+                       unsigned long UNUSED(data), struct Buffer *UNUSED(err))
 {
   struct Score *tmp = NULL, *last = NULL;
 

--- a/sendlib.c
+++ b/sendlib.c
@@ -2265,7 +2265,7 @@ static char *gen_msgid(void)
   return (mutt_str_strdup(buf));
 }
 
-static void alarm_handler(int sig)
+static void alarm_handler(int UNUSED(sig))
 {
   SigAlrm = 1;
 }

--- a/sidebar.c
+++ b/sidebar.c
@@ -116,8 +116,9 @@ enum SidebarSrc
  * | \%t     | Number of tagged messages
  * | \%!     | 'n!' Flagged messages
  */
-static const char *sidebar_format_str(char *buf, size_t buflen, size_t col, int cols,
-                                      char op, const char *src, const char *prec,
+static const char *sidebar_format_str(char *buf, size_t buflen, size_t col,
+                                      int UNUSED(cols), char op,
+                                      const char *src, const char *prec,
                                       const char *if_str, const char *else_str,
                                       unsigned long data, enum FormatFlag flags)
 {

--- a/thread.c
+++ b/thread.c
@@ -780,7 +780,7 @@ static void check_subjects(struct Context *ctx, int init)
   }
 }
 
-void thread_hash_destructor(int type, void *obj, intptr_t data)
+void thread_hash_destructor(int UNUSED(type), void *obj, intptr_t UNUSED(data))
 {
   FREE(&obj);
 }


### PR DESCRIPTION
OK, I didn't hear any (negative) feedback on my suggestion, so I've created a PR.
It's not _quite_ as clean as I'd liked.
There are 119 parameters marked as unused, but there are a further 16 which are only used conditionally.

What do you think?

- 5165b482 Mark unused parameters
  Add UNUSED macro `__attribute__((__unused__))`

- ad49abd7 Mark conditional parameters
  Add CONDIT macro for parameters in `#ifdef` clauses

- cb671110 Add gcc warning options
  Add two new warning options to the build:
  * `-Wunused-parameter`
  * `-Wshadow`
