### PR TITLE
mxapi: mx_path_canon should not double / uri

### DIFF
--- a/mx.c
+++ b/mx.c
@@ -1462,8 +1462,16 @@ int mx_path_canon(char *buf, size_t buflen, const char *folder, enum MailboxType
     }
     else if ((buf[0] == '+') || (buf[0] == '='))
     {
-      buf[0] = '/';
-      mutt_str_inline_replace(buf, buflen, 0, Folder);
+      size_t folder_len = mutt_str_strlen(Folder);
+      if ((folder_len > 0) && (Folder[folder_len - 1] != '/'))
+      {
+        buf[0] = '/';
+        mutt_str_inline_replace(buf, buflen, 0, Folder);
+      }
+      else
+      {
+        mutt_str_inline_replace(buf, buflen, 1, Folder);
+      }
     }
     else if ((buf[1] == '/') || (buf[1] == '\0'))
     {


### PR DESCRIPTION
At least for imap if "folder=imap://example.com" and mailboxes contains "=Foo"

mx_path_canon will construct imap://example.com//Foo

This change ensures we do not add the extra /.
