### PR TITLE
refactor config setting

### DIFF
--- a/init.c
+++ b/init.c
@@ -3760,16 +3760,6 @@ int mutt_init(int skip_sys_rc, struct ListHead *commands)
     SpoolFile = mutt_str_strdup(buffer);
   }
 
-  p = mutt_str_getenv("VISUAL");
-  if (!p)
-  {
-    p = mutt_str_getenv("EDITOR");
-    if (!p)
-      p = "vi";
-  }
-  Editor = mutt_str_strdup(p);
-  Visual = mutt_str_strdup(p);
-
   p = mutt_str_getenv("REPLYTO");
   if (p)
   {
@@ -3938,6 +3928,16 @@ int mutt_init(int skip_sys_rc, struct ListHead *commands)
   const char *env_tmp = mutt_str_getenv("TMPDIR");
   if (env_tmp)
     mutt_str_replace(&Tmpdir, env_tmp);
+
+  /* "$visual", "$editor" precedence: environment, config file, code */
+  const char *env_ed = mutt_str_getenv("VISUAL");
+  if (!env_ed)
+    env_ed = mutt_str_getenv("EDITOR");
+  if (env_ed)
+  {
+    mutt_str_replace(&Editor, env_ed);
+    mutt_str_replace(&Visual, env_ed);
+  }
 
   if (need_pause && !OPT_NO_CURSES)
   {

--- a/init.c
+++ b/init.c
@@ -3780,7 +3780,7 @@ int mutt_init(int skip_sys_rc, struct ListHead *commands)
   if (p)
     From = mutt_addr_parse_list(NULL, p);
 
-  mutt_ch_set_langinfo_charset();
+  Charset = mutt_ch_get_langinfo_charset();
   mutt_ch_set_charset(Charset);
 
   Matches = mutt_mem_calloc(MatchesListsize, sizeof(char *));

--- a/init.c
+++ b/init.c
@@ -3760,8 +3760,6 @@ int mutt_init(int skip_sys_rc, struct ListHead *commands)
     SpoolFile = mutt_str_strdup(buffer);
   }
 
-  Tmpdir = mutt_str_strdup((p = mutt_str_getenv("TMPDIR")) ? p : "/tmp");
-
   p = mutt_str_getenv("VISUAL");
   if (!p)
   {
@@ -3935,6 +3933,11 @@ int mutt_init(int skip_sys_rc, struct ListHead *commands)
   const char *env_mc = mutt_str_getenv("MAILCAPS");
   if (env_mc)
     mutt_str_replace(&MailcapPath, env_mc);
+
+  /* "$tmpdir" precedence: environment, config file, code */
+  const char *env_tmp = mutt_str_getenv("TMPDIR");
+  if (env_tmp)
+    mutt_str_replace(&Tmpdir, env_tmp);
 
   if (need_pause && !OPT_NO_CURSES)
   {

--- a/init.c
+++ b/init.c
@@ -3745,20 +3745,6 @@ int mutt_init(int skip_sys_rc, struct ListHead *commands)
   snprintf(AttachmentMarker, sizeof(AttachmentMarker), "\033]9;%" PRIu64 "\a",
            mutt_rand64());
 
-#ifdef USE_NNTP
-  p = mutt_str_getenv("NNTPSERVER");
-  if (p)
-  {
-    FREE(&NewsServer);
-    NewsServer = mutt_str_strdup(p);
-  }
-  else
-  {
-    p = mutt_file_read_keyword(SYSCONFDIR "/nntpserver", buffer, sizeof(buffer));
-    NewsServer = mutt_str_strdup(p);
-  }
-#endif
-
   p = mutt_str_getenv("MAIL");
   if (p)
     SpoolFile = mutt_str_strdup(p);

--- a/init.c
+++ b/init.c
@@ -3760,17 +3760,6 @@ int mutt_init(int skip_sys_rc, struct ListHead *commands)
     SpoolFile = mutt_str_strdup(buffer);
   }
 
-  p = mutt_str_getenv("MAILCAPS");
-  if (p)
-    MailcapPath = mutt_str_strdup(p);
-  else
-  {
-    /* Default search path from RFC1524 */
-    MailcapPath = mutt_str_strdup(
-        "~/.mailcap:" PKGDATADIR "/mailcap:" SYSCONFDIR
-        "/mailcap:/etc/mailcap:/usr/etc/mailcap:/usr/local/etc/mailcap");
-  }
-
   Tmpdir = mutt_str_strdup((p = mutt_str_getenv("TMPDIR")) ? p : "/tmp");
 
   p = mutt_str_getenv("VISUAL");
@@ -3941,6 +3930,11 @@ int mutt_init(int skip_sys_rc, struct ListHead *commands)
 
   if (!get_hostname())
     return 1;
+
+  /* "$mailcap_path" precedence: environment, config file, code */
+  const char *env_mc = mutt_str_getenv("MAILCAPS");
+  if (env_mc)
+    mutt_str_replace(&MailcapPath, env_mc);
 
   if (need_pause && !OPT_NO_CURSES)
   {

--- a/init.h
+++ b/init.h
@@ -1685,12 +1685,16 @@ struct Option MuttVars[] = {
   ** .pp
   ** When $$mail_check_stats is \fIset\fP, this variable configures
   ** how often (in seconds) NeoMutt will update message counts.
+  ** .pp
+  ** The default search path is from RFC1524.
   */
-  { "mailcap_path",     DT_STRING,  R_NONE, &MailcapPath, 0 },
+  { "mailcap_path",     DT_STRING,  R_NONE, &MailcapPath, IP "~/.mailcap:" PKGDATADIR "/mailcap:" SYSCONFDIR "/mailcap:/etc/mailcap:/usr/etc/mailcap:/usr/local/etc/mailcap" },
   /*
   ** .pp
   ** This variable specifies which files to consult when attempting to
   ** display MIME bodies not directly supported by NeoMutt.
+  ** .pp
+  ** $$mailcap_path is overridden by the environment variable \fC$$$MAILCAPS\fP.
   */
   { "mailcap_sanitize", DT_BOOL, R_NONE, &MailcapSanitize, 1 },
   /*

--- a/init.h
+++ b/init.h
@@ -813,7 +813,7 @@ struct Option MuttVars[] = {
   ** \fBNote\fP that changes made to the References: and Date: headers are
   ** ignored for interoperability reasons.
   */
-  { "editor",           DT_PATH, R_NONE, &Editor, 0 },
+  { "editor",           DT_PATH, R_NONE, &Editor, IP "vi" },
   /*
   ** .pp
   ** This variable specifies which editor is used by NeoMutt.
@@ -4310,11 +4310,13 @@ struct Option MuttVars[] = {
   ** virtual-mailboxes) as a spool file.
   */
 #endif
-  { "visual",           DT_PATH, R_NONE, &Visual, 0 },
+  { "visual",           DT_PATH, R_NONE, &Visual, IP "vi" },
   /*
   ** .pp
   ** Specifies the visual editor to invoke when the ``\fC~v\fP'' command is
   ** given in the built-in editor.
+  ** .pp
+  ** $$visual is overridden by the environment variable \fC$$$VISUAL\fP.
   */
   { "wait_key",         DT_BOOL, R_NONE, &WaitKey, 1 },
   /*

--- a/init.h
+++ b/init.h
@@ -4155,7 +4155,7 @@ struct Option MuttVars[] = {
   ** .pp
   ** A value of zero or less will cause NeoMutt to never time out.
   */
-  { "tmpdir",           DT_PATH, R_NONE, &Tmpdir, 0 },
+  { "tmpdir",           DT_PATH, R_NONE, &Tmpdir, IP "/tmp" },
   /*
   ** .pp
   ** This variable allows you to specify where NeoMutt will place its

--- a/mutt/charset.c
+++ b/mutt/charset.c
@@ -409,22 +409,22 @@ char *mutt_ch_get_default_charset(void)
 }
 
 /**
- * mutt_ch_set_langinfo_charset - Set the user's choice of character set
+ * mutt_ch_get_langinfo_charset - Get the user's choice of character set
+ * @retval ptr Charset string
  *
- * Lookup the character map used by the user's locale and store it in Charset.
+ * Get the canonical character set used by the user's locale.
+ * The caller must free the returned string.
  */
-void mutt_ch_set_langinfo_charset(void)
+char *mutt_ch_get_langinfo_charset(void)
 {
-  char buf[LONG_STRING];
-  char buf2[LONG_STRING];
+  char buf[LONG_STRING] = "";
 
-  mutt_str_strfcpy(buf, nl_langinfo(CODESET), sizeof(buf));
-  mutt_ch_canonical_charset(buf2, sizeof(buf2), buf);
+  mutt_ch_canonical_charset(buf, sizeof(buf), nl_langinfo(CODESET));
 
-  /* finally, set $charset */
-  Charset = mutt_str_strdup(buf2);
-  if (!Charset)
-    Charset = mutt_str_strdup("iso-8859-1");
+  if (buf[0] != '\0')
+    return mutt_str_strdup(buf);
+
+  return mutt_str_strdup("iso-8859-1");
 }
 
 /**

--- a/mutt/charset.h
+++ b/mutt/charset.h
@@ -85,7 +85,7 @@ extern const struct MimeNames PreferredMIMENames[];
 void             mutt_ch_canonical_charset(char *buf, size_t buflen, const char *name);
 int              mutt_ch_chscmp(const char *cs1, const char *cs2);
 char *           mutt_ch_get_default_charset(void);
-void             mutt_ch_set_langinfo_charset(void);
+char *           mutt_ch_get_langinfo_charset(void);
 void             mutt_ch_set_charset(char *charset);
 
 bool             mutt_ch_lookup_add(enum LookupType type, const char *pat, const char *replace, struct Buffer *err);


### PR DESCRIPTION
Five more simple changes.
They group and document the setting of config variables, making the precedence clearer.

| Prec | Source       | Example                | 
| :--- | :----------- | :--------------------- |
| 1    | command line | `neomutt -d 2`         | 
| 2    | environment  | `export TMPDIR="/tmp"` | 
| 3    | config file  | `~/.neomuttrc`         | 
| 4    | system file  | `/etc/neomuttrc`       | 
| 5    | code         | `init.h`               | 

- 0efe36606 nntp config
- f0c1cddfa mailcap config
- a7416afc2 tmpdir config
- 17e4dd34c editor, visual config
- 3b59d5484 separate get from set Charset

