### PR TITLE
Fix relative symlink resolution

### DIFF
--- a/muttlib.c
+++ b/muttlib.c
@@ -326,10 +326,9 @@ void mutt_buffer_expand_path_regex(struct Buffer *buf, bool regex)
     if ((rc != -1) && S_ISLNK(st.st_mode))
     {
       char path[PATH_MAX];
-      ssize_t len = readlink(mutt_b2s(buf), path, sizeof(path));
-      if (len != -1)
+      if (realpath(mutt_b2s(buf), path))
       {
-        mutt_buffer_strcpy_n(buf, path, len);
+        mutt_buffer_strcpy(buf, path);
       }
     }
   }


### PR DESCRIPTION
### What does this PR do?

When a path at /foo/bar/s is a symlink to rel/path, the canoncial
expanded version should be /foo/bar/rel/path, not ./rel/path.

### What are the relevant issue numbers?

Fixes #1937.

Possibly also #1933 and #1920.

Supersedes #1939.