### PR TITLE
entire-thread: determine current position before resorting.

### DIFF
--- a/index.c
+++ b/index.c
@@ -1983,16 +1983,15 @@ int mutt_index_menu(void)
         }
         if (!prereq(Context, menu, CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE))
           break;
-        int oc = Context->mailbox->msg_count;
+        oldcount = Context->mailbox->msg_count;
+        struct Email *oldcur = CUR_EMAIL;
         if (nm_read_entire_thread(Context->mailbox, CUR_EMAIL) < 0)
         {
           mutt_message(_("Failed to read thread, aborting"));
           break;
         }
-        if (oc < Context->mailbox->msg_count)
+        if (oldcount < Context->mailbox->msg_count)
         {
-          struct Email *oldcur = CUR_EMAIL;
-
           if ((C_Sort & SORT_MASK) == SORT_THREADS)
             mutt_sort_headers(Context, false);
           menu->current = oldcur->virtual;


### PR DESCRIPTION
Previously oldcur was determined after nm_read_entire_thread(),
leading to entire-thread unintentionally jumping to the first message
in the thread.

Before 918885f32db41 that used to work, because mutt_sort_headers()
wasn't called from within nm_read_entire_thread().

Fix by moving oldcount computation a few lines up. Rename oc variable,
to avoid confusion.

Fixes: #1714