### PR TITLE
Relative config variables (part 2)

### DIFF
--- a/init.c
+++ b/init.c
@@ -2212,10 +2212,13 @@ static int parse_set(struct Buffer *buf, struct Buffer *s, unsigned long data,
           mutt_str_strfcpy(scratch, buf->data, sizeof(scratch));
           mutt_expand_path(scratch, sizeof(scratch));
 
-          struct ListNode *np = STAILQ_FIRST(&MuttrcStack);
-          if (!mutt_file_to_absolute_path(scratch, np ? NONULL(np->data) : "./"))
+          if (url_check_scheme(scratch) == U_UNKNOWN) /* probably a local file */
           {
-            mutt_error("Error: impossible to build path of '%s'.", scratch);
+            struct ListNode *np = STAILQ_FIRST(&MuttrcStack);
+            if (!mutt_file_to_absolute_path(scratch, np ? NONULL(np->data) : "./"))
+            {
+              mutt_error("Error: impossible to build path of '%s'.", scratch);
+            }
           }
 
           if (mutt_str_strcmp(MuttVars[idx].name, "debug_file") == 0)
@@ -4260,10 +4263,13 @@ int mutt_option_set(const struct Option *val, struct Buffer *err)
         mutt_str_strfcpy(scratch, NONULL((const char *) val->var), sizeof(scratch));
         mutt_expand_path(scratch, sizeof(scratch));
 
-        struct ListNode *np = STAILQ_FIRST(&MuttrcStack);
-        if (!mutt_file_to_absolute_path(scratch, np ? NONULL(np->data) : "./"))
+        if (url_check_scheme(scratch) == U_UNKNOWN) /* probably a local file */
         {
-          mutt_error("Error: impossible to build path of '%s'.", scratch);
+          struct ListNode *np = STAILQ_FIRST(&MuttrcStack);
+          if (!mutt_file_to_absolute_path(scratch, np ? NONULL(np->data) : "./"))
+          {
+            mutt_error("Error: impossible to build path of '%s'.", scratch);
+          }
         }
 
         /* MuttVars[idx].var is already 'char**' (or some 'void**') or...

--- a/init.c
+++ b/init.c
@@ -1069,7 +1069,6 @@ static void restore_default(struct Option *p)
   switch (DTYPE(p->type))
   {
     case DT_STRING:
-    case DT_COMMAND:
       mutt_str_replace((char **) p->var, (char *) p->initial);
       break;
     case DT_MBTABLE:
@@ -1131,6 +1130,20 @@ static void restore_default(struct Option *p)
       *ptr = mutt_regex_create((const char *) p->initial, p->type, NULL);
       break;
     }
+    case DT_COMMAND:
+    {
+      char *init = (char *) p->initial;
+      FREE((char **) p->var);
+      if (init)
+      {
+        char command[LONG_STRING];
+        mutt_str_strfcpy(command, init, sizeof(command));
+        mutt_expand_path(command, sizeof(command));
+        *((char **) p->var) = mutt_str_strdup(command);
+      }
+
+      break;
+    }
   }
 
   if (p->flags & R_INDEX)
@@ -1169,11 +1182,11 @@ static void set_default(struct Option *p)
   switch (DTYPE(p->type))
   {
     case DT_STRING:
-    case DT_COMMAND:
       if (!p->initial && *((char **) p->var))
         p->initial = (unsigned long) mutt_str_strdup(*((char **) p->var));
       break;
     case DT_PATH:
+    case DT_COMMAND:
       if (!p->initial && *((char **) p->var))
       {
         char *cp = mutt_str_strdup(*((char **) p->var));
@@ -2155,6 +2168,13 @@ static int parse_set(struct Buffer *buf, struct Buffer *s, unsigned long data,
           mutt_pretty_mailbox(tmp2, sizeof(tmp2));
           val = tmp2;
         }
+        else if (DTYPE(MuttVars[idx].type) == DT_COMMAND)
+        {
+          tmp2[0] = '\0';
+          mutt_str_strfcpy(tmp2, NONULL(*((char **) MuttVars[idx].var)), sizeof(tmp2));
+          mutt_pretty_mailbox(tmp2, sizeof(tmp2));
+          val = tmp2;
+        }
         else if (DTYPE(MuttVars[idx].type) == DT_MBTABLE)
         {
           struct MbTable *mbt = (*((struct MbTable **) MuttVars[idx].var));
@@ -2191,6 +2211,13 @@ static int parse_set(struct Buffer *buf, struct Buffer *s, unsigned long data,
           char scratch[PATH_MAX];
           mutt_str_strfcpy(scratch, buf->data, sizeof(scratch));
           mutt_expand_path(scratch, sizeof(scratch));
+
+          struct ListNode *np = STAILQ_FIRST(&MuttrcStack);
+          if (!mutt_file_to_absolute_path(scratch, np ? NONULL(np->data) : "./"))
+          {
+            mutt_error("Error: impossible to build path of '%s'.", scratch);
+          }
+
           if (mutt_str_strcmp(MuttVars[idx].name, "debug_file") == 0)
           {
             mutt_log_set_file(scratch, true);
@@ -2203,8 +2230,17 @@ static int parse_set(struct Buffer *buf, struct Buffer *s, unsigned long data,
             *((char **) MuttVars[idx].var) = mutt_str_strdup(scratch);
           }
         }
-        else if ((idx >= 0) && ((DTYPE(MuttVars[idx].type) == DT_STRING) ||
-                                (DTYPE(MuttVars[idx].type) == DT_COMMAND)))
+        else if ((idx >= 0) && (DTYPE(MuttVars[idx].type) == DT_COMMAND))
+        {
+          char scratch[PATH_MAX];
+          mutt_str_strfcpy(scratch, buf->data, sizeof(scratch));
+          mutt_expand_path(scratch, sizeof(scratch));
+          /* MuttVars[idx].var is already 'char**' (or some 'void**') or...
+           * so cast to 'void*' is okay */
+          FREE((void *) MuttVars[idx].var);
+          *((char **) MuttVars[idx].var) = mutt_str_strdup(scratch);
+        }
+        else if ((idx >= 0) && (DTYPE(MuttVars[idx].type) == DT_STRING))
         {
           if ((strstr(MuttVars[idx].name, "charset") &&
                check_charset(&MuttVars[idx], buf->data) < 0) |
@@ -4223,6 +4259,25 @@ int mutt_option_set(const struct Option *val, struct Buffer *err)
         char scratch[LONG_STRING];
         mutt_str_strfcpy(scratch, NONULL((const char *) val->var), sizeof(scratch));
         mutt_expand_path(scratch, sizeof(scratch));
+
+        struct ListNode *np = STAILQ_FIRST(&MuttrcStack);
+        if (!mutt_file_to_absolute_path(scratch, np ? NONULL(np->data) : "./"))
+        {
+          mutt_error("Error: impossible to build path of '%s'.", scratch);
+        }
+
+        /* MuttVars[idx].var is already 'char**' (or some 'void**') or...
+         * so cast to 'void*' is okay */
+        FREE((void *) MuttVars[idx].var);
+        *((char **) MuttVars[idx].var) = mutt_str_strdup(scratch);
+        break;
+      }
+      case DT_COMMAND:
+      {
+        char scratch[LONG_STRING];
+        mutt_str_strfcpy(scratch, NONULL((const char *) val->var), sizeof(scratch));
+        mutt_expand_path(scratch, sizeof(scratch));
+
         /* MuttVars[idx].var is already 'char**' (or some 'void**') or...
          * so cast to 'void*' is okay */
         FREE((void *) MuttVars[idx].var);
@@ -4230,7 +4285,6 @@ int mutt_option_set(const struct Option *val, struct Buffer *err)
         break;
       }
       case DT_STRING:
-      case DT_COMMAND:
       {
         /* MuttVars[idx].var is already 'char**' (or some 'void**') or...
          * so cast to 'void*' is okay */
@@ -4458,7 +4512,8 @@ int var_to_string(int idx, char *val, size_t len)
 
   tmp[0] = '\0';
 
-  if ((DTYPE(MuttVars[idx].type) == DT_STRING) || (DTYPE(MuttVars[idx].type) == DT_PATH))
+  if ((DTYPE(MuttVars[idx].type) == DT_STRING) || (DTYPE(MuttVars[idx].type) == DT_PATH) ||
+      (DTYPE(MuttVars[idx].type) == DT_COMMAND))
   {
     mutt_str_strfcpy(tmp, NONULL(*((char **) MuttVars[idx].var)), sizeof(tmp));
     if (DTYPE(MuttVars[idx].type) == DT_PATH)

--- a/mutt/file.c
+++ b/mutt/file.c
@@ -1328,8 +1328,7 @@ int mutt_file_to_absolute_path(char *path, const char *reference)
   mutt_str_strncat(abs_path, sizeof(abs_path), path, path_len > 0 ? path_len : 0);
 
   path = realpath(abs_path, path);
-
-  if (!path)
+  if (!path && (errno != ENOENT))
   {
     printf("Error: issue converting path to absolute (%s)", strerror(errno));
     return false;


### PR DESCRIPTION
#1274 allowed more config variables to be used relatively.

Unfortunately there's a bug.
@gahr said:
I think we have a regression here:

My signature is
```
set signature = "echo 'Pietro Cerutti'|"
```

Previously this resulted in my name, now `:set ?signature` gives me
```
signature="/usr/home/gahr/.config/neomutt/echo 'Pietro Cerutti'|"
```

@mjsir911 
Please can you have a look at it.
