### PR TITLE
Fix crash when an email disappears from IMAP

### DIFF
--- a/context.c
+++ b/context.c
@@ -227,7 +227,7 @@ void ctx_update_tables(struct Context *ctx, bool committing)
     }
     else
     {
-      if (m->magic == MUTT_MH || m->magic == MUTT_MAILDIR)
+      if (m->magic == MUTT_MH || m->magic == MUTT_MAILDIR || m->magic == MUTT_IMAP)
       {
         m->size -= (m->emails[i]->content->length + m->emails[i]->content->offset -
                     m->emails[i]->content->hdr_offset);

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -796,9 +796,7 @@ void imap_expunge_mailbox(struct Mailbox *m)
     {
       mutt_debug(LL_DEBUG2, "Expunging message UID %u.\n", imap_edata_get(e)->uid);
 
-      e->active = false;
       e->deleted = true;
-      m->size -= e->content->length;
 
       imap_cache_del(m, e);
 #ifdef USE_HCACHE

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -797,6 +797,7 @@ void imap_expunge_mailbox(struct Mailbox *m)
       mutt_debug(LL_DEBUG2, "Expunging message UID %u.\n", imap_edata_get(e)->uid);
 
       e->active = false;
+      e->deleted = true;
       m->size -= e->content->length;
 
       imap_cache_del(m, e);


### PR DESCRIPTION
* **What does this PR do?**

This fixes an invalid access caused by NeoMutt not correctly rebuilding the context tables when an email disappears from a mailbox.

#1577 