### PR TITLE
Add support for direct color values when using slang

### DIFF
--- a/auto.def
+++ b/auto.def
@@ -592,6 +592,7 @@ switch [opt-val with-ui ncurses] {
     }
     define USE_SLANG_CURSES
     define-feature COLOR
+    define-feature DIRECTCOLOR
   }
 
   default {

--- a/color.h
+++ b/color.h
@@ -26,9 +26,9 @@
 struct Buffer;
 
 void ci_start_color(void);
-int  mutt_alloc_color(int fg, int bg);
-int  mutt_combine_color(int fg_attr, int bg_attr);
-void mutt_free_color(int fg, int bg);
+int  mutt_alloc_color(uint32_t fg, uint32_t bg);
+int  mutt_combine_color(uint32_t fg_attr, uint32_t bg_attr);
+void mutt_free_color(uint32_t fg, uint32_t bg);
 void mutt_free_colors(void);
 enum CommandResult mutt_parse_color(struct Buffer *buf, struct Buffer *s, unsigned long data, struct Buffer *err);
 enum CommandResult mutt_parse_mono(struct Buffer *buf, struct Buffer *s, unsigned long data, struct Buffer *err);

--- a/mutt_curses.h
+++ b/mutt_curses.h
@@ -182,8 +182,8 @@ struct ColorLine
   char *pattern;
   struct Pattern *color_pattern; /**< compiled pattern to speed up index color
                                       calculation */
-  short fg;
-  short bg;
+  uint32_t fg;
+  uint32_t bg;
   int pair;
   STAILQ_ENTRY(ColorLine) entries;
 


### PR DESCRIPTION
slang supports using direct color values in order to create color pairs, this means that neomutt is not limited to the console color palette.

The same is not possible with ncurses, since it doesn't support direct-color values ATM. The only way to have custom colors in ncurses is to set them in the terminal palette, which is very antisocial because there's no way to revert back to the original palette afterwards, leaving the console after quitting neomutt in a weird state (color-wise).

This series adds supports for RGB color values in the neomutt config file, like the following example:

https://gist.github.com/royger/80c8aeff38567aa47274165f2da19117

This is the solarized dark color scheme from:

https://github.com/altercation/mutt-colors-solarized/blob/master/mutt-colors-solarized-dark-256.muttrc

This is a minimal change in order to get some RGB color support, in order to get something similar with ncurses neomutt will have to print it's own escape sequences interleaved with ncurses, which is far from trivial AFAICT.

