### PR TITLE
configure: Check for Docbook DTDs

### DIFF
--- a/auto.def
+++ b/auto.def
@@ -335,13 +335,13 @@ if {[get-define want-doc]} {
     "http://www.oasis-open.org/docbook/xml/4.2/docbookx.dtd">
     <book />}
 
-  if {[catch {exec xsltproc --nonet xslt_test.xsl xslt_test.xml}]} {
+  set err [catch {exec xsltproc --nonet xslt_test.xsl xslt_test.xml}]
+  file delete -- xslt_test.xsl xslt_test.xml
+  if {$err} {
     msg-result "no"
-    exec rm -f xslt_test.xsl xslt_test.xml
     user-error "Install DocBook DTDs or './configure --disable-doc'"
   }
   msg-result "yes"
-  exec rm -f xslt_test.xsl xslt_test.xml
 
   define BUILD_DOC
 }

--- a/auto.def
+++ b/auto.def
@@ -324,18 +324,24 @@ if {[get-define want-doc]} {
   }
 
   msg-checking "Checking for DocBook DTDs..."
-  set book {
-    <?xml version="1.0" standalone="no"?>
-    <!DOCTYPE book PUBLIC
-      "-//OASIS//DTD DocBook XML V4.2//EN"
-      "http://www.oasis-open.org/docbook/xml/4.2/docbookx.dtd"
-    ><book/>
-  }
-  if {[catch {exec xsltproc --nonet doc/html.xsl << $book}]} {
+
+  writefile xslt_test.xsl {<?xml version="1.0"?>
+    <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+      <xsl:import href="http://docbook.sourceforge.net/release/xsl/current/xhtml/docbook.xsl"/>
+    </xsl:stylesheet>}
+
+  writefile xslt_test.xml {<?xml version="1.0" standalone="no"?>
+    <!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.2//EN"
+    "http://www.oasis-open.org/docbook/xml/4.2/docbookx.dtd">
+    <book />}
+
+  if {[catch {exec xsltproc --nonet xslt_test.xsl xslt_test.xml}]} {
     msg-result "no"
-    user-error "Install DocBook DTDs, or './configure --disable-doc'"
+    exec rm -f xslt_test.xsl xslt_test.xml
+    user-error "Install DocBook DTDs or './configure --disable-doc'"
   }
   msg-result "yes"
+  exec rm -f xslt_test.xsl xslt_test.xml
 
   define BUILD_DOC
 }

--- a/auto.def
+++ b/auto.def
@@ -322,6 +322,18 @@ if {[get-define want-doc]} {
   if {![cc-check-progs xsltproc]} {
     user-error "Unable to find xsltproc"
   }
+
+  set dtd_tmp "test.xml"
+  msg-checking "Checking Docbook DTDs are installed..."
+  writefile $dtd_tmp "<?xml version=\"1.0\" standalone=\"no\"?> <!DOCTYPE book PUBLIC \"-//OASIS//DTD DocBook XML V4.2//EN\" \"http://www.oasis-open.org/docbook/xml/4.2/docbookx.dtd\"> <book></book>"
+  if {[catch {exec xsltproc --nonet doc/html.xsl $dtd_tmp > /dev/null} out]} {
+    exec rm -f $dtd_tmp
+    msg-result "no"
+    user-error "Install Docbook DTDs, or './configure --disable-doc'"
+  }
+  exec rm -f $dtd_tmp
+  msg-result "yes"
+
   define BUILD_DOC
 }
 if {[get-define want-full-doc]} {define MAKEDOC_FULL}

--- a/auto.def
+++ b/auto.def
@@ -323,15 +323,18 @@ if {[get-define want-doc]} {
     user-error "Unable to find xsltproc"
   }
 
-  set dtd_tmp "test.xml"
-  msg-checking "Checking Docbook DTDs are installed..."
-  writefile $dtd_tmp "<?xml version=\"1.0\" standalone=\"no\"?> <!DOCTYPE book PUBLIC \"-//OASIS//DTD DocBook XML V4.2//EN\" \"http://www.oasis-open.org/docbook/xml/4.2/docbookx.dtd\"> <book></book>"
-  if {[catch {exec xsltproc --nonet doc/html.xsl $dtd_tmp > /dev/null} out]} {
-    exec rm -f $dtd_tmp
-    msg-result "no"
-    user-error "Install Docbook DTDs, or './configure --disable-doc'"
+  msg-checking "Checking for DocBook DTDs..."
+  set book {
+    <?xml version="1.0" standalone="no"?>
+    <!DOCTYPE book PUBLIC
+      "-//OASIS//DTD DocBook XML V4.2//EN"
+      "http://www.oasis-open.org/docbook/xml/4.2/docbookx.dtd"
+    ><book/>
   }
-  exec rm -f $dtd_tmp
+  if {[catch {exec xsltproc --nonet doc/html.xsl << $book}]} {
+    msg-result "no"
+    user-error "Install DocBook DTDs, or './configure --disable-doc'"
+  }
   msg-result "yes"
 
   define BUILD_DOC


### PR DESCRIPTION
Run xsltproc with a minimal Docbook file.
If this succeeds, then the docs will probably build correctly.