### PR TITLE
Factor out `struct Context`

### DIFF
--- a/compress.c
+++ b/compress.c
@@ -861,12 +861,8 @@ static int comp_msg_commit(struct Context *ctx, struct Message *msg)
 /**
  * comp_msg_close - Implements MxOps::msg_close()
  */
-static int comp_msg_close(struct Context *ctx, struct Message *msg)
+static int comp_msg_close(struct Mailbox *m, struct Message *msg)
 {
-  if (!ctx)
-    return -1;
-
-  struct Mailbox *m = ctx->mailbox;
   if (!m)
     return -1;
 
@@ -879,7 +875,7 @@ static int comp_msg_close(struct Context *ctx, struct Message *msg)
     return -1;
 
   /* Delegate */
-  return ops->msg_close(ctx, msg);
+  return ops->msg_close(m, msg);
 }
 
 /**

--- a/compress.c
+++ b/compress.c
@@ -839,12 +839,10 @@ static int comp_msg_open_new(struct Context *ctx, struct Message *msg, struct Em
  */
 static int comp_msg_commit(struct Mailbox *m, struct Message *msg)
 {
-  if (!m)
+  if (!m || !m->compress_info)
     return -1;
 
   struct CompressInfo *ci = m->compress_info;
-  if (!ci)
-    return -1;
 
   const struct MxOps *ops = ci->child_ops;
   if (!ops)
@@ -859,12 +857,10 @@ static int comp_msg_commit(struct Mailbox *m, struct Message *msg)
  */
 static int comp_msg_close(struct Mailbox *m, struct Message *msg)
 {
-  if (!m)
+  if (!m || !m->compress_info)
     return -1;
 
   struct CompressInfo *ci = m->compress_info;
-  if (!ci)
-    return -1;
 
   const struct MxOps *ops = ci->child_ops;
   if (!ops)
@@ -876,17 +872,13 @@ static int comp_msg_close(struct Mailbox *m, struct Message *msg)
 
 /**
  * comp_msg_padding_size - Bytes of padding between messages - Implements MxOps::msg_padding_size()
- * @param m Mailbox
- * @retval num Number of bytes of padding
  */
 static int comp_msg_padding_size(struct Mailbox *m)
 {
-  if (!m)
-    return -1;
+  if (!m || !m->compress_info)
+    return 0;
 
   struct CompressInfo *ci = m->compress_info;
-  if (!ci)
-    return 0;
 
   const struct MxOps *ops = ci->child_ops;
   if (!ops || !ops->msg_padding_size)
@@ -898,24 +890,18 @@ static int comp_msg_padding_size(struct Mailbox *m)
 /**
  * comp_tags_edit - Implements MxOps::tags_edit()
  */
-static int comp_tags_edit(struct Context *ctx, const char *tags, char *buf, size_t buflen)
+static int comp_tags_edit(struct Mailbox *m, const char *tags, char *buf, size_t buflen)
 {
-  if (!ctx)
+  if (!m || !m->compress_info)
     return 0;
-
-  struct Mailbox *m = ctx->mailbox;
-  if (!m)
-    return -1;
 
   struct CompressInfo *ci = m->compress_info;
-  if (!ci)
-    return 0;
 
   const struct MxOps *ops = ci->child_ops;
   if (!ops || !ops->tags_edit)
     return 0;
 
-  return ops->tags_edit(ctx, tags, buf, buflen);
+  return ops->tags_edit(m, tags, buf, buflen);
 }
 
 /**

--- a/compress.c
+++ b/compress.c
@@ -837,12 +837,8 @@ static int comp_msg_open_new(struct Context *ctx, struct Message *msg, struct Em
 /**
  * comp_msg_commit - Implements MxOps::msg_commit()
  */
-static int comp_msg_commit(struct Context *ctx, struct Message *msg)
+static int comp_msg_commit(struct Mailbox *m, struct Message *msg)
 {
-  if (!ctx)
-    return -1;
-
-  struct Mailbox *m = ctx->mailbox;
   if (!m)
     return -1;
 
@@ -855,7 +851,7 @@ static int comp_msg_commit(struct Context *ctx, struct Message *msg)
     return -1;
 
   /* Delegate */
-  return ops->msg_commit(ctx, msg);
+  return ops->msg_commit(m, msg);
 }
 
 /**

--- a/compress.c
+++ b/compress.c
@@ -876,15 +876,11 @@ static int comp_msg_close(struct Mailbox *m, struct Message *msg)
 
 /**
  * comp_msg_padding_size - Bytes of padding between messages - Implements MxOps::msg_padding_size()
- * @param ctx Mailbox
+ * @param m Mailbox
  * @retval num Number of bytes of padding
  */
-static int comp_msg_padding_size(struct Context *ctx)
+static int comp_msg_padding_size(struct Mailbox *m)
 {
-  if (!ctx)
-    return 0;
-
-  struct Mailbox *m = ctx->mailbox;
   if (!m)
     return -1;
 
@@ -896,7 +892,7 @@ static int comp_msg_padding_size(struct Context *ctx)
   if (!ops || !ops->msg_padding_size)
     return 0;
 
-  return ops->msg_padding_size(ctx);
+  return ops->msg_padding_size(m);
 }
 
 /**

--- a/compress.c
+++ b/compress.c
@@ -941,19 +941,10 @@ enum MailboxType comp_path_probe(const char *path, const struct stat *st)
 /**
  * comp_path_canon - Canonicalise a mailbox path - Implements MxOps::path_canon()
  */
-int comp_path_canon(char *buf, size_t buflen, const char *folder)
+int comp_path_canon(char *buf, size_t buflen)
 {
   if (!buf)
     return -1;
-
-  if ((buf[0] == '+') || (buf[0] == '='))
-  {
-    if (!folder)
-      return -1;
-
-    buf[0] = '/';
-    mutt_str_inline_replace(buf, buflen, 0, folder);
-  }
 
   mutt_path_canon(buf, buflen, HomeDir);
   return 0;

--- a/compress.c
+++ b/compress.c
@@ -558,12 +558,8 @@ cmo_fail:
  * To append to a compressed mailbox we need an append-hook (or both open- and
  * close-hooks).
  */
-static int comp_mbox_open_append(struct Context *ctx, int flags)
+static int comp_mbox_open_append(struct Mailbox *m, int flags)
 {
-  if (!ctx)
-    return -1;
-
-  struct Mailbox *m = ctx->mailbox;
   if (!m)
     return -1;
 
@@ -618,7 +614,7 @@ static int comp_mbox_open_append(struct Context *ctx, int flags)
     goto cmoa_fail2;
   }
 
-  if (ci->child_ops->mbox_open_append(ctx, flags) != 0)
+  if (ci->child_ops->mbox_open_append(m, flags) != 0)
     goto cmoa_fail2;
 
   return 0;

--- a/curs_main.c
+++ b/curs_main.c
@@ -1491,7 +1491,7 @@ int mutt_index_menu(void)
         {
           struct Email *e = Context->mailbox->hdrs[i - 1];
 
-          if (mutt_messages_in_thread(Context, e, 1) != 1)
+          if (mutt_messages_in_thread(Context, e, 1) > 1)
           {
             mutt_uncollapse_thread(Context, e);
             mutt_set_virtual(Context);

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -2821,29 +2821,10 @@ enum MailboxType imap_path_probe(const char *path, const struct stat *st)
 /**
  * imap_path_canon - Canonicalise a mailbox path - Implements MxOps::path_canon()
  */
-int imap_path_canon(char *buf, size_t buflen, const char *folder)
+int imap_path_canon(char *buf, size_t buflen)
 {
   if (!buf)
     return -1;
-
-#if 0
-  if ((buf[0] == '+') || (buf[0] == '='))
-  {
-    if (!folder)
-      return -1;
-
-    size_t flen = mutt_str_strlen(folder);
-    if ((flen > 0) && (folder[flen - 1] != '/'))
-    {
-      buf[0] = '/';
-      mutt_str_inline_replace(buf, buflen, 0, folder);
-    }
-    else
-    {
-      mutt_str_inline_replace(buf, buflen, 1, folder);
-    }
-  }
-#endif
 
   struct Url url;
   char tmp[PATH_MAX];

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -2631,12 +2631,8 @@ static int imap_msg_open_new(struct Context *ctx, struct Message *msg, struct Em
 /**
  * imap_tags_edit - Implements MxOps::tags_edit()
  */
-static int imap_tags_edit(struct Context *ctx, const char *tags, char *buf, size_t buflen)
+static int imap_tags_edit(struct Mailbox *m, const char *tags, char *buf, size_t buflen)
 {
-  if (!ctx)
-    return -1;
-
-  struct Mailbox *m = ctx->mailbox;
   if (!m)
     return -1;
 

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -2488,12 +2488,8 @@ fail:
 /**
  * imap_mbox_open_append - Implements MxOps::mbox_open_append()
  */
-static int imap_mbox_open_append(struct Context *ctx, int flags)
+static int imap_mbox_open_append(struct Mailbox *m, int flags)
 {
-  if (!ctx)
-    return -1;
-
-  struct Mailbox *m = ctx->mailbox;
   if (!m)
     return -1;
 

--- a/imap/imap.h
+++ b/imap/imap.h
@@ -96,7 +96,7 @@ int imap_subscribe(char *path, bool subscribe);
 int imap_complete(char *buf, size_t buflen, char *path);
 int imap_fast_trash(struct Mailbox *m, char *dest);
 int imap_path_probe(const char *path, const struct stat *st);
-int imap_path_canon(char *buf, size_t buflen, const char *folder);
+int imap_path_canon(char *buf, size_t buflen);
 
 extern struct MxOps mx_imap_ops;
 

--- a/imap/imap_private.h
+++ b/imap/imap_private.h
@@ -327,11 +327,11 @@ int imap_read_headers(struct ImapAccountData *adata, unsigned int msn_begin, uns
 char *imap_set_flags(struct ImapAccountData *adata, struct Email *e, char *s, int *server_changes);
 int imap_cache_del(struct ImapAccountData *adata, struct Email *e);
 int imap_cache_clean(struct ImapAccountData *adata);
-int imap_append_message(struct Context *ctx, struct Message *msg);
+int imap_append_message(struct Mailbox *m, struct Message *msg);
 
 int imap_msg_open(struct Context *ctx, struct Message *msg, int msgno);
 int imap_msg_close(struct Mailbox *m, struct Message *msg);
-int imap_msg_commit(struct Context *ctx, struct Message *msg);
+int imap_msg_commit(struct Mailbox *m, struct Message *msg);
 
 /* util.c */
 struct ImapAccountData *imap_adata_get(struct Mailbox *m);

--- a/imap/imap_private.h
+++ b/imap/imap_private.h
@@ -330,7 +330,7 @@ int imap_cache_clean(struct ImapAccountData *adata);
 int imap_append_message(struct Context *ctx, struct Message *msg);
 
 int imap_msg_open(struct Context *ctx, struct Message *msg, int msgno);
-int imap_msg_close(struct Context *ctx, struct Message *msg);
+int imap_msg_close(struct Mailbox *m, struct Message *msg);
 int imap_msg_commit(struct Context *ctx, struct Message *msg);
 
 /* util.c */

--- a/imap/message.c
+++ b/imap/message.c
@@ -2062,7 +2062,7 @@ int imap_msg_commit(struct Context *ctx, struct Message *msg)
  *
  * @note May also return EOF Failure, see errno
  */
-int imap_msg_close(struct Context *ctx, struct Message *msg)
+int imap_msg_close(struct Mailbox *m, struct Message *msg)
 {
   return mutt_file_fclose(&msg->fp);
 }

--- a/imap/message.c
+++ b/imap/message.c
@@ -1370,13 +1370,16 @@ bail:
 
 /**
  * imap_append_message - Write an email back to the server
- * @param ctx Mailbox
+ * @param m   Mailbox
  * @param msg Message to save
  * @retval  0 Success
  * @retval -1 Failure
  */
-int imap_append_message(struct Context *ctx, struct Message *msg)
+int imap_append_message(struct Mailbox *m, struct Message *msg)
 {
+  if (!m || !msg)
+    return -1;
+
   FILE *fp = NULL;
   char buf[LONG_STRING * 2];
   char mbox[LONG_STRING];
@@ -1389,13 +1392,6 @@ int imap_append_message(struct Context *ctx, struct Message *msg)
   int c, last;
   struct ImapMbox mx;
   int rc;
-
-  if (!ctx)
-    return -1;
-
-  struct Mailbox *m = ctx->mailbox;
-  if (!m)
-    return -1;
 
   struct ImapAccountData *adata = imap_adata_get(m);
 
@@ -2048,13 +2044,13 @@ bail:
  *
  * @note May also return EOF Failure, see errno
  */
-int imap_msg_commit(struct Context *ctx, struct Message *msg)
+int imap_msg_commit(struct Mailbox *m, struct Message *msg)
 {
   int r = mutt_file_fclose(&msg->fp);
   if (r != 0)
     return r;
 
-  return imap_append_message(ctx, msg);
+  return imap_append_message(m, msg);
 }
 
 /**

--- a/imap/util.c
+++ b/imap/util.c
@@ -131,7 +131,6 @@ struct ImapAccountData *imap_adata_get(struct Mailbox *m)
  */
 struct ImapAccountData *imap_adata_find(const char *path, struct ImapMbox *mx)
 {
-
   if (imap_parse_path(path, mx) < 0)
     return NULL;
 
@@ -149,7 +148,6 @@ struct ImapAccountData *imap_adata_find(const char *path, struct ImapMbox *mx)
   mutt_debug(3, "no ImapAccountData found\n");
   return NULL;
 }
-
 
 /**
  * imap_get_parent - Get an IMAP folder's parent

--- a/mailbox.c
+++ b/mailbox.c
@@ -777,7 +777,8 @@ int mutt_mailbox_check(int force)
   struct MailboxNode *np = NULL;
   STAILQ_FOREACH(np, &AllMailboxes, entries)
   {
-    mailbox_check(np->m, &contex_sb, check_stats || (!np->m->first_check_stats_done && MailCheckStats));
+    mailbox_check(np->m, &contex_sb,
+                  check_stats || (!np->m->first_check_stats_done && MailCheckStats));
     np->m->first_check_stats_done = true;
   }
 

--- a/maildir/mh.c
+++ b/maildir/mh.c
@@ -2715,12 +2715,8 @@ static int maildir_msg_open_new(struct Context *ctx, struct Message *msg, struct
 /**
  * maildir_msg_commit - Implements MxOps::msg_commit()
  */
-static int maildir_msg_commit(struct Context *ctx, struct Message *msg)
+static int maildir_msg_commit(struct Mailbox *m, struct Message *msg)
 {
-  if (!ctx)
-    return -1;
-
-  struct Mailbox *m = ctx->mailbox;
   if (!m)
     return -1;
 
@@ -3109,12 +3105,8 @@ static int mh_msg_open_new(struct Context *ctx, struct Message *msg, struct Emai
 /**
  * mh_msg_commit - Implements MxOps::msg_commit()
  */
-static int mh_msg_commit(struct Context *ctx, struct Message *msg)
+static int mh_msg_commit(struct Mailbox *m, struct Message *msg)
 {
-  if (!ctx)
-    return -1;
-
-  struct Mailbox *m = ctx->mailbox;
   if (!m)
     return -1;
 

--- a/maildir/mh.c
+++ b/maildir/mh.c
@@ -2747,19 +2747,10 @@ enum MailboxType maildir_path_probe(const char *path, const struct stat *st)
 /**
  * maildir_path_canon - Canonicalise a mailbox path - Implements MxOps::path_canon()
  */
-int maildir_path_canon(char *buf, size_t buflen, const char *folder)
+int maildir_path_canon(char *buf, size_t buflen)
 {
   if (!buf)
     return -1;
-
-  if ((buf[0] == '+') || (buf[0] == '='))
-  {
-    if (!folder)
-      return -1;
-
-    buf[0] = '/';
-    mutt_str_inline_replace(buf, buflen, 0, folder);
-  }
 
   mutt_path_canon(buf, buflen, HomeDir);
   return 0;

--- a/maildir/mh.c
+++ b/maildir/mh.c
@@ -2388,12 +2388,8 @@ static int maildir_mbox_open(struct Context *ctx)
 /**
  * maildir_mbox_open_append - Implements MxOps::mbox_open_append()
  */
-static int maildir_mbox_open_append(struct Context *ctx, int flags)
+static int maildir_mbox_open_append(struct Mailbox *m, int flags)
 {
-  if (!ctx)
-    return -1;
-
-  struct Mailbox *m = ctx->mailbox;
   if (!m)
     return -1;
 
@@ -2821,12 +2817,8 @@ static int mh_mbox_open(struct Context *ctx)
 /**
  * mh_mbox_open_append - Implements MxOps::mbox_open_append()
  */
-static int mh_mbox_open_append(struct Context *ctx, int flags)
+static int mh_mbox_open_append(struct Mailbox *m, int flags)
 {
-  if (!ctx)
-    return -1;
-
-  struct Mailbox *m = ctx->mailbox;
   if (!m)
     return -1;
 

--- a/maildir/mh.c
+++ b/maildir/mh.c
@@ -3126,7 +3126,7 @@ static int mh_msg_commit(struct Context *ctx, struct Message *msg)
  *
  * @note May also return EOF Failure, see errno
  */
-static int mh_msg_close(struct Context *ctx, struct Message *msg)
+static int mh_msg_close(struct Mailbox *m, struct Message *msg)
 {
   return mutt_file_fclose(&msg->fp);
 }

--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -1639,10 +1639,10 @@ static int mbox_msg_close(struct Mailbox *m, struct Message *msg)
 
 /**
  * mbox_msg_padding_size - Bytes of padding between messages - Implements MxOps::msg_padding_size()
- * @param ctx Mailbox
+ * @param m Mailbox
  * @retval 1 Always
  */
-static int mbox_msg_padding_size(struct Context *ctx)
+static int mbox_msg_padding_size(struct Mailbox *m)
 {
   return 1;
 }
@@ -1788,10 +1788,10 @@ static int mmdf_msg_commit(struct Mailbox *m, struct Message *msg)
 
 /**
  * mmdf_msg_padding_size - Bytes of padding between messages - Implements MxOps::msg_padding_size()
- * @param ctx Mailbox
+ * @param m Mailbox
  * @retval 10 Always
  */
-static int mmdf_msg_padding_size(struct Context *ctx)
+static int mmdf_msg_padding_size(struct Mailbox *m)
 {
   return 10;
 }

--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -1627,7 +1627,7 @@ static int mbox_msg_commit(struct Context *ctx, struct Message *msg)
 /**
  * mbox_msg_close - Implements MxOps::msg_close()
  */
-static int mbox_msg_close(struct Context *ctx, struct Message *msg)
+static int mbox_msg_close(struct Mailbox *m, struct Message *msg)
 {
   if (!msg)
     return -1;

--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -983,12 +983,8 @@ static int mbox_mbox_open(struct Context *ctx)
 /**
  * mbox_mbox_open_append - Implements MxOps::mbox_open_append()
  */
-static int mbox_mbox_open_append(struct Context *ctx, int flags)
+static int mbox_mbox_open_append(struct Mailbox *m, int flags)
 {
-  if (!ctx)
-    return -1;
-
-  struct Mailbox *m = ctx->mailbox;
   if (!m)
     return -1;
 

--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -1714,19 +1714,10 @@ enum MailboxType mbox_path_probe(const char *path, const struct stat *st)
 /**
  * mbox_path_canon - Canonicalise a mailbox path - Implements MxOps::path_canon()
  */
-int mbox_path_canon(char *buf, size_t buflen, const char *folder)
+int mbox_path_canon(char *buf, size_t buflen)
 {
   if (!buf)
     return -1;
-
-  if ((buf[0] == '+') || (buf[0] == '='))
-  {
-    if (!folder)
-      return -1;
-
-    buf[0] = '/';
-    mutt_str_inline_replace(buf, buflen, 0, folder);
-  }
 
   mutt_path_canon(buf, buflen, HomeDir);
   return 0;

--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -181,13 +181,18 @@ static void mbox_unlock_mailbox(struct Mailbox *m)
  */
 static int mmdf_parse_mailbox(struct Context *ctx)
 {
-  struct MboxAccountData *adata = mbox_adata_get(ctx->mailbox);
+  if (!ctx || !ctx->mailbox)
+    return -1;
+
+  struct Mailbox *m = ctx->mailbox;
+
+  struct MboxAccountData *adata = mbox_adata_get(m);
   if (!adata)
     return -1;
 
   char buf[HUGE_STRING];
   char return_path[LONG_STRING];
-  int count = 0, oldmsgcount = ctx->mailbox->msg_count;
+  int count = 0, oldmsgcount = m->msg_count;
   int lines;
   time_t t;
   LOFF_T loc, tmploc;
@@ -195,21 +200,21 @@ static int mmdf_parse_mailbox(struct Context *ctx)
   struct stat sb;
   struct Progress progress;
 
-  if (stat(ctx->mailbox->path, &sb) == -1)
+  if (stat(m->path, &sb) == -1)
   {
-    mutt_perror(ctx->mailbox->path);
+    mutt_perror(m->path);
     return -1;
   }
   mutt_get_stat_timespec(&adata->atime, &sb, MUTT_STAT_ATIME);
-  mutt_get_stat_timespec(&ctx->mailbox->mtime, &sb, MUTT_STAT_MTIME);
-  ctx->mailbox->size = sb.st_size;
+  mutt_get_stat_timespec(&m->mtime, &sb, MUTT_STAT_MTIME);
+  m->size = sb.st_size;
 
   buf[sizeof(buf) - 1] = '\0';
 
-  if (!ctx->mailbox->quiet)
+  if (!m->quiet)
   {
     char msgbuf[STRING];
-    snprintf(msgbuf, sizeof(msgbuf), _("Reading %s..."), ctx->mailbox->path);
+    snprintf(msgbuf, sizeof(msgbuf), _("Reading %s..."), m->path);
     mutt_progress_init(&progress, msgbuf, MUTT_PROGRESS_MSG, ReadInc, 0);
   }
 
@@ -228,16 +233,15 @@ static int mmdf_parse_mailbox(struct Context *ctx)
         return -1;
 
       count++;
-      if (!ctx->mailbox->quiet)
-        mutt_progress_update(&progress, count,
-                             (int) (loc / (ctx->mailbox->size / 100 + 1)));
+      if (!m->quiet)
+        mutt_progress_update(&progress, count, (int) (loc / (m->size / 100 + 1)));
 
-      if (ctx->mailbox->msg_count == ctx->mailbox->hdrmax)
-        mx_alloc_memory(ctx->mailbox);
+      if (m->msg_count == m->hdrmax)
+        mx_alloc_memory(m);
       e = mutt_email_new();
-      ctx->mailbox->hdrs[ctx->mailbox->msg_count] = e;
+      m->hdrs[m->msg_count] = e;
       e->offset = loc;
-      e->index = ctx->mailbox->msg_count;
+      e->index = m->msg_count;
 
       if (!fgets(buf, sizeof(buf) - 1, adata->fp))
       {
@@ -270,7 +274,7 @@ static int mmdf_parse_mailbox(struct Context *ctx)
       {
         tmploc = loc + e->content->length;
 
-        if ((tmploc > 0) && (tmploc < ctx->mailbox->size))
+        if ((tmploc > 0) && (tmploc < m->size))
         {
           if (fseeko(adata->fp, tmploc, SEEK_SET) != 0 ||
               !fgets(buf, sizeof(buf) - 1, adata->fp) ||
@@ -310,7 +314,7 @@ static int mmdf_parse_mailbox(struct Context *ctx)
       if (!e->env->from)
         e->env->from = mutt_addr_copy_list(e->env->return_path, false);
 
-      ctx->mailbox->msg_count++;
+      m->msg_count++;
     }
     else
     {
@@ -320,8 +324,8 @@ static int mmdf_parse_mailbox(struct Context *ctx)
     }
   }
 
-  if (ctx->mailbox->msg_count > oldmsgcount)
-    mx_update_context(ctx, ctx->mailbox->msg_count - oldmsgcount);
+  if (m->msg_count > oldmsgcount)
+    mx_update_context(ctx, m->msg_count - oldmsgcount);
 
   if (SigInt == 1)
   {
@@ -347,7 +351,12 @@ static int mmdf_parse_mailbox(struct Context *ctx)
  */
 static int mbox_parse_mailbox(struct Context *ctx)
 {
-  struct MboxAccountData *adata = mbox_adata_get(ctx->mailbox);
+  if (!ctx || !ctx->mailbox)
+    return -1;
+
+  struct Mailbox *m = ctx->mailbox;
+
+  struct MboxAccountData *adata = mbox_adata_get(m);
   if (!adata)
     return -1;
 
@@ -360,34 +369,34 @@ static int mbox_parse_mailbox(struct Context *ctx)
   struct Progress progress;
 
   /* Save information about the folder at the time we opened it. */
-  if (stat(ctx->mailbox->path, &sb) == -1)
+  if (stat(m->path, &sb) == -1)
   {
-    mutt_perror(ctx->mailbox->path);
+    mutt_perror(m->path);
     return -1;
   }
 
-  ctx->mailbox->size = sb.st_size;
-  mutt_get_stat_timespec(&ctx->mailbox->mtime, &sb, MUTT_STAT_MTIME);
+  m->size = sb.st_size;
+  mutt_get_stat_timespec(&m->mtime, &sb, MUTT_STAT_MTIME);
   mutt_get_stat_timespec(&adata->atime, &sb, MUTT_STAT_ATIME);
 
-  if (!ctx->mailbox->readonly)
-    ctx->mailbox->readonly = access(ctx->mailbox->path, W_OK) ? true : false;
+  if (!m->readonly)
+    m->readonly = access(m->path, W_OK) ? true : false;
 
-  if (!ctx->mailbox->quiet)
+  if (!m->quiet)
   {
     char msgbuf[STRING];
-    snprintf(msgbuf, sizeof(msgbuf), _("Reading %s..."), ctx->mailbox->path);
+    snprintf(msgbuf, sizeof(msgbuf), _("Reading %s..."), m->path);
     mutt_progress_init(&progress, msgbuf, MUTT_PROGRESS_MSG, ReadInc, 0);
   }
 
-  if (!ctx->mailbox->hdrs)
+  if (!m->hdrs)
   {
     /* Allocate some memory to get started */
-    ctx->mailbox->hdrmax = ctx->mailbox->msg_count;
-    ctx->mailbox->msg_count = 0;
-    ctx->mailbox->msg_unread = 0;
-    ctx->mailbox->vcount = 0;
-    mx_alloc_memory(ctx->mailbox);
+    m->hdrmax = m->msg_count;
+    m->msg_count = 0;
+    m->msg_unread = 0;
+    m->vcount = 0;
+    mx_alloc_memory(m);
   }
 
   loc = ftello(adata->fp);
@@ -398,7 +407,7 @@ static int mbox_parse_mailbox(struct Context *ctx)
       /* Save the Content-Length of the previous message */
       if (count > 0)
       {
-        struct Email *e = ctx->mailbox->hdrs[ctx->mailbox->msg_count - 1];
+        struct Email *e = m->hdrs[m->msg_count - 1];
         if (e->content->length < 0)
         {
           e->content->length = loc - e->content->offset - 1;
@@ -411,20 +420,20 @@ static int mbox_parse_mailbox(struct Context *ctx)
 
       count++;
 
-      if (!ctx->mailbox->quiet)
+      if (!m->quiet)
       {
         mutt_progress_update(&progress, count,
-                             (int) (ftello(adata->fp) / (ctx->mailbox->size / 100 + 1)));
+                             (int) (ftello(adata->fp) / (m->size / 100 + 1)));
       }
 
-      if (ctx->mailbox->msg_count == ctx->mailbox->hdrmax)
-        mx_alloc_memory(ctx->mailbox);
+      if (m->msg_count == m->hdrmax)
+        mx_alloc_memory(m);
 
-      ctx->mailbox->hdrs[ctx->mailbox->msg_count] = mutt_email_new();
-      curhdr = ctx->mailbox->hdrs[ctx->mailbox->msg_count];
+      m->hdrs[m->msg_count] = mutt_email_new();
+      curhdr = m->hdrs[m->msg_count];
       curhdr->received = t - mutt_date_local_tz(t);
       curhdr->offset = loc;
-      curhdr->index = ctx->mailbox->msg_count;
+      curhdr->index = m->msg_count;
 
       curhdr->env = mutt_rfc822_read_header(adata->fp, curhdr, false, false);
 
@@ -441,11 +450,11 @@ static int mbox_parse_mailbox(struct Context *ctx)
         /* The test below avoids a potential integer overflow if the
          * content-length is huge (thus necessarily invalid).
          */
-        tmploc = (curhdr->content->length < ctx->mailbox->size) ?
+        tmploc = (curhdr->content->length < m->size) ?
                      (loc + curhdr->content->length + 1) :
                      -1;
 
-        if ((tmploc > 0) && (tmploc < ctx->mailbox->size))
+        if ((tmploc > 0) && (tmploc < m->size))
         {
           /* check to see if the content-length looks valid.  we expect to
            * to see a valid message separator at this point in the stream
@@ -465,7 +474,7 @@ static int mbox_parse_mailbox(struct Context *ctx)
             curhdr->content->length = -1;
           }
         }
-        else if (tmploc != ctx->mailbox->size)
+        else if (tmploc != m->size)
         {
           /* content-length would put us past the end of the file, so it
            * must be wrong
@@ -498,7 +507,7 @@ static int mbox_parse_mailbox(struct Context *ctx)
         }
       }
 
-      ctx->mailbox->msg_count++;
+      m->msg_count++;
 
       if (!curhdr->env->return_path && return_path[0])
       {
@@ -524,7 +533,7 @@ static int mbox_parse_mailbox(struct Context *ctx)
    */
   if (count > 0)
   {
-    struct Email *e = ctx->mailbox->hdrs[ctx->mailbox->msg_count - 1];
+    struct Email *e = m->hdrs[m->msg_count - 1];
     if (e->content->length < 0)
     {
       e->content->length = ftello(adata->fp) - e->content->offset - 1;
@@ -556,7 +565,12 @@ static int mbox_parse_mailbox(struct Context *ctx)
  */
 static int reopen_mailbox(struct Context *ctx, int *index_hint)
 {
-  struct MboxAccountData *adata = mbox_adata_get(ctx->mailbox);
+  if (!ctx || !ctx->mailbox)
+    return -1;
+
+  struct Mailbox *m = ctx->mailbox;
+
+  struct MboxAccountData *adata = mbox_adata_get(m);
   if (!adata)
     return -1;
 
@@ -569,9 +583,9 @@ static int reopen_mailbox(struct Context *ctx, int *index_hint)
   int rc = -1;
 
   /* silent operations */
-  ctx->mailbox->quiet = true;
+  m->quiet = true;
 
-  if (!ctx->mailbox->quiet)
+  if (!m->quiet)
     mutt_message(_("Reopening mailbox..."));
 
   /* our heuristics require the old mailbox to be unsorted */
@@ -589,51 +603,50 @@ static int reopen_mailbox(struct Context *ctx, int *index_hint)
   old_msgcount = 0;
 
   /* simulate a close */
-  mutt_hash_destroy(&ctx->mailbox->id_hash);
-  mutt_hash_destroy(&ctx->mailbox->subj_hash);
-  mutt_hash_destroy(&ctx->mailbox->label_hash);
+  mutt_hash_destroy(&m->id_hash);
+  mutt_hash_destroy(&m->subj_hash);
+  mutt_hash_destroy(&m->label_hash);
   mutt_clear_threads(ctx);
-  FREE(&ctx->mailbox->v2r);
-  if (ctx->mailbox->readonly)
+  FREE(&m->v2r);
+  if (m->readonly)
   {
-    for (i = 0; i < ctx->mailbox->msg_count; i++)
-      mutt_email_free(&(ctx->mailbox->hdrs[i])); /* nothing to do! */
-    FREE(&ctx->mailbox->hdrs);
+    for (i = 0; i < m->msg_count; i++)
+      mutt_email_free(&(m->hdrs[i])); /* nothing to do! */
+    FREE(&m->hdrs);
   }
   else
   {
     /* save the old headers */
-    old_msgcount = ctx->mailbox->msg_count;
-    old_hdrs = ctx->mailbox->hdrs;
-    ctx->mailbox->hdrs = NULL;
+    old_msgcount = m->msg_count;
+    old_hdrs = m->hdrs;
+    m->hdrs = NULL;
   }
 
-  ctx->mailbox->hdrmax = 0; /* force allocation of new headers */
-  ctx->mailbox->msg_count = 0;
-  ctx->mailbox->vcount = 0;
+  m->hdrmax = 0; /* force allocation of new headers */
+  m->msg_count = 0;
+  m->vcount = 0;
   ctx->vsize = 0;
   ctx->tagged = 0;
-  ctx->mailbox->msg_deleted = 0;
-  ctx->mailbox->msg_new = 0;
-  ctx->mailbox->msg_unread = 0;
-  ctx->mailbox->msg_flagged = 0;
-  ctx->mailbox->changed = false;
-  ctx->mailbox->id_hash = NULL;
-  ctx->mailbox->subj_hash = NULL;
-  mutt_make_label_hash(ctx->mailbox);
+  m->msg_deleted = 0;
+  m->msg_new = 0;
+  m->msg_unread = 0;
+  m->msg_flagged = 0;
+  m->changed = false;
+  m->id_hash = NULL;
+  m->subj_hash = NULL;
+  mutt_make_label_hash(m);
 
-  switch (ctx->mailbox->magic)
+  switch (m->magic)
   {
     case MUTT_MBOX:
     case MUTT_MMDF:
       cmp_headers = mutt_email_cmp_strict;
       mutt_file_fclose(&adata->fp);
-      adata->fp = mutt_file_fopen(ctx->mailbox->path, "r");
+      adata->fp = mutt_file_fopen(m->path, "r");
       if (!adata->fp)
         rc = -1;
       else
-        rc = ((ctx->mailbox->magic == MUTT_MBOX) ? mbox_parse_mailbox :
-                                                   mmdf_parse_mailbox)(ctx);
+        rc = ((m->magic == MUTT_MBOX) ? mbox_parse_mailbox : mmdf_parse_mailbox)(ctx);
       break;
 
     default:
@@ -648,7 +661,7 @@ static int reopen_mailbox(struct Context *ctx, int *index_hint)
       mutt_email_free(&(old_hdrs[j]));
     FREE(&old_hdrs);
 
-    ctx->mailbox->quiet = false;
+    m->quiet = false;
     return -1;
   }
 
@@ -658,9 +671,9 @@ static int reopen_mailbox(struct Context *ctx, int *index_hint)
 
   index_hint_set = (index_hint == NULL);
 
-  if (!ctx->mailbox->readonly)
+  if (!m->readonly)
   {
-    for (i = 0; i < ctx->mailbox->msg_count; i++)
+    for (i = 0; i < m->msg_count; i++)
     {
       bool found = false;
 
@@ -673,7 +686,7 @@ static int reopen_mailbox(struct Context *ctx, int *index_hint)
       {
         if (!old_hdrs[j])
           continue;
-        if (cmp_headers(ctx->mailbox->hdrs[i], old_hdrs[j]))
+        if (cmp_headers(m->hdrs[i], old_hdrs[j]))
         {
           found = true;
           break;
@@ -685,7 +698,7 @@ static int reopen_mailbox(struct Context *ctx, int *index_hint)
         {
           if (!old_hdrs[j])
             continue;
-          if (cmp_headers(ctx->mailbox->hdrs[i], old_hdrs[j]))
+          if (cmp_headers(m->hdrs[i], old_hdrs[j]))
           {
             found = true;
             break;
@@ -705,14 +718,14 @@ static int reopen_mailbox(struct Context *ctx, int *index_hint)
            * otherwise, the header may have been modified externally,
            * and we don't want to lose _those_ changes
            */
-          mutt_set_flag(ctx, ctx->mailbox->hdrs[i], MUTT_FLAG, old_hdrs[j]->flagged);
-          mutt_set_flag(ctx, ctx->mailbox->hdrs[i], MUTT_REPLIED, old_hdrs[j]->replied);
-          mutt_set_flag(ctx, ctx->mailbox->hdrs[i], MUTT_OLD, old_hdrs[j]->old);
-          mutt_set_flag(ctx, ctx->mailbox->hdrs[i], MUTT_READ, old_hdrs[j]->read);
+          mutt_set_flag(ctx, m->hdrs[i], MUTT_FLAG, old_hdrs[j]->flagged);
+          mutt_set_flag(ctx, m->hdrs[i], MUTT_REPLIED, old_hdrs[j]->replied);
+          mutt_set_flag(ctx, m->hdrs[i], MUTT_OLD, old_hdrs[j]->old);
+          mutt_set_flag(ctx, m->hdrs[i], MUTT_READ, old_hdrs[j]->read);
         }
-        mutt_set_flag(ctx, ctx->mailbox->hdrs[i], MUTT_DELETE, old_hdrs[j]->deleted);
-        mutt_set_flag(ctx, ctx->mailbox->hdrs[i], MUTT_PURGE, old_hdrs[j]->purge);
-        mutt_set_flag(ctx, ctx->mailbox->hdrs[i], MUTT_TAG, old_hdrs[j]->tagged);
+        mutt_set_flag(ctx, m->hdrs[i], MUTT_DELETE, old_hdrs[j]->deleted);
+        mutt_set_flag(ctx, m->hdrs[i], MUTT_PURGE, old_hdrs[j]->purge);
+        mutt_set_flag(ctx, m->hdrs[i], MUTT_TAG, old_hdrs[j]->tagged);
 
         /* we don't need this header any more */
         mutt_email_free(&(old_hdrs[j]));
@@ -731,9 +744,9 @@ static int reopen_mailbox(struct Context *ctx, int *index_hint)
     FREE(&old_hdrs);
   }
 
-  ctx->mailbox->quiet = false;
+  m->quiet = false;
 
-  return (ctx->mailbox->changed || msg_mod) ? MUTT_REOPENED : MUTT_NEW_MAIL;
+  return (m->changed || msg_mod) ? MUTT_REOPENED : MUTT_NEW_MAIL;
 }
 
 /**
@@ -928,6 +941,9 @@ int mbox_ac_add(struct Account *a, struct Mailbox *m)
  */
 static int mbox_mbox_open(struct Context *ctx)
 {
+  if (!ctx || !ctx->mailbox)
+    return -1;
+
   struct Mailbox *m = ctx->mailbox;
 
   if (init_mailbox(m) != 0)
@@ -969,7 +985,12 @@ static int mbox_mbox_open(struct Context *ctx)
  */
 static int mbox_mbox_open_append(struct Context *ctx, int flags)
 {
+  if (!ctx)
+    return -1;
+
   struct Mailbox *m = ctx->mailbox;
+  if (!m)
+    return -1;
 
   if (init_mailbox(m) != 0)
     return -1;
@@ -1009,7 +1030,12 @@ static int mbox_mbox_open_append(struct Context *ctx, int flags)
  */
 static int mbox_mbox_check(struct Context *ctx, int *index_hint)
 {
-  struct MboxAccountData *adata = mbox_adata_get(ctx->mailbox);
+  if (!ctx || !ctx->mailbox)
+    return -1;
+
+  struct Mailbox *m = ctx->mailbox;
+
+  struct MboxAccountData *adata = mbox_adata_get(m);
   if (!adata)
     return -1;
 
@@ -1020,28 +1046,28 @@ static int mbox_mbox_check(struct Context *ctx, int *index_hint)
   bool unlock = false;
   bool modified = false;
 
-  if (stat(ctx->mailbox->path, &st) == 0)
+  if (stat(m->path, &st) == 0)
   {
-    if ((mutt_stat_timespec_compare(&st, MUTT_STAT_MTIME, &ctx->mailbox->mtime) == 0) &&
-        st.st_size == ctx->mailbox->size)
+    if ((mutt_stat_timespec_compare(&st, MUTT_STAT_MTIME, &m->mtime) == 0) &&
+        st.st_size == m->size)
     {
       return 0;
     }
 
-    if (st.st_size == ctx->mailbox->size)
+    if (st.st_size == m->size)
     {
       /* the file was touched, but it is still the same length, so just exit */
-      mutt_get_stat_timespec(&ctx->mailbox->mtime, &st, MUTT_STAT_MTIME);
+      mutt_get_stat_timespec(&m->mtime, &st, MUTT_STAT_MTIME);
       return 0;
     }
 
-    if (st.st_size > ctx->mailbox->size)
+    if (st.st_size > m->size)
     {
       /* lock the file if it isn't already */
       if (!adata->locked)
       {
         mutt_sig_block();
-        if (mbox_lock_mailbox(ctx->mailbox, false, false) == -1)
+        if (mbox_lock_mailbox(m, false, false) == -1)
         {
           mutt_sig_unblock();
           /* we couldn't lock the mailbox, but nothing serious happened:
@@ -1059,17 +1085,17 @@ static int mbox_mbox_check(struct Context *ctx, int *index_hint)
        * folder.
        */
       char buffer[LONG_STRING];
-      if (fseeko(adata->fp, ctx->mailbox->size, SEEK_SET) != 0)
+      if (fseeko(adata->fp, m->size, SEEK_SET) != 0)
         mutt_debug(1, "#1 fseek() failed\n");
       if (fgets(buffer, sizeof(buffer), adata->fp))
       {
-        if ((ctx->mailbox->magic == MUTT_MBOX &&
+        if ((m->magic == MUTT_MBOX &&
              mutt_str_startswith(buffer, "From ", CASE_MATCH)) ||
-            (ctx->mailbox->magic == MUTT_MMDF && (mutt_str_strcmp(buffer, MMDF_SEP) == 0)))
+            (m->magic == MUTT_MMDF && (mutt_str_strcmp(buffer, MMDF_SEP) == 0)))
         {
-          if (fseeko(adata->fp, ctx->mailbox->size, SEEK_SET) != 0)
+          if (fseeko(adata->fp, m->size, SEEK_SET) != 0)
             mutt_debug(1, "#2 fseek() failed\n");
-          if (ctx->mailbox->magic == MUTT_MBOX)
+          if (m->magic == MUTT_MBOX)
             mbox_parse_mailbox(ctx);
           else
             mmdf_parse_mailbox(ctx);
@@ -1081,7 +1107,7 @@ static int mbox_mbox_check(struct Context *ctx, int *index_hint)
 
           if (unlock)
           {
-            mbox_unlock_mailbox(ctx->mailbox);
+            mbox_unlock_mailbox(m);
             mutt_sig_unblock();
           }
 
@@ -1106,7 +1132,7 @@ static int mbox_mbox_check(struct Context *ctx, int *index_hint)
     {
       if (unlock)
       {
-        mbox_unlock_mailbox(ctx->mailbox);
+        mbox_unlock_mailbox(m);
         mutt_sig_unblock();
       }
       return MUTT_REOPENED;
@@ -1115,7 +1141,7 @@ static int mbox_mbox_check(struct Context *ctx, int *index_hint)
 
   /* fatal error */
 
-  mbox_unlock_mailbox(ctx->mailbox);
+  mbox_unlock_mailbox(m);
   mx_fastclose_mailbox(ctx);
   mutt_sig_unblock();
   mutt_error(_("Mailbox was corrupted"));
@@ -1127,7 +1153,12 @@ static int mbox_mbox_check(struct Context *ctx, int *index_hint)
  */
 static int mbox_mbox_sync(struct Context *ctx, int *index_hint)
 {
-  struct MboxAccountData *adata = mbox_adata_get(ctx->mailbox);
+  if (!ctx || !ctx->mailbox)
+    return -1;
+
+  struct Mailbox *m = ctx->mailbox;
+
+  struct MboxAccountData *adata = mbox_adata_get(m);
   if (!adata)
     return -1;
 
@@ -1159,7 +1190,7 @@ static int mbox_mbox_sync(struct Context *ctx, int *index_hint)
   /* need to open the file for writing in such a way that it does not truncate
    * the file, so use read-write mode.
    */
-  adata->fp = freopen(ctx->mailbox->path, "r+", adata->fp);
+  adata->fp = freopen(m->path, "r+", adata->fp);
   if (!adata->fp)
   {
     mx_fastclose_mailbox(ctx);
@@ -1169,7 +1200,7 @@ static int mbox_mbox_sync(struct Context *ctx, int *index_hint)
 
   mutt_sig_block();
 
-  if (mbox_lock_mailbox(ctx->mailbox, true, true) == -1)
+  if (mbox_lock_mailbox(m, true, true) == -1)
   {
     mutt_sig_unblock();
     mutt_error(_("Unable to lock mailbox"));
@@ -1207,14 +1238,14 @@ static int mbox_mbox_sync(struct Context *ctx, int *index_hint)
   /* find the first deleted/changed message.  we save a lot of time by only
    * rewriting the mailbox from the point where it has actually changed.
    */
-  for (i = 0; (i < ctx->mailbox->msg_count) && !ctx->mailbox->hdrs[i]->deleted &&
-              !ctx->mailbox->hdrs[i]->changed && !ctx->mailbox->hdrs[i]->attach_del;
+  for (i = 0; (i < m->msg_count) && !m->hdrs[i]->deleted &&
+              !m->hdrs[i]->changed && !m->hdrs[i]->attach_del;
        i++)
   {
   }
-  if (i == ctx->mailbox->msg_count)
+  if (i == m->msg_count)
   {
-    /* this means ctx->changed or ctx->mailbox->msg_deleted was set, but no
+    /* this means ctx->changed or m->msg_deleted was set, but no
      * messages were found to be changed or deleted.  This should
      * never happen, is we presume it is a bug in neomutt.
      */
@@ -1228,45 +1259,43 @@ static int mbox_mbox_sync(struct Context *ctx, int *index_hint)
   /* save the index of the first changed/deleted message */
   first = i;
   /* where to start overwriting */
-  offset = ctx->mailbox->hdrs[i]->offset;
+  offset = m->hdrs[i]->offset;
 
   /* the offset stored in the header does not include the MMDF_SEP, so make
    * sure we seek to the correct location
    */
-  if (ctx->mailbox->magic == MUTT_MMDF)
+  if (m->magic == MUTT_MMDF)
     offset -= (sizeof(MMDF_SEP) - 1);
 
   /* allocate space for the new offsets */
-  new_offset = mutt_mem_calloc(ctx->mailbox->msg_count - first, sizeof(struct MUpdate));
-  old_offset = mutt_mem_calloc(ctx->mailbox->msg_count - first, sizeof(struct MUpdate));
+  new_offset = mutt_mem_calloc(m->msg_count - first, sizeof(struct MUpdate));
+  old_offset = mutt_mem_calloc(m->msg_count - first, sizeof(struct MUpdate));
 
-  if (!ctx->mailbox->quiet)
+  if (!m->quiet)
   {
-    snprintf(msgbuf, sizeof(msgbuf), _("Writing %s..."), ctx->mailbox->path);
-    mutt_progress_init(&progress, msgbuf, MUTT_PROGRESS_MSG, WriteInc,
-                       ctx->mailbox->msg_count);
+    snprintf(msgbuf, sizeof(msgbuf), _("Writing %s..."), m->path);
+    mutt_progress_init(&progress, msgbuf, MUTT_PROGRESS_MSG, WriteInc, m->msg_count);
   }
 
-  for (i = first, j = 0; i < ctx->mailbox->msg_count; i++)
+  for (i = first, j = 0; i < m->msg_count; i++)
   {
-    if (!ctx->mailbox->quiet)
-      mutt_progress_update(&progress, i,
-                           (int) (ftello(adata->fp) / (ctx->mailbox->size / 100 + 1)));
+    if (!m->quiet)
+      mutt_progress_update(&progress, i, (int) (ftello(adata->fp) / (m->size / 100 + 1)));
     /* back up some information which is needed to restore offsets when
      * something fails.
      */
 
     old_offset[i - first].valid = true;
-    old_offset[i - first].hdr = ctx->mailbox->hdrs[i]->offset;
-    old_offset[i - first].body = ctx->mailbox->hdrs[i]->content->offset;
-    old_offset[i - first].lines = ctx->mailbox->hdrs[i]->lines;
-    old_offset[i - first].length = ctx->mailbox->hdrs[i]->content->length;
+    old_offset[i - first].hdr = m->hdrs[i]->offset;
+    old_offset[i - first].body = m->hdrs[i]->content->offset;
+    old_offset[i - first].lines = m->hdrs[i]->lines;
+    old_offset[i - first].length = m->hdrs[i]->content->length;
 
-    if (!ctx->mailbox->hdrs[i]->deleted)
+    if (!m->hdrs[i]->deleted)
     {
       j++;
 
-      if (ctx->mailbox->magic == MUTT_MMDF)
+      if (m->magic == MUTT_MMDF)
       {
         if (fputs(MMDF_SEP, fp) == EOF)
         {
@@ -1282,7 +1311,7 @@ static int mbox_mbox_sync(struct Context *ctx, int *index_hint)
        */
       new_offset[i - first].hdr = ftello(fp) + offset;
 
-      if (mutt_copy_message_ctx(fp, ctx, ctx->mailbox->hdrs[i], MUTT_CM_UPDATE,
+      if (mutt_copy_message_ctx(fp, ctx, m->hdrs[i], MUTT_CM_UPDATE,
                                 CH_FROM | CH_UPDATE | CH_UPDATE_LEN) != 0)
       {
         mutt_perror(tempfile);
@@ -1296,11 +1325,10 @@ static int mbox_mbox_sync(struct Context *ctx, int *index_hint)
        * we just flush the in memory cache so that the message will be reparsed
        * if the user accesses it later.
        */
-      new_offset[i - first].body =
-          ftello(fp) - ctx->mailbox->hdrs[i]->content->length + offset;
-      mutt_body_free(&ctx->mailbox->hdrs[i]->content->parts);
+      new_offset[i - first].body = ftello(fp) - m->hdrs[i]->content->length + offset;
+      mutt_body_free(&m->hdrs[i]->content->parts);
 
-      switch (ctx->mailbox->magic)
+      switch (m->magic)
       {
         case MUTT_MMDF:
           if (fputs(MMDF_SEP, fp) == EOF)
@@ -1332,9 +1360,9 @@ static int mbox_mbox_sync(struct Context *ctx, int *index_hint)
   fp = NULL;
 
   /* Save the state of this folder. */
-  if (stat(ctx->mailbox->path, &statbuf) == -1)
+  if (stat(m->path, &statbuf) == -1)
   {
-    mutt_perror(ctx->mailbox->path);
+    mutt_perror(m->path);
     unlink(tempfile);
     goto bail;
   }
@@ -1354,8 +1382,8 @@ static int mbox_mbox_sync(struct Context *ctx, int *index_hint)
   if (fseeko(adata->fp, offset, SEEK_SET) != 0 || /* seek the append location */
       /* do a sanity check to make sure the mailbox looks ok */
       !fgets(buf, sizeof(buf), adata->fp) ||
-      (ctx->mailbox->magic == MUTT_MBOX && !mutt_str_startswith(buf, "From ", CASE_MATCH)) ||
-      (ctx->mailbox->magic == MUTT_MMDF && (mutt_str_strcmp(MMDF_SEP, buf) != 0)))
+      (m->magic == MUTT_MBOX && !mutt_str_startswith(buf, "From ", CASE_MATCH)) ||
+      (m->magic == MUTT_MMDF && (mutt_str_strcmp(MMDF_SEP, buf) != 0)))
   {
     mutt_debug(1, "message not in expected position.\n");
     mutt_debug(1, "\tLINE: %s\n", buf);
@@ -1373,7 +1401,7 @@ static int mbox_mbox_sync(struct Context *ctx, int *index_hint)
       /* copy the temp mailbox back into place starting at the first
        * change/deleted message
        */
-      if (!ctx->mailbox->quiet)
+      if (!m->quiet)
         mutt_message(_("Committing changes..."));
       i = mutt_file_copy_stream(fp, adata->fp);
 
@@ -1382,9 +1410,8 @@ static int mbox_mbox_sync(struct Context *ctx, int *index_hint)
     }
     if (i == 0)
     {
-      ctx->mailbox->size = ftello(adata->fp); /* update the mailbox->size of the mailbox */
-      if ((ctx->mailbox->size < 0) ||
-          (ftruncate(fileno(adata->fp), ctx->mailbox->size) != 0))
+      m->size = ftello(adata->fp); /* update the mailbox->size of the mailbox */
+      if ((m->size < 0) || (ftruncate(fileno(adata->fp), m->size) != 0))
       {
         i = -1;
         mutt_debug(1, "ftruncate() failed\n");
@@ -1394,7 +1421,7 @@ static int mbox_mbox_sync(struct Context *ctx, int *index_hint)
 
   mutt_file_fclose(&fp);
   fp = NULL;
-  mbox_unlock_mailbox(ctx->mailbox);
+  mbox_unlock_mailbox(m);
 
   if (mutt_file_fclose(&adata->fp) != 0 || i == -1)
   {
@@ -1417,10 +1444,10 @@ static int mbox_mbox_sync(struct Context *ctx, int *index_hint)
   }
 
   /* Restore the previous access/modification times */
-  mbox_reset_atime(ctx->mailbox, &statbuf);
+  mbox_reset_atime(m, &statbuf);
 
   /* reopen the mailbox in read-only mode */
-  adata->fp = fopen(ctx->mailbox->path, "r");
+  adata->fp = fopen(m->path, "r");
   if (!adata->fp)
   {
     unlink(tempfile);
@@ -1433,14 +1460,14 @@ static int mbox_mbox_sync(struct Context *ctx, int *index_hint)
   }
 
   /* update the offsets of the rewritten messages */
-  for (i = first, j = first; i < ctx->mailbox->msg_count; i++)
+  for (i = first, j = first; i < m->msg_count; i++)
   {
-    if (!ctx->mailbox->hdrs[i]->deleted)
+    if (!m->hdrs[i]->deleted)
     {
-      ctx->mailbox->hdrs[i]->offset = new_offset[i - first].hdr;
-      ctx->mailbox->hdrs[i]->content->hdr_offset = new_offset[i - first].hdr;
-      ctx->mailbox->hdrs[i]->content->offset = new_offset[i - first].body;
-      ctx->mailbox->hdrs[i]->index = j++;
+      m->hdrs[i]->offset = new_offset[i - first].hdr;
+      m->hdrs[i]->content->hdr_offset = new_offset[i - first].hdr;
+      m->hdrs[i]->content->offset = new_offset[i - first].body;
+      m->hdrs[i]->index = j++;
     }
   }
   FREE(&new_offset);
@@ -1450,7 +1477,7 @@ static int mbox_mbox_sync(struct Context *ctx, int *index_hint)
 
   if (CheckMboxSize)
   {
-    tmp = mutt_find_mailbox(ctx->mailbox->path);
+    tmp = mutt_find_mailbox(m->path);
     if (tmp && !tmp->has_new)
       mutt_update_mailbox(tmp);
   }
@@ -1464,24 +1491,24 @@ bail: /* Come here in case of disaster */
   /* restore offsets, as far as they are valid */
   if (first >= 0 && old_offset)
   {
-    for (i = first; (i < ctx->mailbox->msg_count) && old_offset[i - first].valid; i++)
+    for (i = first; (i < m->msg_count) && old_offset[i - first].valid; i++)
     {
-      ctx->mailbox->hdrs[i]->offset = old_offset[i - first].hdr;
-      ctx->mailbox->hdrs[i]->content->hdr_offset = old_offset[i - first].hdr;
-      ctx->mailbox->hdrs[i]->content->offset = old_offset[i - first].body;
-      ctx->mailbox->hdrs[i]->lines = old_offset[i - first].lines;
-      ctx->mailbox->hdrs[i]->content->length = old_offset[i - first].length;
+      m->hdrs[i]->offset = old_offset[i - first].hdr;
+      m->hdrs[i]->content->hdr_offset = old_offset[i - first].hdr;
+      m->hdrs[i]->content->offset = old_offset[i - first].body;
+      m->hdrs[i]->lines = old_offset[i - first].lines;
+      m->hdrs[i]->content->length = old_offset[i - first].length;
     }
   }
 
   /* this is ok to call even if we haven't locked anything */
-  mbox_unlock_mailbox(ctx->mailbox);
+  mbox_unlock_mailbox(m);
 
   mutt_sig_unblock();
   FREE(&new_offset);
   FREE(&old_offset);
 
-  adata->fp = freopen(ctx->mailbox->path, "r", adata->fp);
+  adata->fp = freopen(m->path, "r", adata->fp);
   if (!adata->fp)
   {
     mutt_error(_("Could not reopen mailbox"));
@@ -1501,11 +1528,15 @@ bail: /* Come here in case of disaster */
 
 /**
  * mbox_mbox_close - Implements MxOps::mbox_close()
- * @retval 0 Always
  */
 static int mbox_mbox_close(struct Context *ctx)
 {
-  struct MboxAccountData *adata = mbox_adata_get(ctx->mailbox);
+  if (!ctx || !ctx->mailbox)
+    return -1;
+
+  struct Mailbox *m = ctx->mailbox;
+
+  struct MboxAccountData *adata = mbox_adata_get(m);
   if (!adata)
     return -1;
 
@@ -1521,19 +1552,19 @@ static int mbox_mbox_close(struct Context *ctx)
   mutt_file_fclose(&adata->fp);
 
   /* fix up the times so mailbox won't get confused */
-  if (ctx->peekonly && (ctx->mailbox->path[0] != '\0') &&
-      (mutt_timespec_compare(&ctx->mailbox->mtime, &adata->atime) > 0))
+  if (ctx->peekonly && (m->path[0] != '\0') &&
+      (mutt_timespec_compare(&m->mtime, &adata->atime) > 0))
   {
 #ifdef HAVE_UTIMENSAT
     struct timespec ts[2];
     ts[0] = adata->atime;
-    ts[1] = ctx->mailbox->mtime;
-    utimensat(0, ctx->mailbox->path, ts, 0);
+    ts[1] = m->mtime;
+    utimensat(0, m->path, ts, 0);
 #else
     struct utimbuf ut;
     ut.actime = adata->atime.tv_sec;
-    ut.modtime = ctx->mailbox->mtime.tv_sec;
-    utime(ctx->mailbox->path, &ut);
+    ut.modtime = m->mtime.tv_sec;
+    utime(m->path, &ut);
 #endif
   }
 
@@ -1545,7 +1576,12 @@ static int mbox_mbox_close(struct Context *ctx)
  */
 static int mbox_msg_open(struct Context *ctx, struct Message *msg, int msgno)
 {
-  struct MboxAccountData *adata = mbox_adata_get(ctx->mailbox);
+  if (!ctx || !ctx->mailbox)
+    return -1;
+
+  struct Mailbox *m = ctx->mailbox;
+
+  struct MboxAccountData *adata = mbox_adata_get(m);
   if (!adata)
     return -1;
 
@@ -1556,11 +1592,15 @@ static int mbox_msg_open(struct Context *ctx, struct Message *msg, int msgno)
 
 /**
  * mbox_msg_open_new - Implements MxOps::msg_open_new()
- * @retval 0 Always
  */
 static int mbox_msg_open_new(struct Context *ctx, struct Message *msg, struct Email *e)
 {
-  struct MboxAccountData *adata = mbox_adata_get(ctx->mailbox);
+  if (!ctx || !ctx->mailbox)
+    return -1;
+
+  struct Mailbox *m = ctx->mailbox;
+
+  struct MboxAccountData *adata = mbox_adata_get(m);
   if (!adata)
     return -1;
 
@@ -1573,6 +1613,9 @@ static int mbox_msg_open_new(struct Context *ctx, struct Message *msg, struct Em
  */
 static int mbox_msg_commit(struct Context *ctx, struct Message *msg)
 {
+  if (!msg)
+    return -1;
+
   if (fputc('\n', msg->fp) == EOF)
     return -1;
 
@@ -1587,10 +1630,12 @@ static int mbox_msg_commit(struct Context *ctx, struct Message *msg)
 
 /**
  * mbox_msg_close - Implements MxOps::msg_close()
- * @retval 0 Always
  */
 static int mbox_msg_close(struct Context *ctx, struct Message *msg)
 {
+  if (!msg)
+    return -1;
+
   msg->fp = NULL;
 
   return 0;

--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -1607,7 +1607,7 @@ static int mbox_msg_open_new(struct Context *ctx, struct Message *msg, struct Em
 /**
  * mbox_msg_commit - Implements MxOps::msg_commit()
  */
-static int mbox_msg_commit(struct Context *ctx, struct Message *msg)
+static int mbox_msg_commit(struct Mailbox *m, struct Message *msg)
 {
   if (!msg)
     return -1;
@@ -1772,7 +1772,7 @@ int mbox_path_parent(char *buf, size_t buflen)
 /**
  * mmdf_msg_commit - Implements MxOps::msg_commit()
  */
-static int mmdf_msg_commit(struct Context *ctx, struct Message *msg)
+static int mmdf_msg_commit(struct Mailbox *m, struct Message *msg)
 {
   if (fputs(MMDF_SEP, msg->fp) == EOF)
     return -1;

--- a/muttlib.c
+++ b/muttlib.c
@@ -294,7 +294,7 @@ char *mutt_expand_path_regex(char *buf, size_t buflen, bool regex)
   /* Rewrite IMAP path in canonical form - aids in string comparisons of
    * folders. May possibly fail, in which case buf should be the same. */
   if (imap_path_probe(buf, NULL) == MUTT_IMAP)
-    imap_path_canon(buf, buflen, NULL);
+    imap_path_canon(buf, buflen);
 #endif
 
   return buf;

--- a/mx.c
+++ b/mx.c
@@ -178,43 +178,48 @@ int mx_access(const char *path, int flags)
  */
 static int mx_open_mailbox_append(struct Context *ctx, int flags)
 {
+  if (!ctx || !ctx->mailbox)
+    return -1;
+
+  struct Mailbox *m = ctx->mailbox;
+
   struct stat sb;
 
   ctx->append = true;
-  if ((ctx->mailbox->magic == MUTT_UNKNOWN) || (ctx->mailbox->magic == MUTT_MAILBOX_ERROR))
+  if ((m->magic == MUTT_UNKNOWN) || (m->magic == MUTT_MAILBOX_ERROR))
   {
-    ctx->mailbox->magic = mx_path_probe(ctx->mailbox->path, NULL);
+    m->magic = mx_path_probe(m->path, NULL);
 
-    if (ctx->mailbox->magic == MUTT_UNKNOWN)
+    if (m->magic == MUTT_UNKNOWN)
     {
       if (flags & (MUTT_APPEND | MUTT_NEWFOLDER))
       {
-        ctx->mailbox->magic = MUTT_MAILBOX_ERROR;
+        m->magic = MUTT_MAILBOX_ERROR;
       }
       else
       {
-        mutt_error(_("%s is not a mailbox"), ctx->mailbox->path);
+        mutt_error(_("%s is not a mailbox"), m->path);
         return -1;
       }
     }
 
-    if (ctx->mailbox->magic == MUTT_MAILBOX_ERROR)
+    if (m->magic == MUTT_MAILBOX_ERROR)
     {
-      if (stat(ctx->mailbox->path, &sb) == -1)
+      if (stat(m->path, &sb) == -1)
       {
         if (errno == ENOENT)
         {
 #ifdef USE_COMPRESSED
-          if (mutt_comp_can_append(ctx->mailbox))
-            ctx->mailbox->magic = MUTT_COMPRESSED;
+          if (mutt_comp_can_append(m))
+            m->magic = MUTT_COMPRESSED;
           else
 #endif
-            ctx->mailbox->magic = MboxType;
+            m->magic = MboxType;
           flags |= MUTT_APPENDNEW;
         }
         else
         {
-          mutt_perror(ctx->mailbox->path);
+          mutt_perror(m->path);
           return -1;
         }
       }
@@ -222,13 +227,13 @@ static int mx_open_mailbox_append(struct Context *ctx, int flags)
         return -1;
     }
 
-    ctx->mailbox->mx_ops = mx_get_ops(ctx->mailbox->magic);
+    m->mx_ops = mx_get_ops(m->magic);
   }
 
-  if (!ctx->mailbox->mx_ops || !ctx->mailbox->mx_ops->mbox_open_append)
+  if (!m->mx_ops || !m->mx_ops->mbox_open_append)
     return -1;
 
-  return ctx->mailbox->mx_ops->mbox_open_append(ctx, flags);
+  return m->mx_ops->mbox_open_append(ctx, flags);
 }
 
 /**
@@ -253,34 +258,38 @@ struct Context *mx_mbox_open(struct Mailbox *m, const char *path, int flags)
 
   struct Context *ctx = mutt_mem_calloc(1, sizeof(*ctx));
   ctx->mailbox = m;
-  if (!ctx->mailbox)
-    ctx->mailbox = mx_mbox_find2(path);
-
-  if (!ctx->mailbox)
+  if (!m)
   {
-    ctx->mailbox = mailbox_new();
-    ctx->mailbox->flags = MB_HIDDEN;
-    mutt_str_strfcpy(ctx->mailbox->path, path, sizeof(ctx->mailbox->path));
-    /* int rc = */ mx_path_canon2(ctx->mailbox, Folder);
+    m = mx_mbox_find2(path);
+    ctx->mailbox = m;
   }
 
-  if (!ctx->mailbox->account)
-    ctx->mailbox->account = mx_ac_find(ctx->mailbox);
+  if (!m)
+  {
+    m = mailbox_new();
+    ctx->mailbox = m;
+    m->flags = MB_HIDDEN;
+    mutt_str_strfcpy(m->path, path, sizeof(m->path));
+    /* int rc = */ mx_path_canon2(m, Folder);
+  }
 
-  if (!ctx->mailbox->account)
+  if (!m->account)
+    m->account = mx_ac_find(m);
+
+  if (!m->account)
   {
     struct Account *a = account_create();
-    ctx->mailbox->account = a;
-    a->magic = ctx->mailbox->magic;
+    m->account = a;
+    a->magic = m->magic;
     TAILQ_INSERT_TAIL(&AllAccounts, a, entries);
-    mx_ac_add(a, ctx->mailbox);
+    mx_ac_add(a, m);
   }
 
 #if 0
-  if (!realpath(ctx->mailbox->path, ctx->mailbox->realpath))
+  if (!realpath(m->path, m->realpath))
   {
-    mutt_str_strfcpy(ctx->mailbox->realpath, ctx->mailbox->path,
-                     sizeof(ctx->mailbox->realpath));
+    mutt_str_strfcpy(m->realpath, m->path,
+                     sizeof(m->realpath));
   }
 #endif
 
@@ -288,12 +297,12 @@ struct Context *mx_mbox_open(struct Mailbox *m, const char *path, int flags)
   ctx->collapsed = false;
 
   for (int i = 0; i < RIGHTSMAX; i++)
-    mutt_bit_set(ctx->mailbox->rights, i);
+    mutt_bit_set(m->rights, i);
 
   if (flags & MUTT_QUIET)
-    ctx->mailbox->quiet = true;
+    m->quiet = true;
   if (flags & MUTT_READONLY)
-    ctx->mailbox->readonly = true;
+    m->readonly = true;
   if (flags & MUTT_PEEK)
     ctx->peekonly = true;
 
@@ -308,18 +317,20 @@ struct Context *mx_mbox_open(struct Mailbox *m, const char *path, int flags)
     return ctx;
   }
 
-  ctx->mailbox->magic = mx_path_probe(path, NULL);
-  ctx->mailbox->mx_ops = mx_get_ops(ctx->mailbox->magic);
-
-  // if (ctx->mailbox->path[0] == '\0')
-  //   mutt_str_strfcpy(ctx->mailbox->path, path, sizeof(ctx->mailbox->path));
-
-  if ((ctx->mailbox->magic == MUTT_UNKNOWN) ||
-      (ctx->mailbox->magic == MUTT_MAILBOX_ERROR) || !ctx->mailbox->mx_ops)
+  if (!m->magic)
   {
-    if (ctx->mailbox->magic == MUTT_MAILBOX_ERROR)
+    m->magic = mx_path_probe(path, NULL);
+    m->mx_ops = mx_get_ops(m->magic);
+  }
+
+  // if (m->path[0] == '\0')
+  //   mutt_str_strfcpy(m->path, path, sizeof(m->path));
+
+  if ((m->magic == MUTT_UNKNOWN) || (m->magic == MUTT_MAILBOX_ERROR) || !m->mx_ops)
+  {
+    if (m->magic == MUTT_MAILBOX_ERROR)
       mutt_perror(path);
-    else if (ctx->mailbox->magic == MUTT_UNKNOWN || !ctx->mailbox->mx_ops)
+    else if (m->magic == MUTT_UNKNOWN || !m->mx_ops)
       mutt_error(_("%s is not a mailbox"), path);
 
     mx_fastclose_mailbox(ctx);
@@ -327,21 +338,21 @@ struct Context *mx_mbox_open(struct Mailbox *m, const char *path, int flags)
     return NULL;
   }
 
-  if (!ctx->mailbox->account)
+  if (!m->account)
   {
     struct Account *a = account_create();
-    a->magic = ctx->mailbox->magic;
+    a->magic = m->magic;
     TAILQ_INSERT_TAIL(&AllAccounts, a, entries);
 
-    if (mx_ac_add(a, ctx->mailbox) < 0)
+    if (mx_ac_add(a, m) < 0)
     {
       //error
-      mailbox_free(&ctx->mailbox);
+      mailbox_free(&m);
       return NULL;
     }
   }
 
-  mutt_make_label_hash(ctx->mailbox);
+  mutt_make_label_hash(m);
 
   /* if the user has a `push' command in their .neomuttrc, or in a folder-hook,
    * it will cause the progress messages not to be displayed because
@@ -350,10 +361,10 @@ struct Context *mx_mbox_open(struct Mailbox *m, const char *path, int flags)
    */
   OptForceRefresh = true;
 
-  if (!ctx->mailbox->quiet)
-    mutt_message(_("Reading %s..."), ctx->mailbox->path);
+  if (!m->quiet)
+    mutt_message(_("Reading %s..."), m->path);
 
-  int rc = ctx->mailbox->mx_ops->mbox_open(ctx);
+  int rc = m->mx_ops->mbox_open(ctx);
 
   if ((rc == 0) || (rc == -2))
   {
@@ -365,10 +376,10 @@ struct Context *mx_mbox_open(struct Mailbox *m, const char *path, int flags)
       OptNeedRescore = false;
       mutt_sort_headers(ctx, true);
     }
-    if (!ctx->mailbox->quiet)
+    if (!m->quiet)
       mutt_clear_error();
     if (rc == -2)
-      mutt_error(_("Reading from %s interrupted..."), ctx->mailbox->path);
+      mutt_error(_("Reading from %s interrupted..."), m->path);
   }
   else
   {
@@ -386,28 +397,30 @@ struct Context *mx_mbox_open(struct Mailbox *m, const char *path, int flags)
  */
 void mx_fastclose_mailbox(struct Context *ctx)
 {
-  if (!ctx)
+  if (!ctx || !ctx->mailbox)
     return;
+
+  struct Mailbox *m = ctx->mailbox;
 
   /* never announce that a mailbox we've just left has new mail. #3290
    * TODO: really belongs in mx_mbox_close, but this is a nice hook point */
   if (!ctx->peekonly)
-    mutt_mailbox_setnotified(ctx->mailbox);
+    mutt_mailbox_setnotified(m);
 
-  if (ctx->mailbox->mx_ops)
-    ctx->mailbox->mx_ops->mbox_close(ctx);
+  if (m->mx_ops)
+    m->mx_ops->mbox_close(ctx);
 
-  mutt_hash_destroy(&ctx->mailbox->subj_hash);
-  mutt_hash_destroy(&ctx->mailbox->id_hash);
-  mutt_hash_destroy(&ctx->mailbox->label_hash);
-  if (ctx->mailbox->hdrs)
+  mutt_hash_destroy(&m->subj_hash);
+  mutt_hash_destroy(&m->id_hash);
+  mutt_hash_destroy(&m->label_hash);
+  if (m->hdrs)
   {
     mutt_clear_threads(ctx);
-    for (int i = 0; i < ctx->mailbox->msg_count; i++)
-      mutt_email_free(&ctx->mailbox->hdrs[i]);
-    FREE(&ctx->mailbox->hdrs);
+    for (int i = 0; i < m->msg_count; i++)
+      mutt_email_free(&m->hdrs[i]);
+    FREE(&m->hdrs);
   }
-  FREE(&ctx->mailbox->v2r);
+  FREE(&m->v2r);
   mx_cleanup_context(ctx);
 }
 
@@ -420,20 +433,22 @@ void mx_fastclose_mailbox(struct Context *ctx)
  */
 static int sync_mailbox(struct Context *ctx, int *index_hint)
 {
-  if (!ctx->mailbox->mx_ops || !ctx->mailbox->mx_ops->mbox_sync)
+  if (!ctx || !ctx->mailbox || !ctx->mailbox->mx_ops || !ctx->mailbox->mx_ops->mbox_sync)
     return -1;
 
-  if (!ctx->mailbox->quiet)
+  struct Mailbox *m = ctx->mailbox;
+
+  if (!m->quiet)
   {
     /* L10N: Displayed before/as a mailbox is being synced */
-    mutt_message(_("Writing %s..."), ctx->mailbox->path);
+    mutt_message(_("Writing %s..."), m->path);
   }
 
-  int rc = ctx->mailbox->mx_ops->mbox_sync(ctx, index_hint);
-  if ((rc != 0) && !ctx->mailbox->quiet)
+  int rc = m->mx_ops->mbox_sync(ctx, index_hint);
+  if ((rc != 0) && !m->quiet)
   {
     /* L10N: Displayed if a mailbox sync fails */
-    mutt_error(_("Unable to write %s"), ctx->mailbox->path);
+    mutt_error(_("Unable to write %s"), m->path);
   }
 
   return rc;
@@ -447,21 +462,25 @@ static int sync_mailbox(struct Context *ctx, int *index_hint)
  */
 static int trash_append(struct Context *ctx)
 {
+  if (!ctx || !ctx->mailbox)
+    return -1;
+
+  struct Mailbox *m = ctx->mailbox;
+
   int i;
   struct stat st, stc;
   int opt_confappend, rc;
 
-  if (!Trash || !ctx->mailbox->msg_deleted ||
-      (ctx->mailbox->magic == MUTT_MAILDIR && MaildirTrash))
+  if (!Trash || !m->msg_deleted || (m->magic == MUTT_MAILDIR && MaildirTrash))
   {
     return 0;
   }
 
   int delmsgcount = 0;
   int first_del = -1;
-  for (i = 0; i < ctx->mailbox->msg_count; i++)
+  for (i = 0; i < m->msg_count; i++)
   {
-    if (ctx->mailbox->hdrs[i]->deleted && (!ctx->mailbox->hdrs[i]->purge))
+    if (m->hdrs[i]->deleted && (!m->hdrs[i]->purge))
     {
       if (first_del < 0)
         first_del = i;
@@ -488,7 +507,7 @@ static int trash_append(struct Context *ctx)
     return -1;
   }
 
-  if (lstat(ctx->mailbox->path, &stc) == 0 && stc.st_ino == st.st_ino &&
+  if (lstat(m->path, &stc) == 0 && stc.st_ino == st.st_ino &&
       stc.st_dev == st.st_dev && stc.st_rdev == st.st_rdev)
   {
     return 0; /* we are in the trash folder: simple sync */
@@ -506,11 +525,11 @@ static int trash_append(struct Context *ctx)
   if (ctx_trash)
   {
     /* continue from initial scan above */
-    for (i = first_del; i < ctx->mailbox->msg_count; i++)
+    for (i = first_del; i < m->msg_count; i++)
     {
-      if (ctx->mailbox->hdrs[i]->deleted && (!ctx->mailbox->hdrs[i]->purge))
+      if (m->hdrs[i]->deleted && (!m->hdrs[i]->purge))
       {
-        if (mutt_append_message(ctx_trash, ctx, ctx->mailbox->hdrs[i], 0, 0) == -1)
+        if (mutt_append_message(ctx_trash, ctx, m->hdrs[i], 0, 0) == -1)
         {
           mx_mbox_close(&ctx_trash, NULL);
           return -1;
@@ -544,11 +563,16 @@ int mx_mbox_close(struct Context **pctx, int *index_hint)
     return 0;
 
   struct Context *ctx = *pctx;
+  if (!ctx || !ctx->mailbox)
+    return -1;
+
+  struct Mailbox *m = ctx->mailbox;
+
   int i, move_messages = 0, purge = 1, read_msgs = 0;
   char mbox[PATH_MAX];
   char buf[PATH_MAX + 64];
 
-  if (ctx->mailbox->readonly || ctx->dontwrite || ctx->append)
+  if (m->readonly || ctx->dontwrite || ctx->append)
   {
     mx_fastclose_mailbox(ctx);
     FREE(pctx);
@@ -556,9 +580,9 @@ int mx_mbox_close(struct Context **pctx, int *index_hint)
   }
 
 #ifdef USE_NNTP
-  if (ctx->mailbox->msg_unread && ctx->mailbox->magic == MUTT_NNTP)
+  if (m->msg_unread && m->magic == MUTT_NNTP)
   {
-    struct NntpMboxData *mdata = ctx->mailbox->mdata;
+    struct NntpMboxData *mdata = m->mdata;
 
     if (mdata && mdata->adata && mdata->group)
     {
@@ -571,12 +595,11 @@ int mx_mbox_close(struct Context **pctx, int *index_hint)
   }
 #endif
 
-  for (i = 0; i < ctx->mailbox->msg_count; i++)
+  for (i = 0; i < m->msg_count; i++)
   {
-    if (!ctx->mailbox->hdrs[i])
+    if (!m->hdrs[i])
       break;
-    if (!ctx->mailbox->hdrs[i]->deleted && ctx->mailbox->hdrs[i]->read &&
-        !(ctx->mailbox->hdrs[i]->flagged && KeepFlagged))
+    if (!m->hdrs[i]->deleted && m->hdrs[i]->read && !(m->hdrs[i]->flagged && KeepFlagged))
     {
       read_msgs++;
     }
@@ -584,14 +607,14 @@ int mx_mbox_close(struct Context **pctx, int *index_hint)
 
 #ifdef USE_NNTP
   /* don't need to move articles from newsgroup */
-  if (ctx->mailbox->magic == MUTT_NNTP)
+  if (m->magic == MUTT_NNTP)
     read_msgs = 0;
 #endif
 
   if (read_msgs && Move != MUTT_NO)
   {
     int is_spool;
-    char *p = mutt_find_hook(MUTT_MBOX_HOOK, ctx->mailbox->path);
+    char *p = mutt_find_hook(MUTT_MBOX_HOOK, m->path);
     if (p)
     {
       is_spool = 1;
@@ -600,7 +623,7 @@ int mx_mbox_close(struct Context **pctx, int *index_hint)
     else
     {
       mutt_str_strfcpy(mbox, Mbox, sizeof(mbox));
-      is_spool = mutt_is_spool(ctx->mailbox->path) && !mutt_is_spool(mbox);
+      is_spool = mutt_is_spool(m->path) && !mutt_is_spool(mbox);
     }
 
     if (is_spool && *mbox)
@@ -620,12 +643,11 @@ int mx_mbox_close(struct Context **pctx, int *index_hint)
   /* There is no point in asking whether or not to purge if we are
    * just marking messages as "trash".
    */
-  if (ctx->mailbox->msg_deleted && !(ctx->mailbox->magic == MUTT_MAILDIR && MaildirTrash))
+  if (m->msg_deleted && !(m->magic == MUTT_MAILDIR && MaildirTrash))
   {
     snprintf(buf, sizeof(buf),
-             ngettext("Purge %d deleted message?", "Purge %d deleted messages?",
-                      ctx->mailbox->msg_deleted),
-             ctx->mailbox->msg_deleted);
+             ngettext("Purge %d deleted message?", "Purge %d deleted messages?", m->msg_deleted),
+             m->msg_deleted);
     purge = query_quadoption(Delete, buf);
     if (purge == MUTT_ABORT)
       return -1;
@@ -633,36 +655,34 @@ int mx_mbox_close(struct Context **pctx, int *index_hint)
 
   if (MarkOld)
   {
-    for (i = 0; i < ctx->mailbox->msg_count; i++)
+    for (i = 0; i < m->msg_count; i++)
     {
-      if (!ctx->mailbox->hdrs[i]->deleted && !ctx->mailbox->hdrs[i]->old &&
-          !ctx->mailbox->hdrs[i]->read)
-        mutt_set_flag(ctx, ctx->mailbox->hdrs[i], MUTT_OLD, 1);
+      if (!m->hdrs[i]->deleted && !m->hdrs[i]->old && !m->hdrs[i]->read)
+        mutt_set_flag(ctx, m->hdrs[i], MUTT_OLD, 1);
     }
   }
 
   if (move_messages)
   {
-    if (!ctx->mailbox->quiet)
+    if (!m->quiet)
       mutt_message(_("Moving read messages to %s..."), mbox);
 
 #ifdef USE_IMAP
     /* try to use server-side copy first */
     i = 1;
 
-    if ((ctx->mailbox->magic == MUTT_IMAP) && (imap_path_probe(mbox, NULL) == MUTT_IMAP))
+    if ((m->magic == MUTT_IMAP) && (imap_path_probe(mbox, NULL) == MUTT_IMAP))
     {
       /* tag messages for moving, and clear old tags, if any */
-      for (i = 0; i < ctx->mailbox->msg_count; i++)
+      for (i = 0; i < m->msg_count; i++)
       {
-        if (ctx->mailbox->hdrs[i]->read && !ctx->mailbox->hdrs[i]->deleted &&
-            !(ctx->mailbox->hdrs[i]->flagged && KeepFlagged))
+        if (m->hdrs[i]->read && !m->hdrs[i]->deleted && !(m->hdrs[i]->flagged && KeepFlagged))
         {
-          ctx->mailbox->hdrs[i]->tagged = true;
+          m->hdrs[i]->tagged = true;
         }
         else
         {
-          ctx->mailbox->hdrs[i]->tagged = false;
+          m->hdrs[i]->tagged = false;
         }
       }
 
@@ -680,15 +700,14 @@ int mx_mbox_close(struct Context **pctx, int *index_hint)
       if (!f)
         return -1;
 
-      for (i = 0; i < ctx->mailbox->msg_count; i++)
+      for (i = 0; i < m->msg_count; i++)
       {
-        if (ctx->mailbox->hdrs[i]->read && !ctx->mailbox->hdrs[i]->deleted &&
-            !(ctx->mailbox->hdrs[i]->flagged && KeepFlagged))
+        if (m->hdrs[i]->read && !m->hdrs[i]->deleted && !(m->hdrs[i]->flagged && KeepFlagged))
         {
-          if (mutt_append_message(f, ctx, ctx->mailbox->hdrs[i], 0, CH_UPDATE_LEN) == 0)
+          if (mutt_append_message(f, ctx, m->hdrs[i], 0, CH_UPDATE_LEN) == 0)
           {
-            mutt_set_flag(ctx, ctx->mailbox->hdrs[i], MUTT_DELETE, 1);
-            mutt_set_flag(ctx, ctx->mailbox->hdrs[i], MUTT_PURGE, 1);
+            mutt_set_flag(ctx, m->hdrs[i], MUTT_DELETE, 1);
+            mutt_set_flag(ctx, m->hdrs[i], MUTT_PURGE, 1);
           }
           else
           {
@@ -701,20 +720,19 @@ int mx_mbox_close(struct Context **pctx, int *index_hint)
       mx_mbox_close(&f, NULL);
     }
   }
-  else if (!ctx->mailbox->changed && ctx->mailbox->msg_deleted == 0)
+  else if (!m->changed && m->msg_deleted == 0)
   {
-    if (!ctx->mailbox->quiet)
+    if (!m->quiet)
       mutt_message(_("Mailbox is unchanged"));
-    if (ctx->mailbox->magic == MUTT_MBOX || ctx->mailbox->magic == MUTT_MMDF)
-      mbox_reset_atime(ctx->mailbox, NULL);
+    if (m->magic == MUTT_MBOX || m->magic == MUTT_MMDF)
+      mbox_reset_atime(m, NULL);
     mx_fastclose_mailbox(ctx);
     FREE(pctx);
     return 0;
   }
 
   /* copy mails to the trash before expunging */
-  if (purge && ctx->mailbox->msg_deleted &&
-      (mutt_str_strcmp(ctx->mailbox->path, Trash) != 0))
+  if (purge && m->msg_deleted && (mutt_str_strcmp(m->path, Trash) != 0))
   {
     if (trash_append(ctx) != 0)
       return -1;
@@ -722,7 +740,7 @@ int mx_mbox_close(struct Context **pctx, int *index_hint)
 
 #ifdef USE_IMAP
   /* allow IMAP to preserve the deleted flag across sessions */
-  if (ctx->mailbox->magic == MUTT_IMAP)
+  if (m->magic == MUTT_IMAP)
   {
     int check = imap_sync_mailbox(ctx, (purge != MUTT_NO), true);
     if (check != 0)
@@ -733,15 +751,15 @@ int mx_mbox_close(struct Context **pctx, int *index_hint)
   {
     if (!purge)
     {
-      for (i = 0; i < ctx->mailbox->msg_count; i++)
+      for (i = 0; i < m->msg_count; i++)
       {
-        ctx->mailbox->hdrs[i]->deleted = false;
-        ctx->mailbox->hdrs[i]->purge = false;
+        m->hdrs[i]->deleted = false;
+        m->hdrs[i]->purge = false;
       }
-      ctx->mailbox->msg_deleted = 0;
+      m->msg_deleted = 0;
     }
 
-    if (ctx->mailbox->changed || ctx->mailbox->msg_deleted)
+    if (m->changed || m->msg_deleted)
     {
       int check = sync_mailbox(ctx, index_hint);
       if (check != 0)
@@ -749,40 +767,36 @@ int mx_mbox_close(struct Context **pctx, int *index_hint)
     }
   }
 
-  if (!ctx->mailbox->quiet)
+  if (!m->quiet)
   {
     if (move_messages)
     {
       mutt_message(_("%d kept, %d moved, %d deleted"),
-                   ctx->mailbox->msg_count - ctx->mailbox->msg_deleted,
-                   read_msgs, ctx->mailbox->msg_deleted);
+                   m->msg_count - m->msg_deleted, read_msgs, m->msg_deleted);
     }
     else
-      mutt_message(_("%d kept, %d deleted"),
-                   ctx->mailbox->msg_count - ctx->mailbox->msg_deleted,
-                   ctx->mailbox->msg_deleted);
+      mutt_message(_("%d kept, %d deleted"), m->msg_count - m->msg_deleted, m->msg_deleted);
   }
 
-  if (ctx->mailbox->msg_count == ctx->mailbox->msg_deleted &&
-      (ctx->mailbox->magic == MUTT_MMDF || ctx->mailbox->magic == MUTT_MBOX) &&
-      !mutt_is_spool(ctx->mailbox->path) && !SaveEmpty)
+  if (m->msg_count == m->msg_deleted && (m->magic == MUTT_MMDF || m->magic == MUTT_MBOX) &&
+      !mutt_is_spool(m->path) && !SaveEmpty)
   {
-    mutt_file_unlink_empty(ctx->mailbox->path);
+    mutt_file_unlink_empty(m->path);
   }
 
 #ifdef USE_SIDEBAR
-  if (purge && ctx->mailbox->msg_deleted)
+  if (purge && m->msg_deleted)
   {
-    for (i = 0; i < ctx->mailbox->msg_count; i++)
+    for (i = 0; i < m->msg_count; i++)
     {
-      if (ctx->mailbox->hdrs[i]->deleted && !ctx->mailbox->hdrs[i]->read)
+      if (m->hdrs[i]->deleted && !m->hdrs[i]->read)
       {
-        ctx->mailbox->msg_unread--;
-        if (!ctx->mailbox->hdrs[i]->old)
-          ctx->mailbox->msg_new--;
+        m->msg_unread--;
+        if (!m->hdrs[i]->old)
+          m->msg_new--;
       }
-      if (ctx->mailbox->hdrs[i]->deleted && ctx->mailbox->hdrs[i]->flagged)
-        ctx->mailbox->msg_flagged--;
+      if (m->hdrs[i]->deleted && m->hdrs[i]->flagged)
+        m->msg_flagged--;
     }
   }
 #endif
@@ -800,93 +814,91 @@ int mx_mbox_close(struct Context **pctx, int *index_hint)
  */
 void mx_update_tables(struct Context *ctx, bool committing)
 {
-  if (!ctx)
+  if (!ctx || !ctx->mailbox)
     return;
+
+  struct Mailbox *m = ctx->mailbox;
 
   int i, j, padding;
 
   /* update memory to reflect the new state of the mailbox */
-  ctx->mailbox->vcount = 0;
+  m->vcount = 0;
   ctx->vsize = 0;
   ctx->tagged = 0;
-  ctx->mailbox->msg_deleted = 0;
-  ctx->mailbox->msg_new = 0;
-  ctx->mailbox->msg_unread = 0;
-  ctx->mailbox->changed = false;
-  ctx->mailbox->msg_flagged = 0;
+  m->msg_deleted = 0;
+  m->msg_new = 0;
+  m->msg_unread = 0;
+  m->changed = false;
+  m->msg_flagged = 0;
   padding = mx_msg_padding_size(ctx);
-  for (i = 0, j = 0; i < ctx->mailbox->msg_count; i++)
+  for (i = 0, j = 0; i < m->msg_count; i++)
   {
-    if (!ctx->mailbox->hdrs[i]->quasi_deleted &&
-        ((committing && (!ctx->mailbox->hdrs[i]->deleted ||
-                         (ctx->mailbox->magic == MUTT_MAILDIR && MaildirTrash))) ||
-         (!committing && ctx->mailbox->hdrs[i]->active)))
+    if (!m->hdrs[i]->quasi_deleted &&
+        ((committing && (!m->hdrs[i]->deleted || (m->magic == MUTT_MAILDIR && MaildirTrash))) ||
+         (!committing && m->hdrs[i]->active)))
     {
       if (i != j)
       {
-        ctx->mailbox->hdrs[j] = ctx->mailbox->hdrs[i];
-        ctx->mailbox->hdrs[i] = NULL;
+        m->hdrs[j] = m->hdrs[i];
+        m->hdrs[i] = NULL;
       }
-      ctx->mailbox->hdrs[j]->msgno = j;
-      if (ctx->mailbox->hdrs[j]->virtual != -1)
+      m->hdrs[j]->msgno = j;
+      if (m->hdrs[j]->virtual != -1)
       {
-        ctx->mailbox->v2r[ctx->mailbox->vcount] = j;
-        ctx->mailbox->hdrs[j]->virtual = ctx->mailbox->vcount++;
-        struct Body *b = ctx->mailbox->hdrs[j]->content;
+        m->v2r[m->vcount] = j;
+        m->hdrs[j]->virtual = m->vcount++;
+        struct Body *b = m->hdrs[j]->content;
         ctx->vsize += b->length + b->offset - b->hdr_offset + padding;
       }
 
       if (committing)
-        ctx->mailbox->hdrs[j]->changed = false;
-      else if (ctx->mailbox->hdrs[j]->changed)
-        ctx->mailbox->changed = true;
+        m->hdrs[j]->changed = false;
+      else if (m->hdrs[j]->changed)
+        m->changed = true;
 
-      if (!committing || (ctx->mailbox->magic == MUTT_MAILDIR && MaildirTrash))
+      if (!committing || (m->magic == MUTT_MAILDIR && MaildirTrash))
       {
-        if (ctx->mailbox->hdrs[j]->deleted)
-          ctx->mailbox->msg_deleted++;
+        if (m->hdrs[j]->deleted)
+          m->msg_deleted++;
       }
 
-      if (ctx->mailbox->hdrs[j]->tagged)
+      if (m->hdrs[j]->tagged)
         ctx->tagged++;
-      if (ctx->mailbox->hdrs[j]->flagged)
-        ctx->mailbox->msg_flagged++;
-      if (!ctx->mailbox->hdrs[j]->read)
+      if (m->hdrs[j]->flagged)
+        m->msg_flagged++;
+      if (!m->hdrs[j]->read)
       {
-        ctx->mailbox->msg_unread++;
-        if (!ctx->mailbox->hdrs[j]->old)
-          ctx->mailbox->msg_new++;
+        m->msg_unread++;
+        if (!m->hdrs[j]->old)
+          m->msg_new++;
       }
 
       j++;
     }
     else
     {
-      if (ctx->mailbox->magic == MUTT_MH || ctx->mailbox->magic == MUTT_MAILDIR)
+      if (m->magic == MUTT_MH || m->magic == MUTT_MAILDIR)
       {
-        ctx->mailbox->size -= (ctx->mailbox->hdrs[i]->content->length +
-                               ctx->mailbox->hdrs[i]->content->offset -
-                               ctx->mailbox->hdrs[i]->content->hdr_offset);
+        m->size -= (m->hdrs[i]->content->length + m->hdrs[i]->content->offset -
+                    m->hdrs[i]->content->hdr_offset);
       }
       /* remove message from the hash tables */
-      if (ctx->mailbox->subj_hash && ctx->mailbox->hdrs[i]->env->real_subj)
-        mutt_hash_delete(ctx->mailbox->subj_hash, ctx->mailbox->hdrs[i]->env->real_subj,
-                         ctx->mailbox->hdrs[i]);
-      if (ctx->mailbox->id_hash && ctx->mailbox->hdrs[i]->env->message_id)
-        mutt_hash_delete(ctx->mailbox->id_hash, ctx->mailbox->hdrs[i]->env->message_id,
-                         ctx->mailbox->hdrs[i]);
-      mutt_label_hash_remove(ctx->mailbox, ctx->mailbox->hdrs[i]);
+      if (m->subj_hash && m->hdrs[i]->env->real_subj)
+        mutt_hash_delete(m->subj_hash, m->hdrs[i]->env->real_subj, m->hdrs[i]);
+      if (m->id_hash && m->hdrs[i]->env->message_id)
+        mutt_hash_delete(m->id_hash, m->hdrs[i]->env->message_id, m->hdrs[i]);
+      mutt_label_hash_remove(m, m->hdrs[i]);
       /* The path mx_mbox_check() -> imap_check_mailbox() ->
        *          imap_expunge_mailbox() -> mx_update_tables()
        * can occur before a call to mx_mbox_sync(), resulting in
        * last_tag being stale if it's not reset here.
        */
-      if (ctx->last_tag == ctx->mailbox->hdrs[i])
+      if (ctx->last_tag == m->hdrs[i])
         ctx->last_tag = NULL;
-      mutt_email_free(&ctx->mailbox->hdrs[i]);
+      mutt_email_free(&m->hdrs[i]);
     }
   }
-  ctx->mailbox->msg_count = j;
+  m->msg_count = j;
 }
 
 /**
@@ -898,6 +910,11 @@ void mx_update_tables(struct Context *ctx, bool committing)
  */
 int mx_mbox_sync(struct Context *ctx, int *index_hint)
 {
+  if (!ctx || !ctx->mailbox)
+    return -1;
+
+  struct Mailbox *m = ctx->mailbox;
+
   int rc;
   int purge = 1;
   int msgcount, deleted;
@@ -913,43 +930,42 @@ int mx_mbox_sync(struct Context *ctx, int *index_hint)
     mutt_error(_("Mailbox is marked unwritable. %s"), tmp);
     return -1;
   }
-  else if (ctx->mailbox->readonly)
+  else if (m->readonly)
   {
     mutt_error(_("Mailbox is read-only"));
     return -1;
   }
 
-  if (!ctx->mailbox->changed && !ctx->mailbox->msg_deleted)
+  if (!m->changed && !m->msg_deleted)
   {
-    if (!ctx->mailbox->quiet)
+    if (!m->quiet)
       mutt_message(_("Mailbox is unchanged"));
     return 0;
   }
 
-  if (ctx->mailbox->msg_deleted)
+  if (m->msg_deleted)
   {
     char buf[SHORT_STRING];
 
     snprintf(buf, sizeof(buf),
-             ngettext("Purge %d deleted message?", "Purge %d deleted messages?",
-                      ctx->mailbox->msg_deleted),
-             ctx->mailbox->msg_deleted);
+             ngettext("Purge %d deleted message?", "Purge %d deleted messages?", m->msg_deleted),
+             m->msg_deleted);
     purge = query_quadoption(Delete, buf);
     if (purge == MUTT_ABORT)
       return -1;
     else if (purge == MUTT_NO)
     {
-      if (!ctx->mailbox->changed)
+      if (!m->changed)
         return 0; /* nothing to do! */
       /* let IMAP servers hold on to D flags */
-      if (ctx->mailbox->magic != MUTT_IMAP)
+      if (m->magic != MUTT_IMAP)
       {
-        for (int i = 0; i < ctx->mailbox->msg_count; i++)
+        for (int i = 0; i < m->msg_count; i++)
         {
-          ctx->mailbox->hdrs[i]->deleted = false;
-          ctx->mailbox->hdrs[i]->purge = false;
+          m->hdrs[i]->deleted = false;
+          m->hdrs[i]->purge = false;
         }
-        ctx->mailbox->msg_deleted = 0;
+        m->msg_deleted = 0;
       }
     }
     else if (ctx->last_tag && ctx->last_tag->deleted)
@@ -957,19 +973,18 @@ int mx_mbox_sync(struct Context *ctx, int *index_hint)
   }
 
   /* really only for IMAP - imap_sync_mailbox results in a call to
-   * mx_update_tables, so ctx->mailbox->msg_deleted is 0 when it comes back */
-  msgcount = ctx->mailbox->msg_count;
-  deleted = ctx->mailbox->msg_deleted;
+   * mx_update_tables, so m->msg_deleted is 0 when it comes back */
+  msgcount = m->msg_count;
+  deleted = m->msg_deleted;
 
-  if (purge && ctx->mailbox->msg_deleted &&
-      (mutt_str_strcmp(ctx->mailbox->path, Trash) != 0))
+  if (purge && m->msg_deleted && (mutt_str_strcmp(m->path, Trash) != 0))
   {
     if (trash_append(ctx) != 0)
       return -1;
   }
 
 #ifdef USE_IMAP
-  if (ctx->mailbox->magic == MUTT_IMAP)
+  if (m->magic == MUTT_IMAP)
     rc = imap_sync_mailbox(ctx, purge, false);
   else
 #endif
@@ -977,25 +992,24 @@ int mx_mbox_sync(struct Context *ctx, int *index_hint)
   if (rc == 0)
   {
 #ifdef USE_IMAP
-    if (ctx->mailbox->magic == MUTT_IMAP && !purge)
+    if (m->magic == MUTT_IMAP && !purge)
     {
-      if (!ctx->mailbox->quiet)
+      if (!m->quiet)
         mutt_message(_("Mailbox checkpointed"));
     }
     else
 #endif
     {
-      if (!ctx->mailbox->quiet)
+      if (!m->quiet)
         mutt_message(_("%d kept, %d deleted"), msgcount - deleted, deleted);
     }
 
     mutt_sleep(0);
 
-    if (ctx->mailbox->msg_count == ctx->mailbox->msg_deleted &&
-        (ctx->mailbox->magic == MUTT_MBOX || ctx->mailbox->magic == MUTT_MMDF) &&
-        !mutt_is_spool(ctx->mailbox->path) && !SaveEmpty)
+    if (m->msg_count == m->msg_deleted && (m->magic == MUTT_MBOX || m->magic == MUTT_MMDF) &&
+        !mutt_is_spool(m->path) && !SaveEmpty)
     {
-      unlink(ctx->mailbox->path);
+      unlink(m->path);
       mx_fastclose_mailbox(ctx);
       return 0;
     }
@@ -1007,10 +1021,10 @@ int mx_mbox_sync(struct Context *ctx, int *index_hint)
      * MH and maildir are safe.  mbox-style seems to need re-sorting,
      * at least with the new threading code.
      */
-    if (purge || (ctx->mailbox->magic != MUTT_MAILDIR && ctx->mailbox->magic != MUTT_MH))
+    if (purge || (m->magic != MUTT_MAILDIR && m->magic != MUTT_MH))
     {
       /* IMAP does this automatically after handling EXPUNGE */
-      if (ctx->mailbox->magic != MUTT_IMAP)
+      if (m->magic != MUTT_IMAP)
       {
         mx_update_tables(ctx, true);
         mutt_sort_headers(ctx, true); /* rethread from scratch */
@@ -1030,12 +1044,17 @@ int mx_mbox_sync(struct Context *ctx, int *index_hint)
  */
 struct Message *mx_msg_open_new(struct Context *ctx, struct Email *e, int flags)
 {
+  if (!ctx || !ctx->mailbox)
+    return NULL;
+
+  struct Mailbox *m = ctx->mailbox;
+
   struct Address *p = NULL;
   struct Message *msg = NULL;
 
-  if (!ctx->mailbox->mx_ops || !ctx->mailbox->mx_ops->msg_open_new)
+  if (!m->mx_ops || !m->mx_ops->msg_open_new)
   {
-    mutt_debug(1, "function unimplemented for mailbox type %d.\n", ctx->mailbox->magic);
+    mutt_debug(1, "function unimplemented for mailbox type %d.\n", m->magic);
     return NULL;
   }
 
@@ -1054,13 +1073,12 @@ struct Message *mx_msg_open_new(struct Context *ctx, struct Email *e, int flags)
   if (msg->received == 0)
     time(&msg->received);
 
-  if (ctx->mailbox->mx_ops->msg_open_new(ctx, msg, e) == 0)
+  if (m->mx_ops->msg_open_new(ctx, msg, e) == 0)
   {
-    if (ctx->mailbox->magic == MUTT_MMDF)
+    if (m->magic == MUTT_MMDF)
       fputs(MMDF_SEP, msg->fp);
 
-    if ((ctx->mailbox->magic == MUTT_MBOX || ctx->mailbox->magic == MUTT_MMDF) &&
-        flags & MUTT_ADD_FROM)
+    if ((m->magic == MUTT_MBOX || m->magic == MUTT_MMDF) && flags & MUTT_ADD_FROM)
     {
       if (e)
       {
@@ -1092,13 +1110,12 @@ struct Message *mx_msg_open_new(struct Context *ctx, struct Email *e, int flags)
  */
 int mx_mbox_check(struct Context *ctx, int *index_hint)
 {
-  if (!ctx || !ctx->mailbox->mx_ops)
-  {
-    mutt_debug(1, "null or invalid context.\n");
+  if (!ctx || !ctx->mailbox || !ctx->mailbox->mx_ops)
     return -1;
-  }
 
-  return ctx->mailbox->mx_ops->mbox_check(ctx, index_hint);
+  struct Mailbox *m = ctx->mailbox;
+
+  return m->mx_ops->mbox_check(ctx, index_hint);
 }
 
 /**
@@ -1110,17 +1127,21 @@ int mx_mbox_check(struct Context *ctx, int *index_hint)
  */
 struct Message *mx_msg_open(struct Context *ctx, int msgno)
 {
+  if (!ctx || !ctx->mailbox)
+    return NULL;
+
+  struct Mailbox *m = ctx->mailbox;
+
   struct Message *msg = NULL;
 
-  if (!ctx->mailbox->mx_ops || !ctx->mailbox->mx_ops->msg_open)
+  if (!m->mx_ops || !m->mx_ops->msg_open)
   {
-    mutt_debug(1, "function not implemented for mailbox type %d.\n",
-               ctx->mailbox->magic);
+    mutt_debug(1, "function not implemented for mailbox type %d.\n", m->magic);
     return NULL;
   }
 
   msg = mutt_mem_calloc(1, sizeof(struct Message));
-  if (ctx->mailbox->mx_ops->msg_open(ctx, msg, msgno))
+  if (m->mx_ops->msg_open(ctx, msg, msgno) < 0)
     FREE(&msg);
 
   return msg;
@@ -1135,8 +1156,10 @@ struct Message *mx_msg_open(struct Context *ctx, int msgno)
  */
 int mx_msg_commit(struct Context *ctx, struct Message *msg)
 {
-  if (!ctx->mailbox->mx_ops || !ctx->mailbox->mx_ops->msg_commit)
+  if (!ctx || !ctx->mailbox || !ctx->mailbox->mx_ops || !ctx->mailbox->mx_ops->msg_commit)
     return -1;
+
+  struct Mailbox *m = ctx->mailbox;
 
   if (!(msg->write && ctx->append))
   {
@@ -1144,7 +1167,7 @@ int mx_msg_commit(struct Context *ctx, struct Message *msg)
     return -1;
   }
 
-  return ctx->mailbox->mx_ops->msg_commit(ctx, msg);
+  return m->mx_ops->msg_commit(ctx, msg);
 }
 
 /**
@@ -1156,12 +1179,15 @@ int mx_msg_commit(struct Context *ctx, struct Message *msg)
  */
 int mx_msg_close(struct Context *ctx, struct Message **msg)
 {
-  if (!ctx || !msg || !*msg)
+  if (!ctx || !ctx->mailbox || !msg || !*msg)
     return 0;
+
+  struct Mailbox *m = ctx->mailbox;
+
   int r = 0;
 
-  if (ctx->mailbox->mx_ops && ctx->mailbox->mx_ops->msg_close)
-    r = ctx->mailbox->mx_ops->msg_close(ctx, *msg);
+  if (m->mx_ops && m->mx_ops->msg_close)
+    r = m->mx_ops->msg_close(ctx, *msg);
 
   if ((*msg)->path)
   {
@@ -1217,11 +1243,15 @@ void mx_alloc_memory(struct Mailbox *m)
  */
 void mx_update_context(struct Context *ctx, int new_messages)
 {
+  if (!ctx || !ctx->mailbox)
+    return;
+
+  struct Mailbox *m = ctx->mailbox;
+
   struct Email *e = NULL;
-  for (int msgno = ctx->mailbox->msg_count - new_messages;
-       msgno < ctx->mailbox->msg_count; msgno++)
+  for (int msgno = m->msg_count - new_messages; msgno < m->msg_count; msgno++)
   {
-    e = ctx->mailbox->hdrs[msgno];
+    e = m->hdrs[msgno];
 
     if (WithCrypto)
     {
@@ -1231,8 +1261,8 @@ void mx_update_context(struct Context *ctx, int new_messages)
 
     if (!ctx->pattern)
     {
-      ctx->mailbox->v2r[ctx->mailbox->vcount] = msgno;
-      e->virtual = ctx->mailbox->vcount++;
+      m->v2r[m->vcount] = msgno;
+      e->virtual = m->vcount++;
     }
     else
       e->virtual = -1;
@@ -1242,10 +1272,10 @@ void mx_update_context(struct Context *ctx, int new_messages)
     {
       struct Email *e2 = NULL;
 
-      if (!ctx->mailbox->id_hash)
-        ctx->mailbox->id_hash = mutt_make_id_hash(ctx->mailbox);
+      if (!m->id_hash)
+        m->id_hash = mutt_make_id_hash(m);
 
-      e2 = mutt_hash_find(ctx->mailbox->id_hash, e->env->supersedes);
+      e2 = mutt_hash_find(m->id_hash, e->env->supersedes);
       if (e2)
       {
         e2->superseded = true;
@@ -1255,26 +1285,26 @@ void mx_update_context(struct Context *ctx, int new_messages)
     }
 
     /* add this message to the hash tables */
-    if (ctx->mailbox->id_hash && e->env->message_id)
-      mutt_hash_insert(ctx->mailbox->id_hash, e->env->message_id, e);
-    if (ctx->mailbox->subj_hash && e->env->real_subj)
-      mutt_hash_insert(ctx->mailbox->subj_hash, e->env->real_subj, e);
-    mutt_label_hash_add(ctx->mailbox, e);
+    if (m->id_hash && e->env->message_id)
+      mutt_hash_insert(m->id_hash, e->env->message_id, e);
+    if (m->subj_hash && e->env->real_subj)
+      mutt_hash_insert(m->subj_hash, e->env->real_subj, e);
+    mutt_label_hash_add(m, e);
 
     if (Score)
       mutt_score_message(ctx, e, false);
 
     if (e->changed)
-      ctx->mailbox->changed = true;
+      m->changed = true;
     if (e->flagged)
-      ctx->mailbox->msg_flagged++;
+      m->msg_flagged++;
     if (e->deleted)
-      ctx->mailbox->msg_deleted++;
+      m->msg_deleted++;
     if (!e->read)
     {
-      ctx->mailbox->msg_unread++;
+      m->msg_unread++;
       if (!e->old)
-        ctx->mailbox->msg_new++;
+        m->msg_new++;
     }
   }
 }
@@ -1326,8 +1356,13 @@ int mx_check_empty(const char *path)
  */
 int mx_tags_edit(struct Context *ctx, const char *tags, char *buf, size_t buflen)
 {
-  if (ctx->mailbox->mx_ops->tags_edit)
-    return ctx->mailbox->mx_ops->tags_edit(ctx, tags, buf, buflen);
+  if (!ctx || !ctx->mailbox)
+    return -1;
+
+  struct Mailbox *m = ctx->mailbox;
+
+  if (m->mx_ops->tags_edit)
+    return m->mx_ops->tags_edit(ctx, tags, buf, buflen);
 
   mutt_message(_("Folder doesn't support tagging, aborting"));
   return -1;
@@ -1343,8 +1378,13 @@ int mx_tags_edit(struct Context *ctx, const char *tags, char *buf, size_t buflen
  */
 int mx_tags_commit(struct Context *ctx, struct Email *e, char *tags)
 {
-  if (ctx->mailbox->mx_ops->tags_commit)
-    return ctx->mailbox->mx_ops->tags_commit(ctx, e, tags);
+  if (!ctx || !ctx->mailbox)
+    return -1;
+
+  struct Mailbox *m = ctx->mailbox;
+
+  if (m->mx_ops->tags_commit)
+    return m->mx_ops->tags_commit(ctx, e, tags);
 
   mutt_message(_("Folder doesn't support tagging, aborting"));
   return -1;
@@ -1357,7 +1397,12 @@ int mx_tags_commit(struct Context *ctx, struct Email *e, char *tags)
  */
 bool mx_tags_is_supported(struct Context *ctx)
 {
-  return ctx->mailbox->mx_ops->tags_commit && ctx->mailbox->mx_ops->tags_edit;
+  if (!ctx || !ctx->mailbox)
+    return false;
+
+  struct Mailbox *m = ctx->mailbox;
+
+  return m->mx_ops->tags_commit && m->mx_ops->tags_edit;
 }
 
 /**
@@ -1590,10 +1635,15 @@ int mx_path_parent(char *buf, size_t buflen)
  */
 int mx_msg_padding_size(struct Context *ctx)
 {
-  if (!ctx->mailbox->mx_ops || !ctx->mailbox->mx_ops->msg_padding_size)
+  if (!ctx || !ctx->mailbox)
     return 0;
 
-  return ctx->mailbox->mx_ops->msg_padding_size(ctx);
+  struct Mailbox *m = ctx->mailbox;
+
+  if (!m->mx_ops || !m->mx_ops->msg_padding_size)
+    return 0;
+
+  return m->mx_ops->msg_padding_size(ctx);
 }
 
 /**
@@ -1686,7 +1736,6 @@ int mx_ac_remove(struct Mailbox *m)
   return 0;
 }
 
-
 /**
  * mx_cleanup_context - Release memory and initialize a Context object
  * @param ctx Context to cleanup
@@ -1698,4 +1747,3 @@ void mx_cleanup_context(struct Context *ctx)
     mutt_pattern_free(&ctx->limit_pattern);
   memset(ctx, 0, sizeof(struct Context));
 }
-

--- a/mx.c
+++ b/mx.c
@@ -1187,7 +1187,7 @@ int mx_msg_close(struct Context *ctx, struct Message **msg)
   int r = 0;
 
   if (m->mx_ops && m->mx_ops->msg_close)
-    r = m->mx_ops->msg_close(ctx, *msg);
+    r = m->mx_ops->msg_close(m, *msg);
 
   if ((*msg)->path)
   {

--- a/mx.c
+++ b/mx.c
@@ -1167,7 +1167,7 @@ int mx_msg_commit(struct Context *ctx, struct Message *msg)
     return -1;
   }
 
-  return m->mx_ops->msg_commit(ctx, msg);
+  return m->mx_ops->msg_commit(m, msg);
 }
 
 /**

--- a/mx.c
+++ b/mx.c
@@ -1362,7 +1362,7 @@ int mx_tags_edit(struct Context *ctx, const char *tags, char *buf, size_t buflen
   struct Mailbox *m = ctx->mailbox;
 
   if (m->mx_ops->tags_edit)
-    return m->mx_ops->tags_edit(ctx, tags, buf, buflen);
+    return m->mx_ops->tags_edit(m, tags, buf, buflen);
 
   mutt_message(_("Folder doesn't support tagging, aborting"));
   return -1;

--- a/mx.c
+++ b/mx.c
@@ -1558,7 +1558,7 @@ int mx_path_canon(char *buf, size_t buflen, const char *folder, enum MailboxType
   if (!ops || !ops->path_canon)
     return -1;
 
-  if (ops->path_canon(buf, buflen, folder) < 0)
+  if (ops->path_canon(buf, buflen) < 0)
   {
     mutt_path_canon(buf, buflen, HomeDir);
   }
@@ -1602,7 +1602,7 @@ int mx_path_pretty(char *buf, size_t buflen, const char *folder)
   if (!ops->path_canon)
     return -1;
 
-  if (ops->path_canon(buf, buflen, folder) < 0)
+  if (ops->path_canon(buf, buflen) < 0)
     return -1;
 
   if (!ops->path_pretty)

--- a/mx.c
+++ b/mx.c
@@ -233,7 +233,7 @@ static int mx_open_mailbox_append(struct Context *ctx, int flags)
   if (!m->mx_ops || !m->mx_ops->mbox_open_append)
     return -1;
 
-  return m->mx_ops->mbox_open_append(ctx, flags);
+  return m->mx_ops->mbox_open_append(ctx->mailbox, flags);
 }
 
 /**

--- a/mx.c
+++ b/mx.c
@@ -1643,7 +1643,7 @@ int mx_msg_padding_size(struct Context *ctx)
   if (!m->mx_ops || !m->mx_ops->msg_padding_size)
     return 0;
 
-  return m->mx_ops->msg_padding_size(ctx);
+  return m->mx_ops->msg_padding_size(m);
 }
 
 /**

--- a/mx.h
+++ b/mx.h
@@ -227,11 +227,10 @@ struct MxOps
    * path_canon - Canonicalise a mailbox path
    * @param buf    Path to modify
    * @param buflen Length of buffer
-   * @param folder Base path for '=' substitution
    * @retval  0 Success
    * @retval -1 Failure
    */
-  int (*path_canon)      (char *buf, size_t buflen, const char *folder);
+  int (*path_canon)      (char *buf, size_t buflen);
   /**
    * path_pretty - Abbreviate a mailbox path
    * @param buf    Path to modify

--- a/mx.h
+++ b/mx.h
@@ -161,8 +161,8 @@ struct MxOps
    * @param ctx   Mailbox
    * @param msg   Message to open
    * @param msgno Index of message to open
-   * @retval 0 Success
-   * @retval 1 Error
+   * @retval  0 Success
+   * @retval -1 Error
    */
   int (*msg_open)        (struct Context *ctx, struct Message *msg, int msgno);
   /**

--- a/mx.h
+++ b/mx.h
@@ -127,12 +127,12 @@ struct MxOps
   int (*mbox_open)       (struct Context *ctx);
   /**
    * mbox_open_append - Open a mailbox for appending
-   * @param ctx   Mailbox to open
+   * @param m     Mailbox to open
    * @param flags e.g. #MUTT_READONLY
    * @retval  0 Success
    * @retval -1 Failure
    */
-  int (*mbox_open_append)(struct Context *ctx, int flags);
+  int (*mbox_open_append)(struct Mailbox *m, int flags);
   /**
    * mbox_check - Check for new mail
    * @param ctx Mailbox

--- a/mx.h
+++ b/mx.h
@@ -184,12 +184,12 @@ struct MxOps
   int (*msg_commit)      (struct Context *ctx, struct Message *msg);
   /**
    * msg_close - Close an email
-   * @param ctx Mailbox
+   * @param m   Mailbox
    * @param msg Message to close
    * @retval  0 Success
    * @retval -1 Failure
    */
-  int (*msg_close)       (struct Context *ctx, struct Message *msg);
+  int (*msg_close)       (struct Mailbox *m, struct Message *msg);
   /**
    * msg_padding_size - Bytes of padding between messages
    * @param ctx Mailbox

--- a/mx.h
+++ b/mx.h
@@ -176,12 +176,12 @@ struct MxOps
   int (*msg_open_new)    (struct Context *ctx, struct Message *msg, struct Email *e);
   /**
    * msg_commit - Save changes to an email
-   * @param ctx Mailbox
+   * @param m   Mailbox
    * @param msg Message to commit
    * @retval  0 Success
    * @retval -1 Failure
    */
-  int (*msg_commit)      (struct Context *ctx, struct Message *msg);
+  int (*msg_commit)      (struct Mailbox *m, struct Message *msg);
   /**
    * msg_close - Close an email
    * @param m   Mailbox

--- a/mx.h
+++ b/mx.h
@@ -192,10 +192,10 @@ struct MxOps
   int (*msg_close)       (struct Mailbox *m, struct Message *msg);
   /**
    * msg_padding_size - Bytes of padding between messages
-   * @param ctx Mailbox
+   * @param m Mailbox
    * @retval num Bytes of padding
    */
-  int (*msg_padding_size)(struct Context *ctx);
+  int (*msg_padding_size)(struct Mailbox *m);
   /**
    * tags_edit - Prompt and validate new messages tags
    * @param ctx    Mailbox

--- a/mx.h
+++ b/mx.h
@@ -198,7 +198,7 @@ struct MxOps
   int (*msg_padding_size)(struct Mailbox *m);
   /**
    * tags_edit - Prompt and validate new messages tags
-   * @param ctx    Mailbox
+   * @param m      Mailbox
    * @param tags   Existing tags
    * @param buf    Buffer to store the tags
    * @param buflen Length of buffer
@@ -206,7 +206,7 @@ struct MxOps
    * @retval  0 No valid user input
    * @retval  1 Buf set
    */
-  int (*tags_edit)       (struct Context *ctx, const char *tags, char *buf, size_t buflen);
+  int (*tags_edit)       (struct Mailbox *m, const char *tags, char *buf, size_t buflen);
   /**
    * tags_commit - Save the tags to a message
    * @param ctx Mailbox

--- a/nntp/nntp.c
+++ b/nntp/nntp.c
@@ -2877,27 +2877,10 @@ enum MailboxType nntp_path_probe(const char *path, const struct stat *st)
 /**
  * nntp_path_canon - Canonicalise a mailbox path - Implements MxOps::path_canon()
  */
-int nntp_path_canon(char *buf, size_t buflen, const char *folder)
+int nntp_path_canon(char *buf, size_t buflen)
 {
   if (!buf)
     return -1;
-
-  if ((buf[0] == '+') || (buf[0] == '='))
-  {
-    if (!folder)
-      return -1;
-
-    size_t flen = mutt_str_strlen(folder);
-    if ((flen > 0) && (folder[flen - 1] != '/'))
-    {
-      buf[0] = '/';
-      mutt_str_inline_replace(buf, buflen, 0, folder);
-    }
-    else
-    {
-      mutt_str_inline_replace(buf, buflen, 1, folder);
-    }
-  }
 
   return 0;
 }

--- a/nntp/nntp.c
+++ b/nntp/nntp.c
@@ -2852,7 +2852,7 @@ static int nntp_msg_open(struct Context *ctx, struct Message *msg, int msgno)
  *
  * @note May also return EOF Failure, see errno
  */
-static int nntp_msg_close(struct Context *ctx, struct Message *msg)
+static int nntp_msg_close(struct Mailbox *m, struct Message *msg)
 {
   return mutt_file_fclose(&msg->fp);
 }

--- a/notmuch/mutt_notmuch.c
+++ b/notmuch/mutt_notmuch.c
@@ -2457,7 +2457,7 @@ static int nm_msg_open(struct Context *ctx, struct Message *msg, int msgno)
  * nm_msg_commit - Implements MxOps::msg_commit()
  * @retval -1 Always
  */
-static int nm_msg_commit(struct Context *ctx, struct Message *msg)
+static int nm_msg_commit(struct Mailbox *m, struct Message *msg)
 {
   mutt_error(_("Can't write to virtual folder"));
   return -1;

--- a/notmuch/mutt_notmuch.c
+++ b/notmuch/mutt_notmuch.c
@@ -2544,27 +2544,10 @@ enum MailboxType nm_path_probe(const char *path, const struct stat *st)
 /**
  * nm_path_canon - Canonicalise a mailbox path - Implements MxOps::path_canon()
  */
-int nm_path_canon(char *buf, size_t buflen, const char *folder)
+int nm_path_canon(char *buf, size_t buflen)
 {
   if (!buf)
     return -1;
-
-  if ((buf[0] == '+') || (buf[0] == '='))
-  {
-    if (!folder)
-      return -1;
-
-    size_t flen = mutt_str_strlen(folder);
-    if ((flen > 0) && (folder[flen - 1] != '/'))
-    {
-      buf[0] = '/';
-      mutt_str_inline_replace(buf, buflen, 0, folder);
-    }
-    else
-    {
-      mutt_str_inline_replace(buf, buflen, 1, folder);
-    }
-  }
 
   return 0;
 }

--- a/notmuch/mutt_notmuch.c
+++ b/notmuch/mutt_notmuch.c
@@ -2477,7 +2477,7 @@ static int nm_msg_close(struct Mailbox *m, struct Message *msg)
 /**
  * nm_tags_edit - Implements MxOps::tags_edit()
  */
-static int nm_tags_edit(struct Context *ctx, const char *tags, char *buf, size_t buflen)
+static int nm_tags_edit(struct Mailbox *m, const char *tags, char *buf, size_t buflen)
 {
   *buf = '\0';
   if (mutt_get_field("Add/remove labels: ", buf, buflen, MUTT_NM_TAG) != 0)

--- a/notmuch/mutt_notmuch.c
+++ b/notmuch/mutt_notmuch.c
@@ -2466,7 +2466,7 @@ static int nm_msg_commit(struct Context *ctx, struct Message *msg)
 /**
  * nm_msg_close - Implements MxOps::msg_close()
  */
-static int nm_msg_close(struct Context *ctx, struct Message *msg)
+static int nm_msg_close(struct Mailbox *m, struct Message *msg)
 {
   if (!msg)
     return -1;

--- a/notmuch/mutt_notmuch.c
+++ b/notmuch/mutt_notmuch.c
@@ -1595,7 +1595,12 @@ char *nm_email_get_folder(struct Email *e)
  */
 int nm_read_entire_thread(struct Context *ctx, struct Email *e)
 {
-  struct NmMboxData *mdata = nm_mdata_get(ctx->mailbox);
+  if (!ctx || !ctx->mailbox)
+    return -1;
+
+  struct Mailbox *m = ctx->mailbox;
+
+  struct NmMboxData *mdata = nm_mdata_get(m);
   if (!mdata)
     return -1;
 
@@ -1604,13 +1609,12 @@ int nm_read_entire_thread(struct Context *ctx, struct Email *e)
   notmuch_message_t *msg = NULL;
   int rc = -1;
 
-  if (!(db = nm_db_get(ctx->mailbox, false)) || !(msg = get_nm_message(db, e)))
+  if (!(db = nm_db_get(m, false)) || !(msg = get_nm_message(db, e)))
     goto done;
 
-  mutt_debug(1, "nm: reading entire-thread messages...[current count=%d]\n",
-             ctx->mailbox->msg_count);
+  mutt_debug(1, "nm: reading entire-thread messages...[current count=%d]\n", m->msg_count);
 
-  progress_reset(ctx->mailbox);
+  progress_reset(m);
   const char *id = notmuch_message_get_thread_id(msg);
   if (!id)
     goto done;
@@ -1626,25 +1630,25 @@ int nm_read_entire_thread(struct Context *ctx, struct Email *e)
   apply_exclude_tags(q);
   notmuch_query_set_sort(q, NOTMUCH_SORT_NEWEST_FIRST);
 
-  read_threads_query(ctx->mailbox, q, true, 0);
-  ctx->mailbox->mtime.tv_sec = time(NULL);
-  ctx->mailbox->mtime.tv_nsec = 0;
+  read_threads_query(m, q, true, 0);
+  m->mtime.tv_sec = time(NULL);
+  m->mtime.tv_nsec = 0;
   rc = 0;
 
-  if (ctx->mailbox->msg_count > mdata->oldmsgcount)
-    mx_update_context(ctx, ctx->mailbox->msg_count - mdata->oldmsgcount);
+  if (m->msg_count > mdata->oldmsgcount)
+    mx_update_context(ctx, m->msg_count - mdata->oldmsgcount);
 done:
   if (q)
     notmuch_query_destroy(q);
-  if (!nm_db_is_longrun(ctx->mailbox))
-    nm_db_release(ctx->mailbox);
+  if (!nm_db_is_longrun(m))
+    nm_db_release(m);
 
-  if (ctx->mailbox->msg_count == mdata->oldmsgcount)
+  if (m->msg_count == mdata->oldmsgcount)
     mutt_message(_("No more messages in the thread"));
 
   mdata->oldmsgcount = 0;
   mutt_debug(1, "nm: reading entire-thread messages... done [rc=%d, count=%d]\n",
-             rc, ctx->mailbox->msg_count);
+             rc, m->msg_count);
   return rc;
 }
 
@@ -2127,57 +2131,61 @@ int nm_ac_add(struct Account *a, struct Mailbox *m)
  */
 static int nm_mbox_open(struct Context *ctx)
 {
-  int rc = -1;
-
-  if (init_mailbox(ctx->mailbox) != 0)
+  if (!ctx || !ctx->mailbox)
     return -1;
 
-  struct NmMboxData *mdata = nm_mdata_get(ctx->mailbox);
+  struct Mailbox *m = ctx->mailbox;
+
+  int rc = -1;
+
+  if (init_mailbox(m) != 0)
+    return -1;
+
+  struct NmMboxData *mdata = nm_mdata_get(m);
   if (!mdata)
     return -1;
 
-  mutt_debug(1, "nm: reading messages...[current count=%d]\n", ctx->mailbox->msg_count);
+  mutt_debug(1, "nm: reading messages...[current count=%d]\n", m->msg_count);
 
-  progress_reset(ctx->mailbox);
+  progress_reset(m);
 
-  if (!ctx->mailbox->hdrs)
+  if (!m->hdrs)
   {
     /* Allocate some memory to get started */
-    ctx->mailbox->hdrmax = ctx->mailbox->msg_count;
-    ctx->mailbox->msg_count = 0;
-    ctx->mailbox->vcount = 0;
-    mx_alloc_memory(ctx->mailbox);
+    m->hdrmax = m->msg_count;
+    m->msg_count = 0;
+    m->vcount = 0;
+    mx_alloc_memory(m);
   }
 
-  notmuch_query_t *q = get_query(ctx->mailbox, false);
+  notmuch_query_t *q = get_query(m, false);
   if (q)
   {
     rc = 0;
     switch (mdata->query_type)
     {
       case NM_QUERY_TYPE_MESGS:
-        if (!read_mesgs_query(ctx->mailbox, q, false))
+        if (!read_mesgs_query(m, q, false))
           rc = -2;
         break;
       case NM_QUERY_TYPE_THREADS:
-        if (!read_threads_query(ctx->mailbox, q, false, get_limit(mdata)))
+        if (!read_threads_query(m, q, false, get_limit(mdata)))
           rc = -2;
         break;
     }
     notmuch_query_destroy(q);
   }
 
-  if (!nm_db_is_longrun(ctx->mailbox))
-    nm_db_release(ctx->mailbox);
+  if (!nm_db_is_longrun(m))
+    nm_db_release(m);
 
-  ctx->mailbox->mtime.tv_sec = time(NULL);
-  ctx->mailbox->mtime.tv_nsec = 0;
+  m->mtime.tv_sec = time(NULL);
+  m->mtime.tv_nsec = 0;
 
-  mx_update_context(ctx, ctx->mailbox->msg_count);
+  mx_update_context(ctx, m->msg_count);
   mdata->oldmsgcount = 0;
 
-  mutt_debug(1, "nm: reading messages... done [rc=%d, count=%d]\n", rc,
-             ctx->mailbox->msg_count);
+  mutt_debug(1, "nm: reading messages... done [rc=%d, count=%d]\n", rc, m->msg_count);
   return rc;
 }
 
@@ -2193,33 +2201,37 @@ static int nm_mbox_open(struct Context *ctx)
  */
 static int nm_mbox_check(struct Context *ctx, int *index_hint)
 {
-  struct NmMboxData *mdata = nm_mdata_get(ctx->mailbox);
+  if (!ctx || !ctx->mailbox)
+    return -1;
+
+  struct Mailbox *m = ctx->mailbox;
+
+  struct NmMboxData *mdata = nm_mdata_get(m);
   time_t mtime = 0;
-  if (!mdata || (nm_db_get_mtime(ctx->mailbox, &mtime) != 0))
+  if (!mdata || (nm_db_get_mtime(m, &mtime) != 0))
     return -1;
 
   int new_flags = 0;
   bool occult = false;
 
-  if (ctx->mailbox->mtime.tv_sec >= mtime)
+  if (m->mtime.tv_sec >= mtime)
   {
-    mutt_debug(2, "nm: check unnecessary (db=%lu mailbox=%lu)\n", mtime,
-               ctx->mailbox->mtime);
+    mutt_debug(2, "nm: check unnecessary (db=%lu mailbox=%lu)\n", mtime, m->mtime);
     return 0;
   }
 
-  mutt_debug(1, "nm: checking (db=%lu mailbox=%lu)\n", mtime, ctx->mailbox->mtime);
+  mutt_debug(1, "nm: checking (db=%lu mailbox=%lu)\n", mtime, m->mtime);
 
-  notmuch_query_t *q = get_query(ctx->mailbox, false);
+  notmuch_query_t *q = get_query(m, false);
   if (!q)
     goto done;
 
-  mutt_debug(1, "nm: start checking (count=%d)\n", ctx->mailbox->msg_count);
-  mdata->oldmsgcount = ctx->mailbox->msg_count;
+  mutt_debug(1, "nm: start checking (count=%d)\n", m->msg_count);
+  mdata->oldmsgcount = m->msg_count;
   mdata->noprogress = true;
 
-  for (int i = 0; i < ctx->mailbox->msg_count; i++)
-    ctx->mailbox->hdrs[i]->active = false;
+  for (int i = 0; i < m->msg_count; i++)
+    m->hdrs[i]->active = false;
 
   int limit = get_limit(mdata);
 
@@ -2240,14 +2252,14 @@ static int nm_mbox_check(struct Context *ctx, int *index_hint)
     char old[PATH_MAX];
     const char *new = NULL;
 
-    notmuch_message_t *m = notmuch_messages_get(msgs);
-    struct Email *e = get_mutt_email(ctx->mailbox, m);
+    notmuch_message_t *msg = notmuch_messages_get(msgs);
+    struct Email *e = get_mutt_email(m, msg);
 
     if (!e)
     {
       /* new email */
-      append_message(ctx->mailbox, NULL, m, 0);
-      notmuch_message_destroy(m);
+      append_message(m, NULL, msg, 0);
+      notmuch_message_destroy(msg);
       continue;
     }
 
@@ -2257,7 +2269,7 @@ static int nm_mbox_check(struct Context *ctx, int *index_hint)
     /* Check to see if the message has moved to a different subdirectory.
      * If so, update the associated filename.
      */
-    new = get_message_last_filename(m);
+    new = get_message_last_filename(msg);
     email_get_fullpath(e, old, sizeof(old));
 
     if (mutt_str_strcmp(old, new) != 0)
@@ -2274,40 +2286,39 @@ static int nm_mbox_check(struct Context *ctx, int *index_hint)
       maildir_update_flags(ctx, e, &tmp);
     }
 
-    if (update_email_tags(e, m) == 0)
+    if (update_email_tags(e, msg) == 0)
       new_flags++;
 
-    notmuch_message_destroy(m);
+    notmuch_message_destroy(msg);
   }
 
-  for (int i = 0; i < ctx->mailbox->msg_count; i++)
+  for (int i = 0; i < m->msg_count; i++)
   {
-    if (!ctx->mailbox->hdrs[i]->active)
+    if (!m->hdrs[i]->active)
     {
       occult = true;
       break;
     }
   }
 
-  if (ctx->mailbox->msg_count > mdata->oldmsgcount)
-    mx_update_context(ctx, ctx->mailbox->msg_count - mdata->oldmsgcount);
+  if (m->msg_count > mdata->oldmsgcount)
+    mx_update_context(ctx, m->msg_count - mdata->oldmsgcount);
 done:
   if (q)
     notmuch_query_destroy(q);
 
-  if (!nm_db_is_longrun(ctx->mailbox))
-    nm_db_release(ctx->mailbox);
+  if (!nm_db_is_longrun(m))
+    nm_db_release(m);
 
-  ctx->mailbox->mtime.tv_sec = time(NULL);
-  ctx->mailbox->mtime.tv_nsec = 0;
+  m->mtime.tv_sec = time(NULL);
+  m->mtime.tv_nsec = 0;
 
   mutt_debug(1, "nm: ... check done [count=%d, new_flags=%d, occult=%d]\n",
-             ctx->mailbox->msg_count, new_flags, occult);
+             m->msg_count, new_flags, occult);
 
   return occult ? MUTT_REOPENED :
-                  (ctx->mailbox->msg_count > mdata->oldmsgcount) ?
-                  MUTT_NEW_MAIL :
-                  new_flags ? MUTT_FLAGS : 0;
+                  (m->msg_count > mdata->oldmsgcount) ? MUTT_NEW_MAIL :
+                                                        new_flags ? MUTT_FLAGS : 0;
 }
 
 /**
@@ -2315,33 +2326,37 @@ done:
  */
 static int nm_mbox_sync(struct Context *ctx, int *index_hint)
 {
-  struct NmMboxData *mdata = nm_mdata_get(ctx->mailbox);
+  if (!ctx || !ctx->mailbox)
+    return -1;
+
+  struct Mailbox *m = ctx->mailbox;
+
+  struct NmMboxData *mdata = nm_mdata_get(m);
   if (!mdata)
     return -1;
 
   int rc = 0;
   struct Progress progress;
-  char *uri = mutt_str_strdup(ctx->mailbox->path);
+  char *uri = mutt_str_strdup(m->path);
   bool changed = false;
   char msgbuf[PATH_MAX + 64];
 
   mutt_debug(1, "nm: sync start ...\n");
 
-  if (!ctx->mailbox->quiet)
+  if (!m->quiet)
   {
     /* all is in this function so we don't use data->progress here */
-    snprintf(msgbuf, sizeof(msgbuf), _("Writing %s..."), ctx->mailbox->path);
-    mutt_progress_init(&progress, msgbuf, MUTT_PROGRESS_MSG, WriteInc,
-                       ctx->mailbox->msg_count);
+    snprintf(msgbuf, sizeof(msgbuf), _("Writing %s..."), m->path);
+    mutt_progress_init(&progress, msgbuf, MUTT_PROGRESS_MSG, WriteInc, m->msg_count);
   }
 
-  for (int i = 0; i < ctx->mailbox->msg_count; i++)
+  for (int i = 0; i < m->msg_count; i++)
   {
     char old[PATH_MAX], new[PATH_MAX];
-    struct Email *e = ctx->mailbox->hdrs[i];
+    struct Email *e = m->hdrs[i];
     struct NmEmailData *edata = e->edata;
 
-    if (!ctx->mailbox->quiet)
+    if (!m->quiet)
       mutt_progress_update(&progress, i, -1);
 
     *old = '\0';
@@ -2356,15 +2371,15 @@ static int nm_mbox_sync(struct Context *ctx, int *index_hint)
     else
       email_get_fullpath(e, old, sizeof(old));
 
-    mutt_str_strfcpy(ctx->mailbox->path, edata->folder, sizeof(ctx->mailbox->path));
-    ctx->mailbox->magic = edata->magic;
+    mutt_str_strfcpy(m->path, edata->folder, sizeof(m->path));
+    m->magic = edata->magic;
 #ifdef USE_HCACHE
     rc = mh_sync_mailbox_message(ctx, i, NULL);
 #else
     rc = mh_sync_mailbox_message(ctx, i);
 #endif
-    mutt_str_strfcpy(ctx->mailbox->path, uri, sizeof(ctx->mailbox->path));
-    ctx->mailbox->magic = MUTT_NOTMUCH;
+    mutt_str_strfcpy(m->path, uri, sizeof(m->path));
+    m->magic = MUTT_NOTMUCH;
 
     if (rc)
       break;
@@ -2374,24 +2389,24 @@ static int nm_mbox_sync(struct Context *ctx, int *index_hint)
 
     if (e->deleted || (strcmp(old, new) != 0))
     {
-      if (e->deleted && (remove_filename(ctx->mailbox, old) == 0))
+      if (e->deleted && (remove_filename(m, old) == 0))
         changed = true;
-      else if (*new &&*old && (rename_filename(ctx->mailbox, old, new, e) == 0))
+      else if (*new &&*old && (rename_filename(m, old, new, e) == 0))
         changed = true;
     }
 
     FREE(&edata->oldpath);
   }
 
-  mutt_str_strfcpy(ctx->mailbox->path, uri, sizeof(ctx->mailbox->path));
-  ctx->mailbox->magic = MUTT_NOTMUCH;
+  mutt_str_strfcpy(m->path, uri, sizeof(m->path));
+  m->magic = MUTT_NOTMUCH;
 
-  if (!nm_db_is_longrun(ctx->mailbox))
-    nm_db_release(ctx->mailbox);
+  if (!nm_db_is_longrun(m))
+    nm_db_release(m);
   if (changed)
   {
-    ctx->mailbox->mtime.tv_sec = time(NULL);
-    ctx->mailbox->mtime.tv_nsec = 0;
+    m->mtime.tv_sec = time(NULL);
+    m->mtime.tv_nsec = 0;
   }
 
   FREE(&uri);
@@ -2414,9 +2429,12 @@ static int nm_mbox_close(struct Context *ctx)
  */
 static int nm_msg_open(struct Context *ctx, struct Message *msg, int msgno)
 {
-  if (!ctx || !msg)
-    return 1;
-  struct Email *e = ctx->mailbox->hdrs[msgno];
+  if (!ctx || !ctx->mailbox || !ctx->mailbox->hdrs || !msg)
+    return -1;
+
+  struct Mailbox *m = ctx->mailbox;
+
+  struct Email *e = m->hdrs[msgno];
   char path[PATH_MAX];
   char *folder = nm_email_get_folder(e);
 
@@ -2424,13 +2442,15 @@ static int nm_msg_open(struct Context *ctx, struct Message *msg, int msgno)
 
   msg->fp = fopen(path, "r");
   if (!msg->fp && (errno == ENOENT) &&
-      ((ctx->mailbox->magic == MUTT_MAILDIR) || (ctx->mailbox->magic == MUTT_NOTMUCH)))
+      ((m->magic == MUTT_MAILDIR) || (m->magic == MUTT_NOTMUCH)))
   {
     msg->fp = maildir_open_find_message(folder, e->path, NULL);
   }
 
-  mutt_debug(1, "%s\n", __func__);
-  return !msg->fp;
+  if (!msg->fp)
+    return -1;
+
+  return 0;
 }
 
 /**
@@ -2470,7 +2490,12 @@ static int nm_tags_edit(struct Context *ctx, const char *tags, char *buf, size_t
  */
 static int nm_tags_commit(struct Context *ctx, struct Email *e, char *buf)
 {
-  struct NmMboxData *mdata = nm_mdata_get(ctx->mailbox);
+  if (!ctx || !ctx->mailbox)
+    return -1;
+
+  struct Mailbox *m = ctx->mailbox;
+
+  struct NmMboxData *mdata = nm_mdata_get(m);
   if (!buf || !*buf || !mdata)
     return -1;
 
@@ -2478,7 +2503,7 @@ static int nm_tags_commit(struct Context *ctx, struct Email *e, char *buf)
   notmuch_message_t *msg = NULL;
   int rc = -1;
 
-  if (!(db = nm_db_get(ctx->mailbox, true)) || !(msg = get_nm_message(db, e)))
+  if (!(db = nm_db_get(m, true)) || !(msg = get_nm_message(db, e)))
     goto done;
 
   mutt_debug(1, "nm: tags modify: '%s'\n", buf);
@@ -2491,12 +2516,12 @@ static int nm_tags_commit(struct Context *ctx, struct Email *e, char *buf)
   rc = 0;
   e->changed = true;
 done:
-  if (!nm_db_is_longrun(ctx->mailbox))
-    nm_db_release(ctx->mailbox);
+  if (!nm_db_is_longrun(m))
+    nm_db_release(m);
   if (e->changed)
   {
-    ctx->mailbox->mtime.tv_sec = time(NULL);
-    ctx->mailbox->mtime.tv_nsec = 0;
+    m->mtime.tv_sec = time(NULL);
+    m->mtime.tv_nsec = 0;
   }
   mutt_debug(1, "nm: tags modify done [rc=%d]\n", rc);
   return rc;

--- a/pop/pop.c
+++ b/pop/pop.c
@@ -1257,27 +1257,10 @@ enum MailboxType pop_path_probe(const char *path, const struct stat *st)
 /**
  * pop_path_canon - Canonicalise a mailbox path - Implements MxOps::path_canon()
  */
-int pop_path_canon(char *buf, size_t buflen, const char *folder)
+int pop_path_canon(char *buf, size_t buflen)
 {
   if (!buf)
     return -1;
-
-  if ((buf[0] == '+') || (buf[0] == '='))
-  {
-    if (!folder)
-      return -1;
-
-    size_t flen = mutt_str_strlen(folder);
-    if ((flen > 0) && (folder[flen - 1] != '/'))
-    {
-      buf[0] = '/';
-      mutt_str_inline_replace(buf, buflen, 0, folder);
-    }
-    else
-    {
-      mutt_str_inline_replace(buf, buflen, 1, folder);
-    }
-  }
 
   return 0;
 }

--- a/pop/pop.c
+++ b/pop/pop.c
@@ -1232,7 +1232,7 @@ static int pop_msg_open(struct Context *ctx, struct Message *msg, int msgno)
  * @retval 0   Success
  * @retval EOF Error, see errno
  */
-static int pop_msg_close(struct Context *ctx, struct Message *msg)
+static int pop_msg_close(struct Mailbox *m, struct Message *msg)
 {
   return mutt_file_fclose(&msg->fp);
 }

--- a/pop/pop_auth.c
+++ b/pop/pop_auth.c
@@ -230,7 +230,7 @@ void pop_apop_timestamp(struct PopAccountData *adata, char *buf)
  */
 static enum PopAuthRes pop_auth_apop(struct PopAccountData *adata, const char *method)
 {
-  struct Md5Ctx ctx;
+  struct Md5Ctx mctx;
   unsigned char digest[16];
   char hash[33];
   char buf[LONG_STRING];
@@ -250,10 +250,10 @@ static enum PopAuthRes pop_auth_apop(struct PopAccountData *adata, const char *m
   mutt_message(_("Authenticating (APOP)..."));
 
   /* Compute the authentication hash to send to the server */
-  mutt_md5_init_ctx(&ctx);
-  mutt_md5_process(adata->timestamp, &ctx);
-  mutt_md5_process(adata->conn->account.pass, &ctx);
-  mutt_md5_finish_ctx(&ctx, digest);
+  mutt_md5_init_ctx(&mctx);
+  mutt_md5_process(adata->timestamp, &mctx);
+  mutt_md5_process(adata->conn->account.pass, &mctx);
+  mutt_md5_finish_ctx(&mctx, digest);
   mutt_md5_toascii(digest, hash);
 
   /* Send APOP command to server */


### PR DESCRIPTION
This is a **Work-in-Progress** (barely tested and incomplete)

It aims to reduce the number of `Context` references in the backends.
[This table](https://github.com/neomutt/neomutt/issues/1326#issuecomment-438085645) shows where there's work still to be done.

Refactor `ctx->mailbox` to `m`:
- a3f551f0f pop
- 80a917a88 mbox
- 7d4619196 maildir
- d3fd51edc nntp
- b15ce7371 notmuch
- 20dcb531e compress
- 720d05a00 imap
- 36b3dcebb flags
- b0b316883 mx
- d8617b65c threads

Replace `Context` pointer with `Mailbox` pointer:
- 8ffa6cd2f open_append: remove Context
- 8a2a3d84e msg_close: remove Context
- fb64e838d msg_commit: remove Context
- 2c38d871e msg_padding_size: remove Context
- e574bf2bb tags_edit: remove Context
- ff49ddc75 path_canon: drop folder
