### PR TITLE
Autocrypt support for incoming messages

### DIFF
--- a/copy.c
+++ b/copy.c
@@ -215,6 +215,9 @@ int mutt_copy_hdr(FILE *in, FILE *out, LOFF_T off_start, LOFF_T off_end,
         this_one = NULL;
       }
 
+      if (is_autocrypt)
+        fputs("\n", out_autocrypt);
+
       ignore = true;
       is_autocrypt = false;
       this_is_from = false;
@@ -242,8 +245,12 @@ int mutt_copy_hdr(FILE *in, FILE *out, LOFF_T off_start, LOFF_T off_end,
       {
         if (is_autocrypt)
         {
-            fputs(buf, out_autocrypt);
+          size_t blen = mutt_str_strlen(buf);
+          while (buf[blen -1] == '\n' || buf[blen -1] == '\r')
+            blen--;
+          fwrite(buf, sizeof(char), blen, out_autocrypt);
         }
+
         continue;
       }
       if ((flags & CH_WEED_DELIVERED) &&
@@ -297,7 +304,10 @@ int mutt_copy_hdr(FILE *in, FILE *out, LOFF_T off_start, LOFF_T off_end,
 
     if (is_autocrypt)
     {
-      fputs(buf, out_autocrypt);
+      size_t blen = mutt_str_strlen(buf);
+      while (buf[blen -1] == '\n' || buf[blen -1] == '\r')
+        blen--;
+      fwrite(buf, sizeof(char), blen, out_autocrypt);
     }
 
     if (!ignore)
@@ -342,6 +352,9 @@ int mutt_copy_hdr(FILE *in, FILE *out, LOFF_T off_start, LOFF_T off_end,
 
     this_one = NULL;
   }
+
+  if (is_autocrypt)
+    fputs("\n", out_autocrypt);
 
   /* Now output the headers in order */
   for (x = 0; x < hdr_count; x++)

--- a/copy.c
+++ b/copy.c
@@ -717,6 +717,7 @@ int mutt_copy_message_fp_autocrypt(FILE *fpout, FILE *fpin, struct Header *hdr, 
     memset(&s, 0, sizeof(struct State));
     s.fpin = fpin;
     s.fpout = fpout;
+    s.fpout_gossip = out_autocrypt;
     if (flags & MUTT_CM_PREFIX)
       s.prefix = prefix;
     if (flags & MUTT_CM_DISPLAY)

--- a/copy.h
+++ b/copy.h
@@ -67,12 +67,14 @@ struct Context;
 #define CH_VIRTUAL        (1 << 20) /**< write virtual header lines too */
 
 int mutt_copy_hdr(FILE *in, FILE *out, LOFF_T off_start, LOFF_T off_end,
-                  int flags, const char *prefix);
+                  int flags, const char *prefix, FILE *out_autocrypt);
 
-int mutt_copy_header(FILE *in, struct Header *h, FILE *out, int flags, const char *prefix);
+int mutt_copy_header(FILE *in, struct Header *h, FILE *out, int flags, const char *prefix, FILE *out_autocrypt);
 
 int mutt_copy_message_fp (FILE *fpout, FILE *fpin,          struct Header *hdr, int flags, int chflags);
+int mutt_copy_message_fp_autocrypt (FILE *fpout, FILE *fpin,          struct Header *hdr, int flags, int chflags, FILE *out_autocrypt);
 int mutt_copy_message_ctx(FILE *fpout, struct Context *src, struct Header *hdr, int flags, int chflags);
+int mutt_copy_message_ctx_autocrypt(FILE *fpout, struct Context *src, struct Header *hdr, int flags, int chflags, FILE *out_autocrypt);
 
 int mutt_append_message(struct Context *dest, struct Context *src, struct Header *hdr, int cmflags, int chflags);
 

--- a/editmsg.c
+++ b/editmsg.c
@@ -220,7 +220,7 @@ static int edit_or_view_one_message(bool edit, struct Context *ctx, struct Heade
     goto bail;
   }
 
-  rc = mutt_copy_hdr(fp, msg->fp, 0, sb.st_size, CH_NOLEN | cf, NULL);
+  rc = mutt_copy_hdr(fp, msg->fp, 0, sb.st_size, CH_NOLEN | cf, NULL, NULL);
   if (rc == 0)
   {
     fputc('\n', msg->fp);

--- a/globals.h
+++ b/globals.h
@@ -115,6 +115,7 @@ WHERE char *ContentType;
 WHERE char *DefaultHook;
 WHERE char *DateFormat;
 WHERE char *DisplayFilter;
+WHERE char *AutocryptCmd;
 WHERE char *DsnNotify;
 WHERE char *DsnReturn;
 WHERE char *Editor;

--- a/handler.c
+++ b/handler.c
@@ -1307,7 +1307,7 @@ static int message_handler(struct Body *a, struct State *s)
                        0) |
                       (s->prefix ? CH_PREFIX : 0) | CH_DECODE | CH_FROM |
                       ((s->flags & MUTT_DISPLAY) ? CH_DISPLAY : 0),
-                  s->prefix);
+                  s->prefix, NULL);
 
     if (s->prefix)
       state_puts(s->prefix, s);
@@ -1657,7 +1657,7 @@ static int external_body_handler(struct Body *b, struct State *s)
       }
 
       mutt_copy_hdr(s->fpin, s->fpout, ftello(s->fpin), b->parts->offset,
-                    (Weed ? (CH_WEED | CH_REORDER) : 0) | CH_DECODE, NULL);
+                    (Weed ? (CH_WEED | CH_REORDER) : 0) | CH_DECODE, NULL, NULL);
     }
   }
   else if (expiration && expire < time(NULL))
@@ -1676,7 +1676,7 @@ static int external_body_handler(struct Body *b, struct State *s)
       state_attach_puts(strbuf, s);
 
       mutt_copy_hdr(s->fpin, s->fpout, ftello(s->fpin), b->parts->offset,
-                    (Weed ? (CH_WEED | CH_REORDER) : 0) | CH_DECODE | CH_DISPLAY, NULL);
+                    (Weed ? (CH_WEED | CH_REORDER) : 0) | CH_DECODE | CH_DISPLAY, NULL, NULL);
     }
   }
   else
@@ -1696,7 +1696,7 @@ static int external_body_handler(struct Body *b, struct State *s)
       state_attach_puts(strbuf, s);
 
       mutt_copy_hdr(s->fpin, s->fpout, ftello(s->fpin), b->parts->offset,
-                    (Weed ? (CH_WEED | CH_REORDER) : 0) | CH_DECODE | CH_DISPLAY, NULL);
+                    (Weed ? (CH_WEED | CH_REORDER) : 0) | CH_DECODE | CH_DISPLAY, NULL, NULL);
     }
   }
 

--- a/init.h
+++ b/init.h
@@ -776,6 +776,7 @@ struct Option MuttVars[] = {
   ** This can be fixed by adding this to your config:
   ** \fCcolor body magenta default '^\[-- .* --\]$$$'\fP.
   */
+  { "autocrypt_cmd",   DT_PATH, R_NONE, &AutocryptCmd, IP "" },
   { "dsn_notify",       DT_STRING,  R_NONE, &DsnNotify, IP "" },
   /*
   ** .pp

--- a/ncrypt/pgp.c
+++ b/ncrypt/pgp.c
@@ -922,7 +922,7 @@ static struct Body *pgp_decrypt_part(struct Body *a, struct State *s,
 
   rewind(fpout);
 
-  tattach = mutt_read_mime_header(fpout, 0);
+  tattach = mutt_read_mime_header_gossip(fpout, 0, p->goodsig ? s->fpout_gossip : NULL);
   if (tattach)
   {
     /*

--- a/ncrypt/pgp.c
+++ b/ncrypt/pgp.c
@@ -922,7 +922,7 @@ static struct Body *pgp_decrypt_part(struct Body *a, struct State *s,
 
   rewind(fpout);
 
-  tattach = mutt_read_mime_header_gossip(fpout, 0, p->goodsig ? s->fpout_gossip : NULL);
+  tattach = mutt_read_mime_header_gossip(fpout, 0, s->fpout_gossip);
   if (tattach)
   {
     /*

--- a/pattern.c
+++ b/pattern.c
@@ -931,7 +931,7 @@ static int msg_search(struct Context *ctx, struct Pattern *pat, int msgno)
 #endif
 
     if (pat->op != MUTT_BODY)
-      mutt_copy_header(msg->fp, h, s.fpout, CH_FROM | CH_DECODE, NULL);
+      mutt_copy_header(msg->fp, h, s.fpout, CH_FROM | CH_DECODE, NULL, NULL);
 
     if (pat->op != MUTT_HEADER)
     {

--- a/protos.h
+++ b/protos.h
@@ -110,7 +110,8 @@ struct Body *mutt_remove_multipart(struct Body *b);
 struct Body *mutt_make_multipart(struct Body *b);
 struct Body *mutt_parse_multipart(FILE *fp, const char *boundary, LOFF_T end_off, bool digest);
 struct Body *mutt_rfc822_parse_message(FILE *fp, struct Body *parent);
-struct Body *mutt_read_mime_header(FILE *fp, bool digest);
+struct Body *mutt_read_mime_header(FILE *fp, int digest);
+struct Body *mutt_read_mime_header_gossip(FILE *fp, bool digest, FILE *out_gossip);
 
 struct Content *mutt_get_content_info(const char *fname, struct Body *b);
 

--- a/recvcmd.c
+++ b/recvcmd.c
@@ -345,7 +345,7 @@ static void include_header(int quote, FILE *ifp, struct Header *hdr, FILE *ofp, 
     chflags |= CH_PREFIX;
   }
 
-  mutt_copy_header(ifp, hdr, ofp, chflags, quote ? prefix2 : NULL);
+  mutt_copy_header(ifp, hdr, ofp, chflags, quote ? prefix2 : NULL, NULL);
 }
 
 /**

--- a/sendlib.c
+++ b/sendlib.c
@@ -1201,7 +1201,7 @@ void mutt_message_to_7bit(struct Body *a, FILE *fp)
   transform_to_7bit(a->parts, fpin);
 
   mutt_copy_hdr(fpin, fpout, a->offset, a->offset + a->length,
-                CH_MIME | CH_NONEWLINE | CH_XMIT, NULL);
+                CH_MIME | CH_NONEWLINE | CH_XMIT, NULL, NULL);
 
   fputs("MIME-Version: 1.0\n", fpout);
   mutt_write_mime_header(a->parts, fpout);
@@ -2746,7 +2746,7 @@ static int bounce_message(FILE *fp, struct Header *h, struct Address *to,
     fprintf(f, "Resent-Message-ID: %s\n", msgid_str);
     fputs("Resent-To: ", f);
     mutt_write_address_list(to, f, 11, 0);
-    mutt_copy_header(fp, h, f, ch_flags, NULL);
+    mutt_copy_header(fp, h, f, ch_flags, NULL, NULL);
     fputc('\n', f);
     mutt_file_copy_bytes(fp, f, h->content->length);
     FREE(&msgid_str);

--- a/state.h
+++ b/state.h
@@ -35,6 +35,7 @@ struct State
   FILE *fpout;
   char *prefix;
   int flags;
+  FILE *fpout_gossip;
 };
 
 /* flags for the State struct */


### PR DESCRIPTION
This PR adds some support for [Autocrypt](https://autocrypt.org), in the form of an autocrypt_cmd setting. The setting contains a command name, which is called at message view time and receives Autocrypt-related headers on its stdin. Specifically, it receives the `From`, `To`, `Cc`, `Autocrypt` headers, and also the `Autocrypt-Gossip` header from the outermost decrypted mime part. This information is sufficient to maintain a database of keys in an Autocrypt-compliant manner.

This isn't really camera-ready yet, in particular I didn't document much. But I would be interested in feedback on the concept and implementation.

I had to add a parameter to a bunch of functions, which doesn't feel too elegant. If anyone has a better approach in mind, I'd be all ears :) otherwise this works quite well and isn't too intrusive on other matters.