### PR TITLE
Add $auto_subscribe variable.

### DIFF
--- a/doc/manual.xml.head
+++ b/doc/manual.xml.head
@@ -8640,7 +8640,10 @@ roessler@does-not-exist.org        Thomas Roessler mutt pgp
         through the use of the
         <link linkend="lists"><command>lists</command></link> and
         <link linkend="lists"><command>subscribe</command></link> commands in
-        your <literal>.neomuttrc</literal>.
+        your <literal>.neomuttrc</literal>. Alternatively or additionally, you
+        can set <link linkend="auto-subscribe">$auto_subscribe</link> to 
+        automatically subscribe addresses found in a <literal>List-Post</literal>
+        header.
       </para>
       <para>
         Now that NeoMutt knows what your mailing lists are, it can do several
@@ -14563,7 +14566,6 @@ color index_tags green default
 </screen>
 
       </sect2>
-
       <sect2 id="custom-tags-credits">
         <title>Credits</title>
         <itemizedlist>

--- a/email/parse.h
+++ b/email/parse.h
@@ -30,6 +30,7 @@ struct Body;
 struct Envelope;
 struct Email;
 
+void             mutt_auto_subscribe(const char *mailto);
 int              mutt_check_encoding(const char *c);
 int              mutt_check_mime_type(const char *s);
 char *           mutt_extract_message_id(const char *s, const char **saveptr);

--- a/globals.h
+++ b/globals.h
@@ -54,8 +54,9 @@ WHERE char *LastFolder;    ///< Previously selected mailbox
 
 extern const char *GitVer;
 
-WHERE struct Hash *ReverseAliases; ///< Hash table of aliases (email address -> alias)
-WHERE struct Hash *TagFormats;     ///< Hash table of tag-formats (tag -> format string)
+WHERE struct Hash *ReverseAliases;     ///< Hash table of aliases (email address -> alias)
+WHERE struct Hash *TagFormats;         ///< Hash table of tag-formats (tag -> format string)
+WHERE struct Hash *AutoSubscribeCache; ///< Hash table of auto-subscribed mailing lists
 
 /* Lists of strings */
 WHERE struct ListHead AlternativeOrderList INITVAL(STAILQ_HEAD_INITIALIZER(AlternativeOrderList)); ///< List of preferred mime types to display
@@ -201,6 +202,7 @@ WHERE bool AsciiChars;                     ///< Config: Use plain ASCII characte
 WHERE bool Askbcc;                         ///< Config: Ask the user for the blind-carbon-copy recipients
 WHERE bool Askcc;                          ///< Config: Ask the user for the carbon-copy recipients
 WHERE bool Autoedit;                       ///< Config: Skip the initial compose menu and edit the email
+WHERE bool AutoSubscribe;                  ///< Config: Automatically check if the user is subscribed to a mailing list
 WHERE bool AutoTag;                        ///< Config: Automatically apply actions to all tagged messages
 WHERE bool Beep;                           ///< Config: Make a noise when an error occurs
 WHERE bool BeepNew;                        ///< Config: Make a noise when new mail arrives

--- a/hcache/serialize.c
+++ b/hcache/serialize.c
@@ -37,6 +37,8 @@
 #include <sys/types.h>
 #include "mutt/mutt.h"
 #include "email/lib.h"
+#include "email/parse.h"
+#include "globals.h"
 #include "hcache.h"
 
 /**
@@ -538,6 +540,10 @@ void serial_restore_envelope(struct Envelope *env, const unsigned char *d, int *
   serial_restore_address(&env->mail_followup_to, d, off, convert);
 
   serial_restore_char(&env->list_post, d, off, convert);
+
+  if (AutoSubscribe)
+    mutt_auto_subscribe(env->list_post);
+
   serial_restore_char(&env->subject, d, off, convert);
   serial_restore_int((unsigned int *) (&real_subj_off), d, off);
 

--- a/init.c
+++ b/init.c
@@ -2269,6 +2269,7 @@ static int parse_unignore(struct Buffer *buf, struct Buffer *s,
 static int parse_unlists(struct Buffer *buf, struct Buffer *s,
                          unsigned long data, struct Buffer *err)
 {
+  mutt_hash_destroy(&AutoSubscribeCache);
   do
   {
     mutt_extract_token(buf, s, 0);
@@ -2363,6 +2364,7 @@ static int parse_unsubjectrx_list(struct Buffer *buf, struct Buffer *s,
 static int parse_unsubscribe(struct Buffer *buf, struct Buffer *s,
                              unsigned long data, struct Buffer *err)
 {
+  mutt_hash_destroy(&AutoSubscribeCache);
   do
   {
     mutt_extract_token(buf, s, 0);

--- a/init.h
+++ b/init.h
@@ -359,6 +359,15 @@ struct ConfigDef MuttVars[] = {
   ** will use your locale environment, so there is no need to set
   ** this except to override that default.
   */
+  { "auto_subscribe",   DT_BOOL, R_NONE, &AutoSubscribe, false },
+  /*
+  ** .pp
+  ** When \fIset\fP, Mutt assumes the presence of a List-Post header
+  ** means the recipient is subscribed to the list.  Unless the mailing list
+  ** is in the ``unsubscribe'' or ``unlist'' lists, it will be added
+  ** to the ``$subscribe'' list.  Parsing and checking these things slows
+  ** header reading down, so this option is disabled by default.
+  */
   { "auto_tag",         DT_BOOL, R_NONE, &AutoTag, false },
   /*
   ** .pp


### PR DESCRIPTION
When set, it automatically subscribes to mailing lists found in
List-Post headers.

This commit is based on Michael Elkins's patch from the thread
<https://marc.info/?l=mutt-users&m=127076105423565&w=2>.

I've added an opt-in variable $auto_subscribe and a hash table cache
to speed up reading headers when the variable is set.

Co-authored-by: Austin Ray <austin@austinray.io>

