### PR TITLE
Fix plural messages (#1203)

### DIFF
--- a/curs_main.c
+++ b/curs_main.c
@@ -1374,7 +1374,11 @@ int mutt_index_menu(void)
         CHECK_VISIBLE;
         CHECK_READONLY;
         /* L10N: CHECK_ACL */
-        CHECK_ACL(MUTT_ACL_DELETE, _("Cannot delete message(s)"));
+        /* L10N: Due to the implementation details we do not know whether we
+           delete zero, 1, 12, ... messages. So in English we use
+           "messages". Your language might have other means to express this.
+         */
+        CHECK_ACL(MUTT_ACL_DELETE, _("Cannot delete messages"));
 
         CHECK_ATTACH;
         mutt_pattern_func(MUTT_DELETE, _("Delete messages matching: "));
@@ -1603,7 +1607,11 @@ int mutt_index_menu(void)
         CHECK_VISIBLE;
         CHECK_READONLY;
         /* L10N: CHECK_ACL */
-        CHECK_ACL(MUTT_ACL_DELETE, _("Cannot undelete message(s)"));
+        /* L10N: Due to the implementation details we do not know whether we
+           undelete zero, 1, 12, ... messages. So in English we use
+           "messages". Your language might have other means to express this.
+         */
+        CHECK_ACL(MUTT_ACL_DELETE, _("Cannot undelete messages"));
 
         if (mutt_pattern_func(MUTT_UNDELETE,
                               _("Undelete messages matching: ")) == 0)
@@ -2769,7 +2777,11 @@ int mutt_index_menu(void)
         CHECK_VISIBLE;
         CHECK_READONLY;
         /* L10N: CHECK_ACL */
-        CHECK_ACL(MUTT_ACL_DELETE, _("Cannot delete message(s)"));
+        /* L10N: Due to the implementation details we do not know whether we
+           delete zero, 1, 12, ... messages. So in English we use
+           "messages". Your language might have other means to express this.
+         */
+        CHECK_ACL(MUTT_ACL_DELETE, _("Cannot delete messages"));
 
         {
           int subthread = (op == OP_DELETE_SUBTHREAD);
@@ -3003,7 +3015,11 @@ int mutt_index_menu(void)
         CHECK_VISIBLE;
         CHECK_READONLY;
         /* L10N: CHECK_ACL */
-        CHECK_ACL(MUTT_ACL_SEEN, _("Cannot mark message(s) as read"));
+        /* L10N: Due to the implementation details we do not know whether we
+           mark zero, 1, 12, ... messages as read. So in English we use
+           "messages". Your language might have other means to express this.
+         */
+        CHECK_ACL(MUTT_ACL_SEEN, _("Cannot mark messages as read"));
 
         rc = mutt_thread_set_flag(CURHDR, MUTT_READ, 1, op == OP_MAIN_READ_THREAD ? 0 : 1);
 
@@ -3200,7 +3216,11 @@ int mutt_index_menu(void)
         CHECK_VISIBLE;
         CHECK_READONLY;
         /* L10N: CHECK_ACL */
-        CHECK_ACL(MUTT_ACL_DELETE, _("Cannot undelete message(s)"));
+        /* L10N: Due to the implementation details we do not know whether we
+           undelete zero, 1, 12, ... messages. So in English we use
+           "messages". Your language might have other means to express this.
+         */
+        CHECK_ACL(MUTT_ACL_DELETE, _("Cannot undelete messages"));
 
         rc = mutt_thread_set_flag(CURHDR, MUTT_DELETE, 0, op == OP_UNDELETE_THREAD ? 0 : 1);
         if (rc != -1)

--- a/handler.c
+++ b/handler.c
@@ -1595,30 +1595,60 @@ static int external_body_handler(struct Body *b, struct State *s)
     {
       char *length = NULL;
       char pretty_size[10];
+      long size = 0;
 
       length = mutt_param_get(&b->parameter, "length");
       if (length)
       {
-        mutt_str_pretty_size(pretty_size, sizeof(pretty_size), strtol(length, NULL, 10));
+        size = strtol(length, NULL, 10);
+        mutt_str_pretty_size(pretty_size, sizeof(pretty_size), size);
         if (expire != -1)
         {
-          /* L10N: If the translation of this string is a multi line string, then
-             each line should start with "[-- " and end with " --]".
-             The first "%s/%s" is a MIME type, e.g. "text/plain". The last %s
-             expands to a date as returned by `mutt_date_parse_date()`.
-           */
-          str = _(
+          str = ngettext(
+              /* L10N: If the translation of this string is a multi line string, then
+                 each line should start with "[-- " and end with " --]".
+                 The first "%s/%s" is a MIME type, e.g. "text/plain". The last %s
+                 expands to a date as returned by `mutt_date_parse_date()`.
+
+                 Note: The size argument printed is not the actual number as passed
+                 to gettext but the prettified version, e.g. size = 2048 will be
+                 printed as 2K.  Your language might be sensitive to that: For
+                 example although '1K' and '1024' represent the same number your
+                 language might inflect the noun 'byte' differently.
+
+                 Sadly, we cannot do anything about that at the moment besides
+                 passing the precise size in bytes. If you are interested the
+                 function responsible for the prettification is
+                 mutt_str_pretty_size() in mutt/string.c.
+               */
+              "[-- This %s/%s attachment (size %s byte) has been deleted --]\n"
+              "[-- on %s --]\n",
               "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
-              "[-- on %s --]\n");
+              "[-- on %s --]\n",
+              size);
         }
         else
         {
-          /* L10N: If the translation of this string is a multi line string, then
-             each line should start with "[-- " and end with " --]".
-             The first "%s/%s" is a MIME type, e.g. "text/plain".
-           */
-          str = _("[-- This %s/%s attachment (size %s bytes) has been deleted "
-                  "--]\n");
+          str = ngettext(
+              /* L10N: If the translation of this string is a multi line string, then
+                 each line should start with "[-- " and end with " --]".
+                 The first "%s/%s" is a MIME type, e.g. "text/plain".
+
+                 Note: The size argument printed is not the actual number as passed
+                 to gettext but the prettified version, e.g. size = 2048 will be
+                 printed as 2K.  Your language might be sensitive to that: For
+                 example although '1K' and '1024' represent the same number your
+                 language might inflect the noun 'byte' differently.
+
+                 Sadly, we cannot do anything about that at the moment besides
+                 passing the precise size in bytes. If you are interested the
+                 function responsible for the prettification is
+                 mutt_str_pretty_size() in mutt/string.c.
+               */
+              "[-- This %s/%s attachment (size %s byte) has been deleted --]\n",
+              "[-- This %s/%s attachment (size %s bytes) has been deleted "
+              "--]\n",
+              size);
         }
       }
       else

--- a/mx.c
+++ b/mx.c
@@ -610,15 +610,17 @@ static int trash_append(struct Context *ctx)
 {
   struct Context ctx_trash;
   int i;
+  int delmsgcount;
   struct stat st, stc;
   int opt_confappend, rc;
 
   if (!Trash || !ctx->deleted || (ctx->magic == MUTT_MAILDIR && MaildirTrash))
     return 0;
 
+  delmsgcount = 0;
   for (i = 0; i < ctx->msgcount; i++)
     if (ctx->hdrs[i]->deleted && (!ctx->hdrs[i]->purge))
-      break;
+      delmsgcount++;
   if (i == ctx->msgcount)
     return 0; /* nothing to be done */
 
@@ -631,7 +633,10 @@ static int trash_append(struct Context *ctx)
     Confirmappend = true;
   if (rc != 0)
   {
-    mutt_error(_("message(s) not deleted"));
+    /* L10N: Although we now the precise number of messages, we do not show it to the user.
+       So feel free to use a "generic plural" as plural translation if your language has one.
+     */
+    mutt_error(ngettext("message not deleted", "messages not deleted", delmsgcount));
     return -1;
   }
 

--- a/mx.c
+++ b/mx.c
@@ -756,7 +756,12 @@ int mx_close_mailbox(struct Context *ctx, int *index_hint)
     if (is_spool && *mbox)
     {
       mutt_expand_path(mbox, sizeof(mbox));
-      snprintf(buf, sizeof(buf), _("Move %d read messages to %s?"), read_msgs, mbox);
+      snprintf(buf, sizeof(buf),
+               /* L10N: The first argument is the number of read messages to be
+                  moved, the second argument is the target mailbox. */
+               ngettext("Move %d read message to %s?",
+                        "Move %d read messages to %s?", read_msgs),
+               read_msgs, mbox);
       move_messages = query_quadoption(Move, buf);
       if (move_messages == MUTT_ABORT)
       {

--- a/ncrypt/crypt.c
+++ b/ncrypt/crypt.c
@@ -92,7 +92,13 @@ void crypt_forget_passphrase(void)
     crypt_smime_void_passphrase();
 
   if (WithCrypto)
-    mutt_message(_("Passphrase(s) forgotten."));
+  {
+    /* L10N: Due to the implementation details (e.g. some passwords are managed
+       by gpg-agent) we cannot know whether we forgot zero, 1, 12, ...
+       passwords. So in English we use "Passphrases". Your language might
+       have other means to express this. */
+    mutt_message(_("Passphrases forgotten."));
+  }
 }
 
 #ifndef DEBUG

--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -3667,7 +3667,7 @@ static void print_key_info(gpgme_key_t key, FILE *fp)
   fprintf(fp, "%*s", KeyInfoPadding[KIP_KEY_TYPE], _(KeyInfoPrompts[KIP_KEY_TYPE]));
   /* L10N: This is printed after "Key Type: " and looks like this:
    *       PGP, 2048 bit RSA */
-  fprintf(fp, _("%s, %lu bit %s\n"), s2, aval, s);
+  fprintf(fp, ngettext("%s, %lu bit %s\n", "%s, %lu bit %s\n", aval), s2, aval, s);
 
   fprintf(fp, "%*s", KeyInfoPadding[KIP_KEY_USAGE], _(KeyInfoPrompts[KIP_KEY_USAGE]));
   delim = "";
@@ -3805,7 +3805,9 @@ static void print_key_info(gpgme_key_t key, FILE *fp)
       aval = subkey->length;
 
       fprintf(fp, "%*s", KeyInfoPadding[KIP_KEY_TYPE], _(KeyInfoPrompts[KIP_KEY_TYPE]));
-      fprintf(fp, _("%s, %lu bit %s\n"), "PGP", aval, s);
+      /* L10N: This is printed after "Key Type: " and looks like this:
+       *       PGP, 2048 bit RSA */
+      fprintf(fp, ngettext("%s, %lu bit %s\n", "%s, %lu bit %s\n", aval), "PGP", aval, s);
 
       fprintf(fp, "%*s", KeyInfoPadding[KIP_KEY_USAGE], _(KeyInfoPrompts[KIP_KEY_USAGE]));
       delim = "";

--- a/opcodes.h
+++ b/opcodes.h
@@ -44,9 +44,9 @@
   _fmt(OP_CATCHUP,                        N_("mark all articles in newsgroup as read")) \
   _fmt(OP_CHANGE_DIRECTORY,               N_("change directories")) \
   _fmt(OP_CHECK_NEW,                      N_("check mailboxes for new mail")) \
-  _fmt(OP_COMPOSE_ATTACH_FILE,            N_("attach file(s) to this message")) \
-  _fmt(OP_COMPOSE_ATTACH_MESSAGE,         N_("attach message(s) to this message")) \
-  _fmt(OP_COMPOSE_ATTACH_NEWS_MESSAGE,    N_("attach news article(s) to this message")) \
+  _fmt(OP_COMPOSE_ATTACH_FILE,            N_("attach files to this message")) \
+  _fmt(OP_COMPOSE_ATTACH_MESSAGE,         N_("attach messages to this message")) \
+  _fmt(OP_COMPOSE_ATTACH_NEWS_MESSAGE,    N_("attach news articles to this message")) \
   _fmt(OP_COMPOSE_EDIT_BCC,               N_("edit the BCC list")) \
   _fmt(OP_COMPOSE_EDIT_CC,                N_("edit the CC list")) \
   _fmt(OP_COMPOSE_EDIT_DESCRIPTION,       N_("edit attachment description")) \
@@ -252,7 +252,7 @@
   _fmt(OP_DECRYPT_COPY,                   N_("make decrypted copy")) \
   _fmt(OP_DECRYPT_SAVE,                   N_("make decrypted copy and delete")) \
   _fmt(OP_EXTRACT_KEYS,                   N_("extract supported public keys")) \
-  _fmt(OP_FORGET_PASSPHRASE,              N_("wipe passphrase(s) from memory")) \
+  _fmt(OP_FORGET_PASSPHRASE,              N_("wipe passphrases from memory")) \
 
 #ifdef MIXMASTER
 #define OPS_MIX(_fmt) \

--- a/pager.c
+++ b/pager.c
@@ -2815,7 +2815,11 @@ int mutt_pager(const char *banner, const char *fname, int flags, struct Pager *e
         CHECK_MODE(IsHeader(extra));
         CHECK_READONLY;
         /* L10N: CHECK_ACL */
-        CHECK_ACL(MUTT_ACL_DELETE, _("Cannot delete message(s)"));
+        /* L10N: Due to the implementation details we do not know whether we
+           delete zero, 1, 12, ... messages. So in English we use
+           "messages". Your language might have other means to express this.
+         */
+        CHECK_ACL(MUTT_ACL_DELETE, _("Cannot delete messages"));
 
         {
           int subthread = (ch == OP_DELETE_SUBTHREAD);
@@ -3134,7 +3138,11 @@ int mutt_pager(const char *banner, const char *fname, int flags, struct Pager *e
         CHECK_MODE(IsHeader(extra));
         CHECK_READONLY;
         /* L10N: CHECK_ACL */
-        CHECK_ACL(MUTT_ACL_DELETE, _("Cannot undelete message(s)"));
+        /* L10N: Due to the implementation details we do not know whether we
+           undelete zero, 1, 12, ... messages. So in English we use
+           "messages". Your language might have other means to express this.
+         */
+        CHECK_ACL(MUTT_ACL_DELETE, _("Cannot undelete messages"));
 
         r = mutt_thread_set_flag(extra->hdr, MUTT_DELETE, 0,
                                  ch == OP_UNDELETE_THREAD ? 0 : 1);

--- a/po/bg.po
+++ b/po/bg.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neomutt-20180512\n"
 "Report-Msgid-Bugs-To: neomutt-devel@neomutt.org\n"
-"POT-Creation-Date: 2018-05-20 02:02+0000\n"
+"POT-Creation-Date: 2018-05-22 14:18+0000\n"
 "PO-Revision-Date: 2016-11-09 22:45+0000\n"
 "Last-Translator: Velko Hristov <hristov@informatik.hu-berlin.de>\n"
 "Language-Team: none\n"
@@ -43,7 +43,7 @@ msgstr "Избор"
 
 #: addrbook.c:52 browser.c:75 browser.c:87 compose.c:160 compose.c:172
 #: conn/ssl.c:1041 conn/ssl_gnutls.c:793 curs_main.c:748 curs_main.c:761
-#: history.c:106 ncrypt/crypt_gpgme.c:4219 ncrypt/pgpkey.c:547
+#: history.c:106 ncrypt/crypt_gpgme.c:4221 ncrypt/pgpkey.c:547
 #: ncrypt/smime.c:477 pager.c:2141 postpone.c:65 query.c:72 recvattach.c:70
 msgid "Help"
 msgstr "Помощ"
@@ -698,7 +698,7 @@ msgstr ""
 #. * Since it shares the row with "Encrypt with:", it should not be longer
 #. * than 15-20 character cells.
 #.
-#: compose.c:138 ncrypt/crypt_gpgme.c:4947 ncrypt/pgp.c:1786
+#: compose.c:138 ncrypt/crypt_gpgme.c:4949 ncrypt/pgp.c:1786
 #: ncrypt/smime.c:2127
 msgid "Sign as: "
 msgstr "Подпис като: "
@@ -1247,7 +1247,7 @@ msgstr "отхвърляне(r), еднократно приемане(o)"
 msgid "(r)eject, accept (o)nce"
 msgstr "отхвърляне(r), еднократно приемане(o)"
 
-#: conn/ssl.c:1039 conn/ssl_gnutls.c:791 ncrypt/crypt_gpgme.c:4213
+#: conn/ssl.c:1039 conn/ssl_gnutls.c:791 ncrypt/crypt_gpgme.c:4215
 #: ncrypt/pgpkey.c:541 ncrypt/smime.c:473
 msgid "Exit  "
 msgstr "Изход"
@@ -1433,11 +1433,11 @@ msgstr "Няма отворена пощенска кутия."
 msgid "There are no messages."
 msgstr "Няма писма."
 
-#: curs_main.c:77 mx.c:1061 pager.c:73 recvattach.c:56
+#: curs_main.c:77 mx.c:1071 pager.c:73 recvattach.c:56
 msgid "Mailbox is read-only."
 msgstr "Тази пощенска кутия е само за четене."
 
-#: curs_main.c:79 pager.c:75 recvattach.c:1145
+#: curs_main.c:79 pager.c:75 recvattach.c:1158
 msgid "Function not permitted in attach-message mode."
 msgstr "Тази функция не може да се изпълни при прилагане на писма."
 
@@ -1572,255 +1572,263 @@ msgid "That message is not visible."
 msgstr "Това писмо не е видимо."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:1377 curs_main.c:2772 pager.c:2818
+#. L10N: Due to the implementation details we do not know whether we
+#. delete zero, 1, 12, ... messages. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:1381 curs_main.c:2784 pager.c:2822
 #, fuzzy
-msgid "Cannot delete message(s)"
+msgid "Cannot delete messages"
 msgstr "Няма възстановени писма."
 
-#: curs_main.c:1380
+#: curs_main.c:1384
 msgid "Delete messages matching: "
 msgstr "Изтриване на писма по шаблон: "
 
-#: curs_main.c:1421
+#: curs_main.c:1425
 msgid "No limit pattern is in effect."
 msgstr "Няма активен ограничителен шаблон."
 
 #. L10N: ask for a limit to apply
-#: curs_main.c:1426
+#: curs_main.c:1430
 #, c-format
 msgid "Limit: %s"
 msgstr "Ограничаване: %s"
 
-#: curs_main.c:1464
+#: curs_main.c:1468
 msgid "Limit to messages matching: "
 msgstr "Ограничаване до писмата, отговарящи на: "
 
-#: curs_main.c:1488
+#: curs_main.c:1492
 msgid "To view all messages, limit to \"all\"."
 msgstr ""
 
-#: curs_main.c:1500 pager.c:2318
+#: curs_main.c:1504 pager.c:2318
 msgid "Quit NeoMutt?"
 msgstr "Желаете ли да напуснете neomutt?"
 
-#: curs_main.c:1596
+#: curs_main.c:1600
 msgid "Tag messages matching: "
 msgstr "Маркиране на писмата, отговарящи на: "
 
 #. L10N: CHECK_ACL
-#: curs_main.c:1606 curs_main.c:3203 pager.c:3137
+#. L10N: Due to the implementation details we do not know whether we
+#. undelete zero, 1, 12, ... messages. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:1614 curs_main.c:3223 pager.c:3145
 #, fuzzy
-msgid "Cannot undelete message(s)"
+msgid "Cannot undelete messages"
 msgstr "Няма възстановени писма."
 
-#: curs_main.c:1609
+#: curs_main.c:1617
 msgid "Undelete messages matching: "
 msgstr "Възстановяване на писмата, отговарящи на: "
 
-#: curs_main.c:1619
+#: curs_main.c:1627
 msgid "Untag messages matching: "
 msgstr "Премахване на маркировката от писмата, отговарящи на: "
 
-#: curs_main.c:1653
+#: curs_main.c:1661
 #, fuzzy
 msgid "Logged out of IMAP servers."
 msgstr "Затваряне на връзката към IMAP сървър..."
 
-#: curs_main.c:1753
+#: curs_main.c:1761
 #, fuzzy
 msgid "No virtual folder, aborting."
 msgstr "Прекъсване поради липса на тема."
 
-#: curs_main.c:1761
+#: curs_main.c:1769
 msgid "Failed to read thread, aborting."
 msgstr ""
 
-#: curs_main.c:1793 mx.c:1458 mx.c:1475
+#: curs_main.c:1801 mx.c:1468 mx.c:1485
 msgid "Folder doesn't support tagging, aborting."
 msgstr ""
 
-#: curs_main.c:1808
+#: curs_main.c:1816
 #, fuzzy
 msgid "No tag specified, aborting."
 msgstr "Прекъсване поради липса на тема."
 
-#: curs_main.c:1820
+#: curs_main.c:1828
 #, c-format
 msgid "Update tags..."
 msgstr ""
 
-#: curs_main.c:1857
+#: curs_main.c:1865
 msgid "Failed to modify tags, aborting."
 msgstr ""
 
-#: curs_main.c:1898
+#: curs_main.c:1906
 #, fuzzy
 msgid "No query, aborting."
 msgstr "Прекъсване поради липса на тема."
 
-#: curs_main.c:1902 curs_main.c:1922 curs_main.c:1941
+#: curs_main.c:1910 curs_main.c:1930 curs_main.c:1949
 msgid "Failed to create query, aborting."
 msgstr ""
 
-#: curs_main.c:1911 curs_main.c:1930
+#: curs_main.c:1919 curs_main.c:1938
 msgid "Windowed queries disabled."
 msgstr ""
 
-#: curs_main.c:1916 curs_main.c:1935
+#: curs_main.c:1924 curs_main.c:1943
 msgid "No notmuch vfolder currently loaded."
 msgstr ""
 
-#: curs_main.c:1973
+#: curs_main.c:1981
 msgid "Open mailbox in read-only mode"
 msgstr "Отваряне на пощенската кутия само за четене"
 
-#: curs_main.c:1976
+#: curs_main.c:1984
 #, fuzzy
 msgid "Open virtual folder"
 msgstr "отваря друга пощенска кутия"
 
-#: curs_main.c:1979
+#: curs_main.c:1987
 msgid "Open mailbox"
 msgstr "Отваряне на пощенска кутия"
 
-#: curs_main.c:1989
+#: curs_main.c:1997
 #, fuzzy
 msgid "No mailboxes have new mail"
 msgstr "Няма пощенска кутия с нови писма."
 
-#: curs_main.c:2036
+#: curs_main.c:2044
 #, fuzzy
 msgid "Open newsgroup in read-only mode"
 msgstr "Отваряне на пощенската кутия само за четене"
 
-#: curs_main.c:2038
+#: curs_main.c:2046
 msgid "Open newsgroup"
 msgstr ""
 
-#: curs_main.c:2141
+#: curs_main.c:2149
 #, fuzzy
 msgid "Exit NeoMutt without saving?"
 msgstr "Желаете ли да напуснете NeoMutt без да запишете промените?"
 
-#: curs_main.c:2157
+#: curs_main.c:2165
 #, fuzzy
 msgid "Cannot break thread"
 msgstr "Филтърът не може да бъде създаден"
 
-#: curs_main.c:2160 curs_main.c:2198 curs_main.c:2658 curs_main.c:2690
+#: curs_main.c:2168 curs_main.c:2206 curs_main.c:2666 curs_main.c:2698
 #: flags.c:376 thread.c:1078 thread.c:1134 thread.c:1202
 msgid "Threading is not enabled."
 msgstr "Показването на нишки не е включено."
 
-#: curs_main.c:2173
+#: curs_main.c:2181
 msgid "Thread broken"
 msgstr ""
 
-#: curs_main.c:2185
+#: curs_main.c:2193
 msgid "Thread cannot be broken, message is not part of a thread"
 msgstr ""
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2195
+#: curs_main.c:2203
 msgid "Cannot link threads"
 msgstr ""
 
-#: curs_main.c:2200
+#: curs_main.c:2208
 msgid "No Message-ID: header available to link thread"
 msgstr ""
 
-#: curs_main.c:2202
+#: curs_main.c:2210
 #, fuzzy
 msgid "First, please tag a message to be linked here"
 msgstr "записва писмото като чернова за по-късно изпращане"
 
-#: curs_main.c:2213
+#: curs_main.c:2221
 msgid "Threads linked"
 msgstr ""
 
-#: curs_main.c:2216
+#: curs_main.c:2224
 msgid "No thread linked"
 msgstr ""
 
-#: curs_main.c:2252 curs_main.c:2278
+#: curs_main.c:2260 curs_main.c:2286
 msgid "You are on the last message."
 msgstr "Това е последното писмо."
 
-#: curs_main.c:2260 curs_main.c:2305
+#: curs_main.c:2268 curs_main.c:2313
 msgid "No undeleted messages."
 msgstr "Няма възстановени писма."
 
-#: curs_main.c:2297 curs_main.c:2323
+#: curs_main.c:2305 curs_main.c:2331
 msgid "You are on the first message."
 msgstr "Това е първото писмо."
 
-#: curs_main.c:2395 menu.c:970 pager.c:2440 pattern.c:2110
+#: curs_main.c:2403 menu.c:970 pager.c:2440 pattern.c:2110
 msgid "Search wrapped to top."
 msgstr "Търсенето е започнато отгоре."
 
-#: curs_main.c:2404 pager.c:2463 pattern.c:2121
+#: curs_main.c:2412 pager.c:2463 pattern.c:2121
 msgid "Search wrapped to bottom."
 msgstr "Търсенето е започнато отдолу."
 
-#: curs_main.c:2447
+#: curs_main.c:2455
 #, fuzzy
 msgid "No new messages in this limited view."
 msgstr "Родителското писмо не е видимо в този ограничен изглед"
 
-#: curs_main.c:2449
+#: curs_main.c:2457
 #, fuzzy
 msgid "No new messages."
 msgstr "Няма нови писма."
 
-#: curs_main.c:2454
+#: curs_main.c:2462
 #, fuzzy
 msgid "No unread messages in this limited view."
 msgstr "Родителското писмо не е видимо в този ограничен изглед"
 
-#: curs_main.c:2456
+#: curs_main.c:2464
 #, fuzzy
 msgid "No unread messages."
 msgstr "Няма непрочетени писма"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2474
+#: curs_main.c:2482
 #, fuzzy
 msgid "Cannot flag message"
 msgstr "показва писмо"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2513 pager.c:3100
+#: curs_main.c:2521 pager.c:3104
 msgid "Cannot toggle new"
 msgstr ""
 
-#: curs_main.c:2590
+#: curs_main.c:2598
 msgid "No more threads."
 msgstr "Няма повече нишки."
 
-#: curs_main.c:2592
+#: curs_main.c:2600
 msgid "You are on the first thread."
 msgstr "Това е първата нишка."
 
-#: curs_main.c:2676
+#: curs_main.c:2684
 #, fuzzy
 msgid "Thread contains unread or flagged messages."
 msgstr "Нишката съдържа непрочетени писма."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2726 pager.c:2784
+#: curs_main.c:2734 pager.c:2784
 #, fuzzy
 msgid "Cannot delete message"
 msgstr "Няма възстановени писма."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2838
+#: curs_main.c:2850
 #, fuzzy
 msgid "Cannot edit message"
 msgstr "Невъзможен запис на писмо"
 
 #. L10N: This is displayed when the x-label on one or more
 #. * messages is edited.
-#: curs_main.c:2900 pager.c:3200
+#: curs_main.c:2912 pager.c:3208
 #, fuzzy, c-format
 msgid "%d label changed."
 msgid_plural "%d labels changed."
@@ -1830,28 +1838,32 @@ msgstr[1] "Пощенската кутия е непроменена."
 #. L10N: This is displayed when editing an x-label, but no messages
 #. * were updated.  Possibly due to canceling at the prompt or if the new
 #. * label is the same as the old label.
-#: curs_main.c:2907 pager.c:3204
+#: curs_main.c:2919 pager.c:3212
 #, fuzzy
 msgid "No labels changed."
 msgstr "Пощенската кутия е непроменена."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:3006
+#. L10N: Due to the implementation details we do not know whether we
+#. mark zero, 1, 12, ... messages as read. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:3022
 #, fuzzy
-msgid "Cannot mark message(s) as read"
+msgid "Cannot mark messages as read"
 msgstr "скок към родителското писмо в нишката"
 
 #. L10N: This is the prompt for <mark-message>.  Whatever they
 #. enter will be prefixed by $mark_macro_prefix and will become
 #. a macro hotkey to jump to the currently selected message.
-#: curs_main.c:3042
+#: curs_main.c:3058
 #, fuzzy
 msgid "Enter macro stroke: "
 msgstr "Въведете ключов идентификатор: "
 
 #. L10N: "message hotkey" is the key bindings menu description of a
 #. macro created by <mark-message>.
-#: curs_main.c:3050
+#: curs_main.c:3066
 #, fuzzy
 msgid "message hotkey"
 msgstr "Писмото е записано като чернова."
@@ -1859,28 +1871,28 @@ msgstr "Писмото е записано като чернова."
 #. L10N: This is echoed after <mark-message> creates a new hotkey
 #. macro.  %s is the hotkey string ($mark_macro_prefix followed
 #. by whatever they typed at the prompt.)
-#: curs_main.c:3055
+#: curs_main.c:3071
 #, fuzzy, c-format
 msgid "Message bound to %s."
 msgstr "Писмото е препратено."
 
 #. L10N: This error is printed if <mark-message> cannot find a
 #. Message-ID for the currently selected message in the index.
-#: curs_main.c:3063
+#: curs_main.c:3079
 #, fuzzy
 msgid "No message ID to macro."
 msgstr "В тази кутия няма писма."
 
-#: curs_main.c:3105 pager.c:2961 recvattach.c:1388
+#: curs_main.c:3121 pager.c:2965 recvattach.c:1401
 msgid "Reply by mail as poster prefers?"
 msgstr ""
 
-#: curs_main.c:3108 pager.c:2927 pager.c:2939 pager.c:2964
+#: curs_main.c:3124 pager.c:2931 pager.c:2943 pager.c:2968
 msgid "Posting to this group not allowed, may be moderated. Continue?"
 msgstr ""
 
 #. L10N: CHECK_ACL
-#: curs_main.c:3173 pager.c:3120
+#: curs_main.c:3189 pager.c:3124
 #, fuzzy
 msgid "Cannot undelete message"
 msgstr "Няма възстановени писма."
@@ -2092,12 +2104,34 @@ msgstr "[-- Грешки от %s --]\n"
 msgid "[-- Error: message/external-body has no access-type parameter --]\n"
 msgstr "[-- Грешка: message/external-body няма параметри за метод на достъп --]\n"
 
-#: handler.c:1611
+#. L10N: If the translation of this string is a multi line string, then
+#. each line should start with "[-- " and end with " --]".
+#. The first "%s/%s" is a MIME type, e.g. "text/plain". The last %s
+#. expands to a date as returned by `mutt_date_parse_date()`.
+#.
+#. Note: The size argument printed is not the actual number as passed
+#. to gettext but the prettified version, e.g. size = 2048 will be
+#. printed as 2K.  Your language might be sensitive to that: For
+#. example although '1K' and '1024' represent the same number your
+#. language might inflect the noun 'byte' differently.
+#.
+#. Sadly, we cannot do anything about that at the moment besides
+#. passing the precise size in bytes. If you are interested the
+#. function responsible for the prettification is
+#. mutt_str_pretty_size() in mutt/string.c.
+#.
+#: handler.c:1624
 #, fuzzy, c-format
 msgid ""
+"[-- This %s/%s attachment (size %s byte) has been deleted --]\n"
+"[-- on %s --]\n"
+msgid_plural ""
 "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
 "[-- on %s --]\n"
-msgstr ""
+msgstr[0] ""
+"[-- Това %s/%s приложение (размер %s байта) бе изтрито --]\n"
+"[-- на %s --]\n"
+msgstr[1] ""
 "[-- Това %s/%s приложение (размер %s байта) бе изтрито --]\n"
 "[-- на %s --]\n"
 
@@ -2105,10 +2139,23 @@ msgstr ""
 #. each line should start with "[-- " and end with " --]".
 #. The first "%s/%s" is a MIME type, e.g. "text/plain".
 #.
-#: handler.c:1620
+#. Note: The size argument printed is not the actual number as passed
+#. to gettext but the prettified version, e.g. size = 2048 will be
+#. printed as 2K.  Your language might be sensitive to that: For
+#. example although '1K' and '1024' represent the same number your
+#. language might inflect the noun 'byte' differently.
+#.
+#. Sadly, we cannot do anything about that at the moment besides
+#. passing the precise size in bytes. If you are interested the
+#. function responsible for the prettification is
+#. mutt_str_pretty_size() in mutt/string.c.
+#.
+#: handler.c:1648
 #, fuzzy, c-format
-msgid "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
-msgstr "[-- Това %s/%s приложение (размер %s байта) бе изтрито --]\n"
+msgid "[-- This %s/%s attachment (size %s byte) has been deleted --]\n"
+msgid_plural "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
+msgstr[0] "[-- Това %s/%s приложение (размер %s байта) бе изтрито --]\n"
+msgstr[1] "[-- Това %s/%s приложение (размер %s байта) бе изтрито --]\n"
 
 #. L10N: If the translation of this string is a multi line string, then
 #. each line should start with "[-- " and end with " --]".
@@ -2118,7 +2165,7 @@ msgstr "[-- Това %s/%s приложение (размер %s байта) б�
 #. Caution: Argument three %3$ is also defined but should not be used
 #. in this translation!
 #.
-#: handler.c:1637
+#: handler.c:1667
 #, fuzzy
 msgid ""
 "[-- This %s/%s attachment has been deleted --]\n"
@@ -2131,17 +2178,17 @@ msgstr ""
 #. each line should start with "[-- " and end with " --]".
 #. The first "%s/%s" is a MIME type, e.g. "text/plain".
 #.
-#: handler.c:1646
+#: handler.c:1676
 #, fuzzy, c-format
 msgid "[-- This %s/%s attachment has been deleted --]\n"
 msgstr "[-- Това %s/%s приложение бе изтрито --]\n"
 
-#: handler.c:1656
+#: handler.c:1686
 #, c-format
 msgid "[-- name: %s --]\n"
 msgstr "[-- име: %s --]\n"
 
-#: handler.c:1672
+#: handler.c:1702
 #, fuzzy, c-format
 msgid ""
 "[-- This %s/%s attachment is not included, --]\n"
@@ -2151,7 +2198,7 @@ msgstr ""
 "[-- Това %s/%s приложение не е включено в писмото, --]\n"
 "[-- а файлът, определен за прикачване вече не съществува. --]\n"
 
-#: handler.c:1693
+#: handler.c:1723
 #, fuzzy, c-format
 msgid ""
 "[-- This %s/%s attachment is not included, --]\n"
@@ -2160,52 +2207,52 @@ msgstr ""
 "[-- Това %s/%s приложение не е включено в писмото, --]\n"
 "[-- а указаният метод на достъп %s не се подържа. --]\n"
 
-#: handler.c:1822
+#: handler.c:1852
 #, fuzzy
 msgid "Unable to open memory stream!"
 msgstr "Грешка при отваряне на временния файл!"
 
-#: handler.c:1831
+#: handler.c:1861
 msgid "Unable to open temporary file!"
 msgstr "Грешка при отваряне на временния файл!"
 
-#: handler.c:1881
+#: handler.c:1911
 #, fuzzy
 msgid "failed to re-open memstream!"
 msgstr "Грешка при отваряне на временния файл!"
 
-#: handler.c:2013
+#: handler.c:2043
 msgid "Error: multipart/signed has no protocol."
 msgstr "Грешка: multipart/signed без protocol параметър."
 
-#: handler.c:2076
+#: handler.c:2106
 #, fuzzy
 msgid "[-- This is an attachment (use '%3$s' to view this part) --]\n"
 msgstr "[-- Това %s/%s приложение  (използвайте'%3$s' за да видите тази част) --]\n"
 
-#: handler.c:2082
+#: handler.c:2112
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported (use '%s' to view this part) --]\n"
 msgstr "[-- %s/%s не се поддържа (използвайте'%s' за да видите тази част) --]\n"
 
-#: handler.c:2087
+#: handler.c:2117
 #, fuzzy
 msgid "[-- This is an attachment (need 'view-attachments' bound to key!) --]\n"
 msgstr "[-- Това %s/%s приложение ('view-attachments' няма клавишна комбинация!) --]\n"
 
 #. L10N: %s/%s is a MIME type, e.g. "text/plain".
-#: handler.c:2091
+#: handler.c:2121
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported (need 'view-attachments' bound to key!) --]\n"
 msgstr "[-- %s/%s не се поддържа('view-attachments' няма клавишна комбинация!) --]\n"
 
-#: handler.c:2098
+#: handler.c:2128
 #, fuzzy
 msgid "[-- This is an attachment --]\n"
 msgstr "[-- Това %s/%s приложение --]\n"
 
 #. L10N: %s/%s is a MIME type, e.g. "text/plain".
-#: handler.c:2101
+#: handler.c:2131
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported --]\n"
 msgstr "[-- %s/%s не се поддържа --]\n"
@@ -2513,7 +2560,7 @@ msgstr ""
 msgid "Invalid IMAP flags"
 msgstr "Невалиден   "
 
-#: imap/message.c:477 mx.c:1326
+#: imap/message.c:477 mx.c:1336
 #, fuzzy
 msgid "Integer overflow -- can't allocate memory."
 msgstr "Integer overflow -- заделянето на памет е невъзможно."
@@ -3288,66 +3335,75 @@ msgstr "SSL не е на разположение."
 msgid "Reading from %s interrupted..."
 msgstr "Търсенето е прекъснато."
 
-#: mx.c:634
+#. L10N: Although we now the precise number of messages, we do not show it to the user.
+#. So feel free to use a "generic plural" as plural translation if your language has one.
+#.
+#: mx.c:639
 #, fuzzy
-msgid "message(s) not deleted"
-msgstr "Маркиране на %d съобщения за изтриване..."
+msgid "message not deleted"
+msgid_plural "messages not deleted"
+msgstr[0] "Маркиране на %d съобщения за изтриване..."
+msgstr[1] "Маркиране на %d съобщения за изтриване..."
 
-#: mx.c:671
+#: mx.c:676
 #, fuzzy
 msgid "Can't open trash folder"
 msgstr "Грешка при добавянето на писмо към пощенската кутия: %s"
 
-#: mx.c:710
+#: mx.c:715
 msgid "Mark all articles read?"
 msgstr ""
 
-#: mx.c:754
+#. L10N: The first argument is the number of read messages to be
+#. moved, the second argument is the target mailbox.
+#: mx.c:762
 #, fuzzy, c-format
-msgid "Move %d read messages to %s?"
-msgstr "Желаете ли да преместите прочетените писма в %s?"
+msgid "Move %d read message to %s?"
+msgid_plural "Move %d read messages to %s?"
+msgstr[0] "Желаете ли да преместите прочетените писма в %s?"
+msgstr[1] "Желаете ли да преместите прочетените писма в %s?"
 
-#: mx.c:771 mx.c:1077
+#: mx.c:781 mx.c:1087
 #, fuzzy, c-format
 msgid "Purge %d deleted message?"
 msgid_plural "Purge %d deleted messages?"
 msgstr[0] "Желаете ли да изтриете %d-то отбелязано за изтриване писмо?"
 msgstr[1] "Желаете ли да изтриете  %d отбелязани за изтриване писма?"
 
-#: mx.c:793
+#: mx.c:803
 #, c-format
 msgid "Moving read messages to %s..."
 msgstr "Преместване на прочетените писма в %s..."
 
-#: mx.c:859 mx.c:1068
+#: mx.c:869 mx.c:1078
 msgid "Mailbox is unchanged."
 msgstr "Пощенската кутия е непроменена."
 
-#: mx.c:914
+#: mx.c:924
 #, c-format
 msgid "%d kept, %d moved, %d deleted."
 msgstr "запазени: %d; преместени: %d; изтрити: %d"
 
-#: mx.c:917 mx.c:1130
+#: mx.c:927 mx.c:1140
 #, c-format
 msgid "%d kept, %d deleted."
 msgstr "запазени: %d; изтрити: %d"
 
-#: mx.c:1052
+#: mx.c:1062
 #, c-format
 msgid " Press '%s' to toggle write"
 msgstr "Натиснете '%s' за включване/изключване на режима за запис"
 
-#: mx.c:1054
+#: mx.c:1064
 msgid "Use 'toggle-write' to re-enable write!"
 msgstr "Използвайте 'toggle-write' за реактивиране на режима за запис!"
 
-#: mx.c:1056
+#: mx.c:1066
 #, c-format
 msgid "Mailbox is marked unwritable. %s"
 msgstr "Пощенската кутия е само за четене. %s"
 
-#: mx.c:1124
+#: mx.c:1134
 msgid "Mailbox checkpointed."
 msgstr "Пощенската кутия е отбелязана."
 
@@ -3361,52 +3417,57 @@ msgstr " (текущо време: %c)"
 msgid "[-- %s output follows%s --]\n"
 msgstr "[-- %s следва резултатът%s) --]\n"
 
-#: ncrypt/crypt.c:95
-msgid "Passphrase(s) forgotten."
+#. L10N: Due to the implementation details (e.g. some passwords are managed
+#. by gpg-agent) we cannot know whether we forgot zero, 1, 12, ...
+#. passwords. So in English we use "Passphrases". Your language might
+#. have other means to express this.
+#: ncrypt/crypt.c:100
+#, fuzzy
+msgid "Passphrases forgotten."
 msgstr "Паролите са забравени."
 
-#: ncrypt/crypt.c:155
+#: ncrypt/crypt.c:161
 msgid "Inline PGP can't be used with attachments.  Revert to PGP/MIME?"
 msgstr ""
 
-#: ncrypt/crypt.c:159
+#: ncrypt/crypt.c:165
 msgid "Mail not sent: inline PGP can't be used with attachments."
 msgstr ""
 
-#: ncrypt/crypt.c:166
+#: ncrypt/crypt.c:172
 msgid "Inline PGP can't be used with format=flowed.  Revert to PGP/MIME?"
 msgstr ""
 
-#: ncrypt/crypt.c:170
+#: ncrypt/crypt.c:176
 msgid "Mail not sent: inline PGP can't be used with format=flowed."
 msgstr ""
 
-#: ncrypt/crypt.c:180 ncrypt/cryptglue.c:125 ncrypt/pgpkey.c:589
+#: ncrypt/crypt.c:186 ncrypt/cryptglue.c:125 ncrypt/pgpkey.c:589
 #: ncrypt/pgpkey.c:782
 msgid "Invoking PGP..."
 msgstr "Стартиране на PGP..."
 
-#: ncrypt/crypt.c:192
+#: ncrypt/crypt.c:198
 msgid "Message can't be sent inline.  Revert to using PGP/MIME?"
 msgstr ""
 
-#: ncrypt/crypt.c:194 send.c:1824
+#: ncrypt/crypt.c:200 send.c:1824
 msgid "Mail not sent."
 msgstr "Писмото не е изпратено."
 
-#: ncrypt/crypt.c:540
+#: ncrypt/crypt.c:546
 msgid "S/MIME messages with no hints on content are unsupported."
 msgstr "S/MIME писма без указание за съдържанието им не се поддържат."
 
-#: ncrypt/crypt.c:754 ncrypt/crypt.c:795
+#: ncrypt/crypt.c:760 ncrypt/crypt.c:801
 msgid "Trying to extract PGP keys...\n"
 msgstr "Опит за извличане на PGP ключове...\n"
 
-#: ncrypt/crypt.c:776 ncrypt/crypt.c:816
+#: ncrypt/crypt.c:782 ncrypt/crypt.c:822
 msgid "Trying to extract S/MIME certificates...\n"
 msgstr "Опит за извличане на S/MIME сертификати...\n"
 
-#: ncrypt/crypt.c:976
+#: ncrypt/crypt.c:982
 #, c-format
 msgid ""
 "[-- Error: Unknown multipart/signed protocol %s! --]\n"
@@ -3415,7 +3476,7 @@ msgstr ""
 "[-- Грешка: Непознат multipart/signed протокол %s! --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1016
+#: ncrypt/crypt.c:1022
 #, fuzzy
 msgid ""
 "[-- Error: Missing or bad-format multipart/signed signature! --]\n"
@@ -3424,7 +3485,7 @@ msgstr ""
 "[-- Грешка: Противоречива multipart/signed структура! --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1058
+#: ncrypt/crypt.c:1064
 #, c-format
 msgid ""
 "[-- Warning: We can't verify %s/%s signatures. --]\n"
@@ -3433,7 +3494,7 @@ msgstr ""
 "[-- Предупреждение: %s/%s-подписи не могат да бъдат проверявани. --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1070
+#: ncrypt/crypt.c:1076
 msgid ""
 "[-- The following data is signed --]\n"
 "\n"
@@ -3441,7 +3502,7 @@ msgstr ""
 "[-- Следните данни са подписани --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1075
+#: ncrypt/crypt.c:1081
 msgid ""
 "[-- Warning: Can't find any signatures. --]\n"
 "\n"
@@ -3449,7 +3510,7 @@ msgstr ""
 "[-- Предупреждение: не могат да бъдат намерени подписи. --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1081
+#: ncrypt/crypt.c:1087
 msgid ""
 "\n"
 "[-- End of signed data --]\n"
@@ -3501,7 +3562,7 @@ msgstr ""
 msgid "error reading data object: %s\n"
 msgstr "грешка в шаблона при: %s"
 
-#: ncrypt/crypt_gpgme.c:662 ncrypt/crypt_gpgme.c:3848 ncrypt/pgpkey.c:585
+#: ncrypt/crypt_gpgme.c:662 ncrypt/crypt_gpgme.c:3850 ncrypt/pgpkey.c:585
 #: ncrypt/pgpkey.c:768
 msgid "Can't create temporary file"
 msgstr "Грешка при създаване на временен файл"
@@ -3865,29 +3926,31 @@ msgstr "Невалиден   "
 
 #. L10N: This is printed after "Key Type: " and looks like this:
 #. *       PGP, 2048 bit RSA
-#: ncrypt/crypt_gpgme.c:3670 ncrypt/crypt_gpgme.c:3808
+#: ncrypt/crypt_gpgme.c:3670 ncrypt/crypt_gpgme.c:3810
 #, c-format
 msgid "%s, %lu bit %s\n"
-msgstr ""
+msgid_plural "%s, %lu bit %s\n"
+msgstr[0] ""
+msgstr[1] ""
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3678 ncrypt/crypt_gpgme.c:3815
+#: ncrypt/crypt_gpgme.c:3678 ncrypt/crypt_gpgme.c:3817
 #, fuzzy
 msgid "encryption"
 msgstr "Шифроване"
 
 #: ncrypt/crypt_gpgme.c:3679 ncrypt/crypt_gpgme.c:3685
-#: ncrypt/crypt_gpgme.c:3816 ncrypt/crypt_gpgme.c:3821
+#: ncrypt/crypt_gpgme.c:3818 ncrypt/crypt_gpgme.c:3823
 msgid ", "
 msgstr ""
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3684 ncrypt/crypt_gpgme.c:3820
+#: ncrypt/crypt_gpgme.c:3684 ncrypt/crypt_gpgme.c:3822
 msgid "signing"
 msgstr ""
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3690 ncrypt/crypt_gpgme.c:3825
+#: ncrypt/crypt_gpgme.c:3690 ncrypt/crypt_gpgme.c:3827
 #, fuzzy
 msgid "certification"
 msgstr "Сертификатът е записан"
@@ -3909,70 +3972,70 @@ msgstr "Изтекъл   "
 msgid "[Disabled]"
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:3851
+#: ncrypt/crypt_gpgme.c:3853
 #, fuzzy
 msgid "Collecting data..."
 msgstr "Свързване с %s..."
 
-#: ncrypt/crypt_gpgme.c:3876
+#: ncrypt/crypt_gpgme.c:3878
 #, fuzzy, c-format
 msgid "Error finding issuer key: %s\n"
 msgstr "Грешка при свързване със сървъра: %s"
 
-#: ncrypt/crypt_gpgme.c:3885
+#: ncrypt/crypt_gpgme.c:3887
 #, fuzzy
 msgid "Error: certification chain too long - stopping here\n"
 msgstr "Грешка в командния ред: %s\n"
 
-#: ncrypt/crypt_gpgme.c:3895 ncrypt/pgpkey.c:608
+#: ncrypt/crypt_gpgme.c:3897 ncrypt/pgpkey.c:608
 #, c-format
 msgid "Key ID: 0x%s"
 msgstr "Ключов идентификатор: 0x%s"
 
-#: ncrypt/crypt_gpgme.c:3990
+#: ncrypt/crypt_gpgme.c:3992
 #, fuzzy, c-format
 msgid "gpgme_new failed: %s"
 msgstr "Неуспешен SSL: %s"
 
-#: ncrypt/crypt_gpgme.c:4028 ncrypt/crypt_gpgme.c:4079
+#: ncrypt/crypt_gpgme.c:4030 ncrypt/crypt_gpgme.c:4081
 #, c-format
 msgid "gpgme_op_keylist_start failed: %s"
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4067 ncrypt/crypt_gpgme.c:4109
+#: ncrypt/crypt_gpgme.c:4069 ncrypt/crypt_gpgme.c:4111
 #, c-format
 msgid "gpgme_op_keylist_next failed: %s"
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4185
+#: ncrypt/crypt_gpgme.c:4187
 #, fuzzy
 msgid "All matching keys are marked expired/revoked."
 msgstr "Всички подходящи ключове са остарели, анулирани или деактивирани."
 
-#: ncrypt/crypt_gpgme.c:4215 ncrypt/pgpkey.c:543 ncrypt/smime.c:475
+#: ncrypt/crypt_gpgme.c:4217 ncrypt/pgpkey.c:543 ncrypt/smime.c:475
 msgid "Select  "
 msgstr "Избор "
 
-#: ncrypt/crypt_gpgme.c:4217 ncrypt/pgpkey.c:545
+#: ncrypt/crypt_gpgme.c:4219 ncrypt/pgpkey.c:545
 msgid "Check key  "
 msgstr "Проверка на ключ  "
 
-#: ncrypt/crypt_gpgme.c:4233
+#: ncrypt/crypt_gpgme.c:4235
 #, fuzzy
 msgid "PGP and S/MIME keys matching"
 msgstr "PGP ключове, съвпадащи с \"%s\"."
 
-#: ncrypt/crypt_gpgme.c:4235
+#: ncrypt/crypt_gpgme.c:4237
 #, fuzzy
 msgid "PGP keys matching"
 msgstr "PGP ключове, съвпадащи с \"%s\"."
 
-#: ncrypt/crypt_gpgme.c:4237
+#: ncrypt/crypt_gpgme.c:4239
 #, fuzzy
 msgid "S/MIME keys matching"
 msgstr "S/MIME сертификати, съвпадащи с \"%s\"."
 
-#: ncrypt/crypt_gpgme.c:4239
+#: ncrypt/crypt_gpgme.c:4241
 #, fuzzy
 msgid "keys matching"
 msgstr "PGP ключове, съвпадащи с \"%s\"."
@@ -3981,69 +4044,69 @@ msgstr "PGP ключове, съвпадащи с \"%s\"."
 #. %1$s is one of the previous four entries.
 #. %2$s is an address.
 #. e.g. "S/MIME keys matching <me@mutt.org>."
-#: ncrypt/crypt_gpgme.c:4246
+#: ncrypt/crypt_gpgme.c:4248
 #, c-format
 msgid "%s <%s>."
 msgstr ""
 
 #. L10N:
 #. e.g. 'S/MIME keys matching "Michael Elkins".'
-#: ncrypt/crypt_gpgme.c:4250
+#: ncrypt/crypt_gpgme.c:4252
 #, c-format
 msgid "%s \"%s\"."
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4277 ncrypt/pgpkey.c:628
+#: ncrypt/crypt_gpgme.c:4279 ncrypt/pgpkey.c:628
 msgid "This key can't be used: expired/disabled/revoked."
 msgstr "Този ключ не може да бъде използван, защото е остарял, деактивиран или анулиран."
 
-#: ncrypt/crypt_gpgme.c:4290 ncrypt/pgpkey.c:640 ncrypt/smime.c:505
+#: ncrypt/crypt_gpgme.c:4292 ncrypt/pgpkey.c:640 ncrypt/smime.c:505
 #, fuzzy
 msgid "ID is expired/disabled/revoked. Do you really want to use the key?"
 msgstr "Този идентификатор е остарял, деактивиран или анулиран. Действително ли искате да използвате този ключ?"
 
-#: ncrypt/crypt_gpgme.c:4299 ncrypt/pgpkey.c:650
+#: ncrypt/crypt_gpgme.c:4301 ncrypt/pgpkey.c:650
 #, fuzzy
 msgid "ID is not valid. Do you really want to use the key?"
 msgstr "Този идентификатор не не е валиден. Действително ли искате да използвате този ключ?"
 
-#: ncrypt/crypt_gpgme.c:4302 ncrypt/pgpkey.c:653
+#: ncrypt/crypt_gpgme.c:4304 ncrypt/pgpkey.c:653
 #, fuzzy
 msgid "ID is only marginally valid. Do you really want to use the key?"
 msgstr "Този идентификатор е с ограничена валидност. Действително ли искате да използвате този ключ?"
 
-#: ncrypt/crypt_gpgme.c:4310 ncrypt/pgpkey.c:646 ncrypt/smime.c:509
+#: ncrypt/crypt_gpgme.c:4312 ncrypt/pgpkey.c:646 ncrypt/smime.c:509
 #, fuzzy
 msgid "ID has undefined validity. Do you really want to use the key?"
 msgstr "Този идентификатор е с недефинирана валидност. Действително ли искате да използвате този ключ?"
 
-#: ncrypt/crypt_gpgme.c:4370 ncrypt/crypt_gpgme.c:4479 ncrypt/pgpkey.c:872
+#: ncrypt/crypt_gpgme.c:4372 ncrypt/crypt_gpgme.c:4481 ncrypt/pgpkey.c:872
 #: ncrypt/pgpkey.c:995
 #, c-format
 msgid "Looking for keys matching \"%s\"..."
 msgstr "Търсене на ключове, отговарящи на \"%s\"..."
 
-#: ncrypt/crypt_gpgme.c:4593 ncrypt/pgpkey.c:731 ncrypt/smime.c:811
+#: ncrypt/crypt_gpgme.c:4595 ncrypt/pgpkey.c:731 ncrypt/smime.c:811
 #, c-format
 msgid "No matching keys found for \"%s\""
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4644 ncrypt/pgp.c:1263
+#: ncrypt/crypt_gpgme.c:4646 ncrypt/pgp.c:1263
 #, c-format
 msgid "Use keyID = \"%s\" for %s?"
 msgstr "Желаете ли използвате ключовия идентификатор \"%s\" за %s?"
 
-#: ncrypt/crypt_gpgme.c:4695 ncrypt/pgp.c:1312 ncrypt/smime.c:830
+#: ncrypt/crypt_gpgme.c:4697 ncrypt/pgp.c:1312 ncrypt/smime.c:830
 #: ncrypt/smime.c:938
 #, c-format
 msgid "Enter keyID for %s: "
 msgstr "Въведете ключов идентификатор за %s: "
 
-#: ncrypt/crypt_gpgme.c:4755 ncrypt/pgpkey.c:751
+#: ncrypt/crypt_gpgme.c:4757 ncrypt/pgpkey.c:751
 msgid "Please enter the key ID: "
 msgstr "Моля, въведете ключовия идентификатор: "
 
-#: ncrypt/crypt_gpgme.c:4768
+#: ncrypt/crypt_gpgme.c:4770
 #, fuzzy, c-format
 msgid "Error exporting key: %s\n"
 msgstr "грешка в шаблона при: %s"
@@ -4052,84 +4115,84 @@ msgstr "грешка в шаблона при: %s"
 #. MIME description for exported (attached) keys.
 #. You can translate this entry to a non-ASCII string (it will be encoded),
 #. but it may be safer to keep it untranslated.
-#: ncrypt/crypt_gpgme.c:4787
+#: ncrypt/crypt_gpgme.c:4789
 #, fuzzy, c-format
 msgid "PGP Key 0x%s."
 msgstr "PGP ключ %s."
 
-#: ncrypt/crypt_gpgme.c:4830
+#: ncrypt/crypt_gpgme.c:4832
 msgid "GPGME: OpenPGP protocol not available"
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4838
+#: ncrypt/crypt_gpgme.c:4840
 msgid "GPGME: CMS protocol not available"
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4876
+#: ncrypt/crypt_gpgme.c:4878
 msgid "S/MIME (s)ign, sign (a)s, (p)gp, (c)lear, or (o)ppenc mode off? "
 msgstr "PGP шифроване(e), подпис(s), подпис като(a), и двете(b) или без тях(f)?"
 
 #. L10N: S/MIME options (opportunistic encryption is on)
-#: ncrypt/crypt_gpgme.c:4878
+#: ncrypt/crypt_gpgme.c:4880
 msgid "sapco"
 msgstr "esabf"
 
-#: ncrypt/crypt_gpgme.c:4885
+#: ncrypt/crypt_gpgme.c:4887
 msgid "PGP (s)ign, sign (a)s, s/(m)ime, (c)lear, or (o)ppenc mode off? "
 msgstr "PGP шифроване(e), подпис(s), подпис като(a), и двете(b) или без тях(f)?"
 
 #. L10N: PGP options (opportunistic encryption is on)
-#: ncrypt/crypt_gpgme.c:4887
+#: ncrypt/crypt_gpgme.c:4889
 msgid "samco"
 msgstr "esabf"
 
 #. L10N: S/MIME options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4900
+#: ncrypt/crypt_gpgme.c:4902
 #, fuzzy
 msgid "S/MIME (e)ncrypt, (s)ign, sign (a)s, (b)oth, (p)gp, (c)lear, or (o)ppenc mode? "
 msgstr "PGP шифроване(e), подпис(s), подпис като(a), и двете(b) или без тях(f)?"
 
 #. L10N: S/MIME options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4903
+#: ncrypt/crypt_gpgme.c:4905
 msgid "esabpco"
 msgstr "esabf"
 
 #. L10N: PGP options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4909
+#: ncrypt/crypt_gpgme.c:4911
 #, fuzzy
 msgid "PGP (e)ncrypt, (s)ign, sign (a)s, (b)oth, s/(m)ime, (c)lear, or (o)ppenc mode? "
 msgstr "PGP шифроване(e), подпис(s), подпис като(a), и двете(b) или без тях(f)?"
 
 #. L10N: PGP options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4912
+#: ncrypt/crypt_gpgme.c:4914
 msgid "esabmco"
 msgstr "esabf"
 
-#: ncrypt/crypt_gpgme.c:4925
+#: ncrypt/crypt_gpgme.c:4927
 #, fuzzy
 msgid "S/MIME (e)ncrypt, (s)ign, sign (a)s, (b)oth, (p)gp or (c)lear? "
 msgstr "PGP шифроване(e), подпис(s), подпис като(a), и двете(b) или без тях(f)?"
 
 #. L10N: S/MIME options
-#: ncrypt/crypt_gpgme.c:4927
+#: ncrypt/crypt_gpgme.c:4929
 msgid "esabpc"
 msgstr "esabf"
 
-#: ncrypt/crypt_gpgme.c:4934
+#: ncrypt/crypt_gpgme.c:4936
 #, fuzzy
 msgid "PGP (e)ncrypt, (s)ign, sign (a)s, (b)oth, s/(m)ime or (c)lear? "
 msgstr "PGP шифроване(e), подпис(s), подпис като(a), и двете(b) или без тях(f)?"
 
 #. L10N: PGP options
-#: ncrypt/crypt_gpgme.c:4936
+#: ncrypt/crypt_gpgme.c:4938
 msgid "esabmc"
 msgstr "esabf"
 
-#: ncrypt/crypt_gpgme.c:5087
+#: ncrypt/crypt_gpgme.c:5089
 msgid "Failed to verify sender"
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:5090
+#: ncrypt/crypt_gpgme.c:5092
 #, fuzzy
 msgid "Failed to figure out sender"
 msgstr "Грешка при отваряне на файла за прочит на заглавната информация."
@@ -4529,7 +4592,7 @@ msgstr ""
 msgid "%s is an invalid news server specification!"
 msgstr "%s не е валидна POP пътека"
 
-#: nntp.c:75 nntp.c:612 pop.c:1028 pop_lib.c:405
+#: nntp.c:75 nntp.c:612 pop.c:1031 pop_lib.c:405
 msgid "Server closed connection!"
 msgstr "Сървърът затвори връзката!"
 
@@ -4696,16 +4759,17 @@ msgstr "проверява пощенските кутии за нови пис�
 
 #: opcodes.h:47
 #, fuzzy
-msgid "attach file(s) to this message"
+msgid "attach files to this message"
 msgstr "прилага файл(ове) към писмото"
 
 #: opcodes.h:48
-msgid "attach message(s) to this message"
+#, fuzzy
+msgid "attach messages to this message"
 msgstr "прилага писмо към това писмо"
 
 #: opcodes.h:49
 #, fuzzy
-msgid "attach news article(s) to this message"
+msgid "attach news articles to this message"
 msgstr "прилага файл(ове) към писмото"
 
 #: opcodes.h:50
@@ -5553,7 +5617,8 @@ msgid "extract supported public keys"
 msgstr "извлича поддържаните публични ключове"
 
 #: opcodes.h:255
-msgid "wipe passphrase(s) from memory"
+#, fuzzy
+msgid "wipe passphrases from memory"
 msgstr "отстранява паролите от паметта"
 
 #: opcodes.h:259
@@ -5905,18 +5970,20 @@ msgstr "Няма нови писма в тази POP пощенска кутия
 msgid "Delete messages from server?"
 msgstr "Желаете ли да изтриете писмата на сървъра?"
 
-#: pop.c:954
-#, c-format
-msgid "Reading new messages (%d bytes)..."
-msgstr "Зареждане на новите писма (%d байта)..."
+#: pop.c:955
+#, fuzzy, c-format
+msgid "Reading new messages (%d byte)..."
+msgid_plural "Reading new messages (%d bytes)..."
+msgstr[0] "Зареждане на новите писма (%d байта)..."
+msgstr[1] "Зареждане на новите писма (%d байта)..."
 
-#: pop.c:997
+#: pop.c:1000
 msgid "Error while writing mailbox!"
 msgstr "Грешка при записване на пощенската кутия!"
 
 #. L10N: The plural is picked by the second numerical argument, i.e.
 #. * the %d right before 'messages', i.e. the total number of messages.
-#: pop.c:1003
+#: pop.c:1006
 #, fuzzy, c-format
 msgid "%s [%d of %d message read]"
 msgid_plural "%s [%d of %d messages read]"
@@ -6062,50 +6129,57 @@ msgstr "Предаване на (pipe): "
 msgid "I don't know how to print %s attachments!"
 msgstr "Не е дефинирана команда за отпечатване на %s приложения!"
 
-#: recvattach.c:841
-msgid "Print tagged attachment(s)?"
-msgstr "Желаете ли да отпечатате маркираните приложения?"
+#. L10N: Although we now the precise number of tagged messages, we
+#. do not show it to the user.  So feel free to use a "generic
+#. plural" as plural translation if your language has one.
+#: recvattach.c:852
+#, fuzzy, c-format
+msgid "Print tagged attachment?"
+msgid_plural "Print %d tagged attachments?"
+msgstr[0] "Желаете ли да отпечатате маркираните приложения?"
+msgstr[1] "Желаете ли да отпечатате маркираните приложения?"
 
-#: recvattach.c:842
+#: recvattach.c:853
+#, c-format
 msgid "Print attachment?"
 msgstr "Желаете ли да отпечатате приложението?"
 
-#: recvattach.c:900
+#: recvattach.c:913
 msgid "Structural changes to decrypted attachments are not supported"
 msgstr ""
 
-#: recvattach.c:1046
+#: recvattach.c:1059
 msgid "Can't decrypt encrypted message!"
 msgstr "Грешка при дешифрирането на шифровано писмо!"
 
-#: recvattach.c:1172
+#: recvattach.c:1185
 msgid "Attachments"
 msgstr "Приложения"
 
-#: recvattach.c:1210
+#: recvattach.c:1223
 #, fuzzy
 msgid "There are no subparts to show!"
 msgstr "Няма подчасти, които да бъдат показани!."
 
-#: recvattach.c:1265
+#: recvattach.c:1278
 msgid "Can't delete attachment from POP server."
 msgstr "Грешка при изтриването на приложение от POP сървъра."
 
-#: recvattach.c:1274
+#: recvattach.c:1287
 #, fuzzy
 msgid "Can't delete attachment from news server."
 msgstr "Грешка при изтриването на приложение от POP сървъра."
 
-#: recvattach.c:1281
+#: recvattach.c:1294
 msgid "Deletion of attachments from encrypted messages is unsupported."
 msgstr "Изтриването на приложения от шифровани писма не се поддържа."
 
-#: recvattach.c:1287
+#: recvattach.c:1300
 #, fuzzy
 msgid "Deletion of attachments from signed messages may invalidate the signature."
 msgstr "Изтриването на приложения от шифровани писма не се поддържа."
 
-#: recvattach.c:1305 recvattach.c:1320
+#: recvattach.c:1318 recvattach.c:1333
 msgid "Only deletion of multipart attachments is supported."
 msgstr "Поддържа се само изтриване на приложения от съставни писма."
 
@@ -6525,3 +6599,15 @@ msgstr "Опции при компилация:"
 #: version.c:404
 msgid "Compile options:"
 msgstr "Опции при компилация:"
+
+#, fuzzy
+#~ msgid "Cannot delete message(s)"
+#~ msgstr "Няма възстановени писма."
+
+#, fuzzy
+#~ msgid "Cannot undelete message(s)"
+#~ msgstr "Няма възстановени писма."
+
+#, fuzzy
+#~ msgid "messages not deleted"
+#~ msgstr "Маркиране на %d съобщения за изтриване..."

--- a/po/ca.po
+++ b/po/ca.po
@@ -54,7 +54,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neomutt-20180512\n"
 "Report-Msgid-Bugs-To: neomutt-devel@neomutt.org\n"
-"POT-Creation-Date: 2018-05-20 02:02+0000\n"
+"POT-Creation-Date: 2018-05-22 14:18+0000\n"
 "PO-Revision-Date: 2017-02-18 01:24+0100\n"
 "Last-Translator: Ivan Vilata i Balaguer <ivan@selidor.net>\n"
 "Language-Team: Catalan <ca@dodds.net>\n"
@@ -84,7 +84,7 @@ msgstr "Selecciona"
 
 #: addrbook.c:52 browser.c:75 browser.c:87 compose.c:160 compose.c:172
 #: conn/ssl.c:1041 conn/ssl_gnutls.c:793 curs_main.c:748 curs_main.c:761
-#: history.c:106 ncrypt/crypt_gpgme.c:4219 ncrypt/pgpkey.c:547
+#: history.c:106 ncrypt/crypt_gpgme.c:4221 ncrypt/pgpkey.c:547
 #: ncrypt/smime.c:477 pager.c:2141 postpone.c:65 query.c:72 recvattach.c:70
 msgid "Help"
 msgstr "Ajuda"
@@ -751,7 +751,7 @@ msgstr "Seguretat: "
 #. * Since it shares the row with "Encrypt with:", it should not be longer
 #. * than 15-20 character cells.
 #.
-#: compose.c:138 ncrypt/crypt_gpgme.c:4947 ncrypt/pgp.c:1786
+#: compose.c:138 ncrypt/crypt_gpgme.c:4949 ncrypt/pgp.c:1786
 #: ncrypt/smime.c:2127
 msgid "Sign as: "
 msgstr "Signa com a: "
@@ -1311,7 +1311,7 @@ msgstr "(r)ebutja, accepta (u)na sola volta, sal(t)a"
 msgid "(r)eject, accept (o)nce"
 msgstr "(r)ebutja, accepta (u)na sola volta"
 
-#: conn/ssl.c:1039 conn/ssl_gnutls.c:791 ncrypt/crypt_gpgme.c:4213
+#: conn/ssl.c:1039 conn/ssl_gnutls.c:791 ncrypt/crypt_gpgme.c:4215
 #: ncrypt/pgpkey.c:541 ncrypt/smime.c:473
 msgid "Exit  "
 msgstr "Ix  "
@@ -1494,11 +1494,11 @@ msgstr "No hi ha cap bústia oberta."
 msgid "There are no messages."
 msgstr "No hi ha cap missatge."
 
-#: curs_main.c:77 mx.c:1061 pager.c:73 recvattach.c:56
+#: curs_main.c:77 mx.c:1071 pager.c:73 recvattach.c:56
 msgid "Mailbox is read-only."
 msgstr "La bústia és de només lectura."
 
-#: curs_main.c:79 pager.c:75 recvattach.c:1145
+#: curs_main.c:79 pager.c:75 recvattach.c:1158
 msgid "Function not permitted in attach-message mode."
 msgstr "No es permet aquesta funció al mode d’adjuntar missatges."
 
@@ -1637,256 +1637,266 @@ msgstr "El missatge no és visible."
 
 # Al darrere porta dos punts.  ivb
 #. L10N: CHECK_ACL
-#: curs_main.c:1377 curs_main.c:2772 pager.c:2818
-msgid "Cannot delete message(s)"
+#. L10N: Due to the implementation details we do not know whether we
+#. delete zero, 1, 12, ... messages. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:1381 curs_main.c:2784 pager.c:2822
+#, fuzzy
+msgid "Cannot delete messages"
 msgstr "No es poden esborrar els missatges"
 
-#: curs_main.c:1380
+#: curs_main.c:1384
 msgid "Delete messages matching: "
 msgstr "Esborra els missatges que concorden amb: "
 
-#: curs_main.c:1421
+#: curs_main.c:1425
 msgid "No limit pattern is in effect."
 msgstr "No hi ha cap patró limitant en efecte."
 
 # ivb (2001/12/08)
 # ivb  Nooop!  Només mostra el límit actual.
 #. L10N: ask for a limit to apply
-#: curs_main.c:1426
+#: curs_main.c:1430
 #, c-format
 msgid "Limit: %s"
 msgstr "Límit: %s"
 
-#: curs_main.c:1464
+#: curs_main.c:1468
 msgid "Limit to messages matching: "
 msgstr "Limita als missatges que concorden amb: "
 
-#: curs_main.c:1488
+#: curs_main.c:1492
 msgid "To view all messages, limit to \"all\"."
 msgstr "Per a veure tots els missatges, limiteu a «all»."
 
-#: curs_main.c:1500 pager.c:2318
+#: curs_main.c:1504 pager.c:2318
 msgid "Quit NeoMutt?"
 msgstr "Voleu abandonar NeoMutt?"
 
-#: curs_main.c:1596
+#: curs_main.c:1600
 msgid "Tag messages matching: "
 msgstr "Marca els missatges que concorden amb: "
 
 # Al darrere porta dos punts.  ivb
 #. L10N: CHECK_ACL
-#: curs_main.c:1606 curs_main.c:3203 pager.c:3137
-msgid "Cannot undelete message(s)"
+#. L10N: Due to the implementation details we do not know whether we
+#. undelete zero, 1, 12, ... messages. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:1614 curs_main.c:3223 pager.c:3145
+#, fuzzy
+msgid "Cannot undelete messages"
 msgstr "No es poden restaurar els missatges"
 
-#: curs_main.c:1609
+#: curs_main.c:1617
 msgid "Undelete messages matching: "
 msgstr "Restaura els missatges que concorden amb: "
 
-#: curs_main.c:1619
+#: curs_main.c:1627
 msgid "Untag messages matching: "
 msgstr "Desmarca els missatges que concorden amb: "
 
-#: curs_main.c:1653
+#: curs_main.c:1661
 msgid "Logged out of IMAP servers."
 msgstr "S’ha eixit dels servidors IMAP."
 
-#: curs_main.c:1753
+#: curs_main.c:1761
 #, fuzzy
 msgid "No virtual folder, aborting."
 msgstr "S’avorta el missatge sense assumpte."
 
-#: curs_main.c:1761
+#: curs_main.c:1769
 msgid "Failed to read thread, aborting."
 msgstr ""
 
-#: curs_main.c:1793 mx.c:1458 mx.c:1475
+#: curs_main.c:1801 mx.c:1468 mx.c:1485
 #, fuzzy
 msgid "Folder doesn't support tagging, aborting."
 msgstr "El servidor SMTP no admet autenticació."
 
-#: curs_main.c:1808
+#: curs_main.c:1816
 #, fuzzy
 msgid "No tag specified, aborting."
 msgstr "S’avorta el missatge sense assumpte."
 
-#: curs_main.c:1820
+#: curs_main.c:1828
 #, c-format
 msgid "Update tags..."
 msgstr ""
 
-#: curs_main.c:1857
+#: curs_main.c:1865
 msgid "Failed to modify tags, aborting."
 msgstr ""
 
-#: curs_main.c:1898
+#: curs_main.c:1906
 #, fuzzy
 msgid "No query, aborting."
 msgstr "S’avorta el missatge sense assumpte."
 
-#: curs_main.c:1902 curs_main.c:1922 curs_main.c:1941
+#: curs_main.c:1910 curs_main.c:1930 curs_main.c:1949
 msgid "Failed to create query, aborting."
 msgstr ""
 
-#: curs_main.c:1911 curs_main.c:1930
+#: curs_main.c:1919 curs_main.c:1938
 msgid "Windowed queries disabled."
 msgstr ""
 
-#: curs_main.c:1916 curs_main.c:1935
+#: curs_main.c:1924 curs_main.c:1943
 msgid "No notmuch vfolder currently loaded."
 msgstr ""
 
 # És una pregunta.  -- ivb
-#: curs_main.c:1973
+#: curs_main.c:1981
 msgid "Open mailbox in read-only mode"
 msgstr "Obri en mode de només lectura la bústia"
 
-#: curs_main.c:1976
+#: curs_main.c:1984
 #, fuzzy
 msgid "Open virtual folder"
 msgstr "Obri una carpeta diferent."
 
 # És una pregunta.  -- ivb
-#: curs_main.c:1979
+#: curs_main.c:1987
 msgid "Open mailbox"
 msgstr "Obri la bústia"
 
-#: curs_main.c:1989
+#: curs_main.c:1997
 msgid "No mailboxes have new mail"
 msgstr "No hi ha cap bústia amb correu nou."
 
 # És una pregunta.  -- ivb
-#: curs_main.c:2036
+#: curs_main.c:2044
 #, fuzzy
 msgid "Open newsgroup in read-only mode"
 msgstr "Obri en mode de només lectura la bústia"
 
-#: curs_main.c:2038
+#: curs_main.c:2046
 msgid "Open newsgroup"
 msgstr ""
 
-#: curs_main.c:2141
+#: curs_main.c:2149
 #, fuzzy
 msgid "Exit NeoMutt without saving?"
 msgstr "Voleu abandonar NeoMutt sense desar els canvis?"
 
 # Al darrere porta dos punts.  ivb
-#: curs_main.c:2157
+#: curs_main.c:2165
 #, fuzzy
 msgid "Cannot break thread"
 msgstr "No es poden enllaçar els fils"
 
-#: curs_main.c:2160 curs_main.c:2198 curs_main.c:2658 curs_main.c:2690
+#: curs_main.c:2168 curs_main.c:2206 curs_main.c:2666 curs_main.c:2698
 #: flags.c:376 thread.c:1078 thread.c:1134 thread.c:1202
 msgid "Threading is not enabled."
 msgstr "No s’ha habilitat l’ús de fils."
 
-#: curs_main.c:2173
+#: curs_main.c:2181
 msgid "Thread broken"
 msgstr "S’ha trencat el fil."
 
-#: curs_main.c:2185
+#: curs_main.c:2193
 msgid "Thread cannot be broken, message is not part of a thread"
 msgstr "No es pot trencar el fil, el missatge no n’és part de cap."
 
 # Al darrere porta dos punts.  ivb
 #. L10N: CHECK_ACL
-#: curs_main.c:2195
+#: curs_main.c:2203
 msgid "Cannot link threads"
 msgstr "No es poden enllaçar els fils"
 
-#: curs_main.c:2200
+#: curs_main.c:2208
 msgid "No Message-ID: header available to link thread"
 msgstr "No hi ha capçalera «Message-ID:» amb què enllaçar el fil."
 
-#: curs_main.c:2202
+#: curs_main.c:2210
 msgid "First, please tag a message to be linked here"
 msgstr "Per favor, marqueu un missatge per a enllaçar-lo ací."
 
-#: curs_main.c:2213
+#: curs_main.c:2221
 msgid "Threads linked"
 msgstr "S’han enllaçat els fils."
 
-#: curs_main.c:2216
+#: curs_main.c:2224
 msgid "No thread linked"
 msgstr "No s’ha enllaçat cap fil."
 
-#: curs_main.c:2252 curs_main.c:2278
+#: curs_main.c:2260 curs_main.c:2286
 msgid "You are on the last message."
 msgstr "Vos trobeu sobre el darrer missatge."
 
-#: curs_main.c:2260 curs_main.c:2305
+#: curs_main.c:2268 curs_main.c:2313
 msgid "No undeleted messages."
 msgstr "No hi ha cap missatge no esborrat."
 
-#: curs_main.c:2297 curs_main.c:2323
+#: curs_main.c:2305 curs_main.c:2331
 msgid "You are on the first message."
 msgstr "Vos trobeu sobre el primer missatge."
 
-#: curs_main.c:2395 menu.c:970 pager.c:2440 pattern.c:2110
+#: curs_main.c:2403 menu.c:970 pager.c:2440 pattern.c:2110
 msgid "Search wrapped to top."
 msgstr "La cerca ha tornat al principi."
 
-#: curs_main.c:2404 pager.c:2463 pattern.c:2121
+#: curs_main.c:2412 pager.c:2463 pattern.c:2121
 msgid "Search wrapped to bottom."
 msgstr "La cerca ha tornat al final."
 
-#: curs_main.c:2447
+#: curs_main.c:2455
 msgid "No new messages in this limited view."
 msgstr "No hi ha cap missatge nou en aquesta vista limitada."
 
-#: curs_main.c:2449
+#: curs_main.c:2457
 msgid "No new messages."
 msgstr "No hi ha cap missatge nou."
 
-#: curs_main.c:2454
+#: curs_main.c:2462
 msgid "No unread messages in this limited view."
 msgstr "No hi ha cap missatge no llegit en aquesta vista limitada."
 
-#: curs_main.c:2456
+#: curs_main.c:2464
 msgid "No unread messages."
 msgstr "No hi ha cap missatge no llegit."
 
 # Al darrere porta dos punts.  ivb
 #. L10N: CHECK_ACL
-#: curs_main.c:2474
+#: curs_main.c:2482
 msgid "Cannot flag message"
 msgstr "No es pot senyalar el missatge"
 
 # Al darrere porta dos punts.  ivb
 #. L10N: CHECK_ACL
-#: curs_main.c:2513 pager.c:3100
+#: curs_main.c:2521 pager.c:3104
 msgid "Cannot toggle new"
 msgstr "No es pot canviar el senyalador «nou»"
 
-#: curs_main.c:2590
+#: curs_main.c:2598
 msgid "No more threads."
 msgstr "No hi ha més fils."
 
-#: curs_main.c:2592
+#: curs_main.c:2600
 msgid "You are on the first thread."
 msgstr "Vos trobeu al primer fil."
 
-#: curs_main.c:2676
+#: curs_main.c:2684
 #, fuzzy
 msgid "Thread contains unread or flagged messages."
 msgstr "El fil conté missatges no llegits."
 
 # Al darrere porta dos punts.  ivb
 #. L10N: CHECK_ACL
-#: curs_main.c:2726 pager.c:2784
+#: curs_main.c:2734 pager.c:2784
 msgid "Cannot delete message"
 msgstr "No es pot esborrar el missatge"
 
 # Al darrere porta dos punts.  ivb
 #. L10N: CHECK_ACL
-#: curs_main.c:2838
+#: curs_main.c:2850
 msgid "Cannot edit message"
 msgstr "No es pot editar el missatge."
 
 #. L10N: This is displayed when the x-label on one or more
 #. * messages is edited.
-#: curs_main.c:2900 pager.c:3200
+#: curs_main.c:2912 pager.c:3208
 #, fuzzy, c-format
 msgid "%d label changed."
 msgid_plural "%d labels changed."
@@ -1896,54 +1906,59 @@ msgstr[1] "S’han canviat %d etiquetes."
 #. L10N: This is displayed when editing an x-label, but no messages
 #. * were updated.  Possibly due to canceling at the prompt or if the new
 #. * label is the same as the old label.
-#: curs_main.c:2907 pager.c:3204
+#: curs_main.c:2919 pager.c:3212
 msgid "No labels changed."
 msgstr "No s’ha canviat cap etiqueta."
 
 # Al darrere porta dos punts.  ivb
 #. L10N: CHECK_ACL
-#: curs_main.c:3006
-msgid "Cannot mark message(s) as read"
+#. L10N: Due to the implementation details we do not know whether we
+#. mark zero, 1, 12, ... messages as read. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:3022
+#, fuzzy
+msgid "Cannot mark messages as read"
 msgstr "No es poden marcar els missatges com a llegits"
 
 #. L10N: This is the prompt for <mark-message>.  Whatever they
 #. enter will be prefixed by $mark_macro_prefix and will become
 #. a macro hotkey to jump to the currently selected message.
-#: curs_main.c:3042
+#: curs_main.c:3058
 msgid "Enter macro stroke: "
 msgstr "Entreu una pulsació per a la drecera: "
 
 #. L10N: "message hotkey" is the key bindings menu description of a
 #. macro created by <mark-message>.
-#: curs_main.c:3050
+#: curs_main.c:3066
 msgid "message hotkey"
 msgstr "Drecera de teclat per a un missatge."
 
 #. L10N: This is echoed after <mark-message> creates a new hotkey
 #. macro.  %s is the hotkey string ($mark_macro_prefix followed
 #. by whatever they typed at the prompt.)
-#: curs_main.c:3055
+#: curs_main.c:3071
 #, c-format
 msgid "Message bound to %s."
 msgstr "S’ha vinculat el missatge amb la drecera «%s»."
 
 #. L10N: This error is printed if <mark-message> cannot find a
 #. Message-ID for the currently selected message in the index.
-#: curs_main.c:3063
+#: curs_main.c:3079
 msgid "No message ID to macro."
 msgstr "El missatge no té identificador per a ser vinculat amb la drecera."
 
-#: curs_main.c:3105 pager.c:2961 recvattach.c:1388
+#: curs_main.c:3121 pager.c:2965 recvattach.c:1401
 msgid "Reply by mail as poster prefers?"
 msgstr ""
 
-#: curs_main.c:3108 pager.c:2927 pager.c:2939 pager.c:2964
+#: curs_main.c:3124 pager.c:2931 pager.c:2943 pager.c:2968
 msgid "Posting to this group not allowed, may be moderated. Continue?"
 msgstr ""
 
 # Al darrere porta dos punts.  ivb
 #. L10N: CHECK_ACL
-#: curs_main.c:3173 pager.c:3120
+#: curs_main.c:3189 pager.c:3124
 msgid "Cannot undelete message"
 msgstr "No es pot restaurar el missatge"
 
@@ -2148,12 +2163,35 @@ msgstr ""
 msgid "[-- Error: message/external-body has no access-type parameter --]\n"
 msgstr "[-- Error: La part «message/external-body» no té paràmetre «access-type». --]\n"
 
-#: handler.c:1611
+#. L10N: If the translation of this string is a multi line string, then
+#. each line should start with "[-- " and end with " --]".
+#. The first "%s/%s" is a MIME type, e.g. "text/plain". The last %s
+#. expands to a date as returned by `mutt_date_parse_date()`.
+#.
+#. Note: The size argument printed is not the actual number as passed
+#. to gettext but the prettified version, e.g. size = 2048 will be
+#. printed as 2K.  Your language might be sensitive to that: For
+#. example although '1K' and '1024' represent the same number your
+#. language might inflect the noun 'byte' differently.
+#.
+#. Sadly, we cannot do anything about that at the moment besides
+#. passing the precise size in bytes. If you are interested the
+#. function responsible for the prettification is
+#. mutt_str_pretty_size() in mutt/string.c.
+#.
+#: handler.c:1624
 #, fuzzy, c-format
 msgid ""
+"[-- This %s/%s attachment (size %s byte) has been deleted --]\n"
+"[-- on %s --]\n"
+msgid_plural ""
 "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
 "[-- on %s --]\n"
-msgstr ""
+msgstr[0] ""
+"[-- Aquesta adjunció de tipus «%s/%s» --]\n"
+"[-- (amb mida %s octets) ha estat esborrada --]\n"
+"[-- amb data %s. --]\n"
+msgstr[1] ""
 "[-- Aquesta adjunció de tipus «%s/%s» --]\n"
 "[-- (amb mida %s octets) ha estat esborrada --]\n"
 "[-- amb data %s. --]\n"
@@ -2162,10 +2200,25 @@ msgstr ""
 #. each line should start with "[-- " and end with " --]".
 #. The first "%s/%s" is a MIME type, e.g. "text/plain".
 #.
-#: handler.c:1620
+#. Note: The size argument printed is not the actual number as passed
+#. to gettext but the prettified version, e.g. size = 2048 will be
+#. printed as 2K.  Your language might be sensitive to that: For
+#. example although '1K' and '1024' represent the same number your
+#. language might inflect the noun 'byte' differently.
+#.
+#. Sadly, we cannot do anything about that at the moment besides
+#. passing the precise size in bytes. If you are interested the
+#. function responsible for the prettification is
+#. mutt_str_pretty_size() in mutt/string.c.
+#.
+#: handler.c:1648
 #, fuzzy, c-format
-msgid "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
-msgstr ""
+msgid "[-- This %s/%s attachment (size %s byte) has been deleted --]\n"
+msgid_plural "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
+msgstr[0] ""
+"[-- Aquesta adjunció de tipus «%s/%s» --]\n"
+"[-- (amb mida %s octets) ha estat esborrada --]\n"
+msgstr[1] ""
 "[-- Aquesta adjunció de tipus «%s/%s» --]\n"
 "[-- (amb mida %s octets) ha estat esborrada --]\n"
 
@@ -2177,7 +2230,7 @@ msgstr ""
 #. Caution: Argument three %3$ is also defined but should not be used
 #. in this translation!
 #.
-#: handler.c:1637
+#: handler.c:1667
 #, fuzzy
 msgid ""
 "[-- This %s/%s attachment has been deleted --]\n"
@@ -2191,19 +2244,19 @@ msgstr ""
 #. each line should start with "[-- " and end with " --]".
 #. The first "%s/%s" is a MIME type, e.g. "text/plain".
 #.
-#: handler.c:1646
+#: handler.c:1676
 #, fuzzy, c-format
 msgid "[-- This %s/%s attachment has been deleted --]\n"
 msgstr ""
 "[-- Aquesta adjunció de tipus «%s/%s» --]\n"
 "[-- ha estat esborrada --]\n"
 
-#: handler.c:1656
+#: handler.c:1686
 #, c-format
 msgid "[-- name: %s --]\n"
 msgstr "[-- Nom: %s --]\n"
 
-#: handler.c:1672
+#: handler.c:1702
 #, fuzzy, c-format
 msgid ""
 "[-- This %s/%s attachment is not included, --]\n"
@@ -2213,7 +2266,7 @@ msgstr ""
 "[-- Aquesta adjunció de tipus «%s/%s» no s’inclou, --]\n"
 "[-- i la font externa indicada ha expirat. --]\n"
 
-#: handler.c:1693
+#: handler.c:1723
 #, fuzzy, c-format
 msgid ""
 "[-- This %s/%s attachment is not included, --]\n"
@@ -2222,54 +2275,54 @@ msgstr ""
 "[-- Aquesta adjunció de tipus «%s/%s» no s’inclou, --]\n"
 "[-- i no es pot emprar el mètode d’accés indicat, «%s». --]\n"
 
-#: handler.c:1822
+#: handler.c:1852
 #, fuzzy
 msgid "Unable to open memory stream!"
 msgstr "No s’ha pogut obrir el fitxer temporal."
 
-#: handler.c:1831
+#: handler.c:1861
 msgid "Unable to open temporary file!"
 msgstr "No s’ha pogut obrir el fitxer temporal."
 
-#: handler.c:1881
+#: handler.c:1911
 #, fuzzy
 msgid "failed to re-open memstream!"
 msgstr "No s’ha pogut obrir el fitxer temporal."
 
-#: handler.c:2013
+#: handler.c:2043
 msgid "Error: multipart/signed has no protocol."
 msgstr "Error: La part «multipart/signed» no té paràmetre «protocol»."
 
-#: handler.c:2076
+#: handler.c:2106
 #, fuzzy
 msgid "[-- This is an attachment (use '%3$s' to view this part) --]\n"
 msgstr "[-- Açò és una adjunció. (Useu «%3$s» per a veure aquesta part.) --]\n"
 
-#: handler.c:2082
+#: handler.c:2112
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported (use '%s' to view this part) --]\n"
 msgstr "[-- No es pot mostrar «%s/%s». (Useu «%s» per a veure aquesta part.) --]\n"
 
-#: handler.c:2087
+#: handler.c:2117
 #, fuzzy
 msgid "[-- This is an attachment (need 'view-attachments' bound to key!) --]\n"
 msgstr "[-- Açò és una adjunció. (Vinculeu «view-attachents» a una tecla.) --]\n"
 
 #. L10N: %s/%s is a MIME type, e.g. "text/plain".
-#: handler.c:2091
+#: handler.c:2121
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported (need 'view-attachments' bound to key!) --]\n"
 msgstr "[-- No es pot mostrar «%s/%s». (Vinculeu «view-attachents» a una tecla.) --]\n"
 
 # Es concatenen amb una o cap de les següents i en acabant « --]».  ivb
 # Sí, la concatenació original està malament.  ivb
-#: handler.c:2098
+#: handler.c:2128
 #, fuzzy
 msgid "[-- This is an attachment --]\n"
 msgstr "[-- Açò és una adjunció. --]\n"
 
 #. L10N: %s/%s is a MIME type, e.g. "text/plain".
-#: handler.c:2101
+#: handler.c:2131
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported --]\n"
 msgstr "[-- No es pot mostrar «%s/%s». --]\n"
@@ -2579,7 +2632,7 @@ msgstr "El servidor SMTP no admet autenticació."
 msgid "Invalid IMAP flags"
 msgstr "No vàlid    "
 
-#: imap/message.c:477 mx.c:1326
+#: imap/message.c:477 mx.c:1336
 msgid "Integer overflow -- can't allocate memory."
 msgstr "Desbordament enter, no s’ha pogut reservar memòria."
 
@@ -3382,72 +3435,82 @@ msgstr "SSL no es troba disponible."
 msgid "Reading from %s interrupted..."
 msgstr "S’ha interromput la cerca."
 
-#: mx.c:634
-msgid "message(s) not deleted"
-msgstr "No s’han pogut esborrar els missatges."
+#. L10N: Although we now the precise number of messages, we do not show it to the user.
+#. So feel free to use a "generic plural" as plural translation if your language has one.
+#.
+#: mx.c:639
+#, fuzzy
+msgid "message not deleted"
+msgid_plural "messages not deleted"
+msgstr[0] "No s’han pogut esborrar els missatges."
+msgstr[1] "No s’han pogut esborrar els missatges."
 
 # Condició d’error.  ivb
-#: mx.c:671
+#: mx.c:676
 msgid "Can't open trash folder"
 msgstr "No s’ha pogut obrir la carpeta paperera."
 
-#: mx.c:710
+#: mx.c:715
 msgid "Mark all articles read?"
 msgstr ""
 
-#: mx.c:754
+#. L10N: The first argument is the number of read messages to be
+#. moved, the second argument is the target mailbox.
+#: mx.c:762
 #, fuzzy, c-format
-msgid "Move %d read messages to %s?"
-msgstr "Voleu moure els missatges a «%s»?"
+msgid "Move %d read message to %s?"
+msgid_plural "Move %d read messages to %s?"
+msgstr[0] "Voleu moure els missatges a «%s»?"
+msgstr[1] "Voleu moure els missatges a «%s»?"
 
 # ivb (2001/12/08)
 # ivb  Ací «%d» sempre és 1.
-#: mx.c:771 mx.c:1077
+#: mx.c:781 mx.c:1087
 #, fuzzy, c-format
 msgid "Purge %d deleted message?"
 msgid_plural "Purge %d deleted messages?"
 msgstr[0] "Voleu eliminar %d missatge esborrat?"
 msgstr[1] "Voleu eliminar %d missatges esborrats?"
 
-#: mx.c:793
+#: mx.c:803
 #, c-format
 msgid "Moving read messages to %s..."
 msgstr "S’estan movent els missatges llegits a «%s»…"
 
-#: mx.c:859 mx.c:1068
+#: mx.c:869 mx.c:1078
 msgid "Mailbox is unchanged."
 msgstr "No s’ha modificat la bústia."
 
-#: mx.c:914
+#: mx.c:924
 #, c-format
 msgid "%d kept, %d moved, %d deleted."
 msgstr "%d mantinguts, %d moguts, %d esborrats."
 
-#: mx.c:917 mx.c:1130
+#: mx.c:927 mx.c:1140
 #, c-format
 msgid "%d kept, %d deleted."
 msgstr "%d mantinguts, %d esborrats."
 
 # ivb (2001/12/08)
 # ivb  Pot anar darrere de la següent de la següent.
-#: mx.c:1052
+#: mx.c:1062
 #, c-format
 msgid " Press '%s' to toggle write"
 msgstr "Premeu «%s» per a habilitar l’escriptura."
 
 # ivb (2001/12/08)
 # ivb  Pot anar darrere de la següent.
-#: mx.c:1054
+#: mx.c:1064
 msgid "Use 'toggle-write' to re-enable write!"
 msgstr "Habiliteu l’escriptura amb «toggle-write»."
 
 # Precedeix alguna de les anteriors.  Mantenir breu.  ivb
-#: mx.c:1056
+#: mx.c:1066
 #, c-format
 msgid "Mailbox is marked unwritable. %s"
 msgstr "Bústia en estat de només lectura.  %s"
 
-#: mx.c:1124
+#: mx.c:1134
 msgid "Mailbox checkpointed."
 msgstr "S’ha establert un punt de control a la bústia."
 
@@ -3466,35 +3529,40 @@ msgstr " (data actual: %c)"
 msgid "[-- %s output follows%s --]\n"
 msgstr "[-- Eixida de %s%s: --]\n"
 
-#: ncrypt/crypt.c:95
-msgid "Passphrase(s) forgotten."
+#. L10N: Due to the implementation details (e.g. some passwords are managed
+#. by gpg-agent) we cannot know whether we forgot zero, 1, 12, ...
+#. passwords. So in English we use "Passphrases". Your language might
+#. have other means to express this.
+#: ncrypt/crypt.c:100
+#, fuzzy
+msgid "Passphrases forgotten."
 msgstr "S’han esborrat de la memòria les frases clau."
 
 # No es pot fer mai.  ivb
 # ABREUJAT!  ivb
 # No es pot emprar PGP en línia amb adjuncions.  Voleu recórrer a emprar PGP/MIME?
-#: ncrypt/crypt.c:155
+#: ncrypt/crypt.c:161
 msgid "Inline PGP can't be used with attachments.  Revert to PGP/MIME?"
 msgstr "No es pot emprar PGP en línia amb adjuncions.  Emprar PGP/MIME?"
 
-#: ncrypt/crypt.c:159
+#: ncrypt/crypt.c:165
 msgid "Mail not sent: inline PGP can't be used with attachments."
 msgstr "No s’ha enviat el missatge: no es pot emprar PGP en línia amb adjuncions."
 
 # No es pot fer mai.  ivb
 # ABREUJAT!  ivb
 # No es pot emprar PGP en línia amb adjuncions.  Voleu recórrer a emprar PGP/MIME?
-#: ncrypt/crypt.c:166
+#: ncrypt/crypt.c:172
 #, fuzzy
 msgid "Inline PGP can't be used with format=flowed.  Revert to PGP/MIME?"
 msgstr "No es pot emprar PGP en línia amb adjuncions.  Emprar PGP/MIME?"
 
-#: ncrypt/crypt.c:170
+#: ncrypt/crypt.c:176
 #, fuzzy
 msgid "Mail not sent: inline PGP can't be used with format=flowed."
 msgstr "No s’ha enviat el missatge: no es pot emprar PGP en línia amb adjuncions."
 
-#: ncrypt/crypt.c:180 ncrypt/cryptglue.c:125 ncrypt/pgpkey.c:589
+#: ncrypt/crypt.c:186 ncrypt/cryptglue.c:125 ncrypt/pgpkey.c:589
 #: ncrypt/pgpkey.c:782
 msgid "Invoking PGP..."
 msgstr "S’està invocant PGP…"
@@ -3502,27 +3570,27 @@ msgstr "S’està invocant PGP…"
 # S’ha intentat però ha fallat.  ivb
 # ABREUJAT!  ivb
 # No s’ha pogut enviar el missatge en línia.  Voleu recórrer a emprar PGP/MIME?
-#: ncrypt/crypt.c:192
+#: ncrypt/crypt.c:198
 msgid "Message can't be sent inline.  Revert to using PGP/MIME?"
 msgstr "No s’ha pogut enviar el missatge en línia.  Emprar PGP/MIME?"
 
-#: ncrypt/crypt.c:194 send.c:1824
+#: ncrypt/crypt.c:200 send.c:1824
 msgid "Mail not sent."
 msgstr "No s’ha enviat el missatge."
 
-#: ncrypt/crypt.c:540
+#: ncrypt/crypt.c:546
 msgid "S/MIME messages with no hints on content are unsupported."
 msgstr "No es permeten els misatges S/MIME sense pistes sobre el contingut."
 
-#: ncrypt/crypt.c:754 ncrypt/crypt.c:795
+#: ncrypt/crypt.c:760 ncrypt/crypt.c:801
 msgid "Trying to extract PGP keys...\n"
 msgstr "S’està provant d’extreure les claus PGP…\n"
 
-#: ncrypt/crypt.c:776 ncrypt/crypt.c:816
+#: ncrypt/crypt.c:782 ncrypt/crypt.c:822
 msgid "Trying to extract S/MIME certificates...\n"
 msgstr "S’està provant d’extreure els certificats S/MIME…\n"
 
-#: ncrypt/crypt.c:976
+#: ncrypt/crypt.c:982
 #, c-format
 msgid ""
 "[-- Error: Unknown multipart/signed protocol %s! --]\n"
@@ -3531,7 +3599,7 @@ msgstr ""
 "[-- Error: El protocol «%s» de «multipart/signed» no és conegut. --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1016
+#: ncrypt/crypt.c:1022
 #, fuzzy
 msgid ""
 "[-- Error: Missing or bad-format multipart/signed signature! --]\n"
@@ -3540,7 +3608,7 @@ msgstr ""
 "[-- Error: L’estructura «multipart/signed» no és consistent. --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1058
+#: ncrypt/crypt.c:1064
 #, c-format
 msgid ""
 "[-- Warning: We can't verify %s/%s signatures. --]\n"
@@ -3549,7 +3617,7 @@ msgstr ""
 "[-- Avís: No es poden verificar les signatures «%s/%s». --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1070
+#: ncrypt/crypt.c:1076
 msgid ""
 "[-- The following data is signed --]\n"
 "\n"
@@ -3557,7 +3625,7 @@ msgstr ""
 "[-- Les dades següents es troben signades: --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1075
+#: ncrypt/crypt.c:1081
 msgid ""
 "[-- Warning: Can't find any signatures. --]\n"
 "\n"
@@ -3565,7 +3633,7 @@ msgstr ""
 "[-- Avís: No s’ha trobat cap signatura. --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1081
+#: ncrypt/crypt.c:1087
 msgid ""
 "\n"
 "[-- End of signed data --]\n"
@@ -3618,7 +3686,7 @@ msgstr ""
 msgid "error reading data object: %s\n"
 msgstr "Error en llegir l’objecte de dades: %s\n"
 
-#: ncrypt/crypt_gpgme.c:662 ncrypt/crypt_gpgme.c:3848 ncrypt/pgpkey.c:585
+#: ncrypt/crypt_gpgme.c:662 ncrypt/crypt_gpgme.c:3850 ncrypt/pgpkey.c:585
 #: ncrypt/pgpkey.c:768
 msgid "Can't create temporary file"
 msgstr "No s’ha pogut crear un fitxer temporal."
@@ -3983,31 +4051,33 @@ msgstr "[No és vàlid]"
 # Tipus de certificat, bits de l’algorisme, tipus d’algorisme.  ivb
 #. L10N: This is printed after "Key Type: " and looks like this:
 #. *       PGP, 2048 bit RSA
-#: ncrypt/crypt_gpgme.c:3670 ncrypt/crypt_gpgme.c:3808
-#, c-format
+#: ncrypt/crypt_gpgme.c:3670 ncrypt/crypt_gpgme.c:3810
+#, fuzzy, c-format
 msgid "%s, %lu bit %s\n"
-msgstr "%1$s, %3$s de %2$lu bits\n"
+msgid_plural "%s, %lu bit %s\n"
+msgstr[0] "%1$s, %3$s de %2$lu bits\n"
+msgstr[1] "%1$s, %3$s de %2$lu bits\n"
 
 # Capacitats d’una clau.  ivb
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3678 ncrypt/crypt_gpgme.c:3815
+#: ncrypt/crypt_gpgme.c:3678 ncrypt/crypt_gpgme.c:3817
 msgid "encryption"
 msgstr "xifratge"
 
 #: ncrypt/crypt_gpgme.c:3679 ncrypt/crypt_gpgme.c:3685
-#: ncrypt/crypt_gpgme.c:3816 ncrypt/crypt_gpgme.c:3821
+#: ncrypt/crypt_gpgme.c:3818 ncrypt/crypt_gpgme.c:3823
 msgid ", "
 msgstr ", "
 
 # Capacitats d’una clau.  ivb
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3684 ncrypt/crypt_gpgme.c:3820
+#: ncrypt/crypt_gpgme.c:3684 ncrypt/crypt_gpgme.c:3822
 msgid "signing"
 msgstr "signatura"
 
 # Capacitats d’una clau.  ivb
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3690 ncrypt/crypt_gpgme.c:3825
+#: ncrypt/crypt_gpgme.c:3690 ncrypt/crypt_gpgme.c:3827
 msgid "certification"
 msgstr "certificació"
 
@@ -4029,69 +4099,69 @@ msgstr "[Expirada]"
 msgid "[Disabled]"
 msgstr "[Inhabilitada]"
 
-#: ncrypt/crypt_gpgme.c:3851
+#: ncrypt/crypt_gpgme.c:3853
 msgid "Collecting data..."
 msgstr "S’estan recollint les dades…"
 
-#: ncrypt/crypt_gpgme.c:3876
+#: ncrypt/crypt_gpgme.c:3878
 #, c-format
 msgid "Error finding issuer key: %s\n"
 msgstr "Error en trobar la clau del lliurador: %s\n"
 
-#: ncrypt/crypt_gpgme.c:3885
+#: ncrypt/crypt_gpgme.c:3887
 msgid "Error: certification chain too long - stopping here\n"
 msgstr "Error: La cadena de certificació és massa llarga, s’abandona aquí.\n"
 
-#: ncrypt/crypt_gpgme.c:3895 ncrypt/pgpkey.c:608
+#: ncrypt/crypt_gpgme.c:3897 ncrypt/pgpkey.c:608
 #, c-format
 msgid "Key ID: 0x%s"
 msgstr "ID de la clau: 0x%s"
 
-#: ncrypt/crypt_gpgme.c:3990
+#: ncrypt/crypt_gpgme.c:3992
 #, c-format
 msgid "gpgme_new failed: %s"
 msgstr "Ha fallat gpgme_new(): %s"
 
-#: ncrypt/crypt_gpgme.c:4028 ncrypt/crypt_gpgme.c:4079
+#: ncrypt/crypt_gpgme.c:4030 ncrypt/crypt_gpgme.c:4081
 #, c-format
 msgid "gpgme_op_keylist_start failed: %s"
 msgstr "Ha fallat gpgme_op_keylist_start(): %s"
 
-#: ncrypt/crypt_gpgme.c:4067 ncrypt/crypt_gpgme.c:4109
+#: ncrypt/crypt_gpgme.c:4069 ncrypt/crypt_gpgme.c:4111
 #, c-format
 msgid "gpgme_op_keylist_next failed: %s"
 msgstr "Ha fallat gpgme_op_keylist_next(): %s"
 
-#: ncrypt/crypt_gpgme.c:4185
+#: ncrypt/crypt_gpgme.c:4187
 msgid "All matching keys are marked expired/revoked."
 msgstr "Totes les claus concordants estan marcades com a expirades o revocades."
 
 # Aquest menú no està massa poblat.  -- ivb
-#: ncrypt/crypt_gpgme.c:4215 ncrypt/pgpkey.c:543 ncrypt/smime.c:475
+#: ncrypt/crypt_gpgme.c:4217 ncrypt/pgpkey.c:543 ncrypt/smime.c:475
 msgid "Select  "
 msgstr "Selecciona  "
 
-#: ncrypt/crypt_gpgme.c:4217 ncrypt/pgpkey.c:545
+#: ncrypt/crypt_gpgme.c:4219 ncrypt/pgpkey.c:545
 msgid "Check key  "
 msgstr "Comprova la clau  "
 
 # Darrere va el patró corresponent.  ivb
-#: ncrypt/crypt_gpgme.c:4233
+#: ncrypt/crypt_gpgme.c:4235
 msgid "PGP and S/MIME keys matching"
 msgstr "Claus PGP i S/MIME que concordem amb"
 
 # Darrere va el patró corresponent.  ivb
-#: ncrypt/crypt_gpgme.c:4235
+#: ncrypt/crypt_gpgme.c:4237
 msgid "PGP keys matching"
 msgstr "Claus PGP que concordem amb"
 
 # Darrere va el patró corresponent.  ivb
-#: ncrypt/crypt_gpgme.c:4237
+#: ncrypt/crypt_gpgme.c:4239
 msgid "S/MIME keys matching"
 msgstr "Claus S/MIME que concorden amb"
 
 # Darrere va el patró corresponent.  ivb
-#: ncrypt/crypt_gpgme.c:4239
+#: ncrypt/crypt_gpgme.c:4241
 msgid "keys matching"
 msgstr "Claus que concordem amb"
 
@@ -4100,7 +4170,7 @@ msgstr "Claus que concordem amb"
 #. %1$s is one of the previous four entries.
 #. %2$s is an address.
 #. e.g. "S/MIME keys matching <me@mutt.org>."
-#: ncrypt/crypt_gpgme.c:4246
+#: ncrypt/crypt_gpgme.c:4248
 #, c-format
 msgid "%s <%s>."
 msgstr "%s <%s>."
@@ -4108,19 +4178,19 @@ msgstr "%s <%s>."
 # Nom i àlies?  ivb
 #. L10N:
 #. e.g. 'S/MIME keys matching "Michael Elkins".'
-#: ncrypt/crypt_gpgme.c:4250
+#: ncrypt/crypt_gpgme.c:4252
 #, c-format
 msgid "%s \"%s\"."
 msgstr "%s «%s»."
 
-#: ncrypt/crypt_gpgme.c:4277 ncrypt/pgpkey.c:628
+#: ncrypt/crypt_gpgme.c:4279 ncrypt/pgpkey.c:628
 msgid "This key can't be used: expired/disabled/revoked."
 msgstr "No es pot emprar aquesta clau: es troba expirada, inhabilitada o revocada."
 
 # ivb (2001/12/08)
 # ivb  ABREUJAT!
 # ivb  Aquest ID es troba expirat, inhabilitat o revocat.
-#: ncrypt/crypt_gpgme.c:4290 ncrypt/pgpkey.c:640 ncrypt/smime.c:505
+#: ncrypt/crypt_gpgme.c:4292 ncrypt/pgpkey.c:640 ncrypt/smime.c:505
 #, fuzzy
 msgid "ID is expired/disabled/revoked. Do you really want to use the key?"
 msgstr "ID expirat/inhabilitat/revocat.  Voleu realment emprar la clau?"
@@ -4128,7 +4198,7 @@ msgstr "ID expirat/inhabilitat/revocat.  Voleu realment emprar la clau?"
 # ivb (2001/12/08)
 # ivb  ABREUJAT!
 # ivb  Aquest ID no és vàlid.
-#: ncrypt/crypt_gpgme.c:4299 ncrypt/pgpkey.c:650
+#: ncrypt/crypt_gpgme.c:4301 ncrypt/pgpkey.c:650
 #, fuzzy
 msgid "ID is not valid. Do you really want to use the key?"
 msgstr "L’ID no és vàlid.  Voleu realment emprar la clau?"
@@ -4136,7 +4206,7 @@ msgstr "L’ID no és vàlid.  Voleu realment emprar la clau?"
 # ivb (2001/12/08)
 # ivb  ABREUJAT!
 # ivb  Aquest ID només és lleugerament vàlid.
-#: ncrypt/crypt_gpgme.c:4302 ncrypt/pgpkey.c:653
+#: ncrypt/crypt_gpgme.c:4304 ncrypt/pgpkey.c:653
 #, fuzzy
 msgid "ID is only marginally valid. Do you really want to use the key?"
 msgstr "L’ID és lleugerament vàlid.  Voleu realment emprar la clau?"
@@ -4144,38 +4214,38 @@ msgstr "L’ID és lleugerament vàlid.  Voleu realment emprar la clau?"
 # ivb (2002/02/02)
 # ivb  ABREUJAT! (Hei!  Hui és 2/2/2!)
 # ivb  Aquest ID té una validesa indefinida.
-#: ncrypt/crypt_gpgme.c:4310 ncrypt/pgpkey.c:646 ncrypt/smime.c:509
+#: ncrypt/crypt_gpgme.c:4312 ncrypt/pgpkey.c:646 ncrypt/smime.c:509
 #, fuzzy
 msgid "ID has undefined validity. Do you really want to use the key?"
 msgstr "L’ID té una validesa indefinida.  Voleu realment emprar la clau?"
 
-#: ncrypt/crypt_gpgme.c:4370 ncrypt/crypt_gpgme.c:4479 ncrypt/pgpkey.c:872
+#: ncrypt/crypt_gpgme.c:4372 ncrypt/crypt_gpgme.c:4481 ncrypt/pgpkey.c:872
 #: ncrypt/pgpkey.c:995
 #, c-format
 msgid "Looking for keys matching \"%s\"..."
 msgstr "S’estan cercant les claus que concorden amb «%s»…"
 
-#: ncrypt/crypt_gpgme.c:4593 ncrypt/pgpkey.c:731 ncrypt/smime.c:811
+#: ncrypt/crypt_gpgme.c:4595 ncrypt/pgpkey.c:731 ncrypt/smime.c:811
 #, c-format
 msgid "No matching keys found for \"%s\""
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4644 ncrypt/pgp.c:1263
+#: ncrypt/crypt_gpgme.c:4646 ncrypt/pgp.c:1263
 #, c-format
 msgid "Use keyID = \"%s\" for %s?"
 msgstr "Voleu emprar l’ID de clau «%s» per a %s?"
 
-#: ncrypt/crypt_gpgme.c:4695 ncrypt/pgp.c:1312 ncrypt/smime.c:830
+#: ncrypt/crypt_gpgme.c:4697 ncrypt/pgp.c:1312 ncrypt/smime.c:830
 #: ncrypt/smime.c:938
 #, c-format
 msgid "Enter keyID for %s: "
 msgstr "Entreu l’ID de clau per a %s: "
 
-#: ncrypt/crypt_gpgme.c:4755 ncrypt/pgpkey.c:751
+#: ncrypt/crypt_gpgme.c:4757 ncrypt/pgpkey.c:751
 msgid "Please enter the key ID: "
 msgstr "Per favor, entreu l’ID de la clau: "
 
-#: ncrypt/crypt_gpgme.c:4768
+#: ncrypt/crypt_gpgme.c:4770
 #, c-format
 msgid "Error exporting key: %s\n"
 msgstr "Error en exportar la clau: %s\n"
@@ -4184,92 +4254,92 @@ msgstr "Error en exportar la clau: %s\n"
 #. MIME description for exported (attached) keys.
 #. You can translate this entry to a non-ASCII string (it will be encoded),
 #. but it may be safer to keep it untranslated.
-#: ncrypt/crypt_gpgme.c:4787
+#: ncrypt/crypt_gpgme.c:4789
 #, c-format
 msgid "PGP Key 0x%s."
 msgstr "Clau PGP 0x%s."
 
-#: ncrypt/crypt_gpgme.c:4830
+#: ncrypt/crypt_gpgme.c:4832
 msgid "GPGME: OpenPGP protocol not available"
 msgstr "GPGME: El protocol OpenPGP no es troba disponible."
 
-#: ncrypt/crypt_gpgme.c:4838
+#: ncrypt/crypt_gpgme.c:4840
 msgid "GPGME: CMS protocol not available"
 msgstr "GPGME: El protocol CMS no es troba disponible."
 
-#: ncrypt/crypt_gpgme.c:4876
+#: ncrypt/crypt_gpgme.c:4878
 msgid "S/MIME (s)ign, sign (a)s, (p)gp, (c)lear, or (o)ppenc mode off? "
 msgstr "S/MIME: (s)igna, si(g)na com a, (p)gp, (c)lar, no (o)portunista? "
 
 #. L10N: S/MIME options (opportunistic encryption is on)
-#: ncrypt/crypt_gpgme.c:4878
+#: ncrypt/crypt_gpgme.c:4880
 msgid "sapco"
 msgstr "sgpco"
 
-#: ncrypt/crypt_gpgme.c:4885
+#: ncrypt/crypt_gpgme.c:4887
 msgid "PGP (s)ign, sign (a)s, s/(m)ime, (c)lear, or (o)ppenc mode off? "
 msgstr "PGP: (s)igna, si(g)na com a, s/(m)ime, (c)lar, no (o)portunista? "
 
 #. L10N: PGP options (opportunistic encryption is on)
-#: ncrypt/crypt_gpgme.c:4887
+#: ncrypt/crypt_gpgme.c:4889
 msgid "samco"
 msgstr "sgmco"
 
 #. L10N: S/MIME options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4900
+#: ncrypt/crypt_gpgme.c:4902
 msgid "S/MIME (e)ncrypt, (s)ign, sign (a)s, (b)oth, (p)gp, (c)lear, or (o)ppenc mode? "
 msgstr "S/MIME: (x)ifra, (s)igna, si(g)na com a, (a)mbdós, (p)gp, (c)lar, (o)portunista? "
 
 # (x)ifra, (s)igna, si(g)na com a, (a)mbdós, (p)gp, (c)lar, (o)portunista
 # La «f» i la «c» originals s’agafen en el mateix cas en el codi.  ivb
 #. L10N: S/MIME options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4903
+#: ncrypt/crypt_gpgme.c:4905
 #, fuzzy
 msgid "esabpco"
 msgstr "xsgapco"
 
 #. L10N: PGP options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4909
+#: ncrypt/crypt_gpgme.c:4911
 msgid "PGP (e)ncrypt, (s)ign, sign (a)s, (b)oth, s/(m)ime, (c)lear, or (o)ppenc mode? "
 msgstr "PGP: (x)ifra, (s)igna, si(g)na com a, (a)mbdós, s/(m)ime, (c)lar, (o)portunista? "
 
 # (x)ifra, (s)igna, si(g)na com a, (a)mbdós, s/(m)ime, (c)lar, (o)portunista
 # La «f» i la «c» originals s’agafen en el mateix cas en el codi.  ivb
 #. L10N: PGP options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4912
+#: ncrypt/crypt_gpgme.c:4914
 #, fuzzy
 msgid "esabmco"
 msgstr "xsgamco"
 
-#: ncrypt/crypt_gpgme.c:4925
+#: ncrypt/crypt_gpgme.c:4927
 msgid "S/MIME (e)ncrypt, (s)ign, sign (a)s, (b)oth, (p)gp or (c)lear? "
 msgstr "S/MIME: (x)ifra, (s)igna, si(g)na com a, (a)mbdós, (p)gp, (c)lar? "
 
 # (x)ifra, (s)igna, si(g)na com a, (a)mbdós, (p)gp, (c)lar
 # La «f» i la «c» originals s’agafen en el mateix cas en el codi.  ivb
 #. L10N: S/MIME options
-#: ncrypt/crypt_gpgme.c:4927
+#: ncrypt/crypt_gpgme.c:4929
 #, fuzzy
 msgid "esabpc"
 msgstr "xsgapc"
 
-#: ncrypt/crypt_gpgme.c:4934
+#: ncrypt/crypt_gpgme.c:4936
 msgid "PGP (e)ncrypt, (s)ign, sign (a)s, (b)oth, s/(m)ime or (c)lear? "
 msgstr "PGP: (x)ifra, (s)igna, si(g)na com a, (a)mbdós, s/(m)ime, (c)lar? "
 
 # (x)ifra, (s)igna, si(g)na com a, (a)mbdós, s/(m)ime, (c)lar
 # La «f» i la «c» originals s’agafen en el mateix cas en el codi.  ivb
 #. L10N: PGP options
-#: ncrypt/crypt_gpgme.c:4936
+#: ncrypt/crypt_gpgme.c:4938
 #, fuzzy
 msgid "esabmc"
 msgstr "xsgamc"
 
-#: ncrypt/crypt_gpgme.c:5087
+#: ncrypt/crypt_gpgme.c:5089
 msgid "Failed to verify sender"
 msgstr "No s’ha pogut verificar el remitent."
 
-#: ncrypt/crypt_gpgme.c:5090
+#: ncrypt/crypt_gpgme.c:5092
 msgid "Failed to figure out sender"
 msgstr "No s’ha pogut endevinar el remitent."
 
@@ -4695,7 +4765,7 @@ msgstr ""
 msgid "%s is an invalid news server specification!"
 msgstr "«%s» no és un camí POP vàlid."
 
-#: nntp.c:75 nntp.c:612 pop.c:1028 pop_lib.c:405
+#: nntp.c:75 nntp.c:612 pop.c:1031 pop_lib.c:405
 msgid "Server closed connection!"
 msgstr "El servidor ha tancat la connexió."
 
@@ -4864,16 +4934,18 @@ msgid "check mailboxes for new mail"
 msgstr "Comprova si hi ha correu nou a les bústies."
 
 #: opcodes.h:47
-msgid "attach file(s) to this message"
+#, fuzzy
+msgid "attach files to this message"
 msgstr "Adjunta fitxers a aquest missatge."
 
 #: opcodes.h:48
-msgid "attach message(s) to this message"
+#, fuzzy
+msgid "attach messages to this message"
 msgstr "Adjunta missatges a aquest missatge."
 
 #: opcodes.h:49
 #, fuzzy
-msgid "attach news article(s) to this message"
+msgid "attach news articles to this message"
 msgstr "Adjunta fitxers a aquest missatge."
 
 #: opcodes.h:50
@@ -5725,7 +5797,8 @@ msgid "extract supported public keys"
 msgstr "Extreu totes les claus públiques possibles."
 
 #: opcodes.h:255
-msgid "wipe passphrase(s) from memory"
+#, fuzzy
+msgid "wipe passphrases from memory"
 msgstr "Esborra de la memòria les frases clau."
 
 #: opcodes.h:259
@@ -6079,18 +6152,20 @@ msgstr "No hi ha correu nou a la bústia POP."
 msgid "Delete messages from server?"
 msgstr "Voleu eliminar els missatges del servidor?"
 
-#: pop.c:954
-#, c-format
-msgid "Reading new messages (%d bytes)..."
-msgstr "S’estan llegint els missatges nous (%d octets)…"
+#: pop.c:955
+#, fuzzy, c-format
+msgid "Reading new messages (%d byte)..."
+msgid_plural "Reading new messages (%d bytes)..."
+msgstr[0] "S’estan llegint els missatges nous (%d octets)…"
+msgstr[1] "S’estan llegint els missatges nous (%d octets)…"
 
-#: pop.c:997
+#: pop.c:1000
 msgid "Error while writing mailbox!"
 msgstr "Error en escriure a la bústia."
 
 #. L10N: The plural is picked by the second numerical argument, i.e.
 #. * the %d right before 'messages', i.e. the total number of messages.
-#: pop.c:1003
+#: pop.c:1006
 #, fuzzy, c-format
 msgid "%s [%d of %d message read]"
 msgid_plural "%s [%d of %d messages read]"
@@ -6240,48 +6315,55 @@ msgstr "Redirigeix a: "
 msgid "I don't know how to print %s attachments!"
 msgstr "Es desconeix com imprimir adjuncions de tipus «%s»."
 
-#: recvattach.c:841
-msgid "Print tagged attachment(s)?"
-msgstr "Voleu imprimir les adjuncions seleccionades?"
+#. L10N: Although we now the precise number of tagged messages, we
+#. do not show it to the user.  So feel free to use a "generic
+#. plural" as plural translation if your language has one.
+#: recvattach.c:852
+#, fuzzy, c-format
+msgid "Print tagged attachment?"
+msgid_plural "Print %d tagged attachments?"
+msgstr[0] "Voleu imprimir les adjuncions seleccionades?"
+msgstr[1] "Voleu imprimir les adjuncions seleccionades?"
 
-#: recvattach.c:842
+#: recvattach.c:853
+#, c-format
 msgid "Print attachment?"
 msgstr "Voleu imprimir l’adjunció?"
 
-#: recvattach.c:900
+#: recvattach.c:913
 msgid "Structural changes to decrypted attachments are not supported"
 msgstr "No es permeten els canvis estructurals als adjunts desxifrats."
 
-#: recvattach.c:1046
+#: recvattach.c:1059
 msgid "Can't decrypt encrypted message!"
 msgstr "No s’ha pogut desxifrar el missatge xifrat."
 
-#: recvattach.c:1172
+#: recvattach.c:1185
 msgid "Attachments"
 msgstr "Adjuncions"
 
-#: recvattach.c:1210
+#: recvattach.c:1223
 msgid "There are no subparts to show!"
 msgstr "No hi ha cap subpart a mostrar."
 
-#: recvattach.c:1265
+#: recvattach.c:1278
 msgid "Can't delete attachment from POP server."
 msgstr "No es poden esborrar les adjuncions d’un servidor POP."
 
-#: recvattach.c:1274
+#: recvattach.c:1287
 #, fuzzy
 msgid "Can't delete attachment from news server."
 msgstr "No es poden esborrar les adjuncions d’un servidor POP."
 
-#: recvattach.c:1281
+#: recvattach.c:1294
 msgid "Deletion of attachments from encrypted messages is unsupported."
 msgstr "No es poden esborrar les adjuncions d’un missatge xifrat."
 
-#: recvattach.c:1287
+#: recvattach.c:1300
 msgid "Deletion of attachments from signed messages may invalidate the signature."
 msgstr "Esborrar les adjuncions d’un missatge xifrat pot invalidar-ne la signatura."
 
-#: recvattach.c:1305 recvattach.c:1320
+#: recvattach.c:1318 recvattach.c:1333
 msgid "Only deletion of multipart attachments is supported."
 msgstr "Només es poden esborrar les adjuncions dels missatges «multipart»."
 
@@ -6734,3 +6816,15 @@ msgstr "Opcions de compilació:"
 #: version.c:404
 msgid "Compile options:"
 msgstr "Opcions de compilació:"
+
+# Al darrere porta dos punts.  ivb
+#~ msgid "Cannot delete message(s)"
+#~ msgstr "No es poden esborrar els missatges"
+
+# Al darrere porta dos punts.  ivb
+#~ msgid "Cannot undelete message(s)"
+#~ msgstr "No es poden restaurar els missatges"
+
+#, fuzzy
+#~ msgid "messages not deleted"
+#~ msgstr "No s’han pogut esborrar els missatges."

--- a/po/cs.po
+++ b/po/cs.po
@@ -18,7 +18,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neomutt-20180512\n"
 "Report-Msgid-Bugs-To: neomutt-devel@neomutt.org\n"
-"POT-Creation-Date: 2018-05-20 02:02+0000\n"
+"POT-Creation-Date: 2018-05-22 14:18+0000\n"
 "PO-Revision-Date: 2018-03-06 15:18+0100\n"
 "Last-Translator: David Sterba <dsterba@suse.cz>\n"
 "Language-Team: Czech <translation-team-cs@lists.sourceforge.net>\n"
@@ -48,7 +48,7 @@ msgstr "Volba"
 
 #: addrbook.c:52 browser.c:75 browser.c:87 compose.c:160 compose.c:172
 #: conn/ssl.c:1041 conn/ssl_gnutls.c:793 curs_main.c:748 curs_main.c:761
-#: history.c:106 ncrypt/crypt_gpgme.c:4219 ncrypt/pgpkey.c:547
+#: history.c:106 ncrypt/crypt_gpgme.c:4221 ncrypt/pgpkey.c:547
 #: ncrypt/smime.c:477 pager.c:2141 postpone.c:65 query.c:72 recvattach.c:70
 msgid "Help"
 msgstr "Nápověda"
@@ -674,7 +674,7 @@ msgstr "Zabezpečení: "
 #. * Since it shares the row with "Encrypt with:", it should not be longer
 #. * than 15-20 character cells.
 #.
-#: compose.c:138 ncrypt/crypt_gpgme.c:4947 ncrypt/pgp.c:1786
+#: compose.c:138 ncrypt/crypt_gpgme.c:4949 ncrypt/pgp.c:1786
 #: ncrypt/smime.c:2127
 msgid "Sign as: "
 msgstr "Podepsat jako: "
@@ -1205,7 +1205,7 @@ msgstr "(o)dmítnout, akceptovat pouze (t)eď, pře(s)kočit"
 msgid "(r)eject, accept (o)nce"
 msgstr "(o)dmítnout, akceptovat pouze (t)eď "
 
-#: conn/ssl.c:1039 conn/ssl_gnutls.c:791 ncrypt/crypt_gpgme.c:4213
+#: conn/ssl.c:1039 conn/ssl_gnutls.c:791 ncrypt/crypt_gpgme.c:4215
 #: ncrypt/pgpkey.c:541 ncrypt/smime.c:473
 msgid "Exit  "
 msgstr "Ukončit  "
@@ -1384,11 +1384,11 @@ msgstr "Žádná schránka není otevřena."
 msgid "There are no messages."
 msgstr "Nejsou žádné zprávy."
 
-#: curs_main.c:77 mx.c:1061 pager.c:73 recvattach.c:56
+#: curs_main.c:77 mx.c:1071 pager.c:73 recvattach.c:56
 msgid "Mailbox is read-only."
 msgstr "Ze schránky je možné pouze číst."
 
-#: curs_main.c:79 pager.c:75 recvattach.c:1145
+#: curs_main.c:79 pager.c:75 recvattach.c:1158
 msgid "Function not permitted in attach-message mode."
 msgstr "V režimu přikládání zpráv není tato funkce povolena."
 
@@ -1518,236 +1518,246 @@ msgid "That message is not visible."
 msgstr "Tato zpráva není viditelná."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:1377 curs_main.c:2772 pager.c:2818
-msgid "Cannot delete message(s)"
+#. L10N: Due to the implementation details we do not know whether we
+#. delete zero, 1, 12, ... messages. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:1381 curs_main.c:2784 pager.c:2822
+#, fuzzy
+msgid "Cannot delete messages"
 msgstr "Zprávu(-y) nelze smazat"
 
-#: curs_main.c:1380
+#: curs_main.c:1384
 msgid "Delete messages matching: "
 msgstr "Smazat zprávy shodující se s: "
 
-#: curs_main.c:1421
+#: curs_main.c:1425
 msgid "No limit pattern is in effect."
 msgstr "Žádné omezení není zavedeno."
 
 #. L10N: ask for a limit to apply
-#: curs_main.c:1426
+#: curs_main.c:1430
 #, c-format
 msgid "Limit: %s"
 msgstr "Omezení: %s"
 
-#: curs_main.c:1464
+#: curs_main.c:1468
 msgid "Limit to messages matching: "
 msgstr "Omezit na zprávy shodující se s: "
 
-#: curs_main.c:1488
+#: curs_main.c:1492
 msgid "To view all messages, limit to \"all\"."
 msgstr "Pro zobrazení všech zpráv změňte omezení na „all“."
 
-#: curs_main.c:1500 pager.c:2318
+#: curs_main.c:1504 pager.c:2318
 msgid "Quit NeoMutt?"
 msgstr "Ukončit NeoMutt?"
 
-#: curs_main.c:1596
+#: curs_main.c:1600
 msgid "Tag messages matching: "
 msgstr "Označit zprávy shodující se s: "
 
 #. L10N: CHECK_ACL
-#: curs_main.c:1606 curs_main.c:3203 pager.c:3137
-msgid "Cannot undelete message(s)"
+#. L10N: Due to the implementation details we do not know whether we
+#. undelete zero, 1, 12, ... messages. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:1614 curs_main.c:3223 pager.c:3145
+#, fuzzy
+msgid "Cannot undelete messages"
 msgstr "Zprávu(-y) nelze obnovit"
 
-#: curs_main.c:1609
+#: curs_main.c:1617
 msgid "Undelete messages matching: "
 msgstr "Obnovit zprávy shodující se s: "
 
-#: curs_main.c:1619
+#: curs_main.c:1627
 msgid "Untag messages matching: "
 msgstr "Odznačit zprávy shodující se s: "
 
-#: curs_main.c:1653
+#: curs_main.c:1661
 msgid "Logged out of IMAP servers."
 msgstr "Odhlášeno z IMAP serverů."
 
-#: curs_main.c:1753
+#: curs_main.c:1761
 msgid "No virtual folder, aborting."
 msgstr "Virtuální složka není specifikována, zrušeno."
 
-#: curs_main.c:1761
+#: curs_main.c:1769
 msgid "Failed to read thread, aborting."
 msgstr "Selhalo čtení vlákna, zrušeno."
 
-#: curs_main.c:1793 mx.c:1458 mx.c:1475
+#: curs_main.c:1801 mx.c:1468 mx.c:1485
 msgid "Folder doesn't support tagging, aborting."
 msgstr "Složka nepodporuje značky, zrušeno."
 
-#: curs_main.c:1808
+#: curs_main.c:1816
 msgid "No tag specified, aborting."
 msgstr "Značka není specifikována, zrušeno."
 
-#: curs_main.c:1820
+#: curs_main.c:1828
 #, c-format
 msgid "Update tags..."
 msgstr "Aktualizovat značky…"
 
-#: curs_main.c:1857
+#: curs_main.c:1865
 msgid "Failed to modify tags, aborting."
 msgstr "Selhala úprava značek, zrušeno."
 
-#: curs_main.c:1898
+#: curs_main.c:1906
 msgid "No query, aborting."
 msgstr "Dotaz není specifikován, zrušeno."
 
-#: curs_main.c:1902 curs_main.c:1922 curs_main.c:1941
+#: curs_main.c:1910 curs_main.c:1930 curs_main.c:1949
 msgid "Failed to create query, aborting."
 msgstr "Nezdařílo se vytvořit dotaz, zrušeno."
 
-#: curs_main.c:1911 curs_main.c:1930
+#: curs_main.c:1919 curs_main.c:1938
 msgid "Windowed queries disabled."
 msgstr "Dotazy do okna nejsou povoleny."
 
-#: curs_main.c:1916 curs_main.c:1935
+#: curs_main.c:1924 curs_main.c:1943
 msgid "No notmuch vfolder currently loaded."
 msgstr "Není natažena žádná virtuální složka (notmuch)."
 
-#: curs_main.c:1973
+#: curs_main.c:1981
 msgid "Open mailbox in read-only mode"
 msgstr "Otevřít schránku pouze pro čtení"
 
-#: curs_main.c:1976
+#: curs_main.c:1984
 msgid "Open virtual folder"
 msgstr "Otevřít virtuální složku"
 
-#: curs_main.c:1979
+#: curs_main.c:1987
 msgid "Open mailbox"
 msgstr "Otevřít schránku"
 
-#: curs_main.c:1989
+#: curs_main.c:1997
 msgid "No mailboxes have new mail"
 msgstr "V žádné schránce není nová pošta"
 
-#: curs_main.c:2036
+#: curs_main.c:2044
 msgid "Open newsgroup in read-only mode"
 msgstr "Otevřít diskusní skupinu pouze pro čtení"
 
-#: curs_main.c:2038
+#: curs_main.c:2046
 msgid "Open newsgroup"
 msgstr "Otevřít diskusní skupinu"
 
-#: curs_main.c:2141
+#: curs_main.c:2149
 msgid "Exit NeoMutt without saving?"
 msgstr "Ukončit NeoMutt bez uložení změn?"
 
-#: curs_main.c:2157
+#: curs_main.c:2165
 msgid "Cannot break thread"
 msgstr "Vlákno nelze rozdělit"
 
-#: curs_main.c:2160 curs_main.c:2198 curs_main.c:2658 curs_main.c:2690
+#: curs_main.c:2168 curs_main.c:2206 curs_main.c:2666 curs_main.c:2698
 #: flags.c:376 thread.c:1078 thread.c:1134 thread.c:1202
 msgid "Threading is not enabled."
 msgstr "Vlákna nejsou podporována."
 
-#: curs_main.c:2173
+#: curs_main.c:2181
 msgid "Thread broken"
 msgstr "Vlákno rozděleno"
 
-#: curs_main.c:2185
+#: curs_main.c:2193
 msgid "Thread cannot be broken, message is not part of a thread"
 msgstr "Vlákno nelze rozdělit, zpráva není součástí vlákna"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2195
+#: curs_main.c:2203
 msgid "Cannot link threads"
 msgstr "Vlákna nelze spojit"
 
-#: curs_main.c:2200
+#: curs_main.c:2208
 msgid "No Message-ID: header available to link thread"
 msgstr "Pro spojení vláken chybí hlavička Message-ID"
 
-#: curs_main.c:2202
+#: curs_main.c:2210
 msgid "First, please tag a message to be linked here"
 msgstr "Aby sem mohla být zpráva připojena, nejprve musíte nějakou označit"
 
-#: curs_main.c:2213
+#: curs_main.c:2221
 msgid "Threads linked"
 msgstr "Vlákna spojena"
 
-#: curs_main.c:2216
+#: curs_main.c:2224
 msgid "No thread linked"
 msgstr "Žádné vlákno nespojeno"
 
-#: curs_main.c:2252 curs_main.c:2278
+#: curs_main.c:2260 curs_main.c:2286
 msgid "You are on the last message."
 msgstr "Jste na poslední zprávě."
 
-#: curs_main.c:2260 curs_main.c:2305
+#: curs_main.c:2268 curs_main.c:2313
 msgid "No undeleted messages."
 msgstr "Nejsou žádné obnovené zprávy."
 
-#: curs_main.c:2297 curs_main.c:2323
+#: curs_main.c:2305 curs_main.c:2331
 msgid "You are on the first message."
 msgstr "Jste na první zprávě."
 
-#: curs_main.c:2395 menu.c:970 pager.c:2440 pattern.c:2110
+#: curs_main.c:2403 menu.c:970 pager.c:2440 pattern.c:2110
 msgid "Search wrapped to top."
 msgstr "Hledání pokračuje od začátku."
 
-#: curs_main.c:2404 pager.c:2463 pattern.c:2121
+#: curs_main.c:2412 pager.c:2463 pattern.c:2121
 msgid "Search wrapped to bottom."
 msgstr "Hledání pokračuje od konce."
 
-#: curs_main.c:2447
+#: curs_main.c:2455
 msgid "No new messages in this limited view."
 msgstr "Žádné nové zprávy v tomto omezeném zobrazení."
 
-#: curs_main.c:2449
+#: curs_main.c:2457
 msgid "No new messages."
 msgstr "Žádné nové zprávy."
 
-#: curs_main.c:2454
+#: curs_main.c:2462
 msgid "No unread messages in this limited view."
 msgstr "Žádné nepřečtené zprávy v tomto omezeném zobrazení."
 
-#: curs_main.c:2456
+#: curs_main.c:2464
 msgid "No unread messages."
 msgstr "Žádné nepřečtené zprávy."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2474
+#: curs_main.c:2482
 msgid "Cannot flag message"
 msgstr "Zprávě nelze nastavit příznak"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2513 pager.c:3100
+#: curs_main.c:2521 pager.c:3104
 msgid "Cannot toggle new"
 msgstr "Nelze přepnout mezi nová/stará"
 
-#: curs_main.c:2590
+#: curs_main.c:2598
 msgid "No more threads."
 msgstr "Nejsou další vlákna."
 
-#: curs_main.c:2592
+#: curs_main.c:2600
 msgid "You are on the first thread."
 msgstr "Jste na prvním vláknu."
 
-#: curs_main.c:2676
+#: curs_main.c:2684
 msgid "Thread contains unread or flagged messages."
 msgstr "Vlákno obsahuje nepřečtené zprávy nebo zprávy s příznakem."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2726 pager.c:2784
+#: curs_main.c:2734 pager.c:2784
 msgid "Cannot delete message"
 msgstr "Zprávu nelze smazat"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2838
+#: curs_main.c:2850
 msgid "Cannot edit message"
 msgstr "Zprávu nelze upravit"
 
 # FIXME: Pluralize
 #. L10N: This is displayed when the x-label on one or more
 #. * messages is edited.
-#: curs_main.c:2900 pager.c:3200
+#: curs_main.c:2912 pager.c:3208
 #, c-format
 msgid "%d label changed."
 msgid_plural "%d labels changed."
@@ -1758,52 +1768,57 @@ msgstr[2] "%d štítků změněno."
 #. L10N: This is displayed when editing an x-label, but no messages
 #. * were updated.  Possibly due to canceling at the prompt or if the new
 #. * label is the same as the old label.
-#: curs_main.c:2907 pager.c:3204
+#: curs_main.c:2919 pager.c:3212
 msgid "No labels changed."
 msgstr "Žádné štítky nebyly změněny."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:3006
-msgid "Cannot mark message(s) as read"
+#. L10N: Due to the implementation details we do not know whether we
+#. mark zero, 1, 12, ... messages as read. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:3022
+#, fuzzy
+msgid "Cannot mark messages as read"
 msgstr "Zprávu(-y) nelze označit za přečtenou(-é)"
 
 #. L10N: This is the prompt for <mark-message>.  Whatever they
 #. enter will be prefixed by $mark_macro_prefix and will become
 #. a macro hotkey to jump to the currently selected message.
-#: curs_main.c:3042
+#: curs_main.c:3058
 msgid "Enter macro stroke: "
 msgstr "Zadejte značku: "
 
 #. L10N: "message hotkey" is the key bindings menu description of a
 #. macro created by <mark-message>.
-#: curs_main.c:3050
+#: curs_main.c:3066
 msgid "message hotkey"
 msgstr "horká klávesa pro značku zprávy"
 
 #. L10N: This is echoed after <mark-message> creates a new hotkey
 #. macro.  %s is the hotkey string ($mark_macro_prefix followed
 #. by whatever they typed at the prompt.)
-#: curs_main.c:3055
+#: curs_main.c:3071
 #, c-format
 msgid "Message bound to %s."
 msgstr "Zpráva svázána se značkou %s."
 
 #. L10N: This error is printed if <mark-message> cannot find a
 #. Message-ID for the currently selected message in the index.
-#: curs_main.c:3063
+#: curs_main.c:3079
 msgid "No message ID to macro."
 msgstr "ID zprávy ze značky neexistuje."
 
-#: curs_main.c:3105 pager.c:2961 recvattach.c:1388
+#: curs_main.c:3121 pager.c:2965 recvattach.c:1401
 msgid "Reply by mail as poster prefers?"
 msgstr "Odpovědět e-mailem dle návrhu autora?"
 
-#: curs_main.c:3108 pager.c:2927 pager.c:2939 pager.c:2964
+#: curs_main.c:3124 pager.c:2931 pager.c:2943 pager.c:2968
 msgid "Posting to this group not allowed, may be moderated. Continue?"
 msgstr "Publikování do této skupiny není povoleno, může být moderována. Pokračovat?"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:3173 pager.c:3120
+#: curs_main.c:3189 pager.c:3124
 msgid "Cannot undelete message"
 msgstr "Zprávu nelze obnovit"
 
@@ -1994,12 +2009,37 @@ msgstr "[-- Automaticky zobrazuji standardní chybový výstup %s --]\n"
 msgid "[-- Error: message/external-body has no access-type parameter --]\n"
 msgstr "[-- Chyba: typ „message/external-body“ nemá parametr „access-type“ --]\n"
 
-#: handler.c:1611
-#, c-format
+#. L10N: If the translation of this string is a multi line string, then
+#. each line should start with "[-- " and end with " --]".
+#. The first "%s/%s" is a MIME type, e.g. "text/plain". The last %s
+#. expands to a date as returned by `mutt_date_parse_date()`.
+#.
+#. Note: The size argument printed is not the actual number as passed
+#. to gettext but the prettified version, e.g. size = 2048 will be
+#. printed as 2K.  Your language might be sensitive to that: For
+#. example although '1K' and '1024' represent the same number your
+#. language might inflect the noun 'byte' differently.
+#.
+#. Sadly, we cannot do anything about that at the moment besides
+#. passing the precise size in bytes. If you are interested the
+#. function responsible for the prettification is
+#. mutt_str_pretty_size() in mutt/string.c.
+#.
+#: handler.c:1624
+#, fuzzy, c-format
 msgid ""
+"[-- This %s/%s attachment (size %s byte) has been deleted --]\n"
+"[-- on %s --]\n"
+msgid_plural ""
 "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
 "[-- on %s --]\n"
-msgstr ""
+msgstr[0] ""
+"[-- Tato příloha typu „%s/%s“ (o velikosti v bajtech: %s) byla smazána --]\n"
+"[-- %s --]\n"
+msgstr[1] ""
+"[-- Tato příloha typu „%s/%s“ (o velikosti v bajtech: %s) byla smazána --]\n"
+"[-- %s --]\n"
+msgstr[2] ""
 "[-- Tato příloha typu „%s/%s“ (o velikosti v bajtech: %s) byla smazána --]\n"
 "[-- %s --]\n"
 
@@ -2007,10 +2047,24 @@ msgstr ""
 #. each line should start with "[-- " and end with " --]".
 #. The first "%s/%s" is a MIME type, e.g. "text/plain".
 #.
-#: handler.c:1620
-#, c-format
-msgid "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
-msgstr "[-- Tato příloha typu „%s/%s“ (o velikosti v bajtech: %s) byla smazána --]\n"
+#. Note: The size argument printed is not the actual number as passed
+#. to gettext but the prettified version, e.g. size = 2048 will be
+#. printed as 2K.  Your language might be sensitive to that: For
+#. example although '1K' and '1024' represent the same number your
+#. language might inflect the noun 'byte' differently.
+#.
+#. Sadly, we cannot do anything about that at the moment besides
+#. passing the precise size in bytes. If you are interested the
+#. function responsible for the prettification is
+#. mutt_str_pretty_size() in mutt/string.c.
+#.
+#: handler.c:1648
+#, fuzzy, c-format
+msgid "[-- This %s/%s attachment (size %s byte) has been deleted --]\n"
+msgid_plural "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
+msgstr[0] "[-- Tato příloha typu „%s/%s“ (o velikosti v bajtech: %s) byla smazána --]\n"
+msgstr[1] "[-- Tato příloha typu „%s/%s“ (o velikosti v bajtech: %s) byla smazána --]\n"
+msgstr[2] "[-- Tato příloha typu „%s/%s“ (o velikosti v bajtech: %s) byla smazána --]\n"
 
 #. L10N: If the translation of this string is a multi line string, then
 #. each line should start with "[-- " and end with " --]".
@@ -2020,7 +2074,7 @@ msgstr "[-- Tato příloha typu „%s/%s“ (o velikosti v bajtech: %s) byla sma
 #. Caution: Argument three %3$ is also defined but should not be used
 #. in this translation!
 #.
-#: handler.c:1637
+#: handler.c:1667
 msgid ""
 "[-- This %s/%s attachment has been deleted --]\n"
 "[-- on %4$s --]\n"
@@ -2032,17 +2086,17 @@ msgstr ""
 #. each line should start with "[-- " and end with " --]".
 #. The first "%s/%s" is a MIME type, e.g. "text/plain".
 #.
-#: handler.c:1646
+#: handler.c:1676
 #, c-format
 msgid "[-- This %s/%s attachment has been deleted --]\n"
 msgstr "[-- Tato příloha typu „%s/%s“ byla smazána --]\n"
 
-#: handler.c:1656
+#: handler.c:1686
 #, c-format
 msgid "[-- name: %s --]\n"
 msgstr "[-- jméno: %s --]\n"
 
-#: handler.c:1672
+#: handler.c:1702
 #, c-format
 msgid ""
 "[-- This %s/%s attachment is not included, --]\n"
@@ -2052,7 +2106,7 @@ msgstr ""
 "[-- Tato příloha typu „%s/%s“ není přítomna, --]\n"
 "[-- a udaný externí zdroj již není platný --]\n"
 
-#: handler.c:1693
+#: handler.c:1723
 #, c-format
 msgid ""
 "[-- This %s/%s attachment is not included, --]\n"
@@ -2062,47 +2116,47 @@ msgstr ""
 "[-- a udaná hodnota parametru 'access-type %s' --]\n"
 "[-- není podporována --]\n"
 
-#: handler.c:1822
+#: handler.c:1852
 msgid "Unable to open memory stream!"
 msgstr "Memstream nelze otevřít!"
 
-#: handler.c:1831
+#: handler.c:1861
 msgid "Unable to open temporary file!"
 msgstr "Dočasný soubor nelze otevřít!"
 
-#: handler.c:1881
+#: handler.c:1911
 msgid "failed to re-open memstream!"
 msgstr "chyba pří opakovaném otevření memstreamu!"
 
-#: handler.c:2013
+#: handler.c:2043
 msgid "Error: multipart/signed has no protocol."
 msgstr "Chyba: typ „multipart/signed“ bez informace o protokolu"
 
-#: handler.c:2076
+#: handler.c:2106
 msgid "[-- This is an attachment (use '%3$s' to view this part) --]\n"
 msgstr "[-- Toto je příloha (pro zobrazení této části použijte „%3$s“) --]\n"
 
-#: handler.c:2082
+#: handler.c:2112
 #, c-format
 msgid "[-- %s/%s is unsupported (use '%s' to view this part) --]\n"
 msgstr "[-- Typ „%s/%s“ není podporován (pro zobrazení této části použijte „%s“) --]\n"
 
-#: handler.c:2087
+#: handler.c:2117
 msgid "[-- This is an attachment (need 'view-attachments' bound to key!) --]\n"
 msgstr "[-- Toto je příloha (je třeba svázat funkci „view-attachments“ s nějakou klávesou!) --]\n"
 
 #. L10N: %s/%s is a MIME type, e.g. "text/plain".
-#: handler.c:2091
+#: handler.c:2121
 #, c-format
 msgid "[-- %s/%s is unsupported (need 'view-attachments' bound to key!) --]\n"
 msgstr "[-- Typ „%s/%s“ není podporován (je třeba svázat funkci „view-attachments“ s nějakou klávesou!) --]\n"
 
-#: handler.c:2098
+#: handler.c:2128
 msgid "[-- This is an attachment --]\n"
 msgstr "[-- Toto je příloha --]\n"
 
 #. L10N: %s/%s is a MIME type, e.g. "text/plain".
-#: handler.c:2101
+#: handler.c:2131
 #, c-format
 msgid "[-- %s/%s is unsupported --]\n"
 msgstr "[-- Typ „%s/%s“ není podporován --]\n"
@@ -2408,7 +2462,7 @@ msgstr "IMAP server nepodporuje vlastní příznaky"
 msgid "Invalid IMAP flags"
 msgstr "Neplatné IMAP příznaky"
 
-#: imap/message.c:477 mx.c:1326
+#: imap/message.c:477 mx.c:1336
 msgid "Integer overflow -- can't allocate memory."
 msgstr "Přetečení celočíselné proměnné - nelze alokovat paměť."
 
@@ -3223,24 +3277,36 @@ msgstr "SSL není dostupné, nelze se spojit s %s"
 msgid "Reading from %s interrupted..."
 msgstr "Čtení z %s bylo přerušeno…"
 
-#: mx.c:634
-msgid "message(s) not deleted"
-msgstr "zprávy nesmazány"
+#. L10N: Although we now the precise number of messages, we do not show it to the user.
+#. So feel free to use a "generic plural" as plural translation if your language has one.
+#.
+#: mx.c:639
+#, fuzzy
+msgid "message not deleted"
+msgid_plural "messages not deleted"
+msgstr[0] "zprávy nesmazány"
+msgstr[1] "zprávy nesmazány"
+msgstr[2] "zprávy nesmazány"
 
-#: mx.c:671
+#: mx.c:676
 msgid "Can't open trash folder"
 msgstr "Složku koš nelze otevřít"
 
-#: mx.c:710
+#: mx.c:715
 msgid "Mark all articles read?"
 msgstr "Označit všechny články za přečtené?"
 
-#: mx.c:754
-#, c-format
-msgid "Move %d read messages to %s?"
-msgstr "Přesunout %d přečtených zpráv do %s?"
+#. L10N: The first argument is the number of read messages to be
+#. moved, the second argument is the target mailbox.
+#: mx.c:762
+#, fuzzy, c-format
+msgid "Move %d read message to %s?"
+msgid_plural "Move %d read messages to %s?"
+msgstr[0] "Přesunout %d přečtených zpráv do %s?"
+msgstr[1] "Přesunout %d přečtených zpráv do %s?"
+msgstr[2] "Přesunout %d přečtených zpráv do %s?"
 
-#: mx.c:771 mx.c:1077
+#: mx.c:781 mx.c:1087
 #, c-format
 msgid "Purge %d deleted message?"
 msgid_plural "Purge %d deleted messages?"
@@ -3248,40 +3314,40 @@ msgstr[0] "Zahodit smazané zprávy (%d)?"
 msgstr[1] "Zahodit smazané zprávy (%d)?"
 msgstr[2] "Zahodit smazané zprávy (%d)?"
 
-#: mx.c:793
+#: mx.c:803
 #, c-format
 msgid "Moving read messages to %s..."
 msgstr "Přesunuji přečtené zprávy do %s…"
 
-#: mx.c:859 mx.c:1068
+#: mx.c:869 mx.c:1078
 msgid "Mailbox is unchanged."
 msgstr "Obsah schránky nebyl změněn."
 
-#: mx.c:914
+#: mx.c:924
 #, c-format
 msgid "%d kept, %d moved, %d deleted."
 msgstr "ponecháno: %d, přesunuto: %d, smazáno: %d"
 
-#: mx.c:917 mx.c:1130
+#: mx.c:927 mx.c:1140
 #, c-format
 msgid "%d kept, %d deleted."
 msgstr "ponecháno: %d, smazáno: %d"
 
-#: mx.c:1052
+#: mx.c:1062
 #, c-format
 msgid " Press '%s' to toggle write"
 msgstr " Stiskněte „%s“ pro zapnutí zápisu"
 
-#: mx.c:1054
+#: mx.c:1064
 msgid "Use 'toggle-write' to re-enable write!"
 msgstr "Použijte „toggle-write“ pro zapnutí zápisu!"
 
-#: mx.c:1056
+#: mx.c:1066
 #, c-format
 msgid "Mailbox is marked unwritable. %s"
 msgstr "Schránka má vypnut zápis. %s"
 
-#: mx.c:1124
+#: mx.c:1134
 msgid "Mailbox checkpointed."
 msgstr "Do schránky byla vložena kontrolní značka."
 
@@ -3295,52 +3361,57 @@ msgstr " (aktuální čas: %c)"
 msgid "[-- %s output follows%s --]\n"
 msgstr "[-- následuje výstup %s %s --]\n"
 
-#: ncrypt/crypt.c:95
-msgid "Passphrase(s) forgotten."
+#. L10N: Due to the implementation details (e.g. some passwords are managed
+#. by gpg-agent) we cannot know whether we forgot zero, 1, 12, ...
+#. passwords. So in English we use "Passphrases". Your language might
+#. have other means to express this.
+#: ncrypt/crypt.c:100
+#, fuzzy
+msgid "Passphrases forgotten."
 msgstr "Šifrovací heslo(a) zapomenuto(a)."
 
-#: ncrypt/crypt.c:155
+#: ncrypt/crypt.c:161
 msgid "Inline PGP can't be used with attachments.  Revert to PGP/MIME?"
 msgstr "PGP v textu nelze použít s přílohami. Použít PGP/MIME?"
 
-#: ncrypt/crypt.c:159
+#: ncrypt/crypt.c:165
 msgid "Mail not sent: inline PGP can't be used with attachments."
 msgstr "E-mail neodeslán: PGP v textu nelze použít s přílohami."
 
-#: ncrypt/crypt.c:166
+#: ncrypt/crypt.c:172
 msgid "Inline PGP can't be used with format=flowed.  Revert to PGP/MIME?"
 msgstr "PGP v textu nelze použít s „format=flowed“. Použít PGP/MIME?"
 
-#: ncrypt/crypt.c:170
+#: ncrypt/crypt.c:176
 msgid "Mail not sent: inline PGP can't be used with format=flowed."
 msgstr "E-mail neodeslán: PGP v textu nelze použít s „format=flowed“."
 
-#: ncrypt/crypt.c:180 ncrypt/cryptglue.c:125 ncrypt/pgpkey.c:589
+#: ncrypt/crypt.c:186 ncrypt/cryptglue.c:125 ncrypt/pgpkey.c:589
 #: ncrypt/pgpkey.c:782
 msgid "Invoking PGP..."
 msgstr "Spouští se PGP…"
 
-#: ncrypt/crypt.c:192
+#: ncrypt/crypt.c:198
 msgid "Message can't be sent inline.  Revert to using PGP/MIME?"
 msgstr "Zprávu nelze poslat vloženou do textu. Použít PGP/MIME?"
 
-#: ncrypt/crypt.c:194 send.c:1824
+#: ncrypt/crypt.c:200 send.c:1824
 msgid "Mail not sent."
 msgstr "Zpráva nebyla odeslána."
 
-#: ncrypt/crypt.c:540
+#: ncrypt/crypt.c:546
 msgid "S/MIME messages with no hints on content are unsupported."
 msgstr "S/MIME zprávy bez popisu obsahu nejsou podporovány."
 
-#: ncrypt/crypt.c:754 ncrypt/crypt.c:795
+#: ncrypt/crypt.c:760 ncrypt/crypt.c:801
 msgid "Trying to extract PGP keys...\n"
 msgstr "Zkouším extrahovat PGP klíče…\n"
 
-#: ncrypt/crypt.c:776 ncrypt/crypt.c:816
+#: ncrypt/crypt.c:782 ncrypt/crypt.c:822
 msgid "Trying to extract S/MIME certificates...\n"
 msgstr "Zkouším extrahovat S/MIME certifikáty…\n"
 
-#: ncrypt/crypt.c:976
+#: ncrypt/crypt.c:982
 #, c-format
 msgid ""
 "[-- Error: Unknown multipart/signed protocol %s! --]\n"
@@ -3349,7 +3420,7 @@ msgstr ""
 "[-- Chyba: „multipart/signed“ protokol %s není znám! --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1016
+#: ncrypt/crypt.c:1022
 msgid ""
 "[-- Error: Missing or bad-format multipart/signed signature! --]\n"
 "\n"
@@ -3357,7 +3428,7 @@ msgstr ""
 "[-- Chyba: Chybná struktura zprávy typu „multipart/signed“! --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1058
+#: ncrypt/crypt.c:1064
 #, c-format
 msgid ""
 "[-- Warning: We can't verify %s/%s signatures. --]\n"
@@ -3366,7 +3437,7 @@ msgstr ""
 "[-- Varování: Podpisy typu %s/%s nelze ověřit. --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1070
+#: ncrypt/crypt.c:1076
 msgid ""
 "[-- The following data is signed --]\n"
 "\n"
@@ -3374,7 +3445,7 @@ msgstr ""
 "[-- Následují podepsaná data --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1075
+#: ncrypt/crypt.c:1081
 msgid ""
 "[-- Warning: Can't find any signatures. --]\n"
 "\n"
@@ -3382,7 +3453,7 @@ msgstr ""
 "[-- Varování: Nemohu nalézt žádný podpis. --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1081
+#: ncrypt/crypt.c:1087
 msgid ""
 "\n"
 "[-- End of signed data --]\n"
@@ -3433,7 +3504,7 @@ msgstr "[dočasný soubor]"
 msgid "error reading data object: %s\n"
 msgstr "chyba při čtení datového objektu: %s\n"
 
-#: ncrypt/crypt_gpgme.c:662 ncrypt/crypt_gpgme.c:3848 ncrypt/pgpkey.c:585
+#: ncrypt/crypt_gpgme.c:662 ncrypt/crypt_gpgme.c:3850 ncrypt/pgpkey.c:585
 #: ncrypt/pgpkey.c:768
 msgid "Can't create temporary file"
 msgstr "Dočasný soubor nelze vytvořit."
@@ -3781,28 +3852,31 @@ msgstr "[Neplatný]"
 
 #. L10N: This is printed after "Key Type: " and looks like this:
 #. *       PGP, 2048 bit RSA
-#: ncrypt/crypt_gpgme.c:3670 ncrypt/crypt_gpgme.c:3808
-#, c-format
+#: ncrypt/crypt_gpgme.c:3670 ncrypt/crypt_gpgme.c:3810
+#, fuzzy, c-format
 msgid "%s, %lu bit %s\n"
-msgstr "%s, %lu bit %s\n"
+msgid_plural "%s, %lu bit %s\n"
+msgstr[0] "%s, %lu bit %s\n"
+msgstr[1] "%s, %lu bit %s\n"
+msgstr[2] "%s, %lu bit %s\n"
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3678 ncrypt/crypt_gpgme.c:3815
+#: ncrypt/crypt_gpgme.c:3678 ncrypt/crypt_gpgme.c:3817
 msgid "encryption"
 msgstr "šifrovaní"
 
 #: ncrypt/crypt_gpgme.c:3679 ncrypt/crypt_gpgme.c:3685
-#: ncrypt/crypt_gpgme.c:3816 ncrypt/crypt_gpgme.c:3821
+#: ncrypt/crypt_gpgme.c:3818 ncrypt/crypt_gpgme.c:3823
 msgid ", "
 msgstr ", "
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3684 ncrypt/crypt_gpgme.c:3820
+#: ncrypt/crypt_gpgme.c:3684 ncrypt/crypt_gpgme.c:3822
 msgid "signing"
 msgstr "podepisování"
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3690 ncrypt/crypt_gpgme.c:3825
+#: ncrypt/crypt_gpgme.c:3690 ncrypt/crypt_gpgme.c:3827
 msgid "certification"
 msgstr "ověřování"
 
@@ -3821,64 +3895,64 @@ msgstr "[Platnost vypršela]"
 msgid "[Disabled]"
 msgstr "[Zakázán]"
 
-#: ncrypt/crypt_gpgme.c:3851
+#: ncrypt/crypt_gpgme.c:3853
 msgid "Collecting data..."
 msgstr "Sbírám údaje…"
 
-#: ncrypt/crypt_gpgme.c:3876
+#: ncrypt/crypt_gpgme.c:3878
 #, c-format
 msgid "Error finding issuer key: %s\n"
 msgstr "Chyba při vyhledávání klíče vydavatele: %s\n"
 
-#: ncrypt/crypt_gpgme.c:3885
+#: ncrypt/crypt_gpgme.c:3887
 msgid "Error: certification chain too long - stopping here\n"
 msgstr "Chyba: řetězec certifikátů je příliš dlouhý - zde se končí\n"
 
-#: ncrypt/crypt_gpgme.c:3895 ncrypt/pgpkey.c:608
+#: ncrypt/crypt_gpgme.c:3897 ncrypt/pgpkey.c:608
 #, c-format
 msgid "Key ID: 0x%s"
 msgstr "ID klíče: 0x%s"
 
-#: ncrypt/crypt_gpgme.c:3990
+#: ncrypt/crypt_gpgme.c:3992
 #, c-format
 msgid "gpgme_new failed: %s"
 msgstr "gpgme_new selhala: %s"
 
-#: ncrypt/crypt_gpgme.c:4028 ncrypt/crypt_gpgme.c:4079
+#: ncrypt/crypt_gpgme.c:4030 ncrypt/crypt_gpgme.c:4081
 #, c-format
 msgid "gpgme_op_keylist_start failed: %s"
 msgstr "gpgme_op_keylist_start selhala: %s"
 
-#: ncrypt/crypt_gpgme.c:4067 ncrypt/crypt_gpgme.c:4109
+#: ncrypt/crypt_gpgme.c:4069 ncrypt/crypt_gpgme.c:4111
 #, c-format
 msgid "gpgme_op_keylist_next failed: %s"
 msgstr "gpgme_op_keylist_next selhala: %s"
 
-#: ncrypt/crypt_gpgme.c:4185
+#: ncrypt/crypt_gpgme.c:4187
 msgid "All matching keys are marked expired/revoked."
 msgstr "Všem vyhovujícím klíčům vypršela platnost nebo byly zneplatněny."
 
-#: ncrypt/crypt_gpgme.c:4215 ncrypt/pgpkey.c:543 ncrypt/smime.c:475
+#: ncrypt/crypt_gpgme.c:4217 ncrypt/pgpkey.c:543 ncrypt/smime.c:475
 msgid "Select  "
 msgstr "Zvolit "
 
-#: ncrypt/crypt_gpgme.c:4217 ncrypt/pgpkey.c:545
+#: ncrypt/crypt_gpgme.c:4219 ncrypt/pgpkey.c:545
 msgid "Check key  "
 msgstr "Kontrolovat klíč  "
 
-#: ncrypt/crypt_gpgme.c:4233
+#: ncrypt/crypt_gpgme.c:4235
 msgid "PGP and S/MIME keys matching"
 msgstr "PGP a S/MIME klíče vyhovující"
 
-#: ncrypt/crypt_gpgme.c:4235
+#: ncrypt/crypt_gpgme.c:4237
 msgid "PGP keys matching"
 msgstr "PGP klíče vyhovující"
 
-#: ncrypt/crypt_gpgme.c:4237
+#: ncrypt/crypt_gpgme.c:4239
 msgid "S/MIME keys matching"
 msgstr "S/MIME klíče vyhovující"
 
-#: ncrypt/crypt_gpgme.c:4239
+#: ncrypt/crypt_gpgme.c:4241
 msgid "keys matching"
 msgstr "klíče vyhovující"
 
@@ -3886,65 +3960,65 @@ msgstr "klíče vyhovující"
 #. %1$s is one of the previous four entries.
 #. %2$s is an address.
 #. e.g. "S/MIME keys matching <me@mutt.org>."
-#: ncrypt/crypt_gpgme.c:4246
+#: ncrypt/crypt_gpgme.c:4248
 #, c-format
 msgid "%s <%s>."
 msgstr "%s <%s>."
 
 #. L10N:
 #. e.g. 'S/MIME keys matching "Michael Elkins".'
-#: ncrypt/crypt_gpgme.c:4250
+#: ncrypt/crypt_gpgme.c:4252
 #, c-format
 msgid "%s \"%s\"."
 msgstr "%s „%s“."
 
-#: ncrypt/crypt_gpgme.c:4277 ncrypt/pgpkey.c:628
+#: ncrypt/crypt_gpgme.c:4279 ncrypt/pgpkey.c:628
 msgid "This key can't be used: expired/disabled/revoked."
 msgstr "Klíč nelze použít: vypršela jeho platnost, nebo byl zakázán či odvolán."
 
-#: ncrypt/crypt_gpgme.c:4290 ncrypt/pgpkey.c:640 ncrypt/smime.c:505
+#: ncrypt/crypt_gpgme.c:4292 ncrypt/pgpkey.c:640 ncrypt/smime.c:505
 msgid "ID is expired/disabled/revoked. Do you really want to use the key?"
 msgstr "Tomuto ID vypršela platnost, nebo bylo zakázáno či odvoláno. Opravdu chcete tento klíč použít?"
 
-#: ncrypt/crypt_gpgme.c:4299 ncrypt/pgpkey.c:650
+#: ncrypt/crypt_gpgme.c:4301 ncrypt/pgpkey.c:650
 msgid "ID is not valid. Do you really want to use the key?"
 msgstr "Toto ID není platné. Opravdu chcete tento klíč použít?"
 
-#: ncrypt/crypt_gpgme.c:4302 ncrypt/pgpkey.c:653
+#: ncrypt/crypt_gpgme.c:4304 ncrypt/pgpkey.c:653
 msgid "ID is only marginally valid. Do you really want to use the key?"
 msgstr "Důvěryhodnost tohoto ID je pouze částečná. Opravdu chcete tento klíč použít?"
 
-#: ncrypt/crypt_gpgme.c:4310 ncrypt/pgpkey.c:646 ncrypt/smime.c:509
+#: ncrypt/crypt_gpgme.c:4312 ncrypt/pgpkey.c:646 ncrypt/smime.c:509
 msgid "ID has undefined validity. Do you really want to use the key?"
 msgstr "ID nemá definovanou důvěryhodnost. Opravdu chcete tento klíč použít?"
 
-#: ncrypt/crypt_gpgme.c:4370 ncrypt/crypt_gpgme.c:4479 ncrypt/pgpkey.c:872
+#: ncrypt/crypt_gpgme.c:4372 ncrypt/crypt_gpgme.c:4481 ncrypt/pgpkey.c:872
 #: ncrypt/pgpkey.c:995
 #, c-format
 msgid "Looking for keys matching \"%s\"..."
 msgstr "Hledám klíče vyhovující „%s“…"
 
-#: ncrypt/crypt_gpgme.c:4593 ncrypt/pgpkey.c:731 ncrypt/smime.c:811
+#: ncrypt/crypt_gpgme.c:4595 ncrypt/pgpkey.c:731 ncrypt/smime.c:811
 #, c-format
 msgid "No matching keys found for \"%s\""
 msgstr "Nenalezeny vyhovující klíče pro „%s“"
 
-#: ncrypt/crypt_gpgme.c:4644 ncrypt/pgp.c:1263
+#: ncrypt/crypt_gpgme.c:4646 ncrypt/pgp.c:1263
 #, c-format
 msgid "Use keyID = \"%s\" for %s?"
 msgstr "Použít ID klíče „%s“ pro %s?"
 
-#: ncrypt/crypt_gpgme.c:4695 ncrypt/pgp.c:1312 ncrypt/smime.c:830
+#: ncrypt/crypt_gpgme.c:4697 ncrypt/pgp.c:1312 ncrypt/smime.c:830
 #: ncrypt/smime.c:938
 #, c-format
 msgid "Enter keyID for %s: "
 msgstr "Zadejte ID klíče pro %s: "
 
-#: ncrypt/crypt_gpgme.c:4755 ncrypt/pgpkey.c:751
+#: ncrypt/crypt_gpgme.c:4757 ncrypt/pgpkey.c:751
 msgid "Please enter the key ID: "
 msgstr "Zadejte ID klíče: "
 
-#: ncrypt/crypt_gpgme.c:4768
+#: ncrypt/crypt_gpgme.c:4770
 #, c-format
 msgid "Error exporting key: %s\n"
 msgstr "Chyba při exportu klíče: %s\n"
@@ -3953,80 +4027,80 @@ msgstr "Chyba při exportu klíče: %s\n"
 #. MIME description for exported (attached) keys.
 #. You can translate this entry to a non-ASCII string (it will be encoded),
 #. but it may be safer to keep it untranslated.
-#: ncrypt/crypt_gpgme.c:4787
+#: ncrypt/crypt_gpgme.c:4789
 #, c-format
 msgid "PGP Key 0x%s."
 msgstr "Klíč PGP 0x%s."
 
-#: ncrypt/crypt_gpgme.c:4830
+#: ncrypt/crypt_gpgme.c:4832
 msgid "GPGME: OpenPGP protocol not available"
 msgstr "GPGME: Protokol OpenGPG není dostupný"
 
-#: ncrypt/crypt_gpgme.c:4838
+#: ncrypt/crypt_gpgme.c:4840
 msgid "GPGME: CMS protocol not available"
 msgstr "GPGME: Protokol CMS není dostupný"
 
-#: ncrypt/crypt_gpgme.c:4876
+#: ncrypt/crypt_gpgme.c:4878
 msgid "S/MIME (s)ign, sign (a)s, (p)gp, (c)lear, or (o)ppenc mode off? "
 msgstr "S/MIME (p)odepsat, podepsat (j)ako, p(g)p, (n)ic či vypnout pří(l)ež. šifr.? "
 
 #. L10N: S/MIME options (opportunistic encryption is on)
-#: ncrypt/crypt_gpgme.c:4878
+#: ncrypt/crypt_gpgme.c:4880
 msgid "sapco"
 msgstr "pjgnl"
 
-#: ncrypt/crypt_gpgme.c:4885
+#: ncrypt/crypt_gpgme.c:4887
 msgid "PGP (s)ign, sign (a)s, s/(m)ime, (c)lear, or (o)ppenc mode off? "
 msgstr "PGP (p)odepsat, podepsat (j)ako, s/(m)ime, (n)ic či vypnout pří(l)ež. šifr.? "
 
 #. L10N: PGP options (opportunistic encryption is on)
-#: ncrypt/crypt_gpgme.c:4887
+#: ncrypt/crypt_gpgme.c:4889
 msgid "samco"
 msgstr "pjmnl"
 
 #. L10N: S/MIME options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4900
+#: ncrypt/crypt_gpgme.c:4902
 msgid "S/MIME (e)ncrypt, (s)ign, sign (a)s, (b)oth, (p)gp, (c)lear, or (o)ppenc mode? "
 msgstr "S/MIME šif(r)ovat, (p)odepsat, pod.(j)ako, (o)bojí, p(g)p, (n)ic, pří(l).šifr.? "
 
 #. L10N: S/MIME options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4903
+#: ncrypt/crypt_gpgme.c:4905
 msgid "esabpco"
 msgstr "rpjognl"
 
 #. L10N: PGP options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4909
+#: ncrypt/crypt_gpgme.c:4911
 msgid "PGP (e)ncrypt, (s)ign, sign (a)s, (b)oth, s/(m)ime, (c)lear, or (o)ppenc mode? "
 msgstr "PGP šif(r)ovat, (p)odepsat, pod.(j)ako, (o)bojí, s/(m)ime, (n)ic, pří(l).šifr.? "
 
 #. L10N: PGP options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4912
+#: ncrypt/crypt_gpgme.c:4914
 msgid "esabmco"
 msgstr "rpjomnl"
 
-#: ncrypt/crypt_gpgme.c:4925
+#: ncrypt/crypt_gpgme.c:4927
 msgid "S/MIME (e)ncrypt, (s)ign, sign (a)s, (b)oth, (p)gp or (c)lear? "
 msgstr "S/MIME šif(r)ovat, (p)odepsat, podepsat (j)ako, (o)bojí, p(g)p či (n)ic? "
 
 #. L10N: S/MIME options
-#: ncrypt/crypt_gpgme.c:4927
+#: ncrypt/crypt_gpgme.c:4929
 msgid "esabpc"
 msgstr "rpjogn"
 
-#: ncrypt/crypt_gpgme.c:4934
+#: ncrypt/crypt_gpgme.c:4936
 msgid "PGP (e)ncrypt, (s)ign, sign (a)s, (b)oth, s/(m)ime or (c)lear? "
 msgstr "PGP šif(r)ovat, (p)odepsat, podepsat (j)ako, (o)bojí, s/(m)ime, či (n)ic? "
 
 #. L10N: PGP options
-#: ncrypt/crypt_gpgme.c:4936
+#: ncrypt/crypt_gpgme.c:4938
 msgid "esabmc"
 msgstr "rpjomn"
 
-#: ncrypt/crypt_gpgme.c:5087
+#: ncrypt/crypt_gpgme.c:5089
 msgid "Failed to verify sender"
 msgstr "Odesílatele nelze ověřit"
 
-#: ncrypt/crypt_gpgme.c:5090
+#: ncrypt/crypt_gpgme.c:5092
 msgid "Failed to figure out sender"
 msgstr "Nelze určit odesílatele"
 
@@ -4417,7 +4491,7 @@ msgstr "Není definován žádný server diskusních skupin!"
 msgid "%s is an invalid news server specification!"
 msgstr "%s je neplatné zadání serveru diskusních skupin!"
 
-#: nntp.c:75 nntp.c:612 pop.c:1028 pop_lib.c:405
+#: nntp.c:75 nntp.c:612 pop.c:1031 pop_lib.c:405
 msgid "Server closed connection!"
 msgstr "Server uzavřel spojení!"
 
@@ -4575,15 +4649,18 @@ msgid "check mailboxes for new mail"
 msgstr "zjistit zda schránky obsahují novou poštu"
 
 #: opcodes.h:47
-msgid "attach file(s) to this message"
+#, fuzzy
+msgid "attach files to this message"
 msgstr "připojit soubor(-y) k této zprávě"
 
 #: opcodes.h:48
-msgid "attach message(s) to this message"
+#, fuzzy
+msgid "attach messages to this message"
 msgstr "připojit zprávy k této zprávě"
 
 #: opcodes.h:49
-msgid "attach news article(s) to this message"
+#, fuzzy
+msgid "attach news articles to this message"
 msgstr "připojit článek k této zprávě"
 
 #: opcodes.h:50
@@ -5399,7 +5476,8 @@ msgid "extract supported public keys"
 msgstr "extrahovat všechny podporované veřejné klíče"
 
 #: opcodes.h:255
-msgid "wipe passphrase(s) from memory"
+#, fuzzy
+msgid "wipe passphrases from memory"
 msgstr "odstranit všechna hesla z paměti"
 
 #: opcodes.h:259
@@ -5731,18 +5809,21 @@ msgstr "Ve schránce na POP serveru nejsou nové zprávy."
 msgid "Delete messages from server?"
 msgstr "Odstranit zprávy ze serveru?"
 
-#: pop.c:954
-#, c-format
-msgid "Reading new messages (%d bytes)..."
-msgstr "Načítám nové zprávy (počet bajtů: %d)…"
+#: pop.c:955
+#, fuzzy, c-format
+msgid "Reading new messages (%d byte)..."
+msgid_plural "Reading new messages (%d bytes)..."
+msgstr[0] "Načítám nové zprávy (počet bajtů: %d)…"
+msgstr[1] "Načítám nové zprávy (počet bajtů: %d)…"
+msgstr[2] "Načítám nové zprávy (počet bajtů: %d)…"
 
-#: pop.c:997
+#: pop.c:1000
 msgid "Error while writing mailbox!"
 msgstr "Chyba při zápisu do schránky!"
 
 #. L10N: The plural is picked by the second numerical argument, i.e.
 #. * the %d right before 'messages', i.e. the total number of messages.
-#: pop.c:1003
+#: pop.c:1006
 #, c-format
 msgid "%s [%d of %d message read]"
 msgid_plural "%s [%d of %d messages read]"
@@ -5887,47 +5968,55 @@ msgstr "Poslat rourou do: "
 msgid "I don't know how to print %s attachments!"
 msgstr "Neví se, jak vytisknout přílohy typu %s!"
 
-#: recvattach.c:841
-msgid "Print tagged attachment(s)?"
-msgstr "Vytisknout označené přílohy?"
+#. L10N: Although we now the precise number of tagged messages, we
+#. do not show it to the user.  So feel free to use a "generic
+#. plural" as plural translation if your language has one.
+#: recvattach.c:852
+#, fuzzy, c-format
+msgid "Print tagged attachment?"
+msgid_plural "Print %d tagged attachments?"
+msgstr[0] "Vytisknout označené přílohy?"
+msgstr[1] "Vytisknout označené přílohy?"
+msgstr[2] "Vytisknout označené přílohy?"
 
-#: recvattach.c:842
+#: recvattach.c:853
+#, c-format
 msgid "Print attachment?"
 msgstr "Vytisknout přílohu?"
 
-#: recvattach.c:900
+#: recvattach.c:913
 msgid "Structural changes to decrypted attachments are not supported"
 msgstr "Úprava typu souboru rozšifrovaných příloh není podporována"
 
-#: recvattach.c:1046
+#: recvattach.c:1059
 msgid "Can't decrypt encrypted message!"
 msgstr "Nemohu dešifrovat zašifrovanou zprávu!"
 
-#: recvattach.c:1172
+#: recvattach.c:1185
 msgid "Attachments"
 msgstr "Přílohy"
 
-#: recvattach.c:1210
+#: recvattach.c:1223
 msgid "There are no subparts to show!"
 msgstr "Nejsou žádné podčásti pro zobrazení!"
 
-#: recvattach.c:1265
+#: recvattach.c:1278
 msgid "Can't delete attachment from POP server."
 msgstr "Z POP serveru nelze mazat přílohy."
 
-#: recvattach.c:1274
+#: recvattach.c:1287
 msgid "Can't delete attachment from news server."
 msgstr "Nelze smazat přílohu ze serveru diskusních skupin."
 
-#: recvattach.c:1281
+#: recvattach.c:1294
 msgid "Deletion of attachments from encrypted messages is unsupported."
 msgstr "Mazání příloh ze zašifrovaných zpráv není podporováno."
 
-#: recvattach.c:1287
+#: recvattach.c:1300
 msgid "Deletion of attachments from signed messages may invalidate the signature."
 msgstr "Mazání příloh z podepsaných zpráv může zneplatnit podpis."
 
-#: recvattach.c:1305 recvattach.c:1320
+#: recvattach.c:1318 recvattach.c:1333
 msgid "Only deletion of multipart attachments is supported."
 msgstr "Podporováno je pouze mazání příloh o více částech."
 
@@ -6356,3 +6445,13 @@ msgstr "Výchzí volby:"
 #: version.c:404
 msgid "Compile options:"
 msgstr "Přeloženo s volbami:"
+
+#~ msgid "Cannot delete message(s)"
+#~ msgstr "Zprávu(-y) nelze smazat"
+
+#~ msgid "Cannot undelete message(s)"
+#~ msgstr "Zprávu(-y) nelze obnovit"
+
+#, fuzzy
+#~ msgid "messages not deleted"
+#~ msgstr "zprávy nesmazány"

--- a/po/da.po
+++ b/po/da.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neomutt-20180512\n"
 "Report-Msgid-Bugs-To: neomutt-devel@neomutt.org\n"
-"POT-Creation-Date: 2018-05-20 02:02+0000\n"
+"POT-Creation-Date: 2018-05-22 14:18+0000\n"
 "PO-Revision-Date: 2017-02-16 18:06+0100\n"
 "Last-Translator: Morten Bo Johansen <mbj@mbjnet.dk>\n"
 "Language-Team: Danish <dansk@dansk-gruppen.dk>\n"
@@ -41,7 +41,7 @@ msgstr "Vælg"
 
 #: addrbook.c:52 browser.c:75 browser.c:87 compose.c:160 compose.c:172
 #: conn/ssl.c:1041 conn/ssl_gnutls.c:793 curs_main.c:748 curs_main.c:761
-#: history.c:106 ncrypt/crypt_gpgme.c:4219 ncrypt/pgpkey.c:547
+#: history.c:106 ncrypt/crypt_gpgme.c:4221 ncrypt/pgpkey.c:547
 #: ncrypt/smime.c:477 pager.c:2141 postpone.c:65 query.c:72 recvattach.c:70
 msgid "Help"
 msgstr "Hjælp"
@@ -687,7 +687,7 @@ msgstr "Sikkerhed: "
 #. * Since it shares the row with "Encrypt with:", it should not be longer
 #. * than 15-20 character cells.
 #.
-#: compose.c:138 ncrypt/crypt_gpgme.c:4947 ncrypt/pgp.c:1786
+#: compose.c:138 ncrypt/crypt_gpgme.c:4949 ncrypt/pgp.c:1786
 #: ncrypt/smime.c:2127
 msgid "Sign as: "
 msgstr "Underskriv som: "
@@ -1226,7 +1226,7 @@ msgstr "(a)fvis, (g)odkend denne gang, (s)pring over"
 msgid "(r)eject, accept (o)nce"
 msgstr "(a)fvis, (g)odkend denne gang"
 
-#: conn/ssl.c:1039 conn/ssl_gnutls.c:791 ncrypt/crypt_gpgme.c:4213
+#: conn/ssl.c:1039 conn/ssl_gnutls.c:791 ncrypt/crypt_gpgme.c:4215
 #: ncrypt/pgpkey.c:541 ncrypt/smime.c:473
 msgid "Exit  "
 msgstr "Afslut  "
@@ -1405,11 +1405,11 @@ msgstr "Ingen brevbakke er åben."
 msgid "There are no messages."
 msgstr "Der er ingen breve."
 
-#: curs_main.c:77 mx.c:1061 pager.c:73 recvattach.c:56
+#: curs_main.c:77 mx.c:1071 pager.c:73 recvattach.c:56
 msgid "Mailbox is read-only."
 msgstr "Brevbakken er skrivebeskyttet."
 
-#: curs_main.c:79 pager.c:75 recvattach.c:1145
+#: curs_main.c:79 pager.c:75 recvattach.c:1158
 msgid "Function not permitted in attach-message mode."
 msgstr "Funktionen er ikke tilladt ved vedlægning af bilag."
 
@@ -1543,244 +1543,254 @@ msgid "That message is not visible."
 msgstr "Brevet er ikke synligt."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:1377 curs_main.c:2772 pager.c:2818
-msgid "Cannot delete message(s)"
+#. L10N: Due to the implementation details we do not know whether we
+#. delete zero, 1, 12, ... messages. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:1381 curs_main.c:2784 pager.c:2822
+#, fuzzy
+msgid "Cannot delete messages"
 msgstr "Kan ikke slette breve"
 
-#: curs_main.c:1380
+#: curs_main.c:1384
 msgid "Delete messages matching: "
 msgstr "Slet breve efter mønster: "
 
-#: curs_main.c:1421
+#: curs_main.c:1425
 msgid "No limit pattern is in effect."
 msgstr "Intet afgrænsningsmønster er i brug."
 
 #. L10N: ask for a limit to apply
-#: curs_main.c:1426
+#: curs_main.c:1430
 #, c-format
 msgid "Limit: %s"
 msgstr "Afgrænsning: %s"
 
-#: curs_main.c:1464
+#: curs_main.c:1468
 msgid "Limit to messages matching: "
 msgstr "Afgræns til breve efter mønster: "
 
-#: curs_main.c:1488
+#: curs_main.c:1492
 msgid "To view all messages, limit to \"all\"."
 msgstr "Afgræns til \"all\" for at se alle breve."
 
-#: curs_main.c:1500 pager.c:2318
+#: curs_main.c:1504 pager.c:2318
 msgid "Quit NeoMutt?"
 msgstr "Afslut NeoMutt?"
 
-#: curs_main.c:1596
+#: curs_main.c:1600
 msgid "Tag messages matching: "
 msgstr "Udvælg breve efter mønster: "
 
 #. L10N: CHECK_ACL
-#: curs_main.c:1606 curs_main.c:3203 pager.c:3137
-msgid "Cannot undelete message(s)"
+#. L10N: Due to the implementation details we do not know whether we
+#. undelete zero, 1, 12, ... messages. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:1614 curs_main.c:3223 pager.c:3145
+#, fuzzy
+msgid "Cannot undelete messages"
 msgstr "Kan ikke fortryde sletning af breve"
 
-#: curs_main.c:1609
+#: curs_main.c:1617
 msgid "Undelete messages matching: "
 msgstr "Behold breve efter mønster: "
 
-#: curs_main.c:1619
+#: curs_main.c:1627
 msgid "Untag messages matching: "
 msgstr "Fjern valg efter mønster: "
 
-#: curs_main.c:1653
+#: curs_main.c:1661
 msgid "Logged out of IMAP servers."
 msgstr "Logget ud fra IMAP-servere."
 
-#: curs_main.c:1753
+#: curs_main.c:1761
 #, fuzzy
 msgid "No virtual folder, aborting."
 msgstr "Intet emne, afbryder."
 
-#: curs_main.c:1761
+#: curs_main.c:1769
 msgid "Failed to read thread, aborting."
 msgstr ""
 
-#: curs_main.c:1793 mx.c:1458 mx.c:1475
+#: curs_main.c:1801 mx.c:1468 mx.c:1485
 #, fuzzy
 msgid "Folder doesn't support tagging, aborting."
 msgstr "SMTP-server understøtter ikke godkendelse"
 
-#: curs_main.c:1808
+#: curs_main.c:1816
 #, fuzzy
 msgid "No tag specified, aborting."
 msgstr "Intet emne, afbryder."
 
-#: curs_main.c:1820
+#: curs_main.c:1828
 #, c-format
 msgid "Update tags..."
 msgstr ""
 
-#: curs_main.c:1857
+#: curs_main.c:1865
 msgid "Failed to modify tags, aborting."
 msgstr ""
 
-#: curs_main.c:1898
+#: curs_main.c:1906
 #, fuzzy
 msgid "No query, aborting."
 msgstr "Intet emne, afbryder."
 
-#: curs_main.c:1902 curs_main.c:1922 curs_main.c:1941
+#: curs_main.c:1910 curs_main.c:1930 curs_main.c:1949
 msgid "Failed to create query, aborting."
 msgstr ""
 
-#: curs_main.c:1911 curs_main.c:1930
+#: curs_main.c:1919 curs_main.c:1938
 msgid "Windowed queries disabled."
 msgstr ""
 
-#: curs_main.c:1916 curs_main.c:1935
+#: curs_main.c:1924 curs_main.c:1943
 msgid "No notmuch vfolder currently loaded."
 msgstr ""
 
-#: curs_main.c:1973
+#: curs_main.c:1981
 msgid "Open mailbox in read-only mode"
 msgstr "Åbn brevbakke i skrivebeskyttet tilstand"
 
-#: curs_main.c:1976
+#: curs_main.c:1984
 #, fuzzy
 msgid "Open virtual folder"
 msgstr "åbn en anden brevbakke"
 
-#: curs_main.c:1979
+#: curs_main.c:1987
 msgid "Open mailbox"
 msgstr "Åbn brevbakke"
 
-#: curs_main.c:1989
+#: curs_main.c:1997
 msgid "No mailboxes have new mail"
 msgstr "Ingen brevbakker med nye breve"
 
-#: curs_main.c:2036
+#: curs_main.c:2044
 #, fuzzy
 msgid "Open newsgroup in read-only mode"
 msgstr "Åbn brevbakke i skrivebeskyttet tilstand"
 
-#: curs_main.c:2038
+#: curs_main.c:2046
 msgid "Open newsgroup"
 msgstr ""
 
-#: curs_main.c:2141
+#: curs_main.c:2149
 #, fuzzy
 msgid "Exit NeoMutt without saving?"
 msgstr "Afslut NeoMutt uden at gemme?"
 
-#: curs_main.c:2157
+#: curs_main.c:2165
 #, fuzzy
 msgid "Cannot break thread"
 msgstr "Kan ikke sammenkæde tråde"
 
-#: curs_main.c:2160 curs_main.c:2198 curs_main.c:2658 curs_main.c:2690
+#: curs_main.c:2168 curs_main.c:2206 curs_main.c:2666 curs_main.c:2698
 #: flags.c:376 thread.c:1078 thread.c:1134 thread.c:1202
 msgid "Threading is not enabled."
 msgstr "Trådning er ikke i brug."
 
-#: curs_main.c:2173
+#: curs_main.c:2181
 msgid "Thread broken"
 msgstr "Tråden er brudt"
 
-#: curs_main.c:2185
+#: curs_main.c:2193
 msgid "Thread cannot be broken, message is not part of a thread"
 msgstr "Tråden må ikke være brudt, brevet er ikke en del af en tråd"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2195
+#: curs_main.c:2203
 msgid "Cannot link threads"
 msgstr "Kan ikke sammenkæde tråde"
 
-#: curs_main.c:2200
+#: curs_main.c:2208
 msgid "No Message-ID: header available to link thread"
 msgstr "Ingen Message-ID: i brevhoved er tilgængelig til at sammenkæde tråde"
 
-#: curs_main.c:2202
+#: curs_main.c:2210
 msgid "First, please tag a message to be linked here"
 msgstr "Markér et brev til sammenkædning som det første"
 
-#: curs_main.c:2213
+#: curs_main.c:2221
 msgid "Threads linked"
 msgstr "Tråde sammenkædet"
 
-#: curs_main.c:2216
+#: curs_main.c:2224
 msgid "No thread linked"
 msgstr "Ingen tråd sammenkædet"
 
-#: curs_main.c:2252 curs_main.c:2278
+#: curs_main.c:2260 curs_main.c:2286
 msgid "You are on the last message."
 msgstr "Du er ved sidste brev."
 
-#: curs_main.c:2260 curs_main.c:2305
+#: curs_main.c:2268 curs_main.c:2313
 msgid "No undeleted messages."
 msgstr "Alle breve har slette-markering."
 
-#: curs_main.c:2297 curs_main.c:2323
+#: curs_main.c:2305 curs_main.c:2331
 msgid "You are on the first message."
 msgstr "Du er ved første brev."
 
-#: curs_main.c:2395 menu.c:970 pager.c:2440 pattern.c:2110
+#: curs_main.c:2403 menu.c:970 pager.c:2440 pattern.c:2110
 msgid "Search wrapped to top."
 msgstr "Søgning fortsat fra top."
 
-#: curs_main.c:2404 pager.c:2463 pattern.c:2121
+#: curs_main.c:2412 pager.c:2463 pattern.c:2121
 msgid "Search wrapped to bottom."
 msgstr "Søgning fortsat fra bund."
 
-#: curs_main.c:2447
+#: curs_main.c:2455
 msgid "No new messages in this limited view."
 msgstr "Ingen nye breve i denne afgrænsede oversigt."
 
-#: curs_main.c:2449
+#: curs_main.c:2457
 msgid "No new messages."
 msgstr "Ingen nye breve."
 
-#: curs_main.c:2454
+#: curs_main.c:2462
 msgid "No unread messages in this limited view."
 msgstr "Ingen ulæste breve i denne afgrænsede oversigt."
 
-#: curs_main.c:2456
+#: curs_main.c:2464
 msgid "No unread messages."
 msgstr "Ingen ulæste breve."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2474
+#: curs_main.c:2482
 msgid "Cannot flag message"
 msgstr "Kan ikke give brev statusindikator"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2513 pager.c:3100
+#: curs_main.c:2521 pager.c:3104
 msgid "Cannot toggle new"
 msgstr "Kan ikke skifte mellem ny/ikke-ny"
 
-#: curs_main.c:2590
+#: curs_main.c:2598
 msgid "No more threads."
 msgstr "Ikke flere tråde."
 
-#: curs_main.c:2592
+#: curs_main.c:2600
 msgid "You are on the first thread."
 msgstr "Du er ved den første tråd."
 
-#: curs_main.c:2676
+#: curs_main.c:2684
 #, fuzzy
 msgid "Thread contains unread or flagged messages."
 msgstr "Tråden indeholder ulæste breve."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2726 pager.c:2784
+#: curs_main.c:2734 pager.c:2784
 msgid "Cannot delete message"
 msgstr "Kan ikke slette brev"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2838
+#: curs_main.c:2850
 msgid "Cannot edit message"
 msgstr "Kan ikke redigere brev"
 
 #. L10N: This is displayed when the x-label on one or more
 #. * messages is edited.
-#: curs_main.c:2900 pager.c:3200
+#: curs_main.c:2912 pager.c:3208
 #, fuzzy, c-format
 msgid "%d label changed."
 msgid_plural "%d labels changed."
@@ -1790,52 +1800,57 @@ msgstr[1] "%d etiketter ændret."
 #. L10N: This is displayed when editing an x-label, but no messages
 #. * were updated.  Possibly due to canceling at the prompt or if the new
 #. * label is the same as the old label.
-#: curs_main.c:2907 pager.c:3204
+#: curs_main.c:2919 pager.c:3212
 msgid "No labels changed."
 msgstr "Ingen etiketter ændret."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:3006
-msgid "Cannot mark message(s) as read"
+#. L10N: Due to the implementation details we do not know whether we
+#. mark zero, 1, 12, ... messages as read. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:3022
+#, fuzzy
+msgid "Cannot mark messages as read"
 msgstr "Kan ikke markére breve som læst"
 
 #. L10N: This is the prompt for <mark-message>.  Whatever they
 #. enter will be prefixed by $mark_macro_prefix and will become
 #. a macro hotkey to jump to the currently selected message.
-#: curs_main.c:3042
+#: curs_main.c:3058
 msgid "Enter macro stroke: "
 msgstr "Tryk makro-tast: "
 
 #. L10N: "message hotkey" is the key bindings menu description of a
 #. macro created by <mark-message>.
-#: curs_main.c:3050
+#: curs_main.c:3066
 msgid "message hotkey"
 msgstr "brevets genvejstast"
 
 #. L10N: This is echoed after <mark-message> creates a new hotkey
 #. macro.  %s is the hotkey string ($mark_macro_prefix followed
 #. by whatever they typed at the prompt.)
-#: curs_main.c:3055
+#: curs_main.c:3071
 #, c-format
 msgid "Message bound to %s."
 msgstr "Brevet er tildelt %s."
 
 #. L10N: This error is printed if <mark-message> cannot find a
 #. Message-ID for the currently selected message in the index.
-#: curs_main.c:3063
+#: curs_main.c:3079
 msgid "No message ID to macro."
 msgstr "Ingen brev-ID for makro."
 
-#: curs_main.c:3105 pager.c:2961 recvattach.c:1388
+#: curs_main.c:3121 pager.c:2965 recvattach.c:1401
 msgid "Reply by mail as poster prefers?"
 msgstr ""
 
-#: curs_main.c:3108 pager.c:2927 pager.c:2939 pager.c:2964
+#: curs_main.c:3124 pager.c:2931 pager.c:2943 pager.c:2968
 msgid "Posting to this group not allowed, may be moderated. Continue?"
 msgstr ""
 
 #. L10N: CHECK_ACL
-#: curs_main.c:3173 pager.c:3120
+#: curs_main.c:3189 pager.c:3124
 msgid "Cannot undelete message"
 msgstr "Kan ikke fortryde sletning af brev"
 
@@ -2026,12 +2041,34 @@ msgstr "[-- Fejl fra autovisning af %s --]\n"
 msgid "[-- Error: message/external-body has no access-type parameter --]\n"
 msgstr "[-- Fejl: \"message/external-body\" har ingen \"access-type\"-parameter --]\n"
 
-#: handler.c:1611
+#. L10N: If the translation of this string is a multi line string, then
+#. each line should start with "[-- " and end with " --]".
+#. The first "%s/%s" is a MIME type, e.g. "text/plain". The last %s
+#. expands to a date as returned by `mutt_date_parse_date()`.
+#.
+#. Note: The size argument printed is not the actual number as passed
+#. to gettext but the prettified version, e.g. size = 2048 will be
+#. printed as 2K.  Your language might be sensitive to that: For
+#. example although '1K' and '1024' represent the same number your
+#. language might inflect the noun 'byte' differently.
+#.
+#. Sadly, we cannot do anything about that at the moment besides
+#. passing the precise size in bytes. If you are interested the
+#. function responsible for the prettification is
+#. mutt_str_pretty_size() in mutt/string.c.
+#.
+#: handler.c:1624
 #, fuzzy, c-format
 msgid ""
+"[-- This %s/%s attachment (size %s byte) has been deleted --]\n"
+"[-- on %s --]\n"
+msgid_plural ""
 "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
 "[-- on %s --]\n"
-msgstr ""
+msgstr[0] ""
+"[-- Denne %s/%s-del (på %s bytes) er blevet slettet --]\n"
+"[-- den %s --]\n"
+msgstr[1] ""
 "[-- Denne %s/%s-del (på %s bytes) er blevet slettet --]\n"
 "[-- den %s --]\n"
 
@@ -2039,10 +2076,23 @@ msgstr ""
 #. each line should start with "[-- " and end with " --]".
 #. The first "%s/%s" is a MIME type, e.g. "text/plain".
 #.
-#: handler.c:1620
+#. Note: The size argument printed is not the actual number as passed
+#. to gettext but the prettified version, e.g. size = 2048 will be
+#. printed as 2K.  Your language might be sensitive to that: For
+#. example although '1K' and '1024' represent the same number your
+#. language might inflect the noun 'byte' differently.
+#.
+#. Sadly, we cannot do anything about that at the moment besides
+#. passing the precise size in bytes. If you are interested the
+#. function responsible for the prettification is
+#. mutt_str_pretty_size() in mutt/string.c.
+#.
+#: handler.c:1648
 #, fuzzy, c-format
-msgid "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
-msgstr "[-- Denne %s/%s-del (på %s bytes) er blevet slettet --]\n"
+msgid "[-- This %s/%s attachment (size %s byte) has been deleted --]\n"
+msgid_plural "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
+msgstr[0] "[-- Denne %s/%s-del (på %s bytes) er blevet slettet --]\n"
+msgstr[1] "[-- Denne %s/%s-del (på %s bytes) er blevet slettet --]\n"
 
 #. L10N: If the translation of this string is a multi line string, then
 #. each line should start with "[-- " and end with " --]".
@@ -2052,7 +2102,7 @@ msgstr "[-- Denne %s/%s-del (på %s bytes) er blevet slettet --]\n"
 #. Caution: Argument three %3$ is also defined but should not be used
 #. in this translation!
 #.
-#: handler.c:1637
+#: handler.c:1667
 #, fuzzy
 msgid ""
 "[-- This %s/%s attachment has been deleted --]\n"
@@ -2065,17 +2115,17 @@ msgstr ""
 #. each line should start with "[-- " and end with " --]".
 #. The first "%s/%s" is a MIME type, e.g. "text/plain".
 #.
-#: handler.c:1646
+#: handler.c:1676
 #, fuzzy, c-format
 msgid "[-- This %s/%s attachment has been deleted --]\n"
 msgstr "[-- Denne %s/%s-del er blevet slettet --]\n"
 
-#: handler.c:1656
+#: handler.c:1686
 #, c-format
 msgid "[-- name: %s --]\n"
 msgstr "[-- navn %s --]\n"
 
-#: handler.c:1672
+#: handler.c:1702
 #, fuzzy, c-format
 msgid ""
 "[-- This %s/%s attachment is not included, --]\n"
@@ -2085,7 +2135,7 @@ msgstr ""
 "[-- Denne %s/%s-del er ikke medtaget, --]\n"
 "[-- og den angivne eksterne kilde findes ikke mere. --]\n"
 
-#: handler.c:1693
+#: handler.c:1723
 #, fuzzy, c-format
 msgid ""
 "[-- This %s/%s attachment is not included, --]\n"
@@ -2094,51 +2144,51 @@ msgstr ""
 "[-- Denne %s/%s-del er ikke medtaget, --]\n"
 "[-- og den angivne \"access-type\" %s er ikke understøttet --]\n"
 
-#: handler.c:1822
+#: handler.c:1852
 #, fuzzy
 msgid "Unable to open memory stream!"
 msgstr "Kan ikke åbne midlertidig fil!"
 
-#: handler.c:1831
+#: handler.c:1861
 msgid "Unable to open temporary file!"
 msgstr "Kan ikke åbne midlertidig fil!"
 
-#: handler.c:1881
+#: handler.c:1911
 msgid "failed to re-open memstream!"
 msgstr ""
 
-#: handler.c:2013
+#: handler.c:2043
 msgid "Error: multipart/signed has no protocol."
 msgstr "Fejl: \"multipart/signed\" har ingen \"protocol\"-parameter."
 
-#: handler.c:2076
+#: handler.c:2106
 #, fuzzy
 msgid "[-- This is an attachment (use '%3$s' to view this part) --]\n"
 msgstr "[-- Dette er et bilag (brug '%3$s' for vise denne brevdel) --]\n"
 
-#: handler.c:2082
+#: handler.c:2112
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported (use '%s' to view this part) --]\n"
 msgstr "[-- %s/%s er ikke understøttet (brug '%s' for vise denne brevdel) --]\n"
 
-#: handler.c:2087
+#: handler.c:2117
 #, fuzzy
 msgid "[-- This is an attachment (need 'view-attachments' bound to key!) --]\n"
 msgstr "[-- Dette er et bilag ('view-attachments' må tildeles en tast!) --]\n"
 
 #. L10N: %s/%s is a MIME type, e.g. "text/plain".
-#: handler.c:2091
+#: handler.c:2121
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported (need 'view-attachments' bound to key!) --]\n"
 msgstr "[-- %s/%s er ikke understøttet ('view-attachments' må tildeles en tast!) --]\n"
 
-#: handler.c:2098
+#: handler.c:2128
 #, fuzzy
 msgid "[-- This is an attachment --]\n"
 msgstr "[-- Dette er et bilag --]\n"
 
 #. L10N: %s/%s is a MIME type, e.g. "text/plain".
-#: handler.c:2101
+#: handler.c:2131
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported --]\n"
 msgstr "[-- %s/%s er ikke understøttet --]\n"
@@ -2444,7 +2494,7 @@ msgstr "SMTP-server understøtter ikke godkendelse"
 msgid "Invalid IMAP flags"
 msgstr "Ugyldigt   "
 
-#: imap/message.c:477 mx.c:1326
+#: imap/message.c:477 mx.c:1336
 msgid "Integer overflow -- can't allocate memory."
 msgstr "Heltals-overløb, kan ikke tildele hukommelse."
 
@@ -3207,64 +3257,74 @@ msgstr "SSL er ikke tilgængelig."
 msgid "Reading from %s interrupted..."
 msgstr "Søgning afbrudt."
 
-#: mx.c:634
-msgid "message(s) not deleted"
-msgstr "brev(e) som ikke blev slettet"
+#. L10N: Although we now the precise number of messages, we do not show it to the user.
+#. So feel free to use a "generic plural" as plural translation if your language has one.
+#.
+#: mx.c:639
+#, fuzzy
+msgid "message not deleted"
+msgid_plural "messages not deleted"
+msgstr[0] "brev(e) som ikke blev slettet"
+msgstr[1] "brev(e) som ikke blev slettet"
 
-#: mx.c:671
+#: mx.c:676
 msgid "Can't open trash folder"
 msgstr "Kan ikke åbne papirkurv"
 
-#: mx.c:710
+#: mx.c:715
 msgid "Mark all articles read?"
 msgstr ""
 
-#: mx.c:754
-#, c-format
-msgid "Move %d read messages to %s?"
-msgstr "Flyt %d læste breve til %s?"
+#. L10N: The first argument is the number of read messages to be
+#. moved, the second argument is the target mailbox.
+#: mx.c:762
+#, fuzzy, c-format
+msgid "Move %d read message to %s?"
+msgid_plural "Move %d read messages to %s?"
+msgstr[0] "Flyt %d læste breve til %s?"
+msgstr[1] "Flyt %d læste breve til %s?"
 
-#: mx.c:771 mx.c:1077
+#: mx.c:781 mx.c:1087
 #, fuzzy, c-format
 msgid "Purge %d deleted message?"
 msgid_plural "Purge %d deleted messages?"
 msgstr[0] "Fjern %d slettet brev?"
 msgstr[1] "Fjern %d slettede breve?"
 
-#: mx.c:793
+#: mx.c:803
 #, c-format
 msgid "Moving read messages to %s..."
 msgstr "Flytter læste breve til %s ..."
 
-#: mx.c:859 mx.c:1068
+#: mx.c:869 mx.c:1078
 msgid "Mailbox is unchanged."
 msgstr "Brevbakken er uændret."
 
-#: mx.c:914
+#: mx.c:924
 #, c-format
 msgid "%d kept, %d moved, %d deleted."
 msgstr "%d beholdt, %d flyttet, %d slettet."
 
-#: mx.c:917 mx.c:1130
+#: mx.c:927 mx.c:1140
 #, c-format
 msgid "%d kept, %d deleted."
 msgstr "%d beholdt, %d slettet."
 
-#: mx.c:1052
+#: mx.c:1062
 #, c-format
 msgid " Press '%s' to toggle write"
 msgstr " Tast '%s' for at skifte til/fra skrivebeskyttet tilstand"
 
-#: mx.c:1054
+#: mx.c:1064
 msgid "Use 'toggle-write' to re-enable write!"
 msgstr "Brug 'toggle-write' for at muliggøre skrivning!"
 
-#: mx.c:1056
+#: mx.c:1066
 #, c-format
 msgid "Mailbox is marked unwritable. %s"
 msgstr "Brevbakken er skrivebeskyttet. %s"
 
-#: mx.c:1124
+#: mx.c:1134
 msgid "Mailbox checkpointed."
 msgstr "Brevbakke opdateret."
 
@@ -3278,54 +3338,59 @@ msgstr " (aktuelt tidspunkt: %c)"
 msgid "[-- %s output follows%s --]\n"
 msgstr "[-- %s uddata følger%s --]\n"
 
-#: ncrypt/crypt.c:95
-msgid "Passphrase(s) forgotten."
+#. L10N: Due to the implementation details (e.g. some passwords are managed
+#. by gpg-agent) we cannot know whether we forgot zero, 1, 12, ...
+#. passwords. So in English we use "Passphrases". Your language might
+#. have other means to express this.
+#: ncrypt/crypt.c:100
+#, fuzzy
+msgid "Passphrases forgotten."
 msgstr "Har glemt løsen(er)."
 
-#: ncrypt/crypt.c:155
+#: ncrypt/crypt.c:161
 msgid "Inline PGP can't be used with attachments.  Revert to PGP/MIME?"
 msgstr "Integreret PGP kan ikke bruges sammen med bilag. Brug PGP/MIME i stedet?"
 
-#: ncrypt/crypt.c:159
+#: ncrypt/crypt.c:165
 msgid "Mail not sent: inline PGP can't be used with attachments."
 msgstr "Brev ikke sendt: integreret PGP kan ikke bruges sammen med bilag."
 
-#: ncrypt/crypt.c:166
+#: ncrypt/crypt.c:172
 #, fuzzy
 msgid "Inline PGP can't be used with format=flowed.  Revert to PGP/MIME?"
 msgstr "Integreret PGP kan ikke bruges sammen med format=flowed. Brug PGP/MIME i stedet?"
 
-#: ncrypt/crypt.c:170
+#: ncrypt/crypt.c:176
 #, fuzzy
 msgid "Mail not sent: inline PGP can't be used with format=flowed."
 msgstr "Brev ikke sendt: integreret PGP kan ikke bruges sammen med format=flowed."
 
-#: ncrypt/crypt.c:180 ncrypt/cryptglue.c:125 ncrypt/pgpkey.c:589
+#: ncrypt/crypt.c:186 ncrypt/cryptglue.c:125 ncrypt/pgpkey.c:589
 #: ncrypt/pgpkey.c:782
 msgid "Invoking PGP..."
 msgstr "Starter PGP ..."
 
-#: ncrypt/crypt.c:192
+#: ncrypt/crypt.c:198
 msgid "Message can't be sent inline.  Revert to using PGP/MIME?"
 msgstr "Brevet kan ikke sendes integreret. Brug PGP/MIME i stedet?"
 
-#: ncrypt/crypt.c:194 send.c:1824
+#: ncrypt/crypt.c:200 send.c:1824
 msgid "Mail not sent."
 msgstr "Brev ikke sendt."
 
-#: ncrypt/crypt.c:540
+#: ncrypt/crypt.c:546
 msgid "S/MIME messages with no hints on content are unsupported."
 msgstr "S/MIME-breve uden antydning om indhold er ikke understøttet."
 
-#: ncrypt/crypt.c:754 ncrypt/crypt.c:795
+#: ncrypt/crypt.c:760 ncrypt/crypt.c:801
 msgid "Trying to extract PGP keys...\n"
 msgstr "Forsøger at udtrække PGP-nøgler ...\n"
 
-#: ncrypt/crypt.c:776 ncrypt/crypt.c:816
+#: ncrypt/crypt.c:782 ncrypt/crypt.c:822
 msgid "Trying to extract S/MIME certificates...\n"
 msgstr "Forsøger at udtrække S/MIME-certifikater ...\n"
 
-#: ncrypt/crypt.c:976
+#: ncrypt/crypt.c:982
 #, c-format
 msgid ""
 "[-- Error: Unknown multipart/signed protocol %s! --]\n"
@@ -3334,7 +3399,7 @@ msgstr ""
 "[-- Fejl: Ukendt \"multipart/signed\" protokol %s! --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1016
+#: ncrypt/crypt.c:1022
 #, fuzzy
 msgid ""
 "[-- Error: Missing or bad-format multipart/signed signature! --]\n"
@@ -3343,14 +3408,14 @@ msgstr ""
 "[-- Fejl: Inkonsistent \"multipart/signed\" struktur! --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1058
+#: ncrypt/crypt.c:1064
 #, c-format
 msgid ""
 "[-- Warning: We can't verify %s/%s signatures. --]\n"
 "\n"
 msgstr "[-- Advarsel: %s/%s underskrifter kan ikke kontrolleres. --]\n"
 
-#: ncrypt/crypt.c:1070
+#: ncrypt/crypt.c:1076
 msgid ""
 "[-- The following data is signed --]\n"
 "\n"
@@ -3358,13 +3423,13 @@ msgstr ""
 "[-- Følgende data er underskrevet --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1075
+#: ncrypt/crypt.c:1081
 msgid ""
 "[-- Warning: Can't find any signatures. --]\n"
 "\n"
 msgstr "[-- Advarsel: Kan ikke finde nogen underskrifter. --]\n"
 
-#: ncrypt/crypt.c:1081
+#: ncrypt/crypt.c:1087
 msgid ""
 "\n"
 "[-- End of signed data --]\n"
@@ -3415,7 +3480,7 @@ msgstr ""
 msgid "error reading data object: %s\n"
 msgstr "fejl ved læsning af dataobjekt: %s\n"
 
-#: ncrypt/crypt_gpgme.c:662 ncrypt/crypt_gpgme.c:3848 ncrypt/pgpkey.c:585
+#: ncrypt/crypt_gpgme.c:662 ncrypt/crypt_gpgme.c:3850 ncrypt/pgpkey.c:585
 #: ncrypt/pgpkey.c:768
 msgid "Can't create temporary file"
 msgstr "Kan ikke oprette midlertidig fil"
@@ -3755,28 +3820,30 @@ msgstr "[Ugyldigt]"
 
 #. L10N: This is printed after "Key Type: " and looks like this:
 #. *       PGP, 2048 bit RSA
-#: ncrypt/crypt_gpgme.c:3670 ncrypt/crypt_gpgme.c:3808
-#, c-format
+#: ncrypt/crypt_gpgme.c:3670 ncrypt/crypt_gpgme.c:3810
+#, fuzzy, c-format
 msgid "%s, %lu bit %s\n"
-msgstr "%s, %lu-bit %s\n"
+msgid_plural "%s, %lu bit %s\n"
+msgstr[0] "%s, %lu-bit %s\n"
+msgstr[1] "%s, %lu-bit %s\n"
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3678 ncrypt/crypt_gpgme.c:3815
+#: ncrypt/crypt_gpgme.c:3678 ncrypt/crypt_gpgme.c:3817
 msgid "encryption"
 msgstr "kryptering"
 
 #: ncrypt/crypt_gpgme.c:3679 ncrypt/crypt_gpgme.c:3685
-#: ncrypt/crypt_gpgme.c:3816 ncrypt/crypt_gpgme.c:3821
+#: ncrypt/crypt_gpgme.c:3818 ncrypt/crypt_gpgme.c:3823
 msgid ", "
 msgstr ", "
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3684 ncrypt/crypt_gpgme.c:3820
+#: ncrypt/crypt_gpgme.c:3684 ncrypt/crypt_gpgme.c:3822
 msgid "signing"
 msgstr "underskrivning"
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3690 ncrypt/crypt_gpgme.c:3825
+#: ncrypt/crypt_gpgme.c:3690 ncrypt/crypt_gpgme.c:3827
 msgid "certification"
 msgstr "certificering"
 
@@ -3795,64 +3862,64 @@ msgstr "[Udløbet]"
 msgid "[Disabled]"
 msgstr "[Deaktiveret]"
 
-#: ncrypt/crypt_gpgme.c:3851
+#: ncrypt/crypt_gpgme.c:3853
 msgid "Collecting data..."
 msgstr "Samler data ..."
 
-#: ncrypt/crypt_gpgme.c:3876
+#: ncrypt/crypt_gpgme.c:3878
 #, c-format
 msgid "Error finding issuer key: %s\n"
 msgstr "Kunne ikke finde udsteders nøgle: %s\n"
 
-#: ncrypt/crypt_gpgme.c:3885
+#: ncrypt/crypt_gpgme.c:3887
 msgid "Error: certification chain too long - stopping here\n"
 msgstr "Fejl: certificeringskæde er for lang - stopper her\n"
 
-#: ncrypt/crypt_gpgme.c:3895 ncrypt/pgpkey.c:608
+#: ncrypt/crypt_gpgme.c:3897 ncrypt/pgpkey.c:608
 #, c-format
 msgid "Key ID: 0x%s"
 msgstr "Nøgle-id: 0x%s"
 
-#: ncrypt/crypt_gpgme.c:3990
+#: ncrypt/crypt_gpgme.c:3992
 #, c-format
 msgid "gpgme_new failed: %s"
 msgstr "gpgme_new fejlede: %s"
 
-#: ncrypt/crypt_gpgme.c:4028 ncrypt/crypt_gpgme.c:4079
+#: ncrypt/crypt_gpgme.c:4030 ncrypt/crypt_gpgme.c:4081
 #, c-format
 msgid "gpgme_op_keylist_start failed: %s"
 msgstr "gpgme_op_keylist_start fejlede: %s"
 
-#: ncrypt/crypt_gpgme.c:4067 ncrypt/crypt_gpgme.c:4109
+#: ncrypt/crypt_gpgme.c:4069 ncrypt/crypt_gpgme.c:4111
 #, c-format
 msgid "gpgme_op_keylist_next failed: %s"
 msgstr "gpgme_op_keylist_next fejlede: %s"
 
-#: ncrypt/crypt_gpgme.c:4185
+#: ncrypt/crypt_gpgme.c:4187
 msgid "All matching keys are marked expired/revoked."
 msgstr "Alle matchende nøgler er markeret som udløbet/tilbagekaldt."
 
-#: ncrypt/crypt_gpgme.c:4215 ncrypt/pgpkey.c:543 ncrypt/smime.c:475
+#: ncrypt/crypt_gpgme.c:4217 ncrypt/pgpkey.c:543 ncrypt/smime.c:475
 msgid "Select  "
 msgstr "Udvælg  "
 
-#: ncrypt/crypt_gpgme.c:4217 ncrypt/pgpkey.c:545
+#: ncrypt/crypt_gpgme.c:4219 ncrypt/pgpkey.c:545
 msgid "Check key  "
 msgstr "Undersøg nøgle  "
 
-#: ncrypt/crypt_gpgme.c:4233
+#: ncrypt/crypt_gpgme.c:4235
 msgid "PGP and S/MIME keys matching"
 msgstr "PGP- og S/MIME-nøgler som matcher"
 
-#: ncrypt/crypt_gpgme.c:4235
+#: ncrypt/crypt_gpgme.c:4237
 msgid "PGP keys matching"
 msgstr "PGP-nøgler som matcher"
 
-#: ncrypt/crypt_gpgme.c:4237
+#: ncrypt/crypt_gpgme.c:4239
 msgid "S/MIME keys matching"
 msgstr "S/MIME-nøgler som matcher"
 
-#: ncrypt/crypt_gpgme.c:4239
+#: ncrypt/crypt_gpgme.c:4241
 msgid "keys matching"
 msgstr "nøgler som matcher"
 
@@ -3860,69 +3927,69 @@ msgstr "nøgler som matcher"
 #. %1$s is one of the previous four entries.
 #. %2$s is an address.
 #. e.g. "S/MIME keys matching <me@mutt.org>."
-#: ncrypt/crypt_gpgme.c:4246
+#: ncrypt/crypt_gpgme.c:4248
 #, c-format
 msgid "%s <%s>."
 msgstr "%s <%s>."
 
 #. L10N:
 #. e.g. 'S/MIME keys matching "Michael Elkins".'
-#: ncrypt/crypt_gpgme.c:4250
+#: ncrypt/crypt_gpgme.c:4252
 #, c-format
 msgid "%s \"%s\"."
 msgstr "%s \"%s\"."
 
-#: ncrypt/crypt_gpgme.c:4277 ncrypt/pgpkey.c:628
+#: ncrypt/crypt_gpgme.c:4279 ncrypt/pgpkey.c:628
 msgid "This key can't be used: expired/disabled/revoked."
 msgstr "Denne nøgle kan ikke bruges: udløbet/sat ud af kraft/tilbagekaldt."
 
-#: ncrypt/crypt_gpgme.c:4290 ncrypt/pgpkey.c:640 ncrypt/smime.c:505
+#: ncrypt/crypt_gpgme.c:4292 ncrypt/pgpkey.c:640 ncrypt/smime.c:505
 #, fuzzy
 msgid "ID is expired/disabled/revoked. Do you really want to use the key?"
 msgstr "Id er udløbet/ugyldig/ophævet. Vil du virkelig anvende nøglen?"
 
-#: ncrypt/crypt_gpgme.c:4299 ncrypt/pgpkey.c:650
+#: ncrypt/crypt_gpgme.c:4301 ncrypt/pgpkey.c:650
 #, fuzzy
 msgid "ID is not valid. Do you really want to use the key?"
 msgstr "Id er ikke bevist ægte. Vil du virkelig anvende nøglen?"
 
-#: ncrypt/crypt_gpgme.c:4302 ncrypt/pgpkey.c:653
+#: ncrypt/crypt_gpgme.c:4304 ncrypt/pgpkey.c:653
 #, fuzzy
 msgid "ID is only marginally valid. Do you really want to use the key?"
 msgstr "Id er kun bevist marginalt ægte. Vil du virkelig anvende nøglen?"
 
-#: ncrypt/crypt_gpgme.c:4310 ncrypt/pgpkey.c:646 ncrypt/smime.c:509
+#: ncrypt/crypt_gpgme.c:4312 ncrypt/pgpkey.c:646 ncrypt/smime.c:509
 #, fuzzy
 msgid "ID has undefined validity. Do you really want to use the key?"
 msgstr "Ægthed af id er ubestemt. Vil du virkelig anvende nøglen?"
 
-#: ncrypt/crypt_gpgme.c:4370 ncrypt/crypt_gpgme.c:4479 ncrypt/pgpkey.c:872
+#: ncrypt/crypt_gpgme.c:4372 ncrypt/crypt_gpgme.c:4481 ncrypt/pgpkey.c:872
 #: ncrypt/pgpkey.c:995
 #, c-format
 msgid "Looking for keys matching \"%s\"..."
 msgstr "Leder efter nøgler, der matcher \"%s\"..."
 
-#: ncrypt/crypt_gpgme.c:4593 ncrypt/pgpkey.c:731 ncrypt/smime.c:811
+#: ncrypt/crypt_gpgme.c:4595 ncrypt/pgpkey.c:731 ncrypt/smime.c:811
 #, c-format
 msgid "No matching keys found for \"%s\""
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4644 ncrypt/pgp.c:1263
+#: ncrypt/crypt_gpgme.c:4646 ncrypt/pgp.c:1263
 #, c-format
 msgid "Use keyID = \"%s\" for %s?"
 msgstr "Anvend nøgle-id = \"%s\" for %s?"
 
-#: ncrypt/crypt_gpgme.c:4695 ncrypt/pgp.c:1312 ncrypt/smime.c:830
+#: ncrypt/crypt_gpgme.c:4697 ncrypt/pgp.c:1312 ncrypt/smime.c:830
 #: ncrypt/smime.c:938
 #, c-format
 msgid "Enter keyID for %s: "
 msgstr "Anfør nøgle-id for %s: "
 
-#: ncrypt/crypt_gpgme.c:4755 ncrypt/pgpkey.c:751
+#: ncrypt/crypt_gpgme.c:4757 ncrypt/pgpkey.c:751
 msgid "Please enter the key ID: "
 msgstr "Anfør venligst nøgle-id: "
 
-#: ncrypt/crypt_gpgme.c:4768
+#: ncrypt/crypt_gpgme.c:4770
 #, c-format
 msgid "Error exporting key: %s\n"
 msgstr "Fejl ved eksportering af nøgle: %s\n"
@@ -3931,84 +3998,84 @@ msgstr "Fejl ved eksportering af nøgle: %s\n"
 #. MIME description for exported (attached) keys.
 #. You can translate this entry to a non-ASCII string (it will be encoded),
 #. but it may be safer to keep it untranslated.
-#: ncrypt/crypt_gpgme.c:4787
+#: ncrypt/crypt_gpgme.c:4789
 #, c-format
 msgid "PGP Key 0x%s."
 msgstr "PGP-nøgle 0x%s."
 
-#: ncrypt/crypt_gpgme.c:4830
+#: ncrypt/crypt_gpgme.c:4832
 msgid "GPGME: OpenPGP protocol not available"
 msgstr "GPGME: OpenPGP-protokol utilgængelig"
 
-#: ncrypt/crypt_gpgme.c:4838
+#: ncrypt/crypt_gpgme.c:4840
 msgid "GPGME: CMS protocol not available"
 msgstr "GPGME: CMS-protokol utilgængelig"
 
-#: ncrypt/crypt_gpgme.c:4876
+#: ncrypt/crypt_gpgme.c:4878
 msgid "S/MIME (s)ign, sign (a)s, (p)gp, (c)lear, or (o)ppenc mode off? "
 msgstr "S/MIME (u)nderskriv, underskriv (s)om, (p)gp, r(y)d eller (o)ppenc-tilstand fra? "
 
 #. L10N: S/MIME options (opportunistic encryption is on)
-#: ncrypt/crypt_gpgme.c:4878
+#: ncrypt/crypt_gpgme.c:4880
 msgid "sapco"
 msgstr "uspyo"
 
-#: ncrypt/crypt_gpgme.c:4885
+#: ncrypt/crypt_gpgme.c:4887
 msgid "PGP (s)ign, sign (a)s, s/(m)ime, (c)lear, or (o)ppenc mode off? "
 msgstr "PGP (u)nderskriv, underskriv (s)om, s/(m)ime, r(y)d eller (o)ppenc-tilstand fra? "
 
 #. L10N: PGP options (opportunistic encryption is on)
-#: ncrypt/crypt_gpgme.c:4887
+#: ncrypt/crypt_gpgme.c:4889
 msgid "samco"
 msgstr "usmyo"
 
 #. L10N: S/MIME options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4900
+#: ncrypt/crypt_gpgme.c:4902
 msgid "S/MIME (e)ncrypt, (s)ign, sign (a)s, (b)oth, (p)gp, (c)lear, or (o)ppenc mode? "
 msgstr "S/MIME (k)ryptér, (u)nderskriv, underskriv (s)om, (b)egge, (p)gp, r(y)d eller (o)ppenc-tilstand fra? "
 
 #. L10N: S/MIME options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4903
+#: ncrypt/crypt_gpgme.c:4905
 #, fuzzy
 msgid "esabpco"
 msgstr "kusbpyo"
 
 #. L10N: PGP options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4909
+#: ncrypt/crypt_gpgme.c:4911
 msgid "PGP (e)ncrypt, (s)ign, sign (a)s, (b)oth, s/(m)ime, (c)lear, or (o)ppenc mode? "
 msgstr "PGP (k)ryptér, (u)nderskriv, underskriv (s)om, (b)egge, s/(m)ime, r(y)d eller (o)ppenc-tilstand? "
 
 #. L10N: PGP options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4912
+#: ncrypt/crypt_gpgme.c:4914
 #, fuzzy
 msgid "esabmco"
 msgstr "kusbmyo"
 
-#: ncrypt/crypt_gpgme.c:4925
+#: ncrypt/crypt_gpgme.c:4927
 msgid "S/MIME (e)ncrypt, (s)ign, sign (a)s, (b)oth, (p)gp or (c)lear? "
 msgstr "S/MIME (k)ryptér, (u)nderskriv, underskriv (s)om, (b)egge, (p)gp, eller r(y)d? "
 
 #. L10N: S/MIME options
-#: ncrypt/crypt_gpgme.c:4927
+#: ncrypt/crypt_gpgme.c:4929
 #, fuzzy
 msgid "esabpc"
 msgstr "kusbpy"
 
-#: ncrypt/crypt_gpgme.c:4934
+#: ncrypt/crypt_gpgme.c:4936
 msgid "PGP (e)ncrypt, (s)ign, sign (a)s, (b)oth, s/(m)ime or (c)lear? "
 msgstr "PGP (k)ryptér, (u)nderskriv, underskriv (s)om, (b)egge, s/(m)ime, eller r(y)d? "
 
 #. L10N: PGP options
-#: ncrypt/crypt_gpgme.c:4936
+#: ncrypt/crypt_gpgme.c:4938
 #, fuzzy
 msgid "esabmc"
 msgstr "kusbmy"
 
-#: ncrypt/crypt_gpgme.c:5087
+#: ncrypt/crypt_gpgme.c:5089
 msgid "Failed to verify sender"
 msgstr "Kunne ikke verificere afsender"
 
-#: ncrypt/crypt_gpgme.c:5090
+#: ncrypt/crypt_gpgme.c:5092
 msgid "Failed to figure out sender"
 msgstr "Kunne ikke bestemme afsender"
 
@@ -4403,7 +4470,7 @@ msgstr ""
 msgid "%s is an invalid news server specification!"
 msgstr "%s er en ugyldig POP-sti"
 
-#: nntp.c:75 nntp.c:612 pop.c:1028 pop_lib.c:405
+#: nntp.c:75 nntp.c:612 pop.c:1031 pop_lib.c:405
 msgid "Server closed connection!"
 msgstr "Serveren afbrød forbindelsen!"
 
@@ -4569,16 +4636,18 @@ msgid "check mailboxes for new mail"
 msgstr "undersøg brevbakker for nye breve"
 
 #: opcodes.h:47
-msgid "attach file(s) to this message"
+#, fuzzy
+msgid "attach files to this message"
 msgstr "vedlæg fil(er) til dette brev"
 
 #: opcodes.h:48
-msgid "attach message(s) to this message"
+#, fuzzy
+msgid "attach messages to this message"
 msgstr "vedlæg breve til dette brev"
 
 #: opcodes.h:49
 #, fuzzy
-msgid "attach news article(s) to this message"
+msgid "attach news articles to this message"
 msgstr "vedlæg fil(er) til dette brev"
 
 #: opcodes.h:50
@@ -5418,7 +5487,8 @@ msgid "extract supported public keys"
 msgstr "udtræk understøttede offentlige nøgler"
 
 #: opcodes.h:255
-msgid "wipe passphrase(s) from memory"
+#, fuzzy
+msgid "wipe passphrases from memory"
 msgstr "fjern løsen(er) fra hukommelse"
 
 #: opcodes.h:259
@@ -5755,18 +5825,20 @@ msgstr "Ingen nye breve på POP-serveren."
 msgid "Delete messages from server?"
 msgstr "Slet breve på server?"
 
-#: pop.c:954
-#, c-format
-msgid "Reading new messages (%d bytes)..."
-msgstr "Indlæser nye breve (%d bytes) ..."
+#: pop.c:955
+#, fuzzy, c-format
+msgid "Reading new messages (%d byte)..."
+msgid_plural "Reading new messages (%d bytes)..."
+msgstr[0] "Indlæser nye breve (%d bytes) ..."
+msgstr[1] "Indlæser nye breve (%d bytes) ..."
 
-#: pop.c:997
+#: pop.c:1000
 msgid "Error while writing mailbox!"
 msgstr "Fejl ved skrivning til brevbakke!"
 
 #. L10N: The plural is picked by the second numerical argument, i.e.
 #. * the %d right before 'messages', i.e. the total number of messages.
-#: pop.c:1003
+#: pop.c:1006
 #, fuzzy, c-format
 msgid "%s [%d of %d message read]"
 msgid_plural "%s [%d of %d messages read]"
@@ -5910,48 +5982,55 @@ msgstr "Overfør til kommando (pipe): "
 msgid "I don't know how to print %s attachments!"
 msgstr "Jeg ved ikke hvordan man udskriver %s-brevdele!"
 
-#: recvattach.c:841
-msgid "Print tagged attachment(s)?"
-msgstr "Udskriv udvalgte brevdel(e)?"
+#. L10N: Although we now the precise number of tagged messages, we
+#. do not show it to the user.  So feel free to use a "generic
+#. plural" as plural translation if your language has one.
+#: recvattach.c:852
+#, fuzzy, c-format
+msgid "Print tagged attachment?"
+msgid_plural "Print %d tagged attachments?"
+msgstr[0] "Udskriv udvalgte brevdel(e)?"
+msgstr[1] "Udskriv udvalgte brevdel(e)?"
 
-#: recvattach.c:842
+#: recvattach.c:853
+#, c-format
 msgid "Print attachment?"
 msgstr "Udskriv brevdel?"
 
-#: recvattach.c:900
+#: recvattach.c:913
 msgid "Structural changes to decrypted attachments are not supported"
 msgstr "Strukturelle ændringer i dekrypterede bilag understøttes ikke"
 
-#: recvattach.c:1046
+#: recvattach.c:1059
 msgid "Can't decrypt encrypted message!"
 msgstr "Kan ikke dekryptere krypteret brev!"
 
-#: recvattach.c:1172
+#: recvattach.c:1185
 msgid "Attachments"
 msgstr "Brevdele"
 
-#: recvattach.c:1210
+#: recvattach.c:1223
 msgid "There are no subparts to show!"
 msgstr "Der er ingen underdele at vise!"
 
-#: recvattach.c:1265
+#: recvattach.c:1278
 msgid "Can't delete attachment from POP server."
 msgstr "Kan ikke slette bilag fra POP-server."
 
-#: recvattach.c:1274
+#: recvattach.c:1287
 #, fuzzy
 msgid "Can't delete attachment from news server."
 msgstr "Kan ikke slette bilag fra POP-server."
 
-#: recvattach.c:1281
+#: recvattach.c:1294
 msgid "Deletion of attachments from encrypted messages is unsupported."
 msgstr "Sletning af brevdele fra krypterede breve er ikke understøttet."
 
-#: recvattach.c:1287
+#: recvattach.c:1300
 msgid "Deletion of attachments from signed messages may invalidate the signature."
 msgstr "Sletning af brevdele fra underskrevne breve kan gøre underskriften ugyldig."
 
-#: recvattach.c:1305 recvattach.c:1320
+#: recvattach.c:1318 recvattach.c:1333
 msgid "Only deletion of multipart attachments is supported."
 msgstr "Sletning af brevdele fra udelte breve er ikke understøttet."
 
@@ -6384,3 +6463,13 @@ msgstr "Tilvalg ved oversættelsen:"
 #: version.c:404
 msgid "Compile options:"
 msgstr "Tilvalg ved oversættelsen:"
+
+#~ msgid "Cannot delete message(s)"
+#~ msgstr "Kan ikke slette breve"
+
+#~ msgid "Cannot undelete message(s)"
+#~ msgstr "Kan ikke fortryde sletning af breve"
+
+#, fuzzy
+#~ msgid "messages not deleted"
+#~ msgstr "brev(e) som ikke blev slettet"

--- a/po/de.po
+++ b/po/de.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neomutt-20180512\n"
 "Report-Msgid-Bugs-To: neomutt-devel@neomutt.org\n"
-"POT-Creation-Date: 2018-05-20 02:02+0000\n"
+"POT-Creation-Date: 2018-05-22 14:18+0000\n"
 "PO-Revision-Date: 2018-05-09 23:58+0200\n"
 "Last-Translator: Floyd Anderson <f.a@31c0.net>\n"
 "Language-Team: none\n"
@@ -44,7 +44,7 @@ msgstr "Auswählen"
 
 #: addrbook.c:52 browser.c:75 browser.c:87 compose.c:160 compose.c:172
 #: conn/ssl.c:1041 conn/ssl_gnutls.c:793 curs_main.c:748 curs_main.c:761
-#: history.c:106 ncrypt/crypt_gpgme.c:4219 ncrypt/pgpkey.c:547
+#: history.c:106 ncrypt/crypt_gpgme.c:4221 ncrypt/pgpkey.c:547
 #: ncrypt/smime.c:477 pager.c:2141 postpone.c:65 query.c:72 recvattach.c:70
 msgid "Help"
 msgstr "Hilfe"
@@ -664,7 +664,7 @@ msgstr "Sicherheit: "
 #. * Since it shares the row with "Encrypt with:", it should not be longer
 #. * than 15-20 character cells.
 #.
-#: compose.c:138 ncrypt/crypt_gpgme.c:4947 ncrypt/pgp.c:1786
+#: compose.c:138 ncrypt/crypt_gpgme.c:4949 ncrypt/pgp.c:1786
 #: ncrypt/smime.c:2127
 msgid "Sign as: "
 msgstr "Signiere als: "
@@ -1193,7 +1193,7 @@ msgstr "(z)urückweisen, (e)inmal akzeptieren, über(g)ehen"
 msgid "(r)eject, accept (o)nce"
 msgstr "(z)urückweisen, (e)inmal akzeptieren"
 
-#: conn/ssl.c:1039 conn/ssl_gnutls.c:791 ncrypt/crypt_gpgme.c:4213
+#: conn/ssl.c:1039 conn/ssl_gnutls.c:791 ncrypt/crypt_gpgme.c:4215
 #: ncrypt/pgpkey.c:541 ncrypt/smime.c:473
 msgid "Exit  "
 msgstr "Ende  "
@@ -1372,11 +1372,11 @@ msgstr "Keine Mailbox ist geöffnet."
 msgid "There are no messages."
 msgstr "Es sind keine Nachrichten vorhanden."
 
-#: curs_main.c:77 mx.c:1061 pager.c:73 recvattach.c:56
+#: curs_main.c:77 mx.c:1071 pager.c:73 recvattach.c:56
 msgid "Mailbox is read-only."
 msgstr "Mailbox ist schreibgeschützt."
 
-#: curs_main.c:79 pager.c:75 recvattach.c:1145
+#: curs_main.c:79 pager.c:75 recvattach.c:1158
 msgid "Function not permitted in attach-message mode."
 msgstr "Funktion steht beim Anhängen von Nachrichten nicht zur Verfügung."
 
@@ -1506,235 +1506,245 @@ msgid "That message is not visible."
 msgstr "Diese Nachricht ist nicht sichtbar."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:1377 curs_main.c:2772 pager.c:2818
-msgid "Cannot delete message(s)"
+#. L10N: Due to the implementation details we do not know whether we
+#. delete zero, 1, 12, ... messages. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:1381 curs_main.c:2784 pager.c:2822
+#, fuzzy
+msgid "Cannot delete messages"
 msgstr "Kann Nachricht(en) nicht entfernen"
 
-#: curs_main.c:1380
+#: curs_main.c:1384
 msgid "Delete messages matching: "
 msgstr "Lösche Nachrichten nach Muster: "
 
-#: curs_main.c:1421
+#: curs_main.c:1425
 msgid "No limit pattern is in effect."
 msgstr "Zur Zeit ist kein Muster zur Begrenzung aktiv."
 
 #. L10N: ask for a limit to apply
-#: curs_main.c:1426
+#: curs_main.c:1430
 #, c-format
 msgid "Limit: %s"
 msgstr "Begrenze: %s"
 
-#: curs_main.c:1464
+#: curs_main.c:1468
 msgid "Limit to messages matching: "
 msgstr "Begrenze auf Nachrichten nach Muster: "
 
-#: curs_main.c:1488
+#: curs_main.c:1492
 msgid "To view all messages, limit to \"all\"."
 msgstr "Um alle Nachrichten zu sehen, begrenze auf \"all\"."
 
-#: curs_main.c:1500 pager.c:2318
+#: curs_main.c:1504 pager.c:2318
 msgid "Quit NeoMutt?"
 msgstr "NeoMutt beenden?"
 
-#: curs_main.c:1596
+#: curs_main.c:1600
 msgid "Tag messages matching: "
 msgstr "Markiere Nachrichten nach Muster: "
 
 #. L10N: CHECK_ACL
-#: curs_main.c:1606 curs_main.c:3203 pager.c:3137
-msgid "Cannot undelete message(s)"
+#. L10N: Due to the implementation details we do not know whether we
+#. undelete zero, 1, 12, ... messages. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:1614 curs_main.c:3223 pager.c:3145
+#, fuzzy
+msgid "Cannot undelete messages"
 msgstr "Kann Löschmarkierung nicht von Nachricht(en) entfernen"
 
-#: curs_main.c:1609
+#: curs_main.c:1617
 msgid "Undelete messages matching: "
 msgstr "Entferne Löschmarkierung nach Muster: "
 
-#: curs_main.c:1619
+#: curs_main.c:1627
 msgid "Untag messages matching: "
 msgstr "Entferne Markierung nach Muster: "
 
-#: curs_main.c:1653
+#: curs_main.c:1661
 msgid "Logged out of IMAP servers."
 msgstr "Erfolgreich von IMAP-Servern abgemeldet."
 
-#: curs_main.c:1753
+#: curs_main.c:1761
 msgid "No virtual folder, aborting."
 msgstr "Keine virtuelle Mailbox, breche ab."
 
-#: curs_main.c:1761
+#: curs_main.c:1769
 msgid "Failed to read thread, aborting."
 msgstr "Kann Diskussionsfaden nicht lesen, breche ab."
 
-#: curs_main.c:1793 mx.c:1458 mx.c:1475
+#: curs_main.c:1801 mx.c:1468 mx.c:1485
 msgid "Folder doesn't support tagging, aborting."
 msgstr "Ordner unterstützt keine Etikettierung, breche ab."
 
-#: curs_main.c:1808
+#: curs_main.c:1816
 msgid "No tag specified, aborting."
 msgstr "Kein Etikett angegeben, breche ab."
 
-#: curs_main.c:1820
+#: curs_main.c:1828
 #, c-format
 msgid "Update tags..."
 msgstr "Aktualisiere Etiketten..."
 
-#: curs_main.c:1857
+#: curs_main.c:1865
 msgid "Failed to modify tags, aborting."
 msgstr "Konnte Etiketten nicht verändern, breche ab."
 
-#: curs_main.c:1898
+#: curs_main.c:1906
 msgid "No query, aborting."
 msgstr "Keine Anfrage, breche ab."
 
-#: curs_main.c:1902 curs_main.c:1922 curs_main.c:1941
+#: curs_main.c:1910 curs_main.c:1930 curs_main.c:1949
 msgid "Failed to create query, aborting."
 msgstr "Konnte Anfrage nicht erzeugen, breche ab."
 
-#: curs_main.c:1911 curs_main.c:1930
+#: curs_main.c:1919 curs_main.c:1938
 msgid "Windowed queries disabled."
 msgstr "Fragefenster sind ausgeschaltet."
 
-#: curs_main.c:1916 curs_main.c:1935
+#: curs_main.c:1924 curs_main.c:1943
 msgid "No notmuch vfolder currently loaded."
 msgstr "Zurzeit ist kein virtueller Notmuch-Ordner geladen."
 
-#: curs_main.c:1973
+#: curs_main.c:1981
 msgid "Open mailbox in read-only mode"
 msgstr "Öffne Mailbox schreibgeschützt"
 
-#: curs_main.c:1976
+#: curs_main.c:1984
 msgid "Open virtual folder"
 msgstr "Öffne virtuelle Mailbox"
 
-#: curs_main.c:1979
+#: curs_main.c:1987
 msgid "Open mailbox"
 msgstr "Öffne Mailbox"
 
-#: curs_main.c:1989
+#: curs_main.c:1997
 msgid "No mailboxes have new mail"
 msgstr "Keine Mailbox mit neuen Nachrichten"
 
-#: curs_main.c:2036
+#: curs_main.c:2044
 msgid "Open newsgroup in read-only mode"
 msgstr "Öffne Newsgroup schreibgeschützt"
 
-#: curs_main.c:2038
+#: curs_main.c:2046
 msgid "Open newsgroup"
 msgstr "Öffne Newsgroup"
 
-#: curs_main.c:2141
+#: curs_main.c:2149
 msgid "Exit NeoMutt without saving?"
 msgstr "NeoMutt verlassen, ohne Änderungen zu speichern?"
 
-#: curs_main.c:2157
+#: curs_main.c:2165
 msgid "Cannot break thread"
 msgstr "Kann Diskussionsfaden nicht zerteilen"
 
-#: curs_main.c:2160 curs_main.c:2198 curs_main.c:2658 curs_main.c:2690
+#: curs_main.c:2168 curs_main.c:2206 curs_main.c:2666 curs_main.c:2698
 #: flags.c:376 thread.c:1078 thread.c:1134 thread.c:1202
 msgid "Threading is not enabled."
 msgstr "Die Darstellung von Diskussionsfäden ist abgeschaltet."
 
-#: curs_main.c:2173
+#: curs_main.c:2181
 msgid "Thread broken"
 msgstr "Diskussionsfaden unterbrochen"
 
-#: curs_main.c:2185
+#: curs_main.c:2193
 msgid "Thread cannot be broken, message is not part of a thread"
 msgstr "Kann Diskussionsfaden nicht abtrennen, da die Nachricht nicht Teil eines Diskussionsfadens ist"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2195
+#: curs_main.c:2203
 msgid "Cannot link threads"
 msgstr "Kann Diskussionsfäden nicht verbinden"
 
-#: curs_main.c:2200
+#: curs_main.c:2208
 msgid "No Message-ID: header available to link thread"
 msgstr "Keine Message-ID zum Aufbau von Diskussionsfäden verfügbar"
 
-#: curs_main.c:2202
+#: curs_main.c:2210
 msgid "First, please tag a message to be linked here"
 msgstr "Bitte erst eine Nachricht zur Verlinkung markieren"
 
-#: curs_main.c:2213
+#: curs_main.c:2221
 msgid "Threads linked"
 msgstr "Diskussionsfäden verbunden"
 
-#: curs_main.c:2216
+#: curs_main.c:2224
 msgid "No thread linked"
 msgstr "Kein Diskussionsfaden verbunden"
 
-#: curs_main.c:2252 curs_main.c:2278
+#: curs_main.c:2260 curs_main.c:2286
 msgid "You are on the last message."
 msgstr "Das ist bereits auf die letzte Nachricht."
 
-#: curs_main.c:2260 curs_main.c:2305
+#: curs_main.c:2268 curs_main.c:2313
 msgid "No undeleted messages."
 msgstr "Keine ungelöschten Nachrichten."
 
-#: curs_main.c:2297 curs_main.c:2323
+#: curs_main.c:2305 curs_main.c:2331
 msgid "You are on the first message."
 msgstr "Das ist bereits auf die erste Nachricht."
 
-#: curs_main.c:2395 menu.c:970 pager.c:2440 pattern.c:2110
+#: curs_main.c:2403 menu.c:970 pager.c:2440 pattern.c:2110
 msgid "Search wrapped to top."
 msgstr "Suche von vorne begonnen."
 
-#: curs_main.c:2404 pager.c:2463 pattern.c:2121
+#: curs_main.c:2412 pager.c:2463 pattern.c:2121
 msgid "Search wrapped to bottom."
 msgstr "Suche von hinten begonnen."
 
-#: curs_main.c:2447
+#: curs_main.c:2455
 msgid "No new messages in this limited view."
 msgstr "Keine neuen Nachrichten in dieser begrenzten Ansicht."
 
-#: curs_main.c:2449
+#: curs_main.c:2457
 msgid "No new messages."
 msgstr "Keine neuen Nachrichten."
 
-#: curs_main.c:2454
+#: curs_main.c:2462
 msgid "No unread messages in this limited view."
 msgstr "Keine ungelesenen Nachrichten in dieser begrenzten Ansicht."
 
-#: curs_main.c:2456
+#: curs_main.c:2464
 msgid "No unread messages."
 msgstr "Keine ungelesenen Nachrichten."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2474
+#: curs_main.c:2482
 msgid "Cannot flag message"
 msgstr "Kann keinen Statusindikator für Nachricht setzen"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2513 pager.c:3100
+#: curs_main.c:2521 pager.c:3104
 msgid "Cannot toggle new"
 msgstr "Kann nicht umschalten zwischen neu/nicht neu"
 
-#: curs_main.c:2590
+#: curs_main.c:2598
 msgid "No more threads."
 msgstr "Keine weiteren Diskussionsfäden."
 
-#: curs_main.c:2592
+#: curs_main.c:2600
 msgid "You are on the first thread."
 msgstr "Der erste Diskussionsfaden wurde bereits aufgerufen."
 
-#: curs_main.c:2676
+#: curs_main.c:2684
 msgid "Thread contains unread or flagged messages."
 msgstr "Diskussionsfaden enthält ungelesene oder mit Statusindikator versehene Nachrichten."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2726 pager.c:2784
+#: curs_main.c:2734 pager.c:2784
 msgid "Cannot delete message"
 msgstr "Kann Nachricht nicht löschen"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2838
+#: curs_main.c:2850
 msgid "Cannot edit message"
 msgstr "Kann Nachricht nicht bearbeiten"
 
 #. L10N: This is displayed when the x-label on one or more
 #. * messages is edited.
-#: curs_main.c:2900 pager.c:3200
+#: curs_main.c:2912 pager.c:3208
 #, c-format
 msgid "%d label changed."
 msgid_plural "%d labels changed."
@@ -1744,52 +1754,57 @@ msgstr[1] "%d Etiketten verändert."
 #. L10N: This is displayed when editing an x-label, but no messages
 #. * were updated.  Possibly due to canceling at the prompt or if the new
 #. * label is the same as the old label.
-#: curs_main.c:2907 pager.c:3204
+#: curs_main.c:2919 pager.c:3212
 msgid "No labels changed."
 msgstr "Etiketten unverändert."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:3006
-msgid "Cannot mark message(s) as read"
+#. L10N: Due to the implementation details we do not know whether we
+#. mark zero, 1, 12, ... messages as read. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:3022
+#, fuzzy
+msgid "Cannot mark messages as read"
 msgstr "Kann Nachricht(en) nicht als gelesen markieren"
 
 #. L10N: This is the prompt for <mark-message>.  Whatever they
 #. enter will be prefixed by $mark_macro_prefix and will become
 #. a macro hotkey to jump to the currently selected message.
-#: curs_main.c:3042
+#: curs_main.c:3058
 msgid "Enter macro stroke: "
 msgstr "Kurztastenkombination für Makro eingeben: "
 
 #. L10N: "message hotkey" is the key bindings menu description of a
 #. macro created by <mark-message>.
-#: curs_main.c:3050
+#: curs_main.c:3066
 msgid "message hotkey"
 msgstr "Kurztaste für Nachricht"
 
 #. L10N: This is echoed after <mark-message> creates a new hotkey
 #. macro.  %s is the hotkey string ($mark_macro_prefix followed
 #. by whatever they typed at the prompt.)
-#: curs_main.c:3055
+#: curs_main.c:3071
 #, c-format
 msgid "Message bound to %s."
 msgstr "Nachricht wurde an %s gebunden."
 
 #. L10N: This error is printed if <mark-message> cannot find a
 #. Message-ID for the currently selected message in the index.
-#: curs_main.c:3063
+#: curs_main.c:3079
 msgid "No message ID to macro."
 msgstr "Makro benötigt eine Message-ID."
 
-#: curs_main.c:3105 pager.c:2961 recvattach.c:1388
+#: curs_main.c:3121 pager.c:2965 recvattach.c:1401
 msgid "Reply by mail as poster prefers?"
 msgstr "Gemäß dem Wunsch des Autors per Mail antworten?"
 
-#: curs_main.c:3108 pager.c:2927 pager.c:2939 pager.c:2964
+#: curs_main.c:3124 pager.c:2931 pager.c:2943 pager.c:2968
 msgid "Posting to this group not allowed, may be moderated. Continue?"
 msgstr "Das Veröffentlichen in der Newsgroup ist nicht erlaubt, ggf. wird diese moderiert. Fortfahren?"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:3173 pager.c:3120
+#: curs_main.c:3189 pager.c:3124
 msgid "Cannot undelete message"
 msgstr "Kann Löschmarkierung nicht entfernen"
 
@@ -1980,12 +1995,34 @@ msgstr "[-- Fehlerausgabe von %s --]\n"
 msgid "[-- Error: message/external-body has no access-type parameter --]\n"
 msgstr "[-- Fehler: message/external-body hat keinen access-type Parameter --]\n"
 
-#: handler.c:1611
-#, c-format
+#. L10N: If the translation of this string is a multi line string, then
+#. each line should start with "[-- " and end with " --]".
+#. The first "%s/%s" is a MIME type, e.g. "text/plain". The last %s
+#. expands to a date as returned by `mutt_date_parse_date()`.
+#.
+#. Note: The size argument printed is not the actual number as passed
+#. to gettext but the prettified version, e.g. size = 2048 will be
+#. printed as 2K.  Your language might be sensitive to that: For
+#. example although '1K' and '1024' represent the same number your
+#. language might inflect the noun 'byte' differently.
+#.
+#. Sadly, we cannot do anything about that at the moment besides
+#. passing the precise size in bytes. If you are interested the
+#. function responsible for the prettification is
+#. mutt_str_pretty_size() in mutt/string.c.
+#.
+#: handler.c:1624
+#, fuzzy, c-format
 msgid ""
+"[-- This %s/%s attachment (size %s byte) has been deleted --]\n"
+"[-- on %s --]\n"
+msgid_plural ""
 "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
 "[-- on %s --]\n"
-msgstr ""
+msgstr[0] ""
+"[-- Dieser %s/%s-Anhang (Größe %s Byte) wurde gelöscht --]\n"
+"[-- am %s --]\n"
+msgstr[1] ""
 "[-- Dieser %s/%s-Anhang (Größe %s Byte) wurde gelöscht --]\n"
 "[-- am %s --]\n"
 
@@ -1993,10 +2030,23 @@ msgstr ""
 #. each line should start with "[-- " and end with " --]".
 #. The first "%s/%s" is a MIME type, e.g. "text/plain".
 #.
-#: handler.c:1620
-#, c-format
-msgid "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
-msgstr "[-- Dieser %s/%s-Anhang (Größe %s Byte) wurde gelöscht --]\n"
+#. Note: The size argument printed is not the actual number as passed
+#. to gettext but the prettified version, e.g. size = 2048 will be
+#. printed as 2K.  Your language might be sensitive to that: For
+#. example although '1K' and '1024' represent the same number your
+#. language might inflect the noun 'byte' differently.
+#.
+#. Sadly, we cannot do anything about that at the moment besides
+#. passing the precise size in bytes. If you are interested the
+#. function responsible for the prettification is
+#. mutt_str_pretty_size() in mutt/string.c.
+#.
+#: handler.c:1648
+#, fuzzy, c-format
+msgid "[-- This %s/%s attachment (size %s byte) has been deleted --]\n"
+msgid_plural "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
+msgstr[0] "[-- Dieser %s/%s-Anhang (Größe %s Byte) wurde gelöscht --]\n"
+msgstr[1] "[-- Dieser %s/%s-Anhang (Größe %s Byte) wurde gelöscht --]\n"
 
 #. L10N: If the translation of this string is a multi line string, then
 #. each line should start with "[-- " and end with " --]".
@@ -2006,7 +2056,7 @@ msgstr "[-- Dieser %s/%s-Anhang (Größe %s Byte) wurde gelöscht --]\n"
 #. Caution: Argument three %3$ is also defined but should not be used
 #. in this translation!
 #.
-#: handler.c:1637
+#: handler.c:1667
 msgid ""
 "[-- This %s/%s attachment has been deleted --]\n"
 "[-- on %4$s --]\n"
@@ -2018,17 +2068,17 @@ msgstr ""
 #. each line should start with "[-- " and end with " --]".
 #. The first "%s/%s" is a MIME type, e.g. "text/plain".
 #.
-#: handler.c:1646
+#: handler.c:1676
 #, c-format
 msgid "[-- This %s/%s attachment has been deleted --]\n"
 msgstr "[-- Dieser %s/%s-Anhang wurde gelöscht --]\n"
 
-#: handler.c:1656
+#: handler.c:1686
 #, c-format
 msgid "[-- name: %s --]\n"
 msgstr "[-- Name: %s --]\n"
 
-#: handler.c:1672
+#: handler.c:1702
 #, c-format
 msgid ""
 "[-- This %s/%s attachment is not included, --]\n"
@@ -2039,7 +2089,7 @@ msgstr ""
 "[-- und die zugehörige externe Quelle --]\n"
 "[-- existiert nicht mehr. --]\n"
 
-#: handler.c:1693
+#: handler.c:1723
 #, c-format
 msgid ""
 "[-- This %s/%s attachment is not included, --]\n"
@@ -2048,47 +2098,47 @@ msgstr ""
 "[-- Dieser %s/%s-Anhang ist nicht in der Nachricht enthalten, --]\n"
 "[-- und die angegebene Zugangsmethode %s wird nicht unterstützt --]\n"
 
-#: handler.c:1822
+#: handler.c:1852
 msgid "Unable to open memory stream!"
 msgstr "Konnte Datenstrom nicht öffnen!"
 
-#: handler.c:1831
+#: handler.c:1861
 msgid "Unable to open temporary file!"
 msgstr "Konnte Temporärdatei nicht öffnen!"
 
-#: handler.c:1881
+#: handler.c:1911
 msgid "failed to re-open memstream!"
 msgstr "Konnte Datenstrom nicht erneut öffnen!"
 
-#: handler.c:2013
+#: handler.c:2043
 msgid "Error: multipart/signed has no protocol."
 msgstr "Fehler: multipart/signed ohne \"protocol\"-Parameter."
 
-#: handler.c:2076
+#: handler.c:2106
 msgid "[-- This is an attachment (use '%3$s' to view this part) --]\n"
 msgstr "[-- Dies ist ein Anhang ('%3$s' benutzen, um diesen Teil anzuzeigen) --]\n"
 
-#: handler.c:2082
+#: handler.c:2112
 #, c-format
 msgid "[-- %s/%s is unsupported (use '%s' to view this part) --]\n"
 msgstr "[-- %s/%s wird nicht unterstützt ('%s' benutzen, um diesen Teil anzuzeigen) --]\n"
 
-#: handler.c:2087
+#: handler.c:2117
 msgid "[-- This is an attachment (need 'view-attachments' bound to key!) --]\n"
 msgstr "[-- Dies ist ein Anhang (Tastaturbindung für 'view-attachments' benötigt!) --]\n"
 
 #. L10N: %s/%s is a MIME type, e.g. "text/plain".
-#: handler.c:2091
+#: handler.c:2121
 #, c-format
 msgid "[-- %s/%s is unsupported (need 'view-attachments' bound to key!) --]\n"
 msgstr "[-- %s/%s wird nicht unterstützt (Tastaturbindung für 'view-attachments' benötigt!) --]\n"
 
-#: handler.c:2098
+#: handler.c:2128
 msgid "[-- This is an attachment --]\n"
 msgstr "[-- Dies ist ein Anhang --]\n"
 
 #. L10N: %s/%s is a MIME type, e.g. "text/plain".
-#: handler.c:2101
+#: handler.c:2131
 #, c-format
 msgid "[-- %s/%s is unsupported --]\n"
 msgstr "[-- %s/%s wird nicht unterstützt --]\n"
@@ -2390,7 +2440,7 @@ msgstr "IMAP-Server unterstützt keine selbstdefinierten Statusindikatoren"
 msgid "Invalid IMAP flags"
 msgstr "Ungültige IMAP-Statusindikatoren"
 
-#: imap/message.c:477 mx.c:1326
+#: imap/message.c:477 mx.c:1336
 msgid "Integer overflow -- can't allocate memory."
 msgstr "Integer Überlauf -- kann keinen Speicher belegen."
 
@@ -3205,64 +3255,74 @@ msgstr "SSL ist nicht verfügbar, keine Verbindung zu %s"
 msgid "Reading from %s interrupted..."
 msgstr "Lesen von %s unterbrochen..."
 
-#: mx.c:634
-msgid "message(s) not deleted"
-msgstr "Nachrichte(n) nicht gelöscht"
+#. L10N: Although we now the precise number of messages, we do not show it to the user.
+#. So feel free to use a "generic plural" as plural translation if your language has one.
+#.
+#: mx.c:639
+#, fuzzy
+msgid "message not deleted"
+msgid_plural "messages not deleted"
+msgstr[0] "Nachrichte(n) nicht gelöscht"
+msgstr[1] "Nachrichte(n) nicht gelöscht"
 
-#: mx.c:671
+#: mx.c:676
 msgid "Can't open trash folder"
 msgstr "Kann Papierkorb nicht öffnen"
 
-#: mx.c:710
+#: mx.c:715
 msgid "Mark all articles read?"
 msgstr "Alle Artikel als gelesen markieren?"
 
-#: mx.c:754
-#, c-format
-msgid "Move %d read messages to %s?"
-msgstr "%d gelesene Nachrichten nach %s verschieben?"
+#. L10N: The first argument is the number of read messages to be
+#. moved, the second argument is the target mailbox.
+#: mx.c:762
+#, fuzzy, c-format
+msgid "Move %d read message to %s?"
+msgid_plural "Move %d read messages to %s?"
+msgstr[0] "%d gelesene Nachrichten nach %s verschieben?"
+msgstr[1] "%d gelesene Nachrichten nach %s verschieben?"
 
-#: mx.c:771 mx.c:1077
+#: mx.c:781 mx.c:1087
 #, c-format
 msgid "Purge %d deleted message?"
 msgid_plural "Purge %d deleted messages?"
 msgstr[0] "Entferne %d als gelöscht markierte Nachricht?"
 msgstr[1] "Entferne %d als gelöscht markierte Nachrichten?"
 
-#: mx.c:793
+#: mx.c:803
 #, c-format
 msgid "Moving read messages to %s..."
 msgstr "Verschiebe gelesene Nachrichten nach %s..."
 
-#: mx.c:859 mx.c:1068
+#: mx.c:869 mx.c:1078
 msgid "Mailbox is unchanged."
 msgstr "Mailbox unverändert."
 
-#: mx.c:914
+#: mx.c:924
 #, c-format
 msgid "%d kept, %d moved, %d deleted."
 msgstr "%d behalten, %d verschoben, %d gelöscht."
 
-#: mx.c:917 mx.c:1130
+#: mx.c:927 mx.c:1140
 #, c-format
 msgid "%d kept, %d deleted."
 msgstr "%d behalten, %d gelöscht."
 
-#: mx.c:1052
+#: mx.c:1062
 #, c-format
 msgid " Press '%s' to toggle write"
 msgstr " Drücke '%s' zum Umschalten des Schreibmodus"
 
-#: mx.c:1054
+#: mx.c:1064
 msgid "Use 'toggle-write' to re-enable write!"
 msgstr "'toggle-write' reaktiviert den Schreibmodus!"
 
-#: mx.c:1056
+#: mx.c:1066
 #, c-format
 msgid "Mailbox is marked unwritable. %s"
 msgstr "Mailbox ist als schreibgeschützt markiert. %s"
 
-#: mx.c:1124
+#: mx.c:1134
 msgid "Mailbox checkpointed."
 msgstr "Checkpoint in der Mailbox gesetzt."
 
@@ -3276,52 +3336,57 @@ msgstr " (aktuelle Zeit: %c)"
 msgid "[-- %s output follows%s --]\n"
 msgstr "[-- %s Ausgabe folgt%s --]\n"
 
-#: ncrypt/crypt.c:95
-msgid "Passphrase(s) forgotten."
+#. L10N: Due to the implementation details (e.g. some passwords are managed
+#. by gpg-agent) we cannot know whether we forgot zero, 1, 12, ...
+#. passwords. So in English we use "Passphrases". Your language might
+#. have other means to express this.
+#: ncrypt/crypt.c:100
+#, fuzzy
+msgid "Passphrases forgotten."
 msgstr "Mantra(s) vergessen."
 
-#: ncrypt/crypt.c:155
+#: ncrypt/crypt.c:161
 msgid "Inline PGP can't be used with attachments.  Revert to PGP/MIME?"
 msgstr "Inline-PGP funktioniert nicht mit Anhängen. PGP/MIME verwenden?"
 
-#: ncrypt/crypt.c:159
+#: ncrypt/crypt.c:165
 msgid "Mail not sent: inline PGP can't be used with attachments."
 msgstr "Mail nicht versandt: Inline-PGP funktioniert nicht mit Anhängen."
 
-#: ncrypt/crypt.c:166
+#: ncrypt/crypt.c:172
 msgid "Inline PGP can't be used with format=flowed.  Revert to PGP/MIME?"
 msgstr "Inline-PGP funktioniert nicht mit format=flowed. PGP/MIME verwenden?"
 
-#: ncrypt/crypt.c:170
+#: ncrypt/crypt.c:176
 msgid "Mail not sent: inline PGP can't be used with format=flowed."
 msgstr "Mail nicht versandt: Inline-PGP funktioniert nicht mit format=flowed."
 
-#: ncrypt/crypt.c:180 ncrypt/cryptglue.c:125 ncrypt/pgpkey.c:589
+#: ncrypt/crypt.c:186 ncrypt/cryptglue.c:125 ncrypt/pgpkey.c:589
 #: ncrypt/pgpkey.c:782
 msgid "Invoking PGP..."
 msgstr "Rufe PGP auf..."
 
-#: ncrypt/crypt.c:192
+#: ncrypt/crypt.c:198
 msgid "Message can't be sent inline.  Revert to using PGP/MIME?"
 msgstr "Nachricht kann nicht Inline verschickt werden. PGP/MIME verwenden?"
 
-#: ncrypt/crypt.c:194 send.c:1824
+#: ncrypt/crypt.c:200 send.c:1824
 msgid "Mail not sent."
 msgstr "Nachricht nicht verschickt."
 
-#: ncrypt/crypt.c:540
+#: ncrypt/crypt.c:546
 msgid "S/MIME messages with no hints on content are unsupported."
 msgstr "S/MIME-Nachrichten ohne Hinweis auf den Inhalt werden nicht unterstützt."
 
-#: ncrypt/crypt.c:754 ncrypt/crypt.c:795
+#: ncrypt/crypt.c:760 ncrypt/crypt.c:801
 msgid "Trying to extract PGP keys...\n"
 msgstr "Versuche PGP-Schlüssel zu extrahieren...\n"
 
-#: ncrypt/crypt.c:776 ncrypt/crypt.c:816
+#: ncrypt/crypt.c:782 ncrypt/crypt.c:822
 msgid "Trying to extract S/MIME certificates...\n"
 msgstr "Versuche S/MIME-Zertifikate zu extrahieren...\n"
 
-#: ncrypt/crypt.c:976
+#: ncrypt/crypt.c:982
 #, c-format
 msgid ""
 "[-- Error: Unknown multipart/signed protocol %s! --]\n"
@@ -3330,7 +3395,7 @@ msgstr ""
 "[-- Fehler: Unbekanntes multipart/signed Protokoll %s! --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1016
+#: ncrypt/crypt.c:1022
 msgid ""
 "[-- Error: Missing or bad-format multipart/signed signature! --]\n"
 "\n"
@@ -3338,7 +3403,7 @@ msgstr ""
 "[-- Fehler: Inkonsistente multipart/signed Unterschrift! --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1058
+#: ncrypt/crypt.c:1064
 #, c-format
 msgid ""
 "[-- Warning: We can't verify %s/%s signatures. --]\n"
@@ -3347,7 +3412,7 @@ msgstr ""
 "[-- Warnung: %s/%s Unterschriften können nicht geprüft werden. --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1070
+#: ncrypt/crypt.c:1076
 msgid ""
 "[-- The following data is signed --]\n"
 "\n"
@@ -3355,7 +3420,7 @@ msgstr ""
 "[-- Die folgenden Daten sind signiert --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1075
+#: ncrypt/crypt.c:1081
 msgid ""
 "[-- Warning: Can't find any signatures. --]\n"
 "\n"
@@ -3363,7 +3428,7 @@ msgstr ""
 "[-- Warnung: Kann keine Unterschriften finden. --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1081
+#: ncrypt/crypt.c:1087
 msgid ""
 "\n"
 "[-- End of signed data --]\n"
@@ -3414,7 +3479,7 @@ msgstr "[Temporärdatei]"
 msgid "error reading data object: %s\n"
 msgstr "Fehler beim Lesen des Datenobjekts: %s\n"
 
-#: ncrypt/crypt_gpgme.c:662 ncrypt/crypt_gpgme.c:3848 ncrypt/pgpkey.c:585
+#: ncrypt/crypt_gpgme.c:662 ncrypt/crypt_gpgme.c:3850 ncrypt/pgpkey.c:585
 #: ncrypt/pgpkey.c:768
 msgid "Can't create temporary file"
 msgstr "Kann Temporärdatei nicht erzeugen"
@@ -3762,28 +3827,30 @@ msgstr "[Ungültig]"
 
 #. L10N: This is printed after "Key Type: " and looks like this:
 #. *       PGP, 2048 bit RSA
-#: ncrypt/crypt_gpgme.c:3670 ncrypt/crypt_gpgme.c:3808
-#, c-format
+#: ncrypt/crypt_gpgme.c:3670 ncrypt/crypt_gpgme.c:3810
+#, fuzzy, c-format
 msgid "%s, %lu bit %s\n"
-msgstr "%s, %lu Bit %s\n"
+msgid_plural "%s, %lu bit %s\n"
+msgstr[0] "%s, %lu Bit %s\n"
+msgstr[1] "%s, %lu Bit %s\n"
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3678 ncrypt/crypt_gpgme.c:3815
+#: ncrypt/crypt_gpgme.c:3678 ncrypt/crypt_gpgme.c:3817
 msgid "encryption"
 msgstr "Verschlüsselung"
 
 #: ncrypt/crypt_gpgme.c:3679 ncrypt/crypt_gpgme.c:3685
-#: ncrypt/crypt_gpgme.c:3816 ncrypt/crypt_gpgme.c:3821
+#: ncrypt/crypt_gpgme.c:3818 ncrypt/crypt_gpgme.c:3823
 msgid ", "
 msgstr ", "
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3684 ncrypt/crypt_gpgme.c:3820
+#: ncrypt/crypt_gpgme.c:3684 ncrypt/crypt_gpgme.c:3822
 msgid "signing"
 msgstr "Signieren"
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3690 ncrypt/crypt_gpgme.c:3825
+#: ncrypt/crypt_gpgme.c:3690 ncrypt/crypt_gpgme.c:3827
 msgid "certification"
 msgstr "Zertifikat"
 
@@ -3802,64 +3869,64 @@ msgstr "[Abgelaufen]"
 msgid "[Disabled]"
 msgstr "[Deaktiviert]"
 
-#: ncrypt/crypt_gpgme.c:3851
+#: ncrypt/crypt_gpgme.c:3853
 msgid "Collecting data..."
 msgstr "Sammle Informationen..."
 
-#: ncrypt/crypt_gpgme.c:3876
+#: ncrypt/crypt_gpgme.c:3878
 #, c-format
 msgid "Error finding issuer key: %s\n"
 msgstr "Fehler bei der Suche nach dem Schlüssel des Herausgebers: %s\n"
 
-#: ncrypt/crypt_gpgme.c:3885
+#: ncrypt/crypt_gpgme.c:3887
 msgid "Error: certification chain too long - stopping here\n"
 msgstr "Fehler: Zertifikatkette zu lang - Stoppe hier\n"
 
-#: ncrypt/crypt_gpgme.c:3895 ncrypt/pgpkey.c:608
+#: ncrypt/crypt_gpgme.c:3897 ncrypt/pgpkey.c:608
 #, c-format
 msgid "Key ID: 0x%s"
 msgstr "Schlüssel ID: 0x%s"
 
-#: ncrypt/crypt_gpgme.c:3990
+#: ncrypt/crypt_gpgme.c:3992
 #, c-format
 msgid "gpgme_new failed: %s"
 msgstr "gpgme_new fehlgeschlagen: %s"
 
-#: ncrypt/crypt_gpgme.c:4028 ncrypt/crypt_gpgme.c:4079
+#: ncrypt/crypt_gpgme.c:4030 ncrypt/crypt_gpgme.c:4081
 #, c-format
 msgid "gpgme_op_keylist_start failed: %s"
 msgstr "gpgme_op_keylist_start fehlgeschlagen: %s"
 
-#: ncrypt/crypt_gpgme.c:4067 ncrypt/crypt_gpgme.c:4109
+#: ncrypt/crypt_gpgme.c:4069 ncrypt/crypt_gpgme.c:4111
 #, c-format
 msgid "gpgme_op_keylist_next failed: %s"
 msgstr "gpgme_op_keylist_next fehlgeschlagen: %s"
 
-#: ncrypt/crypt_gpgme.c:4185
+#: ncrypt/crypt_gpgme.c:4187
 msgid "All matching keys are marked expired/revoked."
 msgstr "Alle passenden Schlüssel sind abgelaufen/zurückgezogen."
 
-#: ncrypt/crypt_gpgme.c:4215 ncrypt/pgpkey.c:543 ncrypt/smime.c:475
+#: ncrypt/crypt_gpgme.c:4217 ncrypt/pgpkey.c:543 ncrypt/smime.c:475
 msgid "Select  "
 msgstr "Auswahl  "
 
-#: ncrypt/crypt_gpgme.c:4217 ncrypt/pgpkey.c:545
+#: ncrypt/crypt_gpgme.c:4219 ncrypt/pgpkey.c:545
 msgid "Check key  "
 msgstr "Schlüssel prüfen  "
 
-#: ncrypt/crypt_gpgme.c:4233
+#: ncrypt/crypt_gpgme.c:4235
 msgid "PGP and S/MIME keys matching"
 msgstr "Passende PGP- und S/MIME-Schlüssel"
 
-#: ncrypt/crypt_gpgme.c:4235
+#: ncrypt/crypt_gpgme.c:4237
 msgid "PGP keys matching"
 msgstr "Passende PGP-Schlüssel"
 
-#: ncrypt/crypt_gpgme.c:4237
+#: ncrypt/crypt_gpgme.c:4239
 msgid "S/MIME keys matching"
 msgstr "Passende S/MIME-Schlüssel"
 
-#: ncrypt/crypt_gpgme.c:4239
+#: ncrypt/crypt_gpgme.c:4241
 msgid "keys matching"
 msgstr "Passende Schlüssel"
 
@@ -3867,65 +3934,65 @@ msgstr "Passende Schlüssel"
 #. %1$s is one of the previous four entries.
 #. %2$s is an address.
 #. e.g. "S/MIME keys matching <me@mutt.org>."
-#: ncrypt/crypt_gpgme.c:4246
+#: ncrypt/crypt_gpgme.c:4248
 #, c-format
 msgid "%s <%s>."
 msgstr "%s <%s>."
 
 #. L10N:
 #. e.g. 'S/MIME keys matching "Michael Elkins".'
-#: ncrypt/crypt_gpgme.c:4250
+#: ncrypt/crypt_gpgme.c:4252
 #, c-format
 msgid "%s \"%s\"."
 msgstr "%s \"%s\"."
 
-#: ncrypt/crypt_gpgme.c:4277 ncrypt/pgpkey.c:628
+#: ncrypt/crypt_gpgme.c:4279 ncrypt/pgpkey.c:628
 msgid "This key can't be used: expired/disabled/revoked."
 msgstr "Dieser Schlüssel ist nicht verwendbar: veraltet/deaktiviert/zurückgezogen."
 
-#: ncrypt/crypt_gpgme.c:4290 ncrypt/pgpkey.c:640 ncrypt/smime.c:505
+#: ncrypt/crypt_gpgme.c:4292 ncrypt/pgpkey.c:640 ncrypt/smime.c:505
 msgid "ID is expired/disabled/revoked. Do you really want to use the key?"
 msgstr "Diese ID ist veraltet/deaktiviert/zurückgezogen. Soll dieser Schlüssel wirklich benutzt werden?"
 
-#: ncrypt/crypt_gpgme.c:4299 ncrypt/pgpkey.c:650
+#: ncrypt/crypt_gpgme.c:4301 ncrypt/pgpkey.c:650
 msgid "ID is not valid. Do you really want to use the key?"
 msgstr "Diese ID ist ungültig. Soll dieser Schlüssel wirklich benutzt werden?"
 
-#: ncrypt/crypt_gpgme.c:4302 ncrypt/pgpkey.c:653
+#: ncrypt/crypt_gpgme.c:4304 ncrypt/pgpkey.c:653
 msgid "ID is only marginally valid. Do you really want to use the key?"
 msgstr "Diese Gültigkeit dieser ID ist grenzwertig. Soll dieser Schlüssel wirklich benutzt werden?"
 
-#: ncrypt/crypt_gpgme.c:4310 ncrypt/pgpkey.c:646 ncrypt/smime.c:509
+#: ncrypt/crypt_gpgme.c:4312 ncrypt/pgpkey.c:646 ncrypt/smime.c:509
 msgid "ID has undefined validity. Do you really want to use the key?"
 msgstr "Die Gültigkeit dieser ID ist undefiniert. Soll dieser Schlüssel wirklich benutzt werden?"
 
-#: ncrypt/crypt_gpgme.c:4370 ncrypt/crypt_gpgme.c:4479 ncrypt/pgpkey.c:872
+#: ncrypt/crypt_gpgme.c:4372 ncrypt/crypt_gpgme.c:4481 ncrypt/pgpkey.c:872
 #: ncrypt/pgpkey.c:995
 #, c-format
 msgid "Looking for keys matching \"%s\"..."
 msgstr "Suche nach Schlüsseln, die auf \"%s\" passen..."
 
-#: ncrypt/crypt_gpgme.c:4593 ncrypt/pgpkey.c:731 ncrypt/smime.c:811
+#: ncrypt/crypt_gpgme.c:4595 ncrypt/pgpkey.c:731 ncrypt/smime.c:811
 #, c-format
 msgid "No matching keys found for \"%s\""
 msgstr "Keine passenden Schlüssel für \"%s\" gefunden"
 
-#: ncrypt/crypt_gpgme.c:4644 ncrypt/pgp.c:1263
+#: ncrypt/crypt_gpgme.c:4646 ncrypt/pgp.c:1263
 #, c-format
 msgid "Use keyID = \"%s\" for %s?"
 msgstr "Benutze KeyID = \"%s\" für %s?"
 
-#: ncrypt/crypt_gpgme.c:4695 ncrypt/pgp.c:1312 ncrypt/smime.c:830
+#: ncrypt/crypt_gpgme.c:4697 ncrypt/pgp.c:1312 ncrypt/smime.c:830
 #: ncrypt/smime.c:938
 #, c-format
 msgid "Enter keyID for %s: "
 msgstr "KeyID für %s: "
 
-#: ncrypt/crypt_gpgme.c:4755 ncrypt/pgpkey.c:751
+#: ncrypt/crypt_gpgme.c:4757 ncrypt/pgpkey.c:751
 msgid "Please enter the key ID: "
 msgstr "Bitte Schlüsselidentifikation eingeben: "
 
-#: ncrypt/crypt_gpgme.c:4768
+#: ncrypt/crypt_gpgme.c:4770
 #, c-format
 msgid "Error exporting key: %s\n"
 msgstr "Fehler beim Export des Schlüssels: %s\n"
@@ -3934,80 +4001,80 @@ msgstr "Fehler beim Export des Schlüssels: %s\n"
 #. MIME description for exported (attached) keys.
 #. You can translate this entry to a non-ASCII string (it will be encoded),
 #. but it may be safer to keep it untranslated.
-#: ncrypt/crypt_gpgme.c:4787
+#: ncrypt/crypt_gpgme.c:4789
 #, c-format
 msgid "PGP Key 0x%s."
 msgstr "PGP-Schlüssel 0x%s."
 
-#: ncrypt/crypt_gpgme.c:4830
+#: ncrypt/crypt_gpgme.c:4832
 msgid "GPGME: OpenPGP protocol not available"
 msgstr "GPGME: OpenPGP-Protokoll nicht verfügbar"
 
-#: ncrypt/crypt_gpgme.c:4838
+#: ncrypt/crypt_gpgme.c:4840
 msgid "GPGME: CMS protocol not available"
 msgstr "GPGME: CMS-Protokoll nicht verfügbar"
 
-#: ncrypt/crypt_gpgme.c:4876
+#: ncrypt/crypt_gpgme.c:4878
 msgid "S/MIME (s)ign, sign (a)s, (p)gp, (c)lear, or (o)ppenc mode off? "
 msgstr "S/MIME (s)ign., sign. (a)ls, (p)gp, (u)nverschl., oder kein (w)ie-mögl.-Modus? "
 
 #. L10N: S/MIME options (opportunistic encryption is on)
-#: ncrypt/crypt_gpgme.c:4878
+#: ncrypt/crypt_gpgme.c:4880
 msgid "sapco"
 msgstr "sapuw"
 
-#: ncrypt/crypt_gpgme.c:4885
+#: ncrypt/crypt_gpgme.c:4887
 msgid "PGP (s)ign, sign (a)s, s/(m)ime, (c)lear, or (o)ppenc mode off? "
 msgstr "PGP (s)ign., sign. (a)ls, s/(m)ime, (u)nverschl., oder kein (w)ie-mögl.-Modus? "
 
 #. L10N: PGP options (opportunistic encryption is on)
-#: ncrypt/crypt_gpgme.c:4887
+#: ncrypt/crypt_gpgme.c:4889
 msgid "samco"
 msgstr "samuw"
 
 #. L10N: S/MIME options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4900
+#: ncrypt/crypt_gpgme.c:4902
 msgid "S/MIME (e)ncrypt, (s)ign, sign (a)s, (b)oth, (p)gp, (c)lear, or (o)ppenc mode? "
 msgstr "S/MIME (v)erschl., (s)ign., sign. (a)ls, (b)eides, (p)gp, (u)nverschl., oder (w)ie-mögl.-Modus? "
 
 #. L10N: S/MIME options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4903
+#: ncrypt/crypt_gpgme.c:4905
 msgid "esabpco"
 msgstr "vsabpuw"
 
 #. L10N: PGP options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4909
+#: ncrypt/crypt_gpgme.c:4911
 msgid "PGP (e)ncrypt, (s)ign, sign (a)s, (b)oth, s/(m)ime, (c)lear, or (o)ppenc mode? "
 msgstr "PGP (v)erschl., (s)ign., sign. (a)ls, (b)eides, s/(m)ime, (u)nverschl., oder (w)ie-mögl.-Modus? "
 
 #. L10N: PGP options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4912
+#: ncrypt/crypt_gpgme.c:4914
 msgid "esabmco"
 msgstr "vsabmuw"
 
-#: ncrypt/crypt_gpgme.c:4925
+#: ncrypt/crypt_gpgme.c:4927
 msgid "S/MIME (e)ncrypt, (s)ign, sign (a)s, (b)oth, (p)gp or (c)lear? "
 msgstr "S/MIME (v)erschl., (s)ign., sign. (a)ls, (b)eides, (p)gp oder (u)nverschl.? "
 
 #. L10N: S/MIME options
-#: ncrypt/crypt_gpgme.c:4927
+#: ncrypt/crypt_gpgme.c:4929
 msgid "esabpc"
 msgstr "vsabpu"
 
-#: ncrypt/crypt_gpgme.c:4934
+#: ncrypt/crypt_gpgme.c:4936
 msgid "PGP (e)ncrypt, (s)ign, sign (a)s, (b)oth, s/(m)ime or (c)lear? "
 msgstr "PGP (v)erschl., (s)ign., sign. (a)ls, (b)eides, s/(m)ime oder (u)nverschl.? "
 
 #. L10N: PGP options
-#: ncrypt/crypt_gpgme.c:4936
+#: ncrypt/crypt_gpgme.c:4938
 msgid "esabmc"
 msgstr "vsabmu"
 
-#: ncrypt/crypt_gpgme.c:5087
+#: ncrypt/crypt_gpgme.c:5089
 msgid "Failed to verify sender"
 msgstr "Prüfung des Absenders fehlgeschlagen"
 
-#: ncrypt/crypt_gpgme.c:5090
+#: ncrypt/crypt_gpgme.c:5092
 msgid "Failed to figure out sender"
 msgstr "Kann Absender nicht ermitteln"
 
@@ -4395,7 +4462,7 @@ msgstr "Kein Newsserver definiert!"
 msgid "%s is an invalid news server specification!"
 msgstr "%s ist eine ungültige Newsserver-Angabe!"
 
-#: nntp.c:75 nntp.c:612 pop.c:1028 pop_lib.c:405
+#: nntp.c:75 nntp.c:612 pop.c:1031 pop_lib.c:405
 msgid "Server closed connection!"
 msgstr "Server hat Verbindung beendet!"
 
@@ -4553,15 +4620,18 @@ msgid "check mailboxes for new mail"
 msgstr "Überprüfe Mailboxen auf neue Nachrichten"
 
 #: opcodes.h:47
-msgid "attach file(s) to this message"
+#, fuzzy
+msgid "attach files to this message"
 msgstr "Hänge Datei(en) an diese Nachricht an"
 
 #: opcodes.h:48
-msgid "attach message(s) to this message"
+#, fuzzy
+msgid "attach messages to this message"
 msgstr "Hänge Nachricht(en) an diese Nachricht an"
 
 #: opcodes.h:49
-msgid "attach news article(s) to this message"
+#, fuzzy
+msgid "attach news articles to this message"
 msgstr "Hänge News-Artikel an diese Nachricht an"
 
 #: opcodes.h:50
@@ -5377,7 +5447,8 @@ msgid "extract supported public keys"
 msgstr "Extrahiere unterstützte öffentliche Schlüssel"
 
 #: opcodes.h:255
-msgid "wipe passphrase(s) from memory"
+#, fuzzy
+msgid "wipe passphrases from memory"
 msgstr "Entferne Mantra(s) aus Speicher"
 
 #: opcodes.h:259
@@ -5707,18 +5778,20 @@ msgstr "Keine neuen Nachrichten auf dem POP-Server."
 msgid "Delete messages from server?"
 msgstr "Lösche Nachrichten auf dem Server?"
 
-#: pop.c:954
-#, c-format
-msgid "Reading new messages (%d bytes)..."
-msgstr "Lese neue Nachrichten (%d Bytes)..."
+#: pop.c:955
+#, fuzzy, c-format
+msgid "Reading new messages (%d byte)..."
+msgid_plural "Reading new messages (%d bytes)..."
+msgstr[0] "Lese neue Nachrichten (%d Bytes)..."
+msgstr[1] "Lese neue Nachrichten (%d Bytes)..."
 
-#: pop.c:997
+#: pop.c:1000
 msgid "Error while writing mailbox!"
 msgstr "Fehler beim Versuch, die Mailbox zu schreiben!"
 
 #. L10N: The plural is picked by the second numerical argument, i.e.
 #. * the %d right before 'messages', i.e. the total number of messages.
-#: pop.c:1003
+#: pop.c:1006
 #, c-format
 msgid "%s [%d of %d message read]"
 msgid_plural "%s [%d of %d messages read]"
@@ -5862,47 +5935,54 @@ msgstr "Übergebe an (pipe): "
 msgid "I don't know how to print %s attachments!"
 msgstr "Kann %s Anhänge nicht drucken!"
 
-#: recvattach.c:841
-msgid "Print tagged attachment(s)?"
-msgstr "Markierte Anhänge drucken?"
+#. L10N: Although we now the precise number of tagged messages, we
+#. do not show it to the user.  So feel free to use a "generic
+#. plural" as plural translation if your language has one.
+#: recvattach.c:852
+#, fuzzy, c-format
+msgid "Print tagged attachment?"
+msgid_plural "Print %d tagged attachments?"
+msgstr[0] "Markierte Anhänge drucken?"
+msgstr[1] "Markierte Anhänge drucken?"
 
-#: recvattach.c:842
+#: recvattach.c:853
+#, c-format
 msgid "Print attachment?"
 msgstr "Anhang drucken?"
 
-#: recvattach.c:900
+#: recvattach.c:913
 msgid "Structural changes to decrypted attachments are not supported"
 msgstr "Strukturelle Änderungen entschlüsselter Anhänge werden nicht unterstützt"
 
-#: recvattach.c:1046
+#: recvattach.c:1059
 msgid "Can't decrypt encrypted message!"
 msgstr "Kann verschlüsselte Nachricht nicht entschlüsseln!"
 
-#: recvattach.c:1172
+#: recvattach.c:1185
 msgid "Attachments"
 msgstr "Anhänge"
 
-#: recvattach.c:1210
+#: recvattach.c:1223
 msgid "There are no subparts to show!"
 msgstr "Es sind keine Teile zur Anzeige vorhanden!"
 
-#: recvattach.c:1265
+#: recvattach.c:1278
 msgid "Can't delete attachment from POP server."
 msgstr "Kann Dateianhang nicht vom POP-Server löschen."
 
-#: recvattach.c:1274
+#: recvattach.c:1287
 msgid "Can't delete attachment from news server."
 msgstr "Kann Dateianhang nicht vom Newsserver löschen."
 
-#: recvattach.c:1281
+#: recvattach.c:1294
 msgid "Deletion of attachments from encrypted messages is unsupported."
 msgstr "Kann Anhänge verschlüsselter Nachrichten nicht löschen."
 
-#: recvattach.c:1287
+#: recvattach.c:1300
 msgid "Deletion of attachments from signed messages may invalidate the signature."
 msgstr "Das Löschen von Anhängen signierter Nachrichten kann deren Signatur ungültig machen."
 
-#: recvattach.c:1305 recvattach.c:1320
+#: recvattach.c:1318 recvattach.c:1333
 msgid "Only deletion of multipart attachments is supported."
 msgstr "Kann nur aus mehrteiligen Anhängen löschen."
 
@@ -6333,3 +6413,13 @@ msgstr "Standard Einstellungen:"
 #: version.c:404
 msgid "Compile options:"
 msgstr "Einstellungen bei der Kompilierung:"
+
+#~ msgid "Cannot delete message(s)"
+#~ msgstr "Kann Nachricht(en) nicht entfernen"
+
+#~ msgid "Cannot undelete message(s)"
+#~ msgstr "Kann Löschmarkierung nicht von Nachricht(en) entfernen"
+
+#, fuzzy
+#~ msgid "messages not deleted"
+#~ msgstr "Nachrichte(n) nicht gelöscht"

--- a/po/el.po
+++ b/po/el.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neomutt-20180512\n"
 "Report-Msgid-Bugs-To: neomutt-devel@neomutt.org\n"
-"POT-Creation-Date: 2018-05-20 02:02+0000\n"
+"POT-Creation-Date: 2018-05-22 14:18+0000\n"
 "PO-Revision-Date: 2005-02-01 00:01GMT+2\n"
 "Last-Translator: Dokianakis Fanis <madf@hellug.gr>\n"
 "Language-Team: Greek <EL@li.org>\n"
@@ -43,7 +43,7 @@ msgstr "Επιλέξτε"
 
 #: addrbook.c:52 browser.c:75 browser.c:87 compose.c:160 compose.c:172
 #: conn/ssl.c:1041 conn/ssl_gnutls.c:793 curs_main.c:748 curs_main.c:761
-#: history.c:106 ncrypt/crypt_gpgme.c:4219 ncrypt/pgpkey.c:547
+#: history.c:106 ncrypt/crypt_gpgme.c:4221 ncrypt/pgpkey.c:547
 #: ncrypt/smime.c:477 pager.c:2141 postpone.c:65 query.c:72 recvattach.c:70
 msgid "Help"
 msgstr "Βοήθεια"
@@ -697,7 +697,7 @@ msgstr ""
 #. * Since it shares the row with "Encrypt with:", it should not be longer
 #. * than 15-20 character cells.
 #.
-#: compose.c:138 ncrypt/crypt_gpgme.c:4947 ncrypt/pgp.c:1786
+#: compose.c:138 ncrypt/crypt_gpgme.c:4949 ncrypt/pgp.c:1786
 #: ncrypt/smime.c:2127
 msgid "Sign as: "
 msgstr "Υπογραφή ως: "
@@ -1245,7 +1245,7 @@ msgstr "(r)απόρριψη, (o)αποδοχή μια φορά"
 msgid "(r)eject, accept (o)nce"
 msgstr "(r)απόρριψη, (o)αποδοχή μια φορά"
 
-#: conn/ssl.c:1039 conn/ssl_gnutls.c:791 ncrypt/crypt_gpgme.c:4213
+#: conn/ssl.c:1039 conn/ssl_gnutls.c:791 ncrypt/crypt_gpgme.c:4215
 #: ncrypt/pgpkey.c:541 ncrypt/smime.c:473
 msgid "Exit  "
 msgstr "Έξοδος "
@@ -1431,11 +1431,11 @@ msgstr "Δεν υπάρχουν ανοιχτά γραμματοκιβώτια."
 msgid "There are no messages."
 msgstr "Δεν υπάρχουν μηνύματα."
 
-#: curs_main.c:77 mx.c:1061 pager.c:73 recvattach.c:56
+#: curs_main.c:77 mx.c:1071 pager.c:73 recvattach.c:56
 msgid "Mailbox is read-only."
 msgstr "Το γραμματοκιβώτιο είναι μόνο για ανάγνωση."
 
-#: curs_main.c:79 pager.c:75 recvattach.c:1145
+#: curs_main.c:79 pager.c:75 recvattach.c:1158
 msgid "Function not permitted in attach-message mode."
 msgstr "Η λειτουργία απαγορεύεται στην κατάσταση προσάρτηση-μηνύματος."
 
@@ -1570,255 +1570,263 @@ msgid "That message is not visible."
 msgstr "Αυτό το μήνυμα δεν είναι ορατό."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:1377 curs_main.c:2772 pager.c:2818
+#. L10N: Due to the implementation details we do not know whether we
+#. delete zero, 1, 12, ... messages. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:1381 curs_main.c:2784 pager.c:2822
 #, fuzzy
-msgid "Cannot delete message(s)"
+msgid "Cannot delete messages"
 msgstr "Δεν υπάρχουν αποκαταστημένα μηνύματα."
 
-#: curs_main.c:1380
+#: curs_main.c:1384
 msgid "Delete messages matching: "
 msgstr "Διαγραφή παρόμοιων μηνυμάτων: "
 
-#: curs_main.c:1421
+#: curs_main.c:1425
 msgid "No limit pattern is in effect."
 msgstr "Κανένα υπόδειγμα ορίων σε λειτουργία."
 
 #. L10N: ask for a limit to apply
-#: curs_main.c:1426
+#: curs_main.c:1430
 #, c-format
 msgid "Limit: %s"
 msgstr "Όριο: %s"
 
-#: curs_main.c:1464
+#: curs_main.c:1468
 msgid "Limit to messages matching: "
 msgstr "Περιορισμός στα παρόμοια μηνύματα: "
 
-#: curs_main.c:1488
+#: curs_main.c:1492
 msgid "To view all messages, limit to \"all\"."
 msgstr ""
 
-#: curs_main.c:1500 pager.c:2318
+#: curs_main.c:1504 pager.c:2318
 msgid "Quit NeoMutt?"
 msgstr "Έξοδος από το NeoMutt;"
 
-#: curs_main.c:1596
+#: curs_main.c:1600
 msgid "Tag messages matching: "
 msgstr "Σημειώστε μηνύματα που ταιριάζουν σε: "
 
 #. L10N: CHECK_ACL
-#: curs_main.c:1606 curs_main.c:3203 pager.c:3137
+#. L10N: Due to the implementation details we do not know whether we
+#. undelete zero, 1, 12, ... messages. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:1614 curs_main.c:3223 pager.c:3145
 #, fuzzy
-msgid "Cannot undelete message(s)"
+msgid "Cannot undelete messages"
 msgstr "Δεν υπάρχουν αποκαταστημένα μηνύματα."
 
-#: curs_main.c:1609
+#: curs_main.c:1617
 msgid "Undelete messages matching: "
 msgstr "Επαναφορά τα μηνύματα που ταιριάζουν σε: "
 
-#: curs_main.c:1619
+#: curs_main.c:1627
 msgid "Untag messages matching: "
 msgstr "Αφαίρεση της σημείωσης στα μηνύματα που ταιριάζουν σε: "
 
-#: curs_main.c:1653
+#: curs_main.c:1661
 #, fuzzy
 msgid "Logged out of IMAP servers."
 msgstr "Κλείσιμο σύνδεσης στον εξυπηρετητή IMAP..."
 
-#: curs_main.c:1753
+#: curs_main.c:1761
 #, fuzzy
 msgid "No virtual folder, aborting."
 msgstr "Δεν υπάρχει θέμα, εγκατάλειψη."
 
-#: curs_main.c:1761
+#: curs_main.c:1769
 msgid "Failed to read thread, aborting."
 msgstr ""
 
-#: curs_main.c:1793 mx.c:1458 mx.c:1475
+#: curs_main.c:1801 mx.c:1468 mx.c:1485
 msgid "Folder doesn't support tagging, aborting."
 msgstr ""
 
-#: curs_main.c:1808
+#: curs_main.c:1816
 #, fuzzy
 msgid "No tag specified, aborting."
 msgstr "Δεν υπάρχει θέμα, εγκατάλειψη."
 
-#: curs_main.c:1820
+#: curs_main.c:1828
 #, c-format
 msgid "Update tags..."
 msgstr ""
 
-#: curs_main.c:1857
+#: curs_main.c:1865
 msgid "Failed to modify tags, aborting."
 msgstr ""
 
-#: curs_main.c:1898
+#: curs_main.c:1906
 #, fuzzy
 msgid "No query, aborting."
 msgstr "Δεν υπάρχει θέμα, εγκατάλειψη."
 
-#: curs_main.c:1902 curs_main.c:1922 curs_main.c:1941
+#: curs_main.c:1910 curs_main.c:1930 curs_main.c:1949
 msgid "Failed to create query, aborting."
 msgstr ""
 
-#: curs_main.c:1911 curs_main.c:1930
+#: curs_main.c:1919 curs_main.c:1938
 msgid "Windowed queries disabled."
 msgstr ""
 
-#: curs_main.c:1916 curs_main.c:1935
+#: curs_main.c:1924 curs_main.c:1943
 msgid "No notmuch vfolder currently loaded."
 msgstr ""
 
-#: curs_main.c:1973
+#: curs_main.c:1981
 msgid "Open mailbox in read-only mode"
 msgstr "Ανοίξτε το γραμματοκιβώτιο σε κατάσταση μόνο για εγγραφή"
 
-#: curs_main.c:1976
+#: curs_main.c:1984
 #, fuzzy
 msgid "Open virtual folder"
 msgstr "άνοιγμα ενός διαφορετικού φακέλου"
 
-#: curs_main.c:1979
+#: curs_main.c:1987
 msgid "Open mailbox"
 msgstr "Ανοίξτε το γραμματοκιβώτιο"
 
-#: curs_main.c:1989
+#: curs_main.c:1997
 #, fuzzy
 msgid "No mailboxes have new mail"
 msgstr "Δεν υπάρχει νέα αλληλογραφία σε κανένα γραμματοκιβώτιο."
 
-#: curs_main.c:2036
+#: curs_main.c:2044
 #, fuzzy
 msgid "Open newsgroup in read-only mode"
 msgstr "Ανοίξτε το γραμματοκιβώτιο σε κατάσταση μόνο για εγγραφή"
 
-#: curs_main.c:2038
+#: curs_main.c:2046
 msgid "Open newsgroup"
 msgstr ""
 
-#: curs_main.c:2141
+#: curs_main.c:2149
 #, fuzzy
 msgid "Exit NeoMutt without saving?"
 msgstr "Έξοδος από το NeoMutt χωρίς αποθήκευση;"
 
-#: curs_main.c:2157
+#: curs_main.c:2165
 #, fuzzy
 msgid "Cannot break thread"
 msgstr "Αδυναμία δημιουργίας φίλτρου"
 
-#: curs_main.c:2160 curs_main.c:2198 curs_main.c:2658 curs_main.c:2690
+#: curs_main.c:2168 curs_main.c:2206 curs_main.c:2666 curs_main.c:2698
 #: flags.c:376 thread.c:1078 thread.c:1134 thread.c:1202
 msgid "Threading is not enabled."
 msgstr "Η χρήση συζητήσεων δεν έχει ενεργοποιηθεί."
 
-#: curs_main.c:2173
+#: curs_main.c:2181
 msgid "Thread broken"
 msgstr ""
 
-#: curs_main.c:2185
+#: curs_main.c:2193
 msgid "Thread cannot be broken, message is not part of a thread"
 msgstr ""
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2195
+#: curs_main.c:2203
 msgid "Cannot link threads"
 msgstr ""
 
-#: curs_main.c:2200
+#: curs_main.c:2208
 msgid "No Message-ID: header available to link thread"
 msgstr ""
 
-#: curs_main.c:2202
+#: curs_main.c:2210
 #, fuzzy
 msgid "First, please tag a message to be linked here"
 msgstr "αποθήκευση αυτού του μηνύματος για μετέπειτα αποστολή"
 
-#: curs_main.c:2213
+#: curs_main.c:2221
 msgid "Threads linked"
 msgstr ""
 
-#: curs_main.c:2216
+#: curs_main.c:2224
 msgid "No thread linked"
 msgstr ""
 
-#: curs_main.c:2252 curs_main.c:2278
+#: curs_main.c:2260 curs_main.c:2286
 msgid "You are on the last message."
 msgstr "Είστε στο τελευταίο μήνυμα."
 
-#: curs_main.c:2260 curs_main.c:2305
+#: curs_main.c:2268 curs_main.c:2313
 msgid "No undeleted messages."
 msgstr "Δεν υπάρχουν αποκαταστημένα μηνύματα."
 
-#: curs_main.c:2297 curs_main.c:2323
+#: curs_main.c:2305 curs_main.c:2331
 msgid "You are on the first message."
 msgstr "Είστε στο πρώτο μήνυμα."
 
-#: curs_main.c:2395 menu.c:970 pager.c:2440 pattern.c:2110
+#: curs_main.c:2403 menu.c:970 pager.c:2440 pattern.c:2110
 msgid "Search wrapped to top."
 msgstr "Αναζήτηση συνεχίστηκε από την κορυφή."
 
-#: curs_main.c:2404 pager.c:2463 pattern.c:2121
+#: curs_main.c:2412 pager.c:2463 pattern.c:2121
 msgid "Search wrapped to bottom."
 msgstr "Αναζήτηση συνεχίστηκε στη βάση."
 
-#: curs_main.c:2447
+#: curs_main.c:2455
 #, fuzzy
 msgid "No new messages in this limited view."
 msgstr "Το τρέχον μήνυμα δεν είναι ορατό σε αυτή τη περιορισμένη όψη"
 
-#: curs_main.c:2449
+#: curs_main.c:2457
 #, fuzzy
 msgid "No new messages."
 msgstr "Δεν υπάρχουν νέα μηνύματα"
 
-#: curs_main.c:2454
+#: curs_main.c:2462
 #, fuzzy
 msgid "No unread messages in this limited view."
 msgstr "Το τρέχον μήνυμα δεν είναι ορατό σε αυτή τη περιορισμένη όψη"
 
-#: curs_main.c:2456
+#: curs_main.c:2464
 #, fuzzy
 msgid "No unread messages."
 msgstr "Δεν υπάρχουν μη αναγνωσμένα μηνύματα"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2474
+#: curs_main.c:2482
 #, fuzzy
 msgid "Cannot flag message"
 msgstr "απεικόνιση του μηνύματος"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2513 pager.c:3100
+#: curs_main.c:2521 pager.c:3104
 msgid "Cannot toggle new"
 msgstr ""
 
-#: curs_main.c:2590
+#: curs_main.c:2598
 msgid "No more threads."
 msgstr "Δεν υπάρχουν άλλες συζητήσεις."
 
-#: curs_main.c:2592
+#: curs_main.c:2600
 msgid "You are on the first thread."
 msgstr "Είστε στην πρώτη συζήτηση."
 
-#: curs_main.c:2676
+#: curs_main.c:2684
 #, fuzzy
 msgid "Thread contains unread or flagged messages."
 msgstr "Η συζήτηση περιέχει μη αναγνωσμένα μηνύματα."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2726 pager.c:2784
+#: curs_main.c:2734 pager.c:2784
 #, fuzzy
 msgid "Cannot delete message"
 msgstr "Δεν υπάρχουν αποκαταστημένα μηνύματα."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2838
+#: curs_main.c:2850
 #, fuzzy
 msgid "Cannot edit message"
 msgstr "Αδυναμία εγγραφής του μηνύματος"
 
 #. L10N: This is displayed when the x-label on one or more
 #. * messages is edited.
-#: curs_main.c:2900 pager.c:3200
+#: curs_main.c:2912 pager.c:3208
 #, fuzzy, c-format
 msgid "%d label changed."
 msgid_plural "%d labels changed."
@@ -1828,28 +1836,32 @@ msgstr[1] "Δεν έγινε αλλαγή στο γραμματοκιβώτιο 
 #. L10N: This is displayed when editing an x-label, but no messages
 #. * were updated.  Possibly due to canceling at the prompt or if the new
 #. * label is the same as the old label.
-#: curs_main.c:2907 pager.c:3204
+#: curs_main.c:2919 pager.c:3212
 #, fuzzy
 msgid "No labels changed."
 msgstr "Δεν έγινε αλλαγή στο γραμματοκιβώτιο "
 
 #. L10N: CHECK_ACL
-#: curs_main.c:3006
+#. L10N: Due to the implementation details we do not know whether we
+#. mark zero, 1, 12, ... messages as read. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:3022
 #, fuzzy
-msgid "Cannot mark message(s) as read"
+msgid "Cannot mark messages as read"
 msgstr "μετάβαση στο τρέχον μήνυμα της συζήτησης"
 
 #. L10N: This is the prompt for <mark-message>.  Whatever they
 #. enter will be prefixed by $mark_macro_prefix and will become
 #. a macro hotkey to jump to the currently selected message.
-#: curs_main.c:3042
+#: curs_main.c:3058
 #, fuzzy
 msgid "Enter macro stroke: "
 msgstr "Εισάγετε το keyID: "
 
 #. L10N: "message hotkey" is the key bindings menu description of a
 #. macro created by <mark-message>.
-#: curs_main.c:3050
+#: curs_main.c:3066
 #, fuzzy
 msgid "message hotkey"
 msgstr "Το μήνυμα ανεβλήθη."
@@ -1857,28 +1869,28 @@ msgstr "Το μήνυμα ανεβλήθη."
 #. L10N: This is echoed after <mark-message> creates a new hotkey
 #. macro.  %s is the hotkey string ($mark_macro_prefix followed
 #. by whatever they typed at the prompt.)
-#: curs_main.c:3055
+#: curs_main.c:3071
 #, fuzzy, c-format
 msgid "Message bound to %s."
 msgstr "Το μήνυμα διαβιβάστηκε."
 
 #. L10N: This error is printed if <mark-message> cannot find a
 #. Message-ID for the currently selected message in the index.
-#: curs_main.c:3063
+#: curs_main.c:3079
 #, fuzzy
 msgid "No message ID to macro."
 msgstr "Δεν υπάρχουν μηνύματα σε αυτό το φάκελο."
 
-#: curs_main.c:3105 pager.c:2961 recvattach.c:1388
+#: curs_main.c:3121 pager.c:2965 recvattach.c:1401
 msgid "Reply by mail as poster prefers?"
 msgstr ""
 
-#: curs_main.c:3108 pager.c:2927 pager.c:2939 pager.c:2964
+#: curs_main.c:3124 pager.c:2931 pager.c:2943 pager.c:2968
 msgid "Posting to this group not allowed, may be moderated. Continue?"
 msgstr ""
 
 #. L10N: CHECK_ACL
-#: curs_main.c:3173 pager.c:3120
+#: curs_main.c:3189 pager.c:3124
 #, fuzzy
 msgid "Cannot undelete message"
 msgstr "Δεν υπάρχουν αποκαταστημένα μηνύματα."
@@ -2091,12 +2103,34 @@ msgstr "[-- Autoview κανονική έξοδος του %s --]\n"
 msgid "[-- Error: message/external-body has no access-type parameter --]\n"
 msgstr "[-- Σφάλμα: το μήνυμα/εξωτερικό-σώμα δεν έχει παράμετρο access-type --]\n"
 
-#: handler.c:1611
+#. L10N: If the translation of this string is a multi line string, then
+#. each line should start with "[-- " and end with " --]".
+#. The first "%s/%s" is a MIME type, e.g. "text/plain". The last %s
+#. expands to a date as returned by `mutt_date_parse_date()`.
+#.
+#. Note: The size argument printed is not the actual number as passed
+#. to gettext but the prettified version, e.g. size = 2048 will be
+#. printed as 2K.  Your language might be sensitive to that: For
+#. example although '1K' and '1024' represent the same number your
+#. language might inflect the noun 'byte' differently.
+#.
+#. Sadly, we cannot do anything about that at the moment besides
+#. passing the precise size in bytes. If you are interested the
+#. function responsible for the prettification is
+#. mutt_str_pretty_size() in mutt/string.c.
+#.
+#: handler.c:1624
 #, fuzzy, c-format
 msgid ""
+"[-- This %s/%s attachment (size %s byte) has been deleted --]\n"
+"[-- on %s --]\n"
+msgid_plural ""
 "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
 "[-- on %s --]\n"
-msgstr ""
+msgstr[0] ""
+"[-- Αυτή η %s/%s προσάρτηση (μέγεθος %s bytes) έχει διαγραφεί --]\n"
+"[-- στις %s --]\n"
+msgstr[1] ""
 "[-- Αυτή η %s/%s προσάρτηση (μέγεθος %s bytes) έχει διαγραφεί --]\n"
 "[-- στις %s --]\n"
 
@@ -2104,10 +2138,23 @@ msgstr ""
 #. each line should start with "[-- " and end with " --]".
 #. The first "%s/%s" is a MIME type, e.g. "text/plain".
 #.
-#: handler.c:1620
+#. Note: The size argument printed is not the actual number as passed
+#. to gettext but the prettified version, e.g. size = 2048 will be
+#. printed as 2K.  Your language might be sensitive to that: For
+#. example although '1K' and '1024' represent the same number your
+#. language might inflect the noun 'byte' differently.
+#.
+#. Sadly, we cannot do anything about that at the moment besides
+#. passing the precise size in bytes. If you are interested the
+#. function responsible for the prettification is
+#. mutt_str_pretty_size() in mutt/string.c.
+#.
+#: handler.c:1648
 #, fuzzy, c-format
-msgid "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
-msgstr "[-- Αυτή η %s/%s προσάρτηση (μέγεθος %s bytes) έχει διαγραφεί --]\n"
+msgid "[-- This %s/%s attachment (size %s byte) has been deleted --]\n"
+msgid_plural "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
+msgstr[0] "[-- Αυτή η %s/%s προσάρτηση (μέγεθος %s bytes) έχει διαγραφεί --]\n"
+msgstr[1] "[-- Αυτή η %s/%s προσάρτηση (μέγεθος %s bytes) έχει διαγραφεί --]\n"
 
 #. L10N: If the translation of this string is a multi line string, then
 #. each line should start with "[-- " and end with " --]".
@@ -2117,7 +2164,7 @@ msgstr "[-- Αυτή η %s/%s προσάρτηση (μέγεθος %s bytes) έ�
 #. Caution: Argument three %3$ is also defined but should not be used
 #. in this translation!
 #.
-#: handler.c:1637
+#: handler.c:1667
 #, fuzzy
 msgid ""
 "[-- This %s/%s attachment has been deleted --]\n"
@@ -2130,17 +2177,17 @@ msgstr ""
 #. each line should start with "[-- " and end with " --]".
 #. The first "%s/%s" is a MIME type, e.g. "text/plain".
 #.
-#: handler.c:1646
+#: handler.c:1676
 #, fuzzy, c-format
 msgid "[-- This %s/%s attachment has been deleted --]\n"
 msgstr "[-- Αυτή η %s/%s προσάρτηση έχει διαγραφεί --]\n"
 
-#: handler.c:1656
+#: handler.c:1686
 #, c-format
 msgid "[-- name: %s --]\n"
 msgstr "[-- όνομα: %s --]\n"
 
-#: handler.c:1672
+#: handler.c:1702
 #, fuzzy, c-format
 msgid ""
 "[-- This %s/%s attachment is not included, --]\n"
@@ -2151,7 +2198,7 @@ msgstr ""
 "[-- και η ενδεδειγμένη εξωτερική πηγή έχει --]\n"
 "[-- λήξει. --]\n"
 
-#: handler.c:1693
+#: handler.c:1723
 #, fuzzy, c-format
 msgid ""
 "[-- This %s/%s attachment is not included, --]\n"
@@ -2160,52 +2207,52 @@ msgstr ""
 "[-- Αυτή η %s/%s προσάρτηση δεν περιλαμβάνετε, --]\n"
 "[-- και το ενδεδειγμένο access-type %s δεν υποστηρίζεται --]\n"
 
-#: handler.c:1822
+#: handler.c:1852
 #, fuzzy
 msgid "Unable to open memory stream!"
 msgstr "Αδυναμία ανοίγματος προσωρινού αρχείου!"
 
-#: handler.c:1831
+#: handler.c:1861
 msgid "Unable to open temporary file!"
 msgstr "Αδυναμία ανοίγματος προσωρινού αρχείου!"
 
-#: handler.c:1881
+#: handler.c:1911
 #, fuzzy
 msgid "failed to re-open memstream!"
 msgstr "Αδυναμία ανοίγματος προσωρινού αρχείου!"
 
-#: handler.c:2013
+#: handler.c:2043
 msgid "Error: multipart/signed has no protocol."
 msgstr "Σφάλμα: το πολυμερές/υπογεγραμμένο δεν έχει πρωτόκολλο"
 
-#: handler.c:2076
+#: handler.c:2106
 #, fuzzy
 msgid "[-- This is an attachment (use '%3$s' to view this part) --]\n"
 msgstr "[-- Αυτή η %s/%s προσάρτηση (χρησιμοποιήστε το '%3$s' για να δείτε αυτό το μέρος) --]\n"
 
-#: handler.c:2082
+#: handler.c:2112
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported (use '%s' to view this part) --]\n"
 msgstr "[-- Το %s/%s δεν υποστηρίζεται (χρησιμοποιήστε το '%s' για να δείτε αυτό το μέρος) --]\n"
 
-#: handler.c:2087
+#: handler.c:2117
 #, fuzzy
 msgid "[-- This is an attachment (need 'view-attachments' bound to key!) --]\n"
 msgstr "[-- Αυτή η %s/%s προσάρτηση (απαιτείται το 'view-attachments' να είναι συνδεδεμένο με πλήκτρο! --]\n"
 
 #. L10N: %s/%s is a MIME type, e.g. "text/plain".
-#: handler.c:2091
+#: handler.c:2121
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported (need 'view-attachments' bound to key!) --]\n"
 msgstr "[-- Το %s/%s δεν υποστηρίζεται (απαιτείται το 'view-attachments' να είναι συνδεδεμένο με πλήκτρο! --]\n"
 
-#: handler.c:2098
+#: handler.c:2128
 #, fuzzy
 msgid "[-- This is an attachment --]\n"
 msgstr "[-- Αυτή η %s/%s προσάρτηση --]\n"
 
 #. L10N: %s/%s is a MIME type, e.g. "text/plain".
-#: handler.c:2101
+#: handler.c:2131
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported --]\n"
 msgstr "[-- Το %s/%s δεν υποστηρίζεται --]\n"
@@ -2513,7 +2560,7 @@ msgstr ""
 msgid "Invalid IMAP flags"
 msgstr "Μη έγκυρο   "
 
-#: imap/message.c:477 mx.c:1326
+#: imap/message.c:477 mx.c:1336
 msgid "Integer overflow -- can't allocate memory."
 msgstr "Υπερχείλιση ακεραίου -- αδυναμία εκχώρησης μνήμης."
 
@@ -3286,66 +3333,75 @@ msgstr "Το SSL δεν είναι διαθέσιμο."
 msgid "Reading from %s interrupted..."
 msgstr "Η αναζήτηση διακόπηκε."
 
-#: mx.c:634
+#. L10N: Although we now the precise number of messages, we do not show it to the user.
+#. So feel free to use a "generic plural" as plural translation if your language has one.
+#.
+#: mx.c:639
 #, fuzzy
-msgid "message(s) not deleted"
-msgstr "Σημείωση %d διαγραφέντων μηνυμάτων..."
+msgid "message not deleted"
+msgid_plural "messages not deleted"
+msgstr[0] "Σημείωση %d διαγραφέντων μηνυμάτων..."
+msgstr[1] "Σημείωση %d διαγραφέντων μηνυμάτων..."
 
-#: mx.c:671
+#: mx.c:676
 #, fuzzy
 msgid "Can't open trash folder"
 msgstr "Αδυναμία πρόσθεσης στο φάκελο: %s"
 
-#: mx.c:710
+#: mx.c:715
 msgid "Mark all articles read?"
 msgstr ""
 
-#: mx.c:754
+#. L10N: The first argument is the number of read messages to be
+#. moved, the second argument is the target mailbox.
+#: mx.c:762
 #, fuzzy, c-format
-msgid "Move %d read messages to %s?"
-msgstr "Μετακίνηση αναγνωσμένων μηνυμάτων στο %s;"
+msgid "Move %d read message to %s?"
+msgid_plural "Move %d read messages to %s?"
+msgstr[0] "Μετακίνηση αναγνωσμένων μηνυμάτων στο %s;"
+msgstr[1] "Μετακίνηση αναγνωσμένων μηνυμάτων στο %s;"
 
-#: mx.c:771 mx.c:1077
+#: mx.c:781 mx.c:1087
 #, fuzzy, c-format
 msgid "Purge %d deleted message?"
 msgid_plural "Purge %d deleted messages?"
 msgstr[0] "Καθαρισμός %d διεγραμμένου μηνύματος;"
 msgstr[1] "Καθαρισμός %d διεγραμμένων μηνυμάτων;"
 
-#: mx.c:793
+#: mx.c:803
 #, c-format
 msgid "Moving read messages to %s..."
 msgstr "Μετακίνηση αναγνωσμένων μηνυμάτων στο %s..."
 
-#: mx.c:859 mx.c:1068
+#: mx.c:869 mx.c:1078
 msgid "Mailbox is unchanged."
 msgstr "Δεν έγινε αλλαγή στο γραμματοκιβώτιο "
 
-#: mx.c:914
+#: mx.c:924
 #, c-format
 msgid "%d kept, %d moved, %d deleted."
 msgstr "%d κρατήθηκαν, %d μετακινήθηκαν, %d διαγράφηκαν."
 
-#: mx.c:917 mx.c:1130
+#: mx.c:927 mx.c:1140
 #, c-format
 msgid "%d kept, %d deleted."
 msgstr "%d κρατήθηκαν, %d διαγράφηκαν."
 
-#: mx.c:1052
+#: mx.c:1062
 #, c-format
 msgid " Press '%s' to toggle write"
 msgstr "Πατήστε '%s' για να ενεργοποιήσετε την εγγραφή!"
 
-#: mx.c:1054
+#: mx.c:1064
 msgid "Use 'toggle-write' to re-enable write!"
 msgstr "Χρησιμοποιήστε το 'toggle-write' για να ενεργοποιήσετε την εγγραφή!"
 
-#: mx.c:1056
+#: mx.c:1066
 #, c-format
 msgid "Mailbox is marked unwritable. %s"
 msgstr "Το γραμματοκιβώτιο είναι σημειωμένο μη εγγράψιμο. %s"
 
-#: mx.c:1124
+#: mx.c:1134
 msgid "Mailbox checkpointed."
 msgstr "Το γραμματοκιβώτιο σημειώθηκε."
 
@@ -3359,54 +3415,59 @@ msgstr "(τρέχουσα ώρα: %c)"
 msgid "[-- %s output follows%s --]\n"
 msgstr "[-- %s ακολουθεί έξοδος%s --]\n"
 
-#: ncrypt/crypt.c:95
-msgid "Passphrase(s) forgotten."
+#. L10N: Due to the implementation details (e.g. some passwords are managed
+#. by gpg-agent) we cannot know whether we forgot zero, 1, 12, ...
+#. passwords. So in English we use "Passphrases". Your language might
+#. have other means to express this.
+#: ncrypt/crypt.c:100
+#, fuzzy
+msgid "Passphrases forgotten."
 msgstr "Η φράση(-εις)-κλειδί έχει ξεχαστεί."
 
-#: ncrypt/crypt.c:155
+#: ncrypt/crypt.c:161
 #, fuzzy
 msgid "Inline PGP can't be used with attachments.  Revert to PGP/MIME?"
 msgstr "Το μήνυμα δεν μπορεί να σταλεί ως εσωτερικό κείμενο. Να χρησιμοποιηθεί PGP/MIME;"
 
-#: ncrypt/crypt.c:159
+#: ncrypt/crypt.c:165
 msgid "Mail not sent: inline PGP can't be used with attachments."
 msgstr ""
 
-#: ncrypt/crypt.c:166
+#: ncrypt/crypt.c:172
 #, fuzzy
 msgid "Inline PGP can't be used with format=flowed.  Revert to PGP/MIME?"
 msgstr "Το μήνυμα δεν μπορεί να σταλεί ως εσωτερικό κείμενο. Να χρησιμοποιηθεί PGP/MIME;"
 
-#: ncrypt/crypt.c:170
+#: ncrypt/crypt.c:176
 msgid "Mail not sent: inline PGP can't be used with format=flowed."
 msgstr ""
 
-#: ncrypt/crypt.c:180 ncrypt/cryptglue.c:125 ncrypt/pgpkey.c:589
+#: ncrypt/crypt.c:186 ncrypt/cryptglue.c:125 ncrypt/pgpkey.c:589
 #: ncrypt/pgpkey.c:782
 msgid "Invoking PGP..."
 msgstr "Κλήση του PGP..."
 
-#: ncrypt/crypt.c:192
+#: ncrypt/crypt.c:198
 msgid "Message can't be sent inline.  Revert to using PGP/MIME?"
 msgstr "Το μήνυμα δεν μπορεί να σταλεί ως εσωτερικό κείμενο. Να χρησιμοποιηθεί PGP/MIME;"
 
-#: ncrypt/crypt.c:194 send.c:1824
+#: ncrypt/crypt.c:200 send.c:1824
 msgid "Mail not sent."
 msgstr "Το γράμμα δεν εστάλη."
 
-#: ncrypt/crypt.c:540
+#: ncrypt/crypt.c:546
 msgid "S/MIME messages with no hints on content are unsupported."
 msgstr "Δεν υποστηρίζονται μηνύματα S/MIME χωρίς πληροφορίες στην επικεφαλίδα."
 
-#: ncrypt/crypt.c:754 ncrypt/crypt.c:795
+#: ncrypt/crypt.c:760 ncrypt/crypt.c:801
 msgid "Trying to extract PGP keys...\n"
 msgstr "Προσπάθεια εξαγωγής κλειδιών PGP...\n"
 
-#: ncrypt/crypt.c:776 ncrypt/crypt.c:816
+#: ncrypt/crypt.c:782 ncrypt/crypt.c:822
 msgid "Trying to extract S/MIME certificates...\n"
 msgstr "Προσπάθεια εξαγωγής πιστοποιητικών S/MIME...\n"
 
-#: ncrypt/crypt.c:976
+#: ncrypt/crypt.c:982
 #, c-format
 msgid ""
 "[-- Error: Unknown multipart/signed protocol %s! --]\n"
@@ -3415,7 +3476,7 @@ msgstr ""
 "[-- Σφάλμα: Άγνωστο πολυμερές/υπογεγραμμένο πρωτόκολλο %s! --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1016
+#: ncrypt/crypt.c:1022
 #, fuzzy
 msgid ""
 "[-- Error: Missing or bad-format multipart/signed signature! --]\n"
@@ -3424,7 +3485,7 @@ msgstr ""
 "[-- Σφάλμα: Ασυνεπής πολυμερής/υπογεγραμμένη δομή! --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1058
+#: ncrypt/crypt.c:1064
 #, c-format
 msgid ""
 "[-- Warning: We can't verify %s/%s signatures. --]\n"
@@ -3433,7 +3494,7 @@ msgstr ""
 "[-- Προειδοποίηση: αδυναμία επιβεβαίωσης %s%s υπογραφών --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1070
+#: ncrypt/crypt.c:1076
 msgid ""
 "[-- The following data is signed --]\n"
 "\n"
@@ -3441,7 +3502,7 @@ msgstr ""
 "[-- Τα επόμενα δεδομένα είναι υπογεγραμμένα --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1075
+#: ncrypt/crypt.c:1081
 msgid ""
 "[-- Warning: Can't find any signatures. --]\n"
 "\n"
@@ -3449,7 +3510,7 @@ msgstr ""
 "[-- Προειδοποίηση: Αδυναμία εύρεσης υπογραφών. --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1081
+#: ncrypt/crypt.c:1087
 msgid ""
 "\n"
 "[-- End of signed data --]\n"
@@ -3501,7 +3562,7 @@ msgstr ""
 msgid "error reading data object: %s\n"
 msgstr "σφάλμα στο μοντέλο στο: %s"
 
-#: ncrypt/crypt_gpgme.c:662 ncrypt/crypt_gpgme.c:3848 ncrypt/pgpkey.c:585
+#: ncrypt/crypt_gpgme.c:662 ncrypt/crypt_gpgme.c:3850 ncrypt/pgpkey.c:585
 #: ncrypt/pgpkey.c:768
 msgid "Can't create temporary file"
 msgstr "Αδυναμία δημιουργίας προσωρινού αρχείου"
@@ -3866,29 +3927,31 @@ msgstr "Μη έγκυρο   "
 
 #. L10N: This is printed after "Key Type: " and looks like this:
 #. *       PGP, 2048 bit RSA
-#: ncrypt/crypt_gpgme.c:3670 ncrypt/crypt_gpgme.c:3808
+#: ncrypt/crypt_gpgme.c:3670 ncrypt/crypt_gpgme.c:3810
 #, c-format
 msgid "%s, %lu bit %s\n"
-msgstr ""
+msgid_plural "%s, %lu bit %s\n"
+msgstr[0] ""
+msgstr[1] ""
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3678 ncrypt/crypt_gpgme.c:3815
+#: ncrypt/crypt_gpgme.c:3678 ncrypt/crypt_gpgme.c:3817
 #, fuzzy
 msgid "encryption"
 msgstr "Κρυπτογράφηση"
 
 #: ncrypt/crypt_gpgme.c:3679 ncrypt/crypt_gpgme.c:3685
-#: ncrypt/crypt_gpgme.c:3816 ncrypt/crypt_gpgme.c:3821
+#: ncrypt/crypt_gpgme.c:3818 ncrypt/crypt_gpgme.c:3823
 msgid ", "
 msgstr ""
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3684 ncrypt/crypt_gpgme.c:3820
+#: ncrypt/crypt_gpgme.c:3684 ncrypt/crypt_gpgme.c:3822
 msgid "signing"
 msgstr ""
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3690 ncrypt/crypt_gpgme.c:3825
+#: ncrypt/crypt_gpgme.c:3690 ncrypt/crypt_gpgme.c:3827
 #, fuzzy
 msgid "certification"
 msgstr "Το πιστοποιητικό αποθηκεύτηκε"
@@ -3910,70 +3973,70 @@ msgstr "Έληξε   "
 msgid "[Disabled]"
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:3851
+#: ncrypt/crypt_gpgme.c:3853
 #, fuzzy
 msgid "Collecting data..."
 msgstr "Σύνδεση στο %s..."
 
-#: ncrypt/crypt_gpgme.c:3876
+#: ncrypt/crypt_gpgme.c:3878
 #, fuzzy, c-format
 msgid "Error finding issuer key: %s\n"
 msgstr "Σφάλμα κατα τη σύνδεση στο διακομιστή: %s"
 
-#: ncrypt/crypt_gpgme.c:3885
+#: ncrypt/crypt_gpgme.c:3887
 #, fuzzy
 msgid "Error: certification chain too long - stopping here\n"
 msgstr "Λάθος στη γραμμή εντολών: %s\n"
 
-#: ncrypt/crypt_gpgme.c:3895 ncrypt/pgpkey.c:608
+#: ncrypt/crypt_gpgme.c:3897 ncrypt/pgpkey.c:608
 #, c-format
 msgid "Key ID: 0x%s"
 msgstr "ID κλειδιού: 0x%s"
 
-#: ncrypt/crypt_gpgme.c:3990
+#: ncrypt/crypt_gpgme.c:3992
 #, fuzzy, c-format
 msgid "gpgme_new failed: %s"
 msgstr "SSL απέτυχε: %s"
 
-#: ncrypt/crypt_gpgme.c:4028 ncrypt/crypt_gpgme.c:4079
+#: ncrypt/crypt_gpgme.c:4030 ncrypt/crypt_gpgme.c:4081
 #, c-format
 msgid "gpgme_op_keylist_start failed: %s"
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4067 ncrypt/crypt_gpgme.c:4109
+#: ncrypt/crypt_gpgme.c:4069 ncrypt/crypt_gpgme.c:4111
 #, c-format
 msgid "gpgme_op_keylist_next failed: %s"
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4185
+#: ncrypt/crypt_gpgme.c:4187
 #, fuzzy
 msgid "All matching keys are marked expired/revoked."
 msgstr "Όλα τα κλειδιά που ταιριάζουν είναι ληγμένα, ακυρωμένα ή ανενεργά."
 
-#: ncrypt/crypt_gpgme.c:4215 ncrypt/pgpkey.c:543 ncrypt/smime.c:475
+#: ncrypt/crypt_gpgme.c:4217 ncrypt/pgpkey.c:543 ncrypt/smime.c:475
 msgid "Select  "
 msgstr "Διαλέξτε "
 
-#: ncrypt/crypt_gpgme.c:4217 ncrypt/pgpkey.c:545
+#: ncrypt/crypt_gpgme.c:4219 ncrypt/pgpkey.c:545
 msgid "Check key  "
 msgstr "Ελέγξτε κλειδί "
 
-#: ncrypt/crypt_gpgme.c:4233
+#: ncrypt/crypt_gpgme.c:4235
 #, fuzzy
 msgid "PGP and S/MIME keys matching"
 msgstr "Όμοια S/MIME κλειδιά \"%s\"."
 
-#: ncrypt/crypt_gpgme.c:4235
+#: ncrypt/crypt_gpgme.c:4237
 #, fuzzy
 msgid "PGP keys matching"
 msgstr "Όμοια PGP κλειδιά \"%s\"."
 
-#: ncrypt/crypt_gpgme.c:4237
+#: ncrypt/crypt_gpgme.c:4239
 #, fuzzy
 msgid "S/MIME keys matching"
 msgstr "Όμοια πιστοποιητικά S/MIME \"%s\"."
 
-#: ncrypt/crypt_gpgme.c:4239
+#: ncrypt/crypt_gpgme.c:4241
 #, fuzzy
 msgid "keys matching"
 msgstr "Όμοια PGP κλειδιά \"%s\"."
@@ -3982,69 +4045,69 @@ msgstr "Όμοια PGP κλειδιά \"%s\"."
 #. %1$s is one of the previous four entries.
 #. %2$s is an address.
 #. e.g. "S/MIME keys matching <me@mutt.org>."
-#: ncrypt/crypt_gpgme.c:4246
+#: ncrypt/crypt_gpgme.c:4248
 #, c-format
 msgid "%s <%s>."
 msgstr ""
 
 #. L10N:
 #. e.g. 'S/MIME keys matching "Michael Elkins".'
-#: ncrypt/crypt_gpgme.c:4250
+#: ncrypt/crypt_gpgme.c:4252
 #, c-format
 msgid "%s \"%s\"."
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4277 ncrypt/pgpkey.c:628
+#: ncrypt/crypt_gpgme.c:4279 ncrypt/pgpkey.c:628
 msgid "This key can't be used: expired/disabled/revoked."
 msgstr "Αυτό το κλειδί δεν μπορεί να χρησιμοποιηθεί ληγμένο/αχρηστευμένο/άκυρο."
 
-#: ncrypt/crypt_gpgme.c:4290 ncrypt/pgpkey.c:640 ncrypt/smime.c:505
+#: ncrypt/crypt_gpgme.c:4292 ncrypt/pgpkey.c:640 ncrypt/smime.c:505
 #, fuzzy
 msgid "ID is expired/disabled/revoked. Do you really want to use the key?"
 msgstr "Το ID είναι ληγμένο/αχρηστευμένο/άκυρο. Θέλετε σίγουρα να χρησιμοποιήσετε το κλειδί;"
 
-#: ncrypt/crypt_gpgme.c:4299 ncrypt/pgpkey.c:650
+#: ncrypt/crypt_gpgme.c:4301 ncrypt/pgpkey.c:650
 #, fuzzy
 msgid "ID is not valid. Do you really want to use the key?"
 msgstr "Το ID δεν είναι έγκυρο. Θέλετε σίγουρα να χρησιμοποιήσετε το κλειδί;"
 
-#: ncrypt/crypt_gpgme.c:4302 ncrypt/pgpkey.c:653
+#: ncrypt/crypt_gpgme.c:4304 ncrypt/pgpkey.c:653
 #, fuzzy
 msgid "ID is only marginally valid. Do you really want to use the key?"
 msgstr "Το ID είναι μόνο μερικώς έγκυρο. Θέλετε σίγουρα να χρησιμοποιήσετε το κλειδί;"
 
-#: ncrypt/crypt_gpgme.c:4310 ncrypt/pgpkey.c:646 ncrypt/smime.c:509
+#: ncrypt/crypt_gpgme.c:4312 ncrypt/pgpkey.c:646 ncrypt/smime.c:509
 #, fuzzy
 msgid "ID has undefined validity. Do you really want to use the key?"
 msgstr "Το ID έχει μη ορισμένη εγκυρότητα. Θέλετε σίγουρα να χρησιμοποιήσετε το κλειδί;"
 
-#: ncrypt/crypt_gpgme.c:4370 ncrypt/crypt_gpgme.c:4479 ncrypt/pgpkey.c:872
+#: ncrypt/crypt_gpgme.c:4372 ncrypt/crypt_gpgme.c:4481 ncrypt/pgpkey.c:872
 #: ncrypt/pgpkey.c:995
 #, c-format
 msgid "Looking for keys matching \"%s\"..."
 msgstr "Εύρεση όμοιων κλειδιών με \"%s\"..."
 
-#: ncrypt/crypt_gpgme.c:4593 ncrypt/pgpkey.c:731 ncrypt/smime.c:811
+#: ncrypt/crypt_gpgme.c:4595 ncrypt/pgpkey.c:731 ncrypt/smime.c:811
 #, c-format
 msgid "No matching keys found for \"%s\""
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4644 ncrypt/pgp.c:1263
+#: ncrypt/crypt_gpgme.c:4646 ncrypt/pgp.c:1263
 #, c-format
 msgid "Use keyID = \"%s\" for %s?"
 msgstr "Να χρησιμοποιηθεί keyID = \"%s\" για το %s;"
 
-#: ncrypt/crypt_gpgme.c:4695 ncrypt/pgp.c:1312 ncrypt/smime.c:830
+#: ncrypt/crypt_gpgme.c:4697 ncrypt/pgp.c:1312 ncrypt/smime.c:830
 #: ncrypt/smime.c:938
 #, c-format
 msgid "Enter keyID for %s: "
 msgstr "Εισάγετε keyID για το %s: "
 
-#: ncrypt/crypt_gpgme.c:4755 ncrypt/pgpkey.c:751
+#: ncrypt/crypt_gpgme.c:4757 ncrypt/pgpkey.c:751
 msgid "Please enter the key ID: "
 msgstr "Παρακαλώ γράψτε το ID του κλειδιού: "
 
-#: ncrypt/crypt_gpgme.c:4768
+#: ncrypt/crypt_gpgme.c:4770
 #, fuzzy, c-format
 msgid "Error exporting key: %s\n"
 msgstr "σφάλμα στο μοντέλο στο: %s"
@@ -4053,90 +4116,90 @@ msgstr "σφάλμα στο μοντέλο στο: %s"
 #. MIME description for exported (attached) keys.
 #. You can translate this entry to a non-ASCII string (it will be encoded),
 #. but it may be safer to keep it untranslated.
-#: ncrypt/crypt_gpgme.c:4787
+#: ncrypt/crypt_gpgme.c:4789
 #, fuzzy, c-format
 msgid "PGP Key 0x%s."
 msgstr "Κλειδί PGP %s."
 
-#: ncrypt/crypt_gpgme.c:4830
+#: ncrypt/crypt_gpgme.c:4832
 msgid "GPGME: OpenPGP protocol not available"
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4838
+#: ncrypt/crypt_gpgme.c:4840
 msgid "GPGME: CMS protocol not available"
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4876
+#: ncrypt/crypt_gpgme.c:4878
 #, fuzzy
 msgid "S/MIME (s)ign, sign (a)s, (p)gp, (c)lear, or (o)ppenc mode off? "
 msgstr "S/MIME (e)κλείδ, (s)υπογρ, υπογρ.σ(a)ν, (b)κλ+υπ, %s, ή (c)τίποτα; "
 
 #. L10N: S/MIME options (opportunistic encryption is on)
-#: ncrypt/crypt_gpgme.c:4878
+#: ncrypt/crypt_gpgme.c:4880
 msgid "sapco"
 msgstr "esabc"
 
-#: ncrypt/crypt_gpgme.c:4885
+#: ncrypt/crypt_gpgme.c:4887
 #, fuzzy
 msgid "PGP (s)ign, sign (a)s, s/(m)ime, (c)lear, or (o)ppenc mode off? "
 msgstr "PGP (e)κλείδ, (s)υπογρ, υπογρ.σ(a)ν, (b)κλ+υπ, %s, ή (c)τίποτα; "
 
 #. L10N: PGP options (opportunistic encryption is on)
-#: ncrypt/crypt_gpgme.c:4887
+#: ncrypt/crypt_gpgme.c:4889
 msgid "samco"
 msgstr "esabc"
 
 #. L10N: S/MIME options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4900
+#: ncrypt/crypt_gpgme.c:4902
 #, fuzzy
 msgid "S/MIME (e)ncrypt, (s)ign, sign (a)s, (b)oth, (p)gp, (c)lear, or (o)ppenc mode? "
 msgstr "S/MIME (e)κλείδ, (s)υπογρ, υπογρ.σ(a)ν, (b)κλ+υπ, %s, ή (c)τίποτα; "
 
 #. L10N: S/MIME options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4903
+#: ncrypt/crypt_gpgme.c:4905
 #, fuzzy
 msgid "esabpco"
 msgstr "esabc"
 
 #. L10N: PGP options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4909
+#: ncrypt/crypt_gpgme.c:4911
 #, fuzzy
 msgid "PGP (e)ncrypt, (s)ign, sign (a)s, (b)oth, s/(m)ime, (c)lear, or (o)ppenc mode? "
 msgstr "PGP (e)κλείδ, (s)υπογρ, υπογρ.σ(a)ν, (b)κλ+υπ, %s, ή (c)τίποτα; "
 
 #. L10N: PGP options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4912
+#: ncrypt/crypt_gpgme.c:4914
 #, fuzzy
 msgid "esabmco"
 msgstr "esabc"
 
-#: ncrypt/crypt_gpgme.c:4925
+#: ncrypt/crypt_gpgme.c:4927
 #, fuzzy
 msgid "S/MIME (e)ncrypt, (s)ign, sign (a)s, (b)oth, (p)gp or (c)lear? "
 msgstr "S/MIME (e)κλείδ, (s)υπογρ, υπογρ.σ(a)ν, (b)κλ+υπ, %s, ή (c)τίποτα; "
 
 #. L10N: S/MIME options
-#: ncrypt/crypt_gpgme.c:4927
+#: ncrypt/crypt_gpgme.c:4929
 #, fuzzy
 msgid "esabpc"
 msgstr "esabc"
 
-#: ncrypt/crypt_gpgme.c:4934
+#: ncrypt/crypt_gpgme.c:4936
 #, fuzzy
 msgid "PGP (e)ncrypt, (s)ign, sign (a)s, (b)oth, s/(m)ime or (c)lear? "
 msgstr "PGP (e)κλείδ, (s)υπογρ, υπογρ.σ(a)ν, (b)κλ+υπ, %s, ή (c)τίποτα; "
 
 #. L10N: PGP options
-#: ncrypt/crypt_gpgme.c:4936
+#: ncrypt/crypt_gpgme.c:4938
 #, fuzzy
 msgid "esabmc"
 msgstr "esabc"
 
-#: ncrypt/crypt_gpgme.c:5087
+#: ncrypt/crypt_gpgme.c:5089
 msgid "Failed to verify sender"
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:5090
+#: ncrypt/crypt_gpgme.c:5092
 #, fuzzy
 msgid "Failed to figure out sender"
 msgstr "Αποτυχία κατά το άνοιγμα αρχείου για την ανάλυση των επικεφαλίδων."
@@ -4537,7 +4600,7 @@ msgstr ""
 msgid "%s is an invalid news server specification!"
 msgstr "%s είναι μη έγκυρη POP διαδρομή"
 
-#: nntp.c:75 nntp.c:612 pop.c:1028 pop_lib.c:405
+#: nntp.c:75 nntp.c:612 pop.c:1031 pop_lib.c:405
 msgid "Server closed connection!"
 msgstr "Η σύνδεση με τον εξυπηρετητή έκλεισε!"
 
@@ -4703,16 +4766,17 @@ msgstr "εξέταση γραμμα/τίων για νέα αλληλογραφ�
 
 #: opcodes.h:47
 #, fuzzy
-msgid "attach file(s) to this message"
+msgid "attach files to this message"
 msgstr "προσάρτηση αρχείου/ων σε αυτό το μήνυμα"
 
 #: opcodes.h:48
-msgid "attach message(s) to this message"
+#, fuzzy
+msgid "attach messages to this message"
 msgstr "προσάρτηση μηνύματος/των σε αυτό το μήνυμα"
 
 #: opcodes.h:49
 #, fuzzy
-msgid "attach news article(s) to this message"
+msgid "attach news articles to this message"
 msgstr "προσάρτηση αρχείου/ων σε αυτό το μήνυμα"
 
 #: opcodes.h:50
@@ -5559,7 +5623,8 @@ msgid "extract supported public keys"
 msgstr "εξαγωγή των δημόσιων κλειδιών που υποστηρίζονται"
 
 #: opcodes.h:255
-msgid "wipe passphrase(s) from memory"
+#, fuzzy
+msgid "wipe passphrases from memory"
 msgstr "εξαφάνιση της φράσης(-εων) κλειδί από τη μνήμη"
 
 #: opcodes.h:259
@@ -5911,18 +5976,20 @@ msgstr "Δεν υπάρχει αλληλογραφία στο POP γραμματ
 msgid "Delete messages from server?"
 msgstr "Διαγραφή μηνυμάτων από τον εξυπηρετητή;"
 
-#: pop.c:954
-#, c-format
-msgid "Reading new messages (%d bytes)..."
-msgstr "Ανάγνωση νέων μηνυμάτων (%d bytes)..."
+#: pop.c:955
+#, fuzzy, c-format
+msgid "Reading new messages (%d byte)..."
+msgid_plural "Reading new messages (%d bytes)..."
+msgstr[0] "Ανάγνωση νέων μηνυμάτων (%d bytes)..."
+msgstr[1] "Ανάγνωση νέων μηνυμάτων (%d bytes)..."
 
-#: pop.c:997
+#: pop.c:1000
 msgid "Error while writing mailbox!"
 msgstr "Σφάλμα κατά την εγγραφή στο γραμματοκιβώτιο"
 
 #. L10N: The plural is picked by the second numerical argument, i.e.
 #. * the %d right before 'messages', i.e. the total number of messages.
-#: pop.c:1003
+#: pop.c:1006
 #, fuzzy, c-format
 msgid "%s [%d of %d message read]"
 msgid_plural "%s [%d of %d messages read]"
@@ -6067,49 +6134,56 @@ msgstr "Διοχέτευση στο: "
 msgid "I don't know how to print %s attachments!"
 msgstr "Δεν ξέρω πως να τυπώσω τις %s προσαρτήσεις!"
 
-#: recvattach.c:841
-msgid "Print tagged attachment(s)?"
-msgstr "Εκτύπωση σημειωμένου/ων προσάρτησης/σεων;"
+#. L10N: Although we now the precise number of tagged messages, we
+#. do not show it to the user.  So feel free to use a "generic
+#. plural" as plural translation if your language has one.
+#: recvattach.c:852
+#, fuzzy, c-format
+msgid "Print tagged attachment?"
+msgid_plural "Print %d tagged attachments?"
+msgstr[0] "Εκτύπωση σημειωμένου/ων προσάρτησης/σεων;"
+msgstr[1] "Εκτύπωση σημειωμένου/ων προσάρτησης/σεων;"
 
-#: recvattach.c:842
+#: recvattach.c:853
+#, c-format
 msgid "Print attachment?"
 msgstr "Εκτύπωση προσαρτήσεων;"
 
-#: recvattach.c:900
+#: recvattach.c:913
 msgid "Structural changes to decrypted attachments are not supported"
 msgstr ""
 
-#: recvattach.c:1046
+#: recvattach.c:1059
 msgid "Can't decrypt encrypted message!"
 msgstr "Αδυναμία αποκρυπτογράφησης του κρυπτογραφημένου μηνύματος!"
 
-#: recvattach.c:1172
+#: recvattach.c:1185
 msgid "Attachments"
 msgstr "Προσαρτήσεις"
 
-#: recvattach.c:1210
+#: recvattach.c:1223
 msgid "There are no subparts to show!"
 msgstr "Δεν υπάρχουν επιμέρους τμήματα για να εμφανιστούν."
 
-#: recvattach.c:1265
+#: recvattach.c:1278
 msgid "Can't delete attachment from POP server."
 msgstr "Αδυναμία διαγραφής προσάρτησης από τον εξυπηρετητή POP."
 
-#: recvattach.c:1274
+#: recvattach.c:1287
 #, fuzzy
 msgid "Can't delete attachment from news server."
 msgstr "Αδυναμία διαγραφής προσάρτησης από τον εξυπηρετητή POP."
 
-#: recvattach.c:1281
+#: recvattach.c:1294
 msgid "Deletion of attachments from encrypted messages is unsupported."
 msgstr "Η διαγραφή προσαρτήσεων από κρυπτογραφημένα μηνύματα δεν υποστηρίζεται."
 
-#: recvattach.c:1287
+#: recvattach.c:1300
 #, fuzzy
 msgid "Deletion of attachments from signed messages may invalidate the signature."
 msgstr "Η διαγραφή προσαρτήσεων από κρυπτογραφημένα μηνύματα δεν υποστηρίζεται."
 
-#: recvattach.c:1305 recvattach.c:1320
+#: recvattach.c:1318 recvattach.c:1333
 msgid "Only deletion of multipart attachments is supported."
 msgstr "Μόνο η διαγραφή πολυμερών προσαρτήσεων υποστηρίζεται."
 
@@ -6529,3 +6603,15 @@ msgstr "Παράμετροι μεταγλώττισης:"
 #: version.c:404
 msgid "Compile options:"
 msgstr "Παράμετροι μεταγλώττισης:"
+
+#, fuzzy
+#~ msgid "Cannot delete message(s)"
+#~ msgstr "Δεν υπάρχουν αποκαταστημένα μηνύματα."
+
+#, fuzzy
+#~ msgid "Cannot undelete message(s)"
+#~ msgstr "Δεν υπάρχουν αποκαταστημένα μηνύματα."
+
+#, fuzzy
+#~ msgid "messages not deleted"
+#~ msgstr "Σημείωση %d διαγραφέντων μηνυμάτων..."

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neomutt-20180512\n"
 "Report-Msgid-Bugs-To: neomutt-devel@neomutt.org\n"
-"POT-Creation-Date: 2018-05-20 02:02+0000\n"
+"POT-Creation-Date: 2018-05-22 14:18+0000\n"
 "PO-Revision-Date: 2017-04-17 17:06+0100\n"
 "Last-Translator: Richard Russon <rich@flatcap.org>\n"
 "Language-Team: none\n"
@@ -39,7 +39,7 @@ msgstr "Select"
 
 #: addrbook.c:52 browser.c:75 browser.c:87 compose.c:160 compose.c:172
 #: conn/ssl.c:1041 conn/ssl_gnutls.c:793 curs_main.c:748 curs_main.c:761
-#: history.c:106 ncrypt/crypt_gpgme.c:4219 ncrypt/pgpkey.c:547
+#: history.c:106 ncrypt/crypt_gpgme.c:4221 ncrypt/pgpkey.c:547
 #: ncrypt/smime.c:477 pager.c:2141 postpone.c:65 query.c:72 recvattach.c:70
 msgid "Help"
 msgstr "Help"
@@ -659,7 +659,7 @@ msgstr "Security: "
 #. * Since it shares the row with "Encrypt with:", it should not be longer
 #. * than 15-20 character cells.
 #.
-#: compose.c:138 ncrypt/crypt_gpgme.c:4947 ncrypt/pgp.c:1786
+#: compose.c:138 ncrypt/crypt_gpgme.c:4949 ncrypt/pgp.c:1786
 #: ncrypt/smime.c:2127
 msgid "Sign as: "
 msgstr "Sign as: "
@@ -1188,7 +1188,7 @@ msgstr "(r)eject, accept (o)nce, (s)kip"
 msgid "(r)eject, accept (o)nce"
 msgstr "(r)eject, accept (o)nce"
 
-#: conn/ssl.c:1039 conn/ssl_gnutls.c:791 ncrypt/crypt_gpgme.c:4213
+#: conn/ssl.c:1039 conn/ssl_gnutls.c:791 ncrypt/crypt_gpgme.c:4215
 #: ncrypt/pgpkey.c:541 ncrypt/smime.c:473
 msgid "Exit  "
 msgstr "Exit  "
@@ -1367,11 +1367,11 @@ msgstr "No mailbox is open."
 msgid "There are no messages."
 msgstr "There are no messages."
 
-#: curs_main.c:77 mx.c:1061 pager.c:73 recvattach.c:56
+#: curs_main.c:77 mx.c:1071 pager.c:73 recvattach.c:56
 msgid "Mailbox is read-only."
 msgstr "Mailbox is read-only."
 
-#: curs_main.c:79 pager.c:75 recvattach.c:1145
+#: curs_main.c:79 pager.c:75 recvattach.c:1158
 msgid "Function not permitted in attach-message mode."
 msgstr "Function not permitted in attach-message mode."
 
@@ -1501,235 +1501,245 @@ msgid "That message is not visible."
 msgstr "That message is not visible."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:1377 curs_main.c:2772 pager.c:2818
-msgid "Cannot delete message(s)"
+#. L10N: Due to the implementation details we do not know whether we
+#. delete zero, 1, 12, ... messages. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:1381 curs_main.c:2784 pager.c:2822
+#, fuzzy
+msgid "Cannot delete messages"
 msgstr "Cannot delete message(s)"
 
-#: curs_main.c:1380
+#: curs_main.c:1384
 msgid "Delete messages matching: "
 msgstr "Delete messages matching: "
 
-#: curs_main.c:1421
+#: curs_main.c:1425
 msgid "No limit pattern is in effect."
 msgstr "No limit pattern is in effect."
 
 #. L10N: ask for a limit to apply
-#: curs_main.c:1426
+#: curs_main.c:1430
 #, c-format
 msgid "Limit: %s"
 msgstr "Limit: %s"
 
-#: curs_main.c:1464
+#: curs_main.c:1468
 msgid "Limit to messages matching: "
 msgstr "Limit to messages matching: "
 
-#: curs_main.c:1488
+#: curs_main.c:1492
 msgid "To view all messages, limit to \"all\"."
 msgstr "To view all messages, limit to \"all\"."
 
-#: curs_main.c:1500 pager.c:2318
+#: curs_main.c:1504 pager.c:2318
 msgid "Quit NeoMutt?"
 msgstr "Quit NeoMutt?"
 
-#: curs_main.c:1596
+#: curs_main.c:1600
 msgid "Tag messages matching: "
 msgstr "Tag messages matching: "
 
 #. L10N: CHECK_ACL
-#: curs_main.c:1606 curs_main.c:3203 pager.c:3137
-msgid "Cannot undelete message(s)"
+#. L10N: Due to the implementation details we do not know whether we
+#. undelete zero, 1, 12, ... messages. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:1614 curs_main.c:3223 pager.c:3145
+#, fuzzy
+msgid "Cannot undelete messages"
 msgstr "Cannot undelete message(s)"
 
-#: curs_main.c:1609
+#: curs_main.c:1617
 msgid "Undelete messages matching: "
 msgstr "Undelete messages matching: "
 
-#: curs_main.c:1619
+#: curs_main.c:1627
 msgid "Untag messages matching: "
 msgstr "Untag messages matching: "
 
-#: curs_main.c:1653
+#: curs_main.c:1661
 msgid "Logged out of IMAP servers."
 msgstr "Logged out of IMAP servers."
 
-#: curs_main.c:1753
+#: curs_main.c:1761
 msgid "No virtual folder, aborting."
 msgstr "No virtual folder, aborting."
 
-#: curs_main.c:1761
+#: curs_main.c:1769
 msgid "Failed to read thread, aborting."
 msgstr "Failed to read thread, aborting."
 
-#: curs_main.c:1793 mx.c:1458 mx.c:1475
+#: curs_main.c:1801 mx.c:1468 mx.c:1485
 msgid "Folder doesn't support tagging, aborting."
 msgstr "Folder doesn't support tagging, aborting."
 
-#: curs_main.c:1808
+#: curs_main.c:1816
 msgid "No tag specified, aborting."
 msgstr "No tag specified, aborting."
 
-#: curs_main.c:1820
+#: curs_main.c:1828
 #, c-format
 msgid "Update tags..."
 msgstr "Update tags..."
 
-#: curs_main.c:1857
+#: curs_main.c:1865
 msgid "Failed to modify tags, aborting."
 msgstr "Failed to modify tags, aborting."
 
-#: curs_main.c:1898
+#: curs_main.c:1906
 msgid "No query, aborting."
 msgstr "No query, aborting."
 
-#: curs_main.c:1902 curs_main.c:1922 curs_main.c:1941
+#: curs_main.c:1910 curs_main.c:1930 curs_main.c:1949
 msgid "Failed to create query, aborting."
 msgstr "Failed to create query, aborting."
 
-#: curs_main.c:1911 curs_main.c:1930
+#: curs_main.c:1919 curs_main.c:1938
 msgid "Windowed queries disabled."
 msgstr "Windowed queries disabled."
 
-#: curs_main.c:1916 curs_main.c:1935
+#: curs_main.c:1924 curs_main.c:1943
 msgid "No notmuch vfolder currently loaded."
 msgstr "No notmuch vfolder currently loaded."
 
-#: curs_main.c:1973
+#: curs_main.c:1981
 msgid "Open mailbox in read-only mode"
 msgstr "Open mailbox in read-only mode"
 
-#: curs_main.c:1976
+#: curs_main.c:1984
 msgid "Open virtual folder"
 msgstr "Open virtual folder"
 
-#: curs_main.c:1979
+#: curs_main.c:1987
 msgid "Open mailbox"
 msgstr "Open mailbox"
 
-#: curs_main.c:1989
+#: curs_main.c:1997
 msgid "No mailboxes have new mail"
 msgstr "No mailboxes have new mail"
 
-#: curs_main.c:2036
+#: curs_main.c:2044
 msgid "Open newsgroup in read-only mode"
 msgstr "Open newsgroup in read-only mode"
 
-#: curs_main.c:2038
+#: curs_main.c:2046
 msgid "Open newsgroup"
 msgstr "Open newsgroup"
 
-#: curs_main.c:2141
+#: curs_main.c:2149
 msgid "Exit NeoMutt without saving?"
 msgstr "Exit NeoMutt without saving?"
 
-#: curs_main.c:2157
+#: curs_main.c:2165
 msgid "Cannot break thread"
 msgstr "Cannot break thread"
 
-#: curs_main.c:2160 curs_main.c:2198 curs_main.c:2658 curs_main.c:2690
+#: curs_main.c:2168 curs_main.c:2206 curs_main.c:2666 curs_main.c:2698
 #: flags.c:376 thread.c:1078 thread.c:1134 thread.c:1202
 msgid "Threading is not enabled."
 msgstr "Threading is not enabled."
 
-#: curs_main.c:2173
+#: curs_main.c:2181
 msgid "Thread broken"
 msgstr "Thread broken"
 
-#: curs_main.c:2185
+#: curs_main.c:2193
 msgid "Thread cannot be broken, message is not part of a thread"
 msgstr "Thread cannot be broken, message is not part of a thread"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2195
+#: curs_main.c:2203
 msgid "Cannot link threads"
 msgstr "Cannot link threads"
 
-#: curs_main.c:2200
+#: curs_main.c:2208
 msgid "No Message-ID: header available to link thread"
 msgstr "No Message-ID: header available to link thread"
 
-#: curs_main.c:2202
+#: curs_main.c:2210
 msgid "First, please tag a message to be linked here"
 msgstr "First, please tag a message to be linked here"
 
-#: curs_main.c:2213
+#: curs_main.c:2221
 msgid "Threads linked"
 msgstr "Threads linked"
 
-#: curs_main.c:2216
+#: curs_main.c:2224
 msgid "No thread linked"
 msgstr "No thread linked"
 
-#: curs_main.c:2252 curs_main.c:2278
+#: curs_main.c:2260 curs_main.c:2286
 msgid "You are on the last message."
 msgstr "You are on the last message."
 
-#: curs_main.c:2260 curs_main.c:2305
+#: curs_main.c:2268 curs_main.c:2313
 msgid "No undeleted messages."
 msgstr "No undeleted messages."
 
-#: curs_main.c:2297 curs_main.c:2323
+#: curs_main.c:2305 curs_main.c:2331
 msgid "You are on the first message."
 msgstr "You are on the first message."
 
-#: curs_main.c:2395 menu.c:970 pager.c:2440 pattern.c:2110
+#: curs_main.c:2403 menu.c:970 pager.c:2440 pattern.c:2110
 msgid "Search wrapped to top."
 msgstr "Search wrapped to top."
 
-#: curs_main.c:2404 pager.c:2463 pattern.c:2121
+#: curs_main.c:2412 pager.c:2463 pattern.c:2121
 msgid "Search wrapped to bottom."
 msgstr "Search wrapped to bottom."
 
-#: curs_main.c:2447
+#: curs_main.c:2455
 msgid "No new messages in this limited view."
 msgstr "No new messages in this limited view."
 
-#: curs_main.c:2449
+#: curs_main.c:2457
 msgid "No new messages."
 msgstr "No new messages."
 
-#: curs_main.c:2454
+#: curs_main.c:2462
 msgid "No unread messages in this limited view."
 msgstr "No unread messages in this limited view."
 
-#: curs_main.c:2456
+#: curs_main.c:2464
 msgid "No unread messages."
 msgstr "No unread messages."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2474
+#: curs_main.c:2482
 msgid "Cannot flag message"
 msgstr "Cannot flag message"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2513 pager.c:3100
+#: curs_main.c:2521 pager.c:3104
 msgid "Cannot toggle new"
 msgstr "Cannot toggle new"
 
-#: curs_main.c:2590
+#: curs_main.c:2598
 msgid "No more threads."
 msgstr "No more threads."
 
-#: curs_main.c:2592
+#: curs_main.c:2600
 msgid "You are on the first thread."
 msgstr "You are on the first thread."
 
-#: curs_main.c:2676
+#: curs_main.c:2684
 msgid "Thread contains unread or flagged messages."
 msgstr "Thread contains unread or flagged messages."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2726 pager.c:2784
+#: curs_main.c:2734 pager.c:2784
 msgid "Cannot delete message"
 msgstr "Cannot delete message"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2838
+#: curs_main.c:2850
 msgid "Cannot edit message"
 msgstr "Cannot edit message"
 
 #. L10N: This is displayed when the x-label on one or more
 #. * messages is edited.
-#: curs_main.c:2900 pager.c:3200
+#: curs_main.c:2912 pager.c:3208
 #, c-format
 msgid "%d label changed."
 msgid_plural "%d labels changed."
@@ -1739,52 +1749,57 @@ msgstr[1] "%d labels changed."
 #. L10N: This is displayed when editing an x-label, but no messages
 #. * were updated.  Possibly due to canceling at the prompt or if the new
 #. * label is the same as the old label.
-#: curs_main.c:2907 pager.c:3204
+#: curs_main.c:2919 pager.c:3212
 msgid "No labels changed."
 msgstr "No labels changed."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:3006
-msgid "Cannot mark message(s) as read"
+#. L10N: Due to the implementation details we do not know whether we
+#. mark zero, 1, 12, ... messages as read. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:3022
+#, fuzzy
+msgid "Cannot mark messages as read"
 msgstr "Cannot mark message(s) as read"
 
 #. L10N: This is the prompt for <mark-message>.  Whatever they
 #. enter will be prefixed by $mark_macro_prefix and will become
 #. a macro hotkey to jump to the currently selected message.
-#: curs_main.c:3042
+#: curs_main.c:3058
 msgid "Enter macro stroke: "
 msgstr "Enter macro stroke: "
 
 #. L10N: "message hotkey" is the key bindings menu description of a
 #. macro created by <mark-message>.
-#: curs_main.c:3050
+#: curs_main.c:3066
 msgid "message hotkey"
 msgstr "message hotkey"
 
 #. L10N: This is echoed after <mark-message> creates a new hotkey
 #. macro.  %s is the hotkey string ($mark_macro_prefix followed
 #. by whatever they typed at the prompt.)
-#: curs_main.c:3055
+#: curs_main.c:3071
 #, c-format
 msgid "Message bound to %s."
 msgstr "Message bound to %s."
 
 #. L10N: This error is printed if <mark-message> cannot find a
 #. Message-ID for the currently selected message in the index.
-#: curs_main.c:3063
+#: curs_main.c:3079
 msgid "No message ID to macro."
 msgstr "No message ID to macro."
 
-#: curs_main.c:3105 pager.c:2961 recvattach.c:1388
+#: curs_main.c:3121 pager.c:2965 recvattach.c:1401
 msgid "Reply by mail as poster prefers?"
 msgstr "Reply by mail as poster prefers?"
 
-#: curs_main.c:3108 pager.c:2927 pager.c:2939 pager.c:2964
+#: curs_main.c:3124 pager.c:2931 pager.c:2943 pager.c:2968
 msgid "Posting to this group not allowed, may be moderated. Continue?"
 msgstr "Posting to this group not allowed, may be moderated. Continue?"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:3173 pager.c:3120
+#: curs_main.c:3189 pager.c:3124
 msgid "Cannot undelete message"
 msgstr "Cannot undelete message"
 
@@ -1975,12 +1990,34 @@ msgstr "[-- Autoview stderr of %s --]\n"
 msgid "[-- Error: message/external-body has no access-type parameter --]\n"
 msgstr "[-- Error: message/external-body has no access-type parameter --]\n"
 
-#: handler.c:1611
-#, c-format
+#. L10N: If the translation of this string is a multi line string, then
+#. each line should start with "[-- " and end with " --]".
+#. The first "%s/%s" is a MIME type, e.g. "text/plain". The last %s
+#. expands to a date as returned by `mutt_date_parse_date()`.
+#.
+#. Note: The size argument printed is not the actual number as passed
+#. to gettext but the prettified version, e.g. size = 2048 will be
+#. printed as 2K.  Your language might be sensitive to that: For
+#. example although '1K' and '1024' represent the same number your
+#. language might inflect the noun 'byte' differently.
+#.
+#. Sadly, we cannot do anything about that at the moment besides
+#. passing the precise size in bytes. If you are interested the
+#. function responsible for the prettification is
+#. mutt_str_pretty_size() in mutt/string.c.
+#.
+#: handler.c:1624
+#, fuzzy, c-format
 msgid ""
+"[-- This %s/%s attachment (size %s byte) has been deleted --]\n"
+"[-- on %s --]\n"
+msgid_plural ""
 "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
 "[-- on %s --]\n"
-msgstr ""
+msgstr[0] ""
+"[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
+"[-- on %s --]\n"
+msgstr[1] ""
 "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
 "[-- on %s --]\n"
 
@@ -1988,10 +2025,23 @@ msgstr ""
 #. each line should start with "[-- " and end with " --]".
 #. The first "%s/%s" is a MIME type, e.g. "text/plain".
 #.
-#: handler.c:1620
-#, c-format
-msgid "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
-msgstr "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
+#. Note: The size argument printed is not the actual number as passed
+#. to gettext but the prettified version, e.g. size = 2048 will be
+#. printed as 2K.  Your language might be sensitive to that: For
+#. example although '1K' and '1024' represent the same number your
+#. language might inflect the noun 'byte' differently.
+#.
+#. Sadly, we cannot do anything about that at the moment besides
+#. passing the precise size in bytes. If you are interested the
+#. function responsible for the prettification is
+#. mutt_str_pretty_size() in mutt/string.c.
+#.
+#: handler.c:1648
+#, fuzzy, c-format
+msgid "[-- This %s/%s attachment (size %s byte) has been deleted --]\n"
+msgid_plural "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
+msgstr[0] "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
+msgstr[1] "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
 
 #. L10N: If the translation of this string is a multi line string, then
 #. each line should start with "[-- " and end with " --]".
@@ -2001,7 +2051,7 @@ msgstr "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
 #. Caution: Argument three %3$ is also defined but should not be used
 #. in this translation!
 #.
-#: handler.c:1637
+#: handler.c:1667
 msgid ""
 "[-- This %s/%s attachment has been deleted --]\n"
 "[-- on %4$s --]\n"
@@ -2013,17 +2063,17 @@ msgstr ""
 #. each line should start with "[-- " and end with " --]".
 #. The first "%s/%s" is a MIME type, e.g. "text/plain".
 #.
-#: handler.c:1646
+#: handler.c:1676
 #, c-format
 msgid "[-- This %s/%s attachment has been deleted --]\n"
 msgstr "[-- This %s/%s attachment has been deleted --]\n"
 
-#: handler.c:1656
+#: handler.c:1686
 #, c-format
 msgid "[-- name: %s --]\n"
 msgstr "[-- name: %s --]\n"
 
-#: handler.c:1672
+#: handler.c:1702
 #, c-format
 msgid ""
 "[-- This %s/%s attachment is not included, --]\n"
@@ -2034,7 +2084,7 @@ msgstr ""
 "[-- and the indicated external source has --]\n"
 "[-- expired. --]\n"
 
-#: handler.c:1693
+#: handler.c:1723
 #, c-format
 msgid ""
 "[-- This %s/%s attachment is not included, --]\n"
@@ -2043,47 +2093,47 @@ msgstr ""
 "[-- This %s/%s attachment is not included, --]\n"
 "[-- and the indicated access-type %s is unsupported --]\n"
 
-#: handler.c:1822
+#: handler.c:1852
 msgid "Unable to open memory stream!"
 msgstr "Unable to open memory stream!"
 
-#: handler.c:1831
+#: handler.c:1861
 msgid "Unable to open temporary file!"
 msgstr "Unable to open temporary file!"
 
-#: handler.c:1881
+#: handler.c:1911
 msgid "failed to re-open memstream!"
 msgstr "failed to re-open memstream!"
 
-#: handler.c:2013
+#: handler.c:2043
 msgid "Error: multipart/signed has no protocol."
 msgstr "Error: multipart/signed has no protocol."
 
-#: handler.c:2076
+#: handler.c:2106
 msgid "[-- This is an attachment (use '%3$s' to view this part) --]\n"
 msgstr "[-- This is an attachment (use '%3$s' to view this part) --]\n"
 
-#: handler.c:2082
+#: handler.c:2112
 #, c-format
 msgid "[-- %s/%s is unsupported (use '%s' to view this part) --]\n"
 msgstr "[-- %s/%s is unsupported (use '%s' to view this part) --]\n"
 
-#: handler.c:2087
+#: handler.c:2117
 msgid "[-- This is an attachment (need 'view-attachments' bound to key!) --]\n"
 msgstr "[-- This is an attachment (need 'view-attachments' bound to key!) --]\n"
 
 #. L10N: %s/%s is a MIME type, e.g. "text/plain".
-#: handler.c:2091
+#: handler.c:2121
 #, c-format
 msgid "[-- %s/%s is unsupported (need 'view-attachments' bound to key!) --]\n"
 msgstr "[-- %s/%s is unsupported (need 'view-attachments' bound to key!) --]\n"
 
-#: handler.c:2098
+#: handler.c:2128
 msgid "[-- This is an attachment --]\n"
 msgstr "[-- This is an attachment --]\n"
 
 #. L10N: %s/%s is a MIME type, e.g. "text/plain".
-#: handler.c:2101
+#: handler.c:2131
 #, c-format
 msgid "[-- %s/%s is unsupported --]\n"
 msgstr "[-- %s/%s is unsupported --]\n"
@@ -2385,7 +2435,7 @@ msgstr "IMAP server doesn't support custom flags"
 msgid "Invalid IMAP flags"
 msgstr "Invalid IMAP flags"
 
-#: imap/message.c:477 mx.c:1326
+#: imap/message.c:477 mx.c:1336
 msgid "Integer overflow -- can't allocate memory."
 msgstr "Integer overflow -- can't allocate memory."
 
@@ -3198,64 +3248,74 @@ msgstr "SSL is unavailable, cannot connect to %s"
 msgid "Reading from %s interrupted..."
 msgstr "Reading from %s interrupted..."
 
-#: mx.c:634
-msgid "message(s) not deleted"
-msgstr "message(s) not deleted"
+#. L10N: Although we now the precise number of messages, we do not show it to the user.
+#. So feel free to use a "generic plural" as plural translation if your language has one.
+#.
+#: mx.c:639
+#, fuzzy
+msgid "message not deleted"
+msgid_plural "messages not deleted"
+msgstr[0] "message(s) not deleted"
+msgstr[1] "message(s) not deleted"
 
-#: mx.c:671
+#: mx.c:676
 msgid "Can't open trash folder"
 msgstr "Can't open trash folder"
 
-#: mx.c:710
+#: mx.c:715
 msgid "Mark all articles read?"
 msgstr "Mark all articles read?"
 
-#: mx.c:754
-#, c-format
-msgid "Move %d read messages to %s?"
-msgstr "Move %d read messages to %s?"
+#. L10N: The first argument is the number of read messages to be
+#. moved, the second argument is the target mailbox.
+#: mx.c:762
+#, fuzzy, c-format
+msgid "Move %d read message to %s?"
+msgid_plural "Move %d read messages to %s?"
+msgstr[0] "Move %d read messages to %s?"
+msgstr[1] "Move %d read messages to %s?"
 
-#: mx.c:771 mx.c:1077
+#: mx.c:781 mx.c:1087
 #, c-format
 msgid "Purge %d deleted message?"
 msgid_plural "Purge %d deleted messages?"
 msgstr[0] "Purge %d deleted message?"
 msgstr[1] "Purge %d deleted messages?"
 
-#: mx.c:793
+#: mx.c:803
 #, c-format
 msgid "Moving read messages to %s..."
 msgstr "Moving read messages to %s..."
 
-#: mx.c:859 mx.c:1068
+#: mx.c:869 mx.c:1078
 msgid "Mailbox is unchanged."
 msgstr "Mailbox is unchanged."
 
-#: mx.c:914
+#: mx.c:924
 #, c-format
 msgid "%d kept, %d moved, %d deleted."
 msgstr "%d kept, %d moved, %d deleted."
 
-#: mx.c:917 mx.c:1130
+#: mx.c:927 mx.c:1140
 #, c-format
 msgid "%d kept, %d deleted."
 msgstr "%d kept, %d deleted."
 
-#: mx.c:1052
+#: mx.c:1062
 #, c-format
 msgid " Press '%s' to toggle write"
 msgstr " Press '%s' to toggle write"
 
-#: mx.c:1054
+#: mx.c:1064
 msgid "Use 'toggle-write' to re-enable write!"
 msgstr "Use 'toggle-write' to re-enable write!"
 
-#: mx.c:1056
+#: mx.c:1066
 #, c-format
 msgid "Mailbox is marked unwritable. %s"
 msgstr "Mailbox is marked unwritable. %s"
 
-#: mx.c:1124
+#: mx.c:1134
 msgid "Mailbox checkpointed."
 msgstr "Mailbox checkpointed."
 
@@ -3269,52 +3329,57 @@ msgstr " (current time: %c)"
 msgid "[-- %s output follows%s --]\n"
 msgstr "[-- %s output follows%s --]\n"
 
-#: ncrypt/crypt.c:95
-msgid "Passphrase(s) forgotten."
+#. L10N: Due to the implementation details (e.g. some passwords are managed
+#. by gpg-agent) we cannot know whether we forgot zero, 1, 12, ...
+#. passwords. So in English we use "Passphrases". Your language might
+#. have other means to express this.
+#: ncrypt/crypt.c:100
+#, fuzzy
+msgid "Passphrases forgotten."
 msgstr "Passphrase(s) forgotten."
 
-#: ncrypt/crypt.c:155
+#: ncrypt/crypt.c:161
 msgid "Inline PGP can't be used with attachments.  Revert to PGP/MIME?"
 msgstr "Inline PGP can't be used with attachments.  Revert to PGP/MIME?"
 
-#: ncrypt/crypt.c:159
+#: ncrypt/crypt.c:165
 msgid "Mail not sent: inline PGP can't be used with attachments."
 msgstr "Mail not sent: inline PGP can't be used with attachments."
 
-#: ncrypt/crypt.c:166
+#: ncrypt/crypt.c:172
 msgid "Inline PGP can't be used with format=flowed.  Revert to PGP/MIME?"
 msgstr "Inline PGP can't be used with format=flowed.  Revert to PGP/MIME?"
 
-#: ncrypt/crypt.c:170
+#: ncrypt/crypt.c:176
 msgid "Mail not sent: inline PGP can't be used with format=flowed."
 msgstr "Mail not sent: inline PGP can't be used with format=flowed."
 
-#: ncrypt/crypt.c:180 ncrypt/cryptglue.c:125 ncrypt/pgpkey.c:589
+#: ncrypt/crypt.c:186 ncrypt/cryptglue.c:125 ncrypt/pgpkey.c:589
 #: ncrypt/pgpkey.c:782
 msgid "Invoking PGP..."
 msgstr "Invoking PGP..."
 
-#: ncrypt/crypt.c:192
+#: ncrypt/crypt.c:198
 msgid "Message can't be sent inline.  Revert to using PGP/MIME?"
 msgstr "Message can't be sent inline.  Revert to using PGP/MIME?"
 
-#: ncrypt/crypt.c:194 send.c:1824
+#: ncrypt/crypt.c:200 send.c:1824
 msgid "Mail not sent."
 msgstr "Mail not sent."
 
-#: ncrypt/crypt.c:540
+#: ncrypt/crypt.c:546
 msgid "S/MIME messages with no hints on content are unsupported."
 msgstr "S/MIME messages with no hints on content are unsupported."
 
-#: ncrypt/crypt.c:754 ncrypt/crypt.c:795
+#: ncrypt/crypt.c:760 ncrypt/crypt.c:801
 msgid "Trying to extract PGP keys...\n"
 msgstr "Trying to extract PGP keys...\n"
 
-#: ncrypt/crypt.c:776 ncrypt/crypt.c:816
+#: ncrypt/crypt.c:782 ncrypt/crypt.c:822
 msgid "Trying to extract S/MIME certificates...\n"
 msgstr "Trying to extract S/MIME certificates...\n"
 
-#: ncrypt/crypt.c:976
+#: ncrypt/crypt.c:982
 #, c-format
 msgid ""
 "[-- Error: Unknown multipart/signed protocol %s! --]\n"
@@ -3323,7 +3388,7 @@ msgstr ""
 "[-- Error: Unknown multipart/signed protocol %s! --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1016
+#: ncrypt/crypt.c:1022
 msgid ""
 "[-- Error: Missing or bad-format multipart/signed signature! --]\n"
 "\n"
@@ -3331,7 +3396,7 @@ msgstr ""
 "[-- Error: Missing or bad-format multipart/signed signature! --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1058
+#: ncrypt/crypt.c:1064
 #, c-format
 msgid ""
 "[-- Warning: We can't verify %s/%s signatures. --]\n"
@@ -3340,23 +3405,23 @@ msgstr ""
 "[-- Warning: We can't verify %s/%s signatures. --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1070
+#: ncrypt/crypt.c:1076
 msgid ""
 "[-- The following data is signed --]\n"
 "\n"
 msgstr ""
 "[-- The following data is signed --]\n"
-"\n"
-
-#: ncrypt/crypt.c:1075
-msgid ""
-"[-- Warning: Can't find any signatures. --]\n"
-"\n"
-msgstr ""
-"[-- Warning: Can't find any signatures. --]\n"
 "\n"
 
 #: ncrypt/crypt.c:1081
+msgid ""
+"[-- Warning: Can't find any signatures. --]\n"
+"\n"
+msgstr ""
+"[-- Warning: Can't find any signatures. --]\n"
+"\n"
+
+#: ncrypt/crypt.c:1087
 msgid ""
 "\n"
 "[-- End of signed data --]\n"
@@ -3407,7 +3472,7 @@ msgstr "[tempfile]"
 msgid "error reading data object: %s\n"
 msgstr "error reading data object: %s\n"
 
-#: ncrypt/crypt_gpgme.c:662 ncrypt/crypt_gpgme.c:3848 ncrypt/pgpkey.c:585
+#: ncrypt/crypt_gpgme.c:662 ncrypt/crypt_gpgme.c:3850 ncrypt/pgpkey.c:585
 #: ncrypt/pgpkey.c:768
 msgid "Can't create temporary file"
 msgstr "Can't create temporary file"
@@ -3755,28 +3820,30 @@ msgstr "[Invalid]"
 
 #. L10N: This is printed after "Key Type: " and looks like this:
 #. *       PGP, 2048 bit RSA
-#: ncrypt/crypt_gpgme.c:3670 ncrypt/crypt_gpgme.c:3808
-#, c-format
+#: ncrypt/crypt_gpgme.c:3670 ncrypt/crypt_gpgme.c:3810
+#, fuzzy, c-format
 msgid "%s, %lu bit %s\n"
-msgstr "%s, %lu bit %s\n"
+msgid_plural "%s, %lu bit %s\n"
+msgstr[0] "%s, %lu bit %s\n"
+msgstr[1] "%s, %lu bit %s\n"
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3678 ncrypt/crypt_gpgme.c:3815
+#: ncrypt/crypt_gpgme.c:3678 ncrypt/crypt_gpgme.c:3817
 msgid "encryption"
 msgstr "encryption"
 
 #: ncrypt/crypt_gpgme.c:3679 ncrypt/crypt_gpgme.c:3685
-#: ncrypt/crypt_gpgme.c:3816 ncrypt/crypt_gpgme.c:3821
+#: ncrypt/crypt_gpgme.c:3818 ncrypt/crypt_gpgme.c:3823
 msgid ", "
 msgstr ", "
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3684 ncrypt/crypt_gpgme.c:3820
+#: ncrypt/crypt_gpgme.c:3684 ncrypt/crypt_gpgme.c:3822
 msgid "signing"
 msgstr "signing"
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3690 ncrypt/crypt_gpgme.c:3825
+#: ncrypt/crypt_gpgme.c:3690 ncrypt/crypt_gpgme.c:3827
 msgid "certification"
 msgstr "certification"
 
@@ -3795,64 +3862,64 @@ msgstr "[Expired]"
 msgid "[Disabled]"
 msgstr "[Disabled]"
 
-#: ncrypt/crypt_gpgme.c:3851
+#: ncrypt/crypt_gpgme.c:3853
 msgid "Collecting data..."
 msgstr "Collecting data..."
 
-#: ncrypt/crypt_gpgme.c:3876
+#: ncrypt/crypt_gpgme.c:3878
 #, c-format
 msgid "Error finding issuer key: %s\n"
 msgstr "Error finding issuer key: %s\n"
 
-#: ncrypt/crypt_gpgme.c:3885
+#: ncrypt/crypt_gpgme.c:3887
 msgid "Error: certification chain too long - stopping here\n"
 msgstr "Error: certification chain too long - stopping here\n"
 
-#: ncrypt/crypt_gpgme.c:3895 ncrypt/pgpkey.c:608
+#: ncrypt/crypt_gpgme.c:3897 ncrypt/pgpkey.c:608
 #, c-format
 msgid "Key ID: 0x%s"
 msgstr "Key ID: 0x%s"
 
-#: ncrypt/crypt_gpgme.c:3990
+#: ncrypt/crypt_gpgme.c:3992
 #, c-format
 msgid "gpgme_new failed: %s"
 msgstr "gpgme_new failed: %s"
 
-#: ncrypt/crypt_gpgme.c:4028 ncrypt/crypt_gpgme.c:4079
+#: ncrypt/crypt_gpgme.c:4030 ncrypt/crypt_gpgme.c:4081
 #, c-format
 msgid "gpgme_op_keylist_start failed: %s"
 msgstr "gpgme_op_keylist_start failed: %s"
 
-#: ncrypt/crypt_gpgme.c:4067 ncrypt/crypt_gpgme.c:4109
+#: ncrypt/crypt_gpgme.c:4069 ncrypt/crypt_gpgme.c:4111
 #, c-format
 msgid "gpgme_op_keylist_next failed: %s"
 msgstr "gpgme_op_keylist_next failed: %s"
 
-#: ncrypt/crypt_gpgme.c:4185
+#: ncrypt/crypt_gpgme.c:4187
 msgid "All matching keys are marked expired/revoked."
 msgstr "All matching keys are marked expired/revoked."
 
-#: ncrypt/crypt_gpgme.c:4215 ncrypt/pgpkey.c:543 ncrypt/smime.c:475
+#: ncrypt/crypt_gpgme.c:4217 ncrypt/pgpkey.c:543 ncrypt/smime.c:475
 msgid "Select  "
 msgstr "Select  "
 
-#: ncrypt/crypt_gpgme.c:4217 ncrypt/pgpkey.c:545
+#: ncrypt/crypt_gpgme.c:4219 ncrypt/pgpkey.c:545
 msgid "Check key  "
 msgstr "Check key  "
 
-#: ncrypt/crypt_gpgme.c:4233
+#: ncrypt/crypt_gpgme.c:4235
 msgid "PGP and S/MIME keys matching"
 msgstr "PGP and S/MIME keys matching"
 
-#: ncrypt/crypt_gpgme.c:4235
+#: ncrypt/crypt_gpgme.c:4237
 msgid "PGP keys matching"
 msgstr "PGP keys matching"
 
-#: ncrypt/crypt_gpgme.c:4237
+#: ncrypt/crypt_gpgme.c:4239
 msgid "S/MIME keys matching"
 msgstr "S/MIME keys matching"
 
-#: ncrypt/crypt_gpgme.c:4239
+#: ncrypt/crypt_gpgme.c:4241
 msgid "keys matching"
 msgstr "keys matching"
 
@@ -3860,65 +3927,65 @@ msgstr "keys matching"
 #. %1$s is one of the previous four entries.
 #. %2$s is an address.
 #. e.g. "S/MIME keys matching <me@mutt.org>."
-#: ncrypt/crypt_gpgme.c:4246
+#: ncrypt/crypt_gpgme.c:4248
 #, c-format
 msgid "%s <%s>."
 msgstr "%s <%s>."
 
 #. L10N:
 #. e.g. 'S/MIME keys matching "Michael Elkins".'
-#: ncrypt/crypt_gpgme.c:4250
+#: ncrypt/crypt_gpgme.c:4252
 #, c-format
 msgid "%s \"%s\"."
 msgstr "%s \"%s\"."
 
-#: ncrypt/crypt_gpgme.c:4277 ncrypt/pgpkey.c:628
+#: ncrypt/crypt_gpgme.c:4279 ncrypt/pgpkey.c:628
 msgid "This key can't be used: expired/disabled/revoked."
 msgstr "This key can't be used: expired/disabled/revoked."
 
-#: ncrypt/crypt_gpgme.c:4290 ncrypt/pgpkey.c:640 ncrypt/smime.c:505
+#: ncrypt/crypt_gpgme.c:4292 ncrypt/pgpkey.c:640 ncrypt/smime.c:505
 msgid "ID is expired/disabled/revoked. Do you really want to use the key?"
 msgstr "ID is expired/disabled/revoked. Do you really want to use the key?"
 
-#: ncrypt/crypt_gpgme.c:4299 ncrypt/pgpkey.c:650
+#: ncrypt/crypt_gpgme.c:4301 ncrypt/pgpkey.c:650
 msgid "ID is not valid. Do you really want to use the key?"
 msgstr "ID is not valid. Do you really want to use the key?"
 
-#: ncrypt/crypt_gpgme.c:4302 ncrypt/pgpkey.c:653
+#: ncrypt/crypt_gpgme.c:4304 ncrypt/pgpkey.c:653
 msgid "ID is only marginally valid. Do you really want to use the key?"
 msgstr "ID is only marginally valid. Do you really want to use the key?"
 
-#: ncrypt/crypt_gpgme.c:4310 ncrypt/pgpkey.c:646 ncrypt/smime.c:509
+#: ncrypt/crypt_gpgme.c:4312 ncrypt/pgpkey.c:646 ncrypt/smime.c:509
 msgid "ID has undefined validity. Do you really want to use the key?"
 msgstr "ID has undefined validity. Do you really want to use the key?"
 
-#: ncrypt/crypt_gpgme.c:4370 ncrypt/crypt_gpgme.c:4479 ncrypt/pgpkey.c:872
+#: ncrypt/crypt_gpgme.c:4372 ncrypt/crypt_gpgme.c:4481 ncrypt/pgpkey.c:872
 #: ncrypt/pgpkey.c:995
 #, c-format
 msgid "Looking for keys matching \"%s\"..."
 msgstr "Looking for keys matching \"%s\"..."
 
-#: ncrypt/crypt_gpgme.c:4593 ncrypt/pgpkey.c:731 ncrypt/smime.c:811
+#: ncrypt/crypt_gpgme.c:4595 ncrypt/pgpkey.c:731 ncrypt/smime.c:811
 #, c-format
 msgid "No matching keys found for \"%s\""
 msgstr "No matching keys found for \"%s\""
 
-#: ncrypt/crypt_gpgme.c:4644 ncrypt/pgp.c:1263
+#: ncrypt/crypt_gpgme.c:4646 ncrypt/pgp.c:1263
 #, c-format
 msgid "Use keyID = \"%s\" for %s?"
 msgstr "Use keyID = \"%s\" for %s?"
 
-#: ncrypt/crypt_gpgme.c:4695 ncrypt/pgp.c:1312 ncrypt/smime.c:830
+#: ncrypt/crypt_gpgme.c:4697 ncrypt/pgp.c:1312 ncrypt/smime.c:830
 #: ncrypt/smime.c:938
 #, c-format
 msgid "Enter keyID for %s: "
 msgstr "Enter keyID for %s: "
 
-#: ncrypt/crypt_gpgme.c:4755 ncrypt/pgpkey.c:751
+#: ncrypt/crypt_gpgme.c:4757 ncrypt/pgpkey.c:751
 msgid "Please enter the key ID: "
 msgstr "Please enter the key ID: "
 
-#: ncrypt/crypt_gpgme.c:4768
+#: ncrypt/crypt_gpgme.c:4770
 #, c-format
 msgid "Error exporting key: %s\n"
 msgstr "Error exporting key: %s\n"
@@ -3927,80 +3994,80 @@ msgstr "Error exporting key: %s\n"
 #. MIME description for exported (attached) keys.
 #. You can translate this entry to a non-ASCII string (it will be encoded),
 #. but it may be safer to keep it untranslated.
-#: ncrypt/crypt_gpgme.c:4787
+#: ncrypt/crypt_gpgme.c:4789
 #, c-format
 msgid "PGP Key 0x%s."
 msgstr "PGP Key 0x%s."
 
-#: ncrypt/crypt_gpgme.c:4830
+#: ncrypt/crypt_gpgme.c:4832
 msgid "GPGME: OpenPGP protocol not available"
 msgstr "GPGME: OpenPGP protocol not available"
 
-#: ncrypt/crypt_gpgme.c:4838
+#: ncrypt/crypt_gpgme.c:4840
 msgid "GPGME: CMS protocol not available"
 msgstr "GPGME: CMS protocol not available"
 
-#: ncrypt/crypt_gpgme.c:4876
+#: ncrypt/crypt_gpgme.c:4878
 msgid "S/MIME (s)ign, sign (a)s, (p)gp, (c)lear, or (o)ppenc mode off? "
 msgstr "S/MIME (s)ign, sign (a)s, (p)gp, (c)lear, or (o)ppenc mode off? "
 
 #. L10N: S/MIME options (opportunistic encryption is on)
-#: ncrypt/crypt_gpgme.c:4878
+#: ncrypt/crypt_gpgme.c:4880
 msgid "sapco"
 msgstr "sapco"
 
-#: ncrypt/crypt_gpgme.c:4885
+#: ncrypt/crypt_gpgme.c:4887
 msgid "PGP (s)ign, sign (a)s, s/(m)ime, (c)lear, or (o)ppenc mode off? "
 msgstr "PGP (s)ign, sign (a)s, s/(m)ime, (c)lear, or (o)ppenc mode off? "
 
 #. L10N: PGP options (opportunistic encryption is on)
-#: ncrypt/crypt_gpgme.c:4887
+#: ncrypt/crypt_gpgme.c:4889
 msgid "samco"
 msgstr "samco"
 
 #. L10N: S/MIME options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4900
+#: ncrypt/crypt_gpgme.c:4902
 msgid "S/MIME (e)ncrypt, (s)ign, sign (a)s, (b)oth, (p)gp, (c)lear, or (o)ppenc mode? "
 msgstr "S/MIME (e)ncrypt, (s)ign, sign (a)s, (b)oth, (p)gp, (c)lear, or (o)ppenc mode? "
 
 #. L10N: S/MIME options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4903
+#: ncrypt/crypt_gpgme.c:4905
 msgid "esabpco"
 msgstr "esabpco"
 
 #. L10N: PGP options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4909
+#: ncrypt/crypt_gpgme.c:4911
 msgid "PGP (e)ncrypt, (s)ign, sign (a)s, (b)oth, s/(m)ime, (c)lear, or (o)ppenc mode? "
 msgstr "PGP (e)ncrypt, (s)ign, sign (a)s, (b)oth, s/(m)ime, (c)lear, or (o)ppenc mode? "
 
 #. L10N: PGP options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4912
+#: ncrypt/crypt_gpgme.c:4914
 msgid "esabmco"
 msgstr "esabmco"
 
-#: ncrypt/crypt_gpgme.c:4925
+#: ncrypt/crypt_gpgme.c:4927
 msgid "S/MIME (e)ncrypt, (s)ign, sign (a)s, (b)oth, (p)gp or (c)lear? "
 msgstr "S/MIME (e)ncrypt, (s)ign, sign (a)s, (b)oth, (p)gp or (c)lear? "
 
 #. L10N: S/MIME options
-#: ncrypt/crypt_gpgme.c:4927
+#: ncrypt/crypt_gpgme.c:4929
 msgid "esabpc"
 msgstr "esabpc"
 
-#: ncrypt/crypt_gpgme.c:4934
+#: ncrypt/crypt_gpgme.c:4936
 msgid "PGP (e)ncrypt, (s)ign, sign (a)s, (b)oth, s/(m)ime or (c)lear? "
 msgstr "PGP (e)ncrypt, (s)ign, sign (a)s, (b)oth, s/(m)ime or (c)lear? "
 
 #. L10N: PGP options
-#: ncrypt/crypt_gpgme.c:4936
+#: ncrypt/crypt_gpgme.c:4938
 msgid "esabmc"
 msgstr "esabmc"
 
-#: ncrypt/crypt_gpgme.c:5087
+#: ncrypt/crypt_gpgme.c:5089
 msgid "Failed to verify sender"
 msgstr "Failed to verify sender"
 
-#: ncrypt/crypt_gpgme.c:5090
+#: ncrypt/crypt_gpgme.c:5092
 msgid "Failed to figure out sender"
 msgstr "Failed to figure out sender"
 
@@ -4388,7 +4455,7 @@ msgstr "No news server defined!"
 msgid "%s is an invalid news server specification!"
 msgstr "%s is an invalid news server specification!"
 
-#: nntp.c:75 nntp.c:612 pop.c:1028 pop_lib.c:405
+#: nntp.c:75 nntp.c:612 pop.c:1031 pop_lib.c:405
 msgid "Server closed connection!"
 msgstr "Server closed connection!"
 
@@ -4546,15 +4613,18 @@ msgid "check mailboxes for new mail"
 msgstr "check mailboxes for new mail"
 
 #: opcodes.h:47
-msgid "attach file(s) to this message"
+#, fuzzy
+msgid "attach files to this message"
 msgstr "attach file(s) to this message"
 
 #: opcodes.h:48
-msgid "attach message(s) to this message"
+#, fuzzy
+msgid "attach messages to this message"
 msgstr "attach message(s) to this message"
 
 #: opcodes.h:49
-msgid "attach news article(s) to this message"
+#, fuzzy
+msgid "attach news articles to this message"
 msgstr "attach news article(s) to this message"
 
 #: opcodes.h:50
@@ -5370,7 +5440,8 @@ msgid "extract supported public keys"
 msgstr "extract supported public keys"
 
 #: opcodes.h:255
-msgid "wipe passphrase(s) from memory"
+#, fuzzy
+msgid "wipe passphrases from memory"
 msgstr "wipe passphrase(s) from memory"
 
 #: opcodes.h:259
@@ -5700,18 +5771,20 @@ msgstr "No new mail in POP mailbox."
 msgid "Delete messages from server?"
 msgstr "Delete messages from server?"
 
-#: pop.c:954
-#, c-format
-msgid "Reading new messages (%d bytes)..."
-msgstr "Reading new messages (%d bytes)..."
+#: pop.c:955
+#, fuzzy, c-format
+msgid "Reading new messages (%d byte)..."
+msgid_plural "Reading new messages (%d bytes)..."
+msgstr[0] "Reading new messages (%d bytes)..."
+msgstr[1] "Reading new messages (%d bytes)..."
 
-#: pop.c:997
+#: pop.c:1000
 msgid "Error while writing mailbox!"
 msgstr "Error while writing mailbox!"
 
 #. L10N: The plural is picked by the second numerical argument, i.e.
 #. * the %d right before 'messages', i.e. the total number of messages.
-#: pop.c:1003
+#: pop.c:1006
 #, c-format
 msgid "%s [%d of %d message read]"
 msgid_plural "%s [%d of %d messages read]"
@@ -5855,47 +5928,54 @@ msgstr "Pipe to: "
 msgid "I don't know how to print %s attachments!"
 msgstr "I don't know how to print %s attachments!"
 
-#: recvattach.c:841
-msgid "Print tagged attachment(s)?"
-msgstr "Print tagged attachment(s)?"
+#. L10N: Although we now the precise number of tagged messages, we
+#. do not show it to the user.  So feel free to use a "generic
+#. plural" as plural translation if your language has one.
+#: recvattach.c:852
+#, fuzzy, c-format
+msgid "Print tagged attachment?"
+msgid_plural "Print %d tagged attachments?"
+msgstr[0] "Print tagged attachment(s)?"
+msgstr[1] "Print tagged attachment(s)?"
 
-#: recvattach.c:842
+#: recvattach.c:853
+#, c-format
 msgid "Print attachment?"
 msgstr "Print attachment?"
 
-#: recvattach.c:900
+#: recvattach.c:913
 msgid "Structural changes to decrypted attachments are not supported"
 msgstr "Structural changes to decrypted attachments are not supported"
 
-#: recvattach.c:1046
+#: recvattach.c:1059
 msgid "Can't decrypt encrypted message!"
 msgstr "Can't decrypt encrypted message!"
 
-#: recvattach.c:1172
+#: recvattach.c:1185
 msgid "Attachments"
 msgstr "Attachments"
 
-#: recvattach.c:1210
+#: recvattach.c:1223
 msgid "There are no subparts to show!"
 msgstr "There are no subparts to show!"
 
-#: recvattach.c:1265
+#: recvattach.c:1278
 msgid "Can't delete attachment from POP server."
 msgstr "Can't delete attachment from POP server."
 
-#: recvattach.c:1274
+#: recvattach.c:1287
 msgid "Can't delete attachment from news server."
 msgstr "Can't delete attachment from news server."
 
-#: recvattach.c:1281
+#: recvattach.c:1294
 msgid "Deletion of attachments from encrypted messages is unsupported."
 msgstr "Deletion of attachments from encrypted messages is unsupported."
 
-#: recvattach.c:1287
+#: recvattach.c:1300
 msgid "Deletion of attachments from signed messages may invalidate the signature."
 msgstr "Deletion of attachments from signed messages may invalidate the signature."
 
-#: recvattach.c:1305 recvattach.c:1320
+#: recvattach.c:1318 recvattach.c:1333
 msgid "Only deletion of multipart attachments is supported."
 msgstr "Only deletion of multipart attachments is supported."
 
@@ -6324,3 +6404,13 @@ msgstr "Default options:"
 #: version.c:404
 msgid "Compile options:"
 msgstr "Compile options:"
+
+#~ msgid "Cannot delete message(s)"
+#~ msgstr "Cannot delete message(s)"
+
+#~ msgid "Cannot undelete message(s)"
+#~ msgstr "Cannot undelete message(s)"
+
+#, fuzzy
+#~ msgid "messages not deleted"
+#~ msgstr "message(s) not deleted"

--- a/po/eo.po
+++ b/po/eo.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neomutt-20180512\n"
 "Report-Msgid-Bugs-To: neomutt-devel@neomutt.org\n"
-"POT-Creation-Date: 2018-05-20 02:02+0000\n"
+"POT-Creation-Date: 2018-05-22 14:18+0000\n"
 "PO-Revision-Date: 2017-02-22 21:14+0100\n"
 "Last-Translator: Benno Schulenberg <benno@vertaalt.nl>\n"
 "Language-Team: Esperanto <translation-team-eo@lists.sourceforge.net>\n"
@@ -40,7 +40,7 @@ msgstr "Elekto"
 
 #: addrbook.c:52 browser.c:75 browser.c:87 compose.c:160 compose.c:172
 #: conn/ssl.c:1041 conn/ssl_gnutls.c:793 curs_main.c:748 curs_main.c:761
-#: history.c:106 ncrypt/crypt_gpgme.c:4219 ncrypt/pgpkey.c:547
+#: history.c:106 ncrypt/crypt_gpgme.c:4221 ncrypt/pgpkey.c:547
 #: ncrypt/smime.c:477 pager.c:2141 postpone.c:65 query.c:72 recvattach.c:70
 msgid "Help"
 msgstr "Helpo"
@@ -687,7 +687,7 @@ msgstr ""
 #. * Since it shares the row with "Encrypt with:", it should not be longer
 #. * than 15-20 character cells.
 #.
-#: compose.c:138 ncrypt/crypt_gpgme.c:4947 ncrypt/pgp.c:1786
+#: compose.c:138 ncrypt/crypt_gpgme.c:4949 ncrypt/pgp.c:1786
 #: ncrypt/smime.c:2127
 msgid "Sign as: "
 msgstr "Subskribi kiel: "
@@ -1225,7 +1225,7 @@ msgstr "(m)alakcepti, akcepti (u)nufoje, (s)kip"
 msgid "(r)eject, accept (o)nce"
 msgstr "(m)alakcepti, akcepti (u)nufoje"
 
-#: conn/ssl.c:1039 conn/ssl_gnutls.c:791 ncrypt/crypt_gpgme.c:4213
+#: conn/ssl.c:1039 conn/ssl_gnutls.c:791 ncrypt/crypt_gpgme.c:4215
 #: ncrypt/pgpkey.c:541 ncrypt/smime.c:473
 msgid "Exit  "
 msgstr "Eliri  "
@@ -1404,11 +1404,11 @@ msgstr "Neniu poŝtfako estas malfermita."
 msgid "There are no messages."
 msgstr "Ne estas mesaĝoj."
 
-#: curs_main.c:77 mx.c:1061 pager.c:73 recvattach.c:56
+#: curs_main.c:77 mx.c:1071 pager.c:73 recvattach.c:56
 msgid "Mailbox is read-only."
 msgstr "Poŝtfako estas nurlega."
 
-#: curs_main.c:79 pager.c:75 recvattach.c:1145
+#: curs_main.c:79 pager.c:75 recvattach.c:1158
 msgid "Function not permitted in attach-message mode."
 msgstr "Funkcio nepermesata dum elektado de aldonoj."
 
@@ -1542,244 +1542,254 @@ msgid "That message is not visible."
 msgstr "Tiu mesaĝo ne estas videbla."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:1377 curs_main.c:2772 pager.c:2818
-msgid "Cannot delete message(s)"
+#. L10N: Due to the implementation details we do not know whether we
+#. delete zero, 1, 12, ... messages. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:1381 curs_main.c:2784 pager.c:2822
+#, fuzzy
+msgid "Cannot delete messages"
 msgstr "Ne eblas forviŝi mesaĝo(j)n"
 
-#: curs_main.c:1380
+#: curs_main.c:1384
 msgid "Delete messages matching: "
 msgstr "Forviŝi mesaĝojn laŭ la ŝablono: "
 
-#: curs_main.c:1421
+#: curs_main.c:1425
 msgid "No limit pattern is in effect."
 msgstr "Nenia ŝablono estas aktiva."
 
 #. L10N: ask for a limit to apply
-#: curs_main.c:1426
+#: curs_main.c:1430
 #, c-format
 msgid "Limit: %s"
 msgstr "Ŝablono: %s"
 
-#: curs_main.c:1464
+#: curs_main.c:1468
 msgid "Limit to messages matching: "
 msgstr "Limigi al mesaĝoj laŭ la ŝablono: "
 
-#: curs_main.c:1488
+#: curs_main.c:1492
 msgid "To view all messages, limit to \"all\"."
 msgstr "Por vidi ĉiujn mesaĝojn, limigu al \"all\"."
 
-#: curs_main.c:1500 pager.c:2318
+#: curs_main.c:1504 pager.c:2318
 msgid "Quit NeoMutt?"
 msgstr "Ĉu eliri el NeoMutt?"
 
-#: curs_main.c:1596
+#: curs_main.c:1600
 msgid "Tag messages matching: "
 msgstr "Marki mesaĝojn laŭ la ŝablono: "
 
 #. L10N: CHECK_ACL
-#: curs_main.c:1606 curs_main.c:3203 pager.c:3137
-msgid "Cannot undelete message(s)"
+#. L10N: Due to the implementation details we do not know whether we
+#. undelete zero, 1, 12, ... messages. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:1614 curs_main.c:3223 pager.c:3145
+#, fuzzy
+msgid "Cannot undelete messages"
 msgstr "Ne eblas malforviŝi mesaĝo(j)n"
 
-#: curs_main.c:1609
+#: curs_main.c:1617
 msgid "Undelete messages matching: "
 msgstr "Malforviŝi mesaĝojn laŭ la ŝablono: "
 
-#: curs_main.c:1619
+#: curs_main.c:1627
 msgid "Untag messages matching: "
 msgstr "Malmarki mesaĝojn laŭ la ŝablono: "
 
-#: curs_main.c:1653
+#: curs_main.c:1661
 msgid "Logged out of IMAP servers."
 msgstr "Elsalutis el IMAP-serviloj."
 
-#: curs_main.c:1753
+#: curs_main.c:1761
 #, fuzzy
 msgid "No virtual folder, aborting."
 msgstr "Mankas temlinio; eliras."
 
-#: curs_main.c:1761
+#: curs_main.c:1769
 msgid "Failed to read thread, aborting."
 msgstr ""
 
-#: curs_main.c:1793 mx.c:1458 mx.c:1475
+#: curs_main.c:1801 mx.c:1468 mx.c:1485
 #, fuzzy
 msgid "Folder doesn't support tagging, aborting."
 msgstr "SMTP-servilo ne akceptas rajtiĝon"
 
-#: curs_main.c:1808
+#: curs_main.c:1816
 #, fuzzy
 msgid "No tag specified, aborting."
 msgstr "Mankas temlinio; eliras."
 
-#: curs_main.c:1820
+#: curs_main.c:1828
 #, c-format
 msgid "Update tags..."
 msgstr ""
 
-#: curs_main.c:1857
+#: curs_main.c:1865
 msgid "Failed to modify tags, aborting."
 msgstr ""
 
-#: curs_main.c:1898
+#: curs_main.c:1906
 #, fuzzy
 msgid "No query, aborting."
 msgstr "Mankas temlinio; eliras."
 
-#: curs_main.c:1902 curs_main.c:1922 curs_main.c:1941
+#: curs_main.c:1910 curs_main.c:1930 curs_main.c:1949
 msgid "Failed to create query, aborting."
 msgstr ""
 
-#: curs_main.c:1911 curs_main.c:1930
+#: curs_main.c:1919 curs_main.c:1938
 msgid "Windowed queries disabled."
 msgstr ""
 
-#: curs_main.c:1916 curs_main.c:1935
+#: curs_main.c:1924 curs_main.c:1943
 msgid "No notmuch vfolder currently loaded."
 msgstr ""
 
-#: curs_main.c:1973
+#: curs_main.c:1981
 msgid "Open mailbox in read-only mode"
 msgstr "Malfermi poŝtfakon nurlege"
 
-#: curs_main.c:1976
+#: curs_main.c:1984
 #, fuzzy
 msgid "Open virtual folder"
 msgstr "malfermi alian poŝtfakon"
 
-#: curs_main.c:1979
+#: curs_main.c:1987
 msgid "Open mailbox"
 msgstr "Malfermi poŝtfakon"
 
-#: curs_main.c:1989
+#: curs_main.c:1997
 msgid "No mailboxes have new mail"
 msgstr "Neniu poŝtfako havas novan poŝton."
 
-#: curs_main.c:2036
+#: curs_main.c:2044
 #, fuzzy
 msgid "Open newsgroup in read-only mode"
 msgstr "Malfermi poŝtfakon nurlege"
 
-#: curs_main.c:2038
+#: curs_main.c:2046
 msgid "Open newsgroup"
 msgstr ""
 
-#: curs_main.c:2141
+#: curs_main.c:2149
 #, fuzzy
 msgid "Exit NeoMutt without saving?"
 msgstr "Eliri el NeoMutt sen skribi?"
 
-#: curs_main.c:2157
+#: curs_main.c:2165
 #, fuzzy
 msgid "Cannot break thread"
 msgstr "Ne eblas ligi fadenojn"
 
-#: curs_main.c:2160 curs_main.c:2198 curs_main.c:2658 curs_main.c:2690
+#: curs_main.c:2168 curs_main.c:2206 curs_main.c:2666 curs_main.c:2698
 #: flags.c:376 thread.c:1078 thread.c:1134 thread.c:1202
 msgid "Threading is not enabled."
 msgstr "Fadenoj ne estas ŝaltitaj."
 
-#: curs_main.c:2173
+#: curs_main.c:2181
 msgid "Thread broken"
 msgstr "Fadeno rompiĝis"
 
-#: curs_main.c:2185
+#: curs_main.c:2193
 msgid "Thread cannot be broken, message is not part of a thread"
 msgstr "Ne eblas rompi fadenon; mesaĝo ne estas parto de fadeno"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2195
+#: curs_main.c:2203
 msgid "Cannot link threads"
 msgstr "Ne eblas ligi fadenojn"
 
-#: curs_main.c:2200
+#: curs_main.c:2208
 msgid "No Message-ID: header available to link thread"
 msgstr "Neniu 'Message-ID:'-ĉapaĵo disponeblas por ligi fadenon"
 
-#: curs_main.c:2202
+#: curs_main.c:2210
 msgid "First, please tag a message to be linked here"
 msgstr "Unue, bonvolu marki mesaĝon por ligi ĝin ĉi tie"
 
-#: curs_main.c:2213
+#: curs_main.c:2221
 msgid "Threads linked"
 msgstr "Fadenoj ligitaj"
 
-#: curs_main.c:2216
+#: curs_main.c:2224
 msgid "No thread linked"
 msgstr "Neniu fadeno ligita"
 
-#: curs_main.c:2252 curs_main.c:2278
+#: curs_main.c:2260 curs_main.c:2286
 msgid "You are on the last message."
 msgstr "Vi estas ĉe la lasta mesaĝo."
 
-#: curs_main.c:2260 curs_main.c:2305
+#: curs_main.c:2268 curs_main.c:2313
 msgid "No undeleted messages."
 msgstr "Malestas malforviŝitaj mesaĝoj."
 
-#: curs_main.c:2297 curs_main.c:2323
+#: curs_main.c:2305 curs_main.c:2331
 msgid "You are on the first message."
 msgstr "Vi estas ĉe la unua mesaĝo."
 
-#: curs_main.c:2395 menu.c:970 pager.c:2440 pattern.c:2110
+#: curs_main.c:2403 menu.c:970 pager.c:2440 pattern.c:2110
 msgid "Search wrapped to top."
 msgstr "Serĉo rekomencis ĉe la komenco."
 
-#: curs_main.c:2404 pager.c:2463 pattern.c:2121
+#: curs_main.c:2412 pager.c:2463 pattern.c:2121
 msgid "Search wrapped to bottom."
 msgstr "Serĉo rekomencis ĉe la fino."
 
-#: curs_main.c:2447
+#: curs_main.c:2455
 msgid "No new messages in this limited view."
 msgstr "Malestas novaj mesaĝoj en ĉi tiu limigita rigardo."
 
-#: curs_main.c:2449
+#: curs_main.c:2457
 msgid "No new messages."
 msgstr "Malestas novaj mesaĝoj."
 
-#: curs_main.c:2454
+#: curs_main.c:2462
 msgid "No unread messages in this limited view."
 msgstr "Malestas nelegitaj mesaĝoj en ĉi tiu limigita rigardo."
 
-#: curs_main.c:2456
+#: curs_main.c:2464
 msgid "No unread messages."
 msgstr "Malestas nelegitaj mesaĝoj."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2474
+#: curs_main.c:2482
 msgid "Cannot flag message"
 msgstr "Ne eblas flagi mesaĝon"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2513 pager.c:3100
+#: curs_main.c:2521 pager.c:3104
 msgid "Cannot toggle new"
 msgstr "Ne eblas (mal)ŝalti \"nova\""
 
-#: curs_main.c:2590
+#: curs_main.c:2598
 msgid "No more threads."
 msgstr "Ne restas fadenoj."
 
-#: curs_main.c:2592
+#: curs_main.c:2600
 msgid "You are on the first thread."
 msgstr "Vi estas ĉe la unua fadeno."
 
-#: curs_main.c:2676
+#: curs_main.c:2684
 #, fuzzy
 msgid "Thread contains unread or flagged messages."
 msgstr "Fadeno enhavas nelegitajn mesaĝojn."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2726 pager.c:2784
+#: curs_main.c:2734 pager.c:2784
 msgid "Cannot delete message"
 msgstr "Ne eblas forviŝi mesaĝon"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2838
+#: curs_main.c:2850
 msgid "Cannot edit message"
 msgstr "Ne eblas redakti mesaĝon"
 
 #. L10N: This is displayed when the x-label on one or more
 #. * messages is edited.
-#: curs_main.c:2900 pager.c:3200
+#: curs_main.c:2912 pager.c:3208
 #, fuzzy, c-format
 msgid "%d label changed."
 msgid_plural "%d labels changed."
@@ -1789,52 +1799,57 @@ msgstr[1] "%d etikedoj ŝanĝiĝis."
 #. L10N: This is displayed when editing an x-label, but no messages
 #. * were updated.  Possibly due to canceling at the prompt or if the new
 #. * label is the same as the old label.
-#: curs_main.c:2907 pager.c:3204
+#: curs_main.c:2919 pager.c:3212
 msgid "No labels changed."
 msgstr "Neniu etikedo ŝanĝiĝis."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:3006
-msgid "Cannot mark message(s) as read"
+#. L10N: Due to the implementation details we do not know whether we
+#. mark zero, 1, 12, ... messages as read. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:3022
+#, fuzzy
+msgid "Cannot mark messages as read"
 msgstr "Ne eblas marki mesaĝo(j)n kiel legita(j)n"
 
 #. L10N: This is the prompt for <mark-message>.  Whatever they
 #. enter will be prefixed by $mark_macro_prefix and will become
 #. a macro hotkey to jump to the currently selected message.
-#: curs_main.c:3042
+#: curs_main.c:3058
 msgid "Enter macro stroke: "
 msgstr "Tajpu makroan klavon: "
 
 #. L10N: "message hotkey" is the key bindings menu description of a
 #. macro created by <mark-message>.
-#: curs_main.c:3050
+#: curs_main.c:3066
 msgid "message hotkey"
 msgstr "fulmklavo por mesaĝo"
 
 #. L10N: This is echoed after <mark-message> creates a new hotkey
 #. macro.  %s is the hotkey string ($mark_macro_prefix followed
 #. by whatever they typed at the prompt.)
-#: curs_main.c:3055
+#: curs_main.c:3071
 #, c-format
 msgid "Message bound to %s."
 msgstr "Mesaĝo ligiĝis al %s."
 
 #. L10N: This error is printed if <mark-message> cannot find a
 #. Message-ID for the currently selected message in the index.
-#: curs_main.c:3063
+#: curs_main.c:3079
 msgid "No message ID to macro."
 msgstr "Mesaĝa ID mankas en indekso."
 
-#: curs_main.c:3105 pager.c:2961 recvattach.c:1388
+#: curs_main.c:3121 pager.c:2965 recvattach.c:1401
 msgid "Reply by mail as poster prefers?"
 msgstr ""
 
-#: curs_main.c:3108 pager.c:2927 pager.c:2939 pager.c:2964
+#: curs_main.c:3124 pager.c:2931 pager.c:2943 pager.c:2968
 msgid "Posting to this group not allowed, may be moderated. Continue?"
 msgstr ""
 
 #. L10N: CHECK_ACL
-#: curs_main.c:3173 pager.c:3120
+#: curs_main.c:3189 pager.c:3124
 msgid "Cannot undelete message"
 msgstr "Ne eblas malforviŝi mesaĝon"
 
@@ -2025,12 +2040,34 @@ msgstr "[-- Erareligo de %s --]\n"
 msgid "[-- Error: message/external-body has no access-type parameter --]\n"
 msgstr "[-- Eraro: parto message/external ne havas parametro access-type --]\n"
 
-#: handler.c:1611
+#. L10N: If the translation of this string is a multi line string, then
+#. each line should start with "[-- " and end with " --]".
+#. The first "%s/%s" is a MIME type, e.g. "text/plain". The last %s
+#. expands to a date as returned by `mutt_date_parse_date()`.
+#.
+#. Note: The size argument printed is not the actual number as passed
+#. to gettext but the prettified version, e.g. size = 2048 will be
+#. printed as 2K.  Your language might be sensitive to that: For
+#. example although '1K' and '1024' represent the same number your
+#. language might inflect the noun 'byte' differently.
+#.
+#. Sadly, we cannot do anything about that at the moment besides
+#. passing the precise size in bytes. If you are interested the
+#. function responsible for the prettification is
+#. mutt_str_pretty_size() in mutt/string.c.
+#.
+#: handler.c:1624
 #, fuzzy, c-format
 msgid ""
+"[-- This %s/%s attachment (size %s byte) has been deleted --]\n"
+"[-- on %s --]\n"
+msgid_plural ""
 "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
 "[-- on %s --]\n"
-msgstr ""
+msgstr[0] ""
+"[-- Ĉi tiu %s/%s-parto (grando %s bitokoj) estas forviŝita --]\n"
+"[-- je %s --]\n"
+msgstr[1] ""
 "[-- Ĉi tiu %s/%s-parto (grando %s bitokoj) estas forviŝita --]\n"
 "[-- je %s --]\n"
 
@@ -2038,10 +2075,23 @@ msgstr ""
 #. each line should start with "[-- " and end with " --]".
 #. The first "%s/%s" is a MIME type, e.g. "text/plain".
 #.
-#: handler.c:1620
+#. Note: The size argument printed is not the actual number as passed
+#. to gettext but the prettified version, e.g. size = 2048 will be
+#. printed as 2K.  Your language might be sensitive to that: For
+#. example although '1K' and '1024' represent the same number your
+#. language might inflect the noun 'byte' differently.
+#.
+#. Sadly, we cannot do anything about that at the moment besides
+#. passing the precise size in bytes. If you are interested the
+#. function responsible for the prettification is
+#. mutt_str_pretty_size() in mutt/string.c.
+#.
+#: handler.c:1648
 #, fuzzy, c-format
-msgid "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
-msgstr "[-- Ĉi tiu %s/%s-parto (grando %s bitokoj) estas forviŝita --]\n"
+msgid "[-- This %s/%s attachment (size %s byte) has been deleted --]\n"
+msgid_plural "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
+msgstr[0] "[-- Ĉi tiu %s/%s-parto (grando %s bitokoj) estas forviŝita --]\n"
+msgstr[1] "[-- Ĉi tiu %s/%s-parto (grando %s bitokoj) estas forviŝita --]\n"
 
 #. L10N: If the translation of this string is a multi line string, then
 #. each line should start with "[-- " and end with " --]".
@@ -2051,7 +2101,7 @@ msgstr "[-- Ĉi tiu %s/%s-parto (grando %s bitokoj) estas forviŝita --]\n"
 #. Caution: Argument three %3$ is also defined but should not be used
 #. in this translation!
 #.
-#: handler.c:1637
+#: handler.c:1667
 #, fuzzy
 msgid ""
 "[-- This %s/%s attachment has been deleted --]\n"
@@ -2064,17 +2114,17 @@ msgstr ""
 #. each line should start with "[-- " and end with " --]".
 #. The first "%s/%s" is a MIME type, e.g. "text/plain".
 #.
-#: handler.c:1646
+#: handler.c:1676
 #, fuzzy, c-format
 msgid "[-- This %s/%s attachment has been deleted --]\n"
 msgstr "[-- Ĉi tiu %s/%s-parto estas forviŝita --]\n"
 
-#: handler.c:1656
+#: handler.c:1686
 #, c-format
 msgid "[-- name: %s --]\n"
 msgstr "[-- nomo: %s --]\n"
 
-#: handler.c:1672
+#: handler.c:1702
 #, fuzzy, c-format
 msgid ""
 "[-- This %s/%s attachment is not included, --]\n"
@@ -2084,7 +2134,7 @@ msgstr ""
 "[-- Ĉi tiu %s/%s-parto ne estas inkluzivita, --]\n"
 "[-- kaj la indikita ekstera fonto eksvalidiĝis. --]\n"
 
-#: handler.c:1693
+#: handler.c:1723
 #, fuzzy, c-format
 msgid ""
 "[-- This %s/%s attachment is not included, --]\n"
@@ -2093,51 +2143,51 @@ msgstr ""
 "[-- Ĉi tiu %s/%s-parto ne estas inkluzivita, --]\n"
 "[-- kaj NeoMutt ne kapablas je la indikita alirmaniero %s. --]\n"
 
-#: handler.c:1822
+#: handler.c:1852
 #, fuzzy
 msgid "Unable to open memory stream!"
 msgstr "Ne eblas malfermi dumtempan dosieron!"
 
-#: handler.c:1831
+#: handler.c:1861
 msgid "Unable to open temporary file!"
 msgstr "Ne eblas malfermi dumtempan dosieron!"
 
-#: handler.c:1881
+#: handler.c:1911
 msgid "failed to re-open memstream!"
 msgstr ""
 
-#: handler.c:2013
+#: handler.c:2043
 msgid "Error: multipart/signed has no protocol."
 msgstr "Eraro: multipart/signed ne havas parametron 'protocol'!"
 
-#: handler.c:2076
+#: handler.c:2106
 #, fuzzy
 msgid "[-- This is an attachment (use '%3$s' to view this part) --]\n"
 msgstr "[-- Ĉi tiu estas parto (uzu '%3$s' por vidigi ĉi tiun parton) --]\n"
 
-#: handler.c:2082
+#: handler.c:2112
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported (use '%s' to view this part) --]\n"
 msgstr "[-- %s/%s ne estas konata (uzu '%s' por vidigi ĉi tiun parton) --]\n"
 
-#: handler.c:2087
+#: handler.c:2117
 #, fuzzy
 msgid "[-- This is an attachment (need 'view-attachments' bound to key!) --]\n"
 msgstr "[-- Ĉi tiu estas parto (bezonas klavodifinon por 'view-attachments'!) --]\n"
 
 #. L10N: %s/%s is a MIME type, e.g. "text/plain".
-#: handler.c:2091
+#: handler.c:2121
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported (need 'view-attachments' bound to key!) --]\n"
 msgstr "[-- %s/%s ne estas konata (bezonas klavodifinon por 'view-attachments'!) --]\n"
 
-#: handler.c:2098
+#: handler.c:2128
 #, fuzzy
 msgid "[-- This is an attachment --]\n"
 msgstr "[-- Ĉi tiu estas parto --]\n"
 
 #. L10N: %s/%s is a MIME type, e.g. "text/plain".
-#: handler.c:2101
+#: handler.c:2131
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported --]\n"
 msgstr "[-- %s/%s ne estas konata --]\n"
@@ -2443,7 +2493,7 @@ msgstr "SMTP-servilo ne akceptas rajtiĝon"
 msgid "Invalid IMAP flags"
 msgstr "Nevalida      "
 
-#: imap/message.c:477 mx.c:1326
+#: imap/message.c:477 mx.c:1336
 msgid "Integer overflow -- can't allocate memory."
 msgstr "Entjera troo -- ne eblas asigni memoron."
 
@@ -3206,64 +3256,74 @@ msgstr "SSL ne disponeblas."
 msgid "Reading from %s interrupted..."
 msgstr "Serĉo interrompita."
 
-#: mx.c:634
-msgid "message(s) not deleted"
-msgstr "mesaĝo(j) ne forviŝiĝis"
+#. L10N: Although we now the precise number of messages, we do not show it to the user.
+#. So feel free to use a "generic plural" as plural translation if your language has one.
+#.
+#: mx.c:639
+#, fuzzy
+msgid "message not deleted"
+msgid_plural "messages not deleted"
+msgstr[0] "mesaĝo(j) ne forviŝiĝis"
+msgstr[1] "mesaĝo(j) ne forviŝiĝis"
 
-#: mx.c:671
+#: mx.c:676
 msgid "Can't open trash folder"
 msgstr "Ne eblas malfermi rubujon"
 
-#: mx.c:710
+#: mx.c:715
 msgid "Mark all articles read?"
 msgstr ""
 
-#: mx.c:754
+#. L10N: The first argument is the number of read messages to be
+#. moved, the second argument is the target mailbox.
+#: mx.c:762
 #, fuzzy, c-format
-msgid "Move %d read messages to %s?"
-msgstr "Ĉu movi legitajn mesaĝojn al %s?"
+msgid "Move %d read message to %s?"
+msgid_plural "Move %d read messages to %s?"
+msgstr[0] "Ĉu movi legitajn mesaĝojn al %s?"
+msgstr[1] "Ĉu movi legitajn mesaĝojn al %s?"
 
-#: mx.c:771 mx.c:1077
+#: mx.c:781 mx.c:1087
 #, fuzzy, c-format
 msgid "Purge %d deleted message?"
 msgid_plural "Purge %d deleted messages?"
 msgstr[0] "Ĉu forpurigi %d forviŝitan mesaĝon?"
 msgstr[1] "Ĉu forpurigi %d forviŝitajn mesaĝojn?"
 
-#: mx.c:793
+#: mx.c:803
 #, c-format
 msgid "Moving read messages to %s..."
 msgstr "Movas legitajn mesaĝojn al %s..."
 
-#: mx.c:859 mx.c:1068
+#: mx.c:869 mx.c:1078
 msgid "Mailbox is unchanged."
 msgstr "Poŝtfako estas neŝanĝita."
 
-#: mx.c:914
+#: mx.c:924
 #, c-format
 msgid "%d kept, %d moved, %d deleted."
 msgstr "%d retenite, %d movite, %d forviŝite."
 
-#: mx.c:917 mx.c:1130
+#: mx.c:927 mx.c:1140
 #, c-format
 msgid "%d kept, %d deleted."
 msgstr "%d retenite, %d forviŝite."
 
-#: mx.c:1052
+#: mx.c:1062
 #, c-format
 msgid " Press '%s' to toggle write"
 msgstr " Premu '%s' por (mal)ŝalti skribon"
 
-#: mx.c:1054
+#: mx.c:1064
 msgid "Use 'toggle-write' to re-enable write!"
 msgstr "Uzu 'toggle-write' por reebligi skribon!"
 
-#: mx.c:1056
+#: mx.c:1066
 #, c-format
 msgid "Mailbox is marked unwritable. %s"
 msgstr "Poŝtfako estas markita kiel neskribebla. %s"
 
-#: mx.c:1124
+#: mx.c:1134
 msgid "Mailbox checkpointed."
 msgstr "Poŝtfako sinkronigita."
 
@@ -3277,54 +3337,59 @@ msgstr " (nuna horo: %c)"
 msgid "[-- %s output follows%s --]\n"
 msgstr "[-- %s eligo sekvas%s --]\n"
 
-#: ncrypt/crypt.c:95
-msgid "Passphrase(s) forgotten."
+#. L10N: Due to the implementation details (e.g. some passwords are managed
+#. by gpg-agent) we cannot know whether we forgot zero, 1, 12, ...
+#. passwords. So in English we use "Passphrases". Your language might
+#. have other means to express this.
+#: ncrypt/crypt.c:100
+#, fuzzy
+msgid "Passphrases forgotten."
 msgstr "Pasfrazo(j) forgesita(j)."
 
-#: ncrypt/crypt.c:155
+#: ncrypt/crypt.c:161
 msgid "Inline PGP can't be used with attachments.  Revert to PGP/MIME?"
 msgstr "Ne eblas uzi PGP kun aldonaĵoj.  Ĉu refali al PGP/MIME?"
 
-#: ncrypt/crypt.c:159
+#: ncrypt/crypt.c:165
 msgid "Mail not sent: inline PGP can't be used with attachments."
 msgstr "Mesaĝo ne sendita: ne eblas uzi enteksta PGP kun aldonaĵoj."
 
-#: ncrypt/crypt.c:166
+#: ncrypt/crypt.c:172
 #, fuzzy
 msgid "Inline PGP can't be used with format=flowed.  Revert to PGP/MIME?"
 msgstr "Ne eblas uzi PGP kun aldonaĵoj.  Ĉu refali al PGP/MIME?"
 
-#: ncrypt/crypt.c:170
+#: ncrypt/crypt.c:176
 #, fuzzy
 msgid "Mail not sent: inline PGP can't be used with format=flowed."
 msgstr "Mesaĝo ne sendita: ne eblas uzi enteksta PGP kun aldonaĵoj."
 
-#: ncrypt/crypt.c:180 ncrypt/cryptglue.c:125 ncrypt/pgpkey.c:589
+#: ncrypt/crypt.c:186 ncrypt/cryptglue.c:125 ncrypt/pgpkey.c:589
 #: ncrypt/pgpkey.c:782
 msgid "Invoking PGP..."
 msgstr "Alvokas PGP..."
 
-#: ncrypt/crypt.c:192
+#: ncrypt/crypt.c:198
 msgid "Message can't be sent inline.  Revert to using PGP/MIME?"
 msgstr "Ne eblas sendi mesaĝon entekste.  Ĉu refali al PGP/MIME?"
 
-#: ncrypt/crypt.c:194 send.c:1824
+#: ncrypt/crypt.c:200 send.c:1824
 msgid "Mail not sent."
 msgstr "Mesaĝo ne sendita."
 
-#: ncrypt/crypt.c:540
+#: ncrypt/crypt.c:546
 msgid "S/MIME messages with no hints on content are unsupported."
 msgstr "S/MIME-mesaĝoj sen informoj pri enhavo ne funkcias."
 
-#: ncrypt/crypt.c:754 ncrypt/crypt.c:795
+#: ncrypt/crypt.c:760 ncrypt/crypt.c:801
 msgid "Trying to extract PGP keys...\n"
 msgstr "Provas eltiri PGP-ŝlosilojn...\n"
 
-#: ncrypt/crypt.c:776 ncrypt/crypt.c:816
+#: ncrypt/crypt.c:782 ncrypt/crypt.c:822
 msgid "Trying to extract S/MIME certificates...\n"
 msgstr "Provas eltiri S/MIME-atestilojn...\n"
 
-#: ncrypt/crypt.c:976
+#: ncrypt/crypt.c:982
 #, c-format
 msgid ""
 "[-- Error: Unknown multipart/signed protocol %s! --]\n"
@@ -3333,7 +3398,7 @@ msgstr ""
 "[-- Eraro: nekonata multipart/signed-protokolo %s! --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1016
+#: ncrypt/crypt.c:1022
 #, fuzzy
 msgid ""
 "[-- Error: Missing or bad-format multipart/signed signature! --]\n"
@@ -3342,7 +3407,7 @@ msgstr ""
 "[-- Eraro: malĝusta strukturo de multipart/signed! --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1058
+#: ncrypt/crypt.c:1064
 #, c-format
 msgid ""
 "[-- Warning: We can't verify %s/%s signatures. --]\n"
@@ -3351,7 +3416,7 @@ msgstr ""
 "[-- Averto: ne eblas kontroli %s/%s-subskribojn. --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1070
+#: ncrypt/crypt.c:1076
 msgid ""
 "[-- The following data is signed --]\n"
 "\n"
@@ -3359,7 +3424,7 @@ msgstr ""
 "[-- La sekvaj datenoj estas subskribitaj --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1075
+#: ncrypt/crypt.c:1081
 msgid ""
 "[-- Warning: Can't find any signatures. --]\n"
 "\n"
@@ -3367,7 +3432,7 @@ msgstr ""
 "[-- Averto: ne eblas trovi subskribon. --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1081
+#: ncrypt/crypt.c:1087
 msgid ""
 "\n"
 "[-- End of signed data --]\n"
@@ -3418,7 +3483,7 @@ msgstr ""
 msgid "error reading data object: %s\n"
 msgstr "eraro en legado de datenobjekto: %s\n"
 
-#: ncrypt/crypt_gpgme.c:662 ncrypt/crypt_gpgme.c:3848 ncrypt/pgpkey.c:585
+#: ncrypt/crypt_gpgme.c:662 ncrypt/crypt_gpgme.c:3850 ncrypt/pgpkey.c:585
 #: ncrypt/pgpkey.c:768
 msgid "Can't create temporary file"
 msgstr "Ne eblas krei dumtempan dosieron"
@@ -3770,28 +3835,30 @@ msgstr "[Nevalida]"
 
 #. L10N: This is printed after "Key Type: " and looks like this:
 #. *       PGP, 2048 bit RSA
-#: ncrypt/crypt_gpgme.c:3670 ncrypt/crypt_gpgme.c:3808
+#: ncrypt/crypt_gpgme.c:3670 ncrypt/crypt_gpgme.c:3810
 #, fuzzy, c-format
 msgid "%s, %lu bit %s\n"
-msgstr "Ŝlosilspeco: %s, %lu-bita %s\n"
+msgid_plural "%s, %lu bit %s\n"
+msgstr[0] "Ŝlosilspeco: %s, %lu-bita %s\n"
+msgstr[1] "Ŝlosilspeco: %s, %lu-bita %s\n"
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3678 ncrypt/crypt_gpgme.c:3815
+#: ncrypt/crypt_gpgme.c:3678 ncrypt/crypt_gpgme.c:3817
 msgid "encryption"
 msgstr "ĉifrado"
 
 #: ncrypt/crypt_gpgme.c:3679 ncrypt/crypt_gpgme.c:3685
-#: ncrypt/crypt_gpgme.c:3816 ncrypt/crypt_gpgme.c:3821
+#: ncrypt/crypt_gpgme.c:3818 ncrypt/crypt_gpgme.c:3823
 msgid ", "
 msgstr ", "
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3684 ncrypt/crypt_gpgme.c:3820
+#: ncrypt/crypt_gpgme.c:3684 ncrypt/crypt_gpgme.c:3822
 msgid "signing"
 msgstr "subskribo"
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3690 ncrypt/crypt_gpgme.c:3825
+#: ncrypt/crypt_gpgme.c:3690 ncrypt/crypt_gpgme.c:3827
 msgid "certification"
 msgstr "atestado"
 
@@ -3810,64 +3877,64 @@ msgstr "[Eksvalidiĝinte]"
 msgid "[Disabled]"
 msgstr "[Malŝaltita]"
 
-#: ncrypt/crypt_gpgme.c:3851
+#: ncrypt/crypt_gpgme.c:3853
 msgid "Collecting data..."
 msgstr "Kolektas datenojn..."
 
-#: ncrypt/crypt_gpgme.c:3876
+#: ncrypt/crypt_gpgme.c:3878
 #, c-format
 msgid "Error finding issuer key: %s\n"
 msgstr "Eraro dum trovado de eldoninto-ŝlosilo: %s\n"
 
-#: ncrypt/crypt_gpgme.c:3885
+#: ncrypt/crypt_gpgme.c:3887
 msgid "Error: certification chain too long - stopping here\n"
 msgstr "Eraro: atestado-ĉeno tro longas -- haltas ĉi tie\n"
 
-#: ncrypt/crypt_gpgme.c:3895 ncrypt/pgpkey.c:608
+#: ncrypt/crypt_gpgme.c:3897 ncrypt/pgpkey.c:608
 #, c-format
 msgid "Key ID: 0x%s"
 msgstr "Key ID: 0x%s"
 
-#: ncrypt/crypt_gpgme.c:3990
+#: ncrypt/crypt_gpgme.c:3992
 #, c-format
 msgid "gpgme_new failed: %s"
 msgstr "gpgme_new() malsukcesis: %s"
 
-#: ncrypt/crypt_gpgme.c:4028 ncrypt/crypt_gpgme.c:4079
+#: ncrypt/crypt_gpgme.c:4030 ncrypt/crypt_gpgme.c:4081
 #, c-format
 msgid "gpgme_op_keylist_start failed: %s"
 msgstr "gpgme_op_keylist_start() malsukcesis: %s"
 
-#: ncrypt/crypt_gpgme.c:4067 ncrypt/crypt_gpgme.c:4109
+#: ncrypt/crypt_gpgme.c:4069 ncrypt/crypt_gpgme.c:4111
 #, c-format
 msgid "gpgme_op_keylist_next failed: %s"
 msgstr "gpgme_op_keylist_next() malsukcesis: %s"
 
-#: ncrypt/crypt_gpgme.c:4185
+#: ncrypt/crypt_gpgme.c:4187
 msgid "All matching keys are marked expired/revoked."
 msgstr "Ĉiuj kongruaj ŝlosiloj estas eksvalidiĝintaj/revokitaj."
 
-#: ncrypt/crypt_gpgme.c:4215 ncrypt/pgpkey.c:543 ncrypt/smime.c:475
+#: ncrypt/crypt_gpgme.c:4217 ncrypt/pgpkey.c:543 ncrypt/smime.c:475
 msgid "Select  "
 msgstr "Elekti  "
 
-#: ncrypt/crypt_gpgme.c:4217 ncrypt/pgpkey.c:545
+#: ncrypt/crypt_gpgme.c:4219 ncrypt/pgpkey.c:545
 msgid "Check key  "
 msgstr "Kontroli ŝlosilon  "
 
-#: ncrypt/crypt_gpgme.c:4233
+#: ncrypt/crypt_gpgme.c:4235
 msgid "PGP and S/MIME keys matching"
 msgstr "PGP- kaj S/MIME-ŝlosiloj kongruaj"
 
-#: ncrypt/crypt_gpgme.c:4235
+#: ncrypt/crypt_gpgme.c:4237
 msgid "PGP keys matching"
 msgstr "PGP-ŝlosiloj kongruaj"
 
-#: ncrypt/crypt_gpgme.c:4237
+#: ncrypt/crypt_gpgme.c:4239
 msgid "S/MIME keys matching"
 msgstr "S/MIME-ŝlosiloj kongruaj"
 
-#: ncrypt/crypt_gpgme.c:4239
+#: ncrypt/crypt_gpgme.c:4241
 msgid "keys matching"
 msgstr "ŝlosiloj kongruaj"
 
@@ -3875,69 +3942,69 @@ msgstr "ŝlosiloj kongruaj"
 #. %1$s is one of the previous four entries.
 #. %2$s is an address.
 #. e.g. "S/MIME keys matching <me@mutt.org>."
-#: ncrypt/crypt_gpgme.c:4246
+#: ncrypt/crypt_gpgme.c:4248
 #, c-format
 msgid "%s <%s>."
 msgstr "%s <%s>."
 
 #. L10N:
 #. e.g. 'S/MIME keys matching "Michael Elkins".'
-#: ncrypt/crypt_gpgme.c:4250
+#: ncrypt/crypt_gpgme.c:4252
 #, c-format
 msgid "%s \"%s\"."
 msgstr "%s \"%s\"."
 
-#: ncrypt/crypt_gpgme.c:4277 ncrypt/pgpkey.c:628
+#: ncrypt/crypt_gpgme.c:4279 ncrypt/pgpkey.c:628
 msgid "This key can't be used: expired/disabled/revoked."
 msgstr "Ĉi tiu ŝlosilo ne estas uzebla: eksvalidiĝinta/malŝaltita/revokita."
 
-#: ncrypt/crypt_gpgme.c:4290 ncrypt/pgpkey.c:640 ncrypt/smime.c:505
+#: ncrypt/crypt_gpgme.c:4292 ncrypt/pgpkey.c:640 ncrypt/smime.c:505
 #, fuzzy
 msgid "ID is expired/disabled/revoked. Do you really want to use the key?"
 msgstr "ID estas eksvalidiĝinta/malŝaltita/revokita. Ĉu vi vere volas uzi la ŝlosilon?"
 
-#: ncrypt/crypt_gpgme.c:4299 ncrypt/pgpkey.c:650
+#: ncrypt/crypt_gpgme.c:4301 ncrypt/pgpkey.c:650
 #, fuzzy
 msgid "ID is not valid. Do you really want to use the key?"
 msgstr "ID ne estas valida. Ĉu vi vere volas uzi la ŝlosilon?"
 
-#: ncrypt/crypt_gpgme.c:4302 ncrypt/pgpkey.c:653
+#: ncrypt/crypt_gpgme.c:4304 ncrypt/pgpkey.c:653
 #, fuzzy
 msgid "ID is only marginally valid. Do you really want to use the key?"
 msgstr "ID estas nur iomete valida. Ĉu vi vere volas uzi la ŝlosilon?"
 
-#: ncrypt/crypt_gpgme.c:4310 ncrypt/pgpkey.c:646 ncrypt/smime.c:509
+#: ncrypt/crypt_gpgme.c:4312 ncrypt/pgpkey.c:646 ncrypt/smime.c:509
 #, fuzzy
 msgid "ID has undefined validity. Do you really want to use the key?"
 msgstr "ID havas nedifinitan validecon. Ĉu vi vere volas uzi la ŝlosilon?"
 
-#: ncrypt/crypt_gpgme.c:4370 ncrypt/crypt_gpgme.c:4479 ncrypt/pgpkey.c:872
+#: ncrypt/crypt_gpgme.c:4372 ncrypt/crypt_gpgme.c:4481 ncrypt/pgpkey.c:872
 #: ncrypt/pgpkey.c:995
 #, c-format
 msgid "Looking for keys matching \"%s\"..."
 msgstr "Serĉas ŝlosilojn kiuj kongruas kun \"%s\"..."
 
-#: ncrypt/crypt_gpgme.c:4593 ncrypt/pgpkey.c:731 ncrypt/smime.c:811
+#: ncrypt/crypt_gpgme.c:4595 ncrypt/pgpkey.c:731 ncrypt/smime.c:811
 #, c-format
 msgid "No matching keys found for \"%s\""
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4644 ncrypt/pgp.c:1263
+#: ncrypt/crypt_gpgme.c:4646 ncrypt/pgp.c:1263
 #, c-format
 msgid "Use keyID = \"%s\" for %s?"
 msgstr "Ĉu uzi keyID = \"%s\" por %s?"
 
-#: ncrypt/crypt_gpgme.c:4695 ncrypt/pgp.c:1312 ncrypt/smime.c:830
+#: ncrypt/crypt_gpgme.c:4697 ncrypt/pgp.c:1312 ncrypt/smime.c:830
 #: ncrypt/smime.c:938
 #, c-format
 msgid "Enter keyID for %s: "
 msgstr "Donu keyID por %s: "
 
-#: ncrypt/crypt_gpgme.c:4755 ncrypt/pgpkey.c:751
+#: ncrypt/crypt_gpgme.c:4757 ncrypt/pgpkey.c:751
 msgid "Please enter the key ID: "
 msgstr "Bonvolu doni la ŝlosilidentigilon: "
 
-#: ncrypt/crypt_gpgme.c:4768
+#: ncrypt/crypt_gpgme.c:4770
 #, c-format
 msgid "Error exporting key: %s\n"
 msgstr "Eraro dum eksportado de ŝlosilo: %s\n"
@@ -3946,83 +4013,83 @@ msgstr "Eraro dum eksportado de ŝlosilo: %s\n"
 #. MIME description for exported (attached) keys.
 #. You can translate this entry to a non-ASCII string (it will be encoded),
 #. but it may be safer to keep it untranslated.
-#: ncrypt/crypt_gpgme.c:4787
+#: ncrypt/crypt_gpgme.c:4789
 #, c-format
 msgid "PGP Key 0x%s."
 msgstr "PGP-ŝlosilo 0x%s."
 
-#: ncrypt/crypt_gpgme.c:4830
+#: ncrypt/crypt_gpgme.c:4832
 msgid "GPGME: OpenPGP protocol not available"
 msgstr "GPGME: OpenPGP-protokolo ne disponeblas"
 
-#: ncrypt/crypt_gpgme.c:4838
+#: ncrypt/crypt_gpgme.c:4840
 msgid "GPGME: CMS protocol not available"
 msgstr "GPGME: CMS-protokolo ne disponeblas"
 
-#: ncrypt/crypt_gpgme.c:4876
+#: ncrypt/crypt_gpgme.c:4878
 msgid "S/MIME (s)ign, sign (a)s, (p)gp, (c)lear, or (o)ppenc mode off? "
 msgstr "S/MIME (s)ubskribi, subskribi (k)iel, (p)gp, (f)orgesi, aŭ ne (o)ppenc-moduso? "
 
 #. L10N: S/MIME options (opportunistic encryption is on)
-#: ncrypt/crypt_gpgme.c:4878
+#: ncrypt/crypt_gpgme.c:4880
 msgid "sapco"
 msgstr "skpfo"
 
-#: ncrypt/crypt_gpgme.c:4885
+#: ncrypt/crypt_gpgme.c:4887
 msgid "PGP (s)ign, sign (a)s, s/(m)ime, (c)lear, or (o)ppenc mode off? "
 msgstr "PGP (s)ubskribi, subskribi (k)iel, s/(m)ime, (f)orgesi, aŭ ne (o)ppenc-moduso? "
 
 #. L10N: PGP options (opportunistic encryption is on)
-#: ncrypt/crypt_gpgme.c:4887
+#: ncrypt/crypt_gpgme.c:4889
 msgid "samco"
 msgstr "skmfo"
 
 #. L10N: S/MIME options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4900
+#: ncrypt/crypt_gpgme.c:4902
 msgid "S/MIME (e)ncrypt, (s)ign, sign (a)s, (b)oth, (p)gp, (c)lear, or (o)ppenc mode? "
 msgstr "S/MIME ĉ(i)fri, (s)ubskribi, (k)iel, (a)mbaŭ, (p)gp, (f)or, aŭ (o)ppenc-moduso? "
 
 #. L10N: S/MIME options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4903
+#: ncrypt/crypt_gpgme.c:4905
 msgid "esabpco"
 msgstr "iskapfo"
 
 #. L10N: PGP options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4909
+#: ncrypt/crypt_gpgme.c:4911
 msgid "PGP (e)ncrypt, (s)ign, sign (a)s, (b)oth, s/(m)ime, (c)lear, or (o)ppenc mode? "
 msgstr "PGP ĉ(i)fri, (s)ubskribi, (k)iel, (a)mbaŭ, s/(m)ime, (f)or, aŭ (o)ppenc-moduso? "
 
 #. L10N: PGP options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4912
+#: ncrypt/crypt_gpgme.c:4914
 #, fuzzy
 msgid "esabmco"
 msgstr "iskamfo"
 
-#: ncrypt/crypt_gpgme.c:4925
+#: ncrypt/crypt_gpgme.c:4927
 msgid "S/MIME (e)ncrypt, (s)ign, sign (a)s, (b)oth, (p)gp or (c)lear? "
 msgstr "S/MIME ĉ(i)fri, (s)ubskribi, subskribi (k)iel, (a)mbaŭ, \"(p)gp\", aŭ (f)orgesi? "
 
 #. L10N: S/MIME options
-#: ncrypt/crypt_gpgme.c:4927
+#: ncrypt/crypt_gpgme.c:4929
 #, fuzzy
 msgid "esabpc"
 msgstr "iskapf"
 
-#: ncrypt/crypt_gpgme.c:4934
+#: ncrypt/crypt_gpgme.c:4936
 msgid "PGP (e)ncrypt, (s)ign, sign (a)s, (b)oth, s/(m)ime or (c)lear? "
 msgstr "PGP ĉ(i)fri, (s)ubskribi, subskribi (k)iel, (a)mbaŭ, \"s/(m)ime\", aŭ (f)orgesi? "
 
 #. L10N: PGP options
-#: ncrypt/crypt_gpgme.c:4936
+#: ncrypt/crypt_gpgme.c:4938
 #, fuzzy
 msgid "esabmc"
 msgstr "iskamf"
 
-#: ncrypt/crypt_gpgme.c:5087
+#: ncrypt/crypt_gpgme.c:5089
 msgid "Failed to verify sender"
 msgstr "Malsukcesis kontroli sendinton"
 
-#: ncrypt/crypt_gpgme.c:5090
+#: ncrypt/crypt_gpgme.c:5092
 msgid "Failed to figure out sender"
 msgstr "Malsukcesis eltrovi sendinton"
 
@@ -4415,7 +4482,7 @@ msgstr ""
 msgid "%s is an invalid news server specification!"
 msgstr "%s ne estas valida POP-vojo"
 
-#: nntp.c:75 nntp.c:612 pop.c:1028 pop_lib.c:405
+#: nntp.c:75 nntp.c:612 pop.c:1031 pop_lib.c:405
 msgid "Server closed connection!"
 msgstr "Servilo fermis la konekton!"
 
@@ -4581,16 +4648,18 @@ msgid "check mailboxes for new mail"
 msgstr "kontroli poŝtfakojn pri novaj mesaĝoj"
 
 #: opcodes.h:47
-msgid "attach file(s) to this message"
+#, fuzzy
+msgid "attach files to this message"
 msgstr "aldoni dosiero(j)n al ĉi tiu mesaĝo"
 
 #: opcodes.h:48
-msgid "attach message(s) to this message"
+#, fuzzy
+msgid "attach messages to this message"
 msgstr "aldoni mesaĝo(j)n al ĉi tiu mesaĝo"
 
 #: opcodes.h:49
 #, fuzzy
-msgid "attach news article(s) to this message"
+msgid "attach news articles to this message"
 msgstr "aldoni dosiero(j)n al ĉi tiu mesaĝo"
 
 #: opcodes.h:50
@@ -5431,7 +5500,8 @@ msgid "extract supported public keys"
 msgstr "eltiri publikajn ŝlosilojn"
 
 #: opcodes.h:255
-msgid "wipe passphrase(s) from memory"
+#, fuzzy
+msgid "wipe passphrases from memory"
 msgstr "forviŝi pasfrazo(j)n el memoro"
 
 #: opcodes.h:259
@@ -5768,18 +5838,20 @@ msgstr "Malestas novaj mesaĝoj en POP-poŝtfako."
 msgid "Delete messages from server?"
 msgstr "Ĉu forviŝi mesaĝojn de servilo?"
 
-#: pop.c:954
-#, c-format
-msgid "Reading new messages (%d bytes)..."
-msgstr "Legas novajn mesaĝojn (%d bitokojn)..."
+#: pop.c:955
+#, fuzzy, c-format
+msgid "Reading new messages (%d byte)..."
+msgid_plural "Reading new messages (%d bytes)..."
+msgstr[0] "Legas novajn mesaĝojn (%d bitokojn)..."
+msgstr[1] "Legas novajn mesaĝojn (%d bitokojn)..."
 
-#: pop.c:997
+#: pop.c:1000
 msgid "Error while writing mailbox!"
 msgstr "Eraro dum skribado de poŝtfako!"
 
 #. L10N: The plural is picked by the second numerical argument, i.e.
 #. * the %d right before 'messages', i.e. the total number of messages.
-#: pop.c:1003
+#: pop.c:1006
 #, fuzzy, c-format
 msgid "%s [%d of %d message read]"
 msgid_plural "%s [%d of %d messages read]"
@@ -5923,48 +5995,55 @@ msgstr "Trakti per: "
 msgid "I don't know how to print %s attachments!"
 msgstr "Mi ne scias kiel presi %s-partojn!"
 
-#: recvattach.c:841
-msgid "Print tagged attachment(s)?"
-msgstr "Ĉu presi markitajn partojn?"
+#. L10N: Although we now the precise number of tagged messages, we
+#. do not show it to the user.  So feel free to use a "generic
+#. plural" as plural translation if your language has one.
+#: recvattach.c:852
+#, fuzzy, c-format
+msgid "Print tagged attachment?"
+msgid_plural "Print %d tagged attachments?"
+msgstr[0] "Ĉu presi markitajn partojn?"
+msgstr[1] "Ĉu presi markitajn partojn?"
 
-#: recvattach.c:842
+#: recvattach.c:853
+#, c-format
 msgid "Print attachment?"
 msgstr "Ĉu presi parton?"
 
-#: recvattach.c:900
+#: recvattach.c:913
 msgid "Structural changes to decrypted attachments are not supported"
 msgstr ""
 
-#: recvattach.c:1046
+#: recvattach.c:1059
 msgid "Can't decrypt encrypted message!"
 msgstr "Ne eblas malĉifri ĉifritan mesaĝon!"
 
-#: recvattach.c:1172
+#: recvattach.c:1185
 msgid "Attachments"
 msgstr "Partoj"
 
-#: recvattach.c:1210
+#: recvattach.c:1223
 msgid "There are no subparts to show!"
 msgstr "Mankas subpartoj por montri!"
 
-#: recvattach.c:1265
+#: recvattach.c:1278
 msgid "Can't delete attachment from POP server."
 msgstr "Ne eblas forviŝi parton de POP-servilo."
 
-#: recvattach.c:1274
+#: recvattach.c:1287
 #, fuzzy
 msgid "Can't delete attachment from news server."
 msgstr "Ne eblas forviŝi parton de POP-servilo."
 
-#: recvattach.c:1281
+#: recvattach.c:1294
 msgid "Deletion of attachments from encrypted messages is unsupported."
 msgstr "NeoMutt ne kapablas forviŝi partojn el ĉifrita mesaĝo."
 
-#: recvattach.c:1287
+#: recvattach.c:1300
 msgid "Deletion of attachments from signed messages may invalidate the signature."
 msgstr "Forviŝi partojn el ĉifrita mesaĝo eble malvalidigas la subskribon."
 
-#: recvattach.c:1305 recvattach.c:1320
+#: recvattach.c:1318 recvattach.c:1333
 msgid "Only deletion of multipart attachments is supported."
 msgstr "NeoMutt kapablas forviŝi nur multipart-partojn."
 
@@ -6397,3 +6476,13 @@ msgstr "Parametroj de la tradukaĵo:"
 #: version.c:404
 msgid "Compile options:"
 msgstr "Parametroj de la tradukaĵo:"
+
+#~ msgid "Cannot delete message(s)"
+#~ msgstr "Ne eblas forviŝi mesaĝo(j)n"
+
+#~ msgid "Cannot undelete message(s)"
+#~ msgstr "Ne eblas malforviŝi mesaĝo(j)n"
+
+#, fuzzy
+#~ msgid "messages not deleted"
+#~ msgstr "mesaĝo(j) ne forviŝiĝis"

--- a/po/es.po
+++ b/po/es.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neomutt-20180512\n"
 "Report-Msgid-Bugs-To: neomutt-devel@neomutt.org\n"
-"POT-Creation-Date: 2018-05-20 02:02+0000\n"
+"POT-Creation-Date: 2018-05-22 14:18+0000\n"
 "PO-Revision-Date: 2016-11-28 19:29+0100\n"
 "Last-Translator: Rubén Llorente\n"
 "Language-Team: none\n"
@@ -40,7 +40,7 @@ msgstr "Seleccionar"
 
 #: addrbook.c:52 browser.c:75 browser.c:87 compose.c:160 compose.c:172
 #: conn/ssl.c:1041 conn/ssl_gnutls.c:793 curs_main.c:748 curs_main.c:761
-#: history.c:106 ncrypt/crypt_gpgme.c:4219 ncrypt/pgpkey.c:547
+#: history.c:106 ncrypt/crypt_gpgme.c:4221 ncrypt/pgpkey.c:547
 #: ncrypt/smime.c:477 pager.c:2141 postpone.c:65 query.c:72 recvattach.c:70
 msgid "Help"
 msgstr "Ayuda"
@@ -697,7 +697,7 @@ msgstr ""
 #. * Since it shares the row with "Encrypt with:", it should not be longer
 #. * than 15-20 character cells.
 #.
-#: compose.c:138 ncrypt/crypt_gpgme.c:4947 ncrypt/pgp.c:1786
+#: compose.c:138 ncrypt/crypt_gpgme.c:4949 ncrypt/pgp.c:1786
 #: ncrypt/smime.c:2127
 msgid "Sign as: "
 msgstr "Firmar como: "
@@ -1246,7 +1246,7 @@ msgstr "(r)echazar, aceptar (u)na vez"
 msgid "(r)eject, accept (o)nce"
 msgstr "(r)echazar, aceptar (u)na vez"
 
-#: conn/ssl.c:1039 conn/ssl_gnutls.c:791 ncrypt/crypt_gpgme.c:4213
+#: conn/ssl.c:1039 conn/ssl_gnutls.c:791 ncrypt/crypt_gpgme.c:4215
 #: ncrypt/pgpkey.c:541 ncrypt/smime.c:473
 msgid "Exit  "
 msgstr "Salir  "
@@ -1432,11 +1432,11 @@ msgstr "Ningún buzón está abierto."
 msgid "There are no messages."
 msgstr "No hay mensajes."
 
-#: curs_main.c:77 mx.c:1061 pager.c:73 recvattach.c:56
+#: curs_main.c:77 mx.c:1071 pager.c:73 recvattach.c:56
 msgid "Mailbox is read-only."
 msgstr "El buzón es de sólo lectura."
 
-#: curs_main.c:79 pager.c:75 recvattach.c:1145
+#: curs_main.c:79 pager.c:75 recvattach.c:1158
 msgid "Function not permitted in attach-message mode."
 msgstr "Función no permitida en el modo de adjuntar mensaje."
 
@@ -1572,254 +1572,262 @@ msgid "That message is not visible."
 msgstr "Ese mensaje no es visible."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:1377 curs_main.c:2772 pager.c:2818
+#. L10N: Due to the implementation details we do not know whether we
+#. delete zero, 1, 12, ... messages. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:1381 curs_main.c:2784 pager.c:2822
 #, fuzzy
-msgid "Cannot delete message(s)"
+msgid "Cannot delete messages"
 msgstr "No hay mensajes sin suprimir."
 
-#: curs_main.c:1380
+#: curs_main.c:1384
 msgid "Delete messages matching: "
 msgstr "Suprimir mensajes que coincidan con: "
 
-#: curs_main.c:1421
+#: curs_main.c:1425
 msgid "No limit pattern is in effect."
 msgstr "No hay patrón limitante activo."
 
 #. L10N: ask for a limit to apply
-#: curs_main.c:1426
+#: curs_main.c:1430
 #, c-format
 msgid "Limit: %s"
 msgstr "Límite: %s"
 
-#: curs_main.c:1464
+#: curs_main.c:1468
 msgid "Limit to messages matching: "
 msgstr "Limitar a mensajes que coincidan con: "
 
-#: curs_main.c:1488
+#: curs_main.c:1492
 msgid "To view all messages, limit to \"all\"."
 msgstr "Para ver todos los mensajes, limite a \"all\"."
 
-#: curs_main.c:1500 pager.c:2318
+#: curs_main.c:1504 pager.c:2318
 msgid "Quit NeoMutt?"
 msgstr "¿Salir de NeoMutt?"
 
-#: curs_main.c:1596
+#: curs_main.c:1600
 msgid "Tag messages matching: "
 msgstr "Marcar mensajes que coincidan con: "
 
 #. L10N: CHECK_ACL
-#: curs_main.c:1606 curs_main.c:3203 pager.c:3137
+#. L10N: Due to the implementation details we do not know whether we
+#. undelete zero, 1, 12, ... messages. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:1614 curs_main.c:3223 pager.c:3145
 #, fuzzy
-msgid "Cannot undelete message(s)"
+msgid "Cannot undelete messages"
 msgstr "No hay mensajes sin suprimir."
 
-#: curs_main.c:1609
+#: curs_main.c:1617
 msgid "Undelete messages matching: "
 msgstr "No suprimir mensajes que coincidan con: "
 
-#: curs_main.c:1619
+#: curs_main.c:1627
 msgid "Untag messages matching: "
 msgstr "Desmarcar mensajes que coincidan con: "
 
-#: curs_main.c:1653
+#: curs_main.c:1661
 #, fuzzy
 msgid "Logged out of IMAP servers."
 msgstr "Cerrando conexión al servidor IMAP..."
 
-#: curs_main.c:1753
+#: curs_main.c:1761
 #, fuzzy
 msgid "No virtual folder, aborting."
 msgstr "Sin asunto, cancelando."
 
-#: curs_main.c:1761
+#: curs_main.c:1769
 msgid "Failed to read thread, aborting."
 msgstr "Fallo al leer el hilo, abortando."
 
-#: curs_main.c:1793 mx.c:1458 mx.c:1475
+#: curs_main.c:1801 mx.c:1468 mx.c:1485
 msgid "Folder doesn't support tagging, aborting."
 msgstr ""
 
-#: curs_main.c:1808
+#: curs_main.c:1816
 msgid "No tag specified, aborting."
 msgstr ""
 
-#: curs_main.c:1820
+#: curs_main.c:1828
 #, c-format
 msgid "Update tags..."
 msgstr ""
 
-#: curs_main.c:1857
+#: curs_main.c:1865
 msgid "Failed to modify tags, aborting."
 msgstr ""
 
-#: curs_main.c:1898
+#: curs_main.c:1906
 #, fuzzy
 msgid "No query, aborting."
 msgstr "Sin asunto, cancelando."
 
-#: curs_main.c:1902 curs_main.c:1922 curs_main.c:1941
+#: curs_main.c:1910 curs_main.c:1930 curs_main.c:1949
 msgid "Failed to create query, aborting."
 msgstr "Fallo al crear petición, abortando."
 
-#: curs_main.c:1911 curs_main.c:1930
+#: curs_main.c:1919 curs_main.c:1938
 msgid "Windowed queries disabled."
 msgstr ""
 
-#: curs_main.c:1916 curs_main.c:1935
+#: curs_main.c:1924 curs_main.c:1943
 msgid "No notmuch vfolder currently loaded."
 msgstr ""
 
-#: curs_main.c:1973
+#: curs_main.c:1981
 msgid "Open mailbox in read-only mode"
 msgstr "Abrir buzón en modo de sólo lectura"
 
-#: curs_main.c:1976
+#: curs_main.c:1984
 #, fuzzy
 msgid "Open virtual folder"
 msgstr "abrir otro buzón"
 
-#: curs_main.c:1979
+#: curs_main.c:1987
 msgid "Open mailbox"
 msgstr "Abrir buzón"
 
-#: curs_main.c:1989
+#: curs_main.c:1997
 #, fuzzy
 msgid "No mailboxes have new mail"
 msgstr "Ningún buzón con correo nuevo."
 
-#: curs_main.c:2036
+#: curs_main.c:2044
 #, fuzzy
 msgid "Open newsgroup in read-only mode"
 msgstr "Abrir buzón en modo de sólo lectura"
 
-#: curs_main.c:2038
+#: curs_main.c:2046
 msgid "Open newsgroup"
 msgstr "Abrir grupo de noticias"
 
-#: curs_main.c:2141
+#: curs_main.c:2149
 #, fuzzy
 msgid "Exit NeoMutt without saving?"
 msgstr "¿Salir de NeoMutt sin guardar?"
 
-#: curs_main.c:2157
+#: curs_main.c:2165
 #, fuzzy
 msgid "Cannot break thread"
 msgstr "No se pudo crear el filtro"
 
-#: curs_main.c:2160 curs_main.c:2198 curs_main.c:2658 curs_main.c:2690
+#: curs_main.c:2168 curs_main.c:2206 curs_main.c:2666 curs_main.c:2698
 #: flags.c:376 thread.c:1078 thread.c:1134 thread.c:1202
 msgid "Threading is not enabled."
 msgstr "La muestra por hilos no está activada."
 
-#: curs_main.c:2173
+#: curs_main.c:2181
 msgid "Thread broken"
 msgstr "Hilo roto"
 
-#: curs_main.c:2185
+#: curs_main.c:2193
 msgid "Thread cannot be broken, message is not part of a thread"
 msgstr "El hilo no puede romperse, el mensaje no es parte de un hilo"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2195
+#: curs_main.c:2203
 msgid "Cannot link threads"
 msgstr "No se pueden vincular los hilos"
 
-#: curs_main.c:2200
+#: curs_main.c:2208
 msgid "No Message-ID: header available to link thread"
 msgstr ""
 
-#: curs_main.c:2202
+#: curs_main.c:2210
 #, fuzzy
 msgid "First, please tag a message to be linked here"
 msgstr "guardar este mensaje para enviarlo después"
 
-#: curs_main.c:2213
+#: curs_main.c:2221
 msgid "Threads linked"
 msgstr "Hilos enlazados"
 
-#: curs_main.c:2216
+#: curs_main.c:2224
 msgid "No thread linked"
 msgstr "Ningún hilo enlazado"
 
-#: curs_main.c:2252 curs_main.c:2278
+#: curs_main.c:2260 curs_main.c:2286
 msgid "You are on the last message."
 msgstr "Está en el último mensaje."
 
-#: curs_main.c:2260 curs_main.c:2305
+#: curs_main.c:2268 curs_main.c:2313
 msgid "No undeleted messages."
 msgstr "No hay mensajes sin suprimir."
 
-#: curs_main.c:2297 curs_main.c:2323
+#: curs_main.c:2305 curs_main.c:2331
 msgid "You are on the first message."
 msgstr "Está en el primer mensaje."
 
-#: curs_main.c:2395 menu.c:970 pager.c:2440 pattern.c:2110
+#: curs_main.c:2403 menu.c:970 pager.c:2440 pattern.c:2110
 msgid "Search wrapped to top."
 msgstr "La búsqueda volvió a empezar desde arriba."
 
-#: curs_main.c:2404 pager.c:2463 pattern.c:2121
+#: curs_main.c:2412 pager.c:2463 pattern.c:2121
 msgid "Search wrapped to bottom."
 msgstr "La búsqueda volvió a empezar desde abajo."
 
-#: curs_main.c:2447
+#: curs_main.c:2455
 #, fuzzy
 msgid "No new messages in this limited view."
 msgstr "El mensaje anterior no es visible en vista limitada"
 
-#: curs_main.c:2449
+#: curs_main.c:2457
 #, fuzzy
 msgid "No new messages."
 msgstr "No hay mensajes nuevos"
 
-#: curs_main.c:2454
+#: curs_main.c:2462
 #, fuzzy
 msgid "No unread messages in this limited view."
 msgstr "El mensaje anterior no es visible en vista limitada"
 
-#: curs_main.c:2456
+#: curs_main.c:2464
 #, fuzzy
 msgid "No unread messages."
 msgstr "No hay mensajes sin leer"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2474
+#: curs_main.c:2482
 #, fuzzy
 msgid "Cannot flag message"
 msgstr "mostrar el mensaje"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2513 pager.c:3100
+#: curs_main.c:2521 pager.c:3104
 msgid "Cannot toggle new"
 msgstr ""
 
-#: curs_main.c:2590
+#: curs_main.c:2598
 msgid "No more threads."
 msgstr "No hay mas hilos."
 
-#: curs_main.c:2592
+#: curs_main.c:2600
 msgid "You are on the first thread."
 msgstr "Ya está en el primer hilo."
 
-#: curs_main.c:2676
+#: curs_main.c:2684
 #, fuzzy
 msgid "Thread contains unread or flagged messages."
 msgstr "El hilo contiene mensajes sin leer."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2726 pager.c:2784
+#: curs_main.c:2734 pager.c:2784
 #, fuzzy
 msgid "Cannot delete message"
 msgstr "No hay mensajes sin suprimir."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2838
+#: curs_main.c:2850
 #, fuzzy
 msgid "Cannot edit message"
 msgstr "No se pudo escribir el mensaje"
 
 #. L10N: This is displayed when the x-label on one or more
 #. * messages is edited.
-#: curs_main.c:2900 pager.c:3200
+#: curs_main.c:2912 pager.c:3208
 #, fuzzy, c-format
 msgid "%d label changed."
 msgid_plural "%d labels changed."
@@ -1829,28 +1837,32 @@ msgstr[1] "Buzón sin cambios."
 #. L10N: This is displayed when editing an x-label, but no messages
 #. * were updated.  Possibly due to canceling at the prompt or if the new
 #. * label is the same as the old label.
-#: curs_main.c:2907 pager.c:3204
+#: curs_main.c:2919 pager.c:3212
 #, fuzzy
 msgid "No labels changed."
 msgstr "Buzón sin cambios."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:3006
+#. L10N: Due to the implementation details we do not know whether we
+#. mark zero, 1, 12, ... messages as read. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:3022
 #, fuzzy
-msgid "Cannot mark message(s) as read"
+msgid "Cannot mark messages as read"
 msgstr "saltar al mensaje anterior en el hilo"
 
 #. L10N: This is the prompt for <mark-message>.  Whatever they
 #. enter will be prefixed by $mark_macro_prefix and will become
 #. a macro hotkey to jump to the currently selected message.
-#: curs_main.c:3042
+#: curs_main.c:3058
 #, fuzzy
 msgid "Enter macro stroke: "
 msgstr "Entre keyID para %s: "
 
 #. L10N: "message hotkey" is the key bindings menu description of a
 #. macro created by <mark-message>.
-#: curs_main.c:3050
+#: curs_main.c:3066
 #, fuzzy
 msgid "message hotkey"
 msgstr "Mensaje pospuesto."
@@ -1858,28 +1870,28 @@ msgstr "Mensaje pospuesto."
 #. L10N: This is echoed after <mark-message> creates a new hotkey
 #. macro.  %s is the hotkey string ($mark_macro_prefix followed
 #. by whatever they typed at the prompt.)
-#: curs_main.c:3055
+#: curs_main.c:3071
 #, fuzzy, c-format
 msgid "Message bound to %s."
 msgstr "Mensaje rebotado."
 
 #. L10N: This error is printed if <mark-message> cannot find a
 #. Message-ID for the currently selected message in the index.
-#: curs_main.c:3063
+#: curs_main.c:3079
 #, fuzzy
 msgid "No message ID to macro."
 msgstr "No hay mensajes en esa carpeta."
 
-#: curs_main.c:3105 pager.c:2961 recvattach.c:1388
+#: curs_main.c:3121 pager.c:2965 recvattach.c:1401
 msgid "Reply by mail as poster prefers?"
 msgstr "¿Responder mediante email tal y como el autor del mensaje prefiere?"
 
-#: curs_main.c:3108 pager.c:2927 pager.c:2939 pager.c:2964
+#: curs_main.c:3124 pager.c:2931 pager.c:2943 pager.c:2968
 msgid "Posting to this group not allowed, may be moderated. Continue?"
 msgstr "Enviar un mensaje a este grupo no está permitido, puede ser un grupo moderado. ¿Continuar?"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:3173 pager.c:3120
+#: curs_main.c:3189 pager.c:3124
 #, fuzzy
 msgid "Cannot undelete message"
 msgstr "No hay mensajes sin suprimir."
@@ -2091,12 +2103,34 @@ msgstr "[-- Error al ejecutar %s --]\n"
 msgid "[-- Error: message/external-body has no access-type parameter --]\n"
 msgstr "[-- Error: Contenido message/external no tiene parámetro acces-type --]\n"
 
-#: handler.c:1611
+#. L10N: If the translation of this string is a multi line string, then
+#. each line should start with "[-- " and end with " --]".
+#. The first "%s/%s" is a MIME type, e.g. "text/plain". The last %s
+#. expands to a date as returned by `mutt_date_parse_date()`.
+#.
+#. Note: The size argument printed is not the actual number as passed
+#. to gettext but the prettified version, e.g. size = 2048 will be
+#. printed as 2K.  Your language might be sensitive to that: For
+#. example although '1K' and '1024' represent the same number your
+#. language might inflect the noun 'byte' differently.
+#.
+#. Sadly, we cannot do anything about that at the moment besides
+#. passing the precise size in bytes. If you are interested the
+#. function responsible for the prettification is
+#. mutt_str_pretty_size() in mutt/string.c.
+#.
+#: handler.c:1624
 #, fuzzy, c-format
 msgid ""
+"[-- This %s/%s attachment (size %s byte) has been deleted --]\n"
+"[-- on %s --]\n"
+msgid_plural ""
 "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
 "[-- on %s --]\n"
-msgstr ""
+msgstr[0] ""
+"[-- Este archivo adjunto %s/%s (tamaño %s bytes) ha sido suprimido --]\n"
+"[-- el %s --]\n"
+msgstr[1] ""
 "[-- Este archivo adjunto %s/%s (tamaño %s bytes) ha sido suprimido --]\n"
 "[-- el %s --]\n"
 
@@ -2104,10 +2138,23 @@ msgstr ""
 #. each line should start with "[-- " and end with " --]".
 #. The first "%s/%s" is a MIME type, e.g. "text/plain".
 #.
-#: handler.c:1620
+#. Note: The size argument printed is not the actual number as passed
+#. to gettext but the prettified version, e.g. size = 2048 will be
+#. printed as 2K.  Your language might be sensitive to that: For
+#. example although '1K' and '1024' represent the same number your
+#. language might inflect the noun 'byte' differently.
+#.
+#. Sadly, we cannot do anything about that at the moment besides
+#. passing the precise size in bytes. If you are interested the
+#. function responsible for the prettification is
+#. mutt_str_pretty_size() in mutt/string.c.
+#.
+#: handler.c:1648
 #, fuzzy, c-format
-msgid "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
-msgstr "[-- Este archivo adjunto %s/%s (tamaño %s bytes) ha sido suprimido --]\n"
+msgid "[-- This %s/%s attachment (size %s byte) has been deleted --]\n"
+msgid_plural "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
+msgstr[0] "[-- Este archivo adjunto %s/%s (tamaño %s bytes) ha sido suprimido --]\n"
+msgstr[1] "[-- Este archivo adjunto %s/%s (tamaño %s bytes) ha sido suprimido --]\n"
 
 #. L10N: If the translation of this string is a multi line string, then
 #. each line should start with "[-- " and end with " --]".
@@ -2117,7 +2164,7 @@ msgstr "[-- Este archivo adjunto %s/%s (tamaño %s bytes) ha sido suprimido --]\
 #. Caution: Argument three %3$ is also defined but should not be used
 #. in this translation!
 #.
-#: handler.c:1637
+#: handler.c:1667
 #, fuzzy
 msgid ""
 "[-- This %s/%s attachment has been deleted --]\n"
@@ -2130,17 +2177,17 @@ msgstr ""
 #. each line should start with "[-- " and end with " --]".
 #. The first "%s/%s" is a MIME type, e.g. "text/plain".
 #.
-#: handler.c:1646
+#: handler.c:1676
 #, fuzzy, c-format
 msgid "[-- This %s/%s attachment has been deleted --]\n"
 msgstr "[-- Este archivo adjunto %s/%s ha sido suprimido --]\n"
 
-#: handler.c:1656
+#: handler.c:1686
 #, c-format
 msgid "[-- name: %s --]\n"
 msgstr "[-- nombre: %s --]\n"
 
-#: handler.c:1672
+#: handler.c:1702
 #, fuzzy, c-format
 msgid ""
 "[-- This %s/%s attachment is not included, --]\n"
@@ -2150,7 +2197,7 @@ msgstr ""
 "[-- Este archivo adjunto %s/%s [-- Este archivo adjunto %s/%s no está incluido --]\n"
 "[-- y la fuente externa indicada ha expirado. --]\n"
 
-#: handler.c:1693
+#: handler.c:1723
 #, fuzzy, c-format
 msgid ""
 "[-- This %s/%s attachment is not included, --]\n"
@@ -2159,52 +2206,52 @@ msgstr ""
 "[-- Este archivo adjunto %s/%s [-- Este archivo adjunto %s/%s no está incluido --]\n"
 "[-- y el tipo de acceso indicado %s no está soportado --]\n"
 
-#: handler.c:1822
+#: handler.c:1852
 #, fuzzy
 msgid "Unable to open memory stream!"
 msgstr "¡Imposible abrir archivo temporal!"
 
-#: handler.c:1831
+#: handler.c:1861
 msgid "Unable to open temporary file!"
 msgstr "¡Imposible abrir archivo temporal!"
 
-#: handler.c:1881
+#: handler.c:1911
 #, fuzzy
 msgid "failed to re-open memstream!"
 msgstr "¡Imposible abrir archivo temporal!"
 
-#: handler.c:2013
+#: handler.c:2043
 msgid "Error: multipart/signed has no protocol."
 msgstr "Error: multipart/signed no tiene protocolo."
 
-#: handler.c:2076
+#: handler.c:2106
 #, fuzzy
 msgid "[-- This is an attachment (use '%3$s' to view this part) --]\n"
 msgstr "[-- Este archivo adjunto %s/%s (use '%3$s' para ver esta parte) --]\n"
 
-#: handler.c:2082
+#: handler.c:2112
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported (use '%s' to view this part) --]\n"
 msgstr "[-- %s/%s no está soportado (use '%s' para ver esta parte) --]\n"
 
-#: handler.c:2087
+#: handler.c:2117
 #, fuzzy
 msgid "[-- This is an attachment (need 'view-attachments' bound to key!) --]\n"
 msgstr "[-- Este archivo adjunto %s/%s (necesita 'view-attachments' enlazado a una tecla) --]\n"
 
 #. L10N: %s/%s is a MIME type, e.g. "text/plain".
-#: handler.c:2091
+#: handler.c:2121
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported (need 'view-attachments' bound to key!) --]\n"
 msgstr "[-- %s/%s no está soportado (necesita 'view-attachments' enlazado a una tecla) --]\n"
 
-#: handler.c:2098
+#: handler.c:2128
 #, fuzzy
 msgid "[-- This is an attachment --]\n"
 msgstr "[-- Este archivo adjunto %s/%s --]\n"
 
 #. L10N: %s/%s is a MIME type, e.g. "text/plain".
-#: handler.c:2101
+#: handler.c:2131
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported --]\n"
 msgstr "[-- %s/%s no está soportado --]\n"
@@ -2515,7 +2562,7 @@ msgstr ""
 msgid "Invalid IMAP flags"
 msgstr ""
 
-#: imap/message.c:477 mx.c:1326
+#: imap/message.c:477 mx.c:1336
 msgid "Integer overflow -- can't allocate memory."
 msgstr "Desbordameinto de número entero - no se puede asignar memoria."
 
@@ -3291,66 +3338,75 @@ msgstr ""
 msgid "Reading from %s interrupted..."
 msgstr "Búsqueda interrumpida."
 
-#: mx.c:634
+#. L10N: Although we now the precise number of messages, we do not show it to the user.
+#. So feel free to use a "generic plural" as plural translation if your language has one.
+#.
+#: mx.c:639
 #, fuzzy
-msgid "message(s) not deleted"
-msgstr "Marcando %d mensajes como suprimidos..."
+msgid "message not deleted"
+msgid_plural "messages not deleted"
+msgstr[0] "Marcando %d mensajes como suprimidos..."
+msgstr[1] "Marcando %d mensajes como suprimidos..."
 
-#: mx.c:671
+#: mx.c:676
 #, fuzzy
 msgid "Can't open trash folder"
 msgstr "No se pudo agregar a la carpeta: %s"
 
-#: mx.c:710
+#: mx.c:715
 msgid "Mark all articles read?"
 msgstr "¿Marcar todos los artículos como leídos?"
 
-#: mx.c:754
-#, c-format
-msgid "Move %d read messages to %s?"
-msgstr ""
+#. L10N: The first argument is the number of read messages to be
+#. moved, the second argument is the target mailbox.
+#: mx.c:762
+#, fuzzy, c-format
+msgid "Move %d read message to %s?"
+msgid_plural "Move %d read messages to %s?"
+msgstr[0] "Moviendo mensajes leídos a %s..."
+msgstr[1] "Moviendo mensajes leídos a %s..."
 
-#: mx.c:771 mx.c:1077
+#: mx.c:781 mx.c:1087
 #, fuzzy, c-format
 msgid "Purge %d deleted message?"
 msgid_plural "Purge %d deleted messages?"
 msgstr[0] "¿Expulsar %d mensaje suprimido?"
 msgstr[1] "¿Expulsar %d mensajes suprimidos?"
 
-#: mx.c:793
+#: mx.c:803
 #, c-format
 msgid "Moving read messages to %s..."
 msgstr "Moviendo mensajes leídos a %s..."
 
-#: mx.c:859 mx.c:1068
+#: mx.c:869 mx.c:1078
 msgid "Mailbox is unchanged."
 msgstr "Buzón sin cambios."
 
-#: mx.c:914
+#: mx.c:924
 #, c-format
 msgid "%d kept, %d moved, %d deleted."
 msgstr "quedan %d, %d movidos, %d suprimidos."
 
-#: mx.c:917 mx.c:1130
+#: mx.c:927 mx.c:1140
 #, c-format
 msgid "%d kept, %d deleted."
 msgstr "quedan %d, %d suprimidos."
 
-#: mx.c:1052
+#: mx.c:1062
 #, c-format
 msgid " Press '%s' to toggle write"
 msgstr "Presione '%s' para cambiar escritura"
 
-#: mx.c:1054
+#: mx.c:1064
 msgid "Use 'toggle-write' to re-enable write!"
 msgstr "¡Use 'toggle-write' para activar escritura!"
 
-#: mx.c:1056
+#: mx.c:1066
 #, c-format
 msgid "Mailbox is marked unwritable. %s"
 msgstr "Buzón está marcado inescribible. %s"
 
-#: mx.c:1124
+#: mx.c:1134
 msgid "Mailbox checkpointed."
 msgstr "El buzón fue marcado."
 
@@ -3364,55 +3420,59 @@ msgstr " (fecha actual: %c)"
 msgid "[-- %s output follows%s --]\n"
 msgstr "[-- Salida de PGP a continuación (tiempo actual: %c) --]\n"
 
-#: ncrypt/crypt.c:95
+#. L10N: Due to the implementation details (e.g. some passwords are managed
+#. by gpg-agent) we cannot know whether we forgot zero, 1, 12, ...
+#. passwords. So in English we use "Passphrases". Your language might
+#. have other means to express this.
+#: ncrypt/crypt.c:100
 #, fuzzy
-msgid "Passphrase(s) forgotten."
+msgid "Passphrases forgotten."
 msgstr "Contraseña PGP olvidada."
 
-#: ncrypt/crypt.c:155
+#: ncrypt/crypt.c:161
 msgid "Inline PGP can't be used with attachments.  Revert to PGP/MIME?"
 msgstr "PGP Inline no puede ser utilizado con adjuntos. ¿Cambiar a PGP/MIME?"
 
-#: ncrypt/crypt.c:159
+#: ncrypt/crypt.c:165
 msgid "Mail not sent: inline PGP can't be used with attachments."
 msgstr "Email no enviado: PGP inline no puede utilizarse con adjuntos."
 
-#: ncrypt/crypt.c:166
+#: ncrypt/crypt.c:172
 #, fuzzy
 msgid "Inline PGP can't be used with format=flowed.  Revert to PGP/MIME?"
 msgstr "PGP Inline no puede ser utilizado con adjuntos. ¿Cambiar a PGP/MIME?"
 
-#: ncrypt/crypt.c:170
+#: ncrypt/crypt.c:176
 #, fuzzy
 msgid "Mail not sent: inline PGP can't be used with format=flowed."
 msgstr "Email no enviado: PGP inline no puede utilizarse con adjuntos."
 
-#: ncrypt/crypt.c:180 ncrypt/cryptglue.c:125 ncrypt/pgpkey.c:589
+#: ncrypt/crypt.c:186 ncrypt/cryptglue.c:125 ncrypt/pgpkey.c:589
 #: ncrypt/pgpkey.c:782
 msgid "Invoking PGP..."
 msgstr "Invocando PGP..."
 
-#: ncrypt/crypt.c:192
+#: ncrypt/crypt.c:198
 msgid "Message can't be sent inline.  Revert to using PGP/MIME?"
 msgstr "El mensaje no puede enviarse en modo inline. ¿Cambiar a PGP/MIME?"
 
-#: ncrypt/crypt.c:194 send.c:1824
+#: ncrypt/crypt.c:200 send.c:1824
 msgid "Mail not sent."
 msgstr "Mensaje no enviado."
 
-#: ncrypt/crypt.c:540
+#: ncrypt/crypt.c:546
 msgid "S/MIME messages with no hints on content are unsupported."
 msgstr "Los mensajes S/MIME sin pistas sobre el contenido no están soportados."
 
-#: ncrypt/crypt.c:754 ncrypt/crypt.c:795
+#: ncrypt/crypt.c:760 ncrypt/crypt.c:801
 msgid "Trying to extract PGP keys...\n"
 msgstr "Intentando extraer las claces PGP... \n"
 
-#: ncrypt/crypt.c:776 ncrypt/crypt.c:816
+#: ncrypt/crypt.c:782 ncrypt/crypt.c:822
 msgid "Trying to extract S/MIME certificates...\n"
 msgstr "Intentando extraer los certificados S/MIME... \n"
 
-#: ncrypt/crypt.c:976
+#: ncrypt/crypt.c:982
 #, c-format
 msgid ""
 "[-- Error: Unknown multipart/signed protocol %s! --]\n"
@@ -3421,7 +3481,7 @@ msgstr ""
 "[-- Error: ¡Protocolo multipart/signed %s desconocido! --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1016
+#: ncrypt/crypt.c:1022
 #, fuzzy
 msgid ""
 "[-- Error: Missing or bad-format multipart/signed signature! --]\n"
@@ -3430,7 +3490,7 @@ msgstr ""
 "[-- Error: ¡Estructura multipart/signed inconsistente! --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1058
+#: ncrypt/crypt.c:1064
 #, c-format
 msgid ""
 "[-- Warning: We can't verify %s/%s signatures. --]\n"
@@ -3439,7 +3499,7 @@ msgstr ""
 "[-- Advertencia: No se pudieron verificar %s/%s firmas. --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1070
+#: ncrypt/crypt.c:1076
 #, fuzzy
 msgid ""
 "[-- The following data is signed --]\n"
@@ -3448,7 +3508,7 @@ msgstr ""
 "[-- Los siguientes datos están firmados --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1075
+#: ncrypt/crypt.c:1081
 msgid ""
 "[-- Warning: Can't find any signatures. --]\n"
 "\n"
@@ -3456,7 +3516,7 @@ msgstr ""
 "[-- Advertencia: No se pudieron encontrar firmas. --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1081
+#: ncrypt/crypt.c:1087
 #, fuzzy
 msgid ""
 "\n"
@@ -3509,7 +3569,7 @@ msgstr ""
 msgid "error reading data object: %s\n"
 msgstr "error en patrón en: %s"
 
-#: ncrypt/crypt_gpgme.c:662 ncrypt/crypt_gpgme.c:3848 ncrypt/pgpkey.c:585
+#: ncrypt/crypt_gpgme.c:662 ncrypt/crypt_gpgme.c:3850 ncrypt/pgpkey.c:585
 #: ncrypt/pgpkey.c:768
 msgid "Can't create temporary file"
 msgstr "No se pudo crear archivo temporal"
@@ -3895,29 +3955,31 @@ msgstr "Mes inválido: %s"
 
 #. L10N: This is printed after "Key Type: " and looks like this:
 #. *       PGP, 2048 bit RSA
-#: ncrypt/crypt_gpgme.c:3670 ncrypt/crypt_gpgme.c:3808
+#: ncrypt/crypt_gpgme.c:3670 ncrypt/crypt_gpgme.c:3810
 #, fuzzy, c-format
 msgid "%s, %lu bit %s\n"
-msgstr "Tipo de clave ..: %s, %lu bit %s\n"
+msgid_plural "%s, %lu bit %s\n"
+msgstr[0] "Tipo de clave ..: %s, %lu bit %s\n"
+msgstr[1] "Tipo de clave ..: %s, %lu bit %s\n"
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3678 ncrypt/crypt_gpgme.c:3815
+#: ncrypt/crypt_gpgme.c:3678 ncrypt/crypt_gpgme.c:3817
 #, fuzzy
 msgid "encryption"
 msgstr "Cifrar"
 
 #: ncrypt/crypt_gpgme.c:3679 ncrypt/crypt_gpgme.c:3685
-#: ncrypt/crypt_gpgme.c:3816 ncrypt/crypt_gpgme.c:3821
+#: ncrypt/crypt_gpgme.c:3818 ncrypt/crypt_gpgme.c:3823
 msgid ", "
 msgstr ", "
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3684 ncrypt/crypt_gpgme.c:3820
+#: ncrypt/crypt_gpgme.c:3684 ncrypt/crypt_gpgme.c:3822
 msgid "signing"
 msgstr "firmando"
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3690 ncrypt/crypt_gpgme.c:3825
+#: ncrypt/crypt_gpgme.c:3690 ncrypt/crypt_gpgme.c:3827
 #, fuzzy
 msgid "certification"
 msgstr "El certificado fue guardado"
@@ -3938,70 +4000,70 @@ msgstr "Salir  "
 msgid "[Disabled]"
 msgstr "[Disactivada]"
 
-#: ncrypt/crypt_gpgme.c:3851
+#: ncrypt/crypt_gpgme.c:3853
 #, fuzzy
 msgid "Collecting data..."
 msgstr "Conectando a %s..."
 
-#: ncrypt/crypt_gpgme.c:3876
+#: ncrypt/crypt_gpgme.c:3878
 #, fuzzy, c-format
 msgid "Error finding issuer key: %s\n"
 msgstr "Error al conectar al servidor: %s"
 
-#: ncrypt/crypt_gpgme.c:3885
+#: ncrypt/crypt_gpgme.c:3887
 #, fuzzy
 msgid "Error: certification chain too long - stopping here\n"
 msgstr "Error en línea de comando: %s\n"
 
-#: ncrypt/crypt_gpgme.c:3895 ncrypt/pgpkey.c:608
+#: ncrypt/crypt_gpgme.c:3897 ncrypt/pgpkey.c:608
 #, c-format
 msgid "Key ID: 0x%s"
 msgstr "Key ID: 0x%s"
 
-#: ncrypt/crypt_gpgme.c:3990
+#: ncrypt/crypt_gpgme.c:3992
 #, fuzzy, c-format
 msgid "gpgme_new failed: %s"
 msgstr "CLOSE falló"
 
-#: ncrypt/crypt_gpgme.c:4028 ncrypt/crypt_gpgme.c:4079
+#: ncrypt/crypt_gpgme.c:4030 ncrypt/crypt_gpgme.c:4081
 #, c-format
 msgid "gpgme_op_keylist_start failed: %s"
 msgstr "gpgme_op_keylist_start falló: %s"
 
-#: ncrypt/crypt_gpgme.c:4067 ncrypt/crypt_gpgme.c:4109
+#: ncrypt/crypt_gpgme.c:4069 ncrypt/crypt_gpgme.c:4111
 #, c-format
 msgid "gpgme_op_keylist_next failed: %s"
 msgstr "gpgme_op_keylist_next falló: %s"
 
-#: ncrypt/crypt_gpgme.c:4185
+#: ncrypt/crypt_gpgme.c:4187
 #, fuzzy
 msgid "All matching keys are marked expired/revoked."
 msgstr "Todas las llaves que coinciden están marcadas expiradas/revocadas."
 
-#: ncrypt/crypt_gpgme.c:4215 ncrypt/pgpkey.c:543 ncrypt/smime.c:475
+#: ncrypt/crypt_gpgme.c:4217 ncrypt/pgpkey.c:543 ncrypt/smime.c:475
 msgid "Select  "
 msgstr "Seleccionar  "
 
-#: ncrypt/crypt_gpgme.c:4217 ncrypt/pgpkey.c:545
+#: ncrypt/crypt_gpgme.c:4219 ncrypt/pgpkey.c:545
 msgid "Check key  "
 msgstr "Verificar clave  "
 
-#: ncrypt/crypt_gpgme.c:4233
+#: ncrypt/crypt_gpgme.c:4235
 #, fuzzy
 msgid "PGP and S/MIME keys matching"
 msgstr "Claves S/MIME que coinciden con \"%s\"."
 
-#: ncrypt/crypt_gpgme.c:4235
+#: ncrypt/crypt_gpgme.c:4237
 #, fuzzy
 msgid "PGP keys matching"
 msgstr "Claves PGP que coinciden con \"%s\"."
 
-#: ncrypt/crypt_gpgme.c:4237
+#: ncrypt/crypt_gpgme.c:4239
 #, fuzzy
 msgid "S/MIME keys matching"
 msgstr "Claves S/MIME que coinciden con \"%s\"."
 
-#: ncrypt/crypt_gpgme.c:4239
+#: ncrypt/crypt_gpgme.c:4241
 #, fuzzy
 msgid "keys matching"
 msgstr "Claves PGP que coinciden con \"%s\"."
@@ -4010,69 +4072,69 @@ msgstr "Claves PGP que coinciden con \"%s\"."
 #. %1$s is one of the previous four entries.
 #. %2$s is an address.
 #. e.g. "S/MIME keys matching <me@mutt.org>."
-#: ncrypt/crypt_gpgme.c:4246
+#: ncrypt/crypt_gpgme.c:4248
 #, fuzzy, c-format
 msgid "%s <%s>."
 msgstr "%s [%s]\n"
 
 #. L10N:
 #. e.g. 'S/MIME keys matching "Michael Elkins".'
-#: ncrypt/crypt_gpgme.c:4250
+#: ncrypt/crypt_gpgme.c:4252
 #, fuzzy, c-format
 msgid "%s \"%s\"."
 msgstr "%s [%s]\n"
 
-#: ncrypt/crypt_gpgme.c:4277 ncrypt/pgpkey.c:628
+#: ncrypt/crypt_gpgme.c:4279 ncrypt/pgpkey.c:628
 msgid "This key can't be used: expired/disabled/revoked."
 msgstr "Esta clave no se puede usar: expirada/desactivada/revocada."
 
-#: ncrypt/crypt_gpgme.c:4290 ncrypt/pgpkey.c:640 ncrypt/smime.c:505
+#: ncrypt/crypt_gpgme.c:4292 ncrypt/pgpkey.c:640 ncrypt/smime.c:505
 #, fuzzy
 msgid "ID is expired/disabled/revoked. Do you really want to use the key?"
 msgstr "Esta clave está expirada/desactivada/revocada. ¿Realmente quiere utilizar la llave?"
 
-#: ncrypt/crypt_gpgme.c:4299 ncrypt/pgpkey.c:650
+#: ncrypt/crypt_gpgme.c:4301 ncrypt/pgpkey.c:650
 #, fuzzy
 msgid "ID is not valid. Do you really want to use the key?"
 msgstr "Esta ID no es de confianza. ¿Realmente quiere utilizar la llave?"
 
-#: ncrypt/crypt_gpgme.c:4302 ncrypt/pgpkey.c:653
+#: ncrypt/crypt_gpgme.c:4304 ncrypt/pgpkey.c:653
 #, fuzzy
 msgid "ID is only marginally valid. Do you really want to use the key?"
 msgstr "Esta ID es marginalmente de confianza. ¿Realmente quiere utilizar la llave?"
 
-#: ncrypt/crypt_gpgme.c:4310 ncrypt/pgpkey.c:646 ncrypt/smime.c:509
+#: ncrypt/crypt_gpgme.c:4312 ncrypt/pgpkey.c:646 ncrypt/smime.c:509
 #, fuzzy
 msgid "ID has undefined validity. Do you really want to use the key?"
 msgstr "El identificador tiene una validez indefinida. ¿Realmente quiere utilizar la llave?"
 
-#: ncrypt/crypt_gpgme.c:4370 ncrypt/crypt_gpgme.c:4479 ncrypt/pgpkey.c:872
+#: ncrypt/crypt_gpgme.c:4372 ncrypt/crypt_gpgme.c:4481 ncrypt/pgpkey.c:872
 #: ncrypt/pgpkey.c:995
 #, c-format
 msgid "Looking for keys matching \"%s\"..."
 msgstr "Buscando claves que coincidan con \"%s\"..."
 
-#: ncrypt/crypt_gpgme.c:4593 ncrypt/pgpkey.c:731 ncrypt/smime.c:811
+#: ncrypt/crypt_gpgme.c:4595 ncrypt/pgpkey.c:731 ncrypt/smime.c:811
 #, c-format
 msgid "No matching keys found for \"%s\""
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4644 ncrypt/pgp.c:1263
+#: ncrypt/crypt_gpgme.c:4646 ncrypt/pgp.c:1263
 #, c-format
 msgid "Use keyID = \"%s\" for %s?"
 msgstr "¿Usar keyID = \"%s\" para %s?"
 
-#: ncrypt/crypt_gpgme.c:4695 ncrypt/pgp.c:1312 ncrypt/smime.c:830
+#: ncrypt/crypt_gpgme.c:4697 ncrypt/pgp.c:1312 ncrypt/smime.c:830
 #: ncrypt/smime.c:938
 #, c-format
 msgid "Enter keyID for %s: "
 msgstr "Entre keyID para %s: "
 
-#: ncrypt/crypt_gpgme.c:4755 ncrypt/pgpkey.c:751
+#: ncrypt/crypt_gpgme.c:4757 ncrypt/pgpkey.c:751
 msgid "Please enter the key ID: "
 msgstr "Por favor entre la identificación de la clave: "
 
-#: ncrypt/crypt_gpgme.c:4768
+#: ncrypt/crypt_gpgme.c:4770
 #, fuzzy, c-format
 msgid "Error exporting key: %s\n"
 msgstr "error en patrón en: %s"
@@ -4081,86 +4143,86 @@ msgstr "error en patrón en: %s"
 #. MIME description for exported (attached) keys.
 #. You can translate this entry to a non-ASCII string (it will be encoded),
 #. but it may be safer to keep it untranslated.
-#: ncrypt/crypt_gpgme.c:4787
+#: ncrypt/crypt_gpgme.c:4789
 #, fuzzy, c-format
 msgid "PGP Key 0x%s."
 msgstr "Clave PGP %s."
 
-#: ncrypt/crypt_gpgme.c:4830
+#: ncrypt/crypt_gpgme.c:4832
 msgid "GPGME: OpenPGP protocol not available"
 msgstr "GPGME: protocolo OpenPGP no disponible"
 
-#: ncrypt/crypt_gpgme.c:4838
+#: ncrypt/crypt_gpgme.c:4840
 msgid "GPGME: CMS protocol not available"
 msgstr "GPGME: protocolo CMS no disponible"
 
-#: ncrypt/crypt_gpgme.c:4876
+#: ncrypt/crypt_gpgme.c:4878
 #, fuzzy
 msgid "S/MIME (s)ign, sign (a)s, (p)gp, (c)lear, or (o)ppenc mode off? "
 msgstr "¿co(d)ificar, f(i)rmar (c)omo, amb(o)s, inc(l)uido, o ca(n)celar? "
 
 #. L10N: S/MIME options (opportunistic encryption is on)
-#: ncrypt/crypt_gpgme.c:4878
+#: ncrypt/crypt_gpgme.c:4880
 msgid "sapco"
 msgstr "dicoln"
 
-#: ncrypt/crypt_gpgme.c:4885
+#: ncrypt/crypt_gpgme.c:4887
 #, fuzzy
 msgid "PGP (s)ign, sign (a)s, s/(m)ime, (c)lear, or (o)ppenc mode off? "
 msgstr "¿co(d)ificar, f(i)rmar (c)omo, amb(o)s, inc(l)uido, o ca(n)celar? "
 
 #. L10N: PGP options (opportunistic encryption is on)
-#: ncrypt/crypt_gpgme.c:4887
+#: ncrypt/crypt_gpgme.c:4889
 msgid "samco"
 msgstr "dicoln"
 
 #. L10N: S/MIME options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4900
+#: ncrypt/crypt_gpgme.c:4902
 #, fuzzy
 msgid "S/MIME (e)ncrypt, (s)ign, sign (a)s, (b)oth, (p)gp, (c)lear, or (o)ppenc mode? "
 msgstr "¿co(d)ificar, f(i)rmar (c)omo, amb(o)s, inc(l)uido, o ca(n)celar? "
 
 #. L10N: S/MIME options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4903
+#: ncrypt/crypt_gpgme.c:4905
 msgid "esabpco"
 msgstr "dicoln"
 
 #. L10N: PGP options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4909
+#: ncrypt/crypt_gpgme.c:4911
 #, fuzzy
 msgid "PGP (e)ncrypt, (s)ign, sign (a)s, (b)oth, s/(m)ime, (c)lear, or (o)ppenc mode? "
 msgstr "¿co(d)ificar, f(i)rmar (c)omo, amb(o)s, inc(l)uido, o ca(n)celar? "
 
 #. L10N: PGP options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4912
+#: ncrypt/crypt_gpgme.c:4914
 msgid "esabmco"
 msgstr "dicoln"
 
-#: ncrypt/crypt_gpgme.c:4925
+#: ncrypt/crypt_gpgme.c:4927
 #, fuzzy
 msgid "S/MIME (e)ncrypt, (s)ign, sign (a)s, (b)oth, (p)gp or (c)lear? "
 msgstr "¿co(d)ificar, f(i)rmar (c)omo, amb(o)s, inc(l)uido, o ca(n)celar? "
 
 #. L10N: S/MIME options
-#: ncrypt/crypt_gpgme.c:4927
+#: ncrypt/crypt_gpgme.c:4929
 msgid "esabpc"
 msgstr "dicoln"
 
-#: ncrypt/crypt_gpgme.c:4934
+#: ncrypt/crypt_gpgme.c:4936
 #, fuzzy
 msgid "PGP (e)ncrypt, (s)ign, sign (a)s, (b)oth, s/(m)ime or (c)lear? "
 msgstr "¿co(d)ificar, f(i)rmar (c)omo, amb(o)s, inc(l)uido, o ca(n)celar? "
 
 #. L10N: PGP options
-#: ncrypt/crypt_gpgme.c:4936
+#: ncrypt/crypt_gpgme.c:4938
 msgid "esabmc"
 msgstr "dicoln"
 
-#: ncrypt/crypt_gpgme.c:5087
+#: ncrypt/crypt_gpgme.c:5089
 msgid "Failed to verify sender"
 msgstr "Fallo al verificar el remitente"
 
-#: ncrypt/crypt_gpgme.c:5090
+#: ncrypt/crypt_gpgme.c:5092
 #, fuzzy
 msgid "Failed to figure out sender"
 msgstr "Error al abrir el archivo para leer las cabeceras."
@@ -4578,7 +4640,7 @@ msgstr "¡NO hay servidor de noticias definido!"
 msgid "%s is an invalid news server specification!"
 msgstr "¡%s es una especificación de servidor de noticias inválida!"
 
-#: nntp.c:75 nntp.c:612 pop.c:1028 pop_lib.c:405
+#: nntp.c:75 nntp.c:612 pop.c:1031 pop_lib.c:405
 msgid "Server closed connection!"
 msgstr "¡El servidor cerró la conneción!"
 
@@ -4745,16 +4807,17 @@ msgstr "revisar buzones por correo nuevo"
 
 #: opcodes.h:47
 #, fuzzy
-msgid "attach file(s) to this message"
+msgid "attach files to this message"
 msgstr "adjuntar archivo(s) a este mensaje"
 
 #: opcodes.h:48
-msgid "attach message(s) to this message"
+#, fuzzy
+msgid "attach messages to this message"
 msgstr "adjuntar mensaje(s) a este mensaje"
 
 #: opcodes.h:49
 #, fuzzy
-msgid "attach news article(s) to this message"
+msgid "attach news articles to this message"
 msgstr "adjuntar archivo(s) a este mensaje"
 
 #: opcodes.h:50
@@ -5603,7 +5666,7 @@ msgstr "extraer claves PGP públicas"
 
 #: opcodes.h:255
 #, fuzzy
-msgid "wipe passphrase(s) from memory"
+msgid "wipe passphrases from memory"
 msgstr "borrar contraseña PGP de la memoria"
 
 #: opcodes.h:259
@@ -5956,18 +6019,20 @@ msgstr "No hay correo nuevo en el buzón POP."
 msgid "Delete messages from server?"
 msgstr "¿Suprimir mensajes del servidor?"
 
-#: pop.c:954
-#, c-format
-msgid "Reading new messages (%d bytes)..."
-msgstr "Leyendo mensajes nuevos (%d bytes)..."
+#: pop.c:955
+#, fuzzy, c-format
+msgid "Reading new messages (%d byte)..."
+msgid_plural "Reading new messages (%d bytes)..."
+msgstr[0] "Leyendo mensajes nuevos (%d bytes)..."
+msgstr[1] "Leyendo mensajes nuevos (%d bytes)..."
 
-#: pop.c:997
+#: pop.c:1000
 msgid "Error while writing mailbox!"
 msgstr "¡Error al escribir el buzón!"
 
 #. L10N: The plural is picked by the second numerical argument, i.e.
 #. * the %d right before 'messages', i.e. the total number of messages.
-#: pop.c:1003
+#: pop.c:1006
 #, fuzzy, c-format
 msgid "%s [%d of %d message read]"
 msgid_plural "%s [%d of %d messages read]"
@@ -6115,51 +6180,58 @@ msgstr "Redirigir a: "
 msgid "I don't know how to print %s attachments!"
 msgstr "¡No sé cómo imprimir archivos adjuntos %s!"
 
-#: recvattach.c:841
-msgid "Print tagged attachment(s)?"
-msgstr "¿Imprimir archivo(s) adjunto(s) marcado(s)?"
+#. L10N: Although we now the precise number of tagged messages, we
+#. do not show it to the user.  So feel free to use a "generic
+#. plural" as plural translation if your language has one.
+#: recvattach.c:852
+#, fuzzy, c-format
+msgid "Print tagged attachment?"
+msgid_plural "Print %d tagged attachments?"
+msgstr[0] "¿Imprimir archivo(s) adjunto(s) marcado(s)?"
+msgstr[1] "¿Imprimir archivo(s) adjunto(s) marcado(s)?"
 
-#: recvattach.c:842
+#: recvattach.c:853
+#, c-format
 msgid "Print attachment?"
 msgstr "¿Imprimir archivo adjunto?"
 
-#: recvattach.c:900
+#: recvattach.c:913
 msgid "Structural changes to decrypted attachments are not supported"
 msgstr ""
 
-#: recvattach.c:1046
+#: recvattach.c:1059
 #, fuzzy
 msgid "Can't decrypt encrypted message!"
 msgstr "No fue encontrado ningún mensaje marcado."
 
-#: recvattach.c:1172
+#: recvattach.c:1185
 msgid "Attachments"
 msgstr "Archivos adjuntos"
 
-#: recvattach.c:1210
+#: recvattach.c:1223
 msgid "There are no subparts to show!"
 msgstr "¡No hay subpartes para mostrar!"
 
-#: recvattach.c:1265
+#: recvattach.c:1278
 msgid "Can't delete attachment from POP server."
 msgstr "No se puede suprimir un archivo adjunto del servidor POP."
 
-#: recvattach.c:1274
+#: recvattach.c:1287
 #, fuzzy
 msgid "Can't delete attachment from news server."
 msgstr "No se puede suprimir un archivo adjunto del servidor POP."
 
-#: recvattach.c:1281
+#: recvattach.c:1294
 #, fuzzy
 msgid "Deletion of attachments from encrypted messages is unsupported."
 msgstr "Suprimir archivos adjuntos de mensajes PGP no es soportado."
 
-#: recvattach.c:1287
+#: recvattach.c:1300
 #, fuzzy
 msgid "Deletion of attachments from signed messages may invalidate the signature."
 msgstr "Suprimir archivos adjuntos de mensajes PGP no es soportado."
 
-#: recvattach.c:1305 recvattach.c:1320
+#: recvattach.c:1318 recvattach.c:1333
 msgid "Only deletion of multipart attachments is supported."
 msgstr "Suprimir sólo es soportado con archivos adjuntos tipo multiparte."
 
@@ -6581,3 +6653,15 @@ msgstr "Opciones especificadas al compilar:"
 #: version.c:404
 msgid "Compile options:"
 msgstr "Opciones especificadas al compilar:"
+
+#, fuzzy
+#~ msgid "Cannot delete message(s)"
+#~ msgstr "No hay mensajes sin suprimir."
+
+#, fuzzy
+#~ msgid "Cannot undelete message(s)"
+#~ msgstr "No hay mensajes sin suprimir."
+
+#, fuzzy
+#~ msgid "messages not deleted"
+#~ msgstr "Marcando %d mensajes como suprimidos..."

--- a/po/et.po
+++ b/po/et.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neomutt-20180512\n"
 "Report-Msgid-Bugs-To: neomutt-devel@neomutt.org\n"
-"POT-Creation-Date: 2018-05-20 02:02+0000\n"
+"POT-Creation-Date: 2018-05-22 14:18+0000\n"
 "PO-Revision-Date: 2002-12-09 17:19+02:00\n"
 "Last-Translator: Toomas Soome <tsoome@muhv.pri.ee>\n"
 "Language-Team: Estonian <et@li.org>\n"
@@ -39,7 +39,7 @@ msgstr "Vali"
 
 #: addrbook.c:52 browser.c:75 browser.c:87 compose.c:160 compose.c:172
 #: conn/ssl.c:1041 conn/ssl_gnutls.c:793 curs_main.c:748 curs_main.c:761
-#: history.c:106 ncrypt/crypt_gpgme.c:4219 ncrypt/pgpkey.c:547
+#: history.c:106 ncrypt/crypt_gpgme.c:4221 ncrypt/pgpkey.c:547
 #: ncrypt/smime.c:477 pager.c:2141 postpone.c:65 query.c:72 recvattach.c:70
 msgid "Help"
 msgstr "Appi"
@@ -694,7 +694,7 @@ msgstr ""
 #. * Since it shares the row with "Encrypt with:", it should not be longer
 #. * than 15-20 character cells.
 #.
-#: compose.c:138 ncrypt/crypt_gpgme.c:4947 ncrypt/pgp.c:1786
+#: compose.c:138 ncrypt/crypt_gpgme.c:4949 ncrypt/pgp.c:1786
 #: ncrypt/smime.c:2127
 msgid "Sign as: "
 msgstr "Allkirjasta kui: "
@@ -1241,7 +1241,7 @@ msgstr "(k)eeldu, (n)õustu korra"
 msgid "(r)eject, accept (o)nce"
 msgstr "(k)eeldu, (n)õustu korra"
 
-#: conn/ssl.c:1039 conn/ssl_gnutls.c:791 ncrypt/crypt_gpgme.c:4213
+#: conn/ssl.c:1039 conn/ssl_gnutls.c:791 ncrypt/crypt_gpgme.c:4215
 #: ncrypt/pgpkey.c:541 ncrypt/smime.c:473
 msgid "Exit  "
 msgstr "Välju  "
@@ -1427,11 +1427,11 @@ msgstr "Avatud postkaste pole."
 msgid "There are no messages."
 msgstr "Teateid ei ole."
 
-#: curs_main.c:77 mx.c:1061 pager.c:73 recvattach.c:56
+#: curs_main.c:77 mx.c:1071 pager.c:73 recvattach.c:56
 msgid "Mailbox is read-only."
 msgstr "Postkast on ainult lugemiseks."
 
-#: curs_main.c:79 pager.c:75 recvattach.c:1145
+#: curs_main.c:79 pager.c:75 recvattach.c:1158
 msgid "Function not permitted in attach-message mode."
 msgstr "Funktsioon ei ole teate lisamise moodis lubatud."
 
@@ -1567,255 +1567,263 @@ msgid "That message is not visible."
 msgstr "See teate ei ole nähtav."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:1377 curs_main.c:2772 pager.c:2818
+#. L10N: Due to the implementation details we do not know whether we
+#. delete zero, 1, 12, ... messages. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:1381 curs_main.c:2784 pager.c:2822
 #, fuzzy
-msgid "Cannot delete message(s)"
+msgid "Cannot delete messages"
 msgstr "Kustutamata teateid pole."
 
-#: curs_main.c:1380
+#: curs_main.c:1384
 msgid "Delete messages matching: "
 msgstr "Kustuta teated mustriga: "
 
-#: curs_main.c:1421
+#: curs_main.c:1425
 msgid "No limit pattern is in effect."
 msgstr "Kehtivat piirangumustrit ei ole."
 
 #. L10N: ask for a limit to apply
-#: curs_main.c:1426
+#: curs_main.c:1430
 #, c-format
 msgid "Limit: %s"
 msgstr "Piirang: %s"
 
-#: curs_main.c:1464
+#: curs_main.c:1468
 msgid "Limit to messages matching: "
 msgstr "Piirdu teadetega mustriga: "
 
-#: curs_main.c:1488
+#: curs_main.c:1492
 msgid "To view all messages, limit to \"all\"."
 msgstr ""
 
-#: curs_main.c:1500 pager.c:2318
+#: curs_main.c:1504 pager.c:2318
 msgid "Quit NeoMutt?"
 msgstr "Väljun NeoMuttist?"
 
-#: curs_main.c:1596
+#: curs_main.c:1600
 msgid "Tag messages matching: "
 msgstr "Märgi teated mustriga: "
 
 #. L10N: CHECK_ACL
-#: curs_main.c:1606 curs_main.c:3203 pager.c:3137
+#. L10N: Due to the implementation details we do not know whether we
+#. undelete zero, 1, 12, ... messages. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:1614 curs_main.c:3223 pager.c:3145
 #, fuzzy
-msgid "Cannot undelete message(s)"
+msgid "Cannot undelete messages"
 msgstr "Kustutamata teateid pole."
 
-#: curs_main.c:1609
+#: curs_main.c:1617
 msgid "Undelete messages matching: "
 msgstr "Taasta teated mustriga: "
 
-#: curs_main.c:1619
+#: curs_main.c:1627
 msgid "Untag messages matching: "
 msgstr "Võta märk teadetelt mustriga: "
 
-#: curs_main.c:1653
+#: curs_main.c:1661
 #, fuzzy
 msgid "Logged out of IMAP servers."
 msgstr "Sulen ühenduse IMAP serveriga..."
 
-#: curs_main.c:1753
+#: curs_main.c:1761
 #, fuzzy
 msgid "No virtual folder, aborting."
 msgstr "Teema puudub, katkestan."
 
-#: curs_main.c:1761
+#: curs_main.c:1769
 msgid "Failed to read thread, aborting."
 msgstr ""
 
-#: curs_main.c:1793 mx.c:1458 mx.c:1475
+#: curs_main.c:1801 mx.c:1468 mx.c:1485
 msgid "Folder doesn't support tagging, aborting."
 msgstr ""
 
-#: curs_main.c:1808
+#: curs_main.c:1816
 #, fuzzy
 msgid "No tag specified, aborting."
 msgstr "Teema puudub, katkestan."
 
-#: curs_main.c:1820
+#: curs_main.c:1828
 #, c-format
 msgid "Update tags..."
 msgstr ""
 
-#: curs_main.c:1857
+#: curs_main.c:1865
 msgid "Failed to modify tags, aborting."
 msgstr ""
 
-#: curs_main.c:1898
+#: curs_main.c:1906
 #, fuzzy
 msgid "No query, aborting."
 msgstr "Teema puudub, katkestan."
 
-#: curs_main.c:1902 curs_main.c:1922 curs_main.c:1941
+#: curs_main.c:1910 curs_main.c:1930 curs_main.c:1949
 msgid "Failed to create query, aborting."
 msgstr ""
 
-#: curs_main.c:1911 curs_main.c:1930
+#: curs_main.c:1919 curs_main.c:1938
 msgid "Windowed queries disabled."
 msgstr ""
 
-#: curs_main.c:1916 curs_main.c:1935
+#: curs_main.c:1924 curs_main.c:1943
 msgid "No notmuch vfolder currently loaded."
 msgstr ""
 
-#: curs_main.c:1973
+#: curs_main.c:1981
 msgid "Open mailbox in read-only mode"
 msgstr "Avan postkasti ainult lugemiseks"
 
-#: curs_main.c:1976
+#: curs_main.c:1984
 #, fuzzy
 msgid "Open virtual folder"
 msgstr "ava teine kaust"
 
-#: curs_main.c:1979
+#: curs_main.c:1987
 msgid "Open mailbox"
 msgstr "Avan postkasti"
 
-#: curs_main.c:1989
+#: curs_main.c:1997
 #, fuzzy
 msgid "No mailboxes have new mail"
 msgstr "Uute teadetega postkaste ei ole."
 
-#: curs_main.c:2036
+#: curs_main.c:2044
 #, fuzzy
 msgid "Open newsgroup in read-only mode"
 msgstr "Avan postkasti ainult lugemiseks"
 
-#: curs_main.c:2038
+#: curs_main.c:2046
 msgid "Open newsgroup"
 msgstr ""
 
-#: curs_main.c:2141
+#: curs_main.c:2149
 #, fuzzy
 msgid "Exit NeoMutt without saving?"
 msgstr "Väljun NeoMuttist salvestamata?"
 
-#: curs_main.c:2157
+#: curs_main.c:2165
 #, fuzzy
 msgid "Cannot break thread"
 msgstr "Filtri loomine ebaõnnestus"
 
-#: curs_main.c:2160 curs_main.c:2198 curs_main.c:2658 curs_main.c:2690
+#: curs_main.c:2168 curs_main.c:2206 curs_main.c:2666 curs_main.c:2698
 #: flags.c:376 thread.c:1078 thread.c:1134 thread.c:1202
 msgid "Threading is not enabled."
 msgstr "Teemad ei ole lubatud."
 
-#: curs_main.c:2173
+#: curs_main.c:2181
 msgid "Thread broken"
 msgstr ""
 
-#: curs_main.c:2185
+#: curs_main.c:2193
 msgid "Thread cannot be broken, message is not part of a thread"
 msgstr ""
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2195
+#: curs_main.c:2203
 msgid "Cannot link threads"
 msgstr ""
 
-#: curs_main.c:2200
+#: curs_main.c:2208
 msgid "No Message-ID: header available to link thread"
 msgstr ""
 
-#: curs_main.c:2202
+#: curs_main.c:2210
 #, fuzzy
 msgid "First, please tag a message to be linked here"
 msgstr "salvesta teade hilisemaks saatmiseks"
 
-#: curs_main.c:2213
+#: curs_main.c:2221
 msgid "Threads linked"
 msgstr ""
 
-#: curs_main.c:2216
+#: curs_main.c:2224
 msgid "No thread linked"
 msgstr ""
 
-#: curs_main.c:2252 curs_main.c:2278
+#: curs_main.c:2260 curs_main.c:2286
 msgid "You are on the last message."
 msgstr "Te olete viimasel teatel."
 
-#: curs_main.c:2260 curs_main.c:2305
+#: curs_main.c:2268 curs_main.c:2313
 msgid "No undeleted messages."
 msgstr "Kustutamata teateid pole."
 
-#: curs_main.c:2297 curs_main.c:2323
+#: curs_main.c:2305 curs_main.c:2331
 msgid "You are on the first message."
 msgstr "Te olete esimesel teatel."
 
-#: curs_main.c:2395 menu.c:970 pager.c:2440 pattern.c:2110
+#: curs_main.c:2403 menu.c:970 pager.c:2440 pattern.c:2110
 msgid "Search wrapped to top."
 msgstr "Otsing pööras algusest tagasi."
 
-#: curs_main.c:2404 pager.c:2463 pattern.c:2121
+#: curs_main.c:2412 pager.c:2463 pattern.c:2121
 msgid "Search wrapped to bottom."
 msgstr "Otsing pööras lõpust tagasi."
 
-#: curs_main.c:2447
+#: curs_main.c:2455
 #, fuzzy
 msgid "No new messages in this limited view."
 msgstr "Vanem teade ei ole selles piiratud vaates nähtav."
 
-#: curs_main.c:2449
+#: curs_main.c:2457
 #, fuzzy
 msgid "No new messages."
 msgstr "Uusi teateid pole"
 
-#: curs_main.c:2454
+#: curs_main.c:2462
 #, fuzzy
 msgid "No unread messages in this limited view."
 msgstr "Vanem teade ei ole selles piiratud vaates nähtav."
 
-#: curs_main.c:2456
+#: curs_main.c:2464
 #, fuzzy
 msgid "No unread messages."
 msgstr "Lugemata teateid pole"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2474
+#: curs_main.c:2482
 #, fuzzy
 msgid "Cannot flag message"
 msgstr "näita teadet"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2513 pager.c:3100
+#: curs_main.c:2521 pager.c:3104
 msgid "Cannot toggle new"
 msgstr ""
 
-#: curs_main.c:2590
+#: curs_main.c:2598
 msgid "No more threads."
 msgstr "Rohkem teemasid pole."
 
-#: curs_main.c:2592
+#: curs_main.c:2600
 msgid "You are on the first thread."
 msgstr "Te olete esimesel teemal."
 
-#: curs_main.c:2676
+#: curs_main.c:2684
 #, fuzzy
 msgid "Thread contains unread or flagged messages."
 msgstr "Teema sisaldab lugemata teateid."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2726 pager.c:2784
+#: curs_main.c:2734 pager.c:2784
 #, fuzzy
 msgid "Cannot delete message"
 msgstr "Kustutamata teateid pole."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2838
+#: curs_main.c:2850
 #, fuzzy
 msgid "Cannot edit message"
 msgstr "Teadet ei õnnestu kirjutada"
 
 #. L10N: This is displayed when the x-label on one or more
 #. * messages is edited.
-#: curs_main.c:2900 pager.c:3200
+#: curs_main.c:2912 pager.c:3208
 #, fuzzy, c-format
 msgid "%d label changed."
 msgid_plural "%d labels changed."
@@ -1825,28 +1833,32 @@ msgstr[1] "Postkasti ei muudetud."
 #. L10N: This is displayed when editing an x-label, but no messages
 #. * were updated.  Possibly due to canceling at the prompt or if the new
 #. * label is the same as the old label.
-#: curs_main.c:2907 pager.c:3204
+#: curs_main.c:2919 pager.c:3212
 #, fuzzy
 msgid "No labels changed."
 msgstr "Postkasti ei muudetud."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:3006
+#. L10N: Due to the implementation details we do not know whether we
+#. mark zero, 1, 12, ... messages as read. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:3022
 #, fuzzy
-msgid "Cannot mark message(s) as read"
+msgid "Cannot mark messages as read"
 msgstr "hüppa teema vanemteatele"
 
 #. L10N: This is the prompt for <mark-message>.  Whatever they
 #. enter will be prefixed by $mark_macro_prefix and will become
 #. a macro hotkey to jump to the currently selected message.
-#: curs_main.c:3042
+#: curs_main.c:3058
 #, fuzzy
 msgid "Enter macro stroke: "
 msgstr "Sisestage võtme ID: "
 
 #. L10N: "message hotkey" is the key bindings menu description of a
 #. macro created by <mark-message>.
-#: curs_main.c:3050
+#: curs_main.c:3066
 #, fuzzy
 msgid "message hotkey"
 msgstr "Teade jäeti postitusootele."
@@ -1854,28 +1866,28 @@ msgstr "Teade jäeti postitusootele."
 #. L10N: This is echoed after <mark-message> creates a new hotkey
 #. macro.  %s is the hotkey string ($mark_macro_prefix followed
 #. by whatever they typed at the prompt.)
-#: curs_main.c:3055
+#: curs_main.c:3071
 #, fuzzy, c-format
 msgid "Message bound to %s."
 msgstr "Teade on peegeldatud."
 
 #. L10N: This error is printed if <mark-message> cannot find a
 #. Message-ID for the currently selected message in the index.
-#: curs_main.c:3063
+#: curs_main.c:3079
 #, fuzzy
 msgid "No message ID to macro."
 msgstr "Selles kaustas ei ole teateid."
 
-#: curs_main.c:3105 pager.c:2961 recvattach.c:1388
+#: curs_main.c:3121 pager.c:2965 recvattach.c:1401
 msgid "Reply by mail as poster prefers?"
 msgstr ""
 
-#: curs_main.c:3108 pager.c:2927 pager.c:2939 pager.c:2964
+#: curs_main.c:3124 pager.c:2931 pager.c:2943 pager.c:2968
 msgid "Posting to this group not allowed, may be moderated. Continue?"
 msgstr ""
 
 #. L10N: CHECK_ACL
-#: curs_main.c:3173 pager.c:3120
+#: curs_main.c:3189 pager.c:3124
 #, fuzzy
 msgid "Cannot undelete message"
 msgstr "Kustutamata teateid pole."
@@ -2087,12 +2099,34 @@ msgstr "[-- Autovaate %s stderr --]\n"
 msgid "[-- Error: message/external-body has no access-type parameter --]\n"
 msgstr "[-- Viga: message/external-body juurdepääsu parameeter puudub --]\n"
 
-#: handler.c:1611
+#. L10N: If the translation of this string is a multi line string, then
+#. each line should start with "[-- " and end with " --]".
+#. The first "%s/%s" is a MIME type, e.g. "text/plain". The last %s
+#. expands to a date as returned by `mutt_date_parse_date()`.
+#.
+#. Note: The size argument printed is not the actual number as passed
+#. to gettext but the prettified version, e.g. size = 2048 will be
+#. printed as 2K.  Your language might be sensitive to that: For
+#. example although '1K' and '1024' represent the same number your
+#. language might inflect the noun 'byte' differently.
+#.
+#. Sadly, we cannot do anything about that at the moment besides
+#. passing the precise size in bytes. If you are interested the
+#. function responsible for the prettification is
+#. mutt_str_pretty_size() in mutt/string.c.
+#.
+#: handler.c:1624
 #, fuzzy, c-format
 msgid ""
+"[-- This %s/%s attachment (size %s byte) has been deleted --]\n"
+"[-- on %s --]\n"
+msgid_plural ""
 "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
 "[-- on %s --]\n"
-msgstr ""
+msgstr[0] ""
+"[-- See %s/%s lisa (maht %s baiti) on kustutatud --]\n"
+"[-- %s --]\n"
+msgstr[1] ""
 "[-- See %s/%s lisa (maht %s baiti) on kustutatud --]\n"
 "[-- %s --]\n"
 
@@ -2100,10 +2134,23 @@ msgstr ""
 #. each line should start with "[-- " and end with " --]".
 #. The first "%s/%s" is a MIME type, e.g. "text/plain".
 #.
-#: handler.c:1620
+#. Note: The size argument printed is not the actual number as passed
+#. to gettext but the prettified version, e.g. size = 2048 will be
+#. printed as 2K.  Your language might be sensitive to that: For
+#. example although '1K' and '1024' represent the same number your
+#. language might inflect the noun 'byte' differently.
+#.
+#. Sadly, we cannot do anything about that at the moment besides
+#. passing the precise size in bytes. If you are interested the
+#. function responsible for the prettification is
+#. mutt_str_pretty_size() in mutt/string.c.
+#.
+#: handler.c:1648
 #, fuzzy, c-format
-msgid "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
-msgstr "[-- See %s/%s lisa (maht %s baiti) on kustutatud --]\n"
+msgid "[-- This %s/%s attachment (size %s byte) has been deleted --]\n"
+msgid_plural "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
+msgstr[0] "[-- See %s/%s lisa (maht %s baiti) on kustutatud --]\n"
+msgstr[1] "[-- See %s/%s lisa (maht %s baiti) on kustutatud --]\n"
 
 #. L10N: If the translation of this string is a multi line string, then
 #. each line should start with "[-- " and end with " --]".
@@ -2113,7 +2160,7 @@ msgstr "[-- See %s/%s lisa (maht %s baiti) on kustutatud --]\n"
 #. Caution: Argument three %3$ is also defined but should not be used
 #. in this translation!
 #.
-#: handler.c:1637
+#: handler.c:1667
 #, fuzzy
 msgid ""
 "[-- This %s/%s attachment has been deleted --]\n"
@@ -2126,17 +2173,17 @@ msgstr ""
 #. each line should start with "[-- " and end with " --]".
 #. The first "%s/%s" is a MIME type, e.g. "text/plain".
 #.
-#: handler.c:1646
+#: handler.c:1676
 #, fuzzy, c-format
 msgid "[-- This %s/%s attachment has been deleted --]\n"
 msgstr "[-- See %s/%s lisa on kustutatud --]\n"
 
-#: handler.c:1656
+#: handler.c:1686
 #, c-format
 msgid "[-- name: %s --]\n"
 msgstr "[-- nimi: %s --]\n"
 
-#: handler.c:1672
+#: handler.c:1702
 #, fuzzy, c-format
 msgid ""
 "[-- This %s/%s attachment is not included, --]\n"
@@ -2146,7 +2193,7 @@ msgstr ""
 "[-- Seda %s/%s lisa ei ole kaasatud, --]\n"
 "[-- ja näidatud väline allikas on aegunud --]\n"
 
-#: handler.c:1693
+#: handler.c:1723
 #, fuzzy, c-format
 msgid ""
 "[-- This %s/%s attachment is not included, --]\n"
@@ -2155,52 +2202,52 @@ msgstr ""
 "[-- Seda %s/%s lisa ei ole kaasatud, --]\n"
 "[-- ja näidatud juurdepääsu tüüpi %s ei toetata --]\n"
 
-#: handler.c:1822
+#: handler.c:1852
 #, fuzzy
 msgid "Unable to open memory stream!"
 msgstr "Ajutise faili avamine ebaõnnestus!"
 
-#: handler.c:1831
+#: handler.c:1861
 msgid "Unable to open temporary file!"
 msgstr "Ajutise faili avamine ebaõnnestus!"
 
-#: handler.c:1881
+#: handler.c:1911
 #, fuzzy
 msgid "failed to re-open memstream!"
 msgstr "Ajutise faili avamine ebaõnnestus!"
 
-#: handler.c:2013
+#: handler.c:2043
 msgid "Error: multipart/signed has no protocol."
 msgstr "Viga: multipart/signed teatel puudub protokoll."
 
-#: handler.c:2076
+#: handler.c:2106
 #, fuzzy
 msgid "[-- This is an attachment (use '%3$s' to view this part) --]\n"
 msgstr "[-- See %s/%s lisa (selle osa vaatamiseks kasutage '%3$s') --]\n"
 
-#: handler.c:2082
+#: handler.c:2112
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported (use '%s' to view this part) --]\n"
 msgstr "[-- %s/%s ei toetata (selle osa vaatamiseks kasutage '%s') --]\n"
 
-#: handler.c:2087
+#: handler.c:2117
 #, fuzzy
 msgid "[-- This is an attachment (need 'view-attachments' bound to key!) --]\n"
 msgstr "[-- See %s/%s lisa ('view-attachments' peab olema klahviga seotud!) --]\n"
 
 #. L10N: %s/%s is a MIME type, e.g. "text/plain".
-#: handler.c:2091
+#: handler.c:2121
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported (need 'view-attachments' bound to key!) --]\n"
 msgstr "[-- %s/%s ei toetata ('view-attachments' peab olema klahviga seotud!) --]\n"
 
-#: handler.c:2098
+#: handler.c:2128
 #, fuzzy
 msgid "[-- This is an attachment --]\n"
 msgstr "[-- See %s/%s lisa --]\n"
 
 #. L10N: %s/%s is a MIME type, e.g. "text/plain".
-#: handler.c:2101
+#: handler.c:2131
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported --]\n"
 msgstr "[-- %s/%s ei toetata --]\n"
@@ -2508,7 +2555,7 @@ msgstr ""
 msgid "Invalid IMAP flags"
 msgstr "Vigane    "
 
-#: imap/message.c:477 mx.c:1326
+#: imap/message.c:477 mx.c:1336
 msgid "Integer overflow -- can't allocate memory."
 msgstr ""
 
@@ -3283,66 +3330,75 @@ msgstr "SSL ei ole kasutatav."
 msgid "Reading from %s interrupted..."
 msgstr "Otsing katkestati."
 
-#: mx.c:634
+#. L10N: Although we now the precise number of messages, we do not show it to the user.
+#. So feel free to use a "generic plural" as plural translation if your language has one.
+#.
+#: mx.c:639
 #, fuzzy
-msgid "message(s) not deleted"
-msgstr "märgin %d teadet kustutatuks..."
+msgid "message not deleted"
+msgid_plural "messages not deleted"
+msgstr[0] "märgin %d teadet kustutatuks..."
+msgstr[1] "märgin %d teadet kustutatuks..."
 
-#: mx.c:671
+#: mx.c:676
 #, fuzzy
 msgid "Can't open trash folder"
 msgstr "Kausta ei saa lisada: %s"
 
-#: mx.c:710
+#: mx.c:715
 msgid "Mark all articles read?"
 msgstr ""
 
-#: mx.c:754
+#. L10N: The first argument is the number of read messages to be
+#. moved, the second argument is the target mailbox.
+#: mx.c:762
 #, fuzzy, c-format
-msgid "Move %d read messages to %s?"
-msgstr "Tõstan loetud teated postkasti %s?"
+msgid "Move %d read message to %s?"
+msgid_plural "Move %d read messages to %s?"
+msgstr[0] "Tõstan loetud teated postkasti %s?"
+msgstr[1] "Tõstan loetud teated postkasti %s?"
 
-#: mx.c:771 mx.c:1077
+#: mx.c:781 mx.c:1087
 #, fuzzy, c-format
 msgid "Purge %d deleted message?"
 msgid_plural "Purge %d deleted messages?"
 msgstr[0] "Eemaldan %d kustutatud teate?"
 msgstr[1] "Eemaldan %d kustutatud teadet?"
 
-#: mx.c:793
+#: mx.c:803
 #, c-format
 msgid "Moving read messages to %s..."
 msgstr "Tõstan loetud teated kausta %s..."
 
-#: mx.c:859 mx.c:1068
+#: mx.c:869 mx.c:1078
 msgid "Mailbox is unchanged."
 msgstr "Postkasti ei muudetud."
 
-#: mx.c:914
+#: mx.c:924
 #, c-format
 msgid "%d kept, %d moved, %d deleted."
 msgstr "%d säilitatud, %d tõstetud, %d kustutatud."
 
-#: mx.c:917 mx.c:1130
+#: mx.c:927 mx.c:1140
 #, c-format
 msgid "%d kept, %d deleted."
 msgstr "%d säilitatud, %d kustutatud."
 
-#: mx.c:1052
+#: mx.c:1062
 #, c-format
 msgid " Press '%s' to toggle write"
 msgstr "Kirjutamise lülitamiseks vajutage '%s'"
 
-#: mx.c:1054
+#: mx.c:1064
 msgid "Use 'toggle-write' to re-enable write!"
 msgstr "Kirjutamise uuesti lubamiseks kasutage 'toggle-write'!"
 
-#: mx.c:1056
+#: mx.c:1066
 #, c-format
 msgid "Mailbox is marked unwritable. %s"
 msgstr "Postkast on märgitud mittekirjutatavaks. %s"
 
-#: mx.c:1124
+#: mx.c:1134
 msgid "Mailbox checkpointed."
 msgstr "Postkast on kontrollitud."
 
@@ -3356,52 +3412,57 @@ msgstr " (praegune aeg: %c)"
 msgid "[-- %s output follows%s --]\n"
 msgstr "[-- järgneb %s väljund%s --]\n"
 
-#: ncrypt/crypt.c:95
-msgid "Passphrase(s) forgotten."
+#. L10N: Due to the implementation details (e.g. some passwords are managed
+#. by gpg-agent) we cannot know whether we forgot zero, 1, 12, ...
+#. passwords. So in English we use "Passphrases". Your language might
+#. have other means to express this.
+#: ncrypt/crypt.c:100
+#, fuzzy
+msgid "Passphrases forgotten."
 msgstr "Parool(id) on unustatud."
 
-#: ncrypt/crypt.c:155
+#: ncrypt/crypt.c:161
 msgid "Inline PGP can't be used with attachments.  Revert to PGP/MIME?"
 msgstr ""
 
-#: ncrypt/crypt.c:159
+#: ncrypt/crypt.c:165
 msgid "Mail not sent: inline PGP can't be used with attachments."
 msgstr ""
 
-#: ncrypt/crypt.c:166
+#: ncrypt/crypt.c:172
 msgid "Inline PGP can't be used with format=flowed.  Revert to PGP/MIME?"
 msgstr ""
 
-#: ncrypt/crypt.c:170
+#: ncrypt/crypt.c:176
 msgid "Mail not sent: inline PGP can't be used with format=flowed."
 msgstr ""
 
-#: ncrypt/crypt.c:180 ncrypt/cryptglue.c:125 ncrypt/pgpkey.c:589
+#: ncrypt/crypt.c:186 ncrypt/cryptglue.c:125 ncrypt/pgpkey.c:589
 #: ncrypt/pgpkey.c:782
 msgid "Invoking PGP..."
 msgstr "Käivitan PGP..."
 
-#: ncrypt/crypt.c:192
+#: ncrypt/crypt.c:198
 msgid "Message can't be sent inline.  Revert to using PGP/MIME?"
 msgstr ""
 
-#: ncrypt/crypt.c:194 send.c:1824
+#: ncrypt/crypt.c:200 send.c:1824
 msgid "Mail not sent."
 msgstr "Kirja ei saadetud."
 
-#: ncrypt/crypt.c:540
+#: ncrypt/crypt.c:546
 msgid "S/MIME messages with no hints on content are unsupported."
 msgstr "Sisu vihjeta S/MIME teateid ei toetata."
 
-#: ncrypt/crypt.c:754 ncrypt/crypt.c:795
+#: ncrypt/crypt.c:760 ncrypt/crypt.c:801
 msgid "Trying to extract PGP keys...\n"
 msgstr "Proovin eraldada PGP võtmed...\n"
 
-#: ncrypt/crypt.c:776 ncrypt/crypt.c:816
+#: ncrypt/crypt.c:782 ncrypt/crypt.c:822
 msgid "Trying to extract S/MIME certificates...\n"
 msgstr "Proovin eraldada S/MIME sertifikaadid...\n"
 
-#: ncrypt/crypt.c:976
+#: ncrypt/crypt.c:982
 #, c-format
 msgid ""
 "[-- Error: Unknown multipart/signed protocol %s! --]\n"
@@ -3410,7 +3471,7 @@ msgstr ""
 "[-- Viga: Tundmatu multipart/signed protokoll %s! --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1016
+#: ncrypt/crypt.c:1022
 #, fuzzy
 msgid ""
 "[-- Error: Missing or bad-format multipart/signed signature! --]\n"
@@ -3419,7 +3480,7 @@ msgstr ""
 "[-- Viga: Vigane multipart/signed struktuur! --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1058
+#: ncrypt/crypt.c:1064
 #, c-format
 msgid ""
 "[-- Warning: We can't verify %s/%s signatures. --]\n"
@@ -3428,7 +3489,7 @@ msgstr ""
 "[-- Hoiatus: Me ai saa kontrollida %s/%s allkirju. --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1070
+#: ncrypt/crypt.c:1076
 msgid ""
 "[-- The following data is signed --]\n"
 "\n"
@@ -3436,7 +3497,7 @@ msgstr ""
 "[-- Järgnev info on allkirjastatud --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1075
+#: ncrypt/crypt.c:1081
 msgid ""
 "[-- Warning: Can't find any signatures. --]\n"
 "\n"
@@ -3444,7 +3505,7 @@ msgstr ""
 "[-- Hoiatus: Ei leia ühtegi allkirja. --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1081
+#: ncrypt/crypt.c:1087
 msgid ""
 "\n"
 "[-- End of signed data --]\n"
@@ -3496,7 +3557,7 @@ msgstr ""
 msgid "error reading data object: %s\n"
 msgstr "viga mustris: %s"
 
-#: ncrypt/crypt_gpgme.c:662 ncrypt/crypt_gpgme.c:3848 ncrypt/pgpkey.c:585
+#: ncrypt/crypt_gpgme.c:662 ncrypt/crypt_gpgme.c:3850 ncrypt/pgpkey.c:585
 #: ncrypt/pgpkey.c:768
 msgid "Can't create temporary file"
 msgstr "Ei õnnestu avada ajutist faili"
@@ -3860,29 +3921,31 @@ msgstr "Vigane    "
 
 #. L10N: This is printed after "Key Type: " and looks like this:
 #. *       PGP, 2048 bit RSA
-#: ncrypt/crypt_gpgme.c:3670 ncrypt/crypt_gpgme.c:3808
+#: ncrypt/crypt_gpgme.c:3670 ncrypt/crypt_gpgme.c:3810
 #, c-format
 msgid "%s, %lu bit %s\n"
-msgstr ""
+msgid_plural "%s, %lu bit %s\n"
+msgstr[0] ""
+msgstr[1] ""
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3678 ncrypt/crypt_gpgme.c:3815
+#: ncrypt/crypt_gpgme.c:3678 ncrypt/crypt_gpgme.c:3817
 #, fuzzy
 msgid "encryption"
 msgstr "Krüpti"
 
 #: ncrypt/crypt_gpgme.c:3679 ncrypt/crypt_gpgme.c:3685
-#: ncrypt/crypt_gpgme.c:3816 ncrypt/crypt_gpgme.c:3821
+#: ncrypt/crypt_gpgme.c:3818 ncrypt/crypt_gpgme.c:3823
 msgid ", "
 msgstr ""
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3684 ncrypt/crypt_gpgme.c:3820
+#: ncrypt/crypt_gpgme.c:3684 ncrypt/crypt_gpgme.c:3822
 msgid "signing"
 msgstr ""
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3690 ncrypt/crypt_gpgme.c:3825
+#: ncrypt/crypt_gpgme.c:3690 ncrypt/crypt_gpgme.c:3827
 #, fuzzy
 msgid "certification"
 msgstr "Sertifikaat on salvestatud"
@@ -3904,70 +3967,70 @@ msgstr "Aegunud   "
 msgid "[Disabled]"
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:3851
+#: ncrypt/crypt_gpgme.c:3853
 #, fuzzy
 msgid "Collecting data..."
 msgstr "Ühendus serverisse %s..."
 
-#: ncrypt/crypt_gpgme.c:3876
+#: ncrypt/crypt_gpgme.c:3878
 #, fuzzy, c-format
 msgid "Error finding issuer key: %s\n"
 msgstr "Viga serveriga ühenduse loomisel: %s"
 
-#: ncrypt/crypt_gpgme.c:3885
+#: ncrypt/crypt_gpgme.c:3887
 #, fuzzy
 msgid "Error: certification chain too long - stopping here\n"
 msgstr "Viga käsureal: %s\n"
 
-#: ncrypt/crypt_gpgme.c:3895 ncrypt/pgpkey.c:608
+#: ncrypt/crypt_gpgme.c:3897 ncrypt/pgpkey.c:608
 #, c-format
 msgid "Key ID: 0x%s"
 msgstr "Võtme ID: 0x%s"
 
-#: ncrypt/crypt_gpgme.c:3990
+#: ncrypt/crypt_gpgme.c:3992
 #, fuzzy, c-format
 msgid "gpgme_new failed: %s"
 msgstr "SSL ebaõnnestus: %s"
 
-#: ncrypt/crypt_gpgme.c:4028 ncrypt/crypt_gpgme.c:4079
+#: ncrypt/crypt_gpgme.c:4030 ncrypt/crypt_gpgme.c:4081
 #, c-format
 msgid "gpgme_op_keylist_start failed: %s"
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4067 ncrypt/crypt_gpgme.c:4109
+#: ncrypt/crypt_gpgme.c:4069 ncrypt/crypt_gpgme.c:4111
 #, c-format
 msgid "gpgme_op_keylist_next failed: %s"
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4185
+#: ncrypt/crypt_gpgme.c:4187
 #, fuzzy
 msgid "All matching keys are marked expired/revoked."
 msgstr "Kõik sobivad võtmed on märgitud aegunuks/tühistatuks."
 
-#: ncrypt/crypt_gpgme.c:4215 ncrypt/pgpkey.c:543 ncrypt/smime.c:475
+#: ncrypt/crypt_gpgme.c:4217 ncrypt/pgpkey.c:543 ncrypt/smime.c:475
 msgid "Select  "
 msgstr "Vali  "
 
-#: ncrypt/crypt_gpgme.c:4217 ncrypt/pgpkey.c:545
+#: ncrypt/crypt_gpgme.c:4219 ncrypt/pgpkey.c:545
 msgid "Check key  "
 msgstr "Võtme kontroll  "
 
-#: ncrypt/crypt_gpgme.c:4233
+#: ncrypt/crypt_gpgme.c:4235
 #, fuzzy
 msgid "PGP and S/MIME keys matching"
 msgstr "PGP võtmed, mis sisaldavad \"%s\"."
 
-#: ncrypt/crypt_gpgme.c:4235
+#: ncrypt/crypt_gpgme.c:4237
 #, fuzzy
 msgid "PGP keys matching"
 msgstr "PGP võtmed, mis sisaldavad \"%s\"."
 
-#: ncrypt/crypt_gpgme.c:4237
+#: ncrypt/crypt_gpgme.c:4239
 #, fuzzy
 msgid "S/MIME keys matching"
 msgstr "S/MIME sertifikaadid, mis sisaldavad \"%s\"."
 
-#: ncrypt/crypt_gpgme.c:4239
+#: ncrypt/crypt_gpgme.c:4241
 #, fuzzy
 msgid "keys matching"
 msgstr "PGP võtmed, mis sisaldavad \"%s\"."
@@ -3976,69 +4039,69 @@ msgstr "PGP võtmed, mis sisaldavad \"%s\"."
 #. %1$s is one of the previous four entries.
 #. %2$s is an address.
 #. e.g. "S/MIME keys matching <me@mutt.org>."
-#: ncrypt/crypt_gpgme.c:4246
+#: ncrypt/crypt_gpgme.c:4248
 #, c-format
 msgid "%s <%s>."
 msgstr ""
 
 #. L10N:
 #. e.g. 'S/MIME keys matching "Michael Elkins".'
-#: ncrypt/crypt_gpgme.c:4250
+#: ncrypt/crypt_gpgme.c:4252
 #, c-format
 msgid "%s \"%s\"."
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4277 ncrypt/pgpkey.c:628
+#: ncrypt/crypt_gpgme.c:4279 ncrypt/pgpkey.c:628
 msgid "This key can't be used: expired/disabled/revoked."
 msgstr "Seda võtit ei saa kasutada: aegunud/blokeeritud/tühistatud."
 
-#: ncrypt/crypt_gpgme.c:4290 ncrypt/pgpkey.c:640 ncrypt/smime.c:505
+#: ncrypt/crypt_gpgme.c:4292 ncrypt/pgpkey.c:640 ncrypt/smime.c:505
 #, fuzzy
 msgid "ID is expired/disabled/revoked. Do you really want to use the key?"
 msgstr "ID on aegunud/blokeeritud/tühistatud. Kas te soovite seda võtit tõesti kasutada?"
 
-#: ncrypt/crypt_gpgme.c:4299 ncrypt/pgpkey.c:650
+#: ncrypt/crypt_gpgme.c:4301 ncrypt/pgpkey.c:650
 #, fuzzy
 msgid "ID is not valid. Do you really want to use the key?"
 msgstr "ID ei ole kehtiv. Kas te soovite seda võtit tõesti kasutada?"
 
-#: ncrypt/crypt_gpgme.c:4302 ncrypt/pgpkey.c:653
+#: ncrypt/crypt_gpgme.c:4304 ncrypt/pgpkey.c:653
 #, fuzzy
 msgid "ID is only marginally valid. Do you really want to use the key?"
 msgstr "ID on ainult osaliselt kehtiv. Kas te soovite seda võtit tõesti kasutada?"
 
-#: ncrypt/crypt_gpgme.c:4310 ncrypt/pgpkey.c:646 ncrypt/smime.c:509
+#: ncrypt/crypt_gpgme.c:4312 ncrypt/pgpkey.c:646 ncrypt/smime.c:509
 #, fuzzy
 msgid "ID has undefined validity. Do you really want to use the key?"
 msgstr "ID kehtivuse väärtus ei ole defineeritud. Kas te soovite seda võtit tõesti kasutada?"
 
-#: ncrypt/crypt_gpgme.c:4370 ncrypt/crypt_gpgme.c:4479 ncrypt/pgpkey.c:872
+#: ncrypt/crypt_gpgme.c:4372 ncrypt/crypt_gpgme.c:4481 ncrypt/pgpkey.c:872
 #: ncrypt/pgpkey.c:995
 #, c-format
 msgid "Looking for keys matching \"%s\"..."
 msgstr "Otsin võtmeid, mis sisaldavad \"%s\"..."
 
-#: ncrypt/crypt_gpgme.c:4593 ncrypt/pgpkey.c:731 ncrypt/smime.c:811
+#: ncrypt/crypt_gpgme.c:4595 ncrypt/pgpkey.c:731 ncrypt/smime.c:811
 #, c-format
 msgid "No matching keys found for \"%s\""
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4644 ncrypt/pgp.c:1263
+#: ncrypt/crypt_gpgme.c:4646 ncrypt/pgp.c:1263
 #, c-format
 msgid "Use keyID = \"%s\" for %s?"
 msgstr "Kasutan kasutajat = \"%s\" teatel %s?"
 
-#: ncrypt/crypt_gpgme.c:4695 ncrypt/pgp.c:1312 ncrypt/smime.c:830
+#: ncrypt/crypt_gpgme.c:4697 ncrypt/pgp.c:1312 ncrypt/smime.c:830
 #: ncrypt/smime.c:938
 #, c-format
 msgid "Enter keyID for %s: "
 msgstr "Sisestage kasutaja teatele %s: "
 
-#: ncrypt/crypt_gpgme.c:4755 ncrypt/pgpkey.c:751
+#: ncrypt/crypt_gpgme.c:4757 ncrypt/pgpkey.c:751
 msgid "Please enter the key ID: "
 msgstr "Palun sisestage võtme ID: "
 
-#: ncrypt/crypt_gpgme.c:4768
+#: ncrypt/crypt_gpgme.c:4770
 #, fuzzy, c-format
 msgid "Error exporting key: %s\n"
 msgstr "viga mustris: %s"
@@ -4047,86 +4110,86 @@ msgstr "viga mustris: %s"
 #. MIME description for exported (attached) keys.
 #. You can translate this entry to a non-ASCII string (it will be encoded),
 #. but it may be safer to keep it untranslated.
-#: ncrypt/crypt_gpgme.c:4787
+#: ncrypt/crypt_gpgme.c:4789
 #, fuzzy, c-format
 msgid "PGP Key 0x%s."
 msgstr "PGP Võti %s."
 
-#: ncrypt/crypt_gpgme.c:4830
+#: ncrypt/crypt_gpgme.c:4832
 msgid "GPGME: OpenPGP protocol not available"
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4838
+#: ncrypt/crypt_gpgme.c:4840
 msgid "GPGME: CMS protocol not available"
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4876
+#: ncrypt/crypt_gpgme.c:4878
 #, fuzzy
 msgid "S/MIME (s)ign, sign (a)s, (p)gp, (c)lear, or (o)ppenc mode off? "
 msgstr "PGP (k)rüpti, (a)llkiri, allk. ku(i), (m)õlemad, k(e)hasse, või (u)nusta? "
 
 #. L10N: S/MIME options (opportunistic encryption is on)
-#: ncrypt/crypt_gpgme.c:4878
+#: ncrypt/crypt_gpgme.c:4880
 msgid "sapco"
 msgstr "kaimeu"
 
-#: ncrypt/crypt_gpgme.c:4885
+#: ncrypt/crypt_gpgme.c:4887
 #, fuzzy
 msgid "PGP (s)ign, sign (a)s, s/(m)ime, (c)lear, or (o)ppenc mode off? "
 msgstr "PGP (k)rüpti, (a)llkiri, allk. ku(i), (m)õlemad, k(e)hasse, või (u)nusta? "
 
 #. L10N: PGP options (opportunistic encryption is on)
-#: ncrypt/crypt_gpgme.c:4887
+#: ncrypt/crypt_gpgme.c:4889
 msgid "samco"
 msgstr "kaimeu"
 
 #. L10N: S/MIME options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4900
+#: ncrypt/crypt_gpgme.c:4902
 #, fuzzy
 msgid "S/MIME (e)ncrypt, (s)ign, sign (a)s, (b)oth, (p)gp, (c)lear, or (o)ppenc mode? "
 msgstr "PGP (k)rüpti, (a)llkiri, allk. ku(i), (m)õlemad, k(e)hasse, või (u)nusta? "
 
 #. L10N: S/MIME options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4903
+#: ncrypt/crypt_gpgme.c:4905
 msgid "esabpco"
 msgstr "kaimeu"
 
 #. L10N: PGP options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4909
+#: ncrypt/crypt_gpgme.c:4911
 #, fuzzy
 msgid "PGP (e)ncrypt, (s)ign, sign (a)s, (b)oth, s/(m)ime, (c)lear, or (o)ppenc mode? "
 msgstr "PGP (k)rüpti, (a)llkiri, allk. ku(i), (m)õlemad, k(e)hasse, või (u)nusta? "
 
 #. L10N: PGP options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4912
+#: ncrypt/crypt_gpgme.c:4914
 msgid "esabmco"
 msgstr "kaimeu"
 
-#: ncrypt/crypt_gpgme.c:4925
+#: ncrypt/crypt_gpgme.c:4927
 #, fuzzy
 msgid "S/MIME (e)ncrypt, (s)ign, sign (a)s, (b)oth, (p)gp or (c)lear? "
 msgstr "PGP (k)rüpti, (a)llkiri, allk. ku(i), (m)õlemad, k(e)hasse, või (u)nusta? "
 
 #. L10N: S/MIME options
-#: ncrypt/crypt_gpgme.c:4927
+#: ncrypt/crypt_gpgme.c:4929
 msgid "esabpc"
 msgstr "kaimeu"
 
-#: ncrypt/crypt_gpgme.c:4934
+#: ncrypt/crypt_gpgme.c:4936
 #, fuzzy
 msgid "PGP (e)ncrypt, (s)ign, sign (a)s, (b)oth, s/(m)ime or (c)lear? "
 msgstr "PGP (k)rüpti, (a)llkiri, allk. ku(i), (m)õlemad, k(e)hasse, või (u)nusta? "
 
 #. L10N: PGP options
-#: ncrypt/crypt_gpgme.c:4936
+#: ncrypt/crypt_gpgme.c:4938
 msgid "esabmc"
 msgstr "kaimeu"
 
-#: ncrypt/crypt_gpgme.c:5087
+#: ncrypt/crypt_gpgme.c:5089
 msgid "Failed to verify sender"
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:5090
+#: ncrypt/crypt_gpgme.c:5092
 #, fuzzy
 msgid "Failed to figure out sender"
 msgstr "Faili avamine päiste analüüsiks ebaõnnestus."
@@ -4525,7 +4588,7 @@ msgstr ""
 msgid "%s is an invalid news server specification!"
 msgstr "%s on vigane POP tee"
 
-#: nntp.c:75 nntp.c:612 pop.c:1028 pop_lib.c:405
+#: nntp.c:75 nntp.c:612 pop.c:1031 pop_lib.c:405
 msgid "Server closed connection!"
 msgstr "Server sulges ühenduse!"
 
@@ -4691,16 +4754,17 @@ msgstr "kontrolli uusi kirju postkastides"
 
 #: opcodes.h:47
 #, fuzzy
-msgid "attach file(s) to this message"
+msgid "attach files to this message"
 msgstr "lisa sellele teatele fail(e)"
 
 #: opcodes.h:48
-msgid "attach message(s) to this message"
+#, fuzzy
+msgid "attach messages to this message"
 msgstr "lisa sellele teatele teateid"
 
 #: opcodes.h:49
 #, fuzzy
-msgid "attach news article(s) to this message"
+msgid "attach news articles to this message"
 msgstr "lisa sellele teatele fail(e)"
 
 #: opcodes.h:50
@@ -5550,7 +5614,8 @@ msgid "extract supported public keys"
 msgstr "eralda toetatud avalikud võtmed"
 
 #: opcodes.h:255
-msgid "wipe passphrase(s) from memory"
+#, fuzzy
+msgid "wipe passphrases from memory"
 msgstr "eemalda parool(id) mälust"
 
 #: opcodes.h:259
@@ -5902,18 +5967,20 @@ msgstr "Uusi teateid POP postkastis pole."
 msgid "Delete messages from server?"
 msgstr "Kustutan teated serverist?"
 
-#: pop.c:954
-#, c-format
-msgid "Reading new messages (%d bytes)..."
-msgstr "Loen uusi teateid (%d baiti)..."
+#: pop.c:955
+#, fuzzy, c-format
+msgid "Reading new messages (%d byte)..."
+msgid_plural "Reading new messages (%d bytes)..."
+msgstr[0] "Loen uusi teateid (%d baiti)..."
+msgstr[1] "Loen uusi teateid (%d baiti)..."
 
-#: pop.c:997
+#: pop.c:1000
 msgid "Error while writing mailbox!"
 msgstr "Viga postkasti kirjutamisel!"
 
 #. L10N: The plural is picked by the second numerical argument, i.e.
 #. * the %d right before 'messages', i.e. the total number of messages.
-#: pop.c:1003
+#: pop.c:1006
 #, fuzzy, c-format
 msgid "%s [%d of %d message read]"
 msgid_plural "%s [%d of %d messages read]"
@@ -6059,49 +6126,56 @@ msgstr "Toru käsule: "
 msgid "I don't know how to print %s attachments!"
 msgstr "Ma ei tea, kuidas trükkida %s lisasid!"
 
-#: recvattach.c:841
-msgid "Print tagged attachment(s)?"
-msgstr "Trükin märgitud lisa(d)?"
+#. L10N: Although we now the precise number of tagged messages, we
+#. do not show it to the user.  So feel free to use a "generic
+#. plural" as plural translation if your language has one.
+#: recvattach.c:852
+#, fuzzy, c-format
+msgid "Print tagged attachment?"
+msgid_plural "Print %d tagged attachments?"
+msgstr[0] "Trükin märgitud lisa(d)?"
+msgstr[1] "Trükin märgitud lisa(d)?"
 
-#: recvattach.c:842
+#: recvattach.c:853
+#, c-format
 msgid "Print attachment?"
 msgstr "Trükin lisa?"
 
-#: recvattach.c:900
+#: recvattach.c:913
 msgid "Structural changes to decrypted attachments are not supported"
 msgstr ""
 
-#: recvattach.c:1046
+#: recvattach.c:1059
 msgid "Can't decrypt encrypted message!"
 msgstr "Krüpteeritud teadet ei õnnestu lahti krüpteerida!"
 
-#: recvattach.c:1172
+#: recvattach.c:1185
 msgid "Attachments"
 msgstr "Lisad"
 
-#: recvattach.c:1210
+#: recvattach.c:1223
 msgid "There are no subparts to show!"
 msgstr "Osasid, mida näidata, ei ole!"
 
-#: recvattach.c:1265
+#: recvattach.c:1278
 msgid "Can't delete attachment from POP server."
 msgstr "Lisasid ei saa POP serverilt kustutada."
 
-#: recvattach.c:1274
+#: recvattach.c:1287
 #, fuzzy
 msgid "Can't delete attachment from news server."
 msgstr "Lisasid ei saa POP serverilt kustutada."
 
-#: recvattach.c:1281
+#: recvattach.c:1294
 msgid "Deletion of attachments from encrypted messages is unsupported."
 msgstr "Krüpteeritud teadetest ei saa lisasid eemaldada."
 
-#: recvattach.c:1287
+#: recvattach.c:1300
 #, fuzzy
 msgid "Deletion of attachments from signed messages may invalidate the signature."
 msgstr "Krüpteeritud teadetest ei saa lisasid eemaldada."
 
-#: recvattach.c:1305 recvattach.c:1320
+#: recvattach.c:1318 recvattach.c:1333
 msgid "Only deletion of multipart attachments is supported."
 msgstr "Kustutada saab ainult mitmeosalise teate lisasid."
 
@@ -6521,3 +6595,15 @@ msgstr "Kompileerimise võtmed:"
 #: version.c:404
 msgid "Compile options:"
 msgstr "Kompileerimise võtmed:"
+
+#, fuzzy
+#~ msgid "Cannot delete message(s)"
+#~ msgstr "Kustutamata teateid pole."
+
+#, fuzzy
+#~ msgid "Cannot undelete message(s)"
+#~ msgstr "Kustutamata teateid pole."
+
+#, fuzzy
+#~ msgid "messages not deleted"
+#~ msgstr "märgin %d teadet kustutatuks..."

--- a/po/eu.po
+++ b/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neomutt-20180512\n"
 "Report-Msgid-Bugs-To: neomutt-devel@neomutt.org\n"
-"POT-Creation-Date: 2018-05-20 02:02+0000\n"
+"POT-Creation-Date: 2018-05-22 14:18+0000\n"
 "PO-Revision-Date: 2008-05-20 22:39+0200\n"
 "Last-Translator: Piarres Beobide <pi@beobide.net>\n"
 "Language-Team: Euskara <debian-l10n-basque@lists.debian.org>\n"
@@ -40,7 +40,7 @@ msgstr "Hautatu"
 
 #: addrbook.c:52 browser.c:75 browser.c:87 compose.c:160 compose.c:172
 #: conn/ssl.c:1041 conn/ssl_gnutls.c:793 curs_main.c:748 curs_main.c:761
-#: history.c:106 ncrypt/crypt_gpgme.c:4219 ncrypt/pgpkey.c:547
+#: history.c:106 ncrypt/crypt_gpgme.c:4221 ncrypt/pgpkey.c:547
 #: ncrypt/smime.c:477 pager.c:2141 postpone.c:65 query.c:72 recvattach.c:70
 msgid "Help"
 msgstr "Laguntza"
@@ -690,7 +690,7 @@ msgstr ""
 #. * Since it shares the row with "Encrypt with:", it should not be longer
 #. * than 15-20 character cells.
 #.
-#: compose.c:138 ncrypt/crypt_gpgme.c:4947 ncrypt/pgp.c:1786
+#: compose.c:138 ncrypt/crypt_gpgme.c:4949 ncrypt/pgp.c:1786
 #: ncrypt/smime.c:2127
 msgid "Sign as: "
 msgstr "Honela sinatu: "
@@ -1237,7 +1237,7 @@ msgstr "(u)katu, behin (o)nartu"
 msgid "(r)eject, accept (o)nce"
 msgstr "(u)katu, behin (o)nartu"
 
-#: conn/ssl.c:1039 conn/ssl_gnutls.c:791 ncrypt/crypt_gpgme.c:4213
+#: conn/ssl.c:1039 conn/ssl_gnutls.c:791 ncrypt/crypt_gpgme.c:4215
 #: ncrypt/pgpkey.c:541 ncrypt/smime.c:473
 msgid "Exit  "
 msgstr "Irten  "
@@ -1417,11 +1417,11 @@ msgstr "Ez da postakutxarik irekirik."
 msgid "There are no messages."
 msgstr "Ez daude mezurik."
 
-#: curs_main.c:77 mx.c:1061 pager.c:73 recvattach.c:56
+#: curs_main.c:77 mx.c:1071 pager.c:73 recvattach.c:56
 msgid "Mailbox is read-only."
 msgstr "Irakurketa soileko posta-kutxa."
 
-#: curs_main.c:79 pager.c:75 recvattach.c:1145
+#: curs_main.c:79 pager.c:75 recvattach.c:1158
 msgid "Function not permitted in attach-message mode."
 msgstr "Mezu-gehitze moduan baimenik gabeko funtzioa."
 
@@ -1555,255 +1555,263 @@ msgid "That message is not visible."
 msgstr "Mezu hau ez da ikusgarria."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:1377 curs_main.c:2772 pager.c:2818
+#. L10N: Due to the implementation details we do not know whether we
+#. delete zero, 1, 12, ... messages. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:1381 curs_main.c:2784 pager.c:2822
 #, fuzzy
-msgid "Cannot delete message(s)"
+msgid "Cannot delete messages"
 msgstr "desezabatu mezua(k)"
 
-#: curs_main.c:1380
+#: curs_main.c:1384
 msgid "Delete messages matching: "
 msgstr "Horrelako mezuak ezabatu: "
 
-#: curs_main.c:1421
+#: curs_main.c:1425
 msgid "No limit pattern is in effect."
 msgstr "Ez da muga patroirik funtzionamenduan."
 
 #. L10N: ask for a limit to apply
-#: curs_main.c:1426
+#: curs_main.c:1430
 #, c-format
 msgid "Limit: %s"
 msgstr "Muga: %s"
 
-#: curs_main.c:1464
+#: curs_main.c:1468
 msgid "Limit to messages matching: "
 msgstr "Hau duten mezuetara mugatu: "
 
-#: curs_main.c:1488
+#: curs_main.c:1492
 msgid "To view all messages, limit to \"all\"."
 msgstr "Mezu guztiak ikusteko, \"dena\" bezala mugatu."
 
-#: curs_main.c:1500 pager.c:2318
+#: curs_main.c:1504 pager.c:2318
 msgid "Quit NeoMutt?"
 msgstr "NeoMutt Itxi?"
 
-#: curs_main.c:1596
+#: curs_main.c:1600
 msgid "Tag messages matching: "
 msgstr "Horrelako mezuak markatu: "
 
 #. L10N: CHECK_ACL
-#: curs_main.c:1606 curs_main.c:3203 pager.c:3137
+#. L10N: Due to the implementation details we do not know whether we
+#. undelete zero, 1, 12, ... messages. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:1614 curs_main.c:3223 pager.c:3145
 #, fuzzy
-msgid "Cannot undelete message(s)"
+msgid "Cannot undelete messages"
 msgstr "desezabatu mezua(k)"
 
-#: curs_main.c:1609
+#: curs_main.c:1617
 msgid "Undelete messages matching: "
 msgstr "Hau betetzen duten mezua desezabatu: "
 
-#: curs_main.c:1619
+#: curs_main.c:1627
 msgid "Untag messages matching: "
 msgstr "Horrelako mezuen marka ezabatzen: "
 
-#: curs_main.c:1653
+#: curs_main.c:1661
 msgid "Logged out of IMAP servers."
 msgstr ""
 
-#: curs_main.c:1753
+#: curs_main.c:1761
 #, fuzzy
 msgid "No virtual folder, aborting."
 msgstr "Ez du gairik, ezeztatzen."
 
-#: curs_main.c:1761
+#: curs_main.c:1769
 msgid "Failed to read thread, aborting."
 msgstr ""
 
-#: curs_main.c:1793 mx.c:1458 mx.c:1475
+#: curs_main.c:1801 mx.c:1468 mx.c:1485
 #, fuzzy
 msgid "Folder doesn't support tagging, aborting."
 msgstr "SMTP zerbitzariak ez du autentifikazioa onartzen"
 
-#: curs_main.c:1808
+#: curs_main.c:1816
 #, fuzzy
 msgid "No tag specified, aborting."
 msgstr "Ez du gairik, ezeztatzen."
 
-#: curs_main.c:1820
+#: curs_main.c:1828
 #, c-format
 msgid "Update tags..."
 msgstr ""
 
-#: curs_main.c:1857
+#: curs_main.c:1865
 msgid "Failed to modify tags, aborting."
 msgstr ""
 
-#: curs_main.c:1898
+#: curs_main.c:1906
 #, fuzzy
 msgid "No query, aborting."
 msgstr "Ez du gairik, ezeztatzen."
 
-#: curs_main.c:1902 curs_main.c:1922 curs_main.c:1941
+#: curs_main.c:1910 curs_main.c:1930 curs_main.c:1949
 msgid "Failed to create query, aborting."
 msgstr ""
 
-#: curs_main.c:1911 curs_main.c:1930
+#: curs_main.c:1919 curs_main.c:1938
 msgid "Windowed queries disabled."
 msgstr ""
 
-#: curs_main.c:1916 curs_main.c:1935
+#: curs_main.c:1924 curs_main.c:1943
 msgid "No notmuch vfolder currently loaded."
 msgstr ""
 
-#: curs_main.c:1973
+#: curs_main.c:1981
 msgid "Open mailbox in read-only mode"
 msgstr "Postakutxa irakurtzeko bakarrik ireki"
 
-#: curs_main.c:1976
+#: curs_main.c:1984
 #, fuzzy
 msgid "Open virtual folder"
 msgstr "beste karpeta bat ireki"
 
-#: curs_main.c:1979
+#: curs_main.c:1987
 msgid "Open mailbox"
 msgstr "Postakutxa ireki"
 
-#: curs_main.c:1989
+#: curs_main.c:1997
 msgid "No mailboxes have new mail"
 msgstr "Ez dago posta berririk duen postakutxarik"
 
-#: curs_main.c:2036
+#: curs_main.c:2044
 #, fuzzy
 msgid "Open newsgroup in read-only mode"
 msgstr "Postakutxa irakurtzeko bakarrik ireki"
 
-#: curs_main.c:2038
+#: curs_main.c:2046
 msgid "Open newsgroup"
 msgstr ""
 
-#: curs_main.c:2141
+#: curs_main.c:2149
 #, fuzzy
 msgid "Exit NeoMutt without saving?"
 msgstr "NeoMutt gorde gabe itxi?"
 
-#: curs_main.c:2157
+#: curs_main.c:2165
 #, fuzzy
 msgid "Cannot break thread"
 msgstr "hariak lotu"
 
-#: curs_main.c:2160 curs_main.c:2198 curs_main.c:2658 curs_main.c:2690
+#: curs_main.c:2168 curs_main.c:2206 curs_main.c:2666 curs_main.c:2698
 #: flags.c:376 thread.c:1078 thread.c:1134 thread.c:1202
 msgid "Threading is not enabled."
 msgstr "Hari bihurketa ez dago gaiturik."
 
-#: curs_main.c:2173
+#: curs_main.c:2181
 msgid "Thread broken"
 msgstr "Haria apurturik"
 
-#: curs_main.c:2185
+#: curs_main.c:2193
 msgid "Thread cannot be broken, message is not part of a thread"
 msgstr ""
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2195
+#: curs_main.c:2203
 #, fuzzy
 msgid "Cannot link threads"
 msgstr "hariak lotu"
 
-#: curs_main.c:2200
+#: curs_main.c:2208
 msgid "No Message-ID: header available to link thread"
 msgstr "Ez da Mezu-ID burua jaso harira lotzeko"
 
-#: curs_main.c:2202
+#: curs_main.c:2210
 msgid "First, please tag a message to be linked here"
 msgstr "Lehenengo, markatu mezu bat hemen lotzeko"
 
-#: curs_main.c:2213
+#: curs_main.c:2221
 msgid "Threads linked"
 msgstr "Hariak loturik"
 
-#: curs_main.c:2216
+#: curs_main.c:2224
 msgid "No thread linked"
 msgstr "Hariak ez dira lotu"
 
-#: curs_main.c:2252 curs_main.c:2278
+#: curs_main.c:2260 curs_main.c:2286
 msgid "You are on the last message."
 msgstr "Azkenengo mezuan zaude."
 
-#: curs_main.c:2260 curs_main.c:2305
+#: curs_main.c:2268 curs_main.c:2313
 msgid "No undeleted messages."
 msgstr "Ez dago desezabatutako mezurik."
 
-#: curs_main.c:2297 curs_main.c:2323
+#: curs_main.c:2305 curs_main.c:2331
 msgid "You are on the first message."
 msgstr "Lehenengo mezuan zaude."
 
-#: curs_main.c:2395 menu.c:970 pager.c:2440 pattern.c:2110
+#: curs_main.c:2403 menu.c:970 pager.c:2440 pattern.c:2110
 msgid "Search wrapped to top."
 msgstr "Bilaketa berriz hasieratik hasi da."
 
-#: curs_main.c:2404 pager.c:2463 pattern.c:2121
+#: curs_main.c:2412 pager.c:2463 pattern.c:2121
 msgid "Search wrapped to bottom."
 msgstr "Bilaketa berriz amaieratik hasi da."
 
-#: curs_main.c:2447
+#: curs_main.c:2455
 #, fuzzy
 msgid "No new messages in this limited view."
 msgstr "Jatorrizko mezua ez da ikusgarria bistaratze mugatu honetan."
 
-#: curs_main.c:2449
+#: curs_main.c:2457
 #, fuzzy
 msgid "No new messages."
 msgstr "Ez dago mezu berririk"
 
-#: curs_main.c:2454
+#: curs_main.c:2462
 #, fuzzy
 msgid "No unread messages in this limited view."
 msgstr "Jatorrizko mezua ez da ikusgarria bistaratze mugatu honetan."
 
-#: curs_main.c:2456
+#: curs_main.c:2464
 #, fuzzy
 msgid "No unread messages."
 msgstr "Ez dago irakurgabeko mezurik"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2474
+#: curs_main.c:2482
 #, fuzzy
 msgid "Cannot flag message"
 msgstr "markatu mezua"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2513 pager.c:3100
+#: curs_main.c:2521 pager.c:3104
 #, fuzzy
 msgid "Cannot toggle new"
 msgstr "txandakatu berria"
 
-#: curs_main.c:2590
+#: curs_main.c:2598
 msgid "No more threads."
 msgstr "Ez dago hari gehiagorik."
 
-#: curs_main.c:2592
+#: curs_main.c:2600
 msgid "You are on the first thread."
 msgstr "Lehenengo harian zaude."
 
-#: curs_main.c:2676
+#: curs_main.c:2684
 #, fuzzy
 msgid "Thread contains unread or flagged messages."
 msgstr "Irakurgabeko mezuak dituen haria."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2726 pager.c:2784
+#: curs_main.c:2734 pager.c:2784
 #, fuzzy
 msgid "Cannot delete message"
 msgstr "desezabatu mezua"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2838
+#: curs_main.c:2850
 #, fuzzy
 msgid "Cannot edit message"
 msgstr "Ezin da mezua idatzi"
 
 #. L10N: This is displayed when the x-label on one or more
 #. * messages is edited.
-#: curs_main.c:2900 pager.c:3200
+#: curs_main.c:2912 pager.c:3208
 #, fuzzy, c-format
 msgid "%d label changed."
 msgid_plural "%d labels changed."
@@ -1813,28 +1821,32 @@ msgstr[1] "Postakutxak ez du aldaketarik."
 #. L10N: This is displayed when editing an x-label, but no messages
 #. * were updated.  Possibly due to canceling at the prompt or if the new
 #. * label is the same as the old label.
-#: curs_main.c:2907 pager.c:3204
+#: curs_main.c:2919 pager.c:3212
 #, fuzzy
 msgid "No labels changed."
 msgstr "Postakutxak ez du aldaketarik."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:3006
+#. L10N: Due to the implementation details we do not know whether we
+#. mark zero, 1, 12, ... messages as read. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:3022
 #, fuzzy
-msgid "Cannot mark message(s) as read"
+msgid "Cannot mark messages as read"
 msgstr "markatu mezua(k) irakurri gisa"
 
 #. L10N: This is the prompt for <mark-message>.  Whatever they
 #. enter will be prefixed by $mark_macro_prefix and will become
 #. a macro hotkey to jump to the currently selected message.
-#: curs_main.c:3042
+#: curs_main.c:3058
 #, fuzzy
 msgid "Enter macro stroke: "
 msgstr "IDgakoa sartu: "
 
 #. L10N: "message hotkey" is the key bindings menu description of a
 #. macro created by <mark-message>.
-#: curs_main.c:3050
+#: curs_main.c:3066
 #, fuzzy
 msgid "message hotkey"
 msgstr "Mezua atzeraturik."
@@ -1842,28 +1854,28 @@ msgstr "Mezua atzeraturik."
 #. L10N: This is echoed after <mark-message> creates a new hotkey
 #. macro.  %s is the hotkey string ($mark_macro_prefix followed
 #. by whatever they typed at the prompt.)
-#: curs_main.c:3055
+#: curs_main.c:3071
 #, fuzzy, c-format
 msgid "Message bound to %s."
 msgstr "Mezua errebotaturik."
 
 #. L10N: This error is printed if <mark-message> cannot find a
 #. Message-ID for the currently selected message in the index.
-#: curs_main.c:3063
+#: curs_main.c:3079
 #, fuzzy
 msgid "No message ID to macro."
 msgstr "Ez dago mezurik karpeta honetan."
 
-#: curs_main.c:3105 pager.c:2961 recvattach.c:1388
+#: curs_main.c:3121 pager.c:2965 recvattach.c:1401
 msgid "Reply by mail as poster prefers?"
 msgstr ""
 
-#: curs_main.c:3108 pager.c:2927 pager.c:2939 pager.c:2964
+#: curs_main.c:3124 pager.c:2931 pager.c:2943 pager.c:2968
 msgid "Posting to this group not allowed, may be moderated. Continue?"
 msgstr ""
 
 #. L10N: CHECK_ACL
-#: curs_main.c:3173 pager.c:3120
+#: curs_main.c:3189 pager.c:3124
 #, fuzzy
 msgid "Cannot undelete message"
 msgstr "desezabatu mezua"
@@ -2057,12 +2069,34 @@ msgstr "[-- Aurreikusi %s-eko stderr --]\n"
 msgid "[-- Error: message/external-body has no access-type parameter --]\n"
 msgstr "[-- Erroreak: mezu/kanpoko edukiak ez du access-type parametrorik --]\n"
 
-#: handler.c:1611
+#. L10N: If the translation of this string is a multi line string, then
+#. each line should start with "[-- " and end with " --]".
+#. The first "%s/%s" is a MIME type, e.g. "text/plain". The last %s
+#. expands to a date as returned by `mutt_date_parse_date()`.
+#.
+#. Note: The size argument printed is not the actual number as passed
+#. to gettext but the prettified version, e.g. size = 2048 will be
+#. printed as 2K.  Your language might be sensitive to that: For
+#. example although '1K' and '1024' represent the same number your
+#. language might inflect the noun 'byte' differently.
+#.
+#. Sadly, we cannot do anything about that at the moment besides
+#. passing the precise size in bytes. If you are interested the
+#. function responsible for the prettification is
+#. mutt_str_pretty_size() in mutt/string.c.
+#.
+#: handler.c:1624
 #, fuzzy, c-format
 msgid ""
+"[-- This %s/%s attachment (size %s byte) has been deleted --]\n"
+"[-- on %s --]\n"
+msgid_plural ""
 "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
 "[-- on %s --]\n"
-msgstr ""
+msgstr[0] ""
+"[--  %s/%s gehigarri hau (tamaina %s byte) ezabatua izan da --]\n"
+"[-- %s-an --]\n"
+msgstr[1] ""
 "[--  %s/%s gehigarri hau (tamaina %s byte) ezabatua izan da --]\n"
 "[-- %s-an --]\n"
 
@@ -2070,10 +2104,23 @@ msgstr ""
 #. each line should start with "[-- " and end with " --]".
 #. The first "%s/%s" is a MIME type, e.g. "text/plain".
 #.
-#: handler.c:1620
+#. Note: The size argument printed is not the actual number as passed
+#. to gettext but the prettified version, e.g. size = 2048 will be
+#. printed as 2K.  Your language might be sensitive to that: For
+#. example although '1K' and '1024' represent the same number your
+#. language might inflect the noun 'byte' differently.
+#.
+#. Sadly, we cannot do anything about that at the moment besides
+#. passing the precise size in bytes. If you are interested the
+#. function responsible for the prettification is
+#. mutt_str_pretty_size() in mutt/string.c.
+#.
+#: handler.c:1648
 #, fuzzy, c-format
-msgid "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
-msgstr "[--  %s/%s gehigarri hau (tamaina %s byte) ezabatua izan da --]\n"
+msgid "[-- This %s/%s attachment (size %s byte) has been deleted --]\n"
+msgid_plural "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
+msgstr[0] "[--  %s/%s gehigarri hau (tamaina %s byte) ezabatua izan da --]\n"
+msgstr[1] "[--  %s/%s gehigarri hau (tamaina %s byte) ezabatua izan da --]\n"
 
 #. L10N: If the translation of this string is a multi line string, then
 #. each line should start with "[-- " and end with " --]".
@@ -2083,7 +2130,7 @@ msgstr "[--  %s/%s gehigarri hau (tamaina %s byte) ezabatua izan da --]\n"
 #. Caution: Argument three %3$ is also defined but should not be used
 #. in this translation!
 #.
-#: handler.c:1637
+#: handler.c:1667
 #, fuzzy
 msgid ""
 "[-- This %s/%s attachment has been deleted --]\n"
@@ -2096,17 +2143,17 @@ msgstr ""
 #. each line should start with "[-- " and end with " --]".
 #. The first "%s/%s" is a MIME type, e.g. "text/plain".
 #.
-#: handler.c:1646
+#: handler.c:1676
 #, fuzzy, c-format
 msgid "[-- This %s/%s attachment has been deleted --]\n"
 msgstr "[--  %s/%s gehigarri hau ezabatua izan da --]\n"
 
-#: handler.c:1656
+#: handler.c:1686
 #, c-format
 msgid "[-- name: %s --]\n"
 msgstr "[-- izena: %s --]\n"
 
-#: handler.c:1672
+#: handler.c:1702
 #, fuzzy, c-format
 msgid ""
 "[-- This %s/%s attachment is not included, --]\n"
@@ -2117,7 +2164,7 @@ msgstr ""
 "[-- ezarritako kanpoko jatorria denboraz --]\n"
 "[-- kanpo dago. --]\n"
 
-#: handler.c:1693
+#: handler.c:1723
 #, fuzzy, c-format
 msgid ""
 "[-- This %s/%s attachment is not included, --]\n"
@@ -2126,52 +2173,52 @@ msgstr ""
 "[-- %s/%s gehigarria ez dago gehiturik, --]\n"
 "[-- eta ezarritako access type %s ez da onartzen --]\n"
 
-#: handler.c:1822
+#: handler.c:1852
 #, fuzzy
 msgid "Unable to open memory stream!"
 msgstr "Ezin da behin-behineko fitxategia ireki!"
 
-#: handler.c:1831
+#: handler.c:1861
 msgid "Unable to open temporary file!"
 msgstr "Ezin da behin-behineko fitxategia ireki!"
 
-#: handler.c:1881
+#: handler.c:1911
 #, fuzzy
 msgid "failed to re-open memstream!"
 msgstr "Ezin da behin-behineko fitxategia ireki!"
 
-#: handler.c:2013
+#: handler.c:2043
 msgid "Error: multipart/signed has no protocol."
 msgstr "Errorea: zati anitzeko sinadurak ez du protokolorik."
 
-#: handler.c:2076
+#: handler.c:2106
 #, fuzzy
 msgid "[-- This is an attachment (use '%3$s' to view this part) --]\n"
 msgstr "[--  %s/%s gehigarri hau ('%3$s' erabili zati hau ikusteko) --]\n"
 
-#: handler.c:2082
+#: handler.c:2112
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported (use '%s' to view this part) --]\n"
 msgstr "[-- %s/%s ez da onartzen ('%s' erabili zati hau ikusteko) --]\n"
 
-#: handler.c:2087
+#: handler.c:2117
 #, fuzzy
 msgid "[-- This is an attachment (need 'view-attachments' bound to key!) --]\n"
 msgstr "[--  %s/%s gehigarri hau (lotu 'view-attachments' tekla bati!) --]\n"
 
 #. L10N: %s/%s is a MIME type, e.g. "text/plain".
-#: handler.c:2091
+#: handler.c:2121
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported (need 'view-attachments' bound to key!) --]\n"
 msgstr "[-- %s/%s ez da onartzen (lotu 'view-attachments' tekla bati!) --]\n"
 
-#: handler.c:2098
+#: handler.c:2128
 #, fuzzy
 msgid "[-- This is an attachment --]\n"
 msgstr "[--  %s/%s gehigarri hau --]\n"
 
 #. L10N: %s/%s is a MIME type, e.g. "text/plain".
-#: handler.c:2101
+#: handler.c:2131
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported --]\n"
 msgstr "[-- %s/%s ez da onartzen --]\n"
@@ -2478,7 +2525,7 @@ msgstr "SMTP zerbitzariak ez du autentifikazioa onartzen"
 msgid "Invalid IMAP flags"
 msgstr "Baliogabea        "
 
-#: imap/message.c:477 mx.c:1326
+#: imap/message.c:477 mx.c:1336
 msgid "Integer overflow -- can't allocate memory."
 msgstr "Integral gainezkatzea -- ezin da memoria esleitu."
 
@@ -3244,66 +3291,75 @@ msgstr "SSL ez da erabilgarri."
 msgid "Reading from %s interrupted..."
 msgstr "Bilaketa geldiarazirik."
 
-#: mx.c:634
+#. L10N: Although we now the precise number of messages, we do not show it to the user.
+#. So feel free to use a "generic plural" as plural translation if your language has one.
+#.
+#: mx.c:639
 #, fuzzy
-msgid "message(s) not deleted"
-msgstr "Mezu ezabatuak markatzen..."
+msgid "message not deleted"
+msgid_plural "messages not deleted"
+msgstr[0] "Mezu ezabatuak markatzen..."
+msgstr[1] "Mezu ezabatuak markatzen..."
 
-#: mx.c:671
+#: mx.c:676
 #, fuzzy
 msgid "Can't open trash folder"
 msgstr "Ezin karpetan gehitu: %s"
 
-#: mx.c:710
+#: mx.c:715
 msgid "Mark all articles read?"
 msgstr ""
 
-#: mx.c:754
+#. L10N: The first argument is the number of read messages to be
+#. moved, the second argument is the target mailbox.
+#: mx.c:762
 #, fuzzy, c-format
-msgid "Move %d read messages to %s?"
-msgstr "Irakurritako mezuak %s-ra mugitu?"
+msgid "Move %d read message to %s?"
+msgid_plural "Move %d read messages to %s?"
+msgstr[0] "Irakurritako mezuak %s-ra mugitu?"
+msgstr[1] "Irakurritako mezuak %s-ra mugitu?"
 
-#: mx.c:771 mx.c:1077
+#: mx.c:781 mx.c:1087
 #, fuzzy, c-format
 msgid "Purge %d deleted message?"
 msgid_plural "Purge %d deleted messages?"
 msgstr[0] "Ezabatutako %d mezua betirako ezabatu?"
 msgstr[1] "Ezabatutako %d mezuak betirako ezabatu?"
 
-#: mx.c:793
+#: mx.c:803
 #, c-format
 msgid "Moving read messages to %s..."
 msgstr "Irakurritako mezuak %s-ra mugitzen..."
 
-#: mx.c:859 mx.c:1068
+#: mx.c:869 mx.c:1078
 msgid "Mailbox is unchanged."
 msgstr "Postakutxak ez du aldaketarik."
 
-#: mx.c:914
+#: mx.c:924
 #, c-format
 msgid "%d kept, %d moved, %d deleted."
 msgstr "%d utzi, %d mugiturik, %d ezabaturik."
 
-#: mx.c:917 mx.c:1130
+#: mx.c:927 mx.c:1140
 #, c-format
 msgid "%d kept, %d deleted."
 msgstr "%d utzi, %d ezabaturik."
 
-#: mx.c:1052
+#: mx.c:1062
 #, c-format
 msgid " Press '%s' to toggle write"
 msgstr " %s sakatu idatzitarikoa aldatzeko"
 
-#: mx.c:1054
+#: mx.c:1064
 msgid "Use 'toggle-write' to re-enable write!"
 msgstr "'toogle-write' erabili idazketa berriz gaitzeko!"
 
-#: mx.c:1056
+#: mx.c:1066
 #, c-format
 msgid "Mailbox is marked unwritable. %s"
 msgstr "Postakutxa idaztezin bezala markatuta. %s"
 
-#: mx.c:1124
+#: mx.c:1134
 msgid "Mailbox checkpointed."
 msgstr "Postakutxa markaturik."
 
@@ -3317,54 +3373,59 @@ msgstr " (uneko ordua:%c)"
 msgid "[-- %s output follows%s --]\n"
 msgstr "[-- %s irteera jarraian%s --]\n"
 
-#: ncrypt/crypt.c:95
-msgid "Passphrase(s) forgotten."
+#. L10N: Due to the implementation details (e.g. some passwords are managed
+#. by gpg-agent) we cannot know whether we forgot zero, 1, 12, ...
+#. passwords. So in English we use "Passphrases". Your language might
+#. have other means to express this.
+#: ncrypt/crypt.c:100
+#, fuzzy
+msgid "Passphrases forgotten."
 msgstr "Pasahitza(k) ahazturik."
 
-#: ncrypt/crypt.c:155
+#: ncrypt/crypt.c:161
 #, fuzzy
 msgid "Inline PGP can't be used with attachments.  Revert to PGP/MIME?"
 msgstr "Mezua ezin da erantsia bidali.  PGP/MIME erabiltzea itzuli?"
 
-#: ncrypt/crypt.c:159
+#: ncrypt/crypt.c:165
 msgid "Mail not sent: inline PGP can't be used with attachments."
 msgstr ""
 
-#: ncrypt/crypt.c:166
+#: ncrypt/crypt.c:172
 #, fuzzy
 msgid "Inline PGP can't be used with format=flowed.  Revert to PGP/MIME?"
 msgstr "Mezua ezin da erantsia bidali.  PGP/MIME erabiltzea itzuli?"
 
-#: ncrypt/crypt.c:170
+#: ncrypt/crypt.c:176
 msgid "Mail not sent: inline PGP can't be used with format=flowed."
 msgstr ""
 
-#: ncrypt/crypt.c:180 ncrypt/cryptglue.c:125 ncrypt/pgpkey.c:589
+#: ncrypt/crypt.c:186 ncrypt/cryptglue.c:125 ncrypt/pgpkey.c:589
 #: ncrypt/pgpkey.c:782
 msgid "Invoking PGP..."
 msgstr "PGP deitzen..."
 
-#: ncrypt/crypt.c:192
+#: ncrypt/crypt.c:198
 msgid "Message can't be sent inline.  Revert to using PGP/MIME?"
 msgstr "Mezua ezin da erantsia bidali.  PGP/MIME erabiltzea itzuli?"
 
-#: ncrypt/crypt.c:194 send.c:1824
+#: ncrypt/crypt.c:200 send.c:1824
 msgid "Mail not sent."
 msgstr "Eposta ez da bidali."
 
-#: ncrypt/crypt.c:540
+#: ncrypt/crypt.c:546
 msgid "S/MIME messages with no hints on content are unsupported."
 msgstr "S/MIME mezuak ez dira onartzen edukian gomendiorik ez badute."
 
-#: ncrypt/crypt.c:754 ncrypt/crypt.c:795
+#: ncrypt/crypt.c:760 ncrypt/crypt.c:801
 msgid "Trying to extract PGP keys...\n"
 msgstr "PGP-gakoak ateratzen saiatzen...\n"
 
-#: ncrypt/crypt.c:776 ncrypt/crypt.c:816
+#: ncrypt/crypt.c:782 ncrypt/crypt.c:822
 msgid "Trying to extract S/MIME certificates...\n"
 msgstr "S/MIME ziurtagiria ateratzen saiatzen...\n"
 
-#: ncrypt/crypt.c:976
+#: ncrypt/crypt.c:982
 #, c-format
 msgid ""
 "[-- Error: Unknown multipart/signed protocol %s! --]\n"
@@ -3373,7 +3434,7 @@ msgstr ""
 "[-- Errorea: zatianitz/sinatutako protokolo ezezaguna %s! --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1016
+#: ncrypt/crypt.c:1022
 #, fuzzy
 msgid ""
 "[-- Error: Missing or bad-format multipart/signed signature! --]\n"
@@ -3382,7 +3443,7 @@ msgstr ""
 "[-- Errorea: konsistentzi gabeko zatianitz/sinaturiko estruktura! --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1058
+#: ncrypt/crypt.c:1064
 #, c-format
 msgid ""
 "[-- Warning: We can't verify %s/%s signatures. --]\n"
@@ -3391,7 +3452,7 @@ msgstr ""
 "[-- Kontuz: Ezin dira %s/%s sinadurak egiaztatu. --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1070
+#: ncrypt/crypt.c:1076
 msgid ""
 "[-- The following data is signed --]\n"
 "\n"
@@ -3399,7 +3460,7 @@ msgstr ""
 "[-- Hurrengo datuak sinaturik daude --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1075
+#: ncrypt/crypt.c:1081
 msgid ""
 "[-- Warning: Can't find any signatures. --]\n"
 "\n"
@@ -3407,7 +3468,7 @@ msgstr ""
 "[-- Kontuz: Ez da sinadurarik aurkitu. --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1081
+#: ncrypt/crypt.c:1087
 msgid ""
 "\n"
 "[-- End of signed data --]\n"
@@ -3458,7 +3519,7 @@ msgstr ""
 msgid "error reading data object: %s\n"
 msgstr "errorea datu objektua irakurtzerakoan: %s\n"
 
-#: ncrypt/crypt_gpgme.c:662 ncrypt/crypt_gpgme.c:3848 ncrypt/pgpkey.c:585
+#: ncrypt/crypt_gpgme.c:662 ncrypt/crypt_gpgme.c:3850 ncrypt/pgpkey.c:585
 #: ncrypt/pgpkey.c:768
 msgid "Can't create temporary file"
 msgstr "Ezin da behin-behineko fitxategia sortu"
@@ -3820,28 +3881,30 @@ msgstr "[Baliogabea]"
 
 #. L10N: This is printed after "Key Type: " and looks like this:
 #. *       PGP, 2048 bit RSA
-#: ncrypt/crypt_gpgme.c:3670 ncrypt/crypt_gpgme.c:3808
+#: ncrypt/crypt_gpgme.c:3670 ncrypt/crypt_gpgme.c:3810
 #, fuzzy, c-format
 msgid "%s, %lu bit %s\n"
-msgstr "Gako mota ..: %s, %lu bit %s\n"
+msgid_plural "%s, %lu bit %s\n"
+msgstr[0] "Gako mota ..: %s, %lu bit %s\n"
+msgstr[1] "Gako mota ..: %s, %lu bit %s\n"
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3678 ncrypt/crypt_gpgme.c:3815
+#: ncrypt/crypt_gpgme.c:3678 ncrypt/crypt_gpgme.c:3817
 msgid "encryption"
 msgstr "enkriptazioa"
 
 #: ncrypt/crypt_gpgme.c:3679 ncrypt/crypt_gpgme.c:3685
-#: ncrypt/crypt_gpgme.c:3816 ncrypt/crypt_gpgme.c:3821
+#: ncrypt/crypt_gpgme.c:3818 ncrypt/crypt_gpgme.c:3823
 msgid ", "
 msgstr ", "
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3684 ncrypt/crypt_gpgme.c:3820
+#: ncrypt/crypt_gpgme.c:3684 ncrypt/crypt_gpgme.c:3822
 msgid "signing"
 msgstr "sinatzen"
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3690 ncrypt/crypt_gpgme.c:3825
+#: ncrypt/crypt_gpgme.c:3690 ncrypt/crypt_gpgme.c:3827
 msgid "certification"
 msgstr "ziurtapena"
 
@@ -3860,65 +3923,65 @@ msgstr "[Iraungia]"
 msgid "[Disabled]"
 msgstr "[Desgaitua]"
 
-#: ncrypt/crypt_gpgme.c:3851
+#: ncrypt/crypt_gpgme.c:3853
 msgid "Collecting data..."
 msgstr "Datuak batzen..."
 
-#: ncrypt/crypt_gpgme.c:3876
+#: ncrypt/crypt_gpgme.c:3878
 #, c-format
 msgid "Error finding issuer key: %s\n"
 msgstr "Errorea jaulkitzaile gakoa bilatzean: %s\n"
 
-#: ncrypt/crypt_gpgme.c:3885
+#: ncrypt/crypt_gpgme.c:3887
 #, fuzzy
 msgid "Error: certification chain too long - stopping here\n"
 msgstr "Errorea: ziurtagiri kate luzeegia - hemen gelditzen\n"
 
-#: ncrypt/crypt_gpgme.c:3895 ncrypt/pgpkey.c:608
+#: ncrypt/crypt_gpgme.c:3897 ncrypt/pgpkey.c:608
 #, c-format
 msgid "Key ID: 0x%s"
 msgstr "Gako IDa: 0x%s"
 
-#: ncrypt/crypt_gpgme.c:3990
+#: ncrypt/crypt_gpgme.c:3992
 #, c-format
 msgid "gpgme_new failed: %s"
 msgstr "gpgme_new hutsa: %s"
 
-#: ncrypt/crypt_gpgme.c:4028 ncrypt/crypt_gpgme.c:4079
+#: ncrypt/crypt_gpgme.c:4030 ncrypt/crypt_gpgme.c:4081
 #, c-format
 msgid "gpgme_op_keylist_start failed: %s"
 msgstr "gpgme_op_keylist_start hutsa: %s"
 
-#: ncrypt/crypt_gpgme.c:4067 ncrypt/crypt_gpgme.c:4109
+#: ncrypt/crypt_gpgme.c:4069 ncrypt/crypt_gpgme.c:4111
 #, c-format
 msgid "gpgme_op_keylist_next failed: %s"
 msgstr "gpgme_op_keylist_next hutsa: %s"
 
-#: ncrypt/crypt_gpgme.c:4185
+#: ncrypt/crypt_gpgme.c:4187
 msgid "All matching keys are marked expired/revoked."
 msgstr "Pareko gako guztiak iraungita/errebokatua bezala markaturik daude."
 
-#: ncrypt/crypt_gpgme.c:4215 ncrypt/pgpkey.c:543 ncrypt/smime.c:475
+#: ncrypt/crypt_gpgme.c:4217 ncrypt/pgpkey.c:543 ncrypt/smime.c:475
 msgid "Select  "
 msgstr "Aukeratu  "
 
-#: ncrypt/crypt_gpgme.c:4217 ncrypt/pgpkey.c:545
+#: ncrypt/crypt_gpgme.c:4219 ncrypt/pgpkey.c:545
 msgid "Check key  "
 msgstr "Gakoa egiaztatu  "
 
-#: ncrypt/crypt_gpgme.c:4233
+#: ncrypt/crypt_gpgme.c:4235
 msgid "PGP and S/MIME keys matching"
 msgstr "PGP eta S/MIME gako parekatzea"
 
-#: ncrypt/crypt_gpgme.c:4235
+#: ncrypt/crypt_gpgme.c:4237
 msgid "PGP keys matching"
 msgstr "PGP gako parekatzea"
 
-#: ncrypt/crypt_gpgme.c:4237
+#: ncrypt/crypt_gpgme.c:4239
 msgid "S/MIME keys matching"
 msgstr "S/MIME gako parekatzea"
 
-#: ncrypt/crypt_gpgme.c:4239
+#: ncrypt/crypt_gpgme.c:4241
 msgid "keys matching"
 msgstr "gako parekatzea"
 
@@ -3926,69 +3989,69 @@ msgstr "gako parekatzea"
 #. %1$s is one of the previous four entries.
 #. %2$s is an address.
 #. e.g. "S/MIME keys matching <me@mutt.org>."
-#: ncrypt/crypt_gpgme.c:4246
+#: ncrypt/crypt_gpgme.c:4248
 #, c-format
 msgid "%s <%s>."
 msgstr "%s <%s>."
 
 #. L10N:
 #. e.g. 'S/MIME keys matching "Michael Elkins".'
-#: ncrypt/crypt_gpgme.c:4250
+#: ncrypt/crypt_gpgme.c:4252
 #, c-format
 msgid "%s \"%s\"."
 msgstr "%s \"%s\"."
 
-#: ncrypt/crypt_gpgme.c:4277 ncrypt/pgpkey.c:628
+#: ncrypt/crypt_gpgme.c:4279 ncrypt/pgpkey.c:628
 msgid "This key can't be used: expired/disabled/revoked."
 msgstr "Gako hau ezin da erabili: iraungita/desgaitua/errebokatuta."
 
-#: ncrypt/crypt_gpgme.c:4290 ncrypt/pgpkey.c:640 ncrypt/smime.c:505
+#: ncrypt/crypt_gpgme.c:4292 ncrypt/pgpkey.c:640 ncrypt/smime.c:505
 #, fuzzy
 msgid "ID is expired/disabled/revoked. Do you really want to use the key?"
 msgstr "ID-a denboraz kanpo/ezgaitua/ukatua dago. Zihur zaude gakoa erabili nahi duzula?"
 
-#: ncrypt/crypt_gpgme.c:4299 ncrypt/pgpkey.c:650
+#: ncrypt/crypt_gpgme.c:4301 ncrypt/pgpkey.c:650
 #, fuzzy
 msgid "ID is not valid. Do you really want to use the key?"
 msgstr "ID-a ez da baliozkoa. Zihur zaude gakoa erabili nahi duzula?"
 
-#: ncrypt/crypt_gpgme.c:4302 ncrypt/pgpkey.c:653
+#: ncrypt/crypt_gpgme.c:4304 ncrypt/pgpkey.c:653
 #, fuzzy
 msgid "ID is only marginally valid. Do you really want to use the key?"
 msgstr "ID bakarrik marginalki erabilgarria da. Zihur zaude gakoa erabili nahi duzula?"
 
-#: ncrypt/crypt_gpgme.c:4310 ncrypt/pgpkey.c:646 ncrypt/smime.c:509
+#: ncrypt/crypt_gpgme.c:4312 ncrypt/pgpkey.c:646 ncrypt/smime.c:509
 #, fuzzy
 msgid "ID has undefined validity. Do you really want to use the key?"
 msgstr "ID-ak mugagabeko balioa du. Zihur zaude gakoa erabili nahi duzula?"
 
-#: ncrypt/crypt_gpgme.c:4370 ncrypt/crypt_gpgme.c:4479 ncrypt/pgpkey.c:872
+#: ncrypt/crypt_gpgme.c:4372 ncrypt/crypt_gpgme.c:4481 ncrypt/pgpkey.c:872
 #: ncrypt/pgpkey.c:995
 #, c-format
 msgid "Looking for keys matching \"%s\"..."
 msgstr "\"%s\" duten gakoen bila..."
 
-#: ncrypt/crypt_gpgme.c:4593 ncrypt/pgpkey.c:731 ncrypt/smime.c:811
+#: ncrypt/crypt_gpgme.c:4595 ncrypt/pgpkey.c:731 ncrypt/smime.c:811
 #, c-format
 msgid "No matching keys found for \"%s\""
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4644 ncrypt/pgp.c:1263
+#: ncrypt/crypt_gpgme.c:4646 ncrypt/pgp.c:1263
 #, c-format
 msgid "Use keyID = \"%s\" for %s?"
 msgstr "ID-gakoa=\"%s\" %s-rako erabili?"
 
-#: ncrypt/crypt_gpgme.c:4695 ncrypt/pgp.c:1312 ncrypt/smime.c:830
+#: ncrypt/crypt_gpgme.c:4697 ncrypt/pgp.c:1312 ncrypt/smime.c:830
 #: ncrypt/smime.c:938
 #, c-format
 msgid "Enter keyID for %s: "
 msgstr "%s-rako ID-gakoa sartu: "
 
-#: ncrypt/crypt_gpgme.c:4755 ncrypt/pgpkey.c:751
+#: ncrypt/crypt_gpgme.c:4757 ncrypt/pgpkey.c:751
 msgid "Please enter the key ID: "
 msgstr "Mesedez sar ezazu gako-ID-a: "
 
-#: ncrypt/crypt_gpgme.c:4768
+#: ncrypt/crypt_gpgme.c:4770
 #, fuzzy, c-format
 msgid "Error exporting key: %s\n"
 msgstr "Errorea gako argibideak eskuratzen: "
@@ -3997,90 +4060,90 @@ msgstr "Errorea gako argibideak eskuratzen: "
 #. MIME description for exported (attached) keys.
 #. You can translate this entry to a non-ASCII string (it will be encoded),
 #. but it may be safer to keep it untranslated.
-#: ncrypt/crypt_gpgme.c:4787
+#: ncrypt/crypt_gpgme.c:4789
 #, fuzzy, c-format
 msgid "PGP Key 0x%s."
 msgstr "PGP Gakoa %s."
 
-#: ncrypt/crypt_gpgme.c:4830
+#: ncrypt/crypt_gpgme.c:4832
 msgid "GPGME: OpenPGP protocol not available"
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4838
+#: ncrypt/crypt_gpgme.c:4840
 msgid "GPGME: CMS protocol not available"
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4876
+#: ncrypt/crypt_gpgme.c:4878
 #, fuzzy
 msgid "S/MIME (s)ign, sign (a)s, (p)gp, (c)lear, or (o)ppenc mode off? "
 msgstr "S/MIME (e)nkript, (s)ina, sin (a) honela, (b)iak, (p)gp or (g)arbitu?"
 
 #. L10N: S/MIME options (opportunistic encryption is on)
-#: ncrypt/crypt_gpgme.c:4878
+#: ncrypt/crypt_gpgme.c:4880
 msgid "sapco"
 msgstr "esabpg"
 
-#: ncrypt/crypt_gpgme.c:4885
+#: ncrypt/crypt_gpgme.c:4887
 #, fuzzy
 msgid "PGP (s)ign, sign (a)s, s/(m)ime, (c)lear, or (o)ppenc mode off? "
 msgstr "PGP (e)nkrippt, (s)ina, sin(a)tu hola, (b)iak, s/(m)ime edo (g)abitu?"
 
 #. L10N: PGP options (opportunistic encryption is on)
-#: ncrypt/crypt_gpgme.c:4887
+#: ncrypt/crypt_gpgme.c:4889
 msgid "samco"
 msgstr "esabmg"
 
 #. L10N: S/MIME options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4900
+#: ncrypt/crypt_gpgme.c:4902
 #, fuzzy
 msgid "S/MIME (e)ncrypt, (s)ign, sign (a)s, (b)oth, (p)gp, (c)lear, or (o)ppenc mode? "
 msgstr "S/MIME (e)nkript, (s)ina, sin (a) honela, (b)iak, (p)gp or (g)arbitu?"
 
 #. L10N: S/MIME options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4903
+#: ncrypt/crypt_gpgme.c:4905
 #, fuzzy
 msgid "esabpco"
 msgstr "esabpg"
 
 #. L10N: PGP options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4909
+#: ncrypt/crypt_gpgme.c:4911
 #, fuzzy
 msgid "PGP (e)ncrypt, (s)ign, sign (a)s, (b)oth, s/(m)ime, (c)lear, or (o)ppenc mode? "
 msgstr "PGP (e)nkrippt, (s)ina, sin(a)tu hola, (b)iak, s/(m)ime edo (g)abitu?"
 
 #. L10N: PGP options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4912
+#: ncrypt/crypt_gpgme.c:4914
 #, fuzzy
 msgid "esabmco"
 msgstr "esabmg"
 
-#: ncrypt/crypt_gpgme.c:4925
+#: ncrypt/crypt_gpgme.c:4927
 #, fuzzy
 msgid "S/MIME (e)ncrypt, (s)ign, sign (a)s, (b)oth, (p)gp or (c)lear? "
 msgstr "S/MIME (e)nkript, (s)ina, sin (a) honela, (b)iak, (p)gp or (g)arbitu?"
 
 #. L10N: S/MIME options
-#: ncrypt/crypt_gpgme.c:4927
+#: ncrypt/crypt_gpgme.c:4929
 #, fuzzy
 msgid "esabpc"
 msgstr "esabpg"
 
-#: ncrypt/crypt_gpgme.c:4934
+#: ncrypt/crypt_gpgme.c:4936
 #, fuzzy
 msgid "PGP (e)ncrypt, (s)ign, sign (a)s, (b)oth, s/(m)ime or (c)lear? "
 msgstr "PGP (e)nkrippt, (s)ina, sin(a)tu hola, (b)iak, s/(m)ime edo (g)abitu?"
 
 #. L10N: PGP options
-#: ncrypt/crypt_gpgme.c:4936
+#: ncrypt/crypt_gpgme.c:4938
 #, fuzzy
 msgid "esabmc"
 msgstr "esabmg"
 
-#: ncrypt/crypt_gpgme.c:5087
+#: ncrypt/crypt_gpgme.c:5089
 msgid "Failed to verify sender"
 msgstr "Huts bidaltzailea egiaztatzerakoan"
 
-#: ncrypt/crypt_gpgme.c:5090
+#: ncrypt/crypt_gpgme.c:5092
 msgid "Failed to figure out sender"
 msgstr "Ezin izan da biltzailea atzeman"
 
@@ -4481,7 +4544,7 @@ msgstr ""
 msgid "%s is an invalid news server specification!"
 msgstr "%s ez da baliozko datu-bidea"
 
-#: nntp.c:75 nntp.c:612 pop.c:1028 pop_lib.c:405
+#: nntp.c:75 nntp.c:612 pop.c:1031 pop_lib.c:405
 msgid "Server closed connection!"
 msgstr "Zerbitzariak konexioa itxi du!"
 
@@ -4647,16 +4710,18 @@ msgid "check mailboxes for new mail"
 msgstr "posta-kutxak eposta berrien bila arakatu"
 
 #: opcodes.h:47
-msgid "attach file(s) to this message"
+#, fuzzy
+msgid "attach files to this message"
 msgstr "fitxategia(k) erantsi mezu honetara"
 
 #: opcodes.h:48
-msgid "attach message(s) to this message"
+#, fuzzy
+msgid "attach messages to this message"
 msgstr "mezua(k) erantsi mezu honetara"
 
 #: opcodes.h:49
 #, fuzzy
-msgid "attach news article(s) to this message"
+msgid "attach news articles to this message"
 msgstr "fitxategia(k) erantsi mezu honetara"
 
 #: opcodes.h:50
@@ -5500,7 +5565,8 @@ msgid "extract supported public keys"
 msgstr "onartutako gako publikoak atera"
 
 #: opcodes.h:255
-msgid "wipe passphrase(s) from memory"
+#, fuzzy
+msgid "wipe passphrases from memory"
 msgstr "pasahitza(k) memoriatik ezabatu"
 
 #: opcodes.h:259
@@ -5849,18 +5915,20 @@ msgstr "Ez dago posta berririk POP postakutxan."
 msgid "Delete messages from server?"
 msgstr "Zerbitzaritik mezuak ezabatu?"
 
-#: pop.c:954
-#, c-format
-msgid "Reading new messages (%d bytes)..."
-msgstr "Mezu berriak irakurtzen (%d byte)..."
+#: pop.c:955
+#, fuzzy, c-format
+msgid "Reading new messages (%d byte)..."
+msgid_plural "Reading new messages (%d bytes)..."
+msgstr[0] "Mezu berriak irakurtzen (%d byte)..."
+msgstr[1] "Mezu berriak irakurtzen (%d byte)..."
 
-#: pop.c:997
+#: pop.c:1000
 msgid "Error while writing mailbox!"
 msgstr "Postakutxa idazterakoan errorea!"
 
 #. L10N: The plural is picked by the second numerical argument, i.e.
 #. * the %d right before 'messages', i.e. the total number of messages.
-#: pop.c:1003
+#: pop.c:1006
 #, fuzzy, c-format
 msgid "%s [%d of %d message read]"
 msgid_plural "%s [%d of %d messages read]"
@@ -6004,49 +6072,56 @@ msgstr "Komandora hodia egin: "
 msgid "I don't know how to print %s attachments!"
 msgstr "Ez dakit nola inprimatu %s gehigarriak!"
 
-#: recvattach.c:841
-msgid "Print tagged attachment(s)?"
-msgstr "Markaturiko mezua(k) inprimatu?"
+#. L10N: Although we now the precise number of tagged messages, we
+#. do not show it to the user.  So feel free to use a "generic
+#. plural" as plural translation if your language has one.
+#: recvattach.c:852
+#, fuzzy, c-format
+msgid "Print tagged attachment?"
+msgid_plural "Print %d tagged attachments?"
+msgstr[0] "Markaturiko mezua(k) inprimatu?"
+msgstr[1] "Markaturiko mezua(k) inprimatu?"
 
-#: recvattach.c:842
+#: recvattach.c:853
+#, c-format
 msgid "Print attachment?"
 msgstr "Gehigarria inprimatu?"
 
-#: recvattach.c:900
+#: recvattach.c:913
 msgid "Structural changes to decrypted attachments are not supported"
 msgstr ""
 
-#: recvattach.c:1046
+#: recvattach.c:1059
 msgid "Can't decrypt encrypted message!"
 msgstr "Ezin da enkriptaturiko mezua desenkriptratu!"
 
-#: recvattach.c:1172
+#: recvattach.c:1185
 msgid "Attachments"
 msgstr "Gehigarriak"
 
-#: recvattach.c:1210
+#: recvattach.c:1223
 msgid "There are no subparts to show!"
 msgstr "Hemen ez dago erakusteko azpizatirik!"
 
-#: recvattach.c:1265
+#: recvattach.c:1278
 msgid "Can't delete attachment from POP server."
 msgstr "Ezi da gehigarria POP zerbitzaritik ezabatu."
 
-#: recvattach.c:1274
+#: recvattach.c:1287
 #, fuzzy
 msgid "Can't delete attachment from news server."
 msgstr "Ezi da gehigarria POP zerbitzaritik ezabatu."
 
-#: recvattach.c:1281
+#: recvattach.c:1294
 msgid "Deletion of attachments from encrypted messages is unsupported."
 msgstr "Enkriptaturiko mezuetatik gehigarriak ezabatzea ez da onartzen."
 
-#: recvattach.c:1287
+#: recvattach.c:1300
 #, fuzzy
 msgid "Deletion of attachments from signed messages may invalidate the signature."
 msgstr "Enkriptaturiko mezuetatik gehigarriak ezabatzea ez da onartzen."
 
-#: recvattach.c:1305 recvattach.c:1320
+#: recvattach.c:1318 recvattach.c:1333
 msgid "Only deletion of multipart attachments is supported."
 msgstr "Zati anitzetako gehigarrien ezabaketa bakarrik onartzen da."
 
@@ -6463,3 +6538,15 @@ msgstr "Konpilazio aukerak:"
 #: version.c:404
 msgid "Compile options:"
 msgstr "Konpilazio aukerak:"
+
+#, fuzzy
+#~ msgid "Cannot delete message(s)"
+#~ msgstr "desezabatu mezua(k)"
+
+#, fuzzy
+#~ msgid "Cannot undelete message(s)"
+#~ msgstr "desezabatu mezua(k)"
+
+#, fuzzy
+#~ msgid "messages not deleted"
+#~ msgstr "Mezu ezabatuak markatzen..."

--- a/po/fr.po
+++ b/po/fr.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neomutt-20180512\n"
 "Report-Msgid-Bugs-To: neomutt-devel@neomutt.org\n"
-"POT-Creation-Date: 2018-05-20 02:02+0000\n"
+"POT-Creation-Date: 2018-05-22 14:18+0000\n"
 "PO-Revision-Date: 2017-02-10 12:46+0100\n"
 "Last-Translator: Vincent Lefevre <vincent@vinc17.net>\n"
 "Language-Team: Vincent Lefevre <vincent@vinc17.net>\n"
@@ -53,7 +53,7 @@ msgstr "Sélectionner"
 
 #: addrbook.c:52 browser.c:75 browser.c:87 compose.c:160 compose.c:172
 #: conn/ssl.c:1041 conn/ssl_gnutls.c:793 curs_main.c:748 curs_main.c:761
-#: history.c:106 ncrypt/crypt_gpgme.c:4219 ncrypt/pgpkey.c:547
+#: history.c:106 ncrypt/crypt_gpgme.c:4221 ncrypt/pgpkey.c:547
 #: ncrypt/smime.c:477 pager.c:2141 postpone.c:65 query.c:72 recvattach.c:70
 msgid "Help"
 msgstr "Aide"
@@ -727,7 +727,7 @@ msgstr "Sécurité : "
 #. * Since it shares the row with "Encrypt with:", it should not be longer
 #. * than 15-20 character cells.
 #.
-#: compose.c:138 ncrypt/crypt_gpgme.c:4947 ncrypt/pgp.c:1786
+#: compose.c:138 ncrypt/crypt_gpgme.c:4949 ncrypt/pgp.c:1786
 #: ncrypt/smime.c:2127
 msgid "Sign as: "
 msgstr "Signer avec : "
@@ -1286,7 +1286,7 @@ msgstr "(r)ejeter, accepter (u)ne fois"
 msgid "(r)eject, accept (o)nce"
 msgstr "(r)ejeter, accepter (u)ne fois"
 
-#: conn/ssl.c:1039 conn/ssl_gnutls.c:791 ncrypt/crypt_gpgme.c:4213
+#: conn/ssl.c:1039 conn/ssl_gnutls.c:791 ncrypt/crypt_gpgme.c:4215
 #: ncrypt/pgpkey.c:541 ncrypt/smime.c:473
 msgid "Exit  "
 msgstr "Quitter  "
@@ -1468,12 +1468,12 @@ msgstr "Aucune boîte aux lettres n'est ouverte."
 msgid "There are no messages."
 msgstr "Il n'y a pas de messages."
 
-#: curs_main.c:77 mx.c:1061 pager.c:73 recvattach.c:56
+#: curs_main.c:77 mx.c:1071 pager.c:73 recvattach.c:56
 msgid "Mailbox is read-only."
 msgstr "La boîte aux lettres est en lecture seule."
 
 # , c-format
-#: curs_main.c:79 pager.c:75 recvattach.c:1145
+#: curs_main.c:79 pager.c:75 recvattach.c:1158
 msgid "Function not permitted in attach-message mode."
 msgstr "Fonction non autorisée en mode attach-message."
 
@@ -1612,245 +1612,255 @@ msgid "That message is not visible."
 msgstr "Ce message n'est pas visible."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:1377 curs_main.c:2772 pager.c:2818
-msgid "Cannot delete message(s)"
+#. L10N: Due to the implementation details we do not know whether we
+#. delete zero, 1, 12, ... messages. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:1381 curs_main.c:2784 pager.c:2822
+#, fuzzy
+msgid "Cannot delete messages"
 msgstr "Impossible d'effacer le(s) message(s)"
 
-#: curs_main.c:1380
+#: curs_main.c:1384
 msgid "Delete messages matching: "
 msgstr "Effacer les messages correspondant à : "
 
-#: curs_main.c:1421
+#: curs_main.c:1425
 msgid "No limit pattern is in effect."
 msgstr "Aucun motif de limite n'est en vigueur."
 
 # , c-format
 #. L10N: ask for a limit to apply
-#: curs_main.c:1426
+#: curs_main.c:1430
 #, c-format
 msgid "Limit: %s"
 msgstr "Limite : %s"
 
-#: curs_main.c:1464
+#: curs_main.c:1468
 msgid "Limit to messages matching: "
 msgstr "Limiter aux messages correspondant à : "
 
-#: curs_main.c:1488
+#: curs_main.c:1492
 msgid "To view all messages, limit to \"all\"."
 msgstr "Pour voir tous les messages, limiter à \"all\"."
 
-#: curs_main.c:1500 pager.c:2318
+#: curs_main.c:1504 pager.c:2318
 msgid "Quit NeoMutt?"
 msgstr "Quitter NeoMutt ?"
 
-#: curs_main.c:1596
+#: curs_main.c:1600
 msgid "Tag messages matching: "
 msgstr "Marquer les messages correspondant à : "
 
 #. L10N: CHECK_ACL
-#: curs_main.c:1606 curs_main.c:3203 pager.c:3137
-msgid "Cannot undelete message(s)"
+#. L10N: Due to the implementation details we do not know whether we
+#. undelete zero, 1, 12, ... messages. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:1614 curs_main.c:3223 pager.c:3145
+#, fuzzy
+msgid "Cannot undelete messages"
 msgstr "Impossible de récupérer le(s) message(s)"
 
-#: curs_main.c:1609
+#: curs_main.c:1617
 msgid "Undelete messages matching: "
 msgstr "Récupérer les messages correspondant à : "
 
-#: curs_main.c:1619
+#: curs_main.c:1627
 msgid "Untag messages matching: "
 msgstr "Démarquer les messages correspondant à : "
 
-#: curs_main.c:1653
+#: curs_main.c:1661
 msgid "Logged out of IMAP servers."
 msgstr "Déconnecté des serveurs IMAP."
 
-#: curs_main.c:1753
+#: curs_main.c:1761
 #, fuzzy
 msgid "No virtual folder, aborting."
 msgstr "Pas d'objet (Subject), abandon."
 
-#: curs_main.c:1761
+#: curs_main.c:1769
 msgid "Failed to read thread, aborting."
 msgstr ""
 
-#: curs_main.c:1793 mx.c:1458 mx.c:1475
+#: curs_main.c:1801 mx.c:1468 mx.c:1485
 #, fuzzy
 msgid "Folder doesn't support tagging, aborting."
 msgstr "Le serveur SMTP ne supporte pas l'authentification"
 
-#: curs_main.c:1808
+#: curs_main.c:1816
 #, fuzzy
 msgid "No tag specified, aborting."
 msgstr "Pas d'objet (Subject), abandon."
 
-#: curs_main.c:1820
+#: curs_main.c:1828
 #, c-format
 msgid "Update tags..."
 msgstr ""
 
-#: curs_main.c:1857
+#: curs_main.c:1865
 msgid "Failed to modify tags, aborting."
 msgstr ""
 
-#: curs_main.c:1898
+#: curs_main.c:1906
 #, fuzzy
 msgid "No query, aborting."
 msgstr "Pas d'objet (Subject), abandon."
 
-#: curs_main.c:1902 curs_main.c:1922 curs_main.c:1941
+#: curs_main.c:1910 curs_main.c:1930 curs_main.c:1949
 msgid "Failed to create query, aborting."
 msgstr ""
 
-#: curs_main.c:1911 curs_main.c:1930
+#: curs_main.c:1919 curs_main.c:1938
 msgid "Windowed queries disabled."
 msgstr ""
 
-#: curs_main.c:1916 curs_main.c:1935
+#: curs_main.c:1924 curs_main.c:1943
 msgid "No notmuch vfolder currently loaded."
 msgstr ""
 
-#: curs_main.c:1973
+#: curs_main.c:1981
 msgid "Open mailbox in read-only mode"
 msgstr "Ouvrir la boîte aux lettres en lecture seule"
 
-#: curs_main.c:1976
+#: curs_main.c:1984
 #, fuzzy
 msgid "Open virtual folder"
 msgstr "ouvrir un dossier différent"
 
-#: curs_main.c:1979
+#: curs_main.c:1987
 msgid "Open mailbox"
 msgstr "Ouvrir la boîte aux lettres"
 
-#: curs_main.c:1989
+#: curs_main.c:1997
 msgid "No mailboxes have new mail"
 msgstr "Pas de boîte aux lettres avec des nouveaux messages"
 
-#: curs_main.c:2036
+#: curs_main.c:2044
 #, fuzzy
 msgid "Open newsgroup in read-only mode"
 msgstr "Ouvrir la boîte aux lettres en lecture seule"
 
-#: curs_main.c:2038
+#: curs_main.c:2046
 msgid "Open newsgroup"
 msgstr ""
 
-#: curs_main.c:2141
+#: curs_main.c:2149
 #, fuzzy
 msgid "Exit NeoMutt without saving?"
 msgstr "Quitter NeoMutt sans sauvegarder ?"
 
-#: curs_main.c:2157
+#: curs_main.c:2165
 #, fuzzy
 msgid "Cannot break thread"
 msgstr "Impossible de lier les discussions"
 
-#: curs_main.c:2160 curs_main.c:2198 curs_main.c:2658 curs_main.c:2690
+#: curs_main.c:2168 curs_main.c:2206 curs_main.c:2666 curs_main.c:2698
 #: flags.c:376 thread.c:1078 thread.c:1134 thread.c:1202
 msgid "Threading is not enabled."
 msgstr "L'affichage des discussions n'est pas activé."
 
-#: curs_main.c:2173
+#: curs_main.c:2181
 msgid "Thread broken"
 msgstr "Discussion cassée"
 
-#: curs_main.c:2185
+#: curs_main.c:2193
 msgid "Thread cannot be broken, message is not part of a thread"
 msgstr "La discussion ne peut pas être cassée, le message n'est pas dans une discussion"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2195
+#: curs_main.c:2203
 msgid "Cannot link threads"
 msgstr "Impossible de lier les discussions"
 
-#: curs_main.c:2200
+#: curs_main.c:2208
 msgid "No Message-ID: header available to link thread"
 msgstr "Pas d'en-tête Message-ID: disponible pour lier la discussion"
 
-#: curs_main.c:2202
+#: curs_main.c:2210
 msgid "First, please tag a message to be linked here"
 msgstr "D'abord, veuillez marquer un message à lier ici"
 
-#: curs_main.c:2213
+#: curs_main.c:2221
 msgid "Threads linked"
 msgstr "Discussions liées"
 
-#: curs_main.c:2216
+#: curs_main.c:2224
 msgid "No thread linked"
 msgstr "Pas de discussion liée"
 
-#: curs_main.c:2252 curs_main.c:2278
+#: curs_main.c:2260 curs_main.c:2286
 msgid "You are on the last message."
 msgstr "Vous êtes sur le dernier message."
 
-#: curs_main.c:2260 curs_main.c:2305
+#: curs_main.c:2268 curs_main.c:2313
 msgid "No undeleted messages."
 msgstr "Pas de message non effacé."
 
-#: curs_main.c:2297 curs_main.c:2323
+#: curs_main.c:2305 curs_main.c:2331
 msgid "You are on the first message."
 msgstr "Vous êtes sur le premier message."
 
-#: curs_main.c:2395 menu.c:970 pager.c:2440 pattern.c:2110
+#: curs_main.c:2403 menu.c:970 pager.c:2440 pattern.c:2110
 msgid "Search wrapped to top."
 msgstr "La recherche est repartie du début."
 
-#: curs_main.c:2404 pager.c:2463 pattern.c:2121
+#: curs_main.c:2412 pager.c:2463 pattern.c:2121
 msgid "Search wrapped to bottom."
 msgstr "La recherche est repartie de la fin."
 
-#: curs_main.c:2447
+#: curs_main.c:2455
 msgid "No new messages in this limited view."
 msgstr "Pas de nouveaux messages dans cette vue limitée."
 
-#: curs_main.c:2449
+#: curs_main.c:2457
 msgid "No new messages."
 msgstr "Pas de nouveaux messages."
 
-#: curs_main.c:2454
+#: curs_main.c:2462
 msgid "No unread messages in this limited view."
 msgstr "Pas de messages non lus dans cette vue limitée."
 
-#: curs_main.c:2456
+#: curs_main.c:2464
 msgid "No unread messages."
 msgstr "Pas de messages non lus."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2474
+#: curs_main.c:2482
 msgid "Cannot flag message"
 msgstr "Impossible de marquer le message"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2513 pager.c:3100
+#: curs_main.c:2521 pager.c:3104
 msgid "Cannot toggle new"
 msgstr "Impossible d'inverser l'indic. 'nouveau'"
 
-#: curs_main.c:2590
+#: curs_main.c:2598
 msgid "No more threads."
 msgstr "Pas d'autres discussions."
 
-#: curs_main.c:2592
+#: curs_main.c:2600
 msgid "You are on the first thread."
 msgstr "Vous êtes sur la première discussion."
 
-#: curs_main.c:2676
+#: curs_main.c:2684
 #, fuzzy
 msgid "Thread contains unread or flagged messages."
 msgstr "Cette discussion contient des messages non-lus."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2726 pager.c:2784
+#: curs_main.c:2734 pager.c:2784
 msgid "Cannot delete message"
 msgstr "Impossible d'effacer le message"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2838
+#: curs_main.c:2850
 msgid "Cannot edit message"
 msgstr "Impossible d'éditer le message"
 
 #. L10N: This is displayed when the x-label on one or more
 #. * messages is edited.
-#: curs_main.c:2900 pager.c:3200
+#: curs_main.c:2912 pager.c:3208
 #, fuzzy, c-format
 msgid "%d label changed."
 msgid_plural "%d labels changed."
@@ -1860,53 +1870,58 @@ msgstr[1] "%d labels ont changé."
 #. L10N: This is displayed when editing an x-label, but no messages
 #. * were updated.  Possibly due to canceling at the prompt or if the new
 #. * label is the same as the old label.
-#: curs_main.c:2907 pager.c:3204
+#: curs_main.c:2919 pager.c:3212
 msgid "No labels changed."
 msgstr "Aucun label n'a changé."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:3006
-msgid "Cannot mark message(s) as read"
+#. L10N: Due to the implementation details we do not know whether we
+#. mark zero, 1, 12, ... messages as read. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:3022
+#, fuzzy
+msgid "Cannot mark messages as read"
 msgstr "Impossible de marquer le(s) message(s) comme lu(s)"
 
 # , c-format
 #. L10N: This is the prompt for <mark-message>.  Whatever they
 #. enter will be prefixed by $mark_macro_prefix and will become
 #. a macro hotkey to jump to the currently selected message.
-#: curs_main.c:3042
+#: curs_main.c:3058
 msgid "Enter macro stroke: "
 msgstr "Entrez les touches de la macro : "
 
 #. L10N: "message hotkey" is the key bindings menu description of a
 #. macro created by <mark-message>.
-#: curs_main.c:3050
+#: curs_main.c:3066
 msgid "message hotkey"
 msgstr "hotkey (marque-page)"
 
 #. L10N: This is echoed after <mark-message> creates a new hotkey
 #. macro.  %s is the hotkey string ($mark_macro_prefix followed
 #. by whatever they typed at the prompt.)
-#: curs_main.c:3055
+#: curs_main.c:3071
 #, c-format
 msgid "Message bound to %s."
 msgstr "Message lié à %s."
 
 #. L10N: This error is printed if <mark-message> cannot find a
 #. Message-ID for the currently selected message in the index.
-#: curs_main.c:3063
+#: curs_main.c:3079
 msgid "No message ID to macro."
 msgstr "Pas de Message-ID pour la macro."
 
-#: curs_main.c:3105 pager.c:2961 recvattach.c:1388
+#: curs_main.c:3121 pager.c:2965 recvattach.c:1401
 msgid "Reply by mail as poster prefers?"
 msgstr ""
 
-#: curs_main.c:3108 pager.c:2927 pager.c:2939 pager.c:2964
+#: curs_main.c:3124 pager.c:2931 pager.c:2943 pager.c:2968
 msgid "Posting to this group not allowed, may be moderated. Continue?"
 msgstr ""
 
 #. L10N: CHECK_ACL
-#: curs_main.c:3173 pager.c:3120
+#: curs_main.c:3189 pager.c:3124
 msgid "Cannot undelete message"
 msgstr "Impossible de récupérer le message"
 
@@ -2112,12 +2127,34 @@ msgid "[-- Error: message/external-body has no access-type parameter --]\n"
 msgstr "[-- Erreur : message/external-body n'a pas de paramètre access-type --]\n"
 
 # , c-format
-#: handler.c:1611
+#. L10N: If the translation of this string is a multi line string, then
+#. each line should start with "[-- " and end with " --]".
+#. The first "%s/%s" is a MIME type, e.g. "text/plain". The last %s
+#. expands to a date as returned by `mutt_date_parse_date()`.
+#.
+#. Note: The size argument printed is not the actual number as passed
+#. to gettext but the prettified version, e.g. size = 2048 will be
+#. printed as 2K.  Your language might be sensitive to that: For
+#. example although '1K' and '1024' represent the same number your
+#. language might inflect the noun 'byte' differently.
+#.
+#. Sadly, we cannot do anything about that at the moment besides
+#. passing the precise size in bytes. If you are interested the
+#. function responsible for the prettification is
+#. mutt_str_pretty_size() in mutt/string.c.
+#.
+#: handler.c:1624
 #, fuzzy, c-format
 msgid ""
+"[-- This %s/%s attachment (size %s byte) has been deleted --]\n"
+"[-- on %s --]\n"
+msgid_plural ""
 "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
 "[-- on %s --]\n"
-msgstr ""
+msgstr[0] ""
+"[-- Cet attachement %s/%s (taille %s octets) a été effacé --]\n"
+"[-- le %s --]\n"
+msgstr[1] ""
 "[-- Cet attachement %s/%s (taille %s octets) a été effacé --]\n"
 "[-- le %s --]\n"
 
@@ -2126,10 +2163,23 @@ msgstr ""
 #. each line should start with "[-- " and end with " --]".
 #. The first "%s/%s" is a MIME type, e.g. "text/plain".
 #.
-#: handler.c:1620
+#. Note: The size argument printed is not the actual number as passed
+#. to gettext but the prettified version, e.g. size = 2048 will be
+#. printed as 2K.  Your language might be sensitive to that: For
+#. example although '1K' and '1024' represent the same number your
+#. language might inflect the noun 'byte' differently.
+#.
+#. Sadly, we cannot do anything about that at the moment besides
+#. passing the precise size in bytes. If you are interested the
+#. function responsible for the prettification is
+#. mutt_str_pretty_size() in mutt/string.c.
+#.
+#: handler.c:1648
 #, fuzzy, c-format
-msgid "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
-msgstr "[-- Cet attachement %s/%s (taille %s octets) a été effacé --]\n"
+msgid "[-- This %s/%s attachment (size %s byte) has been deleted --]\n"
+msgid_plural "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
+msgstr[0] "[-- Cet attachement %s/%s (taille %s octets) a été effacé --]\n"
+msgstr[1] "[-- Cet attachement %s/%s (taille %s octets) a été effacé --]\n"
 
 # , c-format
 #. L10N: If the translation of this string is a multi line string, then
@@ -2140,7 +2190,7 @@ msgstr "[-- Cet attachement %s/%s (taille %s octets) a été effacé --]\n"
 #. Caution: Argument three %3$ is also defined but should not be used
 #. in this translation!
 #.
-#: handler.c:1637
+#: handler.c:1667
 #, fuzzy
 msgid ""
 "[-- This %s/%s attachment has been deleted --]\n"
@@ -2154,18 +2204,18 @@ msgstr ""
 #. each line should start with "[-- " and end with " --]".
 #. The first "%s/%s" is a MIME type, e.g. "text/plain".
 #.
-#: handler.c:1646
+#: handler.c:1676
 #, fuzzy, c-format
 msgid "[-- This %s/%s attachment has been deleted --]\n"
 msgstr "[-- Cet attachement %s/%s a été effacé --]\n"
 
 # , c-format
-#: handler.c:1656
+#: handler.c:1686
 #, c-format
 msgid "[-- name: %s --]\n"
 msgstr "[-- nom : %s --]\n"
 
-#: handler.c:1672
+#: handler.c:1702
 #, fuzzy, c-format
 msgid ""
 "[-- This %s/%s attachment is not included, --]\n"
@@ -2175,7 +2225,7 @@ msgstr ""
 "[-- Cet attachement %s/%s n'est pas inclus, --]\n"
 "[-- et la source externe indiquée a expiré. --]\n"
 
-#: handler.c:1693
+#: handler.c:1723
 #, fuzzy, c-format
 msgid ""
 "[-- This %s/%s attachment is not included, --]\n"
@@ -2184,55 +2234,55 @@ msgstr ""
 "[-- Cet attachement %s/%s n'est pas inclus, --]\n"
 "[-- et l'access-type %s indiqué n'est pas supporté --]\n"
 
-#: handler.c:1822
+#: handler.c:1852
 #, fuzzy
 msgid "Unable to open memory stream!"
 msgstr "Impossible d'ouvrir le fichier temporaire !"
 
-#: handler.c:1831
+#: handler.c:1861
 msgid "Unable to open temporary file!"
 msgstr "Impossible d'ouvrir le fichier temporaire !"
 
-#: handler.c:1881
+#: handler.c:1911
 msgid "failed to re-open memstream!"
 msgstr ""
 
-#: handler.c:2013
+#: handler.c:2043
 msgid "Error: multipart/signed has no protocol."
 msgstr "Erreur : multipart/signed n'a pas de protocole."
 
 # , c-format
-#: handler.c:2076
+#: handler.c:2106
 #, fuzzy
 msgid "[-- This is an attachment (use '%3$s' to view this part) --]\n"
 msgstr "[-- Ceci est un attachement (utilisez '%3$s' pour voir cette partie) --]\n"
 
 # , c-format
-#: handler.c:2082
+#: handler.c:2112
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported (use '%s' to view this part) --]\n"
 msgstr "[-- %s/%s n'est pas disponible (utilisez '%s' pour voir cette partie) --]\n"
 
-#: handler.c:2087
+#: handler.c:2117
 #, fuzzy
 msgid "[-- This is an attachment (need 'view-attachments' bound to key!) --]\n"
 msgstr "[-- Ceci est un attachement (la fonction 'view-attachments' doit être affectée à une touche !) --]\n"
 
 #. L10N: %s/%s is a MIME type, e.g. "text/plain".
-#: handler.c:2091
+#: handler.c:2121
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported (need 'view-attachments' bound to key!) --]\n"
 msgstr "[-- %s/%s n'est pas disponible (la fonction 'view-attachments' doit être affectée à une touche !) --]\n"
 
 # , c-format
-#: handler.c:2098
+#: handler.c:2128
 #, fuzzy
 msgid "[-- This is an attachment --]\n"
 msgstr "[-- Ceci est un attachement --]\n"
 
 # , c-format
 #. L10N: %s/%s is a MIME type, e.g. "text/plain".
-#: handler.c:2101
+#: handler.c:2131
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported --]\n"
 msgstr "[-- %s/%s n'est pas disponible --]\n"
@@ -2553,7 +2603,7 @@ msgstr "Le serveur SMTP ne supporte pas l'authentification"
 msgid "Invalid IMAP flags"
 msgstr "Invalide    "
 
-#: imap/message.c:477 mx.c:1326
+#: imap/message.c:477 mx.c:1336
 msgid "Integer overflow -- can't allocate memory."
 msgstr "Dépassement de capacité sur entier -- impossible d'allouer la mémoire."
 
@@ -3363,27 +3413,37 @@ msgid "Reading from %s interrupted..."
 msgstr "Recherche interrompue."
 
 # , c-format
-#: mx.c:634
-msgid "message(s) not deleted"
-msgstr "message(s) non effacé(s)"
+#. L10N: Although we now the precise number of messages, we do not show it to the user.
+#. So feel free to use a "generic plural" as plural translation if your language has one.
+#.
+#: mx.c:639
+#, fuzzy
+msgid "message not deleted"
+msgid_plural "messages not deleted"
+msgstr[0] "message(s) non effacé(s)"
+msgstr[1] "message(s) non effacé(s)"
 
 # , c-format
-#: mx.c:671
+#: mx.c:676
 msgid "Can't open trash folder"
 msgstr "Impossible d'ouvrir la corbeille"
 
-#: mx.c:710
+#: mx.c:715
 msgid "Mark all articles read?"
 msgstr ""
 
 # , c-format
-#: mx.c:754
-#, c-format
-msgid "Move %d read messages to %s?"
-msgstr "Déplacer %d messages lus dans %s ?"
+#. L10N: The first argument is the number of read messages to be
+#. moved, the second argument is the target mailbox.
+#: mx.c:762
+#, fuzzy, c-format
+msgid "Move %d read message to %s?"
+msgid_plural "Move %d read messages to %s?"
+msgstr[0] "Déplacer %d messages lus dans %s ?"
+msgstr[1] "Déplacer %d messages lus dans %s ?"
 
 # , c-format
-#: mx.c:771 mx.c:1077
+#: mx.c:781 mx.c:1087
 #, fuzzy, c-format
 msgid "Purge %d deleted message?"
 msgid_plural "Purge %d deleted messages?"
@@ -3391,44 +3451,44 @@ msgstr[0] "Effacer %d message marqué à effacer ?"
 msgstr[1] "Effacer %d messages marqués à effacer ?"
 
 # , c-format
-#: mx.c:793
+#: mx.c:803
 #, c-format
 msgid "Moving read messages to %s..."
 msgstr "Déplacement des messages lus dans %s..."
 
-#: mx.c:859 mx.c:1068
+#: mx.c:869 mx.c:1078
 msgid "Mailbox is unchanged."
 msgstr "La boîte aux lettres est inchangée."
 
 # , c-format
-#: mx.c:914
+#: mx.c:924
 #, c-format
 msgid "%d kept, %d moved, %d deleted."
 msgstr "%d gardé(s), %d déplacé(s), %d effacé(s)."
 
 # , c-format
-#: mx.c:917 mx.c:1130
+#: mx.c:927 mx.c:1140
 #, c-format
 msgid "%d kept, %d deleted."
 msgstr "%d gardé(s), %d effacé(s)."
 
 # , c-format
-#: mx.c:1052
+#: mx.c:1062
 #, c-format
 msgid " Press '%s' to toggle write"
 msgstr " Appuyez sur '%s' pour inverser l'écriture autorisée"
 
-#: mx.c:1054
+#: mx.c:1064
 msgid "Use 'toggle-write' to re-enable write!"
 msgstr "Utilisez 'toggle-write' pour réautoriser l'écriture !"
 
 # , c-format
-#: mx.c:1056
+#: mx.c:1066
 #, c-format
 msgid "Mailbox is marked unwritable. %s"
 msgstr "La boîte aux lettres est protégée contre l'écriture. %s"
 
-#: mx.c:1124
+#: mx.c:1134
 msgid "Mailbox checkpointed."
 msgstr "Boîte aux lettres vérifiée."
 
@@ -3442,52 +3502,57 @@ msgstr " (heure courante : %c)"
 msgid "[-- %s output follows%s --]\n"
 msgstr "[-- La sortie %s suit%s --]\n"
 
-#: ncrypt/crypt.c:95
-msgid "Passphrase(s) forgotten."
+#. L10N: Due to the implementation details (e.g. some passwords are managed
+#. by gpg-agent) we cannot know whether we forgot zero, 1, 12, ...
+#. passwords. So in English we use "Passphrases". Your language might
+#. have other means to express this.
+#: ncrypt/crypt.c:100
+#, fuzzy
+msgid "Passphrases forgotten."
 msgstr "Phrase(s) de passe oubliée(s)."
 
-#: ncrypt/crypt.c:155
+#: ncrypt/crypt.c:161
 msgid "Inline PGP can't be used with attachments.  Revert to PGP/MIME?"
 msgstr "PGP en ligne est impossible avec format=flowed. Utiliser PGP/MIME ?"
 
-#: ncrypt/crypt.c:159
+#: ncrypt/crypt.c:165
 msgid "Mail not sent: inline PGP can't be used with attachments."
 msgstr "Message non envoyé : PGP en ligne est impossible avec format=flowed."
 
-#: ncrypt/crypt.c:166
+#: ncrypt/crypt.c:172
 msgid "Inline PGP can't be used with format=flowed.  Revert to PGP/MIME?"
 msgstr "PGP en ligne est impossible avec format=flowed. Utiliser PGP/MIME ?"
 
-#: ncrypt/crypt.c:170
+#: ncrypt/crypt.c:176
 msgid "Mail not sent: inline PGP can't be used with format=flowed."
 msgstr "Message non envoyé : PGP en ligne est impossible avec format=flowed."
 
-#: ncrypt/crypt.c:180 ncrypt/cryptglue.c:125 ncrypt/pgpkey.c:589
+#: ncrypt/crypt.c:186 ncrypt/cryptglue.c:125 ncrypt/pgpkey.c:589
 #: ncrypt/pgpkey.c:782
 msgid "Invoking PGP..."
 msgstr "Appel de PGP..."
 
-#: ncrypt/crypt.c:192
+#: ncrypt/crypt.c:198
 msgid "Message can't be sent inline.  Revert to using PGP/MIME?"
 msgstr "Le message ne peut pas être envoyé en ligne. Utiliser PGP/MIME ?"
 
-#: ncrypt/crypt.c:194 send.c:1824
+#: ncrypt/crypt.c:200 send.c:1824
 msgid "Mail not sent."
 msgstr "Message non envoyé."
 
-#: ncrypt/crypt.c:540
+#: ncrypt/crypt.c:546
 msgid "S/MIME messages with no hints on content are unsupported."
 msgstr "Les messages S/MIME sans indication sur le contenu ne sont pas supportés."
 
-#: ncrypt/crypt.c:754 ncrypt/crypt.c:795
+#: ncrypt/crypt.c:760 ncrypt/crypt.c:801
 msgid "Trying to extract PGP keys...\n"
 msgstr "Tentative d'extraction de clés PGP...\n"
 
-#: ncrypt/crypt.c:776 ncrypt/crypt.c:816
+#: ncrypt/crypt.c:782 ncrypt/crypt.c:822
 msgid "Trying to extract S/MIME certificates...\n"
 msgstr "Tentative d'extraction de certificats S/MIME...\n"
 
-#: ncrypt/crypt.c:976
+#: ncrypt/crypt.c:982
 #, c-format
 msgid ""
 "[-- Error: Unknown multipart/signed protocol %s! --]\n"
@@ -3496,7 +3561,7 @@ msgstr ""
 "[-- Erreur : Protocole multipart/signed %s inconnu ! --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1016
+#: ncrypt/crypt.c:1022
 msgid ""
 "[-- Error: Missing or bad-format multipart/signed signature! --]\n"
 "\n"
@@ -3504,7 +3569,7 @@ msgstr ""
 "[-- Erreur : Signature multipart/signed manquante ou mauvais format ! --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1058
+#: ncrypt/crypt.c:1064
 #, c-format
 msgid ""
 "[-- Warning: We can't verify %s/%s signatures. --]\n"
@@ -3513,7 +3578,7 @@ msgstr ""
 "[-- Attention : les signatures %s/%s ne peuvent pas être vérifiées. --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1070
+#: ncrypt/crypt.c:1076
 msgid ""
 "[-- The following data is signed --]\n"
 "\n"
@@ -3521,7 +3586,7 @@ msgstr ""
 "[-- Les données suivantes sont signées --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1075
+#: ncrypt/crypt.c:1081
 msgid ""
 "[-- Warning: Can't find any signatures. --]\n"
 "\n"
@@ -3529,7 +3594,7 @@ msgstr ""
 "[-- Attention : Impossible de trouver des signatures. --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1081
+#: ncrypt/crypt.c:1087
 msgid ""
 "\n"
 "[-- End of signed data --]\n"
@@ -3585,7 +3650,7 @@ msgstr ""
 msgid "error reading data object: %s\n"
 msgstr "erreur lors de la lecture de l'objet : %s\n"
 
-#: ncrypt/crypt_gpgme.c:662 ncrypt/crypt_gpgme.c:3848 ncrypt/pgpkey.c:585
+#: ncrypt/crypt_gpgme.c:662 ncrypt/crypt_gpgme.c:3850 ncrypt/pgpkey.c:585
 #: ncrypt/pgpkey.c:768
 msgid "Can't create temporary file"
 msgstr "Impossible de créer le fichier temporaire"
@@ -3942,28 +4007,30 @@ msgstr "[Invalide]"
 
 #. L10N: This is printed after "Key Type: " and looks like this:
 #. *       PGP, 2048 bit RSA
-#: ncrypt/crypt_gpgme.c:3670 ncrypt/crypt_gpgme.c:3808
-#, c-format
+#: ncrypt/crypt_gpgme.c:3670 ncrypt/crypt_gpgme.c:3810
+#, fuzzy, c-format
 msgid "%s, %lu bit %s\n"
-msgstr "%s, %lu bits, %s\n"
+msgid_plural "%s, %lu bit %s\n"
+msgstr[0] "%s, %lu bits, %s\n"
+msgstr[1] "%s, %lu bits, %s\n"
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3678 ncrypt/crypt_gpgme.c:3815
+#: ncrypt/crypt_gpgme.c:3678 ncrypt/crypt_gpgme.c:3817
 msgid "encryption"
 msgstr "chiffrage"
 
 #: ncrypt/crypt_gpgme.c:3679 ncrypt/crypt_gpgme.c:3685
-#: ncrypt/crypt_gpgme.c:3816 ncrypt/crypt_gpgme.c:3821
+#: ncrypt/crypt_gpgme.c:3818 ncrypt/crypt_gpgme.c:3823
 msgid ", "
 msgstr ", "
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3684 ncrypt/crypt_gpgme.c:3820
+#: ncrypt/crypt_gpgme.c:3684 ncrypt/crypt_gpgme.c:3822
 msgid "signing"
 msgstr "signature"
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3690 ncrypt/crypt_gpgme.c:3825
+#: ncrypt/crypt_gpgme.c:3690 ncrypt/crypt_gpgme.c:3827
 msgid "certification"
 msgstr "certification"
 
@@ -3983,66 +4050,66 @@ msgid "[Disabled]"
 msgstr "[Désactivée]"
 
 # , c-format
-#: ncrypt/crypt_gpgme.c:3851
+#: ncrypt/crypt_gpgme.c:3853
 msgid "Collecting data..."
 msgstr "Récupération des données..."
 
 # , c-format
-#: ncrypt/crypt_gpgme.c:3876
+#: ncrypt/crypt_gpgme.c:3878
 #, c-format
 msgid "Error finding issuer key: %s\n"
 msgstr "Erreur en cherchant la clé de l'émetteur : %s\n"
 
-#: ncrypt/crypt_gpgme.c:3885
+#: ncrypt/crypt_gpgme.c:3887
 msgid "Error: certification chain too long - stopping here\n"
 msgstr "Erreur : chaîne de certification trop longue - on arrête ici\n"
 
 # , c-format
-#: ncrypt/crypt_gpgme.c:3895 ncrypt/pgpkey.c:608
+#: ncrypt/crypt_gpgme.c:3897 ncrypt/pgpkey.c:608
 #, c-format
 msgid "Key ID: 0x%s"
 msgstr "ID de la clé : 0x%s"
 
-#: ncrypt/crypt_gpgme.c:3990
+#: ncrypt/crypt_gpgme.c:3992
 #, c-format
 msgid "gpgme_new failed: %s"
 msgstr "gpgme_new a échoué : %s"
 
-#: ncrypt/crypt_gpgme.c:4028 ncrypt/crypt_gpgme.c:4079
+#: ncrypt/crypt_gpgme.c:4030 ncrypt/crypt_gpgme.c:4081
 #, c-format
 msgid "gpgme_op_keylist_start failed: %s"
 msgstr "gpgme_op_keylist_start a échoué : %s"
 
-#: ncrypt/crypt_gpgme.c:4067 ncrypt/crypt_gpgme.c:4109
+#: ncrypt/crypt_gpgme.c:4069 ncrypt/crypt_gpgme.c:4111
 #, c-format
 msgid "gpgme_op_keylist_next failed: %s"
 msgstr "gpgme_op_keylist_next a échoué : %s"
 
-#: ncrypt/crypt_gpgme.c:4185
+#: ncrypt/crypt_gpgme.c:4187
 msgid "All matching keys are marked expired/revoked."
 msgstr "Toutes les clés correspondantes sont marquées expirées/révoquées."
 
-#: ncrypt/crypt_gpgme.c:4215 ncrypt/pgpkey.c:543 ncrypt/smime.c:475
+#: ncrypt/crypt_gpgme.c:4217 ncrypt/pgpkey.c:543 ncrypt/smime.c:475
 msgid "Select  "
 msgstr "Sélectionner  "
 
-#: ncrypt/crypt_gpgme.c:4217 ncrypt/pgpkey.c:545
+#: ncrypt/crypt_gpgme.c:4219 ncrypt/pgpkey.c:545
 msgid "Check key  "
 msgstr "Vérifier clé  "
 
-#: ncrypt/crypt_gpgme.c:4233
+#: ncrypt/crypt_gpgme.c:4235
 msgid "PGP and S/MIME keys matching"
 msgstr "clés PGP et S/MIME correspondant à"
 
-#: ncrypt/crypt_gpgme.c:4235
+#: ncrypt/crypt_gpgme.c:4237
 msgid "PGP keys matching"
 msgstr "clés PGP correspondant à"
 
-#: ncrypt/crypt_gpgme.c:4237
+#: ncrypt/crypt_gpgme.c:4239
 msgid "S/MIME keys matching"
 msgstr "clés S/MIME correspondant à"
 
-#: ncrypt/crypt_gpgme.c:4239
+#: ncrypt/crypt_gpgme.c:4241
 msgid "keys matching"
 msgstr "clés correspondant à"
 
@@ -4050,75 +4117,75 @@ msgstr "clés correspondant à"
 #. %1$s is one of the previous four entries.
 #. %2$s is an address.
 #. e.g. "S/MIME keys matching <me@mutt.org>."
-#: ncrypt/crypt_gpgme.c:4246
+#: ncrypt/crypt_gpgme.c:4248
 #, c-format
 msgid "%s <%s>."
 msgstr "%s <%s>."
 
 #. L10N:
 #. e.g. 'S/MIME keys matching "Michael Elkins".'
-#: ncrypt/crypt_gpgme.c:4250
+#: ncrypt/crypt_gpgme.c:4252
 #, c-format
 msgid "%s \"%s\"."
 msgstr "%s \"%s\"."
 
-#: ncrypt/crypt_gpgme.c:4277 ncrypt/pgpkey.c:628
+#: ncrypt/crypt_gpgme.c:4279 ncrypt/pgpkey.c:628
 msgid "This key can't be used: expired/disabled/revoked."
 msgstr "Cette clé ne peut pas être utilisée : expirée/désactivée/révoquée."
 
 # , c-format
-#: ncrypt/crypt_gpgme.c:4290 ncrypt/pgpkey.c:640 ncrypt/smime.c:505
+#: ncrypt/crypt_gpgme.c:4292 ncrypt/pgpkey.c:640 ncrypt/smime.c:505
 #, fuzzy
 msgid "ID is expired/disabled/revoked. Do you really want to use the key?"
 msgstr "L'ID est expiré/désactivé/révoqué. Voulez-vous vraiment utiliser la clé ?"
 
 # , c-format
-#: ncrypt/crypt_gpgme.c:4299 ncrypt/pgpkey.c:650
+#: ncrypt/crypt_gpgme.c:4301 ncrypt/pgpkey.c:650
 #, fuzzy
 msgid "ID is not valid. Do you really want to use the key?"
 msgstr "L'ID n'est pas valide. Voulez-vous vraiment utiliser la clé ?"
 
 # , c-format
-#: ncrypt/crypt_gpgme.c:4302 ncrypt/pgpkey.c:653
+#: ncrypt/crypt_gpgme.c:4304 ncrypt/pgpkey.c:653
 #, fuzzy
 msgid "ID is only marginally valid. Do you really want to use the key?"
 msgstr "L'ID n'est que peu valide. Voulez-vous vraiment utiliser la clé ?"
 
 # , c-format
-#: ncrypt/crypt_gpgme.c:4310 ncrypt/pgpkey.c:646 ncrypt/smime.c:509
+#: ncrypt/crypt_gpgme.c:4312 ncrypt/pgpkey.c:646 ncrypt/smime.c:509
 #, fuzzy
 msgid "ID has undefined validity. Do you really want to use the key?"
 msgstr "L'ID a une validité indéfinie. Voulez-vous vraiment utiliser la clé ?"
 
-#: ncrypt/crypt_gpgme.c:4370 ncrypt/crypt_gpgme.c:4479 ncrypt/pgpkey.c:872
+#: ncrypt/crypt_gpgme.c:4372 ncrypt/crypt_gpgme.c:4481 ncrypt/pgpkey.c:872
 #: ncrypt/pgpkey.c:995
 #, c-format
 msgid "Looking for keys matching \"%s\"..."
 msgstr "Recherche des clés correspondant à \"%s\"..."
 
-#: ncrypt/crypt_gpgme.c:4593 ncrypt/pgpkey.c:731 ncrypt/smime.c:811
+#: ncrypt/crypt_gpgme.c:4595 ncrypt/pgpkey.c:731 ncrypt/smime.c:811
 #, c-format
 msgid "No matching keys found for \"%s\""
 msgstr ""
 
 # , c-format
-#: ncrypt/crypt_gpgme.c:4644 ncrypt/pgp.c:1263
+#: ncrypt/crypt_gpgme.c:4646 ncrypt/pgp.c:1263
 #, c-format
 msgid "Use keyID = \"%s\" for %s?"
 msgstr "Utiliser keyID = \"%s\" pour %s ?"
 
 # , c-format
-#: ncrypt/crypt_gpgme.c:4695 ncrypt/pgp.c:1312 ncrypt/smime.c:830
+#: ncrypt/crypt_gpgme.c:4697 ncrypt/pgp.c:1312 ncrypt/smime.c:830
 #: ncrypt/smime.c:938
 #, c-format
 msgid "Enter keyID for %s: "
 msgstr "Entrez keyID pour %s : "
 
-#: ncrypt/crypt_gpgme.c:4755 ncrypt/pgpkey.c:751
+#: ncrypt/crypt_gpgme.c:4757 ncrypt/pgpkey.c:751
 msgid "Please enter the key ID: "
 msgstr "Veuillez entrer l'ID de la clé : "
 
-#: ncrypt/crypt_gpgme.c:4768
+#: ncrypt/crypt_gpgme.c:4770
 #, c-format
 msgid "Error exporting key: %s\n"
 msgstr "Erreur à l'export de la clé : %s\n"
@@ -4128,80 +4195,80 @@ msgstr "Erreur à l'export de la clé : %s\n"
 #. MIME description for exported (attached) keys.
 #. You can translate this entry to a non-ASCII string (it will be encoded),
 #. but it may be safer to keep it untranslated.
-#: ncrypt/crypt_gpgme.c:4787
+#: ncrypt/crypt_gpgme.c:4789
 #, c-format
 msgid "PGP Key 0x%s."
 msgstr "Clé PGP 0x%s."
 
-#: ncrypt/crypt_gpgme.c:4830
+#: ncrypt/crypt_gpgme.c:4832
 msgid "GPGME: OpenPGP protocol not available"
 msgstr "GPGME : protocole OpenPGP non disponible"
 
-#: ncrypt/crypt_gpgme.c:4838
+#: ncrypt/crypt_gpgme.c:4840
 msgid "GPGME: CMS protocol not available"
 msgstr "GPGME : protocole CMS non disponible"
 
-#: ncrypt/crypt_gpgme.c:4876
+#: ncrypt/crypt_gpgme.c:4878
 msgid "S/MIME (s)ign, sign (a)s, (p)gp, (c)lear, or (o)ppenc mode off? "
 msgstr "Signer s/mime, En tant que, Pgp, Rien, ou mode Oppenc inactif ? "
 
 #. L10N: S/MIME options (opportunistic encryption is on)
-#: ncrypt/crypt_gpgme.c:4878
+#: ncrypt/crypt_gpgme.c:4880
 msgid "sapco"
 msgstr "sepro"
 
-#: ncrypt/crypt_gpgme.c:4885
+#: ncrypt/crypt_gpgme.c:4887
 msgid "PGP (s)ign, sign (a)s, s/(m)ime, (c)lear, or (o)ppenc mode off? "
 msgstr "Signer pgp, En tant que, s/Mime, Rien, ou mode Oppenc inactif ? "
 
 #. L10N: PGP options (opportunistic encryption is on)
-#: ncrypt/crypt_gpgme.c:4887
+#: ncrypt/crypt_gpgme.c:4889
 msgid "samco"
 msgstr "semro"
 
 #. L10N: S/MIME options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4900
+#: ncrypt/crypt_gpgme.c:4902
 msgid "S/MIME (e)ncrypt, (s)ign, sign (a)s, (b)oth, (p)gp, (c)lear, or (o)ppenc mode? "
 msgstr "Chiffrer s/mime, Signer, En tant que, les Deux, Pgp, Rien, ou mode Oppenc ? "
 
 #. L10N: S/MIME options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4903
+#: ncrypt/crypt_gpgme.c:4905
 msgid "esabpco"
 msgstr "csedpro"
 
 #. L10N: PGP options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4909
+#: ncrypt/crypt_gpgme.c:4911
 msgid "PGP (e)ncrypt, (s)ign, sign (a)s, (b)oth, s/(m)ime, (c)lear, or (o)ppenc mode? "
 msgstr "Chiffrer pgp, Signer, En tant que, les Deux, s/Mime, Rien, ou mode Oppenc ? "
 
 #. L10N: PGP options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4912
+#: ncrypt/crypt_gpgme.c:4914
 msgid "esabmco"
 msgstr "csedmro"
 
-#: ncrypt/crypt_gpgme.c:4925
+#: ncrypt/crypt_gpgme.c:4927
 msgid "S/MIME (e)ncrypt, (s)ign, sign (a)s, (b)oth, (p)gp or (c)lear? "
 msgstr "Chiffrer s/mime, Signer, En tant que, les Deux, Pgp, ou Rien ? "
 
 #. L10N: S/MIME options
-#: ncrypt/crypt_gpgme.c:4927
+#: ncrypt/crypt_gpgme.c:4929
 msgid "esabpc"
 msgstr "csedpr"
 
-#: ncrypt/crypt_gpgme.c:4934
+#: ncrypt/crypt_gpgme.c:4936
 msgid "PGP (e)ncrypt, (s)ign, sign (a)s, (b)oth, s/(m)ime or (c)lear? "
 msgstr "Chiffrer pgp, Signer, En tant que, les Deux, s/Mime, ou Rien ? "
 
 #. L10N: PGP options
-#: ncrypt/crypt_gpgme.c:4936
+#: ncrypt/crypt_gpgme.c:4938
 msgid "esabmc"
 msgstr "csedmr"
 
-#: ncrypt/crypt_gpgme.c:5087
+#: ncrypt/crypt_gpgme.c:5089
 msgid "Failed to verify sender"
 msgstr "Impossible de vérifier l'expéditeur"
 
-#: ncrypt/crypt_gpgme.c:5090
+#: ncrypt/crypt_gpgme.c:5092
 msgid "Failed to figure out sender"
 msgstr "Impossible de trouver l'expéditeur"
 
@@ -4594,7 +4661,7 @@ msgstr ""
 msgid "%s is an invalid news server specification!"
 msgstr "%s est un chemin POP invalide"
 
-#: nntp.c:75 nntp.c:612 pop.c:1028 pop_lib.c:405
+#: nntp.c:75 nntp.c:612 pop.c:1031 pop_lib.c:405
 msgid "Server closed connection!"
 msgstr "Le serveur a fermé la connexion !"
 
@@ -4764,16 +4831,18 @@ msgid "check mailboxes for new mail"
 msgstr "vérifier la présence de nouveaux messages dans les BAL"
 
 #: opcodes.h:47
-msgid "attach file(s) to this message"
+#, fuzzy
+msgid "attach files to this message"
 msgstr "attacher des fichiers à ce message"
 
 #: opcodes.h:48
-msgid "attach message(s) to this message"
+#, fuzzy
+msgid "attach messages to this message"
 msgstr "attacher des messages à ce message"
 
 #: opcodes.h:49
 #, fuzzy
-msgid "attach news article(s) to this message"
+msgid "attach news articles to this message"
 msgstr "attacher des fichiers à ce message"
 
 #: opcodes.h:50
@@ -5615,7 +5684,8 @@ msgid "extract supported public keys"
 msgstr "extraire les clés publiques supportées"
 
 #: opcodes.h:255
-msgid "wipe passphrase(s) from memory"
+#, fuzzy
+msgid "wipe passphrases from memory"
 msgstr "effacer les phrases de passe de la mémoire"
 
 #: opcodes.h:259
@@ -5964,19 +6034,21 @@ msgid "Delete messages from server?"
 msgstr "Effacer les messages sur le serveur ?"
 
 # , c-format
-#: pop.c:954
-#, c-format
-msgid "Reading new messages (%d bytes)..."
-msgstr "Lecture de nouveaux messages (%d octets)..."
+#: pop.c:955
+#, fuzzy, c-format
+msgid "Reading new messages (%d byte)..."
+msgid_plural "Reading new messages (%d bytes)..."
+msgstr[0] "Lecture de nouveaux messages (%d octets)..."
+msgstr[1] "Lecture de nouveaux messages (%d octets)..."
 
-#: pop.c:997
+#: pop.c:1000
 msgid "Error while writing mailbox!"
 msgstr "Erreur à l'écriture de la boîte aux lettres !"
 
 # , c-format
 #. L10N: The plural is picked by the second numerical argument, i.e.
 #. * the %d right before 'messages', i.e. the total number of messages.
-#: pop.c:1003
+#: pop.c:1006
 #, fuzzy, c-format
 msgid "%s [%d of %d message read]"
 msgid_plural "%s [%d of %d messages read]"
@@ -6126,48 +6198,55 @@ msgstr "Passer à la commande : "
 msgid "I don't know how to print %s attachments!"
 msgstr "Je ne sais pas comment imprimer %s attachements !"
 
-#: recvattach.c:841
-msgid "Print tagged attachment(s)?"
-msgstr "Imprimer l(es) attachement(s) marqué(s) ?"
+#. L10N: Although we now the precise number of tagged messages, we
+#. do not show it to the user.  So feel free to use a "generic
+#. plural" as plural translation if your language has one.
+#: recvattach.c:852
+#, fuzzy, c-format
+msgid "Print tagged attachment?"
+msgid_plural "Print %d tagged attachments?"
+msgstr[0] "Imprimer l(es) attachement(s) marqué(s) ?"
+msgstr[1] "Imprimer l(es) attachement(s) marqué(s) ?"
 
-#: recvattach.c:842
+#: recvattach.c:853
+#, c-format
 msgid "Print attachment?"
 msgstr "Imprimer l'attachement ?"
 
-#: recvattach.c:900
+#: recvattach.c:913
 msgid "Structural changes to decrypted attachments are not supported"
 msgstr ""
 
-#: recvattach.c:1046
+#: recvattach.c:1059
 msgid "Can't decrypt encrypted message!"
 msgstr "Impossible de déchiffrer le message chiffré !"
 
-#: recvattach.c:1172
+#: recvattach.c:1185
 msgid "Attachments"
 msgstr "Attachements"
 
-#: recvattach.c:1210
+#: recvattach.c:1223
 msgid "There are no subparts to show!"
 msgstr "Il n'y a pas de sous-parties à montrer !"
 
-#: recvattach.c:1265
+#: recvattach.c:1278
 msgid "Can't delete attachment from POP server."
 msgstr "Impossible d'effacer l'attachement depuis le serveur POP."
 
-#: recvattach.c:1274
+#: recvattach.c:1287
 #, fuzzy
 msgid "Can't delete attachment from news server."
 msgstr "Impossible d'effacer l'attachement depuis le serveur POP."
 
-#: recvattach.c:1281
+#: recvattach.c:1294
 msgid "Deletion of attachments from encrypted messages is unsupported."
 msgstr "L'effacement d'attachements de messages chiffrés n'est pas supporté."
 
-#: recvattach.c:1287
+#: recvattach.c:1300
 msgid "Deletion of attachments from signed messages may invalidate the signature."
 msgstr "L'effacement d'attachements de messages signés peut invalider la signature."
 
-#: recvattach.c:1305 recvattach.c:1320
+#: recvattach.c:1318 recvattach.c:1333
 msgid "Only deletion of multipart attachments is supported."
 msgstr "Seul l'effacement d'attachements multipart est supporté."
 
@@ -6610,3 +6689,14 @@ msgstr "Options de compilation :"
 #: version.c:404
 msgid "Compile options:"
 msgstr "Options de compilation :"
+
+#~ msgid "Cannot delete message(s)"
+#~ msgstr "Impossible d'effacer le(s) message(s)"
+
+#~ msgid "Cannot undelete message(s)"
+#~ msgstr "Impossible de récupérer le(s) message(s)"
+
+# , c-format
+#, fuzzy
+#~ msgid "messages not deleted"
+#~ msgstr "message(s) non effacé(s)"

--- a/po/ga.po
+++ b/po/ga.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neomutt-20180512\n"
 "Report-Msgid-Bugs-To: neomutt-devel@neomutt.org\n"
-"POT-Creation-Date: 2018-05-20 02:02+0000\n"
+"POT-Creation-Date: 2018-05-22 14:18+0000\n"
 "PO-Revision-Date: 2006-10-16 14:22-0500\n"
 "Last-Translator: Kevin Patrick Scannell <scannell@SLU.EDU>\n"
 "Language-Team: Irish <ga@li.org>\n"
@@ -39,7 +39,7 @@ msgstr "Roghnaigh"
 
 #: addrbook.c:52 browser.c:75 browser.c:87 compose.c:160 compose.c:172
 #: conn/ssl.c:1041 conn/ssl_gnutls.c:793 curs_main.c:748 curs_main.c:761
-#: history.c:106 ncrypt/crypt_gpgme.c:4219 ncrypt/pgpkey.c:547
+#: history.c:106 ncrypt/crypt_gpgme.c:4221 ncrypt/pgpkey.c:547
 #: ncrypt/smime.c:477 pager.c:2141 postpone.c:65 query.c:72 recvattach.c:70
 msgid "Help"
 msgstr "Cabhair"
@@ -707,7 +707,7 @@ msgstr ""
 #. * Since it shares the row with "Encrypt with:", it should not be longer
 #. * than 15-20 character cells.
 #.
-#: compose.c:138 ncrypt/crypt_gpgme.c:4947 ncrypt/pgp.c:1786
+#: compose.c:138 ncrypt/crypt_gpgme.c:4949 ncrypt/pgp.c:1786
 #: ncrypt/smime.c:2127
 msgid "Sign as: "
 msgstr "Sínigh mar: "
@@ -1258,7 +1258,7 @@ msgstr "(d)iúltaigh, glac leis (u)air amháin"
 msgid "(r)eject, accept (o)nce"
 msgstr "(d)iúltaigh, glac leis (u)air amháin"
 
-#: conn/ssl.c:1039 conn/ssl_gnutls.c:791 ncrypt/crypt_gpgme.c:4213
+#: conn/ssl.c:1039 conn/ssl_gnutls.c:791 ncrypt/crypt_gpgme.c:4215
 #: ncrypt/pgpkey.c:541 ncrypt/smime.c:473
 msgid "Exit  "
 msgstr "Scoir   "
@@ -1438,11 +1438,11 @@ msgstr "Níl aon bhosca poist oscailte."
 msgid "There are no messages."
 msgstr "Níl aon teachtaireacht ann."
 
-#: curs_main.c:77 mx.c:1061 pager.c:73 recvattach.c:56
+#: curs_main.c:77 mx.c:1071 pager.c:73 recvattach.c:56
 msgid "Mailbox is read-only."
 msgstr "Tá an bosca poist inléite amháin."
 
-#: curs_main.c:79 pager.c:75 recvattach.c:1145
+#: curs_main.c:79 pager.c:75 recvattach.c:1158
 msgid "Function not permitted in attach-message mode."
 msgstr "Ní cheadaítear an fheidhm seo sa mhód iatáin."
 
@@ -1577,253 +1577,261 @@ msgid "That message is not visible."
 msgstr "Níl an teachtaireacht sin infheicthe."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:1377 curs_main.c:2772 pager.c:2818
+#. L10N: Due to the implementation details we do not know whether we
+#. delete zero, 1, 12, ... messages. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:1381 curs_main.c:2784 pager.c:2822
 #, fuzzy
-msgid "Cannot delete message(s)"
+msgid "Cannot delete messages"
 msgstr "Níl aon teachtaireacht nach scriosta."
 
-#: curs_main.c:1380
+#: curs_main.c:1384
 msgid "Delete messages matching: "
 msgstr "Scrios teachtaireachtaí atá comhoiriúnach le: "
 
-#: curs_main.c:1421
+#: curs_main.c:1425
 msgid "No limit pattern is in effect."
 msgstr "Níl aon phatrún teorannaithe i bhfeidhm."
 
 #. L10N: ask for a limit to apply
-#: curs_main.c:1426
+#: curs_main.c:1430
 #, c-format
 msgid "Limit: %s"
 msgstr "Teorainn: %s"
 
-#: curs_main.c:1464
+#: curs_main.c:1468
 msgid "Limit to messages matching: "
 msgstr "Teorannaigh go teachtaireachtaí atá comhoiriúnach le: "
 
-#: curs_main.c:1488
+#: curs_main.c:1492
 msgid "To view all messages, limit to \"all\"."
 msgstr "Chun gach teachtaireacht a fheiceáil, socraigh teorainn mar \"all\"."
 
-#: curs_main.c:1500 pager.c:2318
+#: curs_main.c:1504 pager.c:2318
 msgid "Quit NeoMutt?"
 msgstr "Scoir NeoMutt?"
 
-#: curs_main.c:1596
+#: curs_main.c:1600
 msgid "Tag messages matching: "
 msgstr "Clibeáil teachtaireachtaí atá comhoiriúnach le: "
 
 #. L10N: CHECK_ACL
-#: curs_main.c:1606 curs_main.c:3203 pager.c:3137
+#. L10N: Due to the implementation details we do not know whether we
+#. undelete zero, 1, 12, ... messages. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:1614 curs_main.c:3223 pager.c:3145
 #, fuzzy
-msgid "Cannot undelete message(s)"
+msgid "Cannot undelete messages"
 msgstr "Níl aon teachtaireacht nach scriosta."
 
-#: curs_main.c:1609
+#: curs_main.c:1617
 msgid "Undelete messages matching: "
 msgstr "Díscrios teachtaireachtaí atá comhoiriúnach le: "
 
-#: curs_main.c:1619
+#: curs_main.c:1627
 msgid "Untag messages matching: "
 msgstr "Díchlibeáil teachtaireachtaí atá comhoiriúnach le: "
 
-#: curs_main.c:1653
+#: curs_main.c:1661
 msgid "Logged out of IMAP servers."
 msgstr ""
 
-#: curs_main.c:1753
+#: curs_main.c:1761
 #, fuzzy
 msgid "No virtual folder, aborting."
 msgstr "Gan ábhar, á thobscor."
 
-#: curs_main.c:1761
+#: curs_main.c:1769
 msgid "Failed to read thread, aborting."
 msgstr ""
 
-#: curs_main.c:1793 mx.c:1458 mx.c:1475
+#: curs_main.c:1801 mx.c:1468 mx.c:1485
 msgid "Folder doesn't support tagging, aborting."
 msgstr ""
 
-#: curs_main.c:1808
+#: curs_main.c:1816
 #, fuzzy
 msgid "No tag specified, aborting."
 msgstr "Gan ábhar, á thobscor."
 
-#: curs_main.c:1820
+#: curs_main.c:1828
 #, c-format
 msgid "Update tags..."
 msgstr ""
 
-#: curs_main.c:1857
+#: curs_main.c:1865
 msgid "Failed to modify tags, aborting."
 msgstr ""
 
-#: curs_main.c:1898
+#: curs_main.c:1906
 #, fuzzy
 msgid "No query, aborting."
 msgstr "Gan ábhar, á thobscor."
 
-#: curs_main.c:1902 curs_main.c:1922 curs_main.c:1941
+#: curs_main.c:1910 curs_main.c:1930 curs_main.c:1949
 msgid "Failed to create query, aborting."
 msgstr ""
 
-#: curs_main.c:1911 curs_main.c:1930
+#: curs_main.c:1919 curs_main.c:1938
 msgid "Windowed queries disabled."
 msgstr ""
 
-#: curs_main.c:1916 curs_main.c:1935
+#: curs_main.c:1924 curs_main.c:1943
 msgid "No notmuch vfolder currently loaded."
 msgstr ""
 
-#: curs_main.c:1973
+#: curs_main.c:1981
 msgid "Open mailbox in read-only mode"
 msgstr "Oscail bosca poist i mód inléite amháin"
 
-#: curs_main.c:1976
+#: curs_main.c:1984
 #, fuzzy
 msgid "Open virtual folder"
 msgstr "oscail fillteán eile"
 
-#: curs_main.c:1979
+#: curs_main.c:1987
 msgid "Open mailbox"
 msgstr "Oscail bosca poist"
 
-#: curs_main.c:1989
+#: curs_main.c:1997
 #, fuzzy
 msgid "No mailboxes have new mail"
 msgstr "Níl aon bhosca le ríomhphost nua."
 
-#: curs_main.c:2036
+#: curs_main.c:2044
 #, fuzzy
 msgid "Open newsgroup in read-only mode"
 msgstr "Oscail bosca poist i mód inléite amháin"
 
-#: curs_main.c:2038
+#: curs_main.c:2046
 msgid "Open newsgroup"
 msgstr ""
 
-#: curs_main.c:2141
+#: curs_main.c:2149
 #, fuzzy
 msgid "Exit NeoMutt without saving?"
 msgstr "Éirigh as NeoMutt gan sábháil?"
 
-#: curs_main.c:2157
+#: curs_main.c:2165
 #, fuzzy
 msgid "Cannot break thread"
 msgstr "Ní féidir an scagaire a chruthú"
 
-#: curs_main.c:2160 curs_main.c:2198 curs_main.c:2658 curs_main.c:2690
+#: curs_main.c:2168 curs_main.c:2206 curs_main.c:2666 curs_main.c:2698
 #: flags.c:376 thread.c:1078 thread.c:1134 thread.c:1202
 msgid "Threading is not enabled."
 msgstr "Snáithe gan cumasú."
 
-#: curs_main.c:2173
+#: curs_main.c:2181
 msgid "Thread broken"
 msgstr "Snáithe briste"
 
-#: curs_main.c:2185
+#: curs_main.c:2193
 msgid "Thread cannot be broken, message is not part of a thread"
 msgstr ""
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2195
+#: curs_main.c:2203
 msgid "Cannot link threads"
 msgstr ""
 
-#: curs_main.c:2200
+#: curs_main.c:2208
 msgid "No Message-ID: header available to link thread"
 msgstr "Gan cheanntásc 'Message-ID:'; ní féidir an snáithe a nasc"
 
-#: curs_main.c:2202
+#: curs_main.c:2210
 msgid "First, please tag a message to be linked here"
 msgstr "Ar dtús, clibeáil teachtaireacht le nascadh anseo"
 
-#: curs_main.c:2213
+#: curs_main.c:2221
 msgid "Threads linked"
 msgstr "Snáitheanna nasctha"
 
-#: curs_main.c:2216
+#: curs_main.c:2224
 msgid "No thread linked"
 msgstr "Níor nascadh snáithe"
 
-#: curs_main.c:2252 curs_main.c:2278
+#: curs_main.c:2260 curs_main.c:2286
 msgid "You are on the last message."
 msgstr "An teachtaireacht deiridh."
 
-#: curs_main.c:2260 curs_main.c:2305
+#: curs_main.c:2268 curs_main.c:2313
 msgid "No undeleted messages."
 msgstr "Níl aon teachtaireacht nach scriosta."
 
-#: curs_main.c:2297 curs_main.c:2323
+#: curs_main.c:2305 curs_main.c:2331
 msgid "You are on the first message."
 msgstr "An chéad teachtaireacht."
 
-#: curs_main.c:2395 menu.c:970 pager.c:2440 pattern.c:2110
+#: curs_main.c:2403 menu.c:970 pager.c:2440 pattern.c:2110
 msgid "Search wrapped to top."
 msgstr "Thimfhill an cuardach go dtí an barr."
 
-#: curs_main.c:2404 pager.c:2463 pattern.c:2121
+#: curs_main.c:2412 pager.c:2463 pattern.c:2121
 msgid "Search wrapped to bottom."
 msgstr "Thimfhill an cuardach go dtí an bun."
 
-#: curs_main.c:2447
+#: curs_main.c:2455
 #, fuzzy
 msgid "No new messages in this limited view."
 msgstr "Níl an mháthair-theachtaireacht infheicthe san amharc srianta seo."
 
-#: curs_main.c:2449
+#: curs_main.c:2457
 #, fuzzy
 msgid "No new messages."
 msgstr "Níl aon teachtaireacht nua"
 
-#: curs_main.c:2454
+#: curs_main.c:2462
 #, fuzzy
 msgid "No unread messages in this limited view."
 msgstr "Níl an mháthair-theachtaireacht infheicthe san amharc srianta seo."
 
-#: curs_main.c:2456
+#: curs_main.c:2464
 #, fuzzy
 msgid "No unread messages."
 msgstr "Níl aon teachtaireacht gan léamh"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2474
+#: curs_main.c:2482
 #, fuzzy
 msgid "Cannot flag message"
 msgstr "taispeáin teachtaireacht"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2513 pager.c:3100
+#: curs_main.c:2521 pager.c:3104
 msgid "Cannot toggle new"
 msgstr ""
 
-#: curs_main.c:2590
+#: curs_main.c:2598
 msgid "No more threads."
 msgstr "Níl aon snáithe eile."
 
-#: curs_main.c:2592
+#: curs_main.c:2600
 msgid "You are on the first thread."
 msgstr "Is é seo an chéad snáithe."
 
-#: curs_main.c:2676
+#: curs_main.c:2684
 #, fuzzy
 msgid "Thread contains unread or flagged messages."
 msgstr "Tá teachtaireachtaí gan léamh sa snáithe seo."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2726 pager.c:2784
+#: curs_main.c:2734 pager.c:2784
 #, fuzzy
 msgid "Cannot delete message"
 msgstr "Níl aon teachtaireacht nach scriosta."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2838
+#: curs_main.c:2850
 #, fuzzy
 msgid "Cannot edit message"
 msgstr "Ní féidir teachtaireacht a scríobh "
 
 #. L10N: This is displayed when the x-label on one or more
 #. * messages is edited.
-#: curs_main.c:2900 pager.c:3200
+#: curs_main.c:2912 pager.c:3208
 #, fuzzy, c-format
 msgid "%d label changed."
 msgid_plural "%d labels changed."
@@ -1836,28 +1844,32 @@ msgstr[4] "Bosca poist gan athrú."
 #. L10N: This is displayed when editing an x-label, but no messages
 #. * were updated.  Possibly due to canceling at the prompt or if the new
 #. * label is the same as the old label.
-#: curs_main.c:2907 pager.c:3204
+#: curs_main.c:2919 pager.c:3212
 #, fuzzy
 msgid "No labels changed."
 msgstr "Bosca poist gan athrú."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:3006
+#. L10N: Due to the implementation details we do not know whether we
+#. mark zero, 1, 12, ... messages as read. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:3022
 #, fuzzy
-msgid "Cannot mark message(s) as read"
+msgid "Cannot mark messages as read"
 msgstr "léim go máthair-theachtaireacht sa snáithe"
 
 #. L10N: This is the prompt for <mark-message>.  Whatever they
 #. enter will be prefixed by $mark_macro_prefix and will become
 #. a macro hotkey to jump to the currently selected message.
-#: curs_main.c:3042
+#: curs_main.c:3058
 #, fuzzy
 msgid "Enter macro stroke: "
 msgstr "Iontráil aitheantas na heochrach: "
 
 #. L10N: "message hotkey" is the key bindings menu description of a
 #. macro created by <mark-message>.
-#: curs_main.c:3050
+#: curs_main.c:3066
 #, fuzzy
 msgid "message hotkey"
 msgstr "Cuireadh an teachtaireacht ar athlá."
@@ -1865,28 +1877,28 @@ msgstr "Cuireadh an teachtaireacht ar athlá."
 #. L10N: This is echoed after <mark-message> creates a new hotkey
 #. macro.  %s is the hotkey string ($mark_macro_prefix followed
 #. by whatever they typed at the prompt.)
-#: curs_main.c:3055
+#: curs_main.c:3071
 #, fuzzy, c-format
 msgid "Message bound to %s."
 msgstr "Scinneadh an teachtaireacht."
 
 #. L10N: This error is printed if <mark-message> cannot find a
 #. Message-ID for the currently selected message in the index.
-#: curs_main.c:3063
+#: curs_main.c:3079
 #, fuzzy
 msgid "No message ID to macro."
 msgstr "Níl aon teachtaireacht san fhillteán sin."
 
-#: curs_main.c:3105 pager.c:2961 recvattach.c:1388
+#: curs_main.c:3121 pager.c:2965 recvattach.c:1401
 msgid "Reply by mail as poster prefers?"
 msgstr ""
 
-#: curs_main.c:3108 pager.c:2927 pager.c:2939 pager.c:2964
+#: curs_main.c:3124 pager.c:2931 pager.c:2943 pager.c:2968
 msgid "Posting to this group not allowed, may be moderated. Continue?"
 msgstr ""
 
 #. L10N: CHECK_ACL
-#: curs_main.c:3173 pager.c:3120
+#: curs_main.c:3189 pager.c:3124
 #, fuzzy
 msgid "Cannot undelete message"
 msgstr "Níl aon teachtaireacht nach scriosta."
@@ -2080,12 +2092,43 @@ msgstr "[-- Uathamharc ar stderr de %s --]\n"
 msgid "[-- Error: message/external-body has no access-type parameter --]\n"
 msgstr "[-- Earráid: níl aon pharaiméadar den chineál rochtana ag message/external-body --]\n"
 
-#: handler.c:1611
+#. L10N: If the translation of this string is a multi line string, then
+#. each line should start with "[-- " and end with " --]".
+#. The first "%s/%s" is a MIME type, e.g. "text/plain". The last %s
+#. expands to a date as returned by `mutt_date_parse_date()`.
+#.
+#. Note: The size argument printed is not the actual number as passed
+#. to gettext but the prettified version, e.g. size = 2048 will be
+#. printed as 2K.  Your language might be sensitive to that: For
+#. example although '1K' and '1024' represent the same number your
+#. language might inflect the noun 'byte' differently.
+#.
+#. Sadly, we cannot do anything about that at the moment besides
+#. passing the precise size in bytes. If you are interested the
+#. function responsible for the prettification is
+#. mutt_str_pretty_size() in mutt/string.c.
+#.
+#: handler.c:1624
 #, fuzzy, c-format
 msgid ""
+"[-- This %s/%s attachment (size %s byte) has been deleted --]\n"
+"[-- on %s --]\n"
+msgid_plural ""
 "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
 "[-- on %s --]\n"
-msgstr ""
+msgstr[0] ""
+"[-- Bhí an t-iatán seo %s/%s (méid %s beart) scriosta --]\n"
+"[-- ar %s --]\n"
+msgstr[1] ""
+"[-- Bhí an t-iatán seo %s/%s (méid %s beart) scriosta --]\n"
+"[-- ar %s --]\n"
+msgstr[2] ""
+"[-- Bhí an t-iatán seo %s/%s (méid %s beart) scriosta --]\n"
+"[-- ar %s --]\n"
+msgstr[3] ""
+"[-- Bhí an t-iatán seo %s/%s (méid %s beart) scriosta --]\n"
+"[-- ar %s --]\n"
+msgstr[4] ""
 "[-- Bhí an t-iatán seo %s/%s (méid %s beart) scriosta --]\n"
 "[-- ar %s --]\n"
 
@@ -2093,10 +2136,26 @@ msgstr ""
 #. each line should start with "[-- " and end with " --]".
 #. The first "%s/%s" is a MIME type, e.g. "text/plain".
 #.
-#: handler.c:1620
+#. Note: The size argument printed is not the actual number as passed
+#. to gettext but the prettified version, e.g. size = 2048 will be
+#. printed as 2K.  Your language might be sensitive to that: For
+#. example although '1K' and '1024' represent the same number your
+#. language might inflect the noun 'byte' differently.
+#.
+#. Sadly, we cannot do anything about that at the moment besides
+#. passing the precise size in bytes. If you are interested the
+#. function responsible for the prettification is
+#. mutt_str_pretty_size() in mutt/string.c.
+#.
+#: handler.c:1648
 #, fuzzy, c-format
-msgid "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
-msgstr "[-- Bhí an t-iatán seo %s/%s (méid %s beart) scriosta --]\n"
+msgid "[-- This %s/%s attachment (size %s byte) has been deleted --]\n"
+msgid_plural "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
+msgstr[0] "[-- Bhí an t-iatán seo %s/%s (méid %s beart) scriosta --]\n"
+msgstr[1] "[-- Bhí an t-iatán seo %s/%s (méid %s beart) scriosta --]\n"
+msgstr[2] "[-- Bhí an t-iatán seo %s/%s (méid %s beart) scriosta --]\n"
+msgstr[3] "[-- Bhí an t-iatán seo %s/%s (méid %s beart) scriosta --]\n"
+msgstr[4] "[-- Bhí an t-iatán seo %s/%s (méid %s beart) scriosta --]\n"
 
 #. L10N: If the translation of this string is a multi line string, then
 #. each line should start with "[-- " and end with " --]".
@@ -2106,7 +2165,7 @@ msgstr "[-- Bhí an t-iatán seo %s/%s (méid %s beart) scriosta --]\n"
 #. Caution: Argument three %3$ is also defined but should not be used
 #. in this translation!
 #.
-#: handler.c:1637
+#: handler.c:1667
 #, fuzzy
 msgid ""
 "[-- This %s/%s attachment has been deleted --]\n"
@@ -2119,17 +2178,17 @@ msgstr ""
 #. each line should start with "[-- " and end with " --]".
 #. The first "%s/%s" is a MIME type, e.g. "text/plain".
 #.
-#: handler.c:1646
+#: handler.c:1676
 #, fuzzy, c-format
 msgid "[-- This %s/%s attachment has been deleted --]\n"
 msgstr "[-- Bhí an t-iatán seo %s/%s scriosta --]\n"
 
-#: handler.c:1656
+#: handler.c:1686
 #, c-format
 msgid "[-- name: %s --]\n"
 msgstr "[-- ainm: %s --]\n"
 
-#: handler.c:1672
+#: handler.c:1702
 #, fuzzy, c-format
 msgid ""
 "[-- This %s/%s attachment is not included, --]\n"
@@ -2140,7 +2199,7 @@ msgstr ""
 "[-- agus tá an fhoinse sheachtrach sainithe --]\n"
 "[-- i ndiaidh dul as feidhm. --]\n"
 
-#: handler.c:1693
+#: handler.c:1723
 #, fuzzy, c-format
 msgid ""
 "[-- This %s/%s attachment is not included, --]\n"
@@ -2149,52 +2208,52 @@ msgstr ""
 "[-- Níor cuireadh an t-iatán seo %s/%s san áireamh, --]\n"
 "[-- agus ní ghlacann leis an chineál shainithe rochtana %s --]\n"
 
-#: handler.c:1822
+#: handler.c:1852
 #, fuzzy
 msgid "Unable to open memory stream!"
 msgstr "Níorbh fhéidir an comhad sealadach a oscailt!"
 
-#: handler.c:1831
+#: handler.c:1861
 msgid "Unable to open temporary file!"
 msgstr "Níorbh fhéidir an comhad sealadach a oscailt!"
 
-#: handler.c:1881
+#: handler.c:1911
 #, fuzzy
 msgid "failed to re-open memstream!"
 msgstr "Níorbh fhéidir an comhad sealadach a oscailt!"
 
-#: handler.c:2013
+#: handler.c:2043
 msgid "Error: multipart/signed has no protocol."
 msgstr "Earráid: Níl aon phrótacal le haghaidh multipart/signed."
 
-#: handler.c:2076
+#: handler.c:2106
 #, fuzzy
 msgid "[-- This is an attachment (use '%3$s' to view this part) --]\n"
 msgstr "[-- Bhí an t-iatán seo %s/%s (bain úsáid as '%3$s' chun na páirte seo a fheiceáil) --]\n"
 
-#: handler.c:2082
+#: handler.c:2112
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported (use '%s' to view this part) --]\n"
 msgstr "[-- %s/%s gan tacaíocht (bain úsáid as '%s' chun na páirte seo a fheiceáil) --]\n"
 
-#: handler.c:2087
+#: handler.c:2117
 #, fuzzy
 msgid "[-- This is an attachment (need 'view-attachments' bound to key!) --]\n"
 msgstr "[-- Bhí an t-iatán seo %s/%s (ní foláir 'view-attachments' a cheangal le heochair!) --]\n"
 
 #. L10N: %s/%s is a MIME type, e.g. "text/plain".
-#: handler.c:2091
+#: handler.c:2121
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported (need 'view-attachments' bound to key!) --]\n"
 msgstr "[-- %s/%s gan tacaíocht (ní foláir 'view-attachments' a cheangal le heochair!) --]\n"
 
-#: handler.c:2098
+#: handler.c:2128
 #, fuzzy
 msgid "[-- This is an attachment --]\n"
 msgstr "[-- Bhí an t-iatán seo %s/%s --]\n"
 
 #. L10N: %s/%s is a MIME type, e.g. "text/plain".
-#: handler.c:2101
+#: handler.c:2131
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported --]\n"
 msgstr "[-- %s/%s gan tacaíocht --]\n"
@@ -2510,7 +2569,7 @@ msgstr ""
 msgid "Invalid IMAP flags"
 msgstr "Neamhbhailí  "
 
-#: imap/message.c:477 mx.c:1326
+#: imap/message.c:477 mx.c:1336
 msgid "Integer overflow -- can't allocate memory."
 msgstr "Slánuimhir thar maoil -- ní féidir cuimhne a dháileadh."
 
@@ -3279,26 +3338,41 @@ msgstr "Níl SSL ar fáil."
 msgid "Reading from %s interrupted..."
 msgstr "Idirbhriseadh an cuardach."
 
-#: mx.c:634
+#. L10N: Although we now the precise number of messages, we do not show it to the user.
+#. So feel free to use a "generic plural" as plural translation if your language has one.
+#.
+#: mx.c:639
 #, fuzzy
-msgid "message(s) not deleted"
-msgstr "Ag marcáil %d teachtaireacht mar scriosta..."
+msgid "message not deleted"
+msgid_plural "messages not deleted"
+msgstr[0] "Ag marcáil %d teachtaireacht mar scriosta..."
+msgstr[1] "Ag marcáil %d teachtaireacht mar scriosta..."
+msgstr[2] "Ag marcáil %d teachtaireacht mar scriosta..."
+msgstr[3] "Ag marcáil %d teachtaireacht mar scriosta..."
+msgstr[4] "Ag marcáil %d teachtaireacht mar scriosta..."
 
-#: mx.c:671
+#: mx.c:676
 #, fuzzy
 msgid "Can't open trash folder"
 msgstr "Ní féidir aon rud a iarcheangal leis an fhillteán: %s"
 
-#: mx.c:710
+#: mx.c:715
 msgid "Mark all articles read?"
 msgstr ""
 
-#: mx.c:754
+#. L10N: The first argument is the number of read messages to be
+#. moved, the second argument is the target mailbox.
+#: mx.c:762
 #, fuzzy, c-format
-msgid "Move %d read messages to %s?"
-msgstr "Bog na teachtaireachtaí léite go %s?"
+msgid "Move %d read message to %s?"
+msgid_plural "Move %d read messages to %s?"
+msgstr[0] "Bog na teachtaireachtaí léite go %s?"
+msgstr[1] "Bog na teachtaireachtaí léite go %s?"
+msgstr[2] "Bog na teachtaireachtaí léite go %s?"
+msgstr[3] "Bog na teachtaireachtaí léite go %s?"
+msgstr[4] "Bog na teachtaireachtaí léite go %s?"
 
-#: mx.c:771 mx.c:1077
+#: mx.c:781 mx.c:1087
 #, fuzzy, c-format
 msgid "Purge %d deleted message?"
 msgid_plural "Purge %d deleted messages?"
@@ -3308,40 +3382,40 @@ msgstr[2] "Glan %d teachtaireacht scriosta?"
 msgstr[3] "Glan %d teachtaireacht scriosta?"
 msgstr[4] "Glan %d teachtaireacht scriosta?"
 
-#: mx.c:793
+#: mx.c:803
 #, c-format
 msgid "Moving read messages to %s..."
 msgstr "Teachtaireachtaí léite á mbogadh go %s..."
 
-#: mx.c:859 mx.c:1068
+#: mx.c:869 mx.c:1078
 msgid "Mailbox is unchanged."
 msgstr "Bosca poist gan athrú."
 
-#: mx.c:914
+#: mx.c:924
 #, c-format
 msgid "%d kept, %d moved, %d deleted."
 msgstr "%d coinnithe, %d aistrithe, %d scriosta."
 
-#: mx.c:917 mx.c:1130
+#: mx.c:927 mx.c:1140
 #, c-format
 msgid "%d kept, %d deleted."
 msgstr "%d coinnithe, %d scriosta."
 
-#: mx.c:1052
+#: mx.c:1062
 #, c-format
 msgid " Press '%s' to toggle write"
 msgstr " Brúigh '%s' chun mód scríofa a scoránú"
 
-#: mx.c:1054
+#: mx.c:1064
 msgid "Use 'toggle-write' to re-enable write!"
 msgstr "Bain úsáid as 'toggle-write' chun an mód scríofa a athchumasú!"
 
-#: mx.c:1056
+#: mx.c:1066
 #, c-format
 msgid "Mailbox is marked unwritable. %s"
 msgstr "Tá an bosca poist marcáilte \"neamh-inscríofa\". %s"
 
-#: mx.c:1124
+#: mx.c:1134
 msgid "Mailbox checkpointed."
 msgstr "Seicphointeáladh an bosca poist."
 
@@ -3355,54 +3429,59 @@ msgstr " (an t-am anois: %c)"
 msgid "[-- %s output follows%s --]\n"
 msgstr "[-- an t-aschur %s:%s --]\n"
 
-#: ncrypt/crypt.c:95
-msgid "Passphrase(s) forgotten."
+#. L10N: Due to the implementation details (e.g. some passwords are managed
+#. by gpg-agent) we cannot know whether we forgot zero, 1, 12, ...
+#. passwords. So in English we use "Passphrases". Your language might
+#. have other means to express this.
+#: ncrypt/crypt.c:100
+#, fuzzy
+msgid "Passphrases forgotten."
 msgstr "Rinneadh dearmad ar an bhfrása faire."
 
-#: ncrypt/crypt.c:155
+#: ncrypt/crypt.c:161
 #, fuzzy
 msgid "Inline PGP can't be used with attachments.  Revert to PGP/MIME?"
 msgstr "Ní féidir an teachtaireacht a sheoladh inlíne.  Úsáid PGP/MIME?"
 
-#: ncrypt/crypt.c:159
+#: ncrypt/crypt.c:165
 msgid "Mail not sent: inline PGP can't be used with attachments."
 msgstr ""
 
-#: ncrypt/crypt.c:166
+#: ncrypt/crypt.c:172
 #, fuzzy
 msgid "Inline PGP can't be used with format=flowed.  Revert to PGP/MIME?"
 msgstr "Ní féidir an teachtaireacht a sheoladh inlíne.  Úsáid PGP/MIME?"
 
-#: ncrypt/crypt.c:170
+#: ncrypt/crypt.c:176
 msgid "Mail not sent: inline PGP can't be used with format=flowed."
 msgstr ""
 
-#: ncrypt/crypt.c:180 ncrypt/cryptglue.c:125 ncrypt/pgpkey.c:589
+#: ncrypt/crypt.c:186 ncrypt/cryptglue.c:125 ncrypt/pgpkey.c:589
 #: ncrypt/pgpkey.c:782
 msgid "Invoking PGP..."
 msgstr "PGP á thosú..."
 
-#: ncrypt/crypt.c:192
+#: ncrypt/crypt.c:198
 msgid "Message can't be sent inline.  Revert to using PGP/MIME?"
 msgstr "Ní féidir an teachtaireacht a sheoladh inlíne.  Úsáid PGP/MIME?"
 
-#: ncrypt/crypt.c:194 send.c:1824
+#: ncrypt/crypt.c:200 send.c:1824
 msgid "Mail not sent."
 msgstr "Níor seoladh an post."
 
-#: ncrypt/crypt.c:540
+#: ncrypt/crypt.c:546
 msgid "S/MIME messages with no hints on content are unsupported."
 msgstr "Ní ghlacann le teachtaireachtaí S/MIME gan leideanna maidir lena n-inneachar."
 
-#: ncrypt/crypt.c:754 ncrypt/crypt.c:795
+#: ncrypt/crypt.c:760 ncrypt/crypt.c:801
 msgid "Trying to extract PGP keys...\n"
 msgstr "Ag baint triail as eochracha PGP a bhaint amach...\n"
 
-#: ncrypt/crypt.c:776 ncrypt/crypt.c:816
+#: ncrypt/crypt.c:782 ncrypt/crypt.c:822
 msgid "Trying to extract S/MIME certificates...\n"
 msgstr "Ag baint triail as teastais S/MIME a bhaint amach...\n"
 
-#: ncrypt/crypt.c:976
+#: ncrypt/crypt.c:982
 #, c-format
 msgid ""
 "[-- Error: Unknown multipart/signed protocol %s! --]\n"
@@ -3411,7 +3490,7 @@ msgstr ""
 "[-- Earráid: Prótacal anaithnid multipart/signed %s! --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1016
+#: ncrypt/crypt.c:1022
 #, fuzzy
 msgid ""
 "[-- Error: Missing or bad-format multipart/signed signature! --]\n"
@@ -3420,7 +3499,7 @@ msgstr ""
 "[-- Earráid: Struchtúr neamhréireach multipart/signed! --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1058
+#: ncrypt/crypt.c:1064
 #, c-format
 msgid ""
 "[-- Warning: We can't verify %s/%s signatures. --]\n"
@@ -3429,7 +3508,7 @@ msgstr ""
 "[-- Rabhadh: Ní féidir %s/%s síniú a fhíorú. --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1070
+#: ncrypt/crypt.c:1076
 msgid ""
 "[-- The following data is signed --]\n"
 "\n"
@@ -3437,7 +3516,7 @@ msgstr ""
 "[-- Is sínithe iad na sonraí seo a leanas --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1075
+#: ncrypt/crypt.c:1081
 msgid ""
 "[-- Warning: Can't find any signatures. --]\n"
 "\n"
@@ -3445,7 +3524,7 @@ msgstr ""
 "[-- Rabhadh: Ní féidir aon síniú a aimsiú. --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1081
+#: ncrypt/crypt.c:1087
 msgid ""
 "\n"
 "[-- End of signed data --]\n"
@@ -3496,7 +3575,7 @@ msgstr ""
 msgid "error reading data object: %s\n"
 msgstr "earráid agus réad á léamh: %s\n"
 
-#: ncrypt/crypt_gpgme.c:662 ncrypt/crypt_gpgme.c:3848 ncrypt/pgpkey.c:585
+#: ncrypt/crypt_gpgme.c:662 ncrypt/crypt_gpgme.c:3850 ncrypt/pgpkey.c:585
 #: ncrypt/pgpkey.c:768
 msgid "Can't create temporary file"
 msgstr "Ní féidir comhad sealadach a chruthú"
@@ -3859,28 +3938,33 @@ msgstr "[Neamhbhailí]"
 
 #. L10N: This is printed after "Key Type: " and looks like this:
 #. *       PGP, 2048 bit RSA
-#: ncrypt/crypt_gpgme.c:3670 ncrypt/crypt_gpgme.c:3808
+#: ncrypt/crypt_gpgme.c:3670 ncrypt/crypt_gpgme.c:3810
 #, fuzzy, c-format
 msgid "%s, %lu bit %s\n"
-msgstr "Cineál na hEochrach ..: %s, %lu giotán %s\n"
+msgid_plural "%s, %lu bit %s\n"
+msgstr[0] "Cineál na hEochrach ..: %s, %lu giotán %s\n"
+msgstr[1] "Cineál na hEochrach ..: %s, %lu giotán %s\n"
+msgstr[2] "Cineál na hEochrach ..: %s, %lu giotán %s\n"
+msgstr[3] "Cineál na hEochrach ..: %s, %lu giotán %s\n"
+msgstr[4] "Cineál na hEochrach ..: %s, %lu giotán %s\n"
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3678 ncrypt/crypt_gpgme.c:3815
+#: ncrypt/crypt_gpgme.c:3678 ncrypt/crypt_gpgme.c:3817
 msgid "encryption"
 msgstr "criptiúchán"
 
 #: ncrypt/crypt_gpgme.c:3679 ncrypt/crypt_gpgme.c:3685
-#: ncrypt/crypt_gpgme.c:3816 ncrypt/crypt_gpgme.c:3821
+#: ncrypt/crypt_gpgme.c:3818 ncrypt/crypt_gpgme.c:3823
 msgid ", "
 msgstr ", "
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3684 ncrypt/crypt_gpgme.c:3820
+#: ncrypt/crypt_gpgme.c:3684 ncrypt/crypt_gpgme.c:3822
 msgid "signing"
 msgstr "síniú"
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3690 ncrypt/crypt_gpgme.c:3825
+#: ncrypt/crypt_gpgme.c:3690 ncrypt/crypt_gpgme.c:3827
 msgid "certification"
 msgstr "deimhniú"
 
@@ -3899,65 +3983,65 @@ msgstr "[As Feidhm]"
 msgid "[Disabled]"
 msgstr "[Díchumasaithe]"
 
-#: ncrypt/crypt_gpgme.c:3851
+#: ncrypt/crypt_gpgme.c:3853
 msgid "Collecting data..."
 msgstr "Sonraí á mbailiú..."
 
-#: ncrypt/crypt_gpgme.c:3876
+#: ncrypt/crypt_gpgme.c:3878
 #, c-format
 msgid "Error finding issuer key: %s\n"
 msgstr "Earráid agus eochair an eisitheora á aimsiú: %s\n"
 
-#: ncrypt/crypt_gpgme.c:3885
+#: ncrypt/crypt_gpgme.c:3887
 #, fuzzy
 msgid "Error: certification chain too long - stopping here\n"
 msgstr "Earráid: slabhra rófhada deimhnithe - á stopadh anseo\n"
 
-#: ncrypt/crypt_gpgme.c:3895 ncrypt/pgpkey.c:608
+#: ncrypt/crypt_gpgme.c:3897 ncrypt/pgpkey.c:608
 #, c-format
 msgid "Key ID: 0x%s"
 msgstr "Aitheantas na heochrach: 0x%s"
 
-#: ncrypt/crypt_gpgme.c:3990
+#: ncrypt/crypt_gpgme.c:3992
 #, c-format
 msgid "gpgme_new failed: %s"
 msgstr "Theip ar gpgme_new: %s"
 
-#: ncrypt/crypt_gpgme.c:4028 ncrypt/crypt_gpgme.c:4079
+#: ncrypt/crypt_gpgme.c:4030 ncrypt/crypt_gpgme.c:4081
 #, c-format
 msgid "gpgme_op_keylist_start failed: %s"
 msgstr "theip ar gpgme_op_keylist_start: %s"
 
-#: ncrypt/crypt_gpgme.c:4067 ncrypt/crypt_gpgme.c:4109
+#: ncrypt/crypt_gpgme.c:4069 ncrypt/crypt_gpgme.c:4111
 #, c-format
 msgid "gpgme_op_keylist_next failed: %s"
 msgstr "theip ar gpgme_op_keylist_next: %s"
 
-#: ncrypt/crypt_gpgme.c:4185
+#: ncrypt/crypt_gpgme.c:4187
 msgid "All matching keys are marked expired/revoked."
 msgstr "Tá gach eochair chomhoiriúnach marcáilte mar as feidhm/cúlghairthe."
 
-#: ncrypt/crypt_gpgme.c:4215 ncrypt/pgpkey.c:543 ncrypt/smime.c:475
+#: ncrypt/crypt_gpgme.c:4217 ncrypt/pgpkey.c:543 ncrypt/smime.c:475
 msgid "Select  "
 msgstr "Roghnaigh  "
 
-#: ncrypt/crypt_gpgme.c:4217 ncrypt/pgpkey.c:545
+#: ncrypt/crypt_gpgme.c:4219 ncrypt/pgpkey.c:545
 msgid "Check key  "
 msgstr "Seiceáil eochair  "
 
-#: ncrypt/crypt_gpgme.c:4233
+#: ncrypt/crypt_gpgme.c:4235
 msgid "PGP and S/MIME keys matching"
 msgstr "Eochracha PGP agus S/MIME atá comhoiriúnach le"
 
-#: ncrypt/crypt_gpgme.c:4235
+#: ncrypt/crypt_gpgme.c:4237
 msgid "PGP keys matching"
 msgstr "Eochracha PGP atá comhoiriúnach le"
 
-#: ncrypt/crypt_gpgme.c:4237
+#: ncrypt/crypt_gpgme.c:4239
 msgid "S/MIME keys matching"
 msgstr "Eochracha S/MIME atá comhoiriúnach le"
 
-#: ncrypt/crypt_gpgme.c:4239
+#: ncrypt/crypt_gpgme.c:4241
 msgid "keys matching"
 msgstr "eochracha atá comhoiriúnach le"
 
@@ -3965,69 +4049,69 @@ msgstr "eochracha atá comhoiriúnach le"
 #. %1$s is one of the previous four entries.
 #. %2$s is an address.
 #. e.g. "S/MIME keys matching <me@mutt.org>."
-#: ncrypt/crypt_gpgme.c:4246
+#: ncrypt/crypt_gpgme.c:4248
 #, c-format
 msgid "%s <%s>."
 msgstr "%s <%s>."
 
 #. L10N:
 #. e.g. 'S/MIME keys matching "Michael Elkins".'
-#: ncrypt/crypt_gpgme.c:4250
+#: ncrypt/crypt_gpgme.c:4252
 #, c-format
 msgid "%s \"%s\"."
 msgstr "%s \"%s\"."
 
-#: ncrypt/crypt_gpgme.c:4277 ncrypt/pgpkey.c:628
+#: ncrypt/crypt_gpgme.c:4279 ncrypt/pgpkey.c:628
 msgid "This key can't be used: expired/disabled/revoked."
 msgstr "Ní féidir an eochair seo a úsáid: as feidhm/díchumasaithe/cúlghairthe."
 
-#: ncrypt/crypt_gpgme.c:4290 ncrypt/pgpkey.c:640 ncrypt/smime.c:505
+#: ncrypt/crypt_gpgme.c:4292 ncrypt/pgpkey.c:640 ncrypt/smime.c:505
 #, fuzzy
 msgid "ID is expired/disabled/revoked. Do you really want to use the key?"
 msgstr "Tá an t-aitheantas as feidhm/díchumasaithe/cúlghairthe. An bhfuil tú cinnte gur mhaith leat an eochair seo a úsáid?"
 
-#: ncrypt/crypt_gpgme.c:4299 ncrypt/pgpkey.c:650
+#: ncrypt/crypt_gpgme.c:4301 ncrypt/pgpkey.c:650
 #, fuzzy
 msgid "ID is not valid. Do you really want to use the key?"
 msgstr "Níl an t-aitheantas bailí. An bhfuil tú cinnte gur mhaith leat an eochair seo a úsáid?"
 
-#: ncrypt/crypt_gpgme.c:4302 ncrypt/pgpkey.c:653
+#: ncrypt/crypt_gpgme.c:4304 ncrypt/pgpkey.c:653
 #, fuzzy
 msgid "ID is only marginally valid. Do you really want to use the key?"
 msgstr "Is ar éigean atá an t-aitheantas bailí. An bhfuil tú cinnte gur mhaith leat an eochair seo a úsáid?"
 
-#: ncrypt/crypt_gpgme.c:4310 ncrypt/pgpkey.c:646 ncrypt/smime.c:509
+#: ncrypt/crypt_gpgme.c:4312 ncrypt/pgpkey.c:646 ncrypt/smime.c:509
 #, fuzzy
 msgid "ID has undefined validity. Do you really want to use the key?"
 msgstr "Aitheantas gan bailíocht chinnte. An bhfuil tú cinnte gur mhaith leat an eochair seo a úsáid?"
 
-#: ncrypt/crypt_gpgme.c:4370 ncrypt/crypt_gpgme.c:4479 ncrypt/pgpkey.c:872
+#: ncrypt/crypt_gpgme.c:4372 ncrypt/crypt_gpgme.c:4481 ncrypt/pgpkey.c:872
 #: ncrypt/pgpkey.c:995
 #, c-format
 msgid "Looking for keys matching \"%s\"..."
 msgstr "Ag cuardach ar eochracha atá comhoiriúnach le \"%s\"..."
 
-#: ncrypt/crypt_gpgme.c:4593 ncrypt/pgpkey.c:731 ncrypt/smime.c:811
+#: ncrypt/crypt_gpgme.c:4595 ncrypt/pgpkey.c:731 ncrypt/smime.c:811
 #, c-format
 msgid "No matching keys found for \"%s\""
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4644 ncrypt/pgp.c:1263
+#: ncrypt/crypt_gpgme.c:4646 ncrypt/pgp.c:1263
 #, c-format
 msgid "Use keyID = \"%s\" for %s?"
 msgstr "Úsáid aitheantas eochrach = \"%s\" le haghaidh %s?"
 
-#: ncrypt/crypt_gpgme.c:4695 ncrypt/pgp.c:1312 ncrypt/smime.c:830
+#: ncrypt/crypt_gpgme.c:4697 ncrypt/pgp.c:1312 ncrypt/smime.c:830
 #: ncrypt/smime.c:938
 #, c-format
 msgid "Enter keyID for %s: "
 msgstr "Iontráil aitheantas eochrach le haghaidh %s: "
 
-#: ncrypt/crypt_gpgme.c:4755 ncrypt/pgpkey.c:751
+#: ncrypt/crypt_gpgme.c:4757 ncrypt/pgpkey.c:751
 msgid "Please enter the key ID: "
 msgstr "Iontráil aitheantas na heochrach, le do thoil: "
 
-#: ncrypt/crypt_gpgme.c:4768
+#: ncrypt/crypt_gpgme.c:4770
 #, fuzzy, c-format
 msgid "Error exporting key: %s\n"
 msgstr "Earráid agus eolas faoin eochair á fháil: "
@@ -4036,90 +4120,90 @@ msgstr "Earráid agus eolas faoin eochair á fháil: "
 #. MIME description for exported (attached) keys.
 #. You can translate this entry to a non-ASCII string (it will be encoded),
 #. but it may be safer to keep it untranslated.
-#: ncrypt/crypt_gpgme.c:4787
+#: ncrypt/crypt_gpgme.c:4789
 #, fuzzy, c-format
 msgid "PGP Key 0x%s."
 msgstr "Eochair PGP %s."
 
-#: ncrypt/crypt_gpgme.c:4830
+#: ncrypt/crypt_gpgme.c:4832
 msgid "GPGME: OpenPGP protocol not available"
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4838
+#: ncrypt/crypt_gpgme.c:4840
 msgid "GPGME: CMS protocol not available"
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4876
+#: ncrypt/crypt_gpgme.c:4878
 #, fuzzy
 msgid "S/MIME (s)ign, sign (a)s, (p)gp, (c)lear, or (o)ppenc mode off? "
 msgstr "S/MIME (c)ript, (s)ínigh, sínigh (m)ar, (a)raon, (p)gp, nó (g)lan?"
 
 #. L10N: S/MIME options (opportunistic encryption is on)
-#: ncrypt/crypt_gpgme.c:4878
+#: ncrypt/crypt_gpgme.c:4880
 msgid "sapco"
 msgstr "csmapg"
 
-#: ncrypt/crypt_gpgme.c:4885
+#: ncrypt/crypt_gpgme.c:4887
 #, fuzzy
 msgid "PGP (s)ign, sign (a)s, s/(m)ime, (c)lear, or (o)ppenc mode off? "
 msgstr "PGP (c)ript, (s)ínigh, sínigh (m)ar, (a)raon, s/m(i)me, nó (g)lan?"
 
 #. L10N: PGP options (opportunistic encryption is on)
-#: ncrypt/crypt_gpgme.c:4887
+#: ncrypt/crypt_gpgme.c:4889
 msgid "samco"
 msgstr "csmaig"
 
 #. L10N: S/MIME options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4900
+#: ncrypt/crypt_gpgme.c:4902
 #, fuzzy
 msgid "S/MIME (e)ncrypt, (s)ign, sign (a)s, (b)oth, (p)gp, (c)lear, or (o)ppenc mode? "
 msgstr "S/MIME (c)ript, (s)ínigh, sínigh (m)ar, (a)raon, (p)gp, nó (g)lan?"
 
 #. L10N: S/MIME options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4903
+#: ncrypt/crypt_gpgme.c:4905
 #, fuzzy
 msgid "esabpco"
 msgstr "csmapg"
 
 #. L10N: PGP options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4909
+#: ncrypt/crypt_gpgme.c:4911
 #, fuzzy
 msgid "PGP (e)ncrypt, (s)ign, sign (a)s, (b)oth, s/(m)ime, (c)lear, or (o)ppenc mode? "
 msgstr "PGP (c)ript, (s)ínigh, sínigh (m)ar, (a)raon, s/m(i)me, nó (g)lan?"
 
 #. L10N: PGP options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4912
+#: ncrypt/crypt_gpgme.c:4914
 #, fuzzy
 msgid "esabmco"
 msgstr "csmaig"
 
-#: ncrypt/crypt_gpgme.c:4925
+#: ncrypt/crypt_gpgme.c:4927
 #, fuzzy
 msgid "S/MIME (e)ncrypt, (s)ign, sign (a)s, (b)oth, (p)gp or (c)lear? "
 msgstr "S/MIME (c)ript, (s)ínigh, sínigh (m)ar, (a)raon, (p)gp, nó (g)lan?"
 
 #. L10N: S/MIME options
-#: ncrypt/crypt_gpgme.c:4927
+#: ncrypt/crypt_gpgme.c:4929
 #, fuzzy
 msgid "esabpc"
 msgstr "csmapg"
 
-#: ncrypt/crypt_gpgme.c:4934
+#: ncrypt/crypt_gpgme.c:4936
 #, fuzzy
 msgid "PGP (e)ncrypt, (s)ign, sign (a)s, (b)oth, s/(m)ime or (c)lear? "
 msgstr "PGP (c)ript, (s)ínigh, sínigh (m)ar, (a)raon, s/m(i)me, nó (g)lan?"
 
 #. L10N: PGP options
-#: ncrypt/crypt_gpgme.c:4936
+#: ncrypt/crypt_gpgme.c:4938
 #, fuzzy
 msgid "esabmc"
 msgstr "csmaig"
 
-#: ncrypt/crypt_gpgme.c:5087
+#: ncrypt/crypt_gpgme.c:5089
 msgid "Failed to verify sender"
 msgstr "Theip ar fhíorú an tseoltóra"
 
-#: ncrypt/crypt_gpgme.c:5090
+#: ncrypt/crypt_gpgme.c:5092
 msgid "Failed to figure out sender"
 msgstr "Theip ar dhéanamh amach an tseoltóra"
 
@@ -4520,7 +4604,7 @@ msgstr ""
 msgid "%s is an invalid news server specification!"
 msgstr "%s: is conair POP neamhbhailí"
 
-#: nntp.c:75 nntp.c:612 pop.c:1028 pop_lib.c:405
+#: nntp.c:75 nntp.c:612 pop.c:1031 pop_lib.c:405
 msgid "Server closed connection!"
 msgstr "Dhún an freastalaí an nasc!"
 
@@ -4686,16 +4770,17 @@ msgstr "seiceáil boscaí do phost nua"
 
 #: opcodes.h:47
 #, fuzzy
-msgid "attach file(s) to this message"
+msgid "attach files to this message"
 msgstr "ceangail comha(i)d leis an teachtaireacht seo"
 
 #: opcodes.h:48
-msgid "attach message(s) to this message"
+#, fuzzy
+msgid "attach messages to this message"
 msgstr "ceangail teachtaireacht(aí) leis an teachtaireacht seo"
 
 #: opcodes.h:49
 #, fuzzy
-msgid "attach news article(s) to this message"
+msgid "attach news articles to this message"
 msgstr "ceangail comha(i)d leis an teachtaireacht seo"
 
 #: opcodes.h:50
@@ -5540,7 +5625,8 @@ msgid "extract supported public keys"
 msgstr "bain na heochracha poiblí le tacaíocht amach"
 
 #: opcodes.h:255
-msgid "wipe passphrase(s) from memory"
+#, fuzzy
+msgid "wipe passphrases from memory"
 msgstr "bánaigh frása(í) faire as cuimhne"
 
 #: opcodes.h:259
@@ -5894,18 +5980,23 @@ msgstr "Níl aon phost nua sa bhosca POP."
 msgid "Delete messages from server?"
 msgstr "Scrios teachtaireachtaí ón fhreastalaí?"
 
-#: pop.c:954
-#, c-format
-msgid "Reading new messages (%d bytes)..."
-msgstr "Teachtaireachtaí nua á léamh (%d beart)..."
+#: pop.c:955
+#, fuzzy, c-format
+msgid "Reading new messages (%d byte)..."
+msgid_plural "Reading new messages (%d bytes)..."
+msgstr[0] "Teachtaireachtaí nua á léamh (%d beart)..."
+msgstr[1] "Teachtaireachtaí nua á léamh (%d beart)..."
+msgstr[2] "Teachtaireachtaí nua á léamh (%d beart)..."
+msgstr[3] "Teachtaireachtaí nua á léamh (%d beart)..."
+msgstr[4] "Teachtaireachtaí nua á léamh (%d beart)..."
 
-#: pop.c:997
+#: pop.c:1000
 msgid "Error while writing mailbox!"
 msgstr "Earráid agus bosca poist á scríobh!"
 
 #. L10N: The plural is picked by the second numerical argument, i.e.
 #. * the %d right before 'messages', i.e. the total number of messages.
-#: pop.c:1003
+#: pop.c:1006
 #, fuzzy, c-format
 msgid "%s [%d of %d message read]"
 msgid_plural "%s [%d of %d messages read]"
@@ -6052,49 +6143,59 @@ msgstr "Píopa go: "
 msgid "I don't know how to print %s attachments!"
 msgstr "Ní eol dom conas a phriontáil iatáin %s!"
 
-#: recvattach.c:841
-msgid "Print tagged attachment(s)?"
-msgstr "Priontáil iatá(i)n c(h)libeáilte?"
+#. L10N: Although we now the precise number of tagged messages, we
+#. do not show it to the user.  So feel free to use a "generic
+#. plural" as plural translation if your language has one.
+#: recvattach.c:852
+#, fuzzy, c-format
+msgid "Print tagged attachment?"
+msgid_plural "Print %d tagged attachments?"
+msgstr[0] "Priontáil iatá(i)n c(h)libeáilte?"
+msgstr[1] "Priontáil iatá(i)n c(h)libeáilte?"
+msgstr[2] "Priontáil iatá(i)n c(h)libeáilte?"
+msgstr[3] "Priontáil iatá(i)n c(h)libeáilte?"
+msgstr[4] "Priontáil iatá(i)n c(h)libeáilte?"
 
-#: recvattach.c:842
+#: recvattach.c:853
+#, c-format
 msgid "Print attachment?"
 msgstr "Priontáil iatán?"
 
-#: recvattach.c:900
+#: recvattach.c:913
 msgid "Structural changes to decrypted attachments are not supported"
 msgstr ""
 
-#: recvattach.c:1046
+#: recvattach.c:1059
 msgid "Can't decrypt encrypted message!"
 msgstr "Ní féidir teachtaireacht chriptithe a dhíchriptiú!"
 
-#: recvattach.c:1172
+#: recvattach.c:1185
 msgid "Attachments"
 msgstr "Iatáin"
 
-#: recvattach.c:1210
+#: recvattach.c:1223
 msgid "There are no subparts to show!"
 msgstr "Níl aon fopháirt le taispeáint!"
 
-#: recvattach.c:1265
+#: recvattach.c:1278
 msgid "Can't delete attachment from POP server."
 msgstr "Ní féidir an t-iatán a scriosadh ón fhreastalaí POP."
 
-#: recvattach.c:1274
+#: recvattach.c:1287
 #, fuzzy
 msgid "Can't delete attachment from news server."
 msgstr "Ní féidir an t-iatán a scriosadh ón fhreastalaí POP."
 
-#: recvattach.c:1281
+#: recvattach.c:1294
 msgid "Deletion of attachments from encrypted messages is unsupported."
 msgstr "Ní cheadaítear iatáin a bheith scriosta ó theachtaireachtaí criptithe."
 
-#: recvattach.c:1287
+#: recvattach.c:1300
 #, fuzzy
 msgid "Deletion of attachments from signed messages may invalidate the signature."
 msgstr "Ní cheadaítear iatáin a bheith scriosta ó theachtaireachtaí criptithe."
 
-#: recvattach.c:1305 recvattach.c:1320
+#: recvattach.c:1318 recvattach.c:1333
 msgid "Only deletion of multipart attachments is supported."
 msgstr "Ní cheadaítear ach iatáin ilpháirt a bheith scriosta."
 
@@ -6534,3 +6635,15 @@ msgstr "Roghanna tiomsaithe:"
 #: version.c:404
 msgid "Compile options:"
 msgstr "Roghanna tiomsaithe:"
+
+#, fuzzy
+#~ msgid "Cannot delete message(s)"
+#~ msgstr "Níl aon teachtaireacht nach scriosta."
+
+#, fuzzy
+#~ msgid "Cannot undelete message(s)"
+#~ msgstr "Níl aon teachtaireacht nach scriosta."
+
+#, fuzzy
+#~ msgid "messages not deleted"
+#~ msgstr "Ag marcáil %d teachtaireacht mar scriosta..."

--- a/po/gl.po
+++ b/po/gl.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neomutt-20180512\n"
 "Report-Msgid-Bugs-To: neomutt-devel@neomutt.org\n"
-"POT-Creation-Date: 2018-05-20 02:02+0000\n"
+"POT-Creation-Date: 2018-05-22 14:18+0000\n"
 "PO-Revision-Date: 2001-04-22 22:05+0200\n"
 "Last-Translator: Roberto Suarez Soto <ask4it@bigfoot.com>\n"
 "Language-Team: Galician <trasno@ceu.fi.udc.es>\n"
@@ -39,7 +39,7 @@ msgstr "Seleccionar"
 
 #: addrbook.c:52 browser.c:75 browser.c:87 compose.c:160 compose.c:172
 #: conn/ssl.c:1041 conn/ssl_gnutls.c:793 curs_main.c:748 curs_main.c:761
-#: history.c:106 ncrypt/crypt_gpgme.c:4219 ncrypt/pgpkey.c:547
+#: history.c:106 ncrypt/crypt_gpgme.c:4221 ncrypt/pgpkey.c:547
 #: ncrypt/smime.c:477 pager.c:2141 postpone.c:65 query.c:72 recvattach.c:70
 msgid "Help"
 msgstr "Axuda"
@@ -701,7 +701,7 @@ msgstr ""
 #. * Since it shares the row with "Encrypt with:", it should not be longer
 #. * than 15-20 character cells.
 #.
-#: compose.c:138 ncrypt/crypt_gpgme.c:4947 ncrypt/pgp.c:1786
+#: compose.c:138 ncrypt/crypt_gpgme.c:4949 ncrypt/pgp.c:1786
 #: ncrypt/smime.c:2127
 msgid "Sign as: "
 msgstr "Firmar como: "
@@ -1249,7 +1249,7 @@ msgstr "(r)exeitar, aceptar (e)sta vez"
 msgid "(r)eject, accept (o)nce"
 msgstr "(r)exeitar, aceptar (e)sta vez"
 
-#: conn/ssl.c:1039 conn/ssl_gnutls.c:791 ncrypt/crypt_gpgme.c:4213
+#: conn/ssl.c:1039 conn/ssl_gnutls.c:791 ncrypt/crypt_gpgme.c:4215
 #: ncrypt/pgpkey.c:541 ncrypt/smime.c:473
 msgid "Exit  "
 msgstr "Saír  "
@@ -1436,12 +1436,12 @@ msgstr "Non hai buzóns abertos."
 msgid "There are no messages."
 msgstr "Non hai mensaxes."
 
-#: curs_main.c:77 mx.c:1061 pager.c:73 recvattach.c:56
+#: curs_main.c:77 mx.c:1071 pager.c:73 recvattach.c:56
 msgid "Mailbox is read-only."
 msgstr "O buzón é de só lectura."
 
 #
-#: curs_main.c:79 pager.c:75 recvattach.c:1145
+#: curs_main.c:79 pager.c:75 recvattach.c:1158
 msgid "Function not permitted in attach-message mode."
 msgstr "Función non permitida no modo \"adxuntar-mensaxe\"."
 
@@ -1579,255 +1579,263 @@ msgid "That message is not visible."
 msgstr "Esa mensaxe non é visible."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:1377 curs_main.c:2772 pager.c:2818
+#. L10N: Due to the implementation details we do not know whether we
+#. delete zero, 1, 12, ... messages. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:1381 curs_main.c:2784 pager.c:2822
 #, fuzzy
-msgid "Cannot delete message(s)"
+msgid "Cannot delete messages"
 msgstr "Non hai mensaxes recuperadas."
 
-#: curs_main.c:1380
+#: curs_main.c:1384
 msgid "Delete messages matching: "
 msgstr "Borrar as mensaxes que coincidan con: "
 
-#: curs_main.c:1421
+#: curs_main.c:1425
 msgid "No limit pattern is in effect."
 msgstr "Non hai patrón limitante efectivo."
 
 #. L10N: ask for a limit to apply
-#: curs_main.c:1426
+#: curs_main.c:1430
 #, c-format
 msgid "Limit: %s"
 msgstr "Límite: %s"
 
-#: curs_main.c:1464
+#: curs_main.c:1468
 msgid "Limit to messages matching: "
 msgstr "Limitar ás mensaxes que coincidan con: "
 
-#: curs_main.c:1488
+#: curs_main.c:1492
 msgid "To view all messages, limit to \"all\"."
 msgstr ""
 
-#: curs_main.c:1500 pager.c:2318
+#: curs_main.c:1504 pager.c:2318
 msgid "Quit NeoMutt?"
 msgstr "¿Saír de NeoMutt?"
 
-#: curs_main.c:1596
+#: curs_main.c:1600
 msgid "Tag messages matching: "
 msgstr "Marcar as mensaxes que coincidan con: "
 
 #. L10N: CHECK_ACL
-#: curs_main.c:1606 curs_main.c:3203 pager.c:3137
+#. L10N: Due to the implementation details we do not know whether we
+#. undelete zero, 1, 12, ... messages. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:1614 curs_main.c:3223 pager.c:3145
 #, fuzzy
-msgid "Cannot undelete message(s)"
+msgid "Cannot undelete messages"
 msgstr "Non hai mensaxes recuperadas."
 
-#: curs_main.c:1609
+#: curs_main.c:1617
 msgid "Undelete messages matching: "
 msgstr "Recuperar as mensaxes que coincidan con: "
 
-#: curs_main.c:1619
+#: curs_main.c:1627
 msgid "Untag messages matching: "
 msgstr "Desmarcar as mensaxes que coincidan con: "
 
-#: curs_main.c:1653
+#: curs_main.c:1661
 #, fuzzy
 msgid "Logged out of IMAP servers."
 msgstr "Pechando conexión ó servidor IMAP..."
 
-#: curs_main.c:1753
+#: curs_main.c:1761
 #, fuzzy
 msgid "No virtual folder, aborting."
 msgstr "Non hai tema, cancelando."
 
-#: curs_main.c:1761
+#: curs_main.c:1769
 msgid "Failed to read thread, aborting."
 msgstr ""
 
-#: curs_main.c:1793 mx.c:1458 mx.c:1475
+#: curs_main.c:1801 mx.c:1468 mx.c:1485
 msgid "Folder doesn't support tagging, aborting."
 msgstr ""
 
-#: curs_main.c:1808
+#: curs_main.c:1816
 #, fuzzy
 msgid "No tag specified, aborting."
 msgstr "Non hai tema, cancelando."
 
-#: curs_main.c:1820
+#: curs_main.c:1828
 #, c-format
 msgid "Update tags..."
 msgstr ""
 
-#: curs_main.c:1857
+#: curs_main.c:1865
 msgid "Failed to modify tags, aborting."
 msgstr ""
 
-#: curs_main.c:1898
+#: curs_main.c:1906
 #, fuzzy
 msgid "No query, aborting."
 msgstr "Non hai tema, cancelando."
 
-#: curs_main.c:1902 curs_main.c:1922 curs_main.c:1941
+#: curs_main.c:1910 curs_main.c:1930 curs_main.c:1949
 msgid "Failed to create query, aborting."
 msgstr ""
 
-#: curs_main.c:1911 curs_main.c:1930
+#: curs_main.c:1919 curs_main.c:1938
 msgid "Windowed queries disabled."
 msgstr ""
 
-#: curs_main.c:1916 curs_main.c:1935
+#: curs_main.c:1924 curs_main.c:1943
 msgid "No notmuch vfolder currently loaded."
 msgstr ""
 
-#: curs_main.c:1973
+#: curs_main.c:1981
 msgid "Open mailbox in read-only mode"
 msgstr "Abrir buzón en modo de só lectura"
 
-#: curs_main.c:1976
+#: curs_main.c:1984
 #, fuzzy
 msgid "Open virtual folder"
 msgstr "abrir unha carpeta diferente"
 
-#: curs_main.c:1979
+#: curs_main.c:1987
 msgid "Open mailbox"
 msgstr "Abrir buzón"
 
-#: curs_main.c:1989
+#: curs_main.c:1997
 #, fuzzy
 msgid "No mailboxes have new mail"
 msgstr "Non hai buzóns con novo correo."
 
-#: curs_main.c:2036
+#: curs_main.c:2044
 #, fuzzy
 msgid "Open newsgroup in read-only mode"
 msgstr "Abrir buzón en modo de só lectura"
 
-#: curs_main.c:2038
+#: curs_main.c:2046
 msgid "Open newsgroup"
 msgstr ""
 
-#: curs_main.c:2141
+#: curs_main.c:2149
 #, fuzzy
 msgid "Exit NeoMutt without saving?"
 msgstr "¿Saír de NeoMutt sen gardar?"
 
-#: curs_main.c:2157
+#: curs_main.c:2165
 #, fuzzy
 msgid "Cannot break thread"
 msgstr "Non se puido crea-lo filtro"
 
-#: curs_main.c:2160 curs_main.c:2198 curs_main.c:2658 curs_main.c:2690
+#: curs_main.c:2168 curs_main.c:2206 curs_main.c:2666 curs_main.c:2698
 #: flags.c:376 thread.c:1078 thread.c:1134 thread.c:1202
 msgid "Threading is not enabled."
 msgstr "Enfiamento non habilitado."
 
-#: curs_main.c:2173
+#: curs_main.c:2181
 msgid "Thread broken"
 msgstr ""
 
-#: curs_main.c:2185
+#: curs_main.c:2193
 msgid "Thread cannot be broken, message is not part of a thread"
 msgstr ""
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2195
+#: curs_main.c:2203
 msgid "Cannot link threads"
 msgstr ""
 
-#: curs_main.c:2200
+#: curs_main.c:2208
 msgid "No Message-ID: header available to link thread"
 msgstr ""
 
-#: curs_main.c:2202
+#: curs_main.c:2210
 #, fuzzy
 msgid "First, please tag a message to be linked here"
 msgstr "gardar esta mensaxe para mandar logo"
 
-#: curs_main.c:2213
+#: curs_main.c:2221
 msgid "Threads linked"
 msgstr ""
 
-#: curs_main.c:2216
+#: curs_main.c:2224
 msgid "No thread linked"
 msgstr ""
 
-#: curs_main.c:2252 curs_main.c:2278
+#: curs_main.c:2260 curs_main.c:2286
 msgid "You are on the last message."
 msgstr "Está na última mensaxe."
 
-#: curs_main.c:2260 curs_main.c:2305
+#: curs_main.c:2268 curs_main.c:2313
 msgid "No undeleted messages."
 msgstr "Non hai mensaxes recuperadas."
 
-#: curs_main.c:2297 curs_main.c:2323
+#: curs_main.c:2305 curs_main.c:2331
 msgid "You are on the first message."
 msgstr "Está na primeira mensaxe."
 
-#: curs_main.c:2395 menu.c:970 pager.c:2440 pattern.c:2110
+#: curs_main.c:2403 menu.c:970 pager.c:2440 pattern.c:2110
 msgid "Search wrapped to top."
 msgstr "A búsqueda volveu ó principio."
 
-#: curs_main.c:2404 pager.c:2463 pattern.c:2121
+#: curs_main.c:2412 pager.c:2463 pattern.c:2121
 msgid "Search wrapped to bottom."
 msgstr "A búsqueda volveu ó final."
 
-#: curs_main.c:2447
+#: curs_main.c:2455
 #, fuzzy
 msgid "No new messages in this limited view."
 msgstr "A mensaxe pai non é visible na vista limitada."
 
-#: curs_main.c:2449
+#: curs_main.c:2457
 #, fuzzy
 msgid "No new messages."
 msgstr "Non hai novas mensaxes"
 
-#: curs_main.c:2454
+#: curs_main.c:2462
 #, fuzzy
 msgid "No unread messages in this limited view."
 msgstr "A mensaxe pai non é visible na vista limitada."
 
-#: curs_main.c:2456
+#: curs_main.c:2464
 #, fuzzy
 msgid "No unread messages."
 msgstr "Non hai mensaxes sen ler"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2474
+#: curs_main.c:2482
 #, fuzzy
 msgid "Cannot flag message"
 msgstr "amosar unha mensaxe"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2513 pager.c:3100
+#: curs_main.c:2521 pager.c:3104
 msgid "Cannot toggle new"
 msgstr ""
 
-#: curs_main.c:2590
+#: curs_main.c:2598
 msgid "No more threads."
 msgstr "Non hai máis fíos"
 
-#: curs_main.c:2592
+#: curs_main.c:2600
 msgid "You are on the first thread."
 msgstr "Está no primeiro fío"
 
-#: curs_main.c:2676
+#: curs_main.c:2684
 #, fuzzy
 msgid "Thread contains unread or flagged messages."
 msgstr "O fío contén mensaxes sen ler."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2726 pager.c:2784
+#: curs_main.c:2734 pager.c:2784
 #, fuzzy
 msgid "Cannot delete message"
 msgstr "Non hai mensaxes recuperadas."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2838
+#: curs_main.c:2850
 #, fuzzy
 msgid "Cannot edit message"
 msgstr "Non foi posible escribi-la mensaxe"
 
 #. L10N: This is displayed when the x-label on one or more
 #. * messages is edited.
-#: curs_main.c:2900 pager.c:3200
+#: curs_main.c:2912 pager.c:3208
 #, fuzzy, c-format
 msgid "%d label changed."
 msgid_plural "%d labels changed."
@@ -1837,28 +1845,32 @@ msgstr[1] "O buzón non cambiou."
 #. L10N: This is displayed when editing an x-label, but no messages
 #. * were updated.  Possibly due to canceling at the prompt or if the new
 #. * label is the same as the old label.
-#: curs_main.c:2907 pager.c:3204
+#: curs_main.c:2919 pager.c:3212
 #, fuzzy
 msgid "No labels changed."
 msgstr "O buzón non cambiou."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:3006
+#. L10N: Due to the implementation details we do not know whether we
+#. mark zero, 1, 12, ... messages as read. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:3022
 #, fuzzy
-msgid "Cannot mark message(s) as read"
+msgid "Cannot mark messages as read"
 msgstr "saltar á mensaxe pai no fío"
 
 #. L10N: This is the prompt for <mark-message>.  Whatever they
 #. enter will be prefixed by $mark_macro_prefix and will become
 #. a macro hotkey to jump to the currently selected message.
-#: curs_main.c:3042
+#: curs_main.c:3058
 #, fuzzy
 msgid "Enter macro stroke: "
 msgstr "Introduza keyID para %s: "
 
 #. L10N: "message hotkey" is the key bindings menu description of a
 #. macro created by <mark-message>.
-#: curs_main.c:3050
+#: curs_main.c:3066
 #, fuzzy
 msgid "message hotkey"
 msgstr "Mensaxe posposta."
@@ -1866,28 +1878,28 @@ msgstr "Mensaxe posposta."
 #. L10N: This is echoed after <mark-message> creates a new hotkey
 #. macro.  %s is the hotkey string ($mark_macro_prefix followed
 #. by whatever they typed at the prompt.)
-#: curs_main.c:3055
+#: curs_main.c:3071
 #, fuzzy, c-format
 msgid "Message bound to %s."
 msgstr "Mensaxe rebotada."
 
 #. L10N: This error is printed if <mark-message> cannot find a
 #. Message-ID for the currently selected message in the index.
-#: curs_main.c:3063
+#: curs_main.c:3079
 #, fuzzy
 msgid "No message ID to macro."
 msgstr "Non hai mensaxes nese buzón."
 
-#: curs_main.c:3105 pager.c:2961 recvattach.c:1388
+#: curs_main.c:3121 pager.c:2965 recvattach.c:1401
 msgid "Reply by mail as poster prefers?"
 msgstr ""
 
-#: curs_main.c:3108 pager.c:2927 pager.c:2939 pager.c:2964
+#: curs_main.c:3124 pager.c:2931 pager.c:2943 pager.c:2968
 msgid "Posting to this group not allowed, may be moderated. Continue?"
 msgstr ""
 
 #. L10N: CHECK_ACL
-#: curs_main.c:3173 pager.c:3120
+#: curs_main.c:3189 pager.c:3124
 #, fuzzy
 msgid "Cannot undelete message"
 msgstr "Non hai mensaxes recuperadas."
@@ -2099,12 +2111,34 @@ msgstr "[-- Automostra da stderr de %s --]\n"
 msgid "[-- Error: message/external-body has no access-type parameter --]\n"
 msgstr "[-- Erro: mensaxe/corpo externo non ten parámetro \"access-type\"--]\n"
 
-#: handler.c:1611
+#. L10N: If the translation of this string is a multi line string, then
+#. each line should start with "[-- " and end with " --]".
+#. The first "%s/%s" is a MIME type, e.g. "text/plain". The last %s
+#. expands to a date as returned by `mutt_date_parse_date()`.
+#.
+#. Note: The size argument printed is not the actual number as passed
+#. to gettext but the prettified version, e.g. size = 2048 will be
+#. printed as 2K.  Your language might be sensitive to that: For
+#. example although '1K' and '1024' represent the same number your
+#. language might inflect the noun 'byte' differently.
+#.
+#. Sadly, we cannot do anything about that at the moment besides
+#. passing the precise size in bytes. If you are interested the
+#. function responsible for the prettification is
+#. mutt_str_pretty_size() in mutt/string.c.
+#.
+#: handler.c:1624
 #, fuzzy, c-format
 msgid ""
+"[-- This %s/%s attachment (size %s byte) has been deleted --]\n"
+"[-- on %s --]\n"
+msgid_plural ""
 "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
 "[-- on %s --]\n"
-msgstr ""
+msgstr[0] ""
+"[-- Este adxunto %s/%s (tamaño %s bytes) foi borrado --]\n"
+"[-- o %s --]\n"
+msgstr[1] ""
 "[-- Este adxunto %s/%s (tamaño %s bytes) foi borrado --]\n"
 "[-- o %s --]\n"
 
@@ -2112,10 +2146,23 @@ msgstr ""
 #. each line should start with "[-- " and end with " --]".
 #. The first "%s/%s" is a MIME type, e.g. "text/plain".
 #.
-#: handler.c:1620
+#. Note: The size argument printed is not the actual number as passed
+#. to gettext but the prettified version, e.g. size = 2048 will be
+#. printed as 2K.  Your language might be sensitive to that: For
+#. example although '1K' and '1024' represent the same number your
+#. language might inflect the noun 'byte' differently.
+#.
+#. Sadly, we cannot do anything about that at the moment besides
+#. passing the precise size in bytes. If you are interested the
+#. function responsible for the prettification is
+#. mutt_str_pretty_size() in mutt/string.c.
+#.
+#: handler.c:1648
 #, fuzzy, c-format
-msgid "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
-msgstr "[-- Este adxunto %s/%s (tamaño %s bytes) foi borrado --]\n"
+msgid "[-- This %s/%s attachment (size %s byte) has been deleted --]\n"
+msgid_plural "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
+msgstr[0] "[-- Este adxunto %s/%s (tamaño %s bytes) foi borrado --]\n"
+msgstr[1] "[-- Este adxunto %s/%s (tamaño %s bytes) foi borrado --]\n"
 
 #. L10N: If the translation of this string is a multi line string, then
 #. each line should start with "[-- " and end with " --]".
@@ -2125,7 +2172,7 @@ msgstr "[-- Este adxunto %s/%s (tamaño %s bytes) foi borrado --]\n"
 #. Caution: Argument three %3$ is also defined but should not be used
 #. in this translation!
 #.
-#: handler.c:1637
+#: handler.c:1667
 #, fuzzy
 msgid ""
 "[-- This %s/%s attachment has been deleted --]\n"
@@ -2138,17 +2185,17 @@ msgstr ""
 #. each line should start with "[-- " and end with " --]".
 #. The first "%s/%s" is a MIME type, e.g. "text/plain".
 #.
-#: handler.c:1646
+#: handler.c:1676
 #, fuzzy, c-format
 msgid "[-- This %s/%s attachment has been deleted --]\n"
 msgstr "[-- Este adxunto %s/%s foi borrado --]\n"
 
-#: handler.c:1656
+#: handler.c:1686
 #, c-format
 msgid "[-- name: %s --]\n"
 msgstr "[-- nome: %s --]\n"
 
-#: handler.c:1672
+#: handler.c:1702
 #, fuzzy, c-format
 msgid ""
 "[-- This %s/%s attachment is not included, --]\n"
@@ -2158,7 +2205,7 @@ msgstr ""
 "[-- Este adxunto %s/%s non está incluido --]\n"
 "[-- e a fonte externa indicada expirou--]\n"
 
-#: handler.c:1693
+#: handler.c:1723
 #, fuzzy, c-format
 msgid ""
 "[-- This %s/%s attachment is not included, --]\n"
@@ -2167,52 +2214,52 @@ msgstr ""
 "[-- Este adxunto %s/%s non está incluido, --]\n"
 "[-- e o \"access-type\" %s indicado non está soportado --]\n"
 
-#: handler.c:1822
+#: handler.c:1852
 #, fuzzy
 msgid "Unable to open memory stream!"
 msgstr "¡Non foi posible abri-lo ficheiro temporal!"
 
-#: handler.c:1831
+#: handler.c:1861
 msgid "Unable to open temporary file!"
 msgstr "¡Non foi posible abri-lo ficheiro temporal!"
 
-#: handler.c:1881
+#: handler.c:1911
 #, fuzzy
 msgid "failed to re-open memstream!"
 msgstr "¡Non foi posible abri-lo ficheiro temporal!"
 
-#: handler.c:2013
+#: handler.c:2043
 msgid "Error: multipart/signed has no protocol."
 msgstr "Erro: multipart/signed non ten protocolo."
 
-#: handler.c:2076
+#: handler.c:2106
 #, fuzzy
 msgid "[-- This is an attachment (use '%3$s' to view this part) --]\n"
 msgstr "[-- Este adxunto %s/%s (use '%3$s' para ver esta parte) --]\n"
 
-#: handler.c:2082
+#: handler.c:2112
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported (use '%s' to view this part) --]\n"
 msgstr "[-- %s/%s non está soportado (use '%s' para ver esta parte) --]\n"
 
-#: handler.c:2087
+#: handler.c:2117
 #, fuzzy
 msgid "[-- This is an attachment (need 'view-attachments' bound to key!) --]\n"
 msgstr "[-- Este adxunto %s/%s (cómpre que 'view-attachments' esté vinculado a unha tecla!) --]\n"
 
 #. L10N: %s/%s is a MIME type, e.g. "text/plain".
-#: handler.c:2091
+#: handler.c:2121
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported (need 'view-attachments' bound to key!) --]\n"
 msgstr "[-- %s/%s non está soportado (cómpre que 'view-attachments' esté vinculado a unha tecla!) --]\n"
 
-#: handler.c:2098
+#: handler.c:2128
 #, fuzzy
 msgid "[-- This is an attachment --]\n"
 msgstr "[-- Este adxunto %s/%s --]\n"
 
 #. L10N: %s/%s is a MIME type, e.g. "text/plain".
-#: handler.c:2101
+#: handler.c:2131
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported --]\n"
 msgstr "[-- %s/%s non está soportado --]\n"
@@ -2526,7 +2573,7 @@ msgstr ""
 msgid "Invalid IMAP flags"
 msgstr "Mes inválido: %s"
 
-#: imap/message.c:477 mx.c:1326
+#: imap/message.c:477 mx.c:1336
 msgid "Integer overflow -- can't allocate memory."
 msgstr ""
 
@@ -3303,66 +3350,75 @@ msgstr "SSL non está accesible."
 msgid "Reading from %s interrupted..."
 msgstr "Búsqueda interrompida."
 
-#: mx.c:634
+#. L10N: Although we now the precise number of messages, we do not show it to the user.
+#. So feel free to use a "generic plural" as plural translation if your language has one.
+#.
+#: mx.c:639
 #, fuzzy
-msgid "message(s) not deleted"
-msgstr "Marcando %d mensaxes borradas ..."
+msgid "message not deleted"
+msgid_plural "messages not deleted"
+msgstr[0] "Marcando %d mensaxes borradas ..."
+msgstr[1] "Marcando %d mensaxes borradas ..."
 
-#: mx.c:671
+#: mx.c:676
 #, fuzzy
 msgid "Can't open trash folder"
 msgstr "Non foi posible engadir á carpeta: %s"
 
-#: mx.c:710
+#: mx.c:715
 msgid "Mark all articles read?"
 msgstr ""
 
-#: mx.c:754
+#. L10N: The first argument is the number of read messages to be
+#. moved, the second argument is the target mailbox.
+#: mx.c:762
 #, fuzzy, c-format
-msgid "Move %d read messages to %s?"
-msgstr "¿Mover mensaxes lidas a %s?"
+msgid "Move %d read message to %s?"
+msgid_plural "Move %d read messages to %s?"
+msgstr[0] "¿Mover mensaxes lidas a %s?"
+msgstr[1] "¿Mover mensaxes lidas a %s?"
 
-#: mx.c:771 mx.c:1077
+#: mx.c:781 mx.c:1087
 #, fuzzy, c-format
 msgid "Purge %d deleted message?"
 msgid_plural "Purge %d deleted messages?"
 msgstr[0] "¿Purgar %d mensaxe marcada como borrada?"
 msgstr[1] "¿Purgar %d mensaxes marcadas como borradas?"
 
-#: mx.c:793
+#: mx.c:803
 #, c-format
 msgid "Moving read messages to %s..."
 msgstr "Movendo mensaxes lidas a %s..."
 
-#: mx.c:859 mx.c:1068
+#: mx.c:869 mx.c:1078
 msgid "Mailbox is unchanged."
 msgstr "O buzón non cambiou."
 
-#: mx.c:914
+#: mx.c:924
 #, c-format
 msgid "%d kept, %d moved, %d deleted."
 msgstr "%d conservados, %d movidos, %d borrados."
 
-#: mx.c:917 mx.c:1130
+#: mx.c:927 mx.c:1140
 #, c-format
 msgid "%d kept, %d deleted."
 msgstr "%d conservados, %d borrados."
 
-#: mx.c:1052
+#: mx.c:1062
 #, c-format
 msgid " Press '%s' to toggle write"
 msgstr " Pulse '%s' para cambiar a modo escritura"
 
-#: mx.c:1054
+#: mx.c:1064
 msgid "Use 'toggle-write' to re-enable write!"
 msgstr "¡Use 'toggle-write' para restablece-lo modo escritura!"
 
-#: mx.c:1056
+#: mx.c:1066
 #, c-format
 msgid "Mailbox is marked unwritable. %s"
 msgstr "O buzón está marcado como non escribible. %s"
 
-#: mx.c:1124
+#: mx.c:1134
 msgid "Mailbox checkpointed."
 msgstr "Buzón marcado para comprobación."
 
@@ -3376,67 +3432,71 @@ msgstr ""
 msgid "[-- %s output follows%s --]\n"
 msgstr "[-- Saída PGP a continuación (hora actual: %c) --]\n"
 
-#: ncrypt/crypt.c:95
+#. L10N: Due to the implementation details (e.g. some passwords are managed
+#. by gpg-agent) we cannot know whether we forgot zero, 1, 12, ...
+#. passwords. So in English we use "Passphrases". Your language might
+#. have other means to express this.
+#: ncrypt/crypt.c:100
 #, fuzzy
-msgid "Passphrase(s) forgotten."
+msgid "Passphrases forgotten."
 msgstr "Contrasinal PGP esquecido."
 
-#: ncrypt/crypt.c:155
+#: ncrypt/crypt.c:161
 msgid "Inline PGP can't be used with attachments.  Revert to PGP/MIME?"
 msgstr ""
 
-#: ncrypt/crypt.c:159
+#: ncrypt/crypt.c:165
 msgid "Mail not sent: inline PGP can't be used with attachments."
 msgstr ""
 
-#: ncrypt/crypt.c:166
+#: ncrypt/crypt.c:172
 msgid "Inline PGP can't be used with format=flowed.  Revert to PGP/MIME?"
 msgstr ""
 
-#: ncrypt/crypt.c:170
+#: ncrypt/crypt.c:176
 msgid "Mail not sent: inline PGP can't be used with format=flowed."
 msgstr ""
 
-#: ncrypt/crypt.c:180 ncrypt/cryptglue.c:125 ncrypt/pgpkey.c:589
+#: ncrypt/crypt.c:186 ncrypt/cryptglue.c:125 ncrypt/pgpkey.c:589
 #: ncrypt/pgpkey.c:782
 msgid "Invoking PGP..."
 msgstr "Chamando ó PGP..."
 
-#: ncrypt/crypt.c:192
+#: ncrypt/crypt.c:198
 msgid "Message can't be sent inline.  Revert to using PGP/MIME?"
 msgstr ""
 
-#: ncrypt/crypt.c:194 send.c:1824
+#: ncrypt/crypt.c:200 send.c:1824
 msgid "Mail not sent."
 msgstr "Mensaxe non enviada."
 
-#: ncrypt/crypt.c:540
+#: ncrypt/crypt.c:546
 msgid "S/MIME messages with no hints on content are unsupported."
 msgstr ""
 
-#: ncrypt/crypt.c:754 ncrypt/crypt.c:795
+#: ncrypt/crypt.c:760 ncrypt/crypt.c:801
 msgid "Trying to extract PGP keys...\n"
 msgstr ""
 
-#: ncrypt/crypt.c:776 ncrypt/crypt.c:816
+#: ncrypt/crypt.c:782 ncrypt/crypt.c:822
 msgid "Trying to extract S/MIME certificates...\n"
 msgstr ""
 
-#: ncrypt/crypt.c:976
+#: ncrypt/crypt.c:982
 #, c-format
 msgid ""
 "[-- Error: Unknown multipart/signed protocol %s! --]\n"
 "\n"
 msgstr "[-- Erro: protocolo multiparte/asinado %s descoñecido --]\n"
 
-#: ncrypt/crypt.c:1016
+#: ncrypt/crypt.c:1022
 #, fuzzy
 msgid ""
 "[-- Error: Missing or bad-format multipart/signed signature! --]\n"
 "\n"
 msgstr "[-- Erro: estructura multiparte/asinada inconsistente --]\n"
 
-#: ncrypt/crypt.c:1058
+#: ncrypt/crypt.c:1064
 #, c-format
 msgid ""
 "[-- Warning: We can't verify %s/%s signatures. --]\n"
@@ -3445,7 +3505,7 @@ msgstr ""
 "[-- Atención: non é posible verificar sinaturas %s/%s --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1070
+#: ncrypt/crypt.c:1076
 #, fuzzy
 msgid ""
 "[-- The following data is signed --]\n"
@@ -3454,7 +3514,7 @@ msgstr ""
 "[-- Os datos a continuación están asinados --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1075
+#: ncrypt/crypt.c:1081
 msgid ""
 "[-- Warning: Can't find any signatures. --]\n"
 "\n"
@@ -3462,7 +3522,7 @@ msgstr ""
 "[-- Atención: non se atoparon sinaturas. --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1081
+#: ncrypt/crypt.c:1087
 #, fuzzy
 msgid ""
 "\n"
@@ -3515,7 +3575,7 @@ msgstr ""
 msgid "error reading data object: %s\n"
 msgstr "erro no patrón en: %s"
 
-#: ncrypt/crypt_gpgme.c:662 ncrypt/crypt_gpgme.c:3848 ncrypt/pgpkey.c:585
+#: ncrypt/crypt_gpgme.c:662 ncrypt/crypt_gpgme.c:3850 ncrypt/pgpkey.c:585
 #: ncrypt/pgpkey.c:768
 msgid "Can't create temporary file"
 msgstr "Non podo crea-lo ficheiro temporal"
@@ -3894,29 +3954,31 @@ msgstr "Mes inválido: %s"
 
 #. L10N: This is printed after "Key Type: " and looks like this:
 #. *       PGP, 2048 bit RSA
-#: ncrypt/crypt_gpgme.c:3670 ncrypt/crypt_gpgme.c:3808
+#: ncrypt/crypt_gpgme.c:3670 ncrypt/crypt_gpgme.c:3810
 #, c-format
 msgid "%s, %lu bit %s\n"
-msgstr ""
+msgid_plural "%s, %lu bit %s\n"
+msgstr[0] ""
+msgstr[1] ""
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3678 ncrypt/crypt_gpgme.c:3815
+#: ncrypt/crypt_gpgme.c:3678 ncrypt/crypt_gpgme.c:3817
 #, fuzzy
 msgid "encryption"
 msgstr "Encriptar"
 
 #: ncrypt/crypt_gpgme.c:3679 ncrypt/crypt_gpgme.c:3685
-#: ncrypt/crypt_gpgme.c:3816 ncrypt/crypt_gpgme.c:3821
+#: ncrypt/crypt_gpgme.c:3818 ncrypt/crypt_gpgme.c:3823
 msgid ", "
 msgstr ""
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3684 ncrypt/crypt_gpgme.c:3820
+#: ncrypt/crypt_gpgme.c:3684 ncrypt/crypt_gpgme.c:3822
 msgid "signing"
 msgstr ""
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3690 ncrypt/crypt_gpgme.c:3825
+#: ncrypt/crypt_gpgme.c:3690 ncrypt/crypt_gpgme.c:3827
 #, fuzzy
 msgid "certification"
 msgstr "Certificado gardado"
@@ -3937,70 +3999,70 @@ msgstr "Saír  "
 msgid "[Disabled]"
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:3851
+#: ncrypt/crypt_gpgme.c:3853
 #, fuzzy
 msgid "Collecting data..."
 msgstr "Conectando con %s..."
 
-#: ncrypt/crypt_gpgme.c:3876
+#: ncrypt/crypt_gpgme.c:3878
 #, fuzzy, c-format
 msgid "Error finding issuer key: %s\n"
 msgstr "Erro ó conectar có servidor: %s"
 
-#: ncrypt/crypt_gpgme.c:3885
+#: ncrypt/crypt_gpgme.c:3887
 #, fuzzy
 msgid "Error: certification chain too long - stopping here\n"
 msgstr "Erro na liña de comando: %s\n"
 
-#: ncrypt/crypt_gpgme.c:3895 ncrypt/pgpkey.c:608
+#: ncrypt/crypt_gpgme.c:3897 ncrypt/pgpkey.c:608
 #, c-format
 msgid "Key ID: 0x%s"
 msgstr "Key ID: 0x%s"
 
-#: ncrypt/crypt_gpgme.c:3990
+#: ncrypt/crypt_gpgme.c:3992
 #, fuzzy, c-format
 msgid "gpgme_new failed: %s"
 msgstr "O login fallou."
 
-#: ncrypt/crypt_gpgme.c:4028 ncrypt/crypt_gpgme.c:4079
+#: ncrypt/crypt_gpgme.c:4030 ncrypt/crypt_gpgme.c:4081
 #, c-format
 msgid "gpgme_op_keylist_start failed: %s"
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4067 ncrypt/crypt_gpgme.c:4109
+#: ncrypt/crypt_gpgme.c:4069 ncrypt/crypt_gpgme.c:4111
 #, c-format
 msgid "gpgme_op_keylist_next failed: %s"
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4185
+#: ncrypt/crypt_gpgme.c:4187
 #, fuzzy
 msgid "All matching keys are marked expired/revoked."
 msgstr "Tódalas chaves coincidintes están marcadas como expiradas/revocadas."
 
-#: ncrypt/crypt_gpgme.c:4215 ncrypt/pgpkey.c:543 ncrypt/smime.c:475
+#: ncrypt/crypt_gpgme.c:4217 ncrypt/pgpkey.c:543 ncrypt/smime.c:475
 msgid "Select  "
 msgstr "Seleccionar  "
 
-#: ncrypt/crypt_gpgme.c:4217 ncrypt/pgpkey.c:545
+#: ncrypt/crypt_gpgme.c:4219 ncrypt/pgpkey.c:545
 msgid "Check key  "
 msgstr "Comprobar chave  "
 
-#: ncrypt/crypt_gpgme.c:4233
+#: ncrypt/crypt_gpgme.c:4235
 #, fuzzy
 msgid "PGP and S/MIME keys matching"
 msgstr "Chaves S/MIME coincidintes con \"%s\""
 
-#: ncrypt/crypt_gpgme.c:4235
+#: ncrypt/crypt_gpgme.c:4237
 #, fuzzy
 msgid "PGP keys matching"
 msgstr "Chaves PGP coincidintes con \"%s\""
 
-#: ncrypt/crypt_gpgme.c:4237
+#: ncrypt/crypt_gpgme.c:4239
 #, fuzzy
 msgid "S/MIME keys matching"
 msgstr "Chaves S/MIME coincidintes con \"%s\""
 
-#: ncrypt/crypt_gpgme.c:4239
+#: ncrypt/crypt_gpgme.c:4241
 #, fuzzy
 msgid "keys matching"
 msgstr "Chaves PGP coincidintes con \"%s\""
@@ -4009,68 +4071,68 @@ msgstr "Chaves PGP coincidintes con \"%s\""
 #. %1$s is one of the previous four entries.
 #. %2$s is an address.
 #. e.g. "S/MIME keys matching <me@mutt.org>."
-#: ncrypt/crypt_gpgme.c:4246
+#: ncrypt/crypt_gpgme.c:4248
 #, fuzzy, c-format
 msgid "%s <%s>."
 msgstr "%s [%s]\n"
 
 #. L10N:
 #. e.g. 'S/MIME keys matching "Michael Elkins".'
-#: ncrypt/crypt_gpgme.c:4250
+#: ncrypt/crypt_gpgme.c:4252
 #, fuzzy, c-format
 msgid "%s \"%s\"."
 msgstr "%s [%s]\n"
 
-#: ncrypt/crypt_gpgme.c:4277 ncrypt/pgpkey.c:628
+#: ncrypt/crypt_gpgme.c:4279 ncrypt/pgpkey.c:628
 msgid "This key can't be used: expired/disabled/revoked."
 msgstr "Esta chave non pode ser usada: expirada/deshabilitada/revocada."
 
-#: ncrypt/crypt_gpgme.c:4290 ncrypt/pgpkey.c:640 ncrypt/smime.c:505
+#: ncrypt/crypt_gpgme.c:4292 ncrypt/pgpkey.c:640 ncrypt/smime.c:505
 #, fuzzy
 msgid "ID is expired/disabled/revoked. Do you really want to use the key?"
 msgstr "Este ID expirou/foi deshabilitado/foi revocado. ¿Está seguro de querer usa-la chave?"
 
-#: ncrypt/crypt_gpgme.c:4299 ncrypt/pgpkey.c:650
+#: ncrypt/crypt_gpgme.c:4301 ncrypt/pgpkey.c:650
 #, fuzzy
 msgid "ID is not valid. Do you really want to use the key?"
 msgstr "Este ID non é de confianza. ¿Está seguro de querer usa-la chave?"
 
-#: ncrypt/crypt_gpgme.c:4302 ncrypt/pgpkey.c:653
+#: ncrypt/crypt_gpgme.c:4304 ncrypt/pgpkey.c:653
 #, fuzzy
 msgid "ID is only marginally valid. Do you really want to use the key?"
 msgstr "Este ID é de confianza marxinal. ¿Está seguro de querer usa-la chave?"
 
-#: ncrypt/crypt_gpgme.c:4310 ncrypt/pgpkey.c:646 ncrypt/smime.c:509
+#: ncrypt/crypt_gpgme.c:4312 ncrypt/pgpkey.c:646 ncrypt/smime.c:509
 msgid "ID has undefined validity. Do you really want to use the key?"
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4370 ncrypt/crypt_gpgme.c:4479 ncrypt/pgpkey.c:872
+#: ncrypt/crypt_gpgme.c:4372 ncrypt/crypt_gpgme.c:4481 ncrypt/pgpkey.c:872
 #: ncrypt/pgpkey.c:995
 #, c-format
 msgid "Looking for keys matching \"%s\"..."
 msgstr "Buscando chaves que coincidan con \"%s\"..."
 
-#: ncrypt/crypt_gpgme.c:4593 ncrypt/pgpkey.c:731 ncrypt/smime.c:811
+#: ncrypt/crypt_gpgme.c:4595 ncrypt/pgpkey.c:731 ncrypt/smime.c:811
 #, c-format
 msgid "No matching keys found for \"%s\""
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4644 ncrypt/pgp.c:1263
+#: ncrypt/crypt_gpgme.c:4646 ncrypt/pgp.c:1263
 #, c-format
 msgid "Use keyID = \"%s\" for %s?"
 msgstr "¿Usa-lo keyID = \"%s\" para %s?"
 
-#: ncrypt/crypt_gpgme.c:4695 ncrypt/pgp.c:1312 ncrypt/smime.c:830
+#: ncrypt/crypt_gpgme.c:4697 ncrypt/pgp.c:1312 ncrypt/smime.c:830
 #: ncrypt/smime.c:938
 #, c-format
 msgid "Enter keyID for %s: "
 msgstr "Introduza keyID para %s: "
 
-#: ncrypt/crypt_gpgme.c:4755 ncrypt/pgpkey.c:751
+#: ncrypt/crypt_gpgme.c:4757 ncrypt/pgpkey.c:751
 msgid "Please enter the key ID: "
 msgstr "Introduza o key ID: "
 
-#: ncrypt/crypt_gpgme.c:4768
+#: ncrypt/crypt_gpgme.c:4770
 #, fuzzy, c-format
 msgid "Error exporting key: %s\n"
 msgstr "erro no patrón en: %s"
@@ -4079,86 +4141,86 @@ msgstr "erro no patrón en: %s"
 #. MIME description for exported (attached) keys.
 #. You can translate this entry to a non-ASCII string (it will be encoded),
 #. but it may be safer to keep it untranslated.
-#: ncrypt/crypt_gpgme.c:4787
+#: ncrypt/crypt_gpgme.c:4789
 #, fuzzy, c-format
 msgid "PGP Key 0x%s."
 msgstr "Chave PGP %s."
 
-#: ncrypt/crypt_gpgme.c:4830
+#: ncrypt/crypt_gpgme.c:4832
 msgid "GPGME: OpenPGP protocol not available"
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4838
+#: ncrypt/crypt_gpgme.c:4840
 msgid "GPGME: CMS protocol not available"
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4876
+#: ncrypt/crypt_gpgme.c:4878
 #, fuzzy
 msgid "S/MIME (s)ign, sign (a)s, (p)gp, (c)lear, or (o)ppenc mode off? "
 msgstr "¿(e)ncriptar, (f)irmar, firmar (c)omo, (a)mbas, (i)nterior, ou (o)lvidar? "
 
 #. L10N: S/MIME options (opportunistic encryption is on)
-#: ncrypt/crypt_gpgme.c:4878
+#: ncrypt/crypt_gpgme.c:4880
 msgid "sapco"
 msgstr "efcaio"
 
-#: ncrypt/crypt_gpgme.c:4885
+#: ncrypt/crypt_gpgme.c:4887
 #, fuzzy
 msgid "PGP (s)ign, sign (a)s, s/(m)ime, (c)lear, or (o)ppenc mode off? "
 msgstr "¿(e)ncriptar, (f)irmar, firmar (c)omo, (a)mbas, (i)nterior, ou (o)lvidar? "
 
 #. L10N: PGP options (opportunistic encryption is on)
-#: ncrypt/crypt_gpgme.c:4887
+#: ncrypt/crypt_gpgme.c:4889
 msgid "samco"
 msgstr "efcaio"
 
 #. L10N: S/MIME options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4900
+#: ncrypt/crypt_gpgme.c:4902
 #, fuzzy
 msgid "S/MIME (e)ncrypt, (s)ign, sign (a)s, (b)oth, (p)gp, (c)lear, or (o)ppenc mode? "
 msgstr "¿(e)ncriptar, (f)irmar, firmar (c)omo, (a)mbas, (i)nterior, ou (o)lvidar? "
 
 #. L10N: S/MIME options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4903
+#: ncrypt/crypt_gpgme.c:4905
 msgid "esabpco"
 msgstr "efcaio"
 
 #. L10N: PGP options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4909
+#: ncrypt/crypt_gpgme.c:4911
 #, fuzzy
 msgid "PGP (e)ncrypt, (s)ign, sign (a)s, (b)oth, s/(m)ime, (c)lear, or (o)ppenc mode? "
 msgstr "¿(e)ncriptar, (f)irmar, firmar (c)omo, (a)mbas, (i)nterior, ou (o)lvidar? "
 
 #. L10N: PGP options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4912
+#: ncrypt/crypt_gpgme.c:4914
 msgid "esabmco"
 msgstr "efcaio"
 
-#: ncrypt/crypt_gpgme.c:4925
+#: ncrypt/crypt_gpgme.c:4927
 #, fuzzy
 msgid "S/MIME (e)ncrypt, (s)ign, sign (a)s, (b)oth, (p)gp or (c)lear? "
 msgstr "¿(e)ncriptar, (f)irmar, firmar (c)omo, (a)mbas, (i)nterior, ou (o)lvidar? "
 
 #. L10N: S/MIME options
-#: ncrypt/crypt_gpgme.c:4927
+#: ncrypt/crypt_gpgme.c:4929
 msgid "esabpc"
 msgstr "efcaio"
 
-#: ncrypt/crypt_gpgme.c:4934
+#: ncrypt/crypt_gpgme.c:4936
 #, fuzzy
 msgid "PGP (e)ncrypt, (s)ign, sign (a)s, (b)oth, s/(m)ime or (c)lear? "
 msgstr "¿(e)ncriptar, (f)irmar, firmar (c)omo, (a)mbas, (i)nterior, ou (o)lvidar? "
 
 #. L10N: PGP options
-#: ncrypt/crypt_gpgme.c:4936
+#: ncrypt/crypt_gpgme.c:4938
 msgid "esabmc"
 msgstr "efcaio"
 
-#: ncrypt/crypt_gpgme.c:5087
+#: ncrypt/crypt_gpgme.c:5089
 msgid "Failed to verify sender"
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:5090
+#: ncrypt/crypt_gpgme.c:5092
 #, fuzzy
 msgid "Failed to figure out sender"
 msgstr "Fallo ó abri-lo ficheiro para analiza-las cabeceiras."
@@ -4573,7 +4635,7 @@ msgstr "Non foi definido nome de usuario POP."
 msgid "%s is an invalid news server specification!"
 msgstr ""
 
-#: nntp.c:75 nntp.c:612 pop.c:1028 pop_lib.c:405
+#: nntp.c:75 nntp.c:612 pop.c:1031 pop_lib.c:405
 msgid "Server closed connection!"
 msgstr "¡O servidor pechou a conexión!"
 
@@ -4741,16 +4803,17 @@ msgstr "comprobar se hai novo correo nos buzóns"
 
 #: opcodes.h:47
 #, fuzzy
-msgid "attach file(s) to this message"
+msgid "attach files to this message"
 msgstr "adxuntar ficheiro(s) a esta mensaxe"
 
 #: opcodes.h:48
-msgid "attach message(s) to this message"
+#, fuzzy
+msgid "attach messages to this message"
 msgstr "adxuntar mensaxe(s) a esta mensaxe"
 
 #: opcodes.h:49
 #, fuzzy
-msgid "attach news article(s) to this message"
+msgid "attach news articles to this message"
 msgstr "adxuntar ficheiro(s) a esta mensaxe"
 
 #: opcodes.h:50
@@ -5603,7 +5666,7 @@ msgstr "extraer chaves públicas PGP"
 
 #: opcodes.h:255
 #, fuzzy
-msgid "wipe passphrase(s) from memory"
+msgid "wipe passphrases from memory"
 msgstr "borra-lo contrasinal PGP de memoria"
 
 #: opcodes.h:259
@@ -5956,18 +6019,20 @@ msgstr "Non hai novo correo no buzón POP."
 msgid "Delete messages from server?"
 msgstr "¿Borra-las mensaxes do servidor?"
 
-#: pop.c:954
-#, c-format
-msgid "Reading new messages (%d bytes)..."
-msgstr "Lendo novas mensaxes (%d bytes)..."
+#: pop.c:955
+#, fuzzy, c-format
+msgid "Reading new messages (%d byte)..."
+msgid_plural "Reading new messages (%d bytes)..."
+msgstr[0] "Lendo novas mensaxes (%d bytes)..."
+msgstr[1] "Lendo novas mensaxes (%d bytes)..."
 
-#: pop.c:997
+#: pop.c:1000
 msgid "Error while writing mailbox!"
 msgstr "¡Erro cando se estaba a escribi-lo buzón!"
 
 #. L10N: The plural is picked by the second numerical argument, i.e.
 #. * the %d right before 'messages', i.e. the total number of messages.
-#: pop.c:1003
+#: pop.c:1006
 #, fuzzy, c-format
 msgid "%s [%d of %d message read]"
 msgid_plural "%s [%d of %d messages read]"
@@ -6115,52 +6180,59 @@ msgstr "Canalizar a: "
 msgid "I don't know how to print %s attachments!"
 msgstr "¡Non sei cómo imprimir adxuntos %s!"
 
-#: recvattach.c:841
-msgid "Print tagged attachment(s)?"
-msgstr "¿Imprimi-la(s) mensaxe(s) marcada(s)?"
+#. L10N: Although we now the precise number of tagged messages, we
+#. do not show it to the user.  So feel free to use a "generic
+#. plural" as plural translation if your language has one.
+#: recvattach.c:852
+#, fuzzy, c-format
+msgid "Print tagged attachment?"
+msgid_plural "Print %d tagged attachments?"
+msgstr[0] "¿Imprimi-la(s) mensaxe(s) marcada(s)?"
+msgstr[1] "¿Imprimi-la(s) mensaxe(s) marcada(s)?"
 
-#: recvattach.c:842
+#: recvattach.c:853
+#, c-format
 msgid "Print attachment?"
 msgstr "¿Imprimir adxunto?"
 
-#: recvattach.c:900
+#: recvattach.c:913
 msgid "Structural changes to decrypted attachments are not supported"
 msgstr ""
 
-#: recvattach.c:1046
+#: recvattach.c:1059
 #, fuzzy
 msgid "Can't decrypt encrypted message!"
 msgstr "Non foi posible atopar ningunha mensaxe marcada."
 
-#: recvattach.c:1172
+#: recvattach.c:1185
 msgid "Attachments"
 msgstr "Adxuntos"
 
 #
-#: recvattach.c:1210
+#: recvattach.c:1223
 msgid "There are no subparts to show!"
 msgstr "Non hai subpartes que amosar."
 
-#: recvattach.c:1265
+#: recvattach.c:1278
 msgid "Can't delete attachment from POP server."
 msgstr "Non é posible borrar un adxunto do servidor POP."
 
-#: recvattach.c:1274
+#: recvattach.c:1287
 #, fuzzy
 msgid "Can't delete attachment from news server."
 msgstr "Non é posible borrar un adxunto do servidor POP."
 
-#: recvattach.c:1281
+#: recvattach.c:1294
 #, fuzzy
 msgid "Deletion of attachments from encrypted messages is unsupported."
 msgstr "O borrado de adxuntos de mensaxes PGP non está soportado."
 
-#: recvattach.c:1287
+#: recvattach.c:1300
 #, fuzzy
 msgid "Deletion of attachments from signed messages may invalidate the signature."
 msgstr "O borrado de adxuntos de mensaxes PGP non está soportado."
 
-#: recvattach.c:1305 recvattach.c:1320
+#: recvattach.c:1318 recvattach.c:1333
 msgid "Only deletion of multipart attachments is supported."
 msgstr "Só o borrado de adxuntos de mensaxes multiparte está soportado."
 
@@ -6586,3 +6658,15 @@ msgstr "Opcións de compilación:"
 #: version.c:404
 msgid "Compile options:"
 msgstr "Opcións de compilación:"
+
+#, fuzzy
+#~ msgid "Cannot delete message(s)"
+#~ msgstr "Non hai mensaxes recuperadas."
+
+#, fuzzy
+#~ msgid "Cannot undelete message(s)"
+#~ msgstr "Non hai mensaxes recuperadas."
+
+#, fuzzy
+#~ msgid "messages not deleted"
+#~ msgstr "Marcando %d mensaxes borradas ..."

--- a/po/hu.po
+++ b/po/hu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neomutt-20180512\n"
 "Report-Msgid-Bugs-To: neomutt-devel@neomutt.org\n"
-"POT-Creation-Date: 2018-05-20 02:02+0000\n"
+"POT-Creation-Date: 2018-05-22 14:18+0000\n"
 "PO-Revision-Date: 2003-08-01 13:56+0000\n"
 "Last-Translator: Szabolcs Horváth <horvaths@fi.inf.elte.hu>\n"
 "Language-Team: LME Magyaritasok Lista <magyar@lists.linux.hu>\n"
@@ -40,7 +40,7 @@ msgstr "Választ"
 
 #: addrbook.c:52 browser.c:75 browser.c:87 compose.c:160 compose.c:172
 #: conn/ssl.c:1041 conn/ssl_gnutls.c:793 curs_main.c:748 curs_main.c:761
-#: history.c:106 ncrypt/crypt_gpgme.c:4219 ncrypt/pgpkey.c:547
+#: history.c:106 ncrypt/crypt_gpgme.c:4221 ncrypt/pgpkey.c:547
 #: ncrypt/smime.c:477 pager.c:2141 postpone.c:65 query.c:72 recvattach.c:70
 msgid "Help"
 msgstr "Súgó"
@@ -695,7 +695,7 @@ msgstr ""
 #. * Since it shares the row with "Encrypt with:", it should not be longer
 #. * than 15-20 character cells.
 #.
-#: compose.c:138 ncrypt/crypt_gpgme.c:4947 ncrypt/pgp.c:1786
+#: compose.c:138 ncrypt/crypt_gpgme.c:4949 ncrypt/pgp.c:1786
 #: ncrypt/smime.c:2127
 msgid "Sign as: "
 msgstr "Aláír mint: "
@@ -1242,7 +1242,7 @@ msgstr "(v)isszautasít, (e)gyszer elfogad"
 msgid "(r)eject, accept (o)nce"
 msgstr "(v)isszautasít, (e)gyszer elfogad"
 
-#: conn/ssl.c:1039 conn/ssl_gnutls.c:791 ncrypt/crypt_gpgme.c:4213
+#: conn/ssl.c:1039 conn/ssl_gnutls.c:791 ncrypt/crypt_gpgme.c:4215
 #: ncrypt/pgpkey.c:541 ncrypt/smime.c:473
 msgid "Exit  "
 msgstr "Kilép  "
@@ -1428,11 +1428,11 @@ msgstr "Nincs megnyitott postafiók."
 msgid "There are no messages."
 msgstr "Nincs levél."
 
-#: curs_main.c:77 mx.c:1061 pager.c:73 recvattach.c:56
+#: curs_main.c:77 mx.c:1071 pager.c:73 recvattach.c:56
 msgid "Mailbox is read-only."
 msgstr "A postafiók csak olvasható."
 
-#: curs_main.c:79 pager.c:75 recvattach.c:1145
+#: curs_main.c:79 pager.c:75 recvattach.c:1158
 msgid "Function not permitted in attach-message mode."
 msgstr "A funkció levél-csatolás módban le van tiltva."
 
@@ -1568,255 +1568,263 @@ msgid "That message is not visible."
 msgstr "Ez a levél nem látható."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:1377 curs_main.c:2772 pager.c:2818
+#. L10N: Due to the implementation details we do not know whether we
+#. delete zero, 1, 12, ... messages. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:1381 curs_main.c:2784 pager.c:2822
 #, fuzzy
-msgid "Cannot delete message(s)"
+msgid "Cannot delete messages"
 msgstr "Nincs visszaállított levél."
 
-#: curs_main.c:1380
+#: curs_main.c:1384
 msgid "Delete messages matching: "
 msgstr "A mintára illeszkedő levelek törlése: "
 
-#: curs_main.c:1421
+#: curs_main.c:1425
 msgid "No limit pattern is in effect."
 msgstr "A szűrő mintának nincs hatása."
 
 #. L10N: ask for a limit to apply
-#: curs_main.c:1426
+#: curs_main.c:1430
 #, c-format
 msgid "Limit: %s"
 msgstr "Szűkítés: %s"
 
-#: curs_main.c:1464
+#: curs_main.c:1468
 msgid "Limit to messages matching: "
 msgstr "Minta a levelek szűkítéséhez: "
 
-#: curs_main.c:1488
+#: curs_main.c:1492
 msgid "To view all messages, limit to \"all\"."
 msgstr ""
 
-#: curs_main.c:1500 pager.c:2318
+#: curs_main.c:1504 pager.c:2318
 msgid "Quit NeoMutt?"
 msgstr "Kilépsz a NeoMuttból?"
 
-#: curs_main.c:1596
+#: curs_main.c:1600
 msgid "Tag messages matching: "
 msgstr "Minta a levelek kijelöléséhez: "
 
 #. L10N: CHECK_ACL
-#: curs_main.c:1606 curs_main.c:3203 pager.c:3137
+#. L10N: Due to the implementation details we do not know whether we
+#. undelete zero, 1, 12, ... messages. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:1614 curs_main.c:3223 pager.c:3145
 #, fuzzy
-msgid "Cannot undelete message(s)"
+msgid "Cannot undelete messages"
 msgstr "Nincs visszaállított levél."
 
-#: curs_main.c:1609
+#: curs_main.c:1617
 msgid "Undelete messages matching: "
 msgstr "Minta a levelek visszaállításához: "
 
-#: curs_main.c:1619
+#: curs_main.c:1627
 msgid "Untag messages matching: "
 msgstr "Minta a levélkijelölés megszüntetéséhez:"
 
-#: curs_main.c:1653
+#: curs_main.c:1661
 #, fuzzy
 msgid "Logged out of IMAP servers."
 msgstr "IMAP kapcsolat lezárása..."
 
-#: curs_main.c:1753
+#: curs_main.c:1761
 #, fuzzy
 msgid "No virtual folder, aborting."
 msgstr "Nincs tárgy megadva, megszakítom."
 
-#: curs_main.c:1761
+#: curs_main.c:1769
 msgid "Failed to read thread, aborting."
 msgstr ""
 
-#: curs_main.c:1793 mx.c:1458 mx.c:1475
+#: curs_main.c:1801 mx.c:1468 mx.c:1485
 msgid "Folder doesn't support tagging, aborting."
 msgstr ""
 
-#: curs_main.c:1808
+#: curs_main.c:1816
 #, fuzzy
 msgid "No tag specified, aborting."
 msgstr "Nincs tárgy megadva, megszakítom."
 
-#: curs_main.c:1820
+#: curs_main.c:1828
 #, c-format
 msgid "Update tags..."
 msgstr ""
 
-#: curs_main.c:1857
+#: curs_main.c:1865
 msgid "Failed to modify tags, aborting."
 msgstr ""
 
-#: curs_main.c:1898
+#: curs_main.c:1906
 #, fuzzy
 msgid "No query, aborting."
 msgstr "Nincs tárgy megadva, megszakítom."
 
-#: curs_main.c:1902 curs_main.c:1922 curs_main.c:1941
+#: curs_main.c:1910 curs_main.c:1930 curs_main.c:1949
 msgid "Failed to create query, aborting."
 msgstr ""
 
-#: curs_main.c:1911 curs_main.c:1930
+#: curs_main.c:1919 curs_main.c:1938
 msgid "Windowed queries disabled."
 msgstr ""
 
-#: curs_main.c:1916 curs_main.c:1935
+#: curs_main.c:1924 curs_main.c:1943
 msgid "No notmuch vfolder currently loaded."
 msgstr ""
 
-#: curs_main.c:1973
+#: curs_main.c:1981
 msgid "Open mailbox in read-only mode"
 msgstr "Postafiók megnyitása csak olvasásra"
 
-#: curs_main.c:1976
+#: curs_main.c:1984
 #, fuzzy
 msgid "Open virtual folder"
 msgstr "más postafiók megnyitása"
 
-#: curs_main.c:1979
+#: curs_main.c:1987
 msgid "Open mailbox"
 msgstr "Postafiók megnyitása"
 
-#: curs_main.c:1989
+#: curs_main.c:1997
 #, fuzzy
 msgid "No mailboxes have new mail"
 msgstr "Nincs új levél egyik postafiókban sem."
 
-#: curs_main.c:2036
+#: curs_main.c:2044
 #, fuzzy
 msgid "Open newsgroup in read-only mode"
 msgstr "Postafiók megnyitása csak olvasásra"
 
-#: curs_main.c:2038
+#: curs_main.c:2046
 msgid "Open newsgroup"
 msgstr ""
 
-#: curs_main.c:2141
+#: curs_main.c:2149
 #, fuzzy
 msgid "Exit NeoMutt without saving?"
 msgstr "Kilépsz a NeoMuttból mentés nélül?"
 
-#: curs_main.c:2157
+#: curs_main.c:2165
 #, fuzzy
 msgid "Cannot break thread"
 msgstr "Nem lehet szűrőt létrehozni."
 
-#: curs_main.c:2160 curs_main.c:2198 curs_main.c:2658 curs_main.c:2690
+#: curs_main.c:2168 curs_main.c:2206 curs_main.c:2666 curs_main.c:2698
 #: flags.c:376 thread.c:1078 thread.c:1134 thread.c:1202
 msgid "Threading is not enabled."
 msgstr "A témázás le van tiltva."
 
-#: curs_main.c:2173
+#: curs_main.c:2181
 msgid "Thread broken"
 msgstr ""
 
-#: curs_main.c:2185
+#: curs_main.c:2193
 msgid "Thread cannot be broken, message is not part of a thread"
 msgstr ""
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2195
+#: curs_main.c:2203
 msgid "Cannot link threads"
 msgstr ""
 
-#: curs_main.c:2200
+#: curs_main.c:2208
 msgid "No Message-ID: header available to link thread"
 msgstr ""
 
-#: curs_main.c:2202
+#: curs_main.c:2210
 #, fuzzy
 msgid "First, please tag a message to be linked here"
 msgstr "üzenet elmentése későbbi küldéshez"
 
-#: curs_main.c:2213
+#: curs_main.c:2221
 msgid "Threads linked"
 msgstr ""
 
-#: curs_main.c:2216
+#: curs_main.c:2224
 msgid "No thread linked"
 msgstr ""
 
-#: curs_main.c:2252 curs_main.c:2278
+#: curs_main.c:2260 curs_main.c:2286
 msgid "You are on the last message."
 msgstr "Ez az utolsó levél."
 
-#: curs_main.c:2260 curs_main.c:2305
+#: curs_main.c:2268 curs_main.c:2313
 msgid "No undeleted messages."
 msgstr "Nincs visszaállított levél."
 
-#: curs_main.c:2297 curs_main.c:2323
+#: curs_main.c:2305 curs_main.c:2331
 msgid "You are on the first message."
 msgstr "Ez az első levél."
 
-#: curs_main.c:2395 menu.c:970 pager.c:2440 pattern.c:2110
+#: curs_main.c:2403 menu.c:970 pager.c:2440 pattern.c:2110
 msgid "Search wrapped to top."
 msgstr "Keresés az elejétől."
 
-#: curs_main.c:2404 pager.c:2463 pattern.c:2121
+#: curs_main.c:2412 pager.c:2463 pattern.c:2121
 msgid "Search wrapped to bottom."
 msgstr "Keresés a végétől."
 
-#: curs_main.c:2447
+#: curs_main.c:2455
 #, fuzzy
 msgid "No new messages in this limited view."
 msgstr "A nyitóüzenet nem látható a szűkített nézetben."
 
-#: curs_main.c:2449
+#: curs_main.c:2457
 #, fuzzy
 msgid "No new messages."
 msgstr "Nincs új levél"
 
-#: curs_main.c:2454
+#: curs_main.c:2462
 #, fuzzy
 msgid "No unread messages in this limited view."
 msgstr "A nyitóüzenet nem látható a szűkített nézetben."
 
-#: curs_main.c:2456
+#: curs_main.c:2464
 #, fuzzy
 msgid "No unread messages."
 msgstr "Nincs olvasatlan levél"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2474
+#: curs_main.c:2482
 #, fuzzy
 msgid "Cannot flag message"
 msgstr "üzenet megjelenítése"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2513 pager.c:3100
+#: curs_main.c:2521 pager.c:3104
 msgid "Cannot toggle new"
 msgstr ""
 
-#: curs_main.c:2590
+#: curs_main.c:2598
 msgid "No more threads."
 msgstr "Nincs több téma."
 
-#: curs_main.c:2592
+#: curs_main.c:2600
 msgid "You are on the first thread."
 msgstr "Ez az első téma."
 
-#: curs_main.c:2676
+#: curs_main.c:2684
 #, fuzzy
 msgid "Thread contains unread or flagged messages."
 msgstr "A témában olvasatlan levelek vannak."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2726 pager.c:2784
+#: curs_main.c:2734 pager.c:2784
 #, fuzzy
 msgid "Cannot delete message"
 msgstr "Nincs visszaállított levél."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2838
+#: curs_main.c:2850
 #, fuzzy
 msgid "Cannot edit message"
 msgstr "Nem lehet írni a levelet"
 
 #. L10N: This is displayed when the x-label on one or more
 #. * messages is edited.
-#: curs_main.c:2900 pager.c:3200
+#: curs_main.c:2912 pager.c:3208
 #, fuzzy, c-format
 msgid "%d label changed."
 msgid_plural "%d labels changed."
@@ -1826,28 +1834,32 @@ msgstr[1] "Postafiók változatlan."
 #. L10N: This is displayed when editing an x-label, but no messages
 #. * were updated.  Possibly due to canceling at the prompt or if the new
 #. * label is the same as the old label.
-#: curs_main.c:2907 pager.c:3204
+#: curs_main.c:2919 pager.c:3212
 #, fuzzy
 msgid "No labels changed."
 msgstr "Postafiók változatlan."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:3006
+#. L10N: Due to the implementation details we do not know whether we
+#. mark zero, 1, 12, ... messages as read. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:3022
 #, fuzzy
-msgid "Cannot mark message(s) as read"
+msgid "Cannot mark messages as read"
 msgstr "ugrás a levél előzményére ebben a témában"
 
 #. L10N: This is the prompt for <mark-message>.  Whatever they
 #. enter will be prefixed by $mark_macro_prefix and will become
 #. a macro hotkey to jump to the currently selected message.
-#: curs_main.c:3042
+#: curs_main.c:3058
 #, fuzzy
 msgid "Enter macro stroke: "
 msgstr "Add meg a kulcsID-t: "
 
 #. L10N: "message hotkey" is the key bindings menu description of a
 #. macro created by <mark-message>.
-#: curs_main.c:3050
+#: curs_main.c:3066
 #, fuzzy
 msgid "message hotkey"
 msgstr "A levél el lett halasztva."
@@ -1855,28 +1867,28 @@ msgstr "A levél el lett halasztva."
 #. L10N: This is echoed after <mark-message> creates a new hotkey
 #. macro.  %s is the hotkey string ($mark_macro_prefix followed
 #. by whatever they typed at the prompt.)
-#: curs_main.c:3055
+#: curs_main.c:3071
 #, fuzzy, c-format
 msgid "Message bound to %s."
 msgstr "Levél visszaküldve."
 
 #. L10N: This error is printed if <mark-message> cannot find a
 #. Message-ID for the currently selected message in the index.
-#: curs_main.c:3063
+#: curs_main.c:3079
 #, fuzzy
 msgid "No message ID to macro."
 msgstr "Nincs levél ebben a postafiókban."
 
-#: curs_main.c:3105 pager.c:2961 recvattach.c:1388
+#: curs_main.c:3121 pager.c:2965 recvattach.c:1401
 msgid "Reply by mail as poster prefers?"
 msgstr ""
 
-#: curs_main.c:3108 pager.c:2927 pager.c:2939 pager.c:2964
+#: curs_main.c:3124 pager.c:2931 pager.c:2943 pager.c:2968
 msgid "Posting to this group not allowed, may be moderated. Continue?"
 msgstr ""
 
 #. L10N: CHECK_ACL
-#: curs_main.c:3173 pager.c:3120
+#: curs_main.c:3189 pager.c:3124
 #, fuzzy
 msgid "Cannot undelete message"
 msgstr "Nincs visszaállított levél."
@@ -2088,12 +2100,34 @@ msgstr "[-- A(z) %s hiba kimenete --]\n"
 msgid "[-- Error: message/external-body has no access-type parameter --]\n"
 msgstr "[-- Hiba: az üzenetnek/külső-törzsének nincs elérési-típus paramétere --]\n"
 
-#: handler.c:1611
+#. L10N: If the translation of this string is a multi line string, then
+#. each line should start with "[-- " and end with " --]".
+#. The first "%s/%s" is a MIME type, e.g. "text/plain". The last %s
+#. expands to a date as returned by `mutt_date_parse_date()`.
+#.
+#. Note: The size argument printed is not the actual number as passed
+#. to gettext but the prettified version, e.g. size = 2048 will be
+#. printed as 2K.  Your language might be sensitive to that: For
+#. example although '1K' and '1024' represent the same number your
+#. language might inflect the noun 'byte' differently.
+#.
+#. Sadly, we cannot do anything about that at the moment besides
+#. passing the precise size in bytes. If you are interested the
+#. function responsible for the prettification is
+#. mutt_str_pretty_size() in mutt/string.c.
+#.
+#: handler.c:1624
 #, fuzzy, c-format
 msgid ""
+"[-- This %s/%s attachment (size %s byte) has been deleted --]\n"
+"[-- on %s --]\n"
+msgid_plural ""
 "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
 "[-- on %s --]\n"
-msgstr ""
+msgstr[0] ""
+"[-- Ez a %s/%s melléklet (mérete %s bájt) törölve lett --]\n"
+"[-- %s-on --]\n"
+msgstr[1] ""
 "[-- Ez a %s/%s melléklet (mérete %s bájt) törölve lett --]\n"
 "[-- %s-on --]\n"
 
@@ -2101,10 +2135,23 @@ msgstr ""
 #. each line should start with "[-- " and end with " --]".
 #. The first "%s/%s" is a MIME type, e.g. "text/plain".
 #.
-#: handler.c:1620
+#. Note: The size argument printed is not the actual number as passed
+#. to gettext but the prettified version, e.g. size = 2048 will be
+#. printed as 2K.  Your language might be sensitive to that: For
+#. example although '1K' and '1024' represent the same number your
+#. language might inflect the noun 'byte' differently.
+#.
+#. Sadly, we cannot do anything about that at the moment besides
+#. passing the precise size in bytes. If you are interested the
+#. function responsible for the prettification is
+#. mutt_str_pretty_size() in mutt/string.c.
+#.
+#: handler.c:1648
 #, fuzzy, c-format
-msgid "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
-msgstr "[-- Ez a %s/%s melléklet (mérete %s bájt) törölve lett --]\n"
+msgid "[-- This %s/%s attachment (size %s byte) has been deleted --]\n"
+msgid_plural "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
+msgstr[0] "[-- Ez a %s/%s melléklet (mérete %s bájt) törölve lett --]\n"
+msgstr[1] "[-- Ez a %s/%s melléklet (mérete %s bájt) törölve lett --]\n"
 
 #. L10N: If the translation of this string is a multi line string, then
 #. each line should start with "[-- " and end with " --]".
@@ -2114,7 +2161,7 @@ msgstr "[-- Ez a %s/%s melléklet (mérete %s bájt) törölve lett --]\n"
 #. Caution: Argument three %3$ is also defined but should not be used
 #. in this translation!
 #.
-#: handler.c:1637
+#: handler.c:1667
 #, fuzzy
 msgid ""
 "[-- This %s/%s attachment has been deleted --]\n"
@@ -2127,17 +2174,17 @@ msgstr ""
 #. each line should start with "[-- " and end with " --]".
 #. The first "%s/%s" is a MIME type, e.g. "text/plain".
 #.
-#: handler.c:1646
+#: handler.c:1676
 #, fuzzy, c-format
 msgid "[-- This %s/%s attachment has been deleted --]\n"
 msgstr "[-- Ez a %s/%s melléklet  törölve lett --]\n"
 
-#: handler.c:1656
+#: handler.c:1686
 #, c-format
 msgid "[-- name: %s --]\n"
 msgstr "[-- név: %s --]\n"
 
-#: handler.c:1672
+#: handler.c:1702
 #, fuzzy, c-format
 msgid ""
 "[-- This %s/%s attachment is not included, --]\n"
@@ -2148,7 +2195,7 @@ msgstr ""
 "[-- és a jelzett külső forrás --]\n"
 "[-- megszűnt. --]\n"
 
-#: handler.c:1693
+#: handler.c:1723
 #, fuzzy, c-format
 msgid ""
 "[-- This %s/%s attachment is not included, --]\n"
@@ -2157,52 +2204,52 @@ msgstr ""
 "[-- A %s/%s melléklet nincs beágyazva, --]\n"
 "[-- és a jelzett elérési-típus, %s nincs támogatva --]\n"
 
-#: handler.c:1822
+#: handler.c:1852
 #, fuzzy
 msgid "Unable to open memory stream!"
 msgstr "Nem lehet megnyitni átmeneti fájlt!"
 
-#: handler.c:1831
+#: handler.c:1861
 msgid "Unable to open temporary file!"
 msgstr "Nem lehet megnyitni átmeneti fájlt!"
 
-#: handler.c:1881
+#: handler.c:1911
 #, fuzzy
 msgid "failed to re-open memstream!"
 msgstr "Nem lehet megnyitni átmeneti fájlt!"
 
-#: handler.c:2013
+#: handler.c:2043
 msgid "Error: multipart/signed has no protocol."
 msgstr "Hiba: a többrészes/aláírt részhez nincs protokoll megadva."
 
-#: handler.c:2076
+#: handler.c:2106
 #, fuzzy
 msgid "[-- This is an attachment (use '%3$s' to view this part) --]\n"
 msgstr "[-- Ez a %s/%s melléklet (E rész megjelenítéséhez használja a(z) '%3$s'-t) --]\n"
 
-#: handler.c:2082
+#: handler.c:2112
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported (use '%s' to view this part) --]\n"
 msgstr "[-- %s/%s nincs támogatva (E rész megjelenítéséhez használja a(z) '%s'-t) --]\n"
 
-#: handler.c:2087
+#: handler.c:2117
 #, fuzzy
 msgid "[-- This is an attachment (need 'view-attachments' bound to key!) --]\n"
 msgstr "[-- Ez a %s/%s melléklet (a mellélet megtekintéshez billentyű lenyomás szükséges!) --]\n"
 
 #. L10N: %s/%s is a MIME type, e.g. "text/plain".
-#: handler.c:2091
+#: handler.c:2121
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported (need 'view-attachments' bound to key!) --]\n"
 msgstr "[-- %s/%s nincs támogatva (a mellélet megtekintéshez billentyű lenyomás szükséges!) --]\n"
 
-#: handler.c:2098
+#: handler.c:2128
 #, fuzzy
 msgid "[-- This is an attachment --]\n"
 msgstr "[-- Ez a %s/%s melléklet --]\n"
 
 #. L10N: %s/%s is a MIME type, e.g. "text/plain".
-#: handler.c:2101
+#: handler.c:2131
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported --]\n"
 msgstr "[-- %s/%s nincs támogatva --]\n"
@@ -2510,7 +2557,7 @@ msgstr ""
 msgid "Invalid IMAP flags"
 msgstr "Érvénytelen   "
 
-#: imap/message.c:477 mx.c:1326
+#: imap/message.c:477 mx.c:1336
 msgid "Integer overflow -- can't allocate memory."
 msgstr ""
 
@@ -3284,66 +3331,75 @@ msgstr "SSL nem elérhető."
 msgid "Reading from %s interrupted..."
 msgstr "Keresés megszakítva."
 
-#: mx.c:634
+#. L10N: Although we now the precise number of messages, we do not show it to the user.
+#. So feel free to use a "generic plural" as plural translation if your language has one.
+#.
+#: mx.c:639
 #, fuzzy
-msgid "message(s) not deleted"
-msgstr "%d levél megjelölése töröltnek..."
+msgid "message not deleted"
+msgid_plural "messages not deleted"
+msgstr[0] "%d levél megjelölése töröltnek..."
+msgstr[1] "%d levél megjelölése töröltnek..."
 
-#: mx.c:671
+#: mx.c:676
 #, fuzzy
 msgid "Can't open trash folder"
 msgstr "Nem lehet hozzáfűzni a(z) %s postafiókhoz"
 
-#: mx.c:710
+#: mx.c:715
 msgid "Mark all articles read?"
 msgstr ""
 
-#: mx.c:754
+#. L10N: The first argument is the number of read messages to be
+#. moved, the second argument is the target mailbox.
+#: mx.c:762
 #, fuzzy, c-format
-msgid "Move %d read messages to %s?"
-msgstr "Az olvasott leveleket mozgassam a %s postafiókba?"
+msgid "Move %d read message to %s?"
+msgid_plural "Move %d read messages to %s?"
+msgstr[0] "Az olvasott leveleket mozgassam a %s postafiókba?"
+msgstr[1] "Az olvasott leveleket mozgassam a %s postafiókba?"
 
-#: mx.c:771 mx.c:1077
+#: mx.c:781 mx.c:1087
 #, fuzzy, c-format
 msgid "Purge %d deleted message?"
 msgid_plural "Purge %d deleted messages?"
 msgstr[0] "Töröljem a %d töröltnek jelölt levelet?"
 msgstr[1] "Töröljem a %d töröltnek jelölt levelet?"
 
-#: mx.c:793
+#: mx.c:803
 #, c-format
 msgid "Moving read messages to %s..."
 msgstr "Olvasott levelek mozgatása a %s postafiókba..."
 
-#: mx.c:859 mx.c:1068
+#: mx.c:869 mx.c:1078
 msgid "Mailbox is unchanged."
 msgstr "Postafiók változatlan."
 
-#: mx.c:914
+#: mx.c:924
 #, c-format
 msgid "%d kept, %d moved, %d deleted."
 msgstr "%d megtartva, %d átmozgatva, %d törölve."
 
-#: mx.c:917 mx.c:1130
+#: mx.c:927 mx.c:1140
 #, c-format
 msgid "%d kept, %d deleted."
 msgstr "%d megtartva, %d törölve."
 
-#: mx.c:1052
+#: mx.c:1062
 #, c-format
 msgid " Press '%s' to toggle write"
 msgstr " Nyomd meg a '%s' gombot az írás ki/bekapcsolásához"
 
-#: mx.c:1054
+#: mx.c:1064
 msgid "Use 'toggle-write' to re-enable write!"
 msgstr "Használd a 'toggle-write'-ot az írás újra engedélyezéséhez!"
 
-#: mx.c:1056
+#: mx.c:1066
 #, c-format
 msgid "Mailbox is marked unwritable. %s"
 msgstr "A postafiókot megjelöltem nem írhatónak. %s"
 
-#: mx.c:1124
+#: mx.c:1134
 msgid "Mailbox checkpointed."
 msgstr "A postafiók ellenőrizve."
 
@@ -3357,52 +3413,57 @@ msgstr " (pontos idő: %c)"
 msgid "[-- %s output follows%s --]\n"
 msgstr "[-- %s kimenet következik%s --]\n"
 
-#: ncrypt/crypt.c:95
-msgid "Passphrase(s) forgotten."
+#. L10N: Due to the implementation details (e.g. some passwords are managed
+#. by gpg-agent) we cannot know whether we forgot zero, 1, 12, ...
+#. passwords. So in English we use "Passphrases". Your language might
+#. have other means to express this.
+#: ncrypt/crypt.c:100
+#, fuzzy
+msgid "Passphrases forgotten."
 msgstr "Jelszó elfelejtve."
 
-#: ncrypt/crypt.c:155
+#: ncrypt/crypt.c:161
 msgid "Inline PGP can't be used with attachments.  Revert to PGP/MIME?"
 msgstr ""
 
-#: ncrypt/crypt.c:159
+#: ncrypt/crypt.c:165
 msgid "Mail not sent: inline PGP can't be used with attachments."
 msgstr ""
 
-#: ncrypt/crypt.c:166
+#: ncrypt/crypt.c:172
 msgid "Inline PGP can't be used with format=flowed.  Revert to PGP/MIME?"
 msgstr ""
 
-#: ncrypt/crypt.c:170
+#: ncrypt/crypt.c:176
 msgid "Mail not sent: inline PGP can't be used with format=flowed."
 msgstr ""
 
-#: ncrypt/crypt.c:180 ncrypt/cryptglue.c:125 ncrypt/pgpkey.c:589
+#: ncrypt/crypt.c:186 ncrypt/cryptglue.c:125 ncrypt/pgpkey.c:589
 #: ncrypt/pgpkey.c:782
 msgid "Invoking PGP..."
 msgstr "PGP betöltés..."
 
-#: ncrypt/crypt.c:192
+#: ncrypt/crypt.c:198
 msgid "Message can't be sent inline.  Revert to using PGP/MIME?"
 msgstr ""
 
-#: ncrypt/crypt.c:194 send.c:1824
+#: ncrypt/crypt.c:200 send.c:1824
 msgid "Mail not sent."
 msgstr "A levél nem lett elküldve."
 
-#: ncrypt/crypt.c:540
+#: ncrypt/crypt.c:546
 msgid "S/MIME messages with no hints on content are unsupported."
 msgstr "Tartalom-útmutatás nélküli S/MIME üzenetek nem támogatottak."
 
-#: ncrypt/crypt.c:754 ncrypt/crypt.c:795
+#: ncrypt/crypt.c:760 ncrypt/crypt.c:801
 msgid "Trying to extract PGP keys...\n"
 msgstr "PGP kulcsok kibontása...\n"
 
-#: ncrypt/crypt.c:776 ncrypt/crypt.c:816
+#: ncrypt/crypt.c:782 ncrypt/crypt.c:822
 msgid "Trying to extract S/MIME certificates...\n"
 msgstr "S/MIME tanúsítványok kibontása...\n"
 
-#: ncrypt/crypt.c:976
+#: ncrypt/crypt.c:982
 #, c-format
 msgid ""
 "[-- Error: Unknown multipart/signed protocol %s! --]\n"
@@ -3411,7 +3472,7 @@ msgstr ""
 "[-- Hiba: Ismeretlen többrészes/aláírt protokoll %s! --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1016
+#: ncrypt/crypt.c:1022
 #, fuzzy
 msgid ""
 "[-- Error: Missing or bad-format multipart/signed signature! --]\n"
@@ -3420,7 +3481,7 @@ msgstr ""
 "[-- Hiba: Ellentmondó többrészes/aláírt struktúra! --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1058
+#: ncrypt/crypt.c:1064
 #, c-format
 msgid ""
 "[-- Warning: We can't verify %s/%s signatures. --]\n"
@@ -3429,7 +3490,7 @@ msgstr ""
 "[-- Figyelmeztetés: Nem tudtam leellenőrizni a %s/%s aláírásokat. --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1070
+#: ncrypt/crypt.c:1076
 msgid ""
 "[-- The following data is signed --]\n"
 "\n"
@@ -3437,7 +3498,7 @@ msgstr ""
 "[-- A következő adatok alá vannak írva --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1075
+#: ncrypt/crypt.c:1081
 msgid ""
 "[-- Warning: Can't find any signatures. --]\n"
 "\n"
@@ -3445,7 +3506,7 @@ msgstr ""
 "[-- Figyelmeztetés: Nem találtam egy aláírást sem. --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1081
+#: ncrypt/crypt.c:1087
 msgid ""
 "\n"
 "[-- End of signed data --]\n"
@@ -3497,7 +3558,7 @@ msgstr ""
 msgid "error reading data object: %s\n"
 msgstr "hiba a mintában: %s"
 
-#: ncrypt/crypt_gpgme.c:662 ncrypt/crypt_gpgme.c:3848 ncrypt/pgpkey.c:585
+#: ncrypt/crypt_gpgme.c:662 ncrypt/crypt_gpgme.c:3850 ncrypt/pgpkey.c:585
 #: ncrypt/pgpkey.c:768
 msgid "Can't create temporary file"
 msgstr "Nem lehet ideiglenes fájlt létrehozni"
@@ -3861,29 +3922,31 @@ msgstr "Érvénytelen   "
 
 #. L10N: This is printed after "Key Type: " and looks like this:
 #. *       PGP, 2048 bit RSA
-#: ncrypt/crypt_gpgme.c:3670 ncrypt/crypt_gpgme.c:3808
+#: ncrypt/crypt_gpgme.c:3670 ncrypt/crypt_gpgme.c:3810
 #, c-format
 msgid "%s, %lu bit %s\n"
-msgstr ""
+msgid_plural "%s, %lu bit %s\n"
+msgstr[0] ""
+msgstr[1] ""
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3678 ncrypt/crypt_gpgme.c:3815
+#: ncrypt/crypt_gpgme.c:3678 ncrypt/crypt_gpgme.c:3817
 #, fuzzy
 msgid "encryption"
 msgstr "Titkosít"
 
 #: ncrypt/crypt_gpgme.c:3679 ncrypt/crypt_gpgme.c:3685
-#: ncrypt/crypt_gpgme.c:3816 ncrypt/crypt_gpgme.c:3821
+#: ncrypt/crypt_gpgme.c:3818 ncrypt/crypt_gpgme.c:3823
 msgid ", "
 msgstr ""
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3684 ncrypt/crypt_gpgme.c:3820
+#: ncrypt/crypt_gpgme.c:3684 ncrypt/crypt_gpgme.c:3822
 msgid "signing"
 msgstr ""
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3690 ncrypt/crypt_gpgme.c:3825
+#: ncrypt/crypt_gpgme.c:3690 ncrypt/crypt_gpgme.c:3827
 #, fuzzy
 msgid "certification"
 msgstr "A tanúsítvány elmentve"
@@ -3905,70 +3968,70 @@ msgstr "Lejárt        "
 msgid "[Disabled]"
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:3851
+#: ncrypt/crypt_gpgme.c:3853
 #, fuzzy
 msgid "Collecting data..."
 msgstr "Kapcsolódás %s-hez..."
 
-#: ncrypt/crypt_gpgme.c:3876
+#: ncrypt/crypt_gpgme.c:3878
 #, fuzzy, c-format
 msgid "Error finding issuer key: %s\n"
 msgstr "Hiba a szerverre való csatlakozás közben: %s"
 
-#: ncrypt/crypt_gpgme.c:3885
+#: ncrypt/crypt_gpgme.c:3887
 #, fuzzy
 msgid "Error: certification chain too long - stopping here\n"
 msgstr "Hibás parancssor: %s\n"
 
-#: ncrypt/crypt_gpgme.c:3895 ncrypt/pgpkey.c:608
+#: ncrypt/crypt_gpgme.c:3897 ncrypt/pgpkey.c:608
 #, c-format
 msgid "Key ID: 0x%s"
 msgstr "Kulcs ID: 0x%s"
 
-#: ncrypt/crypt_gpgme.c:3990
+#: ncrypt/crypt_gpgme.c:3992
 #, fuzzy, c-format
 msgid "gpgme_new failed: %s"
 msgstr "SSL sikertelen: %s"
 
-#: ncrypt/crypt_gpgme.c:4028 ncrypt/crypt_gpgme.c:4079
+#: ncrypt/crypt_gpgme.c:4030 ncrypt/crypt_gpgme.c:4081
 #, c-format
 msgid "gpgme_op_keylist_start failed: %s"
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4067 ncrypt/crypt_gpgme.c:4109
+#: ncrypt/crypt_gpgme.c:4069 ncrypt/crypt_gpgme.c:4111
 #, c-format
 msgid "gpgme_op_keylist_next failed: %s"
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4185
+#: ncrypt/crypt_gpgme.c:4187
 #, fuzzy
 msgid "All matching keys are marked expired/revoked."
 msgstr "Minden illeszkedő kulcs lejárt/letiltott/visszavont."
 
-#: ncrypt/crypt_gpgme.c:4215 ncrypt/pgpkey.c:543 ncrypt/smime.c:475
+#: ncrypt/crypt_gpgme.c:4217 ncrypt/pgpkey.c:543 ncrypt/smime.c:475
 msgid "Select  "
 msgstr "Választ  "
 
-#: ncrypt/crypt_gpgme.c:4217 ncrypt/pgpkey.c:545
+#: ncrypt/crypt_gpgme.c:4219 ncrypt/pgpkey.c:545
 msgid "Check key  "
 msgstr "Kulcs ellenőrzése  "
 
-#: ncrypt/crypt_gpgme.c:4233
+#: ncrypt/crypt_gpgme.c:4235
 #, fuzzy
 msgid "PGP and S/MIME keys matching"
 msgstr "PGP kulcsok egyeznek \"%s\"."
 
-#: ncrypt/crypt_gpgme.c:4235
+#: ncrypt/crypt_gpgme.c:4237
 #, fuzzy
 msgid "PGP keys matching"
 msgstr "PGP kulcsok egyeznek \"%s\"."
 
-#: ncrypt/crypt_gpgme.c:4237
+#: ncrypt/crypt_gpgme.c:4239
 #, fuzzy
 msgid "S/MIME keys matching"
 msgstr "S/MIME kulcsok egyeznek \"%s\"."
 
-#: ncrypt/crypt_gpgme.c:4239
+#: ncrypt/crypt_gpgme.c:4241
 #, fuzzy
 msgid "keys matching"
 msgstr "PGP kulcsok egyeznek \"%s\"."
@@ -3977,69 +4040,69 @@ msgstr "PGP kulcsok egyeznek \"%s\"."
 #. %1$s is one of the previous four entries.
 #. %2$s is an address.
 #. e.g. "S/MIME keys matching <me@mutt.org>."
-#: ncrypt/crypt_gpgme.c:4246
+#: ncrypt/crypt_gpgme.c:4248
 #, c-format
 msgid "%s <%s>."
 msgstr ""
 
 #. L10N:
 #. e.g. 'S/MIME keys matching "Michael Elkins".'
-#: ncrypt/crypt_gpgme.c:4250
+#: ncrypt/crypt_gpgme.c:4252
 #, c-format
 msgid "%s \"%s\"."
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4277 ncrypt/pgpkey.c:628
+#: ncrypt/crypt_gpgme.c:4279 ncrypt/pgpkey.c:628
 msgid "This key can't be used: expired/disabled/revoked."
 msgstr "Ez a kulcs nem használható: lejárt/letiltott/visszahívott."
 
-#: ncrypt/crypt_gpgme.c:4290 ncrypt/pgpkey.c:640 ncrypt/smime.c:505
+#: ncrypt/crypt_gpgme.c:4292 ncrypt/pgpkey.c:640 ncrypt/smime.c:505
 #, fuzzy
 msgid "ID is expired/disabled/revoked. Do you really want to use the key?"
 msgstr "ID lejárt/letiltott/visszavont. Valóban szeretnéd használni ezt a kulcsot?"
 
-#: ncrypt/crypt_gpgme.c:4299 ncrypt/pgpkey.c:650
+#: ncrypt/crypt_gpgme.c:4301 ncrypt/pgpkey.c:650
 #, fuzzy
 msgid "ID is not valid. Do you really want to use the key?"
 msgstr "Az ID nem érvényes. Valóban szeretnéd használni ezt a kulcsot?"
 
-#: ncrypt/crypt_gpgme.c:4302 ncrypt/pgpkey.c:653
+#: ncrypt/crypt_gpgme.c:4304 ncrypt/pgpkey.c:653
 #, fuzzy
 msgid "ID is only marginally valid. Do you really want to use the key?"
 msgstr "Az ID csak részlegesen érvényes. Valóban szeretnéd használni ezt a kulcsot?"
 
-#: ncrypt/crypt_gpgme.c:4310 ncrypt/pgpkey.c:646 ncrypt/smime.c:509
+#: ncrypt/crypt_gpgme.c:4312 ncrypt/pgpkey.c:646 ncrypt/smime.c:509
 #, fuzzy
 msgid "ID has undefined validity. Do you really want to use the key?"
 msgstr "ID-nek nincs meghatározva az érvényessége. Valóban szeretnéd használni ezt a kulcsot?"
 
-#: ncrypt/crypt_gpgme.c:4370 ncrypt/crypt_gpgme.c:4479 ncrypt/pgpkey.c:872
+#: ncrypt/crypt_gpgme.c:4372 ncrypt/crypt_gpgme.c:4481 ncrypt/pgpkey.c:872
 #: ncrypt/pgpkey.c:995
 #, c-format
 msgid "Looking for keys matching \"%s\"..."
 msgstr "Egyező \"%s\" kulcsok keresése..."
 
-#: ncrypt/crypt_gpgme.c:4593 ncrypt/pgpkey.c:731 ncrypt/smime.c:811
+#: ncrypt/crypt_gpgme.c:4595 ncrypt/pgpkey.c:731 ncrypt/smime.c:811
 #, c-format
 msgid "No matching keys found for \"%s\""
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4644 ncrypt/pgp.c:1263
+#: ncrypt/crypt_gpgme.c:4646 ncrypt/pgp.c:1263
 #, c-format
 msgid "Use keyID = \"%s\" for %s?"
 msgstr "Használjam a kulcsID = \"%s\" ehhez: %s?"
 
-#: ncrypt/crypt_gpgme.c:4695 ncrypt/pgp.c:1312 ncrypt/smime.c:830
+#: ncrypt/crypt_gpgme.c:4697 ncrypt/pgp.c:1312 ncrypt/smime.c:830
 #: ncrypt/smime.c:938
 #, c-format
 msgid "Enter keyID for %s: "
 msgstr "Add meg a kulcsID-t %s-hoz: "
 
-#: ncrypt/crypt_gpgme.c:4755 ncrypt/pgpkey.c:751
+#: ncrypt/crypt_gpgme.c:4757 ncrypt/pgpkey.c:751
 msgid "Please enter the key ID: "
 msgstr "Kérlek írd be a kulcs ID-t: "
 
-#: ncrypt/crypt_gpgme.c:4768
+#: ncrypt/crypt_gpgme.c:4770
 #, fuzzy, c-format
 msgid "Error exporting key: %s\n"
 msgstr "hiba a mintában: %s"
@@ -4048,86 +4111,86 @@ msgstr "hiba a mintában: %s"
 #. MIME description for exported (attached) keys.
 #. You can translate this entry to a non-ASCII string (it will be encoded),
 #. but it may be safer to keep it untranslated.
-#: ncrypt/crypt_gpgme.c:4787
+#: ncrypt/crypt_gpgme.c:4789
 #, fuzzy, c-format
 msgid "PGP Key 0x%s."
 msgstr "PGP Kulcs %s."
 
-#: ncrypt/crypt_gpgme.c:4830
+#: ncrypt/crypt_gpgme.c:4832
 msgid "GPGME: OpenPGP protocol not available"
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4838
+#: ncrypt/crypt_gpgme.c:4840
 msgid "GPGME: CMS protocol not available"
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4876
+#: ncrypt/crypt_gpgme.c:4878
 #, fuzzy
 msgid "S/MIME (s)ign, sign (a)s, (p)gp, (c)lear, or (o)ppenc mode off? "
 msgstr "S/MIME (t)itkosít, (a)láír, aláír (m)int, titkosít é(s) aláír, (b)eágyazott, mé(g)se? "
 
 #. L10N: S/MIME options (opportunistic encryption is on)
-#: ncrypt/crypt_gpgme.c:4878
+#: ncrypt/crypt_gpgme.c:4880
 msgid "sapco"
 msgstr "tamsbg"
 
-#: ncrypt/crypt_gpgme.c:4885
+#: ncrypt/crypt_gpgme.c:4887
 #, fuzzy
 msgid "PGP (s)ign, sign (a)s, s/(m)ime, (c)lear, or (o)ppenc mode off? "
 msgstr "PGP (t)itkosít, (a)láír, aláír (m)int, titkosít é(s) aláír, (b)eágyazott, mé(g)se? "
 
 #. L10N: PGP options (opportunistic encryption is on)
-#: ncrypt/crypt_gpgme.c:4887
+#: ncrypt/crypt_gpgme.c:4889
 msgid "samco"
 msgstr "tamsbg"
 
 #. L10N: S/MIME options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4900
+#: ncrypt/crypt_gpgme.c:4902
 #, fuzzy
 msgid "S/MIME (e)ncrypt, (s)ign, sign (a)s, (b)oth, (p)gp, (c)lear, or (o)ppenc mode? "
 msgstr "S/MIME (t)itkosít, (a)láír, aláír (m)int, titkosít é(s) aláír, (b)eágyazott, mé(g)se? "
 
 #. L10N: S/MIME options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4903
+#: ncrypt/crypt_gpgme.c:4905
 msgid "esabpco"
 msgstr "tamsbg"
 
 #. L10N: PGP options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4909
+#: ncrypt/crypt_gpgme.c:4911
 #, fuzzy
 msgid "PGP (e)ncrypt, (s)ign, sign (a)s, (b)oth, s/(m)ime, (c)lear, or (o)ppenc mode? "
 msgstr "PGP (t)itkosít, (a)láír, aláír (m)int, titkosít é(s) aláír, (b)eágyazott, mé(g)se? "
 
 #. L10N: PGP options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4912
+#: ncrypt/crypt_gpgme.c:4914
 msgid "esabmco"
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4925
+#: ncrypt/crypt_gpgme.c:4927
 #, fuzzy
 msgid "S/MIME (e)ncrypt, (s)ign, sign (a)s, (b)oth, (p)gp or (c)lear? "
 msgstr "S/MIME (t)itkosít, (a)láír, aláír (m)int, titkosít é(s) aláír, (b)eágyazott, mé(g)se? "
 
 #. L10N: S/MIME options
-#: ncrypt/crypt_gpgme.c:4927
+#: ncrypt/crypt_gpgme.c:4929
 msgid "esabpc"
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4934
+#: ncrypt/crypt_gpgme.c:4936
 #, fuzzy
 msgid "PGP (e)ncrypt, (s)ign, sign (a)s, (b)oth, s/(m)ime or (c)lear? "
 msgstr "PGP (t)itkosít, (a)láír, aláír (m)int, titkosít é(s) aláír, (b)eágyazott, mé(g)se? "
 
 #. L10N: PGP options
-#: ncrypt/crypt_gpgme.c:4936
+#: ncrypt/crypt_gpgme.c:4938
 msgid "esabmc"
 msgstr "tamsbg"
 
-#: ncrypt/crypt_gpgme.c:5087
+#: ncrypt/crypt_gpgme.c:5089
 msgid "Failed to verify sender"
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:5090
+#: ncrypt/crypt_gpgme.c:5092
 #, fuzzy
 msgid "Failed to figure out sender"
 msgstr "Fájl megnyitási hiba a fejléc vizsgálatakor."
@@ -4527,7 +4590,7 @@ msgstr ""
 msgid "%s is an invalid news server specification!"
 msgstr "%s érvénytelen POP útvonal"
 
-#: nntp.c:75 nntp.c:612 pop.c:1028 pop_lib.c:405
+#: nntp.c:75 nntp.c:612 pop.c:1031 pop_lib.c:405
 msgid "Server closed connection!"
 msgstr "A szerver lezárta a kapcsolatot!"
 
@@ -4693,16 +4756,17 @@ msgstr "új levél keresése a postafiókokban"
 
 #: opcodes.h:47
 #, fuzzy
-msgid "attach file(s) to this message"
+msgid "attach files to this message"
 msgstr "fájl(ok) csatolása ezen üzenethez"
 
 #: opcodes.h:48
-msgid "attach message(s) to this message"
+#, fuzzy
+msgid "attach messages to this message"
 msgstr "üzenet(ek) csatolása ezen üzenethez"
 
 #: opcodes.h:49
 #, fuzzy
-msgid "attach news article(s) to this message"
+msgid "attach news articles to this message"
 msgstr "fájl(ok) csatolása ezen üzenethez"
 
 #: opcodes.h:50
@@ -5550,7 +5614,8 @@ msgid "extract supported public keys"
 msgstr "támogatott nyilvános kulcsok kibontása"
 
 #: opcodes.h:255
-msgid "wipe passphrase(s) from memory"
+#, fuzzy
+msgid "wipe passphrases from memory"
 msgstr "jelszó törlése a memóriából"
 
 #: opcodes.h:259
@@ -5902,18 +5967,20 @@ msgstr "Nincs új levél a POP postafiókban."
 msgid "Delete messages from server?"
 msgstr "Levelek törlése a szerverről?"
 
-#: pop.c:954
-#, c-format
-msgid "Reading new messages (%d bytes)..."
-msgstr "Új levelek olvasása (%d bytes)..."
+#: pop.c:955
+#, fuzzy, c-format
+msgid "Reading new messages (%d byte)..."
+msgid_plural "Reading new messages (%d bytes)..."
+msgstr[0] "Új levelek olvasása (%d bytes)..."
+msgstr[1] "Új levelek olvasása (%d bytes)..."
 
-#: pop.c:997
+#: pop.c:1000
 msgid "Error while writing mailbox!"
 msgstr "Hiba a postafiók írásakor!"
 
 #. L10N: The plural is picked by the second numerical argument, i.e.
 #. * the %d right before 'messages', i.e. the total number of messages.
-#: pop.c:1003
+#: pop.c:1006
 #, fuzzy, c-format
 msgid "%s [%d of %d message read]"
 msgid_plural "%s [%d of %d messages read]"
@@ -6059,49 +6126,56 @@ msgstr "Átküld: "
 msgid "I don't know how to print %s attachments!"
 msgstr "Nem tudom hogyan kell nyomtatni a(z) %s csatolást!"
 
-#: recvattach.c:841
-msgid "Print tagged attachment(s)?"
-msgstr "Kinyomtassam a kijelölt melléklet(ek)et?"
+#. L10N: Although we now the precise number of tagged messages, we
+#. do not show it to the user.  So feel free to use a "generic
+#. plural" as plural translation if your language has one.
+#: recvattach.c:852
+#, fuzzy, c-format
+msgid "Print tagged attachment?"
+msgid_plural "Print %d tagged attachments?"
+msgstr[0] "Kinyomtassam a kijelölt melléklet(ek)et?"
+msgstr[1] "Kinyomtassam a kijelölt melléklet(ek)et?"
 
-#: recvattach.c:842
+#: recvattach.c:853
+#, c-format
 msgid "Print attachment?"
 msgstr "Kinyomtassam a mellékletet?"
 
-#: recvattach.c:900
+#: recvattach.c:913
 msgid "Structural changes to decrypted attachments are not supported"
 msgstr ""
 
-#: recvattach.c:1046
+#: recvattach.c:1059
 msgid "Can't decrypt encrypted message!"
 msgstr "Nem tudtam visszafejteni a titkosított üzenetet!"
 
-#: recvattach.c:1172
+#: recvattach.c:1185
 msgid "Attachments"
 msgstr "Mellékletek"
 
-#: recvattach.c:1210
+#: recvattach.c:1223
 msgid "There are no subparts to show!"
 msgstr "Nincsenek mutatható részek!"
 
-#: recvattach.c:1265
+#: recvattach.c:1278
 msgid "Can't delete attachment from POP server."
 msgstr "POP kiszolgálón nem lehet mellékletet törölni."
 
-#: recvattach.c:1274
+#: recvattach.c:1287
 #, fuzzy
 msgid "Can't delete attachment from news server."
 msgstr "POP kiszolgálón nem lehet mellékletet törölni."
 
-#: recvattach.c:1281
+#: recvattach.c:1294
 msgid "Deletion of attachments from encrypted messages is unsupported."
 msgstr "Mellékletek törlése kódolt üzenetből nem támogatott."
 
-#: recvattach.c:1287
+#: recvattach.c:1300
 #, fuzzy
 msgid "Deletion of attachments from signed messages may invalidate the signature."
 msgstr "Mellékletek törlése kódolt üzenetből nem támogatott."
 
-#: recvattach.c:1305 recvattach.c:1320
+#: recvattach.c:1318 recvattach.c:1333
 msgid "Only deletion of multipart attachments is supported."
 msgstr "Többrészes csatolásoknál csak a törlés támogatott."
 
@@ -6521,3 +6595,15 @@ msgstr "Fordítási opciók:"
 #: version.c:404
 msgid "Compile options:"
 msgstr "Fordítási opciók:"
+
+#, fuzzy
+#~ msgid "Cannot delete message(s)"
+#~ msgstr "Nincs visszaállított levél."
+
+#, fuzzy
+#~ msgid "Cannot undelete message(s)"
+#~ msgstr "Nincs visszaállított levél."
+
+#, fuzzy
+#~ msgid "messages not deleted"
+#~ msgstr "%d levél megjelölése töröltnek..."

--- a/po/id.po
+++ b/po/id.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neomutt-20180512\n"
 "Report-Msgid-Bugs-To: neomutt-devel@neomutt.org\n"
-"POT-Creation-Date: 2018-05-20 02:02+0000\n"
+"POT-Creation-Date: 2018-05-22 14:18+0000\n"
 "PO-Revision-Date: 2007-11-07 10:39+1100\n"
 "Last-Translator: Ronny Haryanto <ronny@haryan.to>\n"
 "Language-Team: Indonesian <web@linux.or.id>\n"
@@ -41,7 +41,7 @@ msgstr "Pilih"
 
 #: addrbook.c:52 browser.c:75 browser.c:87 compose.c:160 compose.c:172
 #: conn/ssl.c:1041 conn/ssl_gnutls.c:793 curs_main.c:748 curs_main.c:761
-#: history.c:106 ncrypt/crypt_gpgme.c:4219 ncrypt/pgpkey.c:547
+#: history.c:106 ncrypt/crypt_gpgme.c:4221 ncrypt/pgpkey.c:547
 #: ncrypt/smime.c:477 pager.c:2141 postpone.c:65 query.c:72 recvattach.c:70
 msgid "Help"
 msgstr "Bantuan"
@@ -688,7 +688,7 @@ msgstr ""
 #. * Since it shares the row with "Encrypt with:", it should not be longer
 #. * than 15-20 character cells.
 #.
-#: compose.c:138 ncrypt/crypt_gpgme.c:4947 ncrypt/pgp.c:1786
+#: compose.c:138 ncrypt/crypt_gpgme.c:4949 ncrypt/pgp.c:1786
 #: ncrypt/smime.c:2127
 msgid "Sign as: "
 msgstr "Tandatangani sebagai: "
@@ -1234,7 +1234,7 @@ msgstr "(t)olak, terima (s)ekali"
 msgid "(r)eject, accept (o)nce"
 msgstr "(t)olak, terima (s)ekali"
 
-#: conn/ssl.c:1039 conn/ssl_gnutls.c:791 ncrypt/crypt_gpgme.c:4213
+#: conn/ssl.c:1039 conn/ssl_gnutls.c:791 ncrypt/crypt_gpgme.c:4215
 #: ncrypt/pgpkey.c:541 ncrypt/smime.c:473
 msgid "Exit  "
 msgstr "Keluar  "
@@ -1414,11 +1414,11 @@ msgstr "Tidak ada kotak surat yang terbuka."
 msgid "There are no messages."
 msgstr "Tidak ada surat."
 
-#: curs_main.c:77 mx.c:1061 pager.c:73 recvattach.c:56
+#: curs_main.c:77 mx.c:1071 pager.c:73 recvattach.c:56
 msgid "Mailbox is read-only."
 msgstr "Kotak surat hanya bisa dibaca."
 
-#: curs_main.c:79 pager.c:75 recvattach.c:1145
+#: curs_main.c:79 pager.c:75 recvattach.c:1158
 msgid "Function not permitted in attach-message mode."
 msgstr "Fungsi ini tidak diperbolehkan pada mode pelampiran-surat"
 
@@ -1552,255 +1552,263 @@ msgid "That message is not visible."
 msgstr "Surat itu tidak bisa dilihat."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:1377 curs_main.c:2772 pager.c:2818
+#. L10N: Due to the implementation details we do not know whether we
+#. delete zero, 1, 12, ... messages. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:1381 curs_main.c:2784 pager.c:2822
 #, fuzzy
-msgid "Cannot delete message(s)"
+msgid "Cannot delete messages"
 msgstr "tidak jadi hapus surat(-surat)"
 
-#: curs_main.c:1380
+#: curs_main.c:1384
 msgid "Delete messages matching: "
 msgstr "Hapus surat-surat yang: "
 
-#: curs_main.c:1421
+#: curs_main.c:1425
 msgid "No limit pattern is in effect."
 msgstr "Pola batas (limit pattern) tidak ditentukan."
 
 #. L10N: ask for a limit to apply
-#: curs_main.c:1426
+#: curs_main.c:1430
 #, c-format
 msgid "Limit: %s"
 msgstr " Batas: %s"
 
-#: curs_main.c:1464
+#: curs_main.c:1468
 msgid "Limit to messages matching: "
 msgstr "Hanya surat-surat yang: "
 
-#: curs_main.c:1488
+#: curs_main.c:1492
 msgid "To view all messages, limit to \"all\"."
 msgstr "Utk melihat semua pesan, batasi dengan \"semua\"."
 
-#: curs_main.c:1500 pager.c:2318
+#: curs_main.c:1504 pager.c:2318
 msgid "Quit NeoMutt?"
 msgstr "Keluar dari NeoMutt?"
 
-#: curs_main.c:1596
+#: curs_main.c:1600
 msgid "Tag messages matching: "
 msgstr "Tandai surat-surat yang: "
 
 #. L10N: CHECK_ACL
-#: curs_main.c:1606 curs_main.c:3203 pager.c:3137
+#. L10N: Due to the implementation details we do not know whether we
+#. undelete zero, 1, 12, ... messages. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:1614 curs_main.c:3223 pager.c:3145
 #, fuzzy
-msgid "Cannot undelete message(s)"
+msgid "Cannot undelete messages"
 msgstr "tidak jadi hapus surat(-surat)"
 
-#: curs_main.c:1609
+#: curs_main.c:1617
 msgid "Undelete messages matching: "
 msgstr "Tidak jadi hapus surat-surat yang: "
 
-#: curs_main.c:1619
+#: curs_main.c:1627
 msgid "Untag messages matching: "
 msgstr "Tidak jadi tandai surat-surat yang: "
 
-#: curs_main.c:1653
+#: curs_main.c:1661
 msgid "Logged out of IMAP servers."
 msgstr ""
 
-#: curs_main.c:1753
+#: curs_main.c:1761
 #, fuzzy
 msgid "No virtual folder, aborting."
 msgstr "Tidak ada subjek, batal."
 
-#: curs_main.c:1761
+#: curs_main.c:1769
 msgid "Failed to read thread, aborting."
 msgstr ""
 
-#: curs_main.c:1793 mx.c:1458 mx.c:1475
+#: curs_main.c:1801 mx.c:1468 mx.c:1485
 #, fuzzy
 msgid "Folder doesn't support tagging, aborting."
 msgstr "Server SMTP tidak mendukung authentikasi"
 
-#: curs_main.c:1808
+#: curs_main.c:1816
 #, fuzzy
 msgid "No tag specified, aborting."
 msgstr "Tidak ada subjek, batal."
 
-#: curs_main.c:1820
+#: curs_main.c:1828
 #, c-format
 msgid "Update tags..."
 msgstr ""
 
-#: curs_main.c:1857
+#: curs_main.c:1865
 msgid "Failed to modify tags, aborting."
 msgstr ""
 
-#: curs_main.c:1898
+#: curs_main.c:1906
 #, fuzzy
 msgid "No query, aborting."
 msgstr "Tidak ada subjek, batal."
 
-#: curs_main.c:1902 curs_main.c:1922 curs_main.c:1941
+#: curs_main.c:1910 curs_main.c:1930 curs_main.c:1949
 msgid "Failed to create query, aborting."
 msgstr ""
 
-#: curs_main.c:1911 curs_main.c:1930
+#: curs_main.c:1919 curs_main.c:1938
 msgid "Windowed queries disabled."
 msgstr ""
 
-#: curs_main.c:1916 curs_main.c:1935
+#: curs_main.c:1924 curs_main.c:1943
 msgid "No notmuch vfolder currently loaded."
 msgstr ""
 
-#: curs_main.c:1973
+#: curs_main.c:1981
 msgid "Open mailbox in read-only mode"
 msgstr "Buka kotak surat dengan mode read-only"
 
-#: curs_main.c:1976
+#: curs_main.c:1984
 #, fuzzy
 msgid "Open virtual folder"
 msgstr "membuka folder lain"
 
-#: curs_main.c:1979
+#: curs_main.c:1987
 msgid "Open mailbox"
 msgstr "Buka kotak surat"
 
-#: curs_main.c:1989
+#: curs_main.c:1997
 msgid "No mailboxes have new mail"
 msgstr "Tidak ada kotak surat dengan surat baru."
 
-#: curs_main.c:2036
+#: curs_main.c:2044
 #, fuzzy
 msgid "Open newsgroup in read-only mode"
 msgstr "Buka kotak surat dengan mode read-only"
 
-#: curs_main.c:2038
+#: curs_main.c:2046
 msgid "Open newsgroup"
 msgstr ""
 
-#: curs_main.c:2141
+#: curs_main.c:2149
 #, fuzzy
 msgid "Exit NeoMutt without saving?"
 msgstr "Keluar dari NeoMutt tanpa menyimpan?"
 
-#: curs_main.c:2157
+#: curs_main.c:2165
 #, fuzzy
 msgid "Cannot break thread"
 msgstr "hubungkan thread"
 
-#: curs_main.c:2160 curs_main.c:2198 curs_main.c:2658 curs_main.c:2690
+#: curs_main.c:2168 curs_main.c:2206 curs_main.c:2666 curs_main.c:2698
 #: flags.c:376 thread.c:1078 thread.c:1134 thread.c:1202
 msgid "Threading is not enabled."
 msgstr "Tidak disetting untuk melakukan threading."
 
-#: curs_main.c:2173
+#: curs_main.c:2181
 msgid "Thread broken"
 msgstr "Thread dipecah"
 
-#: curs_main.c:2185
+#: curs_main.c:2193
 msgid "Thread cannot be broken, message is not part of a thread"
 msgstr ""
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2195
+#: curs_main.c:2203
 #, fuzzy
 msgid "Cannot link threads"
 msgstr "hubungkan thread"
 
-#: curs_main.c:2200
+#: curs_main.c:2208
 msgid "No Message-ID: header available to link thread"
 msgstr "Tidak ada header Message-ID: tersedia utk menghubungkan thread"
 
-#: curs_main.c:2202
+#: curs_main.c:2210
 msgid "First, please tag a message to be linked here"
 msgstr "Pertama, tandai sebuah surat utk dihubungkan ke sini"
 
-#: curs_main.c:2213
+#: curs_main.c:2221
 msgid "Threads linked"
 msgstr "Thread dihubungkan"
 
-#: curs_main.c:2216
+#: curs_main.c:2224
 msgid "No thread linked"
 msgstr "Tidak ada thread yg dihubungkan"
 
-#: curs_main.c:2252 curs_main.c:2278
+#: curs_main.c:2260 curs_main.c:2286
 msgid "You are on the last message."
 msgstr "Anda sudah di surat yang terakhir."
 
-#: curs_main.c:2260 curs_main.c:2305
+#: curs_main.c:2268 curs_main.c:2313
 msgid "No undeleted messages."
 msgstr "Tidak ada surat yang tidak jadi dihapus."
 
-#: curs_main.c:2297 curs_main.c:2323
+#: curs_main.c:2305 curs_main.c:2331
 msgid "You are on the first message."
 msgstr "Anda sudah di surat yang pertama."
 
-#: curs_main.c:2395 menu.c:970 pager.c:2440 pattern.c:2110
+#: curs_main.c:2403 menu.c:970 pager.c:2440 pattern.c:2110
 msgid "Search wrapped to top."
 msgstr "Pencarian kembali ke atas."
 
-#: curs_main.c:2404 pager.c:2463 pattern.c:2121
+#: curs_main.c:2412 pager.c:2463 pattern.c:2121
 msgid "Search wrapped to bottom."
 msgstr "Pencarian kembali ke bawah."
 
-#: curs_main.c:2447
+#: curs_main.c:2455
 #, fuzzy
 msgid "No new messages in this limited view."
 msgstr "Surat induk tidak bisa dilihat di tampilan terbatas ini."
 
-#: curs_main.c:2449
+#: curs_main.c:2457
 #, fuzzy
 msgid "No new messages."
 msgstr "Tidak ada surat baru"
 
-#: curs_main.c:2454
+#: curs_main.c:2462
 #, fuzzy
 msgid "No unread messages in this limited view."
 msgstr "Surat induk tidak bisa dilihat di tampilan terbatas ini."
 
-#: curs_main.c:2456
+#: curs_main.c:2464
 #, fuzzy
 msgid "No unread messages."
 msgstr "Tidak ada surat yang belum dibaca"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2474
+#: curs_main.c:2482
 #, fuzzy
 msgid "Cannot flag message"
 msgstr "tandai surat"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2513 pager.c:3100
+#: curs_main.c:2521 pager.c:3104
 #, fuzzy
 msgid "Cannot toggle new"
 msgstr "tandai/tidak baru"
 
-#: curs_main.c:2590
+#: curs_main.c:2598
 msgid "No more threads."
 msgstr "Tidak ada thread lagi."
 
-#: curs_main.c:2592
+#: curs_main.c:2600
 msgid "You are on the first thread."
 msgstr "Anda di thread yang pertama."
 
-#: curs_main.c:2676
+#: curs_main.c:2684
 #, fuzzy
 msgid "Thread contains unread or flagged messages."
 msgstr "Thread berisi surat yang belum dibaca."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2726 pager.c:2784
+#: curs_main.c:2734 pager.c:2784
 #, fuzzy
 msgid "Cannot delete message"
 msgstr "tidak jadi hapus surat"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2838
+#: curs_main.c:2850
 #, fuzzy
 msgid "Cannot edit message"
 msgstr "Tidak dapat menulis surat"
 
 #. L10N: This is displayed when the x-label on one or more
 #. * messages is edited.
-#: curs_main.c:2900 pager.c:3200
+#: curs_main.c:2912 pager.c:3208
 #, fuzzy, c-format
 msgid "%d label changed."
 msgid_plural "%d labels changed."
@@ -1809,28 +1817,32 @@ msgstr[0] "Kotak surat tidak berubah."
 #. L10N: This is displayed when editing an x-label, but no messages
 #. * were updated.  Possibly due to canceling at the prompt or if the new
 #. * label is the same as the old label.
-#: curs_main.c:2907 pager.c:3204
+#: curs_main.c:2919 pager.c:3212
 #, fuzzy
 msgid "No labels changed."
 msgstr "Kotak surat tidak berubah."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:3006
+#. L10N: Due to the implementation details we do not know whether we
+#. mark zero, 1, 12, ... messages as read. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:3022
 #, fuzzy
-msgid "Cannot mark message(s) as read"
+msgid "Cannot mark messages as read"
 msgstr "loncat ke surat induk di thread ini"
 
 #. L10N: This is the prompt for <mark-message>.  Whatever they
 #. enter will be prefixed by $mark_macro_prefix and will become
 #. a macro hotkey to jump to the currently selected message.
-#: curs_main.c:3042
+#: curs_main.c:3058
 #, fuzzy
 msgid "Enter macro stroke: "
 msgstr "Masukkan keyID: "
 
 #. L10N: "message hotkey" is the key bindings menu description of a
 #. macro created by <mark-message>.
-#: curs_main.c:3050
+#: curs_main.c:3066
 #, fuzzy
 msgid "message hotkey"
 msgstr "Surat ditunda."
@@ -1838,28 +1850,28 @@ msgstr "Surat ditunda."
 #. L10N: This is echoed after <mark-message> creates a new hotkey
 #. macro.  %s is the hotkey string ($mark_macro_prefix followed
 #. by whatever they typed at the prompt.)
-#: curs_main.c:3055
+#: curs_main.c:3071
 #, fuzzy, c-format
 msgid "Message bound to %s."
 msgstr "Surat telah dibounce."
 
 #. L10N: This error is printed if <mark-message> cannot find a
 #. Message-ID for the currently selected message in the index.
-#: curs_main.c:3063
+#: curs_main.c:3079
 #, fuzzy
 msgid "No message ID to macro."
 msgstr "Tidak ada surat di kotak tersebut."
 
-#: curs_main.c:3105 pager.c:2961 recvattach.c:1388
+#: curs_main.c:3121 pager.c:2965 recvattach.c:1401
 msgid "Reply by mail as poster prefers?"
 msgstr ""
 
-#: curs_main.c:3108 pager.c:2927 pager.c:2939 pager.c:2964
+#: curs_main.c:3124 pager.c:2931 pager.c:2943 pager.c:2968
 msgid "Posting to this group not allowed, may be moderated. Continue?"
 msgstr ""
 
 #. L10N: CHECK_ACL
-#: curs_main.c:3173 pager.c:3120
+#: curs_main.c:3189 pager.c:3124
 #, fuzzy
 msgid "Cannot undelete message"
 msgstr "tidak jadi hapus surat"
@@ -2053,12 +2065,31 @@ msgstr "[-- Stderr dari tampil-otomatis %s --]\n"
 msgid "[-- Error: message/external-body has no access-type parameter --]\n"
 msgstr "[-- Error:  message/external-body tidak punya parameter access-type --]\n"
 
-#: handler.c:1611
+#. L10N: If the translation of this string is a multi line string, then
+#. each line should start with "[-- " and end with " --]".
+#. The first "%s/%s" is a MIME type, e.g. "text/plain". The last %s
+#. expands to a date as returned by `mutt_date_parse_date()`.
+#.
+#. Note: The size argument printed is not the actual number as passed
+#. to gettext but the prettified version, e.g. size = 2048 will be
+#. printed as 2K.  Your language might be sensitive to that: For
+#. example although '1K' and '1024' represent the same number your
+#. language might inflect the noun 'byte' differently.
+#.
+#. Sadly, we cannot do anything about that at the moment besides
+#. passing the precise size in bytes. If you are interested the
+#. function responsible for the prettification is
+#. mutt_str_pretty_size() in mutt/string.c.
+#.
+#: handler.c:1624
 #, fuzzy, c-format
 msgid ""
+"[-- This %s/%s attachment (size %s byte) has been deleted --]\n"
+"[-- on %s --]\n"
+msgid_plural ""
 "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
 "[-- on %s --]\n"
-msgstr ""
+msgstr[0] ""
 "[-- Lampiran %s/%s ini (ukuran %s bytes) telah dihapus --]\n"
 "[-- pada %s --]\n"
 
@@ -2066,10 +2097,22 @@ msgstr ""
 #. each line should start with "[-- " and end with " --]".
 #. The first "%s/%s" is a MIME type, e.g. "text/plain".
 #.
-#: handler.c:1620
+#. Note: The size argument printed is not the actual number as passed
+#. to gettext but the prettified version, e.g. size = 2048 will be
+#. printed as 2K.  Your language might be sensitive to that: For
+#. example although '1K' and '1024' represent the same number your
+#. language might inflect the noun 'byte' differently.
+#.
+#. Sadly, we cannot do anything about that at the moment besides
+#. passing the precise size in bytes. If you are interested the
+#. function responsible for the prettification is
+#. mutt_str_pretty_size() in mutt/string.c.
+#.
+#: handler.c:1648
 #, fuzzy, c-format
-msgid "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
-msgstr "[-- Lampiran %s/%s ini (ukuran %s bytes) telah dihapus --]\n"
+msgid "[-- This %s/%s attachment (size %s byte) has been deleted --]\n"
+msgid_plural "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
+msgstr[0] "[-- Lampiran %s/%s ini (ukuran %s bytes) telah dihapus --]\n"
 
 #. L10N: If the translation of this string is a multi line string, then
 #. each line should start with "[-- " and end with " --]".
@@ -2079,7 +2122,7 @@ msgstr "[-- Lampiran %s/%s ini (ukuran %s bytes) telah dihapus --]\n"
 #. Caution: Argument three %3$ is also defined but should not be used
 #. in this translation!
 #.
-#: handler.c:1637
+#: handler.c:1667
 #, fuzzy
 msgid ""
 "[-- This %s/%s attachment has been deleted --]\n"
@@ -2092,17 +2135,17 @@ msgstr ""
 #. each line should start with "[-- " and end with " --]".
 #. The first "%s/%s" is a MIME type, e.g. "text/plain".
 #.
-#: handler.c:1646
+#: handler.c:1676
 #, fuzzy, c-format
 msgid "[-- This %s/%s attachment has been deleted --]\n"
 msgstr "[-- Lampiran %s/%s ini telah dihapus --]\n"
 
-#: handler.c:1656
+#: handler.c:1686
 #, c-format
 msgid "[-- name: %s --]\n"
 msgstr "[-- nama: %s --]\n"
 
-#: handler.c:1672
+#: handler.c:1702
 #, fuzzy, c-format
 msgid ""
 "[-- This %s/%s attachment is not included, --]\n"
@@ -2113,7 +2156,7 @@ msgstr ""
 "[-- dan sumber eksternal yg disebutkan telah --]\n"
 "[-- kadaluwarsa. --]\n"
 
-#: handler.c:1693
+#: handler.c:1723
 #, fuzzy, c-format
 msgid ""
 "[-- This %s/%s attachment is not included, --]\n"
@@ -2122,52 +2165,52 @@ msgstr ""
 "[-- Lampiran %s/%s ini tidak disertakan, --]\n"
 "[-- dan tipe akses %s tsb tidak didukung --]\n"
 
-#: handler.c:1822
+#: handler.c:1852
 #, fuzzy
 msgid "Unable to open memory stream!"
 msgstr "Tidak bisa membuka file sementara!"
 
-#: handler.c:1831
+#: handler.c:1861
 msgid "Unable to open temporary file!"
 msgstr "Tidak bisa membuka file sementara!"
 
-#: handler.c:1881
+#: handler.c:1911
 #, fuzzy
 msgid "failed to re-open memstream!"
 msgstr "Tidak bisa membuka file sementara!"
 
-#: handler.c:2013
+#: handler.c:2043
 msgid "Error: multipart/signed has no protocol."
 msgstr "Error: multipart/signed tidak punya protokol."
 
-#: handler.c:2076
+#: handler.c:2106
 #, fuzzy
 msgid "[-- This is an attachment (use '%3$s' to view this part) --]\n"
 msgstr "[-- Lampiran %s/%s ini (gunakan '%3$s' untuk melihat bagian ini) --]\n"
 
-#: handler.c:2082
+#: handler.c:2112
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported (use '%s' to view this part) --]\n"
 msgstr "[-- %s/%s tidak didukung (gunakan '%s' untuk melihat bagian ini) --]\n"
 
-#: handler.c:2087
+#: handler.c:2117
 #, fuzzy
 msgid "[-- This is an attachment (need 'view-attachments' bound to key!) --]\n"
 msgstr "[-- Lampiran %s/%s ini (tombol untuk 'view-attachments' belum ditentukan!) --]\n"
 
 #. L10N: %s/%s is a MIME type, e.g. "text/plain".
-#: handler.c:2091
+#: handler.c:2121
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported (need 'view-attachments' bound to key!) --]\n"
 msgstr "[-- %s/%s tidak didukung (tombol untuk 'view-attachments' belum ditentukan!) --]\n"
 
-#: handler.c:2098
+#: handler.c:2128
 #, fuzzy
 msgid "[-- This is an attachment --]\n"
 msgstr "[-- Lampiran %s/%s ini --]\n"
 
 #. L10N: %s/%s is a MIME type, e.g. "text/plain".
-#: handler.c:2101
+#: handler.c:2131
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported --]\n"
 msgstr "[-- %s/%s tidak didukung --]\n"
@@ -2471,7 +2514,7 @@ msgstr "Server SMTP tidak mendukung authentikasi"
 msgid "Invalid IMAP flags"
 msgstr "Tdk valid "
 
-#: imap/message.c:477 mx.c:1326
+#: imap/message.c:477 mx.c:1336
 msgid "Integer overflow -- can't allocate memory."
 msgstr "Integer overflow -- tidak bisa mengalokasikan memori."
 
@@ -3236,65 +3279,72 @@ msgstr "SSL tidak tersedia."
 msgid "Reading from %s interrupted..."
 msgstr "Pencarian dibatalkan."
 
-#: mx.c:634
+#. L10N: Although we now the precise number of messages, we do not show it to the user.
+#. So feel free to use a "generic plural" as plural translation if your language has one.
+#.
+#: mx.c:639
 #, fuzzy
-msgid "message(s) not deleted"
-msgstr "Menandai surat-surat \"dihapus\"..."
+msgid "message not deleted"
+msgid_plural "messages not deleted"
+msgstr[0] "Menandai surat-surat \"dihapus\"..."
 
-#: mx.c:671
+#: mx.c:676
 #, fuzzy
 msgid "Can't open trash folder"
 msgstr "Tidak bisa menambah ke kotak surat: %s"
 
-#: mx.c:710
+#: mx.c:715
 msgid "Mark all articles read?"
 msgstr ""
 
-#: mx.c:754
+#. L10N: The first argument is the number of read messages to be
+#. moved, the second argument is the target mailbox.
+#: mx.c:762
 #, fuzzy, c-format
-msgid "Move %d read messages to %s?"
-msgstr "Pindahkan surat-surat yang sudah dibaca ke %s?"
+msgid "Move %d read message to %s?"
+msgid_plural "Move %d read messages to %s?"
+msgstr[0] "Pindahkan surat-surat yang sudah dibaca ke %s?"
 
-#: mx.c:771 mx.c:1077
+#: mx.c:781 mx.c:1087
 #, fuzzy, c-format
 msgid "Purge %d deleted message?"
 msgid_plural "Purge %d deleted messages?"
 msgstr[0] "Benar-benar hapus %d surat yang ditandai akan dihapus?"
 
-#: mx.c:793
+#: mx.c:803
 #, c-format
 msgid "Moving read messages to %s..."
 msgstr "Pindahkan surat-surat yang sudah dibaca ke %s..."
 
-#: mx.c:859 mx.c:1068
+#: mx.c:869 mx.c:1078
 msgid "Mailbox is unchanged."
 msgstr "Kotak surat tidak berubah."
 
-#: mx.c:914
+#: mx.c:924
 #, c-format
 msgid "%d kept, %d moved, %d deleted."
 msgstr "%d disimpan, %d dipindahkan, %d dihapus."
 
-#: mx.c:917 mx.c:1130
+#: mx.c:927 mx.c:1140
 #, c-format
 msgid "%d kept, %d deleted."
 msgstr "%d disimpan, %d dihapus."
 
-#: mx.c:1052
+#: mx.c:1062
 #, c-format
 msgid " Press '%s' to toggle write"
 msgstr "Tekan '%s' untuk mengeset bisa/tidak menulis"
 
-#: mx.c:1054
+#: mx.c:1064
 msgid "Use 'toggle-write' to re-enable write!"
 msgstr "Gunakan 'toggle-write' supaya bisa menulis lagi!"
 
-#: mx.c:1056
+#: mx.c:1066
 #, c-format
 msgid "Mailbox is marked unwritable. %s"
 msgstr "Kotak surat ditandai tidak boleh ditulisi. %s"
 
-#: mx.c:1124
+#: mx.c:1134
 msgid "Mailbox checkpointed."
 msgstr "Kotak surat telah di-checkpoint."
 
@@ -3308,54 +3358,59 @@ msgstr " (waktu skrg: %c)"
 msgid "[-- %s output follows%s --]\n"
 msgstr "[-- Keluaran dari %s%s --]\n"
 
-#: ncrypt/crypt.c:95
-msgid "Passphrase(s) forgotten."
+#. L10N: Due to the implementation details (e.g. some passwords are managed
+#. by gpg-agent) we cannot know whether we forgot zero, 1, 12, ...
+#. passwords. So in English we use "Passphrases". Your language might
+#. have other means to express this.
+#: ncrypt/crypt.c:100
+#, fuzzy
+msgid "Passphrases forgotten."
 msgstr "Passphrase sudah dilupakan."
 
-#: ncrypt/crypt.c:155
+#: ncrypt/crypt.c:161
 #, fuzzy
 msgid "Inline PGP can't be used with attachments.  Revert to PGP/MIME?"
 msgstr "Pesan tdk bisa dikirim inline. Gunakan PGP/MIME?"
 
-#: ncrypt/crypt.c:159
+#: ncrypt/crypt.c:165
 msgid "Mail not sent: inline PGP can't be used with attachments."
 msgstr ""
 
-#: ncrypt/crypt.c:166
+#: ncrypt/crypt.c:172
 #, fuzzy
 msgid "Inline PGP can't be used with format=flowed.  Revert to PGP/MIME?"
 msgstr "Pesan tdk bisa dikirim inline. Gunakan PGP/MIME?"
 
-#: ncrypt/crypt.c:170
+#: ncrypt/crypt.c:176
 msgid "Mail not sent: inline PGP can't be used with format=flowed."
 msgstr ""
 
-#: ncrypt/crypt.c:180 ncrypt/cryptglue.c:125 ncrypt/pgpkey.c:589
+#: ncrypt/crypt.c:186 ncrypt/cryptglue.c:125 ncrypt/pgpkey.c:589
 #: ncrypt/pgpkey.c:782
 msgid "Invoking PGP..."
 msgstr "Memanggil PGP..."
 
-#: ncrypt/crypt.c:192
+#: ncrypt/crypt.c:198
 msgid "Message can't be sent inline.  Revert to using PGP/MIME?"
 msgstr "Pesan tdk bisa dikirim inline. Gunakan PGP/MIME?"
 
-#: ncrypt/crypt.c:194 send.c:1824
+#: ncrypt/crypt.c:200 send.c:1824
 msgid "Mail not sent."
 msgstr "Surat tidak dikirim."
 
-#: ncrypt/crypt.c:540
+#: ncrypt/crypt.c:546
 msgid "S/MIME messages with no hints on content are unsupported."
 msgstr "Surat2 S/MIME tanpa hints pada isi tidak didukung."
 
-#: ncrypt/crypt.c:754 ncrypt/crypt.c:795
+#: ncrypt/crypt.c:760 ncrypt/crypt.c:801
 msgid "Trying to extract PGP keys...\n"
 msgstr "Mencoba mengekstrak kunci2 PGP...\n"
 
-#: ncrypt/crypt.c:776 ncrypt/crypt.c:816
+#: ncrypt/crypt.c:782 ncrypt/crypt.c:822
 msgid "Trying to extract S/MIME certificates...\n"
 msgstr "Mencoba mengekstrak sertifikat2 S/MIME...\n"
 
-#: ncrypt/crypt.c:976
+#: ncrypt/crypt.c:982
 #, c-format
 msgid ""
 "[-- Error: Unknown multipart/signed protocol %s! --]\n"
@@ -3364,7 +3419,7 @@ msgstr ""
 "[-- Error: Protokol multipart/signed %s tidak dikenal! --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1016
+#: ncrypt/crypt.c:1022
 #, fuzzy
 msgid ""
 "[-- Error: Missing or bad-format multipart/signed signature! --]\n"
@@ -3373,7 +3428,7 @@ msgstr ""
 "[-- Error: Struktur multipart/signed tidak konsisten! --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1058
+#: ncrypt/crypt.c:1064
 #, c-format
 msgid ""
 "[-- Warning: We can't verify %s/%s signatures. --]\n"
@@ -3382,7 +3437,7 @@ msgstr ""
 "[-- Warning: Tidak dapat mem-verifikasi tandatangan %s/%s. --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1070
+#: ncrypt/crypt.c:1076
 msgid ""
 "[-- The following data is signed --]\n"
 "\n"
@@ -3390,7 +3445,7 @@ msgstr ""
 "[-- Data berikut ini ditandatangani --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1075
+#: ncrypt/crypt.c:1081
 msgid ""
 "[-- Warning: Can't find any signatures. --]\n"
 "\n"
@@ -3398,7 +3453,7 @@ msgstr ""
 "[-- Warning: Tidak dapat menemukan tandatangan. --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1081
+#: ncrypt/crypt.c:1087
 msgid ""
 "\n"
 "[-- End of signed data --]\n"
@@ -3449,7 +3504,7 @@ msgstr ""
 msgid "error reading data object: %s\n"
 msgstr "error saat membaca objek data: %s\n"
 
-#: ncrypt/crypt_gpgme.c:662 ncrypt/crypt_gpgme.c:3848 ncrypt/pgpkey.c:585
+#: ncrypt/crypt_gpgme.c:662 ncrypt/crypt_gpgme.c:3850 ncrypt/pgpkey.c:585
 #: ncrypt/pgpkey.c:768
 msgid "Can't create temporary file"
 msgstr "Tidak bisa membuat file sementara"
@@ -3811,28 +3866,29 @@ msgstr "[Tidak valid]"
 
 #. L10N: This is printed after "Key Type: " and looks like this:
 #. *       PGP, 2048 bit RSA
-#: ncrypt/crypt_gpgme.c:3670 ncrypt/crypt_gpgme.c:3808
+#: ncrypt/crypt_gpgme.c:3670 ncrypt/crypt_gpgme.c:3810
 #, fuzzy, c-format
 msgid "%s, %lu bit %s\n"
-msgstr "Jenis Kunci: %s, %lu bit %s\n"
+msgid_plural "%s, %lu bit %s\n"
+msgstr[0] "Jenis Kunci: %s, %lu bit %s\n"
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3678 ncrypt/crypt_gpgme.c:3815
+#: ncrypt/crypt_gpgme.c:3678 ncrypt/crypt_gpgme.c:3817
 msgid "encryption"
 msgstr "enkripsi"
 
 #: ncrypt/crypt_gpgme.c:3679 ncrypt/crypt_gpgme.c:3685
-#: ncrypt/crypt_gpgme.c:3816 ncrypt/crypt_gpgme.c:3821
+#: ncrypt/crypt_gpgme.c:3818 ncrypt/crypt_gpgme.c:3823
 msgid ", "
 msgstr ", "
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3684 ncrypt/crypt_gpgme.c:3820
+#: ncrypt/crypt_gpgme.c:3684 ncrypt/crypt_gpgme.c:3822
 msgid "signing"
 msgstr "menandatangani"
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3690 ncrypt/crypt_gpgme.c:3825
+#: ncrypt/crypt_gpgme.c:3690 ncrypt/crypt_gpgme.c:3827
 msgid "certification"
 msgstr "sertifikasi"
 
@@ -3851,65 +3907,65 @@ msgstr "[Kadaluwarsa]"
 msgid "[Disabled]"
 msgstr "[Tidak aktif]"
 
-#: ncrypt/crypt_gpgme.c:3851
+#: ncrypt/crypt_gpgme.c:3853
 msgid "Collecting data..."
 msgstr "Mengumpulkan data ..."
 
-#: ncrypt/crypt_gpgme.c:3876
+#: ncrypt/crypt_gpgme.c:3878
 #, c-format
 msgid "Error finding issuer key: %s\n"
 msgstr "Error saat mencari kunci yg mengeluarkan: %s\n"
 
-#: ncrypt/crypt_gpgme.c:3885
+#: ncrypt/crypt_gpgme.c:3887
 #, fuzzy
 msgid "Error: certification chain too long - stopping here\n"
 msgstr "Error: rantai sertifikasi terlalu panjang - berhenti di sini\n"
 
-#: ncrypt/crypt_gpgme.c:3895 ncrypt/pgpkey.c:608
+#: ncrypt/crypt_gpgme.c:3897 ncrypt/pgpkey.c:608
 #, c-format
 msgid "Key ID: 0x%s"
 msgstr "Identifikasi kunci: 0x%s"
 
-#: ncrypt/crypt_gpgme.c:3990
+#: ncrypt/crypt_gpgme.c:3992
 #, c-format
 msgid "gpgme_new failed: %s"
 msgstr "gpgme_new gagal: %s"
 
-#: ncrypt/crypt_gpgme.c:4028 ncrypt/crypt_gpgme.c:4079
+#: ncrypt/crypt_gpgme.c:4030 ncrypt/crypt_gpgme.c:4081
 #, c-format
 msgid "gpgme_op_keylist_start failed: %s"
 msgstr "gpgme_op_keylist_start gagal: %s"
 
-#: ncrypt/crypt_gpgme.c:4067 ncrypt/crypt_gpgme.c:4109
+#: ncrypt/crypt_gpgme.c:4069 ncrypt/crypt_gpgme.c:4111
 #, c-format
 msgid "gpgme_op_keylist_next failed: %s"
 msgstr "gpgme_op_keylist_next gagal: %s"
 
-#: ncrypt/crypt_gpgme.c:4185
+#: ncrypt/crypt_gpgme.c:4187
 msgid "All matching keys are marked expired/revoked."
 msgstr "Semua kunci yang cocok ditandai kadaluwarsa/dicabut."
 
-#: ncrypt/crypt_gpgme.c:4215 ncrypt/pgpkey.c:543 ncrypt/smime.c:475
+#: ncrypt/crypt_gpgme.c:4217 ncrypt/pgpkey.c:543 ncrypt/smime.c:475
 msgid "Select  "
 msgstr "Pilih  "
 
-#: ncrypt/crypt_gpgme.c:4217 ncrypt/pgpkey.c:545
+#: ncrypt/crypt_gpgme.c:4219 ncrypt/pgpkey.c:545
 msgid "Check key  "
 msgstr "Cek key  "
 
-#: ncrypt/crypt_gpgme.c:4233
+#: ncrypt/crypt_gpgme.c:4235
 msgid "PGP and S/MIME keys matching"
 msgstr "Kunci-kunci PGP dan S/MIME cocok"
 
-#: ncrypt/crypt_gpgme.c:4235
+#: ncrypt/crypt_gpgme.c:4237
 msgid "PGP keys matching"
 msgstr "Kunci-kunci PGP cocok"
 
-#: ncrypt/crypt_gpgme.c:4237
+#: ncrypt/crypt_gpgme.c:4239
 msgid "S/MIME keys matching"
 msgstr "Kunci-kunci S/MIME cocok"
 
-#: ncrypt/crypt_gpgme.c:4239
+#: ncrypt/crypt_gpgme.c:4241
 msgid "keys matching"
 msgstr "kunci-kunci cocok"
 
@@ -3917,69 +3973,69 @@ msgstr "kunci-kunci cocok"
 #. %1$s is one of the previous four entries.
 #. %2$s is an address.
 #. e.g. "S/MIME keys matching <me@mutt.org>."
-#: ncrypt/crypt_gpgme.c:4246
+#: ncrypt/crypt_gpgme.c:4248
 #, c-format
 msgid "%s <%s>."
 msgstr "%s <%s>."
 
 #. L10N:
 #. e.g. 'S/MIME keys matching "Michael Elkins".'
-#: ncrypt/crypt_gpgme.c:4250
+#: ncrypt/crypt_gpgme.c:4252
 #, c-format
 msgid "%s \"%s\"."
 msgstr "%s \"%s\"."
 
-#: ncrypt/crypt_gpgme.c:4277 ncrypt/pgpkey.c:628
+#: ncrypt/crypt_gpgme.c:4279 ncrypt/pgpkey.c:628
 msgid "This key can't be used: expired/disabled/revoked."
 msgstr "Kunci ini tidak dapat digunakan: kadaluwarsa/disabled/dicabut."
 
-#: ncrypt/crypt_gpgme.c:4290 ncrypt/pgpkey.c:640 ncrypt/smime.c:505
+#: ncrypt/crypt_gpgme.c:4292 ncrypt/pgpkey.c:640 ncrypt/smime.c:505
 #, fuzzy
 msgid "ID is expired/disabled/revoked. Do you really want to use the key?"
 msgstr "ID telah kadaluwarsa/disabled/dicabut. Anda yakin mau menggunakan kunci tsb?"
 
-#: ncrypt/crypt_gpgme.c:4299 ncrypt/pgpkey.c:650
+#: ncrypt/crypt_gpgme.c:4301 ncrypt/pgpkey.c:650
 #, fuzzy
 msgid "ID is not valid. Do you really want to use the key?"
 msgstr "ID tidak valid. Anda yakin mau menggunakan kunci tsb?"
 
-#: ncrypt/crypt_gpgme.c:4302 ncrypt/pgpkey.c:653
+#: ncrypt/crypt_gpgme.c:4304 ncrypt/pgpkey.c:653
 #, fuzzy
 msgid "ID is only marginally valid. Do you really want to use the key?"
 msgstr "ID hanya valid secara marginal. Anda yakin mau menggunakan kunci tsb?"
 
-#: ncrypt/crypt_gpgme.c:4310 ncrypt/pgpkey.c:646 ncrypt/smime.c:509
+#: ncrypt/crypt_gpgme.c:4312 ncrypt/pgpkey.c:646 ncrypt/smime.c:509
 #, fuzzy
 msgid "ID has undefined validity. Do you really want to use the key?"
 msgstr "Validitas ID tidak terdifinisikan. Anda yakin mau menggunakan kunci tsb?"
 
-#: ncrypt/crypt_gpgme.c:4370 ncrypt/crypt_gpgme.c:4479 ncrypt/pgpkey.c:872
+#: ncrypt/crypt_gpgme.c:4372 ncrypt/crypt_gpgme.c:4481 ncrypt/pgpkey.c:872
 #: ncrypt/pgpkey.c:995
 #, c-format
 msgid "Looking for keys matching \"%s\"..."
 msgstr "Mencari kunci yg cocok dengan \"%s\"..."
 
-#: ncrypt/crypt_gpgme.c:4593 ncrypt/pgpkey.c:731 ncrypt/smime.c:811
+#: ncrypt/crypt_gpgme.c:4595 ncrypt/pgpkey.c:731 ncrypt/smime.c:811
 #, c-format
 msgid "No matching keys found for \"%s\""
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4644 ncrypt/pgp.c:1263
+#: ncrypt/crypt_gpgme.c:4646 ncrypt/pgp.c:1263
 #, c-format
 msgid "Use keyID = \"%s\" for %s?"
 msgstr "Gunakan keyID = '%s' untuk %s?"
 
-#: ncrypt/crypt_gpgme.c:4695 ncrypt/pgp.c:1312 ncrypt/smime.c:830
+#: ncrypt/crypt_gpgme.c:4697 ncrypt/pgp.c:1312 ncrypt/smime.c:830
 #: ncrypt/smime.c:938
 #, c-format
 msgid "Enter keyID for %s: "
 msgstr "Masukkan keyID untuk %s: "
 
-#: ncrypt/crypt_gpgme.c:4755 ncrypt/pgpkey.c:751
+#: ncrypt/crypt_gpgme.c:4757 ncrypt/pgpkey.c:751
 msgid "Please enter the key ID: "
 msgstr "Masukkan key ID: "
 
-#: ncrypt/crypt_gpgme.c:4768
+#: ncrypt/crypt_gpgme.c:4770
 #, fuzzy, c-format
 msgid "Error exporting key: %s\n"
 msgstr "Error saat mengambil informasi tentang kunci: "
@@ -3988,90 +4044,90 @@ msgstr "Error saat mengambil informasi tentang kunci: "
 #. MIME description for exported (attached) keys.
 #. You can translate this entry to a non-ASCII string (it will be encoded),
 #. but it may be safer to keep it untranslated.
-#: ncrypt/crypt_gpgme.c:4787
+#: ncrypt/crypt_gpgme.c:4789
 #, fuzzy, c-format
 msgid "PGP Key 0x%s."
 msgstr "Kunci PGP %s."
 
-#: ncrypt/crypt_gpgme.c:4830
+#: ncrypt/crypt_gpgme.c:4832
 msgid "GPGME: OpenPGP protocol not available"
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4838
+#: ncrypt/crypt_gpgme.c:4840
 msgid "GPGME: CMS protocol not available"
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4876
+#: ncrypt/crypt_gpgme.c:4878
 #, fuzzy
 msgid "S/MIME (s)ign, sign (a)s, (p)gp, (c)lear, or (o)ppenc mode off? "
 msgstr "S/MIME (e)nkrip, (t)andatangan, tandatangan (s)bg, ke(d)uanya, (p)gp atau (b)ersih? "
 
 #. L10N: S/MIME options (opportunistic encryption is on)
-#: ncrypt/crypt_gpgme.c:4878
+#: ncrypt/crypt_gpgme.c:4880
 msgid "sapco"
 msgstr "etsdpb"
 
-#: ncrypt/crypt_gpgme.c:4885
+#: ncrypt/crypt_gpgme.c:4887
 #, fuzzy
 msgid "PGP (s)ign, sign (a)s, s/(m)ime, (c)lear, or (o)ppenc mode off? "
 msgstr "PGP (e)nkrip, (t)andatangan, tandatangan (s)bg, ke(d)uanya, s/(m)ime atau (b)ersih? "
 
 #. L10N: PGP options (opportunistic encryption is on)
-#: ncrypt/crypt_gpgme.c:4887
+#: ncrypt/crypt_gpgme.c:4889
 msgid "samco"
 msgstr "etsdmb"
 
 #. L10N: S/MIME options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4900
+#: ncrypt/crypt_gpgme.c:4902
 #, fuzzy
 msgid "S/MIME (e)ncrypt, (s)ign, sign (a)s, (b)oth, (p)gp, (c)lear, or (o)ppenc mode? "
 msgstr "S/MIME (e)nkrip, (t)andatangan, tandatangan (s)bg, ke(d)uanya, (p)gp atau (b)ersih? "
 
 #. L10N: S/MIME options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4903
+#: ncrypt/crypt_gpgme.c:4905
 #, fuzzy
 msgid "esabpco"
 msgstr "etsdpb"
 
 #. L10N: PGP options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4909
+#: ncrypt/crypt_gpgme.c:4911
 #, fuzzy
 msgid "PGP (e)ncrypt, (s)ign, sign (a)s, (b)oth, s/(m)ime, (c)lear, or (o)ppenc mode? "
 msgstr "PGP (e)nkrip, (t)andatangan, tandatangan (s)bg, ke(d)uanya, s/(m)ime atau (b)ersih? "
 
 #. L10N: PGP options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4912
+#: ncrypt/crypt_gpgme.c:4914
 #, fuzzy
 msgid "esabmco"
 msgstr "etsdmb"
 
-#: ncrypt/crypt_gpgme.c:4925
+#: ncrypt/crypt_gpgme.c:4927
 #, fuzzy
 msgid "S/MIME (e)ncrypt, (s)ign, sign (a)s, (b)oth, (p)gp or (c)lear? "
 msgstr "S/MIME (e)nkrip, (t)andatangan, tandatangan (s)bg, ke(d)uanya, (p)gp atau (b)ersih? "
 
 #. L10N: S/MIME options
-#: ncrypt/crypt_gpgme.c:4927
+#: ncrypt/crypt_gpgme.c:4929
 #, fuzzy
 msgid "esabpc"
 msgstr "etsdpb"
 
-#: ncrypt/crypt_gpgme.c:4934
+#: ncrypt/crypt_gpgme.c:4936
 #, fuzzy
 msgid "PGP (e)ncrypt, (s)ign, sign (a)s, (b)oth, s/(m)ime or (c)lear? "
 msgstr "PGP (e)nkrip, (t)andatangan, tandatangan (s)bg, ke(d)uanya, s/(m)ime atau (b)ersih? "
 
 #. L10N: PGP options
-#: ncrypt/crypt_gpgme.c:4936
+#: ncrypt/crypt_gpgme.c:4938
 #, fuzzy
 msgid "esabmc"
 msgstr "etsdmb"
 
-#: ncrypt/crypt_gpgme.c:5087
+#: ncrypt/crypt_gpgme.c:5089
 msgid "Failed to verify sender"
 msgstr "Gagal memverifikasi pengirim"
 
-#: ncrypt/crypt_gpgme.c:5090
+#: ncrypt/crypt_gpgme.c:5092
 msgid "Failed to figure out sender"
 msgstr "Gagal menentukan pengirim"
 
@@ -4472,7 +4528,7 @@ msgstr ""
 msgid "%s is an invalid news server specification!"
 msgstr "%s bukan path POP yang valid"
 
-#: nntp.c:75 nntp.c:612 pop.c:1028 pop_lib.c:405
+#: nntp.c:75 nntp.c:612 pop.c:1031 pop_lib.c:405
 msgid "Server closed connection!"
 msgstr "Server menutup hubungan!"
 
@@ -4638,16 +4694,18 @@ msgid "check mailboxes for new mail"
 msgstr "periksa kotak surat apakah ada surat baru"
 
 #: opcodes.h:47
-msgid "attach file(s) to this message"
+#, fuzzy
+msgid "attach files to this message"
 msgstr "lampirkan file ke surat ini"
 
 #: opcodes.h:48
-msgid "attach message(s) to this message"
+#, fuzzy
+msgid "attach messages to this message"
 msgstr "lampirkan surat lain ke surat ini"
 
 #: opcodes.h:49
 #, fuzzy
-msgid "attach news article(s) to this message"
+msgid "attach news articles to this message"
 msgstr "lampirkan file ke surat ini"
 
 #: opcodes.h:50
@@ -5491,7 +5549,8 @@ msgid "extract supported public keys"
 msgstr "ekstrak kunci2 publik yg didukung"
 
 #: opcodes.h:255
-msgid "wipe passphrase(s) from memory"
+#, fuzzy
+msgid "wipe passphrases from memory"
 msgstr "hapus passphrase dari memory"
 
 #: opcodes.h:259
@@ -5838,18 +5897,19 @@ msgstr "Tidak ada surat baru di kotak surat POP."
 msgid "Delete messages from server?"
 msgstr "Hapus surat-surat dari server?"
 
-#: pop.c:954
-#, c-format
-msgid "Reading new messages (%d bytes)..."
-msgstr "Membaca surat-surat baru (%d bytes)..."
+#: pop.c:955
+#, fuzzy, c-format
+msgid "Reading new messages (%d byte)..."
+msgid_plural "Reading new messages (%d bytes)..."
+msgstr[0] "Membaca surat-surat baru (%d bytes)..."
 
-#: pop.c:997
+#: pop.c:1000
 msgid "Error while writing mailbox!"
 msgstr "Error saat menulis ke kotak surat!"
 
 #. L10N: The plural is picked by the second numerical argument, i.e.
 #. * the %d right before 'messages', i.e. the total number of messages.
-#: pop.c:1003
+#: pop.c:1006
 #, fuzzy, c-format
 msgid "%s [%d of %d message read]"
 msgid_plural "%s [%d of %d messages read]"
@@ -5992,49 +6052,55 @@ msgstr "Pipe ke: "
 msgid "I don't know how to print %s attachments!"
 msgstr "Saya tidak tahu bagaimana mencetak lampiran %s!"
 
-#: recvattach.c:841
-msgid "Print tagged attachment(s)?"
-msgstr "Cetak lampiran yang ditandai?"
+#. L10N: Although we now the precise number of tagged messages, we
+#. do not show it to the user.  So feel free to use a "generic
+#. plural" as plural translation if your language has one.
+#: recvattach.c:852
+#, fuzzy, c-format
+msgid "Print tagged attachment?"
+msgid_plural "Print %d tagged attachments?"
+msgstr[0] "Cetak lampiran yang ditandai?"
 
-#: recvattach.c:842
+#: recvattach.c:853
+#, c-format
 msgid "Print attachment?"
 msgstr "Cetak lampiran?"
 
-#: recvattach.c:900
+#: recvattach.c:913
 msgid "Structural changes to decrypted attachments are not supported"
 msgstr ""
 
-#: recvattach.c:1046
+#: recvattach.c:1059
 msgid "Can't decrypt encrypted message!"
 msgstr "Tidak dapat men-decrypt surat ini!"
 
-#: recvattach.c:1172
+#: recvattach.c:1185
 msgid "Attachments"
 msgstr "Lampiran"
 
-#: recvattach.c:1210
+#: recvattach.c:1223
 msgid "There are no subparts to show!"
 msgstr "Tidak ada sub-bagian yg bisa ditampilkan!"
 
-#: recvattach.c:1265
+#: recvattach.c:1278
 msgid "Can't delete attachment from POP server."
 msgstr "Tidak bisa menghapus lampiran dari server POP."
 
-#: recvattach.c:1274
+#: recvattach.c:1287
 #, fuzzy
 msgid "Can't delete attachment from news server."
 msgstr "Tidak bisa menghapus lampiran dari server POP."
 
-#: recvattach.c:1281
+#: recvattach.c:1294
 msgid "Deletion of attachments from encrypted messages is unsupported."
 msgstr "Penghapusan lampiran dari surat yg dienkripsi tidak didukung."
 
-#: recvattach.c:1287
+#: recvattach.c:1300
 #, fuzzy
 msgid "Deletion of attachments from signed messages may invalidate the signature."
 msgstr "Penghapusan lampiran dari surat yg dienkripsi tidak didukung."
 
-#: recvattach.c:1305 recvattach.c:1320
+#: recvattach.c:1318 recvattach.c:1333
 msgid "Only deletion of multipart attachments is supported."
 msgstr "Hanya penghapusan lampiran dari surat multi bagian yang didukung."
 
@@ -6455,3 +6521,15 @@ msgstr "Opsi2 saat kompilasi:"
 #: version.c:404
 msgid "Compile options:"
 msgstr "Opsi2 saat kompilasi:"
+
+#, fuzzy
+#~ msgid "Cannot delete message(s)"
+#~ msgstr "tidak jadi hapus surat(-surat)"
+
+#, fuzzy
+#~ msgid "Cannot undelete message(s)"
+#~ msgstr "tidak jadi hapus surat(-surat)"
+
+#, fuzzy
+#~ msgid "messages not deleted"
+#~ msgstr "Menandai surat-surat \"dihapus\"..."

--- a/po/it.po
+++ b/po/it.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neomutt-20180512\n"
 "Report-Msgid-Bugs-To: neomutt-devel@neomutt.org\n"
-"POT-Creation-Date: 2018-05-20 02:02+0000\n"
+"POT-Creation-Date: 2018-05-22 14:18+0000\n"
 "PO-Revision-Date: 2012-05-25 22:14+0200\n"
 "Last-Translator: Marco Paolone <marcopaolone@gmail.com>\n"
 "Language-Team: none\n"
@@ -41,7 +41,7 @@ msgstr "Seleziona"
 
 #: addrbook.c:52 browser.c:75 browser.c:87 compose.c:160 compose.c:172
 #: conn/ssl.c:1041 conn/ssl_gnutls.c:793 curs_main.c:748 curs_main.c:761
-#: history.c:106 ncrypt/crypt_gpgme.c:4219 ncrypt/pgpkey.c:547
+#: history.c:106 ncrypt/crypt_gpgme.c:4221 ncrypt/pgpkey.c:547
 #: ncrypt/smime.c:477 pager.c:2141 postpone.c:65 query.c:72 recvattach.c:70
 msgid "Help"
 msgstr "Aiuto"
@@ -689,7 +689,7 @@ msgstr ""
 #. * Since it shares the row with "Encrypt with:", it should not be longer
 #. * than 15-20 character cells.
 #.
-#: compose.c:138 ncrypt/crypt_gpgme.c:4947 ncrypt/pgp.c:1786
+#: compose.c:138 ncrypt/crypt_gpgme.c:4949 ncrypt/pgp.c:1786
 #: ncrypt/smime.c:2127
 msgid "Sign as: "
 msgstr "Firma come: "
@@ -1232,7 +1232,7 @@ msgstr "(r)ifiuta, accetta questa v(o)lta"
 msgid "(r)eject, accept (o)nce"
 msgstr "(r)ifiuta, accetta questa v(o)lta"
 
-#: conn/ssl.c:1039 conn/ssl_gnutls.c:791 ncrypt/crypt_gpgme.c:4213
+#: conn/ssl.c:1039 conn/ssl_gnutls.c:791 ncrypt/crypt_gpgme.c:4215
 #: ncrypt/pgpkey.c:541 ncrypt/smime.c:473
 msgid "Exit  "
 msgstr "Esci  "
@@ -1412,11 +1412,11 @@ msgstr "Nessuna mailbox aperta."
 msgid "There are no messages."
 msgstr "Non ci sono messaggi."
 
-#: curs_main.c:77 mx.c:1061 pager.c:73 recvattach.c:56
+#: curs_main.c:77 mx.c:1071 pager.c:73 recvattach.c:56
 msgid "Mailbox is read-only."
 msgstr "La mailbox è di sola lettura."
 
-#: curs_main.c:79 pager.c:75 recvattach.c:1145
+#: curs_main.c:79 pager.c:75 recvattach.c:1158
 msgid "Function not permitted in attach-message mode."
 msgstr "Funzione non permessa nella modalità attach-message."
 
@@ -1551,255 +1551,263 @@ msgid "That message is not visible."
 msgstr "Questo messaggio non è visibile."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:1377 curs_main.c:2772 pager.c:2818
+#. L10N: Due to the implementation details we do not know whether we
+#. delete zero, 1, 12, ... messages. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:1381 curs_main.c:2784 pager.c:2822
 #, fuzzy
-msgid "Cannot delete message(s)"
+msgid "Cannot delete messages"
 msgstr "ripristina messaggio(i)"
 
-#: curs_main.c:1380
+#: curs_main.c:1384
 msgid "Delete messages matching: "
 msgstr "Cancella i messaggi corrispondenti a: "
 
-#: curs_main.c:1421
+#: curs_main.c:1425
 msgid "No limit pattern is in effect."
 msgstr "Non è attivo alcun modello limitatore."
 
 #. L10N: ask for a limit to apply
-#: curs_main.c:1426
+#: curs_main.c:1430
 #, c-format
 msgid "Limit: %s"
 msgstr "Limita: %s"
 
-#: curs_main.c:1464
+#: curs_main.c:1468
 msgid "Limit to messages matching: "
 msgstr "Limita ai messaggi corrispondenti a: "
 
-#: curs_main.c:1488
+#: curs_main.c:1492
 msgid "To view all messages, limit to \"all\"."
 msgstr "Per visualizzare tutti i messaggi, limitare ad \"all\"."
 
-#: curs_main.c:1500 pager.c:2318
+#: curs_main.c:1504 pager.c:2318
 msgid "Quit NeoMutt?"
 msgstr "Uscire da NeoMutt?"
 
-#: curs_main.c:1596
+#: curs_main.c:1600
 msgid "Tag messages matching: "
 msgstr "Segna i messaggi corrispondenti a: "
 
 #. L10N: CHECK_ACL
-#: curs_main.c:1606 curs_main.c:3203 pager.c:3137
+#. L10N: Due to the implementation details we do not know whether we
+#. undelete zero, 1, 12, ... messages. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:1614 curs_main.c:3223 pager.c:3145
 #, fuzzy
-msgid "Cannot undelete message(s)"
+msgid "Cannot undelete messages"
 msgstr "ripristina messaggio(i)"
 
-#: curs_main.c:1609
+#: curs_main.c:1617
 msgid "Undelete messages matching: "
 msgstr "Ripristina i messaggi corrispondenti a: "
 
-#: curs_main.c:1619
+#: curs_main.c:1627
 msgid "Untag messages matching: "
 msgstr "Togli il segno ai messaggi corrispondenti a: "
 
-#: curs_main.c:1653
+#: curs_main.c:1661
 msgid "Logged out of IMAP servers."
 msgstr "Sessione con i server IMAP terminata."
 
-#: curs_main.c:1753
+#: curs_main.c:1761
 #, fuzzy
 msgid "No virtual folder, aborting."
 msgstr "Nessun oggetto, abbandonato."
 
-#: curs_main.c:1761
+#: curs_main.c:1769
 msgid "Failed to read thread, aborting."
 msgstr ""
 
-#: curs_main.c:1793 mx.c:1458 mx.c:1475
+#: curs_main.c:1801 mx.c:1468 mx.c:1485
 #, fuzzy
 msgid "Folder doesn't support tagging, aborting."
 msgstr "Il server SMTP non supporta l'autenticazione"
 
-#: curs_main.c:1808
+#: curs_main.c:1816
 #, fuzzy
 msgid "No tag specified, aborting."
 msgstr "Nessun oggetto, abbandonato."
 
-#: curs_main.c:1820
+#: curs_main.c:1828
 #, c-format
 msgid "Update tags..."
 msgstr ""
 
-#: curs_main.c:1857
+#: curs_main.c:1865
 msgid "Failed to modify tags, aborting."
 msgstr ""
 
-#: curs_main.c:1898
+#: curs_main.c:1906
 #, fuzzy
 msgid "No query, aborting."
 msgstr "Nessun oggetto, abbandonato."
 
-#: curs_main.c:1902 curs_main.c:1922 curs_main.c:1941
+#: curs_main.c:1910 curs_main.c:1930 curs_main.c:1949
 msgid "Failed to create query, aborting."
 msgstr ""
 
-#: curs_main.c:1911 curs_main.c:1930
+#: curs_main.c:1919 curs_main.c:1938
 msgid "Windowed queries disabled."
 msgstr ""
 
-#: curs_main.c:1916 curs_main.c:1935
+#: curs_main.c:1924 curs_main.c:1943
 msgid "No notmuch vfolder currently loaded."
 msgstr ""
 
-#: curs_main.c:1973
+#: curs_main.c:1981
 msgid "Open mailbox in read-only mode"
 msgstr "Apri la mailbox in sola lettura"
 
-#: curs_main.c:1976
+#: curs_main.c:1984
 #, fuzzy
 msgid "Open virtual folder"
 msgstr "apri un altro folder"
 
-#: curs_main.c:1979
+#: curs_main.c:1987
 msgid "Open mailbox"
 msgstr "Apri la mailbox"
 
-#: curs_main.c:1989
+#: curs_main.c:1997
 msgid "No mailboxes have new mail"
 msgstr "Nessuna mailbox con nuova posta."
 
-#: curs_main.c:2036
+#: curs_main.c:2044
 #, fuzzy
 msgid "Open newsgroup in read-only mode"
 msgstr "Apri la mailbox in sola lettura"
 
-#: curs_main.c:2038
+#: curs_main.c:2046
 msgid "Open newsgroup"
 msgstr ""
 
-#: curs_main.c:2141
+#: curs_main.c:2149
 #, fuzzy
 msgid "Exit NeoMutt without saving?"
 msgstr "Uscire da NeoMutt senza salvare?"
 
-#: curs_main.c:2157
+#: curs_main.c:2165
 #, fuzzy
 msgid "Cannot break thread"
 msgstr "collega thread"
 
-#: curs_main.c:2160 curs_main.c:2198 curs_main.c:2658 curs_main.c:2690
+#: curs_main.c:2168 curs_main.c:2206 curs_main.c:2666 curs_main.c:2698
 #: flags.c:376 thread.c:1078 thread.c:1134 thread.c:1202
 msgid "Threading is not enabled."
 msgstr "Il threading non è attivo."
 
-#: curs_main.c:2173
+#: curs_main.c:2181
 msgid "Thread broken"
 msgstr "Thread corrotto"
 
-#: curs_main.c:2185
+#: curs_main.c:2193
 msgid "Thread cannot be broken, message is not part of a thread"
 msgstr "Il thread non può essere corrotto, il messaggio non fa parte di un thread"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2195
+#: curs_main.c:2203
 #, fuzzy
 msgid "Cannot link threads"
 msgstr "collega thread"
 
-#: curs_main.c:2200
+#: curs_main.c:2208
 msgid "No Message-ID: header available to link thread"
 msgstr "Nessun header Message-ID: disponibile per collegare il thread"
 
-#: curs_main.c:2202
+#: curs_main.c:2210
 msgid "First, please tag a message to be linked here"
 msgstr "Segnare prima il messaggio da collegare qui"
 
-#: curs_main.c:2213
+#: curs_main.c:2221
 msgid "Threads linked"
 msgstr "Thread collegati"
 
-#: curs_main.c:2216
+#: curs_main.c:2224
 msgid "No thread linked"
 msgstr "Nessun thread collegato"
 
-#: curs_main.c:2252 curs_main.c:2278
+#: curs_main.c:2260 curs_main.c:2286
 msgid "You are on the last message."
 msgstr "Sei all'ultimo messaggio."
 
-#: curs_main.c:2260 curs_main.c:2305
+#: curs_main.c:2268 curs_main.c:2313
 msgid "No undeleted messages."
 msgstr "Nessun messaggio ripristinato."
 
-#: curs_main.c:2297 curs_main.c:2323
+#: curs_main.c:2305 curs_main.c:2331
 msgid "You are on the first message."
 msgstr "Sei al primo messaggio."
 
-#: curs_main.c:2395 menu.c:970 pager.c:2440 pattern.c:2110
+#: curs_main.c:2403 menu.c:970 pager.c:2440 pattern.c:2110
 msgid "Search wrapped to top."
 msgstr "La ricerca è ritornata all'inizio."
 
-#: curs_main.c:2404 pager.c:2463 pattern.c:2121
+#: curs_main.c:2412 pager.c:2463 pattern.c:2121
 msgid "Search wrapped to bottom."
 msgstr "La ricerca è ritornata al fondo."
 
-#: curs_main.c:2447
+#: curs_main.c:2455
 #, fuzzy
 msgid "No new messages in this limited view."
 msgstr "Il messaggio padre non è visibil in questa visualizzazione limitata."
 
-#: curs_main.c:2449
+#: curs_main.c:2457
 #, fuzzy
 msgid "No new messages."
 msgstr "Non ci sono nuovi messaggi"
 
-#: curs_main.c:2454
+#: curs_main.c:2462
 #, fuzzy
 msgid "No unread messages in this limited view."
 msgstr "Il messaggio padre non è visibil in questa visualizzazione limitata."
 
-#: curs_main.c:2456
+#: curs_main.c:2464
 #, fuzzy
 msgid "No unread messages."
 msgstr "Non ci sono messaggi non letti"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2474
+#: curs_main.c:2482
 #, fuzzy
 msgid "Cannot flag message"
 msgstr "aggiungi flag al messaggio"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2513 pager.c:3100
+#: curs_main.c:2521 pager.c:3104
 #, fuzzy
 msgid "Cannot toggle new"
 msgstr "(dis)abilita nuovo"
 
-#: curs_main.c:2590
+#: curs_main.c:2598
 msgid "No more threads."
 msgstr "Non ci sono altri thread."
 
-#: curs_main.c:2592
+#: curs_main.c:2600
 msgid "You are on the first thread."
 msgstr "Sei al primo thread."
 
-#: curs_main.c:2676
+#: curs_main.c:2684
 #, fuzzy
 msgid "Thread contains unread or flagged messages."
 msgstr "Il thread contiene messaggi non letti."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2726 pager.c:2784
+#: curs_main.c:2734 pager.c:2784
 #, fuzzy
 msgid "Cannot delete message"
 msgstr "ripristina messaggio"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2838
+#: curs_main.c:2850
 #, fuzzy
 msgid "Cannot edit message"
 msgstr "Impossibile scrivere il messaggio"
 
 #. L10N: This is displayed when the x-label on one or more
 #. * messages is edited.
-#: curs_main.c:2900 pager.c:3200
+#: curs_main.c:2912 pager.c:3208
 #, fuzzy, c-format
 msgid "%d label changed."
 msgid_plural "%d labels changed."
@@ -1809,28 +1817,32 @@ msgstr[1] "La mailbox non è stata modificata."
 #. L10N: This is displayed when editing an x-label, but no messages
 #. * were updated.  Possibly due to canceling at the prompt or if the new
 #. * label is the same as the old label.
-#: curs_main.c:2907 pager.c:3204
+#: curs_main.c:2919 pager.c:3212
 #, fuzzy
 msgid "No labels changed."
 msgstr "La mailbox non è stata modificata."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:3006
+#. L10N: Due to the implementation details we do not know whether we
+#. mark zero, 1, 12, ... messages as read. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:3022
 #, fuzzy
-msgid "Cannot mark message(s) as read"
+msgid "Cannot mark messages as read"
 msgstr "segna messaggio(i) come letto(i)"
 
 #. L10N: This is the prompt for <mark-message>.  Whatever they
 #. enter will be prefixed by $mark_macro_prefix and will become
 #. a macro hotkey to jump to the currently selected message.
-#: curs_main.c:3042
+#: curs_main.c:3058
 #, fuzzy
 msgid "Enter macro stroke: "
 msgstr "Inserire il keyID: "
 
 #. L10N: "message hotkey" is the key bindings menu description of a
 #. macro created by <mark-message>.
-#: curs_main.c:3050
+#: curs_main.c:3066
 #, fuzzy
 msgid "message hotkey"
 msgstr "Il messaggio è stato rimandato."
@@ -1838,28 +1850,28 @@ msgstr "Il messaggio è stato rimandato."
 #. L10N: This is echoed after <mark-message> creates a new hotkey
 #. macro.  %s is the hotkey string ($mark_macro_prefix followed
 #. by whatever they typed at the prompt.)
-#: curs_main.c:3055
+#: curs_main.c:3071
 #, fuzzy, c-format
 msgid "Message bound to %s."
 msgstr "Messaggio rimbalzato."
 
 #. L10N: This error is printed if <mark-message> cannot find a
 #. Message-ID for the currently selected message in the index.
-#: curs_main.c:3063
+#: curs_main.c:3079
 #, fuzzy
 msgid "No message ID to macro."
 msgstr "In questo folder non ci sono messaggi."
 
-#: curs_main.c:3105 pager.c:2961 recvattach.c:1388
+#: curs_main.c:3121 pager.c:2965 recvattach.c:1401
 msgid "Reply by mail as poster prefers?"
 msgstr ""
 
-#: curs_main.c:3108 pager.c:2927 pager.c:2939 pager.c:2964
+#: curs_main.c:3124 pager.c:2931 pager.c:2943 pager.c:2968
 msgid "Posting to this group not allowed, may be moderated. Continue?"
 msgstr ""
 
 #. L10N: CHECK_ACL
-#: curs_main.c:3173 pager.c:3120
+#: curs_main.c:3189 pager.c:3124
 #, fuzzy
 msgid "Cannot undelete message"
 msgstr "ripristina messaggio"
@@ -2052,12 +2064,34 @@ msgstr "[-- stderr dell'autoview di %s --]\n"
 msgid "[-- Error: message/external-body has no access-type parameter --]\n"
 msgstr "[-- Errore: message/external-body non ha un parametro access-type --]\n"
 
-#: handler.c:1611
+#. L10N: If the translation of this string is a multi line string, then
+#. each line should start with "[-- " and end with " --]".
+#. The first "%s/%s" is a MIME type, e.g. "text/plain". The last %s
+#. expands to a date as returned by `mutt_date_parse_date()`.
+#.
+#. Note: The size argument printed is not the actual number as passed
+#. to gettext but the prettified version, e.g. size = 2048 will be
+#. printed as 2K.  Your language might be sensitive to that: For
+#. example although '1K' and '1024' represent the same number your
+#. language might inflect the noun 'byte' differently.
+#.
+#. Sadly, we cannot do anything about that at the moment besides
+#. passing the precise size in bytes. If you are interested the
+#. function responsible for the prettification is
+#. mutt_str_pretty_size() in mutt/string.c.
+#.
+#: handler.c:1624
 #, fuzzy, c-format
 msgid ""
+"[-- This %s/%s attachment (size %s byte) has been deleted --]\n"
+"[-- on %s --]\n"
+msgid_plural ""
 "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
 "[-- on %s --]\n"
-msgstr ""
+msgstr[0] ""
+"[-- Questo allegato %s/%s (dimensioni %s byte) è stato cancellato -- ]\n"
+"[-- su %s --]\n"
+msgstr[1] ""
 "[-- Questo allegato %s/%s (dimensioni %s byte) è stato cancellato -- ]\n"
 "[-- su %s --]\n"
 
@@ -2065,10 +2099,23 @@ msgstr ""
 #. each line should start with "[-- " and end with " --]".
 #. The first "%s/%s" is a MIME type, e.g. "text/plain".
 #.
-#: handler.c:1620
+#. Note: The size argument printed is not the actual number as passed
+#. to gettext but the prettified version, e.g. size = 2048 will be
+#. printed as 2K.  Your language might be sensitive to that: For
+#. example although '1K' and '1024' represent the same number your
+#. language might inflect the noun 'byte' differently.
+#.
+#. Sadly, we cannot do anything about that at the moment besides
+#. passing the precise size in bytes. If you are interested the
+#. function responsible for the prettification is
+#. mutt_str_pretty_size() in mutt/string.c.
+#.
+#: handler.c:1648
 #, fuzzy, c-format
-msgid "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
-msgstr "[-- Questo allegato %s/%s (dimensioni %s byte) è stato cancellato -- ]\n"
+msgid "[-- This %s/%s attachment (size %s byte) has been deleted --]\n"
+msgid_plural "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
+msgstr[0] "[-- Questo allegato %s/%s (dimensioni %s byte) è stato cancellato -- ]\n"
+msgstr[1] "[-- Questo allegato %s/%s (dimensioni %s byte) è stato cancellato -- ]\n"
 
 #. L10N: If the translation of this string is a multi line string, then
 #. each line should start with "[-- " and end with " --]".
@@ -2078,7 +2125,7 @@ msgstr "[-- Questo allegato %s/%s (dimensioni %s byte) è stato cancellato -- ]\
 #. Caution: Argument three %3$ is also defined but should not be used
 #. in this translation!
 #.
-#: handler.c:1637
+#: handler.c:1667
 #, fuzzy
 msgid ""
 "[-- This %s/%s attachment has been deleted --]\n"
@@ -2091,17 +2138,17 @@ msgstr ""
 #. each line should start with "[-- " and end with " --]".
 #. The first "%s/%s" is a MIME type, e.g. "text/plain".
 #.
-#: handler.c:1646
+#: handler.c:1676
 #, fuzzy, c-format
 msgid "[-- This %s/%s attachment has been deleted --]\n"
 msgstr "[-- Questo allegato %s/%s è stato cancellato -- ]\n"
 
-#: handler.c:1656
+#: handler.c:1686
 #, c-format
 msgid "[-- name: %s --]\n"
 msgstr "[-- nome: %s --]\n"
 
-#: handler.c:1672
+#: handler.c:1702
 #, fuzzy, c-format
 msgid ""
 "[-- This %s/%s attachment is not included, --]\n"
@@ -2112,7 +2159,7 @@ msgstr ""
 "[-- e l'origine esterna indicata è --]\n"
 "[-- scaduta. --]\n"
 
-#: handler.c:1693
+#: handler.c:1723
 #, fuzzy, c-format
 msgid ""
 "[-- This %s/%s attachment is not included, --]\n"
@@ -2121,52 +2168,52 @@ msgstr ""
 "[-- Questo allegato %s/%s non è incluso, --]\n"
 "[-- e il l'access-type %s indicato non è gestito --]\n"
 
-#: handler.c:1822
+#: handler.c:1852
 #, fuzzy
 msgid "Unable to open memory stream!"
 msgstr "Impossibile aprire il file temporaneo!"
 
-#: handler.c:1831
+#: handler.c:1861
 msgid "Unable to open temporary file!"
 msgstr "Impossibile aprire il file temporaneo!"
 
-#: handler.c:1881
+#: handler.c:1911
 #, fuzzy
 msgid "failed to re-open memstream!"
 msgstr "Impossibile aprire il file temporaneo!"
 
-#: handler.c:2013
+#: handler.c:2043
 msgid "Error: multipart/signed has no protocol."
 msgstr "Errore: multipart/signed non ha protocollo."
 
-#: handler.c:2076
+#: handler.c:2106
 #, fuzzy
 msgid "[-- This is an attachment (use '%3$s' to view this part) --]\n"
 msgstr "[-- Questo è un allegato (usa '%3$s' per vederlo) --]\n"
 
-#: handler.c:2082
+#: handler.c:2112
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported (use '%s' to view this part) --]\n"
 msgstr "[-- %s/%s non è gestito (usa '%s' per vederlo) --]\n"
 
-#: handler.c:2087
+#: handler.c:2117
 #, fuzzy
 msgid "[-- This is an attachment (need 'view-attachments' bound to key!) --]\n"
 msgstr "[-- Questo è un allegato ('view-attachments' deve essere assegnato a un tasto!) --]\n"
 
 #. L10N: %s/%s is a MIME type, e.g. "text/plain".
-#: handler.c:2091
+#: handler.c:2121
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported (need 'view-attachments' bound to key!) --]\n"
 msgstr "[-- %s/%s non è gestito ('view-attachments' deve essere assegnato a un tasto!) --]\n"
 
-#: handler.c:2098
+#: handler.c:2128
 #, fuzzy
 msgid "[-- This is an attachment --]\n"
 msgstr "[-- Questo è un allegato --]\n"
 
 #. L10N: %s/%s is a MIME type, e.g. "text/plain".
-#: handler.c:2101
+#: handler.c:2131
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported --]\n"
 msgstr "[-- %s/%s non è gestito --]\n"
@@ -2473,7 +2520,7 @@ msgstr "Il server SMTP non supporta l'autenticazione"
 msgid "Invalid IMAP flags"
 msgstr "Non valido   "
 
-#: imap/message.c:477 mx.c:1326
+#: imap/message.c:477 mx.c:1336
 msgid "Integer overflow -- can't allocate memory."
 msgstr "Overflow intero -- impossibile allocare memoria."
 
@@ -3237,66 +3284,75 @@ msgstr "SSL non è disponibile."
 msgid "Reading from %s interrupted..."
 msgstr "Ricerca interrotta."
 
-#: mx.c:634
+#. L10N: Although we now the precise number of messages, we do not show it to the user.
+#. So feel free to use a "generic plural" as plural translation if your language has one.
+#.
+#: mx.c:639
 #, fuzzy
-msgid "message(s) not deleted"
-msgstr "Segno i messaggi come cancellati..."
+msgid "message not deleted"
+msgid_plural "messages not deleted"
+msgstr[0] "Segno i messaggi come cancellati..."
+msgstr[1] "Segno i messaggi come cancellati..."
 
-#: mx.c:671
+#: mx.c:676
 #, fuzzy
 msgid "Can't open trash folder"
 msgstr "Impossibile accodare al folder: %s"
 
-#: mx.c:710
+#: mx.c:715
 msgid "Mark all articles read?"
 msgstr ""
 
-#: mx.c:754
+#. L10N: The first argument is the number of read messages to be
+#. moved, the second argument is the target mailbox.
+#: mx.c:762
 #, fuzzy, c-format
-msgid "Move %d read messages to %s?"
-msgstr "Spostare i messaggi letti in %s?"
+msgid "Move %d read message to %s?"
+msgid_plural "Move %d read messages to %s?"
+msgstr[0] "Spostare i messaggi letti in %s?"
+msgstr[1] "Spostare i messaggi letti in %s?"
 
-#: mx.c:771 mx.c:1077
+#: mx.c:781 mx.c:1087
 #, fuzzy, c-format
 msgid "Purge %d deleted message?"
 msgid_plural "Purge %d deleted messages?"
 msgstr[0] "Eliminare %d messaggio cancellato?"
 msgstr[1] "Eliminare %d messaggi cancellati?"
 
-#: mx.c:793
+#: mx.c:803
 #, c-format
 msgid "Moving read messages to %s..."
 msgstr "Spostamento dei messaggi letti in %s..."
 
-#: mx.c:859 mx.c:1068
+#: mx.c:869 mx.c:1078
 msgid "Mailbox is unchanged."
 msgstr "La mailbox non è stata modificata."
 
-#: mx.c:914
+#: mx.c:924
 #, c-format
 msgid "%d kept, %d moved, %d deleted."
 msgstr "%d tenuti, %d spostati, %d cancellati."
 
-#: mx.c:917 mx.c:1130
+#: mx.c:927 mx.c:1140
 #, c-format
 msgid "%d kept, %d deleted."
 msgstr "%d tenuti, %d cancellati."
 
-#: mx.c:1052
+#: mx.c:1062
 #, c-format
 msgid " Press '%s' to toggle write"
 msgstr " Premere '%s' per (dis)abilitare la scrittura"
 
-#: mx.c:1054
+#: mx.c:1064
 msgid "Use 'toggle-write' to re-enable write!"
 msgstr "Usare 'toggle-write' per riabilitare la scrittura!"
 
-#: mx.c:1056
+#: mx.c:1066
 #, c-format
 msgid "Mailbox is marked unwritable. %s"
 msgstr "La mailbox è indicata non scrivibile. %s"
 
-#: mx.c:1124
+#: mx.c:1134
 msgid "Mailbox checkpointed."
 msgstr "Effettuato il checkpoint della mailbox."
 
@@ -3310,54 +3366,59 @@ msgstr " (orario attuale: %c)"
 msgid "[-- %s output follows%s --]\n"
 msgstr "[-- Segue l'output di %s%s --]\n"
 
-#: ncrypt/crypt.c:95
-msgid "Passphrase(s) forgotten."
+#. L10N: Due to the implementation details (e.g. some passwords are managed
+#. by gpg-agent) we cannot know whether we forgot zero, 1, 12, ...
+#. passwords. So in English we use "Passphrases". Your language might
+#. have other means to express this.
+#: ncrypt/crypt.c:100
+#, fuzzy
+msgid "Passphrases forgotten."
 msgstr "Passphrase dimenticata/e."
 
-#: ncrypt/crypt.c:155
+#: ncrypt/crypt.c:161
 #, fuzzy
 msgid "Inline PGP can't be used with attachments.  Revert to PGP/MIME?"
 msgstr "Il messaggio non può essere inviato in linea.  Riutilizzare PGP/MIME?"
 
-#: ncrypt/crypt.c:159
+#: ncrypt/crypt.c:165
 msgid "Mail not sent: inline PGP can't be used with attachments."
 msgstr ""
 
-#: ncrypt/crypt.c:166
+#: ncrypt/crypt.c:172
 #, fuzzy
 msgid "Inline PGP can't be used with format=flowed.  Revert to PGP/MIME?"
 msgstr "Il messaggio non può essere inviato in linea.  Riutilizzare PGP/MIME?"
 
-#: ncrypt/crypt.c:170
+#: ncrypt/crypt.c:176
 msgid "Mail not sent: inline PGP can't be used with format=flowed."
 msgstr ""
 
-#: ncrypt/crypt.c:180 ncrypt/cryptglue.c:125 ncrypt/pgpkey.c:589
+#: ncrypt/crypt.c:186 ncrypt/cryptglue.c:125 ncrypt/pgpkey.c:589
 #: ncrypt/pgpkey.c:782
 msgid "Invoking PGP..."
 msgstr "Eseguo PGP..."
 
-#: ncrypt/crypt.c:192
+#: ncrypt/crypt.c:198
 msgid "Message can't be sent inline.  Revert to using PGP/MIME?"
 msgstr "Il messaggio non può essere inviato in linea.  Riutilizzare PGP/MIME?"
 
-#: ncrypt/crypt.c:194 send.c:1824
+#: ncrypt/crypt.c:200 send.c:1824
 msgid "Mail not sent."
 msgstr "Il messaggio non è stato inviato."
 
-#: ncrypt/crypt.c:540
+#: ncrypt/crypt.c:546
 msgid "S/MIME messages with no hints on content are unsupported."
 msgstr "I messaggi S/MIME senza suggerimenti del contenuto non sono gestiti."
 
-#: ncrypt/crypt.c:754 ncrypt/crypt.c:795
+#: ncrypt/crypt.c:760 ncrypt/crypt.c:801
 msgid "Trying to extract PGP keys...\n"
 msgstr "Cerco di estrarre le chiavi PGP...\n"
 
-#: ncrypt/crypt.c:776 ncrypt/crypt.c:816
+#: ncrypt/crypt.c:782 ncrypt/crypt.c:822
 msgid "Trying to extract S/MIME certificates...\n"
 msgstr "Cerco di estrarre i certificati S/MIME...\n"
 
-#: ncrypt/crypt.c:976
+#: ncrypt/crypt.c:982
 #, c-format
 msgid ""
 "[-- Error: Unknown multipart/signed protocol %s! --]\n"
@@ -3366,7 +3427,7 @@ msgstr ""
 "[-- Errore: protocollo multipart/signed %s sconosciuto! --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1016
+#: ncrypt/crypt.c:1022
 #, fuzzy
 msgid ""
 "[-- Error: Missing or bad-format multipart/signed signature! --]\n"
@@ -3375,7 +3436,7 @@ msgstr ""
 "[-- Errore: struttura multipart/signed incoerente! --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1058
+#: ncrypt/crypt.c:1064
 #, c-format
 msgid ""
 "[-- Warning: We can't verify %s/%s signatures. --]\n"
@@ -3384,7 +3445,7 @@ msgstr ""
 "[-- Attenzione: impossibile verificare firme %s/%s. --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1070
+#: ncrypt/crypt.c:1076
 msgid ""
 "[-- The following data is signed --]\n"
 "\n"
@@ -3392,7 +3453,7 @@ msgstr ""
 "[-- I seguenti dati sono firmati --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1075
+#: ncrypt/crypt.c:1081
 msgid ""
 "[-- Warning: Can't find any signatures. --]\n"
 "\n"
@@ -3400,7 +3461,7 @@ msgstr ""
 "[-- Attenzione: non è stata trovata alcuna firma. --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1081
+#: ncrypt/crypt.c:1087
 msgid ""
 "\n"
 "[-- End of signed data --]\n"
@@ -3451,7 +3512,7 @@ msgstr ""
 msgid "error reading data object: %s\n"
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:662 ncrypt/crypt_gpgme.c:3848 ncrypt/pgpkey.c:585
+#: ncrypt/crypt_gpgme.c:662 ncrypt/crypt_gpgme.c:3850 ncrypt/pgpkey.c:585
 #: ncrypt/pgpkey.c:768
 msgid "Can't create temporary file"
 msgstr "Impossibile creare il file temporaneo"
@@ -3807,28 +3868,30 @@ msgstr "[Non valido]"
 
 #. L10N: This is printed after "Key Type: " and looks like this:
 #. *       PGP, 2048 bit RSA
-#: ncrypt/crypt_gpgme.c:3670 ncrypt/crypt_gpgme.c:3808
+#: ncrypt/crypt_gpgme.c:3670 ncrypt/crypt_gpgme.c:3810
 #, fuzzy, c-format
 msgid "%s, %lu bit %s\n"
-msgstr "Tipo di chiave ..: %s, %lu bit %s\n"
+msgid_plural "%s, %lu bit %s\n"
+msgstr[0] "Tipo di chiave ..: %s, %lu bit %s\n"
+msgstr[1] "Tipo di chiave ..: %s, %lu bit %s\n"
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3678 ncrypt/crypt_gpgme.c:3815
+#: ncrypt/crypt_gpgme.c:3678 ncrypt/crypt_gpgme.c:3817
 msgid "encryption"
 msgstr "cifratura"
 
 #: ncrypt/crypt_gpgme.c:3679 ncrypt/crypt_gpgme.c:3685
-#: ncrypt/crypt_gpgme.c:3816 ncrypt/crypt_gpgme.c:3821
+#: ncrypt/crypt_gpgme.c:3818 ncrypt/crypt_gpgme.c:3823
 msgid ", "
 msgstr ", "
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3684 ncrypt/crypt_gpgme.c:3820
+#: ncrypt/crypt_gpgme.c:3684 ncrypt/crypt_gpgme.c:3822
 msgid "signing"
 msgstr "firma"
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3690 ncrypt/crypt_gpgme.c:3825
+#: ncrypt/crypt_gpgme.c:3690 ncrypt/crypt_gpgme.c:3827
 msgid "certification"
 msgstr "certificazione"
 
@@ -3847,65 +3910,65 @@ msgstr "[Scaduto]"
 msgid "[Disabled]"
 msgstr "[Disabilitato]"
 
-#: ncrypt/crypt_gpgme.c:3851
+#: ncrypt/crypt_gpgme.c:3853
 msgid "Collecting data..."
 msgstr "Raccolta dei dati..."
 
-#: ncrypt/crypt_gpgme.c:3876
+#: ncrypt/crypt_gpgme.c:3878
 #, c-format
 msgid "Error finding issuer key: %s\n"
 msgstr "Errore nella ricerca dell'emittente della chiave: %s\n"
 
-#: ncrypt/crypt_gpgme.c:3885
+#: ncrypt/crypt_gpgme.c:3887
 #, fuzzy
 msgid "Error: certification chain too long - stopping here\n"
 msgstr "Errore: catena di certificazione troppo lunga - stop\n"
 
-#: ncrypt/crypt_gpgme.c:3895 ncrypt/pgpkey.c:608
+#: ncrypt/crypt_gpgme.c:3897 ncrypt/pgpkey.c:608
 #, c-format
 msgid "Key ID: 0x%s"
 msgstr "Key ID: 0x%s"
 
-#: ncrypt/crypt_gpgme.c:3990
+#: ncrypt/crypt_gpgme.c:3992
 #, c-format
 msgid "gpgme_new failed: %s"
 msgstr "gpg_new fallito: %s"
 
-#: ncrypt/crypt_gpgme.c:4028 ncrypt/crypt_gpgme.c:4079
+#: ncrypt/crypt_gpgme.c:4030 ncrypt/crypt_gpgme.c:4081
 #, c-format
 msgid "gpgme_op_keylist_start failed: %s"
 msgstr "gpgme_op_keylist_start fallito: %s"
 
-#: ncrypt/crypt_gpgme.c:4067 ncrypt/crypt_gpgme.c:4109
+#: ncrypt/crypt_gpgme.c:4069 ncrypt/crypt_gpgme.c:4111
 #, c-format
 msgid "gpgme_op_keylist_next failed: %s"
 msgstr "gpgme_op_keylist_next fallito: %s"
 
-#: ncrypt/crypt_gpgme.c:4185
+#: ncrypt/crypt_gpgme.c:4187
 msgid "All matching keys are marked expired/revoked."
 msgstr "Tutte le chiavi corrispondenti sono scadute/revocate."
 
-#: ncrypt/crypt_gpgme.c:4215 ncrypt/pgpkey.c:543 ncrypt/smime.c:475
+#: ncrypt/crypt_gpgme.c:4217 ncrypt/pgpkey.c:543 ncrypt/smime.c:475
 msgid "Select  "
 msgstr "Seleziona  "
 
-#: ncrypt/crypt_gpgme.c:4217 ncrypt/pgpkey.c:545
+#: ncrypt/crypt_gpgme.c:4219 ncrypt/pgpkey.c:545
 msgid "Check key  "
 msgstr "Controlla chiave  "
 
-#: ncrypt/crypt_gpgme.c:4233
+#: ncrypt/crypt_gpgme.c:4235
 msgid "PGP and S/MIME keys matching"
 msgstr "Chiavi PGP e S/MIME corrispondenti"
 
-#: ncrypt/crypt_gpgme.c:4235
+#: ncrypt/crypt_gpgme.c:4237
 msgid "PGP keys matching"
 msgstr "Chiavi PGP corrispondenti"
 
-#: ncrypt/crypt_gpgme.c:4237
+#: ncrypt/crypt_gpgme.c:4239
 msgid "S/MIME keys matching"
 msgstr "Chiavi S/MIME corrispondenti"
 
-#: ncrypt/crypt_gpgme.c:4239
+#: ncrypt/crypt_gpgme.c:4241
 msgid "keys matching"
 msgstr "Chiavi corrispondenti"
 
@@ -3913,69 +3976,69 @@ msgstr "Chiavi corrispondenti"
 #. %1$s is one of the previous four entries.
 #. %2$s is an address.
 #. e.g. "S/MIME keys matching <me@mutt.org>."
-#: ncrypt/crypt_gpgme.c:4246
+#: ncrypt/crypt_gpgme.c:4248
 #, c-format
 msgid "%s <%s>."
 msgstr "%s <%s>."
 
 #. L10N:
 #. e.g. 'S/MIME keys matching "Michael Elkins".'
-#: ncrypt/crypt_gpgme.c:4250
+#: ncrypt/crypt_gpgme.c:4252
 #, c-format
 msgid "%s \"%s\"."
 msgstr "%s \"%s\"."
 
-#: ncrypt/crypt_gpgme.c:4277 ncrypt/pgpkey.c:628
+#: ncrypt/crypt_gpgme.c:4279 ncrypt/pgpkey.c:628
 msgid "This key can't be used: expired/disabled/revoked."
 msgstr "Questa chiave non può essere usata: è scaduta/disabilitata/revocata."
 
-#: ncrypt/crypt_gpgme.c:4290 ncrypt/pgpkey.c:640 ncrypt/smime.c:505
+#: ncrypt/crypt_gpgme.c:4292 ncrypt/pgpkey.c:640 ncrypt/smime.c:505
 #, fuzzy
 msgid "ID is expired/disabled/revoked. Do you really want to use the key?"
 msgstr "L'ID è scaduto/disabilitato/revocato. Vuoi veramente usare questa chiave?"
 
-#: ncrypt/crypt_gpgme.c:4299 ncrypt/pgpkey.c:650
+#: ncrypt/crypt_gpgme.c:4301 ncrypt/pgpkey.c:650
 #, fuzzy
 msgid "ID is not valid. Do you really want to use the key?"
 msgstr "L'ID non è valido. Vuoi veramente usare questa chiave?"
 
-#: ncrypt/crypt_gpgme.c:4302 ncrypt/pgpkey.c:653
+#: ncrypt/crypt_gpgme.c:4304 ncrypt/pgpkey.c:653
 #, fuzzy
 msgid "ID is only marginally valid. Do you really want to use the key?"
 msgstr "L'ID è solo marginalmente valido. Vuoi veramente usare questa chiave?"
 
-#: ncrypt/crypt_gpgme.c:4310 ncrypt/pgpkey.c:646 ncrypt/smime.c:509
+#: ncrypt/crypt_gpgme.c:4312 ncrypt/pgpkey.c:646 ncrypt/smime.c:509
 #, fuzzy
 msgid "ID has undefined validity. Do you really want to use the key?"
 msgstr "L'ID ha validità indefinita. Vuoi veramente usare questa chiave?"
 
-#: ncrypt/crypt_gpgme.c:4370 ncrypt/crypt_gpgme.c:4479 ncrypt/pgpkey.c:872
+#: ncrypt/crypt_gpgme.c:4372 ncrypt/crypt_gpgme.c:4481 ncrypt/pgpkey.c:872
 #: ncrypt/pgpkey.c:995
 #, c-format
 msgid "Looking for keys matching \"%s\"..."
 msgstr "Ricerca chiavi corrispondenti a \"%s\"..."
 
-#: ncrypt/crypt_gpgme.c:4593 ncrypt/pgpkey.c:731 ncrypt/smime.c:811
+#: ncrypt/crypt_gpgme.c:4595 ncrypt/pgpkey.c:731 ncrypt/smime.c:811
 #, c-format
 msgid "No matching keys found for \"%s\""
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4644 ncrypt/pgp.c:1263
+#: ncrypt/crypt_gpgme.c:4646 ncrypt/pgp.c:1263
 #, c-format
 msgid "Use keyID = \"%s\" for %s?"
 msgstr "Uso il keyID \"%s\" per %s?"
 
-#: ncrypt/crypt_gpgme.c:4695 ncrypt/pgp.c:1312 ncrypt/smime.c:830
+#: ncrypt/crypt_gpgme.c:4697 ncrypt/pgp.c:1312 ncrypt/smime.c:830
 #: ncrypt/smime.c:938
 #, c-format
 msgid "Enter keyID for %s: "
 msgstr "Inserisci il keyID per %s: "
 
-#: ncrypt/crypt_gpgme.c:4755 ncrypt/pgpkey.c:751
+#: ncrypt/crypt_gpgme.c:4757 ncrypt/pgpkey.c:751
 msgid "Please enter the key ID: "
 msgstr "Inserire il key ID: "
 
-#: ncrypt/crypt_gpgme.c:4768
+#: ncrypt/crypt_gpgme.c:4770
 #, fuzzy, c-format
 msgid "Error exporting key: %s\n"
 msgstr "Errore nell'estrazione dei dati della chiave!\n"
@@ -3984,86 +4047,86 @@ msgstr "Errore nell'estrazione dei dati della chiave!\n"
 #. MIME description for exported (attached) keys.
 #. You can translate this entry to a non-ASCII string (it will be encoded),
 #. but it may be safer to keep it untranslated.
-#: ncrypt/crypt_gpgme.c:4787
+#: ncrypt/crypt_gpgme.c:4789
 #, fuzzy, c-format
 msgid "PGP Key 0x%s."
 msgstr "Chiave PGP %s."
 
-#: ncrypt/crypt_gpgme.c:4830
+#: ncrypt/crypt_gpgme.c:4832
 msgid "GPGME: OpenPGP protocol not available"
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4838
+#: ncrypt/crypt_gpgme.c:4840
 msgid "GPGME: CMS protocol not available"
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4876
+#: ncrypt/crypt_gpgme.c:4878
 #, fuzzy
 msgid "S/MIME (s)ign, sign (a)s, (p)gp, (c)lear, or (o)ppenc mode off? "
 msgstr "S/MIME cifra(e), firma(s), firma (c)ome, entram(b)i, (p)gp, annullare(c)?"
 
 #. L10N: S/MIME options (opportunistic encryption is on)
-#: ncrypt/crypt_gpgme.c:4878
+#: ncrypt/crypt_gpgme.c:4880
 msgid "sapco"
 msgstr "escbpc"
 
-#: ncrypt/crypt_gpgme.c:4885
+#: ncrypt/crypt_gpgme.c:4887
 #, fuzzy
 msgid "PGP (s)ign, sign (a)s, s/(m)ime, (c)lear, or (o)ppenc mode off? "
 msgstr "PGP: cifra(e), firma(s), firma (c)ome, entram(b)i, s/(m)ime, annullare(c)?"
 
 #. L10N: PGP options (opportunistic encryption is on)
-#: ncrypt/crypt_gpgme.c:4887
+#: ncrypt/crypt_gpgme.c:4889
 msgid "samco"
 msgstr "escbmc"
 
 #. L10N: S/MIME options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4900
+#: ncrypt/crypt_gpgme.c:4902
 #, fuzzy
 msgid "S/MIME (e)ncrypt, (s)ign, sign (a)s, (b)oth, (p)gp, (c)lear, or (o)ppenc mode? "
 msgstr "S/MIME cifra(e), firma(s), firma (c)ome, entram(b)i, (p)gp, annullare(c)?"
 
 #. L10N: S/MIME options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4903
+#: ncrypt/crypt_gpgme.c:4905
 msgid "esabpco"
 msgstr "escbpc"
 
 #. L10N: PGP options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4909
+#: ncrypt/crypt_gpgme.c:4911
 #, fuzzy
 msgid "PGP (e)ncrypt, (s)ign, sign (a)s, (b)oth, s/(m)ime, (c)lear, or (o)ppenc mode? "
 msgstr "PGP: cifra(e), firma(s), firma (c)ome, entram(b)i, s/(m)ime, annullare(c)?"
 
 #. L10N: PGP options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4912
+#: ncrypt/crypt_gpgme.c:4914
 msgid "esabmco"
 msgstr "escbmc"
 
-#: ncrypt/crypt_gpgme.c:4925
+#: ncrypt/crypt_gpgme.c:4927
 #, fuzzy
 msgid "S/MIME (e)ncrypt, (s)ign, sign (a)s, (b)oth, (p)gp or (c)lear? "
 msgstr "S/MIME cifra(e), firma(s), firma (c)ome, entram(b)i, (p)gp, annullare(c)?"
 
 #. L10N: S/MIME options
-#: ncrypt/crypt_gpgme.c:4927
+#: ncrypt/crypt_gpgme.c:4929
 msgid "esabpc"
 msgstr "escbpc"
 
-#: ncrypt/crypt_gpgme.c:4934
+#: ncrypt/crypt_gpgme.c:4936
 #, fuzzy
 msgid "PGP (e)ncrypt, (s)ign, sign (a)s, (b)oth, s/(m)ime or (c)lear? "
 msgstr "PGP: cifra(e), firma(s), firma (c)ome, entram(b)i, s/(m)ime, annullare(c)?"
 
 #. L10N: PGP options
-#: ncrypt/crypt_gpgme.c:4936
+#: ncrypt/crypt_gpgme.c:4938
 msgid "esabmc"
 msgstr "escbmc"
 
-#: ncrypt/crypt_gpgme.c:5087
+#: ncrypt/crypt_gpgme.c:5089
 msgid "Failed to verify sender"
 msgstr "Errore nella verifica del mittente"
 
-#: ncrypt/crypt_gpgme.c:5090
+#: ncrypt/crypt_gpgme.c:5092
 msgid "Failed to figure out sender"
 msgstr "Errore nel rilevamento del mittente"
 
@@ -4457,7 +4520,7 @@ msgstr ""
 msgid "%s is an invalid news server specification!"
 msgstr "%s non è un percorso POP valido"
 
-#: nntp.c:75 nntp.c:612 pop.c:1028 pop_lib.c:405
+#: nntp.c:75 nntp.c:612 pop.c:1031 pop_lib.c:405
 msgid "Server closed connection!"
 msgstr "Il server ha chiuso la connessione!"
 
@@ -4623,16 +4686,18 @@ msgid "check mailboxes for new mail"
 msgstr "controlla se c'è nuova posta nella mailbox"
 
 #: opcodes.h:47
-msgid "attach file(s) to this message"
+#, fuzzy
+msgid "attach files to this message"
 msgstr "allega uno o più file a questo messaggio"
 
 #: opcodes.h:48
-msgid "attach message(s) to this message"
+#, fuzzy
+msgid "attach messages to this message"
 msgstr "allega uno o più messaggi a questo messaggio"
 
 #: opcodes.h:49
 #, fuzzy
-msgid "attach news article(s) to this message"
+msgid "attach news articles to this message"
 msgstr "allega uno o più file a questo messaggio"
 
 #: opcodes.h:50
@@ -5476,7 +5541,8 @@ msgid "extract supported public keys"
 msgstr "estra le chiavi pubbliche PGP"
 
 #: opcodes.h:255
-msgid "wipe passphrase(s) from memory"
+#, fuzzy
+msgid "wipe passphrases from memory"
 msgstr "cancella la/le passphrase dalla memoria"
 
 #: opcodes.h:259
@@ -5824,18 +5890,20 @@ msgstr "Non c'è nuova posta nella mailbox POP."
 msgid "Delete messages from server?"
 msgstr "Cancellare i messaggi dal server?"
 
-#: pop.c:954
-#, c-format
-msgid "Reading new messages (%d bytes)..."
-msgstr "Lettura dei nuovi messaggi (%d byte)..."
+#: pop.c:955
+#, fuzzy, c-format
+msgid "Reading new messages (%d byte)..."
+msgid_plural "Reading new messages (%d bytes)..."
+msgstr[0] "Lettura dei nuovi messaggi (%d byte)..."
+msgstr[1] "Lettura dei nuovi messaggi (%d byte)..."
 
-#: pop.c:997
+#: pop.c:1000
 msgid "Error while writing mailbox!"
 msgstr "Errore durante la scrittura della mailbox!"
 
 #. L10N: The plural is picked by the second numerical argument, i.e.
 #. * the %d right before 'messages', i.e. the total number of messages.
-#: pop.c:1003
+#: pop.c:1006
 #, fuzzy, c-format
 msgid "%s [%d of %d message read]"
 msgid_plural "%s [%d of %d messages read]"
@@ -5979,49 +6047,56 @@ msgstr "Manda con una pipe a: "
 msgid "I don't know how to print %s attachments!"
 msgstr "Non so come stampare %s allegati!"
 
-#: recvattach.c:841
-msgid "Print tagged attachment(s)?"
-msgstr "Stampare gli allegati segnati?"
+#. L10N: Although we now the precise number of tagged messages, we
+#. do not show it to the user.  So feel free to use a "generic
+#. plural" as plural translation if your language has one.
+#: recvattach.c:852
+#, fuzzy, c-format
+msgid "Print tagged attachment?"
+msgid_plural "Print %d tagged attachments?"
+msgstr[0] "Stampare gli allegati segnati?"
+msgstr[1] "Stampare gli allegati segnati?"
 
-#: recvattach.c:842
+#: recvattach.c:853
+#, c-format
 msgid "Print attachment?"
 msgstr "Stampare l'allegato?"
 
-#: recvattach.c:900
+#: recvattach.c:913
 msgid "Structural changes to decrypted attachments are not supported"
 msgstr ""
 
-#: recvattach.c:1046
+#: recvattach.c:1059
 msgid "Can't decrypt encrypted message!"
 msgstr "Impossibile decifrare il messaggio cifrato!"
 
-#: recvattach.c:1172
+#: recvattach.c:1185
 msgid "Attachments"
 msgstr "Allegati"
 
-#: recvattach.c:1210
+#: recvattach.c:1223
 msgid "There are no subparts to show!"
 msgstr "Non ci sono sottoparti da visualizzare!"
 
-#: recvattach.c:1265
+#: recvattach.c:1278
 msgid "Can't delete attachment from POP server."
 msgstr "Impossibile cancellare l'allegato dal server POP"
 
-#: recvattach.c:1274
+#: recvattach.c:1287
 #, fuzzy
 msgid "Can't delete attachment from news server."
 msgstr "Impossibile cancellare l'allegato dal server POP"
 
-#: recvattach.c:1281
+#: recvattach.c:1294
 msgid "Deletion of attachments from encrypted messages is unsupported."
 msgstr "La cancellazione di allegati da messaggi cifrati non è gestita."
 
-#: recvattach.c:1287
+#: recvattach.c:1300
 #, fuzzy
 msgid "Deletion of attachments from signed messages may invalidate the signature."
 msgstr "La cancellazione di allegati da messaggi cifrati non è gestita."
 
-#: recvattach.c:1305 recvattach.c:1320
+#: recvattach.c:1318 recvattach.c:1333
 msgid "Only deletion of multipart attachments is supported."
 msgstr "È gestita solo la cancellazione degli allegati multiparte."
 
@@ -6443,3 +6518,15 @@ msgstr "Opzioni di compilazione:"
 #: version.c:404
 msgid "Compile options:"
 msgstr "Opzioni di compilazione:"
+
+#, fuzzy
+#~ msgid "Cannot delete message(s)"
+#~ msgstr "ripristina messaggio(i)"
+
+#, fuzzy
+#~ msgid "Cannot undelete message(s)"
+#~ msgstr "ripristina messaggio(i)"
+
+#, fuzzy
+#~ msgid "messages not deleted"
+#~ msgstr "Segno i messaggi come cancellati..."

--- a/po/ja.po
+++ b/po/ja.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neomutt-20180512\n"
 "Report-Msgid-Bugs-To: neomutt-devel@neomutt.org\n"
-"POT-Creation-Date: 2018-05-20 02:02+0000\n"
+"POT-Creation-Date: 2018-05-22 14:18+0000\n"
 "PO-Revision-Date: 2017-06-01 13:00+0900\n"
 "Last-Translator: TAKAHASHI Tamotsu <ttakah@lapis.plala.or.jp>\n"
 "Language-Team: neomutt-j <neomutt-j-users@lists.osdn.me>\n"
@@ -39,7 +39,7 @@ msgstr "選択"
 
 #: addrbook.c:52 browser.c:75 browser.c:87 compose.c:160 compose.c:172
 #: conn/ssl.c:1041 conn/ssl_gnutls.c:793 curs_main.c:748 curs_main.c:761
-#: history.c:106 ncrypt/crypt_gpgme.c:4219 ncrypt/pgpkey.c:547
+#: history.c:106 ncrypt/crypt_gpgme.c:4221 ncrypt/pgpkey.c:547
 #: ncrypt/smime.c:477 pager.c:2141 postpone.c:65 query.c:72 recvattach.c:70
 msgid "Help"
 msgstr "ヘルプ"
@@ -685,7 +685,7 @@ msgstr "暗号と署名: "
 #. * Since it shares the row with "Encrypt with:", it should not be longer
 #. * than 15-20 character cells.
 #.
-#: compose.c:138 ncrypt/crypt_gpgme.c:4947 ncrypt/pgp.c:1786
+#: compose.c:138 ncrypt/crypt_gpgme.c:4949 ncrypt/pgp.c:1786
 #: ncrypt/smime.c:2127
 msgid "Sign as: "
 msgstr "署名に使う鍵: "
@@ -1226,7 +1226,7 @@ msgstr "r:拒否, o:今回のみ承認, s:無視"
 msgid "(r)eject, accept (o)nce"
 msgstr "r:拒否, o:今回のみ承認"
 
-#: conn/ssl.c:1039 conn/ssl_gnutls.c:791 ncrypt/crypt_gpgme.c:4213
+#: conn/ssl.c:1039 conn/ssl_gnutls.c:791 ncrypt/crypt_gpgme.c:4215
 #: ncrypt/pgpkey.c:541 ncrypt/smime.c:473
 msgid "Exit  "
 msgstr "終了  "
@@ -1405,11 +1405,11 @@ msgstr "開いているメールボックスがない。"
 msgid "There are no messages."
 msgstr "メッセージがない。"
 
-#: curs_main.c:77 mx.c:1061 pager.c:73 recvattach.c:56
+#: curs_main.c:77 mx.c:1071 pager.c:73 recvattach.c:56
 msgid "Mailbox is read-only."
 msgstr "メールボックスは読み出し専用。"
 
-#: curs_main.c:79 pager.c:75 recvattach.c:1145
+#: curs_main.c:79 pager.c:75 recvattach.c:1158
 msgid "Function not permitted in attach-message mode."
 msgstr "この機能はメッセージ添付モードでは許可されていない。"
 
@@ -1544,244 +1544,254 @@ msgid "That message is not visible."
 msgstr "そのメッセージは可視ではない。"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:1377 curs_main.c:2772 pager.c:2818
-msgid "Cannot delete message(s)"
+#. L10N: Due to the implementation details we do not know whether we
+#. delete zero, 1, 12, ... messages. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:1381 curs_main.c:2784 pager.c:2822
+#, fuzzy
+msgid "Cannot delete messages"
 msgstr "メッセージを削除できない"
 
-#: curs_main.c:1380
+#: curs_main.c:1384
 msgid "Delete messages matching: "
 msgstr "メッセージを削除するためのパターン: "
 
-#: curs_main.c:1421
+#: curs_main.c:1425
 msgid "No limit pattern is in effect."
 msgstr "現在有効な制限パターンはない。"
 
 #. L10N: ask for a limit to apply
-#: curs_main.c:1426
+#: curs_main.c:1430
 #, c-format
 msgid "Limit: %s"
 msgstr "制限パターン: %s"
 
-#: curs_main.c:1464
+#: curs_main.c:1468
 msgid "Limit to messages matching: "
 msgstr "メッセージの表示を制限するパターン: "
 
-#: curs_main.c:1488
+#: curs_main.c:1492
 msgid "To view all messages, limit to \"all\"."
 msgstr "メッセージをすべて見るには制限を \"all\" にする。"
 
-#: curs_main.c:1500 pager.c:2318
+#: curs_main.c:1504 pager.c:2318
 msgid "Quit NeoMutt?"
 msgstr "NeoMutt を中止?"
 
-#: curs_main.c:1596
+#: curs_main.c:1600
 msgid "Tag messages matching: "
 msgstr "メッセージにタグを付けるためのパターン: "
 
 #. L10N: CHECK_ACL
-#: curs_main.c:1606 curs_main.c:3203 pager.c:3137
-msgid "Cannot undelete message(s)"
+#. L10N: Due to the implementation details we do not know whether we
+#. undelete zero, 1, 12, ... messages. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:1614 curs_main.c:3223 pager.c:3145
+#, fuzzy
+msgid "Cannot undelete messages"
 msgstr "メッセージの削除状態を解除できない"
 
-#: curs_main.c:1609
+#: curs_main.c:1617
 msgid "Undelete messages matching: "
 msgstr "メッセージの削除を解除するためのパターン: "
 
-#: curs_main.c:1619
+#: curs_main.c:1627
 msgid "Untag messages matching: "
 msgstr "メッセージのタグを外すためのパターン: "
 
-#: curs_main.c:1653
+#: curs_main.c:1661
 msgid "Logged out of IMAP servers."
 msgstr "IMAP サーバからログアウトした。"
 
-#: curs_main.c:1753
+#: curs_main.c:1761
 #, fuzzy
 msgid "No virtual folder, aborting."
 msgstr "無題で中止する。"
 
-#: curs_main.c:1761
+#: curs_main.c:1769
 msgid "Failed to read thread, aborting."
 msgstr ""
 
-#: curs_main.c:1793 mx.c:1458 mx.c:1475
+#: curs_main.c:1801 mx.c:1468 mx.c:1485
 #, fuzzy
 msgid "Folder doesn't support tagging, aborting."
 msgstr "SMTP サーバがユーザ認証をサポートしていない"
 
-#: curs_main.c:1808
+#: curs_main.c:1816
 #, fuzzy
 msgid "No tag specified, aborting."
 msgstr "無題で中止する。"
 
-#: curs_main.c:1820
+#: curs_main.c:1828
 #, c-format
 msgid "Update tags..."
 msgstr ""
 
-#: curs_main.c:1857
+#: curs_main.c:1865
 msgid "Failed to modify tags, aborting."
 msgstr ""
 
-#: curs_main.c:1898
+#: curs_main.c:1906
 #, fuzzy
 msgid "No query, aborting."
 msgstr "無題で中止する。"
 
-#: curs_main.c:1902 curs_main.c:1922 curs_main.c:1941
+#: curs_main.c:1910 curs_main.c:1930 curs_main.c:1949
 msgid "Failed to create query, aborting."
 msgstr ""
 
-#: curs_main.c:1911 curs_main.c:1930
+#: curs_main.c:1919 curs_main.c:1938
 msgid "Windowed queries disabled."
 msgstr ""
 
-#: curs_main.c:1916 curs_main.c:1935
+#: curs_main.c:1924 curs_main.c:1943
 msgid "No notmuch vfolder currently loaded."
 msgstr ""
 
-#: curs_main.c:1973
+#: curs_main.c:1981
 msgid "Open mailbox in read-only mode"
 msgstr "読み出し専用モードでメールボックスをオープン"
 
-#: curs_main.c:1976
+#: curs_main.c:1984
 #, fuzzy
 msgid "Open virtual folder"
 msgstr "別のフォルダをオープン"
 
-#: curs_main.c:1979
+#: curs_main.c:1987
 msgid "Open mailbox"
 msgstr "メールボックスをオープン"
 
-#: curs_main.c:1989
+#: curs_main.c:1997
 msgid "No mailboxes have new mail"
 msgstr "新着メールのあるメールボックスはない"
 
-#: curs_main.c:2036
+#: curs_main.c:2044
 #, fuzzy
 msgid "Open newsgroup in read-only mode"
 msgstr "読み出し専用モードでメールボックスをオープン"
 
-#: curs_main.c:2038
+#: curs_main.c:2046
 msgid "Open newsgroup"
 msgstr ""
 
-#: curs_main.c:2141
+#: curs_main.c:2149
 #, fuzzy
 msgid "Exit NeoMutt without saving?"
 msgstr "保存しないで NeoMutt を抜ける?"
 
-#: curs_main.c:2157
+#: curs_main.c:2165
 #, fuzzy
 msgid "Cannot break thread"
 msgstr "スレッドをつなげられない"
 
-#: curs_main.c:2160 curs_main.c:2198 curs_main.c:2658 curs_main.c:2690
+#: curs_main.c:2168 curs_main.c:2206 curs_main.c:2666 curs_main.c:2698
 #: flags.c:376 thread.c:1078 thread.c:1134 thread.c:1202
 msgid "Threading is not enabled."
 msgstr "スレッド表示が有効になっていない。"
 
-#: curs_main.c:2173
+#: curs_main.c:2181
 msgid "Thread broken"
 msgstr "スレッドが外された"
 
-#: curs_main.c:2185
+#: curs_main.c:2193
 msgid "Thread cannot be broken, message is not part of a thread"
 msgstr "スレッドを外せない。メッセージがスレッドの一部ではない"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2195
+#: curs_main.c:2203
 msgid "Cannot link threads"
 msgstr "スレッドをつなげられない"
 
-#: curs_main.c:2200
+#: curs_main.c:2208
 msgid "No Message-ID: header available to link thread"
 msgstr "Message-ID ヘッダが利用できないのでスレッドをつなげられない"
 
-#: curs_main.c:2202
+#: curs_main.c:2210
 msgid "First, please tag a message to be linked here"
 msgstr "その前に、ここへつなげたいメッセージにタグを付けておくこと"
 
-#: curs_main.c:2213
+#: curs_main.c:2221
 msgid "Threads linked"
 msgstr "スレッドがつながった"
 
-#: curs_main.c:2216
+#: curs_main.c:2224
 msgid "No thread linked"
 msgstr "スレッドはつながらなかった"
 
-#: curs_main.c:2252 curs_main.c:2278
+#: curs_main.c:2260 curs_main.c:2286
 msgid "You are on the last message."
 msgstr "すでに最後のメッセージ。"
 
-#: curs_main.c:2260 curs_main.c:2305
+#: curs_main.c:2268 curs_main.c:2313
 msgid "No undeleted messages."
 msgstr "未削除メッセージがない。"
 
-#: curs_main.c:2297 curs_main.c:2323
+#: curs_main.c:2305 curs_main.c:2331
 msgid "You are on the first message."
 msgstr "すでに最初のメッセージ。"
 
-#: curs_main.c:2395 menu.c:970 pager.c:2440 pattern.c:2110
+#: curs_main.c:2403 menu.c:970 pager.c:2440 pattern.c:2110
 msgid "Search wrapped to top."
 msgstr "検索は一番上に戻った。"
 
-#: curs_main.c:2404 pager.c:2463 pattern.c:2121
+#: curs_main.c:2412 pager.c:2463 pattern.c:2121
 msgid "Search wrapped to bottom."
 msgstr "検索は一番下に戻った。"
 
-#: curs_main.c:2447
+#: curs_main.c:2455
 msgid "No new messages in this limited view."
 msgstr "この制限された表示範囲には新着メッセージがない。"
 
-#: curs_main.c:2449
+#: curs_main.c:2457
 msgid "No new messages."
 msgstr "新着メッセージがない。"
 
-#: curs_main.c:2454
+#: curs_main.c:2462
 msgid "No unread messages in this limited view."
 msgstr "この制限された表示範囲には未読メッセージがない。"
 
-#: curs_main.c:2456
+#: curs_main.c:2464
 msgid "No unread messages."
 msgstr "未読メッセージがない。"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2474
+#: curs_main.c:2482
 msgid "Cannot flag message"
 msgstr "メッセージにフラグを設定できない"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2513 pager.c:3100
+#: curs_main.c:2521 pager.c:3104
 msgid "Cannot toggle new"
 msgstr "新着フラグを切替できない"
 
-#: curs_main.c:2590
+#: curs_main.c:2598
 msgid "No more threads."
 msgstr "もうスレッドがない。"
 
-#: curs_main.c:2592
+#: curs_main.c:2600
 msgid "You are on the first thread."
 msgstr "すでに最初のスレッド。"
 
-#: curs_main.c:2676
+#: curs_main.c:2684
 #, fuzzy
 msgid "Thread contains unread or flagged messages."
 msgstr "スレッド中に未読メッセージがある。"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2726 pager.c:2784
+#: curs_main.c:2734 pager.c:2784
 msgid "Cannot delete message"
 msgstr "メッセージを削除できない"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2838
+#: curs_main.c:2850
 msgid "Cannot edit message"
 msgstr "メッセージを編集できない"
 
 #. L10N: This is displayed when the x-label on one or more
 #. * messages is edited.
-#: curs_main.c:2900 pager.c:3200
+#: curs_main.c:2912 pager.c:3208
 #, fuzzy, c-format
 msgid "%d label changed."
 msgid_plural "%d labels changed."
@@ -1791,53 +1801,58 @@ msgstr[1] "%d 個のラベルが変更された。"
 #. L10N: This is displayed when editing an x-label, but no messages
 #. * were updated.  Possibly due to canceling at the prompt or if the new
 #. * label is the same as the old label.
-#: curs_main.c:2907 pager.c:3204
+#: curs_main.c:2919 pager.c:3212
 msgid "No labels changed."
 msgstr "ラベルは変更されなかった。"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:3006
-msgid "Cannot mark message(s) as read"
+#. L10N: Due to the implementation details we do not know whether we
+#. mark zero, 1, 12, ... messages as read. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:3022
+#, fuzzy
+msgid "Cannot mark messages as read"
 msgstr "メッセージを既読にマークできない"
 
 # つまり ~a とすれば後から 'a で戻ってこられるという機能の a の部分。
 #. L10N: This is the prompt for <mark-message>.  Whatever they
 #. enter will be prefixed by $mark_macro_prefix and will become
 #. a macro hotkey to jump to the currently selected message.
-#: curs_main.c:3042
+#: curs_main.c:3058
 msgid "Enter macro stroke: "
 msgstr "マクロ名を入力: "
 
 #. L10N: "message hotkey" is the key bindings menu description of a
 #. macro created by <mark-message>.
-#: curs_main.c:3050
+#: curs_main.c:3066
 msgid "message hotkey"
 msgstr "(mark-message キー)"
 
 #. L10N: This is echoed after <mark-message> creates a new hotkey
 #. macro.  %s is the hotkey string ($mark_macro_prefix followed
 #. by whatever they typed at the prompt.)
-#: curs_main.c:3055
+#: curs_main.c:3071
 #, c-format
 msgid "Message bound to %s."
 msgstr "メッセージは %s に割り当てられた。"
 
 #. L10N: This error is printed if <mark-message> cannot find a
 #. Message-ID for the currently selected message in the index.
-#: curs_main.c:3063
+#: curs_main.c:3079
 msgid "No message ID to macro."
 msgstr "マクロ化するための Message-ID がない。"
 
-#: curs_main.c:3105 pager.c:2961 recvattach.c:1388
+#: curs_main.c:3121 pager.c:2965 recvattach.c:1401
 msgid "Reply by mail as poster prefers?"
 msgstr ""
 
-#: curs_main.c:3108 pager.c:2927 pager.c:2939 pager.c:2964
+#: curs_main.c:3124 pager.c:2931 pager.c:2943 pager.c:2968
 msgid "Posting to this group not allowed, may be moderated. Continue?"
 msgstr ""
 
 #. L10N: CHECK_ACL
-#: curs_main.c:3173 pager.c:3120
+#: curs_main.c:3189 pager.c:3124
 msgid "Cannot undelete message"
 msgstr "メッセージの削除状態を解除できない"
 
@@ -2031,12 +2046,34 @@ msgstr "[-- %s の標準エラー出力を自動表示 --]\n"
 msgid "[-- Error: message/external-body has no access-type parameter --]\n"
 msgstr "[-- エラー: message/external-body に access-type パラメータの指定がない --]\n"
 
-#: handler.c:1611
+#. L10N: If the translation of this string is a multi line string, then
+#. each line should start with "[-- " and end with " --]".
+#. The first "%s/%s" is a MIME type, e.g. "text/plain". The last %s
+#. expands to a date as returned by `mutt_date_parse_date()`.
+#.
+#. Note: The size argument printed is not the actual number as passed
+#. to gettext but the prettified version, e.g. size = 2048 will be
+#. printed as 2K.  Your language might be sensitive to that: For
+#. example although '1K' and '1024' represent the same number your
+#. language might inflect the noun 'byte' differently.
+#.
+#. Sadly, we cannot do anything about that at the moment besides
+#. passing the precise size in bytes. If you are interested the
+#. function responsible for the prettification is
+#. mutt_str_pretty_size() in mutt/string.c.
+#.
+#: handler.c:1624
 #, fuzzy, c-format
 msgid ""
+"[-- This %s/%s attachment (size %s byte) has been deleted --]\n"
+"[-- on %s --]\n"
+msgid_plural ""
 "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
 "[-- on %s --]\n"
-msgstr ""
+msgstr[0] ""
+"[-- この %s/%s 形式添付ファイル(%s バイト)は削除済み --]\n"
+"[-- (%s に削除) --]\n"
+msgstr[1] ""
 "[-- この %s/%s 形式添付ファイル(%s バイト)は削除済み --]\n"
 "[-- (%s に削除) --]\n"
 
@@ -2044,10 +2081,23 @@ msgstr ""
 #. each line should start with "[-- " and end with " --]".
 #. The first "%s/%s" is a MIME type, e.g. "text/plain".
 #.
-#: handler.c:1620
+#. Note: The size argument printed is not the actual number as passed
+#. to gettext but the prettified version, e.g. size = 2048 will be
+#. printed as 2K.  Your language might be sensitive to that: For
+#. example although '1K' and '1024' represent the same number your
+#. language might inflect the noun 'byte' differently.
+#.
+#. Sadly, we cannot do anything about that at the moment besides
+#. passing the precise size in bytes. If you are interested the
+#. function responsible for the prettification is
+#. mutt_str_pretty_size() in mutt/string.c.
+#.
+#: handler.c:1648
 #, fuzzy, c-format
-msgid "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
-msgstr "[-- この %s/%s 形式添付ファイル(%s バイト)は削除済み --]\n"
+msgid "[-- This %s/%s attachment (size %s byte) has been deleted --]\n"
+msgid_plural "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
+msgstr[0] "[-- この %s/%s 形式添付ファイル(%s バイト)は削除済み --]\n"
+msgstr[1] "[-- この %s/%s 形式添付ファイル(%s バイト)は削除済み --]\n"
 
 #. L10N: If the translation of this string is a multi line string, then
 #. each line should start with "[-- " and end with " --]".
@@ -2057,7 +2107,7 @@ msgstr "[-- この %s/%s 形式添付ファイル(%s バイト)は削除済み -
 #. Caution: Argument three %3$ is also defined but should not be used
 #. in this translation!
 #.
-#: handler.c:1637
+#: handler.c:1667
 #, fuzzy
 msgid ""
 "[-- This %s/%s attachment has been deleted --]\n"
@@ -2070,18 +2120,18 @@ msgstr ""
 #. each line should start with "[-- " and end with " --]".
 #. The first "%s/%s" is a MIME type, e.g. "text/plain".
 #.
-#: handler.c:1646
+#: handler.c:1676
 #, fuzzy, c-format
 msgid "[-- This %s/%s attachment has been deleted --]\n"
 msgstr "[-- この %s/%s 形式添付ファイルは削除済み --]\n"
 
-#: handler.c:1656
+#: handler.c:1686
 #, c-format
 msgid "[-- name: %s --]\n"
 msgstr "[-- 名前: %s --]\n"
 
 # 一行にしても大丈夫だと思うのだがなぁ……
-#: handler.c:1672
+#: handler.c:1702
 #, fuzzy, c-format
 msgid ""
 "[-- This %s/%s attachment is not included, --]\n"
@@ -2093,7 +2143,7 @@ msgstr ""
 "[-- 満了している。 --]\n"
 
 # 一行にしても大丈夫だと思うのだがなぁ……
-#: handler.c:1693
+#: handler.c:1723
 #, fuzzy, c-format
 msgid ""
 "[-- This %s/%s attachment is not included, --]\n"
@@ -2102,51 +2152,51 @@ msgstr ""
 "[-- この %s/%s 形式添付ファイルは含まれておらず、 --]\n"
 "[-- かつ、指定された access-type %s は未サポート --]\n"
 
-#: handler.c:1822
+#: handler.c:1852
 #, fuzzy
 msgid "Unable to open memory stream!"
 msgstr "一時ファイルをオープンできない!"
 
-#: handler.c:1831
+#: handler.c:1861
 msgid "Unable to open temporary file!"
 msgstr "一時ファイルをオープンできない!"
 
-#: handler.c:1881
+#: handler.c:1911
 msgid "failed to re-open memstream!"
 msgstr ""
 
-#: handler.c:2013
+#: handler.c:2043
 msgid "Error: multipart/signed has no protocol."
 msgstr "エラー: multipart/signed にプロトコルがない。"
 
-#: handler.c:2076
+#: handler.c:2106
 #, fuzzy
 msgid "[-- This is an attachment (use '%3$s' to view this part) --]\n"
 msgstr "[-- 添付ファイル (このパートを表示するには '%3$s' を使用) --]\n"
 
-#: handler.c:2082
+#: handler.c:2112
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported (use '%s' to view this part) --]\n"
 msgstr "[-- %s/%s 形式は未サポート (このパートを表示するには '%s' を使用) --]\n"
 
-#: handler.c:2087
+#: handler.c:2117
 #, fuzzy
 msgid "[-- This is an attachment (need 'view-attachments' bound to key!) --]\n"
 msgstr "[-- 添付ファイル (キーに 'view-attachments' を割り当てる必要がある!) --]\n"
 
 #. L10N: %s/%s is a MIME type, e.g. "text/plain".
-#: handler.c:2091
+#: handler.c:2121
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported (need 'view-attachments' bound to key!) --]\n"
 msgstr "[-- %s/%s 形式は未サポート (キーに 'view-attachments' を割り当てる必要がある!) --]\n"
 
-#: handler.c:2098
+#: handler.c:2128
 #, fuzzy
 msgid "[-- This is an attachment --]\n"
 msgstr "[-- 添付ファイル --]\n"
 
 #. L10N: %s/%s is a MIME type, e.g. "text/plain".
-#: handler.c:2101
+#: handler.c:2131
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported --]\n"
 msgstr "[-- %s/%s 形式は未サポート --]\n"
@@ -2455,7 +2505,7 @@ msgstr "SMTP サーバがユーザ認証をサポートしていない"
 msgid "Invalid IMAP flags"
 msgstr "不正      "
 
-#: imap/message.c:477 mx.c:1326
+#: imap/message.c:477 mx.c:1336
 msgid "Integer overflow -- can't allocate memory."
 msgstr "桁あふれ -- メモリを割り当てられない。"
 
@@ -3222,64 +3272,74 @@ msgstr "SSL が利用できない。"
 msgid "Reading from %s interrupted..."
 msgstr "検索が中断された。"
 
-#: mx.c:634
-msgid "message(s) not deleted"
-msgstr "メッセージは削除されなかった"
+#. L10N: Although we now the precise number of messages, we do not show it to the user.
+#. So feel free to use a "generic plural" as plural translation if your language has one.
+#.
+#: mx.c:639
+#, fuzzy
+msgid "message not deleted"
+msgid_plural "messages not deleted"
+msgstr[0] "メッセージは削除されなかった"
+msgstr[1] "メッセージは削除されなかった"
 
-#: mx.c:671
+#: mx.c:676
 msgid "Can't open trash folder"
 msgstr "ごみ箱をオープンできない"
 
-#: mx.c:710
+#: mx.c:715
 msgid "Mark all articles read?"
 msgstr ""
 
-#: mx.c:754
+#. L10N: The first argument is the number of read messages to be
+#. moved, the second argument is the target mailbox.
+#: mx.c:762
 #, fuzzy, c-format
-msgid "Move %d read messages to %s?"
-msgstr "%s に既読メッセージを移動?"
+msgid "Move %d read message to %s?"
+msgid_plural "Move %d read messages to %s?"
+msgstr[0] "%s に既読メッセージを移動?"
+msgstr[1] "%s に既読メッセージを移動?"
 
-#: mx.c:771 mx.c:1077
+#: mx.c:781 mx.c:1087
 #, fuzzy, c-format
 msgid "Purge %d deleted message?"
 msgid_plural "Purge %d deleted messages?"
 msgstr[0] "削除された %d メッセージを廃棄?"
 msgstr[1] "削除された %d メッセージを廃棄?"
 
-#: mx.c:793
+#: mx.c:803
 #, c-format
 msgid "Moving read messages to %s..."
 msgstr "%s に既読メッセージを移動中..."
 
-#: mx.c:859 mx.c:1068
+#: mx.c:869 mx.c:1078
 msgid "Mailbox is unchanged."
 msgstr "メールボックスは変更されなかった"
 
-#: mx.c:914
+#: mx.c:924
 #, c-format
 msgid "%d kept, %d moved, %d deleted."
 msgstr "%d 保持、%d 移動、%d 廃棄"
 
-#: mx.c:917 mx.c:1130
+#: mx.c:927 mx.c:1140
 #, c-format
 msgid "%d kept, %d deleted."
 msgstr "%d 保持、%d 廃棄"
 
-#: mx.c:1052
+#: mx.c:1062
 #, c-format
 msgid " Press '%s' to toggle write"
 msgstr " '%s' を押すと変更を書き込むかどうかを切替"
 
-#: mx.c:1054
+#: mx.c:1064
 msgid "Use 'toggle-write' to re-enable write!"
 msgstr "'toggle-write' を使って書き込みを有効にせよ!"
 
-#: mx.c:1056
+#: mx.c:1066
 #, c-format
 msgid "Mailbox is marked unwritable. %s"
 msgstr "メールボックスは書き込み不能にマークされた。%s"
 
-#: mx.c:1124
+#: mx.c:1134
 msgid "Mailbox checkpointed."
 msgstr "メールボックスのチェックポイントを採取した。"
 
@@ -3293,54 +3353,59 @@ msgstr " (現在時刻: %c)"
 msgid "[-- %s output follows%s --]\n"
 msgstr "[-- %s 出力は以下の通り%s --]\n"
 
-#: ncrypt/crypt.c:95
-msgid "Passphrase(s) forgotten."
+#. L10N: Due to the implementation details (e.g. some passwords are managed
+#. by gpg-agent) we cannot know whether we forgot zero, 1, 12, ...
+#. passwords. So in English we use "Passphrases". Your language might
+#. have other means to express this.
+#: ncrypt/crypt.c:100
+#, fuzzy
+msgid "Passphrases forgotten."
 msgstr "パスフレーズがすべてメモリから消去された。"
 
-#: ncrypt/crypt.c:155
+#: ncrypt/crypt.c:161
 msgid "Inline PGP can't be used with attachments.  Revert to PGP/MIME?"
 msgstr "添付ファイルがあるとインライン PGP にできない。PGP/MIME を使う?"
 
-#: ncrypt/crypt.c:159
+#: ncrypt/crypt.c:165
 msgid "Mail not sent: inline PGP can't be used with attachments."
 msgstr "メールは送信されなかった: 添付ファイルがあるとインライン PGP にできない。"
 
-#: ncrypt/crypt.c:166
+#: ncrypt/crypt.c:172
 #, fuzzy
 msgid "Inline PGP can't be used with format=flowed.  Revert to PGP/MIME?"
 msgstr "添付ファイルがあるとインライン PGP にできない。PGP/MIME を使う?"
 
-#: ncrypt/crypt.c:170
+#: ncrypt/crypt.c:176
 #, fuzzy
 msgid "Mail not sent: inline PGP can't be used with format=flowed."
 msgstr "メールは送信されなかった: 添付ファイルがあるとインライン PGP にできない。"
 
-#: ncrypt/crypt.c:180 ncrypt/cryptglue.c:125 ncrypt/pgpkey.c:589
+#: ncrypt/crypt.c:186 ncrypt/cryptglue.c:125 ncrypt/pgpkey.c:589
 #: ncrypt/pgpkey.c:782
 msgid "Invoking PGP..."
 msgstr "PGP 起動中..."
 
-#: ncrypt/crypt.c:192
+#: ncrypt/crypt.c:198
 msgid "Message can't be sent inline.  Revert to using PGP/MIME?"
 msgstr "メッセージをインラインで送信できない。PGP/MIME を使う?"
 
-#: ncrypt/crypt.c:194 send.c:1824
+#: ncrypt/crypt.c:200 send.c:1824
 msgid "Mail not sent."
 msgstr "メールは送信されなかった。"
 
-#: ncrypt/crypt.c:540
+#: ncrypt/crypt.c:546
 msgid "S/MIME messages with no hints on content are unsupported."
 msgstr "内容ヒントのない S/MIME メッセージは未サポート。"
 
-#: ncrypt/crypt.c:754 ncrypt/crypt.c:795
+#: ncrypt/crypt.c:760 ncrypt/crypt.c:801
 msgid "Trying to extract PGP keys...\n"
 msgstr "PGP 鍵の展開を試行中...\n"
 
-#: ncrypt/crypt.c:776 ncrypt/crypt.c:816
+#: ncrypt/crypt.c:782 ncrypt/crypt.c:822
 msgid "Trying to extract S/MIME certificates...\n"
 msgstr "S/MIME 証明書の展開を試行中...\n"
 
-#: ncrypt/crypt.c:976
+#: ncrypt/crypt.c:982
 #, c-format
 msgid ""
 "[-- Error: Unknown multipart/signed protocol %s! --]\n"
@@ -3349,7 +3414,7 @@ msgstr ""
 "[-- エラー: 不明な multipart/signed プロトコル %s! --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1016
+#: ncrypt/crypt.c:1022
 #, fuzzy
 msgid ""
 "[-- Error: Missing or bad-format multipart/signed signature! --]\n"
@@ -3358,7 +3423,7 @@ msgstr ""
 "[-- エラー: multipart/signed 構造が矛盾している! --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1058
+#: ncrypt/crypt.c:1064
 #, c-format
 msgid ""
 "[-- Warning: We can't verify %s/%s signatures. --]\n"
@@ -3367,7 +3432,7 @@ msgstr ""
 "[-- 警告: この NeoMutt では %s/%s 署名を検証できない --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1070
+#: ncrypt/crypt.c:1076
 msgid ""
 "[-- The following data is signed --]\n"
 "\n"
@@ -3375,7 +3440,7 @@ msgstr ""
 "[-- 以下のデータは署名されている --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1075
+#: ncrypt/crypt.c:1081
 msgid ""
 "[-- Warning: Can't find any signatures. --]\n"
 "\n"
@@ -3383,7 +3448,7 @@ msgstr ""
 "[-- 警告: 一つも署名を検出できなかった --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1081
+#: ncrypt/crypt.c:1087
 msgid ""
 "\n"
 "[-- End of signed data --]\n"
@@ -3434,7 +3499,7 @@ msgstr ""
 msgid "error reading data object: %s\n"
 msgstr "データオブジェクト読み出しエラー: %s\n"
 
-#: ncrypt/crypt_gpgme.c:662 ncrypt/crypt_gpgme.c:3848 ncrypt/pgpkey.c:585
+#: ncrypt/crypt_gpgme.c:662 ncrypt/crypt_gpgme.c:3850 ncrypt/pgpkey.c:585
 #: ncrypt/pgpkey.c:768
 msgid "Can't create temporary file"
 msgstr "一時ファイルを作成できない"
@@ -3782,28 +3847,30 @@ msgstr "[不正]"
 
 #. L10N: This is printed after "Key Type: " and looks like this:
 #. *       PGP, 2048 bit RSA
-#: ncrypt/crypt_gpgme.c:3670 ncrypt/crypt_gpgme.c:3808
-#, c-format
+#: ncrypt/crypt_gpgme.c:3670 ncrypt/crypt_gpgme.c:3810
+#, fuzzy, c-format
 msgid "%s, %lu bit %s\n"
-msgstr "%s, %lu ビット %s\n"
+msgid_plural "%s, %lu bit %s\n"
+msgstr[0] "%s, %lu ビット %s\n"
+msgstr[1] "%s, %lu ビット %s\n"
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3678 ncrypt/crypt_gpgme.c:3815
+#: ncrypt/crypt_gpgme.c:3678 ncrypt/crypt_gpgme.c:3817
 msgid "encryption"
 msgstr "暗号化"
 
 #: ncrypt/crypt_gpgme.c:3679 ncrypt/crypt_gpgme.c:3685
-#: ncrypt/crypt_gpgme.c:3816 ncrypt/crypt_gpgme.c:3821
+#: ncrypt/crypt_gpgme.c:3818 ncrypt/crypt_gpgme.c:3823
 msgid ", "
 msgstr " + "
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3684 ncrypt/crypt_gpgme.c:3820
+#: ncrypt/crypt_gpgme.c:3684 ncrypt/crypt_gpgme.c:3822
 msgid "signing"
 msgstr "署名"
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3690 ncrypt/crypt_gpgme.c:3825
+#: ncrypt/crypt_gpgme.c:3690 ncrypt/crypt_gpgme.c:3827
 msgid "certification"
 msgstr "証明"
 
@@ -3822,64 +3889,64 @@ msgstr "[期限切れ]"
 msgid "[Disabled]"
 msgstr "[使用不可]"
 
-#: ncrypt/crypt_gpgme.c:3851
+#: ncrypt/crypt_gpgme.c:3853
 msgid "Collecting data..."
 msgstr "データ収集中..."
 
-#: ncrypt/crypt_gpgme.c:3876
+#: ncrypt/crypt_gpgme.c:3878
 #, c-format
 msgid "Error finding issuer key: %s\n"
 msgstr "発行者鍵の取得エラー: %s\n"
 
-#: ncrypt/crypt_gpgme.c:3885
+#: ncrypt/crypt_gpgme.c:3887
 msgid "Error: certification chain too long - stopping here\n"
 msgstr "エラー: 証明書の連鎖が長すぎる - ここでやめておく\n"
 
-#: ncrypt/crypt_gpgme.c:3895 ncrypt/pgpkey.c:608
+#: ncrypt/crypt_gpgme.c:3897 ncrypt/pgpkey.c:608
 #, c-format
 msgid "Key ID: 0x%s"
 msgstr "鍵 ID: 0x%s"
 
-#: ncrypt/crypt_gpgme.c:3990
+#: ncrypt/crypt_gpgme.c:3992
 #, c-format
 msgid "gpgme_new failed: %s"
 msgstr "gpgme_new 失敗: %s"
 
-#: ncrypt/crypt_gpgme.c:4028 ncrypt/crypt_gpgme.c:4079
+#: ncrypt/crypt_gpgme.c:4030 ncrypt/crypt_gpgme.c:4081
 #, c-format
 msgid "gpgme_op_keylist_start failed: %s"
 msgstr "gpgme_op_keylist_start 失敗: %s"
 
-#: ncrypt/crypt_gpgme.c:4067 ncrypt/crypt_gpgme.c:4109
+#: ncrypt/crypt_gpgme.c:4069 ncrypt/crypt_gpgme.c:4111
 #, c-format
 msgid "gpgme_op_keylist_next failed: %s"
 msgstr "gpgme_op_keylist_next 失敗: %s"
 
-#: ncrypt/crypt_gpgme.c:4185
+#: ncrypt/crypt_gpgme.c:4187
 msgid "All matching keys are marked expired/revoked."
 msgstr "一致した鍵はすべて期限切れか廃棄済み。"
 
-#: ncrypt/crypt_gpgme.c:4215 ncrypt/pgpkey.c:543 ncrypt/smime.c:475
+#: ncrypt/crypt_gpgme.c:4217 ncrypt/pgpkey.c:543 ncrypt/smime.c:475
 msgid "Select  "
 msgstr "選択  "
 
-#: ncrypt/crypt_gpgme.c:4217 ncrypt/pgpkey.c:545
+#: ncrypt/crypt_gpgme.c:4219 ncrypt/pgpkey.c:545
 msgid "Check key  "
 msgstr "鍵検査  "
 
-#: ncrypt/crypt_gpgme.c:4233
+#: ncrypt/crypt_gpgme.c:4235
 msgid "PGP and S/MIME keys matching"
 msgstr "一致する PGP および S/MIME 鍵"
 
-#: ncrypt/crypt_gpgme.c:4235
+#: ncrypt/crypt_gpgme.c:4237
 msgid "PGP keys matching"
 msgstr "一致する PGP 鍵"
 
-#: ncrypt/crypt_gpgme.c:4237
+#: ncrypt/crypt_gpgme.c:4239
 msgid "S/MIME keys matching"
 msgstr "一致する S/MIME 鍵"
 
-#: ncrypt/crypt_gpgme.c:4239
+#: ncrypt/crypt_gpgme.c:4241
 msgid "keys matching"
 msgstr "一致する鍵"
 
@@ -3888,69 +3955,69 @@ msgstr "一致する鍵"
 #. %1$s is one of the previous four entries.
 #. %2$s is an address.
 #. e.g. "S/MIME keys matching <me@mutt.org>."
-#: ncrypt/crypt_gpgme.c:4246
+#: ncrypt/crypt_gpgme.c:4248
 #, c-format
 msgid "%s <%s>."
 msgstr "<%2$s> に%1$s。"
 
 #. L10N:
 #. e.g. 'S/MIME keys matching "Michael Elkins".'
-#: ncrypt/crypt_gpgme.c:4250
+#: ncrypt/crypt_gpgme.c:4252
 #, c-format
 msgid "%s \"%s\"."
 msgstr "「%2$s」に%1$s。"
 
-#: ncrypt/crypt_gpgme.c:4277 ncrypt/pgpkey.c:628
+#: ncrypt/crypt_gpgme.c:4279 ncrypt/pgpkey.c:628
 msgid "This key can't be used: expired/disabled/revoked."
 msgstr "この鍵は期限切れか使用不可か廃棄済みのため、使えない。"
 
-#: ncrypt/crypt_gpgme.c:4290 ncrypt/pgpkey.c:640 ncrypt/smime.c:505
+#: ncrypt/crypt_gpgme.c:4292 ncrypt/pgpkey.c:640 ncrypt/smime.c:505
 #, fuzzy
 msgid "ID is expired/disabled/revoked. Do you really want to use the key?"
 msgstr "ID は期限切れか使用不可か廃棄済み。 本当にこの鍵を使用?"
 
-#: ncrypt/crypt_gpgme.c:4299 ncrypt/pgpkey.c:650
+#: ncrypt/crypt_gpgme.c:4301 ncrypt/pgpkey.c:650
 #, fuzzy
 msgid "ID is not valid. Do you really want to use the key?"
 msgstr "ID は信用されていない。 本当にこの鍵を使用?"
 
-#: ncrypt/crypt_gpgme.c:4302 ncrypt/pgpkey.c:653
+#: ncrypt/crypt_gpgme.c:4304 ncrypt/pgpkey.c:653
 #, fuzzy
 msgid "ID is only marginally valid. Do you really want to use the key?"
 msgstr "ID はかろうじて信用されている。 本当にこの鍵を使用?"
 
-#: ncrypt/crypt_gpgme.c:4310 ncrypt/pgpkey.c:646 ncrypt/smime.c:509
+#: ncrypt/crypt_gpgme.c:4312 ncrypt/pgpkey.c:646 ncrypt/smime.c:509
 #, fuzzy
 msgid "ID has undefined validity. Do you really want to use the key?"
 msgstr "ID は信用度が未定義。 本当にこの鍵を使用?"
 
-#: ncrypt/crypt_gpgme.c:4370 ncrypt/crypt_gpgme.c:4479 ncrypt/pgpkey.c:872
+#: ncrypt/crypt_gpgme.c:4372 ncrypt/crypt_gpgme.c:4481 ncrypt/pgpkey.c:872
 #: ncrypt/pgpkey.c:995
 #, c-format
 msgid "Looking for keys matching \"%s\"..."
 msgstr "\"%s\" に一致する鍵を検索中..."
 
-#: ncrypt/crypt_gpgme.c:4593 ncrypt/pgpkey.c:731 ncrypt/smime.c:811
+#: ncrypt/crypt_gpgme.c:4595 ncrypt/pgpkey.c:731 ncrypt/smime.c:811
 #, c-format
 msgid "No matching keys found for \"%s\""
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4644 ncrypt/pgp.c:1263
+#: ncrypt/crypt_gpgme.c:4646 ncrypt/pgp.c:1263
 #, c-format
 msgid "Use keyID = \"%s\" for %s?"
 msgstr "鍵 ID = \"%s\" を %s に使う?"
 
-#: ncrypt/crypt_gpgme.c:4695 ncrypt/pgp.c:1312 ncrypt/smime.c:830
+#: ncrypt/crypt_gpgme.c:4697 ncrypt/pgp.c:1312 ncrypt/smime.c:830
 #: ncrypt/smime.c:938
 #, c-format
 msgid "Enter keyID for %s: "
 msgstr "%s の鍵 ID 入力: "
 
-#: ncrypt/crypt_gpgme.c:4755 ncrypt/pgpkey.c:751
+#: ncrypt/crypt_gpgme.c:4757 ncrypt/pgpkey.c:751
 msgid "Please enter the key ID: "
 msgstr "鍵 ID を入力: "
 
-#: ncrypt/crypt_gpgme.c:4768
+#: ncrypt/crypt_gpgme.c:4770
 #, c-format
 msgid "Error exporting key: %s\n"
 msgstr "鍵の抽出エラー: %s\n"
@@ -3960,81 +4027,81 @@ msgstr "鍵の抽出エラー: %s\n"
 #. MIME description for exported (attached) keys.
 #. You can translate this entry to a non-ASCII string (it will be encoded),
 #. but it may be safer to keep it untranslated.
-#: ncrypt/crypt_gpgme.c:4787
+#: ncrypt/crypt_gpgme.c:4789
 #, c-format
 msgid "PGP Key 0x%s."
 msgstr "PGP Key 0x%s."
 
-#: ncrypt/crypt_gpgme.c:4830
+#: ncrypt/crypt_gpgme.c:4832
 msgid "GPGME: OpenPGP protocol not available"
 msgstr "GPGME: OpenPGP プロトコルが利用できない"
 
-#: ncrypt/crypt_gpgme.c:4838
+#: ncrypt/crypt_gpgme.c:4840
 msgid "GPGME: CMS protocol not available"
 msgstr "GPGME: CMS プロトコルが利用できない"
 
-#: ncrypt/crypt_gpgme.c:4876
+#: ncrypt/crypt_gpgme.c:4878
 msgid "S/MIME (s)ign, sign (a)s, (p)gp, (c)lear, or (o)ppenc mode off? "
 msgstr "S/MIME s:署名, a:署名鍵選択, p:PGP, c:なし, o:日和見暗号オフ "
 
 #. L10N: S/MIME options (opportunistic encryption is on)
-#: ncrypt/crypt_gpgme.c:4878
+#: ncrypt/crypt_gpgme.c:4880
 msgid "sapco"
 msgstr "sapco"
 
-#: ncrypt/crypt_gpgme.c:4885
+#: ncrypt/crypt_gpgme.c:4887
 msgid "PGP (s)ign, sign (a)s, s/(m)ime, (c)lear, or (o)ppenc mode off? "
 msgstr "PGP s:署名, a:署名鍵選択, m:S/MIME, c:なし, o:日和見暗号オフ "
 
 #. L10N: PGP options (opportunistic encryption is on)
-#: ncrypt/crypt_gpgme.c:4887
+#: ncrypt/crypt_gpgme.c:4889
 msgid "samco"
 msgstr "samco"
 
 # 80-columns 幅にギリギリおさまるか？
 #. L10N: S/MIME options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4900
+#: ncrypt/crypt_gpgme.c:4902
 msgid "S/MIME (e)ncrypt, (s)ign, sign (a)s, (b)oth, (p)gp, (c)lear, or (o)ppenc mode? "
 msgstr "S/MIME e:暗号化, s:署名, a:署名鍵選択, b:暗号+署名, p:PGP, c:なし, o:日和見暗号 "
 
 #. L10N: S/MIME options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4903
+#: ncrypt/crypt_gpgme.c:4905
 msgid "esabpco"
 msgstr "esabpco"
 
 #. L10N: PGP options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4909
+#: ncrypt/crypt_gpgme.c:4911
 msgid "PGP (e)ncrypt, (s)ign, sign (a)s, (b)oth, s/(m)ime, (c)lear, or (o)ppenc mode? "
 msgstr "PGP e:暗号化, s:署名, a:署名鍵選択, b:暗号+署名, m:S/MIME, c:なし, o:日和見暗号 "
 
 #. L10N: PGP options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4912
+#: ncrypt/crypt_gpgme.c:4914
 msgid "esabmco"
 msgstr "esabmco"
 
-#: ncrypt/crypt_gpgme.c:4925
+#: ncrypt/crypt_gpgme.c:4927
 msgid "S/MIME (e)ncrypt, (s)ign, sign (a)s, (b)oth, (p)gp or (c)lear? "
 msgstr "S/MIME e:暗号化, s:署名, a:署名鍵選択, b:暗号+署名, p:PGP, c:なし "
 
 #. L10N: S/MIME options
-#: ncrypt/crypt_gpgme.c:4927
+#: ncrypt/crypt_gpgme.c:4929
 msgid "esabpc"
 msgstr "esabpc"
 
-#: ncrypt/crypt_gpgme.c:4934
+#: ncrypt/crypt_gpgme.c:4936
 msgid "PGP (e)ncrypt, (s)ign, sign (a)s, (b)oth, s/(m)ime or (c)lear? "
 msgstr "PGP e:暗号化, s:署名, a:署名鍵選択, b:暗号+署名, m:S/MIME, c:なし "
 
 #. L10N: PGP options
-#: ncrypt/crypt_gpgme.c:4936
+#: ncrypt/crypt_gpgme.c:4938
 msgid "esabmc"
 msgstr "esabmc"
 
-#: ncrypt/crypt_gpgme.c:5087
+#: ncrypt/crypt_gpgme.c:5089
 msgid "Failed to verify sender"
 msgstr "送信者の検証に失敗した"
 
-#: ncrypt/crypt_gpgme.c:5090
+#: ncrypt/crypt_gpgme.c:5092
 msgid "Failed to figure out sender"
 msgstr "送信者の識別に失敗した"
 
@@ -4426,7 +4493,7 @@ msgstr ""
 msgid "%s is an invalid news server specification!"
 msgstr "%s は不正な POP パス"
 
-#: nntp.c:75 nntp.c:612 pop.c:1028 pop_lib.c:405
+#: nntp.c:75 nntp.c:612 pop.c:1031 pop_lib.c:405
 msgid "Server closed connection!"
 msgstr "サーバが接続を切った!"
 
@@ -4593,16 +4660,18 @@ msgid "check mailboxes for new mail"
 msgstr "メールボックスに新着メールがあるか検査"
 
 #: opcodes.h:47
-msgid "attach file(s) to this message"
+#, fuzzy
+msgid "attach files to this message"
 msgstr "このメッセージにファイルを添付"
 
 #: opcodes.h:48
-msgid "attach message(s) to this message"
+#, fuzzy
+msgid "attach messages to this message"
 msgstr "このメッセージにメッセージを添付"
 
 #: opcodes.h:49
 #, fuzzy
-msgid "attach news article(s) to this message"
+msgid "attach news articles to this message"
 msgstr "このメッセージにファイルを添付"
 
 #: opcodes.h:50
@@ -5444,7 +5513,8 @@ msgid "extract supported public keys"
 msgstr "サポートされている公開鍵を抽出"
 
 #: opcodes.h:255
-msgid "wipe passphrase(s) from memory"
+#, fuzzy
+msgid "wipe passphrases from memory"
 msgstr "パスフレーズをすべてメモリから消去"
 
 #: opcodes.h:259
@@ -5781,18 +5851,20 @@ msgstr "POP メールボックスに新着メールはない。"
 msgid "Delete messages from server?"
 msgstr "サーバからメッセージを削除?"
 
-#: pop.c:954
-#, c-format
-msgid "Reading new messages (%d bytes)..."
-msgstr "新着メッセージ読み出し中 (%d バイト)..."
+#: pop.c:955
+#, fuzzy, c-format
+msgid "Reading new messages (%d byte)..."
+msgid_plural "Reading new messages (%d bytes)..."
+msgstr[0] "新着メッセージ読み出し中 (%d バイト)..."
+msgstr[1] "新着メッセージ読み出し中 (%d バイト)..."
 
-#: pop.c:997
+#: pop.c:1000
 msgid "Error while writing mailbox!"
 msgstr "メールボックス書き込み中にエラー!"
 
 #. L10N: The plural is picked by the second numerical argument, i.e.
 #. * the %d right before 'messages', i.e. the total number of messages.
-#: pop.c:1003
+#: pop.c:1006
 #, fuzzy, c-format
 msgid "%s [%d of %d message read]"
 msgid_plural "%s [%d of %d messages read]"
@@ -5936,48 +6008,55 @@ msgstr "パイプするコマンド: "
 msgid "I don't know how to print %s attachments!"
 msgstr "どのように添付ファイル %s を印刷するか不明!"
 
-#: recvattach.c:841
-msgid "Print tagged attachment(s)?"
-msgstr "タグ付き添付ファイルを印刷?"
+#. L10N: Although we now the precise number of tagged messages, we
+#. do not show it to the user.  So feel free to use a "generic
+#. plural" as plural translation if your language has one.
+#: recvattach.c:852
+#, fuzzy, c-format
+msgid "Print tagged attachment?"
+msgid_plural "Print %d tagged attachments?"
+msgstr[0] "タグ付き添付ファイルを印刷?"
+msgstr[1] "タグ付き添付ファイルを印刷?"
 
-#: recvattach.c:842
+#: recvattach.c:853
+#, c-format
 msgid "Print attachment?"
 msgstr "添付ファイルを印刷?"
 
-#: recvattach.c:900
+#: recvattach.c:913
 msgid "Structural changes to decrypted attachments are not supported"
 msgstr "復号化されたメッセージの構造変更はサポートされていない"
 
-#: recvattach.c:1046
+#: recvattach.c:1059
 msgid "Can't decrypt encrypted message!"
 msgstr "暗号化メッセージを復号化できない!"
 
-#: recvattach.c:1172
+#: recvattach.c:1185
 msgid "Attachments"
 msgstr "添付ファイル"
 
-#: recvattach.c:1210
+#: recvattach.c:1223
 msgid "There are no subparts to show!"
 msgstr "表示すべき副パートがない!"
 
-#: recvattach.c:1265
+#: recvattach.c:1278
 msgid "Can't delete attachment from POP server."
 msgstr "POP サーバから添付ファイルを削除できない。"
 
-#: recvattach.c:1274
+#: recvattach.c:1287
 #, fuzzy
 msgid "Can't delete attachment from news server."
 msgstr "POP サーバから添付ファイルを削除できない。"
 
-#: recvattach.c:1281
+#: recvattach.c:1294
 msgid "Deletion of attachments from encrypted messages is unsupported."
 msgstr "暗号化メッセージからの添付ファイルの削除はサポートされていない。"
 
-#: recvattach.c:1287
+#: recvattach.c:1300
 msgid "Deletion of attachments from signed messages may invalidate the signature."
 msgstr "署名メッセージからの添付ファイルの削除は署名を不正にすることがある。"
 
-#: recvattach.c:1305 recvattach.c:1320
+#: recvattach.c:1318 recvattach.c:1333
 msgid "Only deletion of multipart attachments is supported."
 msgstr "マルチパート添付ファイルの削除のみサポートされている。"
 
@@ -6404,3 +6483,13 @@ msgstr "コンパイル時オプション:"
 #: version.c:404
 msgid "Compile options:"
 msgstr "コンパイル時オプション:"
+
+#~ msgid "Cannot delete message(s)"
+#~ msgstr "メッセージを削除できない"
+
+#~ msgid "Cannot undelete message(s)"
+#~ msgstr "メッセージの削除状態を解除できない"
+
+#, fuzzy
+#~ msgid "messages not deleted"
+#~ msgstr "メッセージは削除されなかった"

--- a/po/ko.po
+++ b/po/ko.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neomutt-20180512\n"
 "Report-Msgid-Bugs-To: neomutt-devel@neomutt.org\n"
-"POT-Creation-Date: 2018-05-20 02:02+0000\n"
+"POT-Creation-Date: 2018-05-22 14:18+0000\n"
 "PO-Revision-Date: 2004-03-03 10:25+900\n"
 "Last-Translator: Im Eunjea <eunjea@kldp.org>\n"
 "Language-Team: Im Eunjea <eunjea@kldp.org>\n"
@@ -41,7 +41,7 @@ msgstr "선택"
 
 #: addrbook.c:52 browser.c:75 browser.c:87 compose.c:160 compose.c:172
 #: conn/ssl.c:1041 conn/ssl_gnutls.c:793 curs_main.c:748 curs_main.c:761
-#: history.c:106 ncrypt/crypt_gpgme.c:4219 ncrypt/pgpkey.c:547
+#: history.c:106 ncrypt/crypt_gpgme.c:4221 ncrypt/pgpkey.c:547
 #: ncrypt/smime.c:477 pager.c:2141 postpone.c:65 query.c:72 recvattach.c:70
 msgid "Help"
 msgstr "도움말"
@@ -691,7 +691,7 @@ msgstr ""
 #. * Since it shares the row with "Encrypt with:", it should not be longer
 #. * than 15-20 character cells.
 #.
-#: compose.c:138 ncrypt/crypt_gpgme.c:4947 ncrypt/pgp.c:1786
+#: compose.c:138 ncrypt/crypt_gpgme.c:4949 ncrypt/pgp.c:1786
 #: ncrypt/smime.c:2127
 msgid "Sign as: "
 msgstr "사용 서명: "
@@ -1237,7 +1237,7 @@ msgstr "거부(r), 이번만 허가(o)"
 msgid "(r)eject, accept (o)nce"
 msgstr "거부(r), 이번만 허가(o)"
 
-#: conn/ssl.c:1039 conn/ssl_gnutls.c:791 ncrypt/crypt_gpgme.c:4213
+#: conn/ssl.c:1039 conn/ssl_gnutls.c:791 ncrypt/crypt_gpgme.c:4215
 #: ncrypt/pgpkey.c:541 ncrypt/smime.c:473
 msgid "Exit  "
 msgstr "끝내기  "
@@ -1423,11 +1423,11 @@ msgstr "열린 메일함이 없음."
 msgid "There are no messages."
 msgstr "메일이 없음."
 
-#: curs_main.c:77 mx.c:1061 pager.c:73 recvattach.c:56
+#: curs_main.c:77 mx.c:1071 pager.c:73 recvattach.c:56
 msgid "Mailbox is read-only."
 msgstr "읽기 전용 메일함."
 
-#: curs_main.c:79 pager.c:75 recvattach.c:1145
+#: curs_main.c:79 pager.c:75 recvattach.c:1158
 msgid "Function not permitted in attach-message mode."
 msgstr "메일 첨부 모드에서 허가되지 않는 기능임."
 
@@ -1562,255 +1562,263 @@ msgid "That message is not visible."
 msgstr "메일이 볼 수 없는 상태임."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:1377 curs_main.c:2772 pager.c:2818
+#. L10N: Due to the implementation details we do not know whether we
+#. delete zero, 1, 12, ... messages. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:1381 curs_main.c:2784 pager.c:2822
 #, fuzzy
-msgid "Cannot delete message(s)"
+msgid "Cannot delete messages"
 msgstr "삭제 취소된 메일 없음."
 
-#: curs_main.c:1380
+#: curs_main.c:1384
 msgid "Delete messages matching: "
 msgstr "일치하는 메일 삭제: "
 
-#: curs_main.c:1421
+#: curs_main.c:1425
 msgid "No limit pattern is in effect."
 msgstr "제한 패턴이 없음."
 
 #. L10N: ask for a limit to apply
-#: curs_main.c:1426
+#: curs_main.c:1430
 #, c-format
 msgid "Limit: %s"
 msgstr "패턴: %s"
 
-#: curs_main.c:1464
+#: curs_main.c:1468
 msgid "Limit to messages matching: "
 msgstr "패턴과 일치하는 메일: "
 
-#: curs_main.c:1488
+#: curs_main.c:1492
 msgid "To view all messages, limit to \"all\"."
 msgstr ""
 
-#: curs_main.c:1500 pager.c:2318
+#: curs_main.c:1504 pager.c:2318
 msgid "Quit NeoMutt?"
 msgstr "NeoMutt을 종료할까요?"
 
-#: curs_main.c:1596
+#: curs_main.c:1600
 msgid "Tag messages matching: "
 msgstr "일치하는 메일에 표시함: "
 
 #. L10N: CHECK_ACL
-#: curs_main.c:1606 curs_main.c:3203 pager.c:3137
+#. L10N: Due to the implementation details we do not know whether we
+#. undelete zero, 1, 12, ... messages. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:1614 curs_main.c:3223 pager.c:3145
 #, fuzzy
-msgid "Cannot undelete message(s)"
+msgid "Cannot undelete messages"
 msgstr "삭제 취소된 메일 없음."
 
-#: curs_main.c:1609
+#: curs_main.c:1617
 msgid "Undelete messages matching: "
 msgstr "일치하는 메일을 삭제 취소: "
 
-#: curs_main.c:1619
+#: curs_main.c:1627
 msgid "Untag messages matching: "
 msgstr "일치하는 메일을 표시 해제: "
 
-#: curs_main.c:1653
+#: curs_main.c:1661
 #, fuzzy
 msgid "Logged out of IMAP servers."
 msgstr "IMAP 서버 접속 닫는 중..."
 
-#: curs_main.c:1753
+#: curs_main.c:1761
 #, fuzzy
 msgid "No virtual folder, aborting."
 msgstr "제목 없음. 끝냅니다."
 
-#: curs_main.c:1761
+#: curs_main.c:1769
 msgid "Failed to read thread, aborting."
 msgstr ""
 
-#: curs_main.c:1793 mx.c:1458 mx.c:1475
+#: curs_main.c:1801 mx.c:1468 mx.c:1485
 msgid "Folder doesn't support tagging, aborting."
 msgstr ""
 
-#: curs_main.c:1808
+#: curs_main.c:1816
 #, fuzzy
 msgid "No tag specified, aborting."
 msgstr "제목 없음. 끝냅니다."
 
-#: curs_main.c:1820
+#: curs_main.c:1828
 #, c-format
 msgid "Update tags..."
 msgstr ""
 
-#: curs_main.c:1857
+#: curs_main.c:1865
 msgid "Failed to modify tags, aborting."
 msgstr ""
 
-#: curs_main.c:1898
+#: curs_main.c:1906
 #, fuzzy
 msgid "No query, aborting."
 msgstr "제목 없음. 끝냅니다."
 
-#: curs_main.c:1902 curs_main.c:1922 curs_main.c:1941
+#: curs_main.c:1910 curs_main.c:1930 curs_main.c:1949
 msgid "Failed to create query, aborting."
 msgstr ""
 
-#: curs_main.c:1911 curs_main.c:1930
+#: curs_main.c:1919 curs_main.c:1938
 msgid "Windowed queries disabled."
 msgstr ""
 
-#: curs_main.c:1916 curs_main.c:1935
+#: curs_main.c:1924 curs_main.c:1943
 msgid "No notmuch vfolder currently loaded."
 msgstr ""
 
-#: curs_main.c:1973
+#: curs_main.c:1981
 msgid "Open mailbox in read-only mode"
 msgstr "읽기 전용으로 메일함 열기"
 
-#: curs_main.c:1976
+#: curs_main.c:1984
 #, fuzzy
 msgid "Open virtual folder"
 msgstr "다른 폴더 열기"
 
-#: curs_main.c:1979
+#: curs_main.c:1987
 msgid "Open mailbox"
 msgstr "메일함 열기"
 
-#: curs_main.c:1989
+#: curs_main.c:1997
 #, fuzzy
 msgid "No mailboxes have new mail"
 msgstr "새 메일이 도착한 메일함 없음."
 
-#: curs_main.c:2036
+#: curs_main.c:2044
 #, fuzzy
 msgid "Open newsgroup in read-only mode"
 msgstr "읽기 전용으로 메일함 열기"
 
-#: curs_main.c:2038
+#: curs_main.c:2046
 msgid "Open newsgroup"
 msgstr ""
 
-#: curs_main.c:2141
+#: curs_main.c:2149
 #, fuzzy
 msgid "Exit NeoMutt without saving?"
 msgstr "저장하지 않고 NeoMutt을 끝낼까요?"
 
-#: curs_main.c:2157
+#: curs_main.c:2165
 #, fuzzy
 msgid "Cannot break thread"
 msgstr "필터를 만들 수 없음"
 
-#: curs_main.c:2160 curs_main.c:2198 curs_main.c:2658 curs_main.c:2690
+#: curs_main.c:2168 curs_main.c:2206 curs_main.c:2666 curs_main.c:2698
 #: flags.c:376 thread.c:1078 thread.c:1134 thread.c:1202
 msgid "Threading is not enabled."
 msgstr "글타래 모드가 아님."
 
-#: curs_main.c:2173
+#: curs_main.c:2181
 msgid "Thread broken"
 msgstr ""
 
-#: curs_main.c:2185
+#: curs_main.c:2193
 msgid "Thread cannot be broken, message is not part of a thread"
 msgstr ""
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2195
+#: curs_main.c:2203
 msgid "Cannot link threads"
 msgstr ""
 
-#: curs_main.c:2200
+#: curs_main.c:2208
 msgid "No Message-ID: header available to link thread"
 msgstr ""
 
-#: curs_main.c:2202
+#: curs_main.c:2210
 #, fuzzy
 msgid "First, please tag a message to be linked here"
 msgstr "현재 메일을 저장 후 나중에 보냄"
 
-#: curs_main.c:2213
+#: curs_main.c:2221
 msgid "Threads linked"
 msgstr ""
 
-#: curs_main.c:2216
+#: curs_main.c:2224
 msgid "No thread linked"
 msgstr ""
 
-#: curs_main.c:2252 curs_main.c:2278
+#: curs_main.c:2260 curs_main.c:2286
 msgid "You are on the last message."
 msgstr "마지막 메세지입니다."
 
-#: curs_main.c:2260 curs_main.c:2305
+#: curs_main.c:2268 curs_main.c:2313
 msgid "No undeleted messages."
 msgstr "삭제 취소된 메일 없음."
 
-#: curs_main.c:2297 curs_main.c:2323
+#: curs_main.c:2305 curs_main.c:2331
 msgid "You are on the first message."
 msgstr "첫번째 메세지입니다."
 
-#: curs_main.c:2395 menu.c:970 pager.c:2440 pattern.c:2110
+#: curs_main.c:2403 menu.c:970 pager.c:2440 pattern.c:2110
 msgid "Search wrapped to top."
 msgstr "위부터 다시 검색."
 
-#: curs_main.c:2404 pager.c:2463 pattern.c:2121
+#: curs_main.c:2412 pager.c:2463 pattern.c:2121
 msgid "Search wrapped to bottom."
 msgstr "아래부터 다시 검색."
 
-#: curs_main.c:2447
+#: curs_main.c:2455
 #, fuzzy
 msgid "No new messages in this limited view."
 msgstr "제한된 보기로 부모 메일은 보이지 않는 상태임."
 
-#: curs_main.c:2449
+#: curs_main.c:2457
 #, fuzzy
 msgid "No new messages."
 msgstr "새 메일 없음"
 
-#: curs_main.c:2454
+#: curs_main.c:2462
 #, fuzzy
 msgid "No unread messages in this limited view."
 msgstr "제한된 보기로 부모 메일은 보이지 않는 상태임."
 
-#: curs_main.c:2456
+#: curs_main.c:2464
 #, fuzzy
 msgid "No unread messages."
 msgstr "읽지 않은 메일 없음"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2474
+#: curs_main.c:2482
 #, fuzzy
 msgid "Cannot flag message"
 msgstr "메일 보기"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2513 pager.c:3100
+#: curs_main.c:2521 pager.c:3104
 msgid "Cannot toggle new"
 msgstr ""
 
-#: curs_main.c:2590
+#: curs_main.c:2598
 msgid "No more threads."
 msgstr "더 이상 글타래 없음."
 
-#: curs_main.c:2592
+#: curs_main.c:2600
 msgid "You are on the first thread."
 msgstr "처음 글타래입니다."
 
-#: curs_main.c:2676
+#: curs_main.c:2684
 #, fuzzy
 msgid "Thread contains unread or flagged messages."
 msgstr "글타래에 읽지 않은 메세지 있음."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2726 pager.c:2784
+#: curs_main.c:2734 pager.c:2784
 #, fuzzy
 msgid "Cannot delete message"
 msgstr "삭제 취소된 메일 없음."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2838
+#: curs_main.c:2850
 #, fuzzy
 msgid "Cannot edit message"
 msgstr "메일을 쓰지 못함"
 
 #. L10N: This is displayed when the x-label on one or more
 #. * messages is edited.
-#: curs_main.c:2900 pager.c:3200
+#: curs_main.c:2912 pager.c:3208
 #, fuzzy, c-format
 msgid "%d label changed."
 msgid_plural "%d labels changed."
@@ -1819,28 +1827,32 @@ msgstr[0] "메일함이 변경되지 않음."
 #. L10N: This is displayed when editing an x-label, but no messages
 #. * were updated.  Possibly due to canceling at the prompt or if the new
 #. * label is the same as the old label.
-#: curs_main.c:2907 pager.c:3204
+#: curs_main.c:2919 pager.c:3212
 #, fuzzy
 msgid "No labels changed."
 msgstr "메일함이 변경되지 않음."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:3006
+#. L10N: Due to the implementation details we do not know whether we
+#. mark zero, 1, 12, ... messages as read. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:3022
 #, fuzzy
-msgid "Cannot mark message(s) as read"
+msgid "Cannot mark messages as read"
 msgstr "글타래의 부모 메일로 이동"
 
 #. L10N: This is the prompt for <mark-message>.  Whatever they
 #. enter will be prefixed by $mark_macro_prefix and will become
 #. a macro hotkey to jump to the currently selected message.
-#: curs_main.c:3042
+#: curs_main.c:3058
 #, fuzzy
 msgid "Enter macro stroke: "
 msgstr "keyID 입력: "
 
 #. L10N: "message hotkey" is the key bindings menu description of a
 #. macro created by <mark-message>.
-#: curs_main.c:3050
+#: curs_main.c:3066
 #, fuzzy
 msgid "message hotkey"
 msgstr "발송 연기됨."
@@ -1848,28 +1860,28 @@ msgstr "발송 연기됨."
 #. L10N: This is echoed after <mark-message> creates a new hotkey
 #. macro.  %s is the hotkey string ($mark_macro_prefix followed
 #. by whatever they typed at the prompt.)
-#: curs_main.c:3055
+#: curs_main.c:3071
 #, fuzzy, c-format
 msgid "Message bound to %s."
 msgstr "메일이 전달됨."
 
 #. L10N: This error is printed if <mark-message> cannot find a
 #. Message-ID for the currently selected message in the index.
-#: curs_main.c:3063
+#: curs_main.c:3079
 #, fuzzy
 msgid "No message ID to macro."
 msgstr "폴더에 메일이 없음."
 
-#: curs_main.c:3105 pager.c:2961 recvattach.c:1388
+#: curs_main.c:3121 pager.c:2965 recvattach.c:1401
 msgid "Reply by mail as poster prefers?"
 msgstr ""
 
-#: curs_main.c:3108 pager.c:2927 pager.c:2939 pager.c:2964
+#: curs_main.c:3124 pager.c:2931 pager.c:2943 pager.c:2968
 msgid "Posting to this group not allowed, may be moderated. Continue?"
 msgstr ""
 
 #. L10N: CHECK_ACL
-#: curs_main.c:3173 pager.c:3120
+#: curs_main.c:3189 pager.c:3124
 #, fuzzy
 msgid "Cannot undelete message"
 msgstr "삭제 취소된 메일 없음."
@@ -2079,12 +2091,31 @@ msgstr "[-- %s의 자동 보기 오류 --]\n"
 msgid "[-- Error: message/external-body has no access-type parameter --]\n"
 msgstr "[-- 오류: message/external-body에 access-type 변수가 없음 --]\n"
 
-#: handler.c:1611
+#. L10N: If the translation of this string is a multi line string, then
+#. each line should start with "[-- " and end with " --]".
+#. The first "%s/%s" is a MIME type, e.g. "text/plain". The last %s
+#. expands to a date as returned by `mutt_date_parse_date()`.
+#.
+#. Note: The size argument printed is not the actual number as passed
+#. to gettext but the prettified version, e.g. size = 2048 will be
+#. printed as 2K.  Your language might be sensitive to that: For
+#. example although '1K' and '1024' represent the same number your
+#. language might inflect the noun 'byte' differently.
+#.
+#. Sadly, we cannot do anything about that at the moment besides
+#. passing the precise size in bytes. If you are interested the
+#. function responsible for the prettification is
+#. mutt_str_pretty_size() in mutt/string.c.
+#.
+#: handler.c:1624
 #, fuzzy, c-format
 msgid ""
+"[-- This %s/%s attachment (size %s byte) has been deleted --]\n"
+"[-- on %s --]\n"
+msgid_plural ""
 "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
 "[-- on %s --]\n"
-msgstr ""
+msgstr[0] ""
 "[ -- %s/%s 첨부물 (크기: %s 바이트) 삭제 되었음 --]\n"
 "[-- %s에 --]\n"
 
@@ -2092,10 +2123,22 @@ msgstr ""
 #. each line should start with "[-- " and end with " --]".
 #. The first "%s/%s" is a MIME type, e.g. "text/plain".
 #.
-#: handler.c:1620
+#. Note: The size argument printed is not the actual number as passed
+#. to gettext but the prettified version, e.g. size = 2048 will be
+#. printed as 2K.  Your language might be sensitive to that: For
+#. example although '1K' and '1024' represent the same number your
+#. language might inflect the noun 'byte' differently.
+#.
+#. Sadly, we cannot do anything about that at the moment besides
+#. passing the precise size in bytes. If you are interested the
+#. function responsible for the prettification is
+#. mutt_str_pretty_size() in mutt/string.c.
+#.
+#: handler.c:1648
 #, fuzzy, c-format
-msgid "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
-msgstr "[ -- %s/%s 첨부물 (크기: %s 바이트) 삭제 되었음 --]\n"
+msgid "[-- This %s/%s attachment (size %s byte) has been deleted --]\n"
+msgid_plural "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
+msgstr[0] "[ -- %s/%s 첨부물 (크기: %s 바이트) 삭제 되었음 --]\n"
 
 #. L10N: If the translation of this string is a multi line string, then
 #. each line should start with "[-- " and end with " --]".
@@ -2105,7 +2148,7 @@ msgstr "[ -- %s/%s 첨부물 (크기: %s 바이트) 삭제 되었음 --]\n"
 #. Caution: Argument three %3$ is also defined but should not be used
 #. in this translation!
 #.
-#: handler.c:1637
+#: handler.c:1667
 #, fuzzy
 msgid ""
 "[-- This %s/%s attachment has been deleted --]\n"
@@ -2118,17 +2161,17 @@ msgstr ""
 #. each line should start with "[-- " and end with " --]".
 #. The first "%s/%s" is a MIME type, e.g. "text/plain".
 #.
-#: handler.c:1646
+#: handler.c:1676
 #, fuzzy, c-format
 msgid "[-- This %s/%s attachment has been deleted --]\n"
 msgstr "[ -- %s/%s 첨부물 삭제 되었음 --]\n"
 
-#: handler.c:1656
+#: handler.c:1686
 #, c-format
 msgid "[-- name: %s --]\n"
 msgstr "[-- 이름: %s --]\n"
 
-#: handler.c:1672
+#: handler.c:1702
 #, fuzzy, c-format
 msgid ""
 "[-- This %s/%s attachment is not included, --]\n"
@@ -2138,7 +2181,7 @@ msgstr ""
 "[-- 이 %s/%s 첨부물은 포함되지 않음, --]\n"
 "[-- 지정된 외부 소스가 만기됨 --]\n"
 
-#: handler.c:1693
+#: handler.c:1723
 #, fuzzy, c-format
 msgid ""
 "[-- This %s/%s attachment is not included, --]\n"
@@ -2147,52 +2190,52 @@ msgstr ""
 "[-- 이 %s/%s 첨부물은 포함되지 않음, --]\n"
 "[-- 지정된 access-type %s는 지원되지 않음 --]\n"
 
-#: handler.c:1822
+#: handler.c:1852
 #, fuzzy
 msgid "Unable to open memory stream!"
 msgstr "임시 파일을 열 수 없음!"
 
-#: handler.c:1831
+#: handler.c:1861
 msgid "Unable to open temporary file!"
 msgstr "임시 파일을 열 수 없음!"
 
-#: handler.c:1881
+#: handler.c:1911
 #, fuzzy
 msgid "failed to re-open memstream!"
 msgstr "임시 파일을 열 수 없음!"
 
-#: handler.c:2013
+#: handler.c:2043
 msgid "Error: multipart/signed has no protocol."
 msgstr "오류: multipart/signed 프로토콜이 없음."
 
-#: handler.c:2076
+#: handler.c:2106
 #, fuzzy
 msgid "[-- This is an attachment (use '%3$s' to view this part) --]\n"
 msgstr "[ -- %s/%s 첨부물 ('%3$s' 키: 부분 보기) --]\n"
 
-#: handler.c:2082
+#: handler.c:2112
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported (use '%s' to view this part) --]\n"
 msgstr "[-- '%s/%s'는 지원되지 않음 ('%s' 키: 부분 보기) --]\n"
 
-#: handler.c:2087
+#: handler.c:2117
 #, fuzzy
 msgid "[-- This is an attachment (need 'view-attachments' bound to key!) --]\n"
 msgstr "[ -- %s/%s 첨부물 ('첨부물 보기' 글쇠 정의가 필요함!) --]\n"
 
 #. L10N: %s/%s is a MIME type, e.g. "text/plain".
-#: handler.c:2091
+#: handler.c:2121
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported (need 'view-attachments' bound to key!) --]\n"
 msgstr "[-- '%s/%s'는 지원되지 않음 ('첨부물 보기' 글쇠 정의가 필요함!) --]\n"
 
-#: handler.c:2098
+#: handler.c:2128
 #, fuzzy
 msgid "[-- This is an attachment --]\n"
 msgstr "[ -- %s/%s 첨부물 --]\n"
 
 #. L10N: %s/%s is a MIME type, e.g. "text/plain".
-#: handler.c:2101
+#: handler.c:2131
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported --]\n"
 msgstr "[-- '%s/%s'는 지원되지 않음 --]\n"
@@ -2497,7 +2540,7 @@ msgstr ""
 msgid "Invalid IMAP flags"
 msgstr "무효   "
 
-#: imap/message.c:477 mx.c:1326
+#: imap/message.c:477 mx.c:1336
 msgid "Integer overflow -- can't allocate memory."
 msgstr ""
 
@@ -3269,65 +3312,72 @@ msgstr "SSL 사용 불가."
 msgid "Reading from %s interrupted..."
 msgstr "찾는 도중 중단됨."
 
-#: mx.c:634
+#. L10N: Although we now the precise number of messages, we do not show it to the user.
+#. So feel free to use a "generic plural" as plural translation if your language has one.
+#.
+#: mx.c:639
 #, fuzzy
-msgid "message(s) not deleted"
-msgstr "%d개의 메일을 삭제 표시함..."
+msgid "message not deleted"
+msgid_plural "messages not deleted"
+msgstr[0] "%d개의 메일을 삭제 표시함..."
 
-#: mx.c:671
+#: mx.c:676
 #, fuzzy
 msgid "Can't open trash folder"
 msgstr "폴더에 첨가할 수 없음: %s"
 
-#: mx.c:710
+#: mx.c:715
 msgid "Mark all articles read?"
 msgstr ""
 
-#: mx.c:754
+#. L10N: The first argument is the number of read messages to be
+#. moved, the second argument is the target mailbox.
+#: mx.c:762
 #, fuzzy, c-format
-msgid "Move %d read messages to %s?"
-msgstr "읽은 메일을 %s로 옮길까요?"
+msgid "Move %d read message to %s?"
+msgid_plural "Move %d read messages to %s?"
+msgstr[0] "읽은 메일을 %s로 옮길까요?"
 
-#: mx.c:771 mx.c:1077
+#: mx.c:781 mx.c:1087
 #, fuzzy, c-format
 msgid "Purge %d deleted message?"
 msgid_plural "Purge %d deleted messages?"
 msgstr[0] "삭제 표시된 메일(%d)을 삭제할까요?"
 
-#: mx.c:793
+#: mx.c:803
 #, c-format
 msgid "Moving read messages to %s..."
 msgstr "읽은 메일을 %s로 옮기는 중..."
 
-#: mx.c:859 mx.c:1068
+#: mx.c:869 mx.c:1078
 msgid "Mailbox is unchanged."
 msgstr "메일함이 변경되지 않음."
 
-#: mx.c:914
+#: mx.c:924
 #, c-format
 msgid "%d kept, %d moved, %d deleted."
 msgstr "%d개 보관, %d개 이동, %d개 삭제"
 
-#: mx.c:917 mx.c:1130
+#: mx.c:927 mx.c:1140
 #, c-format
 msgid "%d kept, %d deleted."
 msgstr "%d개 보관, %d개 삭제"
 
-#: mx.c:1052
+#: mx.c:1062
 #, c-format
 msgid " Press '%s' to toggle write"
 msgstr " 쓰기 상태 바꾸기; '%s'를 누르세요"
 
-#: mx.c:1054
+#: mx.c:1064
 msgid "Use 'toggle-write' to re-enable write!"
 msgstr "다시 쓰기를 가능하게 하려면 'toggle-write'를 사용하세요!"
 
-#: mx.c:1056
+#: mx.c:1066
 #, c-format
 msgid "Mailbox is marked unwritable. %s"
 msgstr "메일함이 쓰기 불가능으로 표시 되었음. %s"
 
-#: mx.c:1124
+#: mx.c:1134
 msgid "Mailbox checkpointed."
 msgstr "메일함이 표시됨."
 
@@ -3341,52 +3391,57 @@ msgstr " (현재 시간: %c)"
 msgid "[-- %s output follows%s --]\n"
 msgstr "[-- %s 출력 결과 %s --]\n"
 
-#: ncrypt/crypt.c:95
-msgid "Passphrase(s) forgotten."
+#. L10N: Due to the implementation details (e.g. some passwords are managed
+#. by gpg-agent) we cannot know whether we forgot zero, 1, 12, ...
+#. passwords. So in English we use "Passphrases". Your language might
+#. have other means to express this.
+#: ncrypt/crypt.c:100
+#, fuzzy
+msgid "Passphrases forgotten."
 msgstr "암호 문구 잊음."
 
-#: ncrypt/crypt.c:155
+#: ncrypt/crypt.c:161
 msgid "Inline PGP can't be used with attachments.  Revert to PGP/MIME?"
 msgstr ""
 
-#: ncrypt/crypt.c:159
+#: ncrypt/crypt.c:165
 msgid "Mail not sent: inline PGP can't be used with attachments."
 msgstr ""
 
-#: ncrypt/crypt.c:166
+#: ncrypt/crypt.c:172
 msgid "Inline PGP can't be used with format=flowed.  Revert to PGP/MIME?"
 msgstr ""
 
-#: ncrypt/crypt.c:170
+#: ncrypt/crypt.c:176
 msgid "Mail not sent: inline PGP can't be used with format=flowed."
 msgstr ""
 
-#: ncrypt/crypt.c:180 ncrypt/cryptglue.c:125 ncrypt/pgpkey.c:589
+#: ncrypt/crypt.c:186 ncrypt/cryptglue.c:125 ncrypt/pgpkey.c:589
 #: ncrypt/pgpkey.c:782
 msgid "Invoking PGP..."
 msgstr "PGP를 구동합니다..."
 
-#: ncrypt/crypt.c:192
+#: ncrypt/crypt.c:198
 msgid "Message can't be sent inline.  Revert to using PGP/MIME?"
 msgstr ""
 
-#: ncrypt/crypt.c:194 send.c:1824
+#: ncrypt/crypt.c:200 send.c:1824
 msgid "Mail not sent."
 msgstr "보내지 않음."
 
-#: ncrypt/crypt.c:540
+#: ncrypt/crypt.c:546
 msgid "S/MIME messages with no hints on content are unsupported."
 msgstr "내용에 S/MIME 표시가 없는 경우는 지원하지 않음."
 
-#: ncrypt/crypt.c:754 ncrypt/crypt.c:795
+#: ncrypt/crypt.c:760 ncrypt/crypt.c:801
 msgid "Trying to extract PGP keys...\n"
 msgstr "PGP 열쇠를 추출하는 중...\n"
 
-#: ncrypt/crypt.c:776 ncrypt/crypt.c:816
+#: ncrypt/crypt.c:782 ncrypt/crypt.c:822
 msgid "Trying to extract S/MIME certificates...\n"
 msgstr "S/MIME 인증서 추출하는 중...\n"
 
-#: ncrypt/crypt.c:976
+#: ncrypt/crypt.c:982
 #, c-format
 msgid ""
 "[-- Error: Unknown multipart/signed protocol %s! --]\n"
@@ -3395,7 +3450,7 @@ msgstr ""
 "[-- 오류: 알 수 없는 multipart/signed 프로토콜 %s! --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1016
+#: ncrypt/crypt.c:1022
 #, fuzzy
 msgid ""
 "[-- Error: Missing or bad-format multipart/signed signature! --]\n"
@@ -3404,7 +3459,7 @@ msgstr ""
 "[-- 오류: 일치하지 않는 multipart/signed 구조! --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1058
+#: ncrypt/crypt.c:1064
 #, c-format
 msgid ""
 "[-- Warning: We can't verify %s/%s signatures. --]\n"
@@ -3413,7 +3468,7 @@ msgstr ""
 "[-- Warning: %s/%s 서명을 확인 할 수 없음 --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1070
+#: ncrypt/crypt.c:1076
 msgid ""
 "[-- The following data is signed --]\n"
 "\n"
@@ -3421,7 +3476,7 @@ msgstr ""
 "[-- 아래의 자료는 서명 되었음 --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1075
+#: ncrypt/crypt.c:1081
 msgid ""
 "[-- Warning: Can't find any signatures. --]\n"
 "\n"
@@ -3429,7 +3484,7 @@ msgstr ""
 "[-- 경고: 서명을 찾을 수 없음. --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1081
+#: ncrypt/crypt.c:1087
 msgid ""
 "\n"
 "[-- End of signed data --]\n"
@@ -3481,7 +3536,7 @@ msgstr ""
 msgid "error reading data object: %s\n"
 msgstr "패턴 오류: %s"
 
-#: ncrypt/crypt_gpgme.c:662 ncrypt/crypt_gpgme.c:3848 ncrypt/pgpkey.c:585
+#: ncrypt/crypt_gpgme.c:662 ncrypt/crypt_gpgme.c:3850 ncrypt/pgpkey.c:585
 #: ncrypt/pgpkey.c:768
 msgid "Can't create temporary file"
 msgstr "임시 파일을 만들 수 없음"
@@ -3849,29 +3904,30 @@ msgstr "무효   "
 
 #. L10N: This is printed after "Key Type: " and looks like this:
 #. *       PGP, 2048 bit RSA
-#: ncrypt/crypt_gpgme.c:3670 ncrypt/crypt_gpgme.c:3808
+#: ncrypt/crypt_gpgme.c:3670 ncrypt/crypt_gpgme.c:3810
 #, c-format
 msgid "%s, %lu bit %s\n"
-msgstr ""
+msgid_plural "%s, %lu bit %s\n"
+msgstr[0] ""
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3678 ncrypt/crypt_gpgme.c:3815
+#: ncrypt/crypt_gpgme.c:3678 ncrypt/crypt_gpgme.c:3817
 #, fuzzy
 msgid "encryption"
 msgstr "암호화"
 
 #: ncrypt/crypt_gpgme.c:3679 ncrypt/crypt_gpgme.c:3685
-#: ncrypt/crypt_gpgme.c:3816 ncrypt/crypt_gpgme.c:3821
+#: ncrypt/crypt_gpgme.c:3818 ncrypt/crypt_gpgme.c:3823
 msgid ", "
 msgstr ""
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3684 ncrypt/crypt_gpgme.c:3820
+#: ncrypt/crypt_gpgme.c:3684 ncrypt/crypt_gpgme.c:3822
 msgid "signing"
 msgstr ""
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3690 ncrypt/crypt_gpgme.c:3825
+#: ncrypt/crypt_gpgme.c:3690 ncrypt/crypt_gpgme.c:3827
 #, fuzzy
 msgid "certification"
 msgstr "인증서 저장됨"
@@ -3893,70 +3949,70 @@ msgstr "만기됨  "
 msgid "[Disabled]"
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:3851
+#: ncrypt/crypt_gpgme.c:3853
 #, fuzzy
 msgid "Collecting data..."
 msgstr "%s로 연결 중..."
 
-#: ncrypt/crypt_gpgme.c:3876
+#: ncrypt/crypt_gpgme.c:3878
 #, fuzzy, c-format
 msgid "Error finding issuer key: %s\n"
 msgstr "%s 서버와의 연결 오류"
 
-#: ncrypt/crypt_gpgme.c:3885
+#: ncrypt/crypt_gpgme.c:3887
 #, fuzzy
 msgid "Error: certification chain too long - stopping here\n"
 msgstr "명령어 오류: %s\n"
 
-#: ncrypt/crypt_gpgme.c:3895 ncrypt/pgpkey.c:608
+#: ncrypt/crypt_gpgme.c:3897 ncrypt/pgpkey.c:608
 #, c-format
 msgid "Key ID: 0x%s"
 msgstr "열쇠 ID: 0x%s"
 
-#: ncrypt/crypt_gpgme.c:3990
+#: ncrypt/crypt_gpgme.c:3992
 #, fuzzy, c-format
 msgid "gpgme_new failed: %s"
 msgstr "SSL 실패: %s"
 
-#: ncrypt/crypt_gpgme.c:4028 ncrypt/crypt_gpgme.c:4079
+#: ncrypt/crypt_gpgme.c:4030 ncrypt/crypt_gpgme.c:4081
 #, c-format
 msgid "gpgme_op_keylist_start failed: %s"
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4067 ncrypt/crypt_gpgme.c:4109
+#: ncrypt/crypt_gpgme.c:4069 ncrypt/crypt_gpgme.c:4111
 #, c-format
 msgid "gpgme_op_keylist_next failed: %s"
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4185
+#: ncrypt/crypt_gpgme.c:4187
 #, fuzzy
 msgid "All matching keys are marked expired/revoked."
 msgstr "모든 키가 만기/취소/사용 불가 입니다."
 
-#: ncrypt/crypt_gpgme.c:4215 ncrypt/pgpkey.c:543 ncrypt/smime.c:475
+#: ncrypt/crypt_gpgme.c:4217 ncrypt/pgpkey.c:543 ncrypt/smime.c:475
 msgid "Select  "
 msgstr "선택  "
 
-#: ncrypt/crypt_gpgme.c:4217 ncrypt/pgpkey.c:545
+#: ncrypt/crypt_gpgme.c:4219 ncrypt/pgpkey.c:545
 msgid "Check key  "
 msgstr "열쇠 확인  "
 
-#: ncrypt/crypt_gpgme.c:4233
+#: ncrypt/crypt_gpgme.c:4235
 #, fuzzy
 msgid "PGP and S/MIME keys matching"
 msgstr "PGP 키가 \"%s\"와 일치함."
 
-#: ncrypt/crypt_gpgme.c:4235
+#: ncrypt/crypt_gpgme.c:4237
 #, fuzzy
 msgid "PGP keys matching"
 msgstr "PGP 키가 \"%s\"와 일치함."
 
-#: ncrypt/crypt_gpgme.c:4237
+#: ncrypt/crypt_gpgme.c:4239
 #, fuzzy
 msgid "S/MIME keys matching"
 msgstr "S/MIME 인증서가 \"%s\"와 일치."
 
-#: ncrypt/crypt_gpgme.c:4239
+#: ncrypt/crypt_gpgme.c:4241
 #, fuzzy
 msgid "keys matching"
 msgstr "PGP 키가 \"%s\"와 일치함."
@@ -3965,69 +4021,69 @@ msgstr "PGP 키가 \"%s\"와 일치함."
 #. %1$s is one of the previous four entries.
 #. %2$s is an address.
 #. e.g. "S/MIME keys matching <me@mutt.org>."
-#: ncrypt/crypt_gpgme.c:4246
+#: ncrypt/crypt_gpgme.c:4248
 #, c-format
 msgid "%s <%s>."
 msgstr ""
 
 #. L10N:
 #. e.g. 'S/MIME keys matching "Michael Elkins".'
-#: ncrypt/crypt_gpgme.c:4250
+#: ncrypt/crypt_gpgme.c:4252
 #, c-format
 msgid "%s \"%s\"."
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4277 ncrypt/pgpkey.c:628
+#: ncrypt/crypt_gpgme.c:4279 ncrypt/pgpkey.c:628
 msgid "This key can't be used: expired/disabled/revoked."
 msgstr "이 키는 사용할 수 없습니다: 만기/사용중지/취소됨."
 
-#: ncrypt/crypt_gpgme.c:4290 ncrypt/pgpkey.c:640 ncrypt/smime.c:505
+#: ncrypt/crypt_gpgme.c:4292 ncrypt/pgpkey.c:640 ncrypt/smime.c:505
 #, fuzzy
 msgid "ID is expired/disabled/revoked. Do you really want to use the key?"
 msgstr "이 키는 만기/사용중지/취소됨. 이 키를 정말로 사용을 하겠습니까?"
 
-#: ncrypt/crypt_gpgme.c:4299 ncrypt/pgpkey.c:650
+#: ncrypt/crypt_gpgme.c:4301 ncrypt/pgpkey.c:650
 #, fuzzy
 msgid "ID is not valid. Do you really want to use the key?"
 msgstr "이 ID는 확실하지 않음. 이 키를 정말로 사용을 하겠습니까?"
 
-#: ncrypt/crypt_gpgme.c:4302 ncrypt/pgpkey.c:653
+#: ncrypt/crypt_gpgme.c:4304 ncrypt/pgpkey.c:653
 #, fuzzy
 msgid "ID is only marginally valid. Do you really want to use the key?"
 msgstr "이 ID는 신용도가 낮음. 이 키를 정말로 사용을 하겠습니까?"
 
-#: ncrypt/crypt_gpgme.c:4310 ncrypt/pgpkey.c:646 ncrypt/smime.c:509
+#: ncrypt/crypt_gpgme.c:4312 ncrypt/pgpkey.c:646 ncrypt/smime.c:509
 #, fuzzy
 msgid "ID has undefined validity. Do you really want to use the key?"
 msgstr "ID의 인증자가 정의되지 않음. 이 키를 정말로 사용을 하겠습니까?"
 
-#: ncrypt/crypt_gpgme.c:4370 ncrypt/crypt_gpgme.c:4479 ncrypt/pgpkey.c:872
+#: ncrypt/crypt_gpgme.c:4372 ncrypt/crypt_gpgme.c:4481 ncrypt/pgpkey.c:872
 #: ncrypt/pgpkey.c:995
 #, c-format
 msgid "Looking for keys matching \"%s\"..."
 msgstr "\"%s\"와 일치하는 키를 찾는 중..."
 
-#: ncrypt/crypt_gpgme.c:4593 ncrypt/pgpkey.c:731 ncrypt/smime.c:811
+#: ncrypt/crypt_gpgme.c:4595 ncrypt/pgpkey.c:731 ncrypt/smime.c:811
 #, c-format
 msgid "No matching keys found for \"%s\""
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4644 ncrypt/pgp.c:1263
+#: ncrypt/crypt_gpgme.c:4646 ncrypt/pgp.c:1263
 #, c-format
 msgid "Use keyID = \"%s\" for %s?"
 msgstr "keyID = \"%s\"를 %s에 사용할까요?"
 
-#: ncrypt/crypt_gpgme.c:4695 ncrypt/pgp.c:1312 ncrypt/smime.c:830
+#: ncrypt/crypt_gpgme.c:4697 ncrypt/pgp.c:1312 ncrypt/smime.c:830
 #: ncrypt/smime.c:938
 #, c-format
 msgid "Enter keyID for %s: "
 msgstr "%s의 keyID 입력: "
 
-#: ncrypt/crypt_gpgme.c:4755 ncrypt/pgpkey.c:751
+#: ncrypt/crypt_gpgme.c:4757 ncrypt/pgpkey.c:751
 msgid "Please enter the key ID: "
 msgstr "열쇠 ID 를 입력하십시요: "
 
-#: ncrypt/crypt_gpgme.c:4768
+#: ncrypt/crypt_gpgme.c:4770
 #, fuzzy, c-format
 msgid "Error exporting key: %s\n"
 msgstr "패턴 오류: %s"
@@ -4036,90 +4092,90 @@ msgstr "패턴 오류: %s"
 #. MIME description for exported (attached) keys.
 #. You can translate this entry to a non-ASCII string (it will be encoded),
 #. but it may be safer to keep it untranslated.
-#: ncrypt/crypt_gpgme.c:4787
+#: ncrypt/crypt_gpgme.c:4789
 #, fuzzy, c-format
 msgid "PGP Key 0x%s."
 msgstr "PGP 키 %s."
 
-#: ncrypt/crypt_gpgme.c:4830
+#: ncrypt/crypt_gpgme.c:4832
 msgid "GPGME: OpenPGP protocol not available"
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4838
+#: ncrypt/crypt_gpgme.c:4840
 msgid "GPGME: CMS protocol not available"
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4876
+#: ncrypt/crypt_gpgme.c:4878
 #, fuzzy
 msgid "S/MIME (s)ign, sign (a)s, (p)gp, (c)lear, or (o)ppenc mode off? "
 msgstr "S/MIME 암호화(e), 서명(s), 사용 서명(a), 둘 다(b), (i)nline, 취소(f)? "
 
 #. L10N: S/MIME options (opportunistic encryption is on)
-#: ncrypt/crypt_gpgme.c:4878
+#: ncrypt/crypt_gpgme.c:4880
 msgid "sapco"
 msgstr "esabif"
 
-#: ncrypt/crypt_gpgme.c:4885
+#: ncrypt/crypt_gpgme.c:4887
 #, fuzzy
 msgid "PGP (s)ign, sign (a)s, s/(m)ime, (c)lear, or (o)ppenc mode off? "
 msgstr "PGP 암호화(e), 서명(s), 사용 서명(a), 둘 다(b), (i)nline, 취소(f)? "
 
 #. L10N: PGP options (opportunistic encryption is on)
-#: ncrypt/crypt_gpgme.c:4887
+#: ncrypt/crypt_gpgme.c:4889
 msgid "samco"
 msgstr "esabif"
 
 #. L10N: S/MIME options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4900
+#: ncrypt/crypt_gpgme.c:4902
 #, fuzzy
 msgid "S/MIME (e)ncrypt, (s)ign, sign (a)s, (b)oth, (p)gp, (c)lear, or (o)ppenc mode? "
 msgstr "S/MIME 암호화(e), 서명(s), 사용 서명(a), 둘 다(b), (i)nline, 취소(f)? "
 
 #. L10N: S/MIME options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4903
+#: ncrypt/crypt_gpgme.c:4905
 #, fuzzy
 msgid "esabpco"
 msgstr "esabif"
 
 #. L10N: PGP options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4909
+#: ncrypt/crypt_gpgme.c:4911
 #, fuzzy
 msgid "PGP (e)ncrypt, (s)ign, sign (a)s, (b)oth, s/(m)ime, (c)lear, or (o)ppenc mode? "
 msgstr "PGP 암호화(e), 서명(s), 사용 서명(a), 둘 다(b), (i)nline, 취소(f)? "
 
 #. L10N: PGP options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4912
+#: ncrypt/crypt_gpgme.c:4914
 #, fuzzy
 msgid "esabmco"
 msgstr "esabif"
 
-#: ncrypt/crypt_gpgme.c:4925
+#: ncrypt/crypt_gpgme.c:4927
 #, fuzzy
 msgid "S/MIME (e)ncrypt, (s)ign, sign (a)s, (b)oth, (p)gp or (c)lear? "
 msgstr "S/MIME 암호화(e), 서명(s), 사용 서명(a), 둘 다(b), (i)nline, 취소(f)? "
 
 #. L10N: S/MIME options
-#: ncrypt/crypt_gpgme.c:4927
+#: ncrypt/crypt_gpgme.c:4929
 #, fuzzy
 msgid "esabpc"
 msgstr "esabif"
 
-#: ncrypt/crypt_gpgme.c:4934
+#: ncrypt/crypt_gpgme.c:4936
 #, fuzzy
 msgid "PGP (e)ncrypt, (s)ign, sign (a)s, (b)oth, s/(m)ime or (c)lear? "
 msgstr "PGP 암호화(e), 서명(s), 사용 서명(a), 둘 다(b), (i)nline, 취소(f)? "
 
 #. L10N: PGP options
-#: ncrypt/crypt_gpgme.c:4936
+#: ncrypt/crypt_gpgme.c:4938
 #, fuzzy
 msgid "esabmc"
 msgstr "esabif"
 
-#: ncrypt/crypt_gpgme.c:5087
+#: ncrypt/crypt_gpgme.c:5089
 msgid "Failed to verify sender"
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:5090
+#: ncrypt/crypt_gpgme.c:5092
 #, fuzzy
 msgid "Failed to figure out sender"
 msgstr "헤더를 분석하기 위한 파일 열기 실패"
@@ -4527,7 +4583,7 @@ msgstr ""
 msgid "%s is an invalid news server specification!"
 msgstr "%s는 잘못된 POP 패스"
 
-#: nntp.c:75 nntp.c:612 pop.c:1028 pop_lib.c:405
+#: nntp.c:75 nntp.c:612 pop.c:1031 pop_lib.c:405
 msgid "Server closed connection!"
 msgstr "서버와 연결이 끊어짐!"
 
@@ -4693,16 +4749,17 @@ msgstr "메일함의 새 메일 확인"
 
 #: opcodes.h:47
 #, fuzzy
-msgid "attach file(s) to this message"
+msgid "attach files to this message"
 msgstr "현재 메세지에 파일 첨부"
 
 #: opcodes.h:48
-msgid "attach message(s) to this message"
+#, fuzzy
+msgid "attach messages to this message"
 msgstr "현재 메세지에 메세지 첨부"
 
 #: opcodes.h:49
 #, fuzzy
-msgid "attach news article(s) to this message"
+msgid "attach news articles to this message"
 msgstr "현재 메세지에 파일 첨부"
 
 #: opcodes.h:50
@@ -5549,7 +5606,8 @@ msgid "extract supported public keys"
 msgstr "공개 열쇠 추출"
 
 #: opcodes.h:255
-msgid "wipe passphrase(s) from memory"
+#, fuzzy
+msgid "wipe passphrases from memory"
 msgstr "메모리에서 암호 문구 지움"
 
 #: opcodes.h:259
@@ -5900,18 +5958,19 @@ msgstr "POP 메일함에 새 메일이 없음."
 msgid "Delete messages from server?"
 msgstr "서버의 메일을 삭제 할까요?"
 
-#: pop.c:954
-#, c-format
-msgid "Reading new messages (%d bytes)..."
-msgstr "새 메일 읽는 중 (%d 바이트)..."
+#: pop.c:955
+#, fuzzy, c-format
+msgid "Reading new messages (%d byte)..."
+msgid_plural "Reading new messages (%d bytes)..."
+msgstr[0] "새 메일 읽는 중 (%d 바이트)..."
 
-#: pop.c:997
+#: pop.c:1000
 msgid "Error while writing mailbox!"
 msgstr "메일함에 쓰는 중 오류!"
 
 #. L10N: The plural is picked by the second numerical argument, i.e.
 #. * the %d right before 'messages', i.e. the total number of messages.
-#: pop.c:1003
+#: pop.c:1006
 #, fuzzy, c-format
 msgid "%s [%d of %d message read]"
 msgid_plural "%s [%d of %d messages read]"
@@ -6056,49 +6115,55 @@ msgstr "연결: "
 msgid "I don't know how to print %s attachments!"
 msgstr "첨부물 %s의 출력 방법을 알 수 없음!"
 
-#: recvattach.c:841
-msgid "Print tagged attachment(s)?"
-msgstr "태그가 붙은 첨부물 출력?"
+#. L10N: Although we now the precise number of tagged messages, we
+#. do not show it to the user.  So feel free to use a "generic
+#. plural" as plural translation if your language has one.
+#: recvattach.c:852
+#, fuzzy, c-format
+msgid "Print tagged attachment?"
+msgid_plural "Print %d tagged attachments?"
+msgstr[0] "태그가 붙은 첨부물 출력?"
 
-#: recvattach.c:842
+#: recvattach.c:853
+#, c-format
 msgid "Print attachment?"
 msgstr "첨부물 출력?"
 
-#: recvattach.c:900
+#: recvattach.c:913
 msgid "Structural changes to decrypted attachments are not supported"
 msgstr ""
 
-#: recvattach.c:1046
+#: recvattach.c:1059
 msgid "Can't decrypt encrypted message!"
 msgstr "암호화된 메일을 해독할 수 없음!"
 
-#: recvattach.c:1172
+#: recvattach.c:1185
 msgid "Attachments"
 msgstr "첨부물"
 
-#: recvattach.c:1210
+#: recvattach.c:1223
 msgid "There are no subparts to show!"
 msgstr "더 이상 첨부물이 없습니다."
 
-#: recvattach.c:1265
+#: recvattach.c:1278
 msgid "Can't delete attachment from POP server."
 msgstr "POP 서버에서 첨부물을 삭제 할수 없음."
 
-#: recvattach.c:1274
+#: recvattach.c:1287
 #, fuzzy
 msgid "Can't delete attachment from news server."
 msgstr "POP 서버에서 첨부물을 삭제 할수 없음."
 
-#: recvattach.c:1281
+#: recvattach.c:1294
 msgid "Deletion of attachments from encrypted messages is unsupported."
 msgstr "암호화된 메일의 첨부물 삭제는 지원되지 않음."
 
-#: recvattach.c:1287
+#: recvattach.c:1300
 #, fuzzy
 msgid "Deletion of attachments from signed messages may invalidate the signature."
 msgstr "암호화된 메일의 첨부물 삭제는 지원되지 않음."
 
-#: recvattach.c:1305 recvattach.c:1320
+#: recvattach.c:1318 recvattach.c:1333
 msgid "Only deletion of multipart attachments is supported."
 msgstr "다중체계 첨부물의 삭제만이 지원됩니다."
 
@@ -6517,3 +6582,15 @@ msgstr "컴파일 선택사항:"
 #: version.c:404
 msgid "Compile options:"
 msgstr "컴파일 선택사항:"
+
+#, fuzzy
+#~ msgid "Cannot delete message(s)"
+#~ msgstr "삭제 취소된 메일 없음."
+
+#, fuzzy
+#~ msgid "Cannot undelete message(s)"
+#~ msgstr "삭제 취소된 메일 없음."
+
+#, fuzzy
+#~ msgid "messages not deleted"
+#~ msgstr "%d개의 메일을 삭제 표시함..."

--- a/po/lt.po
+++ b/po/lt.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neomutt-20180512\n"
 "Report-Msgid-Bugs-To: neomutt-devel@neomutt.org\n"
-"POT-Creation-Date: 2018-05-20 02:02+0000\n"
+"POT-Creation-Date: 2018-05-22 14:18+0000\n"
 "PO-Revision-Date: 2000-11-29 21:22+0200\n"
 "Last-Translator: Marius Gedminas <marius@gedmin.as>\n"
 "Language-Team: Lithuanian <komp_lt@konferencijos.lt>\n"
@@ -41,7 +41,7 @@ msgstr "Pasirinkti"
 
 #: addrbook.c:52 browser.c:75 browser.c:87 compose.c:160 compose.c:172
 #: conn/ssl.c:1041 conn/ssl_gnutls.c:793 curs_main.c:748 curs_main.c:761
-#: history.c:106 ncrypt/crypt_gpgme.c:4219 ncrypt/pgpkey.c:547
+#: history.c:106 ncrypt/crypt_gpgme.c:4221 ncrypt/pgpkey.c:547
 #: ncrypt/smime.c:477 pager.c:2141 postpone.c:65 query.c:72 recvattach.c:70
 msgid "Help"
 msgstr "Pagalba"
@@ -666,7 +666,7 @@ msgstr "Saugumas: "
 #. * Since it shares the row with "Encrypt with:", it should not be longer
 #. * than 15-20 character cells.
 #.
-#: compose.c:138 ncrypt/crypt_gpgme.c:4947 ncrypt/pgp.c:1786
+#: compose.c:138 ncrypt/crypt_gpgme.c:4949 ncrypt/pgp.c:1786
 #: ncrypt/smime.c:2127
 msgid "Sign as: "
 msgstr "Pasirašyti kaip: "
@@ -1196,7 +1196,7 @@ msgstr "(a)tmesti, (p)riimti šįkart, p(r)aleisti"
 msgid "(r)eject, accept (o)nce"
 msgstr "(a)tmesti, (p)riimti šįkart"
 
-#: conn/ssl.c:1039 conn/ssl_gnutls.c:791 ncrypt/crypt_gpgme.c:4213
+#: conn/ssl.c:1039 conn/ssl_gnutls.c:791 ncrypt/crypt_gpgme.c:4215
 #: ncrypt/pgpkey.c:541 ncrypt/smime.c:473
 msgid "Exit  "
 msgstr "Išeiti  "
@@ -1375,11 +1375,11 @@ msgstr "Jokia dėžutė neatidaryta."
 msgid "There are no messages."
 msgstr "Ten nėra laiškų."
 
-#: curs_main.c:77 mx.c:1061 pager.c:73 recvattach.c:56
+#: curs_main.c:77 mx.c:1071 pager.c:73 recvattach.c:56
 msgid "Mailbox is read-only."
 msgstr "Dėžutė yra tik skaitoma."
 
-#: curs_main.c:79 pager.c:75 recvattach.c:1145
+#: curs_main.c:79 pager.c:75 recvattach.c:1158
 msgid "Function not permitted in attach-message mode."
 msgstr "Funkcija neleistina laiško prisegimo režime."
 
@@ -1509,235 +1509,245 @@ msgid "That message is not visible."
 msgstr "Tas laiškas yra nematomas."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:1377 curs_main.c:2772 pager.c:2818
-msgid "Cannot delete message(s)"
+#. L10N: Due to the implementation details we do not know whether we
+#. delete zero, 1, 12, ... messages. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:1381 curs_main.c:2784 pager.c:2822
+#, fuzzy
+msgid "Cannot delete messages"
 msgstr "Negaliu ištrinti laiškų."
 
-#: curs_main.c:1380
+#: curs_main.c:1384
 msgid "Delete messages matching: "
 msgstr "Ištrinti laiškus, tenkinančius: "
 
-#: curs_main.c:1421
+#: curs_main.c:1425
 msgid "No limit pattern is in effect."
 msgstr "Joks ribojimo pattern'as nėra naudojamas."
 
 #. L10N: ask for a limit to apply
-#: curs_main.c:1426
+#: curs_main.c:1430
 #, c-format
 msgid "Limit: %s"
 msgstr "Riba: %s"
 
-#: curs_main.c:1464
+#: curs_main.c:1468
 msgid "Limit to messages matching: "
 msgstr "Riboti iki laiškų, tenkinančių: "
 
-#: curs_main.c:1488
+#: curs_main.c:1492
 msgid "To view all messages, limit to \"all\"."
 msgstr "Norėdami matyti visus laiškus apribokite iki \"all\"."
 
-#: curs_main.c:1500 pager.c:2318
+#: curs_main.c:1504 pager.c:2318
 msgid "Quit NeoMutt?"
 msgstr "Išeiti iš NeoMutt?"
 
-#: curs_main.c:1596
+#: curs_main.c:1600
 msgid "Tag messages matching: "
 msgstr "Pažymėti laiškus, tenkinančius: "
 
 #. L10N: CHECK_ACL
-#: curs_main.c:1606 curs_main.c:3203 pager.c:3137
-msgid "Cannot undelete message(s)"
+#. L10N: Due to the implementation details we do not know whether we
+#. undelete zero, 1, 12, ... messages. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:1614 curs_main.c:3223 pager.c:3145
+#, fuzzy
+msgid "Cannot undelete messages"
 msgstr "Negaliu sugrąžinti laiškų."
 
-#: curs_main.c:1609
+#: curs_main.c:1617
 msgid "Undelete messages matching: "
 msgstr "Sugrąžinti laiškus, tenkinančius: "
 
-#: curs_main.c:1619
+#: curs_main.c:1627
 msgid "Untag messages matching: "
 msgstr "Atžymėti laiškus, tenkinančius: "
 
-#: curs_main.c:1653
+#: curs_main.c:1661
 msgid "Logged out of IMAP servers."
 msgstr "Atsijungiau nuo IMAP serverių."
 
-#: curs_main.c:1753
+#: curs_main.c:1761
 msgid "No virtual folder, aborting."
 msgstr "Nėra virtualaus aplanko, nutraukiu."
 
-#: curs_main.c:1761
+#: curs_main.c:1769
 msgid "Failed to read thread, aborting."
 msgstr "Nepavyko perskaityti gijos, nutraukiu."
 
-#: curs_main.c:1793 mx.c:1458 mx.c:1475
+#: curs_main.c:1801 mx.c:1468 mx.c:1485
 msgid "Folder doesn't support tagging, aborting."
 msgstr "Katalogas nepalaiko etikečių, nutraukiu."
 
-#: curs_main.c:1808
+#: curs_main.c:1816
 msgid "No tag specified, aborting."
 msgstr "Nėra etiketės, nutraukiu."
 
-#: curs_main.c:1820
+#: curs_main.c:1828
 #, c-format
 msgid "Update tags..."
 msgstr "Atnaujinu etiketes..."
 
-#: curs_main.c:1857
+#: curs_main.c:1865
 msgid "Failed to modify tags, aborting."
 msgstr "Nepavyko atnaujinti etikečių, nutraukiu."
 
-#: curs_main.c:1898
+#: curs_main.c:1906
 msgid "No query, aborting."
 msgstr "Nėra užklausos, nutraukiu."
 
-#: curs_main.c:1902 curs_main.c:1922 curs_main.c:1941
+#: curs_main.c:1910 curs_main.c:1930 curs_main.c:1949
 msgid "Failed to create query, aborting."
 msgstr "Nepavyko sukurti užklausos, ašaukiu."
 
-#: curs_main.c:1911 curs_main.c:1930
+#: curs_main.c:1919 curs_main.c:1938
 msgid "Windowed queries disabled."
 msgstr "Langų užklausos išjungtos."
 
-#: curs_main.c:1916 curs_main.c:1935
+#: curs_main.c:1924 curs_main.c:1943
 msgid "No notmuch vfolder currently loaded."
 msgstr "Joks notmuch virtualaus aplanko šiuo metu nėra užkrautas."
 
-#: curs_main.c:1973
+#: curs_main.c:1981
 msgid "Open mailbox in read-only mode"
 msgstr "Atidaryti dėžutę tik skaitymo režimu"
 
-#: curs_main.c:1976
+#: curs_main.c:1984
 msgid "Open virtual folder"
 msgstr "Atidaryti virtualų aplanką"
 
-#: curs_main.c:1979
+#: curs_main.c:1987
 msgid "Open mailbox"
 msgstr "Atidaryti dėžutę"
 
-#: curs_main.c:1989
+#: curs_main.c:1997
 msgid "No mailboxes have new mail"
 msgstr "Nėra dėžučių su nauju paštu"
 
-#: curs_main.c:2036
+#: curs_main.c:2044
 msgid "Open newsgroup in read-only mode"
 msgstr "Atidaryti naujienų grupę tik skaitymo režimu"
 
-#: curs_main.c:2038
+#: curs_main.c:2046
 msgid "Open newsgroup"
 msgstr "Atidaryti naujienų grupę"
 
-#: curs_main.c:2141
+#: curs_main.c:2149
 msgid "Exit NeoMutt without saving?"
 msgstr "Išeiti iš NeoMutt neišsaugojus pakeitimų?"
 
-#: curs_main.c:2157
+#: curs_main.c:2165
 msgid "Cannot break thread"
 msgstr "Negaliu perskelti gijos"
 
-#: curs_main.c:2160 curs_main.c:2198 curs_main.c:2658 curs_main.c:2690
+#: curs_main.c:2168 curs_main.c:2206 curs_main.c:2666 curs_main.c:2698
 #: flags.c:376 thread.c:1078 thread.c:1134 thread.c:1202
 msgid "Threading is not enabled."
 msgstr "Skirstymas gijomis neleidžiamas."
 
-#: curs_main.c:2173
+#: curs_main.c:2181
 msgid "Thread broken"
 msgstr "Gija perskelta"
 
-#: curs_main.c:2185
+#: curs_main.c:2193
 msgid "Thread cannot be broken, message is not part of a thread"
 msgstr "Gija negali būti perskelta: laiškas nėra gijoje"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2195
+#: curs_main.c:2203
 msgid "Cannot link threads"
 msgstr "Negaliu sujungti gijų"
 
-#: curs_main.c:2200
+#: curs_main.c:2208
 msgid "No Message-ID: header available to link thread"
 msgstr "Nėra Message-ID: antraštės, pagal kurią būtų galima sujungti gijas"
 
-#: curs_main.c:2202
+#: curs_main.c:2210
 msgid "First, please tag a message to be linked here"
 msgstr "Pirmiausia pažymėk laišką, kurį reikia prijungti čia"
 
-#: curs_main.c:2213
+#: curs_main.c:2221
 msgid "Threads linked"
 msgstr "Gijos sujungtos"
 
-#: curs_main.c:2216
+#: curs_main.c:2224
 msgid "No thread linked"
 msgstr "Gijos nesujungtos"
 
-#: curs_main.c:2252 curs_main.c:2278
+#: curs_main.c:2260 curs_main.c:2286
 msgid "You are on the last message."
 msgstr "Tu esi ties paskutiniu laišku."
 
-#: curs_main.c:2260 curs_main.c:2305
+#: curs_main.c:2268 curs_main.c:2313
 msgid "No undeleted messages."
 msgstr "Nėra ištrintų laiškų."
 
-#: curs_main.c:2297 curs_main.c:2323
+#: curs_main.c:2305 curs_main.c:2331
 msgid "You are on the first message."
 msgstr "Tu esi ties pirmu laišku."
 
-#: curs_main.c:2395 menu.c:970 pager.c:2440 pattern.c:2110
+#: curs_main.c:2403 menu.c:970 pager.c:2440 pattern.c:2110
 msgid "Search wrapped to top."
 msgstr "Paieška peršoko į viršų."
 
-#: curs_main.c:2404 pager.c:2463 pattern.c:2121
+#: curs_main.c:2412 pager.c:2463 pattern.c:2121
 msgid "Search wrapped to bottom."
 msgstr "Paieška peršoko į apačią."
 
-#: curs_main.c:2447
+#: curs_main.c:2455
 msgid "No new messages in this limited view."
 msgstr "Nėra naujų laiškų ribotame vaizde."
 
-#: curs_main.c:2449
+#: curs_main.c:2457
 msgid "No new messages."
 msgstr "Nėra naujų laiškų."
 
-#: curs_main.c:2454
+#: curs_main.c:2462
 msgid "No unread messages in this limited view."
 msgstr "Nėra neskaitytų laiškų ribotame vaizde."
 
-#: curs_main.c:2456
+#: curs_main.c:2464
 msgid "No unread messages."
 msgstr "Nėra neskaitytų laiškų."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2474
+#: curs_main.c:2482
 msgid "Cannot flag message"
 msgstr "Negaliu pakeisti pakeisti laiško vėliavėlių"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2513 pager.c:3100
+#: curs_main.c:2521 pager.c:3104
 msgid "Cannot toggle new"
 msgstr "Negaliu pakeisti naujumo"
 
-#: curs_main.c:2590
+#: curs_main.c:2598
 msgid "No more threads."
 msgstr "Daugiau gijų nėra."
 
-#: curs_main.c:2592
+#: curs_main.c:2600
 msgid "You are on the first thread."
 msgstr "Tu esi ties pirma gija."
 
-#: curs_main.c:2676
+#: curs_main.c:2684
 msgid "Thread contains unread or flagged messages."
 msgstr "Gijoje yra neskaitytų ar vėliavėle pažymėtų laiškų."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2726 pager.c:2784
+#: curs_main.c:2734 pager.c:2784
 msgid "Cannot delete message"
 msgstr "Negaliu ištrinti laiško"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2838
+#: curs_main.c:2850
 msgid "Cannot edit message"
 msgstr "Negaliu redaguoti laiško"
 
 #. L10N: This is displayed when the x-label on one or more
 #. * messages is edited.
-#: curs_main.c:2900 pager.c:3200
+#: curs_main.c:2912 pager.c:3208
 #, c-format
 msgid "%d label changed."
 msgid_plural "%d labels changed."
@@ -1748,52 +1758,57 @@ msgstr[2] "%d etikečių pakeista."
 #. L10N: This is displayed when editing an x-label, but no messages
 #. * were updated.  Possibly due to canceling at the prompt or if the new
 #. * label is the same as the old label.
-#: curs_main.c:2907 pager.c:3204
+#: curs_main.c:2919 pager.c:3212
 msgid "No labels changed."
 msgstr "Etiketės nepakeistos."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:3006
-msgid "Cannot mark message(s) as read"
+#. L10N: Due to the implementation details we do not know whether we
+#. mark zero, 1, 12, ... messages as read. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:3022
+#, fuzzy
+msgid "Cannot mark messages as read"
 msgstr "Negaliu pažymėti laiškų kaip skaitytų"
 
 #. L10N: This is the prompt for <mark-message>.  Whatever they
 #. enter will be prefixed by $mark_macro_prefix and will become
 #. a macro hotkey to jump to the currently selected message.
-#: curs_main.c:3042
+#: curs_main.c:3058
 msgid "Enter macro stroke: "
 msgstr "Įvesk makrokomandą: "
 
 #. L10N: "message hotkey" is the key bindings menu description of a
 #. macro created by <mark-message>.
-#: curs_main.c:3050
+#: curs_main.c:3066
 msgid "message hotkey"
 msgstr "šokti į pažymėtą laišką"
 
 #. L10N: This is echoed after <mark-message> creates a new hotkey
 #. macro.  %s is the hotkey string ($mark_macro_prefix followed
 #. by whatever they typed at the prompt.)
-#: curs_main.c:3055
+#: curs_main.c:3071
 #, c-format
 msgid "Message bound to %s."
 msgstr "Laiško makrokomanda %s sukurta."
 
 #. L10N: This error is printed if <mark-message> cannot find a
 #. Message-ID for the currently selected message in the index.
-#: curs_main.c:3063
+#: curs_main.c:3079
 msgid "No message ID to macro."
 msgstr "Laiškas neturi ID."
 
-#: curs_main.c:3105 pager.c:2961 recvattach.c:1388
+#: curs_main.c:3121 pager.c:2965 recvattach.c:1401
 msgid "Reply by mail as poster prefers?"
 msgstr "Atsakyti paštu, kaip pageidauja autorius?"
 
-#: curs_main.c:3108 pager.c:2927 pager.c:2939 pager.c:2964
+#: curs_main.c:3124 pager.c:2931 pager.c:2943 pager.c:2968
 msgid "Posting to this group not allowed, may be moderated. Continue?"
 msgstr "Siuntimas į šią grupę neleidžiamas, gali būti moderuotas. Tęsti?"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:3173 pager.c:3120
+#: curs_main.c:3189 pager.c:3124
 msgid "Cannot undelete message"
 msgstr "Negaliu atstatyti ištrinto laiško"
 
@@ -1984,12 +1999,37 @@ msgstr "[-- Automatinės peržiūros %s klaidos --]\n"
 msgid "[-- Error: message/external-body has no access-type parameter --]\n"
 msgstr "[-- Klaida: message/external-body dalis neturi access-type parametro --]\n"
 
-#: handler.c:1611
-#, c-format
+#. L10N: If the translation of this string is a multi line string, then
+#. each line should start with "[-- " and end with " --]".
+#. The first "%s/%s" is a MIME type, e.g. "text/plain". The last %s
+#. expands to a date as returned by `mutt_date_parse_date()`.
+#.
+#. Note: The size argument printed is not the actual number as passed
+#. to gettext but the prettified version, e.g. size = 2048 will be
+#. printed as 2K.  Your language might be sensitive to that: For
+#. example although '1K' and '1024' represent the same number your
+#. language might inflect the noun 'byte' differently.
+#.
+#. Sadly, we cannot do anything about that at the moment besides
+#. passing the precise size in bytes. If you are interested the
+#. function responsible for the prettification is
+#. mutt_str_pretty_size() in mutt/string.c.
+#.
+#: handler.c:1624
+#, fuzzy, c-format
 msgid ""
+"[-- This %s/%s attachment (size %s byte) has been deleted --]\n"
+"[-- on %s --]\n"
+msgid_plural ""
 "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
 "[-- on %s --]\n"
-msgstr ""
+msgstr[0] ""
+"[-- Šis %s/%s priedas (dydis %s baitų) buvo ištrintas --]\n"
+"[-- %s --]\n"
+msgstr[1] ""
+"[-- Šis %s/%s priedas (dydis %s baitų) buvo ištrintas --]\n"
+"[-- %s --]\n"
+msgstr[2] ""
 "[-- Šis %s/%s priedas (dydis %s baitų) buvo ištrintas --]\n"
 "[-- %s --]\n"
 
@@ -1997,10 +2037,24 @@ msgstr ""
 #. each line should start with "[-- " and end with " --]".
 #. The first "%s/%s" is a MIME type, e.g. "text/plain".
 #.
-#: handler.c:1620
-#, c-format
-msgid "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
-msgstr "[-- Šis %s/%s priedas (dydis %s baitų) buvo ištrintas --]\n"
+#. Note: The size argument printed is not the actual number as passed
+#. to gettext but the prettified version, e.g. size = 2048 will be
+#. printed as 2K.  Your language might be sensitive to that: For
+#. example although '1K' and '1024' represent the same number your
+#. language might inflect the noun 'byte' differently.
+#.
+#. Sadly, we cannot do anything about that at the moment besides
+#. passing the precise size in bytes. If you are interested the
+#. function responsible for the prettification is
+#. mutt_str_pretty_size() in mutt/string.c.
+#.
+#: handler.c:1648
+#, fuzzy, c-format
+msgid "[-- This %s/%s attachment (size %s byte) has been deleted --]\n"
+msgid_plural "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
+msgstr[0] "[-- Šis %s/%s priedas (dydis %s baitų) buvo ištrintas --]\n"
+msgstr[1] "[-- Šis %s/%s priedas (dydis %s baitų) buvo ištrintas --]\n"
+msgstr[2] "[-- Šis %s/%s priedas (dydis %s baitų) buvo ištrintas --]\n"
 
 #. L10N: If the translation of this string is a multi line string, then
 #. each line should start with "[-- " and end with " --]".
@@ -2010,7 +2064,7 @@ msgstr "[-- Šis %s/%s priedas (dydis %s baitų) buvo ištrintas --]\n"
 #. Caution: Argument three %3$ is also defined but should not be used
 #. in this translation!
 #.
-#: handler.c:1637
+#: handler.c:1667
 msgid ""
 "[-- This %s/%s attachment has been deleted --]\n"
 "[-- on %4$s --]\n"
@@ -2022,17 +2076,17 @@ msgstr ""
 #. each line should start with "[-- " and end with " --]".
 #. The first "%s/%s" is a MIME type, e.g. "text/plain".
 #.
-#: handler.c:1646
+#: handler.c:1676
 #, c-format
 msgid "[-- This %s/%s attachment has been deleted --]\n"
 msgstr "[-- Šis %s/%s priedas buvo ištrintas --]\n"
 
-#: handler.c:1656
+#: handler.c:1686
 #, c-format
 msgid "[-- name: %s --]\n"
 msgstr "[-- vardas: %s --]\n"
 
-#: handler.c:1672
+#: handler.c:1702
 #, c-format
 msgid ""
 "[-- This %s/%s attachment is not included, --]\n"
@@ -2042,7 +2096,7 @@ msgstr ""
 "[-- Šis %s/%s priedas neįtrauktas, --]\n"
 "[-- o nurodytas išorinis šaltinis paseno. --]\n"
 
-#: handler.c:1693
+#: handler.c:1723
 #, c-format
 msgid ""
 "[-- This %s/%s attachment is not included, --]\n"
@@ -2051,47 +2105,47 @@ msgstr ""
 "[-- Šis %s/%s priedas neįtrauktas, --]\n"
 "[-- o nurodytas pasiekimo tipas %s yra nepalaikomas. --]\n"
 
-#: handler.c:1822
+#: handler.c:1852
 msgid "Unable to open memory stream!"
 msgstr "Negaliu atidaryti atminties srauto!"
 
-#: handler.c:1831
+#: handler.c:1861
 msgid "Unable to open temporary file!"
 msgstr "Negaliu atidaryti laikinos bylos!"
 
-#: handler.c:1881
+#: handler.c:1911
 msgid "failed to re-open memstream!"
 msgstr "nepavyko iš naujo atidaryti atminties srauto!"
 
-#: handler.c:2013
+#: handler.c:2043
 msgid "Error: multipart/signed has no protocol."
 msgstr "Klaida: multipart/signed neturi protokolo."
 
-#: handler.c:2076
+#: handler.c:2106
 msgid "[-- This is an attachment (use '%3$s' to view this part) --]\n"
 msgstr "[-- Čia yra priedas (naudok '%3$s' šiai daliai peržiūrėti) --]\n"
 
-#: handler.c:2082
+#: handler.c:2112
 #, c-format
 msgid "[-- %s/%s is unsupported (use '%s' to view this part) --]\n"
 msgstr "[-- %s/%s yra nepalaikomas (naudok '%s' šiai daliai peržiūrėti) --]\n"
 
-#: handler.c:2087
+#: handler.c:2117
 msgid "[-- This is an attachment (need 'view-attachments' bound to key!) --]\n"
 msgstr "[-- Čia yra priedas ('view-attachments' turi būti susietas su klavišu!) --]\n"
 
 #. L10N: %s/%s is a MIME type, e.g. "text/plain".
-#: handler.c:2091
+#: handler.c:2121
 #, c-format
 msgid "[-- %s/%s is unsupported (need 'view-attachments' bound to key!) --]\n"
 msgstr "[-- %s/%s yra nepalaikomas ('view-attachments' turi būti susietas su klavišu!) --]\n"
 
-#: handler.c:2098
+#: handler.c:2128
 msgid "[-- This is an attachment --]\n"
 msgstr "[-- Čia yra priedas --]\n"
 
 #. L10N: %s/%s is a MIME type, e.g. "text/plain".
-#: handler.c:2101
+#: handler.c:2131
 #, c-format
 msgid "[-- %s/%s is unsupported --]\n"
 msgstr "[-- %s/%s yra nepalaikomas --]\n"
@@ -2396,7 +2450,7 @@ msgstr "IMAP serveris nepalaiko savadarbių vėliavėlių"
 msgid "Invalid IMAP flags"
 msgstr "Blogos IMAP vėliavėlės"
 
-#: imap/message.c:477 mx.c:1326
+#: imap/message.c:477 mx.c:1336
 msgid "Integer overflow -- can't allocate memory."
 msgstr "Sveikųjų skaičių perpildymas - negaliu išskirti atminties."
 
@@ -3212,24 +3266,36 @@ msgstr "SSL nepasiekiamas, negaliu prisijungti prie %s"
 msgid "Reading from %s interrupted..."
 msgstr "Skaitymas iš %s pertrauktas..."
 
-#: mx.c:634
-msgid "message(s) not deleted"
-msgstr "laiškas/ai neištrinti"
+#. L10N: Although we now the precise number of messages, we do not show it to the user.
+#. So feel free to use a "generic plural" as plural translation if your language has one.
+#.
+#: mx.c:639
+#, fuzzy
+msgid "message not deleted"
+msgid_plural "messages not deleted"
+msgstr[0] "laiškas/ai neištrinti"
+msgstr[1] "laiškas/ai neištrinti"
+msgstr[2] "laiškas/ai neištrinti"
 
-#: mx.c:671
+#: mx.c:676
 msgid "Can't open trash folder"
 msgstr "Negaliu atidaryti šiukšlių aplanko"
 
-#: mx.c:710
+#: mx.c:715
 msgid "Mark all articles read?"
 msgstr "Pažymėti visus straipsnius skaitytais?"
 
-#: mx.c:754
-#, c-format
-msgid "Move %d read messages to %s?"
-msgstr "Perkelti %d skaitytų laiškų į %s?"
+#. L10N: The first argument is the number of read messages to be
+#. moved, the second argument is the target mailbox.
+#: mx.c:762
+#, fuzzy, c-format
+msgid "Move %d read message to %s?"
+msgid_plural "Move %d read messages to %s?"
+msgstr[0] "Perkelti %d skaitytų laiškų į %s?"
+msgstr[1] "Perkelti %d skaitytų laiškų į %s?"
+msgstr[2] "Perkelti %d skaitytų laiškų į %s?"
 
-#: mx.c:771 mx.c:1077
+#: mx.c:781 mx.c:1087
 #, c-format
 msgid "Purge %d deleted message?"
 msgid_plural "Purge %d deleted messages?"
@@ -3237,40 +3303,40 @@ msgstr[0] "Sunaikinti %d ištrintą laišką?"
 msgstr[1] "Sunaikinti %d ištrintus laiškus?"
 msgstr[2] "Sunaikinti %d ištrintų laiškų?"
 
-#: mx.c:793
+#: mx.c:803
 #, c-format
 msgid "Moving read messages to %s..."
 msgstr "Perkeliu skaitytus laiškus į %s..."
 
-#: mx.c:859 mx.c:1068
+#: mx.c:869 mx.c:1078
 msgid "Mailbox is unchanged."
 msgstr "Dėžutė yra nepakeista."
 
-#: mx.c:914
+#: mx.c:924
 #, c-format
 msgid "%d kept, %d moved, %d deleted."
 msgstr "%d palikti, %d perkelti, %d ištrinti."
 
-#: mx.c:917 mx.c:1130
+#: mx.c:927 mx.c:1140
 #, c-format
 msgid "%d kept, %d deleted."
 msgstr "%d palikti, %d ištrinti."
 
-#: mx.c:1052
+#: mx.c:1062
 #, c-format
 msgid " Press '%s' to toggle write"
 msgstr " Spausk '%s', kad perjungtum rašymą"
 
-#: mx.c:1054
+#: mx.c:1064
 msgid "Use 'toggle-write' to re-enable write!"
 msgstr "Naudok 'toggle-write', kad vėl galėtum rašyti!"
 
-#: mx.c:1056
+#: mx.c:1066
 #, c-format
 msgid "Mailbox is marked unwritable. %s"
 msgstr "Dėžutė yra padaryta neįrašoma. %s"
 
-#: mx.c:1124
+#: mx.c:1134
 msgid "Mailbox checkpointed."
 msgstr "Dėžutė sutikrinta."
 
@@ -3284,52 +3350,57 @@ msgstr " (dabartinis laikas: %c)"
 msgid "[-- %s output follows%s --]\n"
 msgstr "[-- Toliau %s išvestis%s --]\n"
 
-#: ncrypt/crypt.c:95
-msgid "Passphrase(s) forgotten."
+#. L10N: Due to the implementation details (e.g. some passwords are managed
+#. by gpg-agent) we cannot know whether we forgot zero, 1, 12, ...
+#. passwords. So in English we use "Passphrases". Your language might
+#. have other means to express this.
+#: ncrypt/crypt.c:100
+#, fuzzy
+msgid "Passphrases forgotten."
 msgstr "Slapta frazė pamiršta."
 
-#: ncrypt/crypt.c:155
+#: ncrypt/crypt.c:161
 msgid "Inline PGP can't be used with attachments.  Revert to PGP/MIME?"
 msgstr "Inline PGP negalima naudoti jei laiškas turi priedų.  Naudoti PGP/MIME?"
 
-#: ncrypt/crypt.c:159
+#: ncrypt/crypt.c:165
 msgid "Mail not sent: inline PGP can't be used with attachments."
 msgstr "Laiškas neišsiųstas: inline PGP negalima naudoti, jei laiškas turi priedų."
 
-#: ncrypt/crypt.c:166
+#: ncrypt/crypt.c:172
 msgid "Inline PGP can't be used with format=flowed.  Revert to PGP/MIME?"
 msgstr "Inline PGP negalima naudoti su format=flowed.  Naudoti PGP/MIME?"
 
-#: ncrypt/crypt.c:170
+#: ncrypt/crypt.c:176
 msgid "Mail not sent: inline PGP can't be used with format=flowed."
 msgstr "Laiškas neišsiųstas: inline PGP negalima naudoti su format=flowed."
 
-#: ncrypt/crypt.c:180 ncrypt/cryptglue.c:125 ncrypt/pgpkey.c:589
+#: ncrypt/crypt.c:186 ncrypt/cryptglue.c:125 ncrypt/pgpkey.c:589
 #: ncrypt/pgpkey.c:782
 msgid "Invoking PGP..."
 msgstr "Kviečiu PGP..."
 
-#: ncrypt/crypt.c:192
+#: ncrypt/crypt.c:198
 msgid "Message can't be sent inline.  Revert to using PGP/MIME?"
 msgstr "Laiško nepavyko išsiųsti inline formatu.  Naudoti PGP/MIME?"
 
-#: ncrypt/crypt.c:194 send.c:1824
+#: ncrypt/crypt.c:200 send.c:1824
 msgid "Mail not sent."
 msgstr "Laiškas neišsiųstas."
 
-#: ncrypt/crypt.c:540
+#: ncrypt/crypt.c:546
 msgid "S/MIME messages with no hints on content are unsupported."
 msgstr "S/MIME laiškai be turinio užuominų nepalaikomi."
 
-#: ncrypt/crypt.c:754 ncrypt/crypt.c:795
+#: ncrypt/crypt.c:760 ncrypt/crypt.c:801
 msgid "Trying to extract PGP keys...\n"
 msgstr "Bandau išgauti PGP raktus...\n"
 
-#: ncrypt/crypt.c:776 ncrypt/crypt.c:816
+#: ncrypt/crypt.c:782 ncrypt/crypt.c:822
 msgid "Trying to extract S/MIME certificates...\n"
 msgstr "Bandau išgauti S/MIME sertifikatus...\n"
 
-#: ncrypt/crypt.c:976
+#: ncrypt/crypt.c:982
 #, c-format
 msgid ""
 "[-- Error: Unknown multipart/signed protocol %s! --]\n"
@@ -3338,7 +3409,7 @@ msgstr ""
 "[-- Klaida: Nežinomas multipart/signed protokolas %s! --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1016
+#: ncrypt/crypt.c:1022
 msgid ""
 "[-- Error: Missing or bad-format multipart/signed signature! --]\n"
 "\n"
@@ -3346,7 +3417,7 @@ msgstr ""
 "[-- Klaida: Trūksta multipart/signed parašo arba jis blogo formato! --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1058
+#: ncrypt/crypt.c:1064
 #, c-format
 msgid ""
 "[-- Warning: We can't verify %s/%s signatures. --]\n"
@@ -3355,7 +3426,7 @@ msgstr ""
 "[-- Dėmesio: Negaliu patikrinti %s/%s parašo. --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1070
+#: ncrypt/crypt.c:1076
 msgid ""
 "[-- The following data is signed --]\n"
 "\n"
@@ -3363,7 +3434,7 @@ msgstr ""
 "[-- Toliau einantys duomenys yra pasirašyti --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1075
+#: ncrypt/crypt.c:1081
 msgid ""
 "[-- Warning: Can't find any signatures. --]\n"
 "\n"
@@ -3371,7 +3442,7 @@ msgstr ""
 "[-- Dėmesio: Negaliu rasti jokių parašų --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1081
+#: ncrypt/crypt.c:1087
 msgid ""
 "\n"
 "[-- End of signed data --]\n"
@@ -3422,7 +3493,7 @@ msgstr "[tempfile]"
 msgid "error reading data object: %s\n"
 msgstr "klaida skaitant duomenų objektą: %s\n"
 
-#: ncrypt/crypt_gpgme.c:662 ncrypt/crypt_gpgme.c:3848 ncrypt/pgpkey.c:585
+#: ncrypt/crypt_gpgme.c:662 ncrypt/crypt_gpgme.c:3850 ncrypt/pgpkey.c:585
 #: ncrypt/pgpkey.c:768
 msgid "Can't create temporary file"
 msgstr "Negaliu sukurti laikinos bylos"
@@ -3770,28 +3841,31 @@ msgstr "[Blogas]"
 
 #. L10N: This is printed after "Key Type: " and looks like this:
 #. *       PGP, 2048 bit RSA
-#: ncrypt/crypt_gpgme.c:3670 ncrypt/crypt_gpgme.c:3808
-#, c-format
+#: ncrypt/crypt_gpgme.c:3670 ncrypt/crypt_gpgme.c:3810
+#, fuzzy, c-format
 msgid "%s, %lu bit %s\n"
-msgstr "%s, %lu bitų %s\n"
+msgid_plural "%s, %lu bit %s\n"
+msgstr[0] "%s, %lu bitų %s\n"
+msgstr[1] "%s, %lu bitų %s\n"
+msgstr[2] "%s, %lu bitų %s\n"
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3678 ncrypt/crypt_gpgme.c:3815
+#: ncrypt/crypt_gpgme.c:3678 ncrypt/crypt_gpgme.c:3817
 msgid "encryption"
 msgstr "šifravimui"
 
 #: ncrypt/crypt_gpgme.c:3679 ncrypt/crypt_gpgme.c:3685
-#: ncrypt/crypt_gpgme.c:3816 ncrypt/crypt_gpgme.c:3821
+#: ncrypt/crypt_gpgme.c:3818 ncrypt/crypt_gpgme.c:3823
 msgid ", "
 msgstr ", "
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3684 ncrypt/crypt_gpgme.c:3820
+#: ncrypt/crypt_gpgme.c:3684 ncrypt/crypt_gpgme.c:3822
 msgid "signing"
 msgstr "pasirašymui"
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3690 ncrypt/crypt_gpgme.c:3825
+#: ncrypt/crypt_gpgme.c:3690 ncrypt/crypt_gpgme.c:3827
 msgid "certification"
 msgstr "sertifikavimui"
 
@@ -3810,64 +3884,64 @@ msgstr "[Pasenęs]"
 msgid "[Disabled]"
 msgstr "[Uždraustas]"
 
-#: ncrypt/crypt_gpgme.c:3851
+#: ncrypt/crypt_gpgme.c:3853
 msgid "Collecting data..."
 msgstr "Renku duomenis..."
 
-#: ncrypt/crypt_gpgme.c:3876
+#: ncrypt/crypt_gpgme.c:3878
 #, c-format
 msgid "Error finding issuer key: %s\n"
 msgstr "Klaida ieškant išdavėjo rakto: %s\n"
 
-#: ncrypt/crypt_gpgme.c:3885
+#: ncrypt/crypt_gpgme.c:3887
 msgid "Error: certification chain too long - stopping here\n"
 msgstr "Klaida: sertifikavimo grandinė per ilga - stoju čia\n"
 
-#: ncrypt/crypt_gpgme.c:3895 ncrypt/pgpkey.c:608
+#: ncrypt/crypt_gpgme.c:3897 ncrypt/pgpkey.c:608
 #, c-format
 msgid "Key ID: 0x%s"
 msgstr "Rakto ID: 0x%s"
 
-#: ncrypt/crypt_gpgme.c:3990
+#: ncrypt/crypt_gpgme.c:3992
 #, c-format
 msgid "gpgme_new failed: %s"
 msgstr "gpgme_new nepavyko: %s"
 
-#: ncrypt/crypt_gpgme.c:4028 ncrypt/crypt_gpgme.c:4079
+#: ncrypt/crypt_gpgme.c:4030 ncrypt/crypt_gpgme.c:4081
 #, c-format
 msgid "gpgme_op_keylist_start failed: %s"
 msgstr "gpgme_op_keylist_start nepavyko: %s"
 
-#: ncrypt/crypt_gpgme.c:4067 ncrypt/crypt_gpgme.c:4109
+#: ncrypt/crypt_gpgme.c:4069 ncrypt/crypt_gpgme.c:4111
 #, c-format
 msgid "gpgme_op_keylist_next failed: %s"
 msgstr "gpgme_op_keylist_next nepavyko: %s"
 
-#: ncrypt/crypt_gpgme.c:4185
+#: ncrypt/crypt_gpgme.c:4187
 msgid "All matching keys are marked expired/revoked."
 msgstr "Visi rasti raktai pažymėti kaip pasenę arba atšaukti."
 
-#: ncrypt/crypt_gpgme.c:4215 ncrypt/pgpkey.c:543 ncrypt/smime.c:475
+#: ncrypt/crypt_gpgme.c:4217 ncrypt/pgpkey.c:543 ncrypt/smime.c:475
 msgid "Select  "
 msgstr "Pasirink  "
 
-#: ncrypt/crypt_gpgme.c:4217 ncrypt/pgpkey.c:545
+#: ncrypt/crypt_gpgme.c:4219 ncrypt/pgpkey.c:545
 msgid "Check key  "
 msgstr "Tikrinti raktą  "
 
-#: ncrypt/crypt_gpgme.c:4233
+#: ncrypt/crypt_gpgme.c:4235
 msgid "PGP and S/MIME keys matching"
 msgstr "PGP ir S/MIME raktai, atitinkantys"
 
-#: ncrypt/crypt_gpgme.c:4235
+#: ncrypt/crypt_gpgme.c:4237
 msgid "PGP keys matching"
 msgstr "PGP raktai, atitinkantys"
 
-#: ncrypt/crypt_gpgme.c:4237
+#: ncrypt/crypt_gpgme.c:4239
 msgid "S/MIME keys matching"
 msgstr "S/MIME raktai, atitinkantys"
 
-#: ncrypt/crypt_gpgme.c:4239
+#: ncrypt/crypt_gpgme.c:4241
 msgid "keys matching"
 msgstr "raktai, atitinkantys"
 
@@ -3875,65 +3949,65 @@ msgstr "raktai, atitinkantys"
 #. %1$s is one of the previous four entries.
 #. %2$s is an address.
 #. e.g. "S/MIME keys matching <me@mutt.org>."
-#: ncrypt/crypt_gpgme.c:4246
+#: ncrypt/crypt_gpgme.c:4248
 #, c-format
 msgid "%s <%s>."
 msgstr "%s <%s>."
 
 #. L10N:
 #. e.g. 'S/MIME keys matching "Michael Elkins".'
-#: ncrypt/crypt_gpgme.c:4250
+#: ncrypt/crypt_gpgme.c:4252
 #, c-format
 msgid "%s \"%s\"."
 msgstr "%s \"%s\"."
 
-#: ncrypt/crypt_gpgme.c:4277 ncrypt/pgpkey.c:628
+#: ncrypt/crypt_gpgme.c:4279 ncrypt/pgpkey.c:628
 msgid "This key can't be used: expired/disabled/revoked."
 msgstr "Šis raktas negali būti naudojamas: jis pasenęs/uždraustas/atšauktas."
 
-#: ncrypt/crypt_gpgme.c:4290 ncrypt/pgpkey.c:640 ncrypt/smime.c:505
+#: ncrypt/crypt_gpgme.c:4292 ncrypt/pgpkey.c:640 ncrypt/smime.c:505
 msgid "ID is expired/disabled/revoked. Do you really want to use the key?"
 msgstr "ID pasenęs/uždraustas/atšauktas. Ar tikrai nori naudoti šį raktą?"
 
-#: ncrypt/crypt_gpgme.c:4299 ncrypt/pgpkey.c:650
+#: ncrypt/crypt_gpgme.c:4301 ncrypt/pgpkey.c:650
 msgid "ID is not valid. Do you really want to use the key?"
 msgstr "ID yra nepatikimas. Ar tikrai nori naudoti šį raktą?"
 
-#: ncrypt/crypt_gpgme.c:4302 ncrypt/pgpkey.c:653
+#: ncrypt/crypt_gpgme.c:4304 ncrypt/pgpkey.c:653
 msgid "ID is only marginally valid. Do you really want to use the key?"
 msgstr "ID yra tik vos vos patikimas. Ar tikrai nori naudoti šį raktą?"
 
-#: ncrypt/crypt_gpgme.c:4310 ncrypt/pgpkey.c:646 ncrypt/smime.c:509
+#: ncrypt/crypt_gpgme.c:4312 ncrypt/pgpkey.c:646 ncrypt/smime.c:509
 msgid "ID has undefined validity. Do you really want to use the key?"
 msgstr "ID patikimumas nežinomas. Ar tikrai nori naudoti šį raktą?"
 
-#: ncrypt/crypt_gpgme.c:4370 ncrypt/crypt_gpgme.c:4479 ncrypt/pgpkey.c:872
+#: ncrypt/crypt_gpgme.c:4372 ncrypt/crypt_gpgme.c:4481 ncrypt/pgpkey.c:872
 #: ncrypt/pgpkey.c:995
 #, c-format
 msgid "Looking for keys matching \"%s\"..."
 msgstr "Ieškau raktų, tenkinančių \"%s\"..."
 
-#: ncrypt/crypt_gpgme.c:4593 ncrypt/pgpkey.c:731 ncrypt/smime.c:811
+#: ncrypt/crypt_gpgme.c:4595 ncrypt/pgpkey.c:731 ncrypt/smime.c:811
 #, c-format
 msgid "No matching keys found for \"%s\""
 msgstr "Neradau raktų, tenkinančių \"%s\""
 
-#: ncrypt/crypt_gpgme.c:4644 ncrypt/pgp.c:1263
+#: ncrypt/crypt_gpgme.c:4646 ncrypt/pgp.c:1263
 #, c-format
 msgid "Use keyID = \"%s\" for %s?"
 msgstr "Naudoti raktą ID = \"%s\", skirtą %s?"
 
-#: ncrypt/crypt_gpgme.c:4695 ncrypt/pgp.c:1312 ncrypt/smime.c:830
+#: ncrypt/crypt_gpgme.c:4697 ncrypt/pgp.c:1312 ncrypt/smime.c:830
 #: ncrypt/smime.c:938
 #, c-format
 msgid "Enter keyID for %s: "
 msgstr "Įvesk rakto ID, skirtą %s: "
 
-#: ncrypt/crypt_gpgme.c:4755 ncrypt/pgpkey.c:751
+#: ncrypt/crypt_gpgme.c:4757 ncrypt/pgpkey.c:751
 msgid "Please enter the key ID: "
 msgstr "Prašau, įvesk rakto ID: "
 
-#: ncrypt/crypt_gpgme.c:4768
+#: ncrypt/crypt_gpgme.c:4770
 #, c-format
 msgid "Error exporting key: %s\n"
 msgstr "Klaida eksportuojant raktą: %s\n"
@@ -3942,80 +4016,80 @@ msgstr "Klaida eksportuojant raktą: %s\n"
 #. MIME description for exported (attached) keys.
 #. You can translate this entry to a non-ASCII string (it will be encoded),
 #. but it may be safer to keep it untranslated.
-#: ncrypt/crypt_gpgme.c:4787
+#: ncrypt/crypt_gpgme.c:4789
 #, c-format
 msgid "PGP Key 0x%s."
 msgstr "PGP raktas 0x%s."
 
-#: ncrypt/crypt_gpgme.c:4830
+#: ncrypt/crypt_gpgme.c:4832
 msgid "GPGME: OpenPGP protocol not available"
 msgstr "GPGME: OpenPGP protokolas nepasiekiamas"
 
-#: ncrypt/crypt_gpgme.c:4838
+#: ncrypt/crypt_gpgme.c:4840
 msgid "GPGME: CMS protocol not available"
 msgstr "GPGME: CMS protokolas nepasiekiamas"
 
-#: ncrypt/crypt_gpgme.c:4876
+#: ncrypt/crypt_gpgme.c:4878
 msgid "S/MIME (s)ign, sign (a)s, (p)gp, (c)lear, or (o)ppenc mode off? "
 msgstr "S/MIME: pa(s)irašyti, pasirašyt k(a)ip, (p)gp, (n)ereikia ar išjungti (o)portunistinį šifravimą? "
 
 #. L10N: S/MIME options (opportunistic encryption is on)
-#: ncrypt/crypt_gpgme.c:4878
+#: ncrypt/crypt_gpgme.c:4880
 msgid "sapco"
 msgstr "sapno"
 
-#: ncrypt/crypt_gpgme.c:4885
+#: ncrypt/crypt_gpgme.c:4887
 msgid "PGP (s)ign, sign (a)s, s/(m)ime, (c)lear, or (o)ppenc mode off? "
 msgstr "PGP: pa(s)irašyti, pasirašyt k(a)ip, s/(m)ime, (n)ereikia ar išjungti (o)portunistinį šifravimą? "
 
 #. L10N: PGP options (opportunistic encryption is on)
-#: ncrypt/crypt_gpgme.c:4887
+#: ncrypt/crypt_gpgme.c:4889
 msgid "samco"
 msgstr "samno"
 
 #. L10N: S/MIME options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4900
+#: ncrypt/crypt_gpgme.c:4902
 msgid "S/MIME (e)ncrypt, (s)ign, sign (a)s, (b)oth, (p)gp, (c)lear, or (o)ppenc mode? "
 msgstr "S/MIME: (š)ifruoti, pa(s)irašyti, pasirašyti k(a)ip, a(b)u, (p)gp, (n)ereikia ar įjungti (o)portunistinį šifravimą? "
 
 #. L10N: S/MIME options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4903
+#: ncrypt/crypt_gpgme.c:4905
 msgid "esabpco"
 msgstr "šsabpno"
 
 #. L10N: PGP options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4909
+#: ncrypt/crypt_gpgme.c:4911
 msgid "PGP (e)ncrypt, (s)ign, sign (a)s, (b)oth, s/(m)ime, (c)lear, or (o)ppenc mode? "
 msgstr "PGP: (š)ifruoti, pa(s)irašyti, pasirašyti k(a)ip, a(b)u, s/(m)ime, (n)ereikia ar įjungti (o)portunistinį šifravimą? "
 
 #. L10N: PGP options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4912
+#: ncrypt/crypt_gpgme.c:4914
 msgid "esabmco"
 msgstr "šsabmno"
 
-#: ncrypt/crypt_gpgme.c:4925
+#: ncrypt/crypt_gpgme.c:4927
 msgid "S/MIME (e)ncrypt, (s)ign, sign (a)s, (b)oth, (p)gp or (c)lear? "
 msgstr "S/MIME: (š)ifruoti, pa(s)irašyti, pasirašyti k(a)ip, a(b)u, (p)gp ar (n)ereikia? "
 
 #. L10N: S/MIME options
-#: ncrypt/crypt_gpgme.c:4927
+#: ncrypt/crypt_gpgme.c:4929
 msgid "esabpc"
 msgstr "šsabpn"
 
-#: ncrypt/crypt_gpgme.c:4934
+#: ncrypt/crypt_gpgme.c:4936
 msgid "PGP (e)ncrypt, (s)ign, sign (a)s, (b)oth, s/(m)ime or (c)lear? "
 msgstr "PGP: (š)ifruoti, pa(s)irašyti, pasirašyti k(a)ip, a(b)u, s/(m)ime ar (n)ereikia? "
 
 #. L10N: PGP options
-#: ncrypt/crypt_gpgme.c:4936
+#: ncrypt/crypt_gpgme.c:4938
 msgid "esabmc"
 msgstr "šsabmn"
 
-#: ncrypt/crypt_gpgme.c:5087
+#: ncrypt/crypt_gpgme.c:5089
 msgid "Failed to verify sender"
 msgstr "Nepavyko patikrinti siuntėjo"
 
-#: ncrypt/crypt_gpgme.c:5090
+#: ncrypt/crypt_gpgme.c:5092
 msgid "Failed to figure out sender"
 msgstr "Nepavyko išsiaiškinti, kas siuntėjas"
 
@@ -4403,7 +4477,7 @@ msgstr "Nenurodytas nė vienas naujienų serveris!"
 msgid "%s is an invalid news server specification!"
 msgstr "%s yra bloga naujienų serverio speficikacija!"
 
-#: nntp.c:75 nntp.c:612 pop.c:1028 pop_lib.c:405
+#: nntp.c:75 nntp.c:612 pop.c:1031 pop_lib.c:405
 msgid "Server closed connection!"
 msgstr "Serveris uždarė jungtį!"
 
@@ -4561,15 +4635,18 @@ msgid "check mailboxes for new mail"
 msgstr "tikrinti, ar dėžutėse yra naujo pašto"
 
 #: opcodes.h:47
-msgid "attach file(s) to this message"
+#, fuzzy
+msgid "attach files to this message"
 msgstr "prisegti bylą(as) prie šio laiško"
 
 #: opcodes.h:48
-msgid "attach message(s) to this message"
+#, fuzzy
+msgid "attach messages to this message"
 msgstr "prisegti laišką(as) prie šio laiško"
 
 #: opcodes.h:49
-msgid "attach news article(s) to this message"
+#, fuzzy
+msgid "attach news articles to this message"
 msgstr "prisegti naujienų straipsnį(us) prie šio laiško"
 
 #: opcodes.h:50
@@ -5385,7 +5462,8 @@ msgid "extract supported public keys"
 msgstr "ištraukti palaikomus viešus raktus"
 
 #: opcodes.h:255
-msgid "wipe passphrase(s) from memory"
+#, fuzzy
+msgid "wipe passphrases from memory"
 msgstr "užmiršti slaptą frazę"
 
 #: opcodes.h:259
@@ -5716,18 +5794,21 @@ msgstr "Nėra naujų laiškų POP dėžutėje."
 msgid "Delete messages from server?"
 msgstr "Ištrinti laiškus iš serverio?"
 
-#: pop.c:954
-#, c-format
-msgid "Reading new messages (%d bytes)..."
-msgstr "Skaitau naujus laiškus (%d baitų)..."
+#: pop.c:955
+#, fuzzy, c-format
+msgid "Reading new messages (%d byte)..."
+msgid_plural "Reading new messages (%d bytes)..."
+msgstr[0] "Skaitau naujus laiškus (%d baitų)..."
+msgstr[1] "Skaitau naujus laiškus (%d baitų)..."
+msgstr[2] "Skaitau naujus laiškus (%d baitų)..."
 
-#: pop.c:997
+#: pop.c:1000
 msgid "Error while writing mailbox!"
 msgstr "Klaida rašant į pašto dėžutę!"
 
 #. L10N: The plural is picked by the second numerical argument, i.e.
 #. * the %d right before 'messages', i.e. the total number of messages.
-#: pop.c:1003
+#: pop.c:1006
 #, c-format
 msgid "%s [%d of %d message read]"
 msgid_plural "%s [%d of %d messages read]"
@@ -5872,47 +5953,55 @@ msgstr "Pipe į: "
 msgid "I don't know how to print %s attachments!"
 msgstr "Aš nežinau kaip spausdinti %s priedus!"
 
-#: recvattach.c:841
-msgid "Print tagged attachment(s)?"
-msgstr "Spausdinti pažymėtus priedus?"
+#. L10N: Although we now the precise number of tagged messages, we
+#. do not show it to the user.  So feel free to use a "generic
+#. plural" as plural translation if your language has one.
+#: recvattach.c:852
+#, fuzzy, c-format
+msgid "Print tagged attachment?"
+msgid_plural "Print %d tagged attachments?"
+msgstr[0] "Spausdinti pažymėtus priedus?"
+msgstr[1] "Spausdinti pažymėtus priedus?"
+msgstr[2] "Spausdinti pažymėtus priedus?"
 
-#: recvattach.c:842
+#: recvattach.c:853
+#, c-format
 msgid "Print attachment?"
 msgstr "Spausdinti priedą?"
 
-#: recvattach.c:900
+#: recvattach.c:913
 msgid "Structural changes to decrypted attachments are not supported"
 msgstr "Struktūriniai iššifruotų priedų pakeitimai nepalaikomi"
 
-#: recvattach.c:1046
+#: recvattach.c:1059
 msgid "Can't decrypt encrypted message!"
 msgstr "Negaliu iššifruoti užšifruoti laiško!"
 
-#: recvattach.c:1172
+#: recvattach.c:1185
 msgid "Attachments"
 msgstr "Priedai"
 
-#: recvattach.c:1210
+#: recvattach.c:1223
 msgid "There are no subparts to show!"
 msgstr "Nėra vidinių dalių!"
 
-#: recvattach.c:1265
+#: recvattach.c:1278
 msgid "Can't delete attachment from POP server."
 msgstr "Negaliu ištrinti priedo iš POP serverio."
 
-#: recvattach.c:1274
+#: recvattach.c:1287
 msgid "Can't delete attachment from news server."
 msgstr "Negaliu ištrinti priedo iš naujienų serverio."
 
-#: recvattach.c:1281
+#: recvattach.c:1294
 msgid "Deletion of attachments from encrypted messages is unsupported."
 msgstr "Užšifruotų laiškų priedų ištrynimas nepalaikomas."
 
-#: recvattach.c:1287
+#: recvattach.c:1300
 msgid "Deletion of attachments from signed messages may invalidate the signature."
 msgstr "Pasirašytų laiškų priedų ištrynimas gali sugadinti parašą."
 
-#: recvattach.c:1305 recvattach.c:1320
+#: recvattach.c:1318 recvattach.c:1333
 msgid "Only deletion of multipart attachments is supported."
 msgstr "Palaikomas trynimas tik iš keleto dalių priedų."
 
@@ -6342,3 +6431,13 @@ msgstr "Įprastos parinktys:"
 #: version.c:404
 msgid "Compile options:"
 msgstr "Kompiliavimo parinktys:"
+
+#~ msgid "Cannot delete message(s)"
+#~ msgstr "Negaliu ištrinti laiškų."
+
+#~ msgid "Cannot undelete message(s)"
+#~ msgstr "Negaliu sugrąžinti laiškų."
+
+#, fuzzy
+#~ msgid "messages not deleted"
+#~ msgstr "laiškas/ai neištrinti"

--- a/po/nl.po
+++ b/po/nl.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neomutt-20180512\n"
 "Report-Msgid-Bugs-To: neomutt-devel@neomutt.org\n"
-"POT-Creation-Date: 2018-05-20 02:02+0000\n"
+"POT-Creation-Date: 2018-05-22 14:18+0000\n"
 "PO-Revision-Date: 2017-02-22 20:12+0100\n"
 "Last-Translator: Benno Schulenberg <benno@vertaalt.nl>\n"
 "Language-Team: Dutch <vertaling@vrijschrift.org>\n"
@@ -40,7 +40,7 @@ msgstr "Selecteren"
 
 #: addrbook.c:52 browser.c:75 browser.c:87 compose.c:160 compose.c:172
 #: conn/ssl.c:1041 conn/ssl_gnutls.c:793 curs_main.c:748 curs_main.c:761
-#: history.c:106 ncrypt/crypt_gpgme.c:4219 ncrypt/pgpkey.c:547
+#: history.c:106 ncrypt/crypt_gpgme.c:4221 ncrypt/pgpkey.c:547
 #: ncrypt/smime.c:477 pager.c:2141 postpone.c:65 query.c:72 recvattach.c:70
 msgid "Help"
 msgstr "Hulp"
@@ -687,7 +687,7 @@ msgstr ""
 #. * Since it shares the row with "Encrypt with:", it should not be longer
 #. * than 15-20 character cells.
 #.
-#: compose.c:138 ncrypt/crypt_gpgme.c:4947 ncrypt/pgp.c:1786
+#: compose.c:138 ncrypt/crypt_gpgme.c:4949 ncrypt/pgp.c:1786
 #: ncrypt/smime.c:2127
 msgid "Sign as: "
 msgstr "Ondertekenen als: "
@@ -1225,7 +1225,7 @@ msgstr "(w)eigeren, (e)enmalig toelaten, (s)kip"
 msgid "(r)eject, accept (o)nce"
 msgstr "(w)eigeren, (e)enmalig toelaten"
 
-#: conn/ssl.c:1039 conn/ssl_gnutls.c:791 ncrypt/crypt_gpgme.c:4213
+#: conn/ssl.c:1039 conn/ssl_gnutls.c:791 ncrypt/crypt_gpgme.c:4215
 #: ncrypt/pgpkey.c:541 ncrypt/smime.c:473
 msgid "Exit  "
 msgstr "Einde "
@@ -1404,11 +1404,11 @@ msgstr "Er is geen postvak geopend."
 msgid "There are no messages."
 msgstr "Er zijn geen berichten."
 
-#: curs_main.c:77 mx.c:1061 pager.c:73 recvattach.c:56
+#: curs_main.c:77 mx.c:1071 pager.c:73 recvattach.c:56
 msgid "Mailbox is read-only."
 msgstr "Postvak is schrijfbeveiligd."
 
-#: curs_main.c:79 pager.c:75 recvattach.c:1145
+#: curs_main.c:79 pager.c:75 recvattach.c:1158
 msgid "Function not permitted in attach-message mode."
 msgstr "Functie wordt niet ondersteund in deze modus"
 
@@ -1542,244 +1542,254 @@ msgid "That message is not visible."
 msgstr "Dat bericht is niet zichtbaar."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:1377 curs_main.c:2772 pager.c:2818
-msgid "Cannot delete message(s)"
+#. L10N: Due to the implementation details we do not know whether we
+#. delete zero, 1, 12, ... messages. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:1381 curs_main.c:2784 pager.c:2822
+#, fuzzy
+msgid "Cannot delete messages"
 msgstr "Kan bericht(en) niet verwijderen"
 
-#: curs_main.c:1380
+#: curs_main.c:1384
 msgid "Delete messages matching: "
 msgstr "Wis berichten volgens patroon: "
 
-#: curs_main.c:1421
+#: curs_main.c:1425
 msgid "No limit pattern is in effect."
 msgstr "Er is geen beperkend patroon in werking."
 
 #. L10N: ask for a limit to apply
-#: curs_main.c:1426
+#: curs_main.c:1430
 #, c-format
 msgid "Limit: %s"
 msgstr "Limiet: %s"
 
-#: curs_main.c:1464
+#: curs_main.c:1468
 msgid "Limit to messages matching: "
 msgstr "Beperk berichten volgens patroon: "
 
-#: curs_main.c:1488
+#: curs_main.c:1492
 msgid "To view all messages, limit to \"all\"."
 msgstr "Beperk op \"all\" om alle berichten te bekijken."
 
-#: curs_main.c:1500 pager.c:2318
+#: curs_main.c:1504 pager.c:2318
 msgid "Quit NeoMutt?"
 msgstr "NeoMutt afsluiten?"
 
-#: curs_main.c:1596
+#: curs_main.c:1600
 msgid "Tag messages matching: "
 msgstr "Markeer berichten volgens patroon: "
 
 #. L10N: CHECK_ACL
-#: curs_main.c:1606 curs_main.c:3203 pager.c:3137
-msgid "Cannot undelete message(s)"
+#. L10N: Due to the implementation details we do not know whether we
+#. undelete zero, 1, 12, ... messages. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:1614 curs_main.c:3223 pager.c:3145
+#, fuzzy
+msgid "Cannot undelete messages"
 msgstr "Kan bericht(en) niet herstellen"
 
-#: curs_main.c:1609
+#: curs_main.c:1617
 msgid "Undelete messages matching: "
 msgstr "Herstel berichten volgens patroon: "
 
-#: curs_main.c:1619
+#: curs_main.c:1627
 msgid "Untag messages matching: "
 msgstr "Verwijder markering volgens patroon: "
 
-#: curs_main.c:1653
+#: curs_main.c:1661
 msgid "Logged out of IMAP servers."
 msgstr "Uitgelogd uit IMAP-servers."
 
-#: curs_main.c:1753
+#: curs_main.c:1761
 #, fuzzy
 msgid "No virtual folder, aborting."
 msgstr "Geen onderwerp. Operatie afgebroken."
 
-#: curs_main.c:1761
+#: curs_main.c:1769
 msgid "Failed to read thread, aborting."
 msgstr ""
 
-#: curs_main.c:1793 mx.c:1458 mx.c:1475
+#: curs_main.c:1801 mx.c:1468 mx.c:1485
 #, fuzzy
 msgid "Folder doesn't support tagging, aborting."
 msgstr "SMTP-server ondersteunt geen authenticatie"
 
-#: curs_main.c:1808
+#: curs_main.c:1816
 #, fuzzy
 msgid "No tag specified, aborting."
 msgstr "Geen onderwerp. Operatie afgebroken."
 
-#: curs_main.c:1820
+#: curs_main.c:1828
 #, c-format
 msgid "Update tags..."
 msgstr ""
 
-#: curs_main.c:1857
+#: curs_main.c:1865
 msgid "Failed to modify tags, aborting."
 msgstr ""
 
-#: curs_main.c:1898
+#: curs_main.c:1906
 #, fuzzy
 msgid "No query, aborting."
 msgstr "Geen onderwerp. Operatie afgebroken."
 
-#: curs_main.c:1902 curs_main.c:1922 curs_main.c:1941
+#: curs_main.c:1910 curs_main.c:1930 curs_main.c:1949
 msgid "Failed to create query, aborting."
 msgstr ""
 
-#: curs_main.c:1911 curs_main.c:1930
+#: curs_main.c:1919 curs_main.c:1938
 msgid "Windowed queries disabled."
 msgstr ""
 
-#: curs_main.c:1916 curs_main.c:1935
+#: curs_main.c:1924 curs_main.c:1943
 msgid "No notmuch vfolder currently loaded."
 msgstr ""
 
-#: curs_main.c:1973
+#: curs_main.c:1981
 msgid "Open mailbox in read-only mode"
 msgstr "Open postvak in schrijfbeveiligde modus"
 
-#: curs_main.c:1976
+#: curs_main.c:1984
 #, fuzzy
 msgid "Open virtual folder"
 msgstr "open een ander postvak"
 
-#: curs_main.c:1979
+#: curs_main.c:1987
 msgid "Open mailbox"
 msgstr "Open postvak"
 
-#: curs_main.c:1989
+#: curs_main.c:1997
 msgid "No mailboxes have new mail"
 msgstr "Geen postvak met nieuwe berichten"
 
-#: curs_main.c:2036
+#: curs_main.c:2044
 #, fuzzy
 msgid "Open newsgroup in read-only mode"
 msgstr "Open postvak in schrijfbeveiligde modus"
 
-#: curs_main.c:2038
+#: curs_main.c:2046
 msgid "Open newsgroup"
 msgstr ""
 
-#: curs_main.c:2141
+#: curs_main.c:2149
 #, fuzzy
 msgid "Exit NeoMutt without saving?"
 msgstr "NeoMutt verlaten zonder op te slaan?"
 
-#: curs_main.c:2157
+#: curs_main.c:2165
 #, fuzzy
 msgid "Cannot break thread"
 msgstr "Kan threads niet linken"
 
-#: curs_main.c:2160 curs_main.c:2198 curs_main.c:2658 curs_main.c:2690
+#: curs_main.c:2168 curs_main.c:2206 curs_main.c:2666 curs_main.c:2698
 #: flags.c:376 thread.c:1078 thread.c:1134 thread.c:1202
 msgid "Threading is not enabled."
 msgstr "Het weergeven van threads is niet ingeschakeld."
 
-#: curs_main.c:2173
+#: curs_main.c:2181
 msgid "Thread broken"
 msgstr "Thread is verbroken"
 
-#: curs_main.c:2185
+#: curs_main.c:2193
 msgid "Thread cannot be broken, message is not part of a thread"
 msgstr "Thread kan niet verbroken worden; bericht is geen deel van een thread"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2195
+#: curs_main.c:2203
 msgid "Cannot link threads"
 msgstr "Kan threads niet linken"
 
-#: curs_main.c:2200
+#: curs_main.c:2208
 msgid "No Message-ID: header available to link thread"
 msgstr "Er is geen 'Message-ID'-kopregel beschikbaar om thread te koppelen"
 
-#: curs_main.c:2202
+#: curs_main.c:2210
 msgid "First, please tag a message to be linked here"
 msgstr "Markeer eerst een bericht om hieraan te koppelen"
 
-#: curs_main.c:2213
+#: curs_main.c:2221
 msgid "Threads linked"
 msgstr "Threads gekoppeld"
 
-#: curs_main.c:2216
+#: curs_main.c:2224
 msgid "No thread linked"
 msgstr "Geen thread gekoppeld"
 
-#: curs_main.c:2252 curs_main.c:2278
+#: curs_main.c:2260 curs_main.c:2286
 msgid "You are on the last message."
 msgstr "Dit is het laatste bericht."
 
-#: curs_main.c:2260 curs_main.c:2305
+#: curs_main.c:2268 curs_main.c:2313
 msgid "No undeleted messages."
 msgstr "Alle berichten zijn gewist."
 
-#: curs_main.c:2297 curs_main.c:2323
+#: curs_main.c:2305 curs_main.c:2331
 msgid "You are on the first message."
 msgstr "Dit is het eerste bericht."
 
-#: curs_main.c:2395 menu.c:970 pager.c:2440 pattern.c:2110
+#: curs_main.c:2403 menu.c:970 pager.c:2440 pattern.c:2110
 msgid "Search wrapped to top."
 msgstr "Zoekopdracht is bovenaan herbegonnen."
 
-#: curs_main.c:2404 pager.c:2463 pattern.c:2121
+#: curs_main.c:2412 pager.c:2463 pattern.c:2121
 msgid "Search wrapped to bottom."
 msgstr "Zoekopdracht is onderaan herbegonnen."
 
-#: curs_main.c:2447
+#: curs_main.c:2455
 msgid "No new messages in this limited view."
 msgstr "Geen nieuwe berichten in deze beperkte weergave."
 
-#: curs_main.c:2449
+#: curs_main.c:2457
 msgid "No new messages."
 msgstr "Geen nieuwe berichten."
 
-#: curs_main.c:2454
+#: curs_main.c:2462
 msgid "No unread messages in this limited view."
 msgstr "Geen ongelezen berichten in deze beperkte weergave."
 
-#: curs_main.c:2456
+#: curs_main.c:2464
 msgid "No unread messages."
 msgstr "Geen ongelezen berichten."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2474
+#: curs_main.c:2482
 msgid "Cannot flag message"
 msgstr "Kan bericht niet markeren"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2513 pager.c:3100
+#: curs_main.c:2521 pager.c:3104
 msgid "Cannot toggle new"
 msgstr "Kan 'nieuw'-markering niet omschakelen"
 
-#: curs_main.c:2590
+#: curs_main.c:2598
 msgid "No more threads."
 msgstr "Geen verdere threads."
 
-#: curs_main.c:2592
+#: curs_main.c:2600
 msgid "You are on the first thread."
 msgstr "U bent al bij de eerste thread."
 
-#: curs_main.c:2676
+#: curs_main.c:2684
 #, fuzzy
 msgid "Thread contains unread or flagged messages."
 msgstr "Thread bevat ongelezen berichten"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2726 pager.c:2784
+#: curs_main.c:2734 pager.c:2784
 msgid "Cannot delete message"
 msgstr "Kan bericht niet verwijderen"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2838
+#: curs_main.c:2850
 msgid "Cannot edit message"
 msgstr "Kan bericht niet bewerken"
 
 #. L10N: This is displayed when the x-label on one or more
 #. * messages is edited.
-#: curs_main.c:2900 pager.c:3200
+#: curs_main.c:2912 pager.c:3208
 #, fuzzy, c-format
 msgid "%d label changed."
 msgid_plural "%d labels changed."
@@ -1789,52 +1799,57 @@ msgstr[1] "%d labels veranderd."
 #. L10N: This is displayed when editing an x-label, but no messages
 #. * were updated.  Possibly due to canceling at the prompt or if the new
 #. * label is the same as the old label.
-#: curs_main.c:2907 pager.c:3204
+#: curs_main.c:2919 pager.c:3212
 msgid "No labels changed."
 msgstr "Geen labels veranderd."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:3006
-msgid "Cannot mark message(s) as read"
+#. L10N: Due to the implementation details we do not know whether we
+#. mark zero, 1, 12, ... messages as read. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:3022
+#, fuzzy
+msgid "Cannot mark messages as read"
 msgstr "Kan bericht(en) niet als gelezen markeren"
 
 #. L10N: This is the prompt for <mark-message>.  Whatever they
 #. enter will be prefixed by $mark_macro_prefix and will become
 #. a macro hotkey to jump to the currently selected message.
-#: curs_main.c:3042
+#: curs_main.c:3058
 msgid "Enter macro stroke: "
 msgstr "Typ de macrotoetsaanslag: "
 
 #. L10N: "message hotkey" is the key bindings menu description of a
 #. macro created by <mark-message>.
-#: curs_main.c:3050
+#: curs_main.c:3066
 msgid "message hotkey"
 msgstr "berichtsneltoets"
 
 #. L10N: This is echoed after <mark-message> creates a new hotkey
 #. macro.  %s is the hotkey string ($mark_macro_prefix followed
 #. by whatever they typed at the prompt.)
-#: curs_main.c:3055
+#: curs_main.c:3071
 #, c-format
 msgid "Message bound to %s."
 msgstr "Bericht is gebonden aan %s."
 
 #. L10N: This error is printed if <mark-message> cannot find a
 #. Message-ID for the currently selected message in the index.
-#: curs_main.c:3063
+#: curs_main.c:3079
 msgid "No message ID to macro."
 msgstr "Kan geen ID van dit bericht vinden in de index."
 
-#: curs_main.c:3105 pager.c:2961 recvattach.c:1388
+#: curs_main.c:3121 pager.c:2965 recvattach.c:1401
 msgid "Reply by mail as poster prefers?"
 msgstr ""
 
-#: curs_main.c:3108 pager.c:2927 pager.c:2939 pager.c:2964
+#: curs_main.c:3124 pager.c:2931 pager.c:2943 pager.c:2968
 msgid "Posting to this group not allowed, may be moderated. Continue?"
 msgstr ""
 
 #. L10N: CHECK_ACL
-#: curs_main.c:3173 pager.c:3120
+#: curs_main.c:3189 pager.c:3124
 msgid "Cannot undelete message"
 msgstr "Kan bericht niet herstellen"
 
@@ -2027,12 +2042,34 @@ msgstr "[-- Foutenuitvoer van %s --]\n"
 msgid "[-- Error: message/external-body has no access-type parameter --]\n"
 msgstr "[-- Fout: message/external-body heeft geen access-type parameter --]\n"
 
-#: handler.c:1611
+#. L10N: If the translation of this string is a multi line string, then
+#. each line should start with "[-- " and end with " --]".
+#. The first "%s/%s" is a MIME type, e.g. "text/plain". The last %s
+#. expands to a date as returned by `mutt_date_parse_date()`.
+#.
+#. Note: The size argument printed is not the actual number as passed
+#. to gettext but the prettified version, e.g. size = 2048 will be
+#. printed as 2K.  Your language might be sensitive to that: For
+#. example although '1K' and '1024' represent the same number your
+#. language might inflect the noun 'byte' differently.
+#.
+#. Sadly, we cannot do anything about that at the moment besides
+#. passing the precise size in bytes. If you are interested the
+#. function responsible for the prettification is
+#. mutt_str_pretty_size() in mutt/string.c.
+#.
+#: handler.c:1624
 #, fuzzy, c-format
 msgid ""
+"[-- This %s/%s attachment (size %s byte) has been deleted --]\n"
+"[-- on %s --]\n"
+msgid_plural ""
 "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
 "[-- on %s --]\n"
-msgstr ""
+msgstr[0] ""
+"[-- Deze %s/%s bijlage (grootte %s bytes) werd gewist --]\n"
+"[-- op %s --]\n"
+msgstr[1] ""
 "[-- Deze %s/%s bijlage (grootte %s bytes) werd gewist --]\n"
 "[-- op %s --]\n"
 
@@ -2040,10 +2077,23 @@ msgstr ""
 #. each line should start with "[-- " and end with " --]".
 #. The first "%s/%s" is a MIME type, e.g. "text/plain".
 #.
-#: handler.c:1620
+#. Note: The size argument printed is not the actual number as passed
+#. to gettext but the prettified version, e.g. size = 2048 will be
+#. printed as 2K.  Your language might be sensitive to that: For
+#. example although '1K' and '1024' represent the same number your
+#. language might inflect the noun 'byte' differently.
+#.
+#. Sadly, we cannot do anything about that at the moment besides
+#. passing the precise size in bytes. If you are interested the
+#. function responsible for the prettification is
+#. mutt_str_pretty_size() in mutt/string.c.
+#.
+#: handler.c:1648
 #, fuzzy, c-format
-msgid "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
-msgstr "[-- Deze %s/%s bijlage (grootte %s bytes) werd gewist --]\n"
+msgid "[-- This %s/%s attachment (size %s byte) has been deleted --]\n"
+msgid_plural "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
+msgstr[0] "[-- Deze %s/%s bijlage (grootte %s bytes) werd gewist --]\n"
+msgstr[1] "[-- Deze %s/%s bijlage (grootte %s bytes) werd gewist --]\n"
 
 #. L10N: If the translation of this string is a multi line string, then
 #. each line should start with "[-- " and end with " --]".
@@ -2053,7 +2103,7 @@ msgstr "[-- Deze %s/%s bijlage (grootte %s bytes) werd gewist --]\n"
 #. Caution: Argument three %3$ is also defined but should not be used
 #. in this translation!
 #.
-#: handler.c:1637
+#: handler.c:1667
 #, fuzzy
 msgid ""
 "[-- This %s/%s attachment has been deleted --]\n"
@@ -2066,18 +2116,18 @@ msgstr ""
 #. each line should start with "[-- " and end with " --]".
 #. The first "%s/%s" is a MIME type, e.g. "text/plain".
 #.
-#: handler.c:1646
+#: handler.c:1676
 #, fuzzy, c-format
 msgid "[-- This %s/%s attachment has been deleted --]\n"
 msgstr "[-- Deze %s/%s bijlage werd gewist --]\n"
 
-#: handler.c:1656
+#: handler.c:1686
 #, c-format
 msgid "[-- name: %s --]\n"
 msgstr "[-- naam: %s --]\n"
 
 # FIXME: why the split?
-#: handler.c:1672
+#: handler.c:1702
 #, fuzzy, c-format
 msgid ""
 "[-- This %s/%s attachment is not included, --]\n"
@@ -2089,7 +2139,7 @@ msgstr ""
 "[-- bestaat niet meer. --]\n"
 
 # FIXME: why the split?
-#: handler.c:1693
+#: handler.c:1723
 #, fuzzy, c-format
 msgid ""
 "[-- This %s/%s attachment is not included, --]\n"
@@ -2098,51 +2148,51 @@ msgstr ""
 "[-- Deze %s/%s-bijlage is niet bijgesloten, --]\n"
 "[-- en het access-type %s wordt niet ondersteund --]\n"
 
-#: handler.c:1822
+#: handler.c:1852
 #, fuzzy
 msgid "Unable to open memory stream!"
 msgstr "Tijdelijk bestand kon niet worden geopend!"
 
-#: handler.c:1831
+#: handler.c:1861
 msgid "Unable to open temporary file!"
 msgstr "Tijdelijk bestand kon niet worden geopend!"
 
-#: handler.c:1881
+#: handler.c:1911
 msgid "failed to re-open memstream!"
 msgstr ""
 
-#: handler.c:2013
+#: handler.c:2043
 msgid "Error: multipart/signed has no protocol."
 msgstr "Fout: multipart/signed zonder protocol-parameter."
 
-#: handler.c:2076
+#: handler.c:2106
 #, fuzzy
 msgid "[-- This is an attachment (use '%3$s' to view this part) --]\n"
 msgstr "[-- Dit is een bijlage (gebruik '%3$s' om dit gedeelte weer te geven) --]\n"
 
-#: handler.c:2082
+#: handler.c:2112
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported (use '%s' to view this part) --]\n"
 msgstr "[-- %s/%s wordt niet ondersteund (gebruik '%s' om dit gedeelte weer te geven) --]\n"
 
-#: handler.c:2087
+#: handler.c:2117
 #, fuzzy
 msgid "[-- This is an attachment (need 'view-attachments' bound to key!) --]\n"
 msgstr "[-- Dit is een bijlage ('view-attachments' moet aan een toets gekoppeld zijn!) --]\n"
 
 #. L10N: %s/%s is a MIME type, e.g. "text/plain".
-#: handler.c:2091
+#: handler.c:2121
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported (need 'view-attachments' bound to key!) --]\n"
 msgstr "[-- %s/%s wordt niet ondersteund ('view-attachments' moet aan een toets gekoppeld zijn!) --]\n"
 
-#: handler.c:2098
+#: handler.c:2128
 #, fuzzy
 msgid "[-- This is an attachment --]\n"
 msgstr "[-- Dit is een bijlage --]\n"
 
 #. L10N: %s/%s is a MIME type, e.g. "text/plain".
-#: handler.c:2101
+#: handler.c:2131
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported --]\n"
 msgstr "[-- %s/%s wordt niet ondersteund --]\n"
@@ -2448,7 +2498,7 @@ msgstr "SMTP-server ondersteunt geen authenticatie"
 msgid "Invalid IMAP flags"
 msgstr "Ongeldig    "
 
-#: imap/message.c:477 mx.c:1326
+#: imap/message.c:477 mx.c:1336
 msgid "Integer overflow -- can't allocate memory."
 msgstr "Integer overflow -- kan geen geheugen alloceren!"
 
@@ -3211,64 +3261,74 @@ msgstr "SSL is niet beschikbaar."
 msgid "Reading from %s interrupted..."
 msgstr "Het zoeken is onderbroken."
 
-#: mx.c:634
-msgid "message(s) not deleted"
-msgstr "bericht(en) niet verwijderd"
+#. L10N: Although we now the precise number of messages, we do not show it to the user.
+#. So feel free to use a "generic plural" as plural translation if your language has one.
+#.
+#: mx.c:639
+#, fuzzy
+msgid "message not deleted"
+msgid_plural "messages not deleted"
+msgstr[0] "bericht(en) niet verwijderd"
+msgstr[1] "bericht(en) niet verwijderd"
 
-#: mx.c:671
+#: mx.c:676
 msgid "Can't open trash folder"
 msgstr "Kan prullenmap niet openen"
 
-#: mx.c:710
+#: mx.c:715
 msgid "Mark all articles read?"
 msgstr ""
 
-#: mx.c:754
+#. L10N: The first argument is the number of read messages to be
+#. moved, the second argument is the target mailbox.
+#: mx.c:762
 #, fuzzy, c-format
-msgid "Move %d read messages to %s?"
-msgstr "Gelezen berichten naar %s verplaatsen?"
+msgid "Move %d read message to %s?"
+msgid_plural "Move %d read messages to %s?"
+msgstr[0] "Gelezen berichten naar %s verplaatsen?"
+msgstr[1] "Gelezen berichten naar %s verplaatsen?"
 
-#: mx.c:771 mx.c:1077
+#: mx.c:781 mx.c:1087
 #, fuzzy, c-format
 msgid "Purge %d deleted message?"
 msgid_plural "Purge %d deleted messages?"
 msgstr[0] "%d als gewist gemarkeerde berichten verwijderen?"
 msgstr[1] "%d als gewist gemarkeerde berichten verwijderen?"
 
-#: mx.c:793
+#: mx.c:803
 #, c-format
 msgid "Moving read messages to %s..."
 msgstr "Gelezen berichten worden naar %s verplaatst..."
 
-#: mx.c:859 mx.c:1068
+#: mx.c:869 mx.c:1078
 msgid "Mailbox is unchanged."
 msgstr "Postvak is niet veranderd."
 
-#: mx.c:914
+#: mx.c:924
 #, c-format
 msgid "%d kept, %d moved, %d deleted."
 msgstr "%d bewaard, %d verschoven, %d gewist."
 
-#: mx.c:917 mx.c:1130
+#: mx.c:927 mx.c:1140
 #, c-format
 msgid "%d kept, %d deleted."
 msgstr "%d bewaard, %d gewist."
 
-#: mx.c:1052
+#: mx.c:1062
 #, c-format
 msgid " Press '%s' to toggle write"
 msgstr " Druk '%s' om schrijfmode aan/uit te schakelen"
 
-#: mx.c:1054
+#: mx.c:1064
 msgid "Use 'toggle-write' to re-enable write!"
 msgstr "Gebruik 'toggle-write' om schrijven mogelijk te maken!"
 
-#: mx.c:1056
+#: mx.c:1066
 #, c-format
 msgid "Mailbox is marked unwritable. %s"
 msgstr "Postvak is als schrijfbeveiligd gemarkeerd. %s"
 
-#: mx.c:1124
+#: mx.c:1134
 msgid "Mailbox checkpointed."
 msgstr "Postvak is gecontroleerd."
 
@@ -3282,54 +3342,59 @@ msgstr " (huidige tijd: %c)"
 msgid "[-- %s output follows%s --]\n"
 msgstr "[-- %s uitvoer volgt%s --]\n"
 
-#: ncrypt/crypt.c:95
-msgid "Passphrase(s) forgotten."
+#. L10N: Due to the implementation details (e.g. some passwords are managed
+#. by gpg-agent) we cannot know whether we forgot zero, 1, 12, ...
+#. passwords. So in English we use "Passphrases". Your language might
+#. have other means to express this.
+#: ncrypt/crypt.c:100
+#, fuzzy
+msgid "Passphrases forgotten."
 msgstr "Wachtwoord(en) zijn vergeten."
 
-#: ncrypt/crypt.c:155
+#: ncrypt/crypt.c:161
 msgid "Inline PGP can't be used with attachments.  Revert to PGP/MIME?"
 msgstr "Inline PGP is niet mogelijk met bijlagen.  PGP/MIME gebruiken?"
 
-#: ncrypt/crypt.c:159
+#: ncrypt/crypt.c:165
 msgid "Mail not sent: inline PGP can't be used with attachments."
 msgstr "Bericht is niet verzonden: inline PGP gaat niet met bijlagen."
 
-#: ncrypt/crypt.c:166
+#: ncrypt/crypt.c:172
 #, fuzzy
 msgid "Inline PGP can't be used with format=flowed.  Revert to PGP/MIME?"
 msgstr "Inline PGP is niet mogelijk met bijlagen.  PGP/MIME gebruiken?"
 
-#: ncrypt/crypt.c:170
+#: ncrypt/crypt.c:176
 #, fuzzy
 msgid "Mail not sent: inline PGP can't be used with format=flowed."
 msgstr "Bericht is niet verzonden: inline PGP gaat niet met bijlagen."
 
-#: ncrypt/crypt.c:180 ncrypt/cryptglue.c:125 ncrypt/pgpkey.c:589
+#: ncrypt/crypt.c:186 ncrypt/cryptglue.c:125 ncrypt/pgpkey.c:589
 #: ncrypt/pgpkey.c:782
 msgid "Invoking PGP..."
 msgstr "PGP wordt aangeroepen..."
 
-#: ncrypt/crypt.c:192
+#: ncrypt/crypt.c:198
 msgid "Message can't be sent inline.  Revert to using PGP/MIME?"
 msgstr "Bericht kan niet inline verzonden worden.  PGP/MIME gebruiken?"
 
-#: ncrypt/crypt.c:194 send.c:1824
+#: ncrypt/crypt.c:200 send.c:1824
 msgid "Mail not sent."
 msgstr "Bericht niet verstuurd."
 
-#: ncrypt/crypt.c:540
+#: ncrypt/crypt.c:546
 msgid "S/MIME messages with no hints on content are unsupported."
 msgstr "S/MIME-berichten zonder aanwijzingen over inhoud zijn niet ondersteund."
 
-#: ncrypt/crypt.c:754 ncrypt/crypt.c:795
+#: ncrypt/crypt.c:760 ncrypt/crypt.c:801
 msgid "Trying to extract PGP keys...\n"
 msgstr "PGP-sleutels onttrekken...\n"
 
-#: ncrypt/crypt.c:776 ncrypt/crypt.c:816
+#: ncrypt/crypt.c:782 ncrypt/crypt.c:822
 msgid "Trying to extract S/MIME certificates...\n"
 msgstr "S/MIME-certificaten onttrekken...\n"
 
-#: ncrypt/crypt.c:976
+#: ncrypt/crypt.c:982
 #, c-format
 msgid ""
 "[-- Error: Unknown multipart/signed protocol %s! --]\n"
@@ -3338,7 +3403,7 @@ msgstr ""
 "[-- Fout: Onbekend multipart/signed-protocol: %s! --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1016
+#: ncrypt/crypt.c:1022
 #, fuzzy
 msgid ""
 "[-- Error: Missing or bad-format multipart/signed signature! --]\n"
@@ -3347,7 +3412,7 @@ msgstr ""
 "[-- Fout: Inconsistente multipart/signed-structuur! --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1058
+#: ncrypt/crypt.c:1064
 #, c-format
 msgid ""
 "[-- Warning: We can't verify %s/%s signatures. --]\n"
@@ -3356,7 +3421,7 @@ msgstr ""
 "[-- Waarschuwing: %s/%s-handtekeningen kunnen niet gecontroleerd worden --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1070
+#: ncrypt/crypt.c:1076
 msgid ""
 "[-- The following data is signed --]\n"
 "\n"
@@ -3364,7 +3429,7 @@ msgstr ""
 "[-- De volgende gegevens zijn ondertekend --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1075
+#: ncrypt/crypt.c:1081
 msgid ""
 "[-- Warning: Can't find any signatures. --]\n"
 "\n"
@@ -3372,7 +3437,7 @@ msgstr ""
 "[-- Waarschuwing: kan geen enkele handtekening vinden --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1081
+#: ncrypt/crypt.c:1087
 msgid ""
 "\n"
 "[-- End of signed data --]\n"
@@ -3423,7 +3488,7 @@ msgstr ""
 msgid "error reading data object: %s\n"
 msgstr "fout bij het lezen van het gegevensobject: %s\n"
 
-#: ncrypt/crypt_gpgme.c:662 ncrypt/crypt_gpgme.c:3848 ncrypt/pgpkey.c:585
+#: ncrypt/crypt_gpgme.c:662 ncrypt/crypt_gpgme.c:3850 ncrypt/pgpkey.c:585
 #: ncrypt/pgpkey.c:768
 msgid "Can't create temporary file"
 msgstr "Kan tijdelijk bestand niet aanmaken"
@@ -3777,28 +3842,30 @@ msgstr "[Ongeldig]"
 
 #. L10N: This is printed after "Key Type: " and looks like this:
 #. *       PGP, 2048 bit RSA
-#: ncrypt/crypt_gpgme.c:3670 ncrypt/crypt_gpgme.c:3808
+#: ncrypt/crypt_gpgme.c:3670 ncrypt/crypt_gpgme.c:3810
 #, fuzzy, c-format
 msgid "%s, %lu bit %s\n"
-msgstr "Sltl.type .: %s, %lu bit %s\n"
+msgid_plural "%s, %lu bit %s\n"
+msgstr[0] "Sltl.type .: %s, %lu bit %s\n"
+msgstr[1] "Sltl.type .: %s, %lu bit %s\n"
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3678 ncrypt/crypt_gpgme.c:3815
+#: ncrypt/crypt_gpgme.c:3678 ncrypt/crypt_gpgme.c:3817
 msgid "encryption"
 msgstr "versleuteling "
 
 #: ncrypt/crypt_gpgme.c:3679 ncrypt/crypt_gpgme.c:3685
-#: ncrypt/crypt_gpgme.c:3816 ncrypt/crypt_gpgme.c:3821
+#: ncrypt/crypt_gpgme.c:3818 ncrypt/crypt_gpgme.c:3823
 msgid ", "
 msgstr ", "
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3684 ncrypt/crypt_gpgme.c:3820
+#: ncrypt/crypt_gpgme.c:3684 ncrypt/crypt_gpgme.c:3822
 msgid "signing"
 msgstr "ondertekening"
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3690 ncrypt/crypt_gpgme.c:3825
+#: ncrypt/crypt_gpgme.c:3690 ncrypt/crypt_gpgme.c:3827
 msgid "certification"
 msgstr "certificering"
 
@@ -3817,64 +3884,64 @@ msgstr "[Verlopen]"
 msgid "[Disabled]"
 msgstr "[Uitgeschakeld]"
 
-#: ncrypt/crypt_gpgme.c:3851
+#: ncrypt/crypt_gpgme.c:3853
 msgid "Collecting data..."
 msgstr "Data aan het vergaren..."
 
-#: ncrypt/crypt_gpgme.c:3876
+#: ncrypt/crypt_gpgme.c:3878
 #, c-format
 msgid "Error finding issuer key: %s\n"
 msgstr "Fout bij het vinden van uitgever van sleutel: %s\n"
 
-#: ncrypt/crypt_gpgme.c:3885
+#: ncrypt/crypt_gpgme.c:3887
 msgid "Error: certification chain too long - stopping here\n"
 msgstr "Fout: certificeringsketen is te lang -- gestopt\n"
 
-#: ncrypt/crypt_gpgme.c:3895 ncrypt/pgpkey.c:608
+#: ncrypt/crypt_gpgme.c:3897 ncrypt/pgpkey.c:608
 #, c-format
 msgid "Key ID: 0x%s"
 msgstr "Sleutel-ID: 0x%s"
 
-#: ncrypt/crypt_gpgme.c:3990
+#: ncrypt/crypt_gpgme.c:3992
 #, c-format
 msgid "gpgme_new failed: %s"
 msgstr "gpgme_new() is mislukt: %s"
 
-#: ncrypt/crypt_gpgme.c:4028 ncrypt/crypt_gpgme.c:4079
+#: ncrypt/crypt_gpgme.c:4030 ncrypt/crypt_gpgme.c:4081
 #, c-format
 msgid "gpgme_op_keylist_start failed: %s"
 msgstr "gpgme_op_keylist_start() is mislukt: %s"
 
-#: ncrypt/crypt_gpgme.c:4067 ncrypt/crypt_gpgme.c:4109
+#: ncrypt/crypt_gpgme.c:4069 ncrypt/crypt_gpgme.c:4111
 #, c-format
 msgid "gpgme_op_keylist_next failed: %s"
 msgstr "gpgme_op_keylist_next() is mislukt: %s"
 
-#: ncrypt/crypt_gpgme.c:4185
+#: ncrypt/crypt_gpgme.c:4187
 msgid "All matching keys are marked expired/revoked."
 msgstr "Alle overeenkomende sleutels zijn verlopen/ingetrokken."
 
-#: ncrypt/crypt_gpgme.c:4215 ncrypt/pgpkey.c:543 ncrypt/smime.c:475
+#: ncrypt/crypt_gpgme.c:4217 ncrypt/pgpkey.c:543 ncrypt/smime.c:475
 msgid "Select  "
 msgstr "Selecteer  "
 
-#: ncrypt/crypt_gpgme.c:4217 ncrypt/pgpkey.c:545
+#: ncrypt/crypt_gpgme.c:4219 ncrypt/pgpkey.c:545
 msgid "Check key  "
 msgstr "Controleer sleutel  "
 
-#: ncrypt/crypt_gpgme.c:4233
+#: ncrypt/crypt_gpgme.c:4235
 msgid "PGP and S/MIME keys matching"
 msgstr "PGP- en S/MIME-sleutels voor"
 
-#: ncrypt/crypt_gpgme.c:4235
+#: ncrypt/crypt_gpgme.c:4237
 msgid "PGP keys matching"
 msgstr "PGP-sleutels voor"
 
-#: ncrypt/crypt_gpgme.c:4237
+#: ncrypt/crypt_gpgme.c:4239
 msgid "S/MIME keys matching"
 msgstr "S/MIME-certficaten voor"
 
-#: ncrypt/crypt_gpgme.c:4239
+#: ncrypt/crypt_gpgme.c:4241
 msgid "keys matching"
 msgstr "sleutels voor"
 
@@ -3882,69 +3949,69 @@ msgstr "sleutels voor"
 #. %1$s is one of the previous four entries.
 #. %2$s is an address.
 #. e.g. "S/MIME keys matching <me@mutt.org>."
-#: ncrypt/crypt_gpgme.c:4246
+#: ncrypt/crypt_gpgme.c:4248
 #, c-format
 msgid "%s <%s>."
 msgstr "%s <%s>."
 
 #. L10N:
 #. e.g. 'S/MIME keys matching "Michael Elkins".'
-#: ncrypt/crypt_gpgme.c:4250
+#: ncrypt/crypt_gpgme.c:4252
 #, c-format
 msgid "%s \"%s\"."
 msgstr "%s \"%s\"."
 
-#: ncrypt/crypt_gpgme.c:4277 ncrypt/pgpkey.c:628
+#: ncrypt/crypt_gpgme.c:4279 ncrypt/pgpkey.c:628
 msgid "This key can't be used: expired/disabled/revoked."
 msgstr "Deze sleutel is onbruikbaar: verlopen/ingetrokken."
 
-#: ncrypt/crypt_gpgme.c:4290 ncrypt/pgpkey.c:640 ncrypt/smime.c:505
+#: ncrypt/crypt_gpgme.c:4292 ncrypt/pgpkey.c:640 ncrypt/smime.c:505
 #, fuzzy
 msgid "ID is expired/disabled/revoked. Do you really want to use the key?"
 msgstr "Dit ID is verlopen/uitgeschakeld/ingetrokken. Wilt U deze sleutel gebruiken?"
 
-#: ncrypt/crypt_gpgme.c:4299 ncrypt/pgpkey.c:650
+#: ncrypt/crypt_gpgme.c:4301 ncrypt/pgpkey.c:650
 #, fuzzy
 msgid "ID is not valid. Do you really want to use the key?"
 msgstr "Dit ID is niet geldig. Wilt U deze sleutel gebruiken?"
 
-#: ncrypt/crypt_gpgme.c:4302 ncrypt/pgpkey.c:653
+#: ncrypt/crypt_gpgme.c:4304 ncrypt/pgpkey.c:653
 #, fuzzy
 msgid "ID is only marginally valid. Do you really want to use the key?"
 msgstr "Dit ID is slechts marginaal vertrouwd. Wilt U deze sleutel gebruiken?"
 
-#: ncrypt/crypt_gpgme.c:4310 ncrypt/pgpkey.c:646 ncrypt/smime.c:509
+#: ncrypt/crypt_gpgme.c:4312 ncrypt/pgpkey.c:646 ncrypt/smime.c:509
 #, fuzzy
 msgid "ID has undefined validity. Do you really want to use the key?"
 msgstr "Dit ID heeft een ongedefinieerde geldigheid. Wilt U deze sleutel gebruiken?"
 
-#: ncrypt/crypt_gpgme.c:4370 ncrypt/crypt_gpgme.c:4479 ncrypt/pgpkey.c:872
+#: ncrypt/crypt_gpgme.c:4372 ncrypt/crypt_gpgme.c:4481 ncrypt/pgpkey.c:872
 #: ncrypt/pgpkey.c:995
 #, c-format
 msgid "Looking for keys matching \"%s\"..."
 msgstr "Zoeken naar sleutels voor \"%s\"..."
 
-#: ncrypt/crypt_gpgme.c:4593 ncrypt/pgpkey.c:731 ncrypt/smime.c:811
+#: ncrypt/crypt_gpgme.c:4595 ncrypt/pgpkey.c:731 ncrypt/smime.c:811
 #, c-format
 msgid "No matching keys found for \"%s\""
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4644 ncrypt/pgp.c:1263
+#: ncrypt/crypt_gpgme.c:4646 ncrypt/pgp.c:1263
 #, c-format
 msgid "Use keyID = \"%s\" for %s?"
 msgstr "Sleutel-ID = \"%s\" gebruiken voor %s?"
 
-#: ncrypt/crypt_gpgme.c:4695 ncrypt/pgp.c:1312 ncrypt/smime.c:830
+#: ncrypt/crypt_gpgme.c:4697 ncrypt/pgp.c:1312 ncrypt/smime.c:830
 #: ncrypt/smime.c:938
 #, c-format
 msgid "Enter keyID for %s: "
 msgstr "Sleutel-ID voor %s: "
 
-#: ncrypt/crypt_gpgme.c:4755 ncrypt/pgpkey.c:751
+#: ncrypt/crypt_gpgme.c:4757 ncrypt/pgpkey.c:751
 msgid "Please enter the key ID: "
 msgstr "Geef Key-ID in: "
 
-#: ncrypt/crypt_gpgme.c:4768
+#: ncrypt/crypt_gpgme.c:4770
 #, c-format
 msgid "Error exporting key: %s\n"
 msgstr "Fout bij exporteren van sleutel: %s\n"
@@ -3953,84 +4020,84 @@ msgstr "Fout bij exporteren van sleutel: %s\n"
 #. MIME description for exported (attached) keys.
 #. You can translate this entry to a non-ASCII string (it will be encoded),
 #. but it may be safer to keep it untranslated.
-#: ncrypt/crypt_gpgme.c:4787
+#: ncrypt/crypt_gpgme.c:4789
 #, c-format
 msgid "PGP Key 0x%s."
 msgstr "PGP-sleutel 0x%s."
 
-#: ncrypt/crypt_gpgme.c:4830
+#: ncrypt/crypt_gpgme.c:4832
 msgid "GPGME: OpenPGP protocol not available"
 msgstr "GPGME: OpenPGP-protocol is niet beschikbaar"
 
-#: ncrypt/crypt_gpgme.c:4838
+#: ncrypt/crypt_gpgme.c:4840
 msgid "GPGME: CMS protocol not available"
 msgstr "GPGME: CMS-protocol is niet beschikbaar"
 
-#: ncrypt/crypt_gpgme.c:4876
+#: ncrypt/crypt_gpgme.c:4878
 msgid "S/MIME (s)ign, sign (a)s, (p)gp, (c)lear, or (o)ppenc mode off? "
 msgstr "S/MIME (o)nderteken, ondert. (a)ls, (p)gp, (g)een, of oppenc (u)it? "
 
 #. L10N: S/MIME options (opportunistic encryption is on)
-#: ncrypt/crypt_gpgme.c:4878
+#: ncrypt/crypt_gpgme.c:4880
 msgid "sapco"
 msgstr "oapgu"
 
-#: ncrypt/crypt_gpgme.c:4885
+#: ncrypt/crypt_gpgme.c:4887
 msgid "PGP (s)ign, sign (a)s, s/(m)ime, (c)lear, or (o)ppenc mode off? "
 msgstr "PGP (o)nderteken, ondert. (a)ls, s/(m)ime, (g)een, of oppenc (u)it? "
 
 #. L10N: PGP options (opportunistic encryption is on)
-#: ncrypt/crypt_gpgme.c:4887
+#: ncrypt/crypt_gpgme.c:4889
 msgid "samco"
 msgstr "oamgu"
 
 #. L10N: S/MIME options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4900
+#: ncrypt/crypt_gpgme.c:4902
 msgid "S/MIME (e)ncrypt, (s)ign, sign (a)s, (b)oth, (p)gp, (c)lear, or (o)ppenc mode? "
 msgstr "S/MIME (v)ersleutel, (o)ndert., ond. (a)ls, (b)eiden, (p)gp, (g)een, opp(e)nc? "
 
 #. L10N: S/MIME options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4903
+#: ncrypt/crypt_gpgme.c:4905
 #, fuzzy
 msgid "esabpco"
 msgstr "voabpge"
 
 #. L10N: PGP options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4909
+#: ncrypt/crypt_gpgme.c:4911
 msgid "PGP (e)ncrypt, (s)ign, sign (a)s, (b)oth, s/(m)ime, (c)lear, or (o)ppenc mode? "
 msgstr "PGP (v)ersleutel, (o)ndert., ond. (a)ls, (b)eiden, s/(m)ime, (g)een, opp(e)nc? "
 
 #. L10N: PGP options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4912
+#: ncrypt/crypt_gpgme.c:4914
 #, fuzzy
 msgid "esabmco"
 msgstr "voabmge"
 
-#: ncrypt/crypt_gpgme.c:4925
+#: ncrypt/crypt_gpgme.c:4927
 msgid "S/MIME (e)ncrypt, (s)ign, sign (a)s, (b)oth, (p)gp or (c)lear? "
 msgstr "S/MIME (v)ersleutel, (o)nderteken, ond. (a)ls, (b)eiden, (p)gp, of (g)een? "
 
 #. L10N: S/MIME options
-#: ncrypt/crypt_gpgme.c:4927
+#: ncrypt/crypt_gpgme.c:4929
 #, fuzzy
 msgid "esabpc"
 msgstr "voabpg"
 
-#: ncrypt/crypt_gpgme.c:4934
+#: ncrypt/crypt_gpgme.c:4936
 msgid "PGP (e)ncrypt, (s)ign, sign (a)s, (b)oth, s/(m)ime or (c)lear? "
 msgstr "PGP (v)ersleutel, (o)nderteken, ond. (a)ls, (b)eiden, s/(m)ime, of (g)een? "
 
 #. L10N: PGP options
-#: ncrypt/crypt_gpgme.c:4936
+#: ncrypt/crypt_gpgme.c:4938
 #, fuzzy
 msgid "esabmc"
 msgstr "voabmg"
 
-#: ncrypt/crypt_gpgme.c:5087
+#: ncrypt/crypt_gpgme.c:5089
 msgid "Failed to verify sender"
 msgstr "Verifiëren van afzender is mislukt"
 
-#: ncrypt/crypt_gpgme.c:5090
+#: ncrypt/crypt_gpgme.c:5092
 msgid "Failed to figure out sender"
 msgstr "Kan afzender niet bepalen"
 
@@ -4429,7 +4496,7 @@ msgstr ""
 msgid "%s is an invalid news server specification!"
 msgstr "%s is een ongeldig POP-pad"
 
-#: nntp.c:75 nntp.c:612 pop.c:1028 pop_lib.c:405
+#: nntp.c:75 nntp.c:612 pop.c:1031 pop_lib.c:405
 msgid "Server closed connection!"
 msgstr "Server heeft verbinding gesloten!"
 
@@ -4596,16 +4663,18 @@ msgid "check mailboxes for new mail"
 msgstr "controleer postvakken op nieuwe berichten"
 
 #: opcodes.h:47
-msgid "attach file(s) to this message"
+#, fuzzy
+msgid "attach files to this message"
 msgstr "voeg bestand(en) aan dit bericht toe"
 
 #: opcodes.h:48
-msgid "attach message(s) to this message"
+#, fuzzy
+msgid "attach messages to this message"
 msgstr "voeg bericht(en) aan dit bericht toe"
 
 #: opcodes.h:49
 #, fuzzy
-msgid "attach news article(s) to this message"
+msgid "attach news articles to this message"
 msgstr "voeg bestand(en) aan dit bericht toe"
 
 #: opcodes.h:50
@@ -5446,7 +5515,8 @@ msgid "extract supported public keys"
 msgstr "extraheer ondersteunde publieke sleutels"
 
 #: opcodes.h:255
-msgid "wipe passphrase(s) from memory"
+#, fuzzy
+msgid "wipe passphrases from memory"
 msgstr "verwijder wachtwoord(en) uit geheugen"
 
 #: opcodes.h:259
@@ -5783,18 +5853,20 @@ msgstr "Geen nieuwe berichten op de POP-server."
 msgid "Delete messages from server?"
 msgstr "Berichten op de server verwijderen?"
 
-#: pop.c:954
-#, c-format
-msgid "Reading new messages (%d bytes)..."
-msgstr "Bezig met het lezen van nieuwe berichten (%d bytes)..."
+#: pop.c:955
+#, fuzzy, c-format
+msgid "Reading new messages (%d byte)..."
+msgid_plural "Reading new messages (%d bytes)..."
+msgstr[0] "Bezig met het lezen van nieuwe berichten (%d bytes)..."
+msgstr[1] "Bezig met het lezen van nieuwe berichten (%d bytes)..."
 
-#: pop.c:997
+#: pop.c:1000
 msgid "Error while writing mailbox!"
 msgstr "Er is een fout opgetreden tijdens het schrijven van het postvak!"
 
 #. L10N: The plural is picked by the second numerical argument, i.e.
 #. * the %d right before 'messages', i.e. the total number of messages.
-#: pop.c:1003
+#: pop.c:1006
 #, fuzzy, c-format
 msgid "%s [%d of %d message read]"
 msgid_plural "%s [%d of %d messages read]"
@@ -5938,48 +6010,55 @@ msgstr "Doorgeven aan (pipe): "
 msgid "I don't know how to print %s attachments!"
 msgstr "Kan %s-bijlagen niet afdrukken!"
 
-#: recvattach.c:841
-msgid "Print tagged attachment(s)?"
-msgstr "Gemarkeerde bericht(en) afdrukken?"
+#. L10N: Although we now the precise number of tagged messages, we
+#. do not show it to the user.  So feel free to use a "generic
+#. plural" as plural translation if your language has one.
+#: recvattach.c:852
+#, fuzzy, c-format
+msgid "Print tagged attachment?"
+msgid_plural "Print %d tagged attachments?"
+msgstr[0] "Gemarkeerde bericht(en) afdrukken?"
+msgstr[1] "Gemarkeerde bericht(en) afdrukken?"
 
-#: recvattach.c:842
+#: recvattach.c:853
+#, c-format
 msgid "Print attachment?"
 msgstr "Bijlage afdrukken?"
 
-#: recvattach.c:900
+#: recvattach.c:913
 msgid "Structural changes to decrypted attachments are not supported"
 msgstr ""
 
-#: recvattach.c:1046
+#: recvattach.c:1059
 msgid "Can't decrypt encrypted message!"
 msgstr "Kan het versleutelde bericht niet ontsleutelen!"
 
-#: recvattach.c:1172
+#: recvattach.c:1185
 msgid "Attachments"
 msgstr "Bijlagen"
 
-#: recvattach.c:1210
+#: recvattach.c:1223
 msgid "There are no subparts to show!"
 msgstr "Er zijn geen onderdelen om te laten zien!"
 
-#: recvattach.c:1265
+#: recvattach.c:1278
 msgid "Can't delete attachment from POP server."
 msgstr "Kan de bijlage niet van de POP-server verwijderen."
 
-#: recvattach.c:1274
+#: recvattach.c:1287
 #, fuzzy
 msgid "Can't delete attachment from news server."
 msgstr "Kan de bijlage niet van de POP-server verwijderen."
 
-#: recvattach.c:1281
+#: recvattach.c:1294
 msgid "Deletion of attachments from encrypted messages is unsupported."
 msgstr "Het wissen van bijlagen uit versleutelde berichten wordt niet ondersteund."
 
-#: recvattach.c:1287
+#: recvattach.c:1300
 msgid "Deletion of attachments from signed messages may invalidate the signature."
 msgstr "Het wissen van bijlagen uit versleutelde berichten kan de ondertekening ongeldig maken."
 
-#: recvattach.c:1305 recvattach.c:1320
+#: recvattach.c:1318 recvattach.c:1333
 msgid "Only deletion of multipart attachments is supported."
 msgstr "Kan alleen multipart-bijlagen wissen."
 
@@ -6413,3 +6492,13 @@ msgstr "Opties tijdens compileren:"
 #: version.c:404
 msgid "Compile options:"
 msgstr "Opties tijdens compileren:"
+
+#~ msgid "Cannot delete message(s)"
+#~ msgstr "Kan bericht(en) niet verwijderen"
+
+#~ msgid "Cannot undelete message(s)"
+#~ msgstr "Kan bericht(en) niet herstellen"
+
+#, fuzzy
+#~ msgid "messages not deleted"
+#~ msgstr "bericht(en) niet verwijderd"

--- a/po/pl.po
+++ b/po/pl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neomutt-20180512\n"
 "Report-Msgid-Bugs-To: neomutt-devel@neomutt.org\n"
-"POT-Creation-Date: 2018-05-20 02:02+0000\n"
+"POT-Creation-Date: 2018-05-22 14:18+0000\n"
 "PO-Revision-Date: 2018-03-19 09:22+0100\n"
 "Last-Translator: Marcin Rajner <marcin.rajner@pw.edu.pl>\n"
 "Language-Team: none\n"
@@ -41,7 +41,7 @@ msgstr "Wybierz"
 
 #: addrbook.c:52 browser.c:75 browser.c:87 compose.c:160 compose.c:172
 #: conn/ssl.c:1041 conn/ssl_gnutls.c:793 curs_main.c:748 curs_main.c:761
-#: history.c:106 ncrypt/crypt_gpgme.c:4219 ncrypt/pgpkey.c:547
+#: history.c:106 ncrypt/crypt_gpgme.c:4221 ncrypt/pgpkey.c:547
 #: ncrypt/smime.c:477 pager.c:2141 postpone.c:65 query.c:72 recvattach.c:70
 msgid "Help"
 msgstr "Pomoc"
@@ -686,7 +686,7 @@ msgstr ""
 #. * Since it shares the row with "Encrypt with:", it should not be longer
 #. * than 15-20 character cells.
 #.
-#: compose.c:138 ncrypt/crypt_gpgme.c:4947 ncrypt/pgp.c:1786
+#: compose.c:138 ncrypt/crypt_gpgme.c:4949 ncrypt/pgp.c:1786
 #: ncrypt/smime.c:2127
 msgid "Sign as: "
 msgstr "Podpisz jako: "
@@ -1221,7 +1221,7 @@ msgstr "(o)drzuć, zaakceptuj (r)az, (p)omiń"
 msgid "(r)eject, accept (o)nce"
 msgstr "(o)drzuć, zaakceptuj (r)az"
 
-#: conn/ssl.c:1039 conn/ssl_gnutls.c:791 ncrypt/crypt_gpgme.c:4213
+#: conn/ssl.c:1039 conn/ssl_gnutls.c:791 ncrypt/crypt_gpgme.c:4215
 #: ncrypt/pgpkey.c:541 ncrypt/smime.c:473
 msgid "Exit  "
 msgstr "Wyjście  "
@@ -1400,11 +1400,11 @@ msgstr "Nie otwarto żadnej skrzynki."
 msgid "There are no messages."
 msgstr "Brak listów."
 
-#: curs_main.c:77 mx.c:1061 pager.c:73 recvattach.c:56
+#: curs_main.c:77 mx.c:1071 pager.c:73 recvattach.c:56
 msgid "Mailbox is read-only."
 msgstr "Skrzynka jest tylko do odczytu."
 
-#: curs_main.c:79 pager.c:75 recvattach.c:1145
+#: curs_main.c:79 pager.c:75 recvattach.c:1158
 msgid "Function not permitted in attach-message mode."
 msgstr "Funkcja niedostępna w trybie załączania"
 
@@ -1534,235 +1534,245 @@ msgid "That message is not visible."
 msgstr "Ten list nie jest widoczny."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:1377 curs_main.c:2772 pager.c:2818
-msgid "Cannot delete message(s)"
+#. L10N: Due to the implementation details we do not know whether we
+#. delete zero, 1, 12, ... messages. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:1381 curs_main.c:2784 pager.c:2822
+#, fuzzy
+msgid "Cannot delete messages"
 msgstr "Nie mogę usunąć listów"
 
-#: curs_main.c:1380
+#: curs_main.c:1384
 msgid "Delete messages matching: "
 msgstr "Usuń listy pasujące do wzorca: "
 
-#: curs_main.c:1421
+#: curs_main.c:1425
 msgid "No limit pattern is in effect."
 msgstr "Wzorzec ograniczający nie został określony."
 
 #. L10N: ask for a limit to apply
-#: curs_main.c:1426
+#: curs_main.c:1430
 #, c-format
 msgid "Limit: %s"
 msgstr "Ograniczenie: %s"
 
-#: curs_main.c:1464
+#: curs_main.c:1468
 msgid "Limit to messages matching: "
 msgstr "Ogranicz do pasujących listów: "
 
-#: curs_main.c:1488
+#: curs_main.c:1492
 msgid "To view all messages, limit to \"all\"."
 msgstr "Aby ponownie przeglądać wszystkie listy, ustaw ograniczenie na \".*\""
 
-#: curs_main.c:1500 pager.c:2318
+#: curs_main.c:1504 pager.c:2318
 msgid "Quit NeoMutt?"
 msgstr "Wyjść z NeoMutta?"
 
-#: curs_main.c:1596
+#: curs_main.c:1600
 msgid "Tag messages matching: "
 msgstr "Zaznacz pasujące listy: "
 
 #. L10N: CHECK_ACL
-#: curs_main.c:1606 curs_main.c:3203 pager.c:3137
-msgid "Cannot undelete message(s)"
+#. L10N: Due to the implementation details we do not know whether we
+#. undelete zero, 1, 12, ... messages. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:1614 curs_main.c:3223 pager.c:3145
+#, fuzzy
+msgid "Cannot undelete messages"
 msgstr "Nie mogę przywrócić listów"
 
-#: curs_main.c:1609
+#: curs_main.c:1617
 msgid "Undelete messages matching: "
 msgstr "Odtwórz pasujące listy: "
 
-#: curs_main.c:1619
+#: curs_main.c:1627
 msgid "Untag messages matching: "
 msgstr "Odznacz pasujące listy: "
 
-#: curs_main.c:1653
+#: curs_main.c:1661
 msgid "Logged out of IMAP servers."
 msgstr "Wylogowano z serwera IMAP."
 
-#: curs_main.c:1753
+#: curs_main.c:1761
 msgid "No virtual folder, aborting."
 msgstr "To nie jest folder wirtualny, zaniechano."
 
-#: curs_main.c:1761
+#: curs_main.c:1769
 msgid "Failed to read thread, aborting."
 msgstr "Nie udało się wczytać wątku, zaniechano."
 
-#: curs_main.c:1793 mx.c:1458 mx.c:1475
+#: curs_main.c:1801 mx.c:1468 mx.c:1485
 msgid "Folder doesn't support tagging, aborting."
 msgstr "Folder nie wspiera tagowania, zaniechano."
 
-#: curs_main.c:1808
+#: curs_main.c:1816
 msgid "No tag specified, aborting."
 msgstr "Tag nieokreślony, zaniechano."
 
-#: curs_main.c:1820
+#: curs_main.c:1828
 #, c-format
 msgid "Update tags..."
 msgstr "Aktualizacja tagów..."
 
-#: curs_main.c:1857
+#: curs_main.c:1865
 msgid "Failed to modify tags, aborting."
 msgstr "Nieudana modyfikacja tagów, zaniechano."
 
-#: curs_main.c:1898
+#: curs_main.c:1906
 msgid "No query, aborting."
 msgstr "Brak zapytania, zaniechano."
 
-#: curs_main.c:1902 curs_main.c:1922 curs_main.c:1941
+#: curs_main.c:1910 curs_main.c:1930 curs_main.c:1949
 msgid "Failed to create query, aborting."
 msgstr "Nieudane stworzenie zapytania, zaniechano."
 
-#: curs_main.c:1911 curs_main.c:1930
+#: curs_main.c:1919 curs_main.c:1938
 msgid "Windowed queries disabled."
 msgstr ""
 
-#: curs_main.c:1916 curs_main.c:1935
+#: curs_main.c:1924 curs_main.c:1943
 msgid "No notmuch vfolder currently loaded."
 msgstr "Żaden notmach vfolder nie jest obecnie załadowany."
 
-#: curs_main.c:1973
+#: curs_main.c:1981
 msgid "Open mailbox in read-only mode"
 msgstr "Otwórz skrzynkę tylko do odczytu"
 
-#: curs_main.c:1976
+#: curs_main.c:1984
 msgid "Open virtual folder"
 msgstr "Otwórz folder wirtualny"
 
-#: curs_main.c:1979
+#: curs_main.c:1987
 msgid "Open mailbox"
 msgstr "Otwórz skrzynkę"
 
-#: curs_main.c:1989
+#: curs_main.c:1997
 msgid "No mailboxes have new mail"
 msgstr "Żadna skrzynka nie zawiera nowych listów"
 
-#: curs_main.c:2036
+#: curs_main.c:2044
 msgid "Open newsgroup in read-only mode"
 msgstr "Otwórz grupę dyskusyjną tylko do odczytu"
 
-#: curs_main.c:2038
+#: curs_main.c:2046
 msgid "Open newsgroup"
 msgstr "Otwórz listę dyskusyjną"
 
-#: curs_main.c:2141
+#: curs_main.c:2149
 msgid "Exit NeoMutt without saving?"
 msgstr "Wyjść z NeoMutta bez zapisywania zmian?"
 
-#: curs_main.c:2157
+#: curs_main.c:2165
 msgid "Cannot break thread"
 msgstr "Nie można rozłączyć wątku"
 
-#: curs_main.c:2160 curs_main.c:2198 curs_main.c:2658 curs_main.c:2690
+#: curs_main.c:2168 curs_main.c:2206 curs_main.c:2666 curs_main.c:2698
 #: flags.c:376 thread.c:1078 thread.c:1134 thread.c:1202
 msgid "Threading is not enabled."
 msgstr "Wątkowanie nie zostało włączone."
 
-#: curs_main.c:2173
+#: curs_main.c:2181
 msgid "Thread broken"
 msgstr "Wątek został przerwany"
 
-#: curs_main.c:2185
+#: curs_main.c:2193
 msgid "Thread cannot be broken, message is not part of a thread"
 msgstr "Wątek nie może być rozłączony, wiadomość nie jest częścią wątku"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2195
+#: curs_main.c:2203
 msgid "Cannot link threads"
 msgstr "Ne mogę połączyć wątków"
 
-#: curs_main.c:2200
+#: curs_main.c:2208
 msgid "No Message-ID: header available to link thread"
 msgstr "Brak nagłówka Message-ID: wymaganego do połączenia wątków"
 
-#: curs_main.c:2202
+#: curs_main.c:2210
 msgid "First, please tag a message to be linked here"
 msgstr "Najpierw zaznacz list do połączenia"
 
-#: curs_main.c:2213
+#: curs_main.c:2221
 msgid "Threads linked"
 msgstr "Wątki połączono"
 
-#: curs_main.c:2216
+#: curs_main.c:2224
 msgid "No thread linked"
 msgstr "Wątki nie zostały połączone"
 
-#: curs_main.c:2252 curs_main.c:2278
+#: curs_main.c:2260 curs_main.c:2286
 msgid "You are on the last message."
 msgstr "To jest ostatni list."
 
-#: curs_main.c:2260 curs_main.c:2305
+#: curs_main.c:2268 curs_main.c:2313
 msgid "No undeleted messages."
 msgstr "Brak odtworzonych listów."
 
-#: curs_main.c:2297 curs_main.c:2323
+#: curs_main.c:2305 curs_main.c:2331
 msgid "You are on the first message."
 msgstr "To jest pierwszy list."
 
-#: curs_main.c:2395 menu.c:970 pager.c:2440 pattern.c:2110
+#: curs_main.c:2403 menu.c:970 pager.c:2440 pattern.c:2110
 msgid "Search wrapped to top."
 msgstr "Kontynuacja poszukiwania od początku."
 
-#: curs_main.c:2404 pager.c:2463 pattern.c:2121
+#: curs_main.c:2412 pager.c:2463 pattern.c:2121
 msgid "Search wrapped to bottom."
 msgstr "Kontynuacja poszukiwania od końca."
 
-#: curs_main.c:2447
+#: curs_main.c:2455
 msgid "No new messages in this limited view."
 msgstr "Brak nowych wiadomości dla wybranego ograniczenia."
 
-#: curs_main.c:2449
+#: curs_main.c:2457
 msgid "No new messages."
 msgstr "Brak nowych listów."
 
-#: curs_main.c:2454
+#: curs_main.c:2462
 msgid "No unread messages in this limited view."
 msgstr "Brak nieprzeczytanych listów w trybie ograniczonego przeglądania."
 
-#: curs_main.c:2456
+#: curs_main.c:2464
 msgid "No unread messages."
 msgstr "Brak nieprzeczytanych listów"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2474
+#: curs_main.c:2482
 msgid "Cannot flag message"
 msgstr "Nie można ustawić flagi dla wiadomości"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2513 pager.c:3100
+#: curs_main.c:2521 pager.c:3104
 msgid "Cannot toggle new"
 msgstr "Nie mogę przełączyć flagi new"
 
-#: curs_main.c:2590
+#: curs_main.c:2598
 msgid "No more threads."
 msgstr "Nie ma więcej wątków."
 
-#: curs_main.c:2592
+#: curs_main.c:2600
 msgid "You are on the first thread."
 msgstr "To pierwszy wątek."
 
-#: curs_main.c:2676
+#: curs_main.c:2684
 msgid "Thread contains unread or flagged messages."
 msgstr "Wątek zawiera listy nieprzeczytane lub posiadające flagę."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2726 pager.c:2784
+#: curs_main.c:2734 pager.c:2784
 msgid "Cannot delete message"
 msgstr "Nie można skasować listu"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2838
+#: curs_main.c:2850
 msgid "Cannot edit message"
 msgstr "Nie można edytować listu"
 
 #. L10N: This is displayed when the x-label on one or more
 #. * messages is edited.
-#: curs_main.c:2900 pager.c:3200
+#: curs_main.c:2912 pager.c:3208
 #, fuzzy, c-format
 msgid "%d label changed."
 msgid_plural "%d labels changed."
@@ -1773,52 +1783,57 @@ msgstr[2] "%d zmienionych etykiet."
 #. L10N: This is displayed when editing an x-label, but no messages
 #. * were updated.  Possibly due to canceling at the prompt or if the new
 #. * label is the same as the old label.
-#: curs_main.c:2907 pager.c:3204
+#: curs_main.c:2919 pager.c:3212
 msgid "No labels changed."
 msgstr "Nie zmieniono etykiet."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:3006
-msgid "Cannot mark message(s) as read"
+#. L10N: Due to the implementation details we do not know whether we
+#. mark zero, 1, 12, ... messages as read. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:3022
+#, fuzzy
+msgid "Cannot mark messages as read"
 msgstr "Nie można oznaczyć widomości jako przeczytane"
 
 #. L10N: This is the prompt for <mark-message>.  Whatever they
 #. enter will be prefixed by $mark_macro_prefix and will become
 #. a macro hotkey to jump to the currently selected message.
-#: curs_main.c:3042
+#: curs_main.c:3058
 msgid "Enter macro stroke: "
 msgstr "Wprowadż klawicz makra: "
 
 #. L10N: "message hotkey" is the key bindings menu description of a
 #. macro created by <mark-message>.
-#: curs_main.c:3050
+#: curs_main.c:3066
 msgid "message hotkey"
 msgstr "hotkey listu"
 
 #. L10N: This is echoed after <mark-message> creates a new hotkey
 #. macro.  %s is the hotkey string ($mark_macro_prefix followed
 #. by whatever they typed at the prompt.)
-#: curs_main.c:3055
+#: curs_main.c:3071
 #, c-format
 msgid "Message bound to %s."
 msgstr "Kopia została wysłana do %s."
 
 #. L10N: This error is printed if <mark-message> cannot find a
 #. Message-ID for the currently selected message in the index.
-#: curs_main.c:3063
+#: curs_main.c:3079
 msgid "No message ID to macro."
 msgstr "Brak identyfikatora makra."
 
-#: curs_main.c:3105 pager.c:2961 recvattach.c:1388
+#: curs_main.c:3121 pager.c:2965 recvattach.c:1401
 msgid "Reply by mail as poster prefers?"
 msgstr "Odpowiedzieć przy pomocy maila zgodnie z życzeniem nadawcy?"
 
-#: curs_main.c:3108 pager.c:2927 pager.c:2939 pager.c:2964
+#: curs_main.c:3124 pager.c:2931 pager.c:2943 pager.c:2968
 msgid "Posting to this group not allowed, may be moderated. Continue?"
 msgstr "Dodawanie postów w tej grupie jest niedozwolone, możliwa moderacja. Kontynuować?"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:3173 pager.c:3120
+#: curs_main.c:3189 pager.c:3124
 msgid "Cannot undelete message"
 msgstr "Nieudane przywrócenie listu"
 
@@ -2009,12 +2024,37 @@ msgstr "[-- Komunikaty błędów %s --]\n"
 msgid "[-- Error: message/external-body has no access-type parameter --]\n"
 msgstr "[-- Błąd: message/external-body nie ma ustawionego rodzaju dostępu --]\n"
 
-#: handler.c:1611
+#. L10N: If the translation of this string is a multi line string, then
+#. each line should start with "[-- " and end with " --]".
+#. The first "%s/%s" is a MIME type, e.g. "text/plain". The last %s
+#. expands to a date as returned by `mutt_date_parse_date()`.
+#.
+#. Note: The size argument printed is not the actual number as passed
+#. to gettext but the prettified version, e.g. size = 2048 will be
+#. printed as 2K.  Your language might be sensitive to that: For
+#. example although '1K' and '1024' represent the same number your
+#. language might inflect the noun 'byte' differently.
+#.
+#. Sadly, we cannot do anything about that at the moment besides
+#. passing the precise size in bytes. If you are interested the
+#. function responsible for the prettification is
+#. mutt_str_pretty_size() in mutt/string.c.
+#.
+#: handler.c:1624
 #, fuzzy, c-format
 msgid ""
+"[-- This %s/%s attachment (size %s byte) has been deleted --]\n"
+"[-- on %s --]\n"
+msgid_plural ""
 "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
 "[-- on %s --]\n"
-msgstr ""
+msgstr[0] ""
+"[-- Ten załącznik typu %s/%s (o wielkości %s bajtów) został usunięty --]\n"
+"[-- na %s --]\n"
+msgstr[1] ""
+"[-- Ten załącznik typu %s/%s (o wielkości %s bajtów) został usunięty --]\n"
+"[-- na %s --]\n"
+msgstr[2] ""
 "[-- Ten załącznik typu %s/%s (o wielkości %s bajtów) został usunięty --]\n"
 "[-- na %s --]\n"
 
@@ -2022,10 +2062,24 @@ msgstr ""
 #. each line should start with "[-- " and end with " --]".
 #. The first "%s/%s" is a MIME type, e.g. "text/plain".
 #.
-#: handler.c:1620
+#. Note: The size argument printed is not the actual number as passed
+#. to gettext but the prettified version, e.g. size = 2048 will be
+#. printed as 2K.  Your language might be sensitive to that: For
+#. example although '1K' and '1024' represent the same number your
+#. language might inflect the noun 'byte' differently.
+#.
+#. Sadly, we cannot do anything about that at the moment besides
+#. passing the precise size in bytes. If you are interested the
+#. function responsible for the prettification is
+#. mutt_str_pretty_size() in mutt/string.c.
+#.
+#: handler.c:1648
 #, fuzzy, c-format
-msgid "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
-msgstr "[-- Ten załącznik typu %s/%s (o wielkości %s bajtów) został usunięty --]\n"
+msgid "[-- This %s/%s attachment (size %s byte) has been deleted --]\n"
+msgid_plural "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
+msgstr[0] "[-- Ten załącznik typu %s/%s (o wielkości %s bajtów) został usunięty --]\n"
+msgstr[1] "[-- Ten załącznik typu %s/%s (o wielkości %s bajtów) został usunięty --]\n"
+msgstr[2] "[-- Ten załącznik typu %s/%s (o wielkości %s bajtów) został usunięty --]\n"
 
 #. L10N: If the translation of this string is a multi line string, then
 #. each line should start with "[-- " and end with " --]".
@@ -2035,7 +2089,7 @@ msgstr "[-- Ten załącznik typu %s/%s (o wielkości %s bajtów) został usunię
 #. Caution: Argument three %3$ is also defined but should not be used
 #. in this translation!
 #.
-#: handler.c:1637
+#: handler.c:1667
 #, fuzzy
 msgid ""
 "[-- This %s/%s attachment has been deleted --]\n"
@@ -2048,17 +2102,17 @@ msgstr ""
 #. each line should start with "[-- " and end with " --]".
 #. The first "%s/%s" is a MIME type, e.g. "text/plain".
 #.
-#: handler.c:1646
+#: handler.c:1676
 #, fuzzy, c-format
 msgid "[-- This %s/%s attachment has been deleted --]\n"
 msgstr "[-- Ten załącznik typu %s/%s został usunięty --]\n"
 
-#: handler.c:1656
+#: handler.c:1686
 #, c-format
 msgid "[-- name: %s --]\n"
 msgstr "[-- nazwa: %s --]\n"
 
-#: handler.c:1672
+#: handler.c:1702
 #, fuzzy, c-format
 msgid ""
 "[-- This %s/%s attachment is not included, --]\n"
@@ -2069,7 +2123,7 @@ msgstr ""
 "[-- a podane źródło zewnętrzne jest --]\n"
 "[-- nieaktualne. --]\n"
 
-#: handler.c:1693
+#: handler.c:1723
 #, fuzzy, c-format
 msgid ""
 "[-- This %s/%s attachment is not included, --]\n"
@@ -2078,50 +2132,50 @@ msgstr ""
 "[-- Ten załącznik typu %s/%s nie jest zawarty, --]\n"
 "[-- a podany typ dostępu %s nie jest obsługiwany --]\n"
 
-#: handler.c:1822
+#: handler.c:1852
 msgid "Unable to open memory stream!"
 msgstr "Nie można otworzyć strumienia pamięci!"
 
-#: handler.c:1831
+#: handler.c:1861
 msgid "Unable to open temporary file!"
 msgstr "Nie można otworzyć pliku tymczasowego!"
 
-#: handler.c:1881
+#: handler.c:1911
 msgid "failed to re-open memstream!"
 msgstr "Nie można ponownie otworzyć memstream!"
 
-#: handler.c:2013
+#: handler.c:2043
 msgid "Error: multipart/signed has no protocol."
 msgstr "Błąd: multipart/signed nie ma protokołu."
 
-#: handler.c:2076
+#: handler.c:2106
 #, fuzzy
 msgid "[-- This is an attachment (use '%3$s' to view this part) --]\n"
 msgstr "[-- To jest załącznik (użyj '%3$s' do oglądania tego fragmentu) --]\n"
 
-#: handler.c:2082
+#: handler.c:2112
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported (use '%s' to view this part) --]\n"
 msgstr "[-- typ %s/%s nie jest obsługiwany (użyj '%s' do oglądania tego fragmentu) --]\n"
 
-#: handler.c:2087
+#: handler.c:2117
 #, fuzzy
 msgid "[-- This is an attachment (need 'view-attachments' bound to key!) --]\n"
 msgstr "[-- To jest załącznik (przypisz 'view-attachments' do klawisza!) --]\n"
 
 #. L10N: %s/%s is a MIME type, e.g. "text/plain".
-#: handler.c:2091
+#: handler.c:2121
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported (need 'view-attachments' bound to key!) --]\n"
 msgstr "[-- typ %s/%s nie jest obsługiwany (przypisz 'view-attachments' do klawisza!) --]\n"
 
-#: handler.c:2098
+#: handler.c:2128
 #, fuzzy
 msgid "[-- This is an attachment --]\n"
 msgstr "[-- To jest załącznik --]\n"
 
 #. L10N: %s/%s is a MIME type, e.g. "text/plain".
-#: handler.c:2101
+#: handler.c:2131
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported --]\n"
 msgstr "[-- typ %s/%s nie jest obsługiwany --]\n"
@@ -2427,7 +2481,7 @@ msgstr "Serwer IMAP nie wspiera flag użytkownika"
 msgid "Invalid IMAP flags"
 msgstr "Błędne flagi IMAP"
 
-#: imap/message.c:477 mx.c:1326
+#: imap/message.c:477 mx.c:1336
 msgid "Integer overflow -- can't allocate memory."
 msgstr "Przepełnienie zmiennej całkowitej - nie można zaalokować pamięci."
 
@@ -3184,24 +3238,36 @@ msgstr "Protokół SSL nie jest dostępny, nieudane połączenie z %s"
 msgid "Reading from %s interrupted..."
 msgstr "Przerwano wczytywanie z %s..."
 
-#: mx.c:634
-msgid "message(s) not deleted"
-msgstr "wiadomości nie zostały usunięte"
+#. L10N: Although we now the precise number of messages, we do not show it to the user.
+#. So feel free to use a "generic plural" as plural translation if your language has one.
+#.
+#: mx.c:639
+#, fuzzy
+msgid "message not deleted"
+msgid_plural "messages not deleted"
+msgstr[0] "wiadomości nie zostały usunięte"
+msgstr[1] "wiadomości nie zostały usunięte"
+msgstr[2] "wiadomości nie zostały usunięte"
 
-#: mx.c:671
+#: mx.c:676
 msgid "Can't open trash folder"
 msgstr "Nie można otworzyć folderu trash"
 
-#: mx.c:710
+#: mx.c:715
 msgid "Mark all articles read?"
 msgstr "Zaznaczyć wszystkie artykuły jako przeczytane?"
 
-#: mx.c:754
-#, c-format
-msgid "Move %d read messages to %s?"
-msgstr "Przenieść %d przeczytanych listów do %s?"
+#. L10N: The first argument is the number of read messages to be
+#. moved, the second argument is the target mailbox.
+#: mx.c:762
+#, fuzzy, c-format
+msgid "Move %d read message to %s?"
+msgid_plural "Move %d read messages to %s?"
+msgstr[0] "Przenieść %d przeczytanych listów do %s?"
+msgstr[1] "Przenieść %d przeczytanych listów do %s?"
+msgstr[2] "Przenieść %d przeczytanych listów do %s?"
 
-#: mx.c:771 mx.c:1077
+#: mx.c:781 mx.c:1087
 #, fuzzy, c-format
 msgid "Purge %d deleted message?"
 msgid_plural "Purge %d deleted messages?"
@@ -3209,40 +3275,40 @@ msgstr[0] "Usunąć NIEODWOŁALNIE %d zaznaczony list?"
 msgstr[1] "Usunąć NIEODWOŁALNIE %d zaznaczone listy?"
 msgstr[2] "Usunąć NIEODWOŁALNIE %d zaznaczone listy?"
 
-#: mx.c:793
+#: mx.c:803
 #, c-format
 msgid "Moving read messages to %s..."
 msgstr "Przenoszenie przeczytanych listów do %s..."
 
-#: mx.c:859 mx.c:1068
+#: mx.c:869 mx.c:1078
 msgid "Mailbox is unchanged."
 msgstr "Skrzynka pozostała niezmieniona."
 
-#: mx.c:914
+#: mx.c:924
 #, c-format
 msgid "%d kept, %d moved, %d deleted."
 msgstr "%d zapisano, %d przeniesiono, %d usunięto."
 
-#: mx.c:917 mx.c:1130
+#: mx.c:927 mx.c:1140
 #, c-format
 msgid "%d kept, %d deleted."
 msgstr "%d zapisano, %d usunięto."
 
-#: mx.c:1052
+#: mx.c:1062
 #, c-format
 msgid " Press '%s' to toggle write"
 msgstr " Naciśnij '%s' aby zezwolić na zapisanie"
 
-#: mx.c:1054
+#: mx.c:1064
 msgid "Use 'toggle-write' to re-enable write!"
 msgstr "Użyj 'toggle-write' by ponownie włączyć zapisanie!"
 
-#: mx.c:1056
+#: mx.c:1066
 #, c-format
 msgid "Mailbox is marked unwritable. %s"
 msgstr "Skrzynka jest oznaczona jako niezapisywalna. %s"
 
-#: mx.c:1124
+#: mx.c:1134
 msgid "Mailbox checkpointed."
 msgstr "Zmiany w skrzynce naniesiono."
 
@@ -3256,52 +3322,57 @@ msgstr " (bieżąca data i czas: %c)"
 msgid "[-- %s output follows%s --]\n"
 msgstr "[-- Wynik działania %s %s --]\n"
 
-#: ncrypt/crypt.c:95
-msgid "Passphrase(s) forgotten."
+#. L10N: Due to the implementation details (e.g. some passwords are managed
+#. by gpg-agent) we cannot know whether we forgot zero, 1, 12, ...
+#. passwords. So in English we use "Passphrases". Your language might
+#. have other means to express this.
+#: ncrypt/crypt.c:100
+#, fuzzy
+msgid "Passphrases forgotten."
 msgstr "Hasło(a) zostało(y) zapomniane."
 
-#: ncrypt/crypt.c:155
+#: ncrypt/crypt.c:161
 msgid "Inline PGP can't be used with attachments.  Revert to PGP/MIME?"
 msgstr "Inline PGP nie może zostać użyte do załączników. Użyć PGP/MIME?"
 
-#: ncrypt/crypt.c:159
+#: ncrypt/crypt.c:165
 msgid "Mail not sent: inline PGP can't be used with attachments."
 msgstr "Nie wysłano listu: PGP w treści nie może być używane z załącznikami."
 
-#: ncrypt/crypt.c:166
+#: ncrypt/crypt.c:172
 msgid "Inline PGP can't be used with format=flowed.  Revert to PGP/MIME?"
 msgstr "Inline PGP nie może zostać użyte do formatowania format=flow. Użyć PGP/MIME?"
 
-#: ncrypt/crypt.c:170
+#: ncrypt/crypt.c:176
 msgid "Mail not sent: inline PGP can't be used with format=flowed."
 msgstr "Nie wysłano listu: PGP w treści nie może być używane z format=flowed."
 
-#: ncrypt/crypt.c:180 ncrypt/cryptglue.c:125 ncrypt/pgpkey.c:589
+#: ncrypt/crypt.c:186 ncrypt/cryptglue.c:125 ncrypt/pgpkey.c:589
 #: ncrypt/pgpkey.c:782
 msgid "Invoking PGP..."
 msgstr "Wywoływanie PGP..."
 
-#: ncrypt/crypt.c:192
+#: ncrypt/crypt.c:198
 msgid "Message can't be sent inline.  Revert to using PGP/MIME?"
 msgstr "Nie można wysłać listu w trybie inline. Zastosować PGP/MIME?"
 
-#: ncrypt/crypt.c:194 send.c:1824
+#: ncrypt/crypt.c:200 send.c:1824
 msgid "Mail not sent."
 msgstr "List nie został wysłany."
 
-#: ncrypt/crypt.c:540
+#: ncrypt/crypt.c:546
 msgid "S/MIME messages with no hints on content are unsupported."
 msgstr "Listy S/MIME bez wskazówek co do zawartości nie są obsługiwane."
 
-#: ncrypt/crypt.c:754 ncrypt/crypt.c:795
+#: ncrypt/crypt.c:760 ncrypt/crypt.c:801
 msgid "Trying to extract PGP keys...\n"
 msgstr "Próba skopiowania kluczy PGP...\n"
 
-#: ncrypt/crypt.c:776 ncrypt/crypt.c:816
+#: ncrypt/crypt.c:782 ncrypt/crypt.c:822
 msgid "Trying to extract S/MIME certificates...\n"
 msgstr "Próba skopiowania kluczy S/MIME...\n"
 
-#: ncrypt/crypt.c:976
+#: ncrypt/crypt.c:982
 #, c-format
 msgid ""
 "[-- Error: Unknown multipart/signed protocol %s! --]\n"
@@ -3310,7 +3381,7 @@ msgstr ""
 "[-- Błąd: Nieznany protokół multipart/signed %s! --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1016
+#: ncrypt/crypt.c:1022
 #, fuzzy
 msgid ""
 "[-- Error: Missing or bad-format multipart/signed signature! --]\n"
@@ -3319,7 +3390,7 @@ msgstr ""
 "[-- Błąd: Niespójna struktura multipart/signed ! --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1058
+#: ncrypt/crypt.c:1064
 #, c-format
 msgid ""
 "[-- Warning: We can't verify %s/%s signatures. --]\n"
@@ -3328,7 +3399,7 @@ msgstr ""
 "[-- Ostrzeżenie: nie można zweryfikować podpisów %s/%s --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1070
+#: ncrypt/crypt.c:1076
 msgid ""
 "[-- The following data is signed --]\n"
 "\n"
@@ -3336,7 +3407,7 @@ msgstr ""
 "[-- Poniższe dane są podpisane --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1075
+#: ncrypt/crypt.c:1081
 msgid ""
 "[-- Warning: Can't find any signatures. --]\n"
 "\n"
@@ -3344,7 +3415,7 @@ msgstr ""
 "[-- Ostrzeżenie: Nie znaleziono żadnych podpisów. --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1081
+#: ncrypt/crypt.c:1087
 msgid ""
 "\n"
 "[-- End of signed data --]\n"
@@ -3395,7 +3466,7 @@ msgstr ""
 msgid "error reading data object: %s\n"
 msgstr "Błąd czytania obiektu danych: %s\n"
 
-#: ncrypt/crypt_gpgme.c:662 ncrypt/crypt_gpgme.c:3848 ncrypt/pgpkey.c:585
+#: ncrypt/crypt_gpgme.c:662 ncrypt/crypt_gpgme.c:3850 ncrypt/pgpkey.c:585
 #: ncrypt/pgpkey.c:768
 msgid "Can't create temporary file"
 msgstr "Nie można utworzyć pliku tymczasowego"
@@ -3743,28 +3814,31 @@ msgstr "[Błędny]"
 
 #. L10N: This is printed after "Key Type: " and looks like this:
 #. *       PGP, 2048 bit RSA
-#: ncrypt/crypt_gpgme.c:3670 ncrypt/crypt_gpgme.c:3808
-#, c-format
+#: ncrypt/crypt_gpgme.c:3670 ncrypt/crypt_gpgme.c:3810
+#, fuzzy, c-format
 msgid "%s, %lu bit %s\n"
-msgstr "%s, %lu bitów %s\n"
+msgid_plural "%s, %lu bit %s\n"
+msgstr[0] "%s, %lu bitów %s\n"
+msgstr[1] "%s, %lu bitów %s\n"
+msgstr[2] "%s, %lu bitów %s\n"
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3678 ncrypt/crypt_gpgme.c:3815
+#: ncrypt/crypt_gpgme.c:3678 ncrypt/crypt_gpgme.c:3817
 msgid "encryption"
 msgstr "szyfrowanie"
 
 #: ncrypt/crypt_gpgme.c:3679 ncrypt/crypt_gpgme.c:3685
-#: ncrypt/crypt_gpgme.c:3816 ncrypt/crypt_gpgme.c:3821
+#: ncrypt/crypt_gpgme.c:3818 ncrypt/crypt_gpgme.c:3823
 msgid ", "
 msgstr ", "
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3684 ncrypt/crypt_gpgme.c:3820
+#: ncrypt/crypt_gpgme.c:3684 ncrypt/crypt_gpgme.c:3822
 msgid "signing"
 msgstr "podpisywanie"
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3690 ncrypt/crypt_gpgme.c:3825
+#: ncrypt/crypt_gpgme.c:3690 ncrypt/crypt_gpgme.c:3827
 msgid "certification"
 msgstr "certyfikowanie"
 
@@ -3783,64 +3857,64 @@ msgstr "[Wygasły]"
 msgid "[Disabled]"
 msgstr "[Zablokowany]"
 
-#: ncrypt/crypt_gpgme.c:3851
+#: ncrypt/crypt_gpgme.c:3853
 msgid "Collecting data..."
 msgstr "Gromadzenie danych..."
 
-#: ncrypt/crypt_gpgme.c:3876
+#: ncrypt/crypt_gpgme.c:3878
 #, c-format
 msgid "Error finding issuer key: %s\n"
 msgstr "Nie znaleziono klucza wydawcy: %s\n"
 
-#: ncrypt/crypt_gpgme.c:3885
+#: ncrypt/crypt_gpgme.c:3887
 msgid "Error: certification chain too long - stopping here\n"
 msgstr "Błąd: łąńcuch certyfikatów zbyt długi - przetwarzanie zatrzymano tutaj\n"
 
-#: ncrypt/crypt_gpgme.c:3895 ncrypt/pgpkey.c:608
+#: ncrypt/crypt_gpgme.c:3897 ncrypt/pgpkey.c:608
 #, c-format
 msgid "Key ID: 0x%s"
 msgstr "Identyfikator klucza: 0x%s"
 
-#: ncrypt/crypt_gpgme.c:3990
+#: ncrypt/crypt_gpgme.c:3992
 #, c-format
 msgid "gpgme_new failed: %s"
 msgstr "wykonanie gpgme_new nie powiodło się: %s"
 
-#: ncrypt/crypt_gpgme.c:4028 ncrypt/crypt_gpgme.c:4079
+#: ncrypt/crypt_gpgme.c:4030 ncrypt/crypt_gpgme.c:4081
 #, c-format
 msgid "gpgme_op_keylist_start failed: %s"
 msgstr "wykonanie gpgme_op_keylist_start nie powiodło się: %s"
 
-#: ncrypt/crypt_gpgme.c:4067 ncrypt/crypt_gpgme.c:4109
+#: ncrypt/crypt_gpgme.c:4069 ncrypt/crypt_gpgme.c:4111
 #, c-format
 msgid "gpgme_op_keylist_next failed: %s"
 msgstr "wykonanie gpgme_op_keylist_next nie powiodło się: %s"
 
-#: ncrypt/crypt_gpgme.c:4185
+#: ncrypt/crypt_gpgme.c:4187
 msgid "All matching keys are marked expired/revoked."
 msgstr "Wszystkie pasujące klucze są zaznaczone jako wygasłe lub wycofane."
 
-#: ncrypt/crypt_gpgme.c:4215 ncrypt/pgpkey.c:543 ncrypt/smime.c:475
+#: ncrypt/crypt_gpgme.c:4217 ncrypt/pgpkey.c:543 ncrypt/smime.c:475
 msgid "Select  "
 msgstr "Wybór  "
 
-#: ncrypt/crypt_gpgme.c:4217 ncrypt/pgpkey.c:545
+#: ncrypt/crypt_gpgme.c:4219 ncrypt/pgpkey.c:545
 msgid "Check key  "
 msgstr "Sprawdź klucz  "
 
-#: ncrypt/crypt_gpgme.c:4233
+#: ncrypt/crypt_gpgme.c:4235
 msgid "PGP and S/MIME keys matching"
 msgstr "Pasujące klucze PGP i S/MIME"
 
-#: ncrypt/crypt_gpgme.c:4235
+#: ncrypt/crypt_gpgme.c:4237
 msgid "PGP keys matching"
 msgstr "Pasujące klucze PGP"
 
-#: ncrypt/crypt_gpgme.c:4237
+#: ncrypt/crypt_gpgme.c:4239
 msgid "S/MIME keys matching"
 msgstr "Pasujące klucze S/MIME"
 
-#: ncrypt/crypt_gpgme.c:4239
+#: ncrypt/crypt_gpgme.c:4241
 msgid "keys matching"
 msgstr "pasujące klucze"
 
@@ -3848,69 +3922,69 @@ msgstr "pasujące klucze"
 #. %1$s is one of the previous four entries.
 #. %2$s is an address.
 #. e.g. "S/MIME keys matching <me@mutt.org>."
-#: ncrypt/crypt_gpgme.c:4246
+#: ncrypt/crypt_gpgme.c:4248
 #, c-format
 msgid "%s <%s>."
 msgstr "%s <%s>."
 
 #. L10N:
 #. e.g. 'S/MIME keys matching "Michael Elkins".'
-#: ncrypt/crypt_gpgme.c:4250
+#: ncrypt/crypt_gpgme.c:4252
 #, c-format
 msgid "%s \"%s\"."
 msgstr "%s \"%s\"."
 
-#: ncrypt/crypt_gpgme.c:4277 ncrypt/pgpkey.c:628
+#: ncrypt/crypt_gpgme.c:4279 ncrypt/pgpkey.c:628
 msgid "This key can't be used: expired/disabled/revoked."
 msgstr "Nie można użyć tego klucza: wygasł, został wyłączony lub wyprowadzony."
 
-#: ncrypt/crypt_gpgme.c:4290 ncrypt/pgpkey.c:640 ncrypt/smime.c:505
+#: ncrypt/crypt_gpgme.c:4292 ncrypt/pgpkey.c:640 ncrypt/smime.c:505
 #, fuzzy
 msgid "ID is expired/disabled/revoked. Do you really want to use the key?"
 msgstr "Identyfikator wygasł, został wyłączony lub wyprowadzony. Czy naprawdę chcesz użyć tego klucza?"
 
-#: ncrypt/crypt_gpgme.c:4299 ncrypt/pgpkey.c:650
+#: ncrypt/crypt_gpgme.c:4301 ncrypt/pgpkey.c:650
 #, fuzzy
 msgid "ID is not valid. Do you really want to use the key?"
 msgstr "Nieprawidłowy identyfikator. Czy naprawdę chcesz użyć tego klucza?"
 
-#: ncrypt/crypt_gpgme.c:4302 ncrypt/pgpkey.c:653
+#: ncrypt/crypt_gpgme.c:4304 ncrypt/pgpkey.c:653
 #, fuzzy
 msgid "ID is only marginally valid. Do you really want to use the key?"
 msgstr "Ten identyfikator jest tylko częściowo ważny. Czy naprawdę chcesz użyć tego klucza?"
 
-#: ncrypt/crypt_gpgme.c:4310 ncrypt/pgpkey.c:646 ncrypt/smime.c:509
+#: ncrypt/crypt_gpgme.c:4312 ncrypt/pgpkey.c:646 ncrypt/smime.c:509
 #, fuzzy
 msgid "ID has undefined validity. Do you really want to use the key?"
 msgstr "Poziom ważności tego identyfikatora nie został określony. Czy naprawdę chcesz użyć tego klucza?"
 
-#: ncrypt/crypt_gpgme.c:4370 ncrypt/crypt_gpgme.c:4479 ncrypt/pgpkey.c:872
+#: ncrypt/crypt_gpgme.c:4372 ncrypt/crypt_gpgme.c:4481 ncrypt/pgpkey.c:872
 #: ncrypt/pgpkey.c:995
 #, c-format
 msgid "Looking for keys matching \"%s\"..."
 msgstr "Wyszukiwanie odpowiednich kluczy dla \"%s\"..."
 
-#: ncrypt/crypt_gpgme.c:4593 ncrypt/pgpkey.c:731 ncrypt/smime.c:811
+#: ncrypt/crypt_gpgme.c:4595 ncrypt/pgpkey.c:731 ncrypt/smime.c:811
 #, c-format
 msgid "No matching keys found for \"%s\""
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4644 ncrypt/pgp.c:1263
+#: ncrypt/crypt_gpgme.c:4646 ncrypt/pgp.c:1263
 #, c-format
 msgid "Use keyID = \"%s\" for %s?"
 msgstr "Użyć klucza numer \"%s\" dla %s?"
 
-#: ncrypt/crypt_gpgme.c:4695 ncrypt/pgp.c:1312 ncrypt/smime.c:830
+#: ncrypt/crypt_gpgme.c:4697 ncrypt/pgp.c:1312 ncrypt/smime.c:830
 #: ncrypt/smime.c:938
 #, c-format
 msgid "Enter keyID for %s: "
 msgstr "Wprowadź numer klucza dla %s: "
 
-#: ncrypt/crypt_gpgme.c:4755 ncrypt/pgpkey.c:751
+#: ncrypt/crypt_gpgme.c:4757 ncrypt/pgpkey.c:751
 msgid "Please enter the key ID: "
 msgstr "Podaj identyfikator klucza: "
 
-#: ncrypt/crypt_gpgme.c:4768
+#: ncrypt/crypt_gpgme.c:4770
 #, c-format
 msgid "Error exporting key: %s\n"
 msgstr "Błąd eksportowania klucza: %s\n"
@@ -3919,80 +3993,80 @@ msgstr "Błąd eksportowania klucza: %s\n"
 #. MIME description for exported (attached) keys.
 #. You can translate this entry to a non-ASCII string (it will be encoded),
 #. but it may be safer to keep it untranslated.
-#: ncrypt/crypt_gpgme.c:4787
+#: ncrypt/crypt_gpgme.c:4789
 #, c-format
 msgid "PGP Key 0x%s."
 msgstr "Klucz PGP 0x%s."
 
-#: ncrypt/crypt_gpgme.c:4830
+#: ncrypt/crypt_gpgme.c:4832
 msgid "GPGME: OpenPGP protocol not available"
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4838
+#: ncrypt/crypt_gpgme.c:4840
 msgid "GPGME: CMS protocol not available"
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4876
+#: ncrypt/crypt_gpgme.c:4878
 msgid "S/MIME (s)ign, sign (a)s, (p)gp, (c)lear, or (o)ppenc mode off? "
 msgstr "S/MIME: (p)odpisz, podpisz (j)ako, p(g)p, wy(c)zyść lub wyłącz tryb (o)ppenc? "
 
 #. L10N: S/MIME options (opportunistic encryption is on)
-#: ncrypt/crypt_gpgme.c:4878
+#: ncrypt/crypt_gpgme.c:4880
 msgid "sapco"
 msgstr "pjgco"
 
-#: ncrypt/crypt_gpgme.c:4885
+#: ncrypt/crypt_gpgme.c:4887
 msgid "PGP (s)ign, sign (a)s, s/(m)ime, (c)lear, or (o)ppenc mode off? "
 msgstr "PGP: (p)odpisz, podpisz (j)ako, s/(m)ime, wy(c)zyść lub wyłącz tryb (o)ppenc? "
 
 #. L10N: PGP options (opportunistic encryption is on)
-#: ncrypt/crypt_gpgme.c:4887
+#: ncrypt/crypt_gpgme.c:4889
 msgid "samco"
 msgstr "pjmco"
 
 #. L10N: S/MIME options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4900
+#: ncrypt/crypt_gpgme.c:4902
 msgid "S/MIME (e)ncrypt, (s)ign, sign (a)s, (b)oth, (p)gp, (c)lear, or (o)ppenc mode? "
 msgstr "S/MIME: (z)aszyfruj, (p)odpisz, podpisz (j)ako, o(b)a, p(g)p, wy(c)zyść lub tryb (o)ppenc? "
 
 #. L10N: S/MIME options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4903
+#: ncrypt/crypt_gpgme.c:4905
 msgid "esabpco"
 msgstr "zpjbgco"
 
 #. L10N: PGP options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4909
+#: ncrypt/crypt_gpgme.c:4911
 msgid "PGP (e)ncrypt, (s)ign, sign (a)s, (b)oth, s/(m)ime, (c)lear, or (o)ppenc mode? "
 msgstr "PGP: (z)aszyfruj, (p)odpisz, podpisz (j)ako, o(b)a, (s)/mime, wy(c)zyść lub tryb (o)ppenc? "
 
 #. L10N: PGP options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4912
+#: ncrypt/crypt_gpgme.c:4914
 msgid "esabmco"
 msgstr "zpjbsco"
 
-#: ncrypt/crypt_gpgme.c:4925
+#: ncrypt/crypt_gpgme.c:4927
 msgid "S/MIME (e)ncrypt, (s)ign, sign (a)s, (b)oth, (p)gp or (c)lear? "
 msgstr "S/MIME: (z)aszyfruj, (p)odpisz, podpisz (j)ako, o(b)a, p(g)p, (a)nuluj?"
 
 #. L10N: S/MIME options
-#: ncrypt/crypt_gpgme.c:4927
+#: ncrypt/crypt_gpgme.c:4929
 msgid "esabpc"
 msgstr "zpjbga"
 
-#: ncrypt/crypt_gpgme.c:4934
+#: ncrypt/crypt_gpgme.c:4936
 msgid "PGP (e)ncrypt, (s)ign, sign (a)s, (b)oth, s/(m)ime or (c)lear? "
 msgstr "PGP: (z)aszyfruj, (p)odpisz, podpisz (j)ako, o(b)a, (s)/mime lub (w)yczyść? "
 
 #. L10N: PGP options
-#: ncrypt/crypt_gpgme.c:4936
+#: ncrypt/crypt_gpgme.c:4938
 msgid "esabmc"
 msgstr "zpjbsw"
 
-#: ncrypt/crypt_gpgme.c:5087
+#: ncrypt/crypt_gpgme.c:5089
 msgid "Failed to verify sender"
 msgstr "Błąd weryfikacji nadawcy"
 
-#: ncrypt/crypt_gpgme.c:5090
+#: ncrypt/crypt_gpgme.c:5092
 msgid "Failed to figure out sender"
 msgstr "Błąd określenia nadawcy"
 
@@ -4381,7 +4455,7 @@ msgstr "Nie zdefiniowano serwer wiadomości"
 msgid "%s is an invalid news server specification!"
 msgstr "%s jest nieprawidłową specyfikacją serwera wiadomości!"
 
-#: nntp.c:75 nntp.c:612 pop.c:1028 pop_lib.c:405
+#: nntp.c:75 nntp.c:612 pop.c:1031 pop_lib.c:405
 msgid "Server closed connection!"
 msgstr "Serwer zamknął połączenie!"
 
@@ -4539,15 +4613,18 @@ msgid "check mailboxes for new mail"
 msgstr "szukaj nowych listów w skrzynkach"
 
 #: opcodes.h:47
-msgid "attach file(s) to this message"
+#, fuzzy
+msgid "attach files to this message"
 msgstr "załącz pliki do li(s)tu"
 
 #: opcodes.h:48
-msgid "attach message(s) to this message"
+#, fuzzy
+msgid "attach messages to this message"
 msgstr "dołącz list(y) do tego listu"
 
 #: opcodes.h:49
-msgid "attach news article(s) to this message"
+#, fuzzy
+msgid "attach news articles to this message"
 msgstr "załącz nowe artykuły do tego listu"
 
 #: opcodes.h:50
@@ -5367,7 +5444,8 @@ msgid "extract supported public keys"
 msgstr "kopiuj klucze publiczne"
 
 #: opcodes.h:255
-msgid "wipe passphrase(s) from memory"
+#, fuzzy
+msgid "wipe passphrases from memory"
 msgstr "wymaż hasło z pamięci operacyjnej"
 
 #: opcodes.h:259
@@ -5698,18 +5776,21 @@ msgstr "Brak nowej poczty w skrzynce POP."
 msgid "Delete messages from server?"
 msgstr "Usunąć listy z serwera?"
 
-#: pop.c:954
-#, c-format
-msgid "Reading new messages (%d bytes)..."
-msgstr "Czytanie nowych listów (%d bajtów)..."
+#: pop.c:955
+#, fuzzy, c-format
+msgid "Reading new messages (%d byte)..."
+msgid_plural "Reading new messages (%d bytes)..."
+msgstr[0] "Czytanie nowych listów (%d bajtów)..."
+msgstr[1] "Czytanie nowych listów (%d bajtów)..."
+msgstr[2] "Czytanie nowych listów (%d bajtów)..."
 
-#: pop.c:997
+#: pop.c:1000
 msgid "Error while writing mailbox!"
 msgstr "Błąd podczas zapisywania skrzynki!"
 
 #. L10N: The plural is picked by the second numerical argument, i.e.
 #. * the %d right before 'messages', i.e. the total number of messages.
-#: pop.c:1003
+#: pop.c:1006
 #, fuzzy, c-format
 msgid "%s [%d of %d message read]"
 msgid_plural "%s [%d of %d messages read]"
@@ -5854,47 +5935,55 @@ msgstr "Wyślij przez potok do: "
 msgid "I don't know how to print %s attachments!"
 msgstr "Nie wiem jak wydrukować %s załączników!"
 
-#: recvattach.c:841
-msgid "Print tagged attachment(s)?"
-msgstr "Wydrukować zaznaczony(e) załącznik(i)?"
+#. L10N: Although we now the precise number of tagged messages, we
+#. do not show it to the user.  So feel free to use a "generic
+#. plural" as plural translation if your language has one.
+#: recvattach.c:852
+#, fuzzy, c-format
+msgid "Print tagged attachment?"
+msgid_plural "Print %d tagged attachments?"
+msgstr[0] "Wydrukować zaznaczony(e) załącznik(i)?"
+msgstr[1] "Wydrukować zaznaczony(e) załącznik(i)?"
+msgstr[2] "Wydrukować zaznaczony(e) załącznik(i)?"
 
-#: recvattach.c:842
+#: recvattach.c:853
+#, c-format
 msgid "Print attachment?"
 msgstr "Wydrukować załącznik?"
 
-#: recvattach.c:900
+#: recvattach.c:913
 msgid "Structural changes to decrypted attachments are not supported"
 msgstr ""
 
-#: recvattach.c:1046
+#: recvattach.c:1059
 msgid "Can't decrypt encrypted message!"
 msgstr "Nie można odszyfrować zaszyfrowanego listu!"
 
-#: recvattach.c:1172
+#: recvattach.c:1185
 msgid "Attachments"
 msgstr "Załączniki"
 
-#: recvattach.c:1210
+#: recvattach.c:1223
 msgid "There are no subparts to show!"
 msgstr "Brak pod-listów!"
 
-#: recvattach.c:1265
+#: recvattach.c:1278
 msgid "Can't delete attachment from POP server."
 msgstr "Nie można skasować załącznika na serwerze POP."
 
-#: recvattach.c:1274
+#: recvattach.c:1287
 msgid "Can't delete attachment from news server."
 msgstr "Nie można skasować załącznika na serwerze wiadomości."
 
-#: recvattach.c:1281
+#: recvattach.c:1294
 msgid "Deletion of attachments from encrypted messages is unsupported."
 msgstr "Usuwanie załączników z zaszyfrowanych listów jest niemożliwe."
 
-#: recvattach.c:1287
+#: recvattach.c:1300
 msgid "Deletion of attachments from signed messages may invalidate the signature."
 msgstr "Usuwanie załączników z zaszyfrowanych listów może spowodować nieważność podpisu."
 
-#: recvattach.c:1305 recvattach.c:1320
+#: recvattach.c:1318 recvattach.c:1333
 msgid "Only deletion of multipart attachments is supported."
 msgstr "Możliwe jest jedynie usuwanie załączników multipart."
 
@@ -6322,3 +6411,13 @@ msgstr "Domyślne opcje:"
 #: version.c:404
 msgid "Compile options:"
 msgstr "Parametry kompilacji:"
+
+#~ msgid "Cannot delete message(s)"
+#~ msgstr "Nie mogę usunąć listów"
+
+#~ msgid "Cannot undelete message(s)"
+#~ msgstr "Nie mogę przywrócić listów"
+
+#, fuzzy
+#~ msgid "messages not deleted"
+#~ msgstr "wiadomości nie zostały usunięte"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neomutt-20180512\n"
 "Report-Msgid-Bugs-To: neomutt-devel@neomutt.org\n"
-"POT-Creation-Date: 2018-05-20 02:02+0000\n"
+"POT-Creation-Date: 2018-05-22 14:18+0000\n"
 "PO-Revision-Date: 2018-03-19 01:14-0300\n"
 "Last-Translator: Thiago Costa de Paiva <tecepe@tecepe.eng.br>\n"
 "Language-Team: \n"
@@ -40,7 +40,7 @@ msgstr "Escolher"
 
 #: addrbook.c:52 browser.c:75 browser.c:87 compose.c:160 compose.c:172
 #: conn/ssl.c:1041 conn/ssl_gnutls.c:793 curs_main.c:748 curs_main.c:761
-#: history.c:106 ncrypt/crypt_gpgme.c:4219 ncrypt/pgpkey.c:547
+#: history.c:106 ncrypt/crypt_gpgme.c:4221 ncrypt/pgpkey.c:547
 #: ncrypt/smime.c:477 pager.c:2141 postpone.c:65 query.c:72 recvattach.c:70
 msgid "Help"
 msgstr "Ajuda"
@@ -660,7 +660,7 @@ msgstr "Segurança: "
 #. * Since it shares the row with "Encrypt with:", it should not be longer
 #. * than 15-20 character cells.
 #.
-#: compose.c:138 ncrypt/crypt_gpgme.c:4947 ncrypt/pgp.c:1786
+#: compose.c:138 ncrypt/crypt_gpgme.c:4949 ncrypt/pgp.c:1786
 #: ncrypt/smime.c:2127
 msgid "Sign as: "
 msgstr "Assinar como: "
@@ -1189,7 +1189,7 @@ msgstr "r)rejeitar, o)aceitar uma vez, s)pular"
 msgid "(r)eject, accept (o)nce"
 msgstr "r)rejeitar, o)aceitar uma vez"
 
-#: conn/ssl.c:1039 conn/ssl_gnutls.c:791 ncrypt/crypt_gpgme.c:4213
+#: conn/ssl.c:1039 conn/ssl_gnutls.c:791 ncrypt/crypt_gpgme.c:4215
 #: ncrypt/pgpkey.c:541 ncrypt/smime.c:473
 msgid "Exit  "
 msgstr "Sair  "
@@ -1368,11 +1368,11 @@ msgstr "Nenhuma caixa de mensagens aberta."
 msgid "There are no messages."
 msgstr "Não há mensagens."
 
-#: curs_main.c:77 mx.c:1061 pager.c:73 recvattach.c:56
+#: curs_main.c:77 mx.c:1071 pager.c:73 recvattach.c:56
 msgid "Mailbox is read-only."
 msgstr "Esta caixa é somente para leitura."
 
-#: curs_main.c:79 pager.c:75 recvattach.c:1145
+#: curs_main.c:79 pager.c:75 recvattach.c:1158
 msgid "Function not permitted in attach-message mode."
 msgstr "Função não permitida no modo de anexar mensagem (attach-message)."
 
@@ -1502,235 +1502,245 @@ msgid "That message is not visible."
 msgstr "Aquela mensagem não está visível."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:1377 curs_main.c:2772 pager.c:2818
-msgid "Cannot delete message(s)"
+#. L10N: Due to the implementation details we do not know whether we
+#. delete zero, 1, 12, ... messages. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:1381 curs_main.c:2784 pager.c:2822
+#, fuzzy
+msgid "Cannot delete messages"
 msgstr "Não pude remover mensagem(ns)"
 
-#: curs_main.c:1380
+#: curs_main.c:1384
 msgid "Delete messages matching: "
 msgstr "Apagar mensagens que coincidam: "
 
-#: curs_main.c:1421
+#: curs_main.c:1425
 msgid "No limit pattern is in effect."
 msgstr "Nenhum padrão limitante está em efeito."
 
 #. L10N: ask for a limit to apply
-#: curs_main.c:1426
+#: curs_main.c:1430
 #, c-format
 msgid "Limit: %s"
 msgstr "Limitar: %s"
 
-#: curs_main.c:1464
+#: curs_main.c:1468
 msgid "Limit to messages matching: "
 msgstr "Limitar a mensagens que casem com: "
 
-#: curs_main.c:1488
+#: curs_main.c:1492
 msgid "To view all messages, limit to \"all\"."
 msgstr "Para exibir todas as mensagens, restrinja para \"all\"."
 
-#: curs_main.c:1500 pager.c:2318
+#: curs_main.c:1504 pager.c:2318
 msgid "Quit NeoMutt?"
 msgstr "Sair do NeoMutt?"
 
-#: curs_main.c:1596
+#: curs_main.c:1600
 msgid "Tag messages matching: "
 msgstr "Marcar mensagens que casem com: "
 
 #. L10N: CHECK_ACL
-#: curs_main.c:1606 curs_main.c:3203 pager.c:3137
-msgid "Cannot undelete message(s)"
+#. L10N: Due to the implementation details we do not know whether we
+#. undelete zero, 1, 12, ... messages. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:1614 curs_main.c:3223 pager.c:3145
+#, fuzzy
+msgid "Cannot undelete messages"
 msgstr "Não pude restaurar mensagem(ns)."
 
-#: curs_main.c:1609
+#: curs_main.c:1617
 msgid "Undelete messages matching: "
 msgstr "Restaurar mensagens que casem com: "
 
-#: curs_main.c:1619
+#: curs_main.c:1627
 msgid "Untag messages matching: "
 msgstr "Desmarcar mensagens que casem com: "
 
-#: curs_main.c:1653
+#: curs_main.c:1661
 msgid "Logged out of IMAP servers."
 msgstr "Conexões com os servidores IMAP encerradas."
 
-#: curs_main.c:1753
+#: curs_main.c:1761
 msgid "No virtual folder, aborting."
 msgstr "Não há pasta virtual, cancelado."
 
-#: curs_main.c:1761
+#: curs_main.c:1769
 msgid "Failed to read thread, aborting."
 msgstr "Falha ao accessar thread, cancelado."
 
-#: curs_main.c:1793 mx.c:1458 mx.c:1475
+#: curs_main.c:1801 mx.c:1468 mx.c:1485
 msgid "Folder doesn't support tagging, aborting."
 msgstr "Pasta não tem suporte a tags, cancelado."
 
-#: curs_main.c:1808
+#: curs_main.c:1816
 msgid "No tag specified, aborting."
 msgstr "Nenhuma marcação, cancelado."
 
-#: curs_main.c:1820
+#: curs_main.c:1828
 #, c-format
 msgid "Update tags..."
 msgstr "Atualizando marcas..."
 
-#: curs_main.c:1857
+#: curs_main.c:1865
 msgid "Failed to modify tags, aborting."
 msgstr "Falha ao modificar marcas, cancelado."
 
-#: curs_main.c:1898
+#: curs_main.c:1906
 msgid "No query, aborting."
 msgstr "Nenhuma consulta, cancelado."
 
-#: curs_main.c:1902 curs_main.c:1922 curs_main.c:1941
+#: curs_main.c:1910 curs_main.c:1930 curs_main.c:1949
 msgid "Failed to create query, aborting."
 msgstr "Falha ao criar consulta, cancelado."
 
-#: curs_main.c:1911 curs_main.c:1930
+#: curs_main.c:1919 curs_main.c:1938
 msgid "Windowed queries disabled."
 msgstr "Consultas restritas desabilitadas."
 
-#: curs_main.c:1916 curs_main.c:1935
+#: curs_main.c:1924 curs_main.c:1943
 msgid "No notmuch vfolder currently loaded."
 msgstr "Nenhuma pasta virtual do notmuch carregada."
 
-#: curs_main.c:1973
+#: curs_main.c:1981
 msgid "Open mailbox in read-only mode"
 msgstr "Abrir caixa de mensagens somente para leitura"
 
-#: curs_main.c:1976
+#: curs_main.c:1984
 msgid "Open virtual folder"
 msgstr "Abrir pasta virtual"
 
-#: curs_main.c:1979
+#: curs_main.c:1987
 msgid "Open mailbox"
 msgstr "Abrir caixa de mensagens"
 
-#: curs_main.c:1989
+#: curs_main.c:1997
 msgid "No mailboxes have new mail"
 msgstr "Nenhuma caixa com novas mensagens."
 
-#: curs_main.c:2036
+#: curs_main.c:2044
 msgid "Open newsgroup in read-only mode"
 msgstr "Abrir grupo de notícias em modo somente leitura"
 
-#: curs_main.c:2038
+#: curs_main.c:2046
 msgid "Open newsgroup"
 msgstr "Abrir grupo de notícias"
 
-#: curs_main.c:2141
+#: curs_main.c:2149
 msgid "Exit NeoMutt without saving?"
 msgstr "Sair do NeoMutt sem salvar alterações?"
 
-#: curs_main.c:2157
+#: curs_main.c:2165
 msgid "Cannot break thread"
 msgstr "Não pude quebrar a thread."
 
-#: curs_main.c:2160 curs_main.c:2198 curs_main.c:2658 curs_main.c:2690
+#: curs_main.c:2168 curs_main.c:2206 curs_main.c:2666 curs_main.c:2698
 #: flags.c:376 thread.c:1078 thread.c:1134 thread.c:1202
 msgid "Threading is not enabled."
 msgstr "Visualização por threads não está habilitado."
 
-#: curs_main.c:2173
+#: curs_main.c:2181
 msgid "Thread broken"
 msgstr "Thread quebrada"
 
-#: curs_main.c:2185
+#: curs_main.c:2193
 msgid "Thread cannot be broken, message is not part of a thread"
 msgstr "A thread não pode ser quebrada, mensagem não faz parte de uma thread"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2195
+#: curs_main.c:2203
 msgid "Cannot link threads"
 msgstr "Não pude unir threads"
 
-#: curs_main.c:2200
+#: curs_main.c:2208
 msgid "No Message-ID: header available to link thread"
 msgstr "Nenhum cabeçalho Message-ID disponível para vincular thread"
 
-#: curs_main.c:2202
+#: curs_main.c:2210
 msgid "First, please tag a message to be linked here"
 msgstr "Primeiro, por favor marque mensagem a ser vinculada aqui"
 
-#: curs_main.c:2213
+#: curs_main.c:2221
 msgid "Threads linked"
 msgstr "Threads vinculadas"
 
-#: curs_main.c:2216
+#: curs_main.c:2224
 msgid "No thread linked"
 msgstr "Nenhuma thread vinculada"
 
-#: curs_main.c:2252 curs_main.c:2278
+#: curs_main.c:2260 curs_main.c:2286
 msgid "You are on the last message."
 msgstr "Você está na última mensagem."
 
-#: curs_main.c:2260 curs_main.c:2305
+#: curs_main.c:2268 curs_main.c:2313
 msgid "No undeleted messages."
 msgstr "Nenhuma mensagem não removida."
 
-#: curs_main.c:2297 curs_main.c:2323
+#: curs_main.c:2305 curs_main.c:2331
 msgid "You are on the first message."
 msgstr "Você está na primeira mensagem."
 
-#: curs_main.c:2395 menu.c:970 pager.c:2440 pattern.c:2110
+#: curs_main.c:2403 menu.c:970 pager.c:2440 pattern.c:2110
 msgid "Search wrapped to top."
 msgstr "A pesquisa voltou ao início."
 
-#: curs_main.c:2404 pager.c:2463 pattern.c:2121
+#: curs_main.c:2412 pager.c:2463 pattern.c:2121
 msgid "Search wrapped to bottom."
 msgstr "A pesquisa passou para o final."
 
-#: curs_main.c:2447
+#: curs_main.c:2455
 msgid "No new messages in this limited view."
 msgstr "Nenhuma mensagem nova nesta visão restringida."
 
-#: curs_main.c:2449
+#: curs_main.c:2457
 msgid "No new messages."
 msgstr "Não há mensagens novas."
 
-#: curs_main.c:2454
+#: curs_main.c:2462
 msgid "No unread messages in this limited view."
 msgstr "Nenhuma mensagem não lida nesta visão restringida."
 
-#: curs_main.c:2456
+#: curs_main.c:2464
 msgid "No unread messages."
 msgstr "Não há mensagens não lidas"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2474
+#: curs_main.c:2482
 msgid "Cannot flag message"
 msgstr "Não pude sinalizar mensagem"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2513 pager.c:3100
+#: curs_main.c:2521 pager.c:3104
 msgid "Cannot toggle new"
 msgstr "Não pude alternar sinalização de leitura"
 
-#: curs_main.c:2590
+#: curs_main.c:2598
 msgid "No more threads."
 msgstr "Nenhuma discussão restante."
 
-#: curs_main.c:2592
+#: curs_main.c:2600
 msgid "You are on the first thread."
 msgstr "Você está na primeira discussão."
 
-#: curs_main.c:2676
+#: curs_main.c:2684
 msgid "Thread contains unread or flagged messages."
 msgstr "A discussão contém mensagens sinalizadas ou não lidas."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2726 pager.c:2784
+#: curs_main.c:2734 pager.c:2784
 msgid "Cannot delete message"
 msgstr "Não é possível apagar mensagem"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2838
+#: curs_main.c:2850
 msgid "Cannot edit message"
 msgstr "Não é possível editar mensagem"
 
 #. L10N: This is displayed when the x-label on one or more
 #. * messages is edited.
-#: curs_main.c:2900 pager.c:3200
+#: curs_main.c:2912 pager.c:3208
 #, c-format
 msgid "%d label changed."
 msgid_plural "%d labels changed."
@@ -1740,52 +1750,57 @@ msgstr[1] "%d rótulos alterados."
 #. L10N: This is displayed when editing an x-label, but no messages
 #. * were updated.  Possibly due to canceling at the prompt or if the new
 #. * label is the same as the old label.
-#: curs_main.c:2907 pager.c:3204
+#: curs_main.c:2919 pager.c:3212
 msgid "No labels changed."
 msgstr "Nenhum rótulo foi alterado."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:3006
-msgid "Cannot mark message(s) as read"
+#. L10N: Due to the implementation details we do not know whether we
+#. mark zero, 1, 12, ... messages as read. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:3022
+#, fuzzy
+msgid "Cannot mark messages as read"
 msgstr "Não é possível marcar mensagem(ns) como lida(s)."
 
 #. L10N: This is the prompt for <mark-message>.  Whatever they
 #. enter will be prefixed by $mark_macro_prefix and will become
 #. a macro hotkey to jump to the currently selected message.
-#: curs_main.c:3042
+#: curs_main.c:3058
 msgid "Enter macro stroke: "
 msgstr "Entre com sequência de teclas para atalho da macro: "
 
 #. L10N: "message hotkey" is the key bindings menu description of a
 #. macro created by <mark-message>.
-#: curs_main.c:3050
+#: curs_main.c:3066
 msgid "message hotkey"
 msgstr "descrição do atalho"
 
 #. L10N: This is echoed after <mark-message> creates a new hotkey
 #. macro.  %s is the hotkey string ($mark_macro_prefix followed
 #. by whatever they typed at the prompt.)
-#: curs_main.c:3055
+#: curs_main.c:3071
 #, c-format
 msgid "Message bound to %s."
 msgstr "Mensagem atrelada a %s."
 
 #. L10N: This error is printed if <mark-message> cannot find a
 #. Message-ID for the currently selected message in the index.
-#: curs_main.c:3063
+#: curs_main.c:3079
 msgid "No message ID to macro."
 msgstr "Nenhuma Id de mensagem para macro."
 
-#: curs_main.c:3105 pager.c:2961 recvattach.c:1388
+#: curs_main.c:3121 pager.c:2965 recvattach.c:1401
 msgid "Reply by mail as poster prefers?"
 msgstr "Responder mensagem de acordo com a preferencia do rementente?"
 
-#: curs_main.c:3108 pager.c:2927 pager.c:2939 pager.c:2964
+#: curs_main.c:3124 pager.c:2931 pager.c:2943 pager.c:2968
 msgid "Posting to this group not allowed, may be moderated. Continue?"
 msgstr "Não é permitido postar neste grupo, pode ser moderado. Continuar?"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:3173 pager.c:3120
+#: curs_main.c:3189 pager.c:3124
 msgid "Cannot undelete message"
 msgstr "Não é possível restaurar mensagem."
 
@@ -1976,12 +1991,34 @@ msgstr "[-- Saída de erro da autovisualização de %s --]\n"
 msgid "[-- Error: message/external-body has no access-type parameter --]\n"
 msgstr "[-- Erro: message/external-body não tem parâmetro de tipo de accesso --]\n"
 
-#: handler.c:1611
-#, c-format
+#. L10N: If the translation of this string is a multi line string, then
+#. each line should start with "[-- " and end with " --]".
+#. The first "%s/%s" is a MIME type, e.g. "text/plain". The last %s
+#. expands to a date as returned by `mutt_date_parse_date()`.
+#.
+#. Note: The size argument printed is not the actual number as passed
+#. to gettext but the prettified version, e.g. size = 2048 will be
+#. printed as 2K.  Your language might be sensitive to that: For
+#. example although '1K' and '1024' represent the same number your
+#. language might inflect the noun 'byte' differently.
+#.
+#. Sadly, we cannot do anything about that at the moment besides
+#. passing the precise size in bytes. If you are interested the
+#. function responsible for the prettification is
+#. mutt_str_pretty_size() in mutt/string.c.
+#.
+#: handler.c:1624
+#, fuzzy, c-format
 msgid ""
+"[-- This %s/%s attachment (size %s byte) has been deleted --]\n"
+"[-- on %s --]\n"
+msgid_plural ""
 "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
 "[-- on %s --]\n"
-msgstr ""
+msgstr[0] ""
+"[-- O anexo %s/%s (tamanho %s bytes) foi removido --]\n"
+"[-- em %s --]\n"
+msgstr[1] ""
 "[-- O anexo %s/%s (tamanho %s bytes) foi removido --]\n"
 "[-- em %s --]\n"
 
@@ -1989,10 +2026,23 @@ msgstr ""
 #. each line should start with "[-- " and end with " --]".
 #. The first "%s/%s" is a MIME type, e.g. "text/plain".
 #.
-#: handler.c:1620
-#, c-format
-msgid "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
-msgstr "[-- O anexo %s/%s (tamanho %s bytes) foi removido --]\n"
+#. Note: The size argument printed is not the actual number as passed
+#. to gettext but the prettified version, e.g. size = 2048 will be
+#. printed as 2K.  Your language might be sensitive to that: For
+#. example although '1K' and '1024' represent the same number your
+#. language might inflect the noun 'byte' differently.
+#.
+#. Sadly, we cannot do anything about that at the moment besides
+#. passing the precise size in bytes. If you are interested the
+#. function responsible for the prettification is
+#. mutt_str_pretty_size() in mutt/string.c.
+#.
+#: handler.c:1648
+#, fuzzy, c-format
+msgid "[-- This %s/%s attachment (size %s byte) has been deleted --]\n"
+msgid_plural "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
+msgstr[0] "[-- O anexo %s/%s (tamanho %s bytes) foi removido --]\n"
+msgstr[1] "[-- O anexo %s/%s (tamanho %s bytes) foi removido --]\n"
 
 #. L10N: If the translation of this string is a multi line string, then
 #. each line should start with "[-- " and end with " --]".
@@ -2002,7 +2052,7 @@ msgstr "[-- O anexo %s/%s (tamanho %s bytes) foi removido --]\n"
 #. Caution: Argument three %3$ is also defined but should not be used
 #. in this translation!
 #.
-#: handler.c:1637
+#: handler.c:1667
 msgid ""
 "[-- This %s/%s attachment has been deleted --]\n"
 "[-- on %4$s --]\n"
@@ -2014,17 +2064,17 @@ msgstr ""
 #. each line should start with "[-- " and end with " --]".
 #. The first "%s/%s" is a MIME type, e.g. "text/plain".
 #.
-#: handler.c:1646
+#: handler.c:1676
 #, c-format
 msgid "[-- This %s/%s attachment has been deleted --]\n"
 msgstr "[-- O anexo %s/%s foi removido --]\n"
 
-#: handler.c:1656
+#: handler.c:1686
 #, c-format
 msgid "[-- name: %s --]\n"
 msgstr "[-- nome: %s --]\n"
 
-#: handler.c:1672
+#: handler.c:1702
 #, c-format
 msgid ""
 "[-- This %s/%s attachment is not included, --]\n"
@@ -2035,7 +2085,7 @@ msgstr ""
 "[-- e a fonte externa indicada --]\n"
 "[-- expirou. --]\n"
 
-#: handler.c:1693
+#: handler.c:1723
 #, c-format
 msgid ""
 "[-- This %s/%s attachment is not included, --]\n"
@@ -2044,47 +2094,47 @@ msgstr ""
 "[-- O anexo %s/%s não foi incluído, --]\n"
 "[-- e o tipo de acesso %s não é suportado --]\n"
 
-#: handler.c:1822
+#: handler.c:1852
 msgid "Unable to open memory stream!"
 msgstr "Incapaz de abrir fluxo com a memória"
 
-#: handler.c:1831
+#: handler.c:1861
 msgid "Unable to open temporary file!"
 msgstr "Incapaz de abrir o arquivo temporário!"
 
-#: handler.c:1881
+#: handler.c:1911
 msgid "failed to re-open memstream!"
 msgstr "falha ao re-abrir fluxo com a memória"
 
-#: handler.c:2013
+#: handler.c:2043
 msgid "Error: multipart/signed has no protocol."
 msgstr "Erro: multipart/signed não tem protocolo."
 
-#: handler.c:2076
+#: handler.c:2106
 msgid "[-- This is an attachment (use '%3$s' to view this part) --]\n"
 msgstr "[-- Isto é um anexo (use '%3$s' para exibi-lo) --]\n"
 
-#: handler.c:2082
+#: handler.c:2112
 #, c-format
 msgid "[-- %s/%s is unsupported (use '%s' to view this part) --]\n"
 msgstr "[-- %s/%s não é suportado (use '%s' para exibi-lo) --]\n"
 
-#: handler.c:2087
+#: handler.c:2117
 msgid "[-- This is an attachment (need 'view-attachments' bound to key!) --]\n"
 msgstr "[-- Este é um anexo ('view-attachments' deve estar associado a uma tecla!) --]\n"
 
 #. L10N: %s/%s is a MIME type, e.g. "text/plain".
-#: handler.c:2091
+#: handler.c:2121
 #, c-format
 msgid "[-- %s/%s is unsupported (need 'view-attachments' bound to key!) --]\n"
 msgstr "[-- %s/%s não é suportado ('view-attachments' deve ser associado a uma tecla!) --]\n"
 
-#: handler.c:2098
+#: handler.c:2128
 msgid "[-- This is an attachment --]\n"
 msgstr "[-- Isto é um anexo --]\n"
 
 #. L10N: %s/%s is a MIME type, e.g. "text/plain".
-#: handler.c:2101
+#: handler.c:2131
 #, c-format
 msgid "[-- %s/%s is unsupported --]\n"
 msgstr "[-- %s/%s não é suportado --]\n"
@@ -2386,7 +2436,7 @@ msgstr "Servidor IMAP não suporta sinalizações personalizadas"
 msgid "Invalid IMAP flags"
 msgstr "Sinalizações IMAP inválidas"
 
-#: imap/message.c:477 mx.c:1326
+#: imap/message.c:477 mx.c:1336
 msgid "Integer overflow -- can't allocate memory."
 msgstr "Transbordo (overflow) de inteiros -- incapaz de alocar memória."
 
@@ -3195,64 +3245,74 @@ msgstr "SSL indisponível, incapaz de connectar a %s"
 msgid "Reading from %s interrupted..."
 msgstr "Aquisição de %s interrompida..."
 
-#: mx.c:634
-msgid "message(s) not deleted"
-msgstr "mensagem(ns) não apagadas"
+#. L10N: Although we now the precise number of messages, we do not show it to the user.
+#. So feel free to use a "generic plural" as plural translation if your language has one.
+#.
+#: mx.c:639
+#, fuzzy
+msgid "message not deleted"
+msgid_plural "messages not deleted"
+msgstr[0] "mensagem(ns) não apagadas"
+msgstr[1] "mensagem(ns) não apagadas"
 
-#: mx.c:671
+#: mx.c:676
 msgid "Can't open trash folder"
 msgstr "Incapaz de acessar lixeira"
 
-#: mx.c:710
+#: mx.c:715
 msgid "Mark all articles read?"
 msgstr "Marcar todos artigos como lidos?"
 
-#: mx.c:754
-#, c-format
-msgid "Move %d read messages to %s?"
-msgstr "Mover %d mensagens lidas para %s?"
+#. L10N: The first argument is the number of read messages to be
+#. moved, the second argument is the target mailbox.
+#: mx.c:762
+#, fuzzy, c-format
+msgid "Move %d read message to %s?"
+msgid_plural "Move %d read messages to %s?"
+msgstr[0] "Mover %d mensagens lidas para %s?"
+msgstr[1] "Mover %d mensagens lidas para %s?"
 
-#: mx.c:771 mx.c:1077
+#: mx.c:781 mx.c:1087
 #, c-format
 msgid "Purge %d deleted message?"
 msgid_plural "Purge %d deleted messages?"
 msgstr[0] "Remover %d mensagem apagada?"
 msgstr[1] "Remover %d mensagens apagadas?"
 
-#: mx.c:793
+#: mx.c:803
 #, c-format
 msgid "Moving read messages to %s..."
 msgstr "Movendo mensagens lidas para %s..."
 
-#: mx.c:859 mx.c:1068
+#: mx.c:869 mx.c:1078
 msgid "Mailbox is unchanged."
 msgstr "A caixa de mensagens não sofreu mudanças"
 
-#: mx.c:914
+#: mx.c:924
 #, c-format
 msgid "%d kept, %d moved, %d deleted."
 msgstr "%d mantidas, %d movidas, %d apagadas."
 
-#: mx.c:917 mx.c:1130
+#: mx.c:927 mx.c:1140
 #, c-format
 msgid "%d kept, %d deleted."
 msgstr "%d mantidas, %d apagadas."
 
-#: mx.c:1052
+#: mx.c:1062
 #, c-format
 msgid " Press '%s' to toggle write"
 msgstr " Pressione '%s' para trocar entre gravar ou não"
 
-#: mx.c:1054
+#: mx.c:1064
 msgid "Use 'toggle-write' to re-enable write!"
 msgstr "Use 'toggle-write' para reabilitar a gravação!"
 
-#: mx.c:1056
+#: mx.c:1066
 #, c-format
 msgid "Mailbox is marked unwritable. %s"
 msgstr "A caixa está marcada como não gravável. %s"
 
-#: mx.c:1124
+#: mx.c:1134
 msgid "Mailbox checkpointed."
 msgstr "Ponto de controle feito para caixa de mensagens."
 
@@ -3266,52 +3326,57 @@ msgstr " (tempo atual: %c)"
 msgid "[-- %s output follows%s --]\n"
 msgstr "[-- saída %s segue%s --]\n"
 
-#: ncrypt/crypt.c:95
-msgid "Passphrase(s) forgotten."
+#. L10N: Due to the implementation details (e.g. some passwords are managed
+#. by gpg-agent) we cannot know whether we forgot zero, 1, 12, ...
+#. passwords. So in English we use "Passphrases". Your language might
+#. have other means to express this.
+#: ncrypt/crypt.c:100
+#, fuzzy
+msgid "Passphrases forgotten."
 msgstr "Senha(s) esquecida(s)."
 
-#: ncrypt/crypt.c:155
+#: ncrypt/crypt.c:161
 msgid "Inline PGP can't be used with attachments.  Revert to PGP/MIME?"
 msgstr "PGP incorporado não pode ser usado com anexos. Reverter para PGP/MIME?"
 
-#: ncrypt/crypt.c:159
+#: ncrypt/crypt.c:165
 msgid "Mail not sent: inline PGP can't be used with attachments."
 msgstr "Email não enviado: PGP incorporado não pode ser usado com anexos."
 
-#: ncrypt/crypt.c:166
+#: ncrypt/crypt.c:172
 msgid "Inline PGP can't be used with format=flowed.  Revert to PGP/MIME?"
 msgstr "PGP incorporado não pode ser usado com format=flowed. Reverter para PGP/MIME?"
 
-#: ncrypt/crypt.c:170
+#: ncrypt/crypt.c:176
 msgid "Mail not sent: inline PGP can't be used with format=flowed."
 msgstr "Email não enviado: PGP incorporado não pode ser usado com format=flowed."
 
-#: ncrypt/crypt.c:180 ncrypt/cryptglue.c:125 ncrypt/pgpkey.c:589
+#: ncrypt/crypt.c:186 ncrypt/cryptglue.c:125 ncrypt/pgpkey.c:589
 #: ncrypt/pgpkey.c:782
 msgid "Invoking PGP..."
 msgstr "Executando PGP..."
 
-#: ncrypt/crypt.c:192
+#: ncrypt/crypt.c:198
 msgid "Message can't be sent inline.  Revert to using PGP/MIME?"
 msgstr "Mensagem não pode ser enviada de forma incorporada. Reverter para PGP/MIME?"
 
-#: ncrypt/crypt.c:194 send.c:1824
+#: ncrypt/crypt.c:200 send.c:1824
 msgid "Mail not sent."
 msgstr "Mensagem não enviada."
 
-#: ncrypt/crypt.c:540
+#: ncrypt/crypt.c:546
 msgid "S/MIME messages with no hints on content are unsupported."
 msgstr "Mensagens S/MIME sem dicas no conteúdo não são suportadas."
 
-#: ncrypt/crypt.c:754 ncrypt/crypt.c:795
+#: ncrypt/crypt.c:760 ncrypt/crypt.c:801
 msgid "Trying to extract PGP keys...\n"
 msgstr "Tentando extrair chaves PGP...\n"
 
-#: ncrypt/crypt.c:776 ncrypt/crypt.c:816
+#: ncrypt/crypt.c:782 ncrypt/crypt.c:822
 msgid "Trying to extract S/MIME certificates...\n"
 msgstr "Tentando extrair certificados S/MIME...\n"
 
-#: ncrypt/crypt.c:976
+#: ncrypt/crypt.c:982
 #, c-format
 msgid ""
 "[-- Error: Unknown multipart/signed protocol %s! --]\n"
@@ -3320,7 +3385,7 @@ msgstr ""
 "[-- Erro: Protocolo multipart/signed %s desconhecido! --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1016
+#: ncrypt/crypt.c:1022
 msgid ""
 "[-- Error: Missing or bad-format multipart/signed signature! --]\n"
 "\n"
@@ -3328,7 +3393,7 @@ msgstr ""
 "[-- Erro: Assinatura \"multipart/signed\" omitida ou inconsistente! --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1058
+#: ncrypt/crypt.c:1064
 #, c-format
 msgid ""
 "[-- Warning: We can't verify %s/%s signatures. --]\n"
@@ -3337,7 +3402,7 @@ msgstr ""
 "[-- Aviso: Não foi possível verificar %s/%s assinaturas. --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1070
+#: ncrypt/crypt.c:1076
 msgid ""
 "[-- The following data is signed --]\n"
 "\n"
@@ -3345,7 +3410,7 @@ msgstr ""
 "[-- Os dados a seguir estão assinados --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1075
+#: ncrypt/crypt.c:1081
 msgid ""
 "[-- Warning: Can't find any signatures. --]\n"
 "\n"
@@ -3353,7 +3418,7 @@ msgstr ""
 "[-- Aviso: Não foi possível encontrar assinatura alguma. --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1081
+#: ncrypt/crypt.c:1087
 msgid ""
 "\n"
 "[-- End of signed data --]\n"
@@ -3404,7 +3469,7 @@ msgstr "[arquivo temporário]"
 msgid "error reading data object: %s\n"
 msgstr "erro ao acessar objeto de dados: %s\n"
 
-#: ncrypt/crypt_gpgme.c:662 ncrypt/crypt_gpgme.c:3848 ncrypt/pgpkey.c:585
+#: ncrypt/crypt_gpgme.c:662 ncrypt/crypt_gpgme.c:3850 ncrypt/pgpkey.c:585
 #: ncrypt/pgpkey.c:768
 msgid "Can't create temporary file"
 msgstr "Não foi possível criar um arquivo temporário"
@@ -3750,28 +3815,30 @@ msgstr "[Inválido]"
 
 #. L10N: This is printed after "Key Type: " and looks like this:
 #. *       PGP, 2048 bit RSA
-#: ncrypt/crypt_gpgme.c:3670 ncrypt/crypt_gpgme.c:3808
-#, c-format
+#: ncrypt/crypt_gpgme.c:3670 ncrypt/crypt_gpgme.c:3810
+#, fuzzy, c-format
 msgid "%s, %lu bit %s\n"
-msgstr "%s, %lu bit %s\n"
+msgid_plural "%s, %lu bit %s\n"
+msgstr[0] "%s, %lu bit %s\n"
+msgstr[1] "%s, %lu bit %s\n"
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3678 ncrypt/crypt_gpgme.c:3815
+#: ncrypt/crypt_gpgme.c:3678 ncrypt/crypt_gpgme.c:3817
 msgid "encryption"
 msgstr "encriptação"
 
 #: ncrypt/crypt_gpgme.c:3679 ncrypt/crypt_gpgme.c:3685
-#: ncrypt/crypt_gpgme.c:3816 ncrypt/crypt_gpgme.c:3821
+#: ncrypt/crypt_gpgme.c:3818 ncrypt/crypt_gpgme.c:3823
 msgid ", "
 msgstr ", "
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3684 ncrypt/crypt_gpgme.c:3820
+#: ncrypt/crypt_gpgme.c:3684 ncrypt/crypt_gpgme.c:3822
 msgid "signing"
 msgstr "assinando"
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3690 ncrypt/crypt_gpgme.c:3825
+#: ncrypt/crypt_gpgme.c:3690 ncrypt/crypt_gpgme.c:3827
 msgid "certification"
 msgstr "certificação"
 
@@ -3790,64 +3857,64 @@ msgstr "[Expirado]"
 msgid "[Disabled]"
 msgstr "[Desabilitado]"
 
-#: ncrypt/crypt_gpgme.c:3851
+#: ncrypt/crypt_gpgme.c:3853
 msgid "Collecting data..."
 msgstr "Coletando dados..."
 
-#: ncrypt/crypt_gpgme.c:3876
+#: ncrypt/crypt_gpgme.c:3878
 #, c-format
 msgid "Error finding issuer key: %s\n"
 msgstr "Erro ao procurar emissor da chave: %s\n"
 
-#: ncrypt/crypt_gpgme.c:3885
+#: ncrypt/crypt_gpgme.c:3887
 msgid "Error: certification chain too long - stopping here\n"
 msgstr "Erro: cadeia de certificação longa demais - parando aqui\n"
 
-#: ncrypt/crypt_gpgme.c:3895 ncrypt/pgpkey.c:608
+#: ncrypt/crypt_gpgme.c:3897 ncrypt/pgpkey.c:608
 #, c-format
 msgid "Key ID: 0x%s"
 msgstr "Key ID: 0x%s"
 
-#: ncrypt/crypt_gpgme.c:3990
+#: ncrypt/crypt_gpgme.c:3992
 #, c-format
 msgid "gpgme_new failed: %s"
 msgstr "gpgme_new falhou: %s"
 
-#: ncrypt/crypt_gpgme.c:4028 ncrypt/crypt_gpgme.c:4079
+#: ncrypt/crypt_gpgme.c:4030 ncrypt/crypt_gpgme.c:4081
 #, c-format
 msgid "gpgme_op_keylist_start failed: %s"
 msgstr "gpgme_op_keylist_start falhou: %s"
 
-#: ncrypt/crypt_gpgme.c:4067 ncrypt/crypt_gpgme.c:4109
+#: ncrypt/crypt_gpgme.c:4069 ncrypt/crypt_gpgme.c:4111
 #, c-format
 msgid "gpgme_op_keylist_next failed: %s"
 msgstr "gpgme_op_keylist_next falhou: %s"
 
-#: ncrypt/crypt_gpgme.c:4185
+#: ncrypt/crypt_gpgme.c:4187
 msgid "All matching keys are marked expired/revoked."
 msgstr "Todas chaves coincidentes estão expiradas/revogadas."
 
-#: ncrypt/crypt_gpgme.c:4215 ncrypt/pgpkey.c:543 ncrypt/smime.c:475
+#: ncrypt/crypt_gpgme.c:4217 ncrypt/pgpkey.c:543 ncrypt/smime.c:475
 msgid "Select  "
 msgstr "Escolher  "
 
-#: ncrypt/crypt_gpgme.c:4217 ncrypt/pgpkey.c:545
+#: ncrypt/crypt_gpgme.c:4219 ncrypt/pgpkey.c:545
 msgid "Check key  "
 msgstr "Verificar chave  "
 
-#: ncrypt/crypt_gpgme.c:4233
+#: ncrypt/crypt_gpgme.c:4235
 msgid "PGP and S/MIME keys matching"
 msgstr "Chaves PGP e S/MIME que coincidem"
 
-#: ncrypt/crypt_gpgme.c:4235
+#: ncrypt/crypt_gpgme.c:4237
 msgid "PGP keys matching"
 msgstr "Chaves PGP que coincidem"
 
-#: ncrypt/crypt_gpgme.c:4237
+#: ncrypt/crypt_gpgme.c:4239
 msgid "S/MIME keys matching"
 msgstr "Chaves do S/MIME que coincidem"
 
-#: ncrypt/crypt_gpgme.c:4239
+#: ncrypt/crypt_gpgme.c:4241
 msgid "keys matching"
 msgstr "Chaves que coincidem"
 
@@ -3855,65 +3922,65 @@ msgstr "Chaves que coincidem"
 #. %1$s is one of the previous four entries.
 #. %2$s is an address.
 #. e.g. "S/MIME keys matching <me@mutt.org>."
-#: ncrypt/crypt_gpgme.c:4246
+#: ncrypt/crypt_gpgme.c:4248
 #, c-format
 msgid "%s <%s>."
 msgstr "%s <%s>."
 
 #. L10N:
 #. e.g. 'S/MIME keys matching "Michael Elkins".'
-#: ncrypt/crypt_gpgme.c:4250
+#: ncrypt/crypt_gpgme.c:4252
 #, c-format
 msgid "%s \"%s\"."
 msgstr "%s \"%s\"."
 
-#: ncrypt/crypt_gpgme.c:4277 ncrypt/pgpkey.c:628
+#: ncrypt/crypt_gpgme.c:4279 ncrypt/pgpkey.c:628
 msgid "This key can't be used: expired/disabled/revoked."
 msgstr "Esta chave não pode ser usada: expirada/desabilitada/revogada."
 
-#: ncrypt/crypt_gpgme.c:4290 ncrypt/pgpkey.c:640 ncrypt/smime.c:505
+#: ncrypt/crypt_gpgme.c:4292 ncrypt/pgpkey.c:640 ncrypt/smime.c:505
 msgid "ID is expired/disabled/revoked. Do you really want to use the key?"
 msgstr "ID expirada/desabilitada/revogada. Você realmente quer usar esta chave?"
 
-#: ncrypt/crypt_gpgme.c:4299 ncrypt/pgpkey.c:650
+#: ncrypt/crypt_gpgme.c:4301 ncrypt/pgpkey.c:650
 msgid "ID is not valid. Do you really want to use the key?"
 msgstr "ID inválida. Você realmente quer usar esta chave?"
 
-#: ncrypt/crypt_gpgme.c:4302 ncrypt/pgpkey.c:653
+#: ncrypt/crypt_gpgme.c:4304 ncrypt/pgpkey.c:653
 msgid "ID is only marginally valid. Do you really want to use the key?"
 msgstr "ID apenas marginalmente válida. Você realmente quer usar esta chave?"
 
-#: ncrypt/crypt_gpgme.c:4310 ncrypt/pgpkey.c:646 ncrypt/smime.c:509
+#: ncrypt/crypt_gpgme.c:4312 ncrypt/pgpkey.c:646 ncrypt/smime.c:509
 msgid "ID has undefined validity. Do you really want to use the key?"
 msgstr "ID tem validade indefinida. Você realmente quer usar esta chave?"
 
-#: ncrypt/crypt_gpgme.c:4370 ncrypt/crypt_gpgme.c:4479 ncrypt/pgpkey.c:872
+#: ncrypt/crypt_gpgme.c:4372 ncrypt/crypt_gpgme.c:4481 ncrypt/pgpkey.c:872
 #: ncrypt/pgpkey.c:995
 #, c-format
 msgid "Looking for keys matching \"%s\"..."
 msgstr "Procurando por chaves que casam com \"%s\"..."
 
-#: ncrypt/crypt_gpgme.c:4593 ncrypt/pgpkey.c:731 ncrypt/smime.c:811
+#: ncrypt/crypt_gpgme.c:4595 ncrypt/pgpkey.c:731 ncrypt/smime.c:811
 #, c-format
 msgid "No matching keys found for \"%s\""
 msgstr "Nenhuma chave coincidente encontrada para \"%s\""
 
-#: ncrypt/crypt_gpgme.c:4644 ncrypt/pgp.c:1263
+#: ncrypt/crypt_gpgme.c:4646 ncrypt/pgp.c:1263
 #, c-format
 msgid "Use keyID = \"%s\" for %s?"
 msgstr "Usar keyID = \"%s\" para %s?"
 
-#: ncrypt/crypt_gpgme.c:4695 ncrypt/pgp.c:1312 ncrypt/smime.c:830
+#: ncrypt/crypt_gpgme.c:4697 ncrypt/pgp.c:1312 ncrypt/smime.c:830
 #: ncrypt/smime.c:938
 #, c-format
 msgid "Enter keyID for %s: "
 msgstr "Entre a keyID para %s: "
 
-#: ncrypt/crypt_gpgme.c:4755 ncrypt/pgpkey.c:751
+#: ncrypt/crypt_gpgme.c:4757 ncrypt/pgpkey.c:751
 msgid "Please enter the key ID: "
 msgstr "Por favor entre o key ID: "
 
-#: ncrypt/crypt_gpgme.c:4768
+#: ncrypt/crypt_gpgme.c:4770
 #, c-format
 msgid "Error exporting key: %s\n"
 msgstr "Erro ao exportar chave: %s\n"
@@ -3922,80 +3989,80 @@ msgstr "Erro ao exportar chave: %s\n"
 #. MIME description for exported (attached) keys.
 #. You can translate this entry to a non-ASCII string (it will be encoded),
 #. but it may be safer to keep it untranslated.
-#: ncrypt/crypt_gpgme.c:4787
+#: ncrypt/crypt_gpgme.c:4789
 #, c-format
 msgid "PGP Key 0x%s."
 msgstr "Chave do PGP 0x%s."
 
-#: ncrypt/crypt_gpgme.c:4830
+#: ncrypt/crypt_gpgme.c:4832
 msgid "GPGME: OpenPGP protocol not available"
 msgstr "GPGME: protocolo OpenPGP indisponível"
 
-#: ncrypt/crypt_gpgme.c:4838
+#: ncrypt/crypt_gpgme.c:4840
 msgid "GPGME: CMS protocol not available"
 msgstr "GPGME: protocolo CMS indisponível"
 
-#: ncrypt/crypt_gpgme.c:4876
+#: ncrypt/crypt_gpgme.c:4878
 msgid "S/MIME (s)ign, sign (a)s, (p)gp, (c)lear, or (o)ppenc mode off? "
 msgstr "s)assinar S/MIME, a)assinar como, p)pgp, c)limpar, o)desligar modo oppenc? "
 
 #. L10N: S/MIME options (opportunistic encryption is on)
-#: ncrypt/crypt_gpgme.c:4878
+#: ncrypt/crypt_gpgme.c:4880
 msgid "sapco"
 msgstr "sapco"
 
-#: ncrypt/crypt_gpgme.c:4885
+#: ncrypt/crypt_gpgme.c:4887
 msgid "PGP (s)ign, sign (a)s, s/(m)ime, (c)lear, or (o)ppenc mode off? "
 msgstr "s)assinar PGP, a)assinar como, m)s/mime, c)limpar, o)desligar modo oppenc? "
 
 #. L10N: PGP options (opportunistic encryption is on)
-#: ncrypt/crypt_gpgme.c:4887
+#: ncrypt/crypt_gpgme.c:4889
 msgid "samco"
 msgstr "samco"
 
 #. L10N: S/MIME options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4900
+#: ncrypt/crypt_gpgme.c:4902
 msgid "S/MIME (e)ncrypt, (s)ign, sign (a)s, (b)oth, (p)gp, (c)lear, or (o)ppenc mode? "
 msgstr "e)encriptar, s)assinar, a)assinar como, b)ambos, p)pgp, c)limpar, ou o)oppenc? "
 
 #. L10N: S/MIME options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4903
+#: ncrypt/crypt_gpgme.c:4905
 msgid "esabpco"
 msgstr "esabpco"
 
 #. L10N: PGP options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4909
+#: ncrypt/crypt_gpgme.c:4911
 msgid "PGP (e)ncrypt, (s)ign, sign (a)s, (b)oth, s/(m)ime, (c)lear, or (o)ppenc mode? "
 msgstr "e)encriptar, s)assinar, a)assinar como, b)ambos, m)s/mime, c)limpar, ou o)oppenc? "
 
 #. L10N: PGP options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4912
+#: ncrypt/crypt_gpgme.c:4914
 msgid "esabmco"
 msgstr "esabmco"
 
-#: ncrypt/crypt_gpgme.c:4925
+#: ncrypt/crypt_gpgme.c:4927
 msgid "S/MIME (e)ncrypt, (s)ign, sign (a)s, (b)oth, (p)gp or (c)lear? "
 msgstr "e)encriptar com S/MIME, s)assinar, a)assinar como, b)ambos, p)pgp, ou c)limpar"
 
 #. L10N: S/MIME options
-#: ncrypt/crypt_gpgme.c:4927
+#: ncrypt/crypt_gpgme.c:4929
 msgid "esabpc"
 msgstr "esabpc"
 
-#: ncrypt/crypt_gpgme.c:4934
+#: ncrypt/crypt_gpgme.c:4936
 msgid "PGP (e)ncrypt, (s)ign, sign (a)s, (b)oth, s/(m)ime or (c)lear? "
 msgstr "e)encriptar com PGP, s)assinar, a)assinar como, b)ambos, m)s/mime, ou c)limpar"
 
 #. L10N: PGP options
-#: ncrypt/crypt_gpgme.c:4936
+#: ncrypt/crypt_gpgme.c:4938
 msgid "esabmc"
 msgstr "esabmc"
 
-#: ncrypt/crypt_gpgme.c:5087
+#: ncrypt/crypt_gpgme.c:5089
 msgid "Failed to verify sender"
 msgstr "Falha ao verificar remetente"
 
-#: ncrypt/crypt_gpgme.c:5090
+#: ncrypt/crypt_gpgme.c:5092
 msgid "Failed to figure out sender"
 msgstr "Falha ao descobrir remetente"
 
@@ -4383,7 +4450,7 @@ msgstr "Nenhum servidor de notícias configurado!"
 msgid "%s is an invalid news server specification!"
 msgstr "%s é uma especificação inválida para servidor de notícias!"
 
-#: nntp.c:75 nntp.c:612 pop.c:1028 pop_lib.c:405
+#: nntp.c:75 nntp.c:612 pop.c:1031 pop_lib.c:405
 msgid "Server closed connection!"
 msgstr "O servidor fechou a conexão!"
 
@@ -4541,15 +4608,18 @@ msgid "check mailboxes for new mail"
 msgstr "verifica se há novas mensagens na caixa"
 
 #: opcodes.h:47
-msgid "attach file(s) to this message"
+#, fuzzy
+msgid "attach files to this message"
 msgstr "anexa arquivo(s) nesta mensagem"
 
 #: opcodes.h:48
-msgid "attach message(s) to this message"
+#, fuzzy
+msgid "attach messages to this message"
 msgstr "anexa uma(s) mensagem(ns) à esta mensagem"
 
 #: opcodes.h:49
-msgid "attach news article(s) to this message"
+#, fuzzy
+msgid "attach news articles to this message"
 msgstr "anexa novo(s) artigo(s) nesta mensagem"
 
 #: opcodes.h:50
@@ -5365,7 +5435,8 @@ msgid "extract supported public keys"
 msgstr "extrai as chaves públicas suportadas"
 
 #: opcodes.h:255
-msgid "wipe passphrase(s) from memory"
+#, fuzzy
+msgid "wipe passphrases from memory"
 msgstr "limpa senha(s) da memória"
 
 #: opcodes.h:259
@@ -5695,18 +5766,20 @@ msgstr "Nenhuma mensagem nova no servidor POP."
 msgid "Delete messages from server?"
 msgstr "Apagar mensagens do servidor?"
 
-#: pop.c:954
-#, c-format
-msgid "Reading new messages (%d bytes)..."
-msgstr "Lendo novas mensagens (%d bytes)..."
+#: pop.c:955
+#, fuzzy, c-format
+msgid "Reading new messages (%d byte)..."
+msgid_plural "Reading new messages (%d bytes)..."
+msgstr[0] "Lendo novas mensagens (%d bytes)..."
+msgstr[1] "Lendo novas mensagens (%d bytes)..."
 
-#: pop.c:997
+#: pop.c:1000
 msgid "Error while writing mailbox!"
 msgstr "Erro ao gravar a caixa!"
 
 #. L10N: The plural is picked by the second numerical argument, i.e.
 #. * the %d right before 'messages', i.e. the total number of messages.
-#: pop.c:1003
+#: pop.c:1006
 #, c-format
 msgid "%s [%d of %d message read]"
 msgid_plural "%s [%d of %d messages read]"
@@ -5850,47 +5923,54 @@ msgstr "Passar por cano a: "
 msgid "I don't know how to print %s attachments!"
 msgstr "Eu não sei como imprimir anexos %s!"
 
-#: recvattach.c:841
-msgid "Print tagged attachment(s)?"
-msgstr "Imprimir anexo(s) marcado(s)?"
+#. L10N: Although we now the precise number of tagged messages, we
+#. do not show it to the user.  So feel free to use a "generic
+#. plural" as plural translation if your language has one.
+#: recvattach.c:852
+#, fuzzy, c-format
+msgid "Print tagged attachment?"
+msgid_plural "Print %d tagged attachments?"
+msgstr[0] "Imprimir anexo(s) marcado(s)?"
+msgstr[1] "Imprimir anexo(s) marcado(s)?"
 
-#: recvattach.c:842
+#: recvattach.c:853
+#, c-format
 msgid "Print attachment?"
 msgstr "Imprimir anexo?"
 
-#: recvattach.c:900
+#: recvattach.c:913
 msgid "Structural changes to decrypted attachments are not supported"
 msgstr "Não há suporte para alterações estruturais em anexos desencriptados."
 
-#: recvattach.c:1046
+#: recvattach.c:1059
 msgid "Can't decrypt encrypted message!"
 msgstr "Incapaz de desencriptar mensagem encriptada!"
 
-#: recvattach.c:1172
+#: recvattach.c:1185
 msgid "Attachments"
 msgstr "Anexos"
 
-#: recvattach.c:1210
+#: recvattach.c:1223
 msgid "There are no subparts to show!"
 msgstr "Não existem sub-partes a serem exibidas!"
 
-#: recvattach.c:1265
+#: recvattach.c:1278
 msgid "Can't delete attachment from POP server."
 msgstr "Incapaz de apagar anexos do servidor POP"
 
-#: recvattach.c:1274
+#: recvattach.c:1287
 msgid "Can't delete attachment from news server."
 msgstr "Incapaz de apagar anexos do servidor de notícias"
 
-#: recvattach.c:1281
+#: recvattach.c:1294
 msgid "Deletion of attachments from encrypted messages is unsupported."
 msgstr "Deleção de anexos de mensagens encriptadas não é suportada"
 
-#: recvattach.c:1287
+#: recvattach.c:1300
 msgid "Deletion of attachments from signed messages may invalidate the signature."
 msgstr "Deleção de anexos de mensagens assinadas podem invalidar a assinatura."
 
-#: recvattach.c:1305 recvattach.c:1320
+#: recvattach.c:1318 recvattach.c:1333
 msgid "Only deletion of multipart attachments is supported."
 msgstr "Somente a deleção de anexos multiparte é suportada."
 
@@ -6325,3 +6405,13 @@ msgstr "Opções pré-definidas:"
 #: version.c:404
 msgid "Compile options:"
 msgstr "Opções de compilação:"
+
+#~ msgid "Cannot delete message(s)"
+#~ msgstr "Não pude remover mensagem(ns)"
+
+#~ msgid "Cannot undelete message(s)"
+#~ msgstr "Não pude restaurar mensagem(ns)."
+
+#, fuzzy
+#~ msgid "messages not deleted"
+#~ msgstr "mensagem(ns) não apagadas"

--- a/po/ru.po
+++ b/po/ru.po
@@ -16,7 +16,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neomutt-20180512\n"
 "Report-Msgid-Bugs-To: neomutt-devel@neomutt.org\n"
-"POT-Creation-Date: 2018-05-20 02:02+0000\n"
+"POT-Creation-Date: 2018-05-22 14:18+0000\n"
 "PO-Revision-Date: 2017-02-15 23:39+0200\n"
 "Last-Translator: Vsevolod Volkov <vvv@mutt.org.ua>\n"
 "Language-Team: neomutt-ru@woe.spb.ru\n"
@@ -46,7 +46,7 @@ msgstr "Выбрать"
 
 #: addrbook.c:52 browser.c:75 browser.c:87 compose.c:160 compose.c:172
 #: conn/ssl.c:1041 conn/ssl_gnutls.c:793 curs_main.c:748 curs_main.c:761
-#: history.c:106 ncrypt/crypt_gpgme.c:4219 ncrypt/pgpkey.c:547
+#: history.c:106 ncrypt/crypt_gpgme.c:4221 ncrypt/pgpkey.c:547
 #: ncrypt/smime.c:477 pager.c:2141 postpone.c:65 query.c:72 recvattach.c:70
 msgid "Help"
 msgstr "Помощь"
@@ -697,7 +697,7 @@ msgstr "Безопасность: "
 #. * Since it shares the row with "Encrypt with:", it should not be longer
 #. * than 15-20 character cells.
 #.
-#: compose.c:138 ncrypt/crypt_gpgme.c:4947 ncrypt/pgp.c:1786
+#: compose.c:138 ncrypt/crypt_gpgme.c:4949 ncrypt/pgp.c:1786
 #: ncrypt/smime.c:2127
 msgid "Sign as: "
 msgstr "Подписать как: "
@@ -1236,7 +1236,7 @@ msgstr "(r)отвергнуть, (o)принять, (s)пропустить"
 msgid "(r)eject, accept (o)nce"
 msgstr "(r)отвергнуть, (o)принять"
 
-#: conn/ssl.c:1039 conn/ssl_gnutls.c:791 ncrypt/crypt_gpgme.c:4213
+#: conn/ssl.c:1039 conn/ssl_gnutls.c:791 ncrypt/crypt_gpgme.c:4215
 #: ncrypt/pgpkey.c:541 ncrypt/smime.c:473
 msgid "Exit  "
 msgstr "Выход "
@@ -1415,11 +1415,11 @@ msgstr "Нет открытого почтового ящика."
 msgid "There are no messages."
 msgstr "Сообщений нет."
 
-#: curs_main.c:77 mx.c:1061 pager.c:73 recvattach.c:56
+#: curs_main.c:77 mx.c:1071 pager.c:73 recvattach.c:56
 msgid "Mailbox is read-only."
 msgstr "Почтовый ящик немодифицируем."
 
-#: curs_main.c:79 pager.c:75 recvattach.c:1145
+#: curs_main.c:79 pager.c:75 recvattach.c:1158
 msgid "Function not permitted in attach-message mode."
 msgstr "В режиме \"вложить сообщение\" функция недоступна."
 
@@ -1553,244 +1553,254 @@ msgid "That message is not visible."
 msgstr "Это сообщение невидимо."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:1377 curs_main.c:2772 pager.c:2818
-msgid "Cannot delete message(s)"
+#. L10N: Due to the implementation details we do not know whether we
+#. delete zero, 1, 12, ... messages. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:1381 curs_main.c:2784 pager.c:2822
+#, fuzzy
+msgid "Cannot delete messages"
 msgstr "Не удалось удалить сообщения"
 
-#: curs_main.c:1380
+#: curs_main.c:1384
 msgid "Delete messages matching: "
 msgstr "Удалить сообщения по образцу: "
 
-#: curs_main.c:1421
+#: curs_main.c:1425
 msgid "No limit pattern is in effect."
 msgstr "Шаблон ограничения списка отсутствует."
 
 #. L10N: ask for a limit to apply
-#: curs_main.c:1426
+#: curs_main.c:1430
 #, c-format
 msgid "Limit: %s"
 msgstr "Шаблон ограничения: %s"
 
-#: curs_main.c:1464
+#: curs_main.c:1468
 msgid "Limit to messages matching: "
 msgstr "Ограничиться сообщениями, соответствующими: "
 
-#: curs_main.c:1488
+#: curs_main.c:1492
 msgid "To view all messages, limit to \"all\"."
 msgstr "Используйте \"all\" для просмотра всех сообщений."
 
-#: curs_main.c:1500 pager.c:2318
+#: curs_main.c:1504 pager.c:2318
 msgid "Quit NeoMutt?"
 msgstr "Выйти из NeoMutt?"
 
-#: curs_main.c:1596
+#: curs_main.c:1600
 msgid "Tag messages matching: "
 msgstr "Пометить сообщения по образцу: "
 
 #. L10N: CHECK_ACL
-#: curs_main.c:1606 curs_main.c:3203 pager.c:3137
-msgid "Cannot undelete message(s)"
+#. L10N: Due to the implementation details we do not know whether we
+#. undelete zero, 1, 12, ... messages. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:1614 curs_main.c:3223 pager.c:3145
+#, fuzzy
+msgid "Cannot undelete messages"
 msgstr "Не удалось восстановить сообщения"
 
-#: curs_main.c:1609
+#: curs_main.c:1617
 msgid "Undelete messages matching: "
 msgstr "Восстановить сообщения по образцу: "
 
-#: curs_main.c:1619
+#: curs_main.c:1627
 msgid "Untag messages matching: "
 msgstr "Снять пометку с сообщений по образцу: "
 
-#: curs_main.c:1653
+#: curs_main.c:1661
 msgid "Logged out of IMAP servers."
 msgstr "Соединения с IMAP-серверами отключены."
 
-#: curs_main.c:1753
+#: curs_main.c:1761
 #, fuzzy
 msgid "No virtual folder, aborting."
 msgstr "Нет темы письма, отказ."
 
-#: curs_main.c:1761
+#: curs_main.c:1769
 msgid "Failed to read thread, aborting."
 msgstr ""
 
-#: curs_main.c:1793 mx.c:1458 mx.c:1475
+#: curs_main.c:1801 mx.c:1468 mx.c:1485
 #, fuzzy
 msgid "Folder doesn't support tagging, aborting."
 msgstr "SMTP сервер не поддерживает аутентификацию"
 
-#: curs_main.c:1808
+#: curs_main.c:1816
 #, fuzzy
 msgid "No tag specified, aborting."
 msgstr "Нет темы письма, отказ."
 
-#: curs_main.c:1820
+#: curs_main.c:1828
 #, c-format
 msgid "Update tags..."
 msgstr ""
 
-#: curs_main.c:1857
+#: curs_main.c:1865
 msgid "Failed to modify tags, aborting."
 msgstr ""
 
-#: curs_main.c:1898
+#: curs_main.c:1906
 #, fuzzy
 msgid "No query, aborting."
 msgstr "Нет темы письма, отказ."
 
-#: curs_main.c:1902 curs_main.c:1922 curs_main.c:1941
+#: curs_main.c:1910 curs_main.c:1930 curs_main.c:1949
 msgid "Failed to create query, aborting."
 msgstr ""
 
-#: curs_main.c:1911 curs_main.c:1930
+#: curs_main.c:1919 curs_main.c:1938
 msgid "Windowed queries disabled."
 msgstr ""
 
-#: curs_main.c:1916 curs_main.c:1935
+#: curs_main.c:1924 curs_main.c:1943
 msgid "No notmuch vfolder currently loaded."
 msgstr ""
 
-#: curs_main.c:1973
+#: curs_main.c:1981
 msgid "Open mailbox in read-only mode"
 msgstr "Открыть почтовый ящик только для чтения"
 
-#: curs_main.c:1976
+#: curs_main.c:1984
 #, fuzzy
 msgid "Open virtual folder"
 msgstr "открыть другой почтовый ящик/файл"
 
-#: curs_main.c:1979
+#: curs_main.c:1987
 msgid "Open mailbox"
 msgstr "Открыть почтовый ящик"
 
-#: curs_main.c:1989
+#: curs_main.c:1997
 msgid "No mailboxes have new mail"
 msgstr "Нет почтовых ящиков с новой почтой"
 
-#: curs_main.c:2036
+#: curs_main.c:2044
 #, fuzzy
 msgid "Open newsgroup in read-only mode"
 msgstr "Открыть почтовый ящик только для чтения"
 
-#: curs_main.c:2038
+#: curs_main.c:2046
 msgid "Open newsgroup"
 msgstr ""
 
-#: curs_main.c:2141
+#: curs_main.c:2149
 #, fuzzy
 msgid "Exit NeoMutt without saving?"
 msgstr "Выйти из NeoMutt без сохранения изменений?"
 
-#: curs_main.c:2157
+#: curs_main.c:2165
 #, fuzzy
 msgid "Cannot break thread"
 msgstr "Не удалось соединить дискуссии"
 
-#: curs_main.c:2160 curs_main.c:2198 curs_main.c:2658 curs_main.c:2690
+#: curs_main.c:2168 curs_main.c:2206 curs_main.c:2666 curs_main.c:2698
 #: flags.c:376 thread.c:1078 thread.c:1134 thread.c:1202
 msgid "Threading is not enabled."
 msgstr "Группировка по дискуссиям не включена."
 
-#: curs_main.c:2173
+#: curs_main.c:2181
 msgid "Thread broken"
 msgstr "Дискуссия разделена"
 
-#: curs_main.c:2185
+#: curs_main.c:2193
 msgid "Thread cannot be broken, message is not part of a thread"
 msgstr "Дискуссия не может быть разделена, сообщение не является частью дискуссии"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2195
+#: curs_main.c:2203
 msgid "Cannot link threads"
 msgstr "Не удалось соединить дискуссии"
 
-#: curs_main.c:2200
+#: curs_main.c:2208
 msgid "No Message-ID: header available to link thread"
 msgstr "Отсутствует заголовок Message-ID: для соединения дискуссии"
 
-#: curs_main.c:2202
+#: curs_main.c:2210
 msgid "First, please tag a message to be linked here"
 msgstr "Сначала необходимо пометить сообщение, которое нужно соединить здесь"
 
-#: curs_main.c:2213
+#: curs_main.c:2221
 msgid "Threads linked"
 msgstr "Дискуссии соединены"
 
-#: curs_main.c:2216
+#: curs_main.c:2224
 msgid "No thread linked"
 msgstr "Дискуссии не соединены"
 
-#: curs_main.c:2252 curs_main.c:2278
+#: curs_main.c:2260 curs_main.c:2286
 msgid "You are on the last message."
 msgstr "Это последнее сообщение."
 
-#: curs_main.c:2260 curs_main.c:2305
+#: curs_main.c:2268 curs_main.c:2313
 msgid "No undeleted messages."
 msgstr "Нет восстановленных сообщений."
 
-#: curs_main.c:2297 curs_main.c:2323
+#: curs_main.c:2305 curs_main.c:2331
 msgid "You are on the first message."
 msgstr "Это первое сообщение."
 
-#: curs_main.c:2395 menu.c:970 pager.c:2440 pattern.c:2110
+#: curs_main.c:2403 menu.c:970 pager.c:2440 pattern.c:2110
 msgid "Search wrapped to top."
 msgstr "Достигнут конец; продолжаем поиск с начала."
 
-#: curs_main.c:2404 pager.c:2463 pattern.c:2121
+#: curs_main.c:2412 pager.c:2463 pattern.c:2121
 msgid "Search wrapped to bottom."
 msgstr "Достигнуто начало; продолжаем поиск с конца."
 
-#: curs_main.c:2447
+#: curs_main.c:2455
 msgid "No new messages in this limited view."
 msgstr "Нет новых сообщений при просмотре с ограничением."
 
-#: curs_main.c:2449
+#: curs_main.c:2457
 msgid "No new messages."
 msgstr "Нет новых сообщений."
 
-#: curs_main.c:2454
+#: curs_main.c:2462
 msgid "No unread messages in this limited view."
 msgstr "Нет непрочитанных сообщений при просмотре с ограничением."
 
-#: curs_main.c:2456
+#: curs_main.c:2464
 msgid "No unread messages."
 msgstr "Нет непрочитанных сообщений."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2474
+#: curs_main.c:2482
 msgid "Cannot flag message"
 msgstr "Не удалось переключить флаг сообщения"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2513 pager.c:3100
+#: curs_main.c:2521 pager.c:3104
 msgid "Cannot toggle new"
 msgstr "Не удалось переключить флаг \"новое\""
 
-#: curs_main.c:2590
+#: curs_main.c:2598
 msgid "No more threads."
 msgstr "Нет больше дискуссий."
 
-#: curs_main.c:2592
+#: curs_main.c:2600
 msgid "You are on the first thread."
 msgstr "Это первая дискуссия"
 
-#: curs_main.c:2676
+#: curs_main.c:2684
 #, fuzzy
 msgid "Thread contains unread or flagged messages."
 msgstr "В дискуссии присутствуют непрочитанные сообщения."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2726 pager.c:2784
+#: curs_main.c:2734 pager.c:2784
 msgid "Cannot delete message"
 msgstr "Не удалось удалить сообщение"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2838
+#: curs_main.c:2850
 msgid "Cannot edit message"
 msgstr "Не удалось отредактировать сообщение"
 
 #. L10N: This is displayed when the x-label on one or more
 #. * messages is edited.
-#: curs_main.c:2900 pager.c:3200
+#: curs_main.c:2912 pager.c:3208
 #, fuzzy, c-format
 msgid "%d label changed."
 msgid_plural "%d labels changed."
@@ -1801,52 +1811,57 @@ msgstr[2] "Метки были изменены: %d"
 #. L10N: This is displayed when editing an x-label, but no messages
 #. * were updated.  Possibly due to canceling at the prompt or if the new
 #. * label is the same as the old label.
-#: curs_main.c:2907 pager.c:3204
+#: curs_main.c:2919 pager.c:3212
 msgid "No labels changed."
 msgstr "Ни одна метка не была изменена."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:3006
-msgid "Cannot mark message(s) as read"
+#. L10N: Due to the implementation details we do not know whether we
+#. mark zero, 1, 12, ... messages as read. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:3022
+#, fuzzy
+msgid "Cannot mark messages as read"
 msgstr "Не удалось пометить сообщения как прочитанные"
 
 #. L10N: This is the prompt for <mark-message>.  Whatever they
 #. enter will be prefixed by $mark_macro_prefix and will become
 #. a macro hotkey to jump to the currently selected message.
-#: curs_main.c:3042
+#: curs_main.c:3058
 msgid "Enter macro stroke: "
 msgstr "Введите макрос сообщения: "
 
 #. L10N: "message hotkey" is the key bindings menu description of a
 #. macro created by <mark-message>.
-#: curs_main.c:3050
+#: curs_main.c:3066
 msgid "message hotkey"
 msgstr "макрос сообщения"
 
 #. L10N: This is echoed after <mark-message> creates a new hotkey
 #. macro.  %s is the hotkey string ($mark_macro_prefix followed
 #. by whatever they typed at the prompt.)
-#: curs_main.c:3055
+#: curs_main.c:3071
 #, c-format
 msgid "Message bound to %s."
 msgstr "Сообщение связяно с %s."
 
 #. L10N: This error is printed if <mark-message> cannot find a
 #. Message-ID for the currently selected message in the index.
-#: curs_main.c:3063
+#: curs_main.c:3079
 msgid "No message ID to macro."
 msgstr "Нет Message-ID для создания макроса."
 
-#: curs_main.c:3105 pager.c:2961 recvattach.c:1388
+#: curs_main.c:3121 pager.c:2965 recvattach.c:1401
 msgid "Reply by mail as poster prefers?"
 msgstr ""
 
-#: curs_main.c:3108 pager.c:2927 pager.c:2939 pager.c:2964
+#: curs_main.c:3124 pager.c:2931 pager.c:2943 pager.c:2968
 msgid "Posting to this group not allowed, may be moderated. Continue?"
 msgstr ""
 
 #. L10N: CHECK_ACL
-#: curs_main.c:3173 pager.c:3120
+#: curs_main.c:3189 pager.c:3124
 msgid "Cannot undelete message"
 msgstr "Не удалось восстановить сообщение"
 
@@ -2037,12 +2052,37 @@ msgstr "[-- Автопросмотр стандартного потока ош�
 msgid "[-- Error: message/external-body has no access-type parameter --]\n"
 msgstr "[-- Ошибка: тип message/external требует наличие параметра access-type --]\n"
 
-#: handler.c:1611
+#. L10N: If the translation of this string is a multi line string, then
+#. each line should start with "[-- " and end with " --]".
+#. The first "%s/%s" is a MIME type, e.g. "text/plain". The last %s
+#. expands to a date as returned by `mutt_date_parse_date()`.
+#.
+#. Note: The size argument printed is not the actual number as passed
+#. to gettext but the prettified version, e.g. size = 2048 will be
+#. printed as 2K.  Your language might be sensitive to that: For
+#. example although '1K' and '1024' represent the same number your
+#. language might inflect the noun 'byte' differently.
+#.
+#. Sadly, we cannot do anything about that at the moment besides
+#. passing the precise size in bytes. If you are interested the
+#. function responsible for the prettification is
+#. mutt_str_pretty_size() in mutt/string.c.
+#.
+#: handler.c:1624
 #, fuzzy, c-format
 msgid ""
+"[-- This %s/%s attachment (size %s byte) has been deleted --]\n"
+"[-- on %s --]\n"
+msgid_plural ""
 "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
 "[-- on %s --]\n"
-msgstr ""
+msgstr[0] ""
+"[-- Это вложение типа %s/%s (размер %s байтов) было удалено --]\n"
+"[-- %s --]\n"
+msgstr[1] ""
+"[-- Это вложение типа %s/%s (размер %s байтов) было удалено --]\n"
+"[-- %s --]\n"
+msgstr[2] ""
 "[-- Это вложение типа %s/%s (размер %s байтов) было удалено --]\n"
 "[-- %s --]\n"
 
@@ -2050,10 +2090,24 @@ msgstr ""
 #. each line should start with "[-- " and end with " --]".
 #. The first "%s/%s" is a MIME type, e.g. "text/plain".
 #.
-#: handler.c:1620
+#. Note: The size argument printed is not the actual number as passed
+#. to gettext but the prettified version, e.g. size = 2048 will be
+#. printed as 2K.  Your language might be sensitive to that: For
+#. example although '1K' and '1024' represent the same number your
+#. language might inflect the noun 'byte' differently.
+#.
+#. Sadly, we cannot do anything about that at the moment besides
+#. passing the precise size in bytes. If you are interested the
+#. function responsible for the prettification is
+#. mutt_str_pretty_size() in mutt/string.c.
+#.
+#: handler.c:1648
 #, fuzzy, c-format
-msgid "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
-msgstr "[-- Это вложение типа %s/%s (размер %s байтов) было удалено --]\n"
+msgid "[-- This %s/%s attachment (size %s byte) has been deleted --]\n"
+msgid_plural "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
+msgstr[0] "[-- Это вложение типа %s/%s (размер %s байтов) было удалено --]\n"
+msgstr[1] "[-- Это вложение типа %s/%s (размер %s байтов) было удалено --]\n"
+msgstr[2] "[-- Это вложение типа %s/%s (размер %s байтов) было удалено --]\n"
 
 #. L10N: If the translation of this string is a multi line string, then
 #. each line should start with "[-- " and end with " --]".
@@ -2063,7 +2117,7 @@ msgstr "[-- Это вложение типа %s/%s (размер %s байтов
 #. Caution: Argument three %3$ is also defined but should not be used
 #. in this translation!
 #.
-#: handler.c:1637
+#: handler.c:1667
 #, fuzzy
 msgid ""
 "[-- This %s/%s attachment has been deleted --]\n"
@@ -2076,17 +2130,17 @@ msgstr ""
 #. each line should start with "[-- " and end with " --]".
 #. The first "%s/%s" is a MIME type, e.g. "text/plain".
 #.
-#: handler.c:1646
+#: handler.c:1676
 #, fuzzy, c-format
 msgid "[-- This %s/%s attachment has been deleted --]\n"
 msgstr "[-- Это вложение типа %s/%s было удалено --]\n"
 
-#: handler.c:1656
+#: handler.c:1686
 #, c-format
 msgid "[-- name: %s --]\n"
 msgstr "[-- имя: %s --]\n"
 
-#: handler.c:1672
+#: handler.c:1702
 #, fuzzy, c-format
 msgid ""
 "[-- This %s/%s attachment is not included, --]\n"
@@ -2097,7 +2151,7 @@ msgstr ""
 "[-- в сообщение, и более не содержится в указанном --]\n"
 "[-- внешнем источнике. --]\n"
 
-#: handler.c:1693
+#: handler.c:1723
 #, fuzzy, c-format
 msgid ""
 "[-- This %s/%s attachment is not included, --]\n"
@@ -2106,51 +2160,51 @@ msgstr ""
 "[-- Это вложение типа %s/%s не было включено --]\n"
 "[-- в сообщение, и значение access-type %s не поддерживается --]\n"
 
-#: handler.c:1822
+#: handler.c:1852
 #, fuzzy
 msgid "Unable to open memory stream!"
 msgstr "Не удалось открыть временный файл!"
 
-#: handler.c:1831
+#: handler.c:1861
 msgid "Unable to open temporary file!"
 msgstr "Не удалось открыть временный файл!"
 
-#: handler.c:1881
+#: handler.c:1911
 msgid "failed to re-open memstream!"
 msgstr ""
 
-#: handler.c:2013
+#: handler.c:2043
 msgid "Error: multipart/signed has no protocol."
 msgstr "Ошибка: тип multipart/signed требует наличия параметра protocol."
 
-#: handler.c:2076
+#: handler.c:2106
 #, fuzzy
 msgid "[-- This is an attachment (use '%3$s' to view this part) --]\n"
 msgstr "[-- Это вложение (используйте \"%3$s\" для просмотра этой части) --]\n"
 
-#: handler.c:2082
+#: handler.c:2112
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported (use '%s' to view this part) --]\n"
 msgstr "[-- тип %s/%s не поддерживается (используйте \"%s\" для просмотра этой части) --]\n"
 
-#: handler.c:2087
+#: handler.c:2117
 #, fuzzy
 msgid "[-- This is an attachment (need 'view-attachments' bound to key!) --]\n"
 msgstr "[-- Это вложение (функция view-attachments не назначена ни одной клавише!) --]\n"
 
 #. L10N: %s/%s is a MIME type, e.g. "text/plain".
-#: handler.c:2091
+#: handler.c:2121
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported (need 'view-attachments' bound to key!) --]\n"
 msgstr "[-- тип %s/%s не поддерживается (функция view-attachments не назначена ни одной клавише!) --]\n"
 
-#: handler.c:2098
+#: handler.c:2128
 #, fuzzy
 msgid "[-- This is an attachment --]\n"
 msgstr "[-- Это вложение --]\n"
 
 #. L10N: %s/%s is a MIME type, e.g. "text/plain".
-#: handler.c:2101
+#: handler.c:2131
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported --]\n"
 msgstr "[-- тип %s/%s не поддерживается --]\n"
@@ -2460,7 +2514,7 @@ msgstr "SMTP сервер не поддерживает аутентификац
 msgid "Invalid IMAP flags"
 msgstr "Неправильный "
 
-#: imap/message.c:477 mx.c:1326
+#: imap/message.c:477 mx.c:1336
 msgid "Integer overflow -- can't allocate memory."
 msgstr "Переполнение -- не удалось выделить память."
 
@@ -3226,24 +3280,36 @@ msgstr "SSL-протокол недоступен."
 msgid "Reading from %s interrupted..."
 msgstr "Поиск прерван."
 
-#: mx.c:634
-msgid "message(s) not deleted"
-msgstr "сообщения не удалены"
+#. L10N: Although we now the precise number of messages, we do not show it to the user.
+#. So feel free to use a "generic plural" as plural translation if your language has one.
+#.
+#: mx.c:639
+#, fuzzy
+msgid "message not deleted"
+msgid_plural "messages not deleted"
+msgstr[0] "сообщения не удалены"
+msgstr[1] "сообщения не удалены"
+msgstr[2] "сообщения не удалены"
 
-#: mx.c:671
+#: mx.c:676
 msgid "Can't open trash folder"
 msgstr "Не удалось открыть мусорную корзину"
 
-#: mx.c:710
+#: mx.c:715
 msgid "Mark all articles read?"
 msgstr ""
 
-#: mx.c:754
+#. L10N: The first argument is the number of read messages to be
+#. moved, the second argument is the target mailbox.
+#: mx.c:762
 #, fuzzy, c-format
-msgid "Move %d read messages to %s?"
-msgstr "Переместить прочитанные сообщения в %s?"
+msgid "Move %d read message to %s?"
+msgid_plural "Move %d read messages to %s?"
+msgstr[0] "Переместить прочитанные сообщения в %s?"
+msgstr[1] "Переместить прочитанные сообщения в %s?"
+msgstr[2] "Переместить прочитанные сообщения в %s?"
 
-#: mx.c:771 mx.c:1077
+#: mx.c:781 mx.c:1087
 #, fuzzy, c-format
 msgid "Purge %d deleted message?"
 msgid_plural "Purge %d deleted messages?"
@@ -3251,40 +3317,40 @@ msgstr[0] "Вычистить %d удаленное сообщение?"
 msgstr[1] "Вычистить %d удаленных сообщений?"
 msgstr[2] "Вычистить %d удаленных сообщений?"
 
-#: mx.c:793
+#: mx.c:803
 #, c-format
 msgid "Moving read messages to %s..."
 msgstr "Прочитанные сообщения перемещаются в %s..."
 
-#: mx.c:859 mx.c:1068
+#: mx.c:869 mx.c:1078
 msgid "Mailbox is unchanged."
 msgstr "Почтовый ящик не изменился."
 
-#: mx.c:914
+#: mx.c:924
 #, c-format
 msgid "%d kept, %d moved, %d deleted."
 msgstr "Оставлено: %d, перемещено: %d, удалено: %d."
 
-#: mx.c:917 mx.c:1130
+#: mx.c:927 mx.c:1140
 #, c-format
 msgid "%d kept, %d deleted."
 msgstr "Оставлено: %d, удалено: %d."
 
-#: mx.c:1052
+#: mx.c:1062
 #, c-format
 msgid " Press '%s' to toggle write"
 msgstr " Используйте \"%s\" для разрешения/запрещения записи"
 
-#: mx.c:1054
+#: mx.c:1064
 msgid "Use 'toggle-write' to re-enable write!"
 msgstr "Используйте команду toggle-write для разрешения записи!"
 
-#: mx.c:1056
+#: mx.c:1066
 #, c-format
 msgid "Mailbox is marked unwritable. %s"
 msgstr "Почтовый ящик стал доступен только для чтения. %s"
 
-#: mx.c:1124
+#: mx.c:1134
 msgid "Mailbox checkpointed."
 msgstr "Почтовый ящик обновлен."
 
@@ -3298,54 +3364,59 @@ msgstr " (текущее время: %c)"
 msgid "[-- %s output follows%s --]\n"
 msgstr "[-- Результат работы программы %s%s --]\n"
 
-#: ncrypt/crypt.c:95
-msgid "Passphrase(s) forgotten."
+#. L10N: Due to the implementation details (e.g. some passwords are managed
+#. by gpg-agent) we cannot know whether we forgot zero, 1, 12, ...
+#. passwords. So in English we use "Passphrases". Your language might
+#. have other means to express this.
+#: ncrypt/crypt.c:100
+#, fuzzy
+msgid "Passphrases forgotten."
 msgstr "Фразы-пароли удалены из памяти."
 
-#: ncrypt/crypt.c:155
+#: ncrypt/crypt.c:161
 msgid "Inline PGP can't be used with attachments.  Revert to PGP/MIME?"
 msgstr "Невозможно использовать PGP/текст с вложениями. Применить PGP/MIME?"
 
-#: ncrypt/crypt.c:159
+#: ncrypt/crypt.c:165
 msgid "Mail not sent: inline PGP can't be used with attachments."
 msgstr "Письмо не отправлено: невозможно использовать PGP/текст с вложениями."
 
-#: ncrypt/crypt.c:166
+#: ncrypt/crypt.c:172
 #, fuzzy
 msgid "Inline PGP can't be used with format=flowed.  Revert to PGP/MIME?"
 msgstr "Невозможно использовать PGP/текст с вложениями. Применить PGP/MIME?"
 
-#: ncrypt/crypt.c:170
+#: ncrypt/crypt.c:176
 #, fuzzy
 msgid "Mail not sent: inline PGP can't be used with format=flowed."
 msgstr "Письмо не отправлено: невозможно использовать PGP/текст с вложениями."
 
-#: ncrypt/crypt.c:180 ncrypt/cryptglue.c:125 ncrypt/pgpkey.c:589
+#: ncrypt/crypt.c:186 ncrypt/cryptglue.c:125 ncrypt/pgpkey.c:589
 #: ncrypt/pgpkey.c:782
 msgid "Invoking PGP..."
 msgstr "Запускается программа PGP..."
 
-#: ncrypt/crypt.c:192
+#: ncrypt/crypt.c:198
 msgid "Message can't be sent inline.  Revert to using PGP/MIME?"
 msgstr "Не удалось отправить PGP-сообщение в текстовом формате. Использовать PGP/MIME?"
 
-#: ncrypt/crypt.c:194 send.c:1824
+#: ncrypt/crypt.c:200 send.c:1824
 msgid "Mail not sent."
 msgstr "Письмо не отправлено."
 
-#: ncrypt/crypt.c:540
+#: ncrypt/crypt.c:546
 msgid "S/MIME messages with no hints on content are unsupported."
 msgstr "S/MIME-сообщения без указания типа содержимого не поддерживаются."
 
-#: ncrypt/crypt.c:754 ncrypt/crypt.c:795
+#: ncrypt/crypt.c:760 ncrypt/crypt.c:801
 msgid "Trying to extract PGP keys...\n"
 msgstr "Попытка извлечь PGP ключи...\n"
 
-#: ncrypt/crypt.c:776 ncrypt/crypt.c:816
+#: ncrypt/crypt.c:782 ncrypt/crypt.c:822
 msgid "Trying to extract S/MIME certificates...\n"
 msgstr "Попытка извлечь S/MIME сертификаты...\n"
 
-#: ncrypt/crypt.c:976
+#: ncrypt/crypt.c:982
 #, c-format
 msgid ""
 "[-- Error: Unknown multipart/signed protocol %s! --]\n"
@@ -3354,7 +3425,7 @@ msgstr ""
 "[-- Ошибка: неизвестный multipart/signed протокол %s! --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1016
+#: ncrypt/crypt.c:1022
 #, fuzzy
 msgid ""
 "[-- Error: Missing or bad-format multipart/signed signature! --]\n"
@@ -3363,7 +3434,7 @@ msgstr ""
 "[-- Ошибка: нарушена структура multipart/signed-сообщения! --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1058
+#: ncrypt/crypt.c:1064
 #, c-format
 msgid ""
 "[-- Warning: We can't verify %s/%s signatures. --]\n"
@@ -3372,7 +3443,7 @@ msgstr ""
 "[-- Предупреждение: не удалось проверить %s/%s подписи. --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1070
+#: ncrypt/crypt.c:1076
 msgid ""
 "[-- The following data is signed --]\n"
 "\n"
@@ -3380,7 +3451,7 @@ msgstr ""
 "[-- Начало подписанных данных --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1075
+#: ncrypt/crypt.c:1081
 msgid ""
 "[-- Warning: Can't find any signatures. --]\n"
 "\n"
@@ -3388,7 +3459,7 @@ msgstr ""
 "[-- Предупреждение: не найдено ни одной подписи. --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1081
+#: ncrypt/crypt.c:1087
 msgid ""
 "\n"
 "[-- End of signed data --]\n"
@@ -3439,7 +3510,7 @@ msgstr ""
 msgid "error reading data object: %s\n"
 msgstr "ошибка чтения объекта данных: %s\n"
 
-#: ncrypt/crypt_gpgme.c:662 ncrypt/crypt_gpgme.c:3848 ncrypt/pgpkey.c:585
+#: ncrypt/crypt_gpgme.c:662 ncrypt/crypt_gpgme.c:3850 ncrypt/pgpkey.c:585
 #: ncrypt/pgpkey.c:768
 msgid "Can't create temporary file"
 msgstr "Не удалось создать временный файл"
@@ -3787,28 +3858,31 @@ msgstr "[Неправильное значение]"
 
 #. L10N: This is printed after "Key Type: " and looks like this:
 #. *       PGP, 2048 bit RSA
-#: ncrypt/crypt_gpgme.c:3670 ncrypt/crypt_gpgme.c:3808
-#, c-format
+#: ncrypt/crypt_gpgme.c:3670 ncrypt/crypt_gpgme.c:3810
+#, fuzzy, c-format
 msgid "%s, %lu bit %s\n"
-msgstr "%s, %lu бит %s\n"
+msgid_plural "%s, %lu bit %s\n"
+msgstr[0] "%s, %lu бит %s\n"
+msgstr[1] "%s, %lu бит %s\n"
+msgstr[2] "%s, %lu бит %s\n"
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3678 ncrypt/crypt_gpgme.c:3815
+#: ncrypt/crypt_gpgme.c:3678 ncrypt/crypt_gpgme.c:3817
 msgid "encryption"
 msgstr "шифрование"
 
 #: ncrypt/crypt_gpgme.c:3679 ncrypt/crypt_gpgme.c:3685
-#: ncrypt/crypt_gpgme.c:3816 ncrypt/crypt_gpgme.c:3821
+#: ncrypt/crypt_gpgme.c:3818 ncrypt/crypt_gpgme.c:3823
 msgid ", "
 msgstr ", "
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3684 ncrypt/crypt_gpgme.c:3820
+#: ncrypt/crypt_gpgme.c:3684 ncrypt/crypt_gpgme.c:3822
 msgid "signing"
 msgstr "подпись"
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3690 ncrypt/crypt_gpgme.c:3825
+#: ncrypt/crypt_gpgme.c:3690 ncrypt/crypt_gpgme.c:3827
 msgid "certification"
 msgstr "сертификация"
 
@@ -3827,64 +3901,64 @@ msgstr "[Просрочен]"
 msgid "[Disabled]"
 msgstr "[Запрещён]"
 
-#: ncrypt/crypt_gpgme.c:3851
+#: ncrypt/crypt_gpgme.c:3853
 msgid "Collecting data..."
 msgstr "Сбор данных..."
 
-#: ncrypt/crypt_gpgme.c:3876
+#: ncrypt/crypt_gpgme.c:3878
 #, c-format
 msgid "Error finding issuer key: %s\n"
 msgstr "Ошибка поиска ключа издателя: %s\n"
 
-#: ncrypt/crypt_gpgme.c:3885
+#: ncrypt/crypt_gpgme.c:3887
 msgid "Error: certification chain too long - stopping here\n"
 msgstr "Ошибка: цепь сертификации слишком длинная - поиск прекращён\n"
 
-#: ncrypt/crypt_gpgme.c:3895 ncrypt/pgpkey.c:608
+#: ncrypt/crypt_gpgme.c:3897 ncrypt/pgpkey.c:608
 #, c-format
 msgid "Key ID: 0x%s"
 msgstr "Идентификатор ключа: 0x%s"
 
-#: ncrypt/crypt_gpgme.c:3990
+#: ncrypt/crypt_gpgme.c:3992
 #, c-format
 msgid "gpgme_new failed: %s"
 msgstr "Ошибка gpgme_new: %s"
 
-#: ncrypt/crypt_gpgme.c:4028 ncrypt/crypt_gpgme.c:4079
+#: ncrypt/crypt_gpgme.c:4030 ncrypt/crypt_gpgme.c:4081
 #, c-format
 msgid "gpgme_op_keylist_start failed: %s"
 msgstr "Ошибка gpgme_op_keylist_start: %s"
 
-#: ncrypt/crypt_gpgme.c:4067 ncrypt/crypt_gpgme.c:4109
+#: ncrypt/crypt_gpgme.c:4069 ncrypt/crypt_gpgme.c:4111
 #, c-format
 msgid "gpgme_op_keylist_next failed: %s"
 msgstr "Ошибка gpgme_op_keylist_next: %s"
 
-#: ncrypt/crypt_gpgme.c:4185
+#: ncrypt/crypt_gpgme.c:4187
 msgid "All matching keys are marked expired/revoked."
 msgstr "Все подходящие ключи помечены как просроченные или отозванные."
 
-#: ncrypt/crypt_gpgme.c:4215 ncrypt/pgpkey.c:543 ncrypt/smime.c:475
+#: ncrypt/crypt_gpgme.c:4217 ncrypt/pgpkey.c:543 ncrypt/smime.c:475
 msgid "Select  "
 msgstr "Выбрать "
 
-#: ncrypt/crypt_gpgme.c:4217 ncrypt/pgpkey.c:545
+#: ncrypt/crypt_gpgme.c:4219 ncrypt/pgpkey.c:545
 msgid "Check key  "
 msgstr "Тест ключа "
 
-#: ncrypt/crypt_gpgme.c:4233
+#: ncrypt/crypt_gpgme.c:4235
 msgid "PGP and S/MIME keys matching"
 msgstr "PGP и S/MIME-ключи, соответствующие"
 
-#: ncrypt/crypt_gpgme.c:4235
+#: ncrypt/crypt_gpgme.c:4237
 msgid "PGP keys matching"
 msgstr "PGP-ключи, соответствующие"
 
-#: ncrypt/crypt_gpgme.c:4237
+#: ncrypt/crypt_gpgme.c:4239
 msgid "S/MIME keys matching"
 msgstr "S/MIME-ключи, соответствующие"
 
-#: ncrypt/crypt_gpgme.c:4239
+#: ncrypt/crypt_gpgme.c:4241
 msgid "keys matching"
 msgstr "ключи, соответствующие"
 
@@ -3892,69 +3966,69 @@ msgstr "ключи, соответствующие"
 #. %1$s is one of the previous four entries.
 #. %2$s is an address.
 #. e.g. "S/MIME keys matching <me@mutt.org>."
-#: ncrypt/crypt_gpgme.c:4246
+#: ncrypt/crypt_gpgme.c:4248
 #, c-format
 msgid "%s <%s>."
 msgstr "%s <%s>."
 
 #. L10N:
 #. e.g. 'S/MIME keys matching "Michael Elkins".'
-#: ncrypt/crypt_gpgme.c:4250
+#: ncrypt/crypt_gpgme.c:4252
 #, c-format
 msgid "%s \"%s\"."
 msgstr "%s \"%s\"."
 
-#: ncrypt/crypt_gpgme.c:4277 ncrypt/pgpkey.c:628
+#: ncrypt/crypt_gpgme.c:4279 ncrypt/pgpkey.c:628
 msgid "This key can't be used: expired/disabled/revoked."
 msgstr "Этот ключ не может быть использован: просрочен, запрещен или отозван."
 
-#: ncrypt/crypt_gpgme.c:4290 ncrypt/pgpkey.c:640 ncrypt/smime.c:505
+#: ncrypt/crypt_gpgme.c:4292 ncrypt/pgpkey.c:640 ncrypt/smime.c:505
 #, fuzzy
 msgid "ID is expired/disabled/revoked. Do you really want to use the key?"
 msgstr "ID просрочен, запрещен или отозван. Использовать этот ключ?"
 
-#: ncrypt/crypt_gpgme.c:4299 ncrypt/pgpkey.c:650
+#: ncrypt/crypt_gpgme.c:4301 ncrypt/pgpkey.c:650
 #, fuzzy
 msgid "ID is not valid. Do you really want to use the key?"
 msgstr "ID недействителен. Использовать этот ключ?"
 
-#: ncrypt/crypt_gpgme.c:4302 ncrypt/pgpkey.c:653
+#: ncrypt/crypt_gpgme.c:4304 ncrypt/pgpkey.c:653
 #, fuzzy
 msgid "ID is only marginally valid. Do you really want to use the key?"
 msgstr "ID действителен только частично. Использовать этот ключ?"
 
-#: ncrypt/crypt_gpgme.c:4310 ncrypt/pgpkey.c:646 ncrypt/smime.c:509
+#: ncrypt/crypt_gpgme.c:4312 ncrypt/pgpkey.c:646 ncrypt/smime.c:509
 #, fuzzy
 msgid "ID has undefined validity. Do you really want to use the key?"
 msgstr "Степень доверия для ID не определена. Использовать этот ключ?"
 
-#: ncrypt/crypt_gpgme.c:4370 ncrypt/crypt_gpgme.c:4479 ncrypt/pgpkey.c:872
+#: ncrypt/crypt_gpgme.c:4372 ncrypt/crypt_gpgme.c:4481 ncrypt/pgpkey.c:872
 #: ncrypt/pgpkey.c:995
 #, c-format
 msgid "Looking for keys matching \"%s\"..."
 msgstr "Поиск ключей, соответствующих \"%s\"..."
 
-#: ncrypt/crypt_gpgme.c:4593 ncrypt/pgpkey.c:731 ncrypt/smime.c:811
+#: ncrypt/crypt_gpgme.c:4595 ncrypt/pgpkey.c:731 ncrypt/smime.c:811
 #, c-format
 msgid "No matching keys found for \"%s\""
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4644 ncrypt/pgp.c:1263
+#: ncrypt/crypt_gpgme.c:4646 ncrypt/pgp.c:1263
 #, c-format
 msgid "Use keyID = \"%s\" for %s?"
 msgstr "Использовать ключ \"%s\" для %s?"
 
-#: ncrypt/crypt_gpgme.c:4695 ncrypt/pgp.c:1312 ncrypt/smime.c:830
+#: ncrypt/crypt_gpgme.c:4697 ncrypt/pgp.c:1312 ncrypt/smime.c:830
 #: ncrypt/smime.c:938
 #, c-format
 msgid "Enter keyID for %s: "
 msgstr "Введите идентификатор ключа для %s: "
 
-#: ncrypt/crypt_gpgme.c:4755 ncrypt/pgpkey.c:751
+#: ncrypt/crypt_gpgme.c:4757 ncrypt/pgpkey.c:751
 msgid "Please enter the key ID: "
 msgstr "Введите, пожалуйста, идентификатор ключа: "
 
-#: ncrypt/crypt_gpgme.c:4768
+#: ncrypt/crypt_gpgme.c:4770
 #, c-format
 msgid "Error exporting key: %s\n"
 msgstr "Ошибка экспорта ключа: %s\n"
@@ -3963,84 +4037,84 @@ msgstr "Ошибка экспорта ключа: %s\n"
 #. MIME description for exported (attached) keys.
 #. You can translate this entry to a non-ASCII string (it will be encoded),
 #. but it may be safer to keep it untranslated.
-#: ncrypt/crypt_gpgme.c:4787
+#: ncrypt/crypt_gpgme.c:4789
 #, c-format
 msgid "PGP Key 0x%s."
 msgstr "PGP-ключ 0x%s."
 
-#: ncrypt/crypt_gpgme.c:4830
+#: ncrypt/crypt_gpgme.c:4832
 msgid "GPGME: OpenPGP protocol not available"
 msgstr "GPGME: Протокол OpenPGP не доступен"
 
-#: ncrypt/crypt_gpgme.c:4838
+#: ncrypt/crypt_gpgme.c:4840
 msgid "GPGME: CMS protocol not available"
 msgstr "GPGME: Протокол CMS не доступен"
 
-#: ncrypt/crypt_gpgme.c:4876
+#: ncrypt/crypt_gpgme.c:4878
 msgid "S/MIME (s)ign, sign (a)s, (p)gp, (c)lear, or (o)ppenc mode off? "
 msgstr "S/MIME (s)подпись, (a)подпись как, (p)gp, (c)отказаться, отключить (o)ppenc? "
 
 #. L10N: S/MIME options (opportunistic encryption is on)
-#: ncrypt/crypt_gpgme.c:4878
+#: ncrypt/crypt_gpgme.c:4880
 msgid "sapco"
 msgstr "sapco"
 
-#: ncrypt/crypt_gpgme.c:4885
+#: ncrypt/crypt_gpgme.c:4887
 msgid "PGP (s)ign, sign (a)s, s/(m)ime, (c)lear, or (o)ppenc mode off? "
 msgstr "PGP (s)подпись, (a)подпись как, s/(m)ime, (c)отказаться, отключить (o)ppenc? "
 
 #. L10N: PGP options (opportunistic encryption is on)
-#: ncrypt/crypt_gpgme.c:4887
+#: ncrypt/crypt_gpgme.c:4889
 msgid "samco"
 msgstr "samco"
 
 #. L10N: S/MIME options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4900
+#: ncrypt/crypt_gpgme.c:4902
 msgid "S/MIME (e)ncrypt, (s)ign, sign (a)s, (b)oth, (p)gp, (c)lear, or (o)ppenc mode? "
 msgstr "S/MIME (e)шифр, (s)подпись, (a)подпись как, (b)оба, (p)gp, (c)отказ, (o)ppenc? "
 
 #. L10N: S/MIME options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4903
+#: ncrypt/crypt_gpgme.c:4905
 #, fuzzy
 msgid "esabpco"
 msgstr "esabpc"
 
 #. L10N: PGP options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4909
+#: ncrypt/crypt_gpgme.c:4911
 msgid "PGP (e)ncrypt, (s)ign, sign (a)s, (b)oth, s/(m)ime, (c)lear, or (o)ppenc mode? "
 msgstr "PGP (e)шифр, (s)подпись, (a)подпись как, (b)оба, s/(m)ime, (c)отказ, (o)ppenc? "
 
 #. L10N: PGP options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4912
+#: ncrypt/crypt_gpgme.c:4914
 #, fuzzy
 msgid "esabmco"
 msgstr "esabmco"
 
-#: ncrypt/crypt_gpgme.c:4925
+#: ncrypt/crypt_gpgme.c:4927
 msgid "S/MIME (e)ncrypt, (s)ign, sign (a)s, (b)oth, (p)gp or (c)lear? "
 msgstr "S/MIME (e)шифр, (s)подпись, (a)подпись как, (b)оба, (p)gp, (c)отказаться? "
 
 #. L10N: S/MIME options
-#: ncrypt/crypt_gpgme.c:4927
+#: ncrypt/crypt_gpgme.c:4929
 #, fuzzy
 msgid "esabpc"
 msgstr "esabpc"
 
-#: ncrypt/crypt_gpgme.c:4934
+#: ncrypt/crypt_gpgme.c:4936
 msgid "PGP (e)ncrypt, (s)ign, sign (a)s, (b)oth, s/(m)ime or (c)lear? "
 msgstr "PGP (e)шифр, (s)подпись, (a)подпись как, (b)оба, s/(m)ime, (c)отказаться? "
 
 #. L10N: PGP options
-#: ncrypt/crypt_gpgme.c:4936
+#: ncrypt/crypt_gpgme.c:4938
 #, fuzzy
 msgid "esabmc"
 msgstr "esabmc"
 
-#: ncrypt/crypt_gpgme.c:5087
+#: ncrypt/crypt_gpgme.c:5089
 msgid "Failed to verify sender"
 msgstr "Не удалось проверить отправителя"
 
-#: ncrypt/crypt_gpgme.c:5090
+#: ncrypt/crypt_gpgme.c:5092
 msgid "Failed to figure out sender"
 msgstr "Не удалось вычислить отправителя"
 
@@ -4435,7 +4509,7 @@ msgstr ""
 msgid "%s is an invalid news server specification!"
 msgstr "Неверно указано имя POP-ящика: %s"
 
-#: nntp.c:75 nntp.c:612 pop.c:1028 pop_lib.c:405
+#: nntp.c:75 nntp.c:612 pop.c:1031 pop_lib.c:405
 msgid "Server closed connection!"
 msgstr "Сервер закрыл соединение!"
 
@@ -4601,16 +4675,18 @@ msgid "check mailboxes for new mail"
 msgstr "проверить почтовые ящики на наличие новой почты"
 
 #: opcodes.h:47
-msgid "attach file(s) to this message"
+#, fuzzy
+msgid "attach files to this message"
 msgstr "вложить файлы в это сообщение"
 
 #: opcodes.h:48
-msgid "attach message(s) to this message"
+#, fuzzy
+msgid "attach messages to this message"
 msgstr "вложить сообщения в это сообщение"
 
 #: opcodes.h:49
 #, fuzzy
-msgid "attach news article(s) to this message"
+msgid "attach news articles to this message"
 msgstr "вложить файлы в это сообщение"
 
 #: opcodes.h:50
@@ -5451,7 +5527,8 @@ msgid "extract supported public keys"
 msgstr "извлечь поддерживаемые открытые ключи"
 
 #: opcodes.h:255
-msgid "wipe passphrase(s) from memory"
+#, fuzzy
+msgid "wipe passphrases from memory"
 msgstr "удалить фразы-пароли из памяти"
 
 #: opcodes.h:259
@@ -5789,18 +5866,21 @@ msgstr "Нет новой почты в POP-ящике."
 msgid "Delete messages from server?"
 msgstr "Удалить сообщения с сервера?"
 
-#: pop.c:954
-#, c-format
-msgid "Reading new messages (%d bytes)..."
-msgstr "Читаются новые сообщения (байтов: %d)..."
+#: pop.c:955
+#, fuzzy, c-format
+msgid "Reading new messages (%d byte)..."
+msgid_plural "Reading new messages (%d bytes)..."
+msgstr[0] "Читаются новые сообщения (байтов: %d)..."
+msgstr[1] "Читаются новые сообщения (байтов: %d)..."
+msgstr[2] "Читаются новые сообщения (байтов: %d)..."
 
-#: pop.c:997
+#: pop.c:1000
 msgid "Error while writing mailbox!"
 msgstr "Ошибка записи почтового ящика!"
 
 #. L10N: The plural is picked by the second numerical argument, i.e.
 #. * the %d right before 'messages', i.e. the total number of messages.
-#: pop.c:1003
+#: pop.c:1006
 #, fuzzy, c-format
 msgid "%s [%d of %d message read]"
 msgid_plural "%s [%d of %d messages read]"
@@ -5945,48 +6025,56 @@ msgstr "Передать программе: "
 msgid "I don't know how to print %s attachments!"
 msgstr "Неизвестно как печатать %s вложения!"
 
-#: recvattach.c:841
-msgid "Print tagged attachment(s)?"
-msgstr "Напечатать отмеченные вложения?"
+#. L10N: Although we now the precise number of tagged messages, we
+#. do not show it to the user.  So feel free to use a "generic
+#. plural" as plural translation if your language has one.
+#: recvattach.c:852
+#, fuzzy, c-format
+msgid "Print tagged attachment?"
+msgid_plural "Print %d tagged attachments?"
+msgstr[0] "Напечатать отмеченные вложения?"
+msgstr[1] "Напечатать отмеченные вложения?"
+msgstr[2] "Напечатать отмеченные вложения?"
 
-#: recvattach.c:842
+#: recvattach.c:853
+#, c-format
 msgid "Print attachment?"
 msgstr "Напечатать вложение?"
 
-#: recvattach.c:900
+#: recvattach.c:913
 msgid "Structural changes to decrypted attachments are not supported"
 msgstr "Изменение структуры расшифрованных вложений не поддерживается"
 
-#: recvattach.c:1046
+#: recvattach.c:1059
 msgid "Can't decrypt encrypted message!"
 msgstr "Не удалось расшифровать зашифрованное сообщение!"
 
-#: recvattach.c:1172
+#: recvattach.c:1185
 msgid "Attachments"
 msgstr "Вложения"
 
-#: recvattach.c:1210
+#: recvattach.c:1223
 msgid "There are no subparts to show!"
 msgstr "Дайджест не содержит ни одной части!"
 
-#: recvattach.c:1265
+#: recvattach.c:1278
 msgid "Can't delete attachment from POP server."
 msgstr "Удаление вложений не поддерживается POP-сервером."
 
-#: recvattach.c:1274
+#: recvattach.c:1287
 #, fuzzy
 msgid "Can't delete attachment from news server."
 msgstr "Удаление вложений не поддерживается POP-сервером."
 
-#: recvattach.c:1281
+#: recvattach.c:1294
 msgid "Deletion of attachments from encrypted messages is unsupported."
 msgstr "Удаление вложений из зашифрованных сообщений не поддерживается."
 
-#: recvattach.c:1287
+#: recvattach.c:1300
 msgid "Deletion of attachments from signed messages may invalidate the signature."
 msgstr "Удаление вложений из зашифрованных сообщений может аннулировать подпись."
 
-#: recvattach.c:1305 recvattach.c:1320
+#: recvattach.c:1318 recvattach.c:1333
 msgid "Only deletion of multipart attachments is supported."
 msgstr "Для составных вложений поддерживается только удаление."
 
@@ -6422,3 +6510,13 @@ msgstr "Параметры компиляции:"
 #: version.c:404
 msgid "Compile options:"
 msgstr "Параметры компиляции:"
+
+#~ msgid "Cannot delete message(s)"
+#~ msgstr "Не удалось удалить сообщения"
+
+#~ msgid "Cannot undelete message(s)"
+#~ msgstr "Не удалось восстановить сообщения"
+
+#, fuzzy
+#~ msgid "messages not deleted"
+#~ msgstr "сообщения не удалены"

--- a/po/sk.po
+++ b/po/sk.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neomutt-20180512\n"
 "Report-Msgid-Bugs-To: neomutt-devel@neomutt.org\n"
-"POT-Creation-Date: 2018-05-20 02:02+0000\n"
+"POT-Creation-Date: 2018-05-22 14:18+0000\n"
 "PO-Revision-Date: 2016-11-23 21:20+0100\n"
 "Last-Translator: František Hájik <ferko.hajik@gmail.com>\n"
 "Language-Team: Slovak <sk@li.org>\n"
@@ -40,7 +40,7 @@ msgstr "Označiť"
 
 #: addrbook.c:52 browser.c:75 browser.c:87 compose.c:160 compose.c:172
 #: conn/ssl.c:1041 conn/ssl_gnutls.c:793 curs_main.c:748 curs_main.c:761
-#: history.c:106 ncrypt/crypt_gpgme.c:4219 ncrypt/pgpkey.c:547
+#: history.c:106 ncrypt/crypt_gpgme.c:4221 ncrypt/pgpkey.c:547
 #: ncrypt/smime.c:477 pager.c:2141 postpone.c:65 query.c:72 recvattach.c:70
 msgid "Help"
 msgstr "Pomoc"
@@ -693,7 +693,7 @@ msgstr ""
 #. * Since it shares the row with "Encrypt with:", it should not be longer
 #. * than 15-20 character cells.
 #.
-#: compose.c:138 ncrypt/crypt_gpgme.c:4947 ncrypt/pgp.c:1786
+#: compose.c:138 ncrypt/crypt_gpgme.c:4949 ncrypt/pgp.c:1786
 #: ncrypt/smime.c:2127
 msgid "Sign as: "
 msgstr "Podpíš ako: "
@@ -1240,7 +1240,7 @@ msgstr ""
 msgid "(r)eject, accept (o)nce"
 msgstr ""
 
-#: conn/ssl.c:1039 conn/ssl_gnutls.c:791 ncrypt/crypt_gpgme.c:4213
+#: conn/ssl.c:1039 conn/ssl_gnutls.c:791 ncrypt/crypt_gpgme.c:4215
 #: ncrypt/pgpkey.c:541 ncrypt/smime.c:473
 msgid "Exit  "
 msgstr "Koniec  "
@@ -1423,11 +1423,11 @@ msgstr "Nie je otvorená žiadna schránka."
 msgid "There are no messages."
 msgstr "Nie sú žiadne správy."
 
-#: curs_main.c:77 mx.c:1061 pager.c:73 recvattach.c:56
+#: curs_main.c:77 mx.c:1071 pager.c:73 recvattach.c:56
 msgid "Mailbox is read-only."
 msgstr "Schránka je iba na čítanie."
 
-#: curs_main.c:79 pager.c:75 recvattach.c:1145
+#: curs_main.c:79 pager.c:75 recvattach.c:1158
 msgid "Function not permitted in attach-message mode."
 msgstr "V režime prikladania správ táto funkcia nie je dovolená"
 
@@ -1558,242 +1558,252 @@ msgid "That message is not visible."
 msgstr "Táto správa nie je viditeľná."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:1377 curs_main.c:2772 pager.c:2818
-msgid "Cannot delete message(s)"
+#. L10N: Due to the implementation details we do not know whether we
+#. delete zero, 1, 12, ... messages. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:1381 curs_main.c:2784 pager.c:2822
+#, fuzzy
+msgid "Cannot delete messages"
 msgstr "Nemožno vymazať správu/y."
 
-#: curs_main.c:1380
+#: curs_main.c:1384
 msgid "Delete messages matching: "
 msgstr "Zmazať správy zodpovedajúce: "
 
-#: curs_main.c:1421
+#: curs_main.c:1425
 msgid "No limit pattern is in effect."
 msgstr "Žiadny limitovací vzor nie je aktívny."
 
 #. L10N: ask for a limit to apply
-#: curs_main.c:1426
+#: curs_main.c:1430
 #, c-format
 msgid "Limit: %s"
 msgstr "Limit: %s"
 
-#: curs_main.c:1464
+#: curs_main.c:1468
 msgid "Limit to messages matching: "
 msgstr "Limituj správy zodpovedajúce: "
 
-#: curs_main.c:1488
+#: curs_main.c:1492
 msgid "To view all messages, limit to \"all\"."
 msgstr ""
 
-#: curs_main.c:1500 pager.c:2318
+#: curs_main.c:1504 pager.c:2318
 msgid "Quit NeoMutt?"
 msgstr "Ukončiť NeoMutt?"
 
-#: curs_main.c:1596
+#: curs_main.c:1600
 msgid "Tag messages matching: "
 msgstr "Označ správy zodpovedajúce: "
 
 #. L10N: CHECK_ACL
-#: curs_main.c:1606 curs_main.c:3203 pager.c:3137
-msgid "Cannot undelete message(s)"
+#. L10N: Due to the implementation details we do not know whether we
+#. undelete zero, 1, 12, ... messages. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:1614 curs_main.c:3223 pager.c:3145
+#, fuzzy
+msgid "Cannot undelete messages"
 msgstr "Nemožno odmazať správu/y."
 
-#: curs_main.c:1609
+#: curs_main.c:1617
 msgid "Undelete messages matching: "
 msgstr "Odmaž správy zodpovedajúce: "
 
-#: curs_main.c:1619
+#: curs_main.c:1627
 msgid "Untag messages matching: "
 msgstr "Odznač správy zodpovedajúce: "
 
-#: curs_main.c:1653
+#: curs_main.c:1661
 msgid "Logged out of IMAP servers."
 msgstr "Odhlasujem sa z IMAP servera/ov."
 
-#: curs_main.c:1753
+#: curs_main.c:1761
 msgid "No virtual folder, aborting."
 msgstr "Žiadny virtuálna zložka, ukončujem."
 
-#: curs_main.c:1761
+#: curs_main.c:1769
 msgid "Failed to read thread, aborting."
 msgstr "Zlyhalo načítanie vlákna, ukončujem."
 
-#: curs_main.c:1793 mx.c:1458 mx.c:1475
+#: curs_main.c:1801 mx.c:1468 mx.c:1485
 msgid "Folder doesn't support tagging, aborting."
 msgstr ""
 
-#: curs_main.c:1808
+#: curs_main.c:1816
 #, fuzzy
 msgid "No tag specified, aborting."
 msgstr "Žiadny štítok nebol zadaný, ukončujem."
 
-#: curs_main.c:1820
+#: curs_main.c:1828
 #, fuzzy, c-format
 msgid "Update tags..."
 msgstr "Štítky aktualizované..."
 
-#: curs_main.c:1857
+#: curs_main.c:1865
 #, fuzzy
 msgid "Failed to modify tags, aborting."
 msgstr "Zlyhala modifikácia štítkov, prerušujem."
 
-#: curs_main.c:1898
+#: curs_main.c:1906
 msgid "No query, aborting."
 msgstr "Bez dotazov, ukončujem."
 
-#: curs_main.c:1902 curs_main.c:1922 curs_main.c:1941
+#: curs_main.c:1910 curs_main.c:1930 curs_main.c:1949
 msgid "Failed to create query, aborting."
 msgstr "Zlyhalo vytvorenie dotazu, prerušujem."
 
-#: curs_main.c:1911 curs_main.c:1930
+#: curs_main.c:1919 curs_main.c:1938
 msgid "Windowed queries disabled."
 msgstr ""
 
-#: curs_main.c:1916 curs_main.c:1935
+#: curs_main.c:1924 curs_main.c:1943
 msgid "No notmuch vfolder currently loaded."
 msgstr ""
 
-#: curs_main.c:1973
+#: curs_main.c:1981
 msgid "Open mailbox in read-only mode"
 msgstr "Otvor schránku iba na čítanie."
 
-#: curs_main.c:1976
+#: curs_main.c:1984
 msgid "Open virtual folder"
 msgstr "Otvor virtuálnu zložku."
 
-#: curs_main.c:1979
+#: curs_main.c:1987
 msgid "Open mailbox"
 msgstr "Otvor schránku."
 
-#: curs_main.c:1989
+#: curs_main.c:1997
 msgid "No mailboxes have new mail"
 msgstr "Žiadna schránka s novými správami."
 
-#: curs_main.c:2036
+#: curs_main.c:2044
 msgid "Open newsgroup in read-only mode"
 msgstr "Otvor \"newsgroup\" iba na čítanie."
 
-#: curs_main.c:2038
+#: curs_main.c:2046
 msgid "Open newsgroup"
 msgstr "Otvor newsgroup."
 
-#: curs_main.c:2141
+#: curs_main.c:2149
 msgid "Exit NeoMutt without saving?"
 msgstr "Ukončiť NeoMutt bez uloženia?"
 
-#: curs_main.c:2157
+#: curs_main.c:2165
 msgid "Cannot break thread"
 msgstr "Nemožno porušiť vlákno."
 
-#: curs_main.c:2160 curs_main.c:2198 curs_main.c:2658 curs_main.c:2690
+#: curs_main.c:2168 curs_main.c:2206 curs_main.c:2666 curs_main.c:2698
 #: flags.c:376 thread.c:1078 thread.c:1134 thread.c:1202
 msgid "Threading is not enabled."
 msgstr "Vláknenie nie je povolené."
 
-#: curs_main.c:2173
+#: curs_main.c:2181
 msgid "Thread broken"
 msgstr "Vlákno je porušené."
 
-#: curs_main.c:2185
+#: curs_main.c:2193
 msgid "Thread cannot be broken, message is not part of a thread"
 msgstr "Vlákno nemožno porušiť, správa nie je súčasťou vlákna."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2195
+#: curs_main.c:2203
 msgid "Cannot link threads"
 msgstr "Vlákna sa nedajú prepojiť."
 
-#: curs_main.c:2200
+#: curs_main.c:2208
 #, fuzzy
 msgid "No Message-ID: header available to link thread"
 msgstr "Žiadne ID správy: hlavička je k dispozícii na nalinkovaniu s vláknom."
 
-#: curs_main.c:2202
+#: curs_main.c:2210
 #, fuzzy
 msgid "First, please tag a message to be linked here"
 msgstr "Prosím, najprv označte správu, ktorá tu bude pripojená."
 
-#: curs_main.c:2213
+#: curs_main.c:2221
 #, fuzzy
 msgid "Threads linked"
 msgstr "Vlákna prepojené."
 
-#: curs_main.c:2216
+#: curs_main.c:2224
 #, fuzzy
 msgid "No thread linked"
 msgstr "Žiadna pripojené vlákno."
 
-#: curs_main.c:2252 curs_main.c:2278
+#: curs_main.c:2260 curs_main.c:2286
 msgid "You are on the last message."
 msgstr "Ste na poslednej správe."
 
-#: curs_main.c:2260 curs_main.c:2305
+#: curs_main.c:2268 curs_main.c:2313
 msgid "No undeleted messages."
 msgstr "Žiadne odmazané správy."
 
-#: curs_main.c:2297 curs_main.c:2323
+#: curs_main.c:2305 curs_main.c:2331
 msgid "You are on the first message."
 msgstr "Ste na prvej správe."
 
-#: curs_main.c:2395 menu.c:970 pager.c:2440 pattern.c:2110
+#: curs_main.c:2403 menu.c:970 pager.c:2440 pattern.c:2110
 msgid "Search wrapped to top."
 msgstr "Vyhľadávanie pokračuje z vrchu."
 
-#: curs_main.c:2404 pager.c:2463 pattern.c:2121
+#: curs_main.c:2412 pager.c:2463 pattern.c:2121
 msgid "Search wrapped to bottom."
 msgstr "Vyhľadávanie pokračuje zo spodu."
 
-#: curs_main.c:2447
+#: curs_main.c:2455
 msgid "No new messages in this limited view."
 msgstr "Vo výbere nie je žiadne nové správy."
 
-#: curs_main.c:2449
+#: curs_main.c:2457
 msgid "No new messages."
 msgstr "Žiadne nové správy."
 
-#: curs_main.c:2454
+#: curs_main.c:2462
 msgid "No unread messages in this limited view."
 msgstr "Vo výbere nie je žiadne neprečítané správy."
 
-#: curs_main.c:2456
+#: curs_main.c:2464
 msgid "No unread messages."
 msgstr "Žiadne neprečítané správy."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2474
+#: curs_main.c:2482
 msgid "Cannot flag message"
 msgstr "Nemožno označiť správu."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2513 pager.c:3100
+#: curs_main.c:2521 pager.c:3104
 msgid "Cannot toggle new"
 msgstr "Nemožno prepnúť na novú."
 
-#: curs_main.c:2590
+#: curs_main.c:2598
 msgid "No more threads."
 msgstr "Žiadne ďaľšie vlákna."
 
-#: curs_main.c:2592
+#: curs_main.c:2600
 msgid "You are on the first thread."
 msgstr "Ste na prvom vlákne."
 
-#: curs_main.c:2676
+#: curs_main.c:2684
 #, fuzzy
 msgid "Thread contains unread or flagged messages."
 msgstr "Vlákno obsahuje nečítané správy."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2726 pager.c:2784
+#: curs_main.c:2734 pager.c:2784
 msgid "Cannot delete message"
 msgstr "Správu nemožno zmazať."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2838
+#: curs_main.c:2850
 msgid "Cannot edit message"
 msgstr "Správu nemožno upravovať."
 
 #. L10N: This is displayed when the x-label on one or more
 #. * messages is edited.
-#: curs_main.c:2900 pager.c:3200
+#: curs_main.c:2912 pager.c:3208
 #, fuzzy, c-format
 msgid "%d label changed."
 msgid_plural "%d labels changed."
@@ -1804,26 +1814,31 @@ msgstr[2] "Žiadne štítky neboli zmenené."
 #. L10N: This is displayed when editing an x-label, but no messages
 #. * were updated.  Possibly due to canceling at the prompt or if the new
 #. * label is the same as the old label.
-#: curs_main.c:2907 pager.c:3204
+#: curs_main.c:2919 pager.c:3212
 msgid "No labels changed."
 msgstr "Žiadne štítky neboli zmenené."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:3006
-msgid "Cannot mark message(s) as read"
+#. L10N: Due to the implementation details we do not know whether we
+#. mark zero, 1, 12, ... messages as read. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:3022
+#, fuzzy
+msgid "Cannot mark messages as read"
 msgstr "Nemožno označiť správy za prečítané."
 
 #. L10N: This is the prompt for <mark-message>.  Whatever they
 #. enter will be prefixed by $mark_macro_prefix and will become
 #. a macro hotkey to jump to the currently selected message.
-#: curs_main.c:3042
+#: curs_main.c:3058
 #, fuzzy
 msgid "Enter macro stroke: "
 msgstr "Zadajte ID kľúča pre %s: "
 
 #. L10N: "message hotkey" is the key bindings menu description of a
 #. macro created by <mark-message>.
-#: curs_main.c:3050
+#: curs_main.c:3066
 #, fuzzy
 msgid "message hotkey"
 msgstr "Správa bola odložená."
@@ -1831,28 +1846,28 @@ msgstr "Správa bola odložená."
 #. L10N: This is echoed after <mark-message> creates a new hotkey
 #. macro.  %s is the hotkey string ($mark_macro_prefix followed
 #. by whatever they typed at the prompt.)
-#: curs_main.c:3055
+#: curs_main.c:3071
 #, fuzzy, c-format
 msgid "Message bound to %s."
 msgstr "Správa bola presmerovaná."
 
 #. L10N: This error is printed if <mark-message> cannot find a
 #. Message-ID for the currently selected message in the index.
-#: curs_main.c:3063
+#: curs_main.c:3079
 #, fuzzy
 msgid "No message ID to macro."
 msgstr "V tejto zložke nie sú správy."
 
-#: curs_main.c:3105 pager.c:2961 recvattach.c:1388
+#: curs_main.c:3121 pager.c:2965 recvattach.c:1401
 msgid "Reply by mail as poster prefers?"
 msgstr ""
 
-#: curs_main.c:3108 pager.c:2927 pager.c:2939 pager.c:2964
+#: curs_main.c:3124 pager.c:2931 pager.c:2943 pager.c:2968
 msgid "Posting to this group not allowed, may be moderated. Continue?"
 msgstr ""
 
 #. L10N: CHECK_ACL
-#: curs_main.c:3173 pager.c:3120
+#: curs_main.c:3189 pager.c:3124
 #, fuzzy
 msgid "Cannot undelete message"
 msgstr "Žiadne odmazané správy."
@@ -2066,12 +2081,37 @@ msgstr "[-- Chyba pri automatickom prezeraní (stderr) %s --]\n"
 msgid "[-- Error: message/external-body has no access-type parameter --]\n"
 msgstr "[-- Chyba: message/external-body nemá vyplnený parameter access-type --]\n"
 
-#: handler.c:1611
+#. L10N: If the translation of this string is a multi line string, then
+#. each line should start with "[-- " and end with " --]".
+#. The first "%s/%s" is a MIME type, e.g. "text/plain". The last %s
+#. expands to a date as returned by `mutt_date_parse_date()`.
+#.
+#. Note: The size argument printed is not the actual number as passed
+#. to gettext but the prettified version, e.g. size = 2048 will be
+#. printed as 2K.  Your language might be sensitive to that: For
+#. example although '1K' and '1024' represent the same number your
+#. language might inflect the noun 'byte' differently.
+#.
+#. Sadly, we cannot do anything about that at the moment besides
+#. passing the precise size in bytes. If you are interested the
+#. function responsible for the prettification is
+#. mutt_str_pretty_size() in mutt/string.c.
+#.
+#: handler.c:1624
 #, fuzzy, c-format
 msgid ""
+"[-- This %s/%s attachment (size %s byte) has been deleted --]\n"
+"[-- on %s --]\n"
+msgid_plural ""
 "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
 "[-- on %s --]\n"
-msgstr ""
+msgstr[0] ""
+"[-- Príloha %s/%s (veľkosť %s bytov) bola zmazaná --]\n"
+"[-- na %s --]\n"
+msgstr[1] ""
+"[-- Príloha %s/%s (veľkosť %s bytov) bola zmazaná --]\n"
+"[-- na %s --]\n"
+msgstr[2] ""
 "[-- Príloha %s/%s (veľkosť %s bytov) bola zmazaná --]\n"
 "[-- na %s --]\n"
 
@@ -2079,10 +2119,24 @@ msgstr ""
 #. each line should start with "[-- " and end with " --]".
 #. The first "%s/%s" is a MIME type, e.g. "text/plain".
 #.
-#: handler.c:1620
+#. Note: The size argument printed is not the actual number as passed
+#. to gettext but the prettified version, e.g. size = 2048 will be
+#. printed as 2K.  Your language might be sensitive to that: For
+#. example although '1K' and '1024' represent the same number your
+#. language might inflect the noun 'byte' differently.
+#.
+#. Sadly, we cannot do anything about that at the moment besides
+#. passing the precise size in bytes. If you are interested the
+#. function responsible for the prettification is
+#. mutt_str_pretty_size() in mutt/string.c.
+#.
+#: handler.c:1648
 #, fuzzy, c-format
-msgid "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
-msgstr "[-- Príloha %s/%s (veľkosť %s bytov) bola zmazaná --]\n"
+msgid "[-- This %s/%s attachment (size %s byte) has been deleted --]\n"
+msgid_plural "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
+msgstr[0] "[-- Príloha %s/%s (veľkosť %s bytov) bola zmazaná --]\n"
+msgstr[1] "[-- Príloha %s/%s (veľkosť %s bytov) bola zmazaná --]\n"
+msgstr[2] "[-- Príloha %s/%s (veľkosť %s bytov) bola zmazaná --]\n"
 
 #. L10N: If the translation of this string is a multi line string, then
 #. each line should start with "[-- " and end with " --]".
@@ -2092,7 +2146,7 @@ msgstr "[-- Príloha %s/%s (veľkosť %s bytov) bola zmazaná --]\n"
 #. Caution: Argument three %3$ is also defined but should not be used
 #. in this translation!
 #.
-#: handler.c:1637
+#: handler.c:1667
 #, fuzzy
 msgid ""
 "[-- This %s/%s attachment has been deleted --]\n"
@@ -2105,17 +2159,17 @@ msgstr ""
 #. each line should start with "[-- " and end with " --]".
 #. The first "%s/%s" is a MIME type, e.g. "text/plain".
 #.
-#: handler.c:1646
+#: handler.c:1676
 #, fuzzy, c-format
 msgid "[-- This %s/%s attachment has been deleted --]\n"
 msgstr "[-- Príloha %s/%s bola zmazaná --]\n"
 
-#: handler.c:1656
+#: handler.c:1686
 #, fuzzy, c-format
 msgid "[-- name: %s --]\n"
 msgstr "[-- na %s --]\n"
 
-#: handler.c:1672
+#: handler.c:1702
 #, fuzzy, c-format
 msgid ""
 "[-- This %s/%s attachment is not included, --]\n"
@@ -2126,7 +2180,7 @@ msgstr ""
 "[-- a označenému externému zdroju --]\n"
 "[-- vypršala platnosť. --]\n"
 
-#: handler.c:1693
+#: handler.c:1723
 #, fuzzy, c-format
 msgid ""
 "[-- This %s/%s attachment is not included, --]\n"
@@ -2135,52 +2189,52 @@ msgstr ""
 "[-- Príloha %s/%s nie je vložená v správe, --]\n"
 "[-- a označený typ prístupu %s nie je podporovaný --]\n"
 
-#: handler.c:1822
+#: handler.c:1852
 #, fuzzy
 msgid "Unable to open memory stream!"
 msgstr "Nemožno otvoriť dočasný súbor!"
 
-#: handler.c:1831
+#: handler.c:1861
 msgid "Unable to open temporary file!"
 msgstr "Nemožno otvoriť dočasný súbor!"
 
-#: handler.c:1881
+#: handler.c:1911
 #, fuzzy
 msgid "failed to re-open memstream!"
 msgstr "Nemožno otvoriť dočasný súbor!"
 
-#: handler.c:2013
+#: handler.c:2043
 msgid "Error: multipart/signed has no protocol."
 msgstr "Chyba: multipart/signed nemá protokol."
 
-#: handler.c:2076
+#: handler.c:2106
 #, fuzzy
 msgid "[-- This is an attachment (use '%3$s' to view this part) --]\n"
 msgstr "[-- Príloha %s/%s (použite '%3$s' na prezeranie tejto časti) --]\n"
 
-#: handler.c:2082
+#: handler.c:2112
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported (use '%s' to view this part) --]\n"
 msgstr "[-- %s/%s nie je podporovaný (použite '%s' na prezeranie tejto časti) --]\n"
 
-#: handler.c:2087
+#: handler.c:2117
 #, fuzzy
 msgid "[-- This is an attachment (need 'view-attachments' bound to key!) --]\n"
 msgstr "[-- Príloha %s/%s (potrebujem 'view-attachments' priradené na klávesu!) --]\n"
 
 #. L10N: %s/%s is a MIME type, e.g. "text/plain".
-#: handler.c:2091
+#: handler.c:2121
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported (need 'view-attachments' bound to key!) --]\n"
 msgstr "[-- %s/%s nie je podporovaný (potrebujem 'view-attachments' priradené na klávesu!) --]\n"
 
-#: handler.c:2098
+#: handler.c:2128
 #, fuzzy
 msgid "[-- This is an attachment --]\n"
 msgstr "[-- Príloha %s/%s --]\n"
 
 #. L10N: %s/%s is a MIME type, e.g. "text/plain".
-#: handler.c:2101
+#: handler.c:2131
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported --]\n"
 msgstr "[-- %s/%s nie je podporovaný --]\n"
@@ -2497,7 +2551,7 @@ msgstr ""
 msgid "Invalid IMAP flags"
 msgstr "Neplatný mesiac: %s"
 
-#: imap/message.c:477 mx.c:1326
+#: imap/message.c:477 mx.c:1336
 msgid "Integer overflow -- can't allocate memory."
 msgstr ""
 
@@ -3280,24 +3334,36 @@ msgstr ""
 msgid "Reading from %s interrupted..."
 msgstr "Hľadanie bolo prerušené."
 
-#: mx.c:634
-msgid "message(s) not deleted"
-msgstr "správa/y neboli zmazané"
+#. L10N: Although we now the precise number of messages, we do not show it to the user.
+#. So feel free to use a "generic plural" as plural translation if your language has one.
+#.
+#: mx.c:639
+#, fuzzy
+msgid "message not deleted"
+msgid_plural "messages not deleted"
+msgstr[0] "správa/y neboli zmazané"
+msgstr[1] "správa/y neboli zmazané"
+msgstr[2] "správa/y neboli zmazané"
 
-#: mx.c:671
+#: mx.c:676
 msgid "Can't open trash folder"
 msgstr "Nemožno otvoriť zložku Kôš."
 
-#: mx.c:710
+#: mx.c:715
 msgid "Mark all articles read?"
 msgstr "Označiť všetky položky ako prečítané?"
 
-#: mx.c:754
+#. L10N: The first argument is the number of read messages to be
+#. moved, the second argument is the target mailbox.
+#: mx.c:762
 #, fuzzy, c-format
-msgid "Move %d read messages to %s?"
-msgstr "Presunúť prečítané správy do %s?"
+msgid "Move %d read message to %s?"
+msgid_plural "Move %d read messages to %s?"
+msgstr[0] "Presunúť prečítané správy do %s?"
+msgstr[1] "Presunúť prečítané správy do %s?"
+msgstr[2] "Presunúť prečítané správy do %s?"
 
-#: mx.c:771 mx.c:1077
+#: mx.c:781 mx.c:1087
 #, fuzzy, c-format
 msgid "Purge %d deleted message?"
 msgid_plural "Purge %d deleted messages?"
@@ -3305,40 +3371,40 @@ msgstr[0] "Odstrániť %d zmazané správy?"
 msgstr[1] "Odstrániť %d zmazaných správ?"
 msgstr[2] "Odstrániť %d zmazaných správ?"
 
-#: mx.c:793
+#: mx.c:803
 #, c-format
 msgid "Moving read messages to %s..."
 msgstr "Presúvam prečítané správy do %s..."
 
-#: mx.c:859 mx.c:1068
+#: mx.c:869 mx.c:1078
 msgid "Mailbox is unchanged."
 msgstr "Schránka je bez zmeny."
 
-#: mx.c:914
+#: mx.c:924
 #, c-format
 msgid "%d kept, %d moved, %d deleted."
 msgstr "%d ostalo, %d presunutých, %d vymazaných."
 
-#: mx.c:917 mx.c:1130
+#: mx.c:927 mx.c:1140
 #, c-format
 msgid "%d kept, %d deleted."
 msgstr "%d ostalo, %d vymazaných."
 
-#: mx.c:1052
+#: mx.c:1062
 #, c-format
 msgid " Press '%s' to toggle write"
 msgstr " Stlačte '%s' na prepnutie zápisu"
 
-#: mx.c:1054
+#: mx.c:1064
 msgid "Use 'toggle-write' to re-enable write!"
 msgstr "Použite 'prepnúť-zápis' na povolenie zápisu!"
 
-#: mx.c:1056
+#: mx.c:1066
 #, c-format
 msgid "Mailbox is marked unwritable. %s"
 msgstr "Schránka je označená len na čítanie. %s"
 
-#: mx.c:1124
+#: mx.c:1134
 #, fuzzy
 msgid "Mailbox checkpointed."
 msgstr "Bola zistená slučka v makre."
@@ -3353,68 +3419,73 @@ msgstr "(aktuálny čas: %c)"
 msgid "[-- %s output follows%s --]\n"
 msgstr "[-- Nasleduje výstup %s %s --]\n"
 
-#: ncrypt/crypt.c:95
-msgid "Passphrase(s) forgotten."
+#. L10N: Due to the implementation details (e.g. some passwords are managed
+#. by gpg-agent) we cannot know whether we forgot zero, 1, 12, ...
+#. passwords. So in English we use "Passphrases". Your language might
+#. have other means to express this.
+#: ncrypt/crypt.c:100
+#, fuzzy
+msgid "Passphrases forgotten."
 msgstr "Šifrovacie heslo bolo zabudnuté."
 
-#: ncrypt/crypt.c:155
+#: ncrypt/crypt.c:161
 msgid "Inline PGP can't be used with attachments.  Revert to PGP/MIME?"
 msgstr "PGP sa v texte s prílohami nedá použiť. Použiť PGP/MIME?"
 
-#: ncrypt/crypt.c:159
+#: ncrypt/crypt.c:165
 msgid "Mail not sent: inline PGP can't be used with attachments."
 msgstr "Správa nebola odoslaná: PGP sa v texte s prílohami nedá použiť."
 
-#: ncrypt/crypt.c:166
+#: ncrypt/crypt.c:172
 #, fuzzy
 msgid "Inline PGP can't be used with format=flowed.  Revert to PGP/MIME?"
 msgstr "PGP sa v texte s prílohami nedá použiť. Použiť PGP/MIME?"
 
-#: ncrypt/crypt.c:170
+#: ncrypt/crypt.c:176
 #, fuzzy
 msgid "Mail not sent: inline PGP can't be used with format=flowed."
 msgstr "Správa nebola odoslaná: PGP sa v texte s prílohami nedá použiť."
 
-#: ncrypt/crypt.c:180 ncrypt/cryptglue.c:125 ncrypt/pgpkey.c:589
+#: ncrypt/crypt.c:186 ncrypt/cryptglue.c:125 ncrypt/pgpkey.c:589
 #: ncrypt/pgpkey.c:782
 msgid "Invoking PGP..."
 msgstr "Spúšťam PGP..."
 
-#: ncrypt/crypt.c:192
+#: ncrypt/crypt.c:198
 msgid "Message can't be sent inline.  Revert to using PGP/MIME?"
 msgstr "Správa nemožno poslať vloženú do textu. Použiť PGP/MIME?"
 
-#: ncrypt/crypt.c:194 send.c:1824
+#: ncrypt/crypt.c:200 send.c:1824
 msgid "Mail not sent."
 msgstr "Pošta nebola odoslaná."
 
-#: ncrypt/crypt.c:540
+#: ncrypt/crypt.c:546
 msgid "S/MIME messages with no hints on content are unsupported."
 msgstr ""
 
-#: ncrypt/crypt.c:754 ncrypt/crypt.c:795
+#: ncrypt/crypt.c:760 ncrypt/crypt.c:801
 msgid "Trying to extract PGP keys...\n"
 msgstr "Pokúšam sa extrahovať PGP kľúče ...\n"
 
-#: ncrypt/crypt.c:776 ncrypt/crypt.c:816
+#: ncrypt/crypt.c:782 ncrypt/crypt.c:822
 msgid "Trying to extract S/MIME certificates...\n"
 msgstr "Pokúšam sa extrahovať S/MIME certifikáty ...\n"
 
-#: ncrypt/crypt.c:976
+#: ncrypt/crypt.c:982
 #, c-format
 msgid ""
 "[-- Error: Unknown multipart/signed protocol %s! --]\n"
 "\n"
 msgstr "[--Chyba: neznámy multipart/signet protokol %s! --].\n"
 
-#: ncrypt/crypt.c:1016
+#: ncrypt/crypt.c:1022
 #, fuzzy
 msgid ""
 "[-- Error: Missing or bad-format multipart/signed signature! --]\n"
 "\n"
 msgstr "[--Chyba: Nekonzistentná multipart/signet štruktúra! --].\n"
 
-#: ncrypt/crypt.c:1058
+#: ncrypt/crypt.c:1064
 #, c-format
 msgid ""
 "[-- Warning: We can't verify %s/%s signatures. --]\n"
@@ -3423,7 +3494,7 @@ msgstr ""
 "[-- Upozornenie: Nemôžeme overiť %s/%s podpisy. --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1070
+#: ncrypt/crypt.c:1076
 msgid ""
 "[-- The following data is signed --]\n"
 "\n"
@@ -3431,7 +3502,7 @@ msgstr ""
 "[-- Nasledujúce udaje sú podpísané --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1075
+#: ncrypt/crypt.c:1081
 msgid ""
 "[-- Warning: Can't find any signatures. --]\n"
 "\n"
@@ -3439,7 +3510,7 @@ msgstr ""
 "[-- Upozornenie: Nemôžem nájsť žiadne podpisy. --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1081
+#: ncrypt/crypt.c:1087
 msgid ""
 "\n"
 "[-- End of signed data --]\n"
@@ -3490,7 +3561,7 @@ msgstr ""
 msgid "error reading data object: %s\n"
 msgstr "Chyba pri čítaní dátového objektu: %s\n"
 
-#: ncrypt/crypt_gpgme.c:662 ncrypt/crypt_gpgme.c:3848 ncrypt/pgpkey.c:585
+#: ncrypt/crypt_gpgme.c:662 ncrypt/crypt_gpgme.c:3850 ncrypt/pgpkey.c:585
 #: ncrypt/pgpkey.c:768
 msgid "Can't create temporary file"
 msgstr "Nemožno vytvoriť dočasný súbor"
@@ -3848,28 +3919,31 @@ msgstr "[Neplatný]"
 
 #. L10N: This is printed after "Key Type: " and looks like this:
 #. *       PGP, 2048 bit RSA
-#: ncrypt/crypt_gpgme.c:3670 ncrypt/crypt_gpgme.c:3808
+#: ncrypt/crypt_gpgme.c:3670 ncrypt/crypt_gpgme.c:3810
 #, fuzzy, c-format
 msgid "%s, %lu bit %s\n"
-msgstr "Typ kľúča ....: %s, %lu bit %s\n"
+msgid_plural "%s, %lu bit %s\n"
+msgstr[0] "Typ kľúča ....: %s, %lu bit %s\n"
+msgstr[1] "Typ kľúča ....: %s, %lu bit %s\n"
+msgstr[2] "Typ kľúča ....: %s, %lu bit %s\n"
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3678 ncrypt/crypt_gpgme.c:3815
+#: ncrypt/crypt_gpgme.c:3678 ncrypt/crypt_gpgme.c:3817
 msgid "encryption"
 msgstr "Šifrovanie"
 
 #: ncrypt/crypt_gpgme.c:3679 ncrypt/crypt_gpgme.c:3685
-#: ncrypt/crypt_gpgme.c:3816 ncrypt/crypt_gpgme.c:3821
+#: ncrypt/crypt_gpgme.c:3818 ncrypt/crypt_gpgme.c:3823
 msgid ", "
 msgstr ", "
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3684 ncrypt/crypt_gpgme.c:3820
+#: ncrypt/crypt_gpgme.c:3684 ncrypt/crypt_gpgme.c:3822
 msgid "signing"
 msgstr "podpisovanie"
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3690 ncrypt/crypt_gpgme.c:3825
+#: ncrypt/crypt_gpgme.c:3690 ncrypt/crypt_gpgme.c:3827
 msgid "certification"
 msgstr "overovanie"
 
@@ -3888,64 +3962,64 @@ msgstr "[Expirovaný]"
 msgid "[Disabled]"
 msgstr "[Zakázaný]"
 
-#: ncrypt/crypt_gpgme.c:3851
+#: ncrypt/crypt_gpgme.c:3853
 msgid "Collecting data..."
 msgstr "Zbieram údaje ..."
 
-#: ncrypt/crypt_gpgme.c:3876
+#: ncrypt/crypt_gpgme.c:3878
 #, c-format
 msgid "Error finding issuer key: %s\n"
 msgstr "Chyba pri vyhľadávaní kľúča vydavateľa: %s\n"
 
-#: ncrypt/crypt_gpgme.c:3885
+#: ncrypt/crypt_gpgme.c:3887
 msgid "Error: certification chain too long - stopping here\n"
 msgstr "Chyba: overovací reťazec je príliš dlhý - končí tu\n"
 
-#: ncrypt/crypt_gpgme.c:3895 ncrypt/pgpkey.c:608
+#: ncrypt/crypt_gpgme.c:3897 ncrypt/pgpkey.c:608
 #, c-format
 msgid "Key ID: 0x%s"
 msgstr "ID kľúča: 0x%s"
 
-#: ncrypt/crypt_gpgme.c:3990
+#: ncrypt/crypt_gpgme.c:3992
 #, c-format
 msgid "gpgme_new failed: %s"
 msgstr "gpgme_new zlyhalo: %s"
 
-#: ncrypt/crypt_gpgme.c:4028 ncrypt/crypt_gpgme.c:4079
+#: ncrypt/crypt_gpgme.c:4030 ncrypt/crypt_gpgme.c:4081
 #, c-format
 msgid "gpgme_op_keylist_start failed: %s"
 msgstr "gpgme_op_keylist_start zlyhalo: %s"
 
-#: ncrypt/crypt_gpgme.c:4067 ncrypt/crypt_gpgme.c:4109
+#: ncrypt/crypt_gpgme.c:4069 ncrypt/crypt_gpgme.c:4111
 #, c-format
 msgid "gpgme_op_keylist_next failed: %s"
 msgstr "gpgme_op_keylist_next zlyhalo: %s"
 
-#: ncrypt/crypt_gpgme.c:4185
+#: ncrypt/crypt_gpgme.c:4187
 msgid "All matching keys are marked expired/revoked."
 msgstr "Všetky vyhovujúce kľúče sú buď expirované alebo zneplatnené."
 
-#: ncrypt/crypt_gpgme.c:4215 ncrypt/pgpkey.c:543 ncrypt/smime.c:475
+#: ncrypt/crypt_gpgme.c:4217 ncrypt/pgpkey.c:543 ncrypt/smime.c:475
 msgid "Select  "
 msgstr "Označiť  "
 
-#: ncrypt/crypt_gpgme.c:4217 ncrypt/pgpkey.c:545
+#: ncrypt/crypt_gpgme.c:4219 ncrypt/pgpkey.c:545
 msgid "Check key  "
 msgstr "Skontrolovať kľúč  "
 
-#: ncrypt/crypt_gpgme.c:4233
+#: ncrypt/crypt_gpgme.c:4235
 msgid "PGP and S/MIME keys matching"
 msgstr "PGP a S/MIME kľúče sa zhodujú "
 
-#: ncrypt/crypt_gpgme.c:4235
+#: ncrypt/crypt_gpgme.c:4237
 msgid "PGP keys matching"
 msgstr "Kľúče PGP sa zhodujú"
 
-#: ncrypt/crypt_gpgme.c:4237
+#: ncrypt/crypt_gpgme.c:4239
 msgid "S/MIME keys matching"
 msgstr "Kľúče S/MIME sa zhodujú"
 
-#: ncrypt/crypt_gpgme.c:4239
+#: ncrypt/crypt_gpgme.c:4241
 msgid "keys matching"
 msgstr "Kľúče sa zhodujú"
 
@@ -3953,69 +4027,69 @@ msgstr "Kľúče sa zhodujú"
 #. %1$s is one of the previous four entries.
 #. %2$s is an address.
 #. e.g. "S/MIME keys matching <me@mutt.org>."
-#: ncrypt/crypt_gpgme.c:4246
+#: ncrypt/crypt_gpgme.c:4248
 #, c-format
 msgid "%s <%s>."
 msgstr "%s <%s>."
 
 #. L10N:
 #. e.g. 'S/MIME keys matching "Michael Elkins".'
-#: ncrypt/crypt_gpgme.c:4250
+#: ncrypt/crypt_gpgme.c:4252
 #, c-format
 msgid "%s \"%s\"."
 msgstr "%s \"%s\"."
 
-#: ncrypt/crypt_gpgme.c:4277 ncrypt/pgpkey.c:628
+#: ncrypt/crypt_gpgme.c:4279 ncrypt/pgpkey.c:628
 msgid "This key can't be used: expired/disabled/revoked."
 msgstr "Tento kľúč nemôže byť použitý: je expirovaný/zakázaný/odvolaný."
 
-#: ncrypt/crypt_gpgme.c:4290 ncrypt/pgpkey.c:640 ncrypt/smime.c:505
+#: ncrypt/crypt_gpgme.c:4292 ncrypt/pgpkey.c:640 ncrypt/smime.c:505
 #, fuzzy
 msgid "ID is expired/disabled/revoked. Do you really want to use the key?"
 msgstr "ID je expirovaný/zakázaný/odvolaný. Chcete naozaj použiť tento kľúč?"
 
-#: ncrypt/crypt_gpgme.c:4299 ncrypt/pgpkey.c:650
+#: ncrypt/crypt_gpgme.c:4301 ncrypt/pgpkey.c:650
 #, fuzzy
 msgid "ID is not valid. Do you really want to use the key?"
 msgstr "Toto ID nie je dôveryhodné. Chcete naozaj použiť tento kľúč?"
 
-#: ncrypt/crypt_gpgme.c:4302 ncrypt/pgpkey.c:653
+#: ncrypt/crypt_gpgme.c:4304 ncrypt/pgpkey.c:653
 #, fuzzy
 msgid "ID is only marginally valid. Do you really want to use the key?"
 msgstr "Toto ID je dôveryhodné iba nepatrne. Chcete naozaj použiť tento kľúč?"
 
-#: ncrypt/crypt_gpgme.c:4310 ncrypt/pgpkey.c:646 ncrypt/smime.c:509
+#: ncrypt/crypt_gpgme.c:4312 ncrypt/pgpkey.c:646 ncrypt/smime.c:509
 #, fuzzy
 msgid "ID has undefined validity. Do you really want to use the key?"
 msgstr "ID nemá definovanú dôverihodnosť. Chcete naozaj použiť tento kľúč?"
 
-#: ncrypt/crypt_gpgme.c:4370 ncrypt/crypt_gpgme.c:4479 ncrypt/pgpkey.c:872
+#: ncrypt/crypt_gpgme.c:4372 ncrypt/crypt_gpgme.c:4481 ncrypt/pgpkey.c:872
 #: ncrypt/pgpkey.c:995
 #, c-format
 msgid "Looking for keys matching \"%s\"..."
 msgstr "Hľadám kľúče vyhovujúce \"%s\"..."
 
-#: ncrypt/crypt_gpgme.c:4593 ncrypt/pgpkey.c:731 ncrypt/smime.c:811
+#: ncrypt/crypt_gpgme.c:4595 ncrypt/pgpkey.c:731 ncrypt/smime.c:811
 #, c-format
 msgid "No matching keys found for \"%s\""
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4644 ncrypt/pgp.c:1263
+#: ncrypt/crypt_gpgme.c:4646 ncrypt/pgp.c:1263
 #, c-format
 msgid "Use keyID = \"%s\" for %s?"
 msgstr "Použiť ID kľúča = \"%s\" pre %s?"
 
-#: ncrypt/crypt_gpgme.c:4695 ncrypt/pgp.c:1312 ncrypt/smime.c:830
+#: ncrypt/crypt_gpgme.c:4697 ncrypt/pgp.c:1312 ncrypt/smime.c:830
 #: ncrypt/smime.c:938
 #, c-format
 msgid "Enter keyID for %s: "
 msgstr "Zadajte ID kľúča pre %s: "
 
-#: ncrypt/crypt_gpgme.c:4755 ncrypt/pgpkey.c:751
+#: ncrypt/crypt_gpgme.c:4757 ncrypt/pgpkey.c:751
 msgid "Please enter the key ID: "
 msgstr "Prosím zadajte ID kľúča: "
 
-#: ncrypt/crypt_gpgme.c:4768
+#: ncrypt/crypt_gpgme.c:4770
 #, c-format
 msgid "Error exporting key: %s\n"
 msgstr "Chyba pri exporte kľúča: %s\n"
@@ -4024,84 +4098,84 @@ msgstr "Chyba pri exporte kľúča: %s\n"
 #. MIME description for exported (attached) keys.
 #. You can translate this entry to a non-ASCII string (it will be encoded),
 #. but it may be safer to keep it untranslated.
-#: ncrypt/crypt_gpgme.c:4787
+#: ncrypt/crypt_gpgme.c:4789
 #, c-format
 msgid "PGP Key 0x%s."
 msgstr "PGP kľúč 0x%s."
 
-#: ncrypt/crypt_gpgme.c:4830
+#: ncrypt/crypt_gpgme.c:4832
 msgid "GPGME: OpenPGP protocol not available"
 msgstr "GPGME: OpenPGP protokol nie je k dispozícii."
 
-#: ncrypt/crypt_gpgme.c:4838
+#: ncrypt/crypt_gpgme.c:4840
 msgid "GPGME: CMS protocol not available"
 msgstr "GPGME: CMS protokol nie je k dispozícii."
 
-#: ncrypt/crypt_gpgme.c:4876
+#: ncrypt/crypt_gpgme.c:4878
 msgid "S/MIME (s)ign, sign (a)s, (p)gp, (c)lear, or (o)ppenc mode off? "
 msgstr "S/MIME podpí(s)ať, (p)odpísať ako, p(g)p, (v)yčistiť, alebo vypnúť (o)ppenc mód? "
 
 #. L10N: S/MIME options (opportunistic encryption is on)
-#: ncrypt/crypt_gpgme.c:4878
+#: ncrypt/crypt_gpgme.c:4880
 msgid "sapco"
 msgstr "spgvo"
 
-#: ncrypt/crypt_gpgme.c:4885
+#: ncrypt/crypt_gpgme.c:4887
 msgid "PGP (s)ign, sign (a)s, s/(m)ime, (c)lear, or (o)ppenc mode off? "
 msgstr "PGP podpí(s)ať, (p)odpísať ako, s/(m)ime, (v)yčistiť, alebo vypnúť (o)ppenc mód? "
 
 #. L10N: PGP options (opportunistic encryption is on)
-#: ncrypt/crypt_gpgme.c:4887
+#: ncrypt/crypt_gpgme.c:4889
 msgid "samco"
 msgstr "spmvo"
 
 #. L10N: S/MIME options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4900
+#: ncrypt/crypt_gpgme.c:4902
 msgid "S/MIME (e)ncrypt, (s)ign, sign (a)s, (b)oth, (p)gp, (c)lear, or (o)ppenc mode? "
 msgstr "S/MIME šif(r)ovať, podpí(s)ať, (p)odpísať ako, o(b)e, p(g)p, (v)yčistiť, alebo vypnúť (o)ppenc mód? "
 
 #. L10N: S/MIME options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4903
+#: ncrypt/crypt_gpgme.c:4905
 #, fuzzy
 msgid "esabpco"
 msgstr "rspbgvo"
 
 #. L10N: PGP options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4909
+#: ncrypt/crypt_gpgme.c:4911
 msgid "PGP (e)ncrypt, (s)ign, sign (a)s, (b)oth, s/(m)ime, (c)lear, or (o)ppenc mode? "
 msgstr "PGP šif(r)ovať, podpí(s)ať, (p)odpísať ako, o(b)e, s/(m)ime, (v)yčistiť, alebo vypnúť (o)ppenc mód? "
 
 #. L10N: PGP options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4912
+#: ncrypt/crypt_gpgme.c:4914
 #, fuzzy
 msgid "esabmco"
 msgstr "rspbmvo"
 
-#: ncrypt/crypt_gpgme.c:4925
+#: ncrypt/crypt_gpgme.c:4927
 msgid "S/MIME (e)ncrypt, (s)ign, sign (a)s, (b)oth, (p)gp or (c)lear? "
 msgstr "S/MIME šif(r)ovať, podpí(s)ať, (p)odpísať ako, o(b)e, p(g)p, (v)yčistiť? "
 
 #. L10N: S/MIME options
-#: ncrypt/crypt_gpgme.c:4927
+#: ncrypt/crypt_gpgme.c:4929
 #, fuzzy
 msgid "esabpc"
 msgstr "rspbgv"
 
-#: ncrypt/crypt_gpgme.c:4934
+#: ncrypt/crypt_gpgme.c:4936
 msgid "PGP (e)ncrypt, (s)ign, sign (a)s, (b)oth, s/(m)ime or (c)lear? "
 msgstr "PGP šif(r)ovať, podpí(s)ať, (p)odpísať ako, o(b)e, s/(m)ime, alebo (v)yčistiť? "
 
 #. L10N: PGP options
-#: ncrypt/crypt_gpgme.c:4936
+#: ncrypt/crypt_gpgme.c:4938
 #, fuzzy
 msgid "esabmc"
 msgstr "rspbmv"
 
-#: ncrypt/crypt_gpgme.c:5087
+#: ncrypt/crypt_gpgme.c:5089
 msgid "Failed to verify sender"
 msgstr "Nepodarilo sa overiť odosielateľa."
 
-#: ncrypt/crypt_gpgme.c:5090
+#: ncrypt/crypt_gpgme.c:5092
 msgid "Failed to figure out sender"
 msgstr "Nepodarilo sa zistiť odosielateľa."
 
@@ -4525,7 +4599,7 @@ msgstr "Meno používateľa POP nie je definované."
 msgid "%s is an invalid news server specification!"
 msgstr ""
 
-#: nntp.c:75 nntp.c:612 pop.c:1028 pop_lib.c:405
+#: nntp.c:75 nntp.c:612 pop.c:1031 pop_lib.c:405
 msgid "Server closed connection!"
 msgstr "Server uzavrel spojenie!"
 
@@ -4695,16 +4769,17 @@ msgstr "skontroluj nové správy v schránkach"
 
 #: opcodes.h:47
 #, fuzzy
-msgid "attach file(s) to this message"
+msgid "attach files to this message"
 msgstr "priložiť súbor(y) k tejto správe"
 
 #: opcodes.h:48
-msgid "attach message(s) to this message"
+#, fuzzy
+msgid "attach messages to this message"
 msgstr "priložiť správu/y k tejto správe"
 
 #: opcodes.h:49
 #, fuzzy
-msgid "attach news article(s) to this message"
+msgid "attach news articles to this message"
 msgstr "priložiť súbor(y) k tejto správe"
 
 #: opcodes.h:50
@@ -5553,7 +5628,8 @@ msgid "extract supported public keys"
 msgstr "extrahuj podporované verejné kľúče PGP"
 
 #: opcodes.h:255
-msgid "wipe passphrase(s) from memory"
+#, fuzzy
+msgid "wipe passphrases from memory"
 msgstr "vymaž frázu hesla PGP z pamäte"
 
 #: opcodes.h:259
@@ -5911,18 +5987,21 @@ msgstr "Žiadna nová pošta v schránke POP."
 msgid "Delete messages from server?"
 msgstr "Vymazávam správy zo serveru..."
 
-#: pop.c:954
+#: pop.c:955
 #, fuzzy, c-format
-msgid "Reading new messages (%d bytes)..."
-msgstr "Čítam %d nových správ (%d bytov)..."
+msgid "Reading new messages (%d byte)..."
+msgid_plural "Reading new messages (%d bytes)..."
+msgstr[0] "Čítam %d nových správ (%d bytov)..."
+msgstr[1] "Čítam %d nových správ (%d bytov)..."
+msgstr[2] "Čítam %d nových správ (%d bytov)..."
 
-#: pop.c:997
+#: pop.c:1000
 msgid "Error while writing mailbox!"
 msgstr "Chyba pri zapisovaní do schránky!"
 
 #. L10N: The plural is picked by the second numerical argument, i.e.
 #. * the %d right before 'messages', i.e. the total number of messages.
-#: pop.c:1003
+#: pop.c:1006
 #, fuzzy, c-format
 msgid "%s [%d of %d message read]"
 msgid_plural "%s [%d of %d messages read]"
@@ -6076,53 +6155,61 @@ msgstr "Presmerovať do: "
 msgid "I don't know how to print %s attachments!"
 msgstr "Neviem ako tlačiť prílohy %s!"
 
-#: recvattach.c:841
-msgid "Print tagged attachment(s)?"
-msgstr "Vytlačiť označené prílohy?"
+#. L10N: Although we now the precise number of tagged messages, we
+#. do not show it to the user.  So feel free to use a "generic
+#. plural" as plural translation if your language has one.
+#: recvattach.c:852
+#, fuzzy, c-format
+msgid "Print tagged attachment?"
+msgid_plural "Print %d tagged attachments?"
+msgstr[0] "Vytlačiť označené prílohy?"
+msgstr[1] "Vytlačiť označené prílohy?"
+msgstr[2] "Vytlačiť označené prílohy?"
 
-#: recvattach.c:842
+#: recvattach.c:853
+#, c-format
 msgid "Print attachment?"
 msgstr "Vytlačiť prílohu?"
 
-#: recvattach.c:900
+#: recvattach.c:913
 msgid "Structural changes to decrypted attachments are not supported"
 msgstr ""
 
-#: recvattach.c:1046
+#: recvattach.c:1059
 #, fuzzy
 msgid "Can't decrypt encrypted message!"
 msgstr "použiť ďaľšiu funkciu na označené správy"
 
-#: recvattach.c:1172
+#: recvattach.c:1185
 msgid "Attachments"
 msgstr "Prílohy"
 
-#: recvattach.c:1210
+#: recvattach.c:1223
 #, fuzzy
 msgid "There are no subparts to show!"
 msgstr "Vlákno obsahuje nečítané správy."
 
-#: recvattach.c:1265
+#: recvattach.c:1278
 #, fuzzy
 msgid "Can't delete attachment from POP server."
 msgstr "vybrať poštu z POP serveru"
 
-#: recvattach.c:1274
+#: recvattach.c:1287
 #, fuzzy
 msgid "Can't delete attachment from news server."
 msgstr "vybrať poštu z POP serveru"
 
-#: recvattach.c:1281
+#: recvattach.c:1294
 #, fuzzy
 msgid "Deletion of attachments from encrypted messages is unsupported."
 msgstr "Mazanie príloh z PGP správ nie je podporované."
 
-#: recvattach.c:1287
+#: recvattach.c:1300
 #, fuzzy
 msgid "Deletion of attachments from signed messages may invalidate the signature."
 msgstr "Mazanie príloh z PGP správ nie je podporované."
 
-#: recvattach.c:1305 recvattach.c:1320
+#: recvattach.c:1318 recvattach.c:1333
 msgid "Only deletion of multipart attachments is supported."
 msgstr "je podporované iba mazanie viaczložkových príloh."
 
@@ -6555,3 +6642,13 @@ msgstr "Nastavenia kompilácie:"
 #: version.c:404
 msgid "Compile options:"
 msgstr "Nastavenia kompilácie:"
+
+#~ msgid "Cannot delete message(s)"
+#~ msgstr "Nemožno vymazať správu/y."
+
+#~ msgid "Cannot undelete message(s)"
+#~ msgstr "Nemožno odmazať správu/y."
+
+#, fuzzy
+#~ msgid "messages not deleted"
+#~ msgstr "správa/y neboli zmazané"

--- a/po/sv.po
+++ b/po/sv.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neomutt-20180512\n"
 "Report-Msgid-Bugs-To: neomutt-devel@neomutt.org\n"
-"POT-Creation-Date: 2018-05-20 02:02+0000\n"
+"POT-Creation-Date: 2018-05-22 14:18+0000\n"
 "PO-Revision-Date: 2007-12-15 14:05+0100\n"
 "Last-Translator: Johan Svedberg <johan@svedberg.com>\n"
 "Language-Team: Swedish <sv@li.org>\n"
@@ -38,7 +38,7 @@ msgstr "Välj"
 
 #: addrbook.c:52 browser.c:75 browser.c:87 compose.c:160 compose.c:172
 #: conn/ssl.c:1041 conn/ssl_gnutls.c:793 curs_main.c:748 curs_main.c:761
-#: history.c:106 ncrypt/crypt_gpgme.c:4219 ncrypt/pgpkey.c:547
+#: history.c:106 ncrypt/crypt_gpgme.c:4221 ncrypt/pgpkey.c:547
 #: ncrypt/smime.c:477 pager.c:2141 postpone.c:65 query.c:72 recvattach.c:70
 msgid "Help"
 msgstr "Hjälp"
@@ -690,7 +690,7 @@ msgstr ""
 #. * Since it shares the row with "Encrypt with:", it should not be longer
 #. * than 15-20 character cells.
 #.
-#: compose.c:138 ncrypt/crypt_gpgme.c:4947 ncrypt/pgp.c:1786
+#: compose.c:138 ncrypt/crypt_gpgme.c:4949 ncrypt/pgp.c:1786
 #: ncrypt/smime.c:2127
 msgid "Sign as: "
 msgstr "Signera som: "
@@ -1237,7 +1237,7 @@ msgstr "(f)örkasta, (g)odkänn den här gången"
 msgid "(r)eject, accept (o)nce"
 msgstr "(f)örkasta, (g)odkänn den här gången"
 
-#: conn/ssl.c:1039 conn/ssl_gnutls.c:791 ncrypt/crypt_gpgme.c:4213
+#: conn/ssl.c:1039 conn/ssl_gnutls.c:791 ncrypt/crypt_gpgme.c:4215
 #: ncrypt/pgpkey.c:541 ncrypt/smime.c:473
 msgid "Exit  "
 msgstr "Avsluta "
@@ -1417,11 +1417,11 @@ msgstr "Ingen brevlåda är öppen."
 msgid "There are no messages."
 msgstr "Inga meddelanden."
 
-#: curs_main.c:77 mx.c:1061 pager.c:73 recvattach.c:56
+#: curs_main.c:77 mx.c:1071 pager.c:73 recvattach.c:56
 msgid "Mailbox is read-only."
 msgstr "Brevlådan är skrivskyddad."
 
-#: curs_main.c:79 pager.c:75 recvattach.c:1145
+#: curs_main.c:79 pager.c:75 recvattach.c:1158
 msgid "Function not permitted in attach-message mode."
 msgstr "Funktionen ej tillåten i \"bifoga-meddelande\"-läge."
 
@@ -1555,255 +1555,263 @@ msgid "That message is not visible."
 msgstr "Det meddelandet är inte synligt."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:1377 curs_main.c:2772 pager.c:2818
+#. L10N: Due to the implementation details we do not know whether we
+#. delete zero, 1, 12, ... messages. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:1381 curs_main.c:2784 pager.c:2822
 #, fuzzy
-msgid "Cannot delete message(s)"
+msgid "Cannot delete messages"
 msgstr "återställ meddelande(n)"
 
-#: curs_main.c:1380
+#: curs_main.c:1384
 msgid "Delete messages matching: "
 msgstr "Radera meddelanden som matchar: "
 
-#: curs_main.c:1421
+#: curs_main.c:1425
 msgid "No limit pattern is in effect."
 msgstr "Inget avgränsande mönster är aktivt."
 
 #. L10N: ask for a limit to apply
-#: curs_main.c:1426
+#: curs_main.c:1430
 #, c-format
 msgid "Limit: %s"
 msgstr "Gräns: %s"
 
-#: curs_main.c:1464
+#: curs_main.c:1468
 msgid "Limit to messages matching: "
 msgstr "Visa endast meddelanden som matchar: "
 
-#: curs_main.c:1488
+#: curs_main.c:1492
 msgid "To view all messages, limit to \"all\"."
 msgstr "För att visa alla meddelanden, begränsa till \"all\"."
 
-#: curs_main.c:1500 pager.c:2318
+#: curs_main.c:1504 pager.c:2318
 msgid "Quit NeoMutt?"
 msgstr "Avsluta NeoMutt?"
 
-#: curs_main.c:1596
+#: curs_main.c:1600
 msgid "Tag messages matching: "
 msgstr "Märk meddelanden som matchar: "
 
 #. L10N: CHECK_ACL
-#: curs_main.c:1606 curs_main.c:3203 pager.c:3137
+#. L10N: Due to the implementation details we do not know whether we
+#. undelete zero, 1, 12, ... messages. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:1614 curs_main.c:3223 pager.c:3145
 #, fuzzy
-msgid "Cannot undelete message(s)"
+msgid "Cannot undelete messages"
 msgstr "återställ meddelande(n)"
 
-#: curs_main.c:1609
+#: curs_main.c:1617
 msgid "Undelete messages matching: "
 msgstr "Återställ meddelanden som matchar: "
 
-#: curs_main.c:1619
+#: curs_main.c:1627
 msgid "Untag messages matching: "
 msgstr "Avmarkera meddelanden som matchar: "
 
-#: curs_main.c:1653
+#: curs_main.c:1661
 msgid "Logged out of IMAP servers."
 msgstr ""
 
-#: curs_main.c:1753
+#: curs_main.c:1761
 #, fuzzy
 msgid "No virtual folder, aborting."
 msgstr "Inget ämne, avbryter."
 
-#: curs_main.c:1761
+#: curs_main.c:1769
 msgid "Failed to read thread, aborting."
 msgstr ""
 
-#: curs_main.c:1793 mx.c:1458 mx.c:1475
+#: curs_main.c:1801 mx.c:1468 mx.c:1485
 #, fuzzy
 msgid "Folder doesn't support tagging, aborting."
 msgstr "SMTP-server stöder inte autentisering"
 
-#: curs_main.c:1808
+#: curs_main.c:1816
 #, fuzzy
 msgid "No tag specified, aborting."
 msgstr "Inget ämne, avbryter."
 
-#: curs_main.c:1820
+#: curs_main.c:1828
 #, c-format
 msgid "Update tags..."
 msgstr ""
 
-#: curs_main.c:1857
+#: curs_main.c:1865
 msgid "Failed to modify tags, aborting."
 msgstr ""
 
-#: curs_main.c:1898
+#: curs_main.c:1906
 #, fuzzy
 msgid "No query, aborting."
 msgstr "Inget ämne, avbryter."
 
-#: curs_main.c:1902 curs_main.c:1922 curs_main.c:1941
+#: curs_main.c:1910 curs_main.c:1930 curs_main.c:1949
 msgid "Failed to create query, aborting."
 msgstr ""
 
-#: curs_main.c:1911 curs_main.c:1930
+#: curs_main.c:1919 curs_main.c:1938
 msgid "Windowed queries disabled."
 msgstr ""
 
-#: curs_main.c:1916 curs_main.c:1935
+#: curs_main.c:1924 curs_main.c:1943
 msgid "No notmuch vfolder currently loaded."
 msgstr ""
 
-#: curs_main.c:1973
+#: curs_main.c:1981
 msgid "Open mailbox in read-only mode"
 msgstr "Öppna brevlåda i skrivskyddat läge"
 
-#: curs_main.c:1976
+#: curs_main.c:1984
 #, fuzzy
 msgid "Open virtual folder"
 msgstr "öppna en annan folder"
 
-#: curs_main.c:1979
+#: curs_main.c:1987
 msgid "Open mailbox"
 msgstr "Öppna brevlåda"
 
-#: curs_main.c:1989
+#: curs_main.c:1997
 msgid "No mailboxes have new mail"
 msgstr "Inga brevlådor har nya brev."
 
-#: curs_main.c:2036
+#: curs_main.c:2044
 #, fuzzy
 msgid "Open newsgroup in read-only mode"
 msgstr "Öppna brevlåda i skrivskyddat läge"
 
-#: curs_main.c:2038
+#: curs_main.c:2046
 msgid "Open newsgroup"
 msgstr ""
 
-#: curs_main.c:2141
+#: curs_main.c:2149
 #, fuzzy
 msgid "Exit NeoMutt without saving?"
 msgstr "Avsluta NeoMutt utan att spara?"
 
-#: curs_main.c:2157
+#: curs_main.c:2165
 #, fuzzy
 msgid "Cannot break thread"
 msgstr "länka trådar"
 
-#: curs_main.c:2160 curs_main.c:2198 curs_main.c:2658 curs_main.c:2690
+#: curs_main.c:2168 curs_main.c:2206 curs_main.c:2666 curs_main.c:2698
 #: flags.c:376 thread.c:1078 thread.c:1134 thread.c:1202
 msgid "Threading is not enabled."
 msgstr "Trådning ej aktiverat."
 
-#: curs_main.c:2173
+#: curs_main.c:2181
 msgid "Thread broken"
 msgstr "Tråd bruten"
 
-#: curs_main.c:2185
+#: curs_main.c:2193
 msgid "Thread cannot be broken, message is not part of a thread"
 msgstr ""
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2195
+#: curs_main.c:2203
 #, fuzzy
 msgid "Cannot link threads"
 msgstr "länka trådar"
 
-#: curs_main.c:2200
+#: curs_main.c:2208
 msgid "No Message-ID: header available to link thread"
 msgstr "Inget Message-ID: huvud tillgängligt för att länka tråd"
 
-#: curs_main.c:2202
+#: curs_main.c:2210
 msgid "First, please tag a message to be linked here"
 msgstr "Var vänlig att först markera ett meddelande som ska länkas här"
 
-#: curs_main.c:2213
+#: curs_main.c:2221
 msgid "Threads linked"
 msgstr "Trådar länkade"
 
-#: curs_main.c:2216
+#: curs_main.c:2224
 msgid "No thread linked"
 msgstr "Ingen tråd länkad"
 
-#: curs_main.c:2252 curs_main.c:2278
+#: curs_main.c:2260 curs_main.c:2286
 msgid "You are on the last message."
 msgstr "Du är på det sista meddelandet."
 
-#: curs_main.c:2260 curs_main.c:2305
+#: curs_main.c:2268 curs_main.c:2313
 msgid "No undeleted messages."
 msgstr "Inga återställda meddelanden."
 
-#: curs_main.c:2297 curs_main.c:2323
+#: curs_main.c:2305 curs_main.c:2331
 msgid "You are on the first message."
 msgstr "Du är på det första meddelandet."
 
-#: curs_main.c:2395 menu.c:970 pager.c:2440 pattern.c:2110
+#: curs_main.c:2403 menu.c:970 pager.c:2440 pattern.c:2110
 msgid "Search wrapped to top."
 msgstr "Sökning fortsatte från början."
 
-#: curs_main.c:2404 pager.c:2463 pattern.c:2121
+#: curs_main.c:2412 pager.c:2463 pattern.c:2121
 msgid "Search wrapped to bottom."
 msgstr "Sökning fortsatte från slutet."
 
-#: curs_main.c:2447
+#: curs_main.c:2455
 #, fuzzy
 msgid "No new messages in this limited view."
 msgstr "Första meddelandet är inte synligt i den här begränsade vyn"
 
-#: curs_main.c:2449
+#: curs_main.c:2457
 #, fuzzy
 msgid "No new messages."
 msgstr "Inga nya meddelanden"
 
-#: curs_main.c:2454
+#: curs_main.c:2462
 #, fuzzy
 msgid "No unread messages in this limited view."
 msgstr "Första meddelandet är inte synligt i den här begränsade vyn"
 
-#: curs_main.c:2456
+#: curs_main.c:2464
 #, fuzzy
 msgid "No unread messages."
 msgstr "Inga olästa meddelanden"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2474
+#: curs_main.c:2482
 #, fuzzy
 msgid "Cannot flag message"
 msgstr "flagga meddelande"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2513 pager.c:3100
+#: curs_main.c:2521 pager.c:3104
 #, fuzzy
 msgid "Cannot toggle new"
 msgstr "växla ny"
 
-#: curs_main.c:2590
+#: curs_main.c:2598
 msgid "No more threads."
 msgstr "Inga fler trådar."
 
-#: curs_main.c:2592
+#: curs_main.c:2600
 msgid "You are on the first thread."
 msgstr "Du är på den första tråden."
 
-#: curs_main.c:2676
+#: curs_main.c:2684
 #, fuzzy
 msgid "Thread contains unread or flagged messages."
 msgstr "Tråden innehåller olästa meddelanden."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2726 pager.c:2784
+#: curs_main.c:2734 pager.c:2784
 #, fuzzy
 msgid "Cannot delete message"
 msgstr "återställ meddelande(n)"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2838
+#: curs_main.c:2850
 #, fuzzy
 msgid "Cannot edit message"
 msgstr "Kan inte skriva meddelande"
 
 #. L10N: This is displayed when the x-label on one or more
 #. * messages is edited.
-#: curs_main.c:2900 pager.c:3200
+#: curs_main.c:2912 pager.c:3208
 #, fuzzy, c-format
 msgid "%d label changed."
 msgid_plural "%d labels changed."
@@ -1813,28 +1821,32 @@ msgstr[1] "Brevlåda är oförändrad."
 #. L10N: This is displayed when editing an x-label, but no messages
 #. * were updated.  Possibly due to canceling at the prompt or if the new
 #. * label is the same as the old label.
-#: curs_main.c:2907 pager.c:3204
+#: curs_main.c:2919 pager.c:3212
 #, fuzzy
 msgid "No labels changed."
 msgstr "Brevlåda är oförändrad."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:3006
+#. L10N: Due to the implementation details we do not know whether we
+#. mark zero, 1, 12, ... messages as read. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:3022
 #, fuzzy
-msgid "Cannot mark message(s) as read"
+msgid "Cannot mark messages as read"
 msgstr "markera meddelande(n) som lästa"
 
 #. L10N: This is the prompt for <mark-message>.  Whatever they
 #. enter will be prefixed by $mark_macro_prefix and will become
 #. a macro hotkey to jump to the currently selected message.
-#: curs_main.c:3042
+#: curs_main.c:3058
 #, fuzzy
 msgid "Enter macro stroke: "
 msgstr "Ange nyckel-ID: "
 
 #. L10N: "message hotkey" is the key bindings menu description of a
 #. macro created by <mark-message>.
-#: curs_main.c:3050
+#: curs_main.c:3066
 #, fuzzy
 msgid "message hotkey"
 msgstr "Meddelande uppskjutet."
@@ -1842,28 +1854,28 @@ msgstr "Meddelande uppskjutet."
 #. L10N: This is echoed after <mark-message> creates a new hotkey
 #. macro.  %s is the hotkey string ($mark_macro_prefix followed
 #. by whatever they typed at the prompt.)
-#: curs_main.c:3055
+#: curs_main.c:3071
 #, fuzzy, c-format
 msgid "Message bound to %s."
 msgstr "Meddelande återsänt."
 
 #. L10N: This error is printed if <mark-message> cannot find a
 #. Message-ID for the currently selected message in the index.
-#: curs_main.c:3063
+#: curs_main.c:3079
 #, fuzzy
 msgid "No message ID to macro."
 msgstr "Inga meddelanden i den foldern."
 
-#: curs_main.c:3105 pager.c:2961 recvattach.c:1388
+#: curs_main.c:3121 pager.c:2965 recvattach.c:1401
 msgid "Reply by mail as poster prefers?"
 msgstr ""
 
-#: curs_main.c:3108 pager.c:2927 pager.c:2939 pager.c:2964
+#: curs_main.c:3124 pager.c:2931 pager.c:2943 pager.c:2968
 msgid "Posting to this group not allowed, may be moderated. Continue?"
 msgstr ""
 
 #. L10N: CHECK_ACL
-#: curs_main.c:3173 pager.c:3120
+#: curs_main.c:3189 pager.c:3124
 #, fuzzy
 msgid "Cannot undelete message"
 msgstr "återställ meddelande(n)"
@@ -2057,12 +2069,34 @@ msgstr "[-- Automatisk visning av standardfel gällande %s --]\n"
 msgid "[-- Error: message/external-body has no access-type parameter --]\n"
 msgstr "[-- Fel: \"message/external-body\" har ingen åtkomsttypsparameter --]\n"
 
-#: handler.c:1611
+#. L10N: If the translation of this string is a multi line string, then
+#. each line should start with "[-- " and end with " --]".
+#. The first "%s/%s" is a MIME type, e.g. "text/plain". The last %s
+#. expands to a date as returned by `mutt_date_parse_date()`.
+#.
+#. Note: The size argument printed is not the actual number as passed
+#. to gettext but the prettified version, e.g. size = 2048 will be
+#. printed as 2K.  Your language might be sensitive to that: For
+#. example although '1K' and '1024' represent the same number your
+#. language might inflect the noun 'byte' differently.
+#.
+#. Sadly, we cannot do anything about that at the moment besides
+#. passing the precise size in bytes. If you are interested the
+#. function responsible for the prettification is
+#. mutt_str_pretty_size() in mutt/string.c.
+#.
+#: handler.c:1624
 #, fuzzy, c-format
 msgid ""
+"[-- This %s/%s attachment (size %s byte) has been deleted --]\n"
+"[-- on %s --]\n"
+msgid_plural ""
 "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
 "[-- on %s --]\n"
-msgstr ""
+msgstr[0] ""
+"[-- Den här %s/%s bilagan (storlek %s byte)har raderats --]\n"
+"[-- på %s --]\n"
+msgstr[1] ""
 "[-- Den här %s/%s bilagan (storlek %s byte)har raderats --]\n"
 "[-- på %s --]\n"
 
@@ -2070,10 +2104,23 @@ msgstr ""
 #. each line should start with "[-- " and end with " --]".
 #. The first "%s/%s" is a MIME type, e.g. "text/plain".
 #.
-#: handler.c:1620
+#. Note: The size argument printed is not the actual number as passed
+#. to gettext but the prettified version, e.g. size = 2048 will be
+#. printed as 2K.  Your language might be sensitive to that: For
+#. example although '1K' and '1024' represent the same number your
+#. language might inflect the noun 'byte' differently.
+#.
+#. Sadly, we cannot do anything about that at the moment besides
+#. passing the precise size in bytes. If you are interested the
+#. function responsible for the prettification is
+#. mutt_str_pretty_size() in mutt/string.c.
+#.
+#: handler.c:1648
 #, fuzzy, c-format
-msgid "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
-msgstr "[-- Den här %s/%s bilagan (storlek %s byte)har raderats --]\n"
+msgid "[-- This %s/%s attachment (size %s byte) has been deleted --]\n"
+msgid_plural "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
+msgstr[0] "[-- Den här %s/%s bilagan (storlek %s byte)har raderats --]\n"
+msgstr[1] "[-- Den här %s/%s bilagan (storlek %s byte)har raderats --]\n"
 
 #. L10N: If the translation of this string is a multi line string, then
 #. each line should start with "[-- " and end with " --]".
@@ -2083,7 +2130,7 @@ msgstr "[-- Den här %s/%s bilagan (storlek %s byte)har raderats --]\n"
 #. Caution: Argument three %3$ is also defined but should not be used
 #. in this translation!
 #.
-#: handler.c:1637
+#: handler.c:1667
 #, fuzzy
 msgid ""
 "[-- This %s/%s attachment has been deleted --]\n"
@@ -2096,17 +2143,17 @@ msgstr ""
 #. each line should start with "[-- " and end with " --]".
 #. The first "%s/%s" is a MIME type, e.g. "text/plain".
 #.
-#: handler.c:1646
+#: handler.c:1676
 #, fuzzy, c-format
 msgid "[-- This %s/%s attachment has been deleted --]\n"
 msgstr "[-- Den här %s/%s bilagan har raderats --]\n"
 
-#: handler.c:1656
+#: handler.c:1686
 #, c-format
 msgid "[-- name: %s --]\n"
 msgstr "[-- namn: %s --]\n"
 
-#: handler.c:1672
+#: handler.c:1702
 #, fuzzy, c-format
 msgid ""
 "[-- This %s/%s attachment is not included, --]\n"
@@ -2117,7 +2164,7 @@ msgstr ""
 "[-- och den angivna externa källan har --]\n"
 "[-- utgått. --]\n"
 
-#: handler.c:1693
+#: handler.c:1723
 #, fuzzy, c-format
 msgid ""
 "[-- This %s/%s attachment is not included, --]\n"
@@ -2126,52 +2173,52 @@ msgstr ""
 "[-- Den här %s/%s bilagan är inte inkluderad, --]\n"
 "[-- och den angivna åtkomsttypen %s stöds inte --]\n"
 
-#: handler.c:1822
+#: handler.c:1852
 #, fuzzy
 msgid "Unable to open memory stream!"
 msgstr "Kunde inte öppna tillfällig fil!"
 
-#: handler.c:1831
+#: handler.c:1861
 msgid "Unable to open temporary file!"
 msgstr "Kunde inte öppna tillfällig fil!"
 
-#: handler.c:1881
+#: handler.c:1911
 #, fuzzy
 msgid "failed to re-open memstream!"
 msgstr "Kunde inte öppna tillfällig fil!"
 
-#: handler.c:2013
+#: handler.c:2043
 msgid "Error: multipart/signed has no protocol."
 msgstr "Fel: \"multipart/signed\" har inget protokoll."
 
-#: handler.c:2076
+#: handler.c:2106
 #, fuzzy
 msgid "[-- This is an attachment (use '%3$s' to view this part) --]\n"
 msgstr "[-- Den här %s/%s bilagan (använd \"%3$s\" för att visa den här delen) --]\n"
 
-#: handler.c:2082
+#: handler.c:2112
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported (use '%s' to view this part) --]\n"
 msgstr "[-- %s/%s stöds inte (använd \"%s\" för att visa den här delen) --]\n"
 
-#: handler.c:2087
+#: handler.c:2117
 #, fuzzy
 msgid "[-- This is an attachment (need 'view-attachments' bound to key!) --]\n"
 msgstr "[-- Den här %s/%s bilagan (\"view-attachments\" måste knytas till tangent!) --]\n"
 
 #. L10N: %s/%s is a MIME type, e.g. "text/plain".
-#: handler.c:2091
+#: handler.c:2121
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported (need 'view-attachments' bound to key!) --]\n"
 msgstr "[-- %s/%s stöds inte (\"view-attachments\" måste knytas till tangent!) --]\n"
 
-#: handler.c:2098
+#: handler.c:2128
 #, fuzzy
 msgid "[-- This is an attachment --]\n"
 msgstr "[-- Den här %s/%s bilagan --]\n"
 
 #. L10N: %s/%s is a MIME type, e.g. "text/plain".
-#: handler.c:2101
+#: handler.c:2131
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported --]\n"
 msgstr "[-- %s/%s stöds inte --]\n"
@@ -2478,7 +2525,7 @@ msgstr "SMTP-server stöder inte autentisering"
 msgid "Invalid IMAP flags"
 msgstr "Ogiltig   "
 
-#: imap/message.c:477 mx.c:1326
+#: imap/message.c:477 mx.c:1336
 msgid "Integer overflow -- can't allocate memory."
 msgstr "Heltalsöverflödning -- kan inte allokera minne."
 
@@ -3244,66 +3291,75 @@ msgstr "SSL är otillgängligt."
 msgid "Reading from %s interrupted..."
 msgstr "Sökning avbruten."
 
-#: mx.c:634
+#. L10N: Although we now the precise number of messages, we do not show it to the user.
+#. So feel free to use a "generic plural" as plural translation if your language has one.
+#.
+#: mx.c:639
 #, fuzzy
-msgid "message(s) not deleted"
-msgstr "Markerar raderade meddelanden..."
+msgid "message not deleted"
+msgid_plural "messages not deleted"
+msgstr[0] "Markerar raderade meddelanden..."
+msgstr[1] "Markerar raderade meddelanden..."
 
-#: mx.c:671
+#: mx.c:676
 #, fuzzy
 msgid "Can't open trash folder"
 msgstr "Kan inte lägga till folder: %s"
 
-#: mx.c:710
+#: mx.c:715
 msgid "Mark all articles read?"
 msgstr ""
 
-#: mx.c:754
+#. L10N: The first argument is the number of read messages to be
+#. moved, the second argument is the target mailbox.
+#: mx.c:762
 #, fuzzy, c-format
-msgid "Move %d read messages to %s?"
-msgstr "Flytta lästa meddelanden till %s?"
+msgid "Move %d read message to %s?"
+msgid_plural "Move %d read messages to %s?"
+msgstr[0] "Flytta lästa meddelanden till %s?"
+msgstr[1] "Flytta lästa meddelanden till %s?"
 
-#: mx.c:771 mx.c:1077
+#: mx.c:781 mx.c:1087
 #, fuzzy, c-format
 msgid "Purge %d deleted message?"
 msgid_plural "Purge %d deleted messages?"
 msgstr[0] "Rensa %d raderat meddelande?"
 msgstr[1] "Rensa %d raderade meddelanden?"
 
-#: mx.c:793
+#: mx.c:803
 #, c-format
 msgid "Moving read messages to %s..."
 msgstr "Flyttar lästa meddelanden till %s..."
 
-#: mx.c:859 mx.c:1068
+#: mx.c:869 mx.c:1078
 msgid "Mailbox is unchanged."
 msgstr "Brevlåda är oförändrad."
 
-#: mx.c:914
+#: mx.c:924
 #, c-format
 msgid "%d kept, %d moved, %d deleted."
 msgstr "%d behölls, %d flyttades, %d raderades."
 
-#: mx.c:917 mx.c:1130
+#: mx.c:927 mx.c:1140
 #, c-format
 msgid "%d kept, %d deleted."
 msgstr "%d behölls, %d raderades."
 
-#: mx.c:1052
+#: mx.c:1062
 #, c-format
 msgid " Press '%s' to toggle write"
 msgstr " Tryck \"%s\" för att växla skrivning"
 
-#: mx.c:1054
+#: mx.c:1064
 msgid "Use 'toggle-write' to re-enable write!"
 msgstr "Använd \"toggle-write\" för att återaktivera skrivning!"
 
-#: mx.c:1056
+#: mx.c:1066
 #, c-format
 msgid "Mailbox is marked unwritable. %s"
 msgstr "Brevlåda är märkt som ej skrivbar. %s"
 
-#: mx.c:1124
+#: mx.c:1134
 msgid "Mailbox checkpointed."
 msgstr "Brevlåda är synkroniserad."
 
@@ -3317,54 +3373,59 @@ msgstr " (aktuell tid: %c)"
 msgid "[-- %s output follows%s --]\n"
 msgstr "[-- %s utdata följer%s --]\n"
 
-#: ncrypt/crypt.c:95
-msgid "Passphrase(s) forgotten."
+#. L10N: Due to the implementation details (e.g. some passwords are managed
+#. by gpg-agent) we cannot know whether we forgot zero, 1, 12, ...
+#. passwords. So in English we use "Passphrases". Your language might
+#. have other means to express this.
+#: ncrypt/crypt.c:100
+#, fuzzy
+msgid "Passphrases forgotten."
 msgstr "Lösenfrasen glömd."
 
-#: ncrypt/crypt.c:155
+#: ncrypt/crypt.c:161
 #, fuzzy
 msgid "Inline PGP can't be used with attachments.  Revert to PGP/MIME?"
 msgstr "Meddelande kan inte skickas infogat. Återgå till att använda PGP/MIME?"
 
-#: ncrypt/crypt.c:159
+#: ncrypt/crypt.c:165
 msgid "Mail not sent: inline PGP can't be used with attachments."
 msgstr ""
 
-#: ncrypt/crypt.c:166
+#: ncrypt/crypt.c:172
 #, fuzzy
 msgid "Inline PGP can't be used with format=flowed.  Revert to PGP/MIME?"
 msgstr "Meddelande kan inte skickas infogat. Återgå till att använda PGP/MIME?"
 
-#: ncrypt/crypt.c:170
+#: ncrypt/crypt.c:176
 msgid "Mail not sent: inline PGP can't be used with format=flowed."
 msgstr ""
 
-#: ncrypt/crypt.c:180 ncrypt/cryptglue.c:125 ncrypt/pgpkey.c:589
+#: ncrypt/crypt.c:186 ncrypt/cryptglue.c:125 ncrypt/pgpkey.c:589
 #: ncrypt/pgpkey.c:782
 msgid "Invoking PGP..."
 msgstr "Startar PGP..."
 
-#: ncrypt/crypt.c:192
+#: ncrypt/crypt.c:198
 msgid "Message can't be sent inline.  Revert to using PGP/MIME?"
 msgstr "Meddelande kan inte skickas infogat. Återgå till att använda PGP/MIME?"
 
-#: ncrypt/crypt.c:194 send.c:1824
+#: ncrypt/crypt.c:200 send.c:1824
 msgid "Mail not sent."
 msgstr "Brevet skickades inte."
 
-#: ncrypt/crypt.c:540
+#: ncrypt/crypt.c:546
 msgid "S/MIME messages with no hints on content are unsupported."
 msgstr "S/MIME-meddelanden utan ledtrådar till innehållet stöds ej."
 
-#: ncrypt/crypt.c:754 ncrypt/crypt.c:795
+#: ncrypt/crypt.c:760 ncrypt/crypt.c:801
 msgid "Trying to extract PGP keys...\n"
 msgstr "Försöker att extrahera PGP-nycklar...\n"
 
-#: ncrypt/crypt.c:776 ncrypt/crypt.c:816
+#: ncrypt/crypt.c:782 ncrypt/crypt.c:822
 msgid "Trying to extract S/MIME certificates...\n"
 msgstr "Försöker att extrahera S/MIME-certifikat...\n"
 
-#: ncrypt/crypt.c:976
+#: ncrypt/crypt.c:982
 #, c-format
 msgid ""
 "[-- Error: Unknown multipart/signed protocol %s! --]\n"
@@ -3373,7 +3434,7 @@ msgstr ""
 "[-- Fel: Okänt \"multipart/signed\" protokoll %s! --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1016
+#: ncrypt/crypt.c:1022
 #, fuzzy
 msgid ""
 "[-- Error: Missing or bad-format multipart/signed signature! --]\n"
@@ -3382,7 +3443,7 @@ msgstr ""
 "[-- Fel: Inkonsekvent \"multipart/signed\" struktur! --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1058
+#: ncrypt/crypt.c:1064
 #, c-format
 msgid ""
 "[-- Warning: We can't verify %s/%s signatures. --]\n"
@@ -3391,7 +3452,7 @@ msgstr ""
 "[-- Varning: Vi kan inte verifiera %s/%s signaturer. --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1070
+#: ncrypt/crypt.c:1076
 msgid ""
 "[-- The following data is signed --]\n"
 "\n"
@@ -3399,7 +3460,7 @@ msgstr ""
 "[-- Följande data är signerat --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1075
+#: ncrypt/crypt.c:1081
 msgid ""
 "[-- Warning: Can't find any signatures. --]\n"
 "\n"
@@ -3407,7 +3468,7 @@ msgstr ""
 "[-- Varning: Kan inte hitta några signaturer. --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1081
+#: ncrypt/crypt.c:1087
 msgid ""
 "\n"
 "[-- End of signed data --]\n"
@@ -3458,7 +3519,7 @@ msgstr ""
 msgid "error reading data object: %s\n"
 msgstr "fel vid läsning av dataobjekt: %s\n"
 
-#: ncrypt/crypt_gpgme.c:662 ncrypt/crypt_gpgme.c:3848 ncrypt/pgpkey.c:585
+#: ncrypt/crypt_gpgme.c:662 ncrypt/crypt_gpgme.c:3850 ncrypt/pgpkey.c:585
 #: ncrypt/pgpkey.c:768
 msgid "Can't create temporary file"
 msgstr "Kan inte skapa tillfällig fil"
@@ -3820,28 +3881,30 @@ msgstr "[Ogiltig]"
 
 #. L10N: This is printed after "Key Type: " and looks like this:
 #. *       PGP, 2048 bit RSA
-#: ncrypt/crypt_gpgme.c:3670 ncrypt/crypt_gpgme.c:3808
+#: ncrypt/crypt_gpgme.c:3670 ncrypt/crypt_gpgme.c:3810
 #, fuzzy, c-format
 msgid "%s, %lu bit %s\n"
-msgstr "Nyckel-typ ..: %s, %lu bit %s\n"
+msgid_plural "%s, %lu bit %s\n"
+msgstr[0] "Nyckel-typ ..: %s, %lu bit %s\n"
+msgstr[1] "Nyckel-typ ..: %s, %lu bit %s\n"
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3678 ncrypt/crypt_gpgme.c:3815
+#: ncrypt/crypt_gpgme.c:3678 ncrypt/crypt_gpgme.c:3817
 msgid "encryption"
 msgstr "kryptering"
 
 #: ncrypt/crypt_gpgme.c:3679 ncrypt/crypt_gpgme.c:3685
-#: ncrypt/crypt_gpgme.c:3816 ncrypt/crypt_gpgme.c:3821
+#: ncrypt/crypt_gpgme.c:3818 ncrypt/crypt_gpgme.c:3823
 msgid ", "
 msgstr ", "
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3684 ncrypt/crypt_gpgme.c:3820
+#: ncrypt/crypt_gpgme.c:3684 ncrypt/crypt_gpgme.c:3822
 msgid "signing"
 msgstr "signering"
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3690 ncrypt/crypt_gpgme.c:3825
+#: ncrypt/crypt_gpgme.c:3690 ncrypt/crypt_gpgme.c:3827
 msgid "certification"
 msgstr "certifikat"
 
@@ -3860,65 +3923,65 @@ msgstr "[Utgången]"
 msgid "[Disabled]"
 msgstr "[Inaktiverad]"
 
-#: ncrypt/crypt_gpgme.c:3851
+#: ncrypt/crypt_gpgme.c:3853
 msgid "Collecting data..."
 msgstr "Samlar data..."
 
-#: ncrypt/crypt_gpgme.c:3876
+#: ncrypt/crypt_gpgme.c:3878
 #, c-format
 msgid "Error finding issuer key: %s\n"
 msgstr "Fel vid sökning av utfärdarnyckel: %s\n"
 
-#: ncrypt/crypt_gpgme.c:3885
+#: ncrypt/crypt_gpgme.c:3887
 #, fuzzy
 msgid "Error: certification chain too long - stopping here\n"
 msgstr "Fel: certifikatskedje för lång - stannar här\n"
 
-#: ncrypt/crypt_gpgme.c:3895 ncrypt/pgpkey.c:608
+#: ncrypt/crypt_gpgme.c:3897 ncrypt/pgpkey.c:608
 #, c-format
 msgid "Key ID: 0x%s"
 msgstr "Nyckel-ID: 0x%s"
 
-#: ncrypt/crypt_gpgme.c:3990
+#: ncrypt/crypt_gpgme.c:3992
 #, c-format
 msgid "gpgme_new failed: %s"
 msgstr "gpgme_new misslyckades: %s"
 
-#: ncrypt/crypt_gpgme.c:4028 ncrypt/crypt_gpgme.c:4079
+#: ncrypt/crypt_gpgme.c:4030 ncrypt/crypt_gpgme.c:4081
 #, c-format
 msgid "gpgme_op_keylist_start failed: %s"
 msgstr "gpgme_op_keylist_start misslyckades: %s"
 
-#: ncrypt/crypt_gpgme.c:4067 ncrypt/crypt_gpgme.c:4109
+#: ncrypt/crypt_gpgme.c:4069 ncrypt/crypt_gpgme.c:4111
 #, c-format
 msgid "gpgme_op_keylist_next failed: %s"
 msgstr "gpgme_op_keylist_next misslyckades: %s"
 
-#: ncrypt/crypt_gpgme.c:4185
+#: ncrypt/crypt_gpgme.c:4187
 msgid "All matching keys are marked expired/revoked."
 msgstr "Alla matchande nycklar är markerade utgångna/återkallade."
 
-#: ncrypt/crypt_gpgme.c:4215 ncrypt/pgpkey.c:543 ncrypt/smime.c:475
+#: ncrypt/crypt_gpgme.c:4217 ncrypt/pgpkey.c:543 ncrypt/smime.c:475
 msgid "Select  "
 msgstr "Välj  "
 
-#: ncrypt/crypt_gpgme.c:4217 ncrypt/pgpkey.c:545
+#: ncrypt/crypt_gpgme.c:4219 ncrypt/pgpkey.c:545
 msgid "Check key  "
 msgstr "Kontrollera nyckel "
 
-#: ncrypt/crypt_gpgme.c:4233
+#: ncrypt/crypt_gpgme.c:4235
 msgid "PGP and S/MIME keys matching"
 msgstr "PGP- och S/MIME-nycklar som matchar"
 
-#: ncrypt/crypt_gpgme.c:4235
+#: ncrypt/crypt_gpgme.c:4237
 msgid "PGP keys matching"
 msgstr "PGP-nycklar som matchar"
 
-#: ncrypt/crypt_gpgme.c:4237
+#: ncrypt/crypt_gpgme.c:4239
 msgid "S/MIME keys matching"
 msgstr "S/MIME-nycklar som matchar"
 
-#: ncrypt/crypt_gpgme.c:4239
+#: ncrypt/crypt_gpgme.c:4241
 msgid "keys matching"
 msgstr "nycklar som matchar"
 
@@ -3926,69 +3989,69 @@ msgstr "nycklar som matchar"
 #. %1$s is one of the previous four entries.
 #. %2$s is an address.
 #. e.g. "S/MIME keys matching <me@mutt.org>."
-#: ncrypt/crypt_gpgme.c:4246
+#: ncrypt/crypt_gpgme.c:4248
 #, c-format
 msgid "%s <%s>."
 msgstr "%s <%s>."
 
 #. L10N:
 #. e.g. 'S/MIME keys matching "Michael Elkins".'
-#: ncrypt/crypt_gpgme.c:4250
+#: ncrypt/crypt_gpgme.c:4252
 #, c-format
 msgid "%s \"%s\"."
 msgstr "%s \"%s\"."
 
-#: ncrypt/crypt_gpgme.c:4277 ncrypt/pgpkey.c:628
+#: ncrypt/crypt_gpgme.c:4279 ncrypt/pgpkey.c:628
 msgid "This key can't be used: expired/disabled/revoked."
 msgstr "Den här nyckeln kan inte användas: utgången/inaktiverad/återkallad."
 
-#: ncrypt/crypt_gpgme.c:4290 ncrypt/pgpkey.c:640 ncrypt/smime.c:505
+#: ncrypt/crypt_gpgme.c:4292 ncrypt/pgpkey.c:640 ncrypt/smime.c:505
 #, fuzzy
 msgid "ID is expired/disabled/revoked. Do you really want to use the key?"
 msgstr "ID:t är utgånget/inaktiverat/återkallat. Vill du verkligen använda nyckeln?"
 
-#: ncrypt/crypt_gpgme.c:4299 ncrypt/pgpkey.c:650
+#: ncrypt/crypt_gpgme.c:4301 ncrypt/pgpkey.c:650
 #, fuzzy
 msgid "ID is not valid. Do you really want to use the key?"
 msgstr "ID:t är inte giltigt. Vill du verkligen använda nyckeln?"
 
-#: ncrypt/crypt_gpgme.c:4302 ncrypt/pgpkey.c:653
+#: ncrypt/crypt_gpgme.c:4304 ncrypt/pgpkey.c:653
 #, fuzzy
 msgid "ID is only marginally valid. Do you really want to use the key?"
 msgstr "ID:t är endast marginellt giltigt. Vill du verkligen använda nyckeln?"
 
-#: ncrypt/crypt_gpgme.c:4310 ncrypt/pgpkey.c:646 ncrypt/smime.c:509
+#: ncrypt/crypt_gpgme.c:4312 ncrypt/pgpkey.c:646 ncrypt/smime.c:509
 #, fuzzy
 msgid "ID has undefined validity. Do you really want to use the key?"
 msgstr "ID:t har odefinierad giltighet. Vill du verkligen använda nyckeln?"
 
-#: ncrypt/crypt_gpgme.c:4370 ncrypt/crypt_gpgme.c:4479 ncrypt/pgpkey.c:872
+#: ncrypt/crypt_gpgme.c:4372 ncrypt/crypt_gpgme.c:4481 ncrypt/pgpkey.c:872
 #: ncrypt/pgpkey.c:995
 #, c-format
 msgid "Looking for keys matching \"%s\"..."
 msgstr "Söker efter nycklar som matchar \"%s\"..."
 
-#: ncrypt/crypt_gpgme.c:4593 ncrypt/pgpkey.c:731 ncrypt/smime.c:811
+#: ncrypt/crypt_gpgme.c:4595 ncrypt/pgpkey.c:731 ncrypt/smime.c:811
 #, c-format
 msgid "No matching keys found for \"%s\""
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4644 ncrypt/pgp.c:1263
+#: ncrypt/crypt_gpgme.c:4646 ncrypt/pgp.c:1263
 #, c-format
 msgid "Use keyID = \"%s\" for %s?"
 msgstr "Använd nyckel-ID = \"%s\" för %s?"
 
-#: ncrypt/crypt_gpgme.c:4695 ncrypt/pgp.c:1312 ncrypt/smime.c:830
+#: ncrypt/crypt_gpgme.c:4697 ncrypt/pgp.c:1312 ncrypt/smime.c:830
 #: ncrypt/smime.c:938
 #, c-format
 msgid "Enter keyID for %s: "
 msgstr "Ange nyckel-ID för %s: "
 
-#: ncrypt/crypt_gpgme.c:4755 ncrypt/pgpkey.c:751
+#: ncrypt/crypt_gpgme.c:4757 ncrypt/pgpkey.c:751
 msgid "Please enter the key ID: "
 msgstr "Var vänlig ange nyckel-ID: "
 
-#: ncrypt/crypt_gpgme.c:4768
+#: ncrypt/crypt_gpgme.c:4770
 #, fuzzy, c-format
 msgid "Error exporting key: %s\n"
 msgstr "Fel vid hämtning av nyckelinformation: "
@@ -3997,90 +4060,90 @@ msgstr "Fel vid hämtning av nyckelinformation: "
 #. MIME description for exported (attached) keys.
 #. You can translate this entry to a non-ASCII string (it will be encoded),
 #. but it may be safer to keep it untranslated.
-#: ncrypt/crypt_gpgme.c:4787
+#: ncrypt/crypt_gpgme.c:4789
 #, fuzzy, c-format
 msgid "PGP Key 0x%s."
 msgstr "PGP-nyckel %s."
 
-#: ncrypt/crypt_gpgme.c:4830
+#: ncrypt/crypt_gpgme.c:4832
 msgid "GPGME: OpenPGP protocol not available"
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4838
+#: ncrypt/crypt_gpgme.c:4840
 msgid "GPGME: CMS protocol not available"
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4876
+#: ncrypt/crypt_gpgme.c:4878
 #, fuzzy
 msgid "S/MIME (s)ign, sign (a)s, (p)gp, (c)lear, or (o)ppenc mode off? "
 msgstr "S/MIME (k)ryptera, (s)ignera, signera s(o)m, (b)ägge, (p)gp eller (r)ensa?"
 
 #. L10N: S/MIME options (opportunistic encryption is on)
-#: ncrypt/crypt_gpgme.c:4878
+#: ncrypt/crypt_gpgme.c:4880
 msgid "sapco"
 msgstr "ksobpr"
 
-#: ncrypt/crypt_gpgme.c:4885
+#: ncrypt/crypt_gpgme.c:4887
 #, fuzzy
 msgid "PGP (s)ign, sign (a)s, s/(m)ime, (c)lear, or (o)ppenc mode off? "
 msgstr "PGP (k)ryptera, (s)ignera, signera s(o)m, (b)ägge, s/(m)ime eller (r)ensa?"
 
 #. L10N: PGP options (opportunistic encryption is on)
-#: ncrypt/crypt_gpgme.c:4887
+#: ncrypt/crypt_gpgme.c:4889
 msgid "samco"
 msgstr "ksobmr"
 
 #. L10N: S/MIME options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4900
+#: ncrypt/crypt_gpgme.c:4902
 #, fuzzy
 msgid "S/MIME (e)ncrypt, (s)ign, sign (a)s, (b)oth, (p)gp, (c)lear, or (o)ppenc mode? "
 msgstr "S/MIME (k)ryptera, (s)ignera, signera s(o)m, (b)ägge, (p)gp eller (r)ensa?"
 
 #. L10N: S/MIME options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4903
+#: ncrypt/crypt_gpgme.c:4905
 #, fuzzy
 msgid "esabpco"
 msgstr "ksobpr"
 
 #. L10N: PGP options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4909
+#: ncrypt/crypt_gpgme.c:4911
 #, fuzzy
 msgid "PGP (e)ncrypt, (s)ign, sign (a)s, (b)oth, s/(m)ime, (c)lear, or (o)ppenc mode? "
 msgstr "PGP (k)ryptera, (s)ignera, signera s(o)m, (b)ägge, s/(m)ime eller (r)ensa?"
 
 #. L10N: PGP options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4912
+#: ncrypt/crypt_gpgme.c:4914
 #, fuzzy
 msgid "esabmco"
 msgstr "ksobmr"
 
-#: ncrypt/crypt_gpgme.c:4925
+#: ncrypt/crypt_gpgme.c:4927
 #, fuzzy
 msgid "S/MIME (e)ncrypt, (s)ign, sign (a)s, (b)oth, (p)gp or (c)lear? "
 msgstr "S/MIME (k)ryptera, (s)ignera, signera s(o)m, (b)ägge, (p)gp eller (r)ensa?"
 
 #. L10N: S/MIME options
-#: ncrypt/crypt_gpgme.c:4927
+#: ncrypt/crypt_gpgme.c:4929
 #, fuzzy
 msgid "esabpc"
 msgstr "ksobpr"
 
-#: ncrypt/crypt_gpgme.c:4934
+#: ncrypt/crypt_gpgme.c:4936
 #, fuzzy
 msgid "PGP (e)ncrypt, (s)ign, sign (a)s, (b)oth, s/(m)ime or (c)lear? "
 msgstr "PGP (k)ryptera, (s)ignera, signera s(o)m, (b)ägge, s/(m)ime eller (r)ensa?"
 
 #. L10N: PGP options
-#: ncrypt/crypt_gpgme.c:4936
+#: ncrypt/crypt_gpgme.c:4938
 #, fuzzy
 msgid "esabmc"
 msgstr "ksobmr"
 
-#: ncrypt/crypt_gpgme.c:5087
+#: ncrypt/crypt_gpgme.c:5089
 msgid "Failed to verify sender"
 msgstr "Misslyckades att verifiera sändare"
 
-#: ncrypt/crypt_gpgme.c:5090
+#: ncrypt/crypt_gpgme.c:5092
 msgid "Failed to figure out sender"
 msgstr "Misslyckades att ta reda på sändare"
 
@@ -4485,7 +4548,7 @@ msgstr ""
 msgid "%s is an invalid news server specification!"
 msgstr "%s är en ogilitig POP-sökväg"
 
-#: nntp.c:75 nntp.c:612 pop.c:1028 pop_lib.c:405
+#: nntp.c:75 nntp.c:612 pop.c:1031 pop_lib.c:405
 msgid "Server closed connection!"
 msgstr "Servern stängde förbindelsen!"
 
@@ -4651,16 +4714,18 @@ msgid "check mailboxes for new mail"
 msgstr "kolla brevlådor efter nya brev"
 
 #: opcodes.h:47
-msgid "attach file(s) to this message"
+#, fuzzy
+msgid "attach files to this message"
 msgstr "bifoga fil(er) till det här meddelandet"
 
 #: opcodes.h:48
-msgid "attach message(s) to this message"
+#, fuzzy
+msgid "attach messages to this message"
 msgstr "bifoga meddelande(n) till det här meddelandet"
 
 #: opcodes.h:49
 #, fuzzy
-msgid "attach news article(s) to this message"
+msgid "attach news articles to this message"
 msgstr "bifoga fil(er) till det här meddelandet"
 
 #: opcodes.h:50
@@ -5504,7 +5569,8 @@ msgid "extract supported public keys"
 msgstr "extrahera stödda publika nycklar"
 
 #: opcodes.h:255
-msgid "wipe passphrase(s) from memory"
+#, fuzzy
+msgid "wipe passphrases from memory"
 msgstr "rensa lösenfras(er) från minnet"
 
 #: opcodes.h:259
@@ -5852,18 +5918,20 @@ msgstr "Inga nya brev i POP-brevlåda."
 msgid "Delete messages from server?"
 msgstr "Radera meddelanden från server?"
 
-#: pop.c:954
-#, c-format
-msgid "Reading new messages (%d bytes)..."
-msgstr "Läser nya meddelanden (%d byte)..."
+#: pop.c:955
+#, fuzzy, c-format
+msgid "Reading new messages (%d byte)..."
+msgid_plural "Reading new messages (%d bytes)..."
+msgstr[0] "Läser nya meddelanden (%d byte)..."
+msgstr[1] "Läser nya meddelanden (%d byte)..."
 
-#: pop.c:997
+#: pop.c:1000
 msgid "Error while writing mailbox!"
 msgstr "Fel vid skrivning av brevlåda!"
 
 #. L10N: The plural is picked by the second numerical argument, i.e.
 #. * the %d right before 'messages', i.e. the total number of messages.
-#: pop.c:1003
+#: pop.c:1006
 #, fuzzy, c-format
 msgid "%s [%d of %d message read]"
 msgid_plural "%s [%d of %d messages read]"
@@ -6007,49 +6075,56 @@ msgstr "Skicka genom rör till: "
 msgid "I don't know how to print %s attachments!"
 msgstr "Jag vet inte hur %s bilagor ska skrivas ut!"
 
-#: recvattach.c:841
-msgid "Print tagged attachment(s)?"
-msgstr "Skriv ut märkta bilagor?"
+#. L10N: Although we now the precise number of tagged messages, we
+#. do not show it to the user.  So feel free to use a "generic
+#. plural" as plural translation if your language has one.
+#: recvattach.c:852
+#, fuzzy, c-format
+msgid "Print tagged attachment?"
+msgid_plural "Print %d tagged attachments?"
+msgstr[0] "Skriv ut märkta bilagor?"
+msgstr[1] "Skriv ut märkta bilagor?"
 
-#: recvattach.c:842
+#: recvattach.c:853
+#, c-format
 msgid "Print attachment?"
 msgstr "Skriv ut bilaga?"
 
-#: recvattach.c:900
+#: recvattach.c:913
 msgid "Structural changes to decrypted attachments are not supported"
 msgstr ""
 
-#: recvattach.c:1046
+#: recvattach.c:1059
 msgid "Can't decrypt encrypted message!"
 msgstr "Kan inte avkryptera krypterat meddelande!"
 
-#: recvattach.c:1172
+#: recvattach.c:1185
 msgid "Attachments"
 msgstr "Bilagor"
 
-#: recvattach.c:1210
+#: recvattach.c:1223
 msgid "There are no subparts to show!"
 msgstr "Det finns inga underdelar att visa!"
 
-#: recvattach.c:1265
+#: recvattach.c:1278
 msgid "Can't delete attachment from POP server."
 msgstr "Kan inte radera bilaga från POP-server."
 
-#: recvattach.c:1274
+#: recvattach.c:1287
 #, fuzzy
 msgid "Can't delete attachment from news server."
 msgstr "Kan inte radera bilaga från POP-server."
 
-#: recvattach.c:1281
+#: recvattach.c:1294
 msgid "Deletion of attachments from encrypted messages is unsupported."
 msgstr "Radering av bilagor från krypterade meddelanden stöds ej."
 
-#: recvattach.c:1287
+#: recvattach.c:1300
 #, fuzzy
 msgid "Deletion of attachments from signed messages may invalidate the signature."
 msgstr "Radering av bilagor från krypterade meddelanden stöds ej."
 
-#: recvattach.c:1305 recvattach.c:1320
+#: recvattach.c:1318 recvattach.c:1333
 msgid "Only deletion of multipart attachments is supported."
 msgstr "Endast radering av \"multipart\"-bilagor stöds."
 
@@ -6487,3 +6562,15 @@ msgstr "Kompileringsval:"
 #: version.c:404
 msgid "Compile options:"
 msgstr "Kompileringsval:"
+
+#, fuzzy
+#~ msgid "Cannot delete message(s)"
+#~ msgstr "återställ meddelande(n)"
+
+#, fuzzy
+#~ msgid "Cannot undelete message(s)"
+#~ msgstr "återställ meddelande(n)"
+
+#, fuzzy
+#~ msgid "messages not deleted"
+#~ msgstr "Markerar raderade meddelanden..."

--- a/po/tr.po
+++ b/po/tr.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neomutt-20180512\n"
 "Report-Msgid-Bugs-To: neomutt-devel@neomutt.org\n"
-"POT-Creation-Date: 2018-05-20 02:02+0000\n"
+"POT-Creation-Date: 2018-05-22 14:18+0000\n"
 "PO-Revision-Date: 2006-01-11 04:13+0200\n"
 "Last-Translator: Recai Oktaş <roktas@debian.org>\n"
 "Language-Team: Debian L10n Turkish <debian-l10n-turkish@lists.debian.org>\n"
@@ -41,7 +41,7 @@ msgstr "Seç"
 
 #: addrbook.c:52 browser.c:75 browser.c:87 compose.c:160 compose.c:172
 #: conn/ssl.c:1041 conn/ssl_gnutls.c:793 curs_main.c:748 curs_main.c:761
-#: history.c:106 ncrypt/crypt_gpgme.c:4219 ncrypt/pgpkey.c:547
+#: history.c:106 ncrypt/crypt_gpgme.c:4221 ncrypt/pgpkey.c:547
 #: ncrypt/smime.c:477 pager.c:2141 postpone.c:65 query.c:72 recvattach.c:70
 msgid "Help"
 msgstr "Yardım"
@@ -683,7 +683,7 @@ msgstr ""
 #. * Since it shares the row with "Encrypt with:", it should not be longer
 #. * than 15-20 character cells.
 #.
-#: compose.c:138 ncrypt/crypt_gpgme.c:4947 ncrypt/pgp.c:1786
+#: compose.c:138 ncrypt/crypt_gpgme.c:4949 ncrypt/pgp.c:1786
 #: ncrypt/smime.c:2127
 msgid "Sign as: "
 msgstr "Farklı imzala: "
@@ -1220,7 +1220,7 @@ msgstr "(r)eddet, (s)adece bu defalığına kabul et, (a)tla"
 msgid "(r)eject, accept (o)nce"
 msgstr "(r)eddet, (s)adece bu defalığına kabul et, (a)tla"
 
-#: conn/ssl.c:1039 conn/ssl_gnutls.c:791 ncrypt/crypt_gpgme.c:4213
+#: conn/ssl.c:1039 conn/ssl_gnutls.c:791 ncrypt/crypt_gpgme.c:4215
 #: ncrypt/pgpkey.c:541 ncrypt/smime.c:473
 msgid "Exit  "
 msgstr "Çık  "
@@ -1400,11 +1400,11 @@ msgstr "Hiç bir eposta kutusu açık değil."
 msgid "There are no messages."
 msgstr "İleti yok."
 
-#: curs_main.c:77 mx.c:1061 pager.c:73 recvattach.c:56
+#: curs_main.c:77 mx.c:1071 pager.c:73 recvattach.c:56
 msgid "Mailbox is read-only."
 msgstr "Eposta kutusu salt okunur."
 
-#: curs_main.c:79 pager.c:75 recvattach.c:1145
+#: curs_main.c:79 pager.c:75 recvattach.c:1158
 msgid "Function not permitted in attach-message mode."
 msgstr "Bu işleve ileti ekle kipinde izin verilmiyor."
 
@@ -1538,245 +1538,254 @@ msgid "That message is not visible."
 msgstr "Bu ileti görünmez."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:1377 curs_main.c:2772 pager.c:2818
+#. L10N: Due to the implementation details we do not know whether we
+#. delete zero, 1, 12, ... messages. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:1381 curs_main.c:2784 pager.c:2822
 #, fuzzy
-msgid "Cannot delete message(s)"
+msgid "Cannot delete messages"
 msgstr "İleti(ler) silinemedi"
 
-#: curs_main.c:1380
+#: curs_main.c:1384
 msgid "Delete messages matching: "
 msgstr "Tabire uyan iletileri sil: "
 
-#: curs_main.c:1421
+#: curs_main.c:1425
 msgid "No limit pattern is in effect."
 msgstr "Herhangi bir sınırlandırma tabiri etkin değil."
 
 #. L10N: ask for a limit to apply
-#: curs_main.c:1426
+#: curs_main.c:1430
 #, c-format
 msgid "Limit: %s"
 msgstr "Sınır: %s"
 
-#: curs_main.c:1464
+#: curs_main.c:1468
 msgid "Limit to messages matching: "
 msgstr "Sadece tabire uyan iletiler: "
 
-#: curs_main.c:1488
+#: curs_main.c:1492
 msgid "To view all messages, limit to \"all\"."
 msgstr "İletilerin hepsini görmek için \"all\" tabirini kullanın."
 
-#: curs_main.c:1500 pager.c:2318
+#: curs_main.c:1504 pager.c:2318
 msgid "Quit NeoMutt?"
 msgstr "NeoMutt'tan çıkılsın mı?"
 
-#: curs_main.c:1596
+#: curs_main.c:1600
 msgid "Tag messages matching: "
 msgstr "Tabire uyan iletileri işaretle: "
 
 #. L10N: CHECK_ACL
-#: curs_main.c:1606 curs_main.c:3203 pager.c:3137
-msgid "Cannot undelete message(s)"
+#. L10N: Due to the implementation details we do not know whether we
+#. undelete zero, 1, 12, ... messages. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:1614 curs_main.c:3223 pager.c:3145
+#, fuzzy
+msgid "Cannot undelete messages"
 msgstr "İleti(ler) kurtarılamadı"
 
-#: curs_main.c:1609
+#: curs_main.c:1617
 msgid "Undelete messages matching: "
 msgstr "Tabire uyan iletileri kurtar: "
 
-#: curs_main.c:1619
+#: curs_main.c:1627
 msgid "Untag messages matching: "
 msgstr "Tabire uyan iletilerdeki işareti sil: "
 
-#: curs_main.c:1653
+#: curs_main.c:1661
 msgid "Logged out of IMAP servers."
 msgstr ""
 
-#: curs_main.c:1753
+#: curs_main.c:1761
 msgid "No virtual folder, aborting."
 msgstr "Sanal dizin bulunamadı, iptal ediliyor."
 
-#: curs_main.c:1761
+#: curs_main.c:1769
 msgid "Failed to read thread, aborting."
 msgstr ""
 
-#: curs_main.c:1793 mx.c:1458 mx.c:1475
+#: curs_main.c:1801 mx.c:1468 mx.c:1485
 msgid "Folder doesn't support tagging, aborting."
 msgstr ""
 
-#: curs_main.c:1808
+#: curs_main.c:1816
 #, fuzzy
 msgid "No tag specified, aborting."
 msgstr "Konu girilmedi, iptal ediliyor."
 
-#: curs_main.c:1820
+#: curs_main.c:1828
 #, c-format
 msgid "Update tags..."
 msgstr ""
 
-#: curs_main.c:1857
+#: curs_main.c:1865
 msgid "Failed to modify tags, aborting."
 msgstr ""
 
-#: curs_main.c:1898
+#: curs_main.c:1906
 #, fuzzy
 msgid "No query, aborting."
 msgstr "Konu girilmedi, iptal ediliyor."
 
-#: curs_main.c:1902 curs_main.c:1922 curs_main.c:1941
+#: curs_main.c:1910 curs_main.c:1930 curs_main.c:1949
 msgid "Failed to create query, aborting."
 msgstr ""
 
-#: curs_main.c:1911 curs_main.c:1930
+#: curs_main.c:1919 curs_main.c:1938
 msgid "Windowed queries disabled."
 msgstr ""
 
-#: curs_main.c:1916 curs_main.c:1935
+#: curs_main.c:1924 curs_main.c:1943
 msgid "No notmuch vfolder currently loaded."
 msgstr ""
 
-#: curs_main.c:1973
+#: curs_main.c:1981
 msgid "Open mailbox in read-only mode"
 msgstr "Eposta kutusunu salt okunur aç"
 
-#: curs_main.c:1976
+#: curs_main.c:1984
 msgid "Open virtual folder"
 msgstr "Sanal dizini aç"
 
-#: curs_main.c:1979
+#: curs_main.c:1987
 msgid "Open mailbox"
 msgstr "Eposta kutusunu aç"
 
-#: curs_main.c:1989
+#: curs_main.c:1997
 #, fuzzy
 msgid "No mailboxes have new mail"
 msgstr "Yeni eposta içeren bir eposta kutusu yok."
 
-#: curs_main.c:2036
+#: curs_main.c:2044
 msgid "Open newsgroup in read-only mode"
 msgstr "Haber grubunu salt okunur aç"
 
-#: curs_main.c:2038
+#: curs_main.c:2046
 msgid "Open newsgroup"
 msgstr "Haber grubunu aç"
 
-#: curs_main.c:2141
+#: curs_main.c:2149
 #, fuzzy
 msgid "Exit NeoMutt without saving?"
 msgstr "NeoMutt'tan kaydedilmeden çıkılsın mı?"
 
-#: curs_main.c:2157
+#: curs_main.c:2165
 #, fuzzy
 msgid "Cannot break thread"
 msgstr "Süzgeç oluşturulamadı"
 
-#: curs_main.c:2160 curs_main.c:2198 curs_main.c:2658 curs_main.c:2690
+#: curs_main.c:2168 curs_main.c:2206 curs_main.c:2666 curs_main.c:2698
 #: flags.c:376 thread.c:1078 thread.c:1134 thread.c:1202
 msgid "Threading is not enabled."
 msgstr "İlmek kullanımı etkin değil."
 
-#: curs_main.c:2173
+#: curs_main.c:2181
 msgid "Thread broken"
 msgstr "Kopuk ilmek"
 
-#: curs_main.c:2185
+#: curs_main.c:2193
 msgid "Thread cannot be broken, message is not part of a thread"
 msgstr ""
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2195
+#: curs_main.c:2203
 msgid "Cannot link threads"
 msgstr ""
 
-#: curs_main.c:2200
+#: curs_main.c:2208
 msgid "No Message-ID: header available to link thread"
 msgstr "İlmeğe bağlamakta kullanılabilecek bir \"Message-ID:\" başlığı yok"
 
-#: curs_main.c:2202
+#: curs_main.c:2210
 msgid "First, please tag a message to be linked here"
 msgstr "Öncelikle lütfen buraya bağlanacak bir ileti işaretleyin"
 
-#: curs_main.c:2213
+#: curs_main.c:2221
 msgid "Threads linked"
 msgstr "Bağlanan ilmekler"
 
-#: curs_main.c:2216
+#: curs_main.c:2224
 msgid "No thread linked"
 msgstr "Herhangi bir ilmeğe bağlanmadı"
 
-#: curs_main.c:2252 curs_main.c:2278
+#: curs_main.c:2260 curs_main.c:2286
 msgid "You are on the last message."
 msgstr "Son iletidesiniz."
 
-#: curs_main.c:2260 curs_main.c:2305
+#: curs_main.c:2268 curs_main.c:2313
 msgid "No undeleted messages."
 msgstr "Kurtarılan ileti yok."
 
-#: curs_main.c:2297 curs_main.c:2323
+#: curs_main.c:2305 curs_main.c:2331
 msgid "You are on the first message."
 msgstr "İlk iletidesiniz."
 
-#: curs_main.c:2395 menu.c:970 pager.c:2440 pattern.c:2110
+#: curs_main.c:2403 menu.c:970 pager.c:2440 pattern.c:2110
 msgid "Search wrapped to top."
 msgstr "Arama başa döndü."
 
-#: curs_main.c:2404 pager.c:2463 pattern.c:2121
+#: curs_main.c:2412 pager.c:2463 pattern.c:2121
 msgid "Search wrapped to bottom."
 msgstr "Arama sona ulaştı."
 
-#: curs_main.c:2447
+#: curs_main.c:2455
 #, fuzzy
 msgid "No new messages in this limited view."
 msgstr "Sınırlandırılmış görünümde ana ileti görünemez."
 
-#: curs_main.c:2449
+#: curs_main.c:2457
 msgid "No new messages."
 msgstr "Yeni ileti yok."
 
-#: curs_main.c:2454
+#: curs_main.c:2462
 #, fuzzy
 msgid "No unread messages in this limited view."
 msgstr "Sınırlandırılmış görünümde ana ileti görünemez."
 
-#: curs_main.c:2456
+#: curs_main.c:2464
 msgid "No unread messages."
 msgstr "Okunmamış ileti yok"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2474
+#: curs_main.c:2482
 #, fuzzy
 msgid "Cannot flag message"
 msgstr "iletiyi göster"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2513 pager.c:3100
+#: curs_main.c:2521 pager.c:3104
 msgid "Cannot toggle new"
 msgstr ""
 
-#: curs_main.c:2590
+#: curs_main.c:2598
 msgid "No more threads."
 msgstr "Daha başka ilmek yok."
 
-#: curs_main.c:2592
+#: curs_main.c:2600
 msgid "You are on the first thread."
 msgstr "İlk ilmektesiniz."
 
-#: curs_main.c:2676
+#: curs_main.c:2684
 #, fuzzy
 msgid "Thread contains unread or flagged messages."
 msgstr "İlmek okunmamış iletiler içeriyor."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2726 pager.c:2784
+#: curs_main.c:2734 pager.c:2784
 msgid "Cannot delete message"
 msgstr "İleti silinemedi"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2838
+#: curs_main.c:2850
 msgid "Cannot edit message"
 msgstr "İleti düzenleyemedi"
 
 #. L10N: This is displayed when the x-label on one or more
 #. * messages is edited.
-#: curs_main.c:2900 pager.c:3200
+#: curs_main.c:2912 pager.c:3208
 #, fuzzy, c-format
 msgid "%d label changed."
 msgid_plural "%d labels changed."
@@ -1786,28 +1795,32 @@ msgstr[1] "Eposta kutusunda değişiklik yok."
 #. L10N: This is displayed when editing an x-label, but no messages
 #. * were updated.  Possibly due to canceling at the prompt or if the new
 #. * label is the same as the old label.
-#: curs_main.c:2907 pager.c:3204
+#: curs_main.c:2919 pager.c:3212
 #, fuzzy
 msgid "No labels changed."
 msgstr "Eposta kutusunda değişiklik yok."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:3006
+#. L10N: Due to the implementation details we do not know whether we
+#. mark zero, 1, 12, ... messages as read. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:3022
 #, fuzzy
-msgid "Cannot mark message(s) as read"
+msgid "Cannot mark messages as read"
 msgstr "ilmeği başlatan ana iletiye geç"
 
 #. L10N: This is the prompt for <mark-message>.  Whatever they
 #. enter will be prefixed by $mark_macro_prefix and will become
 #. a macro hotkey to jump to the currently selected message.
-#: curs_main.c:3042
+#: curs_main.c:3058
 #, fuzzy
 msgid "Enter macro stroke: "
 msgstr "%s için anahtar NO'yu girin: "
 
 #. L10N: "message hotkey" is the key bindings menu description of a
 #. macro created by <mark-message>.
-#: curs_main.c:3050
+#: curs_main.c:3066
 #, fuzzy
 msgid "message hotkey"
 msgstr "İleti ertelendi."
@@ -1815,28 +1828,28 @@ msgstr "İleti ertelendi."
 #. L10N: This is echoed after <mark-message> creates a new hotkey
 #. macro.  %s is the hotkey string ($mark_macro_prefix followed
 #. by whatever they typed at the prompt.)
-#: curs_main.c:3055
+#: curs_main.c:3071
 #, fuzzy, c-format
 msgid "Message bound to %s."
 msgstr "İleti geri gönderildi."
 
 #. L10N: This error is printed if <mark-message> cannot find a
 #. Message-ID for the currently selected message in the index.
-#: curs_main.c:3063
+#: curs_main.c:3079
 #, fuzzy
 msgid "No message ID to macro."
 msgstr "Bu klasörde ileti yok."
 
-#: curs_main.c:3105 pager.c:2961 recvattach.c:1388
+#: curs_main.c:3121 pager.c:2965 recvattach.c:1401
 msgid "Reply by mail as poster prefers?"
 msgstr ""
 
-#: curs_main.c:3108 pager.c:2927 pager.c:2939 pager.c:2964
+#: curs_main.c:3124 pager.c:2931 pager.c:2943 pager.c:2968
 msgid "Posting to this group not allowed, may be moderated. Continue?"
 msgstr ""
 
 #. L10N: CHECK_ACL
-#: curs_main.c:3173 pager.c:3120
+#: curs_main.c:3189 pager.c:3124
 msgid "Cannot undelete message"
 msgstr "İleti kurtarılamadı"
 
@@ -2029,12 +2042,34 @@ msgstr "[-- %s otomatik görüntüleme komutunun ürettiği hata --]\n"
 msgid "[-- Error: message/external-body has no access-type parameter --]\n"
 msgstr "[-- Hata: \"message/external-body\" herhangi bir erişim tipi içermiyor --]\n"
 
-#: handler.c:1611
+#. L10N: If the translation of this string is a multi line string, then
+#. each line should start with "[-- " and end with " --]".
+#. The first "%s/%s" is a MIME type, e.g. "text/plain". The last %s
+#. expands to a date as returned by `mutt_date_parse_date()`.
+#.
+#. Note: The size argument printed is not the actual number as passed
+#. to gettext but the prettified version, e.g. size = 2048 will be
+#. printed as 2K.  Your language might be sensitive to that: For
+#. example although '1K' and '1024' represent the same number your
+#. language might inflect the noun 'byte' differently.
+#.
+#. Sadly, we cannot do anything about that at the moment besides
+#. passing the precise size in bytes. If you are interested the
+#. function responsible for the prettification is
+#. mutt_str_pretty_size() in mutt/string.c.
+#.
+#: handler.c:1624
 #, fuzzy, c-format
 msgid ""
+"[-- This %s/%s attachment (size %s byte) has been deleted --]\n"
+"[-- on %s --]\n"
+msgid_plural ""
 "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
 "[-- on %s --]\n"
-msgstr ""
+msgstr[0] ""
+"[-- Bu %s/%s eki(boyut %s bayt) silindi --]\n"
+"[-- %s üzerinde --]\n"
+msgstr[1] ""
 "[-- Bu %s/%s eki(boyut %s bayt) silindi --]\n"
 "[-- %s üzerinde --]\n"
 
@@ -2042,10 +2077,23 @@ msgstr ""
 #. each line should start with "[-- " and end with " --]".
 #. The first "%s/%s" is a MIME type, e.g. "text/plain".
 #.
-#: handler.c:1620
+#. Note: The size argument printed is not the actual number as passed
+#. to gettext but the prettified version, e.g. size = 2048 will be
+#. printed as 2K.  Your language might be sensitive to that: For
+#. example although '1K' and '1024' represent the same number your
+#. language might inflect the noun 'byte' differently.
+#.
+#. Sadly, we cannot do anything about that at the moment besides
+#. passing the precise size in bytes. If you are interested the
+#. function responsible for the prettification is
+#. mutt_str_pretty_size() in mutt/string.c.
+#.
+#: handler.c:1648
 #, fuzzy, c-format
-msgid "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
-msgstr "[-- Bu %s/%s eki(boyut %s bayt) silindi --]\n"
+msgid "[-- This %s/%s attachment (size %s byte) has been deleted --]\n"
+msgid_plural "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
+msgstr[0] "[-- Bu %s/%s eki(boyut %s bayt) silindi --]\n"
+msgstr[1] "[-- Bu %s/%s eki(boyut %s bayt) silindi --]\n"
 
 #. L10N: If the translation of this string is a multi line string, then
 #. each line should start with "[-- " and end with " --]".
@@ -2055,7 +2103,7 @@ msgstr "[-- Bu %s/%s eki(boyut %s bayt) silindi --]\n"
 #. Caution: Argument three %3$ is also defined but should not be used
 #. in this translation!
 #.
-#: handler.c:1637
+#: handler.c:1667
 #, fuzzy
 msgid ""
 "[-- This %s/%s attachment has been deleted --]\n"
@@ -2068,17 +2116,17 @@ msgstr ""
 #. each line should start with "[-- " and end with " --]".
 #. The first "%s/%s" is a MIME type, e.g. "text/plain".
 #.
-#: handler.c:1646
+#: handler.c:1676
 #, fuzzy, c-format
 msgid "[-- This %s/%s attachment has been deleted --]\n"
 msgstr "[-- Bu %s/%s ekisilindi --]\n"
 
-#: handler.c:1656
+#: handler.c:1686
 #, c-format
 msgid "[-- name: %s --]\n"
 msgstr "[-- isim: %s --]\n"
 
-#: handler.c:1672
+#: handler.c:1702
 #, fuzzy, c-format
 msgid ""
 "[-- This %s/%s attachment is not included, --]\n"
@@ -2089,7 +2137,7 @@ msgstr ""
 "[-- ve belirtilen dış kaynak artık geçerli de --]\n"
 "[-- değil. --]\n"
 
-#: handler.c:1693
+#: handler.c:1723
 #, fuzzy, c-format
 msgid ""
 "[-- This %s/%s attachment is not included, --]\n"
@@ -2098,50 +2146,50 @@ msgstr ""
 "[-- Bu %s/%s eki eklenmiyor --]\n"
 "[-- ve belirtilen %s erişim tipi de desteklenmiyor --]\n"
 
-#: handler.c:1822
+#: handler.c:1852
 msgid "Unable to open memory stream!"
 msgstr "Bellek akışı açılamadı!"
 
-#: handler.c:1831
+#: handler.c:1861
 msgid "Unable to open temporary file!"
 msgstr "Geçici dosya açılamadı!"
 
-#: handler.c:1881
+#: handler.c:1911
 msgid "failed to re-open memstream!"
 msgstr "bellek akışını yeniden açma başarısız oldu!"
 
-#: handler.c:2013
+#: handler.c:2043
 msgid "Error: multipart/signed has no protocol."
 msgstr "Hata: \"multipart/signed\"e ait bir protokol yok."
 
-#: handler.c:2076
+#: handler.c:2106
 #, fuzzy
 msgid "[-- This is an attachment (use '%3$s' to view this part) --]\n"
 msgstr "[-- Bu bir ek ('%3$s' ile bu bölümü görüntüleyebilirsiniz) --]\n"
 
-#: handler.c:2082
+#: handler.c:2112
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported (use '%s' to view this part) --]\n"
 msgstr "[-- %s/%s desteklenmiyor ('%s' ile bu bölümü görüntüleyebilirsiniz) --]\n"
 
-#: handler.c:2087
+#: handler.c:2117
 #, fuzzy
 msgid "[-- This is an attachment (need 'view-attachments' bound to key!) --]\n"
 msgstr "[-- Bu bir ek ('view-attachments' komutunun bir tuşa atanması gerekiyor!) --]\n"
 
 #. L10N: %s/%s is a MIME type, e.g. "text/plain".
-#: handler.c:2091
+#: handler.c:2121
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported (need 'view-attachments' bound to key!) --]\n"
 msgstr "[-- %s/%s desteklenmiyor ('view-attachments' komutunun bir tuşa atanması gerekiyor!) --]\n"
 
-#: handler.c:2098
+#: handler.c:2128
 #, fuzzy
 msgid "[-- This is an attachment --]\n"
 msgstr "[-- Bu bir ek --]\n"
 
 #. L10N: %s/%s is a MIME type, e.g. "text/plain".
-#: handler.c:2101
+#: handler.c:2131
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported --]\n"
 msgstr "[-- %s/%s desteklenmiyor --]\n"
@@ -2445,7 +2493,7 @@ msgstr ""
 msgid "Invalid IMAP flags"
 msgstr "Geçersiz IMAP eposta bayrakları"
 
-#: imap/message.c:477 mx.c:1326
+#: imap/message.c:477 mx.c:1336
 msgid "Integer overflow -- can't allocate memory."
 msgstr "Tam sayı taşması -- bellek ayrılamıyor."
 
@@ -3211,66 +3259,75 @@ msgstr "SSL erişilir durumda değil."
 msgid "Reading from %s interrupted..."
 msgstr "Arama iptal edildi."
 
-#: mx.c:634
+#. L10N: Although we now the precise number of messages, we do not show it to the user.
+#. So feel free to use a "generic plural" as plural translation if your language has one.
+#.
+#: mx.c:639
 #, fuzzy
-msgid "message(s) not deleted"
-msgstr "%d ileti silinmek için işaretlendi..."
+msgid "message not deleted"
+msgid_plural "messages not deleted"
+msgstr[0] "%d ileti silinmek için işaretlendi..."
+msgstr[1] "%d ileti silinmek için işaretlendi..."
 
-#: mx.c:671
+#: mx.c:676
 #, fuzzy
 msgid "Can't open trash folder"
 msgstr "%s dizinine eklenemiyor"
 
-#: mx.c:710
+#: mx.c:715
 msgid "Mark all articles read?"
 msgstr ""
 
-#: mx.c:754
+#. L10N: The first argument is the number of read messages to be
+#. moved, the second argument is the target mailbox.
+#: mx.c:762
 #, fuzzy, c-format
-msgid "Move %d read messages to %s?"
-msgstr "Okunan iletiler %s eposta kutusuna taşınsın mı?"
+msgid "Move %d read message to %s?"
+msgid_plural "Move %d read messages to %s?"
+msgstr[0] "Okunan iletiler %s eposta kutusuna taşınsın mı?"
+msgstr[1] "Okunan iletiler %s eposta kutusuna taşınsın mı?"
 
-#: mx.c:771 mx.c:1077
+#: mx.c:781 mx.c:1087
 #, fuzzy, c-format
 msgid "Purge %d deleted message?"
 msgid_plural "Purge %d deleted messages?"
 msgstr[0] "Silmek için işaretlenmiş %d ileti silinsin mi?"
 msgstr[1] "Silmek için işaretlenmiş %d ileti silinsin mi?"
 
-#: mx.c:793
+#: mx.c:803
 #, c-format
 msgid "Moving read messages to %s..."
 msgstr "Okunan iletiler %s eposta kutusuna taşınıyor..."
 
-#: mx.c:859 mx.c:1068
+#: mx.c:869 mx.c:1078
 msgid "Mailbox is unchanged."
 msgstr "Eposta kutusunda değişiklik yok."
 
-#: mx.c:914
+#: mx.c:924
 #, c-format
 msgid "%d kept, %d moved, %d deleted."
 msgstr "%d kaldı, %d taşındı, %d silindi."
 
-#: mx.c:917 mx.c:1130
+#: mx.c:927 mx.c:1140
 #, c-format
 msgid "%d kept, %d deleted."
 msgstr "%d kaldı, %d silindi."
 
-#: mx.c:1052
+#: mx.c:1062
 #, c-format
 msgid " Press '%s' to toggle write"
 msgstr " Yazılabilir yapmak için '%s' tuşuna basınız"
 
-#: mx.c:1054
+#: mx.c:1064
 msgid "Use 'toggle-write' to re-enable write!"
 msgstr "'toggle-write' komutunu kullanarak tekrar yazılabilir yapabilirsiniz!"
 
-#: mx.c:1056
+#: mx.c:1066
 #, c-format
 msgid "Mailbox is marked unwritable. %s"
 msgstr "Eposta kutusu yazılamaz yapıldı. %s"
 
-#: mx.c:1124
+#: mx.c:1134
 msgid "Mailbox checkpointed."
 msgstr "Eposta kutusu denetlendi."
 
@@ -3284,54 +3341,59 @@ msgstr " (şu anki tarih: %c)"
 msgid "[-- %s output follows%s --]\n"
 msgstr "[-- %s çıktısı%s --]\n"
 
-#: ncrypt/crypt.c:95
-msgid "Passphrase(s) forgotten."
+#. L10N: Due to the implementation details (e.g. some passwords are managed
+#. by gpg-agent) we cannot know whether we forgot zero, 1, 12, ...
+#. passwords. So in English we use "Passphrases". Your language might
+#. have other means to express this.
+#: ncrypt/crypt.c:100
+#, fuzzy
+msgid "Passphrases forgotten."
 msgstr "PGP parolası/parolaları unutuldu."
 
-#: ncrypt/crypt.c:155
+#: ncrypt/crypt.c:161
 #, fuzzy
 msgid "Inline PGP can't be used with attachments.  Revert to PGP/MIME?"
 msgstr "İleti satıriçi olarak gönderilemiyor.  PGP/MIME kullanımına geri dönülsün mü?"
 
-#: ncrypt/crypt.c:159
+#: ncrypt/crypt.c:165
 msgid "Mail not sent: inline PGP can't be used with attachments."
 msgstr ""
 
-#: ncrypt/crypt.c:166
+#: ncrypt/crypt.c:172
 #, fuzzy
 msgid "Inline PGP can't be used with format=flowed.  Revert to PGP/MIME?"
 msgstr "İleti satıriçi olarak gönderilemiyor.  PGP/MIME kullanımına geri dönülsün mü?"
 
-#: ncrypt/crypt.c:170
+#: ncrypt/crypt.c:176
 msgid "Mail not sent: inline PGP can't be used with format=flowed."
 msgstr ""
 
-#: ncrypt/crypt.c:180 ncrypt/cryptglue.c:125 ncrypt/pgpkey.c:589
+#: ncrypt/crypt.c:186 ncrypt/cryptglue.c:125 ncrypt/pgpkey.c:589
 #: ncrypt/pgpkey.c:782
 msgid "Invoking PGP..."
 msgstr "PGP çağırılıyor..."
 
-#: ncrypt/crypt.c:192
+#: ncrypt/crypt.c:198
 msgid "Message can't be sent inline.  Revert to using PGP/MIME?"
 msgstr "İleti satıriçi olarak gönderilemiyor.  PGP/MIME kullanımına geri dönülsün mü?"
 
-#: ncrypt/crypt.c:194 send.c:1824
+#: ncrypt/crypt.c:200 send.c:1824
 msgid "Mail not sent."
 msgstr "Eposta gönderilmedi."
 
-#: ncrypt/crypt.c:540
+#: ncrypt/crypt.c:546
 msgid "S/MIME messages with no hints on content are unsupported."
 msgstr "İçeriği hakkında hiçbir bilginin bulunmadığı S/MIME iletilerinin gönderilmesi desteklenmiyor."
 
-#: ncrypt/crypt.c:754 ncrypt/crypt.c:795
+#: ncrypt/crypt.c:760 ncrypt/crypt.c:801
 msgid "Trying to extract PGP keys...\n"
 msgstr "PGP anahtarları belirlenmeye çalışılıyor...\n"
 
-#: ncrypt/crypt.c:776 ncrypt/crypt.c:816
+#: ncrypt/crypt.c:782 ncrypt/crypt.c:822
 msgid "Trying to extract S/MIME certificates...\n"
 msgstr "S/MIME sertifikaları belirlenmeye çalışılıyor...\n"
 
-#: ncrypt/crypt.c:976
+#: ncrypt/crypt.c:982
 #, c-format
 msgid ""
 "[-- Error: Unknown multipart/signed protocol %s! --]\n"
@@ -3340,7 +3402,7 @@ msgstr ""
 "[-- Hata: Bilinmeyen \"multipart/signed\" protokolü %s! --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1016
+#: ncrypt/crypt.c:1022
 #, fuzzy
 msgid ""
 "[-- Error: Missing or bad-format multipart/signed signature! --]\n"
@@ -3349,7 +3411,7 @@ msgstr ""
 "[-- Hata: Tutarsız \"multipart/signed\" yapısı! --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1058
+#: ncrypt/crypt.c:1064
 #, c-format
 msgid ""
 "[-- Warning: We can't verify %s/%s signatures. --]\n"
@@ -3358,7 +3420,7 @@ msgstr ""
 "[-- Uyarı: %s/%s imzaları doğrulanamıyor. --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1070
+#: ncrypt/crypt.c:1076
 msgid ""
 "[-- The following data is signed --]\n"
 "\n"
@@ -3366,7 +3428,7 @@ msgstr ""
 "[-- Aşağıdaki bilgi imzalanmıştır --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1075
+#: ncrypt/crypt.c:1081
 msgid ""
 "[-- Warning: Can't find any signatures. --]\n"
 "\n"
@@ -3374,7 +3436,7 @@ msgstr ""
 "[-- Uyarı: Herhangi bir imza bulunamıyor. --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1081
+#: ncrypt/crypt.c:1087
 msgid ""
 "\n"
 "[-- End of signed data --]\n"
@@ -3426,7 +3488,7 @@ msgstr ""
 msgid "error reading data object: %s\n"
 msgstr "veri nesnesi okunurken hata: %s\n"
 
-#: ncrypt/crypt_gpgme.c:662 ncrypt/crypt_gpgme.c:3848 ncrypt/pgpkey.c:585
+#: ncrypt/crypt_gpgme.c:662 ncrypt/crypt_gpgme.c:3850 ncrypt/pgpkey.c:585
 #: ncrypt/pgpkey.c:768
 msgid "Can't create temporary file"
 msgstr "Geçici dosya oluşturulamıyor"
@@ -3782,28 +3844,30 @@ msgstr "[Geçersiz]"
 
 #. L10N: This is printed after "Key Type: " and looks like this:
 #. *       PGP, 2048 bit RSA
-#: ncrypt/crypt_gpgme.c:3670 ncrypt/crypt_gpgme.c:3808
+#: ncrypt/crypt_gpgme.c:3670 ncrypt/crypt_gpgme.c:3810
 #, c-format
 msgid "%s, %lu bit %s\n"
-msgstr ""
+msgid_plural "%s, %lu bit %s\n"
+msgstr[0] ""
+msgstr[1] ""
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3678 ncrypt/crypt_gpgme.c:3815
+#: ncrypt/crypt_gpgme.c:3678 ncrypt/crypt_gpgme.c:3817
 msgid "encryption"
 msgstr "şifreleme"
 
 #: ncrypt/crypt_gpgme.c:3679 ncrypt/crypt_gpgme.c:3685
-#: ncrypt/crypt_gpgme.c:3816 ncrypt/crypt_gpgme.c:3821
+#: ncrypt/crypt_gpgme.c:3818 ncrypt/crypt_gpgme.c:3823
 msgid ", "
 msgstr ", "
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3684 ncrypt/crypt_gpgme.c:3820
+#: ncrypt/crypt_gpgme.c:3684 ncrypt/crypt_gpgme.c:3822
 msgid "signing"
 msgstr "imza"
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3690 ncrypt/crypt_gpgme.c:3825
+#: ncrypt/crypt_gpgme.c:3690 ncrypt/crypt_gpgme.c:3827
 msgid "certification"
 msgstr "sertifikasyon"
 
@@ -3822,65 +3886,65 @@ msgstr "[Süresi Dolmuş]"
 msgid "[Disabled]"
 msgstr "[Etkin Değil]"
 
-#: ncrypt/crypt_gpgme.c:3851
+#: ncrypt/crypt_gpgme.c:3853
 msgid "Collecting data..."
 msgstr "Veri toplanıyor..."
 
-#: ncrypt/crypt_gpgme.c:3876
+#: ncrypt/crypt_gpgme.c:3878
 #, c-format
 msgid "Error finding issuer key: %s\n"
 msgstr "Yayımcının anahtarı bulunamadı: %s\n"
 
-#: ncrypt/crypt_gpgme.c:3885
+#: ncrypt/crypt_gpgme.c:3887
 #, fuzzy
 msgid "Error: certification chain too long - stopping here\n"
 msgstr "Hata: sertifika zinciri çok uzun - burada duruldu\n"
 
-#: ncrypt/crypt_gpgme.c:3895 ncrypt/pgpkey.c:608
+#: ncrypt/crypt_gpgme.c:3897 ncrypt/pgpkey.c:608
 #, c-format
 msgid "Key ID: 0x%s"
 msgstr "Anahtar kimliği: 0x%s"
 
-#: ncrypt/crypt_gpgme.c:3990
+#: ncrypt/crypt_gpgme.c:3992
 #, c-format
 msgid "gpgme_new failed: %s"
 msgstr "gpgme_new başarısız: %s"
 
-#: ncrypt/crypt_gpgme.c:4028 ncrypt/crypt_gpgme.c:4079
+#: ncrypt/crypt_gpgme.c:4030 ncrypt/crypt_gpgme.c:4081
 #, c-format
 msgid "gpgme_op_keylist_start failed: %s"
 msgstr "gpgme_op_keylist_start başarısız: %s"
 
-#: ncrypt/crypt_gpgme.c:4067 ncrypt/crypt_gpgme.c:4109
+#: ncrypt/crypt_gpgme.c:4069 ncrypt/crypt_gpgme.c:4111
 #, c-format
 msgid "gpgme_op_keylist_next failed: %s"
 msgstr "gpgme_op_keylist_next başarısız: %s"
 
-#: ncrypt/crypt_gpgme.c:4185
+#: ncrypt/crypt_gpgme.c:4187
 msgid "All matching keys are marked expired/revoked."
 msgstr "Bulunan bütün anahtarların süresi bitmiş veya hükümsüzleştirilmiş."
 
-#: ncrypt/crypt_gpgme.c:4215 ncrypt/pgpkey.c:543 ncrypt/smime.c:475
+#: ncrypt/crypt_gpgme.c:4217 ncrypt/pgpkey.c:543 ncrypt/smime.c:475
 msgid "Select  "
 msgstr "Seç  "
 
-#: ncrypt/crypt_gpgme.c:4217 ncrypt/pgpkey.c:545
+#: ncrypt/crypt_gpgme.c:4219 ncrypt/pgpkey.c:545
 msgid "Check key  "
 msgstr "Anahtarı denetle  "
 
-#: ncrypt/crypt_gpgme.c:4233
+#: ncrypt/crypt_gpgme.c:4235
 msgid "PGP and S/MIME keys matching"
 msgstr "PGP ve S/MIME anahtarları uyuşuyor"
 
-#: ncrypt/crypt_gpgme.c:4235
+#: ncrypt/crypt_gpgme.c:4237
 msgid "PGP keys matching"
 msgstr "PGP anahtarları uyuşuyor"
 
-#: ncrypt/crypt_gpgme.c:4237
+#: ncrypt/crypt_gpgme.c:4239
 msgid "S/MIME keys matching"
 msgstr "S/MIME anahtarları uyuşuyor"
 
-#: ncrypt/crypt_gpgme.c:4239
+#: ncrypt/crypt_gpgme.c:4241
 msgid "keys matching"
 msgstr "anahtarlar uyuşuyor"
 
@@ -3888,69 +3952,69 @@ msgstr "anahtarlar uyuşuyor"
 #. %1$s is one of the previous four entries.
 #. %2$s is an address.
 #. e.g. "S/MIME keys matching <me@mutt.org>."
-#: ncrypt/crypt_gpgme.c:4246
+#: ncrypt/crypt_gpgme.c:4248
 #, c-format
 msgid "%s <%s>."
 msgstr "%s <%s>."
 
 #. L10N:
 #. e.g. 'S/MIME keys matching "Michael Elkins".'
-#: ncrypt/crypt_gpgme.c:4250
+#: ncrypt/crypt_gpgme.c:4252
 #, c-format
 msgid "%s \"%s\"."
 msgstr "%s \"%s\"."
 
-#: ncrypt/crypt_gpgme.c:4277 ncrypt/pgpkey.c:628
+#: ncrypt/crypt_gpgme.c:4279 ncrypt/pgpkey.c:628
 msgid "This key can't be used: expired/disabled/revoked."
 msgstr "Bu anahtar kullanılamaz: süresi dolmuş/etkin değil/hükümsüz."
 
-#: ncrypt/crypt_gpgme.c:4290 ncrypt/pgpkey.c:640 ncrypt/smime.c:505
+#: ncrypt/crypt_gpgme.c:4292 ncrypt/pgpkey.c:640 ncrypt/smime.c:505
 #, fuzzy
 msgid "ID is expired/disabled/revoked. Do you really want to use the key?"
 msgstr "Kimlik (ID), süresi dolmuş/etkin değil/hükümsüz durumda. Gerçekten bu anahtarı kullanmak istiyor musunuz?"
 
-#: ncrypt/crypt_gpgme.c:4299 ncrypt/pgpkey.c:650
+#: ncrypt/crypt_gpgme.c:4301 ncrypt/pgpkey.c:650
 #, fuzzy
 msgid "ID is not valid. Do you really want to use the key?"
 msgstr "Kimlik (ID) geçerli değil. Gerçekten bu anahtarı kullanmak istiyor musunuz?"
 
-#: ncrypt/crypt_gpgme.c:4302 ncrypt/pgpkey.c:653
+#: ncrypt/crypt_gpgme.c:4304 ncrypt/pgpkey.c:653
 #, fuzzy
 msgid "ID is only marginally valid. Do you really want to use the key?"
 msgstr "Kimlik (ID) çok az güvenilir. Gerçekten bu anahtarı kullanmak istiyor musunuz?"
 
-#: ncrypt/crypt_gpgme.c:4310 ncrypt/pgpkey.c:646 ncrypt/smime.c:509
+#: ncrypt/crypt_gpgme.c:4312 ncrypt/pgpkey.c:646 ncrypt/smime.c:509
 #, fuzzy
 msgid "ID has undefined validity. Do you really want to use the key?"
 msgstr "Kimliğin (ID) geçerliliği belirsiz. Gerçekten bu anahtarı kullanmak istiyor musunuz?"
 
-#: ncrypt/crypt_gpgme.c:4370 ncrypt/crypt_gpgme.c:4479 ncrypt/pgpkey.c:872
+#: ncrypt/crypt_gpgme.c:4372 ncrypt/crypt_gpgme.c:4481 ncrypt/pgpkey.c:872
 #: ncrypt/pgpkey.c:995
 #, c-format
 msgid "Looking for keys matching \"%s\"..."
 msgstr "\"%s\" tabirine uyan anahtarlar aranıyor..."
 
-#: ncrypt/crypt_gpgme.c:4593 ncrypt/pgpkey.c:731 ncrypt/smime.c:811
+#: ncrypt/crypt_gpgme.c:4595 ncrypt/pgpkey.c:731 ncrypt/smime.c:811
 #, c-format
 msgid "No matching keys found for \"%s\""
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4644 ncrypt/pgp.c:1263
+#: ncrypt/crypt_gpgme.c:4646 ncrypt/pgp.c:1263
 #, c-format
 msgid "Use keyID = \"%s\" for %s?"
 msgstr "%2$s için anahtar NO = \"%1$s\" kullanılsın mı?"
 
-#: ncrypt/crypt_gpgme.c:4695 ncrypt/pgp.c:1312 ncrypt/smime.c:830
+#: ncrypt/crypt_gpgme.c:4697 ncrypt/pgp.c:1312 ncrypt/smime.c:830
 #: ncrypt/smime.c:938
 #, c-format
 msgid "Enter keyID for %s: "
 msgstr "%s için anahtar NO'yu girin: "
 
-#: ncrypt/crypt_gpgme.c:4755 ncrypt/pgpkey.c:751
+#: ncrypt/crypt_gpgme.c:4757 ncrypt/pgpkey.c:751
 msgid "Please enter the key ID: "
 msgstr "Lütfen anahtar numarasını girin: "
 
-#: ncrypt/crypt_gpgme.c:4768
+#: ncrypt/crypt_gpgme.c:4770
 #, fuzzy, c-format
 msgid "Error exporting key: %s\n"
 msgstr "Anahtar bilgisi alınırken hata: "
@@ -3959,82 +4023,82 @@ msgstr "Anahtar bilgisi alınırken hata: "
 #. MIME description for exported (attached) keys.
 #. You can translate this entry to a non-ASCII string (it will be encoded),
 #. but it may be safer to keep it untranslated.
-#: ncrypt/crypt_gpgme.c:4787
+#: ncrypt/crypt_gpgme.c:4789
 #, c-format
 msgid "PGP Key 0x%s."
 msgstr "PGP anahtarı 0x%s."
 
-#: ncrypt/crypt_gpgme.c:4830
+#: ncrypt/crypt_gpgme.c:4832
 msgid "GPGME: OpenPGP protocol not available"
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4838
+#: ncrypt/crypt_gpgme.c:4840
 msgid "GPGME: CMS protocol not available"
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4876
+#: ncrypt/crypt_gpgme.c:4878
 #, fuzzy
 msgid "S/MIME (s)ign, sign (a)s, (p)gp, (c)lear, or (o)ppenc mode off? "
 msgstr "S/MIME i(m)zala, (f)arklı imzala, p(g)p, i(p)tal, veya (o)ppenc modu kapalı? "
 
 #. L10N: S/MIME options (opportunistic encryption is on)
-#: ncrypt/crypt_gpgme.c:4878
+#: ncrypt/crypt_gpgme.c:4880
 msgid "sapco"
 msgstr "mfgpo"
 
-#: ncrypt/crypt_gpgme.c:4885
+#: ncrypt/crypt_gpgme.c:4887
 #, fuzzy
 msgid "PGP (s)ign, sign (a)s, s/(m)ime, (c)lear, or (o)ppenc mode off? "
 msgstr "PGP i(m)zala, (f)arklı imzala, (s)/mime, i(p)tal, veya (o)ppenc modu kapalı? "
 
 #. L10N: PGP options (opportunistic encryption is on)
-#: ncrypt/crypt_gpgme.c:4887
+#: ncrypt/crypt_gpgme.c:4889
 msgid "samco"
 msgstr "mfspo"
 
 #. L10N: S/MIME options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4900
+#: ncrypt/crypt_gpgme.c:4902
 msgid "S/MIME (e)ncrypt, (s)ign, sign (a)s, (b)oth, (p)gp, (c)lear, or (o)ppenc mode? "
 msgstr "S/MIME şif(r)ele, i(m)zala, (f)arklı imzala, i(k)isi de, p(g)p, i(p)tal, veya (o)ppenc modu? "
 
 #. L10N: S/MIME options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4903
+#: ncrypt/crypt_gpgme.c:4905
 msgid "esabpco"
 msgstr "rmfkgpo"
 
 #. L10N: PGP options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4909
+#: ncrypt/crypt_gpgme.c:4911
 msgid "PGP (e)ncrypt, (s)ign, sign (a)s, (b)oth, s/(m)ime, (c)lear, or (o)ppenc mode? "
 msgstr "PGP şif(r)ele, i(m)zala, (f)arklı imzala, i(k)isi de, (s)/mime, i(p)tal, veya (o)ppenc modu? "
 
 #. L10N: PGP options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4912
+#: ncrypt/crypt_gpgme.c:4914
 msgid "esabmco"
 msgstr "rmfkspo"
 
-#: ncrypt/crypt_gpgme.c:4925
+#: ncrypt/crypt_gpgme.c:4927
 msgid "S/MIME (e)ncrypt, (s)ign, sign (a)s, (b)oth, (p)gp or (c)lear? "
 msgstr "S/MIME şif(r)ele, i(m)zala, (f)arklı imzala, i(k)isi de, p(g)p, i(p)tal? "
 
 #. L10N: S/MIME options
-#: ncrypt/crypt_gpgme.c:4927
+#: ncrypt/crypt_gpgme.c:4929
 msgid "esabpc"
 msgstr "rmfkgp"
 
-#: ncrypt/crypt_gpgme.c:4934
+#: ncrypt/crypt_gpgme.c:4936
 msgid "PGP (e)ncrypt, (s)ign, sign (a)s, (b)oth, s/(m)ime or (c)lear? "
 msgstr "PGP şif(r)ele, i(m)zala, (f)arklı imzala, i(k)isi de, (s)/mime, i(p)tal? "
 
 #. L10N: PGP options
-#: ncrypt/crypt_gpgme.c:4936
+#: ncrypt/crypt_gpgme.c:4938
 msgid "esabmc"
 msgstr "rmfksp"
 
-#: ncrypt/crypt_gpgme.c:5087
+#: ncrypt/crypt_gpgme.c:5089
 msgid "Failed to verify sender"
 msgstr "Gönderici doğrulanamadı"
 
-#: ncrypt/crypt_gpgme.c:5090
+#: ncrypt/crypt_gpgme.c:5092
 msgid "Failed to figure out sender"
 msgstr "Göndericinin kim olduğu belirlenemedi"
 
@@ -4433,7 +4497,7 @@ msgstr ""
 msgid "%s is an invalid news server specification!"
 msgstr "%s geçerli bir POP dosyayolu değil"
 
-#: nntp.c:75 nntp.c:612 pop.c:1028 pop_lib.c:405
+#: nntp.c:75 nntp.c:612 pop.c:1031 pop_lib.c:405
 msgid "Server closed connection!"
 msgstr "Sunucu bağlantıyı kesti!"
 
@@ -4599,16 +4663,17 @@ msgstr "eposta kutularını yeni eposta için denetle"
 
 #: opcodes.h:47
 #, fuzzy
-msgid "attach file(s) to this message"
+msgid "attach files to this message"
 msgstr "bu iletiye dosya ekle"
 
 #: opcodes.h:48
-msgid "attach message(s) to this message"
+#, fuzzy
+msgid "attach messages to this message"
 msgstr "bu iletiye ileti ekle"
 
 #: opcodes.h:49
 #, fuzzy
-msgid "attach news article(s) to this message"
+msgid "attach news articles to this message"
 msgstr "bu iletiye dosya ekle"
 
 #: opcodes.h:50
@@ -5453,7 +5518,8 @@ msgid "extract supported public keys"
 msgstr "desteklenen genel anahtarları çıkar"
 
 #: opcodes.h:255
-msgid "wipe passphrase(s) from memory"
+#, fuzzy
+msgid "wipe passphrases from memory"
 msgstr "bellekteki parolaları sil"
 
 #: opcodes.h:259
@@ -5800,18 +5866,20 @@ msgstr "POP eposta kutusunda yeni eposta yok."
 msgid "Delete messages from server?"
 msgstr "İletiler sunucudan silinsin mi?"
 
-#: pop.c:954
-#, c-format
-msgid "Reading new messages (%d bytes)..."
-msgstr "Yeni iletiler okunuyor (%d bayt)..."
+#: pop.c:955
+#, fuzzy, c-format
+msgid "Reading new messages (%d byte)..."
+msgid_plural "Reading new messages (%d bytes)..."
+msgstr[0] "Yeni iletiler okunuyor (%d bayt)..."
+msgstr[1] "Yeni iletiler okunuyor (%d bayt)..."
 
-#: pop.c:997
+#: pop.c:1000
 msgid "Error while writing mailbox!"
 msgstr "Eposta kutusuna yazarken hata oluştu!"
 
 #. L10N: The plural is picked by the second numerical argument, i.e.
 #. * the %d right before 'messages', i.e. the total number of messages.
-#: pop.c:1003
+#: pop.c:1006
 #, fuzzy, c-format
 msgid "%s [%d of %d message read]"
 msgid_plural "%s [%d of %d messages read]"
@@ -5956,49 +6024,56 @@ msgstr "Borula: "
 msgid "I don't know how to print %s attachments!"
 msgstr "%s eklerinin nasıl yazdırılacağı bilinmiyor!"
 
-#: recvattach.c:841
-msgid "Print tagged attachment(s)?"
-msgstr "İşaretli ileti(ler) yazdırılsın mı?"
+#. L10N: Although we now the precise number of tagged messages, we
+#. do not show it to the user.  So feel free to use a "generic
+#. plural" as plural translation if your language has one.
+#: recvattach.c:852
+#, fuzzy, c-format
+msgid "Print tagged attachment?"
+msgid_plural "Print %d tagged attachments?"
+msgstr[0] "İşaretli ileti(ler) yazdırılsın mı?"
+msgstr[1] "İşaretli ileti(ler) yazdırılsın mı?"
 
-#: recvattach.c:842
+#: recvattach.c:853
+#, c-format
 msgid "Print attachment?"
 msgstr "Ek yazdırılsın mı?"
 
-#: recvattach.c:900
+#: recvattach.c:913
 msgid "Structural changes to decrypted attachments are not supported"
 msgstr ""
 
-#: recvattach.c:1046
+#: recvattach.c:1059
 msgid "Can't decrypt encrypted message!"
 msgstr "Şifrelenmiş ileti çözülemiyor!"
 
-#: recvattach.c:1172
+#: recvattach.c:1185
 msgid "Attachments"
 msgstr "Ekler"
 
-#: recvattach.c:1210
+#: recvattach.c:1223
 msgid "There are no subparts to show!"
 msgstr "Gösterilecek bir alt bölüm yok!"
 
-#: recvattach.c:1265
+#: recvattach.c:1278
 msgid "Can't delete attachment from POP server."
 msgstr "Ek, POP sunucusundan silinemiyor."
 
-#: recvattach.c:1274
+#: recvattach.c:1287
 #, fuzzy
 msgid "Can't delete attachment from news server."
 msgstr "Ek, POP sunucusundan silinemiyor."
 
-#: recvattach.c:1281
+#: recvattach.c:1294
 msgid "Deletion of attachments from encrypted messages is unsupported."
 msgstr "Şifrelenmiş bir iletiye ait eklerin silinmesi desteklenmiyor."
 
-#: recvattach.c:1287
+#: recvattach.c:1300
 #, fuzzy
 msgid "Deletion of attachments from signed messages may invalidate the signature."
 msgstr "Şifrelenmiş bir iletiye ait eklerin silinmesi desteklenmiyor."
 
-#: recvattach.c:1305 recvattach.c:1320
+#: recvattach.c:1318 recvattach.c:1333
 msgid "Only deletion of multipart attachments is supported."
 msgstr "Sadece çok parçalı (multipart) eklerin silinmesi destekleniyor."
 
@@ -6438,3 +6513,14 @@ msgstr "Varsayılan seçenekler:"
 #: version.c:404
 msgid "Compile options:"
 msgstr "İnşa seçenekleri:"
+
+#, fuzzy
+#~ msgid "Cannot delete message(s)"
+#~ msgstr "İleti(ler) silinemedi"
+
+#~ msgid "Cannot undelete message(s)"
+#~ msgstr "İleti(ler) kurtarılamadı"
+
+#, fuzzy
+#~ msgid "messages not deleted"
+#~ msgstr "%d ileti silinmek için işaretlendi..."

--- a/po/uk.po
+++ b/po/uk.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neomutt-20180512\n"
 "Report-Msgid-Bugs-To: neomutt-devel@neomutt.org\n"
-"POT-Creation-Date: 2018-05-20 02:02+0000\n"
+"POT-Creation-Date: 2018-05-22 14:18+0000\n"
 "PO-Revision-Date: 2017-02-16 21:22+0200\n"
 "Last-Translator: Vsevolod Volkov <vvv@mutt.org.ua>\n"
 "Language-Team: \n"
@@ -41,7 +41,7 @@ msgstr "Вибір"
 
 #: addrbook.c:52 browser.c:75 browser.c:87 compose.c:160 compose.c:172
 #: conn/ssl.c:1041 conn/ssl_gnutls.c:793 curs_main.c:748 curs_main.c:761
-#: history.c:106 ncrypt/crypt_gpgme.c:4219 ncrypt/pgpkey.c:547
+#: history.c:106 ncrypt/crypt_gpgme.c:4221 ncrypt/pgpkey.c:547
 #: ncrypt/smime.c:477 pager.c:2141 postpone.c:65 query.c:72 recvattach.c:70
 msgid "Help"
 msgstr "Допомога"
@@ -692,7 +692,7 @@ msgstr "Безпека: "
 #. * Since it shares the row with "Encrypt with:", it should not be longer
 #. * than 15-20 character cells.
 #.
-#: compose.c:138 ncrypt/crypt_gpgme.c:4947 ncrypt/pgp.c:1786
+#: compose.c:138 ncrypt/crypt_gpgme.c:4949 ncrypt/pgp.c:1786
 #: ncrypt/smime.c:2127
 msgid "Sign as: "
 msgstr "Підпис як: "
@@ -1231,7 +1231,7 @@ msgstr "(r)не приймати, (o)прийняти одноразово, (s)�
 msgid "(r)eject, accept (o)nce"
 msgstr "(r)не приймати, (o)прийняти одноразово"
 
-#: conn/ssl.c:1039 conn/ssl_gnutls.c:791 ncrypt/crypt_gpgme.c:4213
+#: conn/ssl.c:1039 conn/ssl_gnutls.c:791 ncrypt/crypt_gpgme.c:4215
 #: ncrypt/pgpkey.c:541 ncrypt/smime.c:473
 msgid "Exit  "
 msgstr "Вихід  "
@@ -1410,11 +1410,11 @@ msgstr "Немає відкритої поштової скриньки."
 msgid "There are no messages."
 msgstr "Жодного повідомлення немає."
 
-#: curs_main.c:77 mx.c:1061 pager.c:73 recvattach.c:56
+#: curs_main.c:77 mx.c:1071 pager.c:73 recvattach.c:56
 msgid "Mailbox is read-only."
 msgstr "Поштова скринька відкрита тільки для читання"
 
-#: curs_main.c:79 pager.c:75 recvattach.c:1145
+#: curs_main.c:79 pager.c:75 recvattach.c:1158
 msgid "Function not permitted in attach-message mode."
 msgstr "Функцію не дозволено в режимі додавання повідомлення."
 
@@ -1548,244 +1548,254 @@ msgid "That message is not visible."
 msgstr "Цей лист не можна побачити."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:1377 curs_main.c:2772 pager.c:2818
-msgid "Cannot delete message(s)"
+#. L10N: Due to the implementation details we do not know whether we
+#. delete zero, 1, 12, ... messages. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:1381 curs_main.c:2784 pager.c:2822
+#, fuzzy
+msgid "Cannot delete messages"
 msgstr "Неможливо видалити повідомлення"
 
-#: curs_main.c:1380
+#: curs_main.c:1384
 msgid "Delete messages matching: "
 msgstr "Видалити листи за шаблоном: "
 
-#: curs_main.c:1421
+#: curs_main.c:1425
 msgid "No limit pattern is in effect."
 msgstr "Обмеження не встановлено."
 
 #. L10N: ask for a limit to apply
-#: curs_main.c:1426
+#: curs_main.c:1430
 #, c-format
 msgid "Limit: %s"
 msgstr "Обмеження: %s"
 
-#: curs_main.c:1464
+#: curs_main.c:1468
 msgid "Limit to messages matching: "
 msgstr "Обмежитись повідомленнями за шаблоном: "
 
-#: curs_main.c:1488
+#: curs_main.c:1492
 msgid "To view all messages, limit to \"all\"."
 msgstr "Щоб побачити всі повідомлення, встановіть шаблон \"all\"."
 
-#: curs_main.c:1500 pager.c:2318
+#: curs_main.c:1504 pager.c:2318
 msgid "Quit NeoMutt?"
 msgstr "Вийти з NeoMutt?"
 
-#: curs_main.c:1596
+#: curs_main.c:1600
 msgid "Tag messages matching: "
 msgstr "Виділити листи за шаблоном: "
 
 #. L10N: CHECK_ACL
-#: curs_main.c:1606 curs_main.c:3203 pager.c:3137
-msgid "Cannot undelete message(s)"
+#. L10N: Due to the implementation details we do not know whether we
+#. undelete zero, 1, 12, ... messages. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:1614 curs_main.c:3223 pager.c:3145
+#, fuzzy
+msgid "Cannot undelete messages"
 msgstr "Неможливо відновити повідомлення"
 
-#: curs_main.c:1609
+#: curs_main.c:1617
 msgid "Undelete messages matching: "
 msgstr "Відновити листи за шаблоном: "
 
-#: curs_main.c:1619
+#: curs_main.c:1627
 msgid "Untag messages matching: "
 msgstr "Зняти виділення з листів за шаблоном: "
 
-#: curs_main.c:1653
+#: curs_main.c:1661
 msgid "Logged out of IMAP servers."
 msgstr "Закриття з’єднання з сервером IMAP..."
 
-#: curs_main.c:1753
+#: curs_main.c:1761
 #, fuzzy
 msgid "No virtual folder, aborting."
 msgstr "Теми немає, відмінено."
 
-#: curs_main.c:1761
+#: curs_main.c:1769
 msgid "Failed to read thread, aborting."
 msgstr ""
 
-#: curs_main.c:1793 mx.c:1458 mx.c:1475
+#: curs_main.c:1801 mx.c:1468 mx.c:1485
 #, fuzzy
 msgid "Folder doesn't support tagging, aborting."
 msgstr "SMTP-сервер не підтримує аутентифікації"
 
-#: curs_main.c:1808
+#: curs_main.c:1816
 #, fuzzy
 msgid "No tag specified, aborting."
 msgstr "Теми немає, відмінено."
 
-#: curs_main.c:1820
+#: curs_main.c:1828
 #, c-format
 msgid "Update tags..."
 msgstr ""
 
-#: curs_main.c:1857
+#: curs_main.c:1865
 msgid "Failed to modify tags, aborting."
 msgstr ""
 
-#: curs_main.c:1898
+#: curs_main.c:1906
 #, fuzzy
 msgid "No query, aborting."
 msgstr "Теми немає, відмінено."
 
-#: curs_main.c:1902 curs_main.c:1922 curs_main.c:1941
+#: curs_main.c:1910 curs_main.c:1930 curs_main.c:1949
 msgid "Failed to create query, aborting."
 msgstr ""
 
-#: curs_main.c:1911 curs_main.c:1930
+#: curs_main.c:1919 curs_main.c:1938
 msgid "Windowed queries disabled."
 msgstr ""
 
-#: curs_main.c:1916 curs_main.c:1935
+#: curs_main.c:1924 curs_main.c:1943
 msgid "No notmuch vfolder currently loaded."
 msgstr ""
 
-#: curs_main.c:1973
+#: curs_main.c:1981
 msgid "Open mailbox in read-only mode"
 msgstr "Відкрити скриньку лише для читання"
 
-#: curs_main.c:1976
+#: curs_main.c:1984
 #, fuzzy
 msgid "Open virtual folder"
 msgstr "відкрити іншу поштову скриньку"
 
-#: curs_main.c:1979
+#: curs_main.c:1987
 msgid "Open mailbox"
 msgstr "Відкрити скриньку"
 
-#: curs_main.c:1989
+#: curs_main.c:1997
 msgid "No mailboxes have new mail"
 msgstr "Немає поштової скриньки з новою поштою."
 
-#: curs_main.c:2036
+#: curs_main.c:2044
 #, fuzzy
 msgid "Open newsgroup in read-only mode"
 msgstr "Відкрити скриньку лише для читання"
 
-#: curs_main.c:2038
+#: curs_main.c:2046
 msgid "Open newsgroup"
 msgstr ""
 
-#: curs_main.c:2141
+#: curs_main.c:2149
 #, fuzzy
 msgid "Exit NeoMutt without saving?"
 msgstr "Покинути NeoMutt без збереження змін?"
 
-#: curs_main.c:2157
+#: curs_main.c:2165
 #, fuzzy
 msgid "Cannot break thread"
 msgstr "Неможливо з’єднати розмови"
 
-#: curs_main.c:2160 curs_main.c:2198 curs_main.c:2658 curs_main.c:2690
+#: curs_main.c:2168 curs_main.c:2206 curs_main.c:2666 curs_main.c:2698
 #: flags.c:376 thread.c:1078 thread.c:1134 thread.c:1202
 msgid "Threading is not enabled."
 msgstr "Формування розмов не ввімкнено."
 
-#: curs_main.c:2173
+#: curs_main.c:2181
 msgid "Thread broken"
 msgstr "Розмову розурвано"
 
-#: curs_main.c:2185
+#: curs_main.c:2193
 msgid "Thread cannot be broken, message is not part of a thread"
 msgstr "Розмовву неможливо розірвати: повідомлення не є частиною розмови"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2195
+#: curs_main.c:2203
 msgid "Cannot link threads"
 msgstr "Неможливо з’єднати розмови"
 
-#: curs_main.c:2200
+#: curs_main.c:2208
 msgid "No Message-ID: header available to link thread"
 msgstr "Відсутній заголовок Message-ID для об’єднання розмов"
 
-#: curs_main.c:2202
+#: curs_main.c:2210
 msgid "First, please tag a message to be linked here"
 msgstr "Спершу виділіть листи для об’єднання"
 
-#: curs_main.c:2213
+#: curs_main.c:2221
 msgid "Threads linked"
 msgstr "Розмови об’єднано"
 
-#: curs_main.c:2216
+#: curs_main.c:2224
 msgid "No thread linked"
 msgstr "Розмови не об’єднано"
 
-#: curs_main.c:2252 curs_main.c:2278
+#: curs_main.c:2260 curs_main.c:2286
 msgid "You are on the last message."
 msgstr "Це останній лист."
 
-#: curs_main.c:2260 curs_main.c:2305
+#: curs_main.c:2268 curs_main.c:2313
 msgid "No undeleted messages."
 msgstr "Немає відновлених листів."
 
-#: curs_main.c:2297 curs_main.c:2323
+#: curs_main.c:2305 curs_main.c:2331
 msgid "You are on the first message."
 msgstr "Це перший лист."
 
-#: curs_main.c:2395 menu.c:970 pager.c:2440 pattern.c:2110
+#: curs_main.c:2403 menu.c:970 pager.c:2440 pattern.c:2110
 msgid "Search wrapped to top."
 msgstr "Досягнуто кінець. Пошук перенесено на початок."
 
-#: curs_main.c:2404 pager.c:2463 pattern.c:2121
+#: curs_main.c:2412 pager.c:2463 pattern.c:2121
 msgid "Search wrapped to bottom."
 msgstr "Досягнуто початок. Пошук перенесено на кінець."
 
-#: curs_main.c:2447
+#: curs_main.c:2455
 msgid "No new messages in this limited view."
 msgstr "Немає нових листів при цьому перегляді з обмеженням."
 
-#: curs_main.c:2449
+#: curs_main.c:2457
 msgid "No new messages."
 msgstr "Немає нових листів."
 
-#: curs_main.c:2454
+#: curs_main.c:2462
 msgid "No unread messages in this limited view."
 msgstr "Немає нечитаних листів при цьому перегляді з обмеженням."
 
-#: curs_main.c:2456
+#: curs_main.c:2464
 msgid "No unread messages."
 msgstr "Немає нечитаних листів."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2474
+#: curs_main.c:2482
 msgid "Cannot flag message"
 msgstr "Неможливо змінити атрибут листа"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2513 pager.c:3100
+#: curs_main.c:2521 pager.c:3104
 msgid "Cannot toggle new"
 msgstr "Неможливо змінити атрибут \"Нове\""
 
-#: curs_main.c:2590
+#: curs_main.c:2598
 msgid "No more threads."
 msgstr "Розмов більше нема."
 
-#: curs_main.c:2592
+#: curs_main.c:2600
 msgid "You are on the first thread."
 msgstr "Це перша розмова."
 
-#: curs_main.c:2676
+#: curs_main.c:2684
 #, fuzzy
 msgid "Thread contains unread or flagged messages."
 msgstr "Розмова має нечитані листи."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2726 pager.c:2784
+#: curs_main.c:2734 pager.c:2784
 msgid "Cannot delete message"
 msgstr "Неможливо видалити лист"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2838
+#: curs_main.c:2850
 msgid "Cannot edit message"
 msgstr "Неможливо редагувати лист"
 
 #. L10N: This is displayed when the x-label on one or more
 #. * messages is edited.
-#: curs_main.c:2900 pager.c:3200
+#: curs_main.c:2912 pager.c:3208
 #, fuzzy, c-format
 msgid "%d label changed."
 msgid_plural "%d labels changed."
@@ -1796,52 +1806,57 @@ msgstr[2] "Позначки було змінено: %d"
 #. L10N: This is displayed when editing an x-label, but no messages
 #. * were updated.  Possibly due to canceling at the prompt or if the new
 #. * label is the same as the old label.
-#: curs_main.c:2907 pager.c:3204
+#: curs_main.c:2919 pager.c:3212
 msgid "No labels changed."
 msgstr "Жодної позначки не було змінено."
 
 #. L10N: CHECK_ACL
-#: curs_main.c:3006
-msgid "Cannot mark message(s) as read"
+#. L10N: Due to the implementation details we do not know whether we
+#. mark zero, 1, 12, ... messages as read. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:3022
+#, fuzzy
+msgid "Cannot mark messages as read"
 msgstr "Неможливо позначити лист(и) прочитаним(и)"
 
 #. L10N: This is the prompt for <mark-message>.  Whatever they
 #. enter will be prefixed by $mark_macro_prefix and will become
 #. a macro hotkey to jump to the currently selected message.
-#: curs_main.c:3042
+#: curs_main.c:3058
 msgid "Enter macro stroke: "
 msgstr "Введіть макрос листа: "
 
 #. L10N: "message hotkey" is the key bindings menu description of a
 #. macro created by <mark-message>.
-#: curs_main.c:3050
+#: curs_main.c:3066
 msgid "message hotkey"
 msgstr "макрос листа"
 
 #. L10N: This is echoed after <mark-message> creates a new hotkey
 #. macro.  %s is the hotkey string ($mark_macro_prefix followed
 #. by whatever they typed at the prompt.)
-#: curs_main.c:3055
+#: curs_main.c:3071
 #, c-format
 msgid "Message bound to %s."
 msgstr "Лист пов’язаний з %s."
 
 #. L10N: This error is printed if <mark-message> cannot find a
 #. Message-ID for the currently selected message in the index.
-#: curs_main.c:3063
+#: curs_main.c:3079
 msgid "No message ID to macro."
 msgstr "Немає Message-ID для створення макроса."
 
-#: curs_main.c:3105 pager.c:2961 recvattach.c:1388
+#: curs_main.c:3121 pager.c:2965 recvattach.c:1401
 msgid "Reply by mail as poster prefers?"
 msgstr ""
 
-#: curs_main.c:3108 pager.c:2927 pager.c:2939 pager.c:2964
+#: curs_main.c:3124 pager.c:2931 pager.c:2943 pager.c:2968
 msgid "Posting to this group not allowed, may be moderated. Continue?"
 msgstr ""
 
 #. L10N: CHECK_ACL
-#: curs_main.c:3173 pager.c:3120
+#: curs_main.c:3189 pager.c:3124
 msgid "Cannot undelete message"
 msgstr "Неможливо відновити лист"
 
@@ -2032,12 +2047,37 @@ msgstr "[-- Программа переглядання %s повідомила 
 msgid "[-- Error: message/external-body has no access-type parameter --]\n"
 msgstr "[-- Помилка: message/external-body не має параметру типу доступу --]\n"
 
-#: handler.c:1611
+#. L10N: If the translation of this string is a multi line string, then
+#. each line should start with "[-- " and end with " --]".
+#. The first "%s/%s" is a MIME type, e.g. "text/plain". The last %s
+#. expands to a date as returned by `mutt_date_parse_date()`.
+#.
+#. Note: The size argument printed is not the actual number as passed
+#. to gettext but the prettified version, e.g. size = 2048 will be
+#. printed as 2K.  Your language might be sensitive to that: For
+#. example although '1K' and '1024' represent the same number your
+#. language might inflect the noun 'byte' differently.
+#.
+#. Sadly, we cannot do anything about that at the moment besides
+#. passing the precise size in bytes. If you are interested the
+#. function responsible for the prettification is
+#. mutt_str_pretty_size() in mutt/string.c.
+#.
+#: handler.c:1624
 #, fuzzy, c-format
 msgid ""
+"[-- This %s/%s attachment (size %s byte) has been deleted --]\n"
+"[-- on %s --]\n"
+msgid_plural ""
 "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
 "[-- on %s --]\n"
-msgstr ""
+msgstr[0] ""
+"[-- Цей %s/%s додаток (розм. %s байт) було видалено --]\n"
+"[-- %s --]\n"
+msgstr[1] ""
+"[-- Цей %s/%s додаток (розм. %s байт) було видалено --]\n"
+"[-- %s --]\n"
+msgstr[2] ""
 "[-- Цей %s/%s додаток (розм. %s байт) було видалено --]\n"
 "[-- %s --]\n"
 
@@ -2045,10 +2085,24 @@ msgstr ""
 #. each line should start with "[-- " and end with " --]".
 #. The first "%s/%s" is a MIME type, e.g. "text/plain".
 #.
-#: handler.c:1620
+#. Note: The size argument printed is not the actual number as passed
+#. to gettext but the prettified version, e.g. size = 2048 will be
+#. printed as 2K.  Your language might be sensitive to that: For
+#. example although '1K' and '1024' represent the same number your
+#. language might inflect the noun 'byte' differently.
+#.
+#. Sadly, we cannot do anything about that at the moment besides
+#. passing the precise size in bytes. If you are interested the
+#. function responsible for the prettification is
+#. mutt_str_pretty_size() in mutt/string.c.
+#.
+#: handler.c:1648
 #, fuzzy, c-format
-msgid "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
-msgstr "[-- Цей %s/%s додаток (розм. %s байт) було видалено --]\n"
+msgid "[-- This %s/%s attachment (size %s byte) has been deleted --]\n"
+msgid_plural "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
+msgstr[0] "[-- Цей %s/%s додаток (розм. %s байт) було видалено --]\n"
+msgstr[1] "[-- Цей %s/%s додаток (розм. %s байт) було видалено --]\n"
+msgstr[2] "[-- Цей %s/%s додаток (розм. %s байт) було видалено --]\n"
 
 #. L10N: If the translation of this string is a multi line string, then
 #. each line should start with "[-- " and end with " --]".
@@ -2058,7 +2112,7 @@ msgstr "[-- Цей %s/%s додаток (розм. %s байт) було вид�
 #. Caution: Argument three %3$ is also defined but should not be used
 #. in this translation!
 #.
-#: handler.c:1637
+#: handler.c:1667
 #, fuzzy
 msgid ""
 "[-- This %s/%s attachment has been deleted --]\n"
@@ -2071,17 +2125,17 @@ msgstr ""
 #. each line should start with "[-- " and end with " --]".
 #. The first "%s/%s" is a MIME type, e.g. "text/plain".
 #.
-#: handler.c:1646
+#: handler.c:1676
 #, fuzzy, c-format
 msgid "[-- This %s/%s attachment has been deleted --]\n"
 msgstr "[-- Цей %s/%s додаток було видалено --]\n"
 
-#: handler.c:1656
+#: handler.c:1686
 #, c-format
 msgid "[-- name: %s --]\n"
 msgstr "[-- ім’я: %s --]\n"
 
-#: handler.c:1672
+#: handler.c:1702
 #, fuzzy, c-format
 msgid ""
 "[-- This %s/%s attachment is not included, --]\n"
@@ -2091,7 +2145,7 @@ msgstr ""
 "[-- Цей %s/%s додаток не включено, --]\n"
 "[-- і відповідне зовнішнє джерело видалено за давністю. --]\n"
 
-#: handler.c:1693
+#: handler.c:1723
 #, fuzzy, c-format
 msgid ""
 "[-- This %s/%s attachment is not included, --]\n"
@@ -2100,51 +2154,51 @@ msgstr ""
 "[-- Цей %s/%s додаток не включено, --]\n"
 "[-- відповідний тип доступу %s не підтримується --]\n"
 
-#: handler.c:1822
+#: handler.c:1852
 #, fuzzy
 msgid "Unable to open memory stream!"
 msgstr "Неможливо відкрити тимчасовий файл!"
 
-#: handler.c:1831
+#: handler.c:1861
 msgid "Unable to open temporary file!"
 msgstr "Неможливо відкрити тимчасовий файл!"
 
-#: handler.c:1881
+#: handler.c:1911
 msgid "failed to re-open memstream!"
 msgstr ""
 
-#: handler.c:2013
+#: handler.c:2043
 msgid "Error: multipart/signed has no protocol."
 msgstr "Помилка: немає протоколу для multipart/signed."
 
-#: handler.c:2076
+#: handler.c:2106
 #, fuzzy
 msgid "[-- This is an attachment (use '%3$s' to view this part) --]\n"
 msgstr "[-- Це додаток (використовуйте \"%3$s\" для перегляду цієї частини) --]\n"
 
-#: handler.c:2082
+#: handler.c:2112
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported (use '%s' to view this part) --]\n"
 msgstr "[-- %s/%s не підтримується (використовуйте \"%s\" для перегляду цієї частини) --]\n"
 
-#: handler.c:2087
+#: handler.c:2117
 #, fuzzy
 msgid "[-- This is an attachment (need 'view-attachments' bound to key!) --]\n"
 msgstr "[-- Це додаток (треба призначити клавішу до view-attachments!) --]\n"
 
 #. L10N: %s/%s is a MIME type, e.g. "text/plain".
-#: handler.c:2091
+#: handler.c:2121
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported (need 'view-attachments' bound to key!) --]\n"
 msgstr "[-- %s/%s не підтримується (треба призначити клавішу до view-attachments!) --]\n"
 
-#: handler.c:2098
+#: handler.c:2128
 #, fuzzy
 msgid "[-- This is an attachment --]\n"
 msgstr "[-- Це додаток --]\n"
 
 #. L10N: %s/%s is a MIME type, e.g. "text/plain".
-#: handler.c:2101
+#: handler.c:2131
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported --]\n"
 msgstr "[-- %s/%s не підтримується --]\n"
@@ -2453,7 +2507,7 @@ msgstr "SMTP-сервер не підтримує аутентифікації"
 msgid "Invalid IMAP flags"
 msgstr "Неправ.   "
 
-#: imap/message.c:477 mx.c:1326
+#: imap/message.c:477 mx.c:1336
 msgid "Integer overflow -- can't allocate memory."
 msgstr "Переповнення цілого значення -- неможливо виділити пам’ять!"
 
@@ -3217,24 +3271,36 @@ msgstr "SSL недоступний."
 msgid "Reading from %s interrupted..."
 msgstr "Пошук перервано."
 
-#: mx.c:634
-msgid "message(s) not deleted"
-msgstr "повідомлення не видалені"
+#. L10N: Although we now the precise number of messages, we do not show it to the user.
+#. So feel free to use a "generic plural" as plural translation if your language has one.
+#.
+#: mx.c:639
+#, fuzzy
+msgid "message not deleted"
+msgid_plural "messages not deleted"
+msgstr[0] "повідомлення не видалені"
+msgstr[1] "повідомлення не видалені"
+msgstr[2] "повідомлення не видалені"
 
-#: mx.c:671
+#: mx.c:676
 msgid "Can't open trash folder"
 msgstr "Не вдалось відкрити кошик"
 
-#: mx.c:710
+#: mx.c:715
 msgid "Mark all articles read?"
 msgstr ""
 
-#: mx.c:754
+#. L10N: The first argument is the number of read messages to be
+#. moved, the second argument is the target mailbox.
+#: mx.c:762
 #, fuzzy, c-format
-msgid "Move %d read messages to %s?"
-msgstr "Перенести прочитані листи до %s?"
+msgid "Move %d read message to %s?"
+msgid_plural "Move %d read messages to %s?"
+msgstr[0] "Перенести прочитані листи до %s?"
+msgstr[1] "Перенести прочитані листи до %s?"
+msgstr[2] "Перенести прочитані листи до %s?"
 
-#: mx.c:771 mx.c:1077
+#: mx.c:781 mx.c:1087
 #, fuzzy, c-format
 msgid "Purge %d deleted message?"
 msgid_plural "Purge %d deleted messages?"
@@ -3242,40 +3308,40 @@ msgstr[0] "Знищити %d видалений листі?"
 msgstr[1] "Знищити %d видалених листів?"
 msgstr[2] "Знищити %d видалених листів?"
 
-#: mx.c:793
+#: mx.c:803
 #, c-format
 msgid "Moving read messages to %s..."
 msgstr "Перенос прочитаних листів до %s..."
 
-#: mx.c:859 mx.c:1068
+#: mx.c:869 mx.c:1078
 msgid "Mailbox is unchanged."
 msgstr "Поштову скриньку не змінено."
 
-#: mx.c:914
+#: mx.c:924
 #, c-format
 msgid "%d kept, %d moved, %d deleted."
 msgstr "%d збережено, %d перенесено, %d знищено."
 
-#: mx.c:917 mx.c:1130
+#: mx.c:927 mx.c:1140
 #, c-format
 msgid "%d kept, %d deleted."
 msgstr "%d збережено, %d знищено."
 
-#: mx.c:1052
+#: mx.c:1062
 #, c-format
 msgid " Press '%s' to toggle write"
 msgstr "Натисніть \"%s\" для зміни можливості запису"
 
-#: mx.c:1054
+#: mx.c:1064
 msgid "Use 'toggle-write' to re-enable write!"
 msgstr "Використовуйте toggle-write для ввімкнення запису!"
 
-#: mx.c:1056
+#: mx.c:1066
 #, c-format
 msgid "Mailbox is marked unwritable. %s"
 msgstr "Скриньку помічено незмінюваною. %s"
 
-#: mx.c:1124
+#: mx.c:1134
 msgid "Mailbox checkpointed."
 msgstr "Поштову скриньку перевірено."
 
@@ -3289,54 +3355,59 @@ msgstr " (поточний час: %c)"
 msgid "[-- %s output follows%s --]\n"
 msgstr "[-- Результат роботи %s%s --]\n"
 
-#: ncrypt/crypt.c:95
-msgid "Passphrase(s) forgotten."
+#. L10N: Due to the implementation details (e.g. some passwords are managed
+#. by gpg-agent) we cannot know whether we forgot zero, 1, 12, ...
+#. passwords. So in English we use "Passphrases". Your language might
+#. have other means to express this.
+#: ncrypt/crypt.c:100
+#, fuzzy
+msgid "Passphrases forgotten."
 msgstr "Паролі видалено з пам’яті."
 
-#: ncrypt/crypt.c:155
+#: ncrypt/crypt.c:161
 msgid "Inline PGP can't be used with attachments.  Revert to PGP/MIME?"
 msgstr "Неможливо використовувати PGP/текст з додатками. Використати PGP/MIME?"
 
-#: ncrypt/crypt.c:159
+#: ncrypt/crypt.c:165
 msgid "Mail not sent: inline PGP can't be used with attachments."
 msgstr "Лист не відправлено: неможливо використовувати PGP/текст з додатками."
 
-#: ncrypt/crypt.c:166
+#: ncrypt/crypt.c:172
 #, fuzzy
 msgid "Inline PGP can't be used with format=flowed.  Revert to PGP/MIME?"
 msgstr "Неможливо використовувати PGP/текст з додатками. Використати PGP/MIME?"
 
-#: ncrypt/crypt.c:170
+#: ncrypt/crypt.c:176
 #, fuzzy
 msgid "Mail not sent: inline PGP can't be used with format=flowed."
 msgstr "Лист не відправлено: неможливо використовувати PGP/текст з додатками."
 
-#: ncrypt/crypt.c:180 ncrypt/cryptglue.c:125 ncrypt/pgpkey.c:589
+#: ncrypt/crypt.c:186 ncrypt/cryptglue.c:125 ncrypt/pgpkey.c:589
 #: ncrypt/pgpkey.c:782
 msgid "Invoking PGP..."
 msgstr "Виклик PGP..."
 
-#: ncrypt/crypt.c:192
+#: ncrypt/crypt.c:198
 msgid "Message can't be sent inline.  Revert to using PGP/MIME?"
 msgstr "Повідомлення не може бути відправленим в текстовому форматі. Використовувати PGP/MIME?"
 
-#: ncrypt/crypt.c:194 send.c:1824
+#: ncrypt/crypt.c:200 send.c:1824
 msgid "Mail not sent."
 msgstr "Лист не відправлено."
 
-#: ncrypt/crypt.c:540
+#: ncrypt/crypt.c:546
 msgid "S/MIME messages with no hints on content are unsupported."
 msgstr "Повідомлення S/MIME без вказазування типу даних не підтрмується."
 
-#: ncrypt/crypt.c:754 ncrypt/crypt.c:795
+#: ncrypt/crypt.c:760 ncrypt/crypt.c:801
 msgid "Trying to extract PGP keys...\n"
 msgstr "Спроба видобування ключів PGP...\n"
 
-#: ncrypt/crypt.c:776 ncrypt/crypt.c:816
+#: ncrypt/crypt.c:782 ncrypt/crypt.c:822
 msgid "Trying to extract S/MIME certificates...\n"
 msgstr "Спроба видобування сертифікатів S/MIME...\n"
 
-#: ncrypt/crypt.c:976
+#: ncrypt/crypt.c:982
 #, c-format
 msgid ""
 "[-- Error: Unknown multipart/signed protocol %s! --]\n"
@@ -3345,7 +3416,7 @@ msgstr ""
 "[-- Помилка: невідомий протокол multipart/signed %s! --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1016
+#: ncrypt/crypt.c:1022
 #, fuzzy
 msgid ""
 "[-- Error: Missing or bad-format multipart/signed signature! --]\n"
@@ -3354,7 +3425,7 @@ msgstr ""
 "[-- Помилка: несумісна структура multipart/signed! --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1058
+#: ncrypt/crypt.c:1064
 #, c-format
 msgid ""
 "[-- Warning: We can't verify %s/%s signatures. --]\n"
@@ -3363,7 +3434,7 @@ msgstr ""
 "[-- Попередження: неможливо перевірити %s/%s підписи. --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1070
+#: ncrypt/crypt.c:1076
 msgid ""
 "[-- The following data is signed --]\n"
 "\n"
@@ -3371,7 +3442,7 @@ msgstr ""
 "[-- Наступні дані підписано --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1075
+#: ncrypt/crypt.c:1081
 msgid ""
 "[-- Warning: Can't find any signatures. --]\n"
 "\n"
@@ -3379,7 +3450,7 @@ msgstr ""
 "[-- Попередження: неможливо знайти жодного підпису. --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1081
+#: ncrypt/crypt.c:1087
 msgid ""
 "\n"
 "[-- End of signed data --]\n"
@@ -3430,7 +3501,7 @@ msgstr ""
 msgid "error reading data object: %s\n"
 msgstr "помилка читання об’єкту даних: %s\n"
 
-#: ncrypt/crypt_gpgme.c:662 ncrypt/crypt_gpgme.c:3848 ncrypt/pgpkey.c:585
+#: ncrypt/crypt_gpgme.c:662 ncrypt/crypt_gpgme.c:3850 ncrypt/pgpkey.c:585
 #: ncrypt/pgpkey.c:768
 msgid "Can't create temporary file"
 msgstr "Неможливо створити тимчасовий файл"
@@ -3776,28 +3847,31 @@ msgstr "[Неправильно]"
 
 #. L10N: This is printed after "Key Type: " and looks like this:
 #. *       PGP, 2048 bit RSA
-#: ncrypt/crypt_gpgme.c:3670 ncrypt/crypt_gpgme.c:3808
-#, c-format
+#: ncrypt/crypt_gpgme.c:3670 ncrypt/crypt_gpgme.c:3810
+#, fuzzy, c-format
 msgid "%s, %lu bit %s\n"
-msgstr "%s, %lu біт %s\n"
+msgid_plural "%s, %lu bit %s\n"
+msgstr[0] "%s, %lu біт %s\n"
+msgstr[1] "%s, %lu біт %s\n"
+msgstr[2] "%s, %lu біт %s\n"
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3678 ncrypt/crypt_gpgme.c:3815
+#: ncrypt/crypt_gpgme.c:3678 ncrypt/crypt_gpgme.c:3817
 msgid "encryption"
 msgstr "шифрування"
 
 #: ncrypt/crypt_gpgme.c:3679 ncrypt/crypt_gpgme.c:3685
-#: ncrypt/crypt_gpgme.c:3816 ncrypt/crypt_gpgme.c:3821
+#: ncrypt/crypt_gpgme.c:3818 ncrypt/crypt_gpgme.c:3823
 msgid ", "
 msgstr ", "
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3684 ncrypt/crypt_gpgme.c:3820
+#: ncrypt/crypt_gpgme.c:3684 ncrypt/crypt_gpgme.c:3822
 msgid "signing"
 msgstr "підписування"
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3690 ncrypt/crypt_gpgme.c:3825
+#: ncrypt/crypt_gpgme.c:3690 ncrypt/crypt_gpgme.c:3827
 msgid "certification"
 msgstr "сертифікація"
 
@@ -3816,64 +3890,64 @@ msgstr "[Прострочено]"
 msgid "[Disabled]"
 msgstr "[Заборонено]"
 
-#: ncrypt/crypt_gpgme.c:3851
+#: ncrypt/crypt_gpgme.c:3853
 msgid "Collecting data..."
 msgstr "Збирання даних..."
 
-#: ncrypt/crypt_gpgme.c:3876
+#: ncrypt/crypt_gpgme.c:3878
 #, c-format
 msgid "Error finding issuer key: %s\n"
 msgstr "Помилка пошуку ключа видавця: %s\n"
 
-#: ncrypt/crypt_gpgme.c:3885
+#: ncrypt/crypt_gpgme.c:3887
 msgid "Error: certification chain too long - stopping here\n"
 msgstr "Помилка: ланцюжок сертифікації задовгий, зупиняємось\n"
 
-#: ncrypt/crypt_gpgme.c:3895 ncrypt/pgpkey.c:608
+#: ncrypt/crypt_gpgme.c:3897 ncrypt/pgpkey.c:608
 #, c-format
 msgid "Key ID: 0x%s"
 msgstr "ID ключа: 0x%s"
 
-#: ncrypt/crypt_gpgme.c:3990
+#: ncrypt/crypt_gpgme.c:3992
 #, c-format
 msgid "gpgme_new failed: %s"
 msgstr "Помилка gpgme_new: %s"
 
-#: ncrypt/crypt_gpgme.c:4028 ncrypt/crypt_gpgme.c:4079
+#: ncrypt/crypt_gpgme.c:4030 ncrypt/crypt_gpgme.c:4081
 #, c-format
 msgid "gpgme_op_keylist_start failed: %s"
 msgstr "помилка gpgme_op_keylist_start: %s"
 
-#: ncrypt/crypt_gpgme.c:4067 ncrypt/crypt_gpgme.c:4109
+#: ncrypt/crypt_gpgme.c:4069 ncrypt/crypt_gpgme.c:4111
 #, c-format
 msgid "gpgme_op_keylist_next failed: %s"
 msgstr "помилка gpgme_op_keylist_next: %s"
 
-#: ncrypt/crypt_gpgme.c:4185
+#: ncrypt/crypt_gpgme.c:4187
 msgid "All matching keys are marked expired/revoked."
 msgstr "Всі відповідні ключі відмічено як застарілі чи відкликані."
 
-#: ncrypt/crypt_gpgme.c:4215 ncrypt/pgpkey.c:543 ncrypt/smime.c:475
+#: ncrypt/crypt_gpgme.c:4217 ncrypt/pgpkey.c:543 ncrypt/smime.c:475
 msgid "Select  "
 msgstr "Вибір  "
 
-#: ncrypt/crypt_gpgme.c:4217 ncrypt/pgpkey.c:545
+#: ncrypt/crypt_gpgme.c:4219 ncrypt/pgpkey.c:545
 msgid "Check key  "
 msgstr "Перевірка ключа  "
 
-#: ncrypt/crypt_gpgme.c:4233
+#: ncrypt/crypt_gpgme.c:4235
 msgid "PGP and S/MIME keys matching"
 msgstr "Відповідні PGP і S/MIME ключі"
 
-#: ncrypt/crypt_gpgme.c:4235
+#: ncrypt/crypt_gpgme.c:4237
 msgid "PGP keys matching"
 msgstr "Відповідні PGP ключі"
 
-#: ncrypt/crypt_gpgme.c:4237
+#: ncrypt/crypt_gpgme.c:4239
 msgid "S/MIME keys matching"
 msgstr "Відповідні S/MIME ключі"
 
-#: ncrypt/crypt_gpgme.c:4239
+#: ncrypt/crypt_gpgme.c:4241
 msgid "keys matching"
 msgstr "Відповідні ключі"
 
@@ -3881,69 +3955,69 @@ msgstr "Відповідні ключі"
 #. %1$s is one of the previous four entries.
 #. %2$s is an address.
 #. e.g. "S/MIME keys matching <me@mutt.org>."
-#: ncrypt/crypt_gpgme.c:4246
+#: ncrypt/crypt_gpgme.c:4248
 #, c-format
 msgid "%s <%s>."
 msgstr "%s <%s>."
 
 #. L10N:
 #. e.g. 'S/MIME keys matching "Michael Elkins".'
-#: ncrypt/crypt_gpgme.c:4250
+#: ncrypt/crypt_gpgme.c:4252
 #, c-format
 msgid "%s \"%s\"."
 msgstr "%s \"%s\"."
 
-#: ncrypt/crypt_gpgme.c:4277 ncrypt/pgpkey.c:628
+#: ncrypt/crypt_gpgme.c:4279 ncrypt/pgpkey.c:628
 msgid "This key can't be used: expired/disabled/revoked."
 msgstr "Цей ключ неможливо використати: прострочений, заборонений чи відкликаний."
 
-#: ncrypt/crypt_gpgme.c:4290 ncrypt/pgpkey.c:640 ncrypt/smime.c:505
+#: ncrypt/crypt_gpgme.c:4292 ncrypt/pgpkey.c:640 ncrypt/smime.c:505
 #, fuzzy
 msgid "ID is expired/disabled/revoked. Do you really want to use the key?"
 msgstr "ID прострочений, заборонений чи відкликаний. Ви справді бажаєте використовувати ключ?"
 
-#: ncrypt/crypt_gpgme.c:4299 ncrypt/pgpkey.c:650
+#: ncrypt/crypt_gpgme.c:4301 ncrypt/pgpkey.c:650
 #, fuzzy
 msgid "ID is not valid. Do you really want to use the key?"
 msgstr "ID недійсний. Ви справді бажаєте використовувати ключ?"
 
-#: ncrypt/crypt_gpgme.c:4302 ncrypt/pgpkey.c:653
+#: ncrypt/crypt_gpgme.c:4304 ncrypt/pgpkey.c:653
 #, fuzzy
 msgid "ID is only marginally valid. Do you really want to use the key?"
 msgstr "ID дійсний лише частково. Ви справді бажаєте використовувати ключ?"
 
-#: ncrypt/crypt_gpgme.c:4310 ncrypt/pgpkey.c:646 ncrypt/smime.c:509
+#: ncrypt/crypt_gpgme.c:4312 ncrypt/pgpkey.c:646 ncrypt/smime.c:509
 #, fuzzy
 msgid "ID has undefined validity. Do you really want to use the key?"
 msgstr "Ступінь довіри для ID не визначена. Ви справді бажаєте використовувати ключ?"
 
-#: ncrypt/crypt_gpgme.c:4370 ncrypt/crypt_gpgme.c:4479 ncrypt/pgpkey.c:872
+#: ncrypt/crypt_gpgme.c:4372 ncrypt/crypt_gpgme.c:4481 ncrypt/pgpkey.c:872
 #: ncrypt/pgpkey.c:995
 #, c-format
 msgid "Looking for keys matching \"%s\"..."
 msgstr "Пошук відповідних ключів \"%s\"..."
 
-#: ncrypt/crypt_gpgme.c:4593 ncrypt/pgpkey.c:731 ncrypt/smime.c:811
+#: ncrypt/crypt_gpgme.c:4595 ncrypt/pgpkey.c:731 ncrypt/smime.c:811
 #, c-format
 msgid "No matching keys found for \"%s\""
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4644 ncrypt/pgp.c:1263
+#: ncrypt/crypt_gpgme.c:4646 ncrypt/pgp.c:1263
 #, c-format
 msgid "Use keyID = \"%s\" for %s?"
 msgstr "Використовувати keyID = \"%s\" для %s?"
 
-#: ncrypt/crypt_gpgme.c:4695 ncrypt/pgp.c:1312 ncrypt/smime.c:830
+#: ncrypt/crypt_gpgme.c:4697 ncrypt/pgp.c:1312 ncrypt/smime.c:830
 #: ncrypt/smime.c:938
 #, c-format
 msgid "Enter keyID for %s: "
 msgstr "Введіть keyID для %s: "
 
-#: ncrypt/crypt_gpgme.c:4755 ncrypt/pgpkey.c:751
+#: ncrypt/crypt_gpgme.c:4757 ncrypt/pgpkey.c:751
 msgid "Please enter the key ID: "
 msgstr "Будь ласка, введіть ID ключа: "
 
-#: ncrypt/crypt_gpgme.c:4768
+#: ncrypt/crypt_gpgme.c:4770
 #, c-format
 msgid "Error exporting key: %s\n"
 msgstr "Помилка експорта ключа: %s\n"
@@ -3952,84 +4026,84 @@ msgstr "Помилка експорта ключа: %s\n"
 #. MIME description for exported (attached) keys.
 #. You can translate this entry to a non-ASCII string (it will be encoded),
 #. but it may be safer to keep it untranslated.
-#: ncrypt/crypt_gpgme.c:4787
+#: ncrypt/crypt_gpgme.c:4789
 #, c-format
 msgid "PGP Key 0x%s."
 msgstr "Ключ PGP 0x%s."
 
-#: ncrypt/crypt_gpgme.c:4830
+#: ncrypt/crypt_gpgme.c:4832
 msgid "GPGME: OpenPGP protocol not available"
 msgstr "GPGME: протокол OpenPGP не доступний"
 
-#: ncrypt/crypt_gpgme.c:4838
+#: ncrypt/crypt_gpgme.c:4840
 msgid "GPGME: CMS protocol not available"
 msgstr "GPGME: протокол CMS не доступний"
 
-#: ncrypt/crypt_gpgme.c:4876
+#: ncrypt/crypt_gpgme.c:4878
 msgid "S/MIME (s)ign, sign (a)s, (p)gp, (c)lear, or (o)ppenc mode off? "
 msgstr "S/MIME (s)підп., (a)підп. як, (p)gp, (c)відміна, вимкнути (o)ppenc? "
 
 #. L10N: S/MIME options (opportunistic encryption is on)
-#: ncrypt/crypt_gpgme.c:4878
+#: ncrypt/crypt_gpgme.c:4880
 msgid "sapco"
 msgstr "sapco"
 
-#: ncrypt/crypt_gpgme.c:4885
+#: ncrypt/crypt_gpgme.c:4887
 msgid "PGP (s)ign, sign (a)s, s/(m)ime, (c)lear, or (o)ppenc mode off? "
 msgstr "PGP (s)підп., (a)підп. як, s/(m)ime, (c)відміна, вимкнути (o)ppenc? "
 
 #. L10N: PGP options (opportunistic encryption is on)
-#: ncrypt/crypt_gpgme.c:4887
+#: ncrypt/crypt_gpgme.c:4889
 msgid "samco"
 msgstr "samco"
 
 #. L10N: S/MIME options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4900
+#: ncrypt/crypt_gpgme.c:4902
 msgid "S/MIME (e)ncrypt, (s)ign, sign (a)s, (b)oth, (p)gp, (c)lear, or (o)ppenc mode? "
 msgstr "S/MIME (e)шифр, (s)підп, (a)підп. як, (b)усе, (p)gp, (c)відм, вимк. (o)ppenc? "
 
 #. L10N: S/MIME options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4903
+#: ncrypt/crypt_gpgme.c:4905
 #, fuzzy
 msgid "esabpco"
 msgstr "esabpco"
 
 #. L10N: PGP options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4909
+#: ncrypt/crypt_gpgme.c:4911
 msgid "PGP (e)ncrypt, (s)ign, sign (a)s, (b)oth, s/(m)ime, (c)lear, or (o)ppenc mode? "
 msgstr "PGP (e)шифр, (s)підп, (a)підп. як, (b)усе, s/(m)ime, (c)відм, вимк. (o)ppenc? "
 
 #. L10N: PGP options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4912
+#: ncrypt/crypt_gpgme.c:4914
 #, fuzzy
 msgid "esabmco"
 msgstr "esabmco"
 
-#: ncrypt/crypt_gpgme.c:4925
+#: ncrypt/crypt_gpgme.c:4927
 msgid "S/MIME (e)ncrypt, (s)ign, sign (a)s, (b)oth, (p)gp or (c)lear? "
 msgstr "S/MIME (e)шифр., (s)підп., (a)підп. як, (b)усе, (p)gp, (c)відміна? "
 
 #. L10N: S/MIME options
-#: ncrypt/crypt_gpgme.c:4927
+#: ncrypt/crypt_gpgme.c:4929
 #, fuzzy
 msgid "esabpc"
 msgstr "esabpc"
 
-#: ncrypt/crypt_gpgme.c:4934
+#: ncrypt/crypt_gpgme.c:4936
 msgid "PGP (e)ncrypt, (s)ign, sign (a)s, (b)oth, s/(m)ime or (c)lear? "
 msgstr "PGP (e)шифр., (s)підп., (a)підп. як, (b)усе, s/(m)ime, (c)відміна? "
 
 #. L10N: PGP options
-#: ncrypt/crypt_gpgme.c:4936
+#: ncrypt/crypt_gpgme.c:4938
 #, fuzzy
 msgid "esabmc"
 msgstr "esabmc"
 
-#: ncrypt/crypt_gpgme.c:5087
+#: ncrypt/crypt_gpgme.c:5089
 msgid "Failed to verify sender"
 msgstr "Відправника не перевірено"
 
-#: ncrypt/crypt_gpgme.c:5090
+#: ncrypt/crypt_gpgme.c:5092
 msgid "Failed to figure out sender"
 msgstr "Відправника не вирахувано"
 
@@ -4424,7 +4498,7 @@ msgstr ""
 msgid "%s is an invalid news server specification!"
 msgstr "%s - неприпустимий шлях POP"
 
-#: nntp.c:75 nntp.c:612 pop.c:1028 pop_lib.c:405
+#: nntp.c:75 nntp.c:612 pop.c:1031 pop_lib.c:405
 msgid "Server closed connection!"
 msgstr "Сервер закрив з’єднання!"
 
@@ -4590,16 +4664,18 @@ msgid "check mailboxes for new mail"
 msgstr "перевірити наявність нової пошти у скриньках"
 
 #: opcodes.h:47
-msgid "attach file(s) to this message"
+#, fuzzy
+msgid "attach files to this message"
 msgstr "приєднати файл(и) до цього листа"
 
 #: opcodes.h:48
-msgid "attach message(s) to this message"
+#, fuzzy
+msgid "attach messages to this message"
 msgstr "приєднати лист(и) до цього листа"
 
 #: opcodes.h:49
 #, fuzzy
-msgid "attach news article(s) to this message"
+msgid "attach news articles to this message"
 msgstr "приєднати файл(и) до цього листа"
 
 #: opcodes.h:50
@@ -5440,7 +5516,8 @@ msgid "extract supported public keys"
 msgstr "розпакувати підтримувані відкриті ключі"
 
 #: opcodes.h:255
-msgid "wipe passphrase(s) from memory"
+#, fuzzy
+msgid "wipe passphrases from memory"
 msgstr "знищити паролі у пам’яті"
 
 #: opcodes.h:259
@@ -5778,18 +5855,21 @@ msgstr "В поштовій скриньці POP немає нових лист�
 msgid "Delete messages from server?"
 msgstr "Видалити повідомлення з серверу?"
 
-#: pop.c:954
-#, c-format
-msgid "Reading new messages (%d bytes)..."
-msgstr "Читання нових повідомлень (%d байт)..."
+#: pop.c:955
+#, fuzzy, c-format
+msgid "Reading new messages (%d byte)..."
+msgid_plural "Reading new messages (%d bytes)..."
+msgstr[0] "Читання нових повідомлень (%d байт)..."
+msgstr[1] "Читання нових повідомлень (%d байт)..."
+msgstr[2] "Читання нових повідомлень (%d байт)..."
 
-#: pop.c:997
+#: pop.c:1000
 msgid "Error while writing mailbox!"
 msgstr "Помилка під час запису поштової скриньки!"
 
 #. L10N: The plural is picked by the second numerical argument, i.e.
 #. * the %d right before 'messages', i.e. the total number of messages.
-#: pop.c:1003
+#: pop.c:1006
 #, fuzzy, c-format
 msgid "%s [%d of %d message read]"
 msgid_plural "%s [%d of %d messages read]"
@@ -5934,48 +6014,56 @@ msgstr "Передати команді: "
 msgid "I don't know how to print %s attachments!"
 msgstr "Невідомо, як друкувати додатки типу %s!"
 
-#: recvattach.c:841
-msgid "Print tagged attachment(s)?"
-msgstr "Друкувати виділені додатки?"
+#. L10N: Although we now the precise number of tagged messages, we
+#. do not show it to the user.  So feel free to use a "generic
+#. plural" as plural translation if your language has one.
+#: recvattach.c:852
+#, fuzzy, c-format
+msgid "Print tagged attachment?"
+msgid_plural "Print %d tagged attachments?"
+msgstr[0] "Друкувати виділені додатки?"
+msgstr[1] "Друкувати виділені додатки?"
+msgstr[2] "Друкувати виділені додатки?"
 
-#: recvattach.c:842
+#: recvattach.c:853
+#, c-format
 msgid "Print attachment?"
 msgstr "Друкувати додаток?"
 
-#: recvattach.c:900
+#: recvattach.c:913
 msgid "Structural changes to decrypted attachments are not supported"
 msgstr "Змінення структури розшифрованих додатків не підтримується"
 
-#: recvattach.c:1046
+#: recvattach.c:1059
 msgid "Can't decrypt encrypted message!"
 msgstr "Не можу розшифрувати листа!"
 
-#: recvattach.c:1172
+#: recvattach.c:1185
 msgid "Attachments"
 msgstr "Додатки"
 
-#: recvattach.c:1210
+#: recvattach.c:1223
 msgid "There are no subparts to show!"
 msgstr "Немає підчастин для проглядання!"
 
-#: recvattach.c:1265
+#: recvattach.c:1278
 msgid "Can't delete attachment from POP server."
 msgstr "Неможливо видалити додаток з сервера POP."
 
-#: recvattach.c:1274
+#: recvattach.c:1287
 #, fuzzy
 msgid "Can't delete attachment from news server."
 msgstr "Неможливо видалити додаток з сервера POP."
 
-#: recvattach.c:1281
+#: recvattach.c:1294
 msgid "Deletion of attachments from encrypted messages is unsupported."
 msgstr "Видалення додатків з шифрованих листів не підтримується."
 
-#: recvattach.c:1287
+#: recvattach.c:1300
 msgid "Deletion of attachments from signed messages may invalidate the signature."
 msgstr "Видалення додатків з підписаних листів може анулювати підпис."
 
-#: recvattach.c:1305 recvattach.c:1320
+#: recvattach.c:1318 recvattach.c:1333
 msgid "Only deletion of multipart attachments is supported."
 msgstr "Підтримується тільки видалення в багаточастинних листах."
 
@@ -6405,3 +6493,13 @@ msgstr "Параметри компіляції:"
 #: version.c:404
 msgid "Compile options:"
 msgstr "Параметри компіляції:"
+
+#~ msgid "Cannot delete message(s)"
+#~ msgstr "Неможливо видалити повідомлення"
+
+#~ msgid "Cannot undelete message(s)"
+#~ msgstr "Неможливо відновити повідомлення"
+
+#, fuzzy
+#~ msgid "messages not deleted"
+#~ msgstr "повідомлення не видалені"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neomutt-20180512\n"
 "Report-Msgid-Bugs-To: neomutt-devel@neomutt.org\n"
-"POT-Creation-Date: 2018-05-20 02:02+0000\n"
+"POT-Creation-Date: 2018-05-22 14:18+0000\n"
 "PO-Revision-Date: 2018-05-11 14:00+0000\n"
 "Last-Translator: Zero King <l2dy@macports.org>\n"
 "Language-Team: i18n-zh <i18n-zh@googlegroups.com>\n"
@@ -44,7 +44,7 @@ msgstr "选择"
 
 #: addrbook.c:52 browser.c:75 browser.c:87 compose.c:160 compose.c:172
 #: conn/ssl.c:1041 conn/ssl_gnutls.c:793 curs_main.c:748 curs_main.c:761
-#: history.c:106 ncrypt/crypt_gpgme.c:4219 ncrypt/pgpkey.c:547
+#: history.c:106 ncrypt/crypt_gpgme.c:4221 ncrypt/pgpkey.c:547
 #: ncrypt/smime.c:477 pager.c:2141 postpone.c:65 query.c:72 recvattach.c:70
 msgid "Help"
 msgstr "帮助"
@@ -659,7 +659,7 @@ msgstr "安全："
 #. * Since it shares the row with "Encrypt with:", it should not be longer
 #. * than 15-20 character cells.
 #.
-#: compose.c:138 ncrypt/crypt_gpgme.c:4947 ncrypt/pgp.c:1786
+#: compose.c:138 ncrypt/crypt_gpgme.c:4949 ncrypt/pgp.c:1786
 #: ncrypt/smime.c:2127
 msgid "Sign as: "
 msgstr "选择身份签署："
@@ -1187,7 +1187,7 @@ msgstr "拒绝(r)，接受一次(o),跳过(s)"
 msgid "(r)eject, accept (o)nce"
 msgstr "拒绝(r)，接受一次(o)"
 
-#: conn/ssl.c:1039 conn/ssl_gnutls.c:791 ncrypt/crypt_gpgme.c:4213
+#: conn/ssl.c:1039 conn/ssl_gnutls.c:791 ncrypt/crypt_gpgme.c:4215
 #: ncrypt/pgpkey.c:541 ncrypt/smime.c:473
 msgid "Exit  "
 msgstr "退出  "
@@ -1368,11 +1368,11 @@ msgstr "没有已打开信箱。"
 msgid "There are no messages."
 msgstr "没有信件。"
 
-#: curs_main.c:77 mx.c:1061 pager.c:73 recvattach.c:56
+#: curs_main.c:77 mx.c:1071 pager.c:73 recvattach.c:56
 msgid "Mailbox is read-only."
 msgstr "信箱是只读的。"
 
-#: curs_main.c:79 pager.c:75 recvattach.c:1145
+#: curs_main.c:79 pager.c:75 recvattach.c:1158
 msgid "Function not permitted in attach-message mode."
 msgstr "功能在附加信件(attach-message)模式下不被支持。"
 
@@ -1502,235 +1502,245 @@ msgid "That message is not visible."
 msgstr "这封信件无法显示。"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:1377 curs_main.c:2772 pager.c:2818
-msgid "Cannot delete message(s)"
+#. L10N: Due to the implementation details we do not know whether we
+#. delete zero, 1, 12, ... messages. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:1381 curs_main.c:2784 pager.c:2822
+#, fuzzy
+msgid "Cannot delete messages"
 msgstr "不能够删除信件"
 
-#: curs_main.c:1380
+#: curs_main.c:1384
 msgid "Delete messages matching: "
 msgstr "删除符合此模式的信件："
 
-#: curs_main.c:1421
+#: curs_main.c:1425
 msgid "No limit pattern is in effect."
 msgstr "当前没有限制模式起作用。"
 
 #. L10N: ask for a limit to apply
-#: curs_main.c:1426
+#: curs_main.c:1430
 #, c-format
 msgid "Limit: %s"
 msgstr "限制：%s"
 
-#: curs_main.c:1464
+#: curs_main.c:1468
 msgid "Limit to messages matching: "
 msgstr "限制符合此模式的信件："
 
-#: curs_main.c:1488
+#: curs_main.c:1492
 msgid "To view all messages, limit to \"all\"."
 msgstr "要查看所有信件，请将限制设为 \"all\"。"
 
-#: curs_main.c:1500 pager.c:2318
+#: curs_main.c:1504 pager.c:2318
 msgid "Quit NeoMutt?"
 msgstr "离开 NeoMutt？"
 
-#: curs_main.c:1596
+#: curs_main.c:1600
 msgid "Tag messages matching: "
 msgstr "标记符合此模式的信件："
 
 #. L10N: CHECK_ACL
-#: curs_main.c:1606 curs_main.c:3203 pager.c:3137
-msgid "Cannot undelete message(s)"
+#. L10N: Due to the implementation details we do not know whether we
+#. undelete zero, 1, 12, ... messages. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:1614 curs_main.c:3223 pager.c:3145
+#, fuzzy
+msgid "Cannot undelete messages"
 msgstr "不能够反删除信件"
 
-#: curs_main.c:1609
+#: curs_main.c:1617
 msgid "Undelete messages matching: "
 msgstr "反删除符合此模式的信件："
 
-#: curs_main.c:1619
+#: curs_main.c:1627
 msgid "Untag messages matching: "
 msgstr "反标记符合此模式的信件："
 
-#: curs_main.c:1653
+#: curs_main.c:1661
 msgid "Logged out of IMAP servers."
 msgstr "正在退出 IMAP 服务器."
 
-#: curs_main.c:1753
+#: curs_main.c:1761
 msgid "No virtual folder, aborting."
 msgstr "没有虚拟文件夹，正在中止。"
 
-#: curs_main.c:1761
+#: curs_main.c:1769
 msgid "Failed to read thread, aborting."
 msgstr "无法读取线索，正在中止。"
 
-#: curs_main.c:1793 mx.c:1458 mx.c:1475
+#: curs_main.c:1801 mx.c:1468 mx.c:1485
 msgid "Folder doesn't support tagging, aborting."
 msgstr "文件夹不支持标签，正在终止。"
 
-#: curs_main.c:1808
+#: curs_main.c:1816
 msgid "No tag specified, aborting."
 msgstr "没有特殊标签，正在中止。"
 
-#: curs_main.c:1820
+#: curs_main.c:1828
 #, c-format
 msgid "Update tags..."
 msgstr "更新标签中..."
 
-#: curs_main.c:1857
+#: curs_main.c:1865
 msgid "Failed to modify tags, aborting."
 msgstr "无法修改标签，正在中止。"
 
-#: curs_main.c:1898
+#: curs_main.c:1906
 msgid "No query, aborting."
 msgstr "没有查询，正在中止。"
 
-#: curs_main.c:1902 curs_main.c:1922 curs_main.c:1941
+#: curs_main.c:1910 curs_main.c:1930 curs_main.c:1949
 msgid "Failed to create query, aborting."
 msgstr "无法创建查询，正在中止。"
 
-#: curs_main.c:1911 curs_main.c:1930
+#: curs_main.c:1919 curs_main.c:1938
 msgid "Windowed queries disabled."
 msgstr "窗口查询已禁用。"
 
-#: curs_main.c:1916 curs_main.c:1935
+#: curs_main.c:1924 curs_main.c:1943
 msgid "No notmuch vfolder currently loaded."
 msgstr "现在没有加载 notmuch 虚拟文件夹。"
 
-#: curs_main.c:1973
+#: curs_main.c:1981
 msgid "Open mailbox in read-only mode"
 msgstr "用只读模式打开信箱"
 
-#: curs_main.c:1976
+#: curs_main.c:1984
 msgid "Open virtual folder"
 msgstr "打开虚拟文件夹"
 
-#: curs_main.c:1979
+#: curs_main.c:1987
 msgid "Open mailbox"
 msgstr "打开信箱"
 
-#: curs_main.c:1989
+#: curs_main.c:1997
 msgid "No mailboxes have new mail"
 msgstr "没有信箱有新信件"
 
-#: curs_main.c:2036
+#: curs_main.c:2044
 msgid "Open newsgroup in read-only mode"
 msgstr "用只读模式打开新闻组"
 
-#: curs_main.c:2038
+#: curs_main.c:2046
 msgid "Open newsgroup"
 msgstr "打开新闻组"
 
-#: curs_main.c:2141
+#: curs_main.c:2149
 msgid "Exit NeoMutt without saving?"
 msgstr "不保存便退出 NeoMutt 吗？"
 
-#: curs_main.c:2157
+#: curs_main.c:2165
 msgid "Cannot break thread"
 msgstr "不能中断线索"
 
-#: curs_main.c:2160 curs_main.c:2198 curs_main.c:2658 curs_main.c:2690
+#: curs_main.c:2168 curs_main.c:2206 curs_main.c:2666 curs_main.c:2698
 #: flags.c:376 thread.c:1078 thread.c:1134 thread.c:1202
 msgid "Threading is not enabled."
 msgstr "线索功能尚未启动。"
 
-#: curs_main.c:2173
+#: curs_main.c:2181
 msgid "Thread broken"
 msgstr "线索有误"
 
-#: curs_main.c:2185
+#: curs_main.c:2193
 msgid "Thread cannot be broken, message is not part of a thread"
 msgstr "线索不能够打破，信件不是该线索的一部分"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2195
+#: curs_main.c:2203
 msgid "Cannot link threads"
 msgstr "不能够链接线索"
 
-#: curs_main.c:2200
+#: curs_main.c:2208
 msgid "No Message-ID: header available to link thread"
 msgstr "无 Message-ID: 标头可用于链接线索"
 
-#: curs_main.c:2202
+#: curs_main.c:2210
 msgid "First, please tag a message to be linked here"
 msgstr "首先，请标记一封信件以链接于此"
 
-#: curs_main.c:2213
+#: curs_main.c:2221
 msgid "Threads linked"
 msgstr "线索已链接"
 
-#: curs_main.c:2216
+#: curs_main.c:2224
 msgid "No thread linked"
 msgstr "无线索来链接"
 
-#: curs_main.c:2252 curs_main.c:2278
+#: curs_main.c:2260 curs_main.c:2286
 msgid "You are on the last message."
 msgstr "您已经在最后一封信了。"
 
-#: curs_main.c:2260 curs_main.c:2305
+#: curs_main.c:2268 curs_main.c:2313
 msgid "No undeleted messages."
 msgstr "没有要反删除的信件。"
 
-#: curs_main.c:2297 curs_main.c:2323
+#: curs_main.c:2305 curs_main.c:2331
 msgid "You are on the first message."
 msgstr "您已经在第一封信了。"
 
-#: curs_main.c:2395 menu.c:970 pager.c:2440 pattern.c:2110
+#: curs_main.c:2403 menu.c:970 pager.c:2440 pattern.c:2110
 msgid "Search wrapped to top."
 msgstr "搜寻从开头重新开始。"
 
-#: curs_main.c:2404 pager.c:2463 pattern.c:2121
+#: curs_main.c:2412 pager.c:2463 pattern.c:2121
 msgid "Search wrapped to bottom."
 msgstr "搜寻从结尾重新开始。"
 
-#: curs_main.c:2447
+#: curs_main.c:2455
 msgid "No new messages in this limited view."
 msgstr "没有新的信件在此限制视图中。"
 
-#: curs_main.c:2449
+#: curs_main.c:2457
 msgid "No new messages."
 msgstr "没有新信件。"
 
-#: curs_main.c:2454
+#: curs_main.c:2462
 msgid "No unread messages in this limited view."
 msgstr "在此限制视图中没有未读信件。"
 
-#: curs_main.c:2456
+#: curs_main.c:2464
 msgid "No unread messages."
 msgstr "没有尚未读取的信件。"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2474
+#: curs_main.c:2482
 msgid "Cannot flag message"
 msgstr "不能够标记信件"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2513 pager.c:3100
+#: curs_main.c:2521 pager.c:3104
 msgid "Cannot toggle new"
 msgstr "不能够处理新的"
 
-#: curs_main.c:2590
+#: curs_main.c:2598
 msgid "No more threads."
 msgstr "没有更多的线索。"
 
-#: curs_main.c:2592
+#: curs_main.c:2600
 msgid "You are on the first thread."
 msgstr "您在第一个线索上。"
 
-#: curs_main.c:2676
+#: curs_main.c:2684
 msgid "Thread contains unread or flagged messages."
 msgstr "线索中有尚未读取或者被标记的信件。"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2726 pager.c:2784
+#: curs_main.c:2734 pager.c:2784
 msgid "Cannot delete message"
 msgstr "不能够删除信件"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2838
+#: curs_main.c:2850
 msgid "Cannot edit message"
 msgstr "无法编辑信件"
 
 #. L10N: This is displayed when the x-label on one or more
 #. * messages is edited.
-#: curs_main.c:2900 pager.c:3200
+#: curs_main.c:2912 pager.c:3208
 #, c-format
 msgid "%d label changed."
 msgid_plural "%d labels changed."
@@ -1739,52 +1749,57 @@ msgstr[0] "%d 标签改变。"
 #. L10N: This is displayed when editing an x-label, but no messages
 #. * were updated.  Possibly due to canceling at the prompt or if the new
 #. * label is the same as the old label.
-#: curs_main.c:2907 pager.c:3204
+#: curs_main.c:2919 pager.c:3212
 msgid "No labels changed."
 msgstr "没有标签改变。"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:3006
-msgid "Cannot mark message(s) as read"
+#. L10N: Due to the implementation details we do not know whether we
+#. mark zero, 1, 12, ... messages as read. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:3022
+#, fuzzy
+msgid "Cannot mark messages as read"
 msgstr "不能够标记信件为已读"
 
 #. L10N: This is the prompt for <mark-message>.  Whatever they
 #. enter will be prefixed by $mark_macro_prefix and will become
 #. a macro hotkey to jump to the currently selected message.
-#: curs_main.c:3042
+#: curs_main.c:3058
 msgid "Enter macro stroke: "
 msgstr "请输入宏按键："
 
 #. L10N: "message hotkey" is the key bindings menu description of a
 #. macro created by <mark-message>.
-#: curs_main.c:3050
+#: curs_main.c:3066
 msgid "message hotkey"
 msgstr "信件热键"
 
 #. L10N: This is echoed after <mark-message> creates a new hotkey
 #. macro.  %s is the hotkey string ($mark_macro_prefix followed
 #. by whatever they typed at the prompt.)
-#: curs_main.c:3055
+#: curs_main.c:3071
 #, c-format
 msgid "Message bound to %s."
 msgstr "信件已退回给 %s。"
 
 #. L10N: This error is printed if <mark-message> cannot find a
 #. Message-ID for the currently selected message in the index.
-#: curs_main.c:3063
+#: curs_main.c:3079
 msgid "No message ID to macro."
 msgstr "没有可标记的信件 ID。"
 
-#: curs_main.c:3105 pager.c:2961 recvattach.c:1388
+#: curs_main.c:3121 pager.c:2965 recvattach.c:1401
 msgid "Reply by mail as poster prefers?"
 msgstr "按发帖人的偏好通过邮件回复？"
 
-#: curs_main.c:3108 pager.c:2927 pager.c:2939 pager.c:2964
+#: curs_main.c:3124 pager.c:2931 pager.c:2943 pager.c:2968
 msgid "Posting to this group not allowed, may be moderated. Continue?"
 msgstr "不允许在这个组里发帖，帖子可能会被审核，继续？"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:3173 pager.c:3120
+#: curs_main.c:3189 pager.c:3124
 msgid "Cannot undelete message"
 msgstr "不能反删除信件"
 
@@ -1975,12 +1990,31 @@ msgstr "[-- 自动显示的 %s 输出到标准错误(stderr)的内容 --]\n"
 msgid "[-- Error: message/external-body has no access-type parameter --]\n"
 msgstr "[-- 错误：message/external-body 没有访问类型参数 --]\n"
 
-#: handler.c:1611
-#, c-format
+#. L10N: If the translation of this string is a multi line string, then
+#. each line should start with "[-- " and end with " --]".
+#. The first "%s/%s" is a MIME type, e.g. "text/plain". The last %s
+#. expands to a date as returned by `mutt_date_parse_date()`.
+#.
+#. Note: The size argument printed is not the actual number as passed
+#. to gettext but the prettified version, e.g. size = 2048 will be
+#. printed as 2K.  Your language might be sensitive to that: For
+#. example although '1K' and '1024' represent the same number your
+#. language might inflect the noun 'byte' differently.
+#.
+#. Sadly, we cannot do anything about that at the moment besides
+#. passing the precise size in bytes. If you are interested the
+#. function responsible for the prettification is
+#. mutt_str_pretty_size() in mutt/string.c.
+#.
+#: handler.c:1624
+#, fuzzy, c-format
 msgid ""
+"[-- This %s/%s attachment (size %s byte) has been deleted --]\n"
+"[-- on %s --]\n"
+msgid_plural ""
 "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
 "[-- on %s --]\n"
-msgstr ""
+msgstr[0] ""
 "[-- 此 %s/%s 附件 (大小 %s 字节) 已经被删除 --]\n"
 "[-- 在 %s --]\n"
 
@@ -1988,10 +2022,22 @@ msgstr ""
 #. each line should start with "[-- " and end with " --]".
 #. The first "%s/%s" is a MIME type, e.g. "text/plain".
 #.
-#: handler.c:1620
-#, c-format
-msgid "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
-msgstr "[-- 此 %s/%s 附件 (大小 %s 字节) 已经被删除 --]\n"
+#. Note: The size argument printed is not the actual number as passed
+#. to gettext but the prettified version, e.g. size = 2048 will be
+#. printed as 2K.  Your language might be sensitive to that: For
+#. example although '1K' and '1024' represent the same number your
+#. language might inflect the noun 'byte' differently.
+#.
+#. Sadly, we cannot do anything about that at the moment besides
+#. passing the precise size in bytes. If you are interested the
+#. function responsible for the prettification is
+#. mutt_str_pretty_size() in mutt/string.c.
+#.
+#: handler.c:1648
+#, fuzzy, c-format
+msgid "[-- This %s/%s attachment (size %s byte) has been deleted --]\n"
+msgid_plural "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
+msgstr[0] "[-- 此 %s/%s 附件 (大小 %s 字节) 已经被删除 --]\n"
 
 #. L10N: If the translation of this string is a multi line string, then
 #. each line should start with "[-- " and end with " --]".
@@ -2001,7 +2047,7 @@ msgstr "[-- 此 %s/%s 附件 (大小 %s 字节) 已经被删除 --]\n"
 #. Caution: Argument three %3$ is also defined but should not be used
 #. in this translation!
 #.
-#: handler.c:1637
+#: handler.c:1667
 msgid ""
 "[-- This %s/%s attachment has been deleted --]\n"
 "[-- on %4$s --]\n"
@@ -2013,17 +2059,17 @@ msgstr ""
 #. each line should start with "[-- " and end with " --]".
 #. The first "%s/%s" is a MIME type, e.g. "text/plain".
 #.
-#: handler.c:1646
+#: handler.c:1676
 #, c-format
 msgid "[-- This %s/%s attachment has been deleted --]\n"
 msgstr "[-- 此 %s/%s 附件 已经被删除 --]\n"
 
-#: handler.c:1656
+#: handler.c:1686
 #, c-format
 msgid "[-- name: %s --]\n"
 msgstr "[-- 名称：%s --]\n"
 
-#: handler.c:1672
+#: handler.c:1702
 #, c-format
 msgid ""
 "[-- This %s/%s attachment is not included, --]\n"
@@ -2034,7 +2080,7 @@ msgstr ""
 "[-- 并且其标明的外部源已 --]\n"
 "[-- 过期。 --]\n"
 
-#: handler.c:1693
+#: handler.c:1723
 #, c-format
 msgid ""
 "[-- This %s/%s attachment is not included, --]\n"
@@ -2043,47 +2089,47 @@ msgstr ""
 "[-- 此 %s/%s 附件未被包含， --]\n"
 "[-- 并且其标明的访问类型 %s 不被支持 --]\n"
 
-#: handler.c:1822
+#: handler.c:1852
 msgid "Unable to open memory stream!"
 msgstr "无法打开内存文件！"
 
-#: handler.c:1831
+#: handler.c:1861
 msgid "Unable to open temporary file!"
 msgstr "无法打开临时文件！"
 
-#: handler.c:1881
+#: handler.c:1911
 msgid "failed to re-open memstream!"
 msgstr "无法重新打开临时内存流文件！"
 
-#: handler.c:2013
+#: handler.c:2043
 msgid "Error: multipart/signed has no protocol."
 msgstr "错误：multipart/signed 没有协议。"
 
-#: handler.c:2076
+#: handler.c:2106
 msgid "[-- This is an attachment (use '%3$s' to view this part) --]\n"
 msgstr "[-- 这是一个附件 (使用 '%3$s' 来显示这部份) --]\n"
 
-#: handler.c:2082
+#: handler.c:2112
 #, c-format
 msgid "[-- %s/%s is unsupported (use '%s' to view this part) --]\n"
 msgstr "[-- %s/%s 尚未支持 (使用 '%s' 来显示这部份) --]\n"
 
-#: handler.c:2087
+#: handler.c:2117
 msgid "[-- This is an attachment (need 'view-attachments' bound to key!) --]\n"
 msgstr "[-- 这是一个附件 (需要将 'view-attachments' 绑定到键！) --]\n"
 
 #. L10N: %s/%s is a MIME type, e.g. "text/plain".
-#: handler.c:2091
+#: handler.c:2121
 #, c-format
 msgid "[-- %s/%s is unsupported (need 'view-attachments' bound to key!) --]\n"
 msgstr "[-- %s/%s 尚未支持 (需要将 'view-attachments' 绑定到键！) --]\n"
 
-#: handler.c:2098
+#: handler.c:2128
 msgid "[-- This is an attachment --]\n"
 msgstr "[-- 这是一个附件 --]\n"
 
 #. L10N: %s/%s is a MIME type, e.g. "text/plain".
-#: handler.c:2101
+#: handler.c:2131
 #, c-format
 msgid "[-- %s/%s is unsupported --]\n"
 msgstr "[-- %s/%s 尚未支持 --]\n"
@@ -2382,7 +2428,7 @@ msgstr "IMAP 服务器不支持自定义标记"
 msgid "Invalid IMAP flags"
 msgstr "无效的 IMAP 标记"
 
-#: imap/message.c:477 mx.c:1326
+#: imap/message.c:477 mx.c:1336
 msgid "Integer overflow -- can't allocate memory."
 msgstr "整数溢出 -- 无法分配到内存。"
 
@@ -3191,63 +3237,71 @@ msgstr "SSL 不可用，无法连接到 %s"
 msgid "Reading from %s interrupted..."
 msgstr "读取 %s 已中断..."
 
-#: mx.c:634
-msgid "message(s) not deleted"
-msgstr "信件未被删除"
+#. L10N: Although we now the precise number of messages, we do not show it to the user.
+#. So feel free to use a "generic plural" as plural translation if your language has one.
+#.
+#: mx.c:639
+#, fuzzy
+msgid "message not deleted"
+msgid_plural "messages not deleted"
+msgstr[0] "信件未被删除"
 
-#: mx.c:671
+#: mx.c:676
 msgid "Can't open trash folder"
 msgstr "无法打开回收站"
 
-#: mx.c:710
+#: mx.c:715
 msgid "Mark all articles read?"
 msgstr "标记所有的帖子已经阅读？"
 
-#: mx.c:754
-#, c-format
-msgid "Move %d read messages to %s?"
-msgstr "移动 %d 封已读取的信件到 %s？"
+#. L10N: The first argument is the number of read messages to be
+#. moved, the second argument is the target mailbox.
+#: mx.c:762
+#, fuzzy, c-format
+msgid "Move %d read message to %s?"
+msgid_plural "Move %d read messages to %s?"
+msgstr[0] "移动 %d 封已读取的信件到 %s？"
 
-#: mx.c:771 mx.c:1077
+#: mx.c:781 mx.c:1087
 #, c-format
 msgid "Purge %d deleted message?"
 msgid_plural "Purge %d deleted messages?"
 msgstr[0] "清除 %d 封已经被删除的信件？"
 
-#: mx.c:793
+#: mx.c:803
 #, c-format
 msgid "Moving read messages to %s..."
 msgstr "正在搬移已经读取的信件到 %s ..."
 
-#: mx.c:859 mx.c:1068
+#: mx.c:869 mx.c:1078
 msgid "Mailbox is unchanged."
 msgstr "信箱没有改变。"
 
-#: mx.c:914
+#: mx.c:924
 #, c-format
 msgid "%d kept, %d moved, %d deleted."
 msgstr "保留 %d 封，移动 %d 封，删除 %d 封。"
 
-#: mx.c:917 mx.c:1130
+#: mx.c:927 mx.c:1140
 #, c-format
 msgid "%d kept, %d deleted."
 msgstr "保留 %d 封，删除 %d 封。"
 
-#: mx.c:1052
+#: mx.c:1062
 #, c-format
 msgid " Press '%s' to toggle write"
 msgstr " 请按下 '%s' 来切换写入"
 
-#: mx.c:1054
+#: mx.c:1064
 msgid "Use 'toggle-write' to re-enable write!"
 msgstr "请使用 'toggle-write' 来重新启动写入!"
 
-#: mx.c:1056
+#: mx.c:1066
 #, c-format
 msgid "Mailbox is marked unwritable. %s"
 msgstr "信箱已标记为不可写。%s"
 
-#: mx.c:1124
+#: mx.c:1134
 msgid "Mailbox checkpointed."
 msgstr "信箱已检查。"
 
@@ -3261,52 +3315,57 @@ msgstr " (当前时间：%c)"
 msgid "[-- %s output follows%s --]\n"
 msgstr "[-- %s 输出如下%s --]\n"
 
-#: ncrypt/crypt.c:95
-msgid "Passphrase(s) forgotten."
+#. L10N: Due to the implementation details (e.g. some passwords are managed
+#. by gpg-agent) we cannot know whether we forgot zero, 1, 12, ...
+#. passwords. So in English we use "Passphrases". Your language might
+#. have other means to express this.
+#: ncrypt/crypt.c:100
+#, fuzzy
+msgid "Passphrases forgotten."
 msgstr "已忘记通行密码。"
 
-#: ncrypt/crypt.c:155
+#: ncrypt/crypt.c:161
 msgid "Inline PGP can't be used with attachments.  Revert to PGP/MIME?"
 msgstr "嵌入 PGP 不支持附件。回到使用 PGP/MIME 吗？"
 
-#: ncrypt/crypt.c:159
+#: ncrypt/crypt.c:165
 msgid "Mail not sent: inline PGP can't be used with attachments."
 msgstr "信件无法发送：嵌入 PGP 不能用于附件。"
 
-#: ncrypt/crypt.c:166
+#: ncrypt/crypt.c:172
 msgid "Inline PGP can't be used with format=flowed.  Revert to PGP/MIME?"
 msgstr "嵌入 PGP 不支持 format=flowed。回到使用 PGP/MIME 吗？"
 
-#: ncrypt/crypt.c:170
+#: ncrypt/crypt.c:176
 msgid "Mail not sent: inline PGP can't be used with format=flowed."
 msgstr "信件无法发送：嵌入 PGP 不能用于 format=flowed。"
 
-#: ncrypt/crypt.c:180 ncrypt/cryptglue.c:125 ncrypt/pgpkey.c:589
+#: ncrypt/crypt.c:186 ncrypt/cryptglue.c:125 ncrypt/pgpkey.c:589
 #: ncrypt/pgpkey.c:782
 msgid "Invoking PGP..."
 msgstr "正在调用 PGP..."
 
-#: ncrypt/crypt.c:192
+#: ncrypt/crypt.c:198
 msgid "Message can't be sent inline.  Revert to using PGP/MIME?"
 msgstr "无法将信件嵌入发送。回到使用 PGP/MIME 吗？"
 
-#: ncrypt/crypt.c:194 send.c:1824
+#: ncrypt/crypt.c:200 send.c:1824
 msgid "Mail not sent."
 msgstr "信件没有寄出。"
 
-#: ncrypt/crypt.c:540
+#: ncrypt/crypt.c:546
 msgid "S/MIME messages with no hints on content are unsupported."
 msgstr "不支持没有内容提示的 S/MIME 消息。"
 
-#: ncrypt/crypt.c:754 ncrypt/crypt.c:795
+#: ncrypt/crypt.c:760 ncrypt/crypt.c:801
 msgid "Trying to extract PGP keys...\n"
 msgstr "正在尝试提取 PGP 密钥...\n"
 
-#: ncrypt/crypt.c:776 ncrypt/crypt.c:816
+#: ncrypt/crypt.c:782 ncrypt/crypt.c:822
 msgid "Trying to extract S/MIME certificates...\n"
 msgstr "正在尝试提取 S/MIME 证书...\n"
 
-#: ncrypt/crypt.c:976
+#: ncrypt/crypt.c:982
 #, c-format
 msgid ""
 "[-- Error: Unknown multipart/signed protocol %s! --]\n"
@@ -3315,7 +3374,7 @@ msgstr ""
 "[-- 错误：未知的 multipart/signed 协议 %s！ --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1016
+#: ncrypt/crypt.c:1022
 msgid ""
 "[-- Error: Missing or bad-format multipart/signed signature! --]\n"
 "\n"
@@ -3323,7 +3382,7 @@ msgstr ""
 "[-- 错误：缺失或格式错误的 multipart/signed 签名！ --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1058
+#: ncrypt/crypt.c:1064
 #, c-format
 msgid ""
 "[-- Warning: We can't verify %s/%s signatures. --]\n"
@@ -3332,7 +3391,7 @@ msgstr ""
 "[-- 警告：我们不能证实 %s/%s 签名。 --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1070
+#: ncrypt/crypt.c:1076
 msgid ""
 "[-- The following data is signed --]\n"
 "\n"
@@ -3340,7 +3399,7 @@ msgstr ""
 "[-- 以下数据已签署 --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1075
+#: ncrypt/crypt.c:1081
 msgid ""
 "[-- Warning: Can't find any signatures. --]\n"
 "\n"
@@ -3348,7 +3407,7 @@ msgstr ""
 "[-- 警告：找不到任何的签名。 --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1081
+#: ncrypt/crypt.c:1087
 msgid ""
 "\n"
 "[-- End of signed data --]\n"
@@ -3399,7 +3458,7 @@ msgstr "[临时文件]"
 msgid "error reading data object: %s\n"
 msgstr "读取数据对象时出错：%s\n"
 
-#: ncrypt/crypt_gpgme.c:662 ncrypt/crypt_gpgme.c:3848 ncrypt/pgpkey.c:585
+#: ncrypt/crypt_gpgme.c:662 ncrypt/crypt_gpgme.c:3850 ncrypt/pgpkey.c:585
 #: ncrypt/pgpkey.c:768
 msgid "Can't create temporary file"
 msgstr "无法建立暂存档"
@@ -3747,28 +3806,29 @@ msgstr "[无效]"
 
 #. L10N: This is printed after "Key Type: " and looks like this:
 #. *       PGP, 2048 bit RSA
-#: ncrypt/crypt_gpgme.c:3670 ncrypt/crypt_gpgme.c:3808
-#, c-format
+#: ncrypt/crypt_gpgme.c:3670 ncrypt/crypt_gpgme.c:3810
+#, fuzzy, c-format
 msgid "%s, %lu bit %s\n"
-msgstr "%s，%lu 位 %s\n"
+msgid_plural "%s, %lu bit %s\n"
+msgstr[0] "%s，%lu 位 %s\n"
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3678 ncrypt/crypt_gpgme.c:3815
+#: ncrypt/crypt_gpgme.c:3678 ncrypt/crypt_gpgme.c:3817
 msgid "encryption"
 msgstr "加密"
 
 #: ncrypt/crypt_gpgme.c:3679 ncrypt/crypt_gpgme.c:3685
-#: ncrypt/crypt_gpgme.c:3816 ncrypt/crypt_gpgme.c:3821
+#: ncrypt/crypt_gpgme.c:3818 ncrypt/crypt_gpgme.c:3823
 msgid ", "
 msgstr ", "
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3684 ncrypt/crypt_gpgme.c:3820
+#: ncrypt/crypt_gpgme.c:3684 ncrypt/crypt_gpgme.c:3822
 msgid "signing"
 msgstr "正在签署"
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3690 ncrypt/crypt_gpgme.c:3825
+#: ncrypt/crypt_gpgme.c:3690 ncrypt/crypt_gpgme.c:3827
 msgid "certification"
 msgstr "证书"
 
@@ -3787,64 +3847,64 @@ msgstr "[已过期]"
 msgid "[Disabled]"
 msgstr "[已禁用]"
 
-#: ncrypt/crypt_gpgme.c:3851
+#: ncrypt/crypt_gpgme.c:3853
 msgid "Collecting data..."
 msgstr "正在收集数据..."
 
-#: ncrypt/crypt_gpgme.c:3876
+#: ncrypt/crypt_gpgme.c:3878
 #, c-format
 msgid "Error finding issuer key: %s\n"
 msgstr "查找发放者密钥出错：%s\n"
 
-#: ncrypt/crypt_gpgme.c:3885
+#: ncrypt/crypt_gpgme.c:3887
 msgid "Error: certification chain too long - stopping here\n"
 msgstr "错误：证书链过长 - 就此打住\n"
 
-#: ncrypt/crypt_gpgme.c:3895 ncrypt/pgpkey.c:608
+#: ncrypt/crypt_gpgme.c:3897 ncrypt/pgpkey.c:608
 #, c-format
 msgid "Key ID: 0x%s"
 msgstr "密钥 ID：0x%s"
 
-#: ncrypt/crypt_gpgme.c:3990
+#: ncrypt/crypt_gpgme.c:3992
 #, c-format
 msgid "gpgme_new failed: %s"
 msgstr "gpgme_new 失败：%s"
 
-#: ncrypt/crypt_gpgme.c:4028 ncrypt/crypt_gpgme.c:4079
+#: ncrypt/crypt_gpgme.c:4030 ncrypt/crypt_gpgme.c:4081
 #, c-format
 msgid "gpgme_op_keylist_start failed: %s"
 msgstr "gpgme_op_keylist_start 失败：%s"
 
-#: ncrypt/crypt_gpgme.c:4067 ncrypt/crypt_gpgme.c:4109
+#: ncrypt/crypt_gpgme.c:4069 ncrypt/crypt_gpgme.c:4111
 #, c-format
 msgid "gpgme_op_keylist_next failed: %s"
 msgstr "gpgme_op_keylist_next 失败：%s"
 
-#: ncrypt/crypt_gpgme.c:4185
+#: ncrypt/crypt_gpgme.c:4187
 msgid "All matching keys are marked expired/revoked."
 msgstr "所有符合的密钥都被标记为过期/吊销。"
 
-#: ncrypt/crypt_gpgme.c:4215 ncrypt/pgpkey.c:543 ncrypt/smime.c:475
+#: ncrypt/crypt_gpgme.c:4217 ncrypt/pgpkey.c:543 ncrypt/smime.c:475
 msgid "Select  "
 msgstr "选择  "
 
-#: ncrypt/crypt_gpgme.c:4217 ncrypt/pgpkey.c:545
+#: ncrypt/crypt_gpgme.c:4219 ncrypt/pgpkey.c:545
 msgid "Check key  "
 msgstr "检查密钥  "
 
-#: ncrypt/crypt_gpgme.c:4233
+#: ncrypt/crypt_gpgme.c:4235
 msgid "PGP and S/MIME keys matching"
 msgstr "PGP 和 S/MIME 密钥匹配"
 
-#: ncrypt/crypt_gpgme.c:4235
+#: ncrypt/crypt_gpgme.c:4237
 msgid "PGP keys matching"
 msgstr "PGP 密钥匹配"
 
-#: ncrypt/crypt_gpgme.c:4237
+#: ncrypt/crypt_gpgme.c:4239
 msgid "S/MIME keys matching"
 msgstr "S/MIME 密钥匹配"
 
-#: ncrypt/crypt_gpgme.c:4239
+#: ncrypt/crypt_gpgme.c:4241
 msgid "keys matching"
 msgstr "密钥匹配"
 
@@ -3852,65 +3912,65 @@ msgstr "密钥匹配"
 #. %1$s is one of the previous four entries.
 #. %2$s is an address.
 #. e.g. "S/MIME keys matching <me@mutt.org>."
-#: ncrypt/crypt_gpgme.c:4246
+#: ncrypt/crypt_gpgme.c:4248
 #, c-format
 msgid "%s <%s>."
 msgstr "%s <%s>."
 
 #. L10N:
 #. e.g. 'S/MIME keys matching "Michael Elkins".'
-#: ncrypt/crypt_gpgme.c:4250
+#: ncrypt/crypt_gpgme.c:4252
 #, c-format
 msgid "%s \"%s\"."
 msgstr "%s \"%s\"."
 
-#: ncrypt/crypt_gpgme.c:4277 ncrypt/pgpkey.c:628
+#: ncrypt/crypt_gpgme.c:4279 ncrypt/pgpkey.c:628
 msgid "This key can't be used: expired/disabled/revoked."
 msgstr "无法使用这个密钥：已过期/已禁用/已吊销。"
 
-#: ncrypt/crypt_gpgme.c:4290 ncrypt/pgpkey.c:640 ncrypt/smime.c:505
+#: ncrypt/crypt_gpgme.c:4292 ncrypt/pgpkey.c:640 ncrypt/smime.c:505
 msgid "ID is expired/disabled/revoked. Do you really want to use the key?"
 msgstr "ID 已过期/已禁用/已吊销。您真的要使用此密钥吗？"
 
-#: ncrypt/crypt_gpgme.c:4299 ncrypt/pgpkey.c:650
+#: ncrypt/crypt_gpgme.c:4301 ncrypt/pgpkey.c:650
 msgid "ID is not valid. Do you really want to use the key?"
 msgstr "ID 无效。您真的要使用此密钥吗？"
 
-#: ncrypt/crypt_gpgme.c:4302 ncrypt/pgpkey.c:653
+#: ncrypt/crypt_gpgme.c:4304 ncrypt/pgpkey.c:653
 msgid "ID is only marginally valid. Do you really want to use the key?"
 msgstr "ID 仅勉强有效。您真的要使用此密钥吗？"
 
-#: ncrypt/crypt_gpgme.c:4310 ncrypt/pgpkey.c:646 ncrypt/smime.c:509
+#: ncrypt/crypt_gpgme.c:4312 ncrypt/pgpkey.c:646 ncrypt/smime.c:509
 msgid "ID has undefined validity. Do you really want to use the key?"
 msgstr "ID 有效性未定义。您真的要使用此密钥吗？"
 
-#: ncrypt/crypt_gpgme.c:4370 ncrypt/crypt_gpgme.c:4479 ncrypt/pgpkey.c:872
+#: ncrypt/crypt_gpgme.c:4372 ncrypt/crypt_gpgme.c:4481 ncrypt/pgpkey.c:872
 #: ncrypt/pgpkey.c:995
 #, c-format
 msgid "Looking for keys matching \"%s\"..."
 msgstr "正寻找匹配 \"%s\" 的密钥..."
 
-#: ncrypt/crypt_gpgme.c:4593 ncrypt/pgpkey.c:731 ncrypt/smime.c:811
+#: ncrypt/crypt_gpgme.c:4595 ncrypt/pgpkey.c:731 ncrypt/smime.c:811
 #, c-format
 msgid "No matching keys found for \"%s\""
 msgstr "未找到匹配 \"%s\" 的密钥"
 
-#: ncrypt/crypt_gpgme.c:4644 ncrypt/pgp.c:1263
+#: ncrypt/crypt_gpgme.c:4646 ncrypt/pgp.c:1263
 #, c-format
 msgid "Use keyID = \"%s\" for %s?"
 msgstr "要使用 keyID = \"%s\" 用于 %s 吗？"
 
-#: ncrypt/crypt_gpgme.c:4695 ncrypt/pgp.c:1312 ncrypt/smime.c:830
+#: ncrypt/crypt_gpgme.c:4697 ncrypt/pgp.c:1312 ncrypt/smime.c:830
 #: ncrypt/smime.c:938
 #, c-format
 msgid "Enter keyID for %s: "
 msgstr "请输入 %s 的 keyID："
 
-#: ncrypt/crypt_gpgme.c:4755 ncrypt/pgpkey.c:751
+#: ncrypt/crypt_gpgme.c:4757 ncrypt/pgpkey.c:751
 msgid "Please enter the key ID: "
 msgstr "请输入密钥 ID："
 
-#: ncrypt/crypt_gpgme.c:4768
+#: ncrypt/crypt_gpgme.c:4770
 #, c-format
 msgid "Error exporting key: %s\n"
 msgstr "导出密钥时出错：%s\n"
@@ -3919,80 +3979,80 @@ msgstr "导出密钥时出错：%s\n"
 #. MIME description for exported (attached) keys.
 #. You can translate this entry to a non-ASCII string (it will be encoded),
 #. but it may be safer to keep it untranslated.
-#: ncrypt/crypt_gpgme.c:4787
+#: ncrypt/crypt_gpgme.c:4789
 #, c-format
 msgid "PGP Key 0x%s."
 msgstr "PGP 密钥 0x%s。"
 
-#: ncrypt/crypt_gpgme.c:4830
+#: ncrypt/crypt_gpgme.c:4832
 msgid "GPGME: OpenPGP protocol not available"
 msgstr "GPGME：OpenPGP 协议不可用"
 
-#: ncrypt/crypt_gpgme.c:4838
+#: ncrypt/crypt_gpgme.c:4840
 msgid "GPGME: CMS protocol not available"
 msgstr "GPGME：CMS 协议不可用"
 
-#: ncrypt/crypt_gpgme.c:4876
+#: ncrypt/crypt_gpgme.c:4878
 msgid "S/MIME (s)ign, sign (a)s, (p)gp, (c)lear, or (o)ppenc mode off? "
 msgstr "S/MIME 签署(s)，选择身份签署(a)，(p)gp，清除(c)，或关闭机遇加密模式(o)？"
 
 #. L10N: S/MIME options (opportunistic encryption is on)
-#: ncrypt/crypt_gpgme.c:4878
+#: ncrypt/crypt_gpgme.c:4880
 msgid "sapco"
 msgstr "sapco"
 
-#: ncrypt/crypt_gpgme.c:4885
+#: ncrypt/crypt_gpgme.c:4887
 msgid "PGP (s)ign, sign (a)s, s/(m)ime, (c)lear, or (o)ppenc mode off? "
 msgstr "PGP 签署(s)，选择身份签署(a)，s/(m)ime，清除(c)，或关闭机遇加密模式(o)？"
 
 #. L10N: PGP options (opportunistic encryption is on)
-#: ncrypt/crypt_gpgme.c:4887
+#: ncrypt/crypt_gpgme.c:4889
 msgid "samco"
 msgstr "samco"
 
 #. L10N: S/MIME options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4900
+#: ncrypt/crypt_gpgme.c:4902
 msgid "S/MIME (e)ncrypt, (s)ign, sign (a)s, (b)oth, (p)gp, (c)lear, or (o)ppenc mode? "
 msgstr "S/MIME 加密(e)，签署(s)，选择身份签署(a)，两者皆要(b)，(p)gp，清除(c)，或使用机遇加密模式(o)？"
 
 #. L10N: S/MIME options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4903
+#: ncrypt/crypt_gpgme.c:4905
 msgid "esabpco"
 msgstr "esabpco"
 
 #. L10N: PGP options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4909
+#: ncrypt/crypt_gpgme.c:4911
 msgid "PGP (e)ncrypt, (s)ign, sign (a)s, (b)oth, s/(m)ime, (c)lear, or (o)ppenc mode? "
 msgstr "PGP 加密(e)，签署(s)，选择身份签署(a)，两者皆要(b)，s/(m)ime，清除(c)，或使用机遇加密模式(o)？"
 
 #. L10N: PGP options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4912
+#: ncrypt/crypt_gpgme.c:4914
 msgid "esabmco"
 msgstr "esabmco"
 
-#: ncrypt/crypt_gpgme.c:4925
+#: ncrypt/crypt_gpgme.c:4927
 msgid "S/MIME (e)ncrypt, (s)ign, sign (a)s, (b)oth, (p)gp or (c)lear? "
 msgstr "S/MIME 加密(e)，签署(s)，选择身份签署(a)，两者皆要(b)，(p)gp或清除(c)？"
 
 #. L10N: S/MIME options
-#: ncrypt/crypt_gpgme.c:4927
+#: ncrypt/crypt_gpgme.c:4929
 msgid "esabpc"
 msgstr "esabpc"
 
-#: ncrypt/crypt_gpgme.c:4934
+#: ncrypt/crypt_gpgme.c:4936
 msgid "PGP (e)ncrypt, (s)ign, sign (a)s, (b)oth, s/(m)ime or (c)lear? "
 msgstr "PGP 加密(e)，签署(s)，选择身份签署(a)，两者皆要(b)，s/(m)ime 或清除(c)？"
 
 #. L10N: PGP options
-#: ncrypt/crypt_gpgme.c:4936
+#: ncrypt/crypt_gpgme.c:4938
 msgid "esabmc"
 msgstr "esabmc"
 
-#: ncrypt/crypt_gpgme.c:5087
+#: ncrypt/crypt_gpgme.c:5089
 msgid "Failed to verify sender"
 msgstr "验证发送者失败"
 
-#: ncrypt/crypt_gpgme.c:5090
+#: ncrypt/crypt_gpgme.c:5092
 msgid "Failed to figure out sender"
 msgstr "找出发送者失败"
 
@@ -4380,7 +4440,7 @@ msgstr "未定义新闻服务器！"
 msgid "%s is an invalid news server specification!"
 msgstr "%s 是无效的新闻服务器 URL！"
 
-#: nntp.c:75 nntp.c:612 pop.c:1028 pop_lib.c:405
+#: nntp.c:75 nntp.c:612 pop.c:1031 pop_lib.c:405
 msgid "Server closed connection!"
 msgstr "服务器关闭了连接！"
 
@@ -4538,15 +4598,18 @@ msgid "check mailboxes for new mail"
 msgstr "检查信箱是否有新信件"
 
 #: opcodes.h:47
-msgid "attach file(s) to this message"
+#, fuzzy
+msgid "attach files to this message"
 msgstr "将文件附加到此信件作为附件"
 
 #: opcodes.h:48
-msgid "attach message(s) to this message"
+#, fuzzy
+msgid "attach messages to this message"
 msgstr "将信件附加到此信件作为附件"
 
 #: opcodes.h:49
-msgid "attach news article(s) to this message"
+#, fuzzy
+msgid "attach news articles to this message"
 msgstr "将帖子附加到此信件作为附件"
 
 #: opcodes.h:50
@@ -5362,7 +5425,8 @@ msgid "extract supported public keys"
 msgstr "取出支持的公钥"
 
 #: opcodes.h:255
-msgid "wipe passphrase(s) from memory"
+#, fuzzy
+msgid "wipe passphrases from memory"
 msgstr "从内存中清除通行密钥"
 
 #: opcodes.h:259
@@ -5691,18 +5755,19 @@ msgstr "POP 信箱中没有新信件。"
 msgid "Delete messages from server?"
 msgstr "删除服务器上的信件吗？"
 
-#: pop.c:954
-#, c-format
-msgid "Reading new messages (%d bytes)..."
-msgstr "正在读取新信件 (%d 字节)..."
+#: pop.c:955
+#, fuzzy, c-format
+msgid "Reading new messages (%d byte)..."
+msgid_plural "Reading new messages (%d bytes)..."
+msgstr[0] "正在读取新信件 (%d 字节)..."
 
-#: pop.c:997
+#: pop.c:1000
 msgid "Error while writing mailbox!"
 msgstr "写入信箱时出错！"
 
 #. L10N: The plural is picked by the second numerical argument, i.e.
 #. * the %d right before 'messages', i.e. the total number of messages.
-#: pop.c:1003
+#: pop.c:1006
 #, c-format
 msgid "%s [%d of %d message read]"
 msgid_plural "%s [%d of %d messages read]"
@@ -5845,47 +5910,53 @@ msgstr "通过管道传给："
 msgid "I don't know how to print %s attachments!"
 msgstr "我不知道要如何打印 %s 类型的附件！"
 
-#: recvattach.c:841
-msgid "Print tagged attachment(s)?"
-msgstr "打印已标记的附件？"
+#. L10N: Although we now the precise number of tagged messages, we
+#. do not show it to the user.  So feel free to use a "generic
+#. plural" as plural translation if your language has one.
+#: recvattach.c:852
+#, fuzzy, c-format
+msgid "Print tagged attachment?"
+msgid_plural "Print %d tagged attachments?"
+msgstr[0] "打印已标记的附件？"
 
-#: recvattach.c:842
+#: recvattach.c:853
+#, c-format
 msgid "Print attachment?"
 msgstr "打印附件？"
 
-#: recvattach.c:900
+#: recvattach.c:913
 msgid "Structural changes to decrypted attachments are not supported"
 msgstr "不支持对已解密附件的结构性更改"
 
-#: recvattach.c:1046
+#: recvattach.c:1059
 msgid "Can't decrypt encrypted message!"
 msgstr "无法解密加密信件！"
 
-#: recvattach.c:1172
+#: recvattach.c:1185
 msgid "Attachments"
 msgstr "附件"
 
-#: recvattach.c:1210
+#: recvattach.c:1223
 msgid "There are no subparts to show!"
 msgstr "无子部分可显示！"
 
-#: recvattach.c:1265
+#: recvattach.c:1278
 msgid "Can't delete attachment from POP server."
 msgstr "无法从 POP 服务器上删除附件。"
 
-#: recvattach.c:1274
+#: recvattach.c:1287
 msgid "Can't delete attachment from news server."
 msgstr "无法从新闻服务器上删除附件。"
 
-#: recvattach.c:1281
+#: recvattach.c:1294
 msgid "Deletion of attachments from encrypted messages is unsupported."
 msgstr "不支持从加密信件中删除附件。"
 
-#: recvattach.c:1287
+#: recvattach.c:1300
 msgid "Deletion of attachments from signed messages may invalidate the signature."
 msgstr "从已签名的信件中删除附件可能导致签名失效。"
 
-#: recvattach.c:1305 recvattach.c:1320
+#: recvattach.c:1318 recvattach.c:1333
 msgid "Only deletion of multipart attachments is supported."
 msgstr "只支持删除多段附件。"
 
@@ -6307,3 +6378,13 @@ msgstr "默认选项："
 #: version.c:404
 msgid "Compile options:"
 msgstr "编译选项："
+
+#~ msgid "Cannot delete message(s)"
+#~ msgstr "不能够删除信件"
+
+#~ msgid "Cannot undelete message(s)"
+#~ msgstr "不能够反删除信件"
+
+#, fuzzy
+#~ msgid "messages not deleted"
+#~ msgstr "信件未被删除"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: neomutt-20180512\n"
 "Report-Msgid-Bugs-To: neomutt-devel@neomutt.org\n"
-"POT-Creation-Date: 2018-05-20 02:02+0000\n"
+"POT-Creation-Date: 2018-05-22 14:18+0000\n"
 "PO-Revision-Date: 2001-09-06 18:25+0800\n"
 "Last-Translator: Anthony Wong <ypwong@debian.org>\n"
 "Language-Team: Chinese <zh@li.org>\n"
@@ -41,7 +41,7 @@ msgstr "選擇"
 
 #: addrbook.c:52 browser.c:75 browser.c:87 compose.c:160 compose.c:172
 #: conn/ssl.c:1041 conn/ssl_gnutls.c:793 curs_main.c:748 curs_main.c:761
-#: history.c:106 ncrypt/crypt_gpgme.c:4219 ncrypt/pgpkey.c:547
+#: history.c:106 ncrypt/crypt_gpgme.c:4221 ncrypt/pgpkey.c:547
 #: ncrypt/smime.c:477 pager.c:2141 postpone.c:65 query.c:72 recvattach.c:70
 msgid "Help"
 msgstr "求助"
@@ -694,7 +694,7 @@ msgstr ""
 #. * Since it shares the row with "Encrypt with:", it should not be longer
 #. * than 15-20 character cells.
 #.
-#: compose.c:138 ncrypt/crypt_gpgme.c:4947 ncrypt/pgp.c:1786
+#: compose.c:138 ncrypt/crypt_gpgme.c:4949 ncrypt/pgp.c:1786
 #: ncrypt/smime.c:2127
 msgid "Sign as: "
 msgstr "簽名的身份是："
@@ -1241,7 +1241,7 @@ msgstr "(1)不接受，(2)只是這次接受"
 msgid "(r)eject, accept (o)nce"
 msgstr "(1)不接受，(2)只是這次接受"
 
-#: conn/ssl.c:1039 conn/ssl_gnutls.c:791 ncrypt/crypt_gpgme.c:4213
+#: conn/ssl.c:1039 conn/ssl_gnutls.c:791 ncrypt/crypt_gpgme.c:4215
 #: ncrypt/pgpkey.c:541 ncrypt/smime.c:473
 msgid "Exit  "
 msgstr "離開  "
@@ -1429,11 +1429,11 @@ msgstr "沒有已開啟的信箱。"
 msgid "There are no messages."
 msgstr "沒有信件。"
 
-#: curs_main.c:77 mx.c:1061 pager.c:73 recvattach.c:56
+#: curs_main.c:77 mx.c:1071 pager.c:73 recvattach.c:56
 msgid "Mailbox is read-only."
 msgstr "信箱是唯讀的。"
 
-#: curs_main.c:79 pager.c:75 recvattach.c:1145
+#: curs_main.c:79 pager.c:75 recvattach.c:1158
 msgid "Function not permitted in attach-message mode."
 msgstr "功能在 attach-message 模式下不被支援。"
 
@@ -1569,255 +1569,263 @@ msgid "That message is not visible."
 msgstr "這封信件無法顯示。"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:1377 curs_main.c:2772 pager.c:2818
+#. L10N: Due to the implementation details we do not know whether we
+#. delete zero, 1, 12, ... messages. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:1381 curs_main.c:2784 pager.c:2822
 #, fuzzy
-msgid "Cannot delete message(s)"
+msgid "Cannot delete messages"
 msgstr "沒有要反刪除的信件。"
 
-#: curs_main.c:1380
+#: curs_main.c:1384
 msgid "Delete messages matching: "
 msgstr "刪除符合這樣式的信件："
 
-#: curs_main.c:1421
+#: curs_main.c:1425
 msgid "No limit pattern is in effect."
 msgstr "目前未有指定限制樣式。"
 
 #. L10N: ask for a limit to apply
-#: curs_main.c:1426
+#: curs_main.c:1430
 #, c-format
 msgid "Limit: %s"
 msgstr "限制: %s"
 
-#: curs_main.c:1464
+#: curs_main.c:1468
 msgid "Limit to messages matching: "
 msgstr "限制只符合這樣式的信件："
 
-#: curs_main.c:1488
+#: curs_main.c:1492
 msgid "To view all messages, limit to \"all\"."
 msgstr ""
 
-#: curs_main.c:1500 pager.c:2318
+#: curs_main.c:1504 pager.c:2318
 msgid "Quit NeoMutt?"
 msgstr "離開 NeoMutt？"
 
-#: curs_main.c:1596
+#: curs_main.c:1600
 msgid "Tag messages matching: "
 msgstr "標記信件的條件："
 
 #. L10N: CHECK_ACL
-#: curs_main.c:1606 curs_main.c:3203 pager.c:3137
+#. L10N: Due to the implementation details we do not know whether we
+#. undelete zero, 1, 12, ... messages. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:1614 curs_main.c:3223 pager.c:3145
 #, fuzzy
-msgid "Cannot undelete message(s)"
+msgid "Cannot undelete messages"
 msgstr "沒有要反刪除的信件。"
 
-#: curs_main.c:1609
+#: curs_main.c:1617
 msgid "Undelete messages matching: "
 msgstr "反刪除信件的條件："
 
-#: curs_main.c:1619
+#: curs_main.c:1627
 msgid "Untag messages matching: "
 msgstr "反標記信件的條件："
 
-#: curs_main.c:1653
+#: curs_main.c:1661
 #, fuzzy
 msgid "Logged out of IMAP servers."
 msgstr "正在關閉與 IMAP 伺服器的連線…"
 
-#: curs_main.c:1753
+#: curs_main.c:1761
 #, fuzzy
 msgid "No virtual folder, aborting."
 msgstr "沒有標題，正在中斷中。"
 
-#: curs_main.c:1761
+#: curs_main.c:1769
 msgid "Failed to read thread, aborting."
 msgstr ""
 
-#: curs_main.c:1793 mx.c:1458 mx.c:1475
+#: curs_main.c:1801 mx.c:1468 mx.c:1485
 msgid "Folder doesn't support tagging, aborting."
 msgstr ""
 
-#: curs_main.c:1808
+#: curs_main.c:1816
 #, fuzzy
 msgid "No tag specified, aborting."
 msgstr "沒有標題，正在中斷中。"
 
-#: curs_main.c:1820
+#: curs_main.c:1828
 #, c-format
 msgid "Update tags..."
 msgstr ""
 
-#: curs_main.c:1857
+#: curs_main.c:1865
 msgid "Failed to modify tags, aborting."
 msgstr ""
 
-#: curs_main.c:1898
+#: curs_main.c:1906
 #, fuzzy
 msgid "No query, aborting."
 msgstr "沒有標題，正在中斷中。"
 
-#: curs_main.c:1902 curs_main.c:1922 curs_main.c:1941
+#: curs_main.c:1910 curs_main.c:1930 curs_main.c:1949
 msgid "Failed to create query, aborting."
 msgstr ""
 
-#: curs_main.c:1911 curs_main.c:1930
+#: curs_main.c:1919 curs_main.c:1938
 msgid "Windowed queries disabled."
 msgstr ""
 
-#: curs_main.c:1916 curs_main.c:1935
+#: curs_main.c:1924 curs_main.c:1943
 msgid "No notmuch vfolder currently loaded."
 msgstr ""
 
-#: curs_main.c:1973
+#: curs_main.c:1981
 msgid "Open mailbox in read-only mode"
 msgstr "用唯讀模式開啟信箱"
 
-#: curs_main.c:1976
+#: curs_main.c:1984
 #, fuzzy
 msgid "Open virtual folder"
 msgstr "開啟另一個檔案夾"
 
-#: curs_main.c:1979
+#: curs_main.c:1987
 msgid "Open mailbox"
 msgstr "開啟信箱"
 
-#: curs_main.c:1989
+#: curs_main.c:1997
 #, fuzzy
 msgid "No mailboxes have new mail"
 msgstr "沒有信箱有新信件。"
 
-#: curs_main.c:2036
+#: curs_main.c:2044
 #, fuzzy
 msgid "Open newsgroup in read-only mode"
 msgstr "用唯讀模式開啟信箱"
 
-#: curs_main.c:2038
+#: curs_main.c:2046
 msgid "Open newsgroup"
 msgstr ""
 
-#: curs_main.c:2141
+#: curs_main.c:2149
 #, fuzzy
 msgid "Exit NeoMutt without saving?"
 msgstr "不儲存便離開 NeoMutt 嗎？"
 
-#: curs_main.c:2157
+#: curs_main.c:2165
 #, fuzzy
 msgid "Cannot break thread"
 msgstr "無法建立過濾器"
 
-#: curs_main.c:2160 curs_main.c:2198 curs_main.c:2658 curs_main.c:2690
+#: curs_main.c:2168 curs_main.c:2206 curs_main.c:2666 curs_main.c:2698
 #: flags.c:376 thread.c:1078 thread.c:1134 thread.c:1202
 msgid "Threading is not enabled."
 msgstr "序列功能尚未啟動。"
 
-#: curs_main.c:2173
+#: curs_main.c:2181
 msgid "Thread broken"
 msgstr ""
 
-#: curs_main.c:2185
+#: curs_main.c:2193
 msgid "Thread cannot be broken, message is not part of a thread"
 msgstr ""
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2195
+#: curs_main.c:2203
 msgid "Cannot link threads"
 msgstr ""
 
-#: curs_main.c:2200
+#: curs_main.c:2208
 msgid "No Message-ID: header available to link thread"
 msgstr ""
 
-#: curs_main.c:2202
+#: curs_main.c:2210
 #, fuzzy
 msgid "First, please tag a message to be linked here"
 msgstr "儲存信件以便稍後寄出"
 
-#: curs_main.c:2213
+#: curs_main.c:2221
 msgid "Threads linked"
 msgstr ""
 
-#: curs_main.c:2216
+#: curs_main.c:2224
 msgid "No thread linked"
 msgstr ""
 
-#: curs_main.c:2252 curs_main.c:2278
+#: curs_main.c:2260 curs_main.c:2286
 msgid "You are on the last message."
 msgstr "您已經在最後一封信了。"
 
-#: curs_main.c:2260 curs_main.c:2305
+#: curs_main.c:2268 curs_main.c:2313
 msgid "No undeleted messages."
 msgstr "沒有要反刪除的信件。"
 
-#: curs_main.c:2297 curs_main.c:2323
+#: curs_main.c:2305 curs_main.c:2331
 msgid "You are on the first message."
 msgstr "您已經在第一封信了。"
 
-#: curs_main.c:2395 menu.c:970 pager.c:2440 pattern.c:2110
+#: curs_main.c:2403 menu.c:970 pager.c:2440 pattern.c:2110
 msgid "Search wrapped to top."
 msgstr "搜尋至開頭。"
 
-#: curs_main.c:2404 pager.c:2463 pattern.c:2121
+#: curs_main.c:2412 pager.c:2463 pattern.c:2121
 msgid "Search wrapped to bottom."
 msgstr "搜尋至結尾。"
 
-#: curs_main.c:2447
+#: curs_main.c:2455
 #, fuzzy
 msgid "No new messages in this limited view."
 msgstr "在限制閱覽模式下無法顯示主信件。"
 
-#: curs_main.c:2449
+#: curs_main.c:2457
 #, fuzzy
 msgid "No new messages."
 msgstr "沒有新信件"
 
-#: curs_main.c:2454
+#: curs_main.c:2462
 #, fuzzy
 msgid "No unread messages in this limited view."
 msgstr "在限制閱覽模式下無法顯示主信件。"
 
-#: curs_main.c:2456
+#: curs_main.c:2464
 #, fuzzy
 msgid "No unread messages."
 msgstr "沒有尚未讀取的信件"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2474
+#: curs_main.c:2482
 #, fuzzy
 msgid "Cannot flag message"
 msgstr "顯示信件"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2513 pager.c:3100
+#: curs_main.c:2521 pager.c:3104
 msgid "Cannot toggle new"
 msgstr ""
 
-#: curs_main.c:2590
+#: curs_main.c:2598
 msgid "No more threads."
 msgstr "沒有更多的序列"
 
-#: curs_main.c:2592
+#: curs_main.c:2600
 msgid "You are on the first thread."
 msgstr "您已經在第一個序列上。"
 
-#: curs_main.c:2676
+#: curs_main.c:2684
 #, fuzzy
 msgid "Thread contains unread or flagged messages."
 msgstr "序列中有尚未讀取的信件。"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2726 pager.c:2784
+#: curs_main.c:2734 pager.c:2784
 #, fuzzy
 msgid "Cannot delete message"
 msgstr "沒有要反刪除的信件。"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:2838
+#: curs_main.c:2850
 #, fuzzy
 msgid "Cannot edit message"
 msgstr "無法寫信件"
 
 #. L10N: This is displayed when the x-label on one or more
 #. * messages is edited.
-#: curs_main.c:2900 pager.c:3200
+#: curs_main.c:2912 pager.c:3208
 #, fuzzy, c-format
 msgid "%d label changed."
 msgid_plural "%d labels changed."
@@ -1826,28 +1834,32 @@ msgstr[0] "信箱沒有變動。"
 #. L10N: This is displayed when editing an x-label, but no messages
 #. * were updated.  Possibly due to canceling at the prompt or if the new
 #. * label is the same as the old label.
-#: curs_main.c:2907 pager.c:3204
+#: curs_main.c:2919 pager.c:3212
 #, fuzzy
 msgid "No labels changed."
 msgstr "信箱沒有變動。"
 
 #. L10N: CHECK_ACL
-#: curs_main.c:3006
+#. L10N: Due to the implementation details we do not know whether we
+#. mark zero, 1, 12, ... messages as read. So in English we use
+#. "messages". Your language might have other means to express this.
+#.
+#: curs_main.c:3022
 #, fuzzy
-msgid "Cannot mark message(s) as read"
+msgid "Cannot mark messages as read"
 msgstr "跳到這個序列的主信件"
 
 #. L10N: This is the prompt for <mark-message>.  Whatever they
 #. enter will be prefixed by $mark_macro_prefix and will become
 #. a macro hotkey to jump to the currently selected message.
-#: curs_main.c:3042
+#: curs_main.c:3058
 #, fuzzy
 msgid "Enter macro stroke: "
 msgstr "請輸入 %s 的鑰匙 ID："
 
 #. L10N: "message hotkey" is the key bindings menu description of a
 #. macro created by <mark-message>.
-#: curs_main.c:3050
+#: curs_main.c:3066
 #, fuzzy
 msgid "message hotkey"
 msgstr "信件被延遲寄出。"
@@ -1855,28 +1867,28 @@ msgstr "信件被延遲寄出。"
 #. L10N: This is echoed after <mark-message> creates a new hotkey
 #. macro.  %s is the hotkey string ($mark_macro_prefix followed
 #. by whatever they typed at the prompt.)
-#: curs_main.c:3055
+#: curs_main.c:3071
 #, fuzzy, c-format
 msgid "Message bound to %s."
 msgstr "郵件已被傳送。"
 
 #. L10N: This error is printed if <mark-message> cannot find a
 #. Message-ID for the currently selected message in the index.
-#: curs_main.c:3063
+#: curs_main.c:3079
 #, fuzzy
 msgid "No message ID to macro."
 msgstr "檔案夾中沒有信件。"
 
-#: curs_main.c:3105 pager.c:2961 recvattach.c:1388
+#: curs_main.c:3121 pager.c:2965 recvattach.c:1401
 msgid "Reply by mail as poster prefers?"
 msgstr ""
 
-#: curs_main.c:3108 pager.c:2927 pager.c:2939 pager.c:2964
+#: curs_main.c:3124 pager.c:2931 pager.c:2943 pager.c:2968
 msgid "Posting to this group not allowed, may be moderated. Continue?"
 msgstr ""
 
 #. L10N: CHECK_ACL
-#: curs_main.c:3173 pager.c:3120
+#: curs_main.c:3189 pager.c:3124
 #, fuzzy
 msgid "Cannot undelete message"
 msgstr "沒有要反刪除的信件。"
@@ -2088,12 +2100,31 @@ msgstr "[-- 自動顯示 %s 的 stderr 內容 --]\n"
 msgid "[-- Error: message/external-body has no access-type parameter --]\n"
 msgstr "[-- 錯誤：message/external-body 沒有存取類型 (access-type) 的參數 --]\n"
 
-#: handler.c:1611
+#. L10N: If the translation of this string is a multi line string, then
+#. each line should start with "[-- " and end with " --]".
+#. The first "%s/%s" is a MIME type, e.g. "text/plain". The last %s
+#. expands to a date as returned by `mutt_date_parse_date()`.
+#.
+#. Note: The size argument printed is not the actual number as passed
+#. to gettext but the prettified version, e.g. size = 2048 will be
+#. printed as 2K.  Your language might be sensitive to that: For
+#. example although '1K' and '1024' represent the same number your
+#. language might inflect the noun 'byte' differently.
+#.
+#. Sadly, we cannot do anything about that at the moment besides
+#. passing the precise size in bytes. If you are interested the
+#. function responsible for the prettification is
+#. mutt_str_pretty_size() in mutt/string.c.
+#.
+#: handler.c:1624
 #, fuzzy, c-format
 msgid ""
+"[-- This %s/%s attachment (size %s byte) has been deleted --]\n"
+"[-- on %s --]\n"
+msgid_plural ""
 "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
 "[-- on %s --]\n"
-msgstr ""
+msgstr[0] ""
 "[-- 這個 %s/%s 附件 (%s 個位元組) 已經被刪除了 --]\n"
 "[-- 在 %s --]\n"
 
@@ -2101,10 +2132,22 @@ msgstr ""
 #. each line should start with "[-- " and end with " --]".
 #. The first "%s/%s" is a MIME type, e.g. "text/plain".
 #.
-#: handler.c:1620
+#. Note: The size argument printed is not the actual number as passed
+#. to gettext but the prettified version, e.g. size = 2048 will be
+#. printed as 2K.  Your language might be sensitive to that: For
+#. example although '1K' and '1024' represent the same number your
+#. language might inflect the noun 'byte' differently.
+#.
+#. Sadly, we cannot do anything about that at the moment besides
+#. passing the precise size in bytes. If you are interested the
+#. function responsible for the prettification is
+#. mutt_str_pretty_size() in mutt/string.c.
+#.
+#: handler.c:1648
 #, fuzzy, c-format
-msgid "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
-msgstr "[-- 這個 %s/%s 附件 (%s 個位元組) 已經被刪除了 --]\n"
+msgid "[-- This %s/%s attachment (size %s byte) has been deleted --]\n"
+msgid_plural "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
+msgstr[0] "[-- 這個 %s/%s 附件 (%s 個位元組) 已經被刪除了 --]\n"
 
 #. L10N: If the translation of this string is a multi line string, then
 #. each line should start with "[-- " and end with " --]".
@@ -2114,7 +2157,7 @@ msgstr "[-- 這個 %s/%s 附件 (%s 個位元組) 已經被刪除了 --]\n"
 #. Caution: Argument three %3$ is also defined but should not be used
 #. in this translation!
 #.
-#: handler.c:1637
+#: handler.c:1667
 #, fuzzy
 msgid ""
 "[-- This %s/%s attachment has been deleted --]\n"
@@ -2127,17 +2170,17 @@ msgstr ""
 #. each line should start with "[-- " and end with " --]".
 #. The first "%s/%s" is a MIME type, e.g. "text/plain".
 #.
-#: handler.c:1646
+#: handler.c:1676
 #, fuzzy, c-format
 msgid "[-- This %s/%s attachment has been deleted --]\n"
 msgstr "[-- 這個 %s/%s 附件 已經被刪除了 --]\n"
 
-#: handler.c:1656
+#: handler.c:1686
 #, c-format
 msgid "[-- name: %s --]\n"
 msgstr "[-- 名稱：%s --]\n"
 
-#: handler.c:1672
+#: handler.c:1702
 #, fuzzy, c-format
 msgid ""
 "[-- This %s/%s attachment is not included, --]\n"
@@ -2148,7 +2191,7 @@ msgstr ""
 "[-- 並且被指示的外部原始檔已 --]\n"
 "[-- 過期。 --]\n"
 
-#: handler.c:1693
+#: handler.c:1723
 #, fuzzy, c-format
 msgid ""
 "[-- This %s/%s attachment is not included, --]\n"
@@ -2157,52 +2200,52 @@ msgstr ""
 "[-- 這個 %s/%s 附件無法被附上, --]\n"
 "[-- 並且被指示的存取類型 (access-type) %s 不被支援 --]\n"
 
-#: handler.c:1822
+#: handler.c:1852
 #, fuzzy
 msgid "Unable to open memory stream!"
 msgstr "無法開啟暫存檔！"
 
-#: handler.c:1831
+#: handler.c:1861
 msgid "Unable to open temporary file!"
 msgstr "無法開啟暫存檔！"
 
-#: handler.c:1881
+#: handler.c:1911
 #, fuzzy
 msgid "failed to re-open memstream!"
 msgstr "無法開啟暫存檔！"
 
-#: handler.c:2013
+#: handler.c:2043
 msgid "Error: multipart/signed has no protocol."
 msgstr "錯誤：multipart/signed 沒有通訊協定。"
 
-#: handler.c:2076
+#: handler.c:2106
 #, fuzzy
 msgid "[-- This is an attachment (use '%3$s' to view this part) --]\n"
 msgstr "[-- 這個 %s/%s 附件 （按 '%3$s' 來顯示這部份） --]\n"
 
-#: handler.c:2082
+#: handler.c:2112
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported (use '%s' to view this part) --]\n"
 msgstr "[-- %s/%s 尚未支援 （按 '%s' 來顯示這部份） --]\n"
 
-#: handler.c:2087
+#: handler.c:2117
 #, fuzzy
 msgid "[-- This is an attachment (need 'view-attachments' bound to key!) --]\n"
 msgstr "[-- 這個 %s/%s 附件 （需要定義一個鍵給 'view-attachments' 來瀏覽附件！) --]\n"
 
 #. L10N: %s/%s is a MIME type, e.g. "text/plain".
-#: handler.c:2091
+#: handler.c:2121
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported (need 'view-attachments' bound to key!) --]\n"
 msgstr "[-- %s/%s 尚未支援 （需要定義一個鍵給 'view-attachments' 來瀏覽附件！) --]\n"
 
-#: handler.c:2098
+#: handler.c:2128
 #, fuzzy
 msgid "[-- This is an attachment --]\n"
 msgstr "[-- 這個 %s/%s 附件 --]\n"
 
 #. L10N: %s/%s is a MIME type, e.g. "text/plain".
-#: handler.c:2101
+#: handler.c:2131
 #, fuzzy, c-format
 msgid "[-- %s/%s is unsupported --]\n"
 msgstr "[-- %s/%s 尚未支援 --]\n"
@@ -2510,7 +2553,7 @@ msgstr ""
 msgid "Invalid IMAP flags"
 msgstr "無效的月份：%s"
 
-#: imap/message.c:477 mx.c:1326
+#: imap/message.c:477 mx.c:1336
 msgid "Integer overflow -- can't allocate memory."
 msgstr ""
 
@@ -3283,66 +3326,73 @@ msgstr "沒有 SSL 功能"
 msgid "Reading from %s interrupted..."
 msgstr "搜尋已被中斷。"
 
-#: mx.c:634
+#. L10N: Although we now the precise number of messages, we do not show it to the user.
+#. So feel free to use a "generic plural" as plural translation if your language has one.
+#.
+#: mx.c:639
 #, fuzzy
-msgid "message(s) not deleted"
-msgstr "標簽了的 %d 封信件刪去了…"
+msgid "message not deleted"
+msgid_plural "messages not deleted"
+msgstr[0] "標簽了的 %d 封信件刪去了…"
 
-#: mx.c:671
+#: mx.c:676
 #, fuzzy
 msgid "Can't open trash folder"
 msgstr "無法把資料加到檔案夾：%s"
 
-#: mx.c:710
+#: mx.c:715
 msgid "Mark all articles read?"
 msgstr ""
 
-#: mx.c:754
+#. L10N: The first argument is the number of read messages to be
+#. moved, the second argument is the target mailbox.
+#: mx.c:762
 #, fuzzy, c-format
-msgid "Move %d read messages to %s?"
-msgstr "搬移已讀取的信件到 %s？"
+msgid "Move %d read message to %s?"
+msgid_plural "Move %d read messages to %s?"
+msgstr[0] "搬移已讀取的信件到 %s？"
 
-#: mx.c:771 mx.c:1077
+#: mx.c:781 mx.c:1087
 #, fuzzy, c-format
 msgid "Purge %d deleted message?"
 msgid_plural "Purge %d deleted messages?"
 msgstr[0] "清除 %d 封已經被刪除的信件？"
 
-#: mx.c:793
+#: mx.c:803
 #, c-format
 msgid "Moving read messages to %s..."
 msgstr "正在搬移已經讀取的信件到 %s …"
 
-#: mx.c:859 mx.c:1068
+#: mx.c:869 mx.c:1078
 msgid "Mailbox is unchanged."
 msgstr "信箱沒有變動。"
 
-#: mx.c:914
+#: mx.c:924
 #, c-format
 msgid "%d kept, %d moved, %d deleted."
 msgstr "%d 封信件被保留, %d 封信件被搬移, %d 封信件被刪除。"
 
-#: mx.c:917 mx.c:1130
+#: mx.c:927 mx.c:1140
 #, c-format
 msgid "%d kept, %d deleted."
 msgstr "%d 封信件被保留, %d 封信件被刪除。"
 
-#: mx.c:1052
+#: mx.c:1062
 #, c-format
 msgid " Press '%s' to toggle write"
 msgstr " 請按下 '%s' 來切換寫入模式"
 
-#: mx.c:1054
+#: mx.c:1064
 msgid "Use 'toggle-write' to re-enable write!"
 msgstr "請使用 'toggle-write' 來重新啟動寫入功能!"
 
-#: mx.c:1056
+#: mx.c:1066
 #, c-format
 msgid "Mailbox is marked unwritable. %s"
 msgstr "信箱被標記成為無法寫入的. %s"
 
 # How to translate?
-#: mx.c:1124
+#: mx.c:1134
 msgid "Mailbox checkpointed."
 msgstr ""
 
@@ -3356,53 +3406,57 @@ msgstr ""
 msgid "[-- %s output follows%s --]\n"
 msgstr "[-- 以下為 PGP 輸出的資料（現在時間：%c) --]\n"
 
-#: ncrypt/crypt.c:95
+#. L10N: Due to the implementation details (e.g. some passwords are managed
+#. by gpg-agent) we cannot know whether we forgot zero, 1, 12, ...
+#. passwords. So in English we use "Passphrases". Your language might
+#. have other means to express this.
+#: ncrypt/crypt.c:100
 #, fuzzy
-msgid "Passphrase(s) forgotten."
+msgid "Passphrases forgotten."
 msgstr "已忘記 PGP 通行密碼。"
 
-#: ncrypt/crypt.c:155
+#: ncrypt/crypt.c:161
 msgid "Inline PGP can't be used with attachments.  Revert to PGP/MIME?"
 msgstr ""
 
-#: ncrypt/crypt.c:159
+#: ncrypt/crypt.c:165
 msgid "Mail not sent: inline PGP can't be used with attachments."
 msgstr ""
 
-#: ncrypt/crypt.c:166
+#: ncrypt/crypt.c:172
 msgid "Inline PGP can't be used with format=flowed.  Revert to PGP/MIME?"
 msgstr ""
 
-#: ncrypt/crypt.c:170
+#: ncrypt/crypt.c:176
 msgid "Mail not sent: inline PGP can't be used with format=flowed."
 msgstr ""
 
-#: ncrypt/crypt.c:180 ncrypt/cryptglue.c:125 ncrypt/pgpkey.c:589
+#: ncrypt/crypt.c:186 ncrypt/cryptglue.c:125 ncrypt/pgpkey.c:589
 #: ncrypt/pgpkey.c:782
 msgid "Invoking PGP..."
 msgstr "啟動 PGP…"
 
-#: ncrypt/crypt.c:192
+#: ncrypt/crypt.c:198
 msgid "Message can't be sent inline.  Revert to using PGP/MIME?"
 msgstr ""
 
-#: ncrypt/crypt.c:194 send.c:1824
+#: ncrypt/crypt.c:200 send.c:1824
 msgid "Mail not sent."
 msgstr "信件沒有寄出。"
 
-#: ncrypt/crypt.c:540
+#: ncrypt/crypt.c:546
 msgid "S/MIME messages with no hints on content are unsupported."
 msgstr ""
 
-#: ncrypt/crypt.c:754 ncrypt/crypt.c:795
+#: ncrypt/crypt.c:760 ncrypt/crypt.c:801
 msgid "Trying to extract PGP keys...\n"
 msgstr ""
 
-#: ncrypt/crypt.c:776 ncrypt/crypt.c:816
+#: ncrypt/crypt.c:782 ncrypt/crypt.c:822
 msgid "Trying to extract S/MIME certificates...\n"
 msgstr ""
 
-#: ncrypt/crypt.c:976
+#: ncrypt/crypt.c:982
 #, c-format
 msgid ""
 "[-- Error: Unknown multipart/signed protocol %s! --]\n"
@@ -3411,7 +3465,7 @@ msgstr ""
 "[-- 錯誤：不明的 multipart/signed 協定 %s！ --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1016
+#: ncrypt/crypt.c:1022
 #, fuzzy
 msgid ""
 "[-- Error: Missing or bad-format multipart/signed signature! --]\n"
@@ -3420,7 +3474,7 @@ msgstr ""
 "[-- 錯誤：不一致的 multipart/signed 結構！ --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1058
+#: ncrypt/crypt.c:1064
 #, c-format
 msgid ""
 "[-- Warning: We can't verify %s/%s signatures. --]\n"
@@ -3429,7 +3483,7 @@ msgstr ""
 "[-- 警告：我們不能證實 %s/%s 簽名。 --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1070
+#: ncrypt/crypt.c:1076
 #, fuzzy
 msgid ""
 "[-- The following data is signed --]\n"
@@ -3438,7 +3492,7 @@ msgstr ""
 "[-- 以下的資料已被簽署 --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1075
+#: ncrypt/crypt.c:1081
 msgid ""
 "[-- Warning: Can't find any signatures. --]\n"
 "\n"
@@ -3446,7 +3500,7 @@ msgstr ""
 "[-- 警告：找不到任何的簽名。 --]\n"
 "\n"
 
-#: ncrypt/crypt.c:1081
+#: ncrypt/crypt.c:1087
 #, fuzzy
 msgid ""
 "\n"
@@ -3499,7 +3553,7 @@ msgstr ""
 msgid "error reading data object: %s\n"
 msgstr "在樣式上有錯誤：%s"
 
-#: ncrypt/crypt_gpgme.c:662 ncrypt/crypt_gpgme.c:3848 ncrypt/pgpkey.c:585
+#: ncrypt/crypt_gpgme.c:662 ncrypt/crypt_gpgme.c:3850 ncrypt/pgpkey.c:585
 #: ncrypt/pgpkey.c:768
 msgid "Can't create temporary file"
 msgstr "無法建立暫存檔"
@@ -3878,29 +3932,30 @@ msgstr "無效的月份：%s"
 
 #. L10N: This is printed after "Key Type: " and looks like this:
 #. *       PGP, 2048 bit RSA
-#: ncrypt/crypt_gpgme.c:3670 ncrypt/crypt_gpgme.c:3808
+#: ncrypt/crypt_gpgme.c:3670 ncrypt/crypt_gpgme.c:3810
 #, c-format
 msgid "%s, %lu bit %s\n"
-msgstr ""
+msgid_plural "%s, %lu bit %s\n"
+msgstr[0] ""
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3678 ncrypt/crypt_gpgme.c:3815
+#: ncrypt/crypt_gpgme.c:3678 ncrypt/crypt_gpgme.c:3817
 #, fuzzy
 msgid "encryption"
 msgstr "加密"
 
 #: ncrypt/crypt_gpgme.c:3679 ncrypt/crypt_gpgme.c:3685
-#: ncrypt/crypt_gpgme.c:3816 ncrypt/crypt_gpgme.c:3821
+#: ncrypt/crypt_gpgme.c:3818 ncrypt/crypt_gpgme.c:3823
 msgid ", "
 msgstr ""
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3684 ncrypt/crypt_gpgme.c:3820
+#: ncrypt/crypt_gpgme.c:3684 ncrypt/crypt_gpgme.c:3822
 msgid "signing"
 msgstr ""
 
 #. L10N: value in Key Usage: field
-#: ncrypt/crypt_gpgme.c:3690 ncrypt/crypt_gpgme.c:3825
+#: ncrypt/crypt_gpgme.c:3690 ncrypt/crypt_gpgme.c:3827
 #, fuzzy
 msgid "certification"
 msgstr "驗証已儲存"
@@ -3921,70 +3976,70 @@ msgstr "離開  "
 msgid "[Disabled]"
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:3851
+#: ncrypt/crypt_gpgme.c:3853
 #, fuzzy
 msgid "Collecting data..."
 msgstr "正連接到 %s…"
 
-#: ncrypt/crypt_gpgme.c:3876
+#: ncrypt/crypt_gpgme.c:3878
 #, fuzzy, c-format
 msgid "Error finding issuer key: %s\n"
 msgstr "連線到 %s 時失敗"
 
-#: ncrypt/crypt_gpgme.c:3885
+#: ncrypt/crypt_gpgme.c:3887
 #, fuzzy
 msgid "Error: certification chain too long - stopping here\n"
 msgstr "指令行有錯：%s\n"
 
-#: ncrypt/crypt_gpgme.c:3895 ncrypt/pgpkey.c:608
+#: ncrypt/crypt_gpgme.c:3897 ncrypt/pgpkey.c:608
 #, c-format
 msgid "Key ID: 0x%s"
 msgstr "鑰匙 ID：0x%s"
 
-#: ncrypt/crypt_gpgme.c:3990
+#: ncrypt/crypt_gpgme.c:3992
 #, fuzzy, c-format
 msgid "gpgme_new failed: %s"
 msgstr "登入失敗： %s"
 
-#: ncrypt/crypt_gpgme.c:4028 ncrypt/crypt_gpgme.c:4079
+#: ncrypt/crypt_gpgme.c:4030 ncrypt/crypt_gpgme.c:4081
 #, c-format
 msgid "gpgme_op_keylist_start failed: %s"
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4067 ncrypt/crypt_gpgme.c:4109
+#: ncrypt/crypt_gpgme.c:4069 ncrypt/crypt_gpgme.c:4111
 #, c-format
 msgid "gpgme_op_keylist_next failed: %s"
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4185
+#: ncrypt/crypt_gpgme.c:4187
 #, fuzzy
 msgid "All matching keys are marked expired/revoked."
 msgstr "所有符合的鑰匙經已過期或取消。"
 
-#: ncrypt/crypt_gpgme.c:4215 ncrypt/pgpkey.c:543 ncrypt/smime.c:475
+#: ncrypt/crypt_gpgme.c:4217 ncrypt/pgpkey.c:543 ncrypt/smime.c:475
 msgid "Select  "
 msgstr "選擇    "
 
-#: ncrypt/crypt_gpgme.c:4217 ncrypt/pgpkey.c:545
+#: ncrypt/crypt_gpgme.c:4219 ncrypt/pgpkey.c:545
 msgid "Check key  "
 msgstr "檢查鑰匙   "
 
-#: ncrypt/crypt_gpgme.c:4233
+#: ncrypt/crypt_gpgme.c:4235
 #, fuzzy
 msgid "PGP and S/MIME keys matching"
 msgstr "PGP 鑰匙符合 <%s>。"
 
-#: ncrypt/crypt_gpgme.c:4235
+#: ncrypt/crypt_gpgme.c:4237
 #, fuzzy
 msgid "PGP keys matching"
 msgstr "PGP 鑰匙符合 <%s>。"
 
-#: ncrypt/crypt_gpgme.c:4237
+#: ncrypt/crypt_gpgme.c:4239
 #, fuzzy
 msgid "S/MIME keys matching"
 msgstr "S/MIME 鑰匙符合 <%s>。"
 
-#: ncrypt/crypt_gpgme.c:4239
+#: ncrypt/crypt_gpgme.c:4241
 #, fuzzy
 msgid "keys matching"
 msgstr "PGP 鑰匙符合 <%s>。"
@@ -3993,68 +4048,68 @@ msgstr "PGP 鑰匙符合 <%s>。"
 #. %1$s is one of the previous four entries.
 #. %2$s is an address.
 #. e.g. "S/MIME keys matching <me@mutt.org>."
-#: ncrypt/crypt_gpgme.c:4246
+#: ncrypt/crypt_gpgme.c:4248
 #, fuzzy, c-format
 msgid "%s <%s>."
 msgstr "%s 【%s】\n"
 
 #. L10N:
 #. e.g. 'S/MIME keys matching "Michael Elkins".'
-#: ncrypt/crypt_gpgme.c:4250
+#: ncrypt/crypt_gpgme.c:4252
 #, fuzzy, c-format
 msgid "%s \"%s\"."
 msgstr "%s 【%s】\n"
 
-#: ncrypt/crypt_gpgme.c:4277 ncrypt/pgpkey.c:628
+#: ncrypt/crypt_gpgme.c:4279 ncrypt/pgpkey.c:628
 msgid "This key can't be used: expired/disabled/revoked."
 msgstr "這個鑰匙不能使用：過期/停用/已取消。"
 
-#: ncrypt/crypt_gpgme.c:4290 ncrypt/pgpkey.c:640 ncrypt/smime.c:505
+#: ncrypt/crypt_gpgme.c:4292 ncrypt/pgpkey.c:640 ncrypt/smime.c:505
 #, fuzzy
 msgid "ID is expired/disabled/revoked. Do you really want to use the key?"
 msgstr "這個 ID 已過期/停用/取消。 您真的要使用此密钥吗？"
 
-#: ncrypt/crypt_gpgme.c:4299 ncrypt/pgpkey.c:650
+#: ncrypt/crypt_gpgme.c:4301 ncrypt/pgpkey.c:650
 #, fuzzy
 msgid "ID is not valid. Do you really want to use the key?"
 msgstr "這個 ID 不可接受。 您真的要使用此密钥吗？"
 
-#: ncrypt/crypt_gpgme.c:4302 ncrypt/pgpkey.c:653
+#: ncrypt/crypt_gpgme.c:4304 ncrypt/pgpkey.c:653
 #, fuzzy
 msgid "ID is only marginally valid. Do you really want to use the key?"
 msgstr "此 ID 只是勉強可接受。 您真的要使用此密钥吗？"
 
-#: ncrypt/crypt_gpgme.c:4310 ncrypt/pgpkey.c:646 ncrypt/smime.c:509
+#: ncrypt/crypt_gpgme.c:4312 ncrypt/pgpkey.c:646 ncrypt/smime.c:509
 msgid "ID has undefined validity. Do you really want to use the key?"
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4370 ncrypt/crypt_gpgme.c:4479 ncrypt/pgpkey.c:872
+#: ncrypt/crypt_gpgme.c:4372 ncrypt/crypt_gpgme.c:4481 ncrypt/pgpkey.c:872
 #: ncrypt/pgpkey.c:995
 #, c-format
 msgid "Looking for keys matching \"%s\"..."
 msgstr "正找尋匹配 \"%s\" 的鑰匙…"
 
-#: ncrypt/crypt_gpgme.c:4593 ncrypt/pgpkey.c:731 ncrypt/smime.c:811
+#: ncrypt/crypt_gpgme.c:4595 ncrypt/pgpkey.c:731 ncrypt/smime.c:811
 #, c-format
 msgid "No matching keys found for \"%s\""
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4644 ncrypt/pgp.c:1263
+#: ncrypt/crypt_gpgme.c:4646 ncrypt/pgp.c:1263
 #, c-format
 msgid "Use keyID = \"%s\" for %s?"
 msgstr "要為 %2$s 使用鑰匙 ID = \"%1$s\"？"
 
-#: ncrypt/crypt_gpgme.c:4695 ncrypt/pgp.c:1312 ncrypt/smime.c:830
+#: ncrypt/crypt_gpgme.c:4697 ncrypt/pgp.c:1312 ncrypt/smime.c:830
 #: ncrypt/smime.c:938
 #, c-format
 msgid "Enter keyID for %s: "
 msgstr "請輸入 %s 的鑰匙 ID："
 
-#: ncrypt/crypt_gpgme.c:4755 ncrypt/pgpkey.c:751
+#: ncrypt/crypt_gpgme.c:4757 ncrypt/pgpkey.c:751
 msgid "Please enter the key ID: "
 msgstr "請輸入這把鑰匙的 ID："
 
-#: ncrypt/crypt_gpgme.c:4768
+#: ncrypt/crypt_gpgme.c:4770
 #, fuzzy, c-format
 msgid "Error exporting key: %s\n"
 msgstr "在樣式上有錯誤：%s"
@@ -4063,90 +4118,90 @@ msgstr "在樣式上有錯誤：%s"
 #. MIME description for exported (attached) keys.
 #. You can translate this entry to a non-ASCII string (it will be encoded),
 #. but it may be safer to keep it untranslated.
-#: ncrypt/crypt_gpgme.c:4787
+#: ncrypt/crypt_gpgme.c:4789
 #, fuzzy, c-format
 msgid "PGP Key 0x%s."
 msgstr "PGP 鑰匙 %s。"
 
-#: ncrypt/crypt_gpgme.c:4830
+#: ncrypt/crypt_gpgme.c:4832
 msgid "GPGME: OpenPGP protocol not available"
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4838
+#: ncrypt/crypt_gpgme.c:4840
 msgid "GPGME: CMS protocol not available"
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:4876
+#: ncrypt/crypt_gpgme.c:4878
 #, fuzzy
 msgid "S/MIME (s)ign, sign (a)s, (p)gp, (c)lear, or (o)ppenc mode off? "
 msgstr "(1)加密, (2)簽名, (3)用別的身份簽, (4)兩者皆要, 或 (5)放棄？"
 
 #. L10N: S/MIME options (opportunistic encryption is on)
-#: ncrypt/crypt_gpgme.c:4878
+#: ncrypt/crypt_gpgme.c:4880
 msgid "sapco"
 msgstr "12345"
 
-#: ncrypt/crypt_gpgme.c:4885
+#: ncrypt/crypt_gpgme.c:4887
 #, fuzzy
 msgid "PGP (s)ign, sign (a)s, s/(m)ime, (c)lear, or (o)ppenc mode off? "
 msgstr "(1)加密, (2)簽名, (3)用別的身份簽, (4)兩者皆要, 或 (5)放棄？"
 
 #. L10N: PGP options (opportunistic encryption is on)
-#: ncrypt/crypt_gpgme.c:4887
+#: ncrypt/crypt_gpgme.c:4889
 msgid "samco"
 msgstr "12345"
 
 #. L10N: S/MIME options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4900
+#: ncrypt/crypt_gpgme.c:4902
 #, fuzzy
 msgid "S/MIME (e)ncrypt, (s)ign, sign (a)s, (b)oth, (p)gp, (c)lear, or (o)ppenc mode? "
 msgstr "(1)加密, (2)簽名, (3)用別的身份簽, (4)兩者皆要, 或 (5)放棄？"
 
 #. L10N: S/MIME options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4903
+#: ncrypt/crypt_gpgme.c:4905
 #, fuzzy
 msgid "esabpco"
 msgstr "12345"
 
 #. L10N: PGP options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4909
+#: ncrypt/crypt_gpgme.c:4911
 #, fuzzy
 msgid "PGP (e)ncrypt, (s)ign, sign (a)s, (b)oth, s/(m)ime, (c)lear, or (o)ppenc mode? "
 msgstr "(1)加密, (2)簽名, (3)用別的身份簽, (4)兩者皆要, 或 (5)放棄？"
 
 #. L10N: PGP options (opportunistic encryption is off)
-#: ncrypt/crypt_gpgme.c:4912
+#: ncrypt/crypt_gpgme.c:4914
 #, fuzzy
 msgid "esabmco"
 msgstr "12345"
 
-#: ncrypt/crypt_gpgme.c:4925
+#: ncrypt/crypt_gpgme.c:4927
 #, fuzzy
 msgid "S/MIME (e)ncrypt, (s)ign, sign (a)s, (b)oth, (p)gp or (c)lear? "
 msgstr "(1)加密, (2)簽名, (3)用別的身份簽, (4)兩者皆要, 或 (5)放棄？"
 
 #. L10N: S/MIME options
-#: ncrypt/crypt_gpgme.c:4927
+#: ncrypt/crypt_gpgme.c:4929
 #, fuzzy
 msgid "esabpc"
 msgstr "12345"
 
-#: ncrypt/crypt_gpgme.c:4934
+#: ncrypt/crypt_gpgme.c:4936
 #, fuzzy
 msgid "PGP (e)ncrypt, (s)ign, sign (a)s, (b)oth, s/(m)ime or (c)lear? "
 msgstr "(1)加密, (2)簽名, (3)用別的身份簽, (4)兩者皆要, 或 (5)放棄？"
 
 #. L10N: PGP options
-#: ncrypt/crypt_gpgme.c:4936
+#: ncrypt/crypt_gpgme.c:4938
 #, fuzzy
 msgid "esabmc"
 msgstr "12345"
 
-#: ncrypt/crypt_gpgme.c:5087
+#: ncrypt/crypt_gpgme.c:5089
 msgid "Failed to verify sender"
 msgstr ""
 
-#: ncrypt/crypt_gpgme.c:5090
+#: ncrypt/crypt_gpgme.c:5092
 #, fuzzy
 msgid "Failed to figure out sender"
 msgstr "開啟檔案來分析檔頭失敗。"
@@ -4569,7 +4624,7 @@ msgstr "沒有被定義的 POP 使用者名稱。"
 msgid "%s is an invalid news server specification!"
 msgstr ""
 
-#: nntp.c:75 nntp.c:612 pop.c:1028 pop_lib.c:405
+#: nntp.c:75 nntp.c:612 pop.c:1031 pop_lib.c:405
 msgid "Server closed connection!"
 msgstr "與伺服器的聯結中斷了!"
 
@@ -4736,16 +4791,17 @@ msgstr "檢查信箱是否有新信件"
 
 #: opcodes.h:47
 #, fuzzy
-msgid "attach file(s) to this message"
+msgid "attach files to this message"
 msgstr "在這封信件中夾帶檔案"
 
 #: opcodes.h:48
-msgid "attach message(s) to this message"
+#, fuzzy
+msgid "attach messages to this message"
 msgstr "在這封信件中夾帶信件"
 
 #: opcodes.h:49
 #, fuzzy
-msgid "attach news article(s) to this message"
+msgid "attach news articles to this message"
 msgstr "在這封信件中夾帶檔案"
 
 #: opcodes.h:50
@@ -5599,7 +5655,7 @@ msgstr "擷取 PGP 公共鑰匙"
 
 #: opcodes.h:255
 #, fuzzy
-msgid "wipe passphrase(s) from memory"
+msgid "wipe passphrases from memory"
 msgstr "清除記憶體中的 PGP 通行密碼"
 
 #: opcodes.h:259
@@ -5952,18 +6008,19 @@ msgstr "POP 信箱中沒有新的信件"
 msgid "Delete messages from server?"
 msgstr "刪除伺服器上的信件嗎？"
 
-#: pop.c:954
-#, c-format
-msgid "Reading new messages (%d bytes)..."
-msgstr "讀取新信件中 (%d 個位元組)…"
+#: pop.c:955
+#, fuzzy, c-format
+msgid "Reading new messages (%d byte)..."
+msgid_plural "Reading new messages (%d bytes)..."
+msgstr[0] "讀取新信件中 (%d 個位元組)…"
 
-#: pop.c:997
+#: pop.c:1000
 msgid "Error while writing mailbox!"
 msgstr "寫入信箱時發生錯誤！"
 
 #. L10N: The plural is picked by the second numerical argument, i.e.
 #. * the %d right before 'messages', i.e. the total number of messages.
-#: pop.c:1003
+#: pop.c:1006
 #, fuzzy, c-format
 msgid "%s [%d of %d message read]"
 msgid_plural "%s [%d of %d messages read]"
@@ -6110,51 +6167,57 @@ msgstr "導引至："
 msgid "I don't know how to print %s attachments!"
 msgstr "我不知道要怎麼列印 %s 附件!"
 
-#: recvattach.c:841
-msgid "Print tagged attachment(s)?"
-msgstr "是否要列印標記起來的附件?"
+#. L10N: Although we now the precise number of tagged messages, we
+#. do not show it to the user.  So feel free to use a "generic
+#. plural" as plural translation if your language has one.
+#: recvattach.c:852
+#, fuzzy, c-format
+msgid "Print tagged attachment?"
+msgid_plural "Print %d tagged attachments?"
+msgstr[0] "是否要列印標記起來的附件?"
 
-#: recvattach.c:842
+#: recvattach.c:853
+#, c-format
 msgid "Print attachment?"
 msgstr "是否要列印附件?"
 
-#: recvattach.c:900
+#: recvattach.c:913
 msgid "Structural changes to decrypted attachments are not supported"
 msgstr ""
 
-#: recvattach.c:1046
+#: recvattach.c:1059
 #, fuzzy
 msgid "Can't decrypt encrypted message!"
 msgstr "找不到已標記的訊息"
 
-#: recvattach.c:1172
+#: recvattach.c:1185
 msgid "Attachments"
 msgstr "附件"
 
-#: recvattach.c:1210
+#: recvattach.c:1223
 msgid "There are no subparts to show!"
 msgstr "沒有部件！"
 
-#: recvattach.c:1265
+#: recvattach.c:1278
 msgid "Can't delete attachment from POP server."
 msgstr "無法從 POP 伺服器刪除附件。"
 
-#: recvattach.c:1274
+#: recvattach.c:1287
 #, fuzzy
 msgid "Can't delete attachment from news server."
 msgstr "無法從 POP 伺服器刪除附件。"
 
-#: recvattach.c:1281
+#: recvattach.c:1294
 #, fuzzy
 msgid "Deletion of attachments from encrypted messages is unsupported."
 msgstr "未支援刪除 PGP 信件所附帶的附件。"
 
-#: recvattach.c:1287
+#: recvattach.c:1300
 #, fuzzy
 msgid "Deletion of attachments from signed messages may invalidate the signature."
 msgstr "未支援刪除 PGP 信件所附帶的附件。"
 
-#: recvattach.c:1305 recvattach.c:1320
+#: recvattach.c:1318 recvattach.c:1333
 msgid "Only deletion of multipart attachments is supported."
 msgstr "只支援刪除多重附件"
 
@@ -6575,3 +6638,15 @@ msgstr "編譯選項："
 #: version.c:404
 msgid "Compile options:"
 msgstr "編譯選項："
+
+#, fuzzy
+#~ msgid "Cannot delete message(s)"
+#~ msgstr "沒有要反刪除的信件。"
+
+#, fuzzy
+#~ msgid "Cannot undelete message(s)"
+#~ msgstr "沒有要反刪除的信件。"
+
+#, fuzzy
+#~ msgid "messages not deleted"
+#~ msgstr "標簽了的 %d 封信件刪去了…"

--- a/pop.c
+++ b/pop.c
@@ -951,7 +951,10 @@ void pop_fetch_mail(void)
 
   delanswer = query_quadoption(PopDelete, _("Delete messages from server?"));
 
-  snprintf(msgbuf, sizeof(msgbuf), _("Reading new messages (%d bytes)..."), bytes);
+  snprintf(msgbuf, sizeof(msgbuf),
+           ngettext("Reading new messages (%d byte)...",
+                    "Reading new messages (%d bytes)...", bytes),
+           bytes);
   mutt_message("%s", msgbuf);
 
   for (int i = last + 1; i <= msgs; i++)

--- a/recvattach.c
+++ b/recvattach.c
@@ -836,10 +836,23 @@ static void print_attachment_list(struct AttachCtx *actx, FILE *fp, bool tag,
 
 void mutt_print_attachment_list(struct AttachCtx *actx, FILE *fp, bool tag, struct Body *top)
 {
+  char prompt[SHORT_STRING];
   struct State state = { 0 };
+  int tagmsgcount = 0;
 
-  if (query_quadoption(Print, tag ? _("Print tagged attachment(s)?") :
-                                    _("Print attachment?")) != MUTT_YES)
+  if (tag)
+    for (int i = 0; i < actx->idxlen; i++)
+      if (actx->idx[i]->content->tagged)
+        tagmsgcount++;
+
+  snprintf(prompt, sizeof(prompt),
+           /* L10N: Although we now the precise number of tagged messages, we
+              do not show it to the user.  So feel free to use a "generic
+              plural" as plural translation if your language has one. */
+           tag ? ngettext("Print tagged attachment?", "Print %d tagged attachments?", tagmsgcount) :
+                 _("Print attachment?"),
+           tagmsgcount);
+  if (query_quadoption(Print, prompt) != MUTT_YES)
     return;
 
   if (!AttachSplit)


### PR DESCRIPTION
Revisit plural messages as noted in issue #1203.

Some messages cannot be fixed, some only if we completely reword them or rewrite the programming logic. For those cases I've added a note for the translator. Others were straight forward.

Here is a quick recap of the details:

```        
curs_main.c:1377:  CHECK_ACL(MUTT_ACL_DELETE, _("Cannot delete message(s)"));
curs_main.c:1606:  CHECK_ACL(MUTT_ACL_DELETE, _("Cannot undelete message(s)"));
curs_main.c:2772:  CHECK_ACL(MUTT_ACL_DELETE, _("Cannot delete message(s)"));
curs_main.c:3006:  CHECK_ACL(MUTT_ACL_SEEN, _("Cannot mark message(s) as read"));
curs_main.c:3203:  CHECK_ACL(MUTT_ACL_DELETE, _("Cannot undelete message(s)"));
pager.c:2818:      CHECK_ACL(MUTT_ACL_DELETE, _("Cannot delete message(s)"));
pager.c:3137:      CHECK_ACL(MUTT_ACL_DELETE, _("Cannot undelete message(s)"));
```
Cannot be fixed unless we either reword them or change the logic to get a the precise number of messages. Note that these strings are part of the expression "%s: Operation not permitted by ACL" (with %s the above strings). I added a comment for the translator to it.

```
opcodes.h:47:      _fmt(OP_COMPOSE_ATTACH_FILE, N_("attach file(s) to this message")) \
opcodes.h:48:      _fmt(OP_COMPOSE_ATTACH_MESSAGE, N_("attach message(s) to this message")) \
opcodes.h:49:      _fmt(OP_COMPOSE_ATTACH_NEWS_MESSAGE, N_("attach news article(s) to this message")) \
opcodes.h:255:     _fmt(OP_FORGET_PASSPHRASE, N_("wipe passphrase(s) from memory")) \
```
These are part of a global macro and GNU gettext cannot use ngettext inside of it (we use `N_` not `_` here). So unless we rewrite that code or do other fancy stuff we cannot fix it.

```
handler.c:1611: "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
handler.c:1620: "[-- This %s/%s attachment (size %s bytes) has been deleted --]\n"
```
We use ngettext here to distinguish wrt the size. However, %s will be replaced by the prettified version of size, e.g. `2K`. Some languages might be sensitive to such suffixes, e.g. `1K bytes` and `1024 bytes` might inflect 'byte' differently. I added a note to make the translators aware of that.

```
mx.c:754: "Move %d read messages to %s?"
pop.c:954: snprintf(msgbuf, sizeof(msgbuf), _("Reading new messages (%d bytes)..."), bytes);
```
Straight forward


```
mx.c:634:          mutt_error(_("message(s) not deleted"));
recvattach.c:841:  if (query_quadoption(Print, tag ? _("Print tagged attachment(s)?") :
```
We count the messages and use `ngettext()` but we don't use the number in the user messages.
We noted that for the translators.

```
ncrypt/crypt.c:95: mutt_message(_("Passphrase(s) forgotten."));
```
We stick with the "generic plural" of "Passphrase(s)". There is currently no way to get the number of passphrases due to implementation details, e.g. sometimes gpg-agent handles the passphrases.
We added a comment so that the translators are aware of it.