### PR TITLE
Devel/ext search with folder

### DIFF
--- a/compress.c
+++ b/compress.c
@@ -268,18 +268,20 @@ static const char *compress_format_str(char *buf, size_t buflen, size_t col, int
     return src;
 
   struct Mailbox *m = (struct Mailbox *) data;
+  const char *stuffing = NULL;
 
   switch (op)
   {
     case 'f':
       /* Compressed file */
-      snprintf(buf, buflen, "%s", NONULL(mutt_path_escape(m->realpath)));
+      stuffing = mutt_path_escape(m->realpath);
       break;
     case 't':
       /* Plaintext, temporary file */
-      snprintf(buf, buflen, "%s", NONULL(mutt_path_escape(m->path)));
+      stuffing = mutt_path_escape(m->path);
       break;
   }
+  snprintf(buf, buflen, "%s", NONULL(stuffing));
   return src;
 }
 


### PR DESCRIPTION
It passes the extra folder path argument to the external search filter, as we discussed.

Also, a small side fix in compress.c : escape_path() was double-evaluated.

I have left a number of separate commits because I think they reflect separate changes, but I can squash them if you prefer that.
