### PR TITLE
Avoid logging single new lines at the end of header fields

### DIFF
--- a/curs_lib.c
+++ b/curs_lib.c
@@ -1288,13 +1288,24 @@ int mutt_strwidth(const char *s)
 {
   if (!s)
     return 0;
+  return mutt_strnwidth(s, mutt_str_strlen(s));
+}
+
+/**
+ * mutt_strwidth - Measure a string's width in screen cells
+ * @param s String to be measured
+ * @param n Length of string to be measured
+ * @retval num Screen cells string would use
+ */
+int mutt_strnwidth(const char *s, size_t n)
+{
+  if (!s)
+    return 0;
 
   wchar_t wc;
   int w;
   size_t k;
   mbstate_t mbstate;
-
-  size_t n = mutt_str_strlen(s);
 
   memset(&mbstate, 0, sizeof(mbstate));
   for (w = 0; n && (k = mbrtowc(&wc, s, n, &mbstate)); s += k, n -= k)

--- a/curs_lib.h
+++ b/curs_lib.h
@@ -76,6 +76,7 @@ void         mutt_refresh(void);
 void         mutt_show_error(void);
 void         mutt_simple_format(char *buf, size_t buflen, int min_width, int max_width, enum FormatJustify justify, char pad_char, const char *s, size_t n, bool arboreal);
 int          mutt_strwidth(const char *s);
+int          mutt_strnwidth(const char *s, size_t len);
 void         mutt_unget_event(int ch, int op);
 void         mutt_unget_string(const char *s);
 size_t       mutt_wstr_trunc(const char *src, size_t maxlen, size_t maxwid, size_t *width);


### PR DESCRIPTION
This commit reorganizes a bit the logging around write_one_header, so
that "too long" messages are only printed when the header is actually
too long, and new lines at the end of header lines do not get emitted by
them selves in the log.
