### PR TITLE
Change dependency chain regarding git_ver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,7 @@ doc/neomuttrc.5
 # Generated source
 config.h
 conststrings.c
-git_ver.h
+git_ver.c
 hcache/hcversion.h
 
 # Misc

--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -64,7 +64,7 @@ NEOMUTT=	neomutt$(EXEEXT)
 NEOMUTTOBJS=	account.o addrbook.o alias.o bcache.o browser.o color.o commands.o \
 		complete.o compose.o compress.o conststrings.o copy.o \
 		curs_lib.o edit.o editmsg.o enriched.o enter.o \
-		filter.o flags.o group.o handler.o hdrline.o help.o hook.o \
+		filter.o flags.o git_ver.o group.o handler.o hdrline.o help.o hook.o \
 		index.o init.o keymap.o mailbox.o main.o menu.o muttlib.o \
 		mutt_account.o mutt_attach.o mutt_body.o mutt_header.o \
 		mutt_history.o mutt_logging.o mutt_parse.o mutt_signal.o \
@@ -259,7 +259,7 @@ ALLOBJS+=	$(LIBMUTTOBJS)
 
 ###############################################################################
 # generated
-GENERATED=	git_ver.h hcache/hcversion.h
+GENERATED=	git_ver.c hcache/hcversion.h
 CLEANFILES+=	$(GENERATED)
 
 ##############################################################################
@@ -271,8 +271,7 @@ all: $(BINFILES) $(LIBBINFILES) $(ALL_TARGETS)
 	$(CC) $(CFLAGS) -MT $@ -MD -MP -MF $*.Tpo -c -o $@ $<
 	@mv $*.Tpo $*.Po
 
-# make sure git_ver.h is built before any .o files
-$(ALLOBJS):	git_ver.h
+$(ALLOBJS):
 
 # mutt
 $(NEOMUTT): $(GENERATED) $(NEOMUTTOBJS) $(MUTTLIBS)
@@ -368,12 +367,12 @@ $(PGPEWRAP): $(PGPEWRAPOBJS)
 	$(CC) $(LDFLAGS) -o $@ $(PGPEWRAPOBJS)
 
 # generated
-git_ver.h: $(ALL_FILES)
+git_ver.c: $(ALL_FILES)
 	version=`git describe --dirty --abbrev=6 --match "neomutt-*" 2> /dev/null | \
 		sed -e 's/^neomutt-[0-9]\{8\}//; s/-g\([a-z0-9]\{6\}\)/-\1/'`; \
-	echo 'const char *GitVer = "'$$version'";' > git_ver.h.tmp; \
-	cmp -s git_ver.h.tmp git_ver.h || mv git_ver.h.tmp git_ver.h; \
-	rm -f git_ver.h.tmp
+	echo 'const char *GitVer = "'$$version'";' > $@.tmp; \
+	cmp -s $@.tmp $@ || mv $@.tmp $@; \
+	rm -f $@.tmp
 
 hcache/hcversion.h:	$(SRCDIR)/email/address.h \
 			$(SRCDIR)/email/body.h \

--- a/globals.h
+++ b/globals.h
@@ -31,7 +31,6 @@
 
 #ifdef MAIN_C
 /* so that global vars get included */
-#include "git_ver.h"
 #include "mx.h"
 #include "ncrypt/ncrypt.h"
 #include "sort.h"


### PR DESCRIPTION
* **What does this PR do?**

Replaces `git_ver.h` with `git_ver.{c,o}` and removes dependency from all files on `git_ver.h`, having a dependency on only the final `$(NEOMUTT)` target

Every time I changed my git's state, the entire repository was rebuilt because `git_ver.h` changed: https://pastebin.com/v629aTPr

On top of that, it seems on some machines this dependency does not even get processed and the `git_ver.h` file is not updates: https://pastebin.com/xKXhD78R