### PR TITLE
Expose EXTRA_CFLAGS_FOR_BUILD and EXTRA_LDFLAGS_FOR_BUILD

### DIFF
--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -4,10 +4,16 @@
 PACKAGE=	@PACKAGE@
 PACKAGE_VERSION=@PACKAGE_VERSION@
 
+# Build-time compiler and flags. These are used for building executables that
+# are only used at build-time, e.g., doc/makedoc. These are different from CC /
+# CFLAGS / LDFLAGS because the host and target systems might be different.
+CC_FOR_BUILD=		@CC_FOR_BUILD@
+CFLAGS_FOR_BUILD=	@CFLAGS_FOR_BUILD@ $(EXTRA_CFLAGS_FOR_BUILD)
+LDFLAGS_FOR_BUILD=	@LDFLAGS_FOR_BUILD@ $(EXTRA_LDFLAGS_FOR_BUILD)
+
 PWD=		@PWD@
 AR=		@AR@
 CC=		@CC@
-CC_FOR_BUILD=	@CC_FOR_BUILD@ @CFLAGS_FOR_BUILD@
 CPP=		@CPP@
 CFLAGS=		@CPPFLAGS@ @CFLAGS@ -I. -I@top_srcdir@ -Wall $(EXTRA_CFLAGS)
 LDFLAGS=	@LDFLAGS@ $(EXTRA_LDFLAGS)

--- a/auto.def
+++ b/auto.def
@@ -186,6 +186,7 @@ if {1} {
     user-error "C99 is required"
   }
   define-append CFLAGS_FOR_BUILD -std=c99
+  define LDFLAGS_FOR_BUILD {}
 
   # Check for tools and programs
   cc-check-tools ar ranlib strip

--- a/doc/Makefile.autosetup
+++ b/doc/Makefile.autosetup
@@ -1,7 +1,8 @@
-MAKEDOC_CPP = $(CC_FOR_BUILD) -D_MAKEDOC -E -C -I.
+MAKEDOC_CPP = $(CC_FOR_BUILD) $(CFLAGS_FOR_BUILD) -D_MAKEDOC -E -C -I.
 
 doc/makedoc$(EXEEXT): $(SRCDIR)/doc/makedoc.c
-	$(CC_FOR_BUILD) -I. -o $@ $(SRCDIR)/doc/makedoc.c
+	$(CC_FOR_BUILD) -I. $(CFLAGS_FOR_BUILD) $(LDFLAGS_FOR_BUILD) \
+	    -o $@ $(SRCDIR)/doc/makedoc.c
 
 doc/neomuttrc: $(SRCDIR)/init.h doc/makedoc$(EXEEXT) $(SRCDIR)/doc/neomuttrc.head
 	sed -e 's,@docdir@,$(docdir),' $(SRCDIR)/doc/neomuttrc.head \


### PR DESCRIPTION
This allows distros to set flags that must be used both for building
target and host executables.

Issue #980
