### PR TITLE
Fix utf7/utf8 conversion of mailbox names in LIST response

### DIFF
--- a/imap/command.c
+++ b/imap/command.c
@@ -630,7 +630,7 @@ static void cmd_parse_list(struct ImapAccountData *adata, char *s)
     s = imap_next_word(s);
     if (s[0] != '\0')
       s[-1] = '\0';
-    imap_unmunge_mbox_name(adata, list->name);
+    imap_unmunge_mbox_name(adata->unicode, list->name);
   }
 
   if (list->name[0] == '\0')


### PR DESCRIPTION
Because of a wrong argument passed into `imap_unmunge_mbox_name`, mailbox names encoded in utf7 are not properly converted into utf8. This causes two problems:

1. mailbox names are mangled in the UI (M&AOY-lstr&APY-m instead of Mælström)

2. mailbox names are re-encoded to utf7 before being sent to the server, resulting in "Mailbox does not exists" errors in commands such as DELETE