### PR TITLE
notmuch: close thread queries' hcache on SigInt

### DIFF
--- a/notmuch/mutt_notmuch.c
+++ b/notmuch/mutt_notmuch.c
@@ -1184,6 +1184,7 @@ static bool read_threads_query(struct Mailbox *m, notmuch_query_t *q, bool dedup
   {
     if (SigInt == 1)
     {
+      nm_hcache_close(h);
       SigInt = 0;
       return false;
     }


### PR DESCRIPTION
While looking for ways to improve `notmuch` performance, I noticed `read_threads_query()` does not close hcache on SigInt. It's companion function, `read_mesgs_query()` closes hcache on SigInt.

This is my mistake as I failed to notice it in #1602's review.

Sadly, this removes Neomutt's ability to run at >100% efficiency when re-opening a thread query after SigInt

![110-percent](https://user-images.githubusercontent.com/1640737/54791558-c59b7c80-4c10-11e9-83eb-de3949911ceb.png)
