### PR TITLE
Use gmtime_r and localtime_r

### DIFF
--- a/browser.c
+++ b/browser.c
@@ -396,7 +396,9 @@ static const char *folder_format_str(char *buf, size_t buflen, size_t col, int c
         if (!do_locales)
           setlocale(LC_TIME, "C");
         char date[128];
-        strftime(date, sizeof(date), t_fmt, localtime(&folder->ff->mtime));
+        struct tm tm = { 0 };
+        localtime_r(&folder->ff->mtime, &tm);
+        strftime(date, sizeof(date), t_fmt, &tm);
         if (!do_locales)
           setlocale(LC_TIME, "");
 

--- a/f1
+++ b/f1
@@ -1,0 +1,126 @@
+Encapsulate gmtime() and localtime()
+
+There are over 20 places where NeoMutt uses these time functions.
+It makes sense to wrap these calls in a function and simplify the callers.
+  
+Some typical patterns are:
+  
+- `time()` -\> `time_t` \-> `localtime()` -> `struct tm`
+  The current time is split into (year, month, day, etc)
+
+- `time_t` -\> `localtime()` -\> `struct tm` -\> `strftime()`
+  An existing timestamp is formatted into a string
+
+- `time_t` -\> `gmtime()` -\> `struct tm`
+  An existing timestamp is split into (year, month, day, etc)
+
+The second part of this task is to convert to using the thread-safe versions of these two functions:
+- `gmtime()` -\> `gmtime_r()`
+- `localtime()` -\> `localtime_r()`
+
+--------------------------------------------------------------------------------
+
+pattern.c:403:19: 
+	time() -> now -> localtime -> tm
+
+pattern.c:618:21: 
+pattern.c:690:25: 
+	time() -> now -> localtime -> tm min,max
+
+nntp/nntp.c:2181:8: 
+	time() -> now
+	nntp string -> now
+
+	time_t -> string
+
+hdrline.c:676:16: 
+hdrline.c:817:16: 
+hdrline.c:819:16: 
+hdrline.c:823:16: 
+	time() -> now -> localtime -> tm
+	time_t -> localtime -> tm
+
+hdrline.c:833:16: 
+	time_t -> gmtime -> tm
+
+browser.c:401:45: 
+	time_t -> localtime -> (tm) -> strftime
+
+sendlib.c:2475:19: 
+	time() -> now -> localtime -> tm
+
+ncrypt/pgpkey.c:301:12: 
+	time_t -> localtime -> (tm) -> strftime
+
+ncrypt/crypt.c:91:54: 
+	time() -> now -> localtime -> (tm) -> strftime
+
+ncrypt/crypt_gpgme.c:1259:48: 
+	time_t -> localtime -> (tm) -> strftime
+
+ncrypt/crypt_gpgme.c:2533:48: 
+	time_t -> localtime -> (tm) -> strftime
+
+ncrypt/crypt_gpgme.c:3484:14: 
+	time_t -> localtime -> (tm) -> strftime
+
+ncrypt/crypt_gpgme.c:4124:10: 
+	time_t -> localtime -> (tm) -> strftime
+
+ncrypt/crypt_gpgme.c:4134:10: 
+	time_t -> localtime -> (tm) -> strftime
+
+ncrypt/crypt_gpgme.c:4272:14: 
+	time_t -> localtime -> (tm) -> strftime
+
+ncrypt/crypt_gpgme.c:4282:14: 
+	time_t -> localtime -> (tm) -> strftime
+
+mutt/date.c:133:19: 
+	time_t -> localtime -> tm
+
+mutt/date.c:221:9: 
+	time_t -> gmtime -> tm -> compute_tz()
+
+mutt/date.c:383:18: 
+	time() -> now -> localtime -> tm -> mutt_date_local_tz()
+
+mutt/date.c:604:19: 
+	time_t -> localtime -> tm
+
+mutt/date.c:627:19: 
+	time_t -> gmtime -> tm
+
+mutt/logging.c:86:53: 
+	time_t -> localtime -> (tm) -> strftime
+
+mutt/logging.c:380:44: 
+	time_t -> localtime -> (tm) -> strftime
+
+
+nntp string -> now
+time() -> now
+time() -> now -> localtime -> (tm) -> strftime
+time() -> now -> localtime -> tm
+time() -> now -> localtime -> tm
+time() -> now -> localtime -> tm
+time() -> now -> localtime -> tm -> mutt_date_local_tz()
+time() -> now -> localtime -> tm min,max
+time_t -> gmtime -> tm
+time_t -> gmtime -> tm
+time_t -> gmtime -> tm -> compute_tz()
+time_t -> localtime -> (tm) -> strftime
+time_t -> localtime -> (tm) -> strftime
+time_t -> localtime -> (tm) -> strftime
+time_t -> localtime -> (tm) -> strftime
+time_t -> localtime -> (tm) -> strftime
+time_t -> localtime -> (tm) -> strftime
+time_t -> localtime -> (tm) -> strftime
+time_t -> localtime -> (tm) -> strftime
+time_t -> localtime -> (tm) -> strftime
+time_t -> localtime -> (tm) -> strftime
+time_t -> localtime -> (tm) -> strftime
+time_t -> localtime -> tm
+time_t -> localtime -> tm
+time_t -> localtime -> tm
+time_t -> string

--- a/hdrline.c
+++ b/hdrline.c
@@ -664,7 +664,7 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
       /* preprocess $date_format to handle %Z */
       {
         const char *cp = NULL;
-        struct tm *tm = NULL;
+        struct tm tm = { 0 };
         time_t now;
         int j = 0;
 
@@ -672,7 +672,7 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
         {
           char *is = NULL;
           now = time(NULL);
-          tm = localtime(&now);
+          localtime_r(&now, &tm);
           now -= (op == '(') ? e->received : e->date_sent;
 
           is = (char *) prec;
@@ -695,8 +695,7 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
                   t--;
                   t *= (60 * 60 * 24 * 365);
                 }
-                t += ((tm->tm_mon * 60 * 60 * 24 * 30) + (tm->tm_mday * 60 * 60 * 24) +
-                      (tm->tm_hour * 60 * 60) + (tm->tm_min * 60) + tm->tm_sec);
+                t += ((tm.tm_mon * 60 * 60 * 24 * 30) + (tm.tm_mday * 60 * 60 * 24) + (tm.tm_hour * 60 * 60) + (tm.tm_min * 60) + tm.tm_sec);
                 break;
 
               case 'm':
@@ -705,8 +704,7 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
                   t--;
                   t *= (60 * 60 * 24 * 30);
                 }
-                t += ((tm->tm_mday * 60 * 60 * 24) + (tm->tm_hour * 60 * 60) +
-                      (tm->tm_min * 60) + tm->tm_sec);
+                t += ((tm.tm_mday * 60 * 60 * 24) + (tm.tm_hour * 60 * 60) + (tm.tm_min * 60) + tm.tm_sec);
                 break;
 
               case 'w':
@@ -715,8 +713,7 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
                   t--;
                   t *= (60 * 60 * 24 * 7);
                 }
-                t += ((tm->tm_wday * 60 * 60 * 24) + (tm->tm_hour * 60 * 60) +
-                      (tm->tm_min * 60) + tm->tm_sec);
+                t += ((tm.tm_wday * 60 * 60 * 24) + (tm.tm_hour * 60 * 60) + (tm.tm_min * 60) + tm.tm_sec);
                 break;
 
               case 'd':
@@ -725,7 +722,7 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
                   t--;
                   t *= (60 * 60 * 24);
                 }
-                t += ((tm->tm_hour * 60 * 60) + (tm->tm_min * 60) + tm->tm_sec);
+                t += ((tm.tm_hour * 60 * 60) + (tm.tm_min * 60) + tm.tm_sec);
                 break;
 
               case 'H':
@@ -734,7 +731,7 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
                   t--;
                   t *= (60 * 60);
                 }
-                t += ((tm->tm_min * 60) + tm->tm_sec);
+                t += ((tm.tm_min * 60) + tm.tm_sec);
                 break;
 
               case 'M':
@@ -743,7 +740,7 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
                   t--;
                   t *= (60);
                 }
-                t += (tm->tm_sec);
+                t += (tm.tm_sec);
                 break;
 
               default:
@@ -813,13 +810,13 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
         *p = 0;
 
         if ((op == '[') || (op == 'D'))
-          tm = localtime(&e->date_sent);
+          localtime_r(&e->date_sent, &tm);
         else if (op == '(')
-          tm = localtime(&e->received);
+          localtime_r(&e->received, &tm);
         else if (op == '<')
         {
           now = time(NULL);
-          tm = localtime(&now);
+          localtime_r(&now, &tm);
         }
         else
         {
@@ -829,12 +826,12 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
             now -= (e->zhours * 3600 + e->zminutes * 60);
           else
             now += (e->zhours * 3600 + e->zminutes * 60);
-          tm = gmtime(&now);
+          gmtime_r(&now, &tm);
         }
 
         if (!do_locales)
           setlocale(LC_TIME, "C");
-        strftime(tmp, sizeof(tmp), buf, tm);
+        strftime(tmp, sizeof(tmp), buf, &tm);
         if (!do_locales)
           setlocale(LC_TIME, "");
 
@@ -844,8 +841,8 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
 
         if ((len > 0) && (op != 'd') && (op != 'D')) /* Skip ending op */
           src = cp + 1;
+        break;
       }
-      break;
 
     case 'e':
       snprintf(fmt, sizeof(fmt), "%%%sd", prec);

--- a/mutt/logging.c
+++ b/mutt/logging.c
@@ -83,7 +83,9 @@ static const char *timestamp(time_t stamp)
 
   if (stamp != last)
   {
-    strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", localtime(&stamp));
+    struct tm tm = { 0 };
+    localtime_r(&stamp, &tm);
+    strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", &tm);
     last = stamp;
   }
 
@@ -375,9 +377,11 @@ int log_queue_save(FILE *fp)
   char buf[32];
   int count = 0;
   struct LogLine *ll = NULL;
+  struct tm tm = { 0 };
   STAILQ_FOREACH(ll, &LogQueue, entries)
   {
-    strftime(buf, sizeof(buf), "%H:%M:%S", localtime(&ll->time));
+    localtime_r(&ll->time, &tm);
+    strftime(buf, sizeof(buf), "%H:%M:%S", &tm);
     fprintf(fp, "[%s]<%c> %s", buf, LevelAbbr[ll->level + 3], ll->message);
     if (ll->level <= 0)
       fputs("\n", fp);

--- a/ncrypt/crypt.c
+++ b/ncrypt/crypt.c
@@ -88,7 +88,9 @@ void crypt_current_time(struct State *s, const char *app_name)
   if (C_CryptTimestamp)
   {
     t = time(NULL);
-    strftime(p, sizeof(p), _(" (current time: %c)"), localtime(&t));
+    struct tm tm = { 0 };
+    localtime_r(&t, &tm);
+    strftime(p, sizeof(p), _(" (current time: %c)"), &tm);
   }
   else
     *p = '\0';

--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -1256,7 +1256,9 @@ static void print_time(time_t t, struct State *s)
 {
   char p[256];
 
-  strftime(p, sizeof(p), nl_langinfo(D_T_FMT), localtime(&t));
+  struct tm tm = { 0 };
+  localtime_r(&t, &tm);
+  strftime(p, sizeof(p), nl_langinfo(D_T_FMT), &tm);
   state_puts(p, s);
 }
 
@@ -2529,7 +2531,9 @@ static int pgp_gpgme_extract_keys(gpgme_data_t keydata, FILE **fp)
       if (len > 8)
         shortid += len - 8;
       tt = subkey->timestamp;
-      strftime(date, sizeof(date), "%Y-%m-%d", localtime(&tt));
+      struct tm tm = { 0 };
+      localtime_r(&tt, &tm);
+      strftime(date, sizeof(date), "%Y-%m-%d", &tm);
 
       if (!more)
       {
@@ -3438,7 +3442,7 @@ static const char *crypt_format_str(char *buf, size_t buflen, size_t col, int co
     {
       char buf2[128];
       bool do_locales = true;
-      struct tm *tm = NULL;
+      struct tm tm = { 0 };
       size_t len;
 
       char *p = buf;
@@ -3480,12 +3484,12 @@ static const char *crypt_format_str(char *buf, size_t buflen, size_t col, int co
         if (key->kobj->subkeys && (key->kobj->subkeys->timestamp > 0))
           tt = key->kobj->subkeys->timestamp;
 
-        tm = localtime(&tt);
+        localtime_r(&tt, &tm);
       }
 
       if (!do_locales)
         setlocale(LC_TIME, "C");
-      strftime(buf2, sizeof(buf2), buf, tm);
+      strftime(buf2, sizeof(buf2), buf, &tm);
       if (!do_locales)
         setlocale(LC_TIME, "");
 
@@ -4067,7 +4071,6 @@ static void print_key_info(gpgme_key_t key, FILE *fp)
   int idx;
   const char *s = NULL, *s2 = NULL;
   time_t tt = 0;
-  struct tm *tm = NULL;
   char shortbuf[128];
   unsigned long aval = 0;
   const char *delim = NULL;
@@ -4119,8 +4122,9 @@ static void print_key_info(gpgme_key_t key, FILE *fp)
   {
     tt = key->subkeys->timestamp;
 
-    tm = localtime(&tt);
-    strftime(shortbuf, sizeof(shortbuf), nl_langinfo(D_T_FMT), tm);
+    struct tm tm = { 0 };
+    localtime_r(&tt, &tm);
+    strftime(shortbuf, sizeof(shortbuf), nl_langinfo(D_T_FMT), &tm);
     fprintf(fp, "%*s%s\n", KeyInfoPadding[KIP_VALID_FROM],
             _(KeyInfoPrompts[KIP_VALID_FROM]), shortbuf);
   }
@@ -4129,8 +4133,9 @@ static void print_key_info(gpgme_key_t key, FILE *fp)
   {
     tt = key->subkeys->expires;
 
-    tm = localtime(&tt);
-    strftime(shortbuf, sizeof(shortbuf), nl_langinfo(D_T_FMT), tm);
+    struct tm tm = { 0 };
+    localtime_r(&tt, &tm);
+    strftime(shortbuf, sizeof(shortbuf), nl_langinfo(D_T_FMT), &tm);
     fprintf(fp, "%*s%s\n", KeyInfoPadding[KIP_VALID_TO],
             _(KeyInfoPrompts[KIP_VALID_TO]), shortbuf);
   }
@@ -4267,8 +4272,9 @@ static void print_key_info(gpgme_key_t key, FILE *fp)
       {
         tt = subkey->timestamp;
 
-        tm = localtime(&tt);
-        strftime(shortbuf, sizeof(shortbuf), nl_langinfo(D_T_FMT), tm);
+        struct tm tm = { 0 };
+        localtime_r(&tt, &tm);
+        strftime(shortbuf, sizeof(shortbuf), nl_langinfo(D_T_FMT), &tm);
         fprintf(fp, "%*s%s\n", KeyInfoPadding[KIP_VALID_FROM],
                 _(KeyInfoPrompts[KIP_VALID_FROM]), shortbuf);
       }
@@ -4277,8 +4283,9 @@ static void print_key_info(gpgme_key_t key, FILE *fp)
       {
         tt = subkey->expires;
 
-        tm = localtime(&tt);
-        strftime(shortbuf, sizeof(shortbuf), nl_langinfo(D_T_FMT), tm);
+        struct tm tm = { 0 };
+        localtime_r(&tt, &tm);
+        strftime(shortbuf, sizeof(shortbuf), nl_langinfo(D_T_FMT), &tm);
         fprintf(fp, "%*s%s\n", KeyInfoPadding[KIP_VALID_TO],
                 _(KeyInfoPrompts[KIP_VALID_TO]), shortbuf);
       }

--- a/ncrypt/pgpkey.c
+++ b/ncrypt/pgpkey.c
@@ -261,7 +261,6 @@ static const char *pgp_entry_fmt(char *buf, size_t buflen, size_t col, int cols,
     {
       char buf2[128];
       bool do_locales = true;
-      struct tm *tm = NULL;
       size_t len;
 
       char *p = buf;
@@ -297,11 +296,12 @@ static const char *pgp_entry_fmt(char *buf, size_t buflen, size_t col, int cols,
       }
       *p = 0;
 
-      tm = localtime(&key->gen_time);
+      struct tm tm = { 0 };
+      localtime_r(&key->gen_time, &tm);
 
       if (!do_locales)
         setlocale(LC_TIME, "C");
-      strftime(buf2, sizeof(buf2), buf, tm);
+      strftime(buf2, sizeof(buf2), buf, &tm);
       if (!do_locales)
         setlocale(LC_TIME, "");
 

--- a/nntp/nntp.c
+++ b/nntp/nntp.c
@@ -2131,7 +2131,6 @@ int nntp_check_new_groups(struct Mailbox *m, struct NntpAccountData *adata)
 {
   struct NntpMboxData tmp_mdata;
   time_t now;
-  struct tm *tm = NULL;
   char buf[1024];
   char *msg = _("Checking for new newsgroups...");
   unsigned int i;
@@ -2178,10 +2177,10 @@ int nntp_check_new_groups(struct Mailbox *m, struct NntpAccountData *adata)
   else
     tmp_mdata.group = NULL;
   i = adata->groups_num;
-  tm = gmtime(&adata->newgroups_time);
+  struct tm tm = { 0 };
+  gmtime_r(&adata->newgroups_time, &tm);
   snprintf(buf, sizeof(buf), "NEWGROUPS %02d%02d%02d %02d%02d%02d GMT\r\n",
-           tm->tm_year % 100, tm->tm_mon + 1, tm->tm_mday, tm->tm_hour,
-           tm->tm_min, tm->tm_sec);
+           tm.tm_year % 100, tm.tm_mon + 1, tm.tm_mday, tm.tm_hour, tm.tm_min, tm.tm_sec);
   rc = nntp_fetch_lines(&tmp_mdata, buf, sizeof(buf), msg, nntp_add_group, adata);
   if (rc)
   {

--- a/pattern.c
+++ b/pattern.c
@@ -402,7 +402,8 @@ static const char *get_date(const char *s, struct tm *t, struct Buffer *err)
 {
   char *p = NULL;
   time_t now = time(NULL);
-  struct tm *tm = localtime(&now);
+  struct tm tm = { 0 };
+  localtime_r(&now, &tm);
 
   t->tm_mday = strtol(s, &p, 10);
   if ((t->tm_mday < 1) || (t->tm_mday > 31))
@@ -413,8 +414,8 @@ static const char *get_date(const char *s, struct tm *t, struct Buffer *err)
   if (*p != '/')
   {
     /* fill in today's month and year */
-    t->tm_mon = tm->tm_mon;
-    t->tm_year = tm->tm_year;
+    t->tm_mon = tm.tm_mon;
+    t->tm_year = tm.tm_year;
     return p;
   }
   p++;
@@ -426,7 +427,7 @@ static const char *get_date(const char *s, struct tm *t, struct Buffer *err)
   }
   if (*p != '/')
   {
-    t->tm_year = tm->tm_year;
+    t->tm_year = tm.tm_year;
     return p;
   }
   p++;
@@ -618,17 +619,17 @@ static bool eat_date(struct Pattern *pat, struct Buffer *s, struct Buffer *err)
        >3d      more than three days ago
        =3d      exactly three days ago */
     time_t now = time(NULL);
-    struct tm *tm = localtime(&now);
+    struct tm *tm = NULL;
     bool exact = false;
 
     if (buf.data[0] == '<')
     {
-      memcpy(&min, tm, sizeof(min));
+      localtime_r(&now, &min);
       tm = &min;
     }
     else
     {
-      memcpy(&max, tm, sizeof(max));
+      localtime_r(&now, &max);
       tm = &max;
 
       if (buf.data[0] == '=')
@@ -690,9 +691,8 @@ static bool eat_date(struct Pattern *pat, struct Buffer *s, struct Buffer *err)
       if (!have_min)
       { /* save base minimum and set current date, e.g. for "-3d+1d" */
         time_t now = time(NULL);
-        struct tm *tm = localtime(&now);
         memcpy(&base_min, &min, sizeof(base_min));
-        memcpy(&min, tm, sizeof(min));
+        localtime_r(&now, &min);
         min.tm_hour = 0;
         min.tm_sec = 0;
         min.tm_min = 0;

--- a/sendlib.c
+++ b/sendlib.c
@@ -2476,13 +2476,14 @@ static char *gen_msgid(void)
   mutt_rand_base32(rndid, sizeof(rndid) - 1);
   rndid[MUTT_RANDTAG_LEN] = 0;
   now = time(NULL);
-  struct tm *tm = gmtime(&now);
   const char *fqdn = mutt_fqdn(false);
   if (!fqdn)
     fqdn = NONULL(ShortHostname);
 
-  snprintf(buf, sizeof(buf), "<%d%02d%02d%02d%02d%02d.%s@%s>", tm->tm_year + 1900,
-           tm->tm_mon + 1, tm->tm_mday, tm->tm_hour, tm->tm_min, tm->tm_sec, rndid, fqdn);
+  struct tm tm = { 0 };
+  gmtime_r(&now, &tm);
+  snprintf(buf, sizeof(buf), "<%d%02d%02d%02d%02d%02d.%s@%s>", tm.tm_year + 1900,
+           tm.tm_mon + 1, tm.tm_mday, tm.tm_hour, tm.tm_min, tm.tm_sec, rndid, fqdn);
   return mutt_str_strdup(buf);
 }
 


### PR DESCRIPTION
Use `gmtime_r()` and `localtime_r()`, rather than their non-thread-safe versions.