### PR TITLE
Fix crash when trying to collapse a limit not matching any messages

### DIFF
--- a/index.c
+++ b/index.c
@@ -254,6 +254,9 @@ static void collapse_all(struct Menu *menu, int toggle)
   else
     final = CUR_EMAIL->virtual;
 
+  if (final == -1)
+    return;
+
   base = Context->mailbox->emails[Context->mailbox->v2r[final]];
 
   /* Iterate all threads, perform collapse/uncollapse as needed */


### PR DESCRIPTION
This is a follow-up of #1685
