### PR TITLE
Replace two 'regexp' variables with 'regex'

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -951,9 +951,9 @@
 * Features
   - nntp: use safe_{fopen,fclose}
   - nntp: fix resource leak
-  - forgotten-attachment: Ignore lines matching quote_regexp.
+  - forgotten-attachment: Ignore lines matching quote_regex.
   - forgotten-attachment: Fix checking logic.
-  - forgotten-attachment: Update docs regarding $quote_regexp.
+  - forgotten-attachment: Update docs regarding $quote_regex.
   - notmuch: Add a fake "Folder" header to viewed emails
   - sidebar: consider description when using whitelist
   - skip-quoted: skip to body

--- a/contrib/sample.neomuttrc
+++ b/contrib/sample.neomuttrc
@@ -72,7 +72,7 @@ set read_inc=25			# show progress when reading a mailbox
 #set recall			# prompt to recall postponed messages
 set record=+outbox		# default location to save outgoing mail
 set reply_to			# always use reply-to if present
-#set reply_regexp="^(re:[ \t]*)+"# how to identify replies in the subject:
+#set reply_regex="^(re:[ \t]*)+"# how to identify replies in the subject:
 #set resolve		# move to the next message when an action is performed
 #set reverse_alias		# attempt to look up my names for people
 set reverse_name		# use my address as it appears in the message
@@ -254,12 +254,12 @@ save-hook ^judge +diplomacy
 #folder-hook mutt	'set index_format="%4C %Z %02m/%02N %-20.20F (%4l) %s"'
 #folder-hook =mutt	my_hdr Revolution: \#9 # real comment
 
-#folder-hook .		'set reply_regexp="^re:[ \t]*"'
+#folder-hook .		'set reply_regex="^re:[ \t]*"'
 
 # this mailing list prepends "[WM]" to all non reply subjects, so set
-# $reply_regexp to ignore it
+# $reply_regex to ignore it
 # Warning: May break threads for other people.
-#folder-hook +wmaker	'set reply_regexp="^(re:[ \t]*)?\[WM\][ \t]*"'
+#folder-hook +wmaker	'set reply_regex="^(re:[ \t]*)?\[WM\][ \t]*"'
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 #

--- a/contrib/sample.neomuttrc
+++ b/contrib/sample.neomuttrc
@@ -67,7 +67,7 @@ set postponed=+postponed	# mailbox to store postponed messages in
 #set print=ask-yes		# ask me if I really want to print messages
 set print_command=/bin/false	# how to print things (I like to save trees)
 set noprompt_after	# ask me for a command after the external pager exits
-#set quote_regexp="^ *[a-zA-Z]*[>:#}]"	# how to catch quoted text
+#set quote_regex="^ *[a-zA-Z]*[>:#}]"	# how to catch quoted text
 set read_inc=25			# show progress when reading a mailbox
 #set recall			# prompt to recall postponed messages
 set record=+outbox		# default location to save outgoing mail

--- a/contrib/sample.neomuttrc-tlr
+++ b/contrib/sample.neomuttrc-tlr
@@ -234,7 +234,7 @@ set   print=ask-no                      # Don't waste paper
 set   print_command="enscript -2Gr -Email"      # Two columns, landscape, fancy header.
 set   print_split=yes                   # Invoke enscript once per message
 set   quit=yes                          # Don't ask me whether or not I want to quit.
-set   quote_regexp="^ *[a-zA-Z]*[>|][>:|]*"     # Recognize quotes in the pager.
+set   quote_regex="^ *[a-zA-Z]*[>|][>:|]*"     # Recognize quotes in the pager.
 set   read_inc=50                       # Progress indicator when reading folders.
 set   recall=ask-no                     # When I say "compose", ask me whether I want to continue
                                         # composing a postponed message.

--- a/contrib/sample.neomuttrc-tlr
+++ b/contrib/sample.neomuttrc-tlr
@@ -266,7 +266,7 @@ set   encode_from                       # "From " in the beginning of a line tri
 set   nowait_key                        # Return immediately from external programs
 set   forward_format="[fwd] %s (from: %a)"      # A different subject for forwarded messages
 set   nobeep                            # Shut up. ;-)
-set   reply_regexp="^((re([\\[0-9\\]+])*|aw):[ \t]*)+[ \t]*"    # A regular expression to detect replies
+set   reply_regex="^((re([\\[0-9\\]+])*|aw):[ \t]*)+[ \t]*"    # A regular expression to detect replies
 set   header                            # Include the message header when replying.
 set   ignore_list_reply_to              # Ignore Reply-To headers pointing to mailing lists.
 set   norfc2047_parameters              # Sometimes, I get mails which use a bogus encoding for

--- a/doc/manual.xml.head
+++ b/doc/manual.xml.head
@@ -2254,7 +2254,7 @@ color sidebar_divider   color8  default
             <anchor id="toggle-quoted" />(default: T)</term>
             <listitem>
               <para>The pager uses the
-              <link linkend="quote-regexp">$quote_regexp</link> variable to
+              <link linkend="quote-regex">$quote_regex</link> variable to
               detect quoted text when displaying the body of the message. This
               function toggles the display of the quoted material in the
               message. It is particularly useful when being interested in just
@@ -4053,7 +4053,7 @@ folder-hook work "set sort=threads"
         </listitem>
         <listitem>
           <para>quoted (text matching
-          <link linkend="quote-regexp">$quote_regexp</link> in the body of a
+          <link linkend="quote-regex">$quote_regex</link> in the body of a
           message)</para>
         </listitem>
         <listitem>
@@ -10748,7 +10748,7 @@ set smime_default_key = "SMIME-KEY"
         certain keyword but there are no attachments added. This is meant to
         ensure that the user does not forget to attach a file after promising
         to do so in the mail.  The attachment keyword will not be scanned in
-        text matched by <link linkend="quote-regexp">$quote_regexp</link>.
+        text matched by <link linkend="quote-regex">$quote_regex</link>.
         </para>
       </sect2>
 

--- a/globals.h
+++ b/globals.h
@@ -324,7 +324,7 @@ WHERE char *NmQueryWindowCurrentSearch;
 /* These variables are backing for config items */
 WHERE struct Regex *GecosMask;
 WHERE struct Regex *Mask;
-WHERE struct Regex *QuoteRegexp;
+WHERE struct Regex *QuoteRegex;
 WHERE struct Regex *ReplyRegexp;
 WHERE struct Regex *Smileys;
 

--- a/globals.h
+++ b/globals.h
@@ -325,7 +325,7 @@ WHERE char *NmQueryWindowCurrentSearch;
 WHERE struct Regex *GecosMask;
 WHERE struct Regex *Mask;
 WHERE struct Regex *QuoteRegex;
-WHERE struct Regex *ReplyRegexp;
+WHERE struct Regex *ReplyRegex;
 WHERE struct Regex *Smileys;
 
 #endif /* _MUTT_GLOBALS_H */

--- a/init.c
+++ b/init.c
@@ -400,9 +400,9 @@ int mutt_option_set(const struct Option *val, struct Buffer *err)
 
         if (parse_regex(idx, &tmp, &err2))
         {
-          /* $reply_regexp and $alternates require special treatment */
+          /* $reply_regex and $alternates require special treatment */
           if (Context && Context->msgcount &&
-              (mutt_str_strcmp(MuttVars[idx].name, "reply_regexp") == 0))
+              (mutt_str_strcmp(MuttVars[idx].name, "reply_regex") == 0))
           {
             regmatch_t pmatch[1];
 
@@ -412,8 +412,8 @@ int mutt_option_set(const struct Option *val, struct Buffer *err)
               if (e && e->subject)
               {
                 e->real_subj = e->subject;
-                if (ReplyRegexp &&
-                    (regexec(ReplyRegexp->regex, e->subject, 1, pmatch, 0) == 0))
+                if (ReplyRegex &&
+                    (regexec(ReplyRegex->regex, e->subject, 1, pmatch, 0) == 0))
                 {
                   e->subject += pmatch[0].rm_eo;
                 }
@@ -2650,7 +2650,7 @@ static int parse_set(struct Buffer *tmp, struct Buffer *s, unsigned long data,
       }
 
       if (OPT_ATTACH_MSG &&
-          (mutt_str_strcmp(MuttVars[idx].name, "reply_regexp") == 0))
+          (mutt_str_strcmp(MuttVars[idx].name, "reply_regex") == 0))
       {
         snprintf(err->data, err->dsize,
                  "Operation not permitted when in attach-message mode.");
@@ -2666,9 +2666,9 @@ static int parse_set(struct Buffer *tmp, struct Buffer *s, unsigned long data,
 
       if (parse_regex(idx, tmp, err))
       {
-        /* $reply_regexp and $alternates require special treatment */
+        /* $reply_regex and $alternates require special treatment */
         if (Context && Context->msgcount &&
-            (mutt_str_strcmp(MuttVars[idx].name, "reply_regexp") == 0))
+            (mutt_str_strcmp(MuttVars[idx].name, "reply_regex") == 0))
         {
           regmatch_t pmatch[1];
 
@@ -2677,8 +2677,8 @@ static int parse_set(struct Buffer *tmp, struct Buffer *s, unsigned long data,
             struct Envelope *e = Context->hdrs[i]->env;
             if (e && e->subject)
             {
-              e->real_subj = (ReplyRegexp &&
-                              (regexec(ReplyRegexp->regex, e->subject, 1, pmatch, 0))) ?
+              e->real_subj = (ReplyRegex &&
+                              (regexec(ReplyRegex->regex, e->subject, 1, pmatch, 0))) ?
                                  e->subject :
                                  e->subject + pmatch[0].rm_eo;
             }

--- a/init.h
+++ b/init.h
@@ -2918,7 +2918,7 @@ struct Option MuttVars[] = {
   ** .pp
   ** Also see $$wrap.
   */
-  { "reply_regexp",     DT_REGEX,   R_INDEX|R_RESORT, UL &ReplyRegexp, UL "^((re|aw|sv)(\\[[0-9]+\\])*:[ \t]*)*" },
+  { "reply_regex",     DT_REGEX,   R_INDEX|R_RESORT, UL &ReplyRegex, UL "^((re|aw|sv)(\\[[0-9]+\\])*:[ \t]*)*" },
   /*
   ** .pp
   ** A regular expression used to recognize reply messages when threading
@@ -4407,6 +4407,7 @@ struct Option MuttVars[] = {
   { "post_indent_str",        DT_SYNONYM, R_NONE, UL "post_indent_string",       0 },
   { "print_cmd",              DT_SYNONYM, R_NONE, UL "print_command",            0 },
   { "quote_regexp",           DT_SYNONYM, R_NONE, UL "quote_regex",              0 },
+  { "reply_regexp",           DT_SYNONYM, R_NONE, UL "reply_regex",              0 },
   { "smime_self_encrypt_as",  DT_SYNONYM, R_NONE, UL "smime_default_key",        0 },
   { "xterm_icon",             DT_SYNONYM, R_NONE, UL "ts_icon_format",           0 },
   { "xterm_set_titles",       DT_SYNONYM, R_NONE, UL "ts_enabled",               0 },

--- a/init.h
+++ b/init.h
@@ -2817,7 +2817,7 @@ struct Option MuttVars[] = {
   ** have no effect, and if it is set to \fIask-yes\fP or \fIask-no\fP, you are
   ** prompted for confirmation when you try to quit.
   */
-  { "quote_regexp",     DT_REGEX,   R_PAGER, UL &QuoteRegexp, UL "^([ \t]*[|>:}#])+" },
+  { "quote_regex",     DT_REGEX,   R_PAGER, UL &QuoteRegex, UL "^([ \t]*[|>:}#])+" },
   /*
   ** .pp
   ** A regular expression used in the internal pager to determine quoted
@@ -3411,7 +3411,7 @@ struct Option MuttVars[] = {
   /*
   ** .pp
   ** The \fIpager\fP uses this variable to catch some common false
-  ** positives of $$quote_regexp, most notably smileys and not consider
+  ** positives of $$quote_regex, most notably smileys and not consider
   ** a line quoted text if it also matches $$smileys. This mostly
   ** happens at the beginning of a line.
   */
@@ -4406,6 +4406,7 @@ struct Option MuttVars[] = {
   { "pgp_verify_sig",         DT_SYNONYM, R_NONE, UL "crypt_verify_sig",         0 },
   { "post_indent_str",        DT_SYNONYM, R_NONE, UL "post_indent_string",       0 },
   { "print_cmd",              DT_SYNONYM, R_NONE, UL "print_command",            0 },
+  { "quote_regexp",           DT_SYNONYM, R_NONE, UL "quote_regex",              0 },
   { "smime_self_encrypt_as",  DT_SYNONYM, R_NONE, UL "smime_default_key",        0 },
   { "xterm_icon",             DT_SYNONYM, R_NONE, UL "ts_icon_format",           0 },
   { "xterm_set_titles",       DT_SYNONYM, R_NONE, UL "ts_enabled",               0 },

--- a/pager.c
+++ b/pager.c
@@ -841,7 +841,7 @@ static void resolve_types(char *buf, char *raw, struct Line *line_info, int n,
   }
   else if (check_sig(buf, line_info, n - 1) == 0)
     line_info[n].type = MT_COLOR_SIGNATURE;
-  else if (QuoteRegexp && regexec(QuoteRegexp->regex, buf, 1, pmatch, 0) == 0)
+  else if (QuoteRegex && regexec(QuoteRegex->regex, buf, 1, pmatch, 0) == 0)
   {
     if (Smileys && (regexec(Smileys->regex, buf, 1, smatch, 0) == 0))
     {
@@ -853,7 +853,7 @@ static void resolve_types(char *buf, char *raw, struct Line *line_info, int n,
         c = buf[smatch[0].rm_so];
         buf[smatch[0].rm_so] = 0;
 
-        if (QuoteRegexp && regexec(QuoteRegexp->regex, buf, 1, pmatch, 0) == 0)
+        if (QuoteRegex && regexec(QuoteRegex->regex, buf, 1, pmatch, 0) == 0)
         {
           if (q_classify && line_info[n].quote == NULL)
             line_info[n].quote = classify_quote(quote_list, buf + pmatch[0].rm_so,
@@ -1490,7 +1490,7 @@ static int display_line(FILE *f, LOFF_T *last_pos, struct Line **line_info,
         (*last)--;
       goto out;
     }
-    if (QuoteRegexp && regexec(QuoteRegexp->regex, (char *) fmt, 1, pmatch, 0) == 0)
+    if (QuoteRegex && regexec(QuoteRegex->regex, (char *) fmt, 1, pmatch, 0) == 0)
     {
       (*line_info)[n].quote =
           classify_quote(quote_list, (char *) fmt + pmatch[0].rm_so,

--- a/parse.c
+++ b/parse.c
@@ -1287,7 +1287,7 @@ struct Envelope *mutt_read_rfc822_header(FILE *f, struct Header *hdr,
 
       mutt_rfc2047_decode(&e->subject);
 
-      if (ReplyRegexp && (regexec(ReplyRegexp->regex, e->subject, 1, pmatch, 0) == 0))
+      if (ReplyRegex && (regexec(ReplyRegex->regex, e->subject, 1, pmatch, 0) == 0))
         e->real_subj = e->subject + pmatch[0].rm_eo;
       else
         e->real_subj = e->subject;

--- a/send.c
+++ b/send.c
@@ -1238,7 +1238,7 @@ static int is_reply(struct Header *reply, struct Header *orig)
 static int search_attach_keyword(char *filename)
 {
   /* Search for the regex in AttachKeyword within a file */
-  if (!AttachKeyword || !QuoteRegexp)
+  if (!AttachKeyword || !QuoteRegex)
     return 0;
 
   FILE *attf = mutt_file_fopen(filename, "r");
@@ -1250,7 +1250,7 @@ static int search_attach_keyword(char *filename)
   while (!feof(attf))
   {
     fgets(inputline, LONG_STRING, attf);
-    if (regexec(QuoteRegexp->regex, inputline, 0, NULL, 0) != 0 &&
+    if (regexec(QuoteRegex->regex, inputline, 0, NULL, 0) != 0 &&
         regexec(AttachKeyword->regex, inputline, 0, NULL, 0) == 0)
     {
       found = 1;


### PR DESCRIPTION
- Rename config:
  - `$quote_regexp` -> `$quote_regex`
  - `$reply_regexp` -> `$reply_regex`
- Create synonyms, so old config works

In the past, the vast majority of the code referred to regular expressions as 'regex', not 'regexp'.
So, I renamed all the `regexp`s that I could.

The last exceptions were two config items.

The 'regexp' versions can be deprecated in the (far) future.