### PR TITLE
Fix regex issues

### DIFF
--- a/browser.c
+++ b/browser.c
@@ -730,7 +730,7 @@ static int examine_directory(struct Menu *menu, struct BrowserState *state,
         continue;
       if (prefix && *prefix && (strncmp(prefix, nntp_data->group, strlen(prefix)) != 0))
         continue;
-      if (Mask && !((regexec(Mask->regex, nntp_data->group, 0, NULL, 0) == 0) ^ Mask->not))
+      if (Mask && Mask->regex && !((regexec(Mask->regex, nntp_data->group, 0, NULL, 0) == 0) ^ Mask->not))
         continue;
       add_folder(menu, state, nntp_data->group, NULL, NULL, NULL, nntp_data);
     }
@@ -788,7 +788,7 @@ static int examine_directory(struct Menu *menu, struct BrowserState *state,
       {
         continue;
       }
-      if (Mask && !((regexec(Mask->regex, de->d_name, 0, NULL, 0) == 0) ^ Mask->not))
+      if (Mask && Mask->regex && !((regexec(Mask->regex, de->d_name, 0, NULL, 0) == 0) ^ Mask->not))
         continue;
 
       mutt_file_concat_path(buffer, d, de->d_name, sizeof(buffer));
@@ -1814,7 +1814,7 @@ void mutt_select_file(char *f, size_t flen, int flags, char ***files, int *numfi
           }
           else
           {
-            if (Mask)
+            if (Mask && Mask->regex)
             {
               regfree(Mask->regex);
               FREE(&Mask->regex);

--- a/imap/browse.c
+++ b/imap/browse.c
@@ -92,7 +92,7 @@ static void add_folder(char delim, char *folder, int noselect, int noinferiors,
   /* apply filemask filter. This should really be done at menu setup rather
    * than at scan, since it's so expensive to scan. But that's big changes
    * to browser.c */
-  if (Mask && !((regexec(Mask->regex, relpath, 0, NULL, 0) == 0) ^ Mask->not))
+  if (Mask && Mask->regex && !((regexec(Mask->regex, relpath, 0, NULL, 0) == 0) ^ Mask->not))
   {
     FREE(&mx.mbox);
     return;

--- a/init.c
+++ b/init.c
@@ -378,7 +378,7 @@ int mutt_option_set(const struct Option *val, struct Buffer *err)
               if (e && e->subject)
               {
                 e->real_subj = e->subject;
-                if (ReplyRegex &&
+                if (ReplyRegex && ReplyRegex->regex &&
                     (regexec(ReplyRegex->regex, e->subject, 1, pmatch, 0) == 0))
                 {
                   e->subject += pmatch[0].rm_eo;
@@ -2604,7 +2604,7 @@ static int parse_set(struct Buffer *tmp, struct Buffer *s, unsigned long data,
             struct Envelope *e = Context->hdrs[i]->env;
             if (e && e->subject)
             {
-              e->real_subj = (ReplyRegex &&
+              e->real_subj = (ReplyRegex && ReplyRegex->regex &&
                               (regexec(ReplyRegex->regex, e->subject, 1, pmatch, 0))) ?
                                  e->subject :
                                  e->subject + pmatch[0].rm_eo;

--- a/init.c
+++ b/init.c
@@ -693,21 +693,13 @@ int mutt_extract_token(struct Buffer *dest, struct Buffer *tok, int flags)
 
 static void free_opt(struct Option *p)
 {
-  struct Regex **pp = NULL;
-
   switch (DTYPE(p->type))
   {
     case DT_ADDRESS:
       mutt_addr_free((struct Address **) p->var);
       break;
     case DT_REGEX:
-      pp = (struct Regex **) p->var;
-      FREE(&(*pp)->pattern);
-      if ((*pp)->regex)
-      {
-        regfree((*pp)->regex);
-        FREE(&(*pp)->regex);
-      }
+      mutt_regex_free((struct Regex **) p->var);
       break;
     case DT_PATH:
     case DT_STRING:

--- a/init.c
+++ b/init.c
@@ -168,62 +168,28 @@ static int toggle_quadoption(int opt)
 
 static int parse_regex(int idx, struct Buffer *tmp, struct Buffer *err)
 {
-  int e, flags = 0;
-  const char *p = NULL;
-  regex_t *rx = NULL;
-  struct Regex *ptr = *(struct Regex **) MuttVars[idx].var;
+  struct Regex **ptr = (struct Regex **) MuttVars[idx].var;
 
-  if (ptr)
+  if (*ptr)
   {
     /* Same pattern as we already have */
-    if (mutt_str_strcmp(ptr->pattern, tmp->data) == 0)
+    if (mutt_str_strcmp((*ptr)->pattern, tmp->data) == 0)
       return 0;
   }
-  else
+
+  if (mutt_buffer_is_empty(tmp))
   {
-    ptr = mutt_mem_calloc(1, sizeof(struct Regex));
-    *(struct Regex **) MuttVars[idx].var = ptr;
-  }
-
-  bool not = false;
-
-  /* Should we use smart case matching? */
-  if (((MuttVars[idx].flags & DT_REGEX_MATCH_CASE) == 0) && mutt_mb_is_lower(tmp->data))
-    flags |= REG_ICASE;
-
-  p = tmp->data;
-  /* Is a prefix of '!' allowed? */
-  if ((MuttVars[idx].flags & DT_REGEX_ALLOW_NOT) != 0)
-  {
-    if (*p == '!')
-    {
-      not = true;
-      p++;
-    }
-  }
-
-  rx = mutt_mem_malloc(sizeof(regex_t));
-  e = REGCOMP(rx, p, flags);
-  if (e != 0)
-  {
-    regerror(e, rx, err->data, err->dsize);
-    FREE(&rx);
+    mutt_regex_free(ptr);
     return 0;
   }
 
-  /* get here only if everything went smoothly */
-  if (ptr->pattern)
-  {
-    FREE(&ptr->pattern);
-    regfree((regex_t *) ptr->regex);
-    FREE(&ptr->regex);
-  }
+  struct Regex *rnew = mutt_regex_create(tmp->data, MuttVars[idx].flags, err);
+  if (!rnew)
+    return 1;
 
-  ptr->pattern = mutt_str_strdup(tmp->data);
-  ptr->regex = rx;
-  ptr->not = not;
-
-  return 1;
+  mutt_regex_free(ptr);
+  *ptr = rnew;
+  return 0;
 }
 
 int query_quadoption(int opt, const char *prompt)
@@ -1924,9 +1890,9 @@ static void set_default(struct Option *p)
       break;
     case DT_REGEX:
     {
-      struct Regex *pp = (struct Regex *) p->var;
-      if (!p->initial && pp->pattern)
-        p->initial = (unsigned long) mutt_str_strdup(pp->pattern);
+      struct Regex **ptr = (struct Regex **) p->var;
+      if (!p->initial && *ptr && (*ptr)->pattern)
+        p->initial = (unsigned long) mutt_str_strdup((*ptr)->pattern);
       break;
     }
   }
@@ -1982,53 +1948,14 @@ static void restore_default(struct Option *p)
       break;
     case DT_REGEX:
     {
-      struct Regex **pp = (struct Regex **) p->var;
-      if (*pp)
-      {
-        FREE(&(*pp)->pattern);
-        if ((*pp)->regex)
-        {
-          regfree((*pp)->regex);
-          FREE(&(*pp)->regex);
-        }
-      }
-      else
-      {
-        *pp = mutt_mem_calloc(1, sizeof(struct Regex));
-      }
+      struct Regex **ptr = (struct Regex **) p->var;
 
-      if (p->initial)
-      {
-        int flags = 0;
-        char *s = (char *) p->initial;
+      if (*ptr)
+        mutt_regex_free(ptr);
 
-        (*pp)->regex = mutt_mem_calloc(1, sizeof(regex_t));
-        (*pp)->pattern = mutt_str_strdup((char *) p->initial);
-        if ((mutt_str_strcmp(p->name, "mask") != 0) &&
-            (mutt_mb_is_lower((const char *) p->initial)))
-        {
-          flags |= REG_ICASE;
-        }
-        if ((mutt_str_strcmp(p->name, "mask") == 0) && *s == '!')
-        {
-          s++;
-          (*pp)->not = true;
-        }
-        int rc = REGCOMP((*pp)->regex, s, flags);
-        if (rc != 0)
-        {
-          char msgbuf[STRING];
-          regerror(rc, (*pp)->regex, msgbuf, sizeof(msgbuf));
-          fprintf(stderr, _("restore_default(%s): error in regex: %s\n"),
-                  p->name, (*pp)->pattern);
-          fprintf(stderr, "%s\n", msgbuf);
-          mutt_sleep(0);
-          FREE(&(*pp)->pattern);
-          FREE(&(*pp)->regex);
-        }
-      }
+      *ptr = mutt_regex_create((const char *) p->initial, p->flags, NULL);
+      break;
     }
-    break;
   }
 
   if (p->flags & R_INDEX)

--- a/mutt/regex.c
+++ b/mutt/regex.c
@@ -220,6 +220,8 @@ bool mutt_regexlist_match(struct RegexList *rl, const char *str)
 
   for (; rl; rl = rl->next)
   {
+    if (!rl->regex || rl->regex->regex)
+      continue;
     if (regexec(rl->regex->regex, str, (size_t) 0, (regmatch_t *) 0, (int) 0) == 0)
     {
       mutt_debug(5, "%s matches %s\n", str, rl->regex->pattern);

--- a/muttlib.c
+++ b/muttlib.c
@@ -320,7 +320,7 @@ char *mutt_gecos_name(char *dest, size_t destlen, struct passwd *pw)
 
   memset(dest, 0, destlen);
 
-  if (GecosMask)
+  if (GecosMask && GecosMask->regex)
   {
     if (regexec(GecosMask->regex, pw->pw_gecos, 1, pat_match, 0) == 0)
       mutt_str_strfcpy(dest, pw->pw_gecos + pat_match[0].rm_so,

--- a/ncrypt/pgp.c
+++ b/ncrypt/pgp.c
@@ -187,7 +187,7 @@ static int pgp_copy_checksig(FILE *fpin, FILE *fpout)
 {
   int rc = -1;
 
-  if (PgpGoodSign)
+  if (PgpGoodSign && PgpGoodSign->regex)
   {
     char *line = NULL;
     int lineno = 0;
@@ -231,7 +231,7 @@ static int pgp_check_decryption_okay(FILE *fpin)
 {
   int rc = -1;
 
-  if (PgpDecryptionOkay)
+  if (PgpDecryptionOkay && PgpDecryptionOkay->regex)
   {
     char *line = NULL;
     int lineno = 0;

--- a/pager.c
+++ b/pager.c
@@ -841,9 +841,9 @@ static void resolve_types(char *buf, char *raw, struct Line *line_info, int n,
   }
   else if (check_sig(buf, line_info, n - 1) == 0)
     line_info[n].type = MT_COLOR_SIGNATURE;
-  else if (QuoteRegex && regexec(QuoteRegex->regex, buf, 1, pmatch, 0) == 0)
+  else if (QuoteRegex && QuoteRegex->regex && regexec(QuoteRegex->regex, buf, 1, pmatch, 0) == 0)
   {
-    if (Smileys && (regexec(Smileys->regex, buf, 1, smatch, 0) == 0))
+    if (Smileys && Smileys->regex && (regexec(Smileys->regex, buf, 1, smatch, 0) == 0))
     {
       if (smatch[0].rm_so > 0)
       {
@@ -853,7 +853,7 @@ static void resolve_types(char *buf, char *raw, struct Line *line_info, int n,
         c = buf[smatch[0].rm_so];
         buf[smatch[0].rm_so] = 0;
 
-        if (QuoteRegex && regexec(QuoteRegex->regex, buf, 1, pmatch, 0) == 0)
+        if (regexec(QuoteRegex->regex, buf, 1, pmatch, 0) == 0)
         {
           if (q_classify && line_info[n].quote == NULL)
             line_info[n].quote = classify_quote(quote_list, buf + pmatch[0].rm_so,
@@ -1490,7 +1490,7 @@ static int display_line(FILE *f, LOFF_T *last_pos, struct Line **line_info,
         (*last)--;
       goto out;
     }
-    if (QuoteRegex && regexec(QuoteRegex->regex, (char *) fmt, 1, pmatch, 0) == 0)
+    if (QuoteRegex && QuoteRegex->regex && regexec(QuoteRegex->regex, (char *) fmt, 1, pmatch, 0) == 0)
     {
       (*line_info)[n].quote =
           classify_quote(quote_list, (char *) fmt + pmatch[0].rm_so,

--- a/parse.c
+++ b/parse.c
@@ -1280,7 +1280,7 @@ struct Envelope *mutt_read_rfc822_header(FILE *f, struct Header *hdr,
 
       mutt_rfc2047_decode(&e->subject);
 
-      if (ReplyRegex && (regexec(ReplyRegex->regex, e->subject, 1, pmatch, 0) == 0))
+      if (ReplyRegex && ReplyRegex->regex && (regexec(ReplyRegex->regex, e->subject, 1, pmatch, 0) == 0))
         e->real_subj = e->subject + pmatch[0].rm_eo;
       else
         e->real_subj = e->subject;

--- a/send.c
+++ b/send.c
@@ -1237,7 +1237,7 @@ static int is_reply(struct Header *reply, struct Header *orig)
 static int search_attach_keyword(char *filename)
 {
   /* Search for the regex in AttachKeyword within a file */
-  if (!AttachKeyword || !QuoteRegex)
+  if (!AttachKeyword || !AttachKeyword->regex || !QuoteRegex || !QuoteRegex->regex)
     return 0;
 
   FILE *attf = mutt_file_fopen(filename, "r");


### PR DESCRIPTION
The bug happened when setting a regex config to a bad string, or an empty string.
The code would only partially construct a Regex object.

- All-or-nothing construction of Regex objects
- Check all the regex pointers before calling external functions
- Fix cleanup routine (thanks @gahr)

Note: The construction code is much smaller than the original because the logic has been simplified.

The code used to have lots of special cases for certain variables.
These cases were changed into flags, e.g. `DT_REGEX_ALLOW_NOT` and added to `mutt_regex_create()`.
