### PR TITLE
imap: reduce complexity of imap_exec

### DIFF
--- a/imap/auth_login.c
+++ b/imap/auth_login.c
@@ -46,7 +46,6 @@ enum ImapAuthRes imap_auth_login(struct ImapAccountData *adata, const char *meth
 {
   char q_user[STRING], q_pass[STRING];
   char buf[LONG_STRING];
-  int rc;
 
   if (mutt_bit_isset(adata->capabilities, LOGINDISABLED))
   {
@@ -71,9 +70,7 @@ enum ImapAuthRes imap_auth_login(struct ImapAccountData *adata, const char *meth
     mutt_debug(2, "Sending LOGIN command for %s...\n", adata->conn->account.user);
 
   snprintf(buf, sizeof(buf), "LOGIN %s %s", q_user, q_pass);
-  rc = imap_exec(adata, buf, IMAP_CMD_FAIL_OK | IMAP_CMD_PASS);
-
-  if (!rc)
+  if (imap_exec(adata, buf, IMAP_CMD_PASS) != IMAP_EXEC_SUCCESS)
   {
     mutt_clear_error(); /* clear "Logging in...".  fixes #3524 */
     return IMAP_AUTH_SUCCESS;

--- a/imap/auth_oauth.c
+++ b/imap/auth_oauth.c
@@ -72,21 +72,21 @@ enum ImapAuthRes imap_auth_oauth(struct ImapAccountData *adata, const char *meth
   /* This doesn't really contain a password, but the token is good for
    * an hour, so suppress it anyways.
    */
-  rc = imap_exec(adata, ibuf, IMAP_CMD_FAIL_OK | IMAP_CMD_PASS);
+  rc = imap_exec(adata, ibuf, IMAP_CMD_PASS);
 
   FREE(&oauthbearer);
   FREE(&ibuf);
 
-  if (rc)
+  if (rc == IMAP_EXEC_SUCCESS)
   {
     /* The error response was in SASL continuation, so continue the SASL
      * to cause a failure and exit SASL input.  See RFC 7628 3.2.3
      */
     mutt_socket_send(adata->conn, "\001");
-    rc = imap_exec(adata, ibuf, IMAP_CMD_FAIL_OK);
+    rc = imap_exec(adata, ibuf, 0);
   }
 
-  if (!rc)
+  if (rc != IMAP_EXEC_SUCCESS)
   {
     mutt_clear_error();
     return IMAP_AUTH_SUCCESS;

--- a/imap/imap_private.h
+++ b/imap/imap_private.h
@@ -73,10 +73,19 @@ struct Progress;
 #define IMAP_FLAGS_PENDING    (1 << 4)
 
 /* imap_exec flags (see imap_exec) */
-#define IMAP_CMD_FAIL_OK (1 << 0)
-#define IMAP_CMD_PASS    (1 << 1)
-#define IMAP_CMD_QUEUE   (1 << 2)
-#define IMAP_CMD_POLL    (1 << 3)
+#define IMAP_CMD_PASS    (1 << 0)  /**< Run the imap command and all previous commands queued */
+#define IMAP_CMD_QUEUE   (1 << 1)  /**< Queue a command */
+#define IMAP_CMD_POLL    (1 << 2)  /**< Poll the tcp connection before running the imap command */
+
+/**
+ * enum ImapExecResult - imap_exec return code
+ */
+enum ImapExecResult
+{
+  IMAP_EXEC_SUCCESS = 0, /**< Imap command executed or queued successfully */
+  IMAP_EXEC_ERROR,       /**< Imap command failure */
+  IMAP_EXEC_FATAL        /**< Imap connection failure */
+};
 
 /* length of "DD-MMM-YYYY HH:MM:SS +ZZzz" (null-terminated) */
 #define IMAP_DATELEN 27

--- a/imap/message.c
+++ b/imap/message.c
@@ -1626,7 +1626,7 @@ int imap_copy_messages(struct Context *ctx, struct Email *e, char *dest, bool de
         }
       }
       rc = imap_exec(adata, cmd.data, IMAP_CMD_QUEUE);
-      if (rc < 0)
+      if (rc != IMAP_EXEC_SUCCESS)
       {
         mutt_debug(1, "#2 could not queue copy\n");
         goto out;
@@ -1634,8 +1634,8 @@ int imap_copy_messages(struct Context *ctx, struct Email *e, char *dest, bool de
     }
 
     /* let's get it on */
-    rc = imap_exec(adata, NULL, IMAP_CMD_FAIL_OK);
-    if (rc == -2)
+    rc = imap_exec(adata, NULL, 0);
+    if (rc == IMAP_EXEC_ERROR)
     {
       if (triedcreate)
       {
@@ -1656,7 +1656,7 @@ int imap_copy_messages(struct Context *ctx, struct Email *e, char *dest, bool de
         break;
       triedcreate = 1;
     }
-  } while (rc == -2);
+  } while (rc == IMAP_EXEC_ERROR);
 
   if (rc != 0)
   {


### PR DESCRIPTION
imap_exec flag IMAP_CMD_FAIL_OK is the only one that configure the
function return instead of the function behavior.

Also returned value of the function depends on the flag make hard to
understand what happen after imap_exec() is run.

This change removes this flags, instead we always returns the detailed
returns code, the caller have to deal with it.

Return code are always IMAP_EXEC_SUCCESS/IMAP_EXEC_ERROR/IMAP_EXEC_FATAL and
depends on if the command succeed, failure or if the imap connection
fail.