### PR TITLE
Don't override ndata with temporary context

### DIFF
--- a/mx.c
+++ b/mx.c
@@ -273,8 +273,15 @@ struct Context *mx_mbox_open(struct Mailbox *m, const char *path, int flags)
     /* int rc = */ mx_path_canon2(m, Folder);
   }
 
-  m->notify = ctx_mailbox_changed;
-  m->ndata = ctx;
+
+  /* mailbox can be opened twice by postpone/sendlib/trash code
+   * as workaround we set the context only the first time and for mailbox
+   * without APPEND flag */
+  if (!m->ndata && !(flags & MUTT_APPEND))
+  {
+    m->notify = ctx_mailbox_changed;
+    m->ndata = ctx;
+  }
 
   if ((m->magic == MUTT_UNKNOWN) && (flags & MUTT_NEWFOLDER))
   {


### PR DESCRIPTION
postponed/sendlib code can reopen an already opened mailbox.

This overrides m->ndata with a temporary context but never revert it back to
the previous one.

At first glance, when postponed/sendlib code open the mailbox they don't care
to have their context updated with the notification system. It should be
the Context used for the UI that should be updated instead.

So until we don't open a mailbox twice anymore, just set ndata when it
looks accurate to workaround the issue.