### PR TITLE
[WIP] Do not let libintl.h override setlocale

### DIFF
--- a/main.c
+++ b/main.c
@@ -29,6 +29,7 @@
  */
 
 #define MAIN_C 1
+#define GNULIB_defined_setlocale
 
 #include "config.h"
 #include <errno.h>


### PR DESCRIPTION
This PR aims to partly address #589--only partly--because I believe there are two separate problems reported there, and this fixes only one of them. Both @rlue and I encountered the problem where if `locale` is set to the following:
```
LANG=
LC_COLLATE="C"
LC_CTYPE="UTF-8"
LC_MESSAGES="C"
LC_MONETARY="C"
LC_NUMERIC="C"
LC_TIME="C"
LC_ALL=
```
then `charset` would be incorrectly set to `us-ascii`, causing problems when displaying UTF-8 characters. After some debugging I found out that https://github.com/neomutt/neomutt/blob/eb8b461a79c0c32c8c8eae70a0b762b57585f354/main.c#L323 is actually not using the `setlocale` function provided in `locale.h`, but rather overridden by a macro defined in `libintl.h`, which behaves incorrectly in macOS.

This PR includes a crude fix that addresses the immediate issue by disabling the macro. This is not an optimal solution, so I would love to hear more suggestions and work on this more.

I can think of some possible long-term solutions:
* Refactor the code so that `libintl.h` is isolated from other files as much as possible.
* Change the build configuration to automatically disable the `libintl.h` macro on certain platforms.

**Update**: I have submitted a [bug report](https://savannah.gnu.org/bugs/index.php?54479) to the `gettext` project.