### PR TITLE
notmuch: don't overwrite nm_default_uri

### DIFF
--- a/notmuch/nm_db.c
+++ b/notmuch/nm_db.c
@@ -50,7 +50,8 @@ const char *nm_db_get_filename(struct Mailbox *m)
   if (!db_filename && !Folder)
     return NULL;
 
-  db_filename = Folder;
+  if (!db_filename)
+    db_filename = Folder;
 
   if (nm_path_probe(db_filename, NULL) == MUTT_NOTMUCH)
     db_filename += NmUriProtocolLen;


### PR DESCRIPTION
In commit 1040935, I accidentally removed a check for using `Folder` as
the `db_filename` if `db_filename` is null. My change made it so that it
always overwrote the value.

**What are the relevant issue numbers?**

#1455 