### PR TITLE
fix parsing of urls containing '?'

### DIFF
--- a/mutt/rfc2047.c
+++ b/mutt/rfc2047.c
@@ -658,6 +658,9 @@ void mutt_rfc2047_encode(char **pd, const char *specials, int col, const char *c
  */
 void mutt_rfc2047_decode(char **pd)
 {
+  if (!pd || !*pd)
+    return;
+
   struct Buffer buf = { 0 }; /* Output buffer                          */
   char *s = *pd;             /* Read pointer                           */
   char *beg;                 /* Begin of encoded word                  */
@@ -745,5 +748,4 @@ void mutt_rfc2047_decode(char **pd)
 
   mutt_buffer_addch(&buf, '\0');
   *pd = buf.data;
-  return;
 }

--- a/url.c
+++ b/url.c
@@ -174,12 +174,20 @@ int url_parse(struct Url *u, char *src)
 
   src += 2;
 
-  t = strchr(src, '?');
-  if (t)
+  /* Notmuch and mailto schemes can include a query */
+#ifdef USE_NOTMUCH
+  if ((u->scheme == U_NOTMUCH) || (u->scheme == U_MAILTO))
+#else
+  if (u->scheme == U_MAILTO)
+#endif
   {
-    *t++ = '\0';
-    if (parse_query_string(u, t) < 0)
-      goto err;
+    t = strrchr(src, '?');
+    if (t)
+    {
+      *t++ = '\0';
+      if (parse_query_string(u, t) < 0)
+        goto err;
+    }
   }
 
   u->path = strchr(src, '/');


### PR DESCRIPTION
The URL schemes come in two patterns
- smtp://user:pass@host
- notmuch:///path?query

The 'host' types don't take a query string.
'notmuch' and 'mailto' don't use a 'user:pass' string.

This fix will still be confused by a notmuch URL that has a '?' in the path component, but no query string.  (but I don't think the code ever coped with that).  e.g.

- notmuch:///dir?name/

Fixes #1043
