### PR TITLE
WIP: Send SELECT to IMAP server after reconnect

### DIFF
--- a/imap/command.c
+++ b/imap/command.c
@@ -164,8 +164,10 @@ static void cmd_handle_fatal(struct ImapData *idata)
   if (!idata->recovering)
   {
     idata->recovering = true;
-    if (imap_conn_find(&idata->conn->account, 0))
+    if (imap_conn_find(&idata->conn->account, 0)) {
+      imap_select_mailbox(idata->ctx, idata, &idata->conn->account);
       mutt_clear_error();
+    }
     idata->recovering = false;
   }
 }

--- a/imap/imap_private.h
+++ b/imap/imap_private.h
@@ -278,6 +278,7 @@ int imap_exec_msgset(struct ImapData *idata, const char *pre, const char *post,
 int imap_open_connection(struct ImapData *idata);
 void imap_close_connection(struct ImapData *idata);
 struct ImapData *imap_conn_find(const struct Account *account, int flags);
+void imap_select_mailbox(struct Context *ctx, struct ImapData *idata, struct Account *mx_account);
 int imap_read_literal(FILE *fp, struct ImapData *idata, unsigned long bytes, struct Progress *pbar);
 void imap_expunge_mailbox(struct ImapData *idata);
 void imap_logout(struct ImapData **idata);


### PR DESCRIPTION
This is an attempt to do something about bug #1248

New imap_select_mailbox function split out of imap_open_mailbox to be called during reconnect.

There is a bug in this implementation, it crashes during the reconnection stage with this error:

terminated by signal SIGSEGV (Address boundary error)

Somebody with a better grasp of C might figure out why it is failing.