### PR TITLE
Ncurses always has resizeterm, remove unnecessary ifdefs

### DIFF
--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -66,14 +66,11 @@ NEOMUTTOBJS=	mutt_account.o addrbook.o alias.o attach.o bcache.o body.o \
 		pop_auth.o pop_lib.o postpone.o query.o recvattach.o recvcmd.o \
 		rfc1524.o rfc2047.o rfc2231.o rfc3676.o address.o \
 		safe_asprintf.o score.o send.o sendlib.o sidebar.o mutt_signal.o \
-		smtp.o sort.o state.o status.o system.o thread.o url.o \
+		resize.o smtp.o sort.o state.o status.o system.o thread.o url.o \
 		version.o
 
 @if !HAVE_WCSCASECMP
 NEOMUTTOBJS+=	wcscasecmp.o
-@endif
-@if HAVE_RESIZE
-NEOMUTTOBJS+=	resize.o
 @endif
 @if USE_NOTMUCH
 NEOMUTTOBJS+=	mutt_notmuch.o

--- a/auto.def
+++ b/auto.def
@@ -502,13 +502,10 @@ switch [opt-val with-ui ncurses] {
       if {![cc-check-function-in-lib tgetent $ncurses_lib]} {
         cc-check-function-in-lib tgetent tinfo
       }
-      foreach f {start_color typeahead bkgdset curs_set meta use_default_colors resizeterm} {
+      foreach f {start_color typeahead bkgdset curs_set meta use_default_colors} {
         cc-check-function-in-lib $f $ncurses_lib
       }
       cc-check-functions use_extended_names
-      if {[have-feature RESIZETERM]} {
-        define-feature RESIZE
-      }
     }
 
     if {[have-feature start_color]} {
@@ -528,7 +525,6 @@ switch [opt-val with-ui ncurses] {
     }
     define USE_SLANG_CURSES
     define-feature COLOR
-    define-feature RESIZE
   }
 
   default {

--- a/curs_lib.c
+++ b/curs_lib.c
@@ -181,7 +181,6 @@ int mutt_get_field_full(const char *field, char *buf, size_t buflen,
 
   do
   {
-#if defined(USE_SLANG_CURSES) || defined(HAVE_RESIZETERM)
     if (SigWinch)
     {
       SigWinch = 0;
@@ -189,7 +188,6 @@ int mutt_get_field_full(const char *field, char *buf, size_t buflen,
       clearok(stdscr, TRUE);
       mutt_current_menu_redraw();
     }
-#endif
     mutt_window_clearline(MuttMessageWindow, 0);
     SETCOLOR(MT_COLOR_PROMPT);
     addstr((char *) field); /* cast to get around bad prototypes */
@@ -233,10 +231,8 @@ void mutt_edit_file(const char *editor, const char *data)
     mutt_error(_("Error running \"%s\"!"), cmd);
     mutt_sleep(2);
   }
-#if defined(USE_SLANG_CURSES) || defined(HAVE_RESIZETERM)
   /* the terminal may have been resized while the editor owned it */
   mutt_resize_screen();
-#endif
   keypad(stdscr, true);
   clearok(stdscr, true);
 }
@@ -282,7 +278,6 @@ int mutt_yesorno(const char *msg, int def)
     if (redraw || SigWinch)
     {
       redraw = false;
-#if defined(USE_SLANG_CURSES) || defined(HAVE_RESIZETERM)
       if (SigWinch)
       {
         SigWinch = 0;
@@ -290,7 +285,6 @@ int mutt_yesorno(const char *msg, int def)
         clearok(stdscr, TRUE);
         mutt_current_menu_redraw();
       }
-#endif
       if (MuttMessageWindow->cols)
       {
         prompt_lines = (msg_wid + answer_string_wid + MuttMessageWindow->cols - 1) /
@@ -1061,7 +1055,6 @@ int mutt_multi_choice(char *prompt, char *letters)
     if (redraw || SigWinch)
     {
       redraw = false;
-#if defined(USE_SLANG_CURSES) || defined(HAVE_RESIZETERM)
       if (SigWinch)
       {
         SigWinch = 0;
@@ -1069,7 +1062,6 @@ int mutt_multi_choice(char *prompt, char *letters)
         clearok(stdscr, TRUE);
         mutt_current_menu_redraw();
       }
-#endif
       if (MuttMessageWindow->cols)
       {
         prompt_lines = (mutt_strwidth(prompt) + MuttMessageWindow->cols - 1) /

--- a/curs_main.c
+++ b/curs_main.c
@@ -1093,7 +1093,6 @@ int mutt_index_menu(void)
                          MuttIndexWindow->cols - 1);
       mutt_refresh();
 
-#if defined(USE_SLANG_CURSES) || defined(HAVE_RESIZETERM)
       if (SigWinch)
       {
         mutt_flushinp();
@@ -1107,7 +1106,6 @@ int mutt_index_menu(void)
         clearok(stdscr, true);
         continue;
       }
-#endif
 
       op = km_dokey(MENU_MAIN);
 

--- a/enter.c
+++ b/enter.c
@@ -118,14 +118,12 @@ int mutt_enter_string(char *buf, size_t buflen, int col, int flags)
   struct EnterState *es = mutt_new_enter_state();
   do
   {
-#if defined(USE_SLANG_CURSES) || defined(HAVE_RESIZETERM)
     if (SigWinch)
     {
       SigWinch = 0;
       mutt_resize_screen();
       clearok(stdscr, TRUE);
     }
-#endif
     rc = mutt_enter_string_full(buf, buflen, col, flags, 0, NULL, NULL, es);
   } while (rc == 1);
   mutt_free_enter_state(&es);

--- a/menu.c
+++ b/menu.c
@@ -301,9 +301,7 @@ static void menu_pad_string(struct Menu *menu, char *buf, size_t buflen)
 
 void menu_redraw_full(struct Menu *menu)
 {
-#if !(defined(USE_SLANG_CURSES) || defined(HAVE_RESIZETERM))
   mutt_reflow_windows();
-#endif
   NORMAL_COLOR;
   /* clear() doesn't optimize screen redraws */
   move(0, 0);
@@ -1171,14 +1169,12 @@ int mutt_menu_loop(struct Menu *menu)
 
     mutt_curs_set(1);
 
-#if defined(USE_SLANG_CURSES) || defined(HAVE_RESIZETERM)
     if (SigWinch)
     {
       mutt_resize_screen();
       SigWinch = 0;
       clearok(stdscr, true); /* force complete redraw */
     }
-#endif
 
     if (i < 0)
     {

--- a/mutt/signal.c
+++ b/mutt/signal.c
@@ -132,9 +132,7 @@ void mutt_sig_init(sig_handler_t sig_fn, sig_handler_t exit_fn)
   sigaction(SIGCONT, &act, NULL);
   sigaction(SIGTSTP, &act, NULL);
   sigaction(SIGINT, &act, NULL);
-#if defined(USE_SLANG_CURSES) || defined(HAVE_RESIZETERM)
   sigaction(SIGWINCH, &act, NULL);
-#endif
 
   /* POSIX doesn't allow us to ignore SIGCHLD,
    * so we just install a dummy handler for it */
@@ -162,9 +160,7 @@ void mutt_sig_block(void)
   sigaddset(&Sigset, SIGHUP);
   sigaddset(&Sigset, SIGTSTP);
   sigaddset(&Sigset, SIGINT);
-#if defined(USE_SLANG_CURSES) || defined(HAVE_RESIZETERM)
   sigaddset(&Sigset, SIGWINCH);
-#endif
   sigprocmask(SIG_BLOCK, &Sigset, 0);
   SignalsBlocked = true;
 }

--- a/mutt_signal.c
+++ b/mutt_signal.c
@@ -54,18 +54,14 @@ static void curses_signal_handler(int sig)
       if (!IsEndwin)
         refresh();
       mutt_curs_set(-1);
-#if defined(USE_SLANG_CURSES) || defined(HAVE_RESIZETERM)
       /* We don't receive SIGWINCH when suspended; however, no harm is done by
        * just assuming we received one, and triggering the 'resize' anyway. */
       SigWinch = 1;
-#endif
       break;
 
-#if defined(USE_SLANG_CURSES) || defined(HAVE_RESIZETERM)
     case SIGWINCH:
       SigWinch = 1;
       break;
-#endif
 
     case SIGINT:
       SigInt = 1;

--- a/pager.c
+++ b/pager.c
@@ -168,7 +168,6 @@ struct AnsiAttr
 
 static short InHelp = 0;
 
-#if defined(USE_SLANG_CURSES) || defined(HAVE_RESIZETERM)
 /**
  * struct Resize - Keep track of screen resizing
  */
@@ -178,7 +177,6 @@ static struct Resize
   int search_compiled;
   int search_back;
 } *Resize = NULL;
-#endif
 
 #define NUM_SIG_LINES 4
 
@@ -1743,18 +1741,14 @@ static void pager_menu_redraw(struct Menu *pager_menu)
   struct PagerRedrawData *rd = pager_menu->redraw_data;
   int i, j;
   char buffer[LONG_STRING];
-#if defined(USE_SLANG_CURSES) || defined(HAVE_RESIZETERM)
   int err;
-#endif
 
   if (!rd)
     return;
 
   if (pager_menu->redraw & REDRAW_FULL)
   {
-#if !(defined(USE_SLANG_CURSES) || defined(HAVE_RESIZETERM))
     mutt_reflow_windows();
-#endif
     NORMAL_COLOR;
     /* clear() doesn't optimize screen redraws */
     move(0, 0);
@@ -1810,7 +1804,6 @@ static void pager_menu_redraw(struct Menu *pager_menu)
       NORMAL_COLOR;
     }
 
-#if defined(USE_SLANG_CURSES) || defined(HAVE_RESIZETERM)
     if (Resize)
     {
       rd->search_compiled = Resize->search_compiled;
@@ -1835,7 +1828,6 @@ static void pager_menu_redraw(struct Menu *pager_menu)
 
       FREE(&Resize);
     }
-#endif
 
     if (IsHeader(rd->extra) && PagerIndexLines)
     {
@@ -2249,7 +2241,6 @@ int mutt_pager(const char *banner, const char *fname, int flags, struct Pager *e
       }
     }
 
-#if defined(USE_SLANG_CURSES) || defined(HAVE_RESIZETERM)
     if (SigWinch)
     {
       SigWinch = 0;
@@ -2281,7 +2272,7 @@ int mutt_pager(const char *banner, const char *fname, int flags, struct Pager *e
       }
       continue;
     }
-#endif
+
     if (ch < 0)
     {
       ch = 0;

--- a/resize.c
+++ b/resize.c
@@ -43,7 +43,7 @@ void mutt_resize_screen(void)
   const char *cp = NULL;
   int fd;
   struct winsize w;
-#ifdef HAVE_RESIZETERM
+#if !defined(USE_SLANG_CURSES)
   int SLtt_Screen_Rows, SLtt_Screen_Cols;
 #endif
 

--- a/signal.c
+++ b/signal.c
@@ -86,18 +86,14 @@ static void sighandler(int sig)
       if (!IsEndwin)
         refresh();
       mutt_curs_set(-1);
-#if defined(USE_SLANG_CURSES) || defined(HAVE_RESIZETERM)
       /* We don't receive SIGWINCH when suspended; however, no harm is done by
        * just assuming we received one, and triggering the 'resize' anyway. */
       SigWinch = 1;
-#endif
       break;
 
-#if defined(USE_SLANG_CURSES) || defined(HAVE_RESIZETERM)
     case SIGWINCH:
       SigWinch = 1;
       break;
-#endif
 
     case SIGINT:
       SigInt = 1;
@@ -146,9 +142,7 @@ void mutt_signal_init(void)
   sigaction(SIGCONT, &act, NULL);
   sigaction(SIGTSTP, &act, NULL);
   sigaction(SIGINT, &act, NULL);
-#if defined(USE_SLANG_CURSES) || defined(HAVE_RESIZETERM)
   sigaction(SIGWINCH, &act, NULL);
-#endif
 
   /* POSIX doesn't allow us to ignore SIGCHLD,
    * so we just install a dummy handler for it
@@ -186,9 +180,7 @@ void mutt_block_signals(void)
     sigaddset(&Sigset, SIGHUP);
     sigaddset(&Sigset, SIGTSTP);
     sigaddset(&Sigset, SIGINT);
-#if defined(USE_SLANG_CURSES) || defined(HAVE_RESIZETERM)
     sigaddset(&Sigset, SIGWINCH);
-#endif
     sigprocmask(SIG_BLOCK, &Sigset, 0);
     OPT_SIGNALS_BLOCKED = true;
   }

--- a/version.c
+++ b/version.c
@@ -250,11 +250,6 @@ static struct CompileOptions comp_opts[] = {
 #else
   { "pgp", 0 },
 #endif
-#ifdef HAVE_RESIZETERM
-  { "resizeterm", 1 },
-#else
-  { "resizeterm", 0 },
-#endif
 #ifdef USE_SASL
   { "sasl", 1 },
 #else
@@ -376,7 +371,7 @@ void print_version(void)
 #ifdef NCURSES_VERSION
   printf("\nncurses: %s (compiled with %s)", curses_version(), NCURSES_VERSION);
 #elif defined(USE_SLANG_CURSES)
-  printf("\nslang: %d", SLANG_VERSION);
+  printf("\nslang: %s", SLANG_VERSION_STRING);
 #endif
 
 #ifdef _LIBICONV_VERSION


### PR DESCRIPTION
Issue #1057

While at it, dump a stringified version of slang's version in version.c (did I mention version?)