### PR TITLE
init.c: Ensure more consistent variable dumps

### DIFF
--- a/init.c
+++ b/init.c
@@ -3669,7 +3669,7 @@ int mutt_dump_variables(int hide_sensitive)
 
     if (hide_sensitive && IS_SENSITIVE(MuttVars[i]))
     {
-      mutt_message("%s='***'\n", MuttVars[i].name);
+      mutt_message("%s='***'", MuttVars[i].name);
       continue;
     }
     snprintf(command, sizeof(command), "set ?%s\n", MuttVars[i].name);


### PR DESCRIPTION
* **What does this PR do?**

This avoids blank lines and use double quotes for the `neomutt -D -S`
variable dump as in `neomutt -D`.

It also gives a little bit more detail on sensitive variable values and
should be unique enough to allow filtered results easily.
