### PR TITLE
Add new option to display only non-empty mailboxes in sidebar

### DIFF
--- a/doc/manual.xml.head
+++ b/doc/manual.xml.head
@@ -1029,6 +1029,12 @@ set sidebar_indent_string="  "          <emphasis role="comment"># Indent with t
               show mailboxes that contain new, or flagged, email.
             </para>
             <para>
+              Sometimes it is useful to only show mailboxes that have mails in
+              them, while hiding the rest.
+              <literal>$sidebar_non_empty_mailbox_only</literal> tells the
+              Sidebar to only show mailboxes with a non-zero number of mails.
+            </para>
+            <para>
               If you want some mailboxes to be always visible, then use the
               <literal>sidebar_whitelist</literal> command. It takes a list of
               mailboxes as parameters.

--- a/init.h
+++ b/init.h
@@ -3618,7 +3618,14 @@ struct ConfigDef MuttVars[] = {
   ** When set, the sidebar will only display mailboxes containing new, or
   ** flagged, mail.
   ** .pp
-  ** \fBSee also:\fP $sidebar_whitelist.
+  ** \fBSee also:\fP $$sidebar_whitelist, $$sidebar_non_empty_mailbox_only.
+  */
+  { "sidebar_non_empty_mailbox_only", DT_BOOL, R_SIDEBAR, &C_SidebarNonEmptyOnly, false },
+  /*
+  ** .pp
+  ** When set, the sidebar will only display mailboxes that contain one or more mails.
+  ** .pp
+  ** \fBSee also:\fP $$sidebar_new_mail_only, $$sidebar_whitelist.
   */
   { "sidebar_next_new_wrap", DT_BOOL, R_NONE, &C_SidebarNextNewWrap, false },
   /*

--- a/sidebar.c
+++ b/sidebar.c
@@ -391,13 +391,13 @@ static void update_entries_visibility(void)
 
     if (non_empty_only && (i != OpnIndex) && (sbe->mailbox->msg_count == 0))
     {
-        sbe->is_hidden = true;
+      sbe->is_hidden = true;
     }
 
     if (new_only && (i != OpnIndex) && (sbe->mailbox->msg_unread == 0) &&
         (sbe->mailbox->msg_flagged == 0) && !sbe->mailbox->has_new)
     {
-        sbe->is_hidden = true;
+      sbe->is_hidden = true;
     }
   }
 }

--- a/sidebar.c
+++ b/sidebar.c
@@ -373,15 +373,9 @@ static void update_entries_visibility(void)
 
     sbe->is_hidden = false;
 
-    if ((i == OpnIndex) || (sbe->mailbox->msg_unread > 0) ||
-        sbe->mailbox->has_new || (sbe->mailbox->msg_flagged > 0))
-    {
-      continue;
-    }
-
     if (Context && (mutt_str_strcmp(sbe->mailbox->realpath, Context->mailbox->realpath) == 0))
     {
-      /* Spool directory */
+      /* Spool directories are always visible */
       continue;
     }
 
@@ -392,7 +386,11 @@ static void update_entries_visibility(void)
       continue;
     }
 
-    sbe->is_hidden = true;
+    if (new_only && (i != OpnIndex) && (sbe->mailbox->msg_unread == 0) &&
+        (sbe->mailbox->msg_flagged == 0) && !sbe->mailbox->has_new)
+    {
+        sbe->is_hidden = true;
+    }
   }
 }
 

--- a/sidebar.c
+++ b/sidebar.c
@@ -356,14 +356,22 @@ static void update_entries_visibility(void)
 {
   short new_only = C_SidebarNewMailOnly;
   struct SbEntry *sbe = NULL;
+
+  /* Take the fast path if there is no need to test visibilities */
+  if (!new_only)
+  {
+    for (int i = 0; i < EntryCount; i++)
+    {
+      Entries[i]->is_hidden = false;
+    }
+    return;
+  }
+
   for (int i = 0; i < EntryCount; i++)
   {
     sbe = Entries[i];
 
     sbe->is_hidden = false;
-
-    if (!new_only)
-      continue;
 
     if ((i == OpnIndex) || (sbe->mailbox->msg_unread > 0) ||
         sbe->mailbox->has_new || (sbe->mailbox->msg_flagged > 0))

--- a/sidebar.c
+++ b/sidebar.c
@@ -355,8 +355,9 @@ static int cb_qsort_sbe(const void *a, const void *b)
  */
 static void update_entries_visibility(void)
 {
-  short new_only = C_SidebarNewMailOnly;
-  short non_empty_only = C_SidebarNonEmptyOnly;
+  /* Aliases for readability */
+  const bool new_only = C_SidebarNewMailOnly;
+  const bool non_empty_only = C_SidebarNonEmptyOnly;
   struct SbEntry *sbe = NULL;
 
   /* Take the fast path if there is no need to test visibilities */

--- a/sidebar.h
+++ b/sidebar.h
@@ -38,6 +38,7 @@ extern bool  C_SidebarFolderIndent;
 extern char *C_SidebarFormat;
 extern char *C_SidebarIndentString;
 extern bool  C_SidebarNewMailOnly;
+extern bool  C_SidebarNonEmptyOnly;
 extern bool  C_SidebarNextNewWrap;
 extern bool  C_SidebarShortPath;
 extern short C_SidebarSortMethod;


### PR DESCRIPTION
* **What does this PR do?**
Sometimes, there are multiple mailboxes available for an account, but a lot of them are empty. I want to display only the mailboxes that contain emails in them. This PR adds that option via a new configuration: `$sidebar_non_empty_mailbox_only`.

* **Screenshots (if relevant)**

* **Does this PR meet the acceptance criteria?** (This is just a reminder for you,
  this section can be removed if you fulfill it.)

   - Documentation created/updated (you have to edit
     [doc/manual.xml.head](https://www.github.com/neomutt/neomutt/blob/master/doc/manual.xml.head)
     for that)

   - All builds and tests are passing

   - Added [doxygen code documentation](https://neomutt.org/dev/doxygen)
     [syntax](http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html)

   - Code follows the [style guide](https://neomutt.org/dev/coding-style)

* **What are the relevant issue numbers?**
