### PR TITLE
Fix relative symlink resolution

### DIFF
--- a/muttlib.c
+++ b/muttlib.c
@@ -329,7 +329,18 @@ void mutt_buffer_expand_path_regex(struct Buffer *buf, bool regex)
       ssize_t len = readlink(mutt_b2s(buf), path, sizeof(path));
       if (len != -1)
       {
-        mutt_buffer_strcpy_n(buf, path, len);
+        char *orig_dir = mutt_path_dirname(mutt_b2s(buf));
+        if (*orig_dir)
+        {
+          mutt_buffer_strcpy(buf, orig_dir);
+          mutt_buffer_addch(buf, '/');
+          mutt_buffer_addstr_n(buf, path, len);
+        }
+        else
+        {
+          mutt_buffer_strcpy_n(buf, path, len);
+        }
+        FREE(&orig_dir);
       }
     }
   }


### PR DESCRIPTION
* **What does this PR do?**

When a path at /foo/bar/s is a symlink to rel/path, the canoncial expanded version should be /foo/bar/rel/path, not ./rel/path.

Disclaimer: I am not a C programmer, so please review carefully!

It's possible that nicer fixes exist, e.g. maybe mutt_path_concat() would be better than concatenating the dirname to the rest manually.

Maybe the `*orig_dir` check is pointless, the man page says dirname("noslashes") returns ".".

Maybe the symlink normalization logic needs to be even more smarter (e.g. handle symlinks to symlinks, but avoid infinite loops).

* **Does this PR meet the acceptance criteria?** (This is just a reminder for you,
  this section can be removed if you fulfill it.)


   - All builds and tests are passing

   - Code follows the [style guide](https://neomutt.org/dev/coding-style)

lol I've no idea sorry ;)

* **What are the relevant issue numbers?**

Fixes #1937.

Possibly also #1933 and #1920.
