### PR TITLE
Determine hostname before loading RC file

### DIFF
--- a/init.c
+++ b/init.c
@@ -4063,6 +4063,9 @@ int mutt_init(int skip_sys_rc, struct ListHead *commands)
     }
   }
 
+  if (!get_hostname())
+    return 1;
+
   /* Read the user's initialization file.  */
   struct ListNode *np;
   STAILQ_FOREACH(np, &Muttrc, entries)
@@ -4079,9 +4082,6 @@ int mutt_init(int skip_sys_rc, struct ListHead *commands)
 
   if (execute_commands(commands) != 0)
     need_pause = 1; // TEST13: neomutt -e broken
-
-  if (!get_hostname())
-    return 1;
 
   if (need_pause && !OptNoCurses)
   {


### PR DESCRIPTION
Moved `get_hostname()` to before of the logic for loading the RC file.

If the RC file uses `$hostname`, but lacks `set hostname` then Neomutt
expands it to an empty string. Moving `get_hostname()` to before the RC
file logic allows hostname to have a pseudo-default value, which the RC
file can override. This prevents Neomutt from substituting an empty
string for `$hostname`.

#### What does this PR do?

Loads the hostname before trying to parse the RC file to prevent the substitution of an empty string for `$hostname`

#### What are the relevant issue numbers?
Issue #1213 
