### PR TITLE
compose: fix attach message

### DIFF
--- a/mx.c
+++ b/mx.c
@@ -304,6 +304,12 @@ struct Context *mx_mbox_open(struct Mailbox *m, OpenMailboxFlags flags)
     m->readonly = true;
   m->peekonly = (flags & MUTT_PEEK);
 
+  if (m->opened > 0)
+  {
+    m->opened++;
+    return ctx;
+  }
+
   if (flags & (MUTT_APPEND | MUTT_NEWFOLDER))
   {
     if (mx_open_mailbox_append(ctx->mailbox, flags) != 0)


### PR DESCRIPTION
This fixes some problems when attaching an Email in compose.
 
- Shortcut re-opening a Mailbox
  Re-opening an already open Mailbox wastes time (and confuses IMAP)

- Restore read-only flag afterwards
  (after attaching, the Mailbox was being left read-only)
  