### PR TITLE
boolify: valid_passphrase functions

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -194,7 +194,7 @@ int mutt_display_message(struct Email *cur)
     {
       if (cur->security & APPLICATION_SMIME)
         crypt_smime_getkeys(cur->env);
-      if (!crypt_valid_passphrase(cur->security))
+      if (crypt_valid_passphrase(cur->security))
         return 0;
 
       cmflags |= MUTT_CM_VERIFY;
@@ -508,7 +508,7 @@ static void pipe_msg(struct Mailbox *m, struct Email *e, FILE *fp, bool decode, 
 
   if ((WithCrypto != 0) && decode && e->security & SEC_ENCRYPT)
   {
-    if (!crypt_valid_passphrase(e->security))
+    if (crypt_valid_passphrase(e->security))
       return;
     endwin();
   }
@@ -556,7 +556,7 @@ static int pipe_message(struct Mailbox *m, struct EmailList *el, char *cmd,
     {
       mutt_parse_mime_message(m, en->email);
       if ((en->email->security & SEC_ENCRYPT) &&
-          !crypt_valid_passphrase(en->email->security))
+          crypt_valid_passphrase(en->email->security))
         return 1;
     }
     mutt_endwin();
@@ -584,7 +584,7 @@ static int pipe_message(struct Mailbox *m, struct EmailList *el, char *cmd,
         mutt_message_hook(m, en->email, MUTT_MESSAGE_HOOK);
         mutt_parse_mime_message(m, en->email);
         if ((en->email->security & SEC_ENCRYPT) &&
-            !crypt_valid_passphrase(en->email->security))
+            crypt_valid_passphrase(en->email->security))
         {
           return 1;
         }
@@ -1040,7 +1040,7 @@ int mutt_save_message(struct Mailbox *m, struct EmailList *el, bool delete,
     return -1;
 
   if ((WithCrypto != 0) && need_passphrase && (decode || decrypt) &&
-      !crypt_valid_passphrase(app))
+      crypt_valid_passphrase(app))
   {
     return -1;
   }

--- a/mutt_attach.c
+++ b/mutt_attach.c
@@ -395,7 +395,7 @@ int mutt_view_attachment(FILE *fp, struct Body *a, enum ViewAttachMode mode,
 
   bool is_message = mutt_is_message_type(a->type, a->subtype);
   if ((WithCrypto != 0) && is_message && a->email &&
-      (a->email->security & SEC_ENCRYPT) && !crypt_valid_passphrase(a->email->security))
+      (a->email->security & SEC_ENCRYPT) && crypt_valid_passphrase(a->email->security))
   {
     return rc;
   }

--- a/ncrypt/crypt.c
+++ b/ncrypt/crypt.c
@@ -136,12 +136,11 @@ static void disable_coredumps(void)
 /**
  * crypt_valid_passphrase - Check that we have a usable passphrase, ask if not
  * @param flags Flags, see #SecurityFlags
- * @retval  0 Success
- * @retval -1 Failure
+ * @retval true If we have a usable passphrase
  */
-int crypt_valid_passphrase(SecurityFlags flags)
+bool crypt_valid_passphrase(SecurityFlags flags)
 {
-  int rc = 0;
+  bool rc = true;
 
 #ifndef DEBUG
   disable_coredumps();
@@ -176,7 +175,7 @@ int mutt_protect(struct Email *msg, char *keylist)
   if (!(msg->security & (SEC_ENCRYPT | SEC_SIGN)))
     return 0;
 
-  if ((msg->security & SEC_SIGN) && !crypt_valid_passphrase(msg->security))
+  if ((msg->security & SEC_SIGN) && crypt_valid_passphrase(msg->security))
     return -1;
 
   if (((WithCrypto & APPLICATION_PGP) != 0) && ((msg->security & PGP_INLINE) == PGP_INLINE))
@@ -839,7 +838,7 @@ void crypt_extract_keys_from_messages(struct EmailList *el)
     struct Email *e = en->email;
 
     mutt_parse_mime_message(Context->mailbox, e);
-    if (e->security & SEC_ENCRYPT && !crypt_valid_passphrase(e->security))
+    if (e->security & SEC_ENCRYPT && crypt_valid_passphrase(e->security))
     {
       mutt_file_fclose(&fp_out);
       break;

--- a/ncrypt/crypt_mod.h
+++ b/ncrypt/crypt_mod.h
@@ -51,14 +51,14 @@ struct CryptModuleSpecs
    */
   void         (*void_passphrase)(void);
   /**
-   * valid_passphrase - Ensure we have a valid passphrase
-   * @retval 1 Success
-   * @retval 0 Failed
+   * valid_passphrase - Do we have a valid passphrase?
+   * @retval true  Success
+   * @retval false Failed
    *
    * If the passphrase is within the expiry time (backend-specific), use it.
    * If not prompt the user again.
    */
-  int          (*valid_passphrase)(void);
+  bool         (*valid_passphrase)(void);
   /**
    * decrypt_mime - Decrypt an encrypted MIME part
    * @param[in]  fp_in  File containing the encrypted part

--- a/ncrypt/crypt_mod_pgp_gpgme.c
+++ b/ncrypt/crypt_mod_pgp_gpgme.c
@@ -46,9 +46,9 @@ static void pgp_gpgme_void_passphrase(void)
  *
  * This is handled by gpg-agent.
  */
-static int pgp_gpgme_valid_passphrase(void)
+static bool pgp_gpgme_valid_passphrase(void)
 {
-  return 1;
+  return true;
 }
 
 // clang-format off

--- a/ncrypt/crypt_mod_smime_gpgme.c
+++ b/ncrypt/crypt_mod_smime_gpgme.c
@@ -46,9 +46,9 @@ static void smime_gpgme_void_passphrase(void)
  *
  * This is handled by gpg-agent.
  */
-static int smime_gpgme_valid_passphrase(void)
+static bool smime_gpgme_valid_passphrase(void)
 {
-  return 1;
+  return true;
 }
 
 // clang-format off

--- a/ncrypt/cryptglue.c
+++ b/ncrypt/cryptglue.c
@@ -177,12 +177,12 @@ void crypt_pgp_void_passphrase(void)
 /**
  * crypt_pgp_valid_passphrase - Wrapper for CryptModuleSpecs::valid_passphrase()
  */
-int crypt_pgp_valid_passphrase(void)
+bool crypt_pgp_valid_passphrase(void)
 {
   if (CRYPT_MOD_CALL_CHECK(PGP, valid_passphrase))
     return CRYPT_MOD_CALL(PGP, valid_passphrase)();
 
-  return 0;
+  return true;
 }
 
 /**
@@ -358,12 +358,12 @@ void crypt_smime_void_passphrase(void)
 /**
  * crypt_smime_valid_passphrase - Wrapper for CryptModuleSpecs::valid_passphrase()
  */
-int crypt_smime_valid_passphrase(void)
+bool crypt_smime_valid_passphrase(void)
 {
   if (CRYPT_MOD_CALL_CHECK(SMIME, valid_passphrase))
     return CRYPT_MOD_CALL(SMIME, valid_passphrase)();
 
-  return 0;
+  return true;
 }
 
 /**

--- a/ncrypt/cryptglue.h
+++ b/ncrypt/cryptglue.h
@@ -35,7 +35,7 @@ void         crypt_pgp_invoke_import(const char *fname);
 void         crypt_pgp_set_sender(const char *sender);
 struct Body *crypt_pgp_sign_message(struct Body *a);
 struct Body *crypt_pgp_traditional_encryptsign(struct Body *a, int flags, char *keylist);
-int          crypt_pgp_valid_passphrase(void);
+bool         crypt_pgp_valid_passphrase(void);
 int          crypt_pgp_verify_one(struct Body *sigbdy, struct State *s, const char *tempf);
 void         crypt_pgp_void_passphrase(void);
 
@@ -44,7 +44,7 @@ char *       crypt_smime_find_keys(struct Address *addrlist, bool oppenc_mode);
 void         crypt_smime_invoke_import(char *infile, char *mailbox);
 void         crypt_smime_set_sender(const char *sender);
 struct Body *crypt_smime_sign_message(struct Body *a);
-int          crypt_smime_valid_passphrase(void);
+bool         crypt_smime_valid_passphrase(void);
 int          crypt_smime_verify_one(struct Body *sigbdy, struct State *s, const char *tempf);
 void         crypt_smime_void_passphrase(void);
 

--- a/ncrypt/ncrypt.h
+++ b/ncrypt/ncrypt.h
@@ -186,7 +186,7 @@ void         crypt_forget_passphrase(void);
 int          crypt_get_keys(struct Email *msg, char **keylist, bool oppenc_mode);
 void         crypt_opportunistic_encrypt(struct Email *msg);
 SecurityFlags crypt_query(struct Body *m);
-int          crypt_valid_passphrase(SecurityFlags flags);
+bool         crypt_valid_passphrase(SecurityFlags flags);
 SecurityFlags mutt_is_application_pgp(struct Body *m);
 SecurityFlags mutt_is_application_smime(struct Body *m);
 SecurityFlags mutt_is_malformed_multipart_pgp_encrypted(struct Body *b);

--- a/ncrypt/pgp.c
+++ b/ncrypt/pgp.c
@@ -89,20 +89,20 @@ void pgp_class_void_passphrase(void)
 /**
  * pgp_class_valid_passphrase - Implements CryptModuleSpecs::valid_passphrase()
  */
-int pgp_class_valid_passphrase(void)
+bool pgp_class_valid_passphrase(void)
 {
   time_t now = time(NULL);
 
   if (pgp_use_gpg_agent())
   {
     *PgpPass = '\0';
-    return 1; /* handled by gpg-agent */
+    return true; /* handled by gpg-agent */
   }
 
   if (now < PgpExptime)
   {
     /* Use cached copy.  */
-    return 1;
+    return true;
   }
 
   pgp_class_void_passphrase();
@@ -110,12 +110,12 @@ int pgp_class_valid_passphrase(void)
   if (mutt_get_password(_("Enter PGP passphrase:"), PgpPass, sizeof(PgpPass)) == 0)
   {
     PgpExptime = mutt_date_add_timeout(time(NULL), C_PgpTimeout);
-    return 1;
+    return true;
   }
   else
     PgpExptime = 0;
 
-  return 0;
+  return false;
 }
 
 /**

--- a/ncrypt/pgp.h
+++ b/ncrypt/pgp.h
@@ -53,7 +53,7 @@ int pgp_class_application_handler(struct Body *m, struct State *s);
 int pgp_class_encrypted_handler(struct Body *a, struct State *s);
 void pgp_class_extract_key_from_attachment(FILE *fp, struct Body *top);
 void pgp_class_void_passphrase(void);
-int pgp_class_valid_passphrase(void);
+bool pgp_class_valid_passphrase(void);
 
 int pgp_class_verify_one(struct Body *sigbdy, struct State *s, const char *tempfile);
 struct Body *pgp_class_traditional_encryptsign(struct Body *a, SecurityFlags flags, char *keylist);

--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -168,14 +168,14 @@ void smime_class_void_passphrase(void)
 /**
  * smime_class_valid_passphrase - Implements CryptModuleSpecs::valid_passphrase()
  */
-int smime_class_valid_passphrase(void)
+bool smime_class_valid_passphrase(void)
 {
   time_t now = time(NULL);
 
   if (now < SmimeExptime)
   {
     /* Use cached copy.  */
-    return 1;
+    return true;
   }
 
   smime_class_void_passphrase();
@@ -183,12 +183,12 @@ int smime_class_valid_passphrase(void)
   if (mutt_get_password(_("Enter S/MIME passphrase:"), SmimePass, sizeof(SmimePass)) == 0)
   {
     SmimeExptime = mutt_date_add_timeout(time(NULL), C_SmimeTimeout);
-    return 1;
+    return true;
   }
   else
     SmimeExptime = 0;
 
-  return 0;
+  return false;
 }
 
 /*

--- a/ncrypt/smime.h
+++ b/ncrypt/smime.h
@@ -56,7 +56,7 @@ void         smime_class_getkeys(struct Envelope *env);
 void         smime_class_invoke_import(char *infile, char *mailbox);
 int          smime_class_send_menu(struct Email *msg);
 struct Body *smime_class_sign_message(struct Body *a);
-int          smime_class_valid_passphrase(void);
+bool         smime_class_valid_passphrase(void);
 int          smime_class_verify_one(struct Body *sigbdy, struct State *s, const char *tempfile);
 int          smime_class_verify_sender(struct Email *e);
 void         smime_class_void_passphrase(void);

--- a/pattern.c
+++ b/pattern.c
@@ -1128,7 +1128,7 @@ static bool msg_search(struct Mailbox *m, struct Pattern *pat, int msgno)
       mutt_parse_mime_message(m, e);
 
       if ((WithCrypto != 0) && (e->security & SEC_ENCRYPT) &&
-          !crypt_valid_passphrase(e->security))
+          crypt_valid_passphrase(e->security))
       {
         mx_msg_close(m, &msg);
         if (s.fp_out)

--- a/postpone.c
+++ b/postpone.c
@@ -621,7 +621,7 @@ int mutt_prepare_template(FILE *fp, struct Mailbox *m, struct Email *newhdr,
       (sec_type = mutt_is_multipart_encrypted(newhdr->content)))
   {
     newhdr->security |= sec_type;
-    if (!crypt_valid_passphrase(sec_type))
+    if (crypt_valid_passphrase(sec_type))
       goto bail;
 
     mutt_message(_("Decrypting message..."));
@@ -728,7 +728,7 @@ int mutt_prepare_template(FILE *fp, struct Mailbox *m, struct Email *newhdr,
     {
       if (sec_type & SEC_ENCRYPT)
       {
-        if (!crypt_valid_passphrase(APPLICATION_PGP))
+        if (crypt_valid_passphrase(APPLICATION_PGP))
           goto bail;
         mutt_message(_("Decrypting message..."));
       }
@@ -755,7 +755,7 @@ int mutt_prepare_template(FILE *fp, struct Mailbox *m, struct Email *newhdr,
     {
       if (sec_type & SEC_ENCRYPT)
       {
-        if (!crypt_valid_passphrase(APPLICATION_SMIME))
+        if (crypt_valid_passphrase(APPLICATION_SMIME))
           goto bail;
         crypt_smime_getkeys(newhdr->env);
         mutt_message(_("Decrypting message..."));

--- a/recvattach.c
+++ b/recvattach.c
@@ -1159,7 +1159,7 @@ static void mutt_generate_recvattach_list(struct AttachCtx *actx, struct Email *
 
       if (type & SEC_ENCRYPT)
       {
-        if (!crypt_valid_passphrase(APPLICATION_SMIME))
+        if (crypt_valid_passphrase(APPLICATION_SMIME))
           goto decrypt_failed;
 
         if (e->env)
@@ -1189,7 +1189,7 @@ static void mutt_generate_recvattach_list(struct AttachCtx *actx, struct Email *
     {
       need_secured = 1;
 
-      if (!crypt_valid_passphrase(APPLICATION_PGP))
+      if (crypt_valid_passphrase(APPLICATION_PGP))
         goto decrypt_failed;
 
       secured = !crypt_pgp_decrypt_mime(fp, &fp_new, m, &new_body);

--- a/send.c
+++ b/send.c
@@ -505,7 +505,7 @@ static int include_forward(struct Mailbox *m, struct Email *e, FILE *fp_out)
   if ((WithCrypto != 0) && (e->security & SEC_ENCRYPT) && C_ForwardDecode)
   {
     /* make sure we have the user's passphrase before proceeding... */
-    if (!crypt_valid_passphrase(e->security))
+    if (crypt_valid_passphrase(e->security))
       return -1;
   }
 
@@ -585,7 +585,7 @@ static int include_reply(struct Mailbox *m, struct Email *e, FILE *fp_out)
   if ((WithCrypto != 0) && (e->security & SEC_ENCRYPT))
   {
     /* make sure we have the user's passphrase before proceeding... */
-    if (!crypt_valid_passphrase(e->security))
+    if (crypt_valid_passphrase(e->security))
       return -1;
   }
 

--- a/sendlib.c
+++ b/sendlib.c
@@ -1467,7 +1467,7 @@ struct Body *mutt_make_message_attach(struct Mailbox *m, struct Email *e, bool a
   {
     if ((C_MimeForwardDecode || C_ForwardDecrypt) && (e->security & SEC_ENCRYPT))
     {
-      if (!crypt_valid_passphrase(e->security))
+      if (crypt_valid_passphrase(e->security))
         return NULL;
     }
   }


### PR DESCRIPTION
Change the functions that sound boolean to be boolean.
This gets its own PR because of its _perceived_ complexity.
There are no functional changes.

**Note**: All of the functions **sound** boolean, but some of them returned `0` on success.
This lead to a lot of code, like below, where `action()` is a successful outcome.

```c
if (!valid())
{
  action()
}
```

The following now all return `bool`:
- `valid_passphrase()`
- `crypt_valid_passphrase()`
- `crypt_pgp_valid_passphrase()`
- `crypt_smime_valid_passphrase()`
- `pgp_class_valid_passphrase()`
- `pgp_gpgme_valid_passphrase()`
- `smime_class_valid_passphrase()`
- `smime_gpgme_valid_passphrase()`

