### PR TITLE
eliminate MuttIndexWindow from create_filter()

### DIFF
--- a/browser.c
+++ b/browser.c
@@ -1979,7 +1979,7 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
           struct Body *b = mutt_make_file_attach(buf2);
           if (b)
           {
-            mutt_view_attachment(NULL, b, MUTT_VA_REGULAR, NULL, NULL);
+            mutt_view_attachment(NULL, b, MUTT_VA_REGULAR, NULL, NULL, menu->indexwin);
             mutt_body_free(&b);
             menu->redraw = REDRAW_FULL;
           }

--- a/commands.c
+++ b/commands.c
@@ -206,6 +206,10 @@ int mutt_display_message(struct MuttWindow *win, struct Mailbox *m, struct Email
   mutt_parse_mime_message(m, e);
   mutt_message_hook(m, e, MUTT_MESSAGE_HOOK);
 
+  char columns[16];
+  snprintf(columns, sizeof(columns), "%d", win->cols);
+  mutt_envlist_set("COLUMNS", columns, true);
+
   /* see if crypto is needed for this message.  if so, we should exit curses */
   if ((WithCrypto != 0) && e->security)
   {
@@ -382,6 +386,7 @@ int mutt_display_message(struct MuttWindow *win, struct Mailbox *m, struct Email
   }
 
 cleanup:
+  mutt_envlist_unset("COLUMNS");
   mutt_buffer_pool_release(&tempfile);
   return rc;
 }

--- a/filter.c
+++ b/filter.c
@@ -150,13 +150,6 @@ pid_t mutt_create_filter_fd(const char *cmd, FILE **fp_in, FILE **fp_out,
       close(fderr);
     }
 
-    if (MuttIndexWindow && (MuttIndexWindow->cols > 0))
-    {
-      char columns[16];
-      snprintf(columns, sizeof(columns), "%d", MuttIndexWindow->cols);
-      mutt_envlist_set("COLUMNS", columns, true);
-    }
-
     execle(EXEC_SHELL, "sh", "-c", cmd, NULL, mutt_envlist_getlist());
     _exit(127);
   }

--- a/mutt_attach.h
+++ b/mutt_attach.h
@@ -29,9 +29,10 @@
 #include <stdio.h>
 
 struct AttachCtx;
-struct Menu;
-struct Email;
 struct Body;
+struct Email;
+struct Menu;
+struct MuttWindow;
 
 /**
  * enum ViewAttachMode - Options for mutt_view_attachment()
@@ -67,7 +68,7 @@ void mutt_pipe_attachment_list(struct AttachCtx *actx, FILE *fp, bool tag,
 void mutt_print_attachment_list(struct AttachCtx *actx, FILE *fp, bool tag,
                                 struct Body *top);
 
-int mutt_view_attachment(FILE *fp, struct Body *a, enum ViewAttachMode mode, struct Email *e, struct AttachCtx *actx);
+int mutt_view_attachment(FILE *fp, struct Body *a, enum ViewAttachMode mode, struct Email *e, struct AttachCtx *actx, struct MuttWindow *win);
 
 void mutt_check_lookup_list(struct Body *b, char *type, size_t len);
 int mutt_compose_attachment(struct Body *a);

--- a/recvattach.c
+++ b/recvattach.c
@@ -1152,7 +1152,7 @@ int mutt_attach_display_loop(struct Menu *menu, int op, struct Email *e,
 
       case OP_VIEW_ATTACH:
         op = mutt_view_attachment(CUR_ATTACH->fp, CUR_ATTACH->content,
-                                  MUTT_VA_REGULAR, e, actx);
+                                  MUTT_VA_REGULAR, e, actx, menu->indexwin);
         break;
 
       case OP_NEXT_ENTRY:
@@ -1442,12 +1442,14 @@ void mutt_view_attachments(struct Email *e)
     switch (op)
     {
       case OP_ATTACH_VIEW_MAILCAP:
-        mutt_view_attachment(CUR_ATTACH->fp, CUR_ATTACH->content, MUTT_VA_MAILCAP, e, actx);
+        mutt_view_attachment(CUR_ATTACH->fp, CUR_ATTACH->content,
+                             MUTT_VA_MAILCAP, e, actx, menu->indexwin);
         menu->redraw = REDRAW_FULL;
         break;
 
       case OP_ATTACH_VIEW_TEXT:
-        mutt_view_attachment(CUR_ATTACH->fp, CUR_ATTACH->content, MUTT_VA_AS_TEXT, e, actx);
+        mutt_view_attachment(CUR_ATTACH->fp, CUR_ATTACH->content,
+                             MUTT_VA_AS_TEXT, e, actx, menu->indexwin);
         menu->redraw = REDRAW_FULL;
         break;
 


### PR DESCRIPTION
Low urgency.

`mutt_create_filter_fd()` uses the screen width to set the environment variable `$COLUMNS`.
This allows certain filters / mailcap programs to adjust their output.

`$COLUMNS` is set/reset in the smallest scope possible.

This variable isn't set globally to avoid affecting other programs which don't need to know.