### PR TITLE
Fix type mismatch in mutt_pretty_size()

### DIFF
--- a/muttlib.c
+++ b/muttlib.c
@@ -611,14 +611,14 @@ void mutt_pretty_size(char *s, size_t len, size_t n)
   else if (n < 1023949) /* 10K - 999K */
   {
     /* 51 is magic which causes 10189/10240 to be rounded up to 10 */
-    snprintf(s, len, OFF_T_FMT "K", (n + 51) / 1024);
+    snprintf(s, len, "%zuK", (n + 51) / 1024);
   }
   else if (n < 10433332) /* 1.0M - 9.9M */
     snprintf(s, len, "%3.1fM", n / 1048576.0);
   else /* 10M+ */
   {
     /* (10433332 + 52428) / 1048576 = 10 */
-    snprintf(s, len, OFF_T_FMT "M", (n + 52428) / 1048576);
+    snprintf(s, len, "%zuM", (n + 52428) / 1048576);
   }
 }
 


### PR DESCRIPTION
Fixes the following GCC warnings:

    muttlib.c: In function ‘mutt_pretty_size’:
    config.h:55:19: warning: format ‘%lld’ expects argument of type ‘long long int’, but argument 4 has type ‘size_t {aka unsigned int}’ [-Wformat=]
     #define OFF_T_FMT "%" PRId64
                       ^
    muttlib.c:614:22: note: in expansion of macro ‘OFF_T_FMT’
         snprintf(s, len, OFF_T_FMT "K", (n + 51) / 1024);
                          ^~~~~~~~~
    config.h:55:19: warning: format ‘%lld’ expects argument of type ‘long long int’, but argument 4 has type ‘size_t {aka unsigned int}’ [-Wformat=]
     #define OFF_T_FMT "%" PRId64
                       ^
    muttlib.c:621:22: note: in expansion of macro ‘OFF_T_FMT’
         snprintf(s, len, OFF_T_FMT "M", (n + 52428) / 1048576);
                          ^~~~~~~~~