### PR TITLE
Allow to disable IMAP's ENABLE extension to work-around broken servers

### DIFF
--- a/imap/imap.c
+++ b/imap/imap.c
@@ -68,6 +68,7 @@ struct stat;
 
 /* These Config Variables are only used in imap/imap.c */
 bool C_ImapIdle; ///< Config: (imap) Use the IMAP IDLE extension to check for new mail
+bool C_ImapRfc5161; ///< Config: (imap) Use the IMAP ENABLE extension to select capabilities
 
 /**
  * check_capabilities - Make sure we can log in to this server
@@ -1926,7 +1927,7 @@ int imap_login(struct ImapAccountData *adata)
     imap_exec(adata, "CAPABILITY", IMAP_CMD_QUEUE);
 
     /* enable RFC6855, if the server supports that */
-    if (adata->capabilities & IMAP_CAP_ENABLE)
+    if (C_ImapRfc5161 && (adata->capabilities & IMAP_CAP_ENABLE))
       imap_exec(adata, "ENABLE UTF8=ACCEPT", IMAP_CMD_QUEUE);
 
     /* enable QRESYNC.  Advertising QRESYNC also means CONDSTORE
@@ -1934,7 +1935,7 @@ int imap_login(struct ImapAccountData *adata)
     if (adata->capabilities & IMAP_CAP_QRESYNC)
     {
       adata->capabilities |= IMAP_CAP_CONDSTORE;
-      if (C_ImapQresync)
+      if (C_ImapRfc5161 && C_ImapQresync)
         imap_exec(adata, "ENABLE QRESYNC", IMAP_CMD_QUEUE);
     }
 

--- a/imap/imap.h
+++ b/imap/imap.h
@@ -66,6 +66,7 @@ extern char *C_ImapAuthenticators;
 
 /* These Config Variables are only used in imap/imap.c */
 extern bool C_ImapIdle;
+extern bool C_ImapRfc5161;
 
 /* These Config Variables are only used in imap/message.c */
 extern char *C_ImapHeaders;

--- a/init.h
+++ b/init.h
@@ -1704,6 +1704,15 @@ struct ConfigDef MuttVars[] = {
   ** strange behavior, such as duplicate or missing messages please
   ** file a bug report to let us know.
   */
+  { "imap_rfc5161", DT_BOOL, R_NONE, &C_ImapRfc5161, true },
+  /*
+  ** .pp
+  ** When \fIset\fP, NeoMutt will use the IMAP ENABLE extension (RFC 5161) to
+  ** select CAPABILITIES. Some servers (notably Coremail System IMap Server) do
+  ** not properly respond to ENABLE commands, which might cause NeoMutt to hang.
+  ** If your connection seems to freeze at login, try unsetting this. See also
+  ** https://github.com/neomutt/neomutt/issues/1689
+  */
   { "imap_servernoise",         DT_BOOL, R_NONE, &C_ImapServernoise, true },
   /*
   ** .pp


### PR DESCRIPTION
Issue #1689
