### PR TITLE
Add support for alert (blink) colors.

### DIFF
--- a/color.c
+++ b/color.c
@@ -384,12 +384,18 @@ void mutt_free_color(int fg, int bg)
 static int parse_color_name(const char *s, int *col, int *attr, int is_fg, struct Buffer *err)
 {
   char *eptr = NULL;
-  int is_bright = 0;
+  int is_alert = 0, is_bright = 0;
 
   if (mutt_str_strncasecmp(s, "bright", 6) == 0)
   {
     is_bright = 1;
     s += 6;
+  }
+  else if (mutt_str_strncasecmp(s, "alert", 5) == 0)
+  {
+    is_alert = 1;
+    is_bright = 1;
+    s += 5;
   }
 
   /* allow aliases for xterm color resources */
@@ -411,7 +417,12 @@ static int parse_color_name(const char *s, int *col, int *attr, int is_fg, struc
 
   if (is_bright)
   {
-    if (is_fg)
+    if (is_alert)
+    {
+      *attr |= A_BOLD;
+      *attr |= A_BLINK;
+    }
+    else if (is_fg)
     {
       *attr |= A_BOLD;
     }

--- a/doc/manual.xml.head
+++ b/doc/manual.xml.head
@@ -4197,7 +4197,9 @@ folder-hook work "set sort=threads"
       <emphasis>foreground</emphasis> can optionally be prefixed with the
       keyword
       <literal>bright</literal> to make the foreground color boldfaced (e.g.,
-      <literal>brightred</literal>).</para>
+      <literal>brightred</literal>).
+      <literal>alert</literal> to make a blinking/alert color (e.g.,
+      <literal>alertred</literal>).</para>
       <para>If your terminal supports it, the special keyword
       <emphasis>default</emphasis> can be used as a transparent color. The value
       <emphasis>brightdefault</emphasis> is also valid. If NeoMutt is linked


### PR DESCRIPTION
* **What does this PR do?**
Add support for `alert$color` as neomutt colors. It will make text blink.

* **Are there points in the code the reviewer needs to double check?**
Not really, no.

* **Screenshots (if relevant)**
https://parazyd.org/pub/dev/random/alert.webm

* **What are the relevant issue numbers?**
None. This is a new feature.