### PR TITLE
Trivial fixes

### DIFF
--- a/account.h
+++ b/account.h
@@ -41,7 +41,6 @@ struct Account
   void *adata;
   void (*free_adata)(void **);
 };
-
 TAILQ_HEAD(AccountList, Account);
 
 extern struct AccountList AllAccounts; ///< List of all Accounts

--- a/alias.h
+++ b/alias.h
@@ -42,7 +42,6 @@ struct Alias
   short num;
   TAILQ_ENTRY(Alias) entries;
 };
-
 TAILQ_HEAD(AliasList, Alias);
 
 void            mutt_alias_create(struct Envelope *cur, struct Address *iaddr);

--- a/browser.c
+++ b/browser.c
@@ -2051,7 +2051,7 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
               break;
             }
 
-            int err = REGCOMP(&rx, s, REG_NOSUB);
+            int err = REG_COMP(&rx, s, REG_NOSUB);
             if (err != 0)
             {
               regerror(err, &rx, buf->data, buf->dsize);

--- a/browser.c
+++ b/browser.c
@@ -1105,7 +1105,7 @@ void mutt_browser_select_dir(const char *f)
 }
 
 /**
- * mutt_select_file - Let the user select a file
+ * mutt_buffer_select_file - Let the user select a file
  * @param[in]  file     Buffer for the result
  * @param[in]  flags    Flags, see #SelectFileFlags
  * @param[out] files    Array of selected files

--- a/color.c
+++ b/color.c
@@ -819,7 +819,7 @@ static enum CommandResult add_pattern(struct ColorLineHead *top, const char *s,
       else
         flags = REG_ICASE;
 
-      const int r = REGCOMP(&tmp->regex, s, flags);
+      const int r = REG_COMP(&tmp->regex, s, flags);
       if (r != 0)
       {
         regerror(r, &tmp->regex, err->data, err->dsize);

--- a/commands.c
+++ b/commands.c
@@ -1015,7 +1015,7 @@ int mutt_save_message(struct Mailbox *m, struct EmailList *el, bool delete,
   mutt_default_save(buf, sizeof(buf), en->email);
 
   mutt_pretty_mailbox(buf, sizeof(buf));
-  if (mutt_enter_fname(prompt, buf, sizeof(buf), 0) == -1)
+  if (mutt_enter_fname(prompt, buf, sizeof(buf), false) == -1)
     return -1;
 
   size_t pathlen = strlen(buf);

--- a/commands.c
+++ b/commands.c
@@ -557,7 +557,9 @@ static int pipe_message(struct Mailbox *m, struct EmailList *el, char *cmd,
       mutt_parse_mime_message(m, en->email);
       if ((en->email->security & SEC_ENCRYPT) &&
           !crypt_valid_passphrase(en->email->security))
+      {
         return 1;
+      }
     }
     mutt_endwin();
 

--- a/compose.c
+++ b/compose.c
@@ -98,7 +98,7 @@ static const char *There_are_no_attachments = N_("There are no attachments");
     break;                                                                     \
   }
 
-#define CURATTACH actx->idx[actx->v2r[menu->current]]
+#define CUR_ATTACH actx->idx[actx->v2r[menu->current]]
 
 /**
  * enum HeaderField - Ordered list of headers for the compose screen
@@ -267,7 +267,7 @@ static void snd_make_entry(char *buf, size_t buflen, struct Menu *menu, int line
  */
 static void redraw_crypt_lines(struct Email *msg)
 {
-  SETCOLOR(MT_COLOR_COMPOSE_HEADER);
+  SET_COLOR(MT_COLOR_COMPOSE_HEADER);
   mutt_window_mvprintw(MuttIndexWindow, HDR_CRYPT, 0, "%*s",
                        HeaderPadding[HDR_CRYPT], _(Prompts[HDR_CRYPT]));
   NORMAL_COLOR;
@@ -280,23 +280,23 @@ static void redraw_crypt_lines(struct Email *msg)
 
   if ((msg->security & (SEC_ENCRYPT | SEC_SIGN)) == (SEC_ENCRYPT | SEC_SIGN))
   {
-    SETCOLOR(MT_COLOR_COMPOSE_SECURITY_BOTH);
+    SET_COLOR(MT_COLOR_COMPOSE_SECURITY_BOTH);
     addstr(_("Sign, Encrypt"));
   }
   else if (msg->security & SEC_ENCRYPT)
   {
-    SETCOLOR(MT_COLOR_COMPOSE_SECURITY_ENCRYPT);
+    SET_COLOR(MT_COLOR_COMPOSE_SECURITY_ENCRYPT);
     addstr(_("Encrypt"));
   }
   else if (msg->security & SEC_SIGN)
   {
-    SETCOLOR(MT_COLOR_COMPOSE_SECURITY_SIGN);
+    SET_COLOR(MT_COLOR_COMPOSE_SECURITY_SIGN);
     addstr(_("Sign"));
   }
   else
   {
     /* L10N: This refers to the encryption of the email, e.g. "Security: None" */
-    SETCOLOR(MT_COLOR_COMPOSE_SECURITY_NONE);
+    SET_COLOR(MT_COLOR_COMPOSE_SECURITY_NONE);
     addstr(_("None"));
   }
   NORMAL_COLOR;
@@ -324,7 +324,7 @@ static void redraw_crypt_lines(struct Email *msg)
   if (((WithCrypto & APPLICATION_PGP) != 0) &&
       (msg->security & APPLICATION_PGP) && (msg->security & SEC_SIGN))
   {
-    SETCOLOR(MT_COLOR_COMPOSE_HEADER);
+    SET_COLOR(MT_COLOR_COMPOSE_HEADER);
     printw("%*s", HeaderPadding[HDR_CRYPTINFO], _(Prompts[HDR_CRYPTINFO]));
     NORMAL_COLOR;
     printw("%s", C_PgpSignAs ? C_PgpSignAs : _("<default>"));
@@ -333,7 +333,7 @@ static void redraw_crypt_lines(struct Email *msg)
   if (((WithCrypto & APPLICATION_SMIME) != 0) &&
       (msg->security & APPLICATION_SMIME) && (msg->security & SEC_SIGN))
   {
-    SETCOLOR(MT_COLOR_COMPOSE_HEADER);
+    SET_COLOR(MT_COLOR_COMPOSE_HEADER);
     printw("%*s", HeaderPadding[HDR_CRYPTINFO], _(Prompts[HDR_CRYPTINFO]));
     NORMAL_COLOR;
     printw("%s", C_SmimeSignAs ? C_SmimeSignAs : _("<default>"));
@@ -342,7 +342,7 @@ static void redraw_crypt_lines(struct Email *msg)
   if (((WithCrypto & APPLICATION_SMIME) != 0) && (msg->security & APPLICATION_SMIME) &&
       (msg->security & SEC_ENCRYPT) && C_SmimeEncryptWith && *C_SmimeEncryptWith)
   {
-    SETCOLOR(MT_COLOR_COMPOSE_HEADER);
+    SET_COLOR(MT_COLOR_COMPOSE_HEADER);
     mutt_window_mvprintw(MuttIndexWindow, HDR_CRYPTINFO, 40, "%s", _("Encrypt with: "));
     NORMAL_COLOR;
     printw("%s", NONULL(C_SmimeEncryptWith));
@@ -358,7 +358,7 @@ static void redraw_mix_line(struct ListHead *chain)
 {
   char *t = NULL;
 
-  SETCOLOR(MT_COLOR_COMPOSE_HEADER);
+  SET_COLOR(MT_COLOR_COMPOSE_HEADER);
   mutt_window_mvprintw(MuttIndexWindow, HDR_MIX, 0, "%*s",
                        HeaderPadding[HDR_MIX], _(Prompts[HDR_MIX]));
   NORMAL_COLOR;
@@ -440,7 +440,7 @@ static void draw_envelope_addr(int line, struct Address *addr)
 
   buf[0] = '\0';
   mutt_addr_write(buf, sizeof(buf), addr, true);
-  SETCOLOR(MT_COLOR_COMPOSE_HEADER);
+  SET_COLOR(MT_COLOR_COMPOSE_HEADER);
   mutt_window_mvprintw(MuttIndexWindow, line, 0, "%*s", HeaderPadding[line],
                        _(Prompts[line]));
   NORMAL_COLOR;
@@ -481,7 +481,7 @@ static void draw_envelope(struct Email *msg, char *fcc)
   }
 #endif
 
-  SETCOLOR(MT_COLOR_COMPOSE_HEADER);
+  SET_COLOR(MT_COLOR_COMPOSE_HEADER);
   mutt_window_mvprintw(MuttIndexWindow, HDR_SUBJECT, 0, "%*s",
                        HeaderPadding[HDR_SUBJECT], _(Prompts[HDR_SUBJECT]));
   NORMAL_COLOR;
@@ -489,7 +489,7 @@ static void draw_envelope(struct Email *msg, char *fcc)
 
   draw_envelope_addr(HDR_REPLYTO, msg->env->reply_to);
 
-  SETCOLOR(MT_COLOR_COMPOSE_HEADER);
+  SET_COLOR(MT_COLOR_COMPOSE_HEADER);
   mutt_window_mvprintw(MuttIndexWindow, HDR_FCC, 0, "%*s",
                        HeaderPadding[HDR_FCC], _(Prompts[HDR_FCC]));
   NORMAL_COLOR;
@@ -502,7 +502,7 @@ static void draw_envelope(struct Email *msg, char *fcc)
   redraw_mix_line(&msg->chain);
 #endif
 
-  SETCOLOR(MT_COLOR_STATUS);
+  SET_COLOR(MT_COLOR_STATUS);
   mutt_window_mvaddstr(MuttIndexWindow, HDR_ATTACH - 1, 0, _("-- Attachments"));
   mutt_window_clrtoeol(MuttIndexWindow);
 
@@ -699,7 +699,7 @@ static void compose_custom_redraw(struct Menu *menu)
     compose_status_line(buf, sizeof(buf), 0, MuttStatusWindow->cols, menu,
                         NONULL(C_ComposeFormat));
     mutt_window_move(MuttStatusWindow, 0, 0);
-    SETCOLOR(MT_COLOR_STATUS);
+    SET_COLOR(MT_COLOR_STATUS);
     mutt_paddstr(MuttStatusWindow->cols, buf);
     NORMAL_COLOR;
     menu->redraw &= ~REDRAW_STATUS;
@@ -1518,8 +1518,8 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
 
       case OP_DELETE:
         CHECK_COUNT;
-        if (CURATTACH->unowned)
-          CURATTACH->content->unlink = false;
+        if (CUR_ATTACH->unowned)
+          CUR_ATTACH->content->unlink = false;
         if (delete_attachment(actx, menu->current) == -1)
           break;
         mutt_update_compose_menu(actx, menu, false);
@@ -1532,13 +1532,13 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
       case OP_COMPOSE_TOGGLE_RECODE:
       {
         CHECK_COUNT;
-        if (!mutt_is_text_part(CURATTACH->content))
+        if (!mutt_is_text_part(CUR_ATTACH->content))
         {
           mutt_error(_("Recoding only affects text attachments"));
           break;
         }
-        CURATTACH->content->noconv = !CURATTACH->content->noconv;
-        if (CURATTACH->content->noconv)
+        CUR_ATTACH->content->noconv = !CUR_ATTACH->content->noconv;
+        if (CUR_ATTACH->content->noconv)
           mutt_message(_("The current attachment won't be converted"));
         else
           mutt_message(_("The current attachment will be converted"));
@@ -1549,13 +1549,13 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
 
       case OP_COMPOSE_EDIT_DESCRIPTION:
         CHECK_COUNT;
-        mutt_str_strfcpy(buf,
-                         CURATTACH->content->description ? CURATTACH->content->description : "",
-                         sizeof(buf));
+        mutt_str_strfcpy(
+            buf, CUR_ATTACH->content->description ? CUR_ATTACH->content->description : "",
+            sizeof(buf));
         /* header names should not be translated */
         if (mutt_get_field("Description: ", buf, sizeof(buf), 0) == 0)
         {
-          mutt_str_replace(&CURATTACH->content->description, buf);
+          mutt_str_replace(&CUR_ATTACH->content->description, buf);
           menu->redraw = REDRAW_CURRENT;
         }
         mutt_message_hook(NULL, msg, MUTT_SEND2_HOOK);
@@ -1575,7 +1575,7 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
         }
         else
         {
-          mutt_update_encoding(CURATTACH->content);
+          mutt_update_encoding(CUR_ATTACH->content);
           menu->redraw = REDRAW_CURRENT | REDRAW_STATUS;
         }
         mutt_message_hook(NULL, msg, MUTT_SEND2_HOOK);
@@ -1583,18 +1583,18 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
 
       case OP_COMPOSE_TOGGLE_DISPOSITION:
         /* toggle the content-disposition between inline/attachment */
-        CURATTACH->content->disposition =
-            (CURATTACH->content->disposition == DISP_INLINE) ? DISP_ATTACH : DISP_INLINE;
+        CUR_ATTACH->content->disposition =
+            (CUR_ATTACH->content->disposition == DISP_INLINE) ? DISP_ATTACH : DISP_INLINE;
         menu->redraw = REDRAW_CURRENT;
         break;
 
       case OP_EDIT_TYPE:
         CHECK_COUNT;
         {
-          mutt_edit_content_type(NULL, CURATTACH->content, NULL);
+          mutt_edit_content_type(NULL, CUR_ATTACH->content, NULL);
 
           /* this may have been a change to text/something */
-          mutt_update_encoding(CURATTACH->content);
+          mutt_update_encoding(CUR_ATTACH->content);
 
           menu->redraw = REDRAW_CURRENT;
         }
@@ -1604,11 +1604,11 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
       case OP_COMPOSE_EDIT_LANGUAGE:
         CHECK_COUNT;
         buf[0] = '\0'; /* clear buffer first */
-        if (CURATTACH->content->language)
-          mutt_str_strfcpy(buf, CURATTACH->content->language, sizeof(buf));
+        if (CUR_ATTACH->content->language)
+          mutt_str_strfcpy(buf, CUR_ATTACH->content->language, sizeof(buf));
         if (mutt_get_field("Content-Language: ", buf, sizeof(buf), 0) == 0)
         {
-          CURATTACH->content->language = mutt_str_strdup(buf);
+          CUR_ATTACH->content->language = mutt_str_strdup(buf);
           menu->redraw = REDRAW_CURRENT | REDRAW_STATUS;
           mutt_clear_error();
         }
@@ -1619,14 +1619,14 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
 
       case OP_COMPOSE_EDIT_ENCODING:
         CHECK_COUNT;
-        mutt_str_strfcpy(buf, ENCODING(CURATTACH->content->encoding), sizeof(buf));
+        mutt_str_strfcpy(buf, ENCODING(CUR_ATTACH->content->encoding), sizeof(buf));
         if ((mutt_get_field("Content-Transfer-Encoding: ", buf, sizeof(buf), 0) == 0) &&
             (buf[0] != '\0'))
         {
           int enc = mutt_check_encoding(buf);
           if ((enc != ENC_OTHER) && (enc != ENC_UUENCODED))
           {
-            CURATTACH->content->encoding = enc;
+            CUR_ATTACH->content->encoding = enc;
             menu->redraw = REDRAW_CURRENT | REDRAW_STATUS;
             mutt_clear_error();
           }
@@ -1666,15 +1666,15 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
 
       case OP_COMPOSE_EDIT_FILE:
         CHECK_COUNT;
-        mutt_edit_file(NONULL(C_Editor), CURATTACH->content->filename);
-        mutt_update_encoding(CURATTACH->content);
+        mutt_edit_file(NONULL(C_Editor), CUR_ATTACH->content->filename);
+        mutt_update_encoding(CUR_ATTACH->content);
         menu->redraw = REDRAW_CURRENT | REDRAW_STATUS;
         mutt_message_hook(NULL, msg, MUTT_SEND2_HOOK);
         break;
 
       case OP_COMPOSE_TOGGLE_UNLINK:
         CHECK_COUNT;
-        CURATTACH->content->unlink = !CURATTACH->content->unlink;
+        CUR_ATTACH->content->unlink = !CUR_ATTACH->content->unlink;
 
         menu->redraw = REDRAW_INDEX;
         /* No send2hook since this doesn't change the message. */
@@ -1691,7 +1691,7 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
           }
           menu->redraw = REDRAW_FULL;
         }
-        else if (mutt_get_tmp_attachment(CURATTACH->content) == 0)
+        else if (mutt_get_tmp_attachment(CUR_ATTACH->content) == 0)
           menu->redraw = REDRAW_CURRENT;
 
         /* No send2hook since this doesn't change the message. */
@@ -1701,17 +1701,17 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
       {
         CHECK_COUNT;
         char *src = NULL;
-        if (CURATTACH->content->d_filename)
-          src = CURATTACH->content->d_filename;
+        if (CUR_ATTACH->content->d_filename)
+          src = CUR_ATTACH->content->d_filename;
         else
-          src = CURATTACH->content->filename;
+          src = CUR_ATTACH->content->filename;
         mutt_str_strfcpy(buf, mutt_path_basename(NONULL(src)), sizeof(buf));
         int ret = mutt_get_field(_("Send attachment with name: "), buf, sizeof(buf), MUTT_FILE);
         if (ret == 0)
         {
           /* As opposed to RENAME_FILE, we don't check buf[0] because it's
            * valid to set an empty string here, to erase what was set */
-          mutt_str_replace(&CURATTACH->content->d_filename, buf);
+          mutt_str_replace(&CUR_ATTACH->content->d_filename, buf);
           menu->redraw = REDRAW_CURRENT;
         }
         break;
@@ -1719,13 +1719,13 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
 
       case OP_COMPOSE_RENAME_FILE:
         CHECK_COUNT;
-        mutt_str_strfcpy(buf, CURATTACH->content->filename, sizeof(buf));
+        mutt_str_strfcpy(buf, CUR_ATTACH->content->filename, sizeof(buf));
         mutt_pretty_mailbox(buf, sizeof(buf));
         if ((mutt_get_field(_("Rename to: "), buf, sizeof(buf), MUTT_FILE) == 0) &&
             (buf[0] != '\0'))
         {
           struct stat st;
-          if (stat(CURATTACH->content->filename, &st) == -1)
+          if (stat(CUR_ATTACH->content->filename, &st) == -1)
           {
             /* L10N: "stat" is a system call. Do "man 2 stat" for more information. */
             mutt_error(_("Can't stat %s: %s"), buf, strerror(errno));
@@ -1733,14 +1733,14 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
           }
 
           mutt_expand_path(buf, sizeof(buf));
-          if (mutt_file_rename(CURATTACH->content->filename, buf))
+          if (mutt_file_rename(CUR_ATTACH->content->filename, buf))
             break;
 
-          mutt_str_replace(&CURATTACH->content->filename, buf);
+          mutt_str_replace(&CUR_ATTACH->content->filename, buf);
           menu->redraw = REDRAW_CURRENT;
 
-          if (CURATTACH->content->stamp >= st.st_mtime)
-            mutt_stamp_attachment(CURATTACH->content);
+          if (CUR_ATTACH->content->stamp >= st.st_mtime)
+            mutt_stamp_attachment(CUR_ATTACH->content);
         }
         mutt_message_hook(NULL, msg, MUTT_SEND2_HOOK);
         break;
@@ -1797,14 +1797,14 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
         }
         update_idx(menu, actx, new);
 
-        CURATTACH->content->type = itype;
-        mutt_str_replace(&CURATTACH->content->subtype, p);
-        CURATTACH->content->unlink = true;
+        CUR_ATTACH->content->type = itype;
+        mutt_str_replace(&CUR_ATTACH->content->subtype, p);
+        CUR_ATTACH->content->unlink = true;
         menu->redraw |= REDRAW_INDEX | REDRAW_STATUS;
 
-        if (mutt_compose_attachment(CURATTACH->content))
+        if (mutt_compose_attachment(CUR_ATTACH->content))
         {
-          mutt_update_encoding(CURATTACH->content);
+          mutt_update_encoding(CUR_ATTACH->content);
           menu->redraw = REDRAW_FULL;
         }
         mutt_message_hook(NULL, msg, MUTT_SEND2_HOOK);
@@ -1813,9 +1813,9 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
 
       case OP_COMPOSE_EDIT_MIME:
         CHECK_COUNT;
-        if (mutt_edit_attachment(CURATTACH->content))
+        if (mutt_edit_attachment(CUR_ATTACH->content))
         {
-          mutt_update_encoding(CURATTACH->content);
+          mutt_update_encoding(CUR_ATTACH->content);
           menu->redraw = REDRAW_FULL;
         }
         mutt_message_hook(NULL, msg, MUTT_SEND2_HOOK);
@@ -1832,13 +1832,13 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
       case OP_SAVE:
         CHECK_COUNT;
         mutt_save_attachment_list(actx, NULL, menu->tagprefix,
-                                  CURATTACH->content, NULL, menu);
+                                  CUR_ATTACH->content, NULL, menu);
         /* no send2hook, since this doesn't modify the message */
         break;
 
       case OP_PRINT:
         CHECK_COUNT;
-        mutt_print_attachment_list(actx, NULL, menu->tagprefix, CURATTACH->content);
+        mutt_print_attachment_list(actx, NULL, menu->tagprefix, CUR_ATTACH->content);
         /* no send2hook, since this doesn't modify the message */
         break;
 
@@ -1846,7 +1846,7 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
       case OP_FILTER:
         CHECK_COUNT;
         mutt_pipe_attachment_list(actx, NULL, menu->tagprefix,
-                                  CURATTACH->content, (op == OP_FILTER));
+                                  CUR_ATTACH->content, (op == OP_FILTER));
         if (op == OP_FILTER) /* cte might have changed */
           menu->redraw = menu->tagprefix ? REDRAW_FULL : REDRAW_CURRENT;
         menu->redraw |= REDRAW_STATUS;

--- a/compose.c
+++ b/compose.c
@@ -1417,7 +1417,7 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
             mutt_pretty_mailbox(buf, sizeof(buf));
           }
 
-        if ((mutt_enter_fname(prompt, buf, sizeof(buf), 1) == -1) || (buf[0] == '\0'))
+        if ((mutt_enter_fname(prompt, buf, sizeof(buf), true) == -1) || (buf[0] == '\0'))
           break;
 
 #ifdef USE_NNTP
@@ -1914,7 +1914,7 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
         }
         if (actx->idxlen)
           msg->content = actx->idx[0]->content;
-        if ((mutt_enter_fname(_("Write message to mailbox"), buf, sizeof(buf), 1) != -1) &&
+        if ((mutt_enter_fname(_("Write message to mailbox"), buf, sizeof(buf), true) != -1) &&
             (buf[0] != '\0'))
         {
           mutt_message(_("Writing message to %s ..."), buf);

--- a/config/regex.c
+++ b/config/regex.c
@@ -294,7 +294,7 @@ struct Regex *regex_new(const char *str, int flags, struct Buffer *err)
     str++;
   }
 
-  int rc = REGCOMP(reg->regex, str, rflags);
+  int rc = REG_COMP(reg->regex, str, rflags);
   if ((rc != 0) && err)
   {
     regerror(rc, reg->regex, err->data, err->dsize);

--- a/conn/socket.h
+++ b/conn/socket.h
@@ -40,11 +40,6 @@ enum ConnectionType
 
 struct Connection;
 
-/**
- * struct ConnectionList - A list of connections
- */
-TAILQ_HEAD(ConnectionList, Connection);
-
 struct Connection *mutt_socket_new(enum ConnectionType type);
 
 int mutt_socket_open(struct Connection *conn);

--- a/conn/ssl.c
+++ b/conn/ssl.c
@@ -68,9 +68,9 @@
 
 const int dialog_row_len = 128;
 
-/* Just in case OpenSSL doesn't define DEVRANDOM */
-#ifndef DEVRANDOM
-#define DEVRANDOM "/dev/urandom"
+/* Just in case OpenSSL doesn't define DEV_RANDOM */
+#ifndef DEV_RANDOM
+#define DEV_RANDOM "/dev/urandom"
 #endif
 
 /* LibreSSL defines OPENSSL_VERSION_NUMBER but sets it to 0x20000000L.
@@ -92,7 +92,7 @@ const int dialog_row_len = 128;
 #else
 static int entropy_byte_count = 0;
 /* OpenSSL fills the entropy pool from /dev/urandom if it exists */
-#define HAVE_ENTROPY() (!access(DEVRANDOM, R_OK) || entropy_byte_count >= 16)
+#define HAVE_ENTROPY() (!access(DEV_RANDOM, R_OK) || entropy_byte_count >= 16)
 #endif
 
 /* index for storing hostname as application specific data in SSL structure */

--- a/conn/ssl_gnutls.c
+++ b/conn/ssl_gnutls.c
@@ -203,8 +203,8 @@ static int tls_check_stored_hostname(const gnutls_datum_t *cert, const char *hos
   FILE *fp = fopen(C_CertificateFile, "r");
   if (fp)
   {
-    if (REGCOMP(&preg, "^#H ([a-zA-Z0-9_\\.-]+) ([0-9A-F]{4}( [0-9A-F]{4}){7})[ \t]*$",
-                REG_ICASE) != 0)
+    if (REG_COMP(&preg, "^#H ([a-zA-Z0-9_\\.-]+) ([0-9A-F]{4}( [0-9A-F]{4}){7})[ \t]*$",
+                 REG_ICASE) != 0)
     {
       mutt_file_fclose(&fp);
       return 0;

--- a/conn/tunnel.c
+++ b/conn/tunnel.c
@@ -102,7 +102,7 @@ static int tunnel_socket_open(struct Connection *conn)
     /* Don't let the subprocess think it can use the controlling tty */
     setsid();
 
-    execle(EXECSHELL, "sh", "-c", C_Tunnel, NULL, mutt_envlist_getlist());
+    execle(EXEC_SHELL, "sh", "-c", C_Tunnel, NULL, mutt_envlist_getlist());
     _exit(127);
   }
   mutt_sig_unblock_system(true);

--- a/copy.c
+++ b/copy.c
@@ -343,9 +343,10 @@ int mutt_copy_hdr(FILE *fp_in, FILE *fp_out, LOFF_T off_start, LOFF_T off_end,
        * decoding may have concatenated lines.  */
       if (chflags & (CH_DECODE | CH_PREFIX))
       {
-        if (mutt_write_one_header(
-                fp_out, 0, headers[x], (chflags & CH_PREFIX) ? prefix : 0,
-                mutt_window_wrap_cols(MuttIndexWindow, C_Wrap), chflags) == -1)
+        const char *pre = (chflags & CH_PREFIX) ? prefix : NULL;
+        const int wraplen = mutt_window_wrap_cols(MuttIndexWindow, C_Wrap);
+
+        if (mutt_write_one_header(fp_out, 0, headers[x], pre, wraplen, chflags) == -1)
         {
           error = true;
           break;

--- a/curs_lib.c
+++ b/curs_lib.c
@@ -225,7 +225,7 @@ struct Event mutt_getch(void)
     /* send ALT-x as ESC-x */
     ch &= ~0x80;
     mutt_unget_event(ch, 0);
-    ret.ch = '\033';
+    ret.ch = '\033'; // Escape
     ret.op = 0;
     return ret;
   }

--- a/curs_lib.c
+++ b/curs_lib.c
@@ -266,7 +266,7 @@ int mutt_get_field_full(const char *field, char *buf, size_t buflen, CompletionF
       mutt_menu_current_redraw();
     }
     mutt_window_clearline(MuttMessageWindow, 0);
-    SETCOLOR(MT_COLOR_PROMPT);
+    SET_COLOR(MT_COLOR_PROMPT);
     addstr(field);
     NORMAL_COLOR;
     mutt_refresh();
@@ -346,9 +346,9 @@ enum QuadOption mutt_yesorno(const char *msg, enum QuadOption def)
   answer[1] = '\0';
 
   bool reyes_ok = (expr = nl_langinfo(YESEXPR)) && (expr[0] == '^') &&
-                  (REGCOMP(&reyes, expr, REG_NOSUB) == 0);
+                  (REG_COMP(&reyes, expr, REG_NOSUB) == 0);
   bool reno_ok = (expr = nl_langinfo(NOEXPR)) && (expr[0] == '^') &&
-                 (REGCOMP(&reno, expr, REG_NOSUB) == 0);
+                 (REG_COMP(&reno, expr, REG_NOSUB) == 0);
 
   /* In order to prevent the default answer to the question to wrapped
    * around the screen in the even the question is wider than the screen,
@@ -389,7 +389,7 @@ enum QuadOption mutt_yesorno(const char *msg, enum QuadOption def)
           prompt_lines * MuttMessageWindow->cols - answer_string_wid, NULL);
 
       mutt_window_move(MuttMessageWindow, 0, 0);
-      SETCOLOR(MT_COLOR_PROMPT);
+      SET_COLOR(MT_COLOR_PROMPT);
       addnstr(msg, trunc_msg_len);
       addstr(answer_string);
       NORMAL_COLOR;
@@ -485,7 +485,7 @@ void mutt_show_error(void)
   if (OptKeepQuiet || !ErrorBufMessage)
     return;
 
-  SETCOLOR(OptMsgErr ? MT_COLOR_ERROR : MT_COLOR_MESSAGE);
+  SET_COLOR(OptMsgErr ? MT_COLOR_ERROR : MT_COLOR_MESSAGE);
   mutt_window_mvaddstr(MuttMessageWindow, 0, 0, ErrorBuf);
   NORMAL_COLOR;
   mutt_window_clrtoeol(MuttMessageWindow);
@@ -609,7 +609,7 @@ int mutt_enter_fname_full(const char *prompt, char *buf, size_t buflen, bool mai
 {
   struct Event ch;
 
-  SETCOLOR(MT_COLOR_PROMPT);
+  SET_COLOR(MT_COLOR_PROMPT);
   mutt_window_mvaddstr(MuttMessageWindow, 0, 0, (char *) prompt);
   addstr(_(" ('?' for list): "));
   NORMAL_COLOR;
@@ -829,13 +829,13 @@ int mutt_multi_choice(const char *prompt, const char *letters)
         while ((cur = strchr(prompt, '(')))
         {
           // write the part between prompt and cur using MT_COLOR_PROMPT
-          SETCOLOR(MT_COLOR_PROMPT);
+          SET_COLOR(MT_COLOR_PROMPT);
           addnstr(prompt, cur - prompt);
 
           if (isalnum(cur[1]) && (cur[2] == ')'))
           {
             // we have a single letter within parentheses
-            SETCOLOR(MT_COLOR_OPTIONS);
+            SET_COLOR(MT_COLOR_OPTIONS);
             addch(cur[1]);
             prompt = cur + 3;
           }
@@ -848,7 +848,7 @@ int mutt_multi_choice(const char *prompt, const char *letters)
         }
       }
 
-      SETCOLOR(MT_COLOR_PROMPT);
+      SET_COLOR(MT_COLOR_PROMPT);
       addstr(prompt);
       NORMAL_COLOR;
 

--- a/edit.c
+++ b/edit.c
@@ -427,7 +427,7 @@ int mutt_builtin_editor(const char *path, struct Email *msg, struct Email *cur)
     {
       /* remove trailing whitespace from the line */
       p = tmp + mutt_str_strlen(tmp) - 1;
-      while ((p >= tmp) && ISSPACE(*p))
+      while ((p >= tmp) && IS_SPACE(*p))
         *p-- = '\0';
 
       p = tmp + 2;

--- a/editmsg.c
+++ b/editmsg.c
@@ -83,7 +83,8 @@ static int ev_message(enum EvMessage action, struct Mailbox *m, struct Email *e)
   }
 
   const CopyHeaderFlags chflags =
-      CH_NOLEN | (((m->magic == MUTT_MBOX) || (m->magic == MUTT_MMDF)) ? CH_NO_FLAGS : CH_NOSTATUS);
+      CH_NOLEN |
+      (((m->magic == MUTT_MBOX) || (m->magic == MUTT_MMDF)) ? CH_NO_FLAGS : CH_NOSTATUS);
   rc = mutt_append_message(ctx_tmp->mailbox, m, e, MUTT_CM_NO_FLAGS, chflags);
   int oerrno = errno;
 

--- a/email/email.h
+++ b/email/email.h
@@ -123,7 +123,6 @@ struct EmailNode
   struct Email *email;
   STAILQ_ENTRY(EmailNode) entries;
 };
-
 STAILQ_HEAD(EmailList, EmailNode);
 
 bool          mutt_email_cmp_strict(const struct Email *e1, const struct Email *e2);

--- a/email/from.c
+++ b/email/from.c
@@ -68,7 +68,7 @@ bool is_from(const char *s, char *path, size_t pathlen, time_t *tp)
     const char *p = NULL;
     short q = 0;
 
-    for (p = s; *p && (q || !ISSPACE(*p)); p++)
+    for (p = s; *p && (q || !IS_SPACE(*p)); p++)
     {
       if (*p == '\\')
       {

--- a/email/group.h
+++ b/email/group.h
@@ -50,10 +50,6 @@ struct GroupNode
   struct Group *group;
   STAILQ_ENTRY(GroupNode) entries;
 };
-
-/**
- * struct GroupList - A list of GroupNodes
- */
 STAILQ_HEAD(GroupList, GroupNode);
 
 void mutt_grouplist_init(void);

--- a/email/parameter.h
+++ b/email/parameter.h
@@ -27,11 +27,6 @@
 #include "mutt/mutt.h"
 
 /**
- * struct ParameterList - List of parameters
- */
-TAILQ_HEAD(ParameterList, Parameter);
-
-/**
  * struct Parameter - Attribute associated with a MIME part
  */
 struct Parameter
@@ -40,6 +35,7 @@ struct Parameter
   char *value;
   TAILQ_ENTRY(Parameter) entries;
 };
+TAILQ_HEAD(ParameterList, Parameter);
 
 bool              mutt_param_cmp_strict(const struct ParameterList *p1, const struct ParameterList *p2);
 void              mutt_param_delete(struct ParameterList *p, const char *attribute);

--- a/email/parse.c
+++ b/email/parse.c
@@ -437,7 +437,7 @@ void mutt_parse_content_type(const char *s, struct Body *ct)
   if (pc)
   {
     *pc++ = 0;
-    while (*pc && ISSPACE(*pc))
+    while (*pc && IS_SPACE(*pc))
       pc++;
     parse_parameters(&ct->parameter, pc);
 
@@ -461,7 +461,7 @@ void mutt_parse_content_type(const char *s, struct Body *ct)
   if (subtype)
   {
     *subtype++ = '\0';
-    for (pc = subtype; *pc && !ISSPACE(*pc) && (*pc != ';'); pc++)
+    for (pc = subtype; *pc && !IS_SPACE(*pc) && (*pc != ';'); pc++)
       ;
     *pc = '\0';
     ct->subtype = mutt_str_strdup(subtype);
@@ -944,7 +944,7 @@ char *mutt_rfc822_read_line(FILE *fp, char *line, size_t *linelen)
   while (true)
   {
     if (!fgets(buf, *linelen - offset, fp) || /* end of file or */
-        (ISSPACE(*line) && !offset))          /* end of headers */
+        (IS_SPACE(*line) && !offset))         /* end of headers */
     {
       *line = '\0';
       return line;
@@ -958,7 +958,7 @@ char *mutt_rfc822_read_line(FILE *fp, char *line, size_t *linelen)
     if (*buf == '\n')
     {
       /* we did get a full line. remove trailing space */
-      while (ISSPACE(*buf))
+      while (IS_SPACE(*buf))
       {
         *buf-- = '\0'; /* we can't come beyond line's beginning because
                         * it begins with a non-space */
@@ -1349,7 +1349,7 @@ struct Body *mutt_parse_multipart(FILE *fp, const char *boundary, LOFF_T end_off
       if (len > 0)
       {
         /* Remove any trailing whitespace, up to the length of the boundary */
-        for (size_t i = len - 1; ISSPACE(buf[i]) && (i >= (blen + 2)); i--)
+        for (size_t i = len - 1; IS_SPACE(buf[i]) && (i >= (blen + 2)); i--)
           buf[i] = '\0';
       }
 

--- a/email/url.h
+++ b/email/url.h
@@ -58,7 +58,6 @@ struct UrlQueryString
   char *value;
   STAILQ_ENTRY(UrlQueryString) entries;
 };
-
 STAILQ_HEAD(UrlQueryStringHead, UrlQueryString);
 
 /**

--- a/enriched.c
+++ b/enriched.c
@@ -310,19 +310,19 @@ static void enriched_putwc(wchar_t c, struct EnrichedState *stte)
       if (stte->tag_level[RICH_BOLD])
       {
         stte->buffer[stte->buf_used++] = c;
-        stte->buffer[stte->buf_used++] = (wchar_t) '\010';
+        stte->buffer[stte->buf_used++] = (wchar_t) '\010'; // Ctrl-H (backspace)
         stte->buffer[stte->buf_used++] = c;
       }
       else if (stte->tag_level[RICH_UNDERLINE])
       {
         stte->buffer[stte->buf_used++] = '_';
-        stte->buffer[stte->buf_used++] = (wchar_t) '\010';
+        stte->buffer[stte->buf_used++] = (wchar_t) '\010'; // Ctrl-H (backspace)
         stte->buffer[stte->buf_used++] = c;
       }
       else if (stte->tag_level[RICH_ITALIC])
       {
         stte->buffer[stte->buf_used++] = c;
-        stte->buffer[stte->buf_used++] = (wchar_t) '\010';
+        stte->buffer[stte->buf_used++] = (wchar_t) '\010'; // Ctrl-H (backspace)
         stte->buffer[stte->buf_used++] = '_';
       }
       else
@@ -402,40 +402,40 @@ static void enriched_set_flags(const wchar_t *tag, struct EnrichedState *stte)
         stte->param[stte->param_used] = (wchar_t) '\0';
         if (wcscasecmp(L"black", stte->param) == 0)
         {
-          enriched_puts("\033[30m", stte);
+          enriched_puts("\033[30m", stte); // Escape
         }
         else if (wcscasecmp(L"red", stte->param) == 0)
         {
-          enriched_puts("\033[31m", stte);
+          enriched_puts("\033[31m", stte); // Escape
         }
         else if (wcscasecmp(L"green", stte->param) == 0)
         {
-          enriched_puts("\033[32m", stte);
+          enriched_puts("\033[32m", stte); // Escape
         }
         else if (wcscasecmp(L"yellow", stte->param) == 0)
         {
-          enriched_puts("\033[33m", stte);
+          enriched_puts("\033[33m", stte); // Escape
         }
         else if (wcscasecmp(L"blue", stte->param) == 0)
         {
-          enriched_puts("\033[34m", stte);
+          enriched_puts("\033[34m", stte); // Escape
         }
         else if (wcscasecmp(L"magenta", stte->param) == 0)
         {
-          enriched_puts("\033[35m", stte);
+          enriched_puts("\033[35m", stte); // Escape
         }
         else if (wcscasecmp(L"cyan", stte->param) == 0)
         {
-          enriched_puts("\033[36m", stte);
+          enriched_puts("\033[36m", stte); // Escape
         }
         else if (wcscasecmp(L"white", stte->param) == 0)
         {
-          enriched_puts("\033[37m", stte);
+          enriched_puts("\033[37m", stte); // Escape
         }
       }
       if ((stte->s->flags & MUTT_DISPLAY) && (j == RICH_COLOR))
       {
-        enriched_puts("\033[0m", stte);
+        enriched_puts("\033[0m", stte); // Escape
       }
 
       /* flush parameter buffer when closing the tag */

--- a/filter.c
+++ b/filter.c
@@ -156,7 +156,7 @@ pid_t mutt_create_filter_fd(const char *cmd, FILE **fp_in, FILE **fp_out,
       mutt_envlist_set("COLUMNS", columns, 1);
     }
 
-    execle(EXECSHELL, "sh", "-c", cmd, NULL, mutt_envlist_getlist());
+    execle(EXEC_SHELL, "sh", "-c", cmd, NULL, mutt_envlist_getlist());
     _exit(127);
   }
   else if (pid == -1)

--- a/functions.h
+++ b/functions.h
@@ -79,11 +79,11 @@ const struct Binding OpGeneric[] = { /* map: generic */
   { "previous-entry",  OP_PREV_ENTRY,           "k" },
   { "previous-line",   OP_PREV_LINE,            "<" },
   { "previous-page",   OP_PREV_PAGE,            "Z" },
-  { "refresh",         OP_REDRAW,               "\014" },
+  { "refresh",         OP_REDRAW,               "\014" },                       // Ctrl-L
   { "search",          OP_SEARCH,               "/" },
   { "search-next",     OP_SEARCH_NEXT,          "n" },
   { "search-opposite", OP_SEARCH_OPPOSITE,      NULL },
-  { "search-reverse",  OP_SEARCH_REVERSE,       "\033/" },
+  { "search-reverse",  OP_SEARCH_REVERSE,       "\033/" },                      // <Alt-/>
   { "select-entry",    OP_GENERIC_SELECT_ENTRY, "\n" },
   { "select-entry",    OP_GENERIC_SELECT_ENTRY, "\r" },
   { "shell-escape",    OP_SHELL_ESCAPE,         "!" },
@@ -105,7 +105,7 @@ const struct Binding OpMain[] = { /* map: index */
   { "catchup",                   OP_CATCHUP,                        NULL },
 #endif
   { "change-folder",             OP_MAIN_CHANGE_FOLDER,             "c" },
-  { "change-folder-readonly",    OP_MAIN_CHANGE_FOLDER_READONLY,    "\033c" },
+  { "change-folder-readonly",    OP_MAIN_CHANGE_FOLDER_READONLY,    "\033c" },  // <Alt-c>
 #ifdef USE_NNTP
   { "change-newsgroup",          OP_MAIN_CHANGE_GROUP,              NULL },
   { "change-newsgroup-readonly", OP_MAIN_CHANGE_GROUP_READONLY,     NULL },
@@ -113,21 +113,21 @@ const struct Binding OpMain[] = { /* map: index */
 #ifdef USE_NOTMUCH
   { "change-vfolder",            OP_MAIN_CHANGE_VFOLDER,            NULL },
 #endif
-  { "check-traditional-pgp",     OP_CHECK_TRADITIONAL,              "\033P" },
+  { "check-traditional-pgp",     OP_CHECK_TRADITIONAL,              "\033P" },  // <Alt-P>
   { "clear-flag",                OP_MAIN_CLEAR_FLAG,                "W" },
-  { "collapse-all",              OP_MAIN_COLLAPSE_ALL,              "\033V" },
-  { "collapse-thread",           OP_MAIN_COLLAPSE_THREAD,           "\033v" },
+  { "collapse-all",              OP_MAIN_COLLAPSE_ALL,              "\033V" },  // <Alt-V>
+  { "collapse-thread",           OP_MAIN_COLLAPSE_THREAD,           "\033v" },  // <Alt-v>
   { "compose-to-sender",         OP_COMPOSE_TO_SENDER,              NULL },
   { "copy-message",              OP_COPY_MESSAGE,                   "C" },
   { "create-alias",              OP_CREATE_ALIAS,                   "a" },
-  { "decode-copy",               OP_DECODE_COPY,                    "\033C" },
-  { "decode-save",               OP_DECODE_SAVE,                    "\033s" },
+  { "decode-copy",               OP_DECODE_COPY,                    "\033C" },  // <Alt-C>
+  { "decode-save",               OP_DECODE_SAVE,                    "\033s" },  // <Alt-s>
   { "decrypt-copy",              OP_DECRYPT_COPY,                   NULL },
   { "decrypt-save",              OP_DECRYPT_SAVE,                   NULL },
   { "delete-message",            OP_DELETE,                         "d" },
   { "delete-pattern",            OP_MAIN_DELETE_PATTERN,            "D" },
-  { "delete-subthread",          OP_DELETE_SUBTHREAD,               "\033d" },
-  { "delete-thread",             OP_DELETE_THREAD,                  "\004" },
+  { "delete-subthread",          OP_DELETE_SUBTHREAD,               "\033d" },  // <Alt-d>
+  { "delete-thread",             OP_DELETE_THREAD,                  "\004" },   // Ctrl-D
   { "display-address",           OP_DISPLAY_ADDRESS,                "@" },
   { "display-message",           OP_DISPLAY_MESSAGE,                "\n" },
   { "display-message",           OP_DISPLAY_MESSAGE,                "\r" },
@@ -136,11 +136,11 @@ const struct Binding OpMain[] = { /* map: index */
   { "edit-label",                OP_EDIT_LABEL,                     "Y" },
   { "edit-or-view-raw-message",  OP_EDIT_OR_VIEW_RAW_MESSAGE,       "e" },
   { "edit-raw-message",          OP_EDIT_RAW_MESSAGE,               NULL },
-  { "edit-type",                 OP_EDIT_TYPE,                      "\005" },
+  { "edit-type",                 OP_EDIT_TYPE,                      "\005" },   // Ctrl-E
 #ifdef USE_NOTMUCH
   { "entire-thread",             OP_MAIN_ENTIRE_THREAD,             NULL },
 #endif
-  { "extract-keys",              OP_EXTRACT_KEYS,                   "\013" },
+  { "extract-keys",              OP_EXTRACT_KEYS,                   "\013" },   // Ctrl-K
 #ifdef USE_POP
   { "fetch-mail",                OP_MAIN_FETCH_MAIL,                "G" },
 #endif
@@ -148,7 +148,7 @@ const struct Binding OpMain[] = { /* map: index */
 #ifdef USE_NNTP
   { "followup-message",          OP_FOLLOWUP,                       NULL },
 #endif
-  { "forget-passphrase",         OP_FORGET_PASSPHRASE,              "\006" },
+  { "forget-passphrase",         OP_FORGET_PASSPHRASE,              "\006" },   // Ctrl-F
   { "forward-message",           OP_FORWARD_MESSAGE,                "f" },
 #ifdef USE_NNTP
   { "forward-to-group",          OP_FORWARD_TO_GROUP,               NULL },
@@ -167,7 +167,7 @@ const struct Binding OpMain[] = { /* map: index */
   { "link-threads",              OP_MAIN_LINK_THREADS,              "&" },
   { "list-reply",                OP_LIST_REPLY,                     "L" },
   { "mail",                      OP_MAIL,                           "m" },
-  { "mail-key",                  OP_MAIL_KEY,                       "\033k" },
+  { "mail-key",                  OP_MAIL_KEY,                       "\033k" },  // <Alt-k>
   { "mailbox-list",              OP_MAILBOX_LIST,                   "." },
   { "mark-message",              OP_MARK_MSG,                       "~" },
   { "modify-labels",             OP_MAIN_MODIFY_TAGS,               NULL }, // NOTE(sileht): kept for backward compatibility
@@ -176,8 +176,8 @@ const struct Binding OpMain[] = { /* map: index */
   { "modify-tags-then-hide",     OP_MAIN_MODIFY_TAGS_THEN_HIDE,     NULL },
   { "next-new",                  OP_MAIN_NEXT_NEW,                  NULL },
   { "next-new-then-unread",      OP_MAIN_NEXT_NEW_THEN_UNREAD,      "\t" },
-  { "next-subthread",            OP_MAIN_NEXT_SUBTHREAD,            "\033n" },
-  { "next-thread",               OP_MAIN_NEXT_THREAD,               "\016" },
+  { "next-subthread",            OP_MAIN_NEXT_SUBTHREAD,            "\033n" },  // <Alt-n>
+  { "next-thread",               OP_MAIN_NEXT_THREAD,               "\016" },   // Ctrl-N
   { "next-undeleted",            OP_MAIN_NEXT_UNDELETED,            "j" },
   { "next-unread",               OP_MAIN_NEXT_UNREAD,               NULL },
   { "next-unread-mailbox",       OP_MAIN_NEXT_UNREAD_MAILBOX,       NULL },
@@ -187,9 +187,9 @@ const struct Binding OpMain[] = { /* map: index */
   { "post-message",              OP_POST,                           NULL },
 #endif
   { "previous-new",              OP_MAIN_PREV_NEW,                  NULL },
-  { "previous-new-then-unread",  OP_MAIN_PREV_NEW_THEN_UNREAD,      "\033\t" },
-  { "previous-subthread",        OP_MAIN_PREV_SUBTHREAD,            "\033p" },
-  { "previous-thread",           OP_MAIN_PREV_THREAD,               "\020" },
+  { "previous-new-then-unread",  OP_MAIN_PREV_NEW_THEN_UNREAD,      "\033\t" }, // <Alt-\>
+  { "previous-subthread",        OP_MAIN_PREV_SUBTHREAD,            "\033p" },  // <Alt-p>
+  { "previous-thread",           OP_MAIN_PREV_THREAD,               "\020" },   // Ctrl-P
   { "previous-undeleted",        OP_MAIN_PREV_UNDELETED,            "k" },
   { "previous-unread",           OP_MAIN_PREV_UNREAD,               NULL },
   { "print-message",             OP_PRINT,                          "p" },
@@ -198,18 +198,18 @@ const struct Binding OpMain[] = { /* map: index */
   { "quasi-delete",              OP_MAIN_QUASI_DELETE,              NULL },
   { "query",                     OP_QUERY,                          "Q" },
   { "quit",                      OP_QUIT,                           "q" },
-  { "read-subthread",            OP_MAIN_READ_SUBTHREAD,            "\033r" },
-  { "read-thread",               OP_MAIN_READ_THREAD,               "\022" },
+  { "read-subthread",            OP_MAIN_READ_SUBTHREAD,            "\033r" },  // <Alt-r>
+  { "read-thread",               OP_MAIN_READ_THREAD,               "\022" },   // Ctrl-R
   { "recall-message",            OP_RECALL_MESSAGE,                 "R" },
 #ifdef USE_NNTP
   { "reconstruct-thread",        OP_RECONSTRUCT_THREAD,             NULL },
 #endif
   { "reply",                     OP_REPLY,                          "r" },
-  { "resend-message",            OP_RESEND,                         "\033e" },
+  { "resend-message",            OP_RESEND,                         "\033e" },  // <Alt-e>
   { "root-message",              OP_MAIN_ROOT_MESSAGE,              NULL },
   { "save-message",              OP_SAVE,                           "s" },
   { "set-flag",                  OP_MAIN_SET_FLAG,                  "w" },
-  { "show-limit",                OP_MAIN_SHOW_LIMIT,                "\033l" },
+  { "show-limit",                OP_MAIN_SHOW_LIMIT,                "\033l" },  // <Alt-l>
   { "show-log-messages",         OP_SHOW_LOG_MESSAGES,              "M" },
   { "show-version",              OP_VERSION,                        "V" },
 #ifdef USE_SIDEBAR
@@ -228,15 +228,15 @@ const struct Binding OpMain[] = { /* map: index */
   { "sync-mailbox",              OP_MAIN_SYNC_FOLDER,               "$" },
   { "tag-pattern",               OP_MAIN_TAG_PATTERN,               "T" },
   { "tag-subthread",             OP_TAG_SUBTHREAD,                  NULL },
-  { "tag-thread",                OP_TAG_THREAD,                     "\033t" },
+  { "tag-thread",                OP_TAG_THREAD,                     "\033t" },  // <Alt-t>
   { "toggle-new",                OP_TOGGLE_NEW,                     "N" },
   { "toggle-read",               OP_TOGGLE_READ,                    NULL },
   { "toggle-write",              OP_TOGGLE_WRITE,                   "%" },
   { "undelete-message",          OP_UNDELETE,                       "u" },
   { "undelete-pattern",          OP_MAIN_UNDELETE_PATTERN,          "U" },
-  { "undelete-subthread",        OP_UNDELETE_SUBTHREAD,             "\033u" },
-  { "undelete-thread",           OP_UNDELETE_THREAD,                "\025" },
-  { "untag-pattern",             OP_MAIN_UNTAG_PATTERN,             "\024" },
+  { "undelete-subthread",        OP_UNDELETE_SUBTHREAD,             "\033u" },  // <Alt-u>
+  { "undelete-thread",           OP_UNDELETE_THREAD,                "\025" },   // Ctrl-U
+  { "untag-pattern",             OP_MAIN_UNTAG_PATTERN,             "\024" },   // Ctrl-T
 #ifdef USE_NOTMUCH
   { "vfolder-from-query",        OP_MAIN_VFOLDER_FROM_QUERY,        NULL },
   { "vfolder-from-query-readonly", OP_MAIN_VFOLDER_FROM_QUERY_READONLY, NULL },
@@ -258,7 +258,7 @@ const struct Binding OpPager[] = { /* map: pager */
   { "bounce-message",            OP_BOUNCE_MESSAGE,               "b" },
   { "break-thread",              OP_MAIN_BREAK_THREAD,            "#" },
   { "change-folder",             OP_MAIN_CHANGE_FOLDER,           "c" },
-  { "change-folder-readonly",    OP_MAIN_CHANGE_FOLDER_READONLY,  "\033c" },
+  { "change-folder-readonly",    OP_MAIN_CHANGE_FOLDER_READONLY,  "\033c" },    // <Alt-c>
 #ifdef USE_NNTP
   { "change-newsgroup",          OP_MAIN_CHANGE_GROUP,            NULL },
   { "change-newsgroup-readonly", OP_MAIN_CHANGE_GROUP_READONLY,   NULL },
@@ -267,36 +267,36 @@ const struct Binding OpPager[] = { /* map: pager */
   { "change-vfolder",            OP_MAIN_CHANGE_VFOLDER,          NULL },
 #endif
   { "check-stats",               OP_CHECK_STATS,                  NULL },
-  { "check-traditional-pgp",     OP_CHECK_TRADITIONAL,            "\033P" },
+  { "check-traditional-pgp",     OP_CHECK_TRADITIONAL,            "\033P" },    // <Alt-P>
   { "clear-flag",                OP_MAIN_CLEAR_FLAG,              "W" },
   { "compose-to-sender",         OP_COMPOSE_TO_SENDER,            NULL },
   { "copy-message",              OP_COPY_MESSAGE,                 "C" },
   { "create-alias",              OP_CREATE_ALIAS,                 "a" },
-  { "decode-copy",               OP_DECODE_COPY,                  "\033C" },
-  { "decode-save",               OP_DECODE_SAVE,                  "\033s" },
+  { "decode-copy",               OP_DECODE_COPY,                  "\033C" },    // <Alt-C>
+  { "decode-save",               OP_DECODE_SAVE,                  "\033s" },    // <Alt-s>
   { "decrypt-copy",              OP_DECRYPT_COPY,                 NULL },
   { "decrypt-save",              OP_DECRYPT_SAVE,                 NULL },
   { "delete-message",            OP_DELETE,                       "d" },
-  { "delete-subthread",          OP_DELETE_SUBTHREAD,             "\033d" },
-  { "delete-thread",             OP_DELETE_THREAD,                "\004" },
+  { "delete-subthread",          OP_DELETE_SUBTHREAD,             "\033d" },    // <Alt-d>
+  { "delete-thread",             OP_DELETE_THREAD,                "\004" },     // Ctrl-D
   { "display-address",           OP_DISPLAY_ADDRESS,              "@" },
   { "display-toggle-weed",       OP_DISPLAY_HEADERS,              "h" },
   { "edit",                      OP_EDIT_RAW_MESSAGE,             NULL },
   { "edit-label",                OP_EDIT_LABEL,                   "Y" },
   { "edit-or-view-raw-message",  OP_EDIT_OR_VIEW_RAW_MESSAGE,     "e" },
   { "edit-raw-message",          OP_EDIT_RAW_MESSAGE,             NULL },
-  { "edit-type",                 OP_EDIT_TYPE,                    "\005" },
+  { "edit-type",                 OP_EDIT_TYPE,                    "\005" },     // Ctrl-E
   { "enter-command",             OP_ENTER_COMMAND,                ":" },
 #ifdef USE_NOTMUCH
   { "entire-thread",             OP_MAIN_ENTIRE_THREAD,           NULL },
 #endif
   { "exit",                      OP_EXIT,                         "q" },
-  { "extract-keys",              OP_EXTRACT_KEYS,                 "\013" },
+  { "extract-keys",              OP_EXTRACT_KEYS,                 "\013" },     // Ctrl-K
   { "flag-message",              OP_FLAG_MESSAGE,                 "F" },
 #ifdef USE_NNTP
   { "followup-message",          OP_FOLLOWUP,                     NULL },
 #endif
-  { "forget-passphrase",         OP_FORGET_PASSPHRASE,            "\006" },
+  { "forget-passphrase",         OP_FORGET_PASSPHRASE,            "\006" },     // Ctrl-F
   { "forward-message",           OP_FORWARD_MESSAGE,              "f" },
 #ifdef USE_NNTP
   { "forward-to-group",          OP_FORWARD_TO_GROUP,             NULL },
@@ -314,7 +314,7 @@ const struct Binding OpPager[] = { /* map: pager */
   { "link-threads",              OP_MAIN_LINK_THREADS,            "&" },
   { "list-reply",                OP_LIST_REPLY,                   "L" },
   { "mail",                      OP_MAIL,                         "m" },
-  { "mail-key",                  OP_MAIL_KEY,                     "\033k" },
+  { "mail-key",                  OP_MAIL_KEY,                     "\033k" },    // <Alt-k>
   { "mailbox-list",              OP_MAILBOX_LIST,                 "." },
   { "mark-as-new",               OP_TOGGLE_NEW,                   "N" },
   { "modify-labels",             OP_MAIN_MODIFY_TAGS,             NULL }, // NOTE(sileht): kept for backward compatibility
@@ -327,8 +327,8 @@ const struct Binding OpPager[] = { /* map: pager */
   { "next-new",                  OP_MAIN_NEXT_NEW,                NULL },
   { "next-new-then-unread",      OP_MAIN_NEXT_NEW_THEN_UNREAD,    "\t" },
   { "next-page",                 OP_NEXT_PAGE,                    " " },
-  { "next-subthread",            OP_MAIN_NEXT_SUBTHREAD,          "\033n" },
-  { "next-thread",               OP_MAIN_NEXT_THREAD,             "\016" },
+  { "next-subthread",            OP_MAIN_NEXT_SUBTHREAD,          "\033n" },    // <Alt-n>
+  { "next-thread",               OP_MAIN_NEXT_THREAD,             "\016" },     // Ctrl-N
   { "next-undeleted",            OP_MAIN_NEXT_UNDELETED,          "j" },
   { "next-unread",               OP_MAIN_NEXT_UNREAD,             NULL },
   { "next-unread-mailbox",       OP_MAIN_NEXT_UNREAD_MAILBOX,     NULL },
@@ -342,8 +342,8 @@ const struct Binding OpPager[] = { /* map: pager */
   { "previous-new",              OP_MAIN_PREV_NEW,                NULL },
   { "previous-new-then-unread",  OP_MAIN_PREV_NEW_THEN_UNREAD,    NULL },
   { "previous-page",             OP_PREV_PAGE,                    "-" },
-  { "previous-subthread",        OP_MAIN_PREV_SUBTHREAD,          "\033p" },
-  { "previous-thread",           OP_MAIN_PREV_THREAD,             "\020" },
+  { "previous-subthread",        OP_MAIN_PREV_SUBTHREAD,          "\033p" },    // <Alt-p>
+  { "previous-thread",           OP_MAIN_PREV_THREAD,             "\020" },     // Ctrl-P
   { "previous-undeleted",        OP_MAIN_PREV_UNDELETED,          "k" },
   { "previous-unread",           OP_MAIN_PREV_UNREAD,             NULL },
   { "print-message",             OP_PRINT,                        "p" },
@@ -351,21 +351,21 @@ const struct Binding OpPager[] = { /* map: pager */
   { "purge-thread",              OP_PURGE_THREAD,                 NULL },
   { "quasi-delete",              OP_MAIN_QUASI_DELETE,            NULL },
   { "quit",                      OP_QUIT,                         "Q" },
-  { "read-subthread",            OP_MAIN_READ_SUBTHREAD,          "\033r" },
-  { "read-thread",               OP_MAIN_READ_THREAD,             "\022" },
+  { "read-subthread",            OP_MAIN_READ_SUBTHREAD,          "\033r" },    // <Alt-r>
+  { "read-thread",               OP_MAIN_READ_THREAD,             "\022" },     // Ctrl-R
   { "recall-message",            OP_RECALL_MESSAGE,               "R" },
 #ifdef USE_NNTP
   { "reconstruct-thread",        OP_RECONSTRUCT_THREAD,           NULL },
 #endif
-  { "redraw-screen",             OP_REDRAW,                       "\014" },
+  { "redraw-screen",             OP_REDRAW,                       "\014" },     // Ctrl-L
   { "reply",                     OP_REPLY,                        "r" },
-  { "resend-message",            OP_RESEND,                       "\033e" },
+  { "resend-message",            OP_RESEND,                       "\033e" },    // <Alt-e>
   { "root-message",              OP_MAIN_ROOT_MESSAGE,            NULL },
   { "save-message",              OP_SAVE,                         "s" },
   { "search",                    OP_SEARCH,                       "/" },
   { "search-next",               OP_SEARCH_NEXT,                  "n" },
   { "search-opposite",           OP_SEARCH_OPPOSITE,              NULL },
-  { "search-reverse",            OP_SEARCH_REVERSE,               "\033/" },
+  { "search-reverse",            OP_SEARCH_REVERSE,               "\033/" },    // <Alt-/>
   { "search-toggle",             OP_SEARCH_TOGGLE,                "\\" },
   { "set-flag",                  OP_MAIN_SET_FLAG,                "w" },
   { "shell-escape",              OP_SHELL_ESCAPE,                 "!" },
@@ -389,8 +389,8 @@ const struct Binding OpPager[] = { /* map: pager */
   { "toggle-quoted",             OP_PAGER_HIDE_QUOTED,            "T" },
   { "top",                       OP_PAGER_TOP,                    "^" },
   { "undelete-message",          OP_UNDELETE,                     "u" },
-  { "undelete-subthread",        OP_UNDELETE_SUBTHREAD,           "\033u" },
-  { "undelete-thread",           OP_UNDELETE_THREAD,              "\025" },
+  { "undelete-subthread",        OP_UNDELETE_SUBTHREAD,           "\033u" },    // <Alt-u>
+  { "undelete-thread",           OP_UNDELETE_THREAD,              "\025" },     // Ctrl-U
 #ifdef USE_NOTMUCH
   { "vfolder-from-query",        OP_MAIN_VFOLDER_FROM_QUERY,      NULL },
   { "vfolder-from-query-readonly", OP_MAIN_VFOLDER_FROM_QUERY_READONLY, NULL },
@@ -408,17 +408,17 @@ const struct Binding OpPager[] = { /* map: pager */
  */
 const struct Binding OpAttach[] = { /* map: attachment */
   { "bounce-message",        OP_BOUNCE_MESSAGE,              "b" },
-  { "check-traditional-pgp", OP_CHECK_TRADITIONAL,           "\033P" },
+  { "check-traditional-pgp", OP_CHECK_TRADITIONAL,           "\033P" },         // <Alt-P>
   { "collapse-parts",        OP_ATTACH_COLLAPSE,             "v" },
   { "compose-to-sender",     OP_COMPOSE_TO_SENDER,           NULL },
   { "delete-entry",          OP_DELETE,                      "d" },
   { "display-toggle-weed",   OP_DISPLAY_HEADERS,             "h" },
-  { "edit-type",             OP_EDIT_TYPE,                   "\005" },
-  { "extract-keys",          OP_EXTRACT_KEYS,                "\013" },
+  { "edit-type",             OP_EDIT_TYPE,                   "\005" },          // Ctrl-E
+  { "extract-keys",          OP_EXTRACT_KEYS,                "\013" },          // Ctrl-K
 #ifdef USE_NNTP
   { "followup-message",      OP_FOLLOWUP,                    NULL },
 #endif
-  { "forget-passphrase",     OP_FORGET_PASSPHRASE,           "\006" },
+  { "forget-passphrase",     OP_FORGET_PASSPHRASE,           "\006" },          // Ctrl-F
   { "forward-message",       OP_FORWARD_MESSAGE,             "f" },
 #ifdef USE_NNTP
   { "forward-to-group",      OP_FORWARD_TO_GROUP,            NULL },
@@ -429,7 +429,7 @@ const struct Binding OpAttach[] = { /* map: attachment */
   { "pipe-entry",            OP_PIPE,                        "|" },
   { "print-entry",           OP_PRINT,                       "p" },
   { "reply",                 OP_REPLY,                       "r" },
-  { "resend-message",        OP_RESEND,                      "\033e" },
+  { "resend-message",        OP_RESEND,                      "\033e" },         // <Alt-e>
   { "save-entry",            OP_SAVE,                        "s" },
   { "undelete-entry",        OP_UNDELETE,                    "u" },
   { "view-attach",           OP_VIEW_ATTACH,                 "\n" },
@@ -444,7 +444,7 @@ const struct Binding OpAttach[] = { /* map: attachment */
  */
 const struct Binding OpCompose[] = { /* map: compose */
   { "attach-file",           OP_COMPOSE_ATTACH_FILE,         "a" },
-  { "attach-key",            OP_COMPOSE_ATTACH_KEY,          "\033k" },
+  { "attach-key",            OP_COMPOSE_ATTACH_KEY,          "\033k" },         // <Alt-k>
   { "attach-message",        OP_COMPOSE_ATTACH_MESSAGE,      "A" },
 #ifdef USE_NNTP
   { "attach-news-message",   OP_COMPOSE_ATTACH_NEWS_MESSAGE, NULL },
@@ -455,15 +455,15 @@ const struct Binding OpCompose[] = { /* map: compose */
   { "edit-bcc",              OP_COMPOSE_EDIT_BCC,            "b" },
   { "edit-cc",               OP_COMPOSE_EDIT_CC,             "c" },
   { "edit-description",      OP_COMPOSE_EDIT_DESCRIPTION,    "d" },
-  { "edit-encoding",         OP_COMPOSE_EDIT_ENCODING,       "\005" },
+  { "edit-encoding",         OP_COMPOSE_EDIT_ENCODING,       "\005" },          // Ctrl-E
   { "edit-fcc",              OP_COMPOSE_EDIT_FCC,            "f" },
-  { "edit-file",             OP_COMPOSE_EDIT_FILE,           "\030e" },
+  { "edit-file",             OP_COMPOSE_EDIT_FILE,           "\030e" },         // <Alt-e>
 #ifdef USE_NNTP
   { "edit-followup-to",      OP_COMPOSE_EDIT_FOLLOWUP_TO,    NULL },
 #endif
-  { "edit-from",             OP_COMPOSE_EDIT_FROM,           "\033f" },
+  { "edit-from",             OP_COMPOSE_EDIT_FROM,           "\033f" },         // <Alt-f>
   { "edit-headers",          OP_COMPOSE_EDIT_HEADERS,        "E" },
-  { "edit-language",         OP_COMPOSE_EDIT_LANGUAGE,       "\014" },
+  { "edit-language",         OP_COMPOSE_EDIT_LANGUAGE,       "\014" },          // Ctrl-L
   { "edit-message",          OP_COMPOSE_EDIT_MESSAGE,        "e" },
   { "edit-mime",             OP_COMPOSE_EDIT_MIME,           "m" },
 #ifdef USE_NNTP
@@ -472,12 +472,12 @@ const struct Binding OpCompose[] = { /* map: compose */
   { "edit-reply-to",         OP_COMPOSE_EDIT_REPLY_TO,       "r" },
   { "edit-subject",          OP_COMPOSE_EDIT_SUBJECT,        "s" },
   { "edit-to",               OP_COMPOSE_EDIT_TO,             "t" },
-  { "edit-type",             OP_EDIT_TYPE,                   "\024" },
+  { "edit-type",             OP_EDIT_TYPE,                   "\024" },          // Ctrl-T
 #ifdef USE_NNTP
   { "edit-x-comment-to",     OP_COMPOSE_EDIT_X_COMMENT_TO,   NULL },
 #endif
   { "filter-entry",          OP_FILTER,                      "F" },
-  { "forget-passphrase",     OP_FORGET_PASSPHRASE,           "\006" },
+  { "forget-passphrase",     OP_FORGET_PASSPHRASE,           "\006" },          // Ctrl-F
   { "get-attachment",        OP_COMPOSE_GET_ATTACHMENT,      "G" },
   { "group-alternatives",    OP_COMPOSE_GROUP_ALTS,          "&" },
   { "group-multilingual",    OP_COMPOSE_GROUP_LINGUAL,       "^" },
@@ -492,11 +492,11 @@ const struct Binding OpCompose[] = { /* map: compose */
   { "pipe-entry",            OP_PIPE,                        "|" },
   { "postpone-message",      OP_COMPOSE_POSTPONE_MESSAGE,    "P" },
   { "print-entry",           OP_PRINT,                       "l" },
-  { "rename-attachment",     OP_COMPOSE_RENAME_ATTACHMENT,   "\017" },
+  { "rename-attachment",     OP_COMPOSE_RENAME_ATTACHMENT,   "\017" },          // Ctrl-O
   { "rename-file",           OP_COMPOSE_RENAME_FILE,         "R" },
   { "send-message",          OP_COMPOSE_SEND_MESSAGE,        "y" },
   { "smime-menu",            OP_COMPOSE_SMIME_MENU,          "S" },
-  { "toggle-disposition",    OP_COMPOSE_TOGGLE_DISPOSITION,  "\004" },
+  { "toggle-disposition",    OP_COMPOSE_TOGGLE_DISPOSITION,  "\004" },          // Ctrl-D
   { "toggle-recode",         OP_COMPOSE_TOGGLE_RECODE,       NULL },
   { "toggle-unlink",         OP_COMPOSE_TOGGLE_UNLINK,       "u" },
   { "update-encoding",       OP_COMPOSE_UPDATE_ENCODING,     "U" },
@@ -592,29 +592,29 @@ const struct Binding OpQuery[] = { /* map: query */
  * OpEditor - Key bindings for the editor menu
  */
 const struct Binding OpEditor[] = { /* map: editor */
-  { "backspace",             OP_EDITOR_BACKSPACE,            "\010" },
-  { "backward-char",         OP_EDITOR_BACKWARD_CHAR,        "\002" },
-  { "backward-word",         OP_EDITOR_BACKWARD_WORD,        "\033b" },
-  { "bol",                   OP_EDITOR_BOL,                  "\001" },
-  { "capitalize-word",       OP_EDITOR_CAPITALIZE_WORD,      "\033c" },
+  { "backspace",             OP_EDITOR_BACKSPACE,            "\010" },          // Ctrl-H
+  { "backward-char",         OP_EDITOR_BACKWARD_CHAR,        "\002" },          // Ctrl-B
+  { "backward-word",         OP_EDITOR_BACKWARD_WORD,        "\033b" },         // <Alt-b>
+  { "bol",                   OP_EDITOR_BOL,                  "\001" },          // Ctrl-A
+  { "capitalize-word",       OP_EDITOR_CAPITALIZE_WORD,      "\033c" },         // <Alt-c>
   { "complete",              OP_EDITOR_COMPLETE,             "\t" },
-  { "complete-query",        OP_EDITOR_COMPLETE_QUERY,       "\024" },
-  { "delete-char",           OP_EDITOR_DELETE_CHAR,          "\004" },
-  { "downcase-word",         OP_EDITOR_DOWNCASE_WORD,        "\033l" },
-  { "eol",                   OP_EDITOR_EOL,                  "\005" },
-  { "forward-char",          OP_EDITOR_FORWARD_CHAR,         "\006" },
-  { "forward-word",          OP_EDITOR_FORWARD_WORD,         "\033f" },
+  { "complete-query",        OP_EDITOR_COMPLETE_QUERY,       "\024" },          // Ctrl-T
+  { "delete-char",           OP_EDITOR_DELETE_CHAR,          "\004" },          // Ctrl-D
+  { "downcase-word",         OP_EDITOR_DOWNCASE_WORD,        "\033l" },         // <Alt-l>
+  { "eol",                   OP_EDITOR_EOL,                  "\005" },          // Ctrl-E
+  { "forward-char",          OP_EDITOR_FORWARD_CHAR,         "\006" },          // Ctrl-F
+  { "forward-word",          OP_EDITOR_FORWARD_WORD,         "\033f" },         // <Alt-f>
   { "history-down",          OP_EDITOR_HISTORY_DOWN,         NULL },
-  { "history-search",        OP_EDITOR_HISTORY_SEARCH,       "\022" },
+  { "history-search",        OP_EDITOR_HISTORY_SEARCH,       "\022" },          // Ctrl-R
   { "history-up",            OP_EDITOR_HISTORY_UP,           NULL },
-  { "kill-eol",              OP_EDITOR_KILL_EOL,             "\013" },
-  { "kill-eow",              OP_EDITOR_KILL_EOW,             "\033d" },
-  { "kill-line",             OP_EDITOR_KILL_LINE,            "\025" },
-  { "kill-word",             OP_EDITOR_KILL_WORD,            "\027" },
+  { "kill-eol",              OP_EDITOR_KILL_EOL,             "\013" },          // Ctrl-K
+  { "kill-eow",              OP_EDITOR_KILL_EOW,             "\033d" },         // <Alt-d>
+  { "kill-line",             OP_EDITOR_KILL_LINE,            "\025" },          // Ctrl-U
+  { "kill-word",             OP_EDITOR_KILL_WORD,            "\027" },          // Ctrl-W
   { "mailbox-cycle",         OP_EDITOR_MAILBOX_CYCLE,        " " },
-  { "quote-char",            OP_EDITOR_QUOTE_CHAR,           "\026" },
+  { "quote-char",            OP_EDITOR_QUOTE_CHAR,           "\026" },          // Ctrl-V
   { "transpose-chars",       OP_EDITOR_TRANSPOSE_CHARS,      NULL },
-  { "upcase-word",           OP_EDITOR_UPCASE_WORD,          "\033u" },
+  { "upcase-word",           OP_EDITOR_UPCASE_WORD,          "\033u" },         // <Alt-u>
   /* This is deprecated.  Leave it last so it doesn't show up in the help. */
   { "buffy-cycle",           OP_EDITOR_MAILBOX_CYCLE,        NULL },
   { NULL,                    0,                              NULL },

--- a/handler.c
+++ b/handler.c
@@ -874,7 +874,8 @@ static int external_body_handler(struct Body *b, struct State *s)
       state_attach_puts(strbuf, s);
 
       mutt_copy_hdr(s->fp_in, s->fp_out, ftello(s->fp_in), b->parts->offset,
-                    (C_Weed ? (CH_WEED | CH_REORDER) : CH_NO_FLAGS) | CH_DECODE | CH_DISPLAY, NULL);
+                    (C_Weed ? (CH_WEED | CH_REORDER) : CH_NO_FLAGS) | CH_DECODE | CH_DISPLAY,
+                    NULL);
     }
   }
   else
@@ -891,7 +892,8 @@ static int external_body_handler(struct Body *b, struct State *s)
       state_attach_puts(strbuf, s);
 
       mutt_copy_hdr(s->fp_in, s->fp_out, ftello(s->fp_in), b->parts->offset,
-                    (C_Weed ? (CH_WEED | CH_REORDER) : CH_NO_FLAGS) | CH_DECODE | CH_DISPLAY, NULL);
+                    (C_Weed ? (CH_WEED | CH_REORDER) : CH_NO_FLAGS) | CH_DECODE | CH_DISPLAY,
+                    NULL);
     }
   }
 

--- a/handler.c
+++ b/handler.c
@@ -72,9 +72,9 @@ char *C_ShowMultipartAlternative; ///< Config: How to display 'multipart/alterna
 #define BUFI_SIZE 1000
 #define BUFO_SIZE 2000
 
-#define TXTHTML 1
-#define TXTPLAIN 2
-#define TXTENRICHED 3
+#define TXT_HTML 1
+#define TXT_PLAIN 2
+#define TXT_ENRICHED 3
 
 /**
  * typedef handler_t - Manage a PGP or S/MIME encrypted MIME part
@@ -333,7 +333,7 @@ static void decode_quoted(struct State *s, long len, bool istext, iconv_t cd)
     /* chop trailing whitespace if we got the full line */
     if (last == '\n')
     {
-      while ((linelen > 0) && ISSPACE(line[linelen - 1]))
+      while ((linelen > 0) && IS_SPACE(line[linelen - 1]))
         linelen--;
       line[linelen] = '\0';
     }
@@ -995,20 +995,20 @@ static int alternative_handler(struct Body *a, struct State *s)
     {
       if (b->type == TYPE_TEXT)
       {
-        if ((mutt_str_strcasecmp("plain", b->subtype) == 0) && (type <= TXTPLAIN))
+        if ((mutt_str_strcasecmp("plain", b->subtype) == 0) && (type <= TXT_PLAIN))
         {
           choice = b;
-          type = TXTPLAIN;
+          type = TXT_PLAIN;
         }
-        else if ((mutt_str_strcasecmp("enriched", b->subtype) == 0) && (type <= TXTENRICHED))
+        else if ((mutt_str_strcasecmp("enriched", b->subtype) == 0) && (type <= TXT_ENRICHED))
         {
           choice = b;
-          type = TXTENRICHED;
+          type = TXT_ENRICHED;
         }
-        else if ((mutt_str_strcasecmp("html", b->subtype) == 0) && (type <= TXTHTML))
+        else if ((mutt_str_strcasecmp("html", b->subtype) == 0) && (type <= TXT_HTML))
         {
           choice = b;
-          type = TXTHTML;
+          type = TXT_HTML;
         }
       }
       b = b->next;

--- a/help.c
+++ b/help.c
@@ -182,7 +182,7 @@ static int print_macro(FILE *fp, int maxwidth, const char **macro)
       if (n < 2)
         break;
       n -= 2;
-      if (wc == '\033')
+      if (wc == '\033') // Escape
         fprintf(fp, "\\e");
       else if (wc == '\n')
         fprintf(fp, "\\n");
@@ -308,7 +308,7 @@ static void format_line(FILE *fp, int ismacro, const char *t1, const char *t2, c
   if (ismacro > 0)
   {
     if (mutt_str_strcmp(C_Pager, "builtin") == 0)
-      fputs("_\010", fp);
+      fputs("_\010", fp); // Ctrl-H (backspace)
     fputs("M ", fp);
     col += 2;
 

--- a/hook.c
+++ b/hook.c
@@ -255,7 +255,7 @@ enum CommandResult mutt_parse_hook(struct Buffer *buf, struct Buffer *s,
   {
     /* Hooks not allowing full patterns: Check syntax of regex */
     rx = mutt_mem_malloc(sizeof(regex_t));
-    rc = REGCOMP(rx, NONULL(pattern.data), ((data & MUTT_CRYPT_HOOK) ? REG_ICASE : 0));
+    rc = REG_COMP(rx, NONULL(pattern.data), ((data & MUTT_CRYPT_HOOK) ? REG_ICASE : 0));
     if (rc != 0)
     {
       regerror(rc, rx, err->data, err->dsize);

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -125,7 +125,7 @@ static char *get_flags(struct ListHead *hflags, char *s)
     s++;
     SKIPWS(s);
     const char *flag_word = s;
-    while (*s && (*s != ')') && !ISSPACE(*s))
+    while (*s && (*s != ')') && !IS_SPACE(*s))
       s++;
     const char ctmp = *s;
     *s = '\0';

--- a/imap/imap_private.h
+++ b/imap/imap_private.h
@@ -56,9 +56,7 @@ struct Progress;
 #define IMAP_CMD_RESPOND   2  ///< `+`
 #define IMAP_CMD_NEW       3  ///< ImapCommand.state additions
 
-#define IMAP_CACHE_LEN 10 ///< number of entries in the hash table */
-
-#define SEQLEN 5
+#define SEQ_LEN 5
 #define IMAP_MAX_CMDLEN 1024 ///< Maximum length of command lines before they must be split (for lazy servers)
 
 typedef uint8_t ImapOpenFlags;         ///< Flags, e.g. #MUTT_THREAD_COLLAPSE
@@ -155,7 +153,7 @@ struct ImapList
  */
 struct ImapCommand
 {
-  char seq[SEQLEN + 1]; ///< Command tag, e.g. 'a0001'
+  char seq[SEQ_LEN + 1]; ///< Command tag, e.g. 'a0001'
   int state;            ///< Command state, e.g. #IMAP_CMD_NEW
 };
 

--- a/imap/message.c
+++ b/imap/message.c
@@ -283,7 +283,7 @@ static char *msg_parse_flags(struct ImapHeader *h, char *s)
       char *flag_word = s;
       bool is_system_keyword = mutt_str_startswith(s, "\\", CASE_IGNORE);
 
-      while (*s && !ISSPACE(*s) && (*s != ')'))
+      while (*s && !IS_SPACE(*s) && (*s != ')'))
         s++;
 
       ctmp = *s;
@@ -1472,7 +1472,7 @@ int imap_append_message(struct Mailbox *m, struct Message *msg)
   {
     mutt_debug(LL_DEBUG1, "#1 command failed: %s\n", adata->buf);
 
-    char *pc = adata->buf + SEQLEN;
+    char *pc = adata->buf + SEQ_LEN;
     SKIPWS(pc);
     pc = imap_next_word(pc);
     mutt_error("%s", pc);
@@ -1508,7 +1508,7 @@ int imap_append_message(struct Mailbox *m, struct Message *msg)
   if (!imap_code(adata->buf))
   {
     mutt_debug(LL_DEBUG1, "#2 command failed: %s\n", adata->buf);
-    char *pc = adata->buf + SEQLEN;
+    char *pc = adata->buf + SEQ_LEN;
     SKIPWS(pc);
     pc = imap_next_word(pc);
     mutt_error("%s", pc);

--- a/imap/util.c
+++ b/imap/util.c
@@ -909,7 +909,7 @@ char *imap_next_word(char *s)
     }
     if (*s == '\"')
       quoted = quoted ? 0 : 1;
-    if (!quoted && ISSPACE(*s))
+    if (!quoted && IS_SPACE(*s))
       break;
     s++;
   }

--- a/index.c
+++ b/index.c
@@ -992,7 +992,7 @@ static void index_custom_redraw(struct Menu *menu)
     char buf[1024];
     menu_status_line(buf, sizeof(buf), menu, NONULL(C_StatusFormat));
     mutt_window_move(MuttStatusWindow, 0, 0);
-    SETCOLOR(MT_COLOR_STATUS);
+    SET_COLOR(MT_COLOR_STATUS);
     mutt_draw_statusline(MuttStatusWindow->cols, buf, sizeof(buf));
     NORMAL_COLOR;
     menu->redraw &= ~REDRAW_STATUS;

--- a/index.c
+++ b/index.c
@@ -2265,7 +2265,7 @@ int mutt_index_menu(void)
             mutt_mailbox(Context ? Context->mailbox : NULL, buf, sizeof(buf));
           }
 
-          if (mutt_enter_fname(cp, buf, sizeof(buf), 1) == -1)
+          if (mutt_enter_fname(cp, buf, sizeof(buf), true) == -1)
           {
             if (menu->menu == MENU_PAGER)
             {

--- a/init.c
+++ b/init.c
@@ -76,10 +76,10 @@
  * avoid cyclic sourcing */
 static struct ListHead MuttrcStack = STAILQ_HEAD_INITIALIZER(MuttrcStack);
 
-#define MAXERRS 128
+#define MAX_ERRS 128
 
-#define NUMVARS mutt_array_size(MuttVars)
-#define NUMCOMMANDS mutt_array_size(Commands)
+#define NUM_VARS mutt_array_size(MuttVars)
+#define NUM_COMMANDS mutt_array_size(Commands)
 
 /* Initial string that starts completion. No telling how much the user has
  * typed so far. Allocate 1024 just to be sure! */
@@ -89,7 +89,7 @@ static int NumMatched = 0;          /* Number of matches for completion */
 static char Completed[256] = { 0 }; /* completed string (command or variable) */
 static const char **Matches;
 /* this is a lie until mutt_init runs: */
-static int MatchesListsize = MAX(NUMVARS, NUMCOMMANDS) + 10;
+static int MatchesListsize = MAX(NUM_VARS, NUM_COMMANDS) + 10;
 
 #ifdef USE_NOTMUCH
 /* List of tags found in last call to mutt_nm_query_complete(). */
@@ -164,7 +164,7 @@ static void matches_ensure_morespace(int current)
   if (current <= (MatchesListsize - 2))
     return;
 
-  int base_space = MAX(NUMVARS, NUMCOMMANDS) + 1;
+  int base_space = MAX(NUM_VARS, NUM_COMMANDS) + 1;
   int extra_space = MatchesListsize - base_space;
   extra_space *= 2;
   const int space = base_space + extra_space;
@@ -508,7 +508,7 @@ static enum CommandResult parse_attach_list(struct Buffer *buf, struct Buffer *s
     tmpminor[len + 2] = '\0';
 
     a->major_int = mutt_check_mime_type(a->major);
-    ret = REGCOMP(&a->minor_regex, tmpminor, REG_ICASE);
+    ret = REG_COMP(&a->minor_regex, tmpminor, REG_ICASE);
 
     FREE(&tmpminor);
 
@@ -824,7 +824,7 @@ static int source_rc(const char *rcfile_path, struct Buffer *err)
     if (line_rc == MUTT_CMD_ERROR)
     {
       mutt_error(_("Error in %s, line %d: %s"), rcfile, line, err->data);
-      if (--rc < -MAXERRS)
+      if (--rc < -MAX_ERRS)
       {
         if (conv)
           FREE(&currentline);
@@ -858,7 +858,7 @@ static int source_rc(const char *rcfile_path, struct Buffer *err)
   {
     /* the neomuttrc source keyword */
     mutt_buffer_reset(err);
-    mutt_buffer_printf(err, (rc >= -MAXERRS) ? _("source: errors in %s") : _("source: reading aborted due to too many errors in %s"),
+    mutt_buffer_printf(err, (rc >= -MAX_ERRS) ? _("source: errors in %s") : _("source: reading aborted due to too many errors in %s"),
                        rcfile);
     rc = -1;
   }
@@ -2672,7 +2672,7 @@ int mutt_extract_token(struct Buffer *dest, struct Buffer *tok, TokenFlags flags
   {
     if (!qc)
     {
-      if ((ISSPACE(ch) && !(flags & MUTT_TOKEN_SPACE)) ||
+      if ((IS_SPACE(ch) && !(flags & MUTT_TOKEN_SPACE)) ||
           ((ch == '#') && !(flags & MUTT_TOKEN_COMMENT)) ||
           ((ch == '=') && (flags & MUTT_TOKEN_EQUAL)) ||
           ((ch == '?') && (flags & MUTT_TOKEN_QUESTION)) ||

--- a/init.c
+++ b/init.c
@@ -2703,7 +2703,7 @@ int mutt_extract_token(struct Buffer *dest, struct Buffer *tok, TokenFlags flags
           tok->dptr++;
           break;
         case 'e':
-          mutt_buffer_addch(dest, '\033');
+          mutt_buffer_addch(dest, '\033'); // Escape
           break;
         case 'f':
           mutt_buffer_addch(dest, '\f');
@@ -2736,7 +2736,7 @@ int mutt_extract_token(struct Buffer *dest, struct Buffer *tok, TokenFlags flags
       if (ch == '^')
         mutt_buffer_addch(dest, ch);
       else if (ch == '[')
-        mutt_buffer_addch(dest, '\033');
+        mutt_buffer_addch(dest, '\033'); // Escape
       else if (isalpha((unsigned char) ch))
         mutt_buffer_addch(dest, toupper((unsigned char) ch) - '@');
       else
@@ -3013,10 +3013,10 @@ int mutt_init(bool skip_sys_rc, struct ListHead *commands)
   mutt_menu_init();
   mutt_buffer_pool_init();
 
-  snprintf(AttachmentMarker, sizeof(AttachmentMarker), "\033]9;%" PRIu64 "\a",
+  snprintf(AttachmentMarker, sizeof(AttachmentMarker), "\033]9;%" PRIu64 "\a", // Escape
            mutt_rand64());
 
-  snprintf(ProtectedHeaderMarker, sizeof(ProtectedHeaderMarker), "\033]8;%ld\a",
+  snprintf(ProtectedHeaderMarker, sizeof(ProtectedHeaderMarker), "\033]8;%ld\a", // Escape
            (long) time(NULL));
 
   /* "$spoolfile" precedence: config file, environment */

--- a/init.h
+++ b/init.h
@@ -1552,7 +1552,7 @@ struct ConfigDef MuttVars[] = {
   ** of mailboxes it polls for new mail just as if you had issued individual
   ** "$mailboxes" commands.
   */
-  { "imap_condstore",  DT_BOOL, R_NONE, &C_ImapCondStore, 0 },
+  { "imap_condstore",  DT_BOOL, R_NONE, &C_ImapCondStore, false },
   /*
   ** .pp
   ** When \fIset\fP, mutt will use the CONDSTORE extension (RFC 7162)
@@ -1674,7 +1674,7 @@ struct ConfigDef MuttVars[] = {
   ** for new mail, before timing out and closing the connection.  Set
   ** to 0 to disable timing out.
   */
-  { "imap_qresync",  DT_BOOL, R_NONE, &C_ImapQResync, 0 },
+  { "imap_qresync",  DT_BOOL, R_NONE, &C_ImapQResync, false },
   /*
   ** .pp
   ** When \fIset\fP, mutt will use the QRESYNC extension (RFC 7162)
@@ -2503,7 +2503,7 @@ struct ConfigDef MuttVars[] = {
   ** subprocess failed.
   ** (PGP only)
   */
-  { "pgp_check_gpg_decrypt_status_fd", DT_BOOL, R_NONE, &C_PgpCheckGpgDecryptStatusFd, 1 },
+  { "pgp_check_gpg_decrypt_status_fd", DT_BOOL, R_NONE, &C_PgpCheckGpgDecryptStatusFd, true },
   /*
   ** .pp
   ** If \fIset\fP, mutt will check the status file descriptor output

--- a/keymap.c
+++ b/keymap.c
@@ -97,7 +97,7 @@ static struct Mapping KeyNames[] = {
   { "<End>", KEY_END },
   { "<Enter>", '\n' },
   { "<Return>", '\r' },
-  { "<Esc>", '\033' },
+  { "<Esc>", '\033' }, // Escape
   { "<Tab>", '\t' },
   { "<Space>", ' ' },
 #ifdef KEY_BTAB

--- a/keymap.c
+++ b/keymap.c
@@ -201,7 +201,7 @@ static int parse_keycode(const char *s)
   char *end_char = NULL;
   long int result = strtol(s + 1, &end_char, 8);
   /* allow trailing whitespace, eg.  < 1001 > */
-  while (ISSPACE(*end_char))
+  while (IS_SPACE(*end_char))
     end_char++;
   /* negative keycodes don't make sense, also detect overflow */
   if ((*end_char != '>') || (result < 0) || (result == LONG_MAX))

--- a/mailbox.h
+++ b/mailbox.h
@@ -149,7 +149,6 @@ struct MailboxNode
   struct Mailbox *mailbox;
   STAILQ_ENTRY(MailboxNode) entries;
 };
-
 STAILQ_HEAD(MailboxList, MailboxNode);
 
 extern struct MailboxList AllMailboxes; ///< List of all Mailboxes

--- a/menu.c
+++ b/menu.c
@@ -153,9 +153,9 @@ static void print_enriched_string(int index, int attr, unsigned char *s, bool do
         /* Combining tree fg color and another bg color requires
          * having use_default_colors, because the other bg color
          * may be undefined. */
-        ATTRSET(mutt_combine_color(ColorDefs[MT_COLOR_TREE], attr));
+        ATTR_SET(mutt_combine_color(ColorDefs[MT_COLOR_TREE], attr));
 #else
-        SETCOLOR(MT_COLOR_TREE);
+        SET_COLOR(MT_COLOR_TREE);
 #endif
 
       while (*s && (*s < MUTT_TREE_MAX))
@@ -276,7 +276,7 @@ static void print_enriched_string(int index, int attr, unsigned char *s, bool do
         n--;
       }
       if (do_color)
-        ATTRSET(attr);
+        ATTR_SET(attr);
     }
     else if (*s == MUTT_SPECIAL_INDEX)
     {
@@ -365,7 +365,7 @@ void menu_redraw_full(struct Menu *menu)
 
   if (C_Help)
   {
-    SETCOLOR(MT_COLOR_STATUS);
+    SET_COLOR(MT_COLOR_STATUS);
     mutt_window_move(menu->helpwin, 0, 0);
     mutt_paddstr(menu->helpwin->cols, menu->help);
     NORMAL_COLOR;
@@ -390,7 +390,7 @@ void menu_redraw_status(struct Menu *menu)
   char buf[256];
 
   snprintf(buf, sizeof(buf), "-- NeoMutt: %s", menu->title);
-  SETCOLOR(MT_COLOR_STATUS);
+  SET_COLOR(MT_COLOR_STATUS);
   mutt_window_move(menu->statuswin, 0, 0);
   mutt_paddstr(menu->statuswin->cols, buf);
   NORMAL_COLOR;
@@ -428,17 +428,17 @@ void menu_redraw_index(struct Menu *menu)
       menu_make_entry(buf, sizeof(buf), menu, i);
       menu_pad_string(menu, buf, sizeof(buf));
 
-      ATTRSET(attr);
+      ATTR_SET(attr);
       mutt_window_move(menu->indexwin, i - menu->top + menu->offset, 0);
       do_color = true;
 
       if (i == menu->current)
       {
-        SETCOLOR(MT_COLOR_INDICATOR);
+        SET_COLOR(MT_COLOR_INDICATOR);
         if (C_ArrowCursor)
         {
           addstr("->");
-          ATTRSET(attr);
+          ATTR_SET(attr);
           addch(' ');
         }
         else
@@ -479,7 +479,7 @@ void menu_redraw_motion(struct Menu *menu)
    * position the cursor for drawing. */
   const int old_color = menu->menu_color(menu->oldcurrent);
   mutt_window_move(menu->indexwin, menu->oldcurrent + menu->offset - menu->top, 0);
-  ATTRSET(old_color);
+  ATTR_SET(old_color);
 
   if (C_ArrowCursor)
   {
@@ -495,7 +495,7 @@ void menu_redraw_motion(struct Menu *menu)
     }
 
     /* now draw it in the new location */
-    SETCOLOR(MT_COLOR_INDICATOR);
+    SET_COLOR(MT_COLOR_INDICATOR);
     mutt_window_mvaddstr(menu->indexwin, menu->current + menu->offset - menu->top, 0, "->");
   }
   else
@@ -509,7 +509,7 @@ void menu_redraw_motion(struct Menu *menu)
     const int cur_color = menu->menu_color(menu->current);
     menu_make_entry(buf, sizeof(buf), menu, menu->current);
     menu_pad_string(menu, buf, sizeof(buf));
-    SETCOLOR(MT_COLOR_INDICATOR);
+    SET_COLOR(MT_COLOR_INDICATOR);
     mutt_window_move(menu->indexwin, menu->current + menu->offset - menu->top, 0);
     print_enriched_string(menu->current, cur_color, (unsigned char *) buf, 0);
   }
@@ -530,11 +530,11 @@ void menu_redraw_current(struct Menu *menu)
   menu_make_entry(buf, sizeof(buf), menu, menu->current);
   menu_pad_string(menu, buf, sizeof(buf));
 
-  SETCOLOR(MT_COLOR_INDICATOR);
+  SET_COLOR(MT_COLOR_INDICATOR);
   if (C_ArrowCursor)
   {
     addstr("->");
-    ATTRSET(attr);
+    ATTR_SET(attr);
     addch(' ');
     menu_pad_string(menu, buf, sizeof(buf));
     print_enriched_string(menu->current, attr, (unsigned char *) buf, 1);
@@ -1176,7 +1176,7 @@ static int menu_search(struct Menu *menu, int op)
   if (search_buf)
   {
     int flags = mutt_mb_is_lower(search_buf) ? REG_ICASE : 0;
-    rc = REGCOMP(&re, search_buf, REG_NOSUB | flags);
+    rc = REG_COMP(&re, search_buf, REG_NOSUB | flags);
   }
 
   if (rc != 0)

--- a/mutt.h
+++ b/mutt.h
@@ -132,7 +132,7 @@ struct AttachMatch
   regex_t minor_regex;
 };
 
-#define EXECSHELL "/bin/sh"
+#define EXEC_SHELL "/bin/sh"
 
 char *mutt_compile_help(char *buf, size_t buflen, int menu, const struct Mapping *items);
 

--- a/mutt/buffer.c
+++ b/mutt/buffer.c
@@ -320,7 +320,7 @@ void mutt_buffer_strcpy(struct Buffer *buf, const char *s)
 }
 
 /**
- * mutt_buffer_strcpy - Copy a string into a Buffer
+ * mutt_buffer_strcpy_n - Copy a string into a Buffer
  * @param buf Buffer to overwrite
  * @param s   String to copy
  * @param len Length of string to copy

--- a/mutt/charset.c
+++ b/mutt/charset.c
@@ -450,7 +450,7 @@ bool mutt_ch_lookup_add(enum LookupType type, const char *pat,
     return false;
 
   regex_t *rx = mutt_mem_malloc(sizeof(regex_t));
-  int rc = REGCOMP(rx, pat, REG_ICASE);
+  int rc = REG_COMP(rx, pat, REG_ICASE);
   if (rc != 0)
   {
     regerror(rc, rx, err->data, err->dsize);

--- a/mutt/date.c
+++ b/mutt/date.c
@@ -414,7 +414,7 @@ int mutt_date_check_month(const char *s)
  */
 bool mutt_date_is_day_name(const char *s)
 {
-  if ((strlen(s) < 3) || !*(s + 3) || !ISSPACE(*(s + 3)))
+  if ((strlen(s) < 3) || !*(s + 3) || !IS_SPACE(*(s + 3)))
     return false;
 
   for (int i = 0; i < mutt_array_size(Weekdays); i++)

--- a/mutt/hash.c
+++ b/mutt/hash.c
@@ -34,7 +34,7 @@
 #include "memory.h"
 #include "string2.h"
 
-#define SOMEPRIME 149711
+#define SOME_PRIME 149711
 
 /**
  * gen_string_hash - Generate a hash from a string
@@ -49,7 +49,7 @@ static size_t gen_string_hash(union HashKey key, size_t n)
 
   while (*s)
     h += ((h << 7) + *s++);
-  h = (h * SOMEPRIME) % n;
+  h = (h * SOME_PRIME) % n;
 
   return h;
 }
@@ -80,7 +80,7 @@ static size_t gen_case_string_hash(union HashKey key, size_t n)
 
   while (*s)
     h += ((h << 7) + tolower(*s++));
-  h = (h * SOMEPRIME) % n;
+  h = (h * SOME_PRIME) % n;
 
   return h;
 }

--- a/mutt/list.h
+++ b/mutt/list.h
@@ -35,13 +35,6 @@ struct ListNode
   char *data;
   STAILQ_ENTRY(ListNode) entries;
 };
-
-/**
- * struct ListHead - A generic list of strings
- *
- * The List is stored as a STAILQ.
- * This means that insertions are quick at the head and tail of the list.
- */
 STAILQ_HEAD(ListHead, ListNode);
 
 /**

--- a/mutt/logging.c
+++ b/mutt/logging.c
@@ -485,7 +485,7 @@ int log_disp_terminal(time_t stamp, const char *file, int line,
   }
 
   if (colour > 0)
-    ret += fprintf(fp, "\033[1;%dm", colour);
+    ret += fprintf(fp, "\033[1;%dm", colour); // Escape
 
   fputs(buf, fp);
 
@@ -493,7 +493,7 @@ int log_disp_terminal(time_t stamp, const char *file, int line,
     ret += fprintf(fp, ": %s", strerror(err));
 
   if (colour > 0)
-    ret += fprintf(fp, "\033[0m");
+    ret += fprintf(fp, "\033[0m"); // Escape
 
   ret += fprintf(fp, "\n");
 

--- a/mutt/logging.h
+++ b/mutt/logging.h
@@ -75,13 +75,6 @@ struct LogLine
   char *message;
   STAILQ_ENTRY(LogLine) entries;
 };
-
-/**
- * struct LogList - A list of log lines
- *
- * The Log is stored as a STAILQ.
- * This means that insertions are quick at the head and tail of the list.
- */
 STAILQ_HEAD(LogList, LogLine);
 
 #define mutt_debug(LEVEL, ...) MuttLogger(0, __FILE__, __LINE__, __func__, LEVEL,      __VA_ARGS__)

--- a/mutt/md5.c
+++ b/mutt/md5.c
@@ -40,8 +40,6 @@
 #define SWAP(n) (n)
 #endif
 
-#define BLOCKSIZE 4096
-
 /* This array contains the bytes used to pad the buffer to the next
  * 64-byte boundary.  (RFC1321, 3.1: Step 1)  */
 static const unsigned char fillbuf[64] = { 0x80, 0 /* , 0, 0, ... */ };

--- a/mutt/regex.c
+++ b/mutt/regex.c
@@ -54,7 +54,7 @@ struct Regex *mutt_regex_compile(const char *str, int flags)
   struct Regex *rx = mutt_mem_calloc(1, sizeof(struct Regex));
   rx->pattern = mutt_str_strdup(str);
   rx->regex = mutt_mem_calloc(1, sizeof(regex_t));
-  if (REGCOMP(rx->regex, NONULL(str), flags) != 0)
+  if (REG_COMP(rx->regex, NONULL(str), flags) != 0)
     mutt_regex_free(&rx);
 
   return rx;
@@ -90,7 +90,7 @@ struct Regex *mutt_regex_new(const char *str, int flags, struct Buffer *err)
     str++;
   }
 
-  int rc = REGCOMP(reg->regex, str, rflags);
+  int rc = REG_COMP(reg->regex, str, rflags);
   if ((rc != 0) && err)
   {
     regerror(rc, reg->regex, err->data, err->dsize);

--- a/mutt/regex3.h
+++ b/mutt/regex3.h
@@ -42,14 +42,14 @@ struct Buffer;
 #endif
 
 /**
- * REGCOMP - Compile a regular expression
+ * REG_COMP - Compile a regular expression
  * @param preg   regex_t struct to fill
  * @param regex  Regular expression string
  * @param cflags Flags
  * @retval   0 Success
  * @retval num Failure, e.g. REG_BADPAT
  */
-#define REGCOMP(preg, regex, cflags) regcomp(preg, regex, REG_WORDS | REG_EXTENDED | (cflags))
+#define REG_COMP(preg, regex, cflags) regcomp(preg, regex, REG_WORDS | REG_EXTENDED | (cflags))
 
 /**
  * struct Regex - Cached regular expression

--- a/mutt/regex3.h
+++ b/mutt/regex3.h
@@ -69,7 +69,6 @@ struct RegexListNode
   struct Regex *regex; /**< Regex containing a regular expression */
   STAILQ_ENTRY(RegexListNode) entries; /**< Next item in list */
 };
-
 STAILQ_HEAD(RegexList, RegexListNode);
 
 /**

--- a/mutt/sha1.h
+++ b/mutt/sha1.h
@@ -42,6 +42,4 @@ void mutt_sha1_init(struct Sha1Ctx *sha1ctx);
 void mutt_sha1_transform(uint32_t state[5], const unsigned char buffer[64]);
 void mutt_sha1_update(struct Sha1Ctx *sha1ctx, const unsigned char *data, uint32_t len);
 
-#define SHA_DIGEST_LENGTH 20
-
 #endif /* MUTT_LIB_SHA1_H */

--- a/mutt/string.c
+++ b/mutt/string.c
@@ -731,7 +731,7 @@ char *mutt_str_skip_whitespace(char *p)
  */
 void mutt_str_remove_trailing_ws(char *s)
 {
-  for (char *p = s + mutt_str_strlen(s) - 1; (p >= s) && ISSPACE(*p); p--)
+  for (char *p = s + mutt_str_strlen(s) - 1; (p >= s) && IS_SPACE(*p); p--)
     *p = '\0';
 }
 
@@ -901,7 +901,7 @@ void mutt_str_dequote_comment(char *s)
  */
 const char *mutt_str_next_word(const char *s)
 {
-  while (*s && !ISSPACE(*s))
+  while (*s && !IS_SPACE(*s))
     s++;
   SKIPWS(s);
   return s;
@@ -957,7 +957,7 @@ int mutt_str_word_casecmp(const char *a, const char *b)
   int i;
   for (i = 0; i < (sizeof(tmp) - 2); i++, b++)
   {
-    if (!*b || ISSPACE(*b))
+    if (!*b || IS_SPACE(*b))
     {
       tmp[i] = '\0';
       break;

--- a/mutt/string2.h
+++ b/mutt/string2.h
@@ -34,7 +34,7 @@
 #define STR_COMMAND 8192  ///< Enough space for a long command line
 
 #define NONULL(x) ((x) ? (x) : "")
-#define ISSPACE(ch) isspace((unsigned char) ch)
+#define IS_SPACE(ch) isspace((unsigned char) ch)
 #define EMAIL_WSP " \t\r\n"
 
 /* Exit values */

--- a/mutt_account.h
+++ b/mutt_account.h
@@ -56,7 +56,7 @@ enum AccountType
 };
 
 typedef uint8_t MuttAccountFlags;     ///< Flags, Which ConnAccount fields are initialised, e.g. #MUTT_ACCT_PORT
-#define MUTT_ACCT__NO_FLAGS       0   ///< No flags are set
+#define MUTT_ACCT_NO_FLAGS        0   ///< No flags are set
 #define MUTT_ACCT_PORT      (1 << 0)  ///< Port field has been set
 #define MUTT_ACCT_USER      (1 << 1)  ///< User field has been set
 #define MUTT_ACCT_LOGIN     (1 << 2)  ///< Login field has been set

--- a/mutt_curses.h
+++ b/mutt_curses.h
@@ -211,7 +211,7 @@ extern struct ColorLineHead ColorIndexTagList;     ///< List of colours applied 
  * right column.
  */
 #ifdef HAVE_BKGDSET
-#define SETCOLOR(X)                                                            \
+#define SET_COLOR(X)                                                            \
   do                                                                           \
   {                                                                            \
     if (ColorDefs[X] != 0)                                                     \
@@ -219,9 +219,9 @@ extern struct ColorLineHead ColorIndexTagList;     ///< List of colours applied 
     else                                                                       \
       bkgdset(ColorDefs[MT_COLOR_NORMAL] | ' ');                               \
   } while (false)
-#define ATTRSET(X) bkgdset(X | ' ')
+#define ATTR_SET(X) bkgdset(X | ' ')
 #else
-#define SETCOLOR(X)                                                            \
+#define SET_COLOR(X)                                                            \
   do                                                                           \
   {                                                                            \
     if (ColorDefs[X] != 0)                                                     \
@@ -229,7 +229,7 @@ extern struct ColorLineHead ColorIndexTagList;     ///< List of colours applied 
     else                                                                       \
       attrset(ColorDefs[MT_COLOR_NORMAL]);                                     \
   } while (false)
-#define ATTRSET attrset
+#define ATTR_SET attrset
 #endif
 
 /* reset the color to the normal terminal color as defined by 'color normal ...' */

--- a/mutt_header.c
+++ b/mutt_header.c
@@ -339,7 +339,7 @@ void mutt_edit_headers(const char *editor, const char *body, struct Email *msg,
     else if (((WithCrypto & APPLICATION_PGP) != 0) &&
              (plen = mutt_str_startswith(np->data, "pgp:", CASE_IGNORE)))
     {
-      msg->security = mutt_parse_crypt_hdr(np->data + plen, 0, APPLICATION_PGP);
+      msg->security = mutt_parse_crypt_hdr(np->data + plen, false, APPLICATION_PGP);
       if (msg->security)
         msg->security |= APPLICATION_PGP;
       keep = false;

--- a/mutt_logging.c
+++ b/mutt_logging.c
@@ -202,7 +202,7 @@ int log_disp_curses(time_t stamp, const char *file, int line,
   {
     if (level == LL_ERROR)
       BEEP();
-    SETCOLOR((level == LL_ERROR) ? MT_COLOR_ERROR : MT_COLOR_MESSAGE);
+    SET_COLOR((level == LL_ERROR) ? MT_COLOR_ERROR : MT_COLOR_MESSAGE);
     mutt_window_mvaddstr(MuttMessageWindow, 0, 0, ErrorBuf);
     NORMAL_COLOR;
     mutt_window_clrtoeol(MuttMessageWindow);

--- a/muttlib.c
+++ b/muttlib.c
@@ -846,7 +846,7 @@ void mutt_safe_path(char *buf, size_t buflen, struct Address *a)
 {
   mutt_save_path(buf, buflen, a);
   for (char *p = buf; *p; p++)
-    if ((*p == '/') || ISSPACE(*p) || !IsPrint((unsigned char) *p))
+    if ((*p == '/') || IS_SPACE(*p) || !IsPrint((unsigned char) *p))
       *p = '_';
 }
 

--- a/muttlib.c
+++ b/muttlib.c
@@ -1714,7 +1714,7 @@ int mutt_inbox_cmp(const char *a, const char *b)
 }
 
 /**
- * mutt_buffer_concat - Join a directory name and a filename
+ * mutt_buffer_concat_path - Join a directory name and a filename
  * @param d     Buffer to add to
  * @param dir   Directory name
  * @param fname File name

--- a/ncrypt/crypt.c
+++ b/ncrypt/crypt.c
@@ -136,12 +136,12 @@ static void disable_coredumps(void)
 /**
  * crypt_valid_passphrase - Check that we have a usable passphrase, ask if not
  * @param flags Flags, see #SecurityFlags
- * @retval  0 Success
- * @retval -1 Failure
+ * @retval true  Success
+ * @retval false Failed
  */
-int crypt_valid_passphrase(SecurityFlags flags)
+bool crypt_valid_passphrase(SecurityFlags flags)
 {
-  int rc = 0;
+  bool rc = false;
 
 #ifndef DEBUG
   disable_coredumps();

--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -985,7 +985,7 @@ static char *data_object_to_tempfile(gpgme_data_t data, FILE **fp_ret)
 #if GPGME_VERSION_NUMBER >= 0x010b00 /* gpgme >= 1.11.0 */
 
 /**
- * create_recipient_string - XXX
+ * create_recipient_string - Create a string of recipients
  * @param keylist    Keys, space-separated
  * @param recpstring Buffer to store the recipients
  * @param use_smime  Use SMIME
@@ -3087,10 +3087,7 @@ int pgp_gpgme_application_handler(struct Body *m, struct State *s)
       }
 
       gpgme_data_release(armored_data);
-      if (fp_out)
-      {
-        mutt_file_fclose(&fp_out);
-      }
+      mutt_file_fclose(&fp_out);
     }
     else
     {
@@ -3317,7 +3314,7 @@ int smime_gpgme_application_handler(struct Body *a, struct State *s)
  * | \%p     | Protocol
  * | \%t     | Trust/validity of the key-uid association
  * | \%u     | User id
- * | \%[...] | Date of key using strftime(3)
+ * | \%[fmt] | Date of key using strftime(3)
  * |         |
  * | \%a     | Algorithm
  * | \%c     | Capabilities

--- a/ncrypt/crypt_mod.h
+++ b/ncrypt/crypt_mod.h
@@ -52,13 +52,13 @@ struct CryptModuleSpecs
   void         (*void_passphrase)(void);
   /**
    * valid_passphrase - Ensure we have a valid passphrase
-   * @retval 1 Success
-   * @retval 0 Failed
+   * @retval true  Success
+   * @retval false Failed
    *
    * If the passphrase is within the expiry time (backend-specific), use it.
    * If not prompt the user again.
    */
-  int          (*valid_passphrase)(void);
+  bool         (*valid_passphrase)(void);
   /**
    * decrypt_mime - Decrypt an encrypted MIME part
    * @param[in]  fp_in  File containing the encrypted part

--- a/ncrypt/crypt_mod_pgp_gpgme.c
+++ b/ncrypt/crypt_mod_pgp_gpgme.c
@@ -46,9 +46,9 @@ static void pgp_gpgme_void_passphrase(void)
  *
  * This is handled by gpg-agent.
  */
-static int pgp_gpgme_valid_passphrase(void)
+static bool pgp_gpgme_valid_passphrase(void)
 {
-  return 1;
+  return true;
 }
 
 // clang-format off

--- a/ncrypt/crypt_mod_smime_gpgme.c
+++ b/ncrypt/crypt_mod_smime_gpgme.c
@@ -46,9 +46,9 @@ static void smime_gpgme_void_passphrase(void)
  *
  * This is handled by gpg-agent.
  */
-static int smime_gpgme_valid_passphrase(void)
+static bool smime_gpgme_valid_passphrase(void)
 {
-  return 1;
+  return true;
 }
 
 // clang-format off

--- a/ncrypt/cryptglue.c
+++ b/ncrypt/cryptglue.c
@@ -177,12 +177,12 @@ void crypt_pgp_void_passphrase(void)
 /**
  * crypt_pgp_valid_passphrase - Wrapper for CryptModuleSpecs::valid_passphrase()
  */
-int crypt_pgp_valid_passphrase(void)
+bool crypt_pgp_valid_passphrase(void)
 {
   if (CRYPT_MOD_CALL_CHECK(PGP, valid_passphrase))
     return CRYPT_MOD_CALL(PGP, valid_passphrase)();
 
-  return 0;
+  return false;
 }
 
 /**
@@ -358,12 +358,12 @@ void crypt_smime_void_passphrase(void)
 /**
  * crypt_smime_valid_passphrase - Wrapper for CryptModuleSpecs::valid_passphrase()
  */
-int crypt_smime_valid_passphrase(void)
+bool crypt_smime_valid_passphrase(void)
 {
   if (CRYPT_MOD_CALL_CHECK(SMIME, valid_passphrase))
     return CRYPT_MOD_CALL(SMIME, valid_passphrase)();
 
-  return 0;
+  return false;
 }
 
 /**

--- a/ncrypt/cryptglue.h
+++ b/ncrypt/cryptglue.h
@@ -35,7 +35,7 @@ void         crypt_pgp_invoke_import(const char *fname);
 void         crypt_pgp_set_sender(const char *sender);
 struct Body *crypt_pgp_sign_message(struct Body *a);
 struct Body *crypt_pgp_traditional_encryptsign(struct Body *a, int flags, char *keylist);
-int          crypt_pgp_valid_passphrase(void);
+bool         crypt_pgp_valid_passphrase(void);
 int          crypt_pgp_verify_one(struct Body *sigbdy, struct State *s, const char *tempf);
 void         crypt_pgp_void_passphrase(void);
 
@@ -44,7 +44,7 @@ char *       crypt_smime_find_keys(struct Address *addrlist, bool oppenc_mode);
 void         crypt_smime_invoke_import(char *infile, char *mailbox);
 void         crypt_smime_set_sender(const char *sender);
 struct Body *crypt_smime_sign_message(struct Body *a);
-int          crypt_smime_valid_passphrase(void);
+bool         crypt_smime_valid_passphrase(void);
 int          crypt_smime_verify_one(struct Body *sigbdy, struct State *s, const char *tempf);
 void         crypt_smime_void_passphrase(void);
 

--- a/ncrypt/ncrypt.h
+++ b/ncrypt/ncrypt.h
@@ -186,7 +186,7 @@ void         crypt_forget_passphrase(void);
 int          crypt_get_keys(struct Email *msg, char **keylist, bool oppenc_mode);
 void         crypt_opportunistic_encrypt(struct Email *msg);
 SecurityFlags crypt_query(struct Body *m);
-int          crypt_valid_passphrase(SecurityFlags flags);
+bool         crypt_valid_passphrase(SecurityFlags flags);
 SecurityFlags mutt_is_application_pgp(struct Body *m);
 SecurityFlags mutt_is_application_smime(struct Body *m);
 SecurityFlags mutt_is_malformed_multipart_pgp_encrypted(struct Body *b);

--- a/ncrypt/pgp.c
+++ b/ncrypt/pgp.c
@@ -89,20 +89,20 @@ void pgp_class_void_passphrase(void)
 /**
  * pgp_class_valid_passphrase - Implements CryptModuleSpecs::valid_passphrase()
  */
-int pgp_class_valid_passphrase(void)
+bool pgp_class_valid_passphrase(void)
 {
   time_t now = time(NULL);
 
   if (pgp_use_gpg_agent())
   {
     *PgpPass = '\0';
-    return 1; /* handled by gpg-agent */
+    return true; /* handled by gpg-agent */
   }
 
   if (now < PgpExptime)
   {
     /* Use cached copy.  */
-    return 1;
+    return true;
   }
 
   pgp_class_void_passphrase();
@@ -110,12 +110,12 @@ int pgp_class_valid_passphrase(void)
   if (mutt_get_password(_("Enter PGP passphrase:"), PgpPass, sizeof(PgpPass)) == 0)
   {
     PgpExptime = mutt_date_add_timeout(time(NULL), C_PgpTimeout);
-    return 1;
+    return true;
   }
   else
     PgpExptime = 0;
 
-  return 0;
+  return false;
 }
 
 /**

--- a/ncrypt/pgp.h
+++ b/ncrypt/pgp.h
@@ -53,7 +53,7 @@ int pgp_class_application_handler(struct Body *m, struct State *s);
 int pgp_class_encrypted_handler(struct Body *a, struct State *s);
 void pgp_class_extract_key_from_attachment(FILE *fp, struct Body *top);
 void pgp_class_void_passphrase(void);
-int pgp_class_valid_passphrase(void);
+bool pgp_class_valid_passphrase(void);
 
 int pgp_class_verify_one(struct Body *sigbdy, struct State *s, const char *tempfile);
 struct Body *pgp_class_traditional_encryptsign(struct Body *a, SecurityFlags flags, char *keylist);

--- a/ncrypt/pgpkey.c
+++ b/ncrypt/pgpkey.c
@@ -160,7 +160,7 @@ struct PgpEntry
  * | \%n     | Number
  * | \%t     | Trust/validity of the key-uid association
  * | \%u     | User id
- * | \%[...] | Date of key using strftime(3)
+ * | \%[fmt] | Date of key using strftime(3)
  * |         |
  * | \%a     | Algorithm
  * | \%c     | Capabilities

--- a/ncrypt/pgppacket.c
+++ b/ncrypt/pgppacket.c
@@ -32,7 +32,7 @@
 #include <stdlib.h>
 #include "mutt/mutt.h"
 
-#define CHUNKSIZE 1024 /**< Amount of data to read at once */
+#define CHUNK_SIZE 1024 /**< Amount of data to read at once */
 
 static unsigned char *pbuf = NULL; /**< Cache PGP data packet */
 static size_t plen = 0;            /**< Length of cached packet */
@@ -51,7 +51,7 @@ static int read_material(size_t material, size_t *used, FILE *fp)
 {
   if (*used + material >= plen)
   {
-    size_t nplen = *used + material + CHUNKSIZE;
+    size_t nplen = *used + material + CHUNK_SIZE;
 
     unsigned char *p = realloc(pbuf, nplen);
     if (!p)
@@ -94,7 +94,7 @@ unsigned char *pgp_read_packet(FILE *fp, size_t *len)
 
   if (plen == 0)
   {
-    plen = CHUNKSIZE;
+    plen = CHUNK_SIZE;
     pbuf = mutt_mem_malloc(plen);
   }
 

--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -168,14 +168,14 @@ void smime_class_void_passphrase(void)
 /**
  * smime_class_valid_passphrase - Implements CryptModuleSpecs::valid_passphrase()
  */
-int smime_class_valid_passphrase(void)
+bool smime_class_valid_passphrase(void)
 {
   time_t now = time(NULL);
 
   if (now < SmimeExptime)
   {
     /* Use cached copy.  */
-    return 1;
+    return true;
   }
 
   smime_class_void_passphrase();
@@ -183,12 +183,12 @@ int smime_class_valid_passphrase(void)
   if (mutt_get_password(_("Enter S/MIME passphrase:"), SmimePass, sizeof(SmimePass)) == 0)
   {
     SmimeExptime = mutt_date_add_timeout(time(NULL), C_SmimeTimeout);
-    return 1;
+    return true;
   }
   else
     SmimeExptime = 0;
 
-  return 0;
+  return false;
 }
 
 /*

--- a/ncrypt/smime.h
+++ b/ncrypt/smime.h
@@ -56,7 +56,7 @@ void         smime_class_getkeys(struct Envelope *env);
 void         smime_class_invoke_import(char *infile, char *mailbox);
 int          smime_class_send_menu(struct Email *msg);
 struct Body *smime_class_sign_message(struct Body *a);
-int          smime_class_valid_passphrase(void);
+bool         smime_class_valid_passphrase(void);
 int          smime_class_verify_one(struct Body *sigbdy, struct State *s, const char *tempfile);
 int          smime_class_verify_sender(struct Email *e);
 void         smime_class_void_passphrase(void);

--- a/nntp/nntp.c
+++ b/nntp/nntp.c
@@ -2380,7 +2380,7 @@ int nntp_compare_order(const void *a, const void *b)
   anum_t nb = nntp_edata_get(*eb)->article_num;
   int result = (na == nb) ? 0 : (na > nb) ? 1 : -1;
   result = perform_auxsort(result, a, b);
-  return SORTCODE(result);
+  return SORT_CODE(result);
 }
 
 /**

--- a/pager.c
+++ b/pager.c
@@ -985,7 +985,7 @@ static void resolve_types(char *buf, char *raw, struct Line *line_info, int n,
       }
     }
   }
-  else if (mutt_str_startswith(raw, "\033[0m", CASE_MATCH)) /* a little hack... */
+  else if (mutt_str_startswith(raw, "\033[0m", CASE_MATCH)) // Escape: a little hack...
     line_info[n].type = MT_COLOR_NORMAL;
   else if (check_attachment_marker((char *) raw) == 0)
     line_info[n].type = MT_COLOR_ATTACHMENT;
@@ -1318,7 +1318,7 @@ static int fill_buffer(FILE *fp, LOFF_T *last_pos, LOFF_T offset, unsigned char 
     q = *fmt;
     while (*p)
     {
-      if ((*p == '\010') && (p > *buf))
+      if ((*p == '\010') && (p > *buf)) // Ctrl-H (backspace)
       {
         if (*(p + 1) == '_') /* underline */
           p += 2;
@@ -1330,12 +1330,12 @@ static int fill_buffer(FILE *fp, LOFF_T *last_pos, LOFF_T offset, unsigned char 
         else /* ^H */
           *q++ = *p++;
       }
-      else if ((*p == '\033') && (*(p + 1) == '[') && is_ansi(p + 2))
+      else if ((*p == '\033') && (*(p + 1) == '[') && is_ansi(p + 2)) // Escape
       {
         while (*p++ != 'm') /* skip ANSI sequence */
           ;
       }
-      else if ((*p == '\033') && (*(p + 1) == ']') &&
+      else if ((*p == '\033') && (*(p + 1) == ']') && // Escape
                ((check_attachment_marker((char *) p) == 0) ||
                 (check_protected_header_marker((char *) p) == 0)))
       {
@@ -1388,11 +1388,11 @@ static int format_line(struct Line **line_info, int n, unsigned char *buf,
   for (ch = 0, vch = 0; ch < cnt; ch += k, vch += k)
   {
     /* Handle ANSI sequences */
-    while ((cnt - ch >= 2) && (buf[ch] == '\033') && (buf[ch + 1] == '[') &&
+    while ((cnt - ch >= 2) && (buf[ch] == '\033') && (buf[ch + 1] == '[') && // Escape
            is_ansi(buf + ch + 2))
       ch = grok_ansi(buf, ch + 2, pa) + 1;
 
-    while ((cnt - ch >= 2) && (buf[ch] == '\033') && (buf[ch + 1] == ']') &&
+    while ((cnt - ch >= 2) && (buf[ch] == '\033') && (buf[ch + 1] == ']') && // Escape
            ((check_attachment_marker((char *) buf + ch) == 0) ||
             (check_protected_header_marker((char *) buf + ch) == 0)))
     {

--- a/pager.c
+++ b/pager.c
@@ -94,7 +94,7 @@ bool C_SmartWrap; ///< Config: Wrap text at word boundaries
 struct Regex *C_Smileys; ///< Config: Regex to match smileys to prevent mistakes when quoting text
 bool C_Tilde; ///< Config: Character to pad blank lines in the pager
 
-#define ISHEADER(x) ((x) == MT_COLOR_HEADER || (x) == MT_COLOR_HDEFAULT)
+#define IS_HEADER(x) ((x) == MT_COLOR_HEADER || (x) == MT_COLOR_HDEFAULT)
 
 #define IsAttach(pager) (pager && (pager)->body)
 #define IsMsgAttach(pager)                                                     \
@@ -247,7 +247,7 @@ static int check_sig(const char *s, struct Line *info, int n)
     /* check for a blank line */
     while (*s)
     {
-      if (!ISSPACE(*s))
+      if (!IS_SPACE(*s))
         return 0;
       s++;
     }
@@ -304,7 +304,7 @@ static void resolve_color(struct Line *line_info, int n, int cnt,
   {
     if (!cnt && C_Markers)
     {
-      SETCOLOR(MT_COLOR_MARKERS);
+      SET_COLOR(MT_COLOR_MARKERS);
       addch('+');
       last_color = ColorDefs[MT_COLOR_MARKERS];
     }
@@ -408,7 +408,7 @@ static void resolve_color(struct Line *line_info, int n, int cnt,
 
   if (color != last_color)
   {
-    ATTRSET(color);
+    ATTR_SET(color);
     last_color = color;
   }
 }
@@ -925,7 +925,7 @@ static void resolve_types(char *buf, char *raw, struct Line *line_info, int n,
   bool null_rx;
   int offset, i = 0;
 
-  if ((n == 0) || ISHEADER(line_info[n - 1].type) ||
+  if ((n == 0) || IS_HEADER(line_info[n - 1].type) ||
       (check_protected_header_marker(raw) == 0))
   {
     if (buf[0] == '\n') /* end of header */
@@ -1734,8 +1734,8 @@ static int display_line(FILE *fp, LOFF_T *last_pos, struct Line **line_info,
   /* move the break point only if smart_wrap is set */
   if (C_SmartWrap)
   {
-    if ((cnt < b_read) && (ch != -1) && !ISHEADER((*line_info)[n].type) &&
-        !ISSPACE(buf[cnt]))
+    if ((cnt < b_read) && (ch != -1) && !IS_HEADER((*line_info)[n].type) &&
+        !IS_SPACE(buf[cnt]))
     {
       buf_ptr = buf + ch;
       /* skip trailing blanks */
@@ -1802,7 +1802,7 @@ static int display_line(FILE *fp, LOFF_T *last_pos, struct Line **line_info,
     else
       def_color = ColorDefs[(*line_info)[m].type];
 
-    ATTRSET(def_color);
+    ATTR_SET(def_color);
   }
 
   if (col < pager_window->cols)
@@ -1983,7 +1983,7 @@ static void pager_custom_redraw(struct Menu *pager_menu)
 
     if (C_Help)
     {
-      SETCOLOR(MT_COLOR_STATUS);
+      SET_COLOR(MT_COLOR_STATUS);
       mutt_window_move(MuttHelpWindow, 0, 0);
       mutt_paddstr(MuttHelpWindow->cols, rd->helpstr);
       NORMAL_COLOR;
@@ -1995,7 +1995,7 @@ static void pager_custom_redraw(struct Menu *pager_menu)
       if (rd->search_compiled)
       {
         int flags = mutt_mb_is_lower(rd->searchbuf) ? REG_ICASE : 0;
-        const int err = REGCOMP(&rd->search_re, rd->searchbuf, REG_NEWLINE | flags);
+        const int err = REG_COMP(&rd->search_re, rd->searchbuf, REG_NEWLINE | flags);
         if (err != 0)
         {
           regerror(err, &rd->search_re, buf, sizeof(buf));
@@ -2126,7 +2126,7 @@ static void pager_custom_redraw(struct Menu *pager_menu)
       rd->last_offset = rd->line_info[rd->curline].offset;
     } while (rd->force_redraw);
 
-    SETCOLOR(MT_COLOR_TILDE);
+    SET_COLOR(MT_COLOR_TILDE);
     while (rd->lines < rd->pager_window->rows)
     {
       mutt_window_clrtoeol(rd->pager_window);
@@ -2169,7 +2169,7 @@ static void pager_custom_redraw(struct Menu *pager_menu)
 
     /* print out the pager status bar */
     mutt_window_move(rd->pager_status_window, 0, 0);
-    SETCOLOR(MT_COLOR_STATUS);
+    SET_COLOR(MT_COLOR_STATUS);
 
     if (IsEmail(rd->extra) || IsMsgAttach(rd->extra))
     {
@@ -2207,7 +2207,7 @@ static void pager_custom_redraw(struct Menu *pager_menu)
     menu_status_line(buf, sizeof(buf), rd->index, NONULL(C_StatusFormat));
 
     mutt_window_move(rd->index_status_window, 0, 0);
-    SETCOLOR(MT_COLOR_STATUS);
+    SET_COLOR(MT_COLOR_STATUS);
     mutt_draw_statusline(rd->index_status_window->cols, buf, sizeof(buf));
     NORMAL_COLOR;
   }
@@ -2718,7 +2718,7 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         }
 
         int rflags = mutt_mb_is_lower(searchbuf) ? REG_ICASE : 0;
-        int err = REGCOMP(&rd.search_re, searchbuf, REG_NEWLINE | rflags);
+        int err = REG_COMP(&rd.search_re, searchbuf, REG_NEWLINE | rflags);
         if (err != 0)
         {
           regerror(err, &rd.search_re, buf, sizeof(buf));
@@ -2850,7 +2850,7 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
           int new_topline = rd.topline;
 
           /* Skip all the email headers */
-          if (ISHEADER(rd.line_info[new_topline].type))
+          if (IS_HEADER(rd.line_info[new_topline].type))
           {
             while (((new_topline < rd.last_line) ||
                     (0 == (dretval = display_line(
@@ -2858,7 +2858,7 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
                                &rd.max_line, MUTT_TYPES | (flags & MUTT_PAGER_NOWRAP),
                                &rd.quote_list, &rd.q_level, &rd.force_redraw,
                                &rd.search_re, rd.pager_window)))) &&
-                   ISHEADER(rd.line_info[new_topline].type))
+                   IS_HEADER(rd.line_info[new_topline].type))
             {
               new_topline++;
             }

--- a/pattern.c
+++ b/pattern.c
@@ -230,7 +230,7 @@ static bool eat_regex(struct Pattern *pat, struct Buffer *s, struct Buffer *err)
   {
     pat->p.regex = mutt_mem_malloc(sizeof(regex_t));
     int flags = mutt_mb_is_lower(buf.data) ? REG_ICASE : 0;
-    int rc = REGCOMP(pat->p.regex, buf.data, REG_NEWLINE | REG_NOSUB | flags);
+    int rc = REG_COMP(pat->p.regex, buf.data, REG_NEWLINE | REG_NOSUB | flags);
     if (rc != 0)
     {
       char errmsg[256];

--- a/pattern.c
+++ b/pattern.c
@@ -1635,7 +1635,7 @@ cleanup:
  * @param cache Cached Patterns
  * @retval true If ALL of the Patterns evaluates to true
  */
-static bool perform_and(struct PatternHead *pat, enum PatternExecFlag flags,
+static bool perform_and(struct PatternHead *pat, PatternExecFlags flags,
                         struct Mailbox *m, struct Email *e, struct PatternCache *cache)
 {
   struct Pattern *p = NULL;
@@ -1657,7 +1657,7 @@ static bool perform_and(struct PatternHead *pat, enum PatternExecFlag flags,
  * @param cache Cached Patterns
  * @retval true If ONE (or more) of the Patterns evaluates to true
  */
-static int perform_or(struct PatternHead *pat, enum PatternExecFlag flags,
+static int perform_or(struct PatternHead *pat, PatternExecFlags flags,
                       struct Mailbox *m, struct Email *e, struct PatternCache *cache)
 {
   struct Pattern *p = NULL;
@@ -1791,7 +1791,7 @@ static int match_user(int alladdr, struct Address *a1, struct Address *a2)
  * @retval 1  Success, match found
  * @retval 0  No match
  */
-static int match_threadcomplete(struct PatternHead *pat, enum PatternExecFlag flags,
+static int match_threadcomplete(struct PatternHead *pat, PatternExecFlags flags,
                                 struct Mailbox *m, struct MuttThread *t,
                                 int left, int up, int right, int down)
 {
@@ -1830,7 +1830,7 @@ static int match_threadcomplete(struct PatternHead *pat, enum PatternExecFlag fl
  * @retval  0 Pattern did not match
  * @retval -1 Error
  */
-static int match_threadparent(struct PatternHead *pat, enum PatternExecFlag flags,
+static int match_threadparent(struct PatternHead *pat, PatternExecFlags flags,
                               struct Mailbox *m, struct MuttThread *t)
 {
   if (!t || !t->parent || !t->parent->message)
@@ -1849,7 +1849,7 @@ static int match_threadparent(struct PatternHead *pat, enum PatternExecFlag flag
  * @retval  0 Pattern did not match
  * @retval -1 Error
  */
-static int match_threadchildren(struct PatternHead *pat, enum PatternExecFlag flags,
+static int match_threadchildren(struct PatternHead *pat, PatternExecFlags flags,
                                 struct Mailbox *m, struct MuttThread *t)
 {
   if (!t || !t->child)
@@ -1949,7 +1949,7 @@ static int is_pattern_cache_set(int cache_entry)
  * cache: For repeated matches against the same Header, passing in non-NULL will
  *        store some of the cacheable pattern matches in this structure.
  */
-int mutt_pattern_exec(struct Pattern *pat, enum PatternExecFlag flags,
+int mutt_pattern_exec(struct Pattern *pat, PatternExecFlags flags,
                       struct Mailbox *m, struct Email *e, struct PatternCache *cache)
 {
   int result;

--- a/pattern.h
+++ b/pattern.h
@@ -39,8 +39,6 @@ extern bool C_ThoroughSearch;
 /* flag to mutt_pattern_comp() */
 #define MUTT_FULL_MSG (1 << 0) /* enable body and header matching */
 
-SLIST_HEAD(PatternHead, Pattern);
-
 /**
  * struct Pattern - A simple (non-regex) pattern
  */
@@ -65,6 +63,7 @@ struct Pattern
     struct ListHead multi_cases;
   } p;
 };
+SLIST_HEAD(PatternHead, Pattern);
 
 /**
  * enum PatternExecFlag - Flags for mutt_pattern_exec()

--- a/pattern.h
+++ b/pattern.h
@@ -65,13 +65,9 @@ struct Pattern
 };
 SLIST_HEAD(PatternHead, Pattern);
 
-/**
- * enum PatternExecFlag - Flags for mutt_pattern_exec()
- */
-enum PatternExecFlag
-{
-  MUTT_MATCH_FULL_ADDRESS = 1, ///< Match the full address
-};
+typedef uint8_t PatternExecFlags;         ///< Flags for mutt_pattern_exec(), e.g. #MUTT_MATCH_FULL_ADDRESS
+#define MUTT_PAT_EXEC_NO_FLAGS         0  ///< No flags are set
+#define MUTT_MATCH_FULL_ADDRESS  (1 << 0) ///< Match the full address
 
 /**
  * struct PatternCache - Cache commonly-used patterns
@@ -149,7 +145,7 @@ enum PatternType
   MUTT_PAT_MAX,
 };
 
-int mutt_pattern_exec(struct Pattern *pat, enum PatternExecFlag flags,
+int mutt_pattern_exec(struct Pattern *pat, PatternExecFlags flags,
                       struct Mailbox *m, struct Email *e, struct PatternCache *cache);
 struct PatternHead *mutt_pattern_comp(/* const */ char *s, int flags, struct Buffer *err);
 void mutt_check_simple(char *s, size_t len, const char *simple);

--- a/postpone.c
+++ b/postpone.c
@@ -397,13 +397,13 @@ int mutt_get_postponed(struct Context *ctx, struct Email *hdr,
               /* this is the new way */
               mutt_str_startswith(np->data, "X-Mutt-PGP:", CASE_MATCH)))
     {
-      hdr->security = mutt_parse_crypt_hdr(strchr(np->data, ':') + 1, 1, APPLICATION_PGP);
+      hdr->security = mutt_parse_crypt_hdr(strchr(np->data, ':') + 1, true, APPLICATION_PGP);
       hdr->security |= APPLICATION_PGP;
     }
     else if (((WithCrypto & APPLICATION_SMIME) != 0) &&
              mutt_str_startswith(np->data, "X-Mutt-SMIME:", CASE_MATCH))
     {
-      hdr->security = mutt_parse_crypt_hdr(strchr(np->data, ':') + 1, 1, APPLICATION_SMIME);
+      hdr->security = mutt_parse_crypt_hdr(strchr(np->data, ':') + 1, true, APPLICATION_SMIME);
       hdr->security |= APPLICATION_SMIME;
     }
 
@@ -446,7 +446,7 @@ int mutt_get_postponed(struct Context *ctx, struct Email *hdr,
  * @param crypt_app App, e.g. #APPLICATION_PGP
  * @retval num SecurityFlags, see #SecurityFlags
  */
-SecurityFlags mutt_parse_crypt_hdr(const char *p, int set_empty_signas, SecurityFlags crypt_app)
+SecurityFlags mutt_parse_crypt_hdr(const char *p, bool set_empty_signas, SecurityFlags crypt_app)
 {
   char smime_cryptalg[1024] = "\0";
   char sign_as[1024] = "\0", *q = NULL;

--- a/progress.c
+++ b/progress.c
@@ -74,7 +74,7 @@ static void message_bar(int percent, const char *fmt, ...)
     if (l < w)
     {
       /* The string fits within the colour bar */
-      SETCOLOR(MT_COLOR_PROGRESS);
+      SET_COLOR(MT_COLOR_PROGRESS);
       addstr(buf2);
       w -= l;
       while (w-- > 0)
@@ -91,7 +91,7 @@ static void message_bar(int percent, const char *fmt, ...)
 
       ch = buf2[off];
       buf2[off] = '\0';
-      SETCOLOR(MT_COLOR_PROGRESS);
+      SET_COLOR(MT_COLOR_PROGRESS);
       addstr(buf2);
       buf2[off] = ch;
       NORMAL_COLOR;

--- a/protos.h
+++ b/protos.h
@@ -76,7 +76,7 @@ int mutt_enter_string(char *buf, size_t buflen, int col, CompletionFlags flags);
 int mutt_enter_string_full(char *buf, size_t buflen, int col, CompletionFlags flags, bool multiple,
                            char ***files, int *numfiles, struct EnterState *state);
 int mutt_get_postponed(struct Context *ctx, struct Email *e, struct Email **cur, char *fcc, size_t fcclen);
-SecurityFlags mutt_parse_crypt_hdr(const char *p, int set_empty_signas, SecurityFlags crypt_app);
+SecurityFlags mutt_parse_crypt_hdr(const char *p, bool set_empty_signas, SecurityFlags crypt_app);
 int mutt_num_postponed(struct Mailbox *m, bool force);
 int mutt_thread_set_flag(struct Email *e, int flag, bool bf, bool subthread);
 void mutt_update_num_postponed(void);

--- a/recvattach.c
+++ b/recvattach.c
@@ -88,7 +88,7 @@ static const char *Mailbox_is_read_only = N_("Mailbox is read-only");
     break;                                                                     \
   }
 
-#define CURATTACH actx->idx[actx->v2r[menu->current]]
+#define CUR_ATTACH actx->idx[actx->v2r[menu->current]]
 
 static const struct Mapping AttachHelp[] = {
   { N_("Exit"), OP_EXIT },   { N_("Save"), OP_SAVE }, { N_("Pipe"), OP_PIPE },
@@ -986,7 +986,7 @@ void mutt_print_attachment_list(struct AttachCtx *actx, FILE *fp, bool tag, stru
 static void recvattach_extract_pgp_keys(struct AttachCtx *actx, struct Menu *menu)
 {
   if (!menu->tagprefix)
-    crypt_pgp_extract_key_from_attachment(CURATTACH->fp, CURATTACH->content);
+    crypt_pgp_extract_key_from_attachment(CUR_ATTACH->fp, CUR_ATTACH->content);
   else
   {
     for (int i = 0; i < actx->idxlen; i++)
@@ -1012,7 +1012,7 @@ static int recvattach_pgp_check_traditional(struct AttachCtx *actx, struct Menu 
   int rc = 0;
 
   if (!menu->tagprefix)
-    rc = crypt_pgp_check_traditional(CURATTACH->fp, CURATTACH->content, true);
+    rc = crypt_pgp_check_traditional(CUR_ATTACH->fp, CUR_ATTACH->content, true);
   else
   {
     for (int i = 0; i < actx->idxlen; i++)
@@ -1032,12 +1032,12 @@ static int recvattach_pgp_check_traditional(struct AttachCtx *actx, struct Menu 
 static void recvattach_edit_content_type(struct AttachCtx *actx,
                                          struct Menu *menu, struct Email *e)
 {
-  if (!mutt_edit_content_type(e, CURATTACH->content, CURATTACH->fp))
+  if (!mutt_edit_content_type(e, CUR_ATTACH->content, CUR_ATTACH->fp))
     return;
 
   /* The mutt_update_recvattach_menu() will overwrite any changes
-   * made to a decrypted CURATTACH->content, so warn the user. */
-  if (CURATTACH->decrypted)
+   * made to a decrypted CUR_ATTACH->content, so warn the user. */
+  if (CUR_ATTACH->decrypted)
   {
     mutt_message(
         _("Structural changes to decrypted attachments are not supported"));
@@ -1071,7 +1071,7 @@ int mutt_attach_display_loop(struct Menu *menu, int op, struct Email *e,
         /* fallthrough */
 
       case OP_VIEW_ATTACH:
-        op = mutt_view_attachment(CURATTACH->fp, CURATTACH->content,
+        op = mutt_view_attachment(CUR_ATTACH->fp, CUR_ATTACH->content,
                                   MUTT_VA_REGULAR, e, actx);
         break;
 
@@ -1098,11 +1098,11 @@ int mutt_attach_display_loop(struct Menu *menu, int op, struct Email *e,
       case OP_EDIT_TYPE:
         /* when we edit the content-type, we should redisplay the attachment
          * immediately */
-        mutt_edit_content_type(e, CURATTACH->content, CURATTACH->fp);
+        mutt_edit_content_type(e, CUR_ATTACH->content, CUR_ATTACH->fp);
         if (recv)
           recvattach_edit_content_type(actx, menu, e);
         else
-          mutt_edit_content_type(e, CURATTACH->content, CURATTACH->fp);
+          mutt_edit_content_type(e, CUR_ATTACH->content, CUR_ATTACH->fp);
 
         menu->redraw |= REDRAW_INDEX;
         op = OP_VIEW_ATTACH;
@@ -1299,12 +1299,12 @@ static void attach_collapse(struct AttachCtx *actx, struct Menu *menu)
 {
   int rindex, curlevel;
 
-  CURATTACH->content->collapsed = !CURATTACH->content->collapsed;
+  CUR_ATTACH->content->collapsed = !CUR_ATTACH->content->collapsed;
   /* When expanding, expand all the children too */
-  if (CURATTACH->content->collapsed)
+  if (CUR_ATTACH->content->collapsed)
     return;
 
-  curlevel = CURATTACH->level;
+  curlevel = CUR_ATTACH->level;
   rindex = actx->v2r[menu->current] + 1;
 
   while ((rindex < actx->idxlen) && (actx->idx[rindex]->level > curlevel))
@@ -1363,12 +1363,12 @@ void mutt_view_attachments(struct Email *e)
     switch (op)
     {
       case OP_ATTACH_VIEW_MAILCAP:
-        mutt_view_attachment(CURATTACH->fp, CURATTACH->content, MUTT_VA_MAILCAP, e, actx);
+        mutt_view_attachment(CUR_ATTACH->fp, CUR_ATTACH->content, MUTT_VA_MAILCAP, e, actx);
         menu->redraw = REDRAW_FULL;
         break;
 
       case OP_ATTACH_VIEW_TEXT:
-        mutt_view_attachment(CURATTACH->fp, CURATTACH->content, MUTT_VA_AS_TEXT, e, actx);
+        mutt_view_attachment(CUR_ATTACH->fp, CUR_ATTACH->content, MUTT_VA_AS_TEXT, e, actx);
         menu->redraw = REDRAW_FULL;
         break;
 
@@ -1379,7 +1379,7 @@ void mutt_view_attachments(struct Email *e)
         continue;
 
       case OP_ATTACH_COLLAPSE:
-        if (!CURATTACH->content->parts)
+        if (!CUR_ATTACH->content->parts)
         {
           mutt_error(_("There are no subparts to show"));
           break;
@@ -1410,18 +1410,18 @@ void mutt_view_attachments(struct Email *e)
         break;
 
       case OP_PRINT:
-        mutt_print_attachment_list(actx, CURATTACH->fp, menu->tagprefix,
-                                   CURATTACH->content);
+        mutt_print_attachment_list(actx, CUR_ATTACH->fp, menu->tagprefix,
+                                   CUR_ATTACH->content);
         break;
 
       case OP_PIPE:
-        mutt_pipe_attachment_list(actx, CURATTACH->fp, menu->tagprefix,
-                                  CURATTACH->content, false);
+        mutt_pipe_attachment_list(actx, CUR_ATTACH->fp, menu->tagprefix,
+                                  CUR_ATTACH->content, false);
         break;
 
       case OP_SAVE:
-        mutt_save_attachment_list(actx, CURATTACH->fp, menu->tagprefix,
-                                  CURATTACH->content, e, menu);
+        mutt_save_attachment_list(actx, CUR_ATTACH->fp, menu->tagprefix,
+                                  CUR_ATTACH->content, e, menu);
 
         if (!menu->tagprefix && C_Resolve && (menu->current < menu->max - 1))
           menu->current++;
@@ -1463,9 +1463,9 @@ void mutt_view_attachments(struct Email *e)
         }
         if (!menu->tagprefix)
         {
-          if (CURATTACH->parent_type == TYPE_MULTIPART)
+          if (CUR_ATTACH->parent_type == TYPE_MULTIPART)
           {
-            CURATTACH->content->deleted = true;
+            CUR_ATTACH->content->deleted = true;
             if (C_Resolve && (menu->current < menu->max - 1))
             {
               menu->current++;
@@ -1505,7 +1505,7 @@ void mutt_view_attachments(struct Email *e)
         CHECK_READONLY;
         if (!menu->tagprefix)
         {
-          CURATTACH->content->deleted = false;
+          CUR_ATTACH->content->deleted = false;
           if (C_Resolve && (menu->current < menu->max - 1))
           {
             menu->current++;
@@ -1529,43 +1529,43 @@ void mutt_view_attachments(struct Email *e)
 
       case OP_RESEND:
         CHECK_ATTACH;
-        mutt_attach_resend(CURATTACH->fp, actx,
-                           menu->tagprefix ? NULL : CURATTACH->content);
+        mutt_attach_resend(CUR_ATTACH->fp, actx,
+                           menu->tagprefix ? NULL : CUR_ATTACH->content);
         menu->redraw = REDRAW_FULL;
         break;
 
       case OP_BOUNCE_MESSAGE:
         CHECK_ATTACH;
-        mutt_attach_bounce(m, CURATTACH->fp, actx,
-                           menu->tagprefix ? NULL : CURATTACH->content);
+        mutt_attach_bounce(m, CUR_ATTACH->fp, actx,
+                           menu->tagprefix ? NULL : CUR_ATTACH->content);
         menu->redraw = REDRAW_FULL;
         break;
 
       case OP_FORWARD_MESSAGE:
         CHECK_ATTACH;
-        mutt_attach_forward(CURATTACH->fp, e, actx,
-                            menu->tagprefix ? NULL : CURATTACH->content, SEND_NO_FLAGS);
+        mutt_attach_forward(CUR_ATTACH->fp, e, actx,
+                            menu->tagprefix ? NULL : CUR_ATTACH->content, SEND_NO_FLAGS);
         menu->redraw = REDRAW_FULL;
         break;
 
 #ifdef USE_NNTP
       case OP_FORWARD_TO_GROUP:
         CHECK_ATTACH;
-        mutt_attach_forward(CURATTACH->fp, e, actx,
-                            menu->tagprefix ? NULL : CURATTACH->content, SEND_NEWS);
+        mutt_attach_forward(CUR_ATTACH->fp, e, actx,
+                            menu->tagprefix ? NULL : CUR_ATTACH->content, SEND_NEWS);
         menu->redraw = REDRAW_FULL;
         break;
 
       case OP_FOLLOWUP:
         CHECK_ATTACH;
 
-        if (!CURATTACH->content->email->env->followup_to ||
-            (mutt_str_strcasecmp(CURATTACH->content->email->env->followup_to, "poster") != 0) ||
+        if (!CUR_ATTACH->content->email->env->followup_to ||
+            (mutt_str_strcasecmp(CUR_ATTACH->content->email->env->followup_to, "poster") != 0) ||
             (query_quadoption(C_FollowupToPoster,
                               _("Reply by mail as poster prefers?")) != MUTT_YES))
         {
-          mutt_attach_reply(CURATTACH->fp, e, actx,
-                            menu->tagprefix ? NULL : CURATTACH->content,
+          mutt_attach_reply(CUR_ATTACH->fp, e, actx,
+                            menu->tagprefix ? NULL : CUR_ATTACH->content,
                             SEND_NEWS | SEND_REPLY);
           menu->redraw = REDRAW_FULL;
           break;
@@ -1587,16 +1587,16 @@ void mutt_view_attachments(struct Email *e)
         else if (op == OP_LIST_REPLY)
           flags |= SEND_LIST_REPLY;
 
-        mutt_attach_reply(CURATTACH->fp, e, actx,
-                          menu->tagprefix ? NULL : CURATTACH->content, flags);
+        mutt_attach_reply(CUR_ATTACH->fp, e, actx,
+                          menu->tagprefix ? NULL : CUR_ATTACH->content, flags);
         menu->redraw = REDRAW_FULL;
         break;
       }
 
       case OP_COMPOSE_TO_SENDER:
         CHECK_ATTACH;
-        mutt_attach_mail_sender(CURATTACH->fp, e, actx,
-                                menu->tagprefix ? NULL : CURATTACH->content);
+        mutt_attach_mail_sender(CUR_ATTACH->fp, e, actx,
+                                menu->tagprefix ? NULL : CUR_ATTACH->content);
         menu->redraw = REDRAW_FULL;
         break;
 

--- a/remailer.c
+++ b/remailer.c
@@ -321,7 +321,7 @@ static void mix_redraw_ce(struct Remailer **type2_list, struct Coord *coords,
   if (coords[i].r < MIX_MAXROW)
   {
     if (selected)
-      SETCOLOR(MT_COLOR_INDICATOR);
+      SET_COLOR(MT_COLOR_INDICATOR);
     else
       NORMAL_COLOR;
 
@@ -360,7 +360,7 @@ static void mix_redraw_chain(struct Remailer **type2_list, struct Coord *coords,
  */
 static void mix_redraw_head(struct MixChain *chain)
 {
-  SETCOLOR(MT_COLOR_STATUS);
+  SET_COLOR(MT_COLOR_STATUS);
   mutt_window_mvprintw(MuttIndexWindow, MIX_VOFFSET - 1, 0,
                        "-- Remailer chain [Length: %d]", chain ? chain->cl : 0);
   mutt_window_clrtoeol(MuttIndexWindow);
@@ -513,7 +513,7 @@ static int mix_chain_add(struct MixChain *chain, const char *s, struct Remailer 
 {
   int i;
 
-  if (chain->cl >= MAXMIXES)
+  if (chain->cl >= MAX_MIXES)
     return -1;
 
   if ((mutt_str_strcmp(s, "0") == 0) || (mutt_str_strcasecmp(s, "<random>") == 0))
@@ -669,13 +669,13 @@ void mix_make_chain(struct ListHead *chainhead)
       case OP_GENERIC_SELECT_ENTRY:
       case OP_MIX_APPEND:
       {
-        if ((chain->cl < MAXMIXES) && (c_cur < chain->cl))
+        if ((chain->cl < MAX_MIXES) && (c_cur < chain->cl))
           c_cur++;
       }
       /* fallthrough */
       case OP_MIX_INSERT:
       {
-        if (chain->cl < MAXMIXES)
+        if (chain->cl < MAX_MIXES)
         {
           chain->cl++;
           for (int i = chain->cl - 1; i > c_cur; i--)
@@ -688,7 +688,7 @@ void mix_make_chain(struct ListHead *chainhead)
         else
         {
           /* L10N The '%d' here hard-coded to 19 */
-          mutt_error(_("Mixmaster chains are limited to %d elements"), MAXMIXES);
+          mutt_error(_("Mixmaster chains are limited to %d elements"), MAX_MIXES);
         }
 
         break;

--- a/remailer.h
+++ b/remailer.h
@@ -34,7 +34,7 @@ extern char *C_MixEntryFormat;
 extern char *C_Mixmaster;
 
 /* Mixmaster's maximum chain length.  Don't change this. */
-#define MAXMIXES 19
+#define MAX_MIXES 19
 
 typedef uint8_t MixCapFlags;       ///< Flags, e.g. #MIX_CAP_NO_FLAGS
 #define MIX_CAP_NO_FLAGS        0  ///< No flags are set
@@ -61,7 +61,7 @@ struct Remailer
 struct MixChain
 {
   size_t cl;
-  int ch[MAXMIXES];
+  int ch[MAX_MIXES];
 };
 
 int mix_send_message(struct ListHead *chain, const char *tempfile);

--- a/send.c
+++ b/send.c
@@ -1574,7 +1574,7 @@ full_fcc:
         case 2: /* alternate (m)ailbox */
           /* L10N: This is the prompt to enter an "alternate (m)ailbox" when the
              initial Fcc fails.  */
-          rc = mutt_enter_fname(_("Fcc mailbox"), fcc, fcc_len, 1);
+          rc = mutt_enter_fname(_("Fcc mailbox"), fcc, fcc_len, true);
           if ((rc == -1) || (fcc[0] == '\0'))
           {
             rc = 0;

--- a/sendlib.c
+++ b/sendlib.c
@@ -1149,7 +1149,7 @@ int mutt_lookup_mime_type(struct Body *att, const char *path)
             }
             *p++ = 0;
 
-            for (q = p; *q && !ISSPACE(*q); q++)
+            for (q = p; *q && !IS_SPACE(*q); q++)
               ;
 
             mutt_str_substr_cpy(subtype, p, q, sizeof(subtype));

--- a/sidebar.c
+++ b/sidebar.c
@@ -746,7 +746,7 @@ static int draw_divider(int num_rows, int num_cols)
   if (delim_len > num_cols)
     return 0;
 
-  SETCOLOR(MT_COLOR_DIVIDER);
+  SET_COLOR(MT_COLOR_DIVIDER);
 
   int col = C_SidebarOnRight ? 0 : (C_SidebarWidth - delim_len);
 
@@ -836,25 +836,25 @@ static void draw_sidebar(int num_rows, int num_cols, int div_width)
     if (entryidx == OpnIndex)
     {
       if ((ColorDefs[MT_COLOR_SB_INDICATOR] != 0))
-        SETCOLOR(MT_COLOR_SB_INDICATOR);
+        SET_COLOR(MT_COLOR_SB_INDICATOR);
       else
-        SETCOLOR(MT_COLOR_INDICATOR);
+        SET_COLOR(MT_COLOR_INDICATOR);
     }
     else if (entryidx == HilIndex)
-      SETCOLOR(MT_COLOR_HIGHLIGHT);
+      SET_COLOR(MT_COLOR_HIGHLIGHT);
     else if ((m->msg_unread > 0) || (m->has_new))
-      SETCOLOR(MT_COLOR_NEW);
+      SET_COLOR(MT_COLOR_NEW);
     else if (m->msg_flagged > 0)
-      SETCOLOR(MT_COLOR_FLAGGED);
+      SET_COLOR(MT_COLOR_FLAGGED);
     else if ((ColorDefs[MT_COLOR_SB_SPOOLFILE] != 0) &&
              (mutt_str_strcmp(m->path, C_Spoolfile) == 0))
     {
-      SETCOLOR(MT_COLOR_SB_SPOOLFILE);
+      SET_COLOR(MT_COLOR_SB_SPOOLFILE);
     }
     else
     {
       if (ColorDefs[MT_COLOR_ORDINARY] != 0)
-        SETCOLOR(MT_COLOR_ORDINARY);
+        SET_COLOR(MT_COLOR_ORDINARY);
       else
         NORMAL_COLOR;
     }

--- a/sidebar.h
+++ b/sidebar.h
@@ -28,7 +28,6 @@
 #include <stdbool.h>
 
 struct Mailbox;
-struct Context;
 
 /* These Config Variables are only used in sidebar.c */
 extern short C_SidebarComponentDepth;

--- a/sort.c
+++ b/sort.c
@@ -89,7 +89,7 @@ static int compare_score(const void *a, const void *b)
   struct Email **pb = (struct Email **) b;
   int result = (*pb)->score - (*pa)->score; /* note that this is reverse */
   result = perform_auxsort(result, a, b);
-  return SORTCODE(result);
+  return SORT_CODE(result);
 }
 
 /**
@@ -101,7 +101,7 @@ static int compare_size(const void *a, const void *b)
   struct Email **pb = (struct Email **) b;
   int result = (*pa)->content->length - (*pb)->content->length;
   result = perform_auxsort(result, a, b);
-  return SORTCODE(result);
+  return SORT_CODE(result);
 }
 
 /**
@@ -113,7 +113,7 @@ static int compare_date_sent(const void *a, const void *b)
   struct Email **pb = (struct Email **) b;
   int result = (*pa)->date_sent - (*pb)->date_sent;
   result = perform_auxsort(result, a, b);
-  return SORTCODE(result);
+  return SORT_CODE(result);
 }
 
 /**
@@ -137,7 +137,7 @@ static int compare_subject(const void *a, const void *b)
   else
     rc = mutt_str_strcasecmp((*pa)->env->real_subj, (*pb)->env->real_subj);
   rc = perform_auxsort(rc, a, b);
-  return SORTCODE(rc);
+  return SORT_CODE(rc);
 }
 
 /**
@@ -180,7 +180,7 @@ static int compare_to(const void *a, const void *b)
   const char *fb = mutt_get_name((*ppb)->env->to);
   int result = mutt_str_strncasecmp(fa, fb, sizeof(fa));
   result = perform_auxsort(result, a, b);
-  return SORTCODE(result);
+  return SORT_CODE(result);
 }
 
 /**
@@ -196,7 +196,7 @@ static int compare_from(const void *a, const void *b)
   const char *fb = mutt_get_name((*ppb)->env->from);
   int result = mutt_str_strncasecmp(fa, fb, sizeof(fa));
   result = perform_auxsort(result, a, b);
-  return SORTCODE(result);
+  return SORT_CODE(result);
 }
 
 /**
@@ -208,7 +208,7 @@ static int compare_date_received(const void *a, const void *b)
   struct Email **pb = (struct Email **) b;
   int result = (*pa)->received - (*pb)->received;
   result = perform_auxsort(result, a, b);
-  return SORTCODE(result);
+  return SORT_CODE(result);
 }
 
 /**
@@ -220,7 +220,7 @@ static int compare_order(const void *a, const void *b)
   struct Email **eb = (struct Email **) b;
 
   /* no need to auxsort because you will never have equality here */
-  return SORTCODE((*ea)->index - (*eb)->index);
+  return SORT_CODE((*ea)->index - (*eb)->index);
 }
 
 /**
@@ -242,15 +242,15 @@ static int compare_spam(const void *a, const void *b)
 
   /* If one msg has spam attr but other does not, sort the one with first. */
   if (ahas && !bhas)
-    return SORTCODE(1);
+    return SORT_CODE(1);
   if (!ahas && bhas)
-    return SORTCODE(-1);
+    return SORT_CODE(-1);
 
   /* Else, if neither has a spam attr, presume equality. Fall back on aux. */
   if (!ahas && !bhas)
   {
     result = perform_auxsort(result, a, b);
-    return SORTCODE(result);
+    return SORT_CODE(result);
   }
 
   /* Both have spam attrs. */
@@ -265,7 +265,7 @@ static int compare_spam(const void *a, const void *b)
   /* If either aptr or bptr is equal to data, there is no numeric    */
   /* value for that spam attribute. In this case, compare lexically. */
   if ((aptr == (*ppa)->env->spam->data) || (bptr == (*ppb)->env->spam->data))
-    return SORTCODE(strcmp(aptr, bptr));
+    return SORT_CODE(strcmp(aptr, bptr));
 
   /* Otherwise, we have numeric value for both attrs. If these values */
   /* are equal, then we first fall back upon string comparison, then  */
@@ -276,7 +276,7 @@ static int compare_spam(const void *a, const void *b)
     result = perform_auxsort(result, a, b);
   }
 
-  return SORTCODE(result);
+  return SORT_CODE(result);
 }
 
 /**
@@ -296,20 +296,20 @@ static int compare_label(const void *a, const void *b)
 
   /* First we bias toward a message with a label, if the other does not. */
   if (ahas && !bhas)
-    return SORTCODE(-1);
+    return SORT_CODE(-1);
   if (!ahas && bhas)
-    return SORTCODE(1);
+    return SORT_CODE(1);
 
   /* If neither has a label, use aux sort. */
   if (!ahas && !bhas)
   {
     result = perform_auxsort(result, a, b);
-    return SORTCODE(result);
+    return SORT_CODE(result);
   }
 
   /* If both have a label, we just do a lexical compare. */
   result = mutt_str_strcasecmp((*ppa)->env->x_label, (*ppb)->env->x_label);
-  return SORTCODE(result);
+  return SORT_CODE(result);
 }
 
 /**

--- a/sort.h
+++ b/sort.h
@@ -35,7 +35,7 @@ struct Context;
 /* These Config Variables are only used in sort.c */
 extern bool C_ReverseAlias;
 
-#define SORTCODE(x) ((OptAuxSort ? C_SortAux : C_Sort) & SORT_REVERSE) ? -(x) : x
+#define SORT_CODE(x) ((OptAuxSort ? C_SortAux : C_Sort) & SORT_REVERSE) ? -(x) : x
 
 /**
  * typedef sort_t - Prototype for a function to compare two emails

--- a/system.c
+++ b/system.c
@@ -85,7 +85,7 @@ int mutt_system(const char *cmd)
     sigaction(SIGTSTP, &act, NULL);
     sigaction(SIGCONT, &act, NULL);
 
-    execle(EXECSHELL, "sh", "-c", cmd, NULL, mutt_envlist_getlist());
+    execle(EXEC_SHELL, "sh", "-c", cmd, NULL, mutt_envlist_getlist());
     _exit(127); /* execl error */
   }
   else if (pid != -1)

--- a/terminal.c
+++ b/terminal.c
@@ -43,8 +43,8 @@
 bool TsSupported; /**< Terminal Setting is supported */
 
 /* de facto standard escapes for tsl/fsl */
-static const char *tsl = "\033]0;";
-static const char *fsl = "\007";
+static const char *tsl = "\033]0;"; // Escape
+static const char *fsl = "\007";    // Ctrl-G (BEL)
 
 /**
  * mutt_ts_capability - Check terminal capabilities
@@ -121,5 +121,5 @@ void mutt_ts_icon(char *str)
     return;
 
   /* icon setting is not supported in terminfo, so hardcode the escape */
-  fprintf(stderr, "\033]1;%s\007", str);
+  fprintf(stderr, "\033]1;%s\007", str); // Escape
 }

--- a/test/pattern/extract.c
+++ b/test/pattern/extract.c
@@ -24,7 +24,7 @@ int mutt_extract_token(struct Buffer *dest, struct Buffer *tok, TokenFlags flags
   {
     if (!qc)
     {
-      if ((ISSPACE(ch) && !(flags & MUTT_TOKEN_SPACE)) ||
+      if ((IS_SPACE(ch) && !(flags & MUTT_TOKEN_SPACE)) ||
           ((ch == '#') && !(flags & MUTT_TOKEN_COMMENT)) ||
           ((ch == '=') && (flags & MUTT_TOKEN_EQUAL)) ||
           ((ch == '?') && (flags & MUTT_TOKEN_QUESTION)) ||

--- a/version.c
+++ b/version.c
@@ -319,14 +319,14 @@ static void print_compile_options(struct CompileOptions *co, FILE *fp)
     if (co[i].enabled)
     {
       if (tty)
-        fprintf(fp, "\033[1;32m+%s\033[0m ", co[i].name);
+        fprintf(fp, "\033[1;32m+%s\033[0m ", co[i].name); // Escape
       else
         fprintf(fp, "+%s ", co[i].name);
     }
     else
     {
       if (tty)
-        fprintf(fp, "\033[1;31m-%s\033[0m ", co[i].name);
+        fprintf(fp, "\033[1;31m-%s\033[0m ", co[i].name); // Escape
       else
         fprintf(fp, "-%s ", co[i].name);
     }


### PR DESCRIPTION
These commits are better viewed individually.
There are no functional changes.

- 816fa9773 refactor: light tidying
  - clang-format
  - remove unused declaration
  - use bools in config definitions
  - fix doxygen comments
  - remove unnecessary check
  - tidy list/queue definitions

- 4e9e7f69c tidy macros
  - add underscores
  - remove unused

- 823c72848 comment escape sequences
- 6673622be add: PatternExecFlags for mutt_pattern_exec()

- a24cfcec3 tidy: mutt_copy_hdr()
  Refactor call to `mutt_write_one_header() for clarity

- 1e3d66f89 tidy calls to mutt_copy_hdr()
  Refactor calls to `mutt_copy_hdr()` for clarity

- 47ceaf309 boolify: mutt_parse_crypt_hdr()
- 3472cbdb9 boolify: mutt_enter_fname()
- 9293e73ad boolify: valid_passphrase()