### PR TITLE
notmuch: count flagged messages

### DIFF
--- a/browser.c
+++ b/browser.c
@@ -943,7 +943,7 @@ static int examine_vfolders(struct Menu *menu, struct BrowserState *state)
   {
     if (nm_path_probe(np->m->path, NULL) == MUTT_NOTMUCH)
     {
-      nm_nonctx_get_count(np->m->path, &np->m->msg_count, &np->m->msg_unread);
+      nm_nonctx_get_count(np->m);
       add_folder(menu, state, np->m->path, np->m->desc, NULL, np->m, NULL);
       continue;
     }

--- a/doc/manual.xml.head
+++ b/doc/manual.xml.head
@@ -14556,6 +14556,12 @@ virtual-mailboxes "My INBOX" "notmuch://?query=tag:inbox"
             limit is nm_db_limit.
           </para>
           <para>
+            Due to a limitation with <literal>libnotmuch</literal>, unread and
+            flagged message count may be inaccurate with limit statements.
+            <literal>libnotmuch</literal> cannot return a specific tag count
+            within the first X messages of a query.
+          </para>
+          <para>
             <emphasis role="bold">type=&lt;threads|messages&gt;</emphasis>
           </para>
           <para>

--- a/init.h
+++ b/init.h
@@ -2189,6 +2189,13 @@ struct ConfigDef MuttVars[] = {
   ** variable is used to count unread messages in DB only. All other NeoMutt commands
   ** use standard (e.g. maildir) flags.
   */
+  { "nm_flagged_tag", DT_STRING, R_NONE, &NmFlaggedTag, IP "flagged" },
+  /*
+  ** .pp
+  ** This variable specifies notmuch tag which is used for flagged messages. The
+  ** variable is used to count flagged messages in DB only. All other NeoMutt commands
+  ** use standard (e.g. maildir) flags.
+  */
 #endif
 #ifdef USE_NNTP
   { "nntp_authenticators", DT_STRING, R_NONE, &NntpAuthenticators, 0 },

--- a/mailbox.c
+++ b/mailbox.c
@@ -382,7 +382,7 @@ static void mailbox_check(struct Mailbox *m, struct stat *ctx_sb, bool check_sta
         m->msg_count = 0;
         m->msg_unread = 0;
         m->msg_flagged = 0;
-        nm_nonctx_get_count(m->path, &m->msg_count, &m->msg_unread);
+        nm_nonctx_get_count(m);
         if (m->msg_unread > 0)
         {
           MailboxCount++;

--- a/nntp/nntp.c
+++ b/nntp/nntp.c
@@ -116,7 +116,7 @@ struct ChildCtx
 
 /**
  * nntp_adata_free - Free data attached to the Mailbox
- * @param data NNTP data
+ * @param ptr NNTP data
  *
  * The NntpAccountData struct stores global NNTP data, such as the connection to
  * the database.  This function will close the database, free the resources and

--- a/notmuch/mutt_notmuch.h
+++ b/notmuch/mutt_notmuch.h
@@ -51,6 +51,7 @@ extern int   NmQueryWindowCurrentPosition;
 extern char *NmQueryWindowTimebase;
 extern char *NmRecordTags;
 extern char *NmUnreadTag;
+extern char *NmFlaggedTag;
 
 extern struct MxOps mx_notmuch_ops;
 
@@ -61,7 +62,7 @@ char *nm_email_get_folder        (struct Email *e);
 void  nm_db_longrun_done            (struct Mailbox *m);
 void  nm_db_longrun_init            (struct Mailbox *m, bool writable);
 bool  nm_message_is_still_queried(struct Mailbox *m, struct Email *e);
-int   nm_nonctx_get_count        (char *path, int *all, int *new);
+int   nm_nonctx_get_count        (struct Mailbox *m);
 bool  nm_normalize_uri           (const char *uri, char *buf, size_t buflen);
 void  nm_parse_type_from_query   (struct NmMboxData *mdata, char *buf);
 int   nm_path_probe              (const char *path, const struct stat *st);

--- a/pop/pop.c
+++ b/pop/pop.c
@@ -97,7 +97,7 @@ static const char *cache_id(const char *id)
 
 /**
  * pop_adata_free - Free data attached to the Mailbox
- * @param data POP data
+ * @param ptr POP data
  *
  * The PopAccountData struct stores global POP data, such as the connection to
  * the database.  This function will close the database, free the resources and

--- a/sidebar.c
+++ b/sidebar.c
@@ -876,7 +876,7 @@ static void draw_sidebar(int num_rows, int num_cols, int div_width)
     {
 #ifdef USE_NOTMUCH
       if (m->magic == MUTT_NOTMUCH)
-        nm_nonctx_get_count(m->realpath, &m->msg_count, &m->msg_unread);
+        nm_nonctx_get_count(m);
       else
 #endif
       {


### PR DESCRIPTION
`nm_nonctx_get_count(...)` did not count flagged messages. This means
they could not display flagged message counts in the sidebar _unless_ it
was the active mailbox (handled by a different function.)

This commit introduces NmFlaggedTag, mirrored from NmUnreadTag, and will
query the database for flagged messages.