### PR TITLE
Let mutt_str_str(n)fcpy return the string length, add tests

### DIFF
--- a/mutt/string.c
+++ b/mutt/string.c
@@ -718,9 +718,9 @@ int mutt_str_is_email_wsp(char c)
  * @param src  String to copy
  * @param size Maximum number of characters to copy
  * @param dlen Length of buffer
- * @retval ptr Destination buffer
+ * @retval len Destination string length
  */
-char *mutt_str_strnfcpy(char *dest, char *src, size_t size, size_t dlen)
+size_t mutt_str_strnfcpy(char *dest, char *src, size_t size, size_t dlen)
 {
   if (dlen > size)
     dlen = size - 1;

--- a/mutt/string.c
+++ b/mutt/string.c
@@ -675,16 +675,16 @@ void mutt_str_remove_trailing_ws(char *s)
  * @param dest Buffer for the result
  * @param src  String to copy
  * @param dlen Length of buffer
- * @retval ptr Destination buffer
+ * @retval len Destination string length
  */
-char *mutt_str_strfcpy(char *dest, const char *src, size_t dlen)
+size_t mutt_str_strfcpy(char *dest, const char *src, size_t dlen)
 {
   char *dest0 = dest;
   while ((--dlen > 0) && (*src != '\0'))
     *dest++ = *src++;
 
   *dest = '\0';
-  return dest0;
+  return dest - dest0;
 }
 
 /**

--- a/mutt/string2.h
+++ b/mutt/string2.h
@@ -88,7 +88,7 @@ const char *mutt_str_strchrnul(const char *s, char c);
 int         mutt_str_strcmp(const char *a, const char *b);
 int         mutt_str_strcoll(const char *a, const char *b);
 char *      mutt_str_strdup(const char *s);
-char *      mutt_str_strfcpy(char *dest, const char *src, size_t dlen);
+size_t      mutt_str_strfcpy(char *dest, const char *src, size_t dlen);
 const char *mutt_str_stristr(const char *haystack, const char *needle);
 size_t      mutt_str_strlen(const char *a);
 char *      mutt_str_strlower(char *s);

--- a/mutt/string2.h
+++ b/mutt/string2.h
@@ -95,7 +95,7 @@ char *      mutt_str_strlower(char *s);
 int         mutt_str_strncasecmp(const char *a, const char *b, size_t l);
 char *      mutt_str_strncat(char *d, size_t l, const char *s, size_t sl);
 int         mutt_str_strncmp(const char *a, const char *b, size_t l);
-char *      mutt_str_strnfcpy(char *dest, char *src, size_t size, size_t dlen);
+size_t      mutt_str_strnfcpy(char *dest, char *src, size_t size, size_t dlen);
 char *      mutt_str_substr_cpy(char *dest, const char *begin, const char *end, size_t destlen);
 char *      mutt_str_substr_dup(const char *begin, const char *end);
 const char *mutt_str_sysexit(int e);

--- a/test/Makefile.autosetup
+++ b/test/Makefile.autosetup
@@ -1,7 +1,8 @@
 TEST_OBJS   = test/main.o \
 	      test/base64.o \
 	      test/rfc2047.o \
-	      test/md5.o
+	      test/md5.o \
+	      test/string.o
 
 TEST_BINARY = test/neomutt-test$(EXEEXT)
 

--- a/test/main.c
+++ b/test/main.c
@@ -10,7 +10,8 @@
   NEOMUTT_TEST_ITEM(test_rfc2047)                                              \
   NEOMUTT_TEST_ITEM(test_md5)                                                  \
   NEOMUTT_TEST_ITEM(test_md5_ctx)                                              \
-  NEOMUTT_TEST_ITEM(test_md5_ctx_bytes)
+  NEOMUTT_TEST_ITEM(test_md5_ctx_bytes)                                        \
+  NEOMUTT_TEST_ITEM(test_string_strfcpy)
 
 /******************************************************************************
  * You probably don't need to touch what follows.

--- a/test/string.c
+++ b/test/string.c
@@ -1,0 +1,46 @@
+#define TEST_NO_MAIN
+#include "acutest.h"
+
+#include "mutt/string2.h"
+
+void test_string_strfcpy(void)
+{
+  char src[20] = "\0";
+  char dst[10];
+
+  { /* empty */
+    size_t len = mutt_str_strfcpy(dst, src, sizeof(dst));
+    if (!TEST_CHECK(len == 0))
+    {
+      TEST_MSG("Expected: %zu", 0);
+      TEST_MSG("Actual  : %zu", len);
+    }
+  }
+
+  { /* normal */
+    const char trial[] = "Hello";
+    mutt_str_strfcpy(src, trial, sizeof(src)); /* let's eat our own dogfood */
+    size_t len = mutt_str_strfcpy(dst, src, sizeof(dst));
+    if (!TEST_CHECK(len == sizeof(trial) - 1))
+    {
+      TEST_MSG("Expected: %zu", sizeof(trial) - 1);
+      TEST_MSG("Actual  : %zu", len);
+    }
+    if (!TEST_CHECK(strcmp(dst, trial) == 0))
+    {
+      TEST_MSG("Expected: %s", trial);
+      TEST_MSG("Actual  : %s", dst);
+    }
+  }
+
+  { /* too long */
+    const char trial[] = "Hello Hello Hello";
+    mutt_str_strfcpy(src, trial, sizeof(src));
+    size_t len = mutt_str_strfcpy(dst, src, sizeof(dst));
+    if (!TEST_CHECK(len == sizeof(dst) - 1))
+    {
+      TEST_MSG("Expected: %zu", sizeof(dst) - 1);
+      TEST_MSG("Actual  : %zu", len);
+    }
+  }
+}


### PR DESCRIPTION
The idea is that the currently returned value is of little use, being it the same as the destination parameter. Let's return something useful instead, namely the length of the string which was copied.