### PR TITLE
fix: reset charset

### DIFF
--- a/init.c
+++ b/init.c
@@ -3047,6 +3047,7 @@ int mutt_init(bool skip_sys_rc, struct ListHead *commands)
   }
 
   C_Charset = mutt_ch_get_langinfo_charset();
+  cs_str_initial_set(Config, "charset", C_Charset, NULL);
   mutt_ch_set_charset(C_Charset);
 
   Matches = mutt_mem_calloc(MatchesListsize, sizeof(char *));


### PR DESCRIPTION
Set the "initial" value for "charset" from the user's locale.

"reset charset" left C_Charset empty leading to problems reading strings from the user.
Now, `reset` restores the original value.

Fixes: #1884 

---

The actual cause came after the field had been read.
NeoMutt attempts to check if it's an international email address, but as `C_Charset` is `NULL`, `mutt_idna_local_to_intl()` fails.
The failure causes an error message, which is immediately obscured by the address prompt.

- `ci_send_message()`
- `edit_envelope()`
- `mutt_edit_address()`
- `mutt_addrlist_to_intl()`
- `mutt_idna_local_to_intl()`
