### PR TITLE
github: make removal of irrelevant sections easier

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,12 +1,12 @@
-* **bug reports**
+## bug reports
 
-    * Expected behavior
-    * Actual behavior
-    * Steps to reproduce
-    * Used program versions
-    * Operating System and its version
+* Expected behavior
+* Actual behavior
+* Steps to reproduce
+* Used program versions
+* Operating System and its version
 
-* **feature requests**
+## feature requests
 
-    * Why do you not like the current state?
-    * What would you like to see to change?
+* Why do you not like the current state?
+* What would you like to see to change?


### PR DESCRIPTION
* **What does this PR do?**

When users remove the irrelevant things for their issue, they often
leave the indentation of the nested list. That causes github to render
those lines as code instead of markdown list items.
