### PR TITLE
Fix reply_regexp

### DIFF
--- a/init.h
+++ b/init.h
@@ -2917,12 +2917,12 @@ struct Option MuttVars[] = {
   ** .pp
   ** Also see $$wrap.
   */
-  { "reply_regexp",     DT_REGEX,   R_INDEX|R_RESORT, UL &ReplyRegexp, UL "^(re([\\[0-9\\]+])*|aw):[ \t]*" },
+  { "reply_regexp",     DT_REGEX,   R_INDEX|R_RESORT, UL &ReplyRegexp, UL "^((re|aw|sv)(\\[[0-9]+\\])*:[ \t]*)*" },
   /*
   ** .pp
   ** A regular expression used to recognize reply messages when threading
-  ** and replying. The default value corresponds to the English "Re:" and
-  ** the German "Aw:".
+  ** and replying. The default value corresponds to the English "Re:", the
+  ** German "Aw:" and the Swedish "Sv:".
   */
   { "reply_self",       DT_BOOL, R_NONE, UL &ReplySelf, 0 },
   /*


### PR DESCRIPTION
* **What does this PR do?**
Fixes the incorrectly formatted `reply_regexp` in `init.h`, and also adds the Swedish "Sv:" prefix to it.

* **Are there points in the code the reviewer needs to double check?**
That things still builds, I haven't set up the entire dev environment as this was such a simple fix. Perhaps also some documentation needs updating, e.g. Doxygen run or similar?

* **Screenshots (if relevant)**
N/A

* **Does this PR meet the acceptance criteria?**
It should, as I expect it to build just fine. I couldn't find any places in the manual touching on this feature/setting. Doxygen format should be fine, just added some words.

* **What are the relevant issue numbers?**
None, AFAIK.

* **Other comments**
Please note that the regex still allows the following subject prefixes which I'd argue are not proper. Since it's the current state of things I was reluctant to remove the matching for these cases, even though I think they're wrong: `Re[n][n]:`, `Re[0]:`