### PR TITLE
notmuch: duplicate `uri` during sync

### DIFF
--- a/notmuch/mutt_notmuch.c
+++ b/notmuch/mutt_notmuch.c
@@ -2357,7 +2357,7 @@ static int nm_mbox_sync(struct Context *ctx, int *index_hint)
 
   int rc = 0;
   struct Progress progress;
-  char *uri = ctx->mailbox->path;
+  char *uri = mutt_str_strdup(ctx->mailbox->path);
   bool changed = false;
   char msgbuf[PATH_MAX + 64];
 
@@ -2430,6 +2430,7 @@ static int nm_mbox_sync(struct Context *ctx, int *index_hint)
     ctx->mailbox->mtime.tv_nsec = 0;
   }
 
+  FREE(&uri);
   mutt_debug(1, "nm: .... sync done [rc=%d]\n", rc);
   return rc;
 }


### PR DESCRIPTION
The subsystem reused `ctx->mailbox->path` to store the absolute path for
an email so that it modify the maildir flags. In order to facilitate
this behavior, the subsystem copies the `uri` and uses it to replace the
absolute path after filename modification.

However, the `uri` variable is just a pointer to `ctx->mailbox->path` so
it is overwritten with the physical path.

This commit uses `mutt_str_strdup(...)` to duplicate the `uri` so it can
replace the physical path. Without this duplication, a
`virtual-mailboxes` will lose its notmuch query when modifying tags
corresponding to maildir flags. This results in a `virtual-mailboxes`
disappearing during runtime.

**What are the relevant issue numbers?**

Fixes #1374