### PR TITLE
add sleep after SMTP error

### DIFF
--- a/smtp.c
+++ b/smtp.c
@@ -139,6 +139,7 @@ static int smtp_get_resp(struct Connection *conn)
     return 0;
 
   mutt_error(_("SMTP session failed: %s"), buf);
+  mutt_sleep(0);
   return -1;
 }
 


### PR DESCRIPTION
Add a `mutt_sleep(0)` after an SMTP error message to ensure that the user can read it.

Fixes #982 