### PR TITLE
refactor: startup hostname

### DIFF
--- a/init.c
+++ b/init.c
@@ -3718,11 +3718,85 @@ static char *find_cfg(const char *home, const char *xdg_cfg_home)
   return NULL;
 }
 
+/**
+ * get_hostname - Find the Fully-Qualified Domain Name
+ * @retval true  Success
+ * @retval false Error, failed to find any name
+ *
+ * Use several methods to try to find the Fully-Qualified domain name of this host.
+ * If the user has already configured a hostname, this function will use it.
+ */
+static bool get_hostname(void)
+{
+  char *str = NULL;
+  struct utsname utsname;
+
+  if (Hostname)
+  {
+    str = Hostname;
+  }
+  else
+  {
+    /* The call to uname() shouldn't fail, but if it does, the system is horribly
+     * broken, and the system's networking configuration is in an unreliable
+     * state.  We should bail.  */
+    if ((uname(&utsname)) == -1)
+    {
+      mutt_perror(_("unable to determine nodename via uname()"));
+      return false; // TEST09: can't test
+    }
+
+    str = utsname.nodename;
+  }
+
+  /* some systems report the FQDN instead of just the hostname */
+  char *dot = strchr(str, '.');
+  if (dot)
+    ShortHostname = mutt_str_substr_dup(str, dot);
+  else
+    ShortHostname = mutt_str_strdup(str);
+
+  if (!Hostname)
+  {
+    /* now get FQDN.  Use configured domain first, DNS next, then uname */
+#ifdef DOMAIN
+    /* we have a compile-time domain name, use that for Hostname */
+    Hostname = mutt_mem_malloc(mutt_str_strlen(DOMAIN) + mutt_str_strlen(ShortHostname) + 2);
+    sprintf((char *) Hostname, "%s.%s", NONULL(ShortHostname), DOMAIN);
+#else
+    Hostname = getmailname();
+    if (!Hostname)
+    {
+      char buffer[LONG_STRING];
+      if (getdnsdomainname(buffer, sizeof(buffer)) == 0)
+      {
+        Hostname = mutt_mem_malloc(mutt_str_strlen(buffer) + mutt_str_strlen(ShortHostname) + 2);
+        sprintf((char *) Hostname, "%s.%s", NONULL(ShortHostname), buffer);
+      }
+      else
+      {
+        /* DNS failed, use the nodename.  Whether or not the nodename had a '.'
+         * in it, we can use the nodename as the FQDN.  On hosts where DNS is
+         * not being used, e.g. small network that relies on hosts files, a
+         * short host name is all that is required for SMTP to work correctly.
+         * It could be wrong, but we've done the best we can, at this point the
+         * onus is on the user to provide the correct hostname if the nodename
+         * won't work in their network.  */
+        Hostname = mutt_str_strdup(utsname.nodename);
+      }
+    }
+#endif
+  }
+  if (Hostname)
+    set_default_value("hostname", (intptr_t) mutt_str_strdup(Hostname));
+
+  return true;
+}
+
 int mutt_init(int skip_sys_rc, struct ListHead *commands)
 {
-  struct utsname utsname;
   const char *p = NULL;
-  char buffer[STRING];
+  char buffer[LONG_STRING];
   int need_pause = 0;
   struct Buffer err;
 
@@ -3742,55 +3816,6 @@ int mutt_init(int skip_sys_rc, struct ListHead *commands)
 
   snprintf(AttachmentMarker, sizeof(AttachmentMarker), "\033]9;%" PRIu64 "\a",
            mutt_rand64());
-
-  /* And about the host... */
-
-  /*
-   * The call to uname() shouldn't fail, but if it does, the system is horribly
-   * broken, and the system's networking configuration is in an unreliable
-   * state.  We should bail.
-   */
-  if ((uname(&utsname)) == -1)
-  {
-    mutt_perror(_("unable to determine nodename via uname()"));
-    return 1; // TEST09: can't test
-  }
-
-  /* some systems report the FQDN instead of just the hostname */
-  p = strchr(utsname.nodename, '.');
-  if (p)
-    ShortHostname = mutt_str_substr_dup(utsname.nodename, p);
-  else
-    ShortHostname = mutt_str_strdup(utsname.nodename);
-
-/* now get FQDN.  Use configured domain first, DNS next, then uname */
-#ifdef DOMAIN
-  /* we have a compile-time domain name, use that for Hostname */
-  Hostname = mutt_mem_malloc(mutt_str_strlen(DOMAIN) + mutt_str_strlen(ShortHostname) + 2);
-  sprintf(Hostname, "%s.%s", NONULL(ShortHostname), DOMAIN);
-#else
-  Hostname = getmailname();
-  if (!Hostname)
-  {
-    if (!(getdnsdomainname(buffer, sizeof(buffer))))
-    {
-      Hostname =
-          mutt_mem_malloc(mutt_str_strlen(buffer) + mutt_str_strlen(ShortHostname) + 2);
-      sprintf(Hostname, "%s.%s", NONULL(ShortHostname), buffer);
-    }
-    else
-    {
-      /* DNS failed, use the nodename.  Whether or not the nodename had a '.' in
-       * it, we can use the nodename as the FQDN.  On hosts where DNS is not
-       * being used, e.g. small network that relies on hosts files, a short host
-       * name is all that is required for SMTP to work correctly.  It could be
-       * wrong, but we've done the best we can, at this point the onus is on the
-       * user to provide the correct hostname if the nodename won't work in their
-       * network.  */
-      Hostname = mutt_str_strdup(utsname.nodename);
-    }
-  }
-#endif
 
 #ifdef USE_NNTP
   p = mutt_str_getenv("NNTPSERVER");
@@ -3999,6 +4024,9 @@ int mutt_init(int skip_sys_rc, struct ListHead *commands)
 
   if (execute_commands(commands) != 0)
     need_pause = 1; // TEST13: neomutt -e broken
+
+  if (!get_hostname())
+    return 1;
 
   if (need_pause && !OPT_NO_CURSES)
   {


### PR DESCRIPTION
Refactor the hostname-finding code into a separate function.
Delay the call until after the config and command line have been processed.

This means that some users, with mis-configured network lookups, can work around a long timeout during startup.

---

## Hostname Uses

NeoMutt uses two forms of the hostname:

The **Hostname**, e.g. 'laptop.example.com', is only referenced by `mutt_fqdn()`, which is used to:
- expanding aliases
- determine if an address is _you_
- match encryption keys
- expand outgoing email addresses

The **ShortHostname**, e.g. 'laptop', is used to:
- generate the Message-ID header
- generate some unique temporary filenames
- fallback if the FQDN is missing

## Hostname Sources

To find the hostname the code checks multiple sources in order.
Note: There's no default in `init.h`

1. Config file
   - /etc/neomuttrc
   - ~/.neomuttrc

2. Command line
   - `neomutt -e "set hostname=laptop.example.com"`

3. uname(2)
   - set the ShortHostname (e.g. 'laptop')

4.  First match of:
     1. configured DOMAIN
        `configure --with-domain=example.com`

     2. file
        - `/etc/mailname`
        - `/etc/mail/mailname`

     3. dns
        - `gethostname()` -- For a hostname
        - `getaddrinfo()` or `getaddrinfo_a()` -- For a FQDN