### PR TITLE
add braces to all case blocks

### DIFF
--- a/addrbook.c
+++ b/addrbook.c
@@ -81,26 +81,36 @@ static const char *alias_format_str(char *buf, size_t buflen, size_t col, int co
   switch (op)
   {
     case 'a':
+    {
       mutt_format_s(buf, buflen, prec, alias->name);
       break;
+    }
     case 'f':
+    {
       snprintf(fmt, sizeof(fmt), "%%%ss", prec);
       snprintf(buf, buflen, fmt, alias->del ? "D" : " ");
       break;
+    }
     case 'n':
+    {
       snprintf(fmt, sizeof(fmt), "%%%sd", prec);
       snprintf(buf, buflen, fmt, alias->num + 1);
       break;
+    }
     case 'r':
+    {
       addr[0] = '\0';
       mutt_addrlist_write(addr, sizeof(addr), &alias->addr, true);
       snprintf(fmt, sizeof(fmt), "%%%ss", prec);
       snprintf(buf, buflen, fmt, addr);
       break;
+    }
     case 't':
+    {
       buf[0] = alias->tagged ? '*' : ' ';
       buf[1] = '\0';
       break;
+    }
   }
 
   return src;
@@ -267,6 +277,7 @@ new_aliases:
     {
       case OP_DELETE:
       case OP_UNDELETE:
+      {
         if (menu->tagprefix)
         {
           for (i = 0; i < menu->max; i++)
@@ -285,13 +296,18 @@ new_aliases:
           }
         }
         break;
+      }
       case OP_GENERIC_SELECT_ENTRY:
+      {
         t = menu->current;
         done = true;
         break;
+      }
       case OP_EXIT:
+      {
         done = true;
         break;
+      }
     }
   }
 

--- a/address/address.c
+++ b/address/address.c
@@ -470,6 +470,7 @@ int mutt_addrlist_parse(struct AddressList *al, const char *s)
     {
       case ';':
       case ',':
+      {
         if (phraselen != 0)
         {
           terminate_buffer(phrase, phraselen);
@@ -498,8 +499,10 @@ int mutt_addrlist_parse(struct AddressList *al, const char *s)
         commentlen = 0;
         s++;
         break;
+      }
 
       case '(':
+      {
         if ((commentlen != 0) && (commentlen < (sizeof(comment) - 1)))
           comment[commentlen++] = ' ';
         s = next_token(s, comment, &commentlen, sizeof(comment) - 1);
@@ -509,8 +512,10 @@ int mutt_addrlist_parse(struct AddressList *al, const char *s)
           return 0;
         }
         break;
+      }
 
       case '"':
+      {
         if ((phraselen != 0) && (phraselen < (sizeof(phrase) - 1)))
           phrase[phraselen++] = ' ';
         s = parse_quote(s + 1, phrase, &phraselen, sizeof(phrase) - 1);
@@ -520,6 +525,7 @@ int mutt_addrlist_parse(struct AddressList *al, const char *s)
           return 0;
         }
         break;
+      }
 
       case ':':
       {
@@ -554,6 +560,7 @@ int mutt_addrlist_parse(struct AddressList *al, const char *s)
       }
 
       default:
+      {
         if ((phraselen != 0) && (phraselen < (sizeof(phrase) - 1)) && ws_pending)
           phrase[phraselen++] = ' ';
         s = next_token(s, phrase, &phraselen, sizeof(phrase) - 1);
@@ -563,6 +570,7 @@ int mutt_addrlist_parse(struct AddressList *al, const char *s)
           return 0;
         }
         break;
+      }
     } // switch (*s)
 
     ws_pending = mutt_str_is_email_wsp(*s);

--- a/alias.c
+++ b/alias.c
@@ -404,10 +404,14 @@ retry_name:
     switch (mutt_yesorno(_("Warning: This alias name may not work.  Fix it?"), MUTT_YES))
     {
       case MUTT_YES:
+      {
         mutt_str_strfcpy(buf, fixed, sizeof(buf));
         goto retry_name;
+      }
       case MUTT_ABORT:
+      {
         return;
+      }
       default:; // do nothing
     }
   }

--- a/browser.c
+++ b/browser.c
@@ -282,15 +282,25 @@ static int browser_compare(const void *a, const void *b)
   switch (C_SortBrowser & SORT_MASK)
   {
     case SORT_COUNT:
+    {
       return browser_compare_count(a, b);
+    }
     case SORT_DATE:
+    {
       return browser_compare_date(a, b);
+    }
     case SORT_DESC:
+    {
       return browser_compare_desc(a, b);
+    }
     case SORT_SIZE:
+    {
       return browser_compare_size(a, b);
+    }
     case SORT_UNREAD:
+    {
       return browser_compare_count_new(a, b);
+    }
     case SORT_SUBJECT:
     default:
       return browser_compare_subject(a, b);
@@ -310,15 +320,21 @@ static void browser_sort(struct BrowserState *state)
   {
     /* Also called "I don't care"-sort-method. */
     case SORT_ORDER:
+    {
       return;
 #ifdef USE_NNTP
+    }
     case SORT_SIZE:
     case SORT_DATE:
+    {
       if (OptNews)
         return;
 #endif
+    }
     default:
+    {
       break;
+    }
   }
 
   qsort(state->entry, state->entrylen, sizeof(struct FolderFile), browser_compare);
@@ -379,12 +395,15 @@ static const char *folder_format_str(char *buf, size_t buflen, size_t col, int c
   switch (op)
   {
     case 'C':
+    {
       snprintf(fmt, sizeof(fmt), "%%%sd", prec);
       snprintf(buf, buflen, fmt, folder->num + 1);
       break;
+    }
 
     case 'd':
     case 'D':
+    {
       if (folder->ff->local)
       {
         bool do_locales = true;
@@ -417,6 +436,7 @@ static const char *folder_format_str(char *buf, size_t buflen, size_t col, int c
       else
         mutt_format_s(buf, buflen, prec, "");
       break;
+    }
 
     case 'f':
     {
@@ -476,6 +496,7 @@ static const char *folder_format_str(char *buf, size_t buflen, size_t col, int c
     }
 
     case 'g':
+    {
       if (folder->ff->local)
       {
         struct group *gr = getgrgid(folder->ff->gid);
@@ -490,6 +511,7 @@ static const char *folder_format_str(char *buf, size_t buflen, size_t col, int c
       else
         mutt_format_s(buf, buflen, prec, "");
       break;
+    }
 
     case 'i':
     {
@@ -513,6 +535,7 @@ static const char *folder_format_str(char *buf, size_t buflen, size_t col, int c
     }
 
     case 'l':
+    {
       if (folder->ff->local)
       {
         snprintf(fmt, sizeof(fmt), "%%%sd", prec);
@@ -521,8 +544,10 @@ static const char *folder_format_str(char *buf, size_t buflen, size_t col, int c
       else
         mutt_format_s(buf, buflen, prec, "");
       break;
+    }
 
     case 'm':
+    {
       if (!optional)
       {
         if (folder->ff->has_mailbox)
@@ -536,13 +561,17 @@ static const char *folder_format_str(char *buf, size_t buflen, size_t col, int c
       else if (folder->ff->msg_count == 0)
         optional = 0;
       break;
+    }
 
     case 'N':
+    {
       snprintf(fmt, sizeof(fmt), "%%%sc", prec);
       snprintf(buf, buflen, fmt, folder->ff->has_new_mail ? 'N' : ' ');
       break;
+    }
 
     case 'n':
+    {
       if (!optional)
       {
         if (folder->ff->has_mailbox)
@@ -556,8 +585,10 @@ static const char *folder_format_str(char *buf, size_t buflen, size_t col, int c
       else if (folder->ff->msg_unread == 0)
         optional = 0;
       break;
+    }
 
     case 's':
+    {
       if (folder->ff->local)
       {
         mutt_str_pretty_size(fn, sizeof(fn), folder->ff->size);
@@ -567,13 +598,17 @@ static const char *folder_format_str(char *buf, size_t buflen, size_t col, int c
       else
         mutt_format_s(buf, buflen, prec, "");
       break;
+    }
 
     case 't':
+    {
       snprintf(fmt, sizeof(fmt), "%%%sc", prec);
       snprintf(buf, buflen, fmt, folder->ff->tagged ? '*' : ' ');
       break;
+    }
 
     case 'u':
+    {
       if (folder->ff->local)
       {
         struct passwd *pw = getpwuid(folder->ff->uid);
@@ -588,11 +623,14 @@ static const char *folder_format_str(char *buf, size_t buflen, size_t col, int c
       else
         mutt_format_s(buf, buflen, prec, "");
       break;
+    }
 
     default:
+    {
       snprintf(fmt, sizeof(fmt), "%%%sc", prec);
       snprintf(buf, buflen, fmt, op);
       break;
+    }
   }
 
   if (optional)
@@ -864,16 +902,22 @@ static int examine_mailboxes(struct Menu *menu, struct BrowserState *state)
       {
         case MUTT_IMAP:
         case MUTT_POP:
+        {
           add_folder(menu, state, mutt_b2s(mailbox), np->mailbox->desc, NULL,
                      np->mailbox, NULL);
           continue;
+        }
         case MUTT_NOTMUCH:
         case MUTT_NNTP:
+        {
           add_folder(menu, state, mutt_b2s(np->mailbox->pathbuf),
                      np->mailbox->desc, NULL, np->mailbox, NULL);
           continue;
-        default: /* Continue */
+        }
+        default:
+        { /* Continue */
           break;
+        }
       }
 
       if (lstat(mutt_b2s(np->mailbox->pathbuf), &s) == -1)
@@ -1247,8 +1291,10 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
         case SORT_DESC:
         case SORT_SUBJECT:
         case SORT_ORDER:
+        {
           browser_track = true;
           break;
+        }
       }
 
       /* We use mutt_browser_select_dir to initialize the two
@@ -1278,14 +1324,18 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
             case MUTT_MBOX:
             case MUTT_MH:
             case MUTT_MMDF:
+            {
               if (C_Folder)
                 mutt_buffer_strcpy(LastDir, C_Folder);
               else if (C_Spoolfile)
                 mutt_browser_select_dir(C_Spoolfile);
               break;
+            }
             default:
+            {
               mutt_browser_select_dir(CurrentFolder);
               break;
+            }
           }
         }
         else if (mutt_str_strcmp(CurrentFolder, mutt_b2s(LastDirBackup)) != 0)
@@ -1357,7 +1407,7 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
     {
       case OP_DESCEND_DIRECTORY:
       case OP_GENERIC_SELECT_ENTRY:
-
+      {
         if (state.entrylen == 0)
         {
           mutt_error(_("No files match the file mask"));
@@ -1516,9 +1566,9 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
           mutt_buffer_concat_path(file, mutt_b2s(LastDir),
                                   state.entry[menu->current].name);
         /* fallthrough */
-
+      }
       case OP_EXIT:
-
+      {
         if (multiple)
         {
           char **tfiles = NULL;
@@ -1551,20 +1601,25 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
 
         destroy_state(&state);
         goto bail;
-
+      }
       case OP_BROWSER_TELL:
+      {
         if (state.entrylen)
           mutt_message("%s", state.entry[menu->current].name);
         break;
+      }
 
 #ifdef USE_IMAP
       case OP_BROWSER_TOGGLE_LSUB:
+      {
         bool_str_toggle(Config, "imap_list_subscribed", NULL);
 
         mutt_unget_event(0, OP_CHECK_NEW);
         break;
+      }
 
       case OP_CREATE_MAILBOX:
+      {
         if (!state.imap_browse)
         {
           mutt_error(_("Create is only supported for IMAP mailboxes"));
@@ -1586,8 +1641,10 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
         }
         /* else leave error on screen */
         break;
+      }
 
       case OP_RENAME_MAILBOX:
+      {
         if (!state.entry[menu->current].imap)
           mutt_error(_("Rename is only supported for IMAP mailboxes"));
         else
@@ -1607,8 +1664,10 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
           }
         }
         break;
+      }
 
       case OP_DELETE_MAILBOX:
+      {
         if (!state.entry[menu->current].imap)
           mutt_error(_("Delete is only supported for IMAP mailboxes"));
         else
@@ -1653,11 +1712,12 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
             mutt_message(_("Mailbox not deleted"));
         }
         break;
+      }
 #endif
 
       case OP_GOTO_PARENT:
       case OP_CHANGE_DIRECTORY:
-
+      {
 #ifdef USE_NNTP
         if (OptNews)
           break;
@@ -1746,6 +1806,7 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
           }
         }
         break;
+      }
 
       case OP_ENTER_MASK:
       {
@@ -1820,38 +1881,54 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
             /* L10N: These must match the highlighted letters from "Sort" and "Reverse Sort" */
             _("dazecwn")))
         {
-          case -1: /* abort */
+          case -1:
+          { /* abort */
             resort = false;
             break;
+          }
 
-          case 1: /* (d)ate */
+          case 1:
+          { /* (d)ate */
             sort = SORT_DATE;
             break;
+          }
 
-          case 2: /* (a)lpha */
+          case 2:
+          { /* (a)lpha */
             sort = SORT_SUBJECT;
             break;
+          }
 
-          case 3: /* si(z)e */
+          case 3:
+          { /* si(z)e */
             sort = SORT_SIZE;
             break;
+          }
 
-          case 4: /* d(e)scription */
+          case 4:
+          { /* d(e)scription */
             sort = SORT_DESC;
             break;
+          }
 
-          case 5: /* (c)ount */
+          case 5:
+          { /* (c)ount */
             sort = SORT_COUNT;
             break;
+          }
 
-          case 6: /* ne(w) count */
+          case 6:
+          { /* ne(w) count */
             sort = SORT_UNREAD;
             break;
+          }
 
-          case 7: /* do(n)'t sort */
+          case 7:
+          { /* do(n)'t sort */
             sort = SORT_ORDER;
             resort = false;
             break;
+          }
         }
         if (resort)
         {
@@ -1871,6 +1948,7 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
       case OP_TOGGLE_MAILBOXES:
       case OP_BROWSER_GOTO_FOLDER:
       case OP_CHECK_NEW:
+      {
         if (op == OP_TOGGLE_MAILBOXES)
           mailbox = !mailbox;
 
@@ -1921,12 +1999,16 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
           goto bail;
         init_menu(&state, menu, title, sizeof(title), mailbox);
         break;
+      }
 
       case OP_MAILBOX_LIST:
+      {
         mutt_mailbox_list();
         break;
+      }
 
       case OP_BROWSER_NEW_FILE:
+      {
         mutt_buffer_printf(buf, "%s/", mutt_b2s(LastDir));
         /* buf comes from the buffer pool, so defaults to size 1024 */
         if (mutt_get_field(_("New file name: "), buf->data, buf->dsize, MUTT_FILE) == 0)
@@ -1936,8 +2018,10 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
           goto bail;
         }
         break;
+      }
 
       case OP_BROWSER_VIEW_FILE:
+      {
         if (state.entrylen == 0)
         {
           mutt_error(_("No files match the file mask"));
@@ -1977,10 +2061,12 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
             mutt_error(_("Error trying to view file"));
         }
         break;
+      }
 
 #ifdef USE_NNTP
       case OP_CATCHUP:
       case OP_UNCATCHUP:
+      {
         if (OptNews)
         {
           struct FolderFile *ff = &state.entry[menu->current];
@@ -2007,8 +2093,10 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
           nntp_newsrc_close(CurrentNewsSrv);
         }
         break;
+      }
 
       case OP_LOAD_ACTIVE:
+      {
         if (OptNews)
         {
           struct NntpAccountData *adata = CurrentNewsSrv;
@@ -2037,6 +2125,7 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
           init_menu(&state, menu, title, sizeof(title), mailbox);
         }
         break;
+      }
 #endif /* USE_NNTP */
 
 #if defined(USE_IMAP) || defined(USE_NNTP)

--- a/color.c
+++ b/color.c
@@ -253,13 +253,15 @@ static char *get_color_name(char *dest, size_t destlen, uint32_t val)
   switch (val)
   {
     case COLOR_YELLOW:
+    {
       mutt_str_strfcpy(dest, missing[0], destlen);
       return dest;
-
+    }
     case COLOR_WHITE:
+    {
       mutt_str_strfcpy(dest, missing[1], destlen);
       return dest;
-
+    }
     case COLOR_DEFAULT:
       mutt_str_strfcpy(dest, missing[2], destlen);
       return dest;

--- a/commands.c
+++ b/commands.c
@@ -731,52 +731,75 @@ int mutt_select_sort(bool reverse)
                             /* L10N: These must match the highlighted letters from "Sort" and "Rev-Sort" */
                             _("dfrsotuzcpl")))
   {
-    case -1: /* abort - don't resort */
+    case -1:
+    { /* abort - don't resort */
       return -1;
-
-    case 1: /* (d)ate */
+    }
+    case 1:
+    { /* (d)ate */
       new_sort = SORT_DATE;
       break;
+    }
 
-    case 2: /* (f)rm */
+    case 2:
+    { /* (f)rm */
       new_sort = SORT_FROM;
       break;
+    }
 
-    case 3: /* (r)ecv */
+    case 3:
+    { /* (r)ecv */
       new_sort = SORT_RECEIVED;
       break;
+    }
 
-    case 4: /* (s)ubj */
+    case 4:
+    { /* (s)ubj */
       new_sort = SORT_SUBJECT;
       break;
+    }
 
-    case 5: /* t(o) */
+    case 5:
+    { /* t(o) */
       new_sort = SORT_TO;
       break;
+    }
 
-    case 6: /* (t)hread */
+    case 6:
+    { /* (t)hread */
       new_sort = SORT_THREADS;
       break;
+    }
 
-    case 7: /* (u)nsort */
+    case 7:
+    { /* (u)nsort */
       new_sort = SORT_ORDER;
       break;
+    }
 
-    case 8: /* si(z)e */
+    case 8:
+    { /* si(z)e */
       new_sort = SORT_SIZE;
       break;
+    }
 
-    case 9: /* s(c)ore */
+    case 9:
+    { /* s(c)ore */
       new_sort = SORT_SCORE;
       break;
+    }
 
-    case 10: /* s(p)am */
+    case 10:
+    { /* s(p)am */
       new_sort = SORT_SPAM;
       break;
+    }
 
-    case 11: /* (l)abel */
+    case 11:
+    { /* (l)abel */
       new_sort = SORT_LABEL;
       break;
+    }
   }
   if (reverse)
     new_sort |= SORT_REVERSE;
@@ -1059,11 +1082,15 @@ int mutt_save_message(struct Mailbox *m, struct EmailList *el,
     {
       /* success */
       case 0:
+      {
         mutt_clear_error();
         return 0;
-      /* non-fatal error: continue to fetch/append */
+        /* non-fatal error: continue to fetch/append */
+      }
       case 1:
+      {
         break;
+      }
       /* fatal error, abort */
       case -1:
         return -1;

--- a/compose.c
+++ b/compose.c
@@ -781,14 +781,20 @@ static unsigned long cum_attachs_size(struct Menu *menu)
       switch (b->encoding)
       {
         case ENC_QUOTED_PRINTABLE:
+        {
           s += 3 * (info->lobin + info->hibin) + info->ascii + info->crlf;
           break;
+        }
         case ENC_BASE64:
+        {
           s += (4 * (info->lobin + info->hibin + info->ascii + info->crlf)) / 3;
           break;
+        }
         default:
+        {
           s += info->lobin + info->hibin + info->ascii + info->crlf;
           break;
+        }
       }
     }
   }
@@ -818,33 +824,44 @@ static const char *compose_format_str(char *buf, size_t buflen, size_t col, int 
   *buf = '\0';
   switch (op)
   {
-    case 'a': /* total number of attachments */
+    case 'a':
+    { /* total number of attachments */
       snprintf(fmt, sizeof(fmt), "%%%sd", prec);
       snprintf(buf, buflen, fmt, menu->max);
       break;
+    }
 
-    case 'h': /* hostname */
+    case 'h':
+    { /* hostname */
       snprintf(fmt, sizeof(fmt), "%%%ss", prec);
       snprintf(buf, buflen, fmt, NONULL(ShortHostname));
       break;
+    }
 
-    case 'l': /* approx length of current message in bytes */
+    case 'l':
+    { /* approx length of current message in bytes */
       snprintf(fmt, sizeof(fmt), "%%%ss", prec);
       mutt_str_pretty_size(tmp, sizeof(tmp), menu ? cum_attachs_size(menu) : 0);
       snprintf(buf, buflen, fmt, tmp);
       break;
+    }
 
     case 'v':
+    {
       snprintf(buf, buflen, "%s", mutt_make_version());
       break;
+    }
 
     case 0:
+    {
       *buf = '\0';
       return src;
-
+    }
     default:
+    {
       snprintf(buf, buflen, "%%%s%c", prec, op);
       break;
+    }
   }
 
   if (optional)
@@ -927,11 +944,14 @@ int mutt_compose_menu(struct Email *e, char *fcc, size_t fcclen, struct Email *e
     switch (op)
     {
       case OP_COMPOSE_EDIT_FROM:
+      {
         edit_address_list(HDR_FROM, &e->env->from);
         mutt_message_hook(NULL, e, MUTT_SEND2_HOOK);
         break;
+      }
 
       case OP_COMPOSE_EDIT_TO:
+      {
 #ifdef USE_NNTP
         if (news)
           break;
@@ -944,8 +964,10 @@ int mutt_compose_menu(struct Email *e, char *fcc, size_t fcclen, struct Email *e
         }
         mutt_message_hook(NULL, e, MUTT_SEND2_HOOK);
         break;
+      }
 
       case OP_COMPOSE_EDIT_BCC:
+      {
 #ifdef USE_NNTP
         if (news)
           break;
@@ -958,8 +980,10 @@ int mutt_compose_menu(struct Email *e, char *fcc, size_t fcclen, struct Email *e
         }
         mutt_message_hook(NULL, e, MUTT_SEND2_HOOK);
         break;
+      }
 
       case OP_COMPOSE_EDIT_CC:
+      {
 #ifdef USE_NNTP
         if (news)
           break;
@@ -972,8 +996,10 @@ int mutt_compose_menu(struct Email *e, char *fcc, size_t fcclen, struct Email *e
         }
         mutt_message_hook(NULL, e, MUTT_SEND2_HOOK);
         break;
+      }
 #ifdef USE_NNTP
       case OP_COMPOSE_EDIT_NEWSGROUPS:
+      {
         if (!news)
           break;
         if (e->env->newsgroups)
@@ -990,8 +1016,10 @@ int mutt_compose_menu(struct Email *e, char *fcc, size_t fcclen, struct Email *e
             clrtoeol();
         }
         break;
+      }
 
       case OP_COMPOSE_EDIT_FOLLOWUP_TO:
+      {
         if (!news)
           break;
         if (e->env->followup_to)
@@ -1008,8 +1036,10 @@ int mutt_compose_menu(struct Email *e, char *fcc, size_t fcclen, struct Email *e
             clrtoeol();
         }
         break;
+      }
 
       case OP_COMPOSE_EDIT_X_COMMENT_TO:
+      {
         if (!(news && C_XCommentTo))
           break;
         if (e->env->x_comment_to)
@@ -1026,9 +1056,11 @@ int mutt_compose_menu(struct Email *e, char *fcc, size_t fcclen, struct Email *e
             clrtoeol();
         }
         break;
+      }
 #endif
 
       case OP_COMPOSE_EDIT_SUBJECT:
+      {
         if (e->env->subject)
           mutt_str_strfcpy(buf, e->env->subject, sizeof(buf));
         else
@@ -1044,13 +1076,17 @@ int mutt_compose_menu(struct Email *e, char *fcc, size_t fcclen, struct Email *e
         }
         mutt_message_hook(NULL, e, MUTT_SEND2_HOOK);
         break;
+      }
 
       case OP_COMPOSE_EDIT_REPLY_TO:
+      {
         edit_address_list(HDR_REPLYTO, &e->env->reply_to);
         mutt_message_hook(NULL, e, MUTT_SEND2_HOOK);
         break;
+      }
 
       case OP_COMPOSE_EDIT_FCC:
+      {
         mutt_str_strfcpy(buf, fcc, sizeof(buf));
         if (mutt_get_field(_("Fcc: "), buf, sizeof(buf), MUTT_FILE | MUTT_CLEAR) == 0)
         {
@@ -1062,8 +1098,10 @@ int mutt_compose_menu(struct Email *e, char *fcc, size_t fcclen, struct Email *e
         }
         mutt_message_hook(NULL, e, MUTT_SEND2_HOOK);
         break;
+      }
 
       case OP_COMPOSE_EDIT_MESSAGE:
+      {
         if (C_Editor && (mutt_str_strcmp("builtin", C_Editor) != 0) && !C_EditHeaders)
         {
           mutt_edit_file(C_Editor, e->content->filename);
@@ -1073,8 +1111,9 @@ int mutt_compose_menu(struct Email *e, char *fcc, size_t fcclen, struct Email *e
           break;
         }
         /* fallthrough */
-
+      }
       case OP_COMPOSE_EDIT_HEADERS:
+      {
         if ((mutt_str_strcmp("builtin", C_Editor) != 0) &&
             ((op == OP_COMPOSE_EDIT_HEADERS) || ((op == OP_COMPOSE_EDIT_MESSAGE) && C_EditHeaders)))
         {
@@ -1110,6 +1149,7 @@ int mutt_compose_menu(struct Email *e, char *fcc, size_t fcclen, struct Email *e
         menu->redraw = REDRAW_FULL;
         mutt_message_hook(NULL, e, MUTT_SEND2_HOOK);
         break;
+      }
 
       case OP_COMPOSE_ATTACH_KEY:
       {
@@ -1132,6 +1172,7 @@ int mutt_compose_menu(struct Email *e, char *fcc, size_t fcclen, struct Email *e
       }
 
       case OP_COMPOSE_MOVE_UP:
+      {
         if (menu->current == 0)
         {
           mutt_error(_("Attachment is already at top"));
@@ -1146,8 +1187,10 @@ int mutt_compose_menu(struct Email *e, char *fcc, size_t fcclen, struct Email *e
         menu->redraw = REDRAW_INDEX;
         menu->current--;
         break;
+      }
 
       case OP_COMPOSE_MOVE_DOWN:
+      {
         if (menu->current == (actx->idxlen - 1))
         {
           mutt_error(_("Attachment is already at bottom"));
@@ -1162,6 +1205,7 @@ int mutt_compose_menu(struct Email *e, char *fcc, size_t fcclen, struct Email *e
         menu->redraw = REDRAW_INDEX;
         menu->current++;
         break;
+      }
 
       case OP_COMPOSE_GROUP_ALTS:
       {
@@ -1519,6 +1563,7 @@ int mutt_compose_menu(struct Email *e, char *fcc, size_t fcclen, struct Email *e
       }
 
       case OP_DELETE:
+      {
         CHECK_COUNT;
         if (CUR_ATTACH->unowned)
           CUR_ATTACH->content->unlink = false;
@@ -1530,6 +1575,7 @@ int mutt_compose_menu(struct Email *e, char *fcc, size_t fcclen, struct Email *e
 
         mutt_message_hook(NULL, e, MUTT_SEND2_HOOK);
         break;
+      }
 
       case OP_COMPOSE_TOGGLE_RECODE:
       {
@@ -1550,6 +1596,7 @@ int mutt_compose_menu(struct Email *e, char *fcc, size_t fcclen, struct Email *e
       }
 
       case OP_COMPOSE_EDIT_DESCRIPTION:
+      {
         CHECK_COUNT;
         mutt_str_strfcpy(
             buf, CUR_ATTACH->content->description ? CUR_ATTACH->content->description : "",
@@ -1562,8 +1609,10 @@ int mutt_compose_menu(struct Email *e, char *fcc, size_t fcclen, struct Email *e
         }
         mutt_message_hook(NULL, e, MUTT_SEND2_HOOK);
         break;
+      }
 
       case OP_COMPOSE_UPDATE_ENCODING:
+      {
         CHECK_COUNT;
         if (menu->tagprefix)
         {
@@ -1582,15 +1631,19 @@ int mutt_compose_menu(struct Email *e, char *fcc, size_t fcclen, struct Email *e
         }
         mutt_message_hook(NULL, e, MUTT_SEND2_HOOK);
         break;
+      }
 
       case OP_COMPOSE_TOGGLE_DISPOSITION:
+      {
         /* toggle the content-disposition between inline/attachment */
         CUR_ATTACH->content->disposition =
             (CUR_ATTACH->content->disposition == DISP_INLINE) ? DISP_ATTACH : DISP_INLINE;
         menu->redraw = REDRAW_CURRENT;
         break;
+      }
 
       case OP_EDIT_TYPE:
+      {
         CHECK_COUNT;
         {
           mutt_edit_content_type(NULL, CUR_ATTACH->content, NULL);
@@ -1602,8 +1655,10 @@ int mutt_compose_menu(struct Email *e, char *fcc, size_t fcclen, struct Email *e
         }
         mutt_message_hook(NULL, e, MUTT_SEND2_HOOK);
         break;
+      }
 
       case OP_COMPOSE_EDIT_LANGUAGE:
+      {
         CHECK_COUNT;
         buf[0] = '\0'; /* clear buffer first */
         if (CUR_ATTACH->content->language)
@@ -1618,8 +1673,10 @@ int mutt_compose_menu(struct Email *e, char *fcc, size_t fcclen, struct Email *e
           mutt_warning(_("Empty 'Content-Language'"));
         mutt_message_hook(NULL, e, MUTT_SEND2_HOOK);
         break;
+      }
 
       case OP_COMPOSE_EDIT_ENCODING:
+      {
         CHECK_COUNT;
         mutt_str_strfcpy(buf, ENCODING(CUR_ATTACH->content->encoding), sizeof(buf));
         if ((mutt_get_field("Content-Transfer-Encoding: ", buf, sizeof(buf), 0) == 0) &&
@@ -1637,8 +1694,10 @@ int mutt_compose_menu(struct Email *e, char *fcc, size_t fcclen, struct Email *e
         }
         mutt_message_hook(NULL, e, MUTT_SEND2_HOOK);
         break;
+      }
 
       case OP_COMPOSE_SEND_MESSAGE:
+      {
         /* Note: We don't invoke send2-hook here, since we want to leave
          * users an opportunity to change settings from the ":" prompt.  */
         if (check_attachments(actx) != 0)
@@ -1665,24 +1724,30 @@ int mutt_compose_menu(struct Email *e, char *fcc, size_t fcclen, struct Email *e
         loop = false;
         rc = 0;
         break;
+      }
 
       case OP_COMPOSE_EDIT_FILE:
+      {
         CHECK_COUNT;
         mutt_edit_file(NONULL(C_Editor), CUR_ATTACH->content->filename);
         mutt_update_encoding(CUR_ATTACH->content);
         menu->redraw = REDRAW_CURRENT | REDRAW_STATUS;
         mutt_message_hook(NULL, e, MUTT_SEND2_HOOK);
         break;
+      }
 
       case OP_COMPOSE_TOGGLE_UNLINK:
+      {
         CHECK_COUNT;
         CUR_ATTACH->content->unlink = !CUR_ATTACH->content->unlink;
 
         menu->redraw = REDRAW_INDEX;
         /* No send2hook since this doesn't change the message. */
         break;
+      }
 
       case OP_COMPOSE_GET_ATTACHMENT:
+      {
         CHECK_COUNT;
         if (menu->tagprefix)
         {
@@ -1698,6 +1763,7 @@ int mutt_compose_menu(struct Email *e, char *fcc, size_t fcclen, struct Email *e
 
         /* No send2hook since this doesn't change the message. */
         break;
+      }
 
       case OP_COMPOSE_RENAME_ATTACHMENT:
       {
@@ -1720,6 +1786,7 @@ int mutt_compose_menu(struct Email *e, char *fcc, size_t fcclen, struct Email *e
       }
 
       case OP_COMPOSE_RENAME_FILE:
+      {
         CHECK_COUNT;
         mutt_str_strfcpy(buf, CUR_ATTACH->content->filename, sizeof(buf));
         mutt_pretty_mailbox(buf, sizeof(buf));
@@ -1746,6 +1813,7 @@ int mutt_compose_menu(struct Email *e, char *fcc, size_t fcclen, struct Email *e
         }
         mutt_message_hook(NULL, e, MUTT_SEND2_HOOK);
         break;
+      }
 
       case OP_COMPOSE_NEW_MIME:
       {
@@ -1814,6 +1882,7 @@ int mutt_compose_menu(struct Email *e, char *fcc, size_t fcclen, struct Email *e
       }
 
       case OP_COMPOSE_EDIT_MIME:
+      {
         CHECK_COUNT;
         if (mutt_edit_attachment(CUR_ATTACH->content))
         {
@@ -1822,30 +1891,38 @@ int mutt_compose_menu(struct Email *e, char *fcc, size_t fcclen, struct Email *e
         }
         mutt_message_hook(NULL, e, MUTT_SEND2_HOOK);
         break;
+      }
 
       case OP_VIEW_ATTACH:
       case OP_DISPLAY_HEADERS:
+      {
         CHECK_COUNT;
         mutt_attach_display_loop(menu, op, NULL, actx, false);
         menu->redraw = REDRAW_FULL;
         /* no send2hook, since this doesn't modify the message */
         break;
+      }
 
       case OP_SAVE:
+      {
         CHECK_COUNT;
         mutt_save_attachment_list(actx, NULL, menu->tagprefix,
                                   CUR_ATTACH->content, NULL, menu);
         /* no send2hook, since this doesn't modify the message */
         break;
+      }
 
       case OP_PRINT:
+      {
         CHECK_COUNT;
         mutt_print_attachment_list(actx, NULL, menu->tagprefix, CUR_ATTACH->content);
         /* no send2hook, since this doesn't modify the message */
         break;
+      }
 
       case OP_PIPE:
       case OP_FILTER:
+      {
         CHECK_COUNT;
         mutt_pipe_attachment_list(actx, NULL, menu->tagprefix,
                                   CUR_ATTACH->content, (op == OP_FILTER));
@@ -1854,6 +1931,7 @@ int mutt_compose_menu(struct Email *e, char *fcc, size_t fcclen, struct Email *e
         menu->redraw |= REDRAW_STATUS;
         mutt_message_hook(NULL, e, MUTT_SEND2_HOOK);
         break;
+      }
 
       case OP_EXIT:
       {
@@ -1885,6 +1963,7 @@ int mutt_compose_menu(struct Email *e, char *fcc, size_t fcclen, struct Email *e
         /* fallthrough */
 
       case OP_COMPOSE_POSTPONE_MESSAGE:
+      {
         if (check_attachments(actx) != 0)
         {
           menu->redraw = REDRAW_FULL;
@@ -1894,8 +1973,10 @@ int mutt_compose_menu(struct Email *e, char *fcc, size_t fcclen, struct Email *e
         loop = false;
         rc = 1;
         break;
+      }
 
       case OP_COMPOSE_ISPELL:
+      {
         endwin();
         snprintf(buf, sizeof(buf), "%s -x %s", NONULL(C_Ispell), e->content->filename);
         if (mutt_system(buf) == -1)
@@ -1906,8 +1987,10 @@ int mutt_compose_menu(struct Email *e, char *fcc, size_t fcclen, struct Email *e
           menu->redraw |= REDRAW_STATUS;
         }
         break;
+      }
 
       case OP_COMPOSE_WRITE_MESSAGE:
+      {
         buf[0] = '\0';
         if (Context)
         {
@@ -1931,8 +2014,10 @@ int mutt_compose_menu(struct Email *e, char *fcc, size_t fcclen, struct Email *e
             mutt_message(_("Message written"));
         }
         break;
+      }
 
       case OP_COMPOSE_PGP_MENU:
+      {
         if (!(WithCrypto & APPLICATION_PGP))
           break;
         if (!crypt_has_module_backend(APPLICATION_PGP))
@@ -1960,12 +2045,16 @@ int mutt_compose_menu(struct Email *e, char *fcc, size_t fcclen, struct Email *e
         redraw_crypt_lines(e);
         mutt_message_hook(NULL, e, MUTT_SEND2_HOOK);
         break;
+      }
 
       case OP_FORGET_PASSPHRASE:
+      {
         crypt_forget_passphrase();
         break;
+      }
 
       case OP_COMPOSE_SMIME_MENU:
+      {
         if (!(WithCrypto & APPLICATION_SMIME))
           break;
         if (!crypt_has_module_backend(APPLICATION_SMIME))
@@ -1994,12 +2083,15 @@ int mutt_compose_menu(struct Email *e, char *fcc, size_t fcclen, struct Email *e
         redraw_crypt_lines(e);
         mutt_message_hook(NULL, e, MUTT_SEND2_HOOK);
         break;
+      }
 
 #ifdef MIXMASTER
       case OP_COMPOSE_MIX:
+      {
         mix_make_chain(&e->chain);
         mutt_message_hook(NULL, e, MUTT_SEND2_HOOK);
         break;
+      }
 #endif
     }
   }

--- a/compress.c
+++ b/compress.c
@@ -277,15 +277,19 @@ static const char *compress_format_str(char *buf, size_t buflen, size_t col, int
   switch (op)
   {
     case 'f':
+    {
       /* Compressed file */
       mutt_buffer_quote_filename(quoted, m->realpath, false);
       snprintf(buf, buflen, "%s", mutt_b2s(quoted));
       break;
+    }
     case 't':
+    {
       /* Plaintext, temporary file */
       mutt_buffer_quote_filename(quoted, mutt_b2s(m->pathbuf), false);
       snprintf(buf, buflen, "%s", mutt_b2s(quoted));
       break;
+    }
   }
 
   mutt_buffer_pool_release(&quoted);

--- a/config/dump.c
+++ b/config/dump.c
@@ -55,14 +55,20 @@ size_t escape_string(struct Buffer *buf, const char *src)
     switch (*src)
     {
       case '\n':
+      {
         len += mutt_buffer_addstr(buf, "\\n");
         break;
+      }
       case '\r':
+      {
         len += mutt_buffer_addstr(buf, "\\r");
         break;
+      }
       case '\t':
+      {
         len += mutt_buffer_addstr(buf, "\\t");
         break;
+      }
       default:
         if ((*src == '\\') || (*src == '"'))
           len += mutt_buffer_addch(buf, '\\');

--- a/config/sort.c
+++ b/config/sort.c
@@ -164,27 +164,41 @@ static int sort_string_set(const struct ConfigSet *cs, void *var, struct ConfigD
   switch (cdef->type & DT_SUBTYPE_MASK)
   {
     case DT_SORT_INDEX:
+    {
       id = mutt_map_get_value(value, SortMethods);
       break;
+    }
     case DT_SORT_ALIAS:
+    {
       id = mutt_map_get_value(value, SortAliasMethods);
       break;
+    }
     case DT_SORT_AUX:
+    {
       id = mutt_map_get_value(value, SortAuxMethods);
       break;
+    }
     case DT_SORT_BROWSER:
+    {
       id = mutt_map_get_value(value, SortBrowserMethods);
       break;
+    }
     case DT_SORT_KEYS:
+    {
       id = mutt_map_get_value(value, SortKeyMethods);
       break;
+    }
     case DT_SORT_SIDEBAR:
+    {
       id = mutt_map_get_value(value, SortSidebarMethods);
       break;
+    }
     default:
+    {
       mutt_debug(LL_DEBUG1, "Invalid sort type: %u\n", cdef->type & DT_SUBTYPE_MASK);
       return CSR_ERR_CODE;
       break;
+    }
   }
 
   if (id < 0)
@@ -246,27 +260,41 @@ static int sort_string_get(const struct ConfigSet *cs, void *var,
   switch (cdef->type & DT_SUBTYPE_MASK)
   {
     case DT_SORT_INDEX:
+    {
       str = mutt_map_get_name(sort, SortMethods);
       break;
+    }
     case DT_SORT_ALIAS:
+    {
       str = mutt_map_get_name(sort, SortAliasMethods);
       break;
+    }
     case DT_SORT_AUX:
+    {
       str = mutt_map_get_name(sort, SortAuxMethods);
       break;
+    }
     case DT_SORT_BROWSER:
+    {
       str = mutt_map_get_name(sort, SortBrowserMethods);
       break;
+    }
     case DT_SORT_KEYS:
+    {
       str = mutt_map_get_name(sort, SortKeyMethods);
       break;
+    }
     case DT_SORT_SIDEBAR:
+    {
       str = mutt_map_get_name(sort, SortSidebarMethods);
       break;
+    }
     default:
+    {
       mutt_debug(LL_DEBUG1, "Invalid sort type: %u\n", cdef->type & DT_SUBTYPE_MASK);
       return CSR_ERR_CODE;
       break;
+    }
   }
 
   if (!str)
@@ -294,27 +322,41 @@ static int sort_native_set(const struct ConfigSet *cs, void *var,
   switch (cdef->type & DT_SUBTYPE_MASK)
   {
     case DT_SORT_INDEX:
+    {
       str = mutt_map_get_name((value & SORT_MASK), SortMethods);
       break;
+    }
     case DT_SORT_ALIAS:
+    {
       str = mutt_map_get_name((value & SORT_MASK), SortAliasMethods);
       break;
+    }
     case DT_SORT_AUX:
+    {
       str = mutt_map_get_name((value & SORT_MASK), SortAuxMethods);
       break;
+    }
     case DT_SORT_BROWSER:
+    {
       str = mutt_map_get_name((value & SORT_MASK), SortBrowserMethods);
       break;
+    }
     case DT_SORT_KEYS:
+    {
       str = mutt_map_get_name((value & SORT_MASK), SortKeyMethods);
       break;
+    }
     case DT_SORT_SIDEBAR:
+    {
       str = mutt_map_get_name((value & SORT_MASK), SortSidebarMethods);
       break;
+    }
     default:
+    {
       mutt_debug(LL_DEBUG1, "Invalid sort type: %u\n", cdef->type & DT_SUBTYPE_MASK);
       return CSR_ERR_CODE;
       break;
+    }
   }
 
   if (!str)

--- a/conn/sasl.c
+++ b/conn/sasl.c
@@ -77,47 +77,63 @@ static int getnameinfo_err(int ret)
   switch (ret)
   {
     case EAI_AGAIN:
+    {
       mutt_debug(LL_DEBUG1,
                  "The name could not be resolved at this time.  Future "
                  "attempts may succeed\n");
       err = SASL_TRYAGAIN;
       break;
+    }
     case EAI_BADFLAGS:
+    {
       mutt_debug(LL_DEBUG1, "The flags had an invalid value\n");
       err = SASL_BADPARAM;
       break;
+    }
     case EAI_FAIL:
+    {
       mutt_debug(LL_DEBUG1, "A non-recoverable error occurred\n");
       err = SASL_FAIL;
       break;
+    }
     case EAI_FAMILY:
+    {
       mutt_debug(LL_DEBUG1,
                  "The address family was not recognized or the address "
                  "length was invalid for the specified family\n");
       err = SASL_BADPROT;
       break;
+    }
     case EAI_MEMORY:
+    {
       mutt_debug(LL_DEBUG1, "There was a memory allocation failure\n");
       err = SASL_NOMEM;
       break;
+    }
     case EAI_NONAME:
+    {
       mutt_debug(LL_DEBUG1,
                  "The name does not resolve for the supplied parameters.  "
                  "NI_NAMEREQD is set and the host's name can't be located, "
                  "or both nodename and servname were null.\n");
       err = SASL_FAIL; /* no real equivalent */
       break;
+    }
     case EAI_SYSTEM:
+    {
       mutt_debug(LL_DEBUG1,
                  "A system error occurred.  The error code can be found in "
                  "errno(%d,%s))\n",
                  errno, strerror(errno));
       err = SASL_FAIL; /* no real equivalent */
       break;
+    }
     default:
+    {
       mutt_debug(LL_DEBUG1, "Unknown error %d\n", ret);
       err = SASL_FAIL; /* no real equivalent */
       break;
+    }
   }
   return err;
 }
@@ -175,19 +191,27 @@ static int mutt_sasl_cb_log(void *context, int priority, const char *message)
   {
     case SASL_LOG_TRACE:
     case SASL_LOG_PASS:
+    {
       mutt_priority = 5;
       break;
+    }
     case SASL_LOG_DEBUG:
     case SASL_LOG_NOTE:
+    {
       mutt_priority = 3;
       break;
+    }
     case SASL_LOG_FAIL:
     case SASL_LOG_WARN:
+    {
       mutt_priority = 2;
       break;
+    }
     case SASL_LOG_ERR:
+    {
       mutt_priority = 1;
       break;
+    }
     default:
       mutt_debug(LL_DEBUG1, "SASL unknown log priority: %s\n", message);
       return SASL_OK;
@@ -548,18 +572,26 @@ int mutt_sasl_client_new(struct Connection *conn, sasl_conn_t **saslconn)
   switch (conn->account.type)
   {
     case MUTT_ACCT_TYPE_IMAP:
+    {
       service = "imap";
       break;
+    }
     case MUTT_ACCT_TYPE_POP:
+    {
       service = "pop";
       break;
+    }
     case MUTT_ACCT_TYPE_SMTP:
+    {
       service = "smtp";
       break;
+    }
 #ifdef USE_NNTP
     case MUTT_ACCT_TYPE_NNTP:
+    {
       service = "nntp";
       break;
+    }
 #endif
     default:
       mutt_error(_("Unknown SASL profile"));

--- a/conn/ssl.c
+++ b/conn/ssl.c
@@ -261,13 +261,19 @@ static void ssl_err(struct SslSockData *data, int err)
   switch (e)
   {
     case SSL_ERROR_NONE:
+    {
       return;
+    }
     case SSL_ERROR_ZERO_RETURN:
+    {
       data->isopen = 0;
       break;
+    }
     case SSL_ERROR_SYSCALL:
+    {
       data->isopen = 0;
       break;
+    }
   }
 
   const char *errmsg = NULL;
@@ -276,44 +282,64 @@ static void ssl_err(struct SslSockData *data, int err)
   switch (e)
   {
     case SSL_ERROR_SYSCALL:
+    {
       errmsg = "I/O error";
       break;
+    }
     case SSL_ERROR_WANT_ACCEPT:
+    {
       errmsg = "retry accept";
       break;
+    }
     case SSL_ERROR_WANT_CONNECT:
+    {
       errmsg = "retry connect";
       break;
+    }
     case SSL_ERROR_WANT_READ:
+    {
       errmsg = "retry read";
       break;
+    }
     case SSL_ERROR_WANT_WRITE:
+    {
       errmsg = "retry write";
       break;
+    }
     case SSL_ERROR_WANT_X509_LOOKUP:
+    {
       errmsg = "retry x509 lookup";
       break;
+    }
     case SSL_ERROR_ZERO_RETURN:
+    {
       errmsg = "SSL connection closed";
       break;
+    }
     case SSL_ERROR_SSL:
+    {
       sslerr = ERR_get_error();
       switch (sslerr)
       {
         case 0:
+        {
           switch (err)
           {
             case 0:
+            {
               errmsg = "EOF";
               break;
+            }
             default:
               errmsg = strerror(errno);
           }
           break;
+        }
         default:
           errmsg = ERR_error_string(sslerr, NULL);
       }
       break;
+    }
     default:
       errmsg = "unknown error";
   }
@@ -986,9 +1012,12 @@ static bool interactive_check_cert(X509 *cert, int idx, size_t len, SSL *ssl, bo
       case -1:         /* abort */
       case OP_MAX + 1: /* reject */
       case OP_EXIT:
+      {
         done = 1;
         break;
-      case OP_MAX + 3: /* accept always */
+      }
+      case OP_MAX + 3:
+      { /* accept always */
         if (!allow_always)
           break;
         done = 0;
@@ -1008,18 +1037,23 @@ static bool interactive_check_cert(X509 *cert, int idx, size_t len, SSL *ssl, bo
           mutt_message(_("Certificate saved"));
           mutt_sleep(0);
         }
-      /* fallthrough */
-      case OP_MAX + 2: /* accept once */
+        /* fallthrough */
+      }
+      case OP_MAX + 2:
+      { /* accept once */
         done = 2;
         SSL_set_ex_data(ssl, SkipModeExDataIndex, NULL);
         ssl_cache_trusted_cert(cert);
         break;
-      case OP_MAX + 4: /* skip */
+      }
+      case OP_MAX + 4:
+      { /* skip */
         if (!ALLOW_SKIP)
           break;
         done = 2;
         SSL_set_ex_data(ssl, SkipModeExDataIndex, &SkipModeExDataIndex);
         break;
+      }
     }
   }
   OptIgnoreMacroEvents = false;
@@ -1208,11 +1242,15 @@ static int ssl_negotiate(struct Connection *conn, struct SslSockData *ssldata)
     switch (SSL_get_error(ssldata->ssl, err))
     {
       case SSL_ERROR_SYSCALL:
+      {
         errmsg = _("I/O error");
         break;
+      }
       case SSL_ERROR_SSL:
+      {
         errmsg = ERR_error_string(ERR_get_error(), NULL);
         break;
+      }
       default:
         errmsg = _("unknown error");
     }

--- a/conn/ssl_gnutls.c
+++ b/conn/ssl_gnutls.c
@@ -685,9 +685,12 @@ static int tls_check_one_certificate(const gnutls_datum_t *certdata,
       case -1:         /* abort */
       case OP_MAX + 1: /* reject */
       case OP_EXIT:
+      {
         done = 1;
         break;
-      case OP_MAX + 3: /* accept always */
+      }
+      case OP_MAX + 3:
+      { /* accept always */
         done = 0;
         fp = mutt_file_fopen(C_CertificateFile, "a");
         if (fp)
@@ -725,10 +728,13 @@ static int tls_check_one_certificate(const gnutls_datum_t *certdata,
           mutt_message(_("Certificate saved"));
           mutt_sleep(0);
         }
-      /* fallthrough */
-      case OP_MAX + 2: /* accept once */
+        /* fallthrough */
+      }
+      case OP_MAX + 2:
+      { /* accept once */
         done = 2;
         break;
+      }
     }
   }
   OptIgnoreMacroEvents = false;

--- a/context.c
+++ b/context.c
@@ -264,22 +264,32 @@ void ctx_mailbox_changed(struct Mailbox *m, enum MailboxNotification action)
   switch (action)
   {
     case MBN_CLOSED:
+    {
       mutt_clear_threads(ctx);
       ctx_cleanup(ctx);
       break;
+    }
     case MBN_INVALID:
+    {
       ctx_update(ctx);
       break;
+    }
     case MBN_UPDATE:
+    {
       ctx_update_tables(ctx, true);
       break;
+    }
     case MBN_RESORT:
+    {
       mutt_sort_headers(ctx, true);
       break;
+    }
     case MBN_UNTAG:
+    {
       if (ctx->last_tag && ctx->last_tag->deleted)
         ctx->last_tag = NULL;
       break;
+    }
   }
 }
 

--- a/edit.c
+++ b/edit.c
@@ -438,24 +438,33 @@ int mutt_builtin_editor(const char *path, struct Email *e_new, struct Email *e_c
       switch (tmp[1])
       {
         case '?':
+        {
           addstr(_(EditorHelp1));
           addstr(_(EditorHelp2));
           break;
+        }
         case 'b':
+        {
           mutt_addrlist_parse2(&e_new->env->bcc, p);
           mutt_expand_aliases(&e_new->env->bcc);
           break;
+        }
         case 'c':
+        {
           mutt_addrlist_parse2(&e_new->env->cc, p);
           mutt_expand_aliases(&e_new->env->cc);
           break;
+        }
         case 'h':
+        {
           be_edit_header(e_new->env, true);
           break;
+        }
         case 'F':
         case 'f':
         case 'm':
         case 'M':
+        {
           if (Context)
           {
             if (!*p && e_cur)
@@ -471,7 +480,9 @@ int mutt_builtin_editor(const char *path, struct Email *e_new, struct Email *e_c
           else
             addstr(_("No mailbox.\n"));
           break;
+        }
         case 'p':
+        {
           addstr("-----\n");
           addstr(_("Message contains:\n"));
           be_print_header(e_new->env);
@@ -483,10 +494,14 @@ int mutt_builtin_editor(const char *path, struct Email *e_new, struct Email *e_c
              but means "(press any key to continue using neomutt)". */
           addstr(_("(continue)\n"));
           break;
+        }
         case 'q':
+        {
           done = true;
           break;
+        }
         case 'r':
+        {
           if (*p)
           {
             mutt_str_strfcpy(tmp, p, sizeof(tmp));
@@ -496,14 +511,20 @@ int mutt_builtin_editor(const char *path, struct Email *e_new, struct Email *e_c
           else
             addstr(_("missing filename.\n"));
           break;
+        }
         case 's':
+        {
           mutt_str_replace(&e_new->env->subject, p);
           break;
+        }
         case 't':
+        {
           mutt_addrlist_parse(&e_new->env->to, p);
           mutt_expand_aliases(&e_new->env->to);
           break;
+        }
         case 'u':
+        {
           if (buflen)
           {
             buflen--;
@@ -516,9 +537,11 @@ int mutt_builtin_editor(const char *path, struct Email *e_new, struct Email *e_c
           else
             addstr(_("No lines in message.\n"));
           break;
+        }
 
         case 'e':
         case 'v':
+        {
           if (be_barf_file(path, buf, buflen) == 0)
           {
             const char *tag = NULL;
@@ -545,16 +568,23 @@ int mutt_builtin_editor(const char *path, struct Email *e_new, struct Email *e_c
             addstr(_("(continue)\n"));
           }
           break;
+        }
         case 'w':
+        {
           be_barf_file((p[0] != '\0') ? p : path, buf, buflen);
           break;
+        }
         case 'x':
+        {
           abort = true;
           done = true;
           break;
+        }
         default:
+        {
           printw(_("%s: unknown editor command (~? for help)\n"), tmp);
           break;
+        }
       }
     }
     else if (mutt_str_strcmp(".", tmp) == 0)

--- a/email/parse.c
+++ b/email/parse.c
@@ -548,6 +548,7 @@ int mutt_rfc822_parse_line(struct Envelope *env, struct Email *e, char *line,
   switch (tolower(line[0]))
   {
     case 'a':
+    {
       if (mutt_str_strcasecmp(line + 1, "pparently-to") == 0)
       {
         mutt_addrlist_parse(&env->to, p);
@@ -559,16 +560,20 @@ int mutt_rfc822_parse_line(struct Envelope *env, struct Email *e, char *line,
         matched = true;
       }
       break;
+    }
 
     case 'b':
+    {
       if (mutt_str_strcasecmp(line + 1, "cc") == 0)
       {
         mutt_addrlist_parse(&env->bcc, p);
         matched = true;
       }
       break;
+    }
 
     case 'c':
+    {
       if (mutt_str_strcasecmp(line + 1, "c") == 0)
       {
         mutt_addrlist_parse(&env->cc, p);
@@ -627,8 +632,10 @@ int mutt_rfc822_parse_line(struct Envelope *env, struct Email *e, char *line,
         }
       }
       break;
+    }
 
     case 'd':
+    {
       if (mutt_str_strcasecmp("ate", line + 1) == 0)
       {
         mutt_str_replace(&env->date, p);
@@ -646,16 +653,20 @@ int mutt_rfc822_parse_line(struct Envelope *env, struct Email *e, char *line,
         matched = true;
       }
       break;
+    }
 
     case 'e':
+    {
       if ((mutt_str_strcasecmp("xpires", line + 1) == 0) && e &&
           (mutt_date_parse_date(p, NULL) < time(NULL)))
       {
         e->expired = true;
       }
       break;
+    }
 
     case 'f':
+    {
       if (mutt_str_strcasecmp("rom", line + 1) == 0)
       {
         mutt_addrlist_parse(&env->from, p);
@@ -673,8 +684,10 @@ int mutt_rfc822_parse_line(struct Envelope *env, struct Email *e, char *line,
       }
 #endif
       break;
+    }
 
     case 'i':
+    {
       if (mutt_str_strcasecmp(line + 1, "n-reply-to") == 0)
       {
         mutt_list_free(&env->in_reply_to);
@@ -682,8 +695,10 @@ int mutt_rfc822_parse_line(struct Envelope *env, struct Email *e, char *line,
         matched = true;
       }
       break;
+    }
 
     case 'l':
+    {
       if (mutt_str_strcasecmp(line + 1, "ines") == 0)
       {
         if (e)
@@ -724,8 +739,10 @@ int mutt_rfc822_parse_line(struct Envelope *env, struct Email *e, char *line,
         matched = true;
       }
       break;
+    }
 
     case 'm':
+    {
       if (mutt_str_strcasecmp(line + 1, "ime-version") == 0)
       {
         if (e)
@@ -759,9 +776,11 @@ int mutt_rfc822_parse_line(struct Envelope *env, struct Email *e, char *line,
         }
       }
       break;
+    }
 
 #ifdef USE_NNTP
     case 'n':
+    {
       if (mutt_str_strcasecmp(line + 1, "ewsgroups") == 0)
       {
         FREE(&env->newsgroups);
@@ -770,9 +789,11 @@ int mutt_rfc822_parse_line(struct Envelope *env, struct Email *e, char *line,
         matched = true;
       }
       break;
+    }
 #endif
 
     case 'o':
+    {
       /* field 'Organization:' saves only for pager! */
       if (mutt_str_strcasecmp(line + 1, "rganization") == 0)
       {
@@ -780,8 +801,10 @@ int mutt_rfc822_parse_line(struct Envelope *env, struct Email *e, char *line,
           env->organization = mutt_str_strdup(p);
       }
       break;
+    }
 
     case 'r':
+    {
       if (mutt_str_strcasecmp(line + 1, "eferences") == 0)
       {
         mutt_list_free(&env->references);
@@ -809,8 +832,10 @@ int mutt_rfc822_parse_line(struct Envelope *env, struct Email *e, char *line,
         }
       }
       break;
+    }
 
     case 's':
+    {
       if (mutt_str_strcasecmp(line + 1, "ubject") == 0)
       {
         if (!env->subject)
@@ -831,14 +856,20 @@ int mutt_rfc822_parse_line(struct Envelope *env, struct Email *e, char *line,
             switch (*p)
             {
               case 'O':
+              {
                 e->old = C_MarkOld;
                 break;
+              }
               case 'R':
+              {
                 e->read = true;
                 break;
+              }
               case 'r':
+              {
                 e->replied = true;
                 break;
+              }
             }
             p++;
           }
@@ -853,16 +884,20 @@ int mutt_rfc822_parse_line(struct Envelope *env, struct Email *e, char *line,
         env->supersedes = mutt_str_strdup(p);
       }
       break;
+    }
 
     case 't':
+    {
       if (mutt_str_strcasecmp(line + 1, "o") == 0)
       {
         mutt_addrlist_parse(&env->to, p);
         matched = true;
       }
       break;
+    }
 
     case 'x':
+    {
       if (mutt_str_strcasecmp(line + 1, "-status") == 0)
       {
         if (e)
@@ -872,16 +907,24 @@ int mutt_rfc822_parse_line(struct Envelope *env, struct Email *e, char *line,
             switch (*p)
             {
               case 'A':
+              {
                 e->replied = true;
                 break;
+              }
               case 'D':
+              {
                 e->deleted = true;
                 break;
+              }
               case 'F':
+              {
                 e->flagged = true;
                 break;
+              }
               default:
+              {
                 break;
+              }
             }
             p++;
           }
@@ -913,9 +956,11 @@ int mutt_rfc822_parse_line(struct Envelope *env, struct Email *e, char *line,
         mutt_addrlist_parse(&env->x_original_to, p);
         matched = true;
       }
-
+    }
     default:
+    {
       break;
+    }
   }
 
   /* Keep track of the user-defined headers */
@@ -1292,6 +1337,7 @@ void mutt_parse_part(FILE *fp, struct Body *b)
   switch (b->type)
   {
     case TYPE_MULTIPART:
+    {
 #ifdef SUN_ATTACHMENT
       if (mutt_str_strcasecmp(b->subtype, "x-sun-attachment") == 0)
         bound = "--------";
@@ -1303,8 +1349,10 @@ void mutt_parse_part(FILE *fp, struct Body *b)
       b->parts = mutt_parse_multipart(fp, bound, b->offset + b->length,
                                       (mutt_str_strcasecmp("digest", b->subtype) == 0));
       break;
+    }
 
     case TYPE_MESSAGE:
+    {
       if (b->subtype)
       {
         fseeko(fp, b->offset, SEEK_SET);
@@ -1316,6 +1364,7 @@ void mutt_parse_part(FILE *fp, struct Body *b)
           return;
       }
       break;
+    }
 
     default:
       return;

--- a/enriched.c
+++ b/enriched.c
@@ -507,13 +507,17 @@ int text_enriched_handler(struct Body *a, struct State *s)
     switch (state)
     {
       case TEXT:
+      {
         switch (wc)
         {
           case '<':
+          {
             state = LANGLE;
             break;
+          }
 
           case '\n':
+          {
             if (stte.tag_level[RICH_NOFILL])
             {
               enriched_flush(&stte, true);
@@ -524,13 +528,16 @@ int text_enriched_handler(struct Body *a, struct State *s)
               state = NEWLINE;
             }
             break;
+          }
 
           default:
             enriched_putwc(wc, &stte);
         }
         break;
+      }
 
       case LANGLE:
+      {
         if (wc == (wchar_t) '<')
         {
           enriched_putwc(wc, &stte);
@@ -542,9 +549,11 @@ int text_enriched_handler(struct Body *a, struct State *s)
           tag_len = 0;
           state = TAG;
         }
-      /* Yes, (it wasn't a <<, so this char is first in TAG) */
-      /* fallthrough */
+        /* Yes, (it wasn't a <<, so this char is first in TAG) */
+        /* fallthrough */
+      }
       case TAG:
+      {
         if (wc == (wchar_t) '>')
         {
           tag[tag_len] = (wchar_t) '\0';
@@ -556,13 +565,17 @@ int text_enriched_handler(struct Body *a, struct State *s)
         else
           state = BOGUS_TAG;
         break;
+      }
 
       case BOGUS_TAG:
+      {
         if (wc == (wchar_t) '>')
           state = TEXT;
         break;
+      }
 
       case NEWLINE:
+      {
         if (wc == (wchar_t) '\n')
           enriched_flush(&stte, true);
         else
@@ -572,16 +585,21 @@ int text_enriched_handler(struct Body *a, struct State *s)
           state = TEXT;
         }
         break;
+      }
 
       case ST_EOF:
+      {
         enriched_putwc((wchar_t) '\0', &stte);
         enriched_flush(&stte, true);
         state = DONE;
         break;
+      }
 
       case DONE:
+      {
         /* not reached */
         break;
+      }
     }
   }
 

--- a/enter.c
+++ b/enter.c
@@ -270,6 +270,7 @@ int mutt_enter_string_full(char *buf, size_t buflen, int col,
       switch (ch)
       {
         case OP_EDITOR_HISTORY_UP:
+        {
           state->curpos = state->lastchar;
           if (mutt_hist_at_scratch(hclass))
           {
@@ -279,8 +280,10 @@ int mutt_enter_string_full(char *buf, size_t buflen, int col,
           replace_part(state, 0, mutt_hist_prev(hclass));
           redraw = MUTT_REDRAW_INIT;
           break;
+        }
 
         case OP_EDITOR_HISTORY_DOWN:
+        {
           state->curpos = state->lastchar;
           if (mutt_hist_at_scratch(hclass))
           {
@@ -290,8 +293,10 @@ int mutt_enter_string_full(char *buf, size_t buflen, int col,
           replace_part(state, 0, mutt_hist_next(hclass));
           redraw = MUTT_REDRAW_INIT;
           break;
+        }
 
         case OP_EDITOR_HISTORY_SEARCH:
+        {
           state->curpos = state->lastchar;
           mutt_mb_wcstombs(buf, buflen, state->wbuf, state->curpos);
           mutt_hist_complete(buf, buflen, hclass);
@@ -299,8 +304,10 @@ int mutt_enter_string_full(char *buf, size_t buflen, int col,
           rc = 1;
           goto bye;
           break;
+        }
 
         case OP_EDITOR_BACKSPACE:
+        {
           if (state->curpos == 0)
           {
             // Pressing backspace when no text is in the command prompt shold exit the prompt
@@ -322,25 +329,35 @@ int mutt_enter_string_full(char *buf, size_t buflen, int col,
             state->curpos = i;
           }
           break;
+        }
 
         case OP_EDITOR_BOL:
+        {
           state->curpos = 0;
           break;
+        }
 
         case OP_EDITOR_EOL:
+        {
           redraw = MUTT_REDRAW_INIT;
           break;
+        }
 
         case OP_EDITOR_KILL_LINE:
+        {
           state->curpos = 0;
           state->lastchar = 0;
           break;
+        }
 
         case OP_EDITOR_KILL_EOL:
+        {
           state->lastchar = state->curpos;
           break;
+        }
 
         case OP_EDITOR_BACKWARD_CHAR:
+        {
           if (state->curpos == 0)
             BEEP();
           else
@@ -351,8 +368,10 @@ int mutt_enter_string_full(char *buf, size_t buflen, int col,
               state->curpos--;
           }
           break;
+        }
 
         case OP_EDITOR_FORWARD_CHAR:
+        {
           if (state->curpos == state->lastchar)
             BEEP();
           else
@@ -365,8 +384,10 @@ int mutt_enter_string_full(char *buf, size_t buflen, int col,
             }
           }
           break;
+        }
 
         case OP_EDITOR_BACKWARD_WORD:
+        {
           if (state->curpos == 0)
             BEEP();
           else
@@ -377,8 +398,10 @@ int mutt_enter_string_full(char *buf, size_t buflen, int col,
               state->curpos--;
           }
           break;
+        }
 
         case OP_EDITOR_FORWARD_WORD:
+        {
           if (state->curpos == state->lastchar)
             BEEP();
           else
@@ -395,10 +418,12 @@ int mutt_enter_string_full(char *buf, size_t buflen, int col,
             }
           }
           break;
+        }
 
         case OP_EDITOR_CAPITALIZE_WORD:
         case OP_EDITOR_UPCASE_WORD:
         case OP_EDITOR_DOWNCASE_WORD:
+        {
           if (state->curpos == state->lastchar)
           {
             BEEP();
@@ -422,8 +447,10 @@ int mutt_enter_string_full(char *buf, size_t buflen, int col,
             state->curpos++;
           }
           break;
+        }
 
         case OP_EDITOR_DELETE_CHAR:
+        {
           if (state->curpos == state->lastchar)
             BEEP();
           else
@@ -440,8 +467,10 @@ int mutt_enter_string_full(char *buf, size_t buflen, int col,
             state->lastchar -= i - state->curpos;
           }
           break;
+        }
 
         case OP_EDITOR_KILL_WORD:
+        {
           /* delete to beginning of word */
           if (state->curpos != 0)
           {
@@ -464,6 +493,7 @@ int mutt_enter_string_full(char *buf, size_t buflen, int col,
             state->curpos = i;
           }
           break;
+        }
 
         case OP_EDITOR_KILL_EOW:
         {
@@ -498,6 +528,7 @@ int mutt_enter_string_full(char *buf, size_t buflen, int col,
         }
 
         case OP_EDITOR_MAILBOX_CYCLE:
+        {
           if (flags & MUTT_EFILE)
           {
             first = true; /* clear input if user types a real key later */
@@ -512,9 +543,10 @@ int mutt_enter_string_full(char *buf, size_t buflen, int col,
             goto self_insert;
           }
           /* fallthrough */
-
+        }
         case OP_EDITOR_COMPLETE:
         case OP_EDITOR_COMPLETE_QUERY:
+        {
           state->tabs++;
           if (flags & MUTT_CMD)
           {
@@ -696,6 +728,7 @@ int mutt_enter_string_full(char *buf, size_t buflen, int col,
           else
             goto self_insert;
           break;
+        }
 
         case OP_EDITOR_QUOTE_CHAR:
         {
@@ -713,6 +746,7 @@ int mutt_enter_string_full(char *buf, size_t buflen, int col,
         }
 
         case OP_EDITOR_TRANSPOSE_CHARS:
+        {
           if (state->lastchar < 2)
             BEEP();
           else
@@ -729,6 +763,7 @@ int mutt_enter_string_full(char *buf, size_t buflen, int col,
             state->wbuf[state->curpos - 1] = t;
           }
           break;
+        }
 
         default:
           BEEP();

--- a/flags.c
+++ b/flags.c
@@ -70,7 +70,7 @@ void mutt_set_flag_update(struct Mailbox *m, struct Email *e, int flag, bool bf,
   switch (flag)
   {
     case MUTT_DELETE:
-
+    {
       if (!(m->rights & MUTT_ACL_DELETE))
         return;
 
@@ -119,9 +119,10 @@ void mutt_set_flag_update(struct Mailbox *m, struct Email *e, int flag, bool bf,
           m->changed = true;
       }
       break;
+    }
 
     case MUTT_PURGE:
-
+    {
       if (!(m->rights & MUTT_ACL_DELETE))
         return;
 
@@ -133,9 +134,10 @@ void mutt_set_flag_update(struct Mailbox *m, struct Email *e, int flag, bool bf,
       else if (e->purge)
         e->purge = false;
       break;
+    }
 
     case MUTT_NEW:
-
+    {
       if (!(m->rights & MUTT_ACL_SEEN))
         return;
 
@@ -172,9 +174,10 @@ void mutt_set_flag_update(struct Mailbox *m, struct Email *e, int flag, bool bf,
           m->changed = true;
       }
       break;
+    }
 
     case MUTT_OLD:
-
+    {
       if (!(m->rights & MUTT_ACL_SEEN))
         return;
 
@@ -204,9 +207,10 @@ void mutt_set_flag_update(struct Mailbox *m, struct Email *e, int flag, bool bf,
           m->changed = true;
       }
       break;
+    }
 
     case MUTT_READ:
-
+    {
       if (!(m->rights & MUTT_ACL_SEEN))
         return;
 
@@ -240,9 +244,10 @@ void mutt_set_flag_update(struct Mailbox *m, struct Email *e, int flag, bool bf,
           m->changed = true;
       }
       break;
+    }
 
     case MUTT_REPLIED:
-
+    {
       if (!(m->rights & MUTT_ACL_WRITE))
         return;
 
@@ -275,9 +280,10 @@ void mutt_set_flag_update(struct Mailbox *m, struct Email *e, int flag, bool bf,
           m->changed = true;
       }
       break;
+    }
 
     case MUTT_FLAG:
-
+    {
       if (!(m->rights & MUTT_ACL_WRITE))
         return;
 
@@ -305,8 +311,10 @@ void mutt_set_flag_update(struct Mailbox *m, struct Email *e, int flag, bool bf,
           m->changed = true;
       }
       break;
+    }
 
     case MUTT_TAG:
+    {
       if (bf)
       {
         if (!e->tagged)
@@ -325,6 +333,7 @@ void mutt_set_flag_update(struct Mailbox *m, struct Email *e, int flag, bool bf,
           m->msg_tagged--;
       }
       break;
+    }
   }
 
   if (update)
@@ -461,34 +470,46 @@ int mutt_change_flag(struct Mailbox *m, struct EmailList *el, bool bf)
   {
     case 'd':
     case 'D':
+    {
       if (!bf)
         mutt_emails_set_flag(m, el, MUTT_PURGE, bf);
       flag = MUTT_DELETE;
       break;
+    }
 
     case 'N':
     case 'n':
+    {
       flag = MUTT_NEW;
       break;
+    }
 
     case 'o':
     case 'O':
+    {
       mutt_emails_set_flag(m, el, MUTT_READ, !bf);
       flag = MUTT_OLD;
       break;
+    }
 
     case 'r':
     case 'R':
+    {
       flag = MUTT_REPLIED;
       break;
+    }
 
     case '*':
+    {
       flag = MUTT_TAG;
       break;
+    }
 
     case '!':
+    {
       flag = MUTT_FLAG;
       break;
+    }
 
     default:
       BEEP();

--- a/handler.c
+++ b/handler.c
@@ -251,16 +251,22 @@ static void qp_decode_line(char *dest, char *src, size_t *l, int last)
     switch ((kind = qp_decode_triple(s, &c)))
     {
       case 0:
+      {
         *d++ = c;
         s += 3;
         break; /* qp triple */
+      }
       case -1:
+      {
         *d++ = *s++;
         break; /* single character */
+      }
       case 1:
+      {
         soft = true;
         s++;
         break; /* soft line break */
+      }
     }
   }
 
@@ -1806,29 +1812,37 @@ void mutt_decode_attachment(struct Body *b, struct State *s)
   switch (b->encoding)
   {
     case ENC_QUOTED_PRINTABLE:
+    {
       decode_quoted(s, b->length,
                     istext || (((WithCrypto & APPLICATION_PGP) != 0) &&
                                mutt_is_application_pgp(b)),
                     cd);
       break;
+    }
     case ENC_BASE64:
+    {
       mutt_decode_base64(s, b->length,
                          istext || (((WithCrypto & APPLICATION_PGP) != 0) &&
                                     mutt_is_application_pgp(b)),
                          cd);
       break;
+    }
     case ENC_UUENCODED:
+    {
       decode_uuencoded(s, b->length,
                        istext || (((WithCrypto & APPLICATION_PGP) != 0) &&
                                   mutt_is_application_pgp(b)),
                        cd);
       break;
+    }
     default:
+    {
       decode_xbit(s, b->length,
                   istext || (((WithCrypto & APPLICATION_PGP) != 0) &&
                              mutt_is_application_pgp(b)),
                   cd);
       break;
+    }
   }
 
   if (cd != (iconv_t)(-1))

--- a/hdrline.c
+++ b/hdrline.c
@@ -583,6 +583,7 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
   {
     case 'A':
     case 'I':
+    {
       if (op == 'A')
       {
         if (reply_to && reply_to->mailbox)
@@ -605,8 +606,9 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
         }
       }
       /* fallthrough */
-
+    }
     case 'a':
+    {
       colorlen = add_index_color(buf, buflen, flags, MT_COLOR_INDEX_AUTHOR);
       if (from && from->mailbox)
       {
@@ -616,9 +618,11 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
         mutt_format_s(buf + colorlen, buflen - colorlen, prec, "");
       add_index_color(buf + colorlen, buflen - colorlen, flags, MT_COLOR_INDEX);
       break;
+    }
 
     case 'B':
     case 'K':
+    {
       if (!first_mailing_list(buf, buflen, &e->env->to) &&
           !first_mailing_list(buf, buflen, &e->env->cc))
       {
@@ -639,8 +643,9 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
       }
       /* if 'B' returns nothing */
       /* fallthrough */
-
+    }
     case 'b':
+    {
       if (m)
       {
         p = strrchr(mutt_b2s(m->pathbuf), '/');
@@ -654,20 +659,25 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
       mutt_str_strfcpy(tmp, buf, sizeof(tmp));
       mutt_format_s(buf, buflen, prec, tmp);
       break;
+    }
 
     case 'c':
+    {
       colorlen = add_index_color(buf, buflen, flags, MT_COLOR_INDEX_SIZE);
       mutt_str_pretty_size(tmp, sizeof(tmp), mutt_email_size(e));
       mutt_format_s(buf + colorlen, buflen - colorlen, prec, tmp);
       add_index_color(buf + colorlen, buflen - colorlen, flags, MT_COLOR_INDEX);
       break;
+    }
 
     case 'C':
+    {
       colorlen = add_index_color(fmt, sizeof(fmt), flags, MT_COLOR_INDEX_NUMBER);
       snprintf(fmt + colorlen, sizeof(fmt) - colorlen, "%%%sd", prec);
       add_index_color(fmt + colorlen, sizeof(fmt) - colorlen, flags, MT_COLOR_INDEX);
       snprintf(buf, buflen, fmt, e->msgno + 1);
       break;
+    }
 
     case 'd':
     case 'D':
@@ -703,6 +713,7 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
             switch (*(is++))
             {
               case 'y':
+              {
                 if (t > 1)
                 {
                   t--;
@@ -711,8 +722,10 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
                 t += ((tm.tm_mon * 60 * 60 * 24 * 30) + (tm.tm_mday * 60 * 60 * 24) +
                       (tm.tm_hour * 60 * 60) + (tm.tm_min * 60) + tm.tm_sec);
                 break;
+              }
 
               case 'm':
+              {
                 if (t > 1)
                 {
                   t--;
@@ -721,8 +734,10 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
                 t += ((tm.tm_mday * 60 * 60 * 24) + (tm.tm_hour * 60 * 60) +
                       (tm.tm_min * 60) + tm.tm_sec);
                 break;
+              }
 
               case 'w':
+              {
                 if (t > 1)
                 {
                   t--;
@@ -731,8 +746,10 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
                 t += ((tm.tm_wday * 60 * 60 * 24) + (tm.tm_hour * 60 * 60) +
                       (tm.tm_min * 60) + tm.tm_sec);
                 break;
+              }
 
               case 'd':
+              {
                 if (t > 1)
                 {
                   t--;
@@ -740,8 +757,10 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
                 }
                 t += ((tm.tm_hour * 60 * 60) + (tm.tm_min * 60) + tm.tm_sec);
                 break;
+              }
 
               case 'H':
+              {
                 if (t > 1)
                 {
                   t--;
@@ -749,8 +768,10 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
                 }
                 t += ((tm.tm_min * 60) + tm.tm_sec);
                 break;
+              }
 
               case 'M':
+              {
                 if (t > 1)
                 {
                   t--;
@@ -758,9 +779,12 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
                 }
                 t += (tm.tm_sec);
                 break;
+              }
 
               default:
+              {
                 break;
+              }
             }
             j += t;
           }
@@ -862,11 +886,14 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
       }
 
     case 'e':
+    {
       snprintf(fmt, sizeof(fmt), "%%%sd", prec);
       snprintf(buf, buflen, fmt, mutt_messages_in_thread(m, e, 1));
       break;
+    }
 
     case 'E':
+    {
       if (!optional)
       {
         snprintf(fmt, sizeof(fmt), "%%%sd", prec);
@@ -875,14 +902,18 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
       else if (mutt_messages_in_thread(m, e, 0) <= 1)
         optional = 0;
       break;
+    }
 
     case 'f':
+    {
       tmp[0] = '\0';
       mutt_addrlist_write(tmp, sizeof(tmp), &e->env->from, true);
       mutt_format_s(buf, buflen, prec, tmp);
       break;
+    }
 
     case 'F':
+    {
       if (!optional)
       {
         const bool is_plain = (src[0] == 'p');
@@ -900,8 +931,10 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
         optional = 0;
       }
       break;
+    }
 
     case 'g':
+    {
       tags = driver_tags_get_transformed(&e->tags);
       if (!optional)
       {
@@ -913,6 +946,7 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
         optional = 0;
       FREE(&tags);
       break;
+    }
 
     case 'G':
     {
@@ -955,6 +989,7 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
     }
 
     case 'H':
+    {
       /* (Hormel) spam score */
       if (optional)
         optional = e->env->spam ? 1 : 0;
@@ -964,10 +999,13 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
       else
         mutt_format_s(buf, buflen, prec, "");
       break;
+    }
 
     case 'i':
+    {
       mutt_format_s(buf, buflen, prec, e->env->message_id ? e->env->message_id : "<no.id>");
       break;
+    }
 
     case 'J':
     {
@@ -1009,6 +1047,7 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
     }
 
     case 'l':
+    {
       if (!optional)
       {
         snprintf(fmt, sizeof(fmt), "%%%sd", prec);
@@ -1019,8 +1058,10 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
       else if (e->lines <= 0)
         optional = 0;
       break;
+    }
 
     case 'L':
+    {
       if (!optional)
       {
         colorlen = add_index_color(buf, buflen, flags, MT_COLOR_INDEX_AUTHOR);
@@ -1034,8 +1075,10 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
         optional = 0;
       }
       break;
+    }
 
     case 'm':
+    {
       if (m)
       {
         snprintf(fmt, sizeof(fmt), "%%%sd", prec);
@@ -1044,14 +1087,18 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
       else
         mutt_str_strfcpy(buf, "(null)", buflen);
       break;
+    }
 
     case 'n':
+    {
       colorlen = add_index_color(buf, buflen, flags, MT_COLOR_INDEX_AUTHOR);
       mutt_format_s(buf + colorlen, buflen - colorlen, prec, mutt_get_name(from));
       add_index_color(buf + colorlen, buflen - colorlen, flags, MT_COLOR_INDEX);
       break;
+    }
 
     case 'M':
+    {
       snprintf(fmt, sizeof(fmt), "%%%sd", prec);
       if (!optional)
       {
@@ -1075,8 +1122,10 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
           optional = 0;
       }
       break;
+    }
 
     case 'N':
+    {
       if (!optional)
       {
         snprintf(fmt, sizeof(fmt), "%%%sd", prec);
@@ -1088,8 +1137,10 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
           optional = 0;
       }
       break;
+    }
 
     case 'O':
+    {
       if (!optional)
       {
         make_from_addr(e->env, tmp, sizeof(tmp), true);
@@ -1103,32 +1154,41 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
         optional = 0;
       }
       break;
+    }
 
     case 'P':
+    {
       mutt_str_strfcpy(buf, hfi->pager_progress, buflen);
       break;
+    }
 
 #ifdef USE_NNTP
     case 'q':
+    {
       mutt_format_s(buf, buflen, prec, e->env->newsgroups ? e->env->newsgroups : "");
       break;
+    }
 #endif
 
     case 'r':
+    {
       tmp[0] = '\0';
       mutt_addrlist_write(tmp, sizeof(tmp), &e->env->to, true);
       if (optional && (tmp[0] == '\0'))
         optional = 0;
       mutt_format_s(buf, buflen, prec, tmp);
       break;
+    }
 
     case 'R':
+    {
       tmp[0] = '\0';
       mutt_addrlist_write(tmp, sizeof(tmp), &e->env->cc, true);
       if (optional && (tmp[0] == '\0'))
         optional = 0;
       mutt_format_s(buf, buflen, prec, tmp);
       break;
+    }
 
     case 's':
     {
@@ -1189,6 +1249,7 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
     }
 
     case 't':
+    {
       tmp[0] = '\0';
       if (!check_for_mailing_list(&e->env->to, "To ", tmp, sizeof(tmp)) &&
           !check_for_mailing_list(&e->env->cc, "Cc ", tmp, sizeof(tmp)))
@@ -1200,6 +1261,7 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
       }
       mutt_format_s(buf, buflen, prec, tmp);
       break;
+    }
 
     case 'T':
     {
@@ -1213,6 +1275,7 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
     }
 
     case 'u':
+    {
       if (from && from->mailbox)
       {
         mutt_str_strfcpy(tmp, mutt_addr_for_display(from), sizeof(tmp));
@@ -1224,8 +1287,10 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
         tmp[0] = '\0';
       mutt_format_s(buf, buflen, prec, tmp);
       break;
+    }
 
     case 'v':
+    {
       if (mutt_addr_is_user(from))
       {
         if (to)
@@ -1242,8 +1307,10 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
         *p = '\0';
       mutt_format_s(buf, buflen, prec, tmp);
       break;
+    }
 
     case 'W':
+    {
       if (!optional)
       {
         mutt_format_s(buf, buflen, prec, e->env->organization ? e->env->organization : "");
@@ -1251,9 +1318,11 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
       else if (!e->env->organization)
         optional = 0;
       break;
+    }
 
 #ifdef USE_NNTP
     case 'x':
+    {
       if (!optional)
       {
         mutt_format_s(buf, buflen, prec, e->env->x_comment_to ? e->env->x_comment_to : "");
@@ -1261,6 +1330,7 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
       else if (!e->env->x_comment_to)
         optional = 0;
       break;
+    }
 #endif
 
     case 'X':
@@ -1277,6 +1347,7 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
     }
 
     case 'y':
+    {
       if (optional)
         optional = e->env->x_label ? 1 : 0;
 
@@ -1284,6 +1355,7 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
       mutt_format_s(buf + colorlen, buflen - colorlen, prec, NONULL(e->env->x_label));
       add_index_color(buf + colorlen, buflen - colorlen, flags, MT_COLOR_INDEX);
       break;
+    }
 
     case 'Y':
     {
@@ -1321,6 +1393,7 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
     }
 
     case 'z':
+    {
       if (src[0] == 's') /* status: deleted/new/old/replied */
       {
         const char *ch = NULL;
@@ -1389,6 +1462,7 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
       mutt_format_s(buf + colorlen, buflen - colorlen, prec, tmp);
       add_index_color(buf + colorlen, buflen - colorlen, flags, MT_COLOR_INDEX);
       break;
+    }
 
     case 'Z':
     {
@@ -1471,8 +1545,10 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
       /* fallthrough */
 
     default:
+    {
       snprintf(buf, buflen, "%%%s%c", prec, op);
       break;
+    }
   }
 
   if (optional)

--- a/imap/command.c
+++ b/imap/command.c
@@ -711,46 +711,72 @@ static void cmd_parse_myrights(struct ImapAccountData *adata, const char *s)
     switch (*s)
     {
       case 'a':
+      {
         adata->mailbox->rights |= MUTT_ACL_ADMIN;
         break;
+      }
       case 'e':
+      {
         adata->mailbox->rights |= MUTT_ACL_EXPUNGE;
         break;
+      }
       case 'i':
+      {
         adata->mailbox->rights |= MUTT_ACL_INSERT;
         break;
+      }
       case 'k':
+      {
         adata->mailbox->rights |= MUTT_ACL_CREATE;
         break;
+      }
       case 'l':
+      {
         adata->mailbox->rights |= MUTT_ACL_LOOKUP;
         break;
+      }
       case 'p':
+      {
         adata->mailbox->rights |= MUTT_ACL_POST;
         break;
+      }
       case 'r':
+      {
         adata->mailbox->rights |= MUTT_ACL_READ;
         break;
+      }
       case 's':
+      {
         adata->mailbox->rights |= MUTT_ACL_SEEN;
         break;
+      }
       case 't':
+      {
         adata->mailbox->rights |= MUTT_ACL_DELETE;
         break;
+      }
       case 'w':
+      {
         adata->mailbox->rights |= MUTT_ACL_WRITE;
         break;
+      }
       case 'x':
+      {
         adata->mailbox->rights |= MUTT_ACL_DELMX;
         break;
+      }
 
       /* obsolete rights */
       case 'c':
+      {
         adata->mailbox->rights |= MUTT_ACL_CREATE | MUTT_ACL_DELMX;
         break;
+      }
       case 'd':
+      {
         adata->mailbox->rights |= MUTT_ACL_DELETE | MUTT_ACL_EXPUNGE;
         break;
+      }
       default:
         mutt_debug(LL_DEBUG1, "Unknown right: %c\n", *s);
     }

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -204,33 +204,47 @@ static int make_msg_set(struct Mailbox *m, struct Buffer *buf, int flag,
       switch (flag)
       {
         case MUTT_DELETED:
+        {
           if (emails[n]->deleted != imap_edata_get(emails[n])->deleted)
             match = invert ^ emails[n]->deleted;
           break;
+        }
         case MUTT_FLAG:
+        {
           if (emails[n]->flagged != imap_edata_get(emails[n])->flagged)
             match = invert ^ emails[n]->flagged;
           break;
+        }
         case MUTT_OLD:
+        {
           if (emails[n]->old != imap_edata_get(emails[n])->old)
             match = invert ^ emails[n]->old;
           break;
+        }
         case MUTT_READ:
+        {
           if (emails[n]->read != imap_edata_get(emails[n])->read)
             match = invert ^ emails[n]->read;
           break;
+        }
         case MUTT_REPLIED:
+        {
           if (emails[n]->replied != imap_edata_get(emails[n])->replied)
             match = invert ^ emails[n]->replied;
           break;
+        }
         case MUTT_TAG:
+        {
           if (emails[n]->tagged)
             match = true;
           break;
+        }
         case MUTT_TRASH:
+        {
           if (emails[n]->deleted && !emails[n]->purge)
             match = true;
           break;
+        }
       }
     }
 
@@ -350,12 +364,16 @@ static int do_search(const struct PatternHead *search, bool allpats)
       case MUTT_PAT_BODY:
       case MUTT_PAT_HEADER:
       case MUTT_PAT_WHOLE_MSG:
+      {
         if (pat->stringmatch)
           rc++;
         break;
+      }
       case MUTT_PAT_SERVERSEARCH:
+      {
         rc++;
         break;
+      }
       default:
         if (pat->child && do_search(pat->child, true))
           rc++;
@@ -428,6 +446,7 @@ static int compile_search(struct Mailbox *m, const struct PatternHead *pat, stru
     switch (firstpat->op)
     {
       case MUTT_PAT_HEADER:
+      {
         mutt_buffer_addstr(buf, "HEADER ");
 
         /* extract header name */
@@ -449,16 +468,21 @@ static int compile_search(struct Mailbox *m, const struct PatternHead *pat, stru
         imap_quote_string(term, sizeof(term), delim, false);
         mutt_buffer_addstr(buf, term);
         break;
+      }
       case MUTT_PAT_BODY:
+      {
         mutt_buffer_addstr(buf, "BODY ");
         imap_quote_string(term, sizeof(term), firstpat->p.str, false);
         mutt_buffer_addstr(buf, term);
         break;
+      }
       case MUTT_PAT_WHOLE_MSG:
+      {
         mutt_buffer_addstr(buf, "TEXT ");
         imap_quote_string(term, sizeof(term), firstpat->p.str, false);
         mutt_buffer_addstr(buf, term);
         break;
+      }
       case MUTT_PAT_SERVERSEARCH:
       {
         struct ImapAccountData *adata = imap_adata_get(m);
@@ -1020,8 +1044,8 @@ int imap_exec_msgset(struct Mailbox *m, const char *pre, const char *post,
   struct Buffer *cmd = mutt_buffer_new();
 
   /* We make a copy of the headers just in case resorting doesn't give
-   exactly the original order (duplicate messages?), because other parts of
-   the ctx are tied to the header order. This may be overkill. */
+   * exactly the original order (duplicate messages?), because other parts of
+   * the ctx are tied to the header order. This may be overkill. */
   oldsort = C_Sort;
   if (C_Sort != SORT_ORDER)
   {

--- a/imap/message.c
+++ b/imap/message.c
@@ -631,16 +631,22 @@ static unsigned int imap_fetch_msn_seqset(struct Buffer *b, struct ImapAccountDa
 
       switch (state)
       {
-        case 1: /* single: convert to a range */
+        case 1:
+        { /* single: convert to a range */
           state = 2;
-        /* fallthrough */
-        case 2: /* extend range ending */
+          /* fallthrough */
+        }
+        case 2:
+        { /* extend range ending */
           range_end = msn;
           break;
+        }
         default:
+        {
           state = 1;
           range_begin = msn;
           break;
+        }
       }
     }
     else if (state)

--- a/imap/util.c
+++ b/imap/util.c
@@ -369,16 +369,22 @@ static void imap_msn_index_to_uid_seqset(struct Buffer *b, struct ImapMboxData *
     {
       switch (state)
       {
-        case 1: /* single: convert to a range */
+        case 1:
+        { /* single: convert to a range */
           state = 2;
           /* fall through */
-        case 2: /* extend range ending */
+        }
+        case 2:
+        { /* extend range ending */
           range_end = cur_uid;
           break;
+        }
         default:
+        {
           state = 1;
           range_begin = cur_uid;
           break;
+        }
       }
     }
     else if (state)

--- a/index.c
+++ b/index.c
@@ -1306,55 +1306,85 @@ int mutt_index_menu(void)
          */
 
       case OP_BOTTOM_PAGE:
+      {
         menu_bottom_page(menu);
         break;
+      }
       case OP_CURRENT_BOTTOM:
+      {
         menu_current_bottom(menu);
         break;
+      }
       case OP_CURRENT_MIDDLE:
+      {
         menu_current_middle(menu);
         break;
+      }
       case OP_CURRENT_TOP:
+      {
         menu_current_top(menu);
         break;
+      }
       case OP_FIRST_ENTRY:
+      {
         menu_first_entry(menu);
         break;
+      }
       case OP_HALF_DOWN:
+      {
         menu_half_down(menu);
         break;
+      }
       case OP_HALF_UP:
+      {
         menu_half_up(menu);
         break;
+      }
       case OP_LAST_ENTRY:
+      {
         menu_last_entry(menu);
         break;
+      }
       case OP_MIDDLE_PAGE:
+      {
         menu_middle_page(menu);
         break;
+      }
       case OP_NEXT_LINE:
+      {
         menu_next_line(menu);
         break;
+      }
       case OP_NEXT_PAGE:
+      {
         menu_next_page(menu);
         break;
+      }
       case OP_PREV_LINE:
+      {
         menu_prev_line(menu);
         break;
+      }
       case OP_PREV_PAGE:
+      {
         menu_prev_page(menu);
         break;
+      }
       case OP_TOP_PAGE:
+      {
         menu_top_page(menu);
         break;
+      }
 
 #ifdef USE_NNTP
       case OP_GET_PARENT:
+      {
         if (!prereq(Context, menu, CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE))
           break;
         /* fallthrough */
-
+      }
       case OP_GET_MESSAGE:
+      {
         if (!prereq(Context, menu, CHECK_IN_MAILBOX | CHECK_READONLY | CHECK_ATTACH))
           break;
         if (Context->mailbox->magic == MUTT_NNTP)
@@ -1416,9 +1446,11 @@ int mutt_index_menu(void)
           }
         }
         break;
+      }
 
       case OP_GET_CHILDREN:
       case OP_RECONSTRUCT_THREAD:
+      {
         if (!prereq(Context, menu,
                     CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE | CHECK_READONLY | CHECK_ATTACH))
         {
@@ -1521,6 +1553,7 @@ int mutt_index_menu(void)
           }
         }
         break;
+      }
 #endif
 
       case OP_JUMP:
@@ -1570,6 +1603,7 @@ int mutt_index_menu(void)
          */
 
       case OP_MAIN_DELETE_PATTERN:
+      {
         if (!prereq(Context, menu,
                     CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE | CHECK_READONLY | CHECK_ATTACH))
         {
@@ -1585,14 +1619,17 @@ int mutt_index_menu(void)
         mutt_pattern_func(MUTT_DELETE, _("Delete messages matching: "));
         menu->redraw |= REDRAW_INDEX | REDRAW_STATUS;
         break;
+      }
 
 #ifdef USE_POP
       case OP_MAIN_FETCH_MAIL:
+      {
         if (!prereq(Context, menu, CHECK_ATTACH))
           break;
         pop_fetch_mail();
         menu->redraw = REDRAW_FULL;
         break;
+      }
 #endif /* USE_POP */
 
       case OP_SHOW_LOG_MESSAGES:
@@ -1615,11 +1652,14 @@ int mutt_index_menu(void)
       }
 
       case OP_HELP:
+      {
         mutt_help(MENU_MAIN);
         menu->redraw = REDRAW_FULL;
         break;
+      }
 
       case OP_MAIN_SHOW_LIMIT:
+      {
         if (!prereq(Context, menu, CHECK_IN_MAILBOX))
           break;
         if (!Context->pattern)
@@ -1632,10 +1672,12 @@ int mutt_index_menu(void)
           mutt_message("%s", buf2);
         }
         break;
+      }
 
       case OP_LIMIT_CURRENT_THREAD:
       case OP_MAIN_LIMIT:
       case OP_TOGGLE_READ:
+      {
         if (!prereq(Context, menu, CHECK_IN_MAILBOX))
           break;
         menu->oldcurrent = ((Context->mailbox->vcount != 0) && (menu->current >= 0) &&
@@ -1696,8 +1738,10 @@ int mutt_index_menu(void)
         if (Context->pattern)
           mutt_message(_("To view all messages, limit to \"all\""));
         break;
+      }
 
       case OP_QUIT:
+      {
         close = op;
         if (attach_msg)
         {
@@ -1725,16 +1769,20 @@ int mutt_index_menu(void)
           }
         }
         break;
+      }
 
       case OP_REDRAW:
+      {
         clearok(stdscr, true);
         menu->redraw = REDRAW_FULL;
         break;
+      }
 
       case OP_SEARCH:
       case OP_SEARCH_REVERSE:
       case OP_SEARCH_NEXT:
       case OP_SEARCH_OPPOSITE:
+      {
         if (!prereq(Context, menu, CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE))
           break;
         menu->current = mutt_search_command(menu->current, op);
@@ -1743,9 +1791,11 @@ int mutt_index_menu(void)
         else
           menu->redraw = REDRAW_MOTION;
         break;
+      }
 
       case OP_SORT:
       case OP_SORT_REVERSE:
+      {
         if (mutt_select_sort((op == OP_SORT_REVERSE)) == 0)
         {
           if (Context && (Context->mailbox->msg_count != 0))
@@ -1761,8 +1811,10 @@ int mutt_index_menu(void)
           menu->redraw |= REDRAW_STATUS;
         }
         break;
+      }
 
       case OP_TAG:
+      {
         if (!prereq(Context, menu, CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE))
           break;
         if (tag && !C_AutoTag)
@@ -1793,15 +1845,19 @@ int mutt_index_menu(void)
             menu->redraw |= REDRAW_CURRENT;
         }
         break;
+      }
 
       case OP_MAIN_TAG_PATTERN:
+      {
         if (!prereq(Context, menu, CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE))
           break;
         mutt_pattern_func(MUTT_TAG, _("Tag messages matching: "));
         menu->redraw |= REDRAW_INDEX | REDRAW_STATUS;
         break;
+      }
 
       case OP_MAIN_UNDELETE_PATTERN:
+      {
         if (!prereq(Context, menu, CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE | CHECK_READONLY))
           break;
         /* L10N: CHECK_ACL */
@@ -1817,13 +1873,16 @@ int mutt_index_menu(void)
           menu->redraw |= REDRAW_INDEX | REDRAW_STATUS;
         }
         break;
+      }
 
       case OP_MAIN_UNTAG_PATTERN:
+      {
         if (!prereq(Context, menu, CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE))
           break;
         if (mutt_pattern_func(MUTT_UNTAG, _("Untag messages matching: ")) == 0)
           menu->redraw |= REDRAW_INDEX | REDRAW_STATUS;
         break;
+      }
 
       case OP_COMPOSE_TO_SENDER:
       {
@@ -1843,11 +1902,14 @@ int mutt_index_menu(void)
 
 #ifdef USE_IMAP
       case OP_MAIN_IMAP_FETCH:
+      {
         if (Context && (Context->mailbox->magic == MUTT_IMAP))
           imap_check_mailbox(Context->mailbox, true);
         break;
+      }
 
       case OP_MAIN_IMAP_LOGOUT_ALL:
+      {
         if (Context && (Context->mailbox->magic == MUTT_IMAP))
         {
           int check = mx_mbox_close(&Context);
@@ -1865,9 +1927,11 @@ int mutt_index_menu(void)
         OptSearchInvalid = true;
         menu->redraw = REDRAW_FULL;
         break;
+      }
 #endif
 
       case OP_MAIN_SYNC_FOLDER:
+      {
         if (Context && (Context->mailbox->msg_count == 0))
           break;
 
@@ -1933,8 +1997,10 @@ int mutt_index_menu(void)
         else
           menu->redraw = REDRAW_FULL;
         break;
+      }
 
       case OP_MAIN_QUASI_DELETE:
+      {
         if (!prereq(Context, menu, CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE))
           break;
         if (tag)
@@ -1954,6 +2020,7 @@ int mutt_index_menu(void)
           Context->mailbox->changed = true;
         }
         break;
+      }
 
 #ifdef USE_NOTMUCH
       case OP_MAIN_ENTIRE_THREAD:
@@ -2116,12 +2183,15 @@ int mutt_index_menu(void)
       }
 
       case OP_CHECK_STATS:
+      {
         mutt_check_stats();
         break;
+      }
 
 #ifdef USE_NOTMUCH
       case OP_MAIN_VFOLDER_FROM_QUERY:
       case OP_MAIN_VFOLDER_FROM_QUERY_READONLY:
+      {
         buf[0] = '\0';
         if ((mutt_get_field("Query: ", buf, sizeof(buf), MUTT_NM_QUERY) != 0) || !buf[0])
         {
@@ -2133,8 +2203,10 @@ int mutt_index_menu(void)
         else
           main_change_folder(menu, op, NULL, buf, sizeof(buf), &oldcount, &index_hint);
         break;
+      }
 
       case OP_MAIN_WINDOWED_VFOLDER_BACKWARD:
+      {
         if (!prereq(Context, menu, CHECK_IN_MAILBOX))
           break;
         mutt_debug(LL_DEBUG2, "OP_MAIN_WINDOWED_VFOLDER_BACKWARD\n");
@@ -2155,8 +2227,10 @@ int mutt_index_menu(void)
         else
           main_change_folder(menu, op, NULL, buf, sizeof(buf), &oldcount, &index_hint);
         break;
+      }
 
       case OP_MAIN_WINDOWED_VFOLDER_FORWARD:
+      {
         if (!prereq(Context, menu, CHECK_IN_MAILBOX))
           break;
         if (C_NmQueryWindowDuration <= 0)
@@ -2179,6 +2253,7 @@ int mutt_index_menu(void)
           main_change_folder(menu, op, NULL, buf, sizeof(buf), &oldcount, &index_hint);
         }
         break;
+      }
 
       case OP_MAIN_CHANGE_VFOLDER:
 #endif
@@ -2320,6 +2395,7 @@ int mutt_index_menu(void)
 
       case OP_DISPLAY_MESSAGE:
       case OP_DISPLAY_HEADERS: /* don't weed the headers */
+      {
         if (!prereq(Context, menu, CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE))
           break;
         /* toggle the weeding of headers so that a user can press the key
@@ -2366,8 +2442,9 @@ int mutt_index_menu(void)
         menu->oldcurrent = menu->current;
         update_index(menu, Context, MUTT_NEW_MAIL, Context->mailbox->msg_count, hint);
         continue;
-
+      }
       case OP_EXIT:
+      {
         close = op;
         if ((menu->menu == MENU_MAIN) && attach_msg)
         {
@@ -2386,8 +2463,10 @@ int mutt_index_menu(void)
           done = true;
         }
         break;
+      }
 
       case OP_MAIN_BREAK_THREAD:
+      {
         if (!prereq(Context, menu, CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE | CHECK_READONLY))
           break;
         /* L10N: CHECK_ACL */
@@ -2425,8 +2504,10 @@ int mutt_index_menu(void)
         }
 
         break;
+      }
 
       case OP_MAIN_LINK_THREADS:
+      {
         if (!prereq(Context, menu, CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE | CHECK_READONLY))
           break;
         /* L10N: CHECK_ACL */
@@ -2468,8 +2549,10 @@ int mutt_index_menu(void)
           menu->redraw |= REDRAW_STATUS | REDRAW_INDEX;
 
         break;
+      }
 
       case OP_EDIT_TYPE:
+      {
         if (!prereq(Context, menu, CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE | CHECK_ATTACH))
           break;
         mutt_edit_content_type(CUR_EMAIL, CUR_EMAIL->content, NULL);
@@ -2482,8 +2565,10 @@ int mutt_index_menu(void)
         else
           menu->redraw = REDRAW_CURRENT;
         break;
+      }
 
       case OP_MAIN_NEXT_UNDELETED:
+      {
         if (!prereq(Context, menu, CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE))
           break;
         if (menu->current >= (Context->mailbox->vcount - 1))
@@ -2507,8 +2592,10 @@ int mutt_index_menu(void)
         else
           menu->redraw = REDRAW_MOTION;
         break;
+      }
 
       case OP_NEXT_ENTRY:
+      {
         if (!prereq(Context, menu, CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE))
           break;
         if (menu->current >= (Context->mailbox->vcount - 1))
@@ -2526,8 +2613,10 @@ int mutt_index_menu(void)
         else
           menu->redraw = REDRAW_MOTION;
         break;
+      }
 
       case OP_MAIN_PREV_UNDELETED:
+      {
         if (!prereq(Context, menu, CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE))
           break;
         if (menu->current < 1)
@@ -2550,8 +2639,10 @@ int mutt_index_menu(void)
         else
           menu->redraw = REDRAW_MOTION;
         break;
+      }
 
       case OP_PREV_ENTRY:
+      {
         if (!prereq(Context, menu, CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE))
           break;
         if (menu->current < 1)
@@ -2569,12 +2660,15 @@ int mutt_index_menu(void)
         else
           menu->redraw = REDRAW_MOTION;
         break;
+      }
 
       case OP_DECRYPT_COPY:
       case OP_DECRYPT_SAVE:
+      {
         if (!WithCrypto)
           break;
-      /* fallthrough */
+        /* fallthrough */
+      }
       case OP_COPY_MESSAGE:
       case OP_SAVE:
       case OP_DECODE_COPY:
@@ -2729,6 +2823,7 @@ int mutt_index_menu(void)
         break;
       }
       case OP_FLAG_MESSAGE:
+      {
         if (!prereq(Context, menu, CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE | CHECK_READONLY))
           break;
         /* L10N: CHECK_ACL */
@@ -2767,8 +2862,10 @@ int mutt_index_menu(void)
         }
         menu->redraw |= REDRAW_STATUS;
         break;
+      }
 
       case OP_TOGGLE_NEW:
+      {
         if (!prereq(Context, menu, CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE | CHECK_READONLY))
           break;
         /* L10N: CHECK_ACL */
@@ -2812,8 +2909,10 @@ int mutt_index_menu(void)
           menu->redraw |= REDRAW_STATUS;
         }
         break;
+      }
 
       case OP_TOGGLE_WRITE:
+      {
         if (!prereq(Context, menu, CHECK_IN_MAILBOX))
           break;
         if (mx_toggle_write(Context->mailbox) == 0)
@@ -2827,31 +2926,41 @@ int mutt_index_menu(void)
             menu->redraw |= REDRAW_STATUS;
         }
         break;
+      }
 
       case OP_MAIN_NEXT_THREAD:
       case OP_MAIN_NEXT_SUBTHREAD:
       case OP_MAIN_PREV_THREAD:
       case OP_MAIN_PREV_SUBTHREAD:
+      {
         if (!prereq(Context, menu, CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE))
           break;
 
         switch (op)
         {
           case OP_MAIN_NEXT_THREAD:
+          {
             menu->current = mutt_next_thread(CUR_EMAIL);
             break;
+          }
 
           case OP_MAIN_NEXT_SUBTHREAD:
+          {
             menu->current = mutt_next_subthread(CUR_EMAIL);
             break;
+          }
 
           case OP_MAIN_PREV_THREAD:
+          {
             menu->current = mutt_previous_thread(CUR_EMAIL);
             break;
+          }
 
           case OP_MAIN_PREV_SUBTHREAD:
+          {
             menu->current = mutt_previous_subthread(CUR_EMAIL);
             break;
+          }
         }
 
         if (menu->current < 0)
@@ -2870,9 +2979,11 @@ int mutt_index_menu(void)
         else
           menu->redraw = REDRAW_MOTION;
         break;
+      }
 
       case OP_MAIN_ROOT_MESSAGE:
       case OP_MAIN_PARENT_MESSAGE:
+      {
         if (!prereq(Context, menu, CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE))
           break;
 
@@ -2889,6 +3000,7 @@ int mutt_index_menu(void)
         else
           menu->redraw = REDRAW_MOTION;
         break;
+      }
 
       case OP_MAIN_SET_FLAG:
       case OP_MAIN_CLEAR_FLAG:
@@ -2924,6 +3036,7 @@ int mutt_index_menu(void)
       }
 
       case OP_MAIN_COLLAPSE_THREAD:
+      {
         if (!prereq(Context, menu, CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE))
           break;
 
@@ -2954,8 +3067,10 @@ int mutt_index_menu(void)
         menu->redraw = REDRAW_INDEX | REDRAW_STATUS;
 
         break;
+      }
 
       case OP_MAIN_COLLAPSE_ALL:
+      {
         if (!prereq(Context, menu, CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE))
           break;
 
@@ -2966,6 +3081,7 @@ int mutt_index_menu(void)
         }
         collapse_all(menu, 1);
         break;
+      }
 
         /* --------------------------------------------------------------------
          * These functions are invoked directly from the internal-pager
@@ -2984,15 +3100,19 @@ int mutt_index_menu(void)
       }
 
       case OP_CREATE_ALIAS:
+      {
         mutt_alias_create(Context && Context->mailbox->vcount ? CUR_EMAIL->env : NULL, NULL);
         menu->redraw |= REDRAW_CURRENT;
         break;
+      }
 
       case OP_QUERY:
+      {
         if (!prereq(Context, menu, CHECK_ATTACH))
           break;
         mutt_query_menu(NULL, 0);
         break;
+      }
 
       case OP_PURGE_MESSAGE:
       case OP_DELETE:
@@ -3079,6 +3199,7 @@ int mutt_index_menu(void)
 
 #ifdef USE_NNTP
       case OP_CATCHUP:
+      {
         if (!prereq(Context, menu, CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_READONLY | CHECK_ATTACH))
           break;
         if (Context && (Context->mailbox->magic == MUTT_NNTP))
@@ -3088,19 +3209,24 @@ int mutt_index_menu(void)
             menu->redraw = REDRAW_INDEX | REDRAW_STATUS;
         }
         break;
+      }
 #endif
 
       case OP_DISPLAY_ADDRESS:
+      {
         if (!prereq(Context, menu, CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE))
           break;
         mutt_display_address(CUR_EMAIL->env);
         break;
+      }
 
       case OP_ENTER_COMMAND:
+      {
         mutt_enter_command();
         if (Context)
           mutt_check_rescore(Context->mailbox);
         break;
+      }
 
       case OP_EDIT_OR_VIEW_RAW_MESSAGE:
       case OP_EDIT_RAW_MESSAGE:
@@ -3157,8 +3283,10 @@ int mutt_index_menu(void)
       }
 
       case OP_FORGET_PASSPHRASE:
+      {
         crypt_forget_passphrase();
         break;
+      }
 
       case OP_GROUP_REPLY:
       case OP_GROUP_CHAT_REPLY:
@@ -3228,13 +3356,16 @@ int mutt_index_menu(void)
       }
 
       case OP_MAIL:
+      {
         if (!prereq(Context, menu, CHECK_ATTACH))
           break;
         ci_send_message(SEND_NO_FLAGS, NULL, NULL, Context, NULL);
         menu->redraw = REDRAW_FULL;
         break;
+      }
 
       case OP_MAIL_KEY:
+      {
         if (!(WithCrypto & APPLICATION_PGP))
           break;
         if (!prereq(Context, menu, CHECK_ATTACH))
@@ -3242,6 +3373,7 @@ int mutt_index_menu(void)
         ci_send_message(SEND_KEY, NULL, NULL, NULL, NULL);
         menu->redraw = REDRAW_FULL;
         break;
+      }
 
       case OP_EXTRACT_KEYS:
       {
@@ -3355,6 +3487,7 @@ int mutt_index_menu(void)
       }
 
       case OP_MARK_MSG:
+      {
         if (!prereq(Context, menu, CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE))
           break;
         if (CUR_EMAIL->env->message_id)
@@ -3390,15 +3523,19 @@ int mutt_index_menu(void)
           mutt_error(_("No message ID to macro"));
         }
         break;
+      }
 
       case OP_RECALL_MESSAGE:
+      {
         if (!prereq(Context, menu, CHECK_ATTACH))
           break;
         ci_send_message(SEND_POSTPONED, NULL, NULL, Context, NULL);
         menu->redraw = REDRAW_FULL;
         break;
+      }
 
       case OP_RESEND:
+      {
         if (!prereq(Context, menu, CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE | CHECK_ATTACH))
           break;
 
@@ -3415,15 +3552,18 @@ int mutt_index_menu(void)
 
         menu->redraw = REDRAW_FULL;
         break;
+      }
 
 #ifdef USE_NNTP
       case OP_FOLLOWUP:
       case OP_FORWARD_TO_GROUP:
+      {
         if (!prereq(Context, menu, CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE))
           break;
         /* fallthrough */
-
+      }
       case OP_POST:
+      {
         if (!prereq(Context, menu, CHECK_ATTACH))
           break;
         if ((op != OP_FOLLOWUP) || !CUR_EMAIL->env->followup_to ||
@@ -3452,7 +3592,8 @@ int mutt_index_menu(void)
           break;
         }
 #endif
-      /* fallthrough */
+        /* fallthrough */
+      }
       case OP_REPLY:
       {
         if (!prereq(Context, menu, CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE | CHECK_ATTACH))
@@ -3470,8 +3611,10 @@ int mutt_index_menu(void)
       }
 
       case OP_SHELL_ESCAPE:
+      {
         mutt_shell_escape();
         break;
+      }
 
       case OP_TAG_THREAD:
       case OP_TAG_SUBTHREAD:
@@ -3568,14 +3711,19 @@ int mutt_index_menu(void)
       }
 
       case OP_VERSION:
+      {
         mutt_message(mutt_make_version());
         break;
+      }
 
       case OP_MAILBOX_LIST:
+      {
         mutt_mailbox_list();
         break;
+      }
 
       case OP_VIEW_ATTACHMENTS:
+      {
         if (!prereq(Context, menu, CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE))
           break;
         mutt_view_attachments(CUR_EMAIL);
@@ -3583,13 +3731,18 @@ int mutt_index_menu(void)
           Context->mailbox->changed = true;
         menu->redraw = REDRAW_FULL;
         break;
+      }
 
       case OP_END_COND:
+      {
         break;
+      }
 
       case OP_WHAT_KEY:
+      {
         mutt_what_key();
         break;
+      }
 
 #ifdef USE_SIDEBAR
       case OP_SIDEBAR_NEXT:
@@ -3598,13 +3751,17 @@ int mutt_index_menu(void)
       case OP_SIDEBAR_PAGE_UP:
       case OP_SIDEBAR_PREV:
       case OP_SIDEBAR_PREV_NEW:
+      {
         mutt_sb_change_mailbox(op);
         break;
+      }
 
       case OP_SIDEBAR_TOGGLE_VISIBLE:
+      {
         bool_str_toggle(Config, "sidebar_visible", NULL);
         mutt_window_reflow();
         break;
+      }
 #endif
       default:
         if (menu->menu == MENU_MAIN)

--- a/init.c
+++ b/init.c
@@ -1131,11 +1131,13 @@ static enum CommandResult parse_group(struct Buffer *buf, struct Buffer *s,
       switch (state)
       {
         case GS_NONE:
+        {
           mutt_buffer_printf(err, _("%sgroup: missing -rx or -addr"),
                              (data == MUTT_UNGROUP) ? "un" : "");
           goto warn;
-
+        }
         case GS_RX:
+        {
           if ((data == MUTT_GROUP) &&
               (mutt_grouplist_add_regex(&gl, buf->data, REG_ICASE, err) != 0))
           {
@@ -1147,6 +1149,7 @@ static enum CommandResult parse_group(struct Buffer *buf, struct Buffer *s,
             goto bail;
           }
           break;
+        }
 
         case GS_ADDR:
         {
@@ -2661,26 +2664,38 @@ int mutt_extract_token(struct Buffer *dest, struct Buffer *tok, TokenFlags flags
       {
         case 'c':
         case 'C':
+        {
           if (tok->dptr[0] == '\0')
             return -1; /* premature end of token */
           mutt_buffer_addch(dest, (toupper((unsigned char) tok->dptr[0]) - '@') & 0x7f);
           tok->dptr++;
           break;
+        }
         case 'e':
+        {
           mutt_buffer_addch(dest, '\033'); // Escape
           break;
+        }
         case 'f':
+        {
           mutt_buffer_addch(dest, '\f');
           break;
+        }
         case 'n':
+        {
           mutt_buffer_addch(dest, '\n');
           break;
+        }
         case 'r':
+        {
           mutt_buffer_addch(dest, '\r');
           break;
+        }
         case 't':
+        {
           mutt_buffer_addch(dest, '\t');
           break;
+        }
         default:
           if (isdigit((unsigned char) ch) && isdigit((unsigned char) tok->dptr[0]) &&
               isdigit((unsigned char) tok->dptr[1]))
@@ -3337,8 +3352,9 @@ enum QuadOption query_quadoption(enum QuadOption opt, const char *prompt)
   {
     case MUTT_YES:
     case MUTT_NO:
+    {
       return opt;
-
+    }
     default:
       opt = mutt_yesorno(prompt, (opt == MUTT_ASKYES));
       mutt_window_clearline(MuttMessageWindow, 0);

--- a/keymap.c
+++ b/keymap.c
@@ -1207,37 +1207,65 @@ const struct Binding *km_get_table(int menu)
   switch (menu)
   {
     case MENU_ALIAS:
+    {
       return OpAlias;
+    }
     case MENU_ATTACH:
+    {
       return OpAttach;
+    }
     case MENU_COMPOSE:
+    {
       return OpCompose;
+    }
     case MENU_EDITOR:
+    {
       return OpEditor;
+    }
     case MENU_FOLDER:
+    {
       return OpBrowser;
+    }
     case MENU_GENERIC:
+    {
       return OpGeneric;
 #ifdef CRYPT_BACKEND_GPGME
+    }
     case MENU_KEY_SELECT_PGP:
+    {
       return OpPgp;
+    }
     case MENU_KEY_SELECT_SMIME:
+    {
       return OpSmime;
 #endif
+    }
     case MENU_MAIN:
+    {
       return OpMain;
 #ifdef MIXMASTER
+    }
     case MENU_MIX:
+    {
       return OpMix;
 #endif
+    }
     case MENU_PAGER:
+    {
       return OpPager;
+    }
     case MENU_PGP:
+    {
       return (WithCrypto & APPLICATION_PGP) ? OpPgp : NULL;
+    }
     case MENU_POST:
+    {
       return OpPost;
+    }
     case MENU_QUERY:
+    {
       return OpQuery;
+    }
     case MENU_SUMMARY:
       return OpSummary;
   }

--- a/mailbox.c
+++ b/mailbox.c
@@ -145,11 +145,14 @@ static void mailbox_check(struct Mailbox *m_cur, struct Mailbox *m_check,
     case MUTT_NNTP:
     case MUTT_NOTMUCH:
     case MUTT_IMAP:
+    {
       if (mb_magic != MUTT_IMAP)
         m_check->has_new = false;
       m_check->magic = mb_magic;
       break;
+    }
     default:
+    {
       m_check->has_new = false;
 
       if ((stat(mutt_b2s(m_check->pathbuf), &sb) != 0) ||
@@ -165,6 +168,7 @@ static void mailbox_check(struct Mailbox *m_cur, struct Mailbox *m_check,
         return;
       }
       break; // kept for consistency.
+    }
   }
 
   /* check to see if the folder is the currently selected folder before polling */
@@ -182,9 +186,11 @@ static void mailbox_check(struct Mailbox *m_cur, struct Mailbox *m_check,
       case MUTT_MAILDIR:
       case MUTT_MH:
       case MUTT_NOTMUCH:
+      {
         if (mx_mbox_check_stats(m_check, 0) == 0)
           MailboxCount++;
         break;
+      }
       default:; /* do nothing */
     }
   }

--- a/maildir/shared.c
+++ b/maildir/shared.c
@@ -1300,28 +1300,38 @@ void maildir_parse_flags(struct Email *e, const char *path)
       switch (*p)
       {
         case 'F':
+        {
           e->flagged = true;
           break;
+        }
 
-        case 'R': /* replied */
+        case 'R':
+        { /* replied */
           e->replied = true;
           break;
+        }
 
-        case 'S': /* seen */
+        case 'S':
+        { /* seen */
           e->read = true;
           break;
+        }
 
-        case 'T': /* trashed */
+        case 'T':
+        { /* trashed */
           if (!e->flagged || !C_FlagSafe)
           {
             e->trash = true;
             e->deleted = true;
           }
           break;
+        }
 
         default:
+        {
           *q++ = *p;
           break;
+        }
       }
       p++;
     }

--- a/main.c
+++ b/main.c
@@ -485,95 +485,153 @@ int main(int argc, char *argv[], char *envp[])
       switch (i)
       {
         case 'A':
+        {
           mutt_list_insert_tail(&alias_queries, mutt_str_strdup(optarg));
           break;
+        }
         case 'a':
+        {
           mutt_list_insert_tail(&attach, mutt_str_strdup(optarg));
           break;
+        }
         case 'B':
+        {
           batch_mode = true;
           break;
+        }
         case 'b':
+        {
           mutt_list_insert_tail(&bcc_list, mutt_str_strdup(optarg));
           break;
+        }
         case 'c':
+        {
           mutt_list_insert_tail(&cc_list, mutt_str_strdup(optarg));
           break;
+        }
         case 'D':
+        {
           dump_variables = true;
           break;
+        }
         case 'd':
+        {
           dlevel = optarg;
           break;
+        }
         case 'E':
+        {
           edit_infile = true;
           break;
+        }
         case 'e':
+        {
           mutt_list_insert_tail(&commands, mutt_str_strdup(optarg));
           break;
+        }
         case 'F':
+        {
           mutt_list_insert_tail(&Muttrc, mutt_str_strdup(optarg));
           break;
+        }
         case 'f':
+        {
           mutt_buffer_strcpy(folder, optarg);
           explicit_folder = true;
           break;
+        }
 #ifdef USE_NNTP
-        case 'g': /* Specify a news server */
+        case 'g':
+        { /* Specify a news server */
           cli_nntp = optarg;
           /* fallthrough */
-        case 'G': /* List of newsgroups */
+        }
+        case 'G':
+        { /* List of newsgroups */
           flags |= MUTT_CLI_SELECT | MUTT_CLI_NEWS;
           break;
+        }
 #endif
         case 'H':
+        {
           draft_file = optarg;
           break;
+        }
         case 'i':
+        {
           include_file = optarg;
           break;
+        }
         case 'l':
+        {
           dfile = optarg;
           break;
+        }
         case 'm':
+        {
           new_magic = optarg;
           break;
+        }
         case 'n':
+        {
           flags |= MUTT_CLI_NOSYSRC;
           break;
+        }
         case 'p':
+        {
           sendflags |= SEND_POSTPONED;
           break;
+        }
         case 'Q':
+        {
           mutt_list_insert_tail(&queries, mutt_str_strdup(optarg));
           break;
+        }
         case 'R':
+        {
           flags |= MUTT_CLI_RO; /* read-only mode */
           break;
+        }
         case 'S':
+        {
           hide_sensitive = true;
           break;
+        }
         case 's':
+        {
           subject = optarg;
           break;
+        }
         case 'T':
+        {
           test_config = true;
           break;
+        }
         case 'v':
+        {
           version++;
           break;
-        case 'x': /* mailx compatible send mode */
+        }
+        case 'x':
+        { /* mailx compatible send mode */
           sendflags |= SEND_MAILX;
           break;
-        case 'y': /* My special hack mode */
+        }
+        case 'y':
+        { /* My special hack mode */
           flags |= MUTT_CLI_SELECT;
           break;
+        }
         case 'Z':
+        {
           flags |= MUTT_CLI_MAILBOX | MUTT_CLI_IGNORE;
           break;
+        }
         case 'z':
+        {
           flags |= MUTT_CLI_IGNORE;
           break;
+        }
         default:
           usage();
           OptNoCurses = true;
@@ -1203,8 +1261,10 @@ int main(int argc, char *argv[], char *envp[])
       switch (mx_check_empty(mutt_b2s(folder)))
       {
         case -1:
+        {
           mutt_perror(mutt_b2s(folder));
           goto main_curses; // TEST41: neomutt -z -f missing
+        }
         case 1:
           mutt_error(_("Mailbox is empty"));
           goto main_curses; // TEST42: neomutt -z -f /dev/null

--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -615,6 +615,7 @@ static int reopen_mailbox(struct Mailbox *m, int *index_hint)
   {
     case MUTT_MBOX:
     case MUTT_MMDF:
+    {
       cmp_headers = mutt_email_cmp_strict;
       mutt_file_fclose(&adata->fp);
       adata->fp = mutt_file_fopen(mutt_b2s(m->pathbuf), "r");
@@ -625,10 +626,13 @@ static int reopen_mailbox(struct Mailbox *m, int *index_hint)
       else
         rc = mmdf_parse_mailbox(m);
       break;
+    }
 
     default:
+    {
       rc = -1;
       break;
+    }
   }
 
   if (rc == -1)
@@ -1279,6 +1283,7 @@ static int mbox_mbox_sync(struct Mailbox *m, int *index_hint)
       switch (m->magic)
       {
         case MUTT_MMDF:
+        {
           if (fputs(MMDF_SEP, fp) == EOF)
           {
             mutt_perror(tempfile);
@@ -1286,6 +1291,7 @@ static int mbox_mbox_sync(struct Mailbox *m, int *index_hint)
             goto bail;
           }
           break;
+        }
         default:
           if (fputs("\n", fp) == EOF)
           {

--- a/menu.c
+++ b/menu.c
@@ -91,15 +91,22 @@ static int get_color(int index, unsigned char *s)
   switch (type)
   {
     case MT_COLOR_INDEX_AUTHOR:
+    {
       color = &ColorIndexAuthorList;
       break;
+    }
     case MT_COLOR_INDEX_FLAGS:
+    {
       color = &ColorIndexFlagsList;
       break;
+    }
     case MT_COLOR_INDEX_SUBJECT:
+    {
       color = &ColorIndexSubjectList;
       break;
+    }
     case MT_COLOR_INDEX_TAG:
+    {
       STAILQ_FOREACH(np, &ColorIndexTagList, entries)
       {
         if (strncmp((const char *) (s + 1), np->pattern, strlen(np->pattern)) == 0)
@@ -112,6 +119,7 @@ static int get_color(int index, unsigned char *s)
         }
       }
       return 0;
+    }
     default:
       return ColorDefs[type];
   }
@@ -163,6 +171,7 @@ static void print_enriched_string(int index, int attr, unsigned char *s, bool do
         switch (*s)
         {
           case MUTT_TREE_LLCORNER:
+          {
             if (C_AsciiChars)
               addch('`');
 #ifdef WACS_LLCORNER
@@ -175,7 +184,9 @@ static void print_enriched_string(int index, int attr, unsigned char *s, bool do
               addch(ACS_LLCORNER);
 #endif
             break;
+          }
           case MUTT_TREE_ULCORNER:
+          {
             if (C_AsciiChars)
               addch(',');
 #ifdef WACS_ULCORNER
@@ -188,7 +199,9 @@ static void print_enriched_string(int index, int attr, unsigned char *s, bool do
               addch(ACS_ULCORNER);
 #endif
             break;
+          }
           case MUTT_TREE_LTEE:
+          {
             if (C_AsciiChars)
               addch('|');
 #ifdef WACS_LTEE
@@ -201,7 +214,9 @@ static void print_enriched_string(int index, int attr, unsigned char *s, bool do
               addch(ACS_LTEE);
 #endif
             break;
+          }
           case MUTT_TREE_HLINE:
+          {
             if (C_AsciiChars)
               addch('-');
 #ifdef WACS_HLINE
@@ -214,7 +229,9 @@ static void print_enriched_string(int index, int attr, unsigned char *s, bool do
               addch(ACS_HLINE);
 #endif
             break;
+          }
           case MUTT_TREE_VLINE:
+          {
             if (C_AsciiChars)
               addch('|');
 #ifdef WACS_VLINE
@@ -227,7 +244,9 @@ static void print_enriched_string(int index, int attr, unsigned char *s, bool do
               addch(ACS_VLINE);
 #endif
             break;
+          }
           case MUTT_TREE_TTEE:
+          {
             if (C_AsciiChars)
               addch('-');
 #ifdef WACS_TTEE
@@ -240,7 +259,9 @@ static void print_enriched_string(int index, int attr, unsigned char *s, bool do
               addch(ACS_TTEE);
 #endif
             break;
+          }
           case MUTT_TREE_BTEE:
+          {
             if (C_AsciiChars)
               addch('-');
 #ifdef WACS_BTEE
@@ -253,24 +274,37 @@ static void print_enriched_string(int index, int attr, unsigned char *s, bool do
               addch(ACS_BTEE);
 #endif
             break;
+          }
           case MUTT_TREE_SPACE:
+          {
             addch(' ');
             break;
+          }
           case MUTT_TREE_RARROW:
+          {
             addch('>');
             break;
+          }
           case MUTT_TREE_STAR:
+          {
             addch('*'); /* fake thread indicator */
             break;
+          }
           case MUTT_TREE_HIDDEN:
+          {
             addch('&');
             break;
+          }
           case MUTT_TREE_EQUALS:
+          {
             addch('=');
             break;
+          }
           case MUTT_TREE_MISSING:
+          {
             addch('?');
             break;
+          }
         }
         s++;
         n--;
@@ -1237,15 +1271,23 @@ static int menu_dialog_translate_op(int i)
   switch (i)
   {
     case OP_NEXT_ENTRY:
+    {
       return OP_NEXT_LINE;
+    }
     case OP_PREV_ENTRY:
+    {
       return OP_PREV_LINE;
+    }
     case OP_CURRENT_TOP:
     case OP_FIRST_ENTRY:
+    {
       return OP_TOP_PAGE;
+    }
     case OP_CURRENT_BOTTOM:
     case OP_LAST_ENTRY:
+    {
       return OP_BOTTOM_PAGE;
+    }
     case OP_CURRENT_MIDDLE:
       return OP_MIDDLE_PAGE;
   }
@@ -1453,57 +1495,90 @@ int mutt_menu_loop(struct Menu *menu)
     switch (i)
     {
       case OP_NEXT_ENTRY:
+      {
         menu_next_entry(menu);
         break;
+      }
       case OP_PREV_ENTRY:
+      {
         menu_prev_entry(menu);
         break;
+      }
       case OP_HALF_DOWN:
+      {
         menu_half_down(menu);
         break;
+      }
       case OP_HALF_UP:
+      {
         menu_half_up(menu);
         break;
+      }
       case OP_NEXT_PAGE:
+      {
         menu_next_page(menu);
         break;
+      }
       case OP_PREV_PAGE:
+      {
         menu_prev_page(menu);
         break;
+      }
       case OP_NEXT_LINE:
+      {
         menu_next_line(menu);
         break;
+      }
       case OP_PREV_LINE:
+      {
         menu_prev_line(menu);
         break;
+      }
       case OP_FIRST_ENTRY:
+      {
         menu_first_entry(menu);
         break;
+      }
       case OP_LAST_ENTRY:
+      {
         menu_last_entry(menu);
         break;
+      }
       case OP_TOP_PAGE:
+      {
         menu_top_page(menu);
         break;
+      }
       case OP_MIDDLE_PAGE:
+      {
         menu_middle_page(menu);
         break;
+      }
       case OP_BOTTOM_PAGE:
+      {
         menu_bottom_page(menu);
         break;
+      }
       case OP_CURRENT_TOP:
+      {
         menu_current_top(menu);
         break;
+      }
       case OP_CURRENT_MIDDLE:
+      {
         menu_current_middle(menu);
         break;
+      }
       case OP_CURRENT_BOTTOM:
+      {
         menu_current_bottom(menu);
         break;
+      }
       case OP_SEARCH:
       case OP_SEARCH_REVERSE:
       case OP_SEARCH_NEXT:
       case OP_SEARCH_OPPOSITE:
+      {
         if (menu->menu_search && !menu->dialog) /* Searching dialogs won't work */
         {
           menu->oldcurrent = menu->current;
@@ -1516,19 +1591,25 @@ int mutt_menu_loop(struct Menu *menu)
         else
           mutt_error(_("Search is not implemented for this menu"));
         break;
+      }
 
       case OP_JUMP:
+      {
         if (menu->dialog)
           mutt_error(_("Jumping is not implemented for dialogs"));
         else
           menu_jump(menu);
         break;
+      }
 
       case OP_ENTER_COMMAND:
+      {
         mutt_enter_command();
         break;
+      }
 
       case OP_TAG:
+      {
         if (menu->menu_tag && !menu->dialog)
         {
           if (menu->tagprefix && !C_AutoTag)
@@ -1555,35 +1636,50 @@ int mutt_menu_loop(struct Menu *menu)
         else
           mutt_error(_("Tagging is not supported"));
         break;
+      }
 
       case OP_SHELL_ESCAPE:
+      {
         mutt_shell_escape();
         break;
+      }
 
       case OP_WHAT_KEY:
+      {
         mutt_what_key();
         break;
+      }
 
       case OP_CHECK_STATS:
+      {
         mutt_check_stats();
         break;
+      }
 
       case OP_REDRAW:
+      {
         clearok(stdscr, true);
         menu->redraw = REDRAW_FULL;
         break;
+      }
 
       case OP_HELP:
+      {
         mutt_help(menu->menu);
         menu->redraw = REDRAW_FULL;
         break;
+      }
 
       case OP_NULL:
+      {
         km_error_key(menu->menu);
         break;
+      }
 
       case OP_END_COND:
+      {
         break;
+      }
 
       default:
         if (menu->is_mailbox_list)

--- a/mutt/date.c
+++ b/mutt/date.c
@@ -467,21 +467,26 @@ time_t mutt_date_parse_date(const char *s, struct Tz *tz_out)
   {
     switch (count)
     {
-      case 0: /* day of the month */
+      case 0:
+      { /* day of the month */
         if ((mutt_str_atoi(t, &tm.tm_mday) < 0) || (tm.tm_mday < 0))
           return -1;
         if (tm.tm_mday > 31)
           return -1;
         break;
+      }
 
-      case 1: /* month of the year */
+      case 1:
+      { /* month of the year */
         i = mutt_date_check_month(t);
         if ((i < 0) || (i > 11))
           return -1;
         tm.tm_mon = i;
         break;
+      }
 
-      case 2: /* year */
+      case 2:
+      { /* year */
         if ((mutt_str_atoi(t, &tm.tm_year) < 0) || (tm.tm_year < 0))
           return -1;
         if ((tm.tm_year < 0) || (tm.tm_year > 9999))
@@ -491,8 +496,10 @@ time_t mutt_date_parse_date(const char *s, struct Tz *tz_out)
         else if (tm.tm_year >= 1900)
           tm.tm_year -= 1900;
         break;
+      }
 
-      case 3: /* time of day */
+      case 3:
+      { /* time of day */
         if (sscanf(t, "%d:%d:%d", &hour, &min, &sec) == 3)
           ;
         else if (sscanf(t, "%d:%d", &hour, &min) == 2)
@@ -508,8 +515,10 @@ time_t mutt_date_parse_date(const char *s, struct Tz *tz_out)
         tm.tm_min = min;
         tm.tm_sec = sec;
         break;
+      }
 
-      case 4: /* timezone */
+      case 4:
+      { /* timezone */
         /* sometimes we see things like (MST) or (-0700) so attempt to
          * compensate by uncommenting the string if non-RFC822 compliant */
         ptz = uncomment_timezone(tzstr, sizeof(tzstr), t);
@@ -556,6 +565,7 @@ time_t mutt_date_parse_date(const char *s, struct Tz *tz_out)
         if (!zoccident)
           tz_offset = -tz_offset;
         break;
+      }
     }
     count++;
     t = 0;

--- a/mutt/file.c
+++ b/mutt/file.c
@@ -1447,16 +1447,22 @@ void mutt_file_expand_fmt(struct Buffer *dest, const char *fmt, const char *src)
       switch (p[1])
       {
         case '%':
+        {
           mutt_buffer_addch(dest, *p++);
           break;
+        }
         case 's':
+        {
           found = true;
           mutt_buffer_addstr(dest, src);
           p++;
           break;
+        }
         default:
+        {
           mutt_buffer_addch(dest, *p);
           break;
+        }
       }
     }
     else
@@ -1531,23 +1537,29 @@ void mutt_file_get_stat_timespec(struct timespec *dest, struct stat *sb, enum Mu
   switch (type)
   {
     case MUTT_STAT_ATIME:
+    {
       dest->tv_sec = sb->st_atime;
 #ifdef HAVE_STRUCT_STAT_ST_ATIM_TV_NSEC
       dest->tv_nsec = sb->st_atim.tv_nsec;
 #endif
       break;
+    }
     case MUTT_STAT_MTIME:
+    {
       dest->tv_sec = sb->st_mtime;
 #ifdef HAVE_STRUCT_STAT_ST_MTIM_TV_NSEC
       dest->tv_nsec = sb->st_mtim.tv_nsec;
 #endif
       break;
+    }
     case MUTT_STAT_CTIME:
+    {
       dest->tv_sec = sb->st_ctime;
 #ifdef HAVE_STRUCT_STAT_ST_CTIM_TV_NSEC
       dest->tv_nsec = sb->st_ctim.tv_nsec;
 #endif
       break;
+    }
   }
 }
 

--- a/mutt/logging.c
+++ b/mutt/logging.c
@@ -473,21 +473,29 @@ int log_disp_terminal(time_t stamp, const char *file, int line,
     {
       case LL_PERROR:
       case LL_ERROR:
+      {
         colour = 31;
         break;
+      }
       case LL_WARNING:
+      {
         colour = 33;
         break;
+      }
       case LL_MESSAGE:
+      {
         // colour = 36;
         break;
+      }
       case LL_DEBUG1:
       case LL_DEBUG2:
       case LL_DEBUG3:
       case LL_DEBUG4:
       case LL_DEBUG5:
       case LL_NOTIFY:
+      {
         break;
+      }
     }
   }
 

--- a/mutt_history.c
+++ b/mutt_history.c
@@ -63,8 +63,10 @@ static const char *history_format_str(char *buf, size_t buflen, size_t col, int 
   switch (op)
   {
     case 's':
+    {
       mutt_format_s(buf, buflen, prec, match);
       break;
+    }
   }
 
   return src;
@@ -110,12 +112,15 @@ static void history_menu(char *buf, size_t buflen, char **matches, int match_cou
     switch (mutt_menu_loop(menu))
     {
       case OP_GENERIC_SELECT_ENTRY:
+      {
         mutt_str_strfcpy(buf, matches[menu->current], buflen);
         /* fall through */
-
+      }
       case OP_EXIT:
+      {
         done = true;
         break;
+      }
     }
   }
 

--- a/mutt_lua.c
+++ b/mutt_lua.c
@@ -194,9 +194,11 @@ static int lua_mutt_set(lua_State *l)
       break;
     }
     default:
+    {
       luaL_error(l, "Unsupported NeoMutt parameter type %d for %s", DTYPE(cdef->type), param);
       rc = -1;
       break;
+    }
   }
 
   mutt_buffer_free(&err);
@@ -263,14 +265,20 @@ static int lua_mutt_get(lua_State *l)
       return 1;
     }
     case DT_QUAD:
+    {
       lua_pushinteger(l, *(unsigned char *) cdef->var);
       return 1;
+    }
     case DT_NUMBER:
+    {
       lua_pushinteger(l, (signed short) *((unsigned long *) cdef->var));
       return 1;
+    }
     case DT_BOOL:
+    {
       lua_pushboolean(l, *((bool *) cdef->var));
       return 1;
+    }
     default:
       luaL_error(l, "NeoMutt parameter type %d unknown for %s", cdef->type, param);
       return -1;

--- a/mutt_signal.c
+++ b/mutt_signal.c
@@ -46,7 +46,8 @@ static void curses_signal_handler(int sig)
 
   switch (sig)
   {
-    case SIGTSTP: /* user requested a suspend */
+    case SIGTSTP:
+    { /* user requested a suspend */
       if (!C_Suspend)
         break;
       IsEndwin = isendwin();
@@ -55,8 +56,9 @@ static void curses_signal_handler(int sig)
         endwin();
       kill(0, SIGSTOP);
       /* fallthrough */
-
+    }
     case SIGCONT:
+    {
       if (!IsEndwin)
         refresh();
       mutt_curs_set(-1);
@@ -64,14 +66,19 @@ static void curses_signal_handler(int sig)
        * just assuming we received one, and triggering the 'resize' anyway. */
       SigWinch = 1;
       break;
+    }
 
     case SIGWINCH:
+    {
       SigWinch = 1;
       break;
+    }
 
     case SIGINT:
+    {
       SigInt = 1;
       break;
+    }
   }
   errno = save_errno;
 }

--- a/muttlib.c
+++ b/muttlib.c
@@ -410,15 +410,19 @@ bool mutt_needs_mailcap(struct Body *m)
   switch (m->type)
   {
     case TYPE_TEXT:
+    {
       if (mutt_str_strcasecmp("plain", m->subtype) == 0)
         return false;
       break;
+    }
     case TYPE_APPLICATION:
+    {
       if (((WithCrypto & APPLICATION_PGP) != 0) && mutt_is_application_pgp(m))
         return false;
       if (((WithCrypto & APPLICATION_SMIME) != 0) && mutt_is_application_smime(m))
         return false;
       break;
+    }
 
     case TYPE_MULTIPART:
     case TYPE_MESSAGE:
@@ -732,15 +736,21 @@ int mutt_check_overwrite(const char *attname, const char *path, char *fname,
                  These three letters correspond to the choices in the string.  */
               (_("File is a directory, save under it: (y)es, (n)o, (a)ll?"), _("yna")))
       {
-        case 3: /* all */
+        case 3:
+        { /* all */
           mutt_str_replace(directory, fname);
           break;
-        case 1: /* yes */
+        }
+        case 1:
+        { /* yes */
           FREE(directory);
           break;
-        case -1: /* abort */
+        }
+        case -1:
+        { /* abort */
           FREE(directory);
           return -1;
+        }
         case 2: /* no */
           FREE(directory);
           return 1;
@@ -769,17 +779,24 @@ int mutt_check_overwrite(const char *attname, const char *path, char *fname,
                           // L10N: Options for: File exists, (o)verwrite, (a)ppend, or (c)ancel?
                           _("oac")))
     {
-      case -1: /* abort */
+      case -1:
+      { /* abort */
         return -1;
-      case 3: /* cancel */
+      }
+      case 3:
+      { /* cancel */
         return 1;
-
-      case 2: /* append */
+      }
+      case 2:
+      { /* append */
         *opt = MUTT_SAVE_APPEND;
         break;
-      case 1: /* overwrite */
+      }
+      case 1:
+      { /* overwrite */
         *opt = MUTT_SAVE_OVERWRITE;
         break;
+      }
     }
   }
   return 0;
@@ -1302,23 +1319,35 @@ void mutt_expando_format(char *buf, size_t buflen, size_t col, int cols, const c
       switch (*src)
       {
         case 'f':
+        {
           *wptr = '\f';
           break;
+        }
         case 'n':
+        {
           *wptr = '\n';
           break;
+        }
         case 'r':
+        {
           *wptr = '\r';
           break;
+        }
         case 't':
+        {
           *wptr = '\t';
           break;
+        }
         case 'v':
+        {
           *wptr = '\v';
           break;
+        }
         default:
+        {
           *wptr = *src;
           break;
+        }
       }
       src++;
       wptr++;

--- a/mx.c
+++ b/mx.c
@@ -1158,12 +1158,18 @@ int mx_check_empty(const char *path)
   {
     case MUTT_MBOX:
     case MUTT_MMDF:
+    {
       return mutt_file_check_empty(path);
+    }
     case MUTT_MH:
+    {
       return mh_check_empty(path);
+    }
     case MUTT_MAILDIR:
+    {
       return maildir_check_empty(path);
 #ifdef USE_IMAP
+    }
     case MUTT_IMAP:
     {
       int rc = imap_path_status(path, false);

--- a/ncrypt/crypt.c
+++ b/ncrypt/crypt.c
@@ -1101,20 +1101,25 @@ int mutt_signed_handler(struct Body *a, struct State *s)
     switch (signed_type)
     {
       case SEC_SIGN:
+      {
         if ((a->next->type != TYPE_MULTIPART) ||
             (mutt_str_strcasecmp(a->next->subtype, "mixed") != 0))
         {
           inconsistent = true;
         }
         break;
+      }
       case PGP_SIGN:
+      {
         if ((a->next->type != TYPE_APPLICATION) ||
             (mutt_str_strcasecmp(a->next->subtype, "pgp-signature") != 0))
         {
           inconsistent = true;
         }
         break;
+      }
       case SMIME_SIGN:
+      {
         if ((a->next->type != TYPE_APPLICATION) ||
             ((mutt_str_strcasecmp(a->next->subtype, "x-pkcs7-signature") != 0) &&
              (mutt_str_strcasecmp(a->next->subtype, "pkcs7-signature") != 0)))
@@ -1122,6 +1127,7 @@ int mutt_signed_handler(struct Body *a, struct State *s)
           inconsistent = true;
         }
         break;
+      }
       default:
         inconsistent = true;
     }

--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -642,13 +642,17 @@ static bool crypt_id_is_strong(struct CryptKeyInfo *key)
     case GPGME_VALIDITY_NEVER:
     case GPGME_VALIDITY_UNDEFINED:
     case GPGME_VALIDITY_UNKNOWN:
+    {
       is_strong = false;
       break;
+    }
 
     case GPGME_VALIDITY_FULL:
     case GPGME_VALIDITY_ULTIMATE:
+    {
       is_strong = true;
       break;
+    }
   }
 
   return is_strong;
@@ -1511,8 +1515,7 @@ struct Body *pgp_gpgme_encrypt_message(struct Body *a, char *keylist, bool sign)
   t->parts->next->use_disp = true;
   t->parts->next->disposition = DISP_ATTACH;
   t->parts->next->unlink = true; /* delete after sending the message */
-  t->parts->next->d_filename = mutt_str_strdup("msg.asc"); /* non pgp/mime
-                                                           can save */
+  t->parts->next->d_filename = mutt_str_strdup("msg.asc"); /* non pgp/mime can save */
 
   return t;
 }
@@ -1764,24 +1767,34 @@ static void show_one_sig_validity(gpgme_ctx_t ctx, int idx, struct State *s)
   switch (sig ? sig->validity : 0)
   {
     case GPGME_VALIDITY_UNKNOWN:
+    {
       txt = _("WARNING: We have NO indication whether "
               "the key belongs to the person named "
               "as shown above\n");
       break;
+    }
     case GPGME_VALIDITY_UNDEFINED:
+    {
       break;
+    }
     case GPGME_VALIDITY_NEVER:
+    {
       txt = _("WARNING: The key does NOT BELONG to "
               "the person named as shown above\n");
       break;
+    }
     case GPGME_VALIDITY_MARGINAL:
+    {
       txt = _("WARNING: It is NOT certain that the key "
               "belongs to the person named as shown above\n");
       break;
+    }
     case GPGME_VALIDITY_FULL:
     case GPGME_VALIDITY_ULTIMATE:
+    {
       txt = NULL;
       break;
+    }
   }
   if (txt)
     state_puts(txt, s);
@@ -3359,6 +3372,7 @@ static const char *crypt_format_str(char *buf, size_t buflen, size_t col, int co
   switch (tolower(op))
   {
     case 'a':
+    {
       if (!optional)
       {
         const char *s = NULL;
@@ -3370,8 +3384,10 @@ static const char *crypt_format_str(char *buf, size_t buflen, size_t col, int co
         snprintf(buf, buflen, fmt, s);
       }
       break;
+    }
 
     case 'c':
+    {
       if (!optional)
       {
         snprintf(fmt, sizeof(fmt), "%%%ss", prec);
@@ -3380,8 +3396,10 @@ static const char *crypt_format_str(char *buf, size_t buflen, size_t col, int co
       else if (!(kflags & KEYFLAG_ABILITIES))
         optional = 0;
       break;
+    }
 
     case 'f':
+    {
       if (!optional)
       {
         snprintf(fmt, sizeof(fmt), "%%%sc", prec);
@@ -3390,8 +3408,10 @@ static const char *crypt_format_str(char *buf, size_t buflen, size_t col, int co
       else if (!(kflags & KEYFLAG_RESTRICTIONS))
         optional = 0;
       break;
+    }
 
     case 'k':
+    {
       if (!optional)
       {
         /* fixme: we need a way to distinguish between main and subkeys.
@@ -3400,8 +3420,10 @@ static const char *crypt_format_str(char *buf, size_t buflen, size_t col, int co
         snprintf(buf, buflen, fmt, crypt_keyid(key));
       }
       break;
+    }
 
     case 'l':
+    {
       if (!optional)
       {
         snprintf(fmt, sizeof(fmt), "%%%slu", prec);
@@ -3413,19 +3435,24 @@ static const char *crypt_format_str(char *buf, size_t buflen, size_t col, int co
         snprintf(buf, buflen, fmt, val);
       }
       break;
+    }
 
     case 'n':
+    {
       if (!optional)
       {
         snprintf(fmt, sizeof(fmt), "%%%sd", prec);
         snprintf(buf, buflen, fmt, entry->num);
       }
       break;
+    }
 
     case 'p':
+    {
       snprintf(fmt, sizeof(fmt), "%%%ss", prec);
       snprintf(buf, buflen, fmt, gpgme_get_protocol_name(key->kobj->protocol));
       break;
+    }
 
     case 't':
     {
@@ -3437,24 +3464,36 @@ static const char *crypt_format_str(char *buf, size_t buflen, size_t col, int co
         switch (key->validity)
         {
           case GPGME_VALIDITY_FULL:
+          {
             s = "f";
             break;
+          }
           case GPGME_VALIDITY_MARGINAL:
+          {
             s = "m";
             break;
+          }
           case GPGME_VALIDITY_NEVER:
+          {
             s = "n";
             break;
+          }
           case GPGME_VALIDITY_ULTIMATE:
+          {
             s = "u";
             break;
+          }
           case GPGME_VALIDITY_UNDEFINED:
+          {
             s = "q";
             break;
+          }
           case GPGME_VALIDITY_UNKNOWN:
           default:
+          {
             s = "?";
             break;
+          }
         }
       }
       snprintf(fmt, sizeof(fmt), "%%%sc", prec);
@@ -3463,12 +3502,14 @@ static const char *crypt_format_str(char *buf, size_t buflen, size_t col, int co
     }
 
     case 'u':
+    {
       if (!optional)
       {
         snprintf(fmt, sizeof(fmt), "%%%ss", prec);
         snprintf(buf, buflen, fmt, key->uid);
       }
       break;
+    }
 
     case '[':
     {
@@ -4020,6 +4061,7 @@ static unsigned int key_check_cap(gpgme_key_t key, enum KeyCap cap)
   switch (cap)
   {
     case KEY_CAP_CAN_ENCRYPT:
+    {
       ret = key->can_encrypt;
       if (ret == 0)
       {
@@ -4031,7 +4073,9 @@ static unsigned int key_check_cap(gpgme_key_t key, enum KeyCap cap)
         }
       }
       break;
+    }
     case KEY_CAP_CAN_SIGN:
+    {
       ret = key->can_sign;
       if (ret == 0)
       {
@@ -4043,7 +4087,9 @@ static unsigned int key_check_cap(gpgme_key_t key, enum KeyCap cap)
         }
       }
       break;
+    }
     case KEY_CAP_CAN_CERTIFY:
+    {
       ret = key->can_certify;
       if (ret == 0)
       {
@@ -4055,6 +4101,7 @@ static unsigned int key_check_cap(gpgme_key_t key, enum KeyCap cap)
         }
       }
       break;
+    }
   }
 
   return ret;
@@ -4690,18 +4737,26 @@ static struct CryptKeyInfo *crypt_select_key(struct CryptKeyInfo *keys,
   switch (C_PgpSortKeys & SORT_MASK)
   {
     case SORT_ADDRESS:
+    {
       f = crypt_compare_address;
       break;
+    }
     case SORT_DATE:
+    {
       f = crypt_compare_date;
       break;
+    }
     case SORT_KEYID:
+    {
       f = crypt_compare_keyid;
       break;
+    }
     case SORT_TRUST:
     default:
+    {
       f = crypt_compare_trust;
       break;
+    }
   }
   qsort(key_table, i, sizeof(struct CryptKeyInfo *), f);
 
@@ -4763,15 +4818,20 @@ static struct CryptKeyInfo *crypt_select_key(struct CryptKeyInfo *keys,
     switch (mutt_menu_loop(menu))
     {
       case OP_VERIFY_KEY:
+      {
         verify_key(key_table[menu->current]);
         menu->redraw = REDRAW_FULL;
         break;
+      }
 
       case OP_VIEW_ID:
+      {
         mutt_message("%s", key_table[menu->current]->uid);
         break;
+      }
 
       case OP_GENERIC_SELECT_ENTRY:
+      {
         /* FIXME make error reporting more verbose - this should be
          * easy because gpgme provides more information */
         if (OptPgpCheckTrust)
@@ -4801,21 +4861,29 @@ static struct CryptKeyInfo *crypt_select_key(struct CryptKeyInfo *keys,
             switch (key_table[menu->current]->validity)
             {
               case GPGME_VALIDITY_NEVER:
+              {
                 warn_s =
                     _("ID is not valid. Do you really want to use the key?");
                 break;
+              }
               case GPGME_VALIDITY_MARGINAL:
+              {
                 warn_s = _("ID is only marginally valid. Do you really want to "
                            "use the key?");
                 break;
+              }
               case GPGME_VALIDITY_FULL:
               case GPGME_VALIDITY_ULTIMATE:
+              {
                 break;
+              }
               case GPGME_VALIDITY_UNKNOWN:
               case GPGME_VALIDITY_UNDEFINED:
+              {
                 warn_s = _("ID has undefined validity. Do you really want to "
                            "use the key?");
                 break;
+              }
             }
           }
 
@@ -4844,11 +4912,14 @@ static struct CryptKeyInfo *crypt_select_key(struct CryptKeyInfo *keys,
         k = crypt_copy_key(key_table[menu->current]);
         done = true;
         break;
+      }
 
       case OP_EXIT:
+      {
         k = NULL;
         done = true;
         break;
+      }
     }
   }
 
@@ -5487,7 +5558,8 @@ static int gpgme_send_menu(struct Email *e, int is_smime)
   {
     switch (choices[choice - 1])
     {
-      case 'a': /* sign (a)s */
+      case 'a':
+      { /* sign (a)s */
         p = crypt_ask_for_key(_("Sign as: "), NULL, KEYFLAG_CANSIGN,
                               is_smime ? APPLICATION_SMIME : APPLICATION_PGP, NULL);
         if (p)
@@ -5500,26 +5572,36 @@ static int gpgme_send_menu(struct Email *e, int is_smime)
           e->security |= SEC_SIGN;
         }
         break;
+      }
 
-      case 'b': /* (b)oth */
+      case 'b':
+      { /* (b)oth */
         e->security |= (SEC_ENCRYPT | SEC_SIGN);
         break;
+      }
 
       case 'C':
+      {
         e->security &= ~SEC_SIGN;
         break;
+      }
 
-      case 'c': /* (c)lear */
+      case 'c':
+      { /* (c)lear */
         e->security &= ~(SEC_ENCRYPT | SEC_SIGN);
         break;
+      }
 
-      case 'e': /* (e)ncrypt */
+      case 'e':
+      { /* (e)ncrypt */
         e->security |= SEC_ENCRYPT;
         e->security &= ~SEC_SIGN;
         break;
+      }
 
       case 'm': /* (p)gp or s/(m)ime */
       case 'p':
+      {
         is_smime = !is_smime;
         if (is_smime)
         {
@@ -5533,24 +5615,33 @@ static int gpgme_send_menu(struct Email *e, int is_smime)
         }
         crypt_opportunistic_encrypt(e);
         break;
+      }
 
-      case 'O': /* oppenc mode on */
+      case 'O':
+      { /* oppenc mode on */
         e->security |= SEC_OPPENCRYPT;
         crypt_opportunistic_encrypt(e);
         break;
+      }
 
-      case 'o': /* oppenc mode off */
+      case 'o':
+      { /* oppenc mode off */
         e->security &= ~SEC_OPPENCRYPT;
         break;
+      }
 
-      case 'S': /* (s)ign in oppenc mode */
+      case 'S':
+      { /* (s)ign in oppenc mode */
         e->security |= SEC_SIGN;
         break;
+      }
 
-      case 's': /* (s)ign */
+      case 's':
+      { /* (s)ign */
         e->security &= ~SEC_ENCRYPT;
         e->security |= SEC_SIGN;
         break;
+      }
     }
   }
 

--- a/ncrypt/gnupgparse.c
+++ b/ncrypt/gnupgparse.c
@@ -198,26 +198,40 @@ static struct PgpKeyInfo *parse_pub_line(char *buf, bool *is_subkey, struct PgpK
         switch (*p)
         { /* look only at the first letter */
           case 'd':
+          {
             flags |= KEYFLAG_DISABLED;
             break;
+          }
           case 'e':
+          {
             flags |= KEYFLAG_EXPIRED;
             break;
+          }
           case 'f':
+          {
             trust = 3;
             break;
+          }
           case 'm':
+          {
             trust = 2;
             break;
+          }
           case 'n':
+          {
             trust = 1;
             break;
+          }
           case 'r':
+          {
             flags |= KEYFLAG_REVOKED;
             break;
+          }
           case 'u':
+          {
             trust = 3;
             break;
+          }
         }
 
         if (!is_uid && !(*is_subkey && C_PgpIgnoreSubkeys))
@@ -300,12 +314,18 @@ static struct PgpKeyInfo *parse_pub_line(char *buf, bool *is_subkey, struct PgpK
         }
         break;
       }
-      case 7: /* valid for n days */
+      case 7:
+      { /* valid for n days */
         break;
-      case 8: /* Local id         */
+      }
+      case 8:
+      { /* Local id         */
         break;
-      case 9: /* ownertrust       */
+      }
+      case 9:
+      { /* ownertrust       */
         break;
+      }
       case 10: /* name             */
       {
         /* Empty field or no trailing colon.
@@ -345,9 +365,12 @@ static struct PgpKeyInfo *parse_pub_line(char *buf, bool *is_subkey, struct PgpK
 
         break;
       }
-      case 11: /* signature class  */
+      case 11:
+      { /* signature class  */
         break;
-      case 12: /* key capabilities */
+      }
+      case 12:
+      { /* key capabilities */
         mutt_debug(LL_DEBUG2, "capabilities info: %s\n", p);
 
         while (*p)
@@ -355,16 +378,22 @@ static struct PgpKeyInfo *parse_pub_line(char *buf, bool *is_subkey, struct PgpK
           switch (*p++)
           {
             case 'D':
+            {
               flags |= KEYFLAG_DISABLED;
               break;
+            }
 
             case 'e':
+            {
               flags |= KEYFLAG_CANENCRYPT;
               break;
+            }
 
             case 's':
+            {
               flags |= KEYFLAG_CANSIGN;
               break;
+            }
           }
         }
 
@@ -376,9 +405,12 @@ static struct PgpKeyInfo *parse_pub_line(char *buf, bool *is_subkey, struct PgpK
         }
 
         break;
+      }
 
       default:
+      {
         break;
+      }
     }
   }
 

--- a/ncrypt/pgp.c
+++ b/ncrypt/pgp.c
@@ -1954,7 +1954,8 @@ int pgp_class_send_menu(struct Email *e)
   {
     switch (choices[choice - 1])
     {
-      case 'a': /* sign (a)s */
+      case 'a':
+      { /* sign (a)s */
         OptPgpCheckTrust = false;
 
         p = pgp_ask_for_key(_("Sign as: "), NULL, KEYFLAG_NO_FLAGS, PGP_SECRING);
@@ -1970,45 +1971,64 @@ int pgp_class_send_menu(struct Email *e)
           crypt_pgp_void_passphrase(); /* probably need a different passphrase */
         }
         break;
+      }
 
-      case 'b': /* (b)oth */
+      case 'b':
+      { /* (b)oth */
         e->security |= (SEC_ENCRYPT | SEC_SIGN);
         break;
+      }
 
       case 'C':
+      {
         e->security &= ~SEC_SIGN;
         break;
+      }
 
-      case 'c': /* (c)lear     */
+      case 'c':
+      { /* (c)lear     */
         e->security &= ~(SEC_ENCRYPT | SEC_SIGN);
         break;
+      }
 
-      case 'e': /* (e)ncrypt */
+      case 'e':
+      { /* (e)ncrypt */
         e->security |= SEC_ENCRYPT;
         e->security &= ~SEC_SIGN;
         break;
+      }
 
-      case 'i': /* toggle (i)nline */
+      case 'i':
+      { /* toggle (i)nline */
         e->security ^= SEC_INLINE;
         break;
+      }
 
-      case 'O': /* oppenc mode on */
+      case 'O':
+      { /* oppenc mode on */
         e->security |= SEC_OPPENCRYPT;
         crypt_opportunistic_encrypt(e);
         break;
+      }
 
-      case 'o': /* oppenc mode off */
+      case 'o':
+      { /* oppenc mode off */
         e->security &= ~SEC_OPPENCRYPT;
         break;
+      }
 
-      case 'S': /* (s)ign in oppenc mode */
+      case 'S':
+      { /* (s)ign in oppenc mode */
         e->security |= SEC_SIGN;
         break;
+      }
 
-      case 's': /* (s)ign */
+      case 's':
+      { /* (s)ign */
         e->security &= ~SEC_ENCRYPT;
         e->security |= SEC_SIGN;
         break;
+      }
     }
   }
 

--- a/ncrypt/pgpkey.c
+++ b/ncrypt/pgpkey.c
@@ -197,13 +197,16 @@ static const char *pgp_entry_fmt(char *buf, size_t buflen, size_t col, int cols,
   switch (tolower(op))
   {
     case 'a':
+    {
       if (!optional)
       {
         snprintf(fmt, sizeof(fmt), "%%%ss", prec);
         snprintf(buf, buflen, fmt, key->algorithm);
       }
       break;
+    }
     case 'c':
+    {
       if (!optional)
       {
         snprintf(fmt, sizeof(fmt), "%%%ss", prec);
@@ -212,7 +215,9 @@ static const char *pgp_entry_fmt(char *buf, size_t buflen, size_t col, int cols,
       else if (!(kflags & KEYFLAG_ABILITIES))
         optional = 0;
       break;
+    }
     case 'f':
+    {
       if (!optional)
       {
         snprintf(fmt, sizeof(fmt), "%%%sc", prec);
@@ -221,28 +226,36 @@ static const char *pgp_entry_fmt(char *buf, size_t buflen, size_t col, int cols,
       else if (!(kflags & KEYFLAG_RESTRICTIONS))
         optional = 0;
       break;
+    }
     case 'k':
+    {
       if (!optional)
       {
         snprintf(fmt, sizeof(fmt), "%%%ss", prec);
         snprintf(buf, buflen, fmt, pgp_this_keyid(key));
       }
       break;
+    }
     case 'l':
+    {
       if (!optional)
       {
         snprintf(fmt, sizeof(fmt), "%%%sd", prec);
         snprintf(buf, buflen, fmt, key->keylen);
       }
       break;
+    }
     case 'n':
+    {
       if (!optional)
       {
         snprintf(fmt, sizeof(fmt), "%%%sd", prec);
         snprintf(buf, buflen, fmt, entry->num);
       }
       break;
+    }
     case 't':
+    {
       if (!optional)
       {
         snprintf(fmt, sizeof(fmt), "%%%sc", prec);
@@ -254,13 +267,16 @@ static const char *pgp_entry_fmt(char *buf, size_t buflen, size_t col, int cols,
         optional = 0;
       }
       break;
+    }
     case 'u':
+    {
       if (!optional)
       {
         snprintf(fmt, sizeof(fmt), "%%%ss", prec);
         snprintf(buf, buflen, fmt, NONULL(uid->addr));
       }
       break;
+    }
     case '[':
 
     {
@@ -643,18 +659,26 @@ static struct PgpKeyInfo *pgp_select_key(struct PgpKeyInfo *keys,
   switch (C_PgpSortKeys & SORT_MASK)
   {
     case SORT_ADDRESS:
+    {
       f = pgp_compare_address;
       break;
+    }
     case SORT_DATE:
+    {
       f = pgp_compare_date;
       break;
+    }
     case SORT_KEYID:
+    {
       f = pgp_compare_keyid;
       break;
+    }
     case SORT_TRUST:
     default:
+    {
       f = pgp_compare_trust;
       break;
+    }
   }
   qsort(key_table, i, sizeof(struct PgpUid *), f);
 
@@ -691,7 +715,7 @@ static struct PgpKeyInfo *pgp_select_key(struct PgpKeyInfo *keys,
     switch (mutt_menu_loop(menu))
     {
       case OP_VERIFY_KEY:
-
+      {
         mutt_mktemp(tempfile, sizeof(tempfile));
         FILE *fp_null = fopen("/dev/null", "w");
         if (!fp_null)
@@ -732,14 +756,16 @@ static struct PgpKeyInfo *pgp_select_key(struct PgpKeyInfo *keys,
         menu->redraw = REDRAW_FULL;
 
         break;
+      }
 
       case OP_VIEW_ID:
-
+      {
         mutt_message("%s", NONULL(key_table[menu->current]->addr));
         break;
+      }
 
       case OP_GENERIC_SELECT_ENTRY:
-
+      {
         /* XXX make error reporting more verbose */
 
         if (OptPgpCheckTrust)
@@ -767,16 +793,22 @@ static struct PgpKeyInfo *pgp_select_key(struct PgpKeyInfo *keys,
             switch (key_table[menu->current]->trust & 0x03)
             {
               case 0:
+              {
                 str = _("ID has undefined validity. Do you really want to use "
                         "the key?");
                 break;
+              }
               case 1:
+              {
                 str = _("ID is not valid. Do you really want to use the key?");
                 break;
+              }
               case 2:
+              {
                 str = _("ID is only marginally valid. Do you really want to "
                         "use the key?");
                 break;
+              }
             }
           }
 
@@ -792,12 +824,14 @@ static struct PgpKeyInfo *pgp_select_key(struct PgpKeyInfo *keys,
         kp = key_table[menu->current]->parent;
         done = true;
         break;
+      }
 
       case OP_EXIT:
-
+      {
         kp = NULL;
         done = true;
         break;
+      }
     }
   }
 

--- a/ncrypt/pgplib.c
+++ b/ncrypt/pgplib.c
@@ -43,17 +43,29 @@ const char *pgp_pkalgbytype(unsigned char type)
   switch (type)
   {
     case 1:
+    {
       return "RSA";
+    }
     case 2:
+    {
       return "RSA";
+    }
     case 3:
+    {
       return "RSA";
+    }
     case 16:
+    {
       return "ElG";
+    }
     case 17:
+    {
       return "DSA";
+    }
     case 20:
+    {
       return "ElG";
+    }
     default:
       return "unk";
   }
@@ -72,7 +84,9 @@ bool pgp_canencrypt(unsigned char type)
     case 2:
     case 16:
     case 20:
+    {
       return true;
+    }
     default:
       return false;
   }
@@ -91,7 +105,9 @@ bool pgp_cansign(unsigned char type)
     case 3:
     case 17:
     case 20:
+    {
       return true;
+    }
     default:
       return false;
   }

--- a/ncrypt/pgppacket.c
+++ b/ncrypt/pgppacket.c
@@ -188,9 +188,10 @@ unsigned char *pgp_read_packet(FILE *fp, size_t *len)
       }
 
       case 1:
+      {
         bytes = 2;
         /* fallthrough */
-
+      }
       case 2:
       {
         if (!bytes)

--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -337,8 +337,10 @@ static const char *fmt_smime_command(char *buf, size_t buflen, size_t col, int c
     }
 
     default:
+    {
       *buf = '\0';
       break;
+    }
   }
 
   if (optional)
@@ -455,6 +457,7 @@ static void smime_make_entry(char *buf, size_t buflen, struct Menu *menu, int li
   switch (key->trust)
   {
     case 'e':
+    {
       /* L10N: Describes the trust state of a S/MIME key.
          This translation must be padded with spaces to the right such that it
          has the same length as the other translations.
@@ -462,7 +465,9 @@ static void smime_make_entry(char *buf, size_t buflen, struct Menu *menu, int li
          Expired, Invalid, Revoked, Trusted, Unverified, Verified, and Unknown.  */
       truststate = _("Expired   ");
       break;
+    }
     case 'i':
+    {
       /* L10N: Describes the trust state of a S/MIME key.
          This translation must be padded with spaces to the right such that it
          has the same length as the other translations.
@@ -470,7 +475,9 @@ static void smime_make_entry(char *buf, size_t buflen, struct Menu *menu, int li
          Expired, Invalid, Revoked, Trusted, Unverified, Verified, and Unknown.  */
       truststate = _("Invalid   ");
       break;
+    }
     case 'r':
+    {
       /* L10N: Describes the trust state of a S/MIME key.
          This translation must be padded with spaces to the right such that it
          has the same length as the other translations.
@@ -478,7 +485,9 @@ static void smime_make_entry(char *buf, size_t buflen, struct Menu *menu, int li
          Expired, Invalid, Revoked, Trusted, Unverified, Verified, and Unknown.  */
       truststate = _("Revoked   ");
       break;
+    }
     case 't':
+    {
       /* L10N: Describes the trust state of a S/MIME key.
          This translation must be padded with spaces to the right such that it
          has the same length as the other translations.
@@ -486,7 +495,9 @@ static void smime_make_entry(char *buf, size_t buflen, struct Menu *menu, int li
          Expired, Invalid, Revoked, Trusted, Unverified, Verified, and Unknown.  */
       truststate = _("Trusted   ");
       break;
+    }
     case 'u':
+    {
       /* L10N: Describes the trust state of a S/MIME key.
          This translation must be padded with spaces to the right such that it
          has the same length as the other translations.
@@ -494,7 +505,9 @@ static void smime_make_entry(char *buf, size_t buflen, struct Menu *menu, int li
          Expired, Invalid, Revoked, Trusted, Unverified, Verified, and Unknown.  */
       truststate = _("Unverified");
       break;
+    }
     case 'v':
+    {
       /* L10N: Describes the trust state of a S/MIME key.
          This translation must be padded with spaces to the right such that it
          has the same length as the other translations.
@@ -502,6 +515,7 @@ static void smime_make_entry(char *buf, size_t buflen, struct Menu *menu, int li
          Expired, Invalid, Revoked, Trusted, Unverified, Verified, and Unknown.  */
       truststate = _("Verified  ");
       break;
+    }
     default:
       /* L10N: Describes the trust state of a S/MIME key.
          This translation must be padded with spaces to the right such that it
@@ -574,6 +588,7 @@ static struct SmimeKey *smime_select_key(struct SmimeKey *keys, char *query)
     switch (mutt_menu_loop(menu))
     {
       case OP_GENERIC_SELECT_ENTRY:
+      {
         if (table[menu->current]->trust != 't')
         {
           switch (table[menu->current]->trust)
@@ -581,16 +596,22 @@ static struct SmimeKey *smime_select_key(struct SmimeKey *keys, char *query)
             case 'e':
             case 'i':
             case 'r':
+            {
               s = _("ID is expired/disabled/revoked. Do you really want to use "
                     "the key?");
               break;
+            }
             case 'u':
+            {
               s = _("ID has undefined validity. Do you really want to use the "
                     "key?");
               break;
+            }
             case 'v':
+            {
               s = _("ID is not trusted. Do you really want to use the key?");
               break;
+            }
           }
 
           snprintf(buf, sizeof(buf), "%s", s);
@@ -605,9 +626,12 @@ static struct SmimeKey *smime_select_key(struct SmimeKey *keys, char *query)
         selected_key = table[menu->current];
         done = true;
         break;
+      }
       case OP_EXIT:
+      {
         done = true;
         break;
+      }
     }
   }
 
@@ -648,36 +672,52 @@ static struct SmimeKey *smime_parse_key(char *buf)
 
     switch (field)
     {
-      case 1: /* mailbox */
+      case 1:
+      { /* mailbox */
         key->email = mutt_str_strdup(p);
         break;
-      case 2: /* hash */
+      }
+      case 2:
+      { /* hash */
         key->hash = mutt_str_strdup(p);
         break;
-      case 3: /* label */
+      }
+      case 3:
+      { /* label */
         key->label = mutt_str_strdup(p);
         break;
-      case 4: /* issuer */
+      }
+      case 4:
+      { /* issuer */
         key->issuer = mutt_str_strdup(p);
         break;
-      case 5: /* trust */
+      }
+      case 5:
+      { /* trust */
         key->trust = *p;
         break;
-      case 6: /* purpose */
+      }
+      case 6:
+      { /* purpose */
         while (*p)
         {
           switch (*p++)
           {
             case 'e':
+            {
               key->flags |= KEYFLAG_CANENCRYPT;
               break;
+            }
 
             case 's':
+            {
               key->flags |= KEYFLAG_CANSIGN;
               break;
+            }
           }
         }
         break;
+      }
     }
   }
 
@@ -2359,7 +2399,8 @@ int smime_class_send_menu(struct Email *e)
   {
     switch (choices[choice - 1])
     {
-      case 'a': /* sign (a)s */
+      case 'a':
+      { /* sign (a)s */
         key = smime_ask_for_key(_("Sign as: "), KEYFLAG_CANSIGN, false);
         if (key)
         {
@@ -2373,41 +2414,58 @@ int smime_class_send_menu(struct Email *e)
         }
 
         break;
+      }
 
-      case 'b': /* (b)oth */
+      case 'b':
+      { /* (b)oth */
         e->security |= (SEC_ENCRYPT | SEC_SIGN);
         break;
+      }
 
-      case 'c': /* (c)lear */
+      case 'c':
+      { /* (c)lear */
         e->security &= ~(SEC_ENCRYPT | SEC_SIGN);
         break;
+      }
 
       case 'C':
+      {
         e->security &= ~SEC_SIGN;
         break;
+      }
 
-      case 'e': /* (e)ncrypt */
+      case 'e':
+      { /* (e)ncrypt */
         e->security |= SEC_ENCRYPT;
         e->security &= ~SEC_SIGN;
         break;
+      }
 
-      case 'O': /* oppenc mode on */
+      case 'O':
+      { /* oppenc mode on */
         e->security |= SEC_OPPENCRYPT;
         crypt_opportunistic_encrypt(e);
         break;
+      }
 
-      case 'o': /* oppenc mode off */
+      case 'o':
+      { /* oppenc mode off */
         e->security &= ~SEC_OPPENCRYPT;
         break;
+      }
 
-      case 'S': /* (s)ign in oppenc mode */
+      case 'S':
+      { /* (s)ign in oppenc mode */
         e->security |= SEC_SIGN;
         break;
+      }
 
-      case 's': /* (s)ign */
+      case 's':
+      { /* (s)ign */
         e->security &= ~SEC_ENCRYPT;
         e->security |= SEC_SIGN;
         break;
+      }
 
       case 'w': /* encrypt (w)ith */
       {
@@ -2420,62 +2478,88 @@ int smime_class_send_menu(struct Email *e)
                                     _("123c")))
           {
             case 1:
+            {
               switch (choice = mutt_multi_choice(_("(1) DES, (2) Triple-DES?"),
                                                  // L10N: Options for: (1) DES, (2) Triple-DES
                                                  _("12")))
               {
                 case 1:
+                {
                   mutt_str_replace(&C_SmimeEncryptWith, "des");
                   break;
+                }
                 case 2:
+                {
                   mutt_str_replace(&C_SmimeEncryptWith, "des3");
                   break;
+                }
               }
               break;
+            }
 
             case 2:
+            {
               switch (choice = mutt_multi_choice(
                           _("(1) RC2-40, (2) RC2-64, (3) RC2-128?"),
                           // L10N: Options for: (1) RC2-40, (2) RC2-64, (3) RC2-128
                           _("123")))
               {
                 case 1:
+                {
                   mutt_str_replace(&C_SmimeEncryptWith, "rc2-40");
                   break;
+                }
                 case 2:
+                {
                   mutt_str_replace(&C_SmimeEncryptWith, "rc2-64");
                   break;
+                }
                 case 3:
+                {
                   mutt_str_replace(&C_SmimeEncryptWith, "rc2-128");
                   break;
+                }
               }
               break;
+            }
 
             case 3:
+            {
               switch (choice = mutt_multi_choice(
                           _("(1) AES128, (2) AES192, (3) AES256?"),
                           // L10N: Options for: (1) AES128, (2) AES192, (3) AES256
                           _("123")))
               {
                 case 1:
+                {
                   mutt_str_replace(&C_SmimeEncryptWith, "aes128");
                   break;
+                }
                 case 2:
+                {
                   mutt_str_replace(&C_SmimeEncryptWith, "aes192");
                   break;
+                }
                 case 3:
+                {
                   mutt_str_replace(&C_SmimeEncryptWith, "aes256");
                   break;
+                }
               }
               break;
+            }
 
             case 4:
+            {
               FREE(&C_SmimeEncryptWith);
-            /* (c)lear */
-            /* fallthrough */
-            case -1: /* Ctrl-G or Enter */
+              /* (c)lear */
+              /* fallthrough */
+            }
+            case -1:
+            { /* Ctrl-G or Enter */
               choice = 0;
               break;
+            }
           }
         } while (choice == -1);
         break;

--- a/nntp/browse.c
+++ b/nntp/browse.c
@@ -62,11 +62,14 @@ const char *group_index_format_str(char *buf, size_t buflen, size_t col, int col
   switch (op)
   {
     case 'C':
+    {
       snprintf(fmt, sizeof(fmt), "%%%sd", prec);
       snprintf(buf, buflen, fmt, folder->num + 1);
       break;
+    }
 
     case 'd':
+    {
       if (folder->ff->nd->desc)
       {
         char *desc = mutt_str_strdup(folder->ff->nd->desc);
@@ -84,30 +87,38 @@ const char *group_index_format_str(char *buf, size_t buflen, size_t col, int col
         snprintf(buf, buflen, fmt, "");
       }
       break;
+    }
 
     case 'f':
+    {
       mutt_str_strfcpy(fn, folder->ff->name, sizeof(fn));
       snprintf(fmt, sizeof(fmt), "%%%ss", prec);
       snprintf(buf, buflen, fmt, fn);
       break;
+    }
 
     case 'M':
+    {
       snprintf(fmt, sizeof(fmt), "%%%sc", prec);
       if (folder->ff->nd->deleted)
         snprintf(buf, buflen, fmt, 'D');
       else
         snprintf(buf, buflen, fmt, folder->ff->nd->allowed ? ' ' : '-');
       break;
+    }
 
     case 'N':
+    {
       snprintf(fmt, sizeof(fmt), "%%%sc", prec);
       if (folder->ff->nd->subscribed)
         snprintf(buf, buflen, fmt, ' ');
       else
         snprintf(buf, buflen, fmt, folder->ff->has_new_mail ? 'N' : 'u');
       break;
+    }
 
     case 'n':
+    {
       if (Context && (Context->mailbox->mdata == folder->ff->nd))
       {
         snprintf(fmt, sizeof(fmt), "%%%sd", prec);
@@ -125,8 +136,10 @@ const char *group_index_format_str(char *buf, size_t buflen, size_t col, int col
         snprintf(buf, buflen, fmt, folder->ff->nd->unread);
       }
       break;
+    }
 
     case 's':
+    {
       if (flags & MUTT_FORMAT_OPTIONAL)
       {
         if (folder->ff->nd->unread != 0)
@@ -151,6 +164,7 @@ const char *group_index_format_str(char *buf, size_t buflen, size_t col, int col
         snprintf(buf, buflen, fmt, folder->ff->nd->unread);
       }
       break;
+    }
   }
   return src;
 }

--- a/nntp/newsrc.c
+++ b/nntp/newsrc.c
@@ -929,10 +929,13 @@ const char *nntp_format_str(char *buf, size_t buflen, size_t col, int cols, char
       break;
     }
     case 'p':
+    {
       snprintf(fmt, sizeof(fmt), "%%%su", prec);
       snprintf(buf, buflen, fmt, acct->port);
       break;
+    }
     case 'P':
+    {
       *buf = '\0';
       if (acct->flags & MUTT_ACCT_PORT)
       {
@@ -940,12 +943,15 @@ const char *nntp_format_str(char *buf, size_t buflen, size_t col, int cols, char
         snprintf(buf, buflen, fmt, acct->port);
       }
       break;
+    }
     case 's':
+    {
       mutt_str_strfcpy(fn, acct->host, sizeof(fn));
       mutt_str_strlower(fn);
       snprintf(fmt, sizeof(fmt), "%%%ss", prec);
       snprintf(buf, buflen, fmt, fn);
       break;
+    }
     case 'S':
     {
       struct Url url;
@@ -959,9 +965,11 @@ const char *nntp_format_str(char *buf, size_t buflen, size_t col, int cols, char
       break;
     }
     case 'u':
+    {
       snprintf(fmt, sizeof(fmt), "%%%ss", prec);
       snprintf(buf, buflen, fmt, acct->user);
       break;
+    }
   }
   return src;
 }

--- a/notmuch/mutt_notmuch.c
+++ b/notmuch/mutt_notmuch.c
@@ -1461,10 +1461,13 @@ static int remove_filename(struct Mailbox *m, const char *path)
   switch (st)
   {
     case NOTMUCH_STATUS_SUCCESS:
+    {
       mutt_debug(LL_DEBUG2, "nm: remove success, call unlink\n");
       unlink(path);
       break;
+    }
     case NOTMUCH_STATUS_DUPLICATE_MESSAGE_ID:
+    {
       mutt_debug(LL_DEBUG2, "nm: remove success (duplicate), call unlink\n");
       unlink(path);
       for (ls = notmuch_message_get_filenames(msg);
@@ -1477,9 +1480,12 @@ static int remove_filename(struct Mailbox *m, const char *path)
         notmuch_database_remove_message(db, path);
       }
       break;
+    }
     default:
+    {
       mutt_debug(LL_DEBUG1, "nm: failed to remove '%s' [st=%d]\n", path, (int) st);
       break;
+    }
   }
 
   notmuch_message_destroy(msg);
@@ -1536,8 +1542,11 @@ static int rename_filename(struct Mailbox *m, const char *old_file,
   switch (st)
   {
     case NOTMUCH_STATUS_SUCCESS:
+    {
       break;
+    }
     case NOTMUCH_STATUS_DUPLICATE_MESSAGE_ID:
+    {
       mutt_debug(LL_DEBUG2, "nm: rename: syncing duplicate filename\n");
       notmuch_message_destroy(msg);
       msg = NULL;
@@ -1570,9 +1579,12 @@ static int rename_filename(struct Mailbox *m, const char *old_file,
       notmuch_database_find_message_by_filename(db, new_file, &msg);
       st = NOTMUCH_STATUS_SUCCESS;
       break;
+    }
     default:
+    {
       mutt_debug(LL_DEBUG1, "nm: failed to remove '%s' [st=%d]\n", old_file, (int) st);
       break;
+    }
   }
 
   if ((st == NOTMUCH_STATUS_SUCCESS) && e && msg)
@@ -2179,13 +2191,17 @@ static int nm_mbox_open(struct Mailbox *m)
     switch (mdata->query_type)
     {
       case NM_QUERY_TYPE_MESGS:
+      {
         if (!read_mesgs_query(m, q, false))
           rc = -2;
         break;
+      }
       case NM_QUERY_TYPE_THREADS:
+      {
         if (!read_threads_query(m, q, false, get_limit(mdata)))
           rc = -2;
         break;
+      }
     }
     notmuch_query_destroy(q);
   }

--- a/pager.c
+++ b/pager.c
@@ -2498,11 +2498,14 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
     switch (ch)
     {
       case OP_EXIT:
+      {
         rc = -1;
         ch = -1;
         break;
+      }
 
       case OP_QUIT:
+      {
         if (query_quadoption(C_Quit, _("Quit NeoMutt?")) == MUTT_YES)
         {
           /* avoid prompting again in the index menu */
@@ -2510,8 +2513,10 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
           ch = -1;
         }
         break;
+      }
 
       case OP_NEXT_PAGE:
+      {
         if (rd.line_info[rd.curline].offset < (rd.sb.st_size - 1))
         {
           rd.topline = up_n_lines(C_PagerContext, rd.line_info, rd.curline, rd.hide_quoted);
@@ -2528,8 +2533,10 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
           ch = -1;
         }
         break;
+      }
 
       case OP_PREV_PAGE:
+      {
         if (rd.topline != 0)
         {
           rd.topline = up_n_lines(rd.pager_window->rows - C_PagerContext,
@@ -2538,8 +2545,10 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         else
           mutt_message(_("Top of message is shown"));
         break;
+      }
 
       case OP_NEXT_LINE:
+      {
         if (rd.line_info[rd.curline].offset < (rd.sb.st_size - 1))
         {
           rd.topline++;
@@ -2555,22 +2564,28 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         else
           mutt_message(_("Bottom of message is shown"));
         break;
+      }
 
       case OP_PREV_LINE:
+      {
         if (rd.topline)
           rd.topline = up_n_lines(1, rd.line_info, rd.topline, rd.hide_quoted);
         else
           mutt_error(_("Top of message is shown"));
         break;
+      }
 
       case OP_PAGER_TOP:
+      {
         if (rd.topline)
           rd.topline = 0;
         else
           mutt_error(_("Top of message is shown"));
         break;
+      }
 
       case OP_HALF_UP:
+      {
         if (rd.topline)
         {
           rd.topline = up_n_lines(rd.pager_window->rows / 2 + (rd.pager_window->rows % 2),
@@ -2579,8 +2594,10 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         else
           mutt_error(_("Top of message is shown"));
         break;
+      }
 
       case OP_HALF_DOWN:
+      {
         if (rd.line_info[rd.curline].offset < (rd.sb.st_size - 1))
         {
           rd.topline = up_n_lines(rd.pager_window->rows / 2, rd.line_info,
@@ -2598,9 +2615,11 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
           ch = -1;
         }
         break;
+      }
 
       case OP_SEARCH_NEXT:
       case OP_SEARCH_OPPOSITE:
+      {
         if (rd.search_compiled)
         {
           wrapped = false;
@@ -2674,9 +2693,10 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         }
         /* no previous search pattern */
         /* fallthrough */
-
+      }
       case OP_SEARCH:
       case OP_SEARCH_REVERSE:
+      {
         mutt_str_strfcpy(buf, searchbuf, sizeof(buf));
         if (mutt_get_field(((ch == OP_SEARCH) || (ch == OP_SEARCH_NEXT)) ?
                                _("Search for: ") :
@@ -2805,17 +2825,21 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         }
         pager_menu->redraw = REDRAW_BODY;
         break;
+      }
 
       case OP_SEARCH_TOGGLE:
+      {
         if (rd.search_compiled)
         {
           rd.search_flag ^= MUTT_SEARCH;
           pager_menu->redraw = REDRAW_BODY;
         }
         break;
+      }
 
       case OP_SORT:
       case OP_SORT_REVERSE:
+      {
         CHECK_MODE(IsEmail(extra))
         if (mutt_select_sort((ch == OP_SORT_REVERSE)) == 0)
         {
@@ -2824,8 +2848,10 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
           rc = OP_DISPLAY_MESSAGE;
         }
         break;
+      }
 
       case OP_HELP:
+      {
         /* don't let the user enter the help-menu from the help screen! */
         if (!InHelp)
         {
@@ -2837,8 +2863,10 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         else
           mutt_error(_("Help is currently being shown"));
         break;
+      }
 
       case OP_PAGER_HIDE_QUOTED:
+      {
         if (rd.has_types)
         {
           rd.hide_quoted ^= MUTT_HIDE;
@@ -2848,8 +2876,10 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
             pager_menu->redraw = REDRAW_BODY;
         }
         break;
+      }
 
       case OP_PAGER_SKIP_QUOTED:
+      {
         if (rd.has_types)
         {
           int dretval = 0;
@@ -2908,8 +2938,10 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
           rd.topline = new_topline;
         }
         break;
+      }
 
-      case OP_PAGER_BOTTOM: /* move to the end of the file */
+      case OP_PAGER_BOTTOM:
+      { /* move to the end of the file */
         if (rd.line_info[rd.curline].offset < (rd.sb.st_size - 1))
         {
           int line_num = rd.curline;
@@ -2927,15 +2959,20 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         else
           mutt_error(_("Bottom of message is shown"));
         break;
+      }
 
       case OP_REDRAW:
+      {
         clearok(stdscr, true);
         pager_menu->redraw = REDRAW_FULL;
         break;
+      }
 
       case OP_NULL:
+      {
         km_error_key(MENU_PAGER);
         break;
+      }
 
         /* --------------------------------------------------------------------
          * The following are operations on the current message rather than
@@ -2959,6 +2996,7 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
       }
 
       case OP_RESEND:
+      {
         CHECK_MODE(IsEmail(extra) || IsMsgAttach(extra))
         CHECK_ATTACH;
         if (IsMsgAttach(extra))
@@ -2967,8 +3005,10 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
           mutt_resend_message(NULL, extra->ctx, extra->email);
         pager_menu->redraw = REDRAW_FULL;
         break;
+      }
 
       case OP_COMPOSE_TO_SENDER:
+      {
         CHECK_MODE(IsEmail(extra) || IsMsgAttach(extra));
         CHECK_ATTACH;
         if (IsMsgAttach(extra))
@@ -2982,8 +3022,10 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         }
         pager_menu->redraw = REDRAW_FULL;
         break;
+      }
 
       case OP_CHECK_TRADITIONAL:
+      {
         CHECK_MODE(IsEmail(extra));
         if (!(WithCrypto & APPLICATION_PGP))
           break;
@@ -2993,17 +3035,21 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
           rc = OP_CHECK_TRADITIONAL;
         }
         break;
+      }
 
       case OP_CREATE_ALIAS:
+      {
         CHECK_MODE(IsEmail(extra) || IsMsgAttach(extra));
         if (IsMsgAttach(extra))
           mutt_alias_create(extra->body->email->env, NULL);
         else
           mutt_alias_create(extra->email->env, NULL);
         break;
+      }
 
       case OP_PURGE_MESSAGE:
       case OP_DELETE:
+      {
         CHECK_MODE(IsEmail(extra));
         CHECK_READONLY;
         /* L10N: CHECK_ACL */
@@ -3020,6 +3066,7 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
           rc = OP_MAIN_NEXT_UNDELETED;
         }
         break;
+      }
 
       case OP_MAIN_SET_FLAG:
       case OP_MAIN_CLEAR_FLAG:
@@ -3082,14 +3129,17 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
       }
 
       case OP_DISPLAY_ADDRESS:
+      {
         CHECK_MODE(IsEmail(extra) || IsMsgAttach(extra));
         if (IsMsgAttach(extra))
           mutt_display_address(extra->body->email->env);
         else
           mutt_display_address(extra->email->env);
         break;
+      }
 
       case OP_ENTER_COMMAND:
+      {
         old_PagerIndexLines = C_PagerIndexLines;
 
         mutt_enter_command();
@@ -3118,8 +3168,10 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
 
         ch = 0;
         break;
+      }
 
       case OP_FLAG_MESSAGE:
+      {
         CHECK_MODE(IsEmail(extra));
         CHECK_READONLY;
         /* L10N: CHECK_ACL */
@@ -3133,8 +3185,10 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
           rc = OP_MAIN_NEXT_UNDELETED;
         }
         break;
+      }
 
       case OP_PIPE:
+      {
         CHECK_MODE(IsEmail(extra) || IsAttach(extra));
         if (IsAttach(extra))
           mutt_pipe_attachment_list(extra->actx, extra->fp, false, extra->body, false);
@@ -3146,8 +3200,10 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
           mutt_emaillist_free(&el);
         }
         break;
+      }
 
       case OP_PRINT:
+      {
         CHECK_MODE(IsEmail(extra) || IsAttach(extra));
         if (IsAttach(extra))
           mutt_print_attachment_list(extra->actx, extra->fp, false, extra->body);
@@ -3159,16 +3215,20 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
           mutt_emaillist_free(&el);
         }
         break;
+      }
 
       case OP_MAIL:
+      {
         CHECK_MODE(IsEmail(extra) && !IsAttach(extra));
         CHECK_ATTACH;
         ci_send_message(SEND_NO_FLAGS, NULL, NULL, extra->ctx, NULL);
         pager_menu->redraw = REDRAW_FULL;
         break;
+      }
 
 #ifdef USE_NNTP
       case OP_POST:
+      {
         CHECK_MODE(IsEmail(extra) && !IsAttach(extra));
         CHECK_ATTACH;
         if (extra->ctx && (extra->ctx->mailbox->magic == MUTT_NNTP) &&
@@ -3179,8 +3239,10 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         ci_send_message(SEND_NEWS, NULL, NULL, extra->ctx, NULL);
         pager_menu->redraw = REDRAW_FULL;
         break;
+      }
 
       case OP_FORWARD_TO_GROUP:
+      {
         CHECK_MODE(IsEmail(extra) || IsMsgAttach(extra));
         CHECK_ATTACH;
         if (extra->ctx && (extra->ctx->mailbox->magic == MUTT_NNTP) &&
@@ -3199,8 +3261,10 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         }
         pager_menu->redraw = REDRAW_FULL;
         break;
+      }
 
       case OP_FOLLOWUP:
+      {
         CHECK_MODE(IsEmail(extra) || IsMsgAttach(extra));
         CHECK_ATTACH;
 
@@ -3234,7 +3298,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
           break;
         }
 #endif
-      /* fallthrough */
+        /* fallthrough */
+      }
       case OP_REPLY:
       case OP_GROUP_REPLY:
       case OP_GROUP_CHAT_REPLY:
@@ -3277,6 +3342,7 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
       }
 
       case OP_FORWARD_MESSAGE:
+      {
         CHECK_MODE(IsEmail(extra) || IsMsgAttach(extra));
         CHECK_ATTACH;
         if (IsMsgAttach(extra))
@@ -3290,22 +3356,27 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         }
         pager_menu->redraw = REDRAW_FULL;
         break;
+      }
 
       case OP_DECRYPT_SAVE:
+      {
         if (!WithCrypto)
         {
           ch = -1;
           break;
         }
-      /* fallthrough */
+        /* fallthrough */
+      }
       case OP_SAVE:
+      {
         if (IsAttach(extra))
         {
           mutt_save_attachment_list(extra->actx, extra->fp, false, extra->body,
                                     extra->email, NULL);
           break;
         }
-      /* fallthrough */
+        /* fallthrough */
+      }
       case OP_COPY_MESSAGE:
       case OP_DECODE_SAVE:
       case OP_DECODE_COPY:
@@ -3338,10 +3409,13 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
       }
 
       case OP_SHELL_ESCAPE:
+      {
         mutt_shell_escape();
         break;
+      }
 
       case OP_TAG:
+      {
         CHECK_MODE(IsEmail(extra));
         if (Context)
         {
@@ -3362,8 +3436,10 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
           rc = OP_NEXT_ENTRY;
         }
         break;
+      }
 
       case OP_TOGGLE_NEW:
+      {
         CHECK_MODE(IsEmail(extra));
         CHECK_READONLY;
         /* L10N: CHECK_ACL */
@@ -3382,8 +3458,10 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
           rc = OP_MAIN_NEXT_UNDELETED;
         }
         break;
+      }
 
       case OP_UNDELETE:
+      {
         CHECK_MODE(IsEmail(extra));
         CHECK_READONLY;
         /* L10N: CHECK_ACL */
@@ -3398,6 +3476,7 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
           rc = OP_NEXT_ENTRY;
         }
         break;
+      }
 
       case OP_UNDELETE_THREAD:
       case OP_UNDELETE_SUBTHREAD:
@@ -3434,14 +3513,19 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
       }
 
       case OP_VERSION:
+      {
         mutt_message(mutt_make_version());
         break;
+      }
 
       case OP_MAILBOX_LIST:
+      {
         mutt_mailbox_list();
         break;
+      }
 
       case OP_VIEW_ATTACHMENTS:
+      {
         if (flags & MUTT_PAGER_ATTACHMENT)
         {
           ch = -1;
@@ -3454,6 +3538,7 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
           Context->mailbox->changed = true;
         pager_menu->redraw = REDRAW_FULL;
         break;
+      }
 
       case OP_MAIL_KEY:
       {
@@ -3495,8 +3580,10 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
       }
 
       case OP_FORGET_PASSPHRASE:
+      {
         crypt_forget_passphrase();
         break;
+      }
 
       case OP_EXTRACT_KEYS:
       {
@@ -3515,12 +3602,16 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
       }
 
       case OP_WHAT_KEY:
+      {
         mutt_what_key();
         break;
+      }
 
       case OP_CHECK_STATS:
+      {
         mutt_check_stats();
         break;
+      }
 
 #ifdef USE_SIDEBAR
       case OP_SIDEBAR_NEXT:
@@ -3529,18 +3620,24 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
       case OP_SIDEBAR_PAGE_UP:
       case OP_SIDEBAR_PREV:
       case OP_SIDEBAR_PREV_NEW:
+      {
         mutt_sb_change_mailbox(ch);
         break;
+      }
 
       case OP_SIDEBAR_TOGGLE_VISIBLE:
+      {
         bool_str_toggle(Config, "sidebar_visible", NULL);
         mutt_window_reflow();
         break;
+      }
 #endif
 
       default:
+      {
         ch = -1;
         break;
+      }
     }
   }
 
@@ -3553,12 +3650,16 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
     {
       case -1:
       case OP_DISPLAY_HEADERS:
+      {
         mutt_clear_pager_position();
         break;
+      }
       default:
+      {
         TopLine = rd.topline;
         OldEmail = extra->email;
         break;
+      }
     }
   }
 

--- a/pattern.c
+++ b/pattern.c
@@ -359,26 +359,40 @@ static const char *get_offset(struct tm *tm, const char *s, int sign)
   switch (*ps)
   {
     case 'y':
+    {
       tm->tm_year += offset;
       break;
+    }
     case 'm':
+    {
       tm->tm_mon += offset;
       break;
+    }
     case 'w':
+    {
       tm->tm_mday += 7 * offset;
       break;
+    }
     case 'd':
+    {
       tm->tm_mday += offset;
       break;
+    }
     case 'H':
+    {
       tm->tm_hour += offset;
       break;
+    }
     case 'M':
+    {
       tm->tm_min += offset;
       break;
+    }
     case 'S':
+    {
       tm->tm_sec += offset;
       break;
+    }
     default:
       return s;
   }
@@ -858,11 +872,17 @@ static int scan_range_num(struct Buffer *s, regmatch_t pmatch[], int group, int 
   switch (kind)
   {
     case RANGE_K_REL:
+    {
       return num + CTX_MSGNO(Context);
+    }
     case RANGE_K_LT:
+    {
       return num - 1;
+    }
     case RANGE_K_GT:
+    {
       return num + 1;
+    }
     default:
       return num;
   }
@@ -892,14 +912,22 @@ static int scan_range_slot(struct Buffer *s, regmatch_t pmatch[], int grp, int s
   switch (c)
   {
     case RANGE_CIRCUM:
+    {
       return 1;
+    }
     case RANGE_DOLLAR:
+    {
       return Context->mailbox->msg_count;
+    }
     case RANGE_DOT:
+    {
       return CTX_MSGNO(Context);
+    }
     case RANGE_LT:
     case RANGE_GT:
+    {
       return scan_range_num(s, pmatch, grp + 1, kind);
+    }
     default:
       /* Only other possibility: a number */
       return scan_range_num(s, pmatch, grp, kind);
@@ -1005,12 +1033,16 @@ static bool eat_message_range(struct Pattern *pat, int flags, struct Buffer *s,
     switch (eat_range_by_regex(pat, s, i_kind, err))
     {
       case RANGE_E_CTX:
+      {
         /* This means it matched syntactically but lacked context.
          * No point in continuing. */
         break;
+      }
       case RANGE_E_SYNTAX:
+      {
         /* Try another syntax, then */
         continue;
+      }
       case RANGE_E_OK:
         if (skip_quote && (*s->dptr == '"'))
           s->dptr++;
@@ -1414,18 +1446,25 @@ struct PatternHead *mutt_pattern_comp(const char *s, int flags, struct Buffer *e
     switch (*ps.dptr)
     {
       case '^':
+      {
         ps.dptr++;
         alladdr = !alladdr;
         break;
+      }
       case '!':
+      {
         ps.dptr++;
         pat_not = !pat_not;
         break;
+      }
       case '@':
+      {
         ps.dptr++;
         isalias = !isalias;
         break;
+      }
       case '|':
+      {
         if (!pat_or)
         {
           if (!curlist)
@@ -1456,6 +1495,7 @@ struct PatternHead *mutt_pattern_comp(const char *s, int flags, struct Buffer *e
         alladdr = false;
         isalias = false;
         break;
+      }
       case '%':
       case '=':
       case '~':
@@ -2008,51 +2048,90 @@ int mutt_pattern_exec(struct Pattern *pat, PatternExecFlags flags,
   switch (pat->op)
   {
     case MUTT_PAT_AND:
+    {
       return pat->pat_not ^ (perform_and(pat->child, flags, m, e, cache) > 0);
+    }
     case MUTT_PAT_OR:
+    {
       return pat->pat_not ^ (perform_or(pat->child, flags, m, e, cache) > 0);
+    }
     case MUTT_PAT_THREAD:
+    {
       return pat->pat_not ^
              match_threadcomplete(pat->child, flags, m, e->thread, 1, 1, 1, 1);
+    }
     case MUTT_PAT_PARENT:
+    {
       return pat->pat_not ^ match_threadparent(pat->child, flags, m, e->thread);
+    }
     case MUTT_PAT_CHILDREN:
+    {
       return pat->pat_not ^ match_threadchildren(pat->child, flags, m, e->thread);
+    }
     case MUTT_ALL:
+    {
       return !pat->pat_not;
+    }
     case MUTT_EXPIRED:
+    {
       return pat->pat_not ^ e->expired;
+    }
     case MUTT_SUPERSEDED:
+    {
       return pat->pat_not ^ e->superseded;
+    }
     case MUTT_FLAG:
+    {
       return pat->pat_not ^ e->flagged;
+    }
     case MUTT_TAG:
+    {
       return pat->pat_not ^ e->tagged;
+    }
     case MUTT_NEW:
+    {
       return pat->pat_not ? e->old || e->read : !(e->old || e->read);
+    }
     case MUTT_UNREAD:
+    {
       return pat->pat_not ? e->read : !e->read;
+    }
     case MUTT_REPLIED:
+    {
       return pat->pat_not ^ e->replied;
+    }
     case MUTT_OLD:
+    {
       return pat->pat_not ? (!e->old || e->read) : (e->old && !e->read);
+    }
     case MUTT_READ:
+    {
       return pat->pat_not ^ e->read;
+    }
     case MUTT_DELETED:
+    {
       return pat->pat_not ^ e->deleted;
+    }
     case MUTT_PAT_MESSAGE:
+    {
       return pat->pat_not ^ ((EMSG(e) >= pat->min) && (EMSG(e) <= pat->max));
+    }
     case MUTT_PAT_DATE:
+    {
       if (pat->dynamic)
         match_update_dynamic_date(pat);
       return pat->pat_not ^ (e->date_sent >= pat->min && e->date_sent <= pat->max);
+    }
     case MUTT_PAT_DATE_RECEIVED:
+    {
       if (pat->dynamic)
         match_update_dynamic_date(pat);
       return pat->pat_not ^ (e->received >= pat->min && e->received <= pat->max);
+    }
     case MUTT_PAT_BODY:
     case MUTT_PAT_HEADER:
     case MUTT_PAT_WHOLE_MSG:
+    {
       /* m can be NULL in certain cases, such as when replying to a message
        * from the attachment menu and the user has a reply-hook using "~e" (bug
        * #2190).
@@ -2065,7 +2144,9 @@ int mutt_pattern_exec(struct Pattern *pat, PatternExecFlags flags,
         return e->matched;
 #endif
       return pat->pat_not ^ msg_search(m, pat, e->msgno);
+    }
     case MUTT_PAT_SERVERSEARCH:
+    {
 #ifdef USE_IMAP
       if (!m)
         return 0;
@@ -2081,58 +2162,81 @@ int mutt_pattern_exec(struct Pattern *pat, PatternExecFlags flags,
       mutt_error(_("error: server custom search only supported with IMAP"));
       return -1;
 #endif
+    }
     case MUTT_PAT_SENDER:
+    {
       if (!e->env)
         return 0;
       return pat->pat_not ^ match_addrlist(pat, (flags & MUTT_MATCH_FULL_ADDRESS),
                                            1, &e->env->sender);
+    }
     case MUTT_PAT_FROM:
+    {
       if (!e->env)
         return 0;
       return pat->pat_not ^
              match_addrlist(pat, (flags & MUTT_MATCH_FULL_ADDRESS), 1, &e->env->from);
+    }
     case MUTT_PAT_TO:
+    {
       if (!e->env)
         return 0;
       return pat->pat_not ^
              match_addrlist(pat, (flags & MUTT_MATCH_FULL_ADDRESS), 1, &e->env->to);
+    }
     case MUTT_PAT_CC:
+    {
       if (!e->env)
         return 0;
       return pat->pat_not ^
              match_addrlist(pat, (flags & MUTT_MATCH_FULL_ADDRESS), 1, &e->env->cc);
+    }
     case MUTT_PAT_SUBJECT:
+    {
       if (!e->env)
         return 0;
       return pat->pat_not ^ (e->env->subject && patmatch(pat, e->env->subject));
+    }
     case MUTT_PAT_ID:
     case MUTT_PAT_ID_EXTERNAL:
+    {
       if (!e->env)
         return 0;
       return pat->pat_not ^ (e->env->message_id && patmatch(pat, e->env->message_id));
+    }
     case MUTT_PAT_SCORE:
+    {
       return pat->pat_not ^ (e->score >= pat->min &&
                              (pat->max == MUTT_MAXRANGE || e->score <= pat->max));
+    }
     case MUTT_PAT_SIZE:
+    {
       return pat->pat_not ^
              (e->content->length >= pat->min &&
               (pat->max == MUTT_MAXRANGE || e->content->length <= pat->max));
+    }
     case MUTT_PAT_REFERENCE:
+    {
       if (!e->env)
         return 0;
       return pat->pat_not ^ (match_reference(pat, &e->env->references) ||
                              match_reference(pat, &e->env->in_reply_to));
+    }
     case MUTT_PAT_ADDRESS:
+    {
       if (!e->env)
         return 0;
       return pat->pat_not ^ match_addrlist(pat, (flags & MUTT_MATCH_FULL_ADDRESS),
                                            4, &e->env->from, &e->env->sender,
                                            &e->env->to, &e->env->cc);
+    }
     case MUTT_PAT_RECIPIENT:
+    {
       if (!e->env)
         return 0;
       return pat->pat_not ^ match_addrlist(pat, (flags & MUTT_MATCH_FULL_ADDRESS),
                                            2, &e->env->to, &e->env->cc);
+    }
     case MUTT_PAT_LIST: /* known list, subscribed or not */
     {
       if (!e->env)
@@ -2212,27 +2316,39 @@ int mutt_pattern_exec(struct Pattern *pat, PatternExecFlags flags,
       return pat->pat_not ^ result;
     }
     case MUTT_PAT_COLLAPSED:
+    {
       return pat->pat_not ^ (e->collapsed && e->num_hidden > 1);
+    }
     case MUTT_PAT_CRYPT_SIGN:
+    {
       if (!WithCrypto)
         break;
       return pat->pat_not ^ ((e->security & SEC_SIGN) ? 1 : 0);
+    }
     case MUTT_PAT_CRYPT_VERIFIED:
+    {
       if (!WithCrypto)
         break;
       return pat->pat_not ^ ((e->security & SEC_GOODSIGN) ? 1 : 0);
+    }
     case MUTT_PAT_CRYPT_ENCRYPT:
+    {
       if (!WithCrypto)
         break;
       return pat->pat_not ^ ((e->security & SEC_ENCRYPT) ? 1 : 0);
+    }
     case MUTT_PAT_PGP_KEY:
+    {
       if (!(WithCrypto & APPLICATION_PGP))
         break;
       return pat->pat_not ^ ((e->security & PGP_KEY) == PGP_KEY);
+    }
     case MUTT_PAT_XLABEL:
+    {
       if (!e->env)
         return 0;
       return pat->pat_not ^ (e->env->x_label && patmatch(pat, e->env->x_label));
+    }
     case MUTT_PAT_DRIVER_TAGS:
     {
       char *tags = driver_tags_get(&e->tags);
@@ -2241,13 +2357,18 @@ int mutt_pattern_exec(struct Pattern *pat, PatternExecFlags flags,
       return rc;
     }
     case MUTT_PAT_HORMEL:
+    {
       if (!e->env)
         return 0;
       return pat->pat_not ^ (e->env->spam && e->env->spam->data &&
                              patmatch(pat, e->env->spam->data));
+    }
     case MUTT_PAT_DUPLICATED:
+    {
       return pat->pat_not ^ (e->thread && e->thread->duplicate_thread);
+    }
     case MUTT_PAT_MIMEATTACH:
+    {
       if (!m)
         return 0;
       {
@@ -2255,15 +2376,22 @@ int mutt_pattern_exec(struct Pattern *pat, PatternExecFlags flags,
         return pat->pat_not ^ (count >= pat->min &&
                                (pat->max == MUTT_MAXRANGE || count <= pat->max));
       }
+    }
     case MUTT_PAT_MIMETYPE:
+    {
       if (!m)
         return 0;
       return pat->pat_not ^ match_mime_content_type(pat, m, e);
+    }
     case MUTT_PAT_UNREFERENCED:
+    {
       return pat->pat_not ^ (e->thread && !e->thread->child);
+    }
     case MUTT_PAT_BROKEN:
+    {
       return pat->pat_not ^ (e->thread && e->thread->fake_thread);
 #ifdef USE_NNTP
+    }
     case MUTT_PAT_NEWSGROUPS:
       if (!e->env)
         return 0;
@@ -2498,21 +2626,27 @@ int mutt_pattern_func(int op, char *prompt)
         switch (op)
         {
           case MUTT_UNDELETE:
+          {
             mutt_set_flag(Context->mailbox,
                           Context->mailbox->emails[Context->mailbox->v2r[i]],
                           MUTT_PURGE, false);
-          /* fallthrough */
+            /* fallthrough */
+          }
           case MUTT_DELETE:
+          {
             mutt_set_flag(Context->mailbox,
                           Context->mailbox->emails[Context->mailbox->v2r[i]],
                           MUTT_DELETE, (op == MUTT_DELETE));
             break;
+          }
           case MUTT_TAG:
           case MUTT_UNTAG:
+          {
             mutt_set_flag(Context->mailbox,
                           Context->mailbox->emails[Context->mailbox->v2r[i]],
                           MUTT_TAG, (op == MUTT_TAG));
             break;
+          }
         }
       }
     }

--- a/pop/pop_auth.c
+++ b/pop/pop_auth.c
@@ -261,7 +261,9 @@ static enum PopAuthRes pop_auth_apop(struct PopAccountData *adata, const char *m
   switch (pop_query(adata, buf, sizeof(buf)))
   {
     case 0:
+    {
       return POP_A_SUCCESS;
+    }
     case -1:
       return POP_A_SOCKET;
   }
@@ -321,7 +323,9 @@ static enum PopAuthRes pop_auth_user(struct PopAccountData *adata, const char *m
   switch (ret)
   {
     case 0:
+    {
       return POP_A_SUCCESS;
+    }
     case -1:
       return POP_A_SOCKET;
   }
@@ -366,7 +370,9 @@ static enum PopAuthRes pop_auth_oauth(struct PopAccountData *adata, const char *
   switch (ret)
   {
     case 0:
+    {
       return POP_A_SUCCESS;
+    }
     case -1:
       return POP_A_SOCKET;
   }
@@ -496,9 +502,13 @@ int pop_authenticate(struct PopAccountData *adata)
   switch (ret)
   {
     case POP_A_SUCCESS:
+    {
       return 0;
+    }
     case POP_A_SOCKET:
+    {
       return -1;
+    }
     case POP_A_UNAVAIL:
       if (attempts == 0)
         mutt_error(_("No authenticators available"));

--- a/postpone.c
+++ b/postpone.c
@@ -239,6 +239,7 @@ static struct Email *select_msg(struct Context *ctx)
     {
       case OP_DELETE:
       case OP_UNDELETE:
+      {
         /* should deleted draft messages be saved in the trash folder? */
         mutt_set_flag(ctx->mailbox, ctx->mailbox->emails[menu->current],
                       MUTT_DELETE, (op == OP_DELETE));
@@ -258,15 +259,20 @@ static struct Email *select_msg(struct Context *ctx)
         else
           menu->redraw |= REDRAW_CURRENT;
         break;
+      }
 
       case OP_GENERIC_SELECT_ENTRY:
+      {
         r = menu->current;
         done = true;
         break;
+      }
 
       case OP_EXIT:
+      {
         done = true;
         break;
+      }
     }
   }
 
@@ -463,6 +469,7 @@ SecurityFlags mutt_parse_crypt_hdr(const char *p, bool set_empty_signas, Securit
     {
       case 'c':
       case 'C':
+      {
         q = smime_cryptalg;
 
         if (p[1] == '<')
@@ -482,16 +489,21 @@ SecurityFlags mutt_parse_crypt_hdr(const char *p, bool set_empty_signas, Securit
 
         *q = '\0';
         break;
+      }
 
       case 'e':
       case 'E':
+      {
         flags |= SEC_ENCRYPT;
         break;
+      }
 
       case 'i':
       case 'I':
+      {
         flags |= SEC_INLINE;
         break;
+      }
 
       /* This used to be the micalg parameter.
        *
@@ -499,6 +511,7 @@ SecurityFlags mutt_parse_crypt_hdr(const char *p, bool set_empty_signas, Securit
        * to be able to recall old messages.  */
       case 'm':
       case 'M':
+      {
         if (p[1] == '<')
         {
           for (p += 2; (p[0] != '\0') && (p[0] != '>'); p++)
@@ -511,14 +524,18 @@ SecurityFlags mutt_parse_crypt_hdr(const char *p, bool set_empty_signas, Securit
         }
 
         break;
+      }
 
       case 'o':
       case 'O':
+      {
         flags |= SEC_OPPENCRYPT;
         break;
+      }
 
       case 's':
       case 'S':
+      {
         flags |= SEC_SIGN;
         q = sign_as;
 
@@ -539,6 +556,7 @@ SecurityFlags mutt_parse_crypt_hdr(const char *p, bool set_empty_signas, Securit
 
         q[0] = '\0';
         break;
+      }
 
       default:
         mutt_error(_("Illegal crypto header"));

--- a/query.c
+++ b/query.c
@@ -279,30 +279,42 @@ static const char *query_format_str(char *buf, size_t buflen, size_t col, int co
   switch (op)
   {
     case 'a':
+    {
       mutt_addrlist_write(tmp, sizeof(tmp), &query->addr, true);
       mutt_format_s(buf, buflen, prec, tmp);
       break;
+    }
     case 'c':
+    {
       snprintf(fmt, sizeof(fmt), "%%%sd", prec);
       snprintf(buf, buflen, fmt, query->num + 1);
       break;
+    }
     case 'e':
+    {
       if (!optional)
         mutt_format_s(buf, buflen, prec, NONULL(query->other));
       else if (!query->other || !*query->other)
         optional = 0;
       break;
+    }
     case 'n':
+    {
       mutt_format_s(buf, buflen, prec, NONULL(query->name));
       break;
+    }
     case 't':
+    {
       snprintf(fmt, sizeof(fmt), "%%%sc", prec);
       snprintf(buf, buflen, fmt, entry->tagged ? '*' : ' ');
       break;
+    }
     default:
+    {
       snprintf(fmt, sizeof(fmt), "%%%sc", prec);
       snprintf(buf, buflen, fmt, op);
       break;
+    }
   }
 
   if (optional)
@@ -394,6 +406,7 @@ static void query_menu(char *buf, size_t buflen, struct Query *results, bool ret
       {
         case OP_QUERY_APPEND:
         case OP_QUERY:
+        {
           if ((mutt_get_field(_("Query: "), buf, buflen, 0) == 0) && (buf[0] != '\0'))
           {
             struct Query *newresults = run_query(buf, 0);
@@ -466,8 +479,10 @@ static void query_menu(char *buf, size_t buflen, struct Query *results, bool ret
             }
           }
           break;
+        }
 
         case OP_CREATE_ALIAS:
+        {
           if (menu->tagprefix)
           {
             struct AddressList naddr = TAILQ_HEAD_INITIALIZER(naddr);
@@ -498,14 +513,17 @@ static void query_menu(char *buf, size_t buflen, struct Query *results, bool ret
             }
           }
           break;
+        }
 
         case OP_GENERIC_SELECT_ENTRY:
+        {
           if (retbuf)
           {
             done = 2;
             break;
           }
-        /* fallthrough */
+          /* fallthrough */
+        }
         case OP_MAIL:
         {
           struct Email *e = mutt_email_new();
@@ -540,8 +558,10 @@ static void query_menu(char *buf, size_t buflen, struct Query *results, bool ret
         }
 
         case OP_EXIT:
+        {
           done = 1;
           break;
+        }
       }
     }
 

--- a/recvattach.c
+++ b/recvattach.c
@@ -220,6 +220,7 @@ const char *attach_format_str(char *buf, size_t buflen, size_t col, int cols,
   switch (op)
   {
     case 'C':
+    {
       if (!optional)
       {
         if (mutt_is_text_part(aptr->content) &&
@@ -236,7 +237,9 @@ const char *attach_format_str(char *buf, size_t buflen, size_t col, int cols,
         optional = 0;
       }
       break;
+    }
     case 'c':
+    {
       /* XXX */
       if (!optional)
       {
@@ -247,7 +250,9 @@ const char *attach_format_str(char *buf, size_t buflen, size_t col, int cols,
       else if ((aptr->content->type != TYPE_TEXT) || aptr->content->noconv)
         optional = 0;
       break;
+    }
     case 'd':
+    {
       if (!optional)
       {
         if (aptr->content->description)
@@ -280,8 +285,10 @@ const char *attach_format_str(char *buf, size_t buflen, size_t col, int cols,
       {
         break;
       }
-    /* fallthrough */
+      /* fallthrough */
+    }
     case 'F':
+    {
       if (!optional)
       {
         if (aptr->content->d_filename)
@@ -295,8 +302,10 @@ const char *attach_format_str(char *buf, size_t buflen, size_t col, int cols,
         optional = 0;
         break;
       }
-    /* fallthrough */
+      /* fallthrough */
+    }
     case 'f':
+    {
       if (!optional)
       {
         if (aptr->content->filename && (*aptr->content->filename == '/'))
@@ -313,17 +322,23 @@ const char *attach_format_str(char *buf, size_t buflen, size_t col, int cols,
       else if (!aptr->content->filename)
         optional = 0;
       break;
+    }
     case 'D':
+    {
       if (!optional)
         snprintf(buf, buflen, "%c", aptr->content->deleted ? 'D' : ' ');
       else if (!aptr->content->deleted)
         optional = 0;
       break;
+    }
     case 'e':
+    {
       if (!optional)
         mutt_format_s(buf, buflen, prec, ENCODING(aptr->content->encoding));
       break;
+    }
     case 'I':
+    {
       if (!optional)
       {
         const char dispchar[] = { 'I', 'A', 'F', '-' };
@@ -340,24 +355,32 @@ const char *attach_format_str(char *buf, size_t buflen, size_t col, int cols,
         snprintf(buf, buflen, "%c", ch);
       }
       break;
+    }
     case 'm':
+    {
       if (!optional)
         mutt_format_s(buf, buflen, prec, TYPE(aptr->content));
       break;
+    }
     case 'M':
+    {
       if (!optional)
         mutt_format_s(buf, buflen, prec, aptr->content->subtype);
       else if (!aptr->content->subtype)
         optional = 0;
       break;
+    }
     case 'n':
+    {
       if (!optional)
       {
         snprintf(fmt, sizeof(fmt), "%%%sd", prec);
         snprintf(buf, buflen, fmt, aptr->num + 1);
       }
       break;
+    }
     case 'Q':
+    {
       if (optional)
         optional = aptr->content->attach_qualifies;
       else
@@ -366,6 +389,7 @@ const char *attach_format_str(char *buf, size_t buflen, size_t col, int cols,
         mutt_format_s(buf, buflen, fmt, "Q");
       }
       break;
+    }
     case 's':
     {
       size_t l;
@@ -390,24 +414,31 @@ const char *attach_format_str(char *buf, size_t buflen, size_t col, int cols,
       break;
     }
     case 't':
+    {
       if (!optional)
         snprintf(buf, buflen, "%c", aptr->content->tagged ? '*' : ' ');
       else if (!aptr->content->tagged)
         optional = 0;
       break;
+    }
     case 'T':
+    {
       if (!optional)
         mutt_format_s_tree(buf, buflen, prec, NONULL(aptr->tree));
       else if (!aptr->tree)
         optional = 0;
       break;
+    }
     case 'u':
+    {
       if (!optional)
         snprintf(buf, buflen, "%c", aptr->content->unlink ? '-' : ' ');
       else if (!aptr->content->unlink)
         optional = 0;
       break;
+    }
     case 'X':
+    {
       if (optional)
         optional = (aptr->content->attach_count + aptr->content->attach_qualifies) != 0;
       else
@@ -416,6 +447,7 @@ const char *attach_format_str(char *buf, size_t buflen, size_t col, int cols,
         snprintf(buf, buflen, fmt, aptr->content->attach_count + aptr->content->attach_qualifies);
       }
       break;
+    }
     default:
       *buf = '\0';
   }
@@ -1141,16 +1173,20 @@ int mutt_attach_display_loop(struct Menu *menu, int op, struct Email *e,
     switch (op)
     {
       case OP_DISPLAY_HEADERS:
+      {
         bool_str_toggle(Config, "weed", NULL);
         /* fallthrough */
-
+      }
       case OP_VIEW_ATTACH:
+      {
         op = mutt_view_attachment(CUR_ATTACH->fp, CUR_ATTACH->content,
                                   MUTT_VA_REGULAR, e, actx);
         break;
+      }
 
       case OP_NEXT_ENTRY:
-      case OP_MAIN_NEXT_UNDELETED: /* hack */
+      case OP_MAIN_NEXT_UNDELETED:
+      { /* hack */
         if (menu->current < menu->max - 1)
         {
           menu->current++;
@@ -1159,8 +1195,10 @@ int mutt_attach_display_loop(struct Menu *menu, int op, struct Email *e,
         else
           op = OP_NULL;
         break;
+      }
       case OP_PREV_ENTRY:
-      case OP_MAIN_PREV_UNDELETED: /* hack */
+      case OP_MAIN_PREV_UNDELETED:
+      { /* hack */
         if (menu->current > 0)
         {
           menu->current--;
@@ -1169,7 +1207,9 @@ int mutt_attach_display_loop(struct Menu *menu, int op, struct Email *e,
         else
           op = OP_NULL;
         break;
+      }
       case OP_EDIT_TYPE:
+      {
         /* when we edit the content-type, we should redisplay the attachment
          * immediately */
         mutt_edit_content_type(e, CUR_ATTACH->content, CUR_ATTACH->fp);
@@ -1181,18 +1221,23 @@ int mutt_attach_display_loop(struct Menu *menu, int op, struct Email *e,
         menu->redraw |= REDRAW_INDEX;
         op = OP_VIEW_ATTACH;
         break;
+      }
       /* functions which are passed through from the pager */
       case OP_CHECK_TRADITIONAL:
+      {
         if (!(WithCrypto & APPLICATION_PGP) || (e && e->security & PGP_TRADITIONAL_CHECKED))
         {
           op = OP_NULL;
           break;
         }
-      /* fallthrough */
+        /* fallthrough */
+      }
       case OP_ATTACH_COLLAPSE:
+      {
         if (recv)
           return op;
-      /* fallthrough */
+        /* fallthrough */
+      }
       default:
         op = OP_NULL;
     }
@@ -1436,22 +1481,28 @@ void mutt_view_attachments(struct Email *e)
     switch (op)
     {
       case OP_ATTACH_VIEW_MAILCAP:
+      {
         mutt_view_attachment(CUR_ATTACH->fp, CUR_ATTACH->content, MUTT_VA_MAILCAP, e, actx);
         menu->redraw = REDRAW_FULL;
         break;
+      }
 
       case OP_ATTACH_VIEW_TEXT:
+      {
         mutt_view_attachment(CUR_ATTACH->fp, CUR_ATTACH->content, MUTT_VA_AS_TEXT, e, actx);
         menu->redraw = REDRAW_FULL;
         break;
+      }
 
       case OP_DISPLAY_HEADERS:
       case OP_VIEW_ATTACH:
+      {
         op = mutt_attach_display_loop(menu, op, e, actx, true);
         menu->redraw = REDRAW_FULL;
         continue;
-
+      }
       case OP_ATTACH_COLLAPSE:
+      {
         if (!CUR_ATTACH->content->parts)
         {
           mutt_error(_("There are no subparts to show"));
@@ -1460,20 +1511,26 @@ void mutt_view_attachments(struct Email *e)
         attach_collapse(actx, menu);
         mutt_update_recvattach_menu(actx, menu, false);
         break;
+      }
 
       case OP_FORGET_PASSPHRASE:
+      {
         crypt_forget_passphrase();
         break;
+      }
 
       case OP_EXTRACT_KEYS:
+      {
         if (WithCrypto & APPLICATION_PGP)
         {
           recvattach_extract_pgp_keys(actx, menu);
           menu->redraw = REDRAW_FULL;
         }
         break;
+      }
 
       case OP_CHECK_TRADITIONAL:
+      {
         if (((WithCrypto & APPLICATION_PGP) != 0) &&
             recvattach_pgp_check_traditional(actx, menu))
         {
@@ -1481,18 +1538,24 @@ void mutt_view_attachments(struct Email *e)
           menu->redraw = REDRAW_FULL;
         }
         break;
+      }
 
       case OP_PRINT:
+      {
         mutt_print_attachment_list(actx, CUR_ATTACH->fp, menu->tagprefix,
                                    CUR_ATTACH->content);
         break;
+      }
 
       case OP_PIPE:
+      {
         mutt_pipe_attachment_list(actx, CUR_ATTACH->fp, menu->tagprefix,
                                   CUR_ATTACH->content, false);
         break;
+      }
 
       case OP_SAVE:
+      {
         mutt_save_attachment_list(actx, CUR_ATTACH->fp, menu->tagprefix,
                                   CUR_ATTACH->content, e, menu);
 
@@ -1501,8 +1564,10 @@ void mutt_view_attachments(struct Email *e)
 
         menu->redraw = REDRAW_MOTION_RESYNC | REDRAW_FULL;
         break;
+      }
 
       case OP_DELETE:
+      {
         CHECK_READONLY;
 
 #ifdef USE_POP
@@ -1573,8 +1638,10 @@ void mutt_view_attachments(struct Email *e)
           }
         }
         break;
+      }
 
       case OP_UNDELETE:
+      {
         CHECK_READONLY;
         if (!menu->tagprefix)
         {
@@ -1599,37 +1666,47 @@ void mutt_view_attachments(struct Email *e)
           }
         }
         break;
+      }
 
       case OP_RESEND:
+      {
         CHECK_ATTACH;
         mutt_attach_resend(CUR_ATTACH->fp, actx,
                            menu->tagprefix ? NULL : CUR_ATTACH->content);
         menu->redraw = REDRAW_FULL;
         break;
+      }
 
       case OP_BOUNCE_MESSAGE:
+      {
         CHECK_ATTACH;
         mutt_attach_bounce(m, CUR_ATTACH->fp, actx,
                            menu->tagprefix ? NULL : CUR_ATTACH->content);
         menu->redraw = REDRAW_FULL;
         break;
+      }
 
       case OP_FORWARD_MESSAGE:
+      {
         CHECK_ATTACH;
         mutt_attach_forward(CUR_ATTACH->fp, e, actx,
                             menu->tagprefix ? NULL : CUR_ATTACH->content, SEND_NO_FLAGS);
         menu->redraw = REDRAW_FULL;
         break;
+      }
 
 #ifdef USE_NNTP
       case OP_FORWARD_TO_GROUP:
+      {
         CHECK_ATTACH;
         mutt_attach_forward(CUR_ATTACH->fp, e, actx,
                             menu->tagprefix ? NULL : CUR_ATTACH->content, SEND_NEWS);
         menu->redraw = REDRAW_FULL;
         break;
+      }
 
       case OP_FOLLOWUP:
+      {
         CHECK_ATTACH;
 
         if (!CUR_ATTACH->content->email->env->followup_to ||
@@ -1644,7 +1721,8 @@ void mutt_view_attachments(struct Email *e)
           break;
         }
 #endif
-      /* fallthrough */
+        /* fallthrough */
+      }
       case OP_REPLY:
       case OP_GROUP_REPLY:
       case OP_GROUP_CHAT_REPLY:
@@ -1667,16 +1745,20 @@ void mutt_view_attachments(struct Email *e)
       }
 
       case OP_COMPOSE_TO_SENDER:
+      {
         CHECK_ATTACH;
         mutt_attach_mail_sender(CUR_ATTACH->fp, e, actx,
                                 menu->tagprefix ? NULL : CUR_ATTACH->content);
         menu->redraw = REDRAW_FULL;
         break;
+      }
 
       case OP_EDIT_TYPE:
+      {
         recvattach_edit_content_type(actx, menu, e);
         menu->redraw |= REDRAW_INDEX;
         break;
+      }
 
       case OP_EXIT:
         mx_msg_close(m, &msg);

--- a/remailer.c
+++ b/remailer.c
@@ -81,24 +81,32 @@ static MixCapFlags mix_get_caps(const char *capstr)
     switch (*capstr)
     {
       case 'C':
+      {
         caps |= MIX_CAP_COMPRESS;
         break;
+      }
 
       case 'M':
+      {
         caps |= MIX_CAP_MIDDLEMAN;
         break;
+      }
 
       case 'N':
       {
         switch (*++capstr)
         {
           case 'm':
+          {
             caps |= MIX_CAP_NEWSMAIL;
             break;
+          }
 
           case 'p':
+          {
             caps |= MIX_CAP_NEWSPOST;
             break;
+          }
         }
       }
     }
@@ -443,6 +451,7 @@ static const char *mix_format_str(char *buf, size_t buflen, size_t col, int cols
   switch (op)
   {
     case 'a':
+    {
       if (!optional)
       {
         snprintf(fmt, sizeof(fmt), "%%%ss", prec);
@@ -451,24 +460,30 @@ static const char *mix_format_str(char *buf, size_t buflen, size_t col, int cols
       else if (!remailer->addr)
         optional = 0;
       break;
+    }
 
     case 'c':
+    {
       if (!optional)
       {
         snprintf(fmt, sizeof(fmt), "%%%ss", prec);
         snprintf(buf, buflen, fmt, mix_format_caps(remailer));
       }
       break;
+    }
 
     case 'n':
+    {
       if (!optional)
       {
         snprintf(fmt, sizeof(fmt), "%%%sd", prec);
         snprintf(buf, buflen, fmt, remailer->num);
       }
       break;
+    }
 
     case 's':
+    {
       if (!optional)
       {
         snprintf(fmt, sizeof(fmt), "%%%ss", prec);
@@ -477,6 +492,7 @@ static const char *mix_format_str(char *buf, size_t buflen, size_t col, int cols
       else if (!remailer->shortname)
         optional = 0;
       break;
+    }
 
     default:
       *buf = '\0';

--- a/send.c
+++ b/send.c
@@ -766,12 +766,16 @@ static int default_to(struct AddressList *to, struct Envelope *env, SendFlags fl
       switch (query_quadoption(C_ReplyTo, prompt))
       {
         case MUTT_YES:
+        {
           mutt_addrlist_copy(to, &env->reply_to, false);
           break;
+        }
 
         case MUTT_NO:
+        {
           mutt_addrlist_copy(to, &env->from, false);
           break;
+        }
 
         default:
           return -1; /* abort */
@@ -1632,7 +1636,7 @@ static int save_fcc(struct Email *e, char *fcc, size_t fcc_len, struct Body *cle
           if (mutt_protect(e, pgpkeylist) == -1)
           {
             /* we can't do much about it at this point, so
-           * fallback to saving the whole thing to fcc */
+             * fallback to saving the whole thing to fcc */
             e->content = tmpbody;
             save_sig = NULL;
             goto full_fcc;
@@ -1672,7 +1676,8 @@ full_fcc:
           _("rms"));
       switch (choice)
       {
-        case 2: /* alternate (m)ailbox */
+        case 2:
+        { /* alternate (m)ailbox */
           /* L10N: This is the prompt to enter an "alternate (m)ailbox" when the
              initial Fcc fails.  */
           rc = mutt_enter_fname(_("Fcc mailbox"), fcc, fcc_len, true);
@@ -1682,15 +1687,19 @@ full_fcc:
             break;
           }
           /* fall through */
-
-        case 1: /* (r)etry */
+        }
+        case 1:
+        { /* (r)etry */
           rc = mutt_write_multiple_fcc(fcc, e, NULL, false, NULL, finalpath);
           break;
+        }
 
         case -1: /* abort */
-        case 3:  /* (s)kip */
+        case 3:
+        { /* (s)kip */
           rc = 0;
           break;
+        }
       }
     }
   }

--- a/sendlib.c
+++ b/sendlib.c
@@ -1108,18 +1108,26 @@ enum ContentType mutt_lookup_mime_type(struct Body *att, const char *path)
     {
       /* last file with last entry to match wins type/xtype */
       case 0:
+      {
         /* check default unix mimetypes location first */
         mutt_str_strfcpy(buf, "/etc/mime.types", sizeof(buf));
         break;
+      }
       case 1:
+      {
         mutt_str_strfcpy(buf, SYSCONFDIR "/mime.types", sizeof(buf));
         break;
+      }
       case 2:
+      {
         mutt_str_strfcpy(buf, PKGDATADIR "/mime.types", sizeof(buf));
         break;
+      }
       case 3:
+      {
         snprintf(buf, sizeof(buf), "%s/.mime.types", NONULL(HomeDir));
         break;
+      }
       default:
         mutt_debug(LL_DEBUG1, "Internal error, count = %d\n", count);
         goto bye; /* shouldn't happen */

--- a/sidebar.c
+++ b/sidebar.c
@@ -136,10 +136,13 @@ static const char *sidebar_format_str(char *buf, size_t buflen, size_t col, int 
   switch (op)
   {
     case 'B':
+    {
       mutt_format_s(buf, buflen, prec, sbe->box);
       break;
+    }
 
     case 'd':
+    {
       if (!optional)
       {
         snprintf(fmt, sizeof(fmt), "%%%sd", prec);
@@ -148,15 +151,19 @@ static const char *sidebar_format_str(char *buf, size_t buflen, size_t col, int 
       else if ((c && (Context->mailbox->msg_deleted == 0)) || !c)
         optional = 0;
       break;
+    }
 
     case 'D':
+    {
       if (sbe->mailbox->desc)
         mutt_format_s(buf, buflen, prec, sbe->mailbox->desc);
       else
         mutt_format_s(buf, buflen, prec, sbe->box);
       break;
+    }
 
     case 'F':
+    {
       if (!optional)
       {
         snprintf(fmt, sizeof(fmt), "%%%sd", prec);
@@ -165,8 +172,10 @@ static const char *sidebar_format_str(char *buf, size_t buflen, size_t col, int 
       else if (m->msg_flagged == 0)
         optional = 0;
       break;
+    }
 
     case 'L':
+    {
       if (!optional)
       {
         snprintf(fmt, sizeof(fmt), "%%%sd", prec);
@@ -175,8 +184,10 @@ static const char *sidebar_format_str(char *buf, size_t buflen, size_t col, int 
       else if ((c && (Context->mailbox->vcount == m->msg_count)) || !c)
         optional = 0;
       break;
+    }
 
     case 'N':
+    {
       if (!optional)
       {
         snprintf(fmt, sizeof(fmt), "%%%sd", prec);
@@ -185,8 +196,10 @@ static const char *sidebar_format_str(char *buf, size_t buflen, size_t col, int 
       else if (m->msg_unread == 0)
         optional = 0;
       break;
+    }
 
     case 'n':
+    {
       if (!optional)
       {
         snprintf(fmt, sizeof(fmt), "%%%sc", prec);
@@ -195,8 +208,10 @@ static const char *sidebar_format_str(char *buf, size_t buflen, size_t col, int 
       else if (m->has_new == false)
         optional = 0;
       break;
+    }
 
     case 'S':
+    {
       if (!optional)
       {
         snprintf(fmt, sizeof(fmt), "%%%sd", prec);
@@ -205,8 +220,10 @@ static const char *sidebar_format_str(char *buf, size_t buflen, size_t col, int 
       else if (m->msg_count == 0)
         optional = 0;
       break;
+    }
 
     case 't':
+    {
       if (!optional)
       {
         snprintf(fmt, sizeof(fmt), "%%%sd", prec);
@@ -215,8 +232,10 @@ static const char *sidebar_format_str(char *buf, size_t buflen, size_t col, int 
       else if ((c && (Context->mailbox->msg_tagged == 0)) || !c)
         optional = 0;
       break;
+    }
 
     case '!':
+    {
       if (m->msg_flagged == 0)
         mutt_format_s(buf, buflen, prec, "");
       else if (m->msg_flagged == 1)
@@ -229,6 +248,7 @@ static const char *sidebar_format_str(char *buf, size_t buflen, size_t col, int 
         mutt_format_s(buf, buflen, prec, fmt);
       }
       break;
+    }
   }
 
   if (optional)
@@ -307,26 +327,34 @@ static int cb_qsort_sbe(const void *a, const void *b)
   switch ((C_SidebarSortMethod & SORT_MASK))
   {
     case SORT_COUNT:
+    {
       if (m2->msg_count == m1->msg_count)
         rc = mutt_str_strcoll(mutt_b2s(m1->pathbuf), mutt_b2s(m2->pathbuf));
       else
         rc = (m2->msg_count - m1->msg_count);
       break;
+    }
     case SORT_UNREAD:
+    {
       if (m2->msg_unread == m1->msg_unread)
         rc = mutt_str_strcoll(mutt_b2s(m1->pathbuf), mutt_b2s(m2->pathbuf));
       else
         rc = (m2->msg_unread - m1->msg_unread);
       break;
+    }
     case SORT_DESC:
+    {
       rc = mutt_str_strcmp(m1->desc, m2->desc);
       break;
+    }
     case SORT_FLAGGED:
+    {
       if (m2->msg_flagged == m1->msg_flagged)
         rc = mutt_str_strcoll(mutt_b2s(m1->pathbuf), mutt_b2s(m2->pathbuf));
       else
         rc = (m2->msg_flagged - m1->msg_flagged);
       break;
+    }
     case SORT_PATH:
     {
       rc = mutt_inbox_cmp(mutt_b2s(m1->pathbuf), mutt_b2s(m2->pathbuf));
@@ -757,14 +785,20 @@ static int draw_divider(int num_rows, int num_cols)
     switch (altchar)
     {
       case SB_DIV_USER:
+      {
         addstr(NONULL(C_SidebarDividerChar));
         break;
+      }
       case SB_DIV_ASCII:
+      {
         addch('|');
         break;
+      }
       case SB_DIV_UTF8:
+      {
         addch(ACS_VLINE);
         break;
+      }
     }
   }
 
@@ -1025,29 +1059,41 @@ void mutt_sb_change_mailbox(int op)
   switch (op)
   {
     case OP_SIDEBAR_NEXT:
+    {
       if (!select_next())
         return;
       break;
+    }
     case OP_SIDEBAR_NEXT_NEW:
+    {
       if (!select_next_new())
         return;
       break;
+    }
     case OP_SIDEBAR_PAGE_DOWN:
+    {
       if (!select_page_down())
         return;
       break;
+    }
     case OP_SIDEBAR_PAGE_UP:
+    {
       if (!select_page_up())
         return;
       break;
+    }
     case OP_SIDEBAR_PREV:
+    {
       if (!select_prev())
         return;
       break;
+    }
     case OP_SIDEBAR_PREV_NEW:
+    {
       if (!select_prev_new())
         return;
       break;
+    }
     default:
       return;
   }

--- a/sort.c
+++ b/sort.c
@@ -324,30 +324,50 @@ sort_t *mutt_get_sort_func(enum SortType method)
   switch (method)
   {
     case SORT_DATE:
+    {
       return compare_date_sent;
+    }
     case SORT_FROM:
+    {
       return compare_from;
+    }
     case SORT_LABEL:
+    {
       return compare_label;
+    }
     case SORT_ORDER:
+    {
 #ifdef USE_NNTP
       if (Context && (Context->mailbox->magic == MUTT_NNTP))
         return nntp_compare_order;
       else
 #endif
         return compare_order;
+    }
     case SORT_RECEIVED:
+    {
       return compare_date_received;
+    }
     case SORT_SCORE:
+    {
       return compare_score;
+    }
     case SORT_SIZE:
+    {
       return compare_size;
+    }
     case SORT_SPAM:
+    {
       return compare_spam;
+    }
     case SORT_SUBJECT:
+    {
       return compare_subject;
+    }
     case SORT_TO:
+    {
       return compare_to;
+    }
     default:
       return NULL;
   }

--- a/status.c
+++ b/status.c
@@ -100,6 +100,7 @@ static const char *status_format_str(char *buf, size_t buflen, size_t col, int c
   switch (op)
   {
     case 'b':
+    {
       if (!optional)
       {
         snprintf(fmt, sizeof(fmt), "%%%sd", prec);
@@ -109,8 +110,10 @@ static const char *status_format_str(char *buf, size_t buflen, size_t col, int c
       else if (mutt_mailbox_check(Context ? Context->mailbox : NULL, 0) == 0)
         optional = 0;
       break;
+    }
 
     case 'd':
+    {
       if (!optional)
       {
         snprintf(fmt, sizeof(fmt), "%%%sd", prec);
@@ -119,6 +122,7 @@ static const char *status_format_str(char *buf, size_t buflen, size_t col, int c
       else if (!Context || (Context->mailbox->msg_deleted == 0))
         optional = 0;
       break;
+    }
 
     case 'D':
     {
@@ -162,6 +166,7 @@ static const char *status_format_str(char *buf, size_t buflen, size_t col, int c
       break;
     }
     case 'F':
+    {
       if (!optional)
       {
         snprintf(fmt, sizeof(fmt), "%%%sd", prec);
@@ -170,13 +175,17 @@ static const char *status_format_str(char *buf, size_t buflen, size_t col, int c
       else if (!Context || (Context->mailbox->msg_flagged == 0))
         optional = 0;
       break;
+    }
 
     case 'h':
+    {
       snprintf(fmt, sizeof(fmt), "%%%ss", prec);
       snprintf(buf, buflen, fmt, NONULL(ShortHostname));
       break;
+    }
 
     case 'l':
+    {
       if (!optional)
       {
         snprintf(fmt, sizeof(fmt), "%%%ss", prec);
@@ -186,8 +195,10 @@ static const char *status_format_str(char *buf, size_t buflen, size_t col, int c
       else if (!Context || !Context->mailbox->size)
         optional = 0;
       break;
+    }
 
     case 'L':
+    {
       if (!optional)
       {
         snprintf(fmt, sizeof(fmt), "%%%ss", prec);
@@ -197,8 +208,10 @@ static const char *status_format_str(char *buf, size_t buflen, size_t col, int c
       else if (!Context || !Context->pattern)
         optional = 0;
       break;
+    }
 
     case 'm':
+    {
       if (!optional)
       {
         snprintf(fmt, sizeof(fmt), "%%%sd", prec);
@@ -207,8 +220,10 @@ static const char *status_format_str(char *buf, size_t buflen, size_t col, int c
       else if (!Context || (Context->mailbox->msg_count == 0))
         optional = 0;
       break;
+    }
 
     case 'M':
+    {
       if (!optional)
       {
         snprintf(fmt, sizeof(fmt), "%%%sd", prec);
@@ -217,8 +232,10 @@ static const char *status_format_str(char *buf, size_t buflen, size_t col, int c
       else if (!Context || !Context->pattern)
         optional = 0;
       break;
+    }
 
     case 'n':
+    {
       if (!optional)
       {
         snprintf(fmt, sizeof(fmt), "%%%sd", prec);
@@ -227,8 +244,10 @@ static const char *status_format_str(char *buf, size_t buflen, size_t col, int c
       else if (!Context || (Context->mailbox->msg_new == 0))
         optional = 0;
       break;
+    }
 
     case 'o':
+    {
       if (!optional)
       {
         snprintf(fmt, sizeof(fmt), "%%%sd", prec);
@@ -238,6 +257,7 @@ static const char *status_format_str(char *buf, size_t buflen, size_t col, int c
       else if (!Context || ((Context->mailbox->msg_unread - Context->mailbox->msg_new) == 0))
         optional = 0;
       break;
+    }
 
     case 'p':
     {
@@ -317,16 +337,21 @@ static const char *status_format_str(char *buf, size_t buflen, size_t col, int c
     }
 
     case 's':
+    {
       snprintf(fmt, sizeof(fmt), "%%%ss", prec);
       snprintf(buf, buflen, fmt, get_sort_str(tmp, sizeof(tmp), C_Sort));
       break;
+    }
 
     case 'S':
+    {
       snprintf(fmt, sizeof(fmt), "%%%ss", prec);
       snprintf(buf, buflen, fmt, get_sort_str(tmp, sizeof(tmp), C_SortAux));
       break;
+    }
 
     case 't':
+    {
       if (!optional)
       {
         snprintf(fmt, sizeof(fmt), "%%%sd", prec);
@@ -335,8 +360,10 @@ static const char *status_format_str(char *buf, size_t buflen, size_t col, int c
       else if (!Context || !Context->mailbox || (Context->mailbox->msg_tagged == 0))
         optional = 0;
       break;
+    }
 
     case 'u':
+    {
       if (!optional)
       {
         snprintf(fmt, sizeof(fmt), "%%%sd", prec);
@@ -345,12 +372,16 @@ static const char *status_format_str(char *buf, size_t buflen, size_t col, int c
       else if (!Context || (Context->mailbox->msg_unread == 0))
         optional = 0;
       break;
+    }
 
     case 'v':
+    {
       snprintf(buf, buflen, "%s", mutt_make_version());
       break;
+    }
 
     case 'V':
+    {
       if (!optional)
       {
         snprintf(fmt, sizeof(fmt), "%%%ss", prec);
@@ -359,14 +390,18 @@ static const char *status_format_str(char *buf, size_t buflen, size_t col, int c
       else if (!Context || !Context->pattern)
         optional = 0;
       break;
+    }
 
     case 0:
+    {
       *buf = '\0';
       return src;
-
+    }
     default:
+    {
       snprintf(buf, buflen, "%%%s%c", prec, op);
       break;
+    }
   }
 
   if (optional)


### PR DESCRIPTION
I've used `uncrustify` to add `{}`s to all `case` blocks.
This isn't required by `gcc`/`clang`, but `g++` gives us a lots of warnings.

@fekir 
If this is this helpful, I'll keep it.
(If not, it wasn't much effort to do)