### PR TITLE
promote two functions to libmutt

### DIFF
--- a/browser.c
+++ b/browser.c
@@ -1190,7 +1190,7 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
           mutt_buffer_strcpy_n(LastDir, mutt_b2s(file), i);
         else
         {
-          mutt_getcwd(LastDir);
+          mutt_path_getcwd(LastDir);
           mutt_buffer_addch(LastDir, '/');
           mutt_buffer_addstr_n(LastDir, mutt_b2s(file), i);
         }
@@ -1200,7 +1200,7 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
         if ((mutt_b2s(file))[0] == '/')
           mutt_buffer_strcpy(LastDir, "/");
         else
-          mutt_getcwd(LastDir);
+          mutt_path_getcwd(LastDir);
       }
 
       if ((i <= 0) && (mutt_b2s(file)[0] != '/'))
@@ -1215,7 +1215,7 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
   else
   {
     if (!folder)
-      mutt_getcwd(LastDir);
+      mutt_path_getcwd(LastDir);
     else
     {
       /* Whether we use the tracking feature of the browser depends
@@ -1296,7 +1296,7 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
         LastDir->data[i] = '\0';
       mutt_buffer_fix_dptr(LastDir);
       if (mutt_b2s(LastDir)[0] == '\0')
-        mutt_getcwd(LastDir);
+        mutt_path_getcwd(LastDir);
     }
   }
 

--- a/browser.h
+++ b/browser.h
@@ -107,6 +107,5 @@ void mutt_select_file(char *file, size_t filelen, SelectFileFlags flags, char **
 void mutt_buffer_select_file(struct Buffer *f, SelectFileFlags flags, char ***files, int *numfiles);
 void mutt_browser_select_dir(const char *f);
 void mutt_browser_cleanup(void);
-void mutt_buffer_concat_path(struct Buffer *d, const char *dir, const char *fname);
 
 #endif /* MUTT_BROWSER_H */

--- a/mutt/buffer.c
+++ b/mutt/buffer.c
@@ -455,6 +455,9 @@ size_t mutt_buffer_len(const struct Buffer *buf)
  */
 void mutt_buffer_concat_path(struct Buffer *buf, const char *dir, const char *fname)
 {
+  if (!buf || !dir || !fname)
+    return;
+
   const char *fmt = "%s/%s";
 
   if ((fname[0] == '\0') || ((dir[0] != '\0') && (dir[strlen(dir) - 1] == '/')))

--- a/mutt/buffer.c
+++ b/mutt/buffer.c
@@ -443,3 +443,22 @@ size_t mutt_buffer_len(const struct Buffer *buf)
 
   return buf->dptr - buf->data;
 }
+
+/**
+ * mutt_buffer_concat_path - Join a directory name and a filename
+ * @param buf   Buffer to add to
+ * @param dir   Directory name
+ * @param fname File name
+ *
+ * If both dir and fname are supplied, they are separated with '/'.
+ * If either is missing, then the other will be copied exactly.
+ */
+void mutt_buffer_concat_path(struct Buffer *buf, const char *dir, const char *fname)
+{
+  const char *fmt = "%s/%s";
+
+  if ((fname[0] == '\0') || ((dir[0] != '\0') && (dir[strlen(dir) - 1] == '/')))
+    fmt = "%s%s";
+
+  mutt_buffer_printf(buf, fmt, dir, fname);
+}

--- a/mutt/buffer.h
+++ b/mutt/buffer.h
@@ -48,6 +48,7 @@ size_t         mutt_buffer_addstr       (struct Buffer *buf, const char *s);
 size_t         mutt_buffer_addstr_n     (struct Buffer *buf, const char *s, size_t len);
 int            mutt_buffer_add_printf   (struct Buffer *buf, const char *fmt, ...);
 struct Buffer *mutt_buffer_alloc        (size_t size);
+void           mutt_buffer_concat_path  (struct Buffer *buf, const char *dir, const char *fname);
 void           mutt_buffer_fix_dptr     (struct Buffer *buf);
 void           mutt_buffer_free         (struct Buffer **p);
 struct Buffer *mutt_buffer_from         (const char *seed);

--- a/mutt/path.c
+++ b/mutt/path.c
@@ -36,6 +36,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include "buffer.h"
 #include "logging.h"
 #include "memory.h"
 #include "message.h"
@@ -566,4 +567,23 @@ char *mutt_path_escape(const char *src)
   *destp = '\0';
 
   return dest;
+}
+
+/**
+ * mutt_path_getcwd - Get the current working directory
+ * @param cwd Buffer for the result
+ */
+void mutt_path_getcwd(struct Buffer *cwd)
+{
+  mutt_buffer_increase_size(cwd, PATH_MAX);
+  char *retval = getcwd(cwd->data, cwd->dsize);
+  while (!retval && (errno == ERANGE))
+  {
+    mutt_buffer_increase_size(cwd, cwd->dsize + 256);
+    retval = getcwd(cwd->data, cwd->dsize);
+  }
+  if (retval)
+    mutt_buffer_fix_dptr(cwd);
+  else
+    mutt_buffer_reset(cwd);
 }

--- a/mutt/path.c
+++ b/mutt/path.c
@@ -575,6 +575,9 @@ char *mutt_path_escape(const char *src)
  */
 void mutt_path_getcwd(struct Buffer *cwd)
 {
+  if (!cwd)
+    return;
+
   mutt_buffer_increase_size(cwd, PATH_MAX);
   char *retval = getcwd(cwd->data, cwd->dsize);
   while (!retval && (errno == ERANGE))

--- a/mutt/path.h
+++ b/mutt/path.h
@@ -26,6 +26,8 @@
 #include <stdbool.h>
 #include <stdio.h>
 
+struct Buffer;
+
 bool        mutt_path_abbr_folder(char *buf, size_t buflen, const char *folder);
 const char *mutt_path_basename(const char *f);
 bool        mutt_path_canon(char *buf, size_t buflen, const char *homedir);
@@ -33,6 +35,7 @@ char *      mutt_path_concat(char *d, const char *dir, const char *fname, size_t
 char *      mutt_path_concatn(char *dst, size_t dstlen, const char *dir, size_t dirlen, const char *fname, size_t fnamelen);
 char *      mutt_path_dirname(const char *path);
 char *      mutt_path_escape(const char *src);
+void        mutt_path_getcwd(struct Buffer *cwd);
 bool        mutt_path_parent(char *buf, size_t buflen);
 bool        mutt_path_pretty(char *buf, size_t buflen, const char *homedir);
 size_t      mutt_path_realpath(char *buf);

--- a/muttlib.c
+++ b/muttlib.c
@@ -1712,22 +1712,3 @@ int mutt_inbox_cmp(const char *a, const char *b)
 
   return 0;
 }
-
-/**
- * mutt_buffer_concat_path - Join a directory name and a filename
- * @param d     Buffer to add to
- * @param dir   Directory name
- * @param fname File name
- *
- * If both dir and fname are supplied, they are separated with '/'.
- * If either is missing, then the other will be copied exactly.
- */
-void mutt_buffer_concat_path(struct Buffer *d, const char *dir, const char *fname)
-{
-  const char *fmt = "%s/%s";
-
-  if (!*fname || (*dir && dir[strlen(dir) - 1] == '/'))
-    fmt = "%s%s";
-
-  mutt_buffer_printf(d, fmt, dir, fname);
-}

--- a/muttlib.c
+++ b/muttlib.c
@@ -1731,22 +1731,3 @@ void mutt_buffer_concat_path(struct Buffer *d, const char *dir, const char *fnam
 
   mutt_buffer_printf(d, fmt, dir, fname);
 }
-
-/**
- * mutt_getcwd - Get the current working directory
- * @param cwd Buffer for the result
- */
-void mutt_getcwd(struct Buffer *cwd)
-{
-  mutt_buffer_increase_size(cwd, PATH_MAX);
-  char *retval = getcwd(cwd->data, cwd->dsize);
-  while (!retval && (errno == ERANGE))
-  {
-    mutt_buffer_increase_size(cwd, cwd->dsize + 256);
-    retval = getcwd(cwd->data, cwd->dsize);
-  }
-  if (retval)
-    mutt_buffer_fix_dptr(cwd);
-  else
-    mutt_buffer_reset(cwd);
-}

--- a/muttlib.h
+++ b/muttlib.h
@@ -54,7 +54,6 @@ void        mutt_expando_format(char *buf, size_t buflen, size_t col, int cols, 
 char *      mutt_expand_path(char *s, size_t slen);
 char *      mutt_expand_path_regex(char *buf, size_t buflen, bool regex);
 char *      mutt_gecos_name(char *dest, size_t destlen, struct passwd *pw);
-void        mutt_getcwd(struct Buffer *cwd);
 void        mutt_get_parent_path(const char *path, char *buf, size_t buflen);
 int         mutt_inbox_cmp(const char *a, const char *b);
 bool        mutt_is_text_part(struct Body *b);

--- a/test/Makefile.autosetup
+++ b/test/Makefile.autosetup
@@ -1,5 +1,6 @@
 TEST_OBJS   = test/main.o \
 	      test/base64.o \
+	      test/buffer.o \
 	      test/md5.o \
 	      test/path.o \
 	      test/rfc2047.o \

--- a/test/buffer.c
+++ b/test/buffer.c
@@ -1,0 +1,55 @@
+/**
+ * @file
+ * Test code for Buffers
+ *
+ * @authors
+ * Copyright (C) 2019 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define TEST_NO_MAIN
+#include "acutest.h"
+#include "config.h"
+#include "mutt/mutt.h"
+
+void test_mutt_buffer_concat_path(void)
+{
+  // void mutt_buffer_concat_path(struct Buffer *buf, const char *dir, const char *fname)
+
+  {
+    mutt_buffer_concat_path(NULL, "apple", "banana");
+    TEST_CHECK_(1, "mutt_buffer_concat_path(NULL, \"apple\", \"banana\")");
+  }
+
+  {
+    struct Buffer buf = { 0 };
+    mutt_buffer_concat_path(&buf, NULL, "banana");
+    TEST_CHECK_(1, "mutt_buffer_concat_path(&buf, NULL, \"banana\")");
+  }
+
+  {
+    struct Buffer buf = { 0 };
+    mutt_buffer_concat_path(&buf, "apple", NULL);
+    TEST_CHECK_(1, "mutt_buffer_concat_path(&buf, \"apple\", NULL)");
+  }
+
+  {
+    struct Buffer *buf = mutt_buffer_new();
+    mutt_buffer_concat_path(buf, "apple", "banana");
+    TEST_CHECK(strcmp(mutt_b2s(buf), "apple/banana") == 0);
+    mutt_buffer_free(&buf);
+  }
+}

--- a/test/main.c
+++ b/test/main.c
@@ -17,7 +17,9 @@
   NEOMUTT_TEST_ITEM(test_mutt_path_tidy_slash)                                 \
   NEOMUTT_TEST_ITEM(test_mutt_path_tidy_dotdot)                                \
   NEOMUTT_TEST_ITEM(test_mutt_path_tidy)                                       \
-  NEOMUTT_TEST_ITEM(test_url)
+  NEOMUTT_TEST_ITEM(test_url)                                                  \
+  NEOMUTT_TEST_ITEM(test_mutt_buffer_concat_path)                              \
+  NEOMUTT_TEST_ITEM(test_mutt_path_getcwd)
 
 /******************************************************************************
  * You probably don't need to touch what follows.

--- a/test/path.c
+++ b/test/path.c
@@ -1,8 +1,28 @@
+/**
+ * @file
+ * Test code for paths
+ *
+ * @authors
+ * Copyright (C) 2018-2019 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #define TEST_NO_MAIN
 #include "acutest.h"
-#include "mutt/memory.h"
-#include "mutt/path.h"
-#include "mutt/string2.h"
+#include "mutt/mutt.h"
 
 void test_mutt_path_tidy_slash(void)
 {
@@ -225,3 +245,19 @@ void test_mutt_path_tidy(void)
   }
 }
 
+void test_mutt_path_getcwd(void)
+{
+  // void mutt_path_getcwd(struct Buffer *cwd)
+
+  {
+    mutt_path_getcwd(NULL);
+    TEST_CHECK_(1, "mutt_path_getcwd(NULL)");
+  }
+
+  {
+    struct Buffer *buf = mutt_buffer_new();
+    mutt_path_getcwd(buf);
+    TEST_CHECK(buf->data[0] == '/');
+    mutt_buffer_free(&buf);
+  }
+}


### PR DESCRIPTION
Upstream introduced two new functions.  Move them to libmutt.
- `mutt_buffer_concat_path()`
- `mutt_path_getcwd()`