### PR TITLE
Avoid redundant sort in entire-thread.

### DIFF
--- a/index.c
+++ b/index.c
@@ -1992,8 +1992,7 @@ int mutt_index_menu(void)
         }
         if (oldcount < Context->mailbox->msg_count)
         {
-          if ((C_Sort & SORT_MASK) == SORT_THREADS)
-            mutt_sort_headers(Context, false);
+          /* nm_read_entire_thread() triggers mutt_sort_headers() if necessary */
           menu->current = oldcur->virtual;
           menu->redraw = REDRAW_STATUS | REDRAW_INDEX;
 


### PR DESCRIPTION
918885f added, indirectly, a mutt_sort_headers() call to
nm_read_entire_thread() (via mutt_mailbox_changed() ->
ctx_mailbox_changed() -> ctx_update()), but didn't remove the sort
after nm_read_entire_thread() in mutt_index_menu().

Remove the now superfluous sort.
