### PR TITLE
fix mbox save-to-trash

### DIFF
--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -966,6 +966,7 @@ static int mbox_mbox_open(struct Mailbox *m)
     rc = mmdf_parse_mailbox(m);
   else
     rc = -1;
+  clearerr(adata->fp); // Clear the EOF flag
   mutt_file_touch_atime(fileno(adata->fp));
 
   mbox_unlock_mailbox(m);


### PR DESCRIPTION
Opening an mbox Mailbox, causes the entire file to be read.
A side-effect of this, is that the EOF flag is set on the FILE stream.

Later, when the Mailbox is used for trash, the EOF flag causes the operation to fail.
