### PR TITLE
fix fcc for deep dirs

### DIFF
--- a/maildir/maildir.c
+++ b/maildir/maildir.c
@@ -309,7 +309,7 @@ static int maildir_mbox_open_append(struct Mailbox *m, OpenMailboxFlags flags)
   }
 
   errno = 0;
-  if ((mkdir(mailbox_path(m), S_IRWXU) != 0) && (errno != EEXIST))
+  if ((mutt_file_mkdir(mailbox_path(m), S_IRWXU) != 0) && (errno != EEXIST))
   {
     mutt_perror(mailbox_path(m));
     return -1;

--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -986,6 +986,16 @@ static int mbox_mbox_open_append(struct Mailbox *m, OpenMailboxFlags flags)
 
   if (!adata->fp)
   {
+    // create dir recursively
+    char *tmp_path = mutt_path_dirname(mailbox_path(m));
+    if (mutt_file_mkdir(tmp_path, S_IRWXU) == -1)
+    {
+      mutt_perror(mailbox_path(m));
+      FREE(&tmp_path);
+      return -1;
+    }
+    FREE(&tmp_path);
+
     adata->fp =
         mutt_file_fopen(mailbox_path(m), (flags & MUTT_NEWFOLDER) ? "w+" : "a+");
     if (!adata->fp)

--- a/sendlib.c
+++ b/sendlib.c
@@ -3471,7 +3471,8 @@ int mutt_write_fcc(const char *path, struct Email *e, const char *msgid,
     set_noconv_flags(e->content, false);
 
 done:
-  m_fcc->append = old_append;
+  if (m_fcc)
+    m_fcc->append = old_append;
 #ifdef RECORD_FOLDER_HOOK
   /* We ran a folder hook for the destination mailbox,
    * now we run it for the user's current mailbox */


### PR DESCRIPTION
Saving the sent-mail failed when the destination was a deep
non-existent directory.

Fixes: #1990 