### PR TITLE
agentcrypt: password encryption with ssh-agent

### DIFF
--- a/auto.def
+++ b/auto.def
@@ -59,6 +59,9 @@ options {
   # SASL (IMAP and POP auth)
   sasl=0                    => "Use the SASL network security library"
   with-sasl:path            => "Location of the SASL network security library"
+  # agentcrypt (use ssh agent to encrypt/decrypt passwords)
+  agentcrypt=0              => "Use the agentcrypt library (https://github.com/ndilieto/libagentcrypt)"
+  with-agentcrypt:path      => "Location of the agentcrypt library"
 # Lua
   lua=0                     => "Enable Lua scripting support"
   with-lua:path             => "Location of Lua"
@@ -107,9 +110,9 @@ options {
 if {1} {
   # Keep sorted, please.
   foreach opt {
-    bdb backtrace coverage doc everything fmemopen full-doc gdbm gnutls gpgme
-    gss homespool idn idn2 inotify kyotocabinet lmdb locales-fix lua mixmaster
-    nls notmuch pgp qdbm sasl smime ssl testing tokyocabinet
+    agentcrypt bdb backtrace coverage doc everything fmemopen full-doc gdbm
+    gnutls gpgme gss homespool idn idn2 inotify kyotocabinet lmdb locales-fix
+    lua mixmaster nls notmuch pgp qdbm sasl smime ssl testing tokyocabinet
   } {
     define want-$opt [opt-bool $opt]
   }
@@ -118,8 +121,8 @@ if {1} {
   # relative --enable-opt to true. This allows "--with-opt=/usr" to be used as
   # a shortcut for "--opt --with-opt=/usr".
   foreach opt {
-    bdb gdbm gnutls gpgme gss homespool idn idn2 kyotocabinet lmdb lua mixmaster
-    ncurses nls notmuch qdbm sasl slang ssl tokyocabinet
+    agentcrypt bdb gdbm gnutls gpgme gss homespool idn idn2 kyotocabinet lmdb
+    lua mixmaster ncurses nls notmuch qdbm sasl slang ssl tokyocabinet
   } {
     if {[opt-val with-$opt] ne {}} {
       define want-$opt 1
@@ -450,6 +453,17 @@ if {[get-define want-sasl]} {
   }
   if {![get-define USE_SASL]} {
     user-error "Unable to find SASL"
+  }
+}
+
+# AGENTCRYPT
+if {[get-define want-agentcrypt]} {
+  if {[check-inc-and-lib agentcrypt [opt-val with-agentcrypt $prefix] \
+                         libagentcrypt.h agc_encrypt agentcrypt]} {
+     define USE_AGENTCRYPT
+  }
+  if {![get-define USE_AGENTCRYPT]} {
+    user-error "Unable to find AGENTCRYPT"
   }
 }
 

--- a/init.h
+++ b/init.h
@@ -1660,9 +1660,18 @@ struct ConfigDef MuttVars[] = {
   ** prompt you for your password when you invoke the \fC<imap-fetch-mail>\fP function
   ** or try to open an IMAP folder.
   ** .pp
+  ** If NeoMutt was compiled with agentcrypt support and the string begins with the
+  ** \fBACT:\fP or \fBact:\fP prefix, an attempt to decrypt it is made.
+  ** The encrypted password can be obtained by launching the command
+  ** \fBagentcrypt -t\fP and typing the password followed by a newline.
+  ** If decryption fails for any reason, NeoMutt will prompt you for the password
+  ** instead.
+  ** .pp
   ** \fBWarning\fP: you should only use this option when you are on a
   ** fairly secure machine, because the superuser can read your neomuttrc even
-  ** if you are the only one who can read the file.
+  ** if you are the only one who can read the file. If you use agentcrypt, note
+  ** that the superuser can also decrypt the password, but only when you are
+  ** logged in and have your key loaded or forwarded by ssh-agent.
   */
   { "imap_passive",             DT_BOOL, R_NONE, &C_ImapPassive, true },
   /*
@@ -3021,9 +3030,18 @@ struct ConfigDef MuttVars[] = {
   ** Specifies the password for your POP account.  If \fIunset\fP, NeoMutt will
   ** prompt you for your password when you open a POP mailbox.
   ** .pp
+  ** If NeoMutt was compiled with agentcrypt support and the string begins with the
+  ** \fBACT:\fP or \fBact:\fP prefix, an attempt to decrypt it is made.
+  ** The encrypted password can be obtained by launching the command
+  ** \fBagentcrypt -t\fP and typing the password followed by a newline.
+  ** If decryption fails for any reason, NeoMutt will prompt you for the password
+  ** instead.
+  ** .pp
   ** \fBWarning\fP: you should only use this option when you are on a
-  ** fairly secure machine, because the superuser can read your neomuttrc
-  ** even if you are the only one who can read the file.
+  ** fairly secure machine, because the superuser can read your neomuttrc even
+  ** if you are the only one who can read the file. If you use agentcrypt, note
+  ** that the superuser can also decrypt the password, but only when you are
+  ** logged in and have your key loaded or forwarded by ssh-agent.
   */
   { "pop_reconnect",    DT_QUAD, R_NONE, &C_PopReconnect, MUTT_ASKYES },
   /*
@@ -4087,9 +4105,18 @@ struct ConfigDef MuttVars[] = {
   ** prompt you for your password when you first send mail via SMTP.
   ** See $$smtp_url to configure NeoMutt to send mail via SMTP.
   ** .pp
+  ** If NeoMutt was compiled with agentcrypt support and the string begins with the
+  ** \fBACT:\fP or \fBact:\fP prefix, an attempt to decrypt it is made.
+  ** The encrypted password can be obtained by launching the command
+  ** \fBagentcrypt -t\fP and typing the password followed by a newline.
+  ** If decryption fails for any reason, NeoMutt will prompt you for the password
+  ** instead.
+  ** .pp
   ** \fBWarning\fP: you should only use this option when you are on a
   ** fairly secure machine, because the superuser can read your neomuttrc even
-  ** if you are the only one who can read the file.
+  ** if you are the only one who can read the file. If you use agentcrypt, note
+  ** that the superuser can also decrypt the password, but only when you are
+  ** logged in and have your key loaded or forwarded by ssh-agent.
   */
   { "smtp_url",         DT_STRING, R_NONE|F_SENSITIVE, &C_SmtpUrl, 0 },
   /*

--- a/version.c
+++ b/version.c
@@ -146,6 +146,11 @@ static struct CompileOptions comp_opts_default[] = {
 };
 
 static struct CompileOptions comp_opts[] = {
+#ifdef USE_AGENTCRYPT
+  { "agentcrypt", 1 },
+#else
+  { "agentcrypt", 0 },
+#endif
 #ifdef HAVE_BKGDSET
   { "bkgdset", 1 },
 #else


### PR DESCRIPTION
This commit adds a new 'agentcrypt' feature to NeoMutt, which allows
to securely store encrypted passwords in .neomuttrc and decrypt them
without typing anything, as long as the ssh key used to encrypt the
password is loaded or forwarded by the ssh-agent.

For more information see the modified imap_pass, pop_pass and smtp_pass
documentation in neomuttrc.5

The new feature is disabled by default as it depends on libagentcrypt
which is available at https://github.com/ndilieto/libagentcrypt

To enable it, first install libagentcrypt and then add --agentcrypt to
NeoMutt's ./configure invocation before rebuilding.

