### PR TITLE
Avoid implicit conversion between bool and quadopt

### DIFF
--- a/curs_lib.c
+++ b/curs_lib.c
@@ -326,7 +326,7 @@ void mutt_edit_file(const char *editor, const char *file)
 /**
  * mutt_yesorno - Ask the user a Yes/No question
  * @param msg Prompt
- * @param def Default answer, see #QuadOption
+ * @param def Default answer, #MUTT_YES or #MUTT_NO (see #QuadOption)
  * @retval num Selection made, see #QuadOption
  */
 enum QuadOption mutt_yesorno(const char *msg, enum QuadOption def)

--- a/init.c
+++ b/init.c
@@ -3327,7 +3327,7 @@ enum QuadOption query_quadoption(enum QuadOption opt, const char *prompt)
       return opt;
 
     default:
-      opt = mutt_yesorno(prompt, (opt == MUTT_ASKYES));
+      opt = mutt_yesorno(prompt, (opt == MUTT_ASKYES) ? MUTT_YES : MUTT_NO);
       mutt_window_clearline(MuttMessageWindow, 0);
       return opt;
   }


### PR DESCRIPTION
* **What does this PR do?**

Make the conversion between `bool and `QuadOption` explicit, and avoid
depending on the underlying `enum` value.

Also state that `mutt_yesorno` works correctly for `MUTT_YES` and `MUTT_NO`

* **What are the relevant issue numbers?**

https://github.com/neomutt/neomutt/issues/1765



* **Further consideration**

I've added an `assert` to ensure code-correctness/self-documentation, but I've noticed that they are not used so much in the code base.
Are there some guidelines? Are they accepted/avoided?
On https://neomutt.org/dev/coding-style they are not mentioned.