### PR TITLE
notmuch: remove sidebar and browser special cases

### DIFF
--- a/browser.h
+++ b/browser.h
@@ -40,7 +40,6 @@ extern char *VfolderFormat;
 #define MUTT_SEL_MAILBOX (1 << 0)
 #define MUTT_SEL_MULTI   (1 << 1)
 #define MUTT_SEL_FOLDER  (1 << 2)
-#define MUTT_SEL_VFOLDER (1 << 3)
 
 /**
  * struct FolderFile - Browser entry representing a folder/dir

--- a/curs_lib.c
+++ b/curs_lib.c
@@ -59,9 +59,6 @@
 #ifdef HAVE_ISWBLANK
 #include <wctype.h>
 #endif
-#ifdef USE_NOTMUCH
-#include "notmuch/mutt_notmuch.h"
-#endif
 #ifdef USE_INOTIFY
 #include "monitor.h"
 #endif

--- a/curs_lib.c
+++ b/curs_lib.c
@@ -650,10 +650,6 @@ int mutt_enter_fname_full(const char *prompt, char *buf, size_t buflen, bool mai
       buf[0] = '\0';
     }
     FREE(&pc);
-#ifdef USE_NOTMUCH
-    if ((flags & MUTT_SEL_VFOLDER) && buf[0] && (strncmp(buf, "notmuch://", 10) != 0))
-      nm_description_to_path(buf, buf, buflen);
-#endif
   }
 
   return 0;

--- a/curs_lib.h
+++ b/curs_lib.h
@@ -75,7 +75,6 @@ size_t       mutt_wstr_trunc(const char *src, size_t maxlen, size_t maxwid, size
 int          mutt_yesorno(const char *msg, int def);
 
 #define mutt_enter_fname(A, B, C, D)   mutt_enter_fname_full(A, B, C, D, false, NULL, NULL, 0)
-#define mutt_enter_vfolder(A, B, C, D) mutt_enter_fname_full(A, B, C, D, false, NULL, NULL, MUTT_SEL_VFOLDER)
 #define mutt_get_field(A, B, C, D)     mutt_get_field_full(A, B, C, D, false, NULL, NULL)
 #define mutt_get_password(A, B, C)     mutt_get_field_unbuffered(A, B, C, MUTT_PASS)
 

--- a/curs_main.c
+++ b/curs_main.c
@@ -3469,10 +3469,6 @@ int mutt_index_menu(void)
         bool_str_toggle(Config, "sidebar_visible", NULL);
         mutt_window_reflow();
         break;
-
-      case OP_SIDEBAR_TOGGLE_VIRTUAL:
-        mutt_sb_toggle_virtual();
-        break;
 #endif
       default:
         if (menu->menu == MENU_MAIN)

--- a/curs_main.c
+++ b/curs_main.c
@@ -2151,10 +2151,6 @@ int mutt_index_menu(void)
 
         if (flags)
           cp = _("Open mailbox in read-only mode");
-#ifdef USE_NOTMUCH
-        else if (op == OP_MAIN_CHANGE_VFOLDER)
-          cp = _("Open virtual folder");
-#endif
         else
           cp = _("Open mailbox");
 
@@ -2181,22 +2177,6 @@ int mutt_index_menu(void)
 
           /* Mark the selected dir for the neomutt browser */
           mutt_browser_select_dir(m->path);
-        }
-#endif
-#ifdef USE_NOTMUCH
-        else if (op == OP_MAIN_CHANGE_VFOLDER)
-        {
-          if (Context && (Context->mailbox->magic == MUTT_NOTMUCH))
-          {
-            mutt_str_strfcpy(buf, Context->mailbox->path, sizeof(buf));
-            mutt_mailbox_vfolder(buf, sizeof(buf));
-          }
-          mutt_enter_vfolder(cp, buf, sizeof(buf), 1);
-          if (!buf[0])
-          {
-            mutt_window_clearline(MuttMessageWindow, 0);
-            break;
-          }
         }
 #endif
         else

--- a/init.c
+++ b/init.c
@@ -3088,7 +3088,6 @@ int mutt_init(bool skip_sys_rc, struct ListHead *commands)
       if (mp->m->magic == MUTT_NOTMUCH)
       {
         cs_str_string_set(Config, "spoolfile", mp->m->path, NULL);
-        mutt_sb_toggle_virtual();
         break;
       }
     }

--- a/sidebar.h
+++ b/sidebar.h
@@ -47,6 +47,5 @@ void mutt_sb_draw(void);
 struct Mailbox *mutt_sb_get_highlight(void);
 void mutt_sb_notify_mailbox(struct Mailbox *m, bool created);
 void mutt_sb_set_open_mailbox(void);
-void mutt_sb_toggle_virtual(void);
 
 #endif /* MUTT_SIDEBAR_H */


### PR DESCRIPTION
**What does this PR do?**

Removes the separation between mailboxes and virtual-mailboxes in the sidebar and browser. virtual-mailboxes are the ugly stepchild in NeoMutt, and there is arbitrary separation between them. This branch is working towards making virtual-mailboxes no different than any other.

Altered:
 - Behavior of `%f`. Use path instead of description. 
   `%i` display descriptions.

Removed:
 - `sidebar-toggle-virtual` is created an unnecessary separation between mailboxes and virtual-mailboxes. It's still included as a command (so people don't get config warnings), but does nothing. It might be a good idea to remove it so people don't execute a useless keybinding.
