### PR TITLE
Make sure git_ver.h doesn't eat random 'g's out of tag names

### DIFF
--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -262,7 +262,8 @@ $(PGPRING): $(PGPRINGOBJS) $(LIBMUTT) $(LIBNCRYPT)
 
 # generated
 git_ver.h: $(ALL_FILES)
-	version=`git describe --dirty --abbrev=6 --match "neomutt-*" 2> /dev/null | sed -e 's/^neomutt-[0-9]\{8\}//' -e 's/g//'`; \
+	version=`git describe --dirty --abbrev=6 --match "neomutt-*" 2> /dev/null | \
+		sed -e 's/^neomutt-[0-9]\{8\}//; s/-g\([a-z0-9]\{6\}\)/-\1/'`; \
 	echo 'const char *GitVer = "'$$version'";' > git_ver.h.tmp; \
 	cmp -s git_ver.h.tmp git_ver.h || mv git_ver.h.tmp git_ver.h; \
 	rm -f git_ver.h.tmp


### PR DESCRIPTION
* **What does this PR do?**

This fixes the generation part of `git_ver.h` not to eat away any `g`'s it finds in the output from `git describe`.

This is happening now on master:

```sh
% git describe --dirty --abbrev=6 --match "neomutt-*" | sed -e 's/^neomutt-[0-9]\{8\}//;'
-cygwin-100-gc95a13
% cat git_ver.h
const char *GitVer = "-cywin-100-gc95a13";
```