### PR TITLE
Make Weekdays, Months, and TimeZones statics, expose mutt_date_make_tls

### DIFF
--- a/conn/ssl_gnutls.c
+++ b/conn/ssl_gnutls.c
@@ -556,26 +556,6 @@ static int tls_check_preauth(const gnutls_datum_t *certdata,
 }
 
 /**
- * tls_make_date - Create a TLS date string
- * @param t   Time to convert
- * @param s   Buffer for the string
- * @param len Length of the buffer
- * @retval ptr Pointer to s
- */
-static char *tls_make_date(time_t t, char *s, size_t len)
-{
-  struct tm *l = gmtime(&t);
-
-  if (l)
-    snprintf(s, len, "%s, %d %s %d %02d:%02d:%02d UTC", Weekdays[l->tm_wday], l->tm_mday,
-             Months[l->tm_mon], l->tm_year + 1900, l->tm_hour, l->tm_min, l->tm_sec);
-  else
-    mutt_str_strfcpy(s, _("[invalid date]"), len);
-
-  return s;
-}
-
-/**
  * tls_check_one_certificate - Check a GnuTLS certificate
  * @param certdata List of GnuTLS certificates
  * @param certstat GnuTLS certificate status
@@ -755,12 +735,12 @@ static int tls_check_one_certificate(const gnutls_datum_t *certdata,
   snprintf(menu->dialog[row++], SHORT_STRING, _("This certificate is valid"));
 
   t = gnutls_x509_crt_get_activation_time(cert);
-  snprintf(menu->dialog[row++], SHORT_STRING, _("   from %s"),
-           tls_make_date(t, datestr, 30));
+  mutt_date_make_tls(datestr, sizeof(datestr), t);
+  snprintf(menu->dialog[row++], SHORT_STRING, _("   from %s"), datestr);
 
   t = gnutls_x509_crt_get_expiration_time(cert);
-  snprintf(menu->dialog[row++], SHORT_STRING, _("     to %s"),
-           tls_make_date(t, datestr, 30));
+  mutt_date_make_tls(datestr, sizeof(datestr), t);
+  snprintf(menu->dialog[row++], SHORT_STRING, _("     to %s"), datestr);
 
   fpbuf[0] = '\0';
   tls_fingerprint(GNUTLS_DIG_SHA, fpbuf, sizeof(fpbuf), certdata);

--- a/mutt/date.c
+++ b/mutt/date.c
@@ -25,12 +25,6 @@
  *
  * Some commonly used time and date functions.
  *
- * | Data                      | Description
- * | :------------------------ | :--------------------------------------------------
- * | #Months                   | Months of the year (abbreviated)
- * | #TimeZones                | Lookup table of Time Zones
- * | #Weekdays                 | Day of the week (abbreviated)
- *
  * | Function                   | Description
  * | :------------------------- | :--------------------------------------------------
  * | mutt_date_check_month()    | Is the string a valid month name
@@ -39,6 +33,7 @@
  * | mutt_date_make_date()      | Write a date in RFC822 format to a buffer
  * | mutt_date_make_imap()      | Format date in IMAP style: DD-MMM-YYYY HH:MM:SS +ZZzz
  * | mutt_date_make_time()      | Convert `struct tm` to `time_t`
+ * | mutt_date_make_tls()       | Format date in TLS certificate verification style
  * | mutt_date_normalize_time() | Fix the contents of a struct tm
  * | mutt_date_parse_date()     | Parse a date string in RFC822 format
  * | mutt_date_parse_imap()     | Parse date of the form: DD-MMM-YYYY HH:MM:SS +ZZzz
@@ -64,14 +59,14 @@
 /**
  * Weekdays - Day of the week (abbreviated)
  */
-const char *const Weekdays[] = {
+static const char *const Weekdays[] = {
   "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat",
 };
 
 /**
  * Months - Months of the year (abbreviated)
  */
-const char *const Months[] = {
+static const char *const Months[] = {
   "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul",
   "Aug", "Sep", "Oct", "Nov", "Dec", "ERR",
 };
@@ -82,7 +77,7 @@ const char *const Months[] = {
  *
  * @note Keep in alphabetical order
  */
-const struct Tz TimeZones[] = {
+static const struct Tz TimeZones[] = {
   { "aat",   1,  0, true  }, /* Atlantic Africa Time */
   { "adt",   4,  0, false }, /* Arabia DST */
   { "ast",   3,  0, false }, /* Arabia */
@@ -629,6 +624,25 @@ int mutt_date_make_imap(char *buf, size_t buflen, time_t timestamp)
   return snprintf(buf, buflen, "%02d-%s-%d %02d:%02d:%02d %+03d%02d", tm->tm_mday,
                   Months[tm->tm_mon], tm->tm_year + 1900, tm->tm_hour, tm->tm_min,
                   tm->tm_sec, (int) tz / 60, (int) abs((int) tz) % 60);
+}
+
+/**
+ * mutt_date_make_tls - Format date in TLS certificate verification style
+ * @param buf       Buffer to store the results
+ * @param buflen    Length of buffer
+ * @param timestamp Time to format
+ * @retval int Number of characters written to buf
+ *
+ * e.g., Mar 17 16:40:46 2016 UTC. The time is always in UTC.
+ *
+ * Caller should provide a buffer of at least 27 bytes.
+ */
+int mutt_date_make_tls(char *buf, size_t buflen, time_t timestamp)
+{
+  struct tm *tm = gmtime(&timestamp);
+  return snprintf(buf, buflen, "%s, %d %s %d %02d:%02d:%02d UTC",
+                  Weekdays[tm->tm_wday], tm->tm_mday, Months[tm->tm_mon],
+                  tm->tm_year + 1900, tm->tm_hour, tm->tm_min, tm->tm_sec);
 }
 
 /**

--- a/mutt/date.h
+++ b/mutt/date.h
@@ -37,16 +37,13 @@ struct Tz
   bool zoccident;         /**< True if west of UTC, False if East */
 };
 
-extern const char *const Weekdays[];
-extern const char *const Months[];
-extern const struct Tz TimeZones[];
-
 int     mutt_date_check_month(const char *s);
 bool    mutt_date_is_day_name(const char *s);
 time_t  mutt_date_local_tz(time_t t);
 char   *mutt_date_make_date(char *buf, size_t buflen);
 int     mutt_date_make_imap(char *buf, size_t buflen, time_t timestamp);
 time_t  mutt_date_make_time(struct tm *t, int local);
+int     mutt_date_make_tls(char *buf, size_t buflen, time_t timestamp);
 void    mutt_date_normalize_time(struct tm *tm);
 time_t  mutt_date_parse_date(const char *s, struct Tz *tz_out);
 time_t  mutt_date_parse_imap(char *s);


### PR DESCRIPTION
* **What does this PR do?**

This PR makes three arrays non-global and moves the only external function which used to use them into an API in date.h.