### PR TITLE
Try to infer the signing key from the From address

### DIFF
--- a/ncrypt/crypt.c
+++ b/ncrypt/crypt.c
@@ -365,7 +365,7 @@ int mutt_protect(struct Email *e, char *keylist, bool postpone)
 
     if (((WithCrypto & APPLICATION_PGP) != 0) && (security & APPLICATION_PGP))
     {
-      pbody = crypt_pgp_encrypt_message(e, tmp_pgp_pbody, keylist, sign);
+      pbody = crypt_pgp_encrypt_message(e, tmp_pgp_pbody, keylist, sign, &e->env->from);
       if (!pbody)
       {
         /* did we perform a retainable signature? */

--- a/ncrypt/crypt.c
+++ b/ncrypt/crypt.c
@@ -315,7 +315,7 @@ int mutt_protect(struct Email *e, char *keylist, bool postpone)
   {
     if (((WithCrypto & APPLICATION_SMIME) != 0) && (security & APPLICATION_SMIME))
     {
-      tmp_pbody = crypt_smime_sign_message(e->content);
+      tmp_pbody = crypt_smime_sign_message(e->content, &e->env->from);
       if (!tmp_pbody)
         goto bail;
       pbody = tmp_pbody;
@@ -325,7 +325,7 @@ int mutt_protect(struct Email *e, char *keylist, bool postpone)
     if (((WithCrypto & APPLICATION_PGP) != 0) && (security & APPLICATION_PGP) &&
         (!(security & (SEC_ENCRYPT | SEC_AUTOCRYPT)) || C_PgpRetainableSigs))
     {
-      tmp_pbody = crypt_pgp_sign_message(e->content);
+      tmp_pbody = crypt_pgp_sign_message(e->content, &e->env->from);
       if (!tmp_pbody)
         goto bail;
 

--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -1166,48 +1166,34 @@ static gpgme_key_t *create_recipient_set(const char *keylist, bool use_smime)
 #endif /* GPGME_VERSION_NUMBER >= 0x010b00 */
 
 /**
- * set_signer - Make sure that the correct signer is set
+ * set_signer_from_address - Try to set the context's signer from the address
  * @param ctx       GPGME handle
+ * @param address   Address to try to set as a signer
  * @param for_smime Use S/MIME
- * @retval  0 Success
- * @retval -1 Error
+ * @retval true     Address was set as a signer
+ * @retval false    Address could not be set as a signer
  */
-static int set_signer(gpgme_ctx_t ctx, bool for_smime)
+static bool set_signer_from_address(gpgme_ctx_t ctx, const char * address, bool for_smime)
 {
-  char *signid = NULL;
   gpgme_error_t err;
-  gpgme_ctx_t listctx = NULL;
   gpgme_key_t key = NULL, key2 = NULL;
-  char *fpr = NULL, *fpr2 = NULL;
-
-  if (for_smime)
-    signid = C_SmimeSignAs ? C_SmimeSignAs : C_SmimeDefaultKey;
-#ifdef USE_AUTOCRYPT
-  else if (OptAutocryptGpgme)
-    signid = AutocryptSignAs;
-#endif
-  else
-    signid = C_PgpSignAs ? C_PgpSignAs : C_PgpDefaultKey;
-
-  if (!signid)
-    return 0;
-
-  listctx = create_gpgme_context(for_smime);
-  err = gpgme_op_keylist_start(listctx, signid, 1);
+  gpgme_ctx_t listctx = create_gpgme_context(for_smime);
+  err = gpgme_op_keylist_start(listctx, address, 1);
   if (err == 0)
     err = gpgme_op_keylist_next(listctx, &key);
   if (err)
   {
     gpgme_release(listctx);
-    mutt_error(_("secret key '%s' not found: %s"), signid, gpgme_strerror(err));
-    return -1;
+    mutt_error(_("secret key '%s' not found: %s"), address, gpgme_strerror(err));
+    return false;
   }
-  fpr = "fpr1";
+
+  char *fpr = "fpr1";
   if (key->subkeys)
     fpr = key->subkeys->fpr ? key->subkeys->fpr : key->subkeys->keyid;
   while (gpgme_op_keylist_next(listctx, &key2) == 0)
   {
-    fpr2 = "fpr2";
+    char *fpr2 = "fpr2";
     if (key2->subkeys)
       fpr2 = key2->subkeys->fpr ? key2->subkeys->fpr : key2->subkeys->keyid;
     if (mutt_str_strcmp(fpr, fpr2))
@@ -1215,8 +1201,8 @@ static int set_signer(gpgme_ctx_t ctx, bool for_smime)
       gpgme_key_unref(key);
       gpgme_key_unref(key2);
       gpgme_release(listctx);
-      mutt_error(_("ambiguous specification of secret key '%s'\n"), signid);
-      return -1;
+      mutt_error(_("ambiguous specification of secret key '%s'\n"), address);
+      return false;
     }
     else
     {
@@ -1231,10 +1217,53 @@ static int set_signer(gpgme_ctx_t ctx, bool for_smime)
   gpgme_key_unref(key);
   if (err)
   {
-    mutt_error(_("error setting secret key '%s': %s"), signid, gpgme_strerror(err));
-    return -1;
+    mutt_error(_("error setting secret key '%s': %s"), address, gpgme_strerror(err));
+    return false;
   }
-  return 0;
+  return true;
+}
+
+/**
+ * set_signer - Make sure that the correct signer is set
+ * @param ctx       GPGME handle
+ * @param al        From AddressList
+ * @param for_smime Use S/MIME
+ * @retval  0 Success
+ * @retval -1 Error
+ */
+static int set_signer(gpgme_ctx_t ctx, const struct AddressList * al, bool for_smime)
+{
+  char *signid = NULL;
+
+  if (for_smime)
+    signid = C_SmimeSignAs ? C_SmimeSignAs : C_SmimeDefaultKey;
+#ifdef USE_AUTOCRYPT
+  else if (OptAutocryptGpgme)
+    signid = AutocryptSignAs;
+#endif
+  else
+    signid = C_PgpSignAs ? C_PgpSignAs : C_PgpDefaultKey;
+
+  /* Try getting the signing key from config entries */
+  if (signid && set_signer_from_address(ctx, signid, for_smime))
+  {
+    return 0;
+  }
+
+  /* Try getting the signing key from the From line */
+  if (al)
+  {
+    struct Address *a;
+    TAILQ_FOREACH(a, al, entries)
+    {
+      if (a->mailbox && set_signer_from_address(ctx, a->mailbox, for_smime))
+      {
+        return 0;
+      }
+    }
+  }
+
+  return (!signid && !al) ? 0 : -1;
 }
 
 /**
@@ -1291,7 +1320,7 @@ static char *encrypt_gpgme_object(gpgme_data_t plaintext, char *keylist,
 
   if (combined_signed)
   {
-    if (set_signer(ctx, use_smime))
+    if (set_signer(ctx, NULL, use_smime))
       goto cleanup;
 
     if (C_CryptUsePka)
@@ -1398,11 +1427,12 @@ static void print_time(time_t t, struct State *s)
 /**
  * sign_message - Sign a message
  * @param a         Message to sign
+ * @param from      The From header line
  * @param use_smime If set, use SMIME instead of PGP
  * @retval ptr  new Body
  * @retval NULL error
  */
-static struct Body *sign_message(struct Body *a, bool use_smime)
+static struct Body *sign_message(struct Body *a, const struct AddressList *from, bool use_smime)
 {
   struct Body *t = NULL;
   char *sigfile = NULL;
@@ -1423,7 +1453,7 @@ static struct Body *sign_message(struct Body *a, bool use_smime)
   if (!use_smime)
     gpgme_set_armor(ctx, 1);
 
-  if (set_signer(ctx, use_smime))
+  if (set_signer(ctx, from, use_smime))
   {
     gpgme_data_release(signature);
     gpgme_data_release(message);
@@ -1523,17 +1553,17 @@ static struct Body *sign_message(struct Body *a, bool use_smime)
 /**
  * pgp_gpgme_sign_message - Implements CryptModuleSpecs::sign_message()
  */
-struct Body *pgp_gpgme_sign_message(struct Body *a)
+struct Body *pgp_gpgme_sign_message(struct Body *a, const struct AddressList *from)
 {
-  return sign_message(a, false);
+  return sign_message(a, from, false);
 }
 
 /**
  * smime_gpgme_sign_message - Implements CryptModuleSpecs::sign_message()
  */
-struct Body *smime_gpgme_sign_message(struct Body *a)
+struct Body *smime_gpgme_sign_message(struct Body *a, const struct AddressList *from)
 {
-  return sign_message(a, true);
+  return sign_message(a, from, true);
 }
 
 /**

--- a/ncrypt/crypt_gpgme.h
+++ b/ncrypt/crypt_gpgme.h
@@ -40,7 +40,7 @@ int          pgp_gpgme_application_handler(struct Body *m, struct State *s);
 int          pgp_gpgme_check_traditional(FILE *fp, struct Body *b, bool just_one);
 int          pgp_gpgme_decrypt_mime(FILE *fp_in, FILE **fp_out, struct Body *b, struct Body **cur);
 int          pgp_gpgme_encrypted_handler(struct Body *a, struct State *s);
-struct Body *pgp_gpgme_encrypt_message(struct Body *a, char *keylist, bool sign);
+struct Body *pgp_gpgme_encrypt_message(struct Body *a, char *keylist, bool sign, const struct AddressList *from);
 char *       pgp_gpgme_find_keys(struct AddressList *addrlist, bool oppenc_mode);
 void         pgp_gpgme_init(void);
 void         pgp_gpgme_invoke_import(const char *fname);

--- a/ncrypt/crypt_gpgme.h
+++ b/ncrypt/crypt_gpgme.h
@@ -46,7 +46,7 @@ void         pgp_gpgme_init(void);
 void         pgp_gpgme_invoke_import(const char *fname);
 struct Body *pgp_gpgme_make_key_attachment(void);
 int          pgp_gpgme_send_menu(struct Email *e);
-struct Body *pgp_gpgme_sign_message(struct Body *a);
+struct Body *pgp_gpgme_sign_message(struct Body *a, const struct AddressList *from);
 int          pgp_gpgme_verify_one(struct Body *sigbdy, struct State *s, const char *tempfile);
 
 int          smime_gpgme_application_handler(struct Body *a, struct State *s);
@@ -55,7 +55,7 @@ int          smime_gpgme_decrypt_mime(FILE *fp_in, FILE **fp_out, struct Body *b
 char *       smime_gpgme_find_keys(struct AddressList *addrlist, bool oppenc_mode);
 void         smime_gpgme_init(void);
 int          smime_gpgme_send_menu(struct Email *e);
-struct Body *smime_gpgme_sign_message(struct Body *a);
+struct Body *smime_gpgme_sign_message(struct Body *a, const struct AddressList *from);
 int          smime_gpgme_verify_one(struct Body *sigbdy, struct State *s, const char *tempfile);
 int          smime_gpgme_verify_sender(struct Mailbox *m, struct Email *e);
 

--- a/ncrypt/crypt_mod.h
+++ b/ncrypt/crypt_mod.h
@@ -133,12 +133,14 @@ struct CryptModuleSpecs
    * @param a       Body of email to encrypt
    * @param keylist List of keys, or fingerprints (space separated)
    * @param sign    If true, sign the message too
+   * @param from    From line, to choose the key to sign
    * @retval ptr  Encrypted Body
    * @retval NULL Error
    *
    * Encrypt the mail body to all the given keys.
    */
-  struct Body *(*pgp_encrypt_message)(struct Body *a, char *keylist, bool sign);
+  struct Body *(*pgp_encrypt_message)(struct Body *a, char *keylist, bool sign,
+                                     const struct AddressList *from);
   /**
    * pgp_make_key_attachment - Generate a public key attachment
    * @retval ptr  New Body containing the attachment

--- a/ncrypt/crypt_mod.h
+++ b/ncrypt/crypt_mod.h
@@ -102,10 +102,11 @@ struct CryptModuleSpecs
   /**
    * sign_message - Cryptographically sign the Body of a message
    * @param a Body of the message
+   * @param from From line
    * @retval ptr  New encrypted Body
    * @retval NULL Error
    */
-  struct Body *(*sign_message)(struct Body *a);
+  struct Body *(*sign_message)(struct Body *a, const struct AddressList *from);
   /**
    * verify_one - Check a signed MIME part against a signature
    * @param sigbdy Body of the signed mail

--- a/ncrypt/cryptglue.c
+++ b/ncrypt/cryptglue.c
@@ -329,7 +329,9 @@ struct Body *crypt_pgp_sign_message(struct Body *a, const struct AddressList *fr
 /**
  * crypt_pgp_encrypt_message - Wrapper for CryptModuleSpecs::pgp_encrypt_message()
  */
-struct Body *crypt_pgp_encrypt_message(struct Email *e, struct Body *a, char *keylist, int sign)
+struct Body *crypt_pgp_encrypt_message(struct Email *e, struct Body *a,
+                                       char *keylist, int sign,
+                                       const struct AddressList *from)
 {
 #ifdef USE_AUTOCRYPT
   if (e->security & SEC_AUTOCRYPT)
@@ -338,7 +340,7 @@ struct Body *crypt_pgp_encrypt_message(struct Email *e, struct Body *a, char *ke
       return NULL;
 
     OptAutocryptGpgme = true;
-    struct Body *result = pgp_gpgme_encrypt_message(a, keylist, sign);
+    struct Body *result = pgp_gpgme_encrypt_message(a, keylist, sign, from);
     OptAutocryptGpgme = false;
 
     return result;
@@ -346,7 +348,7 @@ struct Body *crypt_pgp_encrypt_message(struct Email *e, struct Body *a, char *ke
 #endif
 
   if (CRYPT_MOD_CALL_CHECK(PGP, pgp_encrypt_message))
-    return CRYPT_MOD_CALL(PGP, pgp_encrypt_message)(a, keylist, sign);
+    return CRYPT_MOD_CALL(PGP, pgp_encrypt_message)(a, keylist, sign, from);
 
   return NULL;
 }

--- a/ncrypt/cryptglue.c
+++ b/ncrypt/cryptglue.c
@@ -318,10 +318,10 @@ char *crypt_pgp_find_keys(struct AddressList *addrlist, bool oppenc_mode)
 /**
  * crypt_pgp_sign_message - Wrapper for CryptModuleSpecs::sign_message()
  */
-struct Body *crypt_pgp_sign_message(struct Body *a)
+struct Body *crypt_pgp_sign_message(struct Body *a, const struct AddressList *from)
 {
   if (CRYPT_MOD_CALL_CHECK(PGP, sign_message))
-    return CRYPT_MOD_CALL(PGP, sign_message)(a);
+    return CRYPT_MOD_CALL(PGP, sign_message)(a, from);
 
   return NULL;
 }
@@ -478,10 +478,10 @@ char *crypt_smime_find_keys(struct AddressList *addrlist, bool oppenc_mode)
 /**
  * crypt_smime_sign_message - Wrapper for CryptModuleSpecs::sign_message()
  */
-struct Body *crypt_smime_sign_message(struct Body *a)
+struct Body *crypt_smime_sign_message(struct Body *a, const struct AddressList *from)
 {
   if (CRYPT_MOD_CALL_CHECK(SMIME, sign_message))
-    return CRYPT_MOD_CALL(SMIME, sign_message)(a);
+    return CRYPT_MOD_CALL(SMIME, sign_message)(a, from);
 
   return NULL;
 }

--- a/ncrypt/cryptglue.h
+++ b/ncrypt/cryptglue.h
@@ -35,7 +35,7 @@ struct Body *crypt_pgp_encrypt_message(struct Email *e, struct Body *a, char *ke
 char *       crypt_pgp_find_keys(struct AddressList *al, bool oppenc_mode);
 void         crypt_pgp_invoke_import(const char *fname);
 void         crypt_pgp_set_sender(const char *sender);
-struct Body *crypt_pgp_sign_message(struct Body *a);
+struct Body *crypt_pgp_sign_message(struct Body *a, const struct AddressList *from);
 struct Body *crypt_pgp_traditional_encryptsign(struct Body *a, int flags, char *keylist);
 bool         crypt_pgp_valid_passphrase(void);
 int          crypt_pgp_verify_one(struct Body *sigbdy, struct State *s, const char *tempf);
@@ -45,7 +45,7 @@ struct Body *crypt_smime_build_smime_entity(struct Body *a, char *certlist);
 char *       crypt_smime_find_keys(struct AddressList *al, bool oppenc_mode);
 void         crypt_smime_invoke_import(const char *infile, const char *mailbox);
 void         crypt_smime_set_sender(const char *sender);
-struct Body *crypt_smime_sign_message(struct Body *a);
+struct Body *crypt_smime_sign_message(struct Body *a, const struct AddressList *from);
 bool         crypt_smime_valid_passphrase(void);
 int          crypt_smime_verify_one(struct Body *sigbdy, struct State *s, const char *tempf);
 void         crypt_smime_void_passphrase(void);

--- a/ncrypt/cryptglue.h
+++ b/ncrypt/cryptglue.h
@@ -31,7 +31,7 @@ struct Body;
 struct Email;
 struct State;
 
-struct Body *crypt_pgp_encrypt_message(struct Email *e, struct Body *a, char *keylist, int sign);
+struct Body *crypt_pgp_encrypt_message(struct Email *e, struct Body *a, char *keylist, int sign, const struct AddressList *from);
 char *       crypt_pgp_find_keys(struct AddressList *al, bool oppenc_mode);
 void         crypt_pgp_invoke_import(const char *fname);
 void         crypt_pgp_set_sender(const char *sender);

--- a/ncrypt/pgp.c
+++ b/ncrypt/pgp.c
@@ -1543,7 +1543,7 @@ char *pgp_class_find_keys(struct AddressList *addrlist, bool oppenc_mode)
  * @warning "a" is no longer freed in this routine, you need to free it later.
  * This is necessary for $fcc_attach.
  */
-struct Body *pgp_class_encrypt_message(struct Body *a, char *keylist, bool sign)
+struct Body *pgp_class_encrypt_message(struct Body *a, char *keylist, bool sign, const struct AddressList *from)
 {
   char buf[1024];
   FILE *fp_pgp_in = NULL, *fp_tmp = NULL;

--- a/ncrypt/pgp.c
+++ b/ncrypt/pgp.c
@@ -1291,7 +1291,7 @@ int pgp_class_encrypted_handler(struct Body *a, struct State *s)
 /**
  * pgp_class_sign_message - Implements CryptModuleSpecs::sign_message()
  */
-struct Body *pgp_class_sign_message(struct Body *a)
+struct Body *pgp_class_sign_message(struct Body *a, const struct AddressList *from)
 {
   struct Body *t = NULL, *rv = NULL;
   char buf[1024];

--- a/ncrypt/pgp.h
+++ b/ncrypt/pgp.h
@@ -58,7 +58,7 @@ bool pgp_class_valid_passphrase(void);
 
 int pgp_class_verify_one(struct Body *sigbdy, struct State *s, const char *tempfile);
 struct Body *pgp_class_traditional_encryptsign(struct Body *a, SecurityFlags flags, char *keylist);
-struct Body *pgp_class_encrypt_message(struct Body *a, char *keylist, bool sign);
+struct Body *pgp_class_encrypt_message(struct Body *a, char *keylist, bool sign, const struct AddressList *from);
 struct Body *pgp_class_sign_message(struct Body *a, const struct AddressList *from);
 
 int pgp_class_send_menu(struct Email *e);

--- a/ncrypt/pgp.h
+++ b/ncrypt/pgp.h
@@ -59,7 +59,7 @@ bool pgp_class_valid_passphrase(void);
 int pgp_class_verify_one(struct Body *sigbdy, struct State *s, const char *tempfile);
 struct Body *pgp_class_traditional_encryptsign(struct Body *a, SecurityFlags flags, char *keylist);
 struct Body *pgp_class_encrypt_message(struct Body *a, char *keylist, bool sign);
-struct Body *pgp_class_sign_message(struct Body *a);
+struct Body *pgp_class_sign_message(struct Body *a, const struct AddressList *from);
 
 int pgp_class_send_menu(struct Email *e);
 

--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -1709,7 +1709,7 @@ static char *openssl_md_to_smime_micalg(char *md)
 /**
  * smime_class_sign_message - Implements CryptModuleSpecs::sign_message()
  */
-struct Body *smime_class_sign_message(struct Body *a)
+struct Body *smime_class_sign_message(struct Body *a, const struct AddressList *from)
 {
   struct Body *t = NULL;
   struct Body *retval = NULL;

--- a/ncrypt/smime.h
+++ b/ncrypt/smime.h
@@ -62,7 +62,7 @@ char *       smime_class_find_keys(struct AddressList *addrlist, bool oppenc_mod
 void         smime_class_getkeys(struct Envelope *env);
 void         smime_class_invoke_import(const char *infile, const char *mailbox);
 int          smime_class_send_menu(struct Email *e);
-struct Body *smime_class_sign_message(struct Body *a);
+struct Body *smime_class_sign_message(struct Body *a, const struct AddressList *from);
 bool         smime_class_valid_passphrase(void);
 int          smime_class_verify_one(struct Body *sigbdy, struct State *s, const char *tempfile);
 int          smime_class_verify_sender(struct Mailbox *m, struct Email *e);


### PR DESCRIPTION
Currently, when running without autocrypt support, the signing key is
specified statically via settings such as pgp_sign_as / smime_sign_as
and pgp_default_key / smime_default_key. This makes it impractical to
select a signing key based on the address that is being used to send the
email. This is especially true when the From header is set manually via
edit_headers or in the compose screen.

This commit changes the ncrypt API to accept an AddressList as part of
the signing process. This AddressList consists of the addresses in the
From header and is used to help locate a signing key, if none can be
found using the static settings.

Note that only the GPGMe backend supports this new functionality. I am
not touching the GPG backend.