### PR TITLE
build: fix autosetup warning

### DIFF
--- a/auto.def
+++ b/auto.def
@@ -3,7 +3,9 @@
 # Make sure we use /usr as a default prefix on Linux; we can't use $host_
 # variables because this needs to go before the inclusion of the system module.
 if {![catch {exec uname} out] && $out eq {Linux}} {
-  define defaultprefix /usr
+  options-defaults {
+    prefix /usr
+  }
 }
 
 autosetup-require-version 0.6.9


### PR DESCRIPTION
* **What does this PR do?**
Fix a `configure` note from autosetup: `Note: defaultprefix is deprecated. Use options-defaults to set default options`. https://travis-ci.org/neomutt/neomutt/builds/593779676#L512

* **What are the relevant issue numbers?**
N/A