### PR TITLE
account.login is empty, use account.user instead

### DIFF
--- a/imap/command.c
+++ b/imap/command.c
@@ -167,7 +167,7 @@ static void cmd_handle_fatal(struct ImapAccountData *adata)
   {
     mx_fastclose_mailbox(adata->ctx);
     mutt_socket_close(adata->conn);
-    mutt_error(_("Mailbox %s@%s closed"), adata->conn->account.login,
+    mutt_error(_("Mailbox %s@%s closed"), adata->conn->account.user,
                adata->conn->account.host);
     adata->state = IMAP_DISCONNECTED;
   }


### PR DESCRIPTION
When this error triggers I see `Mailbox @localhost closed`. It appears that account.login contains an empty string, while the IMAP username is in account.user.