### PR TITLE
Make buffer pool initialization lazy

### DIFF
--- a/init.c
+++ b/init.c
@@ -3004,7 +3004,6 @@ int mutt_init(bool skip_sys_rc, struct ListHead *commands)
   TagFormats = mutt_hash_new(64, MUTT_HASH_NO_FLAGS);
 
   mutt_menu_init();
-  mutt_buffer_pool_init();
 
   snprintf(AttachmentMarker, sizeof(AttachmentMarker), "\033]9;%" PRIu64 "\a", // Escape
            mutt_rand64());

--- a/mutt/buffer.c
+++ b/mutt/buffer.c
@@ -374,14 +374,6 @@ static void increase_buffer_pool(void)
 }
 
 /**
- * mutt_buffer_pool_init - Initialise the Buffer pool
- */
-void mutt_buffer_pool_init(void)
-{
-  increase_buffer_pool();
-}
-
-/**
  * mutt_buffer_pool_free - Release the Buffer pool
  */
 void mutt_buffer_pool_free(void)

--- a/mutt/buffer.h
+++ b/mutt/buffer.h
@@ -64,7 +64,6 @@ void           mutt_buffer_strcpy_n     (struct Buffer *buf, const char *s, size
 
 void           mutt_buffer_pool_free    (void);
 struct Buffer *mutt_buffer_pool_get     (void);
-void           mutt_buffer_pool_init    (void);
 void           mutt_buffer_pool_release (struct Buffer **pbuf);
 
 #endif /* MUTT_LIB_BUFFER_H */


### PR DESCRIPTION
This fixes an issue in the startup sequence where a buffer is requested from the buffer pool before mutt_buffer_pool_init is called. The latter doubles up the number of buffers even though there are free ones.
