### PR TITLE
imap: handle case where adata->mailbox is NULL

### DIFF
--- a/imap/command.c
+++ b/imap/command.c
@@ -1305,7 +1305,7 @@ void imap_cmd_finish(struct ImapAccountData *adata)
 
   adata->closing = false;
 
-  struct ImapMboxData *mdata = adata->mailbox->mdata;
+  struct ImapMboxData *mdata = imap_mdata_get(adata->mailbox);
 
   if (mdata && mdata->reopen & IMAP_REOPEN_ALLOW)
   {


### PR DESCRIPTION
When selected mailbox in unsubscribed, adata->mailbox may be NULL.

make imap_cmd_finish() handles it.

Closes #1460