### PR TITLE
Add Test Cases for some String Library Functions

### DIFF
--- a/mutt/string.c
+++ b/mutt/string.c
@@ -291,20 +291,19 @@ int mutt_str_atoi(const char *str, int *dst)
  */
 int mutt_str_atoui(const char *str, unsigned int *dst)
 {
-  int rc;
+  if (dst)
+    *dst = 0;
+
   unsigned long res = 0;
-  unsigned int tmp = 0;
-  unsigned int *t = dst ? dst : &tmp;
-
-  *t = 0;
-
-  rc = mutt_str_atoul(str, &res);
+  int rc = mutt_str_atoul(str, &res);
   if (rc < 0)
     return rc;
-  if ((unsigned int) res != res)
+  if (res > UINT_MAX)
     return -2;
 
-  *t = (unsigned int) res;
+  if (dst)
+    *dst = (unsigned int) res;
+
   return rc;
 }
 

--- a/mutt/string.c
+++ b/mutt/string.c
@@ -49,11 +49,13 @@
 /**
  * struct SysExits - Lookup table of error messages
  */
-static const struct SysExits
+struct SysExits
 {
-  int v;
-  const char *str;
-} sysexits_h[] = {
+  int err_num;
+  const char *err_str;
+};
+
+static const struct SysExits sysexits[] = {
 #ifdef EX_USAGE
   { 0xff & EX_USAGE, "Bad usage." },
 #endif
@@ -100,25 +102,22 @@ static const struct SysExits
   { 0xff & EX_NOPERM, "Local configuration error." },
 #endif
   { S_ERR, "Exec error." },
-  { -1, NULL },
 };
 
 /**
  * mutt_str_sysexit - Return a string matching an error code
- * @param e Error code, e.g. EX_NOPERM
+ * @param err_num Error code, e.g. EX_NOPERM
  * @retval ptr string representing the error code
  */
-const char *mutt_str_sysexit(int e)
+const char *mutt_str_sysexit(int err_num)
 {
-  int i;
-
-  for (i = 0; sysexits_h[i].str; i++)
+  for (size_t i = 0; i < mutt_array_size(sysexits); i++)
   {
-    if (e == sysexits_h[i].v)
-      break;
+    if (err_num == sysexits[i].err_num)
+      return sysexits[i].err_str;
   }
 
-  return sysexits_h[i].str;
+  return NULL;
 }
 
 /**

--- a/mutt/string.c
+++ b/mutt/string.c
@@ -232,20 +232,19 @@ int mutt_str_atol(const char *str, long *dst)
  */
 int mutt_str_atos(const char *str, short *dst)
 {
-  int rc;
-  long res;
-  short tmp;
-  short *t = dst ? dst : &tmp;
+  if (dst)
+    *dst = 0;
 
-  *t = 0;
-
-  rc = mutt_str_atol(str, &res);
+  long res = 0;
+  int rc = mutt_str_atol(str, &res);
   if (rc < 0)
     return rc;
-  if ((short) res != res)
+  if ((res < SHRT_MIN) || (res > SHRT_MAX))
     return -2;
 
-  *t = (short) res;
+  if (dst)
+    *dst = (short) res;
+
   return 0;
 }
 

--- a/mutt/string.c
+++ b/mutt/string.c
@@ -262,20 +262,19 @@ int mutt_str_atos(const char *str, short *dst)
  */
 int mutt_str_atoi(const char *str, int *dst)
 {
-  int rc;
-  long res;
-  int tmp;
-  int *t = dst ? dst : &tmp;
+  if (dst)
+    *dst = 0;
 
-  *t = 0;
-
-  rc = mutt_str_atol(str, &res);
+  long res = 0;
+  int rc = mutt_str_atol(str, &res);
   if (rc < 0)
     return rc;
-  if ((int) res != res)
+  if ((res < INT_MIN) || (res > INT_MAX))
     return -2;
 
-  *t = (int) res;
+  if (dst)
+    *dst = (int) res;
+
   return 0;
 }
 

--- a/mutt/string.c
+++ b/mutt/string.c
@@ -197,23 +197,22 @@ size_t mutt_str_startswith(const char *str, const char *prefix, enum CaseSensiti
  */
 int mutt_str_atol(const char *str, long *dst)
 {
-  long r;
-  long *res = dst ? dst : &r;
-  char *e = NULL;
+  if (dst)
+    *dst = 0;
 
-  /* no input: 0 */
-  if (!str || !*str)
-  {
-    *res = 0;
+  if (!str || !*str) /* no input: 0 */
     return 0;
-  }
 
+  char *e = NULL;
   errno = 0;
-  *res = strtol(str, &e, 10);
+
+  long res = strtol(str, &e, 10);
+  if (dst)
+    *dst = res;
+  if (((res == LONG_MIN) || (res == LONG_MAX)) && (errno == ERANGE))
+    return -2;
   if (e && (*e != '\0'))
     return -1;
-  if (errno == ERANGE)
-    return -2;
   return 0;
 }
 

--- a/mutt/string.c
+++ b/mutt/string.c
@@ -352,20 +352,19 @@ int mutt_str_atoul(const char *str, unsigned long *dst)
  */
 int mutt_str_atoull(const char *str, unsigned long long *dst)
 {
-  unsigned long long r;
-  unsigned long long *res = dst ? dst : &r;
-  char *e = NULL;
+  if (dst)
+    *dst = 0;
 
-  /* no input: 0 */
-  if (!str || !*str)
-  {
-    *res = 0;
+  if (!str || !*str) /* no input: 0 */
     return 0;
-  }
 
+  char *e = NULL;
   errno = 0;
-  *res = strtoull(str, &e, 10);
-  if ((*res == ULLONG_MAX) && (errno == ERANGE))
+
+  unsigned long long res = strtoull(str, &e, 10);
+  if (dst)
+    *dst = res;
+  if ((res == ULLONG_MAX) && (errno == ERANGE))
     return -1;
   if (e && (*e != '\0'))
     return 1;

--- a/mutt/string.c
+++ b/mutt/string.c
@@ -320,20 +320,19 @@ int mutt_str_atoui(const char *str, unsigned int *dst)
  */
 int mutt_str_atoul(const char *str, unsigned long *dst)
 {
-  unsigned long r = 0;
-  unsigned long *res = dst ? dst : &r;
-  char *e = NULL;
+  if (dst)
+    *dst = 0;
 
-  /* no input: 0 */
-  if (!str || !*str)
-  {
-    *res = 0;
+  if (!str || !*str) /* no input: 0 */
     return 0;
-  }
 
+  char *e = NULL;
   errno = 0;
-  *res = strtoul(str, &e, 10);
-  if ((*res == ULONG_MAX) && (errno == ERANGE))
+
+  unsigned long res = strtoul(str, &e, 10);
+  if (dst)
+    *dst = res;
+  if ((res == ULONG_MAX) && (errno == ERANGE))
     return -1;
   if (e && (*e != '\0'))
     return 1;

--- a/test/string/mutt_str_atoi.c
+++ b/test/string/mutt_str_atoi.c
@@ -25,11 +25,88 @@
 #include "config.h"
 #include "mutt/mutt.h"
 
+struct TestValue
+{
+  const char *str; ///< String to test
+  int retval;      ///< Expected return value
+  long result;     ///< Expected result (outparam)
+};
+
+// clang-format off
+static const struct TestValue tests[] = {
+  // Valid tests
+  { "0",           0,    0 },
+  { "1",           0,    1 },
+  { "2",           0,    2 },
+  { "3",           0,    3 },
+  { " 3",          0,    3 },
+  { "  3",         0,    3 },
+
+  { "2147483645",  0,    2147483645 },
+  { "2147483646",  0,    2147483646 },
+  { "2147483647",  0,    2147483647 },
+
+  { "-1",          0,    -1 },
+  { "-2",          0,    -2 },
+  { "-3",          0,    -3 },
+  { " -3",         0,    -3 },
+  { "  -3",        0,    -3 },
+
+  { "-2147483646", 0,    -2147483646 },
+  { "-2147483647", 0,    -2147483647 },
+  { "-2147483648", 0,    -2147483648 },
+
+  // Out of range tests
+  { "2147483648",  -2,   0 },
+  { "2147483649",  -2,   0 },
+  { "2147483650",  -2,   0 },
+
+  { "-2147483649", -2,   0 },
+  { "-2147483650", -2,   0 },
+  { "-2147483651", -2,   0 },
+
+  // Invalid tests
+  { "abc",         -1,   0 },
+  { "a123",        -1,   0 },
+  { "a-123",       -1,   0 },
+  { "0a",          -1,   0 },
+  { "123a",        -1,   0 },
+  { "-123a",       -1,   0 },
+  { "1,234",       -1,   0 },
+  { "-1,234",      -1,   0 },
+  { "1.234",       -1,   0 },
+  { "-1.234",      -1,   0 },
+  { ".123",        -1,   0 },
+  { "-.123",       -1,   0 },
+  { "3 ",          -1,   0 },
+  { "-3 ",         -1,   0 },
+};
+// clang-format on
+
+static const int UNEXPECTED = -9999;
+
 void test_mutt_str_atoi(void)
 {
   // int mutt_str_atoi(const char *str, int *dst);
 
+  int result = UNEXPECTED;
+  int retval = 0;
+
+  // Degenerate tests
+  TEST_CHECK(mutt_str_atoi(NULL, &result) == 0);
+  TEST_CHECK(mutt_str_atoi("42", NULL) == 0);
+
+  // Normal tests
+  for (size_t i = 0; i < mutt_array_size(tests); i++)
   {
-    TEST_CHECK(mutt_str_atoi(NULL, NULL) == 0);
+    result = UNEXPECTED;
+    retval = mutt_str_atoi(tests[i].str, &result);
+
+    const bool success = (retval == tests[i].retval) && (result == tests[i].result);
+    if (!TEST_CHECK_(success, "Testing '%s'\n", tests[i].str))
+    {
+      TEST_MSG("retval: Expected: %d, Got: %d\n", tests[i].retval, retval);
+      TEST_MSG("result: Expected: %ld, Got: %ld\n", tests[i].result, result);
+    }
   }
 }

--- a/test/string/mutt_str_atol.c
+++ b/test/string/mutt_str_atol.c
@@ -23,13 +23,94 @@
 #define TEST_NO_MAIN
 #include "acutest.h"
 #include "config.h"
+#include <limits.h>
 #include "mutt/mutt.h"
+
+struct TestValue
+{
+  const char *str; ///< String to test
+  int retval;      ///< Expected return value
+  long result;     ///< Expected result (outparam)
+};
+
+// clang-format off
+static const struct TestValue tests[] = {
+  // Valid tests
+  { "0",                    0,  0 },
+  { "1",                    0,  1 },
+  { "2",                    0,  2 },
+  { "3",                    0,  3 },
+  { " 3",                   0,  3 },
+  { " 3",                   0,  3 },
+
+  { "9223372036854775805",  0,  9223372036854775805 },
+  { "9223372036854775806",  0,  9223372036854775806 },
+  { "9223372036854775807",  0,  LONG_MAX },
+
+  { "-1",                   0,  -1 },
+  { "-2",                   0,  -2 },
+  { "-3",                   0,  -3 },
+  { " -3",                  0,  -3 },
+  { " -3",                  0,  -3 },
+
+  { "-9223372036854775806", 0,  -9223372036854775806 },
+  { "-9223372036854775807", 0,  -9223372036854775807 },
+  { "-9223372036854775808", 0,  LONG_MIN },
+
+  // Out of range tests
+  { "9223372036854775808",  -2, LONG_MAX },
+  { "9223372036854775809",  -2, LONG_MAX },
+  { "9223372036854775810",  -2, LONG_MAX },
+
+  { "-9223372036854775809", -2, LONG_MIN },
+  { "-9223372036854775810", -2, LONG_MIN },
+  { "-9223372036854775811", -2, LONG_MIN },
+
+  // Invalid tests
+  { "abc",                  -1, 0 },
+  { "a123",                 -1, 0 },
+  { "a-123",                -1, 0 },
+  { "0a",                   -1, 0 },
+
+  { "123a",                 -1, 123 },
+  { "-123a",                -1, -123 },
+
+  { "1,234",                -1, 1 },
+  { "-1,234",               -1, -1 },
+  { "1.234",                -1, 1 },
+  { "-1.234",               -1, -1 },
+
+  { ".123",                 -1, 0 },
+  { "-.123",                -1, 0 },
+  { "3 ",                   -1, 3 },
+  { "-3 ",                  -1, -3 },
+};
+// clang-format on
+
+static const long UNEXPECTED = -9999;
 
 void test_mutt_str_atol(void)
 {
   // int mutt_str_atol(const char *str, long *dst);
 
+  long result = UNEXPECTED;
+  int retval = 0;
+
+  // Degenerate tests
+  TEST_CHECK(mutt_str_atol(NULL, &result) == 0);
+  TEST_CHECK(mutt_str_atol("42", NULL) == 0);
+
+  // Normal tests
+  for (size_t i = 0; i < mutt_array_size(tests); i++)
   {
-    TEST_CHECK(mutt_str_atol(NULL, NULL) == 0);
+    result = UNEXPECTED;
+    retval = mutt_str_atol(tests[i].str, &result);
+
+    const bool success = (retval == tests[i].retval) && (result == tests[i].result);
+    if (!TEST_CHECK_(success, "Testing '%s'\n", tests[i].str))
+    {
+      TEST_MSG("retval: Expected: %d, Got: %d\n", tests[i].retval, retval);
+      TEST_MSG("result: Expected: %ld, Got: %ld\n", tests[i].result, result);
+    }
   }
 }

--- a/test/string/mutt_str_atos.c
+++ b/test/string/mutt_str_atos.c
@@ -25,11 +25,88 @@
 #include "config.h"
 #include "mutt/mutt.h"
 
+struct TestValue
+{
+  const char *str; ///< String to test
+  int retval;      ///< Expected return value
+  int result;      ///< Expected result (outparam)
+};
+
+// clang-format off
+static const struct TestValue tests[] = {
+  // Valid tests
+  { "0",      0,  0 },
+  { "1",      0,  1 },
+  { "2",      0,  2 },
+  { "3",      0,  3 },
+  { " 3",     0,  3 },
+  { "  3",    0,  3 },
+
+  { "32765",  0,  32765 },
+  { "32766",  0,  32766 },
+  { "32767",  0,  32767 },
+
+  { "-1",     0,  -1 },
+  { "-2",     0,  -2 },
+  { "-3",     0,  -3 },
+  { " -3",    0,  -3 },
+  { "  -3",   0,  -3 },
+
+  { "-32766", 0,  -32766 },
+  { "-32767", 0,  -32767 },
+  { "-32768", 0,  -32768 },
+
+  // Out of range tests
+  { "32768",  -2, 0 },
+  { "32769",  -2, 0 },
+  { "32770",  -2, 0 },
+
+  { "-32769", -2, 0 },
+  { "-32770", -2, 0 },
+  { "-32771", -2, 0 },
+
+  // Invalid tests
+  { "abc",    -1, 0 },
+  { "a123",   -1, 0 },
+  { "a-123",  -1, 0 },
+  { "0a",     -1, 0 },
+  { "123a",   -1, 0 },
+  { "-123a",  -1, 0 },
+  { "1,234",  -1, 0 },
+  { "-1,234", -1, 0 },
+  { "1.234",  -1, 0 },
+  { "-1.234", -1, 0 },
+  { ".123",   -1, 0 },
+  { "-.123",  -1, 0 },
+  { "3 ",     -1, 0 },
+  { "-3 ",    -1, 0 },
+};
+// clang-format on
+
+static const int UNEXPECTED = -9999;
+
 void test_mutt_str_atos(void)
 {
   // int mutt_str_atos(const char *str, short *dst);
 
+  short result = UNEXPECTED;
+  int retval = 0;
+
+  // Degenerate tests
+  TEST_CHECK(mutt_str_atos(NULL, &result) == 0);
+  TEST_CHECK(mutt_str_atos("42", NULL) == 0);
+
+  // Normal tests
+  for (size_t i = 0; i < mutt_array_size(tests); i++)
   {
-    TEST_CHECK(mutt_str_atos(NULL, NULL) == 0);
+    result = UNEXPECTED;
+    retval = mutt_str_atos(tests[i].str, &result);
+
+    const bool success = (retval == tests[i].retval) && (result == tests[i].result);
+    if (!TEST_CHECK_(success, "Testing '%s'\n", tests[i].str))
+    {
+      TEST_MSG("retval: Expected: %d, Got: %d\n", tests[i].retval, retval);
+      TEST_MSG("result: Expected: %d, Got: %d\n", tests[i].result, result);
+    }
   }
 }

--- a/test/string/mutt_str_atoui.c
+++ b/test/string/mutt_str_atoui.c
@@ -25,11 +25,73 @@
 #include "config.h"
 #include "mutt/mutt.h"
 
+struct TestValue
+{
+  const char *str;      ///< String to test
+  int retval;           ///< Expected return value
+  unsigned long result; ///< Expected result (outparam)
+};
+
+// clang-format off
+static const struct TestValue tests[] = {
+  // Valid tests
+  { "0",           0,    0 },
+  { "1",           0,    1 },
+  { "2",           0,    2 },
+  { "3",           0,    3 },
+  { " 3",          0,    3 },
+  { "  3",         0,    3 },
+
+  { "4294967293",  0,    4294967293 },
+  { "4294967294",  0,    4294967294 },
+  { "4294967295",  0,    4294967295 },
+
+  // Out of range tests
+  { "4294967296",  -2,   0 },
+  { "4294967297",  -2,   0 },
+  { "4294967298",  -2,   0 },
+  { "18446744073709551616", -1, 0 },
+
+  // Invalid tests
+  { "-3",          -2,   0 },
+  { " -3",         -2,   0 },
+  { "  -3",        -2,   0 },
+  { "abc",         1,    0 },
+  { "a123",        1,    0 },
+  { "a-123",       1,    0 },
+  { "0a",          1,    0 },
+  { "123a",        1,    123 },
+  { "1,234",       1,    1 },
+  { "1.234",       1,    1 },
+  { ".123",        1,    0 },
+  { "3 ",          1,    3 },
+};
+// clang-format on
+
+static const int UNEXPECTED = -9999;
+
 void test_mutt_str_atoui(void)
 {
   // int mutt_str_atoui(const char *str, unsigned int *dst);
 
+  unsigned int result = UNEXPECTED;
+  int retval = 0;
+
+  // Degenerate tests
+  TEST_CHECK(mutt_str_atoui(NULL, &result) == 0);
+  TEST_CHECK(mutt_str_atoui("42", NULL) == 0);
+
+  // Normal tests
+  for (size_t i = 0; i < mutt_array_size(tests); i++)
   {
-    TEST_CHECK(mutt_str_atoui(NULL, NULL) == 0);
+    result = UNEXPECTED;
+    retval = mutt_str_atoui(tests[i].str, &result);
+
+    const bool success = (retval == tests[i].retval) && (result == tests[i].result);
+    if (!TEST_CHECK_(success, "Testing '%s'\n", tests[i].str))
+    {
+      TEST_MSG("retval: Expected: %d, Got: %d\n", tests[i].retval, retval);
+      TEST_MSG("result: Expected: %lu, Got: %lu\n", tests[i].result, result);
+    }
   }
 }

--- a/test/string/mutt_str_atoul.c
+++ b/test/string/mutt_str_atoul.c
@@ -23,13 +23,75 @@
 #define TEST_NO_MAIN
 #include "acutest.h"
 #include "config.h"
+#include <limits.h>
 #include "mutt/mutt.h"
+
+struct TestValue
+{
+  const char *str;      ///< String to test
+  int retval;           ///< Expected return value
+  unsigned long result; ///< Expected result (outparam)
+};
+
+// clang-format off
+static const struct TestValue tests[] = {
+  // Valid tests
+  { "0",   0, 0 },
+  { "1",   0, 1 },
+  { "2",   0, 2 },
+  { "3",   0, 3 },
+  { " 3",  0, 3 },
+  { "  3", 0, 3 },
+
+  { "18446744073709551613",  0, 18446744073709551613UL },
+  { "18446744073709551614",  0, 18446744073709551614UL },
+  { "18446744073709551615",  0, 18446744073709551615UL },
+
+  // Out of range tests
+  { "18446744073709551616", -1, ULONG_MAX },
+  { "18446744073709551617", -1, ULONG_MAX },
+  { "18446744073709551618", -1, ULONG_MAX },
+
+  // Invalid tests
+  { "-3",          0,    18446744073709551613UL },
+  { " -3",         0,    18446744073709551613UL },
+  { "  -3",        0,    18446744073709551613UL },
+  { "abc",         1,    0 },
+  { "a123",        1,    0 },
+  { "a-123",       1,    0 },
+  { "0a",          1,    0 },
+  { "123a",        1,    123 },
+  { "1,234",       1,    1 },
+  { "1.234",       1,    1 },
+  { ".123",        1,    0 },
+  { "3 ",          1,    3 },
+};
+// clang-format on
+
+static const int UNEXPECTED = -9999;
 
 void test_mutt_str_atoul(void)
 {
   // int mutt_str_atoul(const char *str, unsigned long *dst);
 
+  unsigned long result = UNEXPECTED;
+  int retval = 0;
+
+  // Degenerate tests
+  TEST_CHECK(mutt_str_atoul(NULL, &result) == 0);
+  TEST_CHECK(mutt_str_atoul("42", NULL) == 0);
+
+  // Normal tests
+  for (size_t i = 0; i < mutt_array_size(tests); i++)
   {
-    TEST_CHECK(mutt_str_atoul(NULL, NULL) == 0);
+    result = UNEXPECTED;
+    retval = mutt_str_atoul(tests[i].str, &result);
+
+    const bool success = (retval == tests[i].retval) && (result == tests[i].result);
+    if (!TEST_CHECK_(success, "Testing '%s'\n", tests[i].str))
+    {
+      TEST_MSG("retval: Expected: %d, Got: %d\n", tests[i].retval, retval);
+      TEST_MSG("result: Expected: %lu, Got: %lu\n", tests[i].result, result);
+    }
   }
 }

--- a/test/string/mutt_str_atoull.c
+++ b/test/string/mutt_str_atoull.c
@@ -23,13 +23,75 @@
 #define TEST_NO_MAIN
 #include "acutest.h"
 #include "config.h"
+#include <limits.h>
 #include "mutt/mutt.h"
+
+struct TestValue
+{
+  const char *str;           ///< String to test
+  int retval;                ///< Expected return value
+  unsigned long long result; ///< Expected result (outparam)
+};
+
+// clang-format off
+static const struct TestValue tests[] = {
+  // Valid tests
+  { "0",   0, 0 },
+  { "1",   0, 1 },
+  { "2",   0, 2 },
+  { "3",   0, 3 },
+  { " 3",  0, 3 },
+  { "  3", 0, 3 },
+
+  { "18446744073709551613",  0, 18446744073709551613UL },
+  { "18446744073709551614",  0, 18446744073709551614UL },
+  { "18446744073709551615",  0, 18446744073709551615UL },
+
+  // Out of range tests
+  { "18446744073709551616", -1, ULONG_MAX },
+  { "18446744073709551617", -1, ULONG_MAX },
+  { "18446744073709551618", -1, ULONG_MAX },
+
+  // Invalid tests
+  { "-3",          0,    18446744073709551613UL },
+  { " -3",         0,    18446744073709551613UL },
+  { "  -3",        0,    18446744073709551613UL },
+  { "abc",         1,    0 },
+  { "a123",        1,    0 },
+  { "a-123",       1,    0 },
+  { "0a",          1,    0 },
+  { "123a",        1,    123 },
+  { "1,234",       1,    1 },
+  { "1.234",       1,    1 },
+  { ".123",        1,    0 },
+  { "3 ",          1,    3 },
+};
+// clang-format on
+
+static const int UNEXPECTED = -9999;
 
 void test_mutt_str_atoull(void)
 {
   // int mutt_str_atoull(const char *str, unsigned long long *dst);
 
+  unsigned long long result = UNEXPECTED;
+  int retval = 0;
+
+  // Degenerate tests
+  TEST_CHECK(mutt_str_atoull(NULL, &result) == 0);
+  TEST_CHECK(mutt_str_atoull("42", NULL) == 0);
+
+  // Normal tests
+  for (size_t i = 0; i < mutt_array_size(tests); i++)
   {
-    TEST_CHECK(mutt_str_atoull(NULL, NULL) == 0);
+    result = UNEXPECTED;
+    retval = mutt_str_atoull(tests[i].str, &result);
+
+    const bool success = (retval == tests[i].retval) && (result == tests[i].result);
+    if (!TEST_CHECK_(success, "Testing '%s'\n", tests[i].str))
+    {
+      TEST_MSG("retval: Expected: %d, Got: %d\n", tests[i].retval, retval);
+      TEST_MSG("result: Expected: %lu, Got: %lu\n", tests[i].result, result);
+    }
   }
 }


### PR DESCRIPTION
There are 7 pairs of commits:

1. Add comprehensive tests
2. Tidy code

... for each of the functions:

- `mutt_str_sysexit()`
- `mutt_str_atos()`
- `mutt_str_atoi()`
- `mutt_str_atol()`
- `mutt_str_atoui()`
- `mutt_str_atoul()`
- `mutt_str_atoull()`

This raises the [coverage of libmutt/string](https://flatcap.org/mutt/lcov/mutt/index.html) to 70.9%.
