### PR TITLE
Devel/const correctness

### DIFF
--- a/addrbook.c
+++ b/addrbook.c
@@ -140,8 +140,8 @@ static int alias_tag(struct Menu *menu, int sel, int act)
  */
 static int alias_sort_alias(const void *a, const void *b)
 {
-  struct Alias *pa = *(struct Alias **) a;
-  struct Alias *pb = *(struct Alias **) b;
+  const struct Alias *pa = *(struct Alias const *const *) a;
+  const struct Alias *pb = *(struct Alias const *const *) b;
   int r = mutt_str_strcasecmp(pa->name, pb->name);
 
   return RSORT(r);
@@ -157,8 +157,8 @@ static int alias_sort_alias(const void *a, const void *b)
  */
 static int alias_sort_address(const void *a, const void *b)
 {
-  struct AddressList *pal = &(*(struct Alias **) a)->addr;
-  struct AddressList *pbl = &(*(struct Alias **) b)->addr;
+  const struct AddressList *pal = &(*(struct Alias const *const *) a)->addr;
+  const struct AddressList *pbl = &(*(struct Alias const *const *) b)->addr;
   int r;
 
   if (pal == pbl)
@@ -169,8 +169,8 @@ static int alias_sort_address(const void *a, const void *b)
     r = 1;
   else
   {
-    struct Address *pa = TAILQ_FIRST(pal);
-    struct Address *pb = TAILQ_FIRST(pbl);
+    const struct Address *pa = TAILQ_FIRST(pal);
+    const struct Address *pb = TAILQ_FIRST(pbl);
     if (pa->personal)
     {
       if (pb->personal)

--- a/browser.c
+++ b/browser.c
@@ -145,8 +145,8 @@ static void destroy_state(struct BrowserState *state)
  */
 static int browser_compare_subject(const void *a, const void *b)
 {
-  struct FolderFile *pa = (struct FolderFile *) a;
-  struct FolderFile *pb = (struct FolderFile *) b;
+  const struct FolderFile *pa = (const struct FolderFile *) a;
+  const struct FolderFile *pb = (const struct FolderFile *) b;
 
   /* inbox should be sorted ahead of its siblings */
   int r = mutt_inbox_cmp(pa->name, pb->name);
@@ -165,8 +165,8 @@ static int browser_compare_subject(const void *a, const void *b)
  */
 static int browser_compare_desc(const void *a, const void *b)
 {
-  struct FolderFile *pa = (struct FolderFile *) a;
-  struct FolderFile *pb = (struct FolderFile *) b;
+  const struct FolderFile *pa = (const struct FolderFile *) a;
+  const struct FolderFile *pb = (const struct FolderFile *) b;
 
   int r = mutt_str_strcoll(pa->desc, pb->desc);
 
@@ -183,8 +183,8 @@ static int browser_compare_desc(const void *a, const void *b)
  */
 static int browser_compare_date(const void *a, const void *b)
 {
-  struct FolderFile *pa = (struct FolderFile *) a;
-  struct FolderFile *pb = (struct FolderFile *) b;
+  const struct FolderFile *pa = (const struct FolderFile *) a;
+  const struct FolderFile *pb = (const struct FolderFile *) b;
 
   int r = pa->mtime - pb->mtime;
 
@@ -201,8 +201,8 @@ static int browser_compare_date(const void *a, const void *b)
  */
 static int browser_compare_size(const void *a, const void *b)
 {
-  struct FolderFile *pa = (struct FolderFile *) a;
-  struct FolderFile *pb = (struct FolderFile *) b;
+  const struct FolderFile *pa = (const struct FolderFile *) a;
+  const struct FolderFile *pb = (const struct FolderFile *) b;
 
   int r = pa->size - pb->size;
 
@@ -219,8 +219,8 @@ static int browser_compare_size(const void *a, const void *b)
  */
 static int browser_compare_count(const void *a, const void *b)
 {
-  struct FolderFile *pa = (struct FolderFile *) a;
-  struct FolderFile *pb = (struct FolderFile *) b;
+  const struct FolderFile *pa = (const struct FolderFile *) a;
+  const struct FolderFile *pb = (const struct FolderFile *) b;
 
   int r = 0;
   if (pa->has_mailbox && pb->has_mailbox)
@@ -243,8 +243,8 @@ static int browser_compare_count(const void *a, const void *b)
  */
 static int browser_compare_count_new(const void *a, const void *b)
 {
-  struct FolderFile *pa = (struct FolderFile *) a;
-  struct FolderFile *pb = (struct FolderFile *) b;
+  const struct FolderFile *pa = (const struct FolderFile *) a;
+  const struct FolderFile *pb = (const struct FolderFile *) b;
 
   int r = 0;
   if (pa->has_mailbox && pb->has_mailbox)
@@ -271,8 +271,8 @@ static int browser_compare_count_new(const void *a, const void *b)
  */
 static int browser_compare(const void *a, const void *b)
 {
-  struct FolderFile *pa = (struct FolderFile *) a;
-  struct FolderFile *pb = (struct FolderFile *) b;
+  const struct FolderFile *pa = (const struct FolderFile *) a;
+  const struct FolderFile *pb = (const struct FolderFile *) b;
 
   if ((mutt_str_strcoll(pa->desc, "../") == 0) || (mutt_str_strcoll(pa->desc, "..") == 0))
     return -1;

--- a/config/dump.c
+++ b/config/dump.c
@@ -105,8 +105,8 @@ int elem_list_sort(const void *a, const void *b)
   if (!a || !b)
     return 0;
 
-  const struct HashElem *hea = *(struct HashElem **) a;
-  const struct HashElem *heb = *(struct HashElem **) b;
+  const struct HashElem *hea = *(struct HashElem const *const *) a;
+  const struct HashElem *heb = *(struct HashElem const *const *) b;
 
   return mutt_str_strcasecmp(hea->key.strkey, heb->key.strkey);
 }

--- a/conn/sasl.c
+++ b/conn/sasl.c
@@ -657,8 +657,9 @@ int mutt_sasl_interact(sasl_interact_t *interaction)
       return SASL_FAIL;
 
     interaction->len = mutt_str_strlen(resp) + 1;
-    interaction->result = mutt_mem_malloc(interaction->len);
-    memcpy((char *) interaction->result, resp, interaction->len);
+    char *result = mutt_mem_malloc(interaction->len);
+    memcpy(result, resp, interaction->len);
+    interaction->result = result;
 
     interaction++;
   }

--- a/curs_lib.c
+++ b/curs_lib.c
@@ -652,7 +652,7 @@ int mutt_buffer_enter_fname_full(const char *prompt, struct Buffer *fname,
   struct KeyEvent ch;
 
   SET_COLOR(MT_COLOR_PROMPT);
-  mutt_window_mvaddstr(MuttMessageWindow, 0, 0, (char *) prompt);
+  mutt_window_mvaddstr(MuttMessageWindow, 0, 0, prompt);
   addstr(_(" ('?' for list): "));
   NORMAL_COLOR;
   if (mutt_buffer_len(fname))

--- a/email/parse.c
+++ b/email/parse.c
@@ -250,7 +250,7 @@ static void parse_content_disposition(const char *s, struct Body *ct)
  * @param head List to receive the references
  * @param s    String to parse
  */
-static void parse_references(struct ListHead *head, char *s)
+static void parse_references(struct ListHead *head, const char *s)
 {
   char *m = NULL;
   const char *sp = NULL;

--- a/hdrline.c
+++ b/hdrline.c
@@ -683,12 +683,11 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
 
         if (optional && ((op == '[') || (op == '(')))
         {
-          char *is = NULL;
           now = time(NULL);
           struct tm tm = mutt_date_localtime(now);
           now -= (op == '(') ? e->received : e->date_sent;
 
-          is = (char *) prec;
+          char *is = (char *) prec;
           bool invert = false;
           if (*is == '>')
           {

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -984,9 +984,10 @@ bool imap_has_flag(struct ListHead *flag_list, const char *flag)
  */
 static int compare_uid(const void *a, const void *b)
 {
-  struct Email **ea = (struct Email **) a;
-  struct Email **eb = (struct Email **) b;
-  return imap_edata_get(*ea)->uid - imap_edata_get(*eb)->uid;
+  const struct Email *ea = *(struct Email const *const *) a;
+  const struct Email *eb = *(struct Email const *const *) b;
+  return imap_edata_get((struct Email *) ea)->uid -
+         imap_edata_get((struct Email *) eb)->uid;
 }
 
 /**

--- a/mutt/hash.c
+++ b/mutt/hash.c
@@ -45,7 +45,7 @@
 static size_t gen_string_hash(union HashKey key, size_t n)
 {
   size_t h = 0;
-  unsigned char *s = (unsigned char *) key.strkey;
+  const unsigned char *s = (const unsigned char *) key.strkey;
 
   while (*s)
     h += ((h << 7) + *s++);
@@ -76,7 +76,7 @@ static int cmp_string_key(union HashKey a, union HashKey b)
 static size_t gen_case_string_hash(union HashKey key, size_t n)
 {
   size_t h = 0;
-  unsigned char *s = (unsigned char *) key.strkey;
+  const unsigned char *s = (const unsigned char *) key.strkey;
 
   while (*s)
     h += ((h << 7) + tolower(*s++));

--- a/mutt_thread.c
+++ b/mutt_thread.c
@@ -635,8 +635,8 @@ static int compare_threads(const void *a, const void *b)
 
   if (a && b)
   {
-    return (*sort_func)(&(*((struct MuttThread **) a))->sort_key,
-                        &(*((struct MuttThread **) b))->sort_key);
+    return (*sort_func)(&(*((struct MuttThread const *const *) a))->sort_key,
+                        &(*((struct MuttThread const *const *) b))->sort_key);
   }
   /* a hack to let us reset sort_func even though we can't
    * have extra arguments because of qsort */

--- a/ncrypt/pgpkey.c
+++ b/ncrypt/pgpkey.c
@@ -353,8 +353,8 @@ static int compare_key_address(const void *a, const void *b)
 {
   int r;
 
-  struct PgpUid **s = (struct PgpUid **) a;
-  struct PgpUid **t = (struct PgpUid **) b;
+  struct PgpUid const *const *s = (struct PgpUid const *const *) a;
+  struct PgpUid const *const *t = (struct PgpUid const *const *) b;
 
   r = mutt_str_strcasecmp((*s)->addr, (*t)->addr);
   if (r != 0)
@@ -392,8 +392,8 @@ static int compare_keyid(const void *a, const void *b)
 {
   int r;
 
-  struct PgpUid **s = (struct PgpUid **) a;
-  struct PgpUid **t = (struct PgpUid **) b;
+  struct PgpUid const *const *s = (struct PgpUid const *const *) a;
+  struct PgpUid const *const *t = (struct PgpUid const *const *) b;
 
   r = mutt_str_strcasecmp(pgp_fpr_or_lkeyid((*s)->parent), pgp_fpr_or_lkeyid((*t)->parent));
   if (r != 0)
@@ -426,8 +426,8 @@ static int pgp_compare_keyid(const void *a, const void *b)
 static int compare_key_date(const void *a, const void *b)
 {
   int r;
-  struct PgpUid **s = (struct PgpUid **) a;
-  struct PgpUid **t = (struct PgpUid **) b;
+  struct PgpUid const *const *s = (struct PgpUid const *const *) a;
+  struct PgpUid const *const *t = (struct PgpUid const *const *) b;
 
   r = ((*s)->parent->gen_time - (*t)->parent->gen_time);
   if (r != 0)
@@ -464,8 +464,8 @@ static int compare_key_trust(const void *a, const void *b)
 {
   int r;
 
-  struct PgpUid **s = (struct PgpUid **) a;
-  struct PgpUid **t = (struct PgpUid **) b;
+  struct PgpUid const *const *s = (struct PgpUid const *const *) a;
+  struct PgpUid const *const *t = (struct PgpUid const *const *) b;
 
   r = (((*s)->parent->flags & KEYFLAG_RESTRICTIONS) -
        ((*t)->parent->flags & KEYFLAG_RESTRICTIONS));

--- a/nntp/nntp.c
+++ b/nntp/nntp.c
@@ -2367,11 +2367,11 @@ int nntp_check_children(struct Context *ctx, const char *msgid)
  */
 int nntp_compare_order(const void *a, const void *b)
 {
-  struct Email **ea = (struct Email **) a;
-  struct Email **eb = (struct Email **) b;
+  const struct Email *ea = *(struct Email const *const *) a;
+  const struct Email *eb = *(struct Email const *const *) b;
 
-  anum_t na = nntp_edata_get(*ea)->article_num;
-  anum_t nb = nntp_edata_get(*eb)->article_num;
+  anum_t na = nntp_edata_get((struct Email *) ea)->article_num;
+  anum_t nb = nntp_edata_get((struct Email *) eb)->article_num;
   int result = (na == nb) ? 0 : (na > nb) ? 1 : -1;
   result = perform_auxsort(result, a, b);
   return SORT_CODE(result);

--- a/pager.c
+++ b/pager.c
@@ -524,7 +524,7 @@ static struct QClass *classify_quote(struct QClass **quote_list, const char *qpt
 {
   struct QClass *q_list = *quote_list;
   struct QClass *qc = NULL, *tmp = NULL, *ptr = NULL, *save = NULL;
-  char *tail_qptr = NULL;
+  const char *tail_qptr = NULL;
   int offset, tail_lng;
   int index = -1;
 
@@ -650,7 +650,7 @@ static struct QClass *classify_quote(struct QClass **quote_list, const char *qpt
 
         q_list = q_list->down;
         tail_lng = length - offset;
-        tail_qptr = (char *) qptr + offset;
+        tail_qptr = qptr + offset;
 
         while (q_list)
         {
@@ -752,7 +752,7 @@ static struct QClass *classify_quote(struct QClass **quote_list, const char *qpt
 
               q_list = q_list->down;
               tail_lng = length - offset;
-              tail_qptr = (char *) qptr + offset;
+              tail_qptr = qptr + offset;
 
               continue;
             }

--- a/rfc3676.c
+++ b/rfc3676.c
@@ -67,7 +67,7 @@ struct FlowedState
 static int get_quote_level(const char *line)
 {
   int quoted = 0;
-  char *p = (char *) line;
+  const char *p = line;
 
   while (p && (*p == '>'))
   {

--- a/sendlib.c
+++ b/sendlib.c
@@ -768,7 +768,7 @@ static void update_content_info(struct Content *info, struct ContentState *s,
  * in.
  */
 static size_t convert_file_to(FILE *fp, const char *fromcode, int ncodes,
-                              const char **tocodes, int *tocode, struct Content *info)
+                              char const *const *tocodes, int *tocode, struct Content *info)
 {
   char bufi[256], bufu[512], bufo[4 * sizeof(bufi)];
   size_t ret;
@@ -960,7 +960,7 @@ static size_t convert_file_from_to(FILE *fp, const char *fromcodes, const char *
         continue;
       fcode = mutt_str_substr_dup(c, c1);
 
-      ret = convert_file_to(fp, fcode, ncodes, (const char **) tcode, &cn, info);
+      ret = convert_file_to(fp, fcode, ncodes, (char const *const *) tcode, &cn, info);
       if (ret != (size_t)(-1))
       {
         *fromcode = fcode;
@@ -974,7 +974,7 @@ static size_t convert_file_from_to(FILE *fp, const char *fromcodes, const char *
   else
   {
     /* There is only one fromcode */
-    ret = convert_file_to(fp, fromcodes, ncodes, (const char **) tcode, &cn, info);
+    ret = convert_file_to(fp, fromcodes, ncodes, (char const *const *) tcode, &cn, info);
     if (ret != (size_t)(-1))
     {
       *tocode = tcode[cn];
@@ -2123,7 +2123,6 @@ static int write_one_header(FILE *fp, int pfxw, int max, int wraplen, const char
 int mutt_write_one_header(FILE *fp, const char *tag, const char *value,
                           const char *pfx, int wraplen, CopyHeaderFlags chflags)
 {
-  char *p = (char *) value;
   char *last = NULL, *line = NULL;
   int max = 0, w, rc = -1;
   int pfxw = mutt_strwidth(pfx);
@@ -2162,7 +2161,7 @@ int mutt_write_one_header(FILE *fp, const char *tag, const char *value,
     }
   }
 
-  p = v;
+  char *p = v;
   last = v;
   line = v;
   while (p && *p)

--- a/sidebar.c
+++ b/sidebar.c
@@ -297,10 +297,10 @@ static void make_sidebar_entry(char *buf, size_t buflen, int width,
  */
 static int cb_qsort_sbe(const void *a, const void *b)
 {
-  const struct SbEntry *sbe1 = *(const struct SbEntry **) a;
-  const struct SbEntry *sbe2 = *(const struct SbEntry **) b;
-  struct Mailbox *m1 = sbe1->mailbox;
-  struct Mailbox *m2 = sbe2->mailbox;
+  const struct SbEntry *sbe1 = *(struct SbEntry const *const *) a;
+  const struct SbEntry *sbe2 = *(struct SbEntry const *const *) b;
+  const struct Mailbox *m1 = sbe1->mailbox;
+  const struct Mailbox *m2 = sbe2->mailbox;
 
   int rc = 0;
 

--- a/sort.c
+++ b/sort.c
@@ -78,7 +78,8 @@ int perform_auxsort(int retval, const void *a, const void *b)
   /* If the items still match, use their index positions
    * to maintain a stable sort order */
   if (retval == 0)
-    retval = (*((struct Email **) a))->index - (*((struct Email **) b))->index;
+    retval = (*((struct Email const *const *) a))->index -
+             (*((struct Email const *const *) b))->index;
   return retval;
 }
 
@@ -87,8 +88,8 @@ int perform_auxsort(int retval, const void *a, const void *b)
  */
 static int compare_score(const void *a, const void *b)
 {
-  struct Email **pa = (struct Email **) a;
-  struct Email **pb = (struct Email **) b;
+  struct Email const *const *pa = (struct Email const *const *) a;
+  struct Email const *const *pb = (struct Email const *const *) b;
   int result = (*pb)->score - (*pa)->score; /* note that this is reverse */
   result = perform_auxsort(result, a, b);
   return SORT_CODE(result);
@@ -99,8 +100,8 @@ static int compare_score(const void *a, const void *b)
  */
 static int compare_size(const void *a, const void *b)
 {
-  struct Email **pa = (struct Email **) a;
-  struct Email **pb = (struct Email **) b;
+  struct Email const *const *pa = (struct Email const *const *) a;
+  struct Email const *const *pb = (struct Email const *const *) b;
   int result = (*pa)->content->length - (*pb)->content->length;
   result = perform_auxsort(result, a, b);
   return SORT_CODE(result);
@@ -111,8 +112,8 @@ static int compare_size(const void *a, const void *b)
  */
 static int compare_date_sent(const void *a, const void *b)
 {
-  struct Email **pa = (struct Email **) a;
-  struct Email **pb = (struct Email **) b;
+  struct Email const *const *pa = (struct Email const *const *) a;
+  struct Email const *const *pb = (struct Email const *const *) b;
   int result = (*pa)->date_sent - (*pb)->date_sent;
   result = perform_auxsort(result, a, b);
   return SORT_CODE(result);
@@ -123,8 +124,8 @@ static int compare_date_sent(const void *a, const void *b)
  */
 static int compare_subject(const void *a, const void *b)
 {
-  struct Email **pa = (struct Email **) a;
-  struct Email **pb = (struct Email **) b;
+  struct Email const *const *pa = (struct Email const *const *) a;
+  struct Email const *const *pb = (struct Email const *const *) b;
   int rc;
 
   if (!(*pa)->env->real_subj)
@@ -174,8 +175,8 @@ const char *mutt_get_name(const struct Address *a)
  */
 static int compare_to(const void *a, const void *b)
 {
-  struct Email **ppa = (struct Email **) a;
-  struct Email **ppb = (struct Email **) b;
+  struct Email const *const *ppa = (struct Email const *const *) a;
+  struct Email const *const *ppb = (struct Email const *const *) b;
   char fa[128];
 
   mutt_str_strfcpy(fa, mutt_get_name(TAILQ_FIRST(&(*ppa)->env->to)), sizeof(fa));
@@ -190,8 +191,8 @@ static int compare_to(const void *a, const void *b)
  */
 static int compare_from(const void *a, const void *b)
 {
-  struct Email **ppa = (struct Email **) a;
-  struct Email **ppb = (struct Email **) b;
+  struct Email const *const *ppa = (struct Email const *const *) a;
+  struct Email const *const *ppb = (struct Email const *const *) b;
   char fa[128];
 
   mutt_str_strfcpy(fa, mutt_get_name(TAILQ_FIRST(&(*ppa)->env->from)), sizeof(fa));
@@ -206,8 +207,8 @@ static int compare_from(const void *a, const void *b)
  */
 static int compare_date_received(const void *a, const void *b)
 {
-  struct Email **pa = (struct Email **) a;
-  struct Email **pb = (struct Email **) b;
+  struct Email const *const *pa = (struct Email const *const *) a;
+  struct Email const *const *pb = (struct Email const *const *) b;
   int result = (*pa)->received - (*pb)->received;
   result = perform_auxsort(result, a, b);
   return SORT_CODE(result);
@@ -218,8 +219,8 @@ static int compare_date_received(const void *a, const void *b)
  */
 static int compare_order(const void *a, const void *b)
 {
-  struct Email **ea = (struct Email **) a;
-  struct Email **eb = (struct Email **) b;
+  struct Email const *const *ea = (struct Email const *const *) a;
+  struct Email const *const *eb = (struct Email const *const *) b;
 
   /* no need to auxsort because you will never have equality here */
   return SORT_CODE((*ea)->index - (*eb)->index);
@@ -230,8 +231,8 @@ static int compare_order(const void *a, const void *b)
  */
 static int compare_spam(const void *a, const void *b)
 {
-  struct Email **ppa = (struct Email **) a;
-  struct Email **ppb = (struct Email **) b;
+  struct Email const *const *ppa = (struct Email const *const *) a;
+  struct Email const *const *ppb = (struct Email const *const *) b;
   char *aptr = NULL, *bptr = NULL;
   int ahas, bhas;
   int result = 0;
@@ -286,8 +287,8 @@ static int compare_spam(const void *a, const void *b)
  */
 static int compare_label(const void *a, const void *b)
 {
-  struct Email **ppa = (struct Email **) a;
-  struct Email **ppb = (struct Email **) b;
+  struct Email const *const *ppa = (struct Email const *const *) a;
+  struct Email const *const *ppb = (struct Email const *const *) b;
   int ahas, bhas, result = 0;
 
   /* As with compare_spam, not all messages will have the x-label

--- a/test/config/common.c
+++ b/test/config/common.c
@@ -119,8 +119,8 @@ void set_list(const struct ConfigSet *cs)
 
 int sort_list_cb(const void *a, const void *b)
 {
-  const char *stra = *(char **) a;
-  const char *strb = *(char **) b;
+  const char *stra = *(char const *const *) a;
+  const char *strb = *(char const *const *) b;
   return strcmp(stra, strb);
 }
 


### PR DESCRIPTION
* **What does this PR do?**

Improve const-correctness.


I've analysed most through `gcc` `-Wcast-qual`, `-Wdiscarded-qualifiers`, `-Wdiscarded-array-qualifiers`, and `g++ -fpermissive`.

All those changes should not change any code behaviour, just reduce the places where to look for UB because of a const casted away.

There are other places where the cast is technically fine, for example functions like `mutt_str_skip_whitespace` should work both with `char*` and with `const char*`. But because of the C type system, and absence of something like templates/generics/overloads, it is not possible 

 * a function that work for both types without a cast/that does not generate a `-Wcast-qual` warning
 * an overload for those types (the most similar things to overload is macro based, and available since  c11: the [generic selection](https://en.cppreference.com/w/c/language/generic))
 * no code duplication (unless replacing the function with a macro)

thus I have no idea how to improve the code in those cases.


Besides, the signature of `iconv` on my system (ubuntu) is `extern size_t iconv (iconv_t __cd, char **__restrict __inbuf, size_t *__restrict __inbytesleft, char **__restrict __outbuf, size_t *__restrict __outbytesleft);`, thus `ICONV_CONST` is defined to nothing.
As this correctly generates `-Wcast-qual` warnings, which I guess are benign, just my function definition not "correct", maybe it makes sense to wrap this function call and to the cast only once.
Or is `iconv` expected in this case to change the content of `inbuf`?