### PR TITLE
tags: fix multiple tags set on multiple emails

### DIFF
--- a/email/tags.c
+++ b/email/tags.c
@@ -198,9 +198,10 @@ bool driver_tags_replace(struct TagHead *head, char *tags)
   if (tags)
   {
     char *tag = NULL;
-    while ((tag = strsep(&tags, " ")))
+    char *split_tags = mutt_str_strdup(tags);
+    while ((tag = strsep(&split_tags, " ")))
       driver_tags_add(head, tag);
-    FREE(&tags);
+    FREE(&split_tags);
   }
   return true;
 }

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -2445,7 +2445,7 @@ static int imap_tags_commit(struct Mailbox *m, struct Email *e, char *buf)
   }
 
   /* We are good sync them */
-  mutt_debug(1, "NEW TAGS: %d\n", buf);
+  mutt_debug(1, "NEW TAGS: %s\n", buf);
   driver_tags_replace(&e->tags, buf);
   FREE(&imap_edata_get(e)->flags_remote);
   imap_edata_get(e)->flags_remote = driver_tags_get_with_hidden(&e->tags);


### PR DESCRIPTION
When we set multiple tags on multiple emails at once, only the first
email get all tags.

This is because we use strsep that will modify the initial buffer that
contains all tags.

This change fixes it by duplicating the buffer of tags before using
strsep on it.