### PR TITLE
 fix(notmuch): sort headers on interrupted read

### DIFF
--- a/mx.c
+++ b/mx.c
@@ -368,7 +368,10 @@ struct Context *mx_mbox_open(struct Mailbox *m, OpenMailboxFlags flags)
     if (!m->quiet)
       mutt_clear_error();
     if (rc == -2)
+    {
       mutt_error(_("Reading from %s interrupted..."), mutt_b2s(m->pathbuf));
+      mutt_sort_headers(ctx, true);
+    }
   }
   else
   {


### PR DESCRIPTION
Commit 45639e4 breaks partial notmuch mailbox loads. If a notmuch mailbox is
interrupted while loading, the index will be empty. To resolve this, add back
the 'mutt_sort_headers()' for the interrupted read case.

Fixes #1800 