### PR TITLE
Implement named mailboxes

### DIFF
--- a/doc/manual.xml.head
+++ b/doc/manual.xml.head
@@ -5256,6 +5256,21 @@ unignore posted-to:
         <arg choice="opt" rep="repeat">
           <replaceable class="parameter">mailbox</replaceable>
         </arg>
+        <command>named-mailboxes</command>
+        <arg choice="plain">
+          <replaceable class="parameter">description</replaceable>
+          <arg choice="plain">
+            <replaceable class="parameter">mailbox</replaceable>
+          </arg>
+        </arg>
+        <group choice="req" rep="repeat">
+          <arg choice="plain">
+            <replaceable class="parameter">description</replaceable>
+            <arg choice="plain">
+              <replaceable class="parameter">mailbox</replaceable>
+            </arg>
+          </arg>
+        </group>
         <command>unmailboxes</command>
         <group choice="req">
           <arg choice="plain">
@@ -5288,8 +5303,10 @@ unignore posted-to:
       </para>
       <para>
         The <quote>unmailboxes</quote> command is used to remove a token from
-        the list of folders which receive mail. Use
-        <quote>unmailboxes&#160;*</quote> to remove all tokens.
+        the list of folders which receive mail. <quote>unmailboxes</quote> can
+        be used on the mailbox path, <quote>$folder</quote>-abbreviated path,
+        or description. Use <quote>unmailboxes&#160;*</quote> to remove all
+        tokens.
       </para>
       <note>
         <para>
@@ -17794,6 +17811,20 @@ neomutt mailto:some@one.org?subject=test&amp;cc=other@one.org
             <arg choice="opt" rep="repeat">
               <replaceable class="parameter">mailbox</replaceable>
             </arg>
+            <command>
+              <link linkend="mailboxes">named-mailboxes</link>
+            </command>
+            <arg choice="plain">
+              <replaceable class="parameter">description</replaceable>
+            </arg>
+            <arg choice="plain">
+              <replaceable class="parameter">mailbox</replaceable>
+            </arg>
+            <group choice="opt" rep="repeat">
+              <arg choice="plain">
+                <replaceable class="parameter">description mailbox</replaceable>
+              </arg>
+            </group>
             <command>
               <link linkend="mailboxes">unmailboxes</link>
             </command>

--- a/doc/manual.xml.head
+++ b/doc/manual.xml.head
@@ -743,10 +743,17 @@ set sidebar_divider_char = '│'          <emphasis role="comment"># Pretty line
                     </entry>
                   </row>
                   <row>
-                    <entry>%S</entry>
-                    <entry>* †</entry>
+                    <entry>%d</entry>
+                    <entry>* ‡</entry>
                     <entry>
-                      Size of mailbox (total number of messages)
+                      Number of deleted messages
+                    </entry>
+                  </row>
+                  <row>
+                    <entry>%D</entry>
+                    <entry></entry>
+                    <entry>
+                      Description of the mailbox
                     </entry>
                   </row>
                   <row>
@@ -757,10 +764,10 @@ set sidebar_divider_char = '│'          <emphasis role="comment"># Pretty line
                     </entry>
                   </row>
                   <row>
-                    <entry>%N</entry>
-                    <entry>* †</entry>
+                    <entry>%L</entry>
+                    <entry>* ‡</entry>
                     <entry>
-                      Number of New messages in the mailbox
+                      Number of messages after limiting
                     </entry>
                   </row>
                   <row>
@@ -772,26 +779,17 @@ set sidebar_divider_char = '│'          <emphasis role="comment"># Pretty line
                     </entry>
                   </row>
                   <row>
-                    <entry>%!</entry>
-                    <entry></entry>
+                    <entry>%N</entry>
+                    <entry>* †</entry>
                     <entry>
-                      <quote>!</quote>: one flagged message; <quote>!!</quote>:
-                      two flagged messages; <quote>n!</quote>: n flagged
-                      messages (for n &gt; 2). Otherwise prints nothing.
+                      Number of New messages in the mailbox
                     </entry>
                   </row>
                   <row>
-                    <entry>%d</entry>
-                    <entry>* ‡</entry>
+                    <entry>%S</entry>
+                    <entry>* †</entry>
                     <entry>
-                      Number of deleted messages
-                    </entry>
-                  </row>
-                  <row>
-                    <entry>%L</entry>
-                    <entry>* ‡</entry>
-                    <entry>
-                      Number of messages after limiting
+                      Size of mailbox (total number of messages)
                     </entry>
                   </row>
                   <row>
@@ -799,6 +797,15 @@ set sidebar_divider_char = '│'          <emphasis role="comment"># Pretty line
                     <entry>* ‡</entry>
                     <entry>
                       Number of tagged messages
+                    </entry>
+                  </row>
+                  <row>
+                    <entry>%!</entry>
+                    <entry></entry>
+                    <entry>
+                      <quote>!</quote>: one flagged message; <quote>!!</quote>:
+                      two flagged messages; <quote>n!</quote>: n flagged
+                      messages (for n &gt; 2). Otherwise prints nothing.
                     </entry>
                   </row>
                   <row>

--- a/init.h
+++ b/init.h
@@ -995,6 +995,7 @@ struct ConfigDef MuttVars[] = {
   **             ``@'' to symbolic links and ``*'' to executable files)
   ** .dt %F  .dd File permissions
   ** .dt %g  .dd Group name (or numeric gid, if missing)
+  ** .dt %i  .dd Description of the folder
   ** .dt %l  .dd Number of hard links
   ** .dt %m  .dd Number of messages in the mailbox *
   ** .dt %n  .dd Number of unread messages in the mailbox *

--- a/init.h
+++ b/init.h
@@ -4685,6 +4685,7 @@ const struct Command Commands[] = {
   { "mime_lookup",         parse_stailq,           UL &MimeLookupList },
   { "mono",                mutt_parse_mono,        0 },
   { "my_hdr",              parse_my_hdr,           0 },
+  { "named-mailboxes",     mutt_parse_mailboxes,   MUTT_NAMED },
   { "nospam",              parse_spam_list,        MUTT_NOSPAM },
 #ifdef USE_COMPRESSED
   { "open-hook",           mutt_parse_hook,        MUTT_OPEN_HOOK },

--- a/init.h
+++ b/init.h
@@ -3419,6 +3419,7 @@ struct ConfigDef MuttVars[] = {
   ** sequences:
   ** .dl
   ** .dt %B  .dd Name of the mailbox
+  ** .dt %D  .dd Description of the mailbox
   ** .dt %S  .dd * Size of mailbox (total number of messages)
   ** .dt %N  .dd * Number of unread messages in the mailbox
   ** .dt %n  .dd N if mailbox has new mail, blank otherwise
@@ -4157,6 +4158,7 @@ struct ConfigDef MuttVars[] = {
   ** .dl
   ** .dt %b  .dd Number of mailboxes with new mail *
   ** .dt %d  .dd Number of deleted messages *
+  ** .dt %D  .dd Description of the mailbox
   ** .dt %f  .dd The full pathname of the current mailbox
   ** .dt %F  .dd Number of flagged messages *
   ** .dt %h  .dd Local hostname

--- a/mailbox.c
+++ b/mailbox.c
@@ -77,6 +77,23 @@ static short MailboxNotify = 0; /**< # of unnotified new boxes */
 struct MailboxList AllMailboxes = STAILQ_HEAD_INITIALIZER(AllMailboxes);
 
 /**
+ * get_mailbox_description - Find a mailbox's description given a path.
+ * @param path Path to the mailbox
+ * @retval ptr Description
+ * @retval NULL No mailbox matching path
+ */
+static char *get_mailbox_description(const char *path)
+{
+  struct MailboxNode *np = NULL;
+  STAILQ_FOREACH(np, &AllMailboxes, entries)
+  {
+    if (np->m->desc && (strcmp(np->m->path, path) == 0))
+      return np->m->desc;
+  }
+  return NULL;
+}
+
+/**
  * mailbox_new - Create a new Mailbox
  * @param path Path to the mailbox
  * @retval ptr New Mailbox
@@ -90,6 +107,7 @@ struct Mailbox *mailbox_new(const char *path)
   char *r = realpath(path, rp);
   mutt_str_strfcpy(mailbox->realpath, r ? rp : path, sizeof(mailbox->realpath));
   mailbox->magic = MUTT_UNKNOWN;
+  mailbox->desc = get_mailbox_description(mailbox->path);
 
   return mailbox;
 }

--- a/sidebar.c
+++ b/sidebar.c
@@ -113,6 +113,7 @@ enum SidebarSrc
  * |:--------|:--------------------------------------------------------
  * | \%B     | Name of the mailbox
  * | \%d     | Number of deleted messages
+ * | \%D     | Description of the mailbox
  * | \%F     | Number of Flagged messages in the mailbox
  * | \%L     | Number of messages after limiting
  * | \%n     | N if mailbox has new mail, blank otherwise
@@ -157,6 +158,13 @@ static const char *sidebar_format_str(char *buf, size_t buflen, size_t col, int 
       }
       else if ((c && Context->deleted == 0) || !c)
         optional = 0;
+      break;
+
+    case 'D':
+      if (sbe->mailbox->desc)
+        mutt_format_s(buf, buflen, prec, sbe->mailbox->desc);
+      else
+        mutt_format_s(buf, buflen, prec, sbe->box);
       break;
 
     case 'F':

--- a/status.c
+++ b/status.c
@@ -69,6 +69,7 @@ static char *get_sort_str(char *buf, size_t buflen, int method)
  * |:--------|:--------------------------------------------------------
  * | \%b     | Number of incoming folders with unread messages
  * | \%d     | Number of deleted messages
+ * | \%D     | Description of the mailbox
  * | \%f     | Full mailbox path
  * | \%F     | Number of flagged messages
  * | \%h     | Hostname
@@ -121,6 +122,19 @@ static const char *status_format_str(char *buf, size_t buflen, size_t col, int c
         optional = 0;
       break;
 
+    case 'D':
+    {
+      struct Mailbox *mbox = Context ? Context->mailbox : NULL;
+      // If there's a description, use it. Otherwise, fall-through
+      if (mbox && mbox->desc)
+      {
+        mutt_str_strfcpy(tmp, mbox->desc, sizeof(tmp));
+        snprintf(fmt, sizeof(fmt), "%%%ss", prec);
+        snprintf(buf, buflen, fmt, tmp);
+        break;
+      }
+    }
+    /* fallthrough */
     case 'f':
     {
       struct Mailbox *m = Context ? Context->mailbox : NULL;


### PR DESCRIPTION
**What does this PR do?**

Allows a user to set a description for a mailbox via `named-mailboxes`. This is similar to `virtual-mailboxes`.

To do this, first I fixed the issue affecting #1354 to recover descriptions when the `Context` is recreated. This allowed me to introduce the `%D` expando for `status_format` and `sidebar_format` so we can display an arbitrary mailbox's description. Then I added the the `named-mailboxes` command and modified `browser.c` to use a description instead of a path if one exists.

Only two known issue:
1. Cannot use description for `spoolfile` (this affects `virtual-mailboxes` as well and should be resolved alongside it)
2. Unable to tab complete on `Open mailbox ('?' for list):` prompt

Here is a partial `.neomuttrc` demonstrating its usage:
```vim
named-mailboxes "Hi Flatcap!" "=austin.duke.ray@gmail.com/INBOX"
mailboxes =austin@austinray.io/INBOX
set spoolfile = =austin.duke.ray@gmail.com/INBOX       
```

**Screenshots (if relevant)**

Here is what it looks like in the sidebar:
![descriptions](https://user-images.githubusercontent.com/1640737/46845062-c4d00600-cda7-11e8-855d-5651d4cbe6cb.png)

![descript](https://user-images.githubusercontent.com/1640737/46881359-3bf1b280-ce19-11e8-8816-56fcae47c43c.png)



**What are the relevant issue numbers?**
#1354 