### PR TITLE
Devel/attachments

### DIFF
--- a/globals.h
+++ b/globals.h
@@ -69,6 +69,7 @@ WHERE struct ListHead Muttrc INITVAL(STAILQ_HEAD_INITIALIZER(Muttrc));
 #ifdef USE_SIDEBAR
 WHERE struct ListHead SidebarWhitelist INITVAL(STAILQ_HEAD_INITIALIZER(SidebarWhitelist));
 #endif
+WHERE struct ListHead TempAttachmentsList INITVAL(STAILQ_HEAD_INITIALIZER(TempAttachmentsList));
 WHERE struct ListHead UserHeader INITVAL(STAILQ_HEAD_INITIALIZER(UserHeader));
 
 /* Lists of AttachMatch */

--- a/main.c
+++ b/main.c
@@ -59,6 +59,7 @@
 #include "keymap.h"
 #include "mailbox.h"
 #include "menu.h"
+#include "mutt_attach.h"
 #include "mutt_curses.h"
 #include "mutt_history.h"
 #include "mutt_logging.h"
@@ -1239,6 +1240,7 @@ main_curses:
   if (repeat_error && ErrorBufMessage)
     puts(ErrorBuf);
 main_exit:
+  mutt_unlink_temp_attachments();
   mutt_list_free(&queries);
   crypto_module_free();
   mutt_window_free();

--- a/mutt_attach.h
+++ b/mutt_attach.h
@@ -55,4 +55,8 @@ int mutt_pipe_attachment(FILE *fp, struct Body *b, const char *path, char *outfi
 int mutt_print_attachment(FILE *fp, struct Body *a);
 int mutt_save_attachment(FILE *fp, struct Body *m, char *path, int flags, struct Email *e);
 
+/* small helper functions to handle temporary attachment files */
+void mutt_add_temp_attachment(char *filename);
+void mutt_unlink_temp_attachments(void);
+
 #endif /* MUTT_MUTT_ATTACH_H */


### PR DESCRIPTION
* **What does this PR do?**
This PR deletes attachments saved to the temporary directory on exit, avoiding the race condition that occurs when using programs which return directly.

See: https://github.com/neomutt/neomutt/issues/1298

* **What are the relevant issue numbers?**
https://github.com/neomutt/neomutt/issues/1298
I think I've even seen a wikipage about this...