### PR TITLE
fix: crash after failed mbox_check

### DIFF
--- a/context.c
+++ b/context.c
@@ -90,8 +90,10 @@ void ctx_cleanup(struct Context *ctx)
     notify_observer_remove(ctx->mailbox->notify, ctx_mailbox_observer, IP ctx);
 
   struct Notify *notify = ctx->notify;
+  struct Mailbox *m = ctx->mailbox;
   memset(ctx, 0, sizeof(struct Context));
   ctx->notify = notify;
+  ctx->mailbox = m;
 }
 
 /**

--- a/index.c
+++ b/index.c
@@ -1202,13 +1202,20 @@ int mutt_index_menu(void)
         /* avoid the message being overwritten by mailbox */
         do_mailbox_notify = false;
 
-        bool q = Context->mailbox->quiet;
-        Context->mailbox->quiet = true;
-        update_index(menu, Context, check, oldcount, index_hint);
-        Context->mailbox->quiet = q;
+        if (Context && Context->mailbox)
+        {
+          bool q = Context->mailbox->quiet;
+          Context->mailbox->quiet = true;
+          update_index(menu, Context, check, oldcount, index_hint);
+          Context->mailbox->quiet = q;
+          menu->max = Context->mailbox->vcount;
+        }
+        else
+        {
+          menu->max = 0;
+        }
 
         menu->redraw = REDRAW_FULL;
-        menu->max = Context->mailbox->vcount;
 
         OptSearchInvalid = true;
       }

--- a/mx.c
+++ b/mx.c
@@ -387,6 +387,7 @@ struct Context *mx_mbox_open(struct Mailbox *m, OpenMailboxFlags flags)
     goto error;
   }
 
+  m->has_new = false;
   OptForceRefresh = false;
 
   return ctx;
@@ -419,8 +420,6 @@ void mx_fastclose_mailbox(struct Mailbox *m)
 
   if (m->mx_ops)
     m->mx_ops->mbox_close(m);
-
-  mailbox_changed(m, MBN_CLOSED);
 
   mutt_hash_free(&m->subj_hash);
   mutt_hash_free(&m->id_hash);
@@ -592,7 +591,7 @@ int mx_mbox_close(struct Context **ptr)
   if (C_MailCheckRecent)
     m->has_new = false;
 
-  if (m->readonly || m->dontwrite || m->append)
+  if (m->readonly || m->dontwrite || m->append || m->peekonly)
   {
     mx_fastclose_mailbox(m);
     ctx_free(ptr);

--- a/pager.c
+++ b/pager.c
@@ -1951,8 +1951,11 @@ static void pager_custom_redraw(struct Menu *pager_menu)
     mutt_window_move_abs(0, 0);
     mutt_window_clrtobot();
 
-    if (IsEmail(rd->extra) && Context && ((Context->mailbox->vcount + 1) < C_PagerIndexLines))
+    if (IsEmail(rd->extra) && Context && Context->mailbox &&
+        ((Context->mailbox->vcount + 1) < C_PagerIndexLines))
+    {
       rd->indexlen = Context->mailbox->vcount + 1;
+    }
     else
       rd->indexlen = C_PagerIndexLines;
 
@@ -2412,7 +2415,7 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
 
         if ((check == MUTT_NEW_MAIL) || (check == MUTT_REOPENED))
         {
-          if (rd.menu && Context)
+          if (rd.menu && Context && Context->mailbox)
           {
             /* After the mailbox has been updated,
              * rd.menu->current might be invalid */


### PR DESCRIPTION
This is a mixed bag of small changes.

Importantly, it:
- Fixes: #1957 - crash when mbox is reopened
- Fixes: #1978 - 'new' flag not cleared

It also:
- 'peeks' when reopening mbox (to avoid losing stats)
- changes a couple of 'closed' notifications to 'update'
  they were causing bits of Mailbox to freed unnecessarily
- adds a number of pointer checks
