### PR TITLE
Trivial code fixes/tidies

### DIFF
--- a/browser.c
+++ b/browser.c
@@ -342,17 +342,17 @@ static bool link_is_dir(const char *folder, const char *path)
  * |:--------|:--------------------------------------------------------
  * | \%C     | Current file number
  * | \%d     | Date/time folder was last modified
- * | \%D     | Date/time folder was last modified using $$date_format.
+ * | \%D     | Date/time folder was last modified using `$date_format.`
  * | \%F     | File permissions
- * | \%f     | Filename (with suffix '/', '@' or '*')
+ * | \%f     | Filename (with suffix `/`, `@` or `*`)
  * | \%g     | Group name (or numeric gid, if missing)
  * | \%i     | Description of the folder
  * | \%l     | Number of hard links
- * | \%m     | Number of messages in the mailbox *
+ * | \%m     | Number of messages in the mailbox
  * | \%N     | N if mailbox has new mail, blank otherwise
- * | \%n     | Number of unread messages in the mailbox *
+ * | \%n     | Number of unread messages in the mailbox
  * | \%s     | Size in bytes
- * | \%t     | '*' if the file is tagged, blank otherwise
+ * | \%t     | `*` if the file is tagged, blank otherwise
  * | \%u     | Owner name (or numeric uid, if missing)
  */
 static const char *folder_format_str(char *buf, size_t buflen, size_t col, int cols,

--- a/color.c
+++ b/color.c
@@ -69,14 +69,14 @@ static int ColorQuoteSize;
 #define COLOR_DEFAULT (-2)
 #define COLOR_UNSET UINT32_MAX
 
-#define GET_COLOR_VALUE(v) ((v) & 0xffffff)
+#define GET_COLOR_VALUE(v) ((v) &0xffffff)
 
 /*
  * Flags for the high 8bits of the color value.
  *
  * Note that no flag means it's a palette color.
  */
-#define RGB24              (1u << 24)
+#define RGB24 (1u << 24)
 
 /**
  * struct ColorList - A set of colors
@@ -469,7 +469,8 @@ void mutt_free_color(uint32_t fg, uint32_t bg)
  *
  * Parse a colour name, such as "red", "brightgreen", "color123".
  */
-static int parse_color_name(const char *s, uint32_t *col, int *attr, bool is_fg, struct Buffer *err)
+static int parse_color_name(const char *s, uint32_t *col, int *attr, bool is_fg,
+                            struct Buffer *err)
 {
   char *eptr = NULL;
   bool is_alert = false, is_bright = false, is_light = false;

--- a/color.c
+++ b/color.c
@@ -509,7 +509,7 @@ static int parse_color_name(const char *s, uint32_t *col, int *attr, bool is_fg,
   {
     s += 1;
     *col = strtoul(s, &eptr, 16);
-    if (!*s || *eptr || (*col == COLOR_UNSET && !OptNoCurses && has_colors()))
+    if (!*s || *eptr || ((*col == COLOR_UNSET) && !OptNoCurses && has_colors()))
     {
       snprintf(err->data, err->dsize, _("%s: color not supported by term"), s);
       return -1;

--- a/commands.c
+++ b/commands.c
@@ -426,7 +426,7 @@ void ci_bounce_message(struct Mailbox *m, struct EmailList *el)
   if (mutt_strwidth(prompt) > MuttMessageWindow->cols - EXTRA_SPACE)
   {
     mutt_simple_format(prompt, sizeof(prompt), 0, MuttMessageWindow->cols - EXTRA_SPACE,
-                       FMT_LEFT, 0, scratch, sizeof(scratch), false);
+                       JUSTIFY_LEFT, 0, scratch, sizeof(scratch), false);
     mutt_str_strcat(prompt, sizeof(prompt), "...?");
   }
   else

--- a/commands.c
+++ b/commands.c
@@ -426,7 +426,7 @@ void ci_bounce_message(struct Mailbox *m, struct EmailList *el)
   if (mutt_strwidth(prompt) > MuttMessageWindow->cols - EXTRA_SPACE)
   {
     mutt_simple_format(prompt, sizeof(prompt), 0, MuttMessageWindow->cols - EXTRA_SPACE,
-                       FMT_LEFT, 0, scratch, sizeof(scratch), 0);
+                       FMT_LEFT, 0, scratch, sizeof(scratch), false);
     mutt_str_strcat(prompt, sizeof(prompt), "...?");
   }
   else

--- a/copy.c
+++ b/copy.c
@@ -760,7 +760,7 @@ int mutt_copy_message_fp(FILE *fp_out, FILE *fp_in, struct Email *e,
 
       fputs(prefix, fp_out);
 
-      while ((c = fgetc(fp_in)) != EOF && bytes--)
+      while (((c = fgetc(fp_in)) != EOF) && bytes--)
       {
         fputc(c, fp_out);
         if (c == '\n')

--- a/curs_lib.c
+++ b/curs_lib.c
@@ -938,7 +938,7 @@ int mutt_addwch(wchar_t wc)
  * character cells when printed.
  */
 void mutt_simple_format(char *buf, size_t buflen, int min_width, int max_width,
-                        int justify, char pad_char, const char *s, size_t n, int arboreal)
+                        int justify, char pad_char, const char *s, size_t n, bool arboreal)
 {
   wchar_t wc;
   int w;
@@ -1050,7 +1050,7 @@ void mutt_simple_format(char *buf, size_t buflen, int min_width, int max_width,
  * except that the numbers in the conversion specification refer to
  * the number of character cells when printed.
  */
-static void format_s_x(char *buf, size_t buflen, const char *prec, const char *s, int arboreal)
+static void format_s_x(char *buf, size_t buflen, const char *prec, const char *s, bool arboreal)
 {
   int justify = FMT_RIGHT;
   char *p = NULL;
@@ -1089,7 +1089,7 @@ static void format_s_x(char *buf, size_t buflen, const char *prec, const char *s
  */
 void mutt_format_s(char *buf, size_t buflen, const char *prec, const char *s)
 {
-  format_s_x(buf, buflen, prec, s, 0);
+  format_s_x(buf, buflen, prec, s, false);
 }
 
 /**
@@ -1101,7 +1101,7 @@ void mutt_format_s(char *buf, size_t buflen, const char *prec, const char *s)
  */
 void mutt_format_s_tree(char *buf, size_t buflen, const char *prec, const char *s)
 {
-  format_s_x(buf, buflen, prec, s, 1);
+  format_s_x(buf, buflen, prec, s, true);
 }
 
 /**

--- a/curs_lib.c
+++ b/curs_lib.c
@@ -355,7 +355,7 @@ enum QuadOption mutt_yesorno(const char *msg, enum QuadOption def)
    * ensure there is enough room for the answer and truncate the question
    * to fit.  */
   mutt_str_asprintf(&answer_string, " ([%s]/%s): ", (def == MUTT_YES) ? yes : no,
-                (def == MUTT_YES) ? no : yes);
+                    (def == MUTT_YES) ? no : yes);
   answer_string_wid = mutt_strwidth(answer_string);
   msg_wid = mutt_strwidth(msg);
 

--- a/curs_lib.c
+++ b/curs_lib.c
@@ -833,7 +833,7 @@ int mutt_multi_choice(const char *prompt, const char *letters)
           SETCOLOR(MT_COLOR_PROMPT);
           addnstr(prompt, cur - prompt);
 
-          if (isalnum(cur[1]) && cur[2] == ')')
+          if (isalnum(cur[1]) && (cur[2] == ')'))
           {
             // we have a single letter within parentheses
             SETCOLOR(MT_COLOR_OPTIONS);

--- a/curs_lib.c
+++ b/curs_lib.c
@@ -927,7 +927,7 @@ int mutt_addwch(wchar_t wc)
  * @param[in]  buflen    Buffer length
  * @param[in]  min_width Minimum width
  * @param[in]  max_width Maximum width
- * @param[in]  justify   Justification, e.g. #FMT_RIGHT
+ * @param[in]  justify   Justification, e.g. #JUSTIFY_RIGHT
  * @param[in]  pad_char  Padding character
  * @param[in]  s         String to format
  * @param[in]  n         Number of bytes of string to format
@@ -938,7 +938,8 @@ int mutt_addwch(wchar_t wc)
  * character cells when printed.
  */
 void mutt_simple_format(char *buf, size_t buflen, int min_width, int max_width,
-                        int justify, char pad_char, const char *s, size_t n, bool arboreal)
+                        enum FormatJustify justify, char pad_char,
+                        const char *s, size_t n, bool arboreal)
 {
   wchar_t wc;
   int w;
@@ -1000,7 +1001,7 @@ void mutt_simple_format(char *buf, size_t buflen, int min_width, int max_width,
   w = ((int) buflen < min_width) ? buflen : min_width;
   if (w <= 0)
     *p = '\0';
-  else if (justify == FMT_RIGHT) /* right justify */
+  else if (justify == JUSTIFY_RIGHT) /* right justify */
   {
     p[w] = '\0';
     while (--p >= buf)
@@ -1008,7 +1009,7 @@ void mutt_simple_format(char *buf, size_t buflen, int min_width, int max_width,
     while (--w >= 0)
       buf[w] = pad_char;
   }
-  else if (justify == FMT_CENTER) /* center */
+  else if (justify == JUSTIFY_CENTER) /* center */
   {
     char *savedp = p;
     int half = (w + 1) / 2; /* half of cushion space */
@@ -1052,7 +1053,7 @@ void mutt_simple_format(char *buf, size_t buflen, int min_width, int max_width,
  */
 static void format_s_x(char *buf, size_t buflen, const char *prec, const char *s, bool arboreal)
 {
-  int justify = FMT_RIGHT;
+  enum FormatJustify justify = JUSTIFY_RIGHT;
   char *p = NULL;
   int min_width;
   int max_width = INT_MAX;
@@ -1060,12 +1061,12 @@ static void format_s_x(char *buf, size_t buflen, const char *prec, const char *s
   if (*prec == '-')
   {
     prec++;
-    justify = FMT_LEFT;
+    justify = JUSTIFY_LEFT;
   }
   else if (*prec == '=')
   {
     prec++;
-    justify = FMT_CENTER;
+    justify = JUSTIFY_CENTER;
   }
   min_width = strtol(prec, &p, 10);
   if (*p == '.')

--- a/curs_lib.h
+++ b/curs_lib.h
@@ -38,10 +38,15 @@ extern bool C_MetaKey; /**< interpret ALT-x as ESC-x */
 
 extern int MuttGetchTimeout; ///< Timeout in ms for mutt_getch()
 
-/* For mutt_simple_format() justifications */
-#define FMT_LEFT   -1
-#define FMT_CENTER 0
-#define FMT_RIGHT  1
+/**
+ * enum FormatJustify - Alignment for mutt_simple_format()
+ */
+enum FormatJustify
+{
+  JUSTIFY_LEFT = -1,  ///< Left justify the text
+  JUSTIFY_CENTER = 0, ///< Centre the text
+  JUSTIFY_RIGHT = 1,  ///< Right justify the text
+};
 
 int          mutt_addwch(wchar_t wc);
 int          mutt_any_key_to_continue(const char *s);
@@ -66,7 +71,7 @@ void         mutt_push_macro_event(int ch, int op);
 void         mutt_query_exit(void);
 void         mutt_refresh(void);
 void         mutt_show_error(void);
-void         mutt_simple_format(char *buf, size_t buflen, int min_width, int max_width, int justify, char pad_char, const char *s, size_t n, bool arboreal);
+void         mutt_simple_format(char *buf, size_t buflen, int min_width, int max_width, enum FormatJustify justify, char pad_char, const char *s, size_t n, bool arboreal);
 int          mutt_strwidth(const char *s);
 void         mutt_unget_event(int ch, int op);
 void         mutt_unget_string(const char *s);

--- a/curs_lib.h
+++ b/curs_lib.h
@@ -66,7 +66,7 @@ void         mutt_push_macro_event(int ch, int op);
 void         mutt_query_exit(void);
 void         mutt_refresh(void);
 void         mutt_show_error(void);
-void         mutt_simple_format(char *buf, size_t buflen, int min_width, int max_width, int justify, char pad_char, const char *s, size_t n, int arboreal);
+void         mutt_simple_format(char *buf, size_t buflen, int min_width, int max_width, int justify, char pad_char, const char *s, size_t n, bool arboreal);
 int          mutt_strwidth(const char *s);
 void         mutt_unget_event(int ch, int op);
 void         mutt_unget_string(const char *s);

--- a/edit.c
+++ b/edit.c
@@ -427,7 +427,7 @@ int mutt_builtin_editor(const char *path, struct Email *msg, struct Email *cur)
     {
       /* remove trailing whitespace from the line */
       p = tmp + mutt_str_strlen(tmp) - 1;
-      while (p >= tmp && ISSPACE(*p))
+      while ((p >= tmp) && ISSPACE(*p))
         *p-- = '\0';
 
       p = tmp + 2;

--- a/editmsg.c
+++ b/editmsg.c
@@ -183,7 +183,8 @@ static int ev_message(enum EvMessage action, struct Mailbox *m, struct Email *e)
   }
 
   MsgOpenFlags of = MUTT_MSG_NO_FLAGS;
-  CopyHeaderFlags cf = (((ctx_app->mailbox->magic == MUTT_MBOX) || (ctx_app->mailbox->magic == MUTT_MMDF)) ?
+  CopyHeaderFlags cf =
+      (((ctx_app->mailbox->magic == MUTT_MBOX) || (ctx_app->mailbox->magic == MUTT_MMDF)) ?
            CH_NO_FLAGS :
            CH_NOSTATUS);
 

--- a/email/email.h
+++ b/email/email.h
@@ -39,7 +39,7 @@ struct Email
   SecurityFlags security;   /**< bit 0-8: flags, bit 9,10: application.
                                  see: ncrypt/ncrypt.h pgplib.h, smime.h */
 
-  bool mime            : 1; /**< has a MIME-Version email? */
+  bool mime            : 1; /**< has a MIME-Version header? */
   bool flagged         : 1; /**< marked important? */
   bool tagged          : 1;
   bool deleted         : 1;

--- a/email/parse.c
+++ b/email/parse.c
@@ -113,7 +113,7 @@ static void parse_parameters(struct ParameterList *param, const char *s)
     {
       i = p - s;
       /* remove whitespace from the end of the attribute name */
-      while (i > 0 && mutt_str_is_email_wsp(s[i - 1]))
+      while ((i > 0) && mutt_str_is_email_wsp(s[i - 1]))
         i--;
 
       /* the check for the missing parameter token is here so that we can skip

--- a/enter.c
+++ b/enter.c
@@ -358,7 +358,7 @@ int mutt_enter_string_full(char *buf, size_t buflen, int col,
           else
           {
             state->curpos++;
-            while (state->curpos < state->lastchar &&
+            while ((state->curpos < state->lastchar) &&
                    COMB_CHAR(state->wbuf[state->curpos]))
             {
               state->curpos++;

--- a/handler.c
+++ b/handler.c
@@ -177,7 +177,7 @@ static void decode_xbit(struct State *s, long len, bool istext, iconv_t cd)
   int c;
   char bufi[BUFI_SIZE];
   size_t l = 0;
-  while ((c = fgetc(s->fp_in)) != EOF && len--)
+  while (((c = fgetc(s->fp_in)) != EOF) && len--)
   {
     if ((c == '\r') && len)
     {
@@ -332,7 +332,7 @@ static void decode_quoted(struct State *s, long len, bool istext, iconv_t cd)
     /* chop trailing whitespace if we got the full line */
     if (last == '\n')
     {
-      while (linelen > 0 && ISSPACE(line[linelen - 1]))
+      while ((linelen > 0) && ISSPACE(line[linelen - 1]))
         linelen--;
       line[linelen] = '\0';
     }
@@ -672,7 +672,7 @@ static int text_plain_handler(struct Body *b, struct State *s)
     if ((mutt_str_strcmp(buf, "-- ") != 0) && C_TextFlowed)
     {
       l = mutt_str_strlen(buf);
-      while (l > 0 && buf[l - 1] == ' ')
+      while ((l > 0) && (buf[l - 1] == ' '))
         buf[--l] = '\0';
     }
     if (s->prefix)

--- a/hdrline.c
+++ b/hdrline.c
@@ -495,21 +495,22 @@ static bool thread_is_old(struct Context *ctx, struct Email *e)
  *
  * | Expando | Description
  * |:--------|:-----------------------------------------------------------------
+ * | \%(fmt) | Date/time when the message was received
  * | \%a     | Address of the author
  * | \%A     | Reply-to address (if present; otherwise: address of author)
  * | \%b     | Filename of the original message folder (think mailbox)
- * | \%B     | The list to which the letter was sent, or else the folder name (%b).
+ * | \%B     | The list to which the letter was sent, or else the folder name (%b)
  * | \%C     | Current message number
  * | \%c     | Number of characters (bytes) in the message
- * | \%D     | Date and time of message using $date_format and local timezone
- * | \%d     | Date and time of message using $date_format and sender's timezone
+ * | \%D     | Date and time of message using `$date_format` and local timezone
+ * | \%d     | Date and time of message using `$date_format` and sender's timezone
  * | \%e     | Current message number in thread
  * | \%E     | Number of messages in current thread
- * | \%F     | Author name, or recipient name if the message is from you
  * | \%Fp    | Like %F, but plain. No contextual formatting is applied to recipient name
+ * | \%F     | Author name, or recipient name if the message is from you
  * | \%f     | Sender (address + real name), either From: or Return-Path:
- * | \%g     | Message tags (e.g. notmuch tags/imap flags)
  * | \%Gx    | Individual message tag (e.g. notmuch tags/imap flags)
+ * | \%g     | Message tags (e.g. notmuch tags/imap flags)
  * | \%H     | Spam attribute(s) of this message
  * | \%I     | Initials of author
  * | \%i     | Message-id of the current message
@@ -519,8 +520,8 @@ static bool thread_is_old(struct Context *ctx, struct Email *e)
  * | \%l     | Number of lines in the message
  * | \%M     | Number of hidden messages if the thread is collapsed
  * | \%m     | Total number of message in the mailbox
- * | \%N     | Message score
  * | \%n     | Author's real name (or address if missing)
+ * | \%N     | Message score
  * | \%O     | Like %L, except using address instead of name
  * | \%P     | Progress indicator for the built-in pager (how much of the file has been displayed)
  * | \%q     | Newsgroup name (if compiled with NNTP support)
@@ -528,20 +529,19 @@ static bool thread_is_old(struct Context *ctx, struct Email *e)
  * | \%r     | Comma separated list of To: recipients
  * | \%S     | Single character status of the message (N/O/D/d/!/r/-)
  * | \%s     | Subject of the message
- * | \%T     | The appropriate character from the $$to_chars string
  * | \%t     | 'To:' field (recipients)
+ * | \%T     | The appropriate character from the `$to_chars` string
  * | \%u     | User (login) name of the author
  * | \%v     | First name of the author, or the recipient if the message is from you
  * | \%W     | Name of organization of author ('Organization:' field)
  * | \%x     | 'X-Comment-To:' field (if present and compiled with NNTP support)
  * | \%X     | Number of MIME attachments
- * | \%Y     | 'X-Label:' field (if present, tree unfolded, and != parent's x-label)
  * | \%y     | 'X-Label:' field (if present)
- * | \%Z     | Combined message flags
+ * | \%Y     | 'X-Label:' field (if present, tree unfolded, and != parent's x-label)
  * | \%zc    | Message crypto flags
  * | \%zs    | Message status flags
  * | \%zt    | Message tag flags
- * | \%(fmt) | Date/time when the message was received
+ * | \%Z     | Combined message flags
  * | \%[fmt] | Message date/time converted to the local time zone
  * | \%{fmt} | Message date/time converted to sender's time zone
  */

--- a/imap/auth_sasl.c
+++ b/imap/auth_sasl.c
@@ -147,7 +147,7 @@ enum ImapAuthRes imap_auth_sasl(struct ImapAccountData *adata, const char *metho
   irc = IMAP_CMD_CONTINUE;
 
   /* looping protocol */
-  while (rc == SASL_CONTINUE || olen > 0)
+  while ((rc == SASL_CONTINUE) || (olen > 0))
   {
     do
       irc = imap_cmd_step(adata);

--- a/imap/command.c
+++ b/imap/command.c
@@ -440,7 +440,7 @@ static void cmd_parse_fetch(struct ImapAccountData *adata, char *s)
         return;
       }
       s++;
-      while (*s && *s != ')')
+      while (*s && (*s != ')'))
         s++;
       if (*s == ')')
         s++;
@@ -479,7 +479,7 @@ static void cmd_parse_fetch(struct ImapAccountData *adata, char *s)
         return;
       }
       s++;
-      while (*s && *s != ')')
+      while (*s && (*s != ')'))
         s++;
       if (*s == ')')
         s++;
@@ -751,7 +751,7 @@ static void cmd_parse_search(struct ImapAccountData *adata, const char *s)
 
   mutt_debug(LL_DEBUG2, "Handling SEARCH\n");
 
-  while ((s = imap_next_word((char *) s)) && *s != '\0')
+  while ((s = imap_next_word((char *) s)) && (*s != '\0'))
   {
     if (mutt_str_atoui(s, &uid) < 0)
       continue;
@@ -827,7 +827,7 @@ static void cmd_parse_status(struct ImapAccountData *adata, char *s)
     mutt_debug(LL_DEBUG1, "Error parsing STATUS\n");
     return;
   }
-  while (*s && *s != ')')
+  while (*s && (*s != ')'))
   {
     value = imap_next_word(s);
 
@@ -906,7 +906,7 @@ static void cmd_parse_enabled(struct ImapAccountData *adata, const char *s)
 {
   mutt_debug(LL_DEBUG2, "Handling ENABLED\n");
 
-  while ((s = imap_next_word((char *) s)) && *s != '\0')
+  while ((s = imap_next_word((char *) s)) && (*s != '\0'))
   {
     if (mutt_str_startswith(s, "UTF8=ACCEPT", CASE_IGNORE) ||
         mutt_str_startswith(s, "UTF8=ONLY", CASE_IGNORE))

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -120,7 +120,7 @@ static char *get_flags(struct ListHead *hflags, char *s)
   }
 
   /* update caller's flags handle */
-  while (*s && *s != ')')
+  while (*s && (*s != ')'))
   {
     s++;
     SKIPWS(s);
@@ -493,7 +493,7 @@ static size_t longest_common_prefix(char *dest, const char *src, size_t start, s
 {
   size_t pos = start;
 
-  while (pos < dlen && dest[pos] && dest[pos] == src[pos])
+  while ((pos < dlen) && dest[pos] && (dest[pos] == src[pos]))
     pos++;
   dest[pos] = '\0';
 
@@ -2343,7 +2343,7 @@ static int imap_tags_edit(struct Mailbox *m, const char *tags, char *buf, size_t
     }
 
     /* Skip duplicate space */
-    while (*checker == ' ' && *(checker + 1) == ' ')
+    while ((*checker == ' ') && (*(checker + 1) == ' '))
       checker++;
 
     /* copy char to new and go the next one */

--- a/imap/message.c
+++ b/imap/message.c
@@ -45,6 +45,7 @@
 #include "bcache.h"
 #include "curs_lib.h"
 #include "globals.h"
+#include "hcache/hcache.h"
 #include "imap/imap.h"
 #include "mailbox.h"
 #include "mutt_account.h"
@@ -55,7 +56,6 @@
 #include "mx.h"
 #include "progress.h"
 #include "protos.h"
-#include "hcache/hcache.h"
 #ifdef ENABLE_NLS
 #include <libintl.h>
 #endif
@@ -1028,12 +1028,12 @@ static int read_headers_fetch_new(struct Mailbox *m, unsigned int msn_begin,
   if (adata->capabilities & IMAP_CAP_IMAP4REV1)
   {
     mutt_str_asprintf(&hdrreq, "BODY.PEEK[HEADER.FIELDS (%s%s%s)]", want_headers,
-                  C_ImapHeaders ? " " : "", NONULL(C_ImapHeaders));
+                      C_ImapHeaders ? " " : "", NONULL(C_ImapHeaders));
   }
   else if (adata->capabilities & IMAP_CAP_IMAP4)
   {
     mutt_str_asprintf(&hdrreq, "RFC822.HEADER.LINES (%s%s%s)", want_headers,
-                  C_ImapHeaders ? " " : "", NONULL(C_ImapHeaders));
+                      C_ImapHeaders ? " " : "", NONULL(C_ImapHeaders));
   }
   else
   { /* Unable to fetch headers for lower versions */
@@ -1069,7 +1069,8 @@ static int read_headers_fetch_new(struct Mailbox *m, unsigned int msn_begin,
 
     fetch_msn_end = msn_end;
     char *cmd = NULL;
-    mutt_str_asprintf(&cmd, "FETCH %s (UID FLAGS INTERNALDATE RFC822.SIZE %s)", b->data, hdrreq);
+    mutt_str_asprintf(&cmd, "FETCH %s (UID FLAGS INTERNALDATE RFC822.SIZE %s)",
+                      b->data, hdrreq);
     imap_cmd_start(adata, cmd);
     FREE(&cmd);
     mutt_buffer_free(&b);

--- a/imap/message.c
+++ b/imap/message.c
@@ -246,7 +246,7 @@ static char *msg_parse_flags(struct ImapHeader *h, char *s)
   edata->old = false;
 
   /* start parsing */
-  while (*s && *s != ')')
+  while (*s && (*s != ')'))
   {
     if ((plen = mutt_str_startswith(s, "\\deleted", CASE_IGNORE)))
     {
@@ -283,7 +283,7 @@ static char *msg_parse_flags(struct ImapHeader *h, char *s)
       char *flag_word = s;
       bool is_system_keyword = mutt_str_startswith(s, "\\", CASE_IGNORE);
 
-      while (*s && !ISSPACE(*s) && *s != ')')
+      while (*s && !ISSPACE(*s) && (*s != ')'))
         s++;
 
       ctmp = *s;
@@ -395,7 +395,7 @@ static int msg_parse_fetch(struct ImapHeader *h, char *s)
         return -1;
       }
       s++;
-      while (*s && *s != ')')
+      while (*s && (*s != ')'))
         s++;
       if (*s == ')')
         s++;

--- a/imap/util.c
+++ b/imap/util.c
@@ -786,7 +786,7 @@ char *imap_fix_path(char server_delim, const char *mailbox, char *path, size_t p
   int i = 0;
   char delim = server_delim;
 
-  while (mailbox && *mailbox && i < plen - 1)
+  while (mailbox && *mailbox && (i < plen - 1))
   {
     if ((C_ImapDelimChars && strchr(C_ImapDelimChars, *mailbox)) ||
         (delim && (*mailbox == delim)))
@@ -796,7 +796,7 @@ char *imap_fix_path(char server_delim, const char *mailbox, char *path, size_t p
         delim = *mailbox;
 
       while (*mailbox && ((C_ImapDelimChars && strchr(C_ImapDelimChars, *mailbox)) ||
-                          (delim && *mailbox == delim)))
+                          (delim && (*mailbox == delim))))
       {
         mailbox++;
       }
@@ -1103,7 +1103,7 @@ int imap_wait_keepalive(pid_t pid)
   sigaction(SIGALRM, &act, &oldalrm);
 
   alarm(C_ImapKeepalive);
-  while (waitpid(pid, &rc, 0) < 0 && errno == EINTR)
+  while ((waitpid(pid, &rc, 0) < 0) && (errno == EINTR))
   {
     alarm(0); /* cancel a possibly pending alarm */
     imap_keepalive();

--- a/imap/util.c
+++ b/imap/util.c
@@ -51,12 +51,12 @@
 #include "bcache.h"
 #include "curs_lib.h"
 #include "globals.h"
+#include "hcache/hcache.h"
 #include "imap/imap.h"
 #include "mailbox.h"
 #include "message.h"
 #include "mutt_account.h"
 #include "options.h"
-#include "hcache/hcache.h"
 
 /* These Config Variables are only used in imap/util.c */
 char *C_ImapDelimChars; ///< Config: (imap) Characters that denote separators in IMAP folders

--- a/mailbox.c
+++ b/mailbox.c
@@ -553,4 +553,3 @@ void mutt_mailbox_size_sub(struct Mailbox *m, const struct Email *e)
 {
   m->size -= mutt_email_size(e);
 }
-

--- a/maildir/maildir.c
+++ b/maildir/maildir.c
@@ -47,12 +47,12 @@
 #include "config/lib.h"
 #include "email/lib.h"
 #include "globals.h"
+#include "hcache/hcache.h"
 #include "mailbox.h"
 #include "maildir/lib.h"
 #include "monitor.h"
 #include "muttlib.h"
 #include "mx.h"
-#include "hcache/hcache.h"
 
 // Flags for maildir_mbox_check()
 #define MMC_NO_DIRS 0        ///< No directories changed

--- a/maildir/shared.c
+++ b/maildir/shared.c
@@ -442,9 +442,9 @@ int maildir_move_to_mailbox(struct Mailbox *m, struct Maildir **ptr)
       continue;
 
     mutt_debug(LL_DEBUG2, "Adding header structure. Flags: %s%s%s%s%s\n",
-                md->email->flagged ? "f" : "", md->email->deleted ? "D" : "",
-                md->email->replied ? "r" : "", md->email->old ? "O" : "",
-                md->email->read ? "R" : "");
+               md->email->flagged ? "f" : "", md->email->deleted ? "D" : "",
+               md->email->replied ? "r" : "", md->email->old ? "O" : "",
+               md->email->read ? "R" : "");
     if (m->msg_count == m->email_max)
       mx_alloc_memory(m);
 

--- a/menu.c
+++ b/menu.c
@@ -345,7 +345,7 @@ static void menu_pad_string(struct Menu *menu, char *buf, size_t buflen)
   int shift = C_ArrowCursor ? 3 : 0;
   int cols = menu->indexwin->cols - shift;
 
-  mutt_simple_format(buf, buflen, cols, cols, FMT_LEFT, ' ', scratch,
+  mutt_simple_format(buf, buflen, cols, cols, JUSTIFY_LEFT, ' ', scratch,
                      mutt_str_strlen(scratch), true);
   buf[buflen - 1] = '\0';
   FREE(&scratch);

--- a/menu.c
+++ b/menu.c
@@ -346,7 +346,7 @@ static void menu_pad_string(struct Menu *menu, char *buf, size_t buflen)
   int cols = menu->indexwin->cols - shift;
 
   mutt_simple_format(buf, buflen, cols, cols, FMT_LEFT, ' ', scratch,
-                     mutt_str_strlen(scratch), 1);
+                     mutt_str_strlen(scratch), true);
   buf[buflen - 1] = '\0';
   FREE(&scratch);
 }

--- a/menu.c
+++ b/menu.c
@@ -158,7 +158,7 @@ static void print_enriched_string(int index, int attr, unsigned char *s, bool do
         SETCOLOR(MT_COLOR_TREE);
 #endif
 
-      while (*s && *s < MUTT_TREE_MAX)
+      while (*s && (*s < MUTT_TREE_MAX))
       {
         switch (*s)
         {
@@ -1190,7 +1190,7 @@ static int menu_search(struct Menu *menu, int op)
 search_next:
   if (wrap)
     mutt_message(_("Search wrapped to top"));
-  while (rc >= 0 && rc < menu->max)
+  while ((rc >= 0) && (rc < menu->max))
   {
     if (menu->menu_search(menu, &re, rc) == 0)
     {

--- a/mutt/history.c
+++ b/mutt/history.c
@@ -114,7 +114,7 @@ static int OldSize = 0;
  */
 static struct History *get_history(enum HistoryClass hclass)
 {
-  if (hclass >= HC_MAX || C_History == 0)
+  if ((hclass >= HC_MAX) || (C_History == 0))
     return NULL;
 
   struct History *hist = &Histories[hclass];

--- a/mutt/md5.c
+++ b/mutt/md5.c
@@ -86,10 +86,10 @@ static void mutt_md5_process_block(const void *buffer, size_t len, struct Md5Ctx
   while (words < endp)
   {
     md5_uint32 *cwp = correct_words;
-    md5_uint32 A_save = A;
-    md5_uint32 B_save = B;
-    md5_uint32 C_save = C;
-    md5_uint32 D_save = D;
+    md5_uint32 save_A = A;
+    md5_uint32 save_B = B;
+    md5_uint32 save_C = C;
+    md5_uint32 save_D = D;
 
     /* First round: using the given function, the context and a constant the
      * next context is computed.  Because the algorithms processing unit is a
@@ -203,10 +203,10 @@ static void mutt_md5_process_block(const void *buffer, size_t len, struct Md5Ctx
     OP(FI, B, C, D, A, 9, 21, 0xeb86d391);
 
     /* Add the starting values of the context. */
-    A += A_save;
-    B += B_save;
-    C += C_save;
-    D += D_save;
+    A += save_A;
+    B += save_B;
+    C += save_C;
+    D += save_D;
   }
 
   /* Put checksum in context given as argument. */

--- a/mutt/string.c
+++ b/mutt/string.c
@@ -37,11 +37,11 @@
 #include <string.h>
 #include <strings.h>
 #include "exit.h"
+#include "list.h"
 #include "logging.h"
 #include "memory.h"
 #include "message.h"
 #include "string2.h"
-#include "list.h"
 #ifdef HAVE_SYSEXITS_H
 #include <sysexits.h>
 #endif

--- a/mutt/string.c
+++ b/mutt/string.c
@@ -978,7 +978,7 @@ int mutt_str_word_casecmp(const char *a, const char *b)
 bool mutt_str_is_ascii(const char *p, size_t len)
 {
   const char *s = p;
-  while (s && (unsigned int) (s - p) < len)
+  while (s && ((unsigned int) (s - p) < len))
   {
     if ((*s & 0x80) != 0)
       return false;

--- a/mutt_logging.c
+++ b/mutt_logging.c
@@ -195,7 +195,7 @@ int log_disp_curses(time_t stamp, const char *file, int line,
     error_pause();
 
   mutt_simple_format(ErrorBuf, sizeof(ErrorBuf), 0, MuttMessageWindow->cols,
-                     FMT_LEFT, 0, buf, sizeof(buf), false);
+                     JUSTIFY_LEFT, 0, buf, sizeof(buf), false);
   ErrorBufMessage = true;
 
   if (!OptKeepQuiet)

--- a/mutt_logging.c
+++ b/mutt_logging.c
@@ -195,7 +195,7 @@ int log_disp_curses(time_t stamp, const char *file, int line,
     error_pause();
 
   mutt_simple_format(ErrorBuf, sizeof(ErrorBuf), 0, MuttMessageWindow->cols,
-                     FMT_LEFT, 0, buf, sizeof(buf), 0);
+                     FMT_LEFT, 0, buf, sizeof(buf), false);
   ErrorBufMessage = true;
 
   if (!OptKeepQuiet)

--- a/mutt_thread.c
+++ b/mutt_thread.c
@@ -441,7 +441,7 @@ static void make_subject_list(struct ListHead *subjects, struct MuttThread *cur,
         mutt_list_insert_after(subjects, np, env->real_subj);
     }
 
-    while (!cur->next && cur != start)
+    while (!cur->next && (cur != start))
     {
       cur = cur->parent;
     }
@@ -579,7 +579,7 @@ static void pseudo_threads(struct Context *ctx)
           }
         }
 
-        while (!tmp->next && tmp != cur)
+        while (!tmp->next && (tmp != cur))
         {
           tmp = tmp->parent;
         }
@@ -891,7 +891,7 @@ void mutt_sort_threads(struct Context *ctx, bool init)
           while (!tmp->message)
             tmp = tmp->child;
           tmp->check_subject = true;
-          while (!tmp->next && tmp != thread)
+          while (!tmp->next && (tmp != thread))
             tmp = tmp->parent;
           if (tmp != thread)
             tmp = tmp->next;

--- a/muttlib.c
+++ b/muttlib.c
@@ -836,7 +836,7 @@ void mutt_expando_format(char *buf, size_t buflen, size_t col, int cols, const c
     {
       /* Scan backwards for backslashes */
       off = n;
-      while (off > 0 && src[off - 2] == '\\')
+      while ((off > 0) && (src[off - 2] == '\\'))
         off--;
     }
 
@@ -904,7 +904,7 @@ void mutt_expando_format(char *buf, size_t buflen, size_t col, int cols, const c
         if (n > 0)
         {
           buf[n] = '\0';
-          while ((n > 0) && (buf[n - 1] == '\n' || buf[n - 1] == '\r'))
+          while ((n > 0) && ((buf[n - 1] == '\n') || (buf[n - 1] == '\r')))
             buf[--n] = '\0';
           mutt_debug(5, "fmtpipe < %s\n", buf);
 
@@ -953,7 +953,7 @@ void mutt_expando_format(char *buf, size_t buflen, size_t col, int cols, const c
     }
   }
 
-  while (*src && wlen < buflen)
+  while (*src && (wlen < buflen))
   {
     if (*src == '%')
     {
@@ -1014,8 +1014,8 @@ void mutt_expando_format(char *buf, size_t buflen, size_t col, int cols, const c
         /* eat the format string */
         cp = prefix;
         count = 0;
-        while (count < sizeof(prefix) && (isdigit((unsigned char) *src) ||
-                                          *src == '.' || *src == '-' || *src == '='))
+        while ((count < sizeof(prefix)) && (isdigit((unsigned char) *src) || (*src == '.') ||
+                                            (*src == '-') || (*src == '=')))
         {
           *cp++ = *src++;
           count++;
@@ -1227,7 +1227,7 @@ void mutt_expando_format(char *buf, size_t buflen, size_t col, int cols, const c
         bool tolower = false;
         bool nodots = false;
 
-        while (ch == '_' || ch == ':')
+        while ((ch == '_') || (ch == ':'))
         {
           if (ch == '_')
             tolower = true;

--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -3269,23 +3269,23 @@ int smime_gpgme_application_handler(struct Body *a, struct State *s)
  *
  * | Expando | Description
  * |:--------|:--------------------------------------------------------
- * | \%u     | User id
  * | \%n     | Number
- * | \%t     | Trust/validity of the key-uid association
  * | \%p     | Protocol
+ * | \%t     | Trust/validity of the key-uid association
+ * | \%u     | User id
  * | \%[...] | Date of key using strftime(3)
  * |         |
- * | \%k     | Key id
  * | \%a     | Algorithm
- * | \%l     | Length
- * | \%f     | Flags
  * | \%c     | Capabilities
+ * | \%f     | Flags
+ * | \%k     | Key id
+ * | \%l     | Length
  * |         |
- * | \%K     | Key id of the principal key
  * | \%A     | Algorithm of the principal key
- * | \%L     | Length of the principal key
- * | \%F     | Flags of the principal key
  * | \%C     | Capabilities of the principal key
+ * | \%F     | Flags of the principal key
+ * | \%K     | Key id of the principal key
+ * | \%L     | Length of the principal key
  */
 static const char *crypt_format_str(char *buf, size_t buflen, size_t col, int cols,
                                     char op, const char *src, const char *prec,

--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -776,7 +776,7 @@ static int have_gpg_version(const char *version)
 
     ctx = create_gpgme_context(false);
     engineinfo = gpgme_ctx_get_engine_info(ctx);
-    while (engineinfo && engineinfo->protocol != GPGME_PROTOCOL_OpenPGP)
+    while (engineinfo && (engineinfo->protocol != GPGME_PROTOCOL_OpenPGP))
       engineinfo = engineinfo->next;
     if (!engineinfo)
     {
@@ -2473,7 +2473,7 @@ static int pgp_gpgme_extract_keys(gpgme_data_t keydata, FILE **fp)
     }
 
     engineinfo = gpgme_ctx_get_engine_info(tmpctx);
-    while (engineinfo && engineinfo->protocol != GPGME_PROTOCOL_OpenPGP)
+    while (engineinfo && (engineinfo->protocol != GPGME_PROTOCOL_OpenPGP))
       engineinfo = engineinfo->next;
     if (!engineinfo)
     {
@@ -3435,7 +3435,7 @@ static const char *crypt_format_str(char *buf, size_t buflen, size_t col, int co
       }
 
       len = buflen - 1;
-      while (len > 0 && *cp != ']')
+      while ((len > 0) && (*cp != ']'))
       {
         if (*cp == '%')
         {

--- a/ncrypt/pgp.c
+++ b/ncrypt/pgp.c
@@ -540,7 +540,7 @@ int pgp_class_application_handler(struct Body *m, struct State *s)
       }
 
       fputs(buf, fp_tmp);
-      while (bytes > 0 && fgets(buf, sizeof(buf) - 1, s->fp_in))
+      while ((bytes > 0) && fgets(buf, sizeof(buf) - 1, s->fp_in))
       {
         offset = ftello(s->fp_in);
         bytes -= (offset - last_pos); /* don't rely on mutt_str_strlen(buf) */

--- a/ncrypt/pgpinvoke.c
+++ b/ncrypt/pgpinvoke.c
@@ -84,7 +84,7 @@ struct PgpCommandContext
  *
  * | Expando | Description
  * |:--------|:-----------------------------------------------------------------
- * | \%a     | Value of $pgp_sign_as if set, otherwise $pgp_default_key
+ * | \%a     | Value of `$pgp_sign_as` if set, otherwise `$pgp_default_key`
  * | \%f     | File containing a message
  * | \%p     | Expands to PGPPASSFD=0 when a pass phrase is needed, to an empty string otherwise
  * | \%r     | One or more key IDs (or fingerprints if available)

--- a/ncrypt/pgpkey.c
+++ b/ncrypt/pgpkey.c
@@ -157,20 +157,22 @@ struct PgpEntry
  *
  * | Expando | Description
  * |:--------|:--------------------------------------------------------
- * | \%a     | Algorithm
- * | \%A     | Algorithm of the princ. key
- * | \%c     | Capabilities
- * | \%C     | Capabilities of the princ. key
- * | \%f     | Flags
- * | \%F     | Flags of the princ. key
- * | \%k     | Key id
- * | \%K     | Key id of the principal key
- * | \%l     | Length
- * | \%L     | Length of the princ. key
  * | \%n     | Number
  * | \%t     | Trust/validity of the key-uid association
  * | \%u     | User id
  * | \%[...] | Date of key using strftime(3)
+ * |         |
+ * | \%a     | Algorithm
+ * | \%c     | Capabilities
+ * | \%f     | Flags
+ * | \%k     | Key id
+ * | \%l     | Length
+ * |         |
+ * | \%A     | Algorithm of the principal key
+ * | \%C     | Capabilities of the principal key
+ * | \%F     | Flags of the principal key
+ * | \%K     | Key id of the principal key
+ * | \%L     | Length of the principal key
  */
 static const char *pgp_entry_fmt(char *buf, size_t buflen, size_t col, int cols,
                                  char op, const char *src, const char *prec,

--- a/ncrypt/pgpkey.c
+++ b/ncrypt/pgpkey.c
@@ -274,7 +274,7 @@ static const char *pgp_entry_fmt(char *buf, size_t buflen, size_t col, int cols,
       }
 
       len = buflen - 1;
-      while (len > 0 && *cp != ']')
+      while ((len > 0) && (*cp != ']'))
       {
         if (*cp == '%')
         {

--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -201,12 +201,12 @@ int smime_class_valid_passphrase(void)
  * | Expando | Description
  * |:--------|:-----------------------------------------------------------------
  * | \%a     | Algorithm used for encryption
- * | \%C     | CA location: Depending on whether $smime_ca_location points to a directory or file
+ * | \%C     | CA location: Depending on whether `$smime_ca_location` points to a directory or file
  * | \%c     | One or more certificate IDs
- * | \%d     | Message digest algorithm specified with $smime_sign_digest_alg
+ * | \%d     | Message digest algorithm specified with `$smime_sign_digest_alg`
  * | \%f     | File containing a message
  * | \%i     | Intermediate certificates
- * | \%k     | The key-pair specified with $smime_default_key
+ * | \%k     | The key-pair specified with `$smime_default_key`
  * | \%s     | File containing the signature part of a multipart/signed attachment when verifying it
  */
 static const char *fmt_smime_command(char *buf, size_t buflen, size_t col, int cols,

--- a/nntp/newsrc.c
+++ b/nntp/newsrc.c
@@ -47,6 +47,7 @@
 #include "bcache.h"
 #include "format_flags.h"
 #include "globals.h"
+#include "hcache/hcache.h"
 #include "mailbox.h"
 #include "mutt_account.h"
 #include "mutt_logging.h"
@@ -56,7 +57,6 @@
 #include "nntp.h"
 #include "protos.h"
 #include "sort.h"
-#include "hcache/hcache.h"
 
 /* These Config Variables are only used in nntp/newsrc.c */
 char *C_NewsCacheDir; ///< Config: (nntp) Directory for cached news articles

--- a/nntp/nntp.c
+++ b/nntp/nntp.c
@@ -48,6 +48,7 @@
 #include "context.h"
 #include "curs_lib.h"
 #include "globals.h"
+#include "hcache/hcache.h"
 #include "hook.h"
 #include "mailbox.h"
 #include "mutt_account.h"
@@ -60,7 +61,6 @@
 #include "progress.h"
 #include "protos.h"
 #include "sort.h"
-#include "hcache/hcache.h"
 #ifdef USE_SASL
 #include <sasl/sasl.h>
 #include <sasl/saslutil.h>

--- a/nntp/nntp.c
+++ b/nntp/nntp.c
@@ -663,7 +663,7 @@ static int nntp_auth(struct NntpAccountData *adata)
         snprintf(buf, sizeof(buf), "AUTHINFO SASL %s", method);
 
         /* looping protocol */
-        while (rc == SASL_CONTINUE || (rc == SASL_OK && client_len))
+        while ((rc == SASL_CONTINUE) || ((rc == SASL_OK) && client_len))
         {
           /* send out client response */
           if (client_len)

--- a/notmuch/mutt_notmuch.c
+++ b/notmuch/mutt_notmuch.c
@@ -55,12 +55,12 @@
 #include "mutt/mutt.h"
 #include "config/lib.h"
 #include "email/lib.h"
-#include "hcache/hcache.h"
 #include "mutt.h"
 #include "mutt_notmuch.h"
 #include "account.h"
 #include "curs_lib.h"
 #include "globals.h"
+#include "hcache/hcache.h"
 #include "index.h"
 #include "mailbox.h"
 #include "maildir/lib.h"
@@ -979,7 +979,7 @@ static void append_message(header_cache_t *h, struct Mailbox *m,
   else
   {
     mutt_hcache_store(h, newpath ? newpath : path,
-        mutt_str_strlen(newpath ? newpath : path), e, 0);
+                      mutt_str_strlen(newpath ? newpath : path), e, 0);
   }
 #endif
   if (init_email(e, newpath ? newpath : path, msg) != 0)
@@ -1021,8 +1021,8 @@ done:
  *
  * Careful, this calls itself recursively to make sure we get everything.
  */
-static void append_replies(header_cache_t *h, struct Mailbox *m, notmuch_query_t *q,
-                           notmuch_message_t *top, bool dedup)
+static void append_replies(header_cache_t *h, struct Mailbox *m,
+                           notmuch_query_t *q, notmuch_message_t *top, bool dedup)
 {
   notmuch_messages_t *msgs = NULL;
 
@@ -1048,8 +1048,8 @@ static void append_replies(header_cache_t *h, struct Mailbox *m, notmuch_query_t
  * add each top level reply in the thread, and then add each reply to the top
  * level replies
  */
-static void append_thread(header_cache_t *h, struct Mailbox *m, notmuch_query_t *q,
-                          notmuch_thread_t *thread, bool dedup)
+static void append_thread(header_cache_t *h, struct Mailbox *m,
+                          notmuch_query_t *q, notmuch_thread_t *thread, bool dedup)
 {
   notmuch_messages_t *msgs = NULL;
 

--- a/pager.c
+++ b/pager.c
@@ -231,7 +231,7 @@ static int check_sig(const char *s, struct Line *info, int n)
 {
   int count = 0;
 
-  while (n > 0 && count <= NUM_SIG_LINES)
+  while ((n > 0) && (count <= NUM_SIG_LINES))
   {
     if (info[n].type != MT_COLOR_SIGNATURE)
       break;
@@ -332,7 +332,7 @@ static void resolve_color(struct Line *line_info, int n, int cnt,
     {
       def_color = class->color;
 
-      while (class && class->length > cnt)
+      while (class && (class->length > cnt))
       {
         def_color = class->color;
         class = class->up;
@@ -994,9 +994,9 @@ static void resolve_types(char *buf, char *raw, struct Line *line_info, int n,
     i = n + 1;
 
     line_info[n].type = MT_COLOR_SIGNATURE;
-    while (i < last && check_sig(buf, line_info, i - 1) == 0 &&
-           (line_info[i].type == MT_COLOR_NORMAL || line_info[i].type == MT_COLOR_QUOTED ||
-            line_info[i].type == MT_COLOR_HEADER))
+    while ((i < last) && (check_sig(buf, line_info, i - 1) == 0) &&
+           ((line_info[i].type == MT_COLOR_NORMAL) || (line_info[i].type == MT_COLOR_QUOTED) ||
+            (line_info[i].type == MT_COLOR_HEADER)))
     {
       /* oops... */
       if (line_info[i].chunks)
@@ -1181,7 +1181,7 @@ static void resolve_types(char *buf, char *raw, struct Line *line_info, int n,
  */
 static bool is_ansi(unsigned char *buf)
 {
-  while ((*buf != '\0') && (isdigit(*buf) || *buf == ';'))
+  while ((*buf != '\0') && (isdigit(*buf) || (*buf == ';')))
     buf++;
   return *buf == 'm';
 }
@@ -1197,7 +1197,7 @@ static int grok_ansi(unsigned char *buf, int pos, struct AnsiAttr *a)
 {
   int x = pos;
 
-  while (isdigit(buf[x]) || buf[x] == ';')
+  while (isdigit(buf[x]) || (buf[x] == ';'))
     x++;
 
   /* Character Attributes */
@@ -1268,7 +1268,7 @@ static int grok_ansi(unsigned char *buf, int pos, struct AnsiAttr *a)
       }
       else
       {
-        while (pos < x && buf[pos] != ';')
+        while ((pos < x) && (buf[pos] != ';'))
           pos++;
         pos++;
       }
@@ -1388,10 +1388,11 @@ static int format_line(struct Line **line_info, int n, unsigned char *buf,
   for (ch = 0, vch = 0; ch < cnt; ch += k, vch += k)
   {
     /* Handle ANSI sequences */
-    while (cnt - ch >= 2 && buf[ch] == '\033' && buf[ch + 1] == '[' && is_ansi(buf + ch + 2))
+    while ((cnt - ch >= 2) && (buf[ch] == '\033') && (buf[ch + 1] == '[') &&
+           is_ansi(buf + ch + 2))
       ch = grok_ansi(buf, ch + 2, pa) + 1;
 
-    while (cnt - ch >= 2 && buf[ch] == '\033' && buf[ch + 1] == ']' &&
+    while ((cnt - ch >= 2) && (buf[ch] == '\033') && (buf[ch + 1] == ']') &&
            ((check_attachment_marker((char *) buf + ch) == 0) ||
             (check_protected_header_marker((char *) buf + ch) == 0)))
     {
@@ -1737,7 +1738,7 @@ static int display_line(FILE *fp, LOFF_T *last_pos, struct Line **line_info,
     {
       buf_ptr = buf + ch;
       /* skip trailing blanks */
-      while (ch && (buf[ch] == ' ' || buf[ch] == '\t' || buf[ch] == '\r'))
+      while (ch && ((buf[ch] == ' ') || (buf[ch] == '\t') || (buf[ch] == '\r')))
         ch--;
       /* A very long word with leading spaces causes infinite
        * wrapping when MUTT_PAGER_NSKIP is set.  A folded header
@@ -1752,7 +1753,7 @@ static int display_line(FILE *fp, LOFF_T *last_pos, struct Line **line_info,
     if (!(flags & MUTT_PAGER_NSKIP))
     {
       /* skip leading blanks on the next line too */
-      while (*buf_ptr == ' ' || *buf_ptr == '\t')
+      while ((*buf_ptr == ' ') || (*buf_ptr == '\t'))
         buf_ptr++;
     }
   }
@@ -1834,7 +1835,7 @@ out:
  */
 static int up_n_lines(int nlines, struct Line *info, int cur, bool hiding)
 {
-  while (cur > 0 && nlines > 0)
+  while ((cur > 0) && (nlines > 0))
   {
     cur--;
     if (!hiding || (info[cur].type != MT_COLOR_QUOTED))
@@ -2106,8 +2107,8 @@ static void pager_custom_redraw(struct Menu *pager_menu)
       rd->lines = 0;
       rd->force_redraw = false;
 
-      while (rd->lines < rd->pager_window->rows &&
-             rd->line_info[rd->curline].offset <= rd->sb.st_size - 1)
+      while ((rd->lines < rd->pager_window->rows) &&
+             (rd->line_info[rd->curline].offset <= rd->sb.st_size - 1))
       {
         if (display_line(rd->fp, &rd->last_pos, &rd->line_info, rd->curline,
                          &rd->last_line, &rd->max_line,
@@ -2850,7 +2851,7 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
           /* Skip all the email headers */
           if (ISHEADER(rd.line_info[new_topline].type))
           {
-            while ((new_topline < rd.last_line ||
+            while (((new_topline < rd.last_line) ||
                     (0 == (dretval = display_line(
                                rd.fp, &rd.last_pos, &rd.line_info, new_topline, &rd.last_line,
                                &rd.max_line, MUTT_TYPES | (flags & MUTT_PAGER_NOWRAP),
@@ -2864,13 +2865,13 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
             break;
           }
 
-          while (((new_topline + C_SkipQuotedOffset) < rd.last_line ||
+          while ((((new_topline + C_SkipQuotedOffset) < rd.last_line) ||
                   (0 == (dretval = display_line(
                              rd.fp, &rd.last_pos, &rd.line_info, new_topline, &rd.last_line,
                              &rd.max_line, MUTT_TYPES | (flags & MUTT_PAGER_NOWRAP),
                              &rd.quote_list, &rd.q_level, &rd.force_redraw,
                              &rd.search_re, rd.pager_window)))) &&
-                 rd.line_info[new_topline + C_SkipQuotedOffset].type != MT_COLOR_QUOTED)
+                 (rd.line_info[new_topline + C_SkipQuotedOffset].type != MT_COLOR_QUOTED))
           {
             new_topline++;
           }
@@ -2881,13 +2882,13 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
             break;
           }
 
-          while (((new_topline + C_SkipQuotedOffset) < rd.last_line ||
+          while ((((new_topline + C_SkipQuotedOffset) < rd.last_line) ||
                   (0 == (dretval = display_line(
                              rd.fp, &rd.last_pos, &rd.line_info, new_topline, &rd.last_line,
                              &rd.max_line, MUTT_TYPES | (flags & MUTT_PAGER_NOWRAP),
                              &rd.quote_list, &rd.q_level, &rd.force_redraw,
                              &rd.search_re, rd.pager_window)))) &&
-                 rd.line_info[new_topline + C_SkipQuotedOffset].type == MT_COLOR_QUOTED)
+                 (rd.line_info[new_topline + C_SkipQuotedOffset].type == MT_COLOR_QUOTED))
           {
             new_topline++;
           }

--- a/pattern.c
+++ b/pattern.c
@@ -2214,7 +2214,7 @@ static void quote_simple(const char *str, char *buf, size_t buflen)
   int i = 0;
 
   buf[i++] = '"';
-  while (*str && i < buflen - 3)
+  while (*str && (i < buflen - 3))
   {
     if ((*str == '\\') || (*str == '"'))
       buf[i++] = '\\';

--- a/pop/pop.c
+++ b/pop/pop.c
@@ -48,6 +48,7 @@
 #include "bcache.h"
 #include "context.h"
 #include "globals.h"
+#include "hcache/hcache.h"
 #include "hook.h"
 #include "mailbox.h"
 #include "mutt_account.h"
@@ -58,7 +59,6 @@
 #include "mx.h"
 #include "ncrypt/ncrypt.h"
 #include "progress.h"
-#include "hcache/hcache.h"
 #ifdef ENABLE_NLS
 #include <libintl.h>
 #endif

--- a/progress.c
+++ b/progress.c
@@ -60,7 +60,8 @@ static void message_bar(int percent, const char *fmt, ...)
   l = mutt_strwidth(buf);
   va_end(ap);
 
-  mutt_simple_format(buf2, sizeof(buf2), 0, COLS - 2, FMT_LEFT, 0, buf, sizeof(buf), false);
+  mutt_simple_format(buf2, sizeof(buf2), 0, COLS - 2, JUSTIFY_LEFT, 0, buf,
+                     sizeof(buf), false);
 
   move(LINES - 1, 0);
 

--- a/progress.c
+++ b/progress.c
@@ -60,7 +60,7 @@ static void message_bar(int percent, const char *fmt, ...)
   l = mutt_strwidth(buf);
   va_end(ap);
 
-  mutt_simple_format(buf2, sizeof(buf2), 0, COLS - 2, FMT_LEFT, 0, buf, sizeof(buf), 0);
+  mutt_simple_format(buf2, sizeof(buf2), 0, COLS - 2, FMT_LEFT, 0, buf, sizeof(buf), false);
 
   move(LINES - 1, 0);
 

--- a/query.c
+++ b/query.c
@@ -242,7 +242,7 @@ static int query_search(struct Menu *menu, regex_t *rx, int line)
  * | \%c     | Current entry number
  * | \%e     | Extra information
  * | \%n     | Destination name
- * | \%t     | '*' if current entry is tagged, a space otherwise
+ * | \%t     | `*` if current entry is tagged, a space otherwise
  */
 static const char *query_format_str(char *buf, size_t buflen, size_t col, int cols,
                                     char op, const char *src, const char *prec,

--- a/recvcmd.c
+++ b/recvcmd.c
@@ -344,7 +344,7 @@ static int is_parent(short i, struct AttachCtx *actx, struct Body *cur)
 {
   short level = actx->idx[i]->level;
 
-  while ((++i < actx->idxlen) && actx->idx[i]->level > level)
+  while ((++i < actx->idxlen) && (actx->idx[i]->level > level))
   {
     if (actx->idx[i]->content == cur)
       return true;

--- a/recvcmd.c
+++ b/recvcmd.c
@@ -242,7 +242,7 @@ void mutt_attach_bounce(struct Mailbox *m, FILE *fp, struct AttachCtx *actx, str
   if (mutt_strwidth(prompt) > MuttMessageWindow->cols - EXTRA_SPACE)
   {
     mutt_simple_format(prompt, sizeof(prompt) - 4, 0, MuttMessageWindow->cols - EXTRA_SPACE,
-                       FMT_LEFT, 0, prompt, sizeof(prompt), 0);
+                       FMT_LEFT, 0, prompt, sizeof(prompt), false);
     mutt_str_strcat(prompt, sizeof(prompt), "...?");
   }
   else

--- a/recvcmd.c
+++ b/recvcmd.c
@@ -242,7 +242,7 @@ void mutt_attach_bounce(struct Mailbox *m, FILE *fp, struct AttachCtx *actx, str
   if (mutt_strwidth(prompt) > MuttMessageWindow->cols - EXTRA_SPACE)
   {
     mutt_simple_format(prompt, sizeof(prompt) - 4, 0, MuttMessageWindow->cols - EXTRA_SPACE,
-                       FMT_LEFT, 0, prompt, sizeof(prompt), false);
+                       JUSTIFY_LEFT, 0, prompt, sizeof(prompt), false);
     mutt_str_strcat(prompt, sizeof(prompt), "...?");
   }
   else

--- a/rfc1524.c
+++ b/rfc1524.c
@@ -82,7 +82,7 @@ int rfc1524_expand_command(struct Body *a, const char *filename,
   if (C_MailcapSanitize)
     mutt_file_sanitize_filename(type2, false);
 
-  while (x < clen - 1 && command[x] && y < sizeof(buf) - 1)
+  while ((x < clen - 1) && command[x] && (y < sizeof(buf) - 1))
   {
     if (command[x] == '\\')
     {
@@ -100,7 +100,7 @@ int rfc1524_expand_command(struct Body *a, const char *filename,
         int z = 0;
 
         x++;
-        while (command[x] && command[x] != '}' && z < sizeof(param) - 1)
+        while (command[x] && (command[x] != '}') && (z < sizeof(param) - 1))
           param[z++] = command[x++];
         param[z] = '\0';
 
@@ -457,7 +457,7 @@ bool rfc1524_mailcap_lookup(struct Body *a, char *type,
   while (!found && *curr)
   {
     int x = 0;
-    while (*curr && *curr != ':' && x < sizeof(path) - 1)
+    while (*curr && (*curr != ':') && (x < sizeof(path) - 1))
     {
       path[x++] = *curr;
       curr++;

--- a/rfc3676.c
+++ b/rfc3676.c
@@ -69,7 +69,7 @@ static int get_quote_level(const char *line)
   int quoted = 0;
   char *p = (char *) line;
 
-  while (p && *p == '>')
+  while (p && (*p == '>'))
   {
     quoted++;
     p++;

--- a/sendlib.c
+++ b/sendlib.c
@@ -1849,7 +1849,7 @@ static int print_val(FILE *fp, const char *pfx, const char *value,
       if ((chflags & CH_DISPLAY) && ((*(value + 1) == ' ') || (*(value + 1) == '\t')))
       {
         value++;
-        while (*value && (*value == ' ' || *value == '\t'))
+        while (*value && ((*value == ' ') || (*value == '\t')))
           value++;
         if (fputc('\t', fp) == EOF)
           return -1;
@@ -1921,7 +1921,7 @@ static int fold_one_header(FILE *fp, const char *tag, const char *value,
     if (display && fold)
     {
       char *pc = buf;
-      while (*pc && (*pc == ' ' || *pc == '\t'))
+      while (*pc && ((*pc == ' ') || (*pc == '\t')))
       {
         pc++;
         col--;
@@ -1943,7 +1943,7 @@ static int fold_one_header(FILE *fp, const char *tag, const char *value,
      * XXX this covers ASCII space only, for display we probably
      * want something like iswspace() here */
     const char *sp = next;
-    while (*sp && (*sp == ' ' || *sp == '\t'))
+    while (*sp && ((*sp == ' ') || (*sp == '\t')))
       sp++;
     if (*sp == '\n')
     {
@@ -2071,7 +2071,7 @@ static int write_one_header(FILE *fp, int pfxw, int max, int wraplen, const char
       /* skip over any leading whitespace (WSP, as defined in RFC5322)
        * NOTE: mutt_str_skip_email_wsp() does the wrong thing here.
        *       See tickets 3609 and 3716. */
-      while (*t == ' ' || *t == '\t')
+      while ((*t == ' ') || (*t == '\t'))
         t++;
 
       valbuf = mutt_str_substr_dup(t, end);

--- a/sidebar.c
+++ b/sidebar.c
@@ -100,16 +100,16 @@ enum DivType
  *
  * | Expando | Description
  * |:--------|:--------------------------------------------------------
+ * | \%!     | 'n!' Flagged messages
  * | \%B     | Name of the mailbox
- * | \%d     | Number of deleted messages
  * | \%D     | Description of the mailbox
+ * | \%d     | Number of deleted messages
  * | \%F     | Number of Flagged messages in the mailbox
  * | \%L     | Number of messages after limiting
  * | \%n     | N if mailbox has new mail, blank otherwise
  * | \%N     | Number of unread messages in the mailbox
  * | \%S     | Size of mailbox (total number of messages)
  * | \%t     | Number of tagged messages
- * | \%!     | 'n!' Flagged messages
  */
 static const char *sidebar_format_str(char *buf, size_t buflen, size_t col, int cols,
                                       char op, const char *src, const char *prec,

--- a/state.c
+++ b/state.c
@@ -108,7 +108,7 @@ int state_putws(const wchar_t *ws, struct State *s)
 {
   const wchar_t *p = ws;
 
-  while (p && *p != L'\0')
+  while (p && (*p != L'\0'))
   {
     if (state_putwc(*p, s) < 0)
       return -1;

--- a/status.c
+++ b/status.c
@@ -65,8 +65,8 @@ static char *get_sort_str(char *buf, size_t buflen, enum SortType method)
  * | Expando | Description
  * |:--------|:--------------------------------------------------------
  * | \%b     | Number of incoming folders with unread messages
- * | \%d     | Number of deleted messages
  * | \%D     | Description of the mailbox
+ * | \%d     | Number of deleted messages
  * | \%f     | Full mailbox path
  * | \%F     | Number of flagged messages
  * | \%h     | Hostname
@@ -80,8 +80,8 @@ static char *get_sort_str(char *buf, size_t buflen, enum SortType method)
  * | \%P     | Percent of way through index
  * | \%R     | Number of read messages
  * | \%r     | Readonly/wontwrite/changed flag
- * | \%S     | Current aux sorting method ($sort_aux)
- * | \%s     | Current sorting method ($sort)
+ * | \%S     | Current aux sorting method (`$sort_aux`)
+ * | \%s     | Current sorting method (`$sort`)
  * | \%t     | # of tagged messages
  * | \%u     | Number of unread messages
  * | \%V     | Currently active limit pattern


### PR DESCRIPTION
- c324f1029 clang-format
- 3ea6c7e42 add parentheses around logic-with-spaces
- a02c29b69 boolify: mutt_simple_format()
- 9a235b38d rename locals to avoid clash
- c171977b3 add: enum FormatJustify
- 62000498c doxy: tidying