### PR TITLE
Mark strings for translation (Fix #1217)

### DIFF
--- a/pager.c
+++ b/pager.c
@@ -1994,7 +1994,7 @@ static void pager_menu_redraw(struct Menu *pager_menu)
       snprintf(pager_progress_str, sizeof(pager_progress_str), OFF_T_FMT "%%",
                (100 * rd->last_offset / rd->sb.st_size));
     else
-      mutt_str_strfcpy(pager_progress_str, (rd->topline == 0) ? "all" : "end",
+      mutt_str_strfcpy(pager_progress_str, (rd->topline == 0) ? _("all") : _("end"),
                        sizeof(pager_progress_str));
 
     /* print out the pager status bar */

--- a/po/bg.po
+++ b/po/bg.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neomutt-20180512\n"
 "Report-Msgid-Bugs-To: neomutt-devel@neomutt.org\n"
-"POT-Creation-Date: 2018-05-19 22:04+0100\n"
+"POT-Creation-Date: 2018-05-20 02:02+0000\n"
 "PO-Revision-Date: 2016-11-09 22:45+0000\n"
 "Last-Translator: Velko Hristov <hristov@informatik.hu-berlin.de>\n"
 "Language-Team: none\n"
@@ -5698,6 +5698,14 @@ msgstr "Приложения"
 #: pager.c:1707 pager.c:1716
 msgid "Next"
 msgstr "Следващо"
+
+#: pager.c:1997
+msgid "all"
+msgstr ""
+
+#: pager.c:1997
+msgid "end"
+msgstr ""
 
 #: pager.c:2334 pager.c:2365 pager.c:2399 pager.c:2719
 msgid "Bottom of message is shown."

--- a/po/ca.po
+++ b/po/ca.po
@@ -54,7 +54,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neomutt-20180512\n"
 "Report-Msgid-Bugs-To: neomutt-devel@neomutt.org\n"
-"POT-Creation-Date: 2018-05-19 22:04+0100\n"
+"POT-Creation-Date: 2018-05-20 02:02+0000\n"
 "PO-Revision-Date: 2017-02-18 01:24+0100\n"
 "Last-Translator: Ivan Vilata i Balaguer <ivan@selidor.net>\n"
 "Language-Team: Catalan <ca@dodds.net>\n"
@@ -5870,6 +5870,14 @@ msgstr "Adjuncs."
 #: pager.c:1707 pager.c:1716
 msgid "Next"
 msgstr "Segnt."
+
+#: pager.c:1997
+msgid "all"
+msgstr ""
+
+#: pager.c:1997
+msgid "end"
+msgstr ""
 
 #: pager.c:2334 pager.c:2365 pager.c:2399 pager.c:2719
 msgid "Bottom of message is shown."

--- a/po/cs.po
+++ b/po/cs.po
@@ -18,7 +18,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neomutt-20180512\n"
 "Report-Msgid-Bugs-To: neomutt-devel@neomutt.org\n"
-"POT-Creation-Date: 2018-05-19 22:04+0100\n"
+"POT-Creation-Date: 2018-05-20 02:02+0000\n"
 "PO-Revision-Date: 2018-03-06 15:18+0100\n"
 "Last-Translator: David Sterba <dsterba@suse.cz>\n"
 "Language-Team: Czech <translation-team-cs@lists.sourceforge.net>\n"
@@ -5529,6 +5529,14 @@ msgstr "Přílohy"
 #: pager.c:1707 pager.c:1716
 msgid "Next"
 msgstr "Další"
+
+#: pager.c:1997
+msgid "all"
+msgstr ""
+
+#: pager.c:1997
+msgid "end"
+msgstr ""
 
 #: pager.c:2334 pager.c:2365 pager.c:2399 pager.c:2719
 msgid "Bottom of message is shown."

--- a/po/da.po
+++ b/po/da.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neomutt-20180512\n"
 "Report-Msgid-Bugs-To: neomutt-devel@neomutt.org\n"
-"POT-Creation-Date: 2018-05-19 22:04+0100\n"
+"POT-Creation-Date: 2018-05-20 02:02+0000\n"
 "PO-Revision-Date: 2017-02-16 18:06+0100\n"
 "Last-Translator: Morten Bo Johansen <mbj@mbjnet.dk>\n"
 "Language-Team: Danish <dansk@dansk-gruppen.dk>\n"
@@ -5551,6 +5551,14 @@ msgstr "Vis brevdel."
 #: pager.c:1707 pager.c:1716
 msgid "Next"
 msgstr "Næste"
+
+#: pager.c:1997
+msgid "all"
+msgstr ""
+
+#: pager.c:1997
+msgid "end"
+msgstr ""
 
 #: pager.c:2334 pager.c:2365 pager.c:2399 pager.c:2719
 msgid "Bottom of message is shown."

--- a/po/de.po
+++ b/po/de.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neomutt-20180512\n"
 "Report-Msgid-Bugs-To: neomutt-devel@neomutt.org\n"
-"POT-Creation-Date: 2018-05-19 22:04+0100\n"
+"POT-Creation-Date: 2018-05-20 02:02+0000\n"
 "PO-Revision-Date: 2018-05-09 23:58+0200\n"
 "Last-Translator: Floyd Anderson <f.a@31c0.net>\n"
 "Language-Team: none\n"
@@ -5507,6 +5507,14 @@ msgstr "Anhänge betr."
 #: pager.c:1707 pager.c:1716
 msgid "Next"
 msgstr "Nächste Nachr."
+
+#: pager.c:1997
+msgid "all"
+msgstr ""
+
+#: pager.c:1997
+msgid "end"
+msgstr ""
 
 #: pager.c:2334 pager.c:2365 pager.c:2399 pager.c:2719
 msgid "Bottom of message is shown."

--- a/po/el.po
+++ b/po/el.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neomutt-20180512\n"
 "Report-Msgid-Bugs-To: neomutt-devel@neomutt.org\n"
-"POT-Creation-Date: 2018-05-19 22:04+0100\n"
+"POT-Creation-Date: 2018-05-20 02:02+0000\n"
 "PO-Revision-Date: 2005-02-01 00:01GMT+2\n"
 "Last-Translator: Dokianakis Fanis <madf@hellug.gr>\n"
 "Language-Team: Greek <EL@li.org>\n"
@@ -5704,6 +5704,14 @@ msgstr "ΌψηΠροσάρτ"
 #: pager.c:1707 pager.c:1716
 msgid "Next"
 msgstr "Επόμενο"
+
+#: pager.c:1997
+msgid "all"
+msgstr ""
+
+#: pager.c:1997
+msgid "end"
+msgstr ""
 
 #: pager.c:2334 pager.c:2365 pager.c:2399 pager.c:2719
 msgid "Bottom of message is shown."

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neomutt-20180512\n"
 "Report-Msgid-Bugs-To: neomutt-devel@neomutt.org\n"
-"POT-Creation-Date: 2018-05-19 22:04+0100\n"
+"POT-Creation-Date: 2018-05-20 02:02+0000\n"
 "PO-Revision-Date: 2017-04-17 17:06+0100\n"
 "Last-Translator: Richard Russon <rich@flatcap.org>\n"
 "Language-Team: none\n"
@@ -5500,6 +5500,14 @@ msgstr "View Attachm."
 #: pager.c:1707 pager.c:1716
 msgid "Next"
 msgstr "Next"
+
+#: pager.c:1997
+msgid "all"
+msgstr ""
+
+#: pager.c:1997
+msgid "end"
+msgstr ""
 
 #: pager.c:2334 pager.c:2365 pager.c:2399 pager.c:2719
 msgid "Bottom of message is shown."

--- a/po/eo.po
+++ b/po/eo.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neomutt-20180512\n"
 "Report-Msgid-Bugs-To: neomutt-devel@neomutt.org\n"
-"POT-Creation-Date: 2018-05-19 22:04+0100\n"
+"POT-Creation-Date: 2018-05-20 02:02+0000\n"
 "PO-Revision-Date: 2017-02-22 21:14+0100\n"
 "Last-Translator: Benno Schulenberg <benno@vertaalt.nl>\n"
 "Language-Team: Esperanto <translation-team-eo@lists.sourceforge.net>\n"
@@ -5564,6 +5564,14 @@ msgstr "Vidi Partojn"
 #: pager.c:1707 pager.c:1716
 msgid "Next"
 msgstr "Sekva"
+
+#: pager.c:1997
+msgid "all"
+msgstr ""
+
+#: pager.c:1997
+msgid "end"
+msgstr ""
 
 #: pager.c:2334 pager.c:2365 pager.c:2399 pager.c:2719
 msgid "Bottom of message is shown."

--- a/po/es.po
+++ b/po/es.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neomutt-20180512\n"
 "Report-Msgid-Bugs-To: neomutt-devel@neomutt.org\n"
-"POT-Creation-Date: 2018-05-19 22:04+0100\n"
+"POT-Creation-Date: 2018-05-20 02:02+0000\n"
 "PO-Revision-Date: 2016-11-28 19:29+0100\n"
 "Last-Translator: Rubén Llorente\n"
 "Language-Team: none\n"
@@ -5749,6 +5749,14 @@ msgstr "Adjuntos"
 #: pager.c:1707 pager.c:1716
 msgid "Next"
 msgstr "Sig."
+
+#: pager.c:1997
+msgid "all"
+msgstr ""
+
+#: pager.c:1997
+msgid "end"
+msgstr ""
 
 #: pager.c:2334 pager.c:2365 pager.c:2399 pager.c:2719
 msgid "Bottom of message is shown."

--- a/po/et.po
+++ b/po/et.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neomutt-20180512\n"
 "Report-Msgid-Bugs-To: neomutt-devel@neomutt.org\n"
-"POT-Creation-Date: 2018-05-19 22:04+0100\n"
+"POT-Creation-Date: 2018-05-20 02:02+0000\n"
 "PO-Revision-Date: 2002-12-09 17:19+02:00\n"
 "Last-Translator: Toomas Soome <tsoome@muhv.pri.ee>\n"
 "Language-Team: Estonian <et@li.org>\n"
@@ -5695,6 +5695,14 @@ msgstr "Vaata lisa"
 #: pager.c:1707 pager.c:1716
 msgid "Next"
 msgstr "Järgm."
+
+#: pager.c:1997
+msgid "all"
+msgstr ""
+
+#: pager.c:1997
+msgid "end"
+msgstr ""
 
 #: pager.c:2334 pager.c:2365 pager.c:2399 pager.c:2719
 msgid "Bottom of message is shown."

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neomutt-20180512\n"
 "Report-Msgid-Bugs-To: neomutt-devel@neomutt.org\n"
-"POT-Creation-Date: 2018-05-19 22:04+0100\n"
+"POT-Creation-Date: 2018-05-20 02:02+0000\n"
 "PO-Revision-Date: 2008-05-20 22:39+0200\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <debian-l10n-basque@lists.debian.org>\n"
@@ -5644,6 +5644,14 @@ msgstr "Ikusi gehigar."
 #: pager.c:1707 pager.c:1716
 msgid "Next"
 msgstr "Hurrengoa"
+
+#: pager.c:1997
+msgid "all"
+msgstr ""
+
+#: pager.c:1997
+msgid "end"
+msgstr ""
 
 #: pager.c:2334 pager.c:2365 pager.c:2399 pager.c:2719
 msgid "Bottom of message is shown."

--- a/po/fr.po
+++ b/po/fr.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neomutt-20180512\n"
 "Report-Msgid-Bugs-To: neomutt-devel@neomutt.org\n"
-"POT-Creation-Date: 2018-05-19 22:04+0100\n"
+"POT-Creation-Date: 2018-05-20 02:02+0000\n"
 "PO-Revision-Date: 2017-02-10 12:46+0100\n"
 "Last-Translator: Vincent Lefevre <vincent@vinc17.net>\n"
 "Language-Team: Vincent Lefevre <vincent@vinc17.net>\n"
@@ -5748,6 +5748,14 @@ msgstr "Voir attach."
 #: pager.c:1707 pager.c:1716
 msgid "Next"
 msgstr "Suivant"
+
+#: pager.c:1997
+msgid "all"
+msgstr ""
+
+#: pager.c:1997
+msgid "end"
+msgstr ""
 
 #: pager.c:2334 pager.c:2365 pager.c:2399 pager.c:2719
 msgid "Bottom of message is shown."

--- a/po/ga.po
+++ b/po/ga.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neomutt-20180512\n"
 "Report-Msgid-Bugs-To: neomutt-devel@neomutt.org\n"
-"POT-Creation-Date: 2018-05-19 22:04+0100\n"
+"POT-Creation-Date: 2018-05-20 02:02+0000\n"
 "PO-Revision-Date: 2006-10-16 14:22-0500\n"
 "Last-Translator: Kevin Patrick Scannell <scannell@SLU.EDU>\n"
 "Language-Team: Irish <ga@li.org>\n"
@@ -5685,6 +5685,14 @@ msgstr "Iatáin"
 #: pager.c:1707 pager.c:1716
 msgid "Next"
 msgstr "Ar Aghaidh"
+
+#: pager.c:1997
+msgid "all"
+msgstr ""
+
+#: pager.c:1997
+msgid "end"
+msgstr ""
 
 #: pager.c:2334 pager.c:2365 pager.c:2399 pager.c:2719
 msgid "Bottom of message is shown."

--- a/po/gl.po
+++ b/po/gl.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neomutt-20180512\n"
 "Report-Msgid-Bugs-To: neomutt-devel@neomutt.org\n"
-"POT-Creation-Date: 2018-05-19 22:04+0100\n"
+"POT-Creation-Date: 2018-05-20 02:02+0000\n"
 "PO-Revision-Date: 2001-04-22 22:05+0200\n"
 "Last-Translator: Roberto Suarez Soto <ask4it@bigfoot.com>\n"
 "Language-Team: Galician <trasno@ceu.fi.udc.es>\n"
@@ -5749,6 +5749,14 @@ msgstr "Ver adxunto"
 #: pager.c:1707 pager.c:1716
 msgid "Next"
 msgstr "Seguinte"
+
+#: pager.c:1997
+msgid "all"
+msgstr ""
+
+#: pager.c:1997
+msgid "end"
+msgstr ""
 
 #: pager.c:2334 pager.c:2365 pager.c:2399 pager.c:2719
 msgid "Bottom of message is shown."

--- a/po/hu.po
+++ b/po/hu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neomutt-20180512\n"
 "Report-Msgid-Bugs-To: neomutt-devel@neomutt.org\n"
-"POT-Creation-Date: 2018-05-19 22:04+0100\n"
+"POT-Creation-Date: 2018-05-20 02:02+0000\n"
 "PO-Revision-Date: 2003-08-01 13:56+0000\n"
 "Last-Translator: Szabolcs Horváth <horvaths@fi.inf.elte.hu>\n"
 "Language-Team: LME Magyaritasok Lista <magyar@lists.linux.hu>\n"
@@ -5695,6 +5695,14 @@ msgstr "Melléklet"
 #: pager.c:1707 pager.c:1716
 msgid "Next"
 msgstr "Köv."
+
+#: pager.c:1997
+msgid "all"
+msgstr ""
+
+#: pager.c:1997
+msgid "end"
+msgstr ""
 
 #: pager.c:2334 pager.c:2365 pager.c:2399 pager.c:2719
 msgid "Bottom of message is shown."

--- a/po/id.po
+++ b/po/id.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neomutt-20180512\n"
 "Report-Msgid-Bugs-To: neomutt-devel@neomutt.org\n"
-"POT-Creation-Date: 2018-05-19 22:04+0100\n"
+"POT-Creation-Date: 2018-05-20 02:02+0000\n"
 "PO-Revision-Date: 2007-11-07 10:39+1100\n"
 "Last-Translator: Ronny Haryanto <ronny@haryan.to>\n"
 "Language-Team: Indonesian <web@linux.or.id>\n"
@@ -5635,6 +5635,14 @@ msgstr "Lampiran"
 #: pager.c:1707 pager.c:1716
 msgid "Next"
 msgstr "Brkt"
+
+#: pager.c:1997
+msgid "all"
+msgstr ""
+
+#: pager.c:1997
+msgid "end"
+msgstr ""
 
 #: pager.c:2334 pager.c:2365 pager.c:2399 pager.c:2719
 msgid "Bottom of message is shown."

--- a/po/it.po
+++ b/po/it.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neomutt-20180512\n"
 "Report-Msgid-Bugs-To: neomutt-devel@neomutt.org\n"
-"POT-Creation-Date: 2018-05-19 22:04+0100\n"
+"POT-Creation-Date: 2018-05-20 02:02+0000\n"
 "PO-Revision-Date: 2012-05-25 22:14+0200\n"
 "Last-Translator: Marco Paolone <marcopaolone@gmail.com>\n"
 "Language-Team: none\n"
@@ -5620,6 +5620,14 @@ msgstr "Vedi Allegato"
 #: pager.c:1707 pager.c:1716
 msgid "Next"
 msgstr "Succ"
+
+#: pager.c:1997
+msgid "all"
+msgstr ""
+
+#: pager.c:1997
+msgid "end"
+msgstr ""
 
 #: pager.c:2334 pager.c:2365 pager.c:2399 pager.c:2719
 msgid "Bottom of message is shown."

--- a/po/ja.po
+++ b/po/ja.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neomutt-20180512\n"
 "Report-Msgid-Bugs-To: neomutt-devel@neomutt.org\n"
-"POT-Creation-Date: 2018-05-19 22:04+0100\n"
+"POT-Creation-Date: 2018-05-20 02:02+0000\n"
 "PO-Revision-Date: 2017-06-01 13:00+0900\n"
 "Last-Translator: TAKAHASHI Tamotsu <ttakah@lapis.plala.or.jp>\n"
 "Language-Team: neomutt-j <neomutt-j-users@lists.osdn.me>\n"
@@ -5577,6 +5577,14 @@ msgstr "添付ファイル"
 #: pager.c:1707 pager.c:1716
 msgid "Next"
 msgstr "次"
+
+#: pager.c:1997
+msgid "all"
+msgstr ""
+
+#: pager.c:1997
+msgid "end"
+msgstr ""
 
 #: pager.c:2334 pager.c:2365 pager.c:2399 pager.c:2719
 msgid "Bottom of message is shown."

--- a/po/ko.po
+++ b/po/ko.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neomutt-20180512\n"
 "Report-Msgid-Bugs-To: neomutt-devel@neomutt.org\n"
-"POT-Creation-Date: 2018-05-19 22:04+0100\n"
+"POT-Creation-Date: 2018-05-20 02:02+0000\n"
 "PO-Revision-Date: 2004-03-03 10:25+900\n"
 "Last-Translator: Im Eunjea <eunjea@kldp.org>\n"
 "Language-Team: Im Eunjea <eunjea@kldp.org>\n"
@@ -5694,6 +5694,14 @@ msgstr "첨부물보기"
 #: pager.c:1707 pager.c:1716
 msgid "Next"
 msgstr "다음"
+
+#: pager.c:1997
+msgid "all"
+msgstr ""
+
+#: pager.c:1997
+msgid "end"
+msgstr ""
 
 #: pager.c:2334 pager.c:2365 pager.c:2399 pager.c:2719
 msgid "Bottom of message is shown."

--- a/po/lt.po
+++ b/po/lt.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neomutt-20180512\n"
 "Report-Msgid-Bugs-To: neomutt-devel@neomutt.org\n"
-"POT-Creation-Date: 2018-05-19 22:04+0100\n"
+"POT-Creation-Date: 2018-05-20 02:02+0000\n"
 "PO-Revision-Date: 2000-11-29 21:22+0200\n"
 "Last-Translator: Marius Gedminas <marius@gedmin.as>\n"
 "Language-Team: Lithuanian <komp_lt@konferencijos.lt>\n"
@@ -5515,6 +5515,14 @@ msgstr "Priedai"
 #: pager.c:1707 pager.c:1716
 msgid "Next"
 msgstr "Kitas"
+
+#: pager.c:1997
+msgid "all"
+msgstr ""
+
+#: pager.c:1997
+msgid "end"
+msgstr ""
 
 #: pager.c:2334 pager.c:2365 pager.c:2399 pager.c:2719
 msgid "Bottom of message is shown."

--- a/po/nl.po
+++ b/po/nl.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neomutt-20180512\n"
 "Report-Msgid-Bugs-To: neomutt-devel@neomutt.org\n"
-"POT-Creation-Date: 2018-05-19 22:04+0100\n"
+"POT-Creation-Date: 2018-05-20 02:02+0000\n"
 "PO-Revision-Date: 2017-02-22 20:12+0100\n"
 "Last-Translator: Benno Schulenberg <benno@vertaalt.nl>\n"
 "Language-Team: Dutch <vertaling@vrijschrift.org>\n"
@@ -5579,6 +5579,14 @@ msgstr "Bijlagen tonen"
 #: pager.c:1707 pager.c:1716
 msgid "Next"
 msgstr "Volgend ber."
+
+#: pager.c:1997
+msgid "all"
+msgstr ""
+
+#: pager.c:1997
+msgid "end"
+msgstr ""
 
 #: pager.c:2334 pager.c:2365 pager.c:2399 pager.c:2719
 msgid "Bottom of message is shown."

--- a/po/pl.po
+++ b/po/pl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neomutt-20180512\n"
 "Report-Msgid-Bugs-To: neomutt-devel@neomutt.org\n"
-"POT-Creation-Date: 2018-05-19 22:04+0100\n"
+"POT-Creation-Date: 2018-05-20 02:02+0000\n"
 "PO-Revision-Date: 2018-03-19 09:22+0100\n"
 "Last-Translator: Marcin Rajner <marcin.rajner@pw.edu.pl>\n"
 "Language-Team: none\n"
@@ -5497,6 +5497,14 @@ msgstr "Zobacz zał."
 #: pager.c:1707 pager.c:1716
 msgid "Next"
 msgstr "Następny"
+
+#: pager.c:1997
+msgid "all"
+msgstr ""
+
+#: pager.c:1997
+msgid "end"
+msgstr ""
 
 #: pager.c:2334 pager.c:2365 pager.c:2399 pager.c:2719
 msgid "Bottom of message is shown."

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neomutt-20180512\n"
 "Report-Msgid-Bugs-To: neomutt-devel@neomutt.org\n"
-"POT-Creation-Date: 2018-05-19 22:04+0100\n"
+"POT-Creation-Date: 2018-05-20 02:02+0000\n"
 "PO-Revision-Date: 2018-03-19 01:14-0300\n"
 "Last-Translator: Thiago Costa de Paiva <tecepe@tecepe.eng.br>\n"
 "Language-Team: \n"
@@ -5495,6 +5495,14 @@ msgstr "Ver Anexo"
 #: pager.c:1707 pager.c:1716
 msgid "Next"
 msgstr "Prox"
+
+#: pager.c:1997
+msgid "all"
+msgstr ""
+
+#: pager.c:1997
+msgid "end"
+msgstr ""
 
 #: pager.c:2334 pager.c:2365 pager.c:2399 pager.c:2719
 msgid "Bottom of message is shown."

--- a/po/ru.po
+++ b/po/ru.po
@@ -16,7 +16,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neomutt-20180512\n"
 "Report-Msgid-Bugs-To: neomutt-devel@neomutt.org\n"
-"POT-Creation-Date: 2018-05-19 22:04+0100\n"
+"POT-Creation-Date: 2018-05-20 02:02+0000\n"
 "PO-Revision-Date: 2017-02-15 23:39+0200\n"
 "Last-Translator: Vsevolod Volkov <vvv@mutt.org.ua>\n"
 "Language-Team: neomutt-ru@woe.spb.ru\n"
@@ -5584,6 +5584,14 @@ msgstr "Вложения"
 #: pager.c:1707 pager.c:1716
 msgid "Next"
 msgstr "Следующий"
+
+#: pager.c:1997
+msgid "all"
+msgstr ""
+
+#: pager.c:1997
+msgid "end"
+msgstr ""
 
 #: pager.c:2334 pager.c:2365 pager.c:2399 pager.c:2719
 msgid "Bottom of message is shown."

--- a/po/sk.po
+++ b/po/sk.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neomutt-20180512\n"
 "Report-Msgid-Bugs-To: neomutt-devel@neomutt.org\n"
-"POT-Creation-Date: 2018-05-19 22:04+0100\n"
+"POT-Creation-Date: 2018-05-20 02:02+0000\n"
 "PO-Revision-Date: 2016-11-23 21:20+0100\n"
 "Last-Translator: František Hájik <ferko.hajik@gmail.com>\n"
 "Language-Team: Slovak <sk@li.org>\n"
@@ -5697,6 +5697,14 @@ msgstr "Pozri prílohu"
 #: pager.c:1707 pager.c:1716
 msgid "Next"
 msgstr "Ďaľší"
+
+#: pager.c:1997
+msgid "all"
+msgstr ""
+
+#: pager.c:1997
+msgid "end"
+msgstr ""
 
 #: pager.c:2334 pager.c:2365 pager.c:2399 pager.c:2719
 msgid "Bottom of message is shown."

--- a/po/sv.po
+++ b/po/sv.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neomutt-20180512\n"
 "Report-Msgid-Bugs-To: neomutt-devel@neomutt.org\n"
-"POT-Creation-Date: 2018-05-19 22:04+0100\n"
+"POT-Creation-Date: 2018-05-20 02:02+0000\n"
 "PO-Revision-Date: 2007-12-15 14:05+0100\n"
 "Last-Translator: Johan Svedberg <johan@svedberg.com>\n"
 "Language-Team: Swedish <sv@li.org>\n"
@@ -5648,6 +5648,14 @@ msgstr "Visa bilaga"
 #: pager.c:1707 pager.c:1716
 msgid "Next"
 msgstr "Nästa"
+
+#: pager.c:1997
+msgid "all"
+msgstr ""
+
+#: pager.c:1997
+msgid "end"
+msgstr ""
 
 #: pager.c:2334 pager.c:2365 pager.c:2399 pager.c:2719
 msgid "Bottom of message is shown."

--- a/po/tr.po
+++ b/po/tr.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neomutt-20180512\n"
 "Report-Msgid-Bugs-To: neomutt-devel@neomutt.org\n"
-"POT-Creation-Date: 2018-05-19 22:04+0100\n"
+"POT-Creation-Date: 2018-05-20 02:02+0000\n"
 "PO-Revision-Date: 2006-01-11 04:13+0200\n"
 "Last-Translator: Recai Oktaş <roktas@debian.org>\n"
 "Language-Team: Debian L10n Turkish <debian-l10n-turkish@lists.debian.org>\n"
@@ -5598,6 +5598,14 @@ msgstr "EkiGörüntüle"
 #: pager.c:1707 pager.c:1716
 msgid "Next"
 msgstr "Sonraki"
+
+#: pager.c:1997
+msgid "all"
+msgstr ""
+
+#: pager.c:1997
+msgid "end"
+msgstr ""
 
 #: pager.c:2334 pager.c:2365 pager.c:2399 pager.c:2719
 msgid "Bottom of message is shown."

--- a/po/uk.po
+++ b/po/uk.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neomutt-20180512\n"
 "Report-Msgid-Bugs-To: neomutt-devel@neomutt.org\n"
-"POT-Creation-Date: 2018-05-19 22:04+0100\n"
+"POT-Creation-Date: 2018-05-20 02:02+0000\n"
 "PO-Revision-Date: 2017-02-16 21:22+0200\n"
 "Last-Translator: Vsevolod Volkov <vvv@mutt.org.ua>\n"
 "Language-Team: \n"
@@ -5573,6 +5573,14 @@ msgstr "Додатки"
 #: pager.c:1707 pager.c:1716
 msgid "Next"
 msgstr "Наст"
+
+#: pager.c:1997
+msgid "all"
+msgstr ""
+
+#: pager.c:1997
+msgid "end"
+msgstr ""
 
 #: pager.c:2334 pager.c:2365 pager.c:2399 pager.c:2719
 msgid "Bottom of message is shown."

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neomutt-20180512\n"
 "Report-Msgid-Bugs-To: neomutt-devel@neomutt.org\n"
-"POT-Creation-Date: 2018-05-19 22:04+0100\n"
+"POT-Creation-Date: 2018-05-20 02:02+0000\n"
 "PO-Revision-Date: 2018-05-11 14:00+0000\n"
 "Last-Translator: Zero King <l2dy@macports.org>\n"
 "Language-Team: i18n-zh <i18n-zh@googlegroups.com>\n"
@@ -5492,6 +5492,14 @@ msgstr "显示附件"
 #: pager.c:1707 pager.c:1716
 msgid "Next"
 msgstr "下一个"
+
+#: pager.c:1997
+msgid "all"
+msgstr ""
+
+#: pager.c:1997
+msgid "end"
+msgstr ""
 
 #: pager.c:2334 pager.c:2365 pager.c:2399 pager.c:2719
 msgid "Bottom of message is shown."

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neomutt-20180512\n"
 "Report-Msgid-Bugs-To: neomutt-devel@neomutt.org\n"
-"POT-Creation-Date: 2018-05-19 22:04+0100\n"
+"POT-Creation-Date: 2018-05-20 02:02+0000\n"
 "PO-Revision-Date: 2001-09-06 18:25+0800\n"
 "Last-Translator: Anthony Wong <ypwong@debian.org>\n"
 "Language-Team: Chinese <zh@li.org>\n"
@@ -5746,6 +5746,14 @@ msgstr "顯示附件。"
 #: pager.c:1707 pager.c:1716
 msgid "Next"
 msgstr "下一個"
+
+#: pager.c:1997
+msgid "all"
+msgstr ""
+
+#: pager.c:1997
+msgid "end"
+msgstr ""
 
 #: pager.c:2334 pager.c:2365 pager.c:2399 pager.c:2719
 msgid "Bottom of message is shown."


### PR DESCRIPTION
Just mark the two end user visible strings for translation and update the po files accordingly.