### PR TITLE
Refactor conditionals with increments

### DIFF
--- a/mutt/file.c
+++ b/mutt/file.c
@@ -1157,12 +1157,16 @@ int mutt_file_lock(int fd, bool excl, bool timeout)
       prev_sb = sb;
 
     /* only unlock file if it is unchanged */
-    if ((prev_sb.st_size == sb.st_size) && (++count >= (timeout ? MAX_LOCK_ATTEMPTS : 0)))
+    if (prev_sb.st_size == sb.st_size)
     {
-      if (timeout)
-        mutt_error(_("Timeout exceeded while attempting flock lock"));
-      rc = -1;
-      break;
+      count++;
+      if (count >= (timeout ? MAX_LOCK_ATTEMPTS : 0))
+      {
+        if (timeout)
+          mutt_error(_("Timeout exceeded while attempting flock lock"));
+        rc = -1;
+        break;
+      }
     }
 
     prev_sb = sb;

--- a/mutt/file.c
+++ b/mutt/file.c
@@ -1085,11 +1085,15 @@ int mutt_file_lock(int fd, bool excl, bool timeout)
       prev_sb = sb;
 
     /* only unlock file if it is unchanged */
-    if ((prev_sb.st_size == sb.st_size) && (++count >= (timeout ? MAX_LOCK_ATTEMPTS : 0)))
+    if (prev_sb.st_size == sb.st_size)
     {
-      if (timeout)
-        mutt_error(_("Timeout exceeded while attempting fcntl lock"));
-      return -1;
+      count++;
+      if (count >= (timeout ? MAX_LOCK_ATTEMPTS : 0))
+      {
+        if (timeout)
+          mutt_error(_("Timeout exceeded while attempting fcntl lock"));
+        return -1;
+      }
     }
 
     prev_sb = sb;

--- a/pager.c
+++ b/pager.c
@@ -2082,11 +2082,15 @@ static void pager_custom_redraw(struct Menu *pager_menu)
                         &rd->quote_list, &rd->q_level, &rd->force_redraw,
                         &rd->search_re, rd->pager_window) == 0)
     {
-      if (!rd->line_info[i].continuation && (++j == rd->lines))
+      if (!rd->line_info[i].continuation)
       {
-        rd->topline = i;
-        if (!rd->search_flag)
-          break;
+        j++;
+        if (j == rd->lines)
+        {
+          rd->topline = i;
+          if (!rd->search_flag)
+            break;
+        }
       }
     }
   }

--- a/sendlib.c
+++ b/sendlib.c
@@ -1832,14 +1832,19 @@ static int print_val(FILE *fp, const char *pfx, const char *value,
   {
     if (fputc(*value, fp) == EOF)
       return -1;
-    /* corner-case: break words longer than 998 chars by force,
-     * mandated by RFC5322 */
-    if (!(chflags & CH_DISPLAY) && (++col >= 998))
+
+    if (!(chflags & CH_DISPLAY))
     {
-      if (fputs("\n ", fp) < 0)
-        return -1;
-      col = 1;
+      col++;
+      /* break words longer than 998 chars by force, mandated by RFC5322 */
+      if (col >= 998)
+      {
+        if (fputs("\n ", fp) < 0)
+          return -1;
+        col = 1;
+      }
     }
+
     if (*value == '\n')
     {
       if (*(value + 1) && pfx && *pfx && (fputs(pfx, fp) == EOF))


### PR DESCRIPTION
Consider the conditional:
```c
if (is_valid && (++num > 10))
{
  action();
}
```

Here, `num` is only incremented if the `is_valid` is true.

These commits refactor the code to be equivalent to:

```c
if (is_valid)
{
  num++;
  if (num > 10)
  {
    action();
  }
}
```

This makes it clear when the number is being incremented.