### PR TITLE
Avoid UB when clearing stdin

### DIFF
--- a/curs_lib.c
+++ b/curs_lib.c
@@ -524,6 +524,19 @@ void mutt_perror_debug(const char *s)
 }
 
 /**
+ * mutt_flush_stdin - remove characters from stdin until '\n' or EOF is encountered
+ */
+void mutt_flush_stdin(void)
+{
+  int c;
+  do 
+  {
+    c = fgetc(stdin);
+  } while ((c != '\n') && (c != EOF));
+}
+
+
+/**
  * mutt_any_key_to_continue - Prompt the user to 'press any key' and wait
  * @param s Message prompt
  * @retval num Key pressed
@@ -550,7 +563,7 @@ int mutt_any_key_to_continue(const char *s)
     fputs(_("Press any key to continue..."), stdout);
   fflush(stdout);
   int ch = fgetc(stdin);
-  fflush(stdin);
+  mutt_flush_stdin();
   tcsetattr(fd, TCSADRAIN, &old);
   close(fd);
   fputs("\r\n", stdout);


### PR DESCRIPTION
Flushing `stdin` is undefined behaviour.

References
 http://www.open-std.org/jtc1/sc22/wg14/www/docs/n1570.pdf, chapter 7.21.5.2 (The fflush function)
 http://en.cppreference.com/w/c/io/fflush

* **What does this PR do?**

Replace a call to `fflush` on stdin


* **Does this PR meet the acceptance criteria?** (This is just a reminder for you,
  this section can be removed if you fulfill it.)

   - Documentation created/updated
No documentation to update

   - All builds and tests are passing

   - Added [doxygen code documentation](https://neomutt.org/dev/doxygen)
     [syntax](http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html)
If the function is appropriate, I'll gladly document it

   - Code follows the [style guide](https://neomutt.org/dev/coding-style)
It should

* **What are the relevant issue numbers?**
None