### PR TITLE
fix: mutt/charset.c: only include libintl.h if ENABLE_NLS is defined

### DIFF
--- a/mutt/charset.c
+++ b/mutt/charset.c
@@ -31,7 +31,6 @@
 #include <errno.h>
 #include <iconv.h>
 #include <langinfo.h>
-#include <libintl.h>
 #include <limits.h>
 #include <regex.h>
 #include <stdbool.h>
@@ -43,6 +42,9 @@
 #include "queue.h"
 #include "regex3.h"
 #include "string2.h"
+#ifdef ENABLE_NLS
+#include <libintl.h>
+#endif
 
 #ifndef EILSEQ
 #define EILSEQ EINVAL


### PR DESCRIPTION
* **What does this PR do?**

Running make with `./configure --disable-nls` fails when it encounters `mutt/charset.c` since it tries to include `libintl.h` which is part of gettext (which for reasons unknown is installed but broken on my mac so I need to disable NLS).

```
$ ./configure --disable-nls
[...]
$ make
[...]
cc -g -O2 -std=c99 -D_ALL_SOURCE=1 -D_GNU_SOURCE=1 -D__EXTENSIONS__ -DNCURSES_WIDECHAR -I/usr/local/include -I. -I. -Wall  -I./test -MT mutt/charset.o -MD -MP -MF mutt/charset.Tpo -c -o mutt/charset.o mutt/charset.c
mutt/charset.c:34:10: fatal error: 'libintl.h' file not found
#include <libintl.h>
         ^~~~~~~~~~~
1 error generated.
make: *** [mutt/charset.o] Error 1
make: *** Waiting for unfinished jobs....
```

* **What are the relevant issue numbers?**
N/A