### PR TITLE
 Let mutt_ch_choose report conversion failure

### DIFF
--- a/handler.c
+++ b/handler.c
@@ -102,7 +102,7 @@ static void convert_to_state(iconv_t cd, char *bufi, size_t *l, struct State *s)
   while (true)
   {
     ob = bufo, obl = sizeof(bufo);
-    mutt_ch_iconv(cd, &ib, &ibl, &ob, &obl, 0, "?");
+    mutt_ch_iconv(cd, &ib, &ibl, &ob, &obl, 0, "?", NULL);
     if (ob == bufo)
       break;
     state_prefix_put(bufo, ob - bufo, s);

--- a/imap/utf7.c
+++ b/imap/utf7.c
@@ -320,7 +320,7 @@ void imap_utf_encode(struct ImapData *idata, char **s)
   if (Charset)
   {
     char *t = mutt_str_strdup(*s);
-    if (t && !mutt_ch_convert_string(&t, Charset, "utf-8", 0))
+    if (t && mutt_ch_convert_string(&t, Charset, "utf-8", 0) == 0)
     {
       FREE(s);
       if (idata->unicode)
@@ -348,7 +348,7 @@ void imap_utf_decode(struct ImapData *idata, char **s)
     else
       t = utf7_to_utf8(*s, strlen(*s), 0, 0);
 
-    if (t && !mutt_ch_convert_string(&t, "utf-8", Charset, 0))
+    if (t && mutt_ch_convert_string(&t, "utf-8", Charset, 0) == 0)
     {
       FREE(s);
       *s = t;

--- a/mutt/charset.c
+++ b/mutt/charset.c
@@ -959,7 +959,7 @@ char *mutt_ch_choose(const char *fromcode, const char *charsets, char *u,
     t[n] = '\0';
 
     s = mutt_str_substr_dup(u, u + ulen);
-    if (mutt_ch_convert_string(&s, fromcode, t, 0))
+    if (mutt_ch_convert_string(&s, fromcode, t, 0) != 0)
     {
       FREE(&t);
       FREE(&s);

--- a/mutt/charset.c
+++ b/mutt/charset.c
@@ -654,7 +654,20 @@ const char *mutt_ch_iconv_lookup(const char *chs)
   return lookup_charset(MUTT_LOOKUP_ICONV, chs);
 }
 
-static int convert_string(char **ps, const char *from, const char *to, int flags)
+/**
+ * mutt_ch_convert_string - Convert a string between encodings
+ * @param[in,out] ps    String to convert
+ * @param[in]     from  Current character set
+ * @param[in]     to    Target character set
+ * @param[in]     flags Flags, e.g.
+ * @retval 0      Success
+ * @retval -1     Invalid arguments or failure to open an iconv channel
+ * @retval errno  Failure in iconv conversion
+ *
+ * Parameter flags is given as-is to mutt_ch_iconv_open().
+ * See there for its meaning and usage policy.
+ */
+int mutt_ch_convert_string(char **ps, const char *from, const char *to, int flags)
 {
   iconv_t cd;
   const char *repls[] = { "\357\277\275", "?", 0 };
@@ -702,24 +715,6 @@ static int convert_string(char **ps, const char *from, const char *to, int flags
 
   mutt_str_adjust(ps);
   return rc;
-}
-
-/**
- * mutt_ch_convert_string - Convert a string between encodings
- * @param[in,out] ps    String to convert
- * @param[in]     from  Current character set
- * @param[in]     to    Target character set
- * @param[in]     flags Flags, e.g.
- * @retval 0  Success
- * @retval -1 Error
- *
- * Parameter flags is given as-is to mutt_ch_iconv_open().
- * See there for its meaning and usage policy.
- */
-int mutt_ch_convert_string(char **ps, const char *from, const char *to, int flags)
-{
-  int rc = convert_string(ps, from, to, flags);
-  return rc == -1 ? -1 : 0;
 }
 
 /**
@@ -964,7 +959,7 @@ char *mutt_ch_choose(const char *fromcode, const char *charsets, char *u,
     t[n] = '\0';
 
     s = mutt_str_substr_dup(u, u + ulen);
-    if (convert_string(&s, fromcode, t, 0))
+    if (mutt_ch_convert_string(&s, fromcode, t, 0))
     {
       FREE(&t);
       FREE(&s);

--- a/mutt/charset.h
+++ b/mutt/charset.h
@@ -93,7 +93,7 @@ void             mutt_ch_lookup_remove(void);
 const char *     mutt_ch_charset_lookup(const char *chs);
 
 iconv_t          mutt_ch_iconv_open(const char *tocode, const char *fromcode, int flags);
-size_t           mutt_ch_iconv(iconv_t cd, const char **inbuf, size_t *inbytesleft, char **outbuf, size_t *outbytesleft, const char **inrepls, const char *outrepl);
+size_t           mutt_ch_iconv(iconv_t cd, const char **inbuf, size_t *inbytesleft, char **outbuf, size_t *outbytesleft, const char **inrepls, const char *outrepl, int *iconverrno);
 const char *     mutt_ch_iconv_lookup(const char *chs);
 int              mutt_ch_convert_string(char **ps, const char *from, const char *to, int flags);
 int              mutt_ch_convert_nonmime_string(char **ps);

--- a/mutt/idna.c
+++ b/mutt/idna.c
@@ -142,10 +142,10 @@ char *mutt_idna_intl_to_local(const char *user, const char *domain, int flags)
 #endif /* HAVE_LIBIDN */
 
   /* we don't want charset-hook effects, so we set flags to 0 */
-  if (mutt_ch_convert_string(&local_user, "utf-8", Charset, 0))
+  if (mutt_ch_convert_string(&local_user, "utf-8", Charset, 0) != 0)
     goto cleanup;
 
-  if (mutt_ch_convert_string(&local_domain, "utf-8", Charset, 0))
+  if (mutt_ch_convert_string(&local_domain, "utf-8", Charset, 0) != 0)
     goto cleanup;
 
   /* make sure that we can convert back and come out with the same
@@ -154,7 +154,7 @@ char *mutt_idna_intl_to_local(const char *user, const char *domain, int flags)
   {
     reversed_user = mutt_str_strdup(local_user);
 
-    if (mutt_ch_convert_string(&reversed_user, Charset, "utf-8", 0))
+    if (mutt_ch_convert_string(&reversed_user, Charset, "utf-8", 0) != 0)
     {
       mutt_debug(1, "Not reversible. Charset conv to utf-8 failed for user = '%s'.\n",
                  reversed_user);
@@ -169,7 +169,7 @@ char *mutt_idna_intl_to_local(const char *user, const char *domain, int flags)
 
     reversed_domain = mutt_str_strdup(local_domain);
 
-    if (mutt_ch_convert_string(&reversed_domain, Charset, "utf-8", 0))
+    if (mutt_ch_convert_string(&reversed_domain, Charset, "utf-8", 0) != 0)
     {
       mutt_debug(1, "Not reversible. Charset conv to utf-8 failed for domain = '%s'.\n",
                  reversed_domain);
@@ -236,10 +236,10 @@ char *mutt_idna_local_to_intl(const char *user, const char *domain)
   char *intl_domain = mutt_str_strdup(domain);
 
   /* we don't want charset-hook effects, so we set flags to 0 */
-  if (mutt_ch_convert_string(&intl_user, Charset, "utf-8", 0))
+  if (mutt_ch_convert_string(&intl_user, Charset, "utf-8", 0) != 0)
     goto cleanup;
 
-  if (mutt_ch_convert_string(&intl_domain, Charset, "utf-8", 0))
+  if (mutt_ch_convert_string(&intl_domain, Charset, "utf-8", 0) != 0)
     goto cleanup;
 
 #ifdef HAVE_LIBIDN

--- a/mutt/idna.c
+++ b/mutt/idna.c
@@ -142,10 +142,10 @@ char *mutt_idna_intl_to_local(const char *user, const char *domain, int flags)
 #endif /* HAVE_LIBIDN */
 
   /* we don't want charset-hook effects, so we set flags to 0 */
-  if (mutt_ch_convert_string(&local_user, "utf-8", Charset, 0) == -1)
+  if (mutt_ch_convert_string(&local_user, "utf-8", Charset, 0))
     goto cleanup;
 
-  if (mutt_ch_convert_string(&local_domain, "utf-8", Charset, 0) == -1)
+  if (mutt_ch_convert_string(&local_domain, "utf-8", Charset, 0))
     goto cleanup;
 
   /* make sure that we can convert back and come out with the same
@@ -154,7 +154,7 @@ char *mutt_idna_intl_to_local(const char *user, const char *domain, int flags)
   {
     reversed_user = mutt_str_strdup(local_user);
 
-    if (mutt_ch_convert_string(&reversed_user, Charset, "utf-8", 0) == -1)
+    if (mutt_ch_convert_string(&reversed_user, Charset, "utf-8", 0))
     {
       mutt_debug(1, "Not reversible. Charset conv to utf-8 failed for user = '%s'.\n",
                  reversed_user);
@@ -169,7 +169,7 @@ char *mutt_idna_intl_to_local(const char *user, const char *domain, int flags)
 
     reversed_domain = mutt_str_strdup(local_domain);
 
-    if (mutt_ch_convert_string(&reversed_domain, Charset, "utf-8", 0) == -1)
+    if (mutt_ch_convert_string(&reversed_domain, Charset, "utf-8", 0))
     {
       mutt_debug(1, "Not reversible. Charset conv to utf-8 failed for domain = '%s'.\n",
                  reversed_domain);
@@ -236,10 +236,10 @@ char *mutt_idna_local_to_intl(const char *user, const char *domain)
   char *intl_domain = mutt_str_strdup(domain);
 
   /* we don't want charset-hook effects, so we set flags to 0 */
-  if (mutt_ch_convert_string(&intl_user, Charset, "utf-8", 0) == -1)
+  if (mutt_ch_convert_string(&intl_user, Charset, "utf-8", 0))
     goto cleanup;
 
-  if (mutt_ch_convert_string(&intl_domain, Charset, "utf-8", 0) == -1)
+  if (mutt_ch_convert_string(&intl_domain, Charset, "utf-8", 0))
     goto cleanup;
 
 #ifdef HAVE_LIBIDN

--- a/mutt/rfc2047.c
+++ b/mutt/rfc2047.c
@@ -439,7 +439,7 @@ static int rfc2047_encode(const char *d, size_t dlen, int col, const char *fromc
 
   /* Try to convert to UTF-8. */
   char *u = mutt_str_substr_dup(d, d + dlen);
-  if (mutt_ch_convert_string(&u, fromcode, icode, 0))
+  if (mutt_ch_convert_string(&u, fromcode, icode, 0) != 0)
   {
     rc = 1;
     icode = 0;


### PR DESCRIPTION
* **What does this PR do?**

Previously, mutt_ch_convert_string returned error only if any arguments failed the sanity check or iconv_open() failed.

With this change, an error value is returned even if the iconv() conversion fails, such as when the input string contains an invalid character in the source character set (EILSEQ).

* **Are there points in the code the reviewer needs to double check?**

I have looked at each caller and it seems to me that this change won't introduce any misbehaviour, but I'm far from being 100% confident.

Issue #1136