### PR TITLE
 Fix bogus mailbox size accounting

### DIFF
--- a/context.c
+++ b/context.c
@@ -226,10 +226,10 @@ void ctx_update_tables(struct Context *ctx, bool committing)
     }
     else
     {
-      if ((m->magic == MUTT_MH) || (m->magic == MUTT_MAILDIR) || (m->magic == MUTT_IMAP))
+      if ((m->magic == MUTT_NOTMUCH) || (m->magic == MUTT_MH) ||
+          (m->magic == MUTT_MAILDIR) || (m->magic == MUTT_IMAP))
       {
-        m->size -= (m->emails[i]->content->length + m->emails[i]->content->offset -
-                    m->emails[i]->content->hdr_offset);
+        mutt_mailbox_size_sub(m, m->emails[i]);
       }
       /* remove message from the hash tables */
       if (m->subj_hash && m->emails[i]->env->real_subj)

--- a/imap/message.c
+++ b/imap/message.c
@@ -805,7 +805,7 @@ static int read_headers_normal_eval_cache(struct ImapAccountData *adata,
         FREE(&tags_copy);
 
         m->msg_count++;
-        m->size += m->emails[idx]->content->length;
+        mutt_mailbox_size_add(m, m->emails[idx]);
 
         /* If this is the first time we are fetching, we need to
          * store the current state of flags back into the header cache */
@@ -885,7 +885,7 @@ static int read_headers_qresync_eval_cache(struct ImapAccountData *adata, char *
       edata->uid = uid;
       mutt_hash_int_insert(mdata->uid_hash, uid, e);
 
-      m->size += e->content->length;
+      mutt_mailbox_size_add(m, e);
       m->emails[m->msg_count++] = e;
 
       msn++;
@@ -1158,7 +1158,7 @@ static int read_headers_fetch_new(struct Mailbox *m, unsigned int msn_begin,
         m->emails[idx]->env = mutt_rfc822_read_header(fp, m->emails[idx], false, false);
         /* content built as a side-effect of mutt_rfc822_read_header */
         m->emails[idx]->content->length = h.content_length;
-        m->size += h.content_length;
+        mutt_mailbox_size_add(m, m->emails[idx]);
 
 #ifdef USE_HCACHE
         imap_hcache_put(mdata, m->emails[idx]);

--- a/mailbox.c
+++ b/mailbox.c
@@ -533,3 +533,37 @@ void mutt_mailbox_changed(struct Mailbox *m, enum MailboxNotification action)
 
   m->notify(m, action);
 }
+
+/**
+ * email_size - Helper function to make sure we always use the same metric to
+ * compute the size of an email
+ * @param e Email
+ * @retval num Size of the email, in bytes
+ */
+static size_t email_size(const struct Email *e)
+{
+  if (!e || !e->content)
+    return 0;
+  return e->content->length + e->content->offset - e->content->hdr_offset;
+}
+
+/**
+ * mutt_mailbox_size_add - Add an email's size to the total size of a Mailbox
+ * @param m Mailbox
+ * @param e Email
+ */
+void mutt_mailbox_size_add(struct Mailbox *m, const struct Email *e)
+{
+  m->size += email_size(e);
+}
+
+/**
+ * mutt_mailbox_size_sub - Subtract an email's size from the total size of a Mailbox
+ * @param m Mailbox
+ * @param e Email
+ */
+void mutt_mailbox_size_sub(struct Mailbox *m, const struct Email *e)
+{
+  m->size -= email_size(e);
+}
+

--- a/mailbox.h
+++ b/mailbox.h
@@ -176,4 +176,7 @@ int mutt_mailbox_check(struct Mailbox *m_cur, int force);
 bool mutt_mailbox_notify(struct Mailbox *m_cur);
 void mutt_mailbox_changed(struct Mailbox *m, enum MailboxNotification action);
 
+void mutt_mailbox_size_add(struct Mailbox *m, const struct Email *e);
+void mutt_mailbox_size_sub(struct Mailbox *m, const struct Email *e);
+
 #endif /* MUTT_MAILBOX_H */

--- a/maildir/shared.c
+++ b/maildir/shared.c
@@ -450,8 +450,7 @@ int maildir_move_to_mailbox(struct Mailbox *m, struct Maildir **ptr)
 
     m->emails[m->msg_count] = md->email;
     m->emails[m->msg_count]->index = m->msg_count;
-    m->size += md->email->content->length + md->email->content->offset -
-                md->email->content->hdr_offset;
+    mutt_mailbox_size_add(m, md->email);
 
     md->email = NULL;
     m->msg_count++;

--- a/notmuch/mutt_notmuch.c
+++ b/notmuch/mutt_notmuch.c
@@ -991,7 +991,7 @@ static void append_message(header_cache_t *h, struct Mailbox *m,
 
   e->active = true;
   e->index = m->msg_count;
-  m->size += e->content->length + e->content->offset - e->content->hdr_offset;
+  mutt_mailbox_size_add(m, e);
   m->emails[m->msg_count] = e;
   m->msg_count++;
 


### PR DESCRIPTION
* **What does this PR do?**

Mailbox size update upon addition of messages was carried out in various places, using various methods. Update upon deletion was handled in a central place. When the methods used to account addition and subtracted don't match, you end up having bogus accounting:

```
---NeoMutt: +Trash [Msgs:0 17592186044412M]
```

This PR adds a centralized way to account mailbox sizes. While at it, I noticed NotMuch mailboxes weren't accounted for when deleting emails. I can't confirm that this fixes the particular issue, as I'm not a NotMuch user.