### PR TITLE
Replace STRING constants

### DIFF
--- a/addrbook.c
+++ b/addrbook.c
@@ -73,7 +73,7 @@ static const char *alias_format_str(char *buf, size_t buflen, size_t col, int co
                                     const char *if_str, const char *else_str,
                                     unsigned long data, int flags)
 {
-  char fmt[SHORT_STRING], addr[SHORT_STRING];
+  char fmt[128], addr[128];
   struct Alias *alias = (struct Alias *) data;
 
   switch (op)

--- a/addrbook.c
+++ b/addrbook.c
@@ -193,7 +193,7 @@ void mutt_alias_menu(char *buf, size_t buflen, struct AliasList *aliases)
   int t = -1;
   int i;
   bool done = false;
-  char helpstr[LONG_STRING];
+  char helpstr[1024];
 
   int omax;
 

--- a/alias.c
+++ b/alias.c
@@ -110,7 +110,7 @@ static struct Address *expand_aliases_r(struct Address *a, struct ListHead *expn
 
         if (pw)
         {
-          char namebuf[STRING];
+          char namebuf[256];
 
           mutt_gecos_name(namebuf, sizeof(namebuf), pw);
           mutt_str_replace(&a->personal, namebuf);

--- a/alias.c
+++ b/alias.c
@@ -368,7 +368,7 @@ struct Address *mutt_get_address(struct Envelope *env, const char **pfxp)
 void mutt_alias_create(struct Envelope *cur, struct Address *iaddr)
 {
   struct Alias *new = NULL;
-  char buf[LONG_STRING], tmp[LONG_STRING], prompt[SHORT_STRING], *pc = NULL;
+  char buf[LONG_STRING], tmp[LONG_STRING], prompt[128], *pc = NULL;
   char *err = NULL;
   char fixed[LONG_STRING];
   FILE *rc = NULL;

--- a/alias.c
+++ b/alias.c
@@ -258,7 +258,7 @@ static int check_alias_name(const char *s, char *dest, size_t destlen)
  */
 static bool string_is_address(const char *str, const char *u, const char *d)
 {
-  char buf[LONG_STRING];
+  char buf[1024];
 
   snprintf(buf, sizeof(buf), "%s@%s", NONULL(u), NONULL(d));
   if (mutt_str_strcasecmp(str, buf) == 0)
@@ -368,9 +368,9 @@ struct Address *mutt_get_address(struct Envelope *env, const char **pfxp)
 void mutt_alias_create(struct Envelope *cur, struct Address *iaddr)
 {
   struct Alias *new = NULL;
-  char buf[LONG_STRING], tmp[LONG_STRING], prompt[128], *pc = NULL;
+  char buf[1024], tmp[1024], prompt[128], *pc = NULL;
   char *err = NULL;
-  char fixed[LONG_STRING];
+  char fixed[1024];
   FILE *rc = NULL;
   struct Address *addr = NULL;
 

--- a/alias.c
+++ b/alias.c
@@ -599,7 +599,7 @@ int mutt_alias_complete(char *buf, size_t buflen)
 {
   struct Alias *a = NULL, *tmp = NULL;
   struct AliasList a_list = TAILQ_HEAD_INITIALIZER(a_list);
-  char bestname[HUGE_STRING] = { 0 };
+  char bestname[8192] = { 0 };
 
   if (buf[0] != 0) /* avoid empty string as strstr argument */
   {

--- a/bcache.c
+++ b/bcache.c
@@ -64,7 +64,7 @@ struct BodyCache
  */
 static int bcache_path(struct ConnAccount *account, const char *mailbox, char *dst, size_t dstlen)
 {
-  char host[STRING];
+  char host[256];
   struct Url url = { U_UNKNOWN };
   int len;
 

--- a/browser.c
+++ b/browser.c
@@ -360,7 +360,7 @@ static const char *folder_format_str(char *buf, size_t buflen, size_t col, int c
                                      const char *if_str, const char *else_str,
                                      unsigned long data, int flags)
 {
-  char fn[SHORT_STRING], fmt[SHORT_STRING], permission[11];
+  char fn[128], fmt[128], permission[11];
   char *t_fmt = NULL;
   struct Folder *folder = (struct Folder *) data;
   struct passwd *pw = NULL;
@@ -397,7 +397,7 @@ static const char *folder_format_str(char *buf, size_t buflen, size_t col, int c
 
         if (!do_locales)
           setlocale(LC_TIME, "C");
-        char date[SHORT_STRING];
+        char date[128];
         strftime(date, sizeof(date), t_fmt, localtime(&folder->ff->mtime));
         if (!do_locales)
           setlocale(LC_TIME, "");
@@ -703,7 +703,7 @@ static int examine_directory(struct Menu *menu, struct BrowserState *state,
     struct stat s;
     DIR *dp = NULL;
     struct dirent *de = NULL;
-    char buffer[PATH_MAX + SHORT_STRING];
+    char buffer[PATH_MAX + 128];
 
     while (stat(d, &s) == -1)
     {
@@ -1563,7 +1563,7 @@ void mutt_select_file(char *file, size_t filelen, int flags, char ***files, int 
           mutt_error(_("Delete is only supported for IMAP mailboxes"));
         else
         {
-          char msg[SHORT_STRING];
+          char msg[128];
           int nentry = menu->current;
 
           // TODO(sileht): It could be better to select INBOX instead. But I

--- a/browser.c
+++ b/browser.c
@@ -1090,7 +1090,7 @@ void mutt_select_file(char *file, size_t filelen, int flags, char ***files, int 
 {
   char buf[PATH_MAX];
   char prefix[PATH_MAX] = "";
-  char helpstr[LONG_STRING];
+  char helpstr[1024];
   char title[256];
   struct BrowserState state = { 0 };
   struct Menu *menu = NULL;

--- a/browser.c
+++ b/browser.c
@@ -1091,7 +1091,7 @@ void mutt_select_file(char *file, size_t filelen, int flags, char ***files, int 
   char buf[PATH_MAX];
   char prefix[PATH_MAX] = "";
   char helpstr[LONG_STRING];
-  char title[STRING];
+  char title[256];
   struct BrowserState state = { 0 };
   struct Menu *menu = NULL;
   bool kill_prefix = false;
@@ -2001,7 +2001,7 @@ void mutt_select_file(char *file, size_t filelen, int flags, char ***files, int 
 
           if ((op == OP_SUBSCRIBE_PATTERN) || (op == OP_UNSUBSCRIBE_PATTERN))
           {
-            char tmp[STRING];
+            char tmp[256];
 
             buf[0] = '\0';
             if (op == OP_SUBSCRIBE_PATTERN)
@@ -2084,7 +2084,7 @@ void mutt_select_file(char *file, size_t filelen, int flags, char ***files, int 
 #endif /* USE_NNTP */
 #ifdef USE_IMAP
         {
-          char tmp[STRING];
+          char tmp[256];
           mutt_str_strfcpy(tmp, state.entry[menu->current].name, sizeof(tmp));
           mutt_expand_path(tmp, sizeof(tmp));
           imap_subscribe(tmp, (op == OP_BROWSER_SUBSCRIBE));

--- a/color.c
+++ b/color.c
@@ -768,7 +768,7 @@ static enum CommandResult add_pattern(struct ColorLineHead *top, const char *s,
     tmp = new_color_line();
     if (is_index)
     {
-      char buf[LONG_STRING];
+      char buf[1024];
       mutt_str_strfcpy(buf, s, sizeof(buf));
       mutt_check_simple(buf, sizeof(buf), NONULL(C_SimpleSearch));
       tmp->color_pattern = mutt_pattern_comp(buf, MUTT_FULL_MSG, err);

--- a/color.c
+++ b/color.c
@@ -321,7 +321,7 @@ int mutt_alloc_color(int fg, int bg)
 #ifdef USE_SLANG_CURSES
   if (fg == COLOR_DEFAULT || bg == COLOR_DEFAULT)
   {
-    char fgc[SHORT_STRING], bgc[SHORT_STRING];
+    char fgc[128], bgc[128];
     SLtt_set_color(i, NULL, get_color_name(fgc, sizeof(fgc), fg),
                    get_color_name(bgc, sizeof(bgc), bg));
   }

--- a/commands.c
+++ b/commands.c
@@ -820,8 +820,8 @@ void mutt_enter_command(void)
   if (mutt_get_field(":", buffer, sizeof(buffer), MUTT_COMMAND) != 0 || !buffer[0])
     return;
 
-  struct Buffer *err = mutt_buffer_alloc(STRING);
-  struct Buffer *token = mutt_buffer_alloc(STRING);
+  struct Buffer *err = mutt_buffer_alloc(256);
+  struct Buffer *token = mutt_buffer_alloc(256);
 
   /* check if buffer is a valid icommand, else fall back quietly to parse_rc_lines */
   enum CommandResult rc = mutt_parse_icommand(buffer, err);
@@ -1179,8 +1179,8 @@ int mutt_edit_content_type(struct Email *e, struct Body *b, FILE *fp)
 {
   char buf[LONG_STRING];
   char obuf[LONG_STRING];
-  char tmp[STRING];
-  char charset[STRING];
+  char tmp[256];
+  char charset[256];
 
   short charset_changed = 0;
   short type_changed = 0;

--- a/commands.c
+++ b/commands.c
@@ -372,8 +372,8 @@ void ci_bounce_message(struct Mailbox *m, struct EmailList *el)
   if (!m || !el || STAILQ_EMPTY(el))
     return;
 
-  char prompt[SHORT_STRING];
-  char scratch[SHORT_STRING];
+  char prompt[128];
+  char scratch[128];
   char buf[HUGE_STRING] = { 0 };
   struct Address *addr = NULL;
   char *err = NULL;
@@ -859,7 +859,7 @@ void mutt_enter_command(void)
 void mutt_display_address(struct Envelope *env)
 {
   const char *pfx = NULL;
-  char buf[SHORT_STRING];
+  char buf[128];
 
   struct Address *addr = mutt_get_address(env, &pfx);
   if (!addr)

--- a/commands.c
+++ b/commands.c
@@ -174,7 +174,7 @@ static void update_protected_headers(struct Email *cur)
  */
 int mutt_display_message(struct Email *cur)
 {
-  char tempfile[PATH_MAX], buf[LONG_STRING];
+  char tempfile[PATH_MAX], buf[1024];
   int rc = 0;
   bool builtin = false;
   int cmflags = MUTT_CM_DECODE | MUTT_CM_DISPLAY | MUTT_CM_CHARCONV;
@@ -654,7 +654,7 @@ void mutt_pipe_message(struct Mailbox *m, struct EmailList *el)
   if (!m || !el)
     return;
 
-  char buffer[LONG_STRING] = { 0 };
+  char buffer[1024] = { 0 };
 
   if ((mutt_get_field(_("Pipe to command: "), buffer, sizeof(buffer), MUTT_CMD) != 0) ||
       (buffer[0] == '\0'))
@@ -786,7 +786,7 @@ int mutt_select_sort(int reverse)
  */
 void mutt_shell_escape(void)
 {
-  char buf[LONG_STRING];
+  char buf[1024];
 
   buf[0] = '\0';
   if (mutt_get_field(_("Shell command: "), buf, sizeof(buf), MUTT_CMD) != 0)
@@ -814,7 +814,7 @@ void mutt_shell_escape(void)
  */
 void mutt_enter_command(void)
 {
-  char buffer[LONG_STRING] = { 0 };
+  char buffer[1024] = { 0 };
 
   /* if enter is pressed after : with no command, just return */
   if (mutt_get_field(":", buffer, sizeof(buffer), MUTT_COMMAND) != 0 || !buffer[0])
@@ -1177,8 +1177,8 @@ int mutt_save_message(struct Mailbox *m, struct EmailList *el, bool delete,
  */
 int mutt_edit_content_type(struct Email *e, struct Body *b, FILE *fp)
 {
-  char buf[LONG_STRING];
-  char obuf[LONG_STRING];
+  char buf[1024];
+  char obuf[1024];
   char tmp[256];
   char charset[256];
 

--- a/commands.c
+++ b/commands.c
@@ -339,7 +339,7 @@ int mutt_display_message(struct Email *cur)
   {
     int r;
 
-    char cmd[HUGE_STRING];
+    char cmd[STR_COMMAND];
     mutt_endwin();
     snprintf(cmd, sizeof(cmd), "%s %s", NONULL(C_Pager), tempfile);
     r = mutt_system(cmd);
@@ -374,7 +374,7 @@ void ci_bounce_message(struct Mailbox *m, struct EmailList *el)
 
   char prompt[128];
   char scratch[128];
-  char buf[HUGE_STRING] = { 0 };
+  char buf[8192] = { 0 };
   struct Address *addr = NULL;
   char *err = NULL;
   int rc;

--- a/compose.c
+++ b/compose.c
@@ -519,7 +519,7 @@ static void draw_envelope(struct Email *msg, char *fcc)
  */
 static void edit_address_list(int line, struct Address **addr)
 {
-  char buf[HUGE_STRING] = ""; /* needs to be large for alias expansion */
+  char buf[8192] = ""; /* needs to be large for alias expansion */
   char *err = NULL;
 
   mutt_addrlist_to_local(*addr);

--- a/compose.c
+++ b/compose.c
@@ -439,7 +439,7 @@ static int check_attachments(struct AttachCtx *actx)
  */
 static void draw_envelope_addr(int line, struct Address *addr)
 {
-  char buf[LONG_STRING];
+  char buf[1024];
 
   buf[0] = '\0';
   mutt_addr_write(buf, sizeof(buf), addr, true);
@@ -698,7 +698,7 @@ static void compose_custom_redraw(struct Menu *menu)
 
   if (menu->redraw & REDRAW_STATUS)
   {
-    char buf[LONG_STRING];
+    char buf[1024];
     compose_status_line(buf, sizeof(buf), 0, MuttStatusWindow->cols, menu,
                         NONULL(C_ComposeFormat));
     mutt_window_move(MuttStatusWindow, 0, 0);
@@ -886,7 +886,7 @@ static void compose_status_line(char *buf, size_t buflen, size_t col, int cols,
  */
 int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email *cur, int flags)
 {
-  char helpstr[LONG_STRING]; // This isn't copied by the help bar
+  char helpstr[1024]; // This isn't copied by the help bar
   char buf[PATH_MAX];
   int op_close = OP_NULL;
   int rc = -1;

--- a/compose.c
+++ b/compose.c
@@ -402,7 +402,7 @@ static int check_attachments(struct AttachCtx *actx)
 {
   int r;
   struct stat st;
-  char pretty[PATH_MAX], msg[PATH_MAX + SHORT_STRING];
+  char pretty[PATH_MAX], msg[PATH_MAX + 128];
 
   for (int i = 0; i < actx->idxlen; i++)
   {
@@ -813,7 +813,7 @@ static const char *compose_format_str(char *buf, size_t buflen, size_t col, int 
                                       const char *if_str, const char *else_str,
                                       unsigned long data, int flags)
 {
-  char fmt[SHORT_STRING], tmp[SHORT_STRING];
+  char fmt[128], tmp[128];
   int optional = (flags & MUTT_FORMAT_OPTIONAL);
   struct Menu *menu = (struct Menu *) data;
 

--- a/compose.c
+++ b/compose.c
@@ -1763,7 +1763,7 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
         mutt_expand_path(buf, sizeof(buf));
 
         /* Call to lookup_mime_type () ?  maybe later */
-        char type[STRING] = { 0 };
+        char type[256] = { 0 };
         if (mutt_get_field("Content-Type: ", type, sizeof(type), 0) != 0 || !type[0])
           continue;
 

--- a/compress.c
+++ b/compress.c
@@ -325,7 +325,7 @@ static void expand_command_str(const struct Mailbox *m, const char *cmd, char *b
 static int execute_command(struct Mailbox *m, const char *command, const char *progress)
 {
   int rc = 1;
-  char sys_cmd[HUGE_STRING];
+  char sys_cmd[STR_COMMAND];
 
   if (!m || !command || !progress)
     return 0;

--- a/config/address.c
+++ b/config/address.c
@@ -115,7 +115,7 @@ static int address_string_get(const struct ConfigSet *cs, void *var,
   if (!cs || !cdef)
     return CSR_ERR_CODE; /* LCOV_EXCL_LINE */
 
-  char tmp[HUGE_STRING] = "";
+  char tmp[8192] = "";
   const char *str = NULL;
 
   if (var)

--- a/config/cfgaccount.c
+++ b/config/cfgaccount.c
@@ -107,8 +107,8 @@ void ac_free(const struct ConfigSet *cs, struct CfgAccount **ac)
   char child[128];
   struct Buffer err;
   mutt_buffer_init(&err);
-  err.data = mutt_mem_calloc(1, STRING);
-  err.dsize = STRING;
+  err.dsize = 256;
+  err.data = mutt_mem_calloc(1, err.dsize);
 
   for (size_t i = 0; i < (*ac)->num_vars; i++)
   {

--- a/config/dump.c
+++ b/config/dump.c
@@ -242,9 +242,9 @@ bool dump_config(struct ConfigSet *cs, enum CsDumpStyle style, int flags, FILE *
 
   bool result = true;
 
-  struct Buffer *value = mutt_buffer_alloc(STRING);
-  struct Buffer *initial = mutt_buffer_alloc(STRING);
-  struct Buffer *tmp = mutt_buffer_alloc(STRING);
+  struct Buffer *value = mutt_buffer_alloc(256);
+  struct Buffer *initial = mutt_buffer_alloc(256);
+  struct Buffer *tmp = mutt_buffer_alloc(256);
 
   for (size_t i = 0; list[i]; i++)
   {

--- a/config/set.c
+++ b/config/set.c
@@ -269,8 +269,8 @@ bool cs_register_variables(const struct ConfigSet *cs, struct ConfigDef vars[], 
 
   struct Buffer err;
   mutt_buffer_init(&err);
-  err.data = calloc(1, STRING);
-  err.dsize = STRING;
+  err.dsize = 256;
+  err.data = calloc(1, err.dsize);
 
   bool rc = true;
 
@@ -302,8 +302,8 @@ struct HashElem *cs_inherit_variable(const struct ConfigSet *cs,
 
   struct Buffer err;
   mutt_buffer_init(&err);
-  err.data = calloc(1, STRING);
-  err.dsize = STRING;
+  err.dsize = 256;
+  err.data = calloc(1, err.dsize);
 
   struct Inheritance *i = mutt_mem_calloc(1, sizeof(*i));
   i->parent = parent;

--- a/conn/connection.h
+++ b/conn/connection.h
@@ -37,7 +37,7 @@ struct Connection
   struct ConnAccount account;
   unsigned int ssf; /**< security strength factor, in bits */
 
-  char inbuf[LONG_STRING];
+  char inbuf[1024];
   int bufpos;
 
   int fd;

--- a/conn/getdomain.c
+++ b/conn/getdomain.c
@@ -46,7 +46,7 @@ int getdnsdomainname(char *buf, size_t buflen)
   int rc = -1;
 
 #if defined(HAVE_GETADDRINFO) || defined(HAVE_GETADDRINFO_A)
-  char node[STRING];
+  char node[256];
   if (gethostname(node, sizeof(node)) != 0)
     return rc;
 

--- a/conn/sasl.c
+++ b/conn/sasl.c
@@ -642,8 +642,8 @@ int mutt_sasl_client_new(struct Connection *conn, sasl_conn_t **saslconn)
  */
 int mutt_sasl_interact(sasl_interact_t *interaction)
 {
-  char prompt[SHORT_STRING];
-  char resp[SHORT_STRING];
+  char prompt[128];
+  char resp[128];
 
   while (interaction->id != SASL_CB_LIST_END)
   {

--- a/conn/ssl.c
+++ b/conn/ssl.c
@@ -66,6 +66,8 @@
 #include "protos.h"
 #include "socket.h"
 
+const int dialog_row_len = 128;
+
 /* Just in case OpenSSL doesn't define DEVRANDOM */
 #ifndef DEVRANDOM
 #define DEVRANDOM "/dev/urandom"
@@ -393,7 +395,7 @@ static int ssl_socket_open_err(struct Connection *conn)
  */
 static char *x509_get_part(X509_NAME *name, int nid)
 {
-  static char data[SHORT_STRING];
+  static char data[128];
 
   if (!name || X509_NAME_get_text_by_NID(name, nid, data, sizeof(data)) < 0)
     mutt_str_strfcpy(data, _("Unknown"), sizeof(data));
@@ -900,45 +902,43 @@ static bool interactive_check_cert(X509 *cert, int idx, size_t len, SSL *ssl, bo
   menu->max = mutt_array_size(part) * 2 + 11;
   menu->dialog = mutt_mem_calloc(1, menu->max * sizeof(char *));
   for (int i = 0; i < menu->max; i++)
-    menu->dialog[i] = mutt_mem_calloc(1, SHORT_STRING * sizeof(char));
+    menu->dialog[i] = mutt_mem_calloc(1, dialog_row_len * sizeof(char));
 
   row = 0;
-  mutt_str_strfcpy(menu->dialog[row], _("This certificate belongs to:"), SHORT_STRING);
+  mutt_str_strfcpy(menu->dialog[row], _("This certificate belongs to:"), dialog_row_len);
   row++;
   x509_subject = X509_get_subject_name(cert);
   for (unsigned int u = 0; u < mutt_array_size(part); u++)
   {
-    snprintf(menu->dialog[row++], SHORT_STRING, "   %s",
-             x509_get_part(x509_subject, part[u]));
+    snprintf(menu->dialog[row++], dialog_row_len, "   %s", x509_get_part(x509_subject, part[u]));
   }
 
   row++;
-  mutt_str_strfcpy(menu->dialog[row], _("This certificate was issued by:"), SHORT_STRING);
+  mutt_str_strfcpy(menu->dialog[row], _("This certificate was issued by:"), dialog_row_len);
   row++;
   x509_issuer = X509_get_issuer_name(cert);
   for (unsigned int u = 0; u < mutt_array_size(part); u++)
   {
-    snprintf(menu->dialog[row++], SHORT_STRING, "   %s",
-             x509_get_part(x509_issuer, part[u]));
+    snprintf(menu->dialog[row++], dialog_row_len, "   %s", x509_get_part(x509_issuer, part[u]));
   }
 
   row++;
-  snprintf(menu->dialog[row++], SHORT_STRING, "%s", _("This certificate is valid"));
-  snprintf(menu->dialog[row++], SHORT_STRING, _("   from %s"),
+  snprintf(menu->dialog[row++], dialog_row_len, "%s", _("This certificate is valid"));
+  snprintf(menu->dialog[row++], dialog_row_len, _("   from %s"),
            asn1time_to_string(X509_getm_notBefore(cert)));
-  snprintf(menu->dialog[row++], SHORT_STRING, _("     to %s"),
+  snprintf(menu->dialog[row++], dialog_row_len, _("     to %s"),
            asn1time_to_string(X509_getm_notAfter(cert)));
 
   row++;
   buf[0] = '\0';
   x509_fingerprint(buf, sizeof(buf), cert, EVP_sha1);
-  snprintf(menu->dialog[row++], SHORT_STRING, _("SHA1 Fingerprint: %s"), buf);
+  snprintf(menu->dialog[row++], dialog_row_len, _("SHA1 Fingerprint: %s"), buf);
   buf[0] = '\0';
   buf[40] = '\0'; /* Ensure the second printed line is null terminated */
   x509_fingerprint(buf, sizeof(buf), cert, EVP_sha256);
   buf[39] = '\0'; /* Divide into two lines of output */
-  snprintf(menu->dialog[row++], SHORT_STRING, "%s%s", _("SHA256 Fingerprint: "), buf);
-  snprintf(menu->dialog[row++], SHORT_STRING, "%*s%s",
+  snprintf(menu->dialog[row++], dialog_row_len, "%s%s", _("SHA256 Fingerprint: "), buf);
+  snprintf(menu->dialog[row++], dialog_row_len, "%*s%s",
            (int) mutt_str_strlen(_("SHA256 Fingerprint: ")), "", buf + 40);
 
   snprintf(title, sizeof(title),

--- a/conn/ssl.c
+++ b/conn/ssl.c
@@ -140,7 +140,7 @@ static int ssl_load_certificates(SSL_CTX *ctx)
   X509 *cert = NULL;
   X509_STORE *store = NULL;
   int rc = 1;
-  char buf[STRING];
+  char buf[256];
 
   mutt_debug(LL_DEBUG2, "loading trusted certificates\n");
   store = SSL_CTX_get_cert_store(ctx);
@@ -890,8 +890,8 @@ static bool interactive_check_cert(X509 *cert, int idx, size_t len, SSL *ssl, bo
   X509_NAME *x509_subject = NULL;
   X509_NAME *x509_issuer = NULL;
   char helpstr[LONG_STRING];
-  char buf[STRING];
-  char title[STRING];
+  char buf[256];
+  char title[256];
   struct Menu *menu = mutt_menu_new(MENU_GENERIC);
   int done, row;
   FILE *fp = NULL;
@@ -1053,7 +1053,7 @@ static bool interactive_check_cert(X509 *cert, int idx, size_t len, SSL *ssl, bo
  */
 static int ssl_verify_callback(int preverify_ok, X509_STORE_CTX *ctx)
 {
-  char buf[STRING];
+  char buf[256];
   const char *host = NULL;
   size_t len;
   int pos;

--- a/conn/ssl.c
+++ b/conn/ssl.c
@@ -889,7 +889,7 @@ static bool interactive_check_cert(X509 *cert, int idx, size_t len, SSL *ssl, bo
   };
   X509_NAME *x509_subject = NULL;
   X509_NAME *x509_issuer = NULL;
-  char helpstr[LONG_STRING];
+  char helpstr[1024];
   char buf[256];
   char title[256];
   struct Menu *menu = mutt_menu_new(MENU_GENERIC);

--- a/conn/ssl_gnutls.c
+++ b/conn/ssl_gnutls.c
@@ -460,7 +460,7 @@ static int tls_check_one_certificate(const gnutls_datum_t *certdata,
   char datestr[30];
   struct Menu *menu = NULL;
   char helpstr[LONG_STRING];
-  char title[STRING];
+  char title[256];
   FILE *fp = NULL;
   gnutls_datum_t pemdata;
   int row, done, ret;

--- a/conn/ssl_gnutls.c
+++ b/conn/ssl_gnutls.c
@@ -62,6 +62,8 @@
 #define CERTERR_INSECUREALG 64
 #define CERTERR_OTHER 128
 
+const int dialog_row_len = 128;
+
 #define CERT_SEP "-----BEGIN"
 
 static int tls_socket_close(struct Connection *conn);
@@ -444,16 +446,16 @@ static int tls_check_one_certificate(const gnutls_datum_t *certdata,
 {
   int certerr, savedcert;
   gnutls_x509_crt_t cert;
-  char buf[SHORT_STRING];
-  char fpbuf[SHORT_STRING];
+  char buf[128];
+  char fpbuf[128];
   size_t buflen;
-  char dn_common_name[SHORT_STRING];
-  char dn_email[SHORT_STRING];
-  char dn_organization[SHORT_STRING];
-  char dn_organizational_unit[SHORT_STRING];
-  char dn_locality[SHORT_STRING];
-  char dn_province[SHORT_STRING];
-  char dn_country[SHORT_STRING];
+  char dn_common_name[128];
+  char dn_email[128];
+  char dn_organization[128];
+  char dn_organizational_unit[128];
+  char dn_locality[128];
+  char dn_province[128];
+  char dn_country[128];
   time_t t;
   char datestr[30];
   struct Menu *menu = NULL;
@@ -484,11 +486,11 @@ static int tls_check_one_certificate(const gnutls_datum_t *certdata,
   menu->max = 27;
   menu->dialog = mutt_mem_calloc(1, menu->max * sizeof(char *));
   for (int i = 0; i < menu->max; i++)
-    menu->dialog[i] = mutt_mem_calloc(1, SHORT_STRING * sizeof(char));
+    menu->dialog[i] = mutt_mem_calloc(1, dialog_row_len * sizeof(char));
   mutt_menu_push_current(menu);
 
   row = 0;
-  mutt_str_strfcpy(menu->dialog[row], _("This certificate belongs to:"), SHORT_STRING);
+  mutt_str_strfcpy(menu->dialog[row], _("This certificate belongs to:"), dialog_row_len);
   row++;
 
   buflen = sizeof(dn_common_name);
@@ -531,14 +533,13 @@ static int tls_check_one_certificate(const gnutls_datum_t *certdata,
     dn_country[0] = '\0';
   }
 
-  snprintf(menu->dialog[row++], SHORT_STRING, "   %s  %s", dn_common_name, dn_email);
-  snprintf(menu->dialog[row++], SHORT_STRING, "   %s", dn_organization);
-  snprintf(menu->dialog[row++], SHORT_STRING, "   %s", dn_organizational_unit);
-  snprintf(menu->dialog[row++], SHORT_STRING, "   %s  %s  %s", dn_locality,
-           dn_province, dn_country);
+  snprintf(menu->dialog[row++], dialog_row_len, "   %s  %s", dn_common_name, dn_email);
+  snprintf(menu->dialog[row++], dialog_row_len, "   %s", dn_organization);
+  snprintf(menu->dialog[row++], dialog_row_len, "   %s", dn_organizational_unit);
+  snprintf(menu->dialog[row++], dialog_row_len, "   %s  %s  %s", dn_locality, dn_province, dn_country);
   row++;
 
-  mutt_str_strfcpy(menu->dialog[row], _("This certificate was issued by:"), SHORT_STRING);
+  mutt_str_strfcpy(menu->dialog[row], _("This certificate was issued by:"), dialog_row_len);
   row++;
 
   buflen = sizeof(dn_common_name);
@@ -584,63 +585,63 @@ static int tls_check_one_certificate(const gnutls_datum_t *certdata,
     dn_country[0] = '\0';
   }
 
-  snprintf(menu->dialog[row++], SHORT_STRING, "   %s  %s", dn_common_name, dn_email);
-  snprintf(menu->dialog[row++], SHORT_STRING, "   %s", dn_organization);
-  snprintf(menu->dialog[row++], SHORT_STRING, "   %s", dn_organizational_unit);
-  snprintf(menu->dialog[row++], SHORT_STRING, "   %s  %s  %s", dn_locality,
+  snprintf(menu->dialog[row++], dialog_row_len, "   %s  %s", dn_common_name, dn_email);
+  snprintf(menu->dialog[row++], dialog_row_len, "   %s", dn_organization);
+  snprintf(menu->dialog[row++], dialog_row_len, "   %s", dn_organizational_unit);
+  snprintf(menu->dialog[row++], dialog_row_len, "   %s  %s  %s", dn_locality,
            dn_province, dn_country);
   row++;
 
-  snprintf(menu->dialog[row++], SHORT_STRING, _("This certificate is valid"));
+  snprintf(menu->dialog[row++], dialog_row_len, _("This certificate is valid"));
 
   t = gnutls_x509_crt_get_activation_time(cert);
   mutt_date_make_tls(datestr, sizeof(datestr), t);
-  snprintf(menu->dialog[row++], SHORT_STRING, _("   from %s"), datestr);
+  snprintf(menu->dialog[row++], dialog_row_len, _("   from %s"), datestr);
 
   t = gnutls_x509_crt_get_expiration_time(cert);
   mutt_date_make_tls(datestr, sizeof(datestr), t);
-  snprintf(menu->dialog[row++], SHORT_STRING, _("     to %s"), datestr);
+  snprintf(menu->dialog[row++], dialog_row_len, _("     to %s"), datestr);
 
   fpbuf[0] = '\0';
   tls_fingerprint(GNUTLS_DIG_SHA, fpbuf, sizeof(fpbuf), certdata);
-  snprintf(menu->dialog[row++], SHORT_STRING, _("SHA1 Fingerprint: %s"), fpbuf);
+  snprintf(menu->dialog[row++], dialog_row_len, _("SHA1 Fingerprint: %s"), fpbuf);
   fpbuf[0] = '\0';
   fpbuf[40] = '\0'; /* Ensure the second printed line is null terminated */
   tls_fingerprint(GNUTLS_DIG_SHA256, fpbuf, sizeof(fpbuf), certdata);
   fpbuf[39] = '\0'; /* Divide into two lines of output */
-  snprintf(menu->dialog[row++], SHORT_STRING, "%s%s", _("SHA256 Fingerprint: "), fpbuf);
-  snprintf(menu->dialog[row++], SHORT_STRING, "%*s%s",
+  snprintf(menu->dialog[row++], dialog_row_len, "%s%s", _("SHA256 Fingerprint: "), fpbuf);
+  snprintf(menu->dialog[row++], dialog_row_len, "%*s%s",
            (int) mutt_str_strlen(_("SHA256 Fingerprint: ")), "", fpbuf + 40);
 
   if (certerr & CERTERR_NOTYETVALID)
   {
     row++;
     mutt_str_strfcpy(menu->dialog[row],
-                     _("WARNING: Server certificate is not yet valid"), SHORT_STRING);
+                     _("WARNING: Server certificate is not yet valid"), dialog_row_len);
   }
   if (certerr & CERTERR_EXPIRED)
   {
     row++;
     mutt_str_strfcpy(menu->dialog[row],
-                     _("WARNING: Server certificate has expired"), SHORT_STRING);
+                     _("WARNING: Server certificate has expired"), dialog_row_len);
   }
   if (certerr & CERTERR_REVOKED)
   {
     row++;
     mutt_str_strfcpy(menu->dialog[row],
-                     _("WARNING: Server certificate has been revoked"), SHORT_STRING);
+                     _("WARNING: Server certificate has been revoked"), dialog_row_len);
   }
   if (certerr & CERTERR_HOSTNAME)
   {
     row++;
     mutt_str_strfcpy(menu->dialog[row],
-                     _("WARNING: Server hostname does not match certificate"), SHORT_STRING);
+                     _("WARNING: Server hostname does not match certificate"), dialog_row_len);
   }
   if (certerr & CERTERR_SIGNERNOTCA)
   {
     row++;
     mutt_str_strfcpy(menu->dialog[row],
-                     _("WARNING: Signer of server certificate is not a CA"), SHORT_STRING);
+                     _("WARNING: Signer of server certificate is not a CA"), dialog_row_len);
   }
 
   snprintf(title, sizeof(title),
@@ -894,7 +895,7 @@ static int tls_set_priority(struct TlsSockData *data)
   size_t nproto = 4;
   size_t priority_size;
 
-  priority_size = SHORT_STRING + mutt_str_strlen(C_SslCiphers);
+  priority_size = mutt_str_strlen(C_SslCiphers) + 128;
   char *priority = mutt_mem_malloc(priority_size);
 
   priority[0] = 0;
@@ -985,7 +986,7 @@ static int tls_set_priority(struct TlsSockData *data)
   {
     row++;
     strfcpy(menu->dialog[row], _("Warning: Server certificate was signed using an insecure algorithm"),
-            SHORT_STRING);
+            dialog_row_len);
   }
 
   /* We use default priorities (see gnutls documentation),

--- a/conn/ssl_gnutls.c
+++ b/conn/ssl_gnutls.c
@@ -459,7 +459,7 @@ static int tls_check_one_certificate(const gnutls_datum_t *certdata,
   time_t t;
   char datestr[30];
   struct Menu *menu = NULL;
-  char helpstr[LONG_STRING];
+  char helpstr[1024];
   char title[256];
   FILE *fp = NULL;
   gnutls_datum_t pemdata;

--- a/copy.c
+++ b/copy.c
@@ -403,8 +403,8 @@ int mutt_copy_header(FILE *in, struct Email *e, FILE *out, int chflags, const ch
 
   if (chflags & CH_TXTPLAIN)
   {
-    char chsbuf[SHORT_STRING];
-    char buffer[SHORT_STRING];
+    char chsbuf[128];
+    char buffer[128];
     fputs("MIME-Version: 1.0\n", out);
     fputs("Content-Transfer-Encoding: 8bit\n", out);
     fputs("Content-Type: text/plain; charset=", out);
@@ -590,7 +590,7 @@ static int count_delete_lines(FILE *fp, struct Body *b, LOFF_T *length, size_t d
 int mutt_copy_message_fp(FILE *fpout, FILE *fpin, struct Email *e, int cmflags, int chflags)
 {
   struct Body *body = e->content;
-  char prefix[SHORT_STRING];
+  char prefix[128];
   LOFF_T new_offset = -1;
   int rc = 0;
 
@@ -612,7 +612,7 @@ int mutt_copy_message_fp(FILE *fpout, FILE *fpin, struct Email *e, int cmflags, 
     {
       int new_lines;
       LOFF_T new_length = body->length;
-      char date[SHORT_STRING];
+      char date[128];
 
       mutt_date_make_date(date, sizeof(date));
       int dlen = mutt_str_strlen(date);

--- a/copy.c
+++ b/copy.c
@@ -75,7 +75,7 @@ int mutt_copy_hdr(FILE *in, FILE *out, LOFF_T off_start, LOFF_T off_end,
   bool from = false;
   bool this_is_from = false;
   bool ignore = false;
-  char buf[LONG_STRING]; /* should be long enough to get most fields in one pass */
+  char buf[1024]; /* should be long enough to get most fields in one pass */
   char *nl = NULL;
   char **headers = NULL;
   int hdr_count;
@@ -470,7 +470,7 @@ int mutt_copy_header(FILE *in, struct Email *e, FILE *out, int chflags, const ch
     char *folder = nm_email_get_folder(e);
     if (folder && !(C_Weed && mutt_matches_ignore("folder")))
     {
-      char buf[LONG_STRING];
+      char buf[1024];
       mutt_str_strfcpy(buf, folder, sizeof(buf));
       mutt_pretty_mailbox(buf, sizeof(buf));
 

--- a/copy.c
+++ b/copy.c
@@ -945,7 +945,7 @@ static int copy_delete_attach(struct Body *b, FILE *fpin, FILE *fpout, char *dat
  */
 static void format_address_header(char **h, struct Address *a)
 {
-  char buf[HUGE_STRING];
+  char buf[8192];
   char cbuf[256];
   char c2buf[256];
   char *p = NULL;

--- a/copy.c
+++ b/copy.c
@@ -825,7 +825,7 @@ int mutt_copy_message_ctx(FILE *fpout, struct Mailbox *src, struct Email *e,
 static int append_message(struct Mailbox *dest, FILE *fpin, struct Mailbox *src,
                           struct Email *e, int cmflags, int chflags)
 {
-  char buf[STRING];
+  char buf[256];
   struct Message *msg = NULL;
   int r;
 
@@ -946,8 +946,8 @@ static int copy_delete_attach(struct Body *b, FILE *fpin, FILE *fpout, char *dat
 static void format_address_header(char **h, struct Address *a)
 {
   char buf[HUGE_STRING];
-  char cbuf[STRING];
-  char c2buf[STRING];
+  char cbuf[256];
+  char c2buf[256];
   char *p = NULL;
   size_t linelen, buflen, plen;
 

--- a/curs_lib.c
+++ b/curs_lib.c
@@ -575,7 +575,7 @@ int mutt_do_pager(const char *banner, const char *tempfile, int do_color, struct
     rc = mutt_pager(banner, tempfile, do_color, info);
   else
   {
-    char cmd[STRING];
+    char cmd[256];
 
     mutt_endwin();
     mutt_file_expand_fmt_quote(cmd, sizeof(cmd), C_Pager, tempfile);

--- a/curs_lib.c
+++ b/curs_lib.c
@@ -307,7 +307,7 @@ int mutt_get_field_unbuffered(const char *msg, char *buf, size_t buflen, int fla
  */
 void mutt_edit_file(const char *editor, const char *file)
 {
-  char cmd[HUGE_STRING];
+  char cmd[STR_COMMAND];
 
   mutt_endwin();
   mutt_file_expand_fmt_quote(cmd, sizeof(cmd), editor, file);

--- a/edit.c
+++ b/edit.c
@@ -92,7 +92,7 @@ static char *EditorHelp2 =
 static char **be_snarf_data(FILE *f, char **buf, int *bufmax, int *buflen,
                             LOFF_T offset, int bytes, int prefix)
 {
-  char tmp[HUGE_STRING];
+  char tmp[8192];
   char *p = tmp;
   int tmplen = sizeof(tmp);
 
@@ -266,7 +266,7 @@ static char **be_include_messages(char *msg, char **buf, int *bufmax,
  */
 static void be_print_header(struct Envelope *env)
 {
-  char tmp[HUGE_STRING];
+  char tmp[8192];
 
   if (env->to)
   {
@@ -308,7 +308,7 @@ static void be_print_header(struct Envelope *env)
  */
 static void be_edit_header(struct Envelope *e, bool force)
 {
-  char tmp[HUGE_STRING];
+  char tmp[8192];
 
   mutt_window_move(MuttMessageWindow, 0, 0);
 

--- a/edit.c
+++ b/edit.c
@@ -135,7 +135,7 @@ static char **be_snarf_data(FILE *f, char **buf, int *bufmax, int *buflen,
  */
 static char **be_snarf_file(const char *path, char **buf, int *max, int *len, bool verbose)
 {
-  char tmp[LONG_STRING];
+  char tmp[1024];
   struct stat sb;
 
   FILE *f = fopen(path, "r");
@@ -210,7 +210,7 @@ static char **be_include_messages(char *msg, char **buf, int *bufmax,
 {
   int n;
   // int offset, bytes;
-  char tmp[LONG_STRING];
+  char tmp[1024];
 
   if (!msg || !buf || !bufmax || !buflen)
     return buf;
@@ -400,7 +400,7 @@ int mutt_builtin_editor(const char *path, struct Email *msg, struct Email *cur)
 {
   char **buf = NULL;
   int bufmax = 0, buflen = 0;
-  char tmp[LONG_STRING];
+  char tmp[1024];
   bool abort = false;
   bool done = false;
   char *p = NULL;

--- a/editmsg.c
+++ b/editmsg.c
@@ -60,7 +60,7 @@
 static int ev_message(enum EvMessage action, struct Mailbox *m, struct Email *e)
 {
   char fname[PATH_MAX];
-  char buf[STRING];
+  char buf[256];
   int rc;
   struct stat sb;
 

--- a/email/address.c
+++ b/email/address.c
@@ -296,7 +296,7 @@ static const char *parse_address(const char *s, char *token, size_t *tokenlen,
 static const char *parse_route_addr(const char *s, char *comment, size_t *commentlen,
                                     size_t commentmax, struct Address *addr)
 {
-  char token[LONG_STRING];
+  char token[1024];
   size_t tokenlen = 0;
 
   s = mutt_str_skip_email_wsp(s);
@@ -352,7 +352,7 @@ static const char *parse_route_addr(const char *s, char *comment, size_t *commen
 static const char *parse_addr_spec(const char *s, char *comment, size_t *commentlen,
                                    size_t commentmax, struct Address *addr)
 {
-  char token[LONG_STRING];
+  char token[1024];
   size_t tokenlen = 0;
 
   s = parse_address(s, token, &tokenlen, sizeof(token) - 1, comment, commentlen,
@@ -466,7 +466,7 @@ struct Address *mutt_addr_parse_list(struct Address *top, const char *s)
 {
   int ws_pending;
   const char *ps = NULL;
-  char comment[LONG_STRING], phrase[LONG_STRING];
+  char comment[1024], phrase[1024];
   size_t phraselen = 0, commentlen = 0;
   struct Address *cur = NULL;
 

--- a/email/address.c
+++ b/email/address.c
@@ -633,7 +633,7 @@ struct Address *mutt_addr_parse_list2(struct Address *p, const char *s)
   const char *q = strpbrk(s, "\"<>():;,\\");
   if (!q)
   {
-    char tmp[HUGE_STRING];
+    char tmp[8192];
 
     mutt_str_strfcpy(tmp, s, sizeof(tmp));
     char *r = tmp;

--- a/email/idna.c
+++ b/email/idna.c
@@ -279,7 +279,7 @@ cleanup:
  */
 const char *mutt_idna_print_version(void)
 {
-  static char vstring[STRING];
+  static char vstring[256];
 
 #ifdef HAVE_IDN2_H
   snprintf(vstring, sizeof(vstring), "libidn2: %s (compiled with %s)",

--- a/email/parse.c
+++ b/email/parse.c
@@ -496,7 +496,7 @@ void mutt_parse_content_type(const char *s, struct Body *ct)
       ct->subtype = mutt_str_strdup("rfc822");
     else if (ct->type == TYPE_OTHER)
     {
-      char buffer[SHORT_STRING];
+      char buffer[128];
 
       ct->type = TYPE_APPLICATION;
       snprintf(buffer, sizeof(buffer), "x-%s", s);

--- a/email/parse.c
+++ b/email/parse.c
@@ -74,7 +74,7 @@ void mutt_auto_subscribe(const char *mailto)
       !mutt_regexlist_match(&UnSubscribedLists, lpenv->to->mailbox))
   {
     struct Buffer err;
-    char errbuf[STRING];
+    char errbuf[256];
     memset(&err, 0, sizeof(err));
     err.data = errbuf;
     err.dsize = sizeof(errbuf);
@@ -987,10 +987,10 @@ char *mutt_rfc822_read_line(FILE *f, char *line, size_t *linelen)
 
     buf++;
     offset = buf - line;
-    if (*linelen < (offset + STRING))
+    if (*linelen < (offset + 256))
     {
       /* grow the buffer */
-      *linelen += STRING;
+      *linelen += 256;
       mutt_mem_realloc(&line, *linelen);
       buf = line + offset;
     }

--- a/email/parse.c
+++ b/email/parse.c
@@ -95,7 +95,7 @@ void mutt_auto_subscribe(const char *mailto)
 static void parse_parameters(struct ParameterList *param, const char *s)
 {
   struct Parameter *new = NULL;
-  char buffer[LONG_STRING];
+  char buffer[1024];
   const char *p = NULL;
   size_t i;
 
@@ -1014,11 +1014,11 @@ char *mutt_rfc822_read_line(FILE *f, char *line, size_t *linelen)
 struct Envelope *mutt_rfc822_read_header(FILE *f, struct Email *e, bool user_hdrs, bool weed)
 {
   struct Envelope *env = mutt_env_new();
-  char *line = mutt_mem_malloc(LONG_STRING);
   char *p = NULL;
   LOFF_T loc;
-  size_t linelen = LONG_STRING;
-  char buf[LONG_STRING + 1];
+  size_t linelen = 1024;
+  char *line = mutt_mem_malloc(linelen);
+  char buf[linelen + 1];
 
   if (e)
   {
@@ -1045,7 +1045,7 @@ struct Envelope *mutt_rfc822_read_header(FILE *f, struct Email *e, bool user_hdr
     p = strpbrk(line, ": \t");
     if (!p || (*p != ':'))
     {
-      char return_path[LONG_STRING];
+      char return_path[1024];
       time_t t;
 
       /* some bogus MTAs will quote the original "From " line */
@@ -1164,8 +1164,8 @@ struct Body *mutt_read_mime_header(FILE *fp, bool digest)
   struct Body *p = mutt_body_new();
   struct Envelope *env = mutt_env_new();
   char *c = NULL;
-  char *line = mutt_mem_malloc(LONG_STRING);
-  size_t linelen = LONG_STRING;
+  size_t linelen = 1024;
+  char *line = mutt_mem_malloc(linelen);
 
   p->hdr_offset = ftello(fp);
 
@@ -1325,7 +1325,7 @@ void mutt_parse_part(FILE *fp, struct Body *b)
  */
 struct Body *mutt_parse_multipart(FILE *fp, const char *boundary, LOFF_T end_off, bool digest)
 {
-  char buffer[LONG_STRING];
+  char buffer[1024];
   struct Body *head = NULL, *last = NULL, *new = NULL;
   bool final = false; /* did we see the ending boundary? */
 
@@ -1336,7 +1336,7 @@ struct Body *mutt_parse_multipart(FILE *fp, const char *boundary, LOFF_T end_off
   }
 
   const size_t blen = mutt_str_strlen(boundary);
-  while ((ftello(fp) < end_off) && fgets(buffer, LONG_STRING, fp))
+  while ((ftello(fp) < end_off) && fgets(buffer, sizeof(buffer), fp))
   {
     const size_t len = mutt_str_strlen(buffer);
 
@@ -1379,7 +1379,7 @@ struct Body *mutt_parse_multipart(FILE *fp, const char *boundary, LOFF_T end_off
           if (mutt_str_atoi(mutt_param_get(&new->parameter, "content-lines"), &lines) < 0)
             lines = 0;
           for (; lines; lines--)
-            if ((ftello(fp) >= end_off) || !fgets(buffer, LONG_STRING, fp))
+            if ((ftello(fp) >= end_off) || !fgets(buffer, sizeof(buffer), fp))
               break;
         }
 #endif

--- a/email/rfc2231.c
+++ b/email/rfc2231.c
@@ -184,8 +184,8 @@ static void free_parameter(struct Rfc2231Parameter **p)
  */
 static void join_continuations(struct ParameterList *p, struct Rfc2231Parameter *par)
 {
-  char attribute[STRING];
-  char charset[STRING];
+  char attribute[256];
+  char charset[256];
 
   while (par)
   {
@@ -239,7 +239,7 @@ void rfc2231_decode_parameters(struct ParameterList *p)
   struct Rfc2231Parameter *conttmp = NULL;
 
   char *s = NULL, *t = NULL;
-  char charset[STRING];
+  char charset[256];
 
   bool encoded;
   int index;

--- a/email/url.c
+++ b/email/url.c
@@ -132,7 +132,7 @@ int url_pct_decode(char *s)
  */
 enum UrlScheme url_check_scheme(const char *s)
 {
-  char sbuf[STRING];
+  char sbuf[256];
   char *t = NULL;
   int i;
 
@@ -365,7 +365,7 @@ int url_tostring(struct Url *u, char *buf, size_t buflen, int flags)
 
     if (u->user && (u->user[0] || !(flags & U_PATH)))
     {
-      char str[STRING];
+      char str[256];
       url_pct_encode(str, sizeof(str), u->user);
       snprintf(buf, buflen, "%s@", str);
       l = strlen(buf);

--- a/enriched.c
+++ b/enriched.c
@@ -279,7 +279,7 @@ static void enriched_putwc(wchar_t c, struct EnrichedState *stte)
     if (stte->tag_level[RICH_COLOR])
     {
       if (stte->param_used + 1 >= stte->param_len)
-        mutt_mem_realloc(&stte->param, (stte->param_len += STRING) * sizeof(wchar_t));
+        mutt_mem_realloc(&stte->param, (stte->param_len += 256) * sizeof(wchar_t));
 
       stte->param[stte->param_used++] = c;
     }
@@ -483,9 +483,9 @@ int text_enriched_handler(struct Body *a, struct State *s)
            ((MuttIndexWindow->cols - 4) < 72) ? (MuttIndexWindow->cols - 4) : 72);
   stte.line_max = stte.wrap_margin * 4;
   stte.line = mutt_mem_calloc(1, (stte.line_max + 1) * sizeof(wchar_t));
-  stte.param = mutt_mem_calloc(1, (STRING) * sizeof(wchar_t));
+  stte.param = mutt_mem_calloc(1, 256 * sizeof(wchar_t));
 
-  stte.param_len = STRING;
+  stte.param_len = 256;
   stte.param_used = 0;
 
   if (s->prefix)

--- a/enriched.c
+++ b/enriched.c
@@ -289,7 +289,7 @@ static void enriched_putwc(wchar_t c, struct EnrichedState *stte)
   /* see if more space is needed (plus extra for possible rich characters) */
   if (stte->buf_len < (stte->buf_used + 3))
   {
-    stte->buf_len += LONG_STRING;
+    stte->buf_len += 1024;
     mutt_mem_realloc(&stte->buffer, (stte->buf_len + 1) * sizeof(wchar_t));
   }
 
@@ -352,7 +352,7 @@ static void enriched_puts(const char *s, struct EnrichedState *stte)
 
   if (stte->buf_len < (stte->buf_used + mutt_str_strlen(s)))
   {
-    stte->buf_len += LONG_STRING;
+    stte->buf_len += 1024;
     mutt_mem_realloc(&stte->buffer, (stte->buf_len + 1) * sizeof(wchar_t));
   }
   c = s;
@@ -474,7 +474,7 @@ int text_enriched_handler(struct Body *a, struct State *s)
   struct EnrichedState stte = { 0 };
   wchar_t wc = 0;
   int tag_len = 0;
-  wchar_t tag[LONG_STRING + 1];
+  wchar_t tag[1024 + 1];
 
   stte.s = s;
   stte.wrap_margin =
@@ -551,7 +551,7 @@ int text_enriched_handler(struct Body *a, struct State *s)
           enriched_set_flags(tag, &stte);
           state = TEXT;
         }
-        else if (tag_len < LONG_STRING) /* ignore overly long tags */
+        else if (tag_len < 1024) /* ignore overly long tags */
           tag[tag_len++] = wc;
         else
           state = BOGUS_TAG;

--- a/globals.h
+++ b/globals.h
@@ -40,10 +40,10 @@ WHERE struct ConfigSet *Config; ///< Wrapper around the user's config settings
 
 WHERE struct Context *Context;
 
-WHERE bool ErrorBufMessage;          ///< true if the last message was an error
-WHERE char ErrorBuf[STRING];         ///< Copy of the last error message
-WHERE char AttachmentMarker[STRING]; ///< Unique ANSI string to mark PGP messages in an email
-WHERE char ProtectedHeaderMarker[STRING]; ///< Unique ANSI string to mark protected headers in an email
+WHERE bool ErrorBufMessage;            ///< true if the last message was an error
+WHERE char ErrorBuf[256];              ///< Copy of the last error message
+WHERE char AttachmentMarker[256];      ///< Unique ANSI string to mark PGP messages in an email
+WHERE char ProtectedHeaderMarker[256]; ///< Unique ANSI string to mark protected headers in an email
 
 WHERE char *HomeDir;       ///< User's home directory
 WHERE char *ShortHostname; ///< Short version of the hostname

--- a/handler.c
+++ b/handler.c
@@ -370,7 +370,7 @@ static unsigned char decode_byte(char ch)
  */
 static void decode_uuencoded(struct State *s, long len, bool istext, iconv_t cd)
 {
-  char tmps[SHORT_STRING];
+  char tmps[128];
   char *pt = NULL;
   char bufi[BUFI_SIZE];
   size_t k = 0;
@@ -481,7 +481,7 @@ static bool is_mmnoask(const char *buf)
  */
 static bool is_autoview(struct Body *b)
 {
-  char type[SHORT_STRING];
+  char type[128];
   bool is_av = false;
 
   snprintf(type, sizeof(type), "%s/%s", TYPE(b), b->subtype);
@@ -1647,7 +1647,7 @@ int mutt_body_handler(struct Body *b, struct State *s)
                                          C_HonorDisposition && (plaintext || handler)))
   {
     const char *str = NULL;
-    char keystroke[SHORT_STRING];
+    char keystroke[128];
     keystroke[0] = '\0';
 
     if (!OptViewAttach)

--- a/handler.c
+++ b/handler.c
@@ -529,7 +529,7 @@ static int autoview_handler(struct Body *a, struct State *s)
   struct Rfc1524MailcapEntry *entry = rfc1524_new_entry();
   char buffer[1024];
   char type[256];
-  char command[HUGE_STRING];
+  char command[STR_COMMAND];
   char tempfile[PATH_MAX] = "";
   char *fname = NULL;
   FILE *fpin = NULL;

--- a/handler.c
+++ b/handler.c
@@ -290,22 +290,22 @@ static void qp_decode_line(char *dest, char *src, size_t *l, int last)
  * size.
  *
  * Now, we don't special-case if the line we read with fgets() isn't
- * terminated. We don't care about this, since STRING > 78, so corrupted input
- * will just be corrupted a bit more. That implies that STRING+1 bytes are
+ * terminated. We don't care about this, since 256 > 78, so corrupted input
+ * will just be corrupted a bit more. That implies that 256+1 bytes are
  * always sufficient to store the result of qp_decode_line.
  *
  * Finally, at soft line breaks, some part of a multibyte character may have
  * been left over by convert_to_state(). This shouldn't be more than 6
- * characters, so STRING + 7 should be sufficient memory to store the decoded
+ * characters, so 256+7 should be sufficient memory to store the decoded
  * data.
  *
  * Just to make sure that I didn't make some off-by-one error above, we just
- * use STRING*2 for the target buffer's size.
+ * use 512 for the target buffer's size.
  */
 static void decode_quoted(struct State *s, long len, bool istext, iconv_t cd)
 {
-  char line[STRING];
-  char decline[2 * STRING];
+  char line[256];
+  char decline[512];
   size_t l = 0;
   size_t l3;
 
@@ -528,7 +528,7 @@ static int autoview_handler(struct Body *a, struct State *s)
 {
   struct Rfc1524MailcapEntry *entry = rfc1524_new_entry();
   char buffer[LONG_STRING];
-  char type[STRING];
+  char type[256];
   char command[HUGE_STRING];
   char tempfile[PATH_MAX] = "";
   char *fname = NULL;
@@ -745,7 +745,7 @@ static int message_handler(struct Body *a, struct State *s)
 static int external_body_handler(struct Body *b, struct State *s)
 {
   const char *str = NULL;
-  char strbuf[LONG_STRING]; // STRING might be too short but LONG_STRING should be large enough
+  char strbuf[LONG_STRING];
 
   const char *access_type = mutt_param_get(&b->parameter, "access-type");
   if (!access_type)

--- a/handler.c
+++ b/handler.c
@@ -432,7 +432,7 @@ static void decode_uuencoded(struct State *s, long len, bool istext, iconv_t cd)
 static bool is_mmnoask(const char *buf)
 {
   char *p = NULL;
-  char tmp[LONG_STRING], *q = NULL;
+  char tmp[1024], *q = NULL;
 
   const char *val = mutt_str_getenv("MM_NOASK");
   if (!val)
@@ -527,7 +527,7 @@ static bool is_autoview(struct Body *b)
 static int autoview_handler(struct Body *a, struct State *s)
 {
   struct Rfc1524MailcapEntry *entry = rfc1524_new_entry();
-  char buffer[LONG_STRING];
+  char buffer[1024];
   char type[256];
   char command[HUGE_STRING];
   char tempfile[PATH_MAX] = "";
@@ -745,7 +745,7 @@ static int message_handler(struct Body *a, struct State *s)
 static int external_body_handler(struct Body *b, struct State *s)
 {
   const char *str = NULL;
-  char strbuf[LONG_STRING];
+  char strbuf[1024];
 
   const char *access_type = mutt_param_get(&b->parameter, "access-type");
   if (!access_type)

--- a/hcache/hcache.c
+++ b/hcache/hcache.c
@@ -462,7 +462,7 @@ int mutt_hcache_delete(header_cache_t *hc, const char *key, size_t keylen)
  */
 const char *mutt_hcache_backend_list(void)
 {
-  char tmp[STRING] = { 0 };
+  char tmp[256] = { 0 };
   const struct HcacheOps **ops = hcache_ops;
   size_t len = 0;
 
@@ -470,9 +470,9 @@ const char *mutt_hcache_backend_list(void)
   {
     if (len != 0)
     {
-      len += snprintf(tmp + len, STRING - len, ", ");
+      len += snprintf(tmp + len, sizeof(tmp) - len, ", ");
     }
-    len += snprintf(tmp + len, STRING - len, "%s", (*ops)->name);
+    len += snprintf(tmp + len, sizeof(tmp) - len, "%s", (*ops)->name);
   }
 
   return mutt_str_strdup(tmp);

--- a/hcache/kc.c
+++ b/hcache/kc.c
@@ -148,8 +148,7 @@ static void hcache_kyotocabinet_close(void **ctx)
  */
 static const char *hcache_kyotocabinet_backend(void)
 {
-  /* SHORT_STRING(128) should be more than enough for KCVERSION */
-  static char version_cache[SHORT_STRING] = "";
+  static char version_cache[128] = ""; ///< should be more than enough for KCVERSION
   if (!version_cache[0])
     snprintf(version_cache, sizeof(version_cache), "kyotocabinet %s", KCVERSION);
 

--- a/hdrline.c
+++ b/hdrline.c
@@ -549,7 +549,7 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
                                     unsigned long data, int flags)
 {
   struct HdrFormatInfo *hfi = (struct HdrFormatInfo *) data;
-  char fmt[SHORT_STRING], tmp[LONG_STRING], *p, *tags = NULL;
+  char fmt[128], tmp[LONG_STRING], *p, *tags = NULL;
   const char *wch = NULL;
   int i;
   int optional = (flags & MUTT_FORMAT_OPTIONAL);

--- a/hdrline.c
+++ b/hdrline.c
@@ -549,7 +549,7 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
                                     unsigned long data, int flags)
 {
   struct HdrFormatInfo *hfi = (struct HdrFormatInfo *) data;
-  char fmt[128], tmp[LONG_STRING], *p, *tags = NULL;
+  char fmt[128], tmp[1024], *p, *tags = NULL;
   const char *wch = NULL;
   int i;
   int optional = (flags & MUTT_FORMAT_OPTIONAL);

--- a/help.c
+++ b/help.c
@@ -294,7 +294,7 @@ static void format_line(FILE *f, int ismacro, const char *t1, const char *t2, co
   if (split)
   {
     col = 0;
-    col_b = LONG_STRING;
+    col_b = 1024;
     fputc('\n', f);
   }
   else
@@ -327,7 +327,7 @@ static void format_line(FILE *f, int ismacro, const char *t1, const char *t2, co
 
   if (split)
   {
-    print_macro(f, LONG_STRING, &t3);
+    print_macro(f, 1024, &t3);
     fputc('\n', f);
   }
   else

--- a/help.c
+++ b/help.c
@@ -87,11 +87,11 @@ static const struct Binding *help_lookup_function(int op, int menu)
  * @param menu   Current Menu
  * @param op     Operation, e.g. OP_DELETE
  *
- * This will return something like: "buf:delete"
+ * This will return something like: "d:delete"
  */
 void mutt_make_help(char *buf, size_t buflen, const char *txt, int menu, int op)
 {
-  char tmp[SHORT_STRING];
+  char tmp[128];
 
   if (km_expand_key(tmp, sizeof(tmp), km_find_func(menu, op)) ||
       km_expand_key(tmp, sizeof(tmp), km_find_func(MENU_GENERIC, op)))
@@ -374,7 +374,7 @@ static void dump_menu(FILE *f, int menu)
 {
   struct Keymap *map = NULL;
   const struct Binding *b = NULL;
-  char buf[SHORT_STRING];
+  char buf[128];
 
   /* browse through the keymap table */
   for (map = Keymaps[menu]; map; map = map->next)
@@ -438,7 +438,7 @@ static void dump_unbound(FILE *f, const struct Binding *funcs,
 void mutt_help(int menu)
 {
   char t[PATH_MAX];
-  char buf[SHORT_STRING];
+  char buf[128];
   FILE *f = NULL;
 
   mutt_mktemp(t, sizeof(t));

--- a/hook.c
+++ b/hook.c
@@ -383,7 +383,7 @@ void mutt_folder_hook(const char *path, const char *desc)
   current_hook_type = MUTT_FOLDER_HOOK;
 
   mutt_buffer_init(&err);
-  err.dsize = STRING;
+  err.dsize = 256;
   err.data = mutt_mem_malloc(err.dsize);
   mutt_buffer_init(&token);
   TAILQ_FOREACH(tmp, &Hooks, entries)
@@ -448,7 +448,7 @@ void mutt_message_hook(struct Mailbox *m, struct Email *e, int type)
   current_hook_type = type;
 
   mutt_buffer_init(&err);
-  err.dsize = STRING;
+  err.dsize = 256;
   err.data = mutt_mem_malloc(err.dsize);
   mutt_buffer_init(&token);
   TAILQ_FOREACH(hook, &Hooks, entries)
@@ -630,7 +630,7 @@ void mutt_account_hook(const char *url)
     return;
 
   mutt_buffer_init(&err);
-  err.dsize = STRING;
+  err.dsize = 256;
   err.data = mutt_mem_malloc(err.dsize);
   mutt_buffer_init(&token);
 
@@ -673,7 +673,7 @@ void mutt_timeout_hook(void)
   struct Hook *hook = NULL;
   struct Buffer token;
   struct Buffer err;
-  char buf[STRING];
+  char buf[256];
 
   mutt_buffer_init(&err);
   err.data = buf;
@@ -712,7 +712,7 @@ void mutt_startup_shutdown_hook(int type)
   struct Hook *hook = NULL;
   struct Buffer token = { 0 };
   struct Buffer err = { 0 };
-  char buf[STRING];
+  char buf[256];
 
   err.data = buf;
   err.dsize = sizeof(buf);

--- a/hook.c
+++ b/hook.c
@@ -167,7 +167,7 @@ enum CommandResult mutt_parse_hook(struct Buffer *buf, struct Buffer *s,
            !(data & (MUTT_CHARSET_HOOK | MUTT_ICONV_HOOK | MUTT_ACCOUNT_HOOK)) &&
            (!WithCrypto || !(data & MUTT_CRYPT_HOOK)))
   {
-    char tmp[HUGE_STRING];
+    char tmp[8192];
 
     /* At this stage remain only message-hooks, reply-hooks, send-hooks,
      * send2-hooks, save-hooks, and fcc-hooks: All those allowing full

--- a/imap/auth_cram.c
+++ b/imap/auth_cram.c
@@ -97,7 +97,7 @@ static void hmac_md5(const char *password, char *challenge, unsigned char *respo
  */
 enum ImapAuthRes imap_auth_cram_md5(struct ImapAccountData *adata, const char *method)
 {
-  char ibuf[LONG_STRING * 2], obuf[LONG_STRING];
+  char ibuf[2048], obuf[1024];
   unsigned char hmac_response[MD5_DIGEST_LEN];
   int len;
   int rc;

--- a/imap/auth_login.c
+++ b/imap/auth_login.c
@@ -45,7 +45,7 @@
 enum ImapAuthRes imap_auth_login(struct ImapAccountData *adata, const char *method)
 {
   char q_user[256], q_pass[256];
-  char buf[LONG_STRING];
+  char buf[1024];
 
   if ((adata->capabilities & IMAP_CAP_LOGINDISABLED))
   {

--- a/imap/auth_login.c
+++ b/imap/auth_login.c
@@ -44,7 +44,7 @@
  */
 enum ImapAuthRes imap_auth_login(struct ImapAccountData *adata, const char *method)
 {
-  char q_user[STRING], q_pass[STRING];
+  char q_user[256], q_pass[256];
   char buf[LONG_STRING];
 
   if ((adata->capabilities & IMAP_CAP_LOGINDISABLED))

--- a/imap/auth_plain.c
+++ b/imap/auth_plain.c
@@ -47,7 +47,7 @@ enum ImapAuthRes imap_auth_plain(struct ImapAccountData *adata, const char *meth
   int rc = IMAP_CMD_CONTINUE;
   enum ImapAuthRes res = IMAP_AUTH_SUCCESS;
   static const char auth_plain_cmd[] = "AUTHENTICATE PLAIN";
-  char buf[STRING] = { 0 };
+  char buf[256] = { 0 };
 
   if (mutt_account_getuser(&adata->conn->account) < 0)
     return IMAP_AUTH_FAILURE;

--- a/imap/auth_sasl.c
+++ b/imap/auth_sasl.c
@@ -127,7 +127,7 @@ enum ImapAuthRes imap_auth_sasl(struct ImapAccountData *adata, const char *metho
 
   mutt_message(_("Authenticating (%s)..."), mech);
 
-  bufsize = ((olen * 2) > LONG_STRING) ? (olen * 2) : LONG_STRING;
+  bufsize = MAX((olen * 2), 1024);
   buf = mutt_mem_malloc(bufsize);
 
   snprintf(buf, bufsize, "AUTHENTICATE %s", mech);

--- a/imap/browse.c
+++ b/imap/browse.c
@@ -66,7 +66,7 @@ static void add_folder(char delim, char *folder, bool noselect, bool noinferiors
   char tmp[PATH_MAX];
   char relpath[PATH_MAX];
   struct ConnAccount conn_account;
-  char mailbox[LONG_STRING];
+  char mailbox[1024];
 
   if (imap_parse_path(state->folder, &conn_account, mailbox, sizeof(mailbox)))
     return;
@@ -366,7 +366,7 @@ int imap_mailbox_create(const char *path)
 {
   struct ImapAccountData *adata = NULL;
   struct ImapMboxData *mdata = NULL;
-  char name[LONG_STRING];
+  char name[1024];
   short n;
 
   if (imap_adata_find(path, &adata, &mdata) < 0)

--- a/imap/command.c
+++ b/imap/command.c
@@ -630,8 +630,8 @@ static void cmd_parse_list(struct ImapAccountData *adata, char *s)
  */
 static void cmd_parse_lsub(struct ImapAccountData *adata, char *s)
 {
-  char buf[STRING];
-  char errstr[STRING];
+  char buf[256];
+  char errstr[256];
   struct Buffer err, token;
   struct Url url;
   struct ImapList list;

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -304,7 +304,7 @@ static int sync_helper(struct Mailbox *m, int right, int flag, const char *name)
 {
   int count = 0;
   int rc;
-  char buf[LONG_STRING];
+  char buf[1024];
 
   if (!m)
     return -1;
@@ -534,7 +534,7 @@ static int complete_hosts(char *buf, size_t buflen)
   TAILQ_FOREACH(conn, mutt_socket_head(), entries)
   {
     struct Url url;
-    char urlstr[LONG_STRING];
+    char urlstr[1024];
 
     if (conn->account.type != MUTT_ACCT_TYPE_IMAP)
       continue;
@@ -569,7 +569,7 @@ static int complete_hosts(char *buf, size_t buflen)
  */
 int imap_create_mailbox(struct ImapAccountData *adata, char *mailbox)
 {
-  char buf[LONG_STRING * 2], mbox[LONG_STRING];
+  char buf[2048], mbox[1024];
 
   imap_munge_mbox_name(adata->unicode, mbox, sizeof(mbox), mailbox);
   snprintf(buf, sizeof(buf), "CREATE %s", mbox);
@@ -611,8 +611,8 @@ int imap_access(const char *path)
  */
 int imap_rename_mailbox(struct ImapAccountData *adata, char *oldname, const char *newname)
 {
-  char oldmbox[LONG_STRING];
-  char newmbox[LONG_STRING];
+  char oldmbox[1024];
+  char newmbox[1024];
   int rc = 0;
 
   imap_munge_mbox_name(adata->unicode, oldmbox, sizeof(oldmbox), oldname);
@@ -847,7 +847,7 @@ void imap_expunge_mailbox(struct Mailbox *m)
  */
 int imap_open_connection(struct ImapAccountData *adata)
 {
-  char buf[LONG_STRING];
+  char buf[1024];
 
   if (mutt_socket_open(adata->conn) < 0)
     return -1;
@@ -1092,7 +1092,7 @@ int imap_sync_message_for_copy(struct Mailbox *m, struct Email *e,
   if (!adata || adata->mailbox != m)
     return -1;
 
-  char flags[LONG_STRING];
+  char flags[1024];
   char *tags = NULL;
   char uid[11];
 
@@ -1262,7 +1262,7 @@ int imap_check_mailbox(struct Mailbox *m, bool force)
 static int imap_status(struct ImapAccountData *adata, struct ImapMboxData *mdata, bool queue)
 {
   char *uid_validity_flag;
-  char command[LONG_STRING * 2];
+  char command[2048];
 
   if (!adata || !mdata)
     return -1;
@@ -1395,8 +1395,8 @@ int imap_subscribe(char *path, bool subscribe)
 {
   struct ImapAccountData *adata = NULL;
   struct ImapMboxData *mdata = NULL;
-  char buf[LONG_STRING * 2];
-  char mbox[LONG_STRING];
+  char buf[2048];
+  char mbox[1024];
   char errstr[256];
   struct Buffer err, token;
   size_t len = 0;
@@ -1453,9 +1453,9 @@ int imap_complete(char *buf, size_t buflen, char *path)
 {
   struct ImapAccountData *adata = NULL;
   struct ImapMboxData *mdata = NULL;
-  char tmp[LONG_STRING * 2];
+  char tmp[2048];
   struct ImapList listresp;
-  char completion[LONG_STRING];
+  char completion[1024];
   int clen;
   size_t matchlen = 0;
   int completions = 0;
@@ -1529,7 +1529,7 @@ int imap_complete(char *buf, size_t buflen, char *path)
  */
 int imap_fast_trash(struct Mailbox *m, char *dest)
 {
-  char prompt[LONG_STRING];
+  char prompt[1024];
   int rc = -1;
   bool triedcreate = false;
   struct Buffer *sync_cmd = NULL;
@@ -1886,7 +1886,7 @@ int imap_ac_add(struct Account *a, struct Mailbox *m)
     struct ImapMboxData *mdata = imap_mdata_new(adata, url->path);
 
     /* fixup path and realpath, mainly to replace / by /INBOX */
-    char buf[LONG_STRING];
+    char buf[1024];
     imap_qualify_path(buf, sizeof(buf), &adata->conn_account, mdata->name);
     mutt_str_strfcpy(m->path, buf, sizeof(m->path));
     mutt_str_strfcpy(m->realpath, m->path, sizeof(m->realpath));

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -421,7 +421,7 @@ static int compile_search(struct Mailbox *m, const struct Pattern *pat, struct B
   }
   else
   {
-    char term[STRING];
+    char term[256];
     char *delim = NULL;
 
     switch (pat->op)
@@ -1397,7 +1397,7 @@ int imap_subscribe(char *path, bool subscribe)
   struct ImapMboxData *mdata = NULL;
   char buf[LONG_STRING * 2];
   char mbox[LONG_STRING];
-  char errstr[STRING];
+  char errstr[256];
   struct Buffer err, token;
   size_t len = 0;
 

--- a/imap/message.c
+++ b/imap/message.c
@@ -326,7 +326,7 @@ static char *msg_parse_flags(struct ImapHeader *h, char *s)
  */
 static int msg_parse_fetch(struct ImapHeader *h, char *s)
 {
-  char tmp[SHORT_STRING];
+  char tmp[128];
   char *ptmp = NULL;
   size_t plen = 0;
 
@@ -1419,7 +1419,7 @@ int imap_append_message(struct Mailbox *m, struct Message *msg)
   FILE *fp = NULL;
   char buf[LONG_STRING * 2];
   char internaldate[IMAP_DATELEN];
-  char imap_flags[SHORT_STRING];
+  char imap_flags[128];
   size_t len;
   struct Progress progressbar;
   size_t sent;

--- a/imap/message.c
+++ b/imap/message.c
@@ -708,7 +708,7 @@ static int read_headers_normal_eval_cache(struct ImapAccountData *adata,
                                           bool store_flag_updates, bool eval_condstore)
 {
   struct Progress progress;
-  char buf[LONG_STRING];
+  char buf[1024];
 
   struct Mailbox *m = adata->mailbox;
   struct ImapMboxData *mdata = imap_mdata_get(m);
@@ -919,7 +919,7 @@ static int read_headers_condstore_qresync_updates(struct ImapAccountData *adata,
                                                   unsigned long long hc_modseq, bool eval_qresync)
 {
   struct Progress progress;
-  char buf[LONG_STRING];
+  char buf[1024];
   unsigned int header_msn = 0;
 
   struct Mailbox *m = adata->mailbox;
@@ -1417,7 +1417,7 @@ int imap_append_message(struct Mailbox *m, struct Message *msg)
     return -1;
 
   FILE *fp = NULL;
-  char buf[LONG_STRING * 2];
+  char buf[1024 * 2];
   char internaldate[IMAP_DATELEN];
   char imap_flags[128];
   size_t len;
@@ -1835,7 +1835,7 @@ int imap_msg_open(struct Mailbox *m, struct Message *msg, int msgno)
     return -1;
 
   struct Envelope *newenv = NULL;
-  char buf[LONG_STRING];
+  char buf[1024];
   char *pc = NULL;
   unsigned int bytes;
   struct Progress progressbar;

--- a/imap/util.c
+++ b/imap/util.c
@@ -137,7 +137,7 @@ int imap_adata_find(const char *path, struct ImapAccountData **adata,
 {
   struct ConnAccount conn_account;
   struct ImapAccountData *tmp_adata;
-  char tmp[LONG_STRING];
+  char tmp[1024];
 
   if (imap_parse_path(path, &conn_account, tmp, sizeof(tmp)) < 0)
     return -1;
@@ -166,7 +166,7 @@ int imap_adata_find(const char *path, struct ImapAccountData **adata,
  */
 struct ImapMboxData *imap_mdata_new(struct ImapAccountData *adata, const char *name)
 {
-  char buf[LONG_STRING];
+  char buf[1024];
   struct ImapMboxData *mdata = mutt_mem_calloc(1, sizeof(struct ImapMboxData));
 
   mdata->real_name = mutt_str_strdup(name);
@@ -307,7 +307,7 @@ void imap_get_parent_path(const char *path, char *buf, size_t buflen)
 {
   struct ImapAccountData *adata = NULL;
   struct ImapMboxData *mdata = NULL;
-  char mbox[LONG_STRING];
+  char mbox[1024];
 
   if (imap_adata_find(path, &adata, &mdata) < 0)
   {
@@ -700,8 +700,8 @@ void imap_pretty_mailbox(char *path, const char *folder)
   int tlen;
   int hlen = 0;
   bool home_match = false;
-  char target_mailbox[LONG_STRING];
-  char home_mailbox[LONG_STRING];
+  char target_mailbox[1024];
+  char home_mailbox[1024];
 
   if (imap_parse_path(path, &target_conn_account, target_mailbox, sizeof(target_mailbox)) < 0)
     return;

--- a/imap/util.c
+++ b/imap/util.c
@@ -532,7 +532,7 @@ int imap_hcache_store_uid_seqset(struct ImapMboxData *mdata)
 
   struct Buffer *b = mutt_buffer_new();
   /* The seqset is likely large.  Preallocate to reduce reallocs */
-  mutt_buffer_increase_size(b, HUGE_STRING);
+  mutt_buffer_increase_size(b, 8192);
   imap_msn_index_to_uid_seqset(b, mdata);
 
   size_t seqset_size = b->dptr - b->data;

--- a/index.c
+++ b/index.c
@@ -983,7 +983,7 @@ static void index_custom_redraw(struct Menu *menu)
 
   if (menu->redraw & REDRAW_STATUS)
   {
-    char buf[LONG_STRING];
+    char buf[1024];
     menu_status_line(buf, sizeof(buf), menu, NONULL(C_StatusFormat));
     mutt_window_move(MuttStatusWindow, 0, 0);
     SETCOLOR(MT_COLOR_STATUS);
@@ -1011,7 +1011,7 @@ static void index_custom_redraw(struct Menu *menu)
  */
 int mutt_index_menu(void)
 {
-  char buf[PATH_MAX], helpstr[LONG_STRING];
+  char buf[PATH_MAX], helpstr[1024];
   int flags;
   int op = OP_NULL;
   bool done = false; /* controls when to exit the "event" loop */
@@ -1125,7 +1125,7 @@ int mutt_index_menu(void)
                 beep();
               if (C_NewMailCommand)
               {
-                char cmd[LONG_STRING];
+                char cmd[1024];
                 menu_status_line(cmd, sizeof(cmd), menu, NONULL(C_NewMailCommand));
                 if (mutt_system(cmd) != 0)
                   mutt_error(_("Error running \"%s\""), cmd);
@@ -1168,7 +1168,7 @@ int mutt_index_menu(void)
             beep();
           if (C_NewMailCommand)
           {
-            char cmd[LONG_STRING];
+            char cmd[1024];
             menu_status_line(cmd, sizeof(cmd), menu, NONULL(C_NewMailCommand));
             if (mutt_system(cmd) != 0)
               mutt_error(_("Error running \"%s\""), cmd);
@@ -1641,7 +1641,7 @@ int mutt_index_menu(void)
                                -1;
         if (op == OP_TOGGLE_READ)
         {
-          char buf2[LONG_STRING];
+          char buf2[1024];
 
           if (!Context->pattern || (strncmp(Context->pattern, "!~R!~D~s", 8) != 0))
           {

--- a/index.c
+++ b/index.c
@@ -1623,7 +1623,7 @@ int mutt_index_menu(void)
           mutt_message(_("No limit pattern is in effect"));
         else
         {
-          char buf2[STRING];
+          char buf2[256];
           /* L10N: ask for a limit to apply */
           snprintf(buf2, sizeof(buf2), _("Limit: %s"), Context->pattern);
           mutt_message("%s", buf2);
@@ -2035,7 +2035,7 @@ int mutt_index_menu(void)
 
           if (!Context->mailbox->quiet)
           {
-            char msgbuf[STRING];
+            char msgbuf[256];
             snprintf(msgbuf, sizeof(msgbuf), _("Update tags..."));
             mutt_progress_init(&progress, msgbuf, MUTT_PROGRESS_MSG, 1,
                                Context->mailbox->msg_tagged);
@@ -3346,7 +3346,7 @@ int mutt_index_menu(void)
           if (!mutt_get_field(_("Enter macro stroke: "), buf2, sizeof(buf2), MUTT_CLEAR) &&
               buf2[0])
           {
-            char str[STRING], macro[STRING];
+            char str[256], macro[256];
             snprintf(str, sizeof(str), "%s%s", C_MarkMacroPrefix, buf2);
             snprintf(macro, sizeof(macro), "<search>~i \"%s\"\n", CUR_EMAIL->env->message_id);
             /* L10N: "message hotkey" is the key bindings menu description of a

--- a/init.c
+++ b/init.c
@@ -81,9 +81,9 @@ static struct ListHead MuttrcStack = STAILQ_HEAD_INITIALIZER(MuttrcStack);
 #define NUMVARS mutt_array_size(MuttVars)
 #define NUMCOMMANDS mutt_array_size(Commands)
 
-/* initial string that starts completion. No telling how much crap
- * the user has typed so far. Allocate LONG_STRING just to be sure! */
-static char UserTyped[LONG_STRING] = { 0 };
+/* Initial string that starts completion. No telling how much the user has
+ * typed so far. Allocate 1024 just to be sure! */
+static char UserTyped[1024] = { 0 };
 
 static int NumMatched = 0;          /* Number of matches for completion */
 static char Completed[256] = { 0 }; /* completed string (command or variable) */
@@ -428,7 +428,7 @@ static bool get_hostname(void)
     C_Hostname = getmailname();
     if (!C_Hostname)
     {
-      char buffer[LONG_STRING];
+      char buffer[1024];
       if (getdnsdomainname(buffer, sizeof(buffer)) == 0)
       {
         C_Hostname = mutt_mem_malloc(mutt_str_strlen(buffer) +
@@ -3018,7 +3018,7 @@ int mutt_get_hook_type(const char *name)
  */
 int mutt_init(bool skip_sys_rc, struct ListHead *commands)
 {
-  char buffer[LONG_STRING];
+  char buffer[1024];
   int need_pause = 0;
   struct Buffer err;
 

--- a/init.c
+++ b/init.c
@@ -85,8 +85,8 @@ static struct ListHead MuttrcStack = STAILQ_HEAD_INITIALIZER(MuttrcStack);
  * the user has typed so far. Allocate LONG_STRING just to be sure! */
 static char UserTyped[LONG_STRING] = { 0 };
 
-static int NumMatched = 0;             /* Number of matches for completion */
-static char Completed[STRING] = { 0 }; /* completed string (command or variable) */
+static int NumMatched = 0;          /* Number of matches for completion */
+static char Completed[256] = { 0 }; /* completed string (command or variable) */
 static const char **Matches;
 /* this is a lie until mutt_init runs: */
 static int MatchesListsize = MAX(NUMVARS, NUMCOMMANDS) + 10;
@@ -284,7 +284,7 @@ static int execute_commands(struct ListHead *p)
   struct Buffer err, token;
 
   mutt_buffer_init(&err);
-  err.dsize = STRING;
+  err.dsize = 256;
   err.data = mutt_mem_malloc(err.dsize);
   mutt_buffer_init(&token);
   struct ListNode *np = NULL;
@@ -336,7 +336,7 @@ static char *find_cfg(const char *home, const char *xdg_cfg_home)
 
     for (int j = 0; names[j]; j++)
     {
-      char buffer[STRING];
+      char buffer[256];
 
       snprintf(buffer, sizeof(buffer), "%s/%s%s", locations[i][0],
                locations[i][1], names[j]);
@@ -2631,14 +2631,14 @@ void mutt_commands_apply(void *data, void (*application)(void *, const struct Co
  */
 int mutt_dump_variables(bool hide_sensitive)
 {
-  char command[STRING];
+  char command[256];
 
   struct Buffer err, token;
 
   mutt_buffer_init(&err);
   mutt_buffer_init(&token);
 
-  err.dsize = STRING;
+  err.dsize = 256;
   err.data = mutt_mem_malloc(err.dsize);
 
   for (int i = 0; MuttVars[i].name; i++)
@@ -3023,7 +3023,7 @@ int mutt_init(bool skip_sys_rc, struct ListHead *commands)
   struct Buffer err;
 
   mutt_buffer_init(&err);
-  err.dsize = STRING;
+  err.dsize = 256;
   err.data = mutt_mem_malloc(err.dsize);
   err.dptr = err.data;
 
@@ -3228,7 +3228,7 @@ int mutt_init(bool skip_sys_rc, struct ListHead *commands)
     struct passwd *pw = getpwuid(getuid());
     if (pw)
     {
-      char buf[STRING];
+      char buf[256];
       C_Realname = mutt_str_strdup(mutt_gecos_name(buf, sizeof(buf), pw));
     }
   }
@@ -3339,8 +3339,8 @@ finish:
  */
 int mutt_query_variables(struct ListHead *queries)
 {
-  struct Buffer *value = mutt_buffer_alloc(STRING);
-  struct Buffer *tmp = mutt_buffer_alloc(STRING);
+  struct Buffer *value = mutt_buffer_alloc(256);
+  struct Buffer *tmp = mutt_buffer_alloc(256);
   int rc = 0;
 
   struct ListNode *np = NULL;
@@ -3780,7 +3780,7 @@ int mutt_var_value_complete(char *buf, size_t buflen, int pos)
   if (mutt_str_startswith(buf, "set", CASE_MATCH))
   {
     const char *myvarval = NULL;
-    char var[STRING];
+    char var[256];
     mutt_str_strfcpy(var, pt, sizeof(var));
     /* ignore the trailing '=' when comparing */
     int vlen = mutt_str_strlen(var);
@@ -3795,7 +3795,7 @@ int mutt_var_value_complete(char *buf, size_t buflen, int pos)
       myvarval = myvar_get(var);
       if (myvarval)
       {
-        struct Buffer *pretty = mutt_buffer_alloc(STRING);
+        struct Buffer *pretty = mutt_buffer_alloc(256);
         pretty_var(myvarval, pretty);
         snprintf(pt, buflen - (pt - buf), "%s=%s", var, pretty->data);
         mutt_buffer_free(&pretty);
@@ -3805,8 +3805,8 @@ int mutt_var_value_complete(char *buf, size_t buflen, int pos)
     }
     else
     {
-      struct Buffer *value = mutt_buffer_alloc(STRING);
-      struct Buffer *pretty = mutt_buffer_alloc(STRING);
+      struct Buffer *value = mutt_buffer_alloc(256);
+      struct Buffer *pretty = mutt_buffer_alloc(256);
       int rc = cs_he_string_get(Config, he, value);
       if (CSR_RESULT(rc) == CSR_SUCCESS)
       {

--- a/keymap.c
+++ b/keymap.c
@@ -223,7 +223,7 @@ static size_t parsekeys(const char *str, keycode_t *d, size_t max)
 {
   int n;
   size_t len = max;
-  char buf[SHORT_STRING];
+  char buf[128];
   char c;
   char *t = NULL;
 
@@ -1033,7 +1033,7 @@ void km_init(void)
  */
 void km_error_key(int menu)
 {
-  char buf[SHORT_STRING];
+  char buf[128];
   int p, op;
 
   struct Keymap *key = km_find_func(menu, OP_HELP);

--- a/mailbox.c
+++ b/mailbox.c
@@ -395,7 +395,7 @@ int mutt_mailbox_check(struct Mailbox *m_cur, int force)
 bool mutt_mailbox_list(void)
 {
   char path[PATH_MAX];
-  char mailboxlist[2 * STRING];
+  char mailboxlist[512];
   size_t pos = 0;
   int first = 1;
 

--- a/maildir/maildir.c
+++ b/maildir/maildir.c
@@ -194,7 +194,7 @@ void maildir_gen_flags(char *dest, size_t destlen, struct Email *e)
 
   if (e && (e->flagged || e->replied || e->read || e->deleted || e->old || e->maildir_flags))
   {
-    char tmp[LONG_STRING];
+    char tmp[1024];
     snprintf(tmp, sizeof(tmp), "%s%s%s%s%s", e->flagged ? "F" : "", e->replied ? "R" : "",
              e->read ? "S" : "", e->deleted ? "T" : "", NONULL(e->maildir_flags));
     if (e->maildir_flags)

--- a/maildir/mh.c
+++ b/maildir/mh.c
@@ -181,9 +181,9 @@ void mh_update_sequences(struct Mailbox *m)
   int flagged = 0;
   int replied = 0;
 
-  char seq_unseen[STRING];
-  char seq_replied[STRING];
-  char seq_flagged[STRING];
+  char seq_unseen[256];
+  char seq_replied[256];
+  char seq_flagged[256];
 
   struct MhSequences mhs = { 0 };
 

--- a/maildir/shared.c
+++ b/maildir/shared.c
@@ -202,9 +202,9 @@ static void mh_sequences_add_one(struct Mailbox *m, int n, bool unseen, bool fla
   char *tmpfname = NULL;
   char sequences[PATH_MAX];
 
-  char seq_unseen[STRING];
-  char seq_replied[STRING];
-  char seq_flagged[STRING];
+  char seq_unseen[256];
+  char seq_replied[256];
+  char seq_flagged[256];
 
   char *buf = NULL;
   int line = 0;
@@ -832,7 +832,7 @@ int mh_read_dir(struct Mailbox *m, const char *subdir)
   struct Maildir *md = NULL;
   struct MhSequences mhs = { 0 };
   struct Maildir **last = NULL;
-  char msgbuf[STRING];
+  char msgbuf[256];
   struct Progress progress;
 
   if (!m->quiet)

--- a/main.c
+++ b/main.c
@@ -921,7 +921,7 @@ int main(int argc, char *argv[], char *envp[])
        */
       if (!edit_infile)
       {
-        char buf[LONG_STRING];
+        char buf[1024];
         mutt_mktemp(buf, sizeof(buf));
         tempfile = mutt_str_strdup(buf);
 

--- a/main.c
+++ b/main.c
@@ -132,8 +132,8 @@ static void test_parse_set(void)
     "%s inv%s=42", "%s inv%s?", "%s &%s",     "%s &%s=42", "%s &%s?",
   };
 
-  struct Buffer *tmp = mutt_buffer_alloc(STRING);
-  struct Buffer *err = mutt_buffer_alloc(STRING);
+  struct Buffer *tmp = mutt_buffer_alloc(256);
+  struct Buffer *err = mutt_buffer_alloc(256);
   char line[64];
 
   for (size_t v = 0; v < mutt_array_size(vars); v++)
@@ -175,7 +175,7 @@ static void reset_tilde(struct ConfigSet *cs)
     "record",     "signature",
   };
 
-  struct Buffer *value = mutt_buffer_alloc(STRING);
+  struct Buffer *value = mutt_buffer_alloc(256);
   for (size_t i = 0; i < mutt_array_size(names); i++)
   {
     struct HashElem *he = cs_get_elem(cs, names[i]);
@@ -805,7 +805,7 @@ int main(int argc, char *argv[], char *envp[])
 #endif
     if (!skip && (stat(fpath, &sb) == -1) && (errno == ENOENT))
     {
-      char msg2[STRING];
+      char msg2[256];
       snprintf(msg2, sizeof(msg2), _("%s does not exist. Create it?"), C_Folder);
       if (mutt_yesorno(msg2, MUTT_YES) == MUTT_YES)
       {

--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -189,7 +189,7 @@ static int mmdf_parse_mailbox(struct Mailbox *m)
     return -1;
 
   char buf[HUGE_STRING];
-  char return_path[LONG_STRING];
+  char return_path[1024];
   int count = 0;
   int lines;
   time_t t;
@@ -1054,7 +1054,7 @@ static int mbox_mbox_check(struct Mailbox *m, int *index_hint)
        * see the message separator at *exactly* what used to be the end of the
        * folder.
        */
-      char buffer[LONG_STRING];
+      char buffer[1024];
       if (fseeko(adata->fp, m->size, SEEK_SET) != 0)
         mutt_debug(LL_DEBUG1, "#1 fseek() failed\n");
       if (fgets(buffer, sizeof(buffer), adata->fp))

--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -211,7 +211,7 @@ static int mmdf_parse_mailbox(struct Mailbox *m)
 
   if (!m->quiet)
   {
-    char msgbuf[STRING];
+    char msgbuf[256];
     snprintf(msgbuf, sizeof(msgbuf), _("Reading %s..."), m->path);
     mutt_progress_init(&progress, msgbuf, MUTT_PROGRESS_MSG, C_ReadInc, 0);
   }
@@ -354,7 +354,7 @@ static int mbox_parse_mailbox(struct Mailbox *m)
     return -1;
 
   struct stat sb;
-  char buf[HUGE_STRING], return_path[STRING];
+  char buf[HUGE_STRING], return_path[256];
   struct Email *e_cur = NULL;
   time_t t;
   int count = 0, lines = 0;
@@ -377,7 +377,7 @@ static int mbox_parse_mailbox(struct Mailbox *m)
 
   if (!m->quiet)
   {
-    char msgbuf[STRING];
+    char msgbuf[256];
     snprintf(msgbuf, sizeof(msgbuf), _("Reading %s..."), m->path);
     mutt_progress_init(&progress, msgbuf, MUTT_PROGRESS_MSG, C_ReadInc, 0);
   }
@@ -1647,7 +1647,7 @@ enum MailboxType mbox_path_probe(const char *path, const struct stat *st)
   }
 
   enum MailboxType magic = MUTT_UNKNOWN;
-  char tmp[STRING];
+  char tmp[256];
   if (fgets(tmp, sizeof(tmp), fp))
   {
     if (mutt_str_startswith(tmp, "From ", CASE_MATCH))

--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -188,7 +188,7 @@ static int mmdf_parse_mailbox(struct Mailbox *m)
   if (!adata)
     return -1;
 
-  char buf[HUGE_STRING];
+  char buf[8192];
   char return_path[1024];
   int count = 0;
   int lines;
@@ -354,7 +354,7 @@ static int mbox_parse_mailbox(struct Mailbox *m)
     return -1;
 
   struct stat sb;
-  char buf[HUGE_STRING], return_path[256];
+  char buf[8192], return_path[256];
   struct Email *e_cur = NULL;
   time_t t;
   int count = 0, lines = 0;

--- a/menu.c
+++ b/menu.c
@@ -387,7 +387,7 @@ void menu_redraw_full(struct Menu *menu)
  */
 void menu_redraw_status(struct Menu *menu)
 {
-  char buf[STRING];
+  char buf[256];
 
   snprintf(buf, sizeof(buf), MUTT_MODEFMT, menu->title);
   SETCOLOR(MT_COLOR_STATUS);

--- a/menu.c
+++ b/menu.c
@@ -415,7 +415,7 @@ void menu_redraw_sidebar(struct Menu *menu)
  */
 void menu_redraw_index(struct Menu *menu)
 {
-  char buf[LONG_STRING];
+  char buf[1024];
   bool do_color;
   int attr;
 
@@ -465,7 +465,7 @@ void menu_redraw_index(struct Menu *menu)
  */
 void menu_redraw_motion(struct Menu *menu)
 {
-  char buf[LONG_STRING];
+  char buf[1024];
 
   if (menu->dialog)
   {
@@ -523,7 +523,7 @@ void menu_redraw_motion(struct Menu *menu)
  */
 void menu_redraw_current(struct Menu *menu)
 {
-  char buf[LONG_STRING];
+  char buf[1024];
   int attr = menu->menu_color(menu->current);
 
   mutt_window_move(menu->indexwin, menu->current + menu->offset - menu->top, 0);
@@ -952,7 +952,7 @@ static int default_color(int line)
  */
 static int generic_search(struct Menu *menu, regex_t *rx, int line)
 {
-  char buf[LONG_STRING];
+  char buf[1024];
 
   menu_make_entry(buf, sizeof(buf), menu, line);
   return regexec(rx, buf, 0, NULL, 0);

--- a/menu.c
+++ b/menu.c
@@ -630,7 +630,7 @@ static void menu_jump(struct Menu *menu)
   if (menu->max)
   {
     mutt_unget_event(LastKey, 0);
-    char buf[SHORT_STRING];
+    char buf[128];
     buf[0] = '\0';
     if (mutt_get_field(_("Jump to: "), buf, sizeof(buf), 0) == 0 && buf[0])
     {
@@ -1145,7 +1145,7 @@ static int menu_search(struct Menu *menu, int op)
   int r = 0, wrap = 0;
   int search_dir;
   regex_t re;
-  char buf[SHORT_STRING];
+  char buf[128];
   char *search_buf =
       menu->menu >= 0 && menu->menu < MENU_MAX ? SearchBuffers[menu->menu] : NULL;
 

--- a/mutt/base64.c
+++ b/mutt/base64.c
@@ -34,6 +34,7 @@
 #include "config.h"
 #include "base64.h"
 #include "buffer.h"
+#include "memory.h"
 #include "string2.h"
 
 #define BAD -1
@@ -183,7 +184,7 @@ int mutt_b64_decode(const char *in, char *out, size_t olen)
  */
 size_t mutt_b64_buffer_encode(struct Buffer *buf, const char *in, size_t len)
 {
-  mutt_buffer_increase_size(buf, ((len * 2) > LONG_STRING) ? (len * 2) : LONG_STRING);
+  mutt_buffer_increase_size(buf, MAX((len * 2), 1024));
   size_t num = mutt_b64_encode(in, len, buf->data, buf->dsize);
   mutt_buffer_fix_dptr(buf);
   return num;

--- a/mutt/buffer.c
+++ b/mutt/buffer.c
@@ -351,7 +351,7 @@ static void increase_buffer_pool(void)
   mutt_mem_realloc(&BufferPool, BufferPoolLen * sizeof(struct Buffer *));
   while (BufferPoolCount < 5)
   {
-    newbuf = mutt_buffer_alloc(LONG_STRING);
+    newbuf = mutt_buffer_alloc(1024);
     BufferPool[BufferPoolCount++] = newbuf;
   }
 }
@@ -406,9 +406,9 @@ void mutt_buffer_pool_release(struct Buffer **pbuf)
   }
 
   struct Buffer *buf = *pbuf;
-  if (buf->dsize > (LONG_STRING * 2))
+  if (buf->dsize > 2048)
   {
-    buf->dsize = LONG_STRING;
+    buf->dsize = 1024;
     mutt_mem_realloc(&buf->data, buf->dsize);
   }
   mutt_buffer_reset(buf);

--- a/mutt/charset.c
+++ b/mutt/charset.c
@@ -400,7 +400,7 @@ bool mutt_ch_chscmp(const char *cs1, const char *cs2)
  */
 char *mutt_ch_get_default_charset(void)
 {
-  static char fcharset[SHORT_STRING];
+  static char fcharset[128];
   const char *c = C_AssumedCharset;
   const char *c1 = NULL;
 
@@ -530,8 +530,8 @@ const char *mutt_ch_charset_lookup(const char *chs)
  */
 iconv_t mutt_ch_iconv_open(const char *tocode, const char *fromcode, int flags)
 {
-  char tocode1[SHORT_STRING];
-  char fromcode1[SHORT_STRING];
+  char tocode1[128];
+  char fromcode1[128];
   const char *tocode2 = NULL, *fromcode2 = NULL;
   const char *tmp = NULL;
 

--- a/mutt/charset.c
+++ b/mutt/charset.c
@@ -381,7 +381,7 @@ bool mutt_ch_chscmp(const char *cs1, const char *cs2)
   if (!cs1 || !cs2)
     return false;
 
-  char buffer[STRING];
+  char buffer[256];
 
   mutt_ch_canonical_charset(buffer, sizeof(buffer), cs1);
 
@@ -955,7 +955,7 @@ char *mutt_ch_fgetconvs(char *buf, size_t buflen, struct FgetConv *fc)
  */
 void mutt_ch_set_charset(const char *charset)
 {
-  char buffer[STRING];
+  char buffer[256];
 
   mutt_ch_canonical_charset(buffer, sizeof(buffer), charset);
 

--- a/mutt/charset.c
+++ b/mutt/charset.c
@@ -313,7 +313,7 @@ int mutt_ch_convert_nonmime_string(char **ps)
  */
 void mutt_ch_canonical_charset(char *buf, size_t buflen, const char *name)
 {
-  char in[LONG_STRING], scratch[LONG_STRING];
+  char in[1024], scratch[1024];
 
   mutt_str_strfcpy(in, name, sizeof(in));
   char *ext = strchr(in, '/');
@@ -422,7 +422,7 @@ char *mutt_ch_get_default_charset(void)
  */
 char *mutt_ch_get_langinfo_charset(void)
 {
-  char buf[LONG_STRING] = "";
+  char buf[1024] = "";
 
   mutt_ch_canonical_charset(buf, sizeof(buf), nl_langinfo(CODESET));
 
@@ -1046,7 +1046,7 @@ char *mutt_ch_choose(const char *fromcode, const char *charsets, const char *u,
     if (dlen)
       *dlen = elen;
 
-    char canonical_buf[LONG_STRING];
+    char canonical_buf[1024];
     mutt_ch_canonical_charset(canonical_buf, sizeof(canonical_buf), tocode);
     mutt_str_replace(&tocode, canonical_buf);
   }

--- a/mutt/date.c
+++ b/mutt/date.c
@@ -451,8 +451,8 @@ time_t mutt_date_parse_date(const char *s, struct Tz *tz_out)
   int zminutes = 0;
   bool zoccident = false;
   const char *ptz = NULL;
-  char tzstr[SHORT_STRING];
-  char scratch[SHORT_STRING];
+  char tzstr[128];
+  char scratch[128];
 
   /* Don't modify our argument. Fixed-size buffer is ok here since
    * the date format imposes a natural limit.

--- a/mutt/envlist.c
+++ b/mutt/envlist.c
@@ -84,7 +84,7 @@ void mutt_envlist_init(char *envp[])
 bool mutt_envlist_set(const char *name, const char *value, bool overwrite)
 {
   char **envp = EnvList;
-  char work[LONG_STRING];
+  char work[1024];
   int count;
 
   /* Look for current slot to overwrite */

--- a/mutt/file.c
+++ b/mutt/file.c
@@ -263,7 +263,7 @@ int mutt_file_copy_bytes(FILE *in, FILE *out, size_t size)
 int mutt_file_copy_stream(FILE *fin, FILE *fout)
 {
   size_t l;
-  char buf[LONG_STRING];
+  char buf[1024];
 
   while ((l = fread(buf, 1, sizeof(buf), fin)) > 0)
   {

--- a/mutt/file.c
+++ b/mutt/file.c
@@ -636,8 +636,8 @@ char *mutt_file_read_line(char *line, size_t *size, FILE *fp, int *line_num, int
 
   if (!line)
   {
-    line = mutt_mem_malloc(STRING);
-    *size = STRING;
+    *size = 256;
+    line = mutt_mem_malloc(*size);
   }
 
   while (true)
@@ -681,7 +681,7 @@ char *mutt_file_read_line(char *line, size_t *size, FILE *fp, int *line_num, int
         ungetc(c, fp); /* undo our damage */
         /* There wasn't room for the line -- increase "line" */
         offset = *size - 1; /* overwrite the terminating 0 */
-        *size += STRING;
+        *size += 256;
         mutt_mem_realloc(&line, *size);
       }
     }

--- a/mutt/logging.c
+++ b/mutt/logging.c
@@ -396,12 +396,12 @@ int log_queue_save(FILE *fp)
  *
  * @sa log_queue_set_max_size(), log_queue_flush(), log_queue_empty()
  *
- * @warning Log lines are limited to #LONG_STRING bytes.
+ * @warning Log lines are limited to 1024 bytes.
  */
 int log_disp_queue(time_t stamp, const char *file, int line,
                    const char *function, int level, ...)
 {
-  char buf[LONG_STRING] = "";
+  char buf[1024] = "";
   int err = errno;
 
   va_list ap;
@@ -445,7 +445,7 @@ int log_disp_terminal(time_t stamp, const char *file, int line,
   if ((level < LL_PERROR) || (level > LL_MESSAGE))
     return 0;
 
-  char buf[LONG_STRING];
+  char buf[1024];
 
   va_list ap;
   va_start(ap, level);

--- a/mutt/path.c
+++ b/mutt/path.c
@@ -535,7 +535,7 @@ bool mutt_path_abbr_folder(char *buf, size_t buflen, const char *folder)
  */
 char *mutt_path_escape(const char *src)
 {
-  static char dest[HUGE_STRING];
+  static char dest[STR_COMMAND];
   char *destp = dest;
   int destsize = 0;
 

--- a/mutt/path.c
+++ b/mutt/path.c
@@ -241,7 +241,7 @@ bool mutt_path_canon(char *buf, size_t buflen, const char *homedir)
     }
     else
     {
-      char user[SHORT_STRING];
+      char user[128];
       dir = strchr(buf + 1, '/');
       if (dir)
         mutt_str_strfcpy(user, buf + 1, MIN(dir - buf, (unsigned) sizeof(user)));

--- a/mutt/regex.c
+++ b/mutt/regex.c
@@ -342,14 +342,14 @@ int mutt_replacelist_add(struct ReplaceList *rl, const char *pat,
  *
  * If 'buf' is NULL, a new string will be returned.  It must be freed by the caller.
  *
- * @note This function uses a fixed size buffer of LONG_STRING and so should
+ * @note This function uses a fixed size buffer of 1024 and so should
  * only be used for visual modifications, such as disp_subj.
  */
 char *mutt_replacelist_apply(struct ReplaceList *rl, char *buf, size_t buflen, const char *str)
 {
   static regmatch_t *pmatch = NULL;
   static size_t nmatch = 0;
-  static char twinbuf[2][LONG_STRING];
+  static char twinbuf[2][1024];
   int switcher = 0;
   char *p = NULL;
   size_t cpysize, tlen;
@@ -366,7 +366,7 @@ char *mutt_replacelist_apply(struct ReplaceList *rl, char *buf, size_t buflen, c
   src = twinbuf[switcher];
   dst = src;
 
-  mutt_str_strfcpy(src, str, LONG_STRING);
+  mutt_str_strfcpy(src, str, 1024);
 
   struct ReplaceListNode *np = NULL;
   STAILQ_FOREACH(np, rl, entries)
@@ -389,7 +389,7 @@ char *mutt_replacelist_apply(struct ReplaceList *rl, char *buf, size_t buflen, c
       /* Copy into other twinbuf with substitutions */
       if (np->template)
       {
-        for (p = np->template; *p && (tlen < LONG_STRING - 1);)
+        for (p = np->template; *p && (tlen < 1023);)
         {
           if (*p == '%')
           {
@@ -397,14 +397,14 @@ char *mutt_replacelist_apply(struct ReplaceList *rl, char *buf, size_t buflen, c
             if (*p == 'L')
             {
               p++;
-              cpysize = MIN(pmatch[0].rm_so, LONG_STRING - tlen - 1);
+              cpysize = MIN(pmatch[0].rm_so, 1023 - tlen);
               strncpy(&dst[tlen], src, cpysize);
               tlen += cpysize;
             }
             else if (*p == 'R')
             {
               p++;
-              cpysize = MIN(strlen(src) - pmatch[0].rm_eo, LONG_STRING - tlen - 1);
+              cpysize = MIN(strlen(src) - pmatch[0].rm_eo, 1023 - tlen);
               strncpy(&dst[tlen], &src[pmatch[0].rm_eo], cpysize);
               tlen += cpysize;
             }
@@ -414,7 +414,7 @@ char *mutt_replacelist_apply(struct ReplaceList *rl, char *buf, size_t buflen, c
               while (isdigit((unsigned char) *p)) /* skip subst token */
                 p++;
               for (int i = pmatch[n].rm_so;
-                   (i < pmatch[n].rm_eo) && (tlen < LONG_STRING - 1); i++)
+                   (i < pmatch[n].rm_eo) && (tlen < 1023); i++)
               {
                 dst[tlen++] = src[i];
               }

--- a/mutt/string.c
+++ b/mutt/string.c
@@ -948,10 +948,10 @@ const char *mutt_str_rstrnstr(const char *haystack, size_t haystack_length, cons
  */
 int mutt_str_word_casecmp(const char *a, const char *b)
 {
-  char tmp[SHORT_STRING] = "";
+  char tmp[128] = "";
 
   int i;
-  for (i = 0; i < (SHORT_STRING - 2); i++, b++)
+  for (i = 0; i < (sizeof(tmp) - 2); i++, b++)
   {
     if (!*b || ISSPACE(*b))
     {

--- a/mutt/string2.h
+++ b/mutt/string2.h
@@ -31,7 +31,6 @@
 #include <stdbool.h>
 #include <stdio.h>
 
-#define LONG_STRING  1024
 #define HUGE_STRING  8192
 
 #define NONULL(x) (x ? x : "")

--- a/mutt/string2.h
+++ b/mutt/string2.h
@@ -31,7 +31,6 @@
 #include <stdbool.h>
 #include <stdio.h>
 
-#define SHORT_STRING 128
 #define STRING       256
 #define LONG_STRING  1024
 #define HUGE_STRING  8192

--- a/mutt/string2.h
+++ b/mutt/string2.h
@@ -31,7 +31,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 
-#define HUGE_STRING  8192
+#define STR_COMMAND 8192  ///< Enough space for a long command line
 
 #define NONULL(x) (x ? x : "")
 #define ISSPACE(c) isspace((unsigned char) c)

--- a/mutt/string2.h
+++ b/mutt/string2.h
@@ -31,7 +31,6 @@
 #include <stdbool.h>
 #include <stdio.h>
 
-#define STRING       256
 #define LONG_STRING  1024
 #define HUGE_STRING  8192
 

--- a/mutt_account.c
+++ b/mutt_account.c
@@ -206,7 +206,7 @@ void mutt_account_tourl(struct ConnAccount *account, struct Url *url)
  */
 int mutt_account_getuser(struct ConnAccount *account)
 {
-  char prompt[STRING];
+  char prompt[256];
 
   /* already set */
   if (account->flags & MUTT_ACCT_USER)
@@ -287,7 +287,7 @@ int mutt_account_getlogin(struct ConnAccount *account)
  */
 int mutt_account_getpass(struct ConnAccount *account)
 {
-  char prompt[STRING];
+  char prompt[256];
 
   if (account->flags & MUTT_ACCT_PASS)
     return 0;

--- a/mutt_attach.c
+++ b/mutt_attach.c
@@ -66,7 +66,7 @@
  */
 int mutt_get_tmp_attachment(struct Body *a)
 {
-  char type[STRING];
+  char type[256];
   char tempfile[PATH_MAX];
   FILE *fpin = NULL, *fpout = NULL;
   struct stat st;
@@ -110,7 +110,7 @@ int mutt_get_tmp_attachment(struct Body *a)
  */
 int mutt_compose_attachment(struct Body *a)
 {
-  char type[STRING];
+  char type[256];
   char command[HUGE_STRING];
   char newfile[PATH_MAX] = "";
   struct Rfc1524MailcapEntry *entry = rfc1524_new_entry();
@@ -247,7 +247,7 @@ bailout:
  */
 int mutt_edit_attachment(struct Body *a)
 {
-  char type[STRING];
+  char type[256];
   char command[HUGE_STRING];
   char newfile[PATH_MAX] = "";
   struct Rfc1524MailcapEntry *entry = rfc1524_new_entry();
@@ -386,9 +386,9 @@ int mutt_view_attachment(FILE *fp, struct Body *a, int flag, struct Email *e,
   bool use_mailcap = false;
   bool use_pipe = false;
   bool use_pager = true;
-  char type[STRING];
+  char type[256];
   char command[HUGE_STRING];
-  char descrip[STRING];
+  char descrip[256];
   char *fname = NULL;
   struct Rfc1524MailcapEntry *entry = NULL;
   int rc = -1;
@@ -1017,7 +1017,7 @@ int mutt_decode_save_attachment(FILE *fp, struct Body *m, char *path, int displa
 int mutt_print_attachment(FILE *fp, struct Body *a)
 {
   char newfile[PATH_MAX] = "";
-  char type[STRING];
+  char type[256];
   pid_t thepid;
   FILE *ifp = NULL, *fpout = NULL;
   bool unlink_newfile = false;

--- a/mutt_attach.c
+++ b/mutt_attach.c
@@ -111,7 +111,7 @@ int mutt_get_tmp_attachment(struct Body *a)
 int mutt_compose_attachment(struct Body *a)
 {
   char type[256];
-  char command[HUGE_STRING];
+  char command[STR_COMMAND];
   char newfile[PATH_MAX] = "";
   struct Rfc1524MailcapEntry *entry = rfc1524_new_entry();
   bool unlink_newfile = false;
@@ -248,7 +248,7 @@ bailout:
 int mutt_edit_attachment(struct Body *a)
 {
   char type[256];
-  char command[HUGE_STRING];
+  char command[STR_COMMAND];
   char newfile[PATH_MAX] = "";
   struct Rfc1524MailcapEntry *entry = rfc1524_new_entry();
   bool unlink_newfile = false;
@@ -387,7 +387,7 @@ int mutt_view_attachment(FILE *fp, struct Body *a, int flag, struct Email *e,
   bool use_pipe = false;
   bool use_pager = true;
   char type[256];
-  char command[HUGE_STRING];
+  char command[STR_COMMAND];
   char descrip[256];
   char *fname = NULL;
   struct Rfc1524MailcapEntry *entry = NULL;
@@ -801,7 +801,7 @@ int mutt_save_attachment(FILE *fp, struct Body *m, char *path, int flags, struct
     {
       /* message type attachments are written to mail folders. */
 
-      char buf[HUGE_STRING];
+      char buf[8192];
       struct Message *msg = NULL;
       int chflags = 0;
       int r = -1;
@@ -1026,7 +1026,7 @@ int mutt_print_attachment(FILE *fp, struct Body *a)
 
   if (rfc1524_mailcap_lookup(a, type, NULL, MUTT_PRINT))
   {
-    char command[HUGE_STRING];
+    char command[STR_COMMAND];
     int piped = false;
 
     mutt_debug(LL_DEBUG2, "Using mailcap...\n");

--- a/mutt_header.c
+++ b/mutt_header.c
@@ -128,7 +128,7 @@ int mutt_label_message(struct Mailbox *m, struct EmailList *el)
   if (!m || !el)
     return 0;
 
-  char buf[LONG_STRING] = { 0 };
+  char buf[1024] = { 0 };
   char *new = NULL;
 
   struct EmailNode *en = STAILQ_FIRST(el);
@@ -172,7 +172,7 @@ void mutt_edit_headers(const char *editor, const char *body, struct Email *msg,
                        char *fcc, size_t fcclen)
 {
   char path[PATH_MAX]; /* tempfile used to edit headers + body */
-  char buffer[LONG_STRING];
+  char buffer[1024];
   const char *p = NULL;
   int i;
   struct Envelope *n = NULL;

--- a/mutt_history.c
+++ b/mutt_history.c
@@ -92,7 +92,7 @@ static void history_menu(char *buf, size_t buflen, char **matches, int match_cou
 {
   int done = 0;
   char helpstr[LONG_STRING];
-  char title[STRING];
+  char title[256];
 
   snprintf(title, sizeof(title), _("History '%s'"), buf);
 

--- a/mutt_history.c
+++ b/mutt_history.c
@@ -91,7 +91,7 @@ static void history_make_entry(char *buf, size_t buflen, struct Menu *menu, int 
 static void history_menu(char *buf, size_t buflen, char **matches, int match_count)
 {
   int done = 0;
-  char helpstr[LONG_STRING];
+  char helpstr[1024];
   char title[256];
 
   snprintf(title, sizeof(title), _("History '%s'"), buf);

--- a/mutt_logging.c
+++ b/mutt_logging.c
@@ -158,7 +158,7 @@ int log_disp_curses(time_t stamp, const char *file, int line,
   if (level > C_DebugLevel)
     return 0;
 
-  char buf[LONG_STRING];
+  char buf[1024];
 
   va_list ap;
   va_start(ap, level);

--- a/mutt_lua.c
+++ b/mutt_lua.c
@@ -82,7 +82,7 @@ static int lua_mutt_call(lua_State *l)
 {
   mutt_debug(LL_DEBUG2, " * lua_mutt_call()\n");
   struct Buffer token, expn, err;
-  char buffer[LONG_STRING] = "";
+  char buffer[1024] = "";
   const struct Command *command = NULL;
   int rc = 0;
 
@@ -359,7 +359,7 @@ static int lua_mutt_error(lua_State *l)
 static void lua_expose_command(void *p, const struct Command *cmd)
 {
   lua_State *l = (lua_State *) p;
-  char buf[LONG_STRING];
+  char buf[1024];
   snprintf(buf, sizeof(buf), "mutt.command.%s = function (...); mutt.call('%s', ...); end",
            cmd->name, cmd->name);
   (void) luaL_dostring(l, buf);

--- a/mutt_lua.c
+++ b/mutt_lua.c
@@ -90,7 +90,7 @@ static int lua_mutt_call(lua_State *l)
   mutt_buffer_init(&expn);
   mutt_buffer_init(&err);
 
-  err.dsize = STRING;
+  err.dsize = 256;
   err.data = mutt_mem_malloc(err.dsize);
   err.data[0] = '\0';
 
@@ -164,7 +164,7 @@ static int lua_mutt_set(lua_State *l)
   struct ConfigDef *cdef = he->data;
 
   int rc = 0;
-  struct Buffer *err = mutt_buffer_alloc(STRING);
+  struct Buffer *err = mutt_buffer_alloc(256);
 
   switch (DTYPE(cdef->type))
   {
@@ -255,7 +255,7 @@ static int lua_mutt_get(lua_State *l)
     case DT_SORT:
     case DT_STRING:
     {
-      struct Buffer *value = mutt_buffer_alloc(STRING);
+      struct Buffer *value = mutt_buffer_alloc(256);
       int rc = cs_he_string_get(Config, he, value);
       if (CSR_RESULT(rc) != CSR_SUCCESS)
       {
@@ -263,7 +263,7 @@ static int lua_mutt_get(lua_State *l)
         return -1;
       }
 
-      struct Buffer *escaped = mutt_buffer_alloc(STRING);
+      struct Buffer *escaped = mutt_buffer_alloc(256);
       escape_string(escaped, value->data);
       lua_pushstring(l, escaped->data);
       mutt_buffer_free(&value);
@@ -301,7 +301,7 @@ static int lua_mutt_enter(lua_State *l)
   mutt_buffer_init(&err);
   mutt_buffer_init(&token);
 
-  err.dsize = STRING;
+  err.dsize = 256;
   err.data = mutt_mem_malloc(err.dsize);
 
   if (mutt_parse_rc_line(buffer, &token, &err))

--- a/mutt_socket.c
+++ b/mutt_socket.c
@@ -86,7 +86,7 @@ struct Connection *mutt_conn_find(const struct Connection *start,
                                   const struct ConnAccount *account)
 {
   struct Url url;
-  char hook[LONG_STRING];
+  char hook[1024];
 
   /* account isn't actually modified, since url isn't either */
   mutt_account_tourl((struct ConnAccount *) account, &url);

--- a/mutt_window.c
+++ b/mutt_window.c
@@ -53,7 +53,7 @@ struct MuttWindow *MuttSidebarWindow = NULL; /**< Sidebar Window */
  */
 static int vw_printw(SLcurses_Window_Type *win, const char *fmt, va_list ap)
 {
-  char buf[LONG_STRING];
+  char buf[1024];
 
   (void) SLvsnprintf(buf, sizeof(buf), (char *) fmt, ap);
   SLcurses_waddnstr(win, buf, -1);

--- a/muttlib.c
+++ b/muttlib.c
@@ -817,7 +817,7 @@ void mutt_safe_path(char *buf, size_t buflen, struct Address *a)
 void mutt_expando_format(char *buf, size_t buflen, size_t col, int cols, const char *src,
                          format_t *callback, unsigned long data, int flags)
 {
-  char prefix[128], tmp[LONG_STRING], *cp = NULL, *wptr = buf, ch;
+  char prefix[128], tmp[1024], *cp = NULL, *wptr = buf, ch;
   char if_str[128], else_str[128];
   size_t wlen, count, len, wid;
   FILE *filter = NULL;
@@ -850,7 +850,7 @@ void mutt_expando_format(char *buf, size_t buflen, size_t col, int cols, const c
     /* n-off is the number of backslashes. */
     if (off > 0 && ((n - off) % 2) == 0)
     {
-      char srccopy[LONG_STRING];
+      char srccopy[1024];
       int i = 0;
 
       mutt_debug(LL_DEBUG3, "fmtpipe = %s\n", src);

--- a/muttlib.c
+++ b/muttlib.c
@@ -817,8 +817,8 @@ void mutt_safe_path(char *buf, size_t buflen, struct Address *a)
 void mutt_expando_format(char *buf, size_t buflen, size_t col, int cols, const char *src,
                          format_t *callback, unsigned long data, int flags)
 {
-  char prefix[SHORT_STRING], tmp[LONG_STRING], *cp = NULL, *wptr = buf, ch;
-  char if_str[SHORT_STRING], else_str[SHORT_STRING];
+  char prefix[128], tmp[LONG_STRING], *cp = NULL, *wptr = buf, ch;
+  char if_str[128], else_str[128];
   size_t wlen, count, len, wid;
   FILE *filter = NULL;
   char *recycler = NULL;

--- a/muttlib.c
+++ b/muttlib.c
@@ -823,7 +823,7 @@ void mutt_expando_format(char *buf, size_t buflen, size_t col, int cols, const c
   FILE *filter = NULL;
   char *recycler = NULL;
 
-  char src2[STRING];
+  char src2[256];
   mutt_str_strfcpy(src2, src, mutt_str_strlen(src) + 1);
   src = src2;
 
@@ -1492,7 +1492,7 @@ void mutt_sleep(short s)
  */
 const char *mutt_make_version(void)
 {
-  static char vstring[STRING];
+  static char vstring[256];
   snprintf(vstring, sizeof(vstring), "NeoMutt %s%s", PACKAGE_VERSION, GitVer);
   return vstring;
 }

--- a/mx.c
+++ b/mx.c
@@ -805,7 +805,7 @@ int mx_mbox_sync(struct Mailbox *m, int *index_hint)
 
   if (m->dontwrite)
   {
-    char buf[STRING], tmp[STRING];
+    char buf[256], tmp[256];
     if (km_expand_key(buf, sizeof(buf), km_find_func(MENU_MAIN, OP_TOGGLE_WRITE)))
       snprintf(tmp, sizeof(tmp), _(" Press '%s' to toggle write"), buf);
     else

--- a/mx.c
+++ b/mx.c
@@ -829,7 +829,7 @@ int mx_mbox_sync(struct Mailbox *m, int *index_hint)
 
   if (m->msg_deleted != 0)
   {
-    char buf[SHORT_STRING];
+    char buf[128];
 
     snprintf(buf, sizeof(buf),
              ngettext("Purge %d deleted message?", "Purge %d deleted messages?", m->msg_deleted),

--- a/ncrypt/crypt.c
+++ b/ncrypt/crypt.c
@@ -80,7 +80,7 @@ bool C_SmimeSelfEncrypt; ///< Config: Encrypted messages will also be encrypt to
 void crypt_current_time(struct State *s, const char *app_name)
 {
   time_t t;
-  char p[STRING], tmp[STRING];
+  char p[256], tmp[256];
 
   if (!WithCrypto)
     return;

--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -2019,7 +2019,7 @@ static int verify_one(struct Body *sigbdy, struct State *s, const char *tempfile
 
         if (non_pka_notations)
         {
-          char buf[SHORT_STRING];
+          char buf[128];
           snprintf(buf, sizeof(buf),
                    _("*** Begin Notation (signature by: %s) ***\n"), sig->fpr);
           state_puts(buf, s);
@@ -3311,7 +3311,7 @@ static const char *crypt_format_str(char *buf, size_t buflen, size_t col, int co
                                     const char *if_str, const char *else_str,
                                     unsigned long data, int flags)
 {
-  char fmt[SHORT_STRING];
+  char fmt[128];
   int kflags = 0;
   int optional = (flags & MUTT_FORMAT_OPTIONAL);
   const char *s = NULL;
@@ -3437,7 +3437,7 @@ static const char *crypt_format_str(char *buf, size_t buflen, size_t col, int co
 
     case '[':
     {
-      char buf2[SHORT_STRING];
+      char buf2[128];
       bool do_locales = true;
       struct tm *tm = NULL;
       size_t len;
@@ -4070,7 +4070,7 @@ static void print_key_info(gpgme_key_t key, FILE *fp)
   const char *s = NULL, *s2 = NULL;
   time_t tt = 0;
   struct tm *tm = NULL;
-  char shortbuf[SHORT_STRING];
+  char shortbuf[128];
   unsigned long aval = 0;
   const char *delim = NULL;
   int is_pgp = 0;
@@ -5041,7 +5041,7 @@ static struct CryptKeyInfo *crypt_ask_for_key(char *tag, char *whatfor, short ab
                                               unsigned int app, int *forced_valid)
 {
   struct CryptKeyInfo *key = NULL;
-  char resp[SHORT_STRING];
+  char resp[128];
   struct CryptCache *l = NULL;
   int dummy;
 
@@ -5463,7 +5463,7 @@ static int gpgme_send_menu(struct Email *msg, int is_smime)
                               is_smime ? APPLICATION_SMIME : APPLICATION_PGP, NULL);
         if (p)
         {
-          char input_signas[SHORT_STRING];
+          char input_signas[128];
           snprintf(input_signas, sizeof(input_signas), "0x%s", crypt_fpr_or_lkeyid(p));
           mutt_str_replace(is_smime ? &C_SmimeDefaultKey : &C_PgpSignAs, input_signas);
           crypt_free_key(&p);

--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -2606,7 +2606,7 @@ static int line_compare(const char *a, size_t n, const char *b)
 static int pgp_check_traditional_one_body(FILE *fp, struct Body *b)
 {
   char tempfile[PATH_MAX];
-  char buf[HUGE_STRING];
+  char buf[8192];
   FILE *tfp = NULL;
 
   bool sgn = false;
@@ -2800,7 +2800,7 @@ leave:
  */
 static void copy_clearsigned(gpgme_data_t data, struct State *s, char *charset)
 {
-  char buf[HUGE_STRING];
+  char buf[8192];
   bool complete, armor_header;
   FILE *fp = NULL;
 
@@ -2862,7 +2862,7 @@ int pgp_gpgme_application_handler(struct Body *m, struct State *s)
   bool clearsign = false;
   long bytes;
   LOFF_T last_pos;
-  char buf[HUGE_STRING];
+  char buf[8192];
   FILE *pgpout = NULL;
 
   gpgme_error_t err = 0;

--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -1254,7 +1254,7 @@ static int get_micalg(gpgme_ctx_t ctx, int use_smime, char *buf, size_t buflen)
  */
 static void print_time(time_t t, struct State *s)
 {
-  char p[STRING];
+  char p[256];
 
   strftime(p, sizeof(p), nl_langinfo(D_T_FMT), localtime(&t));
   state_puts(p, s);
@@ -2460,7 +2460,7 @@ static int pgp_gpgme_extract_keys(gpgme_data_t keydata, FILE **fp)
   gpgme_subkey_t subkey;
   const char *shortid = NULL;
   size_t len;
-  char date[STRING];
+  char date[256];
   int more;
   int rc = -1;
   time_t tt;
@@ -2871,7 +2871,7 @@ int pgp_gpgme_application_handler(struct Body *m, struct State *s)
   bool maybe_goodsig = true;
   bool have_any_sigs = false;
 
-  char body_charset[STRING]; /* Only used for clearsigned messages. */
+  char body_charset[256]; /* Only used for clearsigned messages. */
 
   mutt_debug(LL_DEBUG2, "Entering handler\n");
 

--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -1872,7 +1872,7 @@ static int show_one_sig_status(gpgme_ctx_t ctx, int idx, struct State *s)
       ; /* No state information so no way to print anything. */
     else if (err)
     {
-      char buf[LONG_STRING];
+      char buf[1024];
       snprintf(buf, sizeof(buf), _("Error getting key information for KeyID %s: %s\n"),
                fpr, gpgme_strerror(err));
       state_puts(buf, s);
@@ -4323,7 +4323,7 @@ static void print_key_info(gpgme_key_t key, FILE *fp)
  */
 static void verify_key(struct CryptKeyInfo *key)
 {
-  char cmd[LONG_STRING], tempfile[PATH_MAX];
+  char cmd[1024], tempfile[PATH_MAX];
   const char *s = NULL;
   gpgme_ctx_t listctx = NULL;
   gpgme_error_t err;
@@ -4629,7 +4629,7 @@ static struct CryptKeyInfo *crypt_select_key(struct CryptKeyInfo *keys,
   int keymax;
   int i;
   bool done = false;
-  char helpstr[LONG_STRING], buf[LONG_STRING];
+  char helpstr[1024], buf[1024];
   struct CryptKeyInfo *k = NULL;
   int (*f)(const void *, const void *);
   enum MenuType menu_to_use = MENU_GENERIC;
@@ -4766,7 +4766,7 @@ static struct CryptKeyInfo *crypt_select_key(struct CryptKeyInfo *keys,
                                  !crypt_id_is_strong(key_table[menu->current])))
         {
           const char *warn_s = NULL;
-          char buf2[LONG_STRING];
+          char buf2[1024];
 
           if (key_table[menu->current]->flags & KEYFLAG_CANTUSE)
           {
@@ -5117,7 +5117,7 @@ static char *find_keys(struct Address *addrlist, unsigned int app, bool oppenc_m
   struct Address *p = NULL, *q = NULL;
   struct CryptKeyInfo *k_info = NULL;
   const char *fqdn = mutt_fqdn(true);
-  char buf[LONG_STRING];
+  char buf[1024];
   int forced_valid;
   int r;
   bool key_selected;
@@ -5253,7 +5253,7 @@ struct Body *pgp_gpgme_make_key_attachment(void)
   gpgme_data_t keydata = NULL;
   gpgme_error_t err;
   struct Body *att = NULL;
-  char buf[LONG_STRING];
+  char buf[1024];
   struct stat sb;
 
   OptPgpCheckTrust = false;

--- a/ncrypt/gnupgparse.c
+++ b/ncrypt/gnupgparse.c
@@ -413,7 +413,7 @@ struct PgpKeyInfo *pgp_get_candidates(enum PgpRing keyring, struct ListHead *hin
 {
   FILE *fp = NULL;
   pid_t thepid;
-  char buf[LONG_STRING];
+  char buf[1024];
   struct PgpKeyInfo *db = NULL, **kend = NULL, *k = NULL, *kk = NULL, *mainkey = NULL;
   int is_sub;
   int devnull;

--- a/ncrypt/pgp.c
+++ b/ncrypt/pgp.c
@@ -74,7 +74,7 @@ struct Regex *C_PgpGoodSign; ///< Config: Text indicating a good signature
 long C_PgpTimeout;           ///< Config: Time in seconds to cache a passphrase
 bool C_PgpUseGpgAgent;       ///< Config: Use a PGP agent for caching passwords
 
-char PgpPass[LONG_STRING];
+char PgpPass[1024];
 time_t PgpExptime = 0; /* when does the cached passphrase expire? */
 
 /**
@@ -999,7 +999,7 @@ static struct Body *pgp_decrypt_part(struct Body *a, struct State *s,
   if (!a || !s || !fpout || !p)
     return NULL;
 
-  char buf[LONG_STRING];
+  char buf[1024];
   FILE *pgpin = NULL, *pgpout = NULL, *pgptmp = NULL;
   struct stat info;
   struct Body *tattach = NULL;
@@ -1293,7 +1293,7 @@ int pgp_class_encrypted_handler(struct Body *a, struct State *s)
 struct Body *pgp_class_sign_message(struct Body *a)
 {
   struct Body *t = NULL;
-  char buffer[LONG_STRING];
+  char buffer[1024];
   char sigfile[PATH_MAX], signedfile[PATH_MAX];
   FILE *pgpin = NULL, *pgpout = NULL, *pgperr = NULL, *sfp = NULL;
   bool err = false;
@@ -1426,7 +1426,7 @@ char *pgp_class_find_keys(struct Address *addrlist, bool oppenc_mode)
   struct Address *addr = NULL;
   struct Address *p = NULL, *q = NULL;
   struct PgpKeyInfo *k_info = NULL;
-  char buf[LONG_STRING];
+  char buf[1024];
   int r;
   bool key_selected;
 
@@ -1540,7 +1540,7 @@ char *pgp_class_find_keys(struct Address *addrlist, bool oppenc_mode)
  */
 struct Body *pgp_class_encrypt_message(struct Body *a, char *keylist, bool sign)
 {
-  char buf[LONG_STRING];
+  char buf[1024];
   char tempfile[PATH_MAX];
   char pgpinfile[PATH_MAX];
   FILE *pgpin = NULL, *fptmp = NULL;
@@ -1849,7 +1849,7 @@ int pgp_class_send_menu(struct Email *msg)
   const char *prompt = NULL;
   const char *letters = NULL;
   const char *choices = NULL;
-  char promptbuf[LONG_STRING];
+  char promptbuf[1024];
   int choice;
 
   if (!(WithCrypto & APPLICATION_PGP))

--- a/ncrypt/pgp.c
+++ b/ncrypt/pgp.c
@@ -1974,7 +1974,7 @@ int pgp_class_send_menu(struct Email *msg)
         p = pgp_ask_for_key(_("Sign as: "), NULL, 0, PGP_SECRING);
         if (p)
         {
-          char input_signas[SHORT_STRING];
+          char input_signas[128];
           snprintf(input_signas, sizeof(input_signas), "0x%s", pgp_fpr_or_lkeyid(p));
           mutt_str_replace(&C_PgpSignAs, input_signas);
           pgp_free_key(&p);

--- a/ncrypt/pgp.c
+++ b/ncrypt/pgp.c
@@ -414,7 +414,7 @@ static int pgp_check_decryption_okay(FILE *fpin)
  */
 static void pgp_copy_clearsigned(FILE *fpin, struct State *s, char *charset)
 {
-  char buf[HUGE_STRING];
+  char buf[8192];
   bool complete, armor_header;
 
   rewind(fpin);
@@ -473,7 +473,7 @@ int pgp_class_application_handler(struct Body *m, struct State *s)
   int c = 1;
   long bytes;
   LOFF_T last_pos, offset;
-  char buf[HUGE_STRING];
+  char buf[8192];
   char tmpfname[PATH_MAX];
   FILE *pgpout = NULL, *pgpin = NULL, *pgperr = NULL;
   FILE *tmpfp = NULL;
@@ -789,7 +789,7 @@ out:
 static int pgp_check_traditional_one_body(FILE *fp, struct Body *b)
 {
   char tempfile[PATH_MAX];
-  char buf[HUGE_STRING];
+  char buf[8192];
   FILE *tfp = NULL;
 
   bool sgn = false;

--- a/ncrypt/pgp.c
+++ b/ncrypt/pgp.c
@@ -483,7 +483,7 @@ int pgp_class_application_handler(struct Body *m, struct State *s)
   bool have_any_sigs = false;
 
   char *gpgcharset = NULL;
-  char body_charset[STRING];
+  char body_charset[256];
   mutt_body_get_charset(m, body_charset, sizeof(body_charset));
 
   rc = 0;
@@ -1674,7 +1674,7 @@ struct Body *pgp_class_traditional_encryptsign(struct Body *a, int flags, char *
   char pgpoutfile[PATH_MAX];
   char pgpinfile[PATH_MAX];
 
-  char body_charset[STRING];
+  char body_charset[256];
   char *from_charset = NULL;
   const char *send_charset = NULL;
 
@@ -1683,7 +1683,7 @@ struct Body *pgp_class_traditional_encryptsign(struct Body *a, int flags, char *
   bool empty = false;
   bool err;
 
-  char buf[STRING];
+  char buf[256];
 
   pid_t thepid;
 

--- a/ncrypt/pgpinvoke.c
+++ b/ncrypt/pgpinvoke.c
@@ -96,7 +96,7 @@ static const char *fmt_pgp_command(char *buf, size_t buflen, size_t col, int col
                                    const char *if_str, const char *else_str,
                                    unsigned long data, int flags)
 {
-  char fmt[SHORT_STRING];
+  char fmt[128];
   struct PgpCommandContext *cctx = (struct PgpCommandContext *) data;
   int optional = (flags & MUTT_FORMAT_OPTIONAL);
 
@@ -398,7 +398,7 @@ pid_t pgp_invoke_traditional(FILE **pgpin, FILE **pgpout, FILE **pgperr,
  */
 void pgp_class_invoke_import(const char *fname)
 {
-  char tmp_fname[PATH_MAX + SHORT_STRING];
+  char tmp_fname[PATH_MAX + 128];
   char cmd[HUGE_STRING];
   struct PgpCommandContext cctx = { 0 };
 

--- a/ncrypt/pgpinvoke.c
+++ b/ncrypt/pgpinvoke.c
@@ -211,7 +211,7 @@ static pid_t pgp_invoke(FILE **pgpin, FILE **pgpout, FILE **pgperr, int pgpinfd,
                         const char *sig_fname, const char *ids, const char *format)
 {
   struct PgpCommandContext cctx = { 0 };
-  char cmd[HUGE_STRING];
+  char cmd[STR_COMMAND];
 
   if (!format || !*format)
     return (pid_t) -1;
@@ -399,7 +399,7 @@ pid_t pgp_invoke_traditional(FILE **pgpin, FILE **pgpout, FILE **pgperr,
 void pgp_class_invoke_import(const char *fname)
 {
   char tmp_fname[PATH_MAX + 128];
-  char cmd[HUGE_STRING];
+  char cmd[STR_COMMAND];
   struct PgpCommandContext cctx = { 0 };
 
   mutt_file_quote_filename(fname, tmp_fname, sizeof(tmp_fname));
@@ -421,7 +421,7 @@ void pgp_class_invoke_getkeys(struct Address *addr)
 {
   char buf[PATH_MAX];
   char tmp[1024];
-  char cmd[HUGE_STRING];
+  char cmd[STR_COMMAND];
   int devnull;
 
   char *personal = NULL;
@@ -524,7 +524,7 @@ pid_t pgp_invoke_list_keys(FILE **pgpin, FILE **pgpout, FILE **pgperr,
                            int pgpinfd, int pgpoutfd, int pgperrfd,
                            enum PgpRing keyring, struct ListHead *hints)
 {
-  char quoted[HUGE_STRING];
+  char quoted[STR_COMMAND];
 
   struct Buffer *uids = mutt_buffer_pool_get();
 

--- a/ncrypt/pgpinvoke.c
+++ b/ncrypt/pgpinvoke.c
@@ -420,7 +420,7 @@ void pgp_class_invoke_import(const char *fname)
 void pgp_class_invoke_getkeys(struct Address *addr)
 {
   char buf[PATH_MAX];
-  char tmp[LONG_STRING];
+  char tmp[1024];
   char cmd[HUGE_STRING];
   int devnull;
 

--- a/ncrypt/pgpkey.c
+++ b/ncrypt/pgpkey.c
@@ -596,7 +596,7 @@ static struct PgpKeyInfo *pgp_select_key(struct PgpKeyInfo *keys,
   struct Menu *menu = NULL;
   int i;
   bool done = false;
-  char helpstr[LONG_STRING], buf[LONG_STRING], tmpbuf[STRING];
+  char helpstr[LONG_STRING], buf[LONG_STRING], tmpbuf[256];
   char cmd[LONG_STRING], tempfile[PATH_MAX];
   FILE *fp = NULL, *devnull = NULL;
   pid_t thepid;
@@ -873,7 +873,7 @@ struct Body *pgp_class_make_key_attachment(void)
 {
   struct Body *att = NULL;
   char buf[LONG_STRING];
-  char tempf[PATH_MAX], tmp[STRING];
+  char tempf[PATH_MAX], tmp[256];
   FILE *tempfp = NULL;
   FILE *devnull = NULL;
   struct stat sb;

--- a/ncrypt/pgpkey.c
+++ b/ncrypt/pgpkey.c
@@ -596,8 +596,8 @@ static struct PgpKeyInfo *pgp_select_key(struct PgpKeyInfo *keys,
   struct Menu *menu = NULL;
   int i;
   bool done = false;
-  char helpstr[LONG_STRING], buf[LONG_STRING], tmpbuf[256];
-  char cmd[LONG_STRING], tempfile[PATH_MAX];
+  char helpstr[1024], buf[1024], tmpbuf[256];
+  char cmd[1024], tempfile[PATH_MAX];
   FILE *fp = NULL, *devnull = NULL;
   pid_t thepid;
   struct PgpKeyInfo *kp = NULL;
@@ -755,7 +755,7 @@ static struct PgpKeyInfo *pgp_select_key(struct PgpKeyInfo *keys,
                                  !pgp_id_is_strong(KeyTable[menu->current])))
         {
           const char *str = "";
-          char buf2[LONG_STRING];
+          char buf2[1024];
 
           if (KeyTable[menu->current]->flags & KEYFLAG_CANTUSE)
           {
@@ -872,7 +872,7 @@ struct PgpKeyInfo *pgp_ask_for_key(char *tag, char *whatfor, short abilities, en
 struct Body *pgp_class_make_key_attachment(void)
 {
   struct Body *att = NULL;
-  char buf[LONG_STRING];
+  char buf[1024];
   char tempf[PATH_MAX], tmp[256];
   FILE *tempfp = NULL;
   FILE *devnull = NULL;

--- a/ncrypt/pgpkey.c
+++ b/ncrypt/pgpkey.c
@@ -176,7 +176,7 @@ static const char *pgp_entry_fmt(char *buf, size_t buflen, size_t col, int cols,
                                  const char *if_str, const char *else_str,
                                  unsigned long data, int flags)
 {
-  char fmt[SHORT_STRING];
+  char fmt[128];
   int kflags = 0;
   int optional = (flags & MUTT_FORMAT_OPTIONAL);
 
@@ -260,7 +260,7 @@ static const char *pgp_entry_fmt(char *buf, size_t buflen, size_t col, int cols,
     case '[':
 
     {
-      char buf2[SHORT_STRING];
+      char buf2[128];
       bool do_locales = true;
       struct tm *tm = NULL;
       size_t len;
@@ -819,7 +819,7 @@ static struct PgpKeyInfo *pgp_select_key(struct PgpKeyInfo *keys,
 struct PgpKeyInfo *pgp_ask_for_key(char *tag, char *whatfor, short abilities, enum PgpRing keyring)
 {
   struct PgpKeyInfo *key = NULL;
-  char resp[SHORT_STRING];
+  char resp[128];
   struct PgpCache *l = NULL;
 
   mutt_clear_error();

--- a/ncrypt/pgpmicalg.c
+++ b/ncrypt/pgpmicalg.c
@@ -67,7 +67,7 @@ static const char *pgp_hash_to_micalg(short id)
  */
 static void pgp_dearmor(FILE *in, FILE *out)
 {
-  char line[HUGE_STRING];
+  char line[8192];
   LOFF_T start;
   LOFF_T end;
   char *r = NULL;

--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -386,7 +386,7 @@ static pid_t smime_invoke(FILE **smimein, FILE **smimeout, FILE **smimeerr,
                           const char *intermediates, const char *format)
 {
   struct SmimeCommandContext cctx = { 0 };
-  char cmd[HUGE_STRING];
+  char cmd[STR_COMMAND];
 
   if (!format || !*format)
     return (pid_t) -1;
@@ -2140,7 +2140,7 @@ static struct Body *smime_handle_entity(struct Body *m, struct State *s, FILE *o
       return NULL;
     }
   }
-  char buf[HUGE_STRING];
+  char buf[8192];
   while (fgets(buf, sizeof(buf) - 1, smimeout))
   {
     const size_t len = mutt_str_strlen(buf);

--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -98,7 +98,7 @@ struct SmimeCommandContext
   const char *intermediates; /**< %i */
 };
 
-char SmimePass[STRING];
+char SmimePass[256];
 time_t SmimeExptime = 0; /* when does the cached passphrase expire? */
 
 static char SmimeKeyToUse[PATH_MAX] = { 0 };
@@ -948,7 +948,7 @@ static void getkeys(char *mailbox)
 
   if (!key)
   {
-    char buf[STRING];
+    char buf[256];
     snprintf(buf, sizeof(buf), _("Enter keyID for %s: "), mailbox);
     key = smime_ask_for_key(buf, KEYFLAG_CANENCRYPT, false);
   }
@@ -1094,7 +1094,7 @@ char *smime_class_find_keys(struct Address *addrlist, bool oppenc_mode)
 static int smime_handle_cert_email(char *certificate, char *mailbox, bool copy,
                                    char ***buffer, int *num)
 {
-  char email[STRING];
+  char email[256];
   int rc = -1, count = 0;
   pid_t thepid;
   size_t len = 0;
@@ -1357,7 +1357,7 @@ static char *smime_extract_signer_certificate(char *infile)
  */
 void smime_class_invoke_import(char *infile, char *mailbox)
 {
-  char *certfile = NULL, buf[STRING];
+  char *certfile = NULL, buf[256];
   FILE *smimein = NULL;
 
   FILE *fperr = mutt_file_mkstemp();

--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -225,7 +225,7 @@ static const char *fmt_smime_command(char *buf, size_t buflen, size_t col, int c
       if (!optional)
       {
         char path[PATH_MAX];
-        char buf1[LONG_STRING], buf2[LONG_STRING];
+        char buf1[1024], buf2[1024];
         struct stat sb;
 
         mutt_str_strfcpy(path, C_SmimeCaLocation, sizeof(path));
@@ -532,8 +532,8 @@ static struct SmimeKey *smime_select_key(struct SmimeKey *keys, char *query)
   int table_index = 0;
   struct SmimeKey *key = NULL;
   struct SmimeKey *selected_key = NULL;
-  char helpstr[LONG_STRING];
-  char buf[LONG_STRING];
+  char helpstr[1024];
+  char buf[1024];
   char title[256];
   struct Menu *menu = NULL;
   const char *s = "";
@@ -717,7 +717,7 @@ static struct SmimeKey *smime_parse_key(char *buf)
 static struct SmimeKey *smime_get_candidates(char *search, bool public)
 {
   char index_file[PATH_MAX];
-  char buf[LONG_STRING];
+  char buf[1024];
   struct SmimeKey *key = NULL, *results = NULL;
   struct SmimeKey **results_end = &results;
 
@@ -1057,7 +1057,7 @@ char *smime_class_find_keys(struct Address *addrlist, bool oppenc_mode)
     key = smime_get_key_by_addr(q->mailbox, KEYFLAG_CANENCRYPT, true, !oppenc_mode);
     if (!key && !oppenc_mode)
     {
-      char buf[LONG_STRING];
+      char buf[1024];
       snprintf(buf, sizeof(buf), _("Enter keyID for %s: "), q->mailbox);
       key = smime_ask_for_key(buf, KEYFLAG_CANENCRYPT, true);
     }
@@ -1544,7 +1544,7 @@ static pid_t smime_invoke_sign(FILE **smimein, FILE **smimeout, FILE **smimeerr,
  */
 struct Body *smime_class_build_smime_entity(struct Body *a, char *certlist)
 {
-  char buf[LONG_STRING], certfile[PATH_MAX];
+  char buf[1024], certfile[PATH_MAX];
   char tempfile[PATH_MAX];
   char smimeinfile[PATH_MAX];
   char *cert_end = NULL;
@@ -1699,7 +1699,7 @@ static char *openssl_md_to_smime_micalg(char *md)
  */
 struct Body *smime_class_sign_message(struct Body *a)
 {
-  char buffer[LONG_STRING];
+  char buffer[1024];
   char signedfile[PATH_MAX], filetosign[PATH_MAX];
   FILE *smimein = NULL, *smimeout = NULL, *smimeerr = NULL, *sfp = NULL;
   int err = 0;

--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -214,7 +214,7 @@ static const char *fmt_smime_command(char *buf, size_t buflen, size_t col, int c
                                      const char *if_str, const char *else_str,
                                      unsigned long data, int flags)
 {
-  char fmt[SHORT_STRING];
+  char fmt[128];
   struct SmimeCommandContext *cctx = (struct SmimeCommandContext *) data;
   int optional = (flags & MUTT_FORMAT_OPTIONAL);
 
@@ -912,7 +912,7 @@ static struct SmimeKey *smime_get_key_by_str(char *str, short abilities, bool pu
 static struct SmimeKey *smime_ask_for_key(char *prompt, short abilities, bool public)
 {
   struct SmimeKey *key = NULL;
-  char resp[SHORT_STRING];
+  char resp[128];
 
   if (!prompt)
     prompt = _("Enter keyID: ");

--- a/nntp/browse.c
+++ b/nntp/browse.c
@@ -56,7 +56,7 @@ const char *group_index_format_str(char *buf, size_t buflen, size_t col, int col
                                    const char *if_str, const char *else_str,
                                    unsigned long data, int flags)
 {
-  char fn[SHORT_STRING], fmt[SHORT_STRING];
+  char fn[128], fmt[128];
   struct Folder *folder = (struct Folder *) data;
 
   switch (op)

--- a/nntp/newsrc.c
+++ b/nntp/newsrc.c
@@ -924,7 +924,7 @@ const char *nntp_format_str(char *buf, size_t buflen, size_t col, int cols, char
   struct NntpAccountData *adata = (struct NntpAccountData *) data;
   struct ConnAccount *acct = &adata->conn->account;
   struct Url url;
-  char fn[SHORT_STRING], fmt[SHORT_STRING], *p = NULL;
+  char fn[128], fmt[128], *p = NULL;
 
   switch (op)
   {

--- a/nntp/newsrc.c
+++ b/nntp/newsrc.c
@@ -446,7 +446,7 @@ int nntp_newsrc_update(struct NntpAccountData *adata)
   if (!adata)
     return -1;
 
-  buflen = 10 * LONG_STRING;
+  buflen = 10240;
   buf = mutt_mem_calloc(1, buflen);
   off = 0;
 
@@ -470,7 +470,7 @@ int nntp_newsrc_update(struct NntpAccountData *adata)
     /* write entries */
     for (unsigned int j = 0; j < mdata->newsrc_len; j++)
     {
-      if (off + LONG_STRING > buflen)
+      if (off + 1024 > buflen)
       {
         buflen *= 2;
         mutt_mem_realloc(&buf, buflen);
@@ -572,7 +572,7 @@ int nntp_add_group(char *line, void *data)
 {
   struct NntpAccountData *adata = data;
   struct NntpMboxData *mdata = NULL;
-  char group[LONG_STRING] = "";
+  char group[1024] = "";
   char desc[HUGE_STRING] = "";
   char mod;
   anum_t first, last;
@@ -653,7 +653,7 @@ int nntp_active_save_cache(struct NntpAccountData *adata)
   if (!adata->cacheable)
     return 0;
 
-  buflen = 10 * LONG_STRING;
+  buflen = 10240;
   buf = mutt_mem_calloc(1, buflen);
   snprintf(buf, buflen, "%lu\n", (unsigned long) adata->newgroups_time);
   off = strlen(buf);

--- a/nntp/newsrc.c
+++ b/nntp/newsrc.c
@@ -573,7 +573,7 @@ int nntp_add_group(char *line, void *data)
   struct NntpAccountData *adata = data;
   struct NntpMboxData *mdata = NULL;
   char group[1024] = "";
-  char desc[HUGE_STRING] = "";
+  char desc[8192] = "";
   char mod;
   anum_t first, last;
 
@@ -611,7 +611,7 @@ int nntp_add_group(char *line, void *data)
  */
 static int active_get_cache(struct NntpAccountData *adata)
 {
-  char buf[HUGE_STRING];
+  char buf[8192];
   char file[PATH_MAX];
   time_t t;
 

--- a/nntp/nntp.c
+++ b/nntp/nntp.c
@@ -980,7 +980,7 @@ static int fetch_description(char *line, void *data)
  */
 static int get_description(struct NntpMboxData *mdata, const char *wildmat, const char *msg)
 {
-  char buf[STRING];
+  char buf[256];
   const char *cmd = NULL;
 
   /* get newsgroup description, if possible */
@@ -1820,7 +1820,7 @@ static int fetch_children(char *line, void *data)
 int nntp_open_connection(struct NntpAccountData *adata)
 {
   struct Connection *conn = adata->conn;
-  char buf[STRING];
+  char buf[256];
   int cap;
   bool posting = false, auth = true;
 
@@ -2063,7 +2063,7 @@ int nntp_post(struct Mailbox *m, const char *msg)
 int nntp_active_fetch(struct NntpAccountData *adata, bool new)
 {
   struct NntpMboxData tmp_mdata;
-  char msg[STRING];
+  char msg[256];
   char buf[LONG_STRING];
   unsigned int i;
   int rc;
@@ -2320,7 +2320,7 @@ int nntp_check_children(struct Context *ctx, const char *msgid)
 
   struct NntpMboxData *mdata = m->mdata;
   struct ChildCtx cc;
-  char buf[STRING];
+  char buf[256];
   int rc;
   bool quiet;
   void *hc = NULL;

--- a/nntp/nntp.c
+++ b/nntp/nntp.c
@@ -241,8 +241,8 @@ static int nntp_capabilities(struct NntpAccountData *adata)
 {
   struct Connection *conn = adata->conn;
   bool mode_reader = false;
-  char buf[LONG_STRING];
-  char authinfo[LONG_STRING] = "";
+  char buf[1024];
+  char authinfo[1024] = "";
 
   adata->hasCAPABILITIES = false;
   adata->hasSTARTTLS = false;
@@ -343,7 +343,7 @@ static int nntp_capabilities(struct NntpAccountData *adata)
 static int nntp_attempt_features(struct NntpAccountData *adata)
 {
   struct Connection *conn = adata->conn;
-  char buf[LONG_STRING];
+  char buf[1024];
 
   /* no CAPABILITIES, trying DATE, LISTGROUP, LIST NEWSGROUPS */
   if (!adata->hasCAPABILITIES)
@@ -418,14 +418,14 @@ static int nntp_attempt_features(struct NntpAccountData *adata)
     else
     {
       int cont = 0;
-      size_t buflen = 2 * LONG_STRING, off = 0, b = 0;
+      size_t buflen = 2048, off = 0, b = 0;
 
       FREE(&adata->overview_fmt);
       adata->overview_fmt = mutt_mem_malloc(buflen);
 
       while (true)
       {
-        if (buflen - off < LONG_STRING)
+        if (buflen - off < 1024)
         {
           buflen *= 2;
           mutt_mem_realloc(&adata->overview_fmt, buflen);
@@ -504,7 +504,7 @@ static bool nntp_memchr(char **haystack, char *sentinel, int needle)
  */
 static void nntp_log_binbuf(const char *buf, size_t len, const char *pfx, int dbg)
 {
-  char tmp[LONG_STRING];
+  char tmp[1024];
   char *p = tmp;
   char *sentinel = tmp + len;
 
@@ -527,8 +527,8 @@ static void nntp_log_binbuf(const char *buf, size_t len, const char *pfx, int db
 static int nntp_auth(struct NntpAccountData *adata)
 {
   struct Connection *conn = adata->conn;
-  char buf[LONG_STRING];
-  char authenticators[LONG_STRING] = "USER";
+  char buf[1024];
+  char authenticators[1024] = "USER";
   char *method = NULL, *a = NULL, *p = NULL;
   unsigned char flags = conn->account.flags;
 
@@ -637,7 +637,7 @@ static int nntp_auth(struct NntpAccountData *adata)
         sasl_conn_t *saslconn = NULL;
         sasl_interact_t *interaction = NULL;
         int rc;
-        char inbuf[LONG_STRING] = "";
+        char inbuf[1024] = "";
         const char *mech = NULL;
         const char *client_out = NULL;
         unsigned int client_len, len;
@@ -788,7 +788,7 @@ static int nntp_auth(struct NntpAccountData *adata)
 static int nntp_query(struct NntpMboxData *mdata, char *line, size_t linelen)
 {
   struct NntpAccountData *adata = mdata->adata;
-  char buf[LONG_STRING] = { 0 };
+  char buf[1024] = { 0 };
 
   if (adata->status == NNTP_BYE)
     return -1;
@@ -870,7 +870,7 @@ static int nntp_fetch_lines(struct NntpMboxData *mdata, char *query, size_t qlen
 
   while (!done)
   {
-    char buf[LONG_STRING];
+    char buf[1024];
     char *line = NULL;
     unsigned int lines = 0;
     size_t off = 0;
@@ -1498,7 +1498,7 @@ static int nntp_fetch_headers(struct Mailbox *m, void *hc, anum_t first, anum_t 
  */
 static int nntp_group_poll(struct NntpMboxData *mdata, bool update_stat)
 {
-  char buf[LONG_STRING] = "";
+  char buf[1024] = "";
   anum_t count, first, last;
 
   /* use GROUP command to poll newsgroup */
@@ -1759,7 +1759,7 @@ static int nntp_date(struct NntpAccountData *adata, time_t *now)
   if (adata->hasDATE)
   {
     struct NntpMboxData mdata;
-    char buf[LONG_STRING];
+    char buf[1024];
     struct tm tm;
     memset(&tm, 0, sizeof(tm));
 
@@ -1982,7 +1982,7 @@ int nntp_post(struct Mailbox *m, const char *msg)
 {
   struct NntpMboxData *mdata = NULL;
   struct NntpMboxData tmp_mdata = { 0 };
-  char buf[LONG_STRING];
+  char buf[1024];
 
   if (m && (m->magic == MUTT_NNTP))
     mdata = m->mdata;
@@ -2064,7 +2064,7 @@ int nntp_active_fetch(struct NntpAccountData *adata, bool new)
 {
   struct NntpMboxData tmp_mdata;
   char msg[256];
-  char buf[LONG_STRING];
+  char buf[1024];
   unsigned int i;
   int rc;
 
@@ -2132,7 +2132,7 @@ int nntp_check_new_groups(struct Mailbox *m, struct NntpAccountData *adata)
   struct NntpMboxData tmp_mdata;
   time_t now;
   struct tm *tm = NULL;
-  char buf[LONG_STRING];
+  char buf[1024];
   char *msg = _("Checking for new newsgroups...");
   unsigned int i;
   int rc, update_active = false;
@@ -2247,7 +2247,7 @@ int nntp_check_msgid(struct Context *ctx, const char *msgid)
   struct Mailbox *m = ctx->mailbox;
 
   struct NntpMboxData *mdata = m->mdata;
-  char buf[LONG_STRING];
+  char buf[1024];
 
   FILE *fp = mutt_file_mkstemp();
   if (!fp)
@@ -2443,7 +2443,7 @@ static int nntp_mbox_open(struct Mailbox *m)
     return -1;
 
   char buf[HUGE_STRING];
-  char server[LONG_STRING];
+  char server[1024];
   char *group = NULL;
   int rc;
   void *hc = NULL;

--- a/nntp/nntp.c
+++ b/nntp/nntp.c
@@ -1257,7 +1257,7 @@ static int nntp_fetch_headers(struct Mailbox *m, void *hc, anum_t first, anum_t 
   struct NntpMboxData *mdata = m->mdata;
   struct FetchCtx fc;
   struct Email *e = NULL;
-  char buf[HUGE_STRING];
+  char buf[8192];
   int rc = 0;
   anum_t current;
   anum_t first_over = first;
@@ -2442,7 +2442,7 @@ static int nntp_mbox_open(struct Mailbox *m)
   if (!m || !m->account)
     return -1;
 
-  char buf[HUGE_STRING];
+  char buf[8192];
   char server[1024];
   char *group = NULL;
   int rc;

--- a/notmuch/mutt_notmuch.c
+++ b/notmuch/mutt_notmuch.c
@@ -819,7 +819,7 @@ static void progress_update(struct Mailbox *m, notmuch_query_t *q)
 
   if (!mdata->progress_ready && q)
   {
-    static char msg[STRING];
+    static char msg[256];
     snprintf(msg, sizeof(msg), _("Reading messages..."));
 
     // The total mail count is in oldmsgcount, so use that instead of recounting.

--- a/notmuch/mutt_notmuch.c
+++ b/notmuch/mutt_notmuch.c
@@ -249,7 +249,7 @@ struct NmEmailData *nm_edata_new(void)
 struct NmMboxData *nm_get_default_data(void)
 {
   // path to DB + query + URI "decoration"
-  char uri[PATH_MAX + LONG_STRING + 32];
+  char uri[PATH_MAX + 1024 + 32];
 
   // Try to use C_NmDefaultUri or C_Folder.
   // If neither are set, it is impossible to create a Notmuch URI.
@@ -496,7 +496,7 @@ static char *get_query_string(struct NmMboxData *mdata, bool window)
 
   if (window)
   {
-    char buf[LONG_STRING];
+    char buf[1024];
     mutt_str_replace(&C_NmQueryWindowCurrentSearch, mdata->db_query);
 
     /* if a date part is defined, do not apply windows (to avoid the risk of
@@ -1686,7 +1686,7 @@ char *nm_uri_from_query(struct Mailbox *m, char *buf, size_t buflen)
 {
   mutt_debug(LL_DEBUG2, "(%s)\n", buf);
   struct NmMboxData *mdata = nm_mdata_get(m);
-  char uri[PATH_MAX + LONG_STRING + 32]; /* path to DB + query + URI "decoration" */
+  char uri[PATH_MAX + 1024 + 32]; /* path to DB + query + URI "decoration" */
   int added;
   bool using_default_data = false;
 

--- a/pager.c
+++ b/pager.c
@@ -2230,8 +2230,8 @@ int mutt_pager(const char *banner, const char *fname, int flags, struct Pager *e
 {
   static char searchbuf[STRING] = "";
   char buffer[LONG_STRING];
-  char helpstr[SHORT_STRING * 2];
-  char tmphelp[SHORT_STRING * 2];
+  char helpstr[256];
+  char tmphelp[256];
   int ch = 0, rc = -1;
   bool first = true;
   int searchctx = 0;

--- a/pager.c
+++ b/pager.c
@@ -2178,7 +2178,7 @@ static void pager_custom_redraw(struct Menu *pager_menu)
     }
     else
     {
-      char bn[STRING];
+      char bn[256];
       snprintf(bn, sizeof(bn), "%s (%s)", rd->banner, pager_progress_str);
       mutt_draw_statusline(rd->pager_status_window->cols, bn, sizeof(bn));
     }
@@ -2228,7 +2228,7 @@ static void pager_custom_redraw(struct Menu *pager_menu)
  */
 int mutt_pager(const char *banner, const char *fname, int flags, struct Pager *extra)
 {
-  static char searchbuf[STRING] = "";
+  static char searchbuf[256] = "";
   char buffer[LONG_STRING];
   char helpstr[256];
   char tmphelp[256];

--- a/pager.c
+++ b/pager.c
@@ -1921,7 +1921,7 @@ struct PagerRedrawData
 static void pager_custom_redraw(struct Menu *pager_menu)
 {
   struct PagerRedrawData *rd = pager_menu->redraw_data;
-  char buffer[LONG_STRING];
+  char buffer[1024];
 
   if (!rd)
     return;
@@ -2229,7 +2229,7 @@ static void pager_custom_redraw(struct Menu *pager_menu)
 int mutt_pager(const char *banner, const char *fname, int flags, struct Pager *extra)
 {
   static char searchbuf[256] = "";
-  char buffer[LONG_STRING];
+  char buffer[1024];
   char helpstr[256];
   char tmphelp[256];
   int ch = 0, rc = -1;
@@ -2436,7 +2436,7 @@ int mutt_pager(const char *banner, const char *fname, int flags, struct Pager *e
           beep();
         if (C_NewMailCommand)
         {
-          char cmd[LONG_STRING];
+          char cmd[1024];
           menu_status_line(cmd, sizeof(cmd), rd.index, NONULL(C_NewMailCommand));
           if (mutt_system(cmd) != 0)
             mutt_error(_("Error running \"%s\""), cmd);

--- a/pattern.c
+++ b/pattern.c
@@ -185,7 +185,7 @@ static struct RangeRegex range_regexes[] = {
 
 static struct Pattern *SearchPattern = NULL; /**< current search pattern */
 static char LastSearch[256] = { 0 };      /**< last pattern searched for */
-static char LastSearchExpn[LONG_STRING] = { 0 }; /**< expanded version of LastSearch */
+static char LastSearchExpn[1024] = { 0 }; /**< expanded version of LastSearch */
 
 /**
  * eat_regex - Parse a regex
@@ -2254,7 +2254,7 @@ void mutt_check_simple(char *s, size_t len, const char *simple)
       mutt_str_strfcpy(s, "~U", len);
     else
     {
-      char tmp[LONG_STRING];
+      char tmp[1024];
       quote_simple(s, tmp, sizeof(tmp));
       mutt_file_expand_fmt(s, len, simple, tmp);
     }
@@ -2334,7 +2334,7 @@ bool mutt_limit_current_thread(struct Email *e)
 int mutt_pattern_func(int op, char *prompt)
 {
   struct Pattern *pat = NULL;
-  char buf[LONG_STRING] = "", *simple = NULL;
+  char buf[1024] = "", *simple = NULL;
   struct Buffer err;
   int rc = -1, padding;
   struct Progress progress;
@@ -2491,7 +2491,7 @@ int mutt_search_command(int cur, int op)
 
     /* compare the *expanded* version of the search pattern in case
        $simple_search has changed while we were searching */
-    char temp[LONG_STRING];
+    char temp[1024];
     mutt_str_strfcpy(temp, buf, sizeof(temp));
     mutt_check_simple(temp, sizeof(temp), NONULL(C_SimpleSearch));
 

--- a/pattern.c
+++ b/pattern.c
@@ -184,7 +184,7 @@ static struct RangeRegex range_regexes[] = {
 // clang-format on
 
 static struct Pattern *SearchPattern = NULL; /**< current search pattern */
-static char LastSearch[STRING] = { 0 };      /**< last pattern searched for */
+static char LastSearch[256] = { 0 };      /**< last pattern searched for */
 static char LastSearchExpn[LONG_STRING] = { 0 }; /**< expanded version of LastSearch */
 
 /**
@@ -197,7 +197,7 @@ static char LastSearchExpn[LONG_STRING] = { 0 }; /**< expanded version of LastSe
 static bool eat_regex(struct Pattern *pat, struct Buffer *s, struct Buffer *err)
 {
   struct Buffer buf;
-  char errmsg[STRING];
+  char errmsg[256];
   int r;
 
   mutt_buffer_init(&buf);
@@ -1197,7 +1197,7 @@ static bool msg_search(struct Mailbox *m, struct Pattern *pat, int msgno)
     }
   }
 
-  size_t blen = STRING;
+  size_t blen = 256;
   char *buf = mutt_mem_malloc(blen);
 
   /* search the file "fp" */
@@ -1850,7 +1850,7 @@ static int match_threadchildren(struct Pattern *pat, enum PatternExecFlag flags,
  */
 static int match_content_type(const struct Pattern *pat, struct Body *b)
 {
-  char buffer[STRING];
+  char buffer[256];
   if (!b)
     return 0;
 
@@ -2350,7 +2350,7 @@ int mutt_pattern_func(int op, char *prompt)
   mutt_check_simple(buf, sizeof(buf), NONULL(C_SimpleSearch));
 
   mutt_buffer_init(&err);
-  err.dsize = STRING;
+  err.dsize = 256;
   err.data = mutt_mem_malloc(err.dsize);
   pat = mutt_pattern_comp(buf, MUTT_FULL_MSG, &err);
   if (!pat)
@@ -2473,7 +2473,7 @@ int mutt_search_command(int cur, int op)
 
   if (!*LastSearch || (op != OP_SEARCH_NEXT && op != OP_SEARCH_OPPOSITE))
   {
-    char buf[STRING];
+    char buf[256];
     mutt_str_strfcpy(buf, *LastSearch ? LastSearch : "", sizeof(buf));
     if (mutt_get_field((op == OP_SEARCH || op == OP_SEARCH_NEXT) ?
                            _("Search for: ") :
@@ -2503,7 +2503,7 @@ int mutt_search_command(int cur, int op)
       mutt_str_strfcpy(LastSearch, buf, sizeof(LastSearch));
       mutt_message(_("Compiling search pattern..."));
       mutt_pattern_free(&SearchPattern);
-      err.dsize = STRING;
+      err.dsize = 256;
       err.data = mutt_mem_malloc(err.dsize);
       SearchPattern = mutt_pattern_comp(temp, MUTT_FULL_MSG, &err);
       if (!SearchPattern)

--- a/pop/pop.c
+++ b/pop/pop.c
@@ -89,7 +89,7 @@ bool C_PopLast;  ///< Config: (pop) Use the 'LAST' command to fetch new mail
  */
 static const char *cache_id(const char *id)
 {
-  static char clean[SHORT_STRING];
+  static char clean[128];
   mutt_str_strfcpy(clean, id, sizeof(clean));
   mutt_file_sanitize_filename(clean, true);
   return clean;
@@ -588,7 +588,7 @@ void pop_fetch_mail(void)
   }
 
   char buffer[LONG_STRING];
-  char msgbuf[SHORT_STRING];
+  char msgbuf[128];
   int delanswer, last = 0, msgs, bytes, rset = 0, ret;
   struct ConnAccount acct;
 

--- a/pop/pop.c
+++ b/pop/pop.c
@@ -189,7 +189,7 @@ static int pop_read_header(struct PopAccountData *adata, struct Email *e)
 
   int index = 0;
   size_t length = 0;
-  char buf[LONG_STRING];
+  char buf[1024];
 
   snprintf(buf, sizeof(buf), "LIST %d\r\n", e->refno);
   int rc = pop_query(adata, buf, sizeof(buf));
@@ -360,7 +360,7 @@ static header_cache_t *pop_hcache_open(struct PopAccountData *adata, const char 
     return mutt_hcache_open(C_HeaderCache, path, NULL);
 
   struct Url url;
-  char p[LONG_STRING];
+  char p[1024];
 
   mutt_account_tourl(&adata->conn->account, &url);
   url.path = HC_FNAME;
@@ -587,7 +587,7 @@ void pop_fetch_mail(void)
     return;
   }
 
-  char buffer[LONG_STRING];
+  char buffer[1024];
   char msgbuf[128];
   int delanswer, last = 0, msgs, bytes, rset = 0, ret;
   struct ConnAccount acct;
@@ -939,7 +939,7 @@ static int pop_mbox_sync(struct Mailbox *m, int *index_hint)
     return -1;
 
   int i, j, ret = 0;
-  char buf[LONG_STRING];
+  char buf[1024];
   struct PopAccountData *adata = pop_adata_get(m);
   struct Progress progress;
 #ifdef USE_HCACHE
@@ -1058,7 +1058,7 @@ static int pop_msg_open(struct Mailbox *m, struct Message *msg, int msgno)
   if (!m)
     return -1;
 
-  char buf[LONG_STRING];
+  char buf[1024];
   char path[PATH_MAX];
   struct Progress progressbar;
   struct PopAccountData *adata = pop_adata_get(m);

--- a/pop/pop_auth.c
+++ b/pop/pop_auth.c
@@ -59,7 +59,7 @@ static enum PopAuthRes pop_auth_sasl(struct PopAccountData *adata, const char *m
   sasl_conn_t *saslconn = NULL;
   sasl_interact_t *interaction = NULL;
   int rc;
-  char inbuf[LONG_STRING];
+  char inbuf[1024];
   const char *mech = NULL;
   const char *pc = NULL;
   unsigned int len = 0, olen = 0, client_start;
@@ -102,7 +102,7 @@ static enum PopAuthRes pop_auth_sasl(struct PopAccountData *adata, const char *m
 
   mutt_message(_("Authenticating (SASL)..."));
 
-  size_t bufsize = ((olen * 2) > LONG_STRING) ? (olen * 2) : LONG_STRING;
+  size_t bufsize = MAX((olen * 2), 1024);
   char *buf = mutt_mem_malloc(bufsize);
 
   snprintf(buf, bufsize, "AUTH %s", mech);
@@ -234,7 +234,7 @@ static enum PopAuthRes pop_auth_apop(struct PopAccountData *adata, const char *m
   struct Md5Ctx mctx;
   unsigned char digest[16];
   char hash[33];
-  char buf[LONG_STRING];
+  char buf[1024];
 
   if (mutt_account_getpass(&adata->conn->account) || !adata->conn->account.pass[0])
     return POP_A_FAILURE;
@@ -289,7 +289,7 @@ static enum PopAuthRes pop_auth_user(struct PopAccountData *adata, const char *m
 
   mutt_message(_("Logging in..."));
 
-  char buf[LONG_STRING];
+  char buf[1024];
   snprintf(buf, sizeof(buf), "USER %s\r\n", adata->conn->account.user);
   int ret = pop_query(adata, buf, sizeof(buf));
 
@@ -374,7 +374,7 @@ static enum PopAuthRes pop_auth_oauth(struct PopAccountData *adata, const char *
   mutt_socket_send(adata->conn, "\001");
 
   char *err = adata->err_msg;
-  char decoded_err[LONG_STRING];
+  char decoded_err[1024];
   int len = mutt_b64_decode(adata->err_msg, decoded_err, sizeof(decoded_err) - 1);
   if (len >= 0)
   {

--- a/pop/pop_lib.c
+++ b/pop/pop_lib.c
@@ -188,7 +188,7 @@ static int fetch_auth(char *line, void *data)
 */
 static int pop_capabilities(struct PopAccountData *adata, int mode)
 {
-  char buf[LONG_STRING];
+  char buf[1024];
 
   /* don't check capabilities on reconnect */
   if (adata->capabilities)
@@ -267,7 +267,7 @@ static int pop_capabilities(struct PopAccountData *adata, int mode)
 */
 int pop_connect(struct PopAccountData *adata)
 {
-  char buf[LONG_STRING];
+  char buf[1024];
 
   adata->status = POP_NONE;
   if (mutt_socket_open(adata->conn) < 0 ||
@@ -302,7 +302,7 @@ int pop_connect(struct PopAccountData *adata)
 */
 int pop_open_connection(struct PopAccountData *adata)
 {
-  char buf[LONG_STRING];
+  char buf[1024];
 
   int rc = pop_connect(adata);
   if (rc < 0)
@@ -411,7 +411,7 @@ void pop_logout(struct Mailbox *m)
   if (adata->status == POP_CONNECTED)
   {
     int ret = 0;
-    char buf[LONG_STRING];
+    char buf[1024];
     mutt_message(_("Closing connection to POP server..."));
 
     if (m->readonly)
@@ -493,7 +493,7 @@ int pop_query_d(struct PopAccountData *adata, char *buf, size_t buflen, char *ms
 int pop_fetch_data(struct PopAccountData *adata, const char *query,
                    struct Progress *progressbar, int (*func)(char *, void *), void *data)
 {
-  char buf[LONG_STRING];
+  char buf[1024];
   long pos = 0;
   size_t lenbuf = 0;
 

--- a/postpone.c
+++ b/postpone.c
@@ -216,7 +216,7 @@ static struct Email *select_msg(struct Context *ctx)
 {
   int r = -1;
   bool done = false;
-  char helpstr[LONG_STRING];
+  char helpstr[1024];
 
   struct Menu *menu = mutt_menu_new(MENU_POST);
   menu->menu_make_entry = post_make_entry;
@@ -451,8 +451,8 @@ int mutt_get_postponed(struct Context *ctx, struct Email *hdr,
  */
 int mutt_parse_crypt_hdr(const char *p, int set_empty_signas, int crypt_app)
 {
-  char smime_cryptalg[LONG_STRING] = "\0";
-  char sign_as[LONG_STRING] = "\0", *q = NULL;
+  char smime_cryptalg[1024] = "\0";
+  char sign_as[1024] = "\0", *q = NULL;
   int flags = 0;
 
   if (!WithCrypto)

--- a/progress.c
+++ b/progress.c
@@ -51,7 +51,7 @@ short C_TimeInc; ///< Config: Frequency of progress bar updates (milliseconds)
 static void message_bar(int percent, const char *fmt, ...)
 {
   va_list ap;
-  char buf[STRING], buf2[STRING];
+  char buf[256], buf2[256];
   int w = percent * COLS / 100;
   size_t l;
 

--- a/progress.c
+++ b/progress.c
@@ -169,7 +169,7 @@ void mutt_progress_init(struct Progress *progress, const char *msg,
  */
 void mutt_progress_update(struct Progress *progress, long pos, int percent)
 {
-  char posstr[SHORT_STRING];
+  char posstr[128];
   bool update = false;
   struct timeval tv = { 0, 0 };
   unsigned int now = 0;

--- a/progress.h
+++ b/progress.h
@@ -43,7 +43,7 @@ struct Progress
   long pos;
   size_t size;
   unsigned int timestamp;
-  char sizestr[SHORT_STRING];
+  char sizestr[128];
 };
 
 void mutt_progress_init(struct Progress *progress, const char *msg,

--- a/query.c
+++ b/query.c
@@ -251,7 +251,7 @@ static const char *query_format_str(char *buf, size_t buflen, size_t col, int co
 {
   struct Entry *entry = (struct Entry *) data;
   struct Query *query = entry->data;
-  char fmt[SHORT_STRING];
+  char fmt[128];
   char tmp[STRING] = "";
   int optional = (flags & MUTT_FORMAT_OPTIONAL);
 

--- a/query.c
+++ b/query.c
@@ -137,7 +137,7 @@ static struct Query *run_query(char *s, int quiet)
   FILE *fp = NULL;
   struct Query *first = NULL;
   struct Query *cur = NULL;
-  char cmd[HUGE_STRING];
+  char cmd[STR_COMMAND];
   char *buf = NULL;
   size_t buflen;
   int dummy = 0;

--- a/query.c
+++ b/query.c
@@ -349,7 +349,7 @@ static void query_menu(char *buf, size_t buflen, struct Query *results, bool ret
     menu->menu_search = query_search;
     menu->menu_tag = query_tag;
     menu->title = title;
-    char helpstr[LONG_STRING];
+    char helpstr[1024];
     menu->help = mutt_compile_help(helpstr, sizeof(helpstr), MENU_QUERY, QueryHelp);
     mutt_menu_push_current(menu);
 

--- a/query.c
+++ b/query.c
@@ -141,7 +141,7 @@ static struct Query *run_query(char *s, int quiet)
   char *buf = NULL;
   size_t buflen;
   int dummy = 0;
-  char msg[STRING];
+  char msg[256];
   char *p = NULL;
   pid_t thepid;
 
@@ -252,7 +252,7 @@ static const char *query_format_str(char *buf, size_t buflen, size_t col, int co
   struct Entry *entry = (struct Entry *) data;
   struct Query *query = entry->data;
   char fmt[128];
-  char tmp[STRING] = "";
+  char tmp[256] = "";
   int optional = (flags & MUTT_FORMAT_OPTIONAL);
 
   switch (op)
@@ -329,7 +329,7 @@ static void query_menu(char *buf, size_t buflen, struct Query *results, bool ret
   struct Email *msg = NULL;
   struct Entry *QueryTable = NULL;
   struct Query *queryp = NULL;
-  char title[STRING];
+  char title[256];
 
   if (!results)
   {
@@ -608,7 +608,7 @@ void mutt_query_menu(char *buf, size_t buflen)
 
   if (!buf)
   {
-    char buffer[STRING] = "";
+    char buffer[256] = "";
 
     query_menu(buffer, sizeof(buffer), NULL, false);
   }

--- a/recvattach.c
+++ b/recvattach.c
@@ -1317,7 +1317,7 @@ static void attach_collapse(struct AttachCtx *actx, struct Menu *menu)
  */
 void mutt_view_attachments(struct Email *e)
 {
-  char helpstr[LONG_STRING];
+  char helpstr[1024];
   struct Body *cur = NULL;
   int flags = 0;
   int op = OP_NULL;

--- a/recvattach.c
+++ b/recvattach.c
@@ -209,8 +209,8 @@ const char *attach_format_str(char *buf, size_t buflen, size_t col, int cols, ch
                               const char *src, const char *prec, const char *if_str,
                               const char *else_str, unsigned long data, int flags)
 {
-  char fmt[SHORT_STRING];
-  char charset[SHORT_STRING];
+  char fmt[128];
+  char charset[128];
   struct AttachPtr *aptr = (struct AttachPtr *) data;
   int optional = (flags & MUTT_FORMAT_OPTIONAL);
   size_t l;
@@ -256,7 +256,7 @@ const char *attach_format_str(char *buf, size_t buflen, size_t col, int cols, ch
         if (mutt_is_message_type(aptr->content->type, aptr->content->subtype) &&
             C_MessageFormat && aptr->content->email)
         {
-          char s[SHORT_STRING];
+          char s[128];
           mutt_make_string_flags(s, sizeof(s), C_MessageFormat, NULL, NULL,
                                  aptr->content->email,
                                  MUTT_FORMAT_FORCESUBJ | MUTT_FORMAT_ARROWCURSOR);
@@ -376,7 +376,7 @@ const char *attach_format_str(char *buf, size_t buflen, size_t col, int cols, ch
 
       if (!optional)
       {
-        char tmp[SHORT_STRING];
+        char tmp[128];
         mutt_str_pretty_size(tmp, sizeof(tmp), l);
         mutt_format_s(buf, buflen, prec, tmp);
       }
@@ -787,7 +787,7 @@ void mutt_pipe_attachment_list(struct AttachCtx *actx, FILE *fp, bool tag,
                                struct Body *top, bool filter)
 {
   struct State state = { 0 };
-  char buf[SHORT_STRING];
+  char buf[128];
 
   if (fp)
     filter = false; /* sanity check: we can't filter in the recv case yet */
@@ -935,7 +935,7 @@ static void print_attachment_list(struct AttachCtx *actx, FILE *fp, bool tag,
  */
 void mutt_print_attachment_list(struct AttachCtx *actx, FILE *fp, bool tag, struct Body *top)
 {
-  char prompt[SHORT_STRING];
+  char prompt[128];
   struct State state = { 0 };
   int tagmsgcount = 0;
 

--- a/recvattach.c
+++ b/recvattach.c
@@ -142,7 +142,7 @@ static void mutt_update_v2r(struct AttachCtx *actx)
  */
 void mutt_update_tree(struct AttachCtx *actx)
 {
-  char buf[STRING];
+  char buf[256];
   char *s = NULL;
 
   mutt_update_v2r(actx);
@@ -680,7 +680,7 @@ static void query_pipe_attachment(char *command, FILE *fp, struct Body *body, bo
 
   if (filter)
   {
-    char warning[PATH_MAX + STRING];
+    char warning[PATH_MAX + 256];
     snprintf(warning, sizeof(warning),
              _("WARNING!  You are about to overwrite %s, continue?"), body->filename);
     if (mutt_yesorno(warning, MUTT_NO) != MUTT_YES)
@@ -827,7 +827,7 @@ void mutt_pipe_attachment_list(struct AttachCtx *actx, FILE *fp, bool tag,
  */
 static bool can_print(struct AttachCtx *actx, struct Body *top, bool tag)
 {
-  char type[STRING];
+  char type[256];
 
   for (int i = 0; !tag || (i < actx->idxlen); i++)
   {
@@ -870,7 +870,7 @@ static bool can_print(struct AttachCtx *actx, struct Body *top, bool tag)
 static void print_attachment_list(struct AttachCtx *actx, FILE *fp, bool tag,
                                   struct Body *top, struct State *state)
 {
-  char type[STRING];
+  char type[256];
 
   for (int i = 0; !tag || (i < actx->idxlen); i++)
   {

--- a/recvcmd.c
+++ b/recvcmd.c
@@ -400,7 +400,7 @@ static struct AttachPtr *find_parent(struct AttachCtx *actx, struct Body *cur, s
 static void include_header(bool quote, FILE *ifp, struct Email *e, FILE *ofp, char *prefix)
 {
   int chflags = CH_DECODE;
-  char prefix2[SHORT_STRING];
+  char prefix2[128];
 
   if (C_Weed)
     chflags |= CH_WEED | CH_REORDER;
@@ -916,7 +916,7 @@ void mutt_attach_reply(FILE *fp, struct Email *e, struct AttachCtx *actx,
   char tmpbody[PATH_MAX];
   FILE *tmpfp = NULL;
 
-  char prefix[SHORT_STRING];
+  char prefix[128];
 
 #ifdef USE_NNTP
   if (flags & SEND_NEWS)

--- a/recvcmd.c
+++ b/recvcmd.c
@@ -167,7 +167,7 @@ void mutt_attach_bounce(struct Mailbox *m, FILE *fp, struct AttachCtx *actx, str
     return;
 
   char prompt[256];
-  char buf[HUGE_STRING];
+  char buf[8192];
   char *err = NULL;
   struct Address *addr = NULL;
   int ret = 0;

--- a/recvcmd.c
+++ b/recvcmd.c
@@ -166,7 +166,7 @@ void mutt_attach_bounce(struct Mailbox *m, FILE *fp, struct AttachCtx *actx, str
   if (!m || !fp || !actx)
     return;
 
-  char prompt[STRING];
+  char prompt[256];
   char buf[HUGE_STRING];
   char *err = NULL;
   struct Address *addr = NULL;
@@ -465,7 +465,7 @@ static void attach_forward_bodies(FILE *fp, struct Email *e, struct AttachCtx *a
   struct Email *e_parent = NULL;
   FILE *parent_fp = NULL;
   char tmpbody[PATH_MAX];
-  char prefix[STRING];
+  char prefix[256];
   int rc = 0;
 
   /* First, find the parent message.

--- a/remailer.c
+++ b/remailer.c
@@ -826,7 +826,7 @@ int mix_check_message(struct Email *msg)
  */
 int mix_send_message(struct ListHead *chain, const char *tempfile)
 {
-  char cd_quoted[STRING];
+  char cd_quoted[256];
   int i = 0;
 
   struct Buffer *cmd = mutt_buffer_pool_get();

--- a/remailer.c
+++ b/remailer.c
@@ -437,7 +437,7 @@ static const char *mix_format_str(char *buf, size_t buflen, size_t col, int cols
                                   const char *if_str, const char *else_str,
                                   unsigned long data, int flags)
 {
-  char fmt[SHORT_STRING];
+  char fmt[128];
   struct Remailer *remailer = (struct Remailer *) data;
   int optional = (flags & MUTT_FORMAT_OPTIONAL);
 

--- a/remailer.c
+++ b/remailer.c
@@ -167,8 +167,8 @@ static struct Remailer **mix_type2_list(size_t *l)
   pid_t mm_pid;
   int devnull;
 
-  char cmd[HUGE_STRING];
-  char line[HUGE_STRING];
+  char cmd[STR_COMMAND];
+  char line[8192];
   char *t = NULL;
 
   struct Remailer **type2_list = NULL, *p = NULL;

--- a/remailer.c
+++ b/remailer.c
@@ -564,7 +564,7 @@ void mix_make_chain(struct ListHead *chainhead)
   struct Coord *coords = NULL;
 
   struct Menu *menu = NULL;
-  char helpstr[LONG_STRING];
+  char helpstr[1024];
   bool loop = true;
 
   char *t = NULL;

--- a/rfc1524.c
+++ b/rfc1524.c
@@ -94,8 +94,8 @@ int rfc1524_expand_command(struct Body *a, const char *filename,
       x++;
       if (command[x] == '{')
       {
-        char param[STRING];
-        char pvalue[STRING];
+        char param[256];
+        char pvalue[256];
         char *pvalue2 = NULL;
         int z = 0;
 
@@ -329,7 +329,7 @@ static int rfc1524_mailcap_parse(struct Body *a, char *filename, char *type,
 
           if (get_field_text(field + plen, &test_command, type, filename, line) && test_command)
           {
-            const size_t len = mutt_str_strlen(test_command) + STRING;
+            const size_t len = mutt_str_strlen(test_command) + 256;
             mutt_mem_realloc(&test_command, len);
             if (rfc1524_expand_command(a, a->filename, type, test_command, len) == 1)
             {

--- a/rfc1524.c
+++ b/rfc1524.c
@@ -75,7 +75,7 @@ int rfc1524_expand_command(struct Body *a, const char *filename,
   int x = 0, y = 0;
   int needspipe = true;
   char buf[HUGE_STRING];
-  char type2[LONG_STRING];
+  char type2[1024];
 
   mutt_str_strfcpy(type2, type, sizeof(type2));
 

--- a/rfc1524.c
+++ b/rfc1524.c
@@ -74,7 +74,7 @@ int rfc1524_expand_command(struct Body *a, const char *filename,
 {
   int x = 0, y = 0;
   int needspipe = true;
-  char buf[HUGE_STRING];
+  char buf[STR_COMMAND];
   char type2[1024];
 
   mutt_str_strfcpy(type2, type, sizeof(type2));

--- a/rfc1524.c
+++ b/rfc1524.c
@@ -457,7 +457,7 @@ int rfc1524_mailcap_lookup(struct Body *a, char *type,
     return 0;
   }
 
-  mutt_check_lookup_list(a, type, SHORT_STRING);
+  mutt_check_lookup_list(a, type, 128);
 
   while (!found && *curr)
   {

--- a/rfc3676.c
+++ b/rfc3676.c
@@ -404,7 +404,7 @@ void rfc3676_space_stuff(struct Email *e)
   size_t len = 0;
   unsigned char c = '\0';
   FILE *in = NULL, *out = NULL;
-  char buf[LONG_STRING];
+  char buf[1024];
   char tmpfile[PATH_MAX];
 
   if (!e || !e->content || !e->content->filename)

--- a/safe_asprintf.c
+++ b/safe_asprintf.c
@@ -76,7 +76,7 @@ int safe_asprintf(char **strp, const char *fmt, ...)
  */
 int safe_asprintf(char **strp, const char *fmt, ...)
 {
-  int rlen = STRING;
+  int rlen = 256;
 
   *strp = mutt_mem_malloc(rlen);
   while (true)

--- a/send.c
+++ b/send.c
@@ -560,7 +560,7 @@ void mutt_make_post_indent(struct Mailbox *m, struct Email *e, FILE *out)
   if (!C_PostIndentString || !out)
     return;
 
-  char buf[STRING];
+  char buf[256];
   mutt_make_string(buf, sizeof(buf), C_PostIndentString, NULL, m, e);
   fputs(buf, out);
   fputc('\n', out);
@@ -617,7 +617,7 @@ static int include_reply(struct Mailbox *m, struct Email *e, FILE *out)
  */
 static int default_to(struct Address **to, struct Envelope *env, int flags, int hmfupto)
 {
-  char prompt[STRING];
+  char prompt[256];
 
   if (flags && env->mail_followup_to && hmfupto == MUTT_YES)
   {
@@ -703,7 +703,7 @@ int mutt_fetch_recips(struct Envelope *out, struct Envelope *in, int flags)
 
   if ((flags & (SEND_LIST_REPLY | SEND_GROUP_REPLY | SEND_GROUP_CHAT_REPLY)) && in->mail_followup_to)
   {
-    char prompt[STRING];
+    char prompt[256];
     snprintf(prompt, sizeof(prompt), _("Follow-up to %s%s?"),
              in->mail_followup_to->mailbox, in->mail_followup_to->next ? ",..." : "");
 
@@ -815,7 +815,7 @@ void mutt_make_forward_subject(struct Envelope *env, struct Mailbox *m, struct E
   if (!env)
     return;
 
-  char buf[STRING];
+  char buf[256];
 
   /* set the default subject for the message. */
   mutt_make_string(buf, sizeof(buf), NONULL(C_ForwardFormat), NULL, m, cur);

--- a/send.c
+++ b/send.c
@@ -457,7 +457,7 @@ void mutt_forward_intro(struct Mailbox *m, struct Email *e, FILE *fp)
   if (!C_ForwardAttributionIntro || !fp)
     return;
 
-  char buf[LONG_STRING];
+  char buf[1024];
   setlocale(LC_TIME, NONULL(C_AttributionLocale));
   mutt_make_string(buf, sizeof(buf), C_ForwardAttributionIntro, NULL, m, e);
   setlocale(LC_TIME, "");
@@ -476,7 +476,7 @@ void mutt_forward_trailer(struct Mailbox *m, struct Email *e, FILE *fp)
   if (!C_ForwardAttributionTrailer || !fp)
     return;
 
-  char buf[LONG_STRING];
+  char buf[1024];
   setlocale(LC_TIME, NONULL(C_AttributionLocale));
   mutt_make_string(buf, sizeof(buf), C_ForwardAttributionTrailer, NULL, m, e);
   setlocale(LC_TIME, "");
@@ -541,7 +541,7 @@ void mutt_make_attribution(struct Mailbox *m, struct Email *e, FILE *out)
   if (!C_Attribution || !out)
     return;
 
-  char buf[LONG_STRING];
+  char buf[1024];
   setlocale(LC_TIME, NONULL(C_AttributionLocale));
   mutt_make_string(buf, sizeof(buf), C_Attribution, NULL, m, e);
   setlocale(LC_TIME, "");
@@ -1442,11 +1442,11 @@ static bool search_attach_keyword(char *filename)
   if (!attf)
     return false;
 
-  char *inputline = mutt_mem_malloc(LONG_STRING);
+  char *inputline = mutt_mem_malloc(1024);
   bool found = false;
   while (!feof(attf))
   {
-    fgets(inputline, LONG_STRING, attf);
+    fgets(inputline, 1024, attf);
     if (!mutt_is_quote_line(inputline, NULL) &&
         regexec(C_AbortNoattachRegex->regex, inputline, 0, NULL, 0) == 0)
     {
@@ -1736,7 +1736,7 @@ static int postpone_message(struct Email *msg, struct Email *cur, char *fcc, int
 int ci_send_message(int flags, struct Email *msg, const char *tempfile,
                     struct Context *ctx, struct EmailList *el)
 {
-  char buf[LONG_STRING];
+  char buf[1024];
   char fcc[PATH_MAX] = ""; /* where to copy this message */
   FILE *tempfp = NULL;
   struct Body *pbody = NULL;

--- a/send.c
+++ b/send.c
@@ -235,7 +235,7 @@ static struct Address *find_mailing_lists(struct Address *t, struct Address *c)
  */
 static int edit_address(struct Address **a, const char *field)
 {
-  char buf[HUGE_STRING];
+  char buf[8192];
   char *err = NULL;
   int idna_ok = 0;
 
@@ -267,7 +267,7 @@ static int edit_address(struct Address **a, const char *field)
  */
 static int edit_envelope(struct Envelope *en, int flags)
 {
-  char buf[HUGE_STRING];
+  char buf[8192];
 
 #ifdef USE_NNTP
   if (OptNewsSend)

--- a/sendlib.c
+++ b/sendlib.c
@@ -1558,7 +1558,7 @@ struct Body *mutt_make_message_attach(struct Mailbox *m, struct Email *e, bool a
 static void run_mime_type_query(struct Body *att)
 {
   FILE *fp, *fperr;
-  char cmd[HUGE_STRING];
+  char cmd[STR_COMMAND];
   char *buf = NULL;
   size_t buflen;
   int dummy = 0;
@@ -1881,7 +1881,7 @@ static int fold_one_header(FILE *fp, const char *tag, const char *value,
                            const char *pfx, int wraplen, int chflags)
 {
   const char *p = value;
-  char buf[HUGE_STRING] = "";
+  char buf[8192] = "";
   int first = 1, col = 0, l = 0;
   const bool display = (chflags & CH_DISPLAY);
 

--- a/sendlib.c
+++ b/sendlib.c
@@ -1462,7 +1462,7 @@ void mutt_update_encoding(struct Body *a)
  */
 struct Body *mutt_make_message_attach(struct Mailbox *m, struct Email *e, bool attach_msg)
 {
-  char buf[LONG_STRING];
+  char buf[1024];
   struct Body *body = NULL;
   FILE *fp = NULL;
   int cmflags, chflags;
@@ -1743,7 +1743,7 @@ struct Body *mutt_remove_multipart(struct Body *b)
 void mutt_write_address_list(struct Address *addr, FILE *fp, int linelen, bool display)
 {
   struct Address *tmp = NULL;
-  char buf[LONG_STRING];
+  char buf[1024];
   int count = 0;
 
   while (addr)
@@ -2217,7 +2217,7 @@ int mutt_rfc822_write_header(FILE *fp, struct Envelope *env,
                              struct Body *attach, enum MuttWriteHeaderMode mode,
                              bool privacy, bool hide_protected_subject)
 {
-  char buf[LONG_STRING];
+  char buf[1024];
   char *p = NULL, *q = NULL;
   bool has_agent = false; /* user defined user-agent header field exists */
 
@@ -2727,7 +2727,7 @@ int mutt_invoke_sendmail(struct Address *from, struct Address *to, struct Addres
 #ifdef USE_NNTP
   if (OptNewsSend)
   {
-    char cmd[LONG_STRING];
+    char cmd[1024];
 
     mutt_expando_format(cmd, sizeof(cmd), 0, MuttIndexWindow->cols,
                         NONULL(C_Inews), nntp_format_str, 0, 0);
@@ -2905,7 +2905,7 @@ void mutt_prepare_envelope(struct Envelope *env, bool final)
       env->to->group = 1;
       env->to->next = mutt_addr_new();
 
-      char buf[LONG_STRING];
+      char buf[1024];
       buf[0] = 0;
       mutt_addr_cat(buf, sizeof(buf), "undisclosed-recipients", AddressSpecials);
 
@@ -3291,7 +3291,7 @@ int mutt_write_fcc(const char *path, struct Email *e, const char *msgid,
 
   if (tempfp)
   {
-    char sasha[LONG_STRING];
+    char sasha[1024];
     int lines = 0;
 
     mutt_write_mime_body(e->content, tempfp);

--- a/sendlib.c
+++ b/sendlib.c
@@ -503,7 +503,7 @@ int mutt_write_mime_body(struct Body *a, FILE *f)
       mutt_error(_("No boundary parameter found [report this error]"));
       return -1;
     }
-    char boundary[SHORT_STRING];
+    char boundary[128];
     mutt_str_strfcpy(boundary, p, sizeof(boundary));
 
     for (struct Body *t = a->parts; t; t = t->next)
@@ -537,7 +537,7 @@ int mutt_write_mime_body(struct Body *a, FILE *f)
 
   if (a->type == TYPE_TEXT && (!a->noconv))
   {
-    char send_charset[SHORT_STRING];
+    char send_charset[128];
     fc = mutt_ch_fgetconv_open(
         fpin, a->charset, mutt_body_get_charset(a, send_charset, sizeof(send_charset)), 0);
   }
@@ -1340,7 +1340,7 @@ static void set_encoding(struct Body *b, struct Content *info)
 {
   if (b->type == TYPE_TEXT)
   {
-    char send_charset[SHORT_STRING];
+    char send_charset[128];
     char *chsname = mutt_body_get_charset(b, send_charset, sizeof(send_charset));
     if ((info->lobin && !mutt_str_startswith(chsname, "iso-2022", CASE_IGNORE)) ||
         info->linemax > 990 || (info->from && C_EncodeFrom))
@@ -2466,7 +2466,7 @@ const char *mutt_fqdn(bool may_hide_host)
  */
 static char *gen_msgid(void)
 {
-  char buf[SHORT_STRING];
+  char buf[128];
   time_t now;
   unsigned char rndid[MUTT_RANDTAG_LEN + 1];
 
@@ -2967,7 +2967,7 @@ static int bounce_message(FILE *fp, struct Email *e, struct Address *to,
   FILE *f = mutt_file_fopen(tempfile, "w");
   if (f)
   {
-    char date[SHORT_STRING];
+    char date[128];
     int chflags = CH_XMIT | CH_NONEWLINE | CH_NOQFROM;
 
     if (!C_BounceDelivered)
@@ -3151,7 +3151,7 @@ int mutt_write_fcc(const char *path, struct Email *e, const char *msgid,
   int rc = -1;
   bool need_mailbox_cleanup = false;
   struct stat st;
-  char buf[SHORT_STRING];
+  char buf[128];
   int onm_flags;
 
   if (post)

--- a/sendlib.c
+++ b/sendlib.c
@@ -374,7 +374,7 @@ int mutt_write_mime_header(struct Body *a, FILE *f)
 
       fputc(';', f);
 
-      char buf[STRING];
+      char buf[256];
       buf[0] = 0;
       tmp = mutt_str_strdup(np->value);
       const int encode = rfc2231_encode_string(&tmp);
@@ -442,7 +442,7 @@ int mutt_write_mime_header(struct Body *a, FILE *f)
           else
             t = fn;
 
-          char buf[STRING];
+          char buf[256];
           buf[0] = 0;
           tmp = mutt_str_strdup(t);
           const int encode = rfc2231_encode_string(&tmp);
@@ -1027,7 +1027,7 @@ struct Content *mutt_get_content_info(const char *fname, struct Body *b)
     {
       if (!chs)
       {
-        char chsbuf[STRING];
+        char chsbuf[256];
         mutt_ch_canonical_charset(chsbuf, sizeof(chsbuf), tocode);
         mutt_param_set(&b->parameter, "charset", chsbuf);
       }
@@ -1074,7 +1074,7 @@ int mutt_lookup_mime_type(struct Body *att, const char *path)
   FILE *f = NULL;
   char *p = NULL, *q = NULL, *ct = NULL;
   char buf[PATH_MAX];
-  char subtype[STRING], xtype[STRING];
+  char subtype[256], xtype[256];
   int szf, sze, cur_sze;
   int type;
   bool found_mimetypes = false;
@@ -1432,7 +1432,7 @@ char *mutt_body_get_charset(struct Body *b, char *buf, size_t buflen)
 void mutt_update_encoding(struct Body *a)
 {
   struct Content *info = NULL;
-  char chsbuf[STRING];
+  char chsbuf[256];
 
   /* override noconv when it's us-ascii */
   if (mutt_ch_is_us_ascii(mutt_body_get_charset(a, chsbuf, sizeof(chsbuf))))
@@ -3016,7 +3016,7 @@ int mutt_bounce_message(FILE *fp, struct Email *e, struct Address *to)
     return -1;
 
   const char *fqdn = mutt_fqdn(true);
-  char resent_from[STRING];
+  char resent_from[256];
   char *err = NULL;
 
   resent_from[0] = '\0';

--- a/sidebar.c
+++ b/sidebar.c
@@ -70,7 +70,7 @@ static short PreviousSort = SORT_ORDER; /* sidebar_sort_method */
  */
 struct SbEntry
 {
-  char box[STRING];        /**< formatted mailbox name */
+  char box[256];           /**< formatted mailbox name */
   struct Mailbox *mailbox; /**< Mailbox this represents */
   bool is_hidden;          /**< Don't show, e.g. $sidebar_new_mail_only */
 };
@@ -117,7 +117,7 @@ static const char *sidebar_format_str(char *buf, size_t buflen, size_t col, int 
 {
   struct SbEntry *sbe = (struct SbEntry *) data;
   unsigned int optional;
-  char fmt[STRING];
+  char fmt[256];
 
   if (!sbe || !buf)
     return src;
@@ -934,7 +934,7 @@ static void draw_sidebar(int num_rows, int num_cols, int div_width)
         mutt_str_strcat(sidebar_folder_name, sfn_len, tmp_folder_name);
       }
     }
-    char str[STRING];
+    char str[256];
     make_sidebar_entry(str, sizeof(str), w, sidebar_folder_name, entry);
     printw("%s", str);
     if (sidebar_folder_depth > 0)

--- a/smtp.c
+++ b/smtp.c
@@ -364,7 +364,7 @@ static int smtp_fill_account(struct ConnAccount *account)
  */
 static int smtp_helo(struct Connection *conn, bool esmtp)
 {
-  char buf[LONG_STRING];
+  char buf[1024];
   const char *fqdn = NULL;
 
   Capabilities = 0;
@@ -433,7 +433,7 @@ static int smtp_auth_sasl(struct Connection *conn, const char *mechlist)
   if (!OptNoCurses)
     mutt_message(_("Authenticating (%s)..."), mech);
 
-  bufsize = ((len * 2) > LONG_STRING) ? (len * 2) : LONG_STRING;
+  bufsize = MAX((len * 2), 1024);
   buf = mutt_mem_malloc(bufsize);
 
   snprintf(buf, bufsize, "AUTH %s", mech);
@@ -543,7 +543,7 @@ static int smtp_auth_oauth(struct Connection *conn)
  */
 static int smtp_auth_plain(struct Connection *conn)
 {
-  char buf[LONG_STRING];
+  char buf[1024];
 
   /* Get username and password. Bail out of any cannot be retrieved. */
   if ((mutt_account_getuser(&conn->account) < 0) ||

--- a/sort.c
+++ b/sort.c
@@ -174,11 +174,11 @@ static int compare_to(const void *a, const void *b)
 {
   struct Email **ppa = (struct Email **) a;
   struct Email **ppb = (struct Email **) b;
-  char fa[SHORT_STRING];
+  char fa[128];
 
-  mutt_str_strfcpy(fa, mutt_get_name((*ppa)->env->to), SHORT_STRING);
+  mutt_str_strfcpy(fa, mutt_get_name((*ppa)->env->to), sizeof(fa));
   const char *fb = mutt_get_name((*ppb)->env->to);
-  int result = mutt_str_strncasecmp(fa, fb, SHORT_STRING);
+  int result = mutt_str_strncasecmp(fa, fb, sizeof(fa));
   result = perform_auxsort(result, a, b);
   return SORTCODE(result);
 }
@@ -190,11 +190,11 @@ static int compare_from(const void *a, const void *b)
 {
   struct Email **ppa = (struct Email **) a;
   struct Email **ppb = (struct Email **) b;
-  char fa[SHORT_STRING];
+  char fa[128];
 
-  mutt_str_strfcpy(fa, mutt_get_name((*ppa)->env->from), SHORT_STRING);
+  mutt_str_strfcpy(fa, mutt_get_name((*ppa)->env->from), sizeof(fa));
   const char *fb = mutt_get_name((*ppb)->env->from);
-  int result = mutt_str_strncasecmp(fa, fb, SHORT_STRING);
+  int result = mutt_str_strncasecmp(fa, fb, sizeof(fa));
   result = perform_auxsort(result, a, b);
   return SORTCODE(result);
 }

--- a/status.c
+++ b/status.c
@@ -92,7 +92,7 @@ static const char *status_format_str(char *buf, size_t buflen, size_t col, int c
                                      const char *if_str, const char *else_str,
                                      unsigned long data, int flags)
 {
-  char fmt[SHORT_STRING], tmp[SHORT_STRING], *cp = NULL;
+  char fmt[128], tmp[128], *cp = NULL;
   int count, optional = (flags & MUTT_FORMAT_OPTIONAL);
   struct Menu *menu = (struct Menu *) data;
 

--- a/test/config/account.c
+++ b/test/config/account.c
@@ -48,8 +48,8 @@ void config_account(void)
 
   struct Buffer err;
   mutt_buffer_init(&err);
-  err.data = mutt_mem_calloc(1, STRING);
-  err.dsize = STRING;
+  err.dsize = 256;
+  err.data = mutt_mem_calloc(1, err.dsize);
   mutt_buffer_reset(&err);
 
   struct ConfigSet *cs = cs_new(30);

--- a/test/config/address.c
+++ b/test/config/address.c
@@ -99,8 +99,8 @@ static bool test_initial_values(struct ConfigSet *cs, struct Buffer *err)
 
   struct Buffer value;
   mutt_buffer_init(&value);
-  value.data = mutt_mem_calloc(1, STRING);
-  value.dsize = STRING;
+  value.dsize = 256;
+  value.data = mutt_mem_calloc(1, value.dsize);
   mutt_buffer_reset(&value);
 
   int rc;
@@ -599,8 +599,8 @@ void config_address(void)
 {
   struct Buffer err;
   mutt_buffer_init(&err);
-  err.data = mutt_mem_calloc(1, STRING);
-  err.dsize = STRING;
+  err.dsize = 256;
+  err.data = mutt_mem_calloc(1, err.dsize);
   mutt_buffer_reset(&err);
 
   struct ConfigSet *cs = cs_new(30);

--- a/test/config/bool.c
+++ b/test/config/bool.c
@@ -91,8 +91,8 @@ static bool test_initial_values(struct ConfigSet *cs, struct Buffer *err)
 
   struct Buffer value;
   mutt_buffer_init(&value);
-  value.data = mutt_mem_calloc(1, STRING);
-  value.dsize = STRING;
+  value.dsize = 256;
+  value.data = mutt_mem_calloc(1, value.dsize);
 
   int rc;
 
@@ -715,8 +715,8 @@ void config_bool(void)
 {
   struct Buffer err;
   mutt_buffer_init(&err);
-  err.data = mutt_mem_calloc(1, STRING);
-  err.dsize = STRING;
+  err.dsize = 256;
+  err.data = mutt_mem_calloc(1, err.dsize);
   mutt_buffer_reset(&err);
 
   struct ConfigSet *cs = cs_new(30);

--- a/test/config/command.c
+++ b/test/config/command.c
@@ -98,8 +98,8 @@ static bool test_initial_values(struct ConfigSet *cs, struct Buffer *err)
 
   struct Buffer value;
   mutt_buffer_init(&value);
-  value.data = mutt_mem_calloc(1, STRING);
-  value.dsize = STRING;
+  value.dsize = 256;
+  value.data = mutt_mem_calloc(1, value.dsize);
   mutt_buffer_reset(&value);
 
   int rc;
@@ -626,8 +626,8 @@ void config_command(void)
 {
   struct Buffer err;
   mutt_buffer_init(&err);
-  err.data = mutt_mem_calloc(1, STRING);
-  err.dsize = STRING;
+  err.dsize = 256;
+  err.data = mutt_mem_calloc(1, err.dsize);
   mutt_buffer_reset(&err);
 
   struct ConfigSet *cs = cs_new(30);

--- a/test/config/common.c
+++ b/test/config/common.c
@@ -86,8 +86,8 @@ bool log_listener(const struct ConfigSet *cs, struct HashElem *he,
 {
   struct Buffer result;
   mutt_buffer_init(&result);
-  result.data = mutt_mem_calloc(1, STRING);
-  result.dsize = STRING;
+  result.dsize = 256;
+  result.data = mutt_mem_calloc(1, result.dsize);
 
   const char *events[] = { "set", "reset", "initial-set" };
 
@@ -129,8 +129,8 @@ void cs_dump_set(const struct ConfigSet *cs)
 
   struct Buffer result;
   mutt_buffer_init(&result);
-  result.data = mutt_mem_calloc(1, STRING);
-  result.dsize = STRING;
+  result.dsize = 256;
+  result.data = mutt_mem_calloc(1, result.dsize);
 
   char tmp[128];
   char *list[26] = { 0 };

--- a/test/config/initial.c
+++ b/test/config/initial.c
@@ -93,8 +93,8 @@ void config_initial(void)
 
   struct Buffer err;
   mutt_buffer_init(&err);
-  err.data = mutt_mem_calloc(1, STRING);
-  err.dsize = STRING;
+  err.dsize = 256;
+  err.data = mutt_mem_calloc(1, err.dsize);
   mutt_buffer_reset(&err);
 
   struct ConfigSet *cs = cs_new(30);

--- a/test/config/long.c
+++ b/test/config/long.c
@@ -91,8 +91,8 @@ static bool test_initial_values(struct ConfigSet *cs, struct Buffer *err)
 
   struct Buffer value;
   mutt_buffer_init(&value);
-  value.data = mutt_mem_calloc(1, STRING);
-  value.dsize = STRING;
+  value.dsize = 256;
+  value.data = mutt_mem_calloc(1, value.dsize);
 
   int rc;
 
@@ -577,8 +577,8 @@ void config_long(void)
 {
   struct Buffer err;
   mutt_buffer_init(&err);
-  err.data = mutt_mem_calloc(1, STRING);
-  err.dsize = STRING;
+  err.dsize = 256;
+  err.data = mutt_mem_calloc(1, err.dsize);
   mutt_buffer_reset(&err);
 
   struct ConfigSet *cs = cs_new(30);

--- a/test/config/magic.c
+++ b/test/config/magic.c
@@ -87,8 +87,8 @@ static bool test_initial_values(struct ConfigSet *cs, struct Buffer *err)
 
   struct Buffer value;
   mutt_buffer_init(&value);
-  value.data = mutt_mem_calloc(1, STRING);
-  value.dsize = STRING;
+  value.dsize = 256;
+  value.data = mutt_mem_calloc(1, value.dsize);
   mutt_buffer_reset(&value);
 
   int rc;
@@ -564,8 +564,8 @@ void config_magic(void)
 {
   struct Buffer err;
   mutt_buffer_init(&err);
-  err.data = mutt_mem_calloc(1, STRING);
-  err.dsize = STRING;
+  err.dsize = 256;
+  err.data = mutt_mem_calloc(1, err.dsize);
   mutt_buffer_reset(&err);
 
   struct ConfigSet *cs = cs_new(30);

--- a/test/config/mbtable.c
+++ b/test/config/mbtable.c
@@ -94,8 +94,8 @@ static bool test_initial_values(struct ConfigSet *cs, struct Buffer *err)
 
   struct Buffer value;
   mutt_buffer_init(&value);
-  value.data = mutt_mem_calloc(1, STRING);
-  value.dsize = STRING;
+  value.dsize = 256;
+  value.data = mutt_mem_calloc(1, value.dsize);
   mutt_buffer_reset(&value);
 
   int rc;
@@ -615,8 +615,8 @@ void config_mbtable(void)
 {
   struct Buffer err;
   mutt_buffer_init(&err);
-  err.data = mutt_mem_calloc(1, STRING);
-  err.dsize = STRING;
+  err.dsize = 256;
+  err.data = mutt_mem_calloc(1, err.dsize);
   mutt_buffer_reset(&err);
 
   struct ConfigSet *cs = cs_new(30);

--- a/test/config/number.c
+++ b/test/config/number.c
@@ -91,8 +91,8 @@ static bool test_initial_values(struct ConfigSet *cs, struct Buffer *err)
 
   struct Buffer value;
   mutt_buffer_init(&value);
-  value.data = mutt_mem_calloc(1, STRING);
-  value.dsize = STRING;
+  value.dsize = 256;
+  value.data = mutt_mem_calloc(1, value.dsize);
 
   int rc;
 
@@ -596,8 +596,8 @@ void config_number(void)
 {
   struct Buffer err;
   mutt_buffer_init(&err);
-  err.data = mutt_mem_calloc(1, STRING);
-  err.dsize = STRING;
+  err.dsize = 256;
+  err.data = mutt_mem_calloc(1, err.dsize);
   mutt_buffer_reset(&err);
 
   struct ConfigSet *cs = cs_new(30);

--- a/test/config/path.c
+++ b/test/config/path.c
@@ -98,8 +98,8 @@ static bool test_initial_values(struct ConfigSet *cs, struct Buffer *err)
 
   struct Buffer value;
   mutt_buffer_init(&value);
-  value.data = mutt_mem_calloc(1, STRING);
-  value.dsize = STRING;
+  value.dsize = 256;
+  value.data = mutt_mem_calloc(1, value.dsize);
   mutt_buffer_reset(&value);
 
   int rc;
@@ -626,8 +626,8 @@ void config_path(void)
 {
   struct Buffer err;
   mutt_buffer_init(&err);
-  err.data = mutt_mem_calloc(1, STRING);
-  err.dsize = STRING;
+  err.dsize = 256;
+  err.data = mutt_mem_calloc(1, err.dsize);
   mutt_buffer_reset(&err);
 
   struct ConfigSet *cs = cs_new(30);

--- a/test/config/quad.c
+++ b/test/config/quad.c
@@ -91,8 +91,8 @@ static bool test_initial_values(struct ConfigSet *cs, struct Buffer *err)
 
   struct Buffer value;
   mutt_buffer_init(&value);
-  value.data = mutt_mem_calloc(1, STRING);
-  value.dsize = STRING;
+  value.dsize = 256;
+  value.data = mutt_mem_calloc(1, value.dsize);
 
   int rc;
 
@@ -676,8 +676,8 @@ void config_quad(void)
 {
   struct Buffer err;
   mutt_buffer_init(&err);
-  err.data = mutt_mem_calloc(1, STRING);
-  err.dsize = STRING;
+  err.dsize = 256;
+  err.data = mutt_mem_calloc(1, err.dsize);
   mutt_buffer_reset(&err);
 
   struct ConfigSet *cs = cs_new(30);

--- a/test/config/regex.c
+++ b/test/config/regex.c
@@ -98,8 +98,8 @@ static bool test_initial_values(struct ConfigSet *cs, struct Buffer *err)
 
   struct Buffer value;
   mutt_buffer_init(&value);
-  value.data = mutt_mem_calloc(1, STRING);
-  value.dsize = STRING;
+  value.dsize = 256;
+  value.data = mutt_mem_calloc(1, value.dsize);
   mutt_buffer_reset(&value);
 
   int rc;
@@ -667,8 +667,8 @@ void config_regex(void)
 {
   struct Buffer err;
   mutt_buffer_init(&err);
-  err.data = mutt_mem_calloc(1, STRING);
-  err.dsize = STRING;
+  err.dsize = 256;
+  err.data = mutt_mem_calloc(1, err.dsize);
   mutt_buffer_reset(&err);
 
   struct ConfigSet *cs = cs_new(30);

--- a/test/config/set.c
+++ b/test/config/set.c
@@ -82,8 +82,8 @@ void config_set(void)
 
   struct Buffer err;
   mutt_buffer_init(&err);
-  err.data = mutt_mem_calloc(1, STRING);
-  err.dsize = STRING;
+  err.dsize = 256;
+  err.data = mutt_mem_calloc(1, err.dsize);
   mutt_buffer_reset(&err);
 
   struct ConfigSet *cs = cs_new(30);

--- a/test/config/sort.c
+++ b/test/config/sort.c
@@ -115,8 +115,8 @@ static bool test_initial_values(struct ConfigSet *cs, struct Buffer *err)
 
   struct Buffer value;
   mutt_buffer_init(&value);
-  value.data = mutt_mem_calloc(1, STRING);
-  value.dsize = STRING;
+  value.dsize = 256;
+  value.data = mutt_mem_calloc(1, value.dsize);
   mutt_buffer_reset(&value);
 
   int rc;
@@ -721,8 +721,8 @@ void config_sort(void)
 {
   struct Buffer err;
   mutt_buffer_init(&err);
-  err.data = mutt_mem_calloc(1, STRING);
-  err.dsize = STRING;
+  err.dsize = 256;
+  err.data = mutt_mem_calloc(1, err.dsize);
   mutt_buffer_reset(&err);
 
   struct ConfigSet *cs = cs_new(30);

--- a/test/config/string.c
+++ b/test/config/string.c
@@ -98,8 +98,8 @@ static bool test_initial_values(struct ConfigSet *cs, struct Buffer *err)
 
   struct Buffer value;
   mutt_buffer_init(&value);
-  value.data = mutt_mem_calloc(1, STRING);
-  value.dsize = STRING;
+  value.dsize = 256;
+  value.data = mutt_mem_calloc(1, value.dsize);
   mutt_buffer_reset(&value);
 
   int rc;
@@ -626,8 +626,8 @@ void config_string(void)
 {
   struct Buffer err;
   mutt_buffer_init(&err);
-  err.data = mutt_mem_calloc(1, STRING);
-  err.dsize = STRING;
+  err.dsize = 256;
+  err.data = mutt_mem_calloc(1, err.dsize);
   mutt_buffer_reset(&err);
 
   struct ConfigSet *cs = cs_new(30);

--- a/test/config/synonym.c
+++ b/test/config/synonym.c
@@ -183,8 +183,8 @@ void config_synonym(void)
 
   struct Buffer err;
   mutt_buffer_init(&err);
-  err.data = mutt_mem_calloc(1, STRING);
-  err.dsize = STRING;
+  err.dsize = 256;
+  err.data = mutt_mem_calloc(1, err.dsize);
   mutt_buffer_reset(&err);
 
   struct ConfigSet *cs = cs_new(30);


### PR DESCRIPTION
Following POLL #1572
Constants like `LONG_STRING` aren't meaningful to anyone, so replace them with their numeric equivalents.

The one exception is `HUGE_STRING` (8192 bytes).  A handful of cases refer to a command line string.  They've been marked, for now, as `STR_COMMAND`. 

I considered a constant `STR_MAILBOX` for every mailbox path (they're currently `PATH_MAX` (4096 bytes)), but that will require a bit more analysis first.

---

There are no functional changes.
Occasionally lines have been reordered to reduce duplication, e.g.
```diff
- char *str = malloc(1024);
- int str_size = 1024;
+ int str_size = 1024;
+ char *str = malloc(str_size);
```

I'm not expecting anyone to read the entire diff :-)