### PR TITLE
Remove reminiscent of txt2c

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,6 @@ hcache/hcversion.h
 neomutt
 pgpewrap
 pgpring
-txt2c
 test/neomutt-test
 
 # ./configure


### PR DESCRIPTION
txt2c is replaced by a routine in the configure/autosetup script.
Update .gitignore accordingly.

This is just a little housekeeping.