### PR TITLE
Allow `type=` statements in `vfolder-from-query`

### DIFF
--- a/mutt/string.c
+++ b/mutt/string.c
@@ -1016,3 +1016,47 @@ bool mutt_str_inline_replace(char *buf, size_t buflen, size_t xlen, const char *
 
   return true;
 }
+
+/**
+ * mutt_str_strcasestr - Find a substring within a string without worrying about case
+ * @param haystack String that may or may not contain the substring
+ * @param needle   Substring we're looking for
+ * @retval ptr  Beginning of substring
+ * @retval NULL Substring is not in substring
+ *
+ * This performs a byte-to-byte check so it will return unspecified
+ * results for multibyte locales.
+ */
+const char *mutt_str_strcasestr(const char *haystack, const char *needle)
+{
+  if (!needle)
+    return NULL;
+
+  size_t haystack_len = mutt_str_strlen(haystack);
+  size_t needle_len = mutt_str_strlen(needle);
+
+  // Empty string exists at the front of a string. Check strstr if you don't believe me.
+  if (needle_len == 0)
+    return haystack;
+
+  // Check size conditions. No point wasting CPU cycles.
+  if ((haystack_len == 0) || (haystack_len < needle_len))
+    return NULL;
+
+  // Only check space that needle could fit in.
+  // Conditional has + 1 to handle when the haystack and needle are the same length.
+  for (size_t i = 0; i < (haystack_len - needle_len) + 1; i++)
+  {
+    for (size_t j = 0; j < needle_len; j++)
+    {
+      if (tolower((unsigned char) haystack[i + j]) != tolower((unsigned char) needle[j]))
+        break;
+
+      // If this statement is true, the needle has been found.
+      if (j == (needle_len - 1))
+        return haystack + i;
+    }
+  }
+
+  return NULL;
+}

--- a/mutt/string.c
+++ b/mutt/string.c
@@ -1018,6 +1018,28 @@ bool mutt_str_inline_replace(char *buf, size_t buflen, size_t xlen, const char *
 }
 
 /**
+ * mutt_str_remall_strcasestr - Remove all occurrences of substring, ignoring case
+ * @param str     String containing the substring
+ * @param target  Target substring for removal
+ * @retval 0 String contained substring and substring was removed successfully
+ * @retval 1 String did not contain substring
+ */
+int mutt_str_remall_strcasestr(char *str, const char *target)
+{
+  int retval = 1;
+
+  // Look through an ensure all instances of the substring are gone.
+  while ((str = (char *) mutt_str_strcasestr(str, target)))
+  {
+    size_t target_len = mutt_str_strlen(target);
+    memmove(str, str + target_len, 1 + strlen(str + target_len));
+    retval = 0; // If we got here, then a substring existed and has been removed.
+  }
+
+  return retval;
+}
+
+/**
  * mutt_str_strcasestr - Find a substring within a string without worrying about case
  * @param haystack String that may or may not contain the substring
  * @param needle   Substring we're looking for

--- a/mutt/string2.h
+++ b/mutt/string2.h
@@ -85,6 +85,7 @@ const char *mutt_str_rstrnstr(const char *haystack, size_t haystack_length, cons
 char *      mutt_str_skip_email_wsp(const char *s);
 char *      mutt_str_skip_whitespace(char *p);
 int         mutt_str_strcasecmp(const char *a, const char *b);
+const char *mutt_str_strcasestr(const char *haystack, const char *needle);
 char *      mutt_str_strcat(char *buf, size_t buflen, const char *s);
 const char *mutt_str_strchrnul(const char *s, char c);
 int         mutt_str_strcmp(const char *a, const char *b);

--- a/mutt/string2.h
+++ b/mutt/string2.h
@@ -79,6 +79,7 @@ size_t      mutt_str_lws_len(const char *s, size_t n);
 size_t      mutt_str_lws_rlen(const char *s, size_t n);
 const char *mutt_str_next_word(const char *s);
 void        mutt_str_pretty_size(char *buf, size_t buflen, size_t num);
+int         mutt_str_remall_strcasestr(char *str, const char *target);
 void        mutt_str_remove_trailing_ws(char *s);
 void        mutt_str_replace(char **p, const char *s);
 const char *mutt_str_rstrnstr(const char *haystack, size_t haystack_length, const char *needle);

--- a/notmuch/mutt_notmuch.h
+++ b/notmuch/mutt_notmuch.h
@@ -39,6 +39,7 @@
 
 struct Context;
 struct Email;
+struct NmMboxData;
 
 /* These Config Variables are only used in notmuch/mutt_notmuch.c */
 extern int   NmDbLimit;
@@ -62,6 +63,7 @@ void  nm_longrun_init            (struct Mailbox *mailbox, bool writable);
 bool  nm_message_is_still_queried(struct Mailbox *mailbox, struct Email *e);
 int   nm_nonctx_get_count        (char *path, int *all, int *new);
 bool  nm_normalize_uri           (const char *uri, char *buf, size_t buflen);
+void  nm_parse_type_from_query   (struct NmMboxData *data, char *buf);
 int   nm_path_probe              (const char *path, const struct stat *st);
 void  nm_query_window_backward   (void);
 void  nm_query_window_forward    (void);

--- a/test/main.c
+++ b/test/main.c
@@ -13,6 +13,7 @@
   NEOMUTT_TEST_ITEM(test_md5_ctx_bytes)                                        \
   NEOMUTT_TEST_ITEM(test_string_strfcpy)                                       \
   NEOMUTT_TEST_ITEM(test_string_strnfcpy)                                      \
+  NEOMUTT_TEST_ITEM(test_string_strcasestr)                                    \
   NEOMUTT_TEST_ITEM(test_addr_mbox_to_udomain)                                 \
   NEOMUTT_TEST_ITEM(test_mutt_path_tidy_slash)                                 \
   NEOMUTT_TEST_ITEM(test_mutt_path_tidy_dotdot)                                \

--- a/test/string.c
+++ b/test/string.c
@@ -107,3 +107,84 @@ void test_string_strnfcpy(void)
     }
   }
 }
+
+void test_string_strcasestr(void)
+{
+  char *haystack_same_size = "hello";
+  char *haystack_larger = "hello, world!";
+  char *haystack_smaller = "heck";
+  char *haystack_mid = "test! hello, world";
+  char *haystack_end = ", world! hello";
+
+  char *empty = "";
+
+  const char *needle = "hEllo";
+  const char *needle_lower = "hello";
+  const char *nonexistent = "goodbye";
+
+  { // Check NULL conditions
+    const char *retval1 = mutt_str_strcasestr(NULL, NULL);
+    const char *retval2 = mutt_str_strcasestr(NULL, needle);
+    const char *retval3 = mutt_str_strcasestr(haystack_same_size, NULL);
+
+    TEST_CHECK_(retval1 == NULL, "Expected: %s, Actual %s", NULL, retval1);
+    TEST_CHECK_(retval2 == NULL, "Expected: %s, Actual %s", NULL, retval2);
+    TEST_CHECK_(retval3 == NULL, "Expected: %s, Actual %s", NULL, retval3);
+  }
+
+  { // Check empty strings
+    const char *retval1 = mutt_str_strcasestr(empty, empty);
+    const char *retval2 = mutt_str_strcasestr(empty, needle);
+    const char *retval3 = mutt_str_strcasestr(haystack_same_size, empty);
+
+    const char *empty_expected = strstr(empty, empty);
+
+    TEST_CHECK_(retval1 == empty_expected, "Expected: %s, Actual %s", "", retval1);
+    TEST_CHECK_(retval2 == NULL, "Expected: %s, Actual %s", NULL, retval2);
+    TEST_CHECK_(retval3 == haystack_same_size, "Expected: %s, Actual %s", haystack_same_size, retval3);
+  }
+
+  { // Check instance where needle is not in haystack.
+    const char *retval1 = mutt_str_strcasestr(haystack_same_size, nonexistent);
+    const char *retval2 = mutt_str_strcasestr(haystack_smaller, nonexistent);
+    const char *retval3 = mutt_str_strcasestr(haystack_larger, nonexistent);
+
+    TEST_CHECK_(retval1 == NULL, "Expected: %s, Actual %s", NULL, retval1);
+    TEST_CHECK_(retval2 == NULL, "Expected: %s, Actual %s", NULL, retval2);
+    TEST_CHECK_(retval3 == NULL, "Expected: %s, Actual %s", NULL, retval3);
+  }
+
+  { // Check instance haystack is the same length as the needle and needle exists.
+    const char *retval = mutt_str_strcasestr(haystack_same_size, needle);
+
+    TEST_CHECK_(retval == haystack_same_size, "Expected: %s, Actual: %s", haystack_same_size, retval);
+  }
+
+  { // Check instance haystack is larger and needle exists.
+    const char *retval = mutt_str_strcasestr(haystack_larger, needle);
+    const char *expected = strstr(haystack_larger, needle_lower);
+
+    TEST_CHECK_(retval == expected, "Expected: %s, Actual: %s", haystack_larger, retval);
+  }
+
+  { // Check instance where word is in the middle
+    const char *retval = mutt_str_strcasestr(haystack_mid, needle);
+    const char *expected = strstr(haystack_mid, needle_lower);
+
+    TEST_CHECK_(retval == expected, "Expected: %s, Actual: %s", expected, retval);
+  }
+
+  { // Check instance where needle is at the end,
+    const char *retval = mutt_str_strcasestr(haystack_end, needle);
+    const char *expected = strstr(haystack_end, needle_lower);
+
+    TEST_CHECK_(retval == expected, "Expected: %s, Actual: %s", expected, retval);
+  }
+
+  { // Check instance where haystack is smaller than needle.
+    const char *retval = mutt_str_strcasestr(haystack_smaller, needle);
+
+    TEST_CHECK_(retval == NULL, "Expected: %s, Actual: %s", NULL, retval);
+  }
+}
+


### PR DESCRIPTION
**What does this PR do?**

This addresses an issue with how Neomutt encodes notmuch queries. If one uses `vfolder-from-query` and includes a `type=` statement, Neomutt will encode the statement as part of the query, which prevents the query type from being changed. Including `type=` statements is documented as supported behavior[0].

This PR achieves the desired result by introducing a case-insensitive implementation of `strstr(...)`, a function for removing all instances of a case-insensitive substring, and combining the two functions to find if a `type=` statement exists and to set the appropriate `query_type` in `NmCtxData`if one exists.

[0] https://neomutt.org/feature/notmuch#3-2-%C2%A0items

**What are the relevant issue numbers?**
#1214
