### PR TITLE
tags: Use STAILQ instead of strsep

### DIFF
--- a/email/tags.c
+++ b/email/tags.c
@@ -197,11 +197,13 @@ bool driver_tags_replace(struct TagHead *head, char *tags)
 
   if (tags)
   {
-    char *tag = NULL;
-    char *split_tags = mutt_str_strdup(tags);
-    while ((tag = strsep(&split_tags, " ")))
-      driver_tags_add(head, tag);
-    FREE(&split_tags);
+    struct ListHead hsplit = mutt_str_split(tags, ' ');
+    struct ListNode *np = NULL;
+    STAILQ_FOREACH(np, &hsplit, entries)
+    {
+      driver_tags_add(head, np->data);
+    }
+    mutt_list_clear(&hsplit);
   }
   return true;
 }

--- a/mutt/string.c
+++ b/mutt/string.c
@@ -38,6 +38,7 @@
 #include "logging.h"
 #include "memory.h"
 #include "string2.h"
+#include "list.h"
 #ifdef HAVE_SYSEXITS_H
 #include <sysexits.h>
 #endif
@@ -1145,4 +1146,33 @@ const char *mutt_str_strcasestr(const char *haystack, const char *needle)
   }
 
   return NULL;
+}
+
+/**
+ * mutt_str_split - return list of the words of the strings
+ * @param src String to split
+ * @param sep Word separator
+ */
+struct ListHead mutt_str_split(const char *src, char sep)
+{
+  struct ListHead head = STAILQ_HEAD_INITIALIZER(head);
+
+  if (!src || !*src)
+    return head;
+
+  while (true)
+  {
+    const char *start = src;
+    while (*src && (*src != sep))
+      src++;
+
+    mutt_list_insert_tail(&head, mutt_str_substr_dup(start, src));
+
+    if (!*src)
+      break;
+
+    src++;
+  }
+
+  return head;
 }

--- a/mutt/string2.h
+++ b/mutt/string2.h
@@ -91,6 +91,7 @@ void        mutt_str_replace(char **p, const char *s);
 const char *mutt_str_rstrnstr(const char *haystack, size_t haystack_length, const char *needle);
 char *      mutt_str_skip_email_wsp(const char *s);
 char *      mutt_str_skip_whitespace(char *p);
+struct ListHead mutt_str_split(const char *src, char sep);
 int         mutt_str_strcasecmp(const char *a, const char *b);
 size_t      mutt_str_startswith(const char *str, const char *prefix, enum CaseSensitivity cs);
 const char *mutt_str_strcasestr(const char *haystack, const char *needle);

--- a/test/main.c
+++ b/test/main.c
@@ -16,6 +16,7 @@
   NEOMUTT_TEST_ITEM(test_string_strfcpy)                                       \
   NEOMUTT_TEST_ITEM(test_string_strnfcpy)                                      \
   NEOMUTT_TEST_ITEM(test_string_strcasestr)                                    \
+  NEOMUTT_TEST_ITEM(test_string_split)                                         \
   NEOMUTT_TEST_ITEM(test_addr_mbox_to_udomain)                                 \
   NEOMUTT_TEST_ITEM(test_mutt_path_tidy_slash)                                 \
   NEOMUTT_TEST_ITEM(test_mutt_path_tidy_dotdot)                                \

--- a/test/string.c
+++ b/test/string.c
@@ -1,6 +1,7 @@
 #define TEST_NO_MAIN
 #include "acutest.h"
 
+#include "mutt/list.h"
 #include "mutt/string2.h"
 
 void test_string_strfcpy(void)
@@ -185,6 +186,95 @@ void test_string_strcasestr(void)
     const char *retval = mutt_str_strcasestr(haystack_smaller, needle);
 
     TEST_CHECK_(retval == NULL, "Expected: %s, Actual: %s", NULL, retval);
+  }
+}
+
+
+void print_compared_list(struct ListHead expected, struct ListHead actual)
+{
+  struct ListNode *np = NULL;
+
+  TEST_MSG("Expected:");
+  STAILQ_FOREACH(np, &expected, entries)
+  {
+    TEST_MSG("* '%s'", np->data);
+  }
+
+  TEST_MSG("Actual:");
+  STAILQ_FOREACH(np, &actual, entries)
+  {
+    TEST_MSG("* '%s'", np->data);
+  }
+
+}
+
+void test_string_split(void)
+{
+  char *one_word = "hello";
+  char *two_words = "hello world";
+  char *words = "hello neomutt world! what's up?";
+  char *ending_sep = "hello world ";
+  char *starting_sep = " hello world";
+  char *other_sep = "hello,world";
+  char *empty = "";
+
+  { // Check NULL conditions
+    struct ListHead retval1 = mutt_str_split(NULL, ' ');
+    struct ListHead retval2 = mutt_str_split(empty, ' ');
+
+    if (!TEST_CHECK(STAILQ_EMPTY(&retval1)))
+      TEST_MSG("Expected: empty");
+    if (!TEST_CHECK(STAILQ_EMPTY(&retval2)))
+      TEST_MSG("Expected: empty");
+  }
+
+  { // Check different words
+    struct ListHead retval1 = mutt_str_split(one_word, ' ');
+    struct ListHead retval2 = mutt_str_split(two_words, ' ');
+    struct ListHead retval3 = mutt_str_split(words, ' ');
+    struct ListHead retval4 = mutt_str_split(ending_sep, ' ');
+    struct ListHead retval5 = mutt_str_split(starting_sep, ' ');
+    struct ListHead retval6 = mutt_str_split(other_sep, ',');
+
+    struct ListHead expectedval1 = STAILQ_HEAD_INITIALIZER(expectedval1);
+    mutt_list_insert_tail(&expectedval1, "hello");
+    if (!TEST_CHECK(mutt_list_compare(&expectedval1, &retval1)))
+      print_compared_list(expectedval1, retval1);
+
+    struct ListHead expectedval2 = STAILQ_HEAD_INITIALIZER(expectedval2);
+    mutt_list_insert_tail(&expectedval2, "hello");
+    mutt_list_insert_tail(&expectedval2, "world");
+    if (!TEST_CHECK(mutt_list_compare(&expectedval2, &retval2)))
+      print_compared_list(expectedval2, retval2);
+
+    struct ListHead expectedval3 = STAILQ_HEAD_INITIALIZER(expectedval3);
+    mutt_list_insert_tail(&expectedval3, "hello");
+    mutt_list_insert_tail(&expectedval3, "neomutt");
+    mutt_list_insert_tail(&expectedval3, "world!");
+    mutt_list_insert_tail(&expectedval3, "what's");
+    mutt_list_insert_tail(&expectedval3, "up?");
+    if (!TEST_CHECK(mutt_list_compare(&expectedval3, &retval3)))
+      print_compared_list(expectedval3, retval3);
+
+    struct ListHead expectedval4 = STAILQ_HEAD_INITIALIZER(expectedval4);
+    mutt_list_insert_tail(&expectedval4, "hello");
+    mutt_list_insert_tail(&expectedval4, "world");
+    mutt_list_insert_tail(&expectedval4, "");
+    if (!TEST_CHECK(mutt_list_compare(&expectedval4, &retval4)))
+      print_compared_list(expectedval4, retval4);
+
+    struct ListHead expectedval5 = STAILQ_HEAD_INITIALIZER(expectedval5);
+    mutt_list_insert_tail(&expectedval5, "");
+    mutt_list_insert_tail(&expectedval5, "hello");
+    mutt_list_insert_tail(&expectedval5, "world");
+    if (!TEST_CHECK(mutt_list_compare(&expectedval5, &retval5)))
+      print_compared_list(expectedval5, retval5);
+
+    struct ListHead expectedval6 = STAILQ_HEAD_INITIALIZER(expectedval6);
+    mutt_list_insert_tail(&expectedval6, "hello");
+    mutt_list_insert_tail(&expectedval6, "world");
+    if (!TEST_CHECK(mutt_list_compare(&expectedval6, &retval6)))
+      print_compared_list(expectedval6, retval6);
   }
 }
 


### PR DESCRIPTION
This change introduces a new string function mutt_str_split(src, sep) to
return a STAILQ of the split string.

This new funtion is used first in tags code.