### PR TITLE
Fix env var quoting in backticks

### DIFF
--- a/mutt.h
+++ b/mutt.h
@@ -70,14 +70,15 @@ struct Mapping;
 #endif
 
 /* flags for mutt_extract_token() */
-#define MUTT_TOKEN_EQUAL         (1<<0)  /* treat '=' as a special */
-#define MUTT_TOKEN_CONDENSE      (1<<1)  /* ^(char) to control chars (macros) */
-#define MUTT_TOKEN_SPACE         (1<<2)  /* don't treat whitespace as a term */
-#define MUTT_TOKEN_QUOTE         (1<<3)  /* don't interpret quotes */
-#define MUTT_TOKEN_PATTERN       (1<<4)  /* !)|~ are terms (for patterns) */
-#define MUTT_TOKEN_COMMENT       (1<<5)  /* don't reap comments */
-#define MUTT_TOKEN_SEMICOLON     (1<<6)  /* don't treat ; as special */
-#define MUTT_TOKEN_BACKTICK_VARS (1<<7)  /* expand variables within backticks */
+#define MUTT_TOKEN_EQUAL         (1<<0)  /**< treat '=' as a special */
+#define MUTT_TOKEN_CONDENSE      (1<<1)  /**< ^(char) to control chars (macros) */
+#define MUTT_TOKEN_SPACE         (1<<2)  /**< don't treat whitespace as a term */
+#define MUTT_TOKEN_QUOTE         (1<<3)  /**< don't interpret quotes */
+#define MUTT_TOKEN_PATTERN       (1<<4)  /**< !)|~ are terms (for patterns) */
+#define MUTT_TOKEN_COMMENT       (1<<5)  /**< don't reap comments */
+#define MUTT_TOKEN_SEMICOLON     (1<<6)  /**< don't treat ; as special */
+#define MUTT_TOKEN_BACKTICK_VARS (1<<7)  /**< expand variables within backticks */
+#define MUTT_TOKEN_NOSHELL       (1<<8)  /**< don't expand environment variables */
 
 /* types for mutt_add_hook() */
 #define MUTT_FOLDERHOOK   (1 << 0)


### PR DESCRIPTION
Issue #1262 

I've added a flag `MUTT_TOKEN_NOSHELL` for `mutt_extract_token()`
When we're recursively expanding backticks, set this flag.

This only affects SHELL variables, so:

```
my_var="`echo $SHELL $folder`"
set ?my_var
```

should show something like: `Europe/London /home/user/mail`
