### PR TITLE
Add envelope's Organization field to hcache

### DIFF
--- a/hcache/hcachever.sh
+++ b/hcache/hcachever.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-BASEVERSION=2
+BASEVERSION=3
 STRUCTURES="Address Body Buffer Email Envelope ListNode Parameter"
 
 cleanstruct () {

--- a/hcache/serialize.c
+++ b/hcache/serialize.c
@@ -500,6 +500,7 @@ unsigned char *serial_dump_envelope(struct Envelope *env, unsigned char *d,
   d = serial_dump_char(env->supersedes, d, off, false);
   d = serial_dump_char(env->date, d, off, false);
   d = serial_dump_char(env->x_label, d, off, convert);
+  d = serial_dump_char(env->organization, d, off, convert);
 
   d = serial_dump_buffer(env->spam, d, off, convert);
 
@@ -553,6 +554,7 @@ void serial_restore_envelope(struct Envelope *env, const unsigned char *d, int *
   serial_restore_char(&env->supersedes, d, off, false);
   serial_restore_char(&env->date, d, off, false);
   serial_restore_char(&env->x_label, d, off, convert);
+  serial_restore_char(&env->organization, d, off, convert);
 
   serial_restore_buffer(&env->spam, d, off, convert);
 


### PR DESCRIPTION
This ensures using %W in index_format while having
header cache enabled works as expected.

Note that as we don't modify the header files that
hcachever.sh is looking for, but the serial_dump_envelope
and serial_restore_envelope functions instead, we have
to increment BASEVERSION to ensure that cache built with
previous versions gets invalidated in all cases.

Fixes #1808 