### PR TITLE
imap: fix oauth

### DIFF
--- a/imap/auth_oauth.c
+++ b/imap/auth_oauth.c
@@ -79,7 +79,7 @@ enum ImapAuthRes imap_auth_oauth(struct ImapAccountData *adata, const char *meth
   FREE(&oauthbearer);
   FREE(&ibuf);
 
-  if (rc == IMAP_EXEC_SUCCESS)
+  if (rc != IMAP_EXEC_SUCCESS)
   {
     /* The error response was in SASL continuation, so continue the SASL
      * to cause a failure and exit SASL input.  See RFC 7628 3.2.3 */
@@ -87,7 +87,7 @@ enum ImapAuthRes imap_auth_oauth(struct ImapAccountData *adata, const char *meth
     rc = imap_exec(adata, ibuf, IMAP_CMD_NO_FLAGS);
   }
 
-  if (rc != IMAP_EXEC_SUCCESS)
+  if (rc == IMAP_EXEC_SUCCESS)
   {
     mutt_clear_error();
     return IMAP_AUTH_SUCCESS;


### PR DESCRIPTION
Currently when oauth success, we got this and neomutt UI got stuck:

[2019-04-21 15:35:38]<5> mutt_socket_readln_d() 5< a0001 OK xxxxxxxxxxxxx@xxxxxxxxx authenticated (Success)
[2019-04-21 15:35:38]<2> mutt_socket_write_d() 5> [2019-04-21 15:35:38]<2> imap_login() Communication encrypted at 256 bits
[2019-04-21 15:35:38]<3> imap_mdata_new() hcache uidvalidity 1, uidnext 228, modseq 0
[2019-04-21 15:35:38]<M> mx_mbox_open() Reading imaps://imap.gmail.com/INBOX...
[2019-04-21 15:35:38]<M> imap_mbox_open() Selecting INBOX...
[2019-04-21 15:35:38]<2> mutt_socket_write_d() 5> a0002 SELECT "INBOX"
[2019-04-21 15:35:38]<5> mutt_socket_readln_d() 5< * BAD [CLIENTBUG] Invalid tag

In fact neomutt send ^A to the server, but this should occurs only if
the authentication fails.

This changes fixes that.