### PR TITLE
doc: add example to find all maildir mailboxes

### DIFF
--- a/doc/manual.xml.head
+++ b/doc/manual.xml.head
@@ -9306,6 +9306,14 @@ subjectrx '\[[^]]*\]:? *' '%L%R'
             don't completely rely on this feature.
           </para>
         </note>
+        <note>
+          <para>
+            When using Maildir, you don't have to manually specify all your mailboxes. You can use this command instead:
+            <screen>
+              mailboxes `find ~/.mail/ -type d -name cur | sed 's:/cur/*$::' | tr '\n' ' '`
+            </screen>
+          </para>
+        </note>
       </sect2>
 
       <sect2 id="calc-mailbox-counts">


### PR DESCRIPTION
* **What does this PR do?**

When you have many Maildir mailboxes (or if you change it regularly), it can be cumbersome to maintain the `mailboxes` list manually. This PR adds an example to automate that.

**NOTE**: I don't think the section ["Monitoring new Mail"](https://neomutt.org/guide/configuration.html#mailboxes) is correct for this example - but i haven't found a better place, since this section is the target-link for the `mailboxes` command in the [reference](https://neomutt.org/guide/reference#2-%C2%A0configuration-commands)
