### PR TITLE
fix new-mail flags and behaviour

### DIFF
--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -805,7 +805,7 @@ static bool test_last_status_new(FILE *fp)
 
   e = email_new();
   tmp_envelope = mutt_rfc822_read_header(fp, e, false, false);
-  if (!(e->read || e->old))
+  if (!e->read && !e->old)
     rc = true;
 
   mutt_env_free(&tmp_envelope);

--- a/mutt_mailbox.c
+++ b/mutt_mailbox.c
@@ -45,20 +45,18 @@ static void mailbox_check(struct Mailbox *m_cur, struct Mailbox *m_check,
 
   enum MailboxType mb_magic = mx_path_probe(mailbox_path(m_check), NULL);
 
+  if ((m_cur == m_check) && C_MailCheckRecent)
+    m_check->has_new = false;
+
   switch (mb_magic)
   {
     case MUTT_POP:
     case MUTT_NNTP:
     case MUTT_NOTMUCH:
     case MUTT_IMAP:
-      if ((mb_magic != MUTT_IMAP) && C_MailCheckRecent)
-        m_check->has_new = false;
       m_check->magic = mb_magic;
       break;
     default:
-      if ((m_cur == m_check) && C_MailCheckRecent)
-        m_check->has_new = false;
-
       if ((stat(mailbox_path(m_check), &sb) != 0) ||
           (S_ISREG(sb.st_mode) && (sb.st_size == 0)) ||
           ((m_check->magic == MUTT_UNKNOWN) &&

--- a/mx.c
+++ b/mx.c
@@ -375,9 +375,6 @@ struct Context *mx_mbox_open(struct Mailbox *m, OpenMailboxFlags flags)
 
   OptForceRefresh = false;
 
-  if (C_MailCheckRecent)
-    ctx->mailbox->has_new = false;
-
   return ctx;
 
 error:
@@ -569,6 +566,9 @@ int mx_mbox_close(struct Context **ptr)
 
   struct Mailbox *m = ctx->mailbox;
 
+  if (C_MailCheckRecent)
+    m->has_new = false;
+
   if (m->readonly || m->dontwrite || m->append)
   {
     mx_fastclose_mailbox(m);
@@ -661,7 +661,7 @@ int mx_mbox_close(struct Context **ptr)
       goto cleanup;
   }
 
-  if (C_MarkOld)
+  if (C_MarkOld && !m->peekonly)
   {
     for (i = 0; i < m->msg_count; i++)
     {


### PR DESCRIPTION
- mbox: don't write unless it's really changed
- imap: clear the new flag on entry

A couple of misplaced flag-settings caused a heap of problems with new mail.
mbox, maildir and imap should now work correctly.