### PR TITLE
mutt/logging.c: set line buffering for logging stream

### DIFF
--- a/mutt/logging.c
+++ b/mutt/logging.c
@@ -128,6 +128,7 @@ int log_file_open(bool verbose)
   LogFileFP = mutt_file_fopen(LogFileName, "a+");
   if (!LogFileFP)
     return -1;
+  setvbuf(LogFileFP, NULL, _IOLBF, 0);
 
   fprintf(LogFileFP, "[%s] NeoMutt%s debugging at level %d\n", timestamp(0),
           NONULL(LogFileVersion), LogFileLevel);


### PR DESCRIPTION
Flush stream to the logging file after adding a line.

Without flushing logging messages are saved to file with delay due to stream buffering.

