### PR TITLE
config: drop wrapmargin

### DIFF
--- a/contrib/sample.neomuttrc-tlr
+++ b/contrib/sample.neomuttrc-tlr
@@ -285,7 +285,7 @@ set smileys="^$"
 set ispell=iaspell
 
 set markers=no                          # Don't mark wrapped lines
-set wrapmargin=4                        # Leave a margin in the pager
+set wrap=-4                             # Leave a margin in the pager
 
 # PGP command configuration
 # source ~/.mutt/pgp2.rc

--- a/doc/neomutt.pwl
+++ b/doc/neomutt.pwl
@@ -397,7 +397,6 @@ dl
 PageDn
 fC
 fetchmail
-wrapmargin
 mailcap
 myscript
 Fi

--- a/init.h
+++ b/init.h
@@ -4901,7 +4901,6 @@ struct ConfigDef MuttVars[] = {
   { "ignore_linear_white_space", DT_DEPRECATED|DT_BOOL,            &C_IgnoreLinearWhiteSpace, false   },
   { "pgp_encrypt_self",          DT_DEPRECATED|DT_QUAD,            &C_PgpEncryptSelf,         MUTT_NO },
   { "smime_encrypt_self",        DT_DEPRECATED|DT_QUAD,            &C_SmimeEncryptSelf,       MUTT_NO },
-  { "wrapmargin",                DT_DEPRECATED|DT_NUMBER|R_PAGER,  &C_Wrap,                   0       },
 
   { "abort_noattach_regexp",  DT_SYNONYM, NULL, IP "abort_noattach_regex",     },
   { "attach_keyword",         DT_SYNONYM, NULL, IP "abort_noattach_regex",     },


### PR DESCRIPTION
'$wrapmargin' is a long-deprecated alternative to '$wrap', except in reverse.
Setting `wrapmargin=4` was equivalent to `wrap=-4`.

The new config system eliminated all the custom handling of options.

Closes: #1883 

---

It was never part of NeoMutt, so this is the simple solution.
Alternatively, I can fix the behaviour until some future 'Deprecation Day'.