### PR TITLE
Command prompt should close when deleting the ':' as it does in vim

### DIFF
--- a/enter.c
+++ b/enter.c
@@ -303,7 +303,13 @@ int mutt_enter_string_full(char *buf, size_t buflen, int col, int flags, bool mu
 
         case OP_EDITOR_BACKSPACE:
           if (state->curpos == 0)
+          {
+            // Pressing backspace when no text is in the command prompt shold exit the prompt
+            if (state->lastchar == 0)
+              goto bye;
+            // Pressing backspace with text in the command prompt should just beep
             BEEP();
+          }
           else
           {
             i = state->curpos;


### PR DESCRIPTION
Fixes #1505 