### PR TITLE
Pull request for better-adata-handling

### DIFF
--- a/imap/browse.c
+++ b/imap/browse.c
@@ -225,13 +225,9 @@ int imap_browse(char *path, struct BrowserState *state)
     // Pick first mailbox connected on the same server
     if (imap_account_match(&mx.account, &mx_tmp.account))
     {
-      /* ensure we are connected */
-      int rc = imap_prepare_mailbox(np->m, &mx, path, buf, sizeof(buf), false, true);
-      if (rc < 0)
-        continue;
-
-      adata = np->m->account->adata;
-      break;
+      adata = imap_adata_get(np->m);
+      if (adata)
+        break;
     }
   }
   FREE(&mx_tmp.mbox);
@@ -389,13 +385,7 @@ int imap_mailbox_create(const char *folder)
   char buf[PATH_MAX];
   short n;
 
-  if (imap_parse_path(folder, &mx) < 0)
-  {
-    mutt_debug(1, "Bad starting path %s\n", folder);
-    return -1;
-  }
-
-  adata = imap_ac_data_find(&mx);
+  adata = imap_adata_find(folder, &mx);
   if (!adata)
   {
     mutt_debug(1, "Couldn't find open connection to %s\n", folder);
@@ -450,13 +440,7 @@ int imap_mailbox_rename(const char *mailbox)
   char buf[PATH_MAX];
   char newname[PATH_MAX];
 
-  if (imap_parse_path(mailbox, &mx) < 0)
-  {
-    mutt_debug(1, "Bad source mailbox %s\n", mailbox);
-    return -1;
-  }
-
-  adata = imap_ac_data_find(&mx);
+  adata = imap_adata_find(mailbox, &mx);
   if (!adata)
   {
     mutt_debug(1, "Couldn't find open connection to %s\n", mailbox);

--- a/imap/imap_private.h
+++ b/imap/imap_private.h
@@ -306,8 +306,7 @@ int imap_login(struct ImapAccountData *adata);
 void imap_logout(struct ImapAccountData **adata);
 int imap_sync_message_for_copy(struct ImapAccountData *adata, struct Email *e, struct Buffer *cmd, int *err_continue);
 bool imap_has_flag(struct ListHead *flag_list, const char *flag);
-int imap_prepare_mailbox(struct Mailbox *m, struct ImapMbox *mx, const char *path, char *mailbox, size_t mailboxlen, bool run_hook, bool create_new_connection);
-struct ImapAccountData *imap_ac_data_find(struct ImapMbox *mx);
+struct ImapAccountData *imap_adata_find(const char *path, struct ImapMbox *mx);
 
 /* auth.c */
 int imap_authenticate(struct ImapAccountData *adata);


### PR DESCRIPTION
imap: simplify getter around ImapAccountData

Since we have accounts and only one connection for imap, we can simply the
code. This does:

* Remove now useless attributes of imap_prepare_mailbox()
* Rename imap_ac_data_find() to imap_adata_find() and move it in util.c aside
  other adata related function.
* Parse path within ImapMbox in imap_adata_find() to remove some common code.
* Create ImapAccountData resource during imap_ac_add()