### PR TITLE
reset notmuch Mailbox->size on opening

### DIFF
--- a/notmuch/mutt_notmuch.c
+++ b/notmuch/mutt_notmuch.c
@@ -2136,6 +2136,7 @@ static int nm_mbox_open(struct Mailbox *m, struct Context *ctx)
     m->hdrmax = m->msg_count;
     m->msg_count = 0;
     m->vcount = 0;
+    m->size = 0;
     mx_alloc_memory(m);
   }
 


### PR DESCRIPTION
previous behaviour: size was not reset. This resulted in mailbox size to
accumulate on each mailbox reopening, hence displaying incorrect mailbox
size information in the status bar.

new behaviour: size is reset to zero.

steps to replicate previous behaviour: open neomutt with vfolder. Press
space to refresh vfolder (open from sidebar) several times. Mailbox size
in the status bar accumulates.

* **What does this PR do?**

fixes a small bug in status bar when using notmuch