### PR TITLE
Fixup smart modify-labels-then-hide for !tag case

### DIFF
--- a/curs_main.c
+++ b/curs_main.c
@@ -1947,7 +1947,12 @@ int mutt_index_menu(void)
           }
           if (op == OP_MAIN_MODIFY_TAGS_THEN_HIDE)
           {
-            CURHDR->quasi_deleted = true;
+            bool still_queried = false;
+#ifdef USE_NOTMUCH
+            if (Context->magic == MUTT_NOTMUCH)
+              still_queried = nm_message_is_still_queried(Context, CURHDR);
+#endif
+            CURHDR->quasi_deleted = !still_queried;
             Context->changed = true;
           }
           if (menu->menu == MENU_PAGER)


### PR DESCRIPTION
The code used to automatically handle setting the quasi delete
state to whether the message is still visible after performing
the change.

This was broken for the !tag case in

commit 7d151fd0919f6cc7ba9cdc1e7de90697c66dce43
Author: Mehdi Abaakouk <sileht@sileht.net>
Date:   Tue Feb 21 10:50:35 2017 +0100

    Share label editing between imap/notmuch

Which replaced the !still_visible with simply true.

