### PR TITLE
Logging improvements (prevent DoS)

### DIFF
--- a/curs_lib.c
+++ b/curs_lib.c
@@ -737,7 +737,7 @@ void mutt_window_getyx(struct MuttWindow *win, int *y, int *x)
 
 void mutt_show_error(void)
 {
-  if (OPT_KEEP_QUIET)
+  if (OPT_KEEP_QUIET || !ErrorBufMessage)
     return;
 
   SETCOLOR(OPT_MSG_ERR ? MT_COLOR_ERROR : MT_COLOR_MESSAGE);

--- a/globals.h
+++ b/globals.h
@@ -37,6 +37,7 @@
 
 WHERE struct Context *Context;
 
+WHERE bool ErrorBufMessage;
 WHERE char ErrorBuf[STRING];
 WHERE char AttachmentMarker[STRING];
 

--- a/main.c
+++ b/main.c
@@ -877,7 +877,7 @@ int main(int argc, char **argv, char **env)
     rv = ci_send_message(sendflags, msg, bodyfile, NULL, NULL);
     /* We WANT the "Mail sent." and any possible, later error */
     log_queue_empty();
-    if (ErrorBuf[0])
+    if (ErrorBufMessage)
       mutt_message("%s", ErrorBuf);
 
     if (edit_infile)
@@ -1046,7 +1046,7 @@ main_curses:
   log_queue_flush(log_disp_terminal);
   mutt_log_stop();
   /* Repeat the last message to the user */
-  if (repeat_error && ErrorBuf[0])
+  if (repeat_error && ErrorBufMessage)
     puts(ErrorBuf);
 main_exit:
   return rc;

--- a/menu.c
+++ b/menu.c
@@ -479,7 +479,7 @@ static void menu_redraw_prompt(struct Menu *menu)
       OPT_MSG_ERR = false;
     }
 
-    if (*ErrorBuf)
+    if (ErrorBufMessage)
       mutt_clear_error();
 
     mutt_window_mvaddstr(menu->messagewin, 0, 0, menu->prompt);


### PR DESCRIPTION
- bbd5beef use sleep_time as error wait time
- 11f3f6cb Don't pause after duplicate messages

The new logging system mean that holding down <kbd>j</kbd> would bombard the user with hundreds of duplicate errors: "You are on the last message.", pausing for 1 second after each.

Fixes #1100 