### PR TITLE
Tidying: non-functional code improvements

### DIFF
--- a/browser.c
+++ b/browser.c
@@ -580,9 +580,11 @@ static const char *folder_format_str(char *buf, size_t buflen, size_t col, int c
   }
 
   if (optional)
-    mutt_expando_format(buf, buflen, col, cols, if_str, folder_format_str, data, 0);
+    mutt_expando_format(buf, buflen, col, cols, if_str, folder_format_str, data,
+                        MUTT_FORMAT_NO_FLAGS);
   else if (flags & MUTT_FORMAT_OPTIONAL)
-    mutt_expando_format(buf, buflen, col, cols, else_str, folder_format_str, data, 0);
+    mutt_expando_format(buf, buflen, col, cols, else_str, folder_format_str,
+                        data, MUTT_FORMAT_NO_FLAGS);
 
   return src;
 }

--- a/color.c
+++ b/color.c
@@ -575,7 +575,7 @@ static void do_uncolor(struct Buffer *buf, struct Buffer *s,
   struct ColorLine *np = NULL, *tmp = NULL;
   do
   {
-    mutt_extract_token(buf, s, 0);
+    mutt_extract_token(buf, s, MUTT_TOKEN_NO_FLAGS);
     if (mutt_str_strcmp("*", buf->data) == 0)
     {
       np = STAILQ_FIRST(cl);
@@ -636,7 +636,7 @@ static enum CommandResult parse_uncolor(struct Buffer *buf, struct Buffer *s,
   int object = 0;
   bool do_cache = false;
 
-  mutt_extract_token(buf, s, 0);
+  mutt_extract_token(buf, s, MUTT_TOKEN_NO_FLAGS);
 
   object = mutt_map_get_value(buf->data, Fields);
   if (object == -1)
@@ -682,7 +682,7 @@ static enum CommandResult parse_uncolor(struct Buffer *buf, struct Buffer *s,
   {
     /* just eat the command, but don't do anything real about it */
     do
-      mutt_extract_token(buf, s, 0);
+      mutt_extract_token(buf, s, MUTT_TOKEN_NO_FLAGS);
     while (MoreArgs(s));
 
     return MUTT_CMD_SUCCESS;
@@ -870,7 +870,7 @@ static int parse_object(struct Buffer *buf, struct Buffer *s, uint32_t *o,
     return -1;
   }
 
-  mutt_extract_token(buf, s, 0);
+  mutt_extract_token(buf, s, MUTT_TOKEN_NO_FLAGS);
   if (mutt_str_startswith(buf->data, "quoted", CASE_MATCH))
   {
     if (buf->data[6])
@@ -896,7 +896,7 @@ static int parse_object(struct Buffer *buf, struct Buffer *s, uint32_t *o,
       return -1;
     }
 
-    mutt_extract_token(buf, s, 0);
+    mutt_extract_token(buf, s, MUTT_TOKEN_NO_FLAGS);
 
     *o = mutt_map_get_value(buf->data, ComposeFields);
     if (*o == -1)
@@ -944,7 +944,7 @@ static int parse_color_pair(struct Buffer *buf, struct Buffer *s, uint32_t *fg,
       return -1;
     }
 
-    mutt_extract_token(buf, s, 0);
+    mutt_extract_token(buf, s, MUTT_TOKEN_NO_FLAGS);
 
     if (mutt_str_strcasecmp("bold", buf->data) == 0)
       *attr |= A_BOLD;
@@ -972,7 +972,7 @@ static int parse_color_pair(struct Buffer *buf, struct Buffer *s, uint32_t *fg,
     return -1;
   }
 
-  mutt_extract_token(buf, s, 0);
+  mutt_extract_token(buf, s, MUTT_TOKEN_NO_FLAGS);
 
   if (parse_color_name(buf->data, bg, attr, false, err) != 0)
     return -1;
@@ -999,7 +999,7 @@ static int parse_attr_spec(struct Buffer *buf, struct Buffer *s, uint32_t *fg,
     return -1;
   }
 
-  mutt_extract_token(buf, s, 0);
+  mutt_extract_token(buf, s, MUTT_TOKEN_NO_FLAGS);
 
   if (mutt_str_strcasecmp("bold", buf->data) == 0)
     *attr |= A_BOLD;
@@ -1079,7 +1079,7 @@ static enum CommandResult parse_color(struct Buffer *buf, struct Buffer *s,
       return MUTT_CMD_WARNING;
     }
 
-    mutt_extract_token(buf, s, 0);
+    mutt_extract_token(buf, s, MUTT_TOKEN_NO_FLAGS);
   }
 
   if (MoreArgs(s) && (object != MT_COLOR_STATUS))
@@ -1125,12 +1125,12 @@ static enum CommandResult parse_color(struct Buffer *buf, struct Buffer *s,
      * 0 arguments: sets the default status color (handled below by else part)
      * 1 argument : colorize pattern on match
      * 2 arguments: colorize nth submatch of pattern */
-    mutt_extract_token(buf, s, 0);
+    mutt_extract_token(buf, s, MUTT_TOKEN_NO_FLAGS);
 
     if (MoreArgs(s))
     {
       struct Buffer temporary = { 0 };
-      mutt_extract_token(&temporary, s, 0);
+      mutt_extract_token(&temporary, s, MUTT_TOKEN_NO_FLAGS);
       match = atoi(temporary.data);
       FREE(&temporary.data);
     }

--- a/commands.c
+++ b/commands.c
@@ -258,12 +258,12 @@ int mutt_display_message(struct Email *cur)
     hfi.pager_progress = ExtPagerProgress;
     hfi.email = cur;
     mutt_make_string_info(buf, sizeof(buf), MuttIndexWindow->cols,
-                          NONULL(C_PagerFormat), &hfi, 0);
+                          NONULL(C_PagerFormat), &hfi, MUTT_FORMAT_NO_FLAGS);
     fputs(buf, fp_out);
     fputs("\n\n", fp_out);
   }
 
-  chflags = (C_Weed ? (CH_WEED | CH_REORDER) : 0) | CH_DECODE | CH_FROM | CH_DISPLAY;
+  chflags = (C_Weed ? (CH_WEED | CH_REORDER) : CH_NO_FLAGS) | CH_DECODE | CH_FROM | CH_DISPLAY;
 #ifdef USE_NOTMUCH
   if (Context->mailbox->magic == MUTT_NOTMUCH)
     chflags |= CH_VIRTUAL;

--- a/compose.c
+++ b/compose.c
@@ -866,7 +866,7 @@ static void compose_status_line(char *buf, size_t buflen, size_t col, int cols,
                                 struct Menu *menu, const char *src)
 {
   mutt_expando_format(buf, buflen, col, cols, src, compose_format_str,
-                      (unsigned long) menu, 0);
+                      (unsigned long) menu, MUTT_FORMAT_NO_FLAGS);
 }
 
 /**

--- a/compress.c
+++ b/compress.c
@@ -308,7 +308,7 @@ static void expand_command_str(const struct Mailbox *m, const char *cmd, char *b
     return;
 
   mutt_expando_format(buf, buflen, 0, buflen, cmd, compress_format_str,
-                      (unsigned long) m, 0);
+                      (unsigned long) m, MUTT_FORMAT_NO_FLAGS);
 }
 
 /**

--- a/config/set.c
+++ b/config/set.c
@@ -162,7 +162,7 @@ void cs_init(struct ConfigSet *cs, size_t size)
     return; /* LCOV_EXCL_LINE */
 
   memset(cs, 0, sizeof(*cs));
-  cs->hash = mutt_hash_new(size, 0);
+  cs->hash = mutt_hash_new(size, MUTT_HASH_NO_FLAGS);
   mutt_hash_set_destructor(cs->hash, destroy, (intptr_t) cs);
 }
 

--- a/conn/tunnel.c
+++ b/conn/tunnel.c
@@ -87,9 +87,9 @@ static int tunnel_socket_open(struct Connection *conn)
   if (pid == 0)
   {
     mutt_sig_unblock_system(false);
-    const int devnull = open("/dev/null", O_RDWR);
-    if ((devnull < 0) || (dup2(pout[0], STDIN_FILENO) < 0) ||
-        (dup2(pin[1], STDOUT_FILENO) < 0) || (dup2(devnull, STDERR_FILENO) < 0))
+    const int fd_null = open("/dev/null", O_RDWR);
+    if ((fd_null < 0) || (dup2(pout[0], STDIN_FILENO) < 0) ||
+        (dup2(pin[1], STDOUT_FILENO) < 0) || (dup2(fd_null, STDERR_FILENO) < 0))
     {
       _exit(127);
     }
@@ -97,7 +97,7 @@ static int tunnel_socket_open(struct Connection *conn)
     close(pin[1]);
     close(pout[0]);
     close(pout[1]);
-    close(devnull);
+    close(fd_null);
 
     /* Don't let the subprocess think it can use the controlling tty */
     setsid();

--- a/copy.c
+++ b/copy.c
@@ -837,7 +837,7 @@ static int append_message(struct Mailbox *dest, FILE *fp_in, struct Mailbox *src
   if (!fgets(buf, sizeof(buf), fp_in))
     return -1;
 
-  msg = mx_msg_open_new(dest, e, is_from(buf, NULL, 0, NULL) ? 0 : MUTT_ADD_FROM);
+  msg = mx_msg_open_new(dest, e, is_from(buf, NULL, 0, NULL) ? MUTT_MSG_NO_FLAGS : MUTT_ADD_FROM);
   if (!msg)
     return -1;
   if ((dest->magic == MUTT_MBOX) || (dest->magic == MUTT_MMDF))

--- a/copy.h
+++ b/copy.h
@@ -67,7 +67,7 @@ typedef uint32_t CopyHeaderFlags;   ///< Flags for mutt_copy_header(), e.g. #CH_
 #define CH_UPDATE_IRT     (1 << 16) ///< Update In-Reply-To:
 #define CH_UPDATE_REFS    (1 << 17) ///< Update References:
 #define CH_DISPLAY        (1 << 18) ///< Display result to user
-#define CH_UPDATE_LABEL   (1 << 19) ///< Update X-Label: from hdr->env->x_label?
+#define CH_UPDATE_LABEL   (1 << 19) ///< Update X-Label: from email->env->x_label?
 #define CH_UPDATE_SUBJECT (1 << 20) ///< Update Subject: protected header update
 #define CH_VIRTUAL        (1 << 21) ///< Write virtual header lines too
 

--- a/curs_lib.c
+++ b/curs_lib.c
@@ -531,27 +531,26 @@ int mutt_any_key_to_continue(const char *s)
 {
   struct termios t;
   struct termios old;
-  int f, ch;
 
-  f = open("/dev/tty", O_RDONLY);
-  if (f < 0)
+  int fd = open("/dev/tty", O_RDONLY);
+  if (fd < 0)
     return EOF;
-  tcgetattr(f, &t);
+  tcgetattr(fd, &t);
   memcpy((void *) &old, (void *) &t, sizeof(struct termios)); /* save original state */
   t.c_lflag &= ~(ICANON | ECHO);
   t.c_cc[VMIN] = 1;
   t.c_cc[VTIME] = 0;
-  tcsetattr(f, TCSADRAIN, &t);
+  tcsetattr(fd, TCSADRAIN, &t);
   fflush(stdout);
   if (s)
     fputs(s, stdout);
   else
     fputs(_("Press any key to continue..."), stdout);
   fflush(stdout);
-  ch = fgetc(stdin);
+  int ch = fgetc(stdin);
   fflush(stdin);
-  tcsetattr(f, TCSADRAIN, &old);
-  close(f);
+  tcsetattr(fd, TCSADRAIN, &old);
+  close(fd);
   fputs("\r\n", stdout);
   mutt_clear_error();
   return (ch >= 0) ? ch : EOF;

--- a/edit.c
+++ b/edit.c
@@ -318,7 +318,7 @@ static void be_edit_header(struct Envelope *e, bool force)
   mutt_addr_write(tmp, sizeof(tmp), e->to, false);
   if (!e->to || force)
   {
-    if (mutt_enter_string(tmp, sizeof(tmp), 4, 0) == 0)
+    if (mutt_enter_string(tmp, sizeof(tmp), 4, MUTT_COMP_NO_FLAGS) == 0)
     {
       mutt_addr_free(&e->to);
       e->to = mutt_addr_parse_list2(e->to, tmp);
@@ -340,7 +340,7 @@ static void be_edit_header(struct Envelope *e, bool force)
   {
     addstr("Subject: ");
     mutt_str_strfcpy(tmp, e->subject ? e->subject : "", sizeof(tmp));
-    if (mutt_enter_string(tmp, sizeof(tmp), 9, 0) == 0)
+    if (mutt_enter_string(tmp, sizeof(tmp), 9, MUTT_COMP_NO_FLAGS) == 0)
       mutt_str_replace(&e->subject, tmp);
     addch('\n');
   }
@@ -351,7 +351,7 @@ static void be_edit_header(struct Envelope *e, bool force)
     tmp[0] = '\0';
     mutt_addrlist_to_local(e->cc);
     mutt_addr_write(tmp, sizeof(tmp), e->cc, false);
-    if (mutt_enter_string(tmp, sizeof(tmp), 4, 0) == 0)
+    if (mutt_enter_string(tmp, sizeof(tmp), 4, MUTT_COMP_NO_FLAGS) == 0)
     {
       mutt_addr_free(&e->cc);
       e->cc = mutt_addr_parse_list2(e->cc, tmp);
@@ -372,7 +372,7 @@ static void be_edit_header(struct Envelope *e, bool force)
     tmp[0] = '\0';
     mutt_addrlist_to_local(e->bcc);
     mutt_addr_write(tmp, sizeof(tmp), e->bcc, false);
-    if (mutt_enter_string(tmp, sizeof(tmp), 5, 0) == 0)
+    if (mutt_enter_string(tmp, sizeof(tmp), 5, MUTT_COMP_NO_FLAGS) == 0)
     {
       mutt_addr_free(&e->bcc);
       e->bcc = mutt_addr_parse_list2(e->bcc, tmp);
@@ -416,7 +416,7 @@ int mutt_builtin_editor(const char *path, struct Email *msg, struct Email *cur)
   tmp[0] = '\0';
   while (!done)
   {
-    if (mutt_enter_string(tmp, sizeof(tmp), 0, 0) == -1)
+    if (mutt_enter_string(tmp, sizeof(tmp), 0, MUTT_COMP_NO_FLAGS) == -1)
     {
       tmp[0] = '\0';
       continue;

--- a/editmsg.c
+++ b/editmsg.c
@@ -82,8 +82,8 @@ static int ev_message(enum EvMessage action, struct Mailbox *m, struct Email *e)
   }
 
   const CopyHeaderFlags chflags =
-      CH_NOLEN | (((m->magic == MUTT_MBOX) || (m->magic == MUTT_MMDF)) ? 0 : CH_NOSTATUS);
-  rc = mutt_append_message(ctx_tmp->mailbox, m, e, 0, chflags);
+      CH_NOLEN | (((m->magic == MUTT_MBOX) || (m->magic == MUTT_MMDF)) ? CH_NO_FLAGS : CH_NOSTATUS);
+  rc = mutt_append_message(ctx_tmp->mailbox, m, e, MUTT_CM_NO_FLAGS, chflags);
   int oerrno = errno;
 
   mx_mbox_close(&ctx_tmp);

--- a/email/body.c
+++ b/email/body.c
@@ -86,7 +86,7 @@ void mutt_body_free(struct Body **p)
 
     if (b->email)
     {
-      /* Don't free twice (b->hdr->content = b->parts) */
+      /* Don't free twice (b->email->content = b->parts) */
       b->email->content = NULL;
       mutt_email_free(&b->email);
     }

--- a/email/group.c
+++ b/email/group.c
@@ -42,7 +42,7 @@ static struct Hash *Groups = NULL;
  */
 void mutt_grouplist_init(void)
 {
-  Groups = mutt_hash_new(1031, 0);
+  Groups = mutt_hash_new(1031, MUTT_HASH_NO_FLAGS);
 }
 
 /**

--- a/enter.c
+++ b/enter.c
@@ -646,8 +646,8 @@ int mutt_enter_string_full(char *buf, size_t buflen, int col,
                  (memcmp(tempbuf, state->wbuf, state->lastchar * sizeof(wchar_t)) == 0)))
             {
               mutt_select_file(buf, buflen,
-                               ((flags & MUTT_EFILE) ? MUTT_SEL_FOLDER : 0) |
-                                   (multiple ? MUTT_SEL_MULTI : 0),
+                               ((flags & MUTT_EFILE) ? MUTT_SEL_FOLDER : MUTT_SEL_NO_FLAGS) |
+                                   (multiple ? MUTT_SEL_MULTI : MUTT_SEL_NO_FLAGS),
                                files, numfiles);
               if (buf[0] != '\0')
               {

--- a/handler.c
+++ b/handler.c
@@ -717,9 +717,9 @@ static int message_handler(struct Body *a, struct State *s)
                   (((s->flags & MUTT_WEED) ||
                     ((s->flags & (MUTT_DISPLAY | MUTT_PRINTING)) && C_Weed)) ?
                        (CH_WEED | CH_REORDER) :
-                       0) |
-                      (s->prefix ? CH_PREFIX : 0) | CH_DECODE | CH_FROM |
-                      ((s->flags & MUTT_DISPLAY) ? CH_DISPLAY : 0),
+                       CH_NO_FLAGS) |
+                      (s->prefix ? CH_PREFIX : CH_NO_FLAGS) | CH_DECODE | CH_FROM |
+                      ((s->flags & MUTT_DISPLAY) ? CH_DISPLAY : CH_NO_FLAGS),
                   s->prefix);
 
     if (s->prefix)
@@ -859,7 +859,7 @@ static int external_body_handler(struct Body *b, struct State *s)
       }
 
       mutt_copy_hdr(s->fp_in, s->fp_out, ftello(s->fp_in), b->parts->offset,
-                    (C_Weed ? (CH_WEED | CH_REORDER) : 0) | CH_DECODE, NULL);
+                    (C_Weed ? (CH_WEED | CH_REORDER) : CH_NO_FLAGS) | CH_DECODE, NULL);
     }
   }
   else if (expiration && (expire < time(NULL)))
@@ -874,7 +874,7 @@ static int external_body_handler(struct Body *b, struct State *s)
       state_attach_puts(strbuf, s);
 
       mutt_copy_hdr(s->fp_in, s->fp_out, ftello(s->fp_in), b->parts->offset,
-                    (C_Weed ? (CH_WEED | CH_REORDER) : 0) | CH_DECODE | CH_DISPLAY, NULL);
+                    (C_Weed ? (CH_WEED | CH_REORDER) : CH_NO_FLAGS) | CH_DECODE | CH_DISPLAY, NULL);
     }
   }
   else
@@ -891,7 +891,7 @@ static int external_body_handler(struct Body *b, struct State *s)
       state_attach_puts(strbuf, s);
 
       mutt_copy_hdr(s->fp_in, s->fp_out, ftello(s->fp_in), b->parts->offset,
-                    (C_Weed ? (CH_WEED | CH_REORDER) : 0) | CH_DECODE | CH_DISPLAY, NULL);
+                    (C_Weed ? (CH_WEED | CH_REORDER) : CH_NO_FLAGS) | CH_DECODE | CH_DISPLAY, NULL);
     }
   }
 

--- a/hdrline.c
+++ b/hdrline.c
@@ -353,32 +353,32 @@ static void make_from(struct Envelope *env, char *buf, size_t buflen,
 
 /**
  * make_from_addr - Create a 'from' address for a reply email
- * @param hdr      Envelope of current email
+ * @param env      Envelope of current email
  * @param buf      Buffer for the result
  * @param buflen   Length of buffer
  * @param do_lists If true, check for mailing lists
  */
-static void make_from_addr(struct Envelope *hdr, char *buf, size_t buflen, bool do_lists)
+static void make_from_addr(struct Envelope *env, char *buf, size_t buflen, bool do_lists)
 {
-  if (!hdr || !buf)
+  if (!env || !buf)
     return;
 
-  bool me = mutt_addr_is_user(hdr->from);
+  bool me = mutt_addr_is_user(env->from);
 
   if (do_lists || me)
   {
-    if (check_for_mailing_list_addr(hdr->to, buf, buflen))
+    if (check_for_mailing_list_addr(env->to, buf, buflen))
       return;
-    if (check_for_mailing_list_addr(hdr->cc, buf, buflen))
+    if (check_for_mailing_list_addr(env->cc, buf, buflen))
       return;
   }
 
-  if (me && hdr->to)
-    snprintf(buf, buflen, "%s", hdr->to->mailbox);
-  else if (me && hdr->cc)
-    snprintf(buf, buflen, "%s", hdr->cc->mailbox);
-  else if (hdr->from)
-    mutt_str_strfcpy(buf, hdr->from->mailbox, buflen);
+  if (me && env->to)
+    snprintf(buf, buflen, "%s", env->to->mailbox);
+  else if (me && env->cc)
+    snprintf(buf, buflen, "%s", env->cc->mailbox);
+  else if (env->from)
+    mutt_str_strfcpy(buf, env->from->mailbox, buflen);
   else
     *buf = '\0';
 }

--- a/hook.c
+++ b/hook.c
@@ -101,7 +101,7 @@ enum CommandResult mutt_parse_hook(struct Buffer *buf, struct Buffer *s,
       not = true;
     }
 
-    mutt_extract_token(&pattern, s, 0);
+    mutt_extract_token(&pattern, s, MUTT_TOKEN_NO_FLAGS);
 
     if (!MoreArgs(s))
     {
@@ -329,7 +329,7 @@ enum CommandResult mutt_parse_unhook(struct Buffer *buf, struct Buffer *s,
 {
   while (MoreArgs(s))
   {
-    mutt_extract_token(buf, s, 0);
+    mutt_extract_token(buf, s, MUTT_TOKEN_NO_FLAGS);
     if (mutt_str_strcmp("*", buf->data) == 0)
     {
       if (current_hook_type)

--- a/hook.c
+++ b/hook.c
@@ -337,7 +337,7 @@ enum CommandResult mutt_parse_unhook(struct Buffer *buf, struct Buffer *s,
         mutt_buffer_printf(err, "%s", _("unhook: Can't do unhook * from within a hook"));
         return MUTT_CMD_WARNING;
       }
-      mutt_delete_hooks(0);
+      mutt_delete_hooks(MUTT_HOOK_NO_FLAGS);
       mutt_ch_lookup_remove();
     }
     else

--- a/icommands.c
+++ b/icommands.c
@@ -285,7 +285,7 @@ static enum CommandResult icmd_bind(struct Buffer *buf, struct Buffer *s,
   mutt_buffer_free(&filebuf);
 
   struct Pager info = { 0 };
-  if (mutt_pager((bind) ? "bind" : "macro", tempfile, 0, &info) == -1)
+  if (mutt_pager((bind) ? "bind" : "macro", tempfile, MUTT_PAGER_NO_FLAGS, &info) == -1)
   {
     mutt_buffer_printf(err, _("Could not create temporary file %s"), tempfile);
     return MUTT_CMD_ERROR;
@@ -312,7 +312,7 @@ static enum CommandResult icmd_set(struct Buffer *buf, struct Buffer *s,
 
   if (mutt_str_strcmp(s->data, "set all") == 0)
   {
-    dump_config(Config, CS_DUMP_STYLE_NEO, 0, fp_out);
+    dump_config(Config, CS_DUMP_STYLE_NEO, CS_DUMP_NO_FLAGS, fp_out);
   }
   else if (mutt_str_strcmp(s->data, "set") == 0)
   {
@@ -327,7 +327,7 @@ static enum CommandResult icmd_set(struct Buffer *buf, struct Buffer *s,
   mutt_file_fclose(&fp_out);
 
   struct Pager info = { 0 };
-  if (mutt_pager("set", tempfile, 0, &info) == -1)
+  if (mutt_pager("set", tempfile, MUTT_PAGER_NO_FLAGS, &info) == -1)
   {
     mutt_buffer_addstr(err, _("Could not create temporary file"));
     return MUTT_CMD_ERROR;
@@ -356,7 +356,7 @@ static enum CommandResult icmd_version(struct Buffer *buf, struct Buffer *s,
   mutt_file_fclose(&fp_out);
 
   struct Pager info = { 0 };
-  if (mutt_pager("version", tempfile, 0, &info) == -1)
+  if (mutt_pager("version", tempfile, MUTT_PAGER_NO_FLAGS, &info) == -1)
   {
     mutt_buffer_addstr(err, _("Could not create temporary file"));
     return MUTT_CMD_ERROR;

--- a/icommands.c
+++ b/icommands.c
@@ -84,7 +84,7 @@ enum CommandResult mutt_parse_icommand(/* const */ char *line, struct Buffer *er
   SKIPWS(expn.dptr);
   while (*expn.dptr)
   {
-    mutt_extract_token(&token, &expn, 0);
+    mutt_extract_token(&token, &expn, MUTT_TOKEN_NO_FLAGS);
     for (size_t i = 0; ICommandList[i].name; i++)
     {
       if (mutt_str_strcmp(token.data, ICommandList[i].name) != 0)
@@ -235,7 +235,7 @@ static enum CommandResult icmd_bind(struct Buffer *buf, struct Buffer *s,
   if (!MoreArgs(s))
     dump_all = true;
   else
-    mutt_extract_token(buf, s, 0);
+    mutt_extract_token(buf, s, MUTT_TOKEN_NO_FLAGS);
 
   if (MoreArgs(s))
   {

--- a/imap/auth_oauth.c
+++ b/imap/auth_oauth.c
@@ -84,7 +84,7 @@ enum ImapAuthRes imap_auth_oauth(struct ImapAccountData *adata, const char *meth
     /* The error response was in SASL continuation, so continue the SASL
      * to cause a failure and exit SASL input.  See RFC 7628 3.2.3 */
     mutt_socket_send(adata->conn, "\001");
-    rc = imap_exec(adata, ibuf, 0);
+    rc = imap_exec(adata, ibuf, IMAP_CMD_NO_FLAGS);
   }
 
   if (rc != IMAP_EXEC_SUCCESS)

--- a/imap/command.c
+++ b/imap/command.c
@@ -1037,7 +1037,7 @@ static int cmd_handle_untagged(struct ImapAccountData *adata)
  */
 int imap_cmd_start(struct ImapAccountData *adata, const char *cmdstr)
 {
-  return cmd_start(adata, cmdstr, 0);
+  return cmd_start(adata, cmdstr, IMAP_CMD_NO_FLAGS);
 }
 
 /**

--- a/imap/message.c
+++ b/imap/message.c
@@ -577,7 +577,7 @@ static void imap_alloc_uid_hash(struct ImapAccountData *adata, unsigned int msn_
 {
   struct ImapMboxData *mdata = adata->mailbox->mdata;
   if (!mdata->uid_hash)
-    mdata->uid_hash = mutt_hash_int_new(MAX(6 * msn_count / 5, 30), 0);
+    mdata->uid_hash = mutt_hash_int_new(MAX(6 * msn_count / 5, 30), MUTT_HASH_NO_FLAGS);
 }
 
 /**
@@ -1646,7 +1646,7 @@ int imap_copy_messages(struct Mailbox *m, struct EmailList *el, char *dest, bool
     }
 
     /* let's get it on */
-    rc = imap_exec(adata, NULL, 0);
+    rc = imap_exec(adata, NULL, IMAP_CMD_NO_FLAGS);
     if (rc == IMAP_EXEC_ERROR)
     {
       if (triedcreate)

--- a/index.c
+++ b/index.c
@@ -3203,7 +3203,7 @@ int mutt_index_menu(void)
       case OP_MAIL:
         if (!prereq(Context, menu, CHECK_ATTACH))
           break;
-        ci_send_message(0, NULL, NULL, Context, NULL);
+        ci_send_message(SEND_NO_FLAGS, NULL, NULL, Context, NULL);
         menu->redraw = REDRAW_FULL;
         break;
 

--- a/init.c
+++ b/init.c
@@ -473,7 +473,7 @@ static enum CommandResult parse_attach_list(struct Buffer *buf, struct Buffer *s
 
   do
   {
-    mutt_extract_token(buf, s, 0);
+    mutt_extract_token(buf, s, MUTT_TOKEN_NO_FLAGS);
 
     if (!buf->data || (*buf->data == '\0'))
       continue;
@@ -550,7 +550,7 @@ static int parse_grouplist(struct GroupList *ctx, struct Buffer *buf,
       goto bail;
     }
 
-    mutt_extract_token(buf, s, 0);
+    mutt_extract_token(buf, s, MUTT_TOKEN_NO_FLAGS);
 
     mutt_grouplist_add(ctx, mutt_pattern_group(buf->data));
 
@@ -560,7 +560,7 @@ static int parse_grouplist(struct GroupList *ctx, struct Buffer *buf,
       goto bail;
     }
 
-    mutt_extract_token(buf, s, 0);
+    mutt_extract_token(buf, s, MUTT_TOKEN_NO_FLAGS);
   }
 
   return 0;
@@ -584,7 +584,7 @@ static enum CommandResult parse_replace_list(struct Buffer *buf, struct Buffer *
     mutt_buffer_printf(err, _("%s: too few arguments"), "subjectrx");
     return MUTT_CMD_WARNING;
   }
-  mutt_extract_token(buf, s, 0);
+  mutt_extract_token(buf, s, MUTT_TOKEN_NO_FLAGS);
 
   /* Second token is a replacement template */
   if (!MoreArgs(s))
@@ -592,7 +592,7 @@ static enum CommandResult parse_replace_list(struct Buffer *buf, struct Buffer *
     mutt_buffer_printf(err, _("%s: too few arguments"), "subjectrx");
     return MUTT_CMD_WARNING;
   }
-  mutt_extract_token(&templ, s, 0);
+  mutt_extract_token(&templ, s, MUTT_TOKEN_NO_FLAGS);
 
   if (mutt_replacelist_add(list, buf->data, templ.data, err) != 0)
   {
@@ -621,7 +621,7 @@ static enum CommandResult parse_unattach_list(struct Buffer *buf, struct Buffer 
 
   do
   {
-    mutt_extract_token(buf, s, 0);
+    mutt_extract_token(buf, s, MUTT_TOKEN_NO_FLAGS);
     FREE(&tmp);
 
     if (mutt_str_strcasecmp(buf->data, "any") == 0)
@@ -682,7 +682,7 @@ static enum CommandResult parse_unreplace_list(struct Buffer *buf, struct Buffer
     return MUTT_CMD_WARNING;
   }
 
-  mutt_extract_token(buf, s, 0);
+  mutt_extract_token(buf, s, MUTT_TOKEN_NO_FLAGS);
 
   /* "*" is a special case. */
   if (mutt_str_strcmp(buf->data, "*") == 0)
@@ -900,7 +900,7 @@ static enum CommandResult parse_alias(struct Buffer *buf, struct Buffer *s,
     return MUTT_CMD_WARNING;
   }
 
-  mutt_extract_token(buf, s, 0);
+  mutt_extract_token(buf, s, MUTT_TOKEN_NO_FLAGS);
 
   if (parse_grouplist(&gc, buf, s, data, err) == -1)
     return MUTT_CMD_ERROR;
@@ -977,7 +977,7 @@ static enum CommandResult parse_alternates(struct Buffer *buf, struct Buffer *s,
 
   do
   {
-    mutt_extract_token(buf, s, 0);
+    mutt_extract_token(buf, s, MUTT_TOKEN_NO_FLAGS);
 
     if (parse_grouplist(&gc, buf, s, data, err) == -1)
       goto bail;
@@ -1008,7 +1008,7 @@ static enum CommandResult parse_attachments(struct Buffer *buf, struct Buffer *s
   char op, *category = NULL;
   struct ListHead *head = NULL;
 
-  mutt_extract_token(buf, s, 0);
+  mutt_extract_token(buf, s, MUTT_TOKEN_NO_FLAGS);
   if (!buf->data || (*buf->data == '\0'))
   {
     mutt_buffer_strcpy(err, _("attachments: no disposition"));
@@ -1070,7 +1070,7 @@ static enum CommandResult parse_echo(struct Buffer *buf, struct Buffer *s,
     mutt_buffer_printf(err, _("%s: too few arguments"), "echo");
     return MUTT_CMD_WARNING;
   }
-  mutt_extract_token(buf, s, 0);
+  mutt_extract_token(buf, s, MUTT_TOKEN_NO_FLAGS);
   OptForceRefresh = true;
   mutt_message("%s", buf->data);
   OptForceRefresh = false;
@@ -1110,7 +1110,7 @@ static enum CommandResult parse_group(struct Buffer *buf, struct Buffer *s,
 
   do
   {
-    mutt_extract_token(buf, s, 0);
+    mutt_extract_token(buf, s, MUTT_TOKEN_NO_FLAGS);
     if (parse_grouplist(&gc, buf, s, data, err) == -1)
       goto bail;
 
@@ -1223,7 +1223,7 @@ static enum CommandResult parse_ifdef(struct Buffer *buf, struct Buffer *s,
 {
   struct Buffer token = { 0 };
 
-  mutt_extract_token(buf, s, 0);
+  mutt_extract_token(buf, s, MUTT_TOKEN_NO_FLAGS);
 
   // is the item defined as:
   bool res = cs_get_elem(Config, buf->data) // a variable?
@@ -1264,7 +1264,7 @@ static enum CommandResult parse_ignore(struct Buffer *buf, struct Buffer *s,
 {
   do
   {
-    mutt_extract_token(buf, s, 0);
+    mutt_extract_token(buf, s, MUTT_TOKEN_NO_FLAGS);
     remove_from_stailq(&UnIgnore, buf->data);
     add_to_stailq(&Ignore, buf->data);
   } while (MoreArgs(s));
@@ -1282,7 +1282,7 @@ static enum CommandResult parse_lists(struct Buffer *buf, struct Buffer *s,
 
   do
   {
-    mutt_extract_token(buf, s, 0);
+    mutt_extract_token(buf, s, MUTT_TOKEN_NO_FLAGS);
 
     if (parse_grouplist(&gc, buf, s, data, err) == -1)
       goto bail;
@@ -1318,7 +1318,7 @@ static enum CommandResult parse_mailboxes(struct Buffer *buf, struct Buffer *s,
 
     if (data & MUTT_NAMED)
     {
-      mutt_extract_token(buf, s, 0);
+      mutt_extract_token(buf, s, MUTT_TOKEN_NO_FLAGS);
       if (buf->data && (*buf->data != '\0'))
       {
         m->desc = mutt_str_strdup(buf->data);
@@ -1330,7 +1330,7 @@ static enum CommandResult parse_mailboxes(struct Buffer *buf, struct Buffer *s,
       }
     }
 
-    mutt_extract_token(buf, s, 0);
+    mutt_extract_token(buf, s, MUTT_TOKEN_NO_FLAGS);
     if (mutt_buffer_is_empty(buf))
     {
       /* Skip empty tokens. */
@@ -1445,7 +1445,7 @@ static enum CommandResult parse_path_list(struct Buffer *buf, struct Buffer *s,
 
   do
   {
-    mutt_extract_token(buf, s, 0);
+    mutt_extract_token(buf, s, MUTT_TOKEN_NO_FLAGS);
     mutt_str_strfcpy(path, buf->data, sizeof(path));
     mutt_expand_path(path, sizeof(path));
     add_to_stailq((struct ListHead *) data, path);
@@ -1466,7 +1466,7 @@ static enum CommandResult parse_path_unlist(struct Buffer *buf, struct Buffer *s
 
   do
   {
-    mutt_extract_token(buf, s, 0);
+    mutt_extract_token(buf, s, MUTT_TOKEN_NO_FLAGS);
     /* Check for deletion of entire list */
     if (mutt_str_strcmp(buf->data, "*") == 0)
     {
@@ -1890,7 +1890,7 @@ static enum CommandResult parse_setenv(struct Buffer *buf, struct Buffer *s,
   }
 
   char *name = mutt_str_strdup(buf->data);
-  mutt_extract_token(buf, s, 0);
+  mutt_extract_token(buf, s, MUTT_TOKEN_NO_FLAGS);
   mutt_envlist_set(name, buf->data, true);
   FREE(&name);
 
@@ -1907,7 +1907,7 @@ static enum CommandResult parse_source(struct Buffer *buf, struct Buffer *s,
 
   do
   {
-    if (mutt_extract_token(buf, s, 0) != 0)
+    if (mutt_extract_token(buf, s, MUTT_TOKEN_NO_FLAGS) != 0)
     {
       mutt_buffer_printf(err, _("source: error at %s"), s->dptr);
       return MUTT_CMD_ERROR;
@@ -1947,7 +1947,7 @@ static enum CommandResult parse_spam_list(struct Buffer *buf, struct Buffer *s,
   }
 
   /* Extract the first token, a regex */
-  mutt_extract_token(buf, s, 0);
+  mutt_extract_token(buf, s, MUTT_TOKEN_NO_FLAGS);
 
   /* data should be either MUTT_SPAM or MUTT_NOSPAM. MUTT_SPAM is for spam commands. */
   if (data == MUTT_SPAM)
@@ -1955,7 +1955,7 @@ static enum CommandResult parse_spam_list(struct Buffer *buf, struct Buffer *s,
     /* If there's a second parameter, it's a template for the spam tag. */
     if (MoreArgs(s))
     {
-      mutt_extract_token(&templ, s, 0);
+      mutt_extract_token(&templ, s, MUTT_TOKEN_NO_FLAGS);
 
       /* Add to the spam list. */
       if (mutt_replacelist_add(&SpamList, buf->data, templ.data, err) != 0)
@@ -2012,7 +2012,7 @@ static enum CommandResult parse_stailq(struct Buffer *buf, struct Buffer *s,
 {
   do
   {
-    mutt_extract_token(buf, s, 0);
+    mutt_extract_token(buf, s, MUTT_TOKEN_NO_FLAGS);
     add_to_stailq((struct ListHead *) data, buf->data);
   } while (MoreArgs(s));
 
@@ -2043,7 +2043,7 @@ static enum CommandResult parse_subscribe(struct Buffer *buf, struct Buffer *s,
 
   do
   {
-    mutt_extract_token(buf, s, 0);
+    mutt_extract_token(buf, s, MUTT_TOKEN_NO_FLAGS);
 
     if (parse_grouplist(&gc, buf, s, data, err) == -1)
       goto bail;
@@ -2085,7 +2085,7 @@ static enum CommandResult parse_subscribe_to(struct Buffer *buf, struct Buffer *
 
   if (MoreArgs(s))
   {
-    mutt_extract_token(buf, s, 0);
+    mutt_extract_token(buf, s, MUTT_TOKEN_NO_FLAGS);
 
     if (MoreArgs(s))
     {
@@ -2134,13 +2134,13 @@ static enum CommandResult parse_tag_formats(struct Buffer *buf, struct Buffer *s
   {
     char *tag = NULL, *format = NULL;
 
-    mutt_extract_token(buf, s, 0);
+    mutt_extract_token(buf, s, MUTT_TOKEN_NO_FLAGS);
     if (buf->data && (*buf->data != '\0'))
       tag = mutt_str_strdup(buf->data);
     else
       continue;
 
-    mutt_extract_token(buf, s, 0);
+    mutt_extract_token(buf, s, MUTT_TOKEN_NO_FLAGS);
     format = mutt_str_strdup(buf->data);
 
     /* avoid duplicates */
@@ -2173,13 +2173,13 @@ static enum CommandResult parse_tag_transforms(struct Buffer *buf, struct Buffer
   {
     char *tag = NULL, *transform = NULL;
 
-    mutt_extract_token(buf, s, 0);
+    mutt_extract_token(buf, s, MUTT_TOKEN_NO_FLAGS);
     if (buf->data && (*buf->data != '\0'))
       tag = mutt_str_strdup(buf->data);
     else
       continue;
 
-    mutt_extract_token(buf, s, 0);
+    mutt_extract_token(buf, s, MUTT_TOKEN_NO_FLAGS);
     transform = mutt_str_strdup(buf->data);
 
     /* avoid duplicates */
@@ -2207,7 +2207,7 @@ static enum CommandResult parse_unalias(struct Buffer *buf, struct Buffer *s,
 
   do
   {
-    mutt_extract_token(buf, s, 0);
+    mutt_extract_token(buf, s, MUTT_TOKEN_NO_FLAGS);
 
     if (mutt_str_strcmp("*", buf->data) == 0)
     {
@@ -2256,7 +2256,7 @@ static enum CommandResult parse_unalternates(struct Buffer *buf, struct Buffer *
   alternates_clean();
   do
   {
-    mutt_extract_token(buf, s, 0);
+    mutt_extract_token(buf, s, MUTT_TOKEN_NO_FLAGS);
     mutt_regexlist_remove(&Alternates, buf->data);
 
     if ((mutt_str_strcmp(buf->data, "*") != 0) &&
@@ -2279,7 +2279,7 @@ static enum CommandResult parse_unattachments(struct Buffer *buf, struct Buffer 
   char op, *p = NULL;
   struct ListHead *head = NULL;
 
-  mutt_extract_token(buf, s, 0);
+  mutt_extract_token(buf, s, MUTT_TOKEN_NO_FLAGS);
   if (!buf->data || (*buf->data == '\0'))
   {
     mutt_buffer_strcpy(err, _("unattachments: no disposition"));
@@ -2324,7 +2324,7 @@ static enum CommandResult parse_unignore(struct Buffer *buf, struct Buffer *s,
 {
   do
   {
-    mutt_extract_token(buf, s, 0);
+    mutt_extract_token(buf, s, MUTT_TOKEN_NO_FLAGS);
 
     /* don't add "*" to the unignore list */
     if (strcmp(buf->data, "*") != 0)
@@ -2345,7 +2345,7 @@ static enum CommandResult parse_unlists(struct Buffer *buf, struct Buffer *s,
   mutt_hash_free(&AutoSubscribeCache);
   do
   {
-    mutt_extract_token(buf, s, 0);
+    mutt_extract_token(buf, s, MUTT_TOKEN_NO_FLAGS);
     mutt_regexlist_remove(&SubscribedLists, buf->data);
     mutt_regexlist_remove(&MailLists, buf->data);
 
@@ -2373,7 +2373,7 @@ static enum CommandResult parse_unmailboxes(struct Buffer *buf, struct Buffer *s
 
   while (!clear_all && MoreArgs(s))
   {
-    mutt_extract_token(buf, s, 0);
+    mutt_extract_token(buf, s, MUTT_TOKEN_NO_FLAGS);
 
     if (mutt_str_strcmp(buf->data, "*") == 0)
     {
@@ -2440,7 +2440,7 @@ static enum CommandResult parse_unmy_hdr(struct Buffer *buf, struct Buffer *s,
 
   do
   {
-    mutt_extract_token(buf, s, 0);
+    mutt_extract_token(buf, s, MUTT_TOKEN_NO_FLAGS);
     if (mutt_str_strcmp("*", buf->data) == 0)
     {
       mutt_list_free(&UserHeader);
@@ -2474,7 +2474,7 @@ static enum CommandResult parse_unstailq(struct Buffer *buf, struct Buffer *s,
 {
   do
   {
-    mutt_extract_token(buf, s, 0);
+    mutt_extract_token(buf, s, MUTT_TOKEN_NO_FLAGS);
     /* Check for deletion of entire list */
     if (mutt_str_strcmp(buf->data, "*") == 0)
     {
@@ -2510,7 +2510,7 @@ static enum CommandResult parse_unsubscribe(struct Buffer *buf, struct Buffer *s
   mutt_hash_free(&AutoSubscribeCache);
   do
   {
-    mutt_extract_token(buf, s, 0);
+    mutt_extract_token(buf, s, MUTT_TOKEN_NO_FLAGS);
     mutt_regexlist_remove(&SubscribedLists, buf->data);
 
     if ((mutt_str_strcmp(buf->data, "*") != 0) &&
@@ -2539,7 +2539,7 @@ static enum CommandResult parse_unsubscribe_from(struct Buffer *buf, struct Buff
 
   if (MoreArgs(s))
   {
-    mutt_extract_token(buf, s, 0);
+    mutt_extract_token(buf, s, MUTT_TOKEN_NO_FLAGS);
 
     if (MoreArgs(s))
     {
@@ -3280,7 +3280,7 @@ enum CommandResult mutt_parse_rc_line(/* const */ char *line,
       expn.dptr++;
       continue;
     }
-    mutt_extract_token(token, &expn, 0);
+    mutt_extract_token(token, &expn, MUTT_TOKEN_NO_FLAGS);
     for (i = 0; Commands[i].name; i++)
     {
       if (mutt_str_strcmp(token->data, Commands[i].name) == 0)

--- a/init.c
+++ b/init.c
@@ -2965,7 +2965,7 @@ void mutt_free_opts(void)
   mutt_replacelist_free(&SpamList);
   mutt_replacelist_free(&SubjectRegexList);
 
-  mutt_delete_hooks(0);
+  mutt_delete_hooks(MUTT_HOOK_NO_FLAGS);
 
   mutt_hist_free();
   mutt_free_keys();
@@ -3348,7 +3348,7 @@ int mutt_query_variables(struct ListHead *queries)
       mutt_buffer_strcpy(value, tmp->data);
     }
 
-    dump_config_neo(Config, he, value, NULL, 0, stdout);
+    dump_config_neo(Config, he, value, NULL, CS_DUMP_NO_FLAGS, stdout);
   }
 
   mutt_buffer_free(&value);

--- a/keymap.c
+++ b/keymap.c
@@ -1127,7 +1127,7 @@ static char *parse_keymap(int *menu, struct Buffer *s, int maxmenus,
   mutt_buffer_init(&buf);
 
   /* menu name */
-  mutt_extract_token(&buf, s, 0);
+  mutt_extract_token(&buf, s, MUTT_TOKEN_NO_FLAGS);
   char *p = buf.data;
   if (MoreArgs(s))
   {
@@ -1151,7 +1151,7 @@ static char *parse_keymap(int *menu, struct Buffer *s, int maxmenus,
     }
     *nummenus = i;
     /* key sequence */
-    mutt_extract_token(&buf, s, 0);
+    mutt_extract_token(&buf, s, MUTT_TOKEN_NO_FLAGS);
 
     if (buf.data[0] == '\0')
     {
@@ -1260,7 +1260,7 @@ enum CommandResult mutt_parse_bind(struct Buffer *buf, struct Buffer *s,
     return MUTT_CMD_ERROR;
 
   /* function to execute */
-  mutt_extract_token(buf, s, 0);
+  mutt_extract_token(buf, s, MUTT_TOKEN_NO_FLAGS);
   if (MoreArgs(s))
   {
     mutt_buffer_printf(err, _("%s: too many arguments"), "bind");
@@ -1394,7 +1394,7 @@ enum CommandResult mutt_parse_unbind(struct Buffer *buf, struct Buffer *s,
   bool all_keys = false;
   char *key = NULL;
 
-  mutt_extract_token(buf, s, 0);
+  mutt_extract_token(buf, s, MUTT_TOKEN_NO_FLAGS);
   if (mutt_str_strcmp(buf->data, "*") == 0)
   {
     for (int i = 0; i < MENU_MAX; i++)
@@ -1405,7 +1405,7 @@ enum CommandResult mutt_parse_unbind(struct Buffer *buf, struct Buffer *s,
 
   if (MoreArgs(s))
   {
-    mutt_extract_token(buf, s, 0);
+    mutt_extract_token(buf, s, MUTT_TOKEN_NO_FLAGS);
     key = buf->data;
   }
   else
@@ -1521,7 +1521,7 @@ enum CommandResult mutt_parse_exec(struct Buffer *buf, struct Buffer *s,
 
   do
   {
-    mutt_extract_token(buf, s, 0);
+    mutt_extract_token(buf, s, MUTT_TOKEN_NO_FLAGS);
     function = buf->data;
 
     bindings = km_get_table(CurrentMenu);

--- a/maildir/maildir.c
+++ b/maildir/maildir.c
@@ -430,7 +430,7 @@ int maildir_mbox_check(struct Mailbox *m, int *index_hint)
   /* we create a hash table keyed off the canonical (sans flags) filename
    * of each message we scanned.  This is used in the loop over the
    * existing messages below to do some correlation.  */
-  fnames = mutt_hash_new(count, 0);
+  fnames = mutt_hash_new(count, MUTT_HASH_NO_FLAGS);
 
   for (p = md; p; p = p->next)
   {

--- a/maildir/mh.c
+++ b/maildir/mh.c
@@ -306,7 +306,7 @@ int mh_read_sequences(struct MhSequences *mhs, const char *path)
   char *buf = NULL;
   size_t sz = 0;
 
-  MhSeqFlags f;
+  MhSeqFlags flags;
   int first, last, rc = 0;
 
   char pathname[PATH_MAX];
@@ -323,11 +323,11 @@ int mh_read_sequences(struct MhSequences *mhs, const char *path)
       continue;
 
     if (mutt_str_strcmp(t, C_MhSeqUnseen) == 0)
-      f = MH_SEQ_UNSEEN;
+      flags = MH_SEQ_UNSEEN;
     else if (mutt_str_strcmp(t, C_MhSeqFlagged) == 0)
-      f = MH_SEQ_FLAGGED;
+      flags = MH_SEQ_FLAGGED;
     else if (mutt_str_strcmp(t, C_MhSeqReplied) == 0)
-      f = MH_SEQ_REPLIED;
+      flags = MH_SEQ_REPLIED;
     else /* unknown sequence */
       continue;
 
@@ -340,7 +340,7 @@ int mh_read_sequences(struct MhSequences *mhs, const char *path)
         goto out;
       }
       for (; first <= last; first++)
-        mhs_set(mhs, first, f);
+        mhs_set(mhs, first, flags);
     }
   }
 
@@ -503,11 +503,11 @@ void mh_update_maildir(struct Maildir *md, struct MhSequences *mhs)
 
     if (mutt_str_atoi(p, &i) < 0)
       continue;
-    MhSeqFlags f = mhs_check(mhs, i);
+    MhSeqFlags flags = mhs_check(mhs, i);
 
-    md->email->read = (f & MH_SEQ_UNSEEN) ? false : true;
-    md->email->flagged = (f & MH_SEQ_FLAGGED) ? true : false;
-    md->email->replied = (f & MH_SEQ_REPLIED) ? true : false;
+    md->email->read = (flags & MH_SEQ_UNSEEN) ? false : true;
+    md->email->flagged = (flags & MH_SEQ_FLAGGED) ? true : false;
+    md->email->replied = (flags & MH_SEQ_REPLIED) ? true : false;
   }
 }
 
@@ -669,7 +669,7 @@ int mh_mbox_check(struct Mailbox *m, int *index_hint)
   mhs_free_sequences(&mhs);
 
   /* check for modifications and adjust flags */
-  fnames = mutt_hash_new(count, 0);
+  fnames = mutt_hash_new(count, MUTT_HASH_NO_FLAGS);
 
   for (p = md; p; p = p->next)
   {

--- a/maildir/shared.c
+++ b/maildir/shared.c
@@ -1096,7 +1096,7 @@ int mh_rewrite_message(struct Mailbox *m, int msgno)
   long old_body_length = e->content->length;
   long old_hdr_lines = e->lines;
 
-  struct Message *dest = mx_msg_open_new(m, e, 0);
+  struct Message *dest = mx_msg_open_new(m, e, MUTT_MSG_NO_FLAGS);
   if (!dest)
     return -1;
 

--- a/main.c
+++ b/main.c
@@ -1206,7 +1206,7 @@ int main(int argc, char *argv[], char *envp[])
 
     repeat_error = true;
     struct Mailbox *m = mx_path_resolve(folder);
-    Context = mx_mbox_open(m, ((flags & MUTT_CLI_RO) || C_ReadOnly) ? MUTT_READONLY : 0);
+    Context = mx_mbox_open(m, ((flags & MUTT_CLI_RO) || C_ReadOnly) ? MUTT_READONLY : MUTT_OPEN_NO_FLAGS);
     if (!Context)
     {
       mailbox_free(&m);

--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -1178,12 +1178,12 @@ static int mbox_mbox_sync(struct Mailbox *m, int *index_hint)
 
   /* Create a temporary file to write the new version of the mailbox in. */
   mutt_mktemp(tempfile, sizeof(tempfile));
-  i = open(tempfile, O_WRONLY | O_EXCL | O_CREAT, 0600);
-  if ((i == -1) || !(fp = fdopen(i, "w")))
+  int fd = open(tempfile, O_WRONLY | O_EXCL | O_CREAT, 0600);
+  if ((fd == -1) || !(fp = fdopen(fd, "w")))
   {
-    if (-1 != i)
+    if (fd != -1)
     {
-      close(i);
+      close(fd);
       unlink(tempfile);
     }
     mutt_error(_("Could not create temporary file"));

--- a/mutt.h
+++ b/mutt.h
@@ -76,7 +76,7 @@ typedef uint16_t TokenFlags;               ///< Flags for mutt_extract_token(), 
 #define MUTT_TOKEN_CONDENSE      (1 << 1)  ///< ^(char) to control chars (macros)
 #define MUTT_TOKEN_SPACE         (1 << 2)  ///< Don't treat whitespace as a term
 #define MUTT_TOKEN_QUOTE         (1 << 3)  ///< Don't interpret quotes
-#define MUTT_TOKEN_PATTERN       (1 << 4)  ///< !)|~ are terms (for patterns)
+#define MUTT_TOKEN_PATTERN       (1 << 4)  ///< ~%=!| are terms (for patterns)
 #define MUTT_TOKEN_COMMENT       (1 << 5)  ///< Don't reap comments
 #define MUTT_TOKEN_SEMICOLON     (1 << 6)  ///< Don't treat ; as special
 #define MUTT_TOKEN_BACKTICK_VARS (1 << 7)  ///< Expand variables within backticks

--- a/mutt/file.c
+++ b/mutt/file.c
@@ -1196,10 +1196,9 @@ int mutt_file_unlock(int fd)
  */
 void mutt_file_unlink_empty(const char *path)
 {
-  int fd;
   struct stat sb;
 
-  fd = open(path, O_RDWR);
+  int fd = open(path, O_RDWR);
   if (fd == -1)
     return;
 

--- a/mutt/signal.c
+++ b/mutt/signal.c
@@ -223,18 +223,18 @@ void mutt_sig_unblock_system(bool catch)
 
 /**
  * mutt_sig_allow_interrupt - Allow/disallow Ctrl-C (SIGINT)
- * @param disposition True to allow Ctrl-C to interrupt signals
+ * @param allow True to allow Ctrl-C to interrupt signals
  *
  * Allow the user to interrupt some long operations.
  */
-void mutt_sig_allow_interrupt(int disposition)
+void mutt_sig_allow_interrupt(bool allow)
 {
   struct sigaction sa;
 
   memset(&sa, 0, sizeof(sa));
   sa.sa_handler = sig_handler;
 #ifdef SA_RESTART
-  if (disposition == 0)
+  if (!allow)
     sa.sa_flags |= SA_RESTART;
 #endif
   sigaction(SIGINT, &sa, NULL);

--- a/mutt/signal2.h
+++ b/mutt/signal2.h
@@ -31,7 +31,7 @@
  */
 typedef void (*sig_handler_t)(int sig);
 
-void mutt_sig_allow_interrupt(int disposition);
+void mutt_sig_allow_interrupt(bool allow);
 void mutt_sig_block(void);
 void mutt_sig_block_system(void);
 void mutt_sig_empty_handler(int sig);

--- a/mutt_account.c
+++ b/mutt_account.c
@@ -231,7 +231,7 @@ int mutt_account_getuser(struct ConnAccount *account)
     /* L10N: Example: Username at myhost.com */
     snprintf(prompt, sizeof(prompt), _("Username at %s: "), account->host);
     mutt_str_strfcpy(account->user, Username, sizeof(account->user));
-    if (mutt_get_field_unbuffered(prompt, account->user, sizeof(account->user), 0))
+    if (mutt_get_field_unbuffered(prompt, account->user, sizeof(account->user), MUTT_COMP_NO_FLAGS))
       return -1;
   }
 

--- a/mutt_attach.c
+++ b/mutt_attach.c
@@ -624,7 +624,7 @@ int mutt_view_attachment(FILE *fp, struct Body *a, enum ViewAttachMode mode,
     info.email = e;
 
     rc = mutt_do_pager(desc, pagerfile,
-                       MUTT_PAGER_ATTACHMENT | (is_message ? MUTT_PAGER_MESSAGE : 0),
+                       MUTT_PAGER_ATTACHMENT | (is_message ? MUTT_PAGER_MESSAGE : MUTT_PAGER_NO_FLAGS),
                        &info);
     *pagerfile = '\0';
   }
@@ -816,7 +816,8 @@ int mutt_save_attachment(FILE *fp, struct Body *m, char *path,
         mailbox_free(&m_att);
         return -1;
       }
-      msg = mx_msg_open_new(ctx->mailbox, en, is_from(buf, NULL, 0, NULL) ? 0 : MUTT_ADD_FROM);
+      msg = mx_msg_open_new(ctx->mailbox, en,
+                            is_from(buf, NULL, 0, NULL) ? MUTT_MSG_NO_FLAGS : MUTT_ADD_FROM);
       if (!msg)
       {
         mx_mbox_close(&ctx);
@@ -825,7 +826,7 @@ int mutt_save_attachment(FILE *fp, struct Body *m, char *path,
       if ((ctx->mailbox->magic == MUTT_MBOX) || (ctx->mailbox->magic == MUTT_MMDF))
         chflags = CH_FROM | CH_UPDATE_LEN;
       chflags |= ((ctx->mailbox->magic == MUTT_MAILDIR) ? CH_NOSTATUS : CH_UPDATE);
-      if ((mutt_copy_message_fp(msg->fp, fp, en, 0, chflags) == 0) &&
+      if ((mutt_copy_message_fp(msg->fp, fp, en, MUTT_CM_NO_FLAGS, chflags) == 0) &&
           (mx_msg_commit(ctx->mailbox, msg) == 0))
       {
         rc = 0;

--- a/mutt_attach.c
+++ b/mutt_attach.c
@@ -485,7 +485,7 @@ int mutt_view_attachment(FILE *fp, struct Body *a, enum ViewAttachMode mode,
   if (use_mailcap)
   {
     pid_t pid = 0;
-    int tempfd = -1, pagerfd = -1;
+    int fd_temp = -1, fd_pager = -1;
 
     if (!use_pager)
       mutt_endwin();
@@ -493,28 +493,28 @@ int mutt_view_attachment(FILE *fp, struct Body *a, enum ViewAttachMode mode,
     if (use_pager || use_pipe)
     {
       if (use_pager &&
-          ((pagerfd = mutt_file_open(pagerfile, O_CREAT | O_EXCL | O_WRONLY)) == -1))
+          ((fd_pager = mutt_file_open(pagerfile, O_CREAT | O_EXCL | O_WRONLY)) == -1))
       {
         mutt_perror("open");
         goto return_error;
       }
-      if (use_pipe && ((tempfd = open(tempfile, 0)) == -1))
+      if (use_pipe && ((fd_temp = open(tempfile, 0)) == -1))
       {
-        if (pagerfd != -1)
-          close(pagerfd);
+        if (fd_pager != -1)
+          close(fd_pager);
         mutt_perror("open");
         goto return_error;
       }
 
-      pid = mutt_create_filter_fd(cmd, NULL, NULL, NULL, use_pipe ? tempfd : -1,
-                                  use_pager ? pagerfd : -1, -1);
+      pid = mutt_create_filter_fd(cmd, NULL, NULL, NULL, use_pipe ? fd_temp : -1,
+                                  use_pager ? fd_pager : -1, -1);
       if (pid == -1)
       {
-        if (pagerfd != -1)
-          close(pagerfd);
+        if (fd_pager != -1)
+          close(fd_pager);
 
-        if (tempfd != -1)
-          close(tempfd);
+        if (fd_temp != -1)
+          close(fd_temp);
 
         mutt_error(_("Can't create filter"));
         goto return_error;
@@ -536,10 +536,10 @@ int mutt_view_attachment(FILE *fp, struct Body *a, enum ViewAttachMode mode,
       if ((mutt_wait_filter(pid) || (entry->needsterminal && C_WaitKey)) && !use_pager)
         mutt_any_key_to_continue(NULL);
 
-      if (tempfd != -1)
-        close(tempfd);
-      if (pagerfd != -1)
-        close(pagerfd);
+      if (fd_temp != -1)
+        close(fd_temp);
+      if (fd_pager != -1)
+        close(fd_pager);
     }
     else
     {

--- a/mutt_lua.c
+++ b/mutt_lua.c
@@ -475,7 +475,7 @@ enum CommandResult mutt_lua_source_file(struct Buffer *buf, struct Buffer *s,
 
   char path[PATH_MAX];
 
-  if (mutt_extract_token(buf, s, 0) != 0)
+  if (mutt_extract_token(buf, s, MUTT_TOKEN_NO_FLAGS) != 0)
   {
     mutt_buffer_printf(err, _("source: error at %s"), s->dptr);
     return MUTT_CMD_ERROR;

--- a/mutt_thread.c
+++ b/mutt_thread.c
@@ -1432,7 +1432,7 @@ int mutt_messages_in_thread(struct Mailbox *m, struct Email *e, int flag)
  */
 struct Hash *mutt_make_id_hash(struct Mailbox *m)
 {
-  struct Hash *hash = mutt_hash_new(m->msg_count * 2, 0);
+  struct Hash *hash = mutt_hash_new(m->msg_count * 2, MUTT_HASH_NO_FLAGS);
 
   for (int i = 0; i < m->msg_count; i++)
   {

--- a/muttlib.c
+++ b/muttlib.c
@@ -907,7 +907,7 @@ void mutt_expando_format(char *buf, size_t buflen, size_t col, int cols, const c
         mutt_debug(LL_DEBUG3, "fmtpipe +++: %s\n", srcbuf->dptr);
         if (word->data)
           *word->data = '\0';
-        mutt_extract_token(word, srcbuf, 0);
+        mutt_extract_token(word, srcbuf, MUTT_TOKEN_NO_FLAGS);
         mutt_debug(LL_DEBUG3, "fmtpipe %2d: %s\n", i++, word->data);
         mutt_buffer_addch(cmd, '\'');
         mutt_expando_format(tmp, sizeof(tmp), 0, cols, word->data, callback,

--- a/mx.c
+++ b/mx.c
@@ -499,7 +499,8 @@ static int trash_append(struct Mailbox *m)
     {
       if (m->emails[i]->deleted && (!m->emails[i]->purge))
       {
-        if (mutt_append_message(ctx_trash->mailbox, m, m->emails[i], 0, 0) == -1)
+        if (mutt_append_message(ctx_trash->mailbox, m, m->emails[i],
+                                MUTT_CM_NO_FLAGS, CH_NO_FLAGS) == -1)
         {
           mx_mbox_close(&ctx_trash);
           return -1;
@@ -683,7 +684,7 @@ int mx_mbox_close(struct Context **ptr)
             !(m->emails[i]->flagged && C_KeepFlagged))
         {
           if (mutt_append_message(ctx_read->mailbox, ctx->mailbox, m->emails[i],
-                                  0, CH_UPDATE_LEN) == 0)
+                                  MUTT_CM_NO_FLAGS, CH_UPDATE_LEN) == 0)
           {
             mutt_set_flag(m, m->emails[i], MUTT_DELETE, true);
             mutt_set_flag(m, m->emails[i], MUTT_PURGE, true);

--- a/ncrypt/crypt.c
+++ b/ncrypt/crypt.c
@@ -696,8 +696,8 @@ SecurityFlags crypt_query(struct Body *m)
 
   if ((m->type == TYPE_MULTIPART) || (m->type == TYPE_MESSAGE))
   {
-    SecurityFlags u = m->parts ? SEC_ALL_FLAGS : 0; /* Bits set in all parts */
-    SecurityFlags w = SEC_NO_FLAGS;                 /* Bits set in any part  */
+    SecurityFlags u = m->parts ? SEC_ALL_FLAGS : SEC_NO_FLAGS; /* Bits set in all parts */
+    SecurityFlags w = SEC_NO_FLAGS; /* Bits set in any part  */
 
     for (struct Body *b = m->parts; b; b = b->next)
     {
@@ -848,7 +848,7 @@ void crypt_extract_keys_from_messages(struct EmailList *el)
     if (((WithCrypto & APPLICATION_PGP) != 0) && (e->security & APPLICATION_PGP))
     {
       mutt_copy_message_ctx(fp_out, Context->mailbox, e,
-                            MUTT_CM_DECODE | MUTT_CM_CHARCONV, 0);
+                            MUTT_CM_DECODE | MUTT_CM_CHARCONV, CH_NO_FLAGS);
       fflush(fp_out);
 
       mutt_endwin();
@@ -862,10 +862,10 @@ void crypt_extract_keys_from_messages(struct EmailList *el)
       {
         mutt_copy_message_ctx(fp_out, Context->mailbox, e,
                               MUTT_CM_NOHEADER | MUTT_CM_DECODE_CRYPT | MUTT_CM_DECODE_SMIME,
-                              0);
+                              CH_NO_FLAGS);
       }
       else
-        mutt_copy_message_ctx(fp_out, Context->mailbox, e, 0, 0);
+        mutt_copy_message_ctx(fp_out, Context->mailbox, e, MUTT_CM_NO_FLAGS, CH_NO_FLAGS);
       fflush(fp_out);
 
       if (e->env->from)

--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -2368,7 +2368,7 @@ int smime_gpgme_decrypt_mime(FILE *fp_in, FILE **fp_out, struct Body *b, struct 
   size_t saved_b_length;
   int saved_b_type;
 
-  if (mutt_is_application_smime(b) == 0)
+  if (mutt_is_application_smime(b) == SEC_NO_FLAGS)
     return -1;
 
   if (b->parts)
@@ -2706,7 +2706,7 @@ int pgp_gpgme_check_traditional(FILE *fp, struct Body *b, bool just_one)
     else if (b->type == TYPE_TEXT)
     {
       SecurityFlags r = mutt_is_application_pgp(b);
-      if (r != 0)
+      if (r)
         rc = (rc || r);
       else
         rc = (pgp_check_traditional_one_body(fp, b) || rc);
@@ -3525,9 +3525,11 @@ static const char *crypt_format_str(char *buf, size_t buflen, size_t col, int co
   }
 
   if (optional)
-    mutt_expando_format(buf, buflen, col, cols, if_str, attach_format_str, data, 0);
+    mutt_expando_format(buf, buflen, col, cols, if_str, attach_format_str, data,
+                        MUTT_FORMAT_NO_FLAGS);
   else if (flags & MUTT_FORMAT_OPTIONAL)
-    mutt_expando_format(buf, buflen, col, cols, else_str, attach_format_str, data, 0);
+    mutt_expando_format(buf, buflen, col, cols, else_str, attach_format_str,
+                        data, MUTT_FORMAT_NO_FLAGS);
   return src;
 }
 
@@ -4390,7 +4392,7 @@ leave:
   mutt_file_fclose(&fp);
   mutt_clear_error();
   snprintf(cmd, sizeof(cmd), _("Key ID: 0x%s"), crypt_keyid(key));
-  mutt_do_pager(cmd, tempfile, 0, NULL);
+  mutt_do_pager(cmd, tempfile, MUTT_PAGER_NO_FLAGS, NULL);
 }
 
 /**
@@ -5281,8 +5283,8 @@ struct Body *pgp_gpgme_make_key_attachment(void)
 
   OptPgpCheckTrust = false;
 
-  struct CryptKeyInfo *key = crypt_ask_for_key(_("Please enter the key ID: "),
-                                               NULL, 0, APPLICATION_PGP, NULL);
+  struct CryptKeyInfo *key = crypt_ask_for_key(_("Please enter the key ID: "), NULL,
+                                               KEYFLAG_NO_FLAGS, APPLICATION_PGP, NULL);
   if (!key)
     goto bail;
   export_keys[0] = key->kobj;

--- a/ncrypt/gnupgparse.c
+++ b/ncrypt/gnupgparse.c
@@ -415,18 +415,17 @@ struct PgpKeyInfo *pgp_get_candidates(enum PgpRing keyring, struct ListHead *hin
   char buf[1024];
   struct PgpKeyInfo *db = NULL, **kend = NULL, *k = NULL, *kk = NULL, *mainkey = NULL;
   bool is_sub = false;
-  int devnull;
 
-  devnull = open("/dev/null", O_RDWR);
-  if (devnull == -1)
+  int fd_null = open("/dev/null", O_RDWR);
+  if (fd_null == -1)
     return NULL;
 
   mutt_str_replace(&chs, C_Charset);
 
-  pid = pgp_invoke_list_keys(NULL, &fp, NULL, -1, -1, devnull, keyring, hints);
+  pid = pgp_invoke_list_keys(NULL, &fp, NULL, -1, -1, fd_null, keyring, hints);
   if (pid == -1)
   {
-    close(devnull);
+    close(fd_null);
     return NULL;
   }
 
@@ -467,7 +466,7 @@ struct PgpKeyInfo *pgp_get_candidates(enum PgpRing keyring, struct ListHead *hin
   mutt_file_fclose(&fp);
   mutt_wait_filter(pid);
 
-  close(devnull);
+  close(fd_null);
 
   return db;
 }

--- a/ncrypt/pgp.c
+++ b/ncrypt/pgp.c
@@ -1955,7 +1955,7 @@ int pgp_class_send_menu(struct Email *msg)
       case 'a': /* sign (a)s */
         OptPgpCheckTrust = false;
 
-        p = pgp_ask_for_key(_("Sign as: "), NULL, 0, PGP_SECRING);
+        p = pgp_ask_for_key(_("Sign as: "), NULL, KEYFLAG_NO_FLAGS, PGP_SECRING);
         if (p)
         {
           char input_signas[128];

--- a/ncrypt/pgpinvoke.c
+++ b/ncrypt/pgpinvoke.c
@@ -164,9 +164,11 @@ static const char *fmt_pgp_command(char *buf, size_t buflen, size_t col, int col
   }
 
   if (optional)
-    mutt_expando_format(buf, buflen, col, cols, if_str, fmt_pgp_command, data, 0);
+    mutt_expando_format(buf, buflen, col, cols, if_str, fmt_pgp_command, data,
+                        MUTT_FORMAT_NO_FLAGS);
   else if (flags & MUTT_FORMAT_OPTIONAL)
-    mutt_expando_format(buf, buflen, col, cols, else_str, fmt_pgp_command, data, 0);
+    mutt_expando_format(buf, buflen, col, cols, else_str, fmt_pgp_command, data,
+                        MUTT_FORMAT_NO_FLAGS);
 
   return src;
 }
@@ -182,7 +184,7 @@ static void mutt_pgp_command(char *buf, size_t buflen,
                              struct PgpCommandContext *cctx, const char *fmt)
 {
   mutt_expando_format(buf, buflen, 0, MuttIndexWindow->cols, NONULL(fmt),
-                      fmt_pgp_command, (unsigned long) cctx, 0);
+                      fmt_pgp_command, (unsigned long) cctx, MUTT_FORMAT_NO_FLAGS);
   mutt_debug(LL_DEBUG2, "%s\n", buf);
 }
 

--- a/ncrypt/pgpinvoke.c
+++ b/ncrypt/pgpinvoke.c
@@ -425,7 +425,6 @@ void pgp_class_invoke_getkeys(struct Address *addr)
   char buf[PATH_MAX];
   char tmp[1024];
   char cmd[STR_COMMAND];
-  int devnull;
 
   char *personal = NULL;
 
@@ -448,7 +447,7 @@ void pgp_class_invoke_getkeys(struct Address *addr)
 
   mutt_pgp_command(cmd, sizeof(cmd), &cctx, C_PgpGetkeysCommand);
 
-  devnull = open("/dev/null", O_RDWR);
+  int fd_null = open("/dev/null", O_RDWR);
 
   if (!isendwin())
     mutt_message(_("Fetching PGP key..."));
@@ -459,8 +458,8 @@ void pgp_class_invoke_getkeys(struct Address *addr)
   if (!isendwin())
     mutt_clear_error();
 
-  if (devnull >= 0)
-    close(devnull);
+  if (fd_null >= 0)
+    close(fd_null);
 }
 
 /**

--- a/ncrypt/pgpkey.c
+++ b/ncrypt/pgpkey.c
@@ -316,9 +316,11 @@ static const char *pgp_entry_fmt(char *buf, size_t buflen, size_t col, int cols,
   }
 
   if (optional)
-    mutt_expando_format(buf, buflen, col, cols, if_str, attach_format_str, data, 0);
+    mutt_expando_format(buf, buflen, col, cols, if_str, attach_format_str, data,
+                        MUTT_FORMAT_NO_FLAGS);
   else if (flags & MUTT_FORMAT_OPTIONAL)
-    mutt_expando_format(buf, buflen, col, cols, else_str, attach_format_str, data, 0);
+    mutt_expando_format(buf, buflen, col, cols, else_str, attach_format_str,
+                        data, MUTT_FORMAT_NO_FLAGS);
   return src;
 }
 
@@ -724,7 +726,7 @@ static struct PgpKeyInfo *pgp_select_key(struct PgpKeyInfo *keys,
         mutt_clear_error();
         snprintf(cmd, sizeof(cmd), _("Key ID: 0x%s"),
                  pgp_keyid(pgp_principal_key(key_table[menu->current]->parent)));
-        mutt_do_pager(cmd, tempfile, 0, NULL);
+        mutt_do_pager(cmd, tempfile, MUTT_PAGER_NO_FLAGS, NULL);
         menu->redraw = REDRAW_FULL;
 
         break;
@@ -875,8 +877,8 @@ struct Body *pgp_class_make_key_attachment(void)
   pid_t pid;
   OptPgpCheckTrust = false;
 
-  struct PgpKeyInfo *key =
-      pgp_ask_for_key(_("Please enter the key ID: "), NULL, 0, PGP_PUBRING);
+  struct PgpKeyInfo *key = pgp_ask_for_key(_("Please enter the key ID: "), NULL,
+                                           KEYFLAG_NO_FLAGS, PGP_PUBRING);
 
   if (!key)
     return NULL;

--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -335,9 +335,11 @@ static const char *fmt_smime_command(char *buf, size_t buflen, size_t col, int c
   }
 
   if (optional)
-    mutt_expando_format(buf, buflen, col, cols, if_str, fmt_smime_command, data, 0);
+    mutt_expando_format(buf, buflen, col, cols, if_str, fmt_smime_command, data,
+                        MUTT_FORMAT_NO_FLAGS);
   else if (flags & MUTT_FORMAT_OPTIONAL)
-    mutt_expando_format(buf, buflen, col, cols, else_str, fmt_smime_command, data, 0);
+    mutt_expando_format(buf, buflen, col, cols, else_str, fmt_smime_command,
+                        data, MUTT_FORMAT_NO_FLAGS);
 
   return src;
 }
@@ -353,7 +355,7 @@ static void smime_command(char *buf, size_t buflen,
                           struct SmimeCommandContext *cctx, const char *fmt)
 {
   mutt_expando_format(buf, buflen, 0, MuttIndexWindow->cols, NONULL(fmt),
-                      fmt_smime_command, (unsigned long) cctx, 0);
+                      fmt_smime_command, (unsigned long) cctx, MUTT_FORMAT_NO_FLAGS);
   mutt_debug(LL_DEBUG2, "%s\n", buf);
 }
 
@@ -1428,7 +1430,7 @@ int smime_class_verify_sender(struct Email *e)
                           CH_MIME | CH_WEED | CH_NONEWLINE);
   }
   else
-    mutt_copy_message_ctx(fp_out, Context->mailbox, e, 0, 0);
+    mutt_copy_message_ctx(fp_out, Context->mailbox, e, MUTT_CM_NO_FLAGS, CH_NO_FLAGS);
 
   fflush(fp_out);
   mutt_file_fclose(&fp_out);

--- a/nntp/newsrc.c
+++ b/nntp/newsrc.c
@@ -1077,8 +1077,8 @@ struct NntpAccountData *nntp_select_server(struct Mailbox *m, char *server, bool
   /* load .newsrc */
   if (rc >= 0)
   {
-    mutt_expando_format(file, sizeof(file), 0, MuttIndexWindow->cols,
-                        NONULL(C_Newsrc), nntp_format_str, (unsigned long) adata, 0);
+    mutt_expando_format(file, sizeof(file), 0, MuttIndexWindow->cols, NONULL(C_Newsrc),
+                        nntp_format_str, (unsigned long) adata, MUTT_FORMAT_NO_FLAGS);
     mutt_expand_path(file, sizeof(file));
     adata->newsrc_file = mutt_str_strdup(file);
     rc = nntp_newsrc_parse(adata);

--- a/nntp/nntp.c
+++ b/nntp/nntp.c
@@ -144,7 +144,7 @@ struct NntpAccountData *nntp_adata_new(struct Connection *conn)
 {
   struct NntpAccountData *adata = mutt_mem_calloc(1, sizeof(struct NntpAccountData));
   adata->conn = conn;
-  adata->groups_hash = mutt_hash_new(1009, 0);
+  adata->groups_hash = mutt_hash_new(1009, MUTT_HASH_NO_FLAGS);
   mutt_hash_set_destructor(adata->groups_hash, nntp_hashelem_free, 0);
   adata->groups_max = 16;
   adata->groups_list =

--- a/notmuch/mutt_notmuch.c
+++ b/notmuch/mutt_notmuch.c
@@ -2297,7 +2297,7 @@ static int nm_mbox_check(struct Mailbox *m, int *index_hint)
     if (!e)
     {
       /* new email */
-      append_message(h, m, NULL, msg, 0);
+      append_message(h, m, NULL, msg, false);
       notmuch_message_destroy(msg);
       continue;
     }

--- a/pager.c
+++ b/pager.c
@@ -2225,7 +2225,7 @@ static void pager_custom_redraw(struct Menu *pager_menu)
  *
  * This pager is actually not so simple as it once was.  It now operates in two
  * modes: one for viewing messages and the other for viewing help.  These can
- * be distinguished by whether or not "hdr" is NULL.  The "hdr" arg is
+ * be distinguished by whether or not "email" is NULL.  The "email" arg is
  * there so that we can do operations on the current message without the need
  * to pop back out to the main-menu.
  */

--- a/pattern.c
+++ b/pattern.c
@@ -449,8 +449,8 @@ static const char *get_date(const char *s, struct tm *t, struct Buffer *err)
 static const char *parse_date_range(const char *pc, struct tm *min, struct tm *max,
                                     bool have_min, struct tm *base_min, struct Buffer *err)
 {
-  PatternFlags flag = MUTT_PDR_NO_FLAGS;
-  while (*pc && ((flag & MUTT_PDR_DONE) == 0))
+  PatternFlags flags = MUTT_PDR_NO_FLAGS;
+  while (*pc && ((flags & MUTT_PDR_DONE) == 0))
   {
     const char *pt = NULL;
     char ch = *pc++;
@@ -463,31 +463,31 @@ static const char *parse_date_range(const char *pc, struct tm *min, struct tm *m
         pt = get_offset(min, pc, -1);
         if (pc == pt)
         {
-          if (flag == MUTT_PDR_NO_FLAGS)
+          if (flags == MUTT_PDR_NO_FLAGS)
           { /* nothing yet and no offset parsed => absolute date? */
             if (!get_date(pc, max, err))
-              flag |= (MUTT_PDR_ABSOLUTE | MUTT_PDR_ERRORDONE); /* done bad */
+              flags |= (MUTT_PDR_ABSOLUTE | MUTT_PDR_ERRORDONE); /* done bad */
             else
             {
               /* reestablish initial base minimum if not specified */
               if (!have_min)
                 memcpy(min, base_min, sizeof(struct tm));
-              flag |= (MUTT_PDR_ABSOLUTE | MUTT_PDR_DONE); /* done good */
+              flags |= (MUTT_PDR_ABSOLUTE | MUTT_PDR_DONE); /* done good */
             }
           }
           else
-            flag |= MUTT_PDR_ERRORDONE;
+            flags |= MUTT_PDR_ERRORDONE;
         }
         else
         {
           pc = pt;
-          if ((flag == MUTT_PDR_NO_FLAGS) && !have_min)
+          if ((flags == MUTT_PDR_NO_FLAGS) && !have_min)
           { /* the very first "-3d" without a previous absolute date */
             max->tm_year = min->tm_year;
             max->tm_mon = min->tm_mon;
             max->tm_mday = min->tm_mday;
           }
-          flag |= MUTT_PDR_MINUS;
+          flags |= MUTT_PDR_MINUS;
         }
         break;
       }
@@ -495,11 +495,11 @@ static const char *parse_date_range(const char *pc, struct tm *min, struct tm *m
       { /* enlarge plus range */
         pt = get_offset(max, pc, 1);
         if (pc == pt)
-          flag |= MUTT_PDR_ERRORDONE;
+          flags |= MUTT_PDR_ERRORDONE;
         else
         {
           pc = pt;
-          flag |= MUTT_PDR_PLUS;
+          flags |= MUTT_PDR_PLUS;
         }
         break;
       }
@@ -507,24 +507,24 @@ static const char *parse_date_range(const char *pc, struct tm *min, struct tm *m
       { /* enlarge window in both directions */
         pt = get_offset(min, pc, -1);
         if (pc == pt)
-          flag |= MUTT_PDR_ERRORDONE;
+          flags |= MUTT_PDR_ERRORDONE;
         else
         {
           pc = get_offset(max, pc, 1);
-          flag |= MUTT_PDR_WINDOW;
+          flags |= MUTT_PDR_WINDOW;
         }
         break;
       }
       default:
-        flag |= MUTT_PDR_ERRORDONE;
+        flags |= MUTT_PDR_ERRORDONE;
     }
     SKIPWS(pc);
   }
-  if ((flag & MUTT_PDR_ERROR) && !(flag & MUTT_PDR_ABSOLUTE))
+  if ((flags & MUTT_PDR_ERROR) && !(flags & MUTT_PDR_ABSOLUTE))
   { /* get_date has its own error message, don't overwrite it here */
     mutt_buffer_printf(err, _("Invalid relative date: %s"), pc - 1);
   }
-  return (flag & MUTT_PDR_ERROR) ? NULL : pc;
+  return (flags & MUTT_PDR_ERROR) ? NULL : pc;
 }
 
 /**

--- a/pattern.c
+++ b/pattern.c
@@ -199,8 +199,6 @@ static char LastSearchExpn[1024] = { 0 }; /**< expanded version of LastSearch */
 static bool eat_regex(struct Pattern *pat, struct Buffer *s, struct Buffer *err)
 {
   struct Buffer buf;
-  char errmsg[256];
-  int r;
 
   mutt_buffer_init(&buf);
   char *pexpr = s->dptr;
@@ -232,10 +230,11 @@ static bool eat_regex(struct Pattern *pat, struct Buffer *s, struct Buffer *err)
   {
     pat->p.regex = mutt_mem_malloc(sizeof(regex_t));
     int flags = mutt_mb_is_lower(buf.data) ? REG_ICASE : 0;
-    r = REGCOMP(pat->p.regex, buf.data, REG_NEWLINE | REG_NOSUB | flags);
-    if (r != 0)
+    int rc = REGCOMP(pat->p.regex, buf.data, REG_NEWLINE | REG_NOSUB | flags);
+    if (rc != 0)
     {
-      regerror(r, pat->p.regex, errmsg, sizeof(errmsg));
+      char errmsg[256];
+      regerror(rc, pat->p.regex, errmsg, sizeof(errmsg));
       mutt_buffer_add_printf(err, "'%s': %s", buf.data, errmsg);
       FREE(&buf.data);
       FREE(&pat->p.regex);

--- a/query.c
+++ b/query.c
@@ -285,9 +285,11 @@ static const char *query_format_str(char *buf, size_t buflen, size_t col, int co
   }
 
   if (optional)
-    mutt_expando_format(buf, buflen, col, cols, if_str, query_format_str, data, 0);
+    mutt_expando_format(buf, buflen, col, cols, if_str, query_format_str, data,
+                        MUTT_FORMAT_NO_FLAGS);
   else if (flags & MUTT_FORMAT_OPTIONAL)
-    mutt_expando_format(buf, buflen, col, cols, else_str, query_format_str, data, 0);
+    mutt_expando_format(buf, buflen, col, cols, else_str, query_format_str,
+                        data, MUTT_FORMAT_NO_FLAGS);
 
   return src;
 }
@@ -497,7 +499,7 @@ static void query_menu(char *buf, size_t buflen, struct Query *results, bool ret
               }
             }
           }
-          ci_send_message(0, msg, NULL, Context, NULL);
+          ci_send_message(SEND_NO_FLAGS, msg, NULL, Context, NULL);
           menu->redraw = REDRAW_FULL;
           break;
         }

--- a/recvattach.c
+++ b/recvattach.c
@@ -420,9 +420,11 @@ const char *attach_format_str(char *buf, size_t buflen, size_t col, int cols,
   }
 
   if (optional)
-    mutt_expando_format(buf, buflen, col, cols, if_str, attach_format_str, data, 0);
+    mutt_expando_format(buf, buflen, col, cols, if_str, attach_format_str, data,
+                        MUTT_FORMAT_NO_FLAGS);
   else if (flags & MUTT_FORMAT_OPTIONAL)
-    mutt_expando_format(buf, buflen, col, cols, else_str, attach_format_str, data, 0);
+    mutt_expando_format(buf, buflen, col, cols, else_str, attach_format_str,
+                        data, MUTT_FORMAT_NO_FLAGS);
   return src;
 }
 
@@ -1542,7 +1544,7 @@ void mutt_view_attachments(struct Email *e)
       case OP_FORWARD_MESSAGE:
         CHECK_ATTACH;
         mutt_attach_forward(CURATTACH->fp, e, actx,
-                            menu->tagprefix ? NULL : CURATTACH->content, 0);
+                            menu->tagprefix ? NULL : CURATTACH->content, SEND_NO_FLAGS);
         menu->redraw = REDRAW_FULL;
         break;
 
@@ -1577,9 +1579,14 @@ void mutt_view_attachments(struct Email *e)
       {
         CHECK_ATTACH;
 
-        SendFlags flags = SEND_REPLY | ((op == OP_GROUP_REPLY) ? SEND_GROUP_REPLY : 0) |
-                          ((op == OP_GROUP_CHAT_REPLY) ? SEND_GROUP_CHAT_REPLY : 0) |
-                          ((op == OP_LIST_REPLY) ? SEND_LIST_REPLY : 0);
+        SendFlags flags = SEND_REPLY;
+        if (op == OP_GROUP_REPLY)
+          flags |= SEND_GROUP_REPLY;
+        else if (op == OP_GROUP_CHAT_REPLY)
+          flags |= SEND_GROUP_CHAT_REPLY;
+        else if (op == OP_LIST_REPLY)
+          flags |= SEND_LIST_REPLY;
+
         mutt_attach_reply(CURATTACH->fp, e, actx,
                           menu->tagprefix ? NULL : CURATTACH->content, flags);
         menu->redraw = REDRAW_FULL;

--- a/recvcmd.c
+++ b/recvcmd.c
@@ -595,7 +595,7 @@ static void attach_forward_bodies(FILE *fp, struct Email *e, struct AttachCtx *a
   /* now that we have the template, send it. */
   struct EmailList el = STAILQ_HEAD_INITIALIZER(el);
   el_add_email(&el, e_parent);
-  ci_send_message(0, e_tmp, tmpbody, NULL, &el);
+  ci_send_message(SEND_NO_FLAGS, e_tmp, tmpbody, NULL, &el);
   el_free(&el);
   return;
 
@@ -1081,5 +1081,5 @@ void mutt_attach_mail_sender(FILE *fp, struct Email *e, struct AttachCtx *actx,
         return;
     }
   }
-  ci_send_message(0, e_tmp, NULL, NULL, NULL);
+  ci_send_message(SEND_NO_FLAGS, e_tmp, NULL, NULL, NULL);
 }

--- a/remailer.c
+++ b/remailer.c
@@ -478,9 +478,11 @@ static const char *mix_format_str(char *buf, size_t buflen, size_t col, int cols
   }
 
   if (optional)
-    mutt_expando_format(buf, buflen, col, cols, if_str, attach_format_str, data, 0);
+    mutt_expando_format(buf, buflen, col, cols, if_str, attach_format_str, data,
+                        MUTT_FORMAT_NO_FLAGS);
   else if (flags & MUTT_FORMAT_OPTIONAL)
-    mutt_expando_format(buf, buflen, col, cols, else_str, attach_format_str, data, 0);
+    mutt_expando_format(buf, buflen, col, cols, else_str, attach_format_str,
+                        data, MUTT_FORMAT_NO_FLAGS);
   return src;
 }
 

--- a/remailer.c
+++ b/remailer.c
@@ -160,7 +160,6 @@ static struct Remailer **mix_type2_list(size_t *l)
 {
   FILE *fp = NULL;
   pid_t mm_pid;
-  int devnull;
 
   char cmd[STR_COMMAND];
   char line[8192];
@@ -172,16 +171,16 @@ static struct Remailer **mix_type2_list(size_t *l)
   if (!l)
     return NULL;
 
-  devnull = open("/dev/null", O_RDWR);
-  if (devnull == -1)
+  int fd_null = open("/dev/null", O_RDWR);
+  if (fd_null == -1)
     return NULL;
 
   snprintf(cmd, sizeof(cmd), "%s -T", C_Mixmaster);
 
-  mm_pid = mutt_create_filter_fd(cmd, NULL, &fp, NULL, devnull, -1, devnull);
+  mm_pid = mutt_create_filter_fd(cmd, NULL, &fp, NULL, fd_null, -1, fd_null);
   if (mm_pid == -1)
   {
-    close(devnull);
+    close(fd_null);
     return NULL;
   }
 
@@ -235,7 +234,7 @@ static struct Remailer **mix_type2_list(size_t *l)
   mix_add_entry(&type2_list, NULL, &slots, &used);
   mutt_wait_filter(mm_pid);
 
-  close(devnull);
+  close(fd_null);
 
   return type2_list;
 }

--- a/score.c
+++ b/score.c
@@ -101,7 +101,7 @@ enum CommandResult mutt_parse_score(struct Buffer *buf, struct Buffer *s,
   struct Score *ptr = NULL, *last = NULL;
   char *pattern = NULL, *pc = NULL;
 
-  mutt_extract_token(buf, s, 0);
+  mutt_extract_token(buf, s, MUTT_TOKEN_NO_FLAGS);
   if (!MoreArgs(s))
   {
     mutt_buffer_printf(err, _("%s: too few arguments"), "score");
@@ -109,7 +109,7 @@ enum CommandResult mutt_parse_score(struct Buffer *buf, struct Buffer *s,
   }
   pattern = buf->data;
   mutt_buffer_init(buf);
-  mutt_extract_token(buf, s, 0);
+  mutt_extract_token(buf, s, MUTT_TOKEN_NO_FLAGS);
   if (MoreArgs(s))
   {
     FREE(&pattern);
@@ -206,7 +206,7 @@ enum CommandResult mutt_parse_unscore(struct Buffer *buf, struct Buffer *s,
 
   while (MoreArgs(s))
   {
-    mutt_extract_token(buf, s, 0);
+    mutt_extract_token(buf, s, MUTT_TOKEN_NO_FLAGS);
     if (mutt_str_strcmp("*", buf->data) == 0)
     {
       for (tmp = ScoreList; tmp;)

--- a/sendlib.c
+++ b/sendlib.c
@@ -2293,9 +2293,9 @@ int mutt_rfc822_write_header(FILE *fp, struct Envelope *env,
   {
     if (hide_protected_subject &&
         ((mode == MUTT_WRITE_HEADER_NORMAL) || (mode == MUTT_WRITE_HEADER_POSTPONE)))
-      mutt_write_one_header(fp, "Subject", C_CryptProtectedHeadersSubject, NULL, 0, 0);
+      mutt_write_one_header(fp, "Subject", C_CryptProtectedHeadersSubject, NULL, 0, CH_NO_FLAGS);
     else
-      mutt_write_one_header(fp, "Subject", env->subject, NULL, 0, 0);
+      mutt_write_one_header(fp, "Subject", env->subject, NULL, 0, CH_NO_FLAGS);
   }
   else if (mode == MUTT_WRITE_HEADER_EDITHDRS)
     fputs("Subject:\n", fp);
@@ -2371,7 +2371,7 @@ int mutt_rfc822_write_header(FILE *fp, struct Envelope *env,
         }
       }
 
-      mutt_write_one_header(fp, tmp->data, p, NULL, 0, 0);
+      mutt_write_one_header(fp, tmp->data, p, NULL, 0, CH_NO_FLAGS);
       *q = ':';
     }
   }
@@ -2717,7 +2717,7 @@ int mutt_invoke_sendmail(struct Address *from, struct Address *to, struct Addres
     char cmd[1024];
 
     mutt_expando_format(cmd, sizeof(cmd), 0, MuttIndexWindow->cols,
-                        NONULL(C_Inews), nntp_format_str, 0, 0);
+                        NONULL(C_Inews), nntp_format_str, 0, MUTT_FORMAT_NO_FLAGS);
     if (!*cmd)
     {
       i = nntp_post(Context->mailbox, msg);
@@ -2847,7 +2847,8 @@ int mutt_invoke_sendmail(struct Address *from, struct Address *to, struct Addres
         struct stat st;
 
         if ((stat(childout, &st) == 0) && (st.st_size > 0))
-          mutt_do_pager(_("Output of the delivery process"), childout, 0, NULL);
+          mutt_do_pager(_("Output of the delivery process"), childout,
+                        MUTT_PAGER_NO_FLAGS, NULL);
       }
     }
   }

--- a/sidebar.c
+++ b/sidebar.c
@@ -267,7 +267,7 @@ static void make_sidebar_entry(char *buf, size_t buflen, int width, char *box,
   mutt_str_strfcpy(sbe->box, box, sizeof(sbe->box));
 
   mutt_expando_format(buf, buflen, 0, width, NONULL(C_SidebarFormat),
-                      sidebar_format_str, (unsigned long) sbe, 0);
+                      sidebar_format_str, (unsigned long) sbe, MUTT_FORMAT_NO_FLAGS);
 
   /* Force string to be exactly the right width */
   int w = mutt_strwidth(buf);

--- a/status.c
+++ b/status.c
@@ -372,12 +372,12 @@ static const char *status_format_str(char *buf, size_t buflen, size_t col, int c
   if (optional)
   {
     mutt_expando_format(buf, buflen, col, cols, if_str, status_format_str,
-                        (unsigned long) menu, 0);
+                        (unsigned long) menu, MUTT_FORMAT_NO_FLAGS);
   }
   else if (flags & MUTT_FORMAT_OPTIONAL)
   {
     mutt_expando_format(buf, buflen, col, cols, else_str, status_format_str,
-                        (unsigned long) menu, 0);
+                        (unsigned long) menu, MUTT_FORMAT_NO_FLAGS);
   }
 
   return src;
@@ -394,5 +394,5 @@ void menu_status_line(char *buf, size_t buflen, struct Menu *menu, const char *p
 {
   mutt_expando_format(buf, buflen, 0,
                       menu ? menu->statuswin->cols : MuttStatusWindow->cols, p,
-                      status_format_str, (unsigned long) menu, 0);
+                      status_format_str, (unsigned long) menu, MUTT_FORMAT_NO_FLAGS);
 }

--- a/test/pattern/extract.c
+++ b/test/pattern/extract.c
@@ -25,10 +25,10 @@ int mutt_extract_token(struct Buffer *dest, struct Buffer *tok, TokenFlags flags
     if (!qc)
     {
       if ((ISSPACE(ch) && !(flags & MUTT_TOKEN_SPACE)) ||
-          (ch == '#' && !(flags & MUTT_TOKEN_COMMENT)) ||
-          (ch == '=' && (flags & MUTT_TOKEN_EQUAL)) ||
-          (ch == '?' && (flags & MUTT_TOKEN_QUESTION)) ||
-          (ch == ';' && !(flags & MUTT_TOKEN_SEMICOLON)) ||
+          ((ch == '#') && !(flags & MUTT_TOKEN_COMMENT)) ||
+          ((ch == '=') && (flags & MUTT_TOKEN_EQUAL)) ||
+          ((ch == '?') && (flags & MUTT_TOKEN_QUESTION)) ||
+          ((ch == ';') && !(flags & MUTT_TOKEN_SEMICOLON)) ||
           ((flags & MUTT_TOKEN_PATTERN) && strchr("~%=!|", ch)))
       {
         break;
@@ -39,9 +39,9 @@ int mutt_extract_token(struct Buffer *dest, struct Buffer *tok, TokenFlags flags
 
     if (ch == qc)
       qc = 0; /* end of quote */
-    else if (!qc && (ch == '\'' || ch == '"') && !(flags & MUTT_TOKEN_QUOTE))
+    else if (!qc && ((ch == '\'') || (ch == '"')) && !(flags & MUTT_TOKEN_QUOTE))
       qc = ch;
-    else if (ch == '\\' && qc != '\'')
+    else if ((ch == '\\') && (qc != '\''))
     {
       if (!*tok->dptr)
         return -1; /* premature end of token */
@@ -80,7 +80,7 @@ int mutt_extract_token(struct Buffer *dest, struct Buffer *tok, TokenFlags flags
             mutt_buffer_addch(dest, ch);
       }
     }
-    else if (ch == '^' && (flags & MUTT_TOKEN_CONDENSE))
+    else if ((ch == '^') && (flags & MUTT_TOKEN_CONDENSE))
     {
       if (!*tok->dptr)
         return -1; /* premature end of token */
@@ -97,7 +97,7 @@ int mutt_extract_token(struct Buffer *dest, struct Buffer *tok, TokenFlags flags
         mutt_buffer_addch(dest, ch);
       }
     }
-    else if (ch == '`' && (!qc || qc == '"'))
+    else if ((ch == '`') && (!qc || (qc == '"')))
     {
       FILE *fp = NULL;
       pid_t pid;
@@ -119,7 +119,7 @@ int mutt_extract_token(struct Buffer *dest, struct Buffer *tok, TokenFlags flags
       } while (pc && *pc != '`');
       if (!pc)
       {
-        mutt_debug(1, "mismatched backticks\n");
+        mutt_debug(LL_DEBUG1, "mismatched backticks\n");
         return -1;
       }
       struct Buffer cmd;
@@ -140,7 +140,7 @@ int mutt_extract_token(struct Buffer *dest, struct Buffer *tok, TokenFlags flags
       pid = mutt_create_filter(cmd.data, NULL, &fp, NULL);
       if (pid < 0)
       {
-        mutt_debug(1, "unable to fork command: %s\n", cmd);
+        mutt_debug(LL_DEBUG1, "unable to fork command: %s\n", cmd);
         FREE(&cmd.data);
         return -1;
       }
@@ -155,7 +155,7 @@ int mutt_extract_token(struct Buffer *dest, struct Buffer *tok, TokenFlags flags
       mutt_wait_filter(pid);
 
       /* if we got output, make a new string consisting of the shell output
-         plus whatever else was left on the original line */
+       * plus whatever else was left on the original line */
       /* BUT: If this is inside a quoted string, directly add output to
        * the token */
       if (expn.data && qc)
@@ -179,8 +179,8 @@ int mutt_extract_token(struct Buffer *dest, struct Buffer *tok, TokenFlags flags
         FREE(&expn.data);
       }
     }
-    else if (ch == '$' && (!qc || qc == '"') &&
-             (*tok->dptr == '{' || isalpha((unsigned char) *tok->dptr)))
+    else if ((ch == '$') && (!qc || (qc == '"')) &&
+             ((*tok->dptr == '{') || isalpha((unsigned char) *tok->dptr)))
     {
       const char *env = NULL;
       char *var = NULL;


### PR DESCRIPTION
- c2b2e100b test: sync mutt_extract_token()
- 253e5dc7e boolify mutt_sig_allow_interrupt()
- f4abf3eb4 unify variable names
- 31ba61d73 use MUTT_TOKEN_NO_FLAGS
- 7eccb18dd reduce scope of variables
- 760358834 rename 'hdr' variables
- 85c0cc368 Replace 0 flags with their NO_FLAGS equivalent
