### PR TITLE
fix: missing ! when checking regex pointer

### DIFF
--- a/mutt/regex.c
+++ b/mutt/regex.c
@@ -217,7 +217,7 @@ bool mutt_regexlist_match(struct RegexList *rl, const char *str)
 
   for (; rl; rl = rl->next)
   {
-    if (!rl->regex || rl->regex->regex)
+    if (!rl->regex || !rl->regex->regex)
       continue;
     if (regexec(rl->regex->regex, str, (size_t) 0, (regmatch_t *) 0, (int) 0) == 0)
     {


### PR DESCRIPTION
* **What does this PR do?**
A `!` was missing when checking regex pointers. This caused some regexes to be ignored.

* **What are the relevant issue numbers?**
#1067 