### PR TITLE
Move LSUB call from connection establishment to mailbox SELECTion

### DIFF
--- a/imap/imap.c
+++ b/imap/imap.c
@@ -992,8 +992,6 @@ struct ImapData *imap_conn_find(const struct Account *account, int flags)
     /* get root delimiter, '/' as default */
     idata->delim = '/';
     imap_exec(idata, "LIST \"\" \"\"", IMAP_CMD_QUEUE);
-    if (ImapCheckSubscribed)
-      imap_exec(idata, "LSUB \"\" \"*\"", IMAP_CMD_QUEUE);
     /* we may need the root delimiter before we open a mailbox */
     imap_exec(idata, NULL, IMAP_CMD_FAIL_OK);
   }
@@ -2058,6 +2056,8 @@ static int imap_open_mailbox(struct Context *ctx)
   }
   FREE(&pmx.mbox);
 
+  if (ImapCheckSubscribed)
+    imap_exec(idata, "LSUB \"\" \"*\"", IMAP_CMD_QUEUE);
   snprintf(bufout, sizeof(bufout), "%s %s", ctx->readonly ? "EXAMINE" : "SELECT", buf);
 
   idata->state = IMAP_SELECTED;

--- a/init.h
+++ b/init.h
@@ -1385,9 +1385,9 @@ struct Option MuttVars[] = {
   /*
   ** .pp
   ** When \fIset\fP, NeoMutt will fetch the set of subscribed folders from
-  ** your server on connection, and add them to the set of mailboxes
-  ** it polls for new mail just as if you had issued individual ``$mailboxes''
-  ** commands.
+  ** your server whenever a mailbox is \fBselected\fP, and add them to the set
+  ** of mailboxes it polls for new mail just as if you had issued individual
+  ** ``$mailboxes'' commands.
   */
   { "imap_delim_chars",         DT_STRING, R_NONE, &ImapDelimChars, IP "/." },
   /*


### PR DESCRIPTION
This changes the place where an LSUB is issued to an IMAP server in
order to populate the buffy list, when imap_check_subscribed is set.

Previously, LSUB was issued when a connection to an IMAP server was
*first* established.  This caused the commands sequence

  ":unmailboxes *<enter><change-folder>imaps://foo.com<enter>"

to populate the buffy list when *first* opening a connection to foo.com,
but not on subsequent back-and-forth between IMAP servers.

The new code moves the LSUB call - and thus the population of the buffy
list - to just before a mailbox is selected.
This fixes the above-mentioned issue, at the cost of additional LSUB
calls when switching between mailboxes on the same server. Given that
the list of subscribed mailboxes is expected to be in the tens, I think
this is a reasonable tradeoff.

Issue #1225
