### PR TITLE
Use Mailbox instead of Context for  mutt_set_flags

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -103,7 +103,7 @@ int mutt_display_message(struct Email *cur)
 
   snprintf(buf, sizeof(buf), "%s/%s", TYPE(cur->content), cur->content->subtype);
 
-  mutt_parse_mime_message(Context, cur);
+  mutt_parse_mime_message(Context->mailbox, cur);
   mutt_message_hook(Context, cur, MUTT_MESSAGE_HOOK);
 
   /* see if crypto is needed for this message.  if so, we should exit curses */
@@ -262,7 +262,7 @@ int mutt_display_message(struct Email *cur)
     if (!OptNoCurses)
       keypad(stdscr, true);
     if (r != -1)
-      mutt_set_flag(Context, cur, MUTT_READ, 1);
+      mutt_set_flag(Context->mailbox, cur, MUTT_READ, 1);
     if (r != -1 && PromptAfter)
     {
       mutt_unget_event(mutt_any_key_to_continue(_("Command: ")), 0);
@@ -424,7 +424,7 @@ static void pipe_msg(struct Email *e, FILE *fp, bool decode, bool print)
   }
 
   if (decode)
-    mutt_parse_mime_message(Context, e);
+    mutt_parse_mime_message(Context->mailbox, e);
 
   mutt_copy_message_ctx(fp, Context, e, cmflags, chflags);
 }
@@ -455,7 +455,7 @@ static int pipe_message(struct Email *e, char *cmd, bool decode, bool print,
 
     if ((WithCrypto != 0) && decode)
     {
-      mutt_parse_mime_message(Context, e);
+      mutt_parse_mime_message(Context->mailbox, e);
       if (e->security & ENCRYPT && !crypt_valid_passphrase(e->security))
         return 1;
     }
@@ -485,7 +485,7 @@ static int pipe_message(struct Email *e, char *cmd, bool decode, bool print,
           continue;
 
         mutt_message_hook(Context, Context->mailbox->hdrs[i], MUTT_MESSAGE_HOOK);
-        mutt_parse_mime_message(Context, Context->mailbox->hdrs[i]);
+        mutt_parse_mime_message(Context->mailbox, Context->mailbox->hdrs[i]);
         if (Context->mailbox->hdrs[i]->security & ENCRYPT &&
             !crypt_valid_passphrase(Context->mailbox->hdrs[i]->security))
         {
@@ -844,7 +844,7 @@ int mutt_save_message_ctx(struct Email *e, bool delete, bool decode,
   set_copy_flags(e, decode, decrypt, &cmflags, &chflags);
 
   if (decode || decrypt)
-    mutt_parse_mime_message(Context, e);
+    mutt_parse_mime_message(Context->mailbox, e);
 
   rc = mutt_append_message(ctx, Context, e, cmflags, chflags);
   if (rc != 0)
@@ -852,10 +852,10 @@ int mutt_save_message_ctx(struct Email *e, bool delete, bool decode,
 
   if (delete)
   {
-    mutt_set_flag(Context, e, MUTT_DELETE, 1);
-    mutt_set_flag(Context, e, MUTT_PURGE, 1);
+    mutt_set_flag(Context->mailbox, e, MUTT_DELETE, 1);
+    mutt_set_flag(Context->mailbox, e, MUTT_PURGE, 1);
     if (DeleteUntag)
-      mutt_set_flag(Context, e, MUTT_TAG, 0);
+      mutt_set_flag(Context->mailbox, e, MUTT_TAG, 0);
   }
 
   return 0;
@@ -1203,8 +1203,8 @@ static bool check_traditional_pgp(struct Email *e, int *redraw)
 
   e->security |= PGP_TRADITIONAL_CHECKED;
 
-  mutt_parse_mime_message(Context, e);
-  struct Message *msg = mx_msg_open(Context, e->msgno);
+  mutt_parse_mime_message(Context->mailbox, e);
+  struct Message *msg = mx_msg_open(Context->mailbox, e->msgno);
   if (!msg)
     return 0;
   if (crypt_pgp_check_traditional(msg->fp, e->content, false))
@@ -1215,7 +1215,7 @@ static bool check_traditional_pgp(struct Email *e, int *redraw)
   }
 
   e->security |= PGP_TRADITIONAL_CHECKED;
-  mx_msg_close(Context, &msg);
+  mx_msg_close(Context->mailbox, &msg);
   return rc;
 }
 

--- a/compress.c
+++ b/compress.c
@@ -801,37 +801,37 @@ static int comp_mbox_close(struct Context *ctx)
 /**
  * comp_msg_open - Implements MxOps::msg_open()
  */
-static int comp_msg_open(struct Context *ctx, struct Message *msg, int msgno)
+static int comp_msg_open(struct Mailbox *m, struct Message *msg, int msgno)
 {
-  if (!ctx || !ctx->mailbox || !ctx->mailbox->compress_info)
+  if (!m || !m->compress_info)
     return -1;
 
-  struct CompressInfo *ci = ctx->mailbox->compress_info;
+  struct CompressInfo *ci = m->compress_info;
 
   const struct MxOps *ops = ci->child_ops;
   if (!ops)
     return -1;
 
   /* Delegate */
-  return ops->msg_open(ctx, msg, msgno);
+  return ops->msg_open(m, msg, msgno);
 }
 
 /**
  * comp_msg_open_new - Implements MxOps::msg_open_new()
  */
-static int comp_msg_open_new(struct Context *ctx, struct Message *msg, struct Email *e)
+static int comp_msg_open_new(struct Mailbox *m, struct Message *msg, struct Email *e)
 {
-  if (!ctx || !ctx->mailbox || !ctx->mailbox->compress_info)
+  if (!m || !m->compress_info)
     return -1;
 
-  struct CompressInfo *ci = ctx->mailbox->compress_info;
+  struct CompressInfo *ci = m->compress_info;
 
   const struct MxOps *ops = ci->child_ops;
   if (!ops)
     return -1;
 
   /* Delegate */
-  return ops->msg_open_new(ctx, msg, e);
+  return ops->msg_open_new(m, msg, e);
 }
 
 /**

--- a/context.h
+++ b/context.h
@@ -41,7 +41,6 @@ struct Context
   struct Email *last_tag;  /**< last tagged msg. used to link threads */
   struct MuttThread *tree;  /**< top of thread tree */
   struct Hash *thread_hash; /**< hash table for threading */
-  int tagged;               /**< how many messages are tagged? */
   int msgnotreadyet;        /**< which msg "new" in pager, -1 if none */
 
   struct Menu *menu; /**< needed for pattern compilation */

--- a/copy.c
+++ b/copy.c
@@ -792,7 +792,7 @@ int mutt_copy_message_fp(FILE *fpout, FILE *fpin, struct Email *e, int flags, in
 int mutt_copy_message_ctx(FILE *fpout, struct Context *src, struct Email *e,
                           int flags, int chflags)
 {
-  struct Message *msg = mx_msg_open(src, e->msgno);
+  struct Message *msg = mx_msg_open(src->mailbox, e->msgno);
   if (!msg)
     return -1;
   if (!e->content)
@@ -803,7 +803,7 @@ int mutt_copy_message_ctx(FILE *fpout, struct Context *src, struct Email *e,
     mutt_debug(1, "failed to detect EOF!\n");
     r = -1;
   }
-  mx_msg_close(src, &msg);
+  mx_msg_close(src->mailbox, &msg);
   return r;
 }
 
@@ -830,7 +830,7 @@ static int append_message(struct Context *dest, FILE *fpin, struct Context *src,
   if (!fgets(buf, sizeof(buf), fpin))
     return -1;
 
-  msg = mx_msg_open_new(dest, e, is_from(buf, NULL, 0, NULL) ? 0 : MUTT_ADD_FROM);
+  msg = mx_msg_open_new(dest->mailbox, e, is_from(buf, NULL, 0, NULL) ? 0 : MUTT_ADD_FROM);
   if (!msg)
     return -1;
   if (dest->mailbox->magic == MUTT_MBOX || dest->mailbox->magic == MUTT_MMDF)
@@ -846,7 +846,7 @@ static int append_message(struct Context *dest, FILE *fpin, struct Context *src,
     nm_update_filename(src->mailbox, NULL, msg->committed_path, e);
 #endif
 
-  mx_msg_close(dest, &msg);
+  mx_msg_close(dest->mailbox, &msg);
   return r;
 }
 
@@ -863,11 +863,11 @@ static int append_message(struct Context *dest, FILE *fpin, struct Context *src,
 int mutt_append_message(struct Context *dest, struct Context *src,
                         struct Email *e, int cmflags, int chflags)
 {
-  struct Message *msg = mx_msg_open(src, e->msgno);
+  struct Message *msg = mx_msg_open(src->mailbox, e->msgno);
   if (!msg)
     return -1;
   int r = append_message(dest, msg->fp, src, e, cmflags, chflags);
-  mx_msg_close(src, &msg);
+  mx_msg_close(src->mailbox, &msg);
   return r;
 }
 

--- a/editmsg.c
+++ b/editmsg.c
@@ -215,7 +215,7 @@ static int edit_or_view_one_message(bool edit, struct Context *ctx, struct Email
   o_old = cur->old;
   cur->read = false;
   cur->old = false;
-  msg = mx_msg_open_new(tmpctx, cur, of);
+  msg = mx_msg_open_new(tmpctx->mailbox, cur, of);
   cur->read = o_read;
   cur->old = o_old;
 
@@ -234,7 +234,7 @@ static int edit_or_view_one_message(bool edit, struct Context *ctx, struct Email
   }
 
   rc = mx_msg_commit(tmpctx, msg);
-  mx_msg_close(tmpctx, &msg);
+  mx_msg_close(tmpctx->mailbox, &msg);
 
   mx_mbox_close(&tmpctx, NULL);
 
@@ -247,12 +247,12 @@ bail:
 
   if (rc == 0)
   {
-    mutt_set_flag(Context, cur, MUTT_DELETE, 1);
-    mutt_set_flag(Context, cur, MUTT_PURGE, 1);
-    mutt_set_flag(Context, cur, MUTT_READ, 1);
+    mutt_set_flag(Context->mailbox, cur, MUTT_DELETE, 1);
+    mutt_set_flag(Context->mailbox, cur, MUTT_PURGE, 1);
+    mutt_set_flag(Context->mailbox, cur, MUTT_READ, 1);
 
     if (DeleteUntag)
-      mutt_set_flag(Context, cur, MUTT_TAG, 0);
+      mutt_set_flag(Context->mailbox, cur, MUTT_TAG, 0);
   }
   else if (rc == -1)
     mutt_message(_("Error. Preserving temporary file: %s"), tmp);

--- a/flags.c
+++ b/flags.c
@@ -62,7 +62,7 @@ void mutt_set_flag_update(struct Context *ctx, struct Email *e, int flag, bool b
 
   bool changed = e->changed;
   int deleted = m->msg_deleted;
-  int tagged = ctx->tagged;
+  int tagged = m->msg_tagged;
   int flagged = m->msg_flagged;
   int update = false;
 
@@ -317,7 +317,7 @@ void mutt_set_flag_update(struct Context *ctx, struct Email *e, int flag, bool b
           update = true;
           e->tagged = true;
           if (upd_ctx)
-            ctx->tagged++;
+            m->msg_tagged++;
         }
       }
       else if (e->tagged)
@@ -325,7 +325,7 @@ void mutt_set_flag_update(struct Context *ctx, struct Email *e, int flag, bool b
         update = true;
         e->tagged = false;
         if (upd_ctx)
-          ctx->tagged--;
+          m->msg_tagged--;
       }
       break;
   }
@@ -343,7 +343,7 @@ void mutt_set_flag_update(struct Context *ctx, struct Email *e, int flag, bool b
    * of this message and not what it was at the time it was last searched.
    */
   if (e->searched && (changed != e->changed || deleted != m->msg_deleted ||
-                      tagged != ctx->tagged || flagged != m->msg_flagged))
+                      tagged != m->msg_tagged || flagged != m->msg_flagged))
   {
     e->searched = false;
   }

--- a/hdrline.c
+++ b/hdrline.c
@@ -1222,7 +1222,7 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
 
     case 'X':
     {
-      int count = mutt_count_body_parts(ctx, e);
+      int count = mutt_count_body_parts(ctx->mailbox, e);
 
       /* The recursion allows messages without depth to return 0. */
       if (optional)

--- a/hook.c
+++ b/hook.c
@@ -35,6 +35,7 @@
 #include <unistd.h>
 #include "mutt/mutt.h"
 #include "email/lib.h"
+#include "context.h"
 #include "mutt.h"
 #include "hook.h"
 #include "alias.h"
@@ -453,7 +454,7 @@ void mutt_message_hook(struct Context *ctx, struct Email *e, int type)
 
     if (hook->type & type)
     {
-      if ((mutt_pattern_exec(hook->pattern, 0, ctx, e, &cache) > 0) ^
+      if ((mutt_pattern_exec(hook->pattern, 0, ctx->mailbox, e, &cache) > 0) ^
           hook->regex.not)
       {
         if (mutt_parse_rc_line(hook->command, &token, &err) == -1)
@@ -501,7 +502,7 @@ static int addr_hook(char *path, size_t pathlen, int type, struct Context *ctx,
 
     if (hook->type & type)
     {
-      if ((mutt_pattern_exec(hook->pattern, 0, ctx, e, &cache) > 0) ^
+      if ((mutt_pattern_exec(hook->pattern, 0, ctx->mailbox, e, &cache) > 0) ^
           hook->regex.not)
       {
         mutt_make_string_flags(path, pathlen, hook->command, ctx, e, MUTT_FORMAT_PLAIN);

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -2317,7 +2317,7 @@ static int imap_mbox_close(struct Context *ctx)
 /**
  * imap_msg_open_new - Implements MxOps::msg_open_new()
  */
-static int imap_msg_open_new(struct Context *ctx, struct Message *msg, struct Email *e)
+static int imap_msg_open_new(struct Mailbox *m, struct Message *msg, struct Email *e)
 {
   char tmp[PATH_MAX];
 

--- a/imap/imap_private.h
+++ b/imap/imap_private.h
@@ -319,7 +319,7 @@ int imap_cache_del(struct ImapAccountData *adata, struct Email *e);
 int imap_cache_clean(struct ImapAccountData *adata);
 int imap_append_message(struct Mailbox *m, struct Message *msg);
 
-int imap_msg_open(struct Context *ctx, struct Message *msg, int msgno);
+int imap_msg_open(struct Mailbox *m, struct Message *msg, int msgno);
 int imap_msg_close(struct Mailbox *m, struct Message *msg);
 int imap_msg_commit(struct Mailbox *m, struct Message *msg);
 

--- a/index.c
+++ b/index.c
@@ -1197,13 +1197,13 @@ int mutt_index_menu(void)
           continue;
         }
 
-        if (!Context)
+        if (!Context || !Context->mailbox)
         {
           mutt_error(_("No mailbox is open"));
           continue;
         }
 
-        if (!Context->tagged)
+        if (!Context->mailbox->msg_tagged)
         {
           if (op == OP_TAG_PREFIX)
             mutt_error(_("No tagged messages"));
@@ -1219,7 +1219,7 @@ int mutt_index_menu(void)
         tag = true;
         continue;
       }
-      else if (AutoTag && Context && Context->tagged)
+      else if (AutoTag && Context && Context->mailbox && Context->mailbox->msg_tagged)
         tag = true;
 
       mutt_clear_error();
@@ -1991,7 +1991,7 @@ int mutt_index_menu(void)
           {
             char msgbuf[STRING];
             snprintf(msgbuf, sizeof(msgbuf), _("Update tags..."));
-            mutt_progress_init(&progress, msgbuf, MUTT_PROGRESS_MSG, 1, Context->tagged);
+            mutt_progress_init(&progress, msgbuf, MUTT_PROGRESS_MSG, 1, Context->mailbox->msg_tagged);
           }
 
 #ifdef USE_NOTMUCH

--- a/index.h
+++ b/index.h
@@ -28,6 +28,7 @@
 
 struct Context;
 struct Email;
+struct Mailbox;
 struct Menu;
 
 /* These Config Variables are only used in index.c */
@@ -44,7 +45,7 @@ int  index_color(int line);
 void index_make_entry(char *buf, size_t buflen, struct Menu *menu, int line);
 void mutt_draw_statusline(int cols, const char *buf, size_t buflen);
 int  mutt_index_menu(void);
-void mutt_set_header_color(struct Context *ctx, struct Email *curhdr);
+void mutt_set_header_color(struct Mailbox *m, struct Email *curhdr);
 void update_index(struct Menu *menu, struct Context *ctx, int check, int oldcount, int index_hint);
 
 #endif /* MUTT_INDEX_H */

--- a/mailbox.h
+++ b/mailbox.h
@@ -89,6 +89,7 @@ struct Mailbox
   int msg_flagged;           /**< number of flagged messages */
   int msg_new;               /**< number of new messages */
   int msg_deleted;           /**< number of deleted messages */
+  int msg_tagged;            /**< how many messages are tagged? */
 
   struct Email **hdrs;
   int hdrmax;               /**< number of pointers in hdrs */

--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -720,14 +720,14 @@ static int reopen_mailbox(struct Context *ctx, int *index_hint)
            * otherwise, the header may have been modified externally,
            * and we don't want to lose _those_ changes
            */
-          mutt_set_flag(ctx, m->hdrs[i], MUTT_FLAG, old_hdrs[j]->flagged);
-          mutt_set_flag(ctx, m->hdrs[i], MUTT_REPLIED, old_hdrs[j]->replied);
-          mutt_set_flag(ctx, m->hdrs[i], MUTT_OLD, old_hdrs[j]->old);
-          mutt_set_flag(ctx, m->hdrs[i], MUTT_READ, old_hdrs[j]->read);
+          mutt_set_flag(m, m->hdrs[i], MUTT_FLAG, old_hdrs[j]->flagged);
+          mutt_set_flag(m, m->hdrs[i], MUTT_REPLIED, old_hdrs[j]->replied);
+          mutt_set_flag(m, m->hdrs[i], MUTT_OLD, old_hdrs[j]->old);
+          mutt_set_flag(m, m->hdrs[i], MUTT_READ, old_hdrs[j]->read);
         }
-        mutt_set_flag(ctx, m->hdrs[i], MUTT_DELETE, old_hdrs[j]->deleted);
-        mutt_set_flag(ctx, m->hdrs[i], MUTT_PURGE, old_hdrs[j]->purge);
-        mutt_set_flag(ctx, m->hdrs[i], MUTT_TAG, old_hdrs[j]->tagged);
+        mutt_set_flag(m, m->hdrs[i], MUTT_DELETE, old_hdrs[j]->deleted);
+        mutt_set_flag(m, m->hdrs[i], MUTT_PURGE, old_hdrs[j]->purge);
+        mutt_set_flag(m, m->hdrs[i], MUTT_TAG, old_hdrs[j]->tagged);
 
         /* we don't need this header any more */
         mutt_email_free(&(old_hdrs[j]));
@@ -1571,12 +1571,10 @@ static int mbox_mbox_close(struct Context *ctx)
 /**
  * mbox_msg_open - Implements MxOps::msg_open()
  */
-static int mbox_msg_open(struct Context *ctx, struct Message *msg, int msgno)
+static int mbox_msg_open(struct Mailbox *m, struct Message *msg, int msgno)
 {
-  if (!ctx || !ctx->mailbox)
+  if (!m)
     return -1;
-
-  struct Mailbox *m = ctx->mailbox;
 
   struct MboxAccountData *adata = mbox_adata_get(m);
   if (!adata)
@@ -1590,12 +1588,10 @@ static int mbox_msg_open(struct Context *ctx, struct Message *msg, int msgno)
 /**
  * mbox_msg_open_new - Implements MxOps::msg_open_new()
  */
-static int mbox_msg_open_new(struct Context *ctx, struct Message *msg, struct Email *e)
+static int mbox_msg_open_new(struct Mailbox *m, struct Message *msg, struct Email *e)
 {
-  if (!ctx || !ctx->mailbox)
+  if (!m)
     return -1;
-
-  struct Mailbox *m = ctx->mailbox;
 
   struct MboxAccountData *adata = mbox_adata_get(m);
   if (!adata)

--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -626,7 +626,7 @@ static int reopen_mailbox(struct Context *ctx, int *index_hint)
   m->msg_count = 0;
   m->vcount = 0;
   ctx->vsize = 0;
-  ctx->tagged = 0;
+  m->msg_tagged = 0;
   m->msg_deleted = 0;
   m->msg_new = 0;
   m->msg_unread = 0;

--- a/menu.c
+++ b/menu.c
@@ -112,7 +112,7 @@ static int get_color(int index, unsigned char *s)
 
   STAILQ_FOREACH(np, color, entries)
   {
-    if (mutt_pattern_exec(np->color_pattern, MUTT_MATCH_FULL_ADDRESS, Context, e, NULL))
+    if (mutt_pattern_exec(np->color_pattern, MUTT_MATCH_FULL_ADDRESS, Context->mailbox, e, NULL))
       return np->pair;
   }
 

--- a/mutt_attach.c
+++ b/mutt_attach.c
@@ -812,7 +812,7 @@ int mutt_save_attachment(FILE *fp, struct Body *m, char *path, int flags, struct
       struct Context *ctx = mx_mbox_open(NULL, path, MUTT_APPEND | MUTT_QUIET);
       if (!ctx)
         return -1;
-      msg = mx_msg_open_new(ctx, en, is_from(buf, NULL, 0, NULL) ? 0 : MUTT_ADD_FROM);
+      msg = mx_msg_open_new(ctx->mailbox, en, is_from(buf, NULL, 0, NULL) ? 0 : MUTT_ADD_FROM);
       if (!msg)
       {
         mx_mbox_close(&ctx, NULL);
@@ -831,7 +831,7 @@ int mutt_save_attachment(FILE *fp, struct Body *m, char *path, int flags, struct
         r = -1;
       }
 
-      mx_msg_close(ctx, &msg);
+      mx_msg_close(ctx->mailbox, &msg);
       mx_mbox_close(&ctx, NULL);
       return r;
     }

--- a/mutt_header.c
+++ b/mutt_header.c
@@ -146,7 +146,7 @@ int mutt_label_message(struct Email *e)
     if (label_message(Context->mailbox, e, new))
     {
       changed++;
-      mutt_set_header_color(Context, e);
+      mutt_set_header_color(Context->mailbox, e);
     }
   }
   else
@@ -160,7 +160,7 @@ int mutt_label_message(struct Email *e)
       if (label_message(Context->mailbox, e2, new))
       {
         changed++;
-        mutt_set_flag(Context, e2, MUTT_TAG, 0);
+        mutt_set_flag(Context->mailbox, e2, MUTT_TAG, 0);
         /* mutt_set_flag re-evals the header color */
       }
     }

--- a/mutt_parse.c
+++ b/mutt_parse.c
@@ -38,10 +38,10 @@ struct Context;
 
 /**
  * mutt_parse_mime_message - Parse a MIME email
- * @param ctx Mailbox
+ * @param m   Mailbox
  * @param cur Email
  */
-void mutt_parse_mime_message(struct Context *ctx, struct Email *cur)
+void mutt_parse_mime_message(struct Mailbox *m, struct Email *cur)
 {
   struct Message *msg = NULL;
 
@@ -53,7 +53,7 @@ void mutt_parse_mime_message(struct Context *ctx, struct Email *cur)
     if (cur->content->parts)
       break; /* The message was parsed earlier. */
 
-    msg = mx_msg_open(ctx, cur->msgno);
+    msg = mx_msg_open(m, cur->msgno);
     if (msg)
     {
       mutt_parse_part(msg->fp, cur->content);
@@ -61,7 +61,7 @@ void mutt_parse_mime_message(struct Context *ctx, struct Email *cur)
       if (WithCrypto)
         cur->security = crypt_query(cur->content);
 
-      mx_msg_close(ctx, &msg);
+      mx_msg_close(m, &msg);
     }
   } while (false);
 
@@ -211,7 +211,7 @@ static int count_body_parts(struct Body *body, int flags)
  * @param e Email
  * @retval num Number of MIME Body parts
  */
-int mutt_count_body_parts(struct Context *ctx, struct Email *e)
+int mutt_count_body_parts(struct Mailbox *m, struct Email *e)
 {
   bool keep_parts = false;
 
@@ -221,7 +221,7 @@ int mutt_count_body_parts(struct Context *ctx, struct Email *e)
   if (e->content->parts)
     keep_parts = true;
   else
-    mutt_parse_mime_message(ctx, e);
+    mutt_parse_mime_message(m, e);
 
   if (!STAILQ_EMPTY(&AttachAllow) || !STAILQ_EMPTY(&AttachExclude) ||
       !STAILQ_EMPTY(&InlineAllow) || !STAILQ_EMPTY(&InlineExclude))

--- a/mutt_parse.h
+++ b/mutt_parse.h
@@ -25,8 +25,9 @@
 
 struct Context;
 struct Email;
+struct Mailbox;
 
-int  mutt_count_body_parts(struct Context *ctx, struct Email *e);
-void mutt_parse_mime_message(struct Context *ctx, struct Email *cur);
+int  mutt_count_body_parts(struct Mailbox *m, struct Email *e);
+void mutt_parse_mime_message(struct Mailbox *m, struct Email *cur);
 
 #endif /* MUTT_MUTT_PARSE_H */

--- a/mutt_thread.c
+++ b/mutt_thread.c
@@ -1466,7 +1466,7 @@ static bool link_threads(struct Email *parent, struct Email *child, struct Conte
 
   mutt_break_thread(child);
   mutt_list_insert_head(&child->env->in_reply_to, mutt_str_strdup(parent->env->message_id));
-  mutt_set_flag(ctx, child, MUTT_TAG, 0);
+  mutt_set_flag(ctx->mailbox, child, MUTT_TAG, 0);
 
   child->env->irt_changed = true;
   child->changed = true;

--- a/mx.c
+++ b/mx.c
@@ -824,7 +824,7 @@ void mx_update_tables(struct Context *ctx, bool committing)
   /* update memory to reflect the new state of the mailbox */
   m->vcount = 0;
   ctx->vsize = 0;
-  ctx->tagged = 0;
+  m->msg_tagged = 0;
   m->msg_deleted = 0;
   m->msg_new = 0;
   m->msg_unread = 0;
@@ -863,7 +863,7 @@ void mx_update_tables(struct Context *ctx, bool committing)
       }
 
       if (m->hdrs[j]->tagged)
-        ctx->tagged++;
+        m->msg_tagged++;
       if (m->hdrs[j]->flagged)
         m->msg_flagged++;
       if (!m->hdrs[j]->read)

--- a/mx.h
+++ b/mx.h
@@ -158,22 +158,22 @@ struct MxOps
   int (*mbox_close)      (struct Context *ctx);
   /**
    * msg_open - Open an email message in mailbox
-   * @param ctx   Mailbox
+   * @param m     Mailbox
    * @param msg   Message to open
    * @param msgno Index of message to open
    * @retval  0 Success
    * @retval -1 Error
    */
-  int (*msg_open)        (struct Context *ctx, struct Message *msg, int msgno);
+  int (*msg_open)        (struct Mailbox *m, struct Message *msg, int msgno);
   /**
    * msg_open_new - Open a new message in a mailbox
-   * @param ctx Mailbox
+   * @param m   Mailbox
    * @param msg Message to open
    * @param e   Email
    * @retval  0 Success
    * @retval -1 Failure
    */
-  int (*msg_open_new)    (struct Context *ctx, struct Message *msg, struct Email *e);
+  int (*msg_open_new)    (struct Mailbox *m, struct Message *msg, struct Email *e);
   /**
    * msg_commit - Save changes to an email
    * @param m   Mailbox
@@ -255,10 +255,10 @@ int             mx_mbox_check      (struct Context *ctx, int *index_hint);
 int             mx_mbox_close      (struct Context **pctx, int *index_hint);
 struct Context *mx_mbox_open       (struct Mailbox *m, const char *path, int flags);
 int             mx_mbox_sync       (struct Context *ctx, int *index_hint);
-int             mx_msg_close       (struct Context *ctx, struct Message **msg);
+int             mx_msg_close       (struct Mailbox *m, struct Message **msg);
 int             mx_msg_commit      (struct Context *ctx, struct Message *msg);
-struct Message *mx_msg_open_new    (struct Context *ctx, struct Email *e, int flags);
-struct Message *mx_msg_open        (struct Context *ctx, int msgno);
+struct Message *mx_msg_open_new    (struct Mailbox *m, struct Email *e, int flags);
+struct Message *mx_msg_open        (struct Mailbox *m, int msgno);
 int             mx_msg_padding_size(struct Context *ctx);
 int             mx_path_canon      (char *buf, size_t buflen, const char *folder, int *magic);
 int             mx_path_canon2     (struct Mailbox *m, const char *folder);

--- a/ncrypt/crypt.c
+++ b/ncrypt/crypt.c
@@ -834,7 +834,7 @@ void crypt_extract_keys_from_messages(struct Email *e)
 
       struct Email *ei = Context->mailbox->hdrs[i];
 
-      mutt_parse_mime_message(Context, ei);
+      mutt_parse_mime_message(Context->mailbox, ei);
       if (ei->security & ENCRYPT && !crypt_valid_passphrase(ei->security))
       {
         mutt_file_fclose(&fpout);
@@ -882,7 +882,7 @@ void crypt_extract_keys_from_messages(struct Email *e)
   }
   else
   {
-    mutt_parse_mime_message(Context, e);
+    mutt_parse_mime_message(Context->mailbox, e);
     if (!(e->security & ENCRYPT && !crypt_valid_passphrase(e->security)))
     {
       if (((WithCrypto & APPLICATION_PGP) != 0) && (e->security & APPLICATION_PGP))

--- a/nntp/newsrc.c
+++ b/nntp/newsrc.c
@@ -1307,7 +1307,7 @@ struct NntpMboxData *mutt_newsgroup_catchup(struct Context *ctx,
   if (m && (m->mdata == mdata))
   {
     for (unsigned int i = 0; i < m->msg_count; i++)
-      mutt_set_flag(ctx, m->hdrs[i], MUTT_READ, 1);
+      mutt_set_flag(m, m->hdrs[i], MUTT_READ, 1);
   }
   return mdata;
 }
@@ -1344,7 +1344,7 @@ struct NntpMboxData *mutt_newsgroup_uncatchup(struct Context *ctx,
   {
     mdata->unread = m->msg_count;
     for (unsigned int i = 0; i < m->msg_count; i++)
-      mutt_set_flag(ctx, m->hdrs[i], MUTT_READ, 0);
+      mutt_set_flag(m, m->hdrs[i], MUTT_READ, 0);
   }
   else
   {

--- a/nntp/nntp.c
+++ b/nntp/nntp.c
@@ -1565,7 +1565,7 @@ static int check_mailbox(struct Context *ctx)
     for (int i = 0; i < m->msg_count; i++)
       mutt_email_free(&m->hdrs[i]);
     m->msg_count = 0;
-    ctx->tagged = 0;
+    m->msg_tagged = 0;
 
     if (mdata->last_message < mdata->last_loaded)
     {

--- a/nntp/nntp.c
+++ b/nntp/nntp.c
@@ -1625,7 +1625,7 @@ static int check_mailbox(struct Context *ctx)
           /* header marked as deleted, removing from context */
           if (deleted)
           {
-            mutt_set_flag(ctx, m->hdrs[i], MUTT_TAG, 0);
+            mutt_set_flag(m, m->hdrs[i], MUTT_TAG, 0);
             mutt_email_free(&m->hdrs[i]);
             continue;
           }
@@ -2721,12 +2721,10 @@ static int nntp_mbox_close(struct Context *ctx)
 /**
  * nntp_msg_open - Implements MxOps::msg_open()
  */
-static int nntp_msg_open(struct Context *ctx, struct Message *msg, int msgno)
+static int nntp_msg_open(struct Mailbox *m, struct Message *msg, int msgno)
 {
-  if (!ctx || !ctx->mailbox || !ctx->mailbox->hdrs || !msg)
+  if (!m || !m->hdrs || !msg)
     return -1;
-
-  struct Mailbox *m = ctx->mailbox;
 
   struct NntpMboxData *mdata = m->mdata;
   struct Email *e = m->hdrs[msgno];
@@ -2835,7 +2833,7 @@ static int nntp_msg_open(struct Context *ctx, struct Message *msg, int msgno)
    * which is probably wrong, but we just call it again here to handle
    * the problem instead of fixing it */
   nntp_edata_get(e)->parsed = true;
-  mutt_parse_mime_message(ctx, e);
+  mutt_parse_mime_message(m, e);
 
   /* these would normally be updated in mx_update_context(), but the
    * full headers aren't parsed with overview, so the information wasn't

--- a/notmuch/mutt_notmuch.c
+++ b/notmuch/mutt_notmuch.c
@@ -1290,21 +1290,21 @@ static int update_email_flags(struct Context *ctx, struct Email *e, const char *
     {
       tag = tag + 1;
       if (strcmp(tag, NmUnreadTag) == 0)
-        mutt_set_flag(ctx, e, MUTT_READ, 1);
+        mutt_set_flag(ctx->mailbox, e, MUTT_READ, 1);
       else if (strcmp(tag, NmRepliedTag) == 0)
-        mutt_set_flag(ctx, e, MUTT_REPLIED, 0);
+        mutt_set_flag(ctx->mailbox, e, MUTT_REPLIED, 0);
       else if (strcmp(tag, NmFlaggedTag) == 0)
-        mutt_set_flag(ctx, e, MUTT_FLAG, 0);
+        mutt_set_flag(ctx->mailbox, e, MUTT_FLAG, 0);
     }
     else
     {
       tag = (*tag == '+') ? tag + 1 : tag;
       if (strcmp(tag, NmUnreadTag) == 0)
-        mutt_set_flag(ctx, e, MUTT_READ, 0);
+        mutt_set_flag(ctx->mailbox, e, MUTT_READ, 0);
       else if (strcmp(tag, NmRepliedTag) == 0)
-        mutt_set_flag(ctx, e, MUTT_REPLIED, 1);
+        mutt_set_flag(ctx->mailbox, e, MUTT_REPLIED, 1);
       else if (strcmp(tag, NmFlaggedTag) == 0)
-        mutt_set_flag(ctx, e, MUTT_FLAG, 1);
+        mutt_set_flag(ctx->mailbox, e, MUTT_FLAG, 1);
     }
     end = NULL;
     tag = NULL;
@@ -2424,12 +2424,10 @@ static int nm_mbox_close(struct Context *ctx)
 /**
  * nm_msg_open - Implements MxOps::msg_open()
  */
-static int nm_msg_open(struct Context *ctx, struct Message *msg, int msgno)
+static int nm_msg_open(struct Mailbox *m, struct Message *msg, int msgno)
 {
-  if (!ctx || !ctx->mailbox || !ctx->mailbox->hdrs || !msg)
+  if (!m || !m->hdrs || !msg)
     return -1;
-
-  struct Mailbox *m = ctx->mailbox;
 
   struct Email *e = m->hdrs[msgno];
   char path[PATH_MAX];
@@ -2508,7 +2506,7 @@ static int nm_tags_commit(struct Context *ctx, struct Email *e, char *buf)
   update_tags(msg, buf);
   update_email_flags(ctx, e, buf);
   update_email_tags(e, msg);
-  mutt_set_header_color(ctx, e);
+  mutt_set_header_color(m, e);
 
   rc = 0;
   e->changed = true;

--- a/pager.c
+++ b/pager.c
@@ -2250,7 +2250,7 @@ int mutt_pager(const char *banner, const char *fname, int flags, struct Pager *e
   if (Context && IsHeader(extra) && !extra->email->read)
   {
     Context->msgnotreadyet = extra->email->msgno;
-    mutt_set_flag(Context, extra->email, MUTT_READ, 1);
+    mutt_set_flag(Context->mailbox, extra->email, MUTT_READ, 1);
   }
 
   rd.max_line = LINES; /* number of lines on screen, from curses */
@@ -2942,10 +2942,10 @@ int mutt_pager(const char *banner, const char *fname, int flags, struct Pager *e
         /* L10N: CHECK_ACL */
         CHECK_ACL(MUTT_ACL_DELETE, _("Cannot delete message"));
 
-        mutt_set_flag(Context, extra->email, MUTT_DELETE, 1);
-        mutt_set_flag(Context, extra->email, MUTT_PURGE, (ch == OP_PURGE_MESSAGE));
+        mutt_set_flag(Context->mailbox, extra->email, MUTT_DELETE, 1);
+        mutt_set_flag(Context->mailbox, extra->email, MUTT_PURGE, (ch == OP_PURGE_MESSAGE));
         if (DeleteUntag)
-          mutt_set_flag(Context, extra->email, MUTT_TAG, 0);
+          mutt_set_flag(Context->mailbox, extra->email, MUTT_TAG, 0);
         pager_menu->redraw |= REDRAW_STATUS | REDRAW_INDEX;
         if (Resolve)
         {
@@ -3050,7 +3050,7 @@ int mutt_pager(const char *banner, const char *fname, int flags, struct Pager *e
         /* L10N: CHECK_ACL */
         CHECK_ACL(MUTT_ACL_WRITE, "Cannot flag message");
 
-        mutt_set_flag(Context, extra->email, MUTT_FLAG, !extra->email->flagged);
+        mutt_set_flag(Context->mailbox, extra->email, MUTT_FLAG, !extra->email->flagged);
         pager_menu->redraw |= REDRAW_STATUS | REDRAW_INDEX;
         if (Resolve)
         {
@@ -3250,7 +3250,7 @@ int mutt_pager(const char *banner, const char *fname, int flags, struct Pager *e
         CHECK_MODE(IsHeader(extra));
         if (Context)
         {
-          mutt_set_flag(Context, extra->email, MUTT_TAG, !extra->email->tagged);
+          mutt_set_flag(Context->mailbox, extra->email, MUTT_TAG, !extra->email->tagged);
 
           Context->last_tag =
               extra->email->tagged ?
@@ -3275,9 +3275,9 @@ int mutt_pager(const char *banner, const char *fname, int flags, struct Pager *e
         CHECK_ACL(MUTT_ACL_SEEN, _("Cannot toggle new"));
 
         if (extra->email->read || extra->email->old)
-          mutt_set_flag(Context, extra->email, MUTT_NEW, 1);
+          mutt_set_flag(Context->mailbox, extra->email, MUTT_NEW, 1);
         else if (!first)
-          mutt_set_flag(Context, extra->email, MUTT_READ, 1);
+          mutt_set_flag(Context->mailbox, extra->email, MUTT_READ, 1);
         first = 0;
         Context->msgnotreadyet = -1;
         pager_menu->redraw |= REDRAW_STATUS | REDRAW_INDEX;
@@ -3294,8 +3294,8 @@ int mutt_pager(const char *banner, const char *fname, int flags, struct Pager *e
         /* L10N: CHECK_ACL */
         CHECK_ACL(MUTT_ACL_DELETE, _("Cannot undelete message"));
 
-        mutt_set_flag(Context, extra->email, MUTT_DELETE, 0);
-        mutt_set_flag(Context, extra->email, MUTT_PURGE, 0);
+        mutt_set_flag(Context->mailbox, extra->email, MUTT_DELETE, 0);
+        mutt_set_flag(Context->mailbox, extra->email, MUTT_PURGE, 0);
         pager_menu->redraw |= REDRAW_STATUS | REDRAW_INDEX;
         if (Resolve)
         {

--- a/pattern.h
+++ b/pattern.h
@@ -30,7 +30,7 @@
 struct Address;
 struct Buffer;
 struct Email;
-struct Context;
+struct Mailbox;
 
 /* These Config Variables are only used in pattern.c */
 extern bool ThoroughSearch;
@@ -91,7 +91,7 @@ struct PatternCache
 
 struct Pattern *mutt_pattern_new(void);
 int mutt_pattern_exec(struct Pattern *pat, enum PatternExecFlag flags,
-                      struct Context *ctx, struct Email *e, struct PatternCache *cache);
+                      struct Mailbox *m, struct Email *e, struct PatternCache *cache);
 struct Pattern *mutt_pattern_comp(/* const */ char *s, int flags, struct Buffer *err);
 void mutt_check_simple(char *s, size_t len, const char *simple);
 void mutt_pattern_free(struct Pattern **pat);

--- a/pop/pop.c
+++ b/pop/pop.c
@@ -674,7 +674,7 @@ void pop_fetch_mail(void)
 
   for (int i = last + 1; i <= msgs; i++)
   {
-    struct Message *msg = mx_msg_open_new(ctx, NULL, MUTT_ADD_FROM);
+    struct Message *msg = mx_msg_open_new(ctx->mailbox, NULL, MUTT_ADD_FROM);
     if (!msg)
       ret = -3;
     else
@@ -690,7 +690,7 @@ void pop_fetch_mail(void)
         ret = -3;
       }
 
-      mx_msg_close(ctx, &msg);
+      mx_msg_close(ctx->mailbox, &msg);
     }
 
     if ((ret == 0) && (delanswer == MUTT_YES))
@@ -1072,12 +1072,10 @@ static int pop_mbox_close(struct Context *ctx)
 /**
  * pop_msg_open - Implements MxOps::msg_open()
  */
-static int pop_msg_open(struct Context *ctx, struct Message *msg, int msgno)
+static int pop_msg_open(struct Mailbox *m, struct Message *msg, int msgno)
 {
-  if (!ctx || !ctx->mailbox)
+  if (!m)
     return -1;
-
-  struct Mailbox *m = ctx->mailbox;
 
   char buf[LONG_STRING];
   char path[PATH_MAX];

--- a/postpone.c
+++ b/postpone.c
@@ -229,7 +229,7 @@ static struct Email *select_msg(void)
       case OP_DELETE:
       case OP_UNDELETE:
         /* should deleted draft messages be saved in the trash folder? */
-        mutt_set_flag(PostContext, PostContext->mailbox->hdrs[menu->current],
+        mutt_set_flag(PostContext->mailbox, PostContext->mailbox->hdrs[menu->current],
                       MUTT_DELETE, (i == OP_DELETE) ? 1 : 0);
         PostCount = PostContext->mailbox->msg_count - PostContext->mailbox->msg_deleted;
         if (Resolve && menu->current < menu->max - 1)
@@ -322,8 +322,8 @@ int mutt_get_postponed(struct Context *ctx, struct Email *hdr,
   }
 
   /* finished with this message, so delete it. */
-  mutt_set_flag(PostContext, e, MUTT_DELETE, 1);
-  mutt_set_flag(PostContext, e, MUTT_PURGE, 1);
+  mutt_set_flag(PostContext->mailbox, e, MUTT_DELETE, 1);
+  mutt_set_flag(PostContext->mailbox, e, MUTT_PURGE, 1);
 
   /* update the count for the status display */
   PostCount = PostContext->mailbox->msg_count - PostContext->mailbox->msg_deleted;
@@ -563,7 +563,7 @@ int mutt_prepare_template(FILE *fp, struct Context *ctx, struct Email *newhdr,
   struct State s = { 0 };
   int sec_type;
 
-  if (!fp && !(msg = mx_msg_open(ctx, e->msgno)))
+  if (!fp && !(msg = mx_msg_open(ctx->mailbox, e->msgno)))
     return -1;
 
   if (!fp)
@@ -773,7 +773,7 @@ bail:
   if (bfp != fp)
     mutt_file_fclose(&bfp);
   if (msg)
-    mx_msg_close(ctx, &msg);
+    mx_msg_close(ctx->mailbox, &msg);
 
   if (rc == -1)
   {

--- a/protos.h
+++ b/protos.h
@@ -34,6 +34,7 @@ struct Context;
 struct EnterState;
 struct Envelope;
 struct Email;
+struct Mailbox;
 
 /**
  * enum XdgType - XDG variable types
@@ -49,7 +50,7 @@ int mutt_system(const char *cmd);
 int mutt_set_xdg_path(enum XdgType type, char *buf, size_t bufsize);
 void mutt_help(int menu);
 void mutt_make_help(char *d, size_t dlen, const char *txt, int menu, int op);
-void mutt_set_flag_update(struct Context *ctx, struct Email *e, int flag, bool bf, bool upd_ctx);
+void mutt_set_flag_update(struct Mailbox *m, struct Email *e, int flag, bool bf, bool upd_ctx);
 #define mutt_set_flag(a, b, c, d) mutt_set_flag_update(a, b, c, d, true)
 void mutt_signal_init(void);
 void mutt_tag_set_flag(int flag, int bf);

--- a/recvattach.c
+++ b/recvattach.c
@@ -1307,11 +1307,11 @@ void mutt_view_attachments(struct Email *e)
   int op = OP_NULL;
 
   /* make sure we have parsed this message */
-  mutt_parse_mime_message(Context, e);
+  mutt_parse_mime_message(Context->mailbox, e);
 
   mutt_message_hook(Context, e, MUTT_MESSAGE_HOOK);
 
-  struct Message *msg = mx_msg_open(Context, e->msgno);
+  struct Message *msg = mx_msg_open(Context->mailbox, e->msgno);
   if (!msg)
     return;
 
@@ -1571,7 +1571,7 @@ void mutt_view_attachments(struct Email *e)
         break;
 
       case OP_EXIT:
-        mx_msg_close(Context, &msg);
+        mx_msg_close(Context->mailbox, &msg);
 
         e->attach_del = false;
         for (int i = 0; i < actx->idxlen; i++)

--- a/recvcmd.c
+++ b/recvcmd.c
@@ -29,6 +29,7 @@
 #include "config/lib.h"
 #include "email/lib.h"
 #include "mutt.h"
+#include "context.h"
 #include "alias.h"
 #include "copy.h"
 #include "curs_lib.h"
@@ -1032,7 +1033,7 @@ void mutt_attach_reply(FILE *fp, struct Email *e, struct AttachCtx *actx,
   if (ci_send_message(flags, tmphdr, tmpbody, NULL,
                       parent_hdr ? parent_hdr : (cur ? cur->email : NULL)) == 0)
   {
-    mutt_set_flag(Context, e, MUTT_REPLIED, 1);
+    mutt_set_flag(Context->mailbox, e, MUTT_REPLIED, 1);
   }
 }
 

--- a/score.c
+++ b/score.c
@@ -184,11 +184,11 @@ void mutt_score_message(struct Context *ctx, struct Email *e, bool upd_ctx)
     e->score = 0;
 
   if (e->score <= ScoreThresholdDelete)
-    mutt_set_flag_update(ctx, e, MUTT_DELETE, true, upd_ctx);
+    mutt_set_flag_update(ctx->mailbox, e, MUTT_DELETE, true, upd_ctx);
   if (e->score <= ScoreThresholdRead)
-    mutt_set_flag_update(ctx, e, MUTT_READ, true, upd_ctx);
+    mutt_set_flag_update(ctx->mailbox, e, MUTT_READ, true, upd_ctx);
   if (e->score >= ScoreThresholdFlag)
-    mutt_set_flag_update(ctx, e, MUTT_FLAG, true, upd_ctx);
+    mutt_set_flag_update(ctx->mailbox, e, MUTT_FLAG, true, upd_ctx);
 }
 
 /**

--- a/send.c
+++ b/send.c
@@ -906,7 +906,7 @@ void mutt_add_to_reference_headers(struct Envelope *env, struct Envelope *curenv
 static void make_reference_headers(struct Envelope *curenv,
                                    struct Envelope *env, struct Context *ctx)
 {
-  if (!env || !ctx)
+  if (!env || !ctx || !ctx->mailbox)
     return;
 
   if (!curenv)
@@ -923,7 +923,7 @@ static void make_reference_headers(struct Envelope *curenv,
   /* if there's more than entry in In-Reply-To (i.e. message has
      multiple parents), don't generate a References: header as it's
      discouraged by RFC2822, sect. 3.6.4 */
-  if (ctx->tagged > 0 && !STAILQ_EMPTY(&env->in_reply_to) &&
+  if (ctx->mailbox->msg_tagged > 0 && !STAILQ_EMPTY(&env->in_reply_to) &&
       STAILQ_NEXT(STAILQ_FIRST(&env->in_reply_to), entries))
   {
     mutt_list_free(&env->references);
@@ -2416,7 +2416,8 @@ int ci_send_message(int flags, struct Email *msg, char *tempfile,
   {
     if (cur && ctx)
       mutt_set_flag(ctx, cur, MUTT_REPLIED, is_reply(cur, msg));
-    else if (!(flags & SEND_POSTPONED) && ctx && ctx->tagged)
+    else if (!(flags & SEND_POSTPONED) && ctx && ctx->mailbox &&
+             ctx->mailbox->msg_tagged)
     {
       for (i = 0; i < ctx->mailbox->msg_count; i++)
       {

--- a/send.c
+++ b/send.c
@@ -537,7 +537,7 @@ static int include_forward(struct Context *ctx, struct Email *cur, FILE *out)
 {
   int chflags = CH_DECODE, cmflags = 0;
 
-  mutt_parse_mime_message(ctx, cur);
+  mutt_parse_mime_message(ctx->mailbox, cur);
   mutt_message_hook(ctx, cur, MUTT_MESSAGE_HOOK);
 
   if ((WithCrypto != 0) && (cur->security & ENCRYPT) && ForwardDecode)
@@ -626,7 +626,7 @@ static int include_reply(struct Context *ctx, struct Email *cur, FILE *out)
       return -1;
   }
 
-  mutt_parse_mime_message(ctx, cur);
+  mutt_parse_mime_message(ctx->mailbox, cur);
   mutt_message_hook(ctx, cur, MUTT_MESSAGE_HOOK);
 
   mutt_make_attribution(ctx, cur, out);
@@ -2415,7 +2415,7 @@ int ci_send_message(int flags, struct Email *msg, char *tempfile,
   if (flags & SEND_REPLY)
   {
     if (cur && ctx)
-      mutt_set_flag(ctx, cur, MUTT_REPLIED, is_reply(cur, msg));
+      mutt_set_flag(ctx->mailbox, cur, MUTT_REPLIED, is_reply(cur, msg));
     else if (!(flags & SEND_POSTPONED) && ctx && ctx->mailbox &&
              ctx->mailbox->msg_tagged)
     {
@@ -2423,7 +2423,7 @@ int ci_send_message(int flags, struct Email *msg, char *tempfile,
       {
         if (message_is_tagged(ctx, i))
         {
-          mutt_set_flag(ctx, ctx->mailbox->hdrs[i], MUTT_REPLIED,
+          mutt_set_flag(ctx->mailbox, ctx->mailbox->hdrs[i], MUTT_REPLIED,
                         is_reply(ctx->mailbox->hdrs[i], msg));
         }
       }

--- a/sendlib.c
+++ b/sendlib.c
@@ -1482,7 +1482,7 @@ struct Body *mutt_make_message_attach(struct Context *ctx, struct Email *e, bool
   body->disposition = DISP_INLINE;
   body->noconv = true;
 
-  mutt_parse_mime_message(ctx, e);
+  mutt_parse_mime_message(ctx->mailbox, e);
 
   chflags = CH_XMIT;
   cmflags = 0;
@@ -2974,7 +2974,7 @@ static int bounce_message(FILE *fp, struct Email *e, struct Address *to,
   }
 
   /* If we failed to open a message, return with error */
-  if (!fp && !(msg = mx_msg_open(Context, e->msgno)))
+  if (!fp && !(msg = mx_msg_open(Context->mailbox, e->msgno)))
     return -1;
 
   if (!fp)
@@ -3018,7 +3018,7 @@ static int bounce_message(FILE *fp, struct Email *e, struct Address *to,
   }
 
   if (msg)
-    mx_msg_close(Context, &msg);
+    mx_msg_close(Context->mailbox, &msg);
 
   return rc;
 }
@@ -3206,7 +3206,7 @@ int mutt_write_fcc(const char *path, struct Email *e, const char *msgid,
   onm_flags = MUTT_ADD_FROM;
   if (post)
     onm_flags |= MUTT_SET_DRAFT;
-  msg = mx_msg_open_new(f, e, onm_flags);
+  msg = mx_msg_open_new(f->mailbox, e, onm_flags);
   if (!msg)
   {
     mutt_file_fclose(&tempfp);
@@ -3327,7 +3327,7 @@ int mutt_write_fcc(const char *path, struct Email *e, const char *msgid,
       mutt_file_fclose(&tempfp);
       unlink(tempfile);
       mx_msg_commit(f, msg); /* XXX really? */
-      mx_msg_close(f, &msg);
+      mx_msg_close(f->mailbox, &msg);
       mx_mbox_close(&f, NULL);
       goto done;
     }
@@ -3358,7 +3358,7 @@ int mutt_write_fcc(const char *path, struct Email *e, const char *msgid,
     rc = -1;
   else if (finalpath)
     *finalpath = mutt_str_strdup(msg->committed_path);
-  mx_msg_close(f, &msg);
+  mx_msg_close(f->mailbox, &msg);
   mx_mbox_close(&f, NULL);
 
   if (!post && need_mailbox_cleanup)

--- a/sidebar.c
+++ b/sidebar.c
@@ -209,9 +209,9 @@ static const char *sidebar_format_str(char *buf, size_t buflen, size_t col, int 
       if (!optional)
       {
         snprintf(fmt, sizeof(fmt), "%%%sd", prec);
-        snprintf(buf, buflen, fmt, c ? Context->tagged : 0);
+        snprintf(buf, buflen, fmt, c ? Context->mailbox->msg_tagged : 0);
       }
-      else if ((c && Context->tagged == 0) || !c)
+      else if ((c && Context->mailbox->msg_tagged == 0) || !c)
         optional = 0;
       break;
 

--- a/status.c
+++ b/status.c
@@ -324,9 +324,9 @@ static const char *status_format_str(char *buf, size_t buflen, size_t col, int c
       if (!optional)
       {
         snprintf(fmt, sizeof(fmt), "%%%sd", prec);
-        snprintf(buf, buflen, fmt, Context ? Context->tagged : 0);
+        snprintf(buf, buflen, fmt, Context ? Context->mailbox->msg_tagged : 0);
       }
-      else if (!Context || !Context->tagged)
+      else if (!Context || !Context->mailbox || !Context->mailbox->msg_tagged)
         optional = 0;
       break;
 


### PR DESCRIPTION
This aims to remove Context from mutt_set_flag, to do so other function
signature have been changed too.

* mutt_set_flag_update
* mx_msg_open
* mx_msg_open_new
* mx_msg_close
* mutt_pattern_exec
* mutt_parse_mime_message
* mutt_set_header_color
* mutt_count_body_parts

And Context->tagged have been moved to Mailbox->msg_tagged