### PR TITLE
Improve hierarchy information accuracy in IMAP browser

### DIFF
--- a/imap/browse.c
+++ b/imap/browse.c
@@ -190,7 +190,7 @@ int imap_browse(const char *path, struct BrowserState *state)
   char buf[PATH_MAX];
   char mbox[PATH_MAX];
   char munged_mbox[PATH_MAX];
-  char list_cmd[18];
+  const char *list_cmd = NULL;
   int len;
   int n;
   char ctmp;
@@ -224,17 +224,16 @@ int imap_browse(const char *path, struct BrowserState *state)
 
   if (C_ImapListSubscribed)
   {
-    const char *lsub_cmd = "LSUB";
-
     /* RFC3348 section 3 states LSUB is unreliable for hierarchy information.
      * The newer LIST extensions are designed for this.  */
     if (adata->capabilities & IMAP_CAP_LIST_EXTENDED)
-      lsub_cmd = "LIST (SUBSCRIBED)";
-    mutt_str_strfcpy(list_cmd, lsub_cmd, sizeof(list_cmd));
+      list_cmd = "LIST (SUBSCRIBED RECURSIVEMATCH)";
+    else
+      list_cmd = "LSUB";
   }
   else
   {
-    mutt_str_strfcpy(list_cmd, "LIST", sizeof(list_cmd));
+    list_cmd = "LIST";
   }
 
   mutt_message(_("Getting folder list..."));

--- a/imap/command.c
+++ b/imap/command.c
@@ -68,7 +68,8 @@ static const char *const Capabilities[] = {
   "AUTH=GSSAPI", "AUTH=ANONYMOUS", "AUTH=OAUTHBEARER",
   "STARTTLS",    "LOGINDISABLED",  "IDLE",
   "SASL-IR",     "ENABLE",         "CONDSTORE",
-  "QRESYNC",     "X-GM-EXT-1",     NULL,
+  "QRESYNC",     "LIST-EXTENDED",  "X-GM-EXT-1",
+  NULL,
 };
 
 /**

--- a/imap/imap_private.h
+++ b/imap/imap_private.h
@@ -133,9 +133,10 @@ typedef uint32_t ImapCapFlags;              ///< Flags, e.g. #IMAP_CAP_IMAP4
 #define IMAP_CAP_ENABLE           (1 << 13) ///< RFC5161
 #define IMAP_CAP_CONDSTORE        (1 << 14) ///< RFC7162
 #define IMAP_CAP_QRESYNC          (1 << 15) ///< RFC7162
-#define IMAP_CAP_X_GM_EXT_1       (1 << 16) ///< https://developers.google.com/gmail/imap/imap-extensions
+#define IMAP_CAP_LIST_EXTENDED    (1 << 16) ///< RFC5258: IMAP4 LIST Command Extensions
+#define IMAP_CAP_X_GM_EXT_1       (1 << 17) ///< https://developers.google.com/gmail/imap/imap-extensions
 
-#define IMAP_CAP_ALL             ((1 << 17) - 1)
+#define IMAP_CAP_ALL             ((1 << 18) - 1)
 
 /**
  * struct ImapList - Items in an IMAP browser


### PR DESCRIPTION
@nnathan 
This is your patch (via upstream).  Please can you check it still works.

---

Currently the IMAP browser relies on LIST and LSUB (for listing subscribed
folders) which may not provide the required hierarchy information.

RFC3348 section 3 goes as far as stating that a client mustn't rely on LSUB
for hierarchy information.

This patch implements the LIST command extensions specified in RFC5258
requiring that a server must respond with hierarchy information for
listed folders (whether or not filtering on subscribed folders).