### PR TITLE
notmuch: implement read-only vfolder-from-query

### DIFF
--- a/doc/manual.xml.head
+++ b/doc/manual.xml.head
@@ -14930,6 +14930,14 @@ virtual-mailboxes "My INBOX" "notmuch://?query=tag:inbox"
                 </entry>
               </row>
               <row>
+                <entry>index,pager</entry>
+                <entry><literal>&lt;vfolder-from-query-readonly&gt;</literal></entry>
+                <entry>
+                  The same as <literal>&lt;vfolder-from-query&gt;</literal>; however, the mailbox
+                  will be read-only.
+                </entry>
+              </row>
+              <row>
                 <entry>index</entry>
                 <entry><literal>&lt;vfolder-window-forward&gt;</literal></entry>
                 <entry>

--- a/functions.h
+++ b/functions.h
@@ -238,6 +238,7 @@ const struct Binding OpMain[] = { /* map: index */
   { "untag-pattern",             OP_MAIN_UNTAG_PATTERN,             "\024" },
 #ifdef USE_NOTMUCH
   { "vfolder-from-query",        OP_MAIN_VFOLDER_FROM_QUERY,        NULL },
+  { "vfolder-from-query-readonly", OP_MAIN_VFOLDER_FROM_QUERY_READONLY, NULL },
   { "vfolder-window-backward",   OP_MAIN_WINDOWED_VFOLDER_BACKWARD, NULL },
   { "vfolder-window-forward",    OP_MAIN_WINDOWED_VFOLDER_FORWARD,  NULL },
 #endif
@@ -390,6 +391,7 @@ const struct Binding OpPager[] = { /* map: pager */
   { "undelete-thread",           OP_UNDELETE_THREAD,              "\025" },
 #ifdef USE_NOTMUCH
   { "vfolder-from-query",        OP_MAIN_VFOLDER_FROM_QUERY,      NULL },
+  { "vfolder-from-query-readonly", OP_MAIN_VFOLDER_FROM_QUERY_READONLY, NULL },
 #endif
   { "view-attachments",          OP_VIEW_ATTACHMENTS,             "v" },
   { "view-raw-message",          OP_VIEW_RAW_MESSAGE,             NULL },

--- a/index.c
+++ b/index.c
@@ -636,7 +636,14 @@ static int main_change_folder(struct Menu *menu, int op, struct Mailbox *m,
   mutt_folder_hook(buf, m ? m->desc : NULL);
 
   const int flags =
-      (ReadOnly || (op == OP_MAIN_CHANGE_FOLDER_READONLY)) ? MUTT_READONLY : 0;
+    (ReadOnly || (op == OP_MAIN_CHANGE_FOLDER_READONLY)
+#ifdef USE_NOTMUCH
+     || (op == OP_MAIN_VFOLDER_FROM_QUERY_READONLY)
+#endif
+     )
+    ? MUTT_READONLY
+    : 0;
+
   Context = mx_mbox_open(m, buf, flags);
   if (Context)
   {
@@ -2090,6 +2097,7 @@ int mutt_index_menu(void)
 
 #ifdef USE_NOTMUCH
       case OP_MAIN_VFOLDER_FROM_QUERY:
+      case OP_MAIN_VFOLDER_FROM_QUERY_READONLY:
         buf[0] = '\0';
         if (mutt_get_field("Query: ", buf, sizeof(buf), MUTT_NM_QUERY) != 0 || !buf[0])
         {

--- a/opcodes.h
+++ b/opcodes.h
@@ -271,6 +271,7 @@
   _fmt(OP_MAIN_CHANGE_VFOLDER,            N_("open a different virtual folder")) \
   _fmt(OP_MAIN_ENTIRE_THREAD,             N_("read entire thread of the current message")) \
   _fmt(OP_MAIN_VFOLDER_FROM_QUERY,        N_("generate virtual folder from query")) \
+  _fmt(OP_MAIN_VFOLDER_FROM_QUERY_READONLY, N_("generate a read-only virtual folder from query")) \
   _fmt(OP_MAIN_WINDOWED_VFOLDER_BACKWARD, N_("shifts virtual folder time window backwards")) \
   _fmt(OP_MAIN_WINDOWED_VFOLDER_FORWARD,  N_("shifts virtual folder time window forwards"))
 #else


### PR DESCRIPTION
**What does this PR do?**

Implemented a read-only variant of vfolder-from-query for users who want
to have an immutable window. This ensures no accidental tag changes
occur.