### PR TITLE
Pull request for devel/sileht-fix-postponed-big

### DIFF
--- a/imap/command.c
+++ b/imap/command.c
@@ -165,7 +165,7 @@ static void cmd_handle_fatal(struct ImapAccountData *adata)
 
   if (adata->state >= IMAP_SELECTED && (mdata->reopen & IMAP_REOPEN_ALLOW))
   {
-    mx_fastclose_mailbox(adata->ctx);
+    mx_fastclose_mailbox(mdata->ctx);
     mutt_socket_close(adata->conn);
     mutt_error(_("Mailbox %s@%s closed"), adata->conn->account.user,
                adata->conn->account.host);

--- a/imap/imap_private.h
+++ b/imap/imap_private.h
@@ -279,6 +279,8 @@ int imap_exec_msgset(struct Mailbox *m, const char *pre, const char *post,
                      int flag, bool changed, bool invert);
 int imap_open_connection(struct ImapAccountData *adata);
 void imap_close_connection(struct ImapAccountData *adata);
+void imap_select_mailbox(struct Mailbox *m);
+int imap_fetch_mailbox(struct Mailbox *m);
 int imap_read_literal(FILE *fp, struct ImapAccountData *adata, unsigned long bytes, struct Progress *pbar);
 void imap_expunge_mailbox(struct Mailbox *m);
 int imap_login(struct ImapAccountData *adata);

--- a/imap/imap_private.h
+++ b/imap/imap_private.h
@@ -30,6 +30,7 @@
 #include <time.h>
 #include "mutt/mutt.h"
 #include "conn/conn.h"
+#include "mailbox.h"
 #ifdef USE_HCACHE
 #include "hcache/hcache.h"
 #endif
@@ -38,6 +39,7 @@ struct Context;
 struct Email;
 struct ImapEmailData;
 struct Mailbox;
+struct MailboxList;
 struct Message;
 struct Progress;
 
@@ -214,8 +216,8 @@ struct ImapAccountData
   struct Buffer *cmdbuf;
 
   char delim;
-  struct Context *ctx;
-  struct Mailbox *mailbox;     /* Current selected mailbox */
+  struct Mailbox *mailbox;          /* Current selected mailbox */
+  struct MailboxList mailboxes;     /* Previous selected mailbox */
 };
 
 /**
@@ -228,6 +230,8 @@ struct ImapMboxData
   char *name;        /**< Mailbox name */
   char *munge_name;  /**< Munged version of the mailbox name */
   char *real_name;   /**< Original Mailbox name, e.g.: INBOX can be just \0 */
+
+  struct Context *ctx;
 
   unsigned char reopen;        /**< Flags, e.g. #IMAP_REOPEN_ALLOW */
   unsigned short check_status; /**< Flags, e.g. #IMAP_NEWMAIL_PENDING */

--- a/imap/util.c
+++ b/imap/util.c
@@ -103,7 +103,7 @@ struct ImapAccountData *imap_adata_new(void)
   adata->cmdbuf = mutt_buffer_new();
   adata->cmdslots = ImapPipelineDepth + 2;
   adata->cmds = mutt_mem_calloc(adata->cmdslots, sizeof(*adata->cmds));
-
+  STAILQ_INIT(&adata->mailboxes);
   return adata;
 }
 


### PR DESCRIPTION
imap: make imap_mbox_open reentrant once.
imap: split imap_mbox_open code

Edit @gahr - I took the liberty to copy the explanation from the second commit:

While we have opened a mailbox, we press 'm' to callback a postponed
message. Neomutt open a view with all postponed messages (with
imap_mbox_open without APPEND flag).

This changes the current select folder on imap server and neomutt never
select back the original folder, letting neomutt into a weird state.

this change update imap_mobx_open/close to become reentrant once to
support the postponed messages use case.

Now when we close the postponed mailbox, we select back the previous
opened mailbox.

Closes #1425