### PR TITLE
notmuch: make sure nm_db_longrun_done() release DB

### DIFF
--- a/notmuch/nm_db.c
+++ b/notmuch/nm_db.c
@@ -302,8 +302,14 @@ void nm_db_longrun_done(struct Mailbox *m)
 {
   struct NmAccountData *adata = nm_adata_get(m);
 
-  if (adata && (nm_db_release(m) == 0))
-    mutt_debug(2, "nm: long run deinitialized\n");
+  if (adata)
+  {
+    adata->longrun = false; /* to force nm_db_release() released DB */
+    if (nm_db_release(m) == 0)
+      mutt_debug(2, "nm: long run deinitialized\n");
+    else
+      adata->longrun = true;
+  }
 }
 
 /**


### PR DESCRIPTION
Since commit 1cdfc0da08e09b1756a7b4d422996e907c4390d0 the function
nm_db_release() does not release DB if long-run state is enabled.
This change make code more readable and shorter.

Unfortunately, nm_db_release() is called from nm_db_longrun_done(), so
after the change the function nm_db_longrun_done() is no-op and long
transaction never finish. It means:

 - changes are not committed the database
 - after mutt restart old state (tags) is read from DB
 - mismatch between notmuch tags and maildir filenames

This commit disables long-run state in nm_db_longrun_done() before
nm_db_release() is called.