### PR TITLE
Add 'account' command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ git:
 
 install:
   - git clone --depth 1 https://github.com/neomutt/travis-build.git ~/config
+  - git clone --depth 1 https://github.com/neomutt/neomutt-test-files.git ~/test-files
 
 before_script:
   - ccache --zero-stats
@@ -47,6 +48,8 @@ before_script:
   - export -f travis_nanoseconds
   - export -f travis_time_finish
   - export -f travis_time_start
+  - export NEOMUTT_TEST_DIR="$HOME/test-files"
+  - (cd ~/test-files && ./setup.sh)
 
 script:
   - ~/config/build

--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -71,7 +71,7 @@ NEOMUTTOBJS=	addrbook.o alias.o bcache.o browser.o commands.o \
 		muttlib.o mx.o mx_path.o myvar.o pager.o pattern.o postpone.o progress.o query.o \
 		recvattach.o recvcmd.o resize.o rfc3676.o score.o send.o sendlib.o \
 		sidebar.o smtp.o sort.o state.o status.o system.o version.o \
-		mutt_commands.o mutt_config.o command_parse.o
+		mutt_commands.o mutt_config.o command_parse.o tracker.o
 
 @if !HAVE_WCSCASECMP
 NEOMUTTOBJS+=	wcscasecmp.o

--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -68,7 +68,7 @@ NEOMUTTOBJS=	addrbook.o alias.o bcache.o browser.o commands.o \
 		keymap.o mailcap.o main.o menu.o mutt_account.o mutt_attach.o \
 		mutt_body.o mutt_header.o mutt_history.o mutt_logging.o mutt_mailbox.o \
 		mutt_parse.o mutt_signal.o mutt_socket.o mutt_thread.o \
-		muttlib.o mx.o myvar.o pager.o pattern.o postpone.o progress.o query.o \
+		muttlib.o mx.o mx_path.o myvar.o pager.o pattern.o postpone.o progress.o query.o \
 		recvattach.o recvcmd.o resize.o rfc3676.o score.o send.o sendlib.o \
 		sidebar.o smtp.o sort.o state.o status.o system.o version.o \
 		mutt_commands.o mutt_config.o command_parse.o

--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -65,7 +65,7 @@ NEOMUTTOBJS=	addrbook.o alias.o bcache.o browser.o commands.o \
 		complete.o compose.o conststrings.o context.o copy.o \
 		edit.o editmsg.o enriched.o enter.o flags.o functions.o \
 		git_ver.o handler.o hdrline.o help.o hook.o icommands.o index.o init.o \
-		keymap.o mailcap.o main.o menu.o mutt_account.o mutt_attach.o \
+		keymap.o local.o mailcap.o main.o menu.o mutt_account.o mutt_attach.o \
 		mutt_body.o mutt_header.o mutt_history.o mutt_logging.o mutt_mailbox.o \
 		mutt_parse.o mutt_signal.o mutt_socket.o mutt_thread.o \
 		muttlib.o mx.o mx_path.o myvar.o pager.o pattern.o postpone.o progress.o query.o \

--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -124,7 +124,7 @@ ALLOBJS+=	$(LIBNNTPOBJS)
 ###############################################################################
 # libcompress
 LIBCOMPRESS=	libcompress.a
-LIBCOMPRESSOBJS=compress/compress.o
+LIBCOMPRESSOBJS=compress/compress.o compress/path.o
 CLEANFILES+=	$(LIBCOMPRESS) $(LIBCOMPRESSOBJS)
 MUTTLIBS+=	$(LIBCOMPRESS)
 ALLOBJS+=	$(LIBCOMPRESSOBJS)
@@ -560,7 +560,9 @@ coverage: all test
 	  --directory address \
 	  --directory config \
 	  --directory email \
-	  --directory mutt
+	  --directory mutt \
+	  --directory compress \
+
 	-genhtml --output-directory lcov --frames lcov.info
 	lcov --list lcov.info
 @endif

--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -108,7 +108,7 @@ ALLOBJS+=	$(LIBAUTOCRYPTOBJS)
 ###############################################################################
 # libpop
 LIBPOP=	libpop.a
-LIBPOPOBJS=	pop/pop.o pop/pop_auth.o pop/pop_lib.o
+LIBPOPOBJS=	pop/pop.o pop/pop_auth.o pop/pop_lib.o pop/path.o
 CLEANFILES+=	$(LIBPOP) $(LIBPOPOBJS)
 MUTTLIBS+=	$(LIBPOP)
 ALLOBJS+=	$(LIBPOPOBJS)
@@ -568,6 +568,7 @@ coverage: all test
 	  --directory mbox \
 	  --directory nntp \
 	  --directory notmuch \
+	  --directory pop
 
 	-genhtml --output-directory lcov --frames lcov.info
 	lcov --list lcov.info

--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -164,7 +164,7 @@ ALLOBJS+=	$(LIBDEBUGOBJS)
 ###############################################################################
 # libmbox
 LIBMBOX=	libmbox.a
-LIBMBOXOBJS=	mbox/mbox.o
+LIBMBOXOBJS=	mbox/mbox.o mbox/path.o
 CLEANFILES+=	$(LIBMBOX) $(LIBMBOXOBJS)
 MUTTLIBS+=	$(LIBMBOX)
 ALLOBJS+=	$(LIBMBOXOBJS)
@@ -565,6 +565,7 @@ coverage: all test
 	  --directory compress \
 	  --directory imap \
 	  --directory maildir \
+	  --directory mbox \
 
 	-genhtml --output-directory lcov --frames lcov.info
 	lcov --list lcov.info

--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -116,7 +116,7 @@ ALLOBJS+=	$(LIBPOPOBJS)
 ###############################################################################
 # libnntp
 LIBNNTP=	libnntp.a
-LIBNNTPOBJS=	nntp/browse.o nntp/complete.o nntp/newsrc.o nntp/nntp.o
+LIBNNTPOBJS=	nntp/browse.o nntp/complete.o nntp/newsrc.o nntp/nntp.o nntp/path.o
 CLEANFILES+=	$(LIBNNTP) $(LIBNNTPOBJS)
 MUTTLIBS+=	$(LIBNNTP)
 ALLOBJS+=	$(LIBNNTPOBJS)
@@ -566,6 +566,7 @@ coverage: all test
 	  --directory imap \
 	  --directory maildir \
 	  --directory mbox \
+	  --directory nntp \
 
 	-genhtml --output-directory lcov --frames lcov.info
 	lcov --list lcov.info

--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -173,7 +173,7 @@ ALLOBJS+=	$(LIBMBOXOBJS)
 # libnotmuch
 @if USE_NOTMUCH
 LIBNOTMUCH=	libnotmuch.a
-LIBNOTMUCHOBJS=	notmuch/mutt_notmuch.o notmuch/nm_db.o
+LIBNOTMUCHOBJS=	notmuch/mutt_notmuch.o notmuch/nm_db.o notmuch/path.o
 CLEANFILES+=	$(LIBNOTMUCH) $(LIBNOTMUCHOBJS)
 MUTTLIBS+=	$(LIBNOTMUCH)
 ALLOBJS+=	$(LIBNOTMUCHOBJS)
@@ -567,6 +567,7 @@ coverage: all test
 	  --directory maildir \
 	  --directory mbox \
 	  --directory nntp \
+	  --directory notmuch \
 
 	-genhtml --output-directory lcov --frames lcov.info
 	lcov --list lcov.info

--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -139,6 +139,10 @@ ALLOBJS+=	$(LIBGUIOBJS)
 
 ###############################################################################
 # libdebug
+LIBDEBUG=	libdebug.a
+@if USE_DEBUG_ACCOUNT
+LIBDEBUGOBJS+=	debug/account.o debug/subset.o
+@endif
 @if HAVE_LIBUNWIND
 LIBDEBUGOBJS+=	debug/backtrace.o
 @endif
@@ -154,7 +158,7 @@ LIBDEBUGOBJS+=	debug/parse_test.o
 @if USE_DEBUG_WINDOW
 LIBDEBUGOBJS+=	debug/window.o
 @endif
-@if HAVE_LIBUNWIND || USE_DEBUG_GRAPHVIZ || USE_DEBUG_NOTIFY || USE_DEBUG_PARSE_TEST || USE_DEBUG_WINDOW
+@if HAVE_LIBUNWIND || USE_DEBUG_ACCOUNT || USE_DEBUG_GRAPHVIZ || USE_DEBUG_NOTIFY || USE_DEBUG_PARSE_TEST || USE_DEBUG_WINDOW
 LIBDEBUG=	libdebug.a
 CLEANFILES+=	$(LIBDEBUG) $(LIBDEBUGOBJS)
 MUTTLIBS+=	$(LIBDEBUG)

--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -182,7 +182,7 @@ ALLOBJS+=	$(LIBNOTMUCHOBJS)
 ###############################################################################
 # libmaildir
 LIBMAILDIR=	libmaildir.a
-LIBMAILDIROBJS=	maildir/maildir.o maildir/mh.o maildir/shared.o
+LIBMAILDIROBJS=	maildir/maildir.o maildir/mh.o maildir/path.o maildir/shared.o
 CLEANFILES+=	$(LIBMAILDIR) $(LIBMAILDIROBJS)
 MUTTLIBS+=	$(LIBMAILDIR)
 ALLOBJS+=	$(LIBMAILDIROBJS)
@@ -564,6 +564,7 @@ coverage: all test
 	  --directory mutt \
 	  --directory compress \
 	  --directory imap \
+	  --directory maildir \
 
 	-genhtml --output-directory lcov --frames lcov.info
 	lcov --list lcov.info

--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -212,7 +212,8 @@ ALLOBJS+=	$(LIBNCRYPTOBJS)
 LIBIMAP=	libimap.a
 LIBIMAPOBJS=	imap/auth.o \
 		imap/auth_login.o imap/auth_oauth.o imap/auth_plain.o imap/browse.o \
-		imap/command.o imap/imap.o imap/message.o imap/utf7.o imap/util.o
+		imap/command.o imap/imap.o imap/message.o imap/utf7.o imap/util.o \
+		imap/path.o
 @if USE_GSS
 LIBIMAPOBJS+=	imap/auth_gss.o
 @endif
@@ -562,6 +563,7 @@ coverage: all test
 	  --directory email \
 	  --directory mutt \
 	  --directory compress \
+	  --directory imap \
 
 	-genhtml --output-directory lcov --frames lcov.info
 	lcov --list lcov.info

--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -293,7 +293,7 @@ ALLOBJS+=	$(PGPEWRAPOBJS)
 ###############################################################################
 # libcore
 LIBCORE=	libcore.a
-LIBCOREOBJS=	core/account.o core/mailbox.o core/neomutt.o
+LIBCOREOBJS=	core/account.o core/mailbox.o core/neomutt.o core/path.o
 
 CLEANFILES+=	$(LIBCORE) $(LIBCOREOBJS)
 MUTTLIBS+=	$(LIBCORE)

--- a/auto.def
+++ b/auto.def
@@ -111,6 +111,7 @@ options {
 # Enable all options
   everything=0              => "Enable all options"
 # Debug options
+  debug-account=0           => "DEBUG: Enable account dump"
   debug-backtrace=0         => "DEBUG: Enable backtrace support with libunwind"
   with-backtrace:path       => "Location of libunwind"
   debug-graphviz=0          => "DEBUG: Enable Graphviz dump"
@@ -127,11 +128,11 @@ options {
 if {1} {
   # Keep sorted, please.
   foreach opt {
-    autocrypt bdb coverage debug-backtrace debug-graphviz debug-notify
-    debug-parse-test debug-window doc everything fmemopen full-doc gdbm gnutls
-    gpgme gss homespool idn idn2 inotify kyotocabinet lmdb locales-fix lua lz4
-    mixmaster nls notmuch pgp pkgconf qdbm sasl smime sqlite ssl testing
-    tokyocabinet zlib zstd
+    autocrypt bdb coverage debug-account debug-backtrace debug-graphviz
+    debug-notify debug-parse-test debug-window doc everything fmemopen full-doc
+    gdbm gnutls gpgme gss homespool idn idn2 inotify kyotocabinet lmdb
+    locales-fix lua lz4 mixmaster nls notmuch pgp pkgconf qdbm sasl smime
+    sqlite ssl testing tokyocabinet zlib zstd
   } {
     define want-$opt [opt-bool $opt]
   }
@@ -1124,6 +1125,11 @@ if {[get-define want-gss]} {
 
 ###############################################################################
 # DEBUG options
+
+# Account dump
+if {[get-define want-debug-account]} {
+  define USE_DEBUG_ACCOUNT 1
+}
 
 # Backtrace support with libunwind
 if {[get-define want-debug-backtrace]} {

--- a/autocrypt/autocrypt.c
+++ b/autocrypt/autocrypt.c
@@ -917,7 +917,7 @@ void mutt_autocrypt_scan_mailboxes(void)
         (!mutt_buffer_is_empty(folderbuf)))
     {
       mutt_buffer_expand_path_regex(folderbuf, false);
-      struct Mailbox *m = mx_path_resolve(mutt_b2s(folderbuf));
+      struct Mailbox *m = mx_path_resolve(mutt_b2s(folderbuf), C_Folder);
       /* NOTE: I am purposely *not* executing folder hooks here,
        * as they can do all sorts of things like push into the getch() buffer.
        * Authentication should be in account-hooks. */

--- a/browser.c
+++ b/browser.c
@@ -882,6 +882,7 @@ static int examine_mailboxes(struct Menu *menu, struct BrowserState *state)
       }
 
       mutt_buffer_strcpy(mailbox, mailbox_path(np->mailbox));
+      //JKJ this could be a file/dir or a mailbox!
       if (C_BrowserAbbreviateMailboxes)
         mutt_buffer_pretty_mailbox(mailbox);
 
@@ -1045,6 +1046,7 @@ static void init_menu(struct BrowserState *state, struct Menu *menu,
     {
       struct Buffer *path = mutt_buffer_pool_get();
       menu->is_mailbox_list = false;
+      //HBH path -> pretty (desc=no)
       mutt_buffer_copy(path, &LastDir);
       mutt_buffer_pretty_mailbox(path);
 #ifdef USE_IMAP
@@ -1067,12 +1069,15 @@ static void init_menu(struct BrowserState *state, struct Menu *menu,
    * The goal is to highlight the good directory if LastDir is the parent dir
    * of LastDirBackup (this occurs mostly when one hit "../"). It should also work
    * properly when the user is in examine_mailboxes-mode.  */
+  //HBH compare path->orig
   if (mutt_str_startswith(mutt_b2s(&LastDirBackup), mutt_b2s(&LastDir), CASE_MATCH))
   {
     char target_dir[PATH_MAX] = { 0 };
 
 #ifdef USE_IMAP
     /* Check what kind of dir LastDirBackup is. */
+    //HBH already have type
+    //HBH ask backend for parent of LastDirBackup, then swap into place
     if (imap_path_probe(mutt_b2s(&LastDirBackup), NULL) == MUTT_IMAP)
     {
       mutt_str_strfcpy(target_dir, mutt_b2s(&LastDirBackup), sizeof(target_dir));
@@ -1111,6 +1116,7 @@ static void init_menu(struct BrowserState *state, struct Menu *menu,
 static int file_tag(struct Menu *menu, int sel, int act)
 {
   struct FolderFile *ff = &(((struct FolderFile *) menu->data)[sel]);
+  //HBH need to check MxOps::is_local?
   if (S_ISDIR(ff->mode) || (S_ISLNK(ff->mode) && link_is_dir(mutt_b2s(&LastDir), ff->name)))
   {
     mutt_error(_("Can't attach a directory"));
@@ -1137,10 +1143,12 @@ void mutt_browser_select_dir(const char *f)
 {
   init_lastdir();
 
+  //HBH set by string CurrentFolder, C_Spoolfile, <change-folder>, etc
   mutt_buffer_strcpy(&LastDirBackup, f);
 
   /* Method that will fetch the parent path depending on the type of the path. */
   char buf[PATH_MAX];
+  //HBH backend get parent
   mutt_get_parent_path(mutt_b2s(&LastDirBackup), buf, sizeof(buf));
   mutt_buffer_strcpy(&LastDir, buf);
 }
@@ -1200,6 +1208,7 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
 
   mailbox = mailbox && folder;
 
+  //HBH backup of
   struct Buffer *OldLastDir = mutt_buffer_pool_get();
   struct Buffer *tmp = mutt_buffer_pool_get();
   struct Buffer *buf = mutt_buffer_pool_get();
@@ -1243,6 +1252,7 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
       state.imap_browse = true;
       if (imap_browse(mutt_b2s(file), &state) == 0)
       {
+        //HBH copy imap-only string (Mailbox)
         mutt_buffer_strcpy(&LastDir, state.folder);
         browser_sort(&state);
       }
@@ -1255,10 +1265,12 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
         ;
       if (i > 0)
       {
+        //HBH strings, local file/dirs
         if ((mutt_b2s(file))[0] == '/')
           mutt_buffer_strcpy_n(&LastDir, mutt_b2s(file), i);
         else
         {
+          //HBH strings, local file/dirs
           mutt_path_getcwd(&LastDir);
           mutt_buffer_addch(&LastDir, '/');
           mutt_buffer_addstr_n(&LastDir, mutt_b2s(file), i);
@@ -1266,6 +1278,7 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
       }
       else
       {
+        //HBH strings, local file/dirs
         if ((mutt_b2s(file))[0] == '/')
           mutt_buffer_strcpy(&LastDir, "/");
         else
@@ -1284,6 +1297,7 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
   else
   {
     if (!folder)
+      //HBH strings, local file/dirs
       mutt_path_getcwd(&LastDir);
     else
     {
@@ -1321,6 +1335,7 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
         {
           /* If browsing in "local"-mode, than we chose to define LastDir to
            * MailDir */
+          //HBH already known
           switch (CurrentFolder->type)
           {
             case MUTT_IMAP:
@@ -1350,6 +1365,7 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
     }
 
 #ifdef USE_IMAP
+    //HBH type already known
     if (!mailbox && (imap_path_probe(mutt_b2s(&LastDir), NULL) == MUTT_IMAP))
     {
       init_state(&state, NULL);

--- a/browser.c
+++ b/browser.c
@@ -809,7 +809,7 @@ static int examine_directory(struct Menu *menu, struct BrowserState *state,
       }
 
       if (np && Context && Context->mailbox &&
-          (mutt_str_strcmp(np->mailbox->realpath, Context->mailbox->realpath) == 0))
+          (mutt_str_strcmp(np->mailbox->path->canon, Context->mailbox->path->canon) == 0))
       {
         np->mailbox->msg_count = Context->mailbox->msg_count;
         np->mailbox->msg_unread = Context->mailbox->msg_unread;
@@ -875,7 +875,7 @@ static int examine_mailboxes(struct Menu *menu, struct BrowserState *state)
         continue;
 
       if (Context && Context->mailbox &&
-          (mutt_str_strcmp(np->mailbox->realpath, Context->mailbox->realpath) == 0))
+          (mutt_str_strcmp(np->mailbox->path->canon, Context->mailbox->path->canon) == 0))
       {
         np->mailbox->msg_count = Context->mailbox->msg_count;
         np->mailbox->msg_unread = Context->mailbox->msg_unread;
@@ -889,12 +889,12 @@ static int examine_mailboxes(struct Menu *menu, struct BrowserState *state)
       {
         case MUTT_IMAP:
         case MUTT_POP:
-          add_folder(menu, state, mutt_b2s(mailbox), np->mailbox->name, NULL,
+          add_folder(menu, state, mutt_b2s(mailbox), np->mailbox->path->desc, NULL,
                      np->mailbox, NULL);
           continue;
         case MUTT_NOTMUCH:
         case MUTT_NNTP:
-          add_folder(menu, state, mailbox_path(np->mailbox), np->mailbox->name,
+          add_folder(menu, state, mailbox_path(np->mailbox), np->mailbox->path->desc,
                      NULL, np->mailbox, NULL);
           continue;
         default: /* Continue */
@@ -921,7 +921,7 @@ static int examine_mailboxes(struct Menu *menu, struct BrowserState *state)
           s.st_mtime = st2.st_mtime;
       }
 
-      add_folder(menu, state, mutt_b2s(mailbox), np->mailbox->name, &s, np->mailbox, NULL);
+      add_folder(menu, state, mutt_b2s(mailbox), np->mailbox->path->desc, &s, np->mailbox, NULL);
     }
     neomutt_mailboxlist_clear(&ml);
   }

--- a/browser.c
+++ b/browser.c
@@ -1321,7 +1321,7 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
         {
           /* If browsing in "local"-mode, than we chose to define LastDir to
            * MailDir */
-          switch (mx_path_probe(CurrentFolder))
+          switch (CurrentFolder->type)
           {
             case MUTT_IMAP:
             case MUTT_MAILDIR:
@@ -1334,13 +1334,13 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
                 mutt_browser_select_dir(C_Spoolfile);
               break;
             default:
-              mutt_browser_select_dir(CurrentFolder);
+              mutt_browser_select_dir(CurrentFolder->orig);
               break;
           }
         }
-        else if (mutt_str_strcmp(CurrentFolder, mutt_b2s(&LastDirBackup)) != 0)
+        else if (mutt_str_strcmp(CurrentFolder->orig, mutt_b2s(&LastDirBackup)) != 0)
         {
-          mutt_browser_select_dir(CurrentFolder);
+          mutt_browser_select_dir(CurrentFolder->orig);
         }
       }
 

--- a/command_parse.c
+++ b/command_parse.c
@@ -974,14 +974,14 @@ enum CommandResult parse_mailboxes(struct Buffer *buf, struct Buffer *s,
 {
   while (MoreArgs(s))
   {
-    struct Mailbox *m = mailbox_new();
+    struct Mailbox *m = mailbox_new(NULL);
 
     if (data & MUTT_NAMED)
     {
       mutt_extract_token(buf, s, MUTT_TOKEN_NO_FLAGS);
       if (buf->data && (*buf->data != '\0'))
       {
-        m->name = mutt_str_strdup(buf->data);
+        mutt_str_replace(&m->path->desc, buf->data);
       }
       else
       {
@@ -998,12 +998,12 @@ enum CommandResult parse_mailboxes(struct Buffer *buf, struct Buffer *s,
       continue;
     }
 
-    mutt_buffer_strcpy(&m->pathbuf, buf->data);
+    mutt_str_replace(&m->path->orig, buf->data);
     /* int rc = */ mx_path_canon2(m, C_Folder);
 
     if (m->magic <= MUTT_UNKNOWN)
     {
-      mutt_error("Unknown Mailbox: %s", m->realpath);
+      mutt_error("Unknown Mailbox: %s", m->path->canon);
       mailbox_free(&m);
       return MUTT_CMD_ERROR;
     }
@@ -1019,7 +1019,7 @@ enum CommandResult parse_mailboxes(struct Buffer *buf, struct Buffer *s,
 
     if (!new_account)
     {
-      struct Mailbox *m_old = mx_mbox_find(a, m->realpath);
+      struct Mailbox *m_old = mx_mbox_find(a, m->path->canon);
       if (m_old)
       {
         if (m_old->flags == MB_HIDDEN)
@@ -2063,7 +2063,7 @@ enum CommandResult parse_unmailboxes(struct Buffer *buf, struct Buffer *s,
       /* Compare against path or desc? Ensure 'buf' is valid */
       if (!clear_all && tmp_valid &&
           (mutt_str_strcasecmp(mutt_b2s(buf), mailbox_path(np->mailbox)) != 0) &&
-          (mutt_str_strcasecmp(mutt_b2s(buf), np->mailbox->name) != 0))
+          (mutt_str_strcasecmp(mutt_b2s(buf), np->mailbox->path->desc) != 0))
       {
         continue;
       }

--- a/command_parse.c
+++ b/command_parse.c
@@ -58,6 +58,7 @@
 #include "myvar.h"
 #include "options.h"
 #include "sidebar.h"
+#include "tracker.h"
 #include "version.h"
 #include "imap/lib.h"
 #ifdef ENABLE_NLS
@@ -482,6 +483,9 @@ int source_rc(const char *rcfile_path, struct Buffer *err)
     return -1;
   }
 
+  // printf("\033[1;32mfile: %s\033[0m\n", rcfile_path);
+  ct_push_top(); // Inherit the 'account' of the parent config file
+
   mutt_buffer_init(&token);
   while ((linebuf = mutt_file_read_line(linebuf, &buflen, fp, &line, MUTT_CONT)))
   {
@@ -557,6 +561,8 @@ int source_rc(const char *rcfile_path, struct Buffer *err)
     FREE(&np);
   }
 
+  // printf("\033[1;32mend of file: %s\033[0m\n", rcfile_path);
+  ct_pop(); // The 'account' command stops at the end of the file
   return rc;
 }
 
@@ -972,82 +978,101 @@ bail:
 enum CommandResult parse_mailboxes(struct Buffer *buf, struct Buffer *s,
                                    unsigned long data, struct Buffer *err)
 {
+  // These won't change during this command
+  struct Account *a = ct_get_account();
+  struct ConfigSubset *sub = a ? a->sub : NeoMutt->sub;
+  struct Buffer *folder = mutt_buffer_pool_get();
+  cs_subset_str_string_get(sub, "folder", folder);
+
+  int rc = MUTT_CMD_ERROR;
+  struct Path *p = NULL;
+  struct Mailbox *m = NULL;
+
   while (MoreArgs(s))
   {
-    struct Mailbox *m = mailbox_new(NULL);
+    p = mutt_path_new();
 
     if (data & MUTT_NAMED)
     {
       mutt_extract_token(buf, s, MUTT_TOKEN_NO_FLAGS);
-      if (buf->data && (*buf->data != '\0'))
-      {
-        mutt_str_replace(&m->path->desc, buf->data);
-      }
-      else
-      {
-        mailbox_free(&m);
-        continue;
-      }
+      p->desc = mutt_buffer_strdup(buf);
     }
 
     mutt_extract_token(buf, s, MUTT_TOKEN_NO_FLAGS);
     if (mutt_buffer_is_empty(buf))
     {
-      /* Skip empty tokens. */
-      mailbox_free(&m);
+      // Skip empty tokens
+      mutt_path_free(&p);
       continue;
     }
 
-    mutt_str_replace(&m->path->orig, buf->data);
-    /* int rc = */ mx_path_canon2(m, C_Folder);
+    p->orig = mutt_buffer_strdup(buf);
 
-    if (m->magic <= MUTT_UNKNOWN)
+    mx_path2_resolve(p, mutt_b2s(folder));
+    if (p->type <= MUTT_UNKNOWN)
     {
-      mutt_error("Unknown Mailbox: %s", m->path->canon);
-      mailbox_free(&m);
-      return MUTT_CMD_ERROR;
+      mutt_error("Unknown Mailbox: %s", p->orig);
+      goto done;
+    }
+
+    // printf("Path:\n\tDesc: %s\n\tOrig: %s\n", p->desc, p->orig);
+
+    struct Mailbox *m_old = mx_path2_find(p);
+    if (m_old)
+    {
+      if (m_old->flags == MB_HIDDEN)
+      {
+        m_old->flags = MB_NORMAL;
+        mutt_sb_notify_mailbox(m_old, true);
+      }
+      mutt_path_free(&p);
+      // printf("existing mailbox\n");
+      continue;
     }
 
     bool new_account = false;
-    struct Account *a = mx_ac_find(m);
+    m = mailbox_new(p);
+    p = NULL; // The Mailbox has taken ownership of the Path
+    m->mx_ops = mx_get_ops(m->magic);
+
+    if (a)
+    {
+      // Use Account from user-supplied 'account' command
+      if (mx_ac_add(a, m) == 0)
+      {
+        ct_set_mailbox(m);
+        m = NULL; // The Account has taken ownership of the Mailbox
+        continue;
+      }
+
+      // The Account doesn't accept the Mailbox
+      a = NULL;
+    }
+
+    // Find existing Account that accepts Path
+    a = mx_ac2_find(m->path);
     if (!a)
     {
+      // or create a new Account
       a = account_new(NULL, NeoMutt->sub);
       a->magic = m->magic;
       new_account = true;
     }
 
-    if (!new_account)
-    {
-      struct Mailbox *m_old = mx_mbox_find(a, m->path->canon);
-      if (m_old)
-      {
-        if (m_old->flags == MB_HIDDEN)
-        {
-          m_old->flags = MB_NORMAL;
-          mutt_sb_notify_mailbox(m_old, true);
-        }
-        mailbox_free(&m);
-        continue;
-      }
-    }
-
     if (mx_ac_add(a, m) < 0)
     {
-      //error
       mailbox_free(&m);
       if (new_account)
-      {
-        cs_subset_free(&a->sub);
-        FREE(&a->name);
-        notify_free(&a->notify);
-        FREE(&a);
-      }
+        account_free(&a);
+
       continue;
     }
+
+    ct_set_account(a);
     if (new_account)
     {
       neomutt_account_add(NeoMutt, a);
+      m->sub->cs = a->sub->cs; // Work around our lazy-allocation order
     }
 
 #ifdef USE_SIDEBAR
@@ -1056,8 +1081,17 @@ enum CommandResult parse_mailboxes(struct Buffer *buf, struct Buffer *s,
 #ifdef USE_INOTIFY
     mutt_monitor_add(m);
 #endif
+    ct_set_mailbox(m);
+    m = NULL; // The Account has taken ownership of the Mailbox
   }
-  return MUTT_CMD_SUCCESS;
+
+  rc = MUTT_CMD_SUCCESS;
+
+done:
+  mutt_path_free(&p);
+  mailbox_free(&m);
+  mutt_buffer_pool_release(&folder);
+  return rc;
 }
 
 /**
@@ -1164,6 +1198,7 @@ enum CommandResult parse_set(struct Buffer *buf, struct Buffer *s,
   static const char *set_commands[] = { "set", "toggle", "unset", "reset" };
 
   int rc = 0;
+  struct ConfigSubset *sub = NeoMutt->sub;
 
   while (MoreArgs(s))
   {
@@ -1215,7 +1250,8 @@ enum CommandResult parse_set(struct Buffer *buf, struct Buffer *s,
     bool my = mutt_str_startswith(buf->data, "my_", CASE_MATCH);
     if (!my)
     {
-      he = cs_subset_lookup(NeoMutt->sub, buf->data);
+      sub = ct_get_sub();
+      he = cs_subset_create_inheritance(sub, buf->data);
       if (!he)
       {
         if (reset && (mutt_str_strcmp(buf->data, "all") == 0))
@@ -1388,7 +1424,8 @@ enum CommandResult parse_set(struct Buffer *buf, struct Buffer *s,
             mutt_buffer_dealloc(&scratch);
           }
 
-          rc = cs_subset_he_string_set(NeoMutt->sub, he, buf->data, err);
+          // printf("\033[1;32mSET: %s = %s\033[0m\n", he->key.strkey, buf->data);
+          rc = cs_subset_he_string_set(sub, he, buf->data, err);
           if (CSR_RESULT(rc) != CSR_SUCCESS)
             return MUTT_CMD_ERROR;
         }
@@ -1399,7 +1436,7 @@ enum CommandResult parse_set(struct Buffer *buf, struct Buffer *s,
         if (bq)
         {
           // mutt_buffer_printf(err, "ACT23 set variable %s to 'yes'", buf->data);
-          rc = cs_subset_he_native_set(NeoMutt->sub, he, true, err);
+          rc = cs_subset_he_native_set(sub, he, true, err);
           if (CSR_RESULT(rc) != CSR_SUCCESS)
             return MUTT_CMD_ERROR;
           continue;
@@ -1459,7 +1496,7 @@ enum CommandResult parse_set(struct Buffer *buf, struct Buffer *s,
       else
       {
         // mutt_buffer_printf(err, "ACT26 UNSET bool/quad variable %s", buf->data);
-        rc = cs_subset_he_native_set(NeoMutt->sub, he, false, err);
+        rc = cs_subset_he_native_set(sub, he, false, err);
         if (CSR_RESULT(rc) != CSR_SUCCESS)
           return MUTT_CMD_ERROR;
       }
@@ -1467,7 +1504,7 @@ enum CommandResult parse_set(struct Buffer *buf, struct Buffer *s,
     }
     else
     {
-      rc = cs_subset_he_string_set(NeoMutt->sub, he, NULL, err);
+      rc = cs_subset_he_string_set(sub, he, NULL, err);
       if (CSR_RESULT(rc) != CSR_SUCCESS)
         return MUTT_CMD_ERROR;
     }

--- a/command_parse.c
+++ b/command_parse.c
@@ -1362,9 +1362,19 @@ enum CommandResult parse_set(struct Buffer *buf, struct Buffer *s,
             mutt_buffer_addstr(err, buf->data);
             return MUTT_CMD_ERROR;
           }
+          char *pretty = NULL;
+          //JKJ Always a filesystem path (file/dir)
           if (DTYPE(he->type) == DT_PATH)
-            mutt_pretty_mailbox(buf->data, buf->dsize);
-          pretty_var(buf->data, err);
+            mutt_path2_pretty(buf->data, HomeDir, &pretty);
+          if (pretty)
+          {
+            pretty_var(pretty, err);
+            FREE(&pretty);
+          }
+          else
+          {
+            pretty_var(buf->data, err);
+          }
         }
         else
         {
@@ -1455,9 +1465,19 @@ enum CommandResult parse_set(struct Buffer *buf, struct Buffer *s,
               mutt_buffer_addstr(err, buf->data);
               return MUTT_CMD_ERROR;
             }
+            char *pretty = NULL;
+            //JKJ Always a filesystem path (file/dir)
             if (DTYPE(he->type) == DT_PATH)
-              mutt_pretty_mailbox(buf->data, buf->dsize);
-            pretty_var(buf->data, err);
+              mutt_path2_pretty(buf->data, HomeDir, &pretty);
+            if (pretty)
+            {
+              pretty_var(pretty, err);
+              FREE(&pretty);
+            }
+            else
+            {
+              pretty_var(buf->data, err);
+            }
           }
           else
           {

--- a/commands.c
+++ b/commands.c
@@ -1119,7 +1119,7 @@ int mutt_save_message(struct Mailbox *m, struct EmailList *el,
   }
 #endif
 
-  struct Mailbox *m_save = mx_path_resolve(mutt_b2s(buf));
+  struct Mailbox *m_save = mx_path_resolve(mutt_b2s(buf), C_Folder);
   bool old_append = m_save->append;
   struct Context *ctx_save = mx_mbox_open(m_save, MUTT_NEWFOLDER);
   if (!ctx_save)

--- a/commands.c
+++ b/commands.c
@@ -1135,7 +1135,7 @@ int mutt_save_message(struct Mailbox *m, struct EmailList *el,
   struct Mailbox *m_comp = NULL;
   if (ctx_save->mailbox->compress_info)
   {
-    m_comp = mailbox_find(ctx_save->mailbox->realpath);
+    m_comp = mailbox_find(ctx_save->mailbox->path->canon);
   }
   /* We probably haven't been opened yet */
   if (m_comp && (m_comp->msg_count == 0))

--- a/compose.c
+++ b/compose.c
@@ -1725,7 +1725,7 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur, 
 
         menu->redraw = REDRAW_FULL;
 
-        struct Mailbox *m = mx_path_resolve(mutt_b2s(&fname));
+        struct Mailbox *m = mx_path_resolve(mutt_b2s(&fname), C_Folder);
         bool old_readonly = m->readonly;
         struct Context *ctx = mx_mbox_open(m, MUTT_READONLY);
         if (!ctx)

--- a/compress/compress.c
+++ b/compress/compress.c
@@ -891,23 +891,6 @@ static int comp_path_canon(char *buf, size_t buflen)
 }
 
 /**
- * comp_path_pretty - Abbreviate a Mailbox path - Implements MxOps::path_pretty()
- */
-static int comp_path_pretty(char *buf, size_t buflen, const char *folder)
-{
-  if (!buf)
-    return -1;
-
-  if (mutt_path_abbr_folder(buf, buflen, folder))
-    return 0;
-
-  if (mutt_path_pretty(buf, buflen, HomeDir, false))
-    return 0;
-
-  return -1;
-}
-
-/**
  * comp_path_parent - Find the parent of a Mailbox path - Implements MxOps::path_parent()
  */
 static int comp_path_parent(char *buf, size_t buflen)
@@ -956,7 +939,6 @@ struct MxOps MxCompOps = {
   .tags_commit      = comp_tags_commit,
   .path_probe       = comp_path_probe,
   .path_canon       = comp_path_canon,
-  .path_pretty      = comp_path_pretty,
   .path_parent      = comp_path_parent,
   .path2_canon      = comp_path2_canon,
   .path2_compare    = comp_path2_compare,

--- a/compress/compress.c
+++ b/compress/compress.c
@@ -47,6 +47,7 @@
 #include "hook.h"
 #include "muttlib.h"
 #include "mx.h"
+#include "path.h"
 #include "protos.h"
 
 struct Email;
@@ -957,5 +958,11 @@ struct MxOps MxCompOps = {
   .path_canon       = comp_path_canon,
   .path_pretty      = comp_path_pretty,
   .path_parent      = comp_path_parent,
+  .path2_canon      = comp_path2_canon,
+  .path2_compare    = comp_path2_compare,
+  .path2_parent     = comp_path2_parent,
+  .path2_pretty     = comp_path2_pretty,
+  .path2_probe      = comp_path2_probe,
+  .path2_tidy       = comp_path2_tidy,
 };
 // clang-format on

--- a/compress/compress.c
+++ b/compress/compress.c
@@ -74,12 +74,12 @@ static bool lock_realpath(struct Mailbox *m, bool excl)
     return true;
 
   if (excl)
-    ci->fp_lock = fopen(m->realpath, "a");
+    ci->fp_lock = fopen(m->path->canon, "a");
   else
-    ci->fp_lock = fopen(m->realpath, "r");
+    ci->fp_lock = fopen(m->path->canon, "r");
   if (!ci->fp_lock)
   {
-    mutt_perror(m->realpath);
+    mutt_perror(m->path->canon);
     return false;
   }
 
@@ -134,12 +134,12 @@ static int setup_paths(struct Mailbox *m)
     return -1;
 
   /* Setup the right paths */
-  mutt_str_replace(&m->realpath, mailbox_path(m));
+  mutt_str_replace(&m->path->canon, mailbox_path(m));
 
   /* We will uncompress to /tmp */
   struct Buffer *buf = mutt_buffer_pool_get();
   mutt_buffer_mktemp(buf);
-  mutt_buffer_copy(&m->pathbuf, buf);
+  mutt_str_replace(&m->path->orig, mutt_b2s(buf));
   mutt_buffer_pool_release(&buf);
 
   FILE *fp = mutt_file_fopen(mailbox_path(m), "w");
@@ -163,7 +163,7 @@ static void store_size(const struct Mailbox *m)
 
   struct CompressInfo *ci = m->compress_info;
 
-  ci->size = mutt_file_get_size(m->realpath);
+  ci->size = mutt_file_get_size(m->path->canon);
 }
 
 /**
@@ -246,7 +246,7 @@ static const char *compress_format_str(char *buf, size_t buflen, size_t col, int
   {
     case 'f':
       /* Compressed file */
-      mutt_buffer_quote_filename(quoted, m->realpath, false);
+      mutt_buffer_quote_filename(quoted, m->path->canon, false);
       snprintf(buf, buflen, "%s", mutt_b2s(quoted));
       break;
     case 't':
@@ -303,7 +303,7 @@ static int execute_command(struct Mailbox *m, const char *command, const char *p
     return 0;
 
   if (!m->quiet)
-    mutt_message(progress, m->realpath);
+    mutt_message(progress, m->path->canon);
 
   int rc = 1;
   char sys_cmd[STR_COMMAND];
@@ -513,7 +513,7 @@ static int comp_mbox_open_append(struct Mailbox *m, OpenMailboxFlags flags)
   }
 
   /* Open the existing mailbox, unless we are appending */
-  if (!ci->cmd_append && (mutt_file_get_size(m->realpath) > 0))
+  if (!ci->cmd_append && (mutt_file_get_size(m->path->canon) > 0))
   {
     int rc = execute_command(m, ci->cmd_open, _("Decompressing %s"));
     if (rc == 0)
@@ -581,7 +581,7 @@ static int comp_mbox_check(struct Mailbox *m, int *index_hint)
   if (!ops)
     return -1;
 
-  int size = mutt_file_get_size(m->realpath);
+  int size = mutt_file_get_size(m->path->canon);
   if (size == ci->size)
     return 0;
 
@@ -681,7 +681,7 @@ static int comp_mbox_close(struct Mailbox *m)
     const char *msg = NULL;
 
     /* The file exists and we can append */
-    if ((access(m->realpath, F_OK) == 0) && ci->cmd_append)
+    if ((access(m->path->canon, F_OK) == 0) && ci->cmd_append)
     {
       append = ci->cmd_append;
       msg = _("Compressed-appending to %s...");
@@ -708,7 +708,7 @@ static int comp_mbox_close(struct Mailbox *m)
     /* If the file was removed, remove the compressed folder too */
     if ((access(mailbox_path(m), F_OK) != 0) && !C_SaveEmpty)
     {
-      remove(m->realpath);
+      remove(m->path->canon);
     }
     else
     {

--- a/compress/lib.h
+++ b/compress/lib.h
@@ -37,6 +37,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include "mx.h"
+#include "path.h"
 
 struct Mailbox;
 

--- a/compress/path.c
+++ b/compress/path.c
@@ -73,16 +73,18 @@ int comp_path2_parent(const struct Path *path, struct Path **parent)
 
 /**
  * comp_path2_pretty - Abbreviate a Mailbox path - Implements MxOps::path2_pretty()
+ *
+ * @note Use the canon path, because that describes the compressed file.
  */
 int comp_path2_pretty(const struct Path *path, const char *folder, char **pretty)
 {
-  if (mutt_path2_abbr_folder(path->orig, folder, pretty))
+  if (mutt_path2_abbr_folder(path->canon, folder, pretty))
     return 1;
 
-  if (mutt_path2_pretty(path->orig, HomeDir, pretty))
+  if (mutt_path2_pretty(path->canon, HomeDir, pretty))
     return 1;
 
-  *pretty = mutt_str_strdup(path->orig);
+  *pretty = mutt_str_strdup(path->canon);
   return 0;
 }
 

--- a/compress/path.c
+++ b/compress/path.c
@@ -1,0 +1,124 @@
+/**
+ * @file
+ * Compress path manipulations
+ *
+ * @authors
+ * Copyright (C) 2020 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @page comp_path Mbox path manipulations
+ *
+ * Mbox path manipulations
+ */
+
+#include "config.h"
+#include <string.h>
+#include <sys/stat.h>
+#include "config/lib.h"
+#include "email/lib.h"
+#include "core/lib.h"
+#include "lib.h"
+#include "globals.h"
+
+extern char *HomeDir;
+
+/**
+ * comp_path2_canon - Canonicalise a Mailbox path - Implements MxOps::path2_canon()
+ */
+int comp_path2_canon(struct Path *path)
+{
+  if (!mutt_path_canon2(path->orig, &path->canon))
+    return -1;
+
+  path->flags |= MPATH_CANONICAL;
+  return 0;
+}
+
+/**
+ * comp_path2_compare - Compare two Mailbox paths - Implements MxOps::path2_compare()
+ */
+int comp_path2_compare(struct Path *path1, struct Path *path2)
+{
+  int rc = mutt_str_strcmp(path1->canon, path2->canon);
+  if (rc < 0)
+    return -1;
+  if (rc > 0)
+    return 1;
+  return 0;
+}
+
+/**
+ * comp_path2_parent - Find the parent of a Mailbox path - Implements MxOps::path2_parent()
+ * @retval -1 Compressed mailbox doesn't have a parent
+ */
+int comp_path2_parent(const struct Path *path, struct Path **parent)
+{
+  return -1;
+}
+
+/**
+ * comp_path2_pretty - Abbreviate a Mailbox path - Implements MxOps::path2_pretty()
+ */
+int comp_path2_pretty(const struct Path *path, const char *folder, char **pretty)
+{
+  if (mutt_path2_abbr_folder(path->orig, folder, pretty))
+    return 1;
+
+  if (mutt_path2_pretty(path->orig, HomeDir, pretty))
+    return 1;
+
+  *pretty = mutt_str_strdup(path->orig);
+  return 0;
+}
+
+/**
+ * comp_path2_probe - Does this Mailbox type recognise this path? - Implements MxOps::path2_probe()
+ *
+ * **Tests**
+ * - Path must exist
+ * - Path must be a file
+ * - Path must match an 'open-hook'
+ */
+int comp_path2_probe(struct Path *path, const struct stat *st)
+{
+  if (!S_ISREG(st->st_mode))
+    return -1;
+
+  if (!mutt_comp_can_read(path->orig))
+    return -1;
+
+  path->type = MUTT_COMPRESSED;
+  return 0;
+}
+
+/**
+ * comp_path2_tidy - Tidy a Mailbox path - Implements MxOps::path2_tidy()
+ */
+int comp_path2_tidy(struct Path *path)
+{
+  char *tidy = mutt_path_tidy2(path->orig, false);
+  if (!tidy)
+    return -1; // LCOV_EXCL_LINE
+
+  FREE(&path->orig);
+  path->orig = tidy;
+  tidy = NULL;
+
+  path->flags |= MPATH_TIDY;
+  return 0;
+}

--- a/compress/path.h
+++ b/compress/path.h
@@ -1,0 +1,36 @@
+/**
+ * @file
+ * Compress path manipulations
+ *
+ * @authors
+ * Copyright (C) 2020 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MUTT_COMPRESS_PATH_H
+#define MUTT_COMPRESS_PATH_H
+
+struct Path;
+struct stat;
+
+int comp_path2_canon  (struct Path *path);
+int comp_path2_compare(struct Path *path1, struct Path *path2);
+int comp_path2_parent (const struct Path *path, struct Path **parent);
+int comp_path2_pretty (const struct Path *path, const char *folder, char **pretty);
+int comp_path2_probe  (struct Path *path, const struct stat *st);
+int comp_path2_tidy   (struct Path *path);
+
+#endif /* MUTT_COMPRESS_PATH_H */

--- a/config/dump.c
+++ b/config/dump.c
@@ -35,7 +35,7 @@
 #include "subset.h"
 #include "types.h"
 
-void mutt_pretty_mailbox(char *buf, size_t buflen);
+extern char *HomeDir;
 
 /**
  * escape_string - Write a string to a buffer, escaping special characters
@@ -206,7 +206,17 @@ bool dump_config(struct ConfigSet *cs, ConfigDumpFlags flags, FILE *fp)
         }
 
         if (((type == DT_PATH) || IS_MAILBOX(he)) && (value.data[0] == '/'))
-          mutt_pretty_mailbox(value.data, value.dsize);
+        {
+          //JKJ Always a filesystem path (file/dir)
+          // mailbox code path needs separating
+          char *pretty = NULL;
+          mutt_path2_pretty(value.data, HomeDir, &pretty);
+          if (pretty)
+          {
+            mutt_buffer_strcpy(&value, pretty);
+            FREE(&pretty);
+          }
+        }
 
         if ((type != DT_BOOL) && (type != DT_NUMBER) && (type != DT_LONG) &&
             (type != DT_QUAD) && !(flags & CS_DUMP_NO_ESCAPING))
@@ -228,7 +238,17 @@ bool dump_config(struct ConfigSet *cs, ConfigDumpFlags flags, FILE *fp)
         }
 
         if (((type == DT_PATH) || IS_MAILBOX(he)) && !(he->type & DT_MAILBOX))
-          mutt_pretty_mailbox(initial.data, initial.dsize);
+        {
+          //JKJ Always a filesystem path (file/dir)
+          // mailbox code path needs separating
+          char *pretty = NULL;
+          mutt_path2_pretty(initial.data, HomeDir, &pretty);
+          if (pretty)
+          {
+            mutt_buffer_strcpy(&initial, pretty);
+            FREE(&pretty);
+          }
+        }
 
         if ((type != DT_BOOL) && (type != DT_NUMBER) && (type != DT_LONG) &&
             (type != DT_QUAD) && !(flags & CS_DUMP_NO_ESCAPING))

--- a/config/subset.c
+++ b/config/subset.c
@@ -107,10 +107,12 @@ void cs_subset_free(struct ConfigSubset **ptr)
     struct HashElem **list = get_elem_list(sub->cs);
     for (size_t i = 0; list[i]; i++)
     {
-      const char *item = list[i]->key.strkey;
-      if (mutt_str_startswith(item, scope, CASE_MATCH) != 0)
+      if (mutt_str_startswith(list[i]->key.strkey, scope, CASE_MATCH) != 0)
       {
+        // The search item may be used after the actual HashElem has been deleted
+        const char *item = mutt_str_strdup(list[i]->key.strkey);
         cs_uninherit_variable(sub->cs, item);
+        FREE(&item);
       }
     }
     FREE(&list);

--- a/conn/sasl.c
+++ b/conn/sasl.c
@@ -568,8 +568,7 @@ static int mutt_sasl_conn_poll(struct Connection *conn, time_t wait_secs)
  * @retval  0 Success
  * @retval -1 Error
  *
- * which also sets various security properties. If this turns out to be fine
- * for POP too we can probably stop exporting mutt_sasl_get_callbacks().
+ * which also sets various security properties.
  */
 int mutt_sasl_client_new(struct Connection *conn, sasl_conn_t **saslconn)
 {

--- a/copy.c
+++ b/copy.c
@@ -475,13 +475,18 @@ int mutt_copy_header(FILE *fp_in, struct Email *e, FILE *fp_out,
     char *folder = nm_email_get_folder(e);
     if (folder && !(C_Weed && mutt_matches_ignore("folder")))
     {
-      char buf[1024];
-      mutt_str_strfcpy(buf, folder, sizeof(buf));
-      mutt_pretty_mailbox(buf, sizeof(buf));
-
-      fputs("Folder: ", fp_out);
-      fputs(buf, fp_out);
-      fputc('\n', fp_out);
+      char *pretty = NULL;
+      //JKJ Always a filesystem path (maildir dir)
+      mutt_path2_pretty(folder, HomeDir, &pretty);
+      if (pretty)
+      {
+        fprintf(fp_out, "Folder: %s\n", pretty);
+        FREE(&pretty);
+      }
+      else
+      {
+        fprintf(fp_out, "Folder: %s\n", folder);
+      }
     }
   }
 #endif

--- a/core/account.c
+++ b/core/account.c
@@ -140,3 +140,21 @@ void account_free(struct Account **ptr)
 
   FREE(ptr);
 }
+
+/**
+ * account_find - Find an Account by its name
+ * @param name Name to find
+ * @retval ptr  Matching Account
+ * @retval NULL None found
+ */
+struct Account *account_find(const char *name)
+{
+  struct Account *np = NULL;
+  TAILQ_FOREACH(np, &NeoMutt->accounts, entries)
+  {
+    if (mutt_str_strcmp(name, np->name) == 0)
+      return np;
+  }
+
+  return NULL;
+}

--- a/core/account.h
+++ b/core/account.h
@@ -63,6 +63,7 @@ enum NotifyAccount
   NT_ACCOUNT_REMOVE,  ///< An Account is about to be destroyed
 };
 
+struct Account *account_find          (const char *name);
 void            account_free          (struct Account **ptr);
 bool            account_mailbox_add   (struct Account *a, struct Mailbox *m);
 bool            account_mailbox_remove(struct Account *a, struct Mailbox *m);

--- a/core/lib.h
+++ b/core/lib.h
@@ -30,6 +30,7 @@
  * | core/account.c      | @subpage core_account      |
  * | core/mailbox.c      | @subpage core_mailbox      |
  * | core/neomutt.c      | @subpage core_neomutt      |
+ * | core/path.c         | @subpage core_path         |
  */
 
 #ifndef MUTT_CORE_LIB_H
@@ -39,6 +40,7 @@
 #include "account.h"
 #include "mailbox.h"
 #include "neomutt.h"
+#include "path.h"
 // IWYU pragma: end_exports
 
 #endif /* MUTT_CORE_LIB_H */

--- a/core/mailbox.c
+++ b/core/mailbox.c
@@ -34,21 +34,28 @@
 #include "email/lib.h"
 #include "mailbox.h"
 #include "neomutt.h"
+#include "path.h"
 
 /**
  * mailbox_new - Create a new Mailbox
+ * @param path Path to use (OPTIONAL)
  * @retval ptr New Mailbox
+ *
+ * @note If a path is supplied, the Mailbox will take ownership of it.
  */
-struct Mailbox *mailbox_new(void)
+struct Mailbox *mailbox_new(struct Path *path)
 {
   struct Mailbox *m = mutt_mem_calloc(1, sizeof(struct Mailbox));
 
-  mutt_buffer_init(&m->pathbuf);
-  m->notify = notify_new();
+  if (path)
+    m->path = path;
+  else
+    m->path = mutt_path_new();
 
   m->email_max = 25;
   m->emails = mutt_mem_calloc(m->email_max, sizeof(struct Email *));
   m->v2r = mutt_mem_calloc(m->email_max, sizeof(int));
+  m->notify = notify_new();
 
   return m;
 }
@@ -71,10 +78,8 @@ void mailbox_free(struct Mailbox **ptr)
   if (m->mdata && m->free_mdata)
     m->free_mdata(&m->mdata);
 
-  mutt_buffer_dealloc(&m->pathbuf);
   cs_subset_free(&m->sub);
-  FREE(&m->name);
-  FREE(&m->realpath);
+  mutt_path_free(&m->path);
   FREE(&m->emails);
   FREE(&m->v2r);
   notify_free(&m->notify);
@@ -133,7 +138,7 @@ struct Mailbox *mailbox_find_name(const char *name)
   struct Mailbox *m = NULL;
   STAILQ_FOREACH(np, &ml, entries)
   {
-    if (mutt_str_strcmp(np->mailbox->name, name) == 0)
+    if (mutt_str_strcmp(np->mailbox->path->desc, name) == 0)
     {
       m = np->mailbox;
       break;
@@ -208,7 +213,7 @@ bool mailbox_set_subset(struct Mailbox *m, struct ConfigSubset *sub)
   if (!m || m->sub || !sub)
     return false;
 
-  m->sub = cs_subset_new(m->name, sub, m->notify);
+  m->sub = cs_subset_new(m->path->desc, sub, m->notify);
   m->sub->scope = SET_SCOPE_MAILBOX;
   return true;
 }

--- a/core/mailbox.c
+++ b/core/mailbox.c
@@ -48,9 +48,14 @@ struct Mailbox *mailbox_new(struct Path *path)
   struct Mailbox *m = mutt_mem_calloc(1, sizeof(struct Mailbox));
 
   if (path)
+  {
     m->path = path;
+    m->magic = path->type;
+  }
   else
+  {
     m->path = mutt_path_new();
+  }
 
   m->email_max = 25;
   m->emails = mutt_mem_calloc(m->email_max, sizeof(struct Email *));

--- a/core/mailbox.h
+++ b/core/mailbox.h
@@ -56,6 +56,8 @@ enum MailboxType
   MUTT_NOTMUCH,            ///< 'Notmuch' (virtual) Mailbox type
   MUTT_POP,                ///< 'POP3' Mailbox type
   MUTT_COMPRESSED,         ///< Compressed file Mailbox type
+  MUTT_LOCAL_FILE,         ///< Local filesystem file
+  MUTT_LOCAL_DIR,          ///< Local filesystem directory
 };
 
 /**

--- a/core/mailbox.h
+++ b/core/mailbox.h
@@ -30,6 +30,8 @@
 #include <sys/types.h>
 #include <time.h>
 #include "mutt/lib.h"
+#include "config/lib.h"
+#include "path.h"
 
 struct ConfigSubset;
 struct Email;
@@ -80,9 +82,7 @@ typedef uint16_t AclFlags;          ///< Flags, e.g. #MUTT_ACL_ADMIN
  */
 struct Mailbox
 {
-  struct Buffer pathbuf;
-  char *realpath;                     ///< Used for duplicate detection, context comparison, and the sidebar
-  char *name;                         ///< A short name for the Mailbox
+  struct Path *path;                  ///< Path representing the Mailbox
   struct ConfigSubset *sub;           ///< Inherited config items
   off_t size;                         ///< Size of the Mailbox
   bool has_new;                       ///< Mailbox has new mail
@@ -178,7 +178,7 @@ void            mailbox_changed   (struct Mailbox *m, enum NotifyMailbox action)
 struct Mailbox *mailbox_find      (const char *path);
 struct Mailbox *mailbox_find_name (const char *name);
 void            mailbox_free      (struct Mailbox **ptr);
-struct Mailbox *mailbox_new       (void);
+struct Mailbox *mailbox_new       (struct Path *path);
 bool            mailbox_set_subset(struct Mailbox *m, struct ConfigSubset *sub);
 void            mailbox_size_add  (struct Mailbox *m, const struct Email *e);
 void            mailbox_size_sub  (struct Mailbox *m, const struct Email *e);
@@ -191,7 +191,7 @@ void            mailbox_update    (struct Mailbox *m);
  */
 static inline const char *mailbox_path(const struct Mailbox *m)
 {
-  return mutt_b2s(&m->pathbuf);
+  return m->path->orig;
 }
 
 #endif /* MUTT_CORE_MAILBOX_H */

--- a/core/path.c
+++ b/core/path.c
@@ -63,6 +63,27 @@ struct Path *mutt_path_new(void)
 }
 
 /**
+ * mutt_path_dup - Duplicate a Path
+ * @param p Path
+ * @retval ptr New Path
+ */
+struct Path *mutt_path_dup(struct Path *p)
+{
+  if (!p)
+    return NULL;
+
+  struct Path *p_new = mutt_path_new();
+
+  p_new->desc = mutt_str_strdup(p->desc);
+  p_new->orig = mutt_str_strdup(p->orig);
+  p_new->canon = mutt_str_strdup(p->canon);
+  p_new->type = p->type;
+  p_new->flags = p->flags;
+
+  return p_new;
+}
+
+/**
  * path_partial_match_string - Compare two strings, allowing for missing values
  * @param str1 First string
  * @param str2 Second string

--- a/core/path.c
+++ b/core/path.c
@@ -61,3 +61,43 @@ struct Path *mutt_path_new(void)
 {
   return mutt_mem_calloc(1, sizeof(struct Path));
 }
+
+/**
+ * path_partial_match_string - Compare two strings, allowing for missing values
+ * @param str1 First string
+ * @param str2 Second string
+ * @retval true Strings match
+ *
+ * @note If both strings are present, they must be identical.
+ *       If either one of the strings is missing, that is also a match.
+ */
+bool path_partial_match_string(const char *str1, const char *str2)
+{
+  if (str1 && (str1[0] == '\0'))
+    str1 = NULL;
+  if (str2 && (str2[0] == '\0'))
+    str2 = NULL;
+  if (!str1 && !str2) // both empty
+    return true;
+  if (!str1 ^ !str2) // one is empty, but not the other
+    return true;
+  return (mutt_str_strcmp(str1, str2) == 0);
+}
+
+/**
+ * path_partial_match_number - Compare two numbers, allowing for missing values
+ * @param num1 First number
+ * @param num2 Second number
+ * @retval true Numbers match
+ *
+ * @note If both numbers are non-zero, they must be identical.
+ *       If either one of the numbers is zero, that is also a match.
+ */
+bool path_partial_match_number(int num1, int num2)
+{
+  if ((num1 == 0) && (num2 == 0)) // both zero
+    return true;
+  if ((num1 == 0) ^ (num2 == 0)) // one is zero, but not the other
+    return true;
+  return (num1 == num2);
+}

--- a/core/path.c
+++ b/core/path.c
@@ -1,0 +1,63 @@
+/**
+ * @file
+ * Mailbox path
+ *
+ * @authors
+ * Copyright (C) 2020 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @page core_path Mailbox path
+ *
+ * Mailbox path
+ */
+
+#include "config.h"
+#include "mutt/lib.h"
+#include "path.h"
+
+/**
+ * mutt_path_free - Free a Path
+ * @param ptr Path to free
+ *
+ * Some of the paths may be shared, so check for dupes before freeing.
+ */
+void mutt_path_free(struct Path **ptr)
+{
+  if (!ptr || !*ptr)
+    return;
+
+  struct Path *path = *ptr;
+
+  if ((path->desc != path->orig) && (path->desc != path->canon))
+    FREE(&path->desc);
+
+  if (path->orig != path->canon)
+    FREE(&path->orig);
+
+  FREE(&path->canon);
+  FREE(ptr);
+}
+
+/**
+ * mutt_path_new - Create a Path
+ * @retval ptr New Path
+ */
+struct Path *mutt_path_new(void)
+{
+  return mutt_mem_calloc(1, sizeof(struct Path));
+}

--- a/core/path.h
+++ b/core/path.h
@@ -1,0 +1,50 @@
+/**
+ * @file
+ * Mailbox path
+ *
+ * @authors
+ * Copyright (C) 2020 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MUTT_CORE_PATH_H
+#define MUTT_CORE_PATH_H
+
+#include <stdint.h>
+
+typedef uint8_t PathFlags;   ///< Flags for Path, e.g. #MPATH_RESOLVED
+#define MPATH_NO_FLAGS        0  ///< No flags are set
+#define MPATH_RESOLVED  (1 << 0) ///< Path has been resolved, see mx_path_resolve()
+#define MPATH_TIDY      (1 << 1) ///< Path has been tidied, see MxOps::path_tidy()
+#define MPATH_CANONICAL (1 << 2) ///< Path is canonical, see MxOps::path_canon()
+#define MPATH_ROOT      (1 << 3) ///< Path is at the root of an Account (it has no parent)
+
+/**
+ * Path - A path to a Mailbox, file or directory
+ */
+struct Path
+{
+  char *desc;      ///< Descriptive name
+  char *orig;      ///< User-entered path
+  char *canon;     ///< Canonical path
+  int type;        ///< Path type, enum MailboxType
+  PathFlags flags; ///< Flags describing what's known about the path
+};
+
+void             mutt_path_free(struct Path **ptr);
+struct Path *mutt_path_new(void);
+
+#endif /* MUTT_CORE_PATH_H */

--- a/core/path.h
+++ b/core/path.h
@@ -44,7 +44,10 @@ struct Path
   PathFlags flags; ///< Flags describing what's known about the path
 };
 
-void             mutt_path_free(struct Path **ptr);
+void         mutt_path_free(struct Path **ptr);
 struct Path *mutt_path_new(void);
+
+bool path_partial_match_string(const char *str1, const char *str2);
+bool path_partial_match_number(int num1, int num2);
 
 #endif /* MUTT_CORE_PATH_H */

--- a/core/path.h
+++ b/core/path.h
@@ -46,6 +46,7 @@ struct Path
 
 void         mutt_path_free(struct Path **ptr);
 struct Path *mutt_path_new(void);
+struct Path *mutt_path_dup(struct Path *p);
 
 bool path_partial_match_string(const char *str1, const char *str2);
 bool path_partial_match_number(int num1, int num2);

--- a/debug/account.c
+++ b/debug/account.c
@@ -1,0 +1,347 @@
+/**
+ * @file
+ * Dump all Accounts
+ *
+ * @authors
+ * Copyright (C) 2019-2020 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @page debug_account Dump all Accounts
+ *
+ * Dump all Accounts
+ */
+
+#include "config.h"
+#include <string.h>
+#include "mutt/lib.h"
+#include "config/lib.h"
+#include "core/lib.h"
+#include "mutt.h"
+#include "lib.h"
+#include "globals.h"
+#include "init.h"
+
+void dump_one(struct Buffer *tmp, struct Buffer *value, const char *name)
+{
+  mutt_buffer_reset(value);
+  mutt_buffer_reset(tmp);
+  struct HashElem *he = NULL;
+  he = cs_get_elem(NeoMutt->sub->cs, name);
+  if (!he)
+  {
+    printf("\n");
+    return;
+  }
+  int type = DTYPE(he->type);
+  cs_he_string_get(NeoMutt->sub->cs, he, value);
+  if ((type != DT_BOOL) && (type != DT_NUMBER) && (type != DT_LONG) && (type != DT_QUAD))
+  {
+    mutt_buffer_reset(tmp);
+    pretty_var(value->data, tmp);
+    mutt_buffer_strcpy(value, tmp->data);
+  }
+  dump_config_neo(NeoMutt->sub->cs, he, value, NULL, CS_DUMP_NO_FLAGS, stdout);
+}
+
+void dump_vars(const char *account)
+{
+  const char *vars[] = { "folder", "index_format", "sort", "sort_aux" };
+  struct Buffer tmp = mutt_buffer_make(1024);
+  struct Buffer value = mutt_buffer_make(1024);
+  char name[128];
+
+  printf("%s:\n", account ? account : "base values");
+  for (size_t i = 0; i < mutt_array_size(vars); i++)
+  {
+    printf("    ");
+    if (account)
+      snprintf(name, sizeof(name), "%s:%s", account, vars[i]);
+    else
+      snprintf(name, sizeof(name), "%s", vars[i]);
+    dump_one(&tmp, &value, name);
+  }
+
+  mutt_buffer_dealloc(&tmp);
+  mutt_buffer_dealloc(&value);
+}
+
+void dump_accounts2(void)
+{
+  printf("\n");
+  dump_vars(NULL);
+  struct Account *np = NULL;
+  TAILQ_FOREACH(np, &NeoMutt->accounts, entries)
+  {
+    dump_vars(np->name);
+  }
+}
+
+void dump_inherited(struct ConfigSet *cs)
+{
+  printf("\n");
+
+  struct Buffer tmp = mutt_buffer_make(1024);
+  struct Buffer value = mutt_buffer_make(1024);
+
+  struct HashElem **list = get_elem_list(cs);
+  for (size_t i = 0; list[i]; i++)
+  {
+    const char *item = list[i]->key.strkey;
+    if (!strchr(item, ':'))
+      continue;
+    cs_he_string_get(cs, list[i], &value);
+    dump_one(&tmp, &value, item);
+  }
+
+  mutt_buffer_dealloc(&tmp);
+  mutt_buffer_dealloc(&value);
+}
+
+void kill_accounts(void)
+{
+  char buf[128];
+  struct Buffer scratch = mutt_buffer_make(1024);
+  struct Buffer err = mutt_buffer_make(1024);
+
+  struct Account *np = NULL;
+  struct Account *tmp = NULL;
+  TAILQ_FOREACH_SAFE(np, &NeoMutt->accounts, entries, tmp)
+  {
+    snprintf(buf, sizeof(buf), "unaccount %s", np->name);
+    mutt_parse_rc_line(buf, &scratch, &err);
+  }
+
+  mutt_buffer_dealloc(&err);
+  mutt_buffer_dealloc(&scratch);
+}
+
+struct HashElem *get_he(struct ConfigSet *cs, const char *name)
+{
+  struct Slist *sl = slist_parse(name, SLIST_SEP_COLON);
+  if (!sl || (sl->count < 1) || (sl->count > 3))
+    return NULL;
+
+  struct ConfigSubset *sub = NULL;
+  if (sl->count == 1)
+  {
+    sub = NeoMutt->sub;
+    goto have_sub;
+  }
+
+  struct ListNode *np = STAILQ_FIRST(&sl->head);
+  struct Account *a = account_find(np->data);
+  if (!a)
+    return NULL;
+
+  if (sl->count == 2)
+  {
+    sub = a->sub;
+    goto have_sub;
+  }
+
+  np = STAILQ_NEXT(STAILQ_FIRST(&sl->head), entries);
+  struct Mailbox *m = mailbox_find(np->data);
+  if (!m)
+    return NULL;
+
+  sub = m->sub;
+  if (sub)
+    ;
+
+have_sub:
+  return NULL;
+}
+
+#if 0
+void test_parse_set2(int argc, char *argv[])
+{
+    struct Buffer *tmp = mutt_buffer_alloc(256);
+    struct Buffer *var = mutt_buffer_alloc(256);
+    struct Buffer *err = mutt_buffer_alloc(256);
+    for (size_t j = 1; j < argc; j++)
+    {
+      mutt_buffer_reset(tmp);
+      mutt_buffer_reset(var);
+      mutt_buffer_reset(err);
+
+      printf("arg = %s\n", argv[j]);
+      mutt_buffer_printf(var, "set %s", argv[j]);
+      var->dptr = var->data + 4;
+      printf("%s\n", var->data);
+      int rc = parse_set(tmp, var, 0, err);
+      mutt_buffer_reset(var);
+      char *eq = strchr(argv[j], '=');
+      if (eq)
+        *eq = '\0';
+      struct HashElem *he = get_he(NeoMutt->sub->cs, argv[j]);
+      cs_subset_he_string_get(sub, he, var);
+      if (rc < 0)
+        printf("%2d %s\n", rc, var->data);
+      else
+        printf("%2d %s = %s\n", rc, argv[j], var->data);
+    }
+    mutt_buffer_free(&err);
+    mutt_buffer_free(&var);
+    mutt_buffer_free(&tmp);
+}
+#endif
+
+void dump_config_notify(const char *level, struct NotifyCallback *nc)
+{
+  if (nc->event_type != NT_CONFIG)
+    return;
+
+  struct EventConfig *ec = nc->event_data;
+  const struct ConfigSubset *sub = ec->sub;
+  const char *scope = "???";
+  switch (sub->scope)
+  {
+    case SET_SCOPE_NEOMUTT:
+      scope = "neomutt";
+      break;
+    case SET_SCOPE_ACCOUNT:
+      scope = "account";
+      break;
+    case SET_SCOPE_MAILBOX:
+      scope = "mailbox";
+      break;
+  }
+
+  printf("Event %s, Observer %s: %s (%s)\n", scope, level, ec->name, NONULL(sub->name));
+}
+
+int neomutt_observer(struct NotifyCallback *nc)
+{
+  dump_config_notify("neomutt", nc);
+  return 0;
+}
+
+int account_observer(struct NotifyCallback *nc)
+{
+  dump_config_notify("account", nc);
+  return 0;
+}
+
+int mailbox_observer(struct NotifyCallback *nc)
+{
+  dump_config_notify("mailbox", nc);
+  return 0;
+}
+
+void test1(struct NeoMutt *n)
+{
+  const char *name = "time_inc";
+  // struct HashElem *he_n = NULL;
+  // struct HashElem *he_a = NULL;
+  // struct HashElem *he_m = NULL;
+  intptr_t val_n;
+  intptr_t val_a;
+  intptr_t val_m;
+
+  struct Account *a = account_new("fruit", n->sub);
+  a->magic = MUTT_MAILDIR;
+
+  struct Mailbox *m = mailbox_new(NULL); // "apple"
+  mailbox_set_subset(m, a->sub);
+  account_mailbox_add(a, m);
+
+  subset_dump(m->sub);
+  // subset_dump_var(m->sub, name);
+
+  notify_observer_add(n->notify, neomutt_observer, NULL);
+  notify_observer_add(a->notify, account_observer, NULL);
+  notify_observer_add(m->notify, mailbox_observer, NULL);
+
+  // cs_subset_str_native_set(m->sub, name, 42, NULL);
+
+  // he_n = cs_subset_lookup(n->sub, name);
+  // he_a = cs_subset_lookup(a->sub, name);
+  // he_m = cs_subset_lookup(m->sub, name);
+
+  // val_n = cs_subset_str_native_get(n->sub, name, NULL);
+  // val_a = cs_subset_str_native_get(a->sub, name, NULL);
+  // val_m = cs_subset_str_native_get(m->sub, name, NULL);
+
+  // printf("neomutt: %ld\n", val_n);
+  // printf("account: %ld\n", val_a);
+  // printf("mailbox: %ld\n", val_m);
+
+  // cs_subset_he_native_set(n->sub, he_n, 10, NULL);
+  cs_subset_str_native_set(n->sub, name, 10, NULL);
+  subset_dump_var(m->sub, name);
+
+  // val_n = cs_subset_str_native_get(n->sub, name, NULL);
+  // val_a = cs_subset_str_native_get(a->sub, name, NULL);
+  // val_m = cs_subset_str_native_get(m->sub, name, NULL);
+
+  // printf("neomutt: %ld\n", val_n);
+  // printf("account: %ld\n", val_a);
+  // printf("mailbox: %ld\n", val_m);
+
+  // cs_subset_he_native_set(a->sub, he_a, 20, NULL);
+  cs_subset_str_native_set(a->sub, name, 20, NULL);
+  subset_dump_var(m->sub, name);
+
+  // val_n = cs_subset_str_native_get(n->sub, name, NULL);
+  // val_a = cs_subset_str_native_get(a->sub, name, NULL);
+  // val_m = cs_subset_str_native_get(m->sub, name, NULL);
+
+  // printf("neomutt: %ld\n", val_n);
+  // printf("account: %ld\n", val_a);
+  // printf("mailbox: %ld\n", val_m);
+
+  // cs_subset_he_native_set(m->sub, he_m, 30, NULL);
+  cs_subset_str_native_set(m->sub, name, 30, NULL);
+  subset_dump_var(m->sub, name);
+
+  val_n = cs_subset_str_native_get(n->sub, name, NULL);
+  val_a = cs_subset_str_native_get(a->sub, name, NULL);
+  val_m = cs_subset_str_native_get(m->sub, name, NULL);
+
+  printf("neomutt: %ld\n", val_n);
+  printf("account: %ld\n", val_a);
+  printf("mailbox: %ld\n", val_m);
+
+  account_free(&a);
+}
+
+void test2(struct NeoMutt *n)
+{
+  const char *name = "copy";
+
+  struct Account *a = account_new("fruit", n->sub);
+  a->magic = MUTT_MAILDIR;
+
+  struct Mailbox *m = mailbox_new(NULL); // "apple"
+  mailbox_set_subset(m, a->sub);
+  account_mailbox_add(a, m);
+
+  cs_subset_str_native_set(n->sub, name, MUTT_ASKNO, NULL);
+  subset_dump_var(m->sub, name);
+
+  quad_str_toggle(m->sub, name, NULL);
+  subset_dump_var(m->sub, name);
+
+  account_free(&a);
+}
+
+void test_config_notify(struct NeoMutt *n)
+{
+  // test1(n);
+  test2(n);
+}

--- a/debug/graphviz.c
+++ b/debug/graphviz.c
@@ -489,22 +489,22 @@ static void dot_mailbox(FILE *fp, struct Mailbox *m, struct ListHead *links)
 
   dot_object_header(fp, m, "Mailbox", "#80ff80");
   dot_mailbox_type(fp, "type", m->magic);
-  if (m->name)
-    dot_type_string(fp, "name", m->name);
+  if (m->path->desc)
+    dot_type_string(fp, "path-&gt;desc", m->path->desc);
 
   if ((m->magic == MUTT_IMAP) || (m->magic == MUTT_POP))
   {
-    dot_path_imap(buf, sizeof(buf), mutt_b2s(&m->pathbuf));
-    dot_type_string(fp, "pathbuf", buf);
-    dot_path_imap(buf, sizeof(buf), m->realpath);
-    dot_type_string(fp, "realpath", buf);
+    dot_path_imap(buf, sizeof(buf), m->path->orig);
+    dot_type_string(fp, "path-&gt;orig", buf);
+    dot_path_imap(buf, sizeof(buf), m->path->canon);
+    dot_type_string(fp, "path-&gt;canon", buf);
   }
   else
   {
-    dot_path_fs(buf, sizeof(buf), mutt_b2s(&m->pathbuf));
-    dot_type_string(fp, "pathbuf", buf);
-    dot_path_fs(buf, sizeof(buf), m->realpath);
-    dot_type_string(fp, "realpath", buf);
+    dot_path_fs(buf, sizeof(buf), m->path->orig);
+    dot_type_string(fp, "path-&gt;orig", buf);
+    dot_path_fs(buf, sizeof(buf), m->path->canon);
+    dot_type_string(fp, "path-&gt;canon", buf);
   }
 
 #ifdef GV_HIDE_MDATA
@@ -555,10 +555,10 @@ static void dot_mailbox(FILE *fp, struct Mailbox *m, struct ListHead *links)
   }
 
 #ifndef GV_HIDE_CONFIG
-  if (m->name)
+  if (m->path->desc)
   {
-    dot_config(fp, m->name, DT_INHERIT_MBOX, m->sub, links);
-    dot_add_link(links, m, m->name, "Mailbox Config", false);
+    dot_config(fp, m->path->desc, DT_INHERIT_MBOX, m->sub, links);
+    dot_add_link(links, m, m->path->desc, "Mailbox Config", false);
   }
 #endif
 }
@@ -592,9 +592,9 @@ static void dot_mailbox_node(FILE *fp, struct MailboxNode *mn, struct ListHead *
 #endif
 
 #ifndef GV_HIDE_CONFIG
-  if (mn->mailbox->name)
+  if (mn->mailbox->path->desc)
   {
-    dot_ptr_name(name, sizeof(name), mn->mailbox->name);
+    dot_ptr_name(name, sizeof(name), mn->mailbox->path->desc);
     mutt_buffer_add_printf(&buf, "%s ", name);
   }
 #endif

--- a/debug/lib.h
+++ b/debug/lib.h
@@ -27,17 +27,33 @@
  *
  * | File                | Description                |
  * | :------------------ | :------------------------- |
+ * | debug/account.c     | @subpage debug_account     |
  * | debug/backtrace.c   | @subpage debug_backtrace   |
  * | debug/graphviz.c    | @subpage debug_graphviz    |
  * | debug/notify.c      | @subpage debug_notify      |
  * | debug/parse_test.c  | @subpage debug_parse       |
+ * | debug/subset.c      | @subpage debug_subset      |
  * | debug/window.c      | @subpage debug_window      |
  */
 
 #ifndef MUTT_DEBUG_LIB_H
 #define MUTT_DEBUG_LIB_H
 
+#include <stddef.h>
+
+struct Buffer;
+struct ConfigSubset;
+struct NeoMutt;
+struct Notify;
 struct NotifyCallback;
+
+// Account
+int  account_observer  (struct NotifyCallback *nc);
+void dump_accounts2    (void);
+void dump_config_notify(const char *level, struct NotifyCallback *nc);
+void kill_accounts     (void);
+int  mailbox_observer  (struct NotifyCallback *nc);
+int  neomutt_observer  (struct NotifyCallback *nc);
 
 // Backtrace
 void show_backtrace(void);
@@ -47,9 +63,15 @@ void dump_graphviz(const char *title);
 
 // Notify
 int debug_notify_observer(struct NotifyCallback *nc);
+size_t observer_count(struct Notify *notify);
 
 // Parse Set
 void test_parse_set(void);
+
+// Subset
+void subset_dump     (const struct ConfigSubset *sub);
+void subset_dump_var (const struct ConfigSubset *sub, const char *var);
+void subset_dump_var2(const struct ConfigSubset *sub, const char *var);
 
 // Window
 void debug_win_dump(void);

--- a/debug/notify.c
+++ b/debug/notify.c
@@ -290,3 +290,18 @@ int debug_notify_observer(struct NotifyCallback *nc)
 
   return 0;
 }
+
+size_t observer_count(struct Notify *notify)
+{
+  if (!notify)
+    return 0;
+
+  size_t count = 0;
+  struct ObserverNode *np = NULL;
+  STAILQ_FOREACH(np, &notify->observers, entries)
+  {
+    count++;
+  }
+
+  return count;
+}

--- a/debug/subset.c
+++ b/debug/subset.c
@@ -1,0 +1,96 @@
+/**
+ * @file
+ * Dump all Config Subsets
+ *
+ * @authors
+ * Copyright (C) 2019-2020 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @page debug_subset Dump all Config Subsets
+ *
+ * Dump all Config Subsets
+ */
+
+#include "config.h"
+#include <limits.h>
+#include <stdint.h>
+#include <stdio.h>
+#include "mutt/lib.h"
+#include "config/lib.h"
+#include "lib.h"
+
+static const char *subset_get_scope(enum ConfigScope scope)
+{
+  switch (scope)
+  {
+    case SET_SCOPE_NEOMUTT:
+      return "neomutt";
+    case SET_SCOPE_ACCOUNT:
+      return "account";
+    case SET_SCOPE_MAILBOX:
+      return "mailbox";
+    default:
+      return "unknown";
+  }
+}
+
+void subset_dump(const struct ConfigSubset *sub)
+{
+  for (; sub; sub = sub->parent)
+  {
+    printf("%s: '%s' (%ld)", subset_get_scope(sub->scope), NONULL(sub->name),
+           observer_count(sub->notify));
+    if (sub->parent)
+      printf(" --> ");
+  }
+  printf("\n");
+}
+
+void subset_dump_var2(const struct ConfigSubset *sub, const char *var)
+{
+  if (!sub)
+    return;
+
+  subset_dump_var2(sub->parent, var);
+  if (sub->parent)
+    printf(", ");
+
+  struct HashElem *he = cs_subset_lookup(sub, var);
+  if (he)
+    printf("\033[1;32m");
+  else
+    printf("\033[1;31m");
+
+  printf("%s:%s", NONULL(sub->name), var);
+
+  printf("\033[0m");
+
+  intptr_t value = cs_he_native_get(sub->cs, he, NULL);
+  if (value == INT_MIN)
+    printf("[X]");
+  else if (DTYPE(he->type) != 0)
+    printf("=%ld", value);
+  else
+    printf("(%ld)", value);
+}
+
+void subset_dump_var(const struct ConfigSubset *sub, const char *var)
+{
+  subset_dump_var2(sub, var);
+  printf("\n");
+}

--- a/editmsg.c
+++ b/editmsg.c
@@ -69,7 +69,7 @@ static int ev_message(enum EvMessage action, struct Mailbox *m, struct Email *e)
   enum MailboxType omagic = C_MboxType;
   C_MboxType = MUTT_MBOX;
 
-  struct Mailbox *m_fname = mx_path_resolve(mutt_b2s(fname));
+  struct Mailbox *m_fname = mx_path_resolve(mutt_b2s(fname), C_Folder);
   struct Context *ctx_tmp = mx_mbox_open(m_fname, MUTT_NEWFOLDER);
 
   C_MboxType = omagic;

--- a/email/url.c
+++ b/email/url.c
@@ -435,3 +435,37 @@ int url_tostring(struct Url *url, char *dest, size_t len, int flags)
 
   return retval;
 }
+
+/**
+ * url_query_strings_match - Are two Url Query Lists identical?
+ * @param qs1 First Query List
+ * @param qs2 Second Query List
+ * @retval true If the Query Lists match
+ *
+ * To match, the Query Lists must:
+ * - Have the same number of entries
+ * - Be in the same order
+ * - All names match
+ * - All values match
+ */
+bool url_query_strings_match(const struct UrlQueryList *qs1, const struct UrlQueryList *qs2)
+{
+  struct UrlQuery *q1 = STAILQ_FIRST(qs1);
+  struct UrlQuery *q2 = STAILQ_FIRST(qs2);
+
+  while (q1 && q2)
+  {
+    if (mutt_str_strcmp(q1->name, q2->name) != 0)
+      return false;
+    if (mutt_str_strcmp(q1->value, q2->value) != 0)
+      return false;
+
+    q1 = STAILQ_NEXT(q1, entries);
+    q2 = STAILQ_NEXT(q2, entries);
+  }
+
+  if (q1 || q2)
+    return false;
+
+  return true;
+}

--- a/email/url.h
+++ b/email/url.h
@@ -81,6 +81,7 @@ struct Url *   url_new         (void);
 struct Url    *url_parse       (const char *src);
 int            url_pct_decode  (char *s);
 void           url_pct_encode  (char *buf, size_t buflen, const char *src);
+bool           url_query_strings_match(const struct UrlQueryList *qs1, const struct UrlQueryList *qs2);
 int            url_tobuffer    (struct Url *url, struct Buffer *dest, int flags);
 int            url_tostring    (struct Url *url, char *buf, size_t buflen, int flags);
 

--- a/enter.c
+++ b/enter.c
@@ -651,6 +651,14 @@ int mutt_enter_string_full(char *buf, size_t buflen, int col,
                                files, numfiles);
               if (buf[0] != '\0')
               {
+                char *pretty = NULL;
+                mutt_path2_pretty(buf, HomeDir, &pretty);
+                if (pretty)
+                {
+                  mutt_str_strfcpy(buf, pretty, buflen);
+                  FREE(&pretty);
+                }
+                //JKJ this could be a file/dir or a mailbox!
                 mutt_pretty_mailbox(buf, buflen);
                 if (!pass)
                   mutt_hist_add(hclass, buf, true);

--- a/globals.h
+++ b/globals.h
@@ -51,8 +51,8 @@ WHERE char *ShortHostname; ///< Short version of the hostname
 
 WHERE char *Username; ///< User's login name
 
-WHERE char *CurrentFolder; ///< Currently selected mailbox
-WHERE char *LastFolder;    ///< Previously selected mailbox
+WHERE struct Path *CurrentFolder; ///< Currently selected mailbox
+WHERE struct Path *LastFolder;    ///< Previously selected mailbox
 
 extern const char *GitVer;
 

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -1897,7 +1897,7 @@ static int imap_ac_add(struct Account *a, struct Mailbox *m)
       return -1;
     }
 
-    mutt_account_hook(m->realpath);
+    mutt_account_hook(m->path->orig);
 
     if (imap_login(adata) < 0)
     {
@@ -1917,8 +1917,8 @@ static int imap_ac_add(struct Account *a, struct Mailbox *m)
     /* fixup path and realpath, mainly to replace / by /INBOX */
     char buf[1024];
     imap_qualify_path(buf, sizeof(buf), &adata->conn->account, mdata->name);
-    mutt_buffer_strcpy(&m->pathbuf, buf);
-    mutt_str_replace(&m->realpath, mailbox_path(m));
+    mutt_str_replace(&m->path->orig, buf);
+    mutt_str_replace(&m->path->canon, mailbox_path(m));
 
     m->mdata = mdata;
     m->free_mdata = imap_mdata_free;

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -2562,18 +2562,6 @@ int imap_expand_path(struct Buffer *buf)
 }
 
 /**
- * imap_path_pretty - Abbreviate a Mailbox path - Implements MxOps::path_pretty()
- */
-static int imap_path_pretty(char *buf, size_t buflen, const char *folder)
-{
-  if (!buf || !folder)
-    return -1;
-
-  imap_pretty_mailbox(buf, buflen, folder);
-  return 0;
-}
-
-/**
  * imap_path_parent - Find the parent of a Mailbox path - Implements MxOps::path_parent()
  */
 static int imap_path_parent(char *buf, size_t buflen)
@@ -2691,7 +2679,6 @@ struct MxOps MxImapOps = {
   .tags_commit      = imap_tags_commit,
   .path_probe       = imap_path_probe,
   .path_canon       = imap_path_canon,
-  .path_pretty      = imap_path_pretty,
   .path_parent      = imap_path_parent,
   .path2_canon      = imap_path2_canon_wrapper,
   .path2_compare    = imap_path2_compare,

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -1323,7 +1323,7 @@ static int imap_mbox_check_stats(struct Mailbox *m, int flags)
  */
 int imap_path_status(const char *path, bool queue)
 {
-  struct Mailbox *m = mx_mbox_find2(path);
+  struct Mailbox *m = mx_mbox_find2(path, C_Folder);
   if (m)
     return imap_mailbox_status(m, queue);
 
@@ -2072,7 +2072,7 @@ static int imap_mbox_open(struct Mailbox *m)
   }
 
   /* pipeline the postponed count if possible */
-  struct Mailbox *m_postponed = mx_mbox_find2(C_Postponed);
+  struct Mailbox *m_postponed = mx_mbox_find2(C_Postponed, C_Folder);
   struct ImapAccountData *postponed_adata = imap_adata_get(m_postponed);
   if (postponed_adata &&
       imap_account_match(&postponed_adata->conn->account, &adata->conn->account))

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -1522,6 +1522,7 @@ int imap_complete(char *buf, size_t buflen, const char *path)
   {
     /* reformat output */
     imap_qualify_path(buf, buflen, &adata->conn->account, completion);
+    //JKJ imap mailbox only
     mutt_pretty_mailbox(buf, buflen);
     return 0;
   }

--- a/imap/imap_private.h
+++ b/imap/imap_private.h
@@ -32,6 +32,8 @@
 #include <time.h>
 #include "mutt/lib.h"
 #include "config/lib.h"
+#include "core/lib.h"
+#include "conn/lib.h"
 #include "hcache/lib.h"
 
 struct Account;
@@ -39,6 +41,7 @@ struct ConnAccount;
 struct Email;
 struct Mailbox;
 struct Message;
+struct Path;
 struct Progress;
 
 #define IMAP_PORT     143  ///< Default port for IMAP

--- a/imap/imap_private.h
+++ b/imap/imap_private.h
@@ -207,7 +207,7 @@ struct ImapAccountData
 
   char delim;
   struct Mailbox *mailbox;     /* Current selected mailbox */
-  struct Account *account;     ///< Parent Account
+  struct Account *account;     ///< Account that owns this Mailbox
 };
 
 /**

--- a/imap/lib.h
+++ b/imap/lib.h
@@ -41,6 +41,7 @@
  * | imap/browse.c     | @subpage imap_browse     |
  * | imap/command.c    | @subpage imap_command    |
  * | imap/message.c    | @subpage imap_message    |
+ * | imap/path.c       | @subpage imap_path       |
  * | imap/utf7.c       | @subpage imap_utf7       |
  * | imap/util.c       | @subpage imap_util       |
  */
@@ -54,12 +55,13 @@
 #include <sys/types.h>
 #include "core/lib.h"
 #include "mx.h"
-#include "config.h"
+#include "path.h"
 
 struct BrowserState;
 struct Buffer;
 struct ConnAccount;
 struct EmailList;
+struct Path;
 struct PatternList;
 struct stat;
 

--- a/imap/path.c
+++ b/imap/path.c
@@ -1,0 +1,276 @@
+/**
+ * @file
+ * IMAP path manipulations
+ *
+ * @authors
+ * Copyright (C) 2020 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @page imap_path IMAP path manipulations
+ *
+ * IMAP path manipulations
+ */
+
+#include "config.h"
+#include <string.h>
+#include "config/lib.h"
+#include "email/lib.h"
+#include "core/lib.h"
+#include "path.h"
+
+extern char *HomeDir;
+
+/**
+ * imap_path2_canon - Canonicalise a Mailbox path - Implements MxOps::path2_canon()
+ * @param path Path to canonicalise
+ * @param user Login username
+ * @param port Server port
+ * @retval  0 Success
+ * @retval -1 Failure
+ */
+int imap_path2_canon(struct Path *path, char *user, int port)
+{
+  struct Url *url = url_parse(path->orig);
+  if (!url)
+    return -1;
+
+  if (!url->user)
+    url->user = user;
+  if (url->port == 0)
+    url->port = port;
+  if (url->pass)
+    url->pass = NULL;
+
+  int rc = -1;
+  struct Buffer buf = mutt_buffer_make(256);
+  if (url_tobuffer(url, &buf, 0) != 0)
+    goto done; // LCOV_EXCL_LINE
+
+  mutt_str_replace(&path->canon, mutt_b2s(&buf));
+  path->flags |= MPATH_CANONICAL;
+  rc = 0;
+
+done:
+  url_free(&url);
+  mutt_buffer_dealloc(&buf);
+  return rc;
+}
+
+/**
+ * imap_path2_compare - Compare two Mailbox paths - Implements MxOps::path2_compare()
+ *
+ * **Tests**
+ * - scheme must match
+ * - host must match
+ * - user must match, or may be absent from one, or absent from both
+ * - pass must match, or may be absent from one, or absent from both
+ * - port must match, or may be absent from one, or absent from both
+ * - path must match
+ */
+int imap_path2_compare(struct Path *path1, struct Path *path2)
+{
+  struct Url *url1 = url_parse(path1->canon);
+  struct Url *url2 = url_parse(path2->canon);
+
+  int rc = url1->scheme - url2->scheme;
+  if (rc != 0)
+    goto done;
+
+  if (url1->user && url2->user)
+  {
+    rc = mutt_str_strcmp(url1->user, url2->user);
+    if (rc != 0)
+      goto done;
+  }
+
+  rc = mutt_str_strcasecmp(url1->host, url2->host);
+  if (rc != 0)
+    goto done;
+
+  if ((url1->port != 0) && (url2->port != 0))
+  {
+    rc = url1->port - url2->port;
+    if (rc != 0)
+      goto done;
+  }
+
+  bool i1 = (mutt_str_strcasecmp(url1->path, "INBOX") == 0);
+  bool i2 = (mutt_str_strcasecmp(url2->path, "INBOX") == 0);
+  if (i1 && !i2)
+  {
+    rc = -1;
+    goto done;
+  }
+  if (!i1 && i2)
+  {
+    rc = 1;
+    goto done;
+  }
+
+  rc = mutt_str_strcmp(url1->path, url2->path);
+
+done:
+  url_free(&url1);
+  url_free(&url2);
+  if (rc < 0)
+    return -1;
+  if (rc > 0)
+    return 1;
+  return 0;
+}
+
+/**
+ * imap_path2_parent - Find the parent of a Mailbox path - Implements MxOps::path2_parent()
+ * @param[in] path    Mailbox path
+ * @param[in] delim   Path delimiters
+ * @param[out] parent Parent of path
+ * @retval  0 Success, parent returned
+ * @retval -1 Failure, path is root, it has no parent
+ * @retval -2 Error
+ */
+int imap_path2_parent(const struct Path *path, char delim, struct Path **parent)
+{
+  int rc = -1;
+  struct Buffer *buf = NULL;
+
+  struct Url *url = url_parse(path->orig);
+  if (!url)
+    return -2;
+
+  if ((url->path[0] == '\0') || (mutt_str_strcmp(url->path, "INBOX") == 0))
+    goto done;
+
+  char *split = strrchr(url->path, delim);
+  if (split)
+    split[0] = '\0';
+  else
+    url->path = NULL;
+
+  buf = mutt_buffer_pool_get();
+  if (url_tobuffer(url, buf, 0) < 0)
+    goto done; // LCOV_EXCL_LINE
+
+  *parent = mutt_path_new();
+  (*parent)->orig = mutt_str_strdup(mutt_b2s(buf));
+  (*parent)->type = path->type;
+  (*parent)->flags = MPATH_RESOLVED;
+  imap_path2_tidy(*parent);
+
+  rc = 0;
+
+done:
+  url_free(&url);
+  mutt_buffer_pool_release(&buf);
+  return rc;
+}
+
+/**
+ * imap_path2_pretty - Abbreviate a Mailbox path - Implements MxOps::path2_pretty()
+ *
+ * **Tests**
+ * - scheme must match
+ * - host must match
+ * - user must match, or may be absent from one, or absent from both
+ * - pass must match, or may be absent from one, or absent from both
+ * - port must match, or may be absent from one, or absent from both
+ */
+int imap_path2_pretty(const struct Path *path, const char *folder, char **pretty)
+{
+  int rc = 0;
+  struct Url *url1 = url_parse(path->orig);
+  struct Url *url2 = url_parse(folder);
+
+  if (url1->scheme != url2->scheme)
+    goto done;
+  if (mutt_str_strcasecmp(url1->host, url2->host) != 0)
+    goto done;
+  if (!path_partial_match_string(url1->user, url2->user))
+    goto done;
+  if (!path_partial_match_number(url1->port, url2->port))
+    goto done;
+  if (!mutt_path2_abbr_folder(url1->path, url2->path, pretty))
+    goto done;
+
+  rc = 1;
+
+done:
+  url_free(&url1);
+  url_free(&url2);
+  return rc;
+}
+
+/**
+ * imap_path2_probe - Does this Mailbox type recognise this path? - Implements MxOps::path2_probe()
+ *
+ * **Tests**
+ * - Path may begin "imap://"
+ * - Path may begin "imaps://"
+ *
+ * @note The case of the URL scheme is ignored
+ */
+int imap_path2_probe(struct Path *path, const struct stat *st)
+{
+  if (!mutt_str_startswith(path->orig, "imap://", CASE_IGNORE) &&
+      !mutt_str_startswith(path->orig, "imaps://", CASE_IGNORE))
+  {
+    return -1;
+  }
+
+  path->type = MUTT_IMAP;
+  return 0;
+}
+
+/**
+ * imap_path2_tidy - Tidy a Mailbox path - Implements MxOps::path2_tidy()
+ * @param path Path to tidy
+ * @retval  0 Success
+ * @retval -1 Failure
+ *
+ * **Changes**
+ * - Lowercase the URL scheme
+ * - Replace empty path with "INBOX"
+ */
+int imap_path2_tidy(struct Path *path)
+{
+  struct Url *url = url_parse(path->orig);
+  if (!url)
+    return -1;
+
+  if (!url->path || (url->path[0] == '\0') ||
+      ((url->path[0] == '/') && (url->path[1] == '\0')) ||
+      (mutt_str_strcasecmp(url->path, "inbox") == 0))
+  {
+    url->path = "INBOX";
+  }
+
+  url->pass = NULL;
+
+  int rc = -1;
+  struct Buffer *buf = mutt_buffer_pool_get();
+  if (url_tobuffer(url, buf, 0) < 0)
+    goto done; // LCOV_EXCL_LINE
+
+  mutt_str_replace(&path->orig, mutt_b2s(buf));
+  path->flags |= MPATH_TIDY;
+  rc = 0;
+
+done:
+  url_free(&url);
+  mutt_buffer_pool_release(&buf);
+  return rc;
+}

--- a/imap/path.c
+++ b/imap/path.c
@@ -195,6 +195,8 @@ int imap_path2_pretty(const struct Path *path, const char *folder, char **pretty
   struct Url *url1 = url_parse(path->orig);
   struct Url *url2 = url_parse(folder);
 
+  if (!url1 || !url2)
+    goto done;
   if (url1->scheme != url2->scheme)
     goto done;
   if (mutt_str_strcasecmp(url1->host, url2->host) != 0)

--- a/imap/path.h
+++ b/imap/path.h
@@ -1,0 +1,36 @@
+/**
+ * @file
+ * IMAP path manipulations
+ *
+ * @authors
+ * Copyright (C) 2020 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MUTT_IMAP_PATH_H
+#define MUTT_IMAP_PATH_H
+
+struct Path;
+struct stat;
+
+int imap_path2_canon  (struct Path *path, char *user, int port);
+int imap_path2_compare(struct Path *path1, struct Path *path2);
+int imap_path2_parent (const struct Path *path, char delim, struct Path **parent);
+int imap_path2_pretty (const struct Path *path, const char *folder, char **pretty);
+int imap_path2_probe  (struct Path *path, const struct stat *st);
+int imap_path2_tidy   (struct Path *path);
+
+#endif /* MUTT_IMAP_PATH_H */

--- a/index.c
+++ b/index.c
@@ -788,7 +788,7 @@ static int main_change_folder(struct Menu *menu, int op, struct Mailbox *m,
   bool free_m = false;
   if (!m)
   {
-    m = mx_path_resolve(buf);
+    m = mx_path_resolve(buf, C_Folder);
     free_m = true;
   }
   Context = mx_mbox_open(m, flags);
@@ -2309,7 +2309,7 @@ int mutt_index_menu(struct MuttWindow *dlg)
         if (nm_url_from_query(NULL, buf, sizeof(buf)))
         {
           // Create mailbox and set name.
-          struct Mailbox *m_new_vfolder = mx_path_resolve(buf);
+          struct Mailbox *m_new_vfolder = mx_path_resolve(buf, C_Folder);
           mutt_str_replace(&m_new_vfolder->path->desc, query_unencoded);
           query_unencoded = NULL;
 
@@ -2480,7 +2480,7 @@ int mutt_index_menu(struct MuttWindow *dlg)
         }
 
         if (!m)
-          m = mx_mbox_find2(mutt_b2s(folderbuf));
+          m = mx_mbox_find2(mutt_b2s(folderbuf), C_Folder);
 
         main_change_folder(menu, op, m, folderbuf->data, folderbuf->dsize,
                            &oldcount, &index_hint, &pager_return);

--- a/index.c
+++ b/index.c
@@ -703,7 +703,7 @@ static int main_change_folder(struct Menu *menu, int op, struct Mailbox *m,
   enum MailboxType magic = mx_path_probe(buf);
   if ((magic == MUTT_MAILBOX_ERROR) || (magic == MUTT_UNKNOWN))
   {
-    // Try to see if the buffer matches a description before we bail.
+    // Try to see if the buffer matches a Mailbox name before we bail.
     // We'll receive a non-null pointer if there is a corresponding mailbox.
     m = mailbox_find_name(buf);
     if (m)
@@ -891,8 +891,22 @@ void index_make_entry(char *buf, size_t buflen, struct Menu *menu, int line)
     }
   }
 
-  mutt_make_string_flags(buf, buflen, menu->win_index->state.cols,
-                         NONULL(C_IndexFormat), Context, Context->mailbox, e, flags);
+  // struct Account *a = Context->mailbox->account;
+  struct Mailbox *m = Context->mailbox;
+  if (m)
+  {
+    struct Buffer *value = mutt_buffer_pool_get();
+    cs_subset_str_string_get(m->sub, "index_format", value);
+
+    mutt_make_string_flags(buf, buflen, menu->win_index->state.cols,
+                           mutt_b2s(value), Context, m, e, flags);
+    mutt_buffer_pool_release(&value);
+  }
+  else
+  {
+    mutt_make_string_flags(buf, buflen, menu->win_index->state.cols,
+                           NONULL(C_IndexFormat), Context, Context->mailbox, e, flags);
+  }
 }
 
 /**

--- a/init.c
+++ b/init.c
@@ -62,6 +62,8 @@
 #include "options.h"
 #include "protos.h"
 #include "sort.h"
+#include "tracker.h"
+#include "version.h"
 #ifdef USE_HCACHE
 #include "hcache/lib.h"
 #endif
@@ -202,6 +204,7 @@ static int execute_commands(struct ListHead *p)
   struct Buffer *err = mutt_buffer_pool_get();
   struct Buffer *token = mutt_buffer_pool_get();
 
+  // printf("\033[1;32mstart of commands\033[0m\n");
   struct ListNode *np = NULL;
   STAILQ_FOREACH(np, p, entries)
   {
@@ -221,6 +224,7 @@ static int execute_commands(struct ListHead *p)
   mutt_buffer_pool_release(&token);
   mutt_buffer_pool_release(&err);
 
+  // printf("\033[1;32mend of commands\033[0m\n");
   return rc;
 }
 
@@ -991,6 +995,7 @@ enum CommandResult mutt_parse_rc_line(/* const */ char *line,
   if (!line || !*line)
     return 0;
 
+  // printf("\033[1;33mRC: %s\033[0m\n", line);
   int i;
   enum CommandResult rc = MUTT_CMD_SUCCESS;
 

--- a/init.c
+++ b/init.c
@@ -1075,7 +1075,10 @@ int mutt_query_variables(struct ListHead *queries)
 
     int type = DTYPE(he->type);
     if (type == DT_PATH)
+    {
+      //JKJ local file/dir only
       mutt_pretty_mailbox(value.data, value.dsize);
+    }
 
     if ((type != DT_BOOL) && (type != DT_NUMBER) && (type != DT_LONG) && (type != DT_QUAD))
     {

--- a/init.c
+++ b/init.c
@@ -690,11 +690,12 @@ void mutt_opts_free(void)
 
   mutt_colors_free(&Colors);
 
-  FREE(&CurrentFolder);
   FREE(&HomeDir);
-  FREE(&LastFolder);
   FREE(&ShortHostname);
   FREE(&Username);
+
+  mutt_path_free(&CurrentFolder);
+  mutt_path_free(&LastFolder);
 
   mutt_replacelist_free(&SpamList);
   mutt_replacelist_free(&SubjectRegexList);

--- a/local.c
+++ b/local.c
@@ -1,0 +1,148 @@
+/**
+ * @file
+ * Fake mailbox backend for local files and directories
+ *
+ * @authors
+ * Copyright (C) 2020 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @page local Fake mailbox backend for local files and directories
+ *
+ * Fake mailbox backend for local files and directories
+ */
+
+#include "config.h"
+#include "mx.h"
+
+/**
+ * local_path2_canon - Canonicalise a Mailbox path - Implements MxOps::path2_canon
+ */
+int local_path2_canon(struct Path *path)
+{
+  return -1;
+}
+
+/**
+ * local_path2_compare - Compare two Mailbox paths - Implements MxOps::path2_compare
+ */
+int local_path2_compare(struct Path *path1, struct Path *local_path2)
+{
+  return -1;
+}
+
+/**
+ * local_path2_parent - Find the parent of a Mailbox path - Implements MxOps::path2_parent
+ */
+int local_path2_parent(const struct Path *path, struct Path **parent)
+{
+  return -1;
+}
+
+/**
+ * local_path2_pretty - Abbreviate a Mailbox path - Implements MxOps::path2_pretty
+ */
+int local_path2_pretty(const struct Path *path, const char *folder, char **pretty)
+{
+  return -1;
+}
+
+/**
+ * local_path2_probe - Does this Mailbox type recognise this path? - Implements MxOps::path2_probe
+ */
+int local_path2_probe(struct Path *path, const struct stat *st)
+{
+  return -1;
+}
+
+/**
+ * local_path2_tidy - Tidy a Mailbox path - Implements MxOps::path2_tidy
+ */
+int local_path2_tidy(struct Path *path)
+{
+  return -1;
+}
+
+// clang-format on
+/**
+ * MxLocalFileOps - Local File - Implements ::MxOps
+ */
+struct MxOps MxLocalFileOps = {
+  .magic            = MUTT_LOCAL_FILE,
+  .name             = "file",
+  .is_local         = true,
+  .ac_find          = NULL,
+  .ac_add           = NULL,
+  .mbox_open        = NULL,
+  .mbox_open_append = NULL,
+  .mbox_check       = NULL,
+  .mbox_check_stats = NULL,
+  .mbox_sync        = NULL,
+  .mbox_close       = NULL,
+  .msg_open         = NULL,
+  .msg_open_new     = NULL,
+  .msg_commit       = NULL,
+  .msg_close        = NULL,
+  .msg_padding_size = NULL,
+  .msg_save_hcache  = NULL,
+  .tags_edit        = NULL,
+  .tags_commit      = NULL,
+  .path_probe       = NULL,
+  .path_canon       = NULL,
+  .path_parent      = NULL,
+  .path2_canon      = local_path2_canon,
+  .path2_compare    = local_path2_compare,
+  .path2_parent     = local_path2_parent,
+  .path2_pretty     = local_path2_pretty,
+  .path2_probe      = local_path2_probe,
+  .path2_tidy       = local_path2_tidy,
+};
+
+/**
+ * MxLocalDirOps - Local Directory - Implements ::MxOps
+ */
+struct MxOps MxLocalDirOps = {
+  .magic            = MUTT_LOCAL_DIR,
+  .name             = "directory",
+  .is_local         = true,
+  .ac_find          = NULL,
+  .ac_add           = NULL,
+  .mbox_open        = NULL,
+  .mbox_open_append = NULL,
+  .mbox_check       = NULL,
+  .mbox_check_stats = NULL,
+  .mbox_sync        = NULL,
+  .mbox_close       = NULL,
+  .msg_open         = NULL,
+  .msg_open_new     = NULL,
+  .msg_commit       = NULL,
+  .msg_close        = NULL,
+  .msg_padding_size = NULL,
+  .msg_save_hcache  = NULL,
+  .tags_edit        = NULL,
+  .tags_commit      = NULL,
+  .path_probe       = NULL,
+  .path_canon       = NULL,
+  .path_parent      = NULL,
+  .path2_canon      = local_path2_canon,
+  .path2_compare    = local_path2_compare,
+  .path2_parent     = local_path2_parent,
+  .path2_pretty     = local_path2_pretty,
+  .path2_probe      = local_path2_probe,
+  .path2_tidy       = local_path2_tidy,
+};
+// clang-format on

--- a/local.h
+++ b/local.h
@@ -1,0 +1,31 @@
+/**
+ * @file
+ * Fake mailbox backend for local files and directories
+ *
+ * @authors
+ * Copyright (C) 2020 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MUTT_LOCAL_H
+#define MUTT_LOCAL_H
+
+#include "mx.h"
+
+extern struct MxOps MxLocalFileOps;
+extern struct MxOps MxLocalDirOps;
+
+#endif /* MUTT_LOCAL_H */

--- a/maildir/lib.h
+++ b/maildir/lib.h
@@ -29,6 +29,7 @@
  * | :---------------- | :----------------------- |
  * | maildir/maildir.c | @subpage maildir_maildir |
  * | maildir/mh.c      | @subpage maildir_mh      |
+ * | maildir/path.c    | @subpage maildir_path    |
  * | maildir/shared.c  | @subpage maildir_shared  |
  */
 
@@ -41,6 +42,7 @@
 #include "core/lib.h"
 #include "hcache/lib.h"
 #include "mx.h"
+#include "path.h"
 
 struct Email;
 

--- a/maildir/maildir.c
+++ b/maildir/maildir.c
@@ -49,6 +49,7 @@
 #include "monitor.h"
 #include "muttlib.h"
 #include "mx.h"
+#include "path.h"
 #include "maildir/lib.h"
 #ifdef USE_HCACHE
 #include "hcache/lib.h"
@@ -728,5 +729,11 @@ struct MxOps MxMaildirOps = {
   .path_canon       = maildir_path_canon,
   .path_pretty      = maildir_path_pretty,
   .path_parent      = maildir_path_parent,
+  .path2_canon      = maildir_path2_canon,
+  .path2_compare    = maildir_path2_compare,
+  .path2_parent     = maildir_path2_parent,
+  .path2_pretty     = maildir_path2_pretty,
+  .path2_probe      = maildir_path2_probe,
+  .path2_tidy       = maildir_path2_tidy,
 };
 // clang-format on

--- a/maildir/maildir.c
+++ b/maildir/maildir.c
@@ -727,7 +727,6 @@ struct MxOps MxMaildirOps = {
   .tags_commit      = NULL,
   .path_probe       = maildir_path_probe,
   .path_canon       = maildir_path_canon,
-  .path_pretty      = maildir_path_pretty,
   .path_parent      = maildir_path_parent,
   .path2_canon      = maildir_path2_canon,
   .path2_compare    = maildir_path2_compare,

--- a/maildir/maildir_private.h
+++ b/maildir/maildir_private.h
@@ -28,12 +28,14 @@
 #include <stdio.h>
 #include <sys/types.h>
 #include <time.h>
+#include "core/lib.h"
 
 struct Account;
 struct Buffer;
 struct Email;
 struct Mailbox;
 struct Message;
+struct Path;
 struct Progress;
 
 /**

--- a/maildir/mh.c
+++ b/maildir/mh.c
@@ -834,7 +834,6 @@ struct MxOps MxMhOps = {
   .tags_commit      = NULL,
   .path_probe       = mh_path_probe,
   .path_canon       = maildir_path_canon,
-  .path_pretty      = maildir_path_pretty,
   .path_parent      = maildir_path_parent,
   .path2_canon      = maildir_path2_canon,
   .path2_compare    = maildir_path2_compare,

--- a/maildir/mh.c
+++ b/maildir/mh.c
@@ -49,6 +49,7 @@
 #include "globals.h"
 #include "monitor.h"
 #include "mx.h"
+#include "path.h"
 
 /**
  * mhs_alloc - Allocate more memory for sequences
@@ -835,5 +836,11 @@ struct MxOps MxMhOps = {
   .path_canon       = maildir_path_canon,
   .path_pretty      = maildir_path_pretty,
   .path_parent      = maildir_path_parent,
+  .path2_canon      = maildir_path2_canon,
+  .path2_compare    = maildir_path2_compare,
+  .path2_parent     = maildir_path2_parent,
+  .path2_pretty     = maildir_path2_pretty,
+  .path2_probe      = mh_path2_probe,
+  .path2_tidy       = maildir_path2_tidy,
 };
 // clang-format on

--- a/maildir/path.c
+++ b/maildir/path.c
@@ -1,0 +1,215 @@
+/**
+ * @file
+ * Maildir path manipulations
+ *
+ * @authors
+ * Copyright (C) 2020 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @page maildir_path Maildir path manipulations
+ *
+ * Maildir path manipulations
+ */
+
+#include "config.h"
+#include <limits.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include "mutt/lib.h"
+#include "config/lib.h"
+#include "core/lib.h"
+
+extern char *HomeDir;
+
+/**
+ * mh_probe - Is this an mh Mailbox?
+ * @param path Path to examine
+ * @param st   stat buffer
+ * @retval  0 Success, mh Mailbox
+ * @retval -1 Path not recognised
+ *
+ * **Tests**
+ * - Path must exist
+ * - Path must be a directory
+ * - Path must have a subdirectory, one of:
+ *   - `.mh_sequences`
+ *   - `.xmhcache`
+ *   - `.mew_cache`
+ *   - `.mew-cache`
+ *   - `.sylpheed_cache`
+ *   - `.overview`
+ */
+static int mh_probe(const char *path, const struct stat *st)
+{
+  if (!S_ISDIR(st->st_mode))
+    return -1;
+
+  /* `.overview` isn't an mh folder, but it allows NeoMutt to read Usenet news
+   * from the spool.  */
+  static const char *tests[] = {
+    "%s/.mh_sequences", "%s/.xmhcache",       "%s/.mew_cache",
+    "%s/.mew-cache",    "%s/.sylpheed_cache", "%s/.overview",
+  };
+
+  char tmp[PATH_MAX];
+  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  {
+    snprintf(tmp, sizeof(tmp), tests[i], path);
+    if (access(tmp, F_OK) == 0)
+      return 0;
+  }
+
+  return -1;
+}
+
+/**
+ * maildir_probe - Is this a maildir Mailbox?
+ *
+ * **Tests**
+ * - Path must exist
+ * - Path must be a directory
+ * - Path must have a subdirectory `cur`
+ *
+ * @note `dir/new` and `dir/tmp` aren't checked
+ */
+static int maildir_probe(const char *path, const struct stat *st)
+{
+  if (!S_ISDIR(st->st_mode))
+    return -1;
+
+  char cur[PATH_MAX];
+  snprintf(cur, sizeof(cur), "%s/cur", path);
+
+  struct stat stc;
+  if ((stat(cur, &stc) != 0) || !S_ISDIR(stc.st_mode))
+    return -1;
+
+  return 0;
+}
+
+/**
+ * maildir_path2_canon - Canonicalise a Mailbox path - Implements MxOps::path2_canon()
+ */
+int maildir_path2_canon(struct Path *path)
+{
+  if (!mutt_path_canon2(path->orig, &path->canon))
+    return -1;
+
+  path->flags |= MPATH_CANONICAL;
+  return 0;
+}
+
+/**
+ * maildir_path2_compare - Compare two Mailbox paths - Implements MxOps::path2_compare()
+ */
+int maildir_path2_compare(struct Path *path1, struct Path *path2)
+{
+  int rc = mutt_str_strcmp(path1->canon, path2->canon);
+  if (rc < 0)
+    return -1;
+  if (rc > 0)
+    return 1;
+  return 0;
+}
+
+/**
+ * maildir_path2_parent - Find the parent of a Mailbox path - Implements MxOps::path2_parent()
+ */
+int maildir_path2_parent(const struct Path *path, struct Path **parent)
+{
+  if (path->orig[1] == '\0')
+    return -1;
+
+  char *par_dir = mutt_path_dirname(path->orig);
+
+  struct stat st = { 0 };
+  stat(par_dir, &st);
+  int rc;
+  if (path->type == MUTT_MAILDIR)
+    rc = maildir_probe(par_dir, &st);
+  else
+    rc = mh_probe(par_dir, &st);
+  if (rc != 0)
+  {
+    FREE(&par_dir);
+    return -1;
+  }
+
+  *parent = mutt_path_new();
+  (*parent)->orig = par_dir;
+  (*parent)->type = path->type;
+  (*parent)->flags = MPATH_RESOLVED | MPATH_TIDY;
+  return 0;
+}
+
+/**
+ * maildir_path2_pretty - Abbreviate a Mailbox path - Implements MxOps::path2_pretty()
+ */
+int maildir_path2_pretty(const struct Path *path, const char *folder, char **pretty)
+{
+  if (mutt_path2_abbr_folder(path->orig, folder, pretty))
+    return 1;
+
+  if (mutt_path2_pretty(path->orig, HomeDir, pretty))
+    return 1;
+
+  *pretty = mutt_str_strdup(path->orig);
+  return 0;
+}
+
+/**
+ * maildir_path2_probe - Does this Mailbox type recognise this path? - Implements MxOps::path2_probe()
+ */
+int maildir_path2_probe(struct Path *path, const struct stat *st)
+{
+  if (maildir_probe(path->orig, st) != 0)
+    return -1;
+
+  path->type = MUTT_MAILDIR;
+  return 0;
+}
+
+/**
+ * maildir_path2_tidy - Tidy a Mailbox path - Implements MxOps::path2_tidy()
+ */
+int maildir_path2_tidy(struct Path *path)
+{
+  char *tidy = mutt_path_tidy2(path->orig, true);
+  if (!tidy)
+    return -1; // LCOV_EXCL_LINE
+
+  FREE(&path->orig);
+  path->orig = tidy;
+  tidy = NULL;
+
+  path->flags |= MPATH_TIDY;
+  return 0;
+}
+
+/**
+ * mh_path2_probe - Does this Mailbox type recognise this path? - Implements MxOps::path2_probe()
+ */
+int mh_path2_probe(struct Path *path, const struct stat *st)
+{
+  if (mh_probe(path->orig, st) != 0)
+    return -1;
+
+  path->type = MUTT_MH;
+  return 0;
+}

--- a/maildir/path.h
+++ b/maildir/path.h
@@ -1,0 +1,37 @@
+/**
+ * @file
+ * Maildir path manipulations
+ *
+ * @authors
+ * Copyright (C) 2020 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MUTT_MAILDIR_PATH_H
+#define MUTT_MAILDIR_PATH_H
+
+struct Path;
+struct stat;
+
+int maildir_path2_canon  (struct Path *path);
+int maildir_path2_compare(struct Path *path1, struct Path *path2);
+int maildir_path2_parent (const struct Path *path, struct Path **parent);
+int maildir_path2_pretty (const struct Path *path, const char *folder, char **pretty);
+int maildir_path2_probe  (struct Path *path, const struct stat *st);
+int maildir_path2_tidy   (struct Path *path);
+int mh_path2_probe       (struct Path *path, const struct stat *st);
+
+#endif /* MUTT_MAILDIR_PATH_H */

--- a/maildir/shared.c
+++ b/maildir/shared.c
@@ -1654,23 +1654,6 @@ int maildir_path_canon(char *buf, size_t buflen)
 }
 
 /**
- * maildir_path_pretty - Abbreviate a Mailbox path - Implements MxOps::path_pretty()
- */
-int maildir_path_pretty(char *buf, size_t buflen, const char *folder)
-{
-  if (!buf)
-    return -1;
-
-  if (mutt_path_abbr_folder(buf, buflen, folder))
-    return 0;
-
-  if (mutt_path_pretty(buf, buflen, HomeDir, false))
-    return 0;
-
-  return -1;
-}
-
-/**
  * maildir_path_parent - Find the parent of a Mailbox path - Implements MxOps::path_parent()
  */
 int maildir_path_parent(char *buf, size_t buflen)

--- a/main.c
+++ b/main.c
@@ -746,6 +746,9 @@ int main(int argc, char *argv[], char *envp[])
 
   if (batch_mode)
   {
+#ifdef USE_DEVEL_GRAPHVIZ
+    dump_graphviz("batch");
+#endif
     goto main_ok; // TEST22: neomutt -B
   }
 

--- a/main.c
+++ b/main.c
@@ -723,14 +723,10 @@ int main(int argc, char *argv[], char *envp[])
 
     mutt_buffer_strcpy(fpath, C_Folder);
     mutt_buffer_expand_path(fpath);
-    bool skip = false;
-#ifdef USE_IMAP
-    /* we're not connected yet - skip mail folder creation */
-    skip |= (imap_path_probe(mutt_b2s(fpath), NULL) == MUTT_IMAP);
-#endif
-#ifdef USE_NNTP
-    skip |= (nntp_path_probe(mutt_b2s(fpath), NULL) == MUTT_NNTP);
-#endif
+    enum MailboxType type = mx_path_probe(mutt_b2s(fpath));
+    //QWQ use MxOps.is_local
+    //QWQ or drop create completely
+    bool skip = (type == MUTT_IMAP) || (type == MUTT_NNTP) || (type == MUTT_NOTMUCH);
     if (!skip && (stat(mutt_b2s(fpath), &sb) == -1) && (errno == ENOENT))
     {
       char msg2[256];

--- a/main.c
+++ b/main.c
@@ -1113,7 +1113,7 @@ int main(int argc, char *argv[], char *envp[])
         // Check if C_Spoolfile corresponds a mailboxes' description.
         struct Mailbox *m_desc = mailbox_find_name(C_Spoolfile);
         if (m_desc)
-          mutt_buffer_strcpy(&folder, m_desc->realpath);
+          mutt_buffer_strcpy(&folder, m_desc->path->canon);
         else
           mutt_buffer_strcpy(&folder, C_Spoolfile);
       }

--- a/main.c
+++ b/main.c
@@ -73,6 +73,7 @@
 #include "protos.h"
 #include "send.h"
 #include "sendlib.h"
+#include "tracker.h"
 #include "version.h"
 #include "ncrypt/lib.h"
 #ifdef ENABLE_NLS
@@ -1155,7 +1156,21 @@ int main(int argc, char *argv[], char *envp[])
     notify_send(NeoMutt->notify, NT_GLOBAL, NT_GLOBAL_STARTUP, NULL);
 
     repeat_error = true;
-    struct Mailbox *m = mx_path_resolve(mutt_b2s(&folder), C_Folder);
+    struct Path *path = mutt_path_new();
+    path->orig = mutt_buffer_strdup(&folder);
+    mx_path2_resolve(path, C_Folder);
+    struct Mailbox *m = mx_path2_find(path);
+    if (m)
+    {
+      mutt_path_free(&path);
+    }
+    else
+    {
+      m = mailbox_new(path);
+      m->mx_ops = mx_get_ops(m->magic);
+      m->flags = MB_HIDDEN;
+      path = NULL;
+    }
     Context = mx_mbox_open(m, ((flags & MUTT_CLI_RO) || C_ReadOnly) ? MUTT_READONLY : MUTT_OPEN_NO_FLAGS);
     if (!Context)
     {

--- a/main.c
+++ b/main.c
@@ -1155,7 +1155,7 @@ int main(int argc, char *argv[], char *envp[])
     notify_send(NeoMutt->notify, NT_GLOBAL, NT_GLOBAL_STARTUP, NULL);
 
     repeat_error = true;
-    struct Mailbox *m = mx_path_resolve(mutt_b2s(&folder));
+    struct Mailbox *m = mx_path_resolve(mutt_b2s(&folder), C_Folder);
     Context = mx_mbox_open(m, ((flags & MUTT_CLI_RO) || C_ReadOnly) ? MUTT_READONLY : MUTT_OPEN_NO_FLAGS);
     if (!Context)
     {

--- a/main.c
+++ b/main.c
@@ -1137,8 +1137,13 @@ int main(int argc, char *argv[], char *envp[])
 #endif
       mutt_buffer_expand_path(&folder);
 
-    mutt_str_replace(&CurrentFolder, mutt_b2s(&folder));
-    mutt_str_replace(&LastFolder, mutt_b2s(&folder));
+    mutt_path_free(&CurrentFolder);
+    CurrentFolder = mutt_path_new();
+    CurrentFolder->orig = mutt_buffer_strdup(&folder);
+    mx_path2_probe(CurrentFolder);
+
+    mutt_path_free(&LastFolder);
+    LastFolder = mutt_path_dup(CurrentFolder);
 
     if (flags & MUTT_CLI_IGNORE)
     {

--- a/mbox/lib.h
+++ b/mbox/lib.h
@@ -29,6 +29,7 @@
  * | File        | Description        |
  * | :---------- | :----------------- |
  * | mbox/mbox.c | @subpage mbox_mbox |
+ * | mbox/path.c | @subpage mbox_path |
  */
 
 #ifndef MUTT_MBOX_LIB_H
@@ -39,6 +40,7 @@
 #include <time.h>
 #include "core/lib.h"
 #include "mx.h"
+#include "path.h"
 
 struct stat;
 

--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -1551,7 +1551,7 @@ static int mbox_mbox_close(struct Mailbox *m)
   mutt_file_fclose(&adata->fp);
 
   /* fix up the times so mailbox won't get confused */
-  if (m->peekonly && !mutt_buffer_is_empty(&m->pathbuf) &&
+  if (m->peekonly && m->path->orig &&
       (mutt_file_timespec_compare(&m->mtime, &adata->atime) > 0))
   {
 #ifdef HAVE_UTIMENSAT

--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -1727,23 +1727,6 @@ static int mbox_path_canon(char *buf, size_t buflen)
 }
 
 /**
- * mbox_path_pretty - Abbreviate a Mailbox path - Implements MxOps::path_pretty()
- */
-static int mbox_path_pretty(char *buf, size_t buflen, const char *folder)
-{
-  if (!buf)
-    return -1;
-
-  if (mutt_path_abbr_folder(buf, buflen, folder))
-    return 0;
-
-  if (mutt_path_pretty(buf, buflen, HomeDir, false))
-    return 0;
-
-  return -1;
-}
-
-/**
  * mbox_path_parent - Find the parent of a Mailbox path - Implements MxOps::path_parent()
  */
 static int mbox_path_parent(char *buf, size_t buflen)
@@ -1868,7 +1851,6 @@ struct MxOps MxMboxOps = {
   .tags_commit      = NULL,
   .path_probe       = mbox_path_probe,
   .path_canon       = mbox_path_canon,
-  .path_pretty      = mbox_path_pretty,
   .path_parent      = mbox_path_parent,
   .path2_canon      = mbox_path2_canon,
   .path2_compare    = mbox_path2_compare,
@@ -1903,7 +1885,6 @@ struct MxOps MxMmdfOps = {
   .tags_commit      = NULL,
   .path_probe       = mbox_path_probe,
   .path_canon       = mbox_path_canon,
-  .path_pretty      = mbox_path_pretty,
   .path_parent      = mbox_path_parent,
   .path2_canon      = mbox_path2_canon,
   .path2_compare    = mbox_path2_compare,

--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -53,6 +53,7 @@
 #include "mutt_header.h"
 #include "muttlib.h"
 #include "mx.h"
+#include "path.h"
 #include "progress.h"
 #include "protos.h"
 #include "sort.h"
@@ -1869,6 +1870,12 @@ struct MxOps MxMboxOps = {
   .path_canon       = mbox_path_canon,
   .path_pretty      = mbox_path_pretty,
   .path_parent      = mbox_path_parent,
+  .path2_canon      = mbox_path2_canon,
+  .path2_compare    = mbox_path2_compare,
+  .path2_parent     = mbox_path2_parent,
+  .path2_pretty     = mbox_path2_pretty,
+  .path2_probe      = mbox_path2_probe,
+  .path2_tidy       = mbox_path2_tidy,
 };
 
 /**
@@ -1898,5 +1905,11 @@ struct MxOps MxMmdfOps = {
   .path_canon       = mbox_path_canon,
   .path_pretty      = mbox_path_pretty,
   .path_parent      = mbox_path_parent,
+  .path2_canon      = mbox_path2_canon,
+  .path2_compare    = mbox_path2_compare,
+  .path2_parent     = mbox_path2_parent,
+  .path2_pretty     = mbox_path2_pretty,
+  .path2_probe      = mbox_path2_probe,
+  .path2_tidy       = mbox_path2_tidy,
 };
 // clang-format on

--- a/mbox/path.c
+++ b/mbox/path.c
@@ -1,0 +1,175 @@
+/**
+ * @file
+ * Mbox path manipulations
+ *
+ * @authors
+ * Copyright (C) 2020 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @page mbox_path Mbox path manipulations
+ *
+ * Mbox path manipulations
+ */
+
+#include "config.h"
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <utime.h>
+#include "config/lib.h"
+#include "email/lib.h"
+#include "core/lib.h"
+#include "lib.h"
+#include "globals.h"
+
+extern char *HomeDir;
+
+/**
+ * mbox_path2_canon - Canonicalise a Mailbox path - Implements MxOps::path2_canon()
+ */
+int mbox_path2_canon(struct Path *path)
+{
+  if (!mutt_path_canon2(path->orig, &path->canon))
+    return -1;
+
+  path->flags |= MPATH_CANONICAL;
+  return 0;
+}
+
+/**
+ * mbox_path2_compare - Compare two Mailbox paths - Implements MxOps::path2_compare()
+ */
+int mbox_path2_compare(struct Path *path1, struct Path *path2)
+{
+  int rc = mutt_str_strcmp(path1->canon, path2->canon);
+  if (rc < 0)
+    return -1;
+  if (rc > 0)
+    return 1;
+  return 0;
+}
+
+/**
+ * mbox_path2_parent - Find the parent of a Mailbox path - Implements MxOps::path2_parent()
+ * @retval -1 Mbox mailbox doesn't have a parent
+ */
+int mbox_path2_parent(const struct Path *path, struct Path **parent)
+{
+  return -1;
+}
+
+/**
+ * mbox_path2_pretty - Abbreviate a Mailbox path - Implements MxOps::path2_pretty()
+ */
+int mbox_path2_pretty(const struct Path *path, const char *folder, char **pretty)
+{
+  if (mutt_path2_abbr_folder(path->orig, folder, pretty))
+    return 1;
+
+  if (mutt_path2_pretty(path->orig, HomeDir, pretty))
+    return 1;
+
+  *pretty = mutt_str_strdup(path->orig);
+  return 0;
+}
+
+/**
+ * mbox_path2_probe - Does this Mailbox type recognise this path? - Implements MxOps::path2_probe()
+ *
+ * **Tests**
+ * - Path must exist
+ * - Path must be a file
+ * - File may be empty
+ * - File may begin with "From " -- mbox format
+ * - File may begin with 4 x Ctrl-A -- mmdf format
+ */
+int mbox_path2_probe(struct Path *path, const struct stat *st)
+{
+  if (S_ISDIR(st->st_mode))
+    return -1;
+
+  if (st->st_size == 0) // Accept an empty file as a valid mbox
+  {
+    path->type = MUTT_MBOX;
+    return 0;
+  }
+
+  FILE *fp = fopen(path->orig, "r");
+  if (!fp)
+    return -1;
+
+  int ch;
+  while ((ch = fgetc(fp)) != EOF)
+  {
+    /* Some mailbox creation tools erroneously append a blank line to
+     * a file before appending a mail message.  This allows neomutt to
+     * detect magic for and thus open those files. */
+    if ((ch != '\n') && (ch != '\r'))
+    {
+      ungetc(ch, fp);
+      break;
+    }
+  }
+
+  enum MailboxType magic = MUTT_UNKNOWN;
+  char tmp[256];
+  if (fgets(tmp, sizeof(tmp), fp))
+  {
+    if (mutt_str_startswith(tmp, "From ", CASE_MATCH))
+      magic = MUTT_MBOX;
+    else if (mutt_str_strcmp(tmp, MMDF_SEP) == 0)
+      magic = MUTT_MMDF;
+  }
+  mutt_file_fclose(&fp);
+
+  // Restore the times as the file was not really accessed.
+  // Detection of "new mail" depends on those times being set correctly.
+#ifdef HAVE_UTIMENSAT
+  struct timespec ts[2];
+  mutt_file_get_stat_timespec(&ts[0], &st, MUTT_STAT_ATIME);
+  mutt_file_get_stat_timespec(&ts[1], &st, MUTT_STAT_MTIME);
+  utimensat(0, path, ts, 0);
+#else
+  struct utimbuf times;
+  times.actime = st->st_atime;
+  times.modtime = st->st_mtime;
+  utime(path->orig, &times);
+#endif
+
+  path->type = magic;
+  if (path->type > MUTT_UNKNOWN)
+    return 0;
+  return -1;
+}
+
+/**
+ * mbox_path2_tidy - Tidy a Mailbox path - Implements MxOps::path2_tidy()
+ */
+int mbox_path2_tidy(struct Path *path)
+{
+  char *tidy = mutt_path_tidy2(path->orig, false);
+  if (!tidy)
+    return -1; // LCOV_EXCL_LINE
+
+  FREE(&path->orig);
+  path->orig = tidy;
+  tidy = NULL;
+
+  path->flags |= MPATH_TIDY;
+  return 0;
+}

--- a/mbox/path.h
+++ b/mbox/path.h
@@ -1,0 +1,36 @@
+/**
+ * @file
+ * Mbox path manipulations
+ *
+ * @authors
+ * Copyright (C) 2020 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MUTT_MBOX_PATH_H
+#define MUTT_MBOX_PATH_H
+
+struct Path;
+struct stat;
+
+int mbox_path2_canon  (struct Path *path);
+int mbox_path2_compare(struct Path *path1, struct Path *path2);
+int mbox_path2_parent (const struct Path *path, struct Path **parent);
+int mbox_path2_pretty (const struct Path *path, const char *folder, char **pretty);
+int mbox_path2_probe  (struct Path *path, const struct stat *st);
+int mbox_path2_tidy   (struct Path *path);
+
+#endif /* MUTT_MBOX_PATH_H */

--- a/monitor.c
+++ b/monitor.c
@@ -333,12 +333,12 @@ static enum ResolveResult monitor_resolve(struct MonitorInfo *info, struct Mailb
   if (m)
   {
     info->magic = m->magic;
-    info->path = m->realpath;
+    info->path = m->path->canon;
   }
   else if (Context && Context->mailbox)
   {
     info->magic = Context->mailbox->magic;
-    info->path = Context->mailbox->realpath;
+    info->path = Context->mailbox->path->canon;
   }
   else
   {
@@ -553,7 +553,7 @@ int mutt_monitor_remove(struct Mailbox *m)
     }
     else
     {
-      if (mailbox_find(Context->mailbox->realpath))
+      if (mailbox_find(Context->mailbox->path->canon))
       {
         rc = 1;
         goto cleanup;

--- a/mutt/hash.c
+++ b/mutt/hash.c
@@ -251,9 +251,14 @@ static void union_hash_delete(struct Hash *table, union HashKey key, const void 
     {
       *last = he->next;
       if (table->free_hdata)
+      {
         table->free_hdata(he->type, he->data, table->hdata);
+        he->data = NULL;
+      }
       if (table->strdup_keys)
         FREE(&he->key.strkey);
+      else
+        he->key.strkey = NULL;
       FREE(&he);
 
       he = *last;

--- a/mutt/notify.c
+++ b/mutt/notify.c
@@ -34,15 +34,6 @@
 #include "queue.h"
 
 /**
- * struct Notify - Notification API
- */
-struct Notify
-{
-  struct Notify *parent;
-  struct ObserverList observers;
-};
-
-/**
  * notify_new - Create a new notifications handler
  * @retval ptr New notification handler
  */

--- a/mutt/notify.h
+++ b/mutt/notify.h
@@ -27,7 +27,14 @@
 #include "notify_type.h"
 #include "observer.h"
 
-struct Notify;
+/**
+ * struct Notify - Notification API
+ */
+struct Notify
+{
+  struct Notify *parent;
+  struct ObserverList observers;
+};
 
 struct Notify *notify_new(void);
 void notify_free(struct Notify **ptr);

--- a/mutt/path.c
+++ b/mutt/path.c
@@ -43,6 +43,8 @@
 #include "message.h"
 #include "string2.h"
 
+extern char *HomeDir;
+
 /**
  * mutt_path_tidy_slash - Remove unnecessary slashes and dots
  * @param[in,out] buf    Path to modify
@@ -209,6 +211,32 @@ bool mutt_path_pretty(char *buf, size_t buflen, const char *homedir, bool is_dir
 }
 
 /**
+ * mutt_path2_pretty - Tidy a filesystem path
+ * @param[in]  path    Path to make pretty
+ * @param[in]  homedir Folder to use for abbrevi
+ * @param[out] pretty  Resulting pretty path
+ * @retval true If path was made pretty
+ *
+ * @note The caller must free the returned pretty string
+ */
+bool mutt_path2_pretty(const char *path, const char *homedir, char **pretty)
+{
+  if (!path || !homedir || !pretty)
+    return false;
+
+  const size_t flen = strlen(homedir);
+  if (flen < 2)
+    return false;
+
+  if (mutt_str_startswith(path, homedir, CASE_MATCH) != flen)
+    return false;
+
+  *pretty = mutt_str_strdup(path + flen - 1);
+  *pretty[0] = '~';
+  return true;
+}
+
+/**
  * mutt_path_tilde - Expand '~' in a path
  * @param buf     Path to modify
  * @param buflen  Length of the buffer
@@ -222,8 +250,10 @@ bool mutt_path_pretty(char *buf, size_t buflen, const char *homedir, bool is_dir
  */
 bool mutt_path_tilde(char *buf, size_t buflen, const char *homedir)
 {
-  if (!buf || (buf[0] != '~'))
+  if (!buf)
     return false;
+  if (buf[0] != '~')
+    return true;
 
   char result[PATH_MAX] = { 0 };
   char *dir = NULL;
@@ -515,6 +545,35 @@ bool mutt_path_abbr_folder(char *buf, size_t buflen, const char *folder)
 }
 
 /**
+ * mutt_path2_abbr_folder - Create a folder abbreviation
+ *
+ * Abbreviate a path using '+' to represent the 'folder'.
+ * If the folder path is passed, it won't be abbreviated to just '+'
+ */
+bool mutt_path2_abbr_folder(const char *path, const char *folder, char **abbr)
+{
+  if (!path || !folder || !abbr)
+    return false;
+
+  // folder matches the start of path
+  size_t flen = strlen(folder);
+  if (mutt_str_startswith(path, folder, CASE_MATCH) != flen)
+    return false;
+
+  if (flen != 0) // Skip the path delimiter
+    flen++;
+
+  const size_t rlen = strlen(path + flen);
+  if (rlen == 0)
+    return false;
+
+  *abbr = mutt_mem_malloc(rlen + 2);
+  mutt_str_strfcpy(*abbr + 1, path + flen, rlen + 1);
+  *abbr[0] = '+';
+  return true;
+}
+
+/**
  * mutt_path_escape - Escapes single quotes in a path for a command string
  * @param src the path to escape
  * @retval ptr The escaped string
@@ -578,4 +637,93 @@ const char *mutt_path_getcwd(struct Buffer *cwd)
     mutt_buffer_reset(cwd);
 
   return retval;
+}
+
+/**
+ * mutt_path_to_absolute2 - Convert relative filepath to an absolute path
+ * @param path      Relative path
+ * @param path_len  Length of path buffer
+ * @param reference Absolute path that @a path is relative to
+ * @retval true  Success
+ * @retval false Failure
+ *
+ * Use POSIX functions to convert a path to absolute, relatively to another path
+ *
+ * @note @a path should be at least of PATH_MAX length
+ */
+bool mutt_path_to_absolute2(char *path, size_t path_len, const char *reference)
+{
+  if (!path || !reference)
+    return false;
+
+  /* if path is already absolute, don't do anything */
+  if ((strlen(path) > 1) && (path[0] == '/'))
+    return true;
+
+  char joined[PATH_MAX];
+  if (!mutt_path_concat(joined, reference, path, sizeof(joined)))
+    return false;
+
+  mutt_str_strfcpy(path, joined, path_len);
+  return true;
+}
+
+/**
+ * mutt_path_tidy2 - Tidy a local filesystem path
+ * @param orig   Path to modify
+ * @param is_dir true if the path is a directory
+ * @retval ptr  Success, tidied Path
+ * @retval NULL Error
+ *
+ * @note The caller must free the returned string
+ */
+char *mutt_path_tidy2(const char *orig, bool is_dir)
+{
+  if (!orig)
+    return NULL;
+
+  char *result = NULL;
+  char path[PATH_MAX] = { 0 };
+  mutt_str_strfcpy(path, orig, sizeof(path));
+
+  struct Buffer cwd = mutt_buffer_make(PATH_MAX);
+  if (!mutt_path_getcwd(&cwd))
+    goto done;
+
+  if (!mutt_path_tilde(path, sizeof(path), HomeDir))
+    goto done;
+
+  if (!mutt_path_to_absolute2(path, sizeof(path), cwd.data))
+    goto done;
+
+  if (!mutt_path_tidy_slash(path, true))
+    goto done;
+
+  if (!mutt_path_tidy_dotdot(path))
+    goto done;
+
+  result = mutt_str_strdup(path);
+
+done:
+  mutt_buffer_dealloc(&cwd);
+  return result;
+}
+
+/**
+ * mutt_path_canon2 - Create the canonical version of a path
+ * @param[in]  orig    Path to canonicalise
+ * @param[out] canon   New canonical path
+ * @retval true Success
+ */
+bool mutt_path_canon2(const char *orig, char **canon)
+{
+  if (!orig || !canon || *canon)
+    return false;
+
+  char real[PATH_MAX] = { 0 };
+  if (!realpath(orig, real))
+    return false;
+
+  *canon = mutt_str_strdup(real);
+  return true;
 }

--- a/mutt/path.h
+++ b/mutt/path.h
@@ -29,16 +29,20 @@
 struct Buffer;
 
 bool        mutt_path_abbr_folder(char *buf, size_t buflen, const char *folder);
+bool        mutt_path2_abbr_folder(const char *path, const char *folder, char **abbr);
 const char *mutt_path_basename(const char *f);
 bool        mutt_path_canon(char *buf, size_t buflen, const char *homedir, bool is_dir);
+bool        mutt_path_canon2(const char *orig, char **canon);
 char *      mutt_path_concat(char *d, const char *dir, const char *fname, size_t l);
 char *      mutt_path_dirname(const char *path);
 char *      mutt_path_escape(const char *src);
 const char *mutt_path_getcwd(struct Buffer *cwd);
 bool        mutt_path_parent(char *buf, size_t buflen);
 bool        mutt_path_pretty(char *buf, size_t buflen, const char *homedir, bool is_dir);
+bool        mutt_path2_pretty(const char *path, const char *homedir, char **pretty);
 size_t      mutt_path_realpath(char *buf);
 bool        mutt_path_tidy(char *buf, bool is_dir);
+char *      mutt_path_tidy2(const char *orig, bool is_dir);
 bool        mutt_path_tidy_dotdot(char *buf);
 bool        mutt_path_tidy_slash(char *buf, bool is_dir);
 bool        mutt_path_tilde(char *buf, size_t buflen, const char *homedir);

--- a/mutt_account.c
+++ b/mutt_account.c
@@ -30,8 +30,13 @@
 #include <stdio.h>
 #include "mutt/lib.h"
 #include "email/lib.h"
+#include "core/lib.h"
 #include "conn/lib.h"
 #include "mutt_account.h"
+#include "globals.h"
+#include "init.h"
+#include "options.h"
+#include "tracker.h"
 
 /**
  * mutt_account_fromurl - Fill ConnAccount with information from url
@@ -131,4 +136,61 @@ void mutt_account_tourl(struct ConnAccount *cac, struct Url *url)
     url->user = cac->user;
   if (cac->flags & MUTT_ACCT_PASS)
     url->pass = cac->pass;
+}
+
+/**
+ * mutt_parse_account - Parse the 'account' command - Implements Command::parse()
+ */
+enum CommandResult mutt_parse_account(struct Buffer *buf, struct Buffer *s,
+                                      unsigned long data, struct Buffer *err)
+{
+  /* Go back to the default account */
+  if (!MoreArgs(s))
+  {
+    ct_set_account(NULL);
+    return MUTT_CMD_SUCCESS;
+  }
+
+  mutt_extract_token(buf, s, MUTT_TOKEN_NO_FLAGS);
+
+  struct Account *a = account_find(buf->data);
+  if (!a)
+  {
+    a = account_new(buf->data, NeoMutt->sub);
+    neomutt_account_add(NeoMutt, a);
+  }
+
+  /* Set the current account, nothing more to do */
+  if (!MoreArgs(s))
+  {
+    ct_set_account(a);
+    return MUTT_CMD_SUCCESS;
+  }
+
+  struct Buffer token = { 0 };
+
+  /* Temporarily alter the current account */
+  ct_push_top();
+  ct_set_account(a);
+
+  /* Process the rest of the line */
+  enum CommandResult rc = mutt_parse_rc_line(s->dptr, &token, err);
+  if (rc == MUTT_CMD_ERROR)
+    mutt_error("%s", err->data);
+
+  ct_pop(); // Restore the previous account
+  mutt_buffer_reset(s);
+
+  FREE(&token.data);
+  return rc;
+}
+
+/**
+ * mutt_parse_unaccount - Parse the 'unaccount' command - Implements Command::parse()
+ */
+enum CommandResult mutt_parse_unaccount(struct Buffer *buf, struct Buffer *s,
+                                        unsigned long data, struct Buffer *err)
+{
+  mutt_message("%s", s->data);
+  return MUTT_CMD_SUCCESS;
 }

--- a/mutt_account.h
+++ b/mutt_account.h
@@ -25,6 +25,10 @@
 #ifndef MUTT_MUTT_ACCOUNT_H
 #define MUTT_MUTT_ACCOUNT_H
 
+#include <stdbool.h>
+#include <stdint.h>
+#include "mutt_commands.h"
+
 struct ConnAccount;
 struct Url;
 
@@ -42,5 +46,8 @@ enum AccountType
 
 int   mutt_account_fromurl(struct ConnAccount *account, const struct Url *url);
 void  mutt_account_tourl  (struct ConnAccount *account, struct Url *url);
+
+enum CommandResult mutt_parse_account  (struct Buffer *buf, struct Buffer *s, unsigned long data, struct Buffer *err);
+enum CommandResult mutt_parse_unaccount(struct Buffer *buf, struct Buffer *s, unsigned long data, struct Buffer *err);
 
 #endif /* MUTT_MUTT_ACCOUNT_H */

--- a/mutt_attach.c
+++ b/mutt_attach.c
@@ -855,7 +855,7 @@ int mutt_save_attachment(FILE *fp, struct Body *m, const char *path,
         return -1;
       if (!fgets(buf, sizeof(buf), fp))
         return -1;
-      struct Mailbox *m_att = mx_path_resolve(path);
+      struct Mailbox *m_att = mx_path_resolve(path, C_Folder);
       struct Context *ctx = mx_mbox_open(m_att, MUTT_APPEND | MUTT_QUIET);
       if (!ctx)
       {

--- a/mutt_commands.c
+++ b/mutt_commands.c
@@ -37,6 +37,8 @@
 #include "mutt_commands.h"
 #include "command_parse.h"
 #include "globals.h"
+#include "init.h"
+#include "mutt_account.h"
 #include "hook.h"
 #include "keymap.h"
 #include "mutt_lua.h"
@@ -45,6 +47,7 @@
 // clang-format off
 const struct Command Commands[] = {
 #ifdef USE_SOCKET
+  { "account",             mutt_parse_account,     0 },
   { "account-hook",        mutt_parse_hook,        MUTT_ACCOUNT_HOOK },
 #endif
   { "alias",               parse_alias,            0 },
@@ -121,6 +124,7 @@ const struct Command Commands[] = {
   { "tag-transforms",      parse_tag_transforms,   0 },
   { "timeout-hook",        mutt_parse_hook,        MUTT_TIMEOUT_HOOK | MUTT_GLOBAL_HOOK },
   { "toggle",              parse_set,              MUTT_SET_INV },
+  { "unaccount",           mutt_parse_unaccount,   0 },
   { "unalias",             parse_unalias,          0 },
   { "unalternates",        parse_unalternates,     0 },
   { "unalternative_order", parse_unstailq,         IP &AlternativeOrderList },

--- a/mutt_config.c
+++ b/mutt_config.c
@@ -1757,7 +1757,7 @@ struct ConfigDef MuttVars[] = {
   ** run on every connection attempt that uses the OAUTHBEARER authentication
   ** mechanism.  See "$oauth" for details.
   */
-  { "imap_pass", DT_STRING|DT_SENSITIVE, &C_ImapPass, 0 },
+  { "imap_pass", DT_STRING|DT_SENSITIVE|DT_INHERIT_ACC, &C_ImapPass, 0 },
   /*
   ** .pp
   ** Specifies the password for your IMAP account.  If \fIunset\fP, NeoMutt will
@@ -1833,7 +1833,7 @@ struct ConfigDef MuttVars[] = {
   ** server which are out of the users' hands, you may wish to suppress
   ** them at some point.
   */
-  { "imap_user", DT_STRING|DT_SENSITIVE, &C_ImapUser, 0 },
+  { "imap_user", DT_STRING|DT_SENSITIVE|DT_INHERIT_ACC, &C_ImapUser, 0 },
   /*
   ** .pp
   ** The name of the user whose mail you intend to access on the IMAP

--- a/mutt_config.c
+++ b/mutt_config.c
@@ -1178,7 +1178,7 @@ struct ConfigDef MuttVars[] = {
   ** .pp
   ** If set, flagged messages can't be deleted.
   */
-  { "folder", DT_STRING|DT_MAILBOX, &C_Folder, IP "~/Mail" },
+  { "folder", DT_STRING|DT_MAILBOX|DT_INHERIT_ACC, &C_Folder, IP "~/Mail" },
   /*
   ** .pp
   ** Specifies the default location of your mailboxes.  A "+" or "=" at the
@@ -1887,7 +1887,7 @@ struct ConfigDef MuttVars[] = {
   ** This option is a format string, please see the description of
   ** $$index_format for supported \fCprintf(3)\fP-style sequences.
   */
-  { "index_format", DT_STRING|DT_NOT_EMPTY|R_INDEX|R_PAGER, &C_IndexFormat, IP "%4C %Z %{%b %d} %-15.15L (%?l?%4l&%4c?) %s" },
+  { "index_format", DT_STRING|DT_NOT_EMPTY|R_INDEX|R_PAGER|DT_INHERIT_ACC|DT_INHERIT_MBOX, &C_IndexFormat, IP "%4C %Z %{%b %d} %-15.15L (%?l?%4l&%4c?) %s" },
   /*
   ** .pp
   ** This variable allows you to customize the message index display to
@@ -4688,7 +4688,7 @@ struct ConfigDef MuttVars[] = {
   ** When \fIset\fP, the internal-pager will pad blank lines to the bottom of the
   ** screen with a tilde ("~").
   */
-  { "time_inc", DT_NUMBER|DT_NOT_NEGATIVE, &C_TimeInc, 0 },
+  { "time_inc", DT_NUMBER|DT_NOT_NEGATIVE|DT_INHERIT_ACC|DT_INHERIT_MBOX, &C_TimeInc, 0 },
   /*
   ** .pp
   ** Along with $$read_inc, $$write_inc, and $$net_inc, this

--- a/mutt_mailbox.c
+++ b/mutt_mailbox.c
@@ -100,7 +100,7 @@ static void mailbox_check(struct Mailbox *m_cur, struct Mailbox *m_check,
   }
 
   /* check to see if the folder is the currently selected folder before polling */
-  if (!m_cur || mutt_buffer_is_empty(&m_cur->pathbuf) ||
+  if (!m_cur || !m_cur->path->orig ||
       (((m_check->magic == MUTT_IMAP) || (m_check->magic == MUTT_NNTP) ||
         (m_check->magic == MUTT_NOTMUCH) || (m_check->magic == MUTT_POP)) ?
            (mutt_str_strcmp(mailbox_path(m_check), mailbox_path(m_cur)) != 0) :
@@ -120,7 +120,7 @@ static void mailbox_check(struct Mailbox *m_cur, struct Mailbox *m_check,
       default:; /* do nothing */
     }
   }
-  else if (C_CheckMboxSize && m_cur && mutt_buffer_is_empty(&m_cur->pathbuf))
+  else if (C_CheckMboxSize && m_cur && !m_cur->path->orig)
     m_check->size = (off_t) sb.st_size; /* update the size of current folder */
 
 #ifdef USE_SIDEBAR
@@ -330,7 +330,10 @@ void mutt_mailbox_next_buffer(struct Mailbox *m_cur, struct Buffer *s)
       {
         if (np->mailbox->magic == MUTT_NOTMUCH) /* only match real mailboxes */
           continue;
-        mutt_buffer_expand_path(&np->mailbox->pathbuf);
+        char buf[PATH_MAX];
+        mutt_str_strfcpy(buf, np->mailbox->path->orig, sizeof(buf));
+        mutt_expand_path(buf, sizeof(buf));
+        mutt_str_replace(&np->mailbox->path->orig, buf);
         if ((found || (pass > 0)) && np->mailbox->has_new)
         {
           mutt_buffer_strcpy(s, mailbox_path(np->mailbox));

--- a/muttlib.c
+++ b/muttlib.c
@@ -264,7 +264,7 @@ void mutt_buffer_expand_path_regex(struct Buffer *buf, bool regex)
       {
         if (s[1] == '!')
         {
-          mutt_buffer_strcpy(p, LastFolder);
+          mutt_buffer_strcpy(p, LastFolder->orig);
           tail = s + 2;
         }
         else
@@ -277,14 +277,14 @@ void mutt_buffer_expand_path_regex(struct Buffer *buf, bool regex)
 
       case '-':
       {
-        mutt_buffer_strcpy(p, LastFolder);
+        mutt_buffer_strcpy(p, LastFolder->orig);
         tail = s + 1;
         break;
       }
 
       case '^':
       {
-        mutt_buffer_strcpy(p, CurrentFolder);
+        mutt_buffer_strcpy(p, CurrentFolder->orig);
         tail = s + 1;
         break;
       }

--- a/muttlib.c
+++ b/muttlib.c
@@ -707,6 +707,7 @@ void mutt_buffer_pretty_mailbox(struct Buffer *buf)
   /* This reduces the size of the Buffer, so we can pass it through.
    * We adjust the size just to make sure buf->data is not NULL though */
   mutt_buffer_alloc(buf, PATH_MAX);
+  //JKJ redirect
   mutt_pretty_mailbox(buf->data, buf->dsize);
   mutt_buffer_fix_dptr(buf);
 }

--- a/mx.c
+++ b/mx.c
@@ -1365,7 +1365,7 @@ int mx_path_canon(char *buf, size_t buflen, const char *folder, enum MailboxType
     {
       if (((buf[2] == '/') || (buf[2] == '\0')))
       {
-        mutt_str_inline_replace(buf, buflen, 2, LastFolder);
+        mutt_str_inline_replace(buf, buflen, 2, LastFolder->orig);
       }
     }
     else if ((buf[0] == '+') || (buf[0] == '='))
@@ -1389,7 +1389,7 @@ int mx_path_canon(char *buf, size_t buflen, const char *folder, enum MailboxType
       }
       else if (buf[0] == '-')
       {
-        mutt_str_inline_replace(buf, buflen, 1, LastFolder);
+        mutt_str_inline_replace(buf, buflen, 1, LastFolder->orig);
       }
       else if (buf[0] == '<')
       {
@@ -1401,7 +1401,7 @@ int mx_path_canon(char *buf, size_t buflen, const char *folder, enum MailboxType
       }
       else if (buf[0] == '^')
       {
-        mutt_str_inline_replace(buf, buflen, 1, CurrentFolder);
+        mutt_str_inline_replace(buf, buflen, 1, CurrentFolder->orig);
       }
       else if (buf[0] == '~')
       {

--- a/mx.c
+++ b/mx.c
@@ -542,7 +542,7 @@ static int trash_append(struct Mailbox *m)
   }
 #endif
 
-  struct Mailbox *m_trash = mx_path_resolve(C_Trash);
+  struct Mailbox *m_trash = mx_path_resolve(C_Trash, C_Folder);
   const bool old_append = m_trash->append;
   struct Context *ctx_trash = mx_mbox_open(m_trash, MUTT_APPEND);
   if (ctx_trash)
@@ -747,7 +747,7 @@ int mx_mbox_close(struct Context **ptr)
     else /* use regular append-copy mode */
 #endif
     {
-      struct Mailbox *m_read = mx_path_resolve(mutt_b2s(mbox));
+      struct Mailbox *m_read = mx_path_resolve(mutt_b2s(mbox), C_Folder);
       struct Context *ctx_read = mx_mbox_open(m_read, MUTT_APPEND);
       if (!ctx_read)
       {
@@ -1619,18 +1619,19 @@ done:
 
 /**
  * mx_mbox_find2 - Find a Mailbox on an Account
- * @param path Path to find
+ * @param path   Path to find
+ * @param folder Root mailbox path
  * @retval ptr  Mailbox
  * @retval NULL No match
  */
-struct Mailbox *mx_mbox_find2(const char *path)
+struct Mailbox *mx_mbox_find2(const char *path, const char *folder)
 {
   if (!path)
     return NULL;
 
   char buf[PATH_MAX];
   mutt_str_strfcpy(buf, path, sizeof(buf));
-  mx_path_canon(buf, sizeof(buf), C_Folder, NULL);
+  mx_path_canon(buf, sizeof(buf), folder, NULL);
 
   struct Account *np = NULL;
   TAILQ_FOREACH(np, &NeoMutt->accounts, entries)
@@ -1645,24 +1646,25 @@ struct Mailbox *mx_mbox_find2(const char *path)
 
 /**
  * mx_path_resolve - Get a Mailbox for a path
- * @param path Mailbox path
+ * @param path   Mailbox path
+ * @param folder Root mailbox path
  * @retval ptr Mailbox
  *
  * If there isn't a Mailbox for the path, one will be created.
  */
-struct Mailbox *mx_path_resolve(const char *path)
+struct Mailbox *mx_path_resolve(const char *path, const char *folder)
 {
   if (!path)
     return NULL;
 
-  struct Mailbox *m = mx_mbox_find2(path);
+  struct Mailbox *m = mx_mbox_find2(path, folder);
   if (m)
     return m;
 
   m = mailbox_new(NULL);
   m->flags = MB_HIDDEN;
   mutt_str_replace(&m->path->orig, path);
-  mx_path_canon2(m, C_Folder);
+  mx_path_canon2(m, folder);
 
   return m;
 }

--- a/mx.c
+++ b/mx.c
@@ -1461,19 +1461,19 @@ int mx_path_canon2(struct Mailbox *m, const char *folder)
 
   char buf[PATH_MAX];
 
-  if (m->realpath)
-    mutt_str_strfcpy(buf, m->realpath, sizeof(buf));
+  if (m->path->canon)
+    mutt_str_strfcpy(buf, m->path->canon, sizeof(buf));
   else
     mutt_str_strfcpy(buf, mailbox_path(m), sizeof(buf));
 
   int rc = mx_path_canon(buf, sizeof(buf), folder, &m->magic);
 
-  mutt_str_replace(&m->realpath, buf);
+  mutt_str_replace(&m->path->canon, buf);
 
   if (rc >= 0)
   {
     m->mx_ops = mx_get_ops(m->magic);
-    mutt_buffer_strcpy(&m->pathbuf, m->realpath);
+    mutt_str_replace(&m->path->orig, m->path->canon);
   }
 
   return rc;
@@ -1548,7 +1548,7 @@ struct Account *mx_ac_find(struct Mailbox *m)
     if (np->magic != m->magic)
       continue;
 
-    if (m->mx_ops->ac_find(np, m->realpath))
+    if (m->mx_ops->ac_find(np, m->path->canon))
       return np;
   }
 
@@ -1582,13 +1582,13 @@ struct Mailbox *mx_mbox_find(struct Account *a, const char *path)
   {
     if (!use_url)
     {
-      if (mutt_str_strcmp(np->mailbox->realpath, path) == 0)
+      if (mutt_str_strcmp(np->mailbox->path->canon, path) == 0)
         return np->mailbox;
       continue;
     }
 
     url_free(&url_a);
-    url_a = url_parse(np->mailbox->realpath);
+    url_a = url_parse(np->mailbox->path->canon);
     if (!url_a)
       continue;
 
@@ -1659,9 +1659,9 @@ struct Mailbox *mx_path_resolve(const char *path)
   if (m)
     return m;
 
-  m = mailbox_new();
+  m = mailbox_new(NULL);
   m->flags = MB_HIDDEN;
-  mutt_buffer_strcpy(&m->pathbuf, path);
+  mutt_str_replace(&m->path->orig, path);
   mx_path_canon2(m, C_Folder);
 
   return m;

--- a/mx.c
+++ b/mx.c
@@ -1480,31 +1480,6 @@ int mx_path_canon2(struct Mailbox *m, const char *folder)
 }
 
 /**
- * mx_path_pretty - Abbreviate a mailbox path - Wrapper for MxOps::path_pretty()
- */
-int mx_path_pretty(char *buf, size_t buflen, const char *folder)
-{
-  enum MailboxType magic = mx_path_probe(buf);
-  const struct MxOps *ops = mx_get_ops(magic);
-  if (!ops)
-    return -1;
-
-  if (!ops->path_canon)
-    return -1;
-
-  if (ops->path_canon(buf, buflen) < 0)
-    return -1;
-
-  if (!ops->path_pretty)
-    return -1;
-
-  if (ops->path_pretty(buf, buflen, folder) < 0)
-    return -1;
-
-  return 0;
-}
-
-/**
  * mx_path_parent - Find the parent of a mailbox path - Wrapper for MxOps::path_parent()
  */
 int mx_path_parent(char *buf, size_t buflen)

--- a/mx.c
+++ b/mx.c
@@ -50,6 +50,7 @@
 #include "hook.h"
 #include "init.h"
 #include "keymap.h"
+#include "local.h"
 #include "mutt_header.h"
 #include "mutt_logging.h"
 #include "mutt_mailbox.h"
@@ -130,6 +131,8 @@ const struct MxOps *mx_ops[] = {
 #ifdef USE_COMPRESSED
   &MxCompOps,
 #endif
+  &MxLocalFileOps,
+  &MxLocalDirOps,
   NULL,
 };
 

--- a/mx.c
+++ b/mx.c
@@ -1730,3 +1730,54 @@ int mx_save_hcache(struct Mailbox *m, struct Email *e)
 
   return m->mx_ops->msg_save_hcache(m, e);
 }
+
+/**
+ * mx_ac2_find - Find the Account owning a Mailbox Path
+ * @param path Mailbox Path
+ * @retval ptr  Account
+ * @retval NULL None found
+ */
+struct Account *mx_ac2_find(const struct Path *path)
+{
+  if (!path || !path->orig || (path->type <= MUTT_UNKNOWN) || !(path->flags & MPATH_RESOLVED))
+    return NULL;
+
+  const struct MxOps *ops = mx_get_ops(path->type);
+  if (!ops)
+    return NULL;
+
+  struct Account *np = NULL;
+  TAILQ_FOREACH(np, &NeoMutt->accounts, entries)
+  {
+    if (np->magic != path->type)
+      continue;
+
+    if (ops->ac2_is_owner(np, path) == 0)
+      return np;
+  }
+
+  return NULL;
+}
+
+/**
+ * mx_path_find - Find a Mailbox by its Path
+ * XXX
+ */
+struct Mailbox *mx_path2_find(struct Path *path)
+{
+  struct MailboxList ml = neomutt_mailboxlist_get_all(NeoMutt, path->type);
+  struct MailboxNode *np = NULL;
+  struct Mailbox *m = NULL;
+
+  STAILQ_FOREACH(np, &ml, entries)
+  {
+    if (mx_path2_compare(np->mailbox->path, path) == 0)
+    {
+      m = np->mailbox;
+      break;
+    }
+  }
+
+  neomutt_mailboxlist_clear(&ml);
+  return m;
+}

--- a/mx.h
+++ b/mx.h
@@ -458,13 +458,13 @@ int             mx_path_canon2     (struct Mailbox *m, const char *folder);
 int             mx_path_parent     (char *buf, size_t buflen);
 int             mx_path_pretty     (char *buf, size_t buflen, const char *folder);
 enum MailboxType mx_path_probe     (const char *path);
-struct Mailbox *mx_path_resolve    (const char *path);
+struct Mailbox *mx_path_resolve    (const char *path, const char *folder);
 int             mx_tags_commit     (struct Mailbox *m, struct Email *e, char *tags);
 int             mx_tags_edit       (struct Mailbox *m, const char *tags, char *buf, size_t buflen);
 
 struct Account *mx_ac_find   (struct Mailbox *m);
 struct Mailbox *mx_mbox_find (struct Account *a, const char *path);
-struct Mailbox *mx_mbox_find2(const char *path);
+struct Mailbox *mx_mbox_find2(const char *path, const char *folder);
 int             mx_ac_add    (struct Account *a, struct Mailbox *m);
 int             mx_ac_remove (struct Mailbox *m);
 

--- a/mx.h
+++ b/mx.h
@@ -34,6 +34,7 @@
 
 struct Email;
 struct Context;
+struct Path;
 struct stat;
 
 extern const struct MxOps *mx_ops[];
@@ -116,6 +117,7 @@ struct MxOps
    * @retval -1 Error
    */
   struct Account *(*ac_find)  (struct Account *a, const char *path);
+
   /**
    * ac_add - Add a Mailbox to an Account
    * @param a Account to add to
@@ -124,6 +126,7 @@ struct MxOps
    * @retval -1 Error
    */
   int             (*ac_add)   (struct Account *a, struct Mailbox *m);
+
   /**
    * mbox_open - Open a Mailbox
    * @param m Mailbox to open
@@ -132,6 +135,7 @@ struct MxOps
    * @retval -2 Aborted
    */
   int (*mbox_open)       (struct Mailbox *m);
+
   /**
    * mbox_open_append - Open a Mailbox for appending
    * @param m     Mailbox to open
@@ -140,6 +144,7 @@ struct MxOps
    * @retval -1 Failure
    */
   int (*mbox_open_append)(struct Mailbox *m, OpenMailboxFlags flags);
+
   /**
    * mbox_check - Check for new mail
    * @param m          Mailbox
@@ -148,6 +153,7 @@ struct MxOps
    * @retval -1 Error
    */
   int (*mbox_check)      (struct Mailbox *m, int *index_hint);
+
   /**
    * mbox_check_stats - Check the Mailbox statistics
    * @param m     Mailbox to check
@@ -157,6 +163,7 @@ struct MxOps
    * @retval -1 Failure
    */
   int (*mbox_check_stats)(struct Mailbox *m, int flags);
+
   /**
    * mbox_sync - Save changes to the Mailbox
    * @param m          Mailbox to sync
@@ -165,6 +172,7 @@ struct MxOps
    * @retval -1 Failure
    */
   int (*mbox_sync)       (struct Mailbox *m, int *index_hint);
+
   /**
    * mbox_close - Close a Mailbox
    * @param m Mailbox to close
@@ -172,6 +180,7 @@ struct MxOps
    * @retval -1 Failure
    */
   int (*mbox_close)      (struct Mailbox *m);
+
   /**
    * msg_open - Open an email message in a Mailbox
    * @param m     Mailbox
@@ -181,6 +190,7 @@ struct MxOps
    * @retval -1 Error
    */
   int (*msg_open)        (struct Mailbox *m, struct Message *msg, int msgno);
+
   /**
    * msg_open_new - Open a new message in a Mailbox
    * @param m   Mailbox
@@ -190,6 +200,7 @@ struct MxOps
    * @retval -1 Failure
    */
   int (*msg_open_new)    (struct Mailbox *m, struct Message *msg, struct Email *e);
+
   /**
    * msg_commit - Save changes to an email
    * @param m   Mailbox
@@ -198,6 +209,7 @@ struct MxOps
    * @retval -1 Failure
    */
   int (*msg_commit)      (struct Mailbox *m, struct Message *msg);
+
   /**
    * msg_close - Close an email
    * @param m   Mailbox
@@ -206,12 +218,14 @@ struct MxOps
    * @retval -1 Failure
    */
   int (*msg_close)       (struct Mailbox *m, struct Message *msg);
+
   /**
    * msg_padding_size - Bytes of padding between messages
    * @param m Mailbox
    * @retval num Bytes of padding
    */
   int (*msg_padding_size)(struct Mailbox *m);
+
   /**
    * msg_save_hcache - Save message to the header cache
    * @param m Mailbox
@@ -220,6 +234,7 @@ struct MxOps
    * @retval -1 Failure
    */
   int (*msg_save_hcache) (struct Mailbox *m, struct Email *e);
+
   /**
    * tags_edit - Prompt and validate new messages tags
    * @param m      Mailbox
@@ -231,6 +246,7 @@ struct MxOps
    * @retval  1 Buf set
    */
   int (*tags_edit)       (struct Mailbox *m, const char *tags, char *buf, size_t buflen);
+
   /**
    * tags_commit - Save the tags to a message
    * @param m Mailbox
@@ -240,6 +256,7 @@ struct MxOps
    * @retval -1 Failure
    */
   int (*tags_commit)     (struct Mailbox *m, struct Email *e, char *buf);
+
   /**
    * path_probe - Does this Mailbox type recognise this path?
    * @param path Path to examine
@@ -247,6 +264,7 @@ struct MxOps
    * @retval num Type, e.g. #MUTT_IMAP
    */
   enum MailboxType (*path_probe)(const char *path, const struct stat *st);
+
   /**
    * path_canon - Canonicalise a Mailbox path
    * @param buf    Path to modify
@@ -255,6 +273,7 @@ struct MxOps
    * @retval -1 Failure
    */
   int (*path_canon)      (char *buf, size_t buflen);
+
   /**
    * path_pretty - Abbreviate a Mailbox path
    * @param buf    Path to modify
@@ -264,6 +283,7 @@ struct MxOps
    * @retval -1 Failure
    */
   int (*path_pretty)     (char *buf, size_t buflen, const char *folder);
+
   /**
    * path_parent - Find the parent of a Mailbox path
    * @param buf    Path to modify
@@ -272,6 +292,153 @@ struct MxOps
    * @retval -1 Failure
    */
   int (*path_parent)     (char *buf, size_t buflen);
+
+  /**
+   * path2_canon - Canonicalise a Mailbox path
+   * @param path Path to canonicalise
+   * @retval  0 Success
+   * @retval -1 Failure
+   *
+   * **Contract**
+   * - @a path        is not NULL
+   * - @a path->orig  is not NULL
+   * - @a path->canon is NULL
+   * - @a path->type  is not #MUTT_UNKNOWN
+   * - @a path->flags has #MPATH_RESOLVED, #MPATH_TIDY
+   * - @a path->flags does not have #MPATH_CANONICAL
+   *
+   * **On success**
+   * - @a path->canon will be set to a new string
+   * - @a path->flags will have #MPATH_CANONICAL added
+   */
+  int (*path2_canon)(struct Path *path);
+
+  /**
+   * path2_compare - Compare two Mailbox paths
+   * @param path1 First  path to compare
+   * @param path2 Second path to compare
+   * @retval -1 path1 precedes path2
+   * @retval  0 path1 and path2 are identical
+   * @retval  1 path2 precedes path1
+   *
+   * **Contract**
+   * - @a path        is not NULL
+   * - @a path->canon is not NULL
+   * - @a path->type  is not #MUTT_UNKNOWN
+   * - @a path->flags has #MPATH_RESOLVED, #MPATH_TIDY, #MPATH_CANONICAL
+   *
+   * The contract applies to both @a path1 and @a path2
+   */
+  int (*path2_compare)(struct Path *path1, struct Path *path2);
+
+  /**
+   * path2_parent - Find the parent of a Mailbox path
+   * @param[in] path    Mailbox path
+   * @param[out] parent Parent of path
+   * @retval  0 Success, parent returned
+   * @retval -1 Failure, path is root, it has no parent
+   * @retval -2 Error
+   *
+   * **Contract**
+   * - @a path        is not NULL
+   * - @a path->orig  is not NULL
+   * - @a path->type  is not #MUTT_UNKNOWN
+   * - @a path->flags has #MPATH_RESOLVED, #MPATH_TIDY
+   * - @a parent      is not NULL
+   * - @a *parent     is NULL
+   *
+   * **On success**
+   * - @a parent        is set to a new Path
+   * - @a parent->orig  is set to the parent
+   * - @a parent->type  is set to @a path->type
+   * - @a parent->flags has #MPATH_RESOLVED, #MPATH_TIDY
+   *
+   * @note The caller must free the returned Path
+   */
+  int (*path2_parent)(const struct Path *path, struct Path **parent);
+
+  /**
+   * path2_pretty - Abbreviate a Mailbox path
+   * @param[in]  path   Mailbox path
+   * @param[in]  folder Folder string to abbreviate with
+   * @param[out] pretty Pretty version of path
+   * @retval  1 Success, Path abbreviated
+   * @retval  0 Failure, No change possible
+   * @retval -1 Error
+   *
+   * **Contract**
+   * - @a path        is not NULL
+   * - @a path->orig  is not NULL
+   * - @a path->type  is not #MUTT_UNKNOWN
+   * - @a path->flags has #MPATH_RESOLVED, #MPATH_TIDY
+   * - @a folder      is not NULL, is not empty
+   * - @a pretty      is not NULL
+   * - @a *pretty     is NULL
+   *
+   * **On success**
+   * - @a pretty is set to the abbreviated path
+   *
+   * @note The caller must free the returned Path
+   */
+  int (*path2_pretty)(const struct Path *path, const char *folder, char **pretty);
+
+  /**
+   * path2_probe - Does this Mailbox type recognise this path?
+   * @param path Path to examine
+   * @param st   stat buffer (for local filesystems)
+   * @retval  0 Success, path recognised
+   * @retval -1 Error or path not recognised
+   *
+   * **Contract**
+   * - @a path        is not NULL
+   * - @a path->orig  is not NULL
+   * - @a path->canon is NULL
+   * - @a path->type  is #MUTT_UNKNOWN
+   * - @a path->flags has #MPATH_RESOLVED, #MPATH_TIDY
+   * - @a path->flags does not have #MPATH_CANONICAL
+   * - @a st          is not NULL if MxOps::is_local is set
+   *
+   * **On success**
+   * - @a path->type is set, e.g. #MUTT_MAILDIR
+   */
+  int (*path2_probe)(struct Path *path, const struct stat *st);
+
+  /**
+   * path2_tidy - Tidy a Mailbox path
+   * @param path Path to tidy
+   * @retval  0 Success
+   * @retval -1 Failure
+   *
+   * **Contract**
+   * - @a path        is not NULL
+   * - @a path->orig  is not NULL
+   * - @a path->canon is NULL
+   * - @a path->type  is not #MUTT_UNKNOWN
+   * - @a path->flags has #MPATH_RESOLVED
+   * - @a path->flags does not have #MPATH_TIDY, #MPATH_CANONICAL
+   *
+   * **On success**
+   * - @a path->orig  will be replaced by a tidier string
+   * - @a path->flags will have #MPATH_TIDY added
+   */
+  int (*path2_tidy)(struct Path *path);
+
+  /**
+   * ac2_is_owner - Does this Account own this Path?
+   * @param a    Account to search
+   * @param path Path to search for
+   * @retval  0 Success
+   * @retval -1 Error
+   *
+   * **Contract**
+   * - @a a           is not NULL
+   * - @a a->magic    matches the backend
+   * - @a path        is not NULL
+   * - @a path->orig  is not NULL
+   * - @a path->type  matches the backend
+   * - @a path->flags has #MPATH_RESOLVED, #MPATH_TIDY
+   */
+  int (*ac2_is_owner)(struct Account *a, const struct Path *path);
 };
 
 /* Wrappers for the Mailbox API, see MxOps */

--- a/mx.h
+++ b/mx.h
@@ -467,7 +467,7 @@ bool                mx_tags_is_supported(struct Mailbox *m);
 int              mx_path2_canon  (struct Path *path);
 int              mx_path2_compare(struct Path *path1, struct Path *path2);
 int              mx_path2_parent (const struct Path *path, struct Path **parent);
-int              mx_path2_pretty (const struct Path *path, const char *folder, char **pretty);
+int              mx_path2_pretty (const struct Path *path, const char *folder, bool use_desc, char **pretty);
 enum MailboxType mx_path2_probe  (struct Path *path);
 int              mx_path2_resolve(struct Path *path, const char *folder);
 struct Mailbox * mx_path2_find   (struct Path *path);

--- a/mx.h
+++ b/mx.h
@@ -480,6 +480,8 @@ int              mx_path2_compare(struct Path *path1, struct Path *path2);
 int              mx_path2_parent (const struct Path *path, struct Path **parent);
 int              mx_path2_pretty (const struct Path *path, const char *folder, char **pretty);
 enum MailboxType mx_path2_probe  (struct Path *path);
-int              mx_path2_resolve(struct Path *path);
+int              mx_path2_resolve(struct Path *path, const char *folder);
+struct Mailbox * mx_path2_find   (struct Path *path);
+struct Account * mx_ac2_find     (const struct Path *path);
 
 #endif /* MUTT_MX_H */

--- a/mx.h
+++ b/mx.h
@@ -275,16 +275,6 @@ struct MxOps
   int (*path_canon)      (char *buf, size_t buflen);
 
   /**
-   * path_pretty - Abbreviate a Mailbox path
-   * @param buf    Path to modify
-   * @param buflen Length of buffer
-   * @param folder Base path for '=' substitution
-   * @retval  0 Success
-   * @retval -1 Failure
-   */
-  int (*path_pretty)     (char *buf, size_t buflen, const char *folder);
-
-  /**
    * path_parent - Find the parent of a Mailbox path
    * @param buf    Path to modify
    * @param buflen Length of buffer
@@ -456,7 +446,6 @@ int             mx_save_hcache     (struct Mailbox *m, struct Email *e);
 int             mx_path_canon      (char *buf, size_t buflen, const char *folder, enum MailboxType *magic);
 int             mx_path_canon2     (struct Mailbox *m, const char *folder);
 int             mx_path_parent     (char *buf, size_t buflen);
-int             mx_path_pretty     (char *buf, size_t buflen, const char *folder);
 enum MailboxType mx_path_probe     (const char *path);
 struct Mailbox *mx_path_resolve    (const char *path, const char *folder);
 int             mx_tags_commit     (struct Mailbox *m, struct Email *e, char *tags);

--- a/mx.h
+++ b/mx.h
@@ -475,4 +475,11 @@ void                mx_fastclose_mailbox(struct Mailbox *m);
 const struct MxOps *mx_get_ops          (enum MailboxType magic);
 bool                mx_tags_is_supported(struct Mailbox *m);
 
+int              mx_path2_canon  (struct Path *path);
+int              mx_path2_compare(struct Path *path1, struct Path *path2);
+int              mx_path2_parent (const struct Path *path, struct Path **parent);
+int              mx_path2_pretty (const struct Path *path, const char *folder, char **pretty);
+enum MailboxType mx_path2_probe  (struct Path *path);
+int              mx_path2_resolve(struct Path *path);
+
 #endif /* MUTT_MX_H */

--- a/mx_path.c
+++ b/mx_path.c
@@ -62,7 +62,8 @@ static int path2_tidy(struct Path *path)
 
 /**
  * path2_resolve - Resolve special strings in a Mailbox Path
- * @param path Path to resolve
+ * @param path   Path to resolve
+ * @param folder Current $folder
  * @retval  0 Success
  * @retval -1 Failure
  *
@@ -83,7 +84,7 @@ static int path2_tidy(struct Path *path)
  *
  * @note Paths beginning with `~` will be expanded later by MxOps::path2_tidy()
  */
-static int path2_resolve(struct Path *path)
+static int path2_resolve(struct Path *path, const char *folder)
 {
   if (!path || !path->orig)
     return -1;
@@ -104,15 +105,15 @@ static int path2_resolve(struct Path *path)
     }
     else if ((buf[0] == '+') || (buf[0] == '='))
     {
-      size_t folder_len = mutt_str_strlen(C_Folder);
-      if ((folder_len > 0) && (C_Folder[folder_len - 1] != '/'))
+      size_t folder_len = mutt_str_strlen(folder);
+      if ((folder_len > 0) && (folder[folder_len - 1] != '/'))
       {
         buf[0] = '/';
-        mutt_str_inline_replace(buf, sizeof(buf), 0, C_Folder);
+        mutt_str_inline_replace(buf, sizeof(buf), 0, folder);
       }
       else
       {
-        mutt_str_inline_replace(buf, sizeof(buf), 1, C_Folder);
+        mutt_str_inline_replace(buf, sizeof(buf), 1, folder);
       }
     }
     else if ((buf[1] == '/') || (buf[1] == '\0'))
@@ -317,9 +318,9 @@ int mx_path2_probe(struct Path *path)
 /**
  * mx_path2_resolve - XXX
  */
-int mx_path2_resolve(struct Path *path)
+int mx_path2_resolve(struct Path *path, const char *folder)
 {
-  int rc = path2_resolve(path);
+  int rc = path2_resolve(path, folder);
   if (rc < 0)
     return rc;
 

--- a/mx_path.c
+++ b/mx_path.c
@@ -100,7 +100,7 @@ static int path2_resolve(struct Path *path, const char *folder)
     {
       if (((buf[2] == '/') || (buf[2] == '\0')))
       {
-        mutt_str_inline_replace(buf, sizeof(buf), 2, LastFolder);
+        mutt_str_inline_replace(buf, sizeof(buf), 2, LastFolder->orig);
       }
     }
     else if ((buf[0] == '+') || (buf[0] == '='))
@@ -124,7 +124,7 @@ static int path2_resolve(struct Path *path, const char *folder)
       }
       else if (buf[0] == '-')
       {
-        mutt_str_inline_replace(buf, sizeof(buf), 1, LastFolder);
+        mutt_str_inline_replace(buf, sizeof(buf), 1, LastFolder->orig);
       }
       else if (buf[0] == '<')
       {
@@ -136,7 +136,7 @@ static int path2_resolve(struct Path *path, const char *folder)
       }
       else if (buf[0] == '^')
       {
-        mutt_str_inline_replace(buf, sizeof(buf), 1, CurrentFolder);
+        mutt_str_inline_replace(buf, sizeof(buf), 1, CurrentFolder->orig);
       }
     }
     else if (buf[0] == '@')

--- a/mx_path.c
+++ b/mx_path.c
@@ -1,0 +1,335 @@
+/**
+ * @file
+ * Mailbox path functions
+ *
+ * @authors
+ * Copyright (C) 2020 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @page mx_path Mailbox path functions
+ *
+ * Mailbox path functions
+ */
+
+#include "config.h"
+#include <errno.h>
+#include <limits.h>
+#include <string.h>
+#include <sys/stat.h>
+#include "email/lib.h"
+#include "alias.h"
+#include "globals.h"
+#include "hook.h"
+#include "mx.h"
+
+/**
+ * path2_tidy - Tidy a Mailbox path
+ */
+static int path2_tidy(struct Path *path)
+{
+  // Contract for MxOps::path2_tidy
+  if (!path || !path->orig || (path->type <= MUTT_UNKNOWN) || !(path->flags & MPATH_RESOLVED))
+    return -1;
+  if (path->flags & MPATH_TIDY)
+    return 0;
+  if (path->canon || (path->flags & MPATH_CANONICAL))
+    return -1;
+
+  const struct MxOps *ops = mx_get_ops(path->type);
+  if (!ops || !ops->path2_tidy)
+    return -1;
+
+  if (ops->path2_tidy(path) != 0)
+    return -1;
+
+  return 0;
+}
+
+/**
+ * path2_resolve - Resolve special strings in a Mailbox Path
+ * @param path Path to resolve
+ * @retval  0 Success
+ * @retval -1 Failure
+ *
+ * Find and expand some special strings found at the beginning of a Mailbox Path.
+ * The strings must be followed by `/` or NUL.
+ *
+ * | String   | Expansion              |
+ * | -------- | ---------------------- |
+ * | `!!`     | Previous Mailbox       |
+ * | `!`      | `$spoolfile`           |
+ * | `+`      | `$folder`              |
+ * | `-`      | Previous Mailbox       |
+ * | `<`      | `$record`              |
+ * | `=`      | `$folder`              |
+ * | `>`      | `$mbox`                |
+ * | `^`      | Current Mailbox        |
+ * | `@alias` | Full name of `alias`   |
+ *
+ * @note Paths beginning with `~` will be expanded later by MxOps::path2_tidy()
+ */
+static int path2_resolve(struct Path *path)
+{
+  if (!path || !path->orig)
+    return -1;
+  if (path->flags & MPATH_RESOLVED)
+    return 0;
+
+  char buf[PATH_MAX];
+  mutt_str_strfcpy(buf, path->orig, sizeof(buf));
+
+  for (size_t i = 0; i < 3; i++)
+  {
+    if ((buf[0] == '!') && (buf[1] == '!'))
+    {
+      if (((buf[2] == '/') || (buf[2] == '\0')))
+      {
+        mutt_str_inline_replace(buf, sizeof(buf), 2, LastFolder);
+      }
+    }
+    else if ((buf[0] == '+') || (buf[0] == '='))
+    {
+      size_t folder_len = mutt_str_strlen(C_Folder);
+      if ((folder_len > 0) && (C_Folder[folder_len - 1] != '/'))
+      {
+        buf[0] = '/';
+        mutt_str_inline_replace(buf, sizeof(buf), 0, C_Folder);
+      }
+      else
+      {
+        mutt_str_inline_replace(buf, sizeof(buf), 1, C_Folder);
+      }
+    }
+    else if ((buf[1] == '/') || (buf[1] == '\0'))
+    {
+      if (buf[0] == '!')
+      {
+        mutt_str_inline_replace(buf, sizeof(buf), 1, C_Spoolfile);
+      }
+      else if (buf[0] == '-')
+      {
+        mutt_str_inline_replace(buf, sizeof(buf), 1, LastFolder);
+      }
+      else if (buf[0] == '<')
+      {
+        mutt_str_inline_replace(buf, sizeof(buf), 1, C_Record);
+      }
+      else if (buf[0] == '>')
+      {
+        mutt_str_inline_replace(buf, sizeof(buf), 1, C_Mbox);
+      }
+      else if (buf[0] == '^')
+      {
+        mutt_str_inline_replace(buf, sizeof(buf), 1, CurrentFolder);
+      }
+    }
+    else if (buf[0] == '@')
+    {
+      /* elm compatibility, @ expands alias to user name */
+      struct AddressList *al = mutt_alias_lookup(buf + 1);
+      if (TAILQ_EMPTY(al))
+        break;
+
+      struct Email *e = email_new();
+      e->env = mutt_env_new();
+      mutt_addrlist_copy(&e->env->from, al, false);
+      mutt_addrlist_copy(&e->env->to, al, false);
+      mutt_default_save(buf, sizeof(buf), e);
+      email_free(&e);
+      break;
+    }
+    else
+    {
+      break;
+    }
+  }
+
+  mutt_str_replace(&path->orig, buf);
+  path->flags |= MPATH_RESOLVED;
+
+  return 0;
+}
+
+/**
+ * mx_path2_canon - Canonicalise a Mailbox path
+ */
+int mx_path2_canon(struct Path *path)
+{
+  if (!path || !path->orig)
+    return -1;
+  if (path->flags & MPATH_CANONICAL)
+    return 0;
+
+  int rc = path2_tidy(path);
+  if (rc < 0)
+    return rc;
+
+  const struct MxOps *ops = mx_get_ops(path->type);
+  if (!ops || !ops->path2_canon)
+    return -1;
+
+  if (ops->path2_canon(path) != 0)
+    return -1;
+
+  return 0;
+}
+
+/**
+ * mx_path2_compare - Compare two Mailbox paths - Wrapper for MxOps::path2_compare()
+ *
+ * The two Paths will be canonicalised, if necessary, before being compared.
+ * @sa MxOps::path2_canon()
+ */
+int mx_path2_compare(struct Path *path1, struct Path *path2)
+{
+  if (!path1 || !path2)
+    return -1;
+  if (!(path1->flags & MPATH_RESOLVED) || !(path2->flags & MPATH_RESOLVED))
+    return -1;
+  if (path1->type != path2->type)
+    return -1;
+  if (mx_path2_canon(path1) != 0)
+    return -1;
+  if (mx_path2_canon(path2) != 0)
+    return -1;
+
+  const struct MxOps *ops = mx_get_ops(path1->type);
+  if (!ops || !ops->path2_compare)
+    return -1;
+
+  return ops->path2_compare(path1, path2);
+}
+
+/**
+ * mx_path2_parent - Find the parent of a Mailbox path
+ * @retval -1 Error
+ * @retval  0 Success, parent returned
+ * @retval  1 Success, path is has no parent
+ */
+int mx_path2_parent(const struct Path *path, struct Path **parent)
+{
+  if (!path)
+    return -1;
+  if (!(path->flags & MPATH_RESOLVED))
+    return -1;
+  if (path->flags & MPATH_ROOT)
+    return 1;
+
+  const struct MxOps *ops = mx_get_ops(path->type);
+  if (!ops || !ops->path2_parent)
+    return -1;
+
+  return ops->path2_parent(path, parent);
+}
+
+/**
+ * mx_path2_pretty - Abbreviate a Mailbox path - Wrapper for MxOps::path2_pretty()
+ *
+ * @note The caller must free the returned string
+ */
+int mx_path2_pretty(const struct Path *path, const char *folder, char **pretty)
+{
+  // Contract for MxOps::path2_pretty
+  if (!path || !path->orig || (path->type <= MUTT_UNKNOWN) ||
+      !(path->flags & MPATH_RESOLVED) || !folder || !pretty || *pretty)
+  {
+    return -1;
+  }
+
+  if (path->desc)
+  {
+    *pretty = mutt_str_strdup(path->desc);
+    return 2;
+  }
+
+  const struct MxOps *ops = mx_get_ops(path->type);
+  if (!ops || !ops->path2_pretty)
+    return -1;
+
+  return ops->path2_pretty(path, folder, pretty);
+}
+
+/**
+ * mx_path2_probe - Determine the Mailbox type of a path
+ * @param path Path to examine
+ * @retval num XXX
+ */
+int mx_path2_probe(struct Path *path)
+{
+  // Contract for MxOps::path2_probe
+  if (!path || !path->orig || path->canon || (path->type > MUTT_UNKNOWN) ||
+      !(path->flags & MPATH_RESOLVED))
+  {
+    return -1;
+  }
+  if (path->flags & (MPATH_TIDY | MPATH_CANONICAL))
+    return 0;
+
+  int rc = 0;
+
+  // First, search the non-local Mailbox types
+  for (const struct MxOps **ops = mx_ops; *ops; ops++)
+  {
+    if ((*ops)->is_local)
+      continue;
+    rc = (*ops)->path2_probe(path, NULL);
+    if (rc == 0)
+      return 0;
+  }
+
+  struct stat st = { 0 };
+  if (stat(path->orig, &st) != 0)
+  {
+    mutt_debug(LL_DEBUG1, "unable to stat %s: %s (errno %d)\n", path->orig,
+               strerror(errno), errno);
+    return -1;
+  }
+
+  // Next, search the local Mailbox types
+  for (const struct MxOps **ops = mx_ops; *ops; ops++)
+  {
+    if (!(*ops)->is_local)
+      continue;
+    rc = (*ops)->path2_probe(path, &st);
+    if (rc == 0)
+      return 0;
+  }
+
+  mutt_debug(LL_DEBUG2, "Can't identify path: %s\n", path->orig);
+  return -1;
+}
+
+/**
+ * mx_path2_resolve - XXX
+ */
+int mx_path2_resolve(struct Path *path)
+{
+  int rc = path2_resolve(path);
+  if (rc < 0)
+    return rc;
+
+  rc = mx_path2_probe(path);
+  if (rc < 0)
+    return rc;
+
+  rc = path2_tidy(path);
+  if (rc < 0)
+    return rc;
+
+  return 0;
+}

--- a/nntp/lib.h
+++ b/nntp/lib.h
@@ -33,6 +33,7 @@
  * | nntp/complete.c | @subpage nntp_complete |
  * | nntp/newsrc.c   | @subpage nntp_newsrc   |
  * | nntp/nntp.c     | @subpage nntp_nntp     |
+ * | nntp/path.c     | @subpage nntp_path     |
  */
 
 #ifndef MUTT_NNTP_LIB_H
@@ -46,6 +47,7 @@
 #include "core/lib.h"
 #include "format_flags.h"
 #include "mx.h"
+#include "path.h"
 
 struct ConnAccount;
 struct stat;

--- a/nntp/nntp.c
+++ b/nntp/nntp.c
@@ -2448,7 +2448,7 @@ static int nntp_mbox_open(struct Mailbox *m)
   url->path = strchr(url->path, '\0');
   url_tostring(url, server, sizeof(server), 0);
 
-  mutt_account_hook(m->realpath);
+  mutt_account_hook(m->path->canon);
   struct NntpAccountData *adata = m->account->adata;
   if (!adata)
   {

--- a/nntp/nntp.c
+++ b/nntp/nntp.c
@@ -2860,15 +2860,6 @@ static int nntp_path_canon(char *buf, size_t buflen)
 }
 
 /**
- * nntp_path_pretty - Abbreviate a Mailbox path - Implements MxOps::path_pretty()
- */
-static int nntp_path_pretty(char *buf, size_t buflen, const char *folder)
-{
-  /* Succeed, but don't do anything, for now */
-  return 0;
-}
-
-/**
  * nntp_path_parent - Find the parent of a Mailbox path - Implements MxOps::path_parent()
  */
 static int nntp_path_parent(char *buf, size_t buflen)
@@ -2989,7 +2980,6 @@ struct MxOps MxNntpOps = {
   .tags_commit      = NULL,
   .path_probe       = nntp_path_probe,
   .path_canon       = nntp_path_canon,
-  .path_pretty      = nntp_path_pretty,
   .path_parent      = nntp_path_parent,
   .path2_canon      = nntp_path2_canon_wrapper,
   .path2_compare    = nntp_path2_compare,

--- a/nntp/nntp_private.h
+++ b/nntp/nntp_private.h
@@ -1,9 +1,9 @@
 /**
  * @file
- * Usenet network mailbox type; talk to an NNTP server
+ * Shared constants/structs that are private to Nntp
  *
  * @authors
- * Copyright (C) 2018 Richard Russon <rich@flatcap.org>
+ * Copyright (C) 2018-2020 Richard Russon <rich@flatcap.org>
  *
  * @copyright
  * This program is free software: you can redistribute it and/or modify it under
@@ -25,12 +25,15 @@
 
 #include "config.h"
 #include <stdint.h>
+#include "core/lib.h"
 #include "hcache/lib.h"
 #include "lib.h"
 
 struct Connection;
 struct Email;
 struct Mailbox;
+struct Path;
+struct stat;
 
 #define NNTP_PORT 119
 #define NNTP_SSL_PORT 563

--- a/nntp/path.c
+++ b/nntp/path.c
@@ -1,0 +1,244 @@
+/**
+ * @file
+ * Nntp path manipulations
+ *
+ * @authors
+ * Copyright (C) 2020 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @page nntp_path Nntp path manipulations
+ *
+ * Nntp path manipulations
+ */
+
+#include "config.h"
+#include <string.h>
+#include "config/lib.h"
+#include "email/lib.h"
+#include "core/lib.h"
+
+extern char *HomeDir;
+
+/**
+ * nntp_path2_canon - Canonicalise a Mailbox path - Implements MxOps::path2_canon()
+ * @param path Path to canonicalise
+ * @param user Login username
+ * @param port Server port
+ * @retval  0 Success
+ * @retval -1 Failure
+ */
+int nntp_path2_canon(struct Path *path, char *user, int port)
+{
+  struct Url *url = url_parse(path->orig);
+  if (!url)
+    return -1;
+
+  if (!url->user)
+    url->user = user;
+  if (url->port == 0)
+    url->port = port;
+  if (url->pass)
+    url->pass = NULL;
+
+  int rc = -1;
+  struct Buffer buf = mutt_buffer_make(256);
+  if (url_tobuffer(url, &buf, 0) != 0)
+    goto done; // LCOV_EXCL_LINE
+
+  mutt_str_replace(&path->canon, mutt_b2s(&buf));
+  path->flags |= MPATH_CANONICAL;
+  rc = 0;
+
+done:
+  url_free(&url);
+  mutt_buffer_dealloc(&buf);
+  return rc;
+}
+
+/**
+ * nntp_path2_compare - Compare two Mailbox paths - Implements MxOps::path2_compare()
+ *
+ * **Tests**
+ * - scheme must match
+ * - host must match
+ * - user must match, or may be absent from one, or absent from both
+ * - pass must match, or may be absent from one, or absent from both
+ * - port must match, or may be absent from one, or absent from both
+ * - path must match
+ */
+int nntp_path2_compare(struct Path *path1, struct Path *path2)
+{
+  struct Url *url1 = url_parse(path1->canon);
+  struct Url *url2 = url_parse(path2->canon);
+
+  int rc = url1->scheme - url2->scheme;
+  if (rc != 0)
+    goto done;
+
+  if (url1->user && url2->user)
+  {
+    rc = mutt_str_strcmp(url1->user, url2->user);
+    if (rc != 0)
+      goto done;
+  }
+
+  rc = mutt_str_strcasecmp(url1->host, url2->host);
+  if (rc != 0)
+    goto done;
+
+  if ((url1->port != 0) && (url2->port != 0))
+  {
+    rc = url1->port - url2->port;
+    if (rc != 0)
+      goto done;
+  }
+
+  rc = mutt_str_strcmp(url1->path, url2->path);
+
+done:
+  url_free(&url1);
+  url_free(&url2);
+  if (rc < 0)
+    return -1;
+  if (rc > 0)
+    return 1;
+  return 0;
+}
+
+/**
+ * nntp_path2_parent - Find the parent of a Mailbox path - Implements MxOps::path2_parent()
+ * @retval  1 Success, path is root, it has no parent
+ * @retval  0 Success, parent returned
+ * @retval -1 Error
+ */
+int nntp_path2_parent(const struct Path *path, struct Path **parent)
+{
+  int rc = -1;
+  struct Buffer *buf = NULL;
+
+  struct Url *url = url_parse(path->orig);
+  if (!url)
+    return -2;
+
+  char *split = strrchr(url->path, '.');
+  if (!split)
+    goto done;
+
+  *split = '\0';
+
+  buf = mutt_buffer_pool_get();
+  if (url_tobuffer(url, buf, 0) < 0)
+    goto done; // LCOV_EXCL_LINE
+
+  *parent = mutt_path_new();
+  (*parent)->orig = mutt_str_strdup(mutt_b2s(buf));
+  (*parent)->type = path->type;
+  (*parent)->flags = MPATH_RESOLVED | MPATH_TIDY;
+
+  rc = 0;
+
+done:
+  url_free(&url);
+  mutt_buffer_pool_release(&buf);
+  return rc;
+}
+
+/**
+ * nntp_path2_pretty - Abbreviate a Mailbox path - Implements MxOps::path2_pretty()
+ *
+ * **Tests**
+ * - scheme must match
+ * - host must match
+ * - user must match, or may be absent from one, or absent from both
+ * - pass must match, or may be absent from one, or absent from both
+ * - port must match, or may be absent from one, or absent from both
+ */
+int nntp_path2_pretty(const struct Path *path, const char *folder, char **pretty)
+{
+  int rc = 0;
+  struct Url *url1 = url_parse(path->orig);
+  struct Url *url2 = url_parse(folder);
+
+  if (url1->scheme != url2->scheme)
+    goto done;
+  if (mutt_str_strcasecmp(url1->host, url2->host) != 0)
+    goto done;
+  if (!path_partial_match_string(url1->user, url2->user))
+    goto done;
+  if (!path_partial_match_number(url1->port, url2->port))
+    goto done;
+  if (!mutt_path2_abbr_folder(url1->path, url2->path, pretty))
+    goto done;
+
+  rc = 1;
+
+done:
+  url_free(&url1);
+  url_free(&url2);
+  return rc;
+}
+
+/**
+ * nntp_path2_probe - Does this Mailbox type recognise this path? - Implements MxOps::path2_probe()
+ *
+ * **Tests**
+ * - Path may begin "news://"
+ * - Path may begin "snews://"
+ *
+ * @note The case of the URL scheme is ignored
+ */
+int nntp_path2_probe(struct Path *path, const struct stat *st)
+{
+  if (!mutt_str_startswith(path->orig, "news://", CASE_IGNORE) &&
+      !mutt_str_startswith(path->orig, "snews://", CASE_IGNORE))
+  {
+    return -1;
+  }
+
+  path->type = MUTT_NNTP;
+  return 0;
+}
+
+/**
+ * nntp_path2_tidy - Tidy a Mailbox path - Implements MxOps::path2_tidy()
+ *
+ * **Changes**
+ * - Lowercase the URL scheme
+ */
+int nntp_path2_tidy(struct Path *path)
+{
+  struct Url *url = url_parse(path->orig);
+  if (!url)
+    return -1;
+
+  url->pass = NULL;
+
+  int rc = -1;
+  struct Buffer *buf = mutt_buffer_pool_get();
+  if (url_tobuffer(url, buf, 0) < 0)
+    goto done; // LCOV_EXCL_LINE
+
+  mutt_str_replace(&path->orig, mutt_b2s(buf));
+  path->flags |= MPATH_TIDY;
+  rc = 0;
+
+done:
+  url_free(&url);
+  mutt_buffer_pool_release(&buf);
+  return rc;
+}

--- a/nntp/path.h
+++ b/nntp/path.h
@@ -1,0 +1,36 @@
+/**
+ * @file
+ * Nntp path manipulations
+ *
+ * @authors
+ * Copyright (C) 2020 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MUTT_NNTP_PATH_H
+#define MUTT_NNTP_PATH_H
+
+struct Path;
+struct stat;
+
+int nntp_path2_canon  (struct Path *path, char *user, int port);
+int nntp_path2_compare(struct Path *path1, struct Path *path2);
+int nntp_path2_parent (const struct Path *path, struct Path **parent);
+int nntp_path2_pretty (const struct Path *path, const char *folder, char **pretty);
+int nntp_path2_probe  (struct Path *path, const struct stat *st);
+int nntp_path2_tidy   (struct Path *path);
+
+#endif /* MUTT_NNTP_PATH_H */

--- a/notmuch/lib.h
+++ b/notmuch/lib.h
@@ -29,6 +29,7 @@
  * | :--------------------- | :------------------ |
  * | notmuch/mutt_notmuch.c | @subpage nm_notmuch |
  * | notmuch/nm_db.c        | @subpage nm_db      |
+ * | notmuch/path.c         | @subpage nm_path    |
  */
 
 #ifndef MUTT_NOTMUCH_LIB_H
@@ -38,6 +39,7 @@
 #include <stdbool.h>
 #include "core/lib.h"
 #include "mx.h"
+#include "path.h"
 
 struct Email;
 struct NmMboxData;

--- a/notmuch/mutt_notmuch.c
+++ b/notmuch/mutt_notmuch.c
@@ -2553,15 +2553,6 @@ static int nm_path_canon(char *buf, size_t buflen)
 }
 
 /**
- * nm_path_pretty - Abbreviate a Mailbox path - Implements MxOps::path_pretty()
- */
-static int nm_path_pretty(char *buf, size_t buflen, const char *folder)
-{
-  /* Succeed, but don't do anything, for now */
-  return 0;
-}
-
-/**
  * nm_path_parent - Find the parent of a Mailbox path - Implements MxOps::path_parent()
  */
 static int nm_path_parent(char *buf, size_t buflen)
@@ -2596,7 +2587,6 @@ struct MxOps MxNotmuchOps = {
   .tags_commit      = nm_tags_commit,
   .path_probe       = nm_path_probe,
   .path_canon       = nm_path_canon,
-  .path_pretty      = nm_path_pretty,
   .path_parent      = nm_path_parent,
   .path2_canon      = nm_path2_canon,
   .path2_compare    = nm_path2_compare,

--- a/notmuch/mutt_notmuch.c
+++ b/notmuch/mutt_notmuch.c
@@ -63,15 +63,11 @@
 #include "index.h"
 #include "mutt_thread.h"
 #include "mx.h"
+#include "path.h"
 #include "progress.h"
 #include "protos.h"
 #include "hcache/lib.h"
 #include "maildir/lib.h"
-
-struct stat;
-
-const char NmUrlProtocol[] = "notmuch://";
-const int NmUrlProtocolLen = sizeof(NmUrlProtocol) - 1;
 
 /* These Config Variables are only used in notmuch/mutt_notmuch.c */
 int C_NmDbLimit;       ///< Config: (notmuch) Default limit for Notmuch queries
@@ -2602,5 +2598,11 @@ struct MxOps MxNotmuchOps = {
   .path_canon       = nm_path_canon,
   .path_pretty      = nm_path_pretty,
   .path_parent      = nm_path_parent,
+  .path2_canon      = nm_path2_canon,
+  .path2_compare    = nm_path2_compare,
+  .path2_parent     = nm_path2_parent,
+  .path2_pretty     = nm_path2_pretty,
+  .path2_probe      = nm_path2_probe,
+  .path2_tidy       = nm_path2_tidy,
 };
 // clang-format on

--- a/notmuch/mutt_notmuch.c
+++ b/notmuch/mutt_notmuch.c
@@ -2378,10 +2378,10 @@ static int nm_mbox_sync(struct Mailbox *m, int *index_hint)
     else
       email_get_fullpath(e, old_file, sizeof(old_file));
 
-    mutt_buffer_strcpy(&m->pathbuf, edata->folder);
+    mutt_str_replace(&m->path->orig, edata->folder);
     m->magic = edata->magic;
     rc = mh_sync_mailbox_message(m, i, h);
-    mutt_buffer_strcpy(&m->pathbuf, url);
+    mutt_str_replace(&m->path->orig, url);
     m->magic = MUTT_NOTMUCH;
 
     if (rc)
@@ -2401,7 +2401,7 @@ static int nm_mbox_sync(struct Mailbox *m, int *index_hint)
     FREE(&edata->oldpath);
   }
 
-  mutt_buffer_strcpy(&m->pathbuf, url);
+  mutt_str_replace(&m->path->orig, url);
   m->magic = MUTT_NOTMUCH;
 
   nm_db_release(m);

--- a/notmuch/notmuch_private.h
+++ b/notmuch/notmuch_private.h
@@ -20,14 +20,17 @@
  * this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef MUTT_NOTMUCH_NOTMUCH_PRIVATE_H
+#define MUTT_NOTMUCH_NOTMUCH_PRIVATE_H
+
 #include <notmuch.h>
 #include <stdbool.h>
 #include <time.h>
 #include "core/lib.h"
 #include "progress.h"
 
-#ifndef MUTT_NOTMUCH_NOTMUCH_PRIVATE_H
-#define MUTT_NOTMUCH_NOTMUCH_PRIVATE_H
+struct Path;
+struct stat;
 
 #ifdef LIBNOTMUCH_CHECK_VERSION
 #undef LIBNOTMUCH_CHECK_VERSION
@@ -40,6 +43,7 @@
    (LIBNOTMUCH_MAJOR_VERSION == (major) &&                                        \
     LIBNOTMUCH_MINOR_VERSION == (minor) && LIBNOTMUCH_MICRO_VERSION >= (micro)))
 
+extern const char NmUrlProtocol[];
 extern const int NmUrlProtocolLen;
 
 /**

--- a/notmuch/path.c
+++ b/notmuch/path.c
@@ -1,0 +1,278 @@
+/**
+ * @file
+ * Notmuch path manipulations
+ *
+ * @authors
+ * Copyright (C) 2020 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @page nm_path Notmuch path manipulations
+ *
+ * Notmuch path manipulations
+ */
+
+#include "config.h"
+#include <limits.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include "notmuch_private.h"
+#include "config/lib.h"
+#include "email/lib.h"
+#include "core/lib.h"
+
+extern char *HomeDir;
+
+const char NmUrlProtocol[] = "notmuch://";
+const int NmUrlProtocolLen = sizeof(NmUrlProtocol) - 1;
+
+/**
+ * qsort_urlquery_cb - Sort two UrlQuery pointers
+ * @param a First UrlQuery
+ * @param b Second UrlQuery
+ * @retval -1 a precedes b
+ * @retval  0 a and b are identical
+ * @retval  1 b precedes a
+ */
+int qsort_urlquery_cb(const void *a, const void *b)
+{
+  const struct UrlQuery *uq1 = *(struct UrlQuery const *const *) a;
+  const struct UrlQuery *uq2 = *(struct UrlQuery const *const *) b;
+
+  int rc = mutt_str_strcmp(uq1->name, uq2->name);
+  if (rc != 0)
+    return rc;
+
+  return mutt_str_strcmp(uq1->value, uq2->value);
+}
+
+/**
+ * nm_path2_canon - Canonicalise a Mailbox path - Implements MxOps::path2_canon()
+ */
+int nm_path2_canon(struct Path *path)
+{
+  int rc = -1;
+
+  struct Buffer buf = mutt_buffer_make(256);
+  struct Url *url = url_parse(path->orig);
+  if (!url)
+    goto done;
+
+  if (url->scheme != U_NOTMUCH)
+    goto done;
+
+  // follow symlinks in db path
+  char real[PATH_MAX] = { 0 };
+  if (!realpath(url->path, real))
+    goto done;
+  url->path = real;
+
+  size_t count = 0;
+  struct UrlQuery *np = NULL;
+  STAILQ_FOREACH(np, &url->query_strings, entries)
+  {
+    count++;
+  }
+
+  struct UrlQuery **all_query = mutt_mem_calloc(count, sizeof(struct UrlQuery *));
+  struct UrlQuery *tmp = NULL;
+  count = 0;
+  STAILQ_FOREACH_SAFE(np, &url->query_strings, entries, tmp)
+  {
+    STAILQ_REMOVE_HEAD(&url->query_strings, entries);
+    all_query[count++] = np;
+  }
+
+  qsort(all_query, count, sizeof(struct UrlQuery *), qsort_urlquery_cb);
+
+  for (size_t i = 0; i < count; i++)
+  {
+    STAILQ_INSERT_TAIL(&url->query_strings, all_query[i], entries);
+  }
+  FREE(&all_query);
+
+  url->host = "/";
+  if (url_tobuffer(url, &buf, U_PATH) != 0)
+    goto done; // LCOV_EXCL_LINE
+
+  mutt_str_replace(&path->canon, mutt_b2s(&buf));
+  path->flags |= MPATH_CANONICAL;
+  rc = 0;
+
+done:
+  url_free(&url);
+  mutt_buffer_dealloc(&buf);
+  return rc;
+}
+
+/**
+ * nm_path2_compare - Compare two Mailbox paths - Implements MxOps::path2_compare()
+ *
+ * **Tests**
+ * - path must match, or may be absent from one, or absent from both
+ * - query_strings must match in number, order, name and value
+ */
+int nm_path2_compare(struct Path *path1, struct Path *path2)
+{
+  struct Url *url1 = url_parse(path1->canon);
+  struct Url *url2 = url_parse(path2->canon);
+
+  int rc = url1->scheme - url2->scheme;
+  if (rc != 0)
+    goto done;
+
+  if (url1->path && url2->path)
+  {
+    rc = mutt_str_strcmp(url1->path, url2->path);
+    if (rc != 0)
+      goto done;
+  }
+
+  const char *q1 = strchr(path1->canon, '?');
+  const char *q2 = strchr(path2->canon, '?');
+
+  rc = mutt_str_strcmp(q1, q2);
+
+done:
+  url_free(&url1);
+  url_free(&url2);
+  if (rc < 0)
+    return -1;
+  if (rc > 0)
+    return 1;
+  return 0;
+}
+
+/**
+ * nm_path2_parent - Find the parent of a Mailbox path - Implements MxOps::path2_parent()
+ * @retval -1 Notmuch mailbox doesn't have a parent
+ */
+int nm_path2_parent(const struct Path *path, struct Path **parent)
+{
+  return -1;
+}
+
+/**
+ * nm_path2_pretty - Abbreviate a Mailbox path - Implements MxOps::path2_pretty()
+ * @retval 0 Notmuch Path can't be made pretty
+ */
+int nm_path2_pretty(const struct Path *path, const char *folder, char **pretty)
+{
+  int rc = 0;
+  struct Url *url1 = url_parse(path->orig);
+  struct Url *url2 = url_parse(folder);
+  struct Buffer buf = mutt_buffer_make(256);
+
+  if (url1->scheme != url2->scheme)
+    goto done;
+
+  if (mutt_str_strcmp(url1->path, url2->path) != 0)
+    goto done;
+
+  url1->path = "//";
+  if (url_tobuffer(url1, &buf, 0) != 0)
+    goto done; // LCOV_EXCL_LINE
+
+  mutt_str_replace(pretty, mutt_b2s(&buf));
+  rc = 1;
+
+done:
+  url_free(&url1);
+  url_free(&url2);
+  mutt_buffer_dealloc(&buf);
+  return rc;
+}
+
+/**
+ * nm_path2_probe - Does this Mailbox type recognise this path? - Implements MxOps::path2_probe()
+ *
+ * **Tests**
+ * - Path must begin "notmuch://"
+ * - Database path must exist
+ * - Database path must be a directory
+ * - Database path must contain a subdirectory `.notmuch`
+ *
+ * @note The case of the URL scheme is ignored
+ */
+int nm_path2_probe(struct Path *path, const struct stat *st)
+{
+  int rc = -1;
+  struct Url *url = url_parse(path->orig);
+  if (!url)
+    return -1;
+
+  if (url->scheme != U_NOTMUCH)
+    goto done;
+
+  // We stat the dir because NeoMutt can't parse the database path itself.
+  struct stat std = { 0 };
+  if ((stat(url->path, &std) != 0) || !S_ISDIR(std.st_mode))
+    goto done;
+
+  char buf[PATH_MAX];
+  snprintf(buf, sizeof(buf), "%s/.notmuch", url->path);
+  memset(&std, 0, sizeof(std));
+  if ((stat(buf, &std) != 0) || !S_ISDIR(std.st_mode))
+    goto done;
+
+  path->type = MUTT_NOTMUCH;
+  rc = 0;
+
+done:
+  url_free(&url);
+  return rc;
+}
+
+/**
+ * nm_path2_tidy - Tidy a Mailbox path - Implements MxOps::path2_tidy()
+ *
+ * **Changes**
+ * - Lowercase the URL scheme
+ * - Tidy the database path
+ */
+int nm_path2_tidy(struct Path *path)
+{
+  int rc = -1;
+  struct Buffer *buf = NULL;
+  char *tidy = NULL;
+
+  struct Url *url = url_parse(path->orig);
+  if (!url)
+    return -1;
+
+  if (url->scheme != U_NOTMUCH)
+    goto done;
+
+  buf = mutt_buffer_pool_get();
+  tidy = mutt_path_tidy2(url->path, true);
+
+  url->host = "/";
+  url->path = tidy;
+  if (url_tobuffer(url, buf, U_PATH) < 0)
+    goto done; // LCOV_EXCL_LINE
+
+  mutt_str_replace(&path->orig, mutt_b2s(buf));
+  path->flags |= MPATH_TIDY;
+  rc = 0;
+
+done:
+  url_free(&url);
+  FREE(&tidy);
+  mutt_buffer_pool_release(&buf);
+  return rc;
+}

--- a/notmuch/path.c
+++ b/notmuch/path.c
@@ -169,7 +169,6 @@ int nm_path2_parent(const struct Path *path, struct Path **parent)
 
 /**
  * nm_path2_pretty - Abbreviate a Mailbox path - Implements MxOps::path2_pretty()
- * @retval 0 Notmuch Path can't be made pretty
  */
 int nm_path2_pretty(const struct Path *path, const char *folder, char **pretty)
 {
@@ -203,9 +202,10 @@ done:
  *
  * **Tests**
  * - Path must begin "notmuch://"
- * - Database path must exist
- * - Database path must be a directory
- * - Database path must contain a subdirectory `.notmuch`
+ * - If supplied:
+ *   - Database path must exist
+ *   - Database path must be a directory
+ *   - Database path must contain a subdirectory `.notmuch`
  *
  * @note The case of the URL scheme is ignored
  */
@@ -219,16 +219,19 @@ int nm_path2_probe(struct Path *path, const struct stat *st)
   if (url->scheme != U_NOTMUCH)
     goto done;
 
-  // We stat the dir because NeoMutt can't parse the database path itself.
-  struct stat std = { 0 };
-  if ((stat(url->path, &std) != 0) || !S_ISDIR(std.st_mode))
-    goto done;
+  if (url->path)
+  {
+    // We stat the dir because NeoMutt can't parse the database path itself.
+    struct stat std = { 0 };
+    if ((stat(url->path, &std) != 0) || !S_ISDIR(std.st_mode))
+      goto done;
 
-  char buf[PATH_MAX];
-  snprintf(buf, sizeof(buf), "%s/.notmuch", url->path);
-  memset(&std, 0, sizeof(std));
-  if ((stat(buf, &std) != 0) || !S_ISDIR(std.st_mode))
-    goto done;
+    char buf[PATH_MAX];
+    snprintf(buf, sizeof(buf), "%s/.notmuch", url->path);
+    memset(&std, 0, sizeof(std));
+    if ((stat(buf, &std) != 0) || !S_ISDIR(std.st_mode))
+      goto done;
+  }
 
   path->type = MUTT_NOTMUCH;
   rc = 0;

--- a/notmuch/path.h
+++ b/notmuch/path.h
@@ -1,0 +1,36 @@
+/**
+ * @file
+ * Notmuch path manipulations
+ *
+ * @authors
+ * Copyright (C) 2020 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MUTT_NOTMUCH_PATH_H
+#define MUTT_NOTMUCH_PATH_H
+
+struct Path;
+struct stat;
+
+int nm_path2_canon  (struct Path *path);
+int nm_path2_compare(struct Path *path1, struct Path *path2);
+int nm_path2_parent (const struct Path *path, struct Path **parent);
+int nm_path2_pretty (const struct Path *path, const char *folder, char **pretty);
+int nm_path2_probe  (struct Path *path, const struct stat *st);
+int nm_path2_tidy   (struct Path *path);
+
+#endif /* MUTT_NOTMUCH_PATH_H */

--- a/pager.c
+++ b/pager.c
@@ -2358,7 +2358,7 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
       int check = mx_mbox_check(Context->mailbox, &index_hint);
       if (check < 0)
       {
-        if (!Context->mailbox || mutt_buffer_is_empty(&Context->mailbox->pathbuf))
+        if (!Context->mailbox || !Context->mailbox->path->orig)
         {
           /* fatal error occurred */
           ctx_free(&Context);

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -15,6 +15,7 @@ command_parse.c
 complete.c
 compose.c
 compress/compress.c
+compress/path.c
 config/address.c
 config/bool.c
 config/dump.c

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -120,6 +120,7 @@ maildir/path.c
 maildir/shared.c
 main.c
 mbox/mbox.c
+mbox/path.c
 menu.c
 monitor.c
 mutt/base64.c

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -192,6 +192,7 @@ opcodes.h
 pager.c
 pattern.c
 pgpewrap.c
+pop/path.c
 pop/pop.c
 pop/pop_auth.c
 pop/pop_lib.c

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -187,6 +187,7 @@ nntp/nntp.c
 nntp/path.c
 notmuch/mutt_notmuch.c
 notmuch/nm_db.c
+notmuch/path.c
 opcodes.h
 pager.c
 pattern.c

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -107,6 +107,7 @@ imap/browse.c
 imap/command.c
 imap/imap.c
 imap/message.c
+imap/path.c
 imap/utf7.c
 imap/util.c
 index.c

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -116,6 +116,7 @@ keymap.c
 mailcap.c
 maildir/maildir.c
 maildir/mh.c
+maildir/path.c
 maildir/shared.c
 main.c
 mbox/mbox.c

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -163,6 +163,7 @@ mutt_socket.c
 mutt_thread.c
 mutt_zstrm.c
 mx.c
+mx_path.c
 myvar.c
 ncrypt/crypt.c
 ncrypt/cryptglue.c

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -184,6 +184,7 @@ nntp/browse.c
 nntp/complete.c
 nntp/newsrc.c
 nntp/nntp.c
+nntp/path.c
 notmuch/mutt_notmuch.c
 notmuch/nm_db.c
 opcodes.h

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -46,6 +46,7 @@ copy.c
 core/account.c
 core/mailbox.c
 core/neomutt.c
+core/path.c
 debug/backtrace.c
 debug/graphviz.c
 debug/notify.c

--- a/pop/lib.h
+++ b/pop/lib.h
@@ -26,6 +26,7 @@
 #include <stdbool.h>
 #include "core/lib.h"
 #include "mx.h"
+#include "path.h"
 
 struct Slist;
 struct stat;
@@ -37,6 +38,7 @@ struct stat;
  *
  * | File           | Description       |
  * | :------------- | :---------------- |
+ * | pop/path.c     | @subpage pop_path |
  * | pop/pop_auth.c | @subpage pop_auth |
  * | pop/pop.c      | @subpage pop_pop  |
  * | pop/pop_lib.c  | @subpage pop_lib  |

--- a/pop/path.c
+++ b/pop/path.c
@@ -1,0 +1,222 @@
+/**
+ * @file
+ * Pop path manipulations
+ *
+ * @authors
+ * Copyright (C) 2020 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @page pop_path Pop path manipulations
+ *
+ * Pop path manipulations
+ */
+
+#include "config.h"
+#include "config/lib.h"
+#include "email/lib.h"
+#include "core/lib.h"
+
+extern char *HomeDir;
+
+/**
+ * pop_path2_canon - Canonicalise a Mailbox path
+ * @param path Path to canonicalise
+ * @param user Login username
+ * @param port Server port
+ * @retval  0 Success
+ * @retval -1 Failure
+ */
+int pop_path2_canon(struct Path *path, char *user, int port)
+{
+  struct Url *url = url_parse(path->orig);
+  if (!url)
+    return -1;
+
+  if (!url->user)
+    url->user = user;
+  if (url->port == 0)
+    url->port = port;
+  if (url->pass)
+    url->pass = NULL;
+
+  int rc = -1;
+  struct Buffer buf = mutt_buffer_make(256);
+  if (url_tobuffer(url, &buf, 0) != 0)
+    goto done; // LCOV_EXCL_LINE
+
+  mutt_str_replace(&path->canon, mutt_b2s(&buf));
+  path->flags |= MPATH_CANONICAL;
+  rc = 0;
+
+done:
+  url_free(&url);
+  mutt_buffer_dealloc(&buf);
+  return rc;
+}
+
+/**
+ * pop_path2_compare - Compare two Mailbox paths - Implements MxOps::path2_compare()
+ *
+ * **Tests**
+ * - scheme must match
+ * - host must match
+ * - user must match, or may be absent from one, or absent from both
+ * - pass must match, or may be absent from one, or absent from both
+ * - port must match, or may be absent from one, or absent from both
+ * - path must match
+ */
+int pop_path2_compare(struct Path *path1, struct Path *path2)
+{
+  struct Url *url1 = url_parse(path1->canon);
+  struct Url *url2 = url_parse(path2->canon);
+
+  int rc = url1->scheme - url2->scheme;
+  if (rc != 0)
+    goto done;
+
+  if (url1->user && url2->user)
+  {
+    rc = mutt_str_strcmp(url1->user, url2->user);
+    if (rc != 0)
+      goto done;
+  }
+
+  rc = mutt_str_strcasecmp(url1->host, url2->host);
+  if (rc != 0)
+    goto done;
+
+  if ((url1->port != 0) && (url2->port != 0))
+  {
+    rc = url1->port - url2->port;
+    if (rc != 0)
+      goto done;
+  }
+
+  rc = mutt_str_strcmp(url1->path, url2->path);
+
+done:
+  url_free(&url1);
+  url_free(&url2);
+  if (rc < 0)
+    return -1;
+  if (rc > 0)
+    return 1;
+  return 0;
+}
+
+/**
+ * pop_path2_parent - Find the parent of a Mailbox path - Implements MxOps::path2_parent()
+ * @retval -1 Pop mailbox doesn't have a parent
+ */
+int pop_path2_parent(const struct Path *path, struct Path **parent)
+{
+  return -1;
+}
+
+/**
+ * pop_path2_pretty - Abbreviate a Mailbox path - Implements MxOps::path2_pretty()
+ *
+ * **Tests**
+ * - scheme must match
+ * - host must match
+ * - user must match, or may be absent from one, or absent from both
+ * - pass must match, or may be absent from one, or absent from both
+ * - port must match, or may be absent from one, or absent from both
+ */
+int pop_path2_pretty(const struct Path *path, const char *folder, char **pretty)
+{
+  int rc = 0;
+  struct Url *url1 = url_parse(path->orig);
+  struct Url *url2 = url_parse(folder);
+
+  if (url1->scheme != url2->scheme)
+    goto done;
+  if (mutt_str_strcasecmp(url1->host, url2->host) != 0)
+    goto done;
+  if (!path_partial_match_string(url1->user, url2->user))
+    goto done;
+  if (!path_partial_match_number(url1->port, url2->port))
+    goto done;
+  if (!mutt_path2_abbr_folder(url1->path, url2->path, pretty))
+    goto done;
+
+  rc = 1;
+
+done:
+  url_free(&url1);
+  url_free(&url2);
+  return rc;
+}
+
+/**
+ * pop_path2_probe - Does this Mailbox type recognise this path? - Implements MxOps::path2_probe()
+ *
+ * **Tests**
+ * - Path may begin "pop://"
+ * - Path may begin "pops://"
+ *
+ * @note The case of the URL scheme is ignored
+ */
+int pop_path2_probe(struct Path *path, const struct stat *st)
+{
+  if (!mutt_str_startswith(path->orig, "pop://", CASE_IGNORE) &&
+      !mutt_str_startswith(path->orig, "pops://", CASE_IGNORE))
+  {
+    return -1;
+  }
+
+  path->type = MUTT_POP;
+  return 0;
+}
+
+/**
+ * pop_path2_tidy - Tidy a Mailbox path - Implements MxOps::path2_tidy()
+ *
+ * **Changes**
+ * - Lowercase the URL scheme
+ * - Replace empty path with "INBOX"
+ */
+int pop_path2_tidy(struct Path *path)
+{
+  struct Url *url = url_parse(path->orig);
+  if (!url)
+    return -1;
+
+  if (!url->path || (url->path[0] == '\0') ||
+      ((url->path[0] == '/') && (url->path[1] == '\0')) ||
+      (mutt_str_strcasecmp(url->path, "inbox") == 0))
+  {
+    url->path = "INBOX";
+  }
+
+  url->pass = NULL;
+
+  int rc = -1;
+  struct Buffer *buf = mutt_buffer_pool_get();
+  if (url_tobuffer(url, buf, 0) < 0)
+    goto done; // LCOV_EXCL_LINE
+
+  mutt_str_replace(&path->orig, mutt_b2s(buf));
+  path->flags |= MPATH_TIDY;
+  rc = 0;
+
+done:
+  url_free(&url);
+  mutt_buffer_pool_release(&buf);
+  return rc;
+}

--- a/pop/path.h
+++ b/pop/path.h
@@ -1,0 +1,36 @@
+/**
+ * @file
+ * Pop path manipulations
+ *
+ * @authors
+ * Copyright (C) 2020 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MUTT_POP_PATH_H
+#define MUTT_POP_PATH_H
+
+struct Path;
+struct stat;
+
+int pop_path2_canon  (struct Path *path, char *user, int port);
+int pop_path2_compare(struct Path *path1, struct Path *path2);
+int pop_path2_parent (const struct Path *path, struct Path **parent);
+int pop_path2_pretty (const struct Path *path, const char *folder, char **pretty);
+int pop_path2_probe  (struct Path *path, const struct stat *st);
+int pop_path2_tidy   (struct Path *path);
+
+#endif /* MUTT_POP_PATH_H */

--- a/pop/pop.c
+++ b/pop/pop.c
@@ -643,7 +643,7 @@ void pop_fetch_mail(void)
     goto finish;
   }
 
-  struct Mailbox *m_spool = mx_path_resolve(C_Spoolfile);
+  struct Mailbox *m_spool = mx_path_resolve(C_Spoolfile, C_Folder);
   struct Context *ctx = mx_mbox_open(m_spool, MUTT_OPEN_NO_FLAGS);
   if (!ctx)
   {

--- a/pop/pop.c
+++ b/pop/pop.c
@@ -825,8 +825,8 @@ static int pop_mbox_open(struct Mailbox *m)
   url.path = NULL;
   url_tostring(&url, buf, sizeof(buf), 0);
 
-  mutt_buffer_strcpy(&m->pathbuf, buf);
-  mutt_str_replace(&m->realpath, mailbox_path(m));
+  mutt_str_replace(&m->path->orig, buf);
+  mutt_str_replace(&m->path->canon, mailbox_path(m));
 
   struct PopAccountData *adata = m->account->adata;
   if (!adata)
@@ -846,7 +846,7 @@ static int pop_mbox_open(struct Mailbox *m)
   }
 
   if (conn->fd < 0)
-    mutt_account_hook(m->realpath);
+    mutt_account_hook(m->path->canon);
 
   if (pop_open_connection(adata) < 0)
     return -1;

--- a/pop/pop.c
+++ b/pop/pop.c
@@ -1255,15 +1255,6 @@ static int pop_path_canon(char *buf, size_t buflen)
 }
 
 /**
- * pop_path_pretty - Abbreviate a Mailbox path - Implements MxOps::path_pretty()
- */
-static int pop_path_pretty(char *buf, size_t buflen, const char *folder)
-{
-  /* Succeed, but don't do anything, for now */
-  return 0;
-}
-
-/**
  * pop_path_parent - Find the parent of a Mailbox path - Implements MxOps::path_parent()
  */
 static int pop_path_parent(char *buf, size_t buflen)
@@ -1348,7 +1339,6 @@ struct MxOps MxPopOps = {
   .tags_commit      = NULL,
   .path_probe       = pop_path_probe,
   .path_canon       = pop_path_canon,
-  .path_pretty      = pop_path_pretty,
   .path_parent      = pop_path_parent,
   .path2_canon      = pop_path2_canon_wrapper,
   .path2_compare    = pop_path2_compare,

--- a/pop/pop.c
+++ b/pop/pop.c
@@ -54,6 +54,7 @@
 #include "mutt_socket.h"
 #include "muttlib.h"
 #include "mx.h"
+#include "path.h"
 #include "progress.h"
 #include "ncrypt/lib.h"
 #ifdef ENABLE_NLS
@@ -1271,6 +1272,56 @@ static int pop_path_parent(char *buf, size_t buflen)
   return 0;
 }
 
+/**
+ * pop_ac2_is_owner - Does this Account own this Path? - Implements MxOps::ac2_is_owner()
+ */
+static int pop_ac2_is_owner(struct Account *a, const struct Path *path)
+{
+  if (a->magic != MUTT_POP)
+    return -1;
+
+  struct Url *url = url_parse(path->orig);
+  struct PopAccountData *adata = a->adata;
+  struct ConnAccount *cac = &adata->conn->account;
+  int rc = -1;
+
+  if (mutt_str_strcasecmp(cac->host, url->host) != 0)
+    goto done;
+  if (!path_partial_match_string(cac->user, url->user))
+    goto done;
+  if (!path_partial_match_string(cac->pass, url->pass))
+    goto done;
+  if (!path_partial_match_number(cac->port, url->port))
+    goto done;
+
+  rc = 0;
+
+done:
+  url_free(&url);
+  return rc;
+}
+
+/**
+ * pop_path2_canon_wrapper - Canonicalise a Mailbox path - Implements MxOps::path2_canon()
+ */
+static int pop_path2_canon_wrapper(struct Path *path)
+{
+  struct Account *np = NULL;
+  TAILQ_FOREACH(np, &NeoMutt->accounts, entries)
+  {
+    if (pop_ac2_is_owner(np, path) == 0)
+      break;
+  }
+
+  if (!np)
+    return -1;
+
+  struct PopAccountData *adata = np->adata;
+  struct ConnAccount *cac = &adata->conn->account;
+
+  return pop_path2_canon(path, cac->user, cac->port);
+}
+
 // clang-format off
 /**
  * MxPopOps - POP Mailbox - Implements ::MxOps
@@ -1299,5 +1350,11 @@ struct MxOps MxPopOps = {
   .path_canon       = pop_path_canon,
   .path_pretty      = pop_path_pretty,
   .path_parent      = pop_path_parent,
+  .path2_canon      = pop_path2_canon_wrapper,
+  .path2_compare    = pop_path2_compare,
+  .path2_parent     = pop_path2_parent,
+  .path2_pretty     = pop_path2_pretty,
+  .path2_probe      = pop_path2_probe,
+  .path2_tidy       = pop_path2_tidy,
 };
 // clang-format on

--- a/pop/pop_private.h
+++ b/pop/pop_private.h
@@ -27,11 +27,15 @@
 #include <stdbool.h>
 #include <time.h>
 #include "mutt/lib.h"
+#include "core/lib.h"
 #include "conn/lib.h"
 
 struct Email;
 struct Mailbox;
+struct Path;
 struct Progress;
+struct stat;
+
 
 #define POP_PORT 110
 #define POP_SSL_PORT 995

--- a/postpone.c
+++ b/postpone.c
@@ -171,7 +171,7 @@ int mutt_num_postponed(struct Mailbox *m, bool force)
     if (optnews)
       OptNews = false;
 #endif
-    struct Mailbox *m_post = mx_path_resolve(C_Postponed);
+    struct Mailbox *m_post = mx_path_resolve(C_Postponed, C_Folder);
     struct Context *ctx = mx_mbox_open(m_post, MUTT_NOSORT | MUTT_QUIET);
     if (ctx)
     {
@@ -339,7 +339,7 @@ int mutt_get_postponed(struct Context *ctx, struct Email *hdr,
   const char *p = NULL;
   struct Context *ctx_post = NULL;
 
-  struct Mailbox *m = mx_path_resolve(C_Postponed);
+  struct Mailbox *m = mx_path_resolve(C_Postponed, C_Folder);
   if (ctx && (ctx->mailbox == m))
     ctx_post = ctx;
   else

--- a/postpone.c
+++ b/postpone.c
@@ -108,7 +108,7 @@ int mutt_num_postponed(struct Mailbox *m, bool force)
     return 0;
 
   // We currently are in the C_Postponed mailbox so just pick the current status
-  if (m && (mutt_str_strcmp(C_Postponed, m->realpath) == 0))
+  if (m && (mutt_str_strcmp(C_Postponed, m->path->canon) == 0))
   {
     PostCount = m->msg_count - m->msg_deleted;
     return PostCount;

--- a/sendlib.c
+++ b/sendlib.c
@@ -3272,7 +3272,7 @@ int mutt_write_fcc(const char *path, struct Email *e, const char *msgid,
 #ifdef RECORD_FOLDER_HOOK
   mutt_folder_hook(path, NULL);
 #endif
-  struct Mailbox *m_fcc = mx_path_resolve(path);
+  struct Mailbox *m_fcc = mx_path_resolve(path, C_Folder);
   bool old_append = m_fcc->append;
   struct Context *ctx_fcc = mx_mbox_open(m_fcc, MUTT_APPEND | MUTT_QUIET);
   if (!ctx_fcc)

--- a/sidebar.c
+++ b/sidebar.c
@@ -904,8 +904,8 @@ static void draw_sidebar(struct MuttWindow *win, int num_rows, int num_cols, int
       col = div_width;
 
     mutt_window_move(win, row, col);
-    if (Context && Context->mailbox && (Context->mailbox->path->canon[0] != '\0') &&
-        (mutt_str_strcmp(m->path->canon, Context->mailbox->path->canon) == 0))
+    if (Context && Context->mailbox && (Context->mailbox->path->orig[0] != '\0') &&
+        (mutt_str_strcmp(m->path->orig, Context->mailbox->path->orig) == 0))
     {
       m->msg_unread = Context->mailbox->msg_unread;
       m->msg_count = Context->mailbox->msg_count;

--- a/status.c
+++ b/status.c
@@ -130,6 +130,7 @@ static const char *status_format_str(char *buf, size_t buflen, size_t col, int c
     {
       char *pretty = NULL;
       struct Mailbox *m = Context ? Context->mailbox : NULL;
+      //JKJ this could be a file/dir or a mailbox!
       if (m)
         mx_path2_pretty(m->path, C_Folder, (op == 'D'), &pretty);
 

--- a/status.c
+++ b/status.c
@@ -128,9 +128,9 @@ static const char *status_format_str(char *buf, size_t buflen, size_t col, int c
     {
       struct Mailbox *m = Context ? Context->mailbox : NULL;
       // If there's a descriptive name, use it. Otherwise, fall-through
-      if (m && m->name)
+      if (m && m->path->desc)
       {
-        mutt_str_strfcpy(tmp, m->name, sizeof(tmp));
+        mutt_str_strfcpy(tmp, m->path->desc, sizeof(tmp));
         snprintf(fmt, sizeof(fmt), "%%%ss", prec);
         snprintf(buf, buflen, fmt, tmp);
         break;
@@ -142,18 +142,18 @@ static const char *status_format_str(char *buf, size_t buflen, size_t col, int c
       struct Mailbox *m = Context ? Context->mailbox : NULL;
 
 #ifdef USE_COMPRESSED
-      if (m && m->compress_info && (m->realpath[0] != '\0'))
+      if (m && m->compress_info && (m->path->canon[0] != '\0'))
       {
-        mutt_str_strfcpy(tmp, m->realpath, sizeof(tmp));
+        mutt_str_strfcpy(tmp, m->path->canon, sizeof(tmp));
         mutt_pretty_mailbox(tmp, sizeof(tmp));
       }
       else
 #endif
-          if (m && (m->magic == MUTT_NOTMUCH) && m->name)
+          if (m && (m->magic == MUTT_NOTMUCH) && m->path->desc)
       {
-        mutt_str_strfcpy(tmp, m->name, sizeof(tmp));
+        mutt_str_strfcpy(tmp, m->path->desc, sizeof(tmp));
       }
-      else if (m && !mutt_buffer_is_empty(&m->pathbuf))
+      else if (m && m->path->orig)
       {
         mutt_str_strfcpy(tmp, mailbox_path(m), sizeof(tmp));
         mutt_pretty_mailbox(tmp, sizeof(tmp));

--- a/test/Makefile.autosetup
+++ b/test/Makefile.autosetup
@@ -281,6 +281,7 @@ MX_PATH_OBJS	= test/mx_path/common.o \
 		  test/mx_path/comp.o \
 		  test/mx_path/imap.o \
 		  test/mx_path/maildir.o \
+		  test/mx_path/mbox.o \
 
 PARAMETER_OBJS	= test/parameter/mutt_param_cmp_strict.o \
 		  test/parameter/mutt_param_delete.o \

--- a/test/Makefile.autosetup
+++ b/test/Makefile.autosetup
@@ -284,6 +284,10 @@ MX_PATH_OBJS	= test/mx_path/common.o \
 		  test/mx_path/mbox.o \
 		  test/mx_path/nntp.o \
 
+@if USE_NOTMUCH
+MX_PATH_OBJS+=	  test/mx_path/notmuch.o
+@endif
+
 PARAMETER_OBJS	= test/parameter/mutt_param_cmp_strict.o \
 		  test/parameter/mutt_param_delete.o \
 		  test/parameter/mutt_param_free.o \

--- a/test/Makefile.autosetup
+++ b/test/Makefile.autosetup
@@ -283,6 +283,7 @@ MX_PATH_OBJS	= test/mx_path/common.o \
 		  test/mx_path/maildir.o \
 		  test/mx_path/mbox.o \
 		  test/mx_path/nntp.o \
+		  test/mx_path/pop.o
 
 @if USE_NOTMUCH
 MX_PATH_OBJS+=	  test/mx_path/notmuch.o

--- a/test/Makefile.autosetup
+++ b/test/Makefile.autosetup
@@ -279,6 +279,7 @@ MEMORY_OBJS	= test/memory/mutt_mem_calloc.o \
 
 MX_PATH_OBJS	= test/mx_path/common.o \
 		  test/mx_path/comp.o \
+		  test/mx_path/imap.o \
 
 PARAMETER_OBJS	= test/parameter/mutt_param_cmp_strict.o \
 		  test/parameter/mutt_param_delete.o \

--- a/test/Makefile.autosetup
+++ b/test/Makefile.autosetup
@@ -280,6 +280,7 @@ MEMORY_OBJS	= test/memory/mutt_mem_calloc.o \
 MX_PATH_OBJS	= test/mx_path/common.o \
 		  test/mx_path/comp.o \
 		  test/mx_path/imap.o \
+		  test/mx_path/maildir.o \
 
 PARAMETER_OBJS	= test/parameter/mutt_param_cmp_strict.o \
 		  test/parameter/mutt_param_delete.o \

--- a/test/Makefile.autosetup
+++ b/test/Makefile.autosetup
@@ -277,6 +277,8 @@ MEMORY_OBJS	= test/memory/mutt_mem_calloc.o \
 		  test/memory/mutt_mem_malloc.o \
 		  test/memory/mutt_mem_realloc.o
 
+MX_PATH_OBJS	= test/mx_path/common.o \
+
 PARAMETER_OBJS	= test/parameter/mutt_param_cmp_strict.o \
 		  test/parameter/mutt_param_delete.o \
 		  test/parameter/mutt_param_free.o \
@@ -432,11 +434,11 @@ BUILD_DIRS	= $(PWD)/test/address $(PWD)/test/attach $(PWD)/test/base64 \
 		  $(PWD)/test/from $(PWD)/test/group $(PWD)/test/gui $(PWD)/test/hash \
 		  $(PWD)/test/history $(PWD)/test/idna $(PWD)/test/list \
 		  $(PWD)/test/logging $(PWD)/test/mapping $(PWD)/test/mbyte \
-		  $(PWD)/test/md5 $(PWD)/test/memory $(PWD)/test/parameter \
-		  $(PWD)/test/parse $(PWD)/test/path $(PWD)/test/pattern \
-		  $(PWD)/test/regex $(PWD)/test/rfc2047 $(PWD)/test/rfc2231 \
-		  $(PWD)/test/signal $(PWD)/test/string $(PWD)/test/tags \
-		  $(PWD)/test/thread $(PWD)/test/url
+		  $(PWD)/test/md5 $(PWD)/test/memory $(PWD)/test/mx_path \
+		  $(PWD)/test/parameter $(PWD)/test/parse $(PWD)/test/path \
+		  $(PWD)/test/pattern $(PWD)/test/regex $(PWD)/test/rfc2047 \
+		  $(PWD)/test/rfc2231 $(PWD)/test/signal $(PWD)/test/string \
+		  $(PWD)/test/tags $(PWD)/test/thread $(PWD)/test/url
 
 TEST_OBJS	= test/main.o \
 		  $(ADDRESS_OBJS) \
@@ -463,6 +465,7 @@ TEST_OBJS	= test/main.o \
 		  $(MBYTE_OBJS) \
 		  $(MD5_OBJS) \
 		  $(MEMORY_OBJS) \
+		  $(MX_PATH_OBJS) \
 		  $(PARAMETER_OBJS) \
 		  $(PARSE_OBJS) \
 		  $(PATH_OBJS) \

--- a/test/Makefile.autosetup
+++ b/test/Makefile.autosetup
@@ -282,6 +282,7 @@ MX_PATH_OBJS	= test/mx_path/common.o \
 		  test/mx_path/imap.o \
 		  test/mx_path/maildir.o \
 		  test/mx_path/mbox.o \
+		  test/mx_path/nntp.o \
 
 PARAMETER_OBJS	= test/parameter/mutt_param_cmp_strict.o \
 		  test/parameter/mutt_param_delete.o \

--- a/test/Makefile.autosetup
+++ b/test/Makefile.autosetup
@@ -278,6 +278,7 @@ MEMORY_OBJS	= test/memory/mutt_mem_calloc.o \
 		  test/memory/mutt_mem_realloc.o
 
 MX_PATH_OBJS	= test/mx_path/common.o \
+		  test/mx_path/comp.o \
 
 PARAMETER_OBJS	= test/parameter/mutt_param_cmp_strict.o \
 		  test/parameter/mutt_param_delete.o \

--- a/test/main.c
+++ b/test/main.c
@@ -414,6 +414,12 @@
   NEOMUTT_TEST_ITEM(test_comp_path2_pretty)                                    \
   NEOMUTT_TEST_ITEM(test_comp_path2_probe)                                     \
   NEOMUTT_TEST_ITEM(test_comp_path2_tidy)                                      \
+  NEOMUTT_TEST_ITEM(test_imap_path2_canon)                                     \
+  NEOMUTT_TEST_ITEM(test_imap_path2_compare)                                   \
+  NEOMUTT_TEST_ITEM(test_imap_path2_parent)                                    \
+  NEOMUTT_TEST_ITEM(test_imap_path2_pretty)                                    \
+  NEOMUTT_TEST_ITEM(test_imap_path2_probe)                                     \
+  NEOMUTT_TEST_ITEM(test_imap_path2_tidy)                                      \
 
 /******************************************************************************
  * You probably don't need to touch what follows.

--- a/test/main.c
+++ b/test/main.c
@@ -440,6 +440,12 @@
   NEOMUTT_TEST_ITEM(test_nntp_path2_pretty)                                    \
   NEOMUTT_TEST_ITEM(test_nntp_path2_probe)                                     \
   NEOMUTT_TEST_ITEM(test_nntp_path2_tidy)                                      \
+  NEOMUTT_TEST_ITEM(test_pop_path2_canon)                                      \
+  NEOMUTT_TEST_ITEM(test_pop_path2_compare)                                    \
+  NEOMUTT_TEST_ITEM(test_pop_path2_parent)                                     \
+  NEOMUTT_TEST_ITEM(test_pop_path2_pretty)                                     \
+  NEOMUTT_TEST_ITEM(test_pop_path2_probe)                                      \
+  NEOMUTT_TEST_ITEM(test_pop_path2_tidy)
 
 #define NOTMUCH_TEST_LIST                                                      \
   NEOMUTT_TEST_ITEM(test_nm_path2_canon)                                       \

--- a/test/main.c
+++ b/test/main.c
@@ -434,6 +434,12 @@
   NEOMUTT_TEST_ITEM(test_mbox_path2_pretty)                                    \
   NEOMUTT_TEST_ITEM(test_mbox_path2_probe)                                     \
   NEOMUTT_TEST_ITEM(test_mbox_path2_tidy)                                      \
+  NEOMUTT_TEST_ITEM(test_nntp_path2_canon)                                     \
+  NEOMUTT_TEST_ITEM(test_nntp_path2_compare)                                   \
+  NEOMUTT_TEST_ITEM(test_nntp_path2_parent)                                    \
+  NEOMUTT_TEST_ITEM(test_nntp_path2_pretty)                                    \
+  NEOMUTT_TEST_ITEM(test_nntp_path2_probe)                                     \
+  NEOMUTT_TEST_ITEM(test_nntp_path2_tidy)                                      \
 
 /******************************************************************************
  * You probably don't need to touch what follows.

--- a/test/main.c
+++ b/test/main.c
@@ -428,6 +428,12 @@
   NEOMUTT_TEST_ITEM(test_maildir_path2_probe)                                  \
   NEOMUTT_TEST_ITEM(test_mh_path2_probe)                                       \
   NEOMUTT_TEST_ITEM(test_maildir_path2_tidy)                                   \
+  NEOMUTT_TEST_ITEM(test_mbox_path2_canon)                                     \
+  NEOMUTT_TEST_ITEM(test_mbox_path2_compare)                                   \
+  NEOMUTT_TEST_ITEM(test_mbox_path2_parent)                                    \
+  NEOMUTT_TEST_ITEM(test_mbox_path2_pretty)                                    \
+  NEOMUTT_TEST_ITEM(test_mbox_path2_probe)                                     \
+  NEOMUTT_TEST_ITEM(test_mbox_path2_tidy)                                      \
 
 /******************************************************************************
  * You probably don't need to touch what follows.

--- a/test/main.c
+++ b/test/main.c
@@ -441,16 +441,31 @@
   NEOMUTT_TEST_ITEM(test_nntp_path2_probe)                                     \
   NEOMUTT_TEST_ITEM(test_nntp_path2_tidy)                                      \
 
+#define NOTMUCH_TEST_LIST                                                      \
+  NEOMUTT_TEST_ITEM(test_nm_path2_canon)                                       \
+  NEOMUTT_TEST_ITEM(test_nm_path2_compare)                                     \
+  NEOMUTT_TEST_ITEM(test_nm_path2_parent)                                      \
+  NEOMUTT_TEST_ITEM(test_nm_path2_pretty)                                      \
+  NEOMUTT_TEST_ITEM(test_nm_path2_probe)                                       \
+  NEOMUTT_TEST_ITEM(test_nm_path2_tidy)
+
 /******************************************************************************
  * You probably don't need to touch what follows.
  *****************************************************************************/
 #define NEOMUTT_TEST_ITEM(x) void x(void);
 NEOMUTT_TEST_LIST
+#ifdef USE_NOTMUCH
+NOTMUCH_TEST_LIST
+#endif
+
 #undef NEOMUTT_TEST_ITEM
 
 TEST_LIST = {
 #define NEOMUTT_TEST_ITEM(x) { #x, x },
   NEOMUTT_TEST_LIST
+#ifdef USE_NOTMUCH
+      NOTMUCH_TEST_LIST
+#endif
 #undef NEOMUTT_TEST_ITEM
   { 0 }
 };

--- a/test/main.c
+++ b/test/main.c
@@ -420,6 +420,14 @@
   NEOMUTT_TEST_ITEM(test_imap_path2_pretty)                                    \
   NEOMUTT_TEST_ITEM(test_imap_path2_probe)                                     \
   NEOMUTT_TEST_ITEM(test_imap_path2_tidy)                                      \
+  NEOMUTT_TEST_ITEM(test_maildir_path2_canon)                                  \
+  NEOMUTT_TEST_ITEM(test_maildir_path2_compare)                                \
+  NEOMUTT_TEST_ITEM(test_maildir_path2_parent)                                 \
+  NEOMUTT_TEST_ITEM(test_mh_path2_parent)                                      \
+  NEOMUTT_TEST_ITEM(test_maildir_path2_pretty)                                 \
+  NEOMUTT_TEST_ITEM(test_maildir_path2_probe)                                  \
+  NEOMUTT_TEST_ITEM(test_mh_path2_probe)                                       \
+  NEOMUTT_TEST_ITEM(test_maildir_path2_tidy)                                   \
 
 /******************************************************************************
  * You probably don't need to touch what follows.

--- a/test/main.c
+++ b/test/main.c
@@ -407,7 +407,13 @@
   NEOMUTT_TEST_ITEM(test_url_pct_encode)                                       \
   NEOMUTT_TEST_ITEM(test_url_tobuffer)                                         \
   NEOMUTT_TEST_ITEM(test_url_tostring)                                         \
-  NEOMUTT_TEST_ITEM(test_window_reflow)
+  NEOMUTT_TEST_ITEM(test_window_reflow)                                        \
+  NEOMUTT_TEST_ITEM(test_comp_path2_canon)                                     \
+  NEOMUTT_TEST_ITEM(test_comp_path2_compare)                                   \
+  NEOMUTT_TEST_ITEM(test_comp_path2_parent)                                    \
+  NEOMUTT_TEST_ITEM(test_comp_path2_pretty)                                    \
+  NEOMUTT_TEST_ITEM(test_comp_path2_probe)                                     \
+  NEOMUTT_TEST_ITEM(test_comp_path2_tidy)                                      \
 
 /******************************************************************************
  * You probably don't need to touch what follows.

--- a/test/main.c
+++ b/test/main.c
@@ -22,6 +22,7 @@
  */
 
 #include "acutest.h"
+#include "config.h"
 
 /******************************************************************************
  * Add your test cases to this list.

--- a/test/mx_path/common.c
+++ b/test/mx_path/common.c
@@ -1,0 +1,26 @@
+/**
+ * @file
+ * Shared code for the MxOps Path functions
+ *
+ * @authors
+ * Copyright (C) 2020 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+#include "mutt/lib.h"
+
+const char *HomeDir;

--- a/test/mx_path/common.c
+++ b/test/mx_path/common.c
@@ -21,6 +21,39 @@
  */
 
 #include "config.h"
+#include <stdio.h>
+#include <string.h>
 #include "mutt/lib.h"
 
 const char *HomeDir;
+
+static const char *get_test_path(void)
+{
+  static const char *path = NULL;
+  if (!path)
+    path = mutt_str_getenv("NEOMUTT_TEST_DIR");
+  if (!path)
+    path = "";
+
+  return path;
+}
+
+void test_gen_path(char *buf, size_t buflen, const char *fmt)
+{
+  snprintf(buf, buflen, NONULL(fmt), get_test_path());
+}
+
+void test_gen_dir(char *buf, size_t buflen, const char *fmt)
+{
+  static const char *dir = NULL;
+  if (!dir)
+  {
+    const char *path = get_test_path();
+    const char *slash = strrchr(path, '/');
+    dir = slash + 1;
+  }
+  if (!dir)
+    dir = "";
+
+  snprintf(buf, buflen, NONULL(fmt), dir);
+}

--- a/test/mx_path/common.h
+++ b/test/mx_path/common.h
@@ -1,0 +1,35 @@
+/**
+ * @file
+ * Shared code for the MxOps Path functions
+ *
+ * @authors
+ * Copyright (C) 2020 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef TEST_MX_PATH_COMMON_H
+#define TEST_MX_PATH_COMMON_H
+
+extern const char *HomeDir;
+
+struct TestValue
+{
+  char *first;
+  char *second;
+  int retval;
+};
+
+#endif /* TEST_MX_PATH_COMMON_H */

--- a/test/mx_path/common.h
+++ b/test/mx_path/common.h
@@ -32,4 +32,7 @@ struct TestValue
   int retval;
 };
 
+void test_gen_dir (char *buf, size_t buflen, const char *fmt);
+void test_gen_path(char *buf, size_t buflen, const char *fmt);
+
 #endif /* TEST_MX_PATH_COMMON_H */

--- a/test/mx_path/comp.c
+++ b/test/mx_path/comp.c
@@ -1,0 +1,237 @@
+/**
+ * @file
+ * Test code for the Compressed MxOps Path functions
+ *
+ * @authors
+ * Copyright (C) 2020 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define TEST_NO_MAIN
+#include "acutest.h"
+#include "config.h"
+#include <stdbool.h>
+#include <string.h>
+#include <sys/stat.h>
+#include "mutt/lib.h"
+#include "core/lib.h"
+#include "common.h"
+#include "compress/path.h"
+
+bool mutt_comp_can_read(const char *path)
+{
+  static const char *suffix = ".gz";
+  size_t len = strlen(path);
+
+  return (strcmp(path + len - 3, suffix) == 0);
+}
+
+void test_comp_path2_canon(void)
+{
+  // clang-format off
+  static const struct TestValue tests[] = {
+    { "/home/mutt/path/compress/apple.gz",         "/home/mutt/path/compress/apple.gz",  0 }, // Real path
+    { "/home/mutt/path/compress/symlink/apple.gz", "/home/mutt/path/compress/apple.gz",  0 }, // Symlink
+    { "/home/mutt/path/compress/missing",          NULL,                                -1 }, // Missing
+  };
+  // clang-format on
+
+  struct Path path = { 0 };
+  int rc;
+  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  {
+    path.orig = tests[i].first;
+    TEST_CASE(path.orig);
+    path.type = MUTT_COMPRESSED;
+    path.flags = MPATH_RESOLVED | MPATH_TIDY;
+
+    rc = comp_path2_canon(&path);
+    TEST_CHECK(rc == tests[i].retval);
+    if (rc == 0)
+    {
+      TEST_CHECK(path.flags & MPATH_CANONICAL);
+      TEST_CHECK(path.canon != NULL);
+      TEST_CHECK(mutt_str_strcmp(path.canon, tests[i].second) == 0);
+    }
+    FREE(&path.canon);
+  }
+}
+
+void test_comp_path2_compare(void)
+{
+  // clang-format off
+  static const struct TestValue tests[] = {
+    { "/home/mutt/path/compress/apple.gz",  "/home/mutt/path/compress/apple.gz",   0 }, // Match
+    { "/home/mutt/path/compress/apple.gz",  "/home/mutt/path/compress/orange.gz", -1 }, // Differ
+    { "/home/mutt/path/compress/orange.gz", "/home/mutt/path/compress/apple.gz",   1 }, // Differ
+  };
+  // clang-format on
+
+  struct Path path1 = {
+    .type = MUTT_COMPRESSED,
+    .flags = MPATH_RESOLVED | MPATH_TIDY | MPATH_CANONICAL,
+  };
+  struct Path path2 = {
+    .type = MUTT_COMPRESSED,
+    .flags = MPATH_RESOLVED | MPATH_TIDY | MPATH_CANONICAL,
+  };
+
+  int rc;
+  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  {
+    path1.canon = (char *) tests[i].first;
+    TEST_CASE(path1.canon);
+
+    path2.canon = (char *) tests[i].second;
+    TEST_CASE(path2.canon);
+
+    rc = comp_path2_compare(&path1, &path2);
+    TEST_CHECK(rc == tests[i].retval);
+  }
+}
+
+void test_comp_path2_parent(void)
+{
+  // clang-format off
+  static struct TestValue tests[] = {
+    { "/home/mutt/path/compress/apple.gz", NULL, -1 },
+  };
+  // clang-format on
+
+  struct Path path = {
+    .type = MUTT_COMPRESSED,
+    .flags = MPATH_RESOLVED | MPATH_TIDY,
+  };
+
+  struct Path *parent = NULL;
+  int rc;
+  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  {
+    path.orig = tests[i].first;
+    TEST_CASE(path.orig);
+
+    rc = comp_path2_parent(&path, &parent);
+    TEST_CHECK(rc == tests[i].retval);
+    TEST_CHECK(mutt_str_strcmp(parent ? parent->orig : NULL, tests[i].second) == 0);
+  }
+}
+
+void test_comp_path2_pretty(void)
+{
+  static const char *folder = "/home/mutt/path";
+  // clang-format off
+  static struct TestValue tests[] = {
+    { "/home/mutt/path/compress/apple.gz",         "+compress/apple.gz",         1 },
+    { "/home/mutt/path/compress/symlink/apple.gz", "+compress/symlink/apple.gz", 1 },
+  };
+  // clang-format on
+
+  struct Path path = {
+    .type = MUTT_COMPRESSED,
+    .flags = MPATH_RESOLVED | MPATH_TIDY,
+  };
+
+  char *pretty = NULL;
+  int rc;
+  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  {
+    path.orig = (char *) tests[i].first;
+    path.canon = (char *) tests[i].first;
+    TEST_CASE(path.orig);
+
+    rc = comp_path2_pretty(&path, folder, &pretty);
+    TEST_CHECK(rc == tests[i].retval);
+    if (rc >= 0)
+    {
+      TEST_CHECK(pretty != NULL);
+      TEST_CHECK(mutt_str_strcmp(pretty, tests[i].second) == 0);
+    }
+    FREE(&pretty);
+  }
+
+  path.orig = tests[0].first;
+  HomeDir = "/home/mutt";
+  rc = comp_path2_pretty(&path, "nowhere", &pretty);
+  TEST_CHECK(rc == 1);
+  TEST_CHECK(pretty != NULL);
+  TEST_CHECK(mutt_str_strcmp(pretty, "~/path/compress/apple.gz") == 0);
+  FREE(&pretty);
+
+  path.orig = tests[0].first;
+  HomeDir = "/home/another";
+  rc = comp_path2_pretty(&path, "nowhere", &pretty);
+  TEST_CHECK(rc == 0);
+  TEST_CHECK(pretty != NULL);
+  TEST_CHECK(mutt_str_strcmp(pretty, tests[0].first) == 0);
+  FREE(&pretty);
+}
+
+void test_comp_path2_probe(void)
+{
+  // clang-format off
+  static const struct TestValue tests[] = {
+    { "/home/mutt/path/compress/apple.gz",  NULL,  0 }, // Accepted
+    { "/home/mutt/path/compress/banana.gz", NULL, -1 }, // Directory
+    { "/home/mutt/path/compress/cherry.xz", NULL, -1 }, // Not accepted
+    { "/home/mutt/path/compress/damson.gz", NULL, -1 }, // Missing
+  };
+  // clang-format on
+
+  struct Path path = { 0 };
+  struct stat st;
+  int rc;
+  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  {
+    path.orig = (char *) tests[i].first;
+    TEST_CASE(path.orig);
+    path.type = MUTT_UNKNOWN;
+    path.flags = MPATH_RESOLVED | MPATH_TIDY;
+    memset(&st, 0, sizeof(st));
+    stat(path.orig, &st);
+    rc = comp_path2_probe(&path, &st);
+    TEST_CHECK(rc == tests[i].retval);
+    if (rc == 0)
+    {
+      TEST_CHECK(path.type > MUTT_UNKNOWN);
+    }
+  }
+}
+
+void test_comp_path2_tidy(void)
+{
+  // clang-format off
+  static const struct TestValue tests[] = {
+    { "/home/mutt/path/./compress/../compress///apple.gz", "/home/mutt/path/compress/apple.gz", 0 },
+  };
+  // clang-format on
+
+  struct Path path = {
+    .type = MUTT_COMPRESSED,
+    .flags = MPATH_RESOLVED,
+  };
+
+  int rc;
+  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  {
+    path.orig = mutt_str_strdup(tests[i].first);
+    rc = comp_path2_tidy(&path);
+    TEST_CHECK(rc == 0);
+    TEST_CHECK(path.orig != NULL);
+    TEST_CHECK(path.flags & MPATH_TIDY);
+    TEST_CHECK(strcmp(path.orig, tests[i].second) == 0);
+    FREE(&path.orig);
+  }
+}

--- a/test/mx_path/imap.c
+++ b/test/mx_path/imap.c
@@ -1,0 +1,255 @@
+/**
+ * @file
+ * Test code for the IMAP MxOps Path functions
+ *
+ * @authors
+ * Copyright (C) 2020 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define TEST_NO_MAIN
+#include "acutest.h"
+#include "config.h"
+#include <string.h>
+#include <sys/stat.h>
+#include "mutt/lib.h"
+#include "core/lib.h"
+#include "common.h"
+#include "imap/path.h"
+
+void test_imap_path2_canon(void)
+{
+  // clang-format off
+  static struct TestValue tests[] = {
+    { "imap://user@example.com:123/INBOX",        "imap://user@example.com:123/INBOX",  0 },
+    { "junk://user@example.com:123/INBOX",        "junk://user@example.com:123/INBOX", -1 },
+    { "imap://example.com:123/INBOX",             "imap://user@example.com:123/INBOX",  0 },
+    { "imap://user@example.com/INBOX",            "imap://user@example.com:123/INBOX",  0 },
+    { "imap://user:secret@example.com:123/INBOX", "imap://user@example.com:123/INBOX",  0 },
+    { "imap://example.com/INBOX",                 "imap://user@example.com:123/INBOX",  0 },
+  };
+  // clang-format on
+
+  struct Path path = { 0 };
+  int rc;
+  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  {
+    path.orig = (char *) tests[i].first;
+    TEST_CASE(path.orig);
+    path.type = MUTT_IMAP;
+    path.flags = MPATH_RESOLVED | MPATH_TIDY;
+
+    rc = imap_path2_canon(&path, "user", 123);
+    TEST_CHECK(rc == tests[i].retval);
+    if (rc == 0)
+    {
+      TEST_CHECK(path.flags & MPATH_CANONICAL);
+      TEST_CHECK(path.canon != NULL);
+      TEST_CHECK(mutt_str_strcmp(path.canon, tests[i].second) == 0);
+    }
+    FREE(&path.canon);
+  }
+}
+
+void test_imap_path2_compare(void)
+{
+  // clang-format off
+  static struct TestValue tests[] = {
+    { "imap://user@example.com:123/INBOX",        "imap://user@example.com:123/INBOX",        0 }, // Match
+    { "imap://user@example.com:123/INBOX",        "imaps://user@example.com:123/INBOX",      -1 }, // Scheme differs
+    { "imaps://user@example.com:123/INBOX",       "imap://user@example.com:123/INBOX",        1 }, // Scheme differs
+    { "imap://adam@example.com:123/INBOX",        "imap://zach@example.com:123/INBOX",       -1 }, // User differs
+    { "imap://zach@example.com:123/INBOX",        "imap://adam@example.com:123/INBOX",        1 }, // User differs
+    { "imap://adam@example.com:123/INBOX",        "imap://example.com:123/INBOX",             0 }, // User missing
+    { "imap://adam:secret@example.com:123/INBOX", "imap://adam:magic@example.com:123/INBOX",  0 }, // Password ignored
+    { "imap://user@example.com:123/INBOX",        "imap://user@flatcap.org:123/INBOX",       -1 }, // Host differs
+    { "imap://user@flatcap.org:123/INBOX",        "imap://user@example.com:123/INBOX",        1 }, // Host differs
+    { "imap://user@example.com:123/INBOX",        "imap://user@example.com:456/INBOX",       -1 }, // Port differs
+    { "imap://user@example.com:456/INBOX",        "imap://user@example.com:123/INBOX",        1 }, // Port differs
+    { "imap://user@example.com:456/INBOX",        "imap://user@example.com/INBOX",            0 }, // Port missing
+    { "imap://user@example.com:123/INBOX",        "imap://user@example.com:123/junk",        -1 }, // Path differs
+    { "imap://user@example.com:123/junk",         "imap://user@example.com:123/INBOX",        1 }, // Path differs
+    { "imap://user@example.com:123/INBOX",        "imap://user@example.com:123/apple",       -1 }, // Inbox sorts first
+    { "imap://user@example.com:123/apple",        "imap://user@example.com:123/INBOX",        1 }, // Inbox sorts first
+  };
+  // clang-format on
+
+  struct Path path1 = {
+    .type = MUTT_IMAP,
+    .flags = MPATH_RESOLVED | MPATH_TIDY | MPATH_CANONICAL,
+  };
+  struct Path path2 = {
+    .type = MUTT_IMAP,
+    .flags = MPATH_RESOLVED | MPATH_TIDY | MPATH_CANONICAL,
+  };
+
+  int rc;
+  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  {
+    path1.canon = (char *) tests[i].first;
+    TEST_CASE(path1.canon);
+
+    path2.canon = (char *) tests[i].second;
+    TEST_CASE(path2.canon);
+
+    rc = imap_path2_compare(&path1, &path2);
+    TEST_CHECK(rc == tests[i].retval);
+  }
+}
+
+void test_imap_path2_parent(void)
+{
+  // clang-format off
+  static struct TestValue tests[] = {
+    { "imap://example.com/apple/banana/cherry", "imap://example.com/apple/banana",  0 },
+    { "imap://example.com/apple/banana",        "imap://example.com/apple",         0 },
+    { "imap://example.com/apple",               "imap://example.com/INBOX",         0 },
+    { "imap://example.com/",                    NULL,                              -1 },
+    { "imap://example.com/INBOX",               NULL,                              -1 },
+    { "junk://example.com/junk",                NULL,                              -2 },
+  };
+  // clang-format on
+
+  struct Path path = {
+    .type = MUTT_IMAP,
+    .flags = MPATH_RESOLVED | MPATH_TIDY,
+  };
+
+  struct Path *parent = NULL;
+  int rc;
+  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  {
+    path.orig = (char *) tests[i].first;
+    TEST_CASE(path.orig);
+
+    rc = imap_path2_parent(&path, '/', &parent);
+    TEST_CHECK(rc == tests[i].retval);
+    if (rc == 0)
+    {
+      TEST_CHECK(parent != NULL);
+      TEST_CHECK(parent->orig != NULL);
+      TEST_CHECK(parent->type == path.type);
+      TEST_CHECK(parent->flags & MPATH_RESOLVED);
+      TEST_CHECK(parent->flags & MPATH_TIDY);
+      TEST_CHECK(mutt_str_strcmp(parent->orig, tests[i].second) == 0);
+      mutt_path_free(&parent);
+    }
+  }
+}
+
+void test_imap_path2_pretty(void)
+{
+  static const char *folder = "imap://user@example.com:123/";
+  // clang-format off
+  static struct TestValue tests[] = {
+    { "imap://example.com/INBOX",         "+INBOX", 1 },
+    { "imaps://example.com/INBOX",        NULL,     0 }, // Scheme differs
+    { "imap://flatcap.org/INBOX",         NULL,     0 }, // Host differs
+    { "imap://another@example.com/INBOX", NULL,     0 }, // User differs
+    { "imap://example.com:456/INBOX",     NULL,     0 }, // Port differs
+    { "imap://example.com/",              NULL,     0 }, // Folder is entire path
+  };
+  // clang-format on
+
+  struct Path path = {
+    .type = MUTT_IMAP,
+    .flags = MPATH_RESOLVED | MPATH_TIDY,
+  };
+
+  char *pretty = NULL;
+  int rc;
+  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  {
+    path.orig = (char *) tests[i].first;
+    TEST_CASE(path.orig);
+
+    rc = imap_path2_pretty(&path, folder, &pretty);
+    TEST_CHECK(rc == tests[i].retval);
+    if (rc > 0)
+    {
+      TEST_CHECK(pretty != NULL);
+      TEST_CHECK(mutt_str_strcmp(pretty, tests[i].second) == 0);
+    }
+    FREE(&pretty);
+  }
+}
+
+void test_imap_path2_probe(void)
+{
+  // clang-format off
+  static const struct TestValue tests[] = {
+    { "imap://example.com/",  NULL,  0 },
+    { "imaps://example.com/", NULL,  0 },
+    { "pop://example.com/",   NULL, -1 },
+  };
+  // clang-format on
+
+  struct Path path = { 0 };
+  struct stat st;
+  int rc;
+  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  {
+    path.orig = (char *) tests[i].first;
+    TEST_CASE(path.orig);
+    path.type = MUTT_UNKNOWN;
+    path.flags = MPATH_NO_FLAGS;
+    memset(&st, 0, sizeof(st));
+    stat(path.orig, &st);
+    rc = imap_path2_probe(&path, &st);
+    TEST_CHECK(rc == tests[i].retval);
+    if (rc == 0)
+    {
+      TEST_CHECK(path.type > MUTT_UNKNOWN);
+    }
+  }
+}
+
+void test_imap_path2_tidy(void)
+{
+  // clang-format off
+  static struct TestValue tests[] = {
+    { "imap://example.com/INBOX", "imap://example.com/INBOX",   0 },
+    { "IMAP://example.com/INBOX", "imap://example.com/INBOX",   0 },
+    { "imap://example.com/inbox", "imap://example.com/INBOX",   0 },
+    { "imap://example.com/",      "imap://example.com/INBOX",   0 },
+    { "imap://example.com",       "imap://example.com/INBOX",   0 },
+    { "imaps://example.com/",     "imaps://example.com/INBOX",  0 },
+    { "junk://example.com/",      "junk://example.com/",       -1 },
+  };
+  // clang-format on
+
+  struct Path path = {
+    .type = MUTT_IMAP,
+    .flags = MPATH_RESOLVED,
+  };
+
+  int rc;
+  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  {
+    path.orig = mutt_str_strdup(tests[i].first);
+    TEST_CASE(path.orig);
+
+    rc = imap_path2_tidy(&path);
+    TEST_CHECK(rc == tests[i].retval);
+    if (rc == 0)
+    {
+      TEST_CHECK(path.orig != NULL);
+      TEST_CHECK(path.flags & MPATH_TIDY);
+      TEST_CHECK(mutt_str_strcmp(path.orig, tests[i].second) == 0);
+    }
+    FREE(&path.orig);
+  }
+}

--- a/test/mx_path/maildir.c
+++ b/test/mx_path/maildir.c
@@ -34,17 +34,23 @@ void test_maildir_path2_canon(void)
 {
   // clang-format off
   static struct TestValue tests[] = {
-    { "/home/mutt/path/maildir/apple",         "/home/mutt/path/maildir/apple",  0 }, // Real path
-    { "/home/mutt/path/maildir/symlink/apple", "/home/mutt/path/maildir/apple",  0 }, // Symlink
-    { "/home/mutt/path/maildir/missing",       NULL,                            -1 }, // Missing
+    { "%s/maildir/apple",         "%s/maildir/apple",  0 }, // Real path
+    { "%s/maildir/symlink/apple", "%s/maildir/apple",  0 }, // Symlink
+    { "%s/maildir/missing",       NULL,               -1 }, // Missing
   };
   // clang-format on
+
+  char first[256] = { 0 };
+  char second[256] = { 0 };
 
   struct Path path = { 0 };
   int rc;
   for (size_t i = 0; i < mutt_array_size(tests); i++)
   {
-    path.orig = tests[i].first;
+    test_gen_path(first, sizeof(first), tests[i].first);
+    test_gen_path(second, sizeof(second), tests[i].second);
+
+    path.orig = first;
     TEST_CASE(path.orig);
     path.type = MUTT_MAILDIR;
     path.flags = MPATH_RESOLVED | MPATH_TIDY;
@@ -55,7 +61,7 @@ void test_maildir_path2_canon(void)
     {
       TEST_CHECK(path.flags & MPATH_CANONICAL);
       TEST_CHECK(path.canon != NULL);
-      TEST_CHECK(mutt_str_strcmp(path.canon, tests[i].second) == 0);
+      TEST_CHECK(mutt_str_strcmp(path.canon, second) == 0);
     }
     FREE(&path.canon);
   }
@@ -65,11 +71,14 @@ void test_maildir_path2_compare(void)
 {
   // clang-format off
   static const struct TestValue tests[] = {
-    { "/home/mutt/path/maildir/apple",  "/home/mutt/path/maildir/apple",   0 }, // Match
-    { "/home/mutt/path/maildir/apple",  "/home/mutt/path/maildir/orange", -1 }, // Differ
-    { "/home/mutt/path/maildir/orange", "/home/mutt/path/maildir/apple",   1 }, // Differ
+    { "%s/maildir/apple",  "%s/maildir/apple",   0 }, // Match
+    { "%s/maildir/apple",  "%s/maildir/orange", -1 }, // Differ
+    { "%s/maildir/orange", "%s/maildir/apple",   1 }, // Differ
   };
   // clang-format on
+
+  char first[256] = { 0 };
+  char second[256] = { 0 };
 
   struct Path path1 = {
     .type = MUTT_MAILDIR,
@@ -83,10 +92,13 @@ void test_maildir_path2_compare(void)
   int rc;
   for (size_t i = 0; i < mutt_array_size(tests); i++)
   {
-    path1.canon = (char *) tests[i].first;
+    test_gen_path(first, sizeof(first), tests[i].first);
+    test_gen_path(second, sizeof(second), tests[i].second);
+
+    path1.canon = first;
     TEST_CASE(path1.canon);
 
-    path2.canon = (char *) tests[i].second;
+    path2.canon = second;
     TEST_CASE(path2.canon);
 
     rc = maildir_path2_compare(&path1, &path2);
@@ -98,11 +110,14 @@ void test_maildir_path2_parent(void)
 {
   // clang-format off
   static struct TestValue tests[] = {
-    { "/home/mutt/path/maildir/apple/child", "/home/mutt/path/maildir/apple",  0 },
-    { "/home/mutt/path/maildir/empty/child", NULL,                            -1 },
-    { "/",                                   NULL,                            -1 },
+    { "%s/maildir/apple/child", "%s/maildir/apple",  0 },
+    { "%s/maildir/empty/child", NULL,               -1 },
+    { "/",                      NULL,               -1 },
   };
   // clang-format on
+
+  char first[256] = { 0 };
+  char second[256] = { 0 };
 
   struct Path path = {
     .type = MUTT_MAILDIR,
@@ -113,7 +128,10 @@ void test_maildir_path2_parent(void)
   int rc;
   for (size_t i = 0; i < mutt_array_size(tests); i++)
   {
-    path.orig = tests[i].first;
+    test_gen_path(first, sizeof(first), tests[i].first);
+    test_gen_path(second, sizeof(second), tests[i].second);
+
+    path.orig = first;
     TEST_CASE(path.orig);
 
     rc = maildir_path2_parent(&path, &parent);
@@ -125,7 +143,7 @@ void test_maildir_path2_parent(void)
       TEST_CHECK(parent->type == path.type);
       TEST_CHECK(parent->flags & MPATH_RESOLVED);
       TEST_CHECK(parent->flags & MPATH_TIDY);
-      TEST_CHECK(mutt_str_strcmp(parent->orig, tests[i].second) == 0);
+      TEST_CHECK(mutt_str_strcmp(parent->orig, second) == 0);
       mutt_path_free(&parent);
     }
   }
@@ -135,11 +153,14 @@ void test_mh_path2_parent(void)
 {
   // clang-format off
   static struct TestValue tests[] = {
-    { "/home/mutt/path/maildir/mh2/child",   "/home/mutt/path/maildir/mh2",  0 },
-    { "/home/mutt/path/maildir/empty/child", NULL,                          -1 },
-    { "/",                                   NULL,                          -1 },
+    { "%s/maildir/mh2/child",   "%s/maildir/mh2",  0 },
+    { "%s/maildir/empty/child", NULL,             -1 },
+    { "/",                      NULL,             -1 },
   };
   // clang-format on
+
+  char first[256] = { 0 };
+  char second[256] = { 0 };
 
   struct Path path = {
     .type = MUTT_MH,
@@ -150,7 +171,10 @@ void test_mh_path2_parent(void)
   int rc;
   for (size_t i = 0; i < mutt_array_size(tests); i++)
   {
-    path.orig = tests[i].first;
+    test_gen_path(first, sizeof(first), tests[i].first);
+    test_gen_path(second, sizeof(second), tests[i].second);
+
+    path.orig = first;
     TEST_CASE(path.orig);
 
     rc = maildir_path2_parent(&path, &parent);
@@ -162,7 +186,7 @@ void test_mh_path2_parent(void)
       TEST_CHECK(parent->type == path.type);
       TEST_CHECK(parent->flags & MPATH_RESOLVED);
       TEST_CHECK(parent->flags & MPATH_TIDY);
-      TEST_CHECK(mutt_str_strcmp(parent->orig, tests[i].second) == 0);
+      TEST_CHECK(mutt_str_strcmp(parent->orig, second) == 0);
       mutt_path_free(&parent);
     }
   }
@@ -170,13 +194,18 @@ void test_mh_path2_parent(void)
 
 void test_maildir_path2_pretty(void)
 {
-  static const char *folder = "/home/mutt/path";
   // clang-format off
   static struct TestValue tests[] = {
-    { "/home/mutt/path/maildir/apple.maildir",         "+maildir/apple.maildir",         1 },
-    { "/home/mutt/path/maildir/symlink/apple.maildir", "+maildir/symlink/apple.maildir", 1 },
+    { "%s/maildir/apple.maildir",         "+maildir/apple.maildir",         1 },
+    { "%s/maildir/symlink/apple.maildir", "+maildir/symlink/apple.maildir", 1 },
   };
   // clang-format on
+
+  char first[256] = { 0 };
+  char second[256] = { 0 };
+  char folder[256] = { 0 };
+
+  test_gen_path(folder, sizeof(folder), "%s");
 
   struct Path path = {
     .type = MUTT_MAILDIR,
@@ -187,7 +216,10 @@ void test_maildir_path2_pretty(void)
   int rc;
   for (size_t i = 0; i < mutt_array_size(tests); i++)
   {
-    path.orig = (char *) tests[i].first;
+    test_gen_path(first, sizeof(first), tests[i].first);
+    test_gen_path(second, sizeof(second), tests[i].second);
+
+    path.orig = first;
     TEST_CASE(path.orig);
 
     rc = maildir_path2_pretty(&path, folder, &pretty);
@@ -195,25 +227,29 @@ void test_maildir_path2_pretty(void)
     if (rc > 0)
     {
       TEST_CHECK(pretty != NULL);
-      TEST_CHECK(mutt_str_strcmp(pretty, tests[i].second) == 0);
+      TEST_CHECK(mutt_str_strcmp(pretty, second) == 0);
     }
     FREE(&pretty);
   }
 
-  path.orig = tests[0].first;
-  HomeDir = "/home/mutt";
+  test_gen_path(first, sizeof(first), tests[0].first);
+  test_gen_dir(second, sizeof(second), "~/%s/maildir/apple.maildir");
+  path.orig = first;
+  HomeDir = mutt_str_getenv("HOME");
   rc = maildir_path2_pretty(&path, "nowhere", &pretty);
   TEST_CHECK(rc == 1);
   TEST_CHECK(pretty != NULL);
-  TEST_CHECK(mutt_str_strcmp(pretty, "~/path/maildir/apple.maildir") == 0);
+  TEST_CHECK(mutt_str_strcmp(pretty, second) == 0);
   FREE(&pretty);
 
-  path.orig = tests[0].first;
+  test_gen_path(first, sizeof(first), tests[0].first);
+  test_gen_path(second, sizeof(second), tests[0].first);
+  path.orig = first;
   HomeDir = "/home/another";
   rc = maildir_path2_pretty(&path, "nowhere", &pretty);
   TEST_CHECK(rc == 0);
   TEST_CHECK(pretty != NULL);
-  TEST_CHECK(mutt_str_strcmp(pretty, tests[0].first) == 0);
+  TEST_CHECK(mutt_str_strcmp(pretty, second) == 0);
   FREE(&pretty);
 }
 
@@ -221,21 +257,25 @@ void test_maildir_path2_probe(void)
 {
   // clang-format off
   static const struct TestValue tests[] = {
-    { "/home/mutt/path/maildir/apple",          NULL,  0 }, // Normal, all 3 subdirs
-    { "/home/mutt/path/maildir/banana",         NULL,  0 }, // Normal, just 'cur' subdir
-    { "/home/mutt/path/maildir/symlink/banana", NULL,  0 }, // Symlink
-    { "/home/mutt/path/maildir/cherry",         NULL, -1 }, // No subdirs
-    { "/home/mutt/path/maildir/damson",         NULL, -1 }, // Unreadable
-    { "/home/mutt/path/maildir/endive",         NULL, -1 }, // File
+    { "%s/maildir/apple",          NULL,  0 }, // Normal, all 3 subdirs
+    { "%s/maildir/banana",         NULL,  0 }, // Normal, just 'cur' subdir
+    { "%s/maildir/symlink/banana", NULL,  0 }, // Symlink
+    { "%s/maildir/cherry",         NULL, -1 }, // No subdirs
+    { "%s/maildir/damson",         NULL, -1 }, // Unreadable
+    { "%s/maildir/endive",         NULL, -1 }, // File
   };
   // clang-format on
+
+  char first[256] = { 0 };
 
   struct Path path = { 0 };
   struct stat st;
   int rc;
   for (size_t i = 0; i < mutt_array_size(tests); i++)
   {
-    path.orig = (char *) tests[i].first;
+    test_gen_path(first, sizeof(first), tests[i].first);
+
+    path.orig = first;
     TEST_CASE(path.orig);
     path.type = MUTT_UNKNOWN;
     path.flags = MPATH_NO_FLAGS;
@@ -254,24 +294,28 @@ void test_mh_path2_probe(void)
 {
   // clang-format off
   static const struct TestValue tests[] = {
-    { "/home/mutt/path/maildir/mh1",         NULL,  0 }, // Contains .mh_sequences
-    { "/home/mutt/path/maildir/mh2",         NULL,  0 }, // Contains .xmhcache
-    { "/home/mutt/path/maildir/symlink/mh2", NULL,  0 }, // Symlink
-    { "/home/mutt/path/maildir/mh3",         NULL,  0 }, // Contains .mew_cache
-    { "/home/mutt/path/maildir/mh4",         NULL,  0 }, // Contains .mew-cache
-    { "/home/mutt/path/maildir/mh5",         NULL,  0 }, // Contains .sylpheed_cache
-    { "/home/mutt/path/maildir/mh6",         NULL,  0 }, // Contains .overview
-    { "/home/mutt/path/maildir/mh7",         NULL, -1 }, // Empty
-    { "/home/mutt/path/maildir/mh8",         NULL, -1 }, // File
+    { "%s/maildir/mh1",         NULL,  0 }, // Contains .mh_sequences
+    { "%s/maildir/mh2",         NULL,  0 }, // Contains .xmhcache
+    { "%s/maildir/symlink/mh2", NULL,  0 }, // Symlink
+    { "%s/maildir/mh3",         NULL,  0 }, // Contains .mew_cache
+    { "%s/maildir/mh4",         NULL,  0 }, // Contains .mew-cache
+    { "%s/maildir/mh5",         NULL,  0 }, // Contains .sylpheed_cache
+    { "%s/maildir/mh6",         NULL,  0 }, // Contains .overview
+    { "%s/maildir/mh7",         NULL, -1 }, // Empty
+    { "%s/maildir/mh8",         NULL, -1 }, // File
   };
   // clang-format on
+
+  char first[256] = { 0 };
 
   struct Path path = { 0 };
   struct stat st;
   int rc;
   for (size_t i = 0; i < mutt_array_size(tests); i++)
   {
-    path.orig = (char *) tests[i].first;
+    test_gen_path(first, sizeof(first), tests[i].first);
+
+    path.orig = first;
     TEST_CASE(path.orig);
     path.type = MUTT_UNKNOWN;
     path.flags = MPATH_NO_FLAGS;
@@ -290,9 +334,12 @@ void test_maildir_path2_tidy(void)
 {
   // clang-format off
   static const struct TestValue tests[] = {
-    { "/home/mutt/path/./maildir/../maildir///apple", "/home/mutt/path/maildir/apple", 0 },
+    { "%s/./maildir/../maildir///apple", "%s/maildir/apple", 0 },
   };
   // clang-format on
+
+  char first[256] = { 0 };
+  char second[256] = { 0 };
 
   struct Path path = {
     .type = MUTT_MAILDIR,
@@ -302,12 +349,15 @@ void test_maildir_path2_tidy(void)
   int rc;
   for (size_t i = 0; i < mutt_array_size(tests); i++)
   {
-    path.orig = mutt_str_strdup(tests[i].first);
+    test_gen_path(first, sizeof(first), tests[i].first);
+    test_gen_path(second, sizeof(second), tests[i].second);
+
+    path.orig = mutt_str_strdup(first);
     rc = maildir_path2_tidy(&path);
     TEST_CHECK(rc == 0);
     TEST_CHECK(path.orig != NULL);
     TEST_CHECK(path.flags & MPATH_TIDY);
-    TEST_CHECK(strcmp(path.orig, tests[i].second) == 0);
+    TEST_CHECK(strcmp(path.orig, second) == 0);
     FREE(&path.orig);
   }
 }

--- a/test/mx_path/maildir.c
+++ b/test/mx_path/maildir.c
@@ -1,0 +1,313 @@
+/**
+ * @file
+ * Test code for the Maildir MxOps Path functions
+ *
+ * @authors
+ * Copyright (C) 2020 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define TEST_NO_MAIN
+#include "acutest.h"
+#include "config.h"
+#include <string.h>
+#include <sys/stat.h>
+#include "mutt/lib.h"
+#include "core/lib.h"
+#include "common.h"
+#include "maildir/path.h"
+
+void test_maildir_path2_canon(void)
+{
+  // clang-format off
+  static struct TestValue tests[] = {
+    { "/home/mutt/path/maildir/apple",         "/home/mutt/path/maildir/apple",  0 }, // Real path
+    { "/home/mutt/path/maildir/symlink/apple", "/home/mutt/path/maildir/apple",  0 }, // Symlink
+    { "/home/mutt/path/maildir/missing",       NULL,                            -1 }, // Missing
+  };
+  // clang-format on
+
+  struct Path path = { 0 };
+  int rc;
+  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  {
+    path.orig = tests[i].first;
+    TEST_CASE(path.orig);
+    path.type = MUTT_MAILDIR;
+    path.flags = MPATH_RESOLVED | MPATH_TIDY;
+
+    rc = maildir_path2_canon(&path);
+    TEST_CHECK(rc == tests[i].retval);
+    if (rc == 0)
+    {
+      TEST_CHECK(path.flags & MPATH_CANONICAL);
+      TEST_CHECK(path.canon != NULL);
+      TEST_CHECK(mutt_str_strcmp(path.canon, tests[i].second) == 0);
+    }
+    FREE(&path.canon);
+  }
+}
+
+void test_maildir_path2_compare(void)
+{
+  // clang-format off
+  static const struct TestValue tests[] = {
+    { "/home/mutt/path/maildir/apple",  "/home/mutt/path/maildir/apple",   0 }, // Match
+    { "/home/mutt/path/maildir/apple",  "/home/mutt/path/maildir/orange", -1 }, // Differ
+    { "/home/mutt/path/maildir/orange", "/home/mutt/path/maildir/apple",   1 }, // Differ
+  };
+  // clang-format on
+
+  struct Path path1 = {
+    .type = MUTT_MAILDIR,
+    .flags = MPATH_RESOLVED | MPATH_TIDY | MPATH_CANONICAL,
+  };
+  struct Path path2 = {
+    .type = MUTT_MAILDIR,
+    .flags = MPATH_RESOLVED | MPATH_TIDY | MPATH_CANONICAL,
+  };
+
+  int rc;
+  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  {
+    path1.canon = (char *) tests[i].first;
+    TEST_CASE(path1.canon);
+
+    path2.canon = (char *) tests[i].second;
+    TEST_CASE(path2.canon);
+
+    rc = maildir_path2_compare(&path1, &path2);
+    TEST_CHECK(rc == tests[i].retval);
+  }
+}
+
+void test_maildir_path2_parent(void)
+{
+  // clang-format off
+  static struct TestValue tests[] = {
+    { "/home/mutt/path/maildir/apple/child", "/home/mutt/path/maildir/apple",  0 },
+    { "/home/mutt/path/maildir/empty/child", NULL,                            -1 },
+    { "/",                                   NULL,                            -1 },
+  };
+  // clang-format on
+
+  struct Path path = {
+    .type = MUTT_MAILDIR,
+    .flags = MPATH_RESOLVED | MPATH_TIDY,
+  };
+
+  struct Path *parent = NULL;
+  int rc;
+  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  {
+    path.orig = tests[i].first;
+    TEST_CASE(path.orig);
+
+    rc = maildir_path2_parent(&path, &parent);
+    TEST_CHECK(rc == tests[i].retval);
+    if (rc == 0)
+    {
+      TEST_CHECK(parent != NULL);
+      TEST_CHECK(parent->orig != NULL);
+      TEST_CHECK(parent->type == path.type);
+      TEST_CHECK(parent->flags & MPATH_RESOLVED);
+      TEST_CHECK(parent->flags & MPATH_TIDY);
+      TEST_CHECK(mutt_str_strcmp(parent->orig, tests[i].second) == 0);
+      mutt_path_free(&parent);
+    }
+  }
+}
+
+void test_mh_path2_parent(void)
+{
+  // clang-format off
+  static struct TestValue tests[] = {
+    { "/home/mutt/path/maildir/mh2/child",   "/home/mutt/path/maildir/mh2",  0 },
+    { "/home/mutt/path/maildir/empty/child", NULL,                          -1 },
+    { "/",                                   NULL,                          -1 },
+  };
+  // clang-format on
+
+  struct Path path = {
+    .type = MUTT_MH,
+    .flags = MPATH_RESOLVED | MPATH_TIDY,
+  };
+
+  struct Path *parent = NULL;
+  int rc;
+  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  {
+    path.orig = tests[i].first;
+    TEST_CASE(path.orig);
+
+    rc = maildir_path2_parent(&path, &parent);
+    TEST_CHECK(rc == tests[i].retval);
+    if (rc == 0)
+    {
+      TEST_CHECK(parent != NULL);
+      TEST_CHECK(parent->orig != NULL);
+      TEST_CHECK(parent->type == path.type);
+      TEST_CHECK(parent->flags & MPATH_RESOLVED);
+      TEST_CHECK(parent->flags & MPATH_TIDY);
+      TEST_CHECK(mutt_str_strcmp(parent->orig, tests[i].second) == 0);
+      mutt_path_free(&parent);
+    }
+  }
+}
+
+void test_maildir_path2_pretty(void)
+{
+  static const char *folder = "/home/mutt/path";
+  // clang-format off
+  static struct TestValue tests[] = {
+    { "/home/mutt/path/maildir/apple.maildir",         "+maildir/apple.maildir",         1 },
+    { "/home/mutt/path/maildir/symlink/apple.maildir", "+maildir/symlink/apple.maildir", 1 },
+  };
+  // clang-format on
+
+  struct Path path = {
+    .type = MUTT_MAILDIR,
+    .flags = MPATH_RESOLVED | MPATH_TIDY,
+  };
+
+  char *pretty = NULL;
+  int rc;
+  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  {
+    path.orig = (char *) tests[i].first;
+    TEST_CASE(path.orig);
+
+    rc = maildir_path2_pretty(&path, folder, &pretty);
+    TEST_CHECK(rc == tests[i].retval);
+    if (rc > 0)
+    {
+      TEST_CHECK(pretty != NULL);
+      TEST_CHECK(mutt_str_strcmp(pretty, tests[i].second) == 0);
+    }
+    FREE(&pretty);
+  }
+
+  path.orig = tests[0].first;
+  HomeDir = "/home/mutt";
+  rc = maildir_path2_pretty(&path, "nowhere", &pretty);
+  TEST_CHECK(rc == 1);
+  TEST_CHECK(pretty != NULL);
+  TEST_CHECK(mutt_str_strcmp(pretty, "~/path/maildir/apple.maildir") == 0);
+  FREE(&pretty);
+
+  path.orig = tests[0].first;
+  HomeDir = "/home/another";
+  rc = maildir_path2_pretty(&path, "nowhere", &pretty);
+  TEST_CHECK(rc == 0);
+  TEST_CHECK(pretty != NULL);
+  TEST_CHECK(mutt_str_strcmp(pretty, tests[0].first) == 0);
+  FREE(&pretty);
+}
+
+void test_maildir_path2_probe(void)
+{
+  // clang-format off
+  static const struct TestValue tests[] = {
+    { "/home/mutt/path/maildir/apple",          NULL,  0 }, // Normal, all 3 subdirs
+    { "/home/mutt/path/maildir/banana",         NULL,  0 }, // Normal, just 'cur' subdir
+    { "/home/mutt/path/maildir/symlink/banana", NULL,  0 }, // Symlink
+    { "/home/mutt/path/maildir/cherry",         NULL, -1 }, // No subdirs
+    { "/home/mutt/path/maildir/damson",         NULL, -1 }, // Unreadable
+    { "/home/mutt/path/maildir/endive",         NULL, -1 }, // File
+  };
+  // clang-format on
+
+  struct Path path = { 0 };
+  struct stat st;
+  int rc;
+  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  {
+    path.orig = (char *) tests[i].first;
+    TEST_CASE(path.orig);
+    path.type = MUTT_UNKNOWN;
+    path.flags = MPATH_NO_FLAGS;
+    memset(&st, 0, sizeof(st));
+    stat(path.orig, &st);
+    rc = maildir_path2_probe(&path, &st);
+    TEST_CHECK(rc == tests[i].retval);
+    if (rc == 0)
+    {
+      TEST_CHECK(path.type > MUTT_UNKNOWN);
+    }
+  }
+}
+
+void test_mh_path2_probe(void)
+{
+  // clang-format off
+  static const struct TestValue tests[] = {
+    { "/home/mutt/path/maildir/mh1",         NULL,  0 }, // Contains .mh_sequences
+    { "/home/mutt/path/maildir/mh2",         NULL,  0 }, // Contains .xmhcache
+    { "/home/mutt/path/maildir/symlink/mh2", NULL,  0 }, // Symlink
+    { "/home/mutt/path/maildir/mh3",         NULL,  0 }, // Contains .mew_cache
+    { "/home/mutt/path/maildir/mh4",         NULL,  0 }, // Contains .mew-cache
+    { "/home/mutt/path/maildir/mh5",         NULL,  0 }, // Contains .sylpheed_cache
+    { "/home/mutt/path/maildir/mh6",         NULL,  0 }, // Contains .overview
+    { "/home/mutt/path/maildir/mh7",         NULL, -1 }, // Empty
+    { "/home/mutt/path/maildir/mh8",         NULL, -1 }, // File
+  };
+  // clang-format on
+
+  struct Path path = { 0 };
+  struct stat st;
+  int rc;
+  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  {
+    path.orig = (char *) tests[i].first;
+    TEST_CASE(path.orig);
+    path.type = MUTT_UNKNOWN;
+    path.flags = MPATH_NO_FLAGS;
+    memset(&st, 0, sizeof(st));
+    stat(path.orig, &st);
+    rc = mh_path2_probe(&path, &st);
+    TEST_CHECK(rc == tests[i].retval);
+    if (rc == 0)
+    {
+      TEST_CHECK(path.type > MUTT_UNKNOWN);
+    }
+  }
+}
+
+void test_maildir_path2_tidy(void)
+{
+  // clang-format off
+  static const struct TestValue tests[] = {
+    { "/home/mutt/path/./maildir/../maildir///apple", "/home/mutt/path/maildir/apple", 0 },
+  };
+  // clang-format on
+
+  struct Path path = {
+    .type = MUTT_MAILDIR,
+    .flags = MPATH_RESOLVED,
+  };
+
+  int rc;
+  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  {
+    path.orig = mutt_str_strdup(tests[i].first);
+    rc = maildir_path2_tidy(&path);
+    TEST_CHECK(rc == 0);
+    TEST_CHECK(path.orig != NULL);
+    TEST_CHECK(path.flags & MPATH_TIDY);
+    TEST_CHECK(strcmp(path.orig, tests[i].second) == 0);
+    FREE(&path.orig);
+  }
+}

--- a/test/mx_path/mbox.c
+++ b/test/mx_path/mbox.c
@@ -1,0 +1,231 @@
+/**
+ * @file
+ * Test code for the Mbox MxOps Path functions
+ *
+ * @authors
+ * Copyright (C) 2020 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define TEST_NO_MAIN
+#include "acutest.h"
+#include "config.h"
+#include <string.h>
+#include <sys/stat.h>
+#include "mutt/lib.h"
+#include "core/lib.h"
+#include "common.h"
+#include "mbox/path.h"
+
+void test_mbox_path2_canon(void)
+{
+  // clang-format off
+  static struct TestValue tests[] = {
+    { "/home/mutt/path/mbox/apple.mbox",         "/home/mutt/path/mbox/apple.mbox",  0 }, // Real path
+    { "/home/mutt/path/mbox/symlink/apple.mbox", "/home/mutt/path/mbox/apple.mbox",  0 }, // Symlink
+    { "/home/mutt/path/mbox/missing",            NULL,                              -1 }, // Missing
+  };
+  // clang-format on
+
+  struct Path path = { 0 };
+  int rc;
+  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  {
+    path.orig = tests[i].first;
+    TEST_CASE(path.orig);
+    path.type = MUTT_MBOX;
+    path.flags = MPATH_RESOLVED | MPATH_TIDY;
+
+    rc = mbox_path2_canon(&path);
+    TEST_CHECK(rc == tests[i].retval);
+    if (rc == 0)
+    {
+      TEST_CHECK(path.flags & MPATH_CANONICAL);
+      TEST_CHECK(path.canon != NULL);
+      TEST_CHECK(mutt_str_strcmp(path.canon, tests[i].second) == 0);
+    }
+    FREE(&path.canon);
+  }
+}
+
+void test_mbox_path2_compare(void)
+{
+  // clang-format off
+  static const struct TestValue tests[] = {
+    { "/home/mutt/path/mbox/apple.mbox",  "/home/mutt/path/mbox/apple.mbox",   0 }, // Match
+    { "/home/mutt/path/mbox/apple.mbox",  "/home/mutt/path/mbox/orange.mbox", -1 }, // Differ
+    { "/home/mutt/path/mbox/orange.mbox", "/home/mutt/path/mbox/apple.mbox",   1 }, // Differ
+  };
+  // clang-format on
+
+  struct Path path1 = {
+    .type = MUTT_MBOX,
+    .flags = MPATH_RESOLVED | MPATH_TIDY | MPATH_CANONICAL,
+  };
+  struct Path path2 = {
+    .type = MUTT_MBOX,
+    .flags = MPATH_RESOLVED | MPATH_TIDY | MPATH_CANONICAL,
+  };
+
+  int rc;
+  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  {
+    path1.canon = (char *) tests[i].first;
+    TEST_CASE(path1.canon);
+
+    path2.canon = (char *) tests[i].second;
+    TEST_CASE(path2.canon);
+
+    rc = mbox_path2_compare(&path1, &path2);
+    TEST_CHECK(rc == tests[i].retval);
+  }
+}
+
+void test_mbox_path2_parent(void)
+{
+  // clang-format off
+  static struct TestValue tests[] = {
+    { "/home/mutt/path/mbox/apple.mbox", NULL, -1 },
+  };
+  // clang-format on
+
+  struct Path path = {
+    .type = MUTT_MBOX,
+    .flags = MPATH_RESOLVED | MPATH_TIDY,
+  };
+
+  struct Path *parent = NULL;
+  int rc;
+  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  {
+    path.orig = tests[i].first;
+    TEST_CASE(path.orig);
+
+    rc = mbox_path2_parent(&path, &parent);
+    TEST_CHECK(rc == tests[i].retval);
+    TEST_CHECK(mutt_str_strcmp(parent ? parent->orig : NULL, tests[i].second) == 0);
+  }
+}
+
+void test_mbox_path2_pretty(void)
+{
+  static const char *folder = "/home/mutt/path";
+  // clang-format off
+  static struct TestValue tests[] = {
+    { "/home/mutt/path/mbox/apple.mbox",         "+mbox/apple.mbox",         1 },
+    { "/home/mutt/path/mbox/symlink/apple.mbox", "+mbox/symlink/apple.mbox", 1 },
+  };
+  // clang-format on
+
+  struct Path path = {
+    .type = MUTT_MBOX,
+    .flags = MPATH_RESOLVED | MPATH_TIDY,
+  };
+
+  char *pretty = NULL;
+  int rc;
+  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  {
+    path.orig = (char *) tests[i].first;
+    TEST_CASE(path.orig);
+
+    rc = mbox_path2_pretty(&path, folder, &pretty);
+    TEST_CHECK(rc == tests[i].retval);
+    if (rc >= 0)
+    {
+      TEST_CHECK(pretty != NULL);
+      TEST_CHECK(mutt_str_strcmp(pretty, tests[i].second) == 0);
+    }
+    FREE(&pretty);
+  }
+
+  path.orig = tests[0].first;
+  HomeDir = "/home/mutt";
+  rc = mbox_path2_pretty(&path, "nowhere", &pretty);
+  TEST_CHECK(rc == 1);
+  TEST_CHECK(pretty != NULL);
+  TEST_CHECK(mutt_str_strcmp(pretty, "~/path/mbox/apple.mbox") == 0);
+  FREE(&pretty);
+
+  path.orig = tests[0].first;
+  HomeDir = "/home/another";
+  rc = mbox_path2_pretty(&path, "nowhere", &pretty);
+  TEST_CHECK(rc == 0);
+  TEST_CHECK(pretty != NULL);
+  TEST_CHECK(mutt_str_strcmp(pretty, tests[0].first) == 0);
+  FREE(&pretty);
+}
+
+void test_mbox_path2_probe(void)
+{
+  // clang-format off
+  static const struct TestValue tests[] = {
+    { "/home/mutt/path/mbox/apple.mbox",          NULL,  0 }, // Empty
+    { "/home/mutt/path/mbox/banana.mbox",         NULL,  0 }, // Normal
+    { "/home/mutt/path/mbox/symlink/banana.mbox", NULL,  0 }, // Symlink
+    { "/home/mutt/path/mbox/cherry.mbox",         NULL, -1 }, // Junk
+    { "/home/mutt/path/mbox/damson.mbox",         NULL, -1 }, // Directory
+    { "/home/mutt/path/mbox/endive.mbox",         NULL, -1 }, // Unreadable
+    { "/home/mutt/path/mbox/fig.mbox",            NULL,  0 }, // Mmdf
+    { "/home/mutt/path/mbox/guava.mbox",          NULL,  0 }, // Missing
+  };
+  // clang-format on
+
+  struct Path path = { 0 };
+  struct stat st;
+  int rc;
+  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  {
+    path.orig = (char *) tests[i].first;
+    TEST_CASE(path.orig);
+    path.type = MUTT_UNKNOWN;
+    path.flags = MPATH_NO_FLAGS;
+    memset(&st, 0, sizeof(st));
+    stat(path.orig, &st);
+    rc = mbox_path2_probe(&path, &st);
+    TEST_CHECK(rc == tests[i].retval);
+    if (rc == 0)
+    {
+      TEST_CHECK(path.type > MUTT_UNKNOWN);
+    }
+  }
+}
+
+void test_mbox_path2_tidy(void)
+{
+  // clang-format off
+  static const struct TestValue tests[] = {
+    { "/home/mutt/path/./mbox/../mbox///apple.mbox", "/home/mutt/path/mbox/apple.mbox", 0 },
+  };
+  // clang-format on
+
+  struct Path path = {
+    .type = MUTT_MBOX,
+    .flags = MPATH_RESOLVED,
+  };
+
+  int rc;
+  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  {
+    path.orig = mutt_str_strdup(tests[i].first);
+    rc = mbox_path2_tidy(&path);
+    TEST_CHECK(rc == 0);
+    TEST_CHECK(path.orig != NULL);
+    TEST_CHECK(path.flags & MPATH_TIDY);
+    TEST_CHECK(strcmp(path.orig, tests[i].second) == 0);
+    FREE(&path.orig);
+  }
+}

--- a/test/mx_path/nntp.c
+++ b/test/mx_path/nntp.c
@@ -1,0 +1,249 @@
+/**
+ * @file
+ * Test code for the NNTP MxOps Path functions
+ *
+ * @authors
+ * Copyright (C) 2020 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define TEST_NO_MAIN
+#include "acutest.h"
+#include "config.h"
+#include <string.h>
+#include <sys/stat.h>
+#include "mutt/lib.h"
+#include "core/lib.h"
+#include "common.h"
+#include "nntp/path.h"
+
+void test_nntp_path2_canon(void)
+{
+  // clang-format off
+  static struct TestValue tests[] = {
+    { "news://user@example.com:123/alt.apple",        "news://user@example.com:123/alt.apple",  0 },
+    { "junk://user@example.com:123/alt.apple",        "junk://user@example.com:123/alt.apple", -1 },
+    { "news://example.com:123/alt.apple",             "news://user@example.com:123/alt.apple",  0 },
+    { "news://user@example.com/alt.apple",            "news://user@example.com:123/alt.apple",  0 },
+    { "news://user:secret@example.com:123/alt.apple", "news://user@example.com:123/alt.apple",  0 },
+    { "news://example.com/alt.apple",                 "news://user@example.com:123/alt.apple",  0 },
+  };
+  // clang-format on
+
+  struct Path path = { 0 };
+  int rc;
+  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  {
+    path.orig = (char *) tests[i].first;
+    path.canon = (char *) mutt_str_strdup(tests[i].first);
+    TEST_CASE(path.orig);
+    path.type = MUTT_NNTP;
+    path.flags = MPATH_RESOLVED | MPATH_TIDY | MPATH_CANONICAL;
+
+    rc = nntp_path2_canon(&path, "user", 123);
+    TEST_CHECK(rc == tests[i].retval);
+    if (rc == 0)
+    {
+      TEST_CHECK(path.flags & MPATH_CANONICAL);
+      TEST_CHECK(path.canon != NULL);
+      TEST_CHECK(mutt_str_strcmp(path.canon, tests[i].second) == 0);
+    }
+    FREE(&path.canon);
+  }
+}
+
+void test_nntp_path2_compare(void)
+{
+  // clang-format off
+  static struct TestValue tests[] = {
+    { "news://user@example.com:123/INBOX",        "news://user@example.com:123/INBOX",        0 }, // Match
+    { "news://user@example.com:123/INBOX",        "snews://user@example.com:123/INBOX",      -1 }, // Scheme differs
+    { "snews://user@example.com:123/INBOX",       "news://user@example.com:123/INBOX",        1 }, // Scheme differs
+    { "news://adam@example.com:123/INBOX",        "news://zach@example.com:123/INBOX",       -1 }, // User differs
+    { "news://zach@example.com:123/INBOX",        "news://adam@example.com:123/INBOX",        1 }, // User differs
+    { "news://adam@example.com:123/INBOX",        "news://example.com:123/INBOX",             0 }, // User missing
+    { "news://adam:secret@example.com:123/INBOX", "news://adam:magic@example.com:123/INBOX",  0 }, // Password ignored
+    { "news://user@example.com:123/INBOX",        "news://user@flatcap.org:123/INBOX",       -1 }, // Host differs
+    { "news://user@flatcap.org:123/INBOX",        "news://user@example.com:123/INBOX",        1 }, // Host differs
+    { "news://user@example.com:123/INBOX",        "news://user@example.com:456/INBOX",       -1 }, // Port differs
+    { "news://user@example.com:456/INBOX",        "news://user@example.com:123/INBOX",        1 }, // Port differs
+    { "news://user@example.com:456/INBOX",        "news://user@example.com/INBOX",            0 }, // Port missing
+    { "news://user@example.com:123/INBOX",        "news://user@example.com:123/junk",        -1 }, // Path differs
+    { "news://user@example.com:123/junk",         "news://user@example.com:123/INBOX",        1 }, // Path differs
+  };
+  // clang-format on
+
+  struct Path path1 = {
+    .type = MUTT_NNTP,
+    .flags = MPATH_RESOLVED | MPATH_TIDY | MPATH_CANONICAL,
+  };
+  struct Path path2 = {
+    .type = MUTT_NNTP,
+    .flags = MPATH_RESOLVED | MPATH_TIDY | MPATH_CANONICAL,
+  };
+
+  int rc;
+  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  {
+    path1.canon = (char *) tests[i].first;
+    TEST_CASE(path1.canon);
+
+    path2.canon = (char *) tests[i].second;
+    TEST_CASE(path2.canon);
+
+    rc = nntp_path2_compare(&path1, &path2);
+    TEST_CHECK(rc == tests[i].retval);
+  }
+}
+
+void test_nntp_path2_parent(void)
+{
+  // clang-format off
+  static struct TestValue tests[] = {
+    { "news://example.com/apple.banana.cherry", "news://example.com/apple.banana",  0 },
+    { "news://example.com/apple.banana",        "news://example.com/apple",         0 },
+    { "news://example.com/apple",               NULL,                              -1 },
+    { "news://example.com/",                    NULL,                              -1 },
+    { "junk://example.com/",                    NULL,                              -2 },
+  };
+  // clang-format on
+
+  struct Path path = {
+    .type = MUTT_NNTP,
+    .flags = MPATH_RESOLVED | MPATH_TIDY,
+  };
+
+  struct Path *parent = NULL;
+  int rc;
+  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  {
+    path.orig = (char *) tests[i].first;
+    TEST_CASE(path.orig);
+
+    rc = nntp_path2_parent(&path, &parent);
+    TEST_CHECK(rc == tests[i].retval);
+    if (rc == 0)
+    {
+      TEST_CHECK(parent != NULL);
+      TEST_CHECK(parent->orig != NULL);
+      TEST_CHECK(parent->type == path.type);
+      TEST_CHECK(parent->flags & MPATH_RESOLVED);
+      TEST_CHECK(parent->flags & MPATH_TIDY);
+      TEST_CHECK(mutt_str_strcmp(parent->orig, tests[i].second) == 0);
+      mutt_path_free(&parent);
+    }
+  }
+}
+
+void test_nntp_path2_pretty(void)
+{
+  static const char *folder = "news://user@example.com:123/";
+  // clang-format off
+  static struct TestValue tests[] = {
+    { "news://example.com/alt.apple",         "+alt.apple", 1 },
+    { "snews://example.com/alt.apple",        NULL,         0 }, // Scheme differs
+    { "news://flatcap.org/alt.apple",         NULL,         0 }, // Host differs
+    { "news://another@example.com/alt.apple", NULL,         0 }, // User differs
+    { "news://example.com:456/alt.apple",     NULL,         0 }, // Port differs
+    { "news://example.com/",                  NULL,         0 }, // Folder is entire path
+  };
+  // clang-format on
+
+  struct Path path = {
+    .type = MUTT_NNTP,
+    .flags = MPATH_RESOLVED | MPATH_TIDY,
+  };
+
+  char *pretty = NULL;
+  int rc;
+  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  {
+    path.orig = (char *) tests[i].first;
+    TEST_CASE(path.orig);
+
+    rc = nntp_path2_pretty(&path, folder, &pretty);
+    TEST_CHECK(rc == tests[i].retval);
+    if (rc > 0)
+    {
+      TEST_CHECK(pretty != NULL);
+      TEST_CHECK(mutt_str_strcmp(pretty, tests[i].second) == 0);
+    }
+    FREE(&pretty);
+  }
+}
+
+void test_nntp_path2_probe(void)
+{
+  // clang-format off
+  static const struct TestValue tests[] = {
+    { "news://example.com/",  NULL,  0 },
+    { "snews://example.com/", NULL,  0 },
+    { "imap://example.com/",  NULL, -1 },
+  };
+  // clang-format on
+
+  struct Path path = { 0 };
+  struct stat st;
+  int rc;
+  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  {
+    path.orig = (char *) tests[i].first;
+    TEST_CASE(path.orig);
+    path.type = MUTT_UNKNOWN;
+    path.flags = MPATH_NO_FLAGS;
+    memset(&st, 0, sizeof(st));
+    stat(path.orig, &st);
+    rc = nntp_path2_probe(&path, &st);
+    TEST_CHECK(rc == tests[i].retval);
+    if (rc == 0)
+    {
+      TEST_CHECK(path.type > MUTT_UNKNOWN);
+    }
+  }
+}
+
+void test_nntp_path2_tidy(void)
+{
+  // clang-format off
+  static struct TestValue tests[] = {
+    { "news://example.com/alt.apple", "news://example.com/alt.apple",  0 },
+    { "NEWS://example.com/alt.apple", "news://example.com/alt.apple",  0 },
+    { "junk://example.com/",          "junk://example.com/",          -1 },
+  };
+  // clang-format on
+
+  struct Path path = {
+    .type = MUTT_NNTP,
+    .flags = MPATH_RESOLVED,
+  };
+
+  int rc;
+  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  {
+    path.orig = mutt_str_strdup(tests[i].first);
+    TEST_CASE(path.orig);
+
+    rc = nntp_path2_tidy(&path);
+    TEST_CHECK(rc == tests[i].retval);
+    if (rc == 0)
+    {
+      TEST_CHECK(path.orig != NULL);
+      TEST_CHECK(path.flags & MPATH_TIDY);
+      TEST_CHECK(mutt_str_strcmp(path.orig, tests[i].second) == 0);
+    }
+    FREE(&path.orig);
+  }
+}

--- a/test/mx_path/notmuch.c
+++ b/test/mx_path/notmuch.c
@@ -1,0 +1,232 @@
+/**
+ * @file
+ * Test code for the Notmuch MxOps Path functions
+ *
+ * @authors
+ * Copyright (C) 2020 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define TEST_NO_MAIN
+#include "acutest.h"
+#include "config.h"
+#include <string.h>
+#include <sys/stat.h>
+#include "mutt/lib.h"
+#include "core/lib.h"
+#include "common.h"
+#include "notmuch/path.h"
+
+void test_nm_path2_canon(void)
+{
+  // clang-format off
+  static struct TestValue tests[] = {
+    { "notmuch:///home/mutt/path/notmuch/apple?one=apple&two=banana",             "notmuch:///home/mutt/path/notmuch/apple?one=apple&two=banana",              0 }, // Same
+    { "notmuch:///home/mutt/path/notmuch/symlink?one=apple&two=banana",           "notmuch:///home/mutt/path/notmuch/apple?one=apple&two=banana",              0 }, // Symlink
+    { "notmuch:///home/mutt/path/notmuch/cherry?one=apple&two=banana",            "notmuch:///home/mutt/path/notmuch/cherry?one=apple&two=banana",            -1 }, // Missing
+    { "notmuch:///home/mutt/path/notmuch/apple?two=banana&one=apple",             "notmuch:///home/mutt/path/notmuch/apple?one=apple&two=banana",              0 }, // Query (sort)
+    { "notmuch:///home/mutt/path/notmuch/apple?one=apple&two=banana&one=cherry",  "notmuch:///home/mutt/path/notmuch/apple?one=apple&one=cherry&two=banana",   0 }, // Query (dupe)
+    { "notmuch:///home/mutt/path/notmuch/apple?one=cherry&two=banana&one=cherry", "notmuch:///home/mutt/path/notmuch/apple?one=cherry&one=cherry&two=banana",  0 }, // Query (dupe)
+    { "pop://example.com/",                                                       "pop://example.com/",                                                       -1 },
+    { "junk://example.com/",                                                      "junk://example.com/",                                                      -1 },
+  };
+  // clang-format on
+
+  struct Path path = { 0 };
+  int rc;
+  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  {
+    path.orig = (char *) tests[i].first;
+    TEST_CASE(path.orig);
+    path.type = MUTT_NOTMUCH;
+    path.flags = MPATH_RESOLVED | MPATH_TIDY;
+
+    rc = nm_path2_canon(&path);
+    TEST_CHECK(rc == tests[i].retval);
+    if (rc == 0)
+    {
+      TEST_CHECK(path.flags & MPATH_CANONICAL);
+      TEST_CHECK(path.canon != NULL);
+      TEST_CHECK(mutt_str_strcmp(path.canon, tests[i].second) == 0);
+    }
+    FREE(&path.canon);
+  }
+}
+
+void test_nm_path2_compare(void)
+{
+  // clang-format off
+  static struct TestValue tests[] = {
+    { "notmuch:///home/mutt/path/notmuch/apple?one=apple&two=banana",           "notmuch:///home/mutt/path/notmuch/apple?one=apple&two=banana",                0 }, // Match
+    { "notmuch:///home/mutt/path/notmuch/apple?one=apple&two=banana",           "pop://example.com/",                                                          1 }, // Scheme differs
+    { "notmuch:///home/mutt/path/notmuch/apple?one=apple&two=banana",           "notmuch:///home/mutt/path/notmuch/banana?one=apple&two=banana",              -1 }, // Path differs
+    { "notmuch:///home/mutt/path/notmuch/apple?one=apple&two=banana",           "notmuch://?one=apple&two=banana",                                             0 }, // Path missing
+    { "notmuch:///home/mutt/path/notmuch/apple?one=apple&two=banana",           "notmuch:///home/mutt/path/notmuch/apple?one=apple",                           1 }, // Query differs (fewer)
+    { "notmuch:///home/mutt/path/notmuch/apple?one=apple&two=banana",           "notmuch:///home/mutt/path/notmuch/apple?one=apple&two=banana&three=cherry",  -1 }, // Query differs (more)
+    { "notmuch:///home/mutt/path/notmuch/apple?one=apple&one=apple&two=banana", "notmuch:///home/mutt/path/notmuch/apple?one=apple&one=apple&two=banana",      0 }, // Query (dupes)
+  };
+  // clang-format on
+
+  struct Path path1 = {
+    .type = MUTT_NOTMUCH,
+    .flags = MPATH_RESOLVED | MPATH_TIDY | MPATH_CANONICAL,
+  };
+  struct Path path2 = {
+    .type = MUTT_NOTMUCH,
+    .flags = MPATH_RESOLVED | MPATH_TIDY | MPATH_CANONICAL,
+  };
+
+  int rc;
+  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  {
+    path1.canon = (char *) tests[i].first;
+    TEST_CASE(path1.canon);
+
+    path2.canon = (char *) tests[i].second;
+    TEST_CASE(path2.canon);
+
+    rc = nm_path2_compare(&path1, &path2);
+    TEST_CHECK(rc == tests[i].retval);
+  }
+}
+
+void test_nm_path2_parent(void)
+{
+  // clang-format off
+  static struct TestValue tests[] = {
+    { "notmuch:///home/mutt/path/notmuch/apple", NULL, -1 },
+  };
+  // clang-format on
+
+  struct Path path = {
+    .type = MUTT_NOTMUCH,
+    .flags = MPATH_RESOLVED | MPATH_TIDY,
+  };
+
+  struct Path *parent = NULL;
+  int rc;
+  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  {
+    path.orig = tests[i].first;
+    TEST_CASE(path.orig);
+
+    rc = nm_path2_parent(&path, &parent);
+    TEST_CHECK(rc == tests[i].retval);
+    TEST_CHECK(mutt_str_strcmp(parent ? parent->orig : NULL, tests[i].second) == 0);
+  }
+}
+
+void test_nm_path2_pretty(void)
+{
+  const char *folder = "notmuch:///home/mutt/path/notmuch/apple";
+  // clang-format off
+  static struct TestValue tests[] = {
+    { "notmuch:///home/mutt/path/notmuch/apple?one=apple&two=banana",  "notmuch://?one=apple&two=banana", 1 },
+    { "notmuch:///home/mutt/path/notmuch/cherry?one=apple&two=banana", NULL,                              0 },
+    { "pop://example.com/",                                            NULL,                              0 },
+  };
+  // clang-format on
+
+  struct Path path = {
+    .type = MUTT_NOTMUCH,
+    .flags = MPATH_RESOLVED | MPATH_TIDY,
+  };
+
+  char *pretty = NULL;
+  int rc;
+  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  {
+    path.orig = (char *) tests[i].first;
+    TEST_CASE(path.orig);
+
+    rc = nm_path2_pretty(&path, folder, &pretty);
+    TEST_CHECK(rc == tests[i].retval);
+    if (rc > 0)
+    {
+      TEST_CHECK(pretty != NULL);
+      TEST_CHECK(mutt_str_strcmp(pretty, tests[i].second) == 0);
+    }
+    FREE(&pretty);
+  }
+}
+
+void test_nm_path2_probe(void)
+{
+  // clang-format off
+  static const struct TestValue tests[] = {
+    { "notmuch:///home/mutt/path/notmuch/apple",   NULL,  0 }, // OK
+    { "notmuch:///home/mutt/path/notmuch/symlink", NULL,  0 }, // Symlink
+    { "notmuch:///home/mutt/path/notmuch/banana",  NULL, -1 }, // Missing .notmuch dir
+    { "notmuch:///home/mutt/path/notmuch/cherry",  NULL, -1 }, // Missing dir
+    { "pop://example.com/",                        NULL, -1 },
+    { "junk://example.com/",                       NULL, -1 },
+  };
+  // clang-format on
+
+  struct Path path = { 0 };
+  struct stat st;
+  int rc;
+  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  {
+    path.orig = (char *) tests[i].first;
+    TEST_CASE(path.orig);
+    path.type = MUTT_UNKNOWN;
+    path.flags = MPATH_NO_FLAGS;
+    memset(&st, 0, sizeof(st));
+    stat(path.orig, &st);
+    rc = nm_path2_probe(&path, &st);
+    TEST_CHECK(rc == tests[i].retval);
+    if (rc == 0)
+    {
+      TEST_CHECK(path.type > MUTT_UNKNOWN);
+    }
+  }
+}
+
+void test_nm_path2_tidy(void)
+{
+  // clang-format off
+  static struct TestValue tests[] = {
+    { "notmuch:///home/mutt/path/notmuch/apple?one=apple&two=banana",          "notmuch:///home/mutt/path/notmuch/apple?one=apple&two=banana",  0 },
+    { "NOTMUCH:///home/mutt/path/notmuch/apple?one=apple&two=banana",          "notmuch:///home/mutt/path/notmuch/apple?one=apple&two=banana",  0 },
+    { "notmuch:///home/mutt/path/../path/notmuch//apple?one=apple&two=banana", "notmuch:///home/mutt/path/notmuch/apple?one=apple&two=banana",  0 },
+    { "pop://example.com/",                                                    "pop://example.com/",                                           -1 },
+    { "junk://example.com/",                                                   "junk://example.com/",                                          -1 },
+  };
+  // clang-format on
+
+  struct Path path = {
+    .type = MUTT_NOTMUCH,
+    .flags = MPATH_RESOLVED,
+  };
+
+  int rc;
+  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  {
+    path.orig = mutt_str_strdup(tests[i].first);
+    TEST_CASE(path.orig);
+
+    rc = nm_path2_tidy(&path);
+    TEST_CHECK(rc == tests[i].retval);
+    if (rc == 0)
+    {
+      TEST_CHECK(path.orig != NULL);
+      TEST_CHECK(path.flags & MPATH_TIDY);
+      TEST_CHECK(mutt_str_strcmp(path.orig, tests[i].second) == 0);
+    }
+    FREE(&path.orig);
+  }
+}

--- a/test/mx_path/pop.c
+++ b/test/mx_path/pop.c
@@ -1,0 +1,248 @@
+/**
+ * @file
+ * Test code for the POP MxOps Path functions
+ *
+ * @authors
+ * Copyright (C) 2020 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define TEST_NO_MAIN
+#include "acutest.h"
+#include "config.h"
+#include <string.h>
+#include <sys/stat.h>
+#include "mutt/lib.h"
+#include "core/lib.h"
+#include "common.h"
+#include "pop/path.h"
+
+void test_pop_path2_canon(void)
+{
+  // clang-format off
+  static struct TestValue tests[] = {
+    { "pop://user@example.com:123/INBOX",        "pop://user@example.com:123/INBOX",   0 },
+    { "junk://user@example.com:123/INBOX",       "junk://user@example.com:123/INBOX", -1 },
+    { "pop://example.com:123/INBOX",             "pop://user@example.com:123/INBOX",   0 },
+    { "pop://user@example.com/INBOX",            "pop://user@example.com:123/INBOX",   0 },
+    { "pop://user:secret@example.com:123/INBOX", "pop://user@example.com:123/INBOX",   0 },
+    { "pop://example.com/INBOX",                 "pop://user@example.com:123/INBOX",   0 },
+  };
+  // clang-format on
+
+  struct Path path = { 0 };
+  int rc;
+  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  {
+    path.orig = (char *) tests[i].first;
+    TEST_CASE(path.orig);
+    path.type = MUTT_POP;
+    path.flags = MPATH_RESOLVED | MPATH_TIDY;
+
+    rc = pop_path2_canon(&path, "user", 123);
+    TEST_CHECK(rc == tests[i].retval);
+    if (rc == 0)
+    {
+      TEST_CHECK(path.flags & MPATH_CANONICAL);
+      TEST_CHECK(path.canon != NULL);
+      TEST_CHECK(mutt_str_strcmp(path.canon, tests[i].second) == 0);
+    }
+    FREE(&path.canon);
+  }
+}
+
+void test_pop_path2_compare(void)
+{
+  // clang-format off
+  static struct TestValue tests[] = {
+    { "pop://user@example.com:123/INBOX",        "pop://user@example.com:123/INBOX",        0 }, // Match
+    { "pop://user@example.com:123/INBOX",        "pops://user@example.com:123/INBOX",      -1 }, // Scheme differs
+    { "pops://user@example.com:123/INBOX",       "pop://user@example.com:123/INBOX",        1 }, // Scheme differs
+    { "pop://adam@example.com:123/INBOX",        "pop://zach@example.com:123/INBOX",       -1 }, // User differs
+    { "pop://zach@example.com:123/INBOX",        "pop://adam@example.com:123/INBOX",        1 }, // User differs
+    { "pop://adam@example.com:123/INBOX",        "pop://example.com:123/INBOX",             0 }, // User missing
+    { "pop://adam:secret@example.com:123/INBOX", "pop://adam:magic@example.com:123/INBOX",  0 }, // Password ignored
+    { "pop://user@example.com:123/INBOX",        "pop://user@flatcap.org:123/INBOX",       -1 }, // Host differs
+    { "pop://user@flatcap.org:123/INBOX",        "pop://user@example.com:123/INBOX",        1 }, // Host differs
+    { "pop://user@example.com:123/INBOX",        "pop://user@example.com:456/INBOX",       -1 }, // Port differs
+    { "pop://user@example.com:456/INBOX",        "pop://user@example.com:123/INBOX",        1 }, // Port differs
+    { "pop://user@example.com:456/INBOX",        "pop://user@example.com/INBOX",            0 }, // Port missing
+    { "pop://user@example.com:123/INBOX",        "pop://user@example.com:123/junk",        -1 }, // Path differs
+    { "pop://user@example.com:123/junk",         "pop://user@example.com:123/INBOX",        1 }, // Path differs
+  };
+  // clang-format on
+
+  struct Path path1 = {
+    .type = MUTT_POP,
+    .flags = MPATH_RESOLVED | MPATH_TIDY | MPATH_CANONICAL,
+  };
+  struct Path path2 = {
+    .type = MUTT_POP,
+    .flags = MPATH_RESOLVED | MPATH_TIDY | MPATH_CANONICAL,
+  };
+
+  int rc;
+  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  {
+    path1.canon = (char *) tests[i].first;
+    TEST_CASE(path1.canon);
+
+    path2.canon = (char *) tests[i].second;
+    TEST_CASE(path2.canon);
+
+    rc = pop_path2_compare(&path1, &path2);
+    TEST_CHECK(rc == tests[i].retval);
+  }
+}
+
+void test_pop_path2_parent(void)
+{
+  // clang-format off
+  static struct TestValue tests[] = {
+    { "pop://example.com/", NULL, -1 },
+  };
+  // clang-format on
+
+  struct Path path = {
+    .type = MUTT_POP,
+    .flags = MPATH_RESOLVED | MPATH_TIDY,
+  };
+
+  struct Path *parent = NULL;
+  int rc;
+  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  {
+    path.orig = (char *) tests[i].first;
+    TEST_CASE(path.orig);
+
+    rc = pop_path2_parent(&path, &parent);
+    TEST_CHECK(rc == tests[i].retval);
+    if (rc == 0)
+    {
+      TEST_CHECK(parent != NULL);
+      TEST_CHECK(parent->orig != NULL);
+      TEST_CHECK(parent->type == path.type);
+      TEST_CHECK(parent->flags & MPATH_RESOLVED);
+      TEST_CHECK(parent->flags & MPATH_TIDY);
+      TEST_CHECK(mutt_str_strcmp(parent->orig, tests[i].second) == 0);
+      mutt_path_free(&parent);
+    }
+  }
+}
+
+void test_pop_path2_pretty(void)
+{
+  static const char *folder = "pop://user@example.com:123/";
+  // clang-format off
+  static struct TestValue tests[] = {
+    { "pop://example.com/INBOX",         "+INBOX", 1 },
+    { "pops://example.com/INBOX",        NULL,     0 }, // Scheme differs
+    { "pop://flatcap.org/INBOX",         NULL,     0 }, // Host differs
+    { "pop://another@example.com/INBOX", NULL,     0 }, // User differs
+    { "pop://example.com:456/INBOX",     NULL,     0 }, // Port differs
+    { "pop://example.com/",              NULL,     0 }, // Folder is entire path
+  };
+  // clang-format on
+
+  struct Path path = {
+    .type = MUTT_POP,
+    .flags = MPATH_RESOLVED | MPATH_TIDY,
+  };
+
+  char *pretty = NULL;
+  int rc;
+  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  {
+    path.orig = (char *) tests[i].first;
+    TEST_CASE(path.orig);
+
+    rc = pop_path2_pretty(&path, folder, &pretty);
+    TEST_CHECK(rc == tests[i].retval);
+    if (rc > 0)
+    {
+      TEST_CHECK(pretty != NULL);
+      TEST_CHECK(mutt_str_strcmp(pretty, tests[i].second) == 0);
+    }
+    FREE(&pretty);
+  }
+}
+
+void test_pop_path2_probe(void)
+{
+  // clang-format off
+  static const struct TestValue tests[] = {
+    { "pop://example.com/",  NULL,  0 },
+    { "pops://example.com/", NULL,  0 },
+    { "imap://example.com",  NULL, -1 },
+  };
+  // clang-format on
+
+  struct Path path = { 0 };
+  struct stat st;
+  int rc;
+  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  {
+    path.orig = (char *) tests[i].first;
+    TEST_CASE(path.orig);
+    path.type = MUTT_UNKNOWN;
+    path.flags = MPATH_NO_FLAGS;
+    memset(&st, 0, sizeof(st));
+    stat(path.orig, &st);
+    rc = pop_path2_probe(&path, &st);
+    TEST_CHECK(rc == tests[i].retval);
+    if (rc == 0)
+    {
+      TEST_CHECK(path.type > MUTT_UNKNOWN);
+    }
+  }
+}
+
+void test_pop_path2_tidy(void)
+{
+  // clang-format off
+  static struct TestValue tests[] = {
+    { "pop://example.com/INBOX", "pop://example.com/INBOX",   0 },
+    { "POP://example.com/INBOX", "pop://example.com/INBOX",   0 },
+    { "pop://example.com/inbox", "pop://example.com/INBOX",   0 },
+    { "pop://example.com/",      "pop://example.com/INBOX",   0 },
+    { "pop://example.com",       "pop://example.com/INBOX",   0 },
+    { "pops://example.com/",     "pops://example.com/INBOX",  0 },
+    { "junk://example.com/",     "junk://example.com/",      -1 },
+  };
+  // clang-format on
+
+  struct Path path = {
+    .type = MUTT_POP,
+    .flags = MPATH_RESOLVED,
+  };
+
+  int rc;
+  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  {
+    path.orig = mutt_str_strdup(tests[i].first);
+    TEST_CASE(path.orig);
+
+    rc = pop_path2_tidy(&path);
+    TEST_CHECK(rc == tests[i].retval);
+    if (rc == 0)
+    {
+      TEST_CHECK(path.orig != NULL);
+      TEST_CHECK(path.flags & MPATH_TIDY);
+      TEST_CHECK(mutt_str_strcmp(path.orig, tests[i].second) == 0);
+    }
+    FREE(&path.orig);
+  }
+}

--- a/tracker.c
+++ b/tracker.c
@@ -1,0 +1,210 @@
+/**
+ * @file
+ * Keep track of the current Account and Mailbox
+ *
+ * @authors
+ * Copyright (C) 2019 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @page tracker Keep track of the current Account and Mailbox
+ *
+ * When reading a config file, keep track of the current Account and Mailbox.
+ */
+
+#include "config.h"
+#include "mutt/lib.h"
+#include "core/lib.h"
+#include "tracker.h"
+
+/**
+ * struct ScopePair - A list of Account,Mailbox pairs
+ *
+ * This is used to keep track of the current 'account' or 'mailbox' command in
+ * the config file.
+ */
+struct ScopePair
+{
+  struct Account *account;
+  struct Mailbox *mailbox;
+  STAILQ_ENTRY(ScopePair) entries;
+};
+STAILQ_HEAD(ScopePairHead, ScopePair);
+
+struct ScopePairHead ConfigStack = STAILQ_HEAD_INITIALIZER(ConfigStack);
+
+/**
+ * ct_get_account - Get the current Account
+ * @retval ptr  An Account
+ * @retval NULL If no 'account' command in use
+ */
+struct Account *ct_get_account(void)
+{
+  struct ScopePair *sp = NULL;
+  STAILQ_FOREACH(sp, &ConfigStack, entries)
+  {
+    if (sp->account)
+      return sp->account;
+  }
+
+  return NULL;
+}
+
+/**
+ * ct_set_account - Set the current Account
+ * @param a Account
+ *
+ * The 'account' command will scope the following config commands.
+ */
+void ct_set_account(struct Account *a)
+{
+  // printf("\033[1;31mset account: %s\033[0m\n", a ? a->name : "[NONE]");
+  struct ScopePair *sp = STAILQ_FIRST(&ConfigStack);
+  if (!sp)
+  {
+    mutt_error("FAIL - stack empty1");
+    return;
+  }
+
+  if (!sp->account && !a)
+    mutt_error("WARN - no active account1");
+  else
+  {
+    sp->account = a;
+    sp->mailbox = NULL;
+  }
+  // ct_dump();
+}
+
+/**
+ * ct_get_mailbox - Get the current Mailbox
+ * @retval ptr  A Mailbox
+ * @retval NULL If no 'mailbox' command in use
+ */
+struct Mailbox *ct_get_mailbox(void)
+{
+  struct ScopePair *sp = NULL;
+  STAILQ_FOREACH(sp, &ConfigStack, entries)
+  {
+    if (sp->account)
+      return sp->mailbox;
+  }
+
+  return NULL;
+}
+
+/**
+ * ct_set_mailbox - Set the current Mailbox
+ * @param m Mailbox
+ *
+ * The 'mailbox' command will scope the following config commands.
+ */
+void ct_set_mailbox(struct Mailbox *m)
+{
+  // printf("\033[1;34mset mailbox: %s\033[0m\n", m ? m->path->desc : "[NONE]");
+  struct ScopePair *sp = STAILQ_FIRST(&ConfigStack);
+  if (!sp)
+    return;
+
+  if (sp->account)
+    sp->mailbox = m;
+  // ct_dump();
+}
+
+/**
+ * ct_push_top - Duplicate the top of the Account/Mailbox stack
+ *
+ * When a new config file is read, the 'account' or 'mailbox' commands are
+ * inherited.
+ */
+void ct_push_top(void)
+{
+  // printf("\033[1;31mpush top\033[0m\n");
+  struct ScopePair *sp_dup = mutt_mem_calloc(1, sizeof(*sp_dup));
+
+  struct ScopePair *sp = STAILQ_FIRST(&ConfigStack);
+  if (sp)
+  {
+    sp_dup->account = sp->account;
+    sp_dup->mailbox = sp->mailbox;
+  }
+
+  STAILQ_INSERT_HEAD(&ConfigStack, sp_dup, entries);
+  // ct_dump();
+}
+
+/**
+ * ct_pop - Pop the current Account/Mailbox from the stack
+ *
+ * When the end of a config file is reached, the current 'account' or 'mailbox'
+ * scope ends.
+ */
+void ct_pop(void)
+{
+  // printf("\033[1;31mpop\033[0m\n");
+  struct ScopePair *sp = STAILQ_FIRST(&ConfigStack);
+  if (!sp)
+  {
+    mutt_error("FAIL - stack empty2");
+    return;
+  }
+
+  STAILQ_REMOVE_HEAD(&ConfigStack, entries);
+  FREE(&sp);
+  // ct_dump();
+}
+
+/**
+ * ct_get_sub - Get the active Config Subset
+ * @retval ptr  Config Subset
+ *
+ * This will depend on any 'account' or 'mailbox' config commands.
+ * If none is active, then the global Subset (from NeoMutt) will be returned.
+ */
+struct ConfigSubset *ct_get_sub(void)
+{
+  struct ScopePair *sp = NULL;
+  STAILQ_FOREACH(sp, &ConfigStack, entries)
+  {
+    if (sp->mailbox)
+      return sp->mailbox->sub;
+    else if (sp->account)
+      return sp->account->sub;
+  }
+
+  return NeoMutt->sub;
+}
+
+/**
+ * ct_dump - Dump the tracker stack
+ */
+void ct_dump(void)
+{
+  size_t i = 0;
+  struct ScopePair *sp = NULL;
+  printf("tracker stack:");
+  STAILQ_FOREACH(sp, &ConfigStack, entries)
+  {
+    i++;
+    struct Account *a = sp->account;
+    const char *a_name = a ? a->name : "-";
+    struct Mailbox *m = sp->mailbox;
+    const char *m_name = m ? m->path->desc : "-";
+    printf(" (%s,%s)", a_name, m_name);
+  }
+  printf("\n");
+}

--- a/tracker.h
+++ b/tracker.h
@@ -1,0 +1,37 @@
+/**
+ * @file
+ * Keep track of the current Account and Mailbox
+ *
+ * @authors
+ * Copyright (C) 1996-2000,2010,2013 Michael R. Elkins <me@mutt.org>
+ * Copyright (C) 2019 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MUTT_TRACKER_H
+#define MUTT_TRACKER_H
+
+struct Account *     ct_get_account(void);
+struct Mailbox *     ct_get_mailbox(void);
+struct ConfigSubset *ct_get_sub(void);
+void                 ct_pop(void);
+void                 ct_push_top(void);
+void                 ct_set_account(struct Account *a);
+void                 ct_set_mailbox(struct Mailbox *m);
+
+void ct_dump(void);
+
+#endif /* MUTT_TRACKER_H */


### PR DESCRIPTION
## New Config Command: `account`

This is the beginning of Account-specific config.

- 5858405d6 add `account` command
  Add a new command and a stack for nested `account` commands

- b30988e1c update config tests
  Fix tests for named `Account`s

This is a quick hack for demonstration purpuses:

- 3f89b0b0f use `Account`-specific `$index_format`

The last two commits are just for testing purposes.
They generate graphviz diagrams and dump Account info.

- 4bc14be9d add dot_dump()
- a1e5b4e65 add debug logging

---

## Setup

- Build this PR, branch [devel/account](https://github.com/neomutt/neomutt/tree/devel/account)
- Clone the [sample-mail](https://github.com/neomutt/sample-mail) repo
- Set an environment variable to the `sample-mail` repo
  `export DEMO_DIR=/home/user/sample-mail`

There are two sample config files: `demo.rc` and `base.rc` (which sources `child.rc`)
They are **equivalent**.

`demo.rc` begins:

```conf
account cars
  set folder = "$DEMO_DIR/cars"
  set index_format = "CARS %4C %Z %{%b %d} %-15.15L (%?l?%4l&%4c?) %s"
  set sort = "from"
  set sort_aux = "from"

  mailboxes "+audi"
  mailboxes "+bentley"
  mailboxes "+chrysler"
  mailboxes "+daimler"
```

## Notes

Leading whitespace is ignored -- it's included for clarity.

The `account` command's scope ends at:
- A new `account NAME` command
- An empty `account` command
- End of file

To use the Account-specific config, the code needs changing to lookup the value, rather than use the global.

In this PR:
- Only four config items have inheritance
- Only `$folder` and `$index_format` are actually used

## Testing

The config files are stripped to an absolute minimum.
They show the sidebar and enable:

- <kbd>Ctrl-P</kbd> - Sidebar previous
- <kbd>Ctrl-N</kbd> - Sidebar next
- <kbd>Ctrl-O</kbd> - Sidebar open

The code can be tested in two ways:

### Normal GUI mode

Use either of `demo.rc` or `base.rc`

`./neomutt -n -d5 -F $DEMO_DIR/demo.rc`

Opening mailboxes in different accounts will show up in the custom `$index_format`
Pressing <kbd>M</kbd> (`<show-log-messages>`) will generate a graphviz diagram of the objects.

### Batch mode

Enabling 'batch mode' with `neomutt -B`, will parse the config, then dump the results.
It will also generate a graphviz diagram of the objects (because I like diagrams :-)

Use either of `demo.rc` or `base.rc`

`./neomutt -n -d5 -F $DEMO_DIR/demo.rc -B`

## What's Next?

- Documentation

- More inheritance
  Each inherited config item will require careful code changes

- Sidebar updates
  The Sidebar needs to be taught about named Accounts