### PR TITLE
Try to keep the current mailbox and the Context more in sync

### DIFF
--- a/maildir/maildir.c
+++ b/maildir/maildir.c
@@ -530,7 +530,7 @@ int maildir_mbox_check(struct Context *ctx, int *index_hint)
   /* Incorporate new messages */
   num_new = maildir_move_to_context(m, &md);
   if (num_new > 0)
-    mx_update_context(ctx, num_new);
+    mx_update_context(ctx);
 
   mutt_buffer_pool_release(&buf);
 

--- a/maildir/mh.c
+++ b/maildir/mh.c
@@ -720,7 +720,7 @@ int mh_mbox_check(struct Context *ctx, int *index_hint)
   /* Incorporate new messages */
   num_new = maildir_move_to_context(m, &md);
   if (num_new > 0)
-    mx_update_context(ctx, num_new);
+    mx_update_context(ctx);
 
   if (occult)
     return MUTT_REOPENED;

--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -1031,7 +1031,7 @@ static int mbox_mbox_check(struct Context *ctx, int *index_hint)
   {
     if (mbox_mbox_open(m, ctx) < 0)
       return -1;
-    mx_update_context(ctx, m->msg_count);
+    mx_update_context(ctx);
   }
 
   struct stat st;
@@ -1094,7 +1094,7 @@ static int mbox_mbox_check(struct Context *ctx, int *index_hint)
             mmdf_parse_mailbox(ctx);
 
           if (m->msg_count > old_msg_count)
-            mx_update_context(ctx, m->msg_count > old_msg_count);
+            mx_update_context(ctx);
 
           /* Only unlock the folder if it was locked inside of this routine.
            * It may have been locked elsewhere, like in
@@ -1124,7 +1124,7 @@ static int mbox_mbox_check(struct Context *ctx, int *index_hint)
   {
     if (reopen_mailbox(ctx, index_hint) != -1)
     {
-      mx_update_context(ctx, m->msg_count);
+      mx_update_context(ctx);
       if (unlock)
       {
         mbox_unlock_mailbox(m);

--- a/mx.c
+++ b/mx.c
@@ -1120,8 +1120,13 @@ int mx_mbox_check(struct Context *ctx, int *index_hint)
     return -1;
 
   struct Mailbox *m = ctx->mailbox;
+  int rc = m->mx_ops->mbox_check(ctx, index_hint);
+  if (rc == MUTT_NEW_MAIL || rc == MUTT_REOPENED)
+  {
+    mx_update_context(ctx);
+  }
 
-  return m->mx_ops->mbox_check(ctx, index_hint);
+  return rc;
 }
 
 /**

--- a/mx.h
+++ b/mx.h
@@ -282,7 +282,7 @@ int                 mx_check_empty      (const char *path);
 void                mx_fastclose_mailbox(struct Context *ctx);
 const struct MxOps *mx_get_ops          (enum MailboxType magic);
 bool                mx_tags_is_supported(struct Mailbox *m);
-void                mx_update_context   (struct Context *ctx, int new_messages);
+void                mx_update_context   (struct Context *ctx);
 void                mx_update_tables    (struct Context *ctx, bool committing);
 void                mx_cleanup_context  (struct Context *ctx);
 

--- a/nntp/nntp.c
+++ b/nntp/nntp.c
@@ -1692,21 +1692,7 @@ static int check_mailbox(struct Context *ctx)
   /* some headers were removed, context must be updated */
   if (ret == MUTT_REOPENED)
   {
-    if (m->subj_hash)
-      mutt_hash_destroy(&m->subj_hash);
-    if (m->id_hash)
-      mutt_hash_destroy(&m->id_hash);
-    mutt_clear_threads(ctx);
-
-    m->vcount = 0;
-    m->msg_deleted = 0;
-    m->msg_new = 0;
-    m->msg_unread = 0;
-    m->msg_flagged = 0;
-    m->changed = false;
-    m->id_hash = NULL;
-    m->subj_hash = NULL;
-    mx_update_context(ctx, m->msg_count);
+    mx_update_context(ctx);
   }
 
   /* fetch headers of new articles */
@@ -1728,7 +1714,7 @@ static int check_mailbox(struct Context *ctx)
     if (rc == 0)
     {
       if (m->msg_count > old_msg_count)
-        mx_update_context(ctx, m->msg_count > old_msg_count);
+        mx_update_context(ctx);
       mdata->last_loaded = mdata->last_message;
     }
     if (ret == 0 && m->msg_count > oldmsgcount)
@@ -2297,7 +2283,7 @@ int nntp_check_msgid(struct Context *ctx, const char *msgid)
   e->changed = true;
   e->received = e->date_sent;
   e->index = m->msg_count++;
-  mx_update_context(ctx, 1);
+  mx_update_context(ctx);
   return 0;
 }
 
@@ -2367,7 +2353,7 @@ int nntp_check_children(struct Context *ctx, const char *msgid)
       break;
   }
   if (m->msg_count > old_msg_count)
-    mx_update_context(ctx, m->msg_count > old_msg_count);
+    mx_update_context(ctx);
 
 #ifdef USE_HCACHE
   mutt_hcache_close(hc);

--- a/notmuch/mutt_notmuch.c
+++ b/notmuch/mutt_notmuch.c
@@ -1632,7 +1632,7 @@ int nm_read_entire_thread(struct Context *ctx, struct Email *e)
   rc = 0;
 
   if (m->msg_count > mdata->oldmsgcount)
-    mx_update_context(ctx, m->msg_count - mdata->oldmsgcount);
+    mx_update_context(ctx);
 done:
   if (q)
     notmuch_query_destroy(q);
@@ -2286,7 +2286,7 @@ static int nm_mbox_check(struct Context *ctx, int *index_hint)
   }
 
   if (m->msg_count > mdata->oldmsgcount)
-    mx_update_context(ctx, m->msg_count - mdata->oldmsgcount);
+    mx_update_context(ctx);
 done:
   if (q)
     notmuch_query_destroy(q);

--- a/pop/pop.c
+++ b/pop/pop.c
@@ -928,7 +928,7 @@ static int pop_mbox_check(struct Context *ctx, int *index_hint)
   int ret = pop_fetch_headers(ctx);
   pop_clear_cache(adata);
   if (m->msg_count > old_msg_count)
-    mx_update_context(ctx, m->msg_count > old_msg_count);
+    mx_update_context(ctx);
 
   if (ret < 0)
     return -1;


### PR DESCRIPTION
* **What does this PR do?**

This tries to avoid going out of sync with mailbox <-> context, by calling `mx_update_context` in a few more places and by making sure that if we call it twice we don't crash.

This is at the cost of recomputing the whole of `Context` each time we call `mx_update_context`.