### PR TITLE
folder-hook: try matching on description

### DIFF
--- a/hook.c
+++ b/hook.c
@@ -369,10 +369,14 @@ enum CommandResult mutt_parse_unhook(struct Buffer *buf, struct Buffer *s,
 
 /**
  * mutt_folder_hook - Perform a folder hook
- * @param path Path to match
+ * @param path Path to potentially match
+ * @param desc Description to potentially match
  */
-void mutt_folder_hook(const char *path)
+void mutt_folder_hook(const char *path, const char *desc)
 {
+  if (!path && !desc)
+    return;
+
   struct Hook *tmp = NULL;
   struct Buffer err, token;
 
@@ -389,7 +393,8 @@ void mutt_folder_hook(const char *path)
 
     if (tmp->type & MUTT_FOLDER_HOOK)
     {
-      if ((regexec(tmp->regex.regex, path, 0, NULL, 0) == 0) ^ tmp->regex.not)
+      if ((path && (regexec(tmp->regex.regex, path, 0, NULL, 0) == 0) ^ tmp->regex.not) ||
+          (desc && (regexec(tmp->regex.regex, desc, 0, NULL, 0) == 0) ^ tmp->regex.not))
       {
         if (mutt_parse_rc_line(tmp->command, &token, &err) == MUTT_CMD_ERROR)
         {

--- a/hook.h
+++ b/hook.h
@@ -66,7 +66,7 @@ void  mutt_crypt_hook(struct ListHead *list, struct Address *addr);
 void  mutt_default_save(char *path, size_t pathlen, struct Email *e);
 void  mutt_delete_hooks(int type);
 char *mutt_find_hook(int type, const char *pat);
-void  mutt_folder_hook(const char *path);
+void  mutt_folder_hook(const char *path, const char *desc);
 void  mutt_message_hook(struct Mailbox *m, struct Email *e, int type);
 enum CommandResult mutt_parse_hook(struct Buffer *buf, struct Buffer *s, unsigned long data, struct Buffer *err);
 enum CommandResult mutt_parse_unhook(struct Buffer *buf, struct Buffer *s, unsigned long data, struct Buffer *err);

--- a/index.c
+++ b/index.c
@@ -633,7 +633,7 @@ static int main_change_folder(struct Menu *menu, int op, struct Mailbox *m,
    * mutt_push/pop_current_menu() functions.  If that changes, the menu
    * would need to be reset here, and the pager cleanup code after the
    * switch statement would need to be run. */
-  mutt_folder_hook(buf);
+  mutt_folder_hook(buf, m->desc);
 
   const int flags =
       (ReadOnly || (op == OP_MAIN_CHANGE_FOLDER_READONLY)) ? MUTT_READONLY : 0;

--- a/main.c
+++ b/main.c
@@ -1201,7 +1201,7 @@ int main(int argc, char *argv[], char *envp[])
       }
     }
 
-    mutt_folder_hook(folder);
+    mutt_folder_hook(folder, NULL);
     mutt_startup_shutdown_hook(MUTT_STARTUP_HOOK);
 
     repeat_error = true;

--- a/sendlib.c
+++ b/sendlib.c
@@ -3180,7 +3180,7 @@ int mutt_write_fcc(const char *path, struct Email *e, const char *msgid,
     set_noconv_flags(e->content, true);
 
 #ifdef RECORD_FOLDER_HOOK
-  mutt_folder_hook(path);
+  mutt_folder_hook(path, NULL);
 #endif
   struct Context *f = mx_mbox_open(NULL, path, MUTT_APPEND | MUTT_QUIET);
   if (!f)
@@ -3377,7 +3377,7 @@ done:
   /* We ran a folder hook for the destination mailbox,
    * now we run it for the user's current mailbox */
   if (Context && Context->mailbox->path)
-    mutt_folder_hook(Context->mailbox->path);
+    mutt_folder_hook(Context->mailbox->path, Context->mailbox->desc);
 #endif
 
   return rc;


### PR DESCRIPTION
Use the description, in addition to the path, when determining to
execute a `folder-hook`. Since `named-mailboxes` and `virtual-mailboxes`
use descriptions to hide ugliness of raw paths, the description may
differ from the path and/or contain information not included in the
path.

The inclusion of description checking makes `folder-hook`s improves its
ergonomics. `notmuch` users were particularly affect by poor
`folder-hook` ergonomics since `virtual-mailboxes` paths often had large
overlap, making it hard to craft a good regex. A workaround was to add a
unique dummy key.

**What are the relevant issue numbers?**
#1125 was tracking `folder-hook` and `notmuch` usage. This PR would provide a proper solution.

**Notes**
This may cause some issues with existing `folder-hook`s if a user is already using `virtual-mailboxes` since existing hooks may now match `virtual-mailboxes` descriptions. This would affect anyone using `named-mailboxes` as well, but that is a much smaller subset of our users.
