### PR TITLE
Tidy space-before-tabs and multiple spaces

### DIFF
--- a/doc/Makefile.autosetup
+++ b/doc/Makefile.autosetup
@@ -35,15 +35,15 @@ srcdir_DOCFILES = $(SRCDIR)/doc/PGP-Notes.txt \
 		  $(SRCDIR)/README.md \
 		  $(SRCDIR)/README.SSL
 
-all-doc: 	$(CHUNKED_DOCFILES) \
-    		doc/index.html \
+all-doc:	$(CHUNKED_DOCFILES) \
+		doc/index.html \
 		doc/manual.html \
 		doc/manual.txt \
 		doc/neomuttrc \
 		doc/neomuttrc.man
 
 doc/manual.html:	doc/manual.xml \
-    			$(SRCDIR)/doc/html.xsl \
+			$(SRCDIR)/doc/html.xsl \
 			$(SRCDIR)/doc/neomutt.xsl \
 			$(SRCDIR)/doc/neomutt.css
 	xsltproc --nonet -o $@ $(SRCDIR)/doc/html.xsl doc/manual.xml
@@ -58,13 +58,13 @@ doc/manual.txt: doc/manual.html
 $(CHUNKED_DOCFILES): doc/index.html
 
 doc/index.html: $(SRCDIR)/doc/chunk.xsl \
-    		$(SRCDIR)/doc/neomutt.xsl \
+		$(SRCDIR)/doc/neomutt.xsl \
 		$(SRCDIR)/doc/neomutt.css \
 		doc/manual.xml
 	xsltproc --nonet -o doc/ $(SRCDIR)/doc/chunk.xsl doc/manual.xml > /dev/null 2>&1
 
 doc/neomuttrc.man:	doc/makedoc$(EXEEXT) \
-    		$(SRCDIR)/init.h \
+		$(SRCDIR)/init.h \
 		$(SRCDIR)/doc/neomuttrc.man.head \
 		$(SRCDIR)/doc/neomuttrc.man.tail
 	$(MAKEDOC_CPP) $(SRCDIR)/init.h | doc/makedoc$(EXEEXT) -m | \
@@ -130,11 +130,11 @@ validate-doc: doc/manual.xml
 	xmllint --noout --noblanks --postvalid doc/manual.xml
 
 spellcheck-doc:
-	-aspell -d american --mode=sgml  --encoding=utf-8 -p \
+	-aspell -d american --mode=sgml --encoding=utf-8 -p \
 	    doc/neomutt.pwl check doc/manual.xml.head
 	-aspell -d american --mode=nroff --encoding=utf-8 -p \
 	    doc/neomutt.pwl check doc/neomuttrc.man.head
-	-aspell -d american --mode=ccpp  --encoding=utf-8 -p \
+	-aspell -d american --mode=ccpp --encoding=utf-8 -p \
 	    doc/neomutt.pwl check init.h
 
 sortcheck-doc: doc/manual.xml

--- a/po/Makefile.autosetup
+++ b/po/Makefile.autosetup
@@ -2,17 +2,17 @@
 
 MSGID_BUGS_ADDRESS = @BUGS_ADDRESS@
 GMSGFMT		= @MSGFMT@
-localedir 	= @MUTTLOCALEDIR@
-XGETTEXT 	= @XGETTEXT@
+localedir	= @MUTTLOCALEDIR@
+XGETTEXT	= @XGETTEXT@
 XGETTEXT_OPTIONS= --keyword=_ --keyword=N_ --no-wrap --add-comments=L10N
-MSGMERGE 	= @MSGMERGE@
+MSGMERGE	= @MSGMERGE@
 MSGMERGE_UPDATE = @MSGMERGE@ --update
 
-MOFILES		=  po/bg.mo po/ca.mo po/cs.mo po/da.mo po/de.mo po/el.mo \
-		   po/en_GB.mo po/eo.mo po/es.mo po/et.mo po/eu.mo po/fr.mo \
-		   po/ga.mo po/gl.mo po/hu.mo po/id.mo po/it.mo po/ja.mo \
-		   po/ko.mo po/lt.mo po/nl.mo po/pl.mo po/pt_BR.mo po/ru.mo \
-		   po/sk.mo po/sv.mo po/tr.mo po/uk.mo po/zh_CN.mo po/zh_TW.mo
+MOFILES		= po/bg.mo po/ca.mo po/cs.mo po/da.mo po/de.mo po/el.mo \
+		  po/en_GB.mo po/eo.mo po/es.mo po/et.mo po/eu.mo po/fr.mo \
+		  po/ga.mo po/gl.mo po/hu.mo po/id.mo po/it.mo po/ja.mo \
+		  po/ko.mo po/lt.mo po/nl.mo po/pl.mo po/pt_BR.mo po/ru.mo \
+		  po/sk.mo po/sv.mo po/tr.mo po/uk.mo po/zh_CN.mo po/zh_TW.mo
 POTFILE		= po/$(PACKAGE).pot
 
 all-po:	$(MOFILES)
@@ -51,7 +51,7 @@ update-po: clean-po
 
 $(PACKAGE).pot-update:
 	$(XGETTEXT) --default-domain=$(PACKAGE) --directory=$(SRCDIR) \
-	    $(XGETTEXT_OPTIONS)  \
+	    $(XGETTEXT_OPTIONS) \
 	    --files-from=po/POTFILES.in \
 	    --copyright-holder='$(COPYRIGHT_HOLDER)' \
 	    --package-name="$(PACKAGE)" \


### PR DESCRIPTION
* **What does this PR do?**
  Sanitise some whitespaces.

* **Are there points in the code the reviewer needs to double check?**
  I’m not sure the following files:

    - autosetup/jimsh0.c
    - mutt/queue.h
    - INSTALL

  should be tidying and how to handle it, because I cannot realise which code
  or format style (whitespace related) they follow.

  Also these files:

    - autosetup/autosetup-config.guess
    - autosetup/autosetup-config.sub

  are more recent upstream [1], but with similar curious whitespaces.

  References:
    - [1] <https://git.savannah.gnu.org/gitweb/?p=config.git;a=tree>

* **Screenshots (if relevant)**
  none

* **What are the relevant issue numbers?**
  none