### PR TITLE
Respect environment VISUAL and EDITOR variables

### DIFF
--- a/init.c
+++ b/init.c
@@ -3905,6 +3905,13 @@ int mutt_init(int skip_sys_rc, struct ListHead *commands)
 
   Matches = mutt_mem_calloc(MatchesListsize, sizeof(char *));
 
+  /* Set standard defaults */
+  for (int i = 0; MuttVars[i].name; i++)
+  {
+    set_default(&MuttVars[i]);
+    restore_default(&MuttVars[i]);
+  }
+
   /* "$mailcap_path" precedence: config file, environment, code */
   MailcapPath = mutt_str_strdup(mutt_str_getenv("MAILCAPS"));
 
@@ -3919,13 +3926,6 @@ int mutt_init(int skip_sys_rc, struct ListHead *commands)
   {
     mutt_str_replace(&Editor, env_ed);
     mutt_str_replace(&Visual, env_ed);
-  }
-
-  /* Set standard defaults */
-  for (int i = 0; MuttVars[i].name; i++)
-  {
-    set_default(&MuttVars[i]);
-    restore_default(&MuttVars[i]);
   }
 
   CurrentMenu = MENU_MAIN;

--- a/init.c
+++ b/init.c
@@ -3913,10 +3913,14 @@ int mutt_init(int skip_sys_rc, struct ListHead *commands)
   }
 
   /* "$mailcap_path" precedence: config file, environment, code */
-  MailcapPath = mutt_str_strdup(mutt_str_getenv("MAILCAPS"));
+  const char *env_mc = mutt_str_getenv("MAILCAPS");
+  if (env_mc)
+    MailcapPath = mutt_str_strdup(env_mc);
 
   /* "$tmpdir" precedence: config file, environment, code */
-  Tmpdir = mutt_str_strdup(mutt_str_getenv("TMPDIR"));
+  const char *env_tmp = mutt_str_getenv("TMPDIR");
+  if (env_tmp)
+    Tmpdir = mutt_str_strdup(env_tmp);
 
   /* "$visual", "$editor" precedence: config file, environment, code */
   const char *env_ed = mutt_str_getenv("VISUAL");


### PR DESCRIPTION
#### **What does this PR do?**

Commit 0ef255e repositioned where Neomutt set its standard defaults in
init.c to after the logic for loading the VISUAL and EDITOR variables.
As a result, Neomutt overrides the values it retrieved from the
environment with the ones from the configuration file. This matches the
desired precedence of config->environment->code.

However, if `editor` is not set in the configuration file then Neomutt
does not retrieve EDITOR and VISUAL again. This results in Neomutt
falling back to the editor specified in the code. Thus the precedence is
config->code.

This commit returns the standard default set loop to its initial
location allowing for the environment variables to be usable.

This fixes #1162 

#### Are there points in the code the reviewer needs to double check?**
`MailcapPath` and `Tmpdir` were affected by commit 0ef255e as well; however, I did not know it when I made my commit since they did not show any errors (they were set in the config file.) Please verify they conform to the desired precedence.

#### What are the relevant issue numbers?**
#1162 