### PR TITLE
fix for pgpewrap in default gpg.rc

### DIFF
--- a/contrib/gpg.rc
+++ b/contrib/gpg.rc
@@ -62,13 +62,13 @@ set pgp_clearsign_command="gpg %?p?--pinentry-mode loopback --passphrase-fd 0? -
 #
 # set pgp_encrypt_only_command="/usr/lib/neomutt/pgpewrap gpg-2comp -v --batch --output - --encrypt --textmode --armor --always-trust -- -r %r -- %f"
 #
-set pgp_encrypt_only_command="/usr/lib/neomutt/pgpewrap gpg --batch --quiet --no-verbose --output - --textmode --armor -- --recipient %r -- --encrypt %f"
+set pgp_encrypt_only_command="/usr/lib/neomutt/pgpewrap gpg --batch --quiet --no-verbose --output - --textmode --armor --encrypt -- --recipient %r -- %f"
 
 # Create an encrypted and signed attachment (note that some users include the --always-trust option here)
 # 
 # set pgp_encrypt_sign_command="/usr/lib/neomutt/pgpewrap gpg-2comp %?p?--passphrase-fd 0? -v --batch --output - --encrypt --sign %?a?-u %a? --armor --always-trust -- -r %r -- %f"
 #
-set pgp_encrypt_sign_command="/usr/lib/neomutt/pgpewrap gpg %?p?--pinentry-mode loopback --passphrase-fd 0? --batch --quiet --no-verbose --textmode --output - %?a?--local-user %a? --armor -- --recipient %r -- --sign --encrypt %f"
+set pgp_encrypt_sign_command="/usr/lib/neomutt/pgpewrap gpg %?p?--pinentry-mode loopback --passphrase-fd 0? --batch --quiet --no-verbose --textmode --output - %?a?--local-user %a? --armor --sign --encrypt -- --recipient %r -- %f"
 
 # Import a key into the public key ring
 #


### PR DESCRIPTION
I believe this fix an bug introduced by changes introduced in Commit 465fad6d21ac3b9d2ae5d12bae7705f5f04323e7 which makes a change to `contrib/gpg.rc` that breaks signed and encrypted mail. The issues is just a typo related to way that `pgpewrap` works. This should fix the bug discussed in issue #998 and seems to do so on my system.

**Please review this carefully.** This is my first commit to mutt/neomutt and I know nothing about `pgpewrap` other than I what I just figured by experimenting with it on the command line. Since this i just a change to a configuration, I've not tested this more carefully than running the new configuration in my version of neomutt (the most recent version in debian).