### PR TITLE
Fix bugs raised by automated testing

### DIFF
--- a/address/address.c
+++ b/address/address.c
@@ -566,10 +566,10 @@ struct Address *mutt_addr_parse_list(struct Address *top, const char *s)
       /* add group terminator */
       cur = mutt_addr_new();
       if (last)
-      {
         last->next = cur;
-        last = cur;
-      }
+      else
+        top = cur;
+      last = cur;
 
       phraselen = 0;
       commentlen = 0;

--- a/color.c
+++ b/color.c
@@ -1132,7 +1132,7 @@ static enum CommandResult parse_color(struct Buffer *buf, struct Buffer *s,
     {
       struct Buffer temporary = { 0 };
       mutt_extract_token(&temporary, s, MUTT_TOKEN_NO_FLAGS);
-      match = atoi(temporary.data);
+      mutt_str_atoui(temporary.data, &match);
       FREE(&temporary.data);
     }
 

--- a/email/parse.c
+++ b/email/parse.c
@@ -479,7 +479,7 @@ void mutt_parse_content_type(const char *s, struct Body *ct)
 
   if (ct->type == TYPE_OTHER)
   {
-    ct->xtype = mutt_str_strdup(s);
+    mutt_str_replace(&ct->xtype, s);
   }
 
   if (!ct->subtype)

--- a/email/rfc2231.c
+++ b/email/rfc2231.c
@@ -285,7 +285,7 @@ void rfc2231_decode_parameters(struct ParameterList *p)
       encoded = (*t == '*');
       *t = '\0';
 
-      index = atoi(s);
+      mutt_str_atoi(s, &index);
 
       conttmp = new_parameter();
       conttmp->attribute = np->attribute;

--- a/maildir/shared.c
+++ b/maildir/shared.c
@@ -933,7 +933,7 @@ int mh_commit_msg(struct Mailbox *m, struct Message *msg, struct Email *e, bool 
     }
     if (!*cp)
     {
-      n = atoi(dep);
+      mutt_str_atoui(dep, &n);
       if (n > hi)
         hi = n;
     }

--- a/mutt/regex.c
+++ b/mutt/regex.c
@@ -313,7 +313,8 @@ int mutt_replacelist_add(struct ReplaceList *rl, const char *pat,
   {
     if (*p == '%')
     {
-      int n = atoi(++p);
+      int n = 0;
+      mutt_str_atoi(++p, &n);
       if (n > np->nmatch)
         np->nmatch = n;
       while (*p && isdigit((int) *p))


### PR DESCRIPTION
- Replace `atoi()` uses with `mutt_str_atoi()`
  which has range checking and returns errors

- Fix memory leaks during header parsing
  These were triggered by some fairly degenerate headers

- Check the value of the 'Content-Length' header more carefully
  Large numbers could cause the `long` to overflow

Thanks to LGTM and oss-fuzz.