### PR TITLE
Factor out mx_update_context() from mbox_open()

### DIFF
--- a/compress.c
+++ b/compress.c
@@ -495,12 +495,10 @@ int comp_ac_add(struct Account *a, struct Mailbox *m)
  * Then determine the type of the mailbox so we can delegate the handling of
  * messages.
  */
-static int comp_mbox_open(struct Context *ctx)
+static int comp_mbox_open(struct Mailbox *m, struct Context *ctx)
 {
   if (!ctx || !ctx->mailbox || (ctx->mailbox->magic != MUTT_COMPRESSED))
     return -1;
-
-  struct Mailbox *m = ctx->mailbox;
 
   struct CompressInfo *ci = set_compress_info(m);
   if (!ci)
@@ -541,7 +539,7 @@ static int comp_mbox_open(struct Context *ctx)
   }
 
   m->account->magic = m->magic;
-  return ci->child_ops->mbox_open(ctx);
+  return ci->child_ops->mbox_open(m, ctx);
 
 cmo_fail:
   /* remove the partial uncompressed file */

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -1974,13 +1974,9 @@ int imap_login(struct ImapAccountData *adata)
 /**
  * imap_mbox_open - Implements MxOps::mbox_open()
  */
-static int imap_mbox_open(struct Context *ctx)
+static int imap_mbox_open(struct Mailbox *m, struct Context *ctx)
 {
-  if (!ctx || !ctx->mailbox)
-    return -1;
-
-  struct Mailbox *m = ctx->mailbox;
-  if (!m->account)
+  if (!m || !m->account)
     return -1;
 
   char buf[PATH_MAX];

--- a/imap/message.c
+++ b/imap/message.c
@@ -1364,7 +1364,6 @@ int imap_read_headers(struct ImapAccountData *adata, unsigned int msn_begin,
     /* TODO: it's not clear to me why we are calling mx_alloc_memory
      *       yet again. */
     mx_alloc_memory(m);
-    mx_update_context(adata->ctx, m->msg_count - oldmsgcount);
   }
 
   mdata->reopen |= IMAP_REOPEN_ALLOW;

--- a/maildir/maildir.c
+++ b/maildir/maildir.c
@@ -153,16 +153,15 @@ cleanup:
 /**
  * maildir_read_dir - Read a Maildir style mailbox
  * @param m   Mailbox
- * @param ctx Mailbox
  * @retval  0 Success
  * @retval -1 Failure
  */
-static int maildir_read_dir(struct Mailbox *m, struct Context *ctx)
+static int maildir_read_dir(struct Mailbox *m)
 {
   /* maildir looks sort of like MH, except that there are two subdirectories
    * of the main folder path from which to read messages
    */
-  if ((mh_read_dir(m, ctx, "new") == -1) || (mh_read_dir(m, ctx, "cur") == -1))
+  if ((mh_read_dir(m, "new") == -1) || (mh_read_dir(m, "cur") == -1))
     return -1;
 
   return 0;
@@ -301,7 +300,7 @@ cleanup:
  */
 static int maildir_mbox_open(struct Mailbox *m, struct Context *ctx)
 {
-  return maildir_read_dir(m, ctx);
+  return maildir_read_dir(m);
 }
 
 /**
@@ -379,7 +378,7 @@ int maildir_mbox_check(struct Context *ctx, int *index_hint)
   int changed = 0;            /* bitmask representing which subdirectories
                                  have changed.  0x1 = new, 0x2 = cur */
   bool occult = false;        /* messages were removed from the mailbox */
-  int have_new = 0;           /* messages were added to the mailbox */
+  int num_new = 0;            /* number of new messages added to the mailbox */
   bool flags_changed = false; /* message flags were changed in the mailbox */
   struct Maildir *md = NULL;  /* list of messages in the mailbox */
   struct Maildir **last = NULL, *p = NULL;
@@ -529,13 +528,15 @@ int maildir_mbox_check(struct Context *ctx, int *index_hint)
   maildir_delayed_parsing(m, &md, NULL);
 
   /* Incorporate new messages */
-  have_new = maildir_move_to_context(ctx->mailbox, ctx, &md);
+  num_new = maildir_move_to_context(m, &md);
+  if (num_new > 0)
+    mx_update_context(ctx, num_new);
 
   mutt_buffer_pool_release(&buf);
 
   if (occult)
     return MUTT_REOPENED;
-  if (have_new)
+  if (num_new > 0)
     return MUTT_NEW_MAIL;
   if (flags_changed)
     return MUTT_FLAGS;

--- a/maildir/maildir.c
+++ b/maildir/maildir.c
@@ -152,16 +152,17 @@ cleanup:
 
 /**
  * maildir_read_dir - Read a Maildir style mailbox
+ * @param m   Mailbox
  * @param ctx Mailbox
  * @retval  0 Success
  * @retval -1 Failure
  */
-static int maildir_read_dir(struct Context *ctx)
+static int maildir_read_dir(struct Mailbox *m, struct Context *ctx)
 {
   /* maildir looks sort of like MH, except that there are two subdirectories
    * of the main folder path from which to read messages
    */
-  if ((mh_read_dir(ctx, "new") == -1) || (mh_read_dir(ctx, "cur") == -1))
+  if ((mh_read_dir(m, ctx, "new") == -1) || (mh_read_dir(m, ctx, "cur") == -1))
     return -1;
 
   return 0;
@@ -298,9 +299,9 @@ cleanup:
 /**
  * maildir_mbox_open - Implements MxOps::mbox_open()
  */
-static int maildir_mbox_open(struct Context *ctx)
+static int maildir_mbox_open(struct Mailbox *m, struct Context *ctx)
 {
-  return maildir_read_dir(ctx);
+  return maildir_read_dir(m, ctx);
 }
 
 /**
@@ -528,7 +529,7 @@ int maildir_mbox_check(struct Context *ctx, int *index_hint)
   maildir_delayed_parsing(m, &md, NULL);
 
   /* Incorporate new messages */
-  have_new = maildir_move_to_context(ctx, &md);
+  have_new = maildir_move_to_context(ctx->mailbox, ctx, &md);
 
   mutt_buffer_pool_release(&buf);
 

--- a/maildir/maildir_private.h
+++ b/maildir/maildir_private.h
@@ -96,7 +96,7 @@ int                     maildir_check_dir      (struct Mailbox *m, const char *d
 void                    maildir_delayed_parsing(struct Mailbox *m, struct Maildir **md, struct Progress *progress);
 struct MaildirMboxData *maildir_mdata_get      (struct Mailbox *m);
 int                     maildir_mh_open_message(struct Mailbox *m, struct Message *msg, int msgno, bool is_maildir);
-int                     maildir_move_to_context(struct Context *ctx, struct Maildir **md);
+int                     maildir_move_to_context(struct Mailbox *m, struct Context *ctx, struct Maildir **md);
 int                     maildir_parse_dir      (struct Mailbox *m, struct Maildir ***last, const char *subdir, int *count, struct Progress *progress);
 void                    maildir_parse_flags    (struct Email *e, const char *path);
 struct Email *          maildir_parse_message  (enum MailboxType magic, const char *fname, bool is_old, struct Email *e);
@@ -105,7 +105,7 @@ void                    maildir_update_tables  (struct Context *ctx, int *index_
 int                     md_commit_message      (struct Mailbox *m, struct Message *msg, struct Email *e);
 int                     mh_commit_msg          (struct Mailbox *m, struct Message *msg, struct Email *e, bool updseq);
 int                     mh_mkstemp             (struct Mailbox *m, FILE **fp, char **tgt);
-int                     mh_read_dir            (struct Context *ctx, const char *subdir);
+int                     mh_read_dir            (struct Mailbox *m, struct Context *ctx, const char *subdir);
 int                     mh_read_sequences      (struct MhSequences *mhs, const char *path);
 short                   mhs_check              (struct MhSequences *mhs, int i);
 void                    mhs_free_sequences     (struct MhSequences *mhs);

--- a/maildir/maildir_private.h
+++ b/maildir/maildir_private.h
@@ -96,7 +96,7 @@ int                     maildir_check_dir      (struct Mailbox *m, const char *d
 void                    maildir_delayed_parsing(struct Mailbox *m, struct Maildir **md, struct Progress *progress);
 struct MaildirMboxData *maildir_mdata_get      (struct Mailbox *m);
 int                     maildir_mh_open_message(struct Mailbox *m, struct Message *msg, int msgno, bool is_maildir);
-int                     maildir_move_to_context(struct Mailbox *m, struct Context *ctx, struct Maildir **md);
+int                     maildir_move_to_context(struct Mailbox *m, struct Maildir **md);
 int                     maildir_parse_dir      (struct Mailbox *m, struct Maildir ***last, const char *subdir, int *count, struct Progress *progress);
 void                    maildir_parse_flags    (struct Email *e, const char *path);
 struct Email *          maildir_parse_message  (enum MailboxType magic, const char *fname, bool is_old, struct Email *e);
@@ -105,7 +105,7 @@ void                    maildir_update_tables  (struct Context *ctx, int *index_
 int                     md_commit_message      (struct Mailbox *m, struct Message *msg, struct Email *e);
 int                     mh_commit_msg          (struct Mailbox *m, struct Message *msg, struct Email *e, bool updseq);
 int                     mh_mkstemp             (struct Mailbox *m, FILE **fp, char **tgt);
-int                     mh_read_dir            (struct Mailbox *m, struct Context *ctx, const char *subdir);
+int                     mh_read_dir            (struct Mailbox *m, const char *subdir);
 int                     mh_read_sequences      (struct MhSequences *mhs, const char *path);
 short                   mhs_check              (struct MhSequences *mhs, int i);
 void                    mhs_free_sequences     (struct MhSequences *mhs);

--- a/maildir/mh.c
+++ b/maildir/mh.c
@@ -551,9 +551,9 @@ int mh_sync_message(struct Mailbox *m, int msgno)
 /**
  * mh_mbox_open - Implements MxOps::mbox_open()
  */
-static int mh_mbox_open(struct Context *ctx)
+static int mh_mbox_open(struct Mailbox *m, struct Context *ctx)
 {
-  return mh_read_dir(ctx, NULL);
+  return mh_read_dir(m, ctx, NULL);
 }
 
 /**
@@ -717,7 +717,7 @@ int mh_mbox_check(struct Context *ctx, int *index_hint)
     maildir_update_tables(ctx, index_hint);
 
   /* Incorporate new messages */
-  have_new = maildir_move_to_context(ctx, &md);
+  have_new = maildir_move_to_context(m, ctx, &md);
 
   if (occult)
     return MUTT_REOPENED;

--- a/maildir/shared.c
+++ b/maildir/shared.c
@@ -415,16 +415,15 @@ cleanup:
 
 /**
  * maildir_add_to_context - Add the Maildir list to the Mailbox
+ * @param m   Mailbox
  * @param ctx Mailbox
  * @param md  Maildir list to copy
  * @retval true If there's new mail
  */
-static bool maildir_add_to_context(struct Context *ctx, struct Maildir *md)
+static bool maildir_add_to_context(struct Mailbox *m, struct Context *ctx, struct Maildir *md)
 {
-  if (!ctx || !ctx->mailbox)
+  if (!m)
     return false;
-
-  struct Mailbox *m = ctx->mailbox;
 
   int oldmsgcount = m->msg_count;
 
@@ -471,14 +470,15 @@ static bool maildir_add_to_context(struct Context *ctx, struct Maildir *md)
 
 /**
  * maildir_move_to_context - Copy the Maildir list to the Mailbox
+ * @param m   Mailbox
  * @param ctx Mailbox
  * @param md  Maildir list to copy, then free
  * @retval 1 If there's new mail
  * @retval 0 Otherwise
  */
-int maildir_move_to_context(struct Context *ctx, struct Maildir **md)
+int maildir_move_to_context(struct Mailbox *m, struct Context *ctx, struct Maildir **md)
 {
-  int r = maildir_add_to_context(ctx, *md);
+  int r = maildir_add_to_context(m, ctx, *md);
   maildir_free_maildir(md);
   return r;
 }
@@ -821,18 +821,17 @@ void maildir_delayed_parsing(struct Mailbox *m, struct Maildir **md, struct Prog
 
 /**
  * mh_read_dir - Read a MH/maildir style mailbox
+ * @param m   Mailbox
  * @param ctx    Mailbox
  * @param subdir NULL for MH mailboxes,
  *               otherwise the subdir of the maildir mailbox to read from
  * @retval  0 Success
  * @retval -1 Failure
  */
-int mh_read_dir(struct Context *ctx, const char *subdir)
+int mh_read_dir(struct Mailbox *m, struct Context *ctx, const char *subdir)
 {
-  if (!ctx || !ctx->mailbox)
+  if (!m)
     return -1;
-
-  struct Mailbox *m = ctx->mailbox;
 
   struct Maildir *md = NULL;
   struct MhSequences mhs = { 0 };
@@ -880,7 +879,7 @@ int mh_read_dir(struct Context *ctx, const char *subdir)
     mhs_free_sequences(&mhs);
   }
 
-  maildir_move_to_context(ctx, &md);
+  maildir_move_to_context(m, ctx, &md);
 
   if (!mdata->mh_umask)
     mdata->mh_umask = mh_umask(m);

--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -941,13 +941,8 @@ int mbox_ac_add(struct Account *a, struct Mailbox *m)
 /**
  * mbox_mbox_open - Implements MxOps::mbox_open()
  */
-static int mbox_mbox_open(struct Context *ctx)
+static int mbox_mbox_open(struct Mailbox *m, struct Context *ctx)
 {
-  if (!ctx || !ctx->mailbox)
-    return -1;
-
-  struct Mailbox *m = ctx->mailbox;
-
   if (init_mailbox(m) != 0)
     return -1;
 
@@ -1037,7 +1032,7 @@ static int mbox_mbox_check(struct Context *ctx, int *index_hint)
   if (!adata)
     return -1;
 
-  if (!adata->fp && (mbox_mbox_open(ctx) < 0))
+  if (!adata->fp && (mbox_mbox_open(m, ctx) < 0))
     return -1;
 
   struct stat st;

--- a/mx.c
+++ b/mx.c
@@ -364,7 +364,7 @@ struct Context *mx_mbox_open(struct Mailbox *m, const char *path, int flags)
   if (!m->quiet)
     mutt_message(_("Reading %s..."), m->path);
 
-  int rc = m->mx_ops->mbox_open(ctx);
+  int rc = m->mx_ops->mbox_open(ctx->mailbox, ctx);
   m->opened++;
 
   if ((rc == 0) || (rc == -2))

--- a/mx.c
+++ b/mx.c
@@ -369,6 +369,8 @@ struct Context *mx_mbox_open(struct Mailbox *m, const char *path, int flags)
 
   int rc = m->mx_ops->mbox_open(ctx->mailbox, ctx);
   m->opened++;
+  if (rc == 0)
+    mx_update_context(ctx, ctx->mailbox->msg_count);
 
   if ((rc == 0) || (rc == -2))
   {

--- a/mx.c
+++ b/mx.c
@@ -296,6 +296,9 @@ struct Context *mx_mbox_open(struct Mailbox *m, const char *path, int flags)
   ctx->msgnotreadyet = -1;
   ctx->collapsed = false;
 
+  m->msg_unread = 0;
+  m->msg_flagged = 0;
+
   for (int i = 0; i < RIGHTSMAX; i++)
     mutt_bit_set(m->rights, i);
 

--- a/mx.h
+++ b/mx.h
@@ -124,6 +124,7 @@ struct MxOps
    * @param ctx Mailbox to open
    * @retval  0 Success
    * @retval -1 Error
+   * @retval -2 Aborted
    */
   int (*mbox_open)       (struct Mailbox *m, struct Context *ctx);
   /**

--- a/mx.h
+++ b/mx.h
@@ -120,11 +120,12 @@ struct MxOps
   int             (*ac_add)   (struct Account *a, struct Mailbox *m);
   /**
    * mbox_open - Open a mailbox
+   * @param m   Mailbox to open
    * @param ctx Mailbox to open
    * @retval  0 Success
    * @retval -1 Error
    */
-  int (*mbox_open)       (struct Context *ctx);
+  int (*mbox_open)       (struct Mailbox *m, struct Context *ctx);
   /**
    * mbox_open_append - Open a mailbox for appending
    * @param m     Mailbox to open

--- a/nntp/nntp.c
+++ b/nntp/nntp.c
@@ -2440,13 +2440,9 @@ int nntp_ac_add(struct Account *a, struct Mailbox *m)
 /**
  * nntp_mbox_open - Implements MxOps::mbox_open()
  */
-static int nntp_mbox_open(struct Context *ctx)
+static int nntp_mbox_open(struct Mailbox *m, struct Context *ctx)
 {
-  if (!ctx || !ctx->mailbox)
-    return -1;
-
-  struct Mailbox *m = ctx->mailbox;
-  if (!m->account)
+  if (!m || !m->account)
     return -1;
 
   char buf[HUGE_STRING];

--- a/notmuch/mutt_notmuch.c
+++ b/notmuch/mutt_notmuch.c
@@ -2173,7 +2173,6 @@ static int nm_mbox_open(struct Mailbox *m, struct Context *ctx)
   m->mtime.tv_sec = time(NULL);
   m->mtime.tv_nsec = 0;
 
-  mx_update_context(ctx, m->msg_count);
   mdata->oldmsgcount = 0;
 
   mutt_debug(1, "nm: reading messages... done [rc=%d, count=%d]\n", rc, m->msg_count);

--- a/notmuch/mutt_notmuch.c
+++ b/notmuch/mutt_notmuch.c
@@ -1125,9 +1125,8 @@ static bool read_threads_query(struct Mailbox *m, notmuch_query_t *q, bool dedup
     return false;
 
   notmuch_threads_t *threads = get_threads(q);
-
   if (!threads)
-    return NULL;
+    return false;
 
   for (; notmuch_threads_valid(threads) && ((limit == 0) || (m->msg_count < limit));
        notmuch_threads_move_to_next(threads))

--- a/notmuch/mutt_notmuch.c
+++ b/notmuch/mutt_notmuch.c
@@ -2126,15 +2126,8 @@ int nm_ac_add(struct Account *a, struct Mailbox *m)
 /**
  * nm_mbox_open - Implements MxOps::mbox_open()
  */
-static int nm_mbox_open(struct Context *ctx)
+static int nm_mbox_open(struct Mailbox *m, struct Context *ctx)
 {
-  if (!ctx || !ctx->mailbox)
-    return -1;
-
-  struct Mailbox *m = ctx->mailbox;
-
-  int rc = -1;
-
   if (init_mailbox(m) != 0)
     return -1;
 
@@ -2154,6 +2147,8 @@ static int nm_mbox_open(struct Context *ctx)
     m->vcount = 0;
     mx_alloc_memory(m);
   }
+
+  int rc = -1;
 
   notmuch_query_t *q = get_query(m, false);
   if (q)

--- a/pop/pop.c
+++ b/pop/pop.c
@@ -825,13 +825,9 @@ int pop_ac_add(struct Account *a, struct Mailbox *m)
  *
  * Fetch only headers
  */
-static int pop_mbox_open(struct Context *ctx)
+static int pop_mbox_open(struct Mailbox *m, struct Context *ctx)
 {
-  if (!ctx || !ctx->mailbox)
-    return -1;
-
-  struct Mailbox *m = ctx->mailbox;
-  if (!m->account)
+  if (!m || !m->account)
     return -1;
 
   char buf[PATH_MAX];

--- a/pop/pop.c
+++ b/pop/pop.c
@@ -533,9 +533,6 @@ static int pop_fetch_headers(struct Context *ctx)
 
       m->msg_count++;
     }
-
-    if (i > old_count)
-      mx_update_context(ctx, i - old_count);
   }
 
 #ifdef USE_HCACHE
@@ -927,8 +924,11 @@ static int pop_mbox_check(struct Context *ctx, int *index_hint)
 
   mutt_message(_("Checking for new messages..."));
 
+  int old_msg_count = m->msg_count;
   int ret = pop_fetch_headers(ctx);
   pop_clear_cache(adata);
+  if (m->msg_count > old_msg_count)
+    mx_update_context(ctx, m->msg_count > old_msg_count);
 
   if (ret < 0)
     return -1;


### PR DESCRIPTION
Following on from [this diagram of Context use](https://github.com/neomutt/neomutt/issues/1326#issuecomment-438085645), I've refactored the backends to move `mx_update_context()` out of `*_mbox_open()`.

Here are a couple of diagrams that may illustrate what I've done.
The represent the function call tree leading to `mx_update_context()`.

**Key:**
- **Solid Red** - The problem function, `mx_update_context()`, which has been eliminated
- **Dot** - New locations of `mx_update_context()` calls
- **Purple** - MXAPI functions
- **Green** - Other functions called by NeoMutt (from outside the email backend)
- **Red** - Private functions

### Mbox backend

![mbox](https://flatcap.org/mutt/mbox-context.svg)

### Nntp backend

![nntp](https://flatcap.org/mutt/nntp-context.svg)

---

This is an improvement for `mbox_open()`, but it just shifts the problem down to `mbox_sync()` and `mbox_check()`.
