### PR TITLE
browser: search on description if it exists

### DIFF
--- a/browser.c
+++ b/browser.c
@@ -1008,7 +1008,10 @@ static int select_file_search(struct Menu *menu, regex_t *rx, int line)
   if (OptNews)
     return regexec(rx, ((struct FolderFile *) menu->data)[line].desc, 0, NULL, 0);
 #endif
-  return regexec(rx, ((struct FolderFile *) menu->data)[line].name, 0, NULL, 0);
+  struct FolderFile current_ff = ((struct FolderFile *) menu->data)[line];
+  char *search_on = current_ff.desc ? current_ff.desc : current_ff.name;
+
+  return regexec(rx, search_on, 0, NULL, 0);
 }
 
 /**


### PR DESCRIPTION
The browser searches on mailbox paths; however, with the introduction of
`named-mailboxes` and merging of `virtual-mailboxes`, it is necessary to
search of descriptions. If not, it may be impossible to find a mailbox
that is named.

For example, if we have `named-mailboxes "Test" "+work"` and searched
for "Test", it will not match because the path does not contain "Test".
Searching "work" would match the "Test" mailbox.

This commit modifies `select_file_search(...)` to use the description if
one exists. This way we can properly match searches for
`named-mailboxes` and `virtual-mailboxes` without know their underlying
mailbox paths.