### PR TITLE
Avoid using reserved identifiers

### DIFF
--- a/mutt/queue.h
+++ b/mutt/queue.h
@@ -30,8 +30,8 @@
  * $FreeBSD: head/sys/sys/queue.h 314436 2017-02-28 23:42:47Z imp $
  */
 
-#ifndef _SYS_QUEUE_H_
-#define	_SYS_QUEUE_H_
+#ifndef SYS_QUEUE_H_
+#define SYS_QUEUE_H_
 
 /*
  * This file defines four types of data structures: singly-linked lists,
@@ -853,4 +853,4 @@ struct {								\
 		(head2)->tqh_last = &(head2)->tqh_first;		\
 } while (0)
 
-#endif /* !_SYS_QUEUE_H_ */
+#endif /* !SYS_QUEUE_H_ */

--- a/test/address/common.h
+++ b/test/address/common.h
@@ -20,8 +20,8 @@
  * this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _TEST_ADDRESS_COMMON_H
-#define _TEST_ADDRESS_COMMON_H
+#ifndef TEST_ADDRESS_COMMON_H
+#define TEST_ADDRESS_COMMON_H
 
 #define TEST_NO_MAIN
 #include "acutest.h"
@@ -39,4 +39,4 @@
     }                                                                          \
   } while (false)
 
-#endif /* _TEST_ADDRESS_COMMON_H */
+#endif /* TEST_ADDRESS_COMMON_H */

--- a/test/config/common.h
+++ b/test/config/common.h
@@ -20,8 +20,8 @@
  * this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _TEST_COMMON_H
-#define _TEST_COMMON_H
+#ifndef TEST_COMMON_H
+#define TEST_COMMON_H
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -45,4 +45,4 @@ int log_observer(struct NotifyCallback *nc);
 void set_list(const struct ConfigSet *cs);
 void cs_dump_set(const struct ConfigSet *cs);
 
-#endif /* _TEST_COMMON_H */
+#endif /* TEST_COMMON_H */

--- a/test/file/common.h
+++ b/test/file/common.h
@@ -20,8 +20,8 @@
  * this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _TEST_FILE_COMMON_H
-#define _TEST_FILE_COMMON_H
+#ifndef TEST_FILE_COMMON_H
+#define TEST_FILE_COMMON_H
 
 #include "acutest.h"
 #include "config.h"
@@ -37,4 +37,4 @@ size_t file_num_test_lines(void);
 #define SET_UP() (file_set_up(__func__))
 #define TEAR_DOWN(fp) (file_tear_down((fp), __func__))
 
-#endif /* _TEST_FILE_COMMON_H */
+#endif /* TEST_FILE_COMMON_H */

--- a/test/md5/common.h
+++ b/test/md5/common.h
@@ -20,8 +20,8 @@
  * this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _TEST_MD5_COMMON_H
-#define _TEST_MD5_COMMON_H
+#ifndef TEST_MD5_COMMON_H
+#define TEST_MD5_COMMON_H
 
 #define TEST_NO_MAIN
 #include "acutest.h"
@@ -35,4 +35,4 @@ struct Md5TestData
 
 extern const struct Md5TestData md5_test_data[];
 
-#endif /* _TEST_MD5_COMMON_H */
+#endif /* TEST_MD5_COMMON_H */

--- a/test/rfc2047/common.h
+++ b/test/rfc2047/common.h
@@ -20,8 +20,8 @@
  * this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _TEST_RFC2047_COMMON_H
-#define _TEST_RFC2047_COMMON_H
+#ifndef TEST_RFC2047_COMMON_H
+#define TEST_RFC2047_COMMON_H
 
 #define TEST_NO_MAIN
 #include "acutest.h"
@@ -38,4 +38,4 @@ struct Rfc2047TestData
 
 extern const struct Rfc2047TestData rfc2047_test_data[];
 
-#endif /* _TEST_RFC2047_COMMON_H */
+#endif /* TEST_RFC2047_COMMON_H */


### PR DESCRIPTION
Found with `clang -Wreserved-id-macro`
