### PR TITLE
Fix new_mail_command notifications

### DIFF
--- a/index.c
+++ b/index.c
@@ -1171,9 +1171,10 @@ int mutt_index_menu(void)
         }
         else if (check == MUTT_NEW_MAIL)
         {
-          for (size_t i = oldcount; i < Context->mailbox->msg_count; i++)
+          for (size_t i = 0; i < Context->mailbox->msg_count; i++)
           {
-            if (!Context->mailbox->emails[i]->read)
+            const struct Email * e= Context->mailbox->emails[i];
+            if (e && !e->read && !e->old)
             {
               mutt_message(_("New mail in this mailbox"));
               if (C_BeepNew)


### PR DESCRIPTION
The assumption that new emails would appear at the end of the
mailbox->emails array is wrong. Let's iterate the whole set of emails
until we find a new mail.

Fixes #1979
