### PR TITLE
lua: fix crash when setting a string

### DIFF
--- a/init.c
+++ b/init.c
@@ -460,7 +460,7 @@ int mutt_option_set(const struct Option *val, struct Buffer *err)
         /* MuttVars[idx].var is already 'char**' (or some 'void**') or...
           * so cast to 'void*' is okay */
         FREE((void *) MuttVars[idx].var);
-        *((char **) MuttVars[idx].var) = mutt_str_strdup(*(char **) val->var);
+        *((char **) MuttVars[idx].var) = mutt_str_strdup((char *) val->var);
       }
       break;
       case DT_BOOL:


### PR DESCRIPTION
Generally, for strings `Option.var` is a `char **` (a pointer to a string pointer).
The Lua setting code uses it differently.  There, it's just a `char *`.

Fixes #1096
