### PR TITLE
Use symbolic log levels

### DIFF
--- a/alias.c
+++ b/alias.c
@@ -77,7 +77,7 @@ static struct Address *expand_aliases_r(struct Address *a, struct ListHead *expn
         {
           if (mutt_str_strcmp(a->mailbox, np->data) == 0) /* alias already found */
           {
-            mutt_debug(1, "loop in alias found for '%s'\n", a->mailbox);
+            mutt_debug(LL_DEBUG1, "loop in alias found for '%s'\n", a->mailbox);
             i = true;
             break;
           }

--- a/bcache.c
+++ b/bcache.c
@@ -79,7 +79,7 @@ static int bcache_path(struct ConnAccount *account, const char *mailbox, char *d
   url.path = NULL;
   if (url_tostring(&url, host, sizeof(host), U_PATH) < 0)
   {
-    mutt_debug(1, "URL to string failed\n");
+    mutt_debug(LL_DEBUG1, "URL to string failed\n");
     return -1;
   }
 
@@ -89,12 +89,12 @@ static int bcache_path(struct ConnAccount *account, const char *mailbox, char *d
 
   mutt_encode_path(dst, dstlen, dst);
 
-  mutt_debug(3, "rc: %d, path: '%s'\n", len, dst);
+  mutt_debug(LL_DEBUG3, "rc: %d, path: '%s'\n", len, dst);
 
   if (len < 0 || (size_t) len >= dstlen - 1)
     return -1;
 
-  mutt_debug(3, "directory: '%s'\n", dst);
+  mutt_debug(LL_DEBUG3, "directory: '%s'\n", dst);
 
   return 0;
 }
@@ -116,7 +116,7 @@ static int mutt_bcache_move(struct BodyCache *bcache, const char *id, const char
   snprintf(path, sizeof(path), "%s%s", bcache->path, id);
   snprintf(newpath, sizeof(newpath), "%s%s", bcache->path, newid);
 
-  mutt_debug(3, "bcache: mv: '%s' '%s'\n", path, newpath);
+  mutt_debug(LL_DEBUG3, "bcache: mv: '%s' '%s'\n", path, newpath);
 
   return rename(path, newpath);
 }
@@ -181,7 +181,7 @@ FILE *mutt_bcache_get(struct BodyCache *bcache, const char *id)
 
   fp = mutt_file_fopen(path, "r");
 
-  mutt_debug(3, "bcache: get: '%s': %s\n", path, fp ? "yes" : "no");
+  mutt_debug(LL_DEBUG3, "bcache: get: '%s': %s\n", path, fp ? "yes" : "no");
 
   return fp;
 }
@@ -227,7 +227,7 @@ FILE *mutt_bcache_put(struct BodyCache *bcache, const char *id)
     }
   }
 
-  mutt_debug(3, "bcache: put: '%s'\n", path);
+  mutt_debug(LL_DEBUG3, "bcache: put: '%s'\n", path);
 
   return mutt_file_fopen(path, "w+");
 }
@@ -266,7 +266,7 @@ int mutt_bcache_del(struct BodyCache *bcache, const char *id)
   mutt_str_strncat(path, sizeof(path), bcache->path, bcache->pathlen);
   mutt_str_strncat(path, sizeof(path), id, mutt_str_strlen(id));
 
-  mutt_debug(3, "bcache: del: '%s'\n", path);
+  mutt_debug(LL_DEBUG3, "bcache: del: '%s'\n", path);
 
   return unlink(path);
 }
@@ -296,7 +296,7 @@ int mutt_bcache_exists(struct BodyCache *bcache, const char *id)
   else
     rc = S_ISREG(st.st_mode) && st.st_size != 0 ? 0 : -1;
 
-  mutt_debug(3, "bcache: exists: '%s': %s\n", path, rc == 0 ? "yes" : "no");
+  mutt_debug(LL_DEBUG3, "bcache: exists: '%s': %s\n", path, rc == 0 ? "yes" : "no");
 
   return rc;
 }
@@ -331,7 +331,7 @@ int mutt_bcache_list(struct BodyCache *bcache, bcache_list_t *want_id, void *dat
 
   rc = 0;
 
-  mutt_debug(3, "bcache: list: dir: '%s'\n", bcache->path);
+  mutt_debug(LL_DEBUG3, "bcache: list: dir: '%s'\n", bcache->path);
 
   while ((de = readdir(d)))
   {
@@ -341,7 +341,7 @@ int mutt_bcache_list(struct BodyCache *bcache, bcache_list_t *want_id, void *dat
       continue;
     }
 
-    mutt_debug(3, "bcache: list: dir: '%s', id :'%s'\n", bcache->path, de->d_name);
+    mutt_debug(LL_DEBUG3, "bcache: list: dir: '%s', id :'%s'\n", bcache->path, de->d_name);
 
     if (want_id && want_id(de->d_name, bcache, data) != 0)
       goto out;
@@ -355,6 +355,6 @@ out:
     if (closedir(d) < 0)
       rc = -1;
   }
-  mutt_debug(3, "bcache: list: did %d entries\n", rc);
+  mutt_debug(LL_DEBUG3, "bcache: list: did %d entries\n", rc);
   return rc;
 }

--- a/browser.c
+++ b/browser.c
@@ -1827,7 +1827,7 @@ void mutt_select_file(char *file, size_t filelen, int flags, char ***files, int 
           /* When in mailboxes mode, disables this feature */
           if (Folder)
           {
-            mutt_debug(3, "= hit! Folder: %s, LastDir: %s\n", Folder, LastDir);
+            mutt_debug(LL_DEBUG3, "= hit! Folder: %s, LastDir: %s\n", Folder, LastDir);
             if (GotoSwapper[0] == '\0')
             {
               if (mutt_str_strcmp(LastDir, Folder) != 0)

--- a/browser.c
+++ b/browser.c
@@ -1827,7 +1827,7 @@ void mutt_select_file(char *file, size_t filelen, int flags, char ***files, int 
           /* When in mailboxes mode, disables this feature */
           if (Folder)
           {
-            mutt_debug(5, "= hit! Folder: %s, LastDir: %s\n", Folder, LastDir);
+            mutt_debug(3, "= hit! Folder: %s, LastDir: %s\n", Folder, LastDir);
             if (GotoSwapper[0] == '\0')
             {
               if (mutt_str_strcmp(LastDir, Folder) != 0)

--- a/color.c
+++ b/color.c
@@ -335,7 +335,7 @@ int mutt_alloc_color(int fg, int bg)
 
     init_pair(i, fg, bg);
 
-  mutt_debug(3, "Color pairs used so far: %d\n", UserColors);
+  mutt_debug(LL_DEBUG3, "Color pairs used so far: %d\n", UserColors);
 
   return COLOR_PAIR(p->index);
 }
@@ -407,7 +407,7 @@ void mutt_free_color(int fg, int bg)
         return;
 
       UserColors--;
-      mutt_debug(1, "Color pairs used so far: %d\n", UserColors);
+      mutt_debug(LL_DEBUG1, "Color pairs used so far: %d\n", UserColors);
 
       if (p == ColorList)
       {
@@ -570,7 +570,7 @@ static void do_uncolor(struct Buffer *buf, struct Buffer *s,
           {
             *do_cache = true;
           }
-          mutt_debug(1, "Freeing pattern \"%s\" from ColorList\n", buf->data);
+          mutt_debug(LL_DEBUG1, "Freeing pattern \"%s\" from ColorList\n", buf->data);
           if (tmp)
             STAILQ_REMOVE_AFTER(cl, tmp, entries);
           else

--- a/commands.c
+++ b/commands.c
@@ -799,7 +799,7 @@ void mutt_shell_escape(void)
   fflush(stdout);
   int rc = mutt_system(buf);
   if (rc == -1)
-    mutt_debug(1, "Error running \"%s\"!", buf);
+    mutt_debug(LL_DEBUG1, "Error running \"%s\"!", buf);
 
   if ((rc != 0) || WaitKey)
     mutt_any_key_to_continue(NULL);

--- a/complete.c
+++ b/complete.c
@@ -67,7 +67,7 @@ int mutt_complete(char *buf, size_t buflen)
   char imap_path[PATH_MAX];
 #endif
 
-  mutt_debug(2, "completing %s\n", buf);
+  mutt_debug(LL_DEBUG2, "completing %s\n", buf);
 
 #ifdef USE_NNTP
   if (OptNews)
@@ -150,7 +150,7 @@ int mutt_complete(char *buf, size_t buflen)
 
   if (!dirp)
   {
-    mutt_debug(1, "%s: %s (errno %d).\n", exp_dirpart, strerror(errno), errno);
+    mutt_debug(LL_DEBUG1, "%s: %s (errno %d).\n", exp_dirpart, strerror(errno), errno);
     return -1;
   }
 

--- a/config/bool.c
+++ b/config/bool.c
@@ -114,7 +114,7 @@ static int bool_string_get(const struct ConfigSet *cs, void *var,
 
   if (index > 1)
   {
-    mutt_debug(1, "Variable has an invalid value: %d\n", index);
+    mutt_debug(LL_DEBUG1, "Variable has an invalid value: %d\n", index);
     return CSR_ERR_INVALID | CSR_INV_TYPE;
   }
 

--- a/config/cfgaccount.c
+++ b/config/cfgaccount.c
@@ -72,7 +72,7 @@ struct CfgAccount *ac_new(const struct ConfigSet *cs, const char *name,
     struct HashElem *parent = cs_get_elem(cs, ac->var_names[i]);
     if (!parent)
     {
-      mutt_debug(1, "%s doesn't exist\n", ac->var_names[i]);
+      mutt_debug(LL_DEBUG1, "%s doesn't exist\n", ac->var_names[i]);
       success = false;
       break;
     }
@@ -81,7 +81,7 @@ struct CfgAccount *ac_new(const struct ConfigSet *cs, const char *name,
     ac->vars[i] = cs_inherit_variable(cs, parent, acname);
     if (!ac->vars[i])
     {
-      mutt_debug(1, "failed to create %s\n", acname);
+      mutt_debug(LL_DEBUG1, "failed to create %s\n", acname);
       success = false;
       break;
     }
@@ -116,7 +116,7 @@ void ac_free(const struct ConfigSet *cs, struct CfgAccount **ac)
     mutt_buffer_reset(&err);
     int result = cs_str_reset(cs, child, &err);
     if (CSR_RESULT(result) != CSR_SUCCESS)
-      mutt_debug(1, "reset failed for %s: %s\n", child, err.data);
+      mutt_debug(LL_DEBUG1, "reset failed for %s: %s\n", child, err.data);
     mutt_hash_delete(cs->hash, child, NULL);
   }
 

--- a/config/dump.c
+++ b/config/dump.c
@@ -134,7 +134,7 @@ struct HashElem **get_elem_list(struct ConfigSet *cs)
     list[index++] = he;
     if (index == 1022)
     {
-      mutt_debug(1, "Too many config items to sort\n");
+      mutt_debug(LL_DEBUG1, "Too many config items to sort\n");
       break;
     }
   }

--- a/config/magic.c
+++ b/config/magic.c
@@ -118,7 +118,7 @@ static int magic_string_get(const struct ConfigSet *cs, void *var,
 
   if ((value < 1) || (value >= (mutt_array_size(MagicValues) - 1)))
   {
-    mutt_debug(1, "Variable has an invalid value: %d\n", value);
+    mutt_debug(LL_DEBUG1, "Variable has an invalid value: %d\n", value);
     return CSR_ERR_INVALID | CSR_INV_TYPE;
   }
 

--- a/config/mbtable.c
+++ b/config/mbtable.c
@@ -70,7 +70,7 @@ struct MbTable *mbtable_parse(const char *s)
     if (k == (size_t)(-1) || k == (size_t)(-2))
     {
       /* XXX put message in err buffer; fail? warning? */
-      mutt_debug(1, "mbtable_parse: mbrtowc returned %d converting %s in %s\n",
+      mutt_debug(LL_DEBUG1, "mbtable_parse: mbrtowc returned %d converting %s in %s\n",
                  (k == (size_t)(-1)) ? -1 : -2, s, t->orig_str);
       if (k == (size_t)(-1))
         memset(&mbstate, 0, sizeof(mbstate));

--- a/config/quad.c
+++ b/config/quad.c
@@ -113,7 +113,7 @@ static int quad_string_get(const struct ConfigSet *cs, void *var,
 
   if (value >= (mutt_array_size(QuadValues) - 1))
   {
-    mutt_debug(1, "Variable has an invalid value: %d\n", value);
+    mutt_debug(LL_DEBUG1, "Variable has an invalid value: %d\n", value);
     return CSR_ERR_INVALID | CSR_INV_TYPE;
   }
 

--- a/config/set.c
+++ b/config/set.c
@@ -278,7 +278,7 @@ bool cs_register_variables(const struct ConfigSet *cs, struct ConfigDef vars[], 
   {
     if (!reg_one_var(cs, &vars[i], &err))
     {
-      mutt_debug(1, "%s\n", err.data);
+      mutt_debug(LL_DEBUG1, "%s\n", err.data);
       rc = false;
     }
   }
@@ -334,7 +334,7 @@ void cs_add_listener(struct ConfigSet *cs, cs_listener fn)
   {
     if (cs->listeners[i] == fn)
     {
-      mutt_debug(1, "Listener was already registered\n");
+      mutt_debug(LL_DEBUG1, "Listener was already registered\n");
       return;
     }
   }
@@ -367,7 +367,7 @@ void cs_remove_listener(struct ConfigSet *cs, cs_listener fn)
       return;
     }
   }
-  mutt_debug(1, "Listener wasn't registered\n");
+  mutt_debug(LL_DEBUG1, "Listener wasn't registered\n");
 }
 
 /**
@@ -482,7 +482,7 @@ int cs_he_initial_set(const struct ConfigSet *cs, struct HashElem *he,
   {
     struct Inheritance *i = he->data;
     cdef = i->parent->data;
-    mutt_debug(1, "Variable '%s' is inherited type.\n", cdef->name);
+    mutt_debug(LL_DEBUG1, "Variable '%s' is inherited type.\n", cdef->name);
     return CSR_ERR_CODE;
   }
 
@@ -490,7 +490,7 @@ int cs_he_initial_set(const struct ConfigSet *cs, struct HashElem *he,
   cst = cs_get_type_def(cs, he->type);
   if (!cst)
   {
-    mutt_debug(1, "Variable '%s' has an invalid type %d\n", cdef->name, he->type);
+    mutt_debug(LL_DEBUG1, "Variable '%s' has an invalid type %d\n", cdef->name, he->type);
     return CSR_ERR_CODE;
   }
 
@@ -559,7 +559,8 @@ int cs_he_initial_get(const struct ConfigSet *cs, struct HashElem *he, struct Bu
 
   if (!cst)
   {
-    mutt_debug(1, "Variable '%s' has an invalid type %d\n", cdef->name, DTYPE(he->type));
+    mutt_debug(LL_DEBUG1, "Variable '%s' has an invalid type %d\n", cdef->name,
+               DTYPE(he->type));
     return CSR_ERR_CODE;
   }
 
@@ -625,7 +626,7 @@ int cs_he_string_set(const struct ConfigSet *cs, struct HashElem *he,
 
   if (!cst)
   {
-    mutt_debug(1, "Variable '%s' has an invalid type %d\n", cdef->name, he->type);
+    mutt_debug(LL_DEBUG1, "Variable '%s' has an invalid type %d\n", cdef->name, he->type);
     return CSR_ERR_CODE;
   }
 
@@ -710,7 +711,8 @@ int cs_he_string_get(const struct ConfigSet *cs, struct HashElem *he, struct Buf
 
   if (!cst)
   {
-    mutt_debug(1, "Variable '%s' has an invalid type %d\n", cdef->name, DTYPE(he->type));
+    mutt_debug(LL_DEBUG1, "Variable '%s' has an invalid type %d\n", cdef->name,
+               DTYPE(he->type));
     return CSR_ERR_CODE;
   }
 
@@ -773,7 +775,7 @@ int cs_he_native_set(const struct ConfigSet *cs, struct HashElem *he,
 
   if (!cst)
   {
-    mutt_debug(1, "Variable '%s' has an invalid type %d\n", cdef->name, he->type);
+    mutt_debug(LL_DEBUG1, "Variable '%s' has an invalid type %d\n", cdef->name, he->type);
     return CSR_ERR_CODE;
   }
 
@@ -830,7 +832,7 @@ int cs_str_native_set(const struct ConfigSet *cs, const char *name,
 
   if (!cst)
   {
-    mutt_debug(1, "Variable '%s' has an invalid type %d\n", cdef->name, he->type);
+    mutt_debug(LL_DEBUG1, "Variable '%s' has an invalid type %d\n", cdef->name, he->type);
     return CSR_ERR_CODE;
   }
 

--- a/config/sort.c
+++ b/config/sort.c
@@ -185,7 +185,7 @@ static int sort_string_set(const struct ConfigSet *cs, void *var, struct ConfigD
       id = mutt_map_get_value(value, SortSidebarMethods);
       break;
     default:
-      mutt_debug(1, "Invalid sort type: %u\n", cdef->type & DT_SUBTYPE_MASK);
+      mutt_debug(LL_DEBUG1, "Invalid sort type: %u\n", cdef->type & DT_SUBTYPE_MASK);
       return CSR_ERR_CODE;
       break;
   }
@@ -267,14 +267,14 @@ static int sort_string_get(const struct ConfigSet *cs, void *var,
       str = mutt_map_get_name(sort, SortSidebarMethods);
       break;
     default:
-      mutt_debug(1, "Invalid sort type: %u\n", cdef->type & DT_SUBTYPE_MASK);
+      mutt_debug(LL_DEBUG1, "Invalid sort type: %u\n", cdef->type & DT_SUBTYPE_MASK);
       return CSR_ERR_CODE;
       break;
   }
 
   if (!str)
   {
-    mutt_debug(1, "Variable has an invalid value: %d/%d\n",
+    mutt_debug(LL_DEBUG1, "Variable has an invalid value: %d/%d\n",
                cdef->type & DT_SUBTYPE_MASK, sort);
     return CSR_ERR_INVALID | CSR_INV_TYPE;
   }
@@ -315,7 +315,7 @@ static int sort_native_set(const struct ConfigSet *cs, void *var,
       str = mutt_map_get_name((value & SORT_MASK), SortSidebarMethods);
       break;
     default:
-      mutt_debug(1, "Invalid sort type: %u\n", cdef->type & DT_SUBTYPE_MASK);
+      mutt_debug(LL_DEBUG1, "Invalid sort type: %u\n", cdef->type & DT_SUBTYPE_MASK);
       return CSR_ERR_CODE;
       break;
   }

--- a/conn/conn_raw.c
+++ b/conn/conn_raw.c
@@ -79,7 +79,7 @@ static int socket_connect(int fd, struct sockaddr *sa)
 #endif
   else
   {
-    mutt_debug(1, "Unknown address family!\n");
+    mutt_debug(LL_DEBUG1, "Unknown address family!\n");
     return -1;
   }
 
@@ -99,7 +99,7 @@ static int socket_connect(int fd, struct sockaddr *sa)
   if (connect(fd, sa, sa_size) < 0)
   {
     save_errno = errno;
-    mutt_debug(2, "Connection failed. errno: %d...\n", errno);
+    mutt_debug(LL_DEBUG2, "Connection failed. errno: %d...\n", errno);
     SigInt = 0; /* reset in case we caught SIGINTR while in connect() */
   }
 

--- a/conn/getdomain.c
+++ b/conn/getdomain.c
@@ -77,7 +77,7 @@ int getdnsdomainname(char *buf, size_t buflen)
       h = reqs[0]->ar_result;
     else if (status == EAI_INPROGRESS)
     {
-      mutt_debug(1, "timeout\n");
+      mutt_debug(LL_DEBUG1, "timeout\n");
       /* request is not finish, cancel it to free it safely */
       if (gai_cancel(reqs[0]) == EAI_NOTCANCELED)
       {
@@ -86,15 +86,15 @@ int getdnsdomainname(char *buf, size_t buflen)
       }
     }
     else
-      mutt_debug(1, "fail: (%d) %s\n", status, gai_strerror(status));
+      mutt_debug(LL_DEBUG1, "fail: (%d) %s\n", status, gai_strerror(status));
   }
   FREE(&reqs[0]);
 
 #else /* !HAVE_GETADDRINFO_A */
 
-  mutt_debug(3, "before getaddrinfo\n");
+  mutt_debug(LL_DEBUG3, "before getaddrinfo\n");
   getaddrinfo(node, NULL, &hints, &h);
-  mutt_debug(3, "after getaddrinfo\n");
+  mutt_debug(LL_DEBUG3, "after getaddrinfo\n");
 
 #endif
 
@@ -103,7 +103,7 @@ int getdnsdomainname(char *buf, size_t buflen)
   {
     mutt_str_strfcpy(buf, ++p, buflen);
     rc = 0;
-    mutt_debug(1, "Hostname: %s\n", buf);
+    mutt_debug(LL_DEBUG1, "Hostname: %s\n", buf);
     freeaddrinfo(h);
   }
 

--- a/conn/sasl.c
+++ b/conn/sasl.c
@@ -73,46 +73,49 @@ static sasl_secret_t *secret_ptr = NULL;
 static int getnameinfo_err(int ret)
 {
   int err;
-  mutt_debug(1, "getnameinfo: ");
+  mutt_debug(LL_DEBUG1, "getnameinfo: ");
   switch (ret)
   {
     case EAI_AGAIN:
-      mutt_debug(1, "The name could not be resolved at this time.  Future "
-                    "attempts may succeed.\n");
+      mutt_debug(LL_DEBUG1,
+                 "The name could not be resolved at this time.  Future "
+                 "attempts may succeed.\n");
       err = SASL_TRYAGAIN;
       break;
     case EAI_BADFLAGS:
-      mutt_debug(1, "The flags had an invalid value.\n");
+      mutt_debug(LL_DEBUG1, "The flags had an invalid value.\n");
       err = SASL_BADPARAM;
       break;
     case EAI_FAIL:
-      mutt_debug(1, "A non-recoverable error occurred.\n");
+      mutt_debug(LL_DEBUG1, "A non-recoverable error occurred.\n");
       err = SASL_FAIL;
       break;
     case EAI_FAMILY:
-      mutt_debug(1, "The address family was not recognized or the address "
-                    "length was invalid for the specified family.\n");
+      mutt_debug(LL_DEBUG1,
+                 "The address family was not recognized or the address "
+                 "length was invalid for the specified family.\n");
       err = SASL_BADPROT;
       break;
     case EAI_MEMORY:
-      mutt_debug(1, "There was a memory allocation failure.\n");
+      mutt_debug(LL_DEBUG1, "There was a memory allocation failure.\n");
       err = SASL_NOMEM;
       break;
     case EAI_NONAME:
-      mutt_debug(1, "The name does not resolve for the supplied parameters.  "
-                    "NI_NAMEREQD is set and the host's name cannot be located, "
-                    "or both nodename and servname were null.\n");
+      mutt_debug(LL_DEBUG1,
+                 "The name does not resolve for the supplied parameters.  "
+                 "NI_NAMEREQD is set and the host's name cannot be located, "
+                 "or both nodename and servname were null.\n");
       err = SASL_FAIL; /* no real equivalent */
       break;
     case EAI_SYSTEM:
-      mutt_debug(1,
+      mutt_debug(LL_DEBUG1,
                  "A system error occurred.  The error code can be found in "
                  "errno(%d,%s)).\n",
                  errno, strerror(errno));
       err = SASL_FAIL; /* no real equivalent */
       break;
     default:
-      mutt_debug(1, "Unknown error %d\n", ret);
+      mutt_debug(LL_DEBUG1, "Unknown error %d\n", ret);
       err = SASL_FAIL; /* no real equivalent */
       break;
   }
@@ -186,7 +189,7 @@ static int mutt_sasl_cb_log(void *context, int priority, const char *message)
       mutt_priority = 1;
       break;
     default:
-      mutt_debug(1, "SASL unknown log priority: %s\n", message);
+      mutt_debug(LL_DEBUG1, "SASL unknown log priority: %s\n", message);
       return SASL_OK;
   }
   mutt_debug(mutt_priority, "SASL: %s\n", message);
@@ -222,7 +225,7 @@ static int mutt_sasl_start(void)
 
   if (rc != SASL_OK)
   {
-    mutt_debug(1, "libsasl initialisation failed.\n");
+    mutt_debug(LL_DEBUG1, "libsasl initialisation failed.\n");
     return SASL_FAIL;
   }
 
@@ -253,8 +256,9 @@ static int mutt_sasl_cb_authname(void *context, int id, const char **result, uns
   if (!account)
     return SASL_BADPARAM;
 
-  mutt_debug(2, "getting %s for %s:%u\n", id == SASL_CB_AUTHNAME ? "authname" : "user",
-             account->host, account->port);
+  mutt_debug(LL_DEBUG2, "getting %s for %s:%u\n",
+             id == SASL_CB_AUTHNAME ? "authname" : "user", account->host,
+             account->port);
 
   if (id == SASL_CB_AUTHNAME)
   {
@@ -291,7 +295,7 @@ static int mutt_sasl_cb_pass(sasl_conn_t *conn, void *context, int id, sasl_secr
   if (!account || !psecret)
     return SASL_BADPARAM;
 
-  mutt_debug(2, "getting password for %s@%s:%u\n", account->login,
+  mutt_debug(LL_DEBUG2, "getting password for %s@%s:%u\n", account->login,
              account->host, account->port);
 
   if (mutt_account_getpass(account) < 0)
@@ -428,7 +432,7 @@ static int mutt_sasl_conn_read(struct Connection *conn, char *buf, size_t count)
       rc = sasl_decode(sasldata->saslconn, buf, rc, &sasldata->buf, &sasldata->blen);
       if (rc != SASL_OK)
       {
-        mutt_debug(1, "SASL decode failed: %s\n", sasl_errstring(rc, NULL, NULL));
+        mutt_debug(LL_DEBUG1, "SASL decode failed: %s\n", sasl_errstring(rc, NULL, NULL));
         goto out;
       }
     } while (sasldata->blen == 0);
@@ -473,7 +477,7 @@ static int mutt_sasl_conn_write(struct Connection *conn, const char *buf, size_t
       rc = sasl_encode(sasldata->saslconn, buf, olen, &pbuf, &plen);
       if (rc != SASL_OK)
       {
-        mutt_debug(1, "SASL encoding failed: %s\n", sasl_errstring(rc, NULL, NULL));
+        mutt_debug(LL_DEBUG1, "SASL encoding failed: %s\n", sasl_errstring(rc, NULL, NULL));
         goto fail;
       }
 
@@ -566,10 +570,10 @@ int mutt_sasl_client_new(struct Connection *conn, sasl_conn_t **saslconn)
     if (iptostring((struct sockaddr *) &local, size, iplocalport, IP_PORT_BUFLEN) == SASL_OK)
       plp = iplocalport;
     else
-      mutt_debug(2, "SASL failed to parse local IP address\n");
+      mutt_debug(LL_DEBUG2, "SASL failed to parse local IP address\n");
   }
   else
-    mutt_debug(2, "SASL failed to get local IP address\n");
+    mutt_debug(LL_DEBUG2, "SASL failed to get local IP address\n");
 
   size = sizeof(remote);
   if (!getpeername(conn->fd, (struct sockaddr *) &remote, &size))
@@ -577,12 +581,12 @@ int mutt_sasl_client_new(struct Connection *conn, sasl_conn_t **saslconn)
     if (iptostring((struct sockaddr *) &remote, size, ipremoteport, IP_PORT_BUFLEN) == SASL_OK)
       prp = ipremoteport;
     else
-      mutt_debug(2, "SASL failed to parse remote IP address\n");
+      mutt_debug(LL_DEBUG2, "SASL failed to parse remote IP address\n");
   }
   else
-    mutt_debug(2, "SASL failed to get remote IP address\n");
+    mutt_debug(LL_DEBUG2, "SASL failed to get remote IP address\n");
 
-  mutt_debug(2, "SASL local ip: %s, remote ip:%s\n", NONULL(plp), NONULL(prp));
+  mutt_debug(LL_DEBUG2, "SASL local ip: %s, remote ip:%s\n", NONULL(plp), NONULL(prp));
 
   rc = sasl_client_new(service, conn->account.host, plp, prp,
                        mutt_sasl_get_callbacks(&conn->account), 0, saslconn);
@@ -607,7 +611,7 @@ int mutt_sasl_client_new(struct Connection *conn, sasl_conn_t **saslconn)
   if (conn->ssf)
   {
     /* I'm not sure this actually has an effect, at least with SASLv2 */
-    mutt_debug(2, "External SSF: %d\n", conn->ssf);
+    mutt_debug(LL_DEBUG2, "External SSF: %d\n", conn->ssf);
     if (sasl_setprop(*saslconn, SASL_SSF_EXTERNAL, &(conn->ssf)) != SASL_OK)
     {
       mutt_error(_("Error setting SASL external security strength"));
@@ -617,7 +621,7 @@ int mutt_sasl_client_new(struct Connection *conn, sasl_conn_t **saslconn)
   }
   if (conn->account.user[0])
   {
-    mutt_debug(2, "External authentication name: %s\n", conn->account.user);
+    mutt_debug(LL_DEBUG2, "External authentication name: %s\n", conn->account.user);
     if (sasl_setprop(*saslconn, SASL_AUTH_EXTERNAL, conn->account.user) != SASL_OK)
     {
       mutt_error(_("Error setting SASL external user name"));
@@ -643,7 +647,7 @@ int mutt_sasl_interact(sasl_interact_t *interaction)
 
   while (interaction->id != SASL_CB_LIST_END)
   {
-    mutt_debug(2, "filling in SASL interaction %ld.\n", interaction->id);
+    mutt_debug(LL_DEBUG2, "filling in SASL interaction %ld.\n", interaction->id);
 
     snprintf(prompt, sizeof(prompt), "%s: ", interaction->prompt);
     resp[0] = '\0';
@@ -678,12 +682,12 @@ void mutt_sasl_setup_conn(struct Connection *conn, sasl_conn_t *saslconn)
   /* get ssf so we know whether we have to (en|de)code read/write */
   sasl_getprop(saslconn, SASL_SSF, &tmp);
   sasldata->ssf = tmp;
-  mutt_debug(3, "SASL protection strength: %u\n", *sasldata->ssf);
+  mutt_debug(LL_DEBUG3, "SASL protection strength: %u\n", *sasldata->ssf);
   /* Add SASL SSF to transport SSF */
   conn->ssf += *sasldata->ssf;
   sasl_getprop(saslconn, SASL_MAXOUTBUF, &tmp);
   sasldata->pbufsize = tmp;
-  mutt_debug(3, "SASL protection buffer size: %u\n", *sasldata->pbufsize);
+  mutt_debug(LL_DEBUG3, "SASL protection buffer size: %u\n", *sasldata->pbufsize);
 
   /* clear input buffer */
   sasldata->buf = NULL;

--- a/conn/socket.c
+++ b/conn/socket.c
@@ -63,9 +63,9 @@ static int socket_preconnect(void)
   if (!Preconnect)
     return 0;
 
-  mutt_debug(2, "Executing preconnect: %s\n", Preconnect);
+  mutt_debug(LL_DEBUG2, "Executing preconnect: %s\n", Preconnect);
   const int rc = mutt_system(Preconnect);
-  mutt_debug(2, "Preconnect result: %d\n", rc);
+  mutt_debug(LL_DEBUG2, "Preconnect result: %d\n", rc);
   if (rc != 0)
   {
     const int save_errno = errno;
@@ -92,7 +92,7 @@ int mutt_socket_open(struct Connection *conn)
 
   rc = conn->conn_open(conn);
 
-  mutt_debug(2, "Connected to %s:%d on fd=%d\n", conn->account.host,
+  mutt_debug(LL_DEBUG2, "Connected to %s:%d on fd=%d\n", conn->account.host,
              conn->account.port, conn->fd);
 
   return rc;
@@ -112,7 +112,7 @@ int mutt_socket_close(struct Connection *conn)
   int rc = -1;
 
   if (conn->fd < 0)
-    mutt_debug(1, "Attempt to close closed connection.\n");
+    mutt_debug(LL_DEBUG1, "Attempt to close closed connection.\n");
   else
     rc = conn->conn_close(conn);
 
@@ -165,7 +165,7 @@ int mutt_socket_write_d(struct Connection *conn, const char *buf, int len, int d
 
   if (conn->fd < 0)
   {
-    mutt_debug(1, "attempt to write to closed connection\n");
+    mutt_debug(LL_DEBUG1, "attempt to write to closed connection\n");
     return -1;
   }
 
@@ -174,14 +174,14 @@ int mutt_socket_write_d(struct Connection *conn, const char *buf, int len, int d
     const int rc = conn->conn_write(conn, buf + sent, len - sent);
     if (rc < 0)
     {
-      mutt_debug(1, "error writing (%s), closing socket\n", strerror(errno));
+      mutt_debug(LL_DEBUG1, "error writing (%s), closing socket\n", strerror(errno));
       mutt_socket_close(conn);
 
       return -1;
     }
 
     if (rc < len - sent)
-      mutt_debug(3, "short write (%d of %d bytes)\n", rc, len - sent);
+      mutt_debug(LL_DEBUG3, "short write (%d of %d bytes)\n", rc, len - sent);
 
     sent += rc;
   }
@@ -223,7 +223,7 @@ int mutt_socket_readchar(struct Connection *conn, char *c)
       conn->available = conn->conn_read(conn, conn->inbuf, sizeof(conn->inbuf));
     else
     {
-      mutt_debug(1, "attempt to read from closed connection.\n");
+      mutt_debug(LL_DEBUG1, "attempt to read from closed connection.\n");
       return -1;
     }
     conn->bufpos = 0;

--- a/conn/ssl.c
+++ b/conn/ssl.c
@@ -140,7 +140,7 @@ static int ssl_load_certificates(SSL_CTX *ctx)
   int rc = 1;
   char buf[STRING];
 
-  mutt_debug(2, "loading trusted certificates\n");
+  mutt_debug(LL_DEBUG2, "loading trusted certificates\n");
   store = SSL_CTX_get_cert_store(ctx);
   if (!store)
   {
@@ -157,7 +157,7 @@ static int ssl_load_certificates(SSL_CTX *ctx)
     if ((X509_cmp_current_time(X509_get0_notBefore(cert)) >= 0) ||
         (X509_cmp_current_time(X509_get0_notAfter(cert)) <= 0))
     {
-      mutt_debug(2, "filtering expired cert: %s\n",
+      mutt_debug(LL_DEBUG2, "filtering expired cert: %s\n",
                  X509_NAME_oneline(X509_get_subject_name(cert), buf, sizeof(buf)));
     }
     else
@@ -196,14 +196,14 @@ static int ssl_set_verify_partial(SSL_CTX *ctx)
       X509_VERIFY_PARAM_set_flags(param, X509_V_FLAG_PARTIAL_CHAIN);
       if (SSL_CTX_set1_param(ctx, param) == 0)
       {
-        mutt_debug(2, "SSL_CTX_set1_param() failed.\n");
+        mutt_debug(LL_DEBUG2, "SSL_CTX_set1_param() failed.\n");
         rc = -1;
       }
       X509_VERIFY_PARAM_free(param);
     }
     else
     {
-      mutt_debug(2, "X509_VERIFY_PARAM_new() failed.\n");
+      mutt_debug(LL_DEBUG2, "X509_VERIFY_PARAM_new() failed.\n");
       rc = -1;
     }
   }
@@ -319,7 +319,7 @@ static void ssl_err(struct SslSockData *data, int err)
       errmsg = "unknown error";
   }
 
-  mutt_debug(1, "SSL error: %s\n", errmsg);
+  mutt_debug(LL_DEBUG1, "SSL error: %s\n", errmsg);
 }
 
 /**
@@ -342,7 +342,7 @@ static void ssl_dprint_err_stack(void)
     output = mutt_mem_malloc(buflen + 1);
     memcpy(output, buf, buflen);
     output[buflen] = '\0';
-    mutt_debug(1, "SSL error stack: %s\n", output);
+    mutt_debug(LL_DEBUG1, "SSL error stack: %s\n", output);
     FREE(&output);
   }
   BIO_free(bio);
@@ -364,8 +364,8 @@ static int ssl_passwd_cb(char *buf, int buflen, int rwflag, void *userdata)
   if (mutt_account_getuser(account) < 0)
     return 0;
 
-  mutt_debug(2, "getting password for %s@%s:%u\n", account->user, account->host,
-             account->port);
+  mutt_debug(LL_DEBUG2, "getting password for %s@%s:%u\n", account->user,
+             account->host, account->port);
 
   if (mutt_account_getpass(account) < 0)
     return 0;
@@ -499,7 +499,7 @@ static bool check_certificate_expiration(X509 *peercert, bool silent)
   {
     if (!silent)
     {
-      mutt_debug(2, "Server certificate is not yet valid\n");
+      mutt_debug(LL_DEBUG2, "Server certificate is not yet valid\n");
       mutt_error(_("Server certificate is not yet valid"));
     }
     return false;
@@ -509,7 +509,7 @@ static bool check_certificate_expiration(X509 *peercert, bool silent)
   {
     if (!silent)
     {
-      mutt_debug(2, "Server certificate has expired\n");
+      mutt_debug(LL_DEBUG2, "Server certificate has expired\n");
       mutt_error(_("Server certificate has expired"));
     }
     return false;
@@ -629,7 +629,7 @@ static void ssl_get_client_cert(struct SslSockData *ssldata, struct Connection *
   if (!SslClientCert)
     return;
 
-  mutt_debug(2, "Using client certificate %s\n", SslClientCert);
+  mutt_debug(LL_DEBUG2, "Using client certificate %s\n", SslClientCert);
   SSL_CTX_set_default_passwd_cb_userdata(ssldata->sctx, &conn->account);
   SSL_CTX_set_default_passwd_cb(ssldata->sctx, ssl_passwd_cb);
   SSL_CTX_use_certificate_file(ssldata->sctx, SslClientCert, SSL_FILETYPE_PEM);
@@ -637,7 +637,7 @@ static void ssl_get_client_cert(struct SslSockData *ssldata, struct Connection *
 
   /* if we are using a client cert, SASL may expect an external auth name */
   if (mutt_account_getuser(&conn->account) < 0)
-    mutt_debug(1, "Couldn't get user info\n");
+    mutt_debug(LL_DEBUG1, "Couldn't get user info\n");
 }
 
 /**
@@ -858,7 +858,7 @@ static bool check_certificate_by_digest(X509 *peercert)
  */
 static int ssl_cache_trusted_cert(X509 *c)
 {
-  mutt_debug(1, "trusted\n");
+  mutt_debug(LL_DEBUG1, "trusted\n");
   if (!SslSessionCerts)
     SslSessionCerts = sk_X509_new_null();
   return sk_X509_push(SslSessionCerts, X509_dup(c));
@@ -1036,7 +1036,7 @@ static bool interactive_check_cert(X509 *cert, int idx, size_t len, SSL *ssl, bo
   OptIgnoreMacroEvents = false;
   mutt_menu_pop_current(menu);
   mutt_menu_destroy(&menu);
-  mutt_debug(2, "done=%d\n", done);
+  mutt_debug(LL_DEBUG2, "done=%d\n", done);
   return done == 2;
 }
 
@@ -1064,13 +1064,14 @@ static int ssl_verify_callback(int preverify_ok, X509_STORE_CTX *ctx)
   ssl = X509_STORE_CTX_get_ex_data(ctx, SSL_get_ex_data_X509_STORE_CTX_idx());
   if (!ssl)
   {
-    mutt_debug(1, "failed to retrieve SSL structure from X509_STORE_CTX\n");
+    mutt_debug(LL_DEBUG1,
+               "failed to retrieve SSL structure from X509_STORE_CTX\n");
     return false;
   }
   host = SSL_get_ex_data(ssl, HostExDataIndex);
   if (!host)
   {
-    mutt_debug(1, "failed to retrieve hostname from SSL structure\n");
+    mutt_debug(LL_DEBUG1, "failed to retrieve hostname from SSL structure\n");
     return false;
   }
 
@@ -1086,7 +1087,7 @@ static int ssl_verify_callback(int preverify_ok, X509_STORE_CTX *ctx)
   pos = X509_STORE_CTX_get_error_depth(ctx);
   len = sk_X509_num(X509_STORE_CTX_get0_chain(ctx));
 
-  mutt_debug(1, "checking cert chain entry %s (preverify: %d skipmode: %d)\n",
+  mutt_debug(LL_DEBUG1, "checking cert chain entry %s (preverify: %d skipmode: %d)\n",
              X509_NAME_oneline(X509_get_subject_name(cert), buf, sizeof(buf)),
              preverify_ok, skip_mode);
 
@@ -1106,7 +1107,7 @@ static int ssl_verify_callback(int preverify_ok, X509_STORE_CTX *ctx)
       if (X509_digest(last_cert, EVP_sha256(), last_cert_md, &last_cert_mdlen) &&
           compare_certificates(cert, last_cert, last_cert_md, last_cert_mdlen))
       {
-        mutt_debug(2, "ignoring duplicate skipped certificate.\n");
+        mutt_debug(LL_DEBUG2, "ignoring duplicate skipped certificate.\n");
         return true;
       }
     }
@@ -1121,7 +1122,7 @@ static int ssl_verify_callback(int preverify_ok, X509_STORE_CTX *ctx)
   /* check session cache first */
   if (check_certificate_cache(cert))
   {
-    mutt_debug(2, "using cached certificate\n");
+    mutt_debug(LL_DEBUG2, "using cached certificate\n");
     SSL_set_ex_data(ssl, SkipModeExDataIndex, NULL);
     return true;
   }
@@ -1137,7 +1138,7 @@ static int ssl_verify_callback(int preverify_ok, X509_STORE_CTX *ctx)
        * for hostname mismatches. */
       return interactive_check_cert(cert, pos, len, ssl, false);
     }
-    mutt_debug(2, "hostname check passed\n");
+    mutt_debug(LL_DEBUG2, "hostname check passed\n");
   }
 
   if (!preverify_ok || skip_mode)
@@ -1145,7 +1146,7 @@ static int ssl_verify_callback(int preverify_ok, X509_STORE_CTX *ctx)
     /* automatic check from user's database */
     if (CertificateFile && check_certificate_by_digest(cert))
     {
-      mutt_debug(2, "digest check passed\n");
+      mutt_debug(LL_DEBUG2, "digest check passed\n");
       SSL_set_ex_data(ssl, SkipModeExDataIndex, NULL);
       return true;
     }
@@ -1153,7 +1154,7 @@ static int ssl_verify_callback(int preverify_ok, X509_STORE_CTX *ctx)
     /* log verification error */
     int err = X509_STORE_CTX_get_error(ctx);
     snprintf(buf, sizeof(buf), "%s (%d)", X509_verify_cert_error_string(err), err);
-    mutt_debug(2, "X509_verify_cert: %s\n", buf);
+    mutt_debug(LL_DEBUG2, "X509_verify_cert: %s\n", buf);
 
     /* prompt user */
     return interactive_check_cert(cert, pos, len, ssl, true);
@@ -1180,26 +1181,28 @@ static int ssl_negotiate(struct Connection *conn, struct SslSockData *ssldata)
   HostExDataIndex = SSL_get_ex_new_index(0, "host", NULL, NULL, NULL);
   if (HostExDataIndex == -1)
   {
-    mutt_debug(1, "#1 failed to get index for application specific data\n");
+    mutt_debug(LL_DEBUG1,
+               "#1 failed to get index for application specific data\n");
     return -1;
   }
 
   if (!SSL_set_ex_data(ssldata->ssl, HostExDataIndex, conn->account.host))
   {
-    mutt_debug(1, "#2 failed to save hostname in SSL structure\n");
+    mutt_debug(LL_DEBUG1, "#2 failed to save hostname in SSL structure\n");
     return -1;
   }
 
   SkipModeExDataIndex = SSL_get_ex_new_index(0, "skip", NULL, NULL, NULL);
   if (SkipModeExDataIndex == -1)
   {
-    mutt_debug(1, "#3 failed to get index for application specific data\n");
+    mutt_debug(LL_DEBUG1,
+               "#3 failed to get index for application specific data\n");
     return -1;
   }
 
   if (!SSL_set_ex_data(ssldata->ssl, SkipModeExDataIndex, NULL))
   {
-    mutt_debug(1, "#4 failed to save skip mode in SSL structure\n");
+    mutt_debug(LL_DEBUG1, "#4 failed to save skip mode in SSL structure\n");
     return -1;
   }
 
@@ -1290,13 +1293,13 @@ static int ssl_setup(struct Connection *conn)
   {
     if (!SSL_CTX_set_default_verify_paths(ssldata->sctx))
     {
-      mutt_debug(1, "Error setting default verify paths\n");
+      mutt_debug(LL_DEBUG1, "Error setting default verify paths\n");
       goto free_ctx;
     }
   }
 
   if (CertificateFile && !ssl_load_certificates(ssldata->sctx))
-    mutt_debug(1, "Error loading trusted certificates\n");
+    mutt_debug(LL_DEBUG1, "Error loading trusted certificates\n");
 
   ssl_get_client_cert(ssldata, conn);
 

--- a/conn/ssl_gnutls.c
+++ b/conn/ssl_gnutls.c
@@ -810,7 +810,7 @@ static int tls_check_certificate(struct Connection *conn)
     {
       rc = gnutls_certificate_set_x509_trust_mem(data->xcred, &cert_list[i], GNUTLS_X509_FMT_DER);
       if (rc != 1)
-        mutt_debug(1, "error trusting certificate %d: %d\n", i, rc);
+        mutt_debug(LL_DEBUG1, "error trusting certificate %d: %d\n", i, rc);
 
       certstat = tls_verify_peers(state);
       /* If the cert chain now verifies, and the peer's cert was otherwise
@@ -844,12 +844,12 @@ static void tls_get_client_cert(struct Connection *conn)
 
   if (gnutls_x509_crt_init(&clientcrt) < 0)
   {
-    mutt_debug(1, "Failed to init gnutls crt\n");
+    mutt_debug(LL_DEBUG1, "Failed to init gnutls crt\n");
     return;
   }
   if (gnutls_x509_crt_import(clientcrt, crtdata, GNUTLS_X509_FMT_DER) < 0)
   {
-    mutt_debug(1, "Failed to import gnutls client crt\n");
+    mutt_debug(LL_DEBUG1, "Failed to import gnutls client crt\n");
     goto err_crt;
   }
   /* get length of DN */
@@ -858,13 +858,13 @@ static void tls_get_client_cert(struct Connection *conn)
   dn = mutt_mem_calloc(1, dnlen);
 
   gnutls_x509_crt_get_dn(clientcrt, dn, &dnlen);
-  mutt_debug(2, "client certificate DN: %s\n", dn);
+  mutt_debug(LL_DEBUG2, "client certificate DN: %s\n", dn);
 
   /* extract CN to use as external user name */
   cn = strstr(dn, "CN=");
   if (!cn)
   {
-    mutt_debug(1, "no CN found in DN\n");
+    mutt_debug(LL_DEBUG1, "no CN found in DN\n");
     goto err_dn;
   }
 
@@ -874,7 +874,7 @@ static void tls_get_client_cert(struct Connection *conn)
 
   /* if we are using a client cert, SASL may expect an external auth name */
   if (mutt_account_getuser(&conn->account) < 0)
-    mutt_debug(1, "Couldn't get user info\n");
+    mutt_debug(LL_DEBUG1, "Couldn't get user info\n");
 
 err_dn:
   FREE(&dn);
@@ -1028,7 +1028,7 @@ static int tls_negotiate(struct Connection *conn)
 
   if (SslClientCert)
   {
-    mutt_debug(2, "Using client certificate %s\n", SslClientCert);
+    mutt_debug(LL_DEBUG2, "Using client certificate %s\n", SslClientCert);
     gnutls_certificate_set_x509_key_file(data->xcred, SslClientCert,
                                          SslClientCert, GNUTLS_X509_FMT_PEM);
   }

--- a/copy.c
+++ b/copy.c
@@ -165,12 +165,12 @@ int mutt_copy_hdr(FILE *in, FILE *out, LOFF_T off_start, LOFF_T off_end,
     struct ListNode *np = NULL;
     STAILQ_FOREACH(np, &HeaderOrderList, entries)
     {
-      mutt_debug(3, "Reorder list: %s\n", np->data);
+      mutt_debug(LL_DEBUG3, "Reorder list: %s\n", np->data);
       hdr_count++;
     }
   }
 
-  mutt_debug(1, "WEED is %s\n", (flags & CH_WEED) ? "Set" : "Not");
+  mutt_debug(LL_DEBUG1, "WEED is %s\n", (flags & CH_WEED) ? "Set" : "Not");
 
   headers = mutt_mem_calloc(hdr_count, sizeof(char *));
 
@@ -284,7 +284,7 @@ int mutt_copy_hdr(FILE *in, FILE *out, LOFF_T off_start, LOFF_T off_end,
           ++x;
           if (mutt_str_startswith(buf, np->data, CASE_IGNORE))
           {
-            mutt_debug(2, "Reorder: %s matches %s", np->data, buf);
+            mutt_debug(LL_DEBUG2, "Reorder: %s matches %s", np->data, buf);
             break;
           }
         }
@@ -295,7 +295,7 @@ int mutt_copy_hdr(FILE *in, FILE *out, LOFF_T off_start, LOFF_T off_end,
 
     if (!ignore)
     {
-      mutt_debug(2, "Reorder: x = %d; hdr_count = %d\n", x, hdr_count);
+      mutt_debug(LL_DEBUG2, "Reorder: x = %d; hdr_count = %d\n", x, hdr_count);
       if (!this_one)
       {
         this_one = mutt_str_strdup(buf);
@@ -837,7 +837,7 @@ int mutt_copy_message_ctx(FILE *fpout, struct Mailbox *src, struct Email *e,
   int r = mutt_copy_message_fp(fpout, msg->fp, e, flags, chflags);
   if ((r == 0) && (ferror(fpout) || feof(fpout)))
   {
-    mutt_debug(1, "failed to detect EOF!\n");
+    mutt_debug(LL_DEBUG1, "failed to detect EOF!\n");
     r = -1;
   }
   mx_msg_close(src, &msg);

--- a/curs_lib.c
+++ b/curs_lib.c
@@ -518,7 +518,7 @@ void mutt_perror_debug(const char *s)
 {
   char *p = strerror(errno);
 
-  mutt_debug(1, "%s: %s (errno = %d)\n", s, p ? p : "unknown error", errno);
+  mutt_debug(LL_DEBUG1, "%s: %s (errno = %d)\n", s, p ? p : "unknown error", errno);
   mutt_error("%s: %s (errno = %d)", s, p ? p : _("unknown error"), errno);
 }
 

--- a/editmsg.c
+++ b/editmsg.c
@@ -119,7 +119,8 @@ static int ev_message(enum EvMessage action, struct Mailbox *m, struct Email *e)
     rc = mutt_file_chmod_rm_stat(fname, S_IWUSR | S_IWGRP | S_IWOTH, &sb);
     if (rc == -1)
     {
-      mutt_debug(1, "Could not remove write permissions of %s: %s", fname, strerror(errno));
+      mutt_debug(LL_DEBUG1, "Could not remove write permissions of %s: %s",
+                 fname, strerror(errno));
       /* Do not bail out here as we are checking afterwards if we should adopt
        * changes of the temporary file. */
     }

--- a/email/address.c
+++ b/email/address.c
@@ -1299,7 +1299,7 @@ struct Address *mutt_addrlist_dedupe(struct Address *addr)
 
     if (dup)
     {
-      mutt_debug(2, "Removing %s\n", addr->mailbox);
+      mutt_debug(LL_DEBUG2, "Removing %s\n", addr->mailbox);
 
       *last = addr->next;
 

--- a/email/body.c
+++ b/email/body.c
@@ -71,7 +71,7 @@ void mutt_body_free(struct Body **p)
     {
       if (b->unlink)
         unlink(b->filename);
-      mutt_debug(1, "%sunlinking %s.\n", b->unlink ? "" : "not ", b->filename);
+      mutt_debug(LL_DEBUG1, "%sunlinking %s.\n", b->unlink ? "" : "not ", b->filename);
     }
 
     FREE(&b->filename);

--- a/email/from.c
+++ b/email/from.c
@@ -91,7 +91,7 @@ bool is_from(const char *s, char *path, size_t pathlen, time_t *tp)
       p = strchr(p + plen, ' ');
       if (!p)
       {
-        mutt_debug(1,
+        mutt_debug(LL_DEBUG1,
                    "error parsing what appears to be a pipermail-style "
                    "obscured return_path: %s\n",
                    s);
@@ -116,7 +116,7 @@ bool is_from(const char *s, char *path, size_t pathlen, time_t *tp)
 
     if (!mutt_date_is_day_name(s))
     {
-      mutt_debug(1, " expected weekday, got: %s\n", s);
+      mutt_debug(LL_DEBUG1, " expected weekday, got: %s\n", s);
       return false;
     }
   }
@@ -198,8 +198,8 @@ bool is_from(const char *s, char *path, size_t pathlen, time_t *tp)
     return false;
   tm.tm_year = (yr > 1900) ? (yr - 1900) : ((yr < 70) ? (yr + 100) : yr);
 
-  mutt_debug(3, "month=%d, day=%d, hr=%d, min=%d, sec=%d, yr=%d.\n", tm.tm_mon,
-             tm.tm_mday, tm.tm_hour, tm.tm_min, tm.tm_sec, tm.tm_year);
+  mutt_debug(LL_DEBUG3, "month=%d, day=%d, hr=%d, min=%d, sec=%d, yr=%d.\n",
+             tm.tm_mon, tm.tm_mday, tm.tm_hour, tm.tm_min, tm.tm_sec, tm.tm_year);
 
   tm.tm_isdst = -1;
 

--- a/email/from.c
+++ b/email/from.c
@@ -61,7 +61,7 @@ bool is_from(const char *s, char *path, size_t pathlen, time_t *tp)
   if (!*s)
     return false;
 
-  mutt_debug(3, "\nis_from(): parsing: %s\n", s);
+  mutt_debug(5, "\nis_from(): parsing: %s\n", s);
 
   if (!mutt_date_is_day_name(s))
   {
@@ -106,7 +106,7 @@ bool is_from(const char *s, char *path, size_t pathlen, time_t *tp)
         len = pathlen - 1;
       memcpy(path, s, len);
       path[len] = '\0';
-      mutt_debug(3, "got return path: %s\n", path);
+      mutt_debug(5, "got return path: %s\n", path);
     }
 
     s = p + 1;

--- a/email/idna.c
+++ b/email/idna.c
@@ -163,14 +163,15 @@ char *mutt_idna_intl_to_local(const char *user, const char *domain, int flags)
 
     if (mutt_ch_convert_string(&reversed_user, Charset, "utf-8", 0) != 0)
     {
-      mutt_debug(1, "Not reversible. Charset conv to utf-8 failed for user = '%s'.\n",
+      mutt_debug(LL_DEBUG1, "Not reversible. Charset conv to utf-8 failed for user = '%s'.\n",
                  reversed_user);
       goto cleanup;
     }
 
     if (mutt_str_strcasecmp(user, reversed_user) != 0)
     {
-      mutt_debug(1, "#1 Not reversible. orig = '%s', reversed = '%s'.\n", user, reversed_user);
+      mutt_debug(LL_DEBUG1, "#1 Not reversible. orig = '%s', reversed = '%s'.\n",
+                 user, reversed_user);
       goto cleanup;
     }
 
@@ -178,7 +179,7 @@ char *mutt_idna_intl_to_local(const char *user, const char *domain, int flags)
 
     if (mutt_ch_convert_string(&reversed_domain, Charset, "utf-8", 0) != 0)
     {
-      mutt_debug(1, "Not reversible. Charset conv to utf-8 failed for domain = '%s'.\n",
+      mutt_debug(LL_DEBUG1, "Not reversible. Charset conv to utf-8 failed for domain = '%s'.\n",
                  reversed_domain);
       goto cleanup;
     }
@@ -192,7 +193,7 @@ char *mutt_idna_intl_to_local(const char *user, const char *domain, int flags)
     {
       if (idna_to_ascii_8z(reversed_domain, &tmp, IDNA_ALLOW_UNASSIGNED) != IDNA_SUCCESS)
       {
-        mutt_debug(1, "Not reversible. idna_to_ascii_8z failed for domain = '%s'.\n",
+        mutt_debug(LL_DEBUG1, "Not reversible. idna_to_ascii_8z failed for domain = '%s'.\n",
                    reversed_domain);
         goto cleanup;
       }
@@ -202,7 +203,8 @@ char *mutt_idna_intl_to_local(const char *user, const char *domain, int flags)
 
     if (mutt_str_strcasecmp(domain, reversed_domain) != 0)
     {
-      mutt_debug(1, "#2 Not reversible. orig = '%s', reversed = '%s'.\n", domain, reversed_domain);
+      mutt_debug(LL_DEBUG1, "#2 Not reversible. orig = '%s', reversed = '%s'.\n",
+                 domain, reversed_domain);
       goto cleanup;
     }
   }

--- a/email/parse.c
+++ b/email/parse.c
@@ -99,14 +99,14 @@ static void parse_parameters(struct ParameterList *param, const char *s)
   const char *p = NULL;
   size_t i;
 
-  mutt_debug(2, "'%s'\n", s);
+  mutt_debug(LL_DEBUG2, "'%s'\n", s);
 
   while (*s)
   {
     p = strpbrk(s, "=;");
     if (!p)
     {
-      mutt_debug(1, "malformed parameter: %s\n", s);
+      mutt_debug(LL_DEBUG1, "malformed parameter: %s\n", s);
       goto bail;
     }
 
@@ -123,7 +123,7 @@ static void parse_parameters(struct ParameterList *param, const char *s)
        */
       if (i == 0)
       {
-        mutt_debug(1, "missing attribute: %s\n", s);
+        mutt_debug(LL_DEBUG1, "missing attribute: %s\n", s);
         new = NULL;
       }
       else
@@ -180,7 +180,7 @@ static void parse_parameters(struct ParameterList *param, const char *s)
       {
         new->value = mutt_str_strdup(buffer);
 
-        mutt_debug(2, "parse_parameter: '%s' = '%s'\n",
+        mutt_debug(LL_DEBUG2, "parse_parameter: '%s' = '%s'\n",
                    new->attribute ? new->attribute : "", new->value ? new->value : "");
 
         /* Add this parameter to the list */
@@ -189,7 +189,7 @@ static void parse_parameters(struct ParameterList *param, const char *s)
     }
     else
     {
-      mutt_debug(1, "parameter with no value: %s\n", s);
+      mutt_debug(LL_DEBUG1, "parameter with no value: %s\n", s);
       s = p;
     }
 
@@ -271,7 +271,7 @@ static void parse_content_language(const char *s, struct Body *ct)
   if (!s || !ct)
     return;
 
-  mutt_debug(2, "RFC8255 >> Content-Language set to %s\n", s);
+  mutt_debug(LL_DEBUG2, "RFC8255 >> Content-Language set to %s\n", s);
   ct->language = mutt_str_strdup(s);
 }
 
@@ -1137,14 +1137,15 @@ struct Envelope *mutt_rfc822_read_header(FILE *f, struct Email *e, bool user_hdr
 
     if (e->received < 0)
     {
-      mutt_debug(1, "resetting invalid received time to 0\n");
+      mutt_debug(LL_DEBUG1, "resetting invalid received time to 0\n");
       e->received = 0;
     }
 
     /* check for missing or invalid date */
     if (e->date_sent <= 0)
     {
-      mutt_debug(1, "no date found, using received time from msg separator\n");
+      mutt_debug(LL_DEBUG1,
+                 "no date found, using received time from msg separator\n");
       e->date_sent = e->received;
     }
   }
@@ -1182,13 +1183,13 @@ struct Body *mutt_read_mime_header(FILE *fp, bool digest)
       c = mutt_str_skip_email_wsp(c + 1);
       if (!*c)
       {
-        mutt_debug(1, "skipping empty header field: %s\n", line);
+        mutt_debug(LL_DEBUG1, "skipping empty header field: %s\n", line);
         continue;
       }
     }
     else
     {
-      mutt_debug(1, "bogus MIME header: %s\n", line);
+      mutt_debug(LL_DEBUG1, "bogus MIME header: %s\n", line);
       break;
     }
 

--- a/handler.c
+++ b/handler.c
@@ -1100,7 +1100,8 @@ static int multilingual_handler(struct Body *a, struct State *s)
   struct Body *zxx_part = NULL;
   char *lang = NULL;
 
-  mutt_debug(2, "RFC8255 >> entering in handler multilingual handler\n");
+  mutt_debug(LL_DEBUG2,
+             "RFC8255 >> entering in handler multilingual handler\n");
   if ((a->encoding == ENC_BASE64) || (a->encoding == ENC_QUOTED_PRINTABLE) ||
       (a->encoding == ENC_UUENCODED))
   {
@@ -1126,7 +1127,8 @@ static int multilingual_handler(struct Body *a, struct State *s)
   char *preferred_languages = NULL;
   if (PreferredLanguages)
   {
-    mutt_debug(2, "RFC8255 >> preferred_languages set in config to '%s'\n", PreferredLanguages);
+    mutt_debug(LL_DEBUG2, "RFC8255 >> preferred_languages set in config to '%s'\n",
+               PreferredLanguages);
     preferred_languages = mutt_str_strdup(PreferredLanguages);
     lang = strtok(preferred_languages, ",");
   }
@@ -1143,11 +1145,11 @@ static int multilingual_handler(struct Body *a, struct State *s)
         if (b->language && (mutt_str_strcmp("zxx", b->language) == 0))
           zxx_part = b;
 
-        mutt_debug(2, "RFC8255 >> comparing configuration preferred_language='%s' to mail part content-language='%s'\n",
+        mutt_debug(LL_DEBUG2, "RFC8255 >> comparing configuration preferred_language='%s' to mail part content-language='%s'\n",
                    lang, b->language);
         if (lang && b->language && (mutt_str_strcmp(lang, b->language) == 0))
         {
-          mutt_debug(2, "RFC8255 >> preferred_language='%s' matches content-language='%s' >> part selected to be displayed\n",
+          mutt_debug(LL_DEBUG2, "RFC8255 >> preferred_language='%s' matches content-language='%s' >> part selected to be displayed\n",
                      lang, b->language);
           choice = b;
           break;
@@ -1238,8 +1240,8 @@ static int multipart_handler(struct Body *a, struct State *s)
     if (rc != 0)
     {
       mutt_error(_("One or more parts of this message could not be displayed"));
-      mutt_debug(1, "Failed on attachment #%d, type %s/%s.\n", count, TYPE(p),
-                 NONULL(p->subtype));
+      mutt_debug(LL_DEBUG1, "Failed on attachment #%d, type %s/%s.\n", count,
+                 TYPE(p), NONULL(p->subtype));
     }
 
     if ((s->flags & MUTT_REPLYING) && IncludeOnlyfirst && (s->flags & MUTT_FIRSTDONE))
@@ -1304,7 +1306,7 @@ static int run_decode_and_handler(struct Body *b, struct State *s,
       if (!s->fpout)
       {
         mutt_error(_("Unable to open 'memory stream'"));
-        mutt_debug(1, "Can't open 'memory stream'.\n");
+        mutt_debug(LL_DEBUG1, "Can't open 'memory stream'.\n");
         return -1;
       }
 #else
@@ -1313,7 +1315,7 @@ static int run_decode_and_handler(struct Body *b, struct State *s,
       if (!s->fpout)
       {
         mutt_error(_("Unable to open temporary file"));
-        mutt_debug(1, "Can't open %s.\n", tempfile);
+        mutt_debug(LL_DEBUG1, "Can't open %s.\n", tempfile);
         return -1;
       }
 #endif
@@ -1382,7 +1384,8 @@ static int run_decode_and_handler(struct Body *b, struct State *s,
     rc = handler(b, s);
     if (rc != 0)
     {
-      mutt_debug(1, "Failed on attachment of type %s/%s.\n", TYPE(b), NONULL(b->subtype));
+      mutt_debug(LL_DEBUG1, "Failed on attachment of type %s/%s.\n", TYPE(b),
+                 NONULL(b->subtype));
     }
 
     if (decode)
@@ -1490,7 +1493,7 @@ void mutt_decode_base64(struct State *s, size_t len, bool istext, iconv_t cd)
     {
       /* "i" may be zero if there is trailing whitespace, which is not an error */
       if (i != 0)
-        mutt_debug(2, "didn't get a multiple of 4 chars.\n");
+        mutt_debug(LL_DEBUG2, "didn't get a multiple of 4 chars.\n");
       break;
     }
 
@@ -1613,7 +1616,8 @@ int mutt_body_handler(struct Body *b, struct State *s)
 
     if ((b->encoding != ENC_7BIT) && (b->encoding != ENC_8BIT) && (b->encoding != ENC_BINARY))
     {
-      mutt_debug(1, "Bad encoding type %d for multipart entity, assuming 7 bit\n", b->encoding);
+      mutt_debug(LL_DEBUG1, "Bad encoding type %d for multipart entity, assuming 7 bit\n",
+                 b->encoding);
       b->encoding = ENC_7BIT;
     }
   }
@@ -1702,7 +1706,8 @@ int mutt_body_handler(struct Body *b, struct State *s)
   s->flags = oflags | (s->flags & MUTT_FIRSTDONE);
   if (rc != 0)
   {
-    mutt_debug(1, "Bailing on attachment of type %s/%s.\n", TYPE(b), NONULL(b->subtype));
+    mutt_debug(LL_DEBUG1, "Bailing on attachment of type %s/%s.\n", TYPE(b),
+               NONULL(b->subtype));
   }
 
   return rc;

--- a/hcache/kc.c
+++ b/hcache/kc.c
@@ -61,7 +61,8 @@ static void *hcache_kyotocabinet_open(const char *path)
   else
   {
     int ecode = kcdbecode(db);
-    mutt_debug(2, "kcdbopen failed for %s: %s (ecode %d)\n", kcdbpath, kcdbemsg(db), ecode);
+    mutt_debug(LL_DEBUG2, "kcdbopen failed for %s: %s (ecode %d)\n", kcdbpath,
+               kcdbemsg(db), ecode);
     kcdbdel(db);
     return NULL;
   }
@@ -137,7 +138,7 @@ static void hcache_kyotocabinet_close(void **ctx)
   if (!kcdbclose(db))
   {
     int ecode = kcdbecode(db);
-    mutt_debug(2, "kcdbclose failed: %s (ecode %d)\n", kcdbemsg(db), ecode);
+    mutt_debug(LL_DEBUG2, "kcdbclose failed: %s (ecode %d)\n", kcdbemsg(db), ecode);
   }
   kcdbdel(db);
 }

--- a/hcache/lmdb.c
+++ b/hcache/lmdb.c
@@ -81,8 +81,8 @@ static int mdb_get_r_txn(struct HcacheLmdbCtx *ctx)
     ctx->txn_mode = TXN_READ;
   else
   {
-    mutt_debug(2, "%s: %s\n", ctx->txn ? "mdb_txn_renew" : "mdb_txn_begin",
-               mdb_strerror(rc));
+    mutt_debug(LL_DEBUG2, "%s: %s\n",
+               ctx->txn ? "mdb_txn_renew" : "mdb_txn_begin", mdb_strerror(rc));
   }
 
   return rc;
@@ -110,7 +110,7 @@ static int mdb_get_w_txn(struct HcacheLmdbCtx *ctx)
   if (rc == MDB_SUCCESS)
     ctx->txn_mode = TXN_WRITE;
   else
-    mutt_debug(2, "mdb_txn_begin: %s\n", mdb_strerror(rc));
+    mutt_debug(LL_DEBUG2, "mdb_txn_begin: %s\n", mdb_strerror(rc));
 
   return rc;
 }
@@ -127,7 +127,7 @@ static void *hcache_lmdb_open(const char *path)
   rc = mdb_env_create(&ctx->env);
   if (rc != MDB_SUCCESS)
   {
-    mutt_debug(2, "mdb_env_create: %s\n", mdb_strerror(rc));
+    mutt_debug(LL_DEBUG2, "mdb_env_create: %s\n", mdb_strerror(rc));
     FREE(&ctx);
     return NULL;
   }
@@ -137,21 +137,21 @@ static void *hcache_lmdb_open(const char *path)
   rc = mdb_env_open(ctx->env, path, MDB_NOSUBDIR, 0644);
   if (rc != MDB_SUCCESS)
   {
-    mutt_debug(2, "mdb_env_open: %s\n", mdb_strerror(rc));
+    mutt_debug(LL_DEBUG2, "mdb_env_open: %s\n", mdb_strerror(rc));
     goto fail_env;
   }
 
   rc = mdb_get_r_txn(ctx);
   if (rc != MDB_SUCCESS)
   {
-    mutt_debug(2, "mdb_txn_begin: %s\n", mdb_strerror(rc));
+    mutt_debug(LL_DEBUG2, "mdb_txn_begin: %s\n", mdb_strerror(rc));
     goto fail_env;
   }
 
   rc = mdb_dbi_open(ctx->txn, NULL, MDB_CREATE, &ctx->db);
   if (rc != MDB_SUCCESS)
   {
-    mutt_debug(2, "mdb_dbi_open: %s\n", mdb_strerror(rc));
+    mutt_debug(LL_DEBUG2, "mdb_dbi_open: %s\n", mdb_strerror(rc));
     goto fail_dbi;
   }
 
@@ -192,7 +192,7 @@ static void *hcache_lmdb_fetch(void *vctx, const char *key, size_t keylen)
   if (rc != MDB_SUCCESS)
   {
     ctx->txn = NULL;
-    mutt_debug(2, "txn_renew: %s\n", mdb_strerror(rc));
+    mutt_debug(LL_DEBUG2, "txn_renew: %s\n", mdb_strerror(rc));
     return NULL;
   }
   rc = mdb_get(ctx->txn, ctx->db, &dkey, &data);
@@ -202,7 +202,7 @@ static void *hcache_lmdb_fetch(void *vctx, const char *key, size_t keylen)
   }
   if (rc != MDB_SUCCESS)
   {
-    mutt_debug(2, "mdb_get: %s\n", mdb_strerror(rc));
+    mutt_debug(LL_DEBUG2, "mdb_get: %s\n", mdb_strerror(rc));
     return NULL;
   }
 
@@ -238,13 +238,13 @@ static int hcache_lmdb_store(void *vctx, const char *key, size_t keylen, void *d
   rc = mdb_get_w_txn(ctx);
   if (rc != MDB_SUCCESS)
   {
-    mutt_debug(2, "mdb_get_w_txn: %s\n", mdb_strerror(rc));
+    mutt_debug(LL_DEBUG2, "mdb_get_w_txn: %s\n", mdb_strerror(rc));
     return rc;
   }
   rc = mdb_put(ctx->txn, ctx->db, &dkey, &databuf, 0);
   if (rc != MDB_SUCCESS)
   {
-    mutt_debug(2, "mdb_put: %s\n", mdb_strerror(rc));
+    mutt_debug(LL_DEBUG2, "mdb_put: %s\n", mdb_strerror(rc));
     mdb_txn_abort(ctx->txn);
     ctx->txn_mode = TXN_UNINITIALIZED;
     ctx->txn = NULL;
@@ -270,13 +270,13 @@ static int hcache_lmdb_delete(void *vctx, const char *key, size_t keylen)
   rc = mdb_get_w_txn(ctx);
   if (rc != MDB_SUCCESS)
   {
-    mutt_debug(2, "mdb_get_w_txn: %s\n", mdb_strerror(rc));
+    mutt_debug(LL_DEBUG2, "mdb_get_w_txn: %s\n", mdb_strerror(rc));
     return rc;
   }
   rc = mdb_del(ctx->txn, ctx->db, &dkey, NULL);
   if (rc != MDB_SUCCESS && rc != MDB_NOTFOUND)
   {
-    mutt_debug(2, "mdb_del: %s\n", mdb_strerror(rc));
+    mutt_debug(LL_DEBUG2, "mdb_del: %s\n", mdb_strerror(rc));
     mdb_txn_abort(ctx->txn);
     ctx->txn_mode = TXN_UNINITIALIZED;
     ctx->txn = NULL;

--- a/hcache/tc.c
+++ b/hcache/tc.c
@@ -52,7 +52,7 @@ static void *hcache_tokyocabinet_open(const char *path)
   else
   {
     int ecode = tcbdbecode(db);
-    mutt_debug(2, "tcbdbopen failed for %s: %s (ecode %d)\n", path,
+    mutt_debug(LL_DEBUG2, "tcbdbopen failed for %s: %s (ecode %d)\n", path,
                tcbdberrmsg(ecode), ecode);
     tcbdbdel(db);
     return NULL;
@@ -128,7 +128,7 @@ static void hcache_tokyocabinet_close(void **ctx)
   if (!tcbdbclose(db))
   {
     int ecode = tcbdbecode(db);
-    mutt_debug(2, "tcbdbclose failed: %s (ecode %d)\n", tcbdberrmsg(ecode), ecode);
+    mutt_debug(LL_DEBUG2, "tcbdbclose failed: %s (ecode %d)\n", tcbdberrmsg(ecode), ecode);
   }
   tcbdbdel(db);
 }

--- a/imap/auth.c
+++ b/imap/auth.c
@@ -70,7 +70,7 @@ int imap_authenticate(struct ImapAccountData *adata)
 
   if (ImapAuthenticators && *ImapAuthenticators)
   {
-    mutt_debug(2, "Trying user-defined imap_authenticators.\n");
+    mutt_debug(LL_DEBUG2, "Trying user-defined imap_authenticators.\n");
 
     /* Try user-specified list of authentication methods */
     char *methods = mutt_str_strdup(ImapAuthenticators);
@@ -84,7 +84,7 @@ int imap_authenticate(struct ImapAccountData *adata)
       if (!method[0])
         continue;
 
-      mutt_debug(2, "Trying method %s\n", method);
+      mutt_debug(LL_DEBUG2, "Trying method %s\n", method);
 
       for (size_t i = 0; i < mutt_array_size(imap_authenticators); ++i)
       {
@@ -106,7 +106,7 @@ int imap_authenticate(struct ImapAccountData *adata)
   else
   {
     /* Fall back to default: any authenticator */
-    mutt_debug(2, "Trying pre-defined imap_authenticators.\n");
+    mutt_debug(LL_DEBUG2, "Trying pre-defined imap_authenticators.\n");
 
     for (size_t i = 0; i < mutt_array_size(imap_authenticators); ++i)
     {

--- a/imap/auth_anon.c
+++ b/imap/auth_anon.c
@@ -65,7 +65,7 @@ enum ImapAuthRes imap_auth_anon(struct ImapAccountData *adata, const char *metho
 
   if (rc != IMAP_CMD_RESPOND)
   {
-    mutt_debug(1, "Invalid response from server.\n");
+    mutt_debug(LL_DEBUG1, "Invalid response from server.\n");
     goto bail;
   }
 
@@ -77,7 +77,7 @@ enum ImapAuthRes imap_auth_anon(struct ImapAccountData *adata, const char *metho
 
   if (rc != IMAP_CMD_OK)
   {
-    mutt_debug(1, "Error receiving server response.\n");
+    mutt_debug(LL_DEBUG1, "Error receiving server response.\n");
     goto bail;
   }
 

--- a/imap/auth_cram.c
+++ b/imap/auth_cram.c
@@ -127,19 +127,19 @@ enum ImapAuthRes imap_auth_cram_md5(struct ImapAccountData *adata, const char *m
 
   if (rc != IMAP_CMD_RESPOND)
   {
-    mutt_debug(1, "Invalid response from server: %s\n", ibuf);
+    mutt_debug(LL_DEBUG1, "Invalid response from server: %s\n", ibuf);
     goto bail;
   }
 
   len = mutt_b64_decode(adata->buf + 2, obuf, sizeof(obuf));
   if (len == -1)
   {
-    mutt_debug(1, "Error decoding base64 response.\n");
+    mutt_debug(LL_DEBUG1, "Error decoding base64 response.\n");
     goto bail;
   }
 
   obuf[len] = '\0';
-  mutt_debug(2, "CRAM challenge: %s\n", obuf);
+  mutt_debug(LL_DEBUG2, "CRAM challenge: %s\n", obuf);
 
   /* The client makes note of the data and then responds with a string
    * consisting of the user name, a space, and a 'digest'. The latter is
@@ -156,7 +156,7 @@ enum ImapAuthRes imap_auth_cram_md5(struct ImapAccountData *adata, const char *m
   /* dubious optimisation I saw elsewhere: make the whole string in one call */
   int off = snprintf(obuf, sizeof(obuf), "%s ", adata->conn->account.user);
   mutt_md5_toascii(hmac_response, obuf + off);
-  mutt_debug(2, "CRAM response: %s\n", obuf);
+  mutt_debug(LL_DEBUG2, "CRAM response: %s\n", obuf);
 
   /* ibuf must be long enough to store the base64 encoding of obuf,
    * plus the additional debris */
@@ -170,7 +170,7 @@ enum ImapAuthRes imap_auth_cram_md5(struct ImapAccountData *adata, const char *m
 
   if (rc != IMAP_CMD_OK)
   {
-    mutt_debug(1, "Error receiving server response.\n");
+    mutt_debug(LL_DEBUG1, "Error receiving server response.\n");
     goto bail;
   }
 

--- a/imap/auth_login.c
+++ b/imap/auth_login.c
@@ -67,7 +67,8 @@ enum ImapAuthRes imap_auth_login(struct ImapAccountData *adata, const char *meth
    * of 5 or higher */
 
   if (DebugLevel < IMAP_LOG_PASS)
-    mutt_debug(2, "Sending LOGIN command for %s...\n", adata->conn->account.user);
+    mutt_debug(LL_DEBUG2, "Sending LOGIN command for %s...\n",
+               adata->conn->account.user);
 
   snprintf(buf, sizeof(buf), "LOGIN %s %s", q_user, q_pass);
   if (imap_exec(adata, buf, IMAP_CMD_PASS) != IMAP_EXEC_SUCCESS)

--- a/imap/auth_sasl.c
+++ b/imap/auth_sasl.c
@@ -60,7 +60,7 @@ enum ImapAuthRes imap_auth_sasl(struct ImapAccountData *adata, const char *metho
 
   if (mutt_sasl_client_new(adata->conn, &saslconn) < 0)
   {
-    mutt_debug(1, "Error allocating SASL connection.\n");
+    mutt_debug(LL_DEBUG1, "Error allocating SASL connection.\n");
     return IMAP_AUTH_FAILURE;
   }
 
@@ -112,7 +112,7 @@ enum ImapAuthRes imap_auth_sasl(struct ImapAccountData *adata, const char *metho
   if (rc != SASL_OK && rc != SASL_CONTINUE)
   {
     if (method)
-      mutt_debug(2, "%s unavailable\n", method);
+      mutt_debug(LL_DEBUG2, "%s unavailable\n", method);
     else
     {
       mutt_debug(
@@ -137,7 +137,7 @@ enum ImapAuthRes imap_auth_sasl(struct ImapAccountData *adata, const char *metho
     buf[len++] = ' ';
     if (sasl_encode64(pc, olen, buf + len, bufsize - len, &olen) != SASL_OK)
     {
-      mutt_debug(1, "#1 error base64-encoding client response.\n");
+      mutt_debug(LL_DEBUG1, "#1 error base64-encoding client response.\n");
       goto bail;
     }
     client_start = false;
@@ -176,7 +176,7 @@ enum ImapAuthRes imap_auth_sasl(struct ImapAccountData *adata, const char *metho
          * include space for the trailing null */
         if (sasl_decode64(adata->buf + 2, len, buf, bufsize - 1, &len) != SASL_OK)
         {
-          mutt_debug(1, "error base64-decoding server response.\n");
+          mutt_debug(LL_DEBUG1, "error base64-decoding server response.\n");
           goto bail;
         }
       }
@@ -207,7 +207,7 @@ enum ImapAuthRes imap_auth_sasl(struct ImapAccountData *adata, const char *metho
       }
       if (sasl_encode64(pc, olen, buf, bufsize, &olen) != SASL_OK)
       {
-        mutt_debug(1, "#2 error base64-encoding client response.\n");
+        mutt_debug(LL_DEBUG1, "#2 error base64-encoding client response.\n");
         goto bail;
       }
     }
@@ -222,7 +222,7 @@ enum ImapAuthRes imap_auth_sasl(struct ImapAccountData *adata, const char *metho
     if (rc < 0)
     {
       mutt_socket_send(adata->conn, "*\r\n");
-      mutt_debug(1, "sasl_client_step error %d\n", rc);
+      mutt_debug(LL_DEBUG1, "sasl_client_step error %d\n", rc);
     }
 
     olen = 0;
@@ -251,7 +251,7 @@ bail:
 
   if (method)
   {
-    mutt_debug(2, "%s failed\n", method);
+    mutt_debug(LL_DEBUG2, "%s failed\n", method);
     return IMAP_AUTH_UNAVAIL;
   }
 

--- a/imap/browse.c
+++ b/imap/browse.c
@@ -237,7 +237,7 @@ int imap_browse(char *path, struct BrowserState *state)
   if (n)
   {
     int rc;
-    mutt_debug(3, "mbox: %s\n", mbox);
+    mutt_debug(LL_DEBUG3, "mbox: %s\n", mbox);
 
     /* if our target exists and has inferiors, enter it if we
      * aren't already going to */
@@ -287,7 +287,7 @@ int imap_browse(char *path, struct BrowserState *state)
 
       if (showparents)
       {
-        mutt_debug(3, "adding parent %s\n", mbox);
+        mutt_debug(LL_DEBUG3, "adding parent %s\n", mbox);
         add_folder(list.delim, mbox, true, false, state, true);
       }
 
@@ -326,10 +326,10 @@ int imap_browse(char *path, struct BrowserState *state)
     state->folder = mutt_str_strdup(buf);
   }
 
-  mutt_debug(3, "Quoting mailbox scan: %s -> ", mbox);
+  mutt_debug(LL_DEBUG3, "Quoting mailbox scan: %s -> ", mbox);
   snprintf(buf, sizeof(buf), "%s%%", mbox);
   imap_munge_mbox_name(adata->unicode, munged_mbox, sizeof(munged_mbox), buf);
-  mutt_debug(3, "%s\n", munged_mbox);
+  mutt_debug(LL_DEBUG3, "%s\n", munged_mbox);
   snprintf(buf, sizeof(buf), "%s \"\" %s", list_cmd, munged_mbox);
   if (browse_add_list_result(adata, buf, state, false))
     goto fail;
@@ -370,7 +370,7 @@ int imap_mailbox_create(const char *path)
 
   if (imap_adata_find(path, &adata, &mdata) < 0)
   {
-    mutt_debug(1, "Couldn't find open connection to %s\n", path);
+    mutt_debug(LL_DEBUG1, "Couldn't find open connection to %s\n", path);
     goto err;
   }
 
@@ -422,7 +422,7 @@ int imap_mailbox_rename(const char *path)
 
   if (imap_adata_find(path, &adata, &mdata) < 0)
   {
-    mutt_debug(1, "Couldn't find open connection to %s\n", path);
+    mutt_debug(LL_DEBUG1, "Couldn't find open connection to %s\n", path);
     return -1;
   }
 

--- a/imap/command.c
+++ b/imap/command.c
@@ -1083,7 +1083,7 @@ int imap_cmd_step(struct ImapAccountData *adata)
     /* back up over '\0' */
     if (len)
       len--;
-    c = mutt_socket_readln(adata->buf + len, adata->blen - len, adata->conn);
+    c = mutt_socket_readln_d(adata->buf + len, adata->blen - len, adata->conn, MUTT_SOCK_LOG_FULL);
     if (c <= 0)
     {
       mutt_debug(1, "Error reading server response.\n");

--- a/imap/command.c
+++ b/imap/command.c
@@ -539,7 +539,7 @@ static void cmd_parse_capability(struct ImapAccountData *adata, char *s)
       if (mutt_str_word_casecmp(Capabilities[i], s) == 0)
       {
         adata->capabilities |= (1 << i);
-        mutt_debug(4, " Found capability \"%s\": %d\n", Capabilities[i], i);
+        mutt_debug(3, " Found capability \"%s\": %d\n", Capabilities[i], i);
         break;
       }
     }

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -111,14 +111,14 @@ static char *get_flags(struct ListHead *hflags, char *s)
   const size_t plen = mutt_str_startswith(s, "FLAGS", CASE_IGNORE);
   if (plen == 0)
   {
-    mutt_debug(1, "not a FLAGS response: %s\n", s);
+    mutt_debug(LL_DEBUG1, "not a FLAGS response: %s\n", s);
     return NULL;
   }
   s += plen;
   SKIPWS(s);
   if (*s != '(')
   {
-    mutt_debug(1, "bogus FLAGS response: %s\n", s);
+    mutt_debug(LL_DEBUG1, "bogus FLAGS response: %s\n", s);
     return NULL;
   }
 
@@ -140,7 +140,7 @@ static char *get_flags(struct ListHead *hflags, char *s)
   /* note bad flags response */
   if (*s != ')')
   {
-    mutt_debug(1, "Unterminated FLAGS response: %s\n", s);
+    mutt_debug(LL_DEBUG1, "Unterminated FLAGS response: %s\n", s);
     mutt_list_free(hflags);
 
     return NULL;
@@ -727,13 +727,13 @@ int imap_read_literal(FILE *fp, struct ImapAccountData *adata,
   if (DebugLevel >= IMAP_LOG_LTRL)
     buf = mutt_buffer_alloc(bytes + 10);
 
-  mutt_debug(2, "reading %ld bytes\n", bytes);
+  mutt_debug(LL_DEBUG2, "reading %ld bytes\n", bytes);
 
   for (unsigned long pos = 0; pos < bytes; pos++)
   {
     if (mutt_socket_readchar(adata->conn, &c) != 1)
     {
-      mutt_debug(1, "error during read, %ld bytes read\n", pos);
+      mutt_debug(LL_DEBUG1, "error during read, %ld bytes read\n", pos);
       adata->status = IMAP_FATAL;
 
       mutt_buffer_free(&buf);
@@ -794,7 +794,7 @@ void imap_expunge_mailbox(struct Mailbox *m)
 
     if (e->index == INT_MAX)
     {
-      mutt_debug(2, "Expunging message UID %u.\n", imap_edata_get(e)->uid);
+      mutt_debug(LL_DEBUG2, "Expunging message UID %u.\n", imap_edata_get(e)->uid);
 
       e->active = false;
       m->size -= e->content->length;
@@ -1219,13 +1219,13 @@ int imap_check_mailbox(struct Mailbox *m, bool force)
     {
       if (imap_cmd_step(adata) != IMAP_CMD_CONTINUE)
       {
-        mutt_debug(1, "Error reading IDLE response\n");
+        mutt_debug(LL_DEBUG1, "Error reading IDLE response\n");
         return -1;
       }
     }
     if (result < 0)
     {
-      mutt_debug(1, "Poll failed, disabling IDLE\n");
+      mutt_debug(LL_DEBUG1, "Poll failed, disabling IDLE\n");
       adata->capabilities &= ~IMAP_CAP_IDLE; // Clear the flag
     }
   }
@@ -1283,7 +1283,7 @@ static int imap_status(struct ImapAccountData *adata, struct ImapMboxData *mdata
     uid_validity_flag = "UID-VALIDITY";
   else
   {
-    mutt_debug(2, "Server doesn't support STATUS\n");
+    mutt_debug(LL_DEBUG2, "Server doesn't support STATUS\n");
     return -1;
   }
 
@@ -1293,7 +1293,7 @@ static int imap_status(struct ImapAccountData *adata, struct ImapMboxData *mdata
   int rc = imap_exec(adata, command, queue ? IMAP_CMD_QUEUE : 0 | IMAP_CMD_POLL);
   if (rc < 0)
   {
-    mutt_debug(1, "Error queueing command\n");
+    mutt_debug(LL_DEBUG1, "Error queueing command\n");
     return rc;
   }
   return mdata->messages;
@@ -1413,7 +1413,7 @@ int imap_subscribe(char *path, bool subscribe)
     len = snprintf(mbox, sizeof(mbox), "%smailboxes ", subscribe ? "" : "un");
     imap_quote_string(mbox + len, sizeof(mbox) - len, path, true);
     if (mutt_parse_rc_line(mbox, &token, &err))
-      mutt_debug(1, "Error adding subscribed mailbox: %s\n", errstr);
+      mutt_debug(LL_DEBUG1, "Error adding subscribed mailbox: %s\n", errstr);
     FREE(&token.data);
   }
 
@@ -1547,7 +1547,7 @@ int imap_fast_trash(struct Mailbox *m, char *dest)
   /* check that the save-to folder is in the same account */
   if (!mutt_account_match(&(adata->conn->account), &(dest_adata->conn->account)))
   {
-    mutt_debug(3, "%s not same server as %s\n", dest, m->path);
+    mutt_debug(LL_DEBUG3, "%s not same server as %s\n", dest, m->path);
     goto out;
   }
 
@@ -1559,7 +1559,7 @@ int imap_fast_trash(struct Mailbox *m, char *dest)
       rc = imap_sync_message_for_copy(m, m->emails[i], sync_cmd, &err_continue);
       if (rc < 0)
       {
-        mutt_debug(1, "could not sync\n");
+        mutt_debug(LL_DEBUG1, "could not sync\n");
         goto out;
       }
     }
@@ -1571,13 +1571,13 @@ int imap_fast_trash(struct Mailbox *m, char *dest)
     rc = imap_exec_msgset(m, "UID COPY", dest_mdata->munge_name, MUTT_TRASH, false, false);
     if (!rc)
     {
-      mutt_debug(1, "No messages to trash\n");
+      mutt_debug(LL_DEBUG1, "No messages to trash\n");
       rc = -1;
       goto out;
     }
     else if (rc < 0)
     {
-      mutt_debug(1, "could not queue copy\n");
+      mutt_debug(LL_DEBUG1, "could not queue copy\n");
       goto out;
     }
     else
@@ -1592,13 +1592,13 @@ int imap_fast_trash(struct Mailbox *m, char *dest)
     {
       if (triedcreate)
       {
-        mutt_debug(1, "Already tried to create mailbox %s\n", dest_mdata->name);
+        mutt_debug(LL_DEBUG1, "Already tried to create mailbox %s\n", dest_mdata->name);
         break;
       }
       /* bail out if command failed for reasons other than nonexistent target */
       if (!mutt_str_startswith(imap_get_qualifier(adata->buf), "[TRYCREATE]", CASE_IGNORE))
         break;
-      mutt_debug(3, "server suggests TRYCREATE\n");
+      mutt_debug(LL_DEBUG3, "server suggests TRYCREATE\n");
       snprintf(prompt, sizeof(prompt), _("Create %s?"), dest_mdata->name);
       if (Confirmcreate && mutt_yesorno(prompt, 1) != MUTT_YES)
       {
@@ -1649,7 +1649,7 @@ int imap_sync_mailbox(struct Mailbox *m, bool expunge, bool close)
 
   if (adata->state < IMAP_SELECTED)
   {
-    mutt_debug(2, "no mailbox selected\n");
+    mutt_debug(LL_DEBUG2, "no mailbox selected\n");
     return -1;
   }
 
@@ -1921,7 +1921,8 @@ int imap_login(struct ImapAccountData *adata)
       adata->state = IMAP_AUTHENTICATED;
       FREE(&adata->capstr);
       if (adata->conn->ssf)
-        mutt_debug(2, "Communication encrypted at %d bits\n", adata->conn->ssf);
+        mutt_debug(LL_DEBUG2, "Communication encrypted at %d bits\n",
+                   adata->conn->ssf);
     }
     else
       mutt_account_unsetpass(&adata->conn->account);
@@ -2037,7 +2038,7 @@ static int imap_mbox_open(struct Mailbox *m)
       /* don't override PERMANENTFLAGS */
       if (STAILQ_EMPTY(&mdata->flags))
       {
-        mutt_debug(3, "Getting mailbox FLAGS\n");
+        mutt_debug(LL_DEBUG3, "Getting mailbox FLAGS\n");
         pc = get_flags(&mdata->flags, pc);
         if (!pc)
           goto fail;
@@ -2046,7 +2047,7 @@ static int imap_mbox_open(struct Mailbox *m)
     /* PERMANENTFLAGS are massaged to look like FLAGS, then override FLAGS */
     else if (mutt_str_startswith(pc, "OK [PERMANENTFLAGS", CASE_IGNORE))
     {
-      mutt_debug(3, "Getting mailbox PERMANENTFLAGS\n");
+      mutt_debug(LL_DEBUG3, "Getting mailbox PERMANENTFLAGS\n");
       /* safe to call on NULL */
       mutt_list_free(&mdata->flags);
       /* skip "OK [PERMANENT" so syntax is the same as FLAGS */
@@ -2058,7 +2059,7 @@ static int imap_mbox_open(struct Mailbox *m)
     /* save UIDVALIDITY for the header cache */
     else if (mutt_str_startswith(pc, "OK [UIDVALIDITY", CASE_IGNORE))
     {
-      mutt_debug(3, "Getting mailbox UIDVALIDITY\n");
+      mutt_debug(LL_DEBUG3, "Getting mailbox UIDVALIDITY\n");
       pc += 3;
       pc = imap_next_word(pc);
       if (mutt_str_atoui(pc, &mdata->uid_validity) < 0)
@@ -2066,7 +2067,7 @@ static int imap_mbox_open(struct Mailbox *m)
     }
     else if (mutt_str_startswith(pc, "OK [UIDNEXT", CASE_IGNORE))
     {
-      mutt_debug(3, "Getting mailbox UIDNEXT\n");
+      mutt_debug(LL_DEBUG3, "Getting mailbox UIDNEXT\n");
       pc += 3;
       pc = imap_next_word(pc);
       if (mutt_str_atoui(pc, &mdata->uid_next) < 0)
@@ -2074,7 +2075,7 @@ static int imap_mbox_open(struct Mailbox *m)
     }
     else if (mutt_str_startswith(pc, "OK [HIGHESTMODSEQ", CASE_IGNORE))
     {
-      mutt_debug(3, "Getting mailbox HIGHESTMODSEQ\n");
+      mutt_debug(LL_DEBUG3, "Getting mailbox HIGHESTMODSEQ\n");
       pc += 3;
       pc = imap_next_word(pc);
       if (mutt_str_atoull(pc, &mdata->modseq) < 0)
@@ -2082,7 +2083,7 @@ static int imap_mbox_open(struct Mailbox *m)
     }
     else if (mutt_str_startswith(pc, "OK [NOMODSEQ", CASE_IGNORE))
     {
-      mutt_debug(3, "Mailbox has NOMODSEQ set\n");
+      mutt_debug(LL_DEBUG3, "Mailbox has NOMODSEQ set\n");
       mdata->modseq = 0;
     }
     else
@@ -2111,7 +2112,7 @@ static int imap_mbox_open(struct Mailbox *m)
   if (mutt_str_startswith(imap_get_qualifier(adata->buf), "[READ-ONLY]", CASE_IGNORE) &&
       !(adata->capabilities & IMAP_CAP_ACL))
   {
-    mutt_debug(2, "Mailbox is read-only.\n");
+    mutt_debug(LL_DEBUG2, "Mailbox is read-only.\n");
     m->readonly = true;
   }
 
@@ -2119,7 +2120,7 @@ static int imap_mbox_open(struct Mailbox *m)
   if (DebugLevel > 2)
   {
     if (STAILQ_EMPTY(&mdata->flags))
-      mutt_debug(3, "No folder flags found\n");
+      mutt_debug(LL_DEBUG3, "No folder flags found\n");
     else
     {
       struct ListNode *np = NULL;
@@ -2130,7 +2131,7 @@ static int imap_mbox_open(struct Mailbox *m)
       {
         mutt_buffer_add_printf(&flag_buffer, "[%s] ", np->data);
       }
-      mutt_debug(3, "%s\n", flag_buffer.data);
+      mutt_debug(LL_DEBUG3, "%s\n", flag_buffer.data);
       FREE(&flag_buffer.data);
     }
   }
@@ -2158,7 +2159,7 @@ static int imap_mbox_open(struct Mailbox *m)
     goto fail;
   }
 
-  mutt_debug(2, "msg_count is %d\n", m->msg_count);
+  mutt_debug(LL_DEBUG2, "msg_count is %d\n", m->msg_count);
   return 0;
 
 fail:
@@ -2395,7 +2396,7 @@ static int imap_tags_commit(struct Mailbox *m, struct Email *e, char *buf)
     cmd = mutt_buffer_new();
     if (!cmd)
     {
-      mutt_debug(1, "unable to allocate buffer\n");
+      mutt_debug(LL_DEBUG1, "unable to allocate buffer\n");
       return -1;
     }
     cmd->dptr = cmd->data;
@@ -2422,7 +2423,7 @@ static int imap_tags_commit(struct Mailbox *m, struct Email *e, char *buf)
     cmd = mutt_buffer_new();
     if (!cmd)
     {
-      mutt_debug(1, "fail to remove old flags\n");
+      mutt_debug(LL_DEBUG1, "fail to remove old flags\n");
       return -1;
     }
     cmd->dptr = cmd->data;
@@ -2434,7 +2435,7 @@ static int imap_tags_commit(struct Mailbox *m, struct Email *e, char *buf)
 
     if (imap_exec(adata, cmd->data, 0) != IMAP_EXEC_SUCCESS)
     {
-      mutt_debug(1, "fail to add new flags\n");
+      mutt_debug(LL_DEBUG1, "fail to add new flags\n");
       mutt_buffer_free(&cmd);
       return -1;
     }
@@ -2443,7 +2444,7 @@ static int imap_tags_commit(struct Mailbox *m, struct Email *e, char *buf)
   }
 
   /* We are good sync them */
-  mutt_debug(1, "NEW TAGS: %s\n", buf);
+  mutt_debug(LL_DEBUG1, "NEW TAGS: %s\n", buf);
   driver_tags_replace(&e->tags, buf);
   FREE(&imap_edata_get(e)->flags_remote);
   imap_edata_get(e)->flags_remote = driver_tags_get_with_hidden(&e->tags);

--- a/imap/imap_private.h
+++ b/imap/imap_private.h
@@ -46,7 +46,7 @@ struct Progress;
 
 /* logging levels */
 #define IMAP_LOG_CMD  2
-#define IMAP_LOG_LTRL 4
+#define IMAP_LOG_LTRL 3
 #define IMAP_LOG_PASS 5
 
 /* IMAP command responses. Used in ImapCommand.state too */

--- a/imap/message.c
+++ b/imap/message.c
@@ -227,14 +227,14 @@ static char *msg_parse_flags(struct ImapHeader *h, char *s)
   size_t plen = mutt_str_startswith(s, "FLAGS", CASE_IGNORE);
   if (plen == 0)
   {
-    mutt_debug(1, "not a FLAGS response: %s\n", s);
+    mutt_debug(LL_DEBUG1, "not a FLAGS response: %s\n", s);
     return NULL;
   }
   s += plen;
   SKIPWS(s);
   if (*s != '(')
   {
-    mutt_debug(1, "bogus FLAGS response: %s\n", s);
+    mutt_debug(LL_DEBUG1, "bogus FLAGS response: %s\n", s);
     return NULL;
   }
   s++;
@@ -309,7 +309,7 @@ static char *msg_parse_flags(struct ImapHeader *h, char *s)
     s++;
   else
   {
-    mutt_debug(1, "Unterminated FLAGS response: %s\n", s);
+    mutt_debug(LL_DEBUG1, "Unterminated FLAGS response: %s\n", s);
     return NULL;
   }
 
@@ -358,7 +358,7 @@ static int msg_parse_fetch(struct ImapHeader *h, char *s)
       SKIPWS(s);
       if (*s != '\"')
       {
-        mutt_debug(1, "bogus INTERNALDATE entry: %s\n", s);
+        mutt_debug(LL_DEBUG1, "bogus INTERNALDATE entry: %s\n", s);
         return -1;
       }
       s++;
@@ -394,7 +394,7 @@ static int msg_parse_fetch(struct ImapHeader *h, char *s)
       SKIPWS(s);
       if (*s != '(')
       {
-        mutt_debug(1, "bogus MODSEQ response: %s\n", s);
+        mutt_debug(LL_DEBUG1, "bogus MODSEQ response: %s\n", s);
         return -1;
       }
       s++;
@@ -404,7 +404,7 @@ static int msg_parse_fetch(struct ImapHeader *h, char *s)
         s++;
       else
       {
-        mutt_debug(1, "Unterminated MODSEQ response: %s\n", s);
+        mutt_debug(LL_DEBUG1, "Unterminated MODSEQ response: %s\n", s);
         return -1;
       }
     }
@@ -750,21 +750,21 @@ static int read_headers_normal_eval_cache(struct ImapAccountData *adata,
 
       if (!h.edata->uid)
       {
-        mutt_debug(2, "skipping hcache FETCH response for message number %d missing a UID\n",
+        mutt_debug(LL_DEBUG2, "skipping hcache FETCH response for message number %d missing a UID\n",
                    h.edata->msn);
         continue;
       }
 
       if ((h.edata->msn < 1) || (h.edata->msn > msn_end))
       {
-        mutt_debug(1, "skipping hcache FETCH response for unknown message number %d\n",
+        mutt_debug(LL_DEBUG1, "skipping hcache FETCH response for unknown message number %d\n",
                    h.edata->msn);
         continue;
       }
 
       if (mdata->msn_index[h.edata->msn - 1])
       {
-        mutt_debug(2, "skipping hcache FETCH for duplicate message %d\n",
+        mutt_debug(LL_DEBUG2, "skipping hcache FETCH for duplicate message %d\n",
                    h.edata->msn);
         continue;
       }
@@ -847,7 +847,7 @@ static int read_headers_qresync_eval_cache(struct ImapAccountData *adata, char *
   int rc;
   unsigned int uid = 0;
 
-  mutt_debug(2, "Reading uid seqset from header cache\n");
+  mutt_debug(LL_DEBUG2, "Reading uid seqset from header cache\n");
   struct Mailbox *m = adata->mailbox;
   struct ImapMboxData *mdata = adata->mailbox->mdata;
   unsigned int msn = 1;
@@ -958,7 +958,8 @@ static int read_headers_condstore_qresync_updates(struct ImapAccountData *adata,
 
     if ((header_msn < 1) || (header_msn > msn_end) || !mdata->msn_index[header_msn - 1])
     {
-      mutt_debug(1, "skipping CONDSTORE flag update for unknown message number %u\n", header_msn);
+      mutt_debug(LL_DEBUG1, "skipping CONDSTORE flag update for unknown message number %u\n",
+                 header_msn);
       continue;
     }
 
@@ -1105,7 +1106,7 @@ static int read_headers_fetch_new(struct Mailbox *m, unsigned int msn_begin,
 
         if (!ftello(fp))
         {
-          mutt_debug(2, "ignoring fetch response with no body\n");
+          mutt_debug(LL_DEBUG2, "ignoring fetch response with no body\n");
           continue;
         }
 
@@ -1114,7 +1115,7 @@ static int read_headers_fetch_new(struct Mailbox *m, unsigned int msn_begin,
 
         if ((h.edata->msn < 1) || (h.edata->msn > fetch_msn_end))
         {
-          mutt_debug(1, "skipping FETCH response for unknown message number %d\n",
+          mutt_debug(LL_DEBUG1, "skipping FETCH response for unknown message number %d\n",
                      h.edata->msn);
           continue;
         }
@@ -1122,7 +1123,7 @@ static int read_headers_fetch_new(struct Mailbox *m, unsigned int msn_begin,
         /* May receive FLAGS updates in a separate untagged response (#2935) */
         if (mdata->msn_index[h.edata->msn - 1])
         {
-          mutt_debug(2, "skipping FETCH response for duplicate message %d\n",
+          mutt_debug(LL_DEBUG2, "skipping FETCH response for duplicate message %d\n",
                      h.edata->msn);
           continue;
         }
@@ -1351,7 +1352,7 @@ int imap_read_headers(struct Mailbox *m, unsigned int msn_begin,
                         sizeof(mdata->uid_validity));
   if (maxuid && mdata->uid_next < maxuid + 1)
   {
-    mutt_debug(2, "Overriding UIDNEXT: %u -> %u\n", mdata->uid_next, maxuid + 1);
+    mutt_debug(LL_DEBUG2, "Overriding UIDNEXT: %u -> %u\n", mdata->uid_next, maxuid + 1);
     mdata->uid_next = maxuid + 1;
   }
   if (mdata->uid_next > 1)
@@ -1477,7 +1478,7 @@ int imap_append_message(struct Mailbox *m, struct Message *msg)
 
   if (rc != IMAP_CMD_RESPOND)
   {
-    mutt_debug(1, "#1 command failed: %s\n", adata->buf);
+    mutt_debug(LL_DEBUG1, "#1 command failed: %s\n", adata->buf);
 
     char *pc = adata->buf + SEQLEN;
     SKIPWS(pc);
@@ -1514,7 +1515,7 @@ int imap_append_message(struct Mailbox *m, struct Message *msg)
 
   if (!imap_code(adata->buf))
   {
-    mutt_debug(1, "#2 command failed: %s\n", adata->buf);
+    mutt_debug(LL_DEBUG1, "#2 command failed: %s\n", adata->buf);
     char *pc = adata->buf + SEQLEN;
     SKIPWS(pc);
     pc = imap_next_word(pc);
@@ -1558,20 +1559,20 @@ int imap_copy_messages(struct Mailbox *m, struct EmailList *el, char *dest, bool
 
   if (single && en->email->attach_del)
   {
-    mutt_debug(3, "#1 Message contains attachments to be deleted\n");
+    mutt_debug(LL_DEBUG3, "#1 Message contains attachments to be deleted\n");
     return 1;
   }
 
   if (imap_parse_path(dest, &conn_account, buf, sizeof(buf)))
   {
-    mutt_debug(1, "bad destination %s\n", dest);
+    mutt_debug(LL_DEBUG1, "bad destination %s\n", dest);
     return -1;
   }
 
   /* check that the save-to folder is in the same account */
   if (!mutt_account_match(&adata->conn->account, &conn_account))
   {
-    mutt_debug(3, "%s not same server as %s\n", dest, m->path);
+    mutt_debug(LL_DEBUG3, "%s not same server as %s\n", dest, m->path);
     return 1;
   }
 
@@ -1596,7 +1597,8 @@ int imap_copy_messages(struct Mailbox *m, struct EmailList *el, char *dest, bool
       {
         if (en->email->attach_del)
         {
-          mutt_debug(3, "#2 Message contains attachments to be deleted\n");
+          mutt_debug(LL_DEBUG3,
+                     "#2 Message contains attachments to be deleted\n");
           return 1;
         }
 
@@ -1605,7 +1607,7 @@ int imap_copy_messages(struct Mailbox *m, struct EmailList *el, char *dest, bool
           rc = imap_sync_message_for_copy(m, en->email, &sync_cmd, &err_continue);
           if (rc < 0)
           {
-            mutt_debug(1, "#1 could not sync\n");
+            mutt_debug(LL_DEBUG1, "#1 could not sync\n");
             goto out;
           }
         }
@@ -1614,13 +1616,13 @@ int imap_copy_messages(struct Mailbox *m, struct EmailList *el, char *dest, bool
       rc = imap_exec_msgset(m, "UID COPY", mmbox, MUTT_TAG, false, false);
       if (!rc)
       {
-        mutt_debug(1, "No messages tagged\n");
+        mutt_debug(LL_DEBUG1, "No messages tagged\n");
         rc = -1;
         goto out;
       }
       else if (rc < 0)
       {
-        mutt_debug(1, "#1 could not queue copy\n");
+        mutt_debug(LL_DEBUG1, "#1 could not queue copy\n");
         goto out;
       }
       else
@@ -1639,14 +1641,14 @@ int imap_copy_messages(struct Mailbox *m, struct EmailList *el, char *dest, bool
         rc = imap_sync_message_for_copy(m, en->email, &sync_cmd, &err_continue);
         if (rc < 0)
         {
-          mutt_debug(1, "#2 could not sync\n");
+          mutt_debug(LL_DEBUG1, "#2 could not sync\n");
           goto out;
         }
       }
       rc = imap_exec(adata, cmd.data, IMAP_CMD_QUEUE);
       if (rc != IMAP_EXEC_SUCCESS)
       {
-        mutt_debug(1, "#2 could not queue copy\n");
+        mutt_debug(LL_DEBUG1, "#2 could not queue copy\n");
         goto out;
       }
     }
@@ -1657,13 +1659,13 @@ int imap_copy_messages(struct Mailbox *m, struct EmailList *el, char *dest, bool
     {
       if (triedcreate)
       {
-        mutt_debug(1, "Already tried to create mailbox %s\n", mbox);
+        mutt_debug(LL_DEBUG1, "Already tried to create mailbox %s\n", mbox);
         break;
       }
       /* bail out if command failed for reasons other than nonexistent target */
       if (!mutt_str_startswith(imap_get_qualifier(adata->buf), "[TRYCREATE]", CASE_IGNORE))
         break;
-      mutt_debug(3, "server suggests TRYCREATE\n");
+      mutt_debug(LL_DEBUG3, "server suggests TRYCREATE\n");
       snprintf(prompt, sizeof(prompt), _("Create %s?"), mbox);
       if (Confirmcreate && mutt_yesorno(prompt, 1) != MUTT_YES)
       {
@@ -1781,7 +1783,7 @@ char *imap_set_flags(struct Mailbox *m, struct Email *e, char *s, bool *server_c
 
   memcpy(&old_edata, edata, sizeof(old_edata));
 
-  mutt_debug(2, "parsing FLAGS\n");
+  mutt_debug(LL_DEBUG2, "parsing FLAGS\n");
   s = msg_parse_flags(&newh, s);
   if (!s)
     return NULL;

--- a/imap/util.c
+++ b/imap/util.c
@@ -156,7 +156,7 @@ int imap_adata_find(const char *path, struct ImapAccountData **adata,
       return 0;
     }
   }
-  mutt_debug(3, "no ImapAccountData found\n");
+  mutt_debug(LL_DEBUG3, "no ImapAccountData found\n");
   return -1;
 }
 
@@ -195,7 +195,7 @@ struct ImapMboxData *imap_mdata_new(struct ImapAccountData *adata, const char *n
       mdata->uid_validity = *(unsigned int *) uidvalidity;
       mdata->uid_next = uidnext ? *(unsigned int *) uidnext : 0;
       mdata->modseq = modseq ? *modseq : 0;
-      mutt_debug(3, "hcache uidvalidity %u, uidnext %u, modseq %llu\n",
+      mutt_debug(LL_DEBUG3, "hcache uidvalidity %u, uidnext %u, modseq %llu\n",
                  mdata->uid_validity, mdata->uid_next, mdata->modseq);
     }
     mutt_hcache_free(hc, &uidvalidity);
@@ -476,7 +476,7 @@ struct Email *imap_hcache_get(struct ImapMboxData *mdata, unsigned int uid)
     if (*(unsigned int *) uv == mdata->uid_validity)
       e = mutt_hcache_restore(uv);
     else
-      mutt_debug(3, "hcache uidvalidity mismatch: %u\n", *(unsigned int *) uv);
+      mutt_debug(LL_DEBUG3, "hcache uidvalidity mismatch: %u\n", *(unsigned int *) uv);
     mutt_hcache_free(mdata->hcache, &uv);
   }
 
@@ -540,7 +540,7 @@ int imap_hcache_store_uid_seqset(struct ImapMboxData *mdata)
     b->data[0] = '\0';
 
   int rc = mutt_hcache_store_raw(mdata->hcache, "/UIDSEQSET", 10, b->data, seqset_size + 1);
-  mutt_debug(3, "Stored /UIDSEQSET %s\n", b->data);
+  mutt_debug(LL_DEBUG3, "Stored /UIDSEQSET %s\n", b->data);
   mutt_buffer_free(&b);
   return rc;
 }
@@ -573,7 +573,7 @@ char *imap_hcache_get_uid_seqset(struct ImapMboxData *mdata)
   char *hc_seqset = mutt_hcache_fetch_raw(mdata->hcache, "/UIDSEQSET", 10);
   char *seqset = mutt_str_strdup(hc_seqset);
   mutt_hcache_free(mdata->hcache, (void **) &hc_seqset);
-  mutt_debug(3, "Retrieved /UIDSEQSET %s\n", NONULL(seqset));
+  mutt_debug(LL_DEBUG3, "Retrieved /UIDSEQSET %s\n", NONULL(seqset));
 
   return seqset;
 }
@@ -604,7 +604,7 @@ int imap_parse_path(const char *path, struct ConnAccount *account, char *mailbox
       ImapPort = ntohs(service->s_port);
     else
       ImapPort = IMAP_PORT;
-    mutt_debug(3, "Using default IMAP port %d\n", ImapPort);
+    mutt_debug(LL_DEBUG3, "Using default IMAP port %d\n", ImapPort);
   }
   if (!ImapsPort)
   {
@@ -613,7 +613,7 @@ int imap_parse_path(const char *path, struct ConnAccount *account, char *mailbox
       ImapsPort = ntohs(service->s_port);
     else
       ImapsPort = IMAP_SSL_PORT;
-    mutt_debug(3, "Using default IMAPS port %d\n", ImapsPort);
+    mutt_debug(LL_DEBUG3, "Using default IMAPS port %d\n", ImapsPort);
   }
 
   /* Defaults */

--- a/imap/util.c
+++ b/imap/util.c
@@ -540,7 +540,7 @@ int imap_hcache_store_uid_seqset(struct ImapMboxData *mdata)
     b->data[0] = '\0';
 
   int rc = mutt_hcache_store_raw(mdata->hcache, "/UIDSEQSET", 10, b->data, seqset_size + 1);
-  mutt_debug(5, "Stored /UIDSEQSET %s\n", b->data);
+  mutt_debug(3, "Stored /UIDSEQSET %s\n", b->data);
   mutt_buffer_free(&b);
   return rc;
 }
@@ -573,7 +573,7 @@ char *imap_hcache_get_uid_seqset(struct ImapMboxData *mdata)
   char *hc_seqset = mutt_hcache_fetch_raw(mdata->hcache, "/UIDSEQSET", 10);
   char *seqset = mutt_str_strdup(hc_seqset);
   mutt_hcache_free(mdata->hcache, (void **) &hc_seqset);
-  mutt_debug(5, "Retrieved /UIDSEQSET %s\n", NONULL(seqset));
+  mutt_debug(3, "Retrieved /UIDSEQSET %s\n", NONULL(seqset));
 
   return seqset;
 }

--- a/index.c
+++ b/index.c
@@ -1224,7 +1224,7 @@ int mutt_index_menu(void)
 
       op = km_dokey(MENU_MAIN);
 
-      mutt_debug(3, "[%d]: Got op %d\n", __LINE__, op);
+      mutt_debug(LL_DEBUG3, "[%d]: Got op %d\n", __LINE__, op);
 
       /* either user abort or timeout */
       if (op < 0)
@@ -2132,7 +2132,7 @@ int mutt_index_menu(void)
       case OP_MAIN_WINDOWED_VFOLDER_BACKWARD:
         if (!prereq(Context, menu, CHECK_IN_MAILBOX))
           break;
-        mutt_debug(2, "OP_MAIN_WINDOWED_VFOLDER_BACKWARD\n");
+        mutt_debug(LL_DEBUG2, "OP_MAIN_WINDOWED_VFOLDER_BACKWARD\n");
         if (NmQueryWindowDuration <= 0)
         {
           mutt_message(_("Windowed queries disabled"));
@@ -2170,7 +2170,7 @@ int mutt_index_menu(void)
           mutt_message(_("Failed to create query, aborting"));
         else
         {
-          mutt_debug(2, "nm: + windowed query (%s)\n", buf);
+          mutt_debug(LL_DEBUG2, "nm: + windowed query (%s)\n", buf);
           main_change_folder(menu, op, NULL, buf, sizeof(buf), &oldcount, &index_hint);
         }
         break;
@@ -3349,7 +3349,7 @@ int mutt_index_menu(void)
                by whatever they typed at the prompt.) */
             snprintf(buf2, sizeof(buf2), _("Message bound to %s"), str);
             mutt_message(buf2);
-            mutt_debug(1, "Mark: %s => %s\n", str, macro);
+            mutt_debug(LL_DEBUG1, "Mark: %s => %s\n", str, macro);
           }
         }
         else

--- a/index.c
+++ b/index.c
@@ -1224,7 +1224,7 @@ int mutt_index_menu(void)
 
       op = km_dokey(MENU_MAIN);
 
-      mutt_debug(4, "[%d]: Got op %d\n", __LINE__, op);
+      mutt_debug(3, "[%d]: Got op %d\n", __LINE__, op);
 
       /* either user abort or timeout */
       if (op < 0)

--- a/init.c
+++ b/init.c
@@ -521,7 +521,7 @@ static enum CommandResult parse_attach_list(struct Buffer *buf, struct Buffer *s
       return MUTT_CMD_ERROR;
     }
 
-    mutt_debug(5, "added %s/%s [%d]\n", a->major, a->minor, a->major_int);
+    mutt_debug(3, "added %s/%s [%d]\n", a->major, a->minor, a->major_int);
 
     mutt_list_insert_tail(head, (char *) a);
   } while (MoreArgs(s));
@@ -648,11 +648,11 @@ static enum CommandResult parse_unattach_list(struct Buffer *buf, struct Buffer 
     STAILQ_FOREACH_SAFE(np, head, entries, tmp2)
     {
       a = (struct AttachMatch *) np->data;
-      mutt_debug(5, "check %s/%s [%d] : %s/%s [%d]\n", a->major, a->minor,
+      mutt_debug(3, "check %s/%s [%d] : %s/%s [%d]\n", a->major, a->minor,
                  a->major_int, tmp, minor, major);
       if (a->major_int == major && (mutt_str_strcasecmp(minor, a->minor) == 0))
       {
-        mutt_debug(5, "removed %s/%s [%d]\n", a->major, a->minor, a->major_int);
+        mutt_debug(3, "removed %s/%s [%d]\n", a->major, a->minor, a->major_int);
         regfree(&a->minor_regex);
         FREE(&a->major);
         STAILQ_REMOVE(head, np, ListNode, entries);
@@ -934,7 +934,7 @@ static enum CommandResult parse_alias(struct Buffer *buf, struct Buffer *s,
   }
 
   mutt_extract_token(buf, s, MUTT_TOKEN_QUOTE | MUTT_TOKEN_SPACE | MUTT_TOKEN_SEMICOLON);
-  mutt_debug(3, "Second token is '%s'.\n", buf->data);
+  mutt_debug(5, "Second token is '%s'.\n", buf->data);
 
   tmp->addr = mutt_addr_parse_list2(tmp->addr, buf->data);
 
@@ -954,9 +954,9 @@ static enum CommandResult parse_alias(struct Buffer *buf, struct Buffer *s,
     for (struct Address *a = tmp->addr; a && a->mailbox; a = a->next)
     {
       if (!a->group)
-        mutt_debug(3, "  %s\n", a->mailbox);
+        mutt_debug(5, "  %s\n", a->mailbox);
       else
-        mutt_debug(3, "  Group %s\n", a->mailbox);
+        mutt_debug(5, "  Group %s\n", a->mailbox);
     }
   }
   mutt_grouplist_destroy(&gc);
@@ -2128,7 +2128,7 @@ static enum CommandResult parse_subscribe_to(struct Buffer *buf, struct Buffer *
     }
     else
     {
-      mutt_debug(5, "Corrupted buffer");
+      mutt_debug(1, "Corrupted buffer");
       return MUTT_CMD_ERROR;
     }
   }
@@ -2582,7 +2582,7 @@ static enum CommandResult parse_unsubscribe_from(struct Buffer *buf, struct Buff
     }
     else
     {
-      mutt_debug(5, "Corrupted buffer");
+      mutt_debug(1, "Corrupted buffer");
       return MUTT_CMD_ERROR;
     }
   }

--- a/init.c
+++ b/init.c
@@ -521,7 +521,7 @@ static enum CommandResult parse_attach_list(struct Buffer *buf, struct Buffer *s
       return MUTT_CMD_ERROR;
     }
 
-    mutt_debug(3, "added %s/%s [%d]\n", a->major, a->minor, a->major_int);
+    mutt_debug(LL_DEBUG3, "added %s/%s [%d]\n", a->major, a->minor, a->major_int);
 
     mutt_list_insert_tail(head, (char *) a);
   } while (MoreArgs(s));
@@ -648,11 +648,11 @@ static enum CommandResult parse_unattach_list(struct Buffer *buf, struct Buffer 
     STAILQ_FOREACH_SAFE(np, head, entries, tmp2)
     {
       a = (struct AttachMatch *) np->data;
-      mutt_debug(3, "check %s/%s [%d] : %s/%s [%d]\n", a->major, a->minor,
-                 a->major_int, tmp, minor, major);
+      mutt_debug(LL_DEBUG3, "check %s/%s [%d] : %s/%s [%d]\n", a->major,
+                 a->minor, a->major_int, tmp, minor, major);
       if (a->major_int == major && (mutt_str_strcasecmp(minor, a->minor) == 0))
       {
-        mutt_debug(3, "removed %s/%s [%d]\n", a->major, a->minor, a->major_int);
+        mutt_debug(LL_DEBUG3, "removed %s/%s [%d]\n", a->major, a->minor, a->major_int);
         regfree(&a->minor_regex);
         FREE(&a->major);
         STAILQ_REMOVE(head, np, ListNode, entries);
@@ -799,7 +799,7 @@ static int source_rc(const char *rcfile_path, struct Buffer *err)
     }
   }
 
-  mutt_debug(2, "Reading configuration file '%s'.\n", rcfile);
+  mutt_debug(LL_DEBUG2, "Reading configuration file '%s'.\n", rcfile);
 
   f = mutt_open_read(rcfile, &pid);
   if (!f)
@@ -2128,7 +2128,7 @@ static enum CommandResult parse_subscribe_to(struct Buffer *buf, struct Buffer *
     }
     else
     {
-      mutt_debug(1, "Corrupted buffer");
+      mutt_debug(LL_DEBUG1, "Corrupted buffer");
       return MUTT_CMD_ERROR;
     }
   }
@@ -2166,7 +2166,7 @@ static enum CommandResult parse_tag_formats(struct Buffer *buf, struct Buffer *s
     tmp = mutt_hash_find(TagFormats, format);
     if (tmp)
     {
-      mutt_debug(3, "tag format '%s' already registered as '%s'\n", format, tmp);
+      mutt_debug(LL_DEBUG3, "tag format '%s' already registered as '%s'\n", format, tmp);
       FREE(&tag);
       FREE(&format);
       continue;
@@ -2205,7 +2205,7 @@ static enum CommandResult parse_tag_transforms(struct Buffer *buf, struct Buffer
     tmp = mutt_hash_find(TagTransforms, tag);
     if (tmp)
     {
-      mutt_debug(3, "tag transform '%s' already registered as '%s'\n", tag, tmp);
+      mutt_debug(LL_DEBUG3, "tag transform '%s' already registered as '%s'\n", tag, tmp);
       FREE(&tag);
       FREE(&transform);
       continue;
@@ -2582,7 +2582,7 @@ static enum CommandResult parse_unsubscribe_from(struct Buffer *buf, struct Buff
     }
     else
     {
-      mutt_debug(1, "Corrupted buffer");
+      mutt_debug(LL_DEBUG1, "Corrupted buffer");
       return MUTT_CMD_ERROR;
     }
   }
@@ -2789,7 +2789,7 @@ int mutt_extract_token(struct Buffer *dest, struct Buffer *tok, int flags)
       } while (pc && *pc != '`');
       if (!pc)
       {
-        mutt_debug(1, "mismatched backticks\n");
+        mutt_debug(LL_DEBUG1, "mismatched backticks\n");
         return -1;
       }
       struct Buffer cmd;
@@ -2810,7 +2810,7 @@ int mutt_extract_token(struct Buffer *dest, struct Buffer *tok, int flags)
       pid = mutt_create_filter(cmd.data, NULL, &fp, NULL);
       if (pid < 0)
       {
-        mutt_debug(1, "unable to fork command: %s\n", cmd);
+        mutt_debug(LL_DEBUG1, "unable to fork command: %s\n", cmd);
         FREE(&cmd.data);
         return -1;
       }

--- a/maildir/maildir.c
+++ b/maildir/maildir.c
@@ -240,7 +240,7 @@ int maildir_sync_message(struct Mailbox *m, int msgno)
     char *p = strrchr(e->path, '/');
     if (!p)
     {
-      mutt_debug(1, "%s: unable to find subdir!\n", e->path);
+      mutt_debug(LL_DEBUG1, "%s: unable to find subdir!\n", e->path);
       return -1;
     }
     p++;
@@ -615,7 +615,7 @@ int maildir_msg_open_new(struct Mailbox *m, struct Message *msg, struct Email *e
     snprintf(path, sizeof(path), "%s/tmp/%s.%lld.R%" PRIu64 ".%s%s", m->path, subdir,
              (long long) time(NULL), mutt_rand64(), NONULL(ShortHostname), suffix);
 
-    mutt_debug(2, "Trying %s.\n", path);
+    mutt_debug(LL_DEBUG2, "Trying %s.\n", path);
 
     fd = open(path, O_WRONLY | O_EXCL | O_CREAT, 0666);
     if (fd == -1)
@@ -629,7 +629,7 @@ int maildir_msg_open_new(struct Mailbox *m, struct Message *msg, struct Email *e
     }
     else
     {
-      mutt_debug(2, "Success.\n");
+      mutt_debug(LL_DEBUG2, "Success.\n");
       msg->path = mutt_str_strdup(path);
       break;
     }

--- a/maildir/shared.c
+++ b/maildir/shared.c
@@ -128,7 +128,7 @@ mode_t mh_umask(struct Mailbox *m)
   struct stat st;
   if (stat(m->path, &st))
   {
-    mutt_debug(1, "stat failed on %s\n", m->path);
+    mutt_debug(LL_DEBUG1, "stat failed on %s\n", m->path);
     return 077;
   }
 
@@ -370,7 +370,7 @@ int maildir_parse_dir(struct Mailbox *m, struct Maildir ***last,
     }
 
     /* FOO - really ignore the return value? */
-    mutt_debug(2, "queueing %s\n", de->d_name);
+    mutt_debug(LL_DEBUG2, "queueing %s\n", de->d_name);
 
     e = mutt_email_new();
     e->old = is_old;
@@ -438,11 +438,11 @@ static int maildir_add_to_context(struct Mailbox *m, struct Maildir *md)
 
   while (md)
   {
-    mutt_debug(2, "Considering %s\n", NONULL(md->canon_fname));
+    mutt_debug(LL_DEBUG2, "Considering %s\n", NONULL(md->canon_fname));
 
     if (md->email)
     {
-      mutt_debug(2, "Adding header structure. Flags: %s%s%s%s%s\n",
+      mutt_debug(LL_DEBUG2, "Adding header structure. Flags: %s%s%s%s%s\n",
                  md->email->flagged ? "f" : "", md->email->deleted ? "D" : "",
                  md->email->replied ? "r" : "", md->email->old ? "O" : "",
                  md->email->read ? "R" : "");
@@ -668,7 +668,7 @@ static void mh_sort_natural(struct Mailbox *m, struct Maildir **md)
 {
   if (!m || !md || !*md || (m->magic != MUTT_MH) || (Sort != SORT_ORDER))
     return;
-  mutt_debug(3, "maildir: sorting %s into natural order\n", m->path);
+  mutt_debug(LL_DEBUG3, "maildir: sorting %s into natural order\n", m->path);
   *md = maildir_sort(*md, (size_t) -1, md_cmp_path);
 }
 
@@ -733,7 +733,7 @@ void maildir_delayed_parsing(struct Mailbox *m, struct Maildir **md, struct Prog
 
     if (!sort)
     {
-      mutt_debug(3, "maildir: need to sort %s by inode\n", m->path);
+      mutt_debug(LL_DEBUG3, "maildir: need to sort %s by inode\n", m->path);
       p = maildir_sort(p, (size_t) -1, md_cmp_inode);
       if (!last)
         *md = p;
@@ -906,7 +906,7 @@ int maildir_mh_open_message(struct Mailbox *m, struct Message *msg, int msgno, b
   if (!msg->fp)
   {
     mutt_perror(path);
-    mutt_debug(1, "fopen: %s: %s (errno %d).\n", path, strerror(errno), errno);
+    mutt_debug(LL_DEBUG1, "fopen: %s: %s (errno %d).\n", path, strerror(errno), errno);
     return -1;
   }
 
@@ -1052,7 +1052,7 @@ int md_commit_message(struct Mailbox *m, struct Message *msg, struct Email *e)
                        mutt_rand64(), NONULL(ShortHostname), suffix);
     mutt_buffer_printf(full, "%s/%s", m->path, mutt_b2s(path));
 
-    mutt_debug(2, "renaming %s to %s.\n", msg->path, mutt_b2s(full));
+    mutt_debug(LL_DEBUG2, "renaming %s to %s.\n", msg->path, mutt_b2s(full));
 
     if (mutt_file_safe_rename(msg->path, mutt_b2s(full)) == 0)
     {

--- a/maildir/shared.c
+++ b/maildir/shared.c
@@ -668,7 +668,7 @@ static void mh_sort_natural(struct Mailbox *m, struct Maildir **md)
 {
   if (!m || !md || !*md || (m->magic != MUTT_MH) || (Sort != SORT_ORDER))
     return;
-  mutt_debug(4, "maildir: sorting %s into natural order\n", m->path);
+  mutt_debug(3, "maildir: sorting %s into natural order\n", m->path);
   *md = maildir_sort(*md, (size_t) -1, md_cmp_path);
 }
 
@@ -733,7 +733,7 @@ void maildir_delayed_parsing(struct Mailbox *m, struct Maildir **md, struct Prog
 
     if (!sort)
     {
-      mutt_debug(4, "maildir: need to sort %s by inode\n", m->path);
+      mutt_debug(3, "maildir: need to sort %s by inode\n", m->path);
       p = maildir_sort(p, (size_t) -1, md_cmp_inode);
       if (!last)
         *md = p;

--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -244,7 +244,7 @@ static int mmdf_parse_mailbox(struct Mailbox *m)
       if (!fgets(buf, sizeof(buf) - 1, adata->fp))
       {
         /* TODO: memory leak??? */
-        mutt_debug(1, "unexpected EOF\n");
+        mutt_debug(LL_DEBUG1, "unexpected EOF\n");
         break;
       }
 
@@ -254,7 +254,7 @@ static int mmdf_parse_mailbox(struct Mailbox *m)
       {
         if (fseeko(adata->fp, loc, SEEK_SET) != 0)
         {
-          mutt_debug(1, "#1 fseek() failed\n");
+          mutt_debug(LL_DEBUG1, "#1 fseek() failed\n");
           mutt_error(_("Mailbox is corrupt"));
           return -1;
         }
@@ -279,7 +279,7 @@ static int mmdf_parse_mailbox(struct Mailbox *m)
               (mutt_str_strcmp(MMDF_SEP, buf) != 0))
           {
             if (fseeko(adata->fp, loc, SEEK_SET) != 0)
-              mutt_debug(1, "#2 fseek() failed\n");
+              mutt_debug(LL_DEBUG1, "#2 fseek() failed\n");
             e->content->length = -1;
           }
         }
@@ -316,7 +316,7 @@ static int mmdf_parse_mailbox(struct Mailbox *m)
     }
     else
     {
-      mutt_debug(1, "corrupt mailbox\n");
+      mutt_debug(LL_DEBUG1, "corrupt mailbox\n");
       mutt_error(_("Mailbox is corrupt"));
       return -1;
     }
@@ -456,13 +456,13 @@ static int mbox_parse_mailbox(struct Mailbox *m)
               !fgets(buf, sizeof(buf), adata->fp) ||
               !mutt_str_startswith(buf, "From ", CASE_MATCH))
           {
-            mutt_debug(1, "bad content-length in message %d (cl=" OFF_T_FMT ")\n",
+            mutt_debug(LL_DEBUG1, "bad content-length in message %d (cl=" OFF_T_FMT ")\n",
                        e_cur->index, e_cur->content->length);
-            mutt_debug(1, "\tLINE: %s", buf);
+            mutt_debug(LL_DEBUG1, "\tLINE: %s", buf);
             /* nope, return the previous position */
             if ((loc < 0) || (fseeko(adata->fp, loc, SEEK_SET) != 0))
             {
-              mutt_debug(1, "#1 fseek() failed\n");
+              mutt_debug(LL_DEBUG1, "#1 fseek() failed\n");
             }
             e_cur->content->length = -1;
           }
@@ -486,7 +486,7 @@ static int mbox_parse_mailbox(struct Mailbox *m)
 
             /* count the number of lines in this message */
             if ((loc < 0) || (fseeko(adata->fp, loc, SEEK_SET) != 0))
-              mutt_debug(1, "#2 fseek() failed\n");
+              mutt_debug(LL_DEBUG1, "#2 fseek() failed\n");
             while (cl-- > 0)
             {
               if (fgetc(adata->fp) == '\n')
@@ -496,7 +496,7 @@ static int mbox_parse_mailbox(struct Mailbox *m)
 
           /* return to the offset of the next message separator */
           if (fseeko(adata->fp, tmploc, SEEK_SET) != 0)
-            mutt_debug(1, "#3 fseek() failed\n");
+            mutt_debug(LL_DEBUG1, "#3 fseek() failed\n");
         }
       }
 
@@ -1056,14 +1056,14 @@ static int mbox_mbox_check(struct Mailbox *m, int *index_hint)
        */
       char buffer[LONG_STRING];
       if (fseeko(adata->fp, m->size, SEEK_SET) != 0)
-        mutt_debug(1, "#1 fseek() failed\n");
+        mutt_debug(LL_DEBUG1, "#1 fseek() failed\n");
       if (fgets(buffer, sizeof(buffer), adata->fp))
       {
         if ((m->magic == MUTT_MBOX && mutt_str_startswith(buffer, "From ", CASE_MATCH)) ||
             (m->magic == MUTT_MMDF && (mutt_str_strcmp(buffer, MMDF_SEP) == 0)))
         {
           if (fseeko(adata->fp, m->size, SEEK_SET) != 0)
-            mutt_debug(1, "#2 fseek() failed\n");
+            mutt_debug(LL_DEBUG1, "#2 fseek() failed\n");
 
           int old_msg_count = m->msg_count;
           if (m->magic == MUTT_MBOX)
@@ -1090,7 +1090,7 @@ static int mbox_mbox_check(struct Mailbox *m, int *index_hint)
       }
       else
       {
-        mutt_debug(1, "fgets returned NULL.\n");
+        mutt_debug(LL_DEBUG1, "fgets returned NULL.\n");
         modified = true;
       }
     }
@@ -1221,7 +1221,7 @@ static int mbox_mbox_sync(struct Mailbox *m, int *index_hint)
      */
     mutt_error(
         _("sync: mbox modified, but no modified messages (report this bug)"));
-    mutt_debug(1, "no modified messages.\n");
+    mutt_debug(LL_DEBUG1, "no modified messages.\n");
     unlink(tempfile);
     goto bail;
   }
@@ -1322,7 +1322,7 @@ static int mbox_mbox_sync(struct Mailbox *m, int *index_hint)
   if (fclose(fp) != 0)
   {
     fp = NULL;
-    mutt_debug(1, "mutt_file_fclose (&) returned non-zero.\n");
+    mutt_debug(LL_DEBUG1, "mutt_file_fclose (&) returned non-zero.\n");
     unlink(tempfile);
     mutt_perror(tempfile);
     goto bail;
@@ -1342,7 +1342,7 @@ static int mbox_mbox_sync(struct Mailbox *m, int *index_hint)
   {
     mutt_sig_unblock();
     mx_fastclose_mailbox(m);
-    mutt_debug(1, "unable to reopen temp copy of mailbox!\n");
+    mutt_debug(LL_DEBUG1, "unable to reopen temp copy of mailbox!\n");
     mutt_perror(tempfile);
     FREE(&new_offset);
     FREE(&old_offset);
@@ -1355,8 +1355,8 @@ static int mbox_mbox_sync(struct Mailbox *m, int *index_hint)
       (m->magic == MUTT_MBOX && !mutt_str_startswith(buf, "From ", CASE_MATCH)) ||
       (m->magic == MUTT_MMDF && (mutt_str_strcmp(MMDF_SEP, buf) != 0)))
   {
-    mutt_debug(1, "message not in expected position.\n");
-    mutt_debug(1, "\tLINE: %s\n", buf);
+    mutt_debug(LL_DEBUG1, "message not in expected position.\n");
+    mutt_debug(LL_DEBUG1, "\tLINE: %s\n", buf);
     i = -1;
   }
   else
@@ -1364,7 +1364,7 @@ static int mbox_mbox_sync(struct Mailbox *m, int *index_hint)
     if (fseeko(adata->fp, offset, SEEK_SET) != 0) /* return to proper offset */
     {
       i = -1;
-      mutt_debug(1, "fseek() failed\n");
+      mutt_debug(LL_DEBUG1, "fseek() failed\n");
     }
     else
     {
@@ -1384,7 +1384,7 @@ static int mbox_mbox_sync(struct Mailbox *m, int *index_hint)
       if ((m->size < 0) || (ftruncate(fileno(adata->fp), m->size) != 0))
       {
         i = -1;
-        mutt_debug(1, "ftruncate() failed\n");
+        mutt_debug(LL_DEBUG1, "ftruncate() failed\n");
       }
     }
   }

--- a/menu.c
+++ b/menu.c
@@ -1051,7 +1051,7 @@ void mutt_menu_pop_current(struct Menu *menu)
 
   if (!MenuStackCount || (MenuStack[MenuStackCount - 1] != menu))
   {
-    mutt_debug(1, "called with inactive menu\n");
+    mutt_debug(LL_DEBUG1, "called with inactive menu\n");
     return;
   }
 

--- a/monitor.c
+++ b/monitor.c
@@ -409,7 +409,7 @@ int mutt_monitor_poll(void)
               while (ptr < (buf + len))
               {
                 event = (const struct inotify_event *) ptr;
-                mutt_debug(5, "+ detail: descriptor=%d mask=0x%x\n", event->wd,
+                mutt_debug(3, "+ detail: descriptor=%d mask=0x%x\n", event->wd,
                            event->mask);
                 if (event->mask & IN_IGNORED)
                   monitor_handle_ignore(event->wd);

--- a/monitor.c
+++ b/monitor.c
@@ -153,7 +153,7 @@ static int monitor_init(void)
     INotifyFd = inotify_init1(IN_NONBLOCK | IN_CLOEXEC);
     if (INotifyFd == -1)
     {
-      mutt_debug(2, "inotify_init1 failed, errno=%d %s\n", errno, strerror(errno));
+      mutt_debug(LL_DEBUG2, "inotify_init1 failed, errno=%d %s\n", errno, strerror(errno));
       return -1;
     }
     mutt_poll_fd_add(0, POLLIN);
@@ -246,12 +246,13 @@ static int monitor_handle_ignore(int desc)
       new_desc = inotify_add_watch(INotifyFd, iter->mh_backup_path, INOTIFY_MASK_FILE);
       if (new_desc == -1)
       {
-        mutt_debug(2, "inotify_add_watch failed for '%s', errno=%d %s\n",
+        mutt_debug(LL_DEBUG2, "inotify_add_watch failed for '%s', errno=%d %s\n",
                    iter->mh_backup_path, errno, strerror(errno));
       }
       else
       {
-        mutt_debug(3, "inotify_add_watch descriptor=%d for '%s'\n", desc, iter->mh_backup_path);
+        mutt_debug(LL_DEBUG3, "inotify_add_watch descriptor=%d for '%s'\n",
+                   desc, iter->mh_backup_path);
         iter->st_dev = sb.st_dev;
         iter->st_ino = sb.st_ino;
         iter->desc = new_desc;
@@ -259,7 +260,7 @@ static int monitor_handle_ignore(int desc)
     }
     else
     {
-      mutt_debug(3, "cleanup watch (implicitly removed) - descriptor=%d\n", desc);
+      mutt_debug(LL_DEBUG3, "cleanup watch (implicitly removed) - descriptor=%d\n", desc);
     }
 
     if (MonitorContextDescriptor == desc)
@@ -373,7 +374,7 @@ int mutt_monitor_poll(void)
       rc = -1;
       if (errno != EINTR)
       {
-        mutt_debug(2, "poll() failed, errno=%d %s\n", errno, strerror(errno));
+        mutt_debug(LL_DEBUG2, "poll() failed, errno=%d %s\n", errno, strerror(errno));
       }
     }
     else
@@ -391,7 +392,7 @@ int mutt_monitor_poll(void)
           else if (PollFds[i].fd == INotifyFd)
           {
             MonitorFilesChanged = 1;
-            mutt_debug(3, "file change(s) detected\n");
+            mutt_debug(LL_DEBUG3, "file change(s) detected\n");
             char *ptr = buf;
             const struct inotify_event *event;
 
@@ -401,7 +402,7 @@ int mutt_monitor_poll(void)
               if (len == -1)
               {
                 if (errno != EAGAIN)
-                  mutt_debug(2, "read inotify events failed, errno=%d %s\n",
+                  mutt_debug(LL_DEBUG2, "read inotify events failed, errno=%d %s\n",
                              errno, strerror(errno));
                 break;
               }
@@ -409,8 +410,8 @@ int mutt_monitor_poll(void)
               while (ptr < (buf + len))
               {
                 event = (const struct inotify_event *) ptr;
-                mutt_debug(3, "+ detail: descriptor=%d mask=0x%x\n", event->wd,
-                           event->mask);
+                mutt_debug(LL_DEBUG3, "+ detail: descriptor=%d mask=0x%x\n",
+                           event->wd, event->mask);
                 if (event->mask & IN_IGNORED)
                   monitor_handle_ignore(event->wd);
                 else if (event->wd == MonitorContextDescriptor)
@@ -453,12 +454,12 @@ int mutt_monitor_add(struct Mailbox *m)
   if (((INotifyFd == -1) && (monitor_init() == -1)) ||
       (desc = inotify_add_watch(INotifyFd, info.path, mask)) == -1)
   {
-    mutt_debug(2, "inotify_add_watch failed for '%s', errno=%d %s\n", info.path,
-               errno, strerror(errno));
+    mutt_debug(LL_DEBUG2, "inotify_add_watch failed for '%s', errno=%d %s\n",
+               info.path, errno, strerror(errno));
     return -1;
   }
 
-  mutt_debug(3, "inotify_add_watch descriptor=%d for '%s'\n", desc, info.path);
+  mutt_debug(LL_DEBUG3, "inotify_add_watch descriptor=%d for '%s'\n", desc, info.path);
   if (!m)
     MonitorContextDescriptor = desc;
 
@@ -506,7 +507,7 @@ int mutt_monitor_remove(struct Mailbox *m)
   }
 
   inotify_rm_watch(info.monitor->desc, INotifyFd);
-  mutt_debug(3, "inotify_rm_watch for '%s' descriptor=%d\n", info.path,
+  mutt_debug(LL_DEBUG3, "inotify_rm_watch for '%s' descriptor=%d\n", info.path,
              info.monitor->desc);
 
   monitor_delete(info.monitor);

--- a/mutt/buffer.c
+++ b/mutt/buffer.c
@@ -369,7 +369,7 @@ void mutt_buffer_pool_init(void)
  */
 void mutt_buffer_pool_free(void)
 {
-  mutt_debug(1, "mutt_buffer_pool_free: %zu of %zu returned to pool\n",
+  mutt_debug(LL_DEBUG1, "mutt_buffer_pool_free: %zu of %zu returned to pool\n",
              BufferPoolCount, BufferPoolLen);
 
   while (BufferPoolCount)
@@ -400,7 +400,7 @@ void mutt_buffer_pool_release(struct Buffer **pbuf)
 
   if (BufferPoolCount >= BufferPoolLen)
   {
-    mutt_debug(1, "Internal buffer pool error\n");
+    mutt_debug(LL_DEBUG1, "Internal buffer pool error\n");
     mutt_buffer_free(pbuf);
     return;
   }

--- a/mutt/date.c
+++ b/mutt/date.c
@@ -506,7 +506,7 @@ time_t mutt_date_parse_date(const char *s, struct Tz *tz_out)
           sec = 0;
         else
         {
-          mutt_debug(1, "could not process time format: %s\n", t);
+          mutt_debug(LL_DEBUG1, "could not process time format: %s\n", t);
           return -1;
         }
         if ((hour < 0) || (hour > 23) || (min < 0) || (min > 59) || (sec < 0) || (sec > 60))
@@ -571,7 +571,7 @@ time_t mutt_date_parse_date(const char *s, struct Tz *tz_out)
 
   if (count < 4) /* don't check for missing timezone */
   {
-    mutt_debug(1, "error parsing date format, using received time\n");
+    mutt_debug(LL_DEBUG1, "error parsing date format, using received time\n");
     return -1;
   }
 

--- a/mutt/file.c
+++ b/mutt/file.c
@@ -109,14 +109,14 @@ static int mkwrapdir(const char *path, char *newfile, size_t nflen, char *newdir
   snprintf(newdir, ndlen, "%s/%s", parent, ".muttXXXXXX");
   if (!mkdtemp(newdir))
   {
-    mutt_debug(1, "mkdtemp() failed\n");
+    mutt_debug(LL_DEBUG1, "mkdtemp() failed\n");
     return -1;
   }
 
   if (snprintf(newfile, nflen, "%s/%s", newdir, NONULL(basename)) >= nflen)
   {
     rmdir(newdir);
-    mutt_debug(1, "string was truncated\n");
+    mutt_debug(LL_DEBUG1, "string was truncated\n");
     return -1;
   }
   return 0;
@@ -358,7 +358,7 @@ int mutt_file_safe_rename(const char *src, const char *target)
     if ((lstat(src, &ssb) == 0) && (lstat(target, &tsb) == 0) &&
         (compare_stat(&ssb, &tsb) == 0))
     {
-      mutt_debug(1, "link (%s, %s) reported failure: %s (%d) but actually succeeded\n",
+      mutt_debug(LL_DEBUG1, "link (%s, %s) reported failure: %s (%d) but actually succeeded\n",
                  src, target, strerror(errno), errno);
       goto success;
     }
@@ -373,7 +373,8 @@ int mutt_file_safe_rename(const char *src, const char *target)
      * With other file systems, rename should just fail when
      * the files reside on different file systems, so it's safe
      * to try it here. */
-    mutt_debug(1, "link (%s, %s) failed: %s (%d)\n", src, target, strerror(errno), errno);
+    mutt_debug(LL_DEBUG1, "link (%s, %s) failed: %s (%d)\n", src, target,
+               strerror(errno), errno);
 
     /* FUSE may return ENOSYS. VFAT may return EPERM. FreeBSD's
      * msdosfs may return EOPNOTSUPP.  ENOTSUP can also appear. */
@@ -386,14 +387,14 @@ int mutt_file_safe_rename(const char *src, const char *target)
 #endif
     )
     {
-      mutt_debug(1, "trying rename...\n");
+      mutt_debug(LL_DEBUG1, "trying rename...\n");
       if (rename(src, target) == -1)
       {
-        mutt_debug(1, "rename (%s, %s) failed: %s (%d)\n", src, target,
+        mutt_debug(LL_DEBUG1, "rename (%s, %s) failed: %s (%d)\n", src, target,
                    strerror(errno), errno);
         return -1;
       }
-      mutt_debug(1, "rename succeeded.\n");
+      mutt_debug(LL_DEBUG1, "rename succeeded.\n");
 
       return 0;
     }
@@ -411,13 +412,13 @@ int mutt_file_safe_rename(const char *src, const char *target)
   /* Stat both links and check if they are equal. */
   if (lstat(src, &ssb) == -1)
   {
-    mutt_debug(1, "#1 can't stat %s: %s (%d)\n", src, strerror(errno), errno);
+    mutt_debug(LL_DEBUG1, "#1 can't stat %s: %s (%d)\n", src, strerror(errno), errno);
     return -1;
   }
 
   if (lstat(target, &tsb) == -1)
   {
-    mutt_debug(1, "#2 can't stat %s: %s (%d)\n", src, strerror(errno), errno);
+    mutt_debug(LL_DEBUG1, "#2 can't stat %s: %s (%d)\n", src, strerror(errno), errno);
     return -1;
   }
 
@@ -425,7 +426,7 @@ int mutt_file_safe_rename(const char *src, const char *target)
 
   if (!compare_stat(&ssb, &tsb))
   {
-    mutt_debug(1, "stat blocks for %s and %s diverge; pretending EEXIST.\n", src, target);
+    mutt_debug(LL_DEBUG1, "stat blocks for %s and %s diverge; pretending EEXIST.\n", src, target);
     errno = EEXIST;
     return -1;
   }
@@ -436,7 +437,7 @@ success:
    * Should we really ignore the return value here? XXX */
   if (unlink(src) == -1)
   {
-    mutt_debug(1, "unlink (%s) failed: %s (%d)\n", src, strerror(errno), errno);
+    mutt_debug(LL_DEBUG1, "unlink (%s) failed: %s (%d)\n", src, strerror(errno), errno);
   }
 
   return 0;
@@ -458,7 +459,7 @@ int mutt_file_rmtree(const char *path)
   DIR *dirp = opendir(path);
   if (!dirp)
   {
-    mutt_debug(1, "error opening directory %s\n", path);
+    mutt_debug(LL_DEBUG1, "error opening directory %s\n", path);
     return -1;
   }
   while ((de = readdir(dirp)))
@@ -1079,7 +1080,7 @@ int mutt_file_lock(int fd, bool excl, bool timeout)
 
   while (fcntl(fd, F_SETLK, &lck) == -1)
   {
-    mutt_debug(1, "fcntl errno %d.\n", errno);
+    mutt_debug(LL_DEBUG1, "fcntl errno %d.\n", errno);
     if ((errno != EAGAIN) && (errno != EACCES))
     {
       mutt_perror("fcntl");

--- a/mutt/group.c
+++ b/mutt/group.c
@@ -77,7 +77,7 @@ struct Group *mutt_pattern_group(const char *k)
   p = mutt_hash_find(Groups, k);
   if (!p)
   {
-    mutt_debug(2, "Creating group %s.\n", k);
+    mutt_debug(LL_DEBUG2, "Creating group %s.\n", k);
     p = mutt_mem_calloc(1, sizeof(struct Group));
     p->name = mutt_str_strdup(k);
     STAILQ_INIT(&p->rs);

--- a/mutt/path.c
+++ b/mutt/path.c
@@ -106,7 +106,7 @@ bool mutt_path_tidy_dotdot(char *buf)
 
   char *dd = buf;
 
-  mutt_debug(3, "Collapse path: %s\n", buf);
+  mutt_debug(LL_DEBUG3, "Collapse path: %s\n", buf);
   while ((dd = strstr(dd, "/..")))
   {
     if (dd[3] == '/') /* paths follow dots */
@@ -147,7 +147,7 @@ bool mutt_path_tidy_dotdot(char *buf)
     dd = buf; /* restart at the beginning */
   }
 
-  mutt_debug(3, "Collapsed to:  %s\n", buf);
+  mutt_debug(LL_DEBUG3, "Collapsed to:  %s\n", buf);
   return true;
 }
 
@@ -232,7 +232,7 @@ bool mutt_path_canon(char *buf, size_t buflen, const char *homedir)
     {
       if (!homedir)
       {
-        mutt_debug(3, "no homedir\n");
+        mutt_debug(LL_DEBUG3, "no homedir\n");
         return false;
       }
 
@@ -251,7 +251,7 @@ bool mutt_path_canon(char *buf, size_t buflen, const char *homedir)
       struct passwd *pw = getpwnam(user);
       if (!pw || !pw->pw_dir)
       {
-        mutt_debug(1, "no such user: %s\n", user);
+        mutt_debug(LL_DEBUG1, "no such user: %s\n", user);
         return false;
       }
 
@@ -261,7 +261,7 @@ bool mutt_path_canon(char *buf, size_t buflen, const char *homedir)
     size_t dirlen = mutt_str_strlen(dir);
     if ((len + dirlen) >= buflen)
     {
-      mutt_debug(3, "result too big for the buffer %d >= %d\n", len + dirlen, buflen);
+      mutt_debug(LL_DEBUG3, "result too big for the buffer %d >= %d\n", len + dirlen, buflen);
       return false;
     }
 
@@ -272,7 +272,7 @@ bool mutt_path_canon(char *buf, size_t buflen, const char *homedir)
   {
     if (!getcwd(result, sizeof(result)))
     {
-      mutt_debug(1, "getcwd failed: %s (%d)\n", strerror(errno), errno);
+      mutt_debug(LL_DEBUG1, "getcwd failed: %s (%d)\n", strerror(errno), errno);
       return false;
     }
 
@@ -280,7 +280,8 @@ bool mutt_path_canon(char *buf, size_t buflen, const char *homedir)
     size_t dirlen = mutt_str_strlen(buf);
     if ((cwdlen + dirlen + 1) >= buflen)
     {
-      mutt_debug(3, "result too big for the buffer %d >= %d\n", cwdlen + dirlen + 1, buflen);
+      mutt_debug(LL_DEBUG3, "result too big for the buffer %d >= %d\n",
+                 cwdlen + dirlen + 1, buflen);
       return false;
     }
 

--- a/mutt/string.c
+++ b/mutt/string.c
@@ -579,7 +579,7 @@ char *mutt_str_substr_dup(const char *begin, const char *end)
 
   if (!begin)
   {
-    mutt_debug(1, "%s: ERROR: 'begin' is NULL\n", __func__);
+    mutt_debug(LL_DEBUG1, "%s: ERROR: 'begin' is NULL\n", __func__);
     return NULL;
   }
 

--- a/mutt_account.c
+++ b/mutt_account.c
@@ -271,7 +271,7 @@ int mutt_account_getlogin(struct ConnAccount *account)
     }
     else
     {
-      mutt_debug(1, "Couldn't get user info\n");
+      mutt_debug(LL_DEBUG1, "Couldn't get user info\n");
       return -1;
     }
   }

--- a/mutt_attach.c
+++ b/mutt_attach.c
@@ -128,7 +128,7 @@ int mutt_compose_attachment(struct Body *a)
         mutt_str_strfcpy(command, entry->composecommand, sizeof(command));
       if (rfc1524_expand_filename(entry->nametemplate, a->filename, newfile, sizeof(newfile)))
       {
-        mutt_debug(1, "oldfile: %s\t newfile: %s\n", a->filename, newfile);
+        mutt_debug(LL_DEBUG1, "oldfile: %s\t newfile: %s\n", a->filename, newfile);
         if (mutt_file_symlink(a->filename, newfile) == -1)
         {
           if (mutt_yesorno(_("Can't match nametemplate, continue?"), MUTT_YES) != MUTT_YES)
@@ -262,7 +262,7 @@ int mutt_edit_attachment(struct Body *a)
       mutt_str_strfcpy(command, entry->editcommand, sizeof(command));
       if (rfc1524_expand_filename(entry->nametemplate, a->filename, newfile, sizeof(newfile)))
       {
-        mutt_debug(1, "oldfile: %s\t newfile: %s\n", a->filename, newfile);
+        mutt_debug(LL_DEBUG1, "oldfile: %s\t newfile: %s\n", a->filename, newfile);
         if (mutt_file_symlink(a->filename, newfile) == -1)
         {
           if (mutt_yesorno(_("Can't match nametemplate, continue?"), MUTT_YES) != MUTT_YES)
@@ -349,7 +349,7 @@ void mutt_check_lookup_list(struct Body *b, char *type, size_t len)
                                    "multipart" :
                                    n == TYPE_TEXT ? "text" : n == TYPE_VIDEO ? "video" : "other",
                  tmp.subtype);
-        mutt_debug(1, "\"%s\" -> %s\n", b->filename, type);
+        mutt_debug(LL_DEBUG1, "\"%s\" -> %s\n", b->filename, type);
       }
       if (tmp.subtype)
         FREE(&tmp.subtype);
@@ -548,7 +548,7 @@ int mutt_view_attachment(FILE *fp, struct Body *a, int flag, struct Email *e,
       /* interactive command */
       int rv = mutt_system(command);
       if (rv == -1)
-        mutt_debug(1, "Error running \"%s\"!", command);
+        mutt_debug(LL_DEBUG1, "Error running \"%s\"!", command);
 
       if ((rv != 0) || (entry->needsterminal && WaitKey))
         mutt_any_key_to_continue(NULL);
@@ -573,8 +573,8 @@ int mutt_view_attachment(FILE *fp, struct Body *a, int flag, struct Email *e,
         decode_state.fpout = mutt_file_fopen(pagerfile, "w");
         if (!decode_state.fpout)
         {
-          mutt_debug(1, "mutt_file_fopen(%s) errno=%d %s\n", pagerfile, errno,
-                     strerror(errno));
+          mutt_debug(LL_DEBUG1, "mutt_file_fopen(%s) errno=%d %s\n", pagerfile,
+                     errno, strerror(errno));
           mutt_perror(pagerfile);
           goto return_error;
         }
@@ -582,7 +582,8 @@ int mutt_view_attachment(FILE *fp, struct Body *a, int flag, struct Email *e,
         decode_state.flags = MUTT_CHARCONV;
         mutt_decode_attachment(a, &decode_state);
         if (fclose(decode_state.fpout) == EOF)
-          mutt_debug(1, "fclose(%s) errno=%d %s\n", pagerfile, errno, strerror(errno));
+          mutt_debug(LL_DEBUG1, "fclose(%s) errno=%d %s\n", pagerfile, errno,
+                     strerror(errno));
       }
       else
       {
@@ -1028,7 +1029,7 @@ int mutt_print_attachment(FILE *fp, struct Body *a)
     char command[HUGE_STRING];
     int piped = false;
 
-    mutt_debug(2, "Using mailcap...\n");
+    mutt_debug(LL_DEBUG2, "Using mailcap...\n");
 
     struct Rfc1524MailcapEntry *entry = rfc1524_new_entry();
     rfc1524_mailcap_lookup(a, type, entry, MUTT_PRINT);
@@ -1088,7 +1089,7 @@ int mutt_print_attachment(FILE *fp, struct Body *a)
     {
       int rc = mutt_system(command);
       if (rc == -1)
-        mutt_debug(1, "Error running \"%s\"!", command);
+        mutt_debug(LL_DEBUG1, "Error running \"%s\"!", command);
 
       if ((rc != 0) || WaitKey)
         mutt_any_key_to_continue(NULL);
@@ -1120,7 +1121,7 @@ int mutt_print_attachment(FILE *fp, struct Body *a)
     mutt_mktemp(newfile, sizeof(newfile));
     if (mutt_decode_save_attachment(fp, a, newfile, MUTT_PRINTING, 0) == 0)
     {
-      mutt_debug(2, "successfully decoded %s type attachment to %s\n", type, newfile);
+      mutt_debug(LL_DEBUG2, "successfully decoded %s type attachment to %s\n", type, newfile);
 
       ifp = fopen(newfile, "r");
       if (!ifp)
@@ -1129,7 +1130,7 @@ int mutt_print_attachment(FILE *fp, struct Body *a)
         goto bail0;
       }
 
-      mutt_debug(2, "successfully opened %s read-only\n", newfile);
+      mutt_debug(LL_DEBUG2, "successfully opened %s read-only\n", newfile);
 
       mutt_endwin();
       thepid = mutt_create_filter(NONULL(PrintCommand), &fpout, NULL, NULL);
@@ -1139,7 +1140,7 @@ int mutt_print_attachment(FILE *fp, struct Body *a)
         goto bail0;
       }
 
-      mutt_debug(2, "Filter created.\n");
+      mutt_debug(LL_DEBUG2, "Filter created.\n");
 
       mutt_file_copy_stream(ifp, fpout);
 

--- a/mutt_header.c
+++ b/mutt_header.c
@@ -217,7 +217,7 @@ void mutt_edit_headers(const char *editor, const char *body, struct Email *msg,
   stat(path, &st);
   if (mtime == st.st_mtime)
   {
-    mutt_debug(1, "temp file was not modified.\n");
+    mutt_debug(LL_DEBUG1, "temp file was not modified.\n");
     /* the file has not changed! */
     mutt_file_unlink(path);
     return;

--- a/mutt_logging.c
+++ b/mutt_logging.c
@@ -80,7 +80,7 @@ static void error_pause(void)
 
   if (gettimeofday(&now, NULL) < 0)
   {
-    mutt_debug(1, "gettimeofday failed: %d\n", errno);
+    mutt_debug(LL_DEBUG1, "gettimeofday failed: %d\n", errno);
     return;
   }
 
@@ -213,7 +213,7 @@ int log_disp_curses(time_t stamp, const char *file, int line,
   {
     OptMsgErr = true;
     if (gettimeofday(&LastError, NULL) < 0)
-      mutt_debug(1, "gettimeofday failed: %d\n", errno);
+      mutt_debug(LL_DEBUG1, "gettimeofday failed: %d\n", errno);
   }
   else
   {

--- a/mutt_lua.c
+++ b/mutt_lua.c
@@ -53,7 +53,7 @@
  */
 static int handle_panic(lua_State *l)
 {
-  mutt_debug(1, "lua runtime panic: %s\n", lua_tostring(l, -1));
+  mutt_debug(LL_DEBUG1, "lua runtime panic: %s\n", lua_tostring(l, -1));
   mutt_error("Lua runtime panic: %s\n", lua_tostring(l, -1));
   lua_pop(l, 1);
   return -1;
@@ -66,7 +66,7 @@ static int handle_panic(lua_State *l)
  */
 static int handle_error(lua_State *l)
 {
-  mutt_debug(1, "lua runtime error: %s\n", lua_tostring(l, -1));
+  mutt_debug(LL_DEBUG1, "lua runtime error: %s\n", lua_tostring(l, -1));
   mutt_error("Lua runtime error: %s\n", lua_tostring(l, -1));
   lua_pop(l, 1);
   return -1;
@@ -80,7 +80,7 @@ static int handle_error(lua_State *l)
  */
 static int lua_mutt_call(lua_State *l)
 {
-  mutt_debug(2, " * lua_mutt_call()\n");
+  mutt_debug(LL_DEBUG2, " * lua_mutt_call()\n");
   struct Buffer token, expn, err;
   char buffer[LONG_STRING] = "";
   const struct Command *command = NULL;
@@ -145,7 +145,7 @@ static int lua_mutt_call(lua_State *l)
 static int lua_mutt_set(lua_State *l)
 {
   const char *param = lua_tostring(l, -2);
-  mutt_debug(2, " * lua_mutt_set(%s)\n", param);
+  mutt_debug(LL_DEBUG2, " * lua_mutt_set(%s)\n", param);
 
   if (mutt_str_startswith(param, "my_", CASE_MATCH))
   {
@@ -219,7 +219,7 @@ static int lua_mutt_set(lua_State *l)
 static int lua_mutt_get(lua_State *l)
 {
   const char *param = lua_tostring(l, -1);
-  mutt_debug(2, " * lua_mutt_get(%s)\n", param);
+  mutt_debug(LL_DEBUG2, " * lua_mutt_get(%s)\n", param);
 
   if (mutt_str_startswith(param, "my_", CASE_MATCH))
   {
@@ -237,7 +237,7 @@ static int lua_mutt_get(lua_State *l)
   struct HashElem *he = cs_get_elem(Config, param);
   if (!he)
   {
-    mutt_debug(2, " * error\n");
+    mutt_debug(LL_DEBUG2, " * error\n");
     luaL_error(l, "NeoMutt parameter not found %s", param);
     return -1;
   }
@@ -293,7 +293,7 @@ static int lua_mutt_get(lua_State *l)
  */
 static int lua_mutt_enter(lua_State *l)
 {
-  mutt_debug(2, " * lua_mutt_enter()\n");
+  mutt_debug(LL_DEBUG2, " * lua_mutt_enter()\n");
   struct Buffer token, err;
   char *buffer = mutt_str_strdup(lua_tostring(l, -1));
   int rc = 0;
@@ -330,7 +330,7 @@ static int lua_mutt_enter(lua_State *l)
  */
 static int lua_mutt_message(lua_State *l)
 {
-  mutt_debug(2, " * lua_mutt_message()\n");
+  mutt_debug(LL_DEBUG2, " * lua_mutt_message()\n");
   const char *msg = lua_tostring(l, -1);
   if (msg)
     mutt_message(msg);
@@ -344,7 +344,7 @@ static int lua_mutt_message(lua_State *l)
  */
 static int lua_mutt_error(lua_State *l)
 {
-  mutt_debug(2, " * lua_mutt_error()\n");
+  mutt_debug(LL_DEBUG2, " * lua_mutt_error()\n");
   const char *msg = lua_tostring(l, -1);
   if (msg)
     mutt_error(msg);
@@ -384,7 +384,7 @@ static const luaL_Reg luaMuttDecl[] = {
  */
 static int luaopen_mutt_decl(lua_State *l)
 {
-  mutt_debug(2, " * luaopen_mutt()\n");
+  mutt_debug(LL_DEBUG2, " * luaopen_mutt()\n");
   luaL_newlib(l, luaMuttDecl);
   int lib_idx = lua_gettop(l);
   /*                  table_idx, key        value,               value's type */
@@ -419,7 +419,7 @@ static bool lua_init(lua_State **l)
   if (*l)
     return true;
 
-  mutt_debug(2, " * lua_init()\n");
+  mutt_debug(LL_DEBUG2, " * lua_init()\n");
   *l = luaL_newstate();
 
   if (!*l)
@@ -448,17 +448,17 @@ enum CommandResult mutt_lua_parse(struct Buffer *buf, struct Buffer *s,
                                   unsigned long data, struct Buffer *err)
 {
   lua_init(&Lua);
-  mutt_debug(2, " * mutt_lua_parse(%s)\n", buf->data);
+  mutt_debug(LL_DEBUG2, " * mutt_lua_parse(%s)\n", buf->data);
 
   if (luaL_dostring(Lua, s->dptr))
   {
-    mutt_debug(2, " * %s -> failure\n", s->dptr);
+    mutt_debug(LL_DEBUG2, " * %s -> failure\n", s->dptr);
     mutt_buffer_printf(err, "%s: %s", s->dptr, lua_tostring(Lua, -1));
     /* pop error message from the stack */
     lua_pop(Lua, 1);
     return MUTT_CMD_ERROR;
   }
-  mutt_debug(2, " * %s -> success\n", s->dptr);
+  mutt_debug(LL_DEBUG2, " * %s -> success\n", s->dptr);
   return MUTT_CMD_SUCCESS;
 }
 
@@ -468,7 +468,7 @@ enum CommandResult mutt_lua_parse(struct Buffer *buf, struct Buffer *s,
 enum CommandResult mutt_lua_source_file(struct Buffer *buf, struct Buffer *s,
                                         unsigned long data, struct Buffer *err)
 {
-  mutt_debug(2, " * mutt_lua_source()\n");
+  mutt_debug(LL_DEBUG2, " * mutt_lua_source()\n");
 
   lua_init(&Lua);
 

--- a/mutt_parse.c
+++ b/mutt_parse.c
@@ -93,17 +93,17 @@ static bool count_body_parts_check(struct ListHead *checklist, struct Body *b, b
   STAILQ_FOREACH(np, checklist, entries)
   {
     a = (struct AttachMatch *) np->data;
-    mutt_debug(5, "%s %d/%s ?? %s/%s [%d]... ", dflt ? "[OK]   " : "[EXCL] ", b->type,
+    mutt_debug(3, "%s %d/%s ?? %s/%s [%d]... ", dflt ? "[OK]   " : "[EXCL] ", b->type,
                b->subtype ? b->subtype : "*", a->major, a->minor, a->major_int);
     if ((a->major_int == TYPE_ANY || a->major_int == b->type) &&
         (!b->subtype || !regexec(&a->minor_regex, b->subtype, 0, NULL, 0)))
     {
-      mutt_debug(5, "yes\n");
+      mutt_debug(3, "yes\n");
       return true;
     }
     else
     {
-      mutt_debug(5, "no\n");
+      mutt_debug(3, "no\n");
     }
   }
 
@@ -194,18 +194,18 @@ static int count_body_parts(struct Body *body, int flags)
       count++;
     bp->attach_qualifies = shallcount ? true : false;
 
-    mutt_debug(5, "%p shallcount = %d\n", (void *) bp, shallcount);
+    mutt_debug(3, "%p shallcount = %d\n", (void *) bp, shallcount);
 
     if (shallrecurse)
     {
-      mutt_debug(5, "%p pre count = %d\n", (void *) bp, count);
+      mutt_debug(3, "%p pre count = %d\n", (void *) bp, count);
       bp->attach_count = count_body_parts(bp->parts, flags & ~MUTT_PARTS_TOPLEVEL);
       count += bp->attach_count;
-      mutt_debug(5, "%p post count = %d\n", (void *) bp, count);
+      mutt_debug(3, "%p post count = %d\n", (void *) bp, count);
     }
   }
 
-  mutt_debug(5, "return %d\n", count < 0 ? 0 : count);
+  mutt_debug(3, "return %d\n", count < 0 ? 0 : count);
   return (count < 0) ? 0 : count;
 }
 

--- a/mutt_parse.c
+++ b/mutt_parse.c
@@ -93,17 +93,17 @@ static bool count_body_parts_check(struct ListHead *checklist, struct Body *b, b
   STAILQ_FOREACH(np, checklist, entries)
   {
     a = (struct AttachMatch *) np->data;
-    mutt_debug(3, "%s %d/%s ?? %s/%s [%d]... ", dflt ? "[OK]   " : "[EXCL] ", b->type,
-               b->subtype ? b->subtype : "*", a->major, a->minor, a->major_int);
+    mutt_debug(LL_DEBUG3, "%s %d/%s ?? %s/%s [%d]... ", dflt ? "[OK]   " : "[EXCL] ",
+               b->type, b->subtype ? b->subtype : "*", a->major, a->minor, a->major_int);
     if ((a->major_int == TYPE_ANY || a->major_int == b->type) &&
         (!b->subtype || !regexec(&a->minor_regex, b->subtype, 0, NULL, 0)))
     {
-      mutt_debug(3, "yes\n");
+      mutt_debug(LL_DEBUG3, "yes\n");
       return true;
     }
     else
     {
-      mutt_debug(3, "no\n");
+      mutt_debug(LL_DEBUG3, "no\n");
     }
   }
 
@@ -194,18 +194,18 @@ static int count_body_parts(struct Body *body, int flags)
       count++;
     bp->attach_qualifies = shallcount ? true : false;
 
-    mutt_debug(3, "%p shallcount = %d\n", (void *) bp, shallcount);
+    mutt_debug(LL_DEBUG3, "%p shallcount = %d\n", (void *) bp, shallcount);
 
     if (shallrecurse)
     {
-      mutt_debug(3, "%p pre count = %d\n", (void *) bp, count);
+      mutt_debug(LL_DEBUG3, "%p pre count = %d\n", (void *) bp, count);
       bp->attach_count = count_body_parts(bp->parts, flags & ~MUTT_PARTS_TOPLEVEL);
       count += bp->attach_count;
-      mutt_debug(3, "%p post count = %d\n", (void *) bp, count);
+      mutt_debug(LL_DEBUG3, "%p post count = %d\n", (void *) bp, count);
     }
   }
 
-  mutt_debug(3, "return %d\n", count < 0 ? 0 : count);
+  mutt_debug(LL_DEBUG3, "return %d\n", count < 0 ? 0 : count);
   return (count < 0) ? 0 : count;
 }
 

--- a/mutt_socket.h
+++ b/mutt_socket.h
@@ -29,7 +29,7 @@ struct Connection;
 /* logging levels */
 #define MUTT_SOCK_LOG_CMD  2
 #define MUTT_SOCK_LOG_HDR  3
-#define MUTT_SOCK_LOG_FULL 4
+#define MUTT_SOCK_LOG_FULL 5
 
 struct Connection *mutt_conn_find(const struct Connection *start, const struct ConnAccount *account);
 struct Connection *mutt_conn_new(const struct ConnAccount *account);

--- a/mutt_window.c
+++ b/mutt_window.c
@@ -224,7 +224,7 @@ void mutt_window_reflow(void)
   if (OptNoCurses)
     return;
 
-  mutt_debug(2, "entering\n");
+  mutt_debug(LL_DEBUG2, "entering\n");
 
   MuttStatusWindow->rows = 1;
   MuttStatusWindow->cols = COLS;

--- a/muttlib.c
+++ b/muttlib.c
@@ -911,7 +911,7 @@ void mutt_expando_format(char *buf, size_t buflen, size_t col, int cols, const c
           buf[n] = 0;
           while ((n > 0) && (buf[n - 1] == '\n' || buf[n - 1] == '\r'))
             buf[--n] = '\0';
-          mutt_debug(3, "fmtpipe < %s\n", buf);
+          mutt_debug(5, "fmtpipe < %s\n", buf);
 
           /* If the result ends with '%', this indicates that the filter
            * generated %-tokens that neomutt can expand.  Eliminate the '%'

--- a/muttlib.c
+++ b/muttlib.c
@@ -556,11 +556,11 @@ void mutt_buffer_mktemp_full(struct Buffer *buf, const char *prefix,
   mutt_buffer_printf(buf, "%s/%s-%s-%d-%d-%ld%ld%s%s", NONULL(Tmpdir), NONULL(prefix),
                      NONULL(Hostname), (int) getuid(), (int) getpid(), random(),
                      random(), suffix ? "." : "", NONULL(suffix));
-  mutt_debug(3, "%s:%d: mutt_mktemp returns \"%s\".\n", src, line, mutt_b2s(buf));
+  mutt_debug(LL_DEBUG3, "%s:%d: mutt_mktemp returns \"%s\".\n", src, line, mutt_b2s(buf));
   if (unlink(mutt_b2s(buf)) && errno != ENOENT)
   {
-    mutt_debug(1, "%s:%d: ERROR: unlink(\"%s\"): %s (errno %d)\n", src, line,
-               mutt_b2s(buf), strerror(errno), errno);
+    mutt_debug(LL_DEBUG1, "%s:%d: ERROR: unlink(\"%s\"): %s (errno %d)\n", src,
+               line, mutt_b2s(buf), strerror(errno), errno);
   }
 }
 
@@ -583,16 +583,16 @@ void mutt_mktemp_full(char *buf, size_t buflen, const char *prefix,
                       (int) getpid(), mutt_rand64(), suffix ? "." : "", NONULL(suffix));
   if (n >= buflen)
   {
-    mutt_debug(1,
+    mutt_debug(LL_DEBUG1,
                "%s:%d: ERROR: insufficient buffer space to hold temporary "
                "filename! buflen=%zu but need %zu\n",
                src, line, buflen, n);
   }
-  mutt_debug(3, "%s:%d: mutt_mktemp returns \"%s\".\n", src, line, buf);
+  mutt_debug(LL_DEBUG3, "%s:%d: mutt_mktemp returns \"%s\".\n", src, line, buf);
   if (unlink(buf) && errno != ENOENT)
   {
-    mutt_debug(1, "%s:%d: ERROR: unlink(\"%s\"): %s (errno %d)\n", src, line,
-               buf, strerror(errno), errno);
+    mutt_debug(LL_DEBUG1, "%s:%d: ERROR: unlink(\"%s\"): %s (errno %d)\n", src,
+               line, buf, strerror(errno), errno);
   }
 }
 
@@ -852,7 +852,7 @@ void mutt_expando_format(char *buf, size_t buflen, size_t col, int cols, const c
       char srccopy[LONG_STRING];
       int i = 0;
 
-      mutt_debug(3, "fmtpipe = %s\n", src);
+      mutt_debug(LL_DEBUG3, "fmtpipe = %s\n", src);
 
       strncpy(srccopy, src, n);
       srccopy[n - 1] = '\0';
@@ -867,11 +867,11 @@ void mutt_expando_format(char *buf, size_t buflen, size_t col, int cols, const c
       do
       {
         /* Extract the command name and copy to command line */
-        mutt_debug(3, "fmtpipe +++: %s\n", srcbuf->dptr);
+        mutt_debug(LL_DEBUG3, "fmtpipe +++: %s\n", srcbuf->dptr);
         if (word->data)
           *word->data = '\0';
         mutt_extract_token(word, srcbuf, 0);
-        mutt_debug(3, "fmtpipe %2d: %s\n", i++, word->data);
+        mutt_debug(LL_DEBUG3, "fmtpipe %2d: %s\n", i++, word->data);
         mutt_buffer_addch(command, '\'');
         mutt_expando_format(tmp, sizeof(tmp), 0, cols, word->data, callback,
                             data, flags | MUTT_FORMAT_NOFILTER);
@@ -892,7 +892,7 @@ void mutt_expando_format(char *buf, size_t buflen, size_t col, int cols, const c
         mutt_buffer_addch(command, ' ');
       } while (MoreArgs(srcbuf));
 
-      mutt_debug(3, "fmtpipe > %s\n", command->data);
+      mutt_debug(LL_DEBUG3, "fmtpipe > %s\n", command->data);
 
       col -= wlen; /* reset to passed in value */
       wptr = buf;  /* reset write ptr */
@@ -905,7 +905,7 @@ void mutt_expando_format(char *buf, size_t buflen, size_t col, int cols, const c
         mutt_file_fclose(&filter);
         rc = mutt_wait_filter(pid);
         if (rc != 0)
-          mutt_debug(1, "format pipe command exited code %d\n", rc);
+          mutt_debug(LL_DEBUG1, "format pipe command exited code %d\n", rc);
         if (n > 0)
         {
           buf[n] = 0;
@@ -941,7 +941,7 @@ void mutt_expando_format(char *buf, size_t buflen, size_t col, int cols, const c
         else
         {
           /* read error */
-          mutt_debug(1, "error reading from fmtpipe: %s (errno=%d)\n",
+          mutt_debug(LL_DEBUG1, "error reading from fmtpipe: %s (errno=%d)\n",
                      strerror(errno), errno);
           *wptr = 0;
         }

--- a/mx.c
+++ b/mx.c
@@ -942,7 +942,7 @@ struct Message *mx_msg_open_new(struct Mailbox *m, struct Email *e, int flags)
 
   if (!m->mx_ops || !m->mx_ops->msg_open_new)
   {
-    mutt_debug(1, "function unimplemented for mailbox type %d.\n", m->magic);
+    mutt_debug(LL_DEBUG1, "function unimplemented for mailbox type %d.\n", m->magic);
     return NULL;
   }
 
@@ -1024,7 +1024,7 @@ struct Message *mx_msg_open(struct Mailbox *m, int msgno)
 
   if (!m->mx_ops || !m->mx_ops->msg_open)
   {
-    mutt_debug(1, "function not implemented for mailbox type %d.\n", m->magic);
+    mutt_debug(LL_DEBUG1, "function not implemented for mailbox type %d.\n", m->magic);
     return NULL;
   }
 
@@ -1049,7 +1049,7 @@ int mx_msg_commit(struct Mailbox *m, struct Message *msg)
 
   if (!(msg->write && m->append))
   {
-    mutt_debug(1, "msg->write = %d, m->append = %d\n", msg->write, m->append);
+    mutt_debug(LL_DEBUG1, "msg->write = %d, m->append = %d\n", msg->write, m->append);
     return -1;
   }
 
@@ -1075,7 +1075,7 @@ int mx_msg_close(struct Mailbox *m, struct Message **msg)
 
   if ((*msg)->path)
   {
-    mutt_debug(1, "unlinking %s\n", (*msg)->path);
+    mutt_debug(LL_DEBUG1, "unlinking %s\n", (*msg)->path);
     unlink((*msg)->path);
     FREE(&(*msg)->path);
   }
@@ -1254,7 +1254,8 @@ enum MailboxType mx_path_probe(const char *path, struct stat *st)
 
   if (stat(path, st) != 0)
   {
-    mutt_debug(1, "unable to stat %s: %s (errno %d).\n", path, strerror(errno), errno);
+    mutt_debug(LL_DEBUG1, "unable to stat %s: %s (errno %d).\n", path,
+               strerror(errno), errno);
     return MUTT_UNKNOWN;
   }
 

--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -780,7 +780,7 @@ static int have_gpg_version(const char *version)
       engineinfo = engineinfo->next;
     if (!engineinfo)
     {
-      mutt_debug(1, "Error finding GPGME PGP engine\n");
+      mutt_debug(LL_DEBUG1, "Error finding GPGME PGP engine\n");
       engine_version = mutt_str_strdup("0.0.0");
     }
     else
@@ -2049,7 +2049,7 @@ static int verify_one(struct Body *sigbdy, struct State *s, const char *tempfile
   gpgme_release(ctx);
 
   state_attach_puts(_("[-- End signature information --]\n\n"), s);
-  mutt_debug(1, "returning %d.\n", badsig);
+  mutt_debug(LL_DEBUG1, "returning %d.\n", badsig);
 
   return badsig ? 1 : anywarn ? 2 : 0;
 }
@@ -2478,7 +2478,7 @@ static int pgp_gpgme_extract_keys(gpgme_data_t keydata, FILE **fp)
     snprintf(tmpdir, sizeof(tmpdir), "%s/neomutt-gpgme-XXXXXX", Tmpdir);
     if (!mkdtemp(tmpdir))
     {
-      mutt_debug(1, "Error creating temporary GPGME home\n");
+      mutt_debug(LL_DEBUG1, "Error creating temporary GPGME home\n");
       goto err_ctx;
     }
 
@@ -2487,7 +2487,7 @@ static int pgp_gpgme_extract_keys(gpgme_data_t keydata, FILE **fp)
       engineinfo = engineinfo->next;
     if (!engineinfo)
     {
-      mutt_debug(1, "Error finding GPGME PGP engine\n");
+      mutt_debug(LL_DEBUG1, "Error finding GPGME PGP engine\n");
       goto err_tmpdir;
     }
 
@@ -2495,7 +2495,7 @@ static int pgp_gpgme_extract_keys(gpgme_data_t keydata, FILE **fp)
                                     engineinfo->file_name, tmpdir);
     if (err != GPG_ERR_NO_ERROR)
     {
-      mutt_debug(1, "Error setting GPGME context home\n");
+      mutt_debug(LL_DEBUG1, "Error setting GPGME context home\n");
       goto err_tmpdir;
     }
   }
@@ -2549,7 +2549,7 @@ static int pgp_gpgme_extract_keys(gpgme_data_t keydata, FILE **fp)
   }
   if (gpg_err_code(err) != GPG_ERR_EOF)
   {
-    mutt_debug(1, "Error listing keys\n");
+    mutt_debug(LL_DEBUG1, "Error listing keys\n");
     goto err_fp;
   }
 
@@ -2873,7 +2873,7 @@ int pgp_gpgme_application_handler(struct Body *m, struct State *s)
 
   char body_charset[STRING]; /* Only used for clearsigned messages. */
 
-  mutt_debug(2, "Entering handler\n");
+  mutt_debug(LL_DEBUG2, "Entering handler\n");
 
   /* For clearsigned messages we won't be able to get a character set
      but we know that this may only be text thus we assume Latin-1
@@ -3084,7 +3084,7 @@ int pgp_gpgme_application_handler(struct Body *m, struct State *s)
                       s);
     return 1;
   }
-  mutt_debug(2, "Leaving handler\n");
+  mutt_debug(LL_DEBUG2, "Leaving handler\n");
 
   return err;
 }
@@ -3100,7 +3100,7 @@ int pgp_gpgme_encrypted_handler(struct Body *a, struct State *s)
   int is_signed;
   int rc = 0;
 
-  mutt_debug(2, "Entering handler\n");
+  mutt_debug(LL_DEBUG2, "Entering handler\n");
 
   FILE *fpout = mutt_file_mkstemp();
   if (!fpout)
@@ -3181,7 +3181,7 @@ int pgp_gpgme_encrypted_handler(struct Body *a, struct State *s)
   }
 
   mutt_file_fclose(&fpout);
-  mutt_debug(2, "Leaving handler\n");
+  mutt_debug(LL_DEBUG2, "Leaving handler\n");
 
   return rc;
 }
@@ -3194,7 +3194,7 @@ int smime_gpgme_application_handler(struct Body *a, struct State *s)
   int is_signed = 0;
   int rc = 0;
 
-  mutt_debug(2, "Entering handler\n");
+  mutt_debug(LL_DEBUG2, "Entering handler\n");
 
   /* clear out any mime headers before the handler, so they can't be spoofed. */
   mutt_env_free(&a->mime_headers);
@@ -3278,7 +3278,7 @@ int smime_gpgme_application_handler(struct Body *a, struct State *s)
   }
 
   mutt_file_fclose(&fpout);
-  mutt_debug(2, "Leaving handler\n");
+  mutt_debug(LL_DEBUG2, "Leaving handler\n");
 
   return rc;
 }
@@ -4875,7 +4875,7 @@ static struct CryptKeyInfo *crypt_getkeybyaddr(struct Address *a,
 
     if (abilities && !(k->flags & abilities))
     {
-      mutt_debug(2, "  insufficient abilities: Has %x, want %x\n", k->flags, abilities);
+      mutt_debug(LL_DEBUG2, "  insufficient abilities: Has %x, want %x\n", k->flags, abilities);
       continue;
     }
 
@@ -5635,7 +5635,7 @@ int smime_gpgme_verify_sender(struct Email *e)
  */
 void pgp_gpgme_set_sender(const char *sender)
 {
-  mutt_debug(2, "setting to: %s\n", sender);
+  mutt_debug(LL_DEBUG2, "setting to: %s\n", sender);
   FREE(&current_sender);
   current_sender = mutt_str_strdup(sender);
 }

--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -4875,7 +4875,7 @@ static struct CryptKeyInfo *crypt_getkeybyaddr(struct Address *a,
 
     if (abilities && !(k->flags & abilities))
     {
-      mutt_debug(5, "  insufficient abilities: Has %x, want %x\n", k->flags, abilities);
+      mutt_debug(2, "  insufficient abilities: Has %x, want %x\n", k->flags, abilities);
       continue;
     }
 

--- a/ncrypt/gnupgparse.c
+++ b/ncrypt/gnupgparse.c
@@ -150,7 +150,7 @@ static struct PgpKeyInfo *parse_pub_line(char *buf, int *is_subkey, struct PgpKe
   else
     memset(&tmp, 0, sizeof(tmp));
 
-  mutt_debug(2, "buf = '%s'\n", buf);
+  mutt_debug(LL_DEBUG2, "buf = '%s'\n", buf);
 
   for (p = buf; p; p = pend)
   {
@@ -168,7 +168,7 @@ static struct PgpKeyInfo *parse_pub_line(char *buf, int *is_subkey, struct PgpKe
     {
       case 1: /* record type */
       {
-        mutt_debug(2, "record type: %s\n", p);
+        mutt_debug(LL_DEBUG2, "record type: %s\n", p);
 
         if (mutt_str_strcmp(p, "pub") == 0)
           is_pub = true;
@@ -192,7 +192,7 @@ static struct PgpKeyInfo *parse_pub_line(char *buf, int *is_subkey, struct PgpKe
       }
       case 2: /* trust info */
       {
-        mutt_debug(2, "trust info: %s\n", p);
+        mutt_debug(LL_DEBUG2, "trust info: %s\n", p);
 
         switch (*p)
         { /* look only at the first letter */
@@ -226,7 +226,7 @@ static struct PgpKeyInfo *parse_pub_line(char *buf, int *is_subkey, struct PgpKe
       }
       case 3: /* key length  */
       {
-        mutt_debug(2, "key len: %s\n", p);
+        mutt_debug(LL_DEBUG2, "key len: %s\n", p);
 
         if (!(*is_subkey && PgpIgnoreSubkeys) && mutt_str_atos(p, &tmp.keylen) < 0)
         {
@@ -236,7 +236,7 @@ static struct PgpKeyInfo *parse_pub_line(char *buf, int *is_subkey, struct PgpKe
       }
       case 4: /* pubkey algo */
       {
-        mutt_debug(2, "pubkey algorithm: %s\n", p);
+        mutt_debug(LL_DEBUG2, "pubkey algorithm: %s\n", p);
 
         if (!(*is_subkey && PgpIgnoreSubkeys))
         {
@@ -250,7 +250,7 @@ static struct PgpKeyInfo *parse_pub_line(char *buf, int *is_subkey, struct PgpKe
       }
       case 5: /* 16 hex digits with the long keyid. */
       {
-        mutt_debug(2, "key id: %s\n", p);
+        mutt_debug(LL_DEBUG2, "key id: %s\n", p);
 
         if (!(*is_subkey && PgpIgnoreSubkeys))
           mutt_str_replace(&tmp.keyid, p);
@@ -258,7 +258,7 @@ static struct PgpKeyInfo *parse_pub_line(char *buf, int *is_subkey, struct PgpKe
       }
       case 6: /* timestamp (1998-02-28) */
       {
-        mutt_debug(2, "time stamp: %s\n", p);
+        mutt_debug(LL_DEBUG2, "time stamp: %s\n", p);
 
         if (strchr(p, '-')) /* gpg pre-2.0.10 used format (yyyy-mm-dd) */
         {
@@ -329,7 +329,7 @@ static struct PgpKeyInfo *parse_pub_line(char *buf, int *is_subkey, struct PgpKe
         if (!is_uid && (*is_subkey && PgpIgnoreSubkeys))
           break;
 
-        mutt_debug(2, "user ID: %s\n", NONULL(p));
+        mutt_debug(LL_DEBUG2, "user ID: %s\n", NONULL(p));
 
         uid = mutt_mem_calloc(1, sizeof(struct PgpUid));
         fix_uid(p);
@@ -349,7 +349,7 @@ static struct PgpKeyInfo *parse_pub_line(char *buf, int *is_subkey, struct PgpKe
       case 11: /* signature class  */
         break;
       case 12: /* key capabilities */
-        mutt_debug(2, "capabilities info: %s\n", p);
+        mutt_debug(LL_DEBUG2, "capabilities info: %s\n", p);
 
         while (*p)
         {
@@ -398,7 +398,7 @@ static struct PgpKeyInfo *parse_pub_line(char *buf, int *is_subkey, struct PgpKe
   return k;
 
 bail:
-  mutt_debug(1, "invalid number: '%s'\n", p);
+  mutt_debug(LL_DEBUG1, "invalid number: '%s'\n", p);
   return NULL;
 }
 

--- a/ncrypt/gnupgparse.c
+++ b/ncrypt/gnupgparse.c
@@ -398,7 +398,7 @@ static struct PgpKeyInfo *parse_pub_line(char *buf, int *is_subkey, struct PgpKe
   return k;
 
 bail:
-  mutt_debug(5, "invalid number: '%s'\n", p);
+  mutt_debug(1, "invalid number: '%s'\n", p);
   return NULL;
 }
 

--- a/ncrypt/pgp.c
+++ b/ncrypt/pgp.c
@@ -263,11 +263,11 @@ static int pgp_copy_checksig(FILE *fpin, FILE *fpout)
     {
       if (regexec(PgpGoodSign->regex, line, 0, NULL, 0) == 0)
       {
-        mutt_debug(2, "\"%s\" matches regex.\n", line);
+        mutt_debug(LL_DEBUG2, "\"%s\" matches regex.\n", line);
         rc = 0;
       }
       else
-        mutt_debug(2, "\"%s\" doesn't match regex.\n", line);
+        mutt_debug(LL_DEBUG2, "\"%s\" doesn't match regex.\n", line);
 
       if (strncmp(line, "[GNUPG:] ", 9) == 0)
         continue;
@@ -278,7 +278,7 @@ static int pgp_copy_checksig(FILE *fpin, FILE *fpout)
   }
   else
   {
-    mutt_debug(2, "No pattern.\n");
+    mutt_debug(LL_DEBUG2, "No pattern.\n");
     mutt_file_copy_stream(fpin, fpout);
     rc = 1;
   }
@@ -310,18 +310,18 @@ static int pgp_check_pgp_decryption_okay_regex(FILE *fpin)
     {
       if (regexec(PgpDecryptionOkay->regex, line, 0, NULL, 0) == 0)
       {
-        mutt_debug(2, "\"%s\" matches regex.\n", line);
+        mutt_debug(LL_DEBUG2, "\"%s\" matches regex.\n", line);
         rc = 0;
         break;
       }
       else
-        mutt_debug(2, "\"%s\" doesn't match regex.\n", line);
+        mutt_debug(LL_DEBUG2, "\"%s\" doesn't match regex.\n", line);
     }
     FREE(&line);
   }
   else
   {
-    mutt_debug(2, "No pattern.\n");
+    mutt_debug(LL_DEBUG2, "No pattern.\n");
     rc = 1;
   }
 
@@ -365,7 +365,7 @@ static int pgp_check_decryption_okay(FILE *fpin)
     if (plen == 0)
       continue;
     s = line + plen;
-    mutt_debug(2, "checking \"%s\".\n", line);
+    mutt_debug(LL_DEBUG2, "checking \"%s\".\n", line);
     if (mutt_str_startswith(s, "BEGIN_DECRYPTION", CASE_MATCH))
       inside_decrypt = 1;
     else if (mutt_str_startswith(s, "END_DECRYPTION", CASE_MATCH))
@@ -374,14 +374,15 @@ static int pgp_check_decryption_okay(FILE *fpin)
     {
       if (!inside_decrypt)
       {
-        mutt_debug(2, "\tPLAINTEXT encountered outside of DECRYPTION.\n");
+        mutt_debug(LL_DEBUG2,
+                   "\tPLAINTEXT encountered outside of DECRYPTION.\n");
         rv = -2;
         break;
       }
     }
     else if (mutt_str_startswith(s, "DECRYPTION_FAILED", CASE_MATCH))
     {
-      mutt_debug(2, "\tDECRYPTION_FAILED encountered.  Failure.\n");
+      mutt_debug(LL_DEBUG2, "\tDECRYPTION_FAILED encountered.  Failure.\n");
       rv = -3;
       break;
     }
@@ -389,7 +390,7 @@ static int pgp_check_decryption_okay(FILE *fpin)
     {
       /* Don't break out because we still have to check for
        * PLAINTEXT outside of the decryption boundaries. */
-      mutt_debug(2, "\tDECRYPTION_OKAY encountered.\n");
+      mutt_debug(LL_DEBUG2, "\tDECRYPTION_OKAY encountered.\n");
       rv = 0;
     }
   }
@@ -698,7 +699,8 @@ int pgp_class_application_handler(struct Body *m, struct State *s)
         int ch;
         char *expected_charset = gpgcharset && *gpgcharset ? gpgcharset : "utf-8";
 
-        mutt_debug(3, "pgp: recoding inline from [%s] to [%s]\n", expected_charset, Charset);
+        mutt_debug(LL_DEBUG3, "pgp: recoding inline from [%s] to [%s]\n",
+                   expected_charset, Charset);
 
         rewind(pgpout);
         state_set_prefix(s);
@@ -919,7 +921,7 @@ int pgp_class_verify_one(struct Body *sigbdy, struct State *s, const char *tempf
     if (rv)
       badsig = -1;
 
-    mutt_debug(1, "mutt_wait_filter returned %d.\n", rv);
+    mutt_debug(LL_DEBUG1, "mutt_wait_filter returned %d.\n", rv);
   }
 
   mutt_file_fclose(&pgperr);
@@ -928,7 +930,7 @@ int pgp_class_verify_one(struct Body *sigbdy, struct State *s, const char *tempf
 
   mutt_file_unlink(sigfile);
 
-  mutt_debug(1, "returning %d.\n", badsig);
+  mutt_debug(LL_DEBUG1, "returning %d.\n", badsig);
 
   return badsig;
 }

--- a/ncrypt/pgp.c
+++ b/ncrypt/pgp.c
@@ -698,7 +698,7 @@ int pgp_class_application_handler(struct Body *m, struct State *s)
         int ch;
         char *expected_charset = gpgcharset && *gpgcharset ? gpgcharset : "utf-8";
 
-        mutt_debug(4, "pgp: recoding inline from [%s] to [%s]\n", expected_charset, Charset);
+        mutt_debug(3, "pgp: recoding inline from [%s] to [%s]\n", expected_charset, Charset);
 
         rewind(pgpout);
         state_set_prefix(s);

--- a/ncrypt/pgpinvoke.c
+++ b/ncrypt/pgpinvoke.c
@@ -184,7 +184,7 @@ static void mutt_pgp_command(char *buf, size_t buflen,
 {
   mutt_expando_format(buf, buflen, 0, MuttIndexWindow->cols, NONULL(fmt),
                       fmt_pgp_command, (unsigned long) cctx, 0);
-  mutt_debug(2, "%s\n", buf);
+  mutt_debug(LL_DEBUG2, "%s\n", buf);
 }
 
 /**
@@ -411,7 +411,7 @@ void pgp_class_invoke_import(const char *fname)
 
   mutt_pgp_command(cmd, sizeof(cmd), &cctx, PgpImportCommand);
   if (mutt_system(cmd) != 0)
-    mutt_debug(1, "Error running \"%s\"!", cmd);
+    mutt_debug(LL_DEBUG1, "Error running \"%s\"!", cmd);
 }
 
 /**
@@ -451,7 +451,7 @@ void pgp_class_invoke_getkeys(struct Address *addr)
     mutt_message(_("Fetching PGP key..."));
 
   if (mutt_system(cmd) != 0)
-    mutt_debug(1, "Error running \"%s\"!", cmd);
+    mutt_debug(LL_DEBUG1, "Error running \"%s\"!", cmd);
 
   if (!isendwin())
     mutt_clear_error();

--- a/ncrypt/pgpkey.c
+++ b/ncrypt/pgpkey.c
@@ -1027,7 +1027,7 @@ struct PgpKeyInfo *pgp_getkeybyaddr(struct Address *a, short abilities,
 
     if (abilities && !(k->flags & abilities))
     {
-      mutt_debug(5, "  insufficient abilities: Has %x, want %x\n", k->flags, abilities);
+      mutt_debug(3, "  insufficient abilities: Has %x, want %x\n", k->flags, abilities);
       continue;
     }
 

--- a/ncrypt/pgpkey.c
+++ b/ncrypt/pgpkey.c
@@ -1027,7 +1027,7 @@ struct PgpKeyInfo *pgp_getkeybyaddr(struct Address *a, short abilities,
 
     if (abilities && !(k->flags & abilities))
     {
-      mutt_debug(3, "  insufficient abilities: Has %x, want %x\n", k->flags, abilities);
+      mutt_debug(LL_DEBUG3, "  insufficient abilities: Has %x, want %x\n", k->flags, abilities);
       continue;
     }
 

--- a/ncrypt/pgpmicalg.c
+++ b/ncrypt/pgpmicalg.c
@@ -85,7 +85,7 @@ static void pgp_dearmor(FILE *in, FILE *out)
   }
   if (!r)
   {
-    mutt_debug(1, "Can't find begin of ASCII armor.\n");
+    mutt_debug(LL_DEBUG1, "Can't find begin of ASCII armor.\n");
     return;
   }
 
@@ -99,7 +99,7 @@ static void pgp_dearmor(FILE *in, FILE *out)
   }
   if (!r)
   {
-    mutt_debug(1, "Armor header doesn't end.\n");
+    mutt_debug(LL_DEBUG1, "Armor header doesn't end.\n");
     return;
   }
 
@@ -117,20 +117,20 @@ static void pgp_dearmor(FILE *in, FILE *out)
   }
   if (!r)
   {
-    mutt_debug(1, "Can't find end of ASCII armor.\n");
+    mutt_debug(LL_DEBUG1, "Can't find end of ASCII armor.\n");
     return;
   }
 
   end = ftello(in) - strlen(line);
   if (end < start)
   {
-    mutt_debug(1, "end < start???\n");
+    mutt_debug(LL_DEBUG1, "end < start???\n");
     return;
   }
 
   if (fseeko(in, start, SEEK_SET) == -1)
   {
-    mutt_debug(1, "Can't seekto start.\n");
+    mutt_debug(LL_DEBUG1, "Can't seekto start.\n");
     return;
   }
 
@@ -148,7 +148,7 @@ static short pgp_mic_from_packet(unsigned char *p, size_t len)
   /* is signature? */
   if ((p[0] & 0x3f) != PT_SIG)
   {
-    mutt_debug(1, "tag = %d, want %d.\n", p[0] & 0x3f, PT_SIG);
+    mutt_debug(LL_DEBUG1, "tag = %d, want %d.\n", p[0] & 0x3f, PT_SIG);
     return -1;
   }
 
@@ -164,7 +164,7 @@ static short pgp_mic_from_packet(unsigned char *p, size_t len)
   }
   else
   {
-    mutt_debug(1, "Bad signature packet.\n");
+    mutt_debug(LL_DEBUG1, "Bad signature packet.\n");
     return -1;
   }
 }
@@ -203,7 +203,7 @@ static short pgp_find_hash(const char *fname)
   }
   else
   {
-    mutt_debug(1, "No packet.\n");
+    mutt_debug(LL_DEBUG1, "No packet.\n");
   }
 
 bye:

--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -354,7 +354,7 @@ static void smime_command(char *buf, size_t buflen,
 {
   mutt_expando_format(buf, buflen, 0, MuttIndexWindow->cols, NONULL(fmt),
                       fmt_smime_command, (unsigned long) cctx, 0);
-  mutt_debug(2, "%s\n", buf);
+  mutt_debug(LL_DEBUG2, "%s\n", buf);
 }
 
 /**

--- a/nntp/newsrc.c
+++ b/nntp/newsrc.c
@@ -584,7 +584,7 @@ int nntp_add_group(char *line, void *data)
   if (sscanf(line, "%1023s " ANUM " " ANUM " %c %8191[^\n]", group, &last,
              &first, &mod, desc) < 4)
   {
-    mutt_debug(4, "Cannot parse server line: %s\n", line);
+    mutt_debug(2, "Cannot parse server line: %s\n", line);
     return 0;
   }
 

--- a/nntp/newsrc.c
+++ b/nntp/newsrc.c
@@ -125,7 +125,7 @@ void nntp_newsrc_close(struct NntpAccountData *adata)
   if (!adata->newsrc_fp)
     return;
 
-  mutt_debug(1, "Unlocking %s\n", adata->newsrc_file);
+  mutt_debug(LL_DEBUG1, "Unlocking %s\n", adata->newsrc_file);
   mutt_file_unlock(fileno(adata->newsrc_fp));
   mutt_file_fclose(&adata->newsrc_fp);
 }
@@ -187,7 +187,7 @@ int nntp_newsrc_parse(struct NntpAccountData *adata)
   }
 
   /* lock it */
-  mutt_debug(1, "Locking %s\n", adata->newsrc_file);
+  mutt_debug(LL_DEBUG1, "Locking %s\n", adata->newsrc_file);
   if (mutt_file_lock(fileno(adata->newsrc_fp), false, true))
   {
     mutt_file_fclose(&adata->newsrc_fp);
@@ -207,7 +207,7 @@ int nntp_newsrc_parse(struct NntpAccountData *adata)
   adata->size = sb.st_size;
   adata->mtime = sb.st_mtime;
   adata->newsrc_modified = true;
-  mutt_debug(1, "Parsing %s\n", adata->newsrc_file);
+  mutt_debug(LL_DEBUG1, "Parsing %s\n", adata->newsrc_file);
 
   /* .newsrc has been externally modified or hasn't been loaded yet */
   for (unsigned int i = 0; i < adata->groups_num; i++)
@@ -286,7 +286,7 @@ int nntp_newsrc_parse(struct NntpAccountData *adata)
     mdata->newsrc_len = j;
     mutt_mem_realloc(&mdata->newsrc_ent, j * sizeof(struct NewsrcEntry));
     nntp_group_unread_stat(mdata);
-    mutt_debug(2, "%s\n", mdata->group);
+    mutt_debug(LL_DEBUG2, "%s\n", mdata->group);
   }
   FREE(&line);
   return 1;
@@ -491,7 +491,7 @@ int nntp_newsrc_update(struct NntpAccountData *adata)
   buf[off] = '\0';
 
   /* newrc being fully rewritten */
-  mutt_debug(1, "Updating %s\n", adata->newsrc_file);
+  mutt_debug(LL_DEBUG1, "Updating %s\n", adata->newsrc_file);
   if (adata->newsrc_file && update_file(adata->newsrc_file, buf) == 0)
   {
     struct stat sb;
@@ -584,7 +584,7 @@ int nntp_add_group(char *line, void *data)
   if (sscanf(line, "%1023s " ANUM " " ANUM " %c %8191[^\n]", group, &last,
              &first, &mod, desc) < 4)
   {
-    mutt_debug(2, "Cannot parse server line: %s\n", line);
+    mutt_debug(LL_DEBUG2, "Cannot parse server line: %s\n", line);
     return 0;
   }
 
@@ -616,7 +616,7 @@ static int active_get_cache(struct NntpAccountData *adata)
   time_t t;
 
   cache_expand(file, sizeof(file), &adata->conn->account, ".active");
-  mutt_debug(1, "Parsing %s\n", file);
+  mutt_debug(LL_DEBUG1, "Parsing %s\n", file);
   FILE *fp = mutt_file_fopen(file, "r");
   if (!fp)
     return -1;
@@ -677,7 +677,7 @@ int nntp_active_save_cache(struct NntpAccountData *adata)
   }
 
   cache_expand(file, sizeof(file), &adata->conn->account, ".active");
-  mutt_debug(1, "Updating %s\n", file);
+  mutt_debug(LL_DEBUG1, "Updating %s\n", file);
   rc = update_file(file, buf);
   FREE(&buf);
   return rc;
@@ -745,7 +745,7 @@ void nntp_hcache_update(struct NntpMboxData *mdata, header_cache_t *hc)
   hdata = mutt_hcache_fetch_raw(hc, "index", 5);
   if (hdata)
   {
-    mutt_debug(2, "mutt_hcache_fetch index: %s\n", (char *) hdata);
+    mutt_debug(LL_DEBUG2, "mutt_hcache_fetch index: %s\n", (char *) hdata);
     if (sscanf(hdata, ANUM " " ANUM, &first, &last) == 2)
     {
       old = true;
@@ -758,7 +758,7 @@ void nntp_hcache_update(struct NntpMboxData *mdata, header_cache_t *hc)
           continue;
 
         snprintf(buf, sizeof(buf), "%u", current);
-        mutt_debug(2, "mutt_hcache_delete %s\n", buf);
+        mutt_debug(LL_DEBUG2, "mutt_hcache_delete %s\n", buf);
         mutt_hcache_delete(hc, buf, strlen(buf));
       }
     }
@@ -769,7 +769,7 @@ void nntp_hcache_update(struct NntpMboxData *mdata, header_cache_t *hc)
   if (!old || mdata->first_message != first || mdata->last_message != last)
   {
     snprintf(buf, sizeof(buf), "%u %u", mdata->first_message, mdata->last_message);
-    mutt_debug(2, "mutt_hcache_store index: %s\n", buf);
+    mutt_debug(LL_DEBUG2, "mutt_hcache_store index: %s\n", buf);
     mutt_hcache_store_raw(hc, "index", 5, buf, strlen(buf) + 1);
   }
 }
@@ -789,7 +789,7 @@ static int nntp_bcache_delete(const char *id, struct BodyCache *bcache, void *da
       anum < mdata->first_message || anum > mdata->last_message)
   {
     if (mdata)
-      mutt_debug(2, "mutt_bcache_del %s\n", id);
+      mutt_debug(LL_DEBUG2, "mutt_bcache_del %s\n", id);
     mutt_bcache_del(bcache, id);
   }
   return 0;
@@ -819,7 +819,7 @@ void nntp_delete_group_cache(struct NntpMboxData *mdata)
   cache_expand(file, sizeof(file), &mdata->adata->conn->account, file);
   unlink(file);
   mdata->last_cached = 0;
-  mutt_debug(2, "%s\n", file);
+  mutt_debug(LL_DEBUG2, "%s\n", file);
 #endif
 
   if (!mdata->bcache)
@@ -828,7 +828,7 @@ void nntp_delete_group_cache(struct NntpMboxData *mdata)
   }
   if (mdata->bcache)
   {
-    mutt_debug(2, "%s/*\n", mdata->group);
+    mutt_debug(LL_DEBUG2, "%s/*\n", mdata->group);
     mutt_bcache_list(mdata->bcache, nntp_bcache_delete, NULL);
     mutt_bcache_close(&mdata->bcache);
   }
@@ -898,7 +898,7 @@ void nntp_clear_cache(struct NntpAccountData *adata)
       if (S_ISDIR(sb.st_mode))
       {
         rmdir(file);
-        mutt_debug(2, "%s\n", file);
+        mutt_debug(LL_DEBUG2, "%s\n", file);
       }
     }
     closedir(dp);
@@ -1141,7 +1141,7 @@ struct NntpAccountData *nntp_select_server(struct Mailbox *m, char *server, bool
             if (last >= mdata->first_message && last <= mdata->last_message)
             {
               mdata->last_cached = last;
-              mutt_debug(2, "%s last_cached=%u\n", mdata->group, last);
+              mutt_debug(LL_DEBUG2, "%s last_cached=%u\n", mdata->group, last);
             }
           }
           mutt_hcache_free(hc, &hdata);

--- a/nntp/nntp.c
+++ b/nntp/nntp.c
@@ -475,6 +475,38 @@ static int nntp_attempt_features(struct NntpAccountData *adata)
   return 0;
 }
 
+#ifdef USE_SASL
+/**
+ * nntp_log_binbuf - log a buffer possibly containing NUL bytes
+ * @param buf source buffer
+ * @param len how many bytes from buf
+ * @param pfx logging prefix (protocol etc.)
+ * @param dbg which loglevel does message belong
+ */
+static void nntp_log_binbuf(const char *buf, size_t len, const char *pfx, int dbg)
+{
+  size_t left = len;
+  char tmp[LONG_STRING];
+  char *p = tmp;
+
+  if (DebugLevel < dbg)
+    return;
+
+  memcpy(tmp, buf, len);
+  tmp[len] = '\0';
+  while (left > 0)
+  {
+    void *vp = memchr(p, '\0', left);
+    if (!vp)
+      break;
+    p = vp;
+    *p++ = '.';
+    left -= (p - tmp);
+  }
+  mutt_debug(dbg, "%s> %s\n", pfx, tmp);
+}
+#endif
+
 /**
  * nntp_auth - Get login, password and authenticate
  * @param adata NNTP server
@@ -630,19 +662,7 @@ static int nntp_auth(struct NntpAccountData *adata)
           /* send out client response */
           if (client_len)
           {
-            if (DebugLevel >= MUTT_SOCK_LOG_FULL)
-            {
-              char tmp[LONG_STRING];
-              memcpy(tmp, client_out, client_len);
-              for (p = tmp; p < tmp + client_len; p++)
-              {
-                if (*p == '\0')
-                  *p = '.';
-              }
-              *p = '\0';
-              mutt_debug(1, "SASL> %s\n", tmp);
-            }
-
+            nntp_log_binbuf(client_out, client_len, "SASL", MUTT_SOCK_LOG_FULL);
             if (*buf)
               mutt_str_strcat(buf, sizeof(buf), " ");
             len = strlen(buf);
@@ -692,18 +712,8 @@ static int nntp_auth(struct NntpAccountData *adata)
             mutt_debug(1, "error base64-decoding server response.\n");
             break;
           }
-          else if (DebugLevel >= MUTT_SOCK_LOG_FULL)
-          {
-            char tmp[LONG_STRING];
-            memcpy(tmp, buf, len);
-            for (p = tmp; p < tmp + len; p++)
-            {
-              if (*p == '\0')
-                *p = '.';
-            }
-            *p = '\0';
-            mutt_debug(1, "SASL< %s\n", tmp);
-          }
+          else
+            nntp_log_binbuf(buf, len, "SASL", MUTT_SOCK_LOG_FULL);
 
           while (true)
           {

--- a/nntp/nntp.c
+++ b/nntp/nntp.c
@@ -562,7 +562,7 @@ static int nntp_auth(struct NntpAccountData *adata)
       p++;
     }
 
-    mutt_debug(1, "available methods: %s\n", adata->authenticators);
+    mutt_debug(LL_DEBUG1, "available methods: %s\n", adata->authenticators);
     a = authenticators;
     while (true)
     {
@@ -593,7 +593,7 @@ static int nntp_auth(struct NntpAccountData *adata)
         if (*m != '\0' && *m != ' ')
           continue;
       }
-      mutt_debug(1, "trying method %s\n", method);
+      mutt_debug(LL_DEBUG1, "trying method %s\n", method);
 
       /* AUTHINFO USER authentication */
       if (strcmp(method, "USER") == 0)
@@ -644,7 +644,7 @@ static int nntp_auth(struct NntpAccountData *adata)
 
         if (mutt_sasl_client_new(conn, &saslconn) < 0)
         {
-          mutt_debug(1, "error allocating SASL connection.\n");
+          mutt_debug(LL_DEBUG1, "error allocating SASL connection.\n");
           continue;
         }
 
@@ -659,7 +659,8 @@ static int nntp_auth(struct NntpAccountData *adata)
         if (rc != SASL_OK && rc != SASL_CONTINUE)
         {
           sasl_dispose(&saslconn);
-          mutt_debug(1, "error starting SASL authentication exchange.\n");
+          mutt_debug(LL_DEBUG1,
+                     "error starting SASL authentication exchange.\n");
           continue;
         }
 
@@ -679,7 +680,7 @@ static int nntp_auth(struct NntpAccountData *adata)
             if (sasl_encode64(client_out, client_len, buf + len,
                               sizeof(buf) - len, &len) != SASL_OK)
             {
-              mutt_debug(1, "error base64-encoding client response.\n");
+              mutt_debug(LL_DEBUG1, "error base64-encoding client response.\n");
               break;
             }
           }
@@ -712,7 +713,7 @@ static int nntp_auth(struct NntpAccountData *adata)
           else if (sasl_decode64(inbuf + 4, strlen(inbuf + 4), buf,
                                  sizeof(buf) - 1, &len) != SASL_OK)
           {
-            mutt_debug(1, "error base64-decoding server response.\n");
+            mutt_debug(LL_DEBUG1, "error base64-decoding server response.\n");
             break;
           }
           else
@@ -962,7 +963,7 @@ static int fetch_description(char *line, void *data)
   if (mdata && (mutt_str_strcmp(desc, mdata->desc) != 0))
   {
     mutt_str_replace(&mdata->desc, desc);
-    mutt_debug(2, "group: %s, desc: %s\n", line, desc);
+    mutt_debug(LL_DEBUG2, "group: %s, desc: %s\n", line, desc);
   }
   return 0;
 }
@@ -1111,7 +1112,7 @@ static int parse_overview_line(char *line, void *data)
     *field++ = '\0';
   if (sscanf(line, ANUM, &anum) != 1)
     return 0;
-  mutt_debug(2, "" ANUM "\n", anum);
+  mutt_debug(LL_DEBUG2, "" ANUM "\n", anum);
 
   /* out of bounds */
   if (anum < fc->first || anum > fc->last)
@@ -1179,7 +1180,7 @@ static int parse_overview_line(char *line, void *data)
     void *hdata = mutt_hcache_fetch(fc->hc, buf, strlen(buf));
     if (hdata)
     {
-      mutt_debug(2, "mutt_hcache_fetch %s\n", buf);
+      mutt_debug(LL_DEBUG2, "mutt_hcache_fetch %s\n", buf);
       mutt_email_free(&e);
       e = mutt_hcache_restore(hdata);
       m->emails[m->msg_count] = e;
@@ -1193,7 +1194,7 @@ static int parse_overview_line(char *line, void *data)
       {
         if (mdata->bcache)
         {
-          mutt_debug(2, "mutt_bcache_del %s\n", buf);
+          mutt_debug(LL_DEBUG2, "mutt_bcache_del %s\n", buf);
           mutt_bcache_del(mdata->bcache, buf);
         }
         save = false;
@@ -1203,7 +1204,7 @@ static int parse_overview_line(char *line, void *data)
     /* not cached yet, store header */
     else
     {
-      mutt_debug(2, "mutt_hcache_store %s\n", buf);
+      mutt_debug(LL_DEBUG2, "mutt_hcache_store %s\n", buf);
       mutt_hcache_store(fc->hc, buf, strlen(buf), e, 0);
     }
   }
@@ -1313,14 +1314,14 @@ static int nntp_fetch_headers(struct Mailbox *m, void *hc, anum_t first, anum_t 
         snprintf(buf, sizeof(buf), "%u", current);
         if (mdata->bcache)
         {
-          mutt_debug(2, "#1 mutt_bcache_del %s\n", buf);
+          mutt_debug(LL_DEBUG2, "#1 mutt_bcache_del %s\n", buf);
           mutt_bcache_del(mdata->bcache, buf);
         }
 
 #ifdef USE_HCACHE
         if (fc.hc)
         {
-          mutt_debug(2, "mutt_hcache_delete %s\n", buf);
+          mutt_debug(LL_DEBUG2, "mutt_hcache_delete %s\n", buf);
           mutt_hcache_delete(fc.hc, buf, strlen(buf));
         }
 #endif
@@ -1361,7 +1362,7 @@ static int nntp_fetch_headers(struct Mailbox *m, void *hc, anum_t first, anum_t 
     hdata = mutt_hcache_fetch(fc.hc, buf, strlen(buf));
     if (hdata)
     {
-      mutt_debug(2, "mutt_hcache_fetch %s\n", buf);
+      mutt_debug(LL_DEBUG2, "mutt_hcache_fetch %s\n", buf);
       e = mutt_hcache_restore(hdata);
       m->emails[m->msg_count] = e;
       mutt_hcache_free(fc.hc, &hdata);
@@ -1373,7 +1374,7 @@ static int nntp_fetch_headers(struct Mailbox *m, void *hc, anum_t first, anum_t 
         mutt_email_free(&e);
         if (mdata->bcache)
         {
-          mutt_debug(2, "#2 mutt_bcache_del %s\n", buf);
+          mutt_debug(LL_DEBUG2, "#2 mutt_bcache_del %s\n", buf);
           mutt_bcache_del(mdata->bcache, buf);
         }
         continue;
@@ -1429,7 +1430,7 @@ static int nntp_fetch_headers(struct Mailbox *m, void *hc, anum_t first, anum_t 
         if (mdata->bcache)
         {
           snprintf(buf, sizeof(buf), "%u", current);
-          mutt_debug(2, "#3 mutt_bcache_del %s\n", buf);
+          mutt_debug(LL_DEBUG2, "#3 mutt_bcache_del %s\n", buf);
           mutt_bcache_del(mdata->bcache, buf);
         }
         rc = 0;
@@ -1626,7 +1627,7 @@ static int check_mailbox(struct Mailbox *m)
         {
           bool deleted;
 
-          mutt_debug(2, "#1 mutt_hcache_fetch %s\n", buf);
+          mutt_debug(LL_DEBUG2, "#1 mutt_hcache_fetch %s\n", buf);
           e = mutt_hcache_restore(hdata);
           mutt_hcache_free(hc, &hdata);
           e->edata = NULL;
@@ -1670,7 +1671,7 @@ static int check_mailbox(struct Mailbox *m)
       hdata = mutt_hcache_fetch(hc, buf, strlen(buf));
       if (hdata)
       {
-        mutt_debug(2, "#2 mutt_hcache_fetch %s\n", buf);
+        mutt_debug(LL_DEBUG2, "#2 mutt_hcache_fetch %s\n", buf);
         if (m->msg_count >= m->email_max)
           mx_alloc_memory(m);
 
@@ -1683,7 +1684,7 @@ static int check_mailbox(struct Mailbox *m)
           mutt_email_free(&e);
           if (mdata->bcache)
           {
-            mutt_debug(2, "mutt_bcache_del %s\n", buf);
+            mutt_debug(LL_DEBUG2, "mutt_bcache_del %s\n", buf);
             mutt_bcache_del(mdata->bcache, buf);
           }
           continue;
@@ -1776,7 +1777,7 @@ static int nntp_date(struct NntpAccountData *adata, time_t *now)
       *now = timegm(&tm);
       if (*now >= 0)
       {
-        mutt_debug(1, "server time is %lu\n", *now);
+        mutt_debug(LL_DEBUG1, "server time is %lu\n", *now);
         return 0;
       }
     }
@@ -2647,7 +2648,7 @@ static int nntp_mbox_sync(struct Mailbox *m, int *index_hint)
     snprintf(buf, sizeof(buf), "%d", nntp_edata_get(e)->article_num);
     if (mdata->bcache && e->deleted)
     {
-      mutt_debug(2, "mutt_bcache_del %s\n", buf);
+      mutt_debug(LL_DEBUG2, "mutt_bcache_del %s\n", buf);
       mutt_bcache_del(mdata->bcache, buf);
     }
 
@@ -2656,7 +2657,7 @@ static int nntp_mbox_sync(struct Mailbox *m, int *index_hint)
     {
       if (e->deleted && !e->read)
         mdata->unread--;
-      mutt_debug(2, "mutt_hcache_store %s\n", buf);
+      mutt_debug(LL_DEBUG2, "mutt_hcache_store %s\n", buf);
       mutt_hcache_store(hc, buf, strlen(buf), e, 0);
     }
 #endif

--- a/notmuch/mutt_notmuch.c
+++ b/notmuch/mutt_notmuch.c
@@ -161,7 +161,7 @@ void nm_mdata_free(void **ptr)
   if (!ptr || !*ptr)
     return;
 
-  mutt_debug(1, "nm: freeing context data %p\n", ptr);
+  mutt_debug(LL_DEBUG1, "nm: freeing context data %p\n", ptr);
 
   struct NmMboxData *mdata = *ptr;
 
@@ -184,7 +184,7 @@ struct NmMboxData *nm_mdata_new(const char *uri)
     return NULL;
 
   struct NmMboxData *mdata = mutt_mem_calloc(1, sizeof(struct NmMboxData));
-  mutt_debug(1, "nm: initialize mailbox mdata %p\n", (void *) mdata);
+  mutt_debug(LL_DEBUG1, "nm: initialize mailbox mdata %p\n", (void *) mdata);
 
   mdata->db_limit = NmDbLimit;
   mdata->query_type = string_to_query_type(NmQueryType);
@@ -225,7 +225,7 @@ void nm_edata_free(void **ptr)
     return;
 
   struct NmEmailData *edata = *ptr;
-  mutt_debug(2, "nm: freeing email %p\n", (void *) edata);
+  mutt_debug(LL_DEBUG2, "nm: freeing email %p\n", (void *) edata);
   FREE(&edata->folder);
   FREE(&edata->oldpath);
   FREE(&edata->virtual_id);
@@ -360,7 +360,7 @@ static bool query_window_check_timebase(const char *timebase)
  */
 static void query_window_reset(void)
 {
-  mutt_debug(2, "entering\n");
+  mutt_debug(LL_DEBUG2, "entering\n");
   cs_str_native_set(Config, "nm_query_window_current_position", 0, NULL);
 }
 
@@ -404,7 +404,7 @@ static void query_window_reset(void)
  */
 static bool windowed_query_from_query(const char *query, char *buf, size_t buflen)
 {
-  mutt_debug(2, "nm: %s\n", query);
+  mutt_debug(LL_DEBUG2, "nm: %s\n", query);
 
   int beg = NmQueryWindowDuration * (NmQueryWindowCurrentPosition + 1);
   int end = NmQueryWindowDuration * NmQueryWindowCurrentPosition;
@@ -424,7 +424,7 @@ static bool windowed_query_from_query(const char *query, char *buf, size_t bufle
   {
     mutt_message(_("Invalid nm_query_window_timebase value (valid values are: "
                    "hour, day, week, month or year)"));
-    mutt_debug(2, "Invalid nm_query_window_timebase value\n");
+    mutt_debug(LL_DEBUG2, "Invalid nm_query_window_timebase value\n");
     return false;
   }
 
@@ -441,7 +441,7 @@ static bool windowed_query_from_query(const char *query, char *buf, size_t bufle
              end, NmQueryWindowTimebase, NmQueryWindowCurrentSearch);
   }
 
-  mutt_debug(2, "nm: %s -> %s\n", query, buf);
+  mutt_debug(LL_DEBUG2, "nm: %s -> %s\n", query, buf);
 
   return true;
 }
@@ -464,7 +464,7 @@ static bool windowed_query_from_query(const char *query, char *buf, size_t bufle
  */
 static char *get_query_string(struct NmMboxData *mdata, bool window)
 {
-  mutt_debug(2, "nm: %s\n", window ? "true" : "false");
+  mutt_debug(LL_DEBUG2, "nm: %s\n", window ? "true" : "false");
 
   if (!mdata)
     return NULL;
@@ -509,10 +509,10 @@ static char *get_query_string(struct NmMboxData *mdata, bool window)
       mdata->db_query = mutt_str_strdup(buf);
     }
 
-    mutt_debug(2, "nm: query (windowed) '%s'\n", mdata->db_query);
+    mutt_debug(LL_DEBUG2, "nm: query (windowed) '%s'\n", mdata->db_query);
   }
   else
-    mutt_debug(2, "nm: query '%s'\n", mdata->db_query);
+    mutt_debug(LL_DEBUG2, "nm: query '%s'\n", mdata->db_query);
 
   return mdata->db_query;
 }
@@ -556,7 +556,7 @@ static void apply_exclude_tags(notmuch_query_t *query)
       break;
     *end = '\0';
 
-    mutt_debug(2, "nm: query exclude tag '%s'\n", tag);
+    mutt_debug(LL_DEBUG2, "nm: query exclude tag '%s'\n", tag);
     notmuch_query_add_tag_exclude(query, tag);
     end = NULL;
     tag = NULL;
@@ -590,7 +590,7 @@ static notmuch_query_t *get_query(struct Mailbox *m, bool writable)
 
   apply_exclude_tags(q);
   notmuch_query_set_sort(q, NOTMUCH_SORT_NEWEST_FIRST);
-  mutt_debug(2, "nm: query successfully initialized (%s)\n", str);
+  mutt_debug(LL_DEBUG2, "nm: query successfully initialized (%s)\n", str);
   return q;
 err:
   nm_db_release(m);
@@ -610,7 +610,7 @@ static int update_email_tags(struct Email *e, notmuch_message_t *msg)
   char *new_tags = NULL;
   char *old_tags = NULL;
 
-  mutt_debug(2, "nm: tags update requested (%s)\n", edata->virtual_id);
+  mutt_debug(LL_DEBUG2, "nm: tags update requested (%s)\n", edata->virtual_id);
 
   for (notmuch_tags_t *tags = notmuch_message_get_tags(msg);
        tags && notmuch_tags_valid(tags); notmuch_tags_move_to_next(tags))
@@ -628,7 +628,7 @@ static int update_email_tags(struct Email *e, notmuch_message_t *msg)
   {
     FREE(&old_tags);
     FREE(&new_tags);
-    mutt_debug(2, "nm: tags unchanged\n");
+    mutt_debug(LL_DEBUG2, "nm: tags unchanged\n");
     return 1;
   }
 
@@ -637,11 +637,11 @@ static int update_email_tags(struct Email *e, notmuch_message_t *msg)
   FREE(&new_tags);
 
   new_tags = driver_tags_get_transformed(&e->tags);
-  mutt_debug(2, "nm: new tags: '%s'\n", new_tags);
+  mutt_debug(LL_DEBUG2, "nm: new tags: '%s'\n", new_tags);
   FREE(&new_tags);
 
   new_tags = driver_tags_get(&e->tags);
-  mutt_debug(2, "nm: new tag transforms: '%s'\n", new_tags);
+  mutt_debug(LL_DEBUG2, "nm: new tag transforms: '%s'\n", new_tags);
   FREE(&new_tags);
 
   return 0;
@@ -658,7 +658,7 @@ static int update_message_path(struct Email *e, const char *path)
 {
   struct NmEmailData *edata = e->edata;
 
-  mutt_debug(2, "nm: path update requested path=%s, (%s)\n", path, edata->virtual_id);
+  mutt_debug(LL_DEBUG2, "nm: path update requested path=%s, (%s)\n", path, edata->virtual_id);
 
   char *p = strrchr(path, '/');
   if (p && ((p - path) > 3) &&
@@ -678,7 +678,7 @@ static int update_message_path(struct Email *e, const char *path)
 
     edata->folder = mutt_str_substr_dup(path, p);
 
-    mutt_debug(2, "nm: folder='%s', file='%s'\n", edata->folder, e->path);
+    mutt_debug(LL_DEBUG2, "nm: folder='%s', file='%s'\n", edata->folder, e->path);
     return 0;
   }
 
@@ -753,7 +753,7 @@ static int init_email(struct Email *e, const char *path, notmuch_message_t *msg)
   const char *id = notmuch_message_get_message_id(msg);
   edata->virtual_id = mutt_str_strdup(id);
 
-  mutt_debug(2, "nm: [e=%p, edata=%p] (%s)\n", (void *) e, (void *) e->edata, id);
+  mutt_debug(LL_DEBUG2, "nm: [e=%p, edata=%p] (%s)\n", (void *) e, (void *) e->edata, id);
 
   if (!e->env->message_id)
     e->env->message_id = nm2mutt_message_id(id);
@@ -849,18 +849,18 @@ static struct Email *get_mutt_email(struct Mailbox *m, notmuch_message_t *msg)
   if (!id)
     return NULL;
 
-  mutt_debug(2, "nm: neomutt email, id='%s'\n", id);
+  mutt_debug(LL_DEBUG2, "nm: neomutt email, id='%s'\n", id);
 
   if (!m->id_hash)
   {
-    mutt_debug(2, "nm: init hash\n");
+    mutt_debug(LL_DEBUG2, "nm: init hash\n");
     m->id_hash = mutt_make_id_hash(m);
     if (!m->id_hash)
       return NULL;
   }
 
   char *mid = nm2mutt_message_id(id);
-  mutt_debug(2, "nm: neomutt id='%s'\n", mid);
+  mutt_debug(LL_DEBUG2, "nm: neomutt id='%s'\n", mid);
 
   struct Email *e = mutt_hash_find(m->id_hash, mid);
   FREE(&mid);
@@ -889,7 +889,7 @@ static void append_message(struct Mailbox *m, notmuch_query_t *q,
   {
     mdata->ignmsgcount++;
     progress_update(m, q);
-    mutt_debug(2, "nm: ignore id=%s, already in the m\n",
+    mutt_debug(LL_DEBUG2, "nm: ignore id=%s, already in the m\n",
                notmuch_message_get_message_id(msg));
     return;
   }
@@ -898,12 +898,12 @@ static void append_message(struct Mailbox *m, notmuch_query_t *q,
   if (!path)
     return;
 
-  mutt_debug(2, "nm: appending message, i=%d, id=%s, path=%s\n", m->msg_count,
-             notmuch_message_get_message_id(msg), path);
+  mutt_debug(LL_DEBUG2, "nm: appending message, i=%d, id=%s, path=%s\n",
+             m->msg_count, notmuch_message_get_message_id(msg), path);
 
   if (m->msg_count >= m->email_max)
   {
-    mutt_debug(2, "nm: allocate mx memory\n");
+    mutt_debug(LL_DEBUG2, "nm: allocate mx memory\n");
     mx_alloc_memory(m);
   }
   if (access(path, F_OK) == 0)
@@ -921,7 +921,7 @@ static void append_message(struct Mailbox *m, notmuch_query_t *q,
         e = maildir_parse_stream(MUTT_MAILDIR, f, newpath, false, NULL);
         fclose(f);
 
-        mutt_debug(1, "nm: not up-to-date: %s -> %s\n", path, newpath);
+        mutt_debug(LL_DEBUG1, "nm: not up-to-date: %s -> %s\n", path, newpath);
       }
     }
     FREE(&folder);
@@ -929,13 +929,13 @@ static void append_message(struct Mailbox *m, notmuch_query_t *q,
 
   if (!e)
   {
-    mutt_debug(1, "nm: failed to parse message: %s\n", path);
+    mutt_debug(LL_DEBUG1, "nm: failed to parse message: %s\n", path);
     goto done;
   }
   if (init_email(e, newpath ? newpath : path, msg) != 0)
   {
     mutt_email_free(&e);
-    mutt_debug(1, "nm: failed to append email!\n");
+    mutt_debug(LL_DEBUG1, "nm: failed to append email!\n");
     goto done;
   }
 
@@ -952,7 +952,7 @@ static void append_message(struct Mailbox *m, notmuch_query_t *q,
 
     if (edata)
     {
-      mutt_debug(1, "nm: remember obsolete path: %s\n", path);
+      mutt_debug(LL_DEBUG1, "nm: remember obsolete path: %s\n", path);
       edata->oldpath = mutt_str_strdup(path);
     }
   }
@@ -1149,7 +1149,7 @@ static notmuch_message_t *get_nm_message(notmuch_database_t *db, struct Email *e
   notmuch_message_t *msg = NULL;
   char *id = email_get_id(e);
 
-  mutt_debug(2, "nm: find message (%s)\n", id);
+  mutt_debug(LL_DEBUG2, "nm: find message (%s)\n", id);
 
   if (id && db)
     notmuch_database_find_message(db, id, &msg);
@@ -1215,12 +1215,12 @@ static int update_tags(notmuch_message_t *msg, const char *tags)
 
     if (*tag == '-')
     {
-      mutt_debug(1, "nm: remove tag: '%s'\n", tag + 1);
+      mutt_debug(LL_DEBUG1, "nm: remove tag: '%s'\n", tag + 1);
       notmuch_message_remove_tag(msg, tag + 1);
     }
     else if (*tag == '!')
     {
-      mutt_debug(1, "nm: toggle tag: '%s'\n", tag + 1);
+      mutt_debug(LL_DEBUG1, "nm: toggle tag: '%s'\n", tag + 1);
       if (nm_message_has_tag(msg, tag + 1))
       {
         notmuch_message_remove_tag(msg, tag + 1);
@@ -1232,7 +1232,7 @@ static int update_tags(notmuch_message_t *msg, const char *tags)
     }
     else
     {
-      mutt_debug(1, "nm: add tag: '%s'\n", (*tag == '+') ? tag + 1 : tag);
+      mutt_debug(LL_DEBUG1, "nm: add tag: '%s'\n", (*tag == '+') ? tag + 1 : tag);
       notmuch_message_add_tag(msg, (*tag == '+') ? tag + 1 : tag);
     }
     end = NULL;
@@ -1357,7 +1357,7 @@ static int rename_maildir_filename(const char *old, char *buf, size_t buflen, st
 
   if (rename(old, buf) != 0)
   {
-    mutt_debug(1, "nm: rename(2) failed %s -> %s\n", old, buf);
+    mutt_debug(LL_DEBUG1, "nm: rename(2) failed %s -> %s\n", old, buf);
     return -1;
   }
 
@@ -1377,7 +1377,7 @@ static int remove_filename(struct Mailbox *m, const char *path)
   if (!mdata)
     return -1;
 
-  mutt_debug(2, "nm: remove filename '%s'\n", path);
+  mutt_debug(LL_DEBUG2, "nm: remove filename '%s'\n", path);
 
   notmuch_database_t *db = nm_db_get(m, true);
   if (!db)
@@ -1400,24 +1400,24 @@ static int remove_filename(struct Mailbox *m, const char *path)
   switch (st)
   {
     case NOTMUCH_STATUS_SUCCESS:
-      mutt_debug(2, "nm: remove success, call unlink\n");
+      mutt_debug(LL_DEBUG2, "nm: remove success, call unlink\n");
       unlink(path);
       break;
     case NOTMUCH_STATUS_DUPLICATE_MESSAGE_ID:
-      mutt_debug(2, "nm: remove success (duplicate), call unlink\n");
+      mutt_debug(LL_DEBUG2, "nm: remove success (duplicate), call unlink\n");
       unlink(path);
       for (ls = notmuch_message_get_filenames(msg);
            ls && notmuch_filenames_valid(ls); notmuch_filenames_move_to_next(ls))
       {
         path = notmuch_filenames_get(ls);
 
-        mutt_debug(2, "nm: remove duplicate: '%s'\n", path);
+        mutt_debug(LL_DEBUG2, "nm: remove duplicate: '%s'\n", path);
         unlink(path);
         notmuch_database_remove_message(db, path);
       }
       break;
     default:
-      mutt_debug(1, "nm: failed to remove '%s' [st=%d]\n", path, (int) st);
+      mutt_debug(LL_DEBUG1, "nm: failed to remove '%s' [st=%d]\n", path, (int) st);
       break;
   }
 
@@ -1452,12 +1452,12 @@ static int rename_filename(struct Mailbox *m, const char *old, const char *new,
   notmuch_filenames_t *ls = NULL;
   notmuch_message_t *msg = NULL;
 
-  mutt_debug(1, "nm: rename filename, %s -> %s\n", old, new);
+  mutt_debug(LL_DEBUG1, "nm: rename filename, %s -> %s\n", old, new);
   int trans = nm_db_trans_begin(m);
   if (trans < 0)
     return -1;
 
-  mutt_debug(2, "nm: rename: add '%s'\n", new);
+  mutt_debug(LL_DEBUG2, "nm: rename: add '%s'\n", new);
 #ifdef HAVE_NOTMUCH_DATABASE_INDEX_FILE
   st = notmuch_database_index_file(db, new, NULL, &msg);
 #else
@@ -1466,18 +1466,18 @@ static int rename_filename(struct Mailbox *m, const char *old, const char *new,
 
   if ((st != NOTMUCH_STATUS_SUCCESS) && (st != NOTMUCH_STATUS_DUPLICATE_MESSAGE_ID))
   {
-    mutt_debug(1, "nm: failed to add '%s' [st=%d]\n", new, (int) st);
+    mutt_debug(LL_DEBUG1, "nm: failed to add '%s' [st=%d]\n", new, (int) st);
     goto done;
   }
 
-  mutt_debug(2, "nm: rename: rem '%s'\n", old);
+  mutt_debug(LL_DEBUG2, "nm: rename: rem '%s'\n", old);
   st = notmuch_database_remove_message(db, old);
   switch (st)
   {
     case NOTMUCH_STATUS_SUCCESS:
       break;
     case NOTMUCH_STATUS_DUPLICATE_MESSAGE_ID:
-      mutt_debug(2, "nm: rename: syncing duplicate filename\n");
+      mutt_debug(LL_DEBUG2, "nm: rename: syncing duplicate filename\n");
       notmuch_message_destroy(msg);
       msg = NULL;
       notmuch_database_find_message_by_filename(db, new, &msg);
@@ -1491,11 +1491,11 @@ static int rename_filename(struct Mailbox *m, const char *old, const char *new,
         if (strcmp(new, path) == 0)
           continue;
 
-        mutt_debug(2, "nm: rename: syncing duplicate: %s\n", path);
+        mutt_debug(LL_DEBUG2, "nm: rename: syncing duplicate: %s\n", path);
 
         if (rename_maildir_filename(path, newpath, sizeof(newpath), e) == 0)
         {
-          mutt_debug(2, "nm: rename dup %s -> %s\n", path, newpath);
+          mutt_debug(LL_DEBUG2, "nm: rename dup %s -> %s\n", path, newpath);
           notmuch_database_remove_message(db, path);
 #ifdef HAVE_NOTMUCH_DATABASE_INDEX_FILE
           notmuch_database_index_file(db, newpath, NULL, NULL);
@@ -1510,7 +1510,7 @@ static int rename_filename(struct Mailbox *m, const char *old, const char *new,
       st = NOTMUCH_STATUS_SUCCESS;
       break;
     default:
-      mutt_debug(1, "nm: failed to remove '%s' [st=%d]\n", old, (int) st);
+      mutt_debug(LL_DEBUG1, "nm: failed to remove '%s' [st=%d]\n", old, (int) st);
       break;
   }
 
@@ -1559,7 +1559,7 @@ static unsigned int count_query(notmuch_database_t *db, const char *qstr, int li
   res = notmuch_query_count_messages(q);
 #endif
   notmuch_query_destroy(q);
-  mutt_debug(1, "nm: count '%s', result=%d\n", qstr, res);
+  mutt_debug(LL_DEBUG1, "nm: count '%s', result=%d\n", qstr, res);
 
   if (limit > 0 && res > limit)
     res = limit;
@@ -1602,7 +1602,8 @@ int nm_read_entire_thread(struct Mailbox *m, struct Email *e)
   if (!(db = nm_db_get(m, false)) || !(msg = get_nm_message(db, e)))
     goto done;
 
-  mutt_debug(1, "nm: reading entire-thread messages...[current count=%d]\n", m->msg_count);
+  mutt_debug(LL_DEBUG1, "nm: reading entire-thread messages...[current count=%d]\n",
+             m->msg_count);
 
   progress_reset(m);
   const char *id = notmuch_message_get_thread_id(msg);
@@ -1637,7 +1638,7 @@ done:
     mutt_message(_("No more messages in the thread"));
 
   mdata->oldmsgcount = 0;
-  mutt_debug(1, "nm: reading entire-thread messages... done [rc=%d, count=%d]\n",
+  mutt_debug(LL_DEBUG1, "nm: reading entire-thread messages... done [rc=%d, count=%d]\n",
              rc, m->msg_count);
   return rc;
 }
@@ -1682,7 +1683,7 @@ void nm_parse_type_from_query(struct NmMboxData *mdata, char *buf)
  */
 char *nm_uri_from_query(struct Mailbox *m, char *buf, size_t buflen)
 {
-  mutt_debug(2, "(%s)\n", buf);
+  mutt_debug(LL_DEBUG2, "(%s)\n", buf);
   struct NmMboxData *mdata = nm_mdata_get(m);
   char uri[PATH_MAX + LONG_STRING + 32]; /* path to DB + query + URI "decoration" */
   int added;
@@ -1728,7 +1729,7 @@ char *nm_uri_from_query(struct Mailbox *m, char *buf, size_t buflen)
   if (using_default_data)
     nm_mdata_free((void **) &mdata);
 
-  mutt_debug(1, "nm: uri from query '%s'\n", buf);
+  mutt_debug(LL_DEBUG1, "nm: uri from query '%s'\n", buf);
   return buf;
 }
 
@@ -1746,7 +1747,7 @@ void nm_query_window_forward(void)
   if (NmQueryWindowCurrentPosition != 0)
     NmQueryWindowCurrentPosition--;
 
-  mutt_debug(2, "(%d)\n", NmQueryWindowCurrentPosition);
+  mutt_debug(LL_DEBUG2, "(%d)\n", NmQueryWindowCurrentPosition);
 }
 
 /**
@@ -1760,7 +1761,7 @@ void nm_query_window_forward(void)
 void nm_query_window_backward(void)
 {
   NmQueryWindowCurrentPosition++;
-  mutt_debug(2, "(%d)\n", NmQueryWindowCurrentPosition);
+  mutt_debug(LL_DEBUG2, "(%d)\n", NmQueryWindowCurrentPosition);
 }
 
 /**
@@ -1783,7 +1784,7 @@ bool nm_message_is_still_queried(struct Mailbox *m, struct Email *e)
   if (safe_asprintf(&new_str, "id:%s and (%s)", email_get_id(e), orig_str) < 0)
     return false;
 
-  mutt_debug(2, "nm: checking if message is still queried: %s\n", new_str);
+  mutt_debug(LL_DEBUG2, "nm: checking if message is still queried: %s\n", new_str);
 
   notmuch_query_t *q = notmuch_query_create(db, new_str);
 
@@ -1815,8 +1816,8 @@ bool nm_message_is_still_queried(struct Mailbox *m, struct Email *e)
 
   notmuch_query_destroy(q);
 
-  mutt_debug(2, "nm: checking if message is still queried: %s = %s\n", new_str,
-             result ? "true" : "false");
+  mutt_debug(LL_DEBUG2, "nm: checking if message is still queried: %s = %s\n",
+             new_str, result ? "true" : "false");
 
   return result;
 }
@@ -1862,7 +1863,7 @@ static int nm_mbox_check_stats(struct Mailbox *m, int flags)
   notmuch_database_t *db = NULL;
   int rc = -1;
   int limit = NmDbLimit;
-  mutt_debug(1, "nm: count\n");
+  mutt_debug(LL_DEBUG1, "nm: count\n");
 
   url = url_parse(m->path);
   if (!url)
@@ -1923,11 +1924,11 @@ done:
   if (db)
   {
     nm_db_free(db);
-    mutt_debug(1, "nm: count close DB\n");
+    mutt_debug(LL_DEBUG1, "nm: count close DB\n");
   }
   url_free(&url);
 
-  mutt_debug(1, "nm: count done [rc=%d]\n", rc);
+  mutt_debug(LL_DEBUG1, "nm: count done [rc=%d]\n", rc);
   return rc;
 }
 
@@ -1981,7 +1982,7 @@ int nm_record_message(struct Mailbox *m, char *path, struct Email *e)
   if (!db)
     return -1;
 
-  mutt_debug(1, "nm: record message: %s\n", path);
+  mutt_debug(LL_DEBUG1, "nm: record message: %s\n", path);
   int trans = nm_db_trans_begin(m);
   if (trans < 0)
     goto done;
@@ -1994,7 +1995,7 @@ int nm_record_message(struct Mailbox *m, char *path, struct Email *e)
 
   if ((st != NOTMUCH_STATUS_SUCCESS) && (st != NOTMUCH_STATUS_DUPLICATE_MESSAGE_ID))
   {
-    mutt_debug(1, "nm: failed to add '%s' [st=%d]\n", path, (int) st);
+    mutt_debug(LL_DEBUG1, "nm: failed to add '%s' [st=%d]\n", path, (int) st);
     goto done;
   }
 
@@ -2047,7 +2048,7 @@ int nm_get_all_tags(struct Mailbox *m, char **tag_list, int *tag_count)
     goto done;
 
   *tag_count = 0;
-  mutt_debug(1, "nm: get all tags\n");
+  mutt_debug(LL_DEBUG1, "nm: get all tags\n");
 
   while (notmuch_tags_valid(tags))
   {
@@ -2069,7 +2070,7 @@ done:
 
   nm_db_release(m);
 
-  mutt_debug(1, "nm: get all tags done [rc=%d tag_count=%u]\n", rc, *tag_count);
+  mutt_debug(LL_DEBUG1, "nm: get all tags done [rc=%d tag_count=%u]\n", rc, *tag_count);
   return rc;
 }
 
@@ -2114,7 +2115,7 @@ static int nm_mbox_open(struct Mailbox *m)
   if (!mdata)
     return -1;
 
-  mutt_debug(1, "nm: reading messages...[current count=%d]\n", m->msg_count);
+  mutt_debug(LL_DEBUG1, "nm: reading messages...[current count=%d]\n", m->msg_count);
 
   progress_reset(m);
 
@@ -2155,7 +2156,7 @@ static int nm_mbox_open(struct Mailbox *m)
 
   mdata->oldmsgcount = 0;
 
-  mutt_debug(1, "nm: reading messages... done [rc=%d, count=%d]\n", rc, m->msg_count);
+  mutt_debug(LL_DEBUG1, "nm: reading messages... done [rc=%d, count=%d]\n", rc, m->msg_count);
   return rc;
 }
 
@@ -2184,17 +2185,17 @@ static int nm_mbox_check(struct Mailbox *m, int *index_hint)
 
   if (m->mtime.tv_sec >= mtime)
   {
-    mutt_debug(2, "nm: check unnecessary (db=%lu mailbox=%lu)\n", mtime, m->mtime);
+    mutt_debug(LL_DEBUG2, "nm: check unnecessary (db=%lu mailbox=%lu)\n", mtime, m->mtime);
     return 0;
   }
 
-  mutt_debug(1, "nm: checking (db=%lu mailbox=%lu)\n", mtime, m->mtime);
+  mutt_debug(LL_DEBUG1, "nm: checking (db=%lu mailbox=%lu)\n", mtime, m->mtime);
 
   notmuch_query_t *q = get_query(m, false);
   if (!q)
     goto done;
 
-  mutt_debug(1, "nm: start checking (count=%d)\n", m->msg_count);
+  mutt_debug(LL_DEBUG1, "nm: start checking (count=%d)\n", m->msg_count);
   mdata->oldmsgcount = m->msg_count;
   mdata->noprogress = true;
 
@@ -2280,7 +2281,7 @@ done:
   m->mtime.tv_sec = time(NULL);
   m->mtime.tv_nsec = 0;
 
-  mutt_debug(1, "nm: ... check done [count=%d, new_flags=%d, occult=%d]\n",
+  mutt_debug(LL_DEBUG1, "nm: ... check done [count=%d, new_flags=%d, occult=%d]\n",
              m->msg_count, new_flags, occult);
 
   return occult ? MUTT_REOPENED :
@@ -2306,7 +2307,7 @@ static int nm_mbox_sync(struct Mailbox *m, int *index_hint)
   bool changed = false;
   char msgbuf[PATH_MAX + 64];
 
-  mutt_debug(1, "nm: sync start ...\n");
+  mutt_debug(LL_DEBUG1, "nm: sync start ...\n");
 
   if (!m->quiet)
   {
@@ -2331,7 +2332,7 @@ static int nm_mbox_sync(struct Mailbox *m, int *index_hint)
     {
       mutt_str_strfcpy(old, edata->oldpath, sizeof(old));
       old[sizeof(old) - 1] = '\0';
-      mutt_debug(2, "nm: fixing obsolete path '%s'\n", old);
+      mutt_debug(LL_DEBUG2, "nm: fixing obsolete path '%s'\n", old);
     }
     else
       email_get_fullpath(e, old, sizeof(old));
@@ -2375,7 +2376,7 @@ static int nm_mbox_sync(struct Mailbox *m, int *index_hint)
   }
 
   FREE(&uri);
-  mutt_debug(1, "nm: .... sync done [rc=%d]\n", rc);
+  mutt_debug(LL_DEBUG1, "nm: .... sync done [rc=%d]\n", rc);
   return rc;
 }
 
@@ -2467,7 +2468,7 @@ static int nm_tags_commit(struct Mailbox *m, struct Email *e, char *buf)
   if (!(db = nm_db_get(m, true)) || !(msg = get_nm_message(db, e)))
     goto done;
 
-  mutt_debug(1, "nm: tags modify: '%s'\n", buf);
+  mutt_debug(LL_DEBUG1, "nm: tags modify: '%s'\n", buf);
 
   update_tags(msg, buf);
   update_email_flags(m, e, buf);
@@ -2483,7 +2484,7 @@ done:
     m->mtime.tv_sec = time(NULL);
     m->mtime.tv_nsec = 0;
   }
-  mutt_debug(1, "nm: tags modify done [rc=%d]\n", rc);
+  mutt_debug(LL_DEBUG1, "nm: tags modify done [rc=%d]\n", rc);
   return rc;
 }
 

--- a/notmuch/nm_db.c
+++ b/notmuch/nm_db.c
@@ -68,7 +68,7 @@ const char *nm_db_get_filename(struct Mailbox *m)
   if (nm_path_probe(db_filename, NULL) == MUTT_NOTMUCH)
     db_filename += NmUriProtocolLen;
 
-  mutt_debug(2, "nm: db filename '%s'\n", db_filename);
+  mutt_debug(LL_DEBUG2, "nm: db filename '%s'\n", db_filename);
   return db_filename;
 }
 
@@ -88,7 +88,7 @@ notmuch_database_t *nm_db_do_open(const char *filename, bool writable, bool verb
   char *msg = NULL;
 #endif
 
-  mutt_debug(1, "nm: db open '%s' %s (timeout %d)\n", filename,
+  mutt_debug(LL_DEBUG1, "nm: db open '%s' %s (timeout %d)\n", filename,
              writable ? "[WRITE]" : "[READ]", NmOpenTimeout);
 
   const notmuch_database_mode_t mode =
@@ -177,7 +177,7 @@ int nm_db_release(struct Mailbox *m)
   if (!adata || !adata->db || nm_db_is_longrun(m))
     return -1;
 
-  mutt_debug(1, "nm: db close\n");
+  mutt_debug(LL_DEBUG1, "nm: db close\n");
   nm_db_free(adata->db);
   adata->db = NULL;
   adata->longrun = false;
@@ -213,7 +213,7 @@ int nm_db_trans_begin(struct Mailbox *m)
   if (adata->trans)
     return 0;
 
-  mutt_debug(2, "nm: db trans start\n");
+  mutt_debug(LL_DEBUG2, "nm: db trans start\n");
   if (notmuch_database_begin_atomic(adata->db))
     return -1;
   adata->trans = true;
@@ -235,7 +235,7 @@ int nm_db_trans_end(struct Mailbox *m)
   if (!adata->trans)
     return 0;
 
-  mutt_debug(2, "nm: db trans end\n");
+  mutt_debug(LL_DEBUG2, "nm: db trans end\n");
   adata->trans = false;
   if (notmuch_database_end_atomic(adata->db))
     return -1;
@@ -260,7 +260,7 @@ int nm_db_get_mtime(struct Mailbox *m, time_t *mtime)
 
   char path[PATH_MAX];
   snprintf(path, sizeof(path), "%s/.notmuch/xapian", nm_db_get_filename(m));
-  mutt_debug(2, "nm: checking '%s' mtime\n", path);
+  mutt_debug(LL_DEBUG2, "nm: checking '%s' mtime\n", path);
 
   struct stat st;
   if (stat(path, &st))
@@ -297,7 +297,7 @@ void nm_db_longrun_init(struct Mailbox *m, bool writable)
     return;
 
   adata->longrun = true;
-  mutt_debug(2, "nm: long run initialized\n");
+  mutt_debug(LL_DEBUG2, "nm: long run initialized\n");
 }
 
 /**
@@ -312,7 +312,7 @@ void nm_db_longrun_done(struct Mailbox *m)
   {
     adata->longrun = false; /* to force nm_db_release() released DB */
     if (nm_db_release(m) == 0)
-      mutt_debug(2, "nm: long run deinitialized\n");
+      mutt_debug(LL_DEBUG2, "nm: long run deinitialized\n");
     else
       adata->longrun = true;
   }
@@ -328,6 +328,6 @@ void nm_db_debug_check(struct Mailbox *m)
   if (!adata || !adata->db)
     return;
 
-  mutt_debug(1, "nm: ERROR: db is open, closing\n");
+  mutt_debug(LL_DEBUG1, "nm: ERROR: db is open, closing\n");
   nm_db_release(m);
 }

--- a/pager.c
+++ b/pager.c
@@ -1333,7 +1333,7 @@ static int fill_buffer(FILE *f, LOFF_T *last_pos, LOFF_T offset, unsigned char *
                ((check_attachment_marker((char *) p) == 0) ||
                 (check_protected_header_marker((char *) p) == 0)))
       {
-        mutt_debug(2, "Seen attachment marker.\n");
+        mutt_debug(LL_DEBUG2, "Seen attachment marker.\n");
         while (*p++ != '\a') /* skip pseudo-ANSI sequence */
           ;
       }
@@ -1403,7 +1403,7 @@ static int format_line(struct Line **line_info, int n, unsigned char *buf, int f
     {
       if (k == (size_t)(-1))
         memset(&mbstate, 0, sizeof(mbstate));
-      mutt_debug(1, "mbrtowc returned %lu; errno = %d.\n", k, errno);
+      mutt_debug(LL_DEBUG1, "mbrtowc returned %lu; errno = %d.\n", k, errno);
       if (col + 4 > wrap_cols)
         break;
       col += 4;
@@ -1420,12 +1420,12 @@ static int format_line(struct Line **line_info, int n, unsigned char *buf, int f
       /* zero width space, zero width no-break space */
       if (wc == 0x200B || wc == 0xFEFF)
       {
-        mutt_debug(3, "skip zero-width character U+%04X\n", (unsigned short) wc);
+        mutt_debug(LL_DEBUG3, "skip zero-width character U+%04X\n", (unsigned short) wc);
         continue;
       }
       if (mutt_mb_is_display_corrupting_utf8(wc))
       {
-        mutt_debug(3, "filtered U+%04X\n", (unsigned short) wc);
+        mutt_debug(LL_DEBUG3, "filtered U+%04X\n", (unsigned short) wc);
         continue;
       }
     }

--- a/pattern.c
+++ b/pattern.c
@@ -304,7 +304,7 @@ static bool eat_query(struct Pattern *pat, struct Buffer *s, struct Buffer *err)
   else
   {
     char *escaped_folder = mutt_path_escape(Context->mailbox->path);
-    mutt_debug(2, "escaped folder path: %s\n", escaped_folder);
+    mutt_debug(LL_DEBUG2, "escaped folder path: %s\n", escaped_folder);
     mutt_buffer_addch(&cmd_buf, '\'');
     mutt_buffer_addstr(&cmd_buf, escaped_folder);
     mutt_buffer_addch(&cmd_buf, '\'');
@@ -823,7 +823,7 @@ static int report_regerror(int regerr, regex_t *preg, struct Buffer *err)
   size_t ds = err->dsize;
 
   if (regerror(regerr, preg, err->data, ds) > ds)
-    mutt_debug(2, "warning: buffer too small for regerror\n");
+    mutt_debug(LL_DEBUG2, "warning: buffer too small for regerror\n");
   /* The return value is fixed, exists only to shorten code at callsite */
   return RANGE_E_SYNTAX;
 }
@@ -987,7 +987,7 @@ static int eat_range_by_regex(struct Pattern *pat, struct Buffer *s, int kind,
   /* Snarf the contents of the two sides of the range. */
   pat->min = scan_range_slot(s, pmatch, pspec->lgrp, RANGE_S_LEFT, kind);
   pat->max = scan_range_slot(s, pmatch, pspec->rgrp, RANGE_S_RIGHT, kind);
-  mutt_debug(1, "pat->min=%d pat->max=%d\n", pat->min, pat->max);
+  mutt_debug(LL_DEBUG1, "pat->min=%d pat->max=%d\n", pat->min, pat->max);
 
   /* Special case for a bare 0. */
   if ((kind == RANGE_K_BARE) && (pat->min == 0) && (pat->max == 0))

--- a/pop/pop.c
+++ b/pop/pop.c
@@ -206,14 +206,14 @@ static int pop_read_header(struct PopAccountData *adata, struct Email *e)
       {
         adata->cmd_top = 1;
 
-        mutt_debug(1, "set TOP capability\n");
+        mutt_debug(LL_DEBUG1, "set TOP capability\n");
       }
 
       if (rc == -2)
       {
         adata->cmd_top = 0;
 
-        mutt_debug(1, "unset TOP capability\n");
+        mutt_debug(LL_DEBUG1, "unset TOP capability\n");
         snprintf(adata->err_msg, sizeof(adata->err_msg), "%s",
                  _("Command TOP is not supported by server"));
       }
@@ -286,7 +286,7 @@ static int fetch_uidl(char *line, void *data)
 
   if (i == m->msg_count)
   {
-    mutt_debug(1, "new header %d %s\n", index, line);
+    mutt_debug(LL_DEBUG1, "new header %d %s\n", index, line);
 
     if (i >= m->email_max)
       mx_alloc_memory(m);
@@ -416,14 +416,14 @@ static int pop_fetch_headers(struct Mailbox *m)
     {
       adata->cmd_uidl = 1;
 
-      mutt_debug(1, "set UIDL capability\n");
+      mutt_debug(LL_DEBUG1, "set UIDL capability\n");
     }
 
     if (ret == -2 && adata->cmd_uidl == 2)
     {
       adata->cmd_uidl = 0;
 
-      mutt_debug(1, "unset UIDL capability\n");
+      mutt_debug(LL_DEBUG1, "unset UIDL capability\n");
       snprintf(adata->err_msg, sizeof(adata->err_msg), "%s",
                _("Command UIDL is not supported by server"));
     }
@@ -564,7 +564,7 @@ static void pop_clear_cache(struct PopAccountData *adata)
   if (!adata->clear_cache)
     return;
 
-  mutt_debug(1, "delete cached messages\n");
+  mutt_debug(LL_DEBUG1, "delete cached messages\n");
 
   for (int i = 0; i < POP_CACHE_LEN; i++)
   {

--- a/pop/pop_auth.c
+++ b/pop/pop_auth.c
@@ -69,7 +69,7 @@ static enum PopAuthRes pop_auth_sasl(struct PopAccountData *adata, const char *m
 
   if (mutt_sasl_client_new(adata->conn, &saslconn) < 0)
   {
-    mutt_debug(1, "Error allocating SASL connection.\n");
+    mutt_debug(LL_DEBUG1, "Error allocating SASL connection.\n");
     return POP_A_FAILURE;
   }
 
@@ -132,7 +132,7 @@ static enum PopAuthRes pop_auth_sasl(struct PopAccountData *adata, const char *m
     if (mutt_str_startswith(inbuf, "+ ", CASE_MATCH) &&
         sasl_decode64(inbuf + 2, strlen(inbuf + 2), buf, bufsize - 1, &len) != SASL_OK)
     {
-      mutt_debug(1, "error base64-decoding server response.\n");
+      mutt_debug(LL_DEBUG1, "error base64-decoding server response.\n");
       goto bail;
     }
 
@@ -168,7 +168,7 @@ static enum PopAuthRes pop_auth_sasl(struct PopAccountData *adata, const char *m
       }
       if (sasl_encode64(pc, olen, buf, bufsize, &olen) != SASL_OK)
       {
-        mutt_debug(1, "error base64-encoding client response.\n");
+        mutt_debug(LL_DEBUG1, "error base64-encoding client response.\n");
         goto bail;
       }
     }
@@ -299,14 +299,14 @@ static enum PopAuthRes pop_auth_user(struct PopAccountData *adata, const char *m
     {
       adata->cmd_user = 1;
 
-      mutt_debug(1, "set USER capability\n");
+      mutt_debug(LL_DEBUG1, "set USER capability\n");
     }
 
     if (ret == -2)
     {
       adata->cmd_user = 0;
 
-      mutt_debug(1, "unset USER capability\n");
+      mutt_debug(LL_DEBUG1, "unset USER capability\n");
       snprintf(adata->err_msg, sizeof(adata->err_msg), "%s",
                _("Command USER is not supported by server"));
     }
@@ -429,7 +429,7 @@ int pop_authenticate(struct PopAccountData *adata)
       comma = strchr(method, ':');
       if (comma)
         *comma++ = '\0';
-      mutt_debug(2, "Trying method %s\n", method);
+      mutt_debug(LL_DEBUG2, "Trying method %s\n", method);
       authenticator = pop_authenticators;
 
       while (authenticator->authenticate)
@@ -472,7 +472,7 @@ int pop_authenticate(struct PopAccountData *adata)
   else
   {
     /* Fall back to default: any authenticator */
-    mutt_debug(2, "Using any available method.\n");
+    mutt_debug(LL_DEBUG2, "Using any available method.\n");
     authenticator = pop_authenticators;
 
     while (authenticator->authenticate)

--- a/pop/pop_auth.c
+++ b/pop/pop_auth.c
@@ -113,7 +113,7 @@ static enum PopAuthRes pop_auth_sasl(struct PopAccountData *adata, const char *m
   {
     mutt_str_strfcpy(buf + olen, "\r\n", bufsize - olen);
     mutt_socket_send(adata->conn, buf);
-    if (mutt_socket_readln(inbuf, sizeof(inbuf), adata->conn) < 0)
+    if (mutt_socket_readln_d(inbuf, sizeof(inbuf), adata->conn, MUTT_SOCK_LOG_FULL) < 0)
     {
       sasl_dispose(&saslconn);
       adata->status = POP_DISCONNECTED;

--- a/pop/pop_lib.c
+++ b/pop/pop_lib.c
@@ -427,7 +427,7 @@ void pop_logout(struct Mailbox *m)
     }
 
     if (ret < 0)
-      mutt_debug(1, "Error closing POP connection\n");
+      mutt_debug(LL_DEBUG1, "Error closing POP connection\n");
 
     mutt_clear_error();
   }

--- a/pop/pop_lib.c
+++ b/pop/pop_lib.c
@@ -447,26 +447,23 @@ void pop_logout(struct Mailbox *m)
 */
 int pop_query_d(struct PopAccountData *adata, char *buf, size_t buflen, char *msg)
 {
-  int dbg = MUTT_SOCK_LOG_CMD;
-
   if (adata->status != POP_CONNECTED)
     return -1;
 
   /* print msg instead of real command */
   if (msg)
   {
-    dbg = MUTT_SOCK_LOG_FULL;
     mutt_debug(MUTT_SOCK_LOG_CMD, "> %s", msg);
   }
 
-  mutt_socket_send_d(adata->conn, buf, dbg);
+  mutt_socket_send_d(adata->conn, buf, MUTT_SOCK_LOG_FULL);
 
   char *c = strpbrk(buf, " \r\n");
   if (c)
     *c = '\0';
   snprintf(adata->err_msg, sizeof(adata->err_msg), "%s: ", buf);
 
-  if (mutt_socket_readln(buf, buflen, adata->conn) < 0)
+  if (mutt_socket_readln_d(buf, buflen, adata->conn, MUTT_SOCK_LOG_FULL) < 0)
   {
     adata->status = POP_DISCONNECTED;
     return -1;
@@ -509,7 +506,8 @@ int pop_fetch_data(struct PopAccountData *adata, const char *query,
 
   while (true)
   {
-    const int chunk = mutt_socket_readln_d(buf, sizeof(buf), adata->conn, MUTT_SOCK_LOG_HDR);
+    const int chunk =
+        mutt_socket_readln_d(buf, sizeof(buf), adata->conn, MUTT_SOCK_LOG_FULL);
     if (chunk < 0)
     {
       adata->status = POP_DISCONNECTED;

--- a/postpone.c
+++ b/postpone.c
@@ -125,10 +125,10 @@ int mutt_num_postponed(struct Mailbox *m, bool force)
       if (newpc >= 0)
       {
         PostCount = newpc;
-        mutt_debug(3, "%d postponed IMAP messages found.\n", PostCount);
+        mutt_debug(LL_DEBUG3, "%d postponed IMAP messages found.\n", PostCount);
       }
       else
-        mutt_debug(3, "using old IMAP postponed count.\n");
+        mutt_debug(LL_DEBUG3, "using old IMAP postponed count.\n");
     }
     return PostCount;
   }

--- a/progress.c
+++ b/progress.c
@@ -144,7 +144,7 @@ void mutt_progress_init(struct Progress *progress, const char *msg,
     return;
   }
   if (gettimeofday(&tv, NULL) < 0)
-    mutt_debug(1, "gettimeofday failed: %d\n", errno);
+    mutt_debug(LL_DEBUG1, "gettimeofday failed: %d\n", errno);
   /* if timestamp is 0 no time-based suppression is done */
   if (TimeInc != 0)
   {

--- a/progress.c
+++ b/progress.c
@@ -211,7 +211,7 @@ void mutt_progress_update(struct Progress *progress, long pos, int percent)
     else
       snprintf(posstr, sizeof(posstr), "%ld", pos);
 
-    mutt_debug(5, "updating progress: %s\n", posstr);
+    mutt_debug(4, "updating progress: %s\n", posstr);
 
     progress->pos = pos;
     if (now)

--- a/query.c
+++ b/query.c
@@ -150,7 +150,7 @@ static struct Query *run_query(char *s, int quiet)
   thepid = mutt_create_filter(cmd, NULL, &fp, NULL);
   if (thepid < 0)
   {
-    mutt_debug(1, "unable to fork command: %s\n", cmd);
+    mutt_debug(LL_DEBUG1, "unable to fork command: %s\n", cmd);
     return 0;
   }
   if (!quiet)
@@ -190,7 +190,7 @@ static struct Query *run_query(char *s, int quiet)
   mutt_file_fclose(&fp);
   if (mutt_wait_filter(thepid))
   {
-    mutt_debug(1, "Error: %s\n", msg);
+    mutt_debug(LL_DEBUG1, "Error: %s\n", msg);
     if (!quiet)
       mutt_error("%s", msg);
   }

--- a/recvattach.c
+++ b/recvattach.c
@@ -332,7 +332,8 @@ const char *attach_format_str(char *buf, size_t buflen, size_t col, int cols,
           ch = dispchar[aptr->content->disposition];
         else
         {
-          mutt_debug(1, "ERROR: invalid content-disposition %d\n", aptr->content->disposition);
+          mutt_debug(LL_DEBUG1, "ERROR: invalid content-disposition %d\n",
+                     aptr->content->disposition);
           ch = '!';
         }
         snprintf(buf, buflen, "%c", ch);

--- a/rfc1524.c
+++ b/rfc1524.c
@@ -237,7 +237,7 @@ static int rfc1524_mailcap_parse(struct Body *a, char *filename, char *type,
       /* ignore comments */
       if (*buf == '#')
         continue;
-      mutt_debug(2, "mailcap entry: %s\n", buf);
+      mutt_debug(LL_DEBUG2, "mailcap entry: %s\n", buf);
 
       /* check type */
       ch = get_field(buf);
@@ -266,7 +266,7 @@ static int rfc1524_mailcap_parse(struct Body *a, char *filename, char *type,
       {
         field = ch;
         ch = get_field(ch);
-        mutt_debug(2, "field: %s\n", field);
+        mutt_debug(LL_DEBUG2, "field: %s\n", field);
         size_t plen;
 
         if (mutt_str_strcasecmp(field, "needsterminal") == 0)
@@ -333,7 +333,7 @@ static int rfc1524_mailcap_parse(struct Body *a, char *filename, char *type,
             mutt_mem_realloc(&test_command, len);
             if (rfc1524_expand_command(a, a->filename, type, test_command, len) == 1)
             {
-              mutt_debug(1, "Command is expecting to be piped\n");
+              mutt_debug(LL_DEBUG1, "Command is expecting to be piped\n");
             }
             if (mutt_system(test_command) != 0)
             {
@@ -476,7 +476,7 @@ int rfc1524_mailcap_lookup(struct Body *a, char *type,
     path[x] = '\0';
     mutt_expand_path(path, sizeof(path));
 
-    mutt_debug(2, "Checking mailcap file: %s\n", path);
+    mutt_debug(LL_DEBUG2, "Checking mailcap file: %s\n", path);
     found = rfc1524_mailcap_parse(a, path, type, entry, opt);
   }
 

--- a/rfc3676.c
+++ b/rfc3676.c
@@ -241,17 +241,17 @@ static void print_flowed_line(char *line, struct State *s, int ql,
   width = quote_width(s, ql);
   last = line[mutt_str_strlen(line) - 1];
 
-  mutt_debug(4, "f=f: line [%s], width = %ld, spaces = %lu\n", line,
+  mutt_debug(5, "f=f: line [%s], width = %ld, spaces = %lu\n", line,
              (long) width, fst->spaces);
 
   for (words = 0; (p = strsep(&line, " "));)
   {
-    mutt_debug(4, "f=f: word [%s], width: %lu, remaining = [%s]\n", p, fst->width, line);
+    mutt_debug(5, "f=f: word [%s], width: %lu, remaining = [%s]\n", p, fst->width, line);
 
     /* remember number of spaces */
     if (!*p)
     {
-      mutt_debug(4, "f=f: additional space\n");
+      mutt_debug(3, "f=f: additional space\n");
       fst->spaces++;
       continue;
     }
@@ -268,7 +268,7 @@ static void print_flowed_line(char *line, struct State *s, int ql,
     if (!(!fst->spaces && fst->delsp && last != ' ') && w < width &&
         w + fst->width + fst->spaces > width)
     {
-      mutt_debug(4, "f=f: break line at %lu, %lu spaces left\n", fst->width, fst->spaces);
+      mutt_debug(3, "f=f: break line at %lu, %lu spaces left\n", fst->width, fst->spaces);
       /* only honor trailing spaces for format=flowed replies */
       if (TextFlowed)
         for (; fst->spaces; fst->spaces--)
@@ -331,7 +331,7 @@ int rfc3676_handler(struct Body *a, struct State *s)
     fst.delsp = 1;
   }
 
-  mutt_debug(4, "f=f: DelSp: %s\n", delsp ? "yes" : "no");
+  mutt_debug(3, "f=f: DelSp: %s\n", delsp ? "yes" : "no");
 
   while ((buf = mutt_file_read_line(buf, &sz, s->fpin, NULL, 0)))
   {
@@ -435,7 +435,7 @@ void rfc3676_space_stuff(struct Email *e)
         c = buf[len - 1];
         buf[len - 1] = '\0';
       }
-      mutt_debug(4, "f=f: line %d needs space-stuffing: '%s'\n", lc, buf);
+      mutt_debug(5, "f=f: line %d needs space-stuffing: '%s'\n", lc, buf);
       if (len > 0)
         buf[len - 1] = c;
     }

--- a/rfc3676.c
+++ b/rfc3676.c
@@ -251,7 +251,7 @@ static void print_flowed_line(char *line, struct State *s, int ql,
     /* remember number of spaces */
     if (!*p)
     {
-      mutt_debug(3, "f=f: additional space\n");
+      mutt_debug(LL_DEBUG3, "f=f: additional space\n");
       fst->spaces++;
       continue;
     }
@@ -268,7 +268,8 @@ static void print_flowed_line(char *line, struct State *s, int ql,
     if (!(!fst->spaces && fst->delsp && last != ' ') && w < width &&
         w + fst->width + fst->spaces > width)
     {
-      mutt_debug(3, "f=f: break line at %lu, %lu spaces left\n", fst->width, fst->spaces);
+      mutt_debug(LL_DEBUG3, "f=f: break line at %lu, %lu spaces left\n",
+                 fst->width, fst->spaces);
       /* only honor trailing spaces for format=flowed replies */
       if (TextFlowed)
         for (; fst->spaces; fst->spaces--)
@@ -331,7 +332,7 @@ int rfc3676_handler(struct Body *a, struct State *s)
     fst.delsp = 1;
   }
 
-  mutt_debug(3, "f=f: DelSp: %s\n", delsp ? "yes" : "no");
+  mutt_debug(LL_DEBUG3, "f=f: DelSp: %s\n", delsp ? "yes" : "no");
 
   while ((buf = mutt_file_read_line(buf, &sz, s->fpin, NULL, 0)))
   {
@@ -409,7 +410,7 @@ void rfc3676_space_stuff(struct Email *e)
   if (!e || !e->content || !e->content->filename)
     return;
 
-  mutt_debug(2, "f=f: postprocess %s\n", e->content->filename);
+  mutt_debug(LL_DEBUG2, "f=f: postprocess %s\n", e->content->filename);
 
   in = mutt_file_fopen(e->content->filename, "r");
   if (!in)

--- a/send.c
+++ b/send.c
@@ -1886,7 +1886,8 @@ int ci_send_message(int flags, struct Email *msg, const char *tempfile,
 
     if (!tempfp)
     {
-      mutt_debug(1, "can't create tempfile %s (errno=%d)\n", msg->content->filename, errno);
+      mutt_debug(LL_DEBUG1, "can't create tempfile %s (errno=%d)\n",
+                 msg->content->filename, errno);
       mutt_perror(msg->content->filename);
       goto cleanup;
     }

--- a/sendlib.c
+++ b/sendlib.c
@@ -1884,7 +1884,7 @@ static int fold_one_header(FILE *fp, const char *tag, const char *value,
   int first = 1, col = 0, l = 0;
   const bool display = (flags & CH_DISPLAY);
 
-  mutt_debug(4, "pfx=[%s], tag=[%s], flags=%d value=[%s]\n", pfx, tag, flags, NONULL(value));
+  mutt_debug(5, "pfx=[%s], tag=[%s], flags=%d value=[%s]\n", pfx, tag, flags, NONULL(value));
 
   if (tag && *tag && fprintf(fp, "%s%s: ", NONULL(pfx), tag) < 0)
     return -1;
@@ -2027,7 +2027,7 @@ static int write_one_header(FILE *fp, int pfxw, int max, int wraplen, const char
   if (!(flags & CH_DISPLAY) && (pfxw + max <= wraplen || is_from))
   {
     valbuf = mutt_str_substr_dup(start, end);
-    mutt_debug(4, "buf[%s%s] short enough, max width = %d <= %d\n", NONULL(pfx),
+    mutt_debug(5, "buf[%s%s] short enough, max width = %d <= %d\n", NONULL(pfx),
                valbuf, max, wraplen);
     if (pfx && *pfx)
     {
@@ -2079,7 +2079,7 @@ static int write_one_header(FILE *fp, int pfxw, int max, int wraplen, const char
 
       valbuf = mutt_str_substr_dup(t, end);
     }
-    mutt_debug(4, "buf[%s%s] too long, max width = %d > %d\n", NONULL(pfx),
+    mutt_debug(2, "buf[%s%s] too long, max width = %d > %d\n", NONULL(pfx),
                NONULL(valbuf), max, wraplen);
     if (fold_one_header(fp, tagbuf, valbuf, pfx, wraplen, flags) < 0)
     {
@@ -2135,7 +2135,7 @@ int mutt_write_one_header(FILE *fp, const char *tag, const char *value,
     /* if header is short enough, simply print it */
     if (!display && mutt_strwidth(tag) + 2 + pfxw + mutt_strwidth(v) <= wraplen)
     {
-      mutt_debug(4, "buf[%s%s: %s] is short enough\n", NONULL(pfx), tag, v);
+      mutt_debug(5, "buf[%s%s: %s] is short enough\n", NONULL(pfx), tag, v);
       if (fprintf(fp, "%s%s: %s\n", NONULL(pfx), tag, v) <= 0)
         goto out;
       rc = 0;

--- a/sendlib.c
+++ b/sendlib.c
@@ -456,7 +456,7 @@ int mutt_write_mime_header(struct Body *a, FILE *f)
     }
     else
     {
-      mutt_debug(1, "ERROR: invalid content-disposition %d\n", a->disposition);
+      mutt_debug(LL_DEBUG1, "ERROR: invalid content-disposition %d\n", a->disposition);
     }
   }
 
@@ -499,7 +499,7 @@ int mutt_write_mime_body(struct Body *a, FILE *f)
     const char *p = mutt_param_get(&a->parameter, "boundary");
     if (!p)
     {
-      mutt_debug(1, "no boundary parameter found\n");
+      mutt_debug(LL_DEBUG1, "no boundary parameter found\n");
       mutt_error(_("No boundary parameter found [report this error]"));
       return -1;
     }
@@ -530,7 +530,7 @@ int mutt_write_mime_body(struct Body *a, FILE *f)
   fpin = fopen(a->filename, "r");
   if (!fpin)
   {
-    mutt_debug(1, "%s no longer exists\n", a->filename);
+    mutt_debug(LL_DEBUG1, "%s no longer exists\n", a->filename);
     mutt_error(_("%s no longer exists"), a->filename);
     return -1;
   }
@@ -1009,7 +1009,7 @@ struct Content *mutt_get_content_info(const char *fname, struct Body *b)
   fp = fopen(fname, "r");
   if (!fp)
   {
-    mutt_debug(1, "%s: %s (errno %d).\n", fname, strerror(errno), errno);
+    mutt_debug(LL_DEBUG1, "%s: %s (errno %d).\n", fname, strerror(errno), errno);
     return NULL;
   }
 
@@ -1107,7 +1107,7 @@ int mutt_lookup_mime_type(struct Body *att, const char *path)
         snprintf(buf, sizeof(buf), "%s/.mime.types", NONULL(HomeDir));
         break;
       default:
-        mutt_debug(1, "Internal error, count = %d.\n", count);
+        mutt_debug(LL_DEBUG1, "Internal error, count = %d.\n", count);
         goto bye; /* shouldn't happen */
     }
 
@@ -2041,7 +2041,7 @@ static int write_one_header(FILE *fp, int pfxw, int max, int wraplen, const char
     t = strchr(valbuf, ':');
     if (!t)
     {
-      mutt_debug(1, "#1 warning: header not in 'key: value' format!\n");
+      mutt_debug(LL_DEBUG1, "#1 warning: header not in 'key: value' format!\n");
       FREE(&valbuf);
       return 0;
     }
@@ -2057,7 +2057,7 @@ static int write_one_header(FILE *fp, int pfxw, int max, int wraplen, const char
     t = strchr(start, ':');
     if (!t || t > end)
     {
-      mutt_debug(1, "#2 warning: header not in 'key: value' format!\n");
+      mutt_debug(LL_DEBUG1, "#2 warning: header not in 'key: value' format!\n");
       return 0;
     }
     if (is_from)
@@ -2079,8 +2079,8 @@ static int write_one_header(FILE *fp, int pfxw, int max, int wraplen, const char
 
       valbuf = mutt_str_substr_dup(t, end);
     }
-    mutt_debug(2, "buf[%s%s] too long, max width = %d > %d\n", NONULL(pfx),
-               NONULL(valbuf), max, wraplen);
+    mutt_debug(LL_DEBUG2, "buf[%s%s] too long, max width = %d > %d\n",
+               NONULL(pfx), NONULL(valbuf), max, wraplen);
     if (fold_one_header(fp, tagbuf, valbuf, pfx, wraplen, flags) < 0)
     {
       FREE(&valbuf);
@@ -3106,7 +3106,7 @@ int mutt_write_multiple_fcc(const char *path, struct Email *e, const char *msgid
   if (!tok)
     return -1;
 
-  mutt_debug(1, "Fcc: initial mailbox = '%s'\n", tok);
+  mutt_debug(LL_DEBUG1, "Fcc: initial mailbox = '%s'\n", tok);
   /* mutt_expand_path already called above for the first token */
   int status = mutt_write_fcc(tok, e, msgid, post, fcc, finalpath);
   if (status != 0)
@@ -3118,10 +3118,10 @@ int mutt_write_multiple_fcc(const char *path, struct Email *e, const char *msgid
       continue;
 
     /* Only call mutt_expand_path if tok has some data */
-    mutt_debug(1, "Fcc: additional mailbox token = '%s'\n", tok);
+    mutt_debug(LL_DEBUG1, "Fcc: additional mailbox token = '%s'\n", tok);
     mutt_str_strfcpy(fcc_expanded, tok, sizeof(fcc_expanded));
     mutt_expand_path(fcc_expanded, sizeof(fcc_expanded));
-    mutt_debug(1, "     Additional mailbox expanded = '%s'\n", fcc_expanded);
+    mutt_debug(LL_DEBUG1, "     Additional mailbox expanded = '%s'\n", fcc_expanded);
     status = mutt_write_fcc(fcc_expanded, e, msgid, post, fcc, finalpath);
     if (status != 0)
       return status;
@@ -3163,7 +3163,7 @@ int mutt_write_fcc(const char *path, struct Email *e, const char *msgid,
   struct Context *ctx_fcc = mx_mbox_open(m_fcc, MUTT_APPEND | MUTT_QUIET);
   if (!ctx_fcc)
   {
-    mutt_debug(1, "unable to open mailbox %s in append-mode, aborting.\n", path);
+    mutt_debug(LL_DEBUG1, "unable to open mailbox %s in append-mode, aborting.\n", path);
     mailbox_free(&m_fcc);
     goto done;
   }
@@ -3309,7 +3309,7 @@ int mutt_write_fcc(const char *path, struct Email *e, const char *msgid,
     fflush(tempfp);
     if (ferror(tempfp))
     {
-      mutt_debug(1, "%s: write failed.\n", tempfile);
+      mutt_debug(LL_DEBUG1, "%s: write failed.\n", tempfile);
       mutt_file_fclose(&tempfp);
       unlink(tempfile);
       mx_msg_commit(ctx_fcc->mailbox, msg); /* XXX really? */

--- a/smtp.c
+++ b/smtp.c
@@ -453,7 +453,7 @@ static int smtp_auth_sasl(struct Connection *conn, const char *mechlist)
   {
     if (mutt_socket_send(conn, buf) < 0)
       goto fail;
-    rc = mutt_socket_readln(buf, bufsize, conn);
+    rc = mutt_socket_readln_d(buf, bufsize, conn, MUTT_SOCK_LOG_FULL);
     if (rc < 0)
       goto fail;
     if (!valid_smtp_code(buf, rc, &rc))

--- a/smtp.c
+++ b/smtp.c
@@ -345,7 +345,7 @@ static int smtp_fill_account(struct ConnAccount *account)
           SmtpPort = ntohs(service->s_port);
         else
           SmtpPort = SMTP_PORT;
-        mutt_debug(3, "Using default SMTP port %d\n", SmtpPort);
+        mutt_debug(LL_DEBUG3, "Using default SMTP port %d\n", SmtpPort);
       }
       account->port = SmtpPort;
     }
@@ -425,7 +425,7 @@ static int smtp_auth_sasl(struct Connection *conn, const char *mechlist)
 
   if (rc != SASL_OK && rc != SASL_CONTINUE)
   {
-    mutt_debug(2, "%s unavailable\n", mech);
+    mutt_debug(LL_DEBUG2, "%s unavailable\n", mech);
     sasl_dispose(&saslconn);
     return SMTP_AUTH_UNAVAIL;
   }
@@ -443,7 +443,7 @@ static int smtp_auth_sasl(struct Connection *conn, const char *mechlist)
     if (sasl_encode64(data, len, buf + mutt_str_strlen(buf),
                       bufsize - mutt_str_strlen(buf), &len) != SASL_OK)
     {
-      mutt_debug(1, "#1 error base64-encoding client response.\n");
+      mutt_debug(LL_DEBUG1, "#1 error base64-encoding client response.\n");
       goto fail;
     }
   }
@@ -464,7 +464,7 @@ static int smtp_auth_sasl(struct Connection *conn, const char *mechlist)
 
     if (sasl_decode64(buf + 4, strlen(buf + 4), buf, bufsize - 1, &len) != SASL_OK)
     {
-      mutt_debug(1, "error base64-decoding server response.\n");
+      mutt_debug(LL_DEBUG1, "error base64-decoding server response.\n");
       goto fail;
     }
 
@@ -484,7 +484,7 @@ static int smtp_auth_sasl(struct Connection *conn, const char *mechlist)
       }
       if (sasl_encode64(data, len, buf, bufsize, &len) != SASL_OK)
       {
-        mutt_debug(1, "#2 error base64-encoding client response.\n");
+        mutt_debug(LL_DEBUG1, "#2 error base64-encoding client response.\n");
         goto fail;
       }
     }
@@ -600,7 +600,7 @@ static int smtp_auth(struct Connection *conn)
       if (!method[0])
         continue;
 
-      mutt_debug(2, "Trying method %s\n", method);
+      mutt_debug(LL_DEBUG2, "Trying method %s\n", method);
 
       if (strcmp(method, "oauthbearer") == 0)
       {


### PR DESCRIPTION
From @nobrowser 

Hi, please merge this so I can avoid continuous and labor-intensive rebasing.
It changes nothing else than change `mutt_debug([1-3], ...)` to `mutt_debug(LL_DEBUG[1-3], ...)` . Thanks.

---

This PR is a step towards factoring out the progress bars and having better defined log levels.
