### PR TITLE
Report GPGme version in neomutt -v

### DIFF
--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -5198,3 +5198,8 @@ void pgp_gpgme_set_sender(const char *sender)
   FREE(&current_sender);
   current_sender = mutt_str_strdup(sender);
 }
+
+const char *mutt_gpgme_print_version()
+{
+    return GPGME_VERSION;
+}

--- a/version.c
+++ b/version.c
@@ -383,6 +383,10 @@ void print_version(void)
   printf("\n%s", mutt_idna_print_version());
 #endif
 
+#ifdef CRYPT_BACKEND_GPGME
+  printf("\nGPGme: %s", mutt_gpgme_print_version());
+#endif
+
 #ifdef USE_HCACHE
   const char *backends = mutt_hcache_backend_list();
   printf("\nhcache backends: %s", backends);


### PR DESCRIPTION
* **What does this PR do?**

Nothing fancy, just add GPGme version to neomutt -v output