### PR TITLE
fix crash when decoding parameters

### DIFF
--- a/rfc2231.c
+++ b/rfc2231.c
@@ -267,7 +267,7 @@ void rfc2231_decode_parameters(struct ParameterList *p)
 
       np->attribute = NULL;
       np->value = NULL;
-      FREE(&p);
+      FREE(&np);
 
       rfc2231_list_insert(&conthead, conttmp);
     }


### PR DESCRIPTION
franks2 reported a crash on irc.

It looks like a typo from when `rfc2231_decode_parameters()` was converted to use TAILQ.
See this chunk in the diff: https://github.com/neomutt/neomutt/commit/2aa6bb0a3b#diff-4c6d574f56ae9eb69dc081817e58beecL285
```
#0  0x00007fb5ccba40bb in __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:51
#1  0x00007fb5ccba5f5d in __GI_abort () at abort.c:90
#2  0x00007fb5ccbee28d in __libc_message (action=action@entry=do_abort, fmt=fmt@entry=0x7fb5ccd15528 "*** Error in `%s': %s: 0x%s ***\n") at ../sysdeps/posix/libc_fatal.c:181
#3  0x00007fb5ccbf564a in malloc_printerr (action=<optimized out>, str=0x7fb5ccd11e7c "free(): invalid size", ptr=<optimized out>, ar_ptr=<optimized out>) at malloc.c:5426
#4  0x00007fb5ccbf773e in _int_free (av=0x7fb5ccf47c20 <main_arena>, p=<optimized out>, have_lock=0) at malloc.c:4175
#5  0x00007fb5ccbfc44e in __GI___libc_free (mem=<optimized out>) at malloc.c:3145
#6  0x000055f57e23cd79 in mutt_mem_free (ptr=ptr@entry=0x7ffc636c0638) at mutt/memory.c:93
#7  0x000055f57e21a67a in rfc2231_decode_parameters (p=<optimized out>, p@entry=0x7ffc636c0e00) at rfc2231.c:270
#8  0x000055f57e207a2b in parse_parameters (param=param@entry=0x7ffc636c0e00, s=0x0) at parse.c:263
#9  0x000055f57e207c99 in parse_content_disposition (s=<optimized out>, s@entry=0x55f58060f2f5 "inline; filename*0=\"DAN Cases  A4SFX v2 available in the next days on Kickstarter.pd\"; filename*1=f", ct=ct@entry=0x55f580a3f410) at parse.c:404
#10 0x000055f57e208ac3 in mutt_read_mime_header (fp=fp@entry=0x55f5808f6c80, digest=digest@entry=0) at parse.c:460
#11 0x000055f57e20a2a1 in mutt_parse_multipart (fp=fp@entry=0x55f5808f6c80, boundary=boundary@entry=0x55f5809473e0 "Apple-Mail=_6F32521F-EFD6-4149-A38B-62DBE7A44758", end_off=211482, digest=0) at parse.c:627
#12 0x000055f57e20a023 in mutt_parse_part (fp=0x55f5808f6c80, b=0x55f580947260) at parse.c:510
#13 0x000055f57e20a4e8 in mutt_parse_mime_message (ctx=0x55f5800829c0, cur=0x55f5801c5c40) at parse.c:753
#14 0x000055f57e20a5c5 in mutt_count_body_parts (ctx=ctx@entry=0x55f5800829c0, hdr=hdr@entry=0x55f5801c5c40) at parse.c:1445
#15 0x000055f57e1d80db in index_format_str (buf=buf@entry=0x7ffc636c1b80 "", buflen=buflen@entry=1024, col=68, cols=cols@entry=133, op=<optimized out>, src=0x7ffc636c1ae3 " %s %> %?g?%g?", prec=0x7ffc636c1980 "", if_str=0x7ffc636c1a00 "¤", else_str=0x7ffc636c1f80 " ", data=140721976517600, flags=(MUTT_FORMAT_MAKEPRINT | MUTT_FORMAT_OPTIONAL | MUTT_FORMAT_ARROWCURSOR | MUTT_FORMAT_INDEX)) at hdrline.c:1160
#16 0x000055f57e1f5bcd in mutt_expando_format (buf=0x7ffc636c2420 "\016#4892\016\033 (\016$204K\016\033) \016\035   \016\033  \016!24/May\016\033  \016\034Jesper Stærkær      \016\033", ' ' <repeats 23 times>, "\016\037[Sentry] [Seatronic] 3 new alerts since May 24, 2017, 8:21 a.m.\016\033", buflen=1023, col=<optimized out>, col@entry=0, cols=133, src=<optimized out>, callback=callback@entry=0x55f57e1d7bc0 <index_format_str>, data=140721976517600, flags=(MUTT_FORMAT_MAKEPRINT | MUTT_FORMAT_OPTIONAL | MUTT_FORMAT_ARROWCURSOR | MUTT_FORMAT_INDEX)) at muttlib.c:1167
#17 0x000055f57e1da8f9 in mutt_make_string_flags (buf=<optimized out>, buflen=<optimized out>, s=<optimized out>, ctx=<optimized out>, hdr=<optimized out>, flags=<optimized out>) at hdrline.c:1362
#18 0x000055f57e1ece74 in menu_redraw_index (menu=menu@entry=0x55f580b7d9f0) at menu.c:362
#19 0x000055f57e1c4748 in index_menu_redraw (menu=0x55f580b7d9f0) at curs_main.c:869
#20 0x000055f57e1c4b6d in mutt_index_menu () at curs_main.c:1073
#21 0x000055f57e1a83cb in main (argc=<optimized out>, argv=0x7ffc636c4408, env=<optimized out>) at main.c:925
```