### PR TITLE
imap: remove ImapCache

### DIFF
--- a/imap/imap.c
+++ b/imap/imap.c
@@ -784,7 +784,6 @@ void imap_expunge_mailbox(struct Mailbox *m)
     return;
 
   struct Email *e = NULL;
-  int cacheno;
   short old_sort;
 
 #ifdef USE_HCACHE
@@ -810,15 +809,6 @@ void imap_expunge_mailbox(struct Mailbox *m)
 #ifdef USE_HCACHE
       imap_hcache_del(mdata, imap_edata_get(e)->uid);
 #endif
-
-      /* free cached body from disk, if necessary */
-      cacheno = imap_edata_get(e)->uid % IMAP_CACHE_LEN;
-      if (mdata->cache[cacheno].uid == imap_edata_get(e)->uid &&
-          mdata->cache[cacheno].path)
-      {
-        unlink(mdata->cache[cacheno].path);
-        FREE(&mdata->cache[cacheno].path);
-      }
 
       mutt_hash_int_delete(mdata->uid_hash, imap_edata_get(e)->uid, e);
 

--- a/imap/imap_private.h
+++ b/imap/imap_private.h
@@ -143,15 +143,6 @@ enum ImapCaps
 };
 
 /**
- * struct ImapCache - IMAP-specific message cache
- */
-struct ImapCache
-{
-  unsigned int uid;
-  char *path;
-};
-
-/**
  * struct ImapList - Items in an IMAP browser
  */
 struct ImapList
@@ -242,7 +233,6 @@ struct ImapMboxData
   unsigned int unseen;
 
   // Cached data used only when the mailbox is opened
-  struct ImapCache cache[IMAP_CACHE_LEN];
   struct Hash *uid_hash;
   struct Email **msn_index;   /**< look up headers by (MSN-1) */
   size_t msn_index_size;       /**< allocation size */

--- a/imap/util.c
+++ b/imap/util.c
@@ -206,16 +206,6 @@ void imap_mdata_cache_reset(struct ImapMboxData *mdata)
   FREE(&mdata->msn_index);
   mdata->msn_index_size = 0;
   mdata->max_msn = 0;
-
-  for (int i = 0; i < IMAP_CACHE_LEN; i++)
-  {
-    if (mdata->cache[i].path)
-    {
-      unlink(mdata->cache[i].path);
-      FREE(&mdata->cache[i].path);
-    }
-  }
-
   mutt_bcache_close(&mdata->bcache);
 }
 


### PR DESCRIPTION
The ImapCache is useless since it's used only when we fail bcache.
And this is not really expected.