### PR TITLE
fix: abort entire-thread if database lacks message

### DIFF
--- a/index.c
+++ b/index.c
@@ -1999,7 +1999,21 @@ int mutt_index_menu(void)
             break;
           }
           else
+          {
             main_change_folder(menu, op, NULL, buf, sizeof(buf), &oldcount, &index_hint);
+
+            // If notmuch doesn't contain the message, we're left in an empty
+            // vfolder. No messages are found, but nm_read_entire_thread assumes
+            // a valid message-id and will throw a segfault.
+            //
+            // To prevent that, stay in the empty vfolder and print an error.
+            if (Context->mailbox->msg_count == 0)
+            {
+              mutt_error(_("failed to find message in notmuch database. try "
+                           "running 'notmuch new'."));
+              break;
+            }
+          }
         }
         oldcount = Context->mailbox->msg_count;
         struct Email *e_oldcur = CUR_EMAIL;


### PR DESCRIPTION
If the notmuch database is missing a message, abort \<entire-thread\>
before causing a segfault. When \<entire-thread\> executes on a message
missing from the database, it segfaults. This happens because the
vfolder returned is empty and not in an properly initialized state for
the notmuch-backend. As such, the notmuch-backend segfaults.

To prevent a segfault, display a warning and pre-maturely exit
\<entire-thread\>. While the user is left in an empty vfolder, this is
consistent behavior for \<entire-thread\>. Ordinarily, you're left with
just the notmuch thread, which doesn't exist in this case.

The location of the abort is perfect for adding behavior to handle the
missing message. In the future, we can automatically run 'notmuch new'
after encountering a missing message. That is outside the scope of this
commit.

Fixes the crash from #1861. @scottkosty and I talked about adding a 
hook, but my primary concern is fixing the crash.
