### PR TITLE
Tidy Buffer usage

### DIFF
--- a/config/cfgaccount.c
+++ b/config/cfgaccount.c
@@ -100,22 +100,19 @@ void ac_free(const struct ConfigSet *cs, struct CfgAccount **ac)
     return; /* LCOV_EXCL_LINE */
 
   char child[128];
-  struct Buffer err;
-  mutt_buffer_init(&err);
-  err.dsize = 256;
-  err.data = mutt_mem_calloc(1, err.dsize);
+  struct Buffer *err = mutt_buffer_pool_get();
 
   for (size_t i = 0; i < (*ac)->num_vars; i++)
   {
     snprintf(child, sizeof(child), "%s:%s", (*ac)->name, (*ac)->var_names[i]);
-    mutt_buffer_reset(&err);
-    int result = cs_str_reset(cs, child, &err);
+    mutt_buffer_reset(err);
+    int result = cs_str_reset(cs, child, err);
     if (CSR_RESULT(result) != CSR_SUCCESS)
-      mutt_debug(LL_DEBUG1, "reset failed for %s: %s\n", child, err.data);
+      mutt_debug(LL_DEBUG1, "reset failed for %s: %s\n", child, mutt_b2s(err));
     mutt_hash_delete(cs->hash, child, NULL);
   }
 
-  FREE(&err.data);
+  mutt_buffer_pool_release(&err);
   FREE(&(*ac)->name);
   FREE(&(*ac)->vars);
   FREE(ac);

--- a/config/set.c
+++ b/config/set.c
@@ -296,11 +296,6 @@ struct HashElem *cs_inherit_variable(const struct ConfigSet *cs,
   if (!cs || !parent)
     return NULL; /* LCOV_EXCL_LINE */
 
-  struct Buffer err;
-  mutt_buffer_init(&err);
-  err.dsize = 256;
-  err.data = calloc(1, err.dsize);
-
   struct Inheritance *i = mutt_mem_calloc(1, sizeof(*i));
   i->parent = parent;
   i->name = mutt_str_strdup(name);
@@ -312,7 +307,6 @@ struct HashElem *cs_inherit_variable(const struct ConfigSet *cs,
     FREE(&i);
   }
 
-  FREE(&err.data);
   return he;
 }
 

--- a/config/set.c
+++ b/config/set.c
@@ -263,23 +263,20 @@ bool cs_register_variables(const struct ConfigSet *cs, struct ConfigDef vars[], 
   if (!cs || !vars)
     return CSR_ERR_CODE; /* LCOV_EXCL_LINE */
 
-  struct Buffer err;
-  mutt_buffer_init(&err);
-  err.dsize = 256;
-  err.data = calloc(1, err.dsize);
+  struct Buffer *err = mutt_buffer_pool_get();
 
   bool rc = true;
 
   for (size_t i = 0; vars[i].name; i++)
   {
-    if (!reg_one_var(cs, &vars[i], &err))
+    if (!reg_one_var(cs, &vars[i], err))
     {
-      mutt_debug(LL_DEBUG1, "%s\n", err.data);
+      mutt_debug(LL_DEBUG1, "%s\n", mutt_b2s(err));
       rc = false;
     }
   }
 
-  FREE(&err.data);
+  mutt_buffer_pool_release(&err);
   return rc;
 }
 

--- a/init.c
+++ b/init.c
@@ -281,28 +281,26 @@ done:
  */
 static int execute_commands(struct ListHead *p)
 {
-  struct Buffer err, token;
+  int rc = 0;
+  struct Buffer *err = mutt_buffer_pool_get();
+  struct Buffer *token = mutt_buffer_pool_get();
 
-  mutt_buffer_init(&err);
-  err.dsize = 256;
-  err.data = mutt_mem_malloc(err.dsize);
-  mutt_buffer_init(&token);
   struct ListNode *np = NULL;
   STAILQ_FOREACH(np, p, entries)
   {
-    if (mutt_parse_rc_line(np->data, &token, &err) == MUTT_CMD_ERROR)
+    if (mutt_parse_rc_line(np->data, token, err) == MUTT_CMD_ERROR)
     {
-      mutt_error(_("Error in command line: %s"), err.data);
-      FREE(&token.data);
-      FREE(&err.data);
+      mutt_error(_("Error in command line: %s"), mutt_b2s(err));
+      mutt_buffer_pool_release(&token);
+      mutt_buffer_pool_release(&err);
 
       return -1;
     }
   }
-  FREE(&token.data);
-  FREE(&err.data);
+  mutt_buffer_pool_release(&token);
+  mutt_buffer_pool_release(&err);
 
-  return 0;
+  return rc;
 }
 
 /**

--- a/init.c
+++ b/init.c
@@ -2609,14 +2609,8 @@ void mutt_commands_apply(void *data, void (*application)(void *, const struct Co
 int mutt_dump_variables(bool hide_sensitive)
 {
   char cmd[256];
-
-  struct Buffer err, token;
-
-  mutt_buffer_init(&err);
-  mutt_buffer_init(&token);
-
-  err.dsize = 256;
-  err.data = mutt_mem_malloc(err.dsize);
+  struct Buffer *err = mutt_buffer_pool_get();
+  struct Buffer *token = mutt_buffer_pool_get();
 
   for (int i = 0; MuttVars[i].name; i++)
   {
@@ -2629,19 +2623,19 @@ int mutt_dump_variables(bool hide_sensitive)
       continue;
     }
     snprintf(cmd, sizeof(cmd), "set ?%s\n", MuttVars[i].name);
-    if (mutt_parse_rc_line(cmd, &token, &err) == MUTT_CMD_ERROR)
+    if (mutt_parse_rc_line(cmd, token, err) == MUTT_CMD_ERROR)
     {
-      mutt_message("%s", err.data);
-      FREE(&token.data);
-      FREE(&err.data);
+      mutt_message("%s", mutt_b2s(err));
+      mutt_buffer_pool_release(&token);
+      mutt_buffer_pool_release(&err);
 
       return 1; // TEST17: can't test
     }
-    mutt_message("%s", err.data);
+    mutt_message("%s", mutt_b2s(err));
   }
 
-  FREE(&token.data);
-  FREE(&err.data);
+  mutt_buffer_pool_release(&token);
+  mutt_buffer_pool_release(&err);
 
   return 0;
 }

--- a/mutt_lua.c
+++ b/mutt_lua.c
@@ -288,31 +288,27 @@ static int lua_mutt_get(lua_State *l)
 static int lua_mutt_enter(lua_State *l)
 {
   mutt_debug(LL_DEBUG2, " * lua_mutt_enter()\n");
-  struct Buffer token, err;
+  struct Buffer *err = mutt_buffer_pool_get();
+  struct Buffer *token = mutt_buffer_pool_get();
   char *buf = mutt_str_strdup(lua_tostring(l, -1));
   int rc = 0;
 
-  mutt_buffer_init(&err);
-  mutt_buffer_init(&token);
-
-  err.dsize = 256;
-  err.data = mutt_mem_malloc(err.dsize);
-
-  if (mutt_parse_rc_line(buf, &token, &err))
+  if (mutt_parse_rc_line(buf, token, err))
   {
-    luaL_error(l, "NeoMutt error: %s", err.data);
+    luaL_error(l, "NeoMutt error: %s", mutt_b2s(err));
     rc = -1;
   }
   else
   {
-    if (!lua_pushstring(l, err.data))
+    if (!lua_pushstring(l, mutt_b2s(err)))
       handle_error(l);
     else
       rc++;
   }
 
   FREE(&buf);
-  FREE(&err.data);
+  mutt_buffer_pool_release(&token);
+  mutt_buffer_pool_release(&err);
 
   return rc;
 }


### PR DESCRIPTION
Simplify functions by allocating Buffers on the heap, rather than using ones on the stack.

