### PR TITLE
Avoid using c++ reserved identifiers

### DIFF
--- a/address/group.c
+++ b/address/group.c
@@ -180,15 +180,15 @@ static void group_add_addrlist(struct Group *g, const struct AddressList *al)
   if (!g || !al)
     return;
 
-  struct AddressList new = TAILQ_HEAD_INITIALIZER(new);
-  mutt_addrlist_copy(&new, al, false);
-  mutt_addrlist_remove_xrefs(&g->al, &new);
+  struct AddressList al_new = TAILQ_HEAD_INITIALIZER(al_new);
+  mutt_addrlist_copy(&al_new, al, false);
+  mutt_addrlist_remove_xrefs(&g->al, &al_new);
   struct Address *a = NULL, *tmp = NULL;
-  TAILQ_FOREACH_SAFE(a, &new, entries, tmp)
+  TAILQ_FOREACH_SAFE(a, &al_new, entries, tmp)
   {
     mutt_addrlist_append(&g->al, a);
   }
-  assert(TAILQ_EMPTY(&new));
+  assert(TAILQ_EMPTY(&al_new));
 }
 
 /**

--- a/browser.c
+++ b/browser.c
@@ -539,7 +539,7 @@ static const char *folder_format_str(char *buf, size_t buflen, size_t col, int c
 
     case 'N':
       snprintf(fmt, sizeof(fmt), "%%%sc", prec);
-      snprintf(buf, buflen, fmt, folder->ff->new ? 'N' : ' ');
+      snprintf(buf, buflen, fmt, folder->ff->has_new_mail ? 'N' : ' ');
       break;
 
     case 'n':
@@ -645,7 +645,7 @@ static void add_folder(struct Menu *menu, struct BrowserState *state,
   if (m)
   {
     (state->entry)[state->entrylen].has_mailbox = true;
-    (state->entry)[state->entrylen].new = m->has_new;
+    (state->entry)[state->entrylen].has_new_mail = m->has_new;
     (state->entry)[state->entrylen].msg_count = m->msg_count;
     (state->entry)[state->entrylen].msg_unread = m->msg_unread;
   }
@@ -829,7 +829,8 @@ static int examine_mailboxes(struct Menu *menu, struct BrowserState *state)
     for (unsigned int i = 0; i < adata->groups_num; i++)
     {
       struct NntpMboxData *mdata = adata->groups_list[i];
-      if (mdata && (mdata->new || (mdata->subscribed && (mdata->unread || !C_ShowOnlyUnread))))
+      if (mdata && (mdata->has_new_mail ||
+                    (mdata->subscribed && (mdata->unread || !C_ShowOnlyUnread))))
       {
         add_folder(menu, state, mdata->group, NULL, NULL, NULL, mdata);
       }

--- a/browser.c
+++ b/browser.c
@@ -708,7 +708,7 @@ static int examine_directory(struct Menu *menu, struct BrowserState *state,
       if (prefix && *prefix && !mutt_str_startswith(mdata->group, prefix, CASE_MATCH))
         continue;
       if (C_Mask && C_Mask->regex &&
-          !((regexec(C_Mask->regex, mdata->group, 0, NULL, 0) == 0) ^ C_Mask->not))
+          !((regexec(C_Mask->regex, mdata->group, 0, NULL, 0) == 0) ^ C_Mask->pat_not))
       {
         continue;
       }
@@ -767,7 +767,7 @@ static int examine_directory(struct Menu *menu, struct BrowserState *state,
         continue;
       }
       if (C_Mask && C_Mask->regex &&
-          !((regexec(C_Mask->regex, de->d_name, 0, NULL, 0) == 0) ^ C_Mask->not))
+          !((regexec(C_Mask->regex, de->d_name, 0, NULL, 0) == 0) ^ C_Mask->pat_not))
       {
         continue;
       }

--- a/browser.h
+++ b/browser.h
@@ -67,9 +67,9 @@ struct FolderFile
   char *name;
   char *desc;
 
-  bool new;       /**< true if mailbox has "new mail" */
-  int msg_count;  /**< total number of messages */
-  int msg_unread; /**< number of unread messages */
+  bool has_new_mail; /**< true if mailbox has "new mail" */
+  int msg_count;     /**< total number of messages */
+  int msg_unread;    /**< number of unread messages */
 
 #ifdef USE_IMAP
   char delim;

--- a/commands.h
+++ b/commands.h
@@ -52,8 +52,8 @@ bool mutt_edit_content_type(struct Email *e, struct Body *b, FILE *fp);
 void mutt_enter_command(void);
 void mutt_pipe_message(struct Mailbox *m, struct EmailList *el);
 void mutt_print_message(struct Mailbox *m, struct EmailList *el);
-int  mutt_save_message_ctx(struct Email *e, bool delete, bool decode, bool decrypt, struct Mailbox *m);
-int  mutt_save_message(struct Mailbox *m, struct EmailList *el, bool delete, bool decode, bool decrypt);
+int  mutt_save_message_ctx(struct Email *e, bool delete_original, bool decode, bool decrypt, struct Mailbox *m);
+int  mutt_save_message(struct Mailbox *m, struct EmailList *el, bool delete_original, bool decode, bool decrypt);
 int  mutt_select_sort(bool reverse);
 void mutt_shell_escape(void);
 

--- a/compose.c
+++ b/compose.c
@@ -604,12 +604,12 @@ static void mutt_gen_compose_attach_list(struct AttachCtx *actx, struct Body *m,
     }
     else
     {
-      struct AttachPtr *new = mutt_mem_calloc(1, sizeof(struct AttachPtr));
-      mutt_actx_add_attach(actx, new);
-      new->content = m;
-      m->aptr = new;
-      new->parent_type = parent_type;
-      new->level = level;
+      struct AttachPtr *ap = mutt_mem_calloc(1, sizeof(struct AttachPtr));
+      mutt_actx_add_attach(actx, ap);
+      ap->content = m;
+      m->aptr = ap;
+      ap->parent_type = parent_type;
+      ap->level = level;
 
       /* We don't support multipart messages in the compose menu yet */
     }
@@ -649,15 +649,15 @@ static void mutt_update_compose_menu(struct AttachCtx *actx, struct Menu *menu, 
  * update_idx - Add a new attchment to the message
  * @param menu Current menu
  * @param actx Attachment context
- * @param new  Attachment to add
+ * @param ap   Attachment to add
  */
-static void update_idx(struct Menu *menu, struct AttachCtx *actx, struct AttachPtr *new)
+static void update_idx(struct Menu *menu, struct AttachCtx *actx, struct AttachPtr *ap)
 {
-  new->level = (actx->idxlen > 0) ? actx->idx[actx->idxlen - 1]->level : 0;
+  ap->level = (actx->idxlen > 0) ? actx->idx[actx->idxlen - 1]->level : 0;
   if (actx->idxlen)
-    actx->idx[actx->idxlen - 1]->content->next = new->content;
-  new->content->aptr = new;
-  mutt_actx_add_attach(actx, new);
+    actx->idx[actx->idxlen - 1]->content->next = ap->content;
+  ap->content->aptr = ap;
+  mutt_actx_add_attach(actx, ap);
   mutt_update_compose_menu(actx, menu, false);
   menu->current = actx->vcount - 1;
 }
@@ -1115,15 +1115,15 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
       {
         if (!(WithCrypto & APPLICATION_PGP))
           break;
-        struct AttachPtr *new = mutt_mem_calloc(1, sizeof(struct AttachPtr));
-        new->content = crypt_pgp_make_key_attachment();
-        if (new->content)
+        struct AttachPtr *ap = mutt_mem_calloc(1, sizeof(struct AttachPtr));
+        ap->content = crypt_pgp_make_key_attachment();
+        if (ap->content)
         {
-          update_idx(menu, actx, new);
+          update_idx(menu, actx, ap);
           menu->redraw |= REDRAW_INDEX;
         }
         else
-          FREE(&new);
+          FREE(&ap);
 
         menu->redraw |= REDRAW_STATUS;
 
@@ -1366,16 +1366,16 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
         for (int i = 0; i < numfiles; i++)
         {
           char *att = files[i];
-          struct AttachPtr *new = mutt_mem_calloc(1, sizeof(struct AttachPtr));
-          new->unowned = true;
-          new->content = mutt_make_file_attach(att);
-          if (new->content)
-            update_idx(menu, actx, new);
+          struct AttachPtr *ap = mutt_mem_calloc(1, sizeof(struct AttachPtr));
+          ap->unowned = true;
+          ap->content = mutt_make_file_attach(att);
+          if (ap->content)
+            update_idx(menu, actx, ap);
           else
           {
             error = true;
             mutt_error(_("Unable to attach %s"), att);
-            FREE(&new);
+            FREE(&ap);
           }
           FREE(&files[i]);
         }
@@ -1488,15 +1488,15 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
           if (!message_is_tagged(Context, i))
             continue;
 
-          struct AttachPtr *new = mutt_mem_calloc(1, sizeof(struct AttachPtr));
-          new->content = mutt_make_message_attach(Context->mailbox,
-                                                  Context->mailbox->emails[i], true);
-          if (new->content)
-            update_idx(menu, actx, new);
+          struct AttachPtr *ap = mutt_mem_calloc(1, sizeof(struct AttachPtr));
+          ap->content = mutt_make_message_attach(Context->mailbox,
+                                                 Context->mailbox->emails[i], true);
+          if (ap->content)
+            update_idx(menu, actx, ap);
           else
           {
             mutt_error(_("Unable to attach"));
-            FREE(&new);
+            FREE(&ap);
           }
         }
         menu->redraw |= REDRAW_FULL;
@@ -1779,25 +1779,25 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
           mutt_error(_("Unknown Content-Type %s"), type);
           continue;
         }
-        struct AttachPtr *new = mutt_mem_calloc(1, sizeof(struct AttachPtr));
+        struct AttachPtr *ap = mutt_mem_calloc(1, sizeof(struct AttachPtr));
         /* Touch the file */
         FILE *fp = mutt_file_fopen(buf, "w");
         if (!fp)
         {
           mutt_error(_("Can't create file %s"), buf);
-          FREE(&new);
+          FREE(&ap);
           continue;
         }
         mutt_file_fclose(&fp);
 
-        new->content = mutt_make_file_attach(buf);
-        if (!new->content)
+        ap->content = mutt_make_file_attach(buf);
+        if (!ap->content)
         {
           mutt_error(_("What we have here is a failure to make an attachment"));
-          FREE(&new);
+          FREE(&ap);
           continue;
         }
-        update_idx(menu, actx, new);
+        update_idx(menu, actx, ap);
 
         CUR_ATTACH->content->type = itype;
         mutt_str_replace(&CUR_ATTACH->content->subtype, p);

--- a/compose.c
+++ b/compose.c
@@ -1462,7 +1462,7 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
           break;
         }
 
-        struct Context *this = Context; /* remember current folder and sort methods */
+        struct Context *ctx_cur = Context; /* remember current folder and sort methods */
         int old_sort = C_Sort; /* C_Sort, SortAux could be changed in mutt_index_menu() */
         int old_sort_aux = C_SortAux;
 
@@ -1475,7 +1475,7 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
         if (!Context)
         {
           /* go back to the folder we started from */
-          Context = this;
+          Context = ctx_cur;
           /* Restore old $sort and $sort_aux */
           C_Sort = old_sort;
           C_SortAux = old_sort_aux;
@@ -1510,7 +1510,7 @@ int mutt_compose_menu(struct Email *msg, char *fcc, size_t fcclen, struct Email 
         }
 
         /* go back to the folder we started from */
-        Context = this;
+        Context = ctx_cur;
         /* Restore old $sort and $sort_aux */
         C_Sort = old_sort;
         C_SortAux = old_sort_aux;

--- a/compress.h
+++ b/compress.h
@@ -48,7 +48,6 @@ struct CompressInfo
 bool mutt_comp_can_append(struct Mailbox *m);
 bool mutt_comp_can_read(const char *path);
 int mutt_comp_valid_command(const char *cmd);
-int comp_path_probe(const char *path, const struct stat *st);
 
 extern struct MxOps MxCompOps;
 

--- a/config/regex.c
+++ b/config/regex.c
@@ -166,7 +166,7 @@ static int regex_native_set(const struct ConfigSet *cs, void *var,
 
   if (orig && orig->pattern)
   {
-    const int flags = orig->not? DT_REGEX_ALLOW_NOT : 0;
+    const int flags = orig->pat_not ? DT_REGEX_ALLOW_NOT : 0;
     r = regex_new(orig->pattern, flags, err);
     if (!r)
       rc = CSR_ERR_INVALID;
@@ -290,7 +290,7 @@ struct Regex *regex_new(const char *str, int flags, struct Buffer *err)
   /* Is a prefix of '!' allowed? */
   if (((flags & DT_REGEX_ALLOW_NOT) != 0) && (str[0] == '!'))
   {
-    reg->not = true;
+    reg->pat_not = true;
     str++;
   }
 

--- a/context.c
+++ b/context.c
@@ -104,10 +104,10 @@ void ctx_update(struct Context *ctx)
     if (!ctx->pattern)
     {
       m->v2r[m->vcount] = msgno;
-      e->virtual = m->vcount++;
+      e->vnum = m->vcount++;
     }
     else
-      e->virtual = -1;
+      e->vnum = -1;
     e->msgno = msgno;
 
     if (e->env->supersedes)
@@ -189,10 +189,10 @@ void ctx_update_tables(struct Context *ctx, bool committing)
         m->emails[i] = NULL;
       }
       m->emails[j]->msgno = j;
-      if (m->emails[j]->virtual != -1)
+      if (m->emails[j]->vnum != -1)
       {
         m->v2r[m->vcount] = j;
-        m->emails[j]->virtual = m->vcount++;
+        m->emails[j]->vnum = m->vcount++;
         struct Body *b = m->emails[j]->content;
         ctx->vsize += b->length + b->offset - b->hdr_offset + padding;
       }

--- a/curs_lib.c
+++ b/curs_lib.c
@@ -529,12 +529,11 @@ void mutt_perror_debug(const char *s)
 void mutt_flush_stdin(void)
 {
   int c;
-  do 
+  do
   {
     c = fgetc(stdin);
   } while ((c != '\n') && (c != EOF));
 }
-
 
 /**
  * mutt_any_key_to_continue - Prompt the user to 'press any key' and wait

--- a/email/email.h
+++ b/email/email.h
@@ -87,7 +87,7 @@ struct Email
   int lines;          /**< how many lines in the body of this message? */
   int index;          /**< the absolute (unsorted) message number */
   int msgno;          /**< number displayed to the user */
-  int virtual;        /**< virtual message number */
+  int vnum;           /**< virtual message number */
   int score;
   struct Envelope *env;      /**< envelope information */
   struct Body *content;      /**< list of MIME parts */

--- a/email/parse.c
+++ b/email/parse.c
@@ -96,7 +96,7 @@ void mutt_auto_subscribe(const char *mailto)
  */
 static void parse_parameters(struct ParameterList *param, const char *s)
 {
-  struct Parameter *new = NULL;
+  struct Parameter *pnew = NULL;
   char buf[1024];
   const char *p = NULL;
   size_t i;
@@ -125,12 +125,12 @@ static void parse_parameters(struct ParameterList *param, const char *s)
       if (i == 0)
       {
         mutt_debug(LL_DEBUG1, "missing attribute: %s\n", s);
-        new = NULL;
+        pnew = NULL;
       }
       else
       {
-        new = mutt_param_new();
-        new->attribute = mutt_str_substr_dup(s, s + i);
+        pnew = mutt_param_new();
+        pnew->attribute = mutt_str_substr_dup(s, s + i);
       }
 
       s = mutt_str_skip_email_wsp(p + 1); /* skip over the = */
@@ -177,15 +177,15 @@ static void parse_parameters(struct ParameterList *param, const char *s)
       }
 
       /* if the attribute token was missing, 'new' will be NULL */
-      if (new)
+      if (pnew)
       {
-        new->value = mutt_str_strdup(buf);
+        pnew->value = mutt_str_strdup(buf);
 
         mutt_debug(LL_DEBUG2, "parse_parameter: '%s' = '%s'\n",
-                   new->attribute ? new->attribute : "", new->value ? new->value : "");
+                   pnew->attribute ? pnew->attribute : "", pnew->value ? pnew->value : "");
 
         /* Add this parameter to the list */
-        TAILQ_INSERT_HEAD(param, new, entries);
+        TAILQ_INSERT_HEAD(param, pnew, entries);
       }
     }
     else

--- a/email/thread.c
+++ b/email/thread.c
@@ -85,25 +85,24 @@ void unlink_message(struct MuttThread **old, struct MuttThread *cur)
 
 /**
  * insert_message - Insert a message into a thread
- * @param[in,out] new       New thread to add
- * @param[in]     newparent Parent of new thread
- * @param[in]     cur       Current thread to add after
+ * @param[in,out] add    New thread to add
+ * @param[in]     parent Parent of new thread
+ * @param[in]     cur    Current thread to add after
  *
- * add cur as a prior sibling of *new, with parent newparent
+ * add cur as a prior sibling of *add, with parent parent
  */
-void insert_message(struct MuttThread **new, struct MuttThread *newparent,
-                    struct MuttThread *cur)
+void insert_message(struct MuttThread **add, struct MuttThread *parent, struct MuttThread *cur)
 {
-  if (!cur || !new)
+  if (!cur || !add)
     return;
 
-  if (*new)
-    (*new)->prev = cur;
+  if (*add)
+    (*add)->prev = cur;
 
-  cur->parent = newparent;
-  cur->next = *new;
+  cur->parent = parent;
+  cur->next = *add;
   cur->prev = NULL;
-  *new = cur;
+  *add = cur;
 }
 
 /**

--- a/email/thread.c
+++ b/email/thread.c
@@ -127,7 +127,7 @@ struct Email *find_virtual(struct MuttThread *cur, int reverse)
 
   struct MuttThread *top = NULL;
 
-  if (cur->message && (cur->message->virtual >= 0))
+  if (cur->message && (cur->message->vnum >= 0))
     return cur->message;
 
   top = cur;
@@ -140,7 +140,7 @@ struct Email *find_virtual(struct MuttThread *cur, int reverse)
 
   while (true)
   {
-    if (cur->message && (cur->message->virtual >= 0))
+    if (cur->message && (cur->message->vnum >= 0))
       return cur->message;
 
     if (cur->child)

--- a/email/thread.h
+++ b/email/thread.h
@@ -51,7 +51,7 @@ struct MuttThread
 
 void           clean_references(struct MuttThread *brk, struct MuttThread *cur);
 struct Email *find_virtual(struct MuttThread *cur, int reverse);
-void           insert_message(struct MuttThread **new, struct MuttThread *newparent, struct MuttThread *cur);
+void           insert_message(struct MuttThread **add, struct MuttThread *parent, struct MuttThread *cur);
 bool           is_descendant(struct MuttThread *a, struct MuttThread *b);
 void           mutt_break_thread(struct Email *e);
 void           thread_hash_destructor(int type, void *obj, intptr_t data);

--- a/hcache/backend.h
+++ b/hcache/backend.h
@@ -77,14 +77,14 @@ struct HcacheOps
    */
   int (*store)(void *ctx, const char *key, size_t keylen, void *data, size_t datalen);
   /**
-   * delete - backend-specific routine to delete a message's headers
+   * delete_header - backend-specific routine to delete a message's headers
    * @param ctx    The backend-specific context retrieved via open()
    * @param key    A message identification string
    * @param keylen The length of the string pointed to by key
    * @retval 0   Success
    * @retval num Error, a backend-specific error code
    */
-  int (*delete)(void *ctx, const char *key, size_t keylen);
+  int (*delete_header)(void *ctx, const char *key, size_t keylen);
   /**
    * close - backend-specific routine to close a context
    * @param[out] ctx The backend-specific context retrieved via open()
@@ -108,7 +108,7 @@ struct HcacheOps
     .fetch   = hcache_##_name##_fetch,                                         \
     .free    = hcache_##_name##_free,                                          \
     .store   = hcache_##_name##_store,                                         \
-    .delete  = hcache_##_name##_delete,                                        \
+    .delete_header  = hcache_##_name##_delete_header,                          \
     .close   = hcache_##_name##_close,                                         \
     .backend = hcache_##_name##_backend,                                       \
   };

--- a/hcache/bdb.c
+++ b/hcache/bdb.c
@@ -204,9 +204,9 @@ static int hcache_bdb_store(void *vctx, const char *key, size_t keylen, void *da
 }
 
 /**
- * hcache_bdb_delete - Implements HcacheOps::delete()
+ * hcache_bdb_delete_header - Implements HcacheOps::delete_header()
  */
-static int hcache_bdb_delete(void *vctx, const char *key, size_t keylen)
+static int hcache_bdb_delete_header(void *vctx, const char *key, size_t keylen)
 {
   if (!vctx)
     return -1;

--- a/hcache/gdbm.c
+++ b/hcache/gdbm.c
@@ -104,9 +104,9 @@ static int hcache_gdbm_store(void *ctx, const char *key, size_t keylen, void *da
 }
 
 /**
- * hcache_gdbm_delete - Implements HcacheOps::delete()
+ * hcache_gdbm_delete_header - Implements HcacheOps::delete_header()
  */
-static int hcache_gdbm_delete(void *ctx, const char *key, size_t keylen)
+static int hcache_gdbm_delete_header(void *ctx, const char *key, size_t keylen)
 {
   if (!ctx)
     return -1;

--- a/hcache/hcache.c
+++ b/hcache/hcache.c
@@ -444,9 +444,9 @@ int mutt_hcache_store_raw(header_cache_t *hc, const char *key, size_t keylen,
 }
 
 /**
- * mutt_hcache_delete - Multiplexor for HcacheOps::delete
+ * mutt_hcache_delete_header - Multiplexor for HcacheOps::delete_header
  */
-int mutt_hcache_delete(header_cache_t *hc, const char *key, size_t keylen)
+int mutt_hcache_delete_header(header_cache_t *hc, const char *key, size_t keylen)
 {
   char path[PATH_MAX];
   const struct HcacheOps *ops = hcache_get_ops();
@@ -456,7 +456,7 @@ int mutt_hcache_delete(header_cache_t *hc, const char *key, size_t keylen)
 
   keylen = snprintf(path, sizeof(path), "%s%s", hc->folder, key);
 
-  return ops->delete (hc->ctx, path, keylen);
+  return ops->delete_header(hc->ctx, path, keylen);
 }
 
 /**

--- a/hcache/hcache.c
+++ b/hcache/hcache.c
@@ -281,7 +281,7 @@ header_cache_t *mutt_hcache_open(const char *path, const char *folder, hcache_na
     STAILQ_FOREACH(sp, &SpamList, entries)
     {
       mutt_md5_process(sp->regex->pattern, &md5ctx);
-      mutt_md5_process(sp->template, &md5ctx);
+      mutt_md5_process(sp->tmpl, &md5ctx);
     }
 
     /* Mix in user's nospam list */

--- a/hcache/hcache.h
+++ b/hcache/hcache.h
@@ -154,14 +154,14 @@ int mutt_hcache_store_raw(header_cache_t *hc, const char *key, size_t keylen,
                           void *data, size_t dlen);
 
 /**
- * mutt_hcache_delete - delete a key / data pair
+ * mutt_hcache_delete_header - delete a key / data pair
  * @param hc     Pointer to the header_cache_t structure got by mutt_hcache_open
  * @param key    Message identification string
  * @param keylen Length of the string pointed to by key
  * @retval 0   Success
  * @retval num Generic or backend-specific error code otherwise
  */
-int mutt_hcache_delete(header_cache_t *hc, const char *key, size_t keylen);
+int mutt_hcache_delete_header(header_cache_t *hc, const char *key, size_t keylen);
 
 /**
  * mutt_hcache_backend_list - get a list of backend identification strings

--- a/hcache/kc.c
+++ b/hcache/kc.c
@@ -110,9 +110,9 @@ static int hcache_kyotocabinet_store(void *ctx, const char *key, size_t keylen,
 }
 
 /**
- * hcache_kyotocabinet_delete - Implements HcacheOps::delete()
+ * hcache_kyotocabinet_delete_header - Implements HcacheOps::delete_header()
  */
-static int hcache_kyotocabinet_delete(void *ctx, const char *key, size_t keylen)
+static int hcache_kyotocabinet_delete_header(void *ctx, const char *key, size_t keylen)
 {
   if (!ctx)
     return -1;

--- a/hcache/lmdb.c
+++ b/hcache/lmdb.c
@@ -251,9 +251,9 @@ static int hcache_lmdb_store(void *vctx, const char *key, size_t keylen, void *d
 }
 
 /**
- * hcache_lmdb_delete - Implements HcacheOps::delete()
+ * hcache_lmdb_delete_header - Implements HcacheOps::delete_header()
  */
-static int hcache_lmdb_delete(void *vctx, const char *key, size_t keylen)
+static int hcache_lmdb_delete_header(void *vctx, const char *key, size_t keylen)
 {
   if (!vctx)
     return -1;

--- a/hcache/qdbm.c
+++ b/hcache/qdbm.c
@@ -87,9 +87,9 @@ static int hcache_qdbm_store(void *ctx, const char *key, size_t keylen, void *da
 }
 
 /**
- * hcache_qdbm_delete - Implements HcacheOps::delete()
+ * hcache_qdbm_delete_header - Implements HcacheOps::delete_header()
  */
-static int hcache_qdbm_delete(void *ctx, const char *key, size_t keylen)
+static int hcache_qdbm_delete_header(void *ctx, const char *key, size_t keylen)
 {
   if (!ctx)
     return -1;

--- a/hcache/tc.c
+++ b/hcache/tc.c
@@ -99,9 +99,9 @@ static int hcache_tokyocabinet_store(void *ctx, const char *key, size_t keylen,
 }
 
 /**
- * hcache_tokyocabinet_delete - Implements HcacheOps::delete()
+ * hcache_tokyocabinet_delete_header - Implements HcacheOps::delete_header()
  */
-static int hcache_tokyocabinet_delete(void *ctx, const char *key, size_t keylen)
+static int hcache_tokyocabinet_delete_header(void *ctx, const char *key, size_t keylen)
 {
   if (!ctx)
     return -1;

--- a/hook.c
+++ b/hook.c
@@ -359,8 +359,8 @@ static void delete_idxfmt_hooks(void)
 /**
  * mutt_parse_idxfmt_hook - Parse the 'index-format-hook' command - Implements ::command_t
  */
-int mutt_parse_idxfmt_hook(struct Buffer *buf, struct Buffer *s,
-                           unsigned long data, struct Buffer *err)
+enum CommandResult mutt_parse_idxfmt_hook(struct Buffer *buf, struct Buffer *s,
+                                          unsigned long data, struct Buffer *err)
 {
   enum CommandResult rc = MUTT_CMD_ERROR;
   bool not = false;

--- a/icommands.h
+++ b/icommands.h
@@ -48,6 +48,6 @@ struct ICommand
   unsigned long data; ///< Private data to pass to the command
 };
 
-int mutt_parse_icommand(/* const */ char *line, struct Buffer *err);
+enum CommandResult mutt_parse_icommand(/* const */ char *line, struct Buffer *err);
 
 #endif /* MUTT_ICOMMANDS_H */

--- a/imap/browse.c
+++ b/imap/browse.c
@@ -125,7 +125,7 @@ static void add_folder(char delim, char *folder, bool noselect, bool noinferiors
   if (np)
   {
     (state->entry)[state->entrylen].has_mailbox = true;
-    (state->entry)[state->entrylen].new = np->mailbox->has_new;
+    (state->entry)[state->entrylen].has_new_mail = np->mailbox->has_new;
     (state->entry)[state->entrylen].msg_count = np->mailbox->msg_count;
     (state->entry)[state->entrylen].msg_unread = np->mailbox->msg_unread;
   }

--- a/imap/browse.c
+++ b/imap/browse.c
@@ -90,7 +90,7 @@ static void add_folder(char delim, char *folder, bool noselect, bool noinferiors
    * than at scan, since it's so expensive to scan. But that's big changes
    * to browser.c */
   if (C_Mask && C_Mask->regex &&
-      !((regexec(C_Mask->regex, relpath, 0, NULL, 0) == 0) ^ C_Mask->not))
+      !((regexec(C_Mask->regex, relpath, 0, NULL, 0) == 0) ^ C_Mask->pat_not))
   {
     return;
   }

--- a/imap/command.c
+++ b/imap/command.c
@@ -794,7 +794,7 @@ static void cmd_parse_status(struct ImapAccountData *adata, char *s)
   char *value = NULL;
   unsigned int olduv, oldun;
   unsigned int litlen;
-  short new = 0;
+  short new_mail = 0;
 
   char *mailbox = imap_next_word(s);
 
@@ -889,26 +889,26 @@ static void cmd_parse_status(struct ImapAccountData *adata, char *s)
     if (olduv && (olduv == mdata->uid_validity))
     {
       if (oldun < mdata->uid_next)
-        new = (mdata->unseen > 0);
+        new_mail = (mdata->unseen > 0);
     }
     else if (!olduv && !oldun)
     {
       /* first check per session, use recent. might need a flag for this. */
-      new = (mdata->recent > 0);
+      new_mail = (mdata->recent > 0);
     }
     else
-      new = (mdata->unseen > 0);
+      new_mail = (mdata->unseen > 0);
   }
   else
-    new = (mdata->unseen > 0);
+    new_mail = (mdata->unseen > 0);
 
 #ifdef USE_SIDEBAR
-  if ((m->has_new != new) || (m->msg_count != mdata->messages) ||
+  if ((m->has_new != new_mail) || (m->msg_count != mdata->messages) ||
       (m->msg_unread != mdata->unseen))
     mutt_menu_set_current_redraw(REDRAW_SIDEBAR);
 #endif
 
-  m->has_new = new;
+  m->has_new = new_mail;
   m->msg_count = mdata->messages;
   m->msg_unread = mdata->unseen;
 

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -2272,7 +2272,7 @@ static int imap_tags_edit(struct Mailbox *m, const char *tags, char *buf, size_t
   if (!mdata)
     return -1;
 
-  char *new = NULL;
+  char *new_tag = NULL;
   char *checker = NULL;
 
   /* Check for \* flags capability */
@@ -2302,7 +2302,7 @@ static int imap_tags_edit(struct Mailbox *m, const char *tags, char *buf, size_t
    * And must be separated by one space.
    */
 
-  new = buf;
+  new_tag = buf;
   checker = buf;
   SKIPWS(checker);
   while (*checker != '\0')
@@ -2330,12 +2330,12 @@ static int imap_tags_edit(struct Mailbox *m, const char *tags, char *buf, size_t
     while ((checker[0] == ' ') && (checker[1] == ' '))
       checker++;
 
-    /* copy char to new and go the next one */
-    *new ++ = *checker++;
+    /* copy char to new_tag and go the next one */
+    *new_tag++ = *checker++;
   }
-  *new = '\0';
-  new = buf; /* rewind */
-  mutt_str_remove_trailing_ws(new);
+  *new_tag = '\0';
+  new_tag = buf; /* rewind */
+  mutt_str_remove_trailing_ws(new_tag);
 
   if (mutt_str_strcmp(tags, buf) == 0)
     return 0;

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -387,7 +387,7 @@ static int compile_search(struct Mailbox *m, const struct PatternHead *pat, stru
   if (do_search(pat, false) == 0)
     return 0;
 
-  if (firstpat->not)
+  if (firstpat->pat_not)
     mutt_buffer_addstr(buf, "NOT ");
 
   if (firstpat->child)

--- a/imap/imap.h
+++ b/imap/imap.h
@@ -101,7 +101,7 @@ int imap_mailbox_create(const char *folder);
 int imap_mailbox_rename(const char *path);
 
 /* message.c */
-int imap_copy_messages(struct Mailbox *m, struct EmailList *el, char *dest, bool delete);
+int imap_copy_messages(struct Mailbox *m, struct EmailList *el, char *dest, bool delete_original);
 
 /* socket.c */
 void imap_logout_all(void);

--- a/imap/imap.h
+++ b/imap/imap.h
@@ -90,7 +90,7 @@ int imap_search(struct Mailbox *m, const struct PatternHead *pat);
 int imap_subscribe(char *path, bool subscribe);
 int imap_complete(char *buf, size_t buflen, char *path);
 int imap_fast_trash(struct Mailbox *m, char *dest);
-int imap_path_probe(const char *path, const struct stat *st);
+enum MailboxType imap_path_probe(const char *path, const struct stat *st);
 int imap_path_canon(char *buf, size_t buflen);
 
 extern struct MxOps MxImapOps;

--- a/imap/message.c
+++ b/imap/message.c
@@ -1555,12 +1555,12 @@ fail:
  * @param m      Mailbox
  * @param el     List of Emails to copy
  * @param dest   Destination folder
- * @param delete Delete the original?
+ * @param delete_original Delete the original?
  * @retval -1 Error
  * @retval  0 Success
  * @retval  1 Non-fatal error - try fetch/append
  */
-int imap_copy_messages(struct Mailbox *m, struct EmailList *el, char *dest, bool delete)
+int imap_copy_messages(struct Mailbox *m, struct EmailList *el, char *dest, bool delete_original)
 {
   if (!m || !el || !dest)
     return -1;
@@ -1706,7 +1706,7 @@ int imap_copy_messages(struct Mailbox *m, struct EmailList *el, char *dest, bool
   }
 
   /* cleanup */
-  if (delete)
+  if (delete_original)
   {
     STAILQ_FOREACH(en, el, entries)
     {

--- a/imap/message.c
+++ b/imap/message.c
@@ -1398,7 +1398,7 @@ int imap_read_headers(struct Mailbox *m, unsigned int msn_begin,
                             sizeof(mdata->modseq));
     }
     else
-      mutt_hcache_delete(mdata->hcache, "/MODSEQ", 7);
+      mutt_hcache_delete_header(mdata->hcache, "/MODSEQ", 7);
 
     if (has_qresync)
       imap_hcache_store_uid_seqset(mdata);

--- a/imap/util.c
+++ b/imap/util.c
@@ -513,7 +513,7 @@ int imap_hcache_del(struct ImapMboxData *mdata, unsigned int uid)
   char key[16];
 
   sprintf(key, "/%u", uid);
-  return mutt_hcache_delete(mdata->hcache, key, mutt_str_strlen(key));
+  return mutt_hcache_delete_header(mdata->hcache, key, mutt_str_strlen(key));
 }
 
 /**
@@ -550,7 +550,7 @@ int imap_hcache_clear_uid_seqset(struct ImapMboxData *mdata)
   if (!mdata->hcache)
     return -1;
 
-  return mutt_hcache_delete(mdata->hcache, "/UIDSEQSET", 10);
+  return mutt_hcache_delete_header(mdata->hcache, "/UIDSEQSET", 10);
 }
 
 /**

--- a/init.c
+++ b/init.c
@@ -177,19 +177,19 @@ static void matches_ensure_morespace(int current)
 
 /**
  * candidate - helper function for completion
- * @param try  User entered data for completion
+ * @param user User entered data for completion
  * @param src  Candidate for completion
  * @param dest Completion result gets here
  * @param dlen Length of dest buffer
  *
  * Changes the dest buffer if necessary/possible to aid completion.
  */
-static void candidate(char *try, const char *src, char *dest, size_t dlen)
+static void candidate(char *user, const char *src, char *dest, size_t dlen)
 {
-  if (!dest || !try || !src)
+  if (!dest || !user || !src)
     return;
 
-  if (strstr(src, try) != src)
+  if (strstr(src, user) != src)
     return;
 
   matches_ensure_morespace(NumMatched);

--- a/maildir/shared.c
+++ b/maildir/shared.c
@@ -1433,7 +1433,7 @@ int mh_sync_mailbox_message(struct Mailbox *m, int msgno, header_cache_t *hc)
           key = e->path + 3;
           keylen = maildir_hcache_keylen(key);
         }
-        mutt_hcache_delete(hc, key, keylen);
+        mutt_hcache_delete_header(hc, key, keylen);
       }
 #endif
       unlink(path);

--- a/mutt/charset.c
+++ b/mutt/charset.c
@@ -466,7 +466,7 @@ bool mutt_ch_lookup_add(enum LookupType type, const char *pat,
   l->replacement = mutt_str_strdup(replace);
   l->regex.pattern = mutt_str_strdup(pat);
   l->regex.regex = rx;
-  l->regex.not = false;
+  l->regex.pat_not = false;
 
   TAILQ_INSERT_TAIL(&Lookups, l, entries);
 

--- a/mutt/regex.c
+++ b/mutt/regex.c
@@ -285,7 +285,7 @@ int mutt_replacelist_add(struct ReplaceList *rl, const char *pat,
        * re-adds conceptually. So we probably want this to imply a
        * removal, then do an add. We can achieve the removal by freeing
        * the template, and leaving t pointed at the current item.  */
-      FREE(&np->template);
+      FREE(&np->tmpl);
       break;
     }
   }
@@ -305,7 +305,7 @@ int mutt_replacelist_add(struct ReplaceList *rl, const char *pat,
   }
 
   /* Now np is the ReplaceListNode that we want to modify. It is prepared. */
-  np->template = mutt_str_strdup(templ);
+  np->tmpl = mutt_str_strdup(templ);
 
   /* Find highest match number in template string */
   np->nmatch = 0;
@@ -392,9 +392,9 @@ char *mutt_replacelist_apply(struct ReplaceList *rl, char *buf, size_t buflen, c
       mutt_debug(5, "%s matches %s\n", src, np->regex->pattern);
 
       /* Copy into other twinbuf with substitutions */
-      if (np->template)
+      if (np->tmpl)
       {
-        for (p = np->template; *p && (tlen < 1023);)
+        for (p = np->tmpl; *p && (tlen < 1023);)
         {
           if (*p == '%')
           {
@@ -455,7 +455,7 @@ void mutt_replacelist_free(struct ReplaceList *rl)
   {
     STAILQ_REMOVE(rl, np, ReplaceListNode, entries);
     mutt_regex_free(&np->regex);
-    FREE(&np->template);
+    FREE(&np->tmpl);
     FREE(&np);
   }
 }
@@ -500,7 +500,7 @@ bool mutt_replacelist_match(struct ReplaceList *rl, char *buf, size_t buflen, co
       mutt_debug(5, "%d subs\n", (int) np->regex->regex->re_nsub);
 
       /* Copy template into buf, with substitutions. */
-      for (p = np->template; *p && tlen < buflen - 1;)
+      for (p = np->tmpl; *p && tlen < buflen - 1;)
       {
         /* backreference to pattern match substring, eg. %1, %2, etc) */
         if (*p == '%')
@@ -575,7 +575,7 @@ int mutt_replacelist_remove(struct ReplaceList *rl, const char *pat)
     {
       STAILQ_REMOVE(rl, np, ReplaceListNode, entries);
       mutt_regex_free(&np->regex);
-      FREE(&np->template);
+      FREE(&np->tmpl);
       FREE(&np);
       nremoved++;
     }

--- a/mutt/regex.c
+++ b/mutt/regex.c
@@ -88,7 +88,7 @@ struct Regex *mutt_regex_new(const char *str, int flags, struct Buffer *err)
   /* Is a prefix of '!' allowed? */
   if (((flags & DT_REGEX_ALLOW_NOT) != 0) && (str[0] == '!'))
   {
-    reg->not = true;
+    reg->pat_not = true;
     str++;
   }
 

--- a/mutt/regex3.h
+++ b/mutt/regex3.h
@@ -78,7 +78,7 @@ struct ReplaceListNode
 {
   struct Regex *regex;      /**< Regex containing a regular expression */
   size_t nmatch;            /**< Match the 'nth' occurrence (0 means the whole expression) */
-  char *template;           /**< Template to match */
+  char *tmpl;               /**< Template to match */
   STAILQ_ENTRY(ReplaceListNode) entries; /**< Next item in list */
 };
 STAILQ_HEAD(ReplaceList, ReplaceListNode);

--- a/mutt/regex3.h
+++ b/mutt/regex3.h
@@ -58,7 +58,7 @@ struct Regex
 {
   char *pattern;  /**< printable version */
   regex_t *regex; /**< compiled expression */
-  bool not;       /**< do not match */
+  bool pat_not;       /**< do not match */
 };
 
 /**

--- a/mutt/signal.c
+++ b/mutt/signal.c
@@ -202,15 +202,15 @@ void mutt_sig_block_system(void)
 
 /**
  * mutt_sig_unblock_system - Restore previously blocked signals
- * @param catch If true, restore previous SIGINT, SIGQUIT behaviour
+ * @param restore If true, restore previous SIGINT, SIGQUIT behaviour
  */
-void mutt_sig_unblock_system(bool catch)
+void mutt_sig_unblock_system(bool restore)
 {
   if (!SysSignalsBlocked)
     return;
 
   sigprocmask(SIG_UNBLOCK, &SigsetSys, NULL);
-  if (catch)
+  if (restore)
   {
     sigaction(SIGQUIT, &SysOldQuit, NULL);
     sigaction(SIGINT, &SysOldInt, NULL);

--- a/mutt/signal2.h
+++ b/mutt/signal2.h
@@ -38,6 +38,6 @@ void mutt_sig_empty_handler(int sig);
 void mutt_sig_exit_handler(int sig);
 void mutt_sig_init(sig_handler_t sig_fn, sig_handler_t exit_fn, sig_handler_t segv_fn);
 void mutt_sig_unblock(void);
-void mutt_sig_unblock_system(bool catch);
+void mutt_sig_unblock_system(bool restore);
 
 #endif /* MUTT_LIB_SIGNAL_H */

--- a/mutt_body.c
+++ b/mutt_body.c
@@ -103,13 +103,13 @@ int mutt_body_copy(FILE *fp, struct Body **tgt, struct Body *src)
     b->email = NULL;
 
   /* copy parameters */
-  struct Parameter *np = NULL, *new = NULL;
+  struct Parameter *np = NULL, *new_param = NULL;
   TAILQ_FOREACH(np, &src->parameter, entries)
   {
-    new = mutt_param_new();
-    new->attribute = mutt_str_strdup(np->attribute);
-    new->value = mutt_str_strdup(np->value);
-    TAILQ_INSERT_HEAD(&b->parameter, new, entries);
+    new_param = mutt_param_new();
+    new_param->attribute = mutt_str_strdup(np->attribute);
+    new_param->value = mutt_str_strdup(np->value);
+    TAILQ_INSERT_HEAD(&b->parameter, new_param, entries);
   }
 
   mutt_stamp_attachment(b);

--- a/mutt_header.c
+++ b/mutt_header.c
@@ -94,21 +94,21 @@ static void label_ref_inc(struct Mailbox *m, char *label)
 
 /**
  * label_message - add an X-Label: field
- * @param[in]  m   Mailbox
- * @param[in]  e   Email
- * @param[out] new Set to true if this is a new label
+ * @param[in]  m         Mailbox
+ * @param[in]  e         Email
+ * @param[out] new_label Set to true if this is a new label
  * @retval true If the label was added
  */
-static bool label_message(struct Mailbox *m, struct Email *e, char *new)
+static bool label_message(struct Mailbox *m, struct Email *e, char *new_label)
 {
   if (!e)
     return false;
-  if (mutt_str_strcmp(e->env->x_label, new) == 0)
+  if (mutt_str_strcmp(e->env->x_label, new_label) == 0)
     return false;
 
   if (e->env->x_label)
     label_ref_dec(m, e->env->x_label);
-  mutt_str_replace(&e->env->x_label, new);
+  mutt_str_replace(&e->env->x_label, new_label);
   if (e->env->x_label)
     label_ref_inc(m, e->env->x_label);
 

--- a/mutt_header.c
+++ b/mutt_header.c
@@ -129,7 +129,6 @@ int mutt_label_message(struct Mailbox *m, struct EmailList *el)
     return 0;
 
   char buf[1024] = { 0 };
-  char *new = NULL;
 
   struct EmailNode *en = STAILQ_FIRST(el);
   if (!STAILQ_NEXT(en, entries))
@@ -142,15 +141,15 @@ int mutt_label_message(struct Mailbox *m, struct EmailList *el)
   if (mutt_get_field("Label: ", buf, sizeof(buf), MUTT_LABEL /* | MUTT_CLEAR */) != 0)
     return 0;
 
-  new = buf;
-  SKIPWS(new);
-  if (*new == '\0')
-    new = NULL;
+  char *new_label = buf;
+  SKIPWS(new_label);
+  if (*new_label == '\0')
+    new_label = NULL;
 
   int changed = 0;
   STAILQ_FOREACH(en, el, entries)
   {
-    if (label_message(m, en->email, new))
+    if (label_message(m, en->email, new_label))
     {
       changed++;
       mutt_set_header_color(m, en->email);

--- a/mutt_logging.c
+++ b/mutt_logging.c
@@ -118,21 +118,21 @@ static const char *rotate_logs(const char *file, int count)
   if (!file)
     return NULL;
 
-  char old[PATH_MAX];
-  char new[PATH_MAX];
+  char old_file[PATH_MAX];
+  char new_file[PATH_MAX];
 
   /* rotate the old debug logs */
   for (count -= 2; count >= 0; count--)
   {
-    snprintf(old, sizeof(old), "%s%d", file, count);
-    snprintf(new, sizeof(new), "%s%d", file, count + 1);
+    snprintf(old_file, sizeof(old_file), "%s%d", file, count);
+    snprintf(new_file, sizeof(new_file), "%s%d", file, count + 1);
 
-    mutt_expand_path(old, sizeof(old));
-    mutt_expand_path(new, sizeof(new));
-    rename(old, new);
+    mutt_expand_path(old_file, sizeof(old_file));
+    mutt_expand_path(new_file, sizeof(new_file));
+    rename(old_file, new_file);
   }
 
-  return mutt_str_strdup(old);
+  return mutt_str_strdup(old_file);
 }
 
 /**

--- a/mutt_thread.c
+++ b/mutt_thread.c
@@ -840,7 +840,7 @@ void mutt_sort_threads(struct Context *ctx, bool init)
 
   struct Email *cur = NULL;
   int i, oldsort, using_refs = 0;
-  struct MuttThread *thread = NULL, *new = NULL, *tmp = NULL;
+  struct MuttThread *thread = NULL, *tnew = NULL, *tmp = NULL;
   struct MuttThread top = { 0 };
   struct ListNode *ref = NULL;
 
@@ -923,7 +923,7 @@ void mutt_sort_threads(struct Context *ctx, bool init)
       }
       else
       {
-        new = (C_DuplicateThreads ? thread : NULL);
+        tnew = (C_DuplicateThreads ? thread : NULL);
 
         thread = mutt_mem_calloc(1, sizeof(struct MuttThread));
         thread->message = cur;
@@ -932,14 +932,14 @@ void mutt_sort_threads(struct Context *ctx, bool init)
         mutt_hash_insert(ctx->thread_hash,
                          cur->env->message_id ? cur->env->message_id : "", thread);
 
-        if (new)
+        if (tnew)
         {
-          if (new->duplicate_thread)
-            new = new->parent;
+          if (tnew->duplicate_thread)
+            tnew = tnew->parent;
 
           thread = cur->thread;
 
-          insert_message(&new->child, new, thread);
+          insert_message(&tnew->child, tnew, thread);
           thread->duplicate_thread = true;
           thread->message->threaded = true;
         }
@@ -950,16 +950,16 @@ void mutt_sort_threads(struct Context *ctx, bool init)
       /* unlink pseudo-threads because they might be children of newly
        * arrived messages */
       thread = cur->thread;
-      for (new = thread->child; new;)
+      for (tnew = thread->child; tnew;)
       {
-        tmp = new->next;
-        if (new->fake_thread)
+        tmp = tnew->next;
+        if (tnew->fake_thread)
         {
-          unlink_message(&thread->child, new);
-          insert_message(&top.child, &top, new);
-          new->fake_thread = false;
+          unlink_message(&thread->child, tnew);
+          insert_message(&top.child, &top, tnew);
+          tnew->fake_thread = false;
         }
-        new = tmp;
+        tnew = tmp;
       }
     }
   }
@@ -1014,24 +1014,24 @@ void mutt_sort_threads(struct Context *ctx, bool init)
       if (!ref)
         break;
 
-      new = mutt_hash_find(ctx->thread_hash, ref->data);
-      if (!new)
+      tnew = mutt_hash_find(ctx->thread_hash, ref->data);
+      if (!tnew)
       {
-        new = mutt_mem_calloc(1, sizeof(struct MuttThread));
-        mutt_hash_insert(ctx->thread_hash, ref->data, new);
+        tnew = mutt_mem_calloc(1, sizeof(struct MuttThread));
+        mutt_hash_insert(ctx->thread_hash, ref->data, tnew);
       }
       else
       {
-        if (new->duplicate_thread)
-          new = new->parent;
-        if (is_descendant(new, thread)) /* no loops! */
+        if (tnew->duplicate_thread)
+          tnew = tnew->parent;
+        if (is_descendant(tnew, thread)) /* no loops! */
           continue;
       }
 
       if (thread->parent)
         unlink_message(&top.child, thread);
-      insert_message(&new->child, new, thread);
-      thread = new;
+      insert_message(&tnew->child, tnew, thread);
+      thread = tnew;
       if (thread->message || (thread->parent && (thread->parent != &top)))
         break;
     }

--- a/mutt_thread.c
+++ b/mutt_thread.c
@@ -65,7 +65,7 @@ bool C_ThreadReceived; ///< Config: Sort threaded messages by their received dat
  */
 static bool is_visible(struct Email *e, struct Context *ctx)
 {
-  return e->virtual >= 0 || (e->collapsed && (!ctx->pattern || e->limited));
+  return e->vnum >= 0 || (e->collapsed && (!ctx->pattern || e->limited));
 }
 
 /**
@@ -1082,7 +1082,7 @@ int mutt_aside_thread(struct Email *e, bool forwards, bool subthreads)
   if ((C_Sort & SORT_MASK) != SORT_THREADS)
   {
     mutt_error(_("Threading is not enabled"));
-    return e->virtual;
+    return e->vnum;
   }
 
   cur = e->thread;
@@ -1127,7 +1127,7 @@ int mutt_aside_thread(struct Email *e, bool forwards, bool subthreads)
     } while (!tmp);
   }
 
-  return tmp->virtual;
+  return tmp->vnum;
 }
 
 /**
@@ -1146,7 +1146,7 @@ int mutt_parent_message(struct Context *ctx, struct Email *e, bool find_root)
   if ((C_Sort & SORT_MASK) != SORT_THREADS)
   {
     mutt_error(_("Threading is not enabled"));
-    return e->virtual;
+    return e->vnum;
   }
 
   /* Root may be the current message */
@@ -1177,14 +1177,14 @@ int mutt_parent_message(struct Context *ctx, struct Email *e, bool find_root)
       mutt_error(_("Parent message is not visible in this limited view"));
     return -1;
   }
-  return parent->virtual;
+  return parent->vnum;
 }
 
 /**
- * mutt_set_virtual - Set the virtual index number of all the messages in a mailbox
+ * mutt_set_vnum - Set the virtual index number of all the messages in a mailbox
  * @param ctx Mailbox
  */
-void mutt_set_virtual(struct Context *ctx)
+void mutt_set_vnum(struct Context *ctx)
 {
   if (!ctx || !ctx->mailbox)
     return;
@@ -1200,9 +1200,9 @@ void mutt_set_virtual(struct Context *ctx)
   for (int i = 0; i < m->msg_count; i++)
   {
     cur = m->emails[i];
-    if (cur->virtual >= 0)
+    if (cur->vnum >= 0)
     {
-      cur->virtual = m->vcount;
+      cur->vnum = m->vcount;
       m->v2r[m->vcount] = i;
       m->vcount++;
       ctx->vsize += cur->content->length + cur->content->offset -
@@ -1226,16 +1226,16 @@ int mutt_traverse_thread(struct Context *ctx, struct Email *cur, MuttThreadFlags
   int final, reverse = (C_Sort & SORT_REVERSE), minmsgno;
   int num_hidden = 0, new = 0, old = 0;
   bool flagged = false;
-  int min_unread_msgno = INT_MAX, min_unread = cur->virtual;
+  int min_unread_msgno = INT_MAX, min_unread = cur->vnum;
 #define CHECK_LIMIT (!ctx->pattern || cur->limited)
 
   if (((C_Sort & SORT_MASK) != SORT_THREADS) && !(flag & MUTT_THREAD_GET_HIDDEN))
   {
     mutt_error(_("Threading is not enabled"));
-    return cur->virtual;
+    return cur->vnum;
   }
 
-  final = cur->virtual;
+  final = cur->vnum;
   thread = cur->thread;
   while (thread->parent)
     thread = thread->parent;
@@ -1253,7 +1253,7 @@ int mutt_traverse_thread(struct Context *ctx, struct Email *cur, MuttThreadFlags
       new = 1;
     if (cur->msgno < min_unread_msgno)
     {
-      min_unread = cur->virtual;
+      min_unread = cur->vnum;
       min_unread_msgno = cur->msgno;
     }
   }
@@ -1261,18 +1261,18 @@ int mutt_traverse_thread(struct Context *ctx, struct Email *cur, MuttThreadFlags
   if (cur->flagged && CHECK_LIMIT)
     flagged = true;
 
-  if ((cur->virtual == -1) && CHECK_LIMIT)
+  if ((cur->vnum == -1) && CHECK_LIMIT)
     num_hidden++;
 
   if (flag & (MUTT_THREAD_COLLAPSE | MUTT_THREAD_UNCOLLAPSE))
   {
     cur->pair = 0; /* force index entry's color to be re-evaluated */
     cur->collapsed = flag & MUTT_THREAD_COLLAPSE;
-    if (cur->virtual != -1)
+    if (cur->vnum != -1)
     {
       roothdr = cur;
       if (flag & MUTT_THREAD_COLLAPSE)
-        final = roothdr->virtual;
+        final = roothdr->vnum;
     }
   }
 
@@ -1305,24 +1305,24 @@ int mutt_traverse_thread(struct Context *ctx, struct Email *cur, MuttThreadFlags
         {
           roothdr = cur;
           if (flag & MUTT_THREAD_COLLAPSE)
-            final = roothdr->virtual;
+            final = roothdr->vnum;
         }
 
         if (reverse && (flag & MUTT_THREAD_COLLAPSE) && (cur->msgno < minmsgno) && CHECK_LIMIT)
         {
           minmsgno = cur->msgno;
-          final = cur->virtual;
+          final = cur->vnum;
         }
 
         if (flag & MUTT_THREAD_COLLAPSE)
         {
           if (cur != roothdr)
-            cur->virtual = -1;
+            cur->vnum = -1;
         }
         else
         {
           if (CHECK_LIMIT)
-            cur->virtual = cur->msgno;
+            cur->vnum = cur->msgno;
         }
       }
 
@@ -1334,7 +1334,7 @@ int mutt_traverse_thread(struct Context *ctx, struct Email *cur, MuttThreadFlags
           new = 1;
         if (cur->msgno < min_unread_msgno)
         {
-          min_unread = cur->virtual;
+          min_unread = cur->vnum;
           min_unread_msgno = cur->msgno;
         }
       }
@@ -1342,7 +1342,7 @@ int mutt_traverse_thread(struct Context *ctx, struct Email *cur, MuttThreadFlags
       if (cur->flagged && CHECK_LIMIT)
         flagged = true;
 
-      if ((cur->virtual == -1) && CHECK_LIMIT)
+      if ((cur->vnum == -1) && CHECK_LIMIT)
         num_hidden++;
     }
 

--- a/mutt_thread.c
+++ b/mutt_thread.c
@@ -1224,7 +1224,7 @@ int mutt_traverse_thread(struct Context *ctx, struct Email *cur, MuttThreadFlags
   struct MuttThread *thread = NULL, *top = NULL;
   struct Email *roothdr = NULL;
   int final, reverse = (C_Sort & SORT_REVERSE), minmsgno;
-  int num_hidden = 0, new = 0, old = 0;
+  int num_hidden = 0, new_mail = 0, old_mail = 0;
   bool flagged = false;
   int min_unread_msgno = INT_MAX, min_unread = cur->vnum;
 #define CHECK_LIMIT (!ctx->pattern || cur->limited)
@@ -1248,9 +1248,9 @@ int mutt_traverse_thread(struct Context *ctx, struct Email *cur, MuttThreadFlags
   if (!cur->read && CHECK_LIMIT)
   {
     if (cur->old)
-      old = 2;
+      old_mail = 2;
     else
-      new = 1;
+      new_mail = 1;
     if (cur->msgno < min_unread_msgno)
     {
       min_unread = cur->vnum;
@@ -1282,7 +1282,7 @@ int mutt_traverse_thread(struct Context *ctx, struct Email *cur, MuttThreadFlags
     if (flag & (MUTT_THREAD_COLLAPSE | MUTT_THREAD_UNCOLLAPSE))
       return final;
     else if (flag & MUTT_THREAD_UNREAD)
-      return (old && new) ? new : (old ? old : new);
+      return (old_mail && new_mail) ? new_mail : (old_mail ? old_mail : new_mail);
     else if (flag & MUTT_THREAD_GET_HIDDEN)
       return num_hidden;
     else if (flag & MUTT_THREAD_NEXT_UNREAD)
@@ -1329,9 +1329,9 @@ int mutt_traverse_thread(struct Context *ctx, struct Email *cur, MuttThreadFlags
       if (!cur->read && CHECK_LIMIT)
       {
         if (cur->old)
-          old = 2;
+          old_mail = 2;
         else
-          new = 1;
+          new_mail = 1;
         if (cur->msgno < min_unread_msgno)
         {
           min_unread = cur->vnum;
@@ -1372,7 +1372,7 @@ int mutt_traverse_thread(struct Context *ctx, struct Email *cur, MuttThreadFlags
   if (flag & (MUTT_THREAD_COLLAPSE | MUTT_THREAD_UNCOLLAPSE))
     return final;
   else if (flag & MUTT_THREAD_UNREAD)
-    return (old && new) ? new : (old ? old : new);
+    return (old_mail && new_mail) ? new_mail : (old_mail ? old_mail : new_mail);
   else if (flag & MUTT_THREAD_GET_HIDDEN)
     return num_hidden + 1;
   else if (flag & MUTT_THREAD_NEXT_UNREAD)

--- a/mutt_thread.h
+++ b/mutt_thread.h
@@ -72,7 +72,7 @@ bool               mutt_link_threads      (struct Email *parent, struct EmailLis
 struct Hash *      mutt_make_id_hash      (struct Mailbox *m);
 int                mutt_messages_in_thread(struct Mailbox *m, struct Email *e, int flag);
 int                mutt_parent_message    (struct Context *ctx, struct Email *e, bool find_root);
-void               mutt_set_virtual       (struct Context *ctx);
+void               mutt_set_vnum          (struct Context *ctx);
 struct MuttThread *mutt_sort_subthreads   (struct MuttThread *thread, bool init);
 void               mutt_sort_threads      (struct Context *ctx, bool init);
 

--- a/mx.h
+++ b/mx.h
@@ -283,7 +283,7 @@ struct Message *mx_msg_open_new    (struct Mailbox *m, struct Email *e, MsgOpenF
 struct Message *mx_msg_open        (struct Mailbox *m, int msgno);
 int             mx_msg_padding_size(struct Mailbox *m);
 int             mx_save_hcache     (struct Mailbox *m, struct Email *e);
-int             mx_path_canon      (char *buf, size_t buflen, const char *folder, int *magic);
+int             mx_path_canon      (char *buf, size_t buflen, const char *folder, enum MailboxType *magic);
 int             mx_path_canon2     (struct Mailbox *m, const char *folder);
 int             mx_path_parent     (char *buf, size_t buflen);
 int             mx_path_pretty     (char *buf, size_t buflen, const char *folder);

--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -703,11 +703,11 @@ static struct SmimeKey *smime_parse_key(char *buf)
 
 /**
  * smime_get_candidates - Find keys matching a string
- * @param search String to match
- * @param public If true, only get the public keys
+ * @param search           String to match
+ * @param only_public_key  If true, only get the public keys
  * @retval ptr Matching key
  */
-static struct SmimeKey *smime_get_candidates(char *search, bool public)
+static struct SmimeKey *smime_get_candidates(char *search, bool only_public_key)
 {
   char index_file[PATH_MAX];
   char buf[1024];
@@ -715,7 +715,7 @@ static struct SmimeKey *smime_get_candidates(char *search, bool public)
   struct SmimeKey **results_end = &results;
 
   snprintf(index_file, sizeof(index_file), "%s/.index",
-           public ? NONULL(C_SmimeCertificates) : NONULL(C_SmimeKeys));
+           only_public_key ? NONULL(C_SmimeCertificates) : NONULL(C_SmimeKeys));
 
   FILE *fp = mutt_file_fopen(index_file, "r");
   if (!fp)
@@ -744,17 +744,17 @@ static struct SmimeKey *smime_get_candidates(char *search, bool public)
 
 /**
  * smime_get_key_by_hash - Find a key by its hash
- * @param hash   Hash to find
- * @param public If true, only get the public keys
+ * @param hash             Hash to find
+ * @param only_public_key  If true, only get the public keys
  * @retval ptr Matching key
  *
  * Returns the first matching key record, without prompting or checking of
  * abilities or trust.
  */
-static struct SmimeKey *smime_get_key_by_hash(char *hash, bool public)
+static struct SmimeKey *smime_get_key_by_hash(char *hash, bool only_public_key)
 {
   struct SmimeKey *match = NULL;
-  struct SmimeKey *results = smime_get_candidates(hash, public);
+  struct SmimeKey *results = smime_get_candidates(hash, only_public_key);
   for (struct SmimeKey *result = results; result; result = result->next)
   {
     if (mutt_str_strcasecmp(hash, result->hash) == 0)
@@ -771,14 +771,14 @@ static struct SmimeKey *smime_get_key_by_hash(char *hash, bool public)
 
 /**
  * smime_get_key_by_addr - Find an SIME key by address
- * @param mailbox   Email address to match
- * @param abilities Abilities to match, see #KeyFlags
- * @param public    If true, only get the public keys
- * @param may_ask   If true, the user may be asked to select a key
+ * @param mailbox          Email address to match
+ * @param abilities        Abilities to match, see #KeyFlags
+ * @param only_public_key  If true, only get the public keys
+ * @param may_ask          If true, the user may be asked to select a key
  * @retval ptr Matching key
  */
 static struct SmimeKey *smime_get_key_by_addr(char *mailbox, KeyFlags abilities,
-                                              bool public, bool may_ask)
+                                              bool only_public_key, bool may_ask)
 {
   if (!mailbox)
     return NULL;
@@ -792,7 +792,7 @@ static struct SmimeKey *smime_get_key_by_addr(char *mailbox, KeyFlags abilities,
   struct SmimeKey *return_key = NULL;
   bool multi_trusted_matches = false;
 
-  results = smime_get_candidates(mailbox, public);
+  results = smime_get_candidates(mailbox, only_public_key);
   for (result = results; result; result = result->next)
   {
     if (abilities && !(result->flags & abilities))
@@ -851,12 +851,12 @@ static struct SmimeKey *smime_get_key_by_addr(char *mailbox, KeyFlags abilities,
 
 /**
  * smime_get_key_by_str - Find an SMIME key by string
- * @param str       String to match
- * @param abilities Abilities to match, see #KeyFlags
- * @param public    If true, only get the public keys
+ * @param str              String to match
+ * @param abilities        Abilities to match, see #KeyFlags
+ * @param only_public_key  If true, only get the public keys
  * @retval ptr Matching key
  */
-static struct SmimeKey *smime_get_key_by_str(char *str, KeyFlags abilities, bool public)
+static struct SmimeKey *smime_get_key_by_str(char *str, KeyFlags abilities, bool only_public_key)
 {
   if (!str)
     return NULL;
@@ -867,7 +867,7 @@ static struct SmimeKey *smime_get_key_by_str(char *str, KeyFlags abilities, bool
   struct SmimeKey *match = NULL;
   struct SmimeKey *return_key = NULL;
 
-  results = smime_get_candidates(str, public);
+  results = smime_get_candidates(str, only_public_key);
   for (result = results; result; result = result->next)
   {
     if (abilities && !(result->flags & abilities))
@@ -897,12 +897,12 @@ static struct SmimeKey *smime_get_key_by_str(char *str, KeyFlags abilities, bool
 
 /**
  * smime_ask_for_key - Ask the user to select a key
- * @param prompt    Prompt to show the user
- * @param abilities Abilities to match, see #KeyFlags
- * @param public    If true, only get the public keys
+ * @param prompt           Prompt to show the user
+ * @param abilities        Abilities to match, see #KeyFlags
+ * @param only_public_key  If true, only get the public keys
  * @retval ptr Selected SMIME key
  */
-static struct SmimeKey *smime_ask_for_key(char *prompt, KeyFlags abilities, bool public)
+static struct SmimeKey *smime_ask_for_key(char *prompt, KeyFlags abilities, bool only_public_key)
 {
   struct SmimeKey *key = NULL;
   char resp[128];
@@ -918,7 +918,7 @@ static struct SmimeKey *smime_ask_for_key(char *prompt, KeyFlags abilities, bool
     if (mutt_get_field(prompt, resp, sizeof(resp), MUTT_CLEAR) != 0)
       return NULL;
 
-    key = smime_get_key_by_str(resp, abilities, public);
+    key = smime_get_key_by_str(resp, abilities, only_public_key);
     if (key)
       return key;
 

--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -450,9 +450,9 @@ static char *smime_key_flags(KeyFlags flags)
 static void smime_make_entry(char *buf, size_t buflen, struct Menu *menu, int line)
 {
   struct SmimeKey **table = menu->data;
-  struct SmimeKey *this = table[line];
+  struct SmimeKey *key = table[line];
   char *truststate = NULL;
-  switch (this->trust)
+  switch (key->trust)
   {
     case 'e':
       /* L10N: Describes the trust state of a S/MIME key.
@@ -510,8 +510,8 @@ static void smime_make_entry(char *buf, size_t buflen, struct Menu *menu, int li
          Expired, Invalid, Revoked, Trusted, Unverified, Verified, and Unknown.  */
       truststate = _("Unknown   ");
   }
-  snprintf(buf, buflen, " 0x%s %s %s %-35.35s %s", this->hash,
-           smime_key_flags(this->flags), truststate, this->email, this->label);
+  snprintf(buf, buflen, " 0x%s %s %s %-35.35s %s", key->hash,
+           smime_key_flags(key->flags), truststate, key->email, key->label);
 }
 
 /**

--- a/nntp/browse.c
+++ b/nntp/browse.c
@@ -104,7 +104,7 @@ const char *group_index_format_str(char *buf, size_t buflen, size_t col, int col
       if (folder->ff->nd->subscribed)
         snprintf(buf, buflen, fmt, ' ');
       else
-        snprintf(buf, buflen, fmt, folder->ff->new ? 'N' : 'u');
+        snprintf(buf, buflen, fmt, folder->ff->has_new_mail ? 'N' : 'u');
       break;
 
     case 'n':

--- a/nntp/newsrc.c
+++ b/nntp/newsrc.c
@@ -747,8 +747,8 @@ void nntp_hcache_update(struct NntpMboxData *mdata, header_cache_t *hc)
           continue;
 
         snprintf(buf, sizeof(buf), "%u", current);
-        mutt_debug(LL_DEBUG2, "mutt_hcache_delete %s\n", buf);
-        mutt_hcache_delete(hc, buf, strlen(buf));
+        mutt_debug(LL_DEBUG2, "mutt_hcache_delete_header %s\n", buf);
+        mutt_hcache_delete_header(hc, buf, strlen(buf));
       }
     }
     mutt_hcache_free(hc, &hdata);

--- a/nntp/nntp.c
+++ b/nntp/nntp.c
@@ -2039,12 +2039,12 @@ int nntp_post(struct Mailbox *m, const char *msg)
 
 /**
  * nntp_active_fetch - Fetch list of all newsgroups from server
- * @param adata NNTP server
- * @param new   Mark the groups as new
+ * @param adata    NNTP server
+ * @param mark_new Mark the groups as new
  * @retval  0 Success
  * @retval -1 Failure
  */
-int nntp_active_fetch(struct NntpAccountData *adata, bool new)
+int nntp_active_fetch(struct NntpAccountData *adata, bool mark_new)
 {
   struct NntpMboxData tmp_mdata;
   char msg[256];
@@ -2072,7 +2072,7 @@ int nntp_active_fetch(struct NntpAccountData *adata, bool new)
     return -1;
   }
 
-  if (new)
+  if (mark_new)
   {
     for (; i < adata->groups_num; i++)
     {

--- a/nntp/nntp.c
+++ b/nntp/nntp.c
@@ -1307,8 +1307,8 @@ static int nntp_fetch_headers(struct Mailbox *m, void *hc, anum_t first, anum_t 
 #ifdef USE_HCACHE
         if (fc.hc)
         {
-          mutt_debug(LL_DEBUG2, "mutt_hcache_delete %s\n", buf);
-          mutt_hcache_delete(fc.hc, buf, strlen(buf));
+          mutt_debug(LL_DEBUG2, "mutt_hcache_delete_header %s\n", buf);
+          mutt_hcache_delete_header(fc.hc, buf, strlen(buf));
         }
 #endif
       }

--- a/nntp/nntp.c
+++ b/nntp/nntp.c
@@ -2077,7 +2077,7 @@ int nntp_active_fetch(struct NntpAccountData *adata, bool new)
     for (; i < adata->groups_num; i++)
     {
       struct NntpMboxData *mdata = adata->groups_list[i];
-      mdata->new = true;
+      mdata->has_new_mail = true;
     }
   }
 
@@ -2184,7 +2184,7 @@ int nntp_check_new_groups(struct Mailbox *m, struct NntpAccountData *adata)
     for (; i < adata->groups_num; i++)
     {
       struct NntpMboxData *mdata = adata->groups_list[i];
-      mdata->new = true;
+      mdata->has_new_mail = true;
     }
 
     /* loading descriptions */

--- a/nntp/nntp.h
+++ b/nntp/nntp.h
@@ -173,7 +173,7 @@ void nntp_expand_path(char *buf, size_t buflen, struct ConnAccount *acct);
 void nntp_clear_cache(struct NntpAccountData *adata);
 const char *nntp_format_str(char *buf, size_t buflen, size_t col, int cols, char op, const char *src, const char *prec, const char *if_str, const char *else_str, unsigned long data, MuttFormatFlags flags);
 int nntp_compare_order(const void *a, const void *b);
-int nntp_path_probe(const char *path, const struct stat *st);
+enum MailboxType nntp_path_probe(const char *path, const struct stat *st);
 const char *group_index_format_str(char *buf, size_t buflen, size_t col, int cols, char op, const char *src, const char *prec, const char *if_str, const char *else_str, unsigned long data, MuttFormatFlags flags);
 int nntp_complete(char *buf, size_t buflen);
 

--- a/nntp/nntp.h
+++ b/nntp/nntp.h
@@ -161,7 +161,7 @@ struct NntpMboxData *mutt_newsgroup_subscribe(struct NntpAccountData *adata, cha
 struct NntpMboxData *mutt_newsgroup_unsubscribe(struct NntpAccountData *adata, char *group);
 struct NntpMboxData *mutt_newsgroup_catchup(struct Mailbox *m, struct NntpAccountData *adata, char *group);
 struct NntpMboxData *mutt_newsgroup_uncatchup(struct Mailbox *m, struct NntpAccountData *adata, char *group);
-int nntp_active_fetch(struct NntpAccountData *adata, bool new);
+int nntp_active_fetch(struct NntpAccountData *adata, bool mark_new);
 int nntp_newsrc_update(struct NntpAccountData *adata);
 int nntp_post(struct Mailbox *m, const char *msg);
 int nntp_check_msgid(struct Context *ctx, const char *msgid);

--- a/nntp/nntp.h
+++ b/nntp/nntp.h
@@ -145,10 +145,10 @@ struct NntpMboxData
   anum_t last_loaded;
   anum_t last_cached;
   anum_t unread;
-  bool subscribed : 1;
-  bool new        : 1;
-  bool allowed    : 1;
-  bool deleted    : 1;
+  bool subscribed   : 1;
+  bool has_new_mail : 1;
+  bool allowed      : 1;
+  bool deleted      : 1;
   unsigned int newsrc_len;
   struct NewsrcEntry *newsrc_ent;
   struct NntpAccountData *adata;

--- a/notmuch/mutt_notmuch.h
+++ b/notmuch/mutt_notmuch.h
@@ -71,7 +71,7 @@ void  nm_query_window_backward   (void);
 void  nm_query_window_forward    (void);
 int   nm_read_entire_thread      (struct Mailbox *m, struct Email *e);
 int   nm_record_message          (struct Mailbox *m, char *path, struct Email *e);
-int   nm_update_filename         (struct Mailbox *m, const char *old, const char *new, struct Email *e);
+int   nm_update_filename         (struct Mailbox *m, const char *old_file, const char *new_file, struct Email *e);
 char *nm_uri_from_query          (struct Mailbox *m, char *buf, size_t buflen);
 
 #endif /* MUTT_NOTMUCH_MUTT_NOTMUCH_H */

--- a/pager.c
+++ b/pager.c
@@ -2029,7 +2029,7 @@ static void pager_custom_redraw(struct Menu *pager_menu)
         rd->index->menu_make_entry = index_make_entry;
         rd->index->menu_color = index_color;
         rd->index->max = Context ? Context->mailbox->vcount : 0;
-        rd->index->current = rd->extra->email->virtual;
+        rd->index->current = rd->extra->email->vnum;
         rd->index->indexwin = rd->index_window;
         rd->index->statuswin = rd->index_status_window;
       }

--- a/pattern.c
+++ b/pattern.c
@@ -1395,7 +1395,7 @@ struct PatternHead *mutt_pattern_comp(const char *s, int flags, struct Buffer *e
   struct PatternHead *last = NULL;
   bool pat_not = false;
   bool alladdr = false;
-  bool or = false;
+  bool pat_or = false;
   bool implicit = true; /* used to detect logical AND operator */
   bool isalias = false;
   short thread_op;
@@ -1426,7 +1426,7 @@ struct PatternHead *mutt_pattern_comp(const char *s, int flags, struct Buffer *e
         isalias = !isalias;
         break;
       case '|':
-        if (! or)
+        if (!pat_or)
         {
           if (!curlist)
           {
@@ -1448,7 +1448,7 @@ struct PatternHead *mutt_pattern_comp(const char *s, int flags, struct Buffer *e
             last = curlist;
           }
 
-          or = true;
+          pat_or = true;
         }
         ps.dptr++;
         implicit = false;
@@ -1511,7 +1511,7 @@ struct PatternHead *mutt_pattern_comp(const char *s, int flags, struct Buffer *e
           ps.dptr = p + 1; /* restore location */
           break;
         }
-        if (implicit && or)
+        if (implicit && pat_or)
         {
           /* A | B & C == (A | B) & C */
           tmp = mutt_pattern_node_new();
@@ -1520,7 +1520,7 @@ struct PatternHead *mutt_pattern_comp(const char *s, int flags, struct Buffer *e
           pat->child = curlist;
           curlist = tmp;
           last = tmp;
-          or = false;
+          pat_or = false;
         }
 
         tmp = mutt_pattern_node_new();
@@ -1622,7 +1622,7 @@ struct PatternHead *mutt_pattern_comp(const char *s, int flags, struct Buffer *e
   {
     tmp = mutt_pattern_node_new();
     struct Pattern *pat = SLIST_FIRST(tmp);
-    pat->op = or ? MUTT_PAT_OR : MUTT_PAT_AND;
+    pat->op = pat_or ? MUTT_PAT_OR : MUTT_PAT_AND;
     pat->child = curlist;
     curlist = tmp;
   }

--- a/pattern.c
+++ b/pattern.c
@@ -179,7 +179,7 @@ struct PatternFlags
 {
   int tag;                ///< character used to represent this op
   int op;                 ///< operation to perform
-  int class;              ///< Pattern class, e.g. #MUTT_FULL_MSG
+  int flags;              ///< Pattern flags, e.g. #MUTT_FULL_MSG
   pattern_eat_t *eat_arg; ///< Callback function to parse the argument
 };
 
@@ -1549,7 +1549,7 @@ struct PatternHead *mutt_pattern_comp(const char *s, int flags, struct Buffer *e
           mutt_buffer_printf(err, _("%c: invalid pattern modifier"), *ps.dptr);
           goto cleanup;
         }
-        if (entry->class && ((flags & entry->class) == 0))
+        if (entry->flags && ((flags & entry->flags) == 0))
         {
           mutt_buffer_printf(err, _("%c: not supported in this mode"), *ps.dptr);
           goto cleanup;

--- a/pattern.c
+++ b/pattern.c
@@ -2388,7 +2388,7 @@ bool mutt_limit_current_thread(struct Email *e)
 
   for (int i = 0; i < Context->mailbox->msg_count; i++)
   {
-    Context->mailbox->emails[i]->virtual = -1;
+    Context->mailbox->emails[i]->vnum = -1;
     Context->mailbox->emails[i]->limited = false;
     Context->mailbox->emails[i]->collapsed = false;
     Context->mailbox->emails[i]->num_hidden = 0;
@@ -2397,7 +2397,7 @@ bool mutt_limit_current_thread(struct Email *e)
     {
       struct Body *body = Context->mailbox->emails[i]->content;
 
-      Context->mailbox->emails[i]->virtual = Context->mailbox->vcount;
+      Context->mailbox->emails[i]->vnum = Context->mailbox->vcount;
       Context->mailbox->emails[i]->limited = true;
       Context->mailbox->v2r[Context->mailbox->vcount] = i;
       Context->mailbox->vcount++;
@@ -2469,14 +2469,14 @@ int mutt_pattern_func(int op, char *prompt)
     {
       mutt_progress_update(&progress, i, -1);
       /* new limit pattern implicitly uncollapses all threads */
-      Context->mailbox->emails[i]->virtual = -1;
+      Context->mailbox->emails[i]->vnum = -1;
       Context->mailbox->emails[i]->limited = false;
       Context->mailbox->emails[i]->collapsed = false;
       Context->mailbox->emails[i]->num_hidden = 0;
       if (mutt_pattern_exec(SLIST_FIRST(pat), MUTT_MATCH_FULL_ADDRESS,
                             Context->mailbox, Context->mailbox->emails[i], NULL))
       {
-        Context->mailbox->emails[i]->virtual = Context->mailbox->vcount;
+        Context->mailbox->emails[i]->vnum = Context->mailbox->vcount;
         Context->mailbox->emails[i]->limited = true;
         Context->mailbox->v2r[Context->mailbox->vcount] = i;
         Context->mailbox->vcount++;

--- a/pattern.h
+++ b/pattern.h
@@ -47,7 +47,7 @@ extern bool C_ThoroughSearch;
 struct Pattern
 {
   short op;
-  bool not : 1;
+  bool pat_not : 1;
   bool alladdr : 1;
   bool stringmatch : 1;
   bool groupmatch : 1;

--- a/pop/pop.c
+++ b/pop/pop.c
@@ -979,7 +979,7 @@ static int pop_mbox_sync(struct Mailbox *m, int *index_hint)
         {
           mutt_bcache_del(adata->bcache, cache_id(edata->uid));
 #ifdef USE_HCACHE
-          mutt_hcache_delete(hc, edata->uid, strlen(edata->uid));
+          mutt_hcache_delete_header(hc, edata->uid, strlen(edata->uid));
 #endif
         }
       }

--- a/pop/pop.h
+++ b/pop/pop.h
@@ -56,6 +56,6 @@ extern unsigned char C_PopReconnect;
 extern struct MxOps MxPopOps;
 
 void pop_fetch_mail(void);
-int pop_path_probe(const char *path, const struct stat *st);
+enum MailboxType pop_path_probe(const char *path, const struct stat *st);
 
 #endif /* MUTT_POP_POP_H */

--- a/recvattach.c
+++ b/recvattach.c
@@ -1215,7 +1215,6 @@ void mutt_generate_recvattach_list(struct AttachCtx *actx, struct Email *e,
                                    struct Body *parts, FILE *fp,
                                    int parent_type, int level, bool decrypted)
 {
-  struct AttachPtr *new = NULL;
   struct Body *m = NULL;
   struct Body *new_body = NULL;
   FILE *fp_new = NULL;
@@ -1293,15 +1292,15 @@ void mutt_generate_recvattach_list(struct AttachCtx *actx, struct Email *e,
     }
     else
     {
-      new = mutt_mem_calloc(1, sizeof(struct AttachPtr));
-      mutt_actx_add_attach(actx, new);
+      struct AttachPtr *ap = mutt_mem_calloc(1, sizeof(struct AttachPtr));
+      mutt_actx_add_attach(actx, ap);
 
-      new->content = m;
-      new->fp = fp;
-      m->aptr = new;
-      new->parent_type = parent_type;
-      new->level = level;
-      new->decrypted = decrypted;
+      ap->content = m;
+      ap->fp = fp;
+      m->aptr = ap;
+      ap->parent_type = parent_type;
+      ap->level = level;
+      ap->decrypted = decrypted;
 
       if (m->type == TYPE_MULTIPART)
         mutt_generate_recvattach_list(actx, e, m->parts, fp, m->type, level + 1, decrypted);

--- a/sendlib.c
+++ b/sendlib.c
@@ -1705,21 +1705,21 @@ static bool check_boundary(const char *boundary, struct Body *b)
  */
 struct Body *mutt_make_multipart(struct Body *b)
 {
-  struct Body *new = mutt_body_new();
-  new->type = TYPE_MULTIPART;
-  new->subtype = mutt_str_strdup("mixed");
-  new->encoding = get_toplevel_encoding(b);
+  struct Body *new_body = mutt_body_new();
+  new_body->type = TYPE_MULTIPART;
+  new_body->subtype = mutt_str_strdup("mixed");
+  new_body->encoding = get_toplevel_encoding(b);
   do
   {
-    mutt_generate_boundary(&new->parameter);
-    if (check_boundary(mutt_param_get(&new->parameter, "boundary"), b))
-      mutt_param_delete(&new->parameter, "boundary");
-  } while (!mutt_param_get(&new->parameter, "boundary"));
-  new->use_disp = false;
-  new->disposition = DISP_INLINE;
-  new->parts = b;
+    mutt_generate_boundary(&new_body->parameter);
+    if (check_boundary(mutt_param_get(&new_body->parameter, "boundary"), b))
+      mutt_param_delete(&new_body->parameter, "boundary");
+  } while (!mutt_param_get(&new_body->parameter, "boundary"));
+  new_body->use_disp = false;
+  new_body->disposition = DISP_INLINE;
+  new_body->parts = b;
 
-  return new;
+  return new_body;
 }
 
 /**

--- a/sort.c
+++ b/sort.c
@@ -431,9 +431,9 @@ void mutt_sort_headers(struct Context *ctx, bool init)
   for (int i = 0; i < ctx->mailbox->msg_count; i++)
   {
     struct Email *cur = ctx->mailbox->emails[i];
-    if ((cur->virtual != -1) || (cur->collapsed && (!ctx->pattern || cur->limited)))
+    if ((cur->vnum != -1) || (cur->collapsed && (!ctx->pattern || cur->limited)))
     {
-      cur->virtual = ctx->mailbox->vcount;
+      cur->vnum = ctx->mailbox->vcount;
       ctx->mailbox->v2r[ctx->mailbox->vcount] = i;
       ctx->mailbox->vcount++;
     }
@@ -454,7 +454,7 @@ void mutt_sort_headers(struct Context *ctx, bool init)
         mutt_collapse_thread(ctx, e);
       top = top->next;
     }
-    mutt_set_virtual(ctx);
+    mutt_set_vnum(ctx);
   }
 
   if (!ctx->mailbox->quiet)

--- a/test/config/regex.c
+++ b/test/config/regex.c
@@ -342,7 +342,7 @@ static bool test_native_set(struct ConfigSet *cs, struct Buffer *err)
     TEST_MSG("%s\n", err->data);
     goto tns_out;
   }
-  TEST_MSG("'%s', not flag set to %d\n", VarIlama->pattern, VarIlama->not);
+  TEST_MSG("'%s', not flag set to %d\n", VarIlama->pattern, VarIlama->pat_not);
 
   name = "Jackfruit";
   mutt_buffer_reset(err);

--- a/test/pattern/comp.c
+++ b/test/pattern/comp.c
@@ -98,7 +98,7 @@ static int canonical_pattern(char *s, struct PatternHead *pat, int indent)
   {
     p += sprintf(p, "{");
     p += sprintf(p, "%d,", e->op);
-    p += sprintf(p, "%d,", e->not);
+    p += sprintf(p, "%d,", e->pat_not);
     p += sprintf(p, "%d,", e->alladdr);
     p += sprintf(p, "%d,", e->stringmatch);
     p += sprintf(p, "%d,", e->groupmatch);
@@ -141,7 +141,7 @@ static int cmp_pattern(struct PatternHead *p1, struct PatternHead *p2)
 
     if (l->op != r->op)
       return 1;
-    if (l->not != r->not)
+    if (l->pat_not != r->pat_not)
       return 1;
     if (l->alladdr != r->alladdr)
       return 1;
@@ -269,7 +269,7 @@ void test_mutt_pattern_comp(void)
     struct PatternHead expected;
     SLIST_INIT(&expected);
     struct Pattern e = { .op = MUTT_PAT_SUBJECT,
-                         .not = false,
+                         .pat_not = false,
                          .alladdr = false,
                          .stringmatch = true,
                          .groupmatch = false,
@@ -315,7 +315,7 @@ void test_mutt_pattern_comp(void)
     struct PatternHead expected;
     SLIST_INIT(&expected);
     struct Pattern e = { .op = MUTT_PAT_SUBJECT,
-                         .not = true,
+                         .pat_not = true,
                          .alladdr = false,
                          .stringmatch = true,
                          .groupmatch = false,
@@ -363,7 +363,7 @@ void test_mutt_pattern_comp(void)
 
     struct Pattern e[3] = { /* root */
                             { .op = MUTT_PAT_AND,
-                              .not = false,
+                              .pat_not = false,
                               .alladdr = false,
                               .stringmatch = false,
                               .groupmatch = false,
@@ -375,7 +375,7 @@ void test_mutt_pattern_comp(void)
                               .p.str = NULL },
                             /* root->child */
                             { .op = MUTT_PAT_SUBJECT,
-                              .not = false,
+                              .pat_not = false,
                               .alladdr = false,
                               .stringmatch = true,
                               .groupmatch = false,
@@ -387,7 +387,7 @@ void test_mutt_pattern_comp(void)
                               .p.str = "foo" },
                             /* root->child->next */
                             { .op = MUTT_PAT_SUBJECT,
-                              .not = false,
+                              .pat_not = false,
                               .alladdr = false,
                               .stringmatch = true,
                               .groupmatch = false,
@@ -442,7 +442,7 @@ void test_mutt_pattern_comp(void)
 
     struct Pattern e[3] = { /* root */
                             { .op = MUTT_PAT_AND,
-                              .not = false,
+                              .pat_not = false,
                               .alladdr = false,
                               .stringmatch = false,
                               .groupmatch = false,
@@ -454,7 +454,7 @@ void test_mutt_pattern_comp(void)
                               .p.str = NULL },
                             /* root->child */
                             { .op = MUTT_PAT_SUBJECT,
-                              .not = false,
+                              .pat_not = false,
                               .alladdr = false,
                               .stringmatch = true,
                               .groupmatch = false,
@@ -466,7 +466,7 @@ void test_mutt_pattern_comp(void)
                               .p.str = "foo" },
                             /* root->child->next */
                             { .op = MUTT_PAT_SUBJECT,
-                              .not = false,
+                              .pat_not = false,
                               .alladdr = false,
                               .stringmatch = true,
                               .groupmatch = false,
@@ -521,7 +521,7 @@ void test_mutt_pattern_comp(void)
 
     struct Pattern e[3] = { /* root */
                             { .op = MUTT_PAT_AND,
-                              .not = true,
+                              .pat_not = true,
                               .alladdr = false,
                               .stringmatch = false,
                               .groupmatch = false,
@@ -533,7 +533,7 @@ void test_mutt_pattern_comp(void)
                               .p.str = NULL },
                             /* root->child */
                             { .op = MUTT_PAT_SUBJECT,
-                              .not = false,
+                              .pat_not = false,
                               .alladdr = false,
                               .stringmatch = true,
                               .groupmatch = false,
@@ -545,7 +545,7 @@ void test_mutt_pattern_comp(void)
                               .p.str = "foo" },
                             /* root->child->next */
                             { .op = MUTT_PAT_SUBJECT,
-                              .not = false,
+                              .pat_not = false,
                               .alladdr = false,
                               .stringmatch = true,
                               .groupmatch = false,
@@ -600,7 +600,7 @@ void test_mutt_pattern_comp(void)
 
     struct Pattern e[4] = { /* root */
                             { .op = MUTT_PAT_AND,
-                              .not = false,
+                              .pat_not = false,
                               .alladdr = false,
                               .stringmatch = false,
                               .groupmatch = false,
@@ -612,7 +612,7 @@ void test_mutt_pattern_comp(void)
                               .p.str = NULL },
                             /* root->child */
                             { .op = MUTT_PAT_SUBJECT,
-                              .not = false,
+                              .pat_not = false,
                               .alladdr = false,
                               .stringmatch = true,
                               .groupmatch = false,
@@ -624,7 +624,7 @@ void test_mutt_pattern_comp(void)
                               .p.str = "foo" },
                             /* root->child->next */
                             { .op = MUTT_PAT_SUBJECT,
-                              .not = false,
+                              .pat_not = false,
                               .alladdr = false,
                               .stringmatch = true,
                               .groupmatch = false,
@@ -636,7 +636,7 @@ void test_mutt_pattern_comp(void)
                               .p.str = "bar" },
                             /* root->child->next->next */
                             { .op = MUTT_PAT_SUBJECT,
-                              .not = false,
+                              .pat_not = false,
                               .alladdr = false,
                               .stringmatch = true,
                               .groupmatch = false,
@@ -691,7 +691,7 @@ void test_mutt_pattern_comp(void)
 
     struct Pattern e[5] = { /* root */
                             { .op = MUTT_PAT_AND,
-                              .not = false,
+                              .pat_not = false,
                               .alladdr = false,
                               .stringmatch = false,
                               .groupmatch = false,
@@ -703,7 +703,7 @@ void test_mutt_pattern_comp(void)
                               .p.str = NULL },
                             /* root->child */
                             { .op = MUTT_PAT_OR,
-                              .not = true,
+                              .pat_not = true,
                               .alladdr = false,
                               .stringmatch = false,
                               .groupmatch = false,
@@ -715,7 +715,7 @@ void test_mutt_pattern_comp(void)
                               .p.str = NULL },
                             /* root->child->child */
                             { .op = MUTT_PAT_SUBJECT,
-                              .not = false,
+                              .pat_not = false,
                               .alladdr = false,
                               .stringmatch = true,
                               .groupmatch = false,
@@ -727,7 +727,7 @@ void test_mutt_pattern_comp(void)
                               .p.str = "foo" },
                             /* root->child->child->next */
                             { .op = MUTT_PAT_SUBJECT,
-                              .not = false,
+                              .pat_not = false,
                               .alladdr = false,
                               .stringmatch = true,
                               .groupmatch = false,
@@ -739,7 +739,7 @@ void test_mutt_pattern_comp(void)
                               .p.str = "bar" },
                             /* root->child->next */
                             { .op = MUTT_PAT_SUBJECT,
-                              .not = false,
+                              .pat_not = false,
                               .alladdr = false,
                               .stringmatch = true,
                               .groupmatch = false,

--- a/test/thread/insert_message.c
+++ b/test/thread/insert_message.c
@@ -29,7 +29,7 @@
 
 void test_insert_message(void)
 {
-  // void insert_message(struct MuttThread **new, struct MuttThread *newparent, struct MuttThread *cur);
+  // void insert_message(struct MuttThread **tnew, struct MuttThread *newparent, struct MuttThread *cur);
 
   {
     struct MuttThread newparent = { 0 };
@@ -39,16 +39,16 @@ void test_insert_message(void)
   }
 
   {
-    struct MuttThread *new = NULL;
+    struct MuttThread *tnew = NULL;
     struct MuttThread cur = { 0 };
-    insert_message(&new, NULL, &cur);
-    TEST_CHECK_(1, "insert_message(&new, NULL, &cur)");
+    insert_message(&tnew, NULL, &cur);
+    TEST_CHECK_(1, "insert_message(&tnew, NULL, &cur)");
   }
 
   {
-    struct MuttThread *new = NULL;
+    struct MuttThread *tnew = NULL;
     struct MuttThread newparent = { 0 };
-    insert_message(&new, &newparent, NULL);
-    TEST_CHECK_(1, "insert_message(&new, &newparent, NULL)");
+    insert_message(&tnew, &newparent, NULL);
+    TEST_CHECK_(1, "insert_message(&tnew, &newparent, NULL)");
   }
 }


### PR DESCRIPTION
`try` is a keyword in c++
While this should not affect C code, it affects unfortunately the
tooling.

This specific instance triggers a "syntax error" in Cppcheck, so it
could hide other problems.

(Cppcheck version  1.86, code parsed with `--language=c --std=c99`)

Of course it is a bug in Cppcheck, but renaming the variable is the most
pragmatic approach, as the bug in Cppcheck does not manifest itself in
a simple program.

* **What does this PR do?**

Remove a reserved keyword from the c++ standard in order to use cppcheck.



Notice:

It might be beneficial for neomutt if a c++ compiler would be able to parse it, as it has better static analysis compared to a c compiler.
Unfortunately there are other reserved keywords, so it would be probably a long-term goal, if there is some interest in it (not the scope of this request or feature-branch).
This is also important for "public" library header files (in case neomutt wants to split some logic in a separate library), as otherwise possible c++ clients wouldn't be able to bind the library.