### PR TITLE
Update to latest autosetup, use @include feature

### DIFF
--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -16,7 +16,7 @@ PWD=		@PWD@
 AR=		@AR@
 CC=		@CC@
 CPP=		@CPP@
-CFLAGS=		@CPPFLAGS@ @CFLAGS@ -I. -I@top_srcdir@ -Wall $(EXTRA_CFLAGS)
+CFLAGS=		@CPPFLAGS@ @CFLAGS@ -I. -I@srcdir@ -Wall $(EXTRA_CFLAGS)
 LDFLAGS=	@LDFLAGS@ $(EXTRA_LDFLAGS)
 EXEEXT=		@EXEEXT@
 LIBS=		@LIBS@
@@ -54,7 +54,7 @@ CLEAN_TARGETS=		@CLEAN_TARGETS@
 INSTALL_TARGETS=	@INSTALL_TARGETS@
 UNINSTALL_TARGETS=	@UNINSTALL_TARGETS@
 
-VPATH=		$(SRCDIR)
+VPATH=		@VPATH@
 
 ALL_FILES!=	(cd $(SRCDIR) && git ls-files 2>/dev/null) || true
 
@@ -468,11 +468,11 @@ coverage: all test
 ##############################################################################
 # include special-purpose makefiles, each one of which MUST define the
 # dedicated all-, clean-, install-, and uninstall- targets.
-include po/Makefile
-include contrib/Makefile
-include doc/Makefile
+@include @srcdir@/po/Makefile.autosetup
+@include @srcdir@/contrib/Makefile.autosetup
+@include @srcdir@/doc/Makefile.autosetup
 @if ENABLE_UNIT_TESTS
-include test/Makefile
+@include @srcdir@/test/Makefile.autosetup
 @endif
 
 # vim: set ts=8 noexpandtab:

--- a/auto.def
+++ b/auto.def
@@ -964,6 +964,7 @@ set auto_rep {
   SUN_ATTACHMENT
   SYSCONFDIR
   USE_*
+  VPATH
   WORDS_BIGENDIAN
 }
 set bare_rep {
@@ -984,14 +985,17 @@ if {[get-define CCACHE] ne {none}} {
 }
 
 ###############################################################################
-# Generate targets and Makefiles for subdirectories
+# Generate targets and Makefile variables for subdirectories
+set vpath "\$(SRCDIR)"
 foreach dir $subdirs {
+  append vpath ":\$(SRCDIR)/$dir"
   define-append ALL_TARGETS all-$dir
   define-append CLEAN_TARGETS clean-$dir
   define-append INSTALL_TARGETS install-$dir
   define-append UNINSTALL_TARGETS uninstall-$dir
-  make-template $dir/Makefile.autosetup $dir/Makefile
+  define-append VPATH
 }
+define VPATH $vpath
 
 ###############################################################################
 # Define package timestamp (UTC) based on PACKAGE_VERSION for:

--- a/autosetup/cc.tcl
+++ b/autosetup/cc.tcl
@@ -466,7 +466,6 @@ proc cc-with {settings args} {
 # Any failures are recorded in 'config.log'
 #
 proc cctest {args} {
-	set src conftest__.c
 	set tmp conftest__
 
 	# Easiest way to merge in the settings
@@ -508,9 +507,11 @@ proc cctest {args} {
 	lappend cmdline {*}[get-define CCACHE]
 	switch -exact -- $opts(-lang) {
 		c++ {
+			set src conftest__.cpp
 			lappend cmdline {*}[get-define CXX] {*}[get-define CXXFLAGS]
 		}
 		c {
+			set src conftest__.c
 			lappend cmdline {*}[get-define CC] {*}[get-define CFLAGS]
 		}
 		default {

--- a/autosetup/system.tcl
+++ b/autosetup/system.tcl
@@ -133,6 +133,102 @@ proc write-if-changed {file buf {script {}}} {
 	}
 }
 
+
+# @include-file infile mapping
+#
+# The core of make-template, called recursively for each @include
+# directive found within that template so that this proc's result
+# is the fully-expanded template.
+#
+# The mapping parameter is how we expand @varname@ within the template.
+# We do that inline within this step only for @include directives which
+# can have variables in the filename arg.  A separate substitution pass
+# happens when this recursive function returns, expanding the rest of
+# the variables.
+#
+proc include-file {infile mapping} {
+	# A stack of true/false conditions, one for each nested conditional
+	# starting with "true"
+	set condstack {1}
+	set result {}
+	set linenum 0
+	foreach line [split [readfile $infile] \n] {
+		incr linenum
+		if {[regexp {^@(if|else|endif)(\s*)(.*)} $line -> condtype condspace condargs]} {
+			if {$condtype eq "if"} {
+				if {[string length $condspace] == 0} {
+					autosetup-error "$infile:$linenum: Invalid expression: $line"
+				}
+				if {[llength $condargs] == 1} {
+					# ABC => [get-define ABC] ni {0 ""}
+					# !ABC => [get-define ABC] in {0 ""}
+					lassign $condargs condvar
+					if {[regexp {^!(.*)} $condvar -> condvar]} {
+						set op in
+					} else {
+						set op ni
+					}
+					set condexpr "\[[list get-define $condvar]\] $op {0 {}}"
+				} else {
+					# Translate alphanumeric ABC into [get-define ABC] and leave the
+					# rest of the expression untouched
+					regsub -all {([A-Z][[:alnum:]_]*)} $condargs {[get-define \1]} condexpr
+				}
+				if {[catch [list expr $condexpr] condval]} {
+					dputs $condval
+					autosetup-error "$infile:$linenum: Invalid expression: $line"
+				}
+				dputs "@$condtype: $condexpr => $condval"
+			}
+			if {$condtype ne "if"} {
+				if {[llength $condstack] <= 1} {
+					autosetup-error "$infile:$linenum: Error: @$condtype missing @if"
+				} elseif {[string length $condargs] && [string index $condargs 0] ne "#"} {
+					autosetup-error "$infile:$linenum: Error: Extra arguments after @$condtype"
+				}
+			}
+			switch -exact $condtype {
+				if {
+					# push condval
+					lappend condstack $condval
+				}
+				else {
+					# Toggle the last entry
+					set condval [lpop condstack]
+					set condval [expr {!$condval}]
+					lappend condstack $condval
+				}
+				endif {
+					if {[llength $condstack] == 0} {
+						user-notice "$infile:$linenum: Error: @endif missing @if"
+					}
+					lpop condstack
+				}
+			}
+			continue
+		} elseif {[regexp {^@include\s+(.*)} $line -> filearg]} {
+			set incfile [string map $mapping $filearg]
+			if {[file exists $incfile]} {
+				lappend ::autosetup(deps) [file-normalize $incfile]
+				lappend result {*}[include-file $incfile $mapping]
+			} else {
+				user-error "$infile:$linenum: Include file $incfile is missing"
+			}
+			continue
+		} elseif {[regexp {^@define\s+(\w+)\s+(.*)} $line -> var val]} {
+			define $var $val
+			continue
+		}
+		# Only output this line if the stack contains all "true"
+		if {"0" in $condstack} {
+			continue
+		}
+		lappend result $line
+	}
+	return $result
+}
+
+
 # @make-template template ?outfile?
 #
 # Reads the input file '<srcdir>/$template' and writes the output file '$outfile'
@@ -195,70 +291,23 @@ proc make-template {template {out {}}} {
 	define srcdir [relative-path [file join $::autosetup(srcdir) $outdir] $outdir]
 	define top_srcdir [relative-path $::autosetup(srcdir) $outdir]
 
-	set mapping {}
-	foreach {n v} [array get ::define] {
-		lappend mapping @$n@ $v
+	# Build map from global defines to their values so they can be
+	# substituted into @include file names.
+	proc build-define-mapping {} {
+		set mapping {}
+		foreach {n v} [array get ::define] {
+			lappend mapping @$n@ $v
+		}
+		return $mapping
 	}
+	set mapping [build-define-mapping]
 
-	# A stack of true/false conditions, one for each nested conditional
-	# starting with "true"
-	set condstack {1}
-	set result {}
-	set linenum 0
-	foreach line [split [readfile $infile] \n] {
-		incr linenum
-		if {[regexp {^@(if|else|endif)\s*(.*)} $line -> condtype condargs]} {
-			if {$condtype eq "if"} {
-				if {[llength $condargs] == 1} {
-					# ABC => [get-define ABC] ni {0 ""}
-					# !ABC => [get-define ABC] in {0 ""}
-					lassign $condargs condvar
-					if {[regexp {^!(.*)} $condvar -> condvar]} {
-						set op in
-					} else {
-						set op ni
-					}
-					set condexpr "\[[list get-define $condvar]\] $op {0 {}}"
-				} else {
-					# Translate alphanumeric ABC into [get-define ABC] and leave the
-					# rest of the expression untouched
-					regsub -all {([A-Z][[:alnum:]_]*)} $condargs {[get-define \1]} condexpr
-				}
-				if {[catch [list expr $condexpr] condval]} {
-					dputs $condval
-					autosetup-error "$infile:$linenum: Invalid expression: $line"
-				}
-				dputs "@$condtype: $condexpr => $condval"
-			}
-			if {$condtype ne "if" && [llength $condstack] <= 1} {
-				autosetup-error "$infile:$linenum: Error: @$condtype missing @if"
-			}
-			switch -exact $condtype {
-				if {
-					# push condval
-					lappend condstack $condval
-				}
-				else {
-					# Toggle the last entry
-					set condval [lpop condstack]
-					set condval [expr {!$condval}]
-					lappend condstack $condval
-				}
-				endif {
-					if {[llength $condstack] == 0} {
-						user-notice "$infile:$linenum: Error: @endif missing @if"
-					}
-					lpop condstack
-				}
-			}
-			continue
-		}
-		# Only output this line if the stack contains all "true"
-		if {"0" in $condstack} {
-			continue
-		}
-		lappend result $line
-	}
+	set result [include-file $infile $mapping]
+
+	# Rebuild the define mapping in case we ran across @define
+	# directives in the template or a file it @included, then
+	# apply that mapping to the expanded template.
+	set mapping [build-define-mapping]
 	write-if-changed $out [string map $mapping [join $result \n]] {
 		msg-result "Created [relative-path $out] from [relative-path $template]"
 	}

--- a/doc/Makefile.autosetup
+++ b/doc/Makefile.autosetup
@@ -10,6 +10,10 @@ doc/neomuttrc: $(SRCDIR)/init.h doc/makedoc$(EXEEXT) $(SRCDIR)/doc/neomuttrc.hea
 	$(MAKEDOC_CPP) $(SRCDIR)/init.h | doc/makedoc$(EXEEXT) -c \
 	    >> doc/neomuttrc
 
+.PHONY: doc
+doc:
+	$(MKDIR_P) doc
+
 @if BUILD_DOC
 
 CHUNKED_DOCFILES = doc/advancedusage.html \
@@ -33,7 +37,8 @@ srcdir_DOCFILES = $(SRCDIR)/doc/smime-notes.txt \
 		  $(SRCDIR)/LICENSE.md \
 		  $(SRCDIR)/README.md
 
-all-doc:	$(CHUNKED_DOCFILES) \
+all-doc:	doc \
+		$(CHUNKED_DOCFILES) \
 		doc/index.html \
 		doc/manual.html \
 		doc/manual.txt \
@@ -159,7 +164,7 @@ sortcheck-doc: doc/manual.xml
 @else
 # Let's generate neomuttrc in all cases: it doesn't require any additional 3rd
 # party dependencies and distributions tend to rely on having it.
-all-doc: doc/neomuttrc
+all-doc: doc doc/neomuttrc
 
 clean-doc:
 	$(RM) doc/neomuttrc doc/makedoc$(EXEEXT)

--- a/po/Makefile.autosetup
+++ b/po/Makefile.autosetup
@@ -15,7 +15,11 @@ MOFILES		= po/bg.mo po/ca.mo po/cs.mo po/da.mo po/de.mo po/el.mo \
 		  po/sk.mo po/sv.mo po/tr.mo po/uk.mo po/zh_CN.mo po/zh_TW.mo
 POTFILE		= po/$(PACKAGE).pot
 
-all-po:	$(MOFILES)
+all-po:	po $(MOFILES)
+
+.PHONY: po
+po:
+	$(MKDIR_P) po
 
 .SUFFIXES: .po .mo
 .po.mo:


### PR DESCRIPTION
By using autosetup's new @include feature, we are left with a single Makefile at build time. This should make it easier to spot dependency errors and faster to process.