### PR TITLE
refactor Email, Body, Envelope

### DIFF
--- a/email/body.h
+++ b/email/body.h
@@ -33,54 +33,62 @@
  */
 struct Body
 {
+  LOFF_T offset;                  ///< offset where the actual data begins
+  LOFF_T length;                  ///< length (in bytes) of attachment
+
+  bool badsig           : 1;      ///< Bad cryptographic signature (needed to check encrypted s/mime-signatures)
+  bool force_charset    : 1;      ///< Send mode: don't adjust the character set when in send-mode.
+  bool goodsig          : 1;      ///< Good cryptographic signature
+#ifdef USE_AUTOCRYPT
+  bool is_autocrypt     : 1;      ///< Flag autocrypt-decrypted messages for replying
+#endif
+  bool noconv           : 1;      ///< Don't do character set conversion
+  bool use_disp         : 1;      ///< Content-Disposition uses filename= ?
+  bool warnsig          : 1;      ///< Maybe good signature
+
+  unsigned int disposition : 2;   ///< content-disposition
+  unsigned int encoding    : 3;   ///< content-transfer-encoding
+  unsigned int type        : 4;   ///< content-type primary type
+
+  // ------------------------------------------------------------
+  // Questionable
+  bool attach_qualifies : 1;      ///< This attachment should be counted
+  bool collapsed        : 1;      ///< Used by recvattach
+  bool deleted          : 1;      ///< Attachment marked for deletion
+  bool tagged           : 1;      ///< This attachment is tagged
+  bool unlink           : 1;      ///< If true, `filename` should be unlink()ed before free()ing this structure
+  short attach_count;             ///< Number of attachments
+  long hdr_offset;                ///< Offset in stream where the headers begin.
+                                  ///< This info is used when invoking metamail, where we need to send the headers of the attachment
+  time_t stamp;                   ///< Time stamp of last encoding update
+
+  // ------------------------------------------------------------
+  // This DATA is cached, but the POINTERS aren't
   char *xtype;                    ///< content-type if x-unknown
   char *subtype;                  ///< content-type subtype
-  char *language;                 ///< content-language (RFC8255)
   struct ParameterList parameter; ///< parameters of the content-type
   char *description;              ///< content-description
   char *form_name;                ///< Content-Disposition form-data name param
-  long hdr_offset;                ///< Offset in stream where the headers begin.
                                   ///< This info is used when invoking metamail, where we need to send the headers of the attachment
-  LOFF_T offset;                  ///< offset where the actual data begins
-  LOFF_T length;                  ///< length (in bytes) of attachment
   char *filename;                 ///< when sending a message, this is the file to which this structure refers
   char *d_filename;               ///< filename to be used for the content-disposition header.
                                   ///< If NULL, filename is used instead.
-  char *charset;                  ///< Send mode: charset of attached file as stored on disk.
-                                  ///< The charset used in the generated message is stored in parameter.
+
+  // ------------------------------------------------------------
+  // Not cached
   struct Content *content;        ///< Detailed info about the content of the attachment.
                                   ///< Used to determine what content-transfer-encoding is required when sending mail.
+  char *charset;                  ///< Send mode: charset of attached file as stored on disk.
+                                  ///< The charset used in the generated message is stored in parameter.
   struct Body *next;              ///< next attachment in the list
   struct Body *parts;             ///< parts of a multipart or message/rfc822
   struct Email *email;            ///< header information for message/rfc822
 
   struct AttachPtr *aptr;         ///< Menu information, used in recvattach.c
 
-  signed short attach_count;      ///< Number of attachments
-
-  time_t stamp;                   ///< Time stamp of last encoding update
-
   struct Envelope *mime_headers;  ///< Memory hole protected headers
+  char *language;                 ///< content-language (RFC8255)
 
-  unsigned int type : 4;          ///< content-type primary type
-  unsigned int encoding : 3;      ///< content-transfer-encoding
-  unsigned int disposition : 2;   ///< content-disposition
-  bool use_disp : 1;              ///< Content-Disposition uses filename= ?
-  bool unlink : 1;                ///< If true, `filename` should be unlink()ed before free()ing this structure
-  bool tagged : 1;                ///< This attachment is tagged
-  bool deleted : 1;               ///< Attachment marked for deletion
-
-  bool noconv : 1;                ///< Don't do character set conversion
-  bool force_charset : 1;         ///< Send mode: don't adjust the character set when in send-mode.
-  bool goodsig : 1;               ///< Good cryptographic signature
-  bool warnsig : 1;               ///< Maybe good signature
-  bool badsig : 1;                ///< Bad cryptographic signature (needed to check encrypted s/mime-signatures)
-#ifdef USE_AUTOCRYPT
-  bool is_autocrypt : 1;          ///< Flag autocrypt-decrypted messages for replying
-#endif
-
-  bool collapsed : 1;             ///< Used by recvattach
-  bool attach_qualifies : 1;      ///< This attachment should be counted
 };
 
 bool         mutt_body_cmp_strict(const struct Body *b1, const struct Body *b2);

--- a/email/email.h
+++ b/email/email.h
@@ -38,70 +38,81 @@ struct Email
 {
   SecurityFlags security;      ///< bit 0-10: flags, bit 11,12: application, bit 13: traditional pgp
                                ///< See: ncrypt/lib.h pgplib.h, smime.h
+  bool active           : 1;   ///< Message is not to be removed
+  bool expired          : 1;   ///< Already expired?
+  bool flagged          : 1;   ///< Marked important?
+  bool mime             : 1;   ///< Has a MIME-Version header?
+  bool old              : 1;   ///< Email is seen, but unread
+  bool read             : 1;   ///< Email is read
+  bool replied          : 1;   ///< Email has been replied to
+  bool superseded       : 1;   ///< Got superseded?
+  bool trash            : 1;   ///< Message is marked as trashed on disk (used by the maildir_trash option)
 
-  bool mime            : 1;    ///< Has a MIME-Version header?
-  bool flagged         : 1;    ///< Marked important?
-  bool tagged          : 1;    ///< Email is tagged
-  bool deleted         : 1;    ///< Email is deleted
-  bool purge           : 1;    ///< Skip trash folder when deleting
-  bool quasi_deleted   : 1;    ///< Deleted from neomutt, but not modified on disk
-  bool changed         : 1;    ///< Email has been edited
-  bool attach_del      : 1;    ///< Has an attachment marked for deletion
-  bool old             : 1;    ///< Email is seen, but unread
-  bool read            : 1;    ///< Email is read
-  bool expired         : 1;    ///< Already expired?
-  bool superseded      : 1;    ///< Got superseded?
-  bool replied         : 1;    ///< Email has been replied to
-  bool subject_changed : 1;    ///< Used for threading
-  bool threaded        : 1;    ///< Used for threading
-  bool display_subject : 1;    ///< Used for threading
-  bool recip_valid     : 1;    ///< Is_recipient is valid
-  bool active          : 1;    ///< Message is not to be removed
-  bool trash           : 1;    ///< Message is marked as trashed on disk (used by the maildir_trash option)
-
-  // timezone of the sender of this message
-  unsigned int zhours   : 5;   ///< Hours away from UTC
-  unsigned int zminutes : 6;   ///< Minutes away from UTC
-  bool zoccident        : 1;   ///< True, if west of UTC, False if east
-
-  bool searched : 1;           ///< Email has been searched
-  bool matched  : 1;           ///< Search matches this Email
-
-  bool attach_valid : 1;       ///< true when the attachment count is valid
-
-  // the following are used to support collapsing threads
-  bool collapsed : 1;          ///< Is this message part of a collapsed thread?
-  bool limited   : 1;          ///< Is this message in a limited view?
-  size_t num_hidden;           ///< Number of hidden messages in this view
-
-  short recipient;             ///< User_is_recipient()'s return value, cached
-
-  int pair;                    ///< Color-pair to use when displaying in the index
+  unsigned int zhours   : 5;   ///< Sender TZ: Hours away from UTC
+  unsigned int zminutes : 6;   ///< Sender TZ: Minutes away from UTC
+  bool zoccident        : 1;   ///< Sender TZ: True, if west of UTC, False if east
 
   time_t date_sent;            ///< Time when the message was sent (UTC)
   time_t received;             ///< Time when the message was placed in the mailbox
-  LOFF_T offset;               ///< Where in the stream does this message begin?
   int lines;                   ///< How many lines in the body of this message?
+
+  // ------------------------------------------------------------
+  // Questionable
+
+  // Only non-zero for 'mbox' which doesn't use the header cache
+  LOFF_T offset;               ///< Where in the stream does this message begin?
+
+  // Saved by Maildir,Pop,Imap but overwritten after reading from cache
   int index;                   ///< The absolute (unsorted) message number
+
+  // Stored as 0 by all backends; always recalculated when opening Mailbox
+  int score;                   ///< Message score
+
+  // Never set when writing to cache
+  bool attach_del      : 1;    ///< Has an attachment marked for deletion
+  bool deleted         : 1;    ///< Email is deleted
+  bool purge           : 1;    ///< Skip trash folder when deleting
+  bool quasi_deleted   : 1;    ///< Deleted from neomutt, but not modified on disk
+
+  // GUI
+  bool display_subject : 1;    ///< Used for threading
+  bool subject_changed : 1;    ///< Used for threading
+
   int msgno;                   ///< Number displayed to the user
   int vnum;                    ///< Virtual message number
-  int score;                   ///< Message score
+
+  // ------------------------------------------------------------
+  // This DATA is cached, but the POINTERS aren't
+
   struct Envelope *env;        ///< Envelope information
   struct Body *content;        ///< List of MIME parts
-  char *path;                  ///< Path of Email (for local Mailboxes)
+  char *maildir_flags;         ///< Unknown maildir flags
 
-  char *tree;                  ///< Character string to print thread tree
-  struct MuttThread *thread;   ///< Thread of Emails
+  // ------------------------------------------------------------
+  // Not cached, mostly View data
+
+  bool attach_valid    : 1;    ///< true when the attachment count is valid
+  bool changed         : 1;    ///< Email has been edited
+  bool collapsed       : 1;    ///< Is this message part of a collapsed thread?
+  bool limited         : 1;    ///< Is this message in a limited view?
+  bool matched         : 1;    ///< Search matches this Email
+  bool recip_valid     : 1;    ///< Is_recipient is valid
+  bool searched        : 1;    ///< Email has been searched
+  bool tagged          : 1;    ///< Email is tagged
+  bool threaded        : 1;    ///< Used for threading
 
   short attach_total;          ///< Number of qualifying attachments in message, if attach_valid
+  size_t num_hidden;           ///< Number of hidden messages in this view
+  short recipient;             ///< User_is_recipient()'s return value, cached
+  int pair;                    ///< Color-pair to use when displaying in the index
+  char *path;                  ///< Path of Email (for local Mailboxes)
+  char *tree;                  ///< Character string to print thread tree
+  struct MuttThread *thread;   ///< Thread of Emails
+  struct TagList tags;         ///< For drivers that support server tagging
 
 #ifdef MIXMASTER
   struct ListHead chain;       ///< Mixmaster chain
 #endif
-
-  struct TagList tags;         ///< For drivers that support server tagging
-
-  char *maildir_flags;         ///< Unknown maildir flags
 
   void *edata;                 ///< Driver-specific data
   void (*free_edata)(void **); ///< Driver-specific data free function

--- a/email/envelope.h
+++ b/email/envelope.h
@@ -61,18 +61,15 @@ struct Envelope
   struct AddressList sender;           ///< Email's sender
   struct AddressList reply_to;         ///< Email's 'reply-to'
   struct AddressList mail_followup_to; ///< Email's 'mail-followup-to'
-  struct AddressList x_original_to;    ///< Email's 'X-Orig-to'
   char *list_post;                     ///< This stores a mailto URL, or nothing
   char *subject;                       ///< Email's subject
   char *real_subj;                     ///< Offset of the real subject
-  char *disp_subj;                     ///< Display subject (modified copy of subject)
   char *message_id;                    ///< Message ID
   char *supersedes;                    ///< Supersedes header
   char *date;                          ///< Sent date
   char *x_label;                       ///< X-Label
   char *organization;                  ///< Organisation header
 #ifdef USE_NNTP
-  char *newsgroups;                    ///< List of newsgroups
   char *xref;                          ///< List of cross-references
   char *followup_to;                   ///< List of 'followup-to' fields
   char *x_comment_to;                  ///< List of 'X-comment-to' fields
@@ -81,6 +78,15 @@ struct Envelope
   struct ListHead references;          ///< message references (in reverse order)
   struct ListHead in_reply_to;         ///< in-reply-to header content
   struct ListHead userhdrs;            ///< user defined headers
+
+  // ------------------------------------------------------------
+  // Not cached
+
+  struct AddressList x_original_to;    ///< Email's 'X-Orig-to'
+  char *disp_subj;                     ///< Display subject (modified copy of subject)
+#ifdef USE_NNTP
+  char *newsgroups;                    ///< List of newsgroups
+#endif
 #ifdef USE_AUTOCRYPT
   struct AutocryptHeader *autocrypt;
   struct AutocryptHeader *autocrypt_gossip;


### PR DESCRIPTION
**Note**: I'm not planning to merge this PR, it's just an RFC.

Move all the header-cached members to the top of the struct.

---

Below the cached members are a few 'questionable' members, which probably shouldn't be cached.
Next come a bunch of pointers,
Then finally all the members that are ignored by the header cache (mostly View data).

The header cache currently stores the entire `struct Email` which is 192 bytes.
By only caching the important data, we can reduce this to 56 bytes (possibly less).

Most of these non-cached members will eventually be moved to a new `struct EmailView`.

---

I'm still working on splitting Data and Views (see [Event-Driven NeoMutt](https://gist.github.com/flatcap/42390bac63c98612818e82ab62152010)).
