### PR TITLE
Eliminate MuttIndexWindow from deep code

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -289,7 +289,7 @@ int mutt_display_message(struct Mailbox *m, struct Email *e)
   if (m->magic == MUTT_NOTMUCH)
     chflags |= CH_VIRTUAL;
 #endif
-  res = mutt_copy_message(fp_out, m, e, cmflags, chflags);
+  res = mutt_copy_message(fp_out, m, e, cmflags, chflags, MuttIndexWindow->cols);
 
   if (((mutt_file_fclose(&fp_out) != 0) && (errno != EPIPE)) || (res < 0))
   {
@@ -540,7 +540,7 @@ static void pipe_msg(struct Mailbox *m, struct Email *e, FILE *fp, bool decode, 
   if (decode)
     mutt_parse_mime_message(m, e);
 
-  mutt_copy_message(fp, m, e, cmflags, chflags);
+  mutt_copy_message(fp, m, e, cmflags, chflags, 0);
 }
 
 /**

--- a/commands.c
+++ b/commands.c
@@ -187,12 +187,13 @@ static void process_protected_headers(struct Email *e)
 
 /**
  * mutt_display_message - Display a message in the pager
- * @param m Mailbox
- * @param e Email to display
+ * @param win Window
+ * @param m   Mailbox
+ * @param e   Email to display
  * @retval  0 Success
  * @retval -1 Error
  */
-int mutt_display_message(struct Mailbox *m, struct Email *e)
+int mutt_display_message(struct MuttWindow *win, struct Mailbox *m, struct Email *e)
 {
   int rc = 0;
   bool builtin = false;
@@ -278,7 +279,7 @@ int mutt_display_message(struct Mailbox *m, struct Email *e)
     hfi.mailbox = m;
     hfi.pager_progress = ExtPagerProgress;
     hfi.email = e;
-    mutt_make_string_info(buf, sizeof(buf), MuttIndexWindow->cols,
+    mutt_make_string_info(buf, sizeof(buf), win->cols,
                           NONULL(C_PagerFormat), &hfi, MUTT_FORMAT_NO_FLAGS);
     fputs(buf, fp_out);
     fputs("\n\n", fp_out);
@@ -289,7 +290,7 @@ int mutt_display_message(struct Mailbox *m, struct Email *e)
   if (m->magic == MUTT_NOTMUCH)
     chflags |= CH_VIRTUAL;
 #endif
-  res = mutt_copy_message(fp_out, m, e, cmflags, chflags, MuttIndexWindow->cols);
+  res = mutt_copy_message(fp_out, m, e, cmflags, chflags, win->cols);
 
   if (((mutt_file_fclose(&fp_out) != 0) && (errno != EPIPE)) || (res < 0))
   {

--- a/commands.h
+++ b/commands.h
@@ -32,6 +32,7 @@ struct Email;
 struct EmailList;
 struct Envelope;
 struct Mailbox;
+struct MuttWindow;
 
 /* These Config Variables are only used in commands.c */
 extern unsigned char C_CryptVerifySig; /* verify PGP signatures */
@@ -47,7 +48,7 @@ void ci_bounce_message(struct Mailbox *m, struct EmailList *el);
 void mutt_check_stats(void);
 bool mutt_check_traditional_pgp(struct EmailList *el, MuttRedrawFlags *redraw);
 void mutt_display_address(struct Envelope *env);
-int  mutt_display_message(struct Mailbox *m, struct Email *e);
+int  mutt_display_message(struct MuttWindow *win, struct Mailbox *m, struct Email *e);
 bool mutt_edit_content_type(struct Email *e, struct Body *b, FILE *fp);
 void mutt_enter_command(void);
 void mutt_pipe_message(struct Mailbox *m, struct EmailList *el);

--- a/compose.c
+++ b/compose.c
@@ -2209,7 +2209,7 @@ int mutt_compose_menu(struct Email *e, char *fcc, size_t fcclen, struct Email *e
 
 #ifdef MIXMASTER
       case OP_COMPOSE_MIX:
-        mix_make_chain(&e->chain);
+        mix_make_chain(menu->indexwin, &e->chain, menu->indexwin->cols);
         mutt_message_hook(NULL, e, MUTT_SEND2_HOOK);
         break;
 #endif

--- a/copy.c
+++ b/copy.c
@@ -609,8 +609,8 @@ int mutt_copy_message_fp(FILE *fp_out, FILE *fp_in, struct Email *e,
     if (C_TextFlowed)
       mutt_str_strfcpy(prefix, ">", sizeof(prefix));
     else
-      mutt_make_string(prefix, sizeof(prefix), NONULL(C_IndentString), Context,
-                       Context->mailbox, e);
+      mutt_make_string(prefix, sizeof(prefix), wraplen, NONULL(C_IndentString),
+                       Context, Context->mailbox, e);
   }
 
   if ((cmflags & MUTT_CM_NOHEADER) == 0)

--- a/copy.h
+++ b/copy.h
@@ -71,12 +71,12 @@ typedef uint32_t CopyHeaderFlags;   ///< Flags for mutt_copy_header(), e.g. #CH_
 #define CH_UPDATE_SUBJECT (1 << 20) ///< Update Subject: protected header update
 #define CH_VIRTUAL        (1 << 21) ///< Write virtual header lines too
 
-int mutt_copy_hdr(FILE *fp_in, FILE *fp_out, LOFF_T off_start, LOFF_T off_end, CopyHeaderFlags chflags, const char *prefix);
+int mutt_copy_hdr(FILE *fp_in, FILE *fp_out, LOFF_T off_start, LOFF_T off_end, CopyHeaderFlags chflags, const char *prefix, int wraplen);
 
-int mutt_copy_header(FILE *fp_in, struct Email *e, FILE *fp_out, CopyHeaderFlags chflags, const char *prefix);
+int mutt_copy_header(FILE *fp_in, struct Email *e, FILE *fp_out, CopyHeaderFlags chflags, const char *prefix, int wraplen);
 
-int mutt_copy_message_fp(FILE *fp_out, FILE *fp_in,       struct Email *e, CopyMessageFlags cmflags, CopyHeaderFlags chflags);
-int mutt_copy_message   (FILE *fp_out, struct Mailbox *m, struct Email *e, CopyMessageFlags cmflags, CopyHeaderFlags chflags);
+int mutt_copy_message_fp(FILE *fp_out, FILE *fp_in,       struct Email *e, CopyMessageFlags cmflags, CopyHeaderFlags chflags, int wraplen);
+int mutt_copy_message   (FILE *fp_out, struct Mailbox *m, struct Email *e, CopyMessageFlags cmflags, CopyHeaderFlags chflags, int wraplen);
 
 int mutt_append_message(struct Mailbox *dest, struct Mailbox *src, struct Email *e, CopyMessageFlags cmflags, CopyHeaderFlags chflags);
 

--- a/edit.c
+++ b/edit.c
@@ -228,7 +228,7 @@ static char **be_include_messages(char *msg, char **buf, int *bufmax,
       if (C_Attribution)
       {
         setlocale(LC_TIME, NONULL(C_AttributionLocale));
-        mutt_make_string(tmp, sizeof(tmp) - 1, C_Attribution, Context,
+        mutt_make_string(tmp, sizeof(tmp) - 1, 0, C_Attribution, Context,
                          Context->mailbox, Context->mailbox->emails[n]);
         setlocale(LC_TIME, "");
         strcat(tmp, "\n");

--- a/editmsg.c
+++ b/editmsg.c
@@ -217,7 +217,7 @@ static int ev_message(enum EvMessage action, struct Mailbox *m, struct Email *e)
     goto bail;
   }
 
-  rc = mutt_copy_hdr(fp, msg->fp, 0, sb.st_size, CH_NOLEN | cf, NULL);
+  rc = mutt_copy_hdr(fp, msg->fp, 0, sb.st_size, CH_NOLEN | cf, NULL, 0);
   if (rc == 0)
   {
     fputc('\n', msg->fp);

--- a/enriched.c
+++ b/enriched.c
@@ -477,10 +477,9 @@ int text_enriched_handler(struct Body *a, struct State *s)
   wchar_t tag[1024 + 1];
 
   stte.s = s;
-  stte.wrap_margin =
-      ((s->flags & MUTT_DISPLAY) ?
-           (MuttIndexWindow->cols - 4) :
-           ((MuttIndexWindow->cols - 4) < 72) ? (MuttIndexWindow->cols - 4) : 72);
+  stte.wrap_margin = ((s->flags & MUTT_DISPLAY) ?
+                          (s->wraplen - 4) :
+                          ((s->wraplen - 4) < 72) ? (s->wraplen - 4) : 72);
   stte.line_max = stte.wrap_margin * 4;
   stte.line = mutt_mem_calloc((stte.line_max + 1), sizeof(wchar_t));
   stte.param = mutt_mem_calloc(256, sizeof(wchar_t));

--- a/handler.c
+++ b/handler.c
@@ -730,7 +730,7 @@ static int message_handler(struct Body *a, struct State *s)
     if (s->flags & MUTT_DISPLAY)
       chflags |= CH_DISPLAY;
 
-    mutt_copy_hdr(s->fp_in, s->fp_out, off_start, b->parts->offset, chflags, s->prefix);
+    mutt_copy_hdr(s->fp_in, s->fp_out, off_start, b->parts->offset, chflags, s->prefix, 0);
 
     if (s->prefix)
       state_puts(s->prefix, s);
@@ -872,7 +872,8 @@ static int external_body_handler(struct Body *b, struct State *s)
       if (C_Weed)
         chflags |= CH_WEED | CH_REORDER;
 
-      mutt_copy_hdr(s->fp_in, s->fp_out, ftello(s->fp_in), b->parts->offset, chflags, NULL);
+      mutt_copy_hdr(s->fp_in, s->fp_out, ftello(s->fp_in), b->parts->offset,
+                    chflags, NULL, 0);
     }
   }
   else if (expiration && (expire < mutt_date_epoch()))
@@ -890,7 +891,8 @@ static int external_body_handler(struct Body *b, struct State *s)
       if (C_Weed)
         chflags |= CH_WEED | CH_REORDER;
 
-      mutt_copy_hdr(s->fp_in, s->fp_out, ftello(s->fp_in), b->parts->offset, chflags, NULL);
+      mutt_copy_hdr(s->fp_in, s->fp_out, ftello(s->fp_in), b->parts->offset,
+                    chflags, NULL, 0);
     }
   }
   else
@@ -910,7 +912,8 @@ static int external_body_handler(struct Body *b, struct State *s)
       if (C_Weed)
         chflags |= CH_WEED | CH_REORDER;
 
-      mutt_copy_hdr(s->fp_in, s->fp_out, ftello(s->fp_in), b->parts->offset, chflags, NULL);
+      mutt_copy_hdr(s->fp_in, s->fp_out, ftello(s->fp_in), b->parts->offset,
+                    chflags, NULL, 0);
     }
   }
 

--- a/hdrline.c
+++ b/hdrline.c
@@ -1488,14 +1488,16 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
  * mutt_make_string_flags - Create formatted strings using mailbox expandos
  * @param buf    Buffer for the result
  * @param buflen Buffer length
+ * @param cols   Number of screen columns (OPTIONAL)
  * @param s      printf-line format string
  * @param ctx    Mailbox Context
  * @param m      Mailbox
  * @param e      Email
  * @param flags  Flags, see #MuttFormatFlags
  */
-void mutt_make_string_flags(char *buf, size_t buflen, const char *s, struct Context *ctx,
-                            struct Mailbox *m, struct Email *e, MuttFormatFlags flags)
+void mutt_make_string_flags(char *buf, size_t buflen, int cols, const char *s,
+                            struct Context *ctx, struct Mailbox *m,
+                            struct Email *e, MuttFormatFlags flags)
 {
   struct HdrFormatInfo hfi;
 
@@ -1504,8 +1506,7 @@ void mutt_make_string_flags(char *buf, size_t buflen, const char *s, struct Cont
   hfi.mailbox = m;
   hfi.pager_progress = 0;
 
-  mutt_expando_format(buf, buflen, 0, MuttIndexWindow->cols, s,
-                      index_format_str, (unsigned long) &hfi, flags);
+  mutt_expando_format(buf, buflen, 0, cols, s, index_format_str, (unsigned long) &hfi, flags);
 }
 
 /**

--- a/hdrline.h
+++ b/hdrline.h
@@ -52,13 +52,13 @@ struct HdrFormatInfo
 
 bool mutt_is_mail_list(const struct Address *addr);
 bool mutt_is_subscribed_list(const struct Address *addr);
-void mutt_make_string_flags(char *buf, size_t buflen, const char *s,
+void mutt_make_string_flags(char *buf, size_t buflen, int cols, const char *s,
                             struct Context *ctx, struct Mailbox *m,
                             struct Email *e, MuttFormatFlags flags);
 void mutt_make_string_info(char *buf, size_t buflen, int cols, const char *s,
                            struct HdrFormatInfo *hfi, MuttFormatFlags flags);
 
-#define mutt_make_string(BUF, BUFLEN, S, CTX, M, E)                            \
-  mutt_make_string_flags(BUF, BUFLEN, S, CTX, M, E, 0)
+#define mutt_make_string(BUF, BUFLEN, COLS, S, CTX, M, E)                      \
+  mutt_make_string_flags(BUF, BUFLEN, COLS, S, CTX, M, E, MUTT_FORMAT_NO_FLAGS)
 
 #endif /* MUTT_HDRLINE_H */

--- a/hook.c
+++ b/hook.c
@@ -644,7 +644,7 @@ static int addr_hook(char *path, size_t pathlen, HookFlags type,
       if ((mutt_pattern_exec(SLIST_FIRST(hook->pattern), 0, m, e, &cache) > 0) ^
           hook->regex.pat_not)
       {
-        mutt_make_string_flags(path, pathlen, hook->command, ctx, m, e, MUTT_FORMAT_PLAIN);
+        mutt_make_string_flags(path, pathlen, 0, hook->command, ctx, m, e, MUTT_FORMAT_PLAIN);
         return 0;
       }
     }

--- a/index.c
+++ b/index.c
@@ -2374,7 +2374,7 @@ int mutt_index_menu(void)
          * set CurrentMenu incorrectly when we return back to the index menu. */
         menu->type = MENU_MAIN;
 
-        op = mutt_display_message(Context->mailbox, CUR_EMAIL);
+        op = mutt_display_message(MuttIndexWindow, Context->mailbox, CUR_EMAIL);
         if (op < 0)
         {
           OptNeedResort = false;

--- a/index.c
+++ b/index.c
@@ -813,8 +813,8 @@ void index_make_entry(char *buf, size_t buflen, struct Menu *menu, int line)
     }
   }
 
-  mutt_make_string_flags(buf, buflen, NONULL(C_IndexFormat), Context,
-                         Context->mailbox, e, flags);
+  mutt_make_string_flags(buf, buflen, menu->indexwin->cols, NONULL(C_IndexFormat),
+                         Context, Context->mailbox, e, flags);
 }
 
 /**

--- a/index.c
+++ b/index.c
@@ -1632,7 +1632,7 @@ int mutt_index_menu(void)
       }
 
       case OP_HELP:
-        mutt_help(MENU_MAIN);
+        mutt_help(MENU_MAIN, MuttIndexWindow->cols);
         menu->redraw = REDRAW_FULL;
         break;
 

--- a/maildir/shared.c
+++ b/maildir/shared.c
@@ -1073,7 +1073,7 @@ int mh_rewrite_message(struct Mailbox *m, int msgno)
   if (!dest)
     return -1;
 
-  int rc = mutt_copy_message(dest->fp, m, e, MUTT_CM_UPDATE, CH_UPDATE | CH_UPDATE_LEN);
+  int rc = mutt_copy_message(dest->fp, m, e, MUTT_CM_UPDATE, CH_UPDATE | CH_UPDATE_LEN, 0);
   if (rc == 0)
   {
     char oldpath[PATH_MAX];

--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -1296,7 +1296,7 @@ static int mbox_mbox_sync(struct Mailbox *m, int *index_hint)
       new_offset[i - first].hdr = ftello(fp) + offset;
 
       if (mutt_copy_message(fp, m, m->emails[i], MUTT_CM_UPDATE,
-                            CH_FROM | CH_UPDATE | CH_UPDATE_LEN) != 0)
+                            CH_FROM | CH_UPDATE | CH_UPDATE_LEN, 0) != 0)
       {
         mutt_perror(tempfile);
         unlink(tempfile);

--- a/menu.c
+++ b/menu.c
@@ -1573,7 +1573,7 @@ int mutt_menu_loop(struct Menu *menu)
         break;
 
       case OP_HELP:
-        mutt_help(menu->type);
+        mutt_help(menu->type, menu->indexwin->cols);
         menu->redraw = REDRAW_FULL;
         break;
 

--- a/mutt_attach.c
+++ b/mutt_attach.c
@@ -831,7 +831,7 @@ int mutt_save_attachment(FILE *fp, struct Body *m, const char *path,
       if ((ctx->mailbox->magic == MUTT_MBOX) || (ctx->mailbox->magic == MUTT_MMDF))
         chflags = CH_FROM | CH_UPDATE_LEN;
       chflags |= ((ctx->mailbox->magic == MUTT_MAILDIR) ? CH_NOSTATUS : CH_UPDATE);
-      if ((mutt_copy_message_fp(msg->fp, fp, e_new, MUTT_CM_NO_FLAGS, chflags) == 0) &&
+      if ((mutt_copy_message_fp(msg->fp, fp, e_new, MUTT_CM_NO_FLAGS, chflags, 0) == 0) &&
           (mx_msg_commit(ctx->mailbox, msg) == 0))
       {
         rc = 0;

--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -1428,10 +1428,10 @@ int smime_class_verify_sender(struct Mailbox *m, struct Email *e)
   if (e->security & SEC_ENCRYPT)
   {
     mutt_copy_message(fp_out, m, e, MUTT_CM_DECODE_CRYPT & MUTT_CM_DECODE_SMIME,
-                      CH_MIME | CH_WEED | CH_NONEWLINE);
+                      CH_MIME | CH_WEED | CH_NONEWLINE, 0);
   }
   else
-    mutt_copy_message(fp_out, m, e, MUTT_CM_NO_FLAGS, CH_NO_FLAGS);
+    mutt_copy_message(fp_out, m, e, MUTT_CM_NO_FLAGS, CH_NO_FLAGS, 0);
 
   fflush(fp_out);
   mutt_file_fclose(&fp_out);

--- a/pager.c
+++ b/pager.c
@@ -2833,7 +2833,7 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         if (!InHelp)
         {
           InHelp = true;
-          mutt_help(MENU_PAGER);
+          mutt_help(MENU_PAGER, MuttIndexWindow->cols);
           pager_menu->redraw = REDRAW_FULL;
           InHelp = false;
         }

--- a/pattern.c
+++ b/pattern.c
@@ -1122,7 +1122,7 @@ static bool msg_search(struct Mailbox *m, struct Pattern *pat, int msgno)
 #endif
 
     if (pat->op != MUTT_PAT_BODY)
-      mutt_copy_header(msg->fp, e, s.fp_out, CH_FROM | CH_DECODE, NULL);
+      mutt_copy_header(msg->fp, e, s.fp_out, CH_FROM | CH_DECODE, NULL, 0);
 
     if (pat->op != MUTT_PAT_HEADER)
     {

--- a/postpone.c
+++ b/postpone.c
@@ -49,6 +49,7 @@
 #include "mutt_logging.h"
 #include "mutt_menu.h"
 #include "mutt_thread.h"
+#include "mutt_window.h"
 #include "muttlib.h"
 #include "mx.h"
 #include "ncrypt/ncrypt.h"
@@ -205,7 +206,8 @@ static void post_make_entry(char *buf, size_t buflen, struct Menu *menu, int lin
 {
   struct Context *ctx = menu->data;
 
-  mutt_make_string_flags(buf, buflen, NONULL(C_IndexFormat), ctx, ctx->mailbox,
+  mutt_make_string_flags(buf, buflen, menu->indexwin->cols,
+                         NONULL(C_IndexFormat), ctx, ctx->mailbox,
                          ctx->mailbox->emails[line], MUTT_FORMAT_ARROWCURSOR);
 }
 

--- a/protos.h
+++ b/protos.h
@@ -63,7 +63,7 @@ int mutt_ev_message(struct Mailbox *m, struct EmailList *el, enum EvMessage acti
 int mutt_system(const char *cmd);
 
 int mutt_set_xdg_path(enum XdgType type, char *buf, size_t bufsize);
-void mutt_help(enum MenuType menu);
+void mutt_help(enum MenuType menu, int wraplan);
 void mutt_make_help(char *d, size_t dlen, const char *txt, enum MenuType menu, int op);
 void mutt_set_flag_update(struct Mailbox *m, struct Email *e, int flag, bool bf, bool upd_mbox);
 #define mutt_set_flag(m, e, flag, bf) mutt_set_flag_update(m, e, flag, bf, true)

--- a/recvattach.c
+++ b/recvattach.c
@@ -258,8 +258,8 @@ const char *attach_format_str(char *buf, size_t buflen, size_t col, int cols,
             C_MessageFormat && aptr->content->email)
         {
           char s[128];
-          mutt_make_string_flags(s, sizeof(s), C_MessageFormat, NULL, NULL,
-                                 aptr->content->email,
+          mutt_make_string_flags(s, sizeof(s), cols, C_MessageFormat, NULL,
+                                 NULL, aptr->content->email,
                                  MUTT_FORMAT_FORCESUBJ | MUTT_FORMAT_ARROWCURSOR);
           if (*s)
           {

--- a/recvcmd.c
+++ b/recvcmd.c
@@ -419,7 +419,7 @@ static void include_header(bool quote, FILE *fp_in, struct Email *e, FILE *fp_ou
     chflags |= CH_PREFIX;
   }
 
-  mutt_copy_header(fp_in, e, fp_out, chflags, quote ? prefix2 : NULL);
+  mutt_copy_header(fp_in, e, fp_out, chflags, quote ? prefix2 : NULL, 0);
 }
 
 /**
@@ -694,7 +694,7 @@ static void attach_forward_msgs(FILE *fp, struct AttachCtx *actx,
     if (cur)
     {
       mutt_forward_intro(Context->mailbox, cur->email, fp_tmp);
-      mutt_copy_message_fp(fp_tmp, fp, cur->email, cmflags, chflags);
+      mutt_copy_message_fp(fp_tmp, fp, cur->email, cmflags, chflags, 0);
       mutt_forward_trailer(Context->mailbox, cur->email, fp_tmp);
     }
     else
@@ -705,7 +705,7 @@ static void attach_forward_msgs(FILE *fp, struct AttachCtx *actx,
         {
           mutt_forward_intro(Context->mailbox, actx->idx[i]->content->email, fp_tmp);
           mutt_copy_message_fp(fp_tmp, actx->idx[i]->fp,
-                               actx->idx[i]->content->email, cmflags, chflags);
+                               actx->idx[i]->content->email, cmflags, chflags, 0);
           mutt_forward_trailer(Context->mailbox, actx->idx[i]->content->email, fp_tmp);
         }
       }
@@ -882,7 +882,7 @@ static void attach_include_reply(FILE *fp, FILE *fp_tmp, struct Email *e)
     cmflags |= MUTT_CM_WEED;
   }
 
-  mutt_copy_message_fp(fp_tmp, fp, e, cmflags, chflags);
+  mutt_copy_message_fp(fp_tmp, fp, e, cmflags, chflags, 0);
   mutt_make_post_indent(Context->mailbox, e, fp_tmp);
 }
 

--- a/recvcmd.c
+++ b/recvcmd.c
@@ -410,7 +410,7 @@ static void include_header(bool quote, FILE *fp_in, struct Email *e, FILE *fp_ou
       mutt_str_strfcpy(prefix2, prefix, sizeof(prefix2));
     else if (!C_TextFlowed)
     {
-      mutt_make_string(prefix2, sizeof(prefix2), NONULL(C_IndentString),
+      mutt_make_string(prefix2, sizeof(prefix2), 0, NONULL(C_IndentString),
                        Context, Context->mailbox, e);
     }
     else
@@ -505,8 +505,8 @@ static void attach_forward_bodies(FILE *fp, struct Email *e, struct AttachCtx *a
       mutt_str_strfcpy(prefix, ">", sizeof(prefix));
     else
     {
-      mutt_make_string(prefix, sizeof(prefix), NONULL(C_IndentString), Context,
-                       Context->mailbox, e_parent);
+      mutt_make_string(prefix, sizeof(prefix), 0, NONULL(C_IndentString),
+                       Context, Context->mailbox, e_parent);
     }
   }
 
@@ -988,8 +988,8 @@ void mutt_attach_reply(FILE *fp, struct Email *e, struct AttachCtx *actx,
 
     if (!C_TextFlowed)
     {
-      mutt_make_string(prefix, sizeof(prefix), NONULL(C_IndentString), Context,
-                       Context->mailbox, e_parent);
+      mutt_make_string(prefix, sizeof(prefix), 0, NONULL(C_IndentString),
+                       Context, Context->mailbox, e_parent);
     }
     else
       mutt_str_strfcpy(prefix, ">", sizeof(prefix));

--- a/remailer.h
+++ b/remailer.h
@@ -26,8 +26,9 @@
 #include <stddef.h>
 #include <stdint.h>
 
-struct ListHead;
 struct Email;
+struct ListHead;
+struct MuttWindow;
 
 /* These Config Variables are only used in remailer.c */
 extern char *C_MixEntryFormat;
@@ -66,6 +67,6 @@ struct MixChain
 
 int mix_send_message(struct ListHead *chain, const char *tempfile);
 int mix_check_message(struct Email *e);
-void mix_make_chain(struct ListHead *chainhead);
+void mix_make_chain(struct MuttWindow *win, struct ListHead *chainhead, int cols);
 
 #endif /* MUTT_REMAILER_H */

--- a/rfc3676.c
+++ b/rfc3676.c
@@ -191,7 +191,8 @@ static void flush_par(struct State *s, struct FlowedState *fst)
  */
 static int quote_width(struct State *s, int ql)
 {
-  int width = mutt_window_wrap_cols(MuttIndexWindow->cols, C_ReflowWrap);
+  const int screen_width = (s->flags & MUTT_DISPLAY) ? s->wraplen : 80;
+  int width = mutt_window_wrap_cols(screen_width, C_ReflowWrap);
   if (C_TextFlowed && (s->flags & MUTT_REPLYING))
   {
     /* When replying, force a wrap at FLOWED_MAX to comply with RFC3676

--- a/send.c
+++ b/send.c
@@ -435,7 +435,7 @@ void mutt_forward_intro(struct Mailbox *m, struct Email *e, FILE *fp)
 
   char buf[1024];
   setlocale(LC_TIME, NONULL(C_AttributionLocale));
-  mutt_make_string(buf, sizeof(buf), C_ForwardAttributionIntro, NULL, m, e);
+  mutt_make_string(buf, sizeof(buf), 0, C_ForwardAttributionIntro, NULL, m, e);
   setlocale(LC_TIME, "");
   fputs(buf, fp);
   fputs("\n\n", fp);
@@ -454,7 +454,7 @@ void mutt_forward_trailer(struct Mailbox *m, struct Email *e, FILE *fp)
 
   char buf[1024];
   setlocale(LC_TIME, NONULL(C_AttributionLocale));
-  mutt_make_string(buf, sizeof(buf), C_ForwardAttributionTrailer, NULL, m, e);
+  mutt_make_string(buf, sizeof(buf), 0, C_ForwardAttributionTrailer, NULL, m, e);
   setlocale(LC_TIME, "");
   fputc('\n', fp);
   fputs(buf, fp);
@@ -640,7 +640,7 @@ void mutt_make_attribution(struct Mailbox *m, struct Email *e, FILE *fp_out)
 
   char buf[1024];
   setlocale(LC_TIME, NONULL(C_AttributionLocale));
-  mutt_make_string(buf, sizeof(buf), C_Attribution, NULL, m, e);
+  mutt_make_string(buf, sizeof(buf), 0, C_Attribution, NULL, m, e);
   setlocale(LC_TIME, "");
   fputs(buf, fp_out);
   fputc('\n', fp_out);
@@ -658,7 +658,7 @@ void mutt_make_post_indent(struct Mailbox *m, struct Email *e, FILE *fp_out)
     return;
 
   char buf[256];
-  mutt_make_string(buf, sizeof(buf), C_PostIndentString, NULL, m, e);
+  mutt_make_string(buf, sizeof(buf), 0, C_PostIndentString, NULL, m, e);
   fputs(buf, fp_out);
   fputc('\n', fp_out);
 }
@@ -927,7 +927,7 @@ void mutt_make_forward_subject(struct Envelope *env, struct Mailbox *m, struct E
   char buf[256];
 
   /* set the default subject for the message. */
-  mutt_make_string(buf, sizeof(buf), NONULL(C_ForwardFormat), NULL, m, e);
+  mutt_make_string(buf, sizeof(buf), 0, NONULL(C_ForwardFormat), NULL, m, e);
   mutt_str_replace(&env->subject, buf);
 }
 

--- a/send.c
+++ b/send.c
@@ -498,11 +498,7 @@ static int include_forward(struct Mailbox *m, struct Email *e, FILE *fp_out)
   if (C_ForwardQuote)
     cmflags |= MUTT_CM_PREFIX;
 
-  /* wrapping headers for forwarding is considered a display
-   * rather than send action */
-  chflags |= CH_DISPLAY;
-
-  mutt_copy_message(fp_out, m, e, cmflags, chflags);
+  mutt_copy_message(fp_out, m, e, cmflags, chflags, 0);
   mutt_forward_trailer(m, e, fp_out);
   return 0;
 }
@@ -701,7 +697,7 @@ static int include_reply(struct Mailbox *m, struct Email *e, FILE *fp_out)
     cmflags |= MUTT_CM_WEED;
   }
 
-  mutt_copy_message(fp_out, m, e, cmflags, chflags);
+  mutt_copy_message(fp_out, m, e, cmflags, chflags, 0);
 
   mutt_make_post_indent(m, e, fp_out);
 

--- a/sendlib.c
+++ b/sendlib.c
@@ -1318,7 +1318,7 @@ void mutt_message_to_7bit(struct Body *a, FILE *fp)
   transform_to_7bit(a->parts, fp_in);
 
   mutt_copy_hdr(fp_in, fp_out, a->offset, a->offset + a->length,
-                CH_MIME | CH_NONEWLINE | CH_XMIT, NULL);
+                CH_MIME | CH_NONEWLINE | CH_XMIT, NULL, 0);
 
   fputs("MIME-Version: 1.0\n", fp_out);
   mutt_write_mime_header(a->parts, fp_out);
@@ -1551,7 +1551,7 @@ struct Body *mutt_make_message_attach(struct Mailbox *m, struct Email *e, bool a
     }
   }
 
-  mutt_copy_message(fp, m, e, cmflags, chflags);
+  mutt_copy_message(fp, m, e, cmflags, chflags, 0);
 
   fflush(fp);
   rewind(fp);
@@ -2148,8 +2148,8 @@ int mutt_write_one_header(FILE *fp, const char *tag, const char *value,
     else
       wraplen = C_WrapHeaders;
   }
-  else if ((wraplen <= 0) || (wraplen > MuttIndexWindow->cols))
-    wraplen = MuttIndexWindow->cols;
+  else if (wraplen <= 0)
+    wraplen = 78;
 
   if (tag)
   {
@@ -3082,7 +3082,7 @@ static int bounce_message(FILE *fp, struct Email *e, struct AddressList *to,
     FREE(&msgid_str);
     fputs("Resent-To: ", fp_tmp);
     mutt_write_addrlist(to, fp_tmp, 11, 0);
-    mutt_copy_header(fp, e, fp_tmp, chflags, NULL);
+    mutt_copy_header(fp, e, fp_tmp, chflags, NULL, 0);
     fputc('\n', fp_tmp);
     mutt_file_copy_bytes(fp, fp_tmp, e->content->length);
     if (mutt_file_fclose(&fp_tmp) != 0)

--- a/state.h
+++ b/state.h
@@ -43,10 +43,11 @@ typedef uint8_t StateFlags;          ///< Flags for State->flags, e.g. #MUTT_DIS
  */
 struct State
 {
-  FILE      *fp_in;  ///< File to read from
-  FILE      *fp_out; ///< File to write to
-  char      *prefix; ///< String to add to the beginning of each output line
-  StateFlags flags;  ///< Flags, e.g. #MUTT_DISPLAY
+  FILE      *fp_in;   ///< File to read from
+  FILE      *fp_out;  ///< File to write to
+  char      *prefix;  ///< String to add to the beginning of each output line
+  StateFlags flags;   ///< Flags, e.g. #MUTT_DISPLAY
+  int        wraplen; ///< Width to wrap lines to (when flags & #MUTT_DISPLAY)
 };
 
 #define state_set_prefix(state) ((state)->flags |= MUTT_PENDINGPREFIX)


### PR DESCRIPTION
## The Problem

Many deep functions in the email-copying code, are using the global variable
MuttIndexWindow in order to perform text-wrapping.

There are a couple of problems with this.  First, text wants to be wrapped to
the **Pager** window, not the Index window.  Currently they're the same width,
but that might not always be the case.  Second, it's a global variable.  It only
makes sense if everyone is using it.

[This scary diagram](https://flatcap.org/mutt/index1.svg) shows a nearly complete call tree for the message copying.
The red nodes show places where MuttIndexWindow is used.

Soon, each panel will control its own window and the global variable will be
eliminated.  Any code needing the dimensions of the window will have to be
passed the information.

This PR solves the immediate problem by passing the width as a parameter to the
functions that need it.  The commit logs give more detail.

## The Deeper Problem

The deeper problem is in the design of the message copying.  It performs several
different tasks: decoding, decrypting, wrapping text and it needs global and
config variables to control its behaviour.  As the functions work, they
serialise their results to a file.

This serialisation means that all the work has to happen in one pass, hence the
need for all the globals.  The contents of the file are used as they are.  For
some callers this is an entire raw email, for others, it's a heavily processed
message for display on screen.

A better solution for this would be to split the tasks into, say:

- Copy message (just the metadata)
- Weed headers
- Fix header order
- Verify message
- Decrypt message
- Extract attachments
- Wrap message
- Serialise message

The caller decides which functions are called and it passes all the
configuration the function will need.  Functions that deal with attachments may
still need to write files.  When all the work has been performed, the final
stage would be to serialise the data to a file, e.g. to a maildir (copy message),
or for the pager (display message).

## The Solution (Part 1)

This PR solves the immediate problem of the global MuttIndexWindow.

Some functions can be fixed by passing an extra parameter.
The rest use a new member added to `struct State`.

This diagram shows the call tree for `mutt_copy_message()` (click to zoom)

![mutt_copy_message](https://flatcap.org/mutt/index4.svg)

- Red dots are functions that used `MuttIndexWindow`
- Red nodes have access to `MuttIndexWindow`
- Blue nodes have an extra parameter
- Yellow nodes use `struct State`
- Dashed lines are **conditional** on the flag(s) mentioned