### PR TITLE
Do not use the account's delimiter if it wasn't figured yet

### DIFF
--- a/imap/util.c
+++ b/imap/util.c
@@ -788,8 +788,9 @@ char *imap_fix_path(struct ImapAccountData *adata, const char *mailbox, char *pa
 {
   int i = 0;
   char delim = '\0';
+  bool use_account_delim = (adata && adata->delim != '\0');
 
-  if (adata)
+  if (use_account_delim)
     delim = adata->delim;
 
   while (mailbox && *mailbox && i < plen - 1)
@@ -797,7 +798,7 @@ char *imap_fix_path(struct ImapAccountData *adata, const char *mailbox, char *pa
     if ((ImapDelimChars && strchr(ImapDelimChars, *mailbox)) || (delim && *mailbox == delim))
     {
       /* use connection delimiter if known. Otherwise use user delimiter */
-      if (!adata)
+      if (!use_account_delim)
         delim = *mailbox;
 
       while (*mailbox && ((ImapDelimChars && strchr(ImapDelimChars, *mailbox)) ||


### PR DESCRIPTION
Closes #1438

* **What does this PR do?**

The account's delimiter character is used to normalize IMAP paths. Between the account is created and the IMAP session is logged-in, the delimiter remains unset (defaults to `\0`). This commit changes `imap_fix_path` not to use such a default delimiter.

This allows to specify a mailbox on startup. It has the (mild) downside that if the mailbox is specified with the wrong delimiter, say `/` instead of `.`, we now exit with an error instead of truncating the mailbox to the parent path.

So, if my IMAP's delimiter is `.`.

| Command | Before this change | After this change |
|---------------|------------------------|----------------------|
| `neomutt -f Lists.Neomutt-devel` | Opens `Lists` | Opens `Lists.Neomutt-devel` |
| `neomutt -f Lists/Neomutt-devel` | Opens `Lists` | Fails with `Invalid mailbox name` error  |
