### PR TITLE
Avoid dangling pointer in Account's mailbox list

### DIFF
--- a/core/account.c
+++ b/core/account.c
@@ -78,7 +78,8 @@ bool account_mailbox_add(struct Account *a, struct Mailbox *m)
  * @param a Account
  * @param m Mailbox to remove
  *
- * @note If m is NULL, all the mailboxes will be removed
+ * @note If m is NULL, all the mailboxes will be removed and FREE'd. Otherwise,
+ * the specified mailbox is removed from the Account but not FREE'd.
  */
 bool account_mailbox_remove(struct Account *a, struct Mailbox *m)
 {
@@ -95,7 +96,8 @@ bool account_mailbox_remove(struct Account *a, struct Mailbox *m)
       struct EventMailbox ev_m = { m };
       notify_send(a->notify, NT_MAILBOX, NT_MAILBOX_REMOVE, IP & ev_m);
       STAILQ_REMOVE(&a->mailboxes, np, MailboxNode, entries);
-      mailbox_free(&np->mailbox);
+      if (!m)
+        mailbox_free(&np->mailbox);
       FREE(&np);
       result = true;
       if (m)

--- a/init.c
+++ b/init.c
@@ -2456,6 +2456,7 @@ static enum CommandResult parse_unmailboxes(struct Buffer *buf, struct Buffer *s
         else
         {
           account_mailbox_remove(np->mailbox->account, np->mailbox);
+          mailbox_free(&np->mailbox);
         }
       }
     }

--- a/main.c
+++ b/main.c
@@ -1233,6 +1233,7 @@ int main(int argc, char *argv[], char *envp[])
       if (m->account)
       {
         account_mailbox_remove(m->account, m);
+        mailbox_free(&m);
         m = NULL;
       }
       else

--- a/mx.c
+++ b/mx.c
@@ -1584,10 +1584,11 @@ int mx_ac_remove(struct Mailbox *m)
   if (!m || !m->account)
     return -1;
 
+  struct Account *a = m->account;
   account_mailbox_remove(m->account, m);
-  if (STAILQ_EMPTY(&m->account->mailboxes))
+  if (STAILQ_EMPTY(&a->mailboxes))
   {
-    neomutt_account_remove(NeoMutt, m->account);
+    neomutt_account_remove(NeoMutt, a);
   }
   return 0;
 }


### PR DESCRIPTION
This fixes a bug whereas the failure to open a fresh mailbox caused the mailbox to remain attached to the Account's mailbox list. Further access to the Account's mailbox list caused the dangling pointer to be dereferenced, thus a crash.