### PR TITLE
Buffer refactoring

### DIFF
--- a/bcache.c
+++ b/bcache.c
@@ -88,7 +88,7 @@ static int bcache_path(struct ConnAccount *account, const char *mailbox, struct 
     mutt_buffer_addch(dst, '/');
 
   mutt_debug(LL_DEBUG3, "path: '%s'\n", mutt_b2s(dst));
-  bcache->path = mutt_str_strdup(mutt_b2s(dst));
+  bcache->path = mutt_buffer_strdup(dst);
 
   mutt_buffer_pool_release(&path);
   mutt_buffer_pool_release(&dst);

--- a/browser.c
+++ b/browser.c
@@ -1545,7 +1545,7 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
               {
                 mutt_buffer_concat_path(tmp, mutt_b2s(&LastDir), ff.name);
                 mutt_buffer_expand_path(tmp);
-                tfiles[j++] = mutt_str_strdup(mutt_b2s(tmp));
+                tfiles[j++] = mutt_buffer_strdup(tmp);
               }
             }
             *files = tfiles;
@@ -1555,7 +1555,7 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
             *numfiles = 1;
             tfiles = mutt_mem_calloc(*numfiles, sizeof(char *));
             mutt_buffer_expand_path(file);
-            tfiles[0] = mutt_str_strdup(mutt_b2s(file));
+            tfiles[0] = mutt_buffer_strdup(file);
             *files = tfiles;
           }
         }

--- a/browser.c
+++ b/browser.c
@@ -1038,7 +1038,7 @@ static void init_menu(struct BrowserState *state, struct Menu *menu,
     {
       struct Buffer *path = mutt_buffer_pool_get();
       menu->is_mailbox_list = false;
-      mutt_buffer_strcpy(path, mutt_b2s(&LastDir));
+      mutt_buffer_copy(path, &LastDir);
       mutt_buffer_pretty_mailbox(path);
 #ifdef USE_IMAP
       if (state->imap_browse && C_ImapListSubscribed)
@@ -1191,7 +1191,7 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
     }
     else
     {
-      mutt_buffer_strcpy(prefix, mutt_b2s(file));
+      mutt_buffer_copy(prefix, file);
     }
   }
   else
@@ -1236,7 +1236,7 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
       }
 
       if ((i <= 0) && (mutt_b2s(file)[0] != '/'))
-        mutt_buffer_strcpy(prefix, mutt_b2s(file));
+        mutt_buffer_copy(prefix, file);
       else
         mutt_buffer_strcpy(prefix, mutt_b2s(file) + i + 1);
       kill_prefix = true;
@@ -1415,7 +1415,7 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
           )
           {
             /* save the old directory */
-            mutt_buffer_strcpy(OldLastDir, mutt_b2s(&LastDir));
+            mutt_buffer_copy(OldLastDir, &LastDir);
 
             if (mutt_str_strcmp(state.entry[menu->current].name, "..") == 0)
             {
@@ -1469,7 +1469,7 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
             {
               mutt_buffer_concat_path(tmp, mutt_b2s(&LastDir),
                                       state.entry[menu->current].name);
-              mutt_buffer_strcpy(&LastDir, mutt_b2s(tmp));
+              mutt_buffer_copy(&LastDir, tmp);
             }
 
             destroy_state(&state);
@@ -1494,7 +1494,7 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
               if (examine_directory(menu, &state, mutt_b2s(&LastDir), mutt_b2s(prefix)) == -1)
               {
                 /* try to restore the old values */
-                mutt_buffer_strcpy(&LastDir, mutt_b2s(OldLastDir));
+                mutt_buffer_copy(&LastDir, OldLastDir);
                 if (examine_directory(menu, &state, mutt_b2s(&LastDir),
                                       mutt_b2s(prefix)) == -1)
                 {
@@ -1674,7 +1674,7 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
           break;
 #endif
 
-        mutt_buffer_strcpy(buf, mutt_b2s(&LastDir));
+        mutt_buffer_copy(buf, &LastDir);
 #ifdef USE_IMAP
         if (!state.imap_browse)
 #endif
@@ -1702,7 +1702,7 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
 #ifdef USE_IMAP
           if (imap_path_probe(mutt_b2s(buf), NULL) == MUTT_IMAP)
           {
-            mutt_buffer_strcpy(&LastDir, mutt_b2s(buf));
+            mutt_buffer_copy(&LastDir, buf);
             destroy_state(&state);
             init_state(&state, NULL);
             state.imap_browse = true;
@@ -1720,7 +1720,7 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
               /* in case dir is relative, make it relative to LastDir,
                * not current working dir */
               mutt_buffer_concat_path(tmp, mutt_b2s(&LastDir), mutt_b2s(buf));
-              mutt_buffer_strcpy(buf, mutt_b2s(tmp));
+              mutt_buffer_copy(buf, tmp);
             }
             /* Resolve path from <chdir>
              * Avoids buildup such as /a/b/../../c
@@ -1735,7 +1735,7 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
               {
                 destroy_state(&state);
                 if (examine_directory(menu, &state, mutt_b2s(buf), mutt_b2s(prefix)) == 0)
-                  mutt_buffer_strcpy(&LastDir, mutt_b2s(buf));
+                  mutt_buffer_copy(&LastDir, buf);
                 else
                 {
                   mutt_error(_("Error scanning directory"));
@@ -1897,13 +1897,13 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
               {
                 /* Stores into goto_swapper LastDir, and swaps to C_Folder */
                 mutt_str_strfcpy(goto_swapper, mutt_b2s(&LastDir), sizeof(goto_swapper));
-                mutt_buffer_strcpy(&LastDirBackup, mutt_b2s(&LastDir));
+                mutt_buffer_copy(&LastDirBackup, &LastDir);
                 mutt_buffer_strcpy(&LastDir, C_Folder);
               }
             }
             else
             {
-              mutt_buffer_strcpy(&LastDirBackup, mutt_b2s(&LastDir));
+              mutt_buffer_copy(&LastDirBackup, &LastDir);
               mutt_buffer_strcpy(&LastDir, goto_swapper);
               goto_swapper[0] = '\0';
             }
@@ -1941,7 +1941,7 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
         /* buf comes from the buffer pool, so defaults to size 1024 */
         if (mutt_buffer_get_field(_("New file name: "), buf, MUTT_FILE) == 0)
         {
-          mutt_buffer_strcpy(file, mutt_b2s(buf));
+          mutt_buffer_copy(file, buf);
           destroy_state(&state);
           goto bail;
         }

--- a/complete.c
+++ b/complete.c
@@ -119,7 +119,7 @@ int mutt_complete(char *buf, size_t buflen)
     {
       mutt_buffer_concatn_path(tmp, mutt_b2s(exp_dirpart), mutt_buffer_len(exp_dirpart),
                                buf + 1, (size_t)(p - buf - 1));
-      mutt_buffer_strcpy(exp_dirpart, mutt_b2s(tmp));
+      mutt_buffer_copy(exp_dirpart, tmp);
       mutt_buffer_substrcpy(dirpart, buf, p + 1);
       mutt_buffer_strcpy(filepart, p + 1);
     }
@@ -143,7 +143,7 @@ int mutt_complete(char *buf, size_t buflen)
       {
         mutt_buffer_substrcpy(dirpart, buf, p);
         mutt_buffer_strcpy(filepart, p + 1);
-        mutt_buffer_strcpy(exp_dirpart, mutt_b2s(dirpart));
+        mutt_buffer_copy(exp_dirpart, dirpart);
         mutt_buffer_expand_path(exp_dirpart);
         dirp = opendir(mutt_b2s(exp_dirpart));
       }
@@ -209,7 +209,7 @@ int mutt_complete(char *buf, size_t buflen)
         }
         else
         {
-          mutt_buffer_strcpy(tmp, mutt_b2s(exp_dirpart));
+          mutt_buffer_copy(tmp, exp_dirpart);
           mutt_buffer_addch(tmp, '/');
         }
         mutt_buffer_addstr(tmp, mutt_b2s(filepart));

--- a/compose.c
+++ b/compose.c
@@ -1256,10 +1256,10 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur, 
         break;
 
       case OP_COMPOSE_EDIT_FCC:
-        mutt_buffer_strcpy(&fname, mutt_b2s(fcc));
+        mutt_buffer_copy(&fname, fcc);
         if (mutt_buffer_get_field(_("Fcc: "), &fname, MUTT_FILE | MUTT_CLEAR) == 0)
         {
-          mutt_buffer_strcpy(fcc, mutt_b2s(&fname));
+          mutt_buffer_copy(fcc, &fname);
           mutt_buffer_pretty_mailbox(fcc);
           mutt_window_move(menu->indexwin, HDR_FCC, HDR_XOFFSET);
           mutt_paddstr(W, mutt_b2s(fcc));

--- a/compress.c
+++ b/compress.c
@@ -140,7 +140,7 @@ static int setup_paths(struct Mailbox *m)
   /* We will uncompress to /tmp */
   struct Buffer *buf = mutt_buffer_pool_get();
   mutt_buffer_mktemp(buf);
-  mutt_buffer_strcpy(&m->pathbuf, mutt_b2s(buf));
+  mutt_buffer_copy(&m->pathbuf, buf);
   mutt_buffer_pool_release(&buf);
 
   FILE *fp = mutt_file_fopen(mailbox_path(m), "w");

--- a/email/parse.c
+++ b/email/parse.c
@@ -199,7 +199,7 @@ static void parse_parameters(struct ParameterList *pl, const char *s, bool allow
       /* if the attribute token was missing, 'new' will be NULL */
       if (pnew)
       {
-        pnew->value = mutt_str_strdup(mutt_b2s(buf));
+        pnew->value = mutt_buffer_strdup(buf);
 
         mutt_debug(LL_DEBUG2, "parse_parameter: '%s' = '%s'\n",
                    pnew->attribute ? pnew->attribute : "", pnew->value ? pnew->value : "");

--- a/email/rfc2231.c
+++ b/email/rfc2231.c
@@ -463,8 +463,8 @@ struct ParameterList rfc2231_encode_string(const char *attribute, char *value)
       cur++;
     }
 
-    current->attribute = mutt_str_strdup(mutt_b2s(cur_attribute));
-    current->value = mutt_str_strdup(mutt_b2s(cur_value));
+    current->attribute = mutt_buffer_strdup(cur_attribute);
+    current->value = mutt_buffer_strdup(cur_value);
 
     mutt_buffer_reset(cur_value);
     cur_value_len = 0;

--- a/hook.c
+++ b/hook.c
@@ -144,7 +144,7 @@ enum CommandResult mutt_parse_hook(struct Buffer *buf, struct Buffer *s,
     }
 
     struct Buffer *tmp = mutt_buffer_pool_get();
-    mutt_buffer_strcpy(tmp, mutt_b2s(pattern));
+    mutt_buffer_copy(tmp, pattern);
     mutt_buffer_expand_path_regex(tmp, true);
 
     /* Check for other mailbox shortcuts that expand to the empty string.
@@ -156,7 +156,7 @@ enum CommandResult mutt_parse_hook(struct Buffer *buf, struct Buffer *s,
       goto cleanup;
     }
 
-    mutt_buffer_strcpy(pattern, mutt_b2s(tmp));
+    mutt_buffer_copy(pattern, tmp);
     mutt_buffer_pool_release(&tmp);
   }
 #ifdef USE_COMPRESSED

--- a/hook.c
+++ b/hook.c
@@ -220,7 +220,7 @@ enum CommandResult mutt_parse_hook(struct Buffer *buf, struct Buffer *s,
          * a common action to perform is to change the default (.) entry
          * based upon some other information. */
         FREE(&hook->command);
-        hook->command = mutt_str_strdup(mutt_b2s(cmd));
+        hook->command = mutt_buffer_strdup(cmd);
         rc = MUTT_CMD_SUCCESS;
         goto cleanup;
       }
@@ -262,9 +262,9 @@ enum CommandResult mutt_parse_hook(struct Buffer *buf, struct Buffer *s,
 
   hook = mutt_mem_calloc(1, sizeof(struct Hook));
   hook->type = data;
-  hook->command = mutt_str_strdup(mutt_b2s(cmd));
+  hook->command = mutt_buffer_strdup(cmd);
   hook->pattern = pat;
-  hook->regex.pattern = mutt_str_strdup(mutt_b2s(pattern));
+  hook->regex.pattern = mutt_buffer_strdup(pattern);
   hook->regex.regex = rx;
   hook->regex.pat_not = pat_not;
   TAILQ_INSERT_TAIL(&Hooks, hook, entries);
@@ -421,9 +421,9 @@ enum CommandResult mutt_parse_idxfmt_hook(struct Buffer *buf, struct Buffer *s,
 
   hook = mutt_mem_calloc(1, sizeof(struct Hook));
   hook->type = data;
-  hook->command = mutt_str_strdup(mutt_b2s(fmtstring));
+  hook->command = mutt_buffer_strdup(fmtstring);
   hook->pattern = pat;
-  hook->regex.pattern = mutt_str_strdup(mutt_b2s(pattern));
+  hook->regex.pattern = mutt_buffer_strdup(pattern);
   hook->regex.regex = NULL;
   hook->regex.pat_not = pat_not;
 

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -2260,7 +2260,7 @@ static int imap_msg_open_new(struct Mailbox *m, struct Message *msg, struct Emai
     goto cleanup;
   }
 
-  msg->path = mutt_str_strdup(mutt_b2s(tmp));
+  msg->path = mutt_buffer_strdup(tmp);
   rc = 0;
 
 cleanup:

--- a/init.c
+++ b/init.c
@@ -1705,7 +1705,7 @@ static enum CommandResult parse_set(struct Buffer *buf, struct Buffer *s,
           {
             mutt_expand_path(buf->data, buf->dsize);
             struct Buffer scratch = mutt_buffer_make(1024);
-            mutt_buffer_strcpy(&scratch, mutt_b2s(buf));
+            mutt_buffer_copy(&scratch, buf);
             size_t scratchlen = mutt_buffer_len(&scratch);
             if (!(he->type & DT_MAILBOX) && (scratchlen != 0))
             {
@@ -1729,7 +1729,7 @@ static enum CommandResult parse_set(struct Buffer *buf, struct Buffer *s,
           else if (IS_COMMAND(he))
           {
             struct Buffer scratch = mutt_buffer_make(1024);
-            mutt_buffer_strcpy(&scratch, mutt_b2s(buf));
+            mutt_buffer_copy(&scratch, buf);
 
             if (mutt_str_strcmp(buf->data, "builtin") != 0)
             {

--- a/mailcap.c
+++ b/mailcap.c
@@ -145,7 +145,7 @@ int mailcap_expand_command(struct Body *a, const char *filename,
     else
       mutt_buffer_addch(buf, *cptr++);
   }
-  mutt_buffer_strcpy(command, mutt_b2s(buf));
+  mutt_buffer_copy(command, buf);
 
   mutt_buffer_pool_release(&buf);
   mutt_buffer_pool_release(&quoted);

--- a/maildir/maildir.c
+++ b/maildir/maildir.c
@@ -437,7 +437,7 @@ int maildir_mbox_check(struct Mailbox *m, int *index_hint)
   for (p = md; p; p = p->next)
   {
     maildir_canon_filename(buf, p->email->path);
-    p->canon_fname = mutt_str_strdup(mutt_b2s(buf));
+    p->canon_fname = mutt_buffer_strdup(buf);
     mutt_hash_insert(fnames, p->canon_fname, p);
   }
 

--- a/maildir/shared.c
+++ b/maildir/shared.c
@@ -387,7 +387,7 @@ int maildir_parse_dir(struct Mailbox *m, struct Maildir ***last,
     if (subdir)
     {
       mutt_buffer_printf(buf, "%s/%s", subdir, de->d_name);
-      e->path = mutt_str_strdup(mutt_b2s(buf));
+      e->path = mutt_buffer_strdup(buf);
     }
     else
       e->path = mutt_str_strdup(de->d_name);
@@ -1201,7 +1201,7 @@ static FILE *md_open_find_message(const char *folder, const char *unique,
   closedir(dp);
 
   if (newname && fp)
-    *newname = mutt_str_strdup(mutt_b2s(fname));
+    *newname = mutt_buffer_strdup(fname);
 
   errno = oe;
 

--- a/mutt/buffer.c
+++ b/mutt/buffer.c
@@ -421,3 +421,18 @@ size_t mutt_buffer_concatn_path(struct Buffer *buf, const char *dir,
     len += mutt_buffer_addstr_n(buf, fname, fnamelen);
   return len;
 }
+
+/**
+ * mutt_buffer_strdup - Copy a Buffer's string
+ * @param buf Buffer to copy
+ * @retval ptr Copy of string
+ *
+ * @note Caller must free the returned string
+ */
+char *mutt_buffer_strdup(struct Buffer *buf)
+{
+  if (!buf)
+    return NULL;
+
+  return mutt_str_strdup(buf->data);
+}

--- a/mutt/buffer.c
+++ b/mutt/buffer.c
@@ -436,3 +436,20 @@ char *mutt_buffer_strdup(struct Buffer *buf)
 
   return mutt_str_strdup(buf->data);
 }
+
+/**
+ * mutt_buffer_copy - Copy a Buffer's contents to another Buffer
+ * @param dst Buffer for result
+ * @param src Buffer to copy
+ */
+size_t mutt_buffer_copy(struct Buffer *dst, const struct Buffer *src)
+{
+  if (!dst)
+    return 0;
+
+  mutt_buffer_reset(dst);
+  if (!src || !src->data)
+    return 0;
+
+  return mutt_buffer_addstr_n(dst, src->data, mutt_buffer_len(src));
+}

--- a/mutt/buffer.c
+++ b/mutt/buffer.c
@@ -4,7 +4,7 @@
  *
  * @authors
  * Copyright (C) 2017 Ian Zimmerman <itz@primate.net>
- * Copyright (C) 2017 Richard Russon <rich@flatcap.org>
+ * Copyright (C) 2017-2019 Richard Russon <rich@flatcap.org>
  *
  * @copyright
  * This program is free software: you can redistribute it and/or modify it under
@@ -305,13 +305,14 @@ void mutt_buffer_dealloc(struct Buffer *buf)
  * mutt_buffer_strcpy - Copy a string into a Buffer
  * @param buf Buffer to overwrite
  * @param s   String to copy
+ * @retval num Bytes written to Buffer
  *
  * Overwrites any existing content.
  */
-void mutt_buffer_strcpy(struct Buffer *buf, const char *s)
+size_t mutt_buffer_strcpy(struct Buffer *buf, const char *s)
 {
   mutt_buffer_reset(buf);
-  mutt_buffer_addstr(buf, s);
+  return mutt_buffer_addstr(buf, s);
 }
 
 /**
@@ -319,13 +320,14 @@ void mutt_buffer_strcpy(struct Buffer *buf, const char *s)
  * @param buf Buffer to overwrite
  * @param s   String to copy
  * @param len Length of string to copy
+ * @retval num Bytes written to Buffer
  *
  * Overwrites any existing content.
  */
-void mutt_buffer_strcpy_n(struct Buffer *buf, const char *s, size_t len)
+size_t mutt_buffer_strcpy_n(struct Buffer *buf, const char *s, size_t len)
 {
   mutt_buffer_reset(buf);
-  mutt_buffer_addstr_n(buf, s, len);
+  return mutt_buffer_addstr_n(buf, s, len);
 }
 
 /**
@@ -333,14 +335,17 @@ void mutt_buffer_strcpy_n(struct Buffer *buf, const char *s, size_t len)
  * @param buf Buffer to overwrite
  * @param beg Start of string to copy
  * @param end End of string to copy
+ * @retval num Bytes written to Buffer
  *
  * Overwrites any existing content.
  */
-void mutt_buffer_substrcpy(struct Buffer *buf, const char *beg, const char *end)
+size_t mutt_buffer_substrcpy(struct Buffer *buf, const char *beg, const char *end)
 {
   mutt_buffer_reset(buf);
-  if (end > beg)
-    mutt_buffer_strcpy_n(buf, beg, end - beg);
+  if (end <= beg)
+    return 0;
+
+  return mutt_buffer_strcpy_n(buf, beg, end - beg);
 }
 
 /**
@@ -361,14 +366,15 @@ size_t mutt_buffer_len(const struct Buffer *buf)
  * @param buf   Buffer to add to
  * @param dir   Directory name
  * @param fname File name
+ * @retval num Bytes written to Buffer
  *
  * If both dir and fname are supplied, they are separated with '/'.
  * If either is missing, then the other will be copied exactly.
  */
-void mutt_buffer_concat_path(struct Buffer *buf, const char *dir, const char *fname)
+size_t mutt_buffer_concat_path(struct Buffer *buf, const char *dir, const char *fname)
 {
   if (!buf)
-    return;
+    return 0;
 
   if (!dir)
     dir = "";
@@ -378,7 +384,7 @@ void mutt_buffer_concat_path(struct Buffer *buf, const char *dir, const char *fn
   const bool d_set = (dir[0] != '\0');
   const bool f_set = (fname[0] != '\0');
   if (!d_set && !f_set)
-    return;
+    return 0;
 
   const int d_len = strlen(dir);
   const bool slash = d_set && (dir[d_len - 1] == '/');
@@ -387,7 +393,7 @@ void mutt_buffer_concat_path(struct Buffer *buf, const char *dir, const char *fn
   if (!f_set || !d_set || slash)
     fmt = "%s%s";
 
-  mutt_buffer_printf(buf, fmt, dir, fname);
+  return mutt_buffer_printf(buf, fmt, dir, fname);
 }
 
 /**
@@ -397,18 +403,21 @@ void mutt_buffer_concat_path(struct Buffer *buf, const char *dir, const char *fn
  * @param dirlen   Directory name
  * @param fname    File name
  * @param fnamelen File name
+ * @retval num Size of buffer
  *
  * If both dir and fname are supplied, they are separated with '/'.
  * If either is missing, then the other will be copied exactly.
  */
-void mutt_buffer_concatn_path(struct Buffer *buf, const char *dir,
+size_t mutt_buffer_concatn_path(struct Buffer *buf, const char *dir,
                               size_t dirlen, const char *fname, size_t fnamelen)
 {
+  size_t len = 0;
   mutt_buffer_reset(buf);
   if (dirlen != 0)
-    mutt_buffer_addstr_n(buf, dir, dirlen);
+    len += mutt_buffer_addstr_n(buf, dir, dirlen);
   if ((dirlen != 0) && (fnamelen != 0))
-    mutt_buffer_addch(buf, '/');
+    len += mutt_buffer_addch(buf, '/');
   if (fnamelen != 0)
-    mutt_buffer_addstr_n(buf, fname, fnamelen);
+    len += mutt_buffer_addstr_n(buf, fname, fnamelen);
+  return len;
 }

--- a/mutt/buffer.h
+++ b/mutt/buffer.h
@@ -61,6 +61,7 @@ int            mutt_buffer_add_printf   (struct Buffer *buf, const char *fmt, ..
 // Functions that OVERWRITE a Buffer
 size_t         mutt_buffer_concat_path  (struct Buffer *buf, const char *dir, const char *fname);
 size_t         mutt_buffer_concatn_path (struct Buffer *dst, const char *dir, size_t dirlen, const char *fname, size_t fnamelen);
+size_t         mutt_buffer_copy         (struct Buffer *dst, const struct Buffer *src);
 int            mutt_buffer_printf       (struct Buffer *buf, const char *fmt, ...);
 size_t         mutt_buffer_strcpy       (struct Buffer *buf, const char *s);
 size_t         mutt_buffer_strcpy_n     (struct Buffer *buf, const char *s, size_t len);

--- a/mutt/buffer.h
+++ b/mutt/buffer.h
@@ -50,6 +50,7 @@ bool           mutt_buffer_is_empty     (const struct Buffer *buf);
 size_t         mutt_buffer_len          (const struct Buffer *buf);
 struct Buffer  mutt_buffer_make         (size_t size);
 void           mutt_buffer_reset        (struct Buffer *buf);
+char *         mutt_buffer_strdup       (struct Buffer *buf);
 
 // Functions that APPEND to a Buffer
 size_t         mutt_buffer_addch        (struct Buffer *buf, char c);

--- a/mutt/buffer.h
+++ b/mutt/buffer.h
@@ -4,7 +4,7 @@
  *
  * @authors
  * Copyright (C) 2017 Ian Zimmerman <itz@primate.net>
- * Copyright (C) 2017 Richard Russon <rich@flatcap.org>
+ * Copyright (C) 2017-2019 Richard Russon <rich@flatcap.org>
  *
  * @copyright
  * This program is free software: you can redistribute it and/or modify it under
@@ -58,11 +58,11 @@ size_t         mutt_buffer_addstr_n     (struct Buffer *buf, const char *s, size
 int            mutt_buffer_add_printf   (struct Buffer *buf, const char *fmt, ...);
 
 // Functions that OVERWRITE a Buffer
-void           mutt_buffer_concat_path  (struct Buffer *buf, const char *dir, const char *fname);
-void           mutt_buffer_concatn_path (struct Buffer *dst, const char *dir, size_t dirlen, const char *fname, size_t fnamelen);
+size_t         mutt_buffer_concat_path  (struct Buffer *buf, const char *dir, const char *fname);
+size_t         mutt_buffer_concatn_path (struct Buffer *dst, const char *dir, size_t dirlen, const char *fname, size_t fnamelen);
 int            mutt_buffer_printf       (struct Buffer *buf, const char *fmt, ...);
-void           mutt_buffer_strcpy       (struct Buffer *buf, const char *s);
-void           mutt_buffer_strcpy_n     (struct Buffer *buf, const char *s, size_t len);
-void           mutt_buffer_substrcpy    (struct Buffer *buf, const char *beg, const char *end);
+size_t         mutt_buffer_strcpy       (struct Buffer *buf, const char *s);
+size_t         mutt_buffer_strcpy_n     (struct Buffer *buf, const char *s, size_t len);
+size_t         mutt_buffer_substrcpy    (struct Buffer *buf, const char *beg, const char *end);
 
 #endif /* MUTT_LIB_BUFFER_H */

--- a/mutt_body.c
+++ b/mutt_body.c
@@ -78,7 +78,7 @@ int mutt_body_copy(FILE *fp, struct Body **tgt, struct Body *src)
   b->parts = NULL;
   b->next = NULL;
 
-  b->filename = mutt_str_strdup(mutt_b2s(tmp));
+  b->filename = mutt_buffer_strdup(tmp);
   b->use_disp = use_disp;
   b->unlink = true;
 

--- a/mutt_logging.c
+++ b/mutt_logging.c
@@ -102,7 +102,7 @@ static const char *rotate_logs(const char *file, int count)
     rename(mutt_b2s(old_file), mutt_b2s(new_file));
   }
 
-  file = mutt_str_strdup(mutt_b2s(old_file));
+  file = mutt_buffer_strdup(old_file);
   mutt_buffer_pool_release(&old_file);
   mutt_buffer_pool_release(&new_file);
 

--- a/muttlib.c
+++ b/muttlib.c
@@ -305,7 +305,7 @@ void mutt_buffer_expand_path_regex(struct Buffer *buf, bool regex)
     else
       mutt_buffer_printf(tmp, "%s%s", mutt_b2s(p), tail);
 
-    mutt_buffer_strcpy(buf, mutt_b2s(tmp));
+    mutt_buffer_copy(buf, tmp);
   } while (recurse);
 
   mutt_buffer_pool_release(&p);

--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -1035,7 +1035,7 @@ static char *data_object_to_tempfile(gpgme_data_t data, FILE **fp_ret)
   }
   if (fp_ret)
     *fp_ret = fp;
-  rv = mutt_str_strdup(mutt_b2s(tempf));
+  rv = mutt_buffer_strdup(tempf);
 
 cleanup:
   mutt_buffer_pool_release(&tempf);

--- a/ncrypt/pgp.c
+++ b/ncrypt/pgp.c
@@ -1406,7 +1406,7 @@ struct Body *pgp_class_sign_message(struct Body *a)
   t = t->parts->next;
   t->type = TYPE_APPLICATION;
   t->subtype = mutt_str_strdup("pgp-signature");
-  t->filename = mutt_str_strdup(mutt_b2s(sigfile));
+  t->filename = mutt_buffer_strdup(sigfile);
   t->use_disp = false;
   t->disposition = DISP_NONE;
   t->encoding = ENC_7BIT;
@@ -1661,7 +1661,7 @@ struct Body *pgp_class_encrypt_message(struct Body *a, char *keylist, bool sign)
   t->parts->next->type = TYPE_APPLICATION;
   t->parts->next->subtype = mutt_str_strdup("octet-stream");
   t->parts->next->encoding = ENC_7BIT;
-  t->parts->next->filename = mutt_str_strdup(mutt_b2s(tempfile));
+  t->parts->next->filename = mutt_buffer_strdup(tempfile);
   t->parts->next->use_disp = true;
   t->parts->next->disposition = DISP_ATTACH;
   t->parts->next->unlink = true; /* delete after sending the message */
@@ -1827,7 +1827,7 @@ struct Body *pgp_class_traditional_encryptsign(struct Body *a, SecurityFlags fla
                  (flags & SEC_ENCRYPT) ? "pgp-encrypted" : "pgp-signed");
   mutt_param_set(&b->parameter, "charset", send_charset);
 
-  b->filename = mutt_str_strdup(mutt_b2s(pgpoutfile));
+  b->filename = mutt_buffer_strdup(pgpoutfile);
 
   b->disposition = DISP_NONE;
   b->unlink = true;

--- a/ncrypt/pgpkey.c
+++ b/ncrypt/pgpkey.c
@@ -930,7 +930,7 @@ struct Body *pgp_class_make_key_attachment(void)
   mutt_file_fclose(&fp_null);
 
   att = mutt_body_new();
-  att->filename = mutt_str_strdup(mutt_b2s(tempf));
+  att->filename = mutt_buffer_strdup(tempf);
   att->unlink = true;
   att->use_disp = false;
   att->type = TYPE_APPLICATION;

--- a/pattern.c
+++ b/pattern.c
@@ -2431,7 +2431,7 @@ int mutt_pattern_func(int op, char *prompt)
 
   mutt_message(_("Compiling search pattern..."));
 
-  char *simple = mutt_str_strdup(mutt_b2s(buf));
+  char *simple = mutt_buffer_strdup(buf);
   mutt_check_simple(buf, NONULL(C_SimpleSearch));
 
   mutt_buffer_init(&err);

--- a/pop/pop.c
+++ b/pop/pop.c
@@ -1167,7 +1167,7 @@ static int pop_msg_open(struct Mailbox *m, struct Message *msg, int msgno)
   else
   {
     cache->index = e->index;
-    cache->path = mutt_str_strdup(mutt_b2s(path));
+    cache->path = mutt_buffer_strdup(path);
   }
   rewind(msg->fp);
 

--- a/recvattach.c
+++ b/recvattach.c
@@ -474,7 +474,7 @@ static void prepend_savedir(struct Buffer *buf)
     mutt_buffer_addstr(tmp, "./");
 
   mutt_buffer_addstr(tmp, mutt_b2s(buf));
-  mutt_buffer_strcpy(buf, mutt_b2s(tmp));
+  mutt_buffer_copy(buf, tmp);
   mutt_buffer_pool_release(&tmp);
 }
 
@@ -552,7 +552,7 @@ static int query_save_attachment(FILE *fp, struct Body *body, struct Email *e, c
       }
       else if (rc == -1)
         goto cleanup;
-      mutt_buffer_strcpy(tfile, mutt_b2s(buf));
+      mutt_buffer_copy(tfile, buf);
     }
     else
     {
@@ -618,7 +618,7 @@ static int save_without_prompting(FILE *fp, struct Body *body, struct Email *e)
 
   if (is_message)
   {
-    mutt_buffer_strcpy(tfile, mutt_b2s(buf));
+    mutt_buffer_copy(tfile, buf);
   }
   else
   {


### PR DESCRIPTION
Low urgency.

The first commit adds return values (of the Buffer size) to several Buffer functions.
We have the information available, so it might be useful.

- `mutt_buffer_concatn_path()`
- `mutt_buffer_concat_path()`           
- `mutt_buffer_strcpy()`                
- `mutt_buffer_strcpy_n()`              
- `mutt_buffer_substrcpy()`  

The next two replace some common patterns (see a lot in the upstream refactoring),
with new functions: `mutt_buffer_strdup()` and `mutt_buffer_copy()`.

```diff
- mutt_str_strdup(mutt_b2s(buf));
+ mutt_buffer_strdup(buf);
```

```diff
- mutt_buffer_strcpy(dst, mutt_b2s(src));
+ mutt_buffer_copy(dst, src);
```