### PR TITLE
fix setting the 'replied' flag

### DIFF
--- a/maildir/maildir.c
+++ b/maildir/maildir.c
@@ -507,7 +507,10 @@ int maildir_mbox_check(struct Mailbox *m, int *index_hint)
   /* Incorporate new messages */
   num_new = maildir_move_to_mailbox(m, &md);
   if (num_new > 0)
+  {
     mutt_mailbox_changed(m, MBN_INVALID);
+    m->changed = true;
+  }
 
   mutt_buffer_pool_release(&buf);
 

--- a/maildir/mh.c
+++ b/maildir/mh.c
@@ -708,7 +708,10 @@ int mh_mbox_check(struct Mailbox *m, int *index_hint)
   /* Incorporate new messages */
   num_new = maildir_move_to_mailbox(m, &md);
   if (num_new > 0)
+  {
     mutt_mailbox_changed(m, MBN_INVALID);
+    m->changed = true;
+  }
 
   if (occult)
     return MUTT_REOPENED;

--- a/send.c
+++ b/send.c
@@ -2457,10 +2457,7 @@ int ci_send_message(SendFlags flags, struct Email *msg, const char *tempfile,
    * In-Reply-To: and References: headers during edit */
   if (flags & SEND_REPLY)
   {
-    if (cur && ctx)
-      mutt_set_flag(ctx->mailbox, cur, MUTT_REPLIED, is_reply(cur, msg));
-    else if (!(flags & SEND_POSTPONED) && ctx && ctx->mailbox &&
-             (ctx->mailbox->msg_tagged != 0))
+    if (!(flags & SEND_POSTPONED) && ctx && ctx->mailbox)
     {
       STAILQ_FOREACH(en, el, entries)
       {

--- a/sendlib.c
+++ b/sendlib.c
@@ -3146,6 +3146,7 @@ int mutt_write_fcc(const char *path, struct Email *e, const char *msgid,
   mutt_folder_hook(path, NULL);
 #endif
   struct Mailbox *m_fcc = mx_path_resolve(path);
+  bool old_append = m_fcc->append;
   struct Context *ctx_fcc = mx_mbox_open(m_fcc, MUTT_APPEND | MUTT_QUIET);
   if (!ctx_fcc)
   {
@@ -3333,6 +3334,7 @@ int mutt_write_fcc(const char *path, struct Email *e, const char *msgid,
     set_noconv_flags(e->content, false);
 
 done:
+  m_fcc->append = old_append;
 #ifdef RECORD_FOLDER_HOOK
   /* We ran a folder hook for the destination mailbox,
    * now we run it for the user's current mailbox */


### PR DESCRIPTION
When replying to an email, mark the original as 'replied'.

Fixes: #1647

**Notes**: `cur` used to refer to the `Email` to change.  It it was `NULL`, then the function would look for tagged `Email`s.  Now, the function is passed an `EmailList` to work on.