### PR TITLE
imap: fix crash when new mail arrives

### DIFF
--- a/imap/imap.c
+++ b/imap/imap.c
@@ -1029,8 +1029,9 @@ int imap_exec_msgset(struct Mailbox *m, const char *pre, const char *post,
   if (C_Sort != SORT_ORDER)
   {
     emails = m->emails;
-    m->emails = mutt_mem_malloc(m->msg_count * sizeof(struct Email *));
-    memcpy(m->emails, emails, m->msg_count * sizeof(struct Email *));
+    // We overcommit here, just in case new mail arrives whilst we're sync-ing
+    m->emails = mutt_mem_malloc(m->email_max * sizeof(struct Email *));
+    memcpy(m->emails, emails, m->email_max * sizeof(struct Email *));
 
     C_Sort = SORT_ORDER;
     qsort(m->emails, m->msg_count, sizeof(struct Email *), compare_uid);


### PR DESCRIPTION
The original code took a copy of the email array, sized exactly for the
number of emails.  If a new mail arrived during the sync process, the
array would overflow causing a crash.

The size of the email array is actually email_max.  This gives us a
little room for new mail.

Ideally read_headers_fetch_new() would resize the email array.

Either way leads to problems sync-ing the original array and notifying
the caller about the new mail.
