### PR TITLE
Removes extra quoted level in bundled themes

### DIFF
--- a/contrib/colorschemes/vombatidae.neomuttrc
+++ b/contrib/colorschemes/vombatidae.neomuttrc
@@ -46,7 +46,6 @@ color quoted5       color36      color234
 color quoted6       color114     color234
 color quoted7       color109     color234
 color quoted8       color41      color234
-color quoted9       color138     color234
 
 # color body          cyan  default  "((ftp|http|https)://|news:)[^ >)\"\t]+"
 # color body          cyan  default  "[-a-z_0-9.+]+@[-a-z_0-9.]+"

--- a/contrib/colorschemes/zenburn.neomuttrc
+++ b/contrib/colorschemes/zenburn.neomuttrc
@@ -65,5 +65,3 @@ color quoted5    color247 color237
 color quoted6    color108 color237
 color quoted7    color116 color237
 color quoted8    color247 color237
-color quoted9    color108 color237
-


### PR DESCRIPTION
* **What does this PR do?**
It removes an invalid highlight group from two themes in the contrib folder.

When sourcing for instance zenburn, I get the following error:

```
Warning in /usr/share/doc/neomutt/colorschemes/zenburn.neomuttrc, line 68: Maximum quoting level is 8
```

I removed `quoted9` in the themes. I hope this is the way to go.