### PR TITLE
Devel/mailsize expandos

### DIFF
--- a/doc/manual.xml.head
+++ b/doc/manual.xml.head
@@ -5018,7 +5018,7 @@ uncolor prompt
               </row>
               <row>
                 <entry>index_size</entry>
-                <entry>Message size, <literal>%c</literal> <literal>%l</literal></entry>
+                <entry>Message size, <literal>%c</literal> <literal>%cr</literal> <literal>%l</literal></entry>
               </row>
               <row>
                 <entry>index_tags</entry>
@@ -7235,7 +7235,8 @@ set index_format="%4C %Z %{%b %d} %-15.15L (%?l?%4l&amp;%4c?)%*  %s"
           <literal>%s</literal> in <link linkend="attach-format">$attach_format</link>,
           <literal>%l</literal> in <link linkend="compose-format">$compose_format</link>,
           <literal>%s</literal> in <link linkend="folder-format">$folder_format</link>,
-          <literal>%c</literal> in <link linkend="index-format">$index_format</link>,
+          <literal>%c</literal> and <literal>%cr</literal>
+            in <link linkend="index-format">$index_format</link>,
           and %l and %L in <link linkend="status-format">$status_format</link>.
           There are four configuration variables that can be used to customize
           how the numbers are displayed.
@@ -13615,7 +13616,7 @@ color index-object foreground background pattern
               <row>
                 <entry><literal>index_size</literal></entry>
                 <entry>no</entry>
-                <entry>Message size, %c %l</entry>
+                <entry>Message size, %c %cr %l</entry>
               </row>
               <row>
                 <entry><literal>index_subject</literal></entry>
@@ -13654,7 +13655,7 @@ color index_date green default
 color index_label default brightgreen
 <emphasis role="comment"># Message number, %C</emphasis>
 color index_number red default
-<emphasis role="comment"># Message size, %c %l</emphasis>
+<emphasis role="comment"># Message size, %c %cr %l</emphasis>
 color index_size cyan default
 
 <emphasis role="comment"># vim: syntax=neomuttrc</emphasis>

--- a/hdrline.c
+++ b/hdrline.c
@@ -508,7 +508,8 @@ static bool thread_is_old(struct Context *ctx, struct Email *e)
  * | \%b     | Filename of the original message folder (think mailbox)
  * | \%B     | The list to which the letter was sent, or else the folder name (%b)
  * | \%C     | Current message number
- * | \%c     | Number of characters (bytes) in the message
+ * | \%c     | Number of characters (bytes) in the body of the message
+ * | \%cr    | Number of characters (bytes) in the message, including header
  * | \%D     | Date and time of message using `$date_format` and local timezone
  * | \%d     | Date and time of message using `$date_format` and sender's timezone
  * | \%e     | Current message number in thread
@@ -656,7 +657,15 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
 
     case 'c':
       colorlen = add_index_color(buf, buflen, flags, MT_COLOR_INDEX_SIZE);
-      mutt_str_pretty_size(tmp, sizeof(tmp), email_size(e));
+      if (src[0] == 'r')
+      {
+        mutt_str_pretty_size(tmp, sizeof(tmp), email_size(e));
+        src++;
+      }
+      else
+      {
+        mutt_str_pretty_size(tmp, sizeof(tmp), e->content->length);
+      }
       mutt_format_s(buf + colorlen, buflen - colorlen, prec, tmp);
       add_index_color(buf + colorlen, buflen - colorlen, flags, MT_COLOR_INDEX);
       break;

--- a/init.h
+++ b/init.h
@@ -1857,7 +1857,8 @@ struct ConfigDef MuttVars[] = {
   ** .dt %b .dd Filename of the original message folder (think mailbox)
   ** .dt %B .dd The list to which the letter was sent, or else the folder name (%b).
   ** .dt %C .dd Current message number
-  ** .dt %c .dd Number of characters (bytes) in the message (see $formatstrings-size)
+  ** .dt %c .dd Number of characters (bytes) in the body of the message (see $formatstrings-size)
+  ** .dt %cr .dd Number of characters (bytes) in the raw message, including the header (see $formatstrings-size)
   ** .dt %D .dd Date and time of message using $date_format and local timezone
   ** .dt %d .dd Date and time of message using $date_format and sender's timezone
   ** .dt %e .dd Current message number in thread


### PR DESCRIPTION
Add a %cr expando to index_format to list the full email size (including
header). The previous %c expando provides the size of the mail body
instead.

Closes #1925.

@neomutt/reviewers This is my first commit, I would be glad about a review! In particular, I am not sure whether I updated the documentation in every necessary place. It would be great, if someone more experienced could check that... Also, do I need to run the `makedoc` script manually or is this automated (I couldn't figure out, how to run it anyway)?

* **What does this PR do?**

Adds the specified expando.

* **Screenshots (if relevant)**

* **Does this PR meet the acceptance criteria?** (This is just a reminder for you,
  this section can be removed if you fulfill it.)

   - Documentation created/updated (you have to edit
     [doc/manual.xml.head](https://www.github.com/neomutt/neomutt/blob/master/doc/manual.xml.head)
     for that)

   - All builds and tests are passing

   - Added [doxygen code documentation](https://neomutt.org/dev/doxygen)
     [syntax](http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html)

   - Code follows the [style guide](https://neomutt.org/dev/coding-style)

* **What are the relevant issue numbers?**
#1925 