### PR TITLE
Generate .clang_complete

### DIFF
--- a/.clang_complete.in
+++ b/.clang_complete.in
@@ -1,0 +1,1 @@
+@cflags-one-per-line@

--- a/.gitignore
+++ b/.gitignore
@@ -93,5 +93,6 @@ po/remove-potcdate.sed
 po/remove-potcdate.sin
 po/Rules-quot
 po/neomutt.pot
+.clang_complete
 
 html

--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -313,7 +313,7 @@ uninstall: $(UNINSTALL_TARGETS)
 distclean: clean
 	$(RM) $(DEPFILES) conststrings.c config.h config.log doc/neomutt.1 \
 		Makefile po/Makefile contrib/Makefile doc/Makefile \
-		test/Makefile autosetup/jimsh0
+		test/Makefile autosetup/jimsh0 .clang_complete
 
 ##############################################################################
 # include generated dependency files

--- a/auto.def
+++ b/auto.def
@@ -899,6 +899,11 @@ define docdir [get-define PKGDOCDIR]
 make-template doc/neomutt.man doc/neomutt.1
 
 ###############################################################################
+# Generate .clang_complete
+define cflags-one-per-line [string map {" " "\n"} [get-define CFLAGS]]
+make-template .clang_complete.in
+
+###############################################################################
 # Print a summary
 user-notice "Summary of build options:
 


### PR DESCRIPTION
For users of https://github.com/Rip-Rip/clang_complete, this allows to
always keep the .clang_complete file in sync with CFLAGS.