### PR TITLE
Eliminating static variable in mutt_file_dirname

### DIFF
--- a/mutt/file.c
+++ b/mutt/file.c
@@ -927,12 +927,10 @@ time_t mutt_file_decrease_mtime(const char *f, struct stat *st)
  * Unlike the IEEE Std 1003.1-2001 specification of dirname(3), this
  * implementation does not modify its parameter, so callers need not manually
  * copy their paths into a modifiable buffer prior to calling this function.
- *
- * @warning mutt_file_dirname() returns a static string which must not be free()'d.
  */
-const char *mutt_file_dirname(const char *p)
+char *mutt_file_dirname(const char *p)
 {
-  static char buf[_POSIX_PATH_MAX];
+  char *buf = mutt_mem_malloc(_POSIX_PATH_MAX);
   mutt_str_strfcpy(buf, p, sizeof(buf));
   return dirname(buf);
 }
@@ -1312,7 +1310,6 @@ int mutt_file_rename(char *oldfile, char *newfile)
  */
 int mutt_file_to_absolute_path(char *path, const char *reference)
 {
-  const char *dirpath = NULL;
   char abs_path[PATH_MAX];
   int path_len;
 
@@ -1322,8 +1319,9 @@ int mutt_file_to_absolute_path(char *path, const char *reference)
     return true;
   }
 
-  dirpath = mutt_file_dirname(reference);
+  char *dirpath = mutt_file_dirname(reference);
   mutt_str_strfcpy(abs_path, dirpath, PATH_MAX);
+  FREE(&dirpath);
   mutt_str_strncat(abs_path, sizeof(abs_path), "/", 1); /* append a / at the end of the path */
 
   path_len = PATH_MAX - strlen(path);

--- a/mutt/file.c
+++ b/mutt/file.c
@@ -921,18 +921,18 @@ time_t mutt_file_decrease_mtime(const char *f, struct stat *st)
 
 /**
  * mutt_file_dirname - Return a path up to, but not including, the final '/'
- * @param  p    Path
+ * @param  path Path
  * @retval ptr  The directory containing p
  *
  * Unlike the IEEE Std 1003.1-2001 specification of dirname(3), this
  * implementation does not modify its parameter, so callers need not manually
  * copy their paths into a modifiable buffer prior to calling this function.
  */
-char *mutt_file_dirname(const char *p)
+char *mutt_file_dirname(const char *path)
 {
-  char *buf = mutt_mem_malloc(_POSIX_PATH_MAX);
-  mutt_str_strfcpy(buf, p, sizeof(buf));
-  return dirname(buf);
+  char buf[PATH_MAX] = { 0 };
+  mutt_str_strfcpy(buf, path, sizeof(buf));
+  return mutt_str_strdup(dirname(buf));
 }
 
 /**
@@ -1388,3 +1388,4 @@ int mutt_file_check_empty(const char *path)
 
   return ((st.st_size == 0));
 }
+

--- a/mutt/file.h
+++ b/mutt/file.h
@@ -46,7 +46,7 @@ char *      mutt_file_concat_path(char *d, const char *dir, const char *fname, s
 int         mutt_file_copy_bytes(FILE *in, FILE *out, size_t size);
 int         mutt_file_copy_stream(FILE *fin, FILE *fout);
 time_t      mutt_file_decrease_mtime(const char *f, struct stat *st);
-char *      mutt_file_dirname(const char *p);
+char *      mutt_file_dirname(const char *path);
 int         mutt_file_fclose(FILE **f);
 FILE *      mutt_file_fopen(const char *path, const char *mode);
 int         mutt_file_fsync_close(FILE **f);

--- a/mutt/file.h
+++ b/mutt/file.h
@@ -46,7 +46,7 @@ char *      mutt_file_concat_path(char *d, const char *dir, const char *fname, s
 int         mutt_file_copy_bytes(FILE *in, FILE *out, size_t size);
 int         mutt_file_copy_stream(FILE *fin, FILE *fout);
 time_t      mutt_file_decrease_mtime(const char *f, struct stat *st);
-const char *mutt_file_dirname(const char *p);
+char *      mutt_file_dirname(const char *p);
 int         mutt_file_fclose(FILE **f);
 FILE *      mutt_file_fopen(const char *path, const char *mode);
 int         mutt_file_fsync_close(FILE **f);

--- a/mutt/string.c
+++ b/mutt/string.c
@@ -636,8 +636,13 @@ void mutt_str_remove_trailing_ws(char *s)
  */
 size_t mutt_str_strfcpy(char *dest, const char *src, size_t dsize)
 {
-  if (dsize == 0)
+  if (!dest || (dsize == 0))
     return 0;
+  if (!src)
+  {
+    dest[0] = '\0';
+    return 0;
+  }
 
   char *dest0 = dest;
   while ((--dsize > 0) && (*src != '\0'))

--- a/muttlib.c
+++ b/muttlib.c
@@ -1360,12 +1360,15 @@ int mutt_save_confirm(const char *s, struct stat *st)
       if (ret == 0)
       {
         /* create dir recursively */
-        if (mutt_file_mkdir(mutt_file_dirname(s), S_IRWXU) == -1)
+        char *tmp_path = mutt_file_dirname(s);
+        if (mutt_file_mkdir(tmp_path, S_IRWXU) == -1)
         {
           /* report failure & abort */
           mutt_perror(s);
+          FREE(&tmp_path);
           return 1;
         }
+        FREE(&tmp_path);
       }
     }
     else


### PR DESCRIPTION
* **What does this PR do?**
Eliminate static variable in mutt_file_dirname
* **Are there points in the code the reviewer needs to double check?**
Yes
* **Screenshots (if relevant)**

* **Does this PR meet the acceptance criteria?** (This is just a reminder for you,
  this section can be removed if you fulfill it.)

   - Documentation created/updated (you have to edit
     [doc/manual.xml.head](https://www.github.com/neomutt/neomutt/blob/master/doc/manual.xml.head)
     for that)

   - All builds are passing

   - Added [doxygen code documentation](https://www.neomutt.org/dev/doxygen)
     [syntax](http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html)

   - Code follows the [style guide](https://www.neomutt.org/dev/coding-style)

* **What are the relevant issue numbers?**
Malloc a char *buf and free it in mutt_file_to_absolate_path() and mutt_save_confirm() 