### PR TITLE
browser: show "Subscribed" in IMAP browser

### DIFF
--- a/browser.c
+++ b/browser.c
@@ -1012,8 +1012,18 @@ static void init_menu(struct BrowserState *state, struct Menu *menu,
       menu->is_mailbox_list = false;
       mutt_buffer_strcpy(path, mutt_b2s(LastDir));
       mutt_buffer_pretty_mailbox(path);
-      snprintf(title, titlelen, _("Directory [%s], File mask: %s"),
-               mutt_b2s(path), NONULL(C_Mask ? C_Mask->pattern : NULL));
+#ifdef USE_IMAP
+      if (state->imap_browse && C_ImapListSubscribed)
+      {
+        snprintf(title, titlelen, _("Subscribed [%s], File mask: %s"),
+                 mutt_b2s(path), NONULL(C_Mask ? C_Mask->pattern : NULL));
+      }
+      else
+#endif
+      {
+        snprintf(title, titlelen, _("Directory [%s], File mask: %s"),
+                 mutt_b2s(path), NONULL(C_Mask ? C_Mask->pattern : NULL));
+      }
       mutt_buffer_pool_release(&path);
     }
   }

--- a/po/bg.po
+++ b/po/bg.po
@@ -177,6 +177,10 @@ msgstr ""
 msgid "Mailboxes [%d]"
 msgstr "Пощенски кутии [%d]"
 
+#, c-format
+msgid "Subscribed [%s], File mask: %s"
+msgstr "Абониран [%s], Файлова маска: %s"
+
 #: browser.c:994
 #, c-format
 msgid "Directory [%s], File mask: %s"

--- a/po/ca.po
+++ b/po/ca.po
@@ -218,6 +218,10 @@ msgstr ""
 msgid "Mailboxes [%d]"
 msgstr "Bústies d’entrada [%d]"
 
+#, c-format
+msgid "Subscribed [%s], File mask: %s"
+msgstr "Subscrites [%s], màscara de fitxers: %s"
+
 #: browser.c:994
 #, c-format
 msgid "Directory [%s], File mask: %s"

--- a/po/cs.po
+++ b/po/cs.po
@@ -178,6 +178,10 @@ msgstr "Diskusní skupiny na serveru [%s]"
 msgid "Mailboxes [%d]"
 msgstr "Schránky [%d]"
 
+#, c-format
+msgid "Subscribed [%s], File mask: %s"
+msgstr "Přihlášená schránka [%s], Souborová maska: %s"
+
 #: browser.c:994
 #, c-format
 msgid "Directory [%s], File mask: %s"

--- a/po/da.po
+++ b/po/da.po
@@ -173,6 +173,10 @@ msgstr ""
 msgid "Mailboxes [%d]"
 msgstr "Indbakker [%d]"
 
+#, c-format
+msgid "Subscribed [%s], File mask: %s"
+msgstr "Abonnementer [%s], filmaske: %s"
+
 #: browser.c:994
 #, c-format
 msgid "Directory [%s], File mask: %s"

--- a/po/de.po
+++ b/po/de.po
@@ -174,6 +174,10 @@ msgstr "Newsgroups auf Server [%s]"
 msgid "Mailboxes [%d]"
 msgstr "Mailbox-Dateien [%d]"
 
+#, c-format
+msgid "Subscribed [%s], File mask: %s"
+msgstr "Abonniert [%s], Dateimaske: %s"
+
 #: browser.c:994
 #, c-format
 msgid "Directory [%s], File mask: %s"

--- a/po/el.po
+++ b/po/el.po
@@ -177,6 +177,10 @@ msgstr ""
 msgid "Mailboxes [%d]"
 msgstr "Γραμματοκιβώτια [%d]"
 
+#, c-format
+msgid "Subscribed [%s], File mask: %s"
+msgstr "Εγγεγραμμένα [%s], Μάσκα αρχείου: %s"
+
 #: browser.c:994
 #, c-format
 msgid "Directory [%s], File mask: %s"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -168,6 +168,10 @@ msgstr "Newsgroups on server [%s]"
 msgid "Mailboxes [%d]"
 msgstr "Mailboxes [%d]"
 
+#, c-format
+msgid "Subscribed [%s], File mask: %s"
+msgstr "Subscribed [%s], File mask: %s"
+
 #: browser.c:994
 #, c-format
 msgid "Directory [%s], File mask: %s"

--- a/po/eo.po
+++ b/po/eo.po
@@ -172,6 +172,10 @@ msgstr ""
 msgid "Mailboxes [%d]"
 msgstr "Poŝtfakoj [%d]"
 
+#, c-format
+msgid "Subscribed [%s], File mask: %s"
+msgstr "Abonita [%s], Dosieromasko: %s"
+
 #: browser.c:994
 #, c-format
 msgid "Directory [%s], File mask: %s"

--- a/po/es.po
+++ b/po/es.po
@@ -170,6 +170,10 @@ msgstr "Grupos de noticias en el servidor [%s]"
 msgid "Mailboxes [%d]"
 msgstr "Buzones [%d]"
 
+#, c-format
+msgid "Subscribed [%s], File mask: %s"
+msgstr "Suscrito [%s], patrón de archivos: %s"
+
 #: browser.c:994
 #, c-format
 msgid "Directory [%s], File mask: %s"

--- a/po/et.po
+++ b/po/et.po
@@ -173,6 +173,10 @@ msgstr ""
 msgid "Mailboxes [%d]"
 msgstr "Postkastid [%d]"
 
+#, c-format
+msgid "Subscribed [%s], File mask: %s"
+msgstr "Tellitud [%s], faili mask: %s"
+
 #: browser.c:994
 #, c-format
 msgid "Directory [%s], File mask: %s"

--- a/po/eu.po
+++ b/po/eu.po
@@ -172,6 +172,10 @@ msgstr ""
 msgid "Mailboxes [%d]"
 msgstr "Postakutxak [%d]"
 
+#, c-format
+msgid "Subscribed [%s], File mask: %s"
+msgstr "Harpidedun [%s], Fitxategi maskara: %s"
+
 #: browser.c:994
 #, c-format
 msgid "Directory [%s], File mask: %s"

--- a/po/fi.po
+++ b/po/fi.po
@@ -176,6 +176,10 @@ msgstr "Uutisryhmät palvelimella [%s]"
 msgid "Mailboxes [%d]"
 msgstr "Postilaatikot [%d]"
 
+#, c-format
+msgid "Subscribed [%s], File mask: %s"
+msgstr "Tilattu [%s], Tiedostomaski: %s"
+
 #: browser.c:994
 #, c-format
 msgid "Directory [%s], File mask: %s"

--- a/po/fr.po
+++ b/po/fr.po
@@ -194,6 +194,10 @@ msgstr ""
 msgid "Mailboxes [%d]"
 msgstr "Boîtes aux lettres [%d]"
 
+#, c-format
+msgid "Subscribed [%s], File mask: %s"
+msgstr "Abonné [%s], masque de fichier : %s"
+
 # , c-format
 #: browser.c:994
 #, c-format

--- a/po/ga.po
+++ b/po/ga.po
@@ -173,6 +173,10 @@ msgstr ""
 msgid "Mailboxes [%d]"
 msgstr "Boscaí Poist [%d]"
 
+#, c-format
+msgid "Subscribed [%s], File mask: %s"
+msgstr "Liostáilte [%s], Masc comhaid: %s"
+
 #: browser.c:994
 #, c-format
 msgid "Directory [%s], File mask: %s"

--- a/po/gl.po
+++ b/po/gl.po
@@ -173,6 +173,10 @@ msgstr ""
 msgid "Mailboxes [%d]"
 msgstr "Buzóns [%d]"
 
+#, c-format
+msgid "Subscribed [%s], File mask: %s"
+msgstr "Subscrito [%s], máscara de ficheiro: %s"
+
 #: browser.c:994
 #, c-format
 msgid "Directory [%s], File mask: %s"

--- a/po/hu.po
+++ b/po/hu.po
@@ -174,6 +174,10 @@ msgstr ""
 msgid "Mailboxes [%d]"
 msgstr "Postafiókok [%d]"
 
+#, c-format
+msgid "Subscribed [%s], File mask: %s"
+msgstr "Felírt [%s], Fájlmaszk: %s"
+
 #: browser.c:994
 #, c-format
 msgid "Directory [%s], File mask: %s"

--- a/po/id.po
+++ b/po/id.po
@@ -175,6 +175,10 @@ msgstr ""
 msgid "Mailboxes [%d]"
 msgstr "Kotak surat [%d]"
 
+#, c-format
+msgid "Subscribed [%s], File mask: %s"
+msgstr "Berlangganan [%s], File mask: %s"
+
 #: browser.c:994
 #, c-format
 msgid "Directory [%s], File mask: %s"

--- a/po/it.po
+++ b/po/it.po
@@ -173,6 +173,10 @@ msgstr ""
 msgid "Mailboxes [%d]"
 msgstr "Mailbox [%d]"
 
+#, c-format
+msgid "Subscribed [%s], File mask: %s"
+msgstr "Iscritto [%s], maschera del file: %s"
+
 #: browser.c:994
 #, c-format
 msgid "Directory [%s], File mask: %s"

--- a/po/ja.po
+++ b/po/ja.po
@@ -172,6 +172,10 @@ msgstr ""
 msgid "Mailboxes [%d]"
 msgstr "メールボックス [%d]"
 
+#, c-format
+msgid "Subscribed [%s], File mask: %s"
+msgstr "購読 [%s], ファイルマスク: %s"
+
 #: browser.c:994
 #, c-format
 msgid "Directory [%s], File mask: %s"

--- a/po/ko.po
+++ b/po/ko.po
@@ -175,6 +175,10 @@ msgstr ""
 msgid "Mailboxes [%d]"
 msgstr "메일함 [%d]"
 
+#, c-format
+msgid "Subscribed [%s], File mask: %s"
+msgstr "가입 [%s], 파일 매스크: %s"
+
 #: browser.c:994
 #, c-format
 msgid "Directory [%s], File mask: %s"

--- a/po/lt.po
+++ b/po/lt.po
@@ -170,6 +170,10 @@ msgstr "Naujienų grupės serveryje [%s]"
 msgid "Mailboxes [%d]"
 msgstr "Pašto dėžutės [%d]"
 
+#, c-format
+msgid "Subscribed [%s], File mask: %s"
+msgstr "Užsakytos [%s], Bylų kaukė: %s"
+
 #: browser.c:994
 #, c-format
 msgid "Directory [%s], File mask: %s"

--- a/po/nl.po
+++ b/po/nl.po
@@ -172,6 +172,10 @@ msgstr "Beschikbare nieuwsgroepen [%s]"
 msgid "Mailboxes [%d]"
 msgstr "Postvakken [%d]"
 
+#, c-format
+msgid "Subscribed [%s], File mask: %s"
+msgstr "Geselecteerd [%s], Bestandsmasker: %s"
+
 #: browser.c:994
 #, c-format
 msgid "Directory [%s], File mask: %s"

--- a/po/pl.po
+++ b/po/pl.po
@@ -170,6 +170,10 @@ msgstr "Listy dyskusyjne na serwerze [%s]"
 msgid "Mailboxes [%d]"
 msgstr "Skrzynki [%d]"
 
+#, c-format
+msgid "Subscribed [%s], File mask: %s"
+msgstr "Zasubskrybowane [%s], wzorzec nazw plików: %s"
+
 #: browser.c:994
 #, c-format
 msgid "Directory [%s], File mask: %s"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -170,6 +170,10 @@ msgstr "Grupo de notícias no servidor [%s]"
 msgid "Mailboxes [%d]"
 msgstr "Caixas de mensagens [%d]"
 
+#, c-format
+msgid "Subscribed [%s], File mask: %s"
+msgstr "[%s] assinada, Máscara de arquivos: %s"
+
 #: browser.c:994
 #, c-format
 msgid "Directory [%s], File mask: %s"

--- a/po/ru.po
+++ b/po/ru.po
@@ -175,6 +175,10 @@ msgstr ""
 msgid "Mailboxes [%d]"
 msgstr "Почтовые ящики [%d]"
 
+#, c-format
+msgid "Subscribed [%s], File mask: %s"
+msgstr "Подключение [%s], маска файла: %s"
+
 #: browser.c:994
 #, c-format
 msgid "Directory [%s], File mask: %s"

--- a/po/sk.po
+++ b/po/sk.po
@@ -169,6 +169,10 @@ msgstr "Skupina správ na servri [%s]"
 msgid "Mailboxes [%d]"
 msgstr "Schránky [%d]"
 
+#, fuzzy, c-format
+msgid "Subscribed [%s], File mask: %s"
+msgstr "Adresár [%s], maska súboru: %s"
+
 #: browser.c:994
 #, c-format
 msgid "Directory [%s], File mask: %s"

--- a/po/sv.po
+++ b/po/sv.po
@@ -172,6 +172,10 @@ msgstr ""
 msgid "Mailboxes [%d]"
 msgstr "Brevlådor [%d]"
 
+#, c-format
+msgid "Subscribed [%s], File mask: %s"
+msgstr "Prenumererar på [%s], filmask: %s"
+
 #: browser.c:994
 #, c-format
 msgid "Directory [%s], File mask: %s"

--- a/po/tr.po
+++ b/po/tr.po
@@ -173,6 +173,10 @@ msgstr "[%s] sunucuda haber grupları"
 msgid "Mailboxes [%d]"
 msgstr "[%d] posta kutusu "
 
+#, c-format
+msgid "Subscribed [%s], File mask: %s"
+msgstr "Abone [%s], Dosya maskesi: %s"
+
 #: browser.c:994
 #, c-format
 msgid "Directory [%s], File mask: %s"

--- a/po/uk.po
+++ b/po/uk.po
@@ -173,6 +173,10 @@ msgstr ""
 msgid "Mailboxes [%d]"
 msgstr "Поштові скриньки [%d]"
 
+#, c-format
+msgid "Subscribed [%s], File mask: %s"
+msgstr "Підписані [%s] з маскою: %s"
+
 #: browser.c:994
 #, c-format
 msgid "Directory [%s], File mask: %s"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -175,6 +175,10 @@ msgstr "新闻组服务器[%s]"
 msgid "Mailboxes [%d]"
 msgstr "信箱 [%d]"
 
+#, c-format
+msgid "Subscribed [%s], File mask: %s"
+msgstr "已订阅 [%s], 文件掩码: %s"
+
 #: browser.c:994
 #, c-format
 msgid "Directory [%s], File mask: %s"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -175,6 +175,10 @@ msgstr ""
 msgid "Mailboxes [%d]"
 msgstr "信箱 [%d]"
 
+#, c-format
+msgid "Subscribed [%s], File mask: %s"
+msgstr "已訂閱 [%s], 檔案遮罩: %s"
+
 #: browser.c:994
 #, c-format
 msgid "Directory [%s], File mask: %s"


### PR DESCRIPTION
Mutt (since 1999) has displayed "Subscribed"/"Directory" in the IMAP browser when toggling filtering mode.

Not sure why but this is absent in neomutt. This PR restores this functionality.

Question: should I also import the language translations?