### PR TITLE
Rewording of "postpone" message to avoid a common confusion

### DIFF
--- a/compose.c
+++ b/compose.c
@@ -1858,7 +1858,7 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
 
       case OP_EXIT:
       {
-        int ans = query_quadoption(Postpone, _("Postpone this message?"));
+        int ans = query_quadoption(Postpone, _("Save (postpone) draft message?"));
         if (ans == MUTT_NO)
         {
           for (int i = 0; i < actx->idxlen; i++)

--- a/init.h
+++ b/init.h
@@ -3002,7 +3002,10 @@ struct ConfigDef MuttVars[] = {
   /*
   ** .pp
   ** Controls whether or not messages are saved in the $$postponed
-  ** mailbox when you elect not to send immediately.
+  ** mailbox when you elect not to send immediately. If set to
+  ** \fIask-yes\fP or \fIask-no\fP, you will be prompted with "Save
+  ** (postpone) draft message?" when quitting from the "compose"
+  ** screen.
   ** .pp
   ** Also see the $$recall variable.
   */


### PR DESCRIPTION
* **What does this PR do?**

Changes the wording of $postpone quadoption message. Global replace of "Postpone this message?" to "Save (postpone) draft message?". Resolves issue #1312. Additional update to documentation via init.h.

* **Screenshots (if relevant)**

![u](https://user-images.githubusercontent.com/12960503/52466360-e4e5bb00-2b36-11e9-9353-41afd0a52873.png)

* **What are the relevant issue numbers?**

#1312
