### PR TITLE
Add ability to limit levels hidden with toggle-quoted command

### DIFF
--- a/doc/manual.xml.head
+++ b/doc/manual.xml.head
@@ -2503,6 +2503,12 @@ color sidebar_divider   color8  default     <emphasis role="comment"># Dark grey
                 just the response and there is a large amount of quoted text in
                 the way.
               </para>
+              <para>
+                The variable
+                <link linkend="toggle-quoted-show-levels">$toggle_quoted_show_levels</link>
+                can be used to show some context by continuing to show that number of levels
+                rather than hiding all quoted levels.
+              </para>
             </listitem>
           </varlistentry>
           <varlistentry>

--- a/globals.h
+++ b/globals.h
@@ -177,6 +177,7 @@ WHERE char *C_NmQueryWindowCurrentSearch;    ///< Config: (notmuch) Current sear
 /* These variables are backing for config items */
 WHERE struct Regex *C_Mask;                  ///< Config: Only display files/dirs matching this regex in the browser
 WHERE struct Regex *C_QuoteRegex;            ///< Config: Regex to match quoted text in a reply
+WHERE int C_ToggleQuotedShowLevels;          ///< Config: Number of quote levels to show with toggle-quoted
 
 /* Quad-options */
 WHERE unsigned char C_Bounce;                ///< Config: Confirm before bouncing a message

--- a/init.h
+++ b/init.h
@@ -3279,6 +3279,13 @@ struct ConfigDef MuttVars[] = {
   ** .pp
   ** Match detection may be overridden by the $$smileys regular expression.
   */
+  { "toggle_quoted_show_levels", DT_NUMBER|DT_NOT_NEGATIVE, &C_ToggleQuotedShowLevels, 0 },
+  /*
+  ** .pp
+  ** Quoted text may be filtered out using the \fC<toggle-quoted>\fP command.
+  ** If set to a number greater than 0, then the \fC<toggle-quoted>\fP
+  ** command will only filter out quote levels above this number.
+  */
   { "read_inc", DT_NUMBER|DT_NOT_NEGATIVE, &C_ReadInc, 10 },
   /*
   ** .pp

--- a/pager.c
+++ b/pager.c
@@ -1712,8 +1712,11 @@ static int display_line(FILE *fp, LOFF_T *last_pos, struct Line **line_info,
     }
 
     /* this also prevents searching through the hidden lines */
-    if ((flags & MUTT_HIDE) && ((*line_info)[n].type == MT_COLOR_QUOTED))
+    if ((flags & MUTT_HIDE) && ((*line_info)[n].type == MT_COLOR_QUOTED) &&
+        (((*line_info)[n].quote == NULL) ||
+         ((*line_info)[n].quote->index >= C_ToggleQuotedShowLevels))) {
       flags = 0; /* MUTT_NOSHOW */
+    }
   }
 
   /* At this point, (*line_info[n]).quote may still be undefined. We


### PR DESCRIPTION
By setting the configuration variable `toggle_quoted_show_levels`, when you
execute the `toggle-quoted` command, the specified number of levels
will continue to be visible.

Closes: #1802 