### PR TITLE
 add keep_ctx config option 

### DIFF
--- a/buffy.h
+++ b/buffy.h
@@ -27,6 +27,7 @@
 #include <stdbool.h>
 #include <sys/types.h>
 #include <time.h>
+#include "context.h"
 #include "where.h"
 
 struct Buffer;
@@ -53,6 +54,7 @@ struct Buffy
   char *desc;
   off_t size;
   struct Buffy *next;
+  struct Context *ctx;       /**< store context for re-use */
   bool new; /**< mailbox has new mail */
 
   /* These next three are only set when MailCheckStats is set */

--- a/globals.h
+++ b/globals.h
@@ -226,6 +226,7 @@ WHERE bool ImapCheckSubscribed;
 WHERE bool ImapListSubscribed;
 WHERE bool ImapPassive;
 WHERE bool ImapPeek;
+WHERE bool KeepCtx;
 #endif
 #ifdef USE_SSL
 #ifndef USE_SSL_GNUTLS

--- a/init.h
+++ b/init.h
@@ -1709,6 +1709,12 @@ struct Option MuttVars[] = {
   ** .pp
   ** How to invoke ispell (GNU's spell-checking software).
   */
+  { "keep_ctx", DT_BOOL, R_NONE, &KeepCtx, false },
+  /*
+  ** .pp
+  ** If \fIset\fP, mailbox contexts are kept in memory, instead of
+  ** being discarded on mailbox switch.
+  */
   { "keep_flagged", DT_BOOL, R_NONE, &KeepFlagged, false },
   /*
   ** .pp


### PR DESCRIPTION
* **What does this PR do?**

Mailbox contexts are kept in memory, instead of being discarded on
mailbox switch. This comes with the trade-off of requiring more memory.
However, switching mailboxes is ultra-fast once they've been loaded.

This is a first attempt to implement this, not asking for a merge yet.
Feedback is welcome though!