### PR TITLE
test: add pattern compilation tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ neomutt
 pgpewrap
 test/config-test
 test/neomutt-test
+test/pattern-test
 
 # Build products
 *.o

--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -61,31 +61,33 @@ ALL_FILES!=	(cd $(SRCDIR) && git ls-files 2>/dev/null) || true
 ###############################################################################
 # neomutt
 NEOMUTT=	neomutt$(EXEEXT)
-NEOMUTTOBJS=	account.o addrbook.o alias.o bcache.o browser.o color.o commands.o \
-		complete.o compose.o compress.o conststrings.o context.o copy.o \
-		curs_lib.o edit.o editmsg.o enriched.o enter.o \
-		filter.o flags.o git_ver.o handler.o hdrline.o help.o hook.o \
-		index.o init.o keymap.o mailbox.o main.o menu.o muttlib.o \
-		mutt_account.o mutt_attach.o mutt_body.o mutt_header.o \
-		mutt_history.o mutt_logging.o mutt_parse.o mutt_signal.o \
-		mutt_socket.o mutt_thread.o mutt_url.o mutt_window.o mx.o myvar.o \
-		pager.o pattern.o postpone.o progress.o query.o recvattach.o \
-		recvcmd.o resize.o rfc1524.o rfc3676.o safe_asprintf.o \
-		score.o send.o sendlib.o sidebar.o smtp.o sort.o state.o \
-		status.o system.o terminal.o version.o icommands.o
+NEOMUTTOBJS_NO_MAIN=	account.o addrbook.o alias.o bcache.o browser.o color.o commands.o \
+			complete.o compose.o compress.o conststrings.o context.o copy.o \
+			curs_lib.o edit.o editmsg.o enriched.o enter.o \
+			filter.o flags.o git_ver.o handler.o hdrline.o help.o hook.o \
+			index.o init.o keymap.o mailbox.o menu.o muttlib.o \
+			mutt_account.o mutt_attach.o mutt_body.o mutt_header.o \
+			mutt_history.o mutt_logging.o mutt_parse.o mutt_signal.o \
+			mutt_socket.o mutt_thread.o mutt_url.o mutt_window.o mx.o myvar.o \
+			pager.o pattern.o postpone.o progress.o query.o recvattach.o \
+			recvcmd.o resize.o rfc1524.o rfc3676.o safe_asprintf.o \
+			score.o send.o sendlib.o sidebar.o smtp.o sort.o state.o \
+			status.o system.o terminal.o version.o icommands.o
 
 @if !HAVE_WCSCASECMP
-NEOMUTTOBJS+=	wcscasecmp.o
+NEOMUTTOBJS_NO_MAIN+=	wcscasecmp.o
 @endif
 @if MIXMASTER
-NEOMUTTOBJS+=	remailer.o
+NEOMUTTOBJS_NO_MAIN+=	remailer.o
 @endif
 @if USE_LUA
-NEOMUTTOBJS+=	mutt_lua.o
+NEOMUTTOBJS_NO_MAIN+=	mutt_lua.o
 @endif
 @if USE_INOTIFY
-NEOMUTTOBJS+=	monitor.o
+NEOMUTTOBJS_NO_MAIN+=	monitor.o
 @endif
+
+NEOMUTTOBJS= $(NEOMUTTOBJS_NO_MAIN) main.o
 CLEANFILES+=	$(NEOMUTT) $(NEOMUTTOBJS)
 ALLOBJS+=	$(NEOMUTTOBJS)
 

--- a/pattern.h
+++ b/pattern.h
@@ -26,6 +26,7 @@
 #include <regex.h>
 #include <stdbool.h>
 #include <stddef.h>
+#include "mutt/list.h"
 
 struct Address;
 struct Buffer;

--- a/test/Makefile.autosetup
+++ b/test/Makefile.autosetup
@@ -6,7 +6,7 @@ TEST_OBJS   = test/main.o \
 	      test/string.o \
 	      test/address.o \
 	      test/url.o \
-          test/file.o
+	      test/file.o
 
 CONFIG_OBJS	= test/config/main.o test/config/account.o \
 		  test/config/address.o test/config/bool.o \
@@ -17,16 +17,22 @@ CONFIG_OBJS	= test/config/main.o test/config/account.o \
 		  test/config/regex.o test/config/set.o test/config/sort.o \
 		  test/config/string.o test/config/synonym.o
 
+PATTERN_OBJS	= test/pattern/main.o \
+		  test/pattern/comp.o
+
 CFLAGS	+= -I$(SRCDIR)/test
 
 TEST_BINARY = test/neomutt-test$(EXEEXT)
 
 TEST_CONFIG = test/config-test$(EXEEXT)
 
+TEST_PATTERN = test/pattern-test$(EXEEXT)
+
 .PHONY: test
-test: $(TEST_BINARY) $(TEST_CONFIG)
+test: $(TEST_BINARY) $(TEST_CONFIG) $(TEST_PATTERN)
 	$(TEST_BINARY)
 	$(TEST_CONFIG)
+	$(TEST_PATTERN)
 
 $(TEST_BINARY): $(TEST_OBJS) $(MUTTLIBS)
 	$(CC) -o $@ $(TEST_OBJS) $(MUTTLIBS) $(LDFLAGS) $(LIBS)
@@ -34,13 +40,18 @@ $(TEST_BINARY): $(TEST_OBJS) $(MUTTLIBS)
 $(TEST_CONFIG): $(PWD)/test/config $(CONFIG_OBJS) $(MUTTLIBS)
 	$(CC) -o $@ $(CONFIG_OBJS) $(MUTTLIBS) $(LDFLAGS) $(LIBS)
 
+$(TEST_PATTERN): $(PATTERN_OBJS) $(NEOMUTTOBJS_NO_MAIN) $(MUTTLIBS)
+	$(CC) -o $@ $(PATTERN_OBJS) $(NEOMUTTOBJS_NO_MAIN) $(MUTTLIBS) $(LDFLAGS) $(LIBS)
+
 $(PWD)/test/config:
 	$(MKDIR_P) $(PWD)/test/config
 
-all-test: $(TEST_BINARY) $(TEST_CONFIG)
+all-test: $(TEST_BINARY) $(TEST_CONFIG) $(TEST_PATTERN)
 
 clean-test:
-	$(RM) $(TEST_BINARY) $(TEST_OBJS) $(TEST_OBJS:.o=.Po) $(TEST_CONFIG) $(CONFIG_OBJS) $(CONFIG_OBJS:.o=.Po)
+	$(RM) $(TEST_BINARY) $(TEST_OBJS) $(TEST_OBJS:.o=.Po) \
+	      $(TEST_CONFIG) $(CONFIG_OBJS) $(CONFIG_OBJS:.o=.Po) \
+	      $(TEST_PATTERN) $(PATTERN_OBJS) $(PATTERN_OBJS:.o=.Po)
 
 install-test:
 uninstall-test:
@@ -50,5 +61,8 @@ TEST_DEPFILES = $(TEST_OBJS:.o=.Po)
 
 CONFIG_DEPFILES = $(CONFIG_OBJS:.o=.Po)
 -include $(CONFIG_DEPFILES)
+
+PATTERN_DEPFILES = $(PATTERN_OBJS:.o=.Po)
+-include $(PATTERN_DEPFILES)
 
 # vim: set ts=8 noexpandtab:

--- a/test/pattern/comp.c
+++ b/test/pattern/comp.c
@@ -1,0 +1,667 @@
+#define TEST_NO_MAIN
+#define MAIN_C 1
+#include "acutest.h"
+
+#include <assert.h>
+#include <string.h>
+#include "mutt/buffer.h"
+#include "mutt/memory.h"
+#include "pattern.h"
+
+#include "alias.h"
+#include "globals.h"
+bool ResumeEditedDraftFiles;
+
+/* All tests are limited to patterns that are stringmatch type only,
+ * such as =s, =b, =f, etc.
+ *
+ * Rationale: (1) there is no way to compare regex types as "equal",
+ *            (2) comparing Group is a pain in the arse,
+ *            (3) similarly comparing lists (ListHead) is annoying.
+ */
+
+/* canoncial representation of Pattern "tree",
+ * s specifies a caller allocated buffer to write the string,
+ * pat specifies the pattern,
+ * indent specifies the indentation level (set to 0 if pat is root of tree),
+ * returns the number of characters written to s (not including trailing '\0')
+ *
+ * A pattern tree with patterns a, b, c, d, e, f, g can be represented graphically
+ * as follows (where a is obviously the root):
+ *
+ *        +-c-+
+ *        |   |
+ *    +-b-+   +-d
+ *    |   |
+ *  a-+   +-e
+ *    |
+ *    +-f-+
+ *        |
+ *        +-g
+ *
+ *  Let left child represent "next" pattern, and right as "child" pattern.
+ *
+ *  Then we can convert the above into a textual representation as follows:
+ *    {a}
+ *      {b}
+ *        {c}
+ *        {d}
+ *      {e}
+ *    {f}
+ *    {g}
+ *
+ *  {a} is the root pattern with child pattern {b} (note: 2 space indent)
+ *  and next pattern {f} (same indent).
+ *  {b} has child {c} and next pattern {e}.
+ *  {c} has next pattern {d}.
+ *  {f} has next pattern {g}.
+ *
+ *  In the representation {a} is expanded to all the pattern fields.
+ */
+static int canonical_pattern(char *s, struct Pattern *pat, int indent)
+{
+  char *p = s;
+
+  for (int i = 0; i < 2*indent; i++) {
+    p += sprintf(p, " ");
+  }
+  p += sprintf(p, "{");
+  p += sprintf(p, "%d,", pat->op);
+  p += sprintf(p, "%d,", pat->not);
+  p += sprintf(p, "%d,", pat->alladdr);
+  p += sprintf(p, "%d,", pat->stringmatch);
+  p += sprintf(p, "%d,", pat->groupmatch);
+  p += sprintf(p, "%d,", pat->ign_case);
+  p += sprintf(p, "%d,", pat->isalias);
+  p += sprintf(p, "%d,", pat->ismulti);
+  p += sprintf(p, "%d,", pat->min);
+  p += sprintf(p, "%d,", pat->max);
+  p += sprintf(p, "\"%s\",", pat->p.str ? pat->p.str : "");
+  p += sprintf(p, "%s,", pat->child ? "(ptr)" : "(null)");
+  p += sprintf(p, "%s", pat->next ? "(ptr)" : "(null)");
+  p += sprintf(p, "}\n");
+
+  if (pat->child)
+  {
+    p += canonical_pattern(p, pat->child, indent + 1);
+  }
+
+  if (pat->next)
+    p += canonical_pattern(p, pat->next, indent);
+
+  return p - s;
+}
+
+/* best-effort pattern tree compare, returns 0 if equal otherwise 1 */
+static int cmp_pattern(struct Pattern *p1, struct Pattern *p2)
+{
+  if (!p1 || !p2)
+    return p1 || p2;
+
+  if (p1->op != p2->op)
+    return 1;
+  if (p1->not != p2->not)
+    return 1;
+  if (p1->alladdr != p2->alladdr)
+    return 1;
+  if (p1->stringmatch != p2->stringmatch)
+    return 1;
+  if (p1->groupmatch != p2->groupmatch)
+    return 1;
+  if (p1->ign_case != p2->ign_case)
+    return 1;
+  if (p1->isalias != p2->isalias)
+    return 1;
+  if (p1->ismulti != p2->ismulti)
+    return 1;
+  if (p1->min != p2->min)
+    return 1;
+  if (p1->max != p2->max)
+    return 1;
+
+  if (p1->stringmatch && strcmp(p1->p.str, p2->p.str))
+    return 1;
+
+  if (cmp_pattern(p1->child, p2->child))
+    return 1;
+
+  return cmp_pattern(p1->next, p2->next);
+}
+
+void test_mutt_pattern_comp(void)
+{
+  struct Buffer err;
+  struct Pattern *pat;
+
+  err.dsize = 1024;
+  err.data = mutt_mem_malloc(err.dsize);
+
+  { /* empty */
+    char *s = "";
+
+    mutt_buffer_reset(&err);
+    pat = mutt_pattern_comp(s, 0, &err);
+
+    if (!TEST_CHECK(!pat))
+    {
+      TEST_MSG("Expected: pat == 0");
+      TEST_MSG("Actual  : pat == %p", pat);
+    }
+
+    char *msg = "empty pattern";
+    if (!TEST_CHECK(!strcmp(err.data, msg)))
+    {
+      TEST_MSG("Expected: %s", msg);
+      TEST_MSG("Actual  : %s", err.data);
+    }
+  }
+
+  { /* invalid */
+    char *s = "x";
+
+    mutt_buffer_reset(&err);
+    pat = mutt_pattern_comp(s, 0, &err);
+
+    if (!TEST_CHECK(!pat))
+    {
+      TEST_MSG("Expected: pat == 0");
+      TEST_MSG("Actual  : pat == %p", pat);
+    }
+
+    char *msg = "error in pattern at: x";
+    if (!TEST_CHECK(!strcmp(err.data, msg)))
+    {
+      TEST_MSG("Expected: %s", msg);
+      TEST_MSG("Actual  : %s", err.data);
+    }
+  }
+
+  { /* missing parameter */
+    char *s = "=s";
+
+    mutt_buffer_reset(&err);
+    pat = mutt_pattern_comp(s, 0, &err);
+
+    if (!TEST_CHECK(!pat))
+    {
+      TEST_MSG("Expected: pat == 0");
+      TEST_MSG("Actual  : pat == %p", pat);
+    }
+
+    char *msg = "missing parameter";
+    if (!TEST_CHECK(!strcmp(err.data, msg)))
+    {
+      TEST_MSG("Expected: %s", msg);
+      TEST_MSG("Actual  : %s", err.data);
+    }
+  }
+
+  { /* error in pattern */
+    char *s = "| =s foo";
+
+    mutt_buffer_reset(&err);
+    pat = mutt_pattern_comp(s, 0, &err);
+
+    if (!TEST_CHECK(!pat))
+    {
+      TEST_MSG("Expected: pat == 0");
+      TEST_MSG("Actual  : pat == %p", pat);
+    }
+
+    char *msg = "error in pattern at: | =s foo";
+    if (!TEST_CHECK(!strcmp(err.data, msg)))
+    {
+      TEST_MSG("Expected: %s", msg);
+      TEST_MSG("Actual  : %s", err.data);
+    }
+  }
+
+  {
+    char *s = "=s foobar";
+
+    mutt_buffer_reset(&err);
+    pat = mutt_pattern_comp(s, 0, &err);
+
+    if (!TEST_CHECK(pat != NULL))
+    {
+      TEST_MSG("Expected: pat != 0");
+      TEST_MSG("Actual  : pat == %p", pat);
+    }
+
+    struct Pattern expected = { .op = 30 /* MUTT_SUBJECT */,
+                                .not = 0,
+                                .alladdr = 0,
+                                .stringmatch = 1,
+                                .groupmatch = 0,
+                                .ign_case = 1,
+                                .isalias = 0,
+                                .ismulti = 0,
+                                .min = 0,
+                                .max = 0,
+                                .next = NULL,
+                                .child = NULL,
+                                .p.str = "foobar" };
+
+    if (!TEST_CHECK(!cmp_pattern(pat, &expected)))
+    {
+      char s[1024];
+      canonical_pattern(s, &expected, 0);
+      TEST_MSG("Expected:\n%s", s);
+      canonical_pattern(s, pat, 0);
+      TEST_MSG("Actual:\n%s", s);
+    }
+
+    char *msg = "";
+    if (!TEST_CHECK(!strcmp(err.data, msg)))
+    {
+      TEST_MSG("Expected: %s", msg);
+      TEST_MSG("Actual  : %s", err.data);
+    }
+
+    mutt_pattern_free(&pat);
+  }
+
+  {
+    char *s = "! =s foobar";
+
+    mutt_buffer_reset(&err);
+    pat = mutt_pattern_comp(s, 0, &err);
+
+    if (!TEST_CHECK(pat != NULL))
+    {
+      TEST_MSG("Expected: pat != 0");
+      TEST_MSG("Actual  : pat == %p", pat);
+    }
+
+    struct Pattern expected = { .op = 30 /* MUTT_SUBJECT */,
+                                .not = 1,
+                                .alladdr = 0,
+                                .stringmatch = 1,
+                                .groupmatch = 0,
+                                .ign_case = 1,
+                                .isalias = 0,
+                                .ismulti = 0,
+                                .min = 0,
+                                .max = 0,
+                                .next = NULL,
+                                .child = NULL,
+                                .p.str = "foobar" };
+
+    if (!TEST_CHECK(!cmp_pattern(pat, &expected)))
+    {
+      char s[1024];
+      canonical_pattern(s, &expected, 0);
+      TEST_MSG("Expected:\n%s", s);
+      canonical_pattern(s, pat, 0);
+      TEST_MSG("Actual:\n%s", s);
+    }
+
+    char *msg = "";
+    if (!TEST_CHECK(!strcmp(err.data, msg)))
+    {
+      TEST_MSG("Expected: %s", msg);
+      TEST_MSG("Actual  : %s", err.data);
+    }
+
+    mutt_pattern_free(&pat);
+  }
+
+  {
+    char *s = "=s foo =s bar";
+
+    mutt_buffer_reset(&err);
+    pat = mutt_pattern_comp(s, 0, &err);
+
+    if (!TEST_CHECK(pat != NULL))
+    {
+      TEST_MSG("Expected: pat != 0");
+      TEST_MSG("Actual  : pat == %p", pat);
+    }
+
+    struct Pattern expected[3] = { /* root */
+                                   { .op = 22 /* MUTT_AND */,
+                                     .not = 0,
+                                     .alladdr = 0,
+                                     .stringmatch = 0,
+                                     .groupmatch = 0,
+                                     .ign_case = 0,
+                                     .isalias = 0,
+                                     .ismulti = 0,
+                                     .min = 0,
+                                     .max = 0,
+                                     .next = NULL,
+                                     .child = NULL,
+                                     .p.str = NULL },
+                                   /* root->child */
+                                   { .op = 30 /* MUTT_SUBJECT */,
+                                     .not = 0,
+                                     .alladdr = 0,
+                                     .stringmatch = 1,
+                                     .groupmatch = 0,
+                                     .ign_case = 1,
+                                     .isalias = 0,
+                                     .ismulti = 0,
+                                     .min = 0,
+                                     .max = 0,
+                                     .next = NULL,
+                                     .child = NULL,
+                                     .p.str = "foo" },
+                                   /* root->child->next */
+                                   { .op = 30 /* MUTT_SUBJECT */,
+                                     .not = 0,
+                                     .alladdr = 0,
+                                     .stringmatch = 1,
+                                     .groupmatch = 0,
+                                     .ign_case = 1,
+                                     .isalias = 0,
+                                     .ismulti = 0,
+                                     .min = 0,
+                                     .max = 0,
+                                     .next = NULL,
+                                     .child = NULL,
+                                     .p.str = "bar" }
+    };
+
+    expected[0].child = &expected[1];
+    expected[1].next = &expected[2];
+
+    if (!TEST_CHECK(!cmp_pattern(pat, &expected[0])))
+    {
+      char s[1024];
+      canonical_pattern(s, &expected[0], 0);
+      TEST_MSG("Expected:\n%s", s);
+      canonical_pattern(s, pat, 0);
+      TEST_MSG("Actual:\n%s", s);
+    }
+
+    char *msg = "";
+    if (!TEST_CHECK(!strcmp(err.data, msg)))
+    {
+      TEST_MSG("Expected: %s", msg);
+      TEST_MSG("Actual  : %s", err.data);
+    }
+
+    mutt_pattern_free(&pat);
+  }
+
+  {
+    char *s = "! (=s foo =s bar)";
+
+    mutt_buffer_reset(&err);
+    pat = mutt_pattern_comp(s, 0, &err);
+
+    if (!TEST_CHECK(pat != NULL))
+    {
+      TEST_MSG("Expected: pat != 0");
+      TEST_MSG("Actual  : pat == %p", pat);
+    }
+
+    struct Pattern expected[3] = { /* root */
+                                   { .op = 22 /* MUTT_AND */,
+                                     .not = 1,
+                                     .alladdr = 0,
+                                     .stringmatch = 0,
+                                     .groupmatch = 0,
+                                     .ign_case = 0,
+                                     .isalias = 0,
+                                     .ismulti = 0,
+                                     .min = 0,
+                                     .max = 0,
+                                     .next = NULL,
+                                     .child = NULL,
+                                     .p.str = NULL },
+                                   /* root->child */
+                                   { .op = 30 /* MUTT_SUBJECT */,
+                                     .not = 0,
+                                     .alladdr = 0,
+                                     .stringmatch = 1,
+                                     .groupmatch = 0,
+                                     .ign_case = 1,
+                                     .isalias = 0,
+                                     .ismulti = 0,
+                                     .min = 0,
+                                     .max = 0,
+                                     .next = NULL,
+                                     .child = NULL,
+                                     .p.str = "foo" },
+                                   /* root->child->next */
+                                   { .op = 30 /* MUTT_SUBJECT */,
+                                     .not = 0,
+                                     .alladdr = 0,
+                                     .stringmatch = 1,
+                                     .groupmatch = 0,
+                                     .ign_case = 1,
+                                     .isalias = 0,
+                                     .ismulti = 0,
+                                     .min = 0,
+                                     .max = 0,
+                                     .next = NULL,
+                                     .child = NULL,
+                                     .p.str = "bar" }
+    };
+
+    expected[0].child = &expected[1];
+    expected[1].next = &expected[2];
+
+    if (!TEST_CHECK(!cmp_pattern(pat, &expected[0])))
+    {
+      char s[1024];
+      canonical_pattern(s, &expected[0], 0);
+      TEST_MSG("Expected:\n%s", s);
+      canonical_pattern(s, pat, 0);
+      TEST_MSG("Actual:\n%s", s);
+    }
+
+    char *msg = "";
+    if (!TEST_CHECK(!strcmp(err.data, msg)))
+    {
+      TEST_MSG("Expected: %s", msg);
+      TEST_MSG("Actual  : %s", err.data);
+    }
+
+    mutt_pattern_free(&pat);
+  }
+
+  {
+    char *s = "=s foo =s bar =s quux";
+
+    mutt_buffer_reset(&err);
+    pat = mutt_pattern_comp(s, 0, &err);
+
+    if (!TEST_CHECK(pat != NULL))
+    {
+      TEST_MSG("Expected: pat != 0");
+      TEST_MSG("Actual  : pat == %p", pat);
+    }
+
+    struct Pattern expected[4] = { /* root */
+                                   { .op = 22 /* MUTT_AND */,
+                                     .not = 0,
+                                     .alladdr = 0,
+                                     .stringmatch = 0,
+                                     .groupmatch = 0,
+                                     .ign_case = 0,
+                                     .isalias = 0,
+                                     .ismulti = 0,
+                                     .min = 0,
+                                     .max = 0,
+                                     .next = NULL,
+                                     .child = NULL,
+                                     .p.str = NULL },
+                                   /* root->child */
+                                   { .op = 30 /* MUTT_SUBJECT */,
+                                     .not = 0,
+                                     .alladdr = 0,
+                                     .stringmatch = 1,
+                                     .groupmatch = 0,
+                                     .ign_case = 1,
+                                     .isalias = 0,
+                                     .ismulti = 0,
+                                     .min = 0,
+                                     .max = 0,
+                                     .next = NULL,
+                                     .child = NULL,
+                                     .p.str = "foo" },
+                                   /* root->child->next */
+                                   { .op = 30 /* MUTT_SUBJECT */,
+                                     .not = 0,
+                                     .alladdr = 0,
+                                     .stringmatch = 1,
+                                     .groupmatch = 0,
+                                     .ign_case = 1,
+                                     .isalias = 0,
+                                     .ismulti = 0,
+                                     .min = 0,
+                                     .max = 0,
+                                     .next = NULL,
+                                     .child = NULL,
+                                     .p.str = "bar" },
+                                   /* root->child->next->next */
+                                   { .op = 30 /* MUTT_SUBJECT */,
+                                     .not = 0,
+                                     .alladdr = 0,
+                                     .stringmatch = 1,
+                                     .groupmatch = 0,
+                                     .ign_case = 1,
+                                     .isalias = 0,
+                                     .ismulti = 0,
+                                     .min = 0,
+                                     .max = 0,
+                                     .next = NULL,
+                                     .child = NULL,
+                                     .p.str = "quux" }
+    };
+
+    expected[0].child = &expected[1];
+    expected[1].next = &expected[2];
+    expected[2].next = &expected[3];
+
+    if (!TEST_CHECK(!cmp_pattern(pat, &expected[0])))
+    {
+      char s[1024];
+      canonical_pattern(s, &expected[0], 0);
+      TEST_MSG("Expected:\n%s", s);
+      canonical_pattern(s, pat, 0);
+      TEST_MSG("Actual:\n%s", s);
+    }
+
+    char *msg = "";
+    if (!TEST_CHECK(!strcmp(err.data, msg)))
+    {
+      TEST_MSG("Expected: %s", msg);
+      TEST_MSG("Actual  : %s", err.data);
+    }
+
+    mutt_pattern_free(&pat);
+  }
+
+  {
+    char *s = "!(=s foo|=s bar) =s quux";
+
+    mutt_buffer_reset(&err);
+    pat = mutt_pattern_comp(s, 0, &err);
+
+    if (!TEST_CHECK(pat != NULL))
+    {
+      TEST_MSG("Expected: pat != 0");
+      TEST_MSG("Actual  : pat == %p", pat);
+    }
+
+    struct Pattern expected[5] = { /* root */
+                                   { .op = 22 /* MUTT_AND */,
+                                     .not = 0,
+                                     .alladdr = 0,
+                                     .stringmatch = 0,
+                                     .groupmatch = 0,
+                                     .ign_case = 0,
+                                     .isalias = 0,
+                                     .ismulti = 0,
+                                     .min = 0,
+                                     .max = 0,
+                                     .next = NULL,
+                                     .child = NULL,
+                                     .p.str = NULL },
+                                   /* root->child */
+                                   { .op = 23 /* MUTT_OR */,
+                                     .not = 1,
+                                     .alladdr = 0,
+                                     .stringmatch = 0,
+                                     .groupmatch = 0,
+                                     .ign_case = 0,
+                                     .isalias = 0,
+                                     .ismulti = 0,
+                                     .min = 0,
+                                     .max = 0,
+                                     .next = NULL,
+                                     .child = NULL,
+                                     .p.str = NULL },
+                                   /* root->child->child */
+                                   { .op = 30 /* MUTT_SUBJECT */,
+                                     .not = 0,
+                                     .alladdr = 0,
+                                     .stringmatch = 1,
+                                     .groupmatch = 0,
+                                     .ign_case = 1,
+                                     .isalias = 0,
+                                     .ismulti = 0,
+                                     .min = 0,
+                                     .max = 0,
+                                     .next = NULL,
+                                     .child = NULL,
+                                     .p.str = "foo" },
+                                   /* root->child->child->next */
+                                   { .op = 30 /* MUTT_SUBJECT */,
+                                     .not = 0,
+                                     .alladdr = 0,
+                                     .stringmatch = 1,
+                                     .groupmatch = 0,
+                                     .ign_case = 1,
+                                     .isalias = 0,
+                                     .ismulti = 0,
+                                     .min = 0,
+                                     .max = 0,
+                                     .next = NULL,
+                                     .child = NULL,
+                                     .p.str = "bar" },
+                                   /* root->child->next */
+                                   { .op = 30 /* MUTT_SUBJECT */,
+                                     .not = 0,
+                                     .alladdr = 0,
+                                     .stringmatch = 1,
+                                     .groupmatch = 0,
+                                     .ign_case = 1,
+                                     .isalias = 0,
+                                     .ismulti = 0,
+                                     .min = 0,
+                                     .max = 0,
+                                     .next = NULL,
+                                     .child = NULL,
+                                     .p.str = "quux" }
+    };
+
+    expected[0].child = &expected[1];
+    expected[1].child = &expected[2];
+    expected[2].next = &expected[3];
+    expected[1].next = &expected[4];
+
+    if (!TEST_CHECK(!cmp_pattern(pat, &expected[0])))
+    {
+      char s[1024];
+      canonical_pattern(s, &expected[0], 0);
+      TEST_MSG("Expected:\n%s", s);
+      canonical_pattern(s, pat, 0);
+      TEST_MSG("Actual:\n%s", s);
+    }
+
+    char *msg = "";
+    if (!TEST_CHECK(!strcmp(err.data, msg)))
+    {
+      TEST_MSG("Expected: %s", msg);
+      TEST_MSG("Actual  : %s", err.data);
+    }
+
+    mutt_pattern_free(&pat);
+  }
+
+  FREE(&err.data);
+}

--- a/test/pattern/main.c
+++ b/test/pattern/main.c
@@ -1,0 +1,21 @@
+#include "acutest.h"
+
+/******************************************************************************
+ * Add your test cases to this list.
+ *****************************************************************************/
+#define NEOMUTT_TEST_LIST                                                      \
+  NEOMUTT_TEST_ITEM(test_mutt_pattern_comp)
+
+/******************************************************************************
+ * You probably don't need to touch what follows.
+ *****************************************************************************/
+#define NEOMUTT_TEST_ITEM(x) void x(void);
+NEOMUTT_TEST_LIST
+#undef NEOMUTT_TEST_ITEM
+
+TEST_LIST = {
+#define NEOMUTT_TEST_ITEM(x) { #x, x },
+  NEOMUTT_TEST_LIST
+#undef NEOMUTT_TEST_ITEM
+  { 0 }
+};


### PR DESCRIPTION
* **What does this PR do?**

Adds a couple of tests for pattern compilation.

This will ease transition to using SLIST/STAILQ to replace Pattern linked-list structures per #1224 .