### PR TITLE
Separate neomutt objects into separate lib

### DIFF
--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -90,6 +90,37 @@ CLEANFILES+=	$(NEOMUTT) $(NEOMUTTOBJS)
 ALLOBJS+=	$(NEOMUTTOBJS)
 
 ###############################################################################
+# libneomutt
+LIBNEOMUTTOBJS=	account.o addrbook.o alias.o bcache.o browser.o color.o commands.o \
+		complete.o compose.o compress.o conststrings.o context.o copy.o \
+		curs_lib.o edit.o editmsg.o enriched.o enter.o \
+		filter.o flags.o git_ver.o handler.o hdrline.o help.o hook.o \
+		index.o init.o keymap.o mailbox.o main.o menu.o muttlib.o \
+		mutt_account.o mutt_attach.o mutt_body.o mutt_header.o \
+		mutt_history.o mutt_logging.o mutt_parse.o mutt_signal.o \
+		mutt_socket.o mutt_thread.o mutt_url.o mutt_window.o mx.o myvar.o \
+		pager.o pattern.o postpone.o progress.o query.o recvattach.o \
+		recvcmd.o resize.o rfc1524.o rfc3676.o safe_asprintf.o \
+		score.o send.o sendlib.o sidebar.o smtp.o sort.o state.o \
+		status.o system.o terminal.o version.o icommands.o
+
+@if !HAVE_WCSCASECMP
+LIBNEOMUTTOBJS+=	wcscasecmp.o
+@endif
+@if MIXMASTER
+LIBNEOMUTTOBJS+=	remailer.o
+@endif
+@if USE_LUA
+LIBNEOMUTTOBJS+=	mutt_lua.o
+@endif
+@if USE_INOTIFY
+LIBNEOMUTTOBJS+=	monitor.o
+@endif
+CLEANFILES+=	$(LIBNEOMUTT) $(LIBNEOMUTTOBJS)
+ALLOBJS+=	$(LIBNEOMUTTOBJS)
+
+
+###############################################################################
 # libpop
 LIBPOP=	libpop.a
 LIBPOPOBJS=	pop/pop_auth.o pop/pop.o pop/pop_lib.o


### PR DESCRIPTION
Just wanted to show a draft before I did anything more. I've recently been given the 
pleasure to work on a refactor which will simplify some regex routines. That part should be ready-ish.

What I wanted to do, was test some neomutt specific code, and I was not able to, due to the way things are bing built right now. I was wondering if an approach in separating the neomutt stuff the way I did would be acceptable? 

Anyway let me know what you think, and I hope this is not too terrible to look at :stuck_out_tongue: 

BTW, if this is ok, and let's say we decide to proceed with this, I'll follow the below guidelines!

(This is incomplete right now, but I'll put more work on it soon, if again, it is OK to do something like this)

* * * 

This should make things more testable

* **What does this PR do?**
Separate neomutt specific objects into separate `libneomutt.a` lib.

* **Screenshots (if relevant)**

* **Does this PR meet the acceptance criteria?** (This is just a reminder for you,
  this section can be removed if you fulfill it.)

   - Documentation created/updated (you have to edit
     [doc/manual.xml.head](https://www.github.com/neomutt/neomutt/blob/master/doc/manual.xml.head)
     for that)

   - All builds and tests are passing

   - Added [doxygen code documentation](https://neomutt.org/dev/doxygen)
     [syntax](http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html)

   - Code follows the [style guide](https://neomutt.org/dev/coding-style)

* **What are the relevant issue numbers?**
