### PR TITLE
Improvements to self-encrypt

### DIFF
--- a/compose.c
+++ b/compose.c
@@ -453,7 +453,7 @@ static void draw_envelope_addr(int line, struct Address *addr)
  * @param msg Header of the message
  * @param fcc Fcc field
  */
-static void draw_envelope(struct Email *msg, char *fcc)
+static void draw_envelope(struct Email *msg)
 {
   draw_envelope_addr(HDR_FROM, msg->env->from);
 #ifdef USE_NNTP
@@ -494,7 +494,7 @@ static void draw_envelope(struct Email *msg, char *fcc)
   mutt_window_mvprintw(MuttIndexWindow, HDR_FCC, 0, "%*s",
                        HeaderPadding[HDR_FCC], _(Prompts[HDR_FCC]));
   NORMAL_COLOR;
-  mutt_paddstr(W, fcc);
+  mutt_paddstr(W, NONULL(msg->fcc));
 
   if (WithCrypto)
     redraw_crypt_lines(msg);
@@ -661,15 +661,6 @@ static void update_idx(struct Menu *menu, struct AttachCtx *actx, struct AttachP
   menu->current = actx->vcount - 1;
 }
 
-/**
- * struct ComposeRedrawData - Keep track when the compose screen needs redrawing
- */
-struct ComposeRedrawData
-{
-  struct Email *email;
-  char *fcc;
-};
-
 static void compose_status_line(char *buf, size_t buflen, size_t col, int cols,
                                 struct Menu *menu, const char *p);
 
@@ -678,16 +669,16 @@ static void compose_status_line(char *buf, size_t buflen, size_t col, int cols,
  */
 static void compose_custom_redraw(struct Menu *menu)
 {
-  struct ComposeRedrawData *rd = menu->redraw_data;
+  struct Email *msg = (struct Email *) menu->redraw_data;
 
-  if (!rd)
+  if (!msg)
     return;
 
   if (menu->redraw & REDRAW_FULL)
   {
     menu_redraw_full(menu);
 
-    draw_envelope(rd->email, rd->fcc);
+    draw_envelope(msg);
     menu->offset = HDR_ATTACH;
     menu->pagelen = MuttIndexWindow->rows - HDR_ATTACH;
   }
@@ -873,15 +864,13 @@ static void compose_status_line(char *buf, size_t buflen, size_t col, int cols,
 /**
  * mutt_compose_menu - Allow the user to edit the message envelope
  * @param msg    Message to fill
- * @param fcc    Buffer to save FCC
- * @param fcclen Length of FCC buffer
  * @param cur    Current message
  * @param flags  Flags, e.g. #MUTT_COMPOSE_NOFREEHEADER
  * @retval  1 Message should be postponed
  * @retval  0 Normal exit
  * @retval -1 Abort message
  */
-int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email *cur, int flags)
+int mutt_compose_menu(struct Email *msg, struct Email *cur, int flags)
 {
   char helpstr[1024]; // This isn't copied by the help bar
   char buf[PATH_MAX];
@@ -889,15 +878,11 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
   int rc = -1;
   bool loop = true;
   bool fcc_set = false; /* has the user edited the Fcc: field ? */
-  struct ComposeRedrawData rd;
 #ifdef USE_NNTP
   bool news = OptNewsSend; /* is it a news article ? */
 #endif
 
   init_header_padding();
-
-  rd.email = msg;
-  rd.fcc = fcc;
 
   struct Menu *menu = mutt_menu_new(MENU_COMPOSE);
   menu->offset = HDR_ATTACH;
@@ -910,7 +895,7 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
 #endif
     menu->help = mutt_compile_help(helpstr, sizeof(helpstr), MENU_COMPOSE, ComposeHelp);
   menu->menu_custom_redraw = compose_custom_redraw;
-  menu->redraw_data = &rd;
+  menu->redraw_data = msg;
   mutt_menu_push_current(menu);
 
   struct AttachCtx *actx = mutt_mem_calloc(sizeof(struct AttachCtx), 1);
@@ -1050,13 +1035,14 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
         break;
 
       case OP_COMPOSE_EDIT_FCC:
-        mutt_str_strfcpy(buf, fcc, sizeof(buf));
+        mutt_str_strfcpy(buf, NONULL(msg->fcc), sizeof(buf));
         if (mutt_get_field(_("Fcc: "), buf, sizeof(buf), MUTT_FILE | MUTT_CLEAR) == 0)
         {
-          mutt_str_strfcpy(fcc, buf, fcclen);
-          mutt_pretty_mailbox(fcc, fcclen);
+          mutt_str_replace(&msg->fcc, buf);
+          if (msg->fcc)
+            mutt_pretty_mailbox(msg->fcc, mutt_str_strlen(msg->fcc));
           mutt_window_move(MuttIndexWindow, HDR_FCC, HDR_XOFFSET);
-          mutt_paddstr(W, fcc);
+          mutt_paddstr(W, NONULL(msg->fcc));
           fcc_set = true;
         }
         mutt_message_hook(NULL, msg, MUTT_SEND2_HOOK);
@@ -1080,7 +1066,7 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
           const char *tag = NULL;
           char *err = NULL;
           mutt_env_to_local(msg->env);
-          mutt_edit_headers(NONULL(C_Editor), msg->content->filename, msg, fcc, fcclen);
+          mutt_edit_headers(NONULL(C_Editor), msg->content->filename, msg);
           if (mutt_env_to_intl(msg->env, &tag, &err))
           {
             mutt_error(_("Bad IDN in '%s': '%s'"), tag, err);
@@ -1651,14 +1637,14 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
           break;
 #endif
 
-        if (!fcc_set && *fcc)
+	if (!fcc_set && msg->fcc && *msg->fcc)
         {
           enum QuadOption ans =
               query_quadoption(C_Copy, _("Save a copy of this message?"));
           if (ans == MUTT_ABORT)
             break;
           else if (ans == MUTT_NO)
-            *fcc = '\0';
+            FREE(&msg->fcc);
         }
 
         loop = false;

--- a/compose.h
+++ b/compose.h
@@ -35,6 +35,6 @@ extern unsigned char C_Postpone;
 /* flags for mutt_compose_menu() */
 #define MUTT_COMPOSE_NOFREEHEADER (1 << 0)
 
-int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email *cur, int flags);
+int mutt_compose_menu(struct Email *msg, struct Email *cur, int flags);
 
 #endif /* MUTT_COMPOSE_H */

--- a/doc/manual.xml.head
+++ b/doc/manual.xml.head
@@ -12686,7 +12686,7 @@ set pgp_default_key  = A4AF18C5582473BD35A1E9CE78BB3D480042198E
               </row>
               <row>
                 <entry><literal>pgp_self_encrypt</literal></entry>
-                <entry>boolean</entry>
+                <entry>quadoption</entry>
                 <entry><literal>yes</literal></entry>
               </row>
               <row>
@@ -12701,7 +12701,7 @@ set pgp_default_key  = A4AF18C5582473BD35A1E9CE78BB3D480042198E
               </row>
               <row>
                 <entry><literal>smime_self_encrypt</literal></entry>
-                <entry>boolean</entry>
+                <entry>quadoption</entry>
                 <entry><literal>yes</literal></entry>
               </row>
               <row>

--- a/edit.c
+++ b/edit.c
@@ -530,7 +530,7 @@ int mutt_builtin_editor(const char *path, struct Email *msg, struct Email *cur)
             if (C_EditHeaders)
             {
               mutt_env_to_local(msg->env);
-              mutt_edit_headers(NONULL(C_Visual), path, msg, NULL, 0);
+              mutt_edit_headers(NONULL(C_Visual), path, msg);
               if (mutt_env_to_intl(msg->env, &tag, &err))
                 printw(_("Bad IDN in '%s': '%s'"), tag, err);
               /* tag is a statically allocated string and should not be freed */

--- a/email/email.c
+++ b/email/email.c
@@ -46,6 +46,7 @@ void mutt_email_free(struct Email **e)
   mutt_body_free(&(*e)->content);
   FREE(&(*e)->maildir_flags);
   FREE(&(*e)->tree);
+  FREE(&(*e)->fcc);
   FREE(&(*e)->path);
 #ifdef MIXMASTER
   mutt_list_free(&(*e)->chain);

--- a/email/email.h
+++ b/email/email.h
@@ -91,6 +91,7 @@ struct Email
   int score;
   struct Envelope *env;      /**< envelope information */
   struct Body *content;      /**< list of MIME parts */
+  char *fcc;
   char *path;
 
   char *tree; /**< character string to print thread tree */

--- a/hook.h
+++ b/hook.h
@@ -75,7 +75,7 @@ void  mutt_message_hook(struct Mailbox *m, struct Email *e, HookFlags type);
 enum CommandResult mutt_parse_idxfmt_hook(struct Buffer *buf, struct Buffer *s, unsigned long data, struct Buffer *err);
 enum CommandResult mutt_parse_hook(struct Buffer *buf, struct Buffer *s, unsigned long data, struct Buffer *err);
 enum CommandResult mutt_parse_unhook(struct Buffer *buf, struct Buffer *s, unsigned long data, struct Buffer *err);
-void  mutt_select_fcc(char *path, size_t pathlen, struct Email *e);
+void  mutt_select_fcc(struct Email *e);
 void  mutt_startup_shutdown_hook(HookFlags type);
 void  mutt_timeout_hook(void);
 

--- a/init.h
+++ b/init.h
@@ -2807,7 +2807,7 @@ struct ConfigDef MuttVars[] = {
   ** removed, while the inner \fCmultipart/signed\fP part is retained.
   ** (PGP only)
   */
-  { "pgp_self_encrypt",    DT_BOOL, R_NONE, &C_PgpSelfEncrypt, true },
+  { "pgp_self_encrypt",    DT_QUAD, R_NONE, &C_PgpSelfEncrypt, MUTT_YES },
   /*
   ** .pp
   ** When \fIset\fP, PGP encrypted messages will also be encrypted
@@ -3983,7 +3983,7 @@ struct ConfigDef MuttVars[] = {
   ** (S/MIME only)
   */
 #endif
-  { "smime_self_encrypt",    DT_BOOL, R_NONE, &C_SmimeSelfEncrypt, true },
+  { "smime_self_encrypt",    DT_QUAD, R_NONE, &C_SmimeSelfEncrypt, MUTT_YES },
   /*
   ** .pp
   ** When \fIset\fP, S/MIME encrypted messages will also be encrypted

--- a/init.h
+++ b/init.h
@@ -4770,8 +4770,6 @@ struct ConfigDef MuttVars[] = {
   /*--*/
 
   { "ignore_linear_white_space", DT_BOOL,   R_NONE,  &C_IgnoreLinearWhiteSpace, false },
-  { "pgp_encrypt_self",          DT_QUAD,   R_NONE,  &C_PgpEncryptSelf,         MUTT_NO },
-  { "smime_encrypt_self",        DT_QUAD,   R_NONE,  &C_SmimeEncryptSelf,       MUTT_NO },
   { "wrapmargin",                DT_NUMBER, R_PAGER, &C_Wrap,                   0 },
 
   { "abort_noattach_regexp",  DT_SYNONYM, R_NONE, NULL, IP "abort_noattach_regex",     },

--- a/init.h
+++ b/init.h
@@ -2810,8 +2810,8 @@ struct ConfigDef MuttVars[] = {
   { "pgp_self_encrypt",    DT_QUAD, R_NONE, &C_PgpSelfEncrypt, MUTT_YES },
   /*
   ** .pp
-  ** When \fIset\fP, PGP encrypted messages will also be encrypted
-  ** using the key in $$pgp_default_key.
+  ** When \fIset\fP, PGP encrypted messages that will be stored locally
+  ** by fcc, will also be encrypted using the key in $$pgp_default_key.
   ** (PGP only)
   */
   { "pgp_show_unusable", DT_BOOL, R_NONE, &C_PgpShowUnusable, true },
@@ -3986,8 +3986,8 @@ struct ConfigDef MuttVars[] = {
   { "smime_self_encrypt",    DT_QUAD, R_NONE, &C_SmimeSelfEncrypt, MUTT_YES },
   /*
   ** .pp
-  ** When \fIset\fP, S/MIME encrypted messages will also be encrypted
-  ** using the certificate in $$smime_default_key.
+  ** When \fIset\fP, S/MIME encrypted messages that will be stored locally
+  ** by fcc, will also be encrypted using the certificate in $$smime_default_key.
   ** (S/MIME only)
   */
   { "smime_sign_as",         DT_STRING, R_NONE, &C_SmimeSignAs, 0 },

--- a/init.h
+++ b/init.h
@@ -2812,6 +2812,8 @@ struct ConfigDef MuttVars[] = {
   ** .pp
   ** When \fIset\fP, PGP encrypted messages that will be stored locally
   ** by fcc, will also be encrypted using the key in $$pgp_default_key.
+  ** If $$pgp_default_key is empty, keys will be searched using the addresses
+  ** in the From header.
   ** (PGP only)
   */
   { "pgp_show_unusable", DT_BOOL, R_NONE, &C_PgpShowUnusable, true },
@@ -3988,6 +3990,8 @@ struct ConfigDef MuttVars[] = {
   ** .pp
   ** When \fIset\fP, S/MIME encrypted messages that will be stored locally
   ** by fcc, will also be encrypted using the certificate in $$smime_default_key.
+  ** If $$smime_default_key is empty, keys will be searched using the addresses
+  ** in the From header.
   ** (S/MIME only)
   */
   { "smime_sign_as",         DT_STRING, R_NONE, &C_SmimeSignAs, 0 },

--- a/mutt_header.c
+++ b/mutt_header.c
@@ -168,8 +168,7 @@ int mutt_label_message(struct Mailbox *m, struct EmailList *el)
  * @param fcc    Buffer for the fcc field
  * @param fcclen Length of buffer
  */
-void mutt_edit_headers(const char *editor, const char *body, struct Email *msg,
-                       char *fcc, size_t fcclen)
+void mutt_edit_headers(const char *editor, const char *body, struct Email *msg)
 {
   char path[PATH_MAX]; /* tempfile used to edit headers + body */
   char buf[1024];
@@ -286,13 +285,14 @@ void mutt_edit_headers(const char *editor, const char *body, struct Email *msg,
     bool keep = true;
     size_t plen;
 
-    if (fcc && (plen = mutt_str_startswith(np->data, "fcc:", CASE_IGNORE)))
+    if (msg->fcc && (plen = mutt_str_startswith(np->data, "fcc:", CASE_IGNORE)))
     {
       p = mutt_str_skip_email_wsp(np->data + plen);
       if (*p)
       {
-        mutt_str_strfcpy(fcc, p, fcclen);
-        mutt_pretty_mailbox(fcc, fcclen);
+        mutt_str_replace(&msg->fcc, p);
+        if (msg->fcc)
+          mutt_pretty_mailbox(msg->fcc, mutt_str_strlen(msg->fcc));
       }
       keep = false;
     }

--- a/mutt_header.h
+++ b/mutt_header.h
@@ -29,7 +29,7 @@ struct Context;
 struct Email;
 struct EmailList;
 
-void mutt_edit_headers(const char *editor, const char *body, struct Email *msg, char *fcc, size_t fcclen);
+void mutt_edit_headers(const char *editor, const char *body, struct Email *msg);
 void mutt_label_hash_add(struct Mailbox *m, struct Email *e);
 void mutt_label_hash_remove(struct Mailbox *m, struct Email *e);
 int mutt_label_message(struct Mailbox *m, struct EmailList *el);

--- a/ncrypt/crypt.c
+++ b/ncrypt/crypt.c
@@ -946,15 +946,19 @@ int crypt_get_keys(struct Email *msg, char **keylist, bool oppenc_mode)
       }
       if (q == MUTT_YES)
       {
-        if (C_PgpDefaultKey)
-          self_encrypt = C_PgpDefaultKey;
-        else
+        mutt_addr_append(&fromlist, msg->env->from, false);
+        keylist_from = crypt_pgp_find_keys(fromlist, 1);
+        self_encrypt = keylist_from;
+        if (!self_encrypt)
         {
-          mutt_addr_append(&fromlist, msg->env->from, false);
-          keylist_from = crypt_pgp_find_keys(fromlist, oppenc_mode);
-          mutt_addr_free(&fromlist);
-          self_encrypt = keylist_from;
+          self_encrypt = C_PgpDefaultKey;
+          if (!self_encrypt && !oppenc_mode)
+          {
+            keylist_from = crypt_pgp_find_keys(fromlist, oppenc_mode);
+            self_encrypt = keylist_from;
+          }
         }
+        mutt_addr_free(&fromlist);
         if (self_encrypt == NULL)
         {
           mutt_addr_free(&addrlist);
@@ -976,15 +980,19 @@ int crypt_get_keys(struct Email *msg, char **keylist, bool oppenc_mode)
       }
       if (q == MUTT_YES)
       {
-        if (C_SmimeDefaultKey)
-          self_encrypt = C_SmimeDefaultKey;
-        else
+        mutt_addr_append(&fromlist, msg->env->from, false);
+        keylist_from = crypt_smime_find_keys(fromlist, 1);
+        self_encrypt = keylist_from;
+        if (!self_encrypt)
         {
-          mutt_addr_append(&fromlist, msg->env->from, false);
-          keylist_from = crypt_smime_find_keys(fromlist, oppenc_mode);
-          mutt_addr_free(&fromlist);
-          self_encrypt = keylist_from;
+          self_encrypt = C_SmimeDefaultKey;
+          if (!self_encrypt && !oppenc_mode)
+          {
+            keylist_from = crypt_smime_find_keys(fromlist, oppenc_mode);
+            self_encrypt = keylist_from;
+          }
         }
+        mutt_addr_free(&fromlist);
         if (self_encrypt == NULL)
         {
           mutt_addr_free(&addrlist);

--- a/ncrypt/crypt.c
+++ b/ncrypt/crypt.c
@@ -62,12 +62,10 @@
 
 /* These Config Variables are only used in ncrypt/crypt.c */
 bool C_CryptTimestamp; ///< Config: Add a timestamp to PGP or SMIME output to prevent spoofing
-unsigned char C_PgpEncryptSelf;
 unsigned char C_PgpMimeAuto; ///< Config: Prompt the user to use MIME if inline PGP fails
 bool C_PgpRetainableSigs; ///< Config: Create nested multipart/signed or encrypted messages
 bool C_PgpSelfEncrypt; ///< Config: Encrypted messages will also be encrypted to C_PgpDefaultKey too
 bool C_PgpStrictEnc; ///< Config: Encode PGP signed messages with quoted-printable (don't unset)
-unsigned char C_SmimeEncryptSelf;
 bool C_SmimeSelfEncrypt; ///< Config: Encrypted messages will also be encrypt to C_SmimeDefaultKey too
 
 /**
@@ -942,7 +940,7 @@ int crypt_get_keys(struct Email *msg, char **keylist, bool oppenc_mode)
         return -1;
       }
       OptPgpCheckTrust = false;
-      if (C_PgpSelfEncrypt || (C_PgpEncryptSelf == MUTT_YES))
+      if (C_PgpSelfEncrypt == MUTT_YES)
         self_encrypt = C_PgpDefaultKey;
     }
     if (((WithCrypto & APPLICATION_SMIME) != 0) && (msg->security & APPLICATION_SMIME))
@@ -953,7 +951,7 @@ int crypt_get_keys(struct Email *msg, char **keylist, bool oppenc_mode)
         mutt_addr_free(&addrlist);
         return -1;
       }
-      if (C_SmimeSelfEncrypt || (C_SmimeEncryptSelf == MUTT_YES))
+      if (C_SmimeSelfEncrypt == MUTT_YES)
         self_encrypt = C_SmimeDefaultKey;
     }
   }

--- a/ncrypt/crypt.c
+++ b/ncrypt/crypt.c
@@ -935,9 +935,10 @@ int crypt_get_keys(struct Email *msg, char **keylist, bool oppenc_mode)
     if (((WithCrypto & APPLICATION_PGP) != 0) && (msg->security & APPLICATION_PGP))
     {
       *keylist = crypt_pgp_find_keys(addrlist, oppenc_mode);
-      if (!*keylist ||
+      q = MUTT_NO;
+      if (!*keylist || (msg->fcc && *msg->fcc &&
             (q = query_quadoption(C_PgpSelfEncrypt,
-              _("Do you want to be able to decrypt it yourself later?"))) == MUTT_ABORT)
+              _("Do you want to be able to decrypt it yourself later?"))) == MUTT_ABORT))
       {
         mutt_addr_free(&addrlist);
         return -1;
@@ -949,9 +950,10 @@ int crypt_get_keys(struct Email *msg, char **keylist, bool oppenc_mode)
     if (((WithCrypto & APPLICATION_SMIME) != 0) && (msg->security & APPLICATION_SMIME))
     {
       *keylist = crypt_smime_find_keys(addrlist, oppenc_mode);
-      if (!*keylist ||
+      q = MUTT_NO;
+      if (!*keylist || (msg->fcc && *msg->fcc &&
             (q = query_quadoption(C_SmimeSelfEncrypt,
-              _("Do you want to be able to decrypt it yourself later?"))) == MUTT_ABORT)
+              _("Do you want to be able to decrypt it yourself later?"))) == MUTT_ABORT))
       {
         mutt_addr_free(&addrlist);
         return -1;

--- a/ncrypt/ncrypt.h
+++ b/ncrypt/ncrypt.h
@@ -65,10 +65,10 @@ extern bool          C_CryptTimestamp;
 extern unsigned char C_PgpEncryptSelf; ///< Deprecated, see #C_PgpSelfEncrypt
 extern unsigned char C_PgpMimeAuto;
 extern bool          C_PgpRetainableSigs;
-extern bool          C_PgpSelfEncrypt;
+extern unsigned char C_PgpSelfEncrypt;
 extern bool          C_PgpStrictEnc;
 extern unsigned char C_SmimeEncryptSelf; ///< Deprecated, see #C_SmimeSelfEncrypt
-extern bool          C_SmimeSelfEncrypt;
+extern unsigned char C_SmimeSelfEncrypt;
 
 /* These Config Variables are only used in ncrypt/cryptglue.c */
 extern bool C_CryptUseGpgme;

--- a/po/de.po
+++ b/po/de.po
@@ -3360,6 +3360,10 @@ msgstr "S/MIME-Nachrichten ohne Hinweis auf den Inhalt werden nicht unterstützt
 msgid "Trying to extract PGP keys...\n"
 msgstr "Versuche PGP-Schlüssel zu extrahieren...\n"
 
+#: ncrypt/crypt.c:899 ncrypt/crypt.c:911
+msgid "Do you want to be able to decrypt it yourself later?"
+msgstr "Möchten Sie es später selber wieder entschlüsseln können?"
+
 #: ncrypt/crypt.c:876
 msgid "Trying to extract S/MIME certificates..."
 msgstr "Versuche S/MIME-Zertifikate zu extrahieren..."

--- a/postpone.c
+++ b/postpone.c
@@ -281,14 +281,11 @@ static struct Email *select_msg(struct Context *ctx)
  * @param[in]  ctx     Context info, used when recalling a message to which we reply
  * @param[in]  hdr     envelope/attachment info for recalled message
  * @param[out] cur     if message was a reply, 'cur' is set to the message which 'hdr' is in reply to
- * @param[in]  fcc     fcc for the recalled message
- * @param[in]  fcclen  max length of fcc
  * @retval -1         Error/no messages
  * @retval 0          Normal exit
  * @retval #SEND_REPLY Recalled message is a reply
  */
-int mutt_get_postponed(struct Context *ctx, struct Email *hdr,
-                       struct Email **cur, char *fcc, size_t fcclen)
+int mutt_get_postponed(struct Context *ctx, struct Email *hdr, struct Email **cur)
 {
   if (!C_Postponed)
     return -1;
@@ -382,8 +379,9 @@ int mutt_get_postponed(struct Context *ctx, struct Email *hdr,
     else if ((plen = mutt_str_startswith(np->data, "X-Mutt-Fcc:", CASE_IGNORE)))
     {
       p = mutt_str_skip_email_wsp(np->data + plen);
-      mutt_str_strfcpy(fcc, p, fcclen);
-      mutt_pretty_mailbox(fcc, fcclen);
+      mutt_str_replace(&hdr->fcc, p);
+      if (hdr->fcc)
+        mutt_pretty_mailbox(hdr->fcc, mutt_str_strlen(hdr->fcc));
 
       /* note that x-mutt-fcc was present.  we do this because we want to add a
        * default fcc if the header was missing, but preserve the request of the

--- a/protos.h
+++ b/protos.h
@@ -75,7 +75,7 @@ int mutt_prepare_template(FILE *fp, struct Mailbox *m, struct Email *newhdr, str
 int mutt_enter_string(char *buf, size_t buflen, int col, CompletionFlags flags);
 int mutt_enter_string_full(char *buf, size_t buflen, int col, CompletionFlags flags, bool multiple,
                            char ***files, int *numfiles, struct EnterState *state);
-int mutt_get_postponed(struct Context *ctx, struct Email *e, struct Email **cur, char *fcc, size_t fcclen);
+int mutt_get_postponed(struct Context *ctx, struct Email *e, struct Email **cur);
 SecurityFlags mutt_parse_crypt_hdr(const char *p, bool set_empty_signas, SecurityFlags crypt_app);
 int mutt_num_postponed(struct Mailbox *m, bool force);
 int mutt_thread_set_flag(struct Email *e, int flag, bool bf, bool subthread);


### PR DESCRIPTION
This patch adds the following features to self-encrypt:

  - *_self_encrypt is a quadoption,
  - if *_default_key is not set, the key is guessed from the "From:" header,
  - do nothing at all if the "Fcc:" field is empty.

The last feature needs an extension of struct Header. In the other case I had to add an fcc parameter to a _lot_ of functions. I put the redesign into a separate branch which I merged before I added the fcc feature.

A subject to discussion could be the name or meaning of the *_default_key variables. The current behaviour is:

  - look at the *_pgp_default variable
  - if empty, look at the From: header
  - if empty as well, ask the user.

Yet, the meaning of the word "default" is what should be done if no value is provided. Therefore, in my opinion, the proceeding should rather be something like:

  - look at the From: header
  - if empty, look at the *_pgp_default variable
  - if empty as well, bother the user with a menu.
