### PR TITLE
tests: fix context for failing idna and date-related tests

### DIFF
--- a/test/address/mutt_addrlist_to_intl.c
+++ b/test/address/mutt_addrlist_to_intl.c
@@ -52,8 +52,11 @@ void test_mutt_addrlist_to_intl(void)
                          .intl = "test@xn--nixierhre-57a.nixieclock-tube.com" },
                        { .local = "test@வலைப்பூ.com", .intl = "test@xn--xlcawl2e7azb.com" } };
 
+    char *prev_charset = C_Charset;
     C_Charset = "utf-8";
 #ifdef HAVE_LIBIDN
+    bool prev_idn_encode = C_IdnEncode;
+    bool prev_idn_decode = C_IdnDecode;
     C_IdnEncode = true;
     C_IdnDecode = true;
 #endif
@@ -72,5 +75,10 @@ void test_mutt_addrlist_to_intl(void)
       TEST_CHECK_STR_EQ(local2intl[i].local, a->mailbox);
       mutt_addrlist_clear(&al);
     }
+    C_Charset = prev_charset;
+#ifdef HAVE_LIBIDN
+    C_IdnEncode = prev_idn_encode;
+    C_IdnDecode = prev_idn_decode;
+#endif
   }
 }

--- a/test/date/mutt_date_localtime.c
+++ b/test/date/mutt_date_localtime.c
@@ -58,6 +58,6 @@ void test_mutt_date_localtime(void)
   {
     TEST_CASE("Today");
     struct tm tm = mutt_date_localtime(MUTT_DATE_NOW);
-    TEST_CHECK(tm.tm_yday >= 119);
+    TEST_CHECK(tm.tm_year >= 119);
   }
 }

--- a/test/rfc2047/rfc2047_decode.c
+++ b/test/rfc2047/rfc2047_decode.c
@@ -38,7 +38,7 @@ void test_rfc2047_decode(void)
     TEST_MSG("Cannot set locale to (en_US|C).UTF-8");
     return;
   }
-
+  char *previous_charset = C_Charset;
   C_Charset = "utf-8";
 
   {
@@ -78,4 +78,6 @@ void test_rfc2047_decode(void)
       FREE(&s);
     }
   }
+
+  C_Charset = previous_charset;
 }

--- a/test/rfc2047/rfc2047_encode.c
+++ b/test/rfc2047/rfc2047_encode.c
@@ -38,7 +38,7 @@ void test_rfc2047_encode(void)
     TEST_MSG("Cannot set locale to (en_US|C).UTF-8");
     return;
   }
-
+  char *previous_charset = C_Charset;
   C_Charset = "utf-8";
 
   {
@@ -73,4 +73,6 @@ void test_rfc2047_encode(void)
       FREE(&s);
     }
   }
+
+  C_Charset = previous_charset;
 }


### PR DESCRIPTION
* **What does this PR do?**

This PR fixes two kind of test failures:
   - `test_mutt_idna_intl_to_local` and `test_mutt_idna_local_to_intl` fail when tests are run in a sandbox or with `--exec=never` because some variables like `C_Charset` are set to some values by other jobs and are not cleaned. `C_Charset`, `C_IdnEncode` and `C_IdnDecode` are now cleaned in the tests changing it.
   - a test is checking that the day of the year is always >= 119 which would cause it to fail when executed between Jan, 1st and Apr, 28th.

* **Screenshots (if relevant)**
N/A

* **What are the relevant issue numbers?**
N/A