### PR TITLE
imap: fix auth login

### DIFF
--- a/imap/auth_login.c
+++ b/imap/auth_login.c
@@ -70,7 +70,7 @@ enum ImapAuthRes imap_auth_login(struct ImapAccountData *adata, const char *meth
     mutt_debug(LL_DEBUG2, "Sending LOGIN command for %s\n", adata->conn->account.user);
 
   snprintf(buf, sizeof(buf), "LOGIN %s %s", q_user, q_pass);
-  if (imap_exec(adata, buf, IMAP_CMD_PASS) != IMAP_EXEC_SUCCESS)
+  if (imap_exec(adata, buf, IMAP_CMD_PASS) == IMAP_EXEC_SUCCESS)
   {
     mutt_clear_error(); /* clear "Logging in...".  fixes #3524 */
     return IMAP_AUTH_SUCCESS;


### PR DESCRIPTION
The auth_login returns an error when it succesfully logins.

This was introduced by 04892a48ea76b37f6aa9b369b5bc4f5cc362878c

This change fixes that.