### PR TITLE
Fix type mismatch in mutt_progress_init()

### DIFF
--- a/curs_lib.c
+++ b/curs_lib.c
@@ -468,7 +468,7 @@ void mutt_progress_init(struct Progress *progress, const char *msg,
     if (progress->flags & MUTT_PROGRESS_SIZE)
       mutt_pretty_size(progress->sizestr, sizeof(progress->sizestr), progress->size);
     else
-      snprintf(progress->sizestr, sizeof(progress->sizestr), "%ld", progress->size);
+      snprintf(progress->sizestr, sizeof(progress->sizestr), "%zu", progress->size);
   }
   if (!inc)
   {


### PR DESCRIPTION
Fixes the following GCC warning:

    curs_lib.c: In function ‘mutt_progress_init’:
    curs_lib.c:471:65: warning: format ‘%ld’ expects argument of type ‘long int’, but argument 4 has type ‘size_t {aka unsigned int}’ [-Wformat=]
           snprintf(progress->sizestr, sizeof(progress->sizestr), "%ld", progress->size);
                                                                     ^