### PR TITLE
Pull request for devel/imapmbox-removal

### DIFF
--- a/imap/browse.c
+++ b/imap/browse.c
@@ -385,7 +385,7 @@ int imap_mailbox_create(const char *path)
   char name[LONG_STRING];
   short n;
 
-  adata = imap_adata_find(path, name, sizeof(name));
+  adata = imap_adata_find(path, name, sizeof(name), false);
   if (!adata)
   {
     mutt_debug(1, "Couldn't find open connection to %s\n", path);
@@ -435,7 +435,7 @@ int imap_mailbox_rename(const char *path)
   char oldname[LONG_STRING];
   char newname[PATH_MAX];
 
-  adata = imap_adata_find(path, oldname, sizeof(oldname));
+  adata = imap_adata_find(path, oldname, sizeof(oldname), false);
   if (!adata)
   {
     mutt_debug(1, "Couldn't find open connection to %s\n", path);

--- a/imap/browse.c
+++ b/imap/browse.c
@@ -367,7 +367,7 @@ fail:
 int imap_mailbox_create(const char *path)
 {
   struct ImapAccountData *adata = NULL;
-  struct ImapMailboxData *mdata = NULL;
+  struct ImapMboxData *mdata = NULL;
   char name[LONG_STRING];
   short n;
 
@@ -419,7 +419,7 @@ err:
 int imap_mailbox_rename(const char *path)
 {
   struct ImapAccountData *adata = NULL;
-  struct ImapMailboxData *mdata = NULL;
+  struct ImapMboxData *mdata = NULL;
   char buf[PATH_MAX];
   char newname[PATH_MAX];
 

--- a/imap/browse.c
+++ b/imap/browse.c
@@ -374,7 +374,6 @@ fail:
 int imap_mailbox_create(const char *path)
 {
   struct ImapAccountData *adata = NULL;
-  char buf[PATH_MAX];
   char name[LONG_STRING];
   short n;
 
@@ -385,26 +384,24 @@ int imap_mailbox_create(const char *path)
     return -1;
   }
 
-  mutt_str_strfcpy(buf, name, sizeof(buf));
-
   /* append a delimiter if necessary */
-  n = mutt_str_strlen(buf);
-  if (n && (n < sizeof(buf) - 1) && (buf[n - 1] != adata->delim))
+  n = mutt_str_strlen(name);
+  if (n && (n < sizeof(name) - 1) && (name[n - 1] != adata->delim))
   {
-    buf[n++] = adata->delim;
-    buf[n] = '\0';
+    name[n++] = adata->delim;
+    name[n] = '\0';
   }
 
-  if (mutt_get_field(_("Create mailbox: "), buf, sizeof(buf), MUTT_FILE) < 0)
+  if (mutt_get_field(_("Create mailbox: "), name, sizeof(name), MUTT_FILE) < 0)
     return -1;
 
-  if (mutt_str_strlen(buf) == 0)
+  if (mutt_str_strlen(name) == 0)
   {
     mutt_error(_("Mailbox must have a name"));
     return -1;
   }
 
-  if (imap_create_mailbox(adata, buf) < 0)
+  if (imap_create_mailbox(adata, name) < 0)
     return -1;
 
   mutt_message(_("Mailbox created"));

--- a/imap/browse.c
+++ b/imap/browse.c
@@ -68,7 +68,7 @@ static void add_folder(char delim, char *folder, bool noselect, bool noinferiors
   struct ConnAccount conn_account;
   char mailbox[LONG_STRING];
 
-  if (imap_parse_path2(state->folder, &conn_account, mailbox, sizeof(mailbox)))
+  if (imap_parse_path(state->folder, &conn_account, mailbox, sizeof(mailbox)))
     return;
 
   if (state->entrylen + 1 == state->entrymax)
@@ -196,7 +196,7 @@ int imap_browse(char *path, struct BrowserState *state)
   bool showparents = false;
   bool save_lsub;
 
-  if (imap_parse_path2(path, &conn_account, buf, sizeof(buf)))
+  if (imap_parse_path(path, &conn_account, buf, sizeof(buf)))
   {
     mutt_error(_("%s is an invalid IMAP path"), path);
     return -1;

--- a/imap/browse.c
+++ b/imap/browse.c
@@ -93,7 +93,7 @@ static void add_folder(char delim, char *folder, bool noselect, bool noinferiors
   if (Mask && Mask->regex && !((regexec(Mask->regex, relpath, 0, NULL, 0) == 0) ^ Mask->not))
     return;
 
-  imap_qualify_path2(tmp, sizeof(tmp), &conn_account, folder);
+  imap_qualify_path(tmp, sizeof(tmp), &conn_account, folder);
   (state->entry)[state->entrylen].name = mutt_str_strdup(tmp);
 
   /* mark desc with delim in browser if it can have subfolders */
@@ -268,7 +268,7 @@ int imap_browse(char *path, struct BrowserState *state)
     if (mbox[n - 1] == list.delim)
     {
       showparents = true;
-      imap_qualify_path2(buf, sizeof(buf), &conn_account, mbox);
+      imap_qualify_path(buf, sizeof(buf), &conn_account, mbox);
       state->folder = mutt_str_strdup(buf);
       n--;
     }
@@ -301,7 +301,7 @@ int imap_browse(char *path, struct BrowserState *state)
         mbox[n++] = ctmp;
         ctmp = mbox[n];
         mbox[n] = '\0';
-        imap_qualify_path2(buf, sizeof(buf), &conn_account, mbox);
+        imap_qualify_path(buf, sizeof(buf), &conn_account, mbox);
         state->folder = mutt_str_strdup(buf);
       }
       mbox[n] = ctmp;
@@ -316,7 +316,7 @@ int imap_browse(char *path, struct BrowserState *state)
         add_folder(adata->delim, relpath, true, false, state, true);
       if (!state->folder)
       {
-        imap_qualify_path2(buf, sizeof(buf), &conn_account, relpath);
+        imap_qualify_path(buf, sizeof(buf), &conn_account, relpath);
         state->folder = mutt_str_strdup(buf);
       }
     }
@@ -325,7 +325,7 @@ int imap_browse(char *path, struct BrowserState *state)
   /* no namespace, no folder: set folder to host only */
   if (!state->folder)
   {
-    imap_qualify_path2(buf, sizeof(buf), &conn_account, NULL);
+    imap_qualify_path(buf, sizeof(buf), &conn_account, NULL);
     state->folder = mutt_str_strdup(buf);
   }
 

--- a/imap/command.c
+++ b/imap/command.c
@@ -869,7 +869,7 @@ static void cmd_parse_status(struct ImapAccountData *adata, char *s)
     struct ImapAccountData *m_adata = imap_adata_get(np->m);
     if (imap_account_match(&adata->conn_account, &m_adata->conn_account))
     {
-      struct ImapMailboxData *mdata = imap_mdata_get(np->m);
+      struct ImapMboxData *mdata = imap_mdata_get(np->m);
       if (mdata && imap_mxcmp(mailbox, mdata->name) == 0)
       {
         mutt_debug(3, "Found %s in mailbox list (OV: %u ON: %u U: %d)\n",

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -2073,9 +2073,6 @@ int imap_ac_add(struct Account *a, struct Mailbox *m)
   if (m->magic != MUTT_IMAP)
     return -1;
 
-  // NOTE(sileht): The goal is to use ImapMbox and imap_parse_path() only here
-  // So we can remove it at this end.
-
   if (!a->adata)
   {
     struct ConnAccount *conn_account = mutt_mem_calloc(1, sizeof(struct ConnAccount));

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -723,15 +723,11 @@ int imap_rename_mailbox(struct ImapAccountData *adata, char *oldname, const char
  */
 int imap_delete_mailbox(struct Mailbox *m, char *path)
 {
-  char buf[PATH_MAX], mbox[PATH_MAX];
+  char buf[PATH_MAX];
 
-  struct ImapAccountData *adata = imap_adata_get(m);
+  struct ImapMailboxData *mdata = imap_mdata_get(m);
 
-  if (imap_parse_path2(path, NULL, buf, sizeof(buf)) < 0)
-    return -1;
-
-  imap_munge_mbox_name(adata, mbox, sizeof(mbox), buf);
-  snprintf(buf, sizeof(buf), "DELETE %s", mbox);
+  snprintf(buf, sizeof(buf), "DELETE %s", mdata->munge_name);
 
   if (imap_exec(m->account->adata, buf, 0) != 0)
     return -1;

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -714,17 +714,15 @@ int imap_rename_mailbox(struct ImapAccountData *adata, char *oldname, const char
  */
 int imap_delete_mailbox(struct Mailbox *m, char *path)
 {
-  struct ImapMbox mx;
   char buf[PATH_MAX], mbox[PATH_MAX];
-
-  if (imap_parse_path(path, &mx) < 0)
-    return -1;
 
   struct ImapAccountData *adata = imap_adata_get(m);
 
-  imap_munge_mbox_name(adata, mbox, sizeof(mbox), mx.mbox);
+  if (imap_parse_path2(path, NULL, buf, sizeof(buf)) < 0)
+    return -1;
+
+  imap_munge_mbox_name(adata, mbox, sizeof(mbox), buf);
   snprintf(buf, sizeof(buf), "DELETE %s", mbox);
-  FREE(&mx.mbox);
 
   if (imap_exec(m->account->adata, buf, 0) != 0)
     return -1;

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -1376,6 +1376,7 @@ int imap_check(struct ImapAccountData *adata, bool force)
 
 /**
  * imap_mailbox_check - Check for new mail in subscribed folders
+ * @param m           Mailbox
  * @param check_stats Check for message stats too
  * @retval num Number of mailboxes with new mail
  * @retval 0   Failure
@@ -1383,97 +1384,65 @@ int imap_check(struct ImapAccountData *adata, bool force)
  * Given a list of mailboxes rather than called once for each so that it can
  * batch the commands and save on round trips.
  */
-int imap_mailbox_check(bool check_stats)
+int imap_mailbox_check(struct Mailbox *m, bool check_stats)
 {
   struct ImapAccountData *adata = NULL;
-  struct ImapAccountData *lastdata = NULL;
   char name[LONG_STRING];
   char command[LONG_STRING * 2];
   char munged[LONG_STRING];
-  int mbcount = 0;
+  struct ImapMbox mx;
 
-  struct MailboxNode *np = NULL;
-  STAILQ_FOREACH(np, &AllMailboxes, entries)
+  if (imap_prepare_mailbox(m, &mx, name, sizeof(name)))
   {
-    /* Init newly-added mailboxes */
-    if (np->m->magic == MUTT_UNKNOWN)
-    {
-      if (imap_path_probe(np->m->path, NULL) == MUTT_IMAP)
-        np->m->magic = MUTT_IMAP;
-    }
+    m->has_new = false;
+    return -1;
+  }
+  FREE(&mx.mbox);
 
-    if (np->m->magic != MUTT_IMAP)
-      continue;
+  adata = m->account->adata;
 
-    if (get_mailbox(np->m->path, &adata, name, sizeof(name)) < 0)
-    {
-      np->m->has_new = false;
-      continue;
-    }
-
-    /* Don't issue STATUS on the selected mailbox, it will be NOOPed or
-     * IDLEd elsewhere.
-     * adata->mailbox may be NULL for connections other than the current
-     * mailbox's, and shouldn't expand to INBOX in that case. #3216. */
-    if (adata->mbox_name && (imap_mxcmp(name, adata->mbox_name) == 0))
-    {
-      np->m->has_new = false;
-      continue;
-    }
-
-    if (!mutt_bit_isset(adata->capabilities, IMAP4REV1) &&
-        !mutt_bit_isset(adata->capabilities, STATUS))
-    {
-      mutt_debug(2, "Server doesn't support STATUS\n");
-      continue;
-    }
-
-    if (lastdata && (adata != lastdata))
-    {
-      /* Send commands to previous server. Sorting the mailbox list
-       * may prevent some infelicitous interleavings */
-      if (imap_exec(lastdata, NULL, IMAP_CMD_FAIL_OK | IMAP_CMD_POLL) == -1)
-        mutt_debug(1, "#1 Error polling mailboxes\n");
-
-      lastdata = NULL;
-    }
-
-    if (!lastdata)
-      lastdata = adata;
-
-    imap_munge_mbox_name(adata, munged, sizeof(munged), name);
-    if (check_stats)
-    {
-      snprintf(command, sizeof(command),
-               "STATUS %s (UIDNEXT UIDVALIDITY UNSEEN RECENT MESSAGES)", munged);
-    }
-    else
-    {
-      snprintf(command, sizeof(command),
-               "STATUS %s (UIDNEXT UIDVALIDITY UNSEEN RECENT)", munged);
-    }
-
-    if (imap_exec(adata, command, IMAP_CMD_QUEUE | IMAP_CMD_POLL) < 0)
-    {
-      mutt_debug(1, "Error queueing command\n");
-      return 0;
-    }
+  /* Don't issue STATUS on the selected mailbox, it will be NOOPed or
+   * IDLEd elsewhere.
+   * adata->mailbox may be NULL for connections other than the current
+   * mailbox's, and shouldn't expand to INBOX in that case. #3216. */
+  if (adata->mbox_name && (imap_mxcmp(name, adata->mbox_name) == 0))
+  {
+    m->has_new = false;
+    return -1;
   }
 
-  if (lastdata && (imap_exec(lastdata, NULL, IMAP_CMD_FAIL_OK | IMAP_CMD_POLL) == -1))
+  if (!mutt_bit_isset(adata->capabilities, IMAP4REV1) &&
+      !mutt_bit_isset(adata->capabilities, STATUS))
+  {
+    mutt_debug(2, "Server doesn't support STATUS\n");
+    return -1;
+  }
+
+  imap_munge_mbox_name(adata, munged, sizeof(munged), name);
+  if (check_stats)
+  {
+    snprintf(command, sizeof(command),
+             "STATUS %s (UIDNEXT UIDVALIDITY UNSEEN RECENT MESSAGES)", munged);
+  }
+  else
+  {
+    snprintf(command, sizeof(command),
+             "STATUS %s (UIDNEXT UIDVALIDITY UNSEEN RECENT)", munged);
+  }
+
+  if (imap_exec(adata, command, IMAP_CMD_QUEUE | IMAP_CMD_POLL) < 0)
+  {
+    mutt_debug(1, "Error queueing command\n");
+    return -1;
+  }
+
+  if (imap_exec(adata, NULL, IMAP_CMD_FAIL_OK | IMAP_CMD_POLL) == -1)
   {
     mutt_debug(1, "#2 Error polling mailboxes\n");
-    return 0;
+    return -1;
   }
 
-  /* collect results */
-  STAILQ_FOREACH(np, &AllMailboxes, entries)
-  {
-    if ((np->m->magic == MUTT_IMAP) && np->m->has_new)
-      mbcount++;
-  }
-
-  return mbcount;
+  return 0;
 }
 
 /**

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -340,7 +340,7 @@ int imap_prepare_mailbox(struct Mailbox *m)
   if (!m || !m->account)
     return -1;
 
-  struct ImapMailboxData *mdata;
+  struct ImapMboxData *mdata;
   struct ImapAccountData *adata = m->account->adata;
 
   mutt_account_hook(m->realpath);
@@ -674,7 +674,7 @@ int imap_create_mailbox(struct ImapAccountData *adata, char *mailbox)
 int imap_access(const char *path)
 {
   struct ImapAccountData *adata = NULL;
-  struct ImapMailboxData *mdata = NULL;
+  struct ImapMboxData *mdata = NULL;
   int rc;
 
   if (imap_adata_find(path, &adata, &mdata) < 0)
@@ -1351,7 +1351,7 @@ int imap_check(struct ImapAccountData *adata, bool force)
 int imap_mailbox_check(struct Mailbox *m, bool check_stats)
 {
   struct ImapAccountData *adata = NULL;
-  struct ImapMailboxData *mdata = NULL;
+  struct ImapMboxData *mdata = NULL;
   char command[LONG_STRING * 2];
 
   if (imap_prepare_mailbox(m))
@@ -1421,7 +1421,7 @@ int imap_status(const char *path, bool queue)
   static int queued = 0;
 
   struct ImapAccountData *adata = NULL;
-  struct ImapMailboxData *mdata = NULL;
+  struct ImapMboxData *mdata = NULL;
   char buf[LONG_STRING * 2];
   struct ImapStatus *status = NULL;
 
@@ -1594,7 +1594,7 @@ int imap_search(struct Mailbox *m, const struct Pattern *pat)
 int imap_subscribe(char *path, bool subscribe)
 {
   struct ImapAccountData *adata = NULL;
-  struct ImapMailboxData *mdata = NULL;
+  struct ImapMboxData *mdata = NULL;
   char buf[LONG_STRING * 2];
   char mbox[LONG_STRING];
   char errstr[STRING];
@@ -1652,7 +1652,7 @@ int imap_subscribe(char *path, bool subscribe)
 int imap_complete(char *buf, size_t buflen, char *path)
 {
   struct ImapAccountData *adata = NULL;
-  struct ImapMailboxData *mdata = NULL;
+  struct ImapMboxData *mdata = NULL;
   char tmp[LONG_STRING * 2];
   struct ImapList listresp;
   char completion[LONG_STRING];
@@ -1738,7 +1738,7 @@ int imap_fast_trash(struct Mailbox *m, char *dest)
 
   struct ImapAccountData *adata = imap_adata_get(m);
   struct ImapAccountData *dest_adata = NULL;
-  struct ImapMailboxData *dest_mdata = NULL;
+  struct ImapMboxData *dest_mdata = NULL;
 
   if (imap_adata_find(dest, &dest_adata, &dest_mdata) < 0)
     return -1;
@@ -2176,7 +2176,7 @@ static int imap_mbox_open(struct Context *ctx)
     return -1;
 
   struct ImapAccountData *adata = m->account->adata;
-  struct ImapMailboxData *mdata = m->mdata;
+  struct ImapMboxData *mdata = m->mdata;
 
   FREE(&(adata->mbox_name));
   adata->mbox_name = mutt_str_strdup(mdata->name);
@@ -2420,7 +2420,7 @@ static int imap_mbox_open_append(struct Mailbox *m, int flags)
     return -1;
 
   struct ImapAccountData *adata = m->account->adata;
-  struct ImapMailboxData *mdata = m->mdata;
+  struct ImapMboxData *mdata = m->mdata;
 
   rc = imap_access2(adata, mdata->name);
   if (rc == 0)

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -1712,7 +1712,7 @@ int imap_complete(char *buf, size_t buflen, char *path)
   if (completions)
   {
     /* reformat output */
-    imap_qualify_path2(buf, buflen, &adata->conn_account, completion);
+    imap_qualify_path(buf, buflen, &adata->conn_account, completion);
     mutt_pretty_mailbox(buf, buflen);
     return 0;
   }
@@ -2181,7 +2181,7 @@ static int imap_mbox_open(struct Context *ctx)
   FREE(&(adata->mbox_name));
   adata->mbox_name = mutt_str_strdup(mdata->name);
   // TODO(sileht): store qualifed path in mdata ?
-  imap_qualify_path2(buf, sizeof(buf), &adata->conn_account, adata->mbox_name);
+  imap_qualify_path(buf, sizeof(buf), &adata->conn_account, adata->mbox_name);
 
   mutt_str_strfcpy(m->path, buf, sizeof(m->path));
   mutt_str_strfcpy(m->realpath, m->path, sizeof(m->realpath));

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -2064,7 +2064,7 @@ int imap_ac_add(struct Account *a, struct Mailbox *m)
     struct ConnAccount *conn_account = mutt_mem_calloc(1, sizeof(struct ConnAccount));
     char mailbox[LONG_STRING];
 
-    if (imap_parse_path2(m->path, conn_account, mailbox, sizeof(mailbox)) < 0)
+    if (imap_parse_path(m->path, conn_account, mailbox, sizeof(mailbox)) < 0)
       return -1;
 
     if (!a->adata)
@@ -2226,7 +2226,7 @@ static int imap_mbox_open(struct Context *ctx)
   char p_mailbox[LONG_STRING];
 
   if ((imap_path_probe(Postponed, NULL) == MUTT_IMAP) &&
-      !imap_parse_path2(Postponed, &p_conn_account, p_mailbox, sizeof(p_mailbox)) &&
+      !imap_parse_path(Postponed, &p_conn_account, p_mailbox, sizeof(p_mailbox)) &&
       mutt_account_match(&p_conn_account, &adata->conn_account))
   {
     imap_status(Postponed, true);

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -1736,29 +1736,20 @@ int imap_fast_trash(struct Mailbox *m, char *dest)
   char mmbox[LONG_STRING];
   char prompt[LONG_STRING];
   int rc;
-  struct ImapMbox mx;
   bool triedcreate = false;
   struct Buffer *sync_cmd = NULL;
   int err_continue = MUTT_NO;
 
   struct ImapAccountData *adata = imap_adata_get(m);
-
-  if (imap_parse_path(dest, &mx))
-  {
-    mutt_debug(1, "bad destination %s\n", dest);
-    return -1;
-  }
+  struct ImapAccountData *dest_adata = imap_adata_find(dest, mbox, sizeof(mbox), true);
 
   /* check that the save-to folder is in the same account */
-  if (!mutt_account_match(&(adata->conn->account), &(mx.account)))
+  if (!mutt_account_match(&(adata->conn->account), &(dest_adata->conn->account)))
   {
     mutt_debug(3, "%s not same server as %s\n", dest, m->path);
     return 1;
   }
 
-  imap_fix_path(adata, mx.mbox, mbox, sizeof(mbox));
-  if (!*mbox)
-    mutt_str_strfcpy(mbox, "INBOX", sizeof(mbox));
   imap_munge_mbox_name(adata, mmbox, sizeof(mmbox), mbox);
 
   sync_cmd = mutt_buffer_new();
@@ -1832,7 +1823,6 @@ int imap_fast_trash(struct Mailbox *m, char *dest)
 
 out:
   mutt_buffer_free(&sync_cmd);
-  FREE(&mx.mbox);
 
   return (rc < 0) ? -1 : rc;
 }

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -2181,15 +2181,12 @@ static int imap_mbox_open(struct Context *ctx)
   char buf[PATH_MAX];
   char bufout[PATH_MAX];
   int count = 0;
-  struct ImapMbox pmx;
   int rc;
   const char *condstore = NULL;
 
   rc = imap_prepare_mailbox(m, buf, sizeof(buf));
   if (rc < 0)
-  {
     return -1;
-  }
 
   struct ImapAccountData *adata = m->account->adata;
   struct ImapMailboxData *mdata = m->mdata;
@@ -2237,13 +2234,15 @@ static int imap_mbox_open(struct Context *ctx)
     mutt_bit_set(adata->mailbox->rights, MUTT_ACL_DELETE);
   }
   /* pipeline the postponed count if possible */
-  pmx.mbox = NULL;
-  if ((imap_path_probe(Postponed, NULL) == MUTT_IMAP) && !imap_parse_path(Postponed, &pmx) &&
-      mutt_account_match(&pmx.account, &adata->conn_account))
+  struct ConnAccount p_conn_account;
+  char p_mailbox[LONG_STRING];
+
+  if ((imap_path_probe(Postponed, NULL) == MUTT_IMAP) &&
+      !imap_parse_path2(Postponed, &p_conn_account, p_mailbox, sizeof(p_mailbox)) &&
+      mutt_account_match(&p_conn_account, &adata->conn_account))
   {
     imap_status(Postponed, true);
   }
-  FREE(&pmx.mbox);
 
   if (ImapCheckSubscribed)
     imap_exec(adata, "LSUB \"\" \"*\"", IMAP_CMD_QUEUE);

--- a/imap/imap.h
+++ b/imap/imap.h
@@ -103,7 +103,7 @@ extern struct MxOps mx_imap_ops;
 /* browse.c */
 int imap_browse(char *path, struct BrowserState *state);
 int imap_mailbox_create(const char *folder);
-int imap_mailbox_rename(const char *mailbox);
+int imap_mailbox_rename(const char *path);
 
 /* message.c */
 int imap_copy_messages(struct Context *ctx, struct Email *e, char *dest, bool delete);

--- a/imap/imap.h
+++ b/imap/imap.h
@@ -75,15 +75,6 @@ extern bool ImapServernoise;
 extern char *ImapDelimChars;
 extern short ImapPipelineDepth;
 
-/**
- * struct ImapMbox - An IMAP mailbox
- */
-struct ImapMbox
-{
-  struct ConnAccount account;
-  char *mbox;
-};
-
 /* imap.c */
 int imap_access(const char *path);
 int imap_check_mailbox(struct Mailbox *m, bool force);
@@ -112,7 +103,6 @@ int imap_copy_messages(struct Context *ctx, struct Email *e, char *dest, bool de
 void imap_logout_all(void);
 
 /* util.c */
-int imap_parse_path(const char *path, struct ImapMbox *mx);
 int imap_parse_path2(const char *path, struct ConnAccount *account, char *mailbox, size_t mailboxlen);
 void imap_pretty_mailbox(char *path, const char *folder);
 

--- a/imap/imap.h
+++ b/imap/imap.h
@@ -89,7 +89,7 @@ int imap_access(const char *path);
 int imap_check_mailbox(struct Mailbox *m, bool force);
 int imap_delete_mailbox(struct Mailbox *m, char *path);
 int imap_sync_mailbox(struct Context *ctx, bool expunge, bool close);
-int imap_mailbox_check(bool check_stats);
+int imap_mailbox_check(struct Mailbox *m, bool check_stats);
 int imap_status(const char *path, bool queue);
 int imap_search(struct Mailbox *m, const struct Pattern *pat);
 int imap_subscribe(char *path, bool subscribe);

--- a/imap/imap.h
+++ b/imap/imap.h
@@ -103,7 +103,7 @@ int imap_copy_messages(struct Context *ctx, struct Email *e, char *dest, bool de
 void imap_logout_all(void);
 
 /* util.c */
-int imap_parse_path2(const char *path, struct ConnAccount *account, char *mailbox, size_t mailboxlen);
+int imap_parse_path(const char *path, struct ConnAccount *account, char *mailbox, size_t mailboxlen);
 void imap_pretty_mailbox(char *path, const char *folder);
 
 int imap_wait_keepalive(pid_t pid);

--- a/imap/imap.h
+++ b/imap/imap.h
@@ -113,6 +113,7 @@ void imap_logout_all(void);
 
 /* util.c */
 int imap_parse_path(const char *path, struct ImapMbox *mx);
+int imap_parse_path2(const char *path, struct ConnAccount *account, char *mailbox, size_t mailboxlen);
 void imap_pretty_mailbox(char *path, const char *folder);
 
 int imap_wait_keepalive(pid_t pid);

--- a/imap/imap_private.h
+++ b/imap/imap_private.h
@@ -318,7 +318,7 @@ int imap_login(struct ImapAccountData *adata);
 void imap_logout(struct ImapAccountData **adata);
 int imap_sync_message_for_copy(struct ImapAccountData *adata, struct Email *e, struct Buffer *cmd, int *err_continue);
 bool imap_has_flag(struct ListHead *flag_list, const char *flag);
-struct ImapAccountData *imap_adata_find(const char *path, char *mailbox, size_t mailboxlen);
+struct ImapAccountData *imap_adata_find(const char *path, char *mailbox, size_t mailboxlen, bool fix_path);
 
 /* auth.c */
 int imap_authenticate(struct ImapAccountData *adata);

--- a/imap/imap_private.h
+++ b/imap/imap_private.h
@@ -317,7 +317,7 @@ int imap_login(struct ImapAccountData *adata);
 void imap_logout(struct ImapAccountData **adata);
 int imap_sync_message_for_copy(struct ImapAccountData *adata, struct Email *e, struct Buffer *cmd, int *err_continue);
 bool imap_has_flag(struct ListHead *flag_list, const char *flag);
-struct ImapAccountData *imap_adata_find(const char *path, char *mailbox, size_t mailboxlen, bool fix_path);
+int imap_adata_find(const char *path, struct ImapAccountData **adata, struct ImapMailboxData **mdata);
 
 /* auth.c */
 int imap_authenticate(struct ImapAccountData *adata);

--- a/imap/imap_private.h
+++ b/imap/imap_private.h
@@ -347,6 +347,7 @@ int imap_msg_commit(struct Mailbox *m, struct Message *msg);
 
 /* util.c */
 struct ImapAccountData *imap_adata_get(struct Mailbox *m);
+struct ImapMailboxData *imap_mdata_get(struct Mailbox *m);
 #ifdef USE_HCACHE
 header_cache_t *imap_hcache_open(struct ImapAccountData *adata, const char *path);
 void imap_hcache_close(struct ImapAccountData *adata);

--- a/imap/imap_private.h
+++ b/imap/imap_private.h
@@ -274,11 +274,11 @@ struct ImapAccountData
 };
 
 /**
- * struct ImapMailboxData - IMAP-specific Mailbox data
+ * struct ImapMboxData - IMAP-specific Mailbox data
  *
  * This data is specific to a Mailbox of an IMAP server
  */
-struct ImapMailboxData
+struct ImapMboxData
 {
   char *name;
   char *munge_name;
@@ -317,7 +317,7 @@ int imap_login(struct ImapAccountData *adata);
 void imap_logout(struct ImapAccountData **adata);
 int imap_sync_message_for_copy(struct ImapAccountData *adata, struct Email *e, struct Buffer *cmd, int *err_continue);
 bool imap_has_flag(struct ListHead *flag_list, const char *flag);
-int imap_adata_find(const char *path, struct ImapAccountData **adata, struct ImapMailboxData **mdata);
+int imap_adata_find(const char *path, struct ImapAccountData **adata, struct ImapMboxData **mdata);
 
 /* auth.c */
 int imap_authenticate(struct ImapAccountData *adata);
@@ -346,7 +346,7 @@ int imap_msg_commit(struct Mailbox *m, struct Message *msg);
 
 /* util.c */
 struct ImapAccountData *imap_adata_get(struct Mailbox *m);
-struct ImapMailboxData *imap_mdata_get(struct Mailbox *m);
+struct ImapMboxData *imap_mdata_get(struct Mailbox *m);
 #ifdef USE_HCACHE
 header_cache_t *imap_hcache_open(struct ImapAccountData *adata, const char *path);
 void imap_hcache_close(struct ImapAccountData *adata);
@@ -362,7 +362,7 @@ int imap_continue(const char *msg, const char *resp);
 void imap_error(const char *where, const char *msg);
 struct ImapAccountData *imap_adata_new(void);
 void imap_adata_free(void **ptr);
-struct ImapMailboxData *imap_mdata_new(struct ImapAccountData *adata, const char* name);
+struct ImapMboxData *imap_mdata_new(struct ImapAccountData *adata, const char* name);
 void imap_mdata_free(void **ptr);
 char *imap_fix_path(struct ImapAccountData *adata, const char *mailbox, char *path, size_t plen);
 void imap_cachepath(struct ImapAccountData *adata, const char *mailbox, char *dest, size_t dlen);

--- a/imap/imap_private.h
+++ b/imap/imap_private.h
@@ -37,7 +37,6 @@
 struct Context;
 struct Email;
 struct ImapEmailData;
-struct ImapMbox;
 struct Mailbox;
 struct Message;
 struct Progress;
@@ -371,7 +370,6 @@ int imap_get_literal_count(const char *buf, unsigned int *bytes);
 char *imap_get_qualifier(char *buf);
 int imap_mxcmp(const char *mx1, const char *mx2);
 char *imap_next_word(char *s);
-void imap_qualify_path(char *buf, size_t buflen, struct ImapMbox *mx, char *path);
 void imap_qualify_path2(char *buf, size_t buflen, struct ConnAccount *conn_account, char *path);
 void imap_quote_string(char *dest, size_t dlen, const char *src, bool quote_backtick);
 void imap_unquote_string(char *s);

--- a/imap/imap_private.h
+++ b/imap/imap_private.h
@@ -371,6 +371,7 @@ char *imap_get_qualifier(char *buf);
 int imap_mxcmp(const char *mx1, const char *mx2);
 char *imap_next_word(char *s);
 void imap_qualify_path(char *buf, size_t buflen, struct ImapMbox *mx, char *path);
+void imap_qualify_path2(char *buf, size_t buflen, struct ConnAccount *conn_account, char *path);
 void imap_quote_string(char *dest, size_t dlen, const char *src, bool quote_backtick);
 void imap_unquote_string(char *s);
 void imap_munge_mbox_name(struct ImapAccountData *adata, char *dest, size_t dlen, const char *src);

--- a/imap/imap_private.h
+++ b/imap/imap_private.h
@@ -305,7 +305,7 @@ struct SeqsetIterator
 /* imap.c */
 int imap_check(struct ImapAccountData *adata, bool force);
 int imap_create_mailbox(struct ImapAccountData *adata, char *mailbox);
-int imap_rename_mailbox(struct ImapAccountData *adata, struct ImapMbox *mx, const char *newname);
+int imap_rename_mailbox(struct ImapAccountData *adata, char *oldname, const char *newname);
 struct ImapStatus *imap_mboxcache_get(struct ImapAccountData *adata, const char *mbox, bool create);
 void imap_mboxcache_free(struct ImapAccountData *adata);
 int imap_exec_msgset(struct ImapAccountData *adata, const char *pre, const char *post,
@@ -318,7 +318,7 @@ int imap_login(struct ImapAccountData *adata);
 void imap_logout(struct ImapAccountData **adata);
 int imap_sync_message_for_copy(struct ImapAccountData *adata, struct Email *e, struct Buffer *cmd, int *err_continue);
 bool imap_has_flag(struct ListHead *flag_list, const char *flag);
-struct ImapAccountData *imap_adata_find(const char *path, struct ImapMbox *mx);
+struct ImapAccountData *imap_adata_find(const char *path, char *mailbox, size_t mailboxlen);
 
 /* auth.c */
 int imap_authenticate(struct ImapAccountData *adata);

--- a/imap/imap_private.h
+++ b/imap/imap_private.h
@@ -275,6 +275,18 @@ struct ImapAccountData
 };
 
 /**
+ * struct ImapMailboxData - IMAP-specific Mailbox data
+ *
+ * This data is specific to a Mailbox of an IMAP server
+ */
+struct ImapMailboxData
+{
+  char *name;
+  char *munge_name;
+  char *real_name;
+};
+
+/**
  * struct SeqsetIterator - UID Sequence Set Iterator
  */
 struct SeqsetIterator
@@ -350,6 +362,8 @@ int imap_continue(const char *msg, const char *resp);
 void imap_error(const char *where, const char *msg);
 struct ImapAccountData *imap_adata_new(void);
 void imap_adata_free(void **ptr);
+struct ImapMailboxData *imap_mdata_new(struct ImapAccountData *adata, const char* name);
+void imap_mdata_free(void **ptr);
 char *imap_fix_path(struct ImapAccountData *adata, const char *mailbox, char *path, size_t plen);
 void imap_cachepath(struct ImapAccountData *adata, const char *mailbox, char *dest, size_t dlen);
 int imap_get_literal_count(const char *buf, unsigned int *bytes);

--- a/imap/imap_private.h
+++ b/imap/imap_private.h
@@ -370,7 +370,7 @@ int imap_get_literal_count(const char *buf, unsigned int *bytes);
 char *imap_get_qualifier(char *buf);
 int imap_mxcmp(const char *mx1, const char *mx2);
 char *imap_next_word(char *s);
-void imap_qualify_path2(char *buf, size_t buflen, struct ConnAccount *conn_account, char *path);
+void imap_qualify_path(char *buf, size_t buflen, struct ConnAccount *conn_account, char *path);
 void imap_quote_string(char *dest, size_t dlen, const char *src, bool quote_backtick);
 void imap_unquote_string(char *s);
 void imap_munge_mbox_name(struct ImapAccountData *adata, char *dest, size_t dlen, const char *src);

--- a/imap/message.c
+++ b/imap/message.c
@@ -1390,15 +1390,14 @@ int imap_append_message(struct Mailbox *m, struct Message *msg)
   struct Progress progressbar;
   size_t sent;
   int c, last;
-  struct ImapMbox mx;
   int rc;
 
   struct ImapAccountData *adata = imap_adata_get(m);
 
-  if (imap_parse_path(m->path, &mx))
+  if (imap_parse_path2(m->path, NULL, buf, sizeof(buf)))
     return -1;
 
-  imap_fix_path(adata, mx.mbox, mailbox, sizeof(mailbox));
+  imap_fix_path(adata, buf, mailbox, sizeof(mailbox));
   if (!*mailbox)
     mutt_str_strfcpy(mailbox, "INBOX", sizeof(mailbox));
 
@@ -1498,11 +1497,9 @@ int imap_append_message(struct Mailbox *m, struct Message *msg)
     goto fail;
   }
 
-  FREE(&mx.mbox);
   return 0;
 
 fail:
-  FREE(&mx.mbox);
   return -1;
 }
 

--- a/imap/message.c
+++ b/imap/message.c
@@ -1529,7 +1529,7 @@ int imap_copy_messages(struct Context *ctx, struct Email *e, char *dest, bool de
 
   struct ImapAccountData *adata = imap_adata_get(m);
 
-  if (imap_parse_path2(dest, &conn_account, buf, sizeof(buf)))
+  if (imap_parse_path(dest, &conn_account, buf, sizeof(buf)))
   {
     mutt_debug(1, "bad destination %s\n", dest);
     return -1;

--- a/imap/message.c
+++ b/imap/message.c
@@ -1391,7 +1391,7 @@ int imap_append_message(struct Mailbox *m, struct Message *msg)
   int rc;
 
   struct ImapAccountData *adata = imap_adata_get(m);
-  struct ImapMailboxData *mdata = imap_mdata_get(m);
+  struct ImapMboxData *mdata = imap_mdata_get(m);
 
   fp = fopen(msg->path, "r");
   if (!fp)

--- a/imap/util.c
+++ b/imap/util.c
@@ -581,6 +581,7 @@ int imap_parse_path2(const char *path, struct ConnAccount *account, char *mailbo
   }
 
   /* Defaults */
+  memset(account, 0, sizeof(struct ConnAccount));
   account->port = ImapPort;
   account->type = MUTT_ACCT_TYPE_IMAP;
 

--- a/imap/util.c
+++ b/imap/util.c
@@ -127,7 +127,7 @@ struct ImapAccountData *imap_adata_get(struct Mailbox *m)
  * imap_adata_find - Find the Account data for this path
  */
 int imap_adata_find(const char *path, struct ImapAccountData **adata,
-                    struct ImapMailboxData **mdata)
+                    struct ImapMboxData **mdata)
 {
   struct ConnAccount conn_account;
   struct ImapAccountData *tmp_adata;
@@ -155,13 +155,13 @@ int imap_adata_find(const char *path, struct ImapAccountData **adata,
 }
 
 /**
- * imap_mdata_new - Allocate and initialise a new ImapMailboxData structure
- * @retval ptr New ImapMailboxData
+ * imap_mdata_new - Allocate and initialise a new ImapMboxData structure
+ * @retval ptr New ImapMboxData
  */
-struct ImapMailboxData *imap_mdata_new(struct ImapAccountData *adata, const char *name)
+struct ImapMboxData *imap_mdata_new(struct ImapAccountData *adata, const char *name)
 {
   char buf[LONG_STRING];
-  struct ImapMailboxData *mdata = mutt_mem_calloc(1, sizeof(struct ImapMailboxData));
+  struct ImapMboxData *mdata = mutt_mem_calloc(1, sizeof(struct ImapMboxData));
 
   mdata->real_name = mutt_str_strdup(name);
 
@@ -177,7 +177,7 @@ struct ImapMailboxData *imap_mdata_new(struct ImapAccountData *adata, const char
 }
 
 /**
- * imap_mdata_free - Release and clear storage in an ImapMailboxData structure
+ * imap_mdata_free - Release and clear storage in an ImapMboxData structure
  * @param ptr Imap Mailbox data
  */
 void imap_mdata_free(void **ptr)
@@ -185,7 +185,7 @@ void imap_mdata_free(void **ptr)
   if (!ptr || !*ptr)
     return;
 
-  struct ImapMailboxData *mdata = *ptr;
+  struct ImapMboxData *mdata = *ptr;
 
   FREE(&mdata->name);
   FREE(&mdata->real_name);
@@ -196,7 +196,7 @@ void imap_mdata_free(void **ptr)
 /**
  * imap_mdata_get - Get the Mailbox data for this mailbox
  */
-struct ImapMailboxData *imap_mdata_get(struct Mailbox *m)
+struct ImapMboxData *imap_mdata_get(struct Mailbox *m)
 {
   if (!m || (m->magic != MUTT_IMAP) || !m->mdata)
     return NULL;
@@ -259,7 +259,7 @@ void imap_get_parent(const char *mbox, char delim, char *buf, size_t buflen)
 void imap_get_parent_path(const char *path, char *buf, size_t buflen)
 {
   struct ImapAccountData *adata = NULL;
-  struct ImapMailboxData *mdata = NULL;
+  struct ImapMboxData *mdata = NULL;
   char mbox[LONG_STRING];
 
   if (imap_adata_find(path, &adata, &mdata) < 0)
@@ -286,7 +286,7 @@ void imap_get_parent_path(const char *path, char *buf, size_t buflen)
 void imap_clean_path(char *path, size_t plen)
 {
   struct ImapAccountData *adata = NULL;
-  struct ImapMailboxData *mdata = NULL;
+  struct ImapMboxData *mdata = NULL;
 
   if (imap_adata_find(path, &adata, &mdata) < 0)
     return;
@@ -383,7 +383,7 @@ header_cache_t *imap_hcache_open(struct ImapAccountData *adata, const char *path
     imap_cachepath(adata, path, mbox, sizeof(mbox));
   else if (adata->mailbox)
   {
-    struct ImapMailboxData *mdata = imap_mdata_get(adata->mailbox);
+    struct ImapMboxData *mdata = imap_mdata_get(adata->mailbox);
     imap_cachepath(adata, mdata->name, mbox, sizeof(mbox));
   }
   else

--- a/imap/util.c
+++ b/imap/util.c
@@ -381,18 +381,16 @@ header_cache_t *imap_hcache_open(struct ImapAccountData *adata, const char *path
   struct Url url;
   char cachepath[PATH_MAX];
   char mbox[PATH_MAX];
-  char buf[PATH_MAX];
 
   if (path)
     imap_cachepath(adata, path, mbox, sizeof(mbox));
-  else
+  else if (adata->mailbox)
   {
-    if (!adata->mailbox ||
-        imap_parse_path2(adata->mailbox->path, NULL, buf, sizeof(buf)) < 0)
-      return NULL;
-
-    imap_cachepath(adata, buf, mbox, sizeof(mbox));
+    struct ImapMailboxData *mdata = imap_mdata_get(adata->mailbox);
+    imap_cachepath(adata, mdata->name, mbox, sizeof(mbox));
   }
+  else
+    return NULL;
 
   if (strstr(mbox, "/../") || (strcmp(mbox, "..") == 0) || (strncmp(mbox, "../", 3) == 0))
     return NULL;

--- a/imap/util.c
+++ b/imap/util.c
@@ -129,10 +129,10 @@ struct ImapAccountData *imap_adata_get(struct Mailbox *m)
 struct ImapAccountData *imap_adata_find(const char *path, char *mailbox,
                                         size_t mailboxlen, bool fix_path)
 {
-  // NOTE(sileht): Remove mx when we are able to pass Mailbox or Url there.
-  struct ImapMbox mx;
+  struct ConnAccount conn_account;
+  char tmp[LONG_STRING];
 
-  if (imap_parse_path(path, &mx) < 0)
+  if (imap_parse_path2(path, &conn_account, tmp, sizeof(tmp)) < 0)
     return NULL;
 
   struct Account *np = NULL;
@@ -143,14 +143,14 @@ struct ImapAccountData *imap_adata_find(const char *path, char *mailbox,
       continue;
 
     adata = np->adata;
-    if (imap_account_match(&adata->conn_account, &mx.account))
+    if (imap_account_match(&adata->conn_account, &conn_account))
     {
-      if (mx.mbox)
+      if (tmp[0] != '\0')
       {
         if (fix_path)
-          imap_fix_path(adata, mx.mbox, mailbox, mailboxlen);
+          imap_fix_path(adata, tmp, mailbox, mailboxlen);
         else
-          mutt_str_strfcpy(mailbox, mx.mbox, mailboxlen);
+          mutt_str_strfcpy(mailbox, tmp, mailboxlen);
       }
       return adata;
     }

--- a/imap/util.c
+++ b/imap/util.c
@@ -673,12 +673,6 @@ int imap_parse_path2(const char *path, struct ConnAccount *account, char *mailbo
 
   return 0;
 }
-int imap_parse_path(const char *path, struct ImapMbox *mx)
-{
-  memset(&mx->account, 0, sizeof(mx->account));
-  mx->mbox = mutt_mem_calloc(1, sizeof(char) * LONG_STRING);
-  return imap_parse_path2(path, &mx->account, mx->mbox, sizeof(char) * LONG_STRING);
-}
 
 /**
  * imap_mxcmp - Compare mailbox names, giving priority to INBOX
@@ -963,25 +957,6 @@ char *imap_next_word(char *s)
 
   SKIPWS(s);
   return s;
-}
-
-/**
- * imap_qualify_path - Make an absolute IMAP folder target
- * @param buf    Buffer for the result
- * @param buflen Length of buffer
- * @param mx     Imap mailbox
- * @param path   Path relative to the mailbox
- *
- * given ImapMbox and relative path.
- */
-void imap_qualify_path(char *buf, size_t buflen, struct ImapMbox *mx, char *path)
-{
-  struct Url url;
-
-  mutt_account_tourl(&mx->account, &url);
-  url.path = path;
-
-  url_tostring(&url, buf, buflen, 0);
 }
 
 /**

--- a/imap/util.c
+++ b/imap/util.c
@@ -378,20 +378,20 @@ static int imap_hcache_namer(const char *path, char *dest, size_t dlen)
  */
 header_cache_t *imap_hcache_open(struct ImapAccountData *adata, const char *path)
 {
-  struct ImapMbox mx;
   struct Url url;
   char cachepath[PATH_MAX];
   char mbox[PATH_MAX];
+  char buf[PATH_MAX];
 
   if (path)
     imap_cachepath(adata, path, mbox, sizeof(mbox));
   else
   {
-    if (!adata->mailbox || imap_parse_path(adata->mailbox->path, &mx) < 0)
+    if (!adata->mailbox ||
+        imap_parse_path2(adata->mailbox->path, NULL, buf, sizeof(buf)) < 0)
       return NULL;
 
-    imap_cachepath(adata, mx.mbox, mbox, sizeof(mbox));
-    FREE(&mx.mbox);
+    imap_cachepath(adata, buf, mbox, sizeof(mbox));
   }
 
   if (strstr(mbox, "/../") || (strcmp(mbox, "..") == 0) || (strncmp(mbox, "../", 3) == 0))

--- a/imap/util.c
+++ b/imap/util.c
@@ -133,7 +133,7 @@ int imap_adata_find(const char *path, struct ImapAccountData **adata,
   struct ImapAccountData *tmp_adata;
   char tmp[LONG_STRING];
 
-  if (imap_parse_path2(path, &conn_account, tmp, sizeof(tmp)) < 0)
+  if (imap_parse_path(path, &conn_account, tmp, sizeof(tmp)) < 0)
     return -1;
 
   struct Account *np = NULL;
@@ -542,7 +542,7 @@ char *imap_hcache_get_uid_seqset(struct ImapAccountData *adata)
 #endif
 
 /**
- * imap_parse_path2 - Parse an IMAP mailbox name into ConnAccount, name
+ * imap_parse_path - Parse an IMAP mailbox name into ConnAccount, name
  * @param path       Mailbox path to parse
  * @param account    Account credentials
  * @param mailbox    Buffer for mailbox name
@@ -553,7 +553,7 @@ char *imap_hcache_get_uid_seqset(struct ImapAccountData *adata)
  * Given an IMAP mailbox name, return host, port and a path IMAP servers will
  * recognize.  mx.mbox is malloc'd, caller must free it
  */
-int imap_parse_path2(const char *path, struct ConnAccount *account, char *mailbox, size_t mailboxlen)
+int imap_parse_path(const char *path, struct ConnAccount *account, char *mailbox, size_t mailboxlen)
 {
   static unsigned short ImapPort = 0;
   static unsigned short ImapsPort = 0;
@@ -671,13 +671,13 @@ void imap_pretty_mailbox(char *path, const char *folder)
   char target_mailbox[LONG_STRING];
   char home_mailbox[LONG_STRING];
 
-  if (imap_parse_path2(path, &target_conn_account, target_mailbox, sizeof(target_mailbox)) < 0)
+  if (imap_parse_path(path, &target_conn_account, target_mailbox, sizeof(target_mailbox)) < 0)
     return;
 
   if (imap_path_probe(folder, NULL) != MUTT_IMAP)
     goto fallback;
 
-  if (imap_parse_path2(folder, &home_conn_account, home_mailbox, sizeof(home_mailbox)) < 0)
+  if (imap_parse_path(folder, &home_conn_account, home_mailbox, sizeof(home_mailbox)) < 0)
     goto fallback;
 
   tlen = mutt_str_strlen(target_mailbox);

--- a/imap/util.c
+++ b/imap/util.c
@@ -606,56 +606,8 @@ int imap_parse_path2(const char *path, struct ConnAccount *account, char *mailbo
     url_free(&url);
     FREE(&c);
   }
-  /* old PINE-compatibility code */
   else
-  {
-    url_free(&url);
-    FREE(&c);
-    char tmp[128];
-    if (sscanf(path, "{%127[^}]}", tmp) != 1)
-      return -1;
-
-    c = strchr(path, '}');
-    if (!c)
-      return -1;
-    else
-    {
-      /* walk past closing '}' */
-      mutt_str_strfcpy(mailbox, c + 1, mailboxlen);
-    }
-
-    c = strrchr(tmp, '@');
-    if (c)
-    {
-      *c = '\0';
-      mutt_str_strfcpy(account->user, tmp, sizeof(account->user));
-      mutt_str_strfcpy(tmp, c + 1, sizeof(tmp));
-      account->flags |= MUTT_ACCT_USER;
-    }
-
-    const int n = sscanf(tmp, "%127[^:/]%127s", account->host, tmp);
-    if (n < 1)
-    {
-      mutt_debug(1, "NULL host in %s\n", path);
-      return -1;
-    }
-
-    if (n > 1)
-    {
-      if (sscanf(tmp, ":%hu%127s", &(account->port), tmp) >= 1)
-        account->flags |= MUTT_ACCT_PORT;
-      if (sscanf(tmp, "/%s", tmp) == 1)
-      {
-        if (mutt_str_startswith(tmp, "ssl", CASE_MATCH))
-          account->flags |= MUTT_ACCT_SSL;
-        else
-        {
-          mutt_debug(1, "Unknown connection type in %s\n", path);
-          return -1;
-        }
-      }
-    }
-  }
+    return -1;
 
   if ((account->flags & MUTT_ACCT_SSL) && !(account->flags & MUTT_ACCT_PORT))
     account->port = ImapsPort;

--- a/imap/util.c
+++ b/imap/util.c
@@ -965,6 +965,21 @@ void imap_qualify_path(char *buf, size_t buflen, struct ImapMbox *mx, char *path
 }
 
 /**
+ * imap_qualify_path2 - Make an absolute IMAP folder target
+ * @param buf    Buffer for the result
+ * @param buflen Length of buffer
+ * @param conn_account     ConnAccount of the account
+ * @param path   Path relative to the mailbox
+ */
+void imap_qualify_path2(char *buf, size_t buflen, struct ConnAccount *conn_account, char *path)
+{
+  struct Url url;
+  mutt_account_tourl(conn_account, &url);
+  url.path = path;
+  url_tostring(&url, buf, buflen, 0);
+}
+
+/**
  * imap_quote_string - quote string according to IMAP rules
  * @param dest           Buffer for the result
  * @param dlen           Length of the buffer

--- a/imap/util.c
+++ b/imap/util.c
@@ -272,7 +272,7 @@ void imap_get_parent_path(const char *path, char *buf, size_t buflen)
   imap_get_parent(mdata->name, adata->delim, mbox, sizeof(mbox));
 
   /* Returns a fully qualified IMAP url */
-  imap_qualify_path2(buf, buflen, &adata->conn_account, mbox);
+  imap_qualify_path(buf, buflen, &adata->conn_account, mbox);
   imap_mdata_free((void *) &mdata);
 }
 
@@ -293,7 +293,7 @@ void imap_clean_path(char *path, size_t plen)
 
   /* Returns a fully qualified IMAP url */
   // TODO(sileht): Put it in mdata directly ?
-  imap_qualify_path2(path, plen, &adata->conn_account, mdata->name);
+  imap_qualify_path(path, plen, &adata->conn_account, mdata->name);
   imap_mdata_free((void *) &mdata);
 }
 
@@ -899,13 +899,13 @@ char *imap_next_word(char *s)
 }
 
 /**
- * imap_qualify_path2 - Make an absolute IMAP folder target
+ * imap_qualify_path - Make an absolute IMAP folder target
  * @param buf    Buffer for the result
  * @param buflen Length of buffer
  * @param conn_account     ConnAccount of the account
  * @param path   Path relative to the mailbox
  */
-void imap_qualify_path2(char *buf, size_t buflen, struct ConnAccount *conn_account, char *path)
+void imap_qualify_path(char *buf, size_t buflen, struct ConnAccount *conn_account, char *path)
 {
   struct Url url;
   mutt_account_tourl(conn_account, &url);

--- a/imap/util.c
+++ b/imap/util.c
@@ -171,7 +171,7 @@ struct ImapMailboxData *imap_mdata_new(struct ImapAccountData *adata, const char
   mdata->real_name = mutt_str_strdup(name);
 
   imap_fix_path(adata, name, buf, sizeof(buf));
-  if (!*buf)
+  if (buf[0] == '\0')
     mutt_str_strfcpy(buf, "INBOX", sizeof(buf));
   mdata->name = mutt_str_strdup(buf);
 

--- a/mailbox.c
+++ b/mailbox.c
@@ -372,7 +372,7 @@ static void mailbox_check(struct Mailbox *m, struct stat *ctx_sb, bool check_sta
         break;
 #ifdef USE_IMAP
       case MUTT_IMAP:
-        if (imap_mailbox_check(m, check_stats) == 0)
+        if (imap_mailbox_check(m, check_stats) == 0 && m->has_new)
           MailboxCount++;
         break;
 #endif


### PR DESCRIPTION
This change reduce the usage of ImapMbox and imap_path_parse()

This change introduces `struct ImapMailboxData` to mainly store
the mbox name in all its form.

Next change will use this names instead of parsing again and again the
path.

At this end we should be able to drop ImapMbox and imap_parse_path().