### PR TITLE
Devel/cppcheck warning

### DIFF
--- a/pgppubring.c
+++ b/pgppubring.c
@@ -458,8 +458,6 @@ static int pgp_parse_pgp2_sig(unsigned char *buf, size_t l,
 static int pgp_parse_pgp3_sig(unsigned char *buf, size_t l,
                               struct PgpKeyInfo *p, struct PgpSignature *s)
 {
-  time_t sig_gen_time = -1;
-  long validity = -1;
   long key_validity = -1;
   unsigned long signerid1 = 0;
   unsigned long signerid2 = 0;
@@ -507,22 +505,11 @@ static int pgp_parse_pgp3_sig(unsigned char *buf, size_t l,
       switch (skt & 0x7f)
       {
         case 2: /* creation time */
-        {
-          if (skl < 4)
-            break;
-          sig_gen_time = 0;
-          for (int i = 0; i < 4; i++)
-            sig_gen_time = (sig_gen_time << 8) + buf[j++];
-
-          break;
-        }
         case 3: /* expiration time */
         {
           if (skl < 4)
             break;
-          validity = 0;
-          for (int i = 0; i < 4; i++)
-            validity = (validity << 8) + buf[j++];
+          j += 4;
           break;
         }
         case 9: /* key expiration time */


### PR DESCRIPTION
* **What does this PR do?**
Clean up warnings issued by static analyzers, I want to get more confident with the code base.
Most commits simply reduce the scope of variable, eventually remove unused variables and sprinkles `const` here and there. Mainly minor changes with a low chance to break something.

* **Are there points in the code the reviewer needs to double check?**
That no behavior has been accidentally changed, for example changing
`````
void f(int x)
{
  int i = 0;
  for (int n = 0; n < 10; ++n)
  {
    do_something(&i);
  }
}
````` 
to 
`````
void f(int x)
{ 
  for (int n = 0; n < 10; ++n)
  {  
    int i = 0;
    do_something(&i);
  }
}

````` 
would be a possibly invalid change.


* **Does this PR meet the acceptance criteria?**
I think so, and I would also propose to add to the  [style guide](https://www.neomutt.org/dev/coding-style) that variables, if possible, should be declared as `const`.
