### PR TITLE
pop: refactor refno

### DIFF
--- a/email/email.h
+++ b/email/email.h
@@ -99,10 +99,6 @@ struct Email
   struct ListHead chain;       ///< Mixmaster chain
 #endif
 
-#ifdef USE_POP
-  int refno;                   ///< Message number on server
-#endif
-
   struct TagList tags;         ///< For drivers that support server tagging
 
   char *maildir_flags;         ///< Unknown maildir flags

--- a/pop/pop.c
+++ b/pop/pop.c
@@ -273,7 +273,7 @@ static int fetch_uidl(const char *line, void *data)
   int i;
   for (i = 0; i < m->msg_count; i++)
   {
-    struct PopEmailData *edata = m->emails[i]->edata;
+    struct PopEmailData *edata = pop_edata_get(m->emails[i]);
     if (mutt_str_strcmp(line, edata->uid) == 0)
       break;
   }
@@ -321,7 +321,7 @@ static int msg_cache_check(const char *id, struct BodyCache *bcache, void *data)
 
   for (int i = 0; i < m->msg_count; i++)
   {
-    struct PopEmailData *edata = m->emails[i]->edata;
+    struct PopEmailData *edata = pop_edata_get(m->emails[i]);
     /* if the id we get is known for a header: done (i.e. keep in cache) */
     if (edata->uid && (mutt_str_strcmp(edata->uid, id) == 0))
       return 0;
@@ -452,7 +452,7 @@ static int pop_fetch_headers(struct Mailbox *m)
     {
       if (!m->quiet)
         mutt_progress_update(&progress, i + 1 - old_count, -1);
-      struct PopEmailData *edata = m->emails[i]->edata;
+      struct PopEmailData *edata = pop_edata_get(m->emails[i]);
 #ifdef USE_HCACHE
       void *data = mutt_hcache_fetch(hc, edata->uid, strlen(edata->uid));
       if (data)
@@ -965,7 +965,7 @@ static int pop_mbox_sync(struct Mailbox *m, int *index_hint)
 
     for (i = 0, j = 0, rc = 0; (rc == 0) && (i < m->msg_count); i++)
     {
-      struct PopEmailData *edata = m->emails[i]->edata;
+      struct PopEmailData *edata = pop_edata_get(m->emails[i]);
       if (m->emails[i]->deleted && (m->emails[i]->refno != -1))
       {
         j++;
@@ -1059,7 +1059,7 @@ static int pop_msg_open(struct Mailbox *m, struct Message *msg, int msgno)
   struct Progress progress;
   struct PopAccountData *adata = pop_adata_get(m);
   struct Email *e = m->emails[msgno];
-  struct PopEmailData *edata = e->edata;
+  struct PopEmailData *edata = pop_edata_get(e);
   bool bcache = true;
 
   /* see if we already have the message in body cache */

--- a/pop/pop_lib.c
+++ b/pop/pop_lib.c
@@ -575,7 +575,7 @@ static int check_uidl(const char *line, void *data)
     struct PopEmailData *edata = pop_edata_get(m->emails[i]);
     if (mutt_str_strcmp(edata->uid, endp) == 0)
     {
-      m->emails[i]->refno = index;
+      edata->refno = index;
       break;
     }
   }
@@ -607,7 +607,10 @@ int pop_reconnect(struct Mailbox *m)
       mutt_progress_init(&progress, _("Verifying message indexes..."), MUTT_PROGRESS_NET, 0);
 
       for (int i = 0; i < m->msg_count; i++)
-        m->emails[i]->refno = -1;
+      {
+        struct PopEmailData *edata = pop_edata_get(m->emails[i]);
+        edata->refno = -1;
+      }
 
       ret = pop_fetch_data(adata, "UIDL\r\n", &progress, check_uidl, m);
       if (ret == -2)

--- a/pop/pop_lib.c
+++ b/pop/pop_lib.c
@@ -248,6 +248,17 @@ static int pop_capabilities(struct PopAccountData *adata, int mode)
 }
 
 /**
+ * pop_edata_get - Get the private data for this Email
+ * @retval ptr Private Email data
+ */
+struct PopEmailData *pop_edata_get(struct Email *e)
+{
+  if (!e)
+    return NULL;
+  return e->edata;
+}
+
+/**
  * pop_connect - Open connection
  * @param adata POP Account data
  * @retval  0 Successful
@@ -561,7 +572,7 @@ static int check_uidl(const char *line, void *data)
   struct Mailbox *m = data;
   for (int i = 0; i < m->msg_count; i++)
   {
-    struct PopEmailData *edata = m->emails[i]->edata;
+    struct PopEmailData *edata = pop_edata_get(m->emails[i]);
     if (mutt_str_strcmp(edata->uid, endp) == 0)
     {
       m->emails[i]->refno = index;

--- a/pop/pop_private.h
+++ b/pop/pop_private.h
@@ -106,6 +106,7 @@ struct PopAccountData
 struct PopEmailData
 {
   const char *uid;
+  int refno;                   ///< Message number on server
 };
 
 /**

--- a/pop/pop_private.h
+++ b/pop/pop_private.h
@@ -29,6 +29,7 @@
 #include "conn/conn.h"
 #include "mutt/mutt.h"
 
+struct Email;
 struct Mailbox;
 struct Progress;
 
@@ -143,5 +144,6 @@ int pop_fetch_data(struct PopAccountData *adata, const char *query,
 int pop_reconnect(struct Mailbox *m);
 void pop_logout(struct Mailbox *m);
 struct PopAccountData *pop_adata_get(struct Mailbox *m);
+struct PopEmailData *pop_edata_get(struct Email *e);
 
 #endif /* MUTT_POP_POP_PRIVATE_H */


### PR DESCRIPTION
Move `Email->refno` to `PopEmailData->refno`

`Email->refno` was only being used in the POP backend.
The value **was** saved in the Header Cache, but the restored value was never used (see `pop_fetch_headers()`).