### PR TITLE
Improve mailcap handling

### DIFF
--- a/handler.c
+++ b/handler.c
@@ -540,7 +540,7 @@ static int autoview_handler(struct Body *a, struct State *s)
   int rc = 0;
 
   snprintf(type, sizeof(type), "%s/%s", TYPE(a), a->subtype);
-  rfc1524_mailcap_lookup(a, type, entry, MUTT_MC_AUTOVIEW);
+  rfc1524_mailcap_lookup(a, type, entry, s->flags & MUTT_REPLYING ? MUTT_MC_COMPOSE : MUTT_MC_AUTOVIEW);
 
   fname = mutt_str_strdup(a->filename);
   mutt_file_sanitize_filename(fname, true);
@@ -549,7 +549,10 @@ static int autoview_handler(struct Body *a, struct State *s)
 
   if (entry->command)
   {
-    mutt_buffer_strcpy(cmd, entry->command);
+    if ((s->flags & MUTT_REPLYING) && entry->composecommand)
+      mutt_buffer_strcpy(cmd, entry->composecommand);
+    else
+      mutt_buffer_strcpy(cmd, entry->command);
 
     /* rfc1524_expand_command returns 0 if the file is required */
     bool piped = mutt_buffer_rfc1524_expand_command(a, mutt_b2s(tempfile), type, cmd);

--- a/mutt_attach.c
+++ b/mutt_attach.c
@@ -345,8 +345,9 @@ void mutt_check_lookup_list(struct Body *b, char *type, size_t len)
         (mutt_str_strcasecmp(type, np->data) == 0))
     {
       struct Body tmp = { 0 };
-      enum ContentType n = mutt_lookup_mime_type(&tmp, b->filename);
-      if (n != TYPE_OTHER)
+      enum ContentType n;
+      if ((n = mutt_lookup_mime_type(&tmp, b->filename)) != TYPE_OTHER ||
+          (n = mutt_lookup_mime_type(&tmp, b->description)) != TYPE_OTHER)
       {
         snprintf(type, len, "%s/%s",
                  (n == TYPE_AUDIO) ?


### PR DESCRIPTION
This PR is primarily to get feedback about whether this is a reasonable approach. And not yet whether it can be committed as is.

The goal of the first patch is to increase the chances of finding a mailcap match. In my experience often "description" will have actual content, even though "filename" doesn't. Therefore it makes sense to match for description if filename doesn't find a match.

The second one is to allow to format attachments correctly. I use a syntax highlighter for patch attachments, but without this path that breaks when composing emails, as the attachment will be formatted with that syntax highlighter as well. Mailcap has 'compose' entries for that, but mutt didn't use them.