### PR TITLE
Accept whitespace in RFC2047 encoded-text productions

### DIFF
--- a/mutt/rfc2047.c
+++ b/mutt/rfc2047.c
@@ -153,7 +153,8 @@ static char *parse_encoded_word(char *str, enum ContentEncoding *enc, char **cha
                             "\\?"
                             "([qQbB])" /* encoding */
                             "\\?"
-                            "([^? ]+)" /* encoded text */
+                            "([^?]+)" /* encoded text - we accept whitespace 
+                                         as some mailers do that, see #1189. */
                             "\\?=",
                             REG_EXTENDED);
     assert(re && "Something is wrong with your RE engine.");

--- a/test/rfc2047.c
+++ b/test/rfc2047.c
@@ -47,6 +47,14 @@ static const struct
       "=?utf-8?B?6IGq5piO55qEICAgIOiBquaYjueahA==?="
     , "聪明的    聪明的"
     , "=?utf-8?B?6IGq5piO55qEICAgIOiBquaYjueahA==?="
+  },
+  {
+    /* Let's accept spaces within encoded-text (issue #1189). In this
+     * particular case, NeoMutt choses to encode only the initial part of the
+     * string, as the remaining part only contains ASCII characters. */
+      "=?UTF-8?Q?Sicherheitsl=C3=BCcke in praktisch allen IT-Systemen?="
+    , "Sicherheitslücke in praktisch allen IT-Systemen"
+    , "=?utf-8?Q?Sicherheitsl=C3=BCcke?= in praktisch allen IT-Systemen"
   }
 };
 /* clang-format on */


### PR DESCRIPTION
Let's be more liberal and accept RFC2047 encoded-test productions that include white space. This is explicitly forbidden by RFC2047, but Mutt has been accepting them since (almost) forever, so let's not break existing clients.

#1189 