### PR TITLE
notmuch: use existing open database if possible

### DIFF
--- a/notmuch/nm_db.c
+++ b/notmuch/nm_db.c
@@ -144,6 +144,10 @@ notmuch_database_t *nm_db_get(struct Mailbox *m, bool writable)
   if (!adata)
     return NULL;
 
+  // Use an existing open db if we have one.
+  if (adata->db)
+    return adata->db;
+
   const char *db_filename = nm_db_get_filename(m);
   if (db_filename)
     adata->db = nm_db_do_open(db_filename, writable, true);


### PR DESCRIPTION
**What does this PR do?**

When this portion of the code was migrated to use `NmAccountData`
instead of `NmMboxData` the check for an existing database handle was
removed. NeoMutt would lock-up trying to open another instance of the
database.

This commit re-adds the existing database check.

**What are the relevant issue numbers?**

Fixes #1373