### PR TITLE
Devel/list find const

### DIFF
--- a/mutt/list.c
+++ b/mutt/list.c
@@ -85,7 +85,7 @@ struct ListNode *mutt_list_insert_after(struct ListHead *h, struct ListNode *n, 
  * @retval ptr ListNode containing the string
  * @retval NULL if the string isn't found
  */
-struct ListNode *mutt_list_find(struct ListHead *h, const char *data)
+struct ListNode *mutt_list_find(const struct ListHead *h, const char *data)
 {
   struct ListNode *np = NULL;
   STAILQ_FOREACH(np, h, entries)

--- a/mutt/list.h
+++ b/mutt/list.h
@@ -52,7 +52,7 @@ typedef void (*list_free_t)(void **ptr);
 
 void             mutt_list_clear(struct ListHead *h);
 int              mutt_list_compare(const struct ListHead *ah, const struct ListHead *bh);
-struct ListNode *mutt_list_find(struct ListHead *h, const char *data);
+struct ListNode *mutt_list_find(const struct ListHead *h, const char *data);
 void             mutt_list_free(struct ListHead *h);
 void             mutt_list_free_type(struct ListHead *h, list_free_t fn);
 struct ListNode *mutt_list_insert_after(struct ListHead *h, struct ListNode *n, char *s);


### PR DESCRIPTION
While working on the message-id stuff, I found this little buglet in the library routines.  Funny that nobody else got there first :-P

`mutt_list_find` in mutt/list.c doesn't change the list, so the list argument should be const.  Otherwise gcc warns, and if you have -Werror on (as you should), errs.

Oh and btw: I am not at all sure that the optimization in `mutt_list_find` which compares the pointers first is valid.  Can you really compare two arbitrary pointers without getting UB?

