### PR TITLE
Add the mutt_ch_check API

### DIFF
--- a/mutt/charset.c
+++ b/mutt/charset.c
@@ -684,7 +684,7 @@ int mutt_ch_check(const char *s, size_t slen, const char *from, const char *to)
   if (cd == (iconv_t)-1)
     return -1;
 
-  const size_t outlen = MB_LEN_MAX * slen;
+  size_t outlen = MB_LEN_MAX * slen;
   char *out = mutt_mem_malloc(outlen + 1);
 
   const size_t convlen = iconv(cd, (ICONV_CONST char **) &s, &slen, &out, (size_t *) &outlen);

--- a/mutt/charset.c
+++ b/mutt/charset.c
@@ -668,6 +668,37 @@ const char *mutt_ch_iconv_lookup(const char *chs)
 }
 
 /**
+ * mutt_ch_check - Check whether a string can be converted between encodings
+ * @param[in] ps    String to check
+ * @param[in] slen  Length of the string to check
+ * @param[in] from  Current character set
+ * @param[in] to    Target character set
+ * @retval 0  Success
+ * @retval -1 Error in iconv_open()
+ * @retval >0 Errno as set by iconv()
+ */
+int mutt_ch_check(const char *s, size_t slen, const char *from, const char *to)
+{
+  int rc = 0;
+  iconv_t cd = mutt_ch_iconv_open(to, from, 0);
+  if (cd == (iconv_t)-1)
+  {
+    return -1;
+  }
+
+  const size_t outlen = MB_LEN_MAX * slen;
+  char *out = mutt_mem_malloc(outlen + 1);
+
+  const size_t convlen = iconv(cd, (ICONV_CONST char **) &s, &slen, &out, (size_t *) &outlen);
+  if (convlen == -1)
+    rc = errno;
+
+  FREE(&out);
+  iconv_close(cd);
+  return rc;
+}
+
+/**
  * mutt_ch_convert_string - Convert a string between encodings
  * @param[in,out] ps    String to convert
  * @param[in]     from  Current character set
@@ -972,7 +1003,9 @@ char *mutt_ch_choose(const char *fromcode, const char *charsets, char *u,
     t[n] = '\0';
 
     s = mutt_str_substr_dup(u, u + ulen);
-    if (mutt_ch_convert_string(&s, fromcode, t, 0) != 0)
+    const int rc = (d != NULL) ? mutt_ch_convert_string(&s, fromcode, t, 0)
+                               : mutt_ch_check(s, ulen, fromcode, t);
+    if (rc)
     {
       FREE(&t);
       FREE(&s);

--- a/mutt/charset.c
+++ b/mutt/charset.c
@@ -682,9 +682,7 @@ int mutt_ch_check(const char *s, size_t slen, const char *from, const char *to)
   int rc = 0;
   iconv_t cd = mutt_ch_iconv_open(to, from, 0);
   if (cd == (iconv_t)-1)
-  {
     return -1;
-  }
 
   const size_t outlen = MB_LEN_MAX * slen;
   char *out = mutt_mem_malloc(outlen + 1);

--- a/mutt/charset.c
+++ b/mutt/charset.c
@@ -686,12 +686,13 @@ int mutt_ch_check(const char *s, size_t slen, const char *from, const char *to)
 
   size_t outlen = MB_LEN_MAX * slen;
   char *out = mutt_mem_malloc(outlen + 1);
+  char *saved_out = out;
 
   const size_t convlen = iconv(cd, (ICONV_CONST char **) &s, &slen, &out, (size_t *) &outlen);
   if (convlen == -1)
     rc = errno;
 
-  FREE(&out);
+  FREE(&saved_out);
   iconv_close(cd);
   return rc;
 }

--- a/mutt/charset.h
+++ b/mutt/charset.h
@@ -104,6 +104,7 @@ void             mutt_ch_fgetconv_close(struct FgetConv **fc);
 int              mutt_ch_fgetconv(struct FgetConv *fc);
 char *           mutt_ch_fgetconvs(char *buf, size_t buflen, struct FgetConv *fc);
 
+int              mutt_ch_check(const char *s, size_t slen, const char *from, const char *to);
 char *           mutt_ch_choose(const char *fromcode, const char *charsets,
                                 char *u, size_t ulen, char **d, size_t *dlen);
 


### PR DESCRIPTION
This adds the mutt_ch_check API that can be used to check whether a string can be converted between character sets. It is stricter than mutt_ch_convert_string in that it doesn't apply any replacement chars to
unconvertible characters and doesn't return the converted string.

This is an alternative approach at fixing #1136, but needs discussion. Possibly we can enhance the `mutt/charset.h` API in the process.