### PR TITLE
Do not use disconnected socket.

### DIFF
--- a/imap/imap.c
+++ b/imap/imap.c
@@ -1192,15 +1192,18 @@ void imap_logout(struct ImapAccountData **adata)
 {
   /* we set status here to let imap_handle_untagged know we _expect_ to
    * receive a bye response (so it doesn't freak out and close the conn) */
-  (*adata)->status = IMAP_BYE;
-  imap_cmd_start(*adata, "LOGOUT");
-  if (ImapPollTimeout <= 0 || mutt_socket_poll((*adata)->conn, ImapPollTimeout) != 0)
+  if ((*adata)->state != IMAP_DISCONNECTED)
   {
-    while (imap_cmd_step(*adata) == IMAP_CMD_CONTINUE)
-      ;
+    (*adata)->status = IMAP_BYE;
+    imap_cmd_start(*adata, "LOGOUT");
+    if (ImapPollTimeout <= 0 || mutt_socket_poll((*adata)->conn, ImapPollTimeout) != 0)
+    {
+      while (imap_cmd_step(*adata) == IMAP_CMD_CONTINUE)
+        ;
+    }
+    mutt_socket_close((*adata)->conn);
   }
 
-  mutt_socket_close((*adata)->conn);
   imap_adata_free((void **) adata);
 }
 


### PR DESCRIPTION
If an IMAP connection was never set up, do not try to write a LOGOUT
command through that connection or to close that socket.

Both results in segmentation faults.

How to reproduce:

- Connect to a server with an invalid or self-signed TLS certificate
- Press "q" to cancel the connection
- Press "q" again to leave neomutt
- neomutt crashes with a segmentation fault

This should at least partly fix https://github.com/neomutt/neomutt/issues/1364