### PR TITLE
nested-if: correctly handle "<" and ">" with %?

### DIFF
--- a/doc/manual.xml.head
+++ b/doc/manual.xml.head
@@ -11866,6 +11866,10 @@ set index_format='%4C %Z %{%b %d} %-25.25n %&lt;M?[%M] %s&amp;%s%* %&lt;l?%l&amp
             <para>Richard Russon
             <email>rich@flatcap.org</email></para>
           </listitem>
+          <listitem>
+            <para>Aleksa Sarai
+            <email>cyphar@cyphar.com</email></para>
+          </listitem>
         </itemizedlist>
       </sect2>
     </sect1>

--- a/muttlib.c
+++ b/muttlib.c
@@ -1057,20 +1057,25 @@ void mutt_expando_format(char *buf, size_t buflen, size_t col, int cols, const c
         /* %?x?y&z? to %<x?y&z> where y and z are nestable */
         char *p = (char *) src;
         *p = '<';
+        /* skip over "x" */
         for (; *p && *p != '?'; p++)
           ;
         /* nothing */
         if (*p == '?')
-        {
           p++;
-        }
+        /* fix up the "y&z" section */
         for (; *p && *p != '?'; p++)
-          ;
-        /* nothing */
-        if (*p == '?')
         {
-          *p = '>';
+            /* escape '<' and '>' to work inside nested-if */
+            if (*p == '<' || *p == '>')
+            {
+              memmove(p+2, p, mutt_str_strlen(p) + 1);
+              *p++ = '\\';
+              *p++ = '\\';
+            }
         }
+        if (*p == '?')
+          *p = '>';
       }
 
       if (*src == '<')


### PR DESCRIPTION
As part of the implementation of [nested-if][1], we translate old-style
conditional expandos into nested-if expandos. However, this translation
did not account for the metacharacters that need to be escaped in
nested-if expandos that are valid in old-style expandos (in particular
"<" and ">"). Correct this by escaping the relevant metacharacters.

With this patch, it is now possible to do something like

  :set status_format=" %rMail%r >%?u? +%u >?"

Without causing an ">" to be included if %u is 0 (which used to be the
case).

[1]: https://www.neomutt.org/feature/nested-if

Fixes: neomutt/neomutt#1001
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>