### PR TITLE
notmuch: use global settings for vfolder-from-query

### DIFF
--- a/curs_main.c
+++ b/curs_main.c
@@ -2068,7 +2068,7 @@ int mutt_index_menu(void)
           mutt_message(_("No query, aborting"));
           break;
         }
-        if (!nm_uri_from_query(Context->mailbox, buf, sizeof(buf)))
+        if (!nm_uri_from_query(NULL, buf, sizeof(buf)))
           mutt_message(_("Failed to create query, aborting"));
         else
           main_change_folder(menu, op, buf, sizeof(buf), &oldcount, &index_hint);


### PR DESCRIPTION
When the <vfolder-from-query> command is run while already in a vfolder,
it takes the current vfolder as context.  That means the global settings
(nm_query_type, nm_db_limit, nm_default_uri) are ignored in favor of the
current vfolder's settings.  This is confusing behavior because the new
vfolder is otherwise independent from the old one.

Set the nm_uri_from_query() context to NULL so that it uses the global
settings instead.

* **What does this PR do?**

* **Screenshots (if relevant)**

* **Does this PR meet the acceptance criteria?** (This is just a reminder for you,
  this section can be removed if you fulfill it.)

   - Documentation created/updated (you have to edit
     [doc/manual.xml.head](https://www.github.com/neomutt/neomutt/blob/master/doc/manual.xml.head)
     for that)

   - All builds and tests are passing

   - Added [doxygen code documentation](https://neomutt.org/dev/doxygen)
     [syntax](http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html)

   - Code follows the [style guide](https://neomutt.org/dev/coding-style)

* **What are the relevant issue numbers?**
