### PR TITLE
remove mailbox.closing

### DIFF
--- a/imap/command.c
+++ b/imap/command.c
@@ -1322,12 +1322,18 @@ void imap_cmd_finish(struct ImapAccountData *adata)
 
   if (adata->status == IMAP_FATAL)
   {
+    adata->closing = false;
     cmd_handle_fatal(adata);
     return;
   }
 
-  if (!(adata->state >= IMAP_SELECTED) || (adata->mailbox && adata->mailbox->closing))
+  if (!(adata->state >= IMAP_SELECTED) || (adata->mailbox && adata->closing))
+  {
+    adata->closing = false;
     return;
+  }
+
+  adata->closing = false;
 
   if (adata->reopen & IMAP_REOPEN_ALLOW)
   {

--- a/imap/imap.h
+++ b/imap/imap.h
@@ -88,7 +88,7 @@ struct ImapMbox
 int imap_access(const char *path);
 int imap_check_mailbox(struct Mailbox *m, bool force);
 int imap_delete_mailbox(struct Mailbox *m, char *path);
-int imap_sync_mailbox(struct Context *ctx, bool expunge);
+int imap_sync_mailbox(struct Context *ctx, bool expunge, bool close);
 int imap_mailbox_check(bool check_stats);
 int imap_status(const char *path, bool queue);
 int imap_search(struct Mailbox *m, const struct Pattern *pat);

--- a/imap/imap_private.h
+++ b/imap/imap_private.h
@@ -213,6 +213,7 @@ struct ImapAccountData
   struct Connection *conn;
   struct ConnAccount conn_account;
   bool recovering;
+  bool closing; /* If true, we are wating for CLOSE completion */
   unsigned char state;  ///< ImapState, e.g. #IMAP_AUTHENTICATED
   unsigned char status; ///< ImapFlags, e.g. #IMAP_FATAL
   /* let me explain capstr: SASL needs the capability string (not bits).

--- a/mailbox.h
+++ b/mailbox.h
@@ -107,7 +107,6 @@ struct Mailbox
   bool changed : 1;   /**< mailbox has been modified */
   bool readonly : 1;  /**< don't allow changes to the mailbox */
   bool quiet : 1;     /**< inhibit status messages? */
-  bool closing : 1;   /**< mailbox is being closed */
 
   unsigned char rights[(RIGHTSMAX + 7) / 8]; /**< ACL bits */
 


### PR DESCRIPTION
remove mailbox.closing

mx_mbox_close() does not always put back mailbox.closing to false.

This make next imap_sync_mailbox() during mx_mbox_sync() closing the
imap connection when it should not.

Since this attribute is only used by imap backend, this change removes
it and handle the imap specific shutdown within the imap backend.