### PR TITLE
fix: trash to non-existent file/dir

### DIFF
--- a/maildir/maildir.c
+++ b/maildir/maildir.c
@@ -300,7 +300,7 @@ static int maildir_mbox_open_append(struct Mailbox *m, OpenMailboxFlags flags)
   if (!m)
     return -1;
 
-  if (!(flags & (MUTT_APPENDNEW | MUTT_NEWFOLDER)))
+  if (!(flags & (MUTT_APPEND | MUTT_APPENDNEW | MUTT_NEWFOLDER)))
   {
     return 0;
   }

--- a/mx.c
+++ b/mx.c
@@ -512,7 +512,7 @@ static int trash_append(struct Mailbox *m)
 #endif
 
   struct Mailbox *m_trash = mx_path_resolve(C_Trash);
-  struct Context *ctx_trash = mx_mbox_open(m_trash, MUTT_OPEN_NO_FLAGS);
+  struct Context *ctx_trash = mx_mbox_open(m_trash, MUTT_APPEND);
   if (ctx_trash)
   {
     bool old_append = m_trash->append;


### PR DESCRIPTION
A missing flag mean that saving trash to a non-existent file/directory would fail.

Tests:
- `mbox_type=mbox`, save to non-existent file, or non-existent dir/file
- `mbox_type=maildir`, save to non-existent dir, or non-existent dir/dir