### PR TITLE
Devel/sidebar strip component

### DIFF
--- a/doc/manual.xml.head
+++ b/doc/manual.xml.head
@@ -748,11 +748,12 @@ mailboxes =water/ocean/atlantic =water/ocean/pacific   =water/ocean/arctic
 </screen>
               <para>Shorten the names:</para>
               <screen>
-set sidebar_short_path                  <emphasis role="comment"># Shorten mailbox names</emphasis>
-set sidebar_delim_chars="/"             <emphasis role="comment"># Delete everything up to the last / character</emphasis>
+set sidebar_short_path                  <emphasis role="comment"># Shorten mailbox names (truncate all subdirs)</emphasis>
+set sidebar_component_depth=1           <emphasis role="comment"># Shorten mailbox names (truncate 1 subdirs)</emphasis>
+set sidebar_delim_chars="/"             <emphasis role="comment"># Delete everything up to the last or Nth / character</emphasis>
 </screen>
               <para>The screenshot below shows what the Sidebar would look like
-              before and after shortening.</para>
+              before and after shortening using <literal>sidebar_short_path</literal>.</para>
               <screen>
 |fruit/apple                            |apple
 |fruit/banana                           |banana
@@ -763,6 +764,19 @@ set sidebar_delim_chars="/"             <emphasis role="comment"># Delete everyt
 |water/ocean/atlantic                   |atlantic
 |water/ocean/pacific                    |pacific
 |water/ocean/arctic                     |arctic
+</screen>
+              <para>The screenshot below shows what the Sidebar would look like
+              before and after shortening using <literal>sidebar_component_depth=1</literal>.</para>
+              <screen>
+|fruit/apple                            |apple
+|fruit/banana                           |banana
+|fruit/cherry                           |cherry
+|water/sea/sicily                       |sea/sicily
+|water/sea/archipelago                  |sea/archipelago
+|water/sea/sibuyan                      |sea/sibuyan
+|water/ocean/atlantic                   |ocean/atlantic
+|water/ocean/pacific                    |ocean/pacific
+|water/ocean/arctic                     |ocean/arctic
 </screen>
             </sect5>
 
@@ -13819,6 +13833,15 @@ set sort_browser="reverse-size"
               </row>
               <row>
                 <entry>
+                  <literal>sidebar_component_depth</literal>
+                </entry>
+                <entry>number</entry>
+                <entry>
+                  <literal>0</literal>
+                </entry>
+              </row>
+              <row>
+                <entry>
                   <literal>sidebar_sort_method</literal>
                 </entry>
                 <entry>enum</entry>
@@ -14119,9 +14142,10 @@ set sidebar_visible = no
 set sidebar_width = 20
 <emphasis role="comment"># Should the mailbox paths be abbreviated?</emphasis>
 set sidebar_short_path = no
+<emphasis role="comment"># Number of top-level mailbox path subdirectories to truncate for display</emphasis>
+set sidebar_component_depth = 0
 <emphasis role="comment"># When abbreviating mailbox path names, use any of these characters as path
 # separators.  Only the part after the last separators will be shown.
-
 # For file folders '/' is good.  For IMAP folders, often '.' is useful.</emphasis>
 set sidebar_delim_chars = '/.'
 <emphasis role="comment"># If the mailbox path is abbreviated, should it be indented?</emphasis>

--- a/globals.h
+++ b/globals.h
@@ -244,6 +244,7 @@ WHERE short ScoreThresholdRead;
 WHERE short ScoreThresholdFlag;
 
 #ifdef USE_SIDEBAR
+WHERE short SidebarComponentDepth;
 WHERE short SidebarWidth;
 WHERE struct ListHead SidebarWhitelist INITVAL(STAILQ_HEAD_INITIALIZER(SidebarWhitelist));
 #endif

--- a/init.h
+++ b/init.h
@@ -3340,7 +3340,8 @@ struct Option MuttVars[] = {
   ** .dt \fCfruit.cherry\fP .dd \fCcherry\fP        .dd \fC..cherry\fP
   ** .de
   ** .pp
-  ** \fBSee also:\fP $$sidebar_delim_chars, $$sidebar_folder_indent, $$sidebar_indent_string.
+  ** \fBSee also:\fP $$sidebar_delim_chars, $$sidebar_folder_indent,
+  ** $$sidebar_indent_string, $$sidebar_component_depth.
   */
   { "sidebar_sort_method", DT_SORT|DT_SORT_SIDEBAR, R_SIDEBAR, UL &SidebarSortMethod, SORT_ORDER },
   /*
@@ -3360,6 +3361,18 @@ struct Option MuttVars[] = {
   ** .pp
   ** You may optionally use the ``reverse-'' prefix to specify reverse sorting
   ** order (example: ``\fCset sort_browser=reverse-date\fP'').
+  */
+  { "sidebar_component_depth", DT_NUMBER, R_SIDEBAR, UL &SidebarComponentDepth, UL 0 },
+  /*
+  ** .pp
+  ** By default the sidebar will show the mailbox's path, relative to the
+  ** $$folder variable. This specifies the number of parent directories to hide
+  ** from display in the sidebar. For example: If a maildir is normally
+  ** displayed in the sidebar as dir1/dir2/dir3/maildir, setting
+  ** \fCsidebar_component_depth=2\fP will display it as dir3/maildir, having
+  ** truncated the 2 highest directories.
+  ** .pp
+  ** \fBSee also:\fP $$sidebar_short_path
   */
   { "sidebar_visible", DT_BOOL, R_REFLOW, OPT_SIDEBAR_VISIBLE, 0 },
   /*

--- a/sidebar.c
+++ b/sidebar.c
@@ -900,6 +900,18 @@ static void draw_sidebar(int num_rows, int num_cols, int div_width)
         }
       }
     }
+    else if ((SidebarComponentDepth > 0) && SidebarDelimChars)
+    {
+      sidebar_folder_name = b->path + maildir_is_prefix * (maildirlen + 1);
+      for (int i = 0; i < SidebarComponentDepth; i++)
+      {
+        char *chars_after_delim = strpbrk(sidebar_folder_name, SidebarDelimChars);
+        if (!chars_after_delim)
+          break;
+        else
+          sidebar_folder_name = chars_after_delim + 1;
+      }
+    }
     else
       sidebar_folder_name = b->path + maildir_is_prefix * (maildirlen + 1);
 


### PR DESCRIPTION
* **What does this PR do?**

In cases of a complex maildir directory structures, one may want to hide the
highest `N` directories from display in the sidebar to keep things looking
clean and legible.

This PR introduces a new config parameter, `sidebar_component_depth`, which
takes a positive integer as its value.

For example, suppose I have the following directory structure:
```
Inbox
dir1/dir2
dir1/dir2/dir3/sushi
dir1/dir2/dir3/neomutt/developer
```

By setting `sidebar_component_depth=2` in one's rc file, the sidebar will
display these maildirs in the following way:
```
Inbox
dir2
dir3/sushi
dir3/neomutt/developer
```

As seen in this example, the two highest directories have been truncated from
each path except in the case when there are `<= N` subdirectories, in which
case the bottom-most directory is displayed.

This parameter has a default value of 0, which disables the feature.

An existing option, `sidebar_short_path`, provides similar behavior,
but truncates all except the bottom-most directories. When that option is
enabled, `sidebar_component_depth` is ignored.

* **Are there points in the code the reviewer needs to double check?**

I think I made the relevant documentation changes, but it's possible I missed something. I'm new here so sanity checks are appreciated.

* **What are the relevant issue numbers?**

Resolves: #813