### PR TITLE
Disable mailbox notify on close

### DIFF
--- a/mx.c
+++ b/mx.c
@@ -384,6 +384,7 @@ void mx_fastclose_mailbox(struct Mailbox *m)
     m->mx_ops->mbox_close(m);
 
   mutt_mailbox_changed(m, MBN_CLOSED);
+  m->notify = NULL;
 
   mutt_hash_free(&m->subj_hash);
   mutt_hash_free(&m->id_hash);


### PR DESCRIPTION
This fixes a crash when two mailboxes have been opened within a session, and an `unmailboxes *` command is issued. In this case, both the current mailbox and the previously opened mailbox have a non-NULL `notify` member. The notify method assumes the mailbox is currently active within the context. The context gets thus doubly freed.
