### PR TITLE
fix Notmuch deprecation warning

### DIFF
--- a/auto.def
+++ b/auto.def
@@ -429,17 +429,14 @@ if {[get-define want-notmuch]} {
   }
   define USE_NOTMUCH
   msg-checking "Checking for Notmuch API version 3..."
-  if {[cctest -includes {notmuch.h} \
-              -code {
-                notmuch_database_open("/path",
-                                      NOTMUCH_DATABASE_MODE_READ_ONLY,
-                                      (notmuch_database_t**)NULL);
-              }]} {
+  if {[cctest -includes {notmuch.h} -libs {-lnotmuch} -link 1 \
+      -code { notmuch_database_open(NULL, 0, NULL); }]} {
     define NOTMUCH_API_3
     msg-result "yes"
   } else {
     msg-result "no"
   }
+  cc-check-function-in-lib notmuch_database_index_file notmuch
 }
 
 ###############################################################################

--- a/mutt_notmuch.c
+++ b/mutt_notmuch.c
@@ -1425,7 +1425,11 @@ static int rename_filename(struct NmCtxData *data, const char *old,
     return -1;
 
   mutt_debug(2, "nm: rename: add '%s'\n", new);
+#ifdef HAVE_NOTMUCH_DATABASE_INDEX_FILE
+  st = notmuch_database_index_file(db, new, NULL, &msg);
+#else
   st = notmuch_database_add_message(db, new, &msg);
+#endif
 
   if ((st != NOTMUCH_STATUS_SUCCESS) && (st != NOTMUCH_STATUS_DUPLICATE_MESSAGE_ID))
   {
@@ -1460,7 +1464,11 @@ static int rename_filename(struct NmCtxData *data, const char *old,
         {
           mutt_debug(2, "nm: rename dup %s -> %s\n", path, newpath);
           notmuch_database_remove_message(db, path);
+#ifdef HAVE_NOTMUCH_DATABASE_INDEX_FILE
+          notmuch_database_index_file(db, newpath, NULL, NULL);
+#else
           notmuch_database_add_message(db, newpath, NULL);
+#endif
         }
       }
       notmuch_message_destroy(msg);
@@ -2007,7 +2015,11 @@ int nm_record_message(struct Context *ctx, char *path, struct Header *h)
   if (trans < 0)
     goto done;
 
+#ifdef HAVE_NOTMUCH_DATABASE_INDEX_FILE
+  st = notmuch_database_index_file(db, path, NULL, &msg);
+#else
   st = notmuch_database_add_message(db, path, &msg);
+#endif
 
   if ((st != NOTMUCH_STATUS_SUCCESS) && (st != NOTMUCH_STATUS_DUPLICATE_MESSAGE_ID))
   {


### PR DESCRIPTION
We need to distinguish between two versions of `notmuch.h`.
Both declare that they are v5.0.0.  They are:

- libnotmuch 5.0 (Notmuch 0.25)
  - `notmuch_database_add_message()` is a normal function
  - `notmuch_database_index_file()` doesn't exist

- libnotmuch 5.1 (Notmuch 0.26)
  - `notmuch_database_add_message()` is **deprecated**
  - `notmuch_database_index_file()` exists

To work around this, we check for `notmuch_database_index_file()` specifically.

<sub>Edited to match new commit</sub>