### PR TITLE
Simple replacements from mutt_mktemp() to mutt_file_mkstemp() in ncrypt

### DIFF
--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -2693,16 +2693,15 @@ int pgp_gpgme_application_handler(struct Body *m, struct State *s)
  */
 int pgp_gpgme_encrypted_handler(struct Body *a, struct State *s)
 {
-  char tempfile[PATH_MAX];
   int is_signed;
   int rc = 0;
 
   mutt_debug(2, "Entering handler\n");
 
-  mutt_mktemp(tempfile, sizeof(tempfile));
-  FILE *fpout = mutt_file_fopen(tempfile, "w+");
+  FILE *fpout = mutt_file_mkstemp();
   if (!fpout)
   {
+    mutt_perror("mutt_file_mkstemp() failed!");
     if (s->flags & MUTT_DISPLAY)
     {
       state_attach_puts(_("[-- Error: could not create temporary file! "
@@ -2759,7 +2758,6 @@ int pgp_gpgme_encrypted_handler(struct Body *a, struct State *s)
   }
 
   mutt_file_fclose(&fpout);
-  mutt_file_unlink(tempfile);
   mutt_debug(2, "Leaving handler\n");
 
   return rc;

--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -2765,17 +2765,16 @@ int pgp_gpgme_encrypted_handler(struct Body *a, struct State *s)
  */
 int smime_gpgme_application_handler(struct Body *a, struct State *s)
 {
-  char tempfile[PATH_MAX];
   int is_signed = 0;
   int rc = 0;
 
   mutt_debug(2, "Entering handler\n");
 
   a->warnsig = false;
-  mutt_mktemp(tempfile, sizeof(tempfile));
-  FILE *fpout = mutt_file_fopen(tempfile, "w+");
+  FILE *fpout = mutt_file_mkstemp();
   if (!fpout)
   {
+    mutt_perror("mutt_file_mkstemp() failed!");
     if (s->flags & MUTT_DISPLAY)
     {
       state_attach_puts(_("[-- Error: could not create temporary file! "
@@ -2834,7 +2833,6 @@ int smime_gpgme_application_handler(struct Body *a, struct State *s)
   }
 
   mutt_file_fclose(&fpout);
-  mutt_file_unlink(tempfile);
   mutt_debug(2, "Leaving handler\n");
 
   return rc;

--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -2122,7 +2122,6 @@ static int pgp_gpgme_extract_keys(gpgme_data_t keydata, FILE **fp, int dryrun)
   /* there's no side-effect free way to view key data in GPGME,
    * so we import the key into a temporary keyring */
   char tmpdir[PATH_MAX];
-  char tmpfile[PATH_MAX];
   gpgme_ctx_t tmpctx;
   gpgme_error_t err;
   gpgme_engine_info_t engineinfo;
@@ -2177,14 +2176,12 @@ static int pgp_gpgme_extract_keys(gpgme_data_t keydata, FILE **fp, int dryrun)
     goto err_tmpdir;
   }
 
-  mutt_mktemp(tmpfile, sizeof(tmpfile));
-  *fp = mutt_file_fopen(tmpfile, "w+");
+  *fp = mutt_file_mkstemp();
   if (!*fp)
   {
-    mutt_perror(tmpfile);
+    mutt_perror("mutt_file_mkstemp() failed!");
     goto err_tmpdir;
   }
-  unlink(tmpfile);
 
   err = gpgme_op_keylist_start(tmpctx, NULL, 0);
   while (!err)

--- a/ncrypt/pgp.c
+++ b/ncrypt/pgp.c
@@ -799,8 +799,8 @@ int pgp_class_check_traditional(FILE *fp, struct Body *b, bool just_one)
  */
 int pgp_class_verify_one(struct Body *sigbdy, struct State *s, const char *tempfile)
 {
-  char sigfile[PATH_MAX], pgperrfile[PATH_MAX];
-  FILE *pgpout = NULL, *pgperr = NULL;
+  char sigfile[PATH_MAX];
+  FILE *pgpout = NULL;
   pid_t thepid;
   int badsig = -1;
 
@@ -817,11 +817,10 @@ int pgp_class_verify_one(struct Body *sigbdy, struct State *s, const char *tempf
   mutt_file_copy_bytes(s->fpin, fp, sigbdy->length);
   mutt_file_fclose(&fp);
 
-  mutt_mktemp(pgperrfile, sizeof(pgperrfile));
-  pgperr = mutt_file_fopen(pgperrfile, "w+");
+  FILE *pgperr = mutt_file_mkstemp();
   if (!pgperr)
   {
-    mutt_perror(pgperrfile);
+    mutt_perror("mutt_file_mkstemp() failed!");
     unlink(sigfile);
     return -1;
   }
@@ -853,7 +852,6 @@ int pgp_class_verify_one(struct Body *sigbdy, struct State *s, const char *tempf
   state_attach_puts(_("[-- End of PGP output --]\n\n"), s);
 
   mutt_file_unlink(sigfile);
-  mutt_file_unlink(pgperrfile);
 
   mutt_debug(1, "returning %d.\n", badsig);
 

--- a/ncrypt/pgp.c
+++ b/ncrypt/pgp.c
@@ -915,19 +915,16 @@ static struct Body *pgp_decrypt_part(struct Body *a, struct State *s,
   FILE *pgpin = NULL, *pgpout = NULL, *pgptmp = NULL;
   struct stat info;
   struct Body *tattach = NULL;
-  char pgperrfile[PATH_MAX];
   char pgptmpfile[PATH_MAX];
   pid_t thepid;
   int rv;
 
-  mutt_mktemp(pgperrfile, sizeof(pgperrfile));
-  FILE *pgperr = mutt_file_fopen(pgperrfile, "w+");
+  FILE *pgperr = mutt_file_mkstemp();
   if (!pgperr)
   {
-    mutt_perror(pgperrfile);
+    mutt_perror("mutt_file_mkstemp() failed!");
     return NULL;
   }
-  unlink(pgperrfile);
 
   mutt_mktemp(pgptmpfile, sizeof(pgptmpfile));
   pgptmp = mutt_file_fopen(pgptmpfile, "w");

--- a/ncrypt/pgp.c
+++ b/ncrypt/pgp.c
@@ -1441,9 +1441,9 @@ char *pgp_class_find_keys(struct Address *addrlist, bool oppenc_mode)
 struct Body *pgp_class_encrypt_message(struct Body *a, char *keylist, bool sign)
 {
   char buf[LONG_STRING];
-  char tempfile[PATH_MAX], pgperrfile[PATH_MAX];
+  char tempfile[PATH_MAX];
   char pgpinfile[PATH_MAX];
-  FILE *pgpin = NULL, *pgperr = NULL, *fptmp = NULL;
+  FILE *pgpin = NULL, *fptmp = NULL;
   struct Body *t = NULL;
   int err = 0;
   int empty = 0;
@@ -1457,16 +1457,14 @@ struct Body *pgp_class_encrypt_message(struct Body *a, char *keylist, bool sign)
     return NULL;
   }
 
-  mutt_mktemp(pgperrfile, sizeof(pgperrfile));
-  pgperr = mutt_file_fopen(pgperrfile, "w+");
+  FILE *pgperr = mutt_file_mkstemp();
   if (!pgperr)
   {
-    mutt_perror(pgperrfile);
+    mutt_perror("mutt_file_mkstemp() failed!");
     unlink(tempfile);
     mutt_file_fclose(&fpout);
     return NULL;
   }
-  unlink(pgperrfile);
 
   mutt_mktemp(pgpinfile, sizeof(pgpinfile));
   fptmp = mutt_file_fopen(pgpinfile, "w");

--- a/ncrypt/pgp.c
+++ b/ncrypt/pgp.c
@@ -1119,15 +1119,14 @@ bail:
  */
 int pgp_class_encrypted_handler(struct Body *a, struct State *s)
 {
-  char tempfile[PATH_MAX];
   FILE *fpin = NULL;
   struct Body *tattach = NULL;
   int rc = 0;
 
-  mutt_mktemp(tempfile, sizeof(tempfile));
-  FILE *fpout = mutt_file_fopen(tempfile, "w+");
+  FILE *fpout = mutt_file_mkstemp();
   if (!fpout)
   {
+    mutt_perror("mutt_file_mkstemp() failed!");
     if (s->flags & MUTT_DISPLAY)
       state_attach_puts(_("[-- Error: could not create temporary file! --]\n"), s);
     return -1;
@@ -1179,7 +1178,6 @@ int pgp_class_encrypted_handler(struct Body *a, struct State *s)
   }
 
   mutt_file_fclose(&fpout);
-  mutt_file_unlink(tempfile);
 
   return rc;
 }

--- a/ncrypt/pgp.c
+++ b/ncrypt/pgp.c
@@ -407,7 +407,6 @@ int pgp_class_application_handler(struct Body *m, struct State *s)
   long bytes;
   LOFF_T last_pos, offset;
   char buf[HUGE_STRING];
-  char pgpoutfile[PATH_MAX];
   char pgperrfile[PATH_MAX];
   char tmpfname[PATH_MAX];
   FILE *pgpout = NULL, *pgpin = NULL, *pgperr = NULL;
@@ -510,16 +509,13 @@ int pgp_class_application_handler(struct Body *m, struct State *s)
       /* Invoke PGP if needed */
       if (!clearsign || (s->flags & MUTT_VERIFY))
       {
-        mutt_mktemp(pgpoutfile, sizeof(pgpoutfile));
-        pgpout = mutt_file_fopen(pgpoutfile, "w+");
+        pgpout = mutt_file_mkstemp();
         if (!pgpout)
         {
-          mutt_perror(pgpoutfile);
+          mutt_perror("mutt_file_mkstemp() failed!");
           rc = -1;
           goto out;
         }
-
-        unlink(pgpoutfile);
 
         mutt_mktemp(pgperrfile, sizeof(pgperrfile));
         if ((pgperr = mutt_file_fopen(pgperrfile, "w+")) == NULL)

--- a/ncrypt/pgp.c
+++ b/ncrypt/pgp.c
@@ -1042,7 +1042,6 @@ static struct Body *pgp_decrypt_part(struct Body *a, struct State *s,
  */
 int pgp_class_decrypt_mime(FILE *fpin, FILE **fpout, struct Body *b, struct Body **cur)
 {
-  char tempfile[PATH_MAX];
   struct State s = { 0 };
   struct Body *p = b;
   bool need_decode = false;
@@ -1070,14 +1069,12 @@ int pgp_class_decrypt_mime(FILE *fpin, FILE **fpout, struct Body *b, struct Body
     saved_offset = b->offset;
     saved_length = b->length;
 
-    mutt_mktemp(tempfile, sizeof(tempfile));
-    decoded_fp = mutt_file_fopen(tempfile, "w+");
+    decoded_fp = mutt_file_mkstemp();
     if (!decoded_fp)
     {
-      mutt_perror(tempfile);
+      mutt_perror("mutt_file_mkstemp() failed!");
       return -1;
     }
-    unlink(tempfile);
 
     fseeko(s.fpin, b->offset, SEEK_SET);
     s.fpout = decoded_fp;
@@ -1092,15 +1089,13 @@ int pgp_class_decrypt_mime(FILE *fpin, FILE **fpout, struct Body *b, struct Body
     s.fpout = 0;
   }
 
-  mutt_mktemp(tempfile, sizeof(tempfile));
-  *fpout = mutt_file_fopen(tempfile, "w+");
+  *fpout = mutt_file_mkstemp();
   if (!*fpout)
   {
-    mutt_perror(tempfile);
+    mutt_perror("mutt_file_mkstemp() failed!");
     rc = -1;
     goto bail;
   }
-  unlink(tempfile);
 
   *cur = pgp_decrypt_part(b, &s, *fpout, p);
   if (!*cur)

--- a/ncrypt/pgp.c
+++ b/ncrypt/pgp.c
@@ -407,7 +407,6 @@ int pgp_class_application_handler(struct Body *m, struct State *s)
   long bytes;
   LOFF_T last_pos, offset;
   char buf[HUGE_STRING];
-  char pgperrfile[PATH_MAX];
   char tmpfname[PATH_MAX];
   FILE *pgpout = NULL, *pgpin = NULL, *pgperr = NULL;
   FILE *tmpfp = NULL;
@@ -517,14 +516,13 @@ int pgp_class_application_handler(struct Body *m, struct State *s)
           goto out;
         }
 
-        mutt_mktemp(pgperrfile, sizeof(pgperrfile));
-        if ((pgperr = mutt_file_fopen(pgperrfile, "w+")) == NULL)
+        pgperr = mutt_file_mkstemp();
+        if (!pgperr)
         {
-          mutt_perror(pgperrfile);
+          mutt_perror("mutt_file_mkstemp() failed!");
           rc = -1;
           goto out;
         }
-        unlink(pgperrfile);
 
         thepid = pgp_invoke_decode(&pgpin, NULL, NULL, -1, fileno(pgpout),
                                    fileno(pgperr), tmpfname, (needpass != 0));

--- a/ncrypt/pgpmicalg.c
+++ b/ncrypt/pgpmicalg.c
@@ -159,18 +159,15 @@ static short pgp_mic_from_packet(unsigned char *p, size_t len)
 
 static short pgp_find_hash(const char *fname)
 {
-  char tempfile[PATH_MAX];
   size_t l;
   short rc = -1;
 
-  mutt_mktemp(tempfile, sizeof(tempfile));
-  FILE *out = mutt_file_fopen(tempfile, "w+");
+  FILE *out = mutt_file_mkstemp();
   if (!out)
   {
-    mutt_perror(tempfile);
+    mutt_perror("mutt_file_mkstemp() failed!");
     goto bye;
   }
-  unlink(tempfile);
 
   FILE *in = fopen(fname, "r");
   if (!in)

--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -1387,7 +1387,7 @@ static pid_t smime_invoke_sign(FILE **smimein, FILE **smimeout, FILE **smimeerr,
 struct Body *smime_class_build_smime_entity(struct Body *a, char *certlist)
 {
   char buf[LONG_STRING], certfile[PATH_MAX];
-  char tempfile[PATH_MAX], smimeerrfile[PATH_MAX];
+  char tempfile[PATH_MAX];
   char smimeinfile[PATH_MAX];
   char *cert_start, *cert_end;
   FILE *smimein = NULL;
@@ -1402,16 +1402,14 @@ struct Body *smime_class_build_smime_entity(struct Body *a, char *certlist)
     return NULL;
   }
 
-  mutt_mktemp(smimeerrfile, sizeof(smimeerrfile));
-  FILE *smimeerr = mutt_file_fopen(smimeerrfile, "w+");
+  FILE *smimeerr = mutt_file_mkstemp();
   if (!smimeerr)
   {
-    mutt_perror(smimeerrfile);
+    mutt_perror("mutt_file_mkstemp() failed!");
     mutt_file_unlink(tempfile);
     mutt_file_fclose(&fpout);
     return NULL;
   }
-  mutt_file_unlink(smimeerrfile);
 
   mutt_mktemp(smimeinfile, sizeof(smimeinfile));
   FILE *fptmp = mutt_file_fopen(smimeinfile, "w+");

--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -1159,18 +1159,15 @@ static char *smime_extract_certificate(char *infile)
 static char *smime_extract_signer_certificate(char *infile)
 {
   char certfile[PATH_MAX];
-  char tmpfname[PATH_MAX];
   pid_t thepid;
   int empty;
 
-  mutt_mktemp(tmpfname, sizeof(tmpfname));
-  FILE *fperr = mutt_file_fopen(tmpfname, "w+");
+  FILE *fperr = mutt_file_mkstemp();
   if (!fperr)
   {
-    mutt_perror(tmpfname);
+    mutt_perror("mutt_file_mkstemp() failed!");
     return NULL;
   }
-  mutt_file_unlink(tmpfname);
 
   mutt_mktemp(certfile, sizeof(certfile));
   FILE *fpout = mutt_file_fopen(certfile, "w+");

--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -1691,7 +1691,7 @@ static pid_t smime_invoke_decrypt(FILE **smimein, FILE **smimeout,
  */
 int smime_class_verify_one(struct Body *sigbdy, struct State *s, const char *tempfile)
 {
-  char signedfile[PATH_MAX], smimeerrfile[PATH_MAX];
+  char signedfile[PATH_MAX];
   FILE *smimeout = NULL;
   pid_t thepid;
   int badsig = -1;
@@ -1738,11 +1738,10 @@ int smime_class_verify_one(struct Body *sigbdy, struct State *s, const char *tem
 
   sigbdy->type = orig_type;
 
-  mutt_mktemp(smimeerrfile, sizeof(smimeerrfile));
-  FILE *smimeerr = mutt_file_fopen(smimeerrfile, "w+");
+  FILE *smimeerr = mutt_file_mkstemp();
   if (!smimeerr)
   {
-    mutt_perror(smimeerrfile);
+    mutt_perror("mutt_file_mkstemp() failed!");
     mutt_file_unlink(signedfile);
     return -1;
   }
@@ -1783,7 +1782,6 @@ int smime_class_verify_one(struct Body *sigbdy, struct State *s, const char *tem
   state_attach_puts(_("[-- End of OpenSSL output --]\n\n"), s);
 
   mutt_file_unlink(signedfile);
-  mutt_file_unlink(smimeerrfile);
 
   sigbdy->length = tmplength;
   sigbdy->offset = tmpoffset;

--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -1789,7 +1789,6 @@ int smime_class_verify_one(struct Body *sigbdy, struct State *s, const char *tem
  */
 static struct Body *smime_handle_entity(struct Body *m, struct State *s, FILE *out_file)
 {
-  char errfile[PATH_MAX];
   char tmpfname[PATH_MAX];
   FILE *tmpfp = NULL, *tmpfp_buffer = NULL, *fpout = NULL;
   struct stat info;
@@ -1810,11 +1809,10 @@ static struct Body *smime_handle_entity(struct Body *m, struct State *s, FILE *o
   FILE *smimeerr = mutt_file_mkstemp();
   if (!smimeerr)
   {
-    mutt_perror(errfile);
+    mutt_perror("mutt_file_mkstemp() failed!");
     mutt_file_fclose(&smimeout);
     return NULL;
   }
-  mutt_file_unlink(errfile);
 
   mutt_mktemp(tmpfname, sizeof(tmpfname));
   tmpfp = mutt_file_fopen(tmpfname, "w+");

--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -1226,27 +1226,23 @@ static char *smime_extract_signer_certificate(char *infile)
  */
 void smime_class_invoke_import(char *infile, char *mailbox)
 {
-  char tmpfname[PATH_MAX], *certfile = NULL, buf[STRING];
+  char *certfile = NULL, buf[STRING];
   FILE *smimein = NULL;
 
-  mutt_mktemp(tmpfname, sizeof(tmpfname));
-  FILE *fperr = mutt_file_fopen(tmpfname, "w+");
+  FILE *fperr = mutt_file_mkstemp();
   if (!fperr)
   {
-    mutt_perror(tmpfname);
+    mutt_perror("mutt_file_mkstemp() failed!");
     return;
   }
-  mutt_file_unlink(tmpfname);
 
-  mutt_mktemp(tmpfname, sizeof(tmpfname));
-  FILE *fpout = mutt_file_fopen(tmpfname, "w+");
+  FILE *fpout = mutt_file_mkstemp();
   if (!fpout)
   {
     mutt_file_fclose(&fperr);
-    mutt_perror(tmpfname);
+    mutt_perror("mutt_file_mkstemp() failed!");
     return;
   }
-  mutt_file_unlink(tmpfname);
 
   buf[0] = '\0';
   if (SmimeAskCertLabel)

--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -1908,16 +1908,14 @@ static struct Body *smime_handle_entity(struct Body *m, struct State *s, FILE *o
     fflush(smimeout);
     rewind(smimeout);
 
-    char tmptmpfname[PATH_MAX];
     if (out_file)
       fpout = out_file;
     else
     {
-      mutt_mktemp(tmptmpfname, sizeof(tmptmpfname));
-      fpout = mutt_file_fopen(tmptmpfname, "w+");
+      fpout = mutt_file_mkstemp();
       if (!fpout)
       {
-        mutt_perror(tmptmpfname);
+        mutt_perror("mutt_file_mkstemp() failed!");
         mutt_file_fclose(&smimeout);
         mutt_file_fclose(&smimeerr);
         return NULL;
@@ -1960,7 +1958,6 @@ static struct Body *smime_handle_entity(struct Body *m, struct State *s, FILE *o
     if (!out_file)
     {
       mutt_file_fclose(&fpout);
-      mutt_file_unlink(tmptmpfname);
     }
     fpout = NULL;
   }

--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -962,30 +962,25 @@ char *smime_class_find_keys(struct Address *addrlist, bool oppenc_mode)
 static int smime_handle_cert_email(char *certificate, char *mailbox, int copy,
                                    char ***buffer, int *num)
 {
-  char tmpfname[PATH_MAX];
   char email[STRING];
   int rc = -1, count = 0;
   pid_t thepid;
   size_t len = 0;
 
-  mutt_mktemp(tmpfname, sizeof(tmpfname));
-  FILE *fperr = mutt_file_fopen(tmpfname, "w+");
+  FILE *fperr = mutt_file_mkstemp();
   if (!fperr)
   {
-    mutt_perror(tmpfname);
+    mutt_perror("mutt_file_mkstemp() failed!");
     return 1;
   }
-  mutt_file_unlink(tmpfname);
 
-  mutt_mktemp(tmpfname, sizeof(tmpfname));
-  FILE *fpout = mutt_file_fopen(tmpfname, "w+");
+  FILE *fpout = mutt_file_mkstemp();
   if (!fpout)
   {
     mutt_file_fclose(&fperr);
-    mutt_perror(tmpfname);
+    mutt_perror("mutt_file_mkstemp() failed!");
     return 1;
   }
-  mutt_file_unlink(tmpfname);
 
   thepid = smime_invoke(NULL, NULL, NULL, -1, fileno(fpout), fileno(fperr), certificate,
                         NULL, NULL, NULL, NULL, NULL, NULL, SmimeGetCertEmailCommand);

--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -1057,18 +1057,15 @@ static int smime_handle_cert_email(char *certificate, char *mailbox, int copy,
 static char *smime_extract_certificate(char *infile)
 {
   char pk7out[PATH_MAX], certfile[PATH_MAX];
-  char tmpfname[PATH_MAX];
   pid_t thepid;
   int empty;
 
-  mutt_mktemp(tmpfname, sizeof(tmpfname));
-  FILE *fperr = mutt_file_fopen(tmpfname, "w+");
+  FILE *fperr = mutt_file_mkstemp();
   if (!fperr)
   {
-    mutt_perror(tmpfname);
+    mutt_perror("mutt_file_mkstemp() failed");
     return NULL;
   }
-  mutt_file_unlink(tmpfname);
 
   mutt_mktemp(pk7out, sizeof(pk7out));
   FILE *fpout = mutt_file_fopen(pk7out, "w+");


### PR DESCRIPTION
* **What does this PR do?**

Replace `mutt_mktemp()` to `mutt_file_mkstemp()` where it is easily done

* **What are the relevant issue numbers?**

#960