### PR TITLE
Fix piecemeal constructed translation string (issue #1680)

### DIFF
--- a/icommands.c
+++ b/icommands.c
@@ -272,8 +272,10 @@ static enum CommandResult icmd_bind(struct Buffer *buf, struct Buffer *s,
 
   if (mutt_buffer_is_empty(filebuf))
   {
-    mutt_buffer_printf(err, _("%s: no %s for this menu"),
-                       dump_all ? "all" : buf->data, bind ? "binds" : "macros");
+    // L10N: '%s' is the name of the menu, e.g. 'index' or 'pager', it might
+    // L10N: also be 'all' when all menus are affected.
+    mutt_buffer_printf(err, bind ? _("%s: no binds for this menu") : _("%s: no macros for this menu"),
+                       dump_all ? "all" : buf->data);
     mutt_buffer_free(&filebuf);
     return MUTT_CMD_ERROR;
   }

--- a/icommands.c
+++ b/icommands.c
@@ -312,7 +312,7 @@ static enum CommandResult icmd_set(struct Buffer *buf, struct Buffer *s,
   FILE *fp_out = mutt_file_fopen(tempfile, "w");
   if (!fp_out)
   {
-    mutt_buffer_addstr(err, _("Could not create temporary file"));
+    mutt_buffer_printf(err, _("Could not create temporary file %s"), tempfile);
     return MUTT_CMD_ERROR;
   }
 
@@ -335,7 +335,7 @@ static enum CommandResult icmd_set(struct Buffer *buf, struct Buffer *s,
   struct Pager info = { 0 };
   if (mutt_pager("set", tempfile, MUTT_PAGER_NO_FLAGS, &info) == -1)
   {
-    mutt_buffer_addstr(err, _("Could not create temporary file"));
+    mutt_buffer_printf(err, _("Could not create temporary file %s"), tempfile);
     return MUTT_CMD_ERROR;
   }
 
@@ -354,7 +354,7 @@ static enum CommandResult icmd_version(struct Buffer *buf, struct Buffer *s,
   FILE *fp_out = mutt_file_fopen(tempfile, "w");
   if (!fp_out)
   {
-    mutt_buffer_addstr(err, _("Could not create temporary file"));
+    mutt_buffer_printf(err, _("Could not create temporary file %s"), tempfile);
     return MUTT_CMD_ERROR;
   }
 
@@ -364,7 +364,7 @@ static enum CommandResult icmd_version(struct Buffer *buf, struct Buffer *s,
   struct Pager info = { 0 };
   if (mutt_pager("version", tempfile, MUTT_PAGER_NO_FLAGS, &info) == -1)
   {
-    mutt_buffer_addstr(err, _("Could not create temporary file"));
+    mutt_buffer_printf(err, _("Could not create temporary file %s"), tempfile);
     return MUTT_CMD_ERROR;
   }
 

--- a/icommands.c
+++ b/icommands.c
@@ -260,6 +260,7 @@ static enum CommandResult icmd_bind(struct Buffer *buf, struct Buffer *s,
     const int menu_index = mutt_map_get_value(buf->data, Menus);
     if (menu_index == -1)
     {
+      // L10N: '%s' is the (misspelled) name of the menu, e.g. 'index' or 'pager'
       mutt_buffer_printf(err, _("%s: no such menu"), buf->data);
       mutt_buffer_free(&filebuf);
       return MUTT_CMD_ERROR;
@@ -281,6 +282,7 @@ static enum CommandResult icmd_bind(struct Buffer *buf, struct Buffer *s,
   fp_out = mutt_file_fopen(tempfile, "w");
   if (!fp_out)
   {
+    // L10N: '%s' is the file name of the temporary file
     mutt_buffer_printf(err, _("Could not create temporary file %s"), tempfile);
     mutt_buffer_free(&filebuf);
     return MUTT_CMD_ERROR;
@@ -293,6 +295,7 @@ static enum CommandResult icmd_bind(struct Buffer *buf, struct Buffer *s,
   struct Pager info = { 0 };
   if (mutt_pager((bind) ? "bind" : "macro", tempfile, MUTT_PAGER_NO_FLAGS, &info) == -1)
   {
+    // L10N: '%s' is the file name of the temporary file
     mutt_buffer_printf(err, _("Could not create temporary file %s"), tempfile);
     return MUTT_CMD_ERROR;
   }
@@ -312,6 +315,7 @@ static enum CommandResult icmd_set(struct Buffer *buf, struct Buffer *s,
   FILE *fp_out = mutt_file_fopen(tempfile, "w");
   if (!fp_out)
   {
+    // L10N: '%s' is the file name of the temporary file
     mutt_buffer_printf(err, _("Could not create temporary file %s"), tempfile);
     return MUTT_CMD_ERROR;
   }
@@ -335,6 +339,7 @@ static enum CommandResult icmd_set(struct Buffer *buf, struct Buffer *s,
   struct Pager info = { 0 };
   if (mutt_pager("set", tempfile, MUTT_PAGER_NO_FLAGS, &info) == -1)
   {
+    // L10N: '%s' is the file name of the temporary file
     mutt_buffer_printf(err, _("Could not create temporary file %s"), tempfile);
     return MUTT_CMD_ERROR;
   }
@@ -354,6 +359,7 @@ static enum CommandResult icmd_version(struct Buffer *buf, struct Buffer *s,
   FILE *fp_out = mutt_file_fopen(tempfile, "w");
   if (!fp_out)
   {
+    // L10N: '%s' is the file name of the temporary file
     mutt_buffer_printf(err, _("Could not create temporary file %s"), tempfile);
     return MUTT_CMD_ERROR;
   }
@@ -364,6 +370,7 @@ static enum CommandResult icmd_version(struct Buffer *buf, struct Buffer *s,
   struct Pager info = { 0 };
   if (mutt_pager("version", tempfile, MUTT_PAGER_NO_FLAGS, &info) == -1)
   {
+    // L10N: '%s' is the file name of the temporary file
     mutt_buffer_printf(err, _("Could not create temporary file %s"), tempfile);
     return MUTT_CMD_ERROR;
   }

--- a/po/bg.po
+++ b/po/bg.po
@@ -1749,17 +1749,25 @@ msgstr "unhook: непознат hook тип: %s"
 msgid "unhook: Can't delete a %s from within a %s"
 msgstr "unhook: Не може да изтриете %s от %s"
 
+#. L10N: '%s' is the (misspelled) name of the menu, e.g. 'index' or 'pager'
 #: icommands.c:257 keymap.c:1143 keymap.c:1322
 #, c-format
 msgid "%s: no such menu"
 msgstr "%s:  няма такова меню"
 
+#. L10N: '%s' is the name of the menu, e.g. 'index' or 'pager', it might
+#. L10N: also be 'all' when all menus are affected.
 #: icommands.c:268
 #, fuzzy, c-format
-msgid "%s: no %s for this menu"
+msgid "%s: no binds for this menu"
 msgstr "%s:  няма такова меню"
 
 #: icommands.c:278 icommands.c:290 imap/message.c:1050
+#, fuzzy, c-format
+msgid "%s: no macros for this menu"
+msgstr "%s:  няма такова меню"
+
+#. L10N: '%s' is the file name of the temporary file
 #, c-format
 msgid "Could not create temporary file %s"
 msgstr "Невъзможно създаването на временен файл %s"

--- a/po/ca.po
+++ b/po/ca.po
@@ -1812,17 +1812,25 @@ msgstr "unhook: El tipus de «hook» no és conegut: %s"
 msgid "unhook: Can't delete a %s from within a %s"
 msgstr "unhook: No es pot esborrar un «%s» des d’un «%s»"
 
+#. L10N: '%s' is the (misspelled) name of the menu, e.g. 'index' or 'pager'
 #: icommands.c:257 keymap.c:1143 keymap.c:1322
 #, c-format
 msgid "%s: no such menu"
 msgstr "%s: El menú no existeix."
 
+#. L10N: '%s' is the name of the menu, e.g. 'index' or 'pager', it might
+#. L10N: also be 'all' when all menus are affected.
 #: icommands.c:268
 #, fuzzy, c-format
-msgid "%s: no %s for this menu"
+msgid "%s: no binds for this menu"
 msgstr "%s: El menú no existeix."
 
 #: icommands.c:278 icommands.c:290 imap/message.c:1050
+#, fuzzy, c-format
+msgid "%s: no macros for this menu"
+msgstr "%s: El menú no existeix."
+
+#. L10N: '%s' is the file name of the temporary file
 #, c-format
 msgid "Could not create temporary file %s"
 msgstr "No s’ha pogut crear el fitxer temporal «%s»."

--- a/po/cs.po
+++ b/po/cs.po
@@ -1681,17 +1681,25 @@ msgstr "unhook: neznámý typ háčku: %s"
 msgid "unhook: Can't delete a %s from within a %s"
 msgstr "unhook: %s nelze z %s smazat"
 
+#. L10N: '%s' is the (misspelled) name of the menu, e.g. 'index' or 'pager'
 #: icommands.c:257 keymap.c:1143 keymap.c:1322
 #, c-format
 msgid "%s: no such menu"
 msgstr "menu %s neexistuje"
 
+#. L10N: '%s' is the name of the menu, e.g. 'index' or 'pager', it might
+#. L10N: also be 'all' when all menus are affected.
 #: icommands.c:268
 #, fuzzy, c-format
-msgid "%s: no %s for this menu"
+msgid "%s: no binds for this menu"
 msgstr "menu %s neexistuje"
 
 #: icommands.c:278 icommands.c:290 imap/message.c:1050
+#, fuzzy, c-format
+msgid "%s: no macros for this menu"
+msgstr "menu %s neexistuje"
+
+#. L10N: '%s' is the file name of the temporary file
 #, c-format
 msgid "Could not create temporary file %s"
 msgstr "Dočasný soubor %s nelze vytvořit"

--- a/po/da.po
+++ b/po/da.po
@@ -1703,17 +1703,25 @@ msgstr "unhook: ukendt hooktype: %s"
 msgid "unhook: Can't delete a %s from within a %s"
 msgstr "unhook: Kan ikke slette en %s inde fra en %s"
 
+#. L10N: '%s' is the (misspelled) name of the menu, e.g. 'index' or 'pager'
 #: icommands.c:257 keymap.c:1143 keymap.c:1322
 #, c-format
 msgid "%s: no such menu"
 msgstr "%s: ukendt menu"
 
+#. L10N: '%s' is the name of the menu, e.g. 'index' or 'pager', it might
+#. L10N: also be 'all' when all menus are affected.
 #: icommands.c:268
 #, fuzzy, c-format
-msgid "%s: no %s for this menu"
+msgid "%s: no binds for this menu"
 msgstr "%s: ukendt menu"
 
 #: icommands.c:278 icommands.c:290 imap/message.c:1050
+#, fuzzy, c-format
+msgid "%s: no macros for this menu"
+msgstr "%s: ukendt menu"
+
+#. L10N: '%s' is the file name of the temporary file
 #, c-format
 msgid "Could not create temporary file %s"
 msgstr "Kunne ikke oprette midlertidig fil %s"

--- a/po/de.po
+++ b/po/de.po
@@ -1665,17 +1665,25 @@ msgstr "unhook: Unbekannter Hook-Typ: %s"
 msgid "unhook: Can't delete a %s from within a %s"
 msgstr "unhook: Kann kein %s innerhalb von %s löschen"
 
+#. L10N: '%s' is the (misspelled) name of the menu, e.g. 'index' or 'pager'
 #: icommands.c:257 keymap.c:1143 keymap.c:1322
 #, c-format
 msgid "%s: no such menu"
 msgstr "Menü \"%s\" existiert nicht"
 
+#. L10N: '%s' is the name of the menu, e.g. 'index' or 'pager', it might
+#. L10N: also be 'all' when all menus are affected.
 #: icommands.c:268
 #, fuzzy, c-format
-msgid "%s: no %s for this menu"
+msgid "%s: no binds for this menu"
 msgstr "%s: kein %s für dieses Menü"
 
 #: icommands.c:278 icommands.c:290 imap/message.c:1050
+#, fuzzy, c-format
+msgid "%s: no macros for this menu"
+msgstr "%s: kein %s für dieses Menü"
+
+#. L10N: '%s' is the file name of the temporary file
 #, c-format
 msgid "Could not create temporary file %s"
 msgstr "Konnte Temporärdatei %s nicht erzeugen"

--- a/po/el.po
+++ b/po/el.po
@@ -1750,17 +1750,25 @@ msgstr "unhook: άγνωστος τύπος hook: %s"
 msgid "unhook: Can't delete a %s from within a %s"
 msgstr "unhook: Αδυναμία διαγραφής ενός %s μέσα από ένα %s"
 
+#. L10N: '%s' is the (misspelled) name of the menu, e.g. 'index' or 'pager'
 #: icommands.c:257 keymap.c:1143 keymap.c:1322
 #, c-format
 msgid "%s: no such menu"
 msgstr "%s: δεν υπάρχει τέτοιο μενού"
 
+#. L10N: '%s' is the name of the menu, e.g. 'index' or 'pager', it might
+#. L10N: also be 'all' when all menus are affected.
 #: icommands.c:268
 #, fuzzy, c-format
-msgid "%s: no %s for this menu"
+msgid "%s: no binds for this menu"
 msgstr "%s: δεν υπάρχει τέτοιο μενού"
 
 #: icommands.c:278 icommands.c:290 imap/message.c:1050
+#, fuzzy, c-format
+msgid "%s: no macros for this menu"
+msgstr "%s: δεν υπάρχει τέτοιο μενού"
+
+#. L10N: '%s' is the file name of the temporary file
 #, c-format
 msgid "Could not create temporary file %s"
 msgstr "Αδυναμία δημιουργίας προσωρινού αρχείου %s"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -1656,6 +1656,7 @@ msgstr "unhook: unknown hook type: %s"
 msgid "unhook: Can't delete a %s from within a %s"
 msgstr "unhook: Can't delete a %s from within a %s"
 
+#. L10N: '%s' is the (misspelled) name of the menu, e.g. 'index' or 'pager'
 #: icommands.c:257 keymap.c:1143 keymap.c:1322
 #, c-format
 msgid "%s: no such menu"
@@ -1666,7 +1667,18 @@ msgstr "%s: no such menu"
 msgid "%s: no %s for this menu"
 msgstr "%s: no %s for this menu"
 
+#. L10N: '%s' is the name of the menu, e.g. 'index' or 'pager', it might
+#. L10N: also be 'all' when all menus are affected.
 #: icommands.c:278 icommands.c:290 imap/message.c:1050
+#, fuzzy, c-format
+msgid "%s: no binds for this menu"
+msgstr "%s: no %s for this menu"
+
+#, fuzzy, c-format
+msgid "%s: no macros for this menu"
+msgstr "%s: no %s for this menu"
+
+#. L10N: '%s' is the file name of the temporary file
 #, c-format
 msgid "Could not create temporary file %s"
 msgstr "Could not create temporary file %s"

--- a/po/eo.po
+++ b/po/eo.po
@@ -1702,17 +1702,25 @@ msgstr "unhook: nekonata speco de hook: %s"
 msgid "unhook: Can't delete a %s from within a %s"
 msgstr "unhook: Ne eblas forviŝi %s de en %s"
 
+#. L10N: '%s' is the (misspelled) name of the menu, e.g. 'index' or 'pager'
 #: icommands.c:257 keymap.c:1143 keymap.c:1322
 #, c-format
 msgid "%s: no such menu"
 msgstr "%s: nekonata menuo"
 
+#. L10N: '%s' is the name of the menu, e.g. 'index' or 'pager', it might
+#. L10N: also be 'all' when all menus are affected.
 #: icommands.c:268
 #, fuzzy, c-format
-msgid "%s: no %s for this menu"
+msgid "%s: no binds for this menu"
 msgstr "%s: nekonata menuo"
 
 #: icommands.c:278 icommands.c:290 imap/message.c:1050
+#, fuzzy, c-format
+msgid "%s: no macros for this menu"
+msgstr "%s: nekonata menuo"
+
+#. L10N: '%s' is the file name of the temporary file
 #, c-format
 msgid "Could not create temporary file %s"
 msgstr "Ne eblis krei dumtempan dosieron %s"

--- a/po/es.po
+++ b/po/es.po
@@ -1696,17 +1696,25 @@ msgstr "unhook: tipo de gancho desconocido: %s"
 msgid "unhook: Can't delete a %s from within a %s"
 msgstr "unhook: No se puede suprimir un %s desde dentro de un %s"
 
+#. L10N: '%s' is the (misspelled) name of the menu, e.g. 'index' or 'pager'
 #: icommands.c:257 keymap.c:1143 keymap.c:1322
 #, c-format
 msgid "%s: no such menu"
 msgstr "%s: menú desconocido"
 
+#. L10N: '%s' is the name of the menu, e.g. 'index' or 'pager', it might
+#. L10N: also be 'all' when all menus are affected.
 #: icommands.c:268
 #, fuzzy, c-format
-msgid "%s: no %s for this menu"
+msgid "%s: no binds for this menu"
 msgstr "%s: menú desconocido"
 
 #: icommands.c:278 icommands.c:290 imap/message.c:1050
+#, fuzzy, c-format
+msgid "%s: no macros for this menu"
+msgstr "%s: menú desconocido"
+
+#. L10N: '%s' is the file name of the temporary file
 #, c-format
 msgid "Could not create temporary file %s"
 msgstr "No se pudo crear el archivo temporáneo %s"

--- a/po/et.po
+++ b/po/et.po
@@ -1743,17 +1743,25 @@ msgstr "unhook: tundmatu seose tüüp: %s"
 msgid "unhook: Can't delete a %s from within a %s"
 msgstr "unhook: %s ei saa %s seest kustutada"
 
+#. L10N: '%s' is the (misspelled) name of the menu, e.g. 'index' or 'pager'
 #: icommands.c:257 keymap.c:1143 keymap.c:1322
 #, c-format
 msgid "%s: no such menu"
 msgstr "%s: sellist menüüd ei ole"
 
+#. L10N: '%s' is the name of the menu, e.g. 'index' or 'pager', it might
+#. L10N: also be 'all' when all menus are affected.
 #: icommands.c:268
 #, fuzzy, c-format
-msgid "%s: no %s for this menu"
+msgid "%s: no binds for this menu"
 msgstr "%s: sellist menüüd ei ole"
 
 #: icommands.c:278 icommands.c:290 imap/message.c:1050
+#, fuzzy, c-format
+msgid "%s: no macros for this menu"
+msgstr "%s: sellist menüüd ei ole"
+
+#. L10N: '%s' is the file name of the temporary file
 #, c-format
 msgid "Could not create temporary file %s"
 msgstr "Ajutise faili %s loomine ebaõnnestus"

--- a/po/eu.po
+++ b/po/eu.po
@@ -1719,17 +1719,25 @@ msgstr "unhook: gantxo mota ezezaguna: %s"
 msgid "unhook: Can't delete a %s from within a %s"
 msgstr "unhook: Ezin da %s bat ezabatu %s baten barnetik"
 
+#. L10N: '%s' is the (misspelled) name of the menu, e.g. 'index' or 'pager'
 #: icommands.c:257 keymap.c:1143 keymap.c:1322
 #, c-format
 msgid "%s: no such menu"
 msgstr "%s: ez da menurik"
 
+#. L10N: '%s' is the name of the menu, e.g. 'index' or 'pager', it might
+#. L10N: also be 'all' when all menus are affected.
 #: icommands.c:268
 #, fuzzy, c-format
-msgid "%s: no %s for this menu"
+msgid "%s: no binds for this menu"
 msgstr "%s: ez da menurik"
 
 #: icommands.c:278 icommands.c:290 imap/message.c:1050
+#, fuzzy, c-format
+msgid "%s: no macros for this menu"
+msgstr "%s: ez da menurik"
+
+#. L10N: '%s' is the file name of the temporary file
 #, c-format
 msgid "Could not create temporary file %s"
 msgstr "Ezin da %s fitxategi tenporala sortu"

--- a/po/fi.po
+++ b/po/fi.po
@@ -1666,17 +1666,25 @@ msgstr "unhook: tuntematon hook-tyyppi: %s"
 msgid "unhook: Can't delete a %s from within a %s"
 msgstr "unhook: Ei voitu poistaa kohdetta %s kohteesta %s"
 
+#. L10N: '%s' is the (misspelled) name of the menu, e.g. 'index' or 'pager'
 #: icommands.c:257 keymap.c:1143 keymap.c:1322
 #, c-format
 msgid "%s: no such menu"
 msgstr "%s: valikko puuttuu"
 
+#. L10N: '%s' is the name of the menu, e.g. 'index' or 'pager', it might
+#. L10N: also be 'all' when all menus are affected.
 #: icommands.c:268
 #, fuzzy, c-format
-msgid "%s: no %s for this menu"
+msgid "%s: no binds for this menu"
 msgstr "%s: valikko puuttuu"
 
 #: icommands.c:278 icommands.c:290 imap/message.c:1050
+#, fuzzy, c-format
+msgid "%s: no macros for this menu"
+msgstr "%s: valikko puuttuu"
+
+#. L10N: '%s' is the file name of the temporary file
 #, c-format
 msgid "Could not create temporary file %s"
 msgstr "Ei voitu luoda väliaikaistiedostoa %s"

--- a/po/fr.po
+++ b/po/fr.po
@@ -1789,18 +1789,27 @@ msgid "unhook: Can't delete a %s from within a %s"
 msgstr "unhook : impossible de supprimer un %s à l'intérieur d'un %s"
 
 # , c-format
+#. L10N: '%s' is the (misspelled) name of the menu, e.g. 'index' or 'pager'
 #: icommands.c:257 keymap.c:1143 keymap.c:1322
 #, c-format
 msgid "%s: no such menu"
 msgstr "%s : ce menu n'existe pas"
 
 # , c-format
+#. L10N: '%s' is the name of the menu, e.g. 'index' or 'pager', it might
+#. L10N: also be 'all' when all menus are affected.
 #: icommands.c:268
 #, fuzzy, c-format
-msgid "%s: no %s for this menu"
+msgid "%s: no binds for this menu"
 msgstr "%s : ce menu n'existe pas"
 
 #: icommands.c:278 icommands.c:290 imap/message.c:1050
+# , c-format
+#, fuzzy, c-format
+msgid "%s: no macros for this menu"
+msgstr "%s : ce menu n'existe pas"
+
+#. L10N: '%s' is the file name of the temporary file
 #, c-format
 msgid "Could not create temporary file %s"
 msgstr "Impossible de créer le fichier temporaire %s"

--- a/po/ga.po
+++ b/po/ga.po
@@ -1753,17 +1753,25 @@ msgstr "unhook: cineál anaithnid crúca: %s"
 msgid "unhook: Can't delete a %s from within a %s"
 msgstr "unhook: Ní féidir %s a scriosadh taobh istigh de %s"
 
+#. L10N: '%s' is the (misspelled) name of the menu, e.g. 'index' or 'pager'
 #: icommands.c:257 keymap.c:1143 keymap.c:1322
 #, c-format
 msgid "%s: no such menu"
 msgstr "%s: níl a leithéid de roghchlár ann"
 
+#. L10N: '%s' is the name of the menu, e.g. 'index' or 'pager', it might
+#. L10N: also be 'all' when all menus are affected.
 #: icommands.c:268
 #, fuzzy, c-format
-msgid "%s: no %s for this menu"
+msgid "%s: no binds for this menu"
 msgstr "%s: níl a leithéid de roghchlár ann"
 
 #: icommands.c:278 icommands.c:290 imap/message.c:1050
+#, fuzzy, c-format
+msgid "%s: no macros for this menu"
+msgstr "%s: níl a leithéid de roghchlár ann"
+
+#. L10N: '%s' is the file name of the temporary file
 #, c-format
 msgid "Could not create temporary file %s"
 msgstr "Níorbh fhéidir comhad sealadach %s a chruthú"

--- a/po/gl.po
+++ b/po/gl.po
@@ -1748,17 +1748,25 @@ msgstr "unhook: tipo descoñecido: %s"
 msgid "unhook: Can't delete a %s from within a %s"
 msgstr "unhook: non é posible borrar un %s dende dentro dun %s"
 
+#. L10N: '%s' is the (misspelled) name of the menu, e.g. 'index' or 'pager'
 #: icommands.c:257 keymap.c:1143 keymap.c:1322
 #, c-format
 msgid "%s: no such menu"
 msgstr "%s: non hai tal menú"
 
+#. L10N: '%s' is the name of the menu, e.g. 'index' or 'pager', it might
+#. L10N: also be 'all' when all menus are affected.
 #: icommands.c:268
 #, fuzzy, c-format
-msgid "%s: no %s for this menu"
+msgid "%s: no binds for this menu"
 msgstr "%s: non hai tal menú"
 
 #: icommands.c:278 icommands.c:290 imap/message.c:1050
+#, fuzzy, c-format
+msgid "%s: no macros for this menu"
+msgstr "%s: non hai tal menú"
+
+#. L10N: '%s' is the file name of the temporary file
 #, fuzzy, c-format
 msgid "Could not create temporary file %s"
 msgstr "¡Non foi posible crear o ficheiro temporal!"

--- a/po/hu.po
+++ b/po/hu.po
@@ -1745,17 +1745,25 @@ msgstr "hozzárendelés törlése: ismeretlen hozzárendelési típus: %s"
 msgid "unhook: Can't delete a %s from within a %s"
 msgstr "unhook: %s-t nem lehet törölni a következőből: %s"
 
+#. L10N: '%s' is the (misspelled) name of the menu, e.g. 'index' or 'pager'
 #: icommands.c:257 keymap.c:1143 keymap.c:1322
 #, c-format
 msgid "%s: no such menu"
 msgstr "%s: nincs ilyen menü"
 
+#. L10N: '%s' is the name of the menu, e.g. 'index' or 'pager', it might
+#. L10N: also be 'all' when all menus are affected.
 #: icommands.c:268
 #, fuzzy, c-format
-msgid "%s: no %s for this menu"
+msgid "%s: no binds for this menu"
 msgstr "%s: nincs ilyen menü"
 
 #: icommands.c:278 icommands.c:290 imap/message.c:1050
+#, fuzzy, c-format
+msgid "%s: no macros for this menu"
+msgstr "%s: nincs ilyen menü"
+
+#. L10N: '%s' is the file name of the temporary file
 #, c-format
 msgid "Could not create temporary file %s"
 msgstr "Nem lehet a %s átmeneti fájlt létrehozni"

--- a/po/id.po
+++ b/po/id.po
@@ -1710,17 +1710,25 @@ msgstr "unhook: jenis tidak dikenali: %s"
 msgid "unhook: Can't delete a %s from within a %s"
 msgstr "unhook: Tidak dapat menghapus %s dari %s"
 
+#. L10N: '%s' is the (misspelled) name of the menu, e.g. 'index' or 'pager'
 #: icommands.c:257 keymap.c:1143 keymap.c:1322
 #, c-format
 msgid "%s: no such menu"
 msgstr "%s: tidak ada menu begitu"
 
+#. L10N: '%s' is the name of the menu, e.g. 'index' or 'pager', it might
+#. L10N: also be 'all' when all menus are affected.
 #: icommands.c:268
 #, fuzzy, c-format
-msgid "%s: no %s for this menu"
+msgid "%s: no binds for this menu"
 msgstr "%s: tidak ada menu begitu"
 
 #: icommands.c:278 icommands.c:290 imap/message.c:1050
+#, fuzzy, c-format
+msgid "%s: no macros for this menu"
+msgstr "%s: tidak ada menu begitu"
+
+#. L10N: '%s' is the file name of the temporary file
 #, c-format
 msgid "Could not create temporary file %s"
 msgstr "Tidak bisa membuat file sementara %s"

--- a/po/it.po
+++ b/po/it.po
@@ -1711,17 +1711,25 @@ msgstr "unhook: tipo di hook sconosciuto: %s"
 msgid "unhook: Can't delete a %s from within a %s"
 msgstr "unhook: impossibile cancellare un %s dentro un %s"
 
+#. L10N: '%s' is the (misspelled) name of the menu, e.g. 'index' or 'pager'
 #: icommands.c:257 keymap.c:1143 keymap.c:1322
 #, c-format
 msgid "%s: no such menu"
 msgstr "%s: menù inesistente"
 
+#. L10N: '%s' is the name of the menu, e.g. 'index' or 'pager', it might
+#. L10N: also be 'all' when all menus are affected.
 #: icommands.c:268
 #, fuzzy, c-format
-msgid "%s: no %s for this menu"
+msgid "%s: no binds for this menu"
 msgstr "%s: menù inesistente"
 
 #: icommands.c:278 icommands.c:290 imap/message.c:1050
+#, fuzzy, c-format
+msgid "%s: no macros for this menu"
+msgstr "%s: menù inesistente"
+
+#. L10N: '%s' is the file name of the temporary file
 #, c-format
 msgid "Could not create temporary file %s"
 msgstr "Impossibile creare il file temporaneo %s"

--- a/po/ja.po
+++ b/po/ja.po
@@ -1696,17 +1696,25 @@ msgstr "unhook: %s は不明なフックタイプ"
 msgid "unhook: Can't delete a %s from within a %s"
 msgstr "unhook: %s を %s 内から削除できない。"
 
+#. L10N: '%s' is the (misspelled) name of the menu, e.g. 'index' or 'pager'
 #: icommands.c:257 keymap.c:1143 keymap.c:1322
 #, c-format
 msgid "%s: no such menu"
 msgstr "%s というメニューはない"
 
+#. L10N: '%s' is the name of the menu, e.g. 'index' or 'pager', it might
+#. L10N: also be 'all' when all menus are affected.
 #: icommands.c:268
 #, fuzzy, c-format
-msgid "%s: no %s for this menu"
+msgid "%s: no binds for this menu"
 msgstr "%s というメニューはない"
 
 #: icommands.c:278 icommands.c:290 imap/message.c:1050
+#, fuzzy, c-format
+msgid "%s: no macros for this menu"
+msgstr "%s というメニューはない"
+
+#. L10N: '%s' is the file name of the temporary file
 #, c-format
 msgid "Could not create temporary file %s"
 msgstr "一時ファイル %s を作成できなかった"

--- a/po/ko.po
+++ b/po/ko.po
@@ -1732,17 +1732,25 @@ msgstr "unhook: 알 수 없는 hook 유형: %s"
 msgid "unhook: Can't delete a %s from within a %s"
 msgstr "unhook: %s를 %s에서 지울 수 없음"
 
+#. L10N: '%s' is the (misspelled) name of the menu, e.g. 'index' or 'pager'
 #: icommands.c:257 keymap.c:1143 keymap.c:1322
 #, c-format
 msgid "%s: no such menu"
 msgstr "%s: 그런 메뉴 없음"
 
+#. L10N: '%s' is the name of the menu, e.g. 'index' or 'pager', it might
+#. L10N: also be 'all' when all menus are affected.
 #: icommands.c:268
 #, fuzzy, c-format
-msgid "%s: no %s for this menu"
+msgid "%s: no binds for this menu"
 msgstr "%s: 그런 메뉴 없음"
 
 #: icommands.c:278 icommands.c:290 imap/message.c:1050
+#, fuzzy, c-format
+msgid "%s: no macros for this menu"
+msgstr "%s: 그런 메뉴 없음"
+
+#. L10N: '%s' is the file name of the temporary file
 #, c-format
 msgid "Could not create temporary file %s"
 msgstr "임시 파일 %s를 만들 수 없음!"

--- a/po/lt.po
+++ b/po/lt.po
@@ -1670,17 +1670,25 @@ msgstr "unhook: nežinomas hook tipas: %s"
 msgid "unhook: Can't delete a %s from within a %s"
 msgstr "unhook: negaliu išmesti %s %s viduje"
 
+#. L10N: '%s' is the (misspelled) name of the menu, e.g. 'index' or 'pager'
 #: icommands.c:257 keymap.c:1143 keymap.c:1322
 #, c-format
 msgid "%s: no such menu"
 msgstr "%s: nėra tokio meniu"
 
+#. L10N: '%s' is the name of the menu, e.g. 'index' or 'pager', it might
+#. L10N: also be 'all' when all menus are affected.
 #: icommands.c:268
 #, fuzzy, c-format
-msgid "%s: no %s for this menu"
+msgid "%s: no binds for this menu"
 msgstr "%s: nėra tokio meniu"
 
 #: icommands.c:278 icommands.c:290 imap/message.c:1050
+#, fuzzy, c-format
+msgid "%s: no macros for this menu"
+msgstr "%s: nėra tokio meniu"
+
+#. L10N: '%s' is the file name of the temporary file
 #, c-format
 msgid "Could not create temporary file %s"
 msgstr "Negaliu sukurti laikinos bylos %s"

--- a/po/nl.po
+++ b/po/nl.po
@@ -1706,17 +1706,25 @@ msgstr "unhook: onbekend 'hook'-type: %s"
 msgid "unhook: Can't delete a %s from within a %s"
 msgstr "unhook: Kan geen %s wissen binnen een %s"
 
+#. L10N: '%s' is the (misspelled) name of the menu, e.g. 'index' or 'pager'
 #: icommands.c:257 keymap.c:1143 keymap.c:1322
 #, c-format
 msgid "%s: no such menu"
 msgstr "%s: onbekend menu"
 
+#. L10N: '%s' is the name of the menu, e.g. 'index' or 'pager', it might
+#. L10N: also be 'all' when all menus are affected.
 #: icommands.c:268
 #, fuzzy, c-format
-msgid "%s: no %s for this menu"
+msgid "%s: no binds for this menu"
 msgstr "%s: onbekend menu"
 
 #: icommands.c:278 icommands.c:290 imap/message.c:1050
+#, fuzzy, c-format
+msgid "%s: no macros for this menu"
+msgstr "%s: onbekend menu"
+
+#. L10N: '%s' is the file name of the temporary file
 #, c-format
 msgid "Could not create temporary file %s"
 msgstr "Tijdelijk bestand %s kon niet worden aangemaakt"

--- a/po/pl.po
+++ b/po/pl.po
@@ -1671,17 +1671,25 @@ msgstr "unhook: nieznany typ polecenia hook: %s"
 msgid "unhook: Can't delete a %s from within a %s"
 msgstr "unhook: Nie można skasować %s z wewnątrz %s"
 
+#. L10N: '%s' is the (misspelled) name of the menu, e.g. 'index' or 'pager'
 #: icommands.c:257 keymap.c:1143 keymap.c:1322
 #, c-format
 msgid "%s: no such menu"
 msgstr "%s: nie ma takiego menu"
 
+#. L10N: '%s' is the name of the menu, e.g. 'index' or 'pager', it might
+#. L10N: also be 'all' when all menus are affected.
 #: icommands.c:268
 #, fuzzy, c-format
-msgid "%s: no %s for this menu"
+msgid "%s: no binds for this menu"
 msgstr "%s: nie ma takiego menu"
 
 #: icommands.c:278 icommands.c:290 imap/message.c:1050
+#, fuzzy, c-format
+msgid "%s: no macros for this menu"
+msgstr "%s: nie ma takiego menu"
+
+#. L10N: '%s' is the file name of the temporary file
 #, c-format
 msgid "Could not create temporary file %s"
 msgstr "Nie można utworzyć pliku tymczasowego %s"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -1662,17 +1662,25 @@ msgstr "unhook: tipo de gancho desconhecido: %s"
 msgid "unhook: Can't delete a %s from within a %s"
 msgstr "unhook: não é possível apagar %s de dentro de %s"
 
+#. L10N: '%s' is the (misspelled) name of the menu, e.g. 'index' or 'pager'
 #: icommands.c:257 keymap.c:1143 keymap.c:1322
 #, c-format
 msgid "%s: no such menu"
 msgstr "%s: não existe tal menu"
 
+#. L10N: '%s' is the name of the menu, e.g. 'index' or 'pager', it might
+#. L10N: also be 'all' when all menus are affected.
 #: icommands.c:268
 #, fuzzy, c-format
-msgid "%s: no %s for this menu"
+msgid "%s: no binds for this menu"
 msgstr "%s: não existe tal menu"
 
 #: icommands.c:278 icommands.c:290 imap/message.c:1050
+#, fuzzy, c-format
+msgid "%s: no macros for this menu"
+msgstr "%s: não existe tal menu"
+
+#. L10N: '%s' is the file name of the temporary file
 #, c-format
 msgid "Could not create temporary file %s"
 msgstr "Não foi possível criar o arquivo temporário %s"

--- a/po/ru.po
+++ b/po/ru.po
@@ -1715,17 +1715,25 @@ msgstr "unhook: неизвестный тип события: %s"
 msgid "unhook: Can't delete a %s from within a %s"
 msgstr "unhook: Невозможно удалить %s из команды %s"
 
+#. L10N: '%s' is the (misspelled) name of the menu, e.g. 'index' or 'pager'
 #: icommands.c:257 keymap.c:1143 keymap.c:1322
 #, c-format
 msgid "%s: no such menu"
 msgstr "%s: нет такого меню"
 
+#. L10N: '%s' is the name of the menu, e.g. 'index' or 'pager', it might
+#. L10N: also be 'all' when all menus are affected.
 #: icommands.c:268
 #, fuzzy, c-format
-msgid "%s: no %s for this menu"
+msgid "%s: no binds for this menu"
 msgstr "%s: нет такого меню"
 
 #: icommands.c:278 icommands.c:290 imap/message.c:1050
+#, fuzzy, c-format
+msgid "%s: no macros for this menu"
+msgstr "%s: нет такого меню"
+
+#. L10N: '%s' is the file name of the temporary file
 #, c-format
 msgid "Could not create temporary file %s"
 msgstr "Не удалось создать временный файл %s"

--- a/po/sk.po
+++ b/po/sk.po
@@ -1722,17 +1722,25 @@ msgstr "%s: neznáma hodnota"
 msgid "unhook: Can't delete a %s from within a %s"
 msgstr ""
 
+#. L10N: '%s' is the (misspelled) name of the menu, e.g. 'index' or 'pager'
 #: icommands.c:257 keymap.c:1143 keymap.c:1322
 #, c-format
 msgid "%s: no such menu"
 msgstr "%s: také menu neexistuje"
 
+#. L10N: '%s' is the name of the menu, e.g. 'index' or 'pager', it might
+#. L10N: also be 'all' when all menus are affected.
 #: icommands.c:268
 #, fuzzy, c-format
-msgid "%s: no %s for this menu"
+msgid "%s: no binds for this menu"
 msgstr "%s: také menu neexistuje"
 
 #: icommands.c:278 icommands.c:290 imap/message.c:1050
+#, fuzzy, c-format
+msgid "%s: no macros for this menu"
+msgstr "%s: také menu neexistuje"
+
+#. L10N: '%s' is the file name of the temporary file
 #, fuzzy, c-format
 msgid "Could not create temporary file %s"
 msgstr "Nemožno vytvoriť dočasný súbor!"

--- a/po/sv.po
+++ b/po/sv.po
@@ -1718,17 +1718,25 @@ msgstr "\"unhook\": okänd \"hook\"-typ: %s"
 msgid "unhook: Can't delete a %s from within a %s"
 msgstr "\"unhook\": Kan inte ta bort en %s inifrån en %s"
 
+#. L10N: '%s' is the (misspelled) name of the menu, e.g. 'index' or 'pager'
 #: icommands.c:257 keymap.c:1143 keymap.c:1322
 #, c-format
 msgid "%s: no such menu"
 msgstr "%s: ingen sådan meny"
 
+#. L10N: '%s' is the name of the menu, e.g. 'index' or 'pager', it might
+#. L10N: also be 'all' when all menus are affected.
 #: icommands.c:268
 #, fuzzy, c-format
-msgid "%s: no %s for this menu"
+msgid "%s: no binds for this menu"
 msgstr "%s: ingen sådan meny"
 
 #: icommands.c:278 icommands.c:290 imap/message.c:1050
+#, fuzzy, c-format
+msgid "%s: no macros for this menu"
+msgstr "%s: ingen sådan meny"
+
+#. L10N: '%s' is the file name of the temporary file
 #, c-format
 msgid "Could not create temporary file %s"
 msgstr "Kunde inte skapa tillfällig fil %s"

--- a/po/tr.po
+++ b/po/tr.po
@@ -1699,17 +1699,25 @@ msgstr "unhook: bilinmeyen kanca (hook) tipi: %s"
 msgid "unhook: Can't delete a %s from within a %s"
 msgstr "unhook: %s bir %s içindeyken silinemez"
 
+#. L10N: '%s' is the (misspelled) name of the menu, e.g. 'index' or 'pager'
 #: icommands.c:257 keymap.c:1143 keymap.c:1322
 #, c-format
 msgid "%s: no such menu"
 msgstr "%s: böyle bir menü yok"
 
+#. L10N: '%s' is the name of the menu, e.g. 'index' or 'pager', it might
+#. L10N: also be 'all' when all menus are affected.
 #: icommands.c:268
 #, fuzzy, c-format
-msgid "%s: no %s for this menu"
+msgid "%s: no binds for this menu"
 msgstr "%s: böyle bir menü yok"
 
 #: icommands.c:278 icommands.c:290 imap/message.c:1050
+#, fuzzy, c-format
+msgid "%s: no macros for this menu"
+msgstr "%s: böyle bir menü yok"
+
+#. L10N: '%s' is the file name of the temporary file
 #, c-format
 msgid "Could not create temporary file %s"
 msgstr "Geçici dosya %s yaratılamadı!"

--- a/po/uk.po
+++ b/po/uk.po
@@ -1712,17 +1712,25 @@ msgstr "unhook: невідомий тип hook: %s"
 msgid "unhook: Can't delete a %s from within a %s"
 msgstr "unhook: Неможливо видалити %s з %s"
 
+#. L10N: '%s' is the (misspelled) name of the menu, e.g. 'index' or 'pager'
 #: icommands.c:257 keymap.c:1143 keymap.c:1322
 #, c-format
 msgid "%s: no such menu"
 msgstr "меню \"%s\" не існує"
 
+#. L10N: '%s' is the name of the menu, e.g. 'index' or 'pager', it might
+#. L10N: also be 'all' when all menus are affected.
 #: icommands.c:268
 #, fuzzy, c-format
-msgid "%s: no %s for this menu"
+msgid "%s: no binds for this menu"
 msgstr "меню \"%s\" не існує"
 
 #: icommands.c:278 icommands.c:290 imap/message.c:1050
+#, fuzzy, c-format
+msgid "%s: no macros for this menu"
+msgstr "меню \"%s\" не існує"
+
+#. L10N: '%s' is the file name of the temporary file
 #, c-format
 msgid "Could not create temporary file %s"
 msgstr "Не вийшло створити тимчасовий файл %s"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1654,6 +1654,7 @@ msgstr "unhook：未知钩子类型：%s"
 msgid "unhook: Can't delete a %s from within a %s"
 msgstr "unhook：无法从 %2$s 中删除 %1$s"
 
+#. L10N: '%s' is the (misspelled) name of the menu, e.g. 'index' or 'pager'
 #: icommands.c:257 keymap.c:1143 keymap.c:1322
 #, c-format
 msgid "%s: no such menu"
@@ -1664,7 +1665,18 @@ msgstr "%s：没有这个选单"
 msgid "%s: no %s for this menu"
 msgstr "%s：该选单无 %s 项"
 
+#. L10N: '%s' is the name of the menu, e.g. 'index' or 'pager', it might
+#. L10N: also be 'all' when all menus are affected.
 #: icommands.c:278 icommands.c:290 imap/message.c:1050
+#, fuzzy, c-format
+msgid "%s: no binds for this menu"
+msgstr "%s：该选单无 %s 项"
+
+#, fuzzy, c-format
+msgid "%s: no macros for this menu"
+msgstr "%s：该选单无 %s 项"
+
+#. L10N: '%s' is the file name of the temporary file
 #, c-format
 msgid "Could not create temporary file %s"
 msgstr "无法创建临时文件 %s"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -1740,17 +1740,25 @@ msgstr "unhook：不明的 hook type %s"
 msgid "unhook: Can't delete a %s from within a %s"
 msgstr "unhook：不能從 %2$s 刪除 %1$s"
 
+#. L10N: '%s' is the (misspelled) name of the menu, e.g. 'index' or 'pager'
 #: icommands.c:257 keymap.c:1143 keymap.c:1322
 #, c-format
 msgid "%s: no such menu"
 msgstr "%s：沒有這個選單"
 
+#. L10N: '%s' is the name of the menu, e.g. 'index' or 'pager', it might
+#. L10N: also be 'all' when all menus are affected.
 #: icommands.c:268
 #, fuzzy, c-format
-msgid "%s: no %s for this menu"
+msgid "%s: no binds for this menu"
 msgstr "%s：沒有這個選單"
 
 #: icommands.c:278 icommands.c:290 imap/message.c:1050
+#, fuzzy, c-format
+msgid "%s: no macros for this menu"
+msgstr "%s：沒有這個選單"
+
+#. L10N: '%s' is the file name of the temporary file
 #, c-format
 msgid "Could not create temporary file %s"
 msgstr "無法建立暫存檔 %s"


### PR DESCRIPTION
Give the translator a complete sentence to translate instead of translating parts and combining them together.

In addition, this pull request contains
* Added hints (aka comments) for the translators of the strings
* Add filename to the error strings. (This is a unification of slightly different worded sentences)

Note:
The po files were updated but only their contents. The line numbers and other changes (form other source files) are not updated. This allows for a better review.

This fixes issue #1680.