### PR TITLE
Notmuch: Change default window to be open ended

### DIFF
--- a/notmuch/mutt_notmuch.c
+++ b/notmuch/mutt_notmuch.c
@@ -421,7 +421,9 @@ static bool windowed_query_from_query(const char *query, char *buf, size_t bufle
 
   if (end == 0)
   {
-    snprintf(buf, buflen, "date:%d%s..now and %s", beg, NmQueryWindowTimebase,
+    // Open-ended date allows mail from the future.
+    // This may occur is the sender's time settings are off.
+    snprintf(buf, buflen, "date:%d%s.. and %s", beg, NmQueryWindowTimebase,
              NmQueryWindowCurrentSearch);
   }
   else


### PR DESCRIPTION
 **What does this PR do?**

Change the default query window to be open ended, allowing for mail
from the future to appear in a query. This may occur if the sender's
time settings are improperly configured.

This change was proposed by @ferriff and I've been testing it for 
several days without issue. Since @ferriff appears to be inactive, I'm
opening this PR.

**What are the relevant issue numbers?**

#748 
