### PR TITLE
Use typedef to name flags/bitfields

### DIFF
--- a/addrbook.c
+++ b/addrbook.c
@@ -71,7 +71,7 @@ static const struct Mapping AliasHelp[] = {
 static const char *alias_format_str(char *buf, size_t buflen, size_t col, int cols,
                                     char op, const char *src, const char *prec,
                                     const char *if_str, const char *else_str,
-                                    unsigned long data, int flags)
+                                    unsigned long data, MuttFormatFlags flags)
 {
   char fmt[128], addr[128];
   struct Alias *alias = (struct Alias *) data;

--- a/browser.c
+++ b/browser.c
@@ -358,7 +358,7 @@ static bool link_is_dir(const char *folder, const char *path)
 static const char *folder_format_str(char *buf, size_t buflen, size_t col, int cols,
                                      char op, const char *src, const char *prec,
                                      const char *if_str, const char *else_str,
-                                     unsigned long data, int flags)
+                                     unsigned long data, MuttFormatFlags flags)
 {
   char fn[128], fmt[128], permission[11];
   char *t_fmt = NULL;

--- a/commands.c
+++ b/commands.c
@@ -178,7 +178,7 @@ int mutt_display_message(struct Email *cur)
   int rc = 0;
   bool builtin = false;
   int cmflags = MUTT_CM_DECODE | MUTT_CM_DISPLAY | MUTT_CM_CHARCONV;
-  int chflags;
+  CopyHeaderFlags chflags;
   FILE *fpout = NULL;
   FILE *fpfilterout = NULL;
   pid_t filterpid = -1;
@@ -471,9 +471,9 @@ void ci_bounce_message(struct Mailbox *m, struct EmailList *el)
  * @param[in]  decode  If true decode the message
  * @param[in]  print   If true, mark the message for printing
  * @param[out] cmflags Copy message flags, e.g. MUTT_CM_DECODE
- * @param[out] chflags Copy header flags, e.g. CH_DECODE
+ * @param[out] chflags Flags, see #CopyHeaderFlags
  */
-static void pipe_set_flags(bool decode, bool print, int *cmflags, int *chflags)
+static void pipe_set_flags(bool decode, bool print, int *cmflags, CopyHeaderFlags *chflags)
 {
   if (decode)
   {
@@ -502,7 +502,7 @@ static void pipe_set_flags(bool decode, bool print, int *cmflags, int *chflags)
 static void pipe_msg(struct Mailbox *m, struct Email *e, FILE *fp, bool decode, bool print)
 {
   int cmflags = 0;
-  int chflags = CH_FROM;
+  CopyHeaderFlags chflags = CH_FROM;
 
   pipe_set_flags(decode, print, &cmflags, &chflags);
 
@@ -882,10 +882,10 @@ void mutt_display_address(struct Envelope *env)
  * @param[in]  decode  If true, decode the message
  * @param[in]  decrypt If true, decrypt the message
  * @param[out] cmflags Copy message flags, e.g. MUTT_CM_DECODE
- * @param[out] chflags Copy header flags, e.g. CH_DECODE
+ * @param[out] chflags Flags, see #CopyHeaderFlags
  */
 static void set_copy_flags(struct Email *e, bool decode, bool decrypt,
-                           int *cmflags, int *chflags)
+                           int *cmflags, CopyHeaderFlags *chflags)
 {
   *cmflags = 0;
   *chflags = CH_UPDATE_LEN;
@@ -941,7 +941,8 @@ static void set_copy_flags(struct Email *e, bool decode, bool decrypt,
 int mutt_save_message_ctx(struct Email *e, bool delete, bool decode,
                           bool decrypt, struct Mailbox *m)
 {
-  int cmflags, chflags;
+  int cmflags;
+  CopyHeaderFlags chflags;
   int rc;
 
   set_copy_flags(e, decode, decrypt, &cmflags, &chflags);

--- a/commands.c
+++ b/commands.c
@@ -1276,10 +1276,10 @@ int mutt_edit_content_type(struct Email *e, struct Body *b, FILE *fp)
 /**
  * check_traditional_pgp - Check for an inline PGP content
  * @param[in]  e      Header of message to check
- * @param[out] redraw Set of #REDRAW_FULL if the screen may need redrawing
+ * @param[out] redraw Flags if the screen needs redrawing, see #MuttRedrawFlags
  * @retval true If message contains inline PGP content
  */
-static bool check_traditional_pgp(struct Email *e, int *redraw)
+static bool check_traditional_pgp(struct Email *e, MuttRedrawFlags *redraw)
 {
   bool rc = false;
 
@@ -1304,10 +1304,10 @@ static bool check_traditional_pgp(struct Email *e, int *redraw)
 /**
  * mutt_check_traditional_pgp - Check if a message has inline PGP content
  * @param[in]  el     List of Emails to check
- * @param[out] redraw Set of #REDRAW_FULL if the screen may need redrawing
+ * @param[out] redraw Flags if the screen needs redrawing, see #MuttRedrawFlags
  * @retval true If message contains inline PGP content
  */
-bool mutt_check_traditional_pgp(struct EmailList *el, int *redraw)
+bool mutt_check_traditional_pgp(struct EmailList *el, MuttRedrawFlags *redraw)
 {
   bool rc = false;
   struct EmailNode *en = NULL;

--- a/commands.c
+++ b/commands.c
@@ -177,7 +177,7 @@ int mutt_display_message(struct Email *cur)
   char tempfile[PATH_MAX], buf[1024];
   int rc = 0;
   bool builtin = false;
-  int cmflags = MUTT_CM_DECODE | MUTT_CM_DISPLAY | MUTT_CM_CHARCONV;
+  CopyMessageFlags cmflags = MUTT_CM_DECODE | MUTT_CM_DISPLAY | MUTT_CM_CHARCONV;
   CopyHeaderFlags chflags;
   FILE *fpout = NULL;
   FILE *fpfilterout = NULL;
@@ -470,10 +470,11 @@ void ci_bounce_message(struct Mailbox *m, struct EmailList *el)
  * pipe_set_flags - Generate flags for copy header/message
  * @param[in]  decode  If true decode the message
  * @param[in]  print   If true, mark the message for printing
- * @param[out] cmflags Copy message flags, e.g. MUTT_CM_DECODE
+ * @param[out] cmflags Flags, see #CopyMessageFlags
  * @param[out] chflags Flags, see #CopyHeaderFlags
  */
-static void pipe_set_flags(bool decode, bool print, int *cmflags, CopyHeaderFlags *chflags)
+static void pipe_set_flags(bool decode, bool print, CopyMessageFlags *cmflags,
+                           CopyHeaderFlags *chflags)
 {
   if (decode)
   {
@@ -501,7 +502,7 @@ static void pipe_set_flags(bool decode, bool print, int *cmflags, CopyHeaderFlag
  */
 static void pipe_msg(struct Mailbox *m, struct Email *e, FILE *fp, bool decode, bool print)
 {
-  int cmflags = 0;
+  CopyMessageFlags cmflags = MUTT_CM_NO_FLAGS;
   CopyHeaderFlags chflags = CH_FROM;
 
   pipe_set_flags(decode, print, &cmflags, &chflags);
@@ -881,13 +882,13 @@ void mutt_display_address(struct Envelope *env)
  * @param[in]  e       Email
  * @param[in]  decode  If true, decode the message
  * @param[in]  decrypt If true, decrypt the message
- * @param[out] cmflags Copy message flags, e.g. MUTT_CM_DECODE
+ * @param[out] cmflags Flags, see #CopyMessageFlags
  * @param[out] chflags Flags, see #CopyHeaderFlags
  */
 static void set_copy_flags(struct Email *e, bool decode, bool decrypt,
-                           int *cmflags, CopyHeaderFlags *chflags)
+                           CopyMessageFlags *cmflags, CopyHeaderFlags *chflags)
 {
-  *cmflags = 0;
+  *cmflags = MUTT_CM_NO_FLAGS;
   *chflags = CH_UPDATE_LEN;
 
   if ((WithCrypto != 0) && !decode && decrypt && (e->security & SEC_ENCRYPT))
@@ -941,8 +942,8 @@ static void set_copy_flags(struct Email *e, bool decode, bool decrypt,
 int mutt_save_message_ctx(struct Email *e, bool delete, bool decode,
                           bool decrypt, struct Mailbox *m)
 {
-  int cmflags;
-  CopyHeaderFlags chflags;
+  CopyMessageFlags cmflags = MUTT_CM_NO_FLAGS;
+  CopyHeaderFlags chflags = CH_NO_FLAGS;
   int rc;
 
   set_copy_flags(e, decode, decrypt, &cmflags, &chflags);

--- a/commands.h
+++ b/commands.h
@@ -25,6 +25,7 @@
 
 #include <stdbool.h>
 #include <stdio.h>
+#include "mutt_menu.h"
 
 struct Body;
 struct Email;
@@ -44,7 +45,7 @@ extern bool          C_PromptAfter;
 
 void ci_bounce_message(struct Mailbox *m, struct EmailList *el);
 void mutt_check_stats(void);
-bool mutt_check_traditional_pgp(struct EmailList *el, int *redraw);
+bool mutt_check_traditional_pgp(struct EmailList *el, MuttRedrawFlags *redraw);
 void mutt_display_address(struct Envelope *env);
 int  mutt_display_message(struct Email *cur);
 int  mutt_edit_content_type(struct Email *e, struct Body *b, FILE *fp);

--- a/compose.c
+++ b/compose.c
@@ -811,7 +811,7 @@ static unsigned long cum_attachs_size(struct Menu *menu)
 static const char *compose_format_str(char *buf, size_t buflen, size_t col, int cols,
                                       char op, const char *src, const char *prec,
                                       const char *if_str, const char *else_str,
-                                      unsigned long data, int flags)
+                                      unsigned long data, MuttFormatFlags flags)
 {
   char fmt[128], tmp[128];
   int optional = (flags & MUTT_FORMAT_OPTIONAL);

--- a/compress.c
+++ b/compress.c
@@ -517,7 +517,7 @@ cmo_fail:
  * To append to a compressed mailbox we need an append-hook (or both open- and
  * close-hooks).
  */
-static int comp_mbox_open_append(struct Mailbox *m, int flags)
+static int comp_mbox_open_append(struct Mailbox *m, OpenMailboxFlags flags)
 {
   if (!m)
     return -1;

--- a/compress.c
+++ b/compress.c
@@ -172,7 +172,7 @@ static void store_size(const struct Mailbox *m)
 
 /**
  * find_hook - Find a hook to match a path
- * @param type Type of hook, e.g. #MUTT_CLOSE_HOOK
+ * @param type Type of hook, see #HookFlags
  * @param path Filename to test
  * @retval ptr  Matching hook command
  * @retval NULL No matches
@@ -186,7 +186,7 @@ static void store_size(const struct Mailbox *m)
  * Call:
  *      find_hook (#MUTT_OPEN_HOOK, "myfile.gz");
  */
-static const char *find_hook(int type, const char *path)
+static const char *find_hook(HookFlags type, const char *path)
 {
   if (!path)
     return NULL;

--- a/compress.c
+++ b/compress.c
@@ -262,7 +262,7 @@ static void free_compress_info(struct Mailbox *m)
 static const char *compress_format_str(char *buf, size_t buflen, size_t col, int cols,
                                        char op, const char *src, const char *prec,
                                        const char *if_str, const char *else_str,
-                                       unsigned long data, int flags)
+                                       unsigned long data, MuttFormatFlags flags)
 {
   if (!buf || (data == 0))
     return src;

--- a/config/dump.c
+++ b/config/dump.c
@@ -150,11 +150,11 @@ struct HashElem **get_elem_list(struct ConfigSet *cs)
  * @param he      HashElem representing config item
  * @param value   Current value of the config item
  * @param initial Initial value of the config item
- * @param flags   Flags, e.g. #CS_DUMP_ONLY_CHANGED
+ * @param flags   Flags, see #ConfigDumpFlags
  * @param fp      File pointer to write to
  */
 void dump_config_mutt(struct ConfigSet *cs, struct HashElem *he, struct Buffer *value,
-                      struct Buffer *initial, int flags, FILE *fp)
+                      struct Buffer *initial, ConfigDumpFlags flags, FILE *fp)
 {
   const char *name = he->key.strkey;
 
@@ -181,11 +181,11 @@ void dump_config_mutt(struct ConfigSet *cs, struct HashElem *he, struct Buffer *
  * @param he      HashElem representing config item
  * @param value   Current value of the config item
  * @param initial Initial value of the config item
- * @param flags   Flags, e.g. #CS_DUMP_ONLY_CHANGED
+ * @param flags   Flags, see #ConfigDumpFlags
  * @param fp      File pointer to write to
  */
 void dump_config_neo(struct ConfigSet *cs, struct HashElem *he, struct Buffer *value,
-                     struct Buffer *initial, int flags, FILE *fp)
+                     struct Buffer *initial, ConfigDumpFlags flags, FILE *fp)
 {
   const char *name = he->key.strkey;
 
@@ -226,10 +226,11 @@ void dump_config_neo(struct ConfigSet *cs, struct HashElem *he, struct Buffer *v
  * dump_config - Write all the config to a file
  * @param cs    ConfigSet to dump
  * @param style Output style, e.g. #CS_DUMP_STYLE_MUTT
- * @param flags Display flags, e.g. #CS_DUMP_ONLY_CHANGED
+ * @param flags Flags, see #ConfigDumpFlags
  * @param fp    File to write config to
  */
-bool dump_config(struct ConfigSet *cs, enum CsDumpStyle style, int flags, FILE *fp)
+bool dump_config(struct ConfigSet *cs, enum CsDumpStyle style,
+                 ConfigDumpFlags flags, FILE *fp)
 {
   if (!cs)
     return false;

--- a/config/dump.h
+++ b/config/dump.h
@@ -40,6 +40,8 @@ enum CsDumpStyle
   CS_DUMP_STYLE_NEO,   ///< Display config in NeoMutt style
 };
 
+typedef uint8_t ConfigDumpFlags;        ///< Flags for dump_config(), e.g. #CS_DUMP_ONLY_CHANGED
+#define CS_DUMP_NO_FLAGS             0  ///< No flags are set
 #define CS_DUMP_ONLY_CHANGED   (1 << 0) ///< Only show config that the user has changed
 #define CS_DUMP_HIDE_SENSITIVE (1 << 1) ///< Obscure sensitive information like passwords
 #define CS_DUMP_NO_ESCAPING    (1 << 2) ///< Do not escape special chars, or quote the string
@@ -49,9 +51,9 @@ enum CsDumpStyle
 #define CS_DUMP_SHOW_DISABLED  (1 << 6) ///< Show disabled config items, too
 #define CS_DUMP_SHOW_SYNONYMS  (1 << 7) ///< Show synonyms and the config items their linked to
 
-void              dump_config_mutt(struct ConfigSet *cs, struct HashElem *he, struct Buffer *value, struct Buffer *initial, int flags, FILE *fp);
-void              dump_config_neo(struct ConfigSet *cs, struct HashElem *he, struct Buffer *value, struct Buffer *initial, int flags, FILE *fp);
-bool              dump_config(struct ConfigSet *cs, enum CsDumpStyle style, int flags, FILE *fp);
+void              dump_config_mutt(struct ConfigSet *cs, struct HashElem *he, struct Buffer *value, struct Buffer *initial, ConfigDumpFlags flags, FILE *fp);
+void              dump_config_neo(struct ConfigSet *cs, struct HashElem *he, struct Buffer *value, struct Buffer *initial, ConfigDumpFlags flags, FILE *fp);
+bool              dump_config(struct ConfigSet *cs, enum CsDumpStyle style, ConfigDumpFlags flags, FILE *fp);
 int               elem_list_sort(const void *a, const void *b);
 size_t            escape_string(struct Buffer *buf, const char *src);
 struct HashElem **get_elem_list(struct ConfigSet *cs);

--- a/config/set.h
+++ b/config/set.h
@@ -162,7 +162,7 @@ struct ConfigDef
 {
   const char   *name;      /**< User-visible name */
   unsigned int  type;      /**< Variable type, e.g. #DT_STRING */
-  intptr_t      flags;     /**< Notification flags, e.g. #R_PAGER */
+  intptr_t      flags;     /**< Notification flags, see #ConfigRedrawFlags */
   void         *var;       /**< Pointer to the global variable */
   intptr_t      initial;   /**< Initial value */
   cs_validator  validator; /**< Validator callback function */

--- a/config/types.h
+++ b/config/types.h
@@ -54,8 +54,8 @@
 #define DT_DISABLED     0x4000 /**< Config item is disabled */
 #define DT_MY_CONFIG    0x8000 /**< Config item is a "my_" variable */
 
-/* forced redraw/resort types + other flags */
-#define R_NONE        0             ///< No refresh/resort flags
+typedef uint16_t ConfigRedrawFlags; ///< Flags for redraw/resort, e.g. #R_INDEX
+#define R_NONE              0       ///< No refresh/resort flags
 #define R_INDEX       (1 << 0)      ///< Redraw the index menu (MENU_MAIN)
 #define R_PAGER       (1 << 1)      ///< Redraw the pager menu
 #define R_PAGER_FLOW  (1 << 2)      ///< Reflow line_info and redraw the pager menu

--- a/conn/connaccount.h
+++ b/conn/connaccount.h
@@ -23,6 +23,8 @@
 #ifndef MUTT_CONN_ACCOUNT_H
 #define MUTT_CONN_ACCOUNT_H
 
+#include "mutt_account.h"
+
 /**
  * struct ConnAccount - Login details for a remote server
  */
@@ -33,8 +35,8 @@ struct ConnAccount
   char pass[256];
   char host[128];
   unsigned short port;
-  unsigned char type;  ///< Connection type, e.g. #MUTT_ACCT_TYPE_IMAP
-  unsigned char flags; ///< Which fields are initialised, e.g. #MUTT_ACCT_USER
+  unsigned char type;     ///< Connection type, e.g. #MUTT_ACCT_TYPE_IMAP
+  MuttAccountFlags flags; ///< Which fields are initialised, e.g. #MUTT_ACCT_USER
 };
 
 #endif /* MUTT_CONN_ACCOUNT_H */

--- a/copy.c
+++ b/copy.c
@@ -584,12 +584,13 @@ static int count_delete_lines(FILE *fp, struct Body *b, LOFF_T *length, size_t d
  * @param fpout   Where to write output
  * @param fpin    Where to get input
  * @param e       Email being copied
- * @param cmflags Flags, e.g. #MUTT_CM_NOHEADER
+ * @param cmflags Flags, see #CopyMessageFlags
  * @param chflags Flags, see #CopyHeaderFlags
  * @retval  0 Success
  * @retval -1 Failure
  */
-int mutt_copy_message_fp(FILE *fpout, FILE *fpin, struct Email *e, int cmflags, CopyHeaderFlags chflags)
+int mutt_copy_message_fp(FILE *fpout, FILE *fpin, struct Email *e,
+                         CopyMessageFlags cmflags, CopyHeaderFlags chflags)
 {
   struct Body *body = e->content;
   char prefix[128];
@@ -787,7 +788,7 @@ int mutt_copy_message_fp(FILE *fpout, FILE *fpin, struct Email *e, int cmflags, 
  * @param fpout   FILE pointer to write to
  * @param src     Source mailbox
  * @param e       Email
- * @param cmflags Flags, see: mutt_copy_message_fp()
+ * @param cmflags Flags, see #CopyMessageFlags
  * @param chflags Flags, see #CopyHeaderFlags
  * @retval  0 Success
  * @retval -1 Failure
@@ -796,7 +797,7 @@ int mutt_copy_message_fp(FILE *fpout, FILE *fpin, struct Email *e, int cmflags, 
  * like partial decode, where it is worth displaying as much as possible
  */
 int mutt_copy_message_ctx(FILE *fpout, struct Mailbox *src, struct Email *e,
-                          int cmflags, CopyHeaderFlags chflags)
+                          CopyMessageFlags cmflags, CopyHeaderFlags chflags)
 {
   struct Message *msg = mx_msg_open(src, e->msgno);
   if (!msg)
@@ -819,13 +820,13 @@ int mutt_copy_message_ctx(FILE *fpout, struct Mailbox *src, struct Email *e,
  * @param fpin    where to get input
  * @param src     source mailbox
  * @param e       Email being copied
- * @param cmflags mutt_open_copy_message() flags
+ * @param cmflags Flags, see #CopyMessageFlags
  * @param chflags Flags, see #CopyHeaderFlags
  * @retval  0 Success
  * @retval -1 Error
  */
 static int append_message(struct Mailbox *dest, FILE *fpin, struct Mailbox *src,
-                          struct Email *e, int cmflags, CopyHeaderFlags chflags)
+                          struct Email *e, CopyMessageFlags cmflags, CopyHeaderFlags chflags)
 {
   char buf[256];
   struct Message *msg = NULL;
@@ -860,13 +861,13 @@ static int append_message(struct Mailbox *dest, FILE *fpin, struct Mailbox *src,
  * @param dest    Destination Mailbox
  * @param src     Source Mailbox
  * @param e       Email
- * @param cmflags mutt_open_copy_message() flags
+ * @param cmflags Flags, see #CopyMessageFlags
  * @param chflags Flags, see #CopyHeaderFlags
  * @retval  0 Success
  * @retval -1 Failure
  */
-int mutt_append_message(struct Mailbox *dest, struct Mailbox *src,
-                        struct Email *e, int cmflags, CopyHeaderFlags chflags)
+int mutt_append_message(struct Mailbox *dest, struct Mailbox *src, struct Email *e,
+                        CopyMessageFlags cmflags, CopyHeaderFlags chflags)
 {
   struct Message *msg = mx_msg_open(src, e->msgno);
   if (!msg)

--- a/copy.c
+++ b/copy.c
@@ -60,7 +60,7 @@ static int copy_delete_attach(struct Body *b, FILE *fpin, FILE *fpout, char *dat
  * @param out       FILE pointer to write to
  * @param off_start Offset to start from
  * @param off_end   Offset to finish at
- * @param chflags   Flags (see below)
+ * @param chflags   Flags, see #CopyHeaderFlags
  * @param prefix    Prefix for quoting headers
  * @retval  0 Success
  * @retval -1 Failure
@@ -70,7 +70,7 @@ static int copy_delete_attach(struct Body *b, FILE *fpin, FILE *fpout, char *dat
  * wrap headers much more aggressively than the other one.
  */
 int mutt_copy_hdr(FILE *in, FILE *out, LOFF_T off_start, LOFF_T off_end,
-                  int chflags, const char *prefix)
+                  CopyHeaderFlags chflags, const char *prefix)
 {
   bool from = false;
   bool this_is_from = false;
@@ -348,7 +348,8 @@ int mutt_copy_hdr(FILE *in, FILE *out, LOFF_T off_start, LOFF_T off_end,
       if (chflags & (CH_DECODE | CH_PREFIX))
       {
         if (mutt_write_one_header(out, 0, headers[x], (chflags & CH_PREFIX) ? prefix : 0,
-                                  mutt_window_wrap_cols(MuttIndexWindow, C_Wrap), chflags) == -1)
+                                  mutt_window_wrap_cols(MuttIndexWindow, C_Wrap),
+                                  chflags) == -1)
         {
           error = true;
           break;
@@ -381,21 +382,22 @@ int mutt_copy_hdr(FILE *in, FILE *out, LOFF_T off_start, LOFF_T off_end,
  * @param in       FILE pointer to read from
  * @param e        Email
  * @param out      FILE pointer to write to
- * @param chflags  Flags, e.g. #CH_DECODE
+ * @param chflags  See #CopyHeaderFlags
  * @param prefix   Prefix for quoting headers (if #CH_PREFIX is set)
  * @retval  0 Success
  * @retval -1 Failure
  */
-int mutt_copy_header(FILE *in, struct Email *e, FILE *out, int chflags, const char *prefix)
+int mutt_copy_header(FILE *in, struct Email *e, FILE *out,
+                     CopyHeaderFlags chflags, const char *prefix)
 {
   char *temp_hdr = NULL;
 
   if (e->env)
   {
     chflags |= ((e->env->changed & MUTT_ENV_CHANGED_IRT) ? CH_UPDATE_IRT : 0) |
-             ((e->env->changed & MUTT_ENV_CHANGED_REFS) ? CH_UPDATE_REFS : 0) |
-             ((e->env->changed & MUTT_ENV_CHANGED_XLABEL) ? CH_UPDATE_LABEL : 0) |
-             ((e->env->changed & MUTT_ENV_CHANGED_SUBJECT) ? CH_UPDATE_SUBJECT : 0);
+               ((e->env->changed & MUTT_ENV_CHANGED_REFS) ? CH_UPDATE_REFS : 0) |
+               ((e->env->changed & MUTT_ENV_CHANGED_XLABEL) ? CH_UPDATE_LABEL : 0) |
+               ((e->env->changed & MUTT_ENV_CHANGED_SUBJECT) ? CH_UPDATE_SUBJECT : 0);
   }
 
   if (mutt_copy_hdr(in, out, e->offset, e->content->offset, chflags, prefix) == -1)
@@ -583,11 +585,11 @@ static int count_delete_lines(FILE *fp, struct Body *b, LOFF_T *length, size_t d
  * @param fpin    Where to get input
  * @param e       Email being copied
  * @param cmflags Flags, e.g. #MUTT_CM_NOHEADER
- * @param chflags Flags to mutt_copy_header()
+ * @param chflags Flags, see #CopyHeaderFlags
  * @retval  0 Success
  * @retval -1 Failure
  */
-int mutt_copy_message_fp(FILE *fpout, FILE *fpin, struct Email *e, int cmflags, int chflags)
+int mutt_copy_message_fp(FILE *fpout, FILE *fpin, struct Email *e, int cmflags, CopyHeaderFlags chflags)
 {
   struct Body *body = e->content;
   char prefix[128];
@@ -786,7 +788,7 @@ int mutt_copy_message_fp(FILE *fpout, FILE *fpin, struct Email *e, int cmflags, 
  * @param src     Source mailbox
  * @param e       Email
  * @param cmflags Flags, see: mutt_copy_message_fp()
- * @param chflags Header flags, see: mutt_copy_header()
+ * @param chflags Flags, see #CopyHeaderFlags
  * @retval  0 Success
  * @retval -1 Failure
  *
@@ -794,7 +796,7 @@ int mutt_copy_message_fp(FILE *fpout, FILE *fpin, struct Email *e, int cmflags, 
  * like partial decode, where it is worth displaying as much as possible
  */
 int mutt_copy_message_ctx(FILE *fpout, struct Mailbox *src, struct Email *e,
-                          int cmflags, int chflags)
+                          int cmflags, CopyHeaderFlags chflags)
 {
   struct Message *msg = mx_msg_open(src, e->msgno);
   if (!msg)
@@ -818,12 +820,12 @@ int mutt_copy_message_ctx(FILE *fpout, struct Mailbox *src, struct Email *e,
  * @param src     source mailbox
  * @param e       Email being copied
  * @param cmflags mutt_open_copy_message() flags
- * @param chflags mutt_copy_header() flags
+ * @param chflags Flags, see #CopyHeaderFlags
  * @retval  0 Success
  * @retval -1 Error
  */
 static int append_message(struct Mailbox *dest, FILE *fpin, struct Mailbox *src,
-                          struct Email *e, int cmflags, int chflags)
+                          struct Email *e, int cmflags, CopyHeaderFlags chflags)
 {
   char buf[256];
   struct Message *msg = NULL;
@@ -858,13 +860,13 @@ static int append_message(struct Mailbox *dest, FILE *fpin, struct Mailbox *src,
  * @param dest    Destination Mailbox
  * @param src     Source Mailbox
  * @param e       Email
- * @param cmflags mutt_open_copy_message() cmflags
- * @param chflags mutt_copy_header() cmflags
+ * @param cmflags mutt_open_copy_message() flags
+ * @param chflags Flags, see #CopyHeaderFlags
  * @retval  0 Success
  * @retval -1 Failure
  */
 int mutt_append_message(struct Mailbox *dest, struct Mailbox *src,
-                        struct Email *e, int cmflags, int chflags)
+                        struct Email *e, int cmflags, CopyHeaderFlags chflags)
 {
   struct Message *msg = mx_msg_open(src, e->msgno);
   if (!msg)

--- a/copy.h
+++ b/copy.h
@@ -43,7 +43,8 @@ struct Mailbox;
 #define MUTT_CM_VERIFY       (1 << 11) ///< Do signature verification
 #define MUTT_CM_DECODE_CRYPT (MUTT_CM_DECODE_PGP | MUTT_CM_DECODE_SMIME)
 
-/* flags for mutt_copy_header() */
+typedef uint32_t CopyHeaderFlags;   ///< Flags for mutt_copy_header(), e.g. #CH_UPDATE
+#define CH_NO_FLAGS             0   ///< No flags are set
 #define CH_UPDATE         (1 << 0)  ///< Update the status and x-status fields?
 #define CH_WEED           (1 << 1)  ///< Weed the headers?
 #define CH_DECODE         (1 << 2)  ///< Do RFC2047 header decoding
@@ -67,14 +68,13 @@ struct Mailbox;
 #define CH_UPDATE_SUBJECT (1 << 20) ///< Update Subject: protected header update
 #define CH_VIRTUAL        (1 << 21) ///< Write virtual header lines too
 
-int mutt_copy_hdr(FILE *in, FILE *out, LOFF_T off_start, LOFF_T off_end,
-                  int chflags, const char *prefix);
+int mutt_copy_hdr(FILE *in, FILE *out, LOFF_T off_start, LOFF_T off_end, CopyHeaderFlags chflags, const char *prefix);
 
-int mutt_copy_header(FILE *in, struct Email *e, FILE *out, int chflags, const char *prefix);
+int mutt_copy_header(FILE *in, struct Email *e, FILE *out, CopyHeaderFlags chflags, const char *prefix);
 
-int mutt_copy_message_fp(FILE *fpout, FILE *fpin,           struct Email *e, int cmflags, int chflags);
-int mutt_copy_message_ctx(FILE *fpout, struct Mailbox *src, struct Email *e, int cmflags, int chflags);
+int mutt_copy_message_fp(FILE *fpout, FILE *fpin,           struct Email *e, int cmflags, CopyHeaderFlags chflags);
+int mutt_copy_message_ctx(FILE *fpout, struct Mailbox *src, struct Email *e, int cmflags, CopyHeaderFlags chflags);
 
-int mutt_append_message(struct Mailbox *dest, struct Mailbox *src, struct Email *e, int cmflags, int chflags);
+int mutt_append_message(struct Mailbox *dest, struct Mailbox *src, struct Email *e, int cmflags, CopyHeaderFlags chflags);
 
 #endif /* MUTT_COPY_H */

--- a/copy.h
+++ b/copy.h
@@ -28,7 +28,8 @@
 struct Email;
 struct Mailbox;
 
-/**< flags to mutt_copy_message */
+typedef uint16_t CopyMessageFlags;     ///< Flags for mutt_copy_message(), e.g. #MUTT_CM_NOHEADER
+#define MUTT_CM_NO_FLAGS           0   ///< No flags are set
 #define MUTT_CM_NOHEADER     (1 << 0)  ///< Don't copy the message header
 #define MUTT_CM_PREFIX       (1 << 1)  ///< Quote the header and body
 #define MUTT_CM_DECODE       (1 << 2)  ///< Decode the message body into text/plain
@@ -72,9 +73,9 @@ int mutt_copy_hdr(FILE *in, FILE *out, LOFF_T off_start, LOFF_T off_end, CopyHea
 
 int mutt_copy_header(FILE *in, struct Email *e, FILE *out, CopyHeaderFlags chflags, const char *prefix);
 
-int mutt_copy_message_fp(FILE *fpout, FILE *fpin,           struct Email *e, int cmflags, CopyHeaderFlags chflags);
-int mutt_copy_message_ctx(FILE *fpout, struct Mailbox *src, struct Email *e, int cmflags, CopyHeaderFlags chflags);
+int mutt_copy_message_fp(FILE *fpout, FILE *fpin,           struct Email *e, CopyMessageFlags cmflags, CopyHeaderFlags chflags);
+int mutt_copy_message_ctx(FILE *fpout, struct Mailbox *src, struct Email *e, CopyMessageFlags cmflags, CopyHeaderFlags chflags);
 
-int mutt_append_message(struct Mailbox *dest, struct Mailbox *src, struct Email *e, int cmflags, CopyHeaderFlags chflags);
+int mutt_append_message(struct Mailbox *dest, struct Mailbox *src, struct Email *e, CopyMessageFlags cmflags, CopyHeaderFlags chflags);
 
 #endif /* MUTT_COPY_H */

--- a/curs_lib.c
+++ b/curs_lib.c
@@ -562,12 +562,13 @@ int mutt_any_key_to_continue(const char *s)
  * mutt_do_pager - Display some page-able text to the user
  * @param banner   Message for status bar
  * @param tempfile File to display
- * @param do_color Flags, e.g. #MUTT_PAGER_MESSAGE
+ * @param do_color Flags, see #PagerFlags
  * @param info     Info about current mailbox (OPTIONAL)
  * @retval  0 Success
  * @retval -1 Error
  */
-int mutt_do_pager(const char *banner, const char *tempfile, int do_color, struct Pager *info)
+int mutt_do_pager(const char *banner, const char *tempfile, PagerFlags do_color,
+                  struct Pager *info)
 {
   int rc;
 

--- a/curs_lib.c
+++ b/curs_lib.c
@@ -240,7 +240,7 @@ struct Event mutt_getch(void)
  * @param[in]  field    Prompt
  * @param[in]  buf      Buffer for the result
  * @param[in]  buflen   Length of buffer
- * @param[in]  complete Flags for completion, e.g. #MUTT_FILE
+ * @param[in]  complete Flags, see #CompletionFlags
  * @param[in]  multiple Allow multiple selections
  * @param[out] files    List of files selected
  * @param[out] numfiles Number of files selected
@@ -248,8 +248,8 @@ struct Event mutt_getch(void)
  * @retval 0  Selection made
  * @retval -1 Aborted
  */
-int mutt_get_field_full(const char *field, char *buf, size_t buflen,
-                        int complete, bool multiple, char ***files, int *numfiles)
+int mutt_get_field_full(const char *field, char *buf, size_t buflen, CompletionFlags complete,
+                        bool multiple, char ***files, int *numfiles)
 {
   int ret;
   int x;
@@ -284,12 +284,12 @@ int mutt_get_field_full(const char *field, char *buf, size_t buflen,
  * @param msg    Prompt
  * @param buf    Buffer for the result
  * @param buflen Length of buffer
- * @param flags  Flags for completion, e.g. #MUTT_FILE
+ * @param flags  Flags, see #CompletionFlags
  * @retval 1  Redraw the screen and call the function again
  * @retval 0  Selection made
  * @retval -1 Aborted
  */
-int mutt_get_field_unbuffered(const char *msg, char *buf, size_t buflen, int flags)
+int mutt_get_field_unbuffered(const char *msg, char *buf, size_t buflen, CompletionFlags flags)
 {
   int rc;
 

--- a/curs_lib.h
+++ b/curs_lib.h
@@ -28,6 +28,7 @@
 #include <stdio.h>
 #include "mutt.h"
 #include "browser.h"
+#include "pager.h"
 
 struct Context;
 struct Pager;
@@ -44,7 +45,7 @@ extern int MuttGetchTimeout; ///< Timeout in ms for mutt_getch()
 
 int          mutt_addwch(wchar_t wc);
 int          mutt_any_key_to_continue(const char *s);
-int          mutt_do_pager(const char *banner, const char *tempfile, int do_color, struct Pager *info);
+int          mutt_do_pager(const char *banner, const char *tempfile, PagerFlags do_color, struct Pager *info);
 void         mutt_edit_file(const char *editor, const char *file);
 void         mutt_endwin(void);
 int          mutt_enter_fname_full(const char *prompt, char *buf, size_t blen, bool mailbox, bool multiple, char ***files, int *numfiles, int flags);

--- a/curs_lib.h
+++ b/curs_lib.h
@@ -55,8 +55,8 @@ void         mutt_format_s(char *buf, size_t buflen, const char *prec, const cha
 void         mutt_format_s_tree(char *buf, size_t buflen, const char *prec, const char *s);
 void         mutt_getch_timeout(int delay);
 struct Event mutt_getch(void);
-int          mutt_get_field_full(const char *field, char *buf, size_t buflen, int complete, bool multiple, char ***files, int *numfiles);
-int          mutt_get_field_unbuffered(const char *msg, char *buf, size_t buflen, int flags);
+int          mutt_get_field_full(const char *field, char *buf, size_t buflen, CompletionFlags complete, bool multiple, char ***files, int *numfiles);
+int          mutt_get_field_unbuffered(const char *msg, char *buf, size_t buflen, CompletionFlags flags);
 int          mutt_multi_choice(const char *prompt, const char *letters);
 void         mutt_need_hard_redraw(void);
 void         mutt_paddstr(int n, const char *s);

--- a/editmsg.c
+++ b/editmsg.c
@@ -81,7 +81,7 @@ static int ev_message(enum EvMessage action, struct Mailbox *m, struct Email *e)
     return -1;
   }
 
-  const int chflags =
+  const CopyHeaderFlags chflags =
       CH_NOLEN | ((m->magic == MUTT_MBOX || m->magic == MUTT_MMDF) ? 0 : CH_NOSTATUS);
   rc = mutt_append_message(tmpctx->mailbox, m, e, 0, chflags);
   int oerrno = errno;
@@ -184,9 +184,10 @@ static int ev_message(enum EvMessage action, struct Mailbox *m, struct Email *e)
   }
 
   MsgOpenFlags of = MUTT_MSG_NO_FLAGS;
-  int cf = (((tmpctx->mailbox->magic == MUTT_MBOX) || (tmpctx->mailbox->magic == MUTT_MMDF)) ?
-                0 :
-                CH_NOSTATUS);
+  CopyHeaderFlags cf =
+      (((tmpctx->mailbox->magic == MUTT_MBOX) || (tmpctx->mailbox->magic == MUTT_MMDF)) ?
+           CH_NO_FLAGS :
+           CH_NOSTATUS);
 
   if (fgets(buf, sizeof(buf), fp) && is_from(buf, NULL, 0, NULL))
   {

--- a/editmsg.c
+++ b/editmsg.c
@@ -183,7 +183,7 @@ static int ev_message(enum EvMessage action, struct Mailbox *m, struct Email *e)
     goto bail;
   }
 
-  int of = 0;
+  MsgOpenFlags of = MUTT_MSG_NO_FLAGS;
   int cf = (((tmpctx->mailbox->magic == MUTT_MBOX) || (tmpctx->mailbox->magic == MUTT_MMDF)) ?
                 0 :
                 CH_NOSTATUS);

--- a/email/email.h
+++ b/email/email.h
@@ -27,6 +27,7 @@
 #include <stdbool.h>
 #include <time.h>
 #include "mutt/mutt.h"
+#include "ncrypt/ncrypt.h"
 #include "tags.h"
 
 /**
@@ -34,7 +35,7 @@
  */
 struct Email
 {
-  unsigned int security : 12; /**< bit 0-8: flags, bit 9,10: application.
+  SecurityFlags security;   /**< bit 0-8: flags, bit 9,10: application.
                                  see: ncrypt/ncrypt.h pgplib.h, smime.h */
 
   bool mime            : 1; /**< has a MIME-Version email? */

--- a/enter.c
+++ b/enter.c
@@ -133,7 +133,7 @@ struct EnterState *mutt_enter_state_new(void)
  * @param buf    Buffer to store the string
  * @param buflen Buffer length
  * @param col    Initial cursor position
- * @param flags  Flags such as MUTT_FILE
+ * @param flags  Flags, see #CompletionFlags
  * @retval 0 if input was given
  * @retval -1 if abort
  *
@@ -142,7 +142,7 @@ struct EnterState *mutt_enter_state_new(void)
  * well, because there is no active menu for the built-in editor.
  * Most callers should prefer mutt_get_field() instead.
  */
-int mutt_enter_string(char *buf, size_t buflen, int col, int flags)
+int mutt_enter_string(char *buf, size_t buflen, int col, CompletionFlags flags)
 {
   int rc;
   struct EnterState *es = mutt_enter_state_new();
@@ -165,7 +165,7 @@ int mutt_enter_string(char *buf, size_t buflen, int col, int flags)
  * @param[in]  buf      Buffer to store the string
  * @param[in]  buflen   Buffer length
  * @param[in]  col      Initial cursor position
- * @param[in]  flags    Flags such as MUTT_FILE
+ * @param[in]  flags    Flags, see #CompletionFlags
  * @param[in]  multiple Allow multiple matches
  * @param[out] files    List of files selected
  * @param[out] numfiles Number of files selected
@@ -174,8 +174,9 @@ int mutt_enter_string(char *buf, size_t buflen, int col, int flags)
  * @retval 0  Selection made
  * @retval -1 Aborted
  */
-int mutt_enter_string_full(char *buf, size_t buflen, int col, int flags, bool multiple,
-                           char ***files, int *numfiles, struct EnterState *state)
+int mutt_enter_string_full(char *buf, size_t buflen, int col,
+                           CompletionFlags flags, bool multiple, char ***files,
+                           int *numfiles, struct EnterState *state)
 {
   int width = MuttMessageWindow->cols - col - 1;
   int redraw;

--- a/format_flags.h
+++ b/format_flags.h
@@ -25,6 +25,8 @@
 
 #include <stddef.h>
 
+typedef uint8_t MuttFormatFlags;         ///< Flags for mutt_expando_format(), e.g. #MUTT_FORMAT_FORCESUBJ
+#define MUTT_FORMAT_NO_FLAGS          0  ///< No flags are set
 #define MUTT_FORMAT_FORCESUBJ   (1 << 0) ///< Print the subject even if unchanged
 #define MUTT_FORMAT_TREE        (1 << 1) ///< Draw the thread tree
 #define MUTT_FORMAT_OPTIONAL    (1 << 2) ///< Allow optional field processing
@@ -46,7 +48,7 @@
  * @param[in]  if_str   If condition is met, display this string
  * @param[in]  else_str Otherwise, display this string
  * @param[in]  data     Pointer to the mailbox Context
- * @param[in]  flags    Format flags
+ * @param[in]  flags    Flags, see #MuttFormatFlags
  * @retval src (unchanged)
  *
  * Each callback function implements some expandos, e.g.
@@ -58,6 +60,6 @@
 typedef const char *format_t(char *buf, size_t buflen, size_t col, int cols,
                              char op, const char *src, const char *prec,
                              const char *if_str, const char *else_str,
-                             unsigned long data, int flags);
+                             unsigned long data, MuttFormatFlags flags);
 
 #endif /* MUTT_FORMAT_FLAGS_H */

--- a/hdrline.c
+++ b/hdrline.c
@@ -190,13 +190,13 @@ static bool first_mailing_list(char *buf, size_t buflen, struct Address *a)
  * add_index_color - Insert a color marker into a string
  * @param buf    Buffer to store marker
  * @param buflen Buffer length
- * @param flags  Flags, e.g. MUTT_FORMAT_INDEX
+ * @param flags  Flags, see #MuttFormatFlags
  * @param color  Color, e.g. MT_COLOR_MESSAGE
  * @retval num Characters written
  *
  * The colors are stored as "magic" strings embedded in the text.
  */
-static size_t add_index_color(char *buf, size_t buflen, int flags, char color)
+static size_t add_index_color(char *buf, size_t buflen, MuttFormatFlags flags, char color)
 {
   /* only add color markers if we are operating on main index entries. */
   if (!(flags & MUTT_FORMAT_INDEX))
@@ -293,7 +293,7 @@ static const char *make_from_prefix(enum FieldType disp)
  * @param buf      Buffer to store the result
  * @param buflen   Size of the buffer
  * @param do_lists Should we check for mailing lists?
- * @param flags    Format flags, e.g. #MUTT_FORMAT_PLAIN
+ * @param flags    Format flags, see #MuttFormatFlags
  *
  * Generate the %F or %L field in $index_format.
  * This is the author, or recipient of the email.
@@ -301,7 +301,8 @@ static const char *make_from_prefix(enum FieldType disp)
  * The field can optionally be prefixed by a character from $from_chars.
  * If $from_chars is not set, the prefix will be, "To", "Cc", etc
  */
-static void make_from(struct Envelope *env, char *buf, size_t buflen, bool do_lists, int flags)
+static void make_from(struct Envelope *env, char *buf, size_t buflen,
+                      bool do_lists, MuttFormatFlags flags)
 {
   if (!env || !buf)
     return;
@@ -546,7 +547,7 @@ static bool thread_is_old(struct Context *ctx, struct Email *e)
 static const char *index_format_str(char *buf, size_t buflen, size_t col, int cols,
                                     char op, const char *src, const char *prec,
                                     const char *if_str, const char *else_str,
-                                    unsigned long data, int flags)
+                                    unsigned long data, MuttFormatFlags flags)
 {
   struct HdrFormatInfo *hfi = (struct HdrFormatInfo *) data;
   char fmt[128], tmp[1024], *p, *tags = NULL;
@@ -873,7 +874,8 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
       {
         const bool is_plain = (src[0] == 'p');
         colorlen = add_index_color(buf, buflen, flags, MT_COLOR_INDEX_AUTHOR);
-        make_from(e->env, tmp, sizeof(tmp), false, (is_plain ? MUTT_FORMAT_PLAIN : 0));
+        make_from(e->env, tmp, sizeof(tmp), false,
+                  (is_plain ? MUTT_FORMAT_PLAIN : MUTT_FORMAT_NO_FLAGS));
         mutt_format_s(buf + colorlen, buflen - colorlen, prec, tmp);
         add_index_color(buf + colorlen, buflen - colorlen, flags, MT_COLOR_INDEX);
 
@@ -1450,10 +1452,10 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
  * @param ctx    Mailbox Context
  * @param m      Mailbox
  * @param e      Email
- * @param flags  Format flags
+ * @param flags  Flags, see #MuttFormatFlags
  */
 void mutt_make_string_flags(char *buf, size_t buflen, const char *s, struct Context *ctx,
-                            struct Mailbox *m, struct Email *e, int flags)
+                            struct Mailbox *m, struct Email *e, MuttFormatFlags flags)
 {
   struct HdrFormatInfo hfi;
 
@@ -1473,10 +1475,10 @@ void mutt_make_string_flags(char *buf, size_t buflen, const char *s, struct Cont
  * @param cols   Number of screen columns
  * @param s      printf-line format string
  * @param hfi    Mailbox data to pass to the formatter
- * @param flags  Format flags
+ * @param flags  Flags, see #MuttFormatFlags
  */
 void mutt_make_string_info(char *buf, size_t buflen, int cols, const char *s,
-                           struct HdrFormatInfo *hfi, int flags)
+                           struct HdrFormatInfo *hfi, MuttFormatFlags flags)
 {
   mutt_expando_format(buf, buflen, 0, cols, s, index_format_str, (unsigned long) hfi, flags);
 }

--- a/hdrline.h
+++ b/hdrline.h
@@ -52,9 +52,9 @@ bool mutt_is_mail_list(struct Address *addr);
 bool mutt_is_subscribed_list(struct Address *addr);
 void mutt_make_string_flags(char *buf, size_t buflen, const char *s,
                             struct Context *ctx, struct Mailbox *m,
-                            struct Email *e, int flags);
+                            struct Email *e, MuttFormatFlags flags);
 void mutt_make_string_info(char *buf, size_t buflen, int cols, const char *s,
-                           struct HdrFormatInfo *hfi, int flags);
+                           struct HdrFormatInfo *hfi, MuttFormatFlags flags);
 
 #define mutt_make_string(BUF, BUFLEN, S, CTX, M, E)                            \
   mutt_make_string_flags(BUF, BUFLEN, S, CTX, M, E, 0)

--- a/hook.c
+++ b/hook.c
@@ -63,7 +63,7 @@ bool C_SaveName; ///< Config: Save outgoing message to mailbox of recipient's na
  */
 struct Hook
 {
-  int type;                ///< Hook type
+  HookFlags type;          ///< Hook type
   struct Regex regex;      ///< Regular expression
   char *command;           ///< Filename, command or pattern to execute
   struct Pattern *pattern; ///< Used for fcc,save,send-hook
@@ -71,7 +71,7 @@ struct Hook
 };
 static TAILQ_HEAD(, Hook) Hooks = TAILQ_HEAD_INITIALIZER(Hooks);
 
-static int current_hook_type = 0;
+static HookFlags current_hook_type = MUTT_HOOK_NO_FLAGS;
 
 /**
  * mutt_parse_hook - Parse the 'hook' family of commands - Implements ::command_t
@@ -303,11 +303,11 @@ static void delete_hook(struct Hook *h)
 
 /**
  * mutt_delete_hooks - Delete matching hooks
- * @param type Hook type to delete, e.g. #MUTT_SEND_HOOK
+ * @param type Hook type to delete, see #HookFlags
  *
  * If 0 is passed, all the hooks will be deleted.
  */
-void mutt_delete_hooks(int type)
+void mutt_delete_hooks(HookFlags type)
 {
   struct Hook *h = NULL;
   struct Hook *tmp = NULL;
@@ -412,13 +412,13 @@ void mutt_folder_hook(const char *path, const char *desc)
 
 /**
  * mutt_find_hook - Find a matching hook
- * @param type Type, e.g. #MUTT_FOLDER_HOOK
+ * @param type Hook type, see #HookFlags
  * @param pat  Pattern to match
  * @retval ptr Command string
  *
  * @note The returned string must not be freed.
  */
-char *mutt_find_hook(int type, const char *pat)
+char *mutt_find_hook(HookFlags type, const char *pat)
 {
   struct Hook *tmp = NULL;
 
@@ -437,9 +437,9 @@ char *mutt_find_hook(int type, const char *pat)
  * mutt_message_hook - Perform a message hook
  * @param m   Mailbox Context
  * @param e   Email
- * @param type Hook type, e.g. #MUTT_MESSAGE_HOOK
+ * @param type Hook type, see #HookFlags
  */
-void mutt_message_hook(struct Mailbox *m, struct Email *e, int type)
+void mutt_message_hook(struct Mailbox *m, struct Email *e, HookFlags type)
 {
   struct Buffer err, token;
   struct Hook *hook = NULL;
@@ -485,14 +485,14 @@ void mutt_message_hook(struct Mailbox *m, struct Email *e, int type)
  * addr_hook - Perform an address hook (get a path)
  * @param path    Buffer for path
  * @param pathlen Length of buffer
- * @param type    Type e.g. #MUTT_FCC_HOOK
+ * @param type    Hook type, see #HookFlags
  * @param ctx     Mailbox Context
  * @param e       Email
  * @retval  0 Success
  * @retval -1 Failure
  */
-static int addr_hook(char *path, size_t pathlen, int type, struct Context *ctx,
-                     struct Email *e)
+static int addr_hook(char *path, size_t pathlen, HookFlags type,
+                     struct Context *ctx, struct Email *e)
 {
   struct Hook *hook = NULL;
   struct PatternCache cache = { 0 };
@@ -582,9 +582,9 @@ void mutt_select_fcc(char *path, size_t pathlen, struct Email *e)
  * list_hook - Find hook strings matching
  * @param[out] matches List of hook strings
  * @param[in]  match   String to match
- * @param[in]  hook    Hook type, e.g. #MUTT_CRYPT_HOOK
+ * @param[in]  hook    Hook type, see #HookFlags
  */
-static void list_hook(struct ListHead *matches, const char *match, int hook)
+static void list_hook(struct ListHead *matches, const char *match, HookFlags hook)
 {
   struct Hook *tmp = NULL;
 
@@ -702,12 +702,12 @@ void mutt_timeout_hook(void)
 
 /**
  * mutt_startup_shutdown_hook - Execute any startup/shutdown hooks
- * @param type Hook type: MUTT_STARTUP_HOOK or MUTT_SHUTDOWN_HOOK
+ * @param type Hook type: #MUTT_STARTUP_HOOK or #MUTT_SHUTDOWN_HOOK
  *
  * The user can configure hooks to be run on startup/shutdown.
  * This function finds all the matching hooks and executes them.
  */
-void mutt_startup_shutdown_hook(int type)
+void mutt_startup_shutdown_hook(HookFlags type)
 {
   struct Hook *hook = NULL;
   struct Buffer token = { 0 };

--- a/hook.c
+++ b/hook.c
@@ -114,7 +114,7 @@ enum CommandResult mutt_parse_hook(struct Buffer *buf, struct Buffer *s,
                      (data & (MUTT_FOLDER_HOOK | MUTT_SEND_HOOK | MUTT_SEND2_HOOK |
                               MUTT_ACCOUNT_HOOK | MUTT_REPLY_HOOK)) ?
                          MUTT_TOKEN_SPACE :
-                         0);
+                         MUTT_TOKEN_NO_FLAGS);
 
   if (!command.data)
   {

--- a/hook.h
+++ b/hook.h
@@ -38,7 +38,8 @@ extern char *C_DefaultHook;
 extern bool  C_ForceName;
 extern bool  C_SaveName;
 
-/* types for mutt_parse_hook() */
+typedef uint32_t HookFlags;          ///< Flags for mutt_parse_hook(), e.g. #MUTT_FOLDER_HOOK
+#define MUTT_HOOK_NO_FLAGS       0   ///< No flags are set
 #define MUTT_FOLDER_HOOK   (1 << 0)  ///< folder-hook: when entering a mailbox
 #define MUTT_MBOX_HOOK     (1 << 1)  ///< mbox-hook: move messages after reading them
 #define MUTT_SEND_HOOK     (1 << 2)  ///< send-hook: when composing a new email
@@ -64,14 +65,14 @@ extern bool  C_SaveName;
 void  mutt_account_hook(const char *url);
 void  mutt_crypt_hook(struct ListHead *list, struct Address *addr);
 void  mutt_default_save(char *path, size_t pathlen, struct Email *e);
-void  mutt_delete_hooks(int type);
-char *mutt_find_hook(int type, const char *pat);
+void  mutt_delete_hooks(HookFlags type);
+char *mutt_find_hook(HookFlags type, const char *pat);
 void  mutt_folder_hook(const char *path, const char *desc);
-void  mutt_message_hook(struct Mailbox *m, struct Email *e, int type);
+void  mutt_message_hook(struct Mailbox *m, struct Email *e, HookFlags type);
 enum CommandResult mutt_parse_hook(struct Buffer *buf, struct Buffer *s, unsigned long data, struct Buffer *err);
 enum CommandResult mutt_parse_unhook(struct Buffer *buf, struct Buffer *s, unsigned long data, struct Buffer *err);
 void  mutt_select_fcc(char *path, size_t pathlen, struct Email *e);
-void  mutt_startup_shutdown_hook(int type);
+void  mutt_startup_shutdown_hook(HookFlags type);
 void  mutt_timeout_hook(void);
 
 #endif /* MUTT_HOOK_H */

--- a/imap/command.c
+++ b/imap/command.c
@@ -119,13 +119,13 @@ static struct ImapCommand *cmd_new(struct ImapAccountData *adata)
  * cmd_queue - Add a IMAP command to the queue
  * @param adata Imap Account data
  * @param cmdstr Command string
- * @param flags  Server flags, e.g. #IMAP_CMD_POLL
+ * @param flags  Server flags, see #ImapCmdFlags
  * @retval  0 Success
  * @retval <0 Failure, e.g. #IMAP_CMD_BAD
  *
  * If the queue is full, attempts to drain it.
  */
-static int cmd_queue(struct ImapAccountData *adata, const char *cmdstr, int flags)
+static int cmd_queue(struct ImapAccountData *adata, const char *cmdstr, ImapCmdFlags flags)
 {
   if (cmd_queue_full(adata))
   {
@@ -183,11 +183,11 @@ static void cmd_handle_fatal(struct ImapAccountData *adata)
  * cmd_start - Start a new IMAP command
  * @param adata Imap Account data
  * @param cmdstr Command string
- * @param flags  Command flags, e.g. #IMAP_CMD_QUEUE
+ * @param flags  Command flags, see #ImapCmdFlags
  * @retval  0 Success
  * @retval <0 Failure, e.g. #IMAP_CMD_BAD
  */
-static int cmd_start(struct ImapAccountData *adata, const char *cmdstr, int flags)
+static int cmd_start(struct ImapAccountData *adata, const char *cmdstr, ImapCmdFlags flags)
 {
   int rc;
 
@@ -1215,14 +1215,14 @@ const char *imap_cmd_trailer(struct ImapAccountData *adata)
  * imap_exec - Execute a command and wait for the response from the server
  * @param adata Imap Account data
  * @param cmdstr Command to execute
- * @param flags  Flags, e.g. #IMAP_CMD_PASS
+ * @param flags  Flags, see #ImapCmdFlags
  * @retval #IMAP_EXEC_SUCCESS Command successful or queued
  * @retval #IMAP_EXEC_ERROR   Command returned an error
  * @retval #IMAP_EXEC_FATAL   Imap connection failure
  *
  * Also, handle untagged responses.
  */
-int imap_exec(struct ImapAccountData *adata, const char *cmdstr, int flags)
+int imap_exec(struct ImapAccountData *adata, const char *cmdstr, ImapCmdFlags flags)
 {
   int rc;
 

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -2171,7 +2171,7 @@ fail:
 /**
  * imap_mbox_open_append - Implements MxOps::mbox_open_append()
  */
-static int imap_mbox_open_append(struct Mailbox *m, int flags)
+static int imap_mbox_open_append(struct Mailbox *m, OpenMailboxFlags flags)
 {
   if (!m || !m->account)
     return -1;

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -1247,7 +1247,7 @@ int imap_check_mailbox(struct Mailbox *m, bool force)
   else if (mdata->check_status & IMAP_FLAGS_PENDING)
     result = MUTT_FLAGS;
 
-  mdata->check_status = 0;
+  mdata->check_status = IMAP_OPEN_NO_FLAGS;
 
   return result;
 }

--- a/imap/imap_private.h
+++ b/imap/imap_private.h
@@ -69,7 +69,8 @@ typedef uint8_t ImapOpenFlags;         ///< Flags, e.g. #MUTT_THREAD_COLLAPSE
 #define IMAP_NEWMAIL_PENDING  (1 << 3) ///< New mail is waiting on the server
 #define IMAP_FLAGS_PENDING    (1 << 4) ///< Flags have changed on the server
 
-/* imap_exec flags (see imap_exec) */
+typedef uint8_t ImapCmdFlags;          ///< Flags for imap_exec(), e.g. #IMAP_CMD_PASS
+#define IMAP_CMD_NO_FLAGS          0   ///< No flags are set
 #define IMAP_CMD_PASS        (1 << 0)  ///< Command contains a password. Suppress logging
 #define IMAP_CMD_QUEUE       (1 << 1)  ///< Queue a command, do not execute
 #define IMAP_CMD_POLL        (1 << 2)  ///< Poll the tcp connection before running the imap command
@@ -279,7 +280,7 @@ int imap_cmd_step(struct ImapAccountData *adata);
 void imap_cmd_finish(struct ImapAccountData *adata);
 bool imap_code(const char *s);
 const char *imap_cmd_trailer(struct ImapAccountData *adata);
-int imap_exec(struct ImapAccountData *adata, const char *cmdstr, int flags);
+int imap_exec(struct ImapAccountData *adata, const char *cmdstr, ImapCmdFlags flags);
 int imap_cmd_idle(struct ImapAccountData *adata);
 
 /* message.c */

--- a/imap/imap_private.h
+++ b/imap/imap_private.h
@@ -61,6 +61,8 @@ struct Progress;
 #define SEQLEN 5
 #define IMAP_MAX_CMDLEN 1024 ///< Maximum length of command lines before they must be split (for lazy servers)
 
+typedef uint8_t ImapOpenFlags;         ///< Flags, e.g. #MUTT_THREAD_COLLAPSE
+#define IMAP_OPEN_NO_FLAGS          0  ///< No flags are set
 #define IMAP_REOPEN_ALLOW     (1 << 0) ///< Allow re-opening a folder upon expunge
 #define IMAP_EXPUNGE_EXPECTED (1 << 1) ///< Messages will be expunged from the server
 #define IMAP_EXPUNGE_PENDING  (1 << 2) ///< Messages on the server have been expunged
@@ -212,8 +214,8 @@ struct ImapMboxData
   char *munge_name;  /**< Munged version of the mailbox name */
   char *real_name;   /**< Original Mailbox name, e.g.: INBOX can be just \0 */
 
-  unsigned char reopen;        /**< Flags, e.g. #IMAP_REOPEN_ALLOW */
-  unsigned short check_status; /**< Flags, e.g. #IMAP_NEWMAIL_PENDING */
+  ImapOpenFlags reopen;        /**< Flags, e.g. #IMAP_REOPEN_ALLOW */
+  ImapOpenFlags check_status;  /**< Flags, e.g. #IMAP_NEWMAIL_PENDING */
   unsigned int new_mail_count; /**< Set when EXISTS notifies of new mail */
 
   // IMAP STATUS information

--- a/index.c
+++ b/index.c
@@ -734,14 +734,14 @@ void index_make_entry(char *buf, size_t buflen, struct Menu *menu, int line)
   if (!e)
     return;
 
-  int flag = MUTT_FORMAT_ARROWCURSOR | MUTT_FORMAT_INDEX;
+  MuttFormatFlags flags = MUTT_FORMAT_ARROWCURSOR | MUTT_FORMAT_INDEX;
   struct MuttThread *tmp = NULL;
 
   if ((C_Sort & SORT_MASK) == SORT_THREADS && e->tree)
   {
-    flag |= MUTT_FORMAT_TREE; /* display the thread tree */
+    flags |= MUTT_FORMAT_TREE; /* display the thread tree */
     if (e->display_subject)
-      flag |= MUTT_FORMAT_FORCESUBJ;
+      flags |= MUTT_FORMAT_FORCESUBJ;
     else
     {
       const int reverse = C_Sort & SORT_REVERSE;
@@ -765,13 +765,13 @@ void index_make_entry(char *buf, size_t buflen, struct Menu *menu, int line)
          * subject... */
         if (reverse ? tmp->message->msgno > edgemsgno : tmp->message->msgno < edgemsgno)
         {
-          flag |= MUTT_FORMAT_FORCESUBJ;
+          flags |= MUTT_FORMAT_FORCESUBJ;
           break;
         }
         else if (tmp->message->virtual >= 0)
           break;
       }
-      if (flag & MUTT_FORMAT_FORCESUBJ)
+      if (flags & MUTT_FORMAT_FORCESUBJ)
       {
         for (tmp = e->thread->prev; tmp; tmp = tmp->prev)
         {
@@ -783,7 +783,7 @@ void index_make_entry(char *buf, size_t buflen, struct Menu *menu, int line)
             break;
           else if (tmp->message->virtual >= 0)
           {
-            flag &= ~MUTT_FORMAT_FORCESUBJ;
+            flags &= ~MUTT_FORMAT_FORCESUBJ;
             break;
           }
         }
@@ -792,7 +792,7 @@ void index_make_entry(char *buf, size_t buflen, struct Menu *menu, int line)
   }
 
   mutt_make_string_flags(buf, buflen, NONULL(C_IndexFormat), Context,
-                         Context->mailbox, e, flag);
+                         Context->mailbox, e, flags);
 }
 
 /**

--- a/index.c
+++ b/index.c
@@ -680,11 +680,11 @@ static int main_change_folder(struct Menu *menu, int op, struct Mailbox *m,
 
   const int flags = (C_ReadOnly || (op == OP_MAIN_CHANGE_FOLDER_READONLY)
 #ifdef USE_NOTMUCH
-                     || (op == OP_MAIN_VFOLDER_FROM_QUERY_READONLY)
+                                  || (op == OP_MAIN_VFOLDER_FROM_QUERY_READONLY)
 #endif
-                         ) ?
-                        MUTT_READONLY :
-                        0;
+                                      ) ?
+                                     MUTT_READONLY :
+                                     MUTT_OPEN_NO_FLAGS;
 
   bool free_m = false;
   if (!m)
@@ -1012,7 +1012,7 @@ static void index_custom_redraw(struct Menu *menu)
 int mutt_index_menu(void)
 {
   char buf[PATH_MAX], helpstr[1024];
-  int flags;
+  OpenMailboxFlags flags;
   int op = OP_NULL;
   bool done = false; /* controls when to exit the "event" loop */
   bool tag = false;  /* has the tag-prefix command been pressed? */
@@ -2204,7 +2204,7 @@ int mutt_index_menu(void)
           flags = MUTT_READONLY;
         }
         else
-          flags = 0;
+          flags = MUTT_OPEN_NO_FLAGS;
 
         if (flags)
           cp = _("Open mailbox in read-only mode");

--- a/init.c
+++ b/init.c
@@ -2673,11 +2673,11 @@ int mutt_dump_variables(bool hide_sensitive)
  * mutt_extract_token - Extract one token from a string
  * @param dest  Buffer for the result
  * @param tok   Buffer containing tokens
- * @param flags Flags, e.g. #MUTT_TOKEN_SPACE
+ * @param flags Flags, see #TokenFlags
  * @retval  0 Success
  * @retval -1 Error
  */
-int mutt_extract_token(struct Buffer *dest, struct Buffer *tok, int flags)
+int mutt_extract_token(struct Buffer *dest, struct Buffer *tok, TokenFlags flags)
 {
   if (!dest || !tok)
     return -1;

--- a/maildir/maildir.c
+++ b/maildir/maildir.c
@@ -304,7 +304,7 @@ static int maildir_mbox_open(struct Mailbox *m)
 /**
  * maildir_mbox_open_append - Implements MxOps::mbox_open_append()
  */
-static int maildir_mbox_open_append(struct Mailbox *m, int flags)
+static int maildir_mbox_open_append(struct Mailbox *m, OpenMailboxFlags flags)
 {
   if (!m)
     return -1;

--- a/maildir/mh.c
+++ b/maildir/mh.c
@@ -552,7 +552,7 @@ static int mh_mbox_open(struct Mailbox *m)
 /**
  * mh_mbox_open_append - Implements MxOps::mbox_open_append()
  */
-static int mh_mbox_open_append(struct Mailbox *m, int flags)
+static int mh_mbox_open_append(struct Mailbox *m, OpenMailboxFlags flags)
 {
   if (!m)
     return -1;

--- a/main.c
+++ b/main.c
@@ -416,7 +416,7 @@ int main(int argc, char *argv[], char *envp[])
   struct ListHead alias_queries = STAILQ_HEAD_INITIALIZER(alias_queries);
   struct ListHead cc_list = STAILQ_HEAD_INITIALIZER(cc_list);
   struct ListHead bcc_list = STAILQ_HEAD_INITIALIZER(bcc_list);
-  int sendflags = 0;
+  SendFlags sendflags = SEND_NO_FLAGS;
   int flags = 0;
   int version = 0;
   int i;

--- a/main.c
+++ b/main.c
@@ -748,7 +748,7 @@ int main(int argc, char *argv[], char *envp[])
   if (dump_variables)
   {
     dump_config(Config, CS_DUMP_STYLE_NEO,
-                hide_sensitive ? CS_DUMP_HIDE_SENSITIVE : 0, stdout);
+                hide_sensitive ? CS_DUMP_HIDE_SENSITIVE : CS_DUMP_NO_FLAGS, stdout);
     goto main_ok; // TEST18: neomutt -D
   }
 

--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -955,7 +955,7 @@ static int mbox_mbox_open(struct Mailbox *m)
 /**
  * mbox_mbox_open_append - Implements MxOps::mbox_open_append()
  */
-static int mbox_mbox_open_append(struct Mailbox *m, int flags)
+static int mbox_mbox_open_append(struct Mailbox *m, OpenMailboxFlags flags)
 {
   if (!m)
     return -1;

--- a/menu.c
+++ b/menu.c
@@ -1583,7 +1583,7 @@ bool mutt_menu_listener(const struct ConfigSet *cs, struct HashElem *he,
                         const char *name, enum ConfigEvent ev)
 {
   const struct ConfigDef *cdef = he->data;
-  int flags = cdef->flags;
+  ConfigRedrawFlags flags = cdef->flags;
 
   if (flags == 0)
     return true;

--- a/menu.c
+++ b/menu.c
@@ -1070,9 +1070,9 @@ void mutt_menu_pop_current(struct Menu *menu)
 
 /**
  * mutt_menu_set_current_redraw - Set redraw flags on the current menu
- * @param redraw Flags to set, e.g. #REDRAW_INDEX
+ * @param redraw Flags to set, see #MuttRedrawFlags
  */
-void mutt_menu_set_current_redraw(int redraw)
+void mutt_menu_set_current_redraw(MuttRedrawFlags redraw)
 {
   struct Menu *current_menu = get_current_menu();
   if (current_menu)
@@ -1096,7 +1096,7 @@ void mutt_menu_set_current_redraw_full(void)
  *
  * This is ignored if it's not the current menu.
  */
-void mutt_menu_set_redraw(int menu_type, int redraw)
+void mutt_menu_set_redraw(int menu_type, MuttRedrawFlags redraw)
 {
   if (CurrentMenu == menu_type)
     mutt_menu_set_current_redraw(redraw);

--- a/mutt.h
+++ b/mutt.h
@@ -55,7 +55,8 @@ struct Mapping;
 #define fgetc fgetc_unlocked
 #endif
 
-/* flags for mutt_enter_string_full() */
+typedef uint16_t CompletionFlags;    ///< Flags for mutt_enter_string_full(), e.g. #MUTT_ALIAS
+#define MUTT_COMP_NO_FLAGS       0   ///< No flags are set
 #define MUTT_ALIAS         (1 << 0)  ///< Do alias "completion" by calling up the alias-menu
 #define MUTT_FILE          (1 << 1)  ///< Do file completion
 #define MUTT_EFILE         (1 << 2)  ///< Do file completion, plus incoming folders

--- a/mutt.h
+++ b/mutt.h
@@ -69,7 +69,8 @@ typedef uint16_t CompletionFlags;    ///< Flags for mutt_enter_string_full(), e.
 #define MUTT_NM_QUERY      (1 << 9)  ///< Notmuch query mode.
 #define MUTT_NM_TAG        (1 << 10) ///< Notmuch tag +/- mode.
 
-/* flags for mutt_extract_token() */
+typedef uint16_t TokenFlags;               ///< Flags for mutt_extract_token(), e.g. #MUTT_TOKEN_EQUAL
+#define MUTT_TOKEN_NO_FLAGS            0   ///< No flags are set
 #define MUTT_TOKEN_EQUAL         (1 << 0)  ///< Treat '=' as a special
 #define MUTT_TOKEN_CONDENSE      (1 << 1)  ///< ^(char) to control chars (macros)
 #define MUTT_TOKEN_SPACE         (1 << 2)  ///< Don't treat whitespace as a term
@@ -211,7 +212,7 @@ int safe_asprintf(char **, const char *, ...);
 
 char *mutt_compile_help(char *buf, size_t buflen, int menu, const struct Mapping *items);
 
-int mutt_extract_token(struct Buffer *dest, struct Buffer *tok, int flags);
+int mutt_extract_token(struct Buffer *dest, struct Buffer *tok, TokenFlags flags);
 void mutt_free_opts(void);
 int query_quadoption(int opt, const char *prompt);
 int mutt_label_complete(char *buf, size_t buflen, int numtabs);

--- a/mutt_account.h
+++ b/mutt_account.h
@@ -26,6 +26,7 @@
 #define MUTT_MUTT_ACCOUNT_H
 
 #include <stdbool.h>
+#include <stdint.h>
 
 struct ConnAccount;
 struct Url;
@@ -54,7 +55,8 @@ enum AccountType
   MUTT_ACCT_TYPE_NNTP,     ///< Nntp (Usenet) Account
 };
 
-/* account flags */
+typedef uint8_t MuttAccountFlags;     ///< Flags, Which ConnAccount fields are initialised, e.g. #MUTT_ACCT_PORT
+#define MUTT_ACCT__NO_FLAGS       0   ///< No flags are set
 #define MUTT_ACCT_PORT      (1 << 0)  ///< Port field has been set
 #define MUTT_ACCT_USER      (1 << 1)  ///< User field has been set
 #define MUTT_ACCT_LOGIN     (1 << 2)  ///< Login field has been set

--- a/mutt_attach.c
+++ b/mutt_attach.c
@@ -803,7 +803,7 @@ int mutt_save_attachment(FILE *fp, struct Body *m, char *path, int flags, struct
 
       char buf[8192];
       struct Message *msg = NULL;
-      int chflags = 0;
+      CopyHeaderFlags chflags = CH_NO_FLAGS;
       int r = -1;
 
       struct Email *en = m->email;

--- a/mutt_history.c
+++ b/mutt_history.c
@@ -56,7 +56,7 @@ static const struct Mapping HistoryHelp[] = {
 static const char *history_format_str(char *buf, size_t buflen, size_t col, int cols,
                                       char op, const char *src, const char *prec,
                                       const char *if_str, const char *else_str,
-                                      unsigned long data, int flags)
+                                      unsigned long data, MuttFormatFlags flags)
 {
   char *match = (char *) data;
 

--- a/mutt_menu.h
+++ b/mutt_menu.h
@@ -37,6 +37,8 @@ extern bool  C_MenuScroll;
 struct ConfigSet;
 struct HashElem;
 
+typedef uint16_t MuttRedrawFlags;      ///< Flags, e.g. #REDRAW_INDEX
+#define REDRAW_NO_FLAGS             0  ///< No flags are set
 #define REDRAW_INDEX          (1 << 0) ///< Redraw the index
 #define REDRAW_MOTION         (1 << 1) ///< Redraw after moving the menu list
 #define REDRAW_MOTION_RESYNCH (1 << 2) ///< Redraw any changing the menu selection
@@ -61,7 +63,7 @@ struct Menu
   void *data;  /**< extra data for the current menu */
   int current; /**< current entry */
   int max;     /**< the number of entries in the menu */
-  int redraw;  /**< when to redraw the screen */
+  MuttRedrawFlags redraw;  /**< when to redraw the screen */
   int menu;    /**< menu definition for keymap entries. */
   int offset;  /**< row offset within the window to start the index */
   int pagelen; /**< number of entries per screen */
@@ -159,9 +161,9 @@ struct Menu *mutt_menu_new(enum MenuType type);
 void         mutt_menu_pop_current(struct Menu *menu);
 void         mutt_menu_push_current(struct Menu *menu);
 void         mutt_menu_set_current_redraw_full(void);
-void         mutt_menu_set_current_redraw(int redraw);
+void         mutt_menu_set_current_redraw(MuttRedrawFlags redraw);
 void         mutt_menu_set_redraw_full(int menu_type);
-void         mutt_menu_set_redraw(int menu_type, int redraw);
+void         mutt_menu_set_redraw(int menu_type, MuttRedrawFlags redraw);
 
 bool mutt_menu_listener(const struct ConfigSet *cs, struct HashElem *he, const char *name, enum ConfigEvent ev);
 

--- a/mutt_thread.c
+++ b/mutt_thread.c
@@ -1214,10 +1214,10 @@ void mutt_set_virtual(struct Context *ctx)
  * mutt_traverse_thread - Recurse through an email thread, matching messages
  * @param ctx  Mailbox
  * @param cur  Header of current message
- * @param flag Flag to set, e.g. #MUTT_THREAD_NEXT_UNREAD
+ * @param flag Flag to set, see #MuttThreadFlags
  * @retval num Number of matches
  */
-int mutt_traverse_thread(struct Context *ctx, struct Email *cur, int flag)
+int mutt_traverse_thread(struct Context *ctx, struct Email *cur, MuttThreadFlags flag)
 {
   struct MuttThread *thread = NULL, *top = NULL;
   struct Email *roothdr = NULL;

--- a/mutt_thread.h
+++ b/mutt_thread.h
@@ -42,6 +42,8 @@ extern bool C_SortRe;
 extern bool C_StrictThreads;
 extern bool C_ThreadReceived;
 
+typedef uint8_t MuttThreadFlags;         ///< Flags, e.g. #MUTT_THREAD_COLLAPSE
+#define MUTT_THREAD_NO_FLAGS          0  ///< No flags are set
 #define MUTT_THREAD_COLLAPSE    (1 << 0) ///< Collapse an email thread
 #define MUTT_THREAD_UNCOLLAPSE  (1 << 1) ///< Uncollapse an email thread
 #define MUTT_THREAD_GET_HIDDEN  (1 << 2) ///< Count non-visible emails in a thread
@@ -49,7 +51,7 @@ extern bool C_ThreadReceived;
 #define MUTT_THREAD_NEXT_UNREAD (1 << 4) ///< Find the next unread email
 #define MUTT_THREAD_FLAGGED     (1 << 5) ///< Count flagged emails in a thread
 
-int mutt_traverse_thread(struct Context *ctx, struct Email *cur, int flag);
+int mutt_traverse_thread(struct Context *ctx, struct Email *cur, MuttThreadFlags flag);
 #define mutt_collapse_thread(ctx, cur)         mutt_traverse_thread(ctx, cur, MUTT_THREAD_COLLAPSE)
 #define mutt_uncollapse_thread(ctx, cur)       mutt_traverse_thread(ctx, cur, MUTT_THREAD_UNCOLLAPSE)
 #define mutt_get_hidden(ctx, cur)              mutt_traverse_thread(ctx, cur, MUTT_THREAD_GET_HIDDEN)

--- a/muttlib.c
+++ b/muttlib.c
@@ -815,7 +815,7 @@ void mutt_safe_path(char *buf, size_t buflen, struct Address *a)
  * @param[in]  flags    Callback flags
  */
 void mutt_expando_format(char *buf, size_t buflen, size_t col, int cols, const char *src,
-                         format_t *callback, unsigned long data, int flags)
+                         format_t *callback, unsigned long data, MuttFormatFlags flags)
 {
   char prefix[128], tmp[1024], *cp = NULL, *wptr = buf, ch;
   char if_str[128], else_str[128];

--- a/muttlib.h
+++ b/muttlib.h
@@ -46,7 +46,7 @@ void        mutt_buffer_adv_mktemp (struct Buffer *buf);
 void        mutt_buffer_mktemp_full(struct Buffer *buf, const char *prefix, const char *suffix, const char *src, int line);
 int         mutt_check_overwrite(const char *attname, const char *path, char *fname, size_t flen, int *append, char **directory);
 void        mutt_encode_path(char *dest, size_t dlen, const char *src);
-void        mutt_expando_format(char *buf, size_t buflen, size_t col, int cols, const char *src, format_t *callback, unsigned long data, int flags);
+void        mutt_expando_format(char *buf, size_t buflen, size_t col, int cols, const char *src, format_t *callback, unsigned long data, MuttFormatFlags flags);
 char *      mutt_expand_path(char *s, size_t slen);
 char *      mutt_expand_path_regex(char *s, size_t slen, bool regex);
 char *      mutt_gecos_name(char *dest, size_t destlen, struct passwd *pw);

--- a/mx.c
+++ b/mx.c
@@ -172,11 +172,11 @@ int mx_access(const char *path, int flags)
 /**
  * mx_open_mailbox_append - Open a mailbox for appending
  * @param m     Mailbox
- * @param flags Flags, e.g. #MUTT_READONLY
+ * @param flags Flags, see #OpenMailboxFlags
  * @retval  0 Success
  * @retval -1 Failure
  */
-static int mx_open_mailbox_append(struct Mailbox *m, int flags)
+static int mx_open_mailbox_append(struct Mailbox *m, OpenMailboxFlags flags)
 {
   if (!m)
     return -1;
@@ -239,11 +239,11 @@ static int mx_open_mailbox_append(struct Mailbox *m, int flags)
 /**
  * mx_mbox_open - Open a mailbox and parse it
  * @param m     Mailbox to open
- * @param flags Flags, e.g. #MUTT_NOSORT
+ * @param flags Flags, see #OpenMailboxFlags
  * @retval ptr  Mailbox context
  * @retval NULL Error
  */
-struct Context *mx_mbox_open(struct Mailbox *m, int flags)
+struct Context *mx_mbox_open(struct Mailbox *m, OpenMailboxFlags flags)
 {
   if (!m)
     return NULL;

--- a/mx.c
+++ b/mx.c
@@ -923,10 +923,10 @@ int mx_mbox_sync(struct Mailbox *m, int *index_hint)
  * mx_msg_open_new - Open a new message
  * @param m     Destination mailbox
  * @param e     Message being copied (required for maildir support, because the filename depends on the message flags)
- * @param flags Flags, e.g. #MUTT_SET_DRAFT
+ * @param flags Flags, see #MsgOpenFlags
  * @retval ptr New Message
  */
-struct Message *mx_msg_open_new(struct Mailbox *m, struct Email *e, int flags)
+struct Message *mx_msg_open_new(struct Mailbox *m, struct Email *e, MsgOpenFlags flags)
 {
   if (!m)
     return NULL;

--- a/mx.h
+++ b/mx.h
@@ -59,7 +59,8 @@ typedef uint8_t OpenMailboxFlags;   ///< Flags for mutt_open_mailbox(), e.g. #MU
 #define MUTT_APPENDNEW     (1 << 6) ///< Set in mx_open_mailbox_append if the mailbox doesn't exist.
                                     ///< Used by maildir/mh to create the mailbox.
 
-/* mx_msg_open_new() */
+typedef uint8_t MsgOpenFlags;      ///< Flags for mx_msg_open_new(), e.g. #MUTT_ADD_FROM
+#define MUTT_MSG_NO_FLAGS       0  ///< No flags are set
 #define MUTT_ADD_FROM     (1 << 0) ///< add a From_ line
 #define MUTT_SET_DRAFT    (1 << 1) ///< set the message draft flag
 
@@ -277,7 +278,7 @@ struct Context *mx_mbox_open       (struct Mailbox *m, OpenMailboxFlags flags);
 int             mx_mbox_sync       (struct Mailbox *m, int *index_hint);
 int             mx_msg_close       (struct Mailbox *m, struct Message **msg);
 int             mx_msg_commit      (struct Mailbox *m, struct Message *msg);
-struct Message *mx_msg_open_new    (struct Mailbox *m, struct Email *e, int flags);
+struct Message *mx_msg_open_new    (struct Mailbox *m, struct Email *e, MsgOpenFlags flags);
 struct Message *mx_msg_open        (struct Mailbox *m, int msgno);
 int             mx_msg_padding_size(struct Mailbox *m);
 int             mx_save_hcache     (struct Mailbox *m, struct Email *e);

--- a/mx.h
+++ b/mx.h
@@ -46,6 +46,8 @@ extern unsigned char C_Move;
 extern char *        C_Trash;
 
 /* flags for mutt_open_mailbox() */
+typedef uint8_t OpenMailboxFlags;   ///< Flags for mutt_open_mailbox(), e.g. #MUTT_NOSORT
+#define MUTT_OPEN_NO_FLAGS       0  ///< No flags are set
 #define MUTT_NOSORT        (1 << 0) ///< Do not sort the mailbox after opening it
 #define MUTT_APPEND        (1 << 1) ///< Open mailbox for appending messages
 #define MUTT_READONLY      (1 << 2) ///< Open in read-only mode
@@ -129,11 +131,11 @@ struct MxOps
   /**
    * mbox_open_append - Open a Mailbox for appending
    * @param m     Mailbox to open
-   * @param flags e.g. #MUTT_READONLY
+   * @param flags Flags, see #OpenMailboxFlags
    * @retval  0 Success
    * @retval -1 Failure
    */
-  int (*mbox_open_append)(struct Mailbox *m, int flags);
+  int (*mbox_open_append)(struct Mailbox *m, OpenMailboxFlags flags);
   /**
    * mbox_check - Check for new mail
    * @param m          Mailbox
@@ -271,7 +273,7 @@ struct MxOps
 int             mx_mbox_check      (struct Mailbox *m, int *index_hint);
 int             mx_mbox_check_stats(struct Mailbox *m, int flags);
 int             mx_mbox_close      (struct Context **ptr);
-struct Context *mx_mbox_open       (struct Mailbox *m, int flags);
+struct Context *mx_mbox_open       (struct Mailbox *m, OpenMailboxFlags flags);
 int             mx_mbox_sync       (struct Mailbox *m, int *index_hint);
 int             mx_msg_close       (struct Mailbox *m, struct Message **msg);
 int             mx_msg_commit      (struct Mailbox *m, struct Message *msg);

--- a/ncrypt/crypt.c
+++ b/ncrypt/crypt.c
@@ -1069,7 +1069,7 @@ int mutt_protected_headers_handler(struct Body *a, struct State *s)
       state_mark_protected_header(s);
       mutt_write_one_header(s->fp_out, "Subject", a->mime_headers->subject,
                             s->prefix, mutt_window_wrap_cols(MuttIndexWindow, C_Wrap),
-                            (s->flags & MUTT_DISPLAY) ? CH_DISPLAY : 0);
+                            (s->flags & MUTT_DISPLAY) ? CH_DISPLAY : CH_NO_FLAGS);
       state_puts("\n", s);
     }
   }

--- a/ncrypt/crypt.c
+++ b/ncrypt/crypt.c
@@ -138,11 +138,11 @@ static void disable_coredumps(void)
 
 /**
  * crypt_valid_passphrase - Check that we have a usable passphrase, ask if not
- * @param flags Flags, e.g. #APPLICATION_PGP
+ * @param flags Flags, see #SecurityFlags
  * @retval  0 Success
  * @retval -1 Failure
  */
-int crypt_valid_passphrase(int flags)
+int crypt_valid_passphrase(SecurityFlags flags)
 {
   int rc = 0;
 
@@ -523,11 +523,11 @@ int mutt_is_malformed_multipart_pgp_encrypted(struct Body *b)
  * mutt_is_application_pgp - Does the message use PGP?
  * @param m Body of email
  * @retval >0 Message uses PGP, e.g. #PGP_ENCRYPT
- * @retval  0 Message doesn't use PGP
+ * @retval  0 Message doesn't use PGP, (#SEC_NO_FLAGS)
  */
-int mutt_is_application_pgp(struct Body *m)
+SecurityFlags mutt_is_application_pgp(struct Body *m)
 {
-  int t = 0;
+  SecurityFlags t = SEC_NO_FLAGS;
   char *p = NULL;
 
   if (m->type == TYPE_APPLICATION)
@@ -582,15 +582,15 @@ int mutt_is_application_pgp(struct Body *m)
  * mutt_is_application_smime - Does the message use S/MIME?
  * @param m Body of email
  * @retval >0 Message uses S/MIME, e.g. #SMIME_ENCRYPT
- * @retval  0 Message doesn't use S/MIME
+ * @retval  0 Message doesn't use S/MIME, (#SEC_NO_FLAGS)
  */
-int mutt_is_application_smime(struct Body *m)
+SecurityFlags mutt_is_application_smime(struct Body *m)
 {
   if (!m)
-    return 0;
+    return SEC_NO_FLAGS;
 
   if (((m->type & TYPE_APPLICATION) == 0) || !m->subtype)
-    return 0;
+    return SEC_NO_FLAGS;
 
   char *t = NULL;
   bool complain = false;
@@ -606,7 +606,7 @@ int mutt_is_application_smime(struct Body *m)
       else if (mutt_str_strcasecmp(t, "signed-data") == 0)
         return SMIME_SIGN | SMIME_OPAQUE;
       else
-        return 0;
+        return SEC_NO_FLAGS;
     }
     /* Netscape 4.7 uses
       * Content-Description: S/MIME Encrypted Message
@@ -617,7 +617,7 @@ int mutt_is_application_smime(struct Body *m)
     complain = true;
   }
   else if (mutt_str_strcasecmp(m->subtype, "octet-stream") != 0)
-    return 0;
+    return SEC_NO_FLAGS;
 
   t = mutt_param_get(&m->parameter, "name");
 
@@ -632,7 +632,7 @@ int mutt_is_application_smime(struct Body *m)
       mutt_message(
           _("S/MIME messages with no hints on content are unsupported"));
     }
-    return 0;
+    return SEC_NO_FLAGS;
   }
 
   /* no .p7c, .p10 support yet. */
@@ -651,26 +651,26 @@ int mutt_is_application_smime(struct Body *m)
       return SMIME_SIGN | SMIME_OPAQUE;
   }
 
-  return 0;
+  return SEC_NO_FLAGS;
 }
 
 /**
  * crypt_query - Check out the type of encryption used
  * @param m Body of email
  * @retval num Flags, e.g. #SEC_GOODSIGN
- * @retval 0   Error
+ * @retval 0   Error (#SEC_NO_FLAGS)
  *
  * Set the cached status values if there are any.
  */
 int crypt_query(struct Body *m)
 {
-  int t = 0;
+  SecurityFlags t = SEC_NO_FLAGS;
 
   if (!WithCrypto)
-    return 0;
+    return SEC_NO_FLAGS;
 
   if (!m)
-    return 0;
+    return SEC_NO_FLAGS;
 
   if (m->type == TYPE_APPLICATION)
   {

--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -114,7 +114,7 @@ struct CryptKeyInfo
   gpgme_key_t kobj;
   int idx;                   /**< and the user ID at this index */
   const char *uid;           /**< and for convenience point to this user ID */
-  unsigned int flags;        /**< global and per uid flags (for convenience) */
+  KeyFlags flags;            /**< global and per uid flags (for convenience) */
   gpgme_validity_t validity; /**< uid validity (cached for convenience) */
 };
 
@@ -516,12 +516,12 @@ static const char *crypt_fpr_or_lkeyid(struct CryptKeyInfo *k)
 
 /**
  * crypt_key_abilities - Parse key flags into a string
- * @param flags Flags, e.g. #KEYFLAG_CANENCRYPT
+ * @param flags Flags, see #KeyFlags
  * @retval ptr Flag string
  *
  * Note: The string is statically allocated.
  */
-static char *crypt_key_abilities(int flags)
+static char *crypt_key_abilities(KeyFlags flags)
 {
   static char buf[3];
 
@@ -546,12 +546,12 @@ static char *crypt_key_abilities(int flags)
 
 /**
  * crypt_flags - Parse the key flags into a single character
- * @param flags Flags, e.g. #KEYFLAG_EXPIRED
+ * @param flags Flags, see #KeyFlags
  * @retval char Flag character
  *
  * The returned character describes the most important flag.
  */
-static char crypt_flags(int flags)
+static char crypt_flags(KeyFlags flags)
 {
   if (flags & KEYFLAG_REVOKED)
     return 'R';
@@ -3312,7 +3312,7 @@ static const char *crypt_format_str(char *buf, size_t buflen, size_t col, int co
                                     unsigned long data, MuttFormatFlags flags)
 {
   char fmt[128];
-  int kflags = 0;
+  KeyFlags kflags = KEYFLAG_NO_FLAGS;
   int optional = (flags & MUTT_FORMAT_OPTIONAL);
   const char *s = NULL;
 
@@ -4505,7 +4505,7 @@ static struct CryptKeyInfo *get_candidates(struct ListHead *hints, unsigned int 
 
     while (!(err = gpgme_op_keylist_next(ctx, &key)))
     {
-      unsigned int flags = 0;
+      KeyFlags flags = KEYFLAG_NO_FLAGS;
 
       if (key_check_cap(key, KEY_CAP_CAN_ENCRYPT))
         flags |= KEYFLAG_CANENCRYPT;
@@ -4556,7 +4556,7 @@ static struct CryptKeyInfo *get_candidates(struct ListHead *hints, unsigned int 
 
     while (!(err = gpgme_op_keylist_next(ctx, &key)))
     {
-      unsigned int flags = KEYFLAG_ISX509;
+      KeyFlags flags = KEYFLAG_ISX509;
 
       if (key_check_cap(key, KEY_CAP_CAN_ENCRYPT))
         flags |= KEYFLAG_CANENCRYPT;
@@ -4828,14 +4828,14 @@ static struct CryptKeyInfo *crypt_select_key(struct CryptKeyInfo *keys,
 /**
  * crypt_getkeybyaddr - Find a key by email address
  * @param[in]  a            Address to match
- * @param[in]  abilities    Abilities to match, e.g. #KEYFLAG_CANENCRYPT
+ * @param[in]  abilities    Abilities to match, see #KeyFlags
  * @param[in]  app          Application type, e.g. #APPLICATION_PGP
  * @param[out] forced_valid Set to true if user overrode key's validity
  * @param[in]  oppenc_mode  If true, use opportunistic encryption
  * @retval ptr Matching key
  */
 static struct CryptKeyInfo *crypt_getkeybyaddr(struct Address *a,
-                                               short abilities, unsigned int app,
+                                               KeyFlags abilities, unsigned int app,
                                                int *forced_valid, bool oppenc_mode)
 {
   struct Address *r = NULL, *p = NULL;
@@ -4958,12 +4958,12 @@ static struct CryptKeyInfo *crypt_getkeybyaddr(struct Address *a,
 /**
  * crypt_getkeybystr - Find a key by string
  * @param[in]  p            String to match
- * @param[in]  abilities    Abilities to match, e.g. #KEYFLAG_CANENCRYPT
+ * @param[in]  abilities    Abilities to match, see #KeyFlags
  * @param[in]  app          Application type, e.g. #APPLICATION_PGP
  * @param[out] forced_valid Set to true if user overrode key's validity
  * @retval ptr Matching key
  */
-static struct CryptKeyInfo *crypt_getkeybystr(char *p, short abilities,
+static struct CryptKeyInfo *crypt_getkeybystr(char *p, KeyFlags abilities,
                                               unsigned int app, int *forced_valid)
 {
   struct ListHead hints = STAILQ_HEAD_INITIALIZER(hints);
@@ -5029,7 +5029,7 @@ static struct CryptKeyInfo *crypt_getkeybystr(char *p, short abilities,
  * crypt_ask_for_key - Ask the user for a key
  * @param[in]  tag          Prompt to display
  * @param[in]  whatfor      Label to use (OPTIONAL)
- * @param[in]  abilities    Flags, e.g. #KEYFLAG_CANSIGN
+ * @param[in]  abilities    Flags, see #KeyFlags
  * @param[in]  app          Application type, e.g. #APPLICATION_PGP
  * @param[out] forced_valid Set to true if user overrode key's validity
  * @retval ptr Copy of the selected key
@@ -5037,7 +5037,7 @@ static struct CryptKeyInfo *crypt_getkeybystr(char *p, short abilities,
  * If whatfor is not null use it as default and store it under that label as
  * the next default.
  */
-static struct CryptKeyInfo *crypt_ask_for_key(char *tag, char *whatfor, short abilities,
+static struct CryptKeyInfo *crypt_ask_for_key(char *tag, char *whatfor, KeyFlags abilities,
                                               unsigned int app, int *forced_valid)
 {
   struct CryptKeyInfo *key = NULL;

--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -2666,14 +2666,13 @@ static int pgp_check_traditional_one_body(FILE *fp, struct Body *b)
 int pgp_gpgme_check_traditional(FILE *fp, struct Body *b, bool just_one)
 {
   int rc = 0;
-  int r;
   for (; b; b = b->next)
   {
     if (!just_one && is_multipart(b))
       rc = (pgp_gpgme_check_traditional(fp, b->parts, false) || rc);
     else if (b->type == TYPE_TEXT)
     {
-      r = mutt_is_application_pgp(b);
+      SecurityFlags r = mutt_is_application_pgp(b);
       if (r != 0)
         rc = (rc || r);
       else
@@ -4450,7 +4449,7 @@ static char *list_to_pattern(struct ListHead *list)
  *
  * Select by looking at the HINTS list.
  */
-static struct CryptKeyInfo *get_candidates(struct ListHead *hints, unsigned int app, int secret)
+static struct CryptKeyInfo *get_candidates(struct ListHead *hints, SecurityFlags app, int secret)
 {
   struct CryptKeyInfo *db = NULL, *k = NULL, **kend = NULL;
   gpgme_error_t err;

--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -3309,7 +3309,7 @@ int smime_gpgme_application_handler(struct Body *a, struct State *s)
 static const char *crypt_format_str(char *buf, size_t buflen, size_t col, int cols,
                                     char op, const char *src, const char *prec,
                                     const char *if_str, const char *else_str,
-                                    unsigned long data, int flags)
+                                    unsigned long data, MuttFormatFlags flags)
 {
   char fmt[128];
   int kflags = 0;

--- a/ncrypt/crypt_mod.h
+++ b/ncrypt/crypt_mod.h
@@ -25,6 +25,7 @@
 
 #include <stdbool.h>
 #include <stdio.h>
+#include "ncrypt.h"
 
 struct Address;
 struct Body;
@@ -152,12 +153,12 @@ struct CryptModuleSpecs
   /**
    * pgp_traditional_encryptsign - Create an inline PGP encrypted, signed email
    * @param a       Body of the email
-   * @param flags   Flags, e.g. #SEC_ENCRYPT
+   * @param flags   Flags, see #SecurityFlags
    * @param keylist List of keys to encrypt to (space-separated)
    * @retval ptr  New encrypted/siged Body
    * @retval NULL Error
    */
-  struct Body *(*pgp_traditional_encryptsign)(struct Body *a, int flags, char *keylist);
+  struct Body *(*pgp_traditional_encryptsign)(struct Body *a, SecurityFlags flags, char *keylist);
   /**
    * pgp_invoke_getkeys - Run a command to download a PGP key
    * @param addr Address to search for

--- a/ncrypt/cryptglue.c
+++ b/ncrypt/cryptglue.c
@@ -131,11 +131,11 @@ void crypt_init(void)
 
 /**
  * crypt_invoke_message - Display an informative message
- * @param type Crypto type, e.g. #APPLICATION_PGP
+ * @param type Crypto type, see #SecurityFlags
  *
  * Show a message that a backend will be invoked.
  */
-void crypt_invoke_message(int type)
+void crypt_invoke_message(SecurityFlags type)
 {
   if (((WithCrypto & APPLICATION_PGP) != 0) && (type & APPLICATION_PGP))
     mutt_message(_("Invoking PGP..."));
@@ -145,11 +145,11 @@ void crypt_invoke_message(int type)
 
 /**
  * crypt_has_module_backend - Is there a crypto backend for a given type?
- * @param type Crypto type, e.g. #APPLICATION_PGP
+ * @param type Crypto type, see #SecurityFlags
  * @retval true  Backend is present
  * @retval false Backend is not present
  */
-bool crypt_has_module_backend(int type)
+bool crypt_has_module_backend(SecurityFlags type)
 {
   if (((WithCrypto & APPLICATION_PGP) != 0) && (type & APPLICATION_PGP) &&
       crypto_module_lookup(APPLICATION_PGP))

--- a/ncrypt/gnupgparse.c
+++ b/ncrypt/gnupgparse.c
@@ -135,7 +135,7 @@ static struct PgpKeyInfo *parse_pub_line(char *buf, int *is_subkey, struct PgpKe
   bool is_fpr = false;
   char *pend = NULL, *p = NULL;
   int trust = 0;
-  int flags = 0;
+  KeyFlags flags = KEYFLAG_NO_FLAGS;
   struct PgpKeyInfo tmp;
 
   *is_subkey = 0;

--- a/ncrypt/ncrypt.h
+++ b/ncrypt/ncrypt.h
@@ -115,6 +115,8 @@ extern long  C_SmimeTimeout;
 extern char *C_SmimeVerifyCommand;
 extern char *C_SmimeVerifyOpaqueCommand;
 
+typedef uint16_t SecurityFlags;           ///< Flags, e.g. #SEC_ENCRYPT
+#define SEC_NO_FLAGS                  0   ///< No flags are set
 #define SEC_ENCRYPT             (1 << 0)  ///< Email is encrypted
 #define SEC_SIGN                (1 << 1)  ///< Email is signed
 #define SEC_GOODSIGN            (1 << 2)  ///< Email has a valid signature
@@ -182,9 +184,9 @@ void         crypt_forget_passphrase(void);
 int          crypt_get_keys(struct Email *msg, char **keylist, bool oppenc_mode);
 void         crypt_opportunistic_encrypt(struct Email *msg);
 int          crypt_query(struct Body *m);
-int          crypt_valid_passphrase(int flags);
-int          mutt_is_application_pgp(struct Body *m);
-int          mutt_is_application_smime(struct Body *m);
+int          crypt_valid_passphrase(SecurityFlags flags);
+SecurityFlags mutt_is_application_pgp(struct Body *m);
+SecurityFlags mutt_is_application_smime(struct Body *m);
 int          mutt_is_malformed_multipart_pgp_encrypted(struct Body *b);
 int          mutt_is_multipart_encrypted(struct Body *b);
 int          mutt_is_multipart_signed(struct Body *b);
@@ -195,9 +197,9 @@ bool         mutt_should_hide_protected_subject(struct Email *e);
 int          mutt_signed_handler(struct Body *a, struct State *s);
 
 /* cryptglue.c */
-bool         crypt_has_module_backend(int type);
+bool         crypt_has_module_backend(SecurityFlags type);
 void         crypt_init(void);
-void         crypt_invoke_message(int type);
+void         crypt_invoke_message(SecurityFlags type);
 int          crypt_pgp_application_handler(struct Body *m, struct State *s);
 int          crypt_pgp_check_traditional(FILE *fp, struct Body *b, bool just_one);
 int          crypt_pgp_decrypt_mime(FILE *a, FILE **b, struct Body *c, struct Body **d);

--- a/ncrypt/ncrypt.h
+++ b/ncrypt/ncrypt.h
@@ -50,6 +50,7 @@
 #define MUTT_NCRYPT_NCRYPT_H
 
 #include <stdbool.h>
+#include <stdint.h>
 #include <stdio.h>
 
 struct Address;
@@ -156,6 +157,8 @@ extern char *C_SmimeVerifyOpaqueCommand;
 #define WithCrypto 0
 #endif
 
+typedef uint16_t KeyFlags;                  ///< Flags describing PGP/SMIME keys, e.g. #KEYFLAG_CANSIGN
+#define KEYFLAG_NO_FLAGS                0   ///< No flags are set
 #define KEYFLAG_CANSIGN           (1 << 0)  ///< Key is suitable for signing
 #define KEYFLAG_CANENCRYPT        (1 << 1)  ///< Key is suitable for encryption
 #define KEYFLAG_ISX509            (1 << 2)  ///< Key is an X.509 key

--- a/ncrypt/pgp.c
+++ b/ncrypt/pgp.c
@@ -1667,7 +1667,7 @@ struct Body *pgp_class_encrypt_message(struct Body *a, char *keylist, bool sign)
 /**
  * pgp_class_traditional_encryptsign - Implements CryptModuleSpecs::pgp_traditional_encryptsign()
  */
-struct Body *pgp_class_traditional_encryptsign(struct Body *a, int flags, char *keylist)
+struct Body *pgp_class_traditional_encryptsign(struct Body *a, SecurityFlags flags, char *keylist)
 {
   struct Body *b = NULL;
 

--- a/ncrypt/pgp.h
+++ b/ncrypt/pgp.h
@@ -55,7 +55,7 @@ void pgp_class_void_passphrase(void);
 int pgp_class_valid_passphrase(void);
 
 int pgp_class_verify_one(struct Body *sigbdy, struct State *s, const char *tempfile);
-struct Body *pgp_class_traditional_encryptsign(struct Body *a, int flags, char *keylist);
+struct Body *pgp_class_traditional_encryptsign(struct Body *a, SecurityFlags flags, char *keylist);
 struct Body *pgp_class_encrypt_message(struct Body *a, char *keylist, bool sign);
 struct Body *pgp_class_sign_message(struct Body *a);
 

--- a/ncrypt/pgpinvoke.c
+++ b/ncrypt/pgpinvoke.c
@@ -94,7 +94,7 @@ struct PgpCommandContext
 static const char *fmt_pgp_command(char *buf, size_t buflen, size_t col, int cols,
                                    char op, const char *src, const char *prec,
                                    const char *if_str, const char *else_str,
-                                   unsigned long data, int flags)
+                                   unsigned long data, MuttFormatFlags flags)
 {
   char fmt[128];
   struct PgpCommandContext *cctx = (struct PgpCommandContext *) data;

--- a/ncrypt/pgpinvoke.c
+++ b/ncrypt/pgpinvoke.c
@@ -369,16 +369,16 @@ pid_t pgp_invoke_encrypt(FILE **pgpin, FILE **pgpout, FILE **pgperr,
  * @param[in]  pgperrfd stderr for the command, or -1 (OPTIONAL)
  * @param[in]  fname    Filename to pass to the command
  * @param[in]  uids     List of IDs/fingerprints, space separated
- * @param[in]  flags    Flags, e.g. #SEC_SIGN, #SEC_ENCRYPT
+ * @param[in]  flags    Flags, see #SecurityFlags
  * @retval num PID of the created process
  * @retval -1  Error creating pipes or forking
  *
  * @note `pgpin` has priority over `pgpinfd`.
  *       Likewise `pgpout` and `pgperr`.
  */
-pid_t pgp_invoke_traditional(FILE **pgpin, FILE **pgpout, FILE **pgperr,
-                             int pgpinfd, int pgpoutfd, int pgperrfd,
-                             const char *fname, const char *uids, int flags)
+pid_t pgp_invoke_traditional(FILE **pgpin, FILE **pgpout, FILE **pgperr, int pgpinfd,
+                             int pgpoutfd, int pgperrfd, const char *fname,
+                             const char *uids, SecurityFlags flags)
 {
   if (flags & SEC_ENCRYPT)
   {

--- a/ncrypt/pgpkey.c
+++ b/ncrypt/pgpkey.c
@@ -82,12 +82,12 @@ static const char trust_flags[] = "?- +";
 
 /**
  * pgp_key_abilities - Turn PGP key abilities into a string
- * @param flags Flags, e.g. #KEYFLAG_CANENCRYPT
+ * @param flags Flags, see #KeyFlags
  * @retval ptr Abilities string
  *
  * @note This returns a pointer to a static buffer
  */
-static char *pgp_key_abilities(int flags)
+static char *pgp_key_abilities(KeyFlags flags)
 {
   static char buf[3];
 
@@ -112,10 +112,10 @@ static char *pgp_key_abilities(int flags)
 
 /**
  * pgp_flags - Turn PGP key flags into a string
- * @param flags Flags, e.g. #KEYFLAG_REVOKED
+ * @param flags Flags, see #KeyFlags
  * @retval char Flag character
  */
-static char pgp_flags(int flags)
+static char pgp_flags(KeyFlags flags)
 {
   if (flags & KEYFLAG_REVOKED)
     return 'R';
@@ -177,7 +177,7 @@ static const char *pgp_entry_fmt(char *buf, size_t buflen, size_t col, int cols,
                                  unsigned long data, MuttFormatFlags flags)
 {
   char fmt[128];
-  int kflags = 0;
+  KeyFlags kflags = KEYFLAG_NO_FLAGS;
   int optional = (flags & MUTT_FORMAT_OPTIONAL);
 
   struct PgpEntry *entry = (struct PgpEntry *) data;
@@ -812,11 +812,12 @@ static struct PgpKeyInfo *pgp_select_key(struct PgpKeyInfo *keys,
  * pgp_ask_for_key - Ask the user for a PGP key
  * @param tag       Prompt for the user
  * @param whatfor   Use for key, e.g. "signing"
- * @param abilities Abilities to match, e.g. #KEYFLAG_CANENCRYPT
+ * @param abilities Abilities to match, see #KeyFlags
  * @param keyring   PGP keyring to use
  * @retval ptr Selected PGP key
  */
-struct PgpKeyInfo *pgp_ask_for_key(char *tag, char *whatfor, short abilities, enum PgpRing keyring)
+struct PgpKeyInfo *pgp_ask_for_key(char *tag, char *whatfor, KeyFlags abilities,
+                                   enum PgpRing keyring)
 {
   struct PgpKeyInfo *key = NULL;
   char resp[128];
@@ -981,12 +982,12 @@ static struct PgpKeyInfo **pgp_get_lastp(struct PgpKeyInfo *p)
 /**
  * pgp_getkeybyaddr - Find a PGP key by address
  * @param a           Email address to match
- * @param abilities   Abilities to match, e.g. #KEYFLAG_CANENCRYPT
+ * @param abilities   Abilities to match, see #KeyFlags
  * @param keyring     PGP keyring to use
  * @param oppenc_mode If true, use opportunistic encryption
  * @retval ptr Matching PGP key
  */
-struct PgpKeyInfo *pgp_getkeybyaddr(struct Address *a, short abilities,
+struct PgpKeyInfo *pgp_getkeybyaddr(struct Address *a, KeyFlags abilities,
                                     enum PgpRing keyring, bool oppenc_mode)
 {
   if (!a)
@@ -1117,11 +1118,11 @@ struct PgpKeyInfo *pgp_getkeybyaddr(struct Address *a, short abilities,
 /**
  * pgp_getkeybystr - Find a PGP key by string
  * @param p         String to match
- * @param abilities   Abilities to match, e.g. #KEYFLAG_CANENCRYPT
+ * @param abilities   Abilities to match, see #KeyFlags
  * @param keyring     PGP keyring to use
  * @retval ptr Matching PGP key
  */
-struct PgpKeyInfo *pgp_getkeybystr(char *p, short abilities, enum PgpRing keyring)
+struct PgpKeyInfo *pgp_getkeybystr(char *p, KeyFlags abilities, enum PgpRing keyring)
 {
   struct ListHead hints = STAILQ_HEAD_INITIALIZER(hints);
   struct PgpKeyInfo *keys = NULL;

--- a/ncrypt/pgpkey.c
+++ b/ncrypt/pgpkey.c
@@ -174,7 +174,7 @@ struct PgpEntry
 static const char *pgp_entry_fmt(char *buf, size_t buflen, size_t col, int cols,
                                  char op, const char *src, const char *prec,
                                  const char *if_str, const char *else_str,
-                                 unsigned long data, int flags)
+                                 unsigned long data, MuttFormatFlags flags)
 {
   char fmt[128];
   int kflags = 0;

--- a/ncrypt/pgpkey.h
+++ b/ncrypt/pgpkey.h
@@ -24,6 +24,7 @@
 #define MUTT_NCRYPT_PGPKEY_H
 
 #include <stdbool.h>
+#include "ncrypt.h"
 
 struct Address;
 
@@ -38,8 +39,8 @@ enum PgpRing
 
 struct Body *pgp_class_make_key_attachment(void);
 
-struct PgpKeyInfo *pgp_ask_for_key(char *tag, char *whatfor, short abilities, enum PgpRing keyring);
-struct PgpKeyInfo *pgp_getkeybyaddr(struct Address *a, short abilities, enum PgpRing keyring, bool oppenc_mode);
-struct PgpKeyInfo *pgp_getkeybystr(char *p, short abilities, enum PgpRing keyring);
+struct PgpKeyInfo *pgp_ask_for_key(char *tag, char *whatfor, KeyFlags abilities, enum PgpRing keyring);
+struct PgpKeyInfo *pgp_getkeybyaddr(struct Address *a, KeyFlags abilities, enum PgpRing keyring, bool oppenc_mode);
+struct PgpKeyInfo *pgp_getkeybystr(char *p, KeyFlags abilities, enum PgpRing keyring);
 
 #endif /* MUTT_NCRYPT_PGPKEY_H */

--- a/ncrypt/pgplib.h
+++ b/ncrypt/pgplib.h
@@ -26,6 +26,7 @@
 
 #include <stdbool.h>
 #include <time.h>
+#include "ncrypt.h"
 
 /**
  * struct PgpUid - PGP User ID
@@ -47,7 +48,7 @@ struct PgpKeyInfo
   char *keyid;
   char *fingerprint;
   struct PgpUid *address;
-  int flags;
+  KeyFlags flags;
   short keylen;
   time_t gen_time;
   int numalg;

--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -2007,7 +2007,7 @@ static struct Body *smime_handle_entity(struct Body *m, struct State *s, FILE *o
   struct stat info;
   struct Body *p = NULL;
   pid_t thepid = -1;
-  unsigned int type = mutt_is_application_smime(m);
+  SecurityFlags type = mutt_is_application_smime(m);
 
   if (!(type & APPLICATION_SMIME))
     return NULL;

--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -411,12 +411,12 @@ static pid_t smime_invoke(FILE **smimein, FILE **smimeout, FILE **smimeerr,
 
 /**
  * smime_key_flags - Turn SMIME key flags into a string
- * @param flags Flags, e.g. #KEYFLAG_CANENCRYPT
+ * @param flags Flags, see #KeyFlags
  * @retval ptr Flag string
  *
  * Note: The string is statically allocated.
  */
-static char *smime_key_flags(int flags)
+static char *smime_key_flags(KeyFlags flags)
 {
   static char buf[3];
 
@@ -779,12 +779,12 @@ static struct SmimeKey *smime_get_key_by_hash(char *hash, bool public)
 /**
  * smime_get_key_by_addr - Find an SIME key by address
  * @param mailbox   Email address to match
- * @param abilities Abilities to match, e.g. #KEYFLAG_CANENCRYPT
+ * @param abilities Abilities to match, see #KeyFlags
  * @param public    If true, only get the public keys
  * @param may_ask   If true, the user may be asked to select a key
  * @retval ptr Matching key
  */
-static struct SmimeKey *smime_get_key_by_addr(char *mailbox, short abilities,
+static struct SmimeKey *smime_get_key_by_addr(char *mailbox, KeyFlags abilities,
                                               bool public, bool may_ask)
 {
   struct SmimeKey *results = NULL, *result = NULL;
@@ -859,11 +859,11 @@ static struct SmimeKey *smime_get_key_by_addr(char *mailbox, short abilities,
 /**
  * smime_get_key_by_str - Find an SMIME key by string
  * @param str       String to match
- * @param abilities Abilities to match, e.g. #KEYFLAG_CANENCRYPT
+ * @param abilities Abilities to match, see #KeyFlags
  * @param public    If true, only get the public keys
  * @retval ptr Matching key
  */
-static struct SmimeKey *smime_get_key_by_str(char *str, short abilities, bool public)
+static struct SmimeKey *smime_get_key_by_str(char *str, KeyFlags abilities, bool public)
 {
   struct SmimeKey *results = NULL, *result = NULL;
   struct SmimeKey *matches = NULL;
@@ -905,11 +905,11 @@ static struct SmimeKey *smime_get_key_by_str(char *str, short abilities, bool pu
 /**
  * smime_ask_for_key - Ask the user to select a key
  * @param prompt    Prompt to show the user
- * @param abilities Abilities to match, e.g. #KEYFLAG_CANENCRYPT
+ * @param abilities Abilities to match, see #KeyFlags
  * @param public    If true, only get the public keys
  * @retval ptr Selected SMIME key
  */
-static struct SmimeKey *smime_ask_for_key(char *prompt, short abilities, bool public)
+static struct SmimeKey *smime_ask_for_key(char *prompt, KeyFlags abilities, bool public)
 {
   struct SmimeKey *key = NULL;
   char resp[128];

--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -212,7 +212,7 @@ int smime_class_valid_passphrase(void)
 static const char *fmt_smime_command(char *buf, size_t buflen, size_t col, int cols,
                                      char op, const char *src, const char *prec,
                                      const char *if_str, const char *else_str,
-                                     unsigned long data, int flags)
+                                     unsigned long data, MuttFormatFlags flags)
 {
   char fmt[128];
   struct SmimeCommandContext *cctx = (struct SmimeCommandContext *) data;

--- a/ncrypt/smime.h
+++ b/ncrypt/smime.h
@@ -43,7 +43,7 @@ struct SmimeKey
   char *label;
   char *issuer;
   char trust; /**< i=Invalid r=revoked e=expired u=unverified v=verified t=trusted */
-  int flags;
+  KeyFlags flags;
   struct SmimeKey *next;
 };
 

--- a/nntp/browse.c
+++ b/nntp/browse.c
@@ -54,7 +54,7 @@
 const char *group_index_format_str(char *buf, size_t buflen, size_t col, int cols,
                                    char op, const char *src, const char *prec,
                                    const char *if_str, const char *else_str,
-                                   unsigned long data, int flags)
+                                   unsigned long data, MuttFormatFlags flags)
 {
   char fn[128], fmt[128];
   struct Folder *folder = (struct Folder *) data;

--- a/nntp/newsrc.c
+++ b/nntp/newsrc.c
@@ -919,7 +919,7 @@ void nntp_clear_cache(struct NntpAccountData *adata)
  */
 const char *nntp_format_str(char *buf, size_t buflen, size_t col, int cols, char op,
                             const char *src, const char *prec, const char *if_str,
-                            const char *else_str, unsigned long data, int flags)
+                            const char *else_str, unsigned long data, MuttFormatFlags flags)
 {
   struct NntpAccountData *adata = (struct NntpAccountData *) data;
   struct ConnAccount *acct = &adata->conn->account;

--- a/nntp/nntp.h
+++ b/nntp/nntp.h
@@ -171,10 +171,10 @@ void nntp_newsrc_close(struct NntpAccountData *adata);
 void nntp_mailbox(struct Mailbox *m, char *buf, size_t buflen);
 void nntp_expand_path(char *buf, size_t buflen, struct ConnAccount *acct);
 void nntp_clear_cache(struct NntpAccountData *adata);
-const char *nntp_format_str(char *buf, size_t buflen, size_t col, int cols, char op, const char *src, const char *prec, const char *if_str, const char *else_str, unsigned long data, int flags);
+const char *nntp_format_str(char *buf, size_t buflen, size_t col, int cols, char op, const char *src, const char *prec, const char *if_str, const char *else_str, unsigned long data, MuttFormatFlags flags);
 int nntp_compare_order(const void *a, const void *b);
 int nntp_path_probe(const char *path, const struct stat *st);
-const char *group_index_format_str(char *buf, size_t buflen, size_t col, int cols, char op, const char *src, const char *prec, const char *if_str, const char *else_str, unsigned long data, int flags);
+const char *group_index_format_str(char *buf, size_t buflen, size_t col, int cols, char op, const char *src, const char *prec, const char *if_str, const char *else_str, unsigned long data, MuttFormatFlags flags);
 int nntp_complete(char *buf, size_t buflen);
 
 #endif /* MUTT_NNTP_NNTP_H */

--- a/pager.c
+++ b/pager.c
@@ -3233,9 +3233,10 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         CHECK_MODE(IsEmail(extra) || IsMsgAttach(extra));
         CHECK_ATTACH;
 
-        int replyflags = SEND_REPLY | (ch == OP_GROUP_REPLY ? SEND_GROUP_REPLY : 0) |
-                         (ch == OP_GROUP_CHAT_REPLY ? SEND_GROUP_CHAT_REPLY : 0) |
-                         (ch == OP_LIST_REPLY ? SEND_LIST_REPLY : 0);
+        SendFlags replyflags =
+            SEND_REPLY | (ch == OP_GROUP_REPLY ? SEND_GROUP_REPLY : 0) |
+            (ch == OP_GROUP_CHAT_REPLY ? SEND_GROUP_CHAT_REPLY : 0) |
+            (ch == OP_LIST_REPLY ? SEND_LIST_REPLY : 0);
 
         if (IsMsgAttach(extra))
           mutt_attach_reply(extra->fp, extra->email, extra->actx, extra->body, replyflags);

--- a/pager.c
+++ b/pager.c
@@ -278,12 +278,12 @@ static int comp_syntax_t(const void *m1, const void *m2)
  * @param line_info Line info array
  * @param n         Line Number (index into line_info)
  * @param cnt       If true, this is a continuation line
- * @param flags     Flags, e.g. #MUTT_PAGER_LOGS
+ * @param flags     Flags, see #PagerFlags
  * @param special   Flags, e.g. A_BOLD
  * @param a         ANSI attributes
  */
-static void resolve_color(struct Line *line_info, int n, int cnt, int flags,
-                          int special, struct AnsiAttr *a)
+static void resolve_color(struct Line *line_info, int n, int cnt,
+                          PagerFlags flags, int special, struct AnsiAttr *a)
 {
   int def_color;         /* color without syntax highlight */
   int color;             /* final color */
@@ -1351,7 +1351,7 @@ static int fill_buffer(FILE *f, LOFF_T *last_pos, LOFF_T offset, unsigned char *
  * @param[out] line_info    Line info
  * @param[in]  n            Line number (index into line_info)
  * @param[in]  buf          Text to display
- * @param[in]  flags        Flags, e.g. #MUTT_PAGER_NOWRAP
+ * @param[in]  flags        Flags, see #PagerFlags
  * @param[out] pa           ANSI attributes used
  * @param[in]  cnt          Length of text buffer
  * @param[out] pspace       Index of last whitespace character
@@ -1361,9 +1361,9 @@ static int fill_buffer(FILE *f, LOFF_T *last_pos, LOFF_T offset, unsigned char *
  * @param[in]  pager_window Window to write to
  * @retval num Number of characters displayed
  */
-static int format_line(struct Line **line_info, int n, unsigned char *buf, int flags,
-                       struct AnsiAttr *pa, int cnt, int *pspace, int *pvch,
-                       int *pcol, int *pspecial, struct MuttWindow *pager_window)
+static int format_line(struct Line **line_info, int n, unsigned char *buf,
+                       PagerFlags flags, struct AnsiAttr *pa, int cnt, int *pspace,
+                       int *pvch, int *pcol, int *pspecial, struct MuttWindow *pager_window)
 {
   int space = -1; /* index of the last space or TAB */
   int col = C_Markers ? (*line_info)[n].continuation : 0;
@@ -1542,7 +1542,7 @@ static int format_line(struct Line **line_info, int n, unsigned char *buf, int f
  * @param[in]  n               Line number
  * @param[out] last            Last line
  * @param[out] max             Maximum number of lines
- * @param[in]  flags           Flags, e.g. #MUTT_SHOWFLAT
+ * @param[in]  flags           Flags, see #PagerFlags
  * @param[out] quote_list      Email quoting style
  * @param[out] q_level         Level of quoting
  * @param[out] force_redraw    Force a repaint
@@ -1552,10 +1552,10 @@ static int format_line(struct Line **line_info, int n, unsigned char *buf, int f
  * @retval 0  normal exit, line was not displayed
  * @retval >0 normal exit, line was displayed
  */
-static int display_line(FILE *f, LOFF_T *last_pos, struct Line **line_info, int n,
-                        int *last, int *max, int flags, struct QClass **quote_list,
-                        int *q_level, bool *force_redraw, regex_t *search_re,
-                        struct MuttWindow *pager_window)
+static int display_line(FILE *f, LOFF_T *last_pos, struct Line **line_info,
+                        int n, int *last, int *max, PagerFlags flags,
+                        struct QClass **quote_list, int *q_level, bool *force_redraw,
+                        regex_t *search_re, struct MuttWindow *pager_window)
 {
   unsigned char *buf = NULL, *fmt = NULL;
   size_t buflen = 0;
@@ -1881,7 +1881,7 @@ void mutt_clear_pager_position(void)
  */
 struct PagerRedrawData
 {
-  int flags;
+  PagerFlags flags;
   struct Pager *extra;
   int indexlen;
   int indicator; /**< the indicator line of the PI */
@@ -1893,7 +1893,7 @@ struct PagerRedrawData
   int topline;
   bool force_redraw;
   int has_types;
-  int hide_quoted;
+  PagerFlags hide_quoted;
   int q_level;
   struct QClass *quote_list;
   LOFF_T last_pos;
@@ -1905,7 +1905,7 @@ struct PagerRedrawData
   struct Menu *index; /**< the Pager Index (PI) */
   regex_t search_re;
   bool search_compiled;
-  int search_flag;
+  PagerFlags search_flag;
   bool search_back;
   const char *banner;
   char *helpstr;
@@ -2226,7 +2226,7 @@ static void pager_custom_redraw(struct Menu *pager_menu)
  * there so that we can do operations on the current message without the need
  * to pop back out to the main-menu.
  */
-int mutt_pager(const char *banner, const char *fname, int flags, struct Pager *extra)
+int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct Pager *extra)
 {
   static char searchbuf[256] = "";
   char buffer[1024];

--- a/pager.h
+++ b/pager.h
@@ -38,7 +38,8 @@ extern bool          C_SmartWrap;
 extern struct Regex *C_Smileys;
 extern bool          C_Tilde;
 
-/* dynamic internal flags */
+typedef uint16_t PagerFlags;              ///< Flags for mutt_pager(), e.g. #MUTT_SHOWFLAT
+#define MUTT_PAGER_NO_FLAGS         0     ///< No flags are set
 #define MUTT_SHOWFLAT         (1 << 0)    ///< Show characters (used for displaying help)
 #define MUTT_SHOWCOLOR        (1 << 1)    ///< Show characters in color otherwise don't show characters
 #define MUTT_HIDE             (1 << 2)    ///< Don't show quoted text
@@ -69,7 +70,7 @@ struct Pager
   struct AttachCtx *actx; /**< attachment information */
 };
 
-int mutt_pager(const char *banner, const char *fname, int flags, struct Pager *extra);
+int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct Pager *extra);
 
 void mutt_clear_pager_position(void);
 

--- a/postpone.c
+++ b/postpone.c
@@ -447,16 +447,16 @@ int mutt_get_postponed(struct Context *ctx, struct Email *hdr,
  * @param p                Header string to parse
  * @param set_empty_signas Allow an empty "Sign as"
  * @param crypt_app App, e.g. #APPLICATION_PGP
- * @retval num Flags, e.g. #SEC_ENCRYPT
+ * @retval num SecurityFlags, see #SecurityFlags
  */
-int mutt_parse_crypt_hdr(const char *p, int set_empty_signas, int crypt_app)
+SecurityFlags mutt_parse_crypt_hdr(const char *p, int set_empty_signas, SecurityFlags crypt_app)
 {
   char smime_cryptalg[1024] = "\0";
   char sign_as[1024] = "\0", *q = NULL;
-  int flags = 0;
+  SecurityFlags flags = SEC_NO_FLAGS;
 
   if (!WithCrypto)
-    return 0;
+    return SEC_NO_FLAGS;
 
   p = mutt_str_skip_email_wsp(p);
   for (; *p; p++)
@@ -478,7 +478,7 @@ int mutt_parse_crypt_hdr(const char *p, int set_empty_signas, int crypt_app)
           if (*p != '>')
           {
             mutt_error(_("Illegal S/MIME header"));
-            return 0;
+            return SEC_NO_FLAGS;
           }
         }
 
@@ -509,7 +509,7 @@ int mutt_parse_crypt_hdr(const char *p, int set_empty_signas, int crypt_app)
           if (*p != '>')
           {
             mutt_error(_("Illegal crypto header"));
-            return 0;
+            return SEC_NO_FLAGS;
           }
         }
 
@@ -535,7 +535,7 @@ int mutt_parse_crypt_hdr(const char *p, int set_empty_signas, int crypt_app)
           if (*p != '>')
           {
             mutt_error(_("Illegal crypto header"));
-            return 0;
+            return SEC_NO_FLAGS;
           }
         }
 
@@ -544,7 +544,7 @@ int mutt_parse_crypt_hdr(const char *p, int set_empty_signas, int crypt_app)
 
       default:
         mutt_error(_("Illegal crypto header"));
-        return 0;
+        return SEC_NO_FLAGS;
     }
   }
 
@@ -590,7 +590,7 @@ int mutt_prepare_template(FILE *fp, struct Mailbox *m, struct Email *newhdr,
   FILE *bfp = NULL;
   int rc = -1;
   struct State s = { 0 };
-  int sec_type;
+  SecurityFlags sec_type;
   struct Envelope *protected_headers = NULL;
 
   if (!fp && !(msg = mx_msg_open(m, e->msgno)))

--- a/protos.h
+++ b/protos.h
@@ -30,6 +30,7 @@
 #include <time.h>
 #include "config/lib.h"
 #include "mutt.h"
+#include "ncrypt/ncrypt.h"
 
 struct Context;
 struct EnterState;
@@ -75,7 +76,7 @@ int mutt_enter_string(char *buf, size_t buflen, int col, CompletionFlags flags);
 int mutt_enter_string_full(char *buf, size_t buflen, int col, CompletionFlags flags, bool multiple,
                            char ***files, int *numfiles, struct EnterState *state);
 int mutt_get_postponed(struct Context *ctx, struct Email *e, struct Email **cur, char *fcc, size_t fcclen);
-int mutt_parse_crypt_hdr(const char *p, int set_empty_signas, int crypt_app);
+SecurityFlags mutt_parse_crypt_hdr(const char *p, int set_empty_signas, SecurityFlags crypt_app);
 int mutt_num_postponed(struct Mailbox *m, bool force);
 int mutt_thread_set_flag(struct Email *e, int flag, bool bf, bool subthread);
 void mutt_update_num_postponed(void);

--- a/protos.h
+++ b/protos.h
@@ -29,6 +29,7 @@
 #include <stdio.h>
 #include <time.h>
 #include "config/lib.h"
+#include "mutt.h"
 
 struct Context;
 struct EnterState;
@@ -70,9 +71,9 @@ int mutt_change_flag(struct Mailbox *m, struct EmailList *el, int bf);
 
 int mutt_complete(char *buf, size_t buflen);
 int mutt_prepare_template(FILE *fp, struct Mailbox *m, struct Email *newhdr, struct Email *e, bool resend);
-int mutt_enter_string(char *buf, size_t buflen, int col, int flags);
-int mutt_enter_string_full(char *buf, size_t buflen, int col, int flags, bool multiple,
-                       char ***files, int *numfiles, struct EnterState *state);
+int mutt_enter_string(char *buf, size_t buflen, int col, CompletionFlags flags);
+int mutt_enter_string_full(char *buf, size_t buflen, int col, CompletionFlags flags, bool multiple,
+                           char ***files, int *numfiles, struct EnterState *state);
 int mutt_get_postponed(struct Context *ctx, struct Email *e, struct Email **cur, char *fcc, size_t fcclen);
 int mutt_parse_crypt_hdr(const char *p, int set_empty_signas, int crypt_app);
 int mutt_num_postponed(struct Mailbox *m, bool force);

--- a/query.c
+++ b/query.c
@@ -247,7 +247,7 @@ static int query_search(struct Menu *menu, regex_t *rx, int line)
 static const char *query_format_str(char *buf, size_t buflen, size_t col, int cols,
                                     char op, const char *src, const char *prec,
                                     const char *if_str, const char *else_str,
-                                    unsigned long data, int flags)
+                                    unsigned long data, MuttFormatFlags flags)
 {
   struct Entry *entry = (struct Entry *) data;
   struct Query *query = entry->data;

--- a/recvattach.c
+++ b/recvattach.c
@@ -1320,7 +1320,7 @@ void mutt_view_attachments(struct Email *e)
 {
   char helpstr[1024];
   struct Body *cur = NULL;
-  int flags = 0;
+  SendFlags flags = SEND_NO_FLAGS;
   int op = OP_NULL;
 
   struct Mailbox *m = Context ? Context->mailbox : NULL;

--- a/recvattach.c
+++ b/recvattach.c
@@ -1136,7 +1136,8 @@ static void mutt_generate_recvattach_list(struct AttachCtx *actx, struct Email *
   struct Body *m = NULL;
   struct Body *new_body = NULL;
   FILE *new_fp = NULL;
-  int type, need_secured, secured;
+  SecurityFlags type;
+  int need_secured, secured;
 
   for (m = parts; m; m = m->next)
   {

--- a/recvattach.c
+++ b/recvattach.c
@@ -205,9 +205,10 @@ void mutt_update_tree(struct AttachCtx *actx)
  * | \%u     | Unlink
  * | \%X     | Number of qualifying MIME parts in this part and its children
  */
-const char *attach_format_str(char *buf, size_t buflen, size_t col, int cols, char op,
-                              const char *src, const char *prec, const char *if_str,
-                              const char *else_str, unsigned long data, int flags)
+const char *attach_format_str(char *buf, size_t buflen, size_t col, int cols,
+                              char op, const char *src, const char *prec,
+                              const char *if_str, const char *else_str,
+                              unsigned long data, MuttFormatFlags flags)
 {
   char fmt[128];
   char charset[128];

--- a/recvattach.h
+++ b/recvattach.h
@@ -41,7 +41,7 @@ extern char *C_MessageFormat;
 void mutt_attach_init(struct AttachCtx *actx);
 void mutt_update_tree(struct AttachCtx *actx);
 
-const char *attach_format_str(char *buf, size_t buflen, size_t col, int cols, char op, const char *src, const char *prec, const char *if_str, const char *else_str, unsigned long data, int flags);
+const char *attach_format_str(char *buf, size_t buflen, size_t col, int cols, char op, const char *src, const char *prec, const char *if_str, const char *else_str, unsigned long data, MuttFormatFlags flags);
 void mutt_view_attachments(struct Email *e);
 
 #endif /* MUTT_RECVATTACH_H */

--- a/recvcmd.c
+++ b/recvcmd.c
@@ -622,7 +622,7 @@ bail:
  * @param fp    File handle to attachment
  * @param actx  Attachment Context
  * @param cur   Attachment to forward (OPTIONAL)
- * @param flags Send mode, e.g. #SEND_RESEND
+ * @param flags Send mode, see #SendFlags
  *
  * This is different from the previous function since we want to mimic the
  * index menu's behavior.
@@ -631,7 +631,8 @@ bail:
  * context structure to find messages, while, on the attachment menu, messages
  * are referenced through the attachment index.
  */
-static void attach_forward_msgs(FILE *fp, struct AttachCtx *actx, struct Body *cur, int flags)
+static void attach_forward_msgs(FILE *fp, struct AttachCtx *actx,
+                                struct Body *cur, SendFlags flags)
 {
   struct Email *e_cur = NULL;
   struct Email *e_tmp = NULL;
@@ -747,10 +748,10 @@ static void attach_forward_msgs(FILE *fp, struct AttachCtx *actx, struct Body *c
  * @param e     Email
  * @param actx  Attachment Context
  * @param cur   Current message
- * @param flags Send mode, e.g. #SEND_RESEND
+ * @param flags Send mode, see #SendFlags
  */
 void mutt_attach_forward(FILE *fp, struct Email *e, struct AttachCtx *actx,
-                         struct Body *cur, int flags)
+                         struct Body *cur, SendFlags flags)
 {
   if (check_all_msg(actx, cur, false))
     attach_forward_msgs(fp, actx, cur, flags);
@@ -770,7 +771,7 @@ void mutt_attach_forward(FILE *fp, struct Email *e, struct AttachCtx *actx,
  * @param env    Envelope to fill in
  * @param actx   Attachment Context
  * @param parent Parent Email
- * @param flags  Flags, e.g. #SEND_LIST_REPLY
+ * @param flags  Flags, see #SendFlags
  * @retval  0 Success
  * @retval -1 Error
  *
@@ -785,7 +786,7 @@ void mutt_attach_forward(FILE *fp, struct Email *e, struct AttachCtx *actx,
  * Note that this code is horribly similar to envelope_defaults() from send.c.
  */
 static int attach_reply_envelope_defaults(struct Envelope *env, struct AttachCtx *actx,
-                                          struct Email *parent, int flags)
+                                          struct Email *parent, SendFlags flags)
 {
   struct Envelope *curenv = NULL;
   struct Email *e = NULL;
@@ -899,10 +900,10 @@ static void attach_include_reply(FILE *fp, FILE *tmpfp, struct Email *cur)
  * @param e     Email
  * @param actx  Attachment Context
  * @param cur   Current message
- * @param flags Send mode, e.g. #SEND_RESEND
+ * @param flags Send mode, see #SendFlags
  */
 void mutt_attach_reply(FILE *fp, struct Email *e, struct AttachCtx *actx,
-                       struct Body *cur, int flags)
+                       struct Body *cur, SendFlags flags)
 {
   bool mime_reply_any = false;
 

--- a/recvcmd.c
+++ b/recvcmd.c
@@ -399,7 +399,7 @@ static struct AttachPtr *find_parent(struct AttachCtx *actx, struct Body *cur, s
  */
 static void include_header(bool quote, FILE *ifp, struct Email *e, FILE *ofp, char *prefix)
 {
-  int chflags = CH_DECODE;
+  CopyHeaderFlags chflags = CH_DECODE;
   char prefix2[128];
 
   if (C_Weed)
@@ -642,7 +642,7 @@ static void attach_forward_msgs(FILE *fp, struct AttachCtx *actx,
   char tmpbody[PATH_MAX];
   FILE *tmpfp = NULL;
 
-  int chflags = CH_XMIT;
+  CopyHeaderFlags chflags = CH_XMIT;
 
   if (cur)
     e_cur = cur->email;
@@ -878,7 +878,7 @@ static int attach_reply_envelope_defaults(struct Envelope *env, struct AttachCtx
 static void attach_include_reply(FILE *fp, FILE *tmpfp, struct Email *cur)
 {
   int cmflags = MUTT_CM_PREFIX | MUTT_CM_DECODE | MUTT_CM_CHARCONV;
-  int chflags = CH_DECODE;
+  CopyHeaderFlags chflags = CH_DECODE;
 
   mutt_make_attribution(Context->mailbox, cur, tmpfp);
 

--- a/recvcmd.c
+++ b/recvcmd.c
@@ -678,7 +678,7 @@ static void attach_forward_msgs(FILE *fp, struct AttachCtx *actx,
       return;
     }
 
-    int cmflags = 0;
+    CopyMessageFlags cmflags = MUTT_CM_NO_FLAGS;
     if (C_ForwardQuote)
     {
       chflags |= CH_PREFIX;
@@ -877,7 +877,7 @@ static int attach_reply_envelope_defaults(struct Envelope *env, struct AttachCtx
  */
 static void attach_include_reply(FILE *fp, FILE *tmpfp, struct Email *cur)
 {
-  int cmflags = MUTT_CM_PREFIX | MUTT_CM_DECODE | MUTT_CM_CHARCONV;
+  CopyMessageFlags cmflags = MUTT_CM_PREFIX | MUTT_CM_DECODE | MUTT_CM_CHARCONV;
   CopyHeaderFlags chflags = CH_DECODE;
 
   mutt_make_attribution(Context->mailbox, cur, tmpfp);

--- a/remailer.c
+++ b/remailer.c
@@ -435,7 +435,7 @@ static const char *mix_format_caps(struct Remailer *r)
 static const char *mix_format_str(char *buf, size_t buflen, size_t col, int cols,
                                   char op, const char *src, const char *prec,
                                   const char *if_str, const char *else_str,
-                                  unsigned long data, int flags)
+                                  unsigned long data, MuttFormatFlags flags)
 {
   char fmt[128];
   struct Remailer *remailer = (struct Remailer *) data;

--- a/send.c
+++ b/send.c
@@ -496,7 +496,7 @@ void mutt_forward_trailer(struct Mailbox *m, struct Email *e, FILE *fp)
 static int include_forward(struct Mailbox *m, struct Email *e, FILE *out)
 {
   CopyHeaderFlags chflags = CH_DECODE;
-  int cmflags = 0;
+  CopyMessageFlags cmflags = MUTT_CM_NO_FLAGS;
 
   mutt_parse_mime_message(m, e);
   mutt_message_hook(m, e, MUTT_MESSAGE_HOOK);
@@ -577,7 +577,8 @@ void mutt_make_post_indent(struct Mailbox *m, struct Email *e, FILE *out)
  */
 static int include_reply(struct Mailbox *m, struct Email *e, FILE *out)
 {
-  int cmflags = MUTT_CM_PREFIX | MUTT_CM_DECODE | MUTT_CM_CHARCONV | MUTT_CM_REPLYING;
+  CopyMessageFlags cmflags =
+      MUTT_CM_PREFIX | MUTT_CM_DECODE | MUTT_CM_CHARCONV | MUTT_CM_REPLYING;
   CopyHeaderFlags chflags = CH_DECODE;
 
   if ((WithCrypto != 0) && (e->security & SEC_ENCRYPT))

--- a/send.c
+++ b/send.c
@@ -495,7 +495,8 @@ void mutt_forward_trailer(struct Mailbox *m, struct Email *e, FILE *fp)
  */
 static int include_forward(struct Mailbox *m, struct Email *e, FILE *out)
 {
-  int chflags = CH_DECODE, cmflags = 0;
+  CopyHeaderFlags chflags = CH_DECODE;
+  int cmflags = 0;
 
   mutt_parse_mime_message(m, e);
   mutt_message_hook(m, e, MUTT_MESSAGE_HOOK);
@@ -577,7 +578,7 @@ void mutt_make_post_indent(struct Mailbox *m, struct Email *e, FILE *out)
 static int include_reply(struct Mailbox *m, struct Email *e, FILE *out)
 {
   int cmflags = MUTT_CM_PREFIX | MUTT_CM_DECODE | MUTT_CM_CHARCONV | MUTT_CM_REPLYING;
-  int chflags = CH_DECODE;
+  CopyHeaderFlags chflags = CH_DECODE;
 
   if ((WithCrypto != 0) && (e->security & SEC_ENCRYPT))
   {

--- a/send.h
+++ b/send.h
@@ -80,7 +80,8 @@ extern char *        C_Signature;
 extern bool          C_SigOnTop;
 extern bool          C_UseFrom;
 
-/* flags to ci_send_message() */
+typedef uint16_t SendFlags;             ///< Flags for ci_send_message(), e.g. #SEND_REPLY
+#define SEND_NO_FLAGS               0   ///< No flags are set
 #define SEND_REPLY            (1 << 0)  ///< Reply to sender
 #define SEND_GROUP_REPLY      (1 << 1)  ///< Reply to all
 #define SEND_LIST_REPLY       (1 << 2)  ///< Reply to mailing list
@@ -97,11 +98,11 @@ extern bool          C_UseFrom;
 #define SEND_GROUP_CHAT_REPLY (1 << 13) ///< Reply to all recipients preserving To/Cc
 #define SEND_NEWS             (1 << 14) ///< Reply to a news article
 
-int             ci_send_message(int flags, struct Email *msg, const char *tempfile, struct Context *ctx, struct EmailList *el);
+int             ci_send_message(SendFlags flags, struct Email *msg, const char *tempfile, struct Context *ctx, struct EmailList *el);
 void            mutt_add_to_reference_headers(struct Envelope *env, struct Envelope *curenv);
 struct Address *mutt_default_from(void);
 void            mutt_encode_descriptions(struct Body *b, bool recurse);
-int             mutt_fetch_recips(struct Envelope *out, struct Envelope *in, int flags);
+int             mutt_fetch_recips(struct Envelope *out, struct Envelope *in, SendFlags flags);
 void            mutt_fix_reply_recipients(struct Envelope *env);
 void            mutt_forward_intro(struct Mailbox *m, struct Email *e, FILE *fp);
 void            mutt_forward_trailer(struct Mailbox *m, struct Email *e, FILE *fp);

--- a/sendlib.c
+++ b/sendlib.c
@@ -1465,7 +1465,7 @@ struct Body *mutt_make_message_attach(struct Mailbox *m, struct Email *e, bool a
   char buf[1024];
   struct Body *body = NULL;
   FILE *fp = NULL;
-  int cmflags, chflags;
+  int cmflags;
   int pgp = WithCrypto ? e->security : 0;
 
   if (WithCrypto)
@@ -1493,7 +1493,7 @@ struct Body *mutt_make_message_attach(struct Mailbox *m, struct Email *e, bool a
 
   mutt_parse_mime_message(m, e);
 
-  chflags = CH_XMIT;
+  CopyHeaderFlags chflags = CH_XMIT;
   cmflags = 0;
 
   /* If we are attaching a message, ignore C_MimeForwardDecode */
@@ -1827,12 +1827,13 @@ void mutt_write_references(const struct ListHead *r, FILE *f, size_t trim)
  * @param fp      File to write to
  * @param pfx     Prefix for headers
  * @param value   Text to be added
- * @param chflags Flags, e.g. #CH_DISPLAY
+ * @param chflags Flags, see #CopyHeaderFlags
  * @param col     Column that this text starts at
  * @retval  0 Success
  * @retval -1 Failure
  */
-static int print_val(FILE *fp, const char *pfx, const char *value, int chflags, size_t col)
+static int print_val(FILE *fp, const char *pfx, const char *value,
+                     CopyHeaderFlags chflags, size_t col)
 {
   while (value && *value)
   {
@@ -1873,19 +1874,20 @@ static int print_val(FILE *fp, const char *pfx, const char *value, int chflags, 
  * @param value   Header value
  * @param pfx     Prefix for header
  * @param wraplen Column to wrap at
- * @param chflags Flags, e.g. #CH_DISPLAY
+ * @param chflags Flags, see #CopyHeaderFlags
  * @retval  0 Success
  * @retval -1 Failure
  */
 static int fold_one_header(FILE *fp, const char *tag, const char *value,
-                           const char *pfx, int wraplen, int chflags)
+                           const char *pfx, int wraplen, CopyHeaderFlags chflags)
 {
   const char *p = value;
   char buf[8192] = "";
   int first = 1, col = 0, l = 0;
   const bool display = (chflags & CH_DISPLAY);
 
-  mutt_debug(5, "pfx=[%s], tag=[%s], flags=%d value=[%s]\n", pfx, tag, chflags, NONULL(value));
+  mutt_debug(5, "pfx=[%s], tag=[%s], flags=%d value=[%s]\n", pfx, tag, chflags,
+             NONULL(value));
 
   if (tag && *tag && fprintf(fp, "%s%s: ", NONULL(pfx), tag) < 0)
     return -1;
@@ -2013,12 +2015,12 @@ static char *unfold_header(char *s)
  * @param pfx     Prefix for header
  * @param start   Start of header line
  * @param end     End of header line
- * @param chflags Flags, e.g. #CH_DISPLAY
+ * @param chflags Flags, see #CopyHeaderFlags
  * @retval  0 Success
  * @retval -1 Failure
  */
 static int write_one_header(FILE *fp, int pfxw, int max, int wraplen, const char *pfx,
-                            const char *start, const char *end, int chflags)
+                            const char *start, const char *end, CopyHeaderFlags chflags)
 {
   char *tagbuf = NULL, *valbuf = NULL, *t = NULL;
   int is_from = (end - start) > 5 && mutt_str_startswith(start, "from ", CASE_IGNORE);
@@ -2101,7 +2103,7 @@ static int write_one_header(FILE *fp, int pfxw, int max, int wraplen, const char
  * @param value   Header value
  * @param pfx     Prefix for header
  * @param wraplen Column to wrap at
- * @param chflags Flags, e.g. #CH_DISPLAY
+ * @param chflags Flags, see #CopyHeaderFlags
  * @retval  0 Success
  * @retval -1 Failure
  *
@@ -2109,7 +2111,7 @@ static int write_one_header(FILE *fp, int pfxw, int max, int wraplen, const char
  * for each one
  */
 int mutt_write_one_header(FILE *fp, const char *tag, const char *value,
-                          const char *pfx, int wraplen, int chflags)
+                          const char *pfx, int wraplen, CopyHeaderFlags chflags)
 {
   char *p = (char *) value, *last = NULL, *line = NULL;
   int max = 0, w, rc = -1;
@@ -2968,7 +2970,7 @@ static int bounce_message(FILE *fp, struct Email *e, struct Address *to,
   if (f)
   {
     char date[128];
-    int chflags = CH_XMIT | CH_NONEWLINE | CH_NOQFROM;
+    CopyHeaderFlags chflags = CH_XMIT | CH_NONEWLINE | CH_NOQFROM;
 
     if (!C_BounceDelivered)
       chflags |= CH_WEED_DELIVERED;

--- a/sendlib.c
+++ b/sendlib.c
@@ -3152,7 +3152,7 @@ int mutt_write_fcc(const char *path, struct Email *e, const char *msgid,
   bool need_mailbox_cleanup = false;
   struct stat st;
   char buf[128];
-  int onm_flags;
+  MsgOpenFlags onm_flags;
 
   if (post)
     set_noconv_flags(e->content, true);

--- a/sendlib.c
+++ b/sendlib.c
@@ -1465,7 +1465,7 @@ struct Body *mutt_make_message_attach(struct Mailbox *m, struct Email *e, bool a
   char buf[1024];
   struct Body *body = NULL;
   FILE *fp = NULL;
-  int cmflags;
+  CopyMessageFlags cmflags;
   int pgp = WithCrypto ? e->security : 0;
 
   if (WithCrypto)
@@ -1494,7 +1494,7 @@ struct Body *mutt_make_message_attach(struct Mailbox *m, struct Email *e, bool a
   mutt_parse_mime_message(m, e);
 
   CopyHeaderFlags chflags = CH_XMIT;
-  cmflags = 0;
+  cmflags = MUTT_CM_NO_FLAGS;
 
   /* If we are attaching a message, ignore C_MimeForwardDecode */
   if (!attach_msg && C_MimeForwardDecode)

--- a/sendlib.h
+++ b/sendlib.h
@@ -25,6 +25,7 @@
 
 #include <stdbool.h>
 #include <stdio.h>
+#include "copy.h"
 
 struct Address;
 struct Body;
@@ -87,7 +88,7 @@ int             mutt_write_fcc(const char *path, struct Email *e, const char *ms
 int             mutt_write_mime_body(struct Body *a, FILE *f);
 int             mutt_write_mime_header(struct Body *a, FILE *f);
 int             mutt_write_multiple_fcc(const char *path, struct Email *e, const char *msgid, bool post, char *fcc, char **finalpath);
-int             mutt_write_one_header(FILE *fp, const char *tag, const char *value, const char *pfx, int wraplen, int chflags);
+int             mutt_write_one_header(FILE *fp, const char *tag, const char *value, const char *pfx, int wraplen, CopyHeaderFlags chflags);
 void            mutt_write_references(const struct ListHead *r, FILE *f, size_t trim);
 
 #endif /* MUTT_SENDLIB_H */

--- a/sidebar.c
+++ b/sidebar.c
@@ -113,7 +113,7 @@ enum DivType
 static const char *sidebar_format_str(char *buf, size_t buflen, size_t col, int cols,
                                       char op, const char *src, const char *prec,
                                       const char *if_str, const char *else_str,
-                                      unsigned long data, int flags)
+                                      unsigned long data, MuttFormatFlags flags)
 {
   struct SbEntry *sbe = (struct SbEntry *) data;
   unsigned int optional;

--- a/state.h
+++ b/state.h
@@ -27,7 +27,8 @@
 #include <stdint.h>
 #include <stdio.h>
 
-/* flags for the State struct */
+typedef uint8_t StateFlags;          ///< Flags for State->flags, e.g. #MUTT_DISPLAY
+#define MUTT_STATE_NO_FLAGS       0  ///< No flags are set
 #define MUTT_DISPLAY        (1 << 0) ///< Output is displayed to the user
 #define MUTT_VERIFY         (1 << 1) ///< Perform signature verification
 #define MUTT_PENDINGPREFIX  (1 << 2) ///< Prefix to write, but character must follow
@@ -45,7 +46,7 @@ struct State
   FILE      *fp_in;  ///< File to read from
   FILE      *fp_out; ///< File to write to
   char      *prefix; ///< String to add to the beginning of each output line
-  int flags;    ///< Flags, e.g. #MUTT_DISPLAY
+  StateFlags flags;  ///< Flags, e.g. #MUTT_DISPLAY
 };
 
 #define state_set_prefix(s) ((s)->flags |= MUTT_PENDINGPREFIX)

--- a/status.c
+++ b/status.c
@@ -90,7 +90,7 @@ static char *get_sort_str(char *buf, size_t buflen, int method)
 static const char *status_format_str(char *buf, size_t buflen, size_t col, int cols,
                                      char op, const char *src, const char *prec,
                                      const char *if_str, const char *else_str,
-                                     unsigned long data, int flags)
+                                     unsigned long data, MuttFormatFlags flags)
 {
   char fmt[128], tmp[128], *cp = NULL;
   int count, optional = (flags & MUTT_FORMAT_OPTIONAL);


### PR DESCRIPTION
Following POLL #1572
Define types for all of the flags/bitfields.
Being 'C' this doesn't add any type safety, but it does make the code far more legible.

There are 20 commits which follow the pattern below.

- CompletionFlags
- ConfigDumpFlags
- ConfigRedrawFlags
- CopyHeaderFlags
- CopyMessageFlags
- HookFlags
- ImapCmdFlags
- ImapOpenFlags
- KeyFlags
- MsgOpenFlags
- MuttAccountFlags
- MuttFormatFlags
- MuttRedrawFlags
- MuttThreadFlags
- OpenMailboxFlags
- PagerFlags
- SecurityFlags
- SendFlags
- StateFlags
- TokenFlags

There are no functional changes, **however** it has highlighted some dependency problems.
I'm not expecting anyone to read the entire diff :-)

---

Given a set of flags, define a type of an appropriate size:
```c
typedef uint8_t FruitFlags;
#define FRUIT_APPLE   (1 << 0)
#define FRUIT_BANANA  (1 << 1)
#define FRUIT_CHERRY  (1 << 2)
```

For each flag set, I've defined a `NO_FLAGS` option.
This is useful when passing **zero** flags (`0`) as a parameter.

I'm not completely certain about the need for this (it's easily undone).

```c
#define FRUIT_NO_FLAGS   0
```

Next, I've traced through every use of the defined symbols to ensure they use the new typedefs:
```diff
- int basket = FRUIT_APPLE | FRUIT_CHERRY;
+ FruitFlags basket = FRUIT_APPLE | FRUIT_CHERRY;
```

Finally, all function parameters have been linked back to the typedef for easy lookup:
```c
/**
 * @param fr Fruit, see #FruitFlags
 */
```