### PR TITLE
curses: clear screen on exit

### DIFF
--- a/main.c
+++ b/main.c
@@ -200,6 +200,8 @@ static void reset_tilde(struct ConfigSet *cs)
  */
 void mutt_exit(int code)
 {
+  clear();
+  refresh();
   mutt_endwin();
   exit(code);
 }
@@ -1233,6 +1235,8 @@ int main(int argc, char *argv[], char *envp[])
 main_ok:
   rc = 0;
 main_curses:
+  clear();
+  refresh();
   mutt_endwin();
   log_queue_flush(log_disp_terminal);
   mutt_unlink_temp_attachments();


### PR DESCRIPTION
On IRC, compi123 reported problems, on FreeBSD 11.2, with text being left behind on the 'alternate' screen after NeoMutt closes.

This PR forcibly clears the screen on exit.
