### PR TITLE
Resolve symbolic links when saving a message

### DIFF
--- a/muttlib.c
+++ b/muttlib.c
@@ -317,7 +317,23 @@ void mutt_buffer_expand_path_regex(struct Buffer *buf, bool regex)
    * folders. May possibly fail, in which case buf should be the same. */
   if (imap_path_probe(mutt_b2s(buf), NULL) == MUTT_IMAP)
     imap_expand_path(buf);
+  else
 #endif
+  {
+    /* Resolve symbolic links */
+    struct stat st;
+    int rc = lstat(mutt_b2s(buf), &st);
+    if ((rc != -1) && S_ISLNK(st.st_mode))
+    {
+      char path[PATH_MAX];
+      ssize_t len = readlink(mutt_b2s(buf), path, sizeof(path));
+      if (len != -1)
+      {
+        mutt_buffer_strcpy_n(buf, path, len);
+      }
+    }
+  }
+
 }
 
 /**


### PR DESCRIPTION
Issue #1898

I'm not totally positive this is the right place to do this - perhaps symlinks should be resolved just before opening a mailbox, so the mailbox path isn't magically changed to follow the symlink.