### PR TITLE
Do not truncate shell commands in backticks on the first ; or #

### DIFF
--- a/init.c
+++ b/init.c
@@ -3554,7 +3554,8 @@ int mutt_extract_token(struct Buffer *dest, struct Buffer *tok, int flags)
       if (flags & MUTT_TOKEN_BACKTICK_VARS)
       {
           /* recursively extract tokens to interpolate variables */
-          mutt_extract_token(&cmd, tok, MUTT_TOKEN_QUOTE | MUTT_TOKEN_SPACE);
+          mutt_extract_token(&cmd, tok, MUTT_TOKEN_QUOTE | MUTT_TOKEN_SPACE |
+            MUTT_TOKEN_COMMENT | MUTT_TOKEN_SEMICOLON);
       }
       else
       {

--- a/init.c
+++ b/init.c
@@ -3553,9 +3553,10 @@ int mutt_extract_token(struct Buffer *dest, struct Buffer *tok, int flags)
       *pc = '\0';
       if (flags & MUTT_TOKEN_BACKTICK_VARS)
       {
-          /* recursively extract tokens to interpolate variables */
-          mutt_extract_token(&cmd, tok, MUTT_TOKEN_QUOTE | MUTT_TOKEN_SPACE |
-            MUTT_TOKEN_COMMENT | MUTT_TOKEN_SEMICOLON);
+        /* recursively extract tokens to interpolate variables */
+        mutt_extract_token(&cmd, tok,
+                           MUTT_TOKEN_QUOTE | MUTT_TOKEN_SPACE |
+                               MUTT_TOKEN_COMMENT | MUTT_TOKEN_SEMICOLON);
       }
       else
       {


### PR DESCRIPTION
Fixes #1216.
