### PR TITLE
Expand variables inside backticks

### DIFF
--- a/init.c
+++ b/init.c
@@ -620,7 +620,15 @@ int mutt_extract_token(struct Buffer *dest, struct Buffer *tok, int flags)
       struct Buffer cmd;
       mutt_buffer_init(&cmd);
       *pc = '\0';
-      mutt_extract_token(&cmd, tok, MUTT_TOKEN_QUOTE | MUTT_TOKEN_SPACE);
+      if (flags & MUTT_TOKEN_BACKTICK_VARS)
+      {
+          /* recursively extract tokens to interpolate variables */
+          mutt_extract_token(&cmd, tok, MUTT_TOKEN_QUOTE | MUTT_TOKEN_SPACE);
+      }
+      else
+      {
+          cmd.data = mutt_str_strdup(tok->dptr);
+      }
       *pc = '`';
       pid = mutt_create_filter(cmd.data, NULL, &fp, NULL);
       if (pid < 0)
@@ -2492,7 +2500,7 @@ static int parse_set(struct Buffer *buf, struct Buffer *s, unsigned long data,
           myvar = mutt_str_strdup(myvar);
         }
 
-        mutt_extract_token(buf, s, 0);
+        mutt_extract_token(buf, s, MUTT_TOKEN_BACKTICK_VARS);
 
         if (myvar)
         {

--- a/mutt.h
+++ b/mutt.h
@@ -70,13 +70,14 @@ struct Mapping;
 #endif
 
 /* flags for mutt_get_token() */
-#define MUTT_TOKEN_EQUAL      1       /* treat '=' as a special */
-#define MUTT_TOKEN_CONDENSE   (1<<1)  /* ^(char) to control chars (macros) */
-#define MUTT_TOKEN_SPACE      (1<<2)  /* don't treat whitespace as a term */
-#define MUTT_TOKEN_QUOTE      (1<<3)  /* don't interpret quotes */
-#define MUTT_TOKEN_PATTERN    (1<<4)  /* !)|~ are terms (for patterns) */
-#define MUTT_TOKEN_COMMENT    (1<<5)  /* don't reap comments */
-#define MUTT_TOKEN_SEMICOLON  (1<<6)  /* don't treat ; as special */
+#define MUTT_TOKEN_EQUAL         (1<<0)  /* treat '=' as a special */
+#define MUTT_TOKEN_CONDENSE      (1<<1)  /* ^(char) to control chars (macros) */
+#define MUTT_TOKEN_SPACE         (1<<2)  /* don't treat whitespace as a term */
+#define MUTT_TOKEN_QUOTE         (1<<3)  /* don't interpret quotes */
+#define MUTT_TOKEN_PATTERN       (1<<4)  /* !)|~ are terms (for patterns) */
+#define MUTT_TOKEN_COMMENT       (1<<5)  /* don't reap comments */
+#define MUTT_TOKEN_SEMICOLON     (1<<6)  /* don't treat ; as special */
+#define MUTT_TOKEN_BACKTICK_VARS (1<<7)  /* expand variables within backticks */
 
 /* types for mutt_add_hook() */
 #define MUTT_FOLDERHOOK   (1 << 0)


### PR DESCRIPTION
This allows for example to simplify the solution given [here](http://mailman.neomutt.org/pipermail/neomutt-users-neomutt.org/2018-April/000325.html) as:

```
:set pager_index_lines=`dc -e "50 $pager_index_lines -p"`
```

Please review, my `mutt_extract_token`-foo is not as advanced.
