### PR TITLE
imap: when opening mailbox, reset Mailbox attrs

### DIFF
--- a/imap/imap.c
+++ b/imap/imap.c
@@ -2652,6 +2652,10 @@ static int imap_mbox_open(struct Context *ctx)
   m->hdrs = mutt_mem_calloc(count, sizeof(struct Email *));
   m->v2r = mutt_mem_calloc(count, sizeof(int));
   m->msg_count = 0;
+  m->msg_unread = 0;
+  m->msg_flagged = 0;
+  m->msg_new = 0;
+  m->size = 0;
   m->vcount = 0;
 
   if (count && (imap_read_headers(adata, 1, count, true) < 0))


### PR DESCRIPTION
imap: when opening mailbox, reset Mailbox attrs

We currently only reset vcount and msg_count.

But imap_read_headers() call from imap_mbox_open() reload all
messages and then call mx_update_context(). So attributes that have not
been reseted will grow from previous values.

This does the reset of size, msg_unread, msg_flagged, msg_new.