### PR TITLE
docbook: set generate.consistent.ids to 1 to make generated html reproducible

### DIFF
--- a/doc/neomutt.xsl
+++ b/doc/neomutt.xsl
@@ -4,6 +4,7 @@
 ]>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
   <xsl:param name="section.autolabel" select="1"></xsl:param>
+  <xsl:param name="generate.consistent.ids" select="1"></xsl:param>
   <xsl:template name="user.head.content">
     <xsl:element name="style">
       <xsl:attribute name="type">text/css</xsl:attribute>


### PR DESCRIPTION
* **What does this PR do?**

Makes HTML generated by docbook reproducible. It sets `<xsl:param name="generate.consistent.ids" select="1"></xsl:param>` in neomutt.xsl.

http://docbook.sourceforge.net/release/xsl/current/doc/fo/generate.consistent.ids.html

Affected files generated by docbook:
```
 gettingstarted.html |    4 ++--
 index.html          |    4 ++--
 manual.html         |    8 ++++----
```


* **Screenshots (if relevant)**

Example in HTML output:

```diff
-     </p></li></ul></div><div class="table"><a id="idm140737315569792"></a><p class="title"><str...
+     </p></li></ul></div><div class="table"><a id="id-1.3.6.5.14.5.6"></a><p class="title"><stro...
```
