### PR TITLE
Fix parsing of GnuPG output

### DIFF
--- a/ncrypt/pgp.c
+++ b/ncrypt/pgp.c
@@ -363,7 +363,7 @@ static int pgp_check_decryption_okay(FILE *fp_in)
 
   while ((line = mutt_file_read_line(line, &linelen, fp_in, &lineno, 0)))
   {
-    size_t plen = mutt_str_startswith(line, "[GNUPG:]", CASE_MATCH);
+    size_t plen = mutt_str_startswith(line, "[GNUPG:] ", CASE_MATCH);
     if (plen == 0)
       continue;
     s = line + plen;


### PR DESCRIPTION
* **What does this PR do?**

In GnuPG output there is a space after "[GNUPG:]". If the space is
not taken into account, the rest of the parsing fails, e.g., because
the variable "line" starts with " BEGIN_DECRYPTION" instead of the
expected "BEGIN_DECRYPTION".

This commit restores the previous parsing functionality. It appears
that the number of spaces does not differ among GnuPG versions.
However, if we wanted to make the code robust to varying amount of
space following "[GNUPG:]", we could either trim the whitespace from
the beginning or take it into account with mutt_str_lws_len().

This commit fixes a regression introduced at c2aa0c06.

* **Screenshots (if relevant)**

No screenshots but below is a (censored) log with debugging information without this patch from current master. Note the "Decryption failed" at the end.

```
[2019-08-17 22:25:53]<1> pgp_class_encrypted_handler() created temp file '/tmp/neomutt-q15HXv'
[2019-08-17 22:25:53]<1> pgp_decrypt_part() created temp file '/tmp/neomutt-bQ88qb'
[2019-08-17 22:25:53]<2> mutt_pgp_command() gpg --status-fd=2  --no-verbose --quiet --batch --output - --decrypt /tmp/neomutt-comp-...
[2019-08-17 22:25:53]<2> pgp_check_decryption_okay() checking "[GNUPG:] ENC_TO ..."
[2019-08-17 22:25:53]<2> pgp_check_decryption_okay() checking "[GNUPG:] ENC_TO ..."
[2019-08-17 22:25:53]<2> pgp_check_decryption_okay() checking "[GNUPG:] KEY_CONSIDERED ..."
[2019-08-17 22:25:53]<2> pgp_check_decryption_okay() checking "[GNUPG:] KEY_CONSIDERED ..."
[2019-08-17 22:25:53]<2> pgp_check_decryption_okay() checking "[GNUPG:] DECRYPTION_KEY ..."
[2019-08-17 22:25:53]<2> pgp_check_decryption_okay() checking "[GNUPG:] BEGIN_DECRYPTION"
[2019-08-17 22:25:53]<2> pgp_check_decryption_okay() checking "[GNUPG:] KEY_CONSIDERED ..."
[2019-08-17 22:25:53]<2> pgp_check_decryption_okay() checking "[GNUPG:] KEY_CONSIDERED ..."
[2019-08-17 22:25:53]<2> pgp_check_decryption_okay() checking "[GNUPG:] DECRYPTION_COMPLIANCE_MODE ..."
[2019-08-17 22:25:53]<2> pgp_check_decryption_okay() checking "[GNUPG:] DECRYPTION_INFO ..."
[2019-08-17 22:25:53]<2> pgp_check_decryption_okay() checking "[GNUPG:] PLAINTEXT ..."
[2019-08-17 22:25:53]<2> pgp_check_decryption_okay() checking "[GNUPG:] NEWSIG"
[2019-08-17 22:25:53]<2> pgp_check_decryption_okay() checking "[GNUPG:] KEY_CONSIDERED ..."
[2019-08-17 22:25:53]<2> pgp_check_decryption_okay() checking "[GNUPG:] SIG_ID ..."
[2019-08-17 22:25:53]<2> pgp_check_decryption_okay() checking "[GNUPG:] KEY_CONSIDERED ..."
[2019-08-17 22:25:53]<2> pgp_check_decryption_okay() checking "[GNUPG:] GOODSIG ..."
[2019-08-17 22:25:53]<2> pgp_check_decryption_okay() checking "[GNUPG:] VALIDSIG ..."
[2019-08-17 22:25:53]<2> pgp_check_decryption_okay() checking "[GNUPG:] KEY_CONSIDERED ..."
[2019-08-17 22:25:53]<2> pgp_check_decryption_okay() checking "[GNUPG:] TRUST_ULTIMATE ..."
[2019-08-17 22:25:53]<2> pgp_check_decryption_okay() checking "[GNUPG:] VERIFICATION_COMPLIANCE_MODE ..."
[2019-08-17 22:25:53]<2> pgp_check_decryption_okay() checking "[GNUPG:] DECRYPTION_OKAY"
[2019-08-17 22:25:53]<2> pgp_check_decryption_okay() checking "[GNUPG:] GOODMDC"
[2019-08-17 22:25:53]<2> pgp_check_decryption_okay() checking "[GNUPG:] END_DECRYPTION"
[2019-08-17 22:25:53]<E> pgp_decrypt_part() Decryption failed
[2019-08-17 22:25:53]<E> pgp_class_encrypted_handler() Could not decrypt PGP message
```