### PR TITLE
Keep adata on imap-logout-all

### DIFF
--- a/imap/imap.c
+++ b/imap/imap.c
@@ -691,17 +691,20 @@ static void imap_logout(struct ImapAccountData *adata)
 {
   /* we set status here to let imap_handle_untagged know we _expect_ to
    * receive a bye response (so it doesn't freak out and close the conn) */
-  if (adata->state != IMAP_DISCONNECTED)
+  if (adata->state == IMAP_DISCONNECTED)
   {
-    adata->status = IMAP_BYE;
-    imap_cmd_start(adata, "LOGOUT");
-    if (ImapPollTimeout <= 0 || mutt_socket_poll(adata->conn, ImapPollTimeout) != 0)
-    {
-      while (imap_cmd_step(adata) == IMAP_CMD_CONTINUE)
-        ;
-    }
-    mutt_socket_close(adata->conn);
+    return;
   }
+
+  adata->status = IMAP_BYE;
+  imap_cmd_start(adata, "LOGOUT");
+  if (ImapPollTimeout <= 0 || mutt_socket_poll(adata->conn, ImapPollTimeout) != 0)
+  {
+    while (imap_cmd_step(adata) == IMAP_CMD_CONTINUE)
+      ;
+  }
+  mutt_socket_close(adata->conn);
+  adata->state = IMAP_DISCONNECTED;
 }
 
 /**

--- a/imap/imap_private.h
+++ b/imap/imap_private.h
@@ -298,7 +298,6 @@ void imap_close_connection(struct ImapAccountData *adata);
 int imap_read_literal(FILE *fp, struct ImapAccountData *adata, unsigned long bytes, struct Progress *pbar);
 void imap_expunge_mailbox(struct ImapAccountData *adata);
 int imap_login(struct ImapAccountData *adata);
-void imap_logout(struct ImapAccountData **adata);
 int imap_sync_message_for_copy(struct ImapAccountData *adata, struct Email *e, struct Buffer *cmd, int *err_continue);
 bool imap_has_flag(struct ListHead *flag_list, const char *flag);
 int imap_adata_find(const char *path, struct ImapAccountData **adata, struct ImapMboxData **mdata);


### PR DESCRIPTION
The former call to `imap_adata_free((void **) adata);` caused an account to be around with no adata associated with it. This caused a crash when trying to access the account later on.