### PR TITLE
build: make samples reflect the provided libexecdir in ./configure

### DIFF
--- a/contrib/Makefile.autosetup
+++ b/contrib/Makefile.autosetup
@@ -10,7 +10,9 @@ clean-contrib:
 install-contrib:
 	$(INSTALL) -d -m 755 $(DESTDIR)$(docdir)/samples
 	for f in $(SAMPLES); do \
-		$(INSTALL) -m 644 $(SRCDIR)/contrib/$$f $(DESTDIR)$(docdir)/samples || exit 1; \
+		sed -e 's!/usr/libexec!$(libexecdir)!g' $(SRCDIR)/contrib/$$f > $(SRCDIR)/contrib/$$f.tmp; \
+		$(INSTALL) -m 644 $(SRCDIR)/contrib/$$f.tmp $(DESTDIR)$(docdir)/samples/$$f || exit 1; \
+		rm -f -- $(SRCDIR)/contrib/$$f.tmp; \
 	done
 	for d in $(CONTRIB_DIRS); do \
 		echo "Creating directory $(DESTDIR)$(docdir)/$$d"; \

--- a/doc/Makefile.autosetup
+++ b/doc/Makefile.autosetup
@@ -85,7 +85,7 @@ doc/neomutt.1:
 doc/manual.xml:	doc/makedoc$(EXEEXT) $(SRCDIR)/init.h $(SRCDIR)/opcodes.h \
 		$(SRCDIR)/doc/manual.xml.head $(SRCDIR)/functions.h \
 		$(SRCDIR)/doc/manual.xml.tail $(SRCDIR)/doc/gen-map-doc
-	( sed -e "s/@VERSION@/$(PACKAGE_VERSION)/" \
+	( sed -e "s/@VERSION@/$(PACKAGE_VERSION)/; s!/usr/libexec!$(libexecdir)!g" \
 	    $(SRCDIR)/doc/manual.xml.head && \
 	    $(MAKEDOC_CPP) $(SRCDIR)/init.h | doc/makedoc$(EXEEXT) -s && \
 	    $(MAKEDOC_CPP) $(SRCDIR)/functions.h | \


### PR DESCRIPTION
* **What does this PR do?**

The /usr/libexec path is hardcoded in some of the samples. Run
sed on the installed versions to reflect the directory provided
in ./configure.

* **What are the relevant issue numbers?**

Fixes issue #1350.