### PR TITLE
Change folder with description in addition to path

### DIFF
--- a/mailbox.c
+++ b/mailbox.c
@@ -290,6 +290,27 @@ struct Mailbox *mutt_find_mailbox(const char *path)
 }
 
 /**
+ * mutt_find_mailbox_desc - Find the mailbox with a given description
+ * @param desc Description to match
+ * @retval ptr Matching Mailbox
+ * @retval NULL No matching mailbox found
+ */
+struct Mailbox *mutt_find_mailbox_desc(const char *desc)
+{
+  if (!desc)
+    return NULL;
+
+  struct MailboxNode *np = NULL;
+  STAILQ_FOREACH(np, &AllMailboxes, entries)
+  {
+    if (np->m->desc && mutt_str_strcmp(np->m->desc, desc) == 0)
+      return np->m;
+  }
+
+  return NULL;
+}
+
+/**
  * mutt_update_mailbox - Get the mailbox's current size
  * @param m Mailbox to check
  */

--- a/mailbox.h
+++ b/mailbox.h
@@ -149,6 +149,7 @@ void            mailbox_free(struct Mailbox **m);
 void            mutt_context_free(struct Context **ctx);
 
 struct Mailbox *mutt_find_mailbox(const char *path);
+struct Mailbox *mutt_find_mailbox_desc(const char *desc);
 void mutt_update_mailbox(struct Mailbox *m);
 
 void mutt_mailbox_cleanup(const char *path, struct stat *st);


### PR DESCRIPTION
**What does this PR do?**

Adds the ability to change folders based on description instead of path. With the introduction of `named-mailboxes` and removal of `virtual-mailboxes`'s special cases, we cannot assume that the user will always provide a path. 

Instead of bailing when path probing fails, try to find a mailbox with a matching description. If successful, overwrite the buffer with its path.

Areas to review before merging:
1. Free allocated memory
    `mutt_str_strdup()` allocates memory, but I have not included a `FREE()` call. I believe two `FREE()` calls are needed: before the `return` on line 620. and after the `mutt_str_replace()` call on line 625. Replacing the `mutt_str_strdup()` with a pointer to `m->path` may obviate any new `FREE()` calls.
2. The affect on hooks.
    This may not be an issue since descriptions would result in bailing before attempting to execute a hook. Since this PR makes sure `buf` is a path, not a description, we shouldn't run into any issues. However, further analysis is warranted to confirm whether or not this is an issue.

**What are the relevant issue numbers?**

#1470