### PR TITLE
build: stop on install failure

### DIFF
--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -294,11 +294,11 @@ install: all $(INSTALL_TARGETS)
 	# Install binaries
 	$(MKDIR_P) $(DESTDIR)$(bindir)
 	for f in $(BINFILES); do \
-		$(INSTALL) $$f $(DESTDIR)$(bindir)/`basename $$f`; \
+		$(INSTALL) $$f $(DESTDIR)$(bindir)/`basename $$f` || exit 1; \
 	done
 	$(MKDIR_P) $(DESTDIR)$(libexecdir)/$(PACKAGE)
 	for f in $(LIBBINFILES); do \
-		$(INSTALL) $$f $(DESTDIR)$(libexecdir)/$(PACKAGE)/`basename $$f`; \
+		$(INSTALL) $$f $(DESTDIR)$(libexecdir)/$(PACKAGE)/`basename $$f` || exit 1; \
 	done
 
 # uninstall

--- a/contrib/Makefile.autosetup
+++ b/contrib/Makefile.autosetup
@@ -10,14 +10,14 @@ clean-contrib:
 install-contrib:
 	$(INSTALL) -d -m 755 $(DESTDIR)$(docdir)/samples
 	for f in $(SAMPLES); do \
-		$(INSTALL) -m 644 $(SRCDIR)/contrib/$$f $(DESTDIR)$(docdir)/samples; \
+		$(INSTALL) -m 644 $(SRCDIR)/contrib/$$f $(DESTDIR)$(docdir)/samples || exit 1; \
 	done
 	for d in $(CONTRIB_DIRS); do \
 		echo "Creating directory $(DESTDIR)$(docdir)/$$d"; \
-		$(INSTALL) -d -m 755 $(DESTDIR)$(docdir)/$$d; \
+		$(INSTALL) -d -m 755 $(DESTDIR)$(docdir)/$$d || exit 1; \
 		for f in $(SRCDIR)/contrib/$$d/*; do \
 			echo "Installing $$f"; \
-			$(INSTALL) -m 644 $$f $(DESTDIR)$(docdir)/$$d; \
+			$(INSTALL) -m 644 $$f $(DESTDIR)$(docdir)/$$d || exit 1; \
 		done \
 	done
 	chmod +x $(DESTDIR)$(docdir)/keybase/*.sh

--- a/doc/Makefile.autosetup
+++ b/doc/Makefile.autosetup
@@ -107,11 +107,11 @@ install-doc: all-doc
 	$(INSTALL) -m 644 $(SRCDIR)/doc/mmdf.5 $(DESTDIR)$(mandir)/man5/mmdf_$(PACKAGE).5
 	$(MKDIR_P) $(DESTDIR)$(docdir)
 	for f in $(srcdir_DOCFILES); do \
-		$(INSTALL) -m 644 $$f $(DESTDIR)$(docdir); \
+		$(INSTALL) -m 644 $$f $(DESTDIR)$(docdir) || exit 1; \
 	done
 	-$(INSTALL) -m 644 doc/manual.txt $(DESTDIR)$(docdir)
 	-for f in $(HTML_DOCFILES); do \
-		$(INSTALL) -m 644 $$f $(DESTDIR)$(docdir); \
+		$(INSTALL) -m 644 $$f $(DESTDIR)$(docdir) || exit 1; \
 	done
 	$(INSTALL) -m 644 doc/neomuttrc $(DESTDIR)$(sysconfdir)/neomuttrc
 	# Install mime.types

--- a/po/Makefile.autosetup
+++ b/po/Makefile.autosetup
@@ -32,7 +32,7 @@ install-po: all-po
 	  lang=`echo $$cat | sed -e 's/\.mo$$//' -e 's|^po/||'`; \
 	  dir=$(DESTDIR)$(localedir)/$$lang/LC_MESSAGES; \
 	  $(MKDIR_P) $$dir; \
-	  $(INSTALL_DATA) $$cat $$dir/$(PACKAGE).mo; \
+	  $(INSTALL_DATA) $$cat $$dir/$(PACKAGE).mo || exit 1; \
 	  echo "installing $$dir/$(PACKAGE).mo"; \
 	done
 


### PR DESCRIPTION
The install was succeeding, even if some files weren't found.
This was due to a `for` loop eating the command's return code.

For the 'uninstall' targets, we don't really care -- they should try to continue.

Please can someone with a non-Linux make check this works ok.