### PR TITLE
lmdb: fix txn leak

### DIFF
--- a/hcache/lmdb.c
+++ b/hcache/lmdb.c
@@ -292,9 +292,13 @@ static void hcache_lmdb_close(void **ptr)
 
   struct HcacheLmdbCtx *db = *ptr;
 
-  if (db->txn && (db->txn_mode == TXN_WRITE))
+  if (db->txn)
   {
-    mdb_txn_commit(db->txn);
+    if (db->txn_mode == TXN_WRITE)
+      mdb_txn_commit(db->txn);
+    else
+      mdb_txn_abort(db->txn);
+
     db->txn_mode = TXN_UNINITIALIZED;
     db->txn = NULL;
   }


### PR DESCRIPTION
Opening a maildir mailbox read-only creates a couple of LMDB transactions (for 'new' and 'cur').
As they are readonly, they don't get committed or aborted (the two actions that free a transaction) when the LMDB connection is closed.

I _think_ this is correct.
It works for read-only and write transactions and ASAN seems happy.
