### PR TITLE
solarized dark color scheme: Remove outdated comment about ncurses

### DIFF
--- a/contrib/colorschemes/solarized-dark-256.neomuttrc
+++ b/contrib/colorschemes/solarized-dark-256.neomuttrc
@@ -1,10 +1,5 @@
 # vim: filetype=muttrc
 
-#
-#
-# make sure that you are using neomutt linked against slang, not ncurses, or
-# suffer the consequences of weird color issues. use "neomutt -v" to check this.
-
 # custom body highlights -----------------------------------------------
 # highlight my name and other personally relevant strings
 #color body          color136        color234        "(ethan|schoonover)"


### PR DESCRIPTION
slang is no longer a requirement for proper colors, one likely related fix is

commit a7102c721893d6a6fc33a8e9590f99c450e9fe9e
Author: Fabrice Bellet <fabrice@bellet.info>
Date:   Fri Aug 4 21:16:53 2017 +0200

    color: call use_default_colors() in a single location

    we call use_default_colors() when parsing colors in rc files only, and
    unconditionally when defining the color of the tree element, because the
    foreground color of the tree element may be combined dynamically with
    the default background color of another element, not explicitely defined
    in an rc file. This patch fixes a bug visible with some versions of the
    ncurses library: use_default_colors() was used too late, and generated
    color leakage effects. (#689)

-> colors look fine on Fedora 28 with ncurses backend. The comment about slang
was in there since the first submission to git in early 2017.
