### PR TITLE
show notmuch library version

### DIFF
--- a/auto.def
+++ b/auto.def
@@ -239,16 +239,6 @@ if {1} {
     define SENDMAIL /usr/sbin/sendmail
   }
 
-  # Version of the C compiler
-  set CC [get-define CC]
-  if {[catch {exec $CC -v} cc_version]} {
-    if {[catch {exec $CC --version} cc_version]} {
-      if {[catch {exec $CC -V} cc_version]} {
-        set cc_version "unknown compiler"
-      }
-    }
-  }
-
   # GCC-specifc CFLAGS
   if {![catch {exec [get-define CC] --version} res]} {
     if {[regexp -nocase gcc $res]} {
@@ -1081,7 +1071,6 @@ if {[get-define want-gss]} {
 ###############################################################################
 # Generate conststrings.c
 set conststrings "\
-  unsigned char cc_version\[\] = {[text2c $cc_version]};\n\
   unsigned char cc_cflags\[\] = {[text2c [get-define CFLAGS]]};\n\
   unsigned char configure_options\[\] = {[text2c $conf_options]};\n"
 if {[catch {set fd [open conststrings.c w]

--- a/version.c
+++ b/version.c
@@ -389,8 +389,13 @@ static char *rstrip_in_place(char *s)
 void print_version(FILE *fp)
 {
   struct utsname uts;
+  bool tty = stdout ? isatty(fileno(stdout)) : false;
+  const char *fmt = "%s\n";
 
-  fprintf(fp, "%s\n", mutt_make_version());
+  if (tty)
+    fmt = "\033[1;36m%s\033[0m\n"; // Escape, cyan
+
+  fprintf(fp, fmt, mutt_make_version());
   fprintf(fp, "%s\n", _(Notice));
 
   uname(&uts);

--- a/version.c
+++ b/version.c
@@ -43,6 +43,9 @@
 #ifdef CRYPT_BACKEND_GPGME
 #include "ncrypt/crypt_gpgme.h"
 #endif
+#ifdef HAVE_NOTMUCH
+#include <notmuch.h>
+#endif
 
 /* #include "muttlib.h" */
 const char *mutt_make_version(void);
@@ -417,6 +420,11 @@ void print_version(FILE *fp)
 
 #ifdef CRYPT_BACKEND_GPGME
   fprintf(fp, "\nGPGme: %s", mutt_gpgme_print_version());
+#endif
+
+#ifdef HAVE_NOTMUCH
+  fprintf(fp, "\nlibnotmuch: %d.%d.%d", LIBNOTMUCH_MAJOR_VERSION,
+          LIBNOTMUCH_MINOR_VERSION, LIBNOTMUCH_MICRO_VERSION);
 #endif
 
 #ifdef USE_HCACHE

--- a/version.c
+++ b/version.c
@@ -54,7 +54,6 @@ const char *mutt_hcache_backend_list(void);
 
 const int SCREEN_WIDTH = 80;
 
-extern unsigned char cc_version[];
 extern unsigned char cc_cflags[];
 extern unsigned char configure_options[];
 
@@ -438,12 +437,8 @@ void print_version(FILE *fp)
   FREE(&backends);
 #endif
 
-  fputs("\n\nCompiler:\n", fp);
-  rstrip_in_place((char *) cc_version);
-  fprintf(fp, "%s\n", (char *) cc_version);
-
   rstrip_in_place((char *) configure_options);
-  fprintf(fp, "\nConfigure options: %s\n", (char *) configure_options);
+  fprintf(fp, "\n\nConfigure options: %s\n", (char *) configure_options);
 
   rstrip_in_place((char *) cc_cflags);
   fprintf(fp, "\nCompilation CFLAGS: %s\n", (char *) cc_cflags);


### PR DESCRIPTION
A trivial change, here.
Display the notmuch library version in the NeoMutt command-line version output.

On RHEL7 (LTS Redhat Version), I'm forced to build NeoMutt against an old version of the Notmuch libraries, due to dependency problems (Gmime 3.0, GPGMe 1.8.0).

We already display 'ncurses', 'libidn' and 'GPGme' library versions.

---

**Question**:

How do people feel about dropping the 'Compiler Version' info?

I've never found any occasion to need it?
(and it takes up a lot of space)