### PR TITLE
Make callback take const param

### DIFF
--- a/pop/pop.c
+++ b/pop/pop.c
@@ -153,7 +153,7 @@ static struct PopEmailData *pop_edata_new(const char *uid)
  * @retval  0 Success
  * @retval -1 Failure
  */
-static int fetch_message(char *line, void *data)
+static int fetch_message(const char *line, void *data)
 {
   FILE *fp = data;
 
@@ -253,7 +253,7 @@ static int pop_read_header(struct PopAccountData *adata, struct Email *e)
  * @retval  0 Success
  * @retval -1 Failure
  */
-static int fetch_uidl(char *line, void *data)
+static int fetch_uidl(const char *line, void *data)
 {
   struct Mailbox *m = data;
   struct PopAccountData *adata = pop_adata_get(m);
@@ -265,7 +265,7 @@ static int fetch_uidl(char *line, void *data)
     return -1;
   while (*endp == ' ')
     endp++;
-  memmove(line, endp, strlen(endp) + 1);
+  line = endp;
 
   /* uid must be at least be 1 byte */
   if (strlen(line) == 0)

--- a/pop/pop_lib.c
+++ b/pop/pop_lib.c
@@ -123,15 +123,14 @@ static void pop_error(struct PopAccountData *adata, char *msg)
  * @param data POP data
  * @retval 0 (always)
  */
-static int fetch_capa(char *line, void *data)
+static int fetch_capa(const char *line, void *data)
 {
   struct PopAccountData *adata = data;
-  char *c = NULL;
 
   if (mutt_str_startswith(line, "SASL", CASE_IGNORE))
   {
     FREE(&adata->auth_list);
-    c = mutt_str_skip_email_wsp(line + 4);
+    const char* c = mutt_str_skip_email_wsp(line + 4);
     adata->auth_list = mutt_str_strdup(c);
   }
 
@@ -156,7 +155,7 @@ static int fetch_capa(char *line, void *data)
  * @param data POP data
  * @retval 0 (always)
  */
-static int fetch_auth(char *line, void *data)
+static int fetch_auth(const char *line, void *data)
 {
   struct PopAccountData *adata = data;
 
@@ -552,7 +551,7 @@ int pop_fetch_data(struct PopAccountData *adata, const char *query,
  * @retval  0 Success
  * @retval -1 Error
  */
-static int check_uidl(char *line, void *data)
+static int check_uidl(const char *line, void *data)
 {
   if (!line || !data)
     return -1;
@@ -565,13 +564,12 @@ static int check_uidl(char *line, void *data)
     return -1;
   while (*endp == ' ')
     endp++;
-  memmove(line, endp, strlen(endp) + 1);
 
   struct Mailbox *m = data;
   for (int i = 0; i < m->msg_count; i++)
   {
     struct PopEmailData *edata = m->emails[i]->edata;
-    if (mutt_str_strcmp(edata->uid, line) == 0)
+    if (mutt_str_strcmp(edata->uid, endp) == 0)
     {
       m->emails[i]->refno = index;
       break;

--- a/pop/pop_private.h
+++ b/pop/pop_private.h
@@ -129,7 +129,7 @@ void pop_apop_timestamp(struct PopAccountData *adata, char *buf);
  * @retval  0 Success
  * @retval -1 Failure
  */
-typedef int (*pop_fetch_t)(char *str, void *data);
+typedef int (*pop_fetch_t)(const char *str, void *data);
 
 /* pop_lib.c */
 #define pop_query(adata, buf, buflen) pop_query_d(adata, buf, buflen, NULL)


### PR DESCRIPTION
Otherwise a realloc is potentnially unsafe

* **What does this PR do?**

Make pop_fetch_t take const char* as param

* **What are the relevant issue numbers?**

https://github.com/neomutt/neomutt/issues/1777