### PR TITLE
Describe <show-messages> more precisely

### DIFF
--- a/curs_main.c
+++ b/curs_main.c
@@ -1408,7 +1408,7 @@ int mutt_index_menu(void)
         break;
 #endif /* USE_POP */
 
-      case OP_SHOW_MESSAGES:
+      case OP_SHOW_LOG_MESSAGES:
       {
         char tempfile[PATH_MAX];
         mutt_mktemp(tempfile, sizeof(tempfile));

--- a/doc/manual.xml.head
+++ b/doc/manual.xml.head
@@ -2964,6 +2964,47 @@ color sidebar_divider   color8  default
       <para>See also the
       <link linkend="postpone">$postpone</link> quad-option.</para>
     </sect1>
+
+    <sect1 id="logging">
+      <title>Logging</title>
+      <para>NeoMutt has different types of logging/error messages</para>
+      <itemizedlist>
+        <listitem>Primitive Errors:
+          errors emitted by C library functions such
+          as <literal>fopen()</literal>.
+        </listitem>
+        <listitem>Errors
+        </listitem>
+        <listitem>Warnings
+        </listitem>
+        <listitem>Message:
+          Informational messages such as <literal>Sorting mailbox...</literal>.
+        </listitem>
+        <listitem>Debug:
+          Debug messages usually only interesting while debugging.
+        </listitem>
+      </itemizedlist>
+      <para>These log messages are shown in the command bar at the bottom of the
+      UI (usually below the status line) and errors are shown in a different
+      colour than the other message types. The colours used for displaying can
+      be adjusted with <literal>color error ...</literal> and <literal>color
+      message ...</literal>, respectively. See the <link linkend="color">
+      description of <literal>color</literal></link> for the precise syntax.
+      </para>
+      <para>The command bar shows only the last message. To show the last 100
+      messages (this includes all types of messages from debug to error) the
+      function <link linkend="tab-index-bindings"><literal>
+      &lt;show-log-messages&gt;</literal></link> can be used.</para>
+      <para>Debug messages are not shown by default. To enable them NeoMutt
+      must be compiled with <literal>+debug</literal>. Furthermore, the debug
+      log level must be set with the <link linkend="tab-commandline-options">
+      <literal>-d</literal> command line parameter</link> at startup. The
+      <literal>-d</literal> parameter expects a debug level which can range
+      from 1 to 5 and affects verbosity of the debug messages. A value of 2 is
+      recommended for the start. If debug logging is enabled, all log messages
+      (i.e.  errors, warnings, ..., debug) are additionally written to the file
+      <literal>~/.neomuttdebug0</literal>.</para>
+    </sect1>
   </chapter>
 
   <chapter id="configuration">

--- a/functions.h
+++ b/functions.h
@@ -202,7 +202,7 @@ const struct Binding OpMain[] = { /* map: index */
   { "save-message",              OP_SAVE,                           "s" },
   { "set-flag",                  OP_MAIN_SET_FLAG,                  "w" },
   { "show-limit",                OP_MAIN_SHOW_LIMIT,                "\033l" },
-  { "show-messages",             OP_SHOW_MESSAGES,                  "M" },
+  { "show-log-messages",         OP_SHOW_LOG_MESSAGES,              "M" },
   { "show-version",              OP_VERSION,                        "V" },
 #ifdef USE_SIDEBAR
   { "sidebar-next",              OP_SIDEBAR_NEXT,                   NULL },

--- a/opcodes.h
+++ b/opcodes.h
@@ -218,7 +218,7 @@
   _fmt(OP_SEARCH_REVERSE,                 N_("search backwards for a regular expression")) \
   _fmt(OP_SEARCH_TOGGLE,                  N_("toggle search pattern coloring")) \
   _fmt(OP_SHELL_ESCAPE,                   N_("invoke a command in a subshell")) \
-  _fmt(OP_SHOW_MESSAGES,                  N_("show messages")) \
+  _fmt(OP_SHOW_MESSAGES,                  N_("show log (and debug) messages")) \
   _fmt(OP_SORT,                           N_("sort messages")) \
   _fmt(OP_SORT_REVERSE,                   N_("sort messages in reverse order")) \
   _fmt(OP_SUBSCRIBE_PATTERN,              N_("subscribe to newsgroups matching a pattern")) \

--- a/opcodes.h
+++ b/opcodes.h
@@ -218,7 +218,7 @@
   _fmt(OP_SEARCH_REVERSE,                 N_("search backwards for a regular expression")) \
   _fmt(OP_SEARCH_TOGGLE,                  N_("toggle search pattern coloring")) \
   _fmt(OP_SHELL_ESCAPE,                   N_("invoke a command in a subshell")) \
-  _fmt(OP_SHOW_MESSAGES,                  N_("show log (and debug) messages")) \
+  _fmt(OP_SHOW_LOG_MESSAGES,              N_("show log (and debug) messages")) \
   _fmt(OP_SORT,                           N_("sort messages")) \
   _fmt(OP_SORT_REVERSE,                   N_("sort messages in reverse order")) \
   _fmt(OP_SUBSCRIBE_PATTERN,              N_("subscribe to newsgroups matching a pattern")) \


### PR DESCRIPTION
The term 'message' is used for log-messages as well as for ordinary
mails. In the help 'message' usually means an email. Adjust the
description of <show-message>/OP_SHOW_MESSAGE to clarify that log and
debug messages are meant.
