### PR TITLE
notmuch: use nm_default_uri if no mailbox data

### DIFF
--- a/notmuch/nm_db.c
+++ b/notmuch/nm_db.c
@@ -53,10 +53,13 @@
 const char *nm_db_get_filename(struct Mailbox *m)
 {
   struct NmMboxData *mdata = nm_mdata_get(m);
-  if (!mdata)
-    return NULL;
+  char *db_filename = NULL;
 
-  char *db_filename = mdata->db_url->path ? mdata->db_url->path : C_NmDefaultUri;
+  if (mdata && mdata->db_url && mdata->db_url->path)
+    db_filename = mdata->db_url->path;
+  else
+    db_filename = C_NmDefaultUri;
+
   if (!db_filename && !C_Folder)
     return NULL;
 


### PR DESCRIPTION
Modify 'nm_db_get_filename' to not terminate early if there's no mailbox
data. The notmuch backend may be activated in a mailbox without mailbox
data (e.g. vfolder-from-query), which results in a NULL DB filename.
Instead, use 'nm_default_uri' as the fallback even when there's no
mailbox data.

Fixes #1923