### PR TITLE
Fix struct Buffer used as %s

### DIFF
--- a/init.c
+++ b/init.c
@@ -2743,7 +2743,7 @@ int mutt_extract_token(struct Buffer *dest, struct Buffer *tok, TokenFlags flags
       pid = mutt_create_filter(cmd.data, NULL, &fp, NULL);
       if (pid < 0)
       {
-        mutt_debug(LL_DEBUG1, "unable to fork command: %s\n", cmd);
+        mutt_debug(LL_DEBUG1, "unable to fork command: %s\n", cmd.data);
         FREE(&cmd.data);
         return -1;
       }


### PR DESCRIPTION
* **What does this PR do?**
`cmd` is a `Buffer` struct, it does not correspond to `%s` in the format string.

* **Does this PR meet the acceptance criteria?** (This is just a reminder for you,
  this section can be removed if you fulfill it.)

   - Documentation created/updated (you have to edit
     [doc/manual.xml.head](https://www.github.com/neomutt/neomutt/blob/master/doc/manual.xml.head)
     for that)

   - All builds and tests are passing

   - Added [doxygen code documentation](https://neomutt.org/dev/doxygen)
     [syntax](http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html)

   - Code follows the [style guide](https://neomutt.org/dev/coding-style)

* **What are the relevant issue numbers?**
