### PR TITLE
Add the "attach_save_dir" config variable

### DIFF
--- a/init.h
+++ b/init.h
@@ -321,6 +321,11 @@ struct ConfigDef MuttVars[] = {
   ** .pp
   ** For an explanation of ``soft-fill'', see the $$index_format documentation.
   */
+  { "attach_save_dir",  DT_PATH, R_NONE, &AttachSaveDir, IP "./" },
+  /*
+  ** .pp
+  ** The directory where attachments are saved.
+  */
   { "attach_sep",       DT_STRING,  R_NONE, &AttachSep, IP "\n" },
   /*
   ** .pp

--- a/recvattach.h
+++ b/recvattach.h
@@ -32,6 +32,7 @@ struct AttachCtx;
 struct Email;
 
 /* These Config Variables are only used in recvattach.c */
+extern char *AttachSaveDir;
 extern char *AttachSep;
 extern bool  AttachSplit;
 extern bool  DigestCollapse;


### PR DESCRIPTION
This specifies the location where attachments are saved. The default is the current working directory.

Issue #1465
