### PR TITLE
Refactor/tidy mutt_compose_menu()

### DIFF
--- a/compose.c
+++ b/compose.c
@@ -932,6 +932,7 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
         edit_address_list(HDR_FROM, &msg->env->from);
         mutt_message_hook(NULL, msg, MUTT_SEND2_HOOK);
         break;
+
       case OP_COMPOSE_EDIT_TO:
 #ifdef USE_NNTP
         if (news)
@@ -945,6 +946,7 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
         }
         mutt_message_hook(NULL, msg, MUTT_SEND2_HOOK);
         break;
+
       case OP_COMPOSE_EDIT_BCC:
 #ifdef USE_NNTP
         if (news)
@@ -958,6 +960,7 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
         }
         mutt_message_hook(NULL, msg, MUTT_SEND2_HOOK);
         break;
+
       case OP_COMPOSE_EDIT_CC:
 #ifdef USE_NNTP
         if (news)
@@ -989,6 +992,7 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
             clrtoeol();
         }
         break;
+
       case OP_COMPOSE_EDIT_FOLLOWUP_TO:
         if (!news)
           break;
@@ -1006,6 +1010,7 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
             clrtoeol();
         }
         break;
+
       case OP_COMPOSE_EDIT_X_COMMENT_TO:
         if (!(news && XCommentTo))
           break;
@@ -1024,6 +1029,7 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
         }
         break;
 #endif
+
       case OP_COMPOSE_EDIT_SUBJECT:
         if (msg->env->subject)
           mutt_str_strfcpy(buf, msg->env->subject, sizeof(buf));
@@ -1040,10 +1046,12 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
         }
         mutt_message_hook(NULL, msg, MUTT_SEND2_HOOK);
         break;
+
       case OP_COMPOSE_EDIT_REPLY_TO:
         edit_address_list(HDR_REPLYTO, &msg->env->reply_to);
         mutt_message_hook(NULL, msg, MUTT_SEND2_HOOK);
         break;
+
       case OP_COMPOSE_EDIT_FCC:
         mutt_str_strfcpy(buf, fcc, sizeof(buf));
         if (mutt_get_field(_("Fcc: "), buf, sizeof(buf), MUTT_FILE | MUTT_CLEAR) == 0)
@@ -1056,6 +1064,7 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
         }
         mutt_message_hook(NULL, msg, MUTT_SEND2_HOOK);
         break;
+
       case OP_COMPOSE_EDIT_MESSAGE:
         if (Editor && (mutt_str_strcmp("builtin", Editor) != 0) && !EditHeaders)
         {
@@ -1066,6 +1075,7 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
           break;
         }
       /* fallthrough */
+
       case OP_COMPOSE_EDIT_HEADERS:
         if ((mutt_str_strcmp("builtin", Editor) != 0) &&
             (op == OP_COMPOSE_EDIT_HEADERS || (op == OP_COMPOSE_EDIT_MESSAGE && EditHeaders)))
@@ -1135,12 +1145,12 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
           break;
         }
         compose_attach_swap(msg->content, actx->idx, menu->current - 1);
-        menu->redraw = 1;
+        menu->redraw = REDRAW_INDEX;
         menu->current--;
         break;
 
       case OP_COMPOSE_MOVE_DOWN:
-        if (menu->current == actx->idxlen - 1)
+        if (menu->current == (actx->idxlen - 1))
         {
           mutt_error(_("Attachment is already at bottom"));
           break;
@@ -1151,7 +1161,7 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
           break;
         }
         compose_attach_swap(msg->content, actx->idx, menu->current);
-        menu->redraw = 1;
+        menu->redraw = REDRAW_INDEX;
         menu->current++;
         break;
 
@@ -1342,9 +1352,9 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
         char **files = NULL;
         buf[0] = '\0';
 
-        if (mutt_enter_fname_full(prompt, buf, sizeof(buf), false, true,
-                                  &files, &numfiles, MUTT_SEL_MULTI) == -1 ||
-            *buf == '\0')
+        if ((mutt_enter_fname_full(prompt, buf, sizeof(buf), false, true,
+                                   &files, &numfiles, MUTT_SEL_MULTI) == -1) ||
+            (*buf == '\0'))
         {
           break;
         }
@@ -1411,7 +1421,7 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
             mutt_pretty_mailbox(buf, sizeof(buf));
           }
 
-        if (mutt_enter_fname(prompt, buf, sizeof(buf), 1) == -1 || (buf[0] == '\0'))
+        if ((mutt_enter_fname(prompt, buf, sizeof(buf), 1) == -1) || (buf[0] == '\0'))
           break;
 
 #ifdef USE_NNTP
@@ -1614,7 +1624,8 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
       case OP_COMPOSE_EDIT_ENCODING:
         CHECK_COUNT;
         mutt_str_strfcpy(buf, ENCODING(CURATTACH->content->encoding), sizeof(buf));
-        if (mutt_get_field("Content-Transfer-Encoding: ", buf, sizeof(buf), 0) == 0 && (buf[0] != '\0'))
+        if (mutt_get_field("Content-Transfer-Encoding: ", buf, sizeof(buf), 0) == 0 &&
+            (buf[0] != '\0'))
         {
           int enc = mutt_check_encoding(buf);
           if ((enc != ENC_OTHER) && (enc != ENC_UUENCODED))
@@ -1630,11 +1641,9 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
         break;
 
       case OP_COMPOSE_SEND_MESSAGE:
-
         /* Note: We don't invoke send2-hook here, since we want to leave
          * users an opportunity to change settings from the ":" prompt.
          */
-
         if (check_attachments(actx) != 0)
         {
           menu->redraw = REDRAW_FULL;
@@ -1717,7 +1726,7 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
         CHECK_COUNT;
         mutt_str_strfcpy(buf, CURATTACH->content->filename, sizeof(buf));
         mutt_pretty_mailbox(buf, sizeof(buf));
-        if (mutt_get_field(_("Rename to: "), buf, sizeof(buf), MUTT_FILE) == 0 &&
+        if ((mutt_get_field(_("Rename to: "), buf, sizeof(buf), MUTT_FILE) == 0) &&
             (buf[0] != '\0'))
         {
           struct stat st;
@@ -1840,7 +1849,7 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
       case OP_FILTER:
         CHECK_COUNT;
         mutt_pipe_attachment_list(actx, NULL, menu->tagprefix,
-                                  CURATTACH->content, op == OP_FILTER);
+                                  CURATTACH->content, (op == OP_FILTER));
         if (op == OP_FILTER) /* cte might have changed */
           menu->redraw = menu->tagprefix ? REDRAW_FULL : REDRAW_CURRENT;
         menu->redraw |= REDRAW_STATUS;
@@ -1876,7 +1885,6 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
         /* fallthrough */
 
       case OP_COMPOSE_POSTPONE_MESSAGE:
-
         if (check_attachments(actx) != 0)
         {
           menu->redraw = REDRAW_FULL;
@@ -1900,7 +1908,6 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
         break;
 
       case OP_COMPOSE_WRITE_MESSAGE:
-
         buf[0] = '\0';
         if (Context)
         {
@@ -1909,7 +1916,7 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
         }
         if (actx->idxlen)
           msg->content = actx->idx[0]->content;
-        if (mutt_enter_fname(_("Write message to mailbox"), buf, sizeof(buf), 1) != -1 &&
+        if ((mutt_enter_fname(_("Write message to mailbox"), buf, sizeof(buf), 1) != -1) &&
             (buf[0] != '\0'))
         {
           mutt_message(_("Writing message to %s ..."), buf);
@@ -1991,7 +1998,6 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
 
 #ifdef MIXMASTER
       case OP_COMPOSE_MIX:
-
         mix_make_chain(&msg->chain);
         mutt_message_hook(NULL, msg, MUTT_SEND2_HOOK);
         break;

--- a/compose.c
+++ b/compose.c
@@ -974,57 +974,54 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
         break;
 #ifdef USE_NNTP
       case OP_COMPOSE_EDIT_NEWSGROUPS:
-        if (news)
+        if (!news)
+          break;
+        if (msg->env->newsgroups)
+          mutt_str_strfcpy(buf, msg->env->newsgroups, sizeof(buf));
+        else
+          buf[0] = 0;
+        if (mutt_get_field("Newsgroups: ", buf, sizeof(buf), 0) == 0)
         {
+          mutt_str_replace(&msg->env->newsgroups, buf);
+          mutt_window_move(MuttIndexWindow, HDR_TO, HDR_XOFFSET);
           if (msg->env->newsgroups)
-            mutt_str_strfcpy(buf, msg->env->newsgroups, sizeof(buf));
+            mutt_paddstr(W, msg->env->newsgroups);
           else
-            buf[0] = 0;
-          if (mutt_get_field("Newsgroups: ", buf, sizeof(buf), 0) == 0)
-          {
-            mutt_str_replace(&msg->env->newsgroups, buf);
-            mutt_window_move(MuttIndexWindow, HDR_TO, HDR_XOFFSET);
-            if (msg->env->newsgroups)
-              mutt_paddstr(W, msg->env->newsgroups);
-            else
-              clrtoeol();
-          }
+            clrtoeol();
         }
         break;
       case OP_COMPOSE_EDIT_FOLLOWUP_TO:
-        if (news)
+        if (!news)
+          break;
+        if (msg->env->followup_to)
+          mutt_str_strfcpy(buf, msg->env->followup_to, sizeof(buf));
+        else
+          buf[0] = 0;
+        if (mutt_get_field("Followup-To: ", buf, sizeof(buf), 0) == 0)
         {
+          mutt_str_replace(&msg->env->followup_to, buf);
+          mutt_window_move(MuttIndexWindow, HDR_CC, HDR_XOFFSET);
           if (msg->env->followup_to)
-            mutt_str_strfcpy(buf, msg->env->followup_to, sizeof(buf));
+            mutt_paddstr(W, msg->env->followup_to);
           else
-            buf[0] = 0;
-          if (mutt_get_field("Followup-To: ", buf, sizeof(buf), 0) == 0)
-          {
-            mutt_str_replace(&msg->env->followup_to, buf);
-            mutt_window_move(MuttIndexWindow, HDR_CC, HDR_XOFFSET);
-            if (msg->env->followup_to)
-              mutt_paddstr(W, msg->env->followup_to);
-            else
-              clrtoeol();
-          }
+            clrtoeol();
         }
         break;
       case OP_COMPOSE_EDIT_X_COMMENT_TO:
-        if (news && XCommentTo)
+        if (!(news && XCommentTo))
+          break;
+        if (msg->env->x_comment_to)
+          mutt_str_strfcpy(buf, msg->env->x_comment_to, sizeof(buf));
+        else
+          buf[0] = 0;
+        if (mutt_get_field("X-Comment-To: ", buf, sizeof(buf), 0) == 0)
         {
+          mutt_str_replace(&msg->env->x_comment_to, buf);
+          mutt_window_move(MuttIndexWindow, HDR_BCC, HDR_XOFFSET);
           if (msg->env->x_comment_to)
-            mutt_str_strfcpy(buf, msg->env->x_comment_to, sizeof(buf));
+            mutt_paddstr(W, msg->env->x_comment_to);
           else
-            buf[0] = 0;
-          if (mutt_get_field("X-Comment-To: ", buf, sizeof(buf), 0) == 0)
-          {
-            mutt_str_replace(&msg->env->x_comment_to, buf);
-            mutt_window_move(MuttIndexWindow, HDR_BCC, HDR_XOFFSET);
-            if (msg->env->x_comment_to)
-              mutt_paddstr(W, msg->env->x_comment_to);
-            else
-              clrtoeol();
-          }
+            clrtoeol();
         }
         break;
 #endif
@@ -1237,9 +1234,9 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
         struct AttachPtr *gptr = mutt_mem_calloc(1, sizeof(struct AttachPtr));
         gptr->content = group;
         update_idx(menu, actx, gptr);
-      }
         menu->redraw = REDRAW_INDEX;
         break;
+      }
 
       case OP_COMPOSE_GROUP_LINGUAL:
       {
@@ -1335,9 +1332,9 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
         struct AttachPtr *gptr = mutt_mem_calloc(1, sizeof(struct AttachPtr));
         gptr->content = group;
         update_idx(menu, actx, gptr);
-      }
         menu->redraw = REDRAW_INDEX;
         break;
+      }
 
       case OP_COMPOSE_ATTACH_FILE:
       {
@@ -1381,9 +1378,9 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
           mutt_clear_error();
 
         menu->redraw |= REDRAW_INDEX | REDRAW_STATUS;
-      }
         mutt_message_hook(NULL, msg, MUTT_SEND2_HOOK);
         break;
+      }
 
       case OP_COMPOSE_ATTACH_MESSAGE:
 #ifdef USE_NNTP
@@ -1813,9 +1810,9 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
           mutt_update_encoding(CURATTACH->content);
           menu->redraw = REDRAW_FULL;
         }
-      }
         mutt_message_hook(NULL, msg, MUTT_SEND2_HOOK);
         break;
+      }
 
       case OP_COMPOSE_EDIT_MIME:
         CHECK_COUNT;

--- a/compose.c
+++ b/compose.c
@@ -887,8 +887,7 @@ static void compose_status_line(char *buf, size_t buflen, size_t col, int cols,
 int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email *cur, int flags)
 {
   char helpstr[LONG_STRING]; // This isn't copied by the help bar
-  char buf[LONG_STRING];
-  char fname[PATH_MAX];
+  char buf[PATH_MAX];
   int op_close = OP_NULL;
   int rc = -1;
   bool loop = true;
@@ -1341,11 +1340,11 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
         char *prompt = _("Attach file");
         int numfiles = 0;
         char **files = NULL;
-        fname[0] = 0;
+        buf[0] = 0;
 
-        if (mutt_enter_fname_full(prompt, fname, sizeof(fname), false, true,
+        if (mutt_enter_fname_full(prompt, buf, sizeof(buf), false, true,
                                   &files, &numfiles, MUTT_SEL_MULTI) == -1 ||
-            *fname == '\0')
+            *buf == '\0')
         {
           break;
         }
@@ -1388,7 +1387,7 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
 #endif
       {
         char *prompt = _("Open mailbox to attach message from");
-        fname[0] = 0;
+        buf[0] = 0;
 
 #ifdef USE_NNTP
         OptNews = false;
@@ -1408,42 +1407,42 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
           if ((op == OP_COMPOSE_ATTACH_MESSAGE) ^ (Context->mailbox->magic == MUTT_NNTP))
 #endif
           {
-            mutt_str_strfcpy(fname, Context->mailbox->path, sizeof(fname));
-            mutt_pretty_mailbox(fname, sizeof(fname));
+            mutt_str_strfcpy(buf, Context->mailbox->path, sizeof(buf));
+            mutt_pretty_mailbox(buf, sizeof(buf));
           }
 
-        if (mutt_enter_fname(prompt, fname, sizeof(fname), 1) == -1 || !fname[0])
+        if (mutt_enter_fname(prompt, buf, sizeof(buf), 1) == -1 || !buf[0])
           break;
 
 #ifdef USE_NNTP
         if (OptNews)
-          nntp_expand_path(fname, sizeof(fname), &CurrentNewsSrv->conn->account);
+          nntp_expand_path(buf, sizeof(buf), &CurrentNewsSrv->conn->account);
         else
 #endif
-          mutt_expand_path(fname, sizeof(fname));
+          mutt_expand_path(buf, sizeof(buf));
 #ifdef USE_IMAP
-        if (imap_path_probe(fname, NULL) != MUTT_IMAP)
+        if (imap_path_probe(buf, NULL) != MUTT_IMAP)
 #endif
 #ifdef USE_POP
-          if (pop_path_probe(fname, NULL) != MUTT_POP)
+          if (pop_path_probe(buf, NULL) != MUTT_POP)
 #endif
 #ifdef USE_NNTP
-            if (!OptNews && (nntp_path_probe(fname, NULL) != MUTT_NNTP))
+            if (!OptNews && (nntp_path_probe(buf, NULL) != MUTT_NNTP))
 #endif
               /* check to make sure the file exists and is readable */
-              if (access(fname, R_OK) == -1)
+              if (access(buf, R_OK) == -1)
               {
-                mutt_perror(fname);
+                mutt_perror(buf);
                 break;
               }
 
         menu->redraw = REDRAW_FULL;
 
-        struct Mailbox *m = mx_path_resolve(fname);
+        struct Mailbox *m = mx_path_resolve(buf);
         struct Context *ctx = mx_mbox_open(m, MUTT_READONLY);
         if (!ctx)
         {
-          mutt_error(_("Unable to open mailbox %s"), fname);
+          mutt_error(_("Unable to open mailbox %s"), buf);
           mailbox_free(&m);
           break;
         }
@@ -1704,14 +1703,14 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
           src = CURATTACH->content->d_filename;
         else
           src = CURATTACH->content->filename;
-        mutt_str_strfcpy(fname, mutt_path_basename(NONULL(src)), sizeof(fname));
-        ret = mutt_get_field(_("Send attachment with name: "), fname, sizeof(fname), MUTT_FILE);
+        mutt_str_strfcpy(buf, mutt_path_basename(NONULL(src)), sizeof(buf));
+        ret = mutt_get_field(_("Send attachment with name: "), buf, sizeof(buf), MUTT_FILE);
         if (ret == 0)
         {
-          /* As opposed to RENAME_FILE, we don't check fname[0] because it's
+          /* As opposed to RENAME_FILE, we don't check buf[0] because it's
            * valid to set an empty string here, to erase what was set
            */
-          mutt_str_replace(&CURATTACH->content->d_filename, fname);
+          mutt_str_replace(&CURATTACH->content->d_filename, buf);
           menu->redraw = REDRAW_CURRENT;
         }
       }
@@ -1719,25 +1718,25 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
 
       case OP_COMPOSE_RENAME_FILE:
         CHECK_COUNT;
-        mutt_str_strfcpy(fname, CURATTACH->content->filename, sizeof(fname));
-        mutt_pretty_mailbox(fname, sizeof(fname));
-        if (mutt_get_field(_("Rename to: "), fname, sizeof(fname), MUTT_FILE) == 0 &&
-            fname[0])
+        mutt_str_strfcpy(buf, CURATTACH->content->filename, sizeof(buf));
+        mutt_pretty_mailbox(buf, sizeof(buf));
+        if (mutt_get_field(_("Rename to: "), buf, sizeof(buf), MUTT_FILE) == 0 &&
+            buf[0])
         {
           struct stat st;
           if (stat(CURATTACH->content->filename, &st) == -1)
           {
             /* L10N:
                "stat" is a system call. Do "man 2 stat" for more information. */
-            mutt_error(_("Can't stat %s: %s"), fname, strerror(errno));
+            mutt_error(_("Can't stat %s: %s"), buf, strerror(errno));
             break;
           }
 
-          mutt_expand_path(fname, sizeof(fname));
-          if (mutt_file_rename(CURATTACH->content->filename, fname))
+          mutt_expand_path(buf, sizeof(buf));
+          if (mutt_file_rename(CURATTACH->content->filename, buf))
             break;
 
-          mutt_str_replace(&CURATTACH->content->filename, fname);
+          mutt_str_replace(&CURATTACH->content->filename, buf);
           menu->redraw = REDRAW_CURRENT;
 
           if (CURATTACH->content->stamp >= st.st_mtime)
@@ -1754,13 +1753,13 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
         FILE *fp = NULL;
 
         mutt_window_clearline(MuttMessageWindow, 0);
-        fname[0] = 0;
-        if (mutt_get_field(_("New file: "), fname, sizeof(fname), MUTT_FILE) != 0 ||
-            !fname[0])
+        buf[0] = 0;
+        if (mutt_get_field(_("New file: "), buf, sizeof(buf), MUTT_FILE) != 0 ||
+            !buf[0])
         {
           continue;
         }
-        mutt_expand_path(fname, sizeof(fname));
+        mutt_expand_path(buf, sizeof(buf));
 
         /* Call to lookup_mime_type () ?  maybe later */
         type[0] = 0;
@@ -1782,16 +1781,16 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
         }
         struct AttachPtr *new = mutt_mem_calloc(1, sizeof(struct AttachPtr));
         /* Touch the file */
-        fp = mutt_file_fopen(fname, "w");
+        fp = mutt_file_fopen(buf, "w");
         if (!fp)
         {
-          mutt_error(_("Can't create file %s"), fname);
+          mutt_error(_("Can't create file %s"), buf);
           FREE(&new);
           continue;
         }
         mutt_file_fclose(&fp);
 
-        new->content = mutt_make_file_attach(fname);
+        new->content = mutt_make_file_attach(buf);
         if (!new->content)
         {
           mutt_error(_("What we have here is a failure to make an attachment"));
@@ -1910,24 +1909,24 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
 
       case OP_COMPOSE_WRITE_MESSAGE:
 
-        fname[0] = '\0';
+        buf[0] = '\0';
         if (Context)
         {
-          mutt_str_strfcpy(fname, Context->mailbox->path, sizeof(fname));
-          mutt_pretty_mailbox(fname, sizeof(fname));
+          mutt_str_strfcpy(buf, Context->mailbox->path, sizeof(buf));
+          mutt_pretty_mailbox(buf, sizeof(buf));
         }
         if (actx->idxlen)
           msg->content = actx->idx[0]->content;
-        if (mutt_enter_fname(_("Write message to mailbox"), fname, sizeof(fname), 1) != -1 &&
-            fname[0])
+        if (mutt_enter_fname(_("Write message to mailbox"), buf, sizeof(buf), 1) != -1 &&
+            buf[0])
         {
-          mutt_message(_("Writing message to %s ..."), fname);
-          mutt_expand_path(fname, sizeof(fname));
+          mutt_message(_("Writing message to %s ..."), buf);
+          mutt_expand_path(buf, sizeof(buf));
 
           if (msg->content->next)
             msg->content = mutt_make_multipart(msg->content);
 
-          if (mutt_write_fcc(fname, msg, NULL, false, NULL, NULL) < 0)
+          if (mutt_write_fcc(buf, msg, NULL, false, NULL, NULL) < 0)
             msg->content = mutt_remove_multipart(msg->content);
           else
             mutt_message(_("Message written"));

--- a/compose.c
+++ b/compose.c
@@ -1679,8 +1679,7 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
         CHECK_COUNT;
         if (menu->tagprefix)
         {
-          struct Body *top = NULL;
-          for (top = msg->content; top; top = top->next)
+          for (struct Body *top = msg->content; top; top = top->next)
           {
             if (top->tagged)
               mutt_get_tmp_attachment(top);
@@ -1695,16 +1694,14 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
 
       case OP_COMPOSE_RENAME_ATTACHMENT:
       {
-        char *src = NULL;
-        int ret;
-
         CHECK_COUNT;
+        char *src = NULL;
         if (CURATTACH->content->d_filename)
           src = CURATTACH->content->d_filename;
         else
           src = CURATTACH->content->filename;
         mutt_str_strfcpy(buf, mutt_path_basename(NONULL(src)), sizeof(buf));
-        ret = mutt_get_field(_("Send attachment with name: "), buf, sizeof(buf), MUTT_FILE);
+        int ret = mutt_get_field(_("Send attachment with name: "), buf, sizeof(buf), MUTT_FILE);
         if (ret == 0)
         {
           /* As opposed to RENAME_FILE, we don't check buf[0] because it's
@@ -1747,11 +1744,6 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
 
       case OP_COMPOSE_NEW_MIME:
       {
-        char type[STRING];
-        char *p = NULL;
-        int itype;
-        FILE *fp = NULL;
-
         mutt_window_clearline(MuttMessageWindow, 0);
         buf[0] = '\0';
         if (mutt_get_field(_("New file: "), buf, sizeof(buf), MUTT_FILE) != 0 ||
@@ -1762,18 +1754,18 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
         mutt_expand_path(buf, sizeof(buf));
 
         /* Call to lookup_mime_type () ?  maybe later */
-        type[0] = 0;
+        char type[STRING] = { 0 };
         if (mutt_get_field("Content-Type: ", type, sizeof(type), 0) != 0 || !type[0])
           continue;
 
-        p = strchr(type, '/');
+        char *p = strchr(type, '/');
         if (!p)
         {
           mutt_error(_("Content-Type is of the form base/sub"));
           continue;
         }
         *p++ = 0;
-        itype = mutt_check_mime_type(type);
+        int itype = mutt_check_mime_type(type);
         if (itype == TYPE_OTHER)
         {
           mutt_error(_("Unknown Content-Type %s"), type);
@@ -1781,7 +1773,7 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
         }
         struct AttachPtr *new = mutt_mem_calloc(1, sizeof(struct AttachPtr));
         /* Touch the file */
-        fp = mutt_file_fopen(buf, "w");
+        FILE *fp = mutt_file_fopen(buf, "w");
         if (!fp)
         {
           mutt_error(_("Can't create file %s"), buf);

--- a/compose.c
+++ b/compose.c
@@ -441,7 +441,7 @@ static void draw_envelope_addr(int line, struct Address *addr)
 {
   char buf[LONG_STRING];
 
-  buf[0] = 0;
+  buf[0] = '\0';
   mutt_addr_write(buf, sizeof(buf), addr, true);
   SETCOLOR(MT_COLOR_COMPOSE_HEADER);
   mutt_window_mvprintw(MuttIndexWindow, line, 0, "%*s", HeaderPadding[line],
@@ -539,7 +539,7 @@ static void edit_address_list(int line, struct Address **addr)
   }
 
   /* redraw the expanded list so the user can see the result */
-  buf[0] = 0;
+  buf[0] = '\0';
   mutt_addr_write(buf, sizeof(buf), *addr, true);
   mutt_window_move(MuttIndexWindow, line, HDR_XOFFSET);
   mutt_paddstr(W, buf);
@@ -817,7 +817,7 @@ static const char *compose_format_str(char *buf, size_t buflen, size_t col, int 
   int optional = (flags & MUTT_FORMAT_OPTIONAL);
   struct Menu *menu = (struct Menu *) data;
 
-  *buf = 0;
+  *buf = '\0';
   switch (op)
   {
     case 'a': /* total number of attachments */
@@ -841,7 +841,7 @@ static const char *compose_format_str(char *buf, size_t buflen, size_t col, int 
       break;
 
     case 0:
-      *buf = 0;
+      *buf = '\0';
       return src;
 
     default:
@@ -978,7 +978,7 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
         if (msg->env->newsgroups)
           mutt_str_strfcpy(buf, msg->env->newsgroups, sizeof(buf));
         else
-          buf[0] = 0;
+          buf[0] = '\0';
         if (mutt_get_field("Newsgroups: ", buf, sizeof(buf), 0) == 0)
         {
           mutt_str_replace(&msg->env->newsgroups, buf);
@@ -995,7 +995,7 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
         if (msg->env->followup_to)
           mutt_str_strfcpy(buf, msg->env->followup_to, sizeof(buf));
         else
-          buf[0] = 0;
+          buf[0] = '\0';
         if (mutt_get_field("Followup-To: ", buf, sizeof(buf), 0) == 0)
         {
           mutt_str_replace(&msg->env->followup_to, buf);
@@ -1012,7 +1012,7 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
         if (msg->env->x_comment_to)
           mutt_str_strfcpy(buf, msg->env->x_comment_to, sizeof(buf));
         else
-          buf[0] = 0;
+          buf[0] = '\0';
         if (mutt_get_field("X-Comment-To: ", buf, sizeof(buf), 0) == 0)
         {
           mutt_str_replace(&msg->env->x_comment_to, buf);
@@ -1028,7 +1028,7 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
         if (msg->env->subject)
           mutt_str_strfcpy(buf, msg->env->subject, sizeof(buf));
         else
-          buf[0] = 0;
+          buf[0] = '\0';
         if (mutt_get_field(_("Subject: "), buf, sizeof(buf), 0) == 0)
         {
           mutt_str_replace(&msg->env->subject, buf);
@@ -1340,7 +1340,7 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
         char *prompt = _("Attach file");
         int numfiles = 0;
         char **files = NULL;
-        buf[0] = 0;
+        buf[0] = '\0';
 
         if (mutt_enter_fname_full(prompt, buf, sizeof(buf), false, true,
                                   &files, &numfiles, MUTT_SEL_MULTI) == -1 ||
@@ -1387,7 +1387,7 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
 #endif
       {
         char *prompt = _("Open mailbox to attach message from");
-        buf[0] = 0;
+        buf[0] = '\0';
 
 #ifdef USE_NNTP
         OptNews = false;
@@ -1411,7 +1411,7 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
             mutt_pretty_mailbox(buf, sizeof(buf));
           }
 
-        if (mutt_enter_fname(prompt, buf, sizeof(buf), 1) == -1 || !buf[0])
+        if (mutt_enter_fname(prompt, buf, sizeof(buf), 1) == -1 || (buf[0] == '\0'))
           break;
 
 #ifdef USE_NNTP
@@ -1597,7 +1597,7 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
 
       case OP_COMPOSE_EDIT_LANGUAGE:
         CHECK_COUNT;
-        buf[0] = 0; /* clear buffer first */
+        buf[0] = '\0'; /* clear buffer first */
         if (CURATTACH->content->language)
           mutt_str_strfcpy(buf, CURATTACH->content->language, sizeof(buf));
         if (mutt_get_field("Content-Language: ", buf, sizeof(buf), 0) == 0)
@@ -1614,7 +1614,7 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
       case OP_COMPOSE_EDIT_ENCODING:
         CHECK_COUNT;
         mutt_str_strfcpy(buf, ENCODING(CURATTACH->content->encoding), sizeof(buf));
-        if (mutt_get_field("Content-Transfer-Encoding: ", buf, sizeof(buf), 0) == 0 && buf[0])
+        if (mutt_get_field("Content-Transfer-Encoding: ", buf, sizeof(buf), 0) == 0 && (buf[0] != '\0'))
         {
           int enc = mutt_check_encoding(buf);
           if ((enc != ENC_OTHER) && (enc != ENC_UUENCODED))
@@ -1652,7 +1652,7 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
           if (ans == MUTT_ABORT)
             break;
           else if (ans == MUTT_NO)
-            *fcc = 0;
+            *fcc = '\0';
         }
 
         loop = false;
@@ -1721,7 +1721,7 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
         mutt_str_strfcpy(buf, CURATTACH->content->filename, sizeof(buf));
         mutt_pretty_mailbox(buf, sizeof(buf));
         if (mutt_get_field(_("Rename to: "), buf, sizeof(buf), MUTT_FILE) == 0 &&
-            buf[0])
+            (buf[0] != '\0'))
         {
           struct stat st;
           if (stat(CURATTACH->content->filename, &st) == -1)
@@ -1753,9 +1753,9 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
         FILE *fp = NULL;
 
         mutt_window_clearline(MuttMessageWindow, 0);
-        buf[0] = 0;
+        buf[0] = '\0';
         if (mutt_get_field(_("New file: "), buf, sizeof(buf), MUTT_FILE) != 0 ||
-            !buf[0])
+            (buf[0] == '\0'))
         {
           continue;
         }
@@ -1918,7 +1918,7 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
         if (actx->idxlen)
           msg->content = actx->idx[0]->content;
         if (mutt_enter_fname(_("Write message to mailbox"), buf, sizeof(buf), 1) != -1 &&
-            buf[0])
+            (buf[0] != '\0'))
         {
           mutt_message(_("Writing message to %s ..."), buf);
           mutt_expand_path(buf, sizeof(buf));

--- a/compose.c
+++ b/compose.c
@@ -229,11 +229,11 @@ static void calc_header_width_padding(int idx, const char *header, bool calc_max
  */
 static void init_header_padding(void)
 {
-  static short done = 0;
+  static bool done = false;
 
   if (done)
     return;
-  done = 1;
+  done = true;
 
   for (int i = 0; i <= HDR_XCOMMENTTO; i++)
     calc_header_width_padding(i, _(Prompts[i]), true);
@@ -891,14 +891,11 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
   char fname[PATH_MAX];
   int op_close = OP_NULL;
   int rc = -1;
-  int loop = 1;
-  int fcc_set = 0; /* has the user edited the Fcc: field ? */
+  bool loop = true;
+  bool fcc_set = false; /* has the user edited the Fcc: field ? */
   struct ComposeRedrawData rd;
 #ifdef USE_NNTP
-  int news = 0; /* is it a news article ? */
-
-  if (OptNewsSend)
-    news++;
+  bool news = OptNewsSend; /* is it a news article ? */
 #endif
 
   init_header_padding();
@@ -1059,7 +1056,7 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
           mutt_pretty_mailbox(fcc, fcclen);
           mutt_window_move(MuttIndexWindow, HDR_FCC, HDR_XOFFSET);
           mutt_paddstr(W, fcc);
-          fcc_set = 1;
+          fcc_set = true;
         }
         mutt_message_hook(NULL, msg, MUTT_SEND2_HOOK);
         break;
@@ -1356,7 +1353,7 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
           break;
         }
 
-        int error = 0;
+        bool error = false;
         if (numfiles > 1)
         {
           mutt_message(ngettext("Attaching selected file...",
@@ -1372,7 +1369,7 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
             update_idx(menu, actx, new);
           else
           {
-            error = 1;
+            error = true;
             mutt_error(_("Unable to attach %s"), att);
             FREE(&new);
           }
@@ -1520,7 +1517,7 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
       case OP_DELETE:
         CHECK_COUNT;
         if (CURATTACH->unowned)
-          CURATTACH->content->unlink = 0;
+          CURATTACH->content->unlink = false;
         if (delete_attachment(actx, menu->current) == -1)
           break;
         mutt_update_compose_menu(actx, menu, false);
@@ -1662,7 +1659,7 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
             *fcc = 0;
         }
 
-        loop = 0;
+        loop = false;
         rc = 0;
         break;
 
@@ -1882,7 +1879,7 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
             }
           }
           rc = -1;
-          loop = 0;
+          loop = false;
           break;
         }
         else if (ans == MUTT_ABORT)
@@ -1898,7 +1895,7 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
           break;
         }
 
-        loop = 0;
+        loop = false;
         rc = 1;
         break;
 


### PR DESCRIPTION
Like the Index and Pager changes, this PR is a step towards splitting up a gigantic `switch` statement.

- 460e9e168 reduce scope of variables
- 8d3a080ff boolify variables
- 02bc2f13b fix scoping
- 7aac12a41 merge non-overlapping buffer use
- 62f4412af use NUL rather than zero
- be0b361f2 var scope
- 9fc86fcde tidy mutt_compose_menu()

There are no functional changes.