### PR TITLE
Handle a BAD response in AUTH PLAIN w/o initial response

### DIFF
--- a/imap/auth_plain.c
+++ b/imap/auth_plain.c
@@ -45,7 +45,7 @@
  */
 enum ImapAuthRes imap_auth_plain(struct ImapData *idata, const char *method)
 {
-  int rc;
+  int rc = IMAP_CMD_CONTINUE;
   enum ImapAuthRes res = IMAP_AUTH_SUCCESS;
   static const char auth_plain_cmd[] = "AUTHENTICATE PLAIN";
   char buf[STRING];
@@ -72,9 +72,10 @@ enum ImapAuthRes imap_auth_plain(struct ImapData *idata, const char *method)
      * credentials after the first command continuation request */
     buf[sizeof(auth_plain_cmd) - 1] = '\0';
     imap_cmd_start(idata, buf);
-    do
+    while (rc == IMAP_CMD_CONTINUE)
+    {
       rc = imap_cmd_step(idata);
-    while (rc == IMAP_CMD_CONTINUE);
+    }
     if (rc == IMAP_CMD_RESPOND)
     {
       mutt_socket_send(idata->conn, buf + sizeof(auth_plain_cmd));
@@ -82,9 +83,10 @@ enum ImapAuthRes imap_auth_plain(struct ImapData *idata, const char *method)
     }
   }
 
-  do
+  while (rc == IMAP_CMD_CONTINUE)
+  {
     rc = imap_cmd_step(idata);
-  while (rc == IMAP_CMD_CONTINUE);
+  }
 
   if (rc == IMAP_CMD_BAD)
   {


### PR DESCRIPTION
The incorrect assumption was that the first line of an AUTH PLAIN w/o
I-R was always successful, so the client could write the second line and
end up with a readable socket that would be activated by the server
sending the final OK or BAD response.
If however the first line results in a BAD response already, the server
wouldn't write anything else and the client would be left polling for an
additional response that never arrives, effectively hanging the process.

Issue #1236

* **What does this PR do?**

* **Screenshots (if relevant)**

* **Does this PR meet the acceptance criteria?** (This is just a reminder for you,
  this section can be removed if you fulfill it.)

   - Documentation created/updated (you have to edit
     [doc/manual.xml.head](https://www.github.com/neomutt/neomutt/blob/master/doc/manual.xml.head)
     for that)

   - All builds and tests are passing

   - Added [doxygen code documentation](https://neomutt.org/dev/doxygen)
     [syntax](http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html)

   - Code follows the [style guide](https://neomutt.org/dev/coding-style)

* **What are the relevant issue numbers?**
