### PR TITLE
Fix mbox's understanding of 'new'

### DIFF
--- a/imap/imap.c
+++ b/imap/imap.c
@@ -1295,7 +1295,7 @@ int imap_mbox_check_stats(struct Mailbox *m, int flags)
 {
   int rc = imap_mailbox_status(m, true);
   if (rc > 0)
-    rc = 0;
+    rc = 1;
   return rc;
 }
 

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -1293,10 +1293,7 @@ static int imap_status(struct ImapAccountData *adata, struct ImapMboxData *mdata
  */
 int imap_mbox_check_stats(struct Mailbox *m, int flags)
 {
-  int rc = imap_mailbox_status(m, true);
-  if (rc > 0)
-    rc = 1;
-  return rc;
+  return imap_mailbox_status(m, true);
 }
 
 /**
@@ -1326,7 +1323,8 @@ int imap_path_status(const char *path, bool queue)
  * imap_mailbox_status - Refresh the number of total and new messages
  * @param m      Mailbox
  * @param queue  Queue the STATUS command
- * @retval num   Total number of messages
+ * @retval num Total number of messages
+ * @retval -1  Error
  *
  * @note Prepare the mailbox if we are not connected
  */

--- a/index.c
+++ b/index.c
@@ -2265,7 +2265,7 @@ int mutt_index_menu(void)
         else
         {
           if (C_ChangeFolderNext && Context && Context->mailbox &&
-              mutt_buffer_is_empty(&Context->mailbox->pathbuf))
+              !mutt_buffer_is_empty(&Context->mailbox->pathbuf))
           {
             mutt_buffer_strcpy(folderbuf, mailbox_path(Context->mailbox));
             mutt_buffer_pretty_mailbox(folderbuf);

--- a/maildir/maildir.c
+++ b/maildir/maildir.c
@@ -549,7 +549,7 @@ static int maildir_mbox_check_stats(struct Mailbox *m, int flags)
   if (check_new || check_stats)
     maildir_check_dir(m, "cur", check_new, check_stats);
 
-  return 0;
+  return (m->msg_new > 0);
 }
 
 /**

--- a/maildir/maildir.c
+++ b/maildir/maildir.c
@@ -549,7 +549,7 @@ static int maildir_mbox_check_stats(struct Mailbox *m, int flags)
   if (check_new || check_stats)
     maildir_check_dir(m, "cur", check_new, check_stats);
 
-  return (m->msg_new > 0);
+  return m->msg_new;
 }
 
 /**

--- a/maildir/mh.c
+++ b/maildir/mh.c
@@ -419,7 +419,7 @@ static int mh_mbox_check_stats(struct Mailbox *m, int flags)
 {
   struct MhSequences mhs = { 0 };
   bool check_new = true;
-  bool rc = false;
+  int rc = -1;
   DIR *dirp = NULL;
   struct dirent *de = NULL;
 
@@ -427,7 +427,7 @@ static int mh_mbox_check_stats(struct Mailbox *m, int flags)
    * since the last m visit, there is no "new mail" */
   if (C_MailCheckRecent && (mh_sequences_changed(m) <= 0))
   {
-    rc = false;
+    rc = 0;
     check_new = false;
   }
 
@@ -435,7 +435,7 @@ static int mh_mbox_check_stats(struct Mailbox *m, int flags)
     return 0;
 
   if (mh_read_sequences(&mhs, mailbox_path(m)) < 0)
-    return false;
+    return -1;
 
   m->msg_count = 0;
   m->msg_unread = 0;
@@ -455,7 +455,7 @@ static int mh_mbox_check_stats(struct Mailbox *m, int flags)
         if (!C_MailCheckRecent || (mh_already_notified(m, i) == 0))
         {
           m->has_new = true;
-          rc = true;
+          rc = 1;
         }
         /* Because we are traversing from high to low, we can stop
          * checking for new mail after the first unseen message.

--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -1781,7 +1781,7 @@ static int mbox_mbox_check_stats(struct Mailbox *m, int flags)
     }
   }
 
-  return 0;
+  return (m->msg_new > 0);
 }
 
 // clang-format off

--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -1495,7 +1495,7 @@ static int mbox_mbox_close(struct Mailbox *m)
   mutt_file_fclose(&adata->fp);
 
   /* fix up the times so mailbox won't get confused */
-  if (m->peekonly && mutt_buffer_is_empty(&m->pathbuf) &&
+  if (m->peekonly && !mutt_buffer_is_empty(&m->pathbuf) &&
       (mutt_file_timespec_compare(&m->mtime, &adata->atime) > 0))
   {
 #ifdef HAVE_UTIMENSAT
@@ -1768,7 +1768,7 @@ static int mbox_mbox_check_stats(struct Mailbox *m, int flags)
   if (m->newly_created && ((sb.st_ctime != sb.st_mtime) || (sb.st_ctime != sb.st_atime)))
     m->newly_created = false;
 
-  if (mutt_file_stat_timespec_compare(&sb, MUTT_STAT_MTIME, &m->stats_last_checked) > 0)
+  if (flags && mutt_file_stat_timespec_compare(&sb, MUTT_STAT_MTIME, &m->stats_last_checked) > 0)
   {
     struct Context *ctx = mx_mbox_open(m, MUTT_QUIET | MUTT_NOSORT | MUTT_PEEK);
     if (ctx)
@@ -1780,6 +1780,9 @@ static int mbox_mbox_check_stats(struct Mailbox *m, int flags)
       mx_mbox_close(&ctx);
     }
   }
+
+  if (m->msg_new == 0)
+    m->has_new = false;
 
   return (m->msg_new > 0);
 }

--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -1784,7 +1784,7 @@ static int mbox_mbox_check_stats(struct Mailbox *m, int flags)
   if (m->msg_new == 0)
     m->has_new = false;
 
-  return (m->msg_new > 0);
+  return m->msg_new;
 }
 
 // clang-format off

--- a/mutt_mailbox.c
+++ b/mutt_mailbox.c
@@ -56,7 +56,8 @@ static void mailbox_check(struct Mailbox *m_cur, struct Mailbox *m_check,
       m_check->magic = mb_magic;
       break;
     default:
-      m_check->has_new = false;
+      if (m_cur == m_check)
+        m_check->has_new = false;
 
       if ((stat(mailbox_path(m_check), &sb) != 0) ||
           (S_ISREG(sb.st_mode) && (sb.st_size == 0)) ||

--- a/mutt_mailbox.c
+++ b/mutt_mailbox.c
@@ -88,7 +88,7 @@ static void mailbox_check(struct Mailbox *m_cur, struct Mailbox *m_check,
       case MUTT_MAILDIR:
       case MUTT_MH:
       case MUTT_NOTMUCH:
-        if (mx_mbox_check_stats(m_check, 0) == 0)
+        if ((mx_mbox_check_stats(m_check, check_stats) == 1) && m_check->has_new)
           MailboxCount++;
         break;
       default:; /* do nothing */
@@ -187,7 +187,7 @@ int mutt_mailbox_check(struct Mailbox *m_cur, int force)
  */
 bool mutt_mailbox_notify(struct Mailbox *m_cur)
 {
-  if (mutt_mailbox_check(m_cur, 0) && MailboxNotify)
+  if ((mutt_mailbox_check(m_cur, 0) > 0) && MailboxNotify)
   {
     return mutt_mailbox_list();
   }
@@ -292,7 +292,7 @@ void mutt_mailbox_next_buffer(struct Mailbox *m_cur, struct Buffer *s)
 {
   mutt_buffer_expand_path(s);
 
-  if (mutt_mailbox_check(m_cur, 0))
+  if (mutt_mailbox_check(m_cur, 0) > 0)
   {
     bool found = false;
     for (int pass = 0; pass < 2; pass++)

--- a/mutt_mailbox.c
+++ b/mutt_mailbox.c
@@ -89,7 +89,7 @@ static void mailbox_check(struct Mailbox *m_cur, struct Mailbox *m_check,
       case MUTT_MAILDIR:
       case MUTT_MH:
       case MUTT_NOTMUCH:
-        if ((mx_mbox_check_stats(m_check, check_stats) == 1) && m_check->has_new)
+        if ((mx_mbox_check_stats(m_check, check_stats) > 0) && m_check->has_new)
           MailboxCount++;
         break;
       default:; /* do nothing */

--- a/mx.c
+++ b/mx.c
@@ -303,12 +303,10 @@ struct Context *mx_mbox_open(struct Mailbox *m, OpenMailboxFlags flags)
   m->msg_flagged = 0;
   m->rights = MUTT_ACL_ALL;
 
-  if (flags & MUTT_QUIET)
-    m->quiet = true;
+  m->quiet = (flags & MUTT_QUIET);
   if (flags & MUTT_READONLY)
     m->readonly = true;
-  if (flags & MUTT_PEEK)
-    m->peekonly = true;
+  m->peekonly = (flags & MUTT_PEEK);
 
   if (flags & (MUTT_APPEND | MUTT_NEWFOLDER))
   {

--- a/mx.h
+++ b/mx.h
@@ -149,7 +149,8 @@ struct MxOps
    * mbox_check_stats - Check the Mailbox statistics
    * @param m     Mailbox to check
    * @param flags Function flags
-   * @retval  0 Success
+   * @retval  0 Success, no new mail
+   * @retval  1 Success, some new mail
    * @retval -1 Failure
    */
   int (*mbox_check_stats)(struct Mailbox *m, int flags);

--- a/mx.h
+++ b/mx.h
@@ -150,7 +150,7 @@ struct MxOps
    * @param m     Mailbox to check
    * @param flags Function flags
    * @retval  0 Success, no new mail
-   * @retval  1 Success, some new mail
+   * @retval >0 Success, number of new emails
    * @retval -1 Failure
    */
   int (*mbox_check_stats)(struct Mailbox *m, int flags);

--- a/notmuch/mutt_notmuch.c
+++ b/notmuch/mutt_notmuch.c
@@ -1996,7 +1996,7 @@ static int nm_mbox_check_stats(struct Mailbox *m, int flags)
   m->msg_flagged = count_query(db, qstr, limit);
   FREE(&qstr);
 
-  rc = 0;
+  rc = (m->msg_new > 0);
 done:
   if (db)
   {

--- a/sidebar.c
+++ b/sidebar.c
@@ -842,7 +842,7 @@ static void draw_sidebar(int num_rows, int num_cols, int div_width)
     }
     else if (entryidx == HilIndex)
       mutt_curses_set_color(MT_COLOR_HIGHLIGHT);
-    else if ((m->msg_unread > 0) || (m->has_new))
+    else if (m->has_new)
       mutt_curses_set_color(MT_COLOR_NEW);
     else if (m->msg_flagged > 0)
       mutt_curses_set_color(MT_COLOR_FLAGGED);


### PR DESCRIPTION
Recent refactoring introduced several bugs related to whether a mailbox was considered _new_.

- 252e4b757 fix: mbox_check_stats() retvals
  We weren't distinguising between 'success: no new mail' and 'success: some new mail', which led to unnecessary checks (which are expensive for mbox).

- cf599f50b fix mbox's handling of new mail
  Make sure that `Mailbox.has_new` behaves correctly, which means checking
  - The timestamp on the mbox file
  - Are there new emails in the Mailbox?
  - Has the user visited the Mailbox?

- a4d9169b8 fix <change-folder> when $change_folder_next is set
  Setting the config variable should pick the **next** Mailbox with new email, not the first

- 1c5ded977 fix sidebar colour for 'new' mailboxes
  Only set the **new** colour, if `Mailbox.has_new` is set

Fixes: #1629 
Fixes: #1730 
