### PR TITLE
Do not interrupt switch fallthrough

### DIFF
--- a/curs_main.c
+++ b/curs_main.c
@@ -1905,6 +1905,10 @@ int mutt_index_menu(void)
         break;
       }
 
+      case OP_CHECK_STATS:
+        mutt_check_stats();
+        break;
+
 #ifdef USE_NOTMUCH
       case OP_MAIN_VFOLDER_FROM_QUERY:
         buf[0] = '\0';
@@ -1963,10 +1967,6 @@ int mutt_index_menu(void)
 
       case OP_MAIN_CHANGE_VFOLDER:
 #endif
-
-      case OP_CHECK_STATS:
-        mutt_check_stats();
-        break;
 
 #ifdef USE_SIDEBAR
       case OP_SIDEBAR_OPEN:


### PR DESCRIPTION
### What does this PR do?

Commit e85c735 introduced the `check-stats` function, designated by
`OP_CHECK_STATS`.

`OP_CHECK_STATS` had been inserted below `OP_MAIN_CHANGE_VFOLDER`, which is
`change-vfolder`'s designation; however, `OP_MAIN_CHANGE_VFOLDER` relies
on C's switch fallthrough logic to execute. As a result,
`change-vfolder` executed `check-stats`'s logic instead of the correct
logic.

This PR moves `OP_CHECK_STATS` to above the `#ifdef` that contains
`OP_MAIN_CHANGE_VFOLDER`, allowing the original `change-vfolder` logic to 
execute instead of `check-stats`'s logic.

#### What are the relevant issue numbers?

Issue #1284
