### PR TITLE
Drop global DocList, attach the parsed result to Mailbox

### DIFF
--- a/help/help.h
+++ b/help/help.h
@@ -42,11 +42,13 @@
 
 extern struct MxOps MxHelpOps;
 
-typedef uint8_t HelpDocFlags;     ///< Types of Help Documents, e.g. #HELP_DOC_INDEX
-#define HELP_DOC_NO_FLAGS      0  ///< No flags are set
+typedef uint8_t HelpDocFlags; ///< Types of Help Documents, e.g. #HELP_DOC_INDEX
+#define HELP_DOC_NO_FLAGS 0   ///< No flags are set
 #define HELP_DOC_UNKNOWN (1 << 0) ///< File isn't a help document
-#define HELP_DOC_INDEX   (1 << 1) ///< Document is treated as help index (index.md)
-#define HELP_DOC_ROOTDOC (1 << 2) ///< Document lives directly in root of #C_HelpDocDir
+#define HELP_DOC_INDEX                                                         \
+  (1 << 1) ///< Document is treated as help index (index.md)
+#define HELP_DOC_ROOTDOC                                                       \
+  (1 << 2) ///< Document lives directly in root of #C_HelpDocDir
 #define HELP_DOC_CHAPTER (1 << 3) ///< Document is treated as help chapter
 #define HELP_DOC_SECTION (1 << 4) ///< Document is treated as help section
 
@@ -64,12 +66,11 @@ struct HelpFileHeader
  */
 struct HelpDocMeta
 {
-  struct Vector *fhdr;   ///< File header lines (list of key/value pairs)
-  char *name;            ///< Base file name
-  HelpDocFlags type;     ///< Type of the help document
+  struct Vector *fhdr; ///< File header lines (list of key/value pairs)
+  char *name;          ///< Base file name
+  HelpDocFlags type;   ///< Type of the help document
 };
 
-void help_doclist_free(void);
-int  help_doclist_init(void);
+int help_doclist_init(struct Vector *DocList);
 
 #endif /* MUTT_HELP_HELP_H */

--- a/help/scan.c
+++ b/help/scan.c
@@ -53,10 +53,9 @@ static int add_file(const char *fpath, const struct stat *sb, int tflag, struct 
   if (tflag == FTW_F)
   {
     char *ext = strrchr(fpath, '.');
-    char *path = mutt_str_strdup(fpath);
     if (ext && !mutt_str_strcmp(ext, ".md"))
     {
-      vector_new_append(&DocPaths, sizeof(char *), path);
+      vector_new_append(&DocPaths, sizeof(char *), mutt_str_strdup(fpath));
     }
   }
   return 0; /* To tell nftw() to continue */
@@ -69,7 +68,6 @@ static int add_file(const char *fpath, const struct stat *sb, int tflag, struct 
  */
 struct Vector *scan_dir(const char *path)
 {
-  vector_free(&DocPaths, NULL);
   DocPaths = vector_new(sizeof(char *));
   // Max of 20 open file handles, 0 flags
   if (nftw(path, add_file, 20, 0) == -1)
@@ -77,5 +75,8 @@ struct Vector *scan_dir(const char *path)
     perror("nftw");
   }
 
-  return DocPaths;
+  struct Vector *paths = DocPaths;
+  DocPaths = NULL;
+
+  return paths;
 }

--- a/help/vector.c
+++ b/help/vector.c
@@ -45,7 +45,10 @@ void vector_free(struct Vector **v, vector_item_free_t item_free)
 
   for (size_t i = 0; i < (*v)->size; i++)
   {
-    item_free(&((*v)->data[i]));
+    if (item_free)
+      item_free(&((*v)->data[i]));
+    else
+      FREE(&((*v)->data[i]));
   }
   FREE(&(*v)->data);
   FREE(v);
@@ -100,7 +103,6 @@ void vector_append(struct Vector *v, void *item)
     mutt_mem_realloc(v->data, v->capa * v->item_size);
   }
 
-  v->data[v->size] = mutt_mem_calloc(1, v->item_size);
   v->data[v->size] = item;
   v->size++;
 }

--- a/mx.c
+++ b/mx.c
@@ -581,7 +581,7 @@ int mx_mbox_close(struct Context **ptr)
   if (m->readonly || m->dontwrite || m->append)
   {
     mx_fastclose_mailbox(m);
-    FREE(ptr);
+    ctx_free(ptr);
     return 0;
   }
 


### PR DESCRIPTION
Drop the global DocList cache and attach DocList to Mailbox

* **What does this PR do?**
Before this change, help.c contains a global DocList containing parsed Email. As help documents are parsed only once. Caching is not necessary. Thus removing all caching logic and attach the DocList to Mailbox's mdata.

* **Screenshots (if relevant)**

* **Does this PR meet the acceptance criteria?** (This is just a reminder for you,
  this section can be removed if you fulfill it.)

   - Documentation created/updated (you have to edit
     [doc/manual.xml.head](https://www.github.com/neomutt/neomutt/blob/master/doc/manual.xml.head)
     for that)

   - All builds and tests are passing

   - Added [doxygen code documentation](https://neomutt.org/dev/doxygen)
     [syntax](http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html)

   - Code follows the [style guide](https://neomutt.org/dev/coding-style)

* **What are the relevant issue numbers?**
