### PR TITLE
boolify mutt_set_flag() and friends

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -349,7 +349,7 @@ int mutt_display_message(struct Email *cur)
     if (!OptNoCurses)
       keypad(stdscr, true);
     if (r != -1)
-      mutt_set_flag(Context->mailbox, cur, MUTT_READ, 1);
+      mutt_set_flag(Context->mailbox, cur, MUTT_READ, true);
     if (r != -1 && PromptAfter)
     {
       mutt_unget_event(mutt_any_key_to_continue(_("Command: ")), 0);
@@ -953,10 +953,10 @@ int mutt_save_message_ctx(struct Email *e, bool delete, bool decode,
 
   if (delete)
   {
-    mutt_set_flag(Context->mailbox, e, MUTT_DELETE, 1);
-    mutt_set_flag(Context->mailbox, e, MUTT_PURGE, 1);
+    mutt_set_flag(Context->mailbox, e, MUTT_DELETE, true);
+    mutt_set_flag(Context->mailbox, e, MUTT_PURGE, true);
     if (DeleteUntag)
-      mutt_set_flag(Context->mailbox, e, MUTT_TAG, 0);
+      mutt_set_flag(Context->mailbox, e, MUTT_TAG, false);
   }
 
   return 0;

--- a/editmsg.c
+++ b/editmsg.c
@@ -233,12 +233,12 @@ bail:
 
   if (rc == 0)
   {
-    mutt_set_flag(m, e, MUTT_DELETE, 1);
-    mutt_set_flag(m, e, MUTT_PURGE, 1);
-    mutt_set_flag(m, e, MUTT_READ, 1);
+    mutt_set_flag(m, e, MUTT_DELETE, true);
+    mutt_set_flag(m, e, MUTT_PURGE, true);
+    mutt_set_flag(m, e, MUTT_READ, true);
 
     if (DeleteUntag)
-      mutt_set_flag(m, e, MUTT_TAG, 0);
+      mutt_set_flag(m, e, MUTT_TAG, false);
   }
   else if (rc == -1)
     mutt_message(_("Error. Preserving temporary file: %s"), fname);

--- a/flags.c
+++ b/flags.c
@@ -354,7 +354,7 @@ void mutt_set_flag_update(struct Mailbox *m, struct Email *e, int flag, bool bf,
  * @param flag Flag to set, e.g. #MUTT_DELETE
  * @param bf   true: set the flag; false: clear the flag
  */
-void mutt_emails_set_flag(struct Mailbox *m, struct EmailList *el, int flag, int bf)
+void mutt_emails_set_flag(struct Mailbox *m, struct EmailList *el, int flag, bool bf)
 {
   if (!m || !el || STAILQ_EMPTY(el))
     return;
@@ -375,7 +375,7 @@ void mutt_emails_set_flag(struct Mailbox *m, struct EmailList *el, int flag, int
  * @retval  0 Success
  * @retval -1 Failure
  */
-int mutt_thread_set_flag(struct Email *e, int flag, int bf, int subthread)
+int mutt_thread_set_flag(struct Email *e, int flag, bool bf, bool subthread)
 {
   struct MuttThread *start = NULL, *cur = e->thread;
 

--- a/imap/message.c
+++ b/imap/message.c
@@ -664,7 +664,7 @@ static void imap_fetch_msn_seqset(struct Buffer *b, struct ImapAccountData *adat
  */
 static void set_changed_flag(struct Mailbox *m, struct Email *e,
                              int local_changes, bool *server_changes, int flag_name,
-                             int old_hd_flag, int new_hd_flag, int h_flag)
+                             bool old_hd_flag, bool new_hd_flag, bool h_flag)
 {
   /* If there are local_changes, we only want to note if the server
    * flags have changed, so we can set a reopen flag in
@@ -1686,10 +1686,10 @@ int imap_copy_messages(struct Mailbox *m, struct EmailList *el, char *dest, bool
   {
     STAILQ_FOREACH(en, el, entries)
     {
-      mutt_set_flag(m, en->email, MUTT_DELETE, 1);
-      mutt_set_flag(m, en->email, MUTT_PURGE, 1);
+      mutt_set_flag(m, en->email, MUTT_DELETE, true);
+      mutt_set_flag(m, en->email, MUTT_PURGE, true);
       if (DeleteUntag)
-        mutt_set_flag(m, en->email, MUTT_TAG, 0);
+        mutt_set_flag(m, en->email, MUTT_TAG, false);
     }
   }
 

--- a/index.c
+++ b/index.c
@@ -1761,7 +1761,7 @@ int mutt_index_menu(void)
         {
           for (size_t i = 0; i < Context->mailbox->msg_count; i++)
             if (message_is_visible(Context, i))
-              mutt_set_flag(Context->mailbox, Context->mailbox->emails[i], MUTT_TAG, 0);
+              mutt_set_flag(Context->mailbox, Context->mailbox->emails[i], MUTT_TAG, false);
           menu->redraw |= REDRAW_STATUS | REDRAW_INDEX;
         }
         else
@@ -2770,18 +2770,18 @@ int mutt_index_menu(void)
               continue;
 
             if (Context->mailbox->emails[i]->read || Context->mailbox->emails[i]->old)
-              mutt_set_flag(Context->mailbox, Context->mailbox->emails[i], MUTT_NEW, 1);
+              mutt_set_flag(Context->mailbox, Context->mailbox->emails[i], MUTT_NEW, true);
             else
-              mutt_set_flag(Context->mailbox, Context->mailbox->emails[i], MUTT_READ, 1);
+              mutt_set_flag(Context->mailbox, Context->mailbox->emails[i], MUTT_READ, true);
           }
           menu->redraw |= REDRAW_STATUS | REDRAW_INDEX;
         }
         else
         {
           if (CUR_EMAIL->read || CUR_EMAIL->old)
-            mutt_set_flag(Context->mailbox, CUR_EMAIL, MUTT_NEW, 1);
+            mutt_set_flag(Context->mailbox, CUR_EMAIL, MUTT_NEW, true);
           else
-            mutt_set_flag(Context->mailbox, CUR_EMAIL, MUTT_READ, 1);
+            mutt_set_flag(Context->mailbox, CUR_EMAIL, MUTT_READ, true);
 
           if (Resolve)
           {
@@ -3035,18 +3035,18 @@ int mutt_index_menu(void)
           break;
 
         int subthread = (op == OP_DELETE_SUBTHREAD);
-        int rc = mutt_thread_set_flag(CUR_EMAIL, MUTT_DELETE, 1, subthread);
+        int rc = mutt_thread_set_flag(CUR_EMAIL, MUTT_DELETE, true, subthread);
         if (rc == -1)
           break;
         if (op == OP_PURGE_THREAD)
         {
-          rc = mutt_thread_set_flag(CUR_EMAIL, MUTT_PURGE, 1, subthread);
+          rc = mutt_thread_set_flag(CUR_EMAIL, MUTT_PURGE, true, subthread);
           if (rc == -1)
             break;
         }
 
         if (DeleteUntag)
-          mutt_thread_set_flag(CUR_EMAIL, MUTT_TAG, 0, subthread);
+          mutt_thread_set_flag(CUR_EMAIL, MUTT_TAG, false, subthread);
         if (Resolve)
         {
           menu->current = ci_next_undeleted(menu->current);
@@ -3294,14 +3294,13 @@ int mutt_index_menu(void)
           break;
         /* L10N: CHECK_ACL */
         /* L10N: Due to the implementation details we do not know whether we
-            mark zero, 1, 12, ... messages as read. So in English we use
-            "messages". Your language might have other means to express this.
-          */
+           mark zero, 1, 12, ... messages as read. So in English we use
+           "messages". Your language might have other means to express this.
+         */
         if (!check_acl(Context, MUTT_ACL_SEEN, _("Cannot mark messages as read")))
           break;
 
-        int rc = mutt_thread_set_flag(CUR_EMAIL, MUTT_READ, 1,
-                                      (op == OP_MAIN_READ_THREAD) ? 0 : 1);
+        int rc = mutt_thread_set_flag(CUR_EMAIL, MUTT_READ, true, (op != OP_MAIN_READ_THREAD));
         if (rc != -1)
         {
           if (Resolve)
@@ -3448,8 +3447,8 @@ int mutt_index_menu(void)
       {
         if (!prereq(Context, menu, CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE))
           break;
-        int rc = mutt_thread_set_flag(CUR_EMAIL, MUTT_TAG, !CUR_EMAIL->tagged,
-                                      (op == OP_TAG_THREAD) ? 0 : 1);
+
+        int rc = mutt_thread_set_flag(CUR_EMAIL, MUTT_TAG, !CUR_EMAIL->tagged, (op != OP_TAG_THREAD));
         if (rc != -1)
         {
           if (Resolve)
@@ -3514,12 +3513,10 @@ int mutt_index_menu(void)
         if (!check_acl(Context, MUTT_ACL_DELETE, _("Cannot undelete messages")))
           break;
 
-        int rc = mutt_thread_set_flag(CUR_EMAIL, MUTT_DELETE, 0,
-                                      (op == OP_UNDELETE_THREAD) ? 0 : 1);
+        int rc = mutt_thread_set_flag(CUR_EMAIL, MUTT_DELETE, false, (op != OP_UNDELETE_THREAD));
         if (rc != -1)
         {
-          rc = mutt_thread_set_flag(CUR_EMAIL, MUTT_PURGE, 0,
-                                    (op == OP_UNDELETE_THREAD) ? 0 : 1);
+          rc = mutt_thread_set_flag(CUR_EMAIL, MUTT_PURGE, false, (op != OP_UNDELETE_THREAD));
         }
         if (rc != -1)
         {

--- a/mutt_thread.c
+++ b/mutt_thread.c
@@ -1463,7 +1463,7 @@ static bool link_threads(struct Email *parent, struct Email *child, struct Mailb
 
   mutt_break_thread(child);
   mutt_list_insert_head(&child->env->in_reply_to, mutt_str_strdup(parent->env->message_id));
-  mutt_set_flag(m, child, MUTT_TAG, 0);
+  mutt_set_flag(m, child, MUTT_TAG, false);
 
   child->changed = true;
   child->env->changed |= MUTT_ENV_CHANGED_IRT;

--- a/mx.c
+++ b/mx.c
@@ -636,7 +636,7 @@ int mx_mbox_close(struct Context **ptr)
     for (i = 0; i < m->msg_count; i++)
     {
       if (!m->emails[i]->deleted && !m->emails[i]->old && !m->emails[i]->read)
-        mutt_set_flag(m, m->emails[i], MUTT_OLD, 1);
+        mutt_set_flag(m, m->emails[i], MUTT_OLD, true);
     }
   }
 
@@ -690,8 +690,8 @@ int mx_mbox_close(struct Context **ptr)
         {
           if (mutt_append_message(ctx_read->mailbox, ctx->mailbox, m->emails[i], 0, CH_UPDATE_LEN) == 0)
           {
-            mutt_set_flag(m, m->emails[i], MUTT_DELETE, 1);
-            mutt_set_flag(m, m->emails[i], MUTT_PURGE, 1);
+            mutt_set_flag(m, m->emails[i], MUTT_DELETE, true);
+            mutt_set_flag(m, m->emails[i], MUTT_PURGE, true);
           }
           else
           {

--- a/nntp/newsrc.c
+++ b/nntp/newsrc.c
@@ -1297,7 +1297,7 @@ struct NntpMboxData *mutt_newsgroup_catchup(struct Mailbox *m,
   if (m && (m->mdata == mdata))
   {
     for (unsigned int i = 0; i < m->msg_count; i++)
-      mutt_set_flag(m, m->emails[i], MUTT_READ, 1);
+      mutt_set_flag(m, m->emails[i], MUTT_READ, true);
   }
   return mdata;
 }
@@ -1333,7 +1333,7 @@ struct NntpMboxData *mutt_newsgroup_uncatchup(struct Mailbox *m,
   {
     mdata->unread = m->msg_count;
     for (unsigned int i = 0; i < m->msg_count; i++)
-      mutt_set_flag(m, m->emails[i], MUTT_READ, 0);
+      mutt_set_flag(m, m->emails[i], MUTT_READ, false);
   }
   else
   {

--- a/nntp/nntp.c
+++ b/nntp/nntp.c
@@ -1624,7 +1624,7 @@ static int check_mailbox(struct Mailbox *m)
           /* header marked as deleted, removing from context */
           if (deleted)
           {
-            mutt_set_flag(m, m->emails[i], MUTT_TAG, 0);
+            mutt_set_flag(m, m->emails[i], MUTT_TAG, false);
             mutt_email_free(&m->emails[i]);
             continue;
           }

--- a/notmuch/mutt_notmuch.c
+++ b/notmuch/mutt_notmuch.c
@@ -1284,21 +1284,21 @@ static int update_email_flags(struct Mailbox *m, struct Email *e, const char *ta
     {
       tag = tag + 1;
       if (strcmp(tag, NmUnreadTag) == 0)
-        mutt_set_flag(m, e, MUTT_READ, 1);
+        mutt_set_flag(m, e, MUTT_READ, true);
       else if (strcmp(tag, NmRepliedTag) == 0)
-        mutt_set_flag(m, e, MUTT_REPLIED, 0);
+        mutt_set_flag(m, e, MUTT_REPLIED, false);
       else if (strcmp(tag, NmFlaggedTag) == 0)
-        mutt_set_flag(m, e, MUTT_FLAG, 0);
+        mutt_set_flag(m, e, MUTT_FLAG, false);
     }
     else
     {
       tag = (*tag == '+') ? tag + 1 : tag;
       if (strcmp(tag, NmUnreadTag) == 0)
-        mutt_set_flag(m, e, MUTT_READ, 0);
+        mutt_set_flag(m, e, MUTT_READ, false);
       else if (strcmp(tag, NmRepliedTag) == 0)
-        mutt_set_flag(m, e, MUTT_REPLIED, 1);
+        mutt_set_flag(m, e, MUTT_REPLIED, true);
       else if (strcmp(tag, NmFlaggedTag) == 0)
-        mutt_set_flag(m, e, MUTT_FLAG, 1);
+        mutt_set_flag(m, e, MUTT_FLAG, true);
     }
     end = NULL;
     tag = NULL;

--- a/pager.c
+++ b/pager.c
@@ -2284,7 +2284,7 @@ int mutt_pager(const char *banner, const char *fname, int flags, struct Pager *e
   if (Context && IsEmail(extra) && !extra->email->read)
   {
     Context->msgnotreadyet = extra->email->msgno;
-    mutt_set_flag(Context->mailbox, extra->email, MUTT_READ, 1);
+    mutt_set_flag(Context->mailbox, extra->email, MUTT_READ, true);
   }
 
   rd.max_line = LINES; /* number of lines on screen, from curses */
@@ -3007,10 +3007,10 @@ int mutt_pager(const char *banner, const char *fname, int flags, struct Pager *e
         /* L10N: CHECK_ACL */
         CHECK_ACL(MUTT_ACL_DELETE, _("Cannot delete message"));
 
-        mutt_set_flag(Context->mailbox, extra->email, MUTT_DELETE, 1);
+        mutt_set_flag(Context->mailbox, extra->email, MUTT_DELETE, true);
         mutt_set_flag(Context->mailbox, extra->email, MUTT_PURGE, (ch == OP_PURGE_MESSAGE));
         if (DeleteUntag)
-          mutt_set_flag(Context->mailbox, extra->email, MUTT_TAG, 0);
+          mutt_set_flag(Context->mailbox, extra->email, MUTT_TAG, false);
         pager_menu->redraw |= REDRAW_STATUS | REDRAW_INDEX;
         if (Resolve)
         {
@@ -3058,7 +3058,7 @@ int mutt_pager(const char *banner, const char *fname, int flags, struct Pager *e
           break;
         if (ch == OP_PURGE_THREAD)
         {
-          r = mutt_thread_set_flag(extra->email, MUTT_PURGE, 1, subthread);
+          r = mutt_thread_set_flag(extra->email, MUTT_PURGE, true, subthread);
           if (r == -1)
             break;
         }
@@ -3380,9 +3380,9 @@ int mutt_pager(const char *banner, const char *fname, int flags, struct Pager *e
         CHECK_ACL(MUTT_ACL_SEEN, _("Cannot toggle new"));
 
         if (extra->email->read || extra->email->old)
-          mutt_set_flag(Context->mailbox, extra->email, MUTT_NEW, 1);
+          mutt_set_flag(Context->mailbox, extra->email, MUTT_NEW, true);
         else if (!first)
-          mutt_set_flag(Context->mailbox, extra->email, MUTT_READ, 1);
+          mutt_set_flag(Context->mailbox, extra->email, MUTT_READ, true);
         first = false;
         Context->msgnotreadyet = -1;
         pager_menu->redraw |= REDRAW_STATUS | REDRAW_INDEX;
@@ -3399,8 +3399,8 @@ int mutt_pager(const char *banner, const char *fname, int flags, struct Pager *e
         /* L10N: CHECK_ACL */
         CHECK_ACL(MUTT_ACL_DELETE, _("Cannot undelete message"));
 
-        mutt_set_flag(Context->mailbox, extra->email, MUTT_DELETE, 0);
-        mutt_set_flag(Context->mailbox, extra->email, MUTT_PURGE, 0);
+        mutt_set_flag(Context->mailbox, extra->email, MUTT_DELETE, false);
+        mutt_set_flag(Context->mailbox, extra->email, MUTT_PURGE, false);
         pager_menu->redraw |= REDRAW_STATUS | REDRAW_INDEX;
         if (Resolve)
         {
@@ -3421,12 +3421,12 @@ int mutt_pager(const char *banner, const char *fname, int flags, struct Pager *e
          */
         CHECK_ACL(MUTT_ACL_DELETE, _("Cannot undelete messages"));
 
-        int r = mutt_thread_set_flag(extra->email, MUTT_DELETE, 0,
-                                     (ch == OP_UNDELETE_THREAD) ? 0 : 1);
+        int r = mutt_thread_set_flag(extra->email, MUTT_DELETE, false,
+                                     (ch != OP_UNDELETE_THREAD));
         if (r != -1)
         {
-          r = mutt_thread_set_flag(extra->email, MUTT_PURGE, 0,
-                                   (ch == OP_UNDELETE_THREAD) ? 0 : 1);
+          r = mutt_thread_set_flag(extra->email, MUTT_PURGE, false,
+                                   (ch != OP_UNDELETE_THREAD));
         }
         if (r != -1)
         {

--- a/pattern.c
+++ b/pattern.c
@@ -2408,7 +2408,7 @@ int mutt_pattern_func(int op, char *prompt)
           case MUTT_UNDELETE:
             mutt_set_flag(Context->mailbox,
                           Context->mailbox->emails[Context->mailbox->v2r[i]],
-                          MUTT_PURGE, 0);
+                          MUTT_PURGE, false);
           /* fallthrough */
           case MUTT_DELETE:
             mutt_set_flag(Context->mailbox,

--- a/postpone.c
+++ b/postpone.c
@@ -241,7 +241,7 @@ static struct Email *select_msg(struct Context *ctx)
       case OP_UNDELETE:
         /* should deleted draft messages be saved in the trash folder? */
         mutt_set_flag(ctx->mailbox, ctx->mailbox->emails[menu->current],
-                      MUTT_DELETE, (i == OP_DELETE) ? 1 : 0);
+                      MUTT_DELETE, (i == OP_DELETE));
         PostCount = ctx->mailbox->msg_count - ctx->mailbox->msg_deleted;
         if (Resolve && menu->current < menu->max - 1)
         {
@@ -348,8 +348,8 @@ int mutt_get_postponed(struct Context *ctx, struct Email *hdr,
   }
 
   /* finished with this message, so delete it. */
-  mutt_set_flag(ctx_post->mailbox, e, MUTT_DELETE, 1);
-  mutt_set_flag(ctx_post->mailbox, e, MUTT_PURGE, 1);
+  mutt_set_flag(ctx_post->mailbox, e, MUTT_DELETE, true);
+  mutt_set_flag(ctx_post->mailbox, e, MUTT_PURGE, true);
 
   /* update the count for the status display */
   PostCount = ctx_post->mailbox->msg_count - ctx_post->mailbox->msg_deleted;

--- a/protos.h
+++ b/protos.h
@@ -63,9 +63,9 @@ int mutt_set_xdg_path(enum XdgType type, char *buf, size_t bufsize);
 void mutt_help(int menu);
 void mutt_make_help(char *d, size_t dlen, const char *txt, int menu, int op);
 void mutt_set_flag_update(struct Mailbox *m, struct Email *e, int flag, bool bf, bool upd_mbox);
-#define mutt_set_flag(a, b, c, d) mutt_set_flag_update(a, b, c, d, true)
+#define mutt_set_flag(m, e, flag, bf) mutt_set_flag_update(m, e, flag, bf, true)
 void mutt_signal_init(void);
-void mutt_emails_set_flag(struct Mailbox *m, struct EmailList *el, int flag, int bf);
+void mutt_emails_set_flag(struct Mailbox *m, struct EmailList *el, int flag, bool bf);
 int mutt_change_flag(struct Mailbox *m, struct EmailList *el, int bf);
 
 int mutt_complete(char *buf, size_t buflen);
@@ -76,7 +76,7 @@ int mutt_enter_string_full(char *buf, size_t buflen, int col, int flags, bool mu
 int mutt_get_postponed(struct Context *ctx, struct Email *e, struct Email **cur, char *fcc, size_t fcclen);
 int mutt_parse_crypt_hdr(const char *p, int set_empty_signas, int crypt_app);
 int mutt_num_postponed(struct Mailbox *m, bool force);
-int mutt_thread_set_flag(struct Email *e, int flag, int bf, int subthread);
+int mutt_thread_set_flag(struct Email *e, int flag, bool bf, bool subthread);
 void mutt_update_num_postponed(void);
 int url_parse_mailto(struct Envelope *e, char **body, const char *src);
 int mutt_is_quote_line(char *buf, regmatch_t *pmatch);

--- a/recvcmd.c
+++ b/recvcmd.c
@@ -1050,7 +1050,7 @@ void mutt_attach_reply(FILE *fp, struct Email *e, struct AttachCtx *actx,
   el_add_email(&el, e_parent ? e_parent : (cur ? cur->email : NULL));
   if (ci_send_message(flags, e_tmp, tmpbody, NULL, &el) == 0)
   {
-    mutt_set_flag(Context->mailbox, e, MUTT_REPLIED, 1);
+    mutt_set_flag(Context->mailbox, e, MUTT_REPLIED, true);
   }
   el_free(&el);
 }


### PR DESCRIPTION
Boolify the parameters of functions `mutt_emails_set_flag()`, `mutt_thread_set_flag()` and macro `mutt_set_flag()`.

There are no functional changes.
