### PR TITLE
Initialize the variable `index_hint`

### DIFF
--- a/index.c
+++ b/index.c
@@ -1026,7 +1026,7 @@ int mutt_index_menu(void)
   bool tag = false;  /* has the tag-prefix command been pressed? */
   int newcount = -1;
   int oldcount = -1;
-  int index_hint; /* used to restore cursor position */
+  int index_hint = 0; /* used to restore cursor position */
   bool do_mailbox_notify = true;
   int close = 0; /* did we OP_QUIT or OP_EXIT out of this menu? */
   int attach_msg = OptAttachMsg;


### PR DESCRIPTION
Prior to this commit, `index_hint` is initialized if `Context && !attach_msg`.

If `query_quadoption(C_Quit, _("Quit NeoMutt?")) == MUTT_YES`,
`!Context || ((check = mx_mbox_close(&Context)) == 0)` is `false` and
`(check == MUTT_NEW_MAIL) || (check == MUTT_REOPENED)` the function `update_index`
is called with parameter `index_hint`.

As one of the condition is `query_quadoption(C_Quit, _("Quit NeoMutt?")) == MUTT_YES`,
the real current position is probably not so important.

* **What does this PR do?**

Initialize `index_hint`, as discussed in https://github.com/neomutt/neomutt/issues/1767
