### PR TITLE
Save attachments without prompting.

### DIFF
--- a/init.h
+++ b/init.h
@@ -330,6 +330,13 @@ struct ConfigDef MuttVars[] = {
   ** .pp
   ** The directory where attachments are saved.
   */
+  { "attach_save_without_prompting",  DT_BOOL, R_NONE, &C_AttachSaveWithoutPrompting, false },
+  /*
+  ** .pp
+  ** This variable, when set to true, will cause attachments to be saved to the
+  ** 'attach_save_dir' location without prompting the user for the filename.
+  ** .pp
+  */
   { "attach_sep",       DT_STRING,  R_NONE, &C_AttachSep, IP "\n" },
   /*
   ** .pp

--- a/recvattach.h
+++ b/recvattach.h
@@ -33,6 +33,7 @@ struct Email;
 
 /* These Config Variables are only used in recvattach.c */
 extern char *C_AttachSaveDir;
+extern char *C_AttachSaveWithoutPrompting;
 extern char *C_AttachSep;
 extern bool  C_AttachSplit;
 extern bool  C_DigestCollapse;


### PR DESCRIPTION
If the 'save_without_prompt' variable is set (to true), then when saving
attachments the user will not be prompted each time for the name of the file.

Handling conflicting filenames is also handled.

closes #1603 

-=david=-