### PR TITLE
pattern: change Pattern linked-list(s) to use queue.h SLIST_* macros

### DIFF
--- a/context.h
+++ b/context.h
@@ -28,6 +28,7 @@
 #include <sys/types.h>
 #include <time.h>
 #include "mailbox.h"
+#include "pattern.h"
 
 struct EmailList;
 
@@ -38,7 +39,7 @@ struct Context
 {
   off_t vsize;
   char *pattern;                 /**< limit pattern string */
-  struct Pattern *limit_pattern; /**< compiled limit pattern */
+  struct PatternHead *limit_pattern; /**< compiled limit pattern */
   struct Email *last_tag;  /**< last tagged msg. used to link threads */
   struct MuttThread *tree;  /**< top of thread tree */
   struct Hash *thread_hash; /**< hash table for threading */

--- a/hook.c
+++ b/hook.c
@@ -63,10 +63,10 @@ bool C_SaveName; ///< Config: Save outgoing message to mailbox of recipient's na
  */
 struct Hook
 {
-  HookFlags type;          ///< Hook type
-  struct Regex regex;      ///< Regular expression
-  char *command;           ///< Filename, command or pattern to execute
-  struct Pattern *pattern; ///< Used for fcc,save,send-hook
+  HookFlags type;              ///< Hook type
+  struct Regex regex;          ///< Regular expression
+  char *command;               ///< Filename, command or pattern to execute
+  struct PatternHead *pattern; ///< Used for fcc,save,send-hook
   TAILQ_ENTRY(Hook) entries;
 };
 static TAILQ_HEAD(, Hook) Hooks = TAILQ_HEAD_INITIALIZER(Hooks);
@@ -86,7 +86,7 @@ enum CommandResult mutt_parse_hook(struct Buffer *buf, struct Buffer *s,
   int rc;
   bool not = false, warning = false;
   regex_t *rx = NULL;
-  struct Pattern *pat = NULL;
+  struct PatternHead *pat = NULL;
   char path[PATH_MAX];
 
   mutt_buffer_init(&pattern);
@@ -457,7 +457,8 @@ void mutt_message_hook(struct Mailbox *m, struct Email *e, HookFlags type)
 
     if (hook->type & type)
     {
-      if ((mutt_pattern_exec(hook->pattern, 0, m, e, &cache) > 0) ^ hook->regex.not)
+      if ((mutt_pattern_exec(SLIST_FIRST(hook->pattern), 0, m, e, &cache) > 0) ^
+          hook->regex.not)
       {
         if (mutt_parse_rc_line(hook->command, &token, &err) == MUTT_CMD_ERROR)
         {
@@ -505,7 +506,8 @@ static int addr_hook(char *path, size_t pathlen, HookFlags type,
     if (hook->type & type)
     {
       struct Mailbox *m = ctx ? ctx->mailbox : NULL;
-      if ((mutt_pattern_exec(hook->pattern, 0, m, e, &cache) > 0) ^ hook->regex.not)
+      if ((mutt_pattern_exec(SLIST_FIRST(hook->pattern), 0, m, e, &cache) > 0) ^
+          hook->regex.not)
       {
         mutt_make_string_flags(path, pathlen, hook->command, ctx, m, e, MUTT_FORMAT_PLAIN);
         return 0;

--- a/imap/imap.h
+++ b/imap/imap.h
@@ -59,6 +59,7 @@ struct EmailList;
 struct Mailbox;
 struct Pattern;
 struct stat;
+struct PatternHead;
 
 /* These Config Variables are only used in imap/auth.c */
 extern char *C_ImapAuthenticators;
@@ -83,7 +84,7 @@ int imap_delete_mailbox(struct Mailbox *m, char *path);
 int imap_sync_mailbox(struct Mailbox *m, bool expunge, bool close);
 int imap_path_status(const char *path, bool queue);
 int imap_mailbox_status(struct Mailbox *m, bool queue);
-int imap_search(struct Mailbox *m, const struct Pattern *pat);
+int imap_search(struct Mailbox *m, const struct PatternHead *pat);
 int imap_subscribe(char *path, bool subscribe);
 int imap_complete(char *buf, size_t buflen, char *path);
 int imap_fast_trash(struct Mailbox *m, char *dest);

--- a/index.c
+++ b/index.c
@@ -458,7 +458,8 @@ static void update_index_threaded(struct Context *ctx, int check, int oldcount)
       else
         e = ctx->mailbox->emails[i];
 
-      if (mutt_pattern_exec(ctx->limit_pattern, MUTT_MATCH_FULL_ADDRESS, ctx->mailbox, e, NULL))
+      if (mutt_pattern_exec(SLIST_FIRST(ctx->limit_pattern),
+                            MUTT_MATCH_FULL_ADDRESS, ctx->mailbox, e, NULL))
       {
         /* virtual will get properly set by mutt_set_virtual(), which
          * is called by mutt_sort_headers() just below. */
@@ -524,7 +525,7 @@ static void update_index_unthreaded(struct Context *ctx, int check, int oldcount
         ctx->vsize = 0;
       }
 
-      if (mutt_pattern_exec(ctx->limit_pattern, MUTT_MATCH_FULL_ADDRESS,
+      if (mutt_pattern_exec(SLIST_FIRST(ctx->limit_pattern), MUTT_MATCH_FULL_ADDRESS,
                             ctx->mailbox, ctx->mailbox->emails[i], NULL))
       {
         assert(ctx->mailbox->vcount < ctx->mailbox->msg_count);
@@ -3619,7 +3620,8 @@ void mutt_set_header_color(struct Mailbox *m, struct Email *e)
 
   STAILQ_FOREACH(color, &ColorIndexList, entries)
   {
-    if (mutt_pattern_exec(color->color_pattern, MUTT_MATCH_FULL_ADDRESS, m, e, &cache))
+    if (mutt_pattern_exec(SLIST_FIRST(color->color_pattern),
+                          MUTT_MATCH_FULL_ADDRESS, m, e, &cache))
     {
       e->pair = color->pair;
       return;

--- a/menu.c
+++ b/menu.c
@@ -118,8 +118,8 @@ static int get_color(int index, unsigned char *s)
 
   STAILQ_FOREACH(np, color, entries)
   {
-    if (mutt_pattern_exec(np->color_pattern, MUTT_MATCH_FULL_ADDRESS,
-                          Context->mailbox, e, NULL))
+    if (mutt_pattern_exec(SLIST_FIRST(np->color_pattern),
+                          MUTT_MATCH_FULL_ADDRESS, Context->mailbox, e, NULL))
       return np->pair;
   }
 

--- a/mutt_curses.h
+++ b/mutt_curses.h
@@ -26,6 +26,7 @@
 
 #include <regex.h>
 #include "mutt/mutt.h"
+#include "pattern.h"
 
 #ifdef USE_SLANG_CURSES
 
@@ -180,8 +181,8 @@ struct ColorLine
   regex_t regex;
   int match; /**< which substringmap 0 for old behaviour */
   char *pattern;
-  struct Pattern *color_pattern; /**< compiled pattern to speed up index color
-                                      calculation */
+  struct PatternHead *color_pattern; /**< compiled pattern to speed up index color
+                                          calculation */
   uint32_t fg;
   uint32_t bg;
   int pair;

--- a/pattern.h
+++ b/pattern.h
@@ -39,6 +39,8 @@ extern bool C_ThoroughSearch;
 /* flag to mutt_pattern_comp() */
 #define MUTT_FULL_MSG (1 << 0) /* enable body and header matching */
 
+SLIST_HEAD(PatternHead, Pattern);
+
 /**
  * struct Pattern - A simple (non-regex) pattern
  */
@@ -54,8 +56,8 @@ struct Pattern
   bool ismulti : 1; /**< multiple case (only for I pattern now) */
   int min;
   int max;
-  struct Pattern *next;
-  struct Pattern *child; /**< arguments to logical op */
+  SLIST_ENTRY(Pattern) entries;
+  struct PatternHead *child; /**< arguments to logical op */
   union {
     regex_t *regex;
     struct Group *group;
@@ -91,7 +93,6 @@ struct PatternCache
   int pers_from_all;  /**< ^~P */
   int pers_from_one;  /**<  ~P */
 };
-
 
 /**
  * enum PatternType - Types of pattern to match
@@ -149,12 +150,11 @@ enum PatternType
   MUTT_PAT_MAX,
 };
 
-struct Pattern *mutt_pattern_new(void);
 int mutt_pattern_exec(struct Pattern *pat, enum PatternExecFlag flags,
                       struct Mailbox *m, struct Email *e, struct PatternCache *cache);
-struct Pattern *mutt_pattern_comp(/* const */ char *s, int flags, struct Buffer *err);
+struct PatternHead *mutt_pattern_comp(/* const */ char *s, int flags, struct Buffer *err);
 void mutt_check_simple(char *s, size_t len, const char *simple);
-void mutt_pattern_free(struct Pattern **pat);
+void mutt_pattern_free(struct PatternHead **pat);
 
 int mutt_which_case(const char *s);
 int mutt_is_list_recipient(bool alladdr, struct Address *a1, struct Address *a2);

--- a/score.c
+++ b/score.c
@@ -56,7 +56,7 @@ short C_ScoreThresholdRead; ///< Config: Messages with a lower score will be aut
 struct Score
 {
   char *str;
-  struct Pattern *pat;
+  struct PatternHead *pat;
   int val;
   bool exact; /**< if this rule matches, don't evaluate any more */
   struct Score *next;
@@ -100,7 +100,6 @@ enum CommandResult mutt_parse_score(struct Buffer *buf, struct Buffer *s,
 {
   struct Score *ptr = NULL, *last = NULL;
   char *pattern = NULL, *pc = NULL;
-  struct Pattern *pat = NULL;
 
   mutt_extract_token(buf, s, 0);
   if (!MoreArgs(s))
@@ -125,7 +124,7 @@ enum CommandResult mutt_parse_score(struct Buffer *buf, struct Buffer *s,
       break;
   if (!ptr)
   {
-    pat = mutt_pattern_comp(pattern, 0, err);
+    struct PatternHead *pat = mutt_pattern_comp(pattern, 0, err);
     if (!pat)
     {
       FREE(&pattern);
@@ -176,7 +175,7 @@ void mutt_score_message(struct Mailbox *m, struct Email *e, bool upd_mbox)
   e->score = 0; /* in case of re-scoring */
   for (tmp = ScoreList; tmp; tmp = tmp->next)
   {
-    if (mutt_pattern_exec(tmp->pat, MUTT_MATCH_FULL_ADDRESS, NULL, e, &cache) > 0)
+    if (mutt_pattern_exec(SLIST_FIRST(tmp->pat), MUTT_MATCH_FULL_ADDRESS, NULL, e, &cache) > 0)
     {
       if (tmp->exact || (tmp->val == 9999) || (tmp->val == -9999))
       {


### PR DESCRIPTION
* **What does this PR do?**

Refactors pattern.[ch] and a few other files to use the SLIST_* macros for linked lists in struct Pattern.

* **What are the relevant issue numbers?**

#1224