### PR TITLE
Remove pgpring.1 from doc/Makefile.autosetup

### DIFF
--- a/doc/Makefile.autosetup
+++ b/doc/Makefile.autosetup
@@ -101,7 +101,6 @@ install-doc: all-doc
 	$(INSTALL) -m 644 doc/neomuttrc.5 $(DESTDIR)$(mandir)/man5/neomuttrc.5
 	$(INSTALL) -m 644 $(SRCDIR)/doc/smime_keys.1 $(DESTDIR)$(mandir)/man1/smime_keys_$(PACKAGE).1
 	$(INSTALL) -m 644 $(SRCDIR)/doc/pgpewrap.1 $(DESTDIR)$(mandir)/man1/pgpewrap_$(PACKAGE).1
-	$(INSTALL) -m 644 $(SRCDIR)/doc/pgpring.1 $(DESTDIR)$(mandir)/man1/pgpring_$(PACKAGE).1
 	$(INSTALL) -m 644 $(SRCDIR)/doc/mbox.5 $(DESTDIR)$(mandir)/man5/mbox_$(PACKAGE).5
 	$(INSTALL) -m 644 $(SRCDIR)/doc/mmdf.5 $(DESTDIR)$(mandir)/man5/mmdf_$(PACKAGE).5
 	$(MKDIR_P) $(DESTDIR)$(docdir)


### PR DESCRIPTION
Since commit e132075a6f9694878e644aa6683665490f2746d5 removes `pgpring.1`,
the reference to `pgpring.1` must be removed from `doc/Makefile.autosetup`
otherwise `make install` will throw an error, which can prevent installation.

The error thrown by `make install` prevented installation on two devices I use regularly.