### PR TITLE
mxapi: introduce mx_msg_flag_modified()

### DIFF
--- a/compress.c
+++ b/compress.c
@@ -981,6 +981,7 @@ struct MxOps MxCompOps = {
   .msg_open_new     = comp_msg_open_new,
   .msg_commit       = comp_msg_commit,
   .msg_close        = comp_msg_close,
+  .msg_flag_modified = NULL,
   .msg_padding_size = comp_msg_padding_size,
   .msg_save_hcache  = comp_msg_save_hcache,
   .tags_edit        = comp_tags_edit,

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -2533,6 +2533,7 @@ struct MxOps MxImapOps = {
   .msg_open_new     = imap_msg_open_new,
   .msg_commit       = imap_msg_commit,
   .msg_close        = imap_msg_close,
+  .msg_flag_modified = NULL,
   .msg_padding_size = NULL,
   .msg_save_hcache  = imap_msg_save_hcache,
   .tags_edit        = imap_tags_edit,

--- a/index.c
+++ b/index.c
@@ -2777,18 +2777,30 @@ int mutt_index_menu(void)
               continue;
 
             if (Context->mailbox->emails[i]->read || Context->mailbox->emails[i]->old)
+            {
               mutt_set_flag(Context->mailbox, Context->mailbox->emails[i], MUTT_NEW, true);
+              mx_msg_flag_modified(Context->mailbox, Context->mailbox->emails[i], MUTT_NEW);
+            }
             else
+            {
               mutt_set_flag(Context->mailbox, Context->mailbox->emails[i], MUTT_READ, true);
+              mx_msg_flag_modified(Context->mailbox, Context->mailbox->emails[i], MUTT_READ);
+            }
           }
           menu->redraw |= REDRAW_STATUS | REDRAW_INDEX;
         }
         else
         {
           if (CUR_EMAIL->read || CUR_EMAIL->old)
+          {
             mutt_set_flag(Context->mailbox, CUR_EMAIL, MUTT_NEW, true);
+            mx_msg_flag_modified(Context->mailbox, CUR_EMAIL, MUTT_NEW);
+          }
           else
+          {
             mutt_set_flag(Context->mailbox, CUR_EMAIL, MUTT_READ, true);
+            mx_msg_flag_modified(Context->mailbox, CUR_EMAIL, MUTT_READ);
+          }
 
           if (C_Resolve)
           {

--- a/maildir/maildir.c
+++ b/maildir/maildir.c
@@ -715,6 +715,7 @@ struct MxOps MxMaildirOps = {
   .msg_open_new     = maildir_msg_open_new,
   .msg_commit       = maildir_msg_commit,
   .msg_close        = mh_msg_close,
+  .msg_flag_modified = NULL,
   .msg_padding_size = NULL,
   .msg_save_hcache  = maildir_msg_save_hcache,
   .tags_edit        = NULL,

--- a/maildir/mh.c
+++ b/maildir/mh.c
@@ -818,6 +818,7 @@ struct MxOps MxMhOps = {
   .msg_open_new     = mh_msg_open_new,
   .msg_commit       = mh_msg_commit,
   .msg_close        = mh_msg_close,
+  .msg_flag_modified = NULL,
   .msg_padding_size = NULL,
   .msg_save_hcache  = mh_msg_save_hcache,
   .tags_edit        = NULL,

--- a/mx.c
+++ b/mx.c
@@ -1080,6 +1080,24 @@ int mx_msg_close(struct Mailbox *m, struct Message **msg)
 }
 
 /**
+ * mx_msg_flag_modified - Notify that a message's flag has been modified.
+ * @param m Mailbox
+ * @param e Email
+ * @param flag Flag
+ * @retval  0 Success
+ * @retval -1 Failure
+ *
+ * Write a single header out to the header cache.
+ */
+int mx_msg_flag_modified(struct Mailbox *m, struct Email *e, int flag)
+{
+  if (!m || !e || !m->mx_ops || !m->mx_ops->msg_flag_modified)
+    return 0;
+
+  return m->mx_ops->msg_flag_modified(m, e, flag);
+}
+
+/**
  * mx_alloc_memory - Create storage for the emails
  * @param m Mailbox
  */

--- a/mx.h
+++ b/mx.h
@@ -203,6 +203,15 @@ struct MxOps
    */
   int (*msg_close)       (struct Mailbox *m, struct Message *msg);
   /**
+   * msg_flag_modified - Notify that a flag has been modified
+   * @param m    Mailbox
+   * @param e    Email whose flags has been altered.
+   * @param flag Flag issued
+   * @retval  0 Success
+   * @retval -1 Failure
+   */
+  int (*msg_flag_modified) (struct Mailbox *m, struct Email *e, int flag);
+  /**
    * msg_padding_size - Bytes of padding between messages
    * @param m Mailbox
    * @retval num Bytes of padding
@@ -278,6 +287,7 @@ struct Context *mx_mbox_open       (struct Mailbox *m, OpenMailboxFlags flags);
 int             mx_mbox_sync       (struct Mailbox *m, int *index_hint);
 int             mx_msg_close       (struct Mailbox *m, struct Message **msg);
 int             mx_msg_commit      (struct Mailbox *m, struct Message *msg);
+int             mx_msg_flag_modified(struct Mailbox *m, struct Email *e, int flag);
 struct Message *mx_msg_open_new    (struct Mailbox *m, struct Email *e, MsgOpenFlags flags);
 struct Message *mx_msg_open        (struct Mailbox *m, int msgno);
 int             mx_msg_padding_size(struct Mailbox *m);

--- a/nntp/nntp.c
+++ b/nntp/nntp.c
@@ -2905,6 +2905,7 @@ struct MxOps MxNntpOps = {
   .msg_open_new     = NULL,
   .msg_commit       = NULL,
   .msg_close        = nntp_msg_close,
+  .msg_flag_modified = NULL,
   .msg_padding_size = NULL,
   .msg_save_hcache  = NULL,
   .tags_edit        = NULL,

--- a/notmuch/mutt_notmuch.c
+++ b/notmuch/mutt_notmuch.c
@@ -2399,6 +2399,22 @@ static int nm_mbox_close(struct Mailbox *m)
 }
 
 /**
+ * nm_flag_modified - Implements MxOps::msg_flag_modified
+ *
+ * Only handles read/unread status so far.
+ */
+int nm_msg_flag_modified(struct Mailbox *m, struct Email *e, int flag) {
+  size_t buflen = sizeof(C_NmUnreadTag) + 1;
+  char buf[buflen];
+  if (e->read)
+    snprintf(buf, buflen, "-%s", C_NmUnreadTag);
+  else
+    snprintf(buf, buflen, "+%s", C_NmUnreadTag);
+
+  return mx_tags_commit(m, e, buf);
+}
+
+/**
  * nm_msg_open - Implements MxOps::msg_open()
  */
 static int nm_msg_open(struct Mailbox *m, struct Message *msg, int msgno)
@@ -2555,6 +2571,7 @@ struct MxOps MxNotmuchOps = {
   .msg_open_new     = maildir_msg_open_new,
   .msg_commit       = nm_msg_commit,
   .msg_close        = nm_msg_close,
+  .msg_flag_modified = nm_msg_flag_modified,
   .msg_padding_size = NULL,
   .msg_save_hcache  = NULL,
   .tags_edit        = nm_tags_edit,

--- a/notmuch/mutt_notmuch.c
+++ b/notmuch/mutt_notmuch.c
@@ -2438,6 +2438,14 @@ static int nm_msg_open(struct Mailbox *m, struct Message *msg, int msgno)
   if (!msg->fp)
     return -1;
 
+  if (!e->read)
+  {
+    size_t buflen = sizeof(C_NmUnreadTag) + 1;
+    char buf[buflen];
+    snprintf(buf, buflen, "-%s", C_NmUnreadTag);
+    mx_tags_commit(m, e, buf);
+  }
+
   return 0;
 }
 

--- a/pager.c
+++ b/pager.c
@@ -3362,9 +3362,15 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         CHECK_ACL(MUTT_ACL_SEEN, _("Cannot toggle new"));
 
         if (extra->email->read || extra->email->old)
+        {
           mutt_set_flag(Context->mailbox, extra->email, MUTT_NEW, true);
+          mx_msg_flag_modified(Context->mailbox, extra->email, MUTT_NEW);
+        }
         else if (!first)
+        {
           mutt_set_flag(Context->mailbox, extra->email, MUTT_READ, true);
+          mx_msg_flag_modified(Context->mailbox, extra->email, MUTT_READ);
+        }
         first = false;
         Context->msgnotreadyet = -1;
         pager_menu->redraw |= REDRAW_STATUS | REDRAW_INDEX;

--- a/pop/pop.c
+++ b/pop/pop.c
@@ -1294,6 +1294,7 @@ struct MxOps MxPopOps = {
   .msg_open_new     = NULL,
   .msg_commit       = NULL,
   .msg_close        = pop_msg_close,
+  .msg_flag_modified = NULL,
   .msg_padding_size = NULL,
   .msg_save_hcache  = pop_msg_save_hcache,
   .tags_edit        = NULL,


### PR DESCRIPTION
Introduce the `mx_msg_flag_modified()` function, which is used to alert a
backend if the flags are changed. This allows the backend to perform
backend-specific tasks. The notmuch backend needs this to proper update
the database when a message is opened or toggle-new is called.

**What are the relevant issue numbers?**

Fixes #1485 
