### PR TITLE
Attachmentfix

### DIFF
--- a/mutt_attach.c
+++ b/mutt_attach.c
@@ -633,6 +633,9 @@ int mutt_view_attachment(FILE *fp, struct Body *a, int flag, struct Header *hdr,
 
 return_error:
 
+  //lolpatch for program that return promptly
+  sleep(1);
+
   if (entry)
     rfc1524_free_entry(&entry);
   if (fp && tempfile[0])

--- a/mutt_attach.c
+++ b/mutt_attach.c
@@ -633,13 +633,16 @@ int mutt_view_attachment(FILE *fp, struct Body *a, int flag, struct Header *hdr,
 
 return_error:
 
-  //lolpatch for program that return promptly
-  sleep(1);
-
   if (entry)
     rfc1524_free_entry(&entry);
   if (fp && tempfile[0])
   {
+    /* Give programs which return directly (i.e. chrome or firefox if they open
+     * the attachment in a new tab) a chance to read the soon-to-be unlinked
+     * file. 0.25 seconds seems to be a good time to wait...
+     */
+    usleep(250000);
+
     /* Restore write permission so mutt_file_unlink can open the file for writing */
     mutt_file_chmod_add(tempfile, S_IWUSR);
     mutt_file_unlink(tempfile);


### PR DESCRIPTION
This pull requests "fixes" the "bug" I filed last week.
It does simply so by waiting for like 0.25 seconds to give programs returning directly a bigger time window to read the soon-to-be unlinked file. (I know this is pretty myopic.)

The other method we had briefly discussed, namely keeping a list of files to be deleted on exit, would probably require the introduction of at least one global variable to be introduced. (So neomutt has always access to that list, anytime it quits. But I don't really know neomutts inner workings.) This would not be compatible with your style guide, i guess.