### PR TITLE
compose: draw status bar with highlights

### DIFF
--- a/compose.c
+++ b/compose.c
@@ -914,7 +914,7 @@ static void compose_custom_redraw(struct Menu *menu)
                         NONULL(C_ComposeFormat));
     mutt_window_move(menu->statuswin, 0, 0);
     mutt_curses_set_color(MT_COLOR_STATUS);
-    mutt_paddstr(menu->statuswin->cols, buf);
+    mutt_draw_statusline(menu->statuswin->cols, buf, sizeof(buf));
     mutt_curses_set_color(MT_COLOR_NORMAL);
     menu->redraw &= ~REDRAW_STATUS;
   }


### PR DESCRIPTION
* **What does this PR do?**
In compose menu, status bar was drawn without highlights applied. Now, it can be colorized with `color status ...`, just like every other status bars.

Not sure why it worked like this before.