### PR TITLE
Start adding notifications

### DIFF
--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -69,7 +69,7 @@ NEOMUTTOBJS=	account.o addrbook.o alias.o bcache.o browser.o color.o commands.o 
 		mutt_account.o mutt_attach.o mutt_body.o mutt_header.o \
 		mutt_history.o mutt_logging.o mutt_parse.o mutt_signal.o \
 		mutt_socket.o mutt_thread.o mutt_window.o mx.o myvar.o \
-		pager.o pattern.o postpone.o progress.o query.o recvattach.o \
+		neomutt.o pager.o pattern.o postpone.o progress.o query.o recvattach.o \
 		recvcmd.o resize.o rfc1524.o rfc3676.o \
 		score.o send.o sendlib.o sidebar.o smtp.o sort.o state.o \
 		status.o system.o terminal.o version.o icommands.o

--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -260,7 +260,8 @@ LIBMUTT=	libmutt.a
 LIBMUTTOBJS=	mutt/base64.o mutt/buffer.o mutt/charset.o mutt/date.o \
 		mutt/envlist.o mutt/exit.o mutt/file.o mutt/hash.o \
 		mutt/history.o mutt/list.o mutt/logging.o mutt/mapping.o \
-		mutt/mbyte.o mutt/md5.o mutt/memory.o mutt/path.o mutt/pool.o \
+		mutt/mbyte.o mutt/md5.o mutt/memory.o mutt/notify.o \
+		mutt/path.o mutt/pool.o \
 		mutt/regex.o mutt/sha1.o mutt/signal.o mutt/string.o
 CLEANFILES+=	$(LIBMUTT) $(LIBMUTTOBJS)
 MUTTLIBS+=	$(LIBMUTT)

--- a/config/bool.c
+++ b/config/bool.c
@@ -226,7 +226,7 @@ int bool_he_toggle(struct ConfigSet *cs, struct HashElem *he, struct Buffer *err
 
   *(char *) var = !value;
 
-  cs_notify_observers(cs, he, he->key.strkey, CE_SET);
+  cs_notify_observers(cs, he, he->key.strkey, NT_CONFIG_SET);
   return CSR_SUCCESS;
 }
 

--- a/config/quad.c
+++ b/config/quad.c
@@ -242,6 +242,6 @@ int quad_he_toggle(struct ConfigSet *cs, struct HashElem *he, struct Buffer *err
 
   *(char *) var = quad_toggle(value);
 
-  cs_notify_observers(cs, he, he->key.strkey, CE_SET);
+  cs_notify_observers(cs, he, he->key.strkey, NT_CONFIG_SET);
   return CSR_SUCCESS;
 }

--- a/config/set.c
+++ b/config/set.c
@@ -177,6 +177,7 @@ void cs_free(struct ConfigSet **cs)
     return;
 
   mutt_hash_free(&(*cs)->hash);
+  notify_free(&(*cs)->notify);
   FREE(cs);
 }
 

--- a/config/set.c
+++ b/config/set.c
@@ -164,6 +164,7 @@ void cs_init(struct ConfigSet *cs, size_t size)
   memset(cs, 0, sizeof(*cs));
   cs->hash = mutt_hash_new(size, MUTT_HASH_NO_FLAGS);
   mutt_hash_set_destructor(cs->hash, destroy, (intptr_t) cs);
+  cs->notify = notify_new(cs, NT_CONFIG);
 }
 
 /**
@@ -308,56 +309,6 @@ struct HashElem *cs_inherit_variable(const struct ConfigSet *cs,
 }
 
 /**
- * cs_add_observer - Add a observer (callback function)
- * @param cs Config items
- * @param fn Observer callback function
- */
-void cs_add_observer(struct ConfigSet *cs, cs_observer fn)
-{
-  if (!cs || !fn)
-    return;
-
-  for (size_t i = 0; i < mutt_array_size(cs->observers); i++)
-  {
-    if (cs->observers[i] == fn)
-    {
-      mutt_debug(LL_DEBUG1, "Observer was already registered\n");
-      return;
-    }
-  }
-
-  for (size_t i = 0; i < mutt_array_size(cs->observers); i++)
-  {
-    if (!cs->observers[i])
-    {
-      cs->observers[i] = fn;
-      return;
-    }
-  }
-}
-
-/**
- * cs_remove_observer - Remove a observer (callback function)
- * @param cs Config items
- * @param fn Observer callback function
- */
-void cs_remove_observer(struct ConfigSet *cs, cs_observer fn)
-{
-  if (!cs || !fn)
-    return;
-
-  for (size_t i = 0; i < mutt_array_size(cs->observers); i++)
-  {
-    if (cs->observers[i] == fn)
-    {
-      cs->observers[i] = NULL;
-      return;
-    }
-  }
-  mutt_debug(LL_DEBUG1, "Observer wasn't registered\n");
-}
-
-/**
  * cs_notify_observers - Notify all observers of an event
  * @param cs   Config items
  * @param he   HashElem representing config item
@@ -365,18 +316,13 @@ void cs_remove_observer(struct ConfigSet *cs, cs_observer fn)
  * @param ev   Type of event
  */
 void cs_notify_observers(const struct ConfigSet *cs, struct HashElem *he,
-                         const char *name, enum ConfigEvent ev)
+                         const char *name, enum NotifyConfig ev)
 {
   if (!cs || !he || !name)
     return;
 
-  for (size_t i = 0; i < mutt_array_size(cs->observers); i++)
-  {
-    if (!cs->observers[i])
-      return;
-
-    cs->observers[i](cs, he, name, ev);
-  }
+  struct EventConfig ec = { cs, he, name };
+  notify_send(cs->notify, NT_CONFIG, ev, IP & ec);
 }
 
 /**
@@ -422,7 +368,7 @@ int cs_he_reset(const struct ConfigSet *cs, struct HashElem *he, struct Buffer *
   }
 
   if ((CSR_RESULT(rc) == CSR_SUCCESS) && !(rc & CSR_SUC_NO_CHANGE))
-    cs_notify_observers(cs, he, he->key.strkey, CE_RESET);
+    cs_notify_observers(cs, he, he->key.strkey, NT_CONFIG_RESET);
   return rc;
 }
 
@@ -485,7 +431,7 @@ int cs_he_initial_set(const struct ConfigSet *cs, struct HashElem *he,
   if (CSR_RESULT(rc) != CSR_SUCCESS)
     return rc;
 
-  cs_notify_observers(cs, he, he->key.strkey, CE_INITIAL_SET);
+  cs_notify_observers(cs, he, he->key.strkey, NT_CONFIG_INITIAL_SET);
   return CSR_SUCCESS;
 }
 
@@ -630,7 +576,7 @@ int cs_he_string_set(const struct ConfigSet *cs, struct HashElem *he,
     he->type = i->parent->type | DT_INHERITED;
   }
   if (!(rc & CSR_SUC_NO_CHANGE))
-    cs_notify_observers(cs, he, he->key.strkey, CE_SET);
+    cs_notify_observers(cs, he, he->key.strkey, NT_CONFIG_SET);
   return rc;
 }
 
@@ -772,7 +718,7 @@ int cs_he_native_set(const struct ConfigSet *cs, struct HashElem *he,
     if (he->type & DT_INHERITED)
       he->type = cdef->type | DT_INHERITED;
     if (!(rc & CSR_SUC_NO_CHANGE))
-      cs_notify_observers(cs, he, cdef->name, CE_SET);
+      cs_notify_observers(cs, he, cdef->name, NT_CONFIG_SET);
   }
 
   return rc;
@@ -826,7 +772,7 @@ int cs_str_native_set(const struct ConfigSet *cs, const char *name,
     if (he->type & DT_INHERITED)
       he->type = cdef->type | DT_INHERITED;
     if (!(rc & CSR_SUC_NO_CHANGE))
-      cs_notify_observers(cs, he, cdef->name, CE_SET);
+      cs_notify_observers(cs, he, cdef->name, NT_CONFIG_SET);
   }
 
   return rc;

--- a/index.c
+++ b/index.c
@@ -3658,16 +3658,20 @@ void mutt_set_header_color(struct Mailbox *m, struct Email *e)
 }
 
 /**
- * mutt_reply_observer - Listen for config changes to "reply_regex" - Implements ::cs_observer()
+ * mutt_reply_observer - Listen for config changes to "reply_regex" - Implements ::observer_t()
  */
-bool mutt_reply_observer(const struct ConfigSet *cs, struct HashElem *he,
-                         const char *name, enum ConfigEvent ev)
+int mutt_reply_observer(struct NotifyCallback *nc)
 {
-  if (mutt_str_strcmp(name, "reply_regex") != 0)
-    return true;
+  if (!nc)
+    return -1;
+
+  struct EventConfig *ec = (struct EventConfig *) nc->event;
+
+  if (mutt_str_strcmp(ec->name, "reply_regex") != 0)
+    return 0;
 
   if (!Context)
-    return true;
+    return 0;
 
   regmatch_t pmatch[1];
 
@@ -3688,5 +3692,5 @@ bool mutt_reply_observer(const struct ConfigSet *cs, struct HashElem *he,
   }
 
   OptResortInit = true; /* trigger a redraw of the index */
-  return true;
+  return 0;
 }

--- a/main.c
+++ b/main.c
@@ -604,6 +604,7 @@ int main(int argc, char *argv[], char *envp[])
   Config = init_config(500);
   if (!Config)
     goto main_curses;
+  notify_set_parent(Config->notify, NeoMutt->notify);
 
   if (!get_user_info(Config))
     goto main_exit;
@@ -825,10 +826,10 @@ int main(int argc, char *argv[], char *envp[])
     goto main_ok; // TEST22: neomutt -B
   }
 
-  cs_add_observer(Config, mutt_hist_observer);
-  cs_add_observer(Config, mutt_log_observer);
-  cs_add_observer(Config, mutt_menu_observer);
-  cs_add_observer(Config, mutt_reply_observer);
+  notify_observer_add(Config->notify, NT_CONFIG, 0, mutt_hist_observer, 0);
+  notify_observer_add(Config->notify, NT_CONFIG, 0, mutt_log_observer, 0);
+  notify_observer_add(Config->notify, NT_CONFIG, 0, mutt_menu_observer, 0);
+  notify_observer_add(Config->notify, NT_CONFIG, 0, mutt_reply_observer, 0);
 
   if (sendflags & SEND_POSTPONED)
   {

--- a/main.c
+++ b/main.c
@@ -69,6 +69,7 @@
 #include "muttlib.h"
 #include "mx.h"
 #include "ncrypt/ncrypt.h"
+#include "neomutt.h"
 #include "options.h"
 #include "protos.h"
 #include "send.h"
@@ -597,6 +598,8 @@ int main(int argc, char *argv[], char *envp[])
     OptNoCurses = true;
     goto main_ok; // TEST04: neomutt -v
   }
+
+  NeoMutt = neomutt_new();
 
   Config = init_config(500);
   if (!Config)
@@ -1262,5 +1265,6 @@ main_exit:
   mutt_free_opts();
   mutt_free_keys();
   cs_free(&Config);
+  neomutt_free(&NeoMutt);
   return rc;
 }

--- a/menu.c
+++ b/menu.c
@@ -1595,16 +1595,20 @@ int mutt_menu_loop(struct Menu *menu)
 }
 
 /**
- * mutt_menu_observer - Listen for config changes affecting the menu - Implements ::cs_observer()
+ * mutt_menu_observer - Listen for config changes affecting the menu - Implements ::observer_t()
  */
-bool mutt_menu_observer(const struct ConfigSet *cs, struct HashElem *he,
-                        const char *name, enum ConfigEvent ev)
+int mutt_menu_observer(struct NotifyCallback *nc)
 {
-  const struct ConfigDef *cdef = he->data;
+  if (!nc)
+    return -1;
+
+  struct EventConfig *ec = (struct EventConfig *) nc->event;
+
+  const struct ConfigDef *cdef = ec->he->data;
   ConfigRedrawFlags flags = cdef->flags;
 
   if (flags == 0)
-    return true;
+    return 0;
 
   if (flags & R_INDEX)
     mutt_menu_set_redraw_full(MENU_MAIN);
@@ -1634,5 +1638,5 @@ bool mutt_menu_observer(const struct ConfigSet *cs, struct HashElem *he,
   if (flags & R_MENU)
     mutt_menu_set_current_redraw_full();
 
-  return true;
+  return 0;
 }

--- a/mutt/logging.c
+++ b/mutt/logging.c
@@ -42,7 +42,7 @@
 #include "queue.h"
 #include "string2.h"
 
-const char *LevelAbbr = "PEWM12345"; /**< Abbreviations of logging level names */
+const char *LevelAbbr = "PEWM12345N"; /**< Abbreviations of logging level names */
 
 /**
  * MuttLogger - The log dispatcher
@@ -486,6 +486,7 @@ int log_disp_terminal(time_t stamp, const char *file, int line,
       case LL_DEBUG3:
       case LL_DEBUG4:
       case LL_DEBUG5:
+      case LL_NOTIFY:
         break;
     }
   }

--- a/mutt/logging.h
+++ b/mutt/logging.h
@@ -58,6 +58,7 @@ enum LogLevel
   LL_DEBUG3  =  3, ///< Log at debug level 3
   LL_DEBUG4  =  4, ///< Log at debug level 4
   LL_DEBUG5  =  5, ///< Log at debug level 5
+  LL_NOTIFY  =  6, ///< Log of notifications
 
   LL_MAX,
 };

--- a/mutt/mutt.h
+++ b/mutt/mutt.h
@@ -42,6 +42,8 @@
  * | mutt/mbyte.c     | @subpage mbyte     |
  * | mutt/md5.c       | @subpage md5       |
  * | mutt/memory.c    | @subpage memory    |
+ * | mutt/notify.c    | @subpage notify    |
+ * | mutt/observer.h  | @subpage observer  |
  * | mutt/path.c      | @subpage path      |
  * | mutt/pool.c      | @subpage pool      |
  * | mutt/regex.c     | @subpage regex     |
@@ -73,6 +75,9 @@
 #include "memory.h"
 #include "message.h"
 #include "queue.h"
+#include "notify.h"
+#include "notify_type.h"
+#include "observer.h"
 #include "path.h"
 #include "pool.h"
 #include "regex3.h"

--- a/mutt/notify.c
+++ b/mutt/notify.c
@@ -1,0 +1,203 @@
+/**
+ * @file
+ * Notification API
+ *
+ * @authors
+ * Copyright (C) 2019 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @page notify Notification API
+ *
+ * Notification API
+ */
+
+#include "config.h"
+#include <stdbool.h>
+#include <stdint.h>
+#include "notify.h"
+
+/**
+ * struct Notify - Notification API
+ */
+struct Notify
+{
+  void *obj;
+  enum NotifyType obj_type;
+  struct Notify *parent;
+  struct ObserverHead observers;
+};
+
+/**
+ * notify_new - Create a new notifications handler
+ * @param object Owner of the object
+ * @param type   Object type, e.g. #NT_ACCOUNT
+ * @retval ptr New notification handler
+ */
+struct Notify *notify_new(void *object, enum NotifyType type)
+{
+  struct Notify *notify = mutt_mem_calloc(1, sizeof(*notify));
+
+  notify->obj = object;
+  notify->obj_type = type;
+  STAILQ_INIT(&notify->observers);
+
+  return notify;
+}
+
+/**
+ * notify_free - Free a notification handler
+ * @param ptr Notification handler to free
+ */
+void notify_free(struct Notify **ptr)
+{
+  if (!ptr || !*ptr)
+    return;
+
+  // struct Notify *notify = *ptr;
+  // NOTIFY observers
+  // FREE observers
+
+  FREE(ptr);
+}
+
+/**
+ * notify_set_parent - Set the parent notification handler
+ * @param notify Notification handler to alter
+ * @param parent Parent notification handler
+ *
+ * Notifications are passed up the tree of handlers.
+ */
+void notify_set_parent(struct Notify *notify, struct Notify *parent)
+{
+  if (!notify || !parent)
+    return;
+
+  notify->parent = parent;
+}
+
+/**
+ * send - Send out a notification message
+ * @param source  Source of the event, e.g. #Account
+ * @param current Current handler, e.g. #NeoMutt
+ * @param type    Type of event, e.g. #NT_ACCOUNT
+ * @param subtype Subtype, e.g. NT_ACCOUNT_NEW
+ * @param data    Private data associated with the event type
+ * @retval true If successfully sent
+ *
+ * Notifications are sent to all matching observers, then propagated up the
+ * handler tree.  For example a "new email" notification would be sent to the
+ * Mailbox that owned it, the Account (owning the Mailbox) and finally the
+ * NeoMutt object.
+ */
+static bool send(struct Notify *source, struct Notify *current, int type,
+                 int subtype, intptr_t data)
+{
+  if (!source || !current)
+    return false;
+
+  // mutt_debug(LL_NOTIFY, "send: %d, %ld\n", type, data);
+  struct ObserverNode *np = NULL;
+  STAILQ_FOREACH(np, &current->observers, entries)
+  {
+    struct Observer *o = np->observer;
+
+    struct NotifyCallback nc = { source->obj, source->obj_type, type,   subtype,
+                                 data,        o->flags,         o->data };
+    o->callback(&nc);
+  }
+
+  if (current->parent)
+    return send(source, current->parent, type, subtype, data);
+  return true;
+}
+
+/**
+ * notify_send - Send out a notification message
+ * @param notify  Notification handler
+ * @param type    Type of event, e.g. #NT_ACCOUNT
+ * @param subtype Subtype, e.g. NT_ACCOUNT_NEW
+ * @param data    Private data associated with the event type
+ * @retval true If successfully sent
+ *
+ * See send() for more details.
+ */
+bool notify_send(struct Notify *notify, int type, int subtype, intptr_t data)
+{
+  return send(notify, notify, type, subtype, data);
+}
+
+/**
+ * notify_observer_add - Add an observer to an object
+ * @param notify   Notification handler
+ * @param type     Type of event to listen for, e.g. #NT_ACCOUNT
+ * @param subtype  Subtype, e.g. NT_ACCOUNT_NEW
+ * @param callback Function to call on a matching event, see ::observer_t
+ * @param data     Private data associated with the event type
+ * @retval true If successful
+ */
+bool notify_observer_add(struct Notify *notify, enum NotifyType type,
+                         int subtype, observer_t callback, intptr_t data)
+{
+  if (!notify || !callback)
+    return false;
+
+  struct ObserverNode *np = NULL;
+  STAILQ_FOREACH(np, &notify->observers, entries)
+  {
+    if (np->observer->callback == callback)
+      return true;
+  }
+
+  struct Observer *o = mutt_mem_calloc(1, sizeof(*o));
+  o->type = type;
+  o->flags = subtype;
+  o->callback = callback;
+  o->data = data;
+
+  np = mutt_mem_calloc(1, sizeof(*np));
+  np->observer = o;
+  STAILQ_INSERT_TAIL(&notify->observers, np, entries);
+
+  return true;
+}
+
+/**
+ * notify_observer_remove - Remove an observer from an object
+ * @param notify   Notification handler
+ * @param callback Function to call on a matching event, see ::observer_t
+ * @retval true If successful
+ */
+bool notify_observer_remove(struct Notify *notify, observer_t callback)
+{
+  if (!notify || !callback)
+    return false;
+
+  struct ObserverNode *np = NULL;
+  STAILQ_FOREACH(np, &notify->observers, entries)
+  {
+    if (np->observer->callback == callback)
+    {
+      STAILQ_REMOVE(&notify->observers, np, ObserverNode, entries);
+      FREE(&np->observer);
+      FREE(&np);
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/mutt/notify.c
+++ b/mutt/notify.c
@@ -68,9 +68,10 @@ void notify_free(struct Notify **ptr)
   if (!ptr || !*ptr)
     return;
 
-  // struct Notify *notify = *ptr;
+  struct Notify *notify = *ptr;
   // NOTIFY observers
-  // FREE observers
+
+  notify_observer_remove(notify, NULL);
 
   FREE(ptr);
 }
@@ -181,16 +182,18 @@ bool notify_observer_add(struct Notify *notify, enum NotifyType type,
  * @param notify   Notification handler
  * @param callback Function to call on a matching event, see ::observer_t
  * @retval true If successful
+ *
+ * If callback is NULL, all the observers will be removed.
  */
 bool notify_observer_remove(struct Notify *notify, observer_t callback)
 {
-  if (!notify || !callback)
+  if (!notify)
     return false;
 
   struct ObserverNode *np = NULL;
   STAILQ_FOREACH(np, &notify->observers, entries)
   {
-    if (np->observer->callback == callback)
+    if (!callback || (np->observer->callback == callback))
     {
       STAILQ_REMOVE(&notify->observers, np, ObserverNode, entries);
       FREE(&np->observer);

--- a/mutt/notify.h
+++ b/mutt/notify.h
@@ -1,6 +1,6 @@
 /**
  * @file
- * NeoMutt container for notifications
+ * Notification API
  *
  * @authors
  * Copyright (C) 2019 Richard Russon <rich@flatcap.org>
@@ -20,43 +20,22 @@
  * this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/**
- * @page neomutt NeoMutt container for notifications
- *
- * NeoMutt container for notifications
- */
+#ifndef MUTT_LIB_NOTIFY_H
+#define MUTT_LIB_NOTIFY_H
 
-#include "config.h"
-#include "mutt/mutt.h"
-#include "neomutt.h"
+#include <stdbool.h>
+#include "observer.h"
+#include "notify_type.h"
 
-struct NeoMutt *NeoMutt; ///< Global NeoMutt object
+struct Notify;
 
-/**
- * neomutt_new - Create the master NeoMutt object
- * @retval ptr New NeoMutt
- */
-struct NeoMutt *neomutt_new(void)
-{
-  struct NeoMutt *n = mutt_mem_calloc(1, sizeof(*NeoMutt));
+struct Notify *notify_new(void *object, enum NotifyType type);
+void notify_free(struct Notify **ptr);
+void notify_set_parent(struct Notify *notify, struct Notify *parent);
 
-  n->notify = notify_new(n, NT_NEOMUTT);
+bool notify_send(struct Notify *notify, int type, int subtype, intptr_t data);
 
-  return n;
-}
+bool notify_observer_add(struct Notify *notify, enum NotifyType type, int subtype, observer_t callback, intptr_t data);
+bool notify_observer_remove(struct Notify *notify, observer_t callback);
 
-/**
- * neomutt_free - Free a NeoMutt
- * @param[out] ptr NeoMutt to free
- */
-void neomutt_free(struct NeoMutt **ptr)
-{
-  if (!ptr || !*ptr)
-    return;
-
-  struct NeoMutt *n = *ptr;
-
-  notify_free(&n->notify);
-
-  FREE(ptr);
-}
+#endif /* MUTT_LIB_NOTIFY_H */

--- a/mutt/notify_type.h
+++ b/mutt/notify_type.h
@@ -1,6 +1,6 @@
 /**
  * @file
- * NeoMutt container for notifications
+ * Notification Types
  *
  * @authors
  * Copyright (C) 2019 Richard Russon <rich@flatcap.org>
@@ -20,43 +20,23 @@
  * this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/**
- * @page neomutt NeoMutt container for notifications
- *
- * NeoMutt container for notifications
- */
-
-#include "config.h"
-#include "mutt/mutt.h"
-#include "neomutt.h"
-
-struct NeoMutt *NeoMutt; ///< Global NeoMutt object
+#ifndef MUTT_LIB_NOTIFY_TYPE_H
+#define MUTT_LIB_NOTIFY_TYPE_H
 
 /**
- * neomutt_new - Create the master NeoMutt object
- * @retval ptr New NeoMutt
+ * enum NotifyType - Notification Types
  */
-struct NeoMutt *neomutt_new(void)
+enum NotifyType
 {
-  struct NeoMutt *n = mutt_mem_calloc(1, sizeof(*NeoMutt));
+  NT_NEOMUTT, ///< Container for all notifications
+  NT_GLOBAL,  ///< Not object-related
+  NT_CONFIG,  ///< Config has changed
+  NT_ACCOUNT, ///< Account has changed
+  NT_MAILBOX, ///< Mailbox has changed
+  NT_EMAIL,   ///< Email has changed
+  NT_WINDOW,  ///< Window has changed
 
-  n->notify = notify_new(n, NT_NEOMUTT);
+  NT_MAX,
+};
 
-  return n;
-}
-
-/**
- * neomutt_free - Free a NeoMutt
- * @param[out] ptr NeoMutt to free
- */
-void neomutt_free(struct NeoMutt **ptr)
-{
-  if (!ptr || !*ptr)
-    return;
-
-  struct NeoMutt *n = *ptr;
-
-  notify_free(&n->notify);
-
-  FREE(ptr);
-}
+#endif /* MUTT_LIB_NOTIFY_TYPE_H */

--- a/mutt/observer.h
+++ b/mutt/observer.h
@@ -1,0 +1,86 @@
+/**
+ * @file
+ * Observer of notifications
+ *
+ * @authors
+ * Copyright (C) 2019 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @page observer Observer of notifications
+ *
+ * Observer of notifications
+ */
+
+#ifndef MUTT_LIB_OBSERVER_H
+#define MUTT_LIB_OBSERVER_H
+
+#include <stdbool.h>
+#include <stdint.h>
+#include "mutt/mutt.h"
+#include "notify_type.h"
+
+struct Notify;
+
+/**
+ * struct NotifyCallback - Data passed to a notification function
+ */
+struct NotifyCallback
+{
+  void *obj;         ///< Notify: Event happened here
+  int obj_type;      ///< Notify: type of object event happened on
+  int event_type;    ///< Send: event type
+  int event_subtype; ///< Send: event subtype
+  intptr_t event;    ///< Send: event data
+  int flags;         ///< Observer: determine event data
+  intptr_t data;     ///< Observer: private to observer
+};
+
+/**
+ * typedef observer_t - Prototype for a notification callback function
+ * @param[in]  flags    Flags, see #MuttFormatFlags
+ * @retval  0 Success
+ * @retval -1 Error
+ */
+typedef int (*observer_t)(struct NotifyCallback *nc);
+
+typedef uint8_t ObserverFlags;     ///< Flags, e.g. #OBSERVE_RECURSIVE
+#define OBSERVE_NO_FLAGS        0  ///< No flags are set
+#define OBSERVE_RECURSIVE (1 << 0) ///< Listen for events of children
+
+/**
+ * struct Observer - An observer of notifications
+ */
+struct Observer
+{
+  enum NotifyType type;  ///< Object to observe to, e.g. #NT_NEOMUTT
+  ObserverFlags flags;   ///< Flags, e.g. #OBSERVE_RECURSIVE
+  observer_t callback;   ///< Callback function for events
+  intptr_t data;         ///< Private data to pass to callback
+};
+
+/**
+ * struct ObserverNode - List of Observers
+ */
+struct ObserverNode
+{
+  struct Observer *observer;
+  STAILQ_ENTRY(ObserverNode) entries;
+};
+STAILQ_HEAD(ObserverHead, ObserverNode);
+
+#endif /* MUTT_LIB_OBSERVER_H */

--- a/mutt_history.c
+++ b/mutt_history.c
@@ -144,14 +144,18 @@ void mutt_hist_complete(char *buf, size_t buflen, enum HistoryClass hclass)
 }
 
 /**
- * mutt_hist_observer - Listen for config changes affecting the history - Implements ::cs_observer()
+ * mutt_hist_observer - Listen for config changes affecting the history - Implements ::observer_t()
  */
-bool mutt_hist_observer(const struct ConfigSet *cs, struct HashElem *he,
-                        const char *name, enum ConfigEvent ev)
+int mutt_hist_observer(struct NotifyCallback *nc)
 {
-  if (mutt_str_strcmp(name, "history") != 0)
-    return true;
+  if (!nc)
+    return -1;
+
+  struct EventConfig *ec = (struct EventConfig *) nc->event;
+
+  if (mutt_str_strcmp(ec->name, "history") != 0)
+    return 0;
 
   mutt_hist_init();
-  return true;
+  return 0;
 }

--- a/mutt_history.h
+++ b/mutt_history.h
@@ -27,6 +27,6 @@
 #include "mutt/mutt.h"
 
 void mutt_hist_complete(char *buf, size_t buflen, enum HistoryClass hclass);
-bool mutt_hist_observer(const struct ConfigSet *cs, struct HashElem *he, const char *name, enum ConfigEvent ev);
+int mutt_hist_observer(struct NotifyCallback *nc);
 
 #endif /* MUTT_MUTT_HISTORY_H */

--- a/mutt_logging.c
+++ b/mutt_logging.c
@@ -335,15 +335,19 @@ int level_validator(const struct ConfigSet *cs, const struct ConfigDef *cdef,
 }
 
 /**
- * mutt_log_observer - Listen for config changes affecting the log file - Implements ::cs_observer()
+ * mutt_log_observer - Listen for config changes affecting the log file - Implements ::observer_t()
  */
-bool mutt_log_observer(const struct ConfigSet *cs, struct HashElem *he,
-                       const char *name, enum ConfigEvent ev)
+int mutt_log_observer(struct NotifyCallback *nc)
 {
-  if (mutt_str_strcmp(name, "debug_file") == 0)
+  if (!nc)
+    return -1;
+
+  struct EventConfig *ec = (struct EventConfig *) nc->event;
+
+  if (mutt_str_strcmp(ec->name, "debug_file") == 0)
     mutt_log_set_file(C_DebugFile, true);
-  else if (mutt_str_strcmp(name, "debug_level") == 0)
+  else if (mutt_str_strcmp(ec->name, "debug_level") == 0)
     mutt_log_set_level(C_DebugLevel, true);
 
-  return true;
+  return 0;
 }

--- a/mutt_logging.h
+++ b/mutt_logging.h
@@ -37,7 +37,7 @@ int  mutt_log_start(void);
 void mutt_log_stop(void);
 int  mutt_log_set_level(int level, bool verbose);
 int  mutt_log_set_file(const char *file, bool verbose);
-bool mutt_log_observer(const struct ConfigSet *cs, struct HashElem *he, const char *name, enum ConfigEvent ev);
+int  mutt_log_observer(struct NotifyCallback *nc);
 int  level_validator(const struct ConfigSet *cs, const struct ConfigDef *cdef, intptr_t value, struct Buffer *err);
 
 void mutt_clear_error(void);

--- a/mutt_menu.h
+++ b/mutt_menu.h
@@ -189,6 +189,6 @@ void         mutt_menu_set_current_redraw(MuttRedrawFlags redraw);
 void         mutt_menu_set_redraw_full(int menu_type);
 void         mutt_menu_set_redraw(int menu_type, MuttRedrawFlags redraw);
 
-bool mutt_menu_observer(const struct ConfigSet *cs, struct HashElem *he, const char *name, enum ConfigEvent ev);
+int mutt_menu_observer(struct NotifyCallback *nc);
 
 #endif /* MUTT_MENU_H */

--- a/neomutt.c
+++ b/neomutt.c
@@ -1,0 +1,58 @@
+/**
+ * @file
+ * NeoMutt container for notifications
+ *
+ * @authors
+ * Copyright (C) 2019 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @page neomutt NeoMutt container for notifications
+ *
+ * NeoMutt container for notifications
+ */
+
+#include "config.h"
+#include "mutt/mutt.h"
+#include "neomutt.h"
+
+struct NeoMutt *NeoMutt; ///< Global NeoMutt object
+
+/**
+ * neomutt_new - Create the master NeoMutt object
+ * @retval ptr New NeoMutt
+ */
+struct NeoMutt *neomutt_new(void)
+{
+  struct NeoMutt *n = mutt_mem_calloc(1, sizeof(*NeoMutt));
+
+  return n;
+}
+
+/**
+ * neomutt_free - Free a NeoMutt
+ * @param[out] ptr NeoMutt to free
+ */
+void neomutt_free(struct NeoMutt **ptr)
+{
+  if (!ptr || !*ptr)
+    return;
+
+  // struct NeoMutt *n = *ptr;
+
+  FREE(ptr);
+}

--- a/neomutt.h
+++ b/neomutt.h
@@ -1,0 +1,41 @@
+/**
+ * @file
+ * NeoMutt container for notifications
+ *
+ * @authors
+ * Copyright (C) 2019 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MUTT_NEOMUTT_H
+#define MUTT_NEOMUTT_H
+
+struct Notify;
+
+/**
+ * struct NeoMutt - Container for notifications
+ */
+struct NeoMutt
+{
+  struct Notify *notify;
+};
+
+extern struct NeoMutt *NeoMutt;
+
+struct NeoMutt *neomutt_new(void);
+void neomutt_free(struct NeoMutt **ptr);
+
+#endif /* MUTT_NEOMUTT_H */

--- a/protos.h
+++ b/protos.h
@@ -86,7 +86,6 @@ int mutt_is_quote_line(char *buf, regmatch_t *pmatch);
 int wcscasecmp(const wchar_t *a, const wchar_t *b);
 #endif
 
-bool mutt_reply_observer(const struct ConfigSet *cs, struct HashElem *he,
-                         const char *name, enum ConfigEvent ev);
+int mutt_reply_observer(struct NotifyCallback *nc);
 
 #endif /* MUTT_PROTOS_H */

--- a/test/config/account.c
+++ b/test/config/account.c
@@ -60,7 +60,7 @@ void config_account(void)
 
   set_list(cs);
 
-  cs_add_observer(cs, log_observer);
+  notify_observer_add(cs->notify, NT_CONFIG, 0, log_observer, 0);
 
   const char *account = "damaged";
   const char *BrokenVarStr[] = {

--- a/test/config/address.c
+++ b/test/config/address.c
@@ -611,7 +611,7 @@ void config_address(void)
     return;
   dont_fail = false;
 
-  cs_add_observer(cs, log_observer);
+  notify_observer_add(cs->notify, NT_CONFIG, 0, log_observer, 0);
 
   set_list(cs);
 

--- a/test/config/bool.c
+++ b/test/config/bool.c
@@ -765,7 +765,7 @@ void config_bool(void)
     return;
   dont_fail = false;
 
-  cs_add_observer(cs, log_observer);
+  notify_observer_add(cs->notify, NT_CONFIG, 0, log_observer, 0);
 
   set_list(cs);
 

--- a/test/config/command.c
+++ b/test/config/command.c
@@ -638,7 +638,7 @@ void config_command(void)
     return;
   dont_fail = false;
 
-  cs_add_observer(cs, log_observer);
+  notify_observer_add(cs->notify, NT_CONFIG, 0, log_observer, 0);
 
   set_list(cs);
 

--- a/test/config/common.c
+++ b/test/config/common.c
@@ -81,9 +81,13 @@ void short_line(void)
   TEST_MSG("%s\n", line + 40);
 }
 
-bool log_observer(const struct ConfigSet *cs, struct HashElem *he,
-                  const char *name, enum ConfigEvent ev)
+int log_observer(struct NotifyCallback *nc)
 {
+  if (!nc)
+    return -1;
+
+  struct EventConfig *ec = (struct EventConfig *) nc->event;
+
   struct Buffer result;
   mutt_buffer_init(&result);
   result.dsize = 256;
@@ -93,12 +97,12 @@ bool log_observer(const struct ConfigSet *cs, struct HashElem *he,
 
   mutt_buffer_reset(&result);
 
-  if (ev != CE_INITIAL_SET)
-    cs_he_string_get(cs, he, &result);
+  if (nc->event_type != NT_CONFIG_INITIAL_SET)
+    cs_he_string_get(ec->cs, ec->he, &result);
   else
-    cs_he_initial_get(cs, he, &result);
+    cs_he_initial_get(ec->cs, ec->he, &result);
 
-  TEST_MSG("Event: %s has been %s to '%s'\n", name, events[ev - 1], result.data);
+  TEST_MSG("Event: %s has been %s to '%s'\n", ec->name, events[nc->event_type - 1], result.data);
 
   FREE(&result.data);
   return true;

--- a/test/config/common.h
+++ b/test/config/common.h
@@ -30,6 +30,7 @@
 struct Buffer;
 struct Hash;
 struct HashElem;
+struct NotifyCallback;
 
 extern const char *line;
 extern bool dont_fail;
@@ -40,7 +41,7 @@ int validator_fail   (const struct ConfigSet *cs, const struct ConfigDef *cdef, 
 
 void log_line(const char *fn);
 void short_line(void);
-bool log_observer(const struct ConfigSet *cs, struct HashElem *he, const char *name, enum ConfigEvent ev);
+int log_observer(struct NotifyCallback *nc);
 void set_list(const struct ConfigSet *cs);
 void cs_dump_set(const struct ConfigSet *cs);
 

--- a/test/config/initial.c
+++ b/test/config/initial.c
@@ -103,7 +103,7 @@ void config_initial(void)
   if (!cs_register_variables(cs, Vars, 0))
     return;
 
-  cs_add_observer(cs, log_observer);
+  notify_observer_add(cs->notify, NT_CONFIG, 0, log_observer, 0);
 
   set_list(cs);
 

--- a/test/config/long.c
+++ b/test/config/long.c
@@ -589,7 +589,7 @@ void config_long(void)
     return;
   dont_fail = false;
 
-  cs_add_observer(cs, log_observer);
+  notify_observer_add(cs->notify, NT_CONFIG, 0, log_observer, 0);
 
   set_list(cs);
 

--- a/test/config/magic.c
+++ b/test/config/magic.c
@@ -576,7 +576,7 @@ void config_magic(void)
     return;
   dont_fail = false;
 
-  cs_add_observer(cs, log_observer);
+  notify_observer_add(cs->notify, NT_CONFIG, 0, log_observer, 0);
 
   set_list(cs);
 

--- a/test/config/mbtable.c
+++ b/test/config/mbtable.c
@@ -627,7 +627,7 @@ void config_mbtable(void)
     return;
   dont_fail = false;
 
-  cs_add_observer(cs, log_observer);
+  notify_observer_add(cs->notify, NT_CONFIG, 0, log_observer, 0);
 
   set_list(cs);
 

--- a/test/config/number.c
+++ b/test/config/number.c
@@ -608,7 +608,7 @@ void config_number(void)
     return;
   dont_fail = false;
 
-  cs_add_observer(cs, log_observer);
+  notify_observer_add(cs->notify, NT_CONFIG, 0, log_observer, 0);
 
   set_list(cs);
 

--- a/test/config/path.c
+++ b/test/config/path.c
@@ -638,7 +638,7 @@ void config_path(void)
     return;
   dont_fail = false;
 
-  cs_add_observer(cs, log_observer);
+  notify_observer_add(cs->notify, NT_CONFIG, 0, log_observer, 0);
 
   set_list(cs);
 

--- a/test/config/quad.c
+++ b/test/config/quad.c
@@ -703,7 +703,7 @@ void config_quad(void)
     return;
   dont_fail = false;
 
-  cs_add_observer(cs, log_observer);
+  notify_observer_add(cs->notify, NT_CONFIG, 0, log_observer, 0);
 
   set_list(cs);
 

--- a/test/config/regex.c
+++ b/test/config/regex.c
@@ -687,7 +687,7 @@ void config_regex(void)
     return;
   dont_fail = false;
 
-  cs_add_observer(cs, log_observer);
+  notify_observer_add(cs->notify, NT_CONFIG, 0, log_observer, 0);
 
   set_list(cs);
 

--- a/test/config/set.c
+++ b/test/config/set.c
@@ -88,20 +88,12 @@ bool degenerate_tests(struct ConfigSet *cs)
   TEST_CHECK_(1, "cs_init(NULL, 100)");
   cs_free(NULL);
   TEST_CHECK_(1, "cs_free(NULL)");
-  cs_add_observer(cs, NULL);
-  TEST_CHECK_(1, "cs_add_observer(cs, NULL)");
-  cs_add_observer(NULL, log_observer);
-  TEST_CHECK_(1, "cs_add_observer(NULL, log_observer)");
-  cs_remove_observer(cs, NULL);
-  TEST_CHECK_(1, "cs_remove_observer(cs, NULL)");
-  cs_remove_observer(NULL, log_observer);
-  TEST_CHECK_(1, "cs_remove_observer(NULL, log_observer)");
-  cs_notify_observers(NULL, he, "apple", CE_SET);
-  TEST_CHECK_(1, "cs_notify_observers(NULL, he, \"apple\", CE_SET)");
-  cs_notify_observers(cs, NULL, "apple", CE_SET);
-  TEST_CHECK_(1, "cs_notify_observers(cs, NULL, \"apple\", CE_SET)");
-  cs_notify_observers(cs, he, NULL, CE_SET);
-  TEST_CHECK_(1, "cs_notify_observers(cs, he, NULL, CE_SET)");
+  cs_notify_observers(NULL, he, "apple", NT_CONFIG_SET);
+  TEST_CHECK_(1, "cs_notify_observers(NULL, he, \"apple\", NT_CONFIG_SET)");
+  cs_notify_observers(cs, NULL, "apple", NT_CONFIG_SET);
+  TEST_CHECK_(1, "cs_notify_observers(cs, NULL, \"apple\", NT_CONFIG_SET)");
+  cs_notify_observers(cs, he, NULL, NT_CONFIG_SET);
+  TEST_CHECK_(1, "cs_notify_observers(cs, he, NULL, NT_CONFIG_SET)");
 
   if (!TEST_CHECK(cs_register_type(NULL, DT_NUMBER, &cst_dummy) == false))
     return false;
@@ -228,11 +220,6 @@ void config_set(void)
   struct ConfigSet *cs = cs_new(30);
   if (!TEST_CHECK(cs != NULL))
     return;
-
-  cs_add_observer(cs, log_observer);
-  cs_add_observer(cs, log_observer); /* dupe */
-  cs_remove_observer(cs, log_observer);
-  cs_remove_observer(cs, log_observer); /* non-existant */
 
   const struct ConfigSetType cst_dummy = {
     "dummy", NULL, NULL, NULL, NULL, NULL, NULL,

--- a/test/config/sort.c
+++ b/test/config/sort.c
@@ -733,7 +733,7 @@ void config_sort(void)
     return;
   dont_fail = false;
 
-  cs_add_observer(cs, log_observer);
+  notify_observer_add(cs->notify, NT_CONFIG, 0, log_observer, 0);
 
   set_list(cs);
 

--- a/test/config/string.c
+++ b/test/config/string.c
@@ -638,7 +638,7 @@ void config_string(void)
     return;
   dont_fail = false;
 
-  cs_add_observer(cs, log_observer);
+  notify_observer_add(cs->notify, NT_CONFIG, 0, log_observer, 0);
 
   set_list(cs);
 

--- a/test/config/synonym.c
+++ b/test/config/synonym.c
@@ -203,7 +203,7 @@ void config_synonym(void)
     return;
   }
 
-  cs_add_observer(cs, log_observer);
+  notify_observer_add(cs->notify, NT_CONFIG, 0, log_observer, 0);
 
   set_list(cs);
 


### PR DESCRIPTION
This PR adds some of the notification framework that I've been promising.
For now, it just creates the top of the tree: NeoMutt and Config.

- 3166e646d debug: add notify level
  Debug level 6!

- e0ea74ba9 add central NeoMutt object
  This is the root of the notifications and will be the parent of Accounts

- de9a52581 add notify/observer
  The Observer API and the notifications

- 677f1740c config notify
  Convert the Config system to use the new notifications

- fa134e6f3 test: fix config tests
  Convert the Config tests to use the new notifications

- adec8f4db DEBUG: notify dump
  A dummy Observer for logging purposes (this won't get merged)

To test this:
- `neomutt -d6`
- open a threaded folder
- `set invascii_chars`

This will toggle a Config item, causing a notification event.
The event will be send to two observers:
- `mutt_menu_observer()` which will cause a repaint of the index
- `notify_dump()` which will log the event
