### PR TITLE
Try adding status indicator R for my address in Reply-To

### DIFF
--- a/doc/manual.xml.head
+++ b/doc/manual.xml.head
@@ -1803,6 +1803,10 @@ color sidebar_divider   color8  default     <emphasis role="comment"># Dark grey
                 <entry>L</entry>
                 <entry>message is sent to a subscribed mailing list</entry>
               </row>
+              <row>
+                <entry>R</entry>
+                <entry>message has your address in the Reply-To field</entry>
+              </row>
             </tbody>
           </tgroup>
         </table>

--- a/hdrline.c
+++ b/hdrline.c
@@ -383,6 +383,7 @@ static bool user_in_addr(struct Address *a)
  * @retval 3 User is in the CC list
  * @retval 4 User is originator
  * @retval 5 Sent to a subscribed mailinglist
+ * @retval 6 User is in the Reply-To list
  */
 static int user_is_recipient(struct Email *e)
 {
@@ -410,6 +411,8 @@ static int user_is_recipient(struct Email *e)
       e->recipient = 5;
     else if (check_for_mailing_list(env->cc, NULL, NULL, 0))
       e->recipient = 5;
+    else if (user_in_addr(env->reply_to))
+      e->recipient = 6;
     else
       e->recipient = 0;
   }

--- a/init.h
+++ b/init.h
@@ -4323,7 +4323,7 @@ struct ConfigDef MuttVars[] = {
   ** If this variable is not set, the environment variable \fC$$$TMPDIR\fP is
   ** used.  Failing that, then ``\fC/tmp\fP'' is used.
   */
-  { "to_chars",         DT_MBTABLE, R_BOTH, &ToChars, IP " +TCFL" },
+  { "to_chars",         DT_MBTABLE, R_BOTH, &ToChars, IP " +TCFLR" },
   /*
   ** .pp
   ** Controls the character used to indicate mail addressed to you.
@@ -4335,6 +4335,7 @@ struct ConfigDef MuttVars[] = {
   ** .dt 4 .dd C .dd Your address is specified in the ``Cc:'' header field, but you are not the only recipient.
   ** .dt 5 .dd F .dd Indicates the mail that was sent by \fIyou\fP.
   ** .dt 6 .dd L .dd Indicates the mail was sent to a mailing-list you subscribe to.
+  ** .dt 7 .dd R .dd Your address appears in the ``Reply-To:'' header field but none of the above applies.
   ** .de
   */
   { "trash",            DT_PATH|DT_MAILBOX, R_NONE, &Trash, 0 },


### PR DESCRIPTION
* **What does this PR do?**

It adds a new "R" flag for the 3rd position of the index %Z field, for when user's own address is in the Reply-To header unless none of the other flags for that field is applicable.

* **Motivation**

Some mailing lists now do the following transformation of the headers: rewrite the From header to the list address, and add a Reply-To header with the poster address.  This feature helps highlight my own posts in folders dedicated to such lists.  Of course if you are _subscribed_ to the list (in the Mutt sense) you'll get the "L" flag instead, but in that case you don't care about hightlighting your posts anyway.

* **Does this PR meet the acceptance criteria?** (This is just a reminder for you,
  this section can be removed if you fulfill it.)

   - Documentation created/updated (you have to edit
     [doc/manual.xml.head](https://www.github.com/neomutt/neomutt/blob/master/doc/manual.xml.head)
     for that)
Not yet.  I'll add that once I see it compiles with travis.

   - All builds and tests are passing
Hopefully

   - Added [doxygen code documentation](https://neomutt.org/dev/doxygen)
     [syntax](http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html)
Yes, I took care of that

   - Code follows the [style guide](https://neomutt.org/dev/coding-style)
Yes

* **What are the relevant issue numbers?**
None, I'm just throwing this out there :p