### PR TITLE
Regexlist-stailq

### DIFF
--- a/alias.c
+++ b/alias.c
@@ -698,10 +698,10 @@ bool mutt_addr_is_user(struct Address *addr)
     return true;
   }
 
-  if (mutt_regexlist_match(Alternates, addr->mailbox))
+  if (mutt_regexlist_match(&Alternates, addr->mailbox))
   {
     mutt_debug(5, "yes, %s matched by alternates.\n", addr->mailbox);
-    if (mutt_regexlist_match(UnAlternates, addr->mailbox))
+    if (mutt_regexlist_match(&UnAlternates, addr->mailbox))
       mutt_debug(5, "but, %s matched by unalternates.\n", addr->mailbox);
     else
       return true;

--- a/globals.h
+++ b/globals.h
@@ -76,14 +76,14 @@ WHERE struct ListHead AttachExclude INITVAL(STAILQ_HEAD_INITIALIZER(AttachExclud
 WHERE struct ListHead InlineAllow INITVAL(STAILQ_HEAD_INITIALIZER(InlineAllow));
 WHERE struct ListHead InlineExclude INITVAL(STAILQ_HEAD_INITIALIZER(InlineExclude));
 
-WHERE struct RegexList *Alternates;
-WHERE struct RegexList *UnAlternates;
-WHERE struct RegexList *MailLists;
-WHERE struct RegexList *UnMailLists;
-WHERE struct RegexList *SubscribedLists;
-WHERE struct RegexList *UnSubscribedLists;
+WHERE struct RegexList Alternates INITVAL(STAILQ_HEAD_INITIALIZER(Alternates));
+WHERE struct RegexList UnAlternates INITVAL(STAILQ_HEAD_INITIALIZER(UnAlternates));
+WHERE struct RegexList MailLists INITVAL(STAILQ_HEAD_INITIALIZER(MailLists));
+WHERE struct RegexList UnMailLists INITVAL(STAILQ_HEAD_INITIALIZER(UnMailLists));
+WHERE struct RegexList SubscribedLists INITVAL(STAILQ_HEAD_INITIALIZER(SubscribedLists));
+WHERE struct RegexList UnSubscribedLists INITVAL(STAILQ_HEAD_INITIALIZER(UnSubscribedLists));
 WHERE struct ReplaceList *SpamList;
-WHERE struct RegexList *NoSpamList;
+WHERE struct RegexList NoSpamList INITVAL(STAILQ_HEAD_INITIALIZER(NoSpamList));
 WHERE struct ReplaceList *SubjectRegexList;
 
 WHERE unsigned short Counter;

--- a/group.c
+++ b/group.c
@@ -53,7 +53,7 @@ static void group_remove(struct Group *g)
     return;
   mutt_hash_delete(Groups, g->name, g);
   mutt_addr_free(&g->as);
-  mutt_regexlist_free(&g->rs);
+  mutt_regexlist_free(g->rs);
   FREE(&g->name);
   FREE(&g);
 }
@@ -133,12 +133,12 @@ static int group_remove_addrlist(struct Group *g, struct Address *a)
 
 static int group_add_regex(struct Group *g, const char *s, int flags, struct Buffer *err)
 {
-  return mutt_regexlist_add(&g->rs, s, flags, err);
+  return mutt_regexlist_add(g->rs, s, flags, err);
 }
 
 static int group_remove_regex(struct Group *g, const char *s)
 {
-  return mutt_regexlist_remove(&g->rs, s);
+  return mutt_regexlist_remove(g->rs, s);
 }
 
 void mutt_group_context_add_addrlist(struct GroupContext *ctx, struct Address *a)

--- a/hdrline.c
+++ b/hdrline.c
@@ -67,17 +67,17 @@ enum FlagChars
 
 bool mutt_is_mail_list(struct Address *addr)
 {
-  if (!mutt_regexlist_match(UnMailLists, addr->mailbox))
-    return mutt_regexlist_match(MailLists, addr->mailbox);
+  if (!mutt_regexlist_match(&UnMailLists, addr->mailbox))
+    return mutt_regexlist_match(&MailLists, addr->mailbox);
   return false;
 }
 
 bool mutt_is_subscribed_list(struct Address *addr)
 {
-  if (!mutt_regexlist_match(UnMailLists, addr->mailbox) &&
-      !mutt_regexlist_match(UnSubscribedLists, addr->mailbox))
+  if (!mutt_regexlist_match(&UnMailLists, addr->mailbox) &&
+      !mutt_regexlist_match(&UnSubscribedLists, addr->mailbox))
   {
-    return mutt_regexlist_match(SubscribedLists, addr->mailbox);
+    return mutt_regexlist_match(&SubscribedLists, addr->mailbox);
   }
   return false;
 }

--- a/mutt/regex3.h
+++ b/mutt/regex3.h
@@ -69,11 +69,14 @@ struct Regex
 /**
  * struct RegexList - List of regular expressions
  */
-struct RegexList
+
+struct RegexListNode
 {
   struct Regex *regex;    /**< Regex containing a regular expression */
-  struct RegexList *next; /**< Next item in list */
+  STAILQ_ENTRY(RegexListNode) entries; /**< Regex  item in list */
 };
+
+STAILQ_HEAD(RegexList, RegexListNode);
 
 /**
  * struct ReplaceList - List of regular expressions
@@ -90,11 +93,11 @@ struct Regex *      mutt_regex_compile(const char *str, int flags);
 struct Regex *      mutt_regex_create(const char *str, int flags, struct Buffer *err);
 void                mutt_regex_free(struct Regex **r);
 
-int                 mutt_regexlist_add(struct RegexList **rl, const char *str, int flags, struct Buffer *err);
-void                mutt_regexlist_free(struct RegexList **rl);
-bool                mutt_regexlist_match(struct RegexList *rl, const char *str);
-struct RegexList *  mutt_regexlist_new(void);
-int                 mutt_regexlist_remove(struct RegexList **rl, const char *str);
+int                 mutt_regexlist_add(struct RegexList *head, const char *str, int flags, struct Buffer *err);
+void                mutt_regexlist_free(struct RegexList *head);
+bool                mutt_regexlist_match(struct RegexList *head, const char *str);
+struct RegexListNode *  mutt_regexlist_new(void);
+int                 mutt_regexlist_remove(struct RegexList *head, const char *str);
 
 int                 mutt_replacelist_add(struct ReplaceList **rl, const char *pat, const char *templ, struct Buffer *err);
 char *              mutt_replacelist_apply(struct ReplaceList *rl, char *buf, size_t buflen, const char *str);

--- a/parse.c
+++ b/parse.c
@@ -1229,7 +1229,7 @@ struct Envelope *mutt_rfc822_read_header(FILE *f, struct Header *hdr,
 
     if (mutt_replacelist_match(SpamList, buf, sizeof(buf), line))
     {
-      if (!mutt_regexlist_match(NoSpamList, line))
+      if (!mutt_regexlist_match(&NoSpamList, line))
       {
         /* if spam tag already exists, figure out how to amend it */
         if (e->spam && *buf)


### PR DESCRIPTION
I have successed compiled the mutt/regex.o, but it fails to rfc2047.o
And it reports:

mutt/regex3.h:76:3: error: expected specifier-qualifier-list before
‘STAILQ_ENTRY’
STAILQ_ENTRY(RegexListNode) entries; /**< Regex  item in list */

How long to see it!

Signed-off-by: Bo YU <yuzibode@126.com>

* **What does this PR do?**
convert  RegexList  to use STAILQ
* **Screenshots (if relevant)**

* **Does this PR meet the acceptance criteria?** (This is just a reminder for you,
  this section can be removed if you fulfill it.)

   - Documentation created/updated (you have to edit
     [doc/manual.xml.head](https://www.github.com/neomutt/neomutt/blob/master/doc/manual.xml.head)
     for that)

   - All builds and tests are passing

   - Added [doxygen code documentation](https://neomutt.org/dev/doxygen)
     [syntax](http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html)

   - Code follows the [style guide](https://neomutt.org/dev/coding-style)

* **What are the relevant issue numbers?**
#1222