### PR TITLE
 Fallback to C.UTF-8 if en_US.UTF-8 cannot be set

### DIFF
--- a/test/rfc2047.c
+++ b/test/rfc2047.c
@@ -53,7 +53,13 @@ static const struct
 
 void test_rfc2047(void)
 {
-  setlocale(LC_ALL, "en_US.UTF-8");
+  if (!TEST_CHECK(setlocale(LC_ALL, "en_US.UTF-8") != NULL) || 
+                  setlocale(LC_ALL, "C.UTF-8") != NULL)
+  {
+    TEST_MSG("Cannot set locale to (en_US|C).UTF-8");
+    return;
+  }
+
   Charset = "utf-8";
 
   for (size_t i = 0; i < mutt_array_size(test_data); ++i)

--- a/test/rfc2047.c
+++ b/test/rfc2047.c
@@ -53,8 +53,8 @@ static const struct
 
 void test_rfc2047(void)
 {
-  if (!TEST_CHECK(setlocale(LC_ALL, "en_US.UTF-8") != NULL) || 
-                  setlocale(LC_ALL, "C.UTF-8") != NULL)
+  if (!TEST_CHECK((setlocale(LC_ALL, "en_US.UTF-8") != NULL) || 
+                  (setlocale(LC_ALL, "C.UTF-8") != NULL)))
   {
     TEST_MSG("Cannot set locale to (en_US|C).UTF-8");
     return;


### PR DESCRIPTION
#1088 