### PR TITLE
imap: open hcache only once per Mailbox

### DIFF
--- a/imap/imap.c
+++ b/imap/imap.c
@@ -787,10 +787,6 @@ void imap_expunge_mailbox(struct Mailbox *m)
   int cacheno;
   short old_sort;
 
-#ifdef USE_HCACHE
-  mdata->hcache = imap_hcache_open(adata, mdata);
-#endif
-
   old_sort = Sort;
   Sort = SORT_ORDER;
   mutt_sort_headers(adata->ctx, false);
@@ -846,10 +842,6 @@ void imap_expunge_mailbox(struct Mailbox *m)
       e->active = true;
     }
   }
-
-#ifdef USE_HCACHE
-  imap_hcache_close(mdata);
-#endif
 
   /* We may be called on to expunge at any time. We can't rely on the caller
    * to always know to rethread */
@@ -1692,10 +1684,6 @@ int imap_sync_mailbox(struct Context *ctx, bool expunge, bool close)
     }
   }
 
-#ifdef USE_HCACHE
-  mdata->hcache = imap_hcache_open(adata, mdata);
-#endif
-
   /* save messages with real (non-flag) changes */
   for (int i = 0; i < m->msg_count; i++)
   {
@@ -1729,10 +1717,6 @@ int imap_sync_mailbox(struct Context *ctx, bool expunge, bool close)
       }
     }
   }
-
-#ifdef USE_HCACHE
-  imap_hcache_close(mdata);
-#endif
 
   /* presort here to avoid doing 10 resorts in imap_exec_msgset */
   oldsort = Sort;

--- a/imap/imap_private.h
+++ b/imap/imap_private.h
@@ -316,7 +316,6 @@ struct ImapAccountData *imap_adata_get(struct Mailbox *m);
 struct ImapMboxData *imap_mdata_get(struct Mailbox *m);
 #ifdef USE_HCACHE
 header_cache_t *imap_hcache_open(struct ImapAccountData *adata, struct ImapMboxData *mdata);
-void imap_hcache_close(struct ImapMboxData *mdata);
 struct Email *imap_hcache_get(struct ImapMboxData *mdata, unsigned int uid);
 int imap_hcache_put(struct ImapMboxData *mdata, struct Email *e);
 int imap_hcache_del(struct ImapMboxData *mdata, unsigned int uid);

--- a/imap/message.c
+++ b/imap/message.c
@@ -972,7 +972,6 @@ static int read_headers_condstore_qresync_updates(struct ImapAccountData *adata,
   /* VANISHED handling: we need to empty out the messages */
   if (mdata->reopen & IMAP_EXPUNGE_PENDING)
   {
-    imap_hcache_close(mdata);
     imap_expunge_mailbox(m);
 
     /* undo expunge count updates.
@@ -985,7 +984,6 @@ static int read_headers_condstore_qresync_updates(struct ImapAccountData *adata,
     m->msg_flagged = 0;
     m->changed = 0;
 
-    mdata->hcache = imap_hcache_open(adata, mdata);
     mdata->reopen &= ~IMAP_EXPUNGE_PENDING;
   }
 
@@ -1258,8 +1256,6 @@ int imap_read_headers(struct Mailbox *m, unsigned int msn_begin,
   mdata->new_mail_count = 0;
 
 #ifdef USE_HCACHE
-  mdata->hcache = imap_hcache_open(adata, mdata);
-
   if (mdata->hcache && initial_download)
   {
     uid_validity = mutt_hcache_fetch_raw(mdata->hcache, "/UIDVALIDITY", 12);
@@ -1395,7 +1391,6 @@ int imap_read_headers(struct Mailbox *m, unsigned int msn_begin,
 
 bail:
 #ifdef USE_HCACHE
-  imap_hcache_close(mdata);
   FREE(&uid_seqset);
 #endif /* USE_HCACHE */
 


### PR DESCRIPTION
This change keeps the hcache open as long as the Mailbox is alive.