### PR TITLE
Correct a few minor errors in the documentation for patterns

### DIFF
--- a/doc/manual.xml.head
+++ b/doc/manual.xml.head
@@ -7476,10 +7476,10 @@ set index_format="%4C %Z %{%b %d} %-15.15L (%?l?%4l&amp;%4c?)%*  %s"
                 </entry>
               </row>
               <row>
-                <entry>~X [ <emphasis>MIN</emphasis>]-[ <emphasis>MAX</emphasis>]</entry>
+                <entry>~X [<emphasis>MIN</emphasis>]-[<emphasis>MAX</emphasis>]</entry>
                 <entry>
-                  messages with <emphasis>MIN</emphasis>to
-                  <emphasis>MAX</emphasis>attachments&#160;*)&#160;****)
+                  messages with <emphasis>MIN</emphasis> to
+                  <emphasis>MAX</emphasis> attachments&#160;*)&#160;****)
                 </entry>
               </row>
               <row>


### PR DESCRIPTION
* **What does this PR do?**
Corrects the following: 
  * The patterns ~b, ~B, and ~h read each message in and should have 4
asterisks instead of 3 (3 refers to patterns with message number range
arguments). Add the missing asterisk to these patterns.
  * Add non-breaking spaces before footnote asterisks.
  * Add or remove missing or excess spacing respectively.