### PR TITLE
add two devel features

### DIFF
--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -156,11 +156,13 @@ ALLOBJS+=	$(LIBNCRYPTOBJS)
 
 ###############################################################################
 # libhelp
+@if USE_DEVEL_HELP
 LIBHELP=	libhelp.a
 LIBHELPOBJS=	help/help.o
 CLEANFILES+=	$(LIBHELP) $(LIBHELPOBJS)
 MUTTLIBS+=	$(LIBHELP)
 ALLOBJS+=	$(LIBHELPOBJS)
+@endif
 
 ###############################################################################
 # libimap

--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -64,7 +64,7 @@ NEOMUTT=	neomutt$(EXEEXT)
 NEOMUTTOBJS=	account.o addrbook.o alias.o bcache.o browser.o color.o commands.o \
 		complete.o compose.o compress.o conststrings.o context.o copy.o \
 		curs_lib.o edit.o editmsg.o enriched.o enter.o \
-		filter.o flags.o git_ver.o handler.o hdrline.o help.o hook.o \
+		filter.o flags.o git_ver.o graphviz.o handler.o hdrline.o help.o hook.o \
 		index.o init.o keymap.o mailbox.o main.o menu.o muttlib.o \
 		mutt_account.o mutt_attach.o mutt_body.o mutt_header.o \
 		mutt_history.o mutt_logging.o mutt_parse.o mutt_signal.o \

--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -155,6 +155,14 @@ MUTTLIBS+=	$(LIBNCRYPT)
 ALLOBJS+=	$(LIBNCRYPTOBJS)
 
 ###############################################################################
+# libhelp
+LIBHELP=	libhelp.a
+LIBHELPOBJS=	help/help.o
+CLEANFILES+=	$(LIBHELP) $(LIBHELPOBJS)
+MUTTLIBS+=	$(LIBHELP)
+ALLOBJS+=	$(LIBHELPOBJS)
+
+###############################################################################
 # libimap
 LIBIMAP=	libimap.a
 LIBIMAPOBJS=	imap/auth.o imap/auth_anon.o imap/auth_cram.o \
@@ -352,6 +360,13 @@ $(LIBNCRYPT): $(PWD)/ncrypt $(LIBNCRYPTOBJS)
 	$(RANLIB) $@
 $(PWD)/ncrypt:
 	$(MKDIR_P) $(PWD)/ncrypt
+
+# libhelp
+$(LIBHELP): $(PWD)/help $(LIBHELPOBJS)
+	$(AR) cr $@ $(LIBHELPOBJS)
+	$(RANLIB) $@
+$(PWD)/help:
+	$(MKDIR_P) $(PWD)/help
 
 # libimap
 $(LIBIMAP): $(PWD)/imap $(LIBIMAPOBJS)

--- a/auto.def
+++ b/auto.def
@@ -95,6 +95,8 @@ options {
 # Testing
   testing=0                 => "Enable Unit Testing"
   coverage=0                => "Enable Coverage Testing"
+# Development
+  devel-help                => "Enable Help Backend (DEVEL)"
 # Configure with pkg-config
   pkgconf=0                 => "Use pkg-config during configure"
 # Enable all options
@@ -109,7 +111,7 @@ options {
 if {1} {
   # Keep sorted, please.
   foreach opt {
-    bdb backtrace coverage doc everything fmemopen full-doc gdbm gnutls gpgme
+    bdb backtrace coverage devel-help doc everything fmemopen full-doc gdbm gnutls gpgme
     gss homespool idn idn2 inotify kyotocabinet lmdb locales-fix lua mixmaster
     nls notmuch pkgconf pgp qdbm sasl smime ssl testing tokyocabinet
   } {
@@ -374,6 +376,10 @@ switch [opt-val with-lock fcntl] {
 ###############################################################################
 # Locales fix
 if {[get-define want-locales-fix]} {define LOCALES_HACK}
+
+###############################################################################
+# (DEVEL) Help Backend
+if {[get-define want-devel-help]} {define USE_DEVEL_HELP}
 
 ###############################################################################
 # Documentation

--- a/auto.def
+++ b/auto.def
@@ -96,6 +96,7 @@ options {
   testing=0                 => "Enable Unit Testing"
   coverage=0                => "Enable Coverage Testing"
 # Development
+  devel-graphviz            => "Enable Graphviz dump (DEVEL)"
   devel-help                => "Enable Help Backend (DEVEL)"
 # Configure with pkg-config
   pkgconf=0                 => "Use pkg-config during configure"
@@ -111,7 +112,7 @@ options {
 if {1} {
   # Keep sorted, please.
   foreach opt {
-    bdb backtrace coverage devel-help doc everything fmemopen full-doc gdbm gnutls gpgme
+    bdb backtrace coverage devel-graphviz devel-help doc everything fmemopen full-doc gdbm gnutls gpgme
     gss homespool idn idn2 inotify kyotocabinet lmdb locales-fix lua mixmaster
     nls notmuch pkgconf pgp qdbm sasl smime ssl testing tokyocabinet
   } {
@@ -378,6 +379,9 @@ switch [opt-val with-lock fcntl] {
 if {[get-define want-locales-fix]} {define LOCALES_HACK}
 
 ###############################################################################
+# (DEVEL) Graphviz dump
+if {[get-define want-devel-graphviz]} {define USE_DEVEL_GRAPHVIZ}
+
 # (DEVEL) Help Backend
 if {[get-define want-devel-help]} {define USE_DEVEL_HELP}
 

--- a/email/url.c
+++ b/email/url.c
@@ -40,7 +40,8 @@ static const struct Mapping UrlMap[] = {
   { "file", U_FILE },   { "imap", U_IMAP },     { "imaps", U_IMAPS },
   { "pop", U_POP },     { "pops", U_POPS },     { "news", U_NNTP },
   { "snews", U_NNTPS }, { "mailto", U_MAILTO }, { "notmuch", U_NOTMUCH },
-  { "smtp", U_SMTP },   { "smtps", U_SMTPS },   { NULL, U_UNKNOWN },
+  { "smtp", U_SMTP },   { "smtps", U_SMTPS },   { "help", U_HELP },
+  { NULL, U_UNKNOWN },
 };
 
 /**

--- a/email/url.c
+++ b/email/url.c
@@ -40,7 +40,10 @@ static const struct Mapping UrlMap[] = {
   { "file", U_FILE },   { "imap", U_IMAP },     { "imaps", U_IMAPS },
   { "pop", U_POP },     { "pops", U_POPS },     { "news", U_NNTP },
   { "snews", U_NNTPS }, { "mailto", U_MAILTO }, { "notmuch", U_NOTMUCH },
-  { "smtp", U_SMTP },   { "smtps", U_SMTPS },   { "help", U_HELP },
+  { "smtp", U_SMTP },   { "smtps", U_SMTPS },
+#ifdef USE_DEVEL_HELP
+  { "help", U_HELP },
+#endif
   { NULL, U_UNKNOWN },
 };
 

--- a/email/url.h
+++ b/email/url.h
@@ -43,6 +43,7 @@ enum UrlScheme
   U_SMTPS,   ///< Url is smtps://
   U_MAILTO,  ///< Url is mailto://
   U_NOTMUCH, ///< Url is notmuch://
+  U_HELP,    ///< Url is help://
 };
 
 #define U_PATH          (1 << 1)

--- a/functions.h
+++ b/functions.h
@@ -70,6 +70,7 @@ const struct Binding OpGeneric[] = { /* map: generic */
   { "half-down",       OP_HALF_DOWN,            "]" },
   { "half-up",         OP_HALF_UP,              "[" },
   { "help",            OP_HELP,                 "?" },
+  { "help-box",        OP_HELP_BOX,             "\033H" },
   { "jump",            OP_JUMP,                 NULL },
   { "last-entry",      OP_LAST_ENTRY,           "*" },
   { "middle-page",     OP_MIDDLE_PAGE,          "M" },

--- a/functions.h
+++ b/functions.h
@@ -70,7 +70,9 @@ const struct Binding OpGeneric[] = { /* map: generic */
   { "half-down",       OP_HALF_DOWN,            "]" },
   { "half-up",         OP_HALF_UP,              "[" },
   { "help",            OP_HELP,                 "?" },
+#ifdef USE_DEVEL_HELP
   { "help-box",        OP_HELP_BOX,             "\033H" },
+#endif
   { "jump",            OP_JUMP,                 NULL },
   { "last-entry",      OP_LAST_ENTRY,           "*" },
   { "middle-page",     OP_MIDDLE_PAGE,          "M" },

--- a/globals.h
+++ b/globals.h
@@ -103,6 +103,7 @@ WHERE char *C_DsnNotify;                     ///< Config: Request notification f
 WHERE char *C_DsnReturn;                     ///< Config: What to send as a notification of message delivery or delay
 WHERE char *C_Editor;                        ///< Config: External command to use as an email editor
 WHERE char *C_ExternalSearchCommand;         ///< Config: External search command
+WHERE char *C_HelpDocDir;
 WHERE char *C_Hostname;                      ///< Config: Fully-qualified domain name of this machine
 WHERE char *C_IndexFormat;                   ///< Config: printf-like format string for the index menu (emails)
 

--- a/globals.h
+++ b/globals.h
@@ -103,7 +103,9 @@ WHERE char *C_DsnNotify;                     ///< Config: Request notification f
 WHERE char *C_DsnReturn;                     ///< Config: What to send as a notification of message delivery or delay
 WHERE char *C_Editor;                        ///< Config: External command to use as an email editor
 WHERE char *C_ExternalSearchCommand;         ///< Config: External search command
+#ifdef USE_DEVEL_HELP
 WHERE char *C_HelpDocDir;
+#endif
 WHERE char *C_Hostname;                      ///< Config: Fully-qualified domain name of this machine
 WHERE char *C_IndexFormat;                   ///< Config: printf-like format string for the index menu (emails)
 

--- a/graphviz.c
+++ b/graphviz.c
@@ -1,0 +1,752 @@
+#include "config.h"
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <time.h>
+#include "imap/imap_private.h"
+#include "maildir/maildir_private.h"
+#include "notmuch/notmuch_private.h"
+#include "pop/pop_private.h"
+#include "email/lib.h"
+#include "conn/conn.h"
+#include "account.h"
+#include "compress.h"
+#include "context.h"
+#include "globals.h"
+#include "mailbox.h"
+#include "mbox/mbox.h"
+#include "nntp/nntp.h"
+#include "notmuch/mutt_notmuch.h"
+
+// #define GV_HIDE_CONTEXT
+#define GV_HIDE_CONTEXT_CONTENTS
+// #define GV_HIDE_MBOX
+
+void dot_type_bool(FILE *fp, const char *name, bool val)
+{
+  static const char *values[] = { "false", "true" };
+  fprintf(fp, "\t\t<tr>\n");
+  fprintf(fp, "\t\t\t<td border=\"0\" align=\"left\">%s</td>\n", name);
+  fprintf(fp, "\t\t\t<td border=\"0\">=</td>\n");
+  fprintf(fp, "\t\t\t<td border=\"0\" align=\"left\">%s</td>\n", values[val]);
+  fprintf(fp, "\t\t</tr>\n");
+}
+
+void dot_type_date(char *buf, size_t buflen, time_t timestamp)
+{
+  mutt_date_localtime_format(buf, buflen, "%Y-%m-%d %H:%M:%S", timestamp);
+}
+
+void dot_type_file(FILE *fp, const char *name, FILE *struct_fp)
+{
+  fprintf(fp, "\t\t<tr>\n");
+  fprintf(fp, "\t\t\t<td border=\"0\" align=\"left\">%s</td>\n", name);
+  fprintf(fp, "\t\t\t<td border=\"0\">=</td>\n");
+  if (struct_fp)
+  {
+    fprintf(fp, "\t\t\t<td border=\"0\" align=\"left\">%p (%d)</td>\n",
+            (void *) struct_fp, fileno(struct_fp));
+  }
+  else
+  {
+    fprintf(fp, "\t\t\t<td border=\"0\" align=\"left\">NULL</td>\n");
+  }
+  fprintf(fp, "\t\t</tr>\n");
+}
+
+void dot_type_number(FILE *fp, const char *name, int num)
+{
+  fprintf(fp, "\t\t<tr>\n");
+  fprintf(fp, "\t\t\t<td border=\"0\" align=\"left\">%s</td>\n", name);
+  fprintf(fp, "\t\t\t<td border=\"0\">=</td>\n");
+  fprintf(fp, "\t\t\t<td border=\"0\" align=\"left\">%d</td>\n", num);
+  fprintf(fp, "\t\t</tr>\n");
+}
+
+void dot_type_string_escape(char *buf, size_t buflen)
+{
+  for (; buf[0]; buf++)
+  {
+    if (buf[0] == '<')
+      mutt_str_inline_replace(buf, buflen, 1, "&lt;");
+    else if (buf[0] == '>')
+      mutt_str_inline_replace(buf, buflen, 1, "&gt;");
+    else if (buf[0] == '&')
+      mutt_str_inline_replace(buf, buflen, 1, "&amp;");
+  }
+}
+
+void dot_type_string(FILE *fp, const char *name, const char *str)
+{
+  char buf[1024] = "[NULL]";
+
+  if (str)
+  {
+    mutt_str_strfcpy(buf, str, sizeof(buf));
+    dot_type_string_escape(buf, sizeof(buf));
+  }
+
+  bool quoted = ((buf[0] != '[') && (buf[0] != '*'));
+
+  fprintf(fp, "\t\t<tr>\n");
+  fprintf(fp, "\t\t\t<td border=\"0\" align=\"left\">%s</td>\n", name);
+  fprintf(fp, "\t\t\t<td border=\"0\">=</td>\n");
+  if (quoted)
+    fprintf(fp, "\t\t\t<td border=\"0\" align=\"left\">\"%s\"</td>\n", buf);
+  else
+    fprintf(fp, "\t\t\t<td border=\"0\" align=\"left\">%s</td>\n", buf);
+  fprintf(fp, "\t\t</tr>\n");
+}
+
+void dot_type_umask(char *buf, size_t buflen, int umask)
+{
+  snprintf(buf, buflen, "0%03o", umask);
+}
+
+void dot_ptr_name(char *buf, size_t buflen, void *ptr)
+{
+  snprintf(buf, buflen, "obj_%p", ptr);
+}
+
+void dot_ptr(FILE *fp, const char *name, void *ptr, const char *colour)
+{
+  fprintf(fp, "\t\t<tr>\n");
+  fprintf(fp, "\t\t\t<td border=\"0\" align=\"left\">%s</td>\n", name);
+  fprintf(fp, "\t\t\t<td border=\"0\">=</td>\n");
+  if (colour && ptr)
+  {
+    fprintf(fp, "\t\t\t<td border=\"0\" align=\"left\" bgcolor=\"%s\">%p</td>\n",
+            colour, ptr);
+  }
+  else
+  {
+    fprintf(fp, "\t\t\t<td border=\"0\" align=\"left\">%p</td>\n", ptr);
+  }
+  fprintf(fp, "\t\t</tr>\n");
+}
+
+void dot_add_link(struct ListHead *links, void *src, void *dst, const char *label, bool back)
+{
+  if (!src || !dst)
+    return;
+
+  char obj1[16] = { 0 };
+  char obj2[16] = { 0 };
+  char text[256] = { 0 };
+  char lstr[128] = { 0 };
+
+  dot_ptr_name(obj1, sizeof(obj1), src);
+  dot_ptr_name(obj2, sizeof(obj2), dst);
+
+  if (label)
+    snprintf(lstr, sizeof(lstr), "edgetooltip=\"%s\"", label);
+
+  snprintf(text, sizeof(text), "%s -> %s [ %s %s ]", obj1, obj2,
+           back ? "dir=back" : "", lstr);
+  mutt_list_insert_tail(links, mutt_str_strdup(text));
+}
+
+void dot_graph_header(FILE *fp)
+{
+  fprintf(fp, "digraph neomutt\n");
+  fprintf(fp, "{\n\n");
+
+  fprintf(fp, "\tgraph [\n");
+  fprintf(fp, "\t\trankdir=\"TB\"\n");
+  fprintf(fp, "\t\tnodesep=\"0.5\"\n");
+  fprintf(fp, "\t\tranksep=\"0.5\"\n");
+  fprintf(fp, "\t];\n");
+  fprintf(fp, "\n");
+  fprintf(fp, "\tnode [\n");
+  fprintf(fp, "\t\tshape=\"plain\"\n");
+  fprintf(fp, "\t];\n");
+  fprintf(fp, "\n");
+  fprintf(fp, "\tedge [\n");
+  fprintf(fp, "\t\tpenwidth=\"4.5\"\n");
+  fprintf(fp, "\t\tarrowsize=\"1.0\"\n");
+  fprintf(fp, "\t\tcolor=\"#c0c0c0\"\n");
+  fprintf(fp, "\t];\n");
+  fprintf(fp, "\n");
+}
+
+void dot_graph_footer(FILE *fp, struct ListHead *links)
+{
+  fprintf(fp, "\n");
+  struct ListNode *np = NULL;
+  STAILQ_FOREACH(np, links, entries)
+  {
+    fprintf(fp, "\t%s;\n", np->data);
+  }
+  fprintf(fp, "\n}\n");
+}
+
+void dot_object_header(FILE *fp, void *ptr, const char *name, const char *colour)
+{
+  char obj[16] = { 0 };
+  dot_ptr_name(obj, sizeof(obj), ptr);
+
+  if (!colour)
+    colour = "#ffff80";
+
+  fprintf(fp, "\t%s [\n", obj);
+  fprintf(fp, "\t\tlabel=<<table cellspacing=\"0\" border=\"1\" rows=\"*\" "
+              "color=\"#d0d0d0\">\n");
+  fprintf(fp, "\t\t<tr>\n");
+  fprintf(fp, "\t\t\t<td border=\"0\" align=\"left\" bgcolor=\"%s\" port=\"top\" colspan=\"3\"><font color=\"#000000\" point-size=\"20\"><b>%s</b></font> <font point-size=\"12\">(%p)</font></td>\n",
+          colour, name, ptr);
+  fprintf(fp, "\t\t</tr>\n");
+}
+
+void dot_object_footer(FILE *fp)
+{
+  fprintf(fp, "\t\t</table>>\n");
+  fprintf(fp, "\t];\n");
+  fprintf(fp, "\n");
+}
+
+void dot_node(FILE *fp, void *ptr, const char *name, const char *colour)
+{
+  char obj[16] = { 0 };
+  dot_ptr_name(obj, sizeof(obj), ptr);
+
+  fprintf(fp, "\t%s [\n", obj);
+  fprintf(fp, "\t\tlabel=<<table cellspacing=\"0\" border=\"1\" rows=\"*\" "
+              "color=\"#d0d0d0\">\n");
+  fprintf(fp, "\t\t<tr>\n");
+  fprintf(fp, "\t\t\t<td border=\"0\" bgcolor=\"%s\" port=\"top\"><font color=\"#000000\" point-size=\"20\"><b>%s</b></font></td>\n",
+          colour, name);
+  fprintf(fp, "\t\t</tr>\n");
+  dot_object_footer(fp);
+}
+
+void dot_node_link(FILE *fp, void *ptr, const char *name, void *link, const char *colour)
+{
+  char obj[16] = { 0 };
+  dot_ptr_name(obj, sizeof(obj), ptr);
+
+  fprintf(fp, "\t%s [\n", obj);
+  fprintf(fp, "\t\tlabel=<<table cellspacing=\"0\" border=\"1\" rows=\"*\" "
+              "color=\"#d0d0d0\">\n");
+  fprintf(fp, "\t\t<tr>\n");
+  fprintf(fp, "\t\t\t<td border=\"0\" bgcolor=\"%s\" port=\"top\"><font color=\"#000000\" point-size=\"20\"><b>%s</b></font></td>\n",
+          colour, name);
+  fprintf(fp, "\t\t</tr>\n");
+
+  fprintf(fp, "\t\t<tr>\n");
+  fprintf(fp, "\t\t\t<td border=\"0\" align=\"left\" bgcolor=\"%s\">%p</td>\n", colour, link);
+  fprintf(fp, "\t\t</tr>\n");
+
+  dot_object_footer(fp);
+}
+
+void dot_path_fs(char *buf, size_t buflen, const char *path)
+{
+  const char *slash = strrchr(path, '/');
+  if (slash)
+    slash++;
+  else
+    slash = path;
+
+  mutt_str_strfcpy(buf, slash, buflen);
+}
+
+void dot_path_imap(char *buf, size_t buflen, const char *path)
+{
+  char tmp[1024] = { 0 };
+  mutt_str_strfcpy(tmp, path, sizeof(tmp));
+
+  struct Url *u = url_parse(tmp);
+
+  if (u->path && (u->path[0] != '\0'))
+    mutt_str_strfcpy(buf, u->path, buflen);
+  else
+    snprintf(buf, buflen, "%s:%s", u->host, u->user);
+
+  url_free(&u);
+}
+
+void dot_comp(FILE *fp, struct CompressInfo *ci, struct ListHead *links)
+{
+  dot_object_header(fp, ci, "CompressInfo", "#c0c060");
+  dot_type_string(fp, "append", ci->cmd_append);
+  dot_type_string(fp, "close", ci->cmd_close);
+  dot_type_string(fp, "open", ci->cmd_open);
+  dot_object_footer(fp);
+}
+
+void dot_mailbox_type(FILE *fp, const char *name, enum MailboxType type)
+{
+  const char *typestr = NULL;
+
+  switch (type)
+  {
+    case MUTT_MBOX:
+      typestr = "MBOX";
+      break;
+    case MUTT_MMDF:
+      typestr = "MMDF";
+      break;
+    case MUTT_MH:
+      typestr = "MH";
+      break;
+    case MUTT_MAILDIR:
+      typestr = "MAILDIR";
+      break;
+    case MUTT_NNTP:
+      typestr = "NNTP";
+      break;
+    case MUTT_IMAP:
+      typestr = "IMAP";
+      break;
+    case MUTT_NOTMUCH:
+      typestr = "NOTMUCH";
+      break;
+    case MUTT_POP:
+      typestr = "POP";
+      break;
+    case MUTT_COMPRESSED:
+      typestr = "COMPRESSED";
+      break;
+    default:
+      typestr = "UNKNOWN";
+  }
+
+  fprintf(fp, "\t\t<tr>\n");
+  fprintf(fp, "\t\t\t<td border=\"0\" align=\"left\">%s</td>\n", name);
+  fprintf(fp, "\t\t\t<td border=\"0\">=</td>\n");
+  fprintf(fp, "\t\t\t<td border=\"0\" align=\"left\">%s</td>\n", typestr);
+  fprintf(fp, "\t\t</tr>\n");
+}
+
+void dot_mailbox_imap(FILE *fp, struct ImapMboxData *mdata, struct ListHead *links)
+{
+  dot_object_header(fp, mdata, "ImapMboxData", "#60c060");
+  dot_type_string(fp, "name", mdata->name);
+  dot_type_string(fp, "munge_name", mdata->munge_name);
+  dot_type_string(fp, "real_name", mdata->real_name);
+  dot_object_footer(fp);
+}
+
+void dot_mailbox_maildir(FILE *fp, struct MaildirMboxData *mdata, struct ListHead *links)
+{
+  char buf[64] = { 0 };
+
+  dot_object_header(fp, mdata, "MaildirMboxData", "#60c060");
+
+  dot_type_date(buf, sizeof(buf), mdata->mtime_cur.tv_sec);
+  dot_type_string(fp, "mtime_cur", buf);
+
+  dot_type_umask(buf, sizeof(buf), mdata->mh_umask);
+  dot_type_string(fp, "mh_umask", buf);
+  dot_object_footer(fp);
+}
+
+void dot_mailbox_mbox(FILE *fp, struct MboxAccountData *mdata, struct ListHead *links)
+{
+  char buf[64] = { 0 };
+
+  dot_object_header(fp, mdata, "MboxAccountData", "#60c060");
+  dot_ptr(fp, "fp", mdata->fp, NULL);
+
+  dot_type_date(buf, sizeof(buf), mdata->atime.tv_sec);
+  dot_type_string(fp, "atime", buf);
+
+  dot_object_footer(fp);
+}
+
+void dot_mailbox_nntp(FILE *fp, struct NntpMboxData *mdata, struct ListHead *links)
+{
+  dot_object_header(fp, mdata, "NntpMboxData", "#60c060");
+  dot_type_string(fp, "group", mdata->group);
+  dot_type_string(fp, "desc", mdata->desc);
+
+  dot_type_number(fp, "first_message", mdata->first_message);
+  dot_type_number(fp, "last_message", mdata->last_message);
+  dot_type_number(fp, "last_loaded", mdata->last_loaded);
+  dot_type_number(fp, "last_cached", mdata->last_cached);
+  dot_type_number(fp, "unread", mdata->unread);
+
+  dot_type_bool(fp, "subscribed", mdata->subscribed);
+  dot_type_bool(fp, "new", mdata->new);
+  dot_type_bool(fp, "allowed", mdata->allowed);
+  dot_type_bool(fp, "deleted", mdata->deleted);
+
+  dot_object_footer(fp);
+}
+
+void dot_mailbox_notmuch(FILE *fp, struct NmMboxData *mdata, struct ListHead *links)
+{
+  dot_object_header(fp, mdata, "NmMboxData", "#60c060");
+  dot_type_number(fp, "db_limit", mdata->db_limit);
+  dot_object_footer(fp);
+}
+
+void dot_mailbox_pop(FILE *fp, struct PopAccountData *mdata, struct ListHead *links)
+{
+  dot_object_header(fp, mdata, "PopAccountData", "#60c060");
+  dot_ptr(fp, "conn", mdata->conn, "#ff8080");
+  dot_object_footer(fp);
+}
+
+void dot_mailbox(FILE *fp, struct Mailbox *m, struct ListHead *links)
+{
+  char buf[64] = { 0 };
+
+  dot_object_header(fp, m, "Mailbox", "#80ff80");
+  dot_mailbox_type(fp, "type", m->magic);
+  if (m->desc)
+    dot_type_string(fp, "desc", m->desc);
+
+  if ((m->magic == MUTT_IMAP) || (m->magic == MUTT_POP))
+  {
+    dot_path_imap(buf, sizeof(buf), mutt_b2s(m->pathbuf));
+    dot_type_string(fp, "pathbuf", buf);
+    dot_path_imap(buf, sizeof(buf), m->realpath);
+    dot_type_string(fp, "realpath", buf);
+  }
+  else
+  {
+    dot_path_fs(buf, sizeof(buf), mutt_b2s(m->pathbuf));
+    dot_type_string(fp, "pathbuf", buf);
+    dot_path_fs(buf, sizeof(buf), m->realpath);
+    dot_type_string(fp, "realpath", buf);
+  }
+
+  // dot_ptr(fp, "mdata", m->mdata, "#e0e060");
+  dot_ptr(fp, "account", m->account, "#80ffff");
+
+  dot_object_footer(fp);
+
+  // dot_add_link(links, m, m->mdata, false);
+
+  if (m->mdata)
+  {
+    if (m->magic == MUTT_MAILDIR)
+      dot_mailbox_maildir(fp, m->mdata, links);
+    else if (m->magic == MUTT_IMAP)
+      dot_mailbox_imap(fp, m->mdata, links);
+    else if (m->magic == MUTT_POP)
+      dot_mailbox_pop(fp, m->mdata, links);
+    else if (m->magic == MUTT_MBOX)
+      dot_mailbox_mbox(fp, m->mdata, links);
+    else if (m->magic == MUTT_NNTP)
+      dot_mailbox_nntp(fp, m->mdata, links);
+    else if (m->magic == MUTT_NOTMUCH)
+      dot_mailbox_notmuch(fp, m->mdata, links);
+
+    dot_add_link(links, m, m->mdata, "Mailbox->mdata", false);
+  }
+
+  if (m->compress_info)
+  {
+    dot_comp(fp, m->compress_info, links);
+    dot_add_link(links, m, m->compress_info, "Mailbox->compress_info", false);
+  }
+}
+
+void dot_mailbox_node(FILE *fp, struct MailboxNode *mn, struct ListHead *links)
+{
+  dot_node(fp, mn, "MN", "#80ff80");
+
+  dot_mailbox(fp, mn->mailbox, links);
+
+  dot_add_link(links, mn, mn->mailbox, "MailboxNode->mailbox", false);
+
+  struct Buffer buf;
+  mutt_buffer_init(&buf);
+
+  char name[256] = { 0 };
+  mutt_buffer_addstr(&buf, "{ rank=same ");
+
+  dot_ptr_name(name, sizeof(name), mn);
+  mutt_buffer_add_printf(&buf, "%s ", name);
+
+  dot_ptr_name(name, sizeof(name), mn->mailbox);
+  mutt_buffer_add_printf(&buf, "%s ", name);
+
+  if (mn->mailbox->mdata)
+  {
+    dot_ptr_name(name, sizeof(name), mn->mailbox->mdata);
+    mutt_buffer_add_printf(&buf, "%s ", name);
+  }
+
+  mutt_buffer_addstr(&buf, "}");
+
+  mutt_list_insert_tail(links, buf.data);
+  buf.data = NULL;
+}
+
+void dot_mailbox_list(FILE *fp, struct MailboxList *ml, struct ListHead *links, bool abbr)
+{
+  struct MailboxNode *prev = NULL;
+  struct MailboxNode *np = NULL;
+  STAILQ_FOREACH(np, ml, entries)
+  {
+    if (abbr)
+      dot_node_link(fp, np, "MN", np->mailbox, "#80ff80");
+    else
+      dot_mailbox_node(fp, np, links);
+    if (prev)
+      dot_add_link(links, prev, np, "MailboxNode->next", false);
+    prev = np;
+  }
+}
+
+void dot_connection(FILE *fp, struct Connection *c, struct ListHead *links)
+{
+  dot_object_header(fp, c, "Connection", "#ff8080");
+  dot_type_string(fp, "user", c->account.user);
+  dot_type_string(fp, "host", c->account.host);
+  dot_type_number(fp, "port", c->account.port);
+  // dot_ptr(fp, "data", c->data, "#60c0c0");
+  dot_type_number(fp, "fd", c->fd);
+  dot_object_footer(fp);
+}
+
+void dot_account_imap(FILE *fp, struct ImapAccountData *adata, struct ListHead *links)
+{
+  dot_object_header(fp, adata, "ImapAccountData", "#60c0c0");
+  // dot_type_string(fp, "mbox_name", adata->mbox_name);
+  // dot_type_string(fp, "login", adata->conn_account.login);
+  dot_type_string(fp, "user", adata->conn_account.user);
+  dot_type_string(fp, "pass", adata->conn_account.pass[0] ? "***" : "");
+  dot_type_number(fp, "port", adata->conn_account.port);
+  // dot_ptr(fp, "conn", adata->conn, "#ff8080");
+  dot_ptr(fp, "mailbox", adata->mailbox, "#80ff80");
+  dot_object_footer(fp);
+
+  if (adata->conn)
+  {
+    dot_connection(fp, adata->conn, links);
+    dot_add_link(links, adata, adata->conn, "ImapAccountData->conn", false);
+  }
+}
+
+void dot_account_mbox(FILE *fp, struct MboxAccountData *adata, struct ListHead *links)
+{
+  char buf[64] = { 0 };
+
+  dot_object_header(fp, adata, "MboxAccountData", "#60c0c0");
+  dot_ptr(fp, "fp", adata->fp, NULL);
+
+  dot_type_date(buf, sizeof(buf), adata->atime.tv_sec);
+  dot_type_string(fp, "atime", buf);
+  dot_type_bool(fp, "locked", adata->locked);
+  dot_type_bool(fp, "append", adata->append);
+
+  dot_object_footer(fp);
+}
+
+void dot_account_nntp(FILE *fp, struct NntpAccountData *adata, struct ListHead *links)
+{
+  dot_object_header(fp, adata, "NntpAccountData", "#60c0c0");
+  dot_type_number(fp, "groups_num", adata->groups_num);
+
+  dot_type_bool(fp, "hasCAPABILITIES", adata->hasCAPABILITIES);
+  dot_type_bool(fp, "hasSTARTTLS", adata->hasSTARTTLS);
+  dot_type_bool(fp, "hasDATE", adata->hasDATE);
+  dot_type_bool(fp, "hasLIST_NEWSGROUPS", adata->hasLIST_NEWSGROUPS);
+  dot_type_bool(fp, "hasXGTITLE", adata->hasXGTITLE);
+  dot_type_bool(fp, "hasLISTGROUP", adata->hasLISTGROUP);
+  dot_type_bool(fp, "hasLISTGROUPrange", adata->hasLISTGROUPrange);
+  dot_type_bool(fp, "hasOVER", adata->hasOVER);
+  dot_type_bool(fp, "hasXOVER", adata->hasXOVER);
+  dot_type_bool(fp, "cacheable", adata->cacheable);
+  dot_type_bool(fp, "newsrc_modified", adata->newsrc_modified);
+
+  dot_type_string(fp, "authenticators", adata->authenticators);
+  dot_type_string(fp, "overview_fmt", adata->overview_fmt);
+  dot_type_string(fp, "newsrc_file", adata->newsrc_file);
+  dot_type_file(fp, "newsrc_fp", adata->fp_newsrc);
+
+  dot_type_number(fp, "groups_num", adata->groups_num);
+  dot_type_number(fp, "groups_max", adata->groups_max);
+
+  char buf[128];
+  dot_type_date(buf, sizeof(buf), adata->mtime);
+  dot_type_string(fp, "mtime", buf);
+  dot_type_date(buf, sizeof(buf), adata->newgroups_time);
+  dot_type_string(fp, "newgroups_time", buf);
+  dot_type_date(buf, sizeof(buf), adata->check_time);
+  dot_type_string(fp, "check_time", buf);
+
+  dot_object_footer(fp);
+
+  if (adata->conn)
+  {
+    dot_connection(fp, adata->conn, links);
+    dot_add_link(links, adata, adata->conn, "NntpAccountData->conn", false);
+  }
+}
+
+void dot_account_notmuch(FILE *fp, struct NmAccountData *adata, struct ListHead *links)
+{
+  dot_object_header(fp, adata, "NmAccountData", "#60c0c0");
+  dot_ptr(fp, "db", adata->db, NULL);
+  dot_object_footer(fp);
+}
+
+void dot_account_pop(FILE *fp, struct PopAccountData *adata, struct ListHead *links)
+{
+  char buf[64] = { 0 };
+
+  dot_object_header(fp, adata, "PopAccountData", "#60c0c0");
+
+  dot_type_date(buf, sizeof(buf), adata->check_time);
+  dot_type_string(fp, "check_time", buf);
+
+  dot_type_string(fp, "login", adata->conn_account.login);
+  dot_type_string(fp, "user", adata->conn_account.user);
+  dot_type_string(fp, "pass", adata->conn_account.pass[0] ? "***" : "");
+  dot_type_number(fp, "port", adata->conn_account.port);
+  // dot_ptr(fp, "conn", adata->conn, "#ff8080");
+  dot_object_footer(fp);
+
+  if (adata->conn)
+  {
+    dot_connection(fp, adata->conn, links);
+    dot_add_link(links, adata, adata->conn, "PopAccountData->conn", false);
+  }
+}
+
+void dot_account(FILE *fp, struct Account *a, struct ListHead *links)
+{
+  dot_object_header(fp, a, "Account", "#80ffff");
+  dot_mailbox_type(fp, "magic", a->magic);
+  dot_type_string(fp, "name", a->name);
+  // dot_ptr(fp, "adata", a->adata, "#60c0c0");
+  dot_object_footer(fp);
+
+  if (a->adata)
+  {
+    if (a->magic == MUTT_IMAP)
+      dot_account_imap(fp, a->adata, links);
+    else if (a->magic == MUTT_POP)
+      dot_account_pop(fp, a->adata, links);
+    else if (a->magic == MUTT_MBOX)
+      dot_account_mbox(fp, a->adata, links);
+    else if (a->magic == MUTT_NNTP)
+      dot_account_nntp(fp, a->adata, links);
+    else if (a->magic == MUTT_NOTMUCH)
+      dot_account_notmuch(fp, a->adata, links);
+
+    dot_add_link(links, a, a->adata, "Account->adata", false);
+  }
+
+  if (a->name)
+  {
+    char name[256] = { 0 };
+    struct Buffer buf;
+    mutt_buffer_init(&buf);
+
+    mutt_buffer_addstr(&buf, "{ rank=same ");
+
+    dot_ptr_name(name, sizeof(name), a);
+    mutt_buffer_add_printf(&buf, "%s ", name);
+
+    dot_ptr_name(name, sizeof(name), a->name);
+    mutt_buffer_add_printf(&buf, "%s ", name);
+
+    mutt_buffer_addstr(&buf, "}");
+    mutt_list_insert_tail(links, buf.data);
+    buf.data = NULL;
+  }
+
+  struct MailboxNode *first = STAILQ_FIRST(&a->mailboxes);
+  dot_add_link(links, a, first, "Account->mailboxes", false);
+  dot_mailbox_list(fp, &a->mailboxes, links, false);
+}
+
+void dot_allaccounts(FILE *fp, struct AccountList *al, struct ListHead *links)
+{
+  struct Account *prev = NULL;
+  struct Account *np = NULL;
+  TAILQ_FOREACH(np, al, entries)
+  {
+#ifdef GV_HIDE_MBOX
+    if (np->magic == MUTT_MBOX)
+      continue;
+#endif
+    dot_account(fp, np, links);
+    if (prev)
+      dot_add_link(links, prev, np, "Account->next", false);
+
+    prev = np;
+  }
+}
+
+void dot_context(FILE *fp, struct Context *ctx, struct ListHead *links)
+{
+  dot_object_header(fp, ctx, "Context", "#ff80ff");
+  dot_ptr(fp, "mailbox", ctx->mailbox, "#80ff80");
+#ifdef GV_HIDE_CONTEXT_CONTENTS
+  dot_type_number(fp, "vsize", ctx->vsize);
+  dot_type_string(fp, "pattern", ctx->pattern);
+  dot_type_bool(fp, "collapsed", ctx->collapsed);
+#endif
+  dot_object_footer(fp);
+}
+
+void dump_graphviz(const char *title)
+{
+  char name[256] = { 0 };
+  struct ListHead links = STAILQ_HEAD_INITIALIZER(links);
+
+  time_t now = time(NULL);
+  if (title)
+  {
+    char date[128];
+    mutt_date_localtime_format(date, sizeof(date), "%R", now);
+    snprintf(name, sizeof(name), "%s-%s.gv", date, title);
+  }
+  else
+  {
+    mutt_date_localtime_format(name, sizeof(name), "%R.gv", now);
+  }
+
+  umask(022);
+  FILE *fp = fopen(name, "w");
+  if (!fp)
+    return;
+
+  dot_graph_header(fp);
+
+  dot_node(fp, &AllAccounts, "AllAccounts", "#80ffff");
+  dot_add_link(&links, &AllAccounts, TAILQ_FIRST(&AllAccounts), "AllAccounts->first", false);
+  dot_allaccounts(fp, &AllAccounts, &links);
+
+#ifndef GV_HIDE_CONTEXT
+  if (Context)
+    dot_context(fp, Context, &links);
+
+  /* Globals */
+  fprintf(fp, "\t{ rank=same ");
+  if (Context)
+  {
+    dot_ptr_name(name, sizeof(name), Context);
+    fprintf(fp, "%s ", name);
+  }
+  dot_ptr_name(name, sizeof(name), &AllAccounts);
+  fprintf(fp, "%s ", name);
+  // dot_ptr_name(name, sizeof(name), connections);
+  // fprintf(fp, "%s ", name);
+  fprintf(fp, "}\n");
+#endif
+
+  fprintf(fp, "\t{ rank=same ");
+  struct Account *np = NULL;
+  TAILQ_FOREACH(np, &AllAccounts, entries)
+  {
+#ifdef GV_HIDE_MBOX
+    if (np->magic == MUTT_MBOX)
+      continue;
+#endif
+    dot_ptr_name(name, sizeof(name), np);
+    fprintf(fp, "%s ", name);
+  }
+  fprintf(fp, "}\n");
+
+  dot_graph_footer(fp, &links);
+  fclose(fp);
+  mutt_list_free(&links);
+}

--- a/help/help.c
+++ b/help/help.c
@@ -1,0 +1,193 @@
+/**
+ * @file
+ * Help system
+ *
+ * @authors
+ * Copyright (C) 2018 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+#include <stddef.h>
+#include <stdbool.h>
+#include "mutt/mutt.h"
+#include "config/lib.h"
+#include "account.h"
+#include "mailbox.h"
+#include "mx.h"
+
+struct Context;
+struct Header;
+struct Message;
+
+int help_mbox_open(struct Mailbox *m)
+{
+  mutt_debug(1, "entering help_mbox_open\n");
+  return -1;
+}
+
+/**
+ * help_ac_find - Find a Account that matches a Mailbox path
+ */
+struct Account *help_ac_find(struct Account *a, const char *path)
+{
+  if (!a || !path)
+    return NULL;
+
+  return a;
+}
+
+/**
+ * help_ac_add - Add a Mailbox to a Account
+ */
+int help_ac_add(struct Account *a, struct Mailbox *m)
+{
+  if (!a || !m)
+    return -1;
+
+  if (m->magic != MUTT_HELP)
+    return -1;
+
+  m->account = a;
+
+  struct MailboxNode *np = mutt_mem_calloc(1, sizeof(*np));
+  np->mailbox = m;
+  STAILQ_INSERT_TAIL(&a->mailboxes, np, entries);
+  return 0;
+}
+
+int help_mbox_open_append(struct Mailbox *m, OpenMailboxFlags flags)
+{
+  mutt_debug(1, "entering help_mbox_open_append\n");
+  return -1;
+}
+
+int help_mbox_check(struct Mailbox *m, int *index_hint)
+{
+  mutt_debug(1, "entering help_mbox_check\n");
+  return -1;
+}
+
+int help_mbox_sync(struct Mailbox *m, int *index_hint)
+{
+  mutt_debug(1, "entering help_mbox_sync\n");
+  return -1;
+}
+
+int help_mbox_close(struct Mailbox *m)
+{
+  mutt_debug(1, "entering help_mbox_close\n");
+  return -1;
+}
+
+int help_msg_open(struct Mailbox *m, struct Message *msg, int msgno)
+{
+  mutt_debug(1, "entering help_msg_open\n");
+  return -1;
+}
+
+int help_msg_open_new(struct Mailbox *m, struct Message *msg, struct Email *e)
+{
+  mutt_debug(1, "entering help_msg_open_new\n");
+  return -1;
+}
+
+int help_msg_commit(struct Mailbox *m, struct Message *msg)
+{
+  mutt_debug(1, "entering help_msg_commit\n");
+  return -1;
+}
+
+int help_msg_close(struct Mailbox *m, struct Message *msg)
+{
+  mutt_debug(1, "entering help_msg_close\n");
+  return -1;
+}
+
+int help_msg_padding_size(struct Mailbox *m)
+{
+  mutt_debug(1, "entering help_msg_padding_size\n");
+  return -1;
+}
+
+int help_tags_edit(struct Mailbox *m, const char *tags, char *buf, size_t buflen)
+{
+  mutt_debug(1, "entering help_tags_edit\n");
+  return -1;
+}
+
+int help_tags_commit(struct Mailbox *m, struct Email *e, char *buf)
+{
+  mutt_debug(1, "entering help_tags_commit\n");
+  return -1;
+}
+
+int help_path_probe(const char *path, const struct stat *st)
+{
+  if (!path)
+    return MUTT_UNKNOWN;
+
+  if (mutt_str_strncasecmp(path, "help://", 7) == 0)
+    return MUTT_HELP;
+
+  return MUTT_UNKNOWN;
+}
+
+int help_path_canon(char *buf, size_t buflen)
+{
+  mutt_debug(1, "entering help_path_canon\n");
+  return 0;
+}
+
+int help_path_pretty(char *buf, size_t buflen, const char *folder)
+{
+  mutt_debug(1, "entering help_path_pretty\n");
+  return -1;
+}
+
+int help_path_parent(char *buf, size_t buflen)
+{
+  mutt_debug(1, "entering help_path_parent\n");
+  return -1;
+}
+
+// clang-format off
+/**
+ * mx_help_ops - Help Mailbox callback functions
+ */
+struct MxOps mx_help_ops = {
+  .magic            = MUTT_HELP,
+  .name             = "help",
+  .ac_find          = help_ac_find,
+  .ac_add           = help_ac_add,
+  .mbox_open        = help_mbox_open,
+  .mbox_open_append = help_mbox_open_append,
+  .mbox_check       = help_mbox_check,
+  .mbox_sync        = help_mbox_sync,
+  .mbox_close       = help_mbox_close,
+  .msg_open         = help_msg_open,
+  .msg_open_new     = help_msg_open_new,
+  .msg_commit       = help_msg_commit,
+  .msg_close        = help_msg_close,
+  .msg_padding_size = help_msg_padding_size,
+  .tags_edit        = help_tags_edit,
+  .tags_commit      = help_tags_commit,
+  .path_probe       = help_path_probe,
+  .path_canon       = help_path_canon,
+  .path_pretty      = help_path_pretty,
+  .path_parent      = help_path_parent,
+};
+// clang-format on

--- a/help/help.c
+++ b/help/help.c
@@ -22,21 +22,997 @@
 
 #include "config.h"
 #include <stddef.h>
+#include <dirent.h>
+#include <errno.h>
+#include <limits.h>
+#include <stdarg.h>
 #include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <time.h>
+#include <unistd.h>
 #include "mutt/mutt.h"
 #include "config/lib.h"
+#include "email/lib.h"
+#include "help.h"
 #include "account.h"
+#include "address/lib.h"
+#include "context.h"
+#include "globals.h"
 #include "mailbox.h"
+#include "mutt_header.h"
+#include "mutt_options.h"
+#include "mutt_thread.h"
+#include "muttlib.h"
 #include "mx.h"
+#include "protos.h"
 
-struct Context;
-struct Header;
-struct Message;
+#define HELP_CACHE_DOCLIST                                                     \
+  1 /* whether to cache the DocList between help_mbox_open calls */
+#define HELP_FHDR_MAXLINES                                                     \
+  -1 /* max help file header lines to read (N < 0 means all) */
+#define HELP_LINK_CHAPTERS                                                     \
+  0 /* whether to link all help chapter upwards to root box */
 
-int help_mbox_open(struct Mailbox *m)
+static bool __Backup_HTS; /* used to restore $hide_thread_subject on help_mbox_close() */
+static char DocDirID[33]; /* MD5 checksum of current $help_doc_dir DT_PATH option */
+static HelpList *DocList; /* all valid help documents within $help_doc_dir folder */
+static size_t UpLink = 0; /* DocList index, used to uplink a parent thread target */
+
+/**
+ * help_list_XXX - Several (helper) functions for a generic list object (HelpList)
+ */
+static void help_list_free(HelpList **list, void (*item_free)(void **))
 {
-  mutt_debug(1, "entering help_mbox_open\n");
-  return -1;
+  if (!list || !*list)
+    return;
+
+  for (size_t i = 0; i < (*list)->size; i++)
+  {
+    item_free(&((*list)->data[i]));
+  }
+  FREE(&(*list)->data);
+  FREE(list);
+}
+
+static void help_list_shrink(HelpList *list)
+{
+  if (!list)
+    return;
+
+  mutt_mem_realloc(list->data, list->size * list->item_size);
+  list->capa = list->size;
+}
+
+static HelpList *help_list_new(size_t item_size)
+{
+  HelpList *list = NULL;
+  if ((item_size == 0) || ((list = mutt_mem_malloc(sizeof(HelpList))) == NULL))
+    return NULL;
+
+  list->item_size = item_size;
+  list->size = 0;
+  list->capa = HELPLIST_INIT_CAPACITY;
+  list->data = mutt_mem_calloc(list->capa, sizeof(void *) * list->item_size);
+  if (!list->data)
+  {
+    FREE(list);
+    list = NULL;
+  }
+
+  return list;
+}
+
+static void help_list_append(HelpList *list, void *item)
+{
+  if (!list || !item)
+    return;
+
+  if (list->size >= list->capa)
+  {
+    list->capa = (list->capa == 0) ? HELPLIST_INIT_CAPACITY : (list->capa * 2);
+    mutt_mem_realloc(list->data, list->capa * list->item_size);
+  }
+
+  list->data[list->size] = mutt_mem_calloc(1, list->item_size);
+  list->data[list->size] = item;
+  list->size++;
+}
+
+static void help_list_new_append(HelpList **list, size_t item_size, void *item)
+{
+  if ((item_size == 0) || !item)
+    return;
+
+  if (!list || !*list)
+    *list = help_list_new(item_size);
+
+  help_list_append(*list, item);
+}
+
+static void *help_list_get(HelpList *list, size_t index, void *(*copy)(const void *) )
+{
+  if (!list || (index >= list->size))
+    return NULL;
+
+  return ((copy) ? copy(list->data[index]) : list->data[index]);
+}
+
+static HelpList *help_list_clone(HelpList *list, bool shrink, void *(*copy)(const void *) )
+{
+  if (!list)
+    return NULL;
+
+  HelpList *clone = help_list_new(list->item_size);
+  for (size_t i = 0; i < list->size; i++)
+    help_list_append(clone, help_list_get(list, i, copy));
+
+  if (shrink)
+    help_list_shrink(clone);
+
+  return clone;
+}
+
+static void help_list_sort(HelpList *list, int (*compare)(const void *, const void *))
+{
+  if (!list)
+    return;
+
+  qsort(list->data, list->size, sizeof(void *), compare);
+}
+
+/**
+ * help_doc_type_cmp - Callback to compare help document types in a generic list
+ *                     used to sort an 'index.md' element to the top of the list
+ * @param   a       ... generic list element pointer to a Header object
+ * @param   b       ... generic list element pointer to a Header object
+ * @retval  -1      ... related to the type, object a is less than object b
+ * @retval   0      ... related to the type, object a is equal object b
+ * @retval   1      ... related to the type, object a is greater than object b
+ */
+static int help_doc_type_cmp(const void *a, const void *b)
+{
+  const struct Email *e1 = *(const struct Email **) a;
+  const struct Email *e2 = *(const struct Email **) b;
+  const HDType t1 = ((const HDMeta *) e1->edata)->type;
+  const HDType t2 = ((const HDMeta *) e2->edata)->type;
+
+  return ((t1 < t2) - (t1 > t2));
+}
+
+/**
+ * help_file_hdr_free - Callback to release used memory of a file header
+ * @param   item    ... generic list element pointer to a file header
+ */
+static void help_file_hdr_free(void **item)
+{
+  HFHeader *fhdr = ((HFHeader *) *item);
+
+  FREE(&fhdr->key);
+  FREE(&fhdr->val);
+  FREE(&fhdr);
+}
+
+/**
+ * help_doc_meta_free - Callback to release used memory of help doc metadata
+ * @param   hdr     ... Header struct that holds the metadata
+ *
+ * @note: Called by mutt_header_free() to free custom metadata in Context::data.
+ */
+static void help_doc_meta_free(void **data)
+{
+  if (!data || !*data)
+    return;
+
+  HDMeta *meta = *data;
+
+  FREE(&meta->name);
+  help_list_free(&meta->fhdr, help_file_hdr_free);
+  *data = NULL;
+}
+
+/**
+ * help_doc_free - Callback to release used memory of a DocList element
+ * @param   item    ... generic list element pointer to a DocList element
+ */
+static void help_doc_free(void **item)
+{
+  struct Email *hdoc = ((struct Email *) *item);
+
+  mutt_email_free(&hdoc);
+  FREE(hdoc);
+}
+
+/**
+ * help_doclist_free - Callback to release used memory of the DocList
+ */
+void help_doclist_free(void)
+{
+  help_list_free(&DocList, help_doc_free);
+  mutt_str_strfcpy(DocDirID, "", sizeof(DocDirID));
+  UpLink = 0;
+}
+
+/**
+ * help_checksum_md5 - Calculate a string MD5 checksum and store it in a buffer
+ * @param   string  ... to hash
+ * @param   digest  ... buffer for storing the calculated hash
+ *
+ * @note: The digest buffer _must_ be at least 33 bytes long (requirement by
+ *        mutt_md5_toascii() function).
+ */
+static void help_checksum_md5(const char *string, char *digest)
+{
+  unsigned char md5[16];
+
+  mutt_md5(NONULL(string), md5);
+  mutt_md5_toascii(md5, digest);
+}
+
+/**
+ * help_docdir_id - Get (and probably previously set) current DocDirID
+ * @param   docdir  ... (optional) path to set the DocDirID from
+ * @retval  pointer ... to current DocDirID MD5 checksum string
+ */
+static char *help_docdir_id(const char *docdir)
+{
+  if (docdir && DocList) /* only set ID if DocList != NULL */
+    help_checksum_md5(docdir, DocDirID);
+
+  return DocDirID;
+}
+
+/**
+ * help_docdir_changed - Determine if $help_doc_dir differs from previous run
+ * @retval  true    ... $help_doc_dir path differs (DocList rebuilt recommended)
+ * @retval  false   ... same $help_doc_dir path where DocList was built from
+ */
+static bool help_docdir_changed(void)
+{
+  char digest[33];
+  help_checksum_md5(C_HelpDocDir, digest);
+
+  return (mutt_str_strcmp(DocDirID, digest) != 0);
+}
+
+/**
+ * help_dirent_type - Get the type of a given dirent entry or its file path
+ * @param   item    ... dirent struct that probably holds the wanted entry type
+ * @param   path    ... alternatively used with stat() to determine its type
+ * @param   as_flag ... return type as d_type value or its representing flag
+ * @retval  type    ... obtained type or DT_UNKNOWN (0) otherwise
+ *
+ * @note: On systems that define macro _DIRENT_HAVE_D_TYPE and supports a d_type
+ *        field, this function may be less costly than an extra call of stat().
+ */
+static DEType help_dirent_type(const struct dirent *item, const char *path, bool as_flag)
+{
+  unsigned char type = 0;
+
+#ifdef _DIRENT_HAVE_D_TYPE
+  type = item->d_type;
+#else
+  struct stat sb;
+
+  if (stat(path, &sb) == 0)
+    type = ((sb.st_mode & 0170000) >> 12);
+#endif
+
+  return (as_flag ? DT2DET(type) : type);
+}
+
+/**
+ * help_file_type - Determine the type of a help file (relative to #C_HelpDocDir)
+ * @param   file    ... as full qualified file path of the document to test
+ * @retval  type    ... of the file/document (as enum helpdoc_type)
+ *
+ * @note: The type of a file is determined only from its path string, so it does
+ *        not need to exist. That means also, a file can have a proper type, but
+ *        the document itself may be invalid (and discarded later by a filter).
+ */
+static HDType help_file_type(const char *file)
+{
+  HDType type = HDT_NONE;
+  const size_t l = mutt_str_strlen(file);
+  const size_t m = mutt_str_strlen(C_HelpDocDir);
+
+  if ((l < 5) || (m == 0) || (l <= m))
+    return type; /* relative subpath requirements doesn't match the minimum */
+
+  const char *p = (file + m);
+  const char *q = (file + l - 3);
+
+  if ((mutt_str_strncasecmp(q, ".md", 3) != 0) ||
+      (mutt_str_strncmp(file, C_HelpDocDir, m) != 0))
+    return type; /* path below C_HelpDocDir and ".md" extension are mandatory */
+
+  if (mutt_str_strcasecmp(q = strrchr(p, '/'), "/index.md") == 0)
+    type = HDT_INDEX; /* help document is a special named ("index.md") file */
+  else
+    type = 0;
+
+  if (p == q)
+    type |= HDT_ROOTDOC; /* help document lives directly in C_HelpDocDir root */
+  else if ((p = strchr(p + 1, '/')) == q)
+    type |= HDT_CHAPTER;
+  else /* handle all remaining (deeper nested) help documents as a section */
+    type |= HDT_SECTION;
+
+  return type;
+}
+
+/**
+ * help_file_header - Process and extract a YAML header of a potential help file
+ * @param   fhdr    ... list where to store the final header information
+ * @param   file    ... path to the (potential help document) file to parse
+ * @param   max     ... how many header lines to read (N < 0 means all)
+ * @retval   N >= 0 ... success, N valid header lines read from file
+ * @retval  -1      ... file isn't a helpdoc: extension doesn't match ".md"
+ * @retval  -2      ... file header not read: file cannot be open for read
+ * @retval  -3      ... found invalid header: no triple-dashed start mark
+ * @retval  -4      ... found invalid header: no triple-dashed end mark
+ */
+static int help_file_header(HelpList **fhdr, const char *file, int max)
+{
+  const char *bfn = mutt_path_basename(NONULL(file));
+  const char *ext = strrchr(bfn, '.');
+  if (!bfn || ext == bfn || mutt_str_strncasecmp(ext, ".md", 3) != 0)
+    return -1;
+
+  FILE *fp = mutt_file_fopen(file, "r");
+  if (!fp)
+    return -2;
+
+  int lineno = 0;
+  size_t linelen;
+  const char *mark = "---";
+
+  char *p = mutt_file_read_line(NULL, &linelen, fp, &lineno, 0);
+  if (mutt_str_strcmp(p, mark) != 0)
+  {
+    mutt_file_fclose(&fp);
+    return -3;
+  }
+
+  HelpList *list = NULL;
+  char *q = NULL;
+  bool endmark = false;
+  int count = 0, limit = ((max < 0) ? -1 : max);
+
+  while ((mutt_file_read_line(p, &linelen, fp, &lineno, 0) != NULL) &&
+         !(endmark = (mutt_str_strcmp(p, mark) == 0)) && ((q = strpbrk(p, ": \t")) != NULL))
+  {
+    if (limit == 0)
+      continue; /* to find the end mark that qualify the header as valid */
+    else if ((p == q) || (*q != ':'))
+      continue; /* to skip wrong keyworded lines, XXX: or should we abort? */
+
+    mutt_str_remove_trailing_ws(p);
+    HFHeader *item = mutt_mem_calloc(1, sizeof(HFHeader));
+    item->key = mutt_str_substr_dup(p, q);
+    item->val = mutt_str_strdup(mutt_str_skip_whitespace(NONULL(++q)));
+    help_list_new_append(&list, sizeof(HFHeader), item);
+
+    count++;
+    limit--;
+  }
+  mutt_file_fclose(&fp);
+  FREE(&p);
+
+  if (!endmark)
+  {
+    help_list_free(&list, help_file_hdr_free);
+    count = -4;
+  }
+  else
+  {
+    help_list_shrink(list);
+    *fhdr = list;
+  }
+
+  return count;
+}
+
+/**
+ * help_file_hdr_find - Find a help document header line by its key(word)
+ * @param   key     ... string to search for in fhdr list (case-sensitive)
+ * @param   fhdr    ... list of HFHeader elements to search for key
+ * @retval  header  ... on success, struct containing the found key
+ * @retval  NULL    ... on failure, or when key could not be found
+ */
+static HFHeader *help_file_hdr_find(const char *key, const HelpList *fhdr)
+{
+  if (!fhdr || !key || !*key)
+    return NULL;
+
+  HFHeader *hdr = NULL;
+  for (size_t i = 0; i < fhdr->size; i++)
+  {
+    if (mutt_str_strcmp(((HFHeader *) fhdr->data[i])->key, key) != 0)
+      continue;
+
+    hdr = fhdr->data[i];
+    break;
+  }
+
+  return hdr;
+}
+
+/**
+ * help_doc_msg_id - Return a simple message ID
+ * @param   tm      ... struct (time.h(0p)) used for date part in the message ID
+ * @retval  string  ... with generated message ID
+ */
+static char *help_doc_msg_id(const struct tm *tm)
+{
+  char buf[128];
+  unsigned char rndid[MUTT_RANDTAG_LEN + 1];
+  mutt_rand_base32(rndid, sizeof(rndid) - 1);
+  rndid[MUTT_RANDTAG_LEN] = 0;
+
+  snprintf(buf, sizeof(buf), "<%d%02d%02d%02d%02d%02d.%s>", tm->tm_year + 1900,
+           tm->tm_mon + 1, tm->tm_mday, tm->tm_hour, tm->tm_min, tm->tm_sec, rndid);
+
+  return mutt_str_strdup(buf);
+}
+
+/**
+ * help_doc_subject - Build a message subject, based on a string format and
+ *                    from the keyword value(s) of help file header line(s)
+ * @param   fhdr    ... list of HFHeader elements to search for key
+ * @param   defsubj ... this given default subject will be used on failures
+ * @param   strfmt  ... the string format to use for the subject line (only
+ *                      string conversion placeholder ("%s") are supported)
+ * @param   key     ... a header line keyword whose value will be used at the
+ *                      related strfmt placeholder position
+ * @param   ...     ... additional keywords to find (not limited in count)
+ * @retval  string  ... on success, holds the built subject or defsubj otherwise
+ *
+ * @note: Whether length, flag nor precision specifier currently supported, only
+ *        poor "%s" placeholder will be recognised.
+ * XXX: - Should the length of the subject line be limited by an additional
+ *        parameter? Currently an internal limit of STRING (256) is used.
+ *      - This function use variable argument list (va_list), that may provide
+ *        more than the real specified arguments and there seems to be no way to
+ *        stop processing after the last real parameter. Therefore, the last
+ *        parameter MUST be NULL currently or weird things happens when count of
+ *        placeholder in strfmt and specified keys differs.
+ */
+static char *help_doc_subject(HelpList *fhdr, const char *defaultsubject,
+                              const char *strfmt, const char *key, ...)
+{
+  va_list ap;
+  char subject[256]; /* XXX: Should trailing white space (from strfmt) be removed? */
+
+  HFHeader *hdr = NULL;
+  const char *f = NULL;
+  const char *p = strfmt;
+  const char *q = NULL;
+  size_t l = 0;
+  int size = 0;
+
+  va_start(ap, key);
+  while ((q = strstr(p, "%s")) && key)
+  {
+    if ((hdr = help_file_hdr_find(key, fhdr)) == NULL)
+    {
+      mutt_str_strfcpy(subject, defaultsubject, sizeof(subject));
+      break;
+    }
+
+    f = mutt_str_substr_dup(p, strstr(q + 2, "%s"));
+    size = snprintf(subject + l, sizeof(subject) - l, f, hdr->val);
+
+    if (size < 0)
+    {
+      mutt_str_strfcpy(subject, defaultsubject, sizeof(subject));
+      break;
+    }
+
+    p += mutt_str_strlen(f);
+    l += size;
+    key = va_arg(ap, const char *);
+  }
+  va_end(ap);
+
+  return mutt_str_strdup(subject);
+}
+
+/**
+ * help_path_transpose - Convert (vice versa) a scheme prefixed into a file path
+ * @param   path    ... to transpose (starts with "help[://]" or $help_doc_dir)
+ * @param   validate... specifies the strictness, if true, file path must exist
+ * @retval  string  ... on success, contains the transposed contrary path
+ * @retval  NULL    ... on failure, path may not exist or was invalid
+ *
+ * @note: The resulting path is sanitised, which means any trailing slash(es) of
+ *        the input path are stripped.
+ */
+static char *help_path_transpose(const char *path, bool validate)
+{
+  if (!path || !*path)
+    return NULL;
+
+  char fqp[PATH_MAX];
+  char url[PATH_MAX];
+
+  const char *docdir = C_HelpDocDir;
+  const char *scheme = "help"; /* TODO: don't hardcode, use sth. like: UrlMap[U_HELP]->name */
+  const char *result = NULL;
+  size_t i = 0;
+  size_t j = 0;
+
+  if (mutt_str_strncasecmp(path, scheme, (j = mutt_str_strlen(scheme))) == 0)
+  { /* unlike url_check_scheme(), allow scheme alone (without a separator) */
+    if ((path[j] != ':') && (path[j] != '\0'))
+      return NULL;
+    else if (path[j] == ':')
+      j += 1;
+
+    result = fqp;
+    i = mutt_str_strlen(docdir);
+  }
+  else if (mutt_str_strncmp(path, docdir, (j = mutt_str_strlen(docdir))) == 0)
+  {
+    if ((path[j] != '/') && (path[j] != '\0'))
+      return NULL;
+
+    result = url;
+    i = mutt_str_strlen(scheme) + 3;
+  }
+  else
+  {
+    return NULL;
+  }
+
+  j += strspn(path + j, "/");
+  snprintf(fqp, sizeof(fqp), "%s/%s", docdir, path + j);
+  snprintf(url, sizeof(url), "%s://%s", scheme, path + j);
+  j = mutt_str_strlen(result);
+
+  while ((i < j) && (result[j - 1] == '/'))
+    j--;
+
+  return (validate && !realpath(fqp, NULL)) ? NULL : strndup(result, j);
+}
+
+/**
+ * help_dirent_filter - Prefilter callback function for help_dir_scan()
+ * @param   de      ... dirent strut, that can be filtered
+ * @param   path    ... dirent related file path, that can be filtered
+ * @param   type    ... help file type, that can be filtered
+ *
+ * @retval  N > 0   ... implies a success, force help_dir_scan() to continue (without recursion)
+ * @retval      0   ... implies a success, causes help_dir_scan() to call its item handler
+ * @retval  N < 0   ... implies a failure, will cause help_dir_scan() to abort
+ *
+ * @note: This function is currently not used.
+ *
+static int help_dirent_filter(const struct dirent *de, const char *path,
+                              const DEType type)
+{
+  if (type != DET_REG)
+    return 0;
+
+  return (help_file_type(path) == HDT_NONE);
+}
+*/
+
+/**
+ * help_dir_scan - Traverse a directory for specific entry types, filter/gather
+ *                 the found result(s)
+ * @param   path    ... directory in which to start the investigation
+ * @param   recursive ... Whether or not to iterate the given path recursively
+ * @param   mask    ... a bit mask that defines which entry type(s) to filter
+ * @param   filter  ... (optional) preselection filter callback function
+ * @param   gather  ... handler callback function for a single result that prior
+ *                      passed the bit mask and preselection filter
+ * @param   items   ... list that can be used to interchange all results between
+ *                      caller and handler function
+ * @retval   0      ... on success, execution ended normally
+ * @retval  -1      ... on failure, when path cannot be opened for reading
+ *
+ * @note: Function only aborts an iteration when the end of directory stream has
+ *        been reached or the callback filter function returns with N < 0, but
+ *        not on failures, to grab as much as possible entries from the stream.
+ *        An entry named "", "." or "..", will always be skipped (and thus never
+ *        delegated to callback functions), but will be solved/expanded for the
+ *        initial path parameter.
+ */
+static int help_dir_scan(const char *path, bool recursive, const DETMask mask,
+                         int (*filter)(const struct dirent *, const char *, DEType),
+                         int (*gather)(HelpList **, const char *), HelpList **items)
+{
+  char curpath[PATH_MAX];
+
+  errno = 0;
+  DIR *dp = opendir(NONULL(realpath(path, curpath)));
+
+  if (!dp)
+  {
+    //mutt_debug(1, "unable to open dir '%s': %s (errno %d).\n", path, strerror(errno), errno);
+    /* XXX: Fake a localised error message by extending an existing one */
+    mutt_error("%s '%s': %s (errno %d).", _("Error opening mailbox"), path,
+               strerror(errno), errno);
+    return -1;
+  }
+
+  while (1)
+  {
+    errno = 0; /* reset errno to distinguish between end-of-(dir)stream and an error */
+    const struct dirent *ep = readdir(dp);
+
+    if (!ep)
+    {
+      if (!errno)
+        break; /* we reached the end-of-stream */
+
+      mutt_debug(1, "unable to read dir: %s (errno %d).\n", strerror(errno), errno);
+      continue; /* this isn't the end-of-stream */
+    }
+
+    const char *np = ep->d_name;
+    if (!np[0] || ((np[0] == '.') && (!np[1] || ((np[1] == '.') && !np[2]))))
+    {
+      continue; /* to skip "", ".", ".." entries */
+    }
+
+    char abspath[mutt_str_strlen(curpath) + mutt_str_strlen(np) + 2];
+    mutt_path_concat(abspath, curpath, np, sizeof(abspath));
+
+    const DEType flag = help_dirent_type(ep, abspath, true);
+    if (mask & flag)
+    { /* delegate preselection processing */
+      int rc = filter ? filter(ep, abspath, flag) : 0;
+      if (rc < 0)
+        break; /* handler wants to abort */
+      else if (0 < rc)
+        continue; /* but skip a recursion */
+      else
+        gather(items, abspath);
+    }
+
+    if ((flag == DET_DIR) && recursive)
+    { /* descend this directory recursive */
+      help_dir_scan(abspath, recursive, mask, filter, gather, items);
+    }
+  }
+  closedir(dp);
+
+  return 0;
+}
+
+/**
+ * help_file_hdr_clone - Callback to clone a file header object (HFHeader)
+ * @param   item    ... list element pointer to the object to copy
+ * @retval  pointer ... on success, to the duplicated object
+ * @retval  NULL    ... on failure, otherwise
+ */
+static void *help_file_hdr_clone(const void *item)
+{
+  if (!item)
+    return NULL;
+
+  HFHeader *src = (HFHeader *) item;
+  HFHeader *dup = mutt_mem_calloc(1, sizeof(HFHeader));
+
+  dup->key = mutt_str_strdup(src->key);
+  dup->val = mutt_str_strdup(src->val);
+
+  return dup;
+}
+
+/**
+ * help_doc_meta_clone - Callback to clone a help metadata object (HDMeta)
+ * @param   item    ... list element pointer to the object to copy
+ * @retval  pointer ... on success, to the duplicated object
+ * @retval  NULL    ... on failure, otherwise
+ */
+static void *help_doc_meta_clone(const void *item)
+{
+  if (!item)
+    return NULL;
+
+  HDMeta *src = (HDMeta *) item;
+  HDMeta *dup = mutt_mem_calloc(1, sizeof(HDMeta));
+
+  dup->fhdr = help_list_clone(src->fhdr, true, help_file_hdr_clone);
+  dup->name = mutt_str_strdup(src->name);
+  dup->type = src->type;
+
+  return dup;
+}
+
+/**
+ * help_doc_clone - Callback to clone a help document object (Header)
+ * @param   item    ... list element pointer to the object to copy
+ * @retval  pointer ... on success, to the duplicated object
+ * @retval  NULL    ... on failure, otherwise
+ *
+ * @note: This function should only duplicate statically defined attributes from
+ *        a Header object that help_doc_from() build and return.
+ */
+static void *help_doc_clone(const void *item)
+{
+  if (!item)
+    return NULL;
+
+  struct Email *src = (struct Email *) item;
+  struct Email *dup = mutt_email_new();
+  /* struct Email */
+  dup->date_sent = src->date_sent;
+  dup->display_subject = src->display_subject;
+  dup->index = src->index;
+  dup->path = mutt_str_strdup(src->path);
+  dup->read = src->read;
+  dup->received = src->received;
+  /* struct Email::data (custom metadata) */
+  dup->edata = help_doc_meta_clone(src->edata);
+  dup->free_edata = help_doc_meta_free;
+  /* struct Body */
+  dup->content = mutt_body_new();
+  dup->content->disposition = src->content->disposition;
+  dup->content->encoding = src->content->encoding;
+  dup->content->length = src->content->length;
+  dup->content->subtype = mutt_str_strdup(src->content->subtype);
+  dup->content->type = src->content->type;
+  /* struct Envelope */
+  dup->env = mutt_env_new();
+  mutt_addrlist_copy(&dup->env->from, &src->env->from, false);
+  dup->env->message_id = mutt_str_strdup(src->env->message_id);
+  dup->env->organization = mutt_str_strdup(src->env->organization);
+  dup->env->subject = mutt_str_strdup(src->env->subject);
+  /* struct Envelope::references */
+  struct ListNode *src_np = NULL, *dup_np = NULL;
+  STAILQ_FOREACH(src_np, &src->env->references, entries)
+  {
+    dup_np = mutt_mem_calloc(1, sizeof(struct ListNode));
+    dup_np->data = mutt_str_strdup(src_np->data);
+    STAILQ_INSERT_TAIL(&dup->env->references, dup_np, entries);
+  }
+
+  return dup;
+}
+
+/**
+ * help_doc_from - Provides a validated/newly created help document (Header) from
+ *                 a full qualified file path
+ * @param   file    ... that is related to be a help document
+ * @retval  pointer ... on success, to a Header structure
+ * @retval  NULL    ... on failure, otherwise
+ *
+ * @note: This function only statically set specific member of a Header structure
+ *        and some attributes, like Header::index, should be reset/updated.
+ *        It also use Header::data to store additional help document information.
+ */
+static struct Email *help_doc_from(const char *file)
+{
+  HDType type = HDT_NONE;
+
+  if ((type = help_file_type(file)) == HDT_NONE)
+    return NULL; /* file is not a valid help doc */
+
+  HelpList *fhdr = NULL;
+  int len = help_file_header(&fhdr, file, HELP_FHDR_MAXLINES);
+  if (!fhdr || (len < 1))
+    return NULL; /* invalid or empty file header */
+
+  /* from here, it should be safe to treat file as a valid help document */
+  const char *bfn = mutt_path_basename(file);
+  const char *pdn = mutt_path_basename(mutt_path_dirname(file));
+  const char *rfp = (file + mutt_str_strlen(C_HelpDocDir) + 1);
+  /* default timestamp, based on PACKAGE_VERSION */
+  struct tm *tm = mutt_mem_calloc(1, sizeof(struct tm));
+  strptime(PACKAGE_VERSION, "%Y%m%d", tm);
+  time_t epoch = mutt_date_make_time(tm, 0);
+  /* default subject, final may come from file header, e.g. "[title]: description" */
+  char sbj[256];
+  snprintf(sbj, sizeof(sbj), "[%s]: %s", pdn, bfn);
+  /* bundle metadata */
+  HDMeta *meta = mutt_mem_calloc(1, sizeof(HDMeta));
+  meta->fhdr = fhdr;
+  meta->name = mutt_str_strdup(bfn);
+  meta->type = type;
+
+  struct Email *hdoc = mutt_email_new();
+  /* struct Email */
+  hdoc->date_sent = epoch;
+  hdoc->display_subject = true;
+  hdoc->index = 0;
+  hdoc->path = mutt_str_strdup(rfp);
+  hdoc->read = true;
+  hdoc->received = epoch;
+  /* struct Email::data (custom metadata) */
+  hdoc->edata = meta;
+  hdoc->free_edata = help_doc_meta_free;
+  /* struct Body */
+  hdoc->content = mutt_body_new();
+  hdoc->content->disposition = DISP_INLINE;
+  hdoc->content->encoding = ENC_8BIT;
+  hdoc->content->length = -1;
+  hdoc->content->subtype = mutt_str_strdup("plain");
+  hdoc->content->type = TYPE_TEXT;
+  /* struct Envelope */
+  hdoc->env = mutt_env_new();
+  mutt_addrlist_parse(&hdoc->env->from, "Richard Russon <rich@flatcap.org>");
+  hdoc->env->message_id = help_doc_msg_id(tm);
+  FREE(tm);
+  hdoc->env->organization = mutt_str_strdup("NeoMutt");
+  hdoc->env->subject =
+      help_doc_subject(fhdr, sbj, "[%s]: %s", "title", "description", NULL);
+
+  return hdoc;
+}
+
+/**
+ * help_doc_gather - Handler callback function for help_dir_scan()
+ *                   Builds a list of help document objects
+ * @param   list    ... generic list, for successfully processed item paths
+ * @param   path    ... absolute path of a dir entry that pass preselection
+ * @retval       0  ... on success,
+ * @retval  N != 0  ... on failure, (not used currently, failures are externally
+ *                      checked and silently suppressed herein)
+ */
+static int help_doc_gather(HelpList **list, const char *path)
+{
+  help_list_new_append(list, sizeof(struct Email *), help_doc_from(path));
+
+  return 0;
+}
+
+/**
+ * help_doc_uplink - Set a reference (threading) of one help document to an other
+ * @param   target  ... document to refer to (via Header::message_id)
+ * @param   source  ... document to link
+ */
+static void help_doc_uplink(const struct Email *target, const struct Email *source)
+{
+  if (!target || !source)
+    return;
+
+  char *tgt_msgid = target->env->message_id;
+  if (!tgt_msgid || !*tgt_msgid)
+    return;
+
+  mutt_list_insert_tail(&source->env->references, mutt_str_strdup(tgt_msgid));
+}
+
+/**
+ * help_dir_read - Read a directory and process its entries (not recursively) to
+ *                 find and link all help documents
+ * @param   path    ... absolute path of a directory
+ *
+ * @note: All sections are linked to their parent chapter regardless how deeply
+ *        they're nested on the filesystem. Empty directories are ignored.
+ */
+static void help_dir_read(const char *path)
+{
+  HelpList *list = NULL;
+
+  if ((help_dir_scan(path, false, DET_REG, NULL, help_doc_gather, &list) != 0) ||
+      (list == NULL))
+    return; /* skip errors and empty folder */
+
+  /* sort any 'index.md' in list to the top */
+  help_list_sort(list, help_doc_type_cmp);
+
+  struct Email *help_msg_top = help_list_get(list, 0, NULL), *help_msg_cur = NULL;
+  HDType help_msg_top_type = ((HDMeta *) help_msg_top->edata)->type;
+
+  /* uplink a help chapter/section top node */
+  if (help_msg_top_type & HDT_CHAPTER)
+  {
+    if (HELP_LINK_CHAPTERS != 0)
+      help_doc_uplink(help_list_get(DocList, 0, NULL), help_msg_top);
+
+    UpLink = DocList->size;
+  }
+  else if (help_msg_top_type & HDT_SECTION)
+    help_doc_uplink(help_list_get(DocList, UpLink, NULL), help_msg_top);
+  else
+    UpLink = 0;
+
+  help_msg_top->index = DocList->size;
+  help_list_append(DocList, help_msg_top);
+
+  /* link remaining docs to first list item */
+  for (size_t i = 1; i < list->size; i++)
+  {
+    help_msg_cur = help_list_get(list, i, NULL);
+    help_doc_uplink(help_msg_top, help_msg_cur);
+
+    help_msg_cur->index = DocList->size;
+    help_list_append(DocList, help_msg_cur);
+  }
+}
+
+/**
+ * help_dir_gather - Handler callback function for help_dir_scan()
+ *                   Simple invoke help_dir_read() to search for help documents
+ * @param   list    ... generic list, for successfully processed item paths (not used)
+ * @param   path    ... absolute path of a dir entry that pass preselection
+ * @retval       0  ... on success,
+ * @retval  N != 0  ... on failure, (not used currently, failures are externally
+ *                      checked and silently suppressed herein)
+ *
+ * @note: The list parameter isn't used herein, because every single result from
+ *        help_scan_dir() will be processed directly.
+ */
+static int help_dir_gather(HelpList **list, const char *path)
+{
+  help_dir_read(path);
+
+  return 0;
+}
+
+/**
+ * help_doclist_init - Initialise the DocList at $help_doc_dir
+ * @retval   0      ... on success,
+ * @retval  -1      ... on failure, when help_dir_scan() of $help_doc_dir fails
+ *
+ * @note: Initialisation depends on several things, like $help_doc_dir changed,
+ *        DocList isn't (and should not) be cached, DocList is empty.
+ */
+int help_doclist_init(void)
+{
+  if ((HELP_CACHE_DOCLIST != 0) && (DocList && !help_docdir_changed()))
+    return 0;
+
+  help_doclist_free();
+  DocList = help_list_new(sizeof(struct Email));
+  help_dir_read(C_HelpDocDir);
+  help_docdir_id(C_HelpDocDir);
+
+  return help_dir_scan(C_HelpDocDir, true, DET_DIR, NULL, help_dir_gather, NULL);
+}
+
+/**
+ * help_doclist_parse - Evaluate and copy the DocList items to Context struct
+ * @param   ctx     ... the current help mailbox object
+ * @retval   0      ... on success,
+ * @retval  -1      ... on failure, e.g. DocList initialisation failed
+ *
+ * @note: XXX This function also sets the status of a help document to unread,
+ *        when its path match the user input, so the index line will mark it.
+ *        This is just a test, has room for improvements and is less-than-ideal,
+ *        because the user needs some knowledge about helpbox folder structure.
+ */
+static int help_doclist_parse(struct Mailbox *m)
+{
+  if ((help_doclist_init() != 0) || (DocList->size == 0))
+    return -1;
+
+  m->emails = (struct Email **) (help_list_clone(DocList, true, help_doc_clone))->data;
+  m->msg_count = m->email_max = DocList->size;
+  mutt_mem_realloc(&m->v2r, sizeof(int) * m->email_max);
+
+  mutt_make_label_hash(m);
+
+  m->readonly = true;
+  /* all document paths are relative to C_HelpDocDir, so no transpose of ctx->path */
+  mutt_str_replace(&m->realpath, C_HelpDocDir);
+
+  /* check (none strict) what the user wants to see */
+  const char *request = help_path_transpose(mutt_b2s(m->pathbuf), false);
+  m->emails[0]->read = false;
+  if (request)
+  {
+    mutt_buffer_increase_size(m->pathbuf, PATH_MAX);
+    mutt_str_strfcpy(m->pathbuf->data, help_path_transpose(request, false), m->pathbuf->dsize); /* just sanitise */
+    request += mutt_str_strlen(C_HelpDocDir) + 1;
+    for (size_t i = 0; i < m->msg_count; i++)
+    { /* TODO: prioritise folder (chapter/section) over root file names */
+      if (mutt_str_strncmp(m->emails[i]->path, request, mutt_str_strlen(request)) == 0)
+      {
+        m->emails[0]->read = true;
+        m->emails[i]->read = false;
+        break;
+      }
+    }
+  }
+
+  return 0;
 }
 
 /**
@@ -69,73 +1045,121 @@ int help_ac_add(struct Account *a, struct Mailbox *m)
   return 0;
 }
 
-int help_mbox_open_append(struct Mailbox *m, OpenMailboxFlags flags)
+static int help_mbox_open(struct Mailbox *m)
+{
+  mutt_debug(1, "entering help_mbox_open\n");
+
+  if (m->magic != MUTT_HELP)
+    return -1;
+
+  /* TODO: ensure either mutt_option_set()/mutt_expand_path() sanitise a DT_PATH
+   * option or let help_docdir_changed() treat "/path" and "/path///" as equally
+   * to avoid a useless re-caching of the same directory */
+  if (help_docdir_changed())
+  {
+    if (access(C_HelpDocDir, F_OK) == 0)
+    { /* ensure a proper path, especially without any trailing slashes */
+      mutt_str_replace(&C_HelpDocDir, NONULL(realpath(C_HelpDocDir, NULL)));
+    }
+    else
+    {
+      mutt_debug(1, "unable to access help mailbox '%s': %s (errno %d).\n",
+                 C_HelpDocDir, strerror(errno), errno);
+      return -1;
+    }
+  }
+
+  __Backup_HTS = C_HideThreadSubject; /* backup the current global setting */
+  C_HideThreadSubject = false; /* temporarily ensure subject is shown in thread view */
+
+  return help_doclist_parse(m);
+}
+
+static int help_mbox_open_append(struct Mailbox *m, OpenMailboxFlags flags)
 {
   mutt_debug(1, "entering help_mbox_open_append\n");
   return -1;
 }
 
-int help_mbox_check(struct Mailbox *m, int *index_hint)
+static int help_mbox_check(struct Mailbox *m, int *index_hint)
 {
   mutt_debug(1, "entering help_mbox_check\n");
-  return -1;
+  return 0;
 }
 
-int help_mbox_sync(struct Mailbox *m, int *index_hint)
+static int help_mbox_sync(struct Mailbox *m, int *index_hint)
 {
   mutt_debug(1, "entering help_mbox_sync\n");
-  return -1;
+  return 0;
 }
 
-int help_mbox_close(struct Mailbox *m)
+static int help_mbox_close(struct Mailbox *m)
 {
   mutt_debug(1, "entering help_mbox_close\n");
-  return -1;
+
+  C_HideThreadSubject = __Backup_HTS; /* restore the previous global setting */
+
+  return 0;
 }
 
-int help_msg_open(struct Mailbox *m, struct Message *msg, int msgno)
+static int help_msg_open(struct Mailbox *m, struct Message *msg, int msgno)
 {
-  mutt_debug(1, "entering help_msg_open\n");
-  return -1;
+  mutt_debug(1, "entering help_msg_open: %d, %s\n", msgno, m->emails[msgno]->env->subject);
+
+  char path[PATH_MAX];
+  snprintf(path, sizeof(path), "%s/%s", m->realpath, m->emails[msgno]->path);
+
+  m->emails[msgno]->read = true; /* reset a probably previously set unread status */
+
+  msg->fp = fopen(path, "r");
+  if (!msg->fp)
+  {
+    mutt_perror(path);
+    mutt_debug(1, "fopen: %s: %s (errno %d).\n", path, strerror(errno), errno);
+    return -1;
+  }
+
+  return 0;
 }
 
-int help_msg_open_new(struct Mailbox *m, struct Message *msg, struct Email *e)
+static int help_msg_open_new(struct Mailbox *m, struct Message *msg, struct Email *e)
 {
   mutt_debug(1, "entering help_msg_open_new\n");
   return -1;
 }
 
-int help_msg_commit(struct Mailbox *m, struct Message *msg)
+static int help_msg_commit(struct Mailbox *m, struct Message *msg)
 {
   mutt_debug(1, "entering help_msg_commit\n");
   return -1;
 }
 
-int help_msg_close(struct Mailbox *m, struct Message *msg)
+static int help_msg_close(struct Mailbox *m, struct Message *msg)
 {
   mutt_debug(1, "entering help_msg_close\n");
-  return -1;
+  mutt_file_fclose(&msg->fp);
+  return 0;
 }
 
-int help_msg_padding_size(struct Mailbox *m)
+static int help_msg_padding_size(struct Mailbox *m)
 {
   mutt_debug(1, "entering help_msg_padding_size\n");
   return -1;
 }
 
-int help_tags_edit(struct Mailbox *m, const char *tags, char *buf, size_t buflen)
+static int help_tags_edit(struct Mailbox *m, const char *tags, char *buf, size_t buflen)
 {
   mutt_debug(1, "entering help_tags_edit\n");
   return -1;
 }
 
-int help_tags_commit(struct Mailbox *m, struct Email *e, char *buf)
+static int help_tags_commit(struct Mailbox *m, struct Email *e, char *buf)
 {
   mutt_debug(1, "entering help_tags_commit\n");
   return -1;
 }
 
-int help_path_probe(const char *path, const struct stat *st)
+static int help_path_probe(const char *path, const struct stat *st)
 {
   if (!path)
     return MUTT_UNKNOWN;
@@ -146,19 +1170,19 @@ int help_path_probe(const char *path, const struct stat *st)
   return MUTT_UNKNOWN;
 }
 
-int help_path_canon(char *buf, size_t buflen)
+static int help_path_canon(char *buf, size_t buflen)
 {
   mutt_debug(1, "entering help_path_canon\n");
   return 0;
 }
 
-int help_path_pretty(char *buf, size_t buflen, const char *folder)
+static int help_path_pretty(char *buf, size_t buflen, const char *folder)
 {
   mutt_debug(1, "entering help_path_pretty\n");
   return -1;
 }
 
-int help_path_parent(char *buf, size_t buflen)
+static int help_path_parent(char *buf, size_t buflen)
 {
   mutt_debug(1, "entering help_path_parent\n");
   return -1;

--- a/help/help.h
+++ b/help/help.h
@@ -1,0 +1,31 @@
+/**
+ * @file
+ * Help system
+ *
+ * @authors
+ * Copyright (C) 2018 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _HELP_HELP_H
+#define _HELP_HELP_H
+
+#include <stdbool.h>
+#include "mx.h"
+
+extern struct MxOps mx_help_ops;
+
+#endif /* _HELP_HELP_H */

--- a/help/help.h
+++ b/help/help.h
@@ -28,4 +28,71 @@
 
 extern struct MxOps mx_help_ops;
 
+/**
+ * enum dirent_type - Constants for d_type field values of the dirent structure
+ *                    and used for bitwise filter mask matching, even the macro
+ *                    _DIRENT_HAVE_D_TYPE for the d_type field is not defined
+ */
+typedef enum dirent_type
+{
+  DET_UNKNOWN = (1 << 0), /* flag for DT_UNKNOWN field value (0) */
+  DET_FIFO    = (1 << 1), /* flag for DT_FIFO field value (1) */
+  DET_CHR     = (1 << 2), /* flag for DT_CHR field value (2) */
+  DET_DIR     = (1 << 3), /* flag for DT_DIR field value (4) */
+  DET_BLK     = (1 << 4), /* flag for DT_BLK field value (6) */
+  DET_REG     = (1 << 5), /* flag for DT_REG field value (8) */
+  DET_LNK     = (1 << 6), /* flag for DT_LNK field value (10) */
+  DET_SOCK    = (1 << 7), /* flag for DT_SOCK field value (12) */
+  DET_WHT     = (1 << 8)  /* flag for DT_WHT (dummy, whiteout inode) field value (14) */
+} DEType;
+#define DT2DET(type) (((type) ? 2 : 1) << ((type) >> 1))
+typedef unsigned int DETMask;
+
+/**
+ * enum helpdoc_type - Describes the type of a help file/document
+ */
+typedef enum helpdoc_type
+{
+  HDT_NONE    = (1 << 0), /* file isn't a help document */
+  HDT_INDEX   = (1 << 1), /* document is treated as help index (index.md) */
+  HDT_ROOTDOC = (1 << 2), /* document lives directly in root of #C_HelpDocDir */
+  HDT_CHAPTER = (1 << 3), /* document is treated as help chapter */
+  HDT_SECTION = (1 << 4)  /* document is treated as help section */
+} HDType;
+typedef unsigned int HDTMask;
+
+/**
+ * struct helplist - Generic list to hold several help elements
+ */
+typedef struct helplist
+{
+  size_t item_size;       /* size of a single element */
+  size_t size;            /* list length */
+  size_t capa;            /* list capacity */
+  void **data;            /* internal list data pointers */
+} HelpList;
+#define HELPLIST_INIT_CAPACITY 10
+
+/**
+ * struct helpfile_header - Describes the header of a help file
+ */
+typedef struct helpfile_header
+{
+  char *key;
+  char *val;
+} HFHeader;
+
+/**
+ * struct helpdoc_meta - Bundle additional information to a help document
+ */
+typedef struct helpdoc_meta
+{
+  HelpList *fhdr;         /* file header lines (list of key/value pairs) */
+  char *name;             /* base file name */
+  HDType type;            /* type of the help document */
+} HDMeta;
+
+void help_doclist_free(void); /* release memory of the cached document list */
+int help_doclist_init(void);  /* can be used for pre-caching help documents */
+
 #endif /* _HELP_HELP_H */

--- a/index.c
+++ b/index.c
@@ -2186,6 +2186,7 @@ int mutt_index_menu(void)
 #ifdef USE_SIDEBAR
       case OP_SIDEBAR_OPEN:
 #endif
+      case OP_HELP_BOX:
       case OP_MAIN_CHANGE_FOLDER:
       case OP_MAIN_NEXT_UNREAD_MAILBOX:
       case OP_MAIN_CHANGE_FOLDER_READONLY:
@@ -2243,6 +2244,15 @@ int mutt_index_menu(void)
           mutt_browser_select_dir(mutt_b2s(m->pathbuf));
         }
 #endif
+        else if (op == OP_HELP_BOX)
+        {
+          cp = _("Open help mailbox/chapter");
+          mutt_str_strfcpy(buf, "help://", sizeof(buf));
+          mutt_enter_fname(cp, buf, sizeof(buf), 1);
+          mutt_buffer_strcpy(folderbuf, buf);
+          if (mutt_buffer_is_empty(folderbuf))
+            mutt_buffer_addstr(folderbuf, C_HelpDocDir);
+        }
         else
         {
           if (C_ChangeFolderNext && Context &&

--- a/index.c
+++ b/index.c
@@ -2186,7 +2186,9 @@ int mutt_index_menu(void)
 #ifdef USE_SIDEBAR
       case OP_SIDEBAR_OPEN:
 #endif
+#ifdef USE_DEVEL_HELP
       case OP_HELP_BOX:
+#endif
       case OP_MAIN_CHANGE_FOLDER:
       case OP_MAIN_NEXT_UNREAD_MAILBOX:
       case OP_MAIN_CHANGE_FOLDER_READONLY:
@@ -2244,6 +2246,7 @@ int mutt_index_menu(void)
           mutt_browser_select_dir(mutt_b2s(m->pathbuf));
         }
 #endif
+#ifdef USE_DEVEL_HELP
         else if (op == OP_HELP_BOX)
         {
           cp = _("Open help mailbox/chapter");
@@ -2253,6 +2256,7 @@ int mutt_index_menu(void)
           if (mutt_buffer_is_empty(folderbuf))
             mutt_buffer_addstr(folderbuf, C_HelpDocDir);
         }
+#endif
         else
         {
           if (C_ChangeFolderNext && Context &&

--- a/init.h
+++ b/init.h
@@ -1427,6 +1427,7 @@ struct ConfigDef MuttVars[] = {
   ** running.  Since this variable is primarily aimed at new users, neither
   ** of these should present a major problem.
   */
+#ifdef USE_DEVEL_HELP
   { "help_doc_dir", DT_STRING|DT_PATH, &C_HelpDocDir, IP PKGDOCDIR "/help" },
   /*
   ** .pp
@@ -1434,6 +1435,7 @@ struct ConfigDef MuttVars[] = {
   ** expect to find its help documents (currently regular Markdown files with a
   ** YAML header, a.k.a. front matter). The help mailbox is handled read-only.
   */
+#endif
   { "hidden_host", DT_BOOL, &C_HiddenHost, false },
   /*
   ** .pp

--- a/init.h
+++ b/init.h
@@ -1427,6 +1427,13 @@ struct ConfigDef MuttVars[] = {
   ** running.  Since this variable is primarily aimed at new users, neither
   ** of these should present a major problem.
   */
+  { "help_doc_dir", DT_STRING|DT_PATH, &C_HelpDocDir, IP PKGDOCDIR "/help" },
+  /*
+  ** .pp
+  ** Specifies the location that will be used as help mailbox and where NeoMutt
+  ** expect to find its help documents (currently regular Markdown files with a
+  ** YAML header, a.k.a. front matter). The help mailbox is handled read-only.
+  */
   { "hidden_host", DT_BOOL, &C_HiddenHost, false },
   /*
   ** .pp

--- a/mailbox.h
+++ b/mailbox.h
@@ -62,6 +62,7 @@ enum MailboxType
   MUTT_NOTMUCH,            ///< 'Notmuch' (virtual) Mailbox type
   MUTT_POP,                ///< 'POP3' Mailbox type
   MUTT_COMPRESSED,         ///< Compressed file Mailbox type
+  MUTT_HELP,               ///< Help/documentation Mailbox type
 };
 
 /**

--- a/mx.c
+++ b/mx.c
@@ -50,6 +50,7 @@
 #include "context.h"
 #include "copy.h"
 #include "globals.h"
+#include "help/help.h"
 #include "hook.h"
 #include "keymap.h"
 #include "mailbox.h"
@@ -128,6 +129,7 @@ static const struct MxOps *mx_ops[] = {
 #ifdef USE_NNTP
   &MxNntpOps,
 #endif
+  &mx_help_ops,
 
   /* Local mailboxes */
   &MxMaildirOps,
@@ -1158,6 +1160,7 @@ int mx_check_empty(const char *path)
   {
     case MUTT_MBOX:
     case MUTT_MMDF:
+    case MUTT_HELP:
       return mutt_file_check_empty(path);
     case MUTT_MH:
       return mh_check_empty(path);
@@ -1258,6 +1261,7 @@ enum MailboxType mx_path_probe(const char *path, struct stat *st)
 #ifdef USE_NNTP
     &MxNntpOps,
 #endif
+    &mx_help_ops,
   };
 
   static const struct MxOps *with_stat[] = {

--- a/mx.c
+++ b/mx.c
@@ -50,7 +50,6 @@
 #include "context.h"
 #include "copy.h"
 #include "globals.h"
-#include "help/help.h"
 #include "hook.h"
 #include "keymap.h"
 #include "mailbox.h"
@@ -87,6 +86,9 @@
 #endif
 #ifdef ENABLE_NLS
 #include <libintl.h>
+#endif
+#ifdef USE_DEVEL_HELP
+#include "help/help.h"
 #endif
 
 /* These Config Variables are only used in mx.c */
@@ -129,7 +131,9 @@ static const struct MxOps *mx_ops[] = {
 #ifdef USE_NNTP
   &MxNntpOps,
 #endif
+#ifdef USE_DEVEL_HELP
   &mx_help_ops,
+#endif
 
   /* Local mailboxes */
   &MxMaildirOps,
@@ -1160,7 +1164,9 @@ int mx_check_empty(const char *path)
   {
     case MUTT_MBOX:
     case MUTT_MMDF:
+#ifdef USE_DEVEL_HELP
     case MUTT_HELP:
+#endif
       return mutt_file_check_empty(path);
     case MUTT_MH:
       return mh_check_empty(path);
@@ -1261,7 +1267,9 @@ enum MailboxType mx_path_probe(const char *path, struct stat *st)
 #ifdef USE_NNTP
     &MxNntpOps,
 #endif
+#ifdef USE_DEVEL_HELP
     &mx_help_ops,
+#endif
   };
 
   static const struct MxOps *with_stat[] = {

--- a/opcodes.h
+++ b/opcodes.h
@@ -142,6 +142,7 @@
   _fmt(OP_HALF_DOWN,                      N_("scroll down 1/2 page")) \
   _fmt(OP_HALF_UP,                        N_("scroll up 1/2 page")) \
   _fmt(OP_HELP,                           N_("this screen")) \
+  _fmt(OP_HELP_BOX,                       N_("open help mailbox")) \
   _fmt(OP_JUMP,                           N_("jump to an index number")) \
   _fmt(OP_LAST_ENTRY,                     N_("move to the last entry")) \
   _fmt(OP_LIMIT_CURRENT_THREAD,           N_("limit view to current thread")) \

--- a/opcodes.h
+++ b/opcodes.h
@@ -142,7 +142,6 @@
   _fmt(OP_HALF_DOWN,                      N_("scroll down 1/2 page")) \
   _fmt(OP_HALF_UP,                        N_("scroll up 1/2 page")) \
   _fmt(OP_HELP,                           N_("this screen")) \
-  _fmt(OP_HELP_BOX,                       N_("open help mailbox")) \
   _fmt(OP_JUMP,                           N_("jump to an index number")) \
   _fmt(OP_LAST_ENTRY,                     N_("move to the last entry")) \
   _fmt(OP_LIMIT_CURRENT_THREAD,           N_("limit view to current thread")) \
@@ -303,6 +302,13 @@
 #define OPS_SMIME(_fmt) \
   _fmt(OP_COMPOSE_SMIME_MENU,             N_("show S/MIME options")) \
 
+#ifdef USE_DEVEL_HELP
+#define OPS_HELP(_fmt) \
+  _fmt(OP_HELP_BOX,                       N_("open help mailbox"))
+#else
+#define OPS_HELP(_)
+#endif
+
 #define OPS(_fmt) \
   OPS_CORE(_fmt) \
   OPS_SIDEBAR(_fmt) \
@@ -311,6 +317,7 @@
   OPS_PGP(_fmt) \
   OPS_SMIME(_fmt) \
   OPS_CRYPT(_fmt) \
+  OPS_HELP(_fmt) \
 
 enum MuttOps {
 #define DEFINE_OPS(opcode, help_string) opcode,

--- a/protos.h
+++ b/protos.h
@@ -88,4 +88,8 @@ int wcscasecmp(const wchar_t *a, const wchar_t *b);
 
 int mutt_reply_observer(struct NotifyCallback *nc);
 
+#ifdef USE_DEVEL_GRAPHVIZ
+void dump_graphviz(const char *title);
+#endif
+
 #endif /* MUTT_PROTOS_H */

--- a/version.c
+++ b/version.c
@@ -161,6 +161,9 @@ static struct CompileOptions comp_opts[] = {
 #else
   { "curs_set", 0 },
 #endif
+#ifdef USE_DEVEL_GRAPHVIZ
+  { "graphviz", 2 },
+#endif
 #ifdef USE_FCNTL
   { "fcntl", 1 },
 #else

--- a/version.c
+++ b/version.c
@@ -106,7 +106,7 @@ static const char *Notice =
 struct CompileOptions
 {
   const char *name;
-  bool enabled;
+  int enabled;  // 0 Disabled, 1 Enabled, 2 Devel only
 };
 
 /* These are sorted by the display string */
@@ -317,20 +317,29 @@ static void print_compile_options(struct CompileOptions *co, FILE *fp)
       fprintf(fp, "\n  ");
     }
     used += len;
-    if (co[i].enabled)
+    const char *fmt = "?%s ";
+    switch (co[i].enabled)
     {
-      if (tty)
-        fprintf(fp, "\033[1;32m+%s\033[0m ", co[i].name); // Escape
-      else
-        fprintf(fp, "+%s ", co[i].name);
+      case 0: // Disabled
+        if (tty)
+          fmt = "\033[1;31m-%s\033[0m "; // Escape, red
+        else
+          fmt = "-%s ";
+        break;
+      case 1: // Enabled
+        if (tty)
+          fmt = "\033[1;32m+%s\033[0m "; // Escape, green
+        else
+          fmt = "+%s ";
+        break;
+      case 2: // Devel only
+        if (tty)
+          fmt = "\033[1;36m!%s\033[0m "; // Escape, cyan
+        else
+          fmt = "+%s ";
+        break;
     }
-    else
-    {
-      if (tty)
-        fprintf(fp, "\033[1;31m-%s\033[0m ", co[i].name); // Escape
-      else
-        fprintf(fp, "-%s ", co[i].name);
-    }
+    fprintf(fp, fmt, co[i].name);
   }
   fprintf(fp, "\n");
 }

--- a/version.c
+++ b/version.c
@@ -206,6 +206,9 @@ static struct CompileOptions comp_opts[] = {
 #else
   { "hcache", 0 },
 #endif
+#ifdef USE_DEVEL_HELP
+  { "help", 2 },
+#endif
 #ifdef HOMESPOOL
   { "homespool", 1 },
 #else


### PR DESCRIPTION
This adds to features, mostly to save my having to rebase them continually.

They are protected by `--devel-X` configure options.
This implies that the features may change without warning.

I've also altered the `neomutt -v` version string to display the devel features.

### Help Mailbox `--devel-help`

This is a very basic working skeleton, that will become an online help browser.
When it's more useful, it will be built-in by default.

### Graphviz Dump `--devel-graphviz`

Create a graphical representation of the `Account` and `Mailbox` objects.
This has no build dependencies, but requires Graphviz/Imagemagick to view the files.

