### PR TITLE
mutt/file.c: split mutt_file_{lock,unlock} into flock/fcntl versions

### DIFF
--- a/AUTOSETUP.md
+++ b/AUTOSETUP.md
@@ -55,7 +55,6 @@ section (it's actually a proc under the hood):
 ```
 options {
    smime=1                    => "Disable S/Mime"
-   flock=0                    => "Enable flock(1)"
    gpgme=0                    => "Enable GPGME"
    with-gpgme:path            => "Location of GPGME"
    with-mailpath:=/var/mail   => "Location of the spool mailboxes"
@@ -64,7 +63,7 @@ options {
 
 A user can configure the build to suit his needs by modifying the default
 values, e.g.,
-`./configure --disable-smime --enable-flock --gpgme --with-gpgme=/usr/local`.
+`./configure --disable-smime --gpgme --with-gpgme=/usr/local`.
 
 Within `auto.def`, option can be easily queried with `[opt-bool smime]` and
 `[opt-val with-gpgme $prefix]`, with the latter using `$prefix` if not value

--- a/INSTALL
+++ b/INSTALL
@@ -42,6 +42,12 @@ to ``configure'' to help it out, or change the default behavior:
 	will automatically look in /usr/include/ncurses for the include
 	files.
 
+--with-lock=(fcntl | flock)
+
+	select between fcntl() and flock() for file locking. Neomutt will
+	use fcntl() by default, but this can result in poor performance 
+	on NFS.
+
 --with-slang[=DIR]
 	use the S-Lang library instead of ncurses.  This library seems to
 	work better for some people because it is less picky about proper
@@ -81,13 +87,6 @@ to ``configure'' to help it out, or change the default behavior:
 
 --disable-nls
 	This switch disables neomutt's native language support.
-
---enable-flock
-	use flock() to lock files.
-
---disable-fcntl
-	by default, NeoMutt uses fcntl() to lock files.  Over NFS this can
-	result in poor performance on read/write.
 
 --enable-locales-fix
 	on some systems, the result of isprint() can't be used reliably

--- a/auto.def
+++ b/auto.def
@@ -32,8 +32,7 @@ options {
   doc=1                     => "Disable building the documentation"
   full-doc=0                => "Build the full documentation set"
   docdir:path               => "Documentation root"
-  flock=0                   => "Use flock() to lock files"
-  fcntl=1                   => "Do NOT use fcntl() to lock files"
+  with-lock:=fcntl          => "Select fcntl() or flock() to lock files"
   fmemopen=0                => "Use fmemopen() for temporary in-memory files"
   locales-fix=0             => "Enable locales fix"
   pgp=1                     => "Disable PGP support"
@@ -101,7 +100,7 @@ options {
 if {1} {
   # Keep sorted, please.
   foreach opt {
-    bdb doc everything fcntl flock fmemopen full-doc gdbm gnutls gpgme gss
+    bdb doc everything fmemopen full-doc gdbm gnutls gpgme gss
     homespool idn idn2 kyotocabinet lmdb locales-fix lua mixmaster nls
     notmuch pgp qdbm sasl smime ssl tokyocabinet
   } {
@@ -313,12 +312,21 @@ if {[get-define want-everything]} {
 }
 
 ###############################################################################
-# flock(1)
-if {[get-define want-flock]} {define USE_FLOCK}
+# Locking
+switch [opt-val with-lock fcntl] {
+  fcntl {
+    define USE_FCNTL
+  }
 
-###############################################################################
-# fcntl(1)
-if {[get-define want-fcntl]} {define USE_FCNTL}
+  flock {
+    define USE_FLOCK
+  }
+
+  default {
+    user-error "Invalid value for --with-lock=[opt-val with-lock], select fcntl\
+                or flock"
+  }
+}
 
 ###############################################################################
 # Locales fix


### PR DESCRIPTION
this splits mutt_file_lock and mutt_file_unlock into separate
fcntl() and flock() based versions.  It teaches ./configure
about the new --with-lock option (--with-lock=fcntl or
--with-lock=flock).

Includes updates to INSTALL and AUTOSETUP.md that reference the
removed --enable-fcntl and --enable-flock options.

Closes #1147