### PR TITLE
notmuch: count messages in queried threads

### DIFF
--- a/notmuch/mutt_notmuch.c
+++ b/notmuch/mutt_notmuch.c
@@ -1731,12 +1731,66 @@ done:
 }
 
 /**
+ * count_query_messages - Count the number of messages in all queried threads
+ * @param query Executed query
+ * @retval num Number of messages
+ */
+static unsigned int count_query_thread_messages(notmuch_query_t *q)
+{
+  unsigned int count = 0;
+  notmuch_threads_t *threads;
+  notmuch_thread_t *thread;
+
+#if LIBNOTMUCH_CHECK_VERSION(5, 0, 0)
+  notmuch_query_search_threads(q, &threads);
+#elif LIBNOTMUCH_CHECK_VERSION(4, 3, 0)
+  notmuch_query_search_threads_st(q, &threads);
+#else
+  threads = notmuch_query_search_threads(q);
+#endif
+
+  for (; // Initialisation is done above to improve readability of for loop.
+       notmuch_threads_valid(threads); notmuch_threads_move_to_next(threads))
+  {
+    thread = notmuch_threads_get(threads);
+
+    count += notmuch_thread_get_total_messages(thread);
+
+    notmuch_thread_destroy(thread);
+  }
+
+  return count;
+}
+
+/**
+ * count_query_messages - Count the number of queried messages
+ * @param query Executed query
+ * @retval num Number of messages
+ */
+static unsigned int count_query_messages(notmuch_query_t *q)
+{
+  unsigned int count = 0;
+
+#if LIBNOTMUCH_CHECK_VERSION(5, 0, 0)
+  if (notmuch_query_count_messages(q, &count) != NOTMUCH_STATUS_SUCCESS)
+    count = 0; /* may not be defined on error */
+#elif LIBNOTMUCH_CHECK_VERSION(4, 3, 0)
+  if (notmuch_query_count_messages_st(q, &count) != NOTMUCH_STATUS_SUCCESS)
+    count = 0; /* may not be defined on error */
+#else
+  count = notmuch_query_count_messages(q);
+#endif
+
+  return count;
+}
+
+/**
  * count_query - Count the results of a query
  * @param db   Notmuch database
  * @param qstr Query to execute
- * @retval num Numner of results
+ * @retval num Number of results
  */
-static unsigned int count_query(notmuch_database_t *db, const char *qstr)
+static unsigned int count_query(notmuch_database_t *db, const char *qstr, enum NmQueryType type)
 {
   notmuch_query_t *q = notmuch_query_create(db, qstr);
   if (!q)
@@ -1745,15 +1799,12 @@ static unsigned int count_query(notmuch_database_t *db, const char *qstr)
   unsigned int res = 0;
 
   apply_exclude_tags(q);
-#if LIBNOTMUCH_CHECK_VERSION(5, 0, 0)
-  if (notmuch_query_count_messages(q, &res) != NOTMUCH_STATUS_SUCCESS)
-    res = 0; /* may not be defined on error */
-#elif LIBNOTMUCH_CHECK_VERSION(4, 3, 0)
-  if (notmuch_query_count_messages_st(q, &res) != NOTMUCH_STATUS_SUCCESS)
-    res = 0; /* may not be defined on error */
-#else
-  res = notmuch_query_count_messages(q);
-#endif
+
+  if (type == NM_QUERY_TYPE_MESGS)
+    res = count_query_messages(q);
+  else if (type == NM_QUERY_TYPE_THREADS)
+    res = count_query_thread_messages(q);
+
   notmuch_query_destroy(q);
   mutt_debug(1, "nm: count '%s', result=%d\n", qstr, res);
 
@@ -2175,6 +2226,7 @@ int nm_nonctx_get_count(char *path, int *all, int *new)
   struct Url url = { U_UNKNOWN };
   char *url_holder = mutt_str_strdup(path);
   char *db_filename = NULL, *db_query = NULL;
+  enum NmQueryType db_query_type = string_to_query_type(NmQueryType);
   notmuch_database_t *db = NULL;
   int rc = -1;
   mutt_debug(1, "nm: count\n");
@@ -2190,7 +2242,10 @@ int nm_nonctx_get_count(char *path, int *all, int *new)
     if (item->value && (strcmp(item->name, "query") == 0))
     {
       db_query = item->value;
-      break;
+    }
+    else if (item->value && (strcmp(item->name, "type") == 0))
+    {
+      db_query_type = string_to_query_type(item->value);
     }
   }
 
@@ -2219,7 +2274,7 @@ int nm_nonctx_get_count(char *path, int *all, int *new)
 
   /* all emails */
   if (all)
-    *all = count_query(db, db_query);
+    *all = count_query(db, db_query, db_query_type);
 
   /* new messages */
   if (new)
@@ -2227,7 +2282,7 @@ int nm_nonctx_get_count(char *path, int *all, int *new)
     char *qstr = NULL;
 
     safe_asprintf(&qstr, "( %s ) tag:%s", db_query, NmUnreadTag);
-    *new = count_query(db, qstr);
+    *new = count_query(db, qstr, db_query_type);
     FREE(&qstr);
   }
 

--- a/notmuch/mutt_notmuch.c
+++ b/notmuch/mutt_notmuch.c
@@ -1731,15 +1731,15 @@ done:
 }
 
 /**
- * count_query_messages - Count the number of messages in all queried threads
+ * count_query_thread_messages - Count the number of messages in all queried threads
  * @param query Executed query
  * @retval num Number of messages
  */
 static unsigned int count_query_thread_messages(notmuch_query_t *q)
 {
   unsigned int count = 0;
-  notmuch_threads_t *threads;
-  notmuch_thread_t *thread;
+  notmuch_threads_t *threads = NULL;
+  notmuch_thread_t *thread = NULL;
 
 #if LIBNOTMUCH_CHECK_VERSION(5, 0, 0)
   notmuch_query_search_threads(q, &threads);


### PR DESCRIPTION

This makes `sidebar_format`'s `%S` display the same value as
`pager_format`'s `%m`.

`count_query` did not handle counting all messages in `type=threads`
queries. It returned the number of messages matching the `query=`
qualifier. Refactored `count_query` into two methods handling
`type=threads` and `type=messages`, respectively.

**Screenshots (if relevant)**
Compare the right-most number of the sidebar for `inbox threads` to the pager. 
Before:
![before](https://user-images.githubusercontent.com/1640737/46786938-5ede7280-cd04-11e8-85f6-f5ff7673f2ca.png)
After:
![after](https://user-images.githubusercontent.com/1640737/46786953-66058080-cd04-11e8-87a0-0f6cb670653e.png)


**What are the relevant issue numbers?**
#721 
