### PR TITLE
Fix table in man page

### DIFF
--- a/doc/neomuttrc.man.head
+++ b/doc/neomuttrc.man.head
@@ -828,7 +828,8 @@ select messages.
 .TS
 box tab(|);
 lb s | lb
-l s | lx .
+l s | lx
+.
 \0Pattern|Description
 _
 \0~A|T{


### PR DESCRIPTION
Previously:

    /usr/bin/tbl:<standard input>:824: unrecognised format `\'
    /usr/bin/tbl:<standard input>:824: giving up on this table

It seems the period after table headers must be on its own line.