### PR TITLE
Ifdef envvars

### DIFF
--- a/doc/manual.xml.head
+++ b/doc/manual.xml.head
@@ -12794,6 +12794,7 @@ finish                                    <emphasis role="comment"># Finish read
 
         <para>
           Here a symbol can be a <link linkend="variables">$variable</link>,
+          environment variable,
           <link linkend="functions">&lt;function&gt;</link>,
           <link linkend="commands">command</link> or compile-time symbol, such
           as <quote>imap</quote>.
@@ -12850,7 +12851,7 @@ ifndef sidebar finish
 <emphasis role="comment">#   ifndef symbol "config-command [args...]"</emphasis>
 <emphasis role="comment">#   finish</emphasis>
 <emphasis role="comment"># The 'ifdef' command tests whether NeoMutt understands the name of</emphasis>
-<emphasis role="comment"># a variable, function, command or compile-time symbol.</emphasis>
+<emphasis role="comment"># a variable, environment variable, function, command or compile-time symbol.</emphasis>
 
 <emphasis role="comment"># If it does, then it executes a config command.</emphasis>
 
@@ -12860,6 +12861,8 @@ ifndef sidebar finish
 
 <emphasis role="comment"># If the 'trash' variable exists, set it.</emphasis>
 ifdef trash 'set trash=~/Mail/trash'
+<emphasis role="comment"># If the 'PS1' environment variable exists, source config file.</emphasis>
+ifdef PS1 'source .neomutt/interactive.rc'
 <emphasis role="comment"># If the 'tag-pattern' function exists, bind a key to it.</emphasis>
 ifdef tag-pattern 'bind index &lt;F6&gt; tag-pattern'
 <emphasis role="comment"># If the 'imap-fetch-mail' command exists, read my IMAP config.</emphasis>


### PR DESCRIPTION
* **What does this PR do?**
Adds ability for ifdef to work with environment variables.

* **Screenshots (if relevant)**
chaotic asciinema…
[![asciicast](https://asciinema.org/a/pQAXhEzRl4cPxzSbaI5TeIo46.svg)](https://asciinema.org/a/pQAXhEzRl4cPxzSbaI5TeIo46)

* **Does this PR meet the acceptance criteria?** 

   - Documentation created/updated
updated.

   - All builds and tests are passing
I'm not sure. I build it if it passes tests we will see.

   - Added [doxygen code documentation](https://neomutt.org/dev/doxygen)
Didn't seem to be necessary.

   - Code follows the [style guide]
I hope so. I tried to keep style I've seen around. Maybe braces are not necessary:
https://neomutt.org/dev/coding-style#braces-placement but I would let it until some code style review.

* **What are the relevant issue numbers?**
No existing issue. But "request" on IRC. Actually fekir was asking same or similar question few days ago.
```
-- Mon, 04 Mar 2019 --
11:20:37            fekir | Is it possible to check in the config file is neomutt is being used interactively or not?
11:21:09            fekir | I would like not to load some configs (like colors), if I#M writing and sending an email directly from bash
11:35:20          jindraj | fekir: maybe using ifdef but I'm still unable prove it 😃
11:38:42            fekir | jindraj: thanks, did not know the ifdef, though I'm unable to see if there is something like "interactive"
11:44:37             gahr | fekir: maybe you could add a "set my_noninteractive=1" when running from a script
11:48:09          jindraj | fekir: I was thinking about `ifdef $PS1 "source config_files_you_want_to_have_in_interactive_mode"`. But it seems like ifdef works with neomutt variables only.
11:56:23            fekir | gahr: how should I accomplish that? Suppose my current command is " echo 'Hello' | neomutt -s 'mail' abc@mail.com -a file.txt". AFAIK I cannot add a config
                          | variable from the cli
```