### PR TITLE
browser: sort_browser attribute being modified after sorting browser

### DIFF
--- a/browser.c
+++ b/browser.c
@@ -1799,11 +1799,15 @@ void mutt_select_file(char *file, size_t filelen, int flags, char ***files, int 
         if (resort)
         {
           sort |= reverse ? SORT_REVERSE : 0;
+          cs_str_native_set(Config, "sort_browser", sort, NULL);
           browser_sort(&state);
           browser_highlight_default(&state, menu);
           menu->redraw = REDRAW_FULL;
         }
-        cs_str_native_set(Config, "sort_browser", sort, NULL);
+        else
+        {
+          cs_str_native_set(Config, "sort_browser", sort, NULL);
+        }
         break;
       }
 


### PR DESCRIPTION
* **What does this PR do?**

`sort_browser` config attribute was modified after calling `browser_sort`.
This means each time the browser was sorted it used the old sort parameter instead of the new one.

* **What are the relevant issue numbers?**

Fixes #1551