### PR TITLE
mx: fix mbox double free

### DIFF
--- a/context.c
+++ b/context.c
@@ -49,7 +49,6 @@ void ctx_free(struct Context **ctx)
   if (!ctx || !*ctx)
     return;
 
-  mailbox_free(&(*ctx)->mailbox);
   FREE(ctx);
 }
 

--- a/mx.c
+++ b/mx.c
@@ -251,9 +251,6 @@ struct Context *mx_mbox_open(struct Mailbox *m, OpenMailboxFlags flags)
   struct Context *ctx = mutt_mem_calloc(1, sizeof(*ctx));
   ctx->mailbox = m;
 
-  m->notify = ctx_mailbox_changed;
-  m->ndata = ctx;
-
   if ((m->magic == MUTT_UNKNOWN) && (flags & (MUTT_NEWFOLDER | MUTT_APPEND)))
   {
     m->magic = C_MboxType;
@@ -271,7 +268,7 @@ struct Context *mx_mbox_open(struct Mailbox *m, OpenMailboxFlags flags)
     }
     if (mx_ac_add(a, m) < 0)
     {
-      mailbox_free(&m);
+      ctx_free(&ctx);
       return NULL;
     }
   }
@@ -355,9 +352,13 @@ struct Context *mx_mbox_open(struct Mailbox *m, OpenMailboxFlags flags)
   {
     mx_fastclose_mailbox(m);
     ctx_free(&ctx);
+    return NULL;
   }
 
   OptForceRefresh = false;
+  m->notify = ctx_mailbox_changed;
+  m->ndata = ctx;
+
   return ctx;
 }
 


### PR DESCRIPTION
Fixes: #1597 

The mx layer shouldn't be freeing the Mailbox (nor `ctx_close()`).
Since we now 'resolve' paths using Mailboxes, their lifespans are greater than just `mbox_open()` to `mbox_close()`.