### PR TITLE
Remove uninitialized char array buf

### DIFF
--- a/imap/imap.c
+++ b/imap/imap.c
@@ -849,8 +849,6 @@ void imap_expunge_mailbox(struct Mailbox *m)
  */
 int imap_open_connection(struct ImapAccountData *adata)
 {
-  char buf[1024];
-
   if (mutt_socket_open(adata->conn) < 0)
     return -1;
 
@@ -920,7 +918,7 @@ int imap_open_connection(struct ImapAccountData *adata)
   }
   else
   {
-    imap_error("imap_open_connection()", buf);
+    imap_error("imap_open_connection()", adata->buf);
     goto bail;
   }
 


### PR DESCRIPTION
* **What does this PR do?**
String `buf` is uninitialized when used here.
* **Screenshots (if relevant)**

* **Does this PR meet the acceptance criteria?** (This is just a reminder for you,
  this section can be removed if you fulfill it.)

   - Documentation created/updated (you have to edit
     [doc/manual.xml.head](https://www.github.com/neomutt/neomutt/blob/master/doc/manual.xml.head)
     for that)

   - All builds and tests are passing

   - Added [doxygen code documentation](https://neomutt.org/dev/doxygen)
     [syntax](http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html)

   - Code follows the [style guide](https://neomutt.org/dev/coding-style)

* **What are the relevant issue numbers?**
