### PR TITLE
Also delete account if needed during unmailboxes

### DIFF
--- a/account.c
+++ b/account.c
@@ -48,7 +48,48 @@ void account_free(struct Account **a)
     return;
 
   if ((*a)->adata)
-    (*a)->free_adata((void **) a);
+    (*a)->free_adata(&(*a)->adata);
 
   FREE(a);
+}
+
+/**
+ * account_remove - Remove an Account from AllAccounts
+ * @param a Account to remove
+ */
+void account_remove(struct Account *a)
+{
+    struct Account *np = NULL;
+    TAILQ_FOREACH(np, &AllAccounts, entries)
+    {
+      if (np == a)
+      {
+        TAILQ_REMOVE(&AllAccounts, np, entries);
+        break;
+      }
+    }
+}
+
+/**
+ * account_remove_mailbox - Remove a Mailbox from an Account
+ * @param a Account
+ * @param m Mailbox to remove
+ */
+void account_remove_mailbox(struct Account *a, struct Mailbox *m)
+{
+  struct MailboxNode *np = NULL;
+  STAILQ_FOREACH(np, &a->mailboxes, entries)
+  {
+    if (np->m == m)
+    {
+      STAILQ_REMOVE(&a->mailboxes, np, MailboxNode, entries);
+      break;
+    }
+  }
+
+  if (STAILQ_EMPTY(&a->mailboxes))
+  {
+    account_remove(a);
+    account_free(&a);
+  }
 }

--- a/account.h
+++ b/account.h
@@ -48,5 +48,7 @@ extern struct AccountList AllAccounts;
 
 struct Account *account_create(void);
 void            account_free(struct Account **a);
+void            account_remove(struct Account *a);
+void            account_remove_mailbox(struct Account *a, struct Mailbox *m);
 
 #endif /* MUTT_ACCOUNT_H */

--- a/mailbox.c
+++ b/mailbox.c
@@ -701,6 +701,7 @@ int mutt_parse_unmailboxes(struct Buffer *buf, struct Buffer *s,
 #ifdef USE_INOTIFY
         mutt_monitor_remove(np->m);
 #endif
+        mx_ac_remove(np->m);
         STAILQ_REMOVE(&AllMailboxes, np, MailboxNode, entries);
         mailbox_free(&np->m);
         FREE(&np);

--- a/mx.c
+++ b/mx.c
@@ -1674,3 +1674,16 @@ int mx_ac_add(struct Account *a, struct Mailbox *m)
 
   return m->mx_ops->ac_add(a, m);
 }
+
+/**
+ * mx_ac_remove - Remove a Mailbox from an Account and delete Account if empty
+ * @param m Mailbox to remove
+ */
+int mx_ac_remove(struct Mailbox *m)
+{
+  if (!m || !m->account)
+    return -1;
+
+  account_remove_mailbox(m->account, m);
+  return 0;
+}

--- a/mx.h
+++ b/mx.h
@@ -273,7 +273,7 @@ struct Account *mx_ac_find(struct Mailbox *m);
 struct Mailbox *mx_mbox_find(struct Account *a, const char *path);
 struct Mailbox *mx_mbox_find2(const char *path);
 int mx_ac_add(struct Account *a, struct Mailbox *m);
-int mx_ac_remove(struct Account *a, struct Mailbox *m);
+int mx_ac_remove(struct Mailbox *m);
 
 int                 mx_access(const char *path, int flags);
 void                mx_alloc_memory(struct Mailbox *m);


### PR DESCRIPTION
Also delete account if needed during unmailboxes

When we do:

    mailboxes imaps://foo
    unmailboxes *
    mailboxes imaps://foo

* account->mailboxes is not cleaned and have pointer to freed mailboxes
* account is still there even if not used

This changes cleanup account->mailboxes and account if needed.