### PR TITLE
Change hcache version when Email struct change

### DIFF
--- a/hcache/hcachever.sh
+++ b/hcache/hcachever.sh
@@ -46,7 +46,7 @@ getstruct () {
   done
 
   case $STRUCT in
-    Address|Body|Buffer|Envelope|Header|ListNode|Parameter)
+    Address|Body|Buffer|Email|Envelope|ListNode|Parameter)
       BODY=`cleanbody "$BODY"`
       echo "$STRUCT: $BODY"
     ;;


### PR DESCRIPTION
On imap when some mails are expunged, many mail disapear from current
mailbox. It's just a rendering issue, when the mailbox is reopened all
expected mails are there.

After a git bisect session, I got the culprit:
b60b10f

This change rename Header to Email struct in the list of structs 
that increases hcache version.