### PR TITLE
lua: fix command-line processing

### DIFF
--- a/mutt_lua.c
+++ b/mutt_lua.c
@@ -459,6 +459,7 @@ enum CommandResult mutt_lua_parse(struct Buffer *buf, struct Buffer *s,
     return MUTT_CMD_ERROR;
   }
   mutt_debug(LL_DEBUG2, " * %s -> success\n", s->dptr);
+  mutt_buffer_reset(s); // Clear the rest of the line
   return MUTT_CMD_SUCCESS;
 }
 


### PR DESCRIPTION
The 'lua' command uses the entire line of text.
Clear the Buffer so that NeoMutt doesn't try to interpret it.

Fixes #1610