### PR TITLE
imap: command: Adds unique sequence IDs

### DIFF
--- a/imap/command.c
+++ b/imap/command.c
@@ -109,7 +109,7 @@ static struct ImapCommand *cmd_new(struct ImapAccountData *adata)
   cmd = adata->cmds + adata->nextcmd;
   adata->nextcmd = (adata->nextcmd + 1) % adata->cmdslots;
 
-  snprintf(cmd->seq, sizeof(cmd->seq), "a%04u", adata->seqno++);
+  snprintf(cmd->seq, sizeof(cmd->seq), "%c%04u", adata->seqid, adata->seqno++);
   if (adata->seqno > 9999)
     adata->seqno = 0;
 

--- a/imap/imap_private.h
+++ b/imap/imap_private.h
@@ -185,7 +185,8 @@ struct ImapAccountData
    * it's just no fun to get the same information twice */
   char *capstr;
   unsigned char capabilities[(IMAP_CAP_MAX + 7) / 8];
-  unsigned int seqno; ///< tag sequence number, e.g. 'a0001'
+  unsigned char seqid; /* tag sequence prefix */
+  unsigned int seqno; ///< tag sequence number, e.g. '{seqid}0001'
   time_t lastread; /**< last time we read a command for the server */
   char *buf;
   size_t blen;

--- a/imap/util.c
+++ b/imap/util.c
@@ -99,10 +99,15 @@ void imap_adata_free(void **ptr)
 struct ImapAccountData *imap_adata_new(void)
 {
   struct ImapAccountData *adata = mutt_mem_calloc(1, sizeof(struct ImapAccountData));
+  static unsigned char new_seqid = 'a';
 
+  adata->seqid = new_seqid;
   adata->cmdbuf = mutt_buffer_new();
   adata->cmdslots = ImapPipelineDepth + 2;
   adata->cmds = mutt_mem_calloc(adata->cmdslots, sizeof(*adata->cmds));
+
+  if (++new_seqid > 'z')
+    new_seqid = 'a';
 
   return adata;
 }


### PR DESCRIPTION
This patch adds support for unique sequence IDs to be logged. Each
new imap account is assigned an ID letter (seqid) which increments
to the next letter (and wraps at 'z') each time a new imap account
is created.

Signed-off-by: Mark Stenglein <mark@stengle.in>

* **Does this PR meet the acceptance criteria?** (This is just a reminder for you,
  this section can be removed if you fulfill it.)

   - Documentation created/updated (you have to edit
     [doc/manual.xml.head](https://www.github.com/neomutt/neomutt/blob/master/doc/manual.xml.head)
     for that)

   - All builds and tests are passing

   - Added [doxygen code documentation](https://neomutt.org/dev/doxygen)
     [syntax](http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html)

   - Code follows the [style guide](https://neomutt.org/dev/coding-style)

* **What are the relevant issue numbers?**
