### PR TITLE
feat: add 'sidebar_unread' color

### DIFF
--- a/color.c
+++ b/color.c
@@ -130,6 +130,7 @@ static const struct Mapping Fields[] = {
   { "sidebar_new",       MT_COLOR_SIDEBAR_NEW },
   { "sidebar_ordinary",  MT_COLOR_SIDEBAR_ORDINARY },
   { "sidebar_spoolfile", MT_COLOR_SIDEBAR_SPOOLFILE },
+  { "sidebar_unread",    MT_COLOR_SIDEBAR_UNREAD },
 #endif
   { "signature",         MT_COLOR_SIGNATURE },
   { "status",            MT_COLOR_STATUS },

--- a/color.h
+++ b/color.h
@@ -89,6 +89,7 @@ enum ColorId
   MT_COLOR_SIDEBAR_NEW,              ///< Mailbox with new mail
   MT_COLOR_SIDEBAR_ORDINARY,         ///< Mailbox with no new or flagged messages
   MT_COLOR_SIDEBAR_SPOOLFILE,        ///< $spoolfile (Spool mailbox)
+  MT_COLOR_SIDEBAR_UNREAD,           ///< Mailbox with unread mail
 #endif
   MT_COLOR_SIGNATURE,                ///< Pager: signature lines
   MT_COLOR_STATUS,                   ///< Status bar (takes a pattern)

--- a/doc/manual.xml.head
+++ b/doc/manual.xml.head
@@ -1104,6 +1104,11 @@ color sidebar_divider   color8  default     <emphasis role="comment"># Dark grey
                 </row>
                 <row>
                   <entry></entry>
+                  <entry><literal>sidebar_unread</literal></entry>
+                  <entry>Mailbox contains unread mail</entry>
+                </row>
+                <row>
+                  <entry></entry>
                   <entry><literal>sidebar_flagged</literal></entry>
                   <entry>Mailbox contains flagged mail</entry>
                 </row>
@@ -5069,6 +5074,10 @@ uncolor index_date
               <row>
                 <entry>sidebar_spoolfile</entry>
                 <entry>Mailbox that receives incoming mail</entry>
+              </row>
+              <row>
+                <entry>sidebar_unread</entry>
+                <entry>Mailboxes containing unread mail</entry>
               </row>
             </tbody>
           </tgroup>
@@ -16758,6 +16767,13 @@ set sort_browser="reverse-size"
                 <entry>default</entry>
                 <entry>
                   Mailbox that receives incoming mail
+                </entry>
+              </row>
+              <row>
+                <entry><literal>sidebar_unread</literal></entry>
+                <entry>default</entry>
+                <entry>
+                  Mailboxes containing unread mail
                 </entry>
               </row>
             </tbody>

--- a/sidebar.c
+++ b/sidebar.c
@@ -844,6 +844,8 @@ static void draw_sidebar(int num_rows, int num_cols, int div_width)
       mutt_curses_set_color(MT_COLOR_SIDEBAR_HIGHLIGHT);
     else if (m->has_new)
       mutt_curses_set_color(MT_COLOR_SIDEBAR_NEW);
+    else if (m->msg_unread > 0)
+      mutt_curses_set_color(MT_COLOR_SIDEBAR_UNREAD);
     else if (m->msg_flagged > 0)
       mutt_curses_set_color(MT_COLOR_SIDEBAR_FLAGGED);
     else if ((Colors->defs[MT_COLOR_SIDEBAR_SPOOLFILE] != 0) &&


### PR DESCRIPTION
With the change to 'sidebar_new' to exclude unread counts, there is no
mechanism to highlight mailboxes with unread mail in the sidebar. This
will appear as a regression to those using 'sidebar_new' for such
purpose.

To span the gap, introduce 'sidebar_unread' which restores the
highlighting for unread mailboxes. It's priority is higher than
'sidebar_flagged'.

Closes #1944
Closes #1875