### PR TITLE
fix(notmuch): ensure message_id is correct

### DIFF
--- a/notmuch/mutt_notmuch.c
+++ b/notmuch/mutt_notmuch.c
@@ -778,8 +778,20 @@ static int init_email(struct Email *e, const char *path, notmuch_message_t *msg)
 
   mutt_debug(LL_DEBUG2, "nm: [e=%p, edata=%p] (%s)\n", (void *) e, (void *) e->edata, id);
 
+  char *nm_msg_id = nm2mutt_message_id(id);
   if (!e->env->message_id)
-    e->env->message_id = nm2mutt_message_id(id);
+  {
+    e->env->message_id = nm_msg_id;
+  }
+  else if (mutt_str_strcmp(e->env->message_id, nm_msg_id) != 0)
+  {
+    FREE(&e->env->message_id);
+    e->env->message_id = nm_msg_id;
+  }
+  else
+  {
+    FREE(&nm_msg_id);
+  }
 
   if (update_message_path(e, path) != 0)
     return -1;


### PR DESCRIPTION
The notmuch-backend initializes a provided email struct with content
from notmuch. In rare instances, a provided email struct has a
message_id that does not match the one from notmuch. No validation to
ensure message_ids match is performed.

An issue occurs when running nm_mbox_check(), which stores all messages
in a hash table. The incorrect message_id is the key so our email is
considered missing, reloaded into the mailbox, and a duplicate appears
in the index. This triggers a warning from neomutt regarding external
modification.

Instead, validate the message_ids to ensure a match so our hash table
keys are correct. As a result, a reload is no longer performed and
neomutt's warning need not occur.

Fixes #1793 