### PR TITLE
fix return code for 'neomutt -Z'

### DIFF
--- a/main.c
+++ b/main.c
@@ -532,8 +532,7 @@ int main(int argc, char **argv, char **env)
   }
 
   /* set defaults and read init files */
-  rc = mutt_init(flags & MUTT_NOSYSRC, &commands);
-  if (rc != 0)
+  if (mutt_init(flags & MUTT_NOSYSRC, &commands) != 0)
     goto main_curses;
 
   /* The command line overrides the config */


### PR DESCRIPTION
`neomutt -Z` should return `1` if there's no new mail.
This allows users to use the check in a script.

Fixes #1112 

