### PR TITLE
Remove duplicate conditional expressions

### DIFF
--- a/email/parse.c
+++ b/email/parse.c
@@ -73,7 +73,7 @@ void mutt_auto_subscribe(const char *mailto)
   if ((mutt_parse_mailto(lpenv, NULL, mailto) != -1) && !TAILQ_EMPTY(&lpenv->to))
   {
     const char *mailbox = TAILQ_FIRST(&lpenv->to)->mailbox;
-    if (mailbox && !mutt_regexlist_match(&UnSubscribedLists, mailbox) &&
+    if (mailbox && !mutt_regexlist_match(&SubscribedLists, mailbox) &&
         !mutt_regexlist_match(&UnMailLists, mailbox) &&
         !mutt_regexlist_match(&UnSubscribedLists, mailbox))
     {

--- a/mutt/charset.c
+++ b/mutt/charset.c
@@ -345,8 +345,7 @@ void mutt_ch_canonical_charset(char *buf, size_t buflen, const char *name)
 
   for (size_t i = 0; PreferredMimeNames[i].key; i++)
   {
-    if ((mutt_str_strcasecmp(scratch, PreferredMimeNames[i].key) == 0) ||
-        (mutt_str_strcasecmp(scratch, PreferredMimeNames[i].key) == 0))
+    if (mutt_str_strcasecmp(scratch, PreferredMimeNames[i].key) == 0)
     {
       mutt_str_strfcpy(buf, PreferredMimeNames[i].pref, buflen);
       goto out;

--- a/sendlib.c
+++ b/sendlib.c
@@ -1154,8 +1154,7 @@ enum ContentType mutt_lookup_mime_type(struct Body *att, const char *path)
         {
           sze = mutt_str_strlen(p);
           if ((sze > cur_sze) && (szf >= sze) &&
-              ((mutt_str_strcasecmp(path + szf - sze, p) == 0) ||
-               (mutt_str_strcasecmp(path + szf - sze, p) == 0)) &&
+              (mutt_str_strcasecmp(path + szf - sze, p) == 0) &&
               ((szf == sze) || (path[szf - sze - 1] == '.')))
           {
             /* get the content-type */


### PR DESCRIPTION
* **What does this PR do?**
`mutt_str_strcasecmp(path + szf - sze, p) == 0` is checked twice, merge them into one.

* **Does this PR meet the acceptance criteria?** (This is just a reminder for you,
  this section can be removed if you fulfill it.)

   - Documentation created/updated (you have to edit
     [doc/manual.xml.head](https://www.github.com/neomutt/neomutt/blob/master/doc/manual.xml.head)
     for that)

   - All builds and tests are passing

   - Added [doxygen code documentation](https://neomutt.org/dev/doxygen)
     [syntax](http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html)

   - Code follows the [style guide](https://neomutt.org/dev/coding-style)

* **What are the relevant issue numbers?**
