### PR TITLE
make OP_HALF_{UP,DOWN} behave symmetric.

### DIFF
--- a/pager.c
+++ b/pager.c
@@ -2573,8 +2573,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
       case OP_HALF_UP:
         if (rd.topline)
         {
-          rd.topline = up_n_lines(rd.pager_window->rows / 2, rd.line_info,
-                                  rd.topline, rd.hide_quoted);
+          rd.topline = up_n_lines(rd.pager_window->rows / 2 + (rd.pager_window->rows % 2),
+                                  rd.line_info, rd.topline, rd.hide_quoted);
         }
         else
           mutt_error(_("Top of message is shown"));


### PR DESCRIPTION
  - the calculation of number of lines to scroll up/down should not
  depend on whether the number of rows in the pager/index/terminal is
  odd or even.
  - this patch will make the behaviour symmetric such that in both cases
  (even/odd number of rows) scrolling up and down by half a page (or the
  other way round) will get you back to the exact same line as before.