### PR TITLE
fix crash saving to mbox

### DIFF
--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -1574,7 +1574,9 @@ static int mbox_msg_open(struct Mailbox *m, struct Message *msg, int msgno)
   if (!adata)
     return -1;
 
-  msg->fp = adata->fp;
+  msg->fp = mutt_file_fopen(mailbox_path(m), "r");
+  if (!msg->fp)
+    return -1;
 
   return 0;
 }
@@ -1623,7 +1625,10 @@ static int mbox_msg_close(struct Mailbox *m, struct Message *msg)
   if (!msg)
     return -1;
 
-  msg->fp = NULL;
+  if (msg->write)
+    msg->fp = NULL;
+  else
+    mutt_file_fclose(&msg->fp);
 
   return 0;
 }

--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -989,18 +989,22 @@ static int mbox_mbox_open_append(struct Mailbox *m, OpenMailboxFlags flags)
   if (!adata)
     return -1;
 
-  adata->fp = mutt_file_fopen(mailbox_path(m), (flags & MUTT_NEWFOLDER) ? "w" : "a");
   if (!adata->fp)
   {
-    mutt_perror(mailbox_path(m));
-    return -1;
-  }
+    adata->fp =
+        mutt_file_fopen(mailbox_path(m), (flags & MUTT_NEWFOLDER) ? "w+" : "a+");
+    if (!adata->fp)
+    {
+      mutt_perror(mailbox_path(m));
+      return -1;
+    }
 
-  if (mbox_lock_mailbox(m, true, true) != false)
-  {
-    mutt_error(_("Couldn't lock %s"), mailbox_path(m));
-    mutt_file_fclose(&adata->fp);
-    return -1;
+    if (mbox_lock_mailbox(m, true, true) != false)
+    {
+      mutt_error(_("Couldn't lock %s"), mailbox_path(m));
+      mutt_file_fclose(&adata->fp);
+      return -1;
+    }
   }
 
   fseek(adata->fp, 0, SEEK_END);

--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -1430,7 +1430,11 @@ static int mbox_mbox_sync(struct Mailbox *m, int *index_hint)
   mbox_reset_atime(m, &statbuf);
 
   /* reopen the mailbox in read-only mode */
-  adata->fp = fopen(mailbox_path(m), "r");
+  adata->fp = mbox_open_readwrite(m);
+  if (!adata->fp)
+  {
+    adata->fp = mbox_open_readonly(m);
+  }
   if (!adata->fp)
   {
     unlink(mutt_b2s(tempfile));

--- a/mx.c
+++ b/mx.c
@@ -299,11 +299,6 @@ struct Context *mx_mbox_open(struct Mailbox *m, OpenMailboxFlags flags)
   ctx->msg_not_read_yet = -1;
   ctx->collapsed = false;
 
-  m->size = 0;
-  m->msg_unread = 0;
-  m->msg_flagged = 0;
-  m->rights = MUTT_ACL_ALL;
-
   m->quiet = (flags & MUTT_QUIET);
   if (flags & MUTT_READONLY)
     m->readonly = true;
@@ -316,6 +311,13 @@ struct Context *mx_mbox_open(struct Mailbox *m, OpenMailboxFlags flags)
       goto error;
     }
     return ctx;
+  }
+  else
+  {
+    m->size = 0;
+    m->msg_unread = 0;
+    m->msg_flagged = 0;
+    m->rights = MUTT_ACL_ALL;
   }
 
   if (m->magic == MUTT_UNKNOWN)

--- a/sort.c
+++ b/sort.c
@@ -331,7 +331,7 @@ sort_t *mutt_get_sort_func(enum SortType method)
       return compare_label;
     case SORT_ORDER:
 #ifdef USE_NNTP
-      if (Context && (Context->mailbox->magic == MUTT_NNTP))
+      if (Context && Context->mailbox && (Context->mailbox->magic == MUTT_NNTP))
         return nntp_compare_order;
       else
 #endif


### PR DESCRIPTION
Change the calls to `fopen()` to always allow reading.

Saving to an email to the current mbox opened the file write-only.
This causes a crash when NeoMutt tries to reuse the FILE handle for reading.

Fixes: #1913
