### PR TITLE
Re-sort resources for better documents

### DIFF
--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -46,6 +46,7 @@ mandir=		@mandir@
 libdir=		@libdir@
 libexecdir=	@libexecdir@
 sysconfdir=	@SYSCONFDIR@
+textdomaindir=	@MUTTLOCALEDIR@
 
 # targets for specific subdirectories
 ALL_TARGETS=		@ALL_TARGETS@

--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -3,6 +3,7 @@
 
 PACKAGE=	@PACKAGE@
 PACKAGE_VERSION=@PACKAGE_VERSION@
+PACKAGE_DATE=	@PACKAGE_DATE@
 
 # Build-time compiler and flags. These are used for building executables that
 # are only used at build-time, e.g., doc/makedoc. These are different from CC /
@@ -55,10 +56,6 @@ UNINSTALL_TARGETS=	@UNINSTALL_TARGETS@
 VPATH=		$(SRCDIR)
 
 ALL_FILES!=	(cd $(SRCDIR) && git ls-files 2>/dev/null) || true
-
-# timestamps
-TS_MAN_CONF=	@TS_MAN_CONF@
-TS_MAN_MAIN=	@TS_MAN_MAIN@
 
 ###############################################################################
 # neomutt

--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -56,6 +56,10 @@ VPATH=		$(SRCDIR)
 
 ALL_FILES!=	(cd $(SRCDIR) && git ls-files 2>/dev/null) || true
 
+# timestamps
+TS_MAN_CONF=	@TS_MAN_CONF@
+TS_MAN_MAIN=	@TS_MAN_MAIN@
+
 ###############################################################################
 # neomutt
 NEOMUTT=	neomutt$(EXEEXT)

--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -43,7 +43,7 @@ datadir=	@PKGDATADIR@
 docdir=		@PKGDOCDIR@
 mandir=		@mandir@
 libdir=		@libdir@
-libexecdir=		@libexecdir@
+libexecdir=	@libexecdir@
 sysconfdir=	@SYSCONFDIR@
 
 # targets for specific subdirectories

--- a/auto.def
+++ b/auto.def
@@ -177,6 +177,29 @@ if {1} {
   proc yesno val {
     expr {$val ? "yes" : "no"}
   }
+
+  # Recent author timestamp of file(s) as UTC, use PACKAGE_VERSION as fallback
+  proc get-author-date {format args} {
+    set oldpwd [pwd]
+    cd $::autosetup(srcdir)
+
+    if {$args eq "" || [catch {
+        set fd [open "|git log -1 --format=%at master -- $args" r]
+        gets $fd epoch
+        close $fd}] || $epoch eq ""
+    } {
+      #user-notice "No author timestamp found, falling back to PACKAGE_VERSION..."
+      if {![set pkgdate [get-define PACKAGE_VERSION]] || [catch {
+          set epoch [clock scan $pkgdate -format {%Y%m%d} -timezone :UTC]}]
+      } {
+        autosetup-error "Cannot get or parse PACKAGE_VERSION as date!"
+      }
+    }
+    cd $oldpwd
+
+
+    return [clock format $epoch -format $format -timezone :UTC]
+  }
 }
 ###############################################################################
 
@@ -916,6 +939,12 @@ foreach dir $subdirs {
   define-append UNINSTALL_TARGETS uninstall-$dir
   make-template $dir/Makefile.autosetup $dir/Makefile
 }
+
+###############################################################################
+# Provide timestamps (UTC) based on most recent author date or PACKAGE_VERSION
+# doc/neomuttrc.man, doc/neomutt.1
+define TS_MAN_CONF [get-author-date "%Y-%m-%d" init.h doc/neomuttrc.man.head doc/neomuttrc.man.tail]
+define TS_MAN_MAIN [get-author-date "%Y-%m-%d" doc/neomutt.man]
 
 ###############################################################################
 # Generate Makefile and config.h

--- a/auto.def
+++ b/auto.def
@@ -189,8 +189,8 @@ if {1} {
         close $fd}] || $epoch eq ""
     } {
       #user-notice "No author timestamp found, falling back to PACKAGE_VERSION..."
-      if {![set pkgdate [get-define PACKAGE_VERSION]] || [catch {
-          set epoch [clock scan $pkgdate -format {%Y%m%d} -timezone :UTC]}]
+      if {[catch {clock scan [get-define PACKAGE_VERSION] \
+                  -format {%Y%m%d} -timezone :UTC} epoch]
       } {
         autosetup-error "Cannot get or parse PACKAGE_VERSION as date!"
       }

--- a/auto.def
+++ b/auto.def
@@ -930,11 +930,6 @@ make-template Makefile.autosetup Makefile
 make-config-header config.h -auto $auto_rep -bare $bare_rep -str $str_rep
 
 ###############################################################################
-# Generate doc/neomutt.1
-define bindir [get-define BINDIR]
-define docdir [get-define PKGDOCDIR]
-
-###############################################################################
 # Generate .clang_complete
 define cflags-one-per-line [string map {" " "\n"} [get-define CFLAGS]]
 make-template .clang_complete.in

--- a/auto.def
+++ b/auto.def
@@ -177,24 +177,6 @@ if {1} {
   proc yesno val {
     expr {$val ? "yes" : "no"}
   }
-
-  # Recent author timestamp of file(s) as UTC, use PACKAGE_VERSION as fallback
-  proc get-author-date {format args} {
-    set oldpwd [pwd]
-    cd $::autosetup(srcdir)
-
-    if {$args eq "" || [catch {
-        set fd [open "|git log -1 --format=%at master -- $args" r]
-        gets $fd epoch
-        close $fd}] || $epoch eq ""
-    } {
-      set epoch [clock scan \
-                   [get-define PACKAGE_VERSION] -format {%Y%m%d} -timezone :UTC]
-    }
-    cd $oldpwd
-
-    return [clock format $epoch -format $format -timezone :UTC]
-  }
 }
 ###############################################################################
 
@@ -938,8 +920,8 @@ foreach dir $subdirs {
 ###############################################################################
 # Provide timestamps (UTC) based on most recent author date or PACKAGE_VERSION
 # doc/neomuttrc.man, doc/neomutt.1
-define TS_MAN_CONF [get-author-date "%Y-%m-%d" init.h doc/neomuttrc.man.head doc/neomuttrc.man.tail]
-define TS_MAN_MAIN [get-author-date "%Y-%m-%d" doc/neomutt.man]
+define PACKAGE_DATE \
+  [regsub {(....)(..)(..)} [get-define PACKAGE_VERSION] {\1-\2-\3}]
 
 ###############################################################################
 # Generate Makefile and config.h
@@ -951,7 +933,6 @@ make-config-header config.h -auto $auto_rep -bare $bare_rep -str $str_rep
 # Generate doc/neomutt.1
 define bindir [get-define BINDIR]
 define docdir [get-define PKGDOCDIR]
-make-template doc/neomutt.man doc/neomutt.1
 
 ###############################################################################
 # Generate .clang_complete

--- a/auto.def
+++ b/auto.def
@@ -918,8 +918,8 @@ foreach dir $subdirs {
 }
 
 ###############################################################################
-# Provide timestamps (UTC) based on most recent author date or PACKAGE_VERSION
-# doc/neomuttrc.man, doc/neomutt.1
+# Define package timestamp (UTC) based on PACKAGE_VERSION for:
+# doc/neomuttrc.5, doc/neomutt.1
 define PACKAGE_DATE \
   [regsub {(....)(..)(..)} [get-define PACKAGE_VERSION] {\1-\2-\3}]
 

--- a/auto.def
+++ b/auto.def
@@ -188,15 +188,10 @@ if {1} {
         gets $fd epoch
         close $fd}] || $epoch eq ""
     } {
-      #user-notice "No author timestamp found, falling back to PACKAGE_VERSION..."
-      if {[catch {clock scan [get-define PACKAGE_VERSION] \
-                  -format {%Y%m%d} -timezone :UTC} epoch]
-      } {
-        autosetup-error "Cannot get or parse PACKAGE_VERSION as date!"
-      }
+      set epoch [clock scan \
+                   [get-define PACKAGE_VERSION] -format {%Y%m%d} -timezone :UTC]
     }
     cd $oldpwd
-
 
     return [clock format $epoch -format $format -timezone :UTC]
   }

--- a/doc/Makefile.autosetup
+++ b/doc/Makefile.autosetup
@@ -68,10 +68,11 @@ doc/neomuttrc.5:	doc/makedoc$(EXEEXT) \
 		$(SRCDIR)/init.h \
 		$(SRCDIR)/doc/neomuttrc.man.head \
 		$(SRCDIR)/doc/neomuttrc.man.tail
-	( sed -e "/^\.TH/s/@MAN_DATE@/$(PACKAGE_DATE)/" \
+	( sed -e "/^\.TH/s|@MAN_DATE@|$(PACKAGE_DATE)|" \
 	    $(SRCDIR)/doc/neomuttrc.man.head && \
-	    $(MAKEDOC_CPP) $(SRCDIR)/init.h | doc/makedoc$(EXEEXT) -m | \
-	    cat - $(SRCDIR)/doc/neomuttrc.man.tail \
+	    $(MAKEDOC_CPP) $(SRCDIR)/init.h | doc/makedoc$(EXEEXT) -m && \
+	    sed -e "s|@MAN_DOCDIR@|$(docdir)|g" \
+	      $(SRCDIR)/doc/neomuttrc.man.tail \
 	) > $@
 
 doc/neomutt.1:

--- a/doc/Makefile.autosetup
+++ b/doc/Makefile.autosetup
@@ -76,8 +76,10 @@ doc/neomuttrc.5:	doc/makedoc$(EXEEXT) \
 
 doc/neomutt.1:
 	( sed -e "/^\.TH/s|@MAN_DATE@|$(PACKAGE_DATE)|" \
-	      -e "s|@MAN_SYSCONFDIR@|$(sysconfdir)|g" \
+	      -e "s|@MAN_DATADIR@|$(datadir)|g" \
 	      -e "s|@MAN_DOCDIR@|$(docdir)|g" \
+	      -e "s|@MAN_SYSCONFDIR@|$(sysconfdir)|g" \
+	      -e "s|@MAN_TEXTDOMAINDIR@|$(textdomaindir)|g" \
 	    $(SRCDIR)/doc/neomutt.man \
 	) > $@
 

--- a/doc/Makefile.autosetup
+++ b/doc/Makefile.autosetup
@@ -40,7 +40,8 @@ all-doc:	$(CHUNKED_DOCFILES) \
 		doc/manual.html \
 		doc/manual.txt \
 		doc/neomuttrc \
-		doc/neomuttrc.man
+		doc/neomutt.1 \
+		doc/neomuttrc.5 \
 
 doc/manual.html:	doc/manual.xml \
 			$(SRCDIR)/doc/html.xsl \
@@ -63,14 +64,19 @@ doc/index.html: $(SRCDIR)/doc/chunk.xsl \
 		doc/manual.xml
 	xsltproc --nonet -o doc/ $(SRCDIR)/doc/chunk.xsl doc/manual.xml > /dev/null 2>&1
 
-doc/neomuttrc.man:	doc/makedoc$(EXEEXT) \
+doc/neomuttrc.5:	doc/makedoc$(EXEEXT) \
 		$(SRCDIR)/init.h \
 		$(SRCDIR)/doc/neomuttrc.man.head \
 		$(SRCDIR)/doc/neomuttrc.man.tail
-	( sed -e "/^\.TH/s/@TS_MAN_CONF@/$(TS_MAN_CONF)/" \
+	( sed -e "/^\.TH/s/@MAN_DATE@/$(PACKAGE_DATE)/" \
 	    $(SRCDIR)/doc/neomuttrc.man.head && \
 	    $(MAKEDOC_CPP) $(SRCDIR)/init.h | doc/makedoc$(EXEEXT) -m | \
 	    cat - $(SRCDIR)/doc/neomuttrc.man.tail \
+	) > $@
+
+doc/neomutt.1:
+	( sed -e "/^\.TH/s/@MAN_DATE@/$(PACKAGE_DATE)/" \
+	    $(SRCDIR)/doc/neomutt.man \
 	) > $@
 
 doc/manual.xml:	doc/makedoc$(EXEEXT) $(SRCDIR)/init.h $(SRCDIR)/opcodes.h \
@@ -89,7 +95,7 @@ install-doc: all-doc
 	$(MKDIR_P) $(DESTDIR)$(mandir)/man5
 	$(MKDIR_P) $(DESTDIR)$(sysconfdir)
 	$(INSTALL) -m 644 doc/neomutt.1 $(DESTDIR)$(mandir)/man1/neomutt.1
-	$(INSTALL) -m 644 doc/neomuttrc.man $(DESTDIR)$(mandir)/man5/neomuttrc.5
+	$(INSTALL) -m 644 doc/neomuttrc.5 $(DESTDIR)$(mandir)/man5/neomuttrc.5
 	$(INSTALL) -m 644 $(SRCDIR)/doc/smime_keys.1 $(DESTDIR)$(mandir)/man1/smime_keys_$(PACKAGE).1
 	$(INSTALL) -m 644 $(SRCDIR)/doc/pgpewrap.1 $(DESTDIR)$(mandir)/man1/pgpewrap_$(PACKAGE).1
 	$(INSTALL) -m 644 $(SRCDIR)/doc/pgpring.1 $(DESTDIR)$(mandir)/man1/pgpring_$(PACKAGE).1
@@ -123,7 +129,7 @@ uninstall-doc:
 	$(RM) $(DESTDIR)$(docdir)/mime.types
 
 clean-doc:
-	$(RM) doc/*.html doc/neomuttrc.man \
+	$(RM) doc/*.html doc/neomuttrc.5 doc/neomutt.1 \
 	    doc/makedoc$(EXEEXT) doc/makedoc.o \
 	    doc/makedoc.Po doc/manual.txt doc/manual.xml \
 	    doc/neomuttrc

--- a/doc/Makefile.autosetup
+++ b/doc/Makefile.autosetup
@@ -67,9 +67,11 @@ doc/neomuttrc.man:	doc/makedoc$(EXEEXT) \
 		$(SRCDIR)/init.h \
 		$(SRCDIR)/doc/neomuttrc.man.head \
 		$(SRCDIR)/doc/neomuttrc.man.tail
-	$(MAKEDOC_CPP) $(SRCDIR)/init.h | doc/makedoc$(EXEEXT) -m | \
-		cat $(SRCDIR)/doc/neomuttrc.man.head - \
-		$(SRCDIR)/doc/neomuttrc.man.tail > $@
+	( sed -e "/^\.TH/s/@TS_MAN_CONF@/$(TS_MAN_CONF)/" \
+	    $(SRCDIR)/doc/neomuttrc.man.head && \
+	    $(MAKEDOC_CPP) $(SRCDIR)/init.h | doc/makedoc$(EXEEXT) -m | \
+	    cat - $(SRCDIR)/doc/neomuttrc.man.tail \
+	) > $@
 
 doc/manual.xml:	doc/makedoc$(EXEEXT) $(SRCDIR)/init.h $(SRCDIR)/opcodes.h \
 		$(SRCDIR)/doc/manual.xml.head $(SRCDIR)/functions.h \

--- a/doc/Makefile.autosetup
+++ b/doc/Makefile.autosetup
@@ -75,7 +75,9 @@ doc/neomuttrc.5:	doc/makedoc$(EXEEXT) \
 	) > $@
 
 doc/neomutt.1:
-	( sed -e "/^\.TH/s/@MAN_DATE@/$(PACKAGE_DATE)/" \
+	( sed -e "/^\.TH/s|@MAN_DATE@|$(PACKAGE_DATE)|" \
+	      -e "s|@MAN_SYSCONFDIR@|$(sysconfdir)|g" \
+	      -e "s|@MAN_DOCDIR@|$(docdir)|g" \
 	    $(SRCDIR)/doc/neomutt.man \
 	) > $@
 

--- a/doc/manual.xml.head
+++ b/doc/manual.xml.head
@@ -3695,7 +3695,7 @@ alternates -group me -group work address3
           <replaceable class="parameter">address</replaceable>
         </arg>
         <arg choice="opt" rep="repeat">
-          <replaceable class="parameter">address</replaceable>
+          <replaceable class="parameter">, address</replaceable>
         </arg>
         <command>unalias</command>
         <arg choice="opt" rep="repeat">
@@ -3798,6 +3798,9 @@ set alias_file=~/.mail_aliases
         <command>bind</command>
         <arg choice="plain">
           <replaceable class="parameter">map</replaceable>
+        </arg>
+        <arg choice="opt" rep="repeat">
+          <replaceable class="parameter">,map</replaceable>
         </arg>
         <arg choice="plain">
           <replaceable class="parameter">key</replaceable>
@@ -4240,6 +4243,9 @@ folder-hook work "set sort=threads"
         <command>macro</command>
         <arg choice="plain">
           <replaceable class="parameter">menu</replaceable>
+        </arg>
+        <arg choice="opt" rep="repeat">
+          <replaceable class="parameter">,menu</replaceable>
         </arg>
         <arg choice="plain">
           <replaceable class="parameter">key</replaceable>
@@ -4777,7 +4783,7 @@ export COLORFGBG
         </arg>
         <command>mono</command>
         <arg choice="plain">
-          <option>index</option>
+          <option>index-object</option>
         </arg>
         <arg choice="plain">
           <replaceable class="parameter">attribute</replaceable>
@@ -6030,6 +6036,12 @@ set spam_separator=", "
                 <arg choice="plain">
                   <option>inv</option>
                 </arg>
+                <arg choice="plain">
+                  <option>&amp;</option>
+                </arg>
+                <arg choice="plain">
+                  <option>?</option>
+                </arg>
               </group>
               <replaceable class="parameter">variable</replaceable>
             </arg>
@@ -6295,8 +6307,8 @@ mailboxes $my_mx +mailbox3
       </para>
       <cmdsynopsis>
         <command>source</command>
-        <arg choice="plain" rep="repeat">
-          <replaceable class="parameter">file</replaceable>
+        <arg choice="plain">
+          <replaceable class="parameter">filename</replaceable>
         </arg>
       </cmdsynopsis>
       <para>
@@ -9791,10 +9803,10 @@ application/ms-excel;   open.pl %s
       <cmdsynopsis>
         <command>auto_view</command>
         <arg choice="plain">
-          <replaceable>mimetype</replaceable>
+          <replaceable>mime-type<arg choice="opt">/mime-subtype</arg></replaceable>
         </arg>
         <arg choice="opt" rep="repeat">
-          <replaceable>mimetype</replaceable>
+          <replaceable>mime-type<arg choice="opt">/mime-subtype</arg></replaceable>
         </arg>
         <command>unauto_view</command>
         <group choice="req">
@@ -9802,7 +9814,7 @@ application/ms-excel;   open.pl %s
             <replaceable>*</replaceable>
           </arg>
           <arg choice="plain" rep="repeat">
-            <replaceable>mimetype</replaceable>
+            <replaceable>mime-type<arg choice="opt">/mime-subtype</arg></replaceable>
           </arg>
         </group>
       </cmdsynopsis>
@@ -9930,16 +9942,28 @@ alternative_order text/enriched text/plain text \
       </para>
       <cmdsynopsis>
         <command>attachments</command>
-        <arg choice="plain">
-          <replaceable>{ + | - }disposition</replaceable>
-        </arg>
+        <group choice="req">
+          <arg choice="plain">
+            <replaceable>+</replaceable>
+          </arg>
+          <arg choice="plain">
+            <replaceable>-</replaceable>
+          </arg>
+        </group>
+        <replaceable>disposition</replaceable>
         <arg choice="plain">
           <replaceable>mime-type</replaceable>
         </arg>
         <command>unattachments</command>
-        <arg choice="plain">
-          <replaceable>{ + | - }disposition</replaceable>
-        </arg>
+        <group choice="req">
+          <arg choice="plain">
+            <replaceable>+</replaceable>
+          </arg>
+          <arg choice="plain">
+            <replaceable>-</replaceable>
+          </arg>
+        </group>
+        <replaceable>disposition</replaceable>
         <arg choice="plain">
           <replaceable>mime-type</replaceable>
         </arg>
@@ -10048,10 +10072,10 @@ attachments  -I message/external-body
       <cmdsynopsis>
         <command>mime_lookup</command>
         <arg choice="plain">
-          <replaceable>mimetype</replaceable>
+          <replaceable>mime-type<arg choice="opt">/mime-subtype</arg></replaceable>
         </arg>
         <arg choice="opt" rep="repeat">
-          <replaceable>mimetype</replaceable>
+          <replaceable>mime-type<arg choice="opt">/mime-subtype</arg></replaceable>
         </arg>
         <command>unmime_lookup</command>
         <group choice="req">
@@ -10059,7 +10083,7 @@ attachments  -I message/external-body
             <replaceable>*</replaceable>
           </arg>
           <arg choice="plain" rep="repeat">
-            <replaceable>mimetype</replaceable>
+            <replaceable>mime-type<arg choice="opt">/mime-subtype</arg></replaceable>
           </arg>
         </group>
       </cmdsynopsis>
@@ -10893,24 +10917,24 @@ bind index,pager @ compose-to-sender
         <cmdsynopsis>
           <command>open-hook</command>
           <arg choice="plain">
-            <replaceable class="parameter">pattern</replaceable>
+            <replaceable class="parameter">regex</replaceable>
           </arg>
           <arg choice="plain">
-            <replaceable class="parameter">shell-command</replaceable>
+            <replaceable class="parameter">&quot;shell-command&quot;</replaceable>
           </arg>
           <command>close-hook</command>
           <arg choice="plain">
-            <replaceable class="parameter">pattern</replaceable>
+            <replaceable class="parameter">regex</replaceable>
           </arg>
           <arg choice="plain">
-            <replaceable class="parameter">shell-command</replaceable>
+            <replaceable class="parameter">&quot;shell-command&quot;</replaceable>
           </arg>
           <command>append-hook</command>
           <arg choice="plain">
-            <replaceable class="parameter">pattern</replaceable>
+            <replaceable class="parameter">regex</replaceable>
           </arg>
           <arg choice="plain">
-            <replaceable class="parameter">shell-command</replaceable>
+            <replaceable class="parameter">&quot;shell-command&quot;</replaceable>
           </arg>
         </cmdsynopsis>
         <para>
@@ -11000,7 +11024,7 @@ bind index,pager @ compose-to-sender
 
         <sect3 id="open-hook">
           <title>Read from compressed mailbox</title>
-          <screen>open-hook regex shell-command</screen>
+          <screen>open-hook regex &quot;shell-command&quot;</screen>
           <para>
             If NeoMutt is unable to open a file, it then looks for
             <literal>open-hook</literal> that matches the filename.
@@ -11043,7 +11067,7 @@ open-hook '\.gz$' "gzip --stdout --decompress '%f' &gt; '%t'"
 
         <sect3 id="close-hook">
           <title>Write to a compressed mailbox</title>
-          <screen>close-hook regex shell-command</screen>
+          <screen>close-hook regex &quot;shell-command&quot;</screen>
           <para>
             When NeoMutt has finished with a compressed mail folder, it will
             look for a matching <literal>close-hook</literal> to recompress the
@@ -11098,7 +11122,7 @@ open-hook '\.gz$' "gzip --stdout --decompress '%f' &gt; '%t'"
 
         <sect3 id="append-hook">
           <title>Append to a compressed mailbox</title>
-          <screen>append-hook regex shell-command</screen>
+          <screen>append-hook regex &quot;shell-command&quot;</screen>
           <para>
             When NeoMutt wants to append an email to a compressed mail folder,
             it will look for a matching <literal>append-hook</literal>. This
@@ -12176,19 +12200,19 @@ set abort_noattach_regex = "\\&lt;attach(|ed|ments?)\\&gt;"
         <cmdsynopsis>
           <command>timeout-hook</command>
           <arg choice="plain">
-            <replaceable class="parameter">NEOMUTT-COMMAND</replaceable>
+            <replaceable class="parameter">command</replaceable>
           </arg>
         </cmdsynopsis>
         <cmdsynopsis>
           <command>startup-hook</command>
           <arg choice="plain">
-            <replaceable class="parameter">NEOMUTT-COMMAND</replaceable>
+            <replaceable class="parameter">command</replaceable>
           </arg>
         </cmdsynopsis>
         <cmdsynopsis>
           <command>shutdown-hook</command>
           <arg choice="plain">
-            <replaceable class="parameter">NEOMUTT-COMMAND</replaceable>
+            <replaceable class="parameter">command</replaceable>
           </arg>
         </cmdsynopsis>
       </sect2>
@@ -12280,9 +12304,9 @@ shutdown-hook 'exec sync-mailbox'
         </para>
 
 <screen>
-ifdef  symbol config-command [args...]  <emphasis role="comment"># If a symbol is defined</emphasis>
-ifndef symbol config-command [args...]  <emphasis role="comment"># If a symbol is not defined</emphasis>
-finish                                  <emphasis role="comment"># Finish reading the current file</emphasis>
+ifdef  symbol "config-command [args...]"  <emphasis role="comment"># If a symbol is defined</emphasis>
+ifndef symbol "config-command [args...]"  <emphasis role="comment"># If a symbol is not defined</emphasis>
+finish                                    <emphasis role="comment"># Finish reading the current file</emphasis>
 </screen>
 
         <para>
@@ -12316,16 +12340,16 @@ ifndef sidebar finish
             <replaceable class="parameter">symbol</replaceable>
           </arg>
           <arg choice="plain">
-            <replaceable class="parameter">"config-command
-            [args]"</replaceable>
+            <replaceable class="parameter">&quot;config-command
+              <arg choice="opt" rep="repeat">args</arg>&quot;</replaceable>
           </arg>
           <command>ifndef</command>
           <arg choice="plain">
             <replaceable class="parameter">symbol</replaceable>
           </arg>
           <arg choice="plain">
-            <replaceable class="parameter">"config-command
-            [args]"</replaceable>
+            <replaceable class="parameter">&quot;config-command
+              <arg choice="opt" rep="repeat">args</arg>&quot;</replaceable>
           </arg>
           <command>finish</command>
         </cmdsynopsis>
@@ -12341,8 +12365,8 @@ ifndef sidebar finish
 <emphasis role="comment"># one config file between versions of NeoMutt that may have different</emphasis>
 <emphasis role="comment"># features compiled in.</emphasis>
 
-<emphasis role="comment">#   ifdef  symbol config-command [args...]</emphasis>
-<emphasis role="comment">#   ifndef symbol config-command [args...]</emphasis>
+<emphasis role="comment">#   ifdef  symbol "config-command [args...]"</emphasis>
+<emphasis role="comment">#   ifndef symbol "config-command [args...]"</emphasis>
 <emphasis role="comment">#   finish</emphasis>
 <emphasis role="comment"># The 'ifdef' command tests whether NeoMutt understands the name of</emphasis>
 <emphasis role="comment"># a variable, function, command or compile-time symbol.</emphasis>
@@ -16850,7 +16874,7 @@ neomutt mailto:some@one.org?subject=test&amp;cc=other@one.org
               <replaceable class="parameter">address</replaceable>
             </arg>
             <arg choice="opt" rep="repeat">
-              <replaceable class="parameter">address</replaceable>
+              <replaceable class="parameter">, address</replaceable>
             </arg>
             <command>
               <link linkend="alias">unalias</link>
@@ -16907,10 +16931,10 @@ neomutt mailto:some@one.org?subject=test&amp;cc=other@one.org
               <link linkend="alternative-order">alternative_order</link>
             </command>
             <arg choice="plain">
-              <replaceable>mimetype</replaceable>
+              <replaceable>mime-type<arg choice="opt">/mime-subtype</arg></replaceable>
             </arg>
             <arg choice="opt" rep="repeat">
-              <replaceable>mimetype</replaceable>
+              <replaceable>mime-type<arg choice="opt">/mime-subtype</arg></replaceable>
             </arg>
             <command>
               <link linkend="alternative-order">unalternative_order</link>
@@ -16920,7 +16944,7 @@ neomutt mailto:some@one.org?subject=test&amp;cc=other@one.org
                 <replaceable>*</replaceable>
               </arg>
               <arg choice="plain" rep="repeat">
-                <replaceable>mimetype</replaceable>
+                <replaceable>mime-type<arg choice="opt">/mime-subtype</arg></replaceable>
               </arg>
             </group>
           </cmdsynopsis>
@@ -16931,10 +16955,10 @@ neomutt mailto:some@one.org?subject=test&amp;cc=other@one.org
               <link linkend="append-hook">append-hook</link>
             </command>
             <arg choice="plain">
-              <replaceable class="parameter">pattern</replaceable>
+              <replaceable class="parameter">regex</replaceable>
             </arg>
             <arg choice="plain">
-              <replaceable class="parameter">shell-command</replaceable>
+              <replaceable class="parameter">&quot;shell-command&quot;</replaceable>
             </arg>
           </cmdsynopsis>
         </listitem>
@@ -16943,18 +16967,30 @@ neomutt mailto:some@one.org?subject=test&amp;cc=other@one.org
             <command>
               <link linkend="attachments">attachments</link>
             </command>
-            <arg choice="plain">
-              <replaceable>{ + | - }disposition</replaceable>
-            </arg>
+            <group choice="req">
+              <arg choice="plain">
+                <replaceable>+</replaceable>
+              </arg>
+              <arg choice="plain">
+                <replaceable>-</replaceable>
+              </arg>
+            </group>
+            <replaceable>disposition</replaceable>
             <arg choice="plain">
               <replaceable>mime-type</replaceable>
             </arg>
             <command>
               <link linkend="attachments">unattachments</link>
             </command>
-            <arg choice="plain">
-              <replaceable>{ + | - }disposition</replaceable>
-            </arg>
+            <group choice="req">
+              <arg choice="plain">
+                <replaceable>+</replaceable>
+              </arg>
+              <arg choice="plain">
+                <replaceable>-</replaceable>
+              </arg>
+            </group>
+            <replaceable>disposition</replaceable>
             <arg choice="plain">
               <replaceable>mime-type</replaceable>
             </arg>
@@ -16966,10 +17002,10 @@ neomutt mailto:some@one.org?subject=test&amp;cc=other@one.org
               <link linkend="auto-view">auto_view</link>
             </command>
             <arg choice="plain">
-              <replaceable>mimetype</replaceable>
+              <replaceable>mime-type<arg choice="opt">/mime-subtype</arg></replaceable>
             </arg>
             <arg choice="opt" rep="repeat">
-              <replaceable>mimetype</replaceable>
+              <replaceable>mime-type<arg choice="opt">/mime-subtype</arg></replaceable>
             </arg>
             <command>
               <link linkend="auto-view">unauto_view</link>
@@ -16979,7 +17015,7 @@ neomutt mailto:some@one.org?subject=test&amp;cc=other@one.org
                 <replaceable>*</replaceable>
               </arg>
               <arg choice="plain" rep="repeat">
-                <replaceable>mimetype</replaceable>
+                <replaceable>mime-type<arg choice="opt">/mime-subtype</arg></replaceable>
               </arg>
             </group>
           </cmdsynopsis>
@@ -16991,6 +17027,9 @@ neomutt mailto:some@one.org?subject=test&amp;cc=other@one.org
             </command>
             <arg choice="plain">
               <replaceable class="parameter">map</replaceable>
+            </arg>
+            <arg choice="opt" rep="repeat">
+              <replaceable class="parameter">,map</replaceable>
             </arg>
             <arg choice="plain">
               <replaceable class="parameter">key</replaceable>
@@ -17019,10 +17058,10 @@ neomutt mailto:some@one.org?subject=test&amp;cc=other@one.org
               <link linkend="close-hook">close-hook</link>
             </command>
             <arg choice="plain">
-              <replaceable class="parameter">pattern</replaceable>
+              <replaceable class="parameter">regex</replaceable>
             </arg>
             <arg choice="plain">
-              <replaceable class="parameter">shell-command</replaceable>
+              <replaceable class="parameter">&quot;shell-command&quot;</replaceable>
             </arg>
           </cmdsynopsis>
         </listitem>
@@ -17248,12 +17287,25 @@ neomutt mailto:some@one.org?subject=test&amp;cc=other@one.org
               <link linkend="ifdef">ifdef</link>
             </command>
             <arg choice="plain">
-              <replaceable class="parameter">item</replaceable>
+              <replaceable class="parameter">symbol</replaceable>
             </arg>
             <arg choice="plain">
-              <replaceable class="parameter">"config-command
-              [args]"</replaceable>
+              <replaceable class="parameter">&quot;config-command
+                <arg choice="opt" rep="repeat">args</arg>&quot;</replaceable>
             </arg>
+            <command>
+              <link linkend="ifdef">ifndef</link>
+            </command>
+            <arg choice="plain">
+              <replaceable class="parameter">symbol</replaceable>
+            </arg>
+            <arg choice="plain">
+              <replaceable class="parameter">&quot;config-command
+                <arg choice="opt" rep="repeat">args</arg>&quot;</replaceable>
+            </arg>
+            <command>
+              <link linkend="ifdef">finish</link>
+            </command>
           </cmdsynopsis>
         </listitem>
         <listitem>
@@ -17319,6 +17371,9 @@ neomutt mailto:some@one.org?subject=test&amp;cc=other@one.org
             </command>
             <arg choice="plain">
               <replaceable class="parameter">menu</replaceable>
+            </arg>
+            <arg choice="opt" rep="repeat">
+              <replaceable class="parameter">,menu</replaceable>
             </arg>
             <arg choice="plain">
               <replaceable class="parameter">key</replaceable>
@@ -17413,10 +17468,10 @@ neomutt mailto:some@one.org?subject=test&amp;cc=other@one.org
               <link linkend="mime-lookup">mime_lookup</link>
             </command>
             <arg choice="plain">
-              <replaceable>mimetype</replaceable>
+              <replaceable>mime-type<arg choice="opt">/mime-subtype</arg></replaceable>
             </arg>
             <arg choice="opt" rep="repeat">
-              <replaceable>mimetype</replaceable>
+              <replaceable>mime-type<arg choice="opt">/mime-subtype</arg></replaceable>
             </arg>
             <command>
               <link linkend="mime-lookup">unmime_lookup</link>
@@ -17426,7 +17481,7 @@ neomutt mailto:some@one.org?subject=test&amp;cc=other@one.org
                 <replaceable>*</replaceable>
               </arg>
               <arg choice="plain" rep="repeat">
-                <replaceable>mimetype</replaceable>
+                <replaceable>mime-type<arg choice="opt">/mime-subtype</arg></replaceable>
               </arg>
             </group>
           </cmdsynopsis>
@@ -17463,7 +17518,7 @@ neomutt mailto:some@one.org?subject=test&amp;cc=other@one.org
               <link linkend="mono">mono</link>
             </command>
             <arg choice="plain">
-              <option>index</option>
+              <option>index-object</option>
             </arg>
             <arg choice="plain">
               <replaceable class="parameter">attribute</replaceable>
@@ -17476,7 +17531,7 @@ neomutt mailto:some@one.org?subject=test&amp;cc=other@one.org
             </command>
             <group choice="req">
               <arg choice="plain">
-                <option>index</option>
+                <option>index-object</option>
               </arg>
               <arg choice="plain">
                 <option>header</option>
@@ -17522,10 +17577,10 @@ neomutt mailto:some@one.org?subject=test&amp;cc=other@one.org
               <link linkend="open-hook">open-hook</link>
             </command>
             <arg choice="plain">
-              <replaceable class="parameter">pattern</replaceable>
+              <replaceable class="parameter">regex</replaceable>
             </arg>
             <arg choice="plain">
-              <replaceable class="parameter">shell-command</replaceable>
+              <replaceable class="parameter">&quot;shell-command&quot;</replaceable>
             </arg>
           </cmdsynopsis>
         </listitem>
@@ -17629,6 +17684,12 @@ neomutt mailto:some@one.org?subject=test&amp;cc=other@one.org
                   <arg choice="plain">
                     <option>inv</option>
                   </arg>
+                  <arg choice="plain">
+                    <option>&amp;</option>
+                  </arg>
+                  <arg choice="plain">
+                    <option>?</option>
+                  </arg>
                 </group>
                 <replaceable class="parameter">variable</replaceable>
               </arg>
@@ -17671,12 +17732,14 @@ neomutt mailto:some@one.org?subject=test&amp;cc=other@one.org
             <command>
               <link linkend="setenv">setenv</link>
             </command>
-            <arg choice="plain">
-              <replaceable class="parameter">[?]variable</replaceable>
-            </arg>
-            <arg choice="opt">
-              <replaceable class="parameter">value</replaceable>
-            </arg>
+            <group choice="req">
+              <arg choice="plain">
+                <replaceable class="parameter">?variable</replaceable>
+              </arg>
+              <arg choice="plain">
+                <replaceable class="parameter">variable value</replaceable>
+              </arg>
+            </group>
             <command>
               <link linkend="setenv">unsetenv</link>
             </command>
@@ -17812,6 +17875,28 @@ neomutt mailto:some@one.org?subject=test&amp;cc=other@one.org
                 <replaceable class="parameter">hook-type</replaceable>
               </arg>
             </group>
+          </cmdsynopsis>
+        </listitem>
+        <listitem>
+          <cmdsynopsis>
+            <command>
+              <link linkend="global-hooks">shutdown-hook</link>
+            </command>
+            <arg choice="plain">
+              <replaceable class="parameter">command</replaceable>
+            </arg>
+            <command>
+              <link linkend="global-hooks">startup-hook</link>
+            </command>
+            <arg choice="plain">
+              <replaceable class="parameter">command</replaceable>
+            </arg>
+            <command>
+              <link linkend="global-hooks">timeout-hook</link>
+            </command>
+            <arg choice="plain">
+              <replaceable class="parameter">command</replaceable>
+            </arg>
           </cmdsynopsis>
         </listitem>
       </itemizedlist>

--- a/doc/manual.xml.head
+++ b/doc/manual.xml.head
@@ -9122,12 +9122,19 @@ macro pager \cb |urlview\n
         file is called <literal>mime.types</literal>.
       </para>
       <para>
-        When you add an attachment to your mail message, NeoMutt searches your
-        personal <literal>mime.types</literal> file at
-        <literal>$HOME/.mime.types</literal>, and then the system
+        When you add an attachment to your mail message, NeoMutt searches the
+        system <literal>mime.types</literal> file at
+        <literal>/etc/mime.types</literal>,
+        <literal>$SYSCONFDIR/mime.types</literal> or
+        <literal>$PKGDATADIR/mime.types</literal> and then your personal
         <literal>mime.types</literal> file at
-        <literal>/usr/local/share/neomutt/mime.types</literal> or
-        <literal>/etc/mime.types</literal>
+        <literal>$HOME/.mime.types</literal>.
+      </para>
+      <para>
+        Where <literal>$HOME</literal> is your home directory. The
+        <literal>$PKGDATADIR</literal> and the <literal>$SYSCONFDIR</literal>
+        directories depend on where NeoMutt is installed: the former is the
+        default for shared data, the latter for system configuration files.
       </para>
       <para>
         Each line starts with the full MIME type, followed by a space and

--- a/doc/manual.xml.head
+++ b/doc/manual.xml.head
@@ -5395,14 +5395,14 @@ my_hdr Organization: A Really Big Company, Anytown, USA
       </para>
       <example id="ex-save-hook-exando">
         <title>Using %-expandos in <command>save-hook</command></title>
-        <screen>
+<screen>
 <emphasis role="comment"># default: save all to ~/Mail/&lt;author name&gt;</emphasis>
 save-hook . ~/Mail/%F
 <emphasis role="comment"># save from me@turing.cs.hmc.edu and me@cs.hmc.edu to $folder/elkins</emphasis>
 save-hook me@(turing\\.)?cs\\.hmc\\.edu$ +elkins
 <emphasis role="comment"># save from aol.com to $folder/spam</emphasis>
 save-hook aol\\.com$ +spam
-        </screen>
+</screen>
       </example>
 
       <para>
@@ -16539,158 +16539,238 @@ folder-hook ^pop 'set read_inc=1'
           </thead>
           <tbody>
             <row>
-              <entry>-A</entry>
+              <entry>-A <literal>alias</literal></entry>
               <entry>
-                expand an alias
+                Print an expanded version of the given <literal>alias</literal>
+                to stdout and exit.
               </entry>
             </row>
             <row>
-              <entry>-a</entry>
+              <entry>-a <literal>file</literal> [<literal>...</literal>]</entry>
               <entry>
-                attach a file to a message
+                Attach one or more <literal>file</literal>s to a message. Must
+                be given at last and separate attachment(s) from address(es)
+                using the &apos;<emphasis role="bold">--</emphasis>&apos;
+                argument, e.g.:
+
+<screen>
+neomutt -a image.jpg -- address1
+neomutt -a image.jpg *.png -- address1 address2
+</screen>
+
               </entry>
             </row>
             <row>
-              <entry>-b</entry>
+              <entry>-B</entry>
               <entry>
-                specify a blind carbon-copy (Bcc) address
+                Run in batch mode (do not start the ncurses UI).
               </entry>
             </row>
             <row>
-              <entry>-c</entry>
+              <entry>-b <literal>address</literal></entry>
               <entry>
-                specify a carbon-copy (Cc) address
+                Specify a blind carbon copy (Bcc) recipient.
               </entry>
             </row>
             <row>
-              <entry>-d</entry>
+              <entry>-c <literal>address</literal></entry>
               <entry>
-                log debugging output to ~/.neomuttdebug0 if NeoMutt was
-                compiled with <literal>+debug</literal>; it can range from 1—5
-                and affects verbosity (a value of 2 is recommended)
+                Specify a carbon copy (Cc) recipient.
               </entry>
             </row>
             <row>
               <entry>-D</entry>
               <entry>
-                print the value of all NeoMutt variables to stdout
+                Dump all configuration variables as
+                &apos;<emphasis role="bold">name=value</emphasis>&apos; pair to
+                stdout.
               </entry>
             </row>
             <row>
               <entry>-D -S</entry>
               <entry>
-                like -D but hide the value of sensitive variables
+                Like <emphasis role="bold">-D</emphasis>, but hide the value of
+                sensitive variables.
+              </entry>
+            </row>
+            <row>
+              <entry>-d <literal>level</literal></entry>
+              <entry>
+                Log debugging output to file (by default to
+                &quot;<literal>~/.neomuttdebug0</literal>&quot;).
+                The <literal>level</literal> can range from 1&ndash;5 and
+                affects verbosity. A value of 2 is recommended. Using this
+                option along with <emphasis role="bold">-l</emphasis> is useful
+                to log the early startup process (before reading any
+                configuration and hence
+                <link linkend="debug-level">$debug_level</link> and
+                <link linkend="debug-file">$debug_file</link>).
               </entry>
             </row>
             <row>
               <entry>-E</entry>
               <entry>
-                edit the draft (-H) or include (-i) file
+                Edit
+                <literal>draft</literal> (<emphasis role="bold">-H</emphasis>) or
+                <literal>include</literal> (<emphasis role="bold">-i</emphasis>)
+                file during message composition.
               </entry>
             </row>
             <row>
-              <entry>-e</entry>
+              <entry>-e <literal>command</literal></entry>
               <entry>
-                specify a config command to be run after initialization files
-                are read
+                Specify a <literal>command</literal> to be run after initial
+                program configuration.
               </entry>
             </row>
             <row>
-              <entry>-f</entry>
+              <entry>-F <literal>config</literal></entry>
               <entry>
-                specify a mailbox to load
+                Specify an alternative initialization file to read. See section
+                <link linkend="configuration-files">Location of Initialization Files</link>
+                for a list of regular configuration files.
               </entry>
             </row>
             <row>
-              <entry>-F</entry>
+              <entry>-f <literal>mailbox</literal></entry>
               <entry>
-                specify an alternate file to read initialization commands
+                Specify a <literal>mailbox</literal> (as defined with
+                <command>mailboxes</command> command) to load.
+              </entry>
+            </row>
+            <row>
+              <entry>-G</entry>
+              <entry>
+                Start NeoMutt with a listing of subscribed newsgroups.
+              </entry>
+            </row>
+            <row>
+              <entry>-g <literal>server</literal></entry>
+              <entry>
+                Like <emphasis role="bold">-G</emphasis>, but start at
+                specified news <literal>server</literal>.
+              </entry>
+            </row>
+            <row>
+              <entry>-H <literal>draft</literal></entry>
+              <entry>
+                Specify a <literal>draft</literal> file with header and body
+                for message composing.
               </entry>
             </row>
             <row>
               <entry>-h</entry>
               <entry>
-                print help on command line options
+                Print this help message and exit.
               </entry>
             </row>
             <row>
-              <entry>-H</entry>
+              <entry>-i <literal>include</literal></entry>
               <entry>
-                specify a draft file from which to read a header and body
+                Specify an <literal>include</literal> file to be embedded in
+                the body of a message.
               </entry>
             </row>
             <row>
-              <entry>-i</entry>
+              <entry>-l <literal>file</literal></entry>
               <entry>
-                specify a file to include in a message composition
+                Specify a <literal>file</literal> for debugging output. This
+                overrules <link linkend="debug-file">$debug_file</link>
+                setting. NeoMutt keeps up to five debug logs ({
+                <literal>file</literal> |
+                <link linkend="debug-file">$debug_file</link> |
+                <literal>~/.neomuttdebug</literal> }[<literal>0-4</literal>])
+                before override the oldest file.
               </entry>
             </row>
             <row>
-              <entry>-m</entry>
+              <entry>-m <literal>type</literal></entry>
               <entry>
-                specify a default mailbox type
+                Specify a default mailbox format <literal>type</literal> for
+                newly created folders. The <literal>type</literal> is either
+                MH, MMDF, Maildir or mbox (case-insensitive).
               </entry>
             </row>
             <row>
               <entry>-n</entry>
               <entry>
-                do not read the system neomuttrc
+                Bypass loading of system-wide configuration file.
               </entry>
             </row>
             <row>
               <entry>-p</entry>
               <entry>
-                recall a postponed message
+                Resume a prior postponed message, if any.
               </entry>
             </row>
             <row>
-              <entry>-Q</entry>
+              <entry>-Q <literal>variable</literal></entry>
               <entry>
-                query a configuration variable
+                Query a configuration <literal>variable</literal> after all
+                configuration files and commands
+                (<emphasis role="bold">-e</emphasis>) have been processed and
+                print its value to stdout.
               </entry>
             </row>
             <row>
               <entry>-R</entry>
               <entry>
-                open mailbox in read-only mode
+                Open mailbox in read-only mode.
               </entry>
             </row>
             <row>
-              <entry>-s</entry>
+              <entry>-s <literal>subject</literal></entry>
               <entry>
-                specify a subject (enclose in quotes if it contains spaces)
+                Specify a <literal>subject</literal> (must be enclosed in
+                quotes if it has spaces).
               </entry>
             </row>
             <row>
               <entry>-v</entry>
               <entry>
-                show version number and compile-time definitions
+                Print the NeoMutt version and compile-time definitions and exit.
+              </entry>
+            </row>
+            <row>
+              <entry>-vv</entry>
+              <entry>
+                Print the NeoMutt license and copyright information and exit.
               </entry>
             </row>
             <row>
               <entry>-x</entry>
               <entry>
-                simulate the mailx(1) compose mode
+                Simulate the <emphasis role="bold">mailx</emphasis>(1) send
+                mode.
               </entry>
             </row>
             <row>
               <entry>-y</entry>
               <entry>
-                show a menu containing the files specified by the
-                <command>mailboxes</command> command
-              </entry>
-            </row>
-            <row>
-              <entry>-z</entry>
-              <entry>
-                exit immediately if there are no messages in the mailbox
+                Start NeoMutt with a listing of all defined mailboxes.
               </entry>
             </row>
             <row>
               <entry>-Z</entry>
               <entry>
-                open the first folder with new message, exit immediately if
-                none
+                Open the first mailbox with new message or exit immediately with
+                exit code 1 if none is found in all defined mailboxes.
+              </entry>
+            </row>
+            <row>
+              <entry>-z</entry>
+              <entry>
+                Open the first or specified
+                (<emphasis role="bold">-f</emphasis>) mailbox if it holds any
+                message or exit immediately with exit code 1 otherwise.
+              </entry>
+            </row>
+            <row>
+              <entry>--</entry>
+              <entry>
+                Special argument forces NeoMutt to stop option parsing and
+                treat remaining arguments as <literal>address</literal> even if
+                they start with a hyphen.
               </entry>
             </row>
           </tbody>

--- a/doc/manual.xml.head
+++ b/doc/manual.xml.head
@@ -5338,94 +5338,8 @@ my_hdr Organization: A Really Big Company, Anytown, USA
       <screen>unmy_hdr to cc</screen>
     </sect1>
 
-    <sect1 id="save-hook">
-      <title>Specify Default Save Mailbox</title>
-      <para>
-        Usage:
-      </para>
-      <cmdsynopsis>
-        <command>save-hook</command>
-        <arg choice="plain">
-          <replaceable class="parameter">pattern</replaceable>
-        </arg>
-        <arg choice="plain">
-          <replaceable class="parameter">mailbox</replaceable>
-        </arg>
-      </cmdsynopsis>
-      <para>
-        This command is used to override the default mailbox used when saving
-        messages. <emphasis>mailbox</emphasis> will be used as the default if
-        the message matches <emphasis>pattern</emphasis>, see
-        <xref linkend="pattern-hook" /> for information on the exact format.
-      </para>
-      <para>
-        To provide more flexibility and good defaults, NeoMutt applies the
-        expandos of <link linkend="index-format">$index_format</link> to
-        <emphasis>mailbox</emphasis> after it was expanded.
-      </para>
-      <example id="ex-save-hook-exando">
-        <title>Using %-expandos in
-        <command>save-hook</command></title>
-
-<screen>
-<emphasis role="comment"># default: save all to ~/Mail/&lt;author name&gt;</emphasis>
-save-hook . ~/Mail/%F
-<emphasis role="comment"># save from me@turing.cs.hmc.edu and me@cs.hmc.edu to $folder/elkins</emphasis>
-save-hook me@(turing\\.)?cs\\.hmc\\.edu$ +elkins
-<emphasis role="comment"># save from aol.com to $folder/spam</emphasis>
-save-hook aol\\.com$ +spam
-</screen>
-
-      </example>
-      <para>
-        Also see the
-        <link linkend="fcc-save-hook"><command>fcc-save-hook</command></link>
-        command.
-      </para>
-    </sect1>
-
-    <sect1 id="fcc-hook">
-      <title>Specify Default Fcc: Mailbox When Composing</title>
-      <para>
-        Usage:
-      </para>
-      <cmdsynopsis>
-        <command>fcc-hook</command>
-        <arg choice="plain">
-          <replaceable class="parameter">pattern</replaceable>
-        </arg>
-        <arg choice="plain">
-          <replaceable class="parameter">mailbox</replaceable>
-        </arg>
-      </cmdsynopsis>
-      <para>
-        This command is used to save outgoing mail in a mailbox other than
-        <link linkend="record">$record</link>. NeoMutt searches the initial
-        list of message recipients for the first matching
-        <emphasis>pattern</emphasis> and uses <emphasis>mailbox</emphasis> as
-        the default Fcc: mailbox. If no match is found the message will be
-        saved to <link linkend="record">$record</link> mailbox.
-      </para>
-      <para>
-        To provide more flexibility and good defaults, NeoMutt applies the
-        expandos of <link linkend="index-format">$index_format</link> to
-        <emphasis>mailbox</emphasis> after it was expanded.
-      </para>
-      <para>
-        See <xref linkend="pattern-hook" /> for information on the exact format
-        of <emphasis>pattern</emphasis>.
-      </para>
-      <screen>fcc-hook [@.]aol\\.com$ +spammers</screen>
-      <para>
-        ...will save a copy of all messages going to the aol.com domain to the
-        `+spammers' mailbox by default. Also see the
-        <link linkend="fcc-save-hook"><command>fcc-save-hook</command></link>
-        command.
-      </para>
-    </sect1>
-
-    <sect1 id="fcc-save-hook">
-      <title>Specify Default Save Filename and Default Fcc: Mailbox at Once</title>
+    <sect1 id="default-save-mailbox">
+      <title>Specify Default Fcc: and/or Save Mailbox</title>
       <para>
         Usage:
       </para>
@@ -5437,13 +5351,70 @@ save-hook aol\\.com$ +spam
         <arg choice="plain">
           <replaceable class="parameter">mailbox</replaceable>
         </arg>
+        <command>fcc-hook</command>
+        <arg choice="plain">
+          <replaceable class="parameter">pattern</replaceable>
+        </arg>
+        <arg choice="plain">
+          <replaceable class="parameter">mailbox</replaceable>
+        </arg>
+        <command>save-hook</command>
+        <arg choice="plain">
+          <replaceable class="parameter">pattern</replaceable>
+        </arg>
+        <arg choice="plain">
+          <replaceable class="parameter">mailbox</replaceable>
+        </arg>
       </cmdsynopsis>
-      <para>
-        This command is a shortcut, equivalent to doing both a
-        <link linkend="fcc-hook"><command>fcc-hook</command></link> and a
-        <link linkend="save-hook"><command>save-hook</command></link> with its
-        arguments, including %-expansion on <emphasis>mailbox</emphasis>
+      <para><anchor id="fcc-save-hook" />
+        <command>fcc-save-hook</command> is a shortcut, equivalent to doing
+        both a <link linkend="fcc-hook"><command>fcc-hook</command></link> and
+        a <link linkend="save-hook"><command>save-hook</command></link> with
+        its arguments, including %-expansion on <emphasis>mailbox</emphasis>
         according to <link linkend="index-format">$index_format</link>.
+      </para>
+
+      <para><anchor id="fcc-hook" />
+        <command>fcc-hook</command> is used to save outgoing mail in a mailbox
+        other than <link linkend="record">$record</link>. NeoMutt searches the
+        initial list of message recipients for the first matching
+        <emphasis>pattern</emphasis> and uses <emphasis>mailbox</emphasis> as
+        the default <quote>Fcc:</quote> mailbox. If no match is found the
+        message will be saved to <link linkend="record">$record</link> mailbox.
+      </para>
+      <screen>fcc-hook [@.]aol\\.com$ +spammers</screen>
+      <para>
+        ...will save a copy of all messages going to the aol.com domain to the
+        <quote>+spammers</quote> mailbox by default.
+      </para>
+
+      <para><anchor id="save-hook" />
+        <command>save-hook</command> is used to override the default mailbox
+        used when saving messages. <emphasis>mailbox</emphasis> will be used
+        as the default if the message matches <emphasis>pattern</emphasis>.
+      </para>
+      <example id="ex-save-hook-exando">
+        <title>Using %-expandos in <command>save-hook</command></title>
+        <screen>
+<emphasis role="comment"># default: save all to ~/Mail/&lt;author name&gt;</emphasis>
+save-hook . ~/Mail/%F
+<emphasis role="comment"># save from me@turing.cs.hmc.edu and me@cs.hmc.edu to $folder/elkins</emphasis>
+save-hook me@(turing\\.)?cs\\.hmc\\.edu$ +elkins
+<emphasis role="comment"># save from aol.com to $folder/spam</emphasis>
+save-hook aol\\.com$ +spam
+        </screen>
+      </example>
+
+      <para>
+        Also see the
+        <link linkend="fcc-save-hook"><command>fcc-save-hook</command></link>
+        command.
+      </para><para>
+        To provide more flexibility and good defaults, NeoMutt applies the
+        expandos of <link linkend="index-format">$index_format</link> to
+        <emphasis>mailbox</emphasis> after it was expanded. See
+        <xref linkend="pattern-hook" /> for information on the exact format of
+        <emphasis>pattern</emphasis>.
       </para>
     </sect1>
 
@@ -6050,13 +6021,6 @@ set spam_separator=", "
             </arg>
           </group>
           <arg choice="opt" rep="repeat"></arg>
-          <command>toggle</command>
-          <arg choice="plain">
-            <replaceable class="parameter">variable</replaceable>
-          </arg>
-          <arg choice="opt" rep="repeat">
-            <replaceable class="parameter">variable</replaceable>
-          </arg>
           <command>unset</command>
           <arg choice="plain">
             <replaceable class="parameter">variable</replaceable>
@@ -6065,6 +6029,13 @@ set spam_separator=", "
             <replaceable class="parameter">variable</replaceable>
           </arg>
           <command>reset</command>
+          <arg choice="plain">
+            <replaceable class="parameter">variable</replaceable>
+          </arg>
+          <arg choice="opt" rep="repeat">
+            <replaceable class="parameter">variable</replaceable>
+          </arg>
+          <command>toggle</command>
           <arg choice="plain">
             <replaceable class="parameter">variable</replaceable>
           </arg>
@@ -8117,17 +8088,10 @@ set index_format="%4C %Z %{%b %d} %-15.15L (%?l?%4l&amp;%4c?)%*  %s"
         </listitem>
         <listitem>
           <para>
-            <link linkend="append-hook"><command>append-hook</command></link>
-          </para>
-        </listitem>
-        <listitem>
-          <para>
             <link linkend="charset-hook"><command>charset-hook</command></link>
           </para>
-        </listitem>
-        <listitem>
           <para>
-            <link linkend="close-hook"><command>close-hook</command></link>
+            <link linkend="iconv-hook"><command>iconv-hook</command></link>
           </para>
         </listitem>
         <listitem>
@@ -8137,22 +8101,18 @@ set index_format="%4C %Z %{%b %d} %-15.15L (%?l?%4l&amp;%4c?)%*  %s"
         </listitem>
         <listitem>
           <para>
+            <link linkend="fcc-save-hook"><command>fcc-save-hook</command></link>
+          </para>
+          <para>
             <link linkend="fcc-hook"><command>fcc-hook</command></link>
           </para>
-        </listitem>
-        <listitem>
           <para>
-            <link linkend="fcc-save-hook"><command>fcc-save-hook</command></link>
+            <link linkend="save-hook"><command>save-hook</command></link>
           </para>
         </listitem>
         <listitem>
           <para>
             <link linkend="folder-hook"><command>folder-hook</command></link>
-          </para>
-        </listitem>
-        <listitem>
-          <para>
-            <link linkend="iconv-hook"><command>iconv-hook</command></link>
           </para>
         </listitem>
         <listitem>
@@ -8169,25 +8129,38 @@ set index_format="%4C %Z %{%b %d} %-15.15L (%?l?%4l&amp;%4c?)%*  %s"
           <para>
             <link linkend="open-hook"><command>open-hook</command></link>
           </para>
+          <para>
+            <link linkend="close-hook"><command>close-hook</command></link>
+          </para>
+          <para>
+            <link linkend="append-hook"><command>append-hook</command></link>
+          </para>
         </listitem>
         <listitem>
           <para>
             <link linkend="reply-hook"><command>reply-hook</command></link>
           </para>
-        </listitem>
-        <listitem>
-          <para>
-            <link linkend="save-hook"><command>save-hook</command></link>
-          </para>
-        </listitem>
-        <listitem>
           <para>
             <link linkend="send-hook"><command>send-hook</command></link>
           </para>
+          <para>
+            <link linkend="send2-hook"><command>send2-hook</command></link>
+          </para>
         </listitem>
         <listitem>
           <para>
-            <link linkend="send2-hook"><command>send2-hook</command></link>
+            <link linkend="global-hooks"><command>timeout-hook</command></link>
+          </para>
+          <para>
+            <link linkend="global-hooks"><command>startup-hook</command></link>
+          </para>
+          <para>
+            <link linkend="global-hooks"><command>shutdown-hook</command></link>
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            <link linkend="unhook"><command>unhook</command></link>
           </para>
         </listitem>
       </itemizedlist>
@@ -8506,8 +8479,9 @@ roessler@does-not-exist.org        Thomas Roessler mutt pgp
             <row>
               <entry><emphasis>@alias</emphasis></entry>
               <entry>
-                to the <link linkend="save-hook">default save folder</link> as
-                determined by the address of the alias
+                to the
+                <link linkend="default-save-mailbox">default save folder</link>
+                as determined by the address of the alias
               </entry>
             </row>
           </tbody>
@@ -16952,19 +16926,6 @@ neomutt mailto:some@one.org?subject=test&amp;cc=other@one.org
         <listitem>
           <cmdsynopsis>
             <command>
-              <link linkend="append-hook">append-hook</link>
-            </command>
-            <arg choice="plain">
-              <replaceable class="parameter">regex</replaceable>
-            </arg>
-            <arg choice="plain">
-              <replaceable class="parameter">&quot;shell-command&quot;</replaceable>
-            </arg>
-          </cmdsynopsis>
-        </listitem>
-        <listitem>
-          <cmdsynopsis>
-            <command>
               <link linkend="attachments">attachments</link>
             </command>
             <group choice="req">
@@ -17050,18 +17011,14 @@ neomutt mailto:some@one.org?subject=test&amp;cc=other@one.org
             <arg choice="plain">
               <replaceable class="parameter">charset</replaceable>
             </arg>
-          </cmdsynopsis>
-        </listitem>
-        <listitem>
-          <cmdsynopsis>
             <command>
-              <link linkend="close-hook">close-hook</link>
+              <link linkend="charset-hook">iconv-hook</link>
             </command>
             <arg choice="plain">
-              <replaceable class="parameter">regex</replaceable>
+              <replaceable class="parameter">charset</replaceable>
             </arg>
             <arg choice="plain">
-              <replaceable class="parameter">&quot;shell-command&quot;</replaceable>
+              <replaceable class="parameter">local-charset</replaceable>
             </arg>
           </cmdsynopsis>
         </listitem>
@@ -17167,7 +17124,7 @@ neomutt mailto:some@one.org?subject=test&amp;cc=other@one.org
         <listitem>
           <cmdsynopsis>
             <command>
-              <link linkend="fcc-hook">fcc-hook</link>
+              <link linkend="default-save-mailbox">fcc-save-hook</link>
             </command>
             <arg choice="plain">
               <replaceable class="parameter">pattern</replaceable>
@@ -17175,12 +17132,17 @@ neomutt mailto:some@one.org?subject=test&amp;cc=other@one.org
             <arg choice="plain">
               <replaceable class="parameter">mailbox</replaceable>
             </arg>
-          </cmdsynopsis>
-        </listitem>
-        <listitem>
-          <cmdsynopsis>
             <command>
-              <link linkend="fcc-save-hook">fcc-save-hook</link>
+              <link linkend="default-save-mailbox">fcc-hook</link>
+            </command>
+            <arg choice="plain">
+              <replaceable class="parameter">pattern</replaceable>
+            </arg>
+            <arg choice="plain">
+              <replaceable class="parameter">mailbox</replaceable>
+            </arg>
+            <command>
+              <link linkend="default-save-mailbox">save-hook</link>
             </command>
             <arg choice="plain">
               <replaceable class="parameter">pattern</replaceable>
@@ -17271,19 +17233,6 @@ neomutt mailto:some@one.org?subject=test&amp;cc=other@one.org
         <listitem>
           <cmdsynopsis>
             <command>
-              <link linkend="iconv-hook">iconv-hook</link>
-            </command>
-            <arg choice="plain">
-              <replaceable class="parameter">charset</replaceable>
-            </arg>
-            <arg choice="plain">
-              <replaceable class="parameter">local-charset</replaceable>
-            </arg>
-          </cmdsynopsis>
-        </listitem>
-        <listitem>
-          <cmdsynopsis>
-            <command>
               <link linkend="ifdef">ifdef</link>
             </command>
             <arg choice="plain">
@@ -17360,6 +17309,34 @@ neomutt mailto:some@one.org?subject=test&amp;cc=other@one.org
               </arg>
               <arg choice="plain" rep="repeat">
                 <replaceable>regex</replaceable>
+              </arg>
+            </group>
+            <command>
+              <link linkend="lists">subscribe</link>
+            </command>
+            <arg choice="opt" rep="repeat">
+              <option>-group</option>
+              <replaceable class="parameter">name</replaceable>
+            </arg>
+            <arg choice="plain">
+              <replaceable class="parameter">regex</replaceable>
+            </arg>
+            <arg choice="opt" rep="repeat">
+              <replaceable class="parameter">regex</replaceable>
+            </arg>
+            <command>
+              <link linkend="lists">unsubscribe</link>
+            </command>
+            <arg choice="opt" rep="repeat">
+              <option>-group</option>
+              <replaceable>name</replaceable>
+            </arg>
+            <group choice="req">
+              <arg choice="plain">
+                <replaceable class="parameter">*</replaceable>
+              </arg>
+              <arg choice="plain" rep="repeat">
+                <replaceable class="parameter">regex</replaceable>
               </arg>
             </group>
           </cmdsynopsis>
@@ -17582,6 +17559,24 @@ neomutt mailto:some@one.org?subject=test&amp;cc=other@one.org
             <arg choice="plain">
               <replaceable class="parameter">&quot;shell-command&quot;</replaceable>
             </arg>
+            <command>
+              <link linkend="close-hook">close-hook</link>
+            </command>
+            <arg choice="plain">
+              <replaceable class="parameter">regex</replaceable>
+            </arg>
+            <arg choice="plain">
+              <replaceable class="parameter">&quot;shell-command&quot;</replaceable>
+            </arg>
+            <command>
+              <link linkend="append-hook">append-hook</link>
+            </command>
+            <arg choice="plain">
+              <replaceable class="parameter">regex</replaceable>
+            </arg>
+            <arg choice="plain">
+              <replaceable class="parameter">&quot;shell-command&quot;</replaceable>
+            </arg>
           </cmdsynopsis>
         </listitem>
         <listitem>
@@ -17597,7 +17592,7 @@ neomutt mailto:some@one.org?subject=test&amp;cc=other@one.org
         <listitem>
           <cmdsynopsis>
             <command>
-              <link linkend="reply-hook">reply-hook</link>
+              <link linkend="send-hook">reply-hook</link>
             </command>
             <arg choice="plain">
               <replaceable class="parameter">pattern</replaceable>
@@ -17605,18 +17600,23 @@ neomutt mailto:some@one.org?subject=test&amp;cc=other@one.org
             <arg choice="plain">
               <replaceable class="parameter">command</replaceable>
             </arg>
-          </cmdsynopsis>
-        </listitem>
-        <listitem>
-          <cmdsynopsis>
             <command>
-              <link linkend="save-hook">save-hook</link>
+              <link linkend="send-hook">send-hook</link>
             </command>
             <arg choice="plain">
               <replaceable class="parameter">pattern</replaceable>
             </arg>
             <arg choice="plain">
-              <replaceable class="parameter">mailbox</replaceable>
+              <replaceable class="parameter">command</replaceable>
+            </arg>
+            <command>
+              <link linkend="send-hook">send2-hook</link>
+            </command>
+            <arg choice="plain">
+              <replaceable class="parameter">pattern</replaceable>
+            </arg>
+            <arg choice="plain">
+              <replaceable class="parameter">command</replaceable>
             </arg>
           </cmdsynopsis>
         </listitem>
@@ -17642,32 +17642,6 @@ neomutt mailto:some@one.org?subject=test&amp;cc=other@one.org
                 <replaceable class="parameter">pattern</replaceable>
               </arg>
             </group>
-          </cmdsynopsis>
-        </listitem>
-        <listitem>
-          <cmdsynopsis>
-            <command>
-              <link linkend="send-hook">send-hook</link>
-            </command>
-            <arg choice="plain">
-              <replaceable class="parameter">pattern</replaceable>
-            </arg>
-            <arg choice="plain">
-              <replaceable class="parameter">command</replaceable>
-            </arg>
-          </cmdsynopsis>
-        </listitem>
-        <listitem>
-          <cmdsynopsis>
-            <command>
-              <link linkend="send2-hook">send2-hook</link>
-            </command>
-            <arg choice="plain">
-              <replaceable class="parameter">pattern</replaceable>
-            </arg>
-            <arg choice="plain">
-              <replaceable class="parameter">command</replaceable>
-            </arg>
           </cmdsynopsis>
         </listitem>
         <listitem>
@@ -17699,15 +17673,6 @@ neomutt mailto:some@one.org?subject=test&amp;cc=other@one.org
             </group>
             <arg choice="opt" rep="repeat"></arg>
             <command>
-              <link linkend="set">toggle</link>
-            </command>
-            <arg choice="plain">
-              <replaceable class="parameter">variable</replaceable>
-            </arg>
-            <arg choice="opt" rep="repeat">
-              <replaceable class="parameter">variable</replaceable>
-            </arg>
-            <command>
               <link linkend="set">unset</link>
             </command>
             <arg choice="plain">
@@ -17718,6 +17683,15 @@ neomutt mailto:some@one.org?subject=test&amp;cc=other@one.org
             </arg>
             <command>
               <link linkend="set">reset</link>
+            </command>
+            <arg choice="plain">
+              <replaceable class="parameter">variable</replaceable>
+            </arg>
+            <arg choice="opt" rep="repeat">
+              <replaceable class="parameter">variable</replaceable>
+            </arg>
+            <command>
+              <link linkend="set">toggle</link>
             </command>
             <arg choice="plain">
               <replaceable class="parameter">variable</replaceable>
@@ -17833,33 +17807,23 @@ neomutt mailto:some@one.org?subject=test&amp;cc=other@one.org
         <listitem>
           <cmdsynopsis>
             <command>
-              <link linkend="subscribe">subscribe</link>
+              <link linkend="global-hooks">timeout-hook</link>
             </command>
-            <arg choice="opt" rep="repeat">
-              <option>-group</option>
-              <replaceable class="parameter">name</replaceable>
-            </arg>
             <arg choice="plain">
-              <replaceable class="parameter">regex</replaceable>
-            </arg>
-            <arg choice="opt" rep="repeat">
-              <replaceable class="parameter">regex</replaceable>
+              <replaceable class="parameter">command</replaceable>
             </arg>
             <command>
-              <link linkend="subscribe">unsubscribe</link>
+              <link linkend="global-hooks">startup-hook</link>
             </command>
-            <arg choice="opt" rep="repeat">
-              <option>-group</option>
-              <replaceable>name</replaceable>
+            <arg choice="plain">
+              <replaceable class="parameter">command</replaceable>
             </arg>
-            <group choice="req">
-              <arg choice="plain">
-                <replaceable class="parameter">*</replaceable>
-              </arg>
-              <arg choice="plain" rep="repeat">
-                <replaceable class="parameter">regex</replaceable>
-              </arg>
-            </group>
+            <command>
+              <link linkend="global-hooks">shutdown-hook</link>
+            </command>
+            <arg choice="plain">
+              <replaceable class="parameter">command</replaceable>
+            </arg>
           </cmdsynopsis>
         </listitem>
         <listitem>
@@ -17875,28 +17839,6 @@ neomutt mailto:some@one.org?subject=test&amp;cc=other@one.org
                 <replaceable class="parameter">hook-type</replaceable>
               </arg>
             </group>
-          </cmdsynopsis>
-        </listitem>
-        <listitem>
-          <cmdsynopsis>
-            <command>
-              <link linkend="global-hooks">shutdown-hook</link>
-            </command>
-            <arg choice="plain">
-              <replaceable class="parameter">command</replaceable>
-            </arg>
-            <command>
-              <link linkend="global-hooks">startup-hook</link>
-            </command>
-            <arg choice="plain">
-              <replaceable class="parameter">command</replaceable>
-            </arg>
-            <command>
-              <link linkend="global-hooks">timeout-hook</link>
-            </command>
-            <arg choice="plain">
-              <replaceable class="parameter">command</replaceable>
-            </arg>
           </cmdsynopsis>
         </listitem>
       </itemizedlist>

--- a/doc/manual.xml.head
+++ b/doc/manual.xml.head
@@ -15,8 +15,8 @@ vim: ts=2 sw=2 sts=2 expandtab:
     <releaseinfo>version @VERSION@</releaseinfo>
     <abstract>
       <para>
-        <quote>All mail clients suck. This one just sucks less.</quote> – me,
-        circa 1995
+        <quote>All mail clients suck. This one just sucks less.</quote>
+        &mdash; me, circa 1995
       </para>
     </abstract>
   </bookinfo>
@@ -462,8 +462,8 @@ Cars            4|  3    ! Aug 16  Ewan Brown       (333)  Hummingbird
             <para>
               Functions <literal>&lt;sidebar-next&gt;</literal> and
               <literal>&lt;sidebar-prev&gt;</literal> move the Sidebar
-              <emphasis role="bold">highlight</emphasis>. They <emphasis
-                role="bold">do not</emphasis> change the open mailbox.
+              <emphasis role="bold">highlight</emphasis>. They
+              <emphasis role="bold">do not</emphasis> change the open mailbox.
             </para>
           </note>
           <para>
@@ -684,7 +684,7 @@ set sidebar_divider_char = '│'          <emphasis role="comment"># Pretty line
               Sidebar display. For an introduction, read
               <link linkend="index-format">format strings</link> including the
               section about
-              <link linkend="formatstrings-conditionals"> conditionals</link>.
+              <link linkend="formatstrings-conditionals">conditionals</link>.
             </para>
             <para>
               The default value is: <literal>%B%* %n</literal>
@@ -842,7 +842,7 @@ set sidebar_divider_char = '│'          <emphasis role="comment"># Pretty line
             </para>
 
             <table>
-              <title>sidebar_format</title>
+              <title>sidebar_format examples</title>
               <tgroup cols="2">
                 <thead>
                   <row>
@@ -1212,8 +1212,8 @@ color sidebar_divider   color8  default     <emphasis role="comment"># Dark grey
       <title>Moving Around in Menus</title>
       <para>
         The most important navigation keys common to line- or entry-based menus
-        are shown in <xref linkend="tab-keys-nav-line" /> and in <xref
-          linkend="tab-keys-nav-page" /> for page-based menus.
+        are shown in <xref linkend="tab-keys-nav-line" /> and in
+        <xref linkend="tab-keys-nav-page" /> for page-based menus.
       </para>
 
       <table id="tab-keys-nav-line">
@@ -4179,9 +4179,10 @@ bind index gg first-entry
         executed in the order given in the <literal>.neomuttrc</literal>.
       </para>
       <para>
-        The regex parameter has <link linkend="shortcuts">mailbox
-          shortcut</link> expansion performed on the first character. See
-        <xref linkend="mailbox-hook" /> for more details.
+        The regex parameter has
+        <link linkend="shortcuts">mailbox shortcut</link> expansion performed
+        on the first character. See <xref linkend="mailbox-hook" /> for more
+        details.
       </para>
       <note>
         <para>
@@ -5340,6 +5341,9 @@ my_hdr Organization: A Really Big Company, Anytown, USA
 
     <sect1 id="default-save-mailbox">
       <title>Specify Default Fcc: and/or Save Mailbox</title>
+      <anchor id="fcc-save-hook" />
+      <anchor id="fcc-hook" />
+      <anchor id="save-hook" />
       <para>
         Usage:
       </para>
@@ -5366,15 +5370,14 @@ my_hdr Organization: A Really Big Company, Anytown, USA
           <replaceable class="parameter">mailbox</replaceable>
         </arg>
       </cmdsynopsis>
-      <para><anchor id="fcc-save-hook" />
+      <para>
         <command>fcc-save-hook</command> is a shortcut, equivalent to doing
         both a <link linkend="fcc-hook"><command>fcc-hook</command></link> and
         a <link linkend="save-hook"><command>save-hook</command></link> with
         its arguments, including %-expansion on <emphasis>mailbox</emphasis>
         according to <link linkend="index-format">$index_format</link>.
       </para>
-
-      <para><anchor id="fcc-hook" />
+      <para>
         <command>fcc-hook</command> is used to save outgoing mail in a mailbox
         other than <link linkend="record">$record</link>. NeoMutt searches the
         initial list of message recipients for the first matching
@@ -5387,14 +5390,14 @@ my_hdr Organization: A Really Big Company, Anytown, USA
         ...will save a copy of all messages going to the aol.com domain to the
         <quote>+spammers</quote> mailbox by default.
       </para>
-
-      <para><anchor id="save-hook" />
+      <para>
         <command>save-hook</command> is used to override the default mailbox
         used when saving messages. <emphasis>mailbox</emphasis> will be used
         as the default if the message matches <emphasis>pattern</emphasis>.
       </para>
       <example id="ex-save-hook-exando">
         <title>Using %-expandos in <command>save-hook</command></title>
+
 <screen>
 <emphasis role="comment"># default: save all to ~/Mail/&lt;author name&gt;</emphasis>
 save-hook . ~/Mail/%F
@@ -5403,13 +5406,14 @@ save-hook me@(turing\\.)?cs\\.hmc\\.edu$ +elkins
 <emphasis role="comment"># save from aol.com to $folder/spam</emphasis>
 save-hook aol\\.com$ +spam
 </screen>
-      </example>
 
+      </example>
       <para>
         Also see the
         <link linkend="fcc-save-hook"><command>fcc-save-hook</command></link>
         command.
-      </para><para>
+      </para>
+      <para>
         To provide more flexibility and good defaults, NeoMutt applies the
         expandos of <link linkend="index-format">$index_format</link> to
         <emphasis>mailbox</emphasis> after it was expanded. See
@@ -8028,7 +8032,7 @@ set index_format="%4C %Z %{%b %d} %-15.15L (%?l?%4l&amp;%4c?)%*  %s"
         (Message marking is really just a shortcut for defining a macro that
         returns you to the current message by searching for its Message-ID.
         You can choose a different prefix by setting the
-        <link linkend="mark-macro-prefix"> $mark_macro_prefix</link> variable.)
+        <link linkend="mark-macro-prefix">$mark_macro_prefix</link> variable.)
       </para>
     </sect1>
 
@@ -8394,8 +8398,8 @@ roessler@does-not-exist.org        Thomas Roessler mutt pgp
         more robust with concurrent clients writing the mailbox, but still may
         suffer from lost flags; message corruption is less likely to occur than
         with mbox/mmdf. It's usually slower to open compared to mbox/mmdf since
-        many small files have to be read (NeoMutt provides <xref
-          linkend="header-caching" /> to greatly speed this process up).
+        many small files have to be read (NeoMutt provides
+        <xref linkend="header-caching" /> to greatly speed this process up).
         Depending on the environment, MH is not very disk-space efficient.
       </para>
       <para>
@@ -9220,7 +9224,7 @@ audio/x-aiff                    aif aifc aiff
       </table>
       <para>
         MIME types are not arbitrary, they need to be assigned by
-        <ulink url="http://www.iana.org/assignments/media-types/"> IANA</ulink>.
+        <ulink url="http://www.iana.org/assignments/media-types/">IANA</ulink>.
       </para>
     </sect1>
 
@@ -9388,7 +9392,7 @@ text/*; more
           parameters can lead to security problems in general. NeoMutt tries to
           quote parameters in expansion of <literal>%s</literal> syntaxes
           properly, and avoids risky characters by substituting them, see the
-          <link linkend="mailcap-sanitize"> $mailcap_sanitize</link> variable.
+          <link linkend="mailcap-sanitize">$mailcap_sanitize</link> variable.
         </para>
         <para>
           Although NeoMutt's procedures to invoke programs with mailcap seem to
@@ -10239,7 +10243,7 @@ smtp://user@host:587/
         <xref linkend="url-syntax" /> for details) using the
         <literal>imap</literal> or <literal>imaps</literal> protocol.
         Alternatively, a pine-compatible notation is also supported, i.e.
-        <literal> {[username@]imapserver[:port][/ssl]}path/to/folder</literal>
+        <literal>{[username@]imapserver[:port][/ssl]}path/to/folder</literal>
       </para>
       <para>
         Note that not all servers use <quote>/</quote> as the hierarchy
@@ -10250,7 +10254,7 @@ smtp://user@host:587/
         When browsing folders on an IMAP server, you can toggle whether to look
         at only the folders you are subscribed to, or all folders with the
         <emphasis>toggle-subscribed</emphasis> command. See also the
-        <link linkend="imap-list-subscribed"> $imap_list_subscribed</link>
+        <link linkend="imap-list-subscribed">$imap_list_subscribed</link>
         variable.
       </para>
       <para>
@@ -14310,7 +14314,7 @@ virtual-mailboxes "My INBOX" "notmuch://?query=tag:inbox"
           </informaltable>
           <para>
             For an explanation of <quote>soft-fill</quote>, see the
-            <link linkend="index-format"> $index_format</link> documentation.
+            <link linkend="index-format">$index_format</link> documentation.
           </para>
           <para>
             * = can be optionally printed if nonzero

--- a/doc/manual.xml.head
+++ b/doc/manual.xml.head
@@ -16777,7 +16777,7 @@ neomutt -a image.jpg *.png -- address1 address2
         </tgroup>
       </table>
       <para>
-        To read messages in a mailbox
+        To read messages in a mailbox or exit immediately
       </para>
       <cmdsynopsis>
         <command>neomutt</command>
@@ -16786,15 +16786,15 @@ neomutt -a image.jpg *.png -- address1 address2
         </arg>
         <arg choice="opt">
           <option>-F</option>
-          <replaceable>neomuttrc</replaceable>
+          <literal>config</literal>
         </arg>
         <arg choice="opt">
           <option>-m</option>
-          <replaceable>type</replaceable>
+          <literal>type</literal>
         </arg>
         <arg choice="opt">
           <option>-f</option>
-          <replaceable>mailbox</replaceable>
+          <literal>mailbox</literal>
         </arg>
       </cmdsynopsis>
       <para>
@@ -16803,31 +16803,41 @@ neomutt -a image.jpg *.png -- address1 address2
       <cmdsynopsis>
         <command>neomutt</command>
         <arg choice="opt">
-          <option>-En</option>
+          <option>-Enx</option>
         </arg>
         <arg choice="opt">
           <option>-F</option>
-          <replaceable>neomuttrc</replaceable>
+          <literal>config</literal>
+        </arg>
+        <arg choice="opt">
+          <option>-b</option>
+          <literal>address</literal>
         </arg>
         <arg choice="opt">
           <option>-c</option>
-          <replaceable>address</replaceable>
+          <literal>address</literal>
         </arg>
         <arg choice="opt">
-          <option>-Hi</option>
-          <replaceable>filename</replaceable>
+          <option>-H</option>
+          <literal>draft</literal>
+        </arg>
+        <arg choice="opt">
+          <option>-i</option>
+          <literal>include</literal>
         </arg>
         <arg choice="opt">
           <option>-s</option>
-          <replaceable>subject</replaceable>
+          <literal>subject</literal>
         </arg>
         <arg choice="opt">
-        <option>-a</option>
-        <replaceable>file</replaceable>
-        <arg choice="opt" rep="repeat" />--</arg>
-        <group choice="plain" rep="repeat">
+          <option>-a</option>
+          <literal>file</literal>
+          <arg choice="opt" rep="repeat" />
+          <option>--</option>
+        </arg>
+        <group choice="req" rep="repeat">
           <arg choice="plain">
-            <replaceable>address</replaceable>
+            <literal>address</literal>
           </arg>
           <arg choice="plain">
             <replaceable>mailto_url</replaceable>
@@ -16869,8 +16879,8 @@ neomutt -s "data set for run #2" professor@bigschool.edu &lt; ~/run2.dat
       <para>
         All files passed with <literal>-a</literal> <emphasis>file</emphasis>
         will be attached as a MIME part to the message. To attach a single or
-        several files, use <quote>--</quote> to separate files and recipient
-        addresses:
+        several files, use <literal>--</literal> to separate files and
+        recipient addresses:
       </para>
       <screen>neomutt -a image.png -- some@one.org</screen>
       <para>

--- a/doc/manual.xml.head
+++ b/doc/manual.xml.head
@@ -4163,7 +4163,7 @@ bind index gg first-entry
       <cmdsynopsis>
         <command>folder-hook</command>
         <arg choice="plain">
-          <replaceable class="parameter">[!]regex</replaceable>
+          <replaceable class="parameter">regex</replaceable>
         </arg>
         <arg choice="plain">
           <replaceable class="parameter">command</replaceable>
@@ -5177,7 +5177,7 @@ unignore posted-to:
       <cmdsynopsis>
         <command>mbox-hook</command>
         <arg choice="plain">
-          <replaceable class="parameter">[!]regex</replaceable>
+          <replaceable class="parameter">regex</replaceable>
         </arg>
         <arg choice="plain">
           <replaceable class="parameter">mailbox</replaceable>
@@ -5346,7 +5346,7 @@ my_hdr Organization: A Really Big Company, Anytown, USA
       <cmdsynopsis>
         <command>save-hook</command>
         <arg choice="plain">
-          <replaceable class="parameter">[!]pattern</replaceable>
+          <replaceable class="parameter">pattern</replaceable>
         </arg>
         <arg choice="plain">
           <replaceable class="parameter">mailbox</replaceable>
@@ -5392,7 +5392,7 @@ save-hook aol\\.com$ +spam
       <cmdsynopsis>
         <command>fcc-hook</command>
         <arg choice="plain">
-          <replaceable class="parameter">[!]pattern</replaceable>
+          <replaceable class="parameter">pattern</replaceable>
         </arg>
         <arg choice="plain">
           <replaceable class="parameter">mailbox</replaceable>
@@ -5432,7 +5432,7 @@ save-hook aol\\.com$ +spam
       <cmdsynopsis>
         <command>fcc-save-hook</command>
         <arg choice="plain">
-          <replaceable class="parameter">[!]pattern</replaceable>
+          <replaceable class="parameter">pattern</replaceable>
         </arg>
         <arg choice="plain">
           <replaceable class="parameter">mailbox</replaceable>
@@ -5457,21 +5457,21 @@ save-hook aol\\.com$ +spam
       <cmdsynopsis>
         <command>reply-hook</command>
         <arg choice="plain">
-          <replaceable class="parameter">[!]pattern</replaceable>
+          <replaceable class="parameter">pattern</replaceable>
         </arg>
         <arg choice="plain">
           <replaceable class="parameter">command</replaceable>
         </arg>
         <command>send-hook</command>
         <arg choice="plain">
-          <replaceable class="parameter">[!]pattern</replaceable>
+          <replaceable class="parameter">pattern</replaceable>
         </arg>
         <arg choice="plain">
           <replaceable class="parameter">command</replaceable>
         </arg>
         <command>send2-hook</command>
         <arg choice="plain">
-          <replaceable class="parameter">[!]pattern</replaceable>
+          <replaceable class="parameter">pattern</replaceable>
         </arg>
         <arg choice="plain">
           <replaceable class="parameter">command</replaceable>
@@ -5556,7 +5556,7 @@ save-hook aol\\.com$ +spam
       <cmdsynopsis>
         <command>message-hook</command>
         <arg choice="plain">
-          <replaceable class="parameter">[!]pattern</replaceable>
+          <replaceable class="parameter">pattern</replaceable>
         </arg>
         <arg choice="plain">
           <replaceable class="parameter">command</replaceable>
@@ -17170,7 +17170,7 @@ neomutt mailto:some@one.org?subject=test&amp;cc=other@one.org
               <link linkend="fcc-hook">fcc-hook</link>
             </command>
             <arg choice="plain">
-              <replaceable class="parameter">[!]pattern</replaceable>
+              <replaceable class="parameter">pattern</replaceable>
             </arg>
             <arg choice="plain">
               <replaceable class="parameter">mailbox</replaceable>
@@ -17183,7 +17183,7 @@ neomutt mailto:some@one.org?subject=test&amp;cc=other@one.org
               <link linkend="fcc-save-hook">fcc-save-hook</link>
             </command>
             <arg choice="plain">
-              <replaceable class="parameter">[!]pattern</replaceable>
+              <replaceable class="parameter">pattern</replaceable>
             </arg>
             <arg choice="plain">
               <replaceable class="parameter">mailbox</replaceable>
@@ -17196,7 +17196,7 @@ neomutt mailto:some@one.org?subject=test&amp;cc=other@one.org
               <link linkend="folder-hook">folder-hook</link>
             </command>
             <arg choice="plain">
-              <replaceable class="parameter">[!]regex</replaceable>
+              <replaceable class="parameter">regex</replaceable>
             </arg>
             <arg choice="plain">
               <replaceable class="parameter">command</replaceable>
@@ -17442,7 +17442,7 @@ neomutt mailto:some@one.org?subject=test&amp;cc=other@one.org
               <link linkend="mbox-hook">mbox-hook</link>
             </command>
             <arg choice="plain">
-              <replaceable class="parameter">[!]regex</replaceable>
+              <replaceable class="parameter">regex</replaceable>
             </arg>
             <arg choice="plain">
               <replaceable class="parameter">mailbox</replaceable>
@@ -17455,7 +17455,7 @@ neomutt mailto:some@one.org?subject=test&amp;cc=other@one.org
               <link linkend="message-hook">message-hook</link>
             </command>
             <arg choice="plain">
-              <replaceable class="parameter">[!]pattern</replaceable>
+              <replaceable class="parameter">pattern</replaceable>
             </arg>
             <arg choice="plain">
               <replaceable class="parameter">command</replaceable>
@@ -17600,7 +17600,7 @@ neomutt mailto:some@one.org?subject=test&amp;cc=other@one.org
               <link linkend="reply-hook">reply-hook</link>
             </command>
             <arg choice="plain">
-              <replaceable class="parameter">[!]pattern</replaceable>
+              <replaceable class="parameter">pattern</replaceable>
             </arg>
             <arg choice="plain">
               <replaceable class="parameter">command</replaceable>
@@ -17613,7 +17613,7 @@ neomutt mailto:some@one.org?subject=test&amp;cc=other@one.org
               <link linkend="save-hook">save-hook</link>
             </command>
             <arg choice="plain">
-              <replaceable class="parameter">[!]pattern</replaceable>
+              <replaceable class="parameter">pattern</replaceable>
             </arg>
             <arg choice="plain">
               <replaceable class="parameter">mailbox</replaceable>
@@ -17650,7 +17650,7 @@ neomutt mailto:some@one.org?subject=test&amp;cc=other@one.org
               <link linkend="send-hook">send-hook</link>
             </command>
             <arg choice="plain">
-              <replaceable class="parameter">[!]pattern</replaceable>
+              <replaceable class="parameter">pattern</replaceable>
             </arg>
             <arg choice="plain">
               <replaceable class="parameter">command</replaceable>
@@ -17663,7 +17663,7 @@ neomutt mailto:some@one.org?subject=test&amp;cc=other@one.org
               <link linkend="send2-hook">send2-hook</link>
             </command>
             <arg choice="plain">
-              <replaceable class="parameter">[!]pattern</replaceable>
+              <replaceable class="parameter">pattern</replaceable>
             </arg>
             <arg choice="plain">
               <replaceable class="parameter">command</replaceable>

--- a/doc/neomutt.man
+++ b/doc/neomutt.man
@@ -28,24 +28,15 @@ neomutt \- The NeoMutt Mail User Agent (MUA)
 .SH SYNTAX
 .\" --------------------------------------------------------------------
 .SY neomutt
-.OP \-GnRyZz
-.OP \-e command
-.OP \-F config
-.OP \-f mailbox
-.OP \-g server
-.OP \-m type
-.YS
-.
-.SY neomutt
 .OP \-Enx
 .OP \-e command
 .OP \-F config
 .OP \-H draft
 .OP \-i include
-.OP \-s subject
 .br
 .OP \-b address
 .OP \-c address
+.OP \-s subject
 .RB [ \-a
 .IR file " [" .\|.\|.\& ]
 .BR \-\- ]
@@ -56,14 +47,22 @@ neomutt \- The NeoMutt Mail User Agent (MUA)
 .OP \-nx
 .OP \-e command
 .OP \-F config
-.OP \-s subject
 .OP \-b address
 .OP \-c address
 .br
+.OP \-s subject
 .RB [ \-a
 .IR file " [" .\|.\|.\& ]
 .BR \-\- ]
 .IR address " [" .\|.\|.\& "] < message"
+.YS
+.
+.SY neomutt
+.OP \-nRy
+.OP \-e command
+.OP \-F config
+.OP \-f mailbox
+.OP \-m type
 .YS
 .
 .SY neomutt
@@ -99,6 +98,20 @@ neomutt \- The NeoMutt Mail User Agent (MUA)
 .OP \-n
 .OP \-e command
 .OP \-F config
+.BI \-G
+.YS
+.
+.SY neomutt
+.OP \-n
+.OP \-e command
+.OP \-F config
+.BI \-g " server"
+.YS
+.
+.SY neomutt
+.OP \-n
+.OP \-e command
+.OP \-F config
 .BI \-p
 .YS
 .
@@ -107,6 +120,21 @@ neomutt \- The NeoMutt Mail User Agent (MUA)
 .OP \-e command
 .OP \-F config
 .BI \-Q " variable"
+.YS
+.
+.SY neomutt
+.OP \-n
+.OP \-e command
+.OP \-F config
+.BI \-Z
+.YS
+.
+.SY neomutt
+.OP \-n
+.OP \-e command
+.OP \-F config
+.BI \-z
+.OP \-f mailbox
 .YS
 .
 .SY neomutt
@@ -132,13 +160,12 @@ HTML, and/or PDF format.
 .\" --------------------------------------------------------------------
 .TP
 .BI \-A " alias"
-An expanded version of the given \fIalias\fP is passed to stdout.
+Print an expanded version of the given \fIalias\fP to stdout and exit.
 .
 .TP
 .BI \-a " file \fR[\fP.\|.\|.\&\fR]\fP"
-Attach a \fIfile\fP to your message using MIME. When attaching single or
-multiple \fIfile\fPs, separating filenames and recipient addresses with
-\(lq\fB\-\-\fP\(rq is mandatory, e.g.:
+Attach one or more \fIfile\fPs to a message. Must be given at last and separate
+attachment(s) from address(es) using the \(aq\fB\-\-\fP\(aq argument, e.g.:
 .RS
 .IP
 .EX
@@ -147,7 +174,6 @@ multiple \fIfile\fPs, separating filenames and recipient addresses with
 .EE
 .RE
 .IP
-This \fB\-a\fP option must be placed at the end of command line options.
 .
 .TP
 .BI \-B
@@ -155,24 +181,26 @@ Run in batch mode (do not start the ncurses UI).
 .
 .TP
 .BI \-b " address"
-Specify a blind-carbon-copy (Bcc) recipient.
+Specify a blind carbon copy (Bcc) recipient.
 .
 .TP
 .BI \-c " address"
-Specify a carbon-copy (Cc) recipient.
+Specify a carbon copy (Cc) recipient.
 .
 .TP
 .BI \-D
-Print the value of all configuration options to stdout.
+Dump all configuration variables as
+.RB \(aq name = value \(aq
+pair to stdout.
 .
 .TP
 .BI \-D\ \-S
-Like \fB\-D\fP but hide the value of sensitive variables.
+Like \fB\-D\fP, but hide the value of sensitive variables.
 .
 .TP
 .BI \-d " level"
-Log debugging output to file, by default to \fI~/.neomuttdebug0\fP. The
-\fIlevel\fP can range from 1\(en5 and affects verbosity. A value of 2 is
+Log debugging output to file (by default to \(dq\fI~/.neomuttdebug0\fP\(dq).
+The \fIlevel\fP can range from 1\(en5 and affects verbosity. A value of 2 is
 recommended.
 .IP
 Using this option along with \fB\-l\fP is useful to log the early startup
@@ -181,22 +209,22 @@ $debug_file).
 .
 .TP
 .BI \-E
-Edit the \fIdraft\fP (\fB\-H\fP) or \fIinclude\fP (\fB\-i\fP) file during
-message composition.
+Edit \fIdraft\fP (\fB\-H\fP) or \fIinclude\fP (\fB\-i\fP) file during message
+composition.
 .
 .TP
 .BI \-e " command"
-Specify a configuration \fIcommand\fP to be run after processing of
-initialization files.
+Specify a \fIcommand\fP to be run after initial program configuration.
 .
 .TP
 .BI \-F " config"
-Specify an alternative initialization file to read, see \fIFILES\fP section
-below for a list of regular configuration files.
+Specify an alternative initialization file to read.
+.IP
+See \fIFILES\fP section below for a list of regular configuration files.
 .
 .TP
 .BI \-f " mailbox"
-Specify which \fImailbox\fP to load.
+Specify a \fImailbox\fP (as defined with \fBmailboxes\fP command) to load.
 .
 .TP
 .BI \-G
@@ -204,63 +232,61 @@ Start NeoMutt with a listing of subscribed newsgroups.
 .
 .TP
 .BI \-g " server"
-Start NeoMutt with a listing of subscribed newsgroups at specified news
-\fIserver\fP.
+Like \fB\-G\fP, but start at specified news \fIserver\fP.
 .
 .TP
 .BI \-H " draft"
-Specify a \fIdraft\fP file which contains header and body to use to send
-a message.
+Specify a \fIdraft\fP file with header and body for message composing.
 .
 .TP
 .BI \-h
-Display this help message.
+Print this help message and exit.
 .
 .TP
 .BI \-i " include"
-Specify a file to \fIinclude\fP into the body of a message.
+Specify an \fIinclude\fP file to be embedded in the body of a message.
 .
 .TP
 .BI \-l " file"
-Overrule $debug_file or default setting with \fIfile\fP for debugging output.
-NeoMutt keeps up to five debug logs
+Specify a \fIfile\fP for debugging output.
+.IP
+This overrules $debug_file setting. NeoMutt keeps up to five debug logs
 .RI "({ " file " | $debug_file | " ~/.neomuttdebug " }[" 0 - 4 ])
-before removing the oldest file.
+before override the oldest file.
 .
 .TP
 .BI \-m " type"
-Specify a default mailbox \fItype\fP for newly created folders.
+Specify a default mailbox format \fItype\fP for newly created folders. The
+\fItype\fP is either MH, MMDF, Maildir or mbox (case-insensitive).
 .
 .TP
 .BI \-n
-Causes NeoMutt to bypass the system configuration file.
+Bypass loading of system-wide configuration file.
 .
 .TP
 .BI \-p
-Resume a postponed message.
+Resume a prior postponed message, if any.
 .
 .TP
 .BI \-Q " variable"
-Query a configuration \fIvariable\fP. The query is executed after all
-configuration files have been parsed, and any commands given on the command
-line have been executed.
+Query a configuration \fIvariable\fP after all configuration files and commands
+(\fB\-e\fP) have been processed and print its value to stdout.
 .
 .TP
 .BI \-R
-Open a mailbox in read-only mode.
+Open mailbox in read-only mode.
 .
 .TP
 .BI \-s " subject"
-Specify the \fIsubject\fP of the message. Must be quoted when it contains
-spaces.
+Specify a \fIsubject\fP (must be enclosed in quotes if it has spaces).
 .
 .TP
 .BI \-v
-Display the NeoMutt version number and compile-time definitions.
+Print the NeoMutt version and compile-time definitions and exit.
 .
 .TP
 .BI \-vv
-Display license and copyright information.
+Print the NeoMutt license and copyright information and exit.
 .
 .TP
 .BI \-x
@@ -270,23 +296,22 @@ send mode.
 .
 .TP
 .BI \-y
-Start NeoMutt with a listing of all mailboxes specified by the \fBmailboxes\fP
-command.
+Start NeoMutt with a listing of all defined mailboxes.
 .
 .TP
 .BI \-Z
-Causes NeoMutt to open the first mailbox specified by the \fBmailboxes\fP
-command which contains new mail.
+Open the first mailbox with new message or exit immediately with exit code 1 if
+none is found in all defined mailboxes.
 .
 .TP
 .BI \-z
-When used with option \fB\-f\fP, causes NeoMutt not to start if there are no
-messages in the mailbox.
+Open the first or specified (\fB\-f\fP) mailbox if it holds any message or exit
+immediately with exit code 1 otherwise.
 .
 .TP
 .BI \-\-
-Treat remaining arguments as \fIaddress\fP even if they start with a dash. See
-also option \fB\-a\fP above.
+Special argument forces NeoMutt to stop option parsing and treat remaining
+arguments as \fIaddress\fP even if they start with a hyphen.
 .
 .\" --------------------------------------------------------------------
 .SH ENVIRONMENT

--- a/doc/neomutt.man
+++ b/doc/neomutt.man
@@ -91,6 +91,14 @@ neomutt \- The NeoMutt Mail User Agent (MUA)
 .OP \-n
 .OP \-e command
 .OP \-F config
+.BI \-d " level"
+.BI \-l " file"
+.YS
+.
+.SY neomutt
+.OP \-n
+.OP \-e command
+.OP \-F config
 .BI \-p
 .YS
 .
@@ -163,14 +171,13 @@ Like \fB\-D\fP but hide the value of sensitive variables.
 .
 .TP
 .BI \-d " level"
-Log debugging output to file, by default to \fI~/.neomuttdebug0\fP, but see
-also configuration variables $debug_file and $debug_level in full manual. The
-\fIlevel\fP can range from 1\(em5 and affects verbosity. A value of 2 is
+Log debugging output to file, by default to \fI~/.neomuttdebug0\fP. The
+\fIlevel\fP can range from 1\(en5 and affects verbosity. A value of 2 is
 recommended.
 .IP
-NeoMutt keeps up to five debug logs
-.RI ( ~/.neomuttdebug [ 0 - 4 ])
-before removing the oldest file on next invocation with this option.
+Using this option along with \fB\-l\fP is useful to log the early startup
+process (before reading any configuration and hence $debug_level and
+$debug_file).
 .
 .TP
 .BI \-E
@@ -212,6 +219,13 @@ Display this help message.
 .TP
 .BI \-i " include"
 Specify a file to \fIinclude\fP into the body of a message.
+.
+.TP
+.BI \-l " file"
+Overrule $debug_file or default setting with \fIfile\fP for debugging output.
+NeoMutt keeps up to five debug logs
+.RI "({ " file " | $debug_file | " ~/.neomuttdebug " }[" 0 - 4 ])
+before removing the oldest file.
 .
 .TP
 .BI \-m " type"
@@ -454,8 +468,8 @@ locations.
 .
 .TP
 .IR "~/.neomuttdebug0"
-Default user debug log file. For further details see command line option
-\fB\-d\fP above.
+User's default debug log file. For further details or customising file path see
+command line options \fB\-d\fP and \fB\-l\fP above.
 .
 .TP
 .IR "/etc/mime.types"

--- a/doc/neomutt.man
+++ b/doc/neomutt.man
@@ -1,4 +1,5 @@
-.\" -*-nroff-*-
+'\" t
+.\" -*- nroff -*-
 .\"
 .\"
 .\"     Copyright (C) 1996-2016 Michael R. Elkins <me@cs.hmc.edu>
@@ -18,210 +19,511 @@
 .\"     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 .\"
 .TH neomutt 1 "@MAN_DATE@" Unix "User Manuals"
+.\" --------------------------------------------------------------------
 .SH NAME
-neomutt \- The NeoMutt Mail User Agent
+.\" --------------------------------------------------------------------
+neomutt \- The NeoMutt Mail User Agent (MUA)
+.
+.\" --------------------------------------------------------------------
 .SH SYNTAX
-.PP
-.B neomutt
-[\-GnRyzZ]
-[\-e \fIcmd\fP] [\-F \fIfile\fP] [\-g \fIserver\fP] [\-m \fItype\fP] [\-f \fIfile\fP]
-.PP
-.B neomutt
-[\-Enx]
-[\-e \fIcmd\fP]
-[\-F \fIfile\fP]
-[\-H \fIfile\fP]
-[\-i \fIfile\fP]
-[\-s \fIsubj\fP]
-[\-b \fIaddr\fP]
-[\-c \fIaddr\fP]
-[\-a \fIfile\fP [...] \-\-]
-\fIaddr|mailto_url\fP [...]
-.PP
-.B neomutt
-[\-nx]
-[\-e \fIcmd\fP]
-[\-F \fIfile\fP]
-[\-s \fIsubj\fP]
-[\-b \fIaddr\fP]
-[\-c \fIaddr\fP]
-[\-a \fIfile\fP [...] \-\-]
-\fIaddr|mailto_url\fP [...]
-< message
-.PP
-.B neomutt
-[\-n] [\-e \fIcmd\fP] [\-F \fIfile\fP] \-p
-.PP
-.B neomutt
-[\-n] [\-e \fIcmd\fP] [\-F \fIfile\fP] \-A \fIalias\fP
-.PP
-.B neomutt
-[\-n] [\-e \fIcmd\fP] [\-F \fIfile\fP] \-Q \fIquery\fP
-.PP
-.B neomutt
-\-v[v]
-.PP
-.B neomutt
-\-D [\-S]
+.\" --------------------------------------------------------------------
+.SY neomutt
+.OP \-GnRyZz
+.OP \-e command
+.OP \-F config
+.OP \-f mailbox
+.OP \-g server
+.OP \-m type
+.YS
+.
+.SY neomutt
+.OP \-Enx
+.OP \-e command
+.OP \-F config
+.OP \-H draft
+.OP \-i include
+.OP \-s subject
+.br
+.OP \-b address
+.OP \-c address
+.RB [ \-a
+.IR file " [" .\|.\|.\& ]
+.BR \-\- ]
+.IR address " [" .\|.\|.\& ]
+.YS
+.
+.SY neomutt
+.OP \-nx
+.OP \-e command
+.OP \-F config
+.OP \-s subject
+.OP \-b address
+.OP \-c address
+.br
+.RB [ \-a
+.IR file " [" .\|.\|.\& ]
+.BR \-\- ]
+.IR address " [" .\|.\|.\& "] < message"
+.YS
+.
+.SY neomutt
+.OP \-n
+.OP \-e command
+.OP \-F config
+.BI \-A " alias"
+.YS
+.
+.SY neomutt
+.OP \-n
+.OP \-e command
+.OP \-F config
+.BR \-B
+.YS
+.
+.SY neomutt
+.OP \-n
+.OP \-e command
+.OP \-F config
+.BR \-D " [" \-S ]
+.YS
+.
+.SY neomutt
+.OP \-n
+.OP \-e command
+.OP \-F config
+.BI \-p
+.YS
+.
+.SY neomutt
+.OP \-n
+.OP \-e command
+.OP \-F config
+.BI \-Q " variable"
+.YS
+.
+.SY neomutt
+.BR \-v [ v ]
+.YS
+.
+.\" --------------------------------------------------------------------
 .SH DESCRIPTION
+.\" --------------------------------------------------------------------
 .PP
-NeoMutt is a small but very powerful text based program for reading and sending electronic
-mail under unix operating systems, including support for color terminals, MIME,
-OpenPGP, and a threaded sorting mode.
+NeoMutt is a small but very powerful text based program for reading and sending
+electronic mail under Unix operating systems, including support for color
+terminals, MIME, OpenPGP, and a threaded sorting mode.
+.
 .PP
-.I Note:
-.IR
-This manual page gives a brief overview of NeoMutt's command line
-options. You should find a copy of the full manual in @MAN_DOCDIR@, in
-text, HTML, and/or PDF format.
+.B Note:
+This manual page gives a brief overview of NeoMutt's command line options. You
+should find a copy of the full manual in \fI@MAN_DOCDIR@\fP, in plain text,
+HTML, and/or PDF format.
+.
+.\" --------------------------------------------------------------------
 .SH OPTIONS
-.PP
-.IP "-A \fIalias\fP"
-An expanded version of the given alias is passed to stdout.
-.IP "-a \fIfile\fP [...]"
-Attach a file to your message using MIME.
-When attaching single or multiple files, separating filenames and recipient addresses with
-"\-\-" is mandatory, e.g. \fBneomutt \-a image.jpg \-\- addr1\fP or
-\fBneomutt \-a img.jpg *.png \-\- addr1 addr2\fP.
-The \-a option must be placed at the end of command line options.
-.IP "-b \fIaddress\fP"
-Specify a blind-carbon-copy (BCC) recipient
-.IP "-c \fIaddress\fP"
-Specify a carbon-copy (CC) recipient
-.IP "-d \fIlevel\fP"
-log debugging output to ~/.neomuttdebug0.
-\fILevel\fP can range from 1-5 and effects verbosity. A value of 2 is
-recommended.
-.IP "-D"
+.\" --------------------------------------------------------------------
+.TP
+.BI \-A " alias"
+An expanded version of the given \fIalias\fP is passed to stdout.
+.
+.TP
+.BI \-a " file \fR[\fP.\|.\|.\&\fR]\fP"
+Attach a \fIfile\fP to your message using MIME. When attaching single or
+multiple \fIfile\fPs, separating filenames and recipient addresses with
+\(lq\fB\-\-\fP\(rq is mandatory, e.g.:
+.RS
+.IP
+.EX
+.BI "neomutt \-a " "image.jpg " "\-\- " "address1 "
+.BI "neomutt \-a " "image.jpg *.png " "\-\- " "address1 address2 "
+.EE
+.RE
+.IP
+This \fB\-a\fP option must be placed at the end of command line options.
+.
+.TP
+.BI \-B
+Run in batch mode (do not start the ncurses UI).
+.
+.TP
+.BI \-b " address"
+Specify a blind-carbon-copy (BCC) recipient.
+.
+.TP
+.BI \-c " address"
+Specify a carbon-copy (CC) recipient.
+.
+.TP
+.BI \-D
 Print the value of all configuration options to stdout.
-.IP "-D -S"
-like -D but hide the value of sensitive variables
-.IP "-E"
-Causes the draft file specified by -H or include file specified by -i
-to be edited during message composition.
-.IP "-e \fIcommand\fP"
-Specify a configuration command to be run after processing of initialization
-files.
-.IP "-f \fImailbox\fP"
-Specify which mailbox to load.
-.IP "-F \fIneomuttrc\fP"
-Specify an initialization file to read instead of ~/.neomuttrc
-.IP "-g \fIserver\fP"
-Start NeoMutt with a listing of subscribed newsgroups at specified news server.
-.IP "-G"
+.
+.TP
+.BI \-D\ \-S
+Like \fB\-D\fP but hide the value of sensitive variables.
+.
+.TP
+.BI \-d " level"
+Log debugging output to file, by default to \fI~/.neomuttdebug0\fP, but see
+also configuration variables $debug_file and $debug_level in full manual. The
+\fIlevel\fP can range from 1\(em5 and affects verbosity. A value of 2 is
+recommended.
+.IP
+NeoMutt keeps up to five debug logs
+.RI ( ~/.neomuttdebug [ 0 - 4 ])
+before removing the oldest file on next invocation with this option.
+.
+.TP
+.BI \-E
+Edit the \fIdraft\fP (\fB\-H\fP) or \fIinclude\fP (\fB\-i\fP) file during
+message composition.
+.
+.TP
+.BI \-e " command"
+Specify a configuration \fIcommand\fP to be run after processing of
+initialization files.
+.
+.TP
+.BI \-F " config"
+Specify an alternative initialization file to read, see \fIFILES\fP section
+below for a list of regular configuration files.
+.
+.TP
+.BI \-f " mailbox"
+Specify which \fImailbox\fP to load.
+.
+.TP
+.BI \-G
 Start NeoMutt with a listing of subscribed newsgroups.
-.IP "-h"
+.
+.TP
+.BI \-g " server"
+Start NeoMutt with a listing of subscribed newsgroups at specified news
+\fIserver\fP.
+.
+.TP
+.BI \-H " draft"
+Specify a \fIdraft\fP file which contains header and body to use to send
+a message.
+.
+.TP
+.BI \-h
 Display help.
-.IP "-H \fIdraft\fP"
-Specify a draft file which contains header and body to use to send a
-message.
-.IP "-i \fIinclude\fP"
-Specify a file to include into the body of a message.
-.IP "-m \fItype\fP       "
-specify a default mailbox type for newly created folders.
-.IP "-n"
+.
+.TP
+.BI \-i " include"
+Specify a file to \fIinclude\fP into the body of a message.
+.
+.TP
+.BI \-m " type"
+Specify a default mailbox \fItype\fP for newly created folders.
+.
+.TP
+.BI \-n
 Causes NeoMutt to bypass the system configuration file.
-.IP "-p"
+.
+.TP
+.BI \-p
 Resume a postponed message.
-.IP "-Q \fIquery\fP"
-Query a configuration variables value.  The query is executed after
-all configuration files have been parsed, and any commands given on
-the command line have been executed.
-.IP "-R"
-Open a mailbox in \fIread-only\fP mode.
-.IP "-s \fIsubject\fP"
-Specify the subject of the message.
-.IP "-v"
+.
+.TP
+.BI \-Q " variable"
+Query a configuration \fIvariable\fP. The query is executed after all
+configuration files have been parsed, and any commands given on the command
+line have been executed.
+.
+.TP
+.BI \-R
+Open a mailbox in read-only mode.
+.
+.TP
+.BI \-s " subject"
+Specify the \fIsubject\fP of the message. Must be quoted when it contains
+spaces.
+.
+.TP
+.BI \-v
 Display the NeoMutt version number and compile-time definitions.
-.IP "-vv"
+.
+.TP
+.BI \-vv
 Display license and copyright information.
-.IP "-x"
+.
+.TP
+.BI \-x
 Emulate the mailx compose mode.
-.IP "-y"
-Start NeoMutt with a listing of all mailboxes specified by the \fImailboxes\fP
+.
+.TP
+.BI \-y
+Start NeoMutt with a listing of all mailboxes specified by the \fBmailboxes\fP
 command.
-.IP "-z"
-When used with \-f, causes NeoMutt not to start if there are no messages in the
-mailbox.
-.IP "-Z"
-Causes NeoMutt to open the first mailbox specified by the \fImailboxes\fP
+.
+.TP
+.BI \-Z
+Causes NeoMutt to open the first mailbox specified by the \fBmailboxes\fP
 command which contains new mail.
-.IP "--"
-Treat remaining arguments as \fIaddr\fP even if they start with a dash.
-See also "\-a" above.
+.
+.TP
+.BI \-z
+When used with option \fB\-f\fP, causes NeoMutt not to start if there are no
+messages in the mailbox.
+.
+.TP
+.BI \-\-
+Treat remaining arguments as \fIaddress\fP even if they start with a dash. See
+also option \fB\-a\fP above.
+.
+.\" --------------------------------------------------------------------
 .SH ENVIRONMENT
-.PP
-.IP "EDITOR"
-Specifies the editor to use if VISUAL is unset.
-.IP "EMAIL"
-The user's e-mail address.
-.IP "HOME"
+.\" --------------------------------------------------------------------
+.TP
+.SM
+.B EDITOR
+Specifies the editor to use if \fIVISUAL\fP is unset. Defaults to the \fBVi\fP
+editor if unset.
+.
+.TP
+.SM
+.B EGDSOCKET
+For OpenSSL since version 0.9.5, files, mentioned at \fIRANDFILE\fP below, can
+be Entropy Gathering Daemon (EGD) sockets. Also, and if exists,
+\fI~/.entropy\fP and \fI/tmp/entropy\fP will be used to initialize SSL library
+functions. Specified sockets must be owned by the user and have permission of
+600 (octal number representing).
+.
+.TP
+.SM
+.B EMAIL
+The user's email address.
+.
+.TP
+.SM
+.B HOME
 Full path of the user's home directory.
-.IP "MAIL"
+.
+.TP
+.SM
+.B MAIL
 Full path of the user's spool mailbox.
-.IP "MAILDIR"
-Full path of the user's spool mailbox if MAIL is unset.  Commonly used when the spool
-mailbox is a
-.B maildir (5)
+.
+.TP
+.SM
+.B MAILCAPS
+Path to search for mailcap files. If unset, a RFC1524 compliant search path
+that is extended with NeoMutt related paths (at position two and three):
+.\" .RS
+.\" .IP
+.RI \(dq \
+"$HOME/\:.mailcap" \:: \
+"@MAN_DATADIR@/\:mailcap" \:: \
+"@MAN_SYSCONFDIR@/\:mailcap" \:: \
+"/etc/\:mailcap" \:: \
+"/usr/\:etc/\:mailcap" \:: \
+"/usr/\:local/\:etc/\:mailcap" \(dq
+.\" .RE
+.\" .IP
+will be used instead.
+.
+.TP
+.SM
+.B MAILDIR
+Full path of the user's spool mailbox if \fIMAIL\fP is unset. Commonly used
+when the spool mailbox is a
+.BR maildir (5)
 folder.
-.IP "MAILCAPS"
-Path to search for mailcap files.
-.IP "MM_NOASK"
+.
+.TP
+.SM
+.B MM_NOASK
 If this variable is set, mailcap are always used without prompting first.
-.IP "PGPPATH"
-Directory in which the user's PGP public keyring can be found.  When used with
+.
+.TP
+.SM
+.B NNTPSERVER
+Similar to configuration variable $news_server, specifies the domain name or
+address of the default NNTP server to connect. If unset,
+\fI@MAN_SYSCONFDIR@/nntpserver\fP is used but can be overridden by command line
+option \fB\-g\fP.
+.
+.TP
+.SM
+.B PGPPATH
+Directory in which the user's PGP public keyring can be found. When used with
 the original PGP program, NeoMutt and
-.B pgpring (1)
+.BR pgpring (1)
 rely on this being set.
-.IP "TMPDIR"
-Directory in which temporary files are created.
-.IP "REPLYTO"
-Default Reply-To address.
-.IP "VISUAL"
+.
+.TP
+.SM
+.B RANDFILE
+Like configuration variable $entropy_file, defines a path to a file which
+includes random data that is used to initialize SSL library functions. If
+unset, \fI~/.rnd\fP is used. DO NOT store important data in the specified file.
+.
+.TP
+.SM
+.B REPLYTO
+When set, specifies the default Reply-To address.
+.
+.TP
+.SM
+.B TEXTDOMAINDIR
+Defines an absolute path corresponding to \fI@MAN_TEXTDOMAINDIR@\fP that will
+be recognised by GNU
+.BR gettext (1)
+and used for Native Language Support (NLS) if enabled.
+.
+.TP
+.SM
+.B TMPDIR
+Directory in which temporary files are created. Defaults to \fI/tmp\fP if
+unset. Configuration variable $tmpdir takes precedence over this one.
+.
+.TP
+.SM
+.B VISUAL
 Specifies the editor to use when composing messages.
+.
+.TP
+.SM
+.B XDG_CONFIG_DIRS
+Specifies a X Desktop Group (XDG) compliant location for the system-wide
+configuration file, as described in \fIFILES\fP section below. This variable
+defaults to \fI/etc/xdg\fP. Bypass loading with command line option \fB\-n\fP.
+.
+.TP
+.SM
+.B XDG_CONFIG_HOME
+Specifies a XDG compliant location for the user-specific configuration file, as
+described in \fIFILES\fP section below. This variable defaults to
+\fI$HOME/.config\fP. Can be overridden by command line option \fB\-F\fP.
+.
+.\" --------------------------------------------------------------------
 .SH FILES
+.\" --------------------------------------------------------------------
+.SS "\s-1Configuration files\s0"
+.\" --------------------------------------------------------------------
 .PP
-.IP "~/.neomuttrc or ~/.neomutt/neomuttrc"
-User configuration file.
-.IP "@MAN_SYSCONFDIR@/neomuttrc"
-System-wide configuration file.
-.IP "/tmp/neomuttXXXXXX"
-Temporary files created by NeoMutt.
-.IP "~/.mailcap"
-User definition for handling non-text MIME types.
-.IP "@MAN_SYSCONFDIR@/mailcap"
-System definition for handling non-text MIME types.
-.IP "~/.mime.types"
-User's personal mapping between MIME types and file extensions.
-.IP "@MAN_SYSCONFDIR@/mime.types"
-System mapping between MIME types and file extensions.
-.IP "@MAN_DOCDIR@/manual.txt"
-The NeoMutt manual.
+NeoMutt will read just the first found configuration file of system-wide and
+user-specific category, from the list below and in that order.
+.
+.PP
+But it allows building of a recursive configuration by using the \fBsource\fP
+command.
+.
+.PP
+.na
+.TS
+allbox tab(|);
+cb cb cb
+r li li .
+\0#N|system-wide|user-specific
+1|$XDG_CONFIG_DIRS/neomutt/neomuttrc|$XDG_CONFIG_HOME/neomutt/neomuttrc
+2|$XDG_CONFIG_DIRS/neomutt/Muttrc \fB*\fP\fR)\fP|$XDG_CONFIG_HOME/neomutt/muttrc
+3|@MAN_SYSCONFDIR@/neomuttrc|$XDG_CONFIG_HOME/mutt/neomuttrc
+4|@MAN_SYSCONFDIR@/Muttrc \fB*\fP\fR)\fP|$XDG_CONFIG_HOME/mutt/muttrc
+5|@MAN_DATADIR@/neomuttrc|~/.neomutt/neomuttrc
+6|@MAN_DATADIR@/Muttrc \fB*\fP\fR)\fP|~/.neomutt/muttrc
+.T&
+r c li .
+7|\(em|~/.mutt/neomuttrc
+8|\(em|~/.mutt/muttrc
+9|\(em|~/.neomuttrc
+10|\(em|~/.muttrc
+.T&
+l s s .
+\0\h'0m'\fB*\fP) Note the case of the filename
+.TE
+\p
+.ad
+.
+.SS "\s-1Other relevant files\s0"
+.\" --------------------------------------------------------------------
+.PP
+Unless otherwise stated, NeoMutt will process all grouped files in the order
+(from top to bottom) as they are specified in that listing.
+.
+.TP
+.IR "~/.mailcap"
+.TQ
+.IR "@MAN_SYSCONFDIR@/mailcap"
+User-specific and system-wide definitions for handling non-text MIME types,
+look at environment variable \fBMAILCAPS\fP above for additional search
+locations.
+.
+.TP
+.IR "~/.neomuttdebug0"
+Default user debug log file. For further details see command line option
+\fB\-d\fP above.
+.
+.TP
+.IR "/etc/mime.types"
+.TQ
+.IR "@MAN_SYSCONFDIR@/mime.types"
+.TQ
+.IR "@MAN_DATADIR@/mime.types"
+.TQ
+.IR "~/.mime.types"
+Description files for simple plain text mapping between MIME types and filename
+extensions. NeoMutt parses these files in the stated order while processing
+attachments to determine their MIME type.
+.
+.TP
+.IR "@MAN_DOCDIR@/manual." { html , pdf , txt }
+The full NeoMutt manual in HTML, PDF or plain text format.
+.
+.TP
+.IR "/tmp/neomutt-XXXX-XXXX-XXXX"
+Temporary files created by NeoMutt. For custom locations look at description of
+the environment variable \fBTMPDIR\fP above. Notice that the suffix
+\fI-XXXX-XXXX-XXXX\fP is just a placeholder for, e.g. hostname, user name/ID,
+process ID and/or other random data.
+.
+.\" --------------------------------------------------------------------
 .SH BUGS
+.\" --------------------------------------------------------------------
 .PP
-See https://github.com/neomutt/neomutt/issues
+See issue tracker at <https://github.com/neomutt/neomutt/issues>.
+.
+.\" --------------------------------------------------------------------
 .SH NO WARRANTIES
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-.SH SEE ALSO
+.\" --------------------------------------------------------------------
 .PP
+This program is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+.
+.\" --------------------------------------------------------------------
+.SH SEE ALSO
+.\"   - sorted by category and name
+.\" --------------------------------------------------------------------
+.PP
+.BR gettext (1),
+.BR msmtp (1),
+.BR notmuch (1),
+.BR pgpring (1),
+.BR sendmail (1),
+.BR smail (1),
+.BR RAND_egd (3),
 .BR curses (3),
+.BR ncurses (3),
 .BR mailcap (5),
 .BR maildir (5),
-.BR notmuch (1),
-.BR msmtp (1),
 .BR mbox (5),
-.BR neomuttrc (5),
-.BR ncurses (3),
-.BR sendmail (1),
-.BR smail (1).
+.BR neomuttrc (5).
+.
 .PP
-The NeoMutt Manual
-.PP
-NeoMutt home page: https://www.neomutt.org
+For further NeoMutt information:
+.RS 4
+.TP
+\(bu the full manual, see \fIFILES\fP section above
+.TQ
+\(bu the home page, <https://www.neomutt.org>
+.RE
+.
+.\" --------------------------------------------------------------------
 .SH AUTHOR
+.\" --------------------------------------------------------------------
 .PP
-Michael Elkins, and others.  Use <neomutt-devel@neomutt.org> to contact
-the developers.
+Michael Elkins, and others. Use <neomutt-devel@\:neomutt.org> to contact the
+developers.
+.

--- a/doc/neomutt.man
+++ b/doc/neomutt.man
@@ -147,11 +147,11 @@ Run in batch mode (do not start the ncurses UI).
 .
 .TP
 .BI \-b " address"
-Specify a blind-carbon-copy (BCC) recipient.
+Specify a blind-carbon-copy (Bcc) recipient.
 .
 .TP
 .BI \-c " address"
-Specify a carbon-copy (CC) recipient.
+Specify a carbon-copy (Cc) recipient.
 .
 .TP
 .BI \-D
@@ -207,7 +207,7 @@ a message.
 .
 .TP
 .BI \-h
-Display help.
+Display this help message.
 .
 .TP
 .BI \-i " include"
@@ -250,7 +250,9 @@ Display license and copyright information.
 .
 .TP
 .BI \-x
-Emulate the mailx compose mode.
+Simulate the
+.BR mailx (1)
+send mode.
 .
 .TP
 .BI \-y
@@ -498,6 +500,7 @@ A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 .\" --------------------------------------------------------------------
 .PP
 .BR gettext (1),
+.BR mailx (1),
 .BR msmtp (1),
 .BR notmuch (1),
 .BR pgpring (1),

--- a/doc/neomutt.man
+++ b/doc/neomutt.man
@@ -19,7 +19,7 @@
 .\"
 .TH neomutt 1 "January 2009" Unix "User Manuals"
 .SH NAME
-neomutt \- The Neomutt Mail User Agent
+neomutt \- The NeoMutt Mail User Agent
 .SH SYNTAX
 .PP
 .B neomutt
@@ -65,13 +65,13 @@ neomutt \- The Neomutt Mail User Agent
 \-D [\-S]
 .SH DESCRIPTION
 .PP
-Neomutt is a small but very powerful text based program for reading and sending electronic
+NeoMutt is a small but very powerful text based program for reading and sending electronic
 mail under unix operating systems, including support for color terminals, MIME,
 OpenPGP, and a threaded sorting mode.
 .PP
 .I Note:
 .IR
-This manual page gives a brief overview of neomutt's command line
+This manual page gives a brief overview of NeoMutt's command line
 options. You should find a copy of the full manual in @docdir@, in
 text, HTML, and/or PDF format.
 .SH OPTIONS
@@ -107,9 +107,9 @@ Specify which mailbox to load.
 .IP "-F \fIneomuttrc\fP"
 Specify an initialization file to read instead of ~/.neomuttrc
 .IP "-g \fIserver\fP"
-Start Neomutt with a listing of subscribed newsgroups at specified news server.
+Start NeoMutt with a listing of subscribed newsgroups at specified news server.
 .IP "-G"
-Start Neomutt with a listing of subscribed newsgroups.
+Start NeoMutt with a listing of subscribed newsgroups.
 .IP "-h"
 Display help.
 .IP "-H \fIdraft\fP"
@@ -120,7 +120,7 @@ Specify a file to include into the body of a message.
 .IP "-m \fItype\fP       "
 specify a default mailbox type for newly created folders.
 .IP "-n"
-Causes Neomutt to bypass the system configuration file.
+Causes NeoMutt to bypass the system configuration file.
 .IP "-p"
 Resume a postponed message.
 .IP "-Q \fIquery\fP"
@@ -132,19 +132,19 @@ Open a mailbox in \fIread-only\fP mode.
 .IP "-s \fIsubject\fP"
 Specify the subject of the message.
 .IP "-v"
-Display the Neomutt version number and compile-time definitions.
+Display the NeoMutt version number and compile-time definitions.
 .IP "-vv"
 Display license and copyright information.
 .IP "-x"
 Emulate the mailx compose mode.
 .IP "-y"
-Start Neomutt with a listing of all mailboxes specified by the \fImailboxes\fP
+Start NeoMutt with a listing of all mailboxes specified by the \fImailboxes\fP
 command.
 .IP "-z"
-When used with \-f, causes Neomutt not to start if there are no messages in the
+When used with \-f, causes NeoMutt not to start if there are no messages in the
 mailbox.
 .IP "-Z"
-Causes Neomutt to open the first mailbox specified by the \fImailboxes\fP
+Causes NeoMutt to open the first mailbox specified by the \fImailboxes\fP
 command which contains new mail.
 .IP "--"
 Treat remaining arguments as \fIaddr\fP even if they start with a dash.
@@ -170,7 +170,7 @@ Path to search for mailcap files.
 If this variable is set, mailcap are always used without prompting first.
 .IP "PGPPATH"
 Directory in which the user's PGP public keyring can be found.  When used with
-the original PGP program, neomutt and
+the original PGP program, NeoMutt and
 .B pgpring (1)
 rely on this being set.
 .IP "TMPDIR"
@@ -186,7 +186,7 @@ User configuration file.
 .IP "@sysconfdir@/neomuttrc"
 System-wide configuration file.
 .IP "/tmp/neomuttXXXXXX"
-Temporary files created by Neomutt.
+Temporary files created by NeoMutt.
 .IP "~/.mailcap"
 User definition for handling non-text MIME types.
 .IP "@sysconfdir@/mailcap"
@@ -196,7 +196,7 @@ User's personal mapping between MIME types and file extensions.
 .IP "@sysconfdir@/mime.types"
 System mapping between MIME types and file extensions.
 .IP "@docdir@/manual.txt"
-The Neomutt manual.
+The NeoMutt manual.
 .SH BUGS
 .PP
 See https://github.com/neomutt/neomutt/issues
@@ -218,9 +218,9 @@ GNU General Public License for more details.
 .BR sendmail (1),
 .BR smail (1).
 .PP
-Neomutt Home Page: https://www.neomutt.org
+The NeoMutt Manual
 .PP
-The Neomutt manual
+NeoMutt home page: https://www.neomutt.org
 .SH AUTHOR
 .PP
 Michael Elkins, and others.  Use <neomutt-devel@neomutt.org> to contact

--- a/doc/neomutt.man
+++ b/doc/neomutt.man
@@ -17,7 +17,7 @@
 .\"     along with this program; if not, write to the Free Software
 .\"     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 .\"
-.TH neomutt 1 "@TS_MAN_MAIN@" Unix "User Manuals"
+.TH neomutt 1 "@MAN_DATE@" Unix "User Manuals"
 .SH NAME
 neomutt \- The NeoMutt Mail User Agent
 .SH SYNTAX

--- a/doc/neomutt.man
+++ b/doc/neomutt.man
@@ -535,9 +535,9 @@ A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 .
 .\" --------------------------------------------------------------------
 .SH SEE ALSO
-.\"   - sorted by category and name
 .\" --------------------------------------------------------------------
 .PP
+.\" sorted by category and name
 .BR gettext (1),
 .BR mailx (1),
 .BR msmtp (1),

--- a/doc/neomutt.man
+++ b/doc/neomutt.man
@@ -17,7 +17,7 @@
 .\"     along with this program; if not, write to the Free Software
 .\"     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 .\"
-.TH neomutt 1 "January 2009" Unix "User Manuals"
+.TH neomutt 1 "@TS_MAN_MAIN@" Unix "User Manuals"
 .SH NAME
 neomutt \- The NeoMutt Mail User Agent
 .SH SYNTAX

--- a/doc/neomutt.man
+++ b/doc/neomutt.man
@@ -72,7 +72,7 @@ OpenPGP, and a threaded sorting mode.
 .I Note:
 .IR
 This manual page gives a brief overview of NeoMutt's command line
-options. You should find a copy of the full manual in @docdir@, in
+options. You should find a copy of the full manual in @MAN_DOCDIR@, in
 text, HTML, and/or PDF format.
 .SH OPTIONS
 .PP
@@ -183,19 +183,19 @@ Specifies the editor to use when composing messages.
 .PP
 .IP "~/.neomuttrc or ~/.neomutt/neomuttrc"
 User configuration file.
-.IP "@sysconfdir@/neomuttrc"
+.IP "@MAN_SYSCONFDIR@/neomuttrc"
 System-wide configuration file.
 .IP "/tmp/neomuttXXXXXX"
 Temporary files created by NeoMutt.
 .IP "~/.mailcap"
 User definition for handling non-text MIME types.
-.IP "@sysconfdir@/mailcap"
+.IP "@MAN_SYSCONFDIR@/mailcap"
 System definition for handling non-text MIME types.
 .IP "~/.mime.types"
 User's personal mapping between MIME types and file extensions.
-.IP "@sysconfdir@/mime.types"
+.IP "@MAN_SYSCONFDIR@/mime.types"
 System mapping between MIME types and file extensions.
-.IP "@docdir@/manual.txt"
+.IP "@MAN_DOCDIR@/manual.txt"
 The NeoMutt manual.
 .SH BUGS
 .PP

--- a/doc/neomuttrc.man.head
+++ b/doc/neomuttrc.man.head
@@ -1,5 +1,5 @@
 '\" t
-.\" -*-nroff-*-
+.\" -*- nroff -*-
 .\"
 .\"     Copyright (C) 1996-2000 Michael R. Elkins <me@cs.hmc.edu>
 .\"     Copyright (C) 1999-2000 Thomas Roessler <roessler@does-not-exist.org>
@@ -27,120 +27,135 @@
 .fi
 ..
 .TH neomuttrc 5 "@MAN_DATE@" Unix "User Manuals"
+.\" --------------------------------------------------------------------
 .SH NAME
-neomuttrc \- Configuration file for the NeoMutt Mail User Agent
+.\" --------------------------------------------------------------------
+neomuttrc \- Configuration file for the NeoMutt Mail User Agent (MUA)
+.
+.\" --------------------------------------------------------------------
 .SH DESCRIPTION
+.\" --------------------------------------------------------------------
 .PP
-A NeoMutt configuration file consists of a series of \(lqcommands\(rq.
-Each line of the file may contain one or more commands.  When
-multiple commands are used, they must be separated by a semicolon
-(\(lq\fB;\fP\(rq).
+A NeoMutt configuration file consists of a series of \(lqcommands\(rq. Each
+line of the file may contain one or more commands. When multiple commands are
+used, they must be separated by a semicolon (\(lq\fB;\fP\(rq).
+.
 .PP
-The hash mark, or pound sign (\(lq\fB#\fP\(rq), is used as a
-\(lqcomment\(rq character. You can use it to annotate your
-initialization file. All text after the comment character to the end
-of the line is ignored.
+The hash mark, or pound sign (\(lq\fB#\fP\(rq), is used as a \(lqcomment\(rq
+character. You can use it to annotate your initialization file. All text after
+the comment character to the end of the line is ignored.
+.
 .PP
-Single quotes (\(lq\fB'\fP\(rq) and double quotes (\(lq\fB"\fP\(rq)
-can be used to quote strings which contain spaces or other special
-characters.  The difference between the two types of quotes is
-similar to that of many popular shell programs, namely that a single
-quote is used to specify a literal string (one that is not
-interpreted for shell variables or quoting with a backslash [see
-next paragraph]), while double quotes indicate a string which
-should be evaluated.  For example, backticks are evaluated inside of
-double quotes, but not single quotes.
+Single quotes (\(lq\fB\(aq\fP\(rq) and double quotes (\(lq\fB\(dq\fP\(rq) can
+be used to quote strings which contain spaces or other special characters. The
+difference between the two types of quotes is similar to that of many popular
+shell programs, namely that a single quote is used to specify a literal string
+(one that is not interpreted for shell variables or quoting with a backslash
+[see next paragraph]), while double quotes indicate a string which should be
+evaluated. For example, backticks are evaluated inside of double quotes, but
+not single quotes.
+.
 .PP
-\fB\(rs\fP quotes the next character, just as in shells such as bash and zsh.
-For example, if want to put quotes (\(lq\fB"\fP\(rq) inside of a
-string, you can use \(lq\fB\(rs\fP\(rq to force the next character
-to be a literal instead of interpreted character.
+\(lq\fB\(rs\fP\(rq quotes the next character, just as in shells such as Bash
+and Zsh. For example, if you want to put quotes (\(lq\fB\(dq\fP\(rq) inside of
+a string, you can use \(lq\fB\(rs\fP\(rq to force the next character to be
+a literal instead of interpreted character.
+.
 .PP
 \(lq\fB\(rs\(rs\fP\(rq means to insert a literal \(lq\fB\(rs\fP\(rq into the
-line.  \(lq\fB\(rsn\fP\(rq and \(lq\fB\(rsr\fP\(rq have their usual
-C meanings of linefeed and carriage-return, respectively.
+line. \(lq\fB\(rsn\fP\(rq and \(lq\fB\(rsr\fP\(rq have their usual C meanings
+of line feed (LF) and carriage return (CR), respectively.
+.
 .PP
 A \(lq\fB\(rs\fP\(rq at the end of a line can be used to split commands over
-multiple lines, provided that the split points don't appear in the
-middle of command names.
+multiple lines, provided that the split points don't appear in the middle of
+command names.
+.
 .PP
 It is also possible to substitute the output of a Unix command in an
-initialization file.  This is accomplished by enclosing the command
-in backticks (\fB`\fP\fIcommand\fP\fB`\fP).
+initialization file. This is accomplished by enclosing the command in backticks
+(\fB\(ga\fP\fIcommand\fP\fB\(ga\fP).
+.
 .PP
-UNIX environment variables can be accessed like the way it is done in shells
-like sh and bash: Prepend the name of the variable by a dollar
+Unix environment variables can be accessed like the way it is done in shells
+like sh and Bash: Prepend the name of the variable by a dollar
 (\(lq\fB\(Do\fP\(rq) sign.
-.PP
+.
+.\" --------------------------------------------------------------------
 .SH COMMANDS
+.\" --------------------------------------------------------------------
+.SS "\s-1Configuration Commands\s0"
+.\" --------------------------------------------------------------------
+.PP
+The following are the commands understood by NeoMutt:
+.
 .PP
 .nf
-\fBaccount-hook\fP [\fB!\fP]\fIregex\fP \fIcommand\fP
+\fBaccount-hook\fP \fIregex\fP \fIcommand\fP
 .fi
 .IP
-This hook is executed whenever you access a remote mailbox. Useful
-to adjust configuration settings to different IMAP or POP servers.
+This hook is executed whenever you access a remote mailbox. Useful to adjust
+configuration settings to different IMAP or POP servers.
+.
 .PP
 .nf
-\fBalias\fP [\fB-group\fP \fIname\fP [...]] \fIkey\fP \fIaddress\fP [\fB,\fP \fIaddress\fP [ ... ]]
-\fBunalias\fP [ \fB*\fP | \fIkey\fP ]
+\fBalias\fP [ \fB\-group\fP \fIname\fP ... ] \fIkey\fP \fIaddress\fP [\fB,\fP \fIaddress\fP ... ]
+\fBunalias\fP [ \fB\-group\fP \fIname\fP ... ] { \fB*\fP | \fIkey\fP ... }
 .fi
 .IP
-\fBalias\fP defines an alias \fIkey\fP for the given addresses. Each
-\fIaddress\fP will be resolved into either an email address (user@example.com)
-or a named email address (User Name <user@example.com>). The address may be specified in either format, or in the format \(lquser@example.com (User
-Name)\(rq.
-\fBunalias\fP removes the alias corresponding to the given \fIkey\fP or
-all aliases when \(lq\fB*\fP\(rq is used as an argument. The optional
-\fB-group\fP argument to \fBalias\fP causes the aliased address(es) to be
-added to the named \fIgroup\fP.
+\fBalias\fP defines a surrogate \fIkey\fP for the given address(es). Each
+\fIaddress\fP will be resolved into either an email address
+(user@\:example.com) or a named email address (User Name <user@\:example.com>).
+The address may be specified in either format, or in the format
+\(lquser@\:example.com (User Name)\(rq.
+.IP
+\fBNote\fP: If you want to create an alias for more than one address, you
+\fBmust\fP separate the addresses with a comma (\(lq\fB,\fP\(rq).
+.IP
+\fBunalias\fP removes the alias corresponding to the given \fIkey\fP or all
+aliases when \(lq\fB*\fP\(rq is used as an argument.
+.IP
+The optional \fB\-group\fP flag causes the address(es) to be added to or
+removed from the \fIname\fPd group.
+.
 .PP
 .nf
-\fBalternates\fP [\fB-group\fP \fIname\fP] \fIregex\fP [ \fIregex\fP [ ... ]]
-\fBunalternates\fP [ \fB*\fP | \fIregex\fP [ \fIregex\fP [ ... ]] ]
+\fBalternates\fP [ \fB\-group\fP \fIname\fP ... ] \fIregex\fP [ \fIregex\fP ... ]
+\fBunalternates\fP [ \fB\-group\fP \fIname\fP ... ] { \fB*\fP | \fIregex\fP ... }
 .fi
 .IP
-\fBalternates\fP is used to inform NeoMutt about alternate addresses
-where you receive mail; you can use regular expressions to specify
-alternate addresses.  This affects NeoMutt's idea about messages
-from you, and messages addressed to you.  \fBunalternates\fP removes
-a regular expression from the list of known alternates. The \fB-group\fP flag
-causes all of the subsequent regular expressions to be added to the named group.
+\fBalternates\fP is used to inform NeoMutt about alternate addresses where you
+receive mail; you can use regular expressions (\fIregex\fP) to specify
+alternate addresses. This affects NeoMutt's idea about messages from you, and
+messages addressed to you.
+.IP
+\fBunalternates\fP can be used to write exceptions to alternates patterns. To
+remove a regular expression from the alternates list, use the unalternates
+command with exactly the same \fIregex\fP or use \(lq\fB*\fP\(rq to remove all
+entries.
+.IP
+The optional \fB\-group\fP flag causes all of the subsequent regular expressions
+to be added to or removed from the \fIname\fPd group.
+.
 .PP
 .nf
-\fBalternative_order\fP \fImime-type\fP[\fB/\fP\fImime-subtype\fP] [ \fImime-type\fP[\fB/\fP\fImime-subtype\fP] ... ]
-\fBunalternative_order\fP [ \fB*\fP | \fImime-type\fP[\fB/\fP\fImime-subtype\fP] ... ]
+\fBalternative_order\fP \fImime-type\fP[/\fImime-subtype\fP] [ \fImime-type\fP[/\fImime-subtype\fP] ... ]
+\fBunalternative_order\fP { \fB*\fP | \fImime-type\fP[/\fImime-subtype\fP] ... }
 .fi
 .IP
-\fBalternative_order\fP command permits you to define an order of preference which is
-used by NeoMutt to determine which part of a
-\fBmultipart/alternative\fP body to display.
-A subtype of \(lq\fB*\fP\(rq matches any subtype, as does an empty
-subtype.   \fBunalternative_order\fP removes entries from the
-ordered list or deletes the entire list when \(lq\fB*\fP\(rq is used
-as an argument.
-.PP
-.nf
-\fBappend-hook\fP \fIregex\fP "\fIcommand\fP"
-\fBclose-hook\fP \fIregex\fP "\fIcommand\fP"
-\fBopen-hook\fP \fIregex\fP "\fIcommand\fP"
-.fi
+\fBalternative_order\fP command permits you to define an order of preference
+that is used by NeoMutt to determine which part of
+a \fBmultipart/\:alternative\fP body to display. A \fImime-subtype\fP of
+\(lq\fB*\fP\(rq matches any \fBmultipart/\:alternative\fP subtype, as does an
+empty \fImime-subtype\fP.
 .IP
-These commands provide a way to handle compressed folders. The given
-\fBregex\fP specifies which folders are taken as compressed (e.g.
-"\fI\\\\.gz$\fP"). The commands tell NeoMutt how to uncompress a folder
-(\fBopen-hook\fP), compress a folder (\fBclose-hook\fP) or append a
-compressed mail to a compressed folder (\fBappend-hook\fP). The
-\fIcommand\fP string is the
-.BR printf (3)
-like format string, and it should accept two parameters: \fB%f\fP,
-which is replaced with the (compressed) folder name, and \fB%t\fP
-which is replaced with the name of the temporary folder to which to
-write.
+\fBunalternative_order\fP removes entries from the ordered list or deletes the
+entire list when \(lq\fB*\fP\(rq is used as an argument.
+.
 .PP
 .nf
-\fBattachments\fP [ \fB+\fP | \fB-\fP ]\fIdisposition\fP \fImime-type\fP
-\fBunattachments\fP [ \fB+\fP | \fB-\fP ]\fIdisposition\fP \fImime-type\fP
+\fBattachments\fP { \fB+\fP | \fB\-\fP }\fIdisposition\fP \fImime-type\fP
+\fBunattachments\fP { \fB+\fP | \fB\-\fP }\fIdisposition\fP \fImime-type\fP
 .fi
 .IP
 You can make your message index display the number of qualifying attachments in
@@ -154,175 +169,245 @@ inline or attachment. You can abbreviate this to \fBI\fP or \fBA\fP.
 \fImime-type\fP is the MIME type of the attachment you want the command to
 affect. A MIME type is always of the format \fBmajor/minor\fP. The major part
 of \fImime-type\fP must be literal text (or the special token \(lq\fB*\fP\(rq,
-but the minor part may be a regular expression. (Therefore, \(lq\fB*/.*\fP\(rq
-matches any MIME type.)
+but the minor part may be a regular expression. Therefore, \(lq\fB*/.*\fP\(rq
+matches any MIME type.
+.
 .PP
 .nf
 \fBauto_view\fP \fImime-type\fP[\fB/\fP\fImime-subtype\fP] [ \fImime-type\fP[\fB/\fP\fImime-subtype\fP] ... ]
-\fBunauto_view\fP [ \fB*\fP | \fImime-type\fP[\fB/\fP\fImime-subtype\fP] ... ]
+\fBunauto_view\fP { \fB*\fP | \fImime-type\fP[\fB/\fP\fImime-subtype\fP] ... }
 .fi
 .IP
-This commands permits you to specify that NeoMutt should automatically
-convert the given MIME types to text/plain when displaying messages.
-For this to work, there must be a
+This commands permits you to specify that NeoMutt should automatically convert
+the given \fImime-type\fPs to text/plain when displaying messages. For this to work,
+there must be a
 .BR mailcap (5)
-entry for the given MIME type with the
-.B copiousoutput
-flag set.  A subtype of \(lq\fB*\fP\(rq
-matches any subtype, as does an empty subtype.
+entry for the given \fImime-type\fP with the \fBcopiousoutput\fP option set.
+A \fImime-subtype\fP of \(lq\fB*\fP\(rq matches any
+\fBmultipart/\:alternative\fP subtype, as does an empty \fImime-subtype\fP.
+.
 .PP
 .nf
-\fBbind\fP \fImenu1,menu2,...\fP \fIkey\fP \fIfunction\fP
+\fBbind\fP \fImap\fP[\fB,\fP\fImap\fP ... ] \fIkey\fP \fIfunction\fP
 .fi
 .IP
-This command binds the given \fIkey\fP for the given \fImenu\fP or \fImenu\fPs
-to the given \fIfunction\fP. Multiple menus may be specified by
-separating them with commas (no whitespace is allowed).
+This command allows you to change the default or define additional key bindings
+(operation invoked when pressing a key).
 .IP
-Valid maps are:
-.BR generic ", " alias ", " attach ", "
-.BR browser ", " editor ", "
-.BR index ", " compose ", "
-.BR pager ", " pgp ", " postpone ", "
-.BR mix .
+\fImap\fP specifies in which menu the binding belongs. Multiple \fImap\fPs may
+be specified by separating them with commas (no additional whitespace is
+allowed). The currently defined \fImap\fPs are:
+.BR alias ", " attach ", " browser ", " compose ", " editor ", " generic ", "
+.BR index ", " mix ", " pager ", " pgp ", " postpone ", " query " and " smime "."
 .IP
-For more information on keys and functions, please consult the NeoMutt
-Manual. Note that the function name is to be specified without
-angle brackets.
+\fIkey\fP is the key (or key sequence) you wish to bind, e.g.
+\(lq\fB\(rsCa\fP\(rq for control-A. In addition, \fIkey\fP may be specified as
+a three digit octal number prefixed with a \(lq\fB\(rs\fP\(rq or as a symbolic
+name. The \fB<what-key>\fP function can be used to explore keycode and
+symbolic names for the keys on your keyboard.
+.IP
+\fIfunction\fP specifies which action to take when key is pressed. Note that
+the function name is to be specified without angle brackets.
+.IP
+For more information on keys and functions, please consult the NeoMutt manual.
+.
 .PP
 .nf
 \fBcharset-hook\fP \fIalias\fP \fIcharset\fP
+\fBiconv-hook\fP \fIcharset\fP \fIlocal-charset\fP
 .fi
 .IP
-This command defines an alias for a character set.  This is useful
-to properly display messages which are tagged with a character set
-name not known to NeoMutt.
+\fBcharset-hook\fP defines an \fIalias\fP for a character set. This is useful to
+properly display messages which are tagged with a character set name not known
+to NeoMutt.
+.IP
+\fBiconv-hook\fP defines a system-specific name for a character set. This is
+useful when your system's
+.BR iconv (3)
+implementation does not understand MIME character set names (such as
+\fBiso-8859-1\fP), but instead insists on being fed with
+implementation-specific character set names (such as \fB8859-1\fP). In this
+specific case, you'd put \(lq\fBiconv-hook\fP\~iso-8859-1\~8859-1\(rq into your
+configuration file.
+.
 .PP
 .nf
-\fBcolor\fP \fIobject\fP \fIforeground\fP \fIbackground\fP [ \fIregex\fP ]
-\fBcolor\fP index \fIforeground\fP \fIbackground\fP [ \fIpattern\fP ]
-\fBuncolor\fP index \fIpattern\fP [ \fIpattern\fP ... ]
+\fBcolor\fP \fIobject\fP \fIforeground\fP \fIbackground\fP
+\fBcolor\fP { header | body } \fIforeground\fP \fIbackground\fP \fIregex\fP
+\fBcolor\fP index-object \fIforeground\fP \fIbackground\fP \fIpattern\fP
+\fBcolor\fP compose \fIcomposeobject\fP \fIforeground\fP \fIbackground\fP
+\fBuncolor\fP { index-object | header | body } { \fB*\fP | \fIpattern\fP ... }
 .fi
 .IP
-If your terminal supports color, these commands can be used to
-assign \fIforeground\fP/\fIbackground\fP combinations to certain
-objects.  Valid objects are:
-.BR attachment ", " body ", " bold ", " error ", " header ", "
-.BR hdrdefault ", " index ", " indicator ", " markers ", "
-.BR message ", " normal ", " prompt ", " quoted ", " quoted\fIN\fP ", "
-.BR search ", " signature ", " status ", " tilde ", " tree ", "
-.BR underline .
-If the sidebar is enabled the following objects are also valid:
-.BR sidebar_divider ", " sidebar_flagged ", " sidebar_highlight ", "
-.BR sidebar_indicator ", " sidebar_new ", " sidebar_spoolfile .
-The
-.BR body " and " header
-objects allow you to restrict the colorization to a regular
-expression.  The \fBindex\fP object permits you to select colored
+If your terminal supports color, these commands can be used to assign
+\fIforeground\fP/\:\fIbackground\fP combinations to certain \fIobject\fPs. The
+currently defined \fIobject\fPs are:
+.BR attach_\:headers ", "
+.BR attachment ", "
+.BR body ", "
+.BR bold ", "
+.BR error ", "
+.BR hdrdefault ", "
+.BR header ", "
+.BR index ", "
+.BR index_\:author ", "
+.BR index_\:collapsed ", "
+.BR index_\:date ", "
+.BR index_\:flags ", "
+.BR index_\:label ", "
+.BR index_\:number ", "
+.BR index_\:size ", "
+.BR index_\:subject ", "
+.BR index_\:tag ", "
+.BR index_\:tags ", "
+.BR indicator ", "
+.BR markers ", "
+.BR message ", "
+.BR normal ", "
+.BR progress ", "
+.BR prompt ", "
+.BR quoted ", "
+.BR quoted\fIN\fP ", "
+.BR search ", "
+.BR signature ", "
+.BR status ", "
+.BR tilde ", "
+.BR tree ", "
+.BR underline "."
+.IP
+If the sidebar is enabled the following \fIobject\fPs are also valid:
+.BR sidebar_\:divider ", "
+.BR sidebar_\:flagged ", "
+.BR sidebar_\:highlight ", "
+.BR sidebar_\:indicator ", "
+.BR sidebar_\:new ", "
+.BR sidebar_\:ordinary ", "
+.BR sidebar_\:spoolfile "."
+.IP
+The \fBbody\fP and \fBheader\fP objects allow you to restrict the colorization
+to a regular expression. The \fBindex-object\fP permits you to select colored
 messages by pattern.
 .IP
+The \fBheader\fP and \fBbody\fP match \fIregex\fP in the header/body of
+a message, \fBindex-object\fP can match \fIpattern\fP in the message index.
+Note that IMAP server-side searches (=b, =B, =h) are not supported for color
+index patterns.
+.IP
 Valid colors include:
-.BR white ", " black ", " green ", " magenta ", " blue ", "
-.BR cyan ", " yellow ", " red ", " default ", " color\fIN\fP .
+.BR default ", "
+.BR black ", "
+.BR red ", "
+.BR green ", "
+.BR yellow ", "
+.BR blue ", "
+.BR magenta ", "
+.BR cyan ", "
+.BR white ", "
+.BR color\fIN\fP "."
+.IP
+The \fBuncolor\fP command can be applied to the index, header and body objects
+only. It removes entries from the list. You must specify the same \fIpattern\fP
+specified in the \fBcolor\fP command for it to be removed. The pattern
+\(lq\fB*\fP\(rq is a special token which means to clear the color list of all
+entries.
+.IP
+For further information on colorization, please consult the NeoMutt manual.
+.
 .PP
 .nf
-\fBcrypt-hook\fP \fIregex\fP \fIkey-id\fP
+\fBcrypt-hook\fP \fIregex\fP \fIkeyid\fP
 .fi
 .IP
-The crypt-hook command provides a method by which you can
-specify the ID of the public key to be used when encrypting messages
-to a certain recipient.  The meaning of \fIkey-id\fP is to be taken
-broadly: This can be a different e-mail address, a numerical \fIkey-id\fP,
-or even just an arbitrary search string.
-You may use multiple
-\fBcrypt-hook\fPs with the same \fIregex\fP; multiple matching
-\fBcrypt-hook\fPs result in the use of multiple \fIkey-id\fPs for
-a recipient.
+The crypt-hook command provides a method by which you can specify the ID of the
+public key to be used when encrypting messages to a certain recipient. The
+meaning of \fIkeyid\fP is to be taken broadly: This can be a different email
+address, a numerical \fIkeyid\fP, or even just an arbitrary search string. You
+may use multiple \fBcrypt-hook\fPs with the same \fIregex\fP; multiple matching
+\fBcrypt-hook\fPs result in the use of multiple \fIkeyid\fPs for a recipient.
+.
 .PP
 .nf
 \fBexec\fP \fIfunction\fP [ \fIfunction\fP ... ]
-.ni
-.IP
-This command can be used to execute any function. Functions are listed in the
-function reference.
-.IP
-\(lq\fBexec\fP \fIfunction\fP\(rq is equivalent to \(lq\fBpush <\fP\fIfunction\fP\fB>\fP\(rq.
-.PP
-.nf
-\fBfcc-hook\fP [\fB!\fP]\fIpattern\fP \fIfilename\fP
-\fBsave-hook\fP [\fB!\fP]\fIpattern\fP \fIfilename\fP
-\fBfcc-save-hook\fP [\fB!\fP]\fIpattern\fP \fIfilename\fP
-.ni
-.IP
-\fBfcc-hook\fP: When an outgoing message matches \fIpattern\fP, the default file
-name for storing a copy (fcc) will be the given \fIfilename\fP.
-.IP
-\fBsave-hook\fP: When a message matches \fIpattern\fP, the default file name when
-saving it will be the given \fIfilename\fP.
-.IP
-\fBfcc-save-hook\fP: This command is an abbreviation for identical \fBfcc-hook\fP and
-\fBsave-hook\fP commands.
-.PP
-.nf
-\fBfolder-hook\fP [\fB!\fP]\fIregex\fP \fIcommand\fP
 .fi
 .IP
-When NeoMutt enters a folder which matches \fIregex\fP (or, when
-\fIregex\fP is preceded by an exclamation mark, does not match
-\fIregex\fP), the given \fIcommand\fP is executed.
-.IP
-When several \fBfolder-hook\fPs match a given mail folder, they are
-executed in the order given in the configuration file.
+This command can be used to execute any \fIfunction\fP. Functions are listed in
+the function reference. \(lq\fBexec\fP \fIfunction\fP\(rq is equivalent to
+\(lq\fBpush\fP <\fIfunction\fP>\(rq.
+.
 .PP
 .nf
-\fBgroup\fP [\fB-group\fP \fIname\fP] [\fB-rx\fP \fIEXPR\fP [ \fI...\fP ]] [\fB-addr\fP \fIaddress\fP [ \fI...\fP ]]
-\fBungroup\fP [\fB-group\fP \fIname\fP ] [ \fB*\fP | [[\fB-rx\fP \fIEXPR\fP [ \fI...\fP ]] [\fB-addr\fP \fIaddress\fP [ \fI...\fP ]]]
+\fBfcc-save-hook\fP \fIpattern\fP \fImailbox\fP
+\fBfcc-hook\fP \fIpattern\fP \fImailbox\fP
+\fBsave-hook\fP \fIpattern\fP \fImailbox\fP
+.fi
+.IP
+\fBfcc-save-hook\fP is a shortcut, equivalent to doing both a \fBfcc-hook\fP
+and a \fBsave-hook\fP with its arguments, including %-expansion on
+\fImailbox\fP according to $index_format.
+.IP
+\fBfcc-hook\fP is used to save outgoing mail in a mailbox other than $record.
+NeoMutt searches the initial list of message recipients for the first matching
+\fIpattern\fP and uses \fImailbox\fP as the default \(lqFcc:\(rq mailbox. If no
+match is found the message will be saved to $record mailbox.
+.IP
+\fBsave-hook\fP is used to override the default mailbox used when saving
+messages. \fImailbox\fP will be used as the default if the message matches
+\fIpattern\fP.
+.IP
+To provide more flexibility and good defaults, NeoMutt applies the expandos of
+$index_format to \fImailbox\fP after it was expanded. See \fIPATTERNS\fP
+section below or consult section \(lq\fBMessage Matching in Hooks\fP\(rq in
+NeoMutt manual for information on the exact format of \fIpattern\fP.
+.
+.PP
+.nf
+\fBfolder-hook\fP \fIregex\fP \fIcommand\fP
+.fi
+.IP
+When NeoMutt enters a folder which matches \fIregex\fP (or, when \fIregex\fP is
+preceded by an exclamation mark, does not match \fIregex\fP), the given
+\fIcommand\fP is executed.
+.IP
+When several \fBfolder-hook\fPs match a given mail folder, they are executed in
+the order given in the configuration file.
+.
+.PP
+.nf
+\fBgroup\fP [ \fB\-group\fP \fIname\fP ... ] { \fB\-rx\fP \fIexpr\fP ... | \fB\-addr\fP \fIaddress\fP ... }
+\fBungroup\fP [ \fB\-group\fP \fIname\fP ... ] { \fB*\fP | \fB\-rx\fP \fIexpr\fP ... | \fB\-addr\fP \fIaddress\fP ... }
 .fi
 .IP
 \fBgroup\fP is used to directly add either addresses or regular expressions to
 the specified group or groups. The different categories of arguments to the
-\fBgroup\fP command can be in any order. The flags \fI-rx\fP and \fI-addr\fP
+\fBgroup\fP command can be in any order. The flags \fB\-rx\fP and \fB\-addr\fP
 specify what the following strings (that cannot begin with a hyphen) should be
 interpreted as: either a regular expression or an email address, respectively.
+.IP
 \fBungroup\fP is used to remove addresses or regular expressions from the
 specified group or groups. The syntax is similar to the \fBgroup\fP command,
 however the special character \(lq\fB*\fP\(rq can be used to empty a group of
 all of its contents.
 .IP
-These address groups can also be created implicitly by the \fBalias\fP, \fBlists\fP,
-\fBsubscribe\fP and \fBalternates\fP commands by specifying the optional \fI-group\fP
-option.
+These address groups can also be created implicitly by the \fBalias\fP,
+\fBlists\fP, \fBsubscribe\fP and \fBalternates\fP commands by specifying the
+optional \fB\-group\fP option.
 .IP
-Once defined, these address groups can be used in patterns to search for and limit the
-display to messages matching a group.
+Once defined, these address groups can be used in patterns to search for and
+limit the display to messages matching a group.
+.
 .PP
 .nf
 \fBhdr_order\fP \fIheader\fP [ \fIheader\fP ... ]
-\fBunhdr_order\fP [ \fB*\fP | \fIheader\fP ... ]
+\fBunhdr_order\fP { \fB*\fP | \fIheader\fP ... }
 .fi
 .IP
 With the \fBhdr_order\fP command you can specify an order in which NeoMutt will
 attempt to present these headers to you when viewing messages.
 .IP
-\(lq\fBunhdr_order *\fP\(rq will clear all previous headers from the order
+\(lq\fBunhdr_order\~*\fP\(rq will clear all previous headers from the order
 list, thus removing the header order effects set by the system-wide startup
 file.
-.PP
-.nf
-\fBiconv-hook\fP \fIcharset\fP \fIlocal-charset\fP
-.fi
-.IP
-This command defines a system-specific name for a character set.
-This is useful when your system's
-.BR iconv (3)
-implementation does not understand MIME character set names (such as
-.BR iso-8859-1 ),
-but instead insists on being fed with implementation-specific
-character set names (such as
-.BR 8859-1 ).
-In this specific case, you'd put this into your configuration file:
-.IP
-.B "iconv-hook iso-8859-1 8859-1"
+.
 .PP
 .nf
 \fBifdef\fP \fIsymbol\fP "\fIconfig-command\fP [ \fIargs\fP ... ]"
@@ -335,571 +420,908 @@ to share one config file between versions of NeoMutt that may have different
 features compiled in.
 .IP
 Here a \fIsymbol\fP can be a
-.BR $variable ", " <function> ", " command " or " compile-time
-.BR symbol ", "
+.BR $variable ", <" function ">, " command " or " "compile-time symbol" ", "
 such as \(lq\fBimap\fP\(rq. A list of compile-time \fIsymbol\fPs can be seen in
-the output of the command \(lq\fBneomutt -v\fP\(rq (in the
+the output of the command \(lq\fBneomutt\~\-v\fP\(rq (in the
 \(lq\fBCompile options\fP\(rq section).
 .IP
 \fBfinish\fP is particularly useful when combined with \fBifndef\fP.
+.
 .PP
 .nf
 \fBignore\fP \fIpattern\fP [ \fIpattern\fP ... ]
-\fBunignore\fP [ \fB*\fP | \fIpattern\fP ... ]
+\fBunignore\fP { \fB*\fP | \fIpattern\fP ... }
 .fi
 .IP
-The \fBignore\fP command permits you to specify header fields which
-you usually don't wish to see.  Any header field whose tag
-\fIbegins\fP with an \(lqignored\(rq pattern will be ignored.
+The \fBignore\fP command allows you to specify header fields which you don't
+normally want to see in the pager. You do not need to specify the full header
+field name. For example, \(lq\fBignore\fP content-\(rq will ignore all header
+fields that begin with the pattern \(lqcontent-\(rq, \(lq\fBignore\fP\~*\(rq
+will ignore all headers.
 .IP
-The \fBunignore\fP command permits you to define exceptions from
-the above mentioned list of ignored headers.
+To remove a previously added token from the list, use the \fBunignore\fP
+command. For example, \(lq\fBunignore\fP\~*\(rq will remove all tokens from the
+ignore list.
+.
 .PP
 .nf
-\fBlists\fP [ \fB-group\fP \fIname\fP ... ] \fIregex\fP [ \fIregex\fP ... ]
-\fBunlists\fP [ \fB-group\fP \fIname\fP ... ] [ \fB*\fP | \fIregex\fP ... ]
-\fBsubscribe\fP [ \fB-group\fP \fIname\fP ... ] \fIregex\fP [ \fIregex\fP ... ]
-\fBunsubscribe\fP [ \fB-group\fP \fIname\fP ... ] [ \fB*\fP | \fIregex\fP ... ]
+\fBlists\fP [ \fB\-group\fP \fIname\fP ... ] \fIregex\fP [ \fIregex\fP ... ]
+\fBunlists\fP [ \fB\-group\fP \fIname\fP ... ] { \fB*\fP | \fIregex\fP ... }
+\fBsubscribe\fP [ \fB\-group\fP \fIname\fP ... ] \fIregex\fP [ \fIregex\fP ... ]
+\fBunsubscribe\fP [ \fB\-group\fP \fIname\fP ... ] { \fB*\fP | \fIregex\fP ... }
 .fi
 .IP
 NeoMutt maintains two lists of mailing list address patterns, a list of
-subscribed mailing lists, and a list of known mailing lists.  All
-subscribed mailing lists are known.  Patterns use regular expressions.
+subscribed mailing lists, and a list of known mailing lists. All subscribed
+mailing lists are known. Patterns use regular expressions.
 .IP
-The \fBlists\fP command adds a mailing list address to the list of
-known mailing lists.  The \fBunlists\fP command removes a mailing
-list from the lists of known and subscribed mailing lists.  The
-\fBsubscribe\fP command adds a mailing list to the lists of known
-and subscribed mailing lists.  The \fBunsubscribe\fP command removes
-it from the list of subscribed mailing lists. The \fB-group\fP flag
-adds all of the subsequent regular expressions to the named group.
+The \fBlists\fP command adds a mailing list address to the list of known
+mailing lists. The \fBunlists\fP command removes a mailing list from the lists
+of known and subscribed mailing lists.
+.IP
+The \fBsubscribe\fP command adds a mailing list to the lists of known and
+subscribed mailing lists. The \fBunsubscribe\fP command removes it from the
+list of subscribed mailing lists.
+.IP
+The \fB\-group\fP flag adds all of the subsequent regular expressions to the
+\fIname\fPd group.
+.
 .PP
 .nf
-\fBmacro\fP \fImenu\fP \fIkey\fP \fIsequence\fP [ \fIdescription\fP ]
+\fBmacro\fP \fImenu\fP[\fB,\fP\fImenu\fP ... ] \fIkey\fP \fIsequence\fP [ \fIdescription\fP ]
 .fi
 .IP
-This command binds the given \fIsequence\fP of keys to the given
-\fIkey\fP in the given \fImenu\fP or menus.  For valid menus, see \fBbind\fP. To
-specify multiple menus, put only a comma between the menus.
+This command binds the given \fIsequence\fP of keys to the given \fIkey\fP in
+the given \fImenu\fP or menus. For currently defined menus, see \fBbind\fP
+command above. To specify multiple menus, put only a comma between the menus.
+.IP
+Optionally you can specify a descriptive text after \fIsequence\fP, which is
+shown in the help screens if they contain a \fIdescription\fP.
+.
 .PP
 .nf
 \fBmailboxes\fP \fImailbox\fP [ \fImailbox\fP ... ]
-\fBunmailboxes\fP [ \fB*\fP | \fImailbox\fP ... ]
+\fBunmailboxes\fP { \fB*\fP | \fImailbox\fP ... }
 .fi
 .IP
-The \fBmailboxes\fP specifies folders which can receive mail and which will
-be checked for new messages.  When changing folders, pressing space
-will cycle through folders with new mail.  The \fBunmailboxes\fP
-command is used to remove a file name from the list of folders which
-can receive mail.  If \(lq\fB*\fP\(rq is specified as the file name, the
-list is emptied.
+The \fBmailboxes\fP specifies folders which can receive mail and which will be
+checked for new messages. When changing folders, pressing space will cycle
+through folders with new mail.
+.IP
+The \fBunmailboxes\fP command is used to remove a file name from the list of
+folders which can receive mail. If \(lq\fB*\fP\(rq is specified as the file
+name, the list is emptied.
+.
 .PP
 .nf
-\fBmailto_allow\fP [ \fB*\fP | \fIheader-field\fP ... ]
-\fBunmailto_allow\fP [ \fB*\fP | \fIheader-field\fP ... ]
+\fBmailto_allow\fP { \fB*\fP | \fIheader-field\fP ... }
+\fBunmailto_allow\fP { \fB*\fP | \fIheader-field\fP ... }
 .fi
 .IP
-These commands allow the user to modify the list of allowed \fIheader-field\fPs
-in a \fImailto:\fP URL that NeoMutt will include in the
-the generated message.  By default the list contains
-\fBsubject\fP and \fBbody\fP, as specified by RFC2368; and
-\fBcc\fP, \fBin-reply-to\fP, and \fBreferences\fP to aid with
-mailto links from mailing lists.
+As a security measure, NeoMutt will only add user-approved \fIheader-field\fPs
+from a \fImailto:\fP URL. This is necessary since NeoMutt will handle certain
+\fIheader-field\fPs, such as \fBAttach\fP, in a special way. The
+\fBmailto_allow\fP and \fBunmailto_allow\fP commands allow the user to modify
+the list of approved headers.
+.IP
+NeoMutt initializes the default list to contain only the \fBSubject\fP and
+\fBBody\fP \fIheader-field\fPs, which are the only requirement specified by the
+\fImailto:\fP specification in RFC2368, and the \fBCc\fP, \fBIn-Reply-To\fP,
+\fBReferences\fP headers to aid with replies to mailing lists.
+.
 .PP
 .nf
-\fBmbox-hook\fP [\fB!\fP]\fIregex\fP \fImailbox\fP
+\fBmbox-hook\fP \fIregex\fP \fImailbox\fP
 .fi
 .IP
-When NeoMutt changes to a mail folder which matches \fIregex\fP,
-\fImailbox\fP will be used as the \(lqmbox\(rq folder, i.e., read
-messages will be moved to that folder when the mail folder is left.
+When NeoMutt changes to a mail folder which matches \fIregex\fP, \fImailbox\fP
+will be used as the \(lqmbox\(rq folder, i.e. read messages will be moved to
+that folder when the mail folder is left.
+.IP
+Note that execution of \fBmbox-hook\fPs is dependent on the $move configuration
+variable. If set to \(lqno\(rq (the default), \fBmbox-hook\fPs will not be
+executed.
 .IP
 The first matching \fBmbox-hook\fP applies.
+.
 .PP
 .nf
-\fBmessage-hook\fP [\fB!\fP]\fIpattern\fP \fIcommand\fP
+\fBmessage-hook\fP \fIpattern\fP \fIcommand\fP
 .fi
 .IP
-Before NeoMutt displays (or formats for replying or forwarding) a
-message which matches the given \fIpattern\fP (or, when it is
-preceded by an exclamation mark, does not match the \fIpattern\fP),
-the given \fIcommand\fP is executed.  When multiple
-\fBmessage-hook\fPs match, they are  executed  in  the order in
+Before NeoMutt displays (or formats for replying or forwarding) a message which
+matches the given \fIpattern\fP (or, when it is preceded by an exclamation
+mark, does not match the \fIpattern\fP), the given \fIcommand\fP is executed.
+When multiple \fBmessage-hook\fPs match, they are executed in the order in
 which they occur in the configuration file.
+.
 .PP
 .nf
 \fBmime_lookup\fP \fImime-type\fP[\fB/\fP\fImime-subtype\fP] [ \fImime-type\fP[\fB/\fP\fImime-subtype\fP] ... ]
-\fBunmime_lookup\fP [ \fB*\fP | \fImime-type\fP[\fB/\fP\fImime-subtype\fP] ... ]
+\fBunmime_lookup\fP { \fB*\fP | \fImime-type\fP[\fB/\fP\fImime-subtype\fP] ... }
 .fi
 .IP
-This command permits you to define a list of \(lqdata\(rq MIME content
-types for which NeoMutt will try to determine the actual file type from
-the file name, and not use a
+This command permits you to define a list of \(lqdata\(rq MIME content types
+for which NeoMutt will try to determine the actual file type from the file
+name, and not use a
 .BR mailcap (5)
-entry given for the original MIME type.  For instance, you may add
-the \fBapplication/octet-stream\fP MIME type to this list.
+entry given for the original MIME type. For instance, you may add the
+\fBapplication/\:octet-stream\fP MIME type to this list.
+.IP
+In addition, the \fBunmime_lookup\fP command may be used to disable this
+feature for any particular MIME type if it had been set, for example in
+a global \fIneomuttrc\fP.
+.
 .PP
 .nf
-\fBmono\fP \fIobject\fP \fIattribute\fP [ \fIregex\fP ]
-\fBmono\fP \fIindex\fP \fIattribute\fP [ \fIpattern\fP ]
-\fBunmono\fP [ \fIindex\fP | \fIheader\fP | \fIbody\fP ] [ \fB*\fP | \fIpattern\fP ... ]
+\fBmono\fP \fIobject\fP \fIattribute\fP
+\fBmono\fP { header | body } \fIattribute\fP \fIregex\fP
+\fBmono\fP index-object \fIattribute\fP \fIpattern\fP
+\fBunmono\fP { index-object | header | body } { \fB*\fP | \fIpattern\fP ... }
 .fi
 .IP
-For terminals which don't support color, you can still assign
-attributes to objects.  Valid attributes include:
-.BR none ", " bold ", " underline ", "
-.BR reverse ", and " standout .
+For terminals which don't support color, you can still assign \fIattribute\fPs
+to objects (see \fBcolor\fP command above). Valid attributes include:
+.BR none ", " bold ", " underline ", " reverse ", and " standout "."
+.
 .PP
 .nf
 \fBmy_hdr\fP \fIstring\fP
-\fBunmy_hdr\fP [ \fB*\fP | \fIfield\fP ... ]
+\fBunmy_hdr\fP { \fB*\fP | \fIfield\fP ... }
 .fi
 .IP
-Using \fBmy_hdr\fP, you can define headers which will be added to
-the messages you compose.  \fBunmy_hdr\fP will remove the given
-user-defined headers.
+Using \fBmy_hdr\fP, you can define headers which will be added to the messages
+you compose. \fBunmy_hdr\fP will remove the given user-defined headers.
+.
+.PP
+.nf
+\fBopen-hook\fP \fIregex\fP "\fIshell-command\fP"
+\fBclose-hook\fP \fIregex\fP "\fIshell-command\fP"
+\fBappend-hook\fP \fIregex\fP "\fIshell-command\fP"
+.fi
+.IP
+These commands provide a way to handle compressed folders. The given
+\fIregex\fP specifies which folders are taken as compressed (e.g.
+\(dq\fB\(rs.gz$\fP\(dq). The commands tell NeoMutt how to uncompress a folder
+(\fBopen-hook\fP), compress a folder (\fBclose-hook\fP) or append a compressed
+mail to a compressed folder (\fBappend-hook\fP). The \fIshell-command\fP is a
+.BR printf (3)
+like format string and must contain two placeholders for from (\fB%f\fP) and to
+(\fB%t\fP) filenames which should be placed inside single-quotes to prevent
+unintended shell expansions. Examples:
+.RS
+.IP
+.EX
+.BR append-hook " \(aq" "\(rs.gz$" "\(aq \(dqgzip \-\-stdout \(aq" "%t" "\(aq >> \(aq" "%f" "\(aq\(dq"
+.BR close-hook " \(aq" "\(rs.gz$" "\(aq \(dqgzip \-\-stdout \(aq" "%t" "\(aq > \(aq" "%f" "\(aq\(dq"
+.BR open-hook " \(aq" "\(rs.gz$" "\(aq \(dqgzip \-\-stdout \-\-decompress \(aq" "%f" "\(aq > \(aq" "%t" "\(aq\(dq"
+.EE
+.RE
+.
 .PP
 .nf
 \fBpush\fP \fIstring\fP
 .fi
 .IP
-This command adds the named \fIstring\fP to the keyboard buffer.
+This command adds the named \fIstring\fP to the beginning of the keyboard
+buffer. The string may contain control characters, key names and function names
+like the sequence string in the \fBmacro\fP command. You may use it to
+automatically run a sequence of commands at startup, or when entering certain
+folders.
+.IP
+For using functions, it's important to use angle brackets (\(lq<\(rq and
+\(lq>\(rq) to make NeoMutt recognize the input as a function name. Otherwise
+it will simulate individual just keystrokes.
+.
+.
 .PP
 .nf
-\fBreply-hook\fP [\fB!\fP]\fIpattern\fP \fIcommand\fP
+\fBreply-hook\fP \fIpattern\fP \fIcommand\fP
+\fBsend-hook\fP \fIpattern\fP \fIcommand\fP
+\fBsend2-hook\fP \fIpattern\fP \fIcommand\fP
 .fi
 .IP
-When replying to a message matching \fIpattern\fP, \fIcommand\fP is
-executed.  When multiple \fBreply-hook\fPs match, they are executed
-in the order in which they occur in the configuration file, but all
-\fBreply-hook\fPs are matched and executed before \fBsend-hook\fPs,
-regardless of their order in the configuration file.
+These commands can be used to execute arbitrary configuration commands based
+upon recipients of the message. \fIpattern\fP is used to match the message, see
+section \(lq\fBMessage Matching in Hooks\fP\(rq in manual for details.
+\fIcommand\fP is executed when \fIpattern\fP matches.
+.IP
+\fBreply-hook\fP is matched against the message you are replying to, instead of
+the message you are sending. \fBsend-hook\fP is matched against all messages,
+both new and replies. \fBNote\fP, \fBreply-hook\fPs are matched before the
+\fBsend-hook\fP, regardless of the order specified in the user's configuration
+file.
+.IP
+\fBsend2-hook\fP is matched every time a message is changed, either by editing
+it, or by using the compose menu to change its recipients or subject.
+\fBsend2-hook\fP is executed after \fBsend-hook\fP, and can, e.g., be used to
+set parameters such as the $sendmail variable depending on the message's sender
+address. \fBNote\fP, \fBsend-hook\fPs are only executed once after getting the
+initial list of recipients.
+.
 .PP
 .nf
 \fBscore\fP \fIpattern\fP \fIvalue\fP
-\fBunscore\fP [ \fB*\fP | \fIpattern\fP ... ]
+\fBunscore\fP { \fB*\fP | \fIpattern\fP ... }
 .fi
 .IP
 The \fBscore\fP command adds \fIvalue\fP to a message's score if \fIpattern\fP
-matches it. \fIpattern\fP is a string in the format described in the patterns
-section. \fIvalue\fP is a positive or negative integer. A message's final score
-is the sum total of all matching score entries.
+matches it. \fIpattern\fP is a string in the format described in the
+\fIPATTERNS\fP section below. \fIvalue\fP is a positive or negative integer.
+A message's final score is the sum total of all matching score entries.
 .IP
 The \fBunscore\fP command removes score entries from the list. You must specify
 the same \fIpattern\fP specified in the \fBscore\fP command for it to be
-removed. The \fIpattern\fP \(lq\fB*\fP\(rq is a special token which means to
-clear the list of all score entries.
+removed. The pattern \(lq\fB*\fP\(rq is a special token which means to clear
+the list of all score entries.
+.
 .PP
 .nf
-\fBsend-hook\fP [\fB!\fP]\fIpattern\fP \fIcommand\fP
+\fBset\fP { [ \fBno\fP | \fBinv\fP | \fB&\fP | \fB?\fP ]\fIvariable\fP | \fIvariable\fP=\fIvalue\fP } [ ... ]
+\fBunset\fP \fIvariable\fP  [ \fIvariable\fP ... ]
+\fBreset\fP \fIvariable\fP  [ \fIvariable\fP ... ]
+\fBtoggle\fP \fIvariable\fP [ \fIvariable\fP ... ]
 .fi
 .IP
-When composing a message matching \fIpattern\fP, \fIcommand\fP is
-executed.  When multiple \fBsend-hook\fPs match, they are executed
-in the order in which they occur in the configuration file.
+These commands are used to set and manipulate configuration \fIvariable\fPs.
+.IP
+NeoMutt knows four basic types of \fIvariable\fPs: boolean, number, string and
+quadoption. Boolean \fIvariable\fPs can be \fBset\fP (true), \fBunset\fP
+(false), or \fBtoggle\fPd. Number \fIvariable\fPs can be assigned a positive
+integer \fIvalue\fP.
+.IP
+String \fIvariable\fPs consist of any number of printable characters and must
+be enclosed in quotes if they contain spaces or tabs. You may also use the
+escape sequences \(lq\fB\(rsn\fP\(rq and \(lq\fB\(rst\fP\(rq for newline and
+tab, respectively.
+.IP
+Quadoption \fIvariable\fPs are used to control whether or not to be prompted
+for certain actions, or to specify a default action. A \fIvalue\fP of \fByes\fP
+will cause the action to be carried out automatically as if you had answered
+\(lqyes\(rq to the question. Similarly, a \fIvalue\fP of \fBno\fP will cause
+the action to be carried out as if you had answered \(lqno\(rq.  A \fIvalue\fP
+of \fBask-yes\fP will cause a prompt with a default answer of \(lqyes\(rq and
+\fBask-no\fP will provide a default answer of \(lqno\(rq.
+.IP
+The \fBtoggle\fP command automatically prepends the \(lq\fBinv\fP\(rq prefix to
+all specified \fIvariable\fPs. The \fBunset\fP command automatically prepends
+the \(lq\fBno\fP\(rq prefix to all specified \fIvariable\fPs. If you use the
+command \fBset\fP and prefix the \fIvariable\fP with \(lq\fB&\fP\(rq this has
+the same behavior as the \fBreset\fP command.
+.IP
+The \fBreset\fP command resets all given \fIvariable\fPs to the compile time
+defaults. With the \fBreset\fP command there exists the special \fIvariable\fP
+\fBall\fP, which allows you to reset all \fIvariable\fPs to their system
+defaults.
+.IP
+Using the <\fBenter-command\fP> function, you can query the \fIvalue\fP of
+a \fIvariable\fP by prefixing the name of the \fIvariable\fP with a question
+mark: \(dq:\fBset\~?\fPallow_8bit\(dq.
+.
 .PP
 .nf
-\fBsend2-hook\fP [\fB!\fP]\fIpattern\fP \fIcommand\fP
-.fi
-.IP
-Whenever a message matching \fIpattern\fP is changed (either by
-editing it or by using the compose menu), \fIcommand\fP
-is executed. When multiple \fBsend2-hook\fPs match, they are
-executed in the order in which they occur in the configuration file.
-Possible applications include setting the $sendmail variable when a
-message's from header is changed.
-.IP
-\fBsend2-hook\fP execution is not triggered by use of
-\fBenter-command\fP from the compose menu.
-.PP
-.nf
-\fBset\fP [\fBno\fP|\fBinv\fP|\fB&\fP|\fB?\fP]\fIvariable\fP[=\fIvalue\fP] [ ... ]
-\fBunset\fP \fIvariable\fP [ ... ]
-\fBreset\fP \fIvariable\fP [ ... ]
-\fBtoggle\fP \fIvariable\fP [ ... ]
-.fi
-.IP
-These commands are used to set and manipulate configuration
-variables.
-.IP
-NeoMutt knows four basic types of variables: boolean, number, string
-and quadoption.  Boolean variables can be \fBset\fP (true),
-\fBunset\fP (false), or \fBtoggle\fPd. Number variables can be assigned
-a positive integer value.
-.IP
-String variables consist of any number of printable characters.
-Strings must be enclosed in quotes if they contain spaces or tabs.
-You may also use the \(lqC\(rq escape sequences \fB\\n\fP and
-\fB\\t\fP for newline and tab, respectively.
-.IP
-Quadoption variables are used to control whether or not to be
-prompted for certain actions, or to specify a default action.  A
-value of \fByes\fP will cause the action to be carried out automatically
-as if you had answered yes to the question.  Similarly, a value of
-\fBno\fP will cause the the action to be carried out as if you had
-answered \(lqno.\(rq A value of \fBask-yes\fP will cause a prompt
-with a default answer of \(lqyes\(rq and \fBask-no\fP will provide a
-default answer of \(lqno.\(rq
-.IP
-The \fBreset\fP command resets all given variables to the compile
-time defaults.  If you reset the special variable \fBall\fP, all
-variables will reset to their compile time defaults.
-.PP
-.nf
-\fBsetenv\fP [\fB?\fP]\fIvariable\fP [ \fIvalue\fP ]
+\fBsetenv\fP { \fB?\fP\fIvariable\fP | \fIvariable\fP \fIvalue\fP }
 \fBunsetenv\fP \fIvariable\fP
 .fi
 .IP
 You can alter the environment that NeoMutt passes on to its child processes
-using the \(lq\fBsetenv\fP\(rq and \(lq\fBunsetenv\fP\(rq operators.
+using the \fBsetenv\fP and \fBunsetenv\fP operators.
 .IP
 You can also query current environment \fIvalue\fPs by prefixing a
 \(lq\fB?\fP\(rq character.
-.PP
-.nf
-\fBshutdown-hook\fP \fIcommand\fP
-.fi
-.IP
-Before NeoMutt is about to exit, and before the mailbox is closed, NeoMutt will run
-the shutdown hook for the given \fIcommand\fP.
+.
 .PP
 .nf
 \fBsidebar_whitelist\fP \fImailbox\fP [ \fImailbox\fP ...]
-\fBunsidebar_whitelist\fP [ \fB*\fP | \fImailbox\fP ... ]
+\fBunsidebar_whitelist\fP { \fB*\fP | \fImailbox\fP ... }
 .fi
 .IP
-This command specifies \fImailboxe\fPs that will always be displayed in the
-sidebar, even if \fB$sidebar_new_mail_only\fP is set and the \fImailbox\fP does
-not contain new mail.
+The \fBsidebar_whitelist\fP command specifies \fImailbox\fPes that will always
+be displayed in the sidebar, even if $sidebar_new_mail_only is set and the
+\fImailbox\fP does not contain new mail.
 .IP
-The \(lq\fBunsidebar_whitelist\fP\(rq command is used to remove
-a \fImailbox\fP from the list of whitelisted mailboxes. Use
-\(lq\fBunsidebar_whitelist *\fP\(rq to remove all mailboxes.
+The \fBunsidebar_whitelist\fP command is used to remove a \fImailbox\fP from
+the list of whitelisted \fImailbox\fPes. Use
+\(lq\fBunsidebar_whitelist\~*\fP\(rq to remove all \fImailbox\fPes.
+.
 .PP
 .nf
 \fBsource\fP \fIfilename\fP
 .fi
 .IP
-The given file will be evaluated as a configuration file.
+This command allows the inclusion of initialization commands from other files.
+If the \fIfilename\fP begins with a tilde (\(lq~\(rq), it will be expanded to
+the path of your home directory.
+.IP
+If the \fIfilename\fP ends with a vertical bar (\(lq|\(rq), then \fIfilename\fP
+is considered to be an executable program from which to read input, (e.g.
+\(lq\fBsource\fP\~\fI~/\:bin/\:myscript\fP|\(rq).
+.
 .PP
 .nf
 \fBspam\fP \fIpattern\fP \fIformat\fP
-\fBnospam\fP [ \fB*\fP | \fIpattern\fP ]
+\fBnospam\fP { \fB*\fP | \fIpattern\fP }
 .fi
 .IP
-These commands define spam-detection patterns from external spam
-filters, so that NeoMutt can
-.BR sort ", " limit ", and " search
-on \(lqspam tags\(rq or \(lqspam attributes\(rq, or \fBdisplay\fP them
-in the index. See the NeoMutt manual for details.
-.PP
-.nf
-\fBstartup-hook\fP \fIcommand\fP
-.fi
+NeoMutt has generalized support for external spam-scoring filters. By defining
+your spam \fIpattern\fPs with the \fBspam\fP and \fBnospam\fP commands, you can
+limit, search, and sort your mail based on its spam attributes, as determined
+by the external filter. You also can display the spam attributes in your index
+display using the %H selector in the $index_format variable. (Tip: try
+\(dq%?H?[%H]\~?\(dq to display spam tags only when they are defined for a given
+message).
 .IP
-Before NeoMutt opens the first mailbox when first starting, NeoMutt will run the
-startup hook for the given \fIcommand\fP.
+For further information on spam-scoring filters, please consult the
+section \(lq\fBSpam Detection\fP\(rq in the NeoMutt manual.
+.
 .PP
 .nf
 \fBsubjectrx\fP \fIpattern\fP \fIreplacement\fP
-\fBunsubjectrx\fP [ \fB*\fP | \fIpattern\fP ]
+\fBunsubjectrx\fP { \fB*\fP | \fIpattern\fP }
 .fi
 .IP
-\fBsubjectrx\fP specifies a regular expression \fIpattern\fP which, if
-detected in a message subject, causes the subject to be replaced with
-the \fIreplacement\fP value. The \fIreplacement\fP is subject to
-substitutions in the same way as for the \fBspam\fP command: %L for
-the text to the left of the match, %R for text to the right of the
-match, and %1 for the first subgroup in the match (etc). If you simply
-want to erase the match, set it to \(lq%L%R\(rq. Any number of
-\fBsubjectrx\fP commands may coexist.
+The \fBsubjectrx\fP command specifies a regular expression \fIpattern\fP which,
+if detected in a message subject, causes the subject to be replaced with the
+\fIreplacement\fP value. The \fIreplacement\fP is subject to substitutions in
+the same way as for the \fBspam\fP command: %L for the text to the left of the
+match, %R for text to the right of the match, and %1 for the first subgroup in
+the match (etc). If you simply want to erase the match, set it to \(lq%L%R\(rq.
+Any number of \fBsubjectrx\fP commands may coexist.
 .IP
-Note this well: the \fIreplacement\fP value replaces the entire
-subject, not just the match!
+Note this well: the \fIreplacement\fP value replaces the entire subject, not
+just the match!
 .IP
-\fBunsubjectrx\fP removes a given \fBsubjectrx\fP from the
-substitution list. If \(lq\fB*\fP\(rq is used as the pattern, all
-substitutions will be removed.
+\fBunsubjectrx\fP removes a given \fBsubjectrx\fP from the substitution list.
+If \(lq\fB*\fP\(rq is used as the pattern, all substitutions will be removed.
+.
 .PP
 .nf
 \fBtimeout-hook\fP \fIcommand\fP
+\fBstartup-hook\fP \fIcommand\fP
+\fBshutdown-hook\fP \fIcommand\fP
 .fi
 .IP
-Run a command periodically when NeoMutt checks for new mail.
-This hook is called every $timeout seconds.
+The \fBGlobal Hooks\fP feature introduces these hooks to NeoMutt. They are
+called when global events take place in NeoMutt. \fBstartup-hook\fP and
+\fBshutdown-hook\fP are most likely to be useful to users of
+.BR notmuch (1).
+.IP
+\fBtimeout-hook\fP runs a \fIcommand\fP periodically when NeoMutt checks for
+new mail. This hook is called every $timeout seconds.
+.IP
+Before NeoMutt opens the first mailbox when first starting, NeoMutt will run
+the \fBstartup-hook\fP for the given \fIcommand\fP.
+.IP
+Before NeoMutt is about to exit, and before the mailbox is closed, NeoMutt will
+run the \fBshutdown-hook\fP for the given \fIcommand\fP.
+.
 .PP
 .nf
-\fBunhook\fP [ \fB*\fP | \fIhook-type\fP ]
+\fBunhook\fP { \fB*\fP | \fIhook-type\fP }
 .fi
 .IP
-This command will remove all hooks of a given type, or all hooks
-when \(lq\fB*\fP\(rq is used as an argument.  \fIhook-type\fP
-can be any of the \fB-hook\fP commands documented above.
-.PP
+This command permits you to flush hooks you have previously defined. You can
+either remove all hooks by giving the \(lq\fB*\fP\(rq character as an argument,
+or you can remove all hooks of a specific \fIhook-type\fP by saying something
+like \(lq\fBunhook\fP\~\fIsend-hook\fP\(rq.
+.
+.\" --------------------------------------------------------------------
 .SH PATTERNS
+.\" --------------------------------------------------------------------
+.SS "\s-1Pattern Modifier\s0"
+.\" --------------------------------------------------------------------
 .PP
-In various places with NeoMutt, including some of the above mentioned
-\fBhook\fP commands, you can specify patterns to match messages.
-.SS Constructing Patterns
-.PP
-A simple pattern consists of an operator of the form
-\(lq\fB~\fP\fIcharacter\fP\(rq, possibly followed by a parameter
-against which NeoMutt is supposed to match the object specified by
-this operator.  For some \fIcharacter\fPs, the \fB~\fP may be
-replaced by another character to alter the behavior of the match.
-These are described in the list of operators, below.
-.PP
-With some of these operators, the object to be matched consists of
-several e-mail addresses.  In these cases, the object is matched if
-at least one of these e-mail addresses matches. You can prepend a
-hat (\(lq\fB^\fP\(rq) character to such a pattern to indicate that
-\fIall\fP addresses must match in order to match the object.
-.PP
-You can construct complex patterns by combining simple patterns with
-logical operators.  Logical AND is specified by simply concatenating
-two simple patterns, for instance \(lq~C neomutt-dev ~s bug\(rq.
-Logical OR is specified by inserting a vertical bar (\(lq\fB|\fP\(rq)
-between two patterns, for instance \(lq~C neomutt-dev | ~s bug\(rq.
-Additionally, you can negate a pattern by prepending a bang
-(\(lq\fB!\fP\(rq) character.  For logical grouping, use braces
-(\(lq()\(rq). Example: \(lq!(~t neomutt|~c mutt) ~f elkins\(rq.
-.SS Simple Patterns
-.PP
-NeoMutt understands the following simple patterns:
-.P
-.PD 0
-.TP 12
-~A
+Many of NeoMutt's commands allow you to specify a pattern to match messages
+.RB ( limit ", " tag-pattern ", " delete-pattern ", the above mentioned " hook
+commands etc.). The table \(lq\fBPattern modifiers\fP\(rq shows several ways to
+select messages.
+.
+.na
+.TS
+box tab(|);
+lb s | lb
+l s | lx .
+\0Pattern|Description
+_
+\0~A|T{
 all messages
-.TP
-~b \fIEXPR\fP
-messages which contain \fIEXPR\fP in the message body.
-.TP
-=b \fISTRING\fP
-messages which contain \fISTRING\fP in the message body. If IMAP is enabled, searches for \fISTRING\fP on the server, rather than downloading each message and searching it locally.
-.TP
-~B \fIEXPR\fP
-messages which contain \fIEXPR\fP in the whole message.
-.TP
-~c \fIEXPR\fP
-messages carbon-copied to \fIEXPR\fP
-.TP
-%c \fIGROUP\fP
+T}
+_
+\0=B \fISTRING\fP|T{
+messages which contain \fISTRING\fP in the whole message. If IMAP is enabled,
+searches for \fISTRING\fP on the server, rather than downloading each message
+and searching it locally.
+T}
+_
+\0=b \fISTRING\fP|T{
+messages which contain \fISTRING\fP in the message body. If IMAP is enabled,
+searches for \fISTRING\fP on the server, rather than downloading each message
+and searching it locally.
+T}
+_
+\0~B \fIEXPR\fP|T{
+messages which contain \fIEXPR\fP in the whole message
+T}
+_
+\0~b \fIEXPR\fP|T{
+messages which contain \fIEXPR\fP in the message body
+T}
+_
+\0%C \fIGROUP\fP|T{
+messages either \(lqTo:\(rq or \(lqCc:\(rq to any member of \fIGROUP\fP
+T}
+_
+\0%c \fIGROUP\fP|T{
 messages carbon-copied to any member of \fIGROUP\fP
-.TP
-~C \fIEXPR\fP
-messages either to: or cc: \fIEXPR\fP
-.TP
-%C \fIGROUP\fP
-messages either to: or cc: to any member of \fIGROUP\fP
-.TP
-~d \fIMIN\fP-\fIMAX\fP
-messages with \(lqdate-sent\(rq in a Date range
-.TP
-~D
+T}
+_
+\0~C \fIEXPR\fP|T{
+messages either \(lqTo:\(rq or \(lqCc:\(rq \fIEXPR\fP
+T}
+_
+\0~c \fIEXPR\fP|T{
+messages carbon-copied to \fIEXPR\fP
+T}
+_
+\0~D|T{
 deleted messages
-.TP
-~e \fIEXPR\fP
-messages which contain \fIEXPR\fP in the \(lqSender\(rq field
-.TP
-%e \fIGROUP\fP
-messages which contain a member of \fIGROUP\fP in the \(lqSender\(rq field
-.TP
-~E
+T}
+_
+\0~d \fIMIN\fP-\fIMAX\fP|T{
+messages with \(lqdate-sent\(rq in a date range
+T}
+_
+\0%e \fIGROUP\fP|T{
+messages which contain a member of \fIGROUP\fP in the \(lqSender:\(rq field
+T}
+_
+\0~E|T{
 expired messages
-.TP
-~f \fIEXPR\fP
-messages originating from \fIEXPR\fP
-.TP
-%f \fIGROUP\fP
+T}
+_
+\0~e \fIEXPR\fP|T{
+messages which contain \fIEXPR\fP in the \(lqSender:\(rq field
+T}
+_
+\0%f \fIGROUP\fP|T{
 messages originating from any member of \fIGROUP\fP
-.TP
-~F
+T}
+_
+\0~F|T{
 flagged messages
-.TP
-~g
-PGP signed messages
-.TP
-~G
-PGP encrypted messages
-.TP
-~h \fIEXPR\fP
+T}
+_
+\0~f \fIEXPR\fP|T{
+messages originating from \fIEXPR\fP
+T}
+_
+\0~G|T{
+cryptographically encrypted messages
+T}
+_
+\0~g|T{
+cryptographically signed messages
+T}
+_
+\0=h \fISTRING\fP|T{
+messages which contain \fISTRING\fP in the message header. If IMAP is enabled,
+searches for \fISTRING\fP on the server, rather than downloading each message
+and searching it locally; \fISTRING\fP must be of the form \(lqHeader:
+substring\(rq (see below).
+T}
+_
+\0~H \fIEXPR\fP|T{
+messages with spam attribute matching \fIEXPR\fP
+T}
+_
+\0~h \fIEXPR\fP|T{
 messages which contain \fIEXPR\fP in the message header
-.TP
-~H \fIEXPR\fP
-messages with spam tags matching \fIEXPR\fP
-.TP
-~i \fIEXPR\fP
-messages which match \fIEXPR\fP in the \(lqMessage-ID\(rq field
-.TP
-~k
+T}
+_
+\0~i \fIEXPR\fP|T{
+messages which match \fIEXPR\fP in the \(lqMessage-ID:\(rq field
+T}
+_
+\0~k|T{
 messages containing PGP key material
-.TP
-~l
-messages addressed to a known mailing list (defined by either \fBsubscribe\fP or \fBlist\fP)
-.TP
-~L \fIEXPR\fP
-messages either originated or received by \fIEXPR\fP
-.TP
-%L \fIGROUP\fP
+T}
+_
+\0%L \fIGROUP\fP|T{
 messages either originated or received by any member of \fIGROUP\fP
-.TP
-~m \fIMIN\fP-\fIMAX\fP
-message in the range \fIMIN\fP to \fIMAX\fP
-.TP
-~n \fIMIN\fP-\fIMAX\fP
-messages with a score in the range \fIMIN\fP to \fIMAX\fP
-.TP
-~N
+T}
+_
+\0~L \fIEXPR\fP|T{
+messages either originated or received by \fIEXPR\fP
+T}
+_
+\0~l|T{
+messages addressed to a known mailing list
+T}
+_
+\0~m <\fIMAX\fP|T{
+messages with numbers less than \fIMAX\fP \fB*\fP)
+T}
+_
+\0~m >\fIMIN\fP|T{
+messages with numbers greater than \fIMIN\fP \fB*\fP)
+T}
+_
+\0~m \fIMIN\fP,\fIMAX\fP|T{
+messages with offsets (from selected message) in the range \fIMIN\fP to
+\fIMAX\fP \fB*\fP)
+T}
+_
+\0~m \fIMIN\fP-\fIMAX\fP|T{
+message in the range \fIMIN\fP to \fIMAX\fP \fB*\fP)
+T}
+_
+\0~m \fIN\fP|T{
+just message number \fIN\fP \fB*\fP)
+T}
+_
+\0~N|T{
 new messages
-.TP
-~O
+T}
+_
+\0~n \fIMIN\fP-\fIMAX\fP|T{
+messages with a score in the range \fIMIN\fP to \fIMAX\fP \fB**\fP)
+T}
+_
+\0~O|T{
 old messages
-.TP
-~p
-messages addressed to you (as defined by \fBalternates\fP)
-.TP
-~P
-messages from you (as defined by \fBalternates\fP)
-.TP
-~Q
+T}
+_
+\0~P|T{
+messages from you (consults \fBalternates\fP)
+T}
+_
+\0~p|T{
+messages addressed to you (consults \fBalternates\fP)
+T}
+_
+\0~Q|T{
 messages which have been replied to
-.TP
-~r \fIMIN\fP-\fIMAX\fP
-messages with \(lqdate-received\(rq in a Date range
-.TP
-~R
+T}
+_
+\0~R|T{
 read messages
-.TP
-~s \fIEXPR\fP
-messages having \fIEXPR\fP in the \(lqSubject\(rq field.
-.TP
-~S
+T}
+_
+\0~r \fIMIN\fP-\fIMAX\fP|T{
+messages with \(lqdate-received\(rq in a date range
+T}
+_
+\0~S|T{
 superseded messages
-.TP
-~t \fIEXPR\fP
-messages addressed to \fIEXPR\fP
-.TP
-~T
+T}
+_
+\0~s \fIEXPR\fP|T{
+messages having \fIEXPR\fP in the \(lqSubject:\(rq field
+T}
+_
+\0~T|T{
 tagged messages
-.TP
-~u
-messages addressed to a subscribed mailing list (defined by \fBsubscribe\fP commands)
-.TP
-~U
+T}
+_
+\0~t \fIEXPR\fP|T{
+messages addressed to \fIEXPR\fP
+T}
+_
+\0~U|T{
 unread messages
-.TP
-~v
-message is part of a collapsed thread.
-.TP
-~V
+T}
+_
+\0~u|T{
+messages addressed to a subscribed mailing list
+T}
+_
+\0~V|T{
 cryptographically verified messages
-.TP
-~x \fIEXPR\fP
-messages which contain \fIEXPR\fP in the \(lqReferences\(rq or \(lqIn-Reply-To\(rq field
-.TP
-~X \fIMIN\fP-\fIMAX\fP
-messages with MIN - MAX attachments
-.TP
-~y \fIEXPR\fP
-messages which contain \fIEXPR\fP in the \(lqX-Label\(rq field
-.TP
-~z \fIMIN\fP-\fIMAX\fP
-messages with a size in the range \fIMIN\fP to \fIMAX\fP
-.TP
-~=
+T}
+_
+\0~v|T{
+message is part of a collapsed thread.
+T}
+_
+\0~X \fIMIN\fP-\fIMAX\fP|T{
+messages with \fIMIN\fP to \fIMAX\fP attachments \fB**\fP)
+T}
+_
+\0~x \fIEXPR\fP|T{
+messages which contain \fIEXPR\fP in the \(lqReferences:\(rq or
+\(lqIn-Reply-To:\(rq field
+T}
+_
+\0~y \fIEXPR\fP|T{
+messages which contain \fIEXPR\fP in their keywords
+T}
+_
+\0~z \fIMIN\fP-\fIMAX\fP|T{
+messages with a size in the range \fIMIN\fP to \fIMAX\fP \fB**\fP) \fB***\fP)
+T}
+_
+\0=/ \fISTRING\fP|T{
+IMAP custom server-side search for \fISTRING\fP. Currently only defined for
+Gmail. See section \(lq\fBGMail Patterns\fP\(rq in NeoMutt manual.
+T}
+_
+\0~=|T{
 duplicated messages (see $duplicate_threads)
-.TP
-~$
+T}
+_
+\0~#|T{
+broken threads (see $strict_threads)
+T}
+_
+\0~$|T{
 unreferenced message (requires threaded view)
-.TP
-~(PATTERN)
-messages in threads containing messages matching a certain pattern, e.g. all threads containing messages from you: ~(~P)
-.TP
-~<(PATTERN)
-messages whose immediate parent matches PATTERN, e.g. replies to your messages: ~<(~P)
-.TP
-~>(PATTERN)
-messages having an immediate child matching PATTERN, e.g. messages you replied to: ~>(~P)
-.PD 1
-.DT
-.PP
-In the above, \fIEXPR\fP is a regular expression.
-.PP
-With the \fB~d\fP, \fB~m\fP, \fB~n\fP, \fB~r\fP, \fB~X\fP, and \fB~z\fP operators, you can also
-specify ranges in the forms \fB<\fP\fIMAX\fP, \fB>\fP\fIMIN\fP,
-\fIMIN\fP\fB-\fP, and \fB-\fP\fIMAX\fP.
-.PP
-With the \fB~z\fP operator, the suffixes \(lqK\(rq and \(lqM\(rq are allowed to specify
+T}
+_
+\0~(\fIPATTERN\fP)|T{
+messages in threads containing messages matching \fIPATTERN\fP, e.g. all
+threads containing messages from you: ~(~P)
+T}
+_
+\0~<(\fIPATTERN\fP)|T{
+messages whose immediate parent matches \fIPATTERN\fP, e.g. replies to your
+messages: ~<(~P)
+T}
+_
+\0~>(\fIPATTERN\fP)|T{
+messages having an immediate child matching \fIPATTERN\fP, e.g. messages you
+replied to: ~>(~P)
+T}
+_
+.T&
+l s s .
+T{
+\0Where \fIEXPR\fP is a regular expression, and \fIGROUP\fP is an address group.
+T}
+.T&
+l l s .
+\p
+\0\h'2m'\fB*\fP)|T{
+The message number ranges (introduced by \(lq\fB~m\fP\(rq) are even
+more general and powerful than the other types of ranges. Read on and see
+section \(lq\fBMessage Ranges\fP\(rq in manual.
+T}
+\0\h'2m'\fB**\fP)|T{
+The forms \(lq<\fIMAX\fP\(rq, \(lq>\fIMIN\fP\(rq, \(lq\fIMIN\fP-\(rq and
+\(lq-\fIMAX\fP\(rq are allowed, too.
+T}
+\0\h'2m'\fB***\fP)|T{
+The suffixes \(lqK\(rq and \(lqM\(rq are allowed to specify
 kilobyte and megabyte respectively.
-.SS Matching dates
+T}
+.TE
+\p
+.ad
+.
 .PP
-The \fB~d\fP and \fB~r\fP operators are used to match date ranges,
-which are interpreted to be given in your local time zone.
+Special attention has to be paid when using regular expressions inside of
+patterns. Specifically, NeoMutt's parser for these patterns will strip one
+level of backslash (\(lq\fB\(rs\fP\(rq), which is normally used for quoting. If
+it is your intention to use a backslash in the regular expression, you will
+need to use two backslashes (\(lq\fB\(rs\(rs\fP\(rq) instead.
+.
 .PP
-A date is of the form
-\fIDD\fP[\fB/\fP\fIMM\fP[\fB/\fP[\fIcc\fP]\fIYY\fP]], that is, a
-two-digit date, optionally followed by a two-digit month, optionally
-followed by a year specifications.  Omitted fields default to the
-current month and year.
+You can force NeoMutt to treat \fIEXPR\fP as a simple \fISTRING\fP instead of
+a regular expression by using \(lq\fB=\fP\(rq instead of \(lq\fB~\fP\(rq in the
+pattern name. For example, \(lq\fB=b\~*.*\fP\(rq will find all messages that
+contain the literal \fISTRING\fP \(lq\fB*.*\fP\(rq. Simple substring matches
+are less powerful than regular expressions but can be considerably faster. This
+is especially true for IMAP folders, because substring matches can be performed
+on the server instead of by fetching every message. IMAP treats
+\(lq\fB=h\fP\(rq specially: it must be of the form
+\(lqHeader:\~\fIsubstring\fP\(rq and will \fBnot\fP partially match header
+names. The \fIsubstring\fP part may be omitted if you simply wish to find
+messages containing a particular header without regard to its value.
+.
 .PP
-NeoMutt understands either two or four digit year specifications.  When
-given a two-digit year, NeoMutt will interpret values less than 70 as
-lying in the 21st century (i.e., \(lq38\(rq means 2038 and not 1938,
-and \(lq00\(rq is interpreted as 2000), and values
-greater than or equal to 70 as lying in the 20th century.
+Patterns matching lists of addresses (notably
+.BR c ", " C ", " p ", " P " and " t )
+match if there is at least one match in the whole list. If you want to make
+sure that all elements of that list match, you need to prefix your pattern with
+\(lq\fB^\fP\(rq.
+.
 .PP
-Note that this behavior \fIis\fP Y2K compliant, but that NeoMutt
-\fIdoes\fP have a Y2.07K problem.
+This example matches all mails which only has recipients from Germany.
+.IP
+Matching all addresses in address lists:
+.BI ^~C\~ \(rs.de$
+.
 .PP
-If a date range consists of a single date, the operator in question
-will match that precise date.  If the date range consists of a dash
-(\(lq\fB-\fP\(rq), followed by a date, this range will match any
-date before and up to the date given.  Similarly, a date followed by
-a dash matches the date given and any later point of time.  Two
-dates, separated by a dash, match any date which lies in the given
-range of time.
+You can restrict address pattern matching to aliases that you have defined with
+the \(lq\fB@\fP\(rq modifier. This example matches messages whose recipients
+are all from Germany \fBand\fP who are known to your alias list.
+.
+.IP
+Matching restricted to aliases:
+.BI ^@~C\~ \(rs.de$
+.
 .PP
-You can also modify any absolute date by giving an error range.  An
-error range consists of one of the characters
-.BR + ,
-.BR - ,
-.BR * ,
-followed by a positive number, followed by one of the unit
-characters
-.BR y ,
-.BR m ,
-.BR w ", or"
-.BR d ,
-specifying a unit of years, months, weeks, or days.
-.B +
-increases the maximum date matched by the given interval of time,
-.B -
-decreases the minimum date matched by the given interval of time, and
-.B *
-increases the maximum date and decreases the minimum date matched by
-the given interval of time.  It is possible to give multiple error
-margins, which cumulate.  Example:
-.B "1/1/2001-1w+2w*3d"
+To match any defined alias, use a regular expression that matches \fBany\fP
+string. This example matches messages whose senders are known aliases.
+.
+.IP
+Matching any defined alias:
+.BI @~f\~ .
+.
+.SS "\s-1Nesting and Boolean Operators\s0"
+.\" --------------------------------------------------------------------
 .PP
-You can also specify offsets relative to the current date.  An
-offset is specified as one of the characters
-.BR < ,
-.BR > ,
-.BR = ,
-followed by a positive number, followed by one of the unit
-characters
-.BR y ,
-.BR m ,
-.BR w ", or"
-.BR d .
-.B >
-matches dates which are older than the specified amount of time, an
-offset which begins with the character
-.B <
-matches dates which are more recent than the specified amount of time,
-and an offset which begins with the character
-.B =
-matches points of time which are precisely the given amount of time
-ago.
+Logical AND is performed by specifying more than one criterion.
+.IP
+For example:
+.BI ~t\~ work " ~f\~" elkins
+.
+.PP
+would select messages which contain the word \(lqwork\(rq in the list of
+recipients \fBand\fP that have the word \(lqelkins\(rq in the \(lqFrom:\(rq
+header field.
+.
+.PP
+NeoMutt also recognizes the following operators to create more complex
+search patterns:
+.
+.RS
+.TP 4
+\(bu \(lq\fB!\fP\(rq \(em logical NOT operator
+.TQ
+\(bu \(lq\fB|\fP\(rq \(em logical OR operator
+.TQ
+\(bu \(lq\fB()\fP\(rq \(em logical grouping operator
+.RE
+.
+.PP
+Here is an example illustrating a complex search pattern. This pattern will
+select all messages which do \fBnot\fP contain \(lqwork\(rq in the \(lqTo:\(rq
+\fBor\fP \(lqCc:\(rq field \fBand\fP which are from \(lqelkins\(rq.
+.
+.IP
+Using boolean operators in patterns:
+.BI !(~t\~ work |~c\~ work ") ~f\~" elkins
+.
+.PP
+Here is an example using white space in the regular expression (note the
+\(lq\fB\(aq\fP\(rq and \(lq\fB\(dq\fP\(rq delimiters). For this to match, the
+mail's subject must match the \(lq^Junk +From +Me$\(rq \fBand\fP it must be
+from either \(lqJim +Somebody\(rq \fBor\fP \(lqEd +SomeoneElse\(rq:
+.
+.IP
+Quoting regex:
+.na
+.IB \(aq ~s\~ "\(dq^Junk +From +Me$\(dq"
+.BI ~f\~( "\(dqJim +Somebody\(dq" | "\(dqEd +SomeoneElse\(dq" ) \(aq
+.ad
+.
+.PP
+\fBNote\fP: If a regular expression contains parenthesis, or a vertical bar
+(\(lq\fB|\fP\(rq), you must enclose the expression in double or single quotes
+since those characters are also used to separate different parts of NeoMutt's
+pattern language.
+.
+.IP
+For example:
+.BI ~f \~\(dquser@ ( home\(rs.org | work\(rs.com ) \(dq
+.
+.PP
+Without the quotes, the parenthesis wouldn't end. This would be separated to
+two OR'd patterns:
+.BI ~f \~user@(home\(rs.org
+.RI "and " work\(rs.com) ". They are never what you want."
+.
+.SS "\s-1Searching by Date\s0"
+.\" --------------------------------------------------------------------
+.PP
+NeoMutt supports two types of dates, \fBabsolute\fP and \fBrelative\fP for
+the \(lq\fB~d\fP\(rq and \(lq\fB~r\fP\(rq pattern.
+.
+.PP
+.nf
+.B Absolute Dates
+.fi
+Dates must be in
+.IR dd [/ mm [/[ CC ] YY ]]
+format (day, month, century and year \(em all parts, with the exception of day,
+are optional, defaulting to the current month and year). An example of a valid
+range of dates is:
+.
+.IP
+Limit to messages matching:
+.IR \fB~d\fP\~20 / 1 / 95 - 31 / 10
+.
+.PP
+When given a two-digit year, NeoMutt will interpret values less than \(lq70\(rq
+as lying in the 21st century (i.e., \(lq38\(rq means 2038 and not 1938, and
+\(lq00\(rq is interpreted as 2000), and values greater than or equal to
+\(lq70\(rq as lying in the 20th century.
+.
+.PP
+If you omit the \fIMIN\fPimum (first) date, and just specify
+.RI - dd / mm / YY ,
+all messages before the given date will be selected. If you omit the
+\fIMAX\fPimum (second) date, and specify
+.IR dd / mm / YY -,
+all messages after the given date will be selected. If you specify a single
+date with no dash (\(lq\fB-\fP\(rq), only messages sent/received on the given
+date will be selected.
+.
+.PP
+You can add error margins to absolute dates. An error margin is a sign
+(\(lq\fB+\fP\(rq or \(lq\fB-\fP\(rq), followed by a digit, followed by one of
+the units in table \(lq\fBDate units\fP\(rq below. As a special case, you can
+replace the sign by a \(lq\fB*\fP\(rq character, which is equivalent to giving
+identical plus and minus error margins.
+.
+.\".TS
+.\"allbox tab(|);
+.\"cb cb
+.\"c l .
+.\"\0Unit|Description
+.\"\0d|Days
+.\"\0w|Weeks
+.\"\0m|Months
+.\"\0y|Years
+.\".TE
+.\"\p
+.\".
+.TS
+allbox center tab(|);
+lb c c c c
+lb l l l l .
+\0Date Unit|d|w|m|y
+\0Description|Days|Weeks|Months|Years
+.TE
+\p
+.
+.PP
+\fBExample\fP: To select any messages two weeks around January 15, 2001, you'd
+use the following pattern:
+.
+.IP
+Limit to messages matching:
+.IR \fB~d\fP\~15 / 1 / 2001 \fB*\fP 2 \fBw\fP
+.
+.PP
+It is possible to give multiple error margins:
+.
+.IP
+which cumulate:
+.IR \fB~d\fP\~1 / 1 / 2001 \fB-\fP 1 \fBw+\fP 2 \fBw*\fP 3 \fBd\fP
+.
+.PP
+.nf
+.B Relative Dates
+.fi
+This type of date is relative to the current date, and may be specified as:
+.
+.RS
+.TP 4
+\(bu \(lq\fB<\fP\fIoffset\fP\(rq for messages newer than \fIoffset\fP units
+.TQ
+\(bu \(lq\fB=\fP\fIoffset\fP\(rq for messages exactly \fIoffset\fP units old
+.TQ
+\(bu \(lq\fB>\fP\fIoffset\fP\(rq for messages older than \fIoffset\fP units
+.RE
+.
+.PP
+\fIoffset\fP is specified as a positive number with one of the units from table
+\(lq\fBDate units\fP\(rq.
+.
+.PP
+\fBExample\fP: To select messages less than 1 month old, you would use:
+.
+.IP
+Limit to messages matching:
+.BI ~d\~< 1 m
+.
+.PP
+\fBNote\fP: All dates used when searching are relative to the \fBlocal\fP time
+zone, so unless you change the setting of your $index_format to include
+a \(lq\fB%[...]\fP\(rq format, these are \fBnot\fP the dates shown in the main
+index.
+.
+.\" --------------------------------------------------------------------
 .SH CONFIGURATION VARIABLES
+.\" --------------------------------------------------------------------

--- a/doc/neomuttrc.man.head
+++ b/doc/neomuttrc.man.head
@@ -139,6 +139,25 @@ which is replaced with the name of the temporary folder to which to
 write.
 .PP
 .nf
+\fBattachments\fP [\fB + \fP | \fB-\fP ]\fIdisposition\fP \fImime-type\fP
+\fBunattachments\fP [\fB + \fP | \fB-\fP ]\fIdisposition\fP \fImime-type\fP
+.fi
+.IP
+You can make your message index display the number of qualifying attachments in
+each message, or search for messages by attachment count. You also can
+configure what kinds of attachments qualify for this feature with the
+\fBattachments\fP and \fBunattachments\fP commands.
+.IP
+\fIdisposition\fP is the attachment's Content-Disposition type \(em either
+inline or attachment. You can abbreviate this to \fBI\fP or \fBA\fP.
+.IP
+\fImime-type\fP is the MIME type of the attachment you want the command to
+affect. A MIME type is always of the format \fBmajor/minor\fP. The major part
+of \fImime-type\fP must be literal text (or the special token \(lq\fB*\fP\(rq,
+but the minor part may be a regular expression. (Therefore, \(lq\fB*/.*\fP\(rq
+matches any MIME type.)
+.PP
+.nf
 \fBauto_view\fP \fItype\fP[\fB/\fP\fIsubtype\fP] [ ... ]
 \fBunauto_view\fP \fItype\fP[\fB/\fP\fIsubtype\fP] [ ... ]
 .fi
@@ -221,6 +240,15 @@ You may use multiple
 a recipient.
 .PP
 .nf
+\fBexec\fP \fIfunction\fP [ \fIfunction\fP ... ]
+.ni
+.IP
+This command can be used to execute any function. Functions are listed in the
+function reference.
+.IP
+\(lq\fBexec\fP \fIfunction\fP\(rq is equivalent to \(lq\fBpush <\fP\fIfunction\fP\fB>\fP\(rq.
+.PP
+.nf
 \fBfcc-hook\fP [\fB!\fP]\fIpattern\fP \fIfilename\fP
 \fBsave-hook\fP [\fB!\fP]\fIpattern\fP \fIfilename\fP
 \fBfcc-save-hook\fP [\fB!\fP]\fIpattern\fP \fIfilename\fP
@@ -269,11 +297,16 @@ Once defined, these address groups can be used in patterns to search for and lim
 display to messages matching a group.
 .PP
 .nf
-\fBhdr_order\fP \fIheader1\fP \fIheader2\fP [ ... ]
+\fBhdr_order\fP \fIheader\fP [ \fIheader\fP ... ]
+\fBunhdr_order\fP [ \fB*\fP | \fIheader\fP ... ]
 .fi
 .IP
-With this command, you can specify an order in which neomutt will
-attempt to present headers to you when viewing messages.
+With the \fBhdr_order\fP command you can specify an order in which NeoMutt will
+attempt to present these headers to you when viewing messages.
+.IP
+\(lq\fBunhdr_order *\fP\(rq will clear all previous headers from the order
+list, thus removing the header order effects set by the system-wide startup
+file.
 .PP
 .nf
 \fBiconv-hook\fP \fIcharset\fP \fIlocal-charset\fP
@@ -292,8 +325,27 @@ In this specific case, you'd put this into your configuration file:
 .B "iconv-hook iso-8859-1 8859-1"
 .PP
 .nf
+\fBifdef\fP \fIsymbol\fP "\fIconfig-command\fP [ \fIargs\fP ... ]"
+\fBifndef\fP \fIsymbol\fP "\fIconfig-command\fP [ \fIargs\fP ... ]"
+\fBfinish\fP
+.fi
+.IP
+The \fBifdef\fP feature introduces three new commands to NeoMutt and allow you
+to share one config file between versions of NeoMutt that may have different
+features compiled in.
+.IP
+Here a \fIsymbol\fP can be a
+.BR $variable ", " <function> ", " command " or " compile-time
+.BR symbol ", "
+such as \(lq\fBimap\fP\(rq. A list of compile-time \fIsymbol\fPs can be seen in
+the output of the command \(lq\fBneomutt -v\fP\(rq (in the
+\(lq\fBCompile options\fP\(rq section).
+.IP
+\fBfinish\fP is particularly useful when combined with \fBifndef\fP.
+.PP
+.nf
 \fBignore\fP \fIpattern\fP [ \fIpattern\fP ... ]
-\fBunignore\fP \fIpattern\fP [ \fIpattern\fP ... ]
+\fBunignore\fP [ \fB*\fP | \fIpattern\fP ... ]
 .fi
 .IP
 The \fBignore\fP command permits you to specify header fields which
@@ -304,10 +356,10 @@ The \fBunignore\fP command permits you to define exceptions from
 the above mentioned list of ignored headers.
 .PP
 .nf
-\fBlists\fP [\fB-group\fP \fIname\fP] \fIregex\fP [ \fIregex\fP ... ]
-\fBunlists\fP \fIregex\fP [ \fIregex\fP ... ]
-\fBsubscribe\fP [\fB-group\fP \fIname\fP] \fIregex\fP [ \fIregex\fP ... ]
-\fBunsubscribe\fP \fIregex\fP [ \fIregex\fP ... ]
+\fBlists\fP [ \fB-group\fP \fIname\fP ... ] \fIregex\fP [ \fIregex\fP ... ]
+\fBunlists\fP [ \fB-group\fP \fIname\fP ... ] [ \fB*\fP | \fIregex\fP ... ]
+\fBsubscribe\fP [ \fB-group\fP \fIname\fP ... ] \fIregex\fP [ \fIregex\fP ... ]
+\fBunsubscribe\fP [ \fB-group\fP \fIname\fP ... ] [ \fB*\fP | \fIregex\fP ... ]
 .fi
 .IP
 NeoMutt maintains two lists of mailing list address patterns, a list of
@@ -323,32 +375,32 @@ it from the list of subscribed mailing lists. The \fB-group\fP flag
 adds all of the subsequent regular expressions to the named group.
 .PP
 .nf
-\fBmacro\fP \fImap\fP \fIkey\fP \fIsequence\fP [ \fIdescription\fP ]
+\fBmacro\fP \fImenu\fP \fIkey\fP \fIsequence\fP [ \fIdescription\fP ]
 .fi
 .IP
 This command binds the given \fIsequence\fP of keys to the given
-\fIkey\fP in the given \fImap\fP or maps.  For valid maps, see \fBbind\fP. To
-specify multiple maps, put only a comma between the maps.
+\fIkey\fP in the given \fImenu\fP or menus.  For valid menus, see \fBbind\fP. To
+specify multiple menus, put only a comma between the menus.
 .PP
 .nf
-\fBmailboxes\fP \fIfilename\fP [ \fIfilename\fP ... ]
-\fBunmailboxes\fP [ \fB*\fP | \fIfilename\fP ... ]
+\fBmailboxes\fP \fImailbox\fP [ \fImailbox\fP ... ]
+\fBunmailboxes\fP [ \fB*\fP | \fImailbox\fP ... ]
 .fi
 .IP
 The \fBmailboxes\fP specifies folders which can receive mail and which will
 be checked for new messages.  When changing folders, pressing space
 will cycle through folders with new mail.  The \fBunmailboxes\fP
 command is used to remove a file name from the list of folders which
-can receive mail.  If "\fB*\fP" is specified as the file name, the
+can receive mail.  If \(lq\fB*\fP\(rq is specified as the file name, the
 list is emptied.
 .PP
 .nf
-\fBmailto_allow\fP \fIheader-field\fP [ ... ]
+\fBmailto_allow\fP [ \fB*\fP | \fIheader-field\fP ... ]
 \fBunmailto_allow\fP [ \fB*\fP | \fIheader-field\fP ... ]
 .fi
 .IP
-These commands allow the user to modify the list of allowed header
-fields in a \fImailto:\fP URL that NeoMutt will include in the
+These commands allow the user to modify the list of allowed \fIheader-field\fPs
+in a \fImailto:\fP URL that NeoMutt will include in the
 the generated message.  By default the list contains
 \fBsubject\fP and \fBbody\fP, as specified by RFC2368; and
 \fBcc\fP, \fBin-reply-to\fP, and \fBreferences\fP to aid with
@@ -376,11 +428,11 @@ the given \fIcommand\fP is executed.  When multiple
 which they occur in the configuration file.
 .PP
 .nf
-\fBmime_lookup\fP \fItype\fP[\fB/\fP\fIsubtype\fP] [ ... ]
-\fBunmime_lookup\fP \fItype\fP[\fB/\fP\fIsubtype\fP] [ ... ]
+\fBmime_lookup\fP \fImime-type\fP[\fB/\fP\fImime-subtype\fP] [ \fImime-type\fP[\fB/\fP\fImime-subtype\fP] ... ]
+\fBunmime_lookup\fP [ \fB*\fP | \fImime-type\fP[\fB/\fP\fImime-subtype\fP] ... ]
 .fi
 .IP
-This command permits you to define a list of "data" MIME content
+This command permits you to define a list of \(lqdata\(rq MIME content
 types for which neomutt will try to determine the actual file type from
 the file name, and not use a
 .BR mailcap (5)
@@ -389,7 +441,8 @@ the \fBapplication/octet-stream\fP MIME type to this list.
 .PP
 .nf
 \fBmono\fP \fIobject\fP \fIattribute\fP [ \fIregex\fP ]
-\fBmono\fP index \fIattribute\fP [ \fIpattern\fP ]
+\fBmono\fP \fIindex\fP \fIattribute\fP [ \fIpattern\fP ]
+\fBunmono\fP [ \fIindex\fP | \fIheader\fP | \fIbody\fP ] [ \fB*\fP | \fIpattern\fP ... ]
 .fi
 .IP
 For terminals which don't support color, you can still assign
@@ -399,7 +452,7 @@ attributes to objects.  Valid attributes include:
 .PP
 .nf
 \fBmy_hdr\fP \fIstring\fP
-\fBunmy_hdr\fP \fIfield\fP
+\fBunmy_hdr\fP [ \fB*\fP | \fIfield\fP ... ]
 .fi
 .IP
 Using \fBmy_hdr\fP, you can define headers which will be added to
@@ -421,6 +474,21 @@ executed.  When multiple \fBreply-hook\fPs match, they are executed
 in the order in which they occur in the configuration file, but all
 \fBreply-hook\fPs are matched and executed before \fBsend-hook\fPs,
 regardless of their order in the configuration file.
+.PP
+.nf
+\fBscore\fP \fIpattern\fP \fIvalue\fP
+\fBunscore\fP [ \fB*\fP | \fIpattern\fP ... ]
+.fi
+.IP
+The \fBscore\fP command adds \fIvalue\fP to a message's score if \fIpattern\fP
+matches it. \fIpattern\fP is a string in the format described in the patterns
+section. \fIvalue\fP is a positive or negative integer. A message's final score
+is the sum total of all matching score entries.
+.IP
+The \fBunscore\fP command removes score entries from the list. You must specify
+the same \fIpattern\fP specified in the \fBscore\fP command for it to be
+removed. The \fIpattern\fP \(lq\fB*\fP\(rq is a special token which means to
+clear the list of all score entries.
 .PP
 .nf
 \fBsend-hook\fP [\fB!\fP]\fIpattern\fP \fIcommand\fP
@@ -478,11 +546,35 @@ time defaults.  If you reset the special variable \fBall\fP, all
 variables will reset to their compile time defaults.
 .PP
 .nf
+\fBsetenv\fP [\fB?\fP]\fIvariable\fP [ \fIvalue\fP ]
+\fBunsetenv\fP \fIvariable\fP
+.fi
+.IP
+You can alter the environment that NeoMutt passes on to its child processes
+using the \(lq\fBsetenv\fP\(rq and \(lq\fBunsetenv\fP\(rq operators.
+.IP
+You can also query current environment \fIvalue\fPs by prefixing a
+\(lq\fB?\fP\(rq character.
+.PP
+.nf
 \fBshutdown-hook\fP \fIcommand\fP
 .fi
 .IP
 Before neomutt is about to exit, and before the mailbox is closed, neomutt will run
 the shutdown hook for the given \fIcommand\fP.
+.PP
+.nf
+\fBsidebar_whitelist\fP \fImailbox\fP [ \fImailbox\fP ...]
+\fBunsidebar_whitelist\fP [ \fB*\fP | \fImailbox\fP ... ]
+.fi
+.IP
+This command specifies \fImailboxe\fPs that will always be displayed in the
+sidebar, even if \fB$sidebar_new_mail_only\fP is set and the \fImailbox\fP does
+not contain new mail.
+.IP
+The \(lq\fBunsidebar_whitelist\fP\(rq command is used to remove
+a \fImailbox\fP from the list of whitelisted mailboxes. Use
+\(lq\fBunsidebar_whitelist *\fP\(rq to remove all mailboxes.
 .PP
 .nf
 \fBsource\fP \fIfilename\fP
@@ -492,12 +584,13 @@ The given file will be evaluated as a configuration file.
 .PP
 .nf
 \fBspam\fP \fIpattern\fP \fIformat\fP
-\fBnospam\fP \fIpattern\fP
+\fBnospam\fP [ \fB*\fP | \fIpattern\fP ]
 .fi
 .IP
 These commands define spam-detection patterns from external spam
-filters, so that neomutt can sort, limit, and search on
-``spam tags'' or ``spam attributes'', or display them
+filters, so that neomutt can
+.BR sort ", " limit ", and " search
+on \(lqspam tags\(rq or \(lqspam attributes\(rq, or \fBdisplay\fP them
 in the index. See the NeoMutt manual for details.
 .PP
 .nf

--- a/doc/neomuttrc.man.head
+++ b/doc/neomuttrc.man.head
@@ -26,7 +26,7 @@
 .ft
 .fi
 ..
-.TH neomuttrc 5 "@TS_MAN_CONF@" Unix "User Manuals"
+.TH neomuttrc 5 "@MAN_DATE@" Unix "User Manuals"
 .SH NAME
 neomuttrc \- Configuration file for the NeoMutt Mail User Agent
 .SH DESCRIPTION

--- a/doc/neomuttrc.man.head
+++ b/doc/neomuttrc.man.head
@@ -31,7 +31,7 @@
 neomuttrc \- Configuration file for the NeoMutt Mail User Agent
 .SH DESCRIPTION
 .PP
-A neomutt configuration file consists of a series of \(lqcommands\(rq.
+A NeoMutt configuration file consists of a series of \(lqcommands\(rq.
 Each line of the file may contain one or more commands.  When
 multiple commands are used, they must be separated by a semicolon
 (\(lq\fB;\fP\(rq).
@@ -83,7 +83,7 @@ to adjust configuration settings to different IMAP or POP servers.
 .PP
 .nf
 \fBalias\fP [\fB-group\fP \fIname\fP [...]] \fIkey\fP \fIaddress\fP [\fB,\fP \fIaddress\fP [ ... ]]
-\fBunalias\fP [\fB * \fP | \fIkey\fP ]
+\fBunalias\fP [ \fB*\fP | \fIkey\fP ]
 .fi
 .IP
 \fBalias\fP defines an alias \fIkey\fP for the given addresses. Each
@@ -97,23 +97,23 @@ added to the named \fIgroup\fP.
 .PP
 .nf
 \fBalternates\fP [\fB-group\fP \fIname\fP] \fIregex\fP [ \fIregex\fP [ ... ]]
-\fBunalternates\fP [\fB * \fP | \fIregex\fP [ \fIregex\fP [ ... ]] ]
+\fBunalternates\fP [ \fB*\fP | \fIregex\fP [ \fIregex\fP [ ... ]] ]
 .fi
 .IP
-\fBalternates\fP is used to inform neomutt about alternate addresses
+\fBalternates\fP is used to inform NeoMutt about alternate addresses
 where you receive mail; you can use regular expressions to specify
-alternate addresses.  This affects neomutt's idea about messages
+alternate addresses.  This affects NeoMutt's idea about messages
 from you, and messages addressed to you.  \fBunalternates\fP removes
 a regular expression from the list of known alternates. The \fB-group\fP flag
 causes all of the subsequent regular expressions to be added to the named group.
 .PP
 .nf
 \fBalternative_order\fP \fItype\fP[\fB/\fP\fIsubtype\fP] [ ... ]
-\fBunalternative_order\fP [\fB * \fP | \fItype\fP/\fIsubtype\fP] [...]
+\fBunalternative_order\fP [ \fB*\fP | \fItype\fP/\fIsubtype\fP] [...]
 .fi
 .IP
 \fBalternative_order\fP command permits you to define an order of preference which is
-used by neomutt to determine which part of a
+used by NeoMutt to determine which part of a
 \fBmultipart/alternative\fP body to display.
 A subtype of \(lq\fB*\fP\(rq matches any subtype, as does an empty
 subtype.   \fBunalternative_order\fP removes entries from the
@@ -139,8 +139,8 @@ which is replaced with the name of the temporary folder to which to
 write.
 .PP
 .nf
-\fBattachments\fP [\fB + \fP | \fB-\fP ]\fIdisposition\fP \fImime-type\fP
-\fBunattachments\fP [\fB + \fP | \fB-\fP ]\fIdisposition\fP \fImime-type\fP
+\fBattachments\fP [ \fB+\fP | \fB-\fP ]\fIdisposition\fP \fImime-type\fP
+\fBunattachments\fP [ \fB+\fP | \fB-\fP ]\fIdisposition\fP \fImime-type\fP
 .fi
 .IP
 You can make your message index display the number of qualifying attachments in
@@ -162,7 +162,7 @@ matches any MIME type.)
 \fBunauto_view\fP \fItype\fP[\fB/\fP\fIsubtype\fP] [ ... ]
 .fi
 .IP
-This commands permits you to specify that neomutt should automatically
+This commands permits you to specify that NeoMutt should automatically
 convert the given MIME types to text/plain when displaying messages.
 For this to work, there must be a
 .BR mailcap (5)
@@ -172,11 +172,11 @@ flag set.  A subtype of \(lq\fB*\fP\(rq
 matches any subtype, as does an empty subtype.
 .PP
 .nf
-\fBbind\fP \fImap1,map2,...\fP \fIkey\fP \fIfunction\fP
+\fBbind\fP \fImenu1,menu2,...\fP \fIkey\fP \fIfunction\fP
 .fi
 .IP
-This command binds the given \fIkey\fP for the given \fImap\fP or maps
-to the given \fIfunction\fP. Multiple maps may be specified by
+This command binds the given \fIkey\fP for the given \fImenu\fP or \fImenu\fPs
+to the given \fIfunction\fP. Multiple menus may be specified by
 separating them with commas (no whitespace is allowed).
 .IP
 Valid maps are:
@@ -196,7 +196,7 @@ angle brackets.
 .IP
 This command defines an alias for a character set.  This is useful
 to properly display messages which are tagged with a character set
-name not known to neomutt.
+name not known to NeoMutt.
 .PP
 .nf
 \fBcolor\fP \fIobject\fP \fIforeground\fP \fIbackground\fP [ \fIregex\fP ]
@@ -231,8 +231,8 @@ Valid colors include:
 .IP
 The crypt-hook command provides a method by which you can
 specify the ID of the public key to be used when encrypting messages
-to a certain recipient.  The meaning of "key ID" is to be taken
-broadly: This can be a different e-mail address, a numerical key ID,
+to a certain recipient.  The meaning of \fIkey-id\fP is to be taken
+broadly: This can be a different e-mail address, a numerical \fIkey-id\fP,
 or even just an arbitrary search string.
 You may use multiple
 \fBcrypt-hook\fPs with the same \fIregex\fP; multiple matching
@@ -267,7 +267,7 @@ saving it will be the given \fIfilename\fP.
 \fBfolder-hook\fP [\fB!\fP]\fIregex\fP \fIcommand\fP
 .fi
 .IP
-When neomutt enters a folder which matches \fIregex\fP (or, when
+When NeoMutt enters a folder which matches \fIregex\fP (or, when
 \fIregex\fP is preceded by an exclamation mark, does not match
 \fIregex\fP), the given \fIcommand\fP is executed.
 .IP
@@ -286,8 +286,8 @@ specify what the following strings (that cannot begin with a hyphen) should be
 interpreted as: either a regular expression or an email address, respectively.
 \fBungroup\fP is used to remove addresses or regular expressions from the
 specified group or groups. The syntax is similar to the \fBgroup\fP command,
-however the special character \fB*\fP can be used to empty a group of all of
-its contents.
+however the special character \(lq\fB*\fP\(rq can be used to empty a group of
+all of its contents.
 .IP
 These address groups can also be created implicitly by the \fBalias\fP, \fBlists\fP,
 \fBsubscribe\fP and \fBalternates\fP commands by specifying the optional \fI-group\fP
@@ -410,7 +410,7 @@ mailto links from mailing lists.
 \fBmbox-hook\fP [\fB!\fP]\fIregex\fP \fImailbox\fP
 .fi
 .IP
-When neomutt changes to a mail folder which matches \fIregex\fP,
+When NeoMutt changes to a mail folder which matches \fIregex\fP,
 \fImailbox\fP will be used as the \(lqmbox\(rq folder, i.e., read
 messages will be moved to that folder when the mail folder is left.
 .IP
@@ -420,7 +420,7 @@ The first matching \fBmbox-hook\fP applies.
 \fBmessage-hook\fP [\fB!\fP]\fIpattern\fP \fIcommand\fP
 .fi
 .IP
-Before neomutt displays (or formats for replying or forwarding) a
+Before NeoMutt displays (or formats for replying or forwarding) a
 message which matches the given \fIpattern\fP (or, when it is
 preceded by an exclamation mark, does not match the \fIpattern\fP),
 the given \fIcommand\fP is executed.  When multiple
@@ -433,7 +433,7 @@ which they occur in the configuration file.
 .fi
 .IP
 This command permits you to define a list of \(lqdata\(rq MIME content
-types for which neomutt will try to determine the actual file type from
+types for which NeoMutt will try to determine the actual file type from
 the file name, and not use a
 .BR mailcap (5)
 entry given for the original MIME type.  For instance, you may add
@@ -560,7 +560,7 @@ You can also query current environment \fIvalue\fPs by prefixing a
 \fBshutdown-hook\fP \fIcommand\fP
 .fi
 .IP
-Before neomutt is about to exit, and before the mailbox is closed, neomutt will run
+Before NeoMutt is about to exit, and before the mailbox is closed, NeoMutt will run
 the shutdown hook for the given \fIcommand\fP.
 .PP
 .nf
@@ -588,7 +588,7 @@ The given file will be evaluated as a configuration file.
 .fi
 .IP
 These commands define spam-detection patterns from external spam
-filters, so that neomutt can
+filters, so that NeoMutt can
 .BR sort ", " limit ", and " search
 on \(lqspam tags\(rq or \(lqspam attributes\(rq, or \fBdisplay\fP them
 in the index. See the NeoMutt manual for details.
@@ -597,7 +597,7 @@ in the index. See the NeoMutt manual for details.
 \fBstartup-hook\fP \fIcommand\fP
 .fi
 .IP
-Before neomutt opens the first mailbox when first starting, neomutt will run the
+Before NeoMutt opens the first mailbox when first starting, NeoMutt will run the
 startup hook for the given \fIcommand\fP.
 .PP
 .nf
@@ -618,7 +618,7 @@ Note this well: the \fIreplacement\fP value replaces the entire
 subject, not just the match!
 .IP
 \fBunsubjectrx\fP removes a given \fBsubjectrx\fP from the
-substitution list. If \fB*\fP is used as the pattern, all
+substitution list. If \(lq\fB*\fP\(rq is used as the pattern, all
 substitutions will be removed.
 .PP
 .nf
@@ -629,7 +629,7 @@ Run a command periodically when NeoMutt checks for new mail.
 This hook is called every $timeout seconds.
 .PP
 .nf
-\fBunhook\fP [\fB * \fP | \fIhook-type\fP ]
+\fBunhook\fP [ \fB*\fP | \fIhook-type\fP ]
 .fi
 .IP
 This command will remove all hooks of a given type, or all hooks
@@ -638,13 +638,13 @@ can be any of the \fB-hook\fP commands documented above.
 .PP
 .SH PATTERNS
 .PP
-In various places with neomutt, including some of the above mentioned
+In various places with NeoMutt, including some of the above mentioned
 \fBhook\fP commands, you can specify patterns to match messages.
 .SS Constructing Patterns
 .PP
 A simple pattern consists of an operator of the form
 \(lq\fB~\fP\fIcharacter\fP\(rq, possibly followed by a parameter
-against which neomutt is supposed to match the object specified by
+against which NeoMutt is supposed to match the object specified by
 this operator.  For some \fIcharacter\fPs, the \fB~\fP may be
 replaced by another character to alter the behavior of the match.
 These are described in the list of operators, below.
@@ -844,12 +844,12 @@ followed by a year specifications.  Omitted fields default to the
 current month and year.
 .PP
 NeoMutt understands either two or four digit year specifications.  When
-given a two-digit year, neomutt will interpret values less than 70 as
+given a two-digit year, NeoMutt will interpret values less than 70 as
 lying in the 21st century (i.e., \(lq38\(rq means 2038 and not 1938,
 and \(lq00\(rq is interpreted as 2000), and values
 greater than or equal to 70 as lying in the 20th century.
 .PP
-Note that this behavior \fIis\fP Y2K compliant, but that neomutt
+Note that this behavior \fIis\fP Y2K compliant, but that NeoMutt
 \fIdoes\fP have a Y2.07K problem.
 .PP
 If a date range consists of a single date, the operator in question

--- a/doc/neomuttrc.man.head
+++ b/doc/neomuttrc.man.head
@@ -108,8 +108,8 @@ a regular expression from the list of known alternates. The \fB-group\fP flag
 causes all of the subsequent regular expressions to be added to the named group.
 .PP
 .nf
-\fBalternative_order\fP \fItype\fP[\fB/\fP\fIsubtype\fP] [ ... ]
-\fBunalternative_order\fP [ \fB*\fP | \fItype\fP/\fIsubtype\fP] [...]
+\fBalternative_order\fP \fImime-type\fP[\fB/\fP\fImime-subtype\fP] [ \fImime-type\fP[\fB/\fP\fImime-subtype\fP] ... ]
+\fBunalternative_order\fP [ \fB*\fP | \fImime-type\fP[\fB/\fP\fImime-subtype\fP] ... ]
 .fi
 .IP
 \fBalternative_order\fP command permits you to define an order of preference which is
@@ -158,8 +158,8 @@ but the minor part may be a regular expression. (Therefore, \(lq\fB*/.*\fP\(rq
 matches any MIME type.)
 .PP
 .nf
-\fBauto_view\fP \fItype\fP[\fB/\fP\fIsubtype\fP] [ ... ]
-\fBunauto_view\fP \fItype\fP[\fB/\fP\fIsubtype\fP] [ ... ]
+\fBauto_view\fP \fImime-type\fP[\fB/\fP\fImime-subtype\fP] [ \fImime-type\fP[\fB/\fP\fImime-subtype\fP] ... ]
+\fBunauto_view\fP [ \fB*\fP | \fImime-type\fP[\fB/\fP\fImime-subtype\fP] ... ]
 .fi
 .IP
 This commands permits you to specify that NeoMutt should automatically

--- a/doc/neomuttrc.man.head
+++ b/doc/neomuttrc.man.head
@@ -26,7 +26,7 @@
 .ft
 .fi
 ..
-.TH neomuttrc 5 "September 2002" Unix "User Manuals"
+.TH neomuttrc 5 "@TS_MAN_CONF@" Unix "User Manuals"
 .SH NAME
 neomuttrc \- Configuration file for the NeoMutt Mail User Agent
 .SH DESCRIPTION

--- a/doc/neomuttrc.man.head
+++ b/doc/neomuttrc.man.head
@@ -75,6 +75,13 @@ like sh and bash: Prepend the name of the variable by a dollar
 .SH COMMANDS
 .PP
 .nf
+\fBaccount-hook\fP [\fB!\fP]\fIregex\fP \fIcommand\fP
+.fi
+.IP
+This hook is executed whenever you access a remote mailbox. Useful
+to adjust configuration settings to different IMAP or POP servers.
+.PP
+.nf
 \fBalias\fP [\fB-group\fP \fIname\fP [...]] \fIkey\fP \fIaddress\fP [\fB,\fP \fIaddress\fP [ ... ]]
 \fBunalias\fP [\fB * \fP | \fIkey\fP ]
 .fi
@@ -87,28 +94,6 @@ Name)\(rq.
 all aliases when \(lq\fB*\fP\(rq is used as an argument. The optional
 \fB-group\fP argument to \fBalias\fP causes the aliased address(es) to be
 added to the named \fIgroup\fP.
-.PP
-.nf
-\fBgroup\fP [\fB-group\fP \fIname\fP] [\fB-rx\fP \fIEXPR\fP [ \fI...\fP ]] [\fB-addr\fP \fIaddress\fP [ \fI...\fP ]]
-\fBungroup\fP [\fB-group\fP \fIname\fP ] [ \fB*\fP | [[\fB-rx\fP \fIEXPR\fP [ \fI...\fP ]] [\fB-addr\fP \fIaddress\fP [ \fI...\fP ]]]
-.fi
-.IP
-\fBgroup\fP is used to directly add either addresses or regular expressions to
-the specified group or groups. The different categories of arguments to the
-\fBgroup\fP command can be in any order. The flags \fI-rx\fP and \fI-addr\fP
-specify what the following strings (that cannot begin with a hyphen) should be
-interpreted as: either a regular expression or an email address, respectively.
-\fBungroup\fP is used to remove addresses or regular expressions from the
-specified group or groups. The syntax is similar to the \fBgroup\fP command,
-however the special character \fB*\fP can be used to empty a group of all of
-its contents.
-.IP
-These address groups can also be created implicitly by the \fBalias\fP, \fBlists\fP,
-\fBsubscribe\fP and \fBalternates\fP commands by specifying the optional \fI-group\fP
-option.
-.IP
-Once defined, these address groups can be used in patterns to search for and limit the
-display to messages matching a group.
 .PP
 .nf
 \fBalternates\fP [\fB-group\fP \fIname\fP] \fIregex\fP [ \fIregex\fP [ ... ]]
@@ -136,6 +121,24 @@ ordered list or deletes the entire list when \(lq\fB*\fP\(rq is used
 as an argument.
 .PP
 .nf
+\fBappend-hook\fP \fIregex\fP "\fIcommand\fP"
+\fBclose-hook\fP \fIregex\fP "\fIcommand\fP"
+\fBopen-hook\fP \fIregex\fP "\fIcommand\fP"
+.fi
+.IP
+These commands provide a way to handle compressed folders. The given
+\fBregex\fP specifies which folders are taken as compressed (e.g.
+"\fI\\\\.gz$\fP"). The commands tell NeoMutt how to uncompress a folder
+(\fBopen-hook\fP), compress a folder (\fBclose-hook\fP) or append a
+compressed mail to a compressed folder (\fBappend-hook\fP). The
+\fIcommand\fP string is the
+.BR printf (3)
+like format string, and it should accept two parameters: \fB%f\fP,
+which is replaced with the (compressed) folder name, and \fB%t\fP
+which is replaced with the name of the temporary folder to which to
+write.
+.PP
+.nf
 \fBauto_view\fP \fItype\fP[\fB/\fP\fIsubtype\fP] [ ... ]
 \fBunauto_view\fP \fItype\fP[\fB/\fP\fIsubtype\fP] [ ... ]
 .fi
@@ -150,18 +153,9 @@ flag set.  A subtype of \(lq\fB*\fP\(rq
 matches any subtype, as does an empty subtype.
 .PP
 .nf
-\fBmime_lookup\fP \fItype\fP[\fB/\fP\fIsubtype\fP] [ ... ]
-\fBunmime_lookup\fP \fItype\fP[\fB/\fP\fIsubtype\fP] [ ... ]
+\fBbind\fP \fImap1,map2,...\fP \fIkey\fP \fIfunction\fP
 .fi
 .IP
-This command permits you to define a list of "data" MIME content
-types for which neomutt will try to determine the actual file type from
-the file name, and not use a
-.BR mailcap (5)
-entry given for the original MIME type.  For instance, you may add
-the \fBapplication/octet-stream\fP MIME type to this list.
-.TP
-\fBbind\fP \fImap1,map2,...\fP \fIkey\fP \fIfunction\fP
 This command binds the given \fIkey\fP for the given \fImap\fP or maps
 to the given \fIfunction\fP. Multiple maps may be specified by
 separating them with commas (no whitespace is allowed).
@@ -176,61 +170,14 @@ Valid maps are:
 For more information on keys and functions, please consult the NeoMutt
 Manual. Note that the function name is to be specified without
 angle brackets.
-.TP
-\fBaccount-hook\fP [\fB!\fP]\fIregex\fP \fIcommand\fP
-This hook is executed whenever you access a remote mailbox. Useful
-to adjust configuration settings to different IMAP or POP servers.
-.TP
+.PP
+.nf
 \fBcharset-hook\fP \fIalias\fP \fIcharset\fP
+.fi
+.IP
 This command defines an alias for a character set.  This is useful
 to properly display messages which are tagged with a character set
 name not known to neomutt.
-.TP
-\fBiconv-hook\fP \fIcharset\fP \fIlocal-charset\fP
-This command defines a system-specific name for a character set.
-This is useful when your system's
-.BR iconv (3)
-implementation does not understand MIME character set names (such as
-.BR iso-8859-1 ),
-but instead insists on being fed with implementation-specific
-character set names (such as
-.BR 8859-1 ).
-In this specific case, you'd put this into your configuration file:
-.IP
-.B "iconv-hook iso-8859-1 8859-1"
-.TP
-\fBmessage-hook\fP [\fB!\fP]\fIpattern\fP \fIcommand\fP
-Before neomutt displays (or formats for replying or forwarding) a
-message which matches the given \fIpattern\fP (or, when it is
-preceded by an exclamation mark, does not match the \fIpattern\fP),
-the given \fIcommand\fP is executed.  When multiple
-\fBmessage-hook\fPs match, they are  executed  in  the order in
-which they occur in the configuration file.
-.TP
-\fBtimeout-hook\fP \fIcommand\fP
-Run a command periodically when NeoMutt checks for new mail.
-This hook is called every $timeout seconds.
-.TP
-\fBstartup-hook\fP \fIcommand\fP
-Before neomutt opens the first mailbox when first starting, neomutt will run the
-startup hook for the given \fIcommand\fP.
-.TP
-\fBshutdown-hook\fP \fIcommand\fP
-Before neomutt is about to exit, and before the mailbox is closed, neomutt will run
-the shutdown hook for the given \fIcommand\fP.
-.TP
-\fBfolder-hook\fP [\fB!\fP]\fIregex\fP \fIcommand\fP
-When neomutt enters a folder which matches \fIregex\fP (or, when
-\fIregex\fP is preceded by an exclamation mark, does not match
-\fIregex\fP), the given \fIcommand\fP is executed.
-.IP
-When several \fBfolder-hook\fPs match a given mail folder, they are
-executed in the order given in the configuration file.
-.TP
-\fBmacro\fP \fImap\fP \fIkey\fP \fIsequence\fP [ \fIdescription\fP ]
-This command binds the given \fIsequence\fP of keys to the given
-\fIkey\fP in the given \fImap\fP or maps.  For valid maps, see \fBbind\fP. To
-specify multiple maps, put only a comma between the maps.
 .PP
 .nf
 \fBcolor\fP \fIobject\fP \fIforeground\fP \fIbackground\fP [ \fIregex\fP ]
@@ -260,16 +207,95 @@ Valid colors include:
 .BR cyan ", " yellow ", " red ", " default ", " color\fIN\fP .
 .PP
 .nf
-\fBmono\fP \fIobject\fP \fIattribute\fP [ \fIregex\fP ]
-\fBmono\fP index \fIattribute\fP [ \fIpattern\fP ]
+\fBcrypt-hook\fP \fIregex\fP \fIkey-id\fP
 .fi
 .IP
-For terminals which don't support color, you can still assign
-attributes to objects.  Valid attributes include:
-.BR none ", " bold ", " underline ", "
-.BR reverse ", and " standout .
-.TP
-[\fBun\fP]\fBignore\fP \fIpattern\fP [ \fIpattern\fP ... ]
+The crypt-hook command provides a method by which you can
+specify the ID of the public key to be used when encrypting messages
+to a certain recipient.  The meaning of "key ID" is to be taken
+broadly: This can be a different e-mail address, a numerical key ID,
+or even just an arbitrary search string.
+You may use multiple
+\fBcrypt-hook\fPs with the same \fIregex\fP; multiple matching
+\fBcrypt-hook\fPs result in the use of multiple \fIkey-id\fPs for
+a recipient.
+.PP
+.nf
+\fBfcc-hook\fP [\fB!\fP]\fIpattern\fP \fIfilename\fP
+\fBsave-hook\fP [\fB!\fP]\fIpattern\fP \fIfilename\fP
+\fBfcc-save-hook\fP [\fB!\fP]\fIpattern\fP \fIfilename\fP
+.ni
+.IP
+\fBfcc-hook\fP: When an outgoing message matches \fIpattern\fP, the default file
+name for storing a copy (fcc) will be the given \fIfilename\fP.
+.IP
+\fBsave-hook\fP: When a message matches \fIpattern\fP, the default file name when
+saving it will be the given \fIfilename\fP.
+.IP
+\fBfcc-save-hook\fP: This command is an abbreviation for identical \fBfcc-hook\fP and
+\fBsave-hook\fP commands.
+.PP
+.nf
+\fBfolder-hook\fP [\fB!\fP]\fIregex\fP \fIcommand\fP
+.fi
+.IP
+When neomutt enters a folder which matches \fIregex\fP (or, when
+\fIregex\fP is preceded by an exclamation mark, does not match
+\fIregex\fP), the given \fIcommand\fP is executed.
+.IP
+When several \fBfolder-hook\fPs match a given mail folder, they are
+executed in the order given in the configuration file.
+.PP
+.nf
+\fBgroup\fP [\fB-group\fP \fIname\fP] [\fB-rx\fP \fIEXPR\fP [ \fI...\fP ]] [\fB-addr\fP \fIaddress\fP [ \fI...\fP ]]
+\fBungroup\fP [\fB-group\fP \fIname\fP ] [ \fB*\fP | [[\fB-rx\fP \fIEXPR\fP [ \fI...\fP ]] [\fB-addr\fP \fIaddress\fP [ \fI...\fP ]]]
+.fi
+.IP
+\fBgroup\fP is used to directly add either addresses or regular expressions to
+the specified group or groups. The different categories of arguments to the
+\fBgroup\fP command can be in any order. The flags \fI-rx\fP and \fI-addr\fP
+specify what the following strings (that cannot begin with a hyphen) should be
+interpreted as: either a regular expression or an email address, respectively.
+\fBungroup\fP is used to remove addresses or regular expressions from the
+specified group or groups. The syntax is similar to the \fBgroup\fP command,
+however the special character \fB*\fP can be used to empty a group of all of
+its contents.
+.IP
+These address groups can also be created implicitly by the \fBalias\fP, \fBlists\fP,
+\fBsubscribe\fP and \fBalternates\fP commands by specifying the optional \fI-group\fP
+option.
+.IP
+Once defined, these address groups can be used in patterns to search for and limit the
+display to messages matching a group.
+.PP
+.nf
+\fBhdr_order\fP \fIheader1\fP \fIheader2\fP [ ... ]
+.fi
+.IP
+With this command, you can specify an order in which neomutt will
+attempt to present headers to you when viewing messages.
+.PP
+.nf
+\fBiconv-hook\fP \fIcharset\fP \fIlocal-charset\fP
+.fi
+.IP
+This command defines a system-specific name for a character set.
+This is useful when your system's
+.BR iconv (3)
+implementation does not understand MIME character set names (such as
+.BR iso-8859-1 ),
+but instead insists on being fed with implementation-specific
+character set names (such as
+.BR 8859-1 ).
+In this specific case, you'd put this into your configuration file:
+.IP
+.B "iconv-hook iso-8859-1 8859-1"
+.PP
+.nf
+\fBignore\fP \fIpattern\fP [ \fIpattern\fP ... ]
+\fBunignore\fP \fIpattern\fP [ \fIpattern\fP ... ]
+.fi
+.IP
 The \fBignore\fP command permits you to specify header fields which
 you usually don't wish to see.  Any header field whose tag
 \fIbegins\fP with an \(lqignored\(rq pattern will be ignored.
@@ -295,13 +321,14 @@ list from the lists of known and subscribed mailing lists.  The
 and subscribed mailing lists.  The \fBunsubscribe\fP command removes
 it from the list of subscribed mailing lists. The \fB-group\fP flag
 adds all of the subsequent regular expressions to the named group.
-.TP
-\fBmbox-hook\fP [\fB!\fP]\fIregex\fP \fImailbox\fP
-When neomutt changes to a mail folder which matches \fIregex\fP,
-\fImailbox\fP will be used as the \(lqmbox\(rq folder, i.e., read
-messages will be moved to that folder when the mail folder is left.
+.PP
+.nf
+\fBmacro\fP \fImap\fP \fIkey\fP \fIsequence\fP [ \fIdescription\fP ]
+.fi
 .IP
-The first matching \fBmbox-hook\fP applies.
+This command binds the given \fIsequence\fP of keys to the given
+\fIkey\fP in the given \fImap\fP or maps.  For valid maps, see \fBbind\fP. To
+specify multiple maps, put only a comma between the maps.
 .PP
 .nf
 \fBmailboxes\fP \fIfilename\fP [ \fIfilename\fP ... ]
@@ -316,6 +343,61 @@ can receive mail.  If "\fB*\fP" is specified as the file name, the
 list is emptied.
 .PP
 .nf
+\fBmailto_allow\fP \fIheader-field\fP [ ... ]
+\fBunmailto_allow\fP [ \fB*\fP | \fIheader-field\fP ... ]
+.fi
+.IP
+These commands allow the user to modify the list of allowed header
+fields in a \fImailto:\fP URL that NeoMutt will include in the
+the generated message.  By default the list contains
+\fBsubject\fP and \fBbody\fP, as specified by RFC2368; and
+\fBcc\fP, \fBin-reply-to\fP, and \fBreferences\fP to aid with
+mailto links from mailing lists.
+.PP
+.nf
+\fBmbox-hook\fP [\fB!\fP]\fIregex\fP \fImailbox\fP
+.fi
+.IP
+When neomutt changes to a mail folder which matches \fIregex\fP,
+\fImailbox\fP will be used as the \(lqmbox\(rq folder, i.e., read
+messages will be moved to that folder when the mail folder is left.
+.IP
+The first matching \fBmbox-hook\fP applies.
+.PP
+.nf
+\fBmessage-hook\fP [\fB!\fP]\fIpattern\fP \fIcommand\fP
+.fi
+.IP
+Before neomutt displays (or formats for replying or forwarding) a
+message which matches the given \fIpattern\fP (or, when it is
+preceded by an exclamation mark, does not match the \fIpattern\fP),
+the given \fIcommand\fP is executed.  When multiple
+\fBmessage-hook\fPs match, they are  executed  in  the order in
+which they occur in the configuration file.
+.PP
+.nf
+\fBmime_lookup\fP \fItype\fP[\fB/\fP\fIsubtype\fP] [ ... ]
+\fBunmime_lookup\fP \fItype\fP[\fB/\fP\fIsubtype\fP] [ ... ]
+.fi
+.IP
+This command permits you to define a list of "data" MIME content
+types for which neomutt will try to determine the actual file type from
+the file name, and not use a
+.BR mailcap (5)
+entry given for the original MIME type.  For instance, you may add
+the \fBapplication/octet-stream\fP MIME type to this list.
+.PP
+.nf
+\fBmono\fP \fIobject\fP \fIattribute\fP [ \fIregex\fP ]
+\fBmono\fP index \fIattribute\fP [ \fIpattern\fP ]
+.fi
+.IP
+For terminals which don't support color, you can still assign
+attributes to objects.  Valid attributes include:
+.BR none ", " bold ", " underline ", "
+.BR reverse ", and " standout .
+.PP
+.nf
 \fBmy_hdr\fP \fIstring\fP
 \fBunmy_hdr\fP \fIfield\fP
 .fi
@@ -323,29 +405,35 @@ list is emptied.
 Using \fBmy_hdr\fP, you can define headers which will be added to
 the messages you compose.  \fBunmy_hdr\fP will remove the given
 user-defined headers.
-.TP
-\fBhdr_order\fP \fIheader1\fP \fIheader2\fP [ ... ]
-With this command, you can specify an order in which neomutt will
-attempt to present headers to you when viewing messages.
-.TP
-\fBsave-hook\fP [\fB!\fP]\fIpattern\fP \fIfilename\fP
-When a message matches \fIpattern\fP, the default file name when
-saving it will be the given \fIfilename\fP.
-.TP
-\fBfcc-hook\fP [\fB!\fP]\fIpattern\fP \fIfilename\fP
-When an outgoing message matches \fIpattern\fP, the default file
-name for storing a copy (fcc) will be the given \fIfilename\fP.
-.TP
-\fBfcc-save-hook\fP [\fB!\fP]\fIpattern\fP \fIfilename\fP
-This command is an abbreviation for identical \fBfcc-hook\fP and
-\fBsave-hook\fP commands.
-.TP
+.PP
+.nf
+\fBpush\fP \fIstring\fP
+.fi
+.IP
+This command adds the named \fIstring\fP to the keyboard buffer.
+.PP
+.nf
+\fBreply-hook\fP [\fB!\fP]\fIpattern\fP \fIcommand\fP
+.fi
+.IP
+When replying to a message matching \fIpattern\fP, \fIcommand\fP is
+executed.  When multiple \fBreply-hook\fPs match, they are executed
+in the order in which they occur in the configuration file, but all
+\fBreply-hook\fPs are matched and executed before \fBsend-hook\fPs,
+regardless of their order in the configuration file.
+.PP
+.nf
 \fBsend-hook\fP [\fB!\fP]\fIpattern\fP \fIcommand\fP
+.fi
+.IP
 When composing a message matching \fIpattern\fP, \fIcommand\fP is
 executed.  When multiple \fBsend-hook\fPs match, they are executed
 in the order in which they occur in the configuration file.
-.TP
+.PP
+.nf
 \fBsend2-hook\fP [\fB!\fP]\fIpattern\fP \fIcommand\fP
+.fi
+.IP
 Whenever a message matching \fIpattern\fP is changed (either by
 editing it or by using the compose menu), \fIcommand\fP
 is executed. When multiple \fBsend2-hook\fPs match, they are
@@ -355,51 +443,12 @@ message's from header is changed.
 .IP
 \fBsend2-hook\fP execution is not triggered by use of
 \fBenter-command\fP from the compose menu.
-.TP
-\fBreply-hook\fP [\fB!\fP]\fIpattern\fP \fIcommand\fP
-When replying to a message matching \fIpattern\fP, \fIcommand\fP is
-executed.  When multiple \fBreply-hook\fPs match, they are executed
-in the order in which they occur in the configuration file, but all
-\fBreply-hook\fPs are matched and executed before \fBsend-hook\fPs,
-regardless of their order in the configuration file.
-.TP
-\fBcrypt-hook\fP \fIregex\fP \fIkey-id\fP
-The crypt-hook command provides a method by which you can
-specify the ID of the public key to be used when encrypting messages
-to a certain recipient.  The meaning of "key ID" is to be taken
-broadly: This can be a different e-mail address, a numerical key ID,
-or even just an arbitrary search string.
-You may use multiple
-\fBcrypt-hook\fPs with the same \fIregex\fP; multiple matching
-\fBcrypt-hook\fPs result in the use of multiple \fIkey-id\fPs for
-a recipient.
-.PP
-.nf
-\fBopen-hook\fP \fIregex\fP "\fIcommand\fP"
-\fBclose-hook\fP \fIregex\fP "\fIcommand\fP"
-\fBappend-hook\fP \fIregex\fP "\fIcommand\fP"
-.fi
-.IP
-These commands provide a way to handle compressed folders. The given
-\fBregex\fP specifies which folders are taken as compressed (e.g.
-"\fI\\\\.gz$\fP"). The commands tell NeoMutt how to uncompress a folder
-(\fBopen-hook\fP), compress a folder (\fBclose-hook\fP) or append a
-compressed mail to a compressed folder (\fBappend-hook\fP). The
-\fIcommand\fP string is the
-.BR printf (3)
-like format string, and it should accept two parameters: \fB%f\fP,
-which is replaced with the (compressed) folder name, and \fB%t\fP
-which is replaced with the name of the temporary folder to which to
-write.
-.TP
-\fBpush\fP \fIstring\fP
-This command adds the named \fIstring\fP to the keyboard buffer.
 .PP
 .nf
 \fBset\fP [\fBno\fP|\fBinv\fP|\fB&\fP|\fB?\fP]\fIvariable\fP[=\fIvalue\fP] [ ... ]
-\fBtoggle\fP \fIvariable\fP [ ... ]
 \fBunset\fP \fIvariable\fP [ ... ]
 \fBreset\fP \fIvariable\fP [ ... ]
+\fBtoggle\fP \fIvariable\fP [ ... ]
 .fi
 .IP
 These commands are used to set and manipulate configuration
@@ -427,8 +476,18 @@ default answer of \(lqno.\(rq
 The \fBreset\fP command resets all given variables to the compile
 time defaults.  If you reset the special variable \fBall\fP, all
 variables will reset to their compile time defaults.
-.TP
+.PP
+.nf
+\fBshutdown-hook\fP \fIcommand\fP
+.fi
+.IP
+Before neomutt is about to exit, and before the mailbox is closed, neomutt will run
+the shutdown hook for the given \fIcommand\fP.
+.PP
+.nf
 \fBsource\fP \fIfilename\fP
+.fi
+.IP
 The given file will be evaluated as a configuration file.
 .PP
 .nf
@@ -440,6 +499,13 @@ These commands define spam-detection patterns from external spam
 filters, so that neomutt can sort, limit, and search on
 ``spam tags'' or ``spam attributes'', or display them
 in the index. See the NeoMutt manual for details.
+.PP
+.nf
+\fBstartup-hook\fP \fIcommand\fP
+.fi
+.IP
+Before neomutt opens the first mailbox when first starting, neomutt will run the
+startup hook for the given \fIcommand\fP.
 .PP
 .nf
 \fBsubjectrx\fP \fIpattern\fP \fIreplacement\fP
@@ -461,23 +527,22 @@ subject, not just the match!
 \fBunsubjectrx\fP removes a given \fBsubjectrx\fP from the
 substitution list. If \fB*\fP is used as the pattern, all
 substitutions will be removed.
-.TP
+.PP
+.nf
+\fBtimeout-hook\fP \fIcommand\fP
+.fi
+.IP
+Run a command periodically when NeoMutt checks for new mail.
+This hook is called every $timeout seconds.
+.PP
+.nf
 \fBunhook\fP [\fB * \fP | \fIhook-type\fP ]
+.fi
+.IP
 This command will remove all hooks of a given type, or all hooks
 when \(lq\fB*\fP\(rq is used as an argument.  \fIhook-type\fP
 can be any of the \fB-hook\fP commands documented above.
 .PP
-.nf
-\fBmailto_allow\fP \fIheader-field\fP [ ... ]
-\fBunmailto_allow\fP [ \fB*\fP | \fIheader-field\fP ... ]
-.fi
-.IP
-These commands allow the user to modify the list of allowed header
-fields in a \fImailto:\fP URL that NeoMutt will include in the
-the generated message.  By default the list contains
-\fBsubject\fP and \fBbody\fP, as specified by RFC2368; and
-\fBcc\fP, \fBin-reply-to\fP, and \fBreferences\fP to aid with
-mailto links from mailing lists.
 .SH PATTERNS
 .PP
 In various places with neomutt, including some of the above mentioned

--- a/doc/neomuttrc.man.tail
+++ b/doc/neomuttrc.man.tail
@@ -1,20 +1,33 @@
-.\" -*-nroff-*-
+.\" -*- nroff -*-
+.\" --------------------------------------------------------------------
 .SH SEE ALSO
+.\"   - sorted by category and name
+.\" --------------------------------------------------------------------
 .PP
 .BR iconv (1),
+.BR neomutt (1),
+.BR notmuch (1),
 .BR iconv (3),
+.BR printf (3),
+.BR strftime (3),
 .BR mailcap (5),
 .BR maildir (5),
 .BR mbox (5),
-.BR neomutt (1),
-.BR printf (3),
-.BR regex (7),
-.BR strftime (3)
+.BR regex (7).
+.
 .PP
-The NeoMutt Manual
-.PP
-The NeoMutt home page: https://www.neomutt.org
+For further NeoMutt information:
+.RS 4
+.TP
+.RI "\(bu the full manual, " "@MAN_DOCDIR@/manual." { html , pdf , txt }
+.TQ
+\(bu the home page, <https://www.neomutt.org>
+.RE
+.
+.\" --------------------------------------------------------------------
 .SH AUTHOR
+.\" --------------------------------------------------------------------
 .PP
-Michael Elkins, and others.  Use <neomutt-devel@neomutt.org> to contact
-the developers.
+Michael Elkins, and others. Use <neomutt-devel@\:neomutt.org> to contact the
+developers.
+.

--- a/doc/neomuttrc.man.tail
+++ b/doc/neomuttrc.man.tail
@@ -1,9 +1,9 @@
 .\" -*- nroff -*-
 .\" --------------------------------------------------------------------
 .SH SEE ALSO
-.\"   - sorted by category and name
 .\" --------------------------------------------------------------------
 .PP
+.\" sorted by category and name
 .BR iconv (1),
 .BR neomutt (1),
 .BR notmuch (1),

--- a/doc/neomuttrc.man.tail
+++ b/doc/neomuttrc.man.tail
@@ -11,9 +11,9 @@
 .BR regex (7),
 .BR strftime (3)
 .PP
-The Neomutt Manual
+The NeoMutt Manual
 .PP
-The Neomutt home page: https://www.neomutt.org
+The NeoMutt home page: https://www.neomutt.org
 .SH AUTHOR
 .PP
 Michael Elkins, and others.  Use <neomutt-devel@neomutt.org> to contact

--- a/sendlib.c
+++ b/sendlib.c
@@ -972,7 +972,7 @@ struct Content *mutt_get_content_info(const char *fname, struct Body *b)
  *
  * Given a file at `path`, see if there is a registered MIME type.
  * Returns the major MIME type, and copies the subtype to ``d''.  First look
- * for ~/.mime.types, then look in a system mime.types if we can find one.
+ * in a system mime.types if we can find one, then look for ~/.mime.types.
  * The longest match is used so that we can match `ps.gz' when `gz' also
  * exists.
  */


### PR DESCRIPTION
* **What does this PR do?**

  The main goal is to build sorted lists of commands, functions and variables
  for the documentation (`manual.xml`, `neomuttrc`, `neomuttrc.man`).

  The latter needs further decisions, because the commands section in
  `neomuttrc(5)` differs, due to usage of file `doc/neomuttrc.man.head`, from
  the generated content of `manual.xml`. Also it is probably about the time
  for timestamp updates within the manual pages:

    - `doc/neomutt.man:20`               ... neomutt 1 "January 2009" Unix "User Manuals"
    - `doc/neomuttrc.man.head:29` ... neomuttrc 5 "September 2002" Unix "User Manuals"

  with the release version date, maybe?

* **Are there points in the code the reviewer needs to double check?**

  If the code re-sort is OK, nothing special yet, I think. The most changes are
  code line moves. Some real changes are related to indentation fixes and
  splitting up some of the preprocessor directives.

  Compiling with `--full-doc` works as usual.
