### PR TITLE
imap: add missing free_edata pointer

### DIFF
--- a/imap/message.c
+++ b/imap/message.c
@@ -776,6 +776,7 @@ static int read_headers_normal_eval_cache(struct ImapAccountData *adata,
 
         /*  mailbox->hdrs[msgno]->received is restored from mutt_hcache_restore */
         m->hdrs[idx]->edata = h.data;
+        m->hdrs[idx]->free_edata = imap_edata_free;
         STAILQ_INIT(&m->hdrs[idx]->tags);
         driver_tags_replace(&m->hdrs[idx]->tags, mutt_str_strdup(h.data->flags_remote));
 


### PR DESCRIPTION
imap sometimes crashes when changing folder or quiting neomutt.

```
 #1  0x000055555563833f in mutt_email_free (e=0x555555b0cb50) at email/email.c:55
 #2  0x00005555555bb4e9 in mx_fastclose_mailbox (ctx=ctx@entry=0x555555980050) at mx.c:407
 #3  0x00005555555bd593 in mx_mbox_close (pctx=0x5555558a69b0 <Context>, index_hint=index_hint@entry=0x7fffffffa074) at mx.c:727
 ...
```

This change adds the missing free_edata pointer to imap_free_edata.