### PR TITLE
Nest Windows

### DIFF
--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -70,7 +70,8 @@ NEOMUTTOBJS=	addrbook.o alias.o bcache.o browser.o color.o commands.o \
 		mutt_parse.o mutt_signal.o mutt_socket.o mutt_thread.o mutt_window.o \
 		muttlib.o mx.o myvar.o pager.o pattern.o postpone.o progress.o query.o \
 		recvattach.o recvcmd.o resize.o rfc3676.o score.o send.o sendlib.o \
-		sidebar.o smtp.o sort.o state.o status.o system.o terminal.o version.o
+		sidebar.o smtp.o sort.o state.o status.o system.o terminal.o version.o \
+		reflow.o
 @if HAVE_LIBUNWIND
 NEOMUTTOBJS+=	backtrace.o
 @endif

--- a/addrbook.c
+++ b/addrbook.c
@@ -110,7 +110,7 @@ static const char *alias_format_str(char *buf, size_t buflen, size_t col, int co
  */
 static void alias_make_entry(char *buf, size_t buflen, struct Menu *menu, int line)
 {
-  mutt_expando_format(buf, buflen, 0, menu->indexwin->cols,
+  mutt_expando_format(buf, buflen, 0, menu->win_index->cols,
                       NONULL(C_AliasFormat), alias_format_str,
                       (unsigned long) ((struct Alias **) menu->data)[line],
                       MUTT_FORMAT_ARROWCURSOR);

--- a/addrbook.c
+++ b/addrbook.c
@@ -110,7 +110,7 @@ static const char *alias_format_str(char *buf, size_t buflen, size_t col, int co
  */
 static void alias_make_entry(char *buf, size_t buflen, struct Menu *menu, int line)
 {
-  mutt_expando_format(buf, buflen, 0, menu->win_index->cols,
+  mutt_expando_format(buf, buflen, 0, menu->win_index->state.cols,
                       NONULL(C_AliasFormat), alias_format_str,
                       (unsigned long) ((struct Alias **) menu->data)[line],
                       MUTT_FORMAT_ARROWCURSOR);

--- a/autocrypt/autocrypt_acct_menu.c
+++ b/autocrypt/autocrypt_acct_menu.c
@@ -159,7 +159,7 @@ static void account_entry(char *buf, size_t buflen, struct Menu *menu, int num)
 {
   struct AccountEntry *entry = &((struct AccountEntry *) menu->data)[num];
 
-  mutt_expando_format(buf, buflen, 0, menu->win_index->cols,
+  mutt_expando_format(buf, buflen, 0, menu->win_index->state.cols,
                       NONULL(C_AutocryptAcctFormat), account_format_str,
                       (unsigned long) entry, MUTT_FORMAT_ARROWCURSOR);
 }

--- a/autocrypt/autocrypt_acct_menu.c
+++ b/autocrypt/autocrypt_acct_menu.c
@@ -159,7 +159,7 @@ static void account_entry(char *buf, size_t buflen, struct Menu *menu, int num)
 {
   struct AccountEntry *entry = &((struct AccountEntry *) menu->data)[num];
 
-  mutt_expando_format(buf, buflen, 0, menu->indexwin->cols,
+  mutt_expando_format(buf, buflen, 0, menu->win_index->cols,
                       NONULL(C_AutocryptAcctFormat), account_format_str,
                       (unsigned long) entry, MUTT_FORMAT_ARROWCURSOR);
 }

--- a/autocrypt/autocrypt_acct_menu.c
+++ b/autocrypt/autocrypt_acct_menu.c
@@ -271,9 +271,38 @@ void mutt_autocrypt_account_menu(void)
   if (mutt_autocrypt_init(false))
     return;
 
+  struct MuttWindow *dlg =
+      mutt_window_new(MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
+                      MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
+  dlg->type = WT_DIALOG;
+  struct MuttWindow *index =
+      mutt_window_new(MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
+                      MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
+  index->type = WT_INDEX;
+  struct MuttWindow *ibar = mutt_window_new(
+      MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_FIXED, 1, MUTT_WIN_SIZE_UNLIMITED);
+  ibar->type = WT_INDEX_BAR;
+
+  if (C_StatusOnTop)
+  {
+    mutt_window_add_child(dlg, ibar);
+    mutt_window_add_child(dlg, index);
+  }
+  else
+  {
+    mutt_window_add_child(dlg, index);
+    mutt_window_add_child(dlg, ibar);
+  }
+
+  dialog_push(dlg);
+
   struct Menu *menu = create_menu();
   if (!menu)
     return;
+
+  menu->pagelen = index->state.rows;
+  menu->win_index = index;
+  menu->win_ibar = ibar;
 
   bool done = false;
   while (!done)
@@ -289,6 +318,9 @@ void mutt_autocrypt_account_menu(void)
         {
           menu_free(&menu);
           menu = create_menu();
+          menu->pagelen = index->state.rows;
+          menu->win_index = index;
+          menu->win_ibar = ibar;
         }
         break;
 
@@ -307,6 +339,9 @@ void mutt_autocrypt_account_menu(void)
           {
             menu_free(&menu);
             menu = create_menu();
+            menu->pagelen = index->state.rows;
+            menu->win_index = index;
+            menu->win_ibar = ibar;
           }
         }
         break;
@@ -332,4 +367,6 @@ void mutt_autocrypt_account_menu(void)
   }
 
   menu_free(&menu);
+  dialog_pop();
+  mutt_window_free(&dlg);
 }

--- a/browser.c
+++ b/browser.c
@@ -957,14 +957,14 @@ static void folder_make_entry(char *buf, size_t buflen, struct Menu *menu, int l
 #ifdef USE_NNTP
   if (OptNews)
   {
-    mutt_expando_format(buf, buflen, 0, menu->win_index->cols,
+    mutt_expando_format(buf, buflen, 0, menu->win_index->state.cols,
                         NONULL(C_GroupIndexFormat), group_index_format_str,
                         (unsigned long) &folder, MUTT_FORMAT_ARROWCURSOR);
   }
   else
 #endif
   {
-    mutt_expando_format(buf, buflen, 0, menu->win_index->cols,
+    mutt_expando_format(buf, buflen, 0, menu->win_index->state.cols,
                         NONULL(C_FolderFormat), folder_format_str,
                         (unsigned long) &folder, MUTT_FORMAT_ARROWCURSOR);
   }

--- a/browser.c
+++ b/browser.c
@@ -957,14 +957,14 @@ static void folder_make_entry(char *buf, size_t buflen, struct Menu *menu, int l
 #ifdef USE_NNTP
   if (OptNews)
   {
-    mutt_expando_format(buf, buflen, 0, menu->indexwin->cols,
+    mutt_expando_format(buf, buflen, 0, menu->win_index->cols,
                         NONULL(C_GroupIndexFormat), group_index_format_str,
                         (unsigned long) &folder, MUTT_FORMAT_ARROWCURSOR);
   }
   else
 #endif
   {
-    mutt_expando_format(buf, buflen, 0, menu->indexwin->cols,
+    mutt_expando_format(buf, buflen, 0, menu->win_index->cols,
                         NONULL(C_FolderFormat), folder_format_str,
                         (unsigned long) &folder, MUTT_FORMAT_ARROWCURSOR);
   }
@@ -1985,7 +1985,7 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
           struct Body *b = mutt_make_file_attach(buf2);
           if (b)
           {
-            mutt_view_attachment(NULL, b, MUTT_VA_REGULAR, NULL, NULL, menu->indexwin);
+            mutt_view_attachment(NULL, b, MUTT_VA_REGULAR, NULL, NULL, menu->win_index);
             mutt_body_free(&b);
             menu->redraw = REDRAW_FULL;
           }

--- a/commands.c
+++ b/commands.c
@@ -208,7 +208,7 @@ int mutt_display_message(struct MuttWindow *win, struct Mailbox *m, struct Email
   mutt_message_hook(m, e, MUTT_MESSAGE_HOOK);
 
   char columns[16];
-  snprintf(columns, sizeof(columns), "%d", win->cols);
+  snprintf(columns, sizeof(columns), "%d", win->state.cols);
   mutt_envlist_set("COLUMNS", columns, true);
 
   /* see if crypto is needed for this message.  if so, we should exit curses */
@@ -284,8 +284,8 @@ int mutt_display_message(struct MuttWindow *win, struct Mailbox *m, struct Email
     hfi.mailbox = m;
     hfi.pager_progress = ExtPagerProgress;
     hfi.email = e;
-    mutt_make_string_info(buf, sizeof(buf), win->cols, NONULL(C_PagerFormat),
-                          &hfi, MUTT_FORMAT_NO_FLAGS);
+    mutt_make_string_info(buf, sizeof(buf), win->state.cols,
+                          NONULL(C_PagerFormat), &hfi, MUTT_FORMAT_NO_FLAGS);
     fputs(buf, fp_out);
     fputs("\n\n", fp_out);
   }
@@ -295,7 +295,7 @@ int mutt_display_message(struct MuttWindow *win, struct Mailbox *m, struct Email
   if (m->magic == MUTT_NOTMUCH)
     chflags |= CH_VIRTUAL;
 #endif
-  res = mutt_copy_message(fp_out, m, e, cmflags, chflags, win->cols);
+  res = mutt_copy_message(fp_out, m, e, cmflags, chflags, win->state.cols);
 
   if (((mutt_file_fclose(&fp_out) != 0) && (errno != EPIPE)) || (res < 0))
   {
@@ -454,9 +454,9 @@ void ci_bounce_message(struct Mailbox *m, struct EmailList *el)
   snprintf(scratch, sizeof(scratch),
            ngettext("Bounce message to %s?", "Bounce messages to %s?", msg_count), buf);
 
-  if (mutt_strwidth(scratch) > MuttMessageWindow->cols - EXTRA_SPACE)
+  if (mutt_strwidth(scratch) > MuttMessageWindow->state.cols - EXTRA_SPACE)
   {
-    mutt_simple_format(prompt, sizeof(prompt), 0, MuttMessageWindow->cols - EXTRA_SPACE,
+    mutt_simple_format(prompt, sizeof(prompt), 0, MuttMessageWindow->state.cols - EXTRA_SPACE,
                        JUSTIFY_LEFT, 0, scratch, sizeof(scratch), false);
     mutt_str_strcat(prompt, sizeof(prompt), "...?");
   }

--- a/commands.c
+++ b/commands.c
@@ -359,6 +359,10 @@ int mutt_display_message(struct MuttWindow *win, struct Mailbox *m, struct Email
     /* Invoke the builtin pager */
     info.email = e;
     info.ctx = Context;
+    info.win_ibar = MuttStatusWindow;
+    info.win_index = MuttIndexWindow;
+    info.win_pbar = MuttPagerBarWindow;
+    info.win_pager = MuttPagerWindow;
     rc = mutt_pager(NULL, mutt_b2s(tempfile), MUTT_PAGER_MESSAGE, &info);
   }
   else

--- a/commands.h
+++ b/commands.h
@@ -48,7 +48,7 @@ void ci_bounce_message(struct Mailbox *m, struct EmailList *el);
 void mutt_check_stats(void);
 bool mutt_check_traditional_pgp(struct EmailList *el, MuttRedrawFlags *redraw);
 void mutt_display_address(struct Envelope *env);
-int  mutt_display_message(struct MuttWindow *win, struct Mailbox *m, struct Email *e);
+int  mutt_display_message(struct MuttWindow *win_index, struct MuttWindow *win_ibar, struct MuttWindow *win_pager, struct MuttWindow *win_pbar, struct Mailbox *m, struct Email *e);
 bool mutt_edit_content_type(struct Email *e, struct Body *b, FILE *fp);
 void mutt_enter_command(void);
 void mutt_pipe_message(struct Mailbox *m, struct EmailList *el);

--- a/compose.c
+++ b/compose.c
@@ -56,6 +56,7 @@
 #include "hook.h"
 #include "index.h"
 #include "keymap.h"
+#include "main.h"
 #include "mutt_attach.h"
 #include "mutt_curses.h"
 #include "mutt_header.h"
@@ -1111,7 +1112,7 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur, 
 
   rd->email = e;
   rd->fcc = fcc;
-  rd->win = MuttIndexWindow;
+  rd->win = NULL; // MuttIndexWindow;
 
   struct Menu *menu = mutt_menu_new(MENU_COMPOSE);
   menu->offset = HDR_ATTACH;
@@ -1685,7 +1686,12 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur, 
         Context = ctx;
         OptAttachMsg = true;
         mutt_message(_("Tag the messages you want to attach"));
-        mutt_index_menu();
+        struct MuttWindow *dlg = index_pager_init();
+        dialog_push(dlg);
+        mutt_index_menu(dlg);
+        dialog_pop();
+        index_pager_shutdown(dlg);
+        mutt_window_free(&dlg);
         OptAttachMsg = false;
 
         if (!Context)

--- a/compose.c
+++ b/compose.c
@@ -317,7 +317,7 @@ static void snd_make_entry(char *buf, size_t buflen, struct Menu *menu, int line
 {
   struct AttachCtx *actx = menu->data;
 
-  mutt_expando_format(buf, buflen, 0, menu->indexwin->cols, NONULL(C_AttachFormat),
+  mutt_expando_format(buf, buflen, 0, menu->win_index->cols, NONULL(C_AttachFormat),
                       attach_format_str, (unsigned long) (actx->idx[actx->v2r[line]]),
                       MUTT_FORMAT_STAT_FILE | MUTT_FORMAT_ARROWCURSOR);
 }
@@ -902,7 +902,7 @@ static void compose_custom_redraw(struct Menu *menu)
 
     draw_envelope(rd);
     menu->offset = HDR_ATTACH;
-    menu->pagelen = menu->indexwin->rows - HDR_ATTACH;
+    menu->pagelen = menu->win_index->rows - HDR_ATTACH;
   }
 
   menu_check_recenter(menu);
@@ -910,11 +910,11 @@ static void compose_custom_redraw(struct Menu *menu)
   if (menu->redraw & REDRAW_STATUS)
   {
     char buf[1024];
-    compose_status_line(buf, sizeof(buf), 0, menu->statuswin->cols, menu,
+    compose_status_line(buf, sizeof(buf), 0, menu->win_ibar->cols, menu,
                         NONULL(C_ComposeFormat));
-    mutt_window_move(menu->statuswin, 0, 0);
+    mutt_window_move(menu->win_ibar, 0, 0);
     mutt_curses_set_color(MT_COLOR_STATUS);
-    mutt_draw_statusline(menu->statuswin->cols, buf, sizeof(buf));
+    mutt_draw_statusline(menu->win_ibar->cols, buf, sizeof(buf));
     mutt_curses_set_color(MT_COLOR_NORMAL);
     menu->redraw &= ~REDRAW_STATUS;
   }
@@ -1189,11 +1189,11 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur, 
         if (mutt_get_field("Newsgroups: ", buf, sizeof(buf), 0) == 0)
         {
           mutt_str_replace(&e->env->newsgroups, buf);
-          mutt_window_move(menu->indexwin, HDR_TO, HDR_XOFFSET);
+          mutt_window_move(menu->win_index, HDR_TO, HDR_XOFFSET);
           if (e->env->newsgroups)
             mutt_paddstr(W, e->env->newsgroups);
           else
-            mutt_window_clrtoeol(menu->indexwin);
+            mutt_window_clrtoeol(menu->win_index);
         }
         break;
 
@@ -1207,11 +1207,11 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur, 
         if (mutt_get_field("Followup-To: ", buf, sizeof(buf), 0) == 0)
         {
           mutt_str_replace(&e->env->followup_to, buf);
-          mutt_window_move(menu->indexwin, HDR_CC, HDR_XOFFSET);
+          mutt_window_move(menu->win_index, HDR_CC, HDR_XOFFSET);
           if (e->env->followup_to)
             mutt_paddstr(W, e->env->followup_to);
           else
-            mutt_window_clrtoeol(menu->indexwin);
+            mutt_window_clrtoeol(menu->win_index);
         }
         break;
 
@@ -1225,11 +1225,11 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur, 
         if (mutt_get_field("X-Comment-To: ", buf, sizeof(buf), 0) == 0)
         {
           mutt_str_replace(&e->env->x_comment_to, buf);
-          mutt_window_move(menu->indexwin, HDR_BCC, HDR_XOFFSET);
+          mutt_window_move(menu->win_index, HDR_BCC, HDR_XOFFSET);
           if (e->env->x_comment_to)
             mutt_paddstr(W, e->env->x_comment_to);
           else
-            mutt_window_clrtoeol(menu->indexwin);
+            mutt_window_clrtoeol(menu->win_index);
         }
         break;
 #endif
@@ -1242,11 +1242,11 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur, 
         if (mutt_get_field(_("Subject: "), buf, sizeof(buf), 0) == 0)
         {
           mutt_str_replace(&e->env->subject, buf);
-          mutt_window_move(menu->indexwin, HDR_SUBJECT, HDR_XOFFSET);
+          mutt_window_move(menu->win_index, HDR_SUBJECT, HDR_XOFFSET);
           if (e->env->subject)
             mutt_paddstr(W, e->env->subject);
           else
-            mutt_window_clrtoeol(menu->indexwin);
+            mutt_window_clrtoeol(menu->win_index);
         }
         mutt_message_hook(NULL, e, MUTT_SEND2_HOOK);
         break;
@@ -1262,7 +1262,7 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur, 
         {
           mutt_buffer_copy(fcc, &fname);
           mutt_buffer_pretty_mailbox(fcc);
-          mutt_window_move(menu->indexwin, HDR_FCC, HDR_XOFFSET);
+          mutt_window_move(menu->win_index, HDR_FCC, HDR_XOFFSET);
           mutt_paddstr(W, mutt_b2s(fcc));
           fcc_set = true;
         }
@@ -2209,7 +2209,7 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur, 
 
 #ifdef MIXMASTER
       case OP_COMPOSE_MIX:
-        mix_make_chain(menu->indexwin, &e->chain, menu->indexwin->cols);
+        mix_make_chain(menu->win_index, &e->chain, menu->win_index->cols);
         mutt_message_hook(NULL, e, MUTT_SEND2_HOOK);
         break;
 #endif

--- a/compose.c
+++ b/compose.c
@@ -159,7 +159,7 @@ int HeaderPadding[HDR_ATTACH_TITLE] = { 0 };
 int MaxHeaderWidth = 0;
 
 #define HDR_XOFFSET MaxHeaderWidth
-#define W (rd->win->cols - MaxHeaderWidth)
+#define W (rd->win->state.cols - MaxHeaderWidth)
 
 static const char *const Prompts[] = {
   /* L10N: Compose menu field.  May not want to translate. */
@@ -317,8 +317,9 @@ static void snd_make_entry(char *buf, size_t buflen, struct Menu *menu, int line
 {
   struct AttachCtx *actx = menu->data;
 
-  mutt_expando_format(buf, buflen, 0, menu->win_index->cols, NONULL(C_AttachFormat),
-                      attach_format_str, (unsigned long) (actx->idx[actx->v2r[line]]),
+  mutt_expando_format(buf, buflen, 0, menu->win_index->state.cols,
+                      NONULL(C_AttachFormat), attach_format_str,
+                      (unsigned long) (actx->idx[actx->v2r[line]]),
                       MUTT_FORMAT_STAT_FILE | MUTT_FORMAT_ARROWCURSOR);
 }
 
@@ -557,7 +558,7 @@ static void redraw_mix_line(struct ListHead *chain, struct ComposeRedrawData *rd
     if (t && (t[0] == '0') && (t[1] == '\0'))
       t = "<random>";
 
-    if (c + mutt_str_strlen(t) + 2 >= rd->win->cols)
+    if (c + mutt_str_strlen(t) + 2 >= rd->win->state.cols)
       break;
 
     mutt_window_addstr(NONULL(t));
@@ -902,7 +903,7 @@ static void compose_custom_redraw(struct Menu *menu)
 
     draw_envelope(rd);
     menu->offset = HDR_ATTACH;
-    menu->pagelen = menu->win_index->rows - HDR_ATTACH;
+    menu->pagelen = menu->win_index->state.rows - HDR_ATTACH;
   }
 
   menu_check_recenter(menu);
@@ -910,11 +911,11 @@ static void compose_custom_redraw(struct Menu *menu)
   if (menu->redraw & REDRAW_STATUS)
   {
     char buf[1024];
-    compose_status_line(buf, sizeof(buf), 0, menu->win_ibar->cols, menu,
+    compose_status_line(buf, sizeof(buf), 0, menu->win_ibar->state.cols, menu,
                         NONULL(C_ComposeFormat));
     mutt_window_move(menu->win_ibar, 0, 0);
     mutt_curses_set_color(MT_COLOR_STATUS);
-    mutt_draw_statusline(menu->win_ibar->cols, buf, sizeof(buf));
+    mutt_draw_statusline(menu->win_ibar->state.cols, buf, sizeof(buf));
     mutt_curses_set_color(MT_COLOR_NORMAL);
     menu->redraw &= ~REDRAW_STATUS;
   }
@@ -2209,7 +2210,7 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur, 
 
 #ifdef MIXMASTER
       case OP_COMPOSE_MIX:
-        mix_make_chain(menu->win_index, &e->chain, menu->win_index->cols);
+        mix_make_chain(menu->win_index, &e->chain, menu->win_index->state.cols);
         mutt_message_hook(NULL, e, MUTT_SEND2_HOOK);
         break;
 #endif

--- a/conn/ssl_gnutls.c
+++ b/conn/ssl_gnutls.c
@@ -41,9 +41,11 @@
 #include "conn_globals.h"
 #include "connaccount.h"
 #include "connection.h"
+#include "globals.h"
 #include "keymap.h"
 #include "mutt_account.h"
 #include "mutt_menu.h"
+#include "mutt_window.h"
 #include "muttlib.h"
 #include "opcodes.h"
 #include "options.h"
@@ -493,7 +495,36 @@ static int tls_check_one_certificate(const gnutls_datum_t *certdata,
 
   struct Buffer *drow = mutt_buffer_pool_get();
 
+  struct MuttWindow *dlg =
+      mutt_window_new(MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
+                      MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
+  dlg->type = WT_DIALOG;
+  struct MuttWindow *index =
+      mutt_window_new(MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
+                      MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
+  index->type = WT_INDEX;
+  struct MuttWindow *ibar = mutt_window_new(
+      MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_FIXED, 1, MUTT_WIN_SIZE_UNLIMITED);
+  ibar->type = WT_INDEX_BAR;
+
+  if (C_StatusOnTop)
+  {
+    mutt_window_add_child(dlg, ibar);
+    mutt_window_add_child(dlg, index);
+  }
+  else
+  {
+    mutt_window_add_child(dlg, index);
+    mutt_window_add_child(dlg, ibar);
+  }
+
+  dialog_push(dlg);
+
   menu = mutt_menu_new(MENU_GENERIC);
+  menu->pagelen = index->state.rows;
+  menu->win_index = index;
+  menu->win_ibar = ibar;
+
   mutt_menu_push_current(menu);
 
   buflen = sizeof(dn_common_name);
@@ -758,6 +789,8 @@ static int tls_check_one_certificate(const gnutls_datum_t *certdata,
   mutt_buffer_pool_release(&drow);
   mutt_menu_pop_current(menu);
   mutt_menu_free(&menu);
+  dialog_pop();
+  mutt_window_free(&dlg);
   gnutls_x509_crt_deinit(cert);
 
   return done == 2;

--- a/curs_lib.c
+++ b/curs_lib.c
@@ -416,13 +416,13 @@ enum QuadOption mutt_yesorno(const char *msg, enum QuadOption def)
         clearok(stdscr, true);
         mutt_menu_current_redraw();
       }
-      if (MuttMessageWindow->cols)
+      if (MuttMessageWindow->state.cols)
       {
-        prompt_lines = (msg_wid + answer_string_wid + MuttMessageWindow->cols - 1) /
-                       MuttMessageWindow->cols;
+        prompt_lines = (msg_wid + answer_string_wid + MuttMessageWindow->state.cols - 1) /
+                       MuttMessageWindow->state.cols;
         prompt_lines = MAX(1, MIN(3, prompt_lines));
       }
-      if (prompt_lines != MuttMessageWindow->rows)
+      if (prompt_lines != MuttMessageWindow->state.rows)
       {
         mutt_window_reflow_message_rows(prompt_lines);
         mutt_menu_current_redraw();
@@ -430,8 +430,8 @@ enum QuadOption mutt_yesorno(const char *msg, enum QuadOption def)
 
       /* maxlen here is sort of arbitrary, so pick a reasonable upper bound */
       trunc_msg_len = mutt_wstr_trunc(
-          msg, (size_t) 4 * prompt_lines * MuttMessageWindow->cols,
-          ((size_t) prompt_lines * MuttMessageWindow->cols) - answer_string_wid, NULL);
+          msg, (size_t) 4 * prompt_lines * MuttMessageWindow->state.cols,
+          ((size_t) prompt_lines * MuttMessageWindow->state.cols) - answer_string_wid, NULL);
 
       mutt_window_move(MuttMessageWindow, 0, 0);
       mutt_curses_set_color(MT_COLOR_PROMPT);
@@ -480,7 +480,7 @@ enum QuadOption mutt_yesorno(const char *msg, enum QuadOption def)
   if (reno_ok)
     regfree(&reno);
 
-  if (MuttMessageWindow->rows == 1)
+  if (MuttMessageWindow->state.rows == 1)
   {
     mutt_window_clearline(MuttMessageWindow, 0);
   }
@@ -881,7 +881,7 @@ int mutt_multi_choice(const char *prompt, const char *letters)
         clearok(stdscr, true);
         mutt_menu_current_redraw();
       }
-      if (MuttMessageWindow->cols)
+      if (MuttMessageWindow->state.cols)
       {
         int width = mutt_strwidth(prompt) + 2; // + '?' + space
         /* If we're going to colour the options,
@@ -889,10 +889,11 @@ int mutt_multi_choice(const char *prompt, const char *letters)
         if (opt_cols)
           width -= 2 * mutt_str_strlen(letters);
 
-        prompt_lines = (width + MuttMessageWindow->cols - 1) / MuttMessageWindow->cols;
+        prompt_lines = (width + MuttMessageWindow->state.cols - 1) /
+                       MuttMessageWindow->state.cols;
         prompt_lines = MAX(1, MIN(3, prompt_lines));
       }
-      if (prompt_lines != MuttMessageWindow->rows)
+      if (prompt_lines != MuttMessageWindow->state.rows)
       {
         mutt_window_reflow_message_rows(prompt_lines);
         mutt_menu_current_redraw();
@@ -965,7 +966,7 @@ int mutt_multi_choice(const char *prompt, const char *letters)
     }
     mutt_beep(false);
   }
-  if (MuttMessageWindow->rows == 1)
+  if (MuttMessageWindow->state.rows == 1)
   {
     mutt_window_clearline(MuttMessageWindow, 0);
   }

--- a/curs_lib.c
+++ b/curs_lib.c
@@ -631,6 +631,13 @@ int mutt_any_key_to_continue(const char *s)
 int mutt_do_pager(const char *banner, const char *tempfile, PagerFlags do_color,
                   struct Pager *info)
 {
+  struct Pager info2 = { 0 };
+  if (!info)
+    info = &info2;
+
+  info->win_pbar = MuttPagerBarWindow;
+  info->win_pager = MuttPagerWindow;
+
   int rc;
 
   if (!C_Pager || (mutt_str_strcmp(C_Pager, "builtin") == 0))

--- a/enter.c
+++ b/enter.c
@@ -179,7 +179,7 @@ int mutt_enter_string_full(char *buf, size_t buflen, int col,
                            CompletionFlags flags, bool multiple, char ***files,
                            int *numfiles, struct EnterState *state)
 {
-  int width = MuttMessageWindow->cols - col - 1;
+  int width = MuttMessageWindow->state.cols - col - 1;
   enum EnterRedrawFlags redraw = ENTER_REDRAW_NONE;
   bool pass = (flags & MUTT_PASS);
   bool first = true;

--- a/globals.h
+++ b/globals.h
@@ -152,9 +152,6 @@ WHERE short C_SleepTime;                     ///< Config: Time to pause after ce
 WHERE short C_Timeout;                       ///< Config: Time to wait for user input in menus
 WHERE short C_Wrap;                          ///< Config: Width to wrap text in the pager
 
-#ifdef USE_SIDEBAR
-WHERE short C_SidebarWidth;                  ///< Config: (sidebar) Width of the sidebar
-#endif
 #ifdef USE_IMAP
 WHERE short C_ImapKeepalive;                 ///< Config: (imap) Time to wait before polling an open IMAP connection
 WHERE short C_ImapPollTimeout;               ///< Config: (imap) Maximum time to wait for a server response
@@ -252,10 +249,6 @@ WHERE bool C_ResumeDraftFiles;               ///< Config: Process draft files li
 WHERE bool C_SaveAddress;                    ///< Config: Use sender's full address as a default save folder
 WHERE bool C_SaveEmpty;                      ///< Config: (mbox,mmdf) Preserve empty mailboxes
 WHERE bool C_Score;                          ///< Config: Use message scoring
-#ifdef USE_SIDEBAR
-WHERE bool C_SidebarVisible;                 ///< Config: (sidebar) Show the sidebar
-WHERE bool C_SidebarOnRight;                 ///< Config: (sidebar) Display the sidebar on the right
-#endif
 WHERE bool C_SizeShowBytes;                  ///< Config: Show smaller sizes in bytes
 WHERE bool C_SizeShowFractions;              ///< Config: Show size fractions with a single decimal place
 WHERE bool C_SizeShowMb;                     ///< Config: Show sizes in megabytes for sizes greater than 1 megabyte

--- a/icommands.c
+++ b/icommands.c
@@ -289,8 +289,7 @@ static enum CommandResult icmd_bind(struct Buffer *buf, struct Buffer *s,
   mutt_file_fclose(&fp_out);
   mutt_buffer_dealloc(&filebuf);
 
-  struct Pager info = { 0 };
-  if (mutt_do_pager((bind) ? "bind" : "macro", tempfile, MUTT_PAGER_NO_FLAGS, &info) == -1)
+  if (mutt_do_pager((bind) ? "bind" : "macro", tempfile, MUTT_PAGER_NO_FLAGS, NULL) == -1)
   {
     // L10N: '%s' is the file name of the temporary file
     mutt_buffer_printf(err, _("Could not create temporary file %s"), tempfile);
@@ -333,8 +332,7 @@ static enum CommandResult icmd_set(struct Buffer *buf, struct Buffer *s,
 
   mutt_file_fclose(&fp_out);
 
-  struct Pager info = { 0 };
-  if (mutt_do_pager("set", tempfile, MUTT_PAGER_NO_FLAGS, &info) == -1)
+  if (mutt_do_pager("set", tempfile, MUTT_PAGER_NO_FLAGS, NULL) == -1)
   {
     // L10N: '%s' is the file name of the temporary file
     mutt_buffer_printf(err, _("Could not create temporary file %s"), tempfile);
@@ -364,8 +362,7 @@ static enum CommandResult icmd_version(struct Buffer *buf, struct Buffer *s,
   print_version(fp_out);
   mutt_file_fclose(&fp_out);
 
-  struct Pager info = { 0 };
-  if (mutt_do_pager("version", tempfile, MUTT_PAGER_NO_FLAGS, &info) == -1)
+  if (mutt_do_pager("version", tempfile, MUTT_PAGER_NO_FLAGS, NULL) == -1)
   {
     // L10N: '%s' is the file name of the temporary file
     mutt_buffer_printf(err, _("Could not create temporary file %s"), tempfile);

--- a/index.c
+++ b/index.c
@@ -894,8 +894,8 @@ void index_make_entry(char *buf, size_t buflen, struct Menu *menu, int line)
     }
   }
 
-  mutt_make_string_flags(buf, buflen, menu->win_index->cols, NONULL(C_IndexFormat),
-                         Context, Context->mailbox, e, flags);
+  mutt_make_string_flags(buf, buflen, menu->win_index->state.cols,
+                         NONULL(C_IndexFormat), Context, Context->mailbox, e, flags);
 }
 
 /**
@@ -1093,7 +1093,7 @@ static void index_custom_redraw(struct Menu *menu)
     menu_status_line(buf, sizeof(buf), menu, NONULL(C_StatusFormat));
     mutt_window_move(menu->win_ibar, 0, 0);
     mutt_curses_set_color(MT_COLOR_STATUS);
-    mutt_draw_statusline(menu->win_ibar->cols, buf, sizeof(buf));
+    mutt_draw_statusline(menu->win_ibar->state.cols, buf, sizeof(buf));
     mutt_curses_set_color(MT_COLOR_NORMAL);
     menu->redraw &= ~REDRAW_STATUS;
     if (C_TsEnabled && TsSupported)
@@ -1316,7 +1316,7 @@ int mutt_index_menu(void)
       else
       {
         mutt_window_move(menu->win_index, menu->current - menu->top + menu->offset,
-                         menu->win_index->cols - 1);
+                         menu->win_index->state.cols - 1);
       }
       mutt_refresh();
 
@@ -1725,7 +1725,7 @@ int mutt_index_menu(void)
       }
 
       case OP_HELP:
-        mutt_help(MENU_MAIN, MuttIndexWindow->cols);
+        mutt_help(MENU_MAIN, MuttIndexWindow->state.cols);
         menu->redraw = REDRAW_FULL;
         break;
 

--- a/index.c
+++ b/index.c
@@ -894,7 +894,7 @@ void index_make_entry(char *buf, size_t buflen, struct Menu *menu, int line)
     }
   }
 
-  mutt_make_string_flags(buf, buflen, menu->indexwin->cols, NONULL(C_IndexFormat),
+  mutt_make_string_flags(buf, buflen, menu->win_index->cols, NONULL(C_IndexFormat),
                          Context, Context->mailbox, e, flags);
 }
 
@@ -1091,9 +1091,9 @@ static void index_custom_redraw(struct Menu *menu)
   {
     char buf[1024];
     menu_status_line(buf, sizeof(buf), menu, NONULL(C_StatusFormat));
-    mutt_window_move(menu->statuswin, 0, 0);
+    mutt_window_move(menu->win_ibar, 0, 0);
     mutt_curses_set_color(MT_COLOR_STATUS);
-    mutt_draw_statusline(menu->statuswin->cols, buf, sizeof(buf));
+    mutt_draw_statusline(menu->win_ibar->cols, buf, sizeof(buf));
     mutt_curses_set_color(MT_COLOR_NORMAL);
     menu->redraw &= ~REDRAW_STATUS;
     if (C_TsEnabled && TsSupported)
@@ -1310,13 +1310,13 @@ int mutt_index_menu(void)
         menu->oldcurrent = -1;
 
       if (C_ArrowCursor)
-        mutt_window_move(menu->indexwin, menu->current - menu->top + menu->offset, 2);
+        mutt_window_move(menu->win_index, menu->current - menu->top + menu->offset, 2);
       else if (C_BrailleFriendly)
-        mutt_window_move(menu->indexwin, menu->current - menu->top + menu->offset, 0);
+        mutt_window_move(menu->win_index, menu->current - menu->top + menu->offset, 0);
       else
       {
-        mutt_window_move(menu->indexwin, menu->current - menu->top + menu->offset,
-                         menu->indexwin->cols - 1);
+        mutt_window_move(menu->win_index, menu->current - menu->top + menu->offset,
+                         menu->win_index->cols - 1);
       }
       mutt_refresh();
 

--- a/index.c
+++ b/index.c
@@ -1143,7 +1143,7 @@ int mutt_index_menu(void)
           IndexHelp);
   menu->menu_custom_redraw = index_custom_redraw;
   mutt_menu_push_current(menu);
-  mutt_window_reflow();
+  mutt_window_reflow(NULL);
 
   if (!attach_msg)
   {
@@ -3870,7 +3870,7 @@ int mutt_index_menu(void)
 
       case OP_SIDEBAR_TOGGLE_VISIBLE:
         bool_str_toggle(Config, "sidebar_visible", NULL);
-        mutt_window_reflow();
+        mutt_window_reflow(NULL);
         break;
 #endif
 

--- a/index.c
+++ b/index.c
@@ -1110,12 +1110,13 @@ static void index_custom_redraw(struct Menu *menu)
 
 /**
  * mutt_index_menu - Display a list of emails
+ * @param dlg Dialog containing Windows to draw on
  * @retval num How the menu was finished, e.g. OP_QUIT, OP_EXIT
  *
  * This function handles the message index window as well as commands returned
  * from the pager (MENU_PAGER).
  */
-int mutt_index_menu(void)
+int mutt_index_menu(struct MuttWindow *dlg)
 {
   char buf[PATH_MAX], helpstr[1024];
   OpenMailboxFlags flags;
@@ -1130,7 +1131,16 @@ int mutt_index_menu(void)
   int attach_msg = OptAttachMsg;
   bool in_pager = false; /* set when pager redirects a function through the index */
 
+  struct MuttWindow *win_index = mutt_window_find(dlg, WT_INDEX);
+  struct MuttWindow *win_ibar = mutt_window_find(dlg, WT_INDEX_BAR);
+  struct MuttWindow *win_pager = mutt_window_find(dlg, WT_PAGER);
+  struct MuttWindow *win_pbar = mutt_window_find(dlg, WT_PAGER_BAR);
+
   struct Menu *menu = mutt_menu_new(MENU_MAIN);
+  menu->pagelen = win_index->state.rows;
+  menu->win_index = win_index;
+  menu->win_ibar = win_ibar;
+
   menu->menu_make_entry = index_make_entry;
   menu->menu_color = index_color;
   menu->current = ci_first_message(Context);
@@ -1725,7 +1735,7 @@ int mutt_index_menu(void)
       }
 
       case OP_HELP:
-        mutt_help(MENU_MAIN, MuttIndexWindow->state.cols);
+        mutt_help(MENU_MAIN, win_index->state.cols);
         menu->redraw = REDRAW_FULL;
         break;
 
@@ -1841,6 +1851,7 @@ int mutt_index_menu(void)
         break;
 
       case OP_REDRAW:
+        mutt_window_reflow(NULL);
         clearok(stdscr, true);
         menu->redraw = REDRAW_FULL;
         break;
@@ -2510,7 +2521,8 @@ int mutt_index_menu(void)
           break;
         int hint = e_cur->index;
 
-        op = mutt_display_message(MuttIndexWindow, Context->mailbox, e_cur);
+        op = mutt_display_message(win_index, win_ibar, win_pager, win_pbar,
+                                  Context->mailbox, e_cur);
         if (op < 0)
         {
           OptNeedResort = false;
@@ -3969,5 +3981,143 @@ int mutt_reply_observer(struct NotifyCallback *nc)
   }
 
   OptResortInit = true; /* trigger a redraw of the index */
+  return 0;
+}
+
+/**
+ * index_pager_init - Allocate the Windows for the Index/Pager
+ * @retval ptr Dialog containing nested Windows
+ */
+struct MuttWindow *index_pager_init(void)
+{
+  struct MuttWindow *dlg =
+      mutt_window_new(MUTT_WIN_ORIENT_HORIZONTAL, MUTT_WIN_SIZE_MAXIMISE,
+                      MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
+  dlg->type = WT_DIALOG;
+  struct MuttWindow *cont_right =
+      mutt_window_new(MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
+                      MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
+  cont_right->type = WT_CONTAINER;
+  struct MuttWindow *panel_index =
+      mutt_window_new(MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
+                      MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
+  panel_index->type = WT_CONTAINER;
+  struct MuttWindow *panel_pager =
+      mutt_window_new(MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
+                      MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
+  panel_pager->type = WT_CONTAINER;
+  panel_pager->state.visible = false; // The Pager and Pager Bar are initially hidden
+
+  struct MuttWindow *win_index =
+      mutt_window_new(MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
+                      MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
+  win_index->type = WT_INDEX;
+  struct MuttWindow *win_pbar = mutt_window_new(
+      MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_FIXED, 1, MUTT_WIN_SIZE_UNLIMITED);
+  win_pbar->type = WT_PAGER_BAR;
+  struct MuttWindow *win_pager =
+      mutt_window_new(MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
+                      MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
+  win_pager->type = WT_PAGER;
+  struct MuttWindow *win_sidebar =
+      mutt_window_new(MUTT_WIN_ORIENT_HORIZONTAL, MUTT_WIN_SIZE_FIXED,
+                      MUTT_WIN_SIZE_UNLIMITED, C_SidebarWidth);
+  win_sidebar->type = WT_SIDEBAR;
+  struct MuttWindow *win_ibar = mutt_window_new(
+      MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_FIXED, 1, MUTT_WIN_SIZE_UNLIMITED);
+  win_ibar->type = WT_INDEX_BAR;
+
+  mutt_window_add_child(dlg, MuttSidebarWindow);
+  mutt_window_add_child(dlg, cont_right);
+
+  mutt_window_add_child(cont_right, panel_index);
+  mutt_window_add_child(panel_index, win_index);
+  mutt_window_add_child(panel_index, win_ibar);
+
+  mutt_window_add_child(cont_right, panel_pager);
+  mutt_window_add_child(panel_pager, win_pager);
+  mutt_window_add_child(panel_pager, win_pbar);
+
+  return dlg;
+}
+
+/**
+ * index_pager_shutdown - Clear up any non-Window parts
+ * @param dlg Dialog
+ */
+void index_pager_shutdown(struct MuttWindow *dlg)
+{
+  if (!dlg)
+    return;
+}
+
+/**
+ * mutt_dlg_index_observer - Listen for config changes affecting the Index/Pager - Implements ::observer_t()
+ */
+int mutt_dlg_index_observer(struct NotifyCallback *nc)
+{
+  if (!nc || !nc->event || !nc->data)
+    return -1;
+
+  struct EventConfig *ec = (struct EventConfig *) nc->event;
+  struct MuttWindow *dlg = (struct MuttWindow *) nc->data;
+
+  struct MuttWindow *win_index = mutt_window_find(dlg, WT_INDEX);
+  struct MuttWindow *win_pager = mutt_window_find(dlg, WT_PAGER);
+  if (!win_index || !win_pager)
+    return -1;
+
+  if (mutt_str_strcmp(ec->name, "status_on_top") == 0)
+  {
+    struct MuttWindow *parent = win_index->parent;
+    if (!parent)
+      return -1;
+    struct MuttWindow *first = TAILQ_FIRST(&parent->children);
+    if (!first)
+      return -1;
+
+    if ((C_StatusOnTop && (first == win_index)) || (!C_StatusOnTop && (first != win_index)))
+    {
+      // Swap the Index and the Index Bar Windows
+      TAILQ_REMOVE(&parent->children, first, entries);
+      TAILQ_INSERT_TAIL(&parent->children, first, entries);
+    }
+
+    parent = win_pager->parent;
+    first = TAILQ_FIRST(&parent->children);
+
+    if ((C_StatusOnTop && (first == win_pager)) || (!C_StatusOnTop && (first != win_pager)))
+    {
+      // Swap the Pager and Pager Bar Windows
+      TAILQ_REMOVE(&parent->children, first, entries);
+      TAILQ_INSERT_TAIL(&parent->children, first, entries);
+    }
+    goto reflow;
+  }
+
+  if (mutt_str_strcmp(ec->name, "pager_index_lines") == 0)
+  {
+    struct MuttWindow *parent = win_pager->parent;
+    if (parent->state.visible)
+    {
+      int vcount = (Context && Context->mailbox) ? Context->mailbox->vcount : 0;
+      win_index->req_rows = MIN(C_PagerIndexLines, vcount);
+      win_index->size = MUTT_WIN_SIZE_FIXED;
+
+      win_index->parent->size = MUTT_WIN_SIZE_MINIMISE;
+      win_index->parent->state.visible = (C_PagerIndexLines != 0);
+    }
+    else
+    {
+      win_index->req_rows = MUTT_WIN_SIZE_UNLIMITED;
+      win_index->size = MUTT_WIN_SIZE_MAXIMISE;
+
+      win_index->parent->size = MUTT_WIN_SIZE_MAXIMISE;
+      win_index->parent->state.visible = true;
+    }
+  }
+
+reflow:
+  mutt_window_reflow(dlg);
   return 0;
 }

--- a/index.h
+++ b/index.h
@@ -30,6 +30,7 @@ struct Context;
 struct Email;
 struct Mailbox;
 struct Menu;
+struct MuttWindow;
 
 /* These Config Variables are only used in index.c */
 extern bool  C_ChangeFolderNext;
@@ -44,8 +45,11 @@ extern bool  C_UncollapseNew;
 int  index_color(int line);
 void index_make_entry(char *buf, size_t buflen, struct Menu *menu, int line);
 void mutt_draw_statusline(int cols, const char *buf, size_t buflen);
-int  mutt_index_menu(void);
+int  mutt_index_menu(struct MuttWindow *dlg);
 void mutt_set_header_color(struct Mailbox *m, struct Email *e);
 void update_index(struct Menu *menu, struct Context *ctx, int check, int oldcount, int index_hint);
+struct MuttWindow *index_pager_init(void);
+void index_pager_shutdown(struct MuttWindow *dlg);
+int mutt_dlg_index_observer(struct NotifyCallback *nc);
 
 #endif /* MUTT_INDEX_H */

--- a/init.h
+++ b/init.h
@@ -2552,7 +2552,7 @@ struct ConfigDef MuttVars[] = {
   ** pager.  The valid sequences are listed in the $$index_format
   ** section.
   */
-  { "pager_index_lines", DT_NUMBER|DT_NOT_NEGATIVE|R_PAGER, &C_PagerIndexLines, 0 },
+  { "pager_index_lines", DT_NUMBER|DT_NOT_NEGATIVE|R_PAGER|R_REFLOW, &C_PagerIndexLines, 0 },
   /*
   ** .pp
   ** Determines the number of lines of a mini-index which is shown when in

--- a/main.c
+++ b/main.c
@@ -689,13 +689,12 @@ int main(int argc, char *argv[], char *envp[])
   if (!OptNoCurses)
   {
     int crc = start_curses();
-
     if (crc != 0)
       goto main_curses; // TEST08: can't test -- fake term?
 
     /* check whether terminal status is supported (must follow curses init) */
     TsSupported = mutt_ts_capability();
-    mutt_window_reflow();
+    mutt_window_set_root(LINES, COLS);
   }
 
   /* set defaults and read init files */

--- a/main.c
+++ b/main.c
@@ -1250,7 +1250,15 @@ int main(int argc, char *argv[], char *envp[])
 #ifdef USE_SIDEBAR
       mutt_sb_set_open_mailbox(Context ? Context->mailbox : NULL);
 #endif
-      mutt_index_menu();
+      struct MuttWindow *dlg = index_pager_init();
+      notify_observer_add(Config->notify, NT_CONFIG, 0, mutt_dlg_index_observer,
+                          (intptr_t) dlg);
+      dialog_push(dlg);
+      mutt_index_menu(dlg);
+      dialog_pop();
+      notify_observer_remove(Config->notify, mutt_dlg_index_observer, (intptr_t) dlg);
+      index_pager_shutdown(dlg);
+      mutt_window_free(&dlg);
       ctx_free(&Context);
       log_queue_empty();
       repeat_error = false;

--- a/main.h
+++ b/main.h
@@ -25,7 +25,11 @@
 
 #include <stdbool.h>
 
+struct NotifyCallback;
+
 /* These Config Variables are only used in main.c */
 extern bool C_ResumeEditedDraftFiles;
+
+int mutt_dlg_index_observer(struct NotifyCallback *nc);
 
 #endif /* MUTT_MAIN_H */

--- a/menu.c
+++ b/menu.c
@@ -341,7 +341,7 @@ static void menu_pad_string(struct Menu *menu, char *buf, size_t buflen)
 {
   char *scratch = mutt_str_strdup(buf);
   int shift = C_ArrowCursor ? 3 : 0;
-  int cols = menu->indexwin->cols - shift;
+  int cols = menu->win_index->cols - shift;
 
   mutt_simple_format(buf, buflen, cols, cols, JUSTIFY_LEFT, ' ', scratch,
                      mutt_str_strlen(scratch), true);
@@ -368,7 +368,7 @@ void menu_redraw_full(struct Menu *menu)
     mutt_curses_set_color(MT_COLOR_NORMAL);
   }
   menu->offset = 0;
-  menu->pagelen = menu->indexwin->rows;
+  menu->pagelen = menu->win_index->rows;
 
   mutt_show_error();
 
@@ -388,8 +388,8 @@ void menu_redraw_status(struct Menu *menu)
 
   snprintf(buf, sizeof(buf), "-- NeoMutt: %s", menu->title);
   mutt_curses_set_color(MT_COLOR_STATUS);
-  mutt_window_move(menu->statuswin, 0, 0);
-  mutt_paddstr(menu->statuswin->cols, buf);
+  mutt_window_move(menu->win_ibar, 0, 0);
+  mutt_paddstr(menu->win_ibar->cols, buf);
   mutt_curses_set_color(MT_COLOR_NORMAL);
   menu->redraw &= ~REDRAW_STATUS;
 }
@@ -426,7 +426,7 @@ void menu_redraw_index(struct Menu *menu)
       menu_pad_string(menu, buf, sizeof(buf));
 
       mutt_curses_set_attr(attr);
-      mutt_window_move(menu->indexwin, i - menu->top + menu->offset, 0);
+      mutt_window_move(menu->win_index, i - menu->top + menu->offset, 0);
       do_color = true;
 
       if (i == menu->current)
@@ -449,7 +449,7 @@ void menu_redraw_index(struct Menu *menu)
     else
     {
       mutt_curses_set_color(MT_COLOR_NORMAL);
-      mutt_window_clearline(menu->indexwin, i - menu->top + menu->offset);
+      mutt_window_clearline(menu->win_index, i - menu->top + menu->offset);
     }
   }
   mutt_curses_set_color(MT_COLOR_NORMAL);
@@ -475,7 +475,7 @@ void menu_redraw_motion(struct Menu *menu)
    * generate status messages.  So we want to call it *before* we
    * position the cursor for drawing. */
   const int old_color = menu->menu_color(menu->oldcurrent);
-  mutt_window_move(menu->indexwin, menu->oldcurrent + menu->offset - menu->top, 0);
+  mutt_window_move(menu->win_index, menu->oldcurrent + menu->offset - menu->top, 0);
   mutt_curses_set_attr(old_color);
 
   if (C_ArrowCursor)
@@ -487,13 +487,13 @@ void menu_redraw_motion(struct Menu *menu)
     {
       menu_make_entry(buf, sizeof(buf), menu, menu->oldcurrent);
       menu_pad_string(menu, buf, sizeof(buf));
-      mutt_window_move(menu->indexwin, menu->oldcurrent + menu->offset - menu->top, 3);
+      mutt_window_move(menu->win_index, menu->oldcurrent + menu->offset - menu->top, 3);
       print_enriched_string(menu->oldcurrent, old_color, (unsigned char *) buf, true);
     }
 
     /* now draw it in the new location */
     mutt_curses_set_color(MT_COLOR_INDICATOR);
-    mutt_window_mvaddstr(menu->indexwin, menu->current + menu->offset - menu->top, 0, "->");
+    mutt_window_mvaddstr(menu->win_index, menu->current + menu->offset - menu->top, 0, "->");
   }
   else
   {
@@ -507,7 +507,7 @@ void menu_redraw_motion(struct Menu *menu)
     menu_make_entry(buf, sizeof(buf), menu, menu->current);
     menu_pad_string(menu, buf, sizeof(buf));
     mutt_curses_set_color(MT_COLOR_INDICATOR);
-    mutt_window_move(menu->indexwin, menu->current + menu->offset - menu->top, 0);
+    mutt_window_move(menu->win_index, menu->current + menu->offset - menu->top, 0);
     print_enriched_string(menu->current, cur_color, (unsigned char *) buf, false);
   }
   menu->redraw &= REDRAW_STATUS;
@@ -523,7 +523,7 @@ void menu_redraw_current(struct Menu *menu)
   char buf[1024];
   int attr = menu->menu_color(menu->current);
 
-  mutt_window_move(menu->indexwin, menu->current + menu->offset - menu->top, 0);
+  mutt_window_move(menu->win_index, menu->current + menu->offset - menu->top, 0);
   menu_make_entry(buf, sizeof(buf), menu, menu->current);
   menu_pad_string(menu, buf, sizeof(buf));
 
@@ -983,8 +983,8 @@ struct Menu *mutt_menu_new(enum MenuType type)
   menu->offset = 0;
   menu->redraw = REDRAW_FULL;
   menu->pagelen = MuttIndexWindow->rows;
-  menu->indexwin = MuttIndexWindow;
-  menu->statuswin = MuttStatusWindow;
+  menu->win_index = MuttIndexWindow;
+  menu->win_ibar = MuttStatusWindow;
   menu->menu_color = default_color;
   menu->menu_search = generic_search;
 
@@ -1382,13 +1382,13 @@ int mutt_menu_loop(struct Menu *menu)
 
     /* move the cursor out of the way */
     if (C_ArrowCursor)
-      mutt_window_move(menu->indexwin, menu->current - menu->top + menu->offset, 2);
+      mutt_window_move(menu->win_index, menu->current - menu->top + menu->offset, 2);
     else if (C_BrailleFriendly)
-      mutt_window_move(menu->indexwin, menu->current - menu->top + menu->offset, 0);
+      mutt_window_move(menu->win_index, menu->current - menu->top + menu->offset, 0);
     else
     {
-      mutt_window_move(menu->indexwin, menu->current - menu->top + menu->offset,
-                       menu->indexwin->cols - 1);
+      mutt_window_move(menu->win_index, menu->current - menu->top + menu->offset,
+                       menu->win_index->cols - 1);
     }
 
     mutt_refresh();
@@ -1574,7 +1574,7 @@ int mutt_menu_loop(struct Menu *menu)
         break;
 
       case OP_HELP:
-        mutt_help(menu->type, menu->indexwin->cols);
+        mutt_help(menu->type, menu->win_index->cols);
         menu->redraw = REDRAW_FULL;
         break;
 

--- a/menu.c
+++ b/menu.c
@@ -974,17 +974,11 @@ struct Menu *mutt_menu_new(enum MenuType type)
 {
   struct Menu *menu = mutt_mem_calloc(1, sizeof(struct Menu));
 
-  if (type >= MENU_MAX)
-    type = MENU_GENERIC;
-
   menu->type = type;
   menu->current = 0;
   menu->top = 0;
   menu->offset = 0;
   menu->redraw = REDRAW_FULL;
-  menu->pagelen = MuttIndexWindow->state.rows;
-  menu->win_index = MuttIndexWindow;
-  menu->win_ibar = MuttStatusWindow;
   menu->menu_color = default_color;
   menu->menu_search = generic_search;
 

--- a/menu.c
+++ b/menu.c
@@ -1672,7 +1672,7 @@ int mutt_menu_config_observer(struct NotifyCallback *nc)
     OptRedrawTree = true;
 
   if (flags & R_REFLOW)
-    mutt_window_reflow();
+    mutt_window_reflow(NULL);
 #ifdef USE_SIDEBAR
   if (flags & R_SIDEBAR)
     mutt_menu_set_current_redraw(REDRAW_SIDEBAR);

--- a/menu.c
+++ b/menu.c
@@ -341,7 +341,7 @@ static void menu_pad_string(struct Menu *menu, char *buf, size_t buflen)
 {
   char *scratch = mutt_str_strdup(buf);
   int shift = C_ArrowCursor ? 3 : 0;
-  int cols = menu->win_index->cols - shift;
+  int cols = menu->win_index->state.cols - shift;
 
   mutt_simple_format(buf, buflen, cols, cols, JUSTIFY_LEFT, ' ', scratch,
                      mutt_str_strlen(scratch), true);
@@ -364,11 +364,11 @@ void menu_redraw_full(struct Menu *menu)
   {
     mutt_curses_set_color(MT_COLOR_STATUS);
     mutt_window_move(MuttHelpWindow, 0, 0);
-    mutt_paddstr(MuttHelpWindow->cols, menu->help);
+    mutt_paddstr(MuttHelpWindow->state.cols, menu->help);
     mutt_curses_set_color(MT_COLOR_NORMAL);
   }
   menu->offset = 0;
-  menu->pagelen = menu->win_index->rows;
+  menu->pagelen = menu->win_index->state.rows;
 
   mutt_show_error();
 
@@ -389,7 +389,7 @@ void menu_redraw_status(struct Menu *menu)
   snprintf(buf, sizeof(buf), "-- NeoMutt: %s", menu->title);
   mutt_curses_set_color(MT_COLOR_STATUS);
   mutt_window_move(menu->win_ibar, 0, 0);
-  mutt_paddstr(menu->win_ibar->cols, buf);
+  mutt_paddstr(menu->win_ibar->state.cols, buf);
   mutt_curses_set_color(MT_COLOR_NORMAL);
   menu->redraw &= ~REDRAW_STATUS;
 }
@@ -982,7 +982,7 @@ struct Menu *mutt_menu_new(enum MenuType type)
   menu->top = 0;
   menu->offset = 0;
   menu->redraw = REDRAW_FULL;
-  menu->pagelen = MuttIndexWindow->rows;
+  menu->pagelen = MuttIndexWindow->state.rows;
   menu->win_index = MuttIndexWindow;
   menu->win_ibar = MuttStatusWindow;
   menu->menu_color = default_color;
@@ -1388,7 +1388,7 @@ int mutt_menu_loop(struct Menu *menu)
     else
     {
       mutt_window_move(menu->win_index, menu->current - menu->top + menu->offset,
-                       menu->win_index->cols - 1);
+                       menu->win_index->state.cols - 1);
     }
 
     mutt_refresh();
@@ -1574,7 +1574,7 @@ int mutt_menu_loop(struct Menu *menu)
         break;
 
       case OP_HELP:
-        mutt_help(menu->type, menu->win_index->cols);
+        mutt_help(menu->type, menu->win_index->state.cols);
         menu->redraw = REDRAW_FULL;
         break;
 

--- a/menu.c
+++ b/menu.c
@@ -402,7 +402,9 @@ void menu_redraw_status(struct Menu *menu)
 void menu_redraw_sidebar(struct Menu *menu)
 {
   menu->redraw &= ~REDRAW_SIDEBAR;
-  mutt_sb_draw();
+  struct MuttWindow *dlg = mutt_window_dialog(menu->win_index);
+  struct MuttWindow *sidebar = mutt_window_find(dlg, WT_SIDEBAR);
+  mutt_sb_draw(sidebar);
 }
 #endif
 

--- a/mutt/notify.c
+++ b/mutt/notify.c
@@ -155,6 +155,9 @@ bool notify_send(struct Notify *notify, int type, int subtype, intptr_t data)
  * @param callback Function to call on a matching event, see ::observer_t
  * @param data     Private data associated with the event type
  * @retval true If successful
+ *
+ * New observers are added to the front of the list, giving them higher
+ * priority than existing observers.
  */
 bool notify_observer_add(struct Notify *notify, enum NotifyType type,
                          int subtype, observer_t callback, intptr_t data)
@@ -177,7 +180,7 @@ bool notify_observer_add(struct Notify *notify, enum NotifyType type,
 
   np = mutt_mem_calloc(1, sizeof(*np));
   np->observer = o;
-  STAILQ_INSERT_TAIL(&notify->observers, np, entries);
+  STAILQ_INSERT_HEAD(&notify->observers, np, entries);
 
   return true;
 }

--- a/mutt_attach.c
+++ b/mutt_attach.c
@@ -412,7 +412,7 @@ int mutt_view_attachment(FILE *fp, struct Body *a, enum ViewAttachMode mode,
   snprintf(type, sizeof(type), "%s/%s", TYPE(a), a->subtype);
 
   char columns[16];
-  snprintf(columns, sizeof(columns), "%d", win->cols);
+  snprintf(columns, sizeof(columns), "%d", win->state.cols);
   mutt_envlist_set("COLUMNS", columns, true);
 
   if (use_mailcap)

--- a/mutt_history.c
+++ b/mutt_history.c
@@ -80,7 +80,7 @@ static void history_make_entry(char *buf, size_t buflen, struct Menu *menu, int 
 {
   char *entry = ((char **) menu->data)[line];
 
-  mutt_expando_format(buf, buflen, 0, menu->win_index->cols, "%s", history_format_str,
+  mutt_expando_format(buf, buflen, 0, menu->win_index->state.cols, "%s", history_format_str,
                       (unsigned long) entry, MUTT_FORMAT_ARROWCURSOR);
 }
 

--- a/mutt_history.c
+++ b/mutt_history.c
@@ -80,7 +80,7 @@ static void history_make_entry(char *buf, size_t buflen, struct Menu *menu, int 
 {
   char *entry = ((char **) menu->data)[line];
 
-  mutt_expando_format(buf, buflen, 0, menu->indexwin->cols, "%s", history_format_str,
+  mutt_expando_format(buf, buflen, 0, menu->win_index->cols, "%s", history_format_str,
                       (unsigned long) entry, MUTT_FORMAT_ARROWCURSOR);
 }
 

--- a/mutt_logging.c
+++ b/mutt_logging.c
@@ -169,7 +169,7 @@ int log_disp_curses(time_t stamp, const char *file, int line,
     error_pause();
 
   mutt_simple_format(ErrorBuf, sizeof(ErrorBuf), 0,
-                     MuttMessageWindow ? MuttMessageWindow->cols : sizeof(ErrorBuf),
+                     MuttMessageWindow ? MuttMessageWindow->state.cols : sizeof(ErrorBuf),
                      JUSTIFY_LEFT, 0, buf, sizeof(buf), false);
   ErrorBufMessage = true;
 

--- a/mutt_mailbox.c
+++ b/mutt_mailbox.c
@@ -223,8 +223,8 @@ bool mutt_mailbox_list(void)
     mutt_buffer_strcpy(path, mailbox_path(np->mailbox));
     mutt_buffer_pretty_mailbox(path);
 
-    if (!first && (MuttMessageWindow->cols >= 7) &&
-        ((pos + mutt_buffer_len(path)) >= ((size_t) MuttMessageWindow->cols - 7)))
+    if (!first && (MuttMessageWindow->state.cols >= 7) &&
+        ((pos + mutt_buffer_len(path)) >= ((size_t) MuttMessageWindow->state.cols - 7)))
     {
       break;
     }

--- a/mutt_menu.h
+++ b/mutt_menu.h
@@ -92,8 +92,8 @@ struct Menu
   int pagelen;            ///< Number of entries per screen
   bool tagprefix : 1;
   bool is_mailbox_list : 1;
-  struct MuttWindow *indexwin;
-  struct MuttWindow *statuswin;
+  struct MuttWindow *win_index;
+  struct MuttWindow *win_ibar;
 
   /* Setting dialog != NULL overrides normal menu behavior.
    * In dialog mode menubar is hidden and prompt keys are checked before

--- a/mutt_window.c
+++ b/mutt_window.c
@@ -45,9 +45,6 @@ struct MuttWindow *RootWindow = NULL;        ///< Parent of all Windows
 struct MuttWindow *MuttDialogWindow = NULL;  ///< Parent of all Dialogs
 struct MuttWindow *MuttHelpWindow = NULL;    ///< Help Window
 struct MuttWindow *MuttMessageWindow = NULL; ///< Message Window
-#ifdef USE_SIDEBAR
-struct MuttWindow *MuttSidebarWindow = NULL; ///< Sidebar Window
-#endif
 
 /**
  * mutt_window_new - Create a new Window
@@ -212,9 +209,6 @@ void mutt_window_free_all(void)
   MuttDialogWindow = NULL;
   MuttHelpWindow = NULL;
   MuttMessageWindow = NULL;
-#ifdef USE_SIDEBAR
-  MuttSidebarWindow = NULL;
-#endif
   mutt_window_free(&RootWindow);
 }
 

--- a/mutt_window.h
+++ b/mutt_window.h
@@ -26,16 +26,29 @@
 #include "config.h"
 
 /**
+ * struct WindowState - The current, or old, state of a Window
+ */
+struct WindowState
+{
+  bool visible;     ///< Window is visible
+  short rows;       ///< Number of rows, can be #MUTT_WIN_SIZE_UNLIMITED
+  short cols;       ///< Number of columns, can be #MUTT_WIN_SIZE_UNLIMITED
+  short row_offset; ///< Absolute on screen row
+  short col_offset; ///< Absolute on screen column
+};
+
+/**
  * struct MuttWindow - A division of the screen
  *
  * Windows for different parts of the screen
  */
 struct MuttWindow
 {
-  int rows;
-  int cols;
-  int row_offset;
-  int col_offset;
+  short req_rows;                    ///< Number of rows required
+  short req_cols;                    ///< Number of columns required
+
+  struct WindowState state;          ///< Current state of the Window
+  struct WindowState old;            ///< Previous state of the Window
 };
 
 extern struct MuttWindow *MuttHelpWindow;

--- a/mutt_window.h
+++ b/mutt_window.h
@@ -106,6 +106,8 @@ struct MuttWindow
 extern struct MuttWindow *MuttHelpWindow;
 extern struct MuttWindow *MuttIndexWindow;
 extern struct MuttWindow *MuttMessageWindow;
+extern struct MuttWindow *MuttPagerBarWindow;
+extern struct MuttWindow *MuttPagerWindow;
 #ifdef USE_SIDEBAR
 extern struct MuttWindow *MuttSidebarWindow;
 #endif
@@ -118,7 +120,7 @@ void               mutt_window_free               (struct MuttWindow **ptr);
 void               mutt_window_free_all           (void);
 void               mutt_window_get_coords         (struct MuttWindow *win, int *col, int *row);
 void               mutt_window_init               (void);
-struct MuttWindow *mutt_window_new                (void);
+struct MuttWindow *mutt_window_new                (enum MuttWindowOrientation orient, enum MuttWindowSize size, int rows, int cols);
 void               mutt_window_reflow             (void);
 void               mutt_window_reflow_message_rows(int mw_rows);
 int                mutt_window_wrap_cols          (int width, short wrap);

--- a/mutt_window.h
+++ b/mutt_window.h
@@ -121,8 +121,9 @@ void               mutt_window_free_all           (void);
 void               mutt_window_get_coords         (struct MuttWindow *win, int *col, int *row);
 void               mutt_window_init               (void);
 struct MuttWindow *mutt_window_new                (enum MuttWindowOrientation orient, enum MuttWindowSize size, int rows, int cols);
-void               mutt_window_reflow             (void);
+void               mutt_window_reflow             (struct MuttWindow *win);
 void               mutt_window_reflow_message_rows(int mw_rows);
+void               mutt_window_set_root           (int rows, int cols);
 int                mutt_window_wrap_cols          (int width, short wrap);
 
 // Functions for drawing on the Window

--- a/mutt_window.h
+++ b/mutt_window.h
@@ -112,6 +112,7 @@ extern struct MuttWindow *MuttSidebarWindow;
 extern struct MuttWindow *MuttStatusWindow;
 
 // Functions that deal with the Window
+void               mutt_window_add_child          (struct MuttWindow *parent, struct MuttWindow *child);
 void               mutt_window_copy_size          (const struct MuttWindow *win_src, struct MuttWindow *win_dst);
 void               mutt_window_free               (struct MuttWindow **ptr);
 void               mutt_window_free_all           (void);
@@ -134,6 +135,11 @@ void mutt_window_move_abs (int row, int col);
 int  mutt_window_mvaddstr (struct MuttWindow *win, int row, int col, const char *str);
 int  mutt_window_mvprintw (struct MuttWindow *win, int row, int col, const char *fmt, ...);
 int  mutt_window_printf   (const char *format, ...);
+bool mutt_window_is_visible(struct MuttWindow *win);
+
+void mutt_winlist_free       (struct MuttWindowList *head);
+struct MuttWindow *mutt_window_find(struct MuttWindow *root, enum WindowType type);
+struct MuttWindow *mutt_window_dialog(struct MuttWindow *win);
 
 void mutt_winlist_free       (struct MuttWindowList *head);
 

--- a/mutt_window.h
+++ b/mutt_window.h
@@ -103,15 +103,12 @@ struct MuttWindow
   void (*free_wdata)(struct MuttWindow *win, void **); ///< Callback function to free private data
 };
 
+extern struct MuttWindow *MuttDialogWindow;
 extern struct MuttWindow *MuttHelpWindow;
-extern struct MuttWindow *MuttIndexWindow;
 extern struct MuttWindow *MuttMessageWindow;
-extern struct MuttWindow *MuttPagerBarWindow;
-extern struct MuttWindow *MuttPagerWindow;
 #ifdef USE_SIDEBAR
 extern struct MuttWindow *MuttSidebarWindow;
 #endif
-extern struct MuttWindow *MuttStatusWindow;
 
 // Functions that deal with the Window
 void               mutt_window_add_child          (struct MuttWindow *parent, struct MuttWindow *child);
@@ -145,5 +142,7 @@ struct MuttWindow *mutt_window_find(struct MuttWindow *root, enum WindowType typ
 struct MuttWindow *mutt_window_dialog(struct MuttWindow *win);
 
 void mutt_winlist_free       (struct MuttWindowList *head);
+void dialog_pop(void);
+void dialog_push(struct MuttWindow *dlg);
 
 #endif /* MUTT_MUTT_WINDOW_H */

--- a/mutt_window.h
+++ b/mutt_window.h
@@ -106,9 +106,6 @@ struct MuttWindow
 extern struct MuttWindow *MuttDialogWindow;
 extern struct MuttWindow *MuttHelpWindow;
 extern struct MuttWindow *MuttMessageWindow;
-#ifdef USE_SIDEBAR
-extern struct MuttWindow *MuttSidebarWindow;
-#endif
 
 // Functions that deal with the Window
 void               mutt_window_add_child          (struct MuttWindow *parent, struct MuttWindow *child);

--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -3640,8 +3640,9 @@ static void crypt_make_entry(char *buf, size_t buflen, struct Menu *menu, int li
   entry.key = key_table[line];
   entry.num = line + 1;
 
-  mutt_expando_format(buf, buflen, 0, menu->win_index->cols, NONULL(C_PgpEntryFormat),
-                      crypt_format_str, (unsigned long) &entry, MUTT_FORMAT_ARROWCURSOR);
+  mutt_expando_format(buf, buflen, 0, menu->win_index->state.cols,
+                      NONULL(C_PgpEntryFormat), crypt_format_str,
+                      (unsigned long) &entry, MUTT_FORMAT_ARROWCURSOR);
 }
 
 /**

--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -4773,7 +4773,37 @@ static struct CryptKeyInfo *crypt_select_key(struct CryptKeyInfo *keys,
   mutt_make_help(buf, sizeof(buf), _("Help"), menu_to_use, OP_HELP);
   strcat(helpstr, buf);
 
+  struct MuttWindow *dlg =
+      mutt_window_new(MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
+                      MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
+  dlg->type = WT_DIALOG;
+  struct MuttWindow *index =
+      mutt_window_new(MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
+                      MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
+  index->type = WT_INDEX;
+  struct MuttWindow *ibar = mutt_window_new(
+      MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_FIXED, 1, MUTT_WIN_SIZE_UNLIMITED);
+  ibar->type = WT_INDEX_BAR;
+
+  if (C_StatusOnTop)
+  {
+    mutt_window_add_child(dlg, ibar);
+    mutt_window_add_child(dlg, index);
+  }
+  else
+  {
+    mutt_window_add_child(dlg, index);
+    mutt_window_add_child(dlg, ibar);
+  }
+
+  dialog_push(dlg);
+
   struct Menu *menu = mutt_menu_new(menu_to_use);
+
+  menu->pagelen = index->state.rows;
+  menu->win_index = index;
+  menu->win_ibar = ibar;
+
   menu->max = i;
   menu->menu_make_entry = crypt_make_entry;
   menu->help = helpstr;
@@ -4908,6 +4938,8 @@ static struct CryptKeyInfo *crypt_select_key(struct CryptKeyInfo *keys,
   mutt_menu_pop_current(menu);
   mutt_menu_free(&menu);
   FREE(&key_table);
+  dialog_pop();
+  mutt_window_free(&dlg);
 
   return k;
 }

--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -3640,7 +3640,7 @@ static void crypt_make_entry(char *buf, size_t buflen, struct Menu *menu, int li
   entry.key = key_table[line];
   entry.num = line + 1;
 
-  mutt_expando_format(buf, buflen, 0, menu->indexwin->cols, NONULL(C_PgpEntryFormat),
+  mutt_expando_format(buf, buflen, 0, menu->win_index->cols, NONULL(C_PgpEntryFormat),
                       crypt_format_str, (unsigned long) &entry, MUTT_FORMAT_ARROWCURSOR);
 }
 

--- a/ncrypt/pgpkey.c
+++ b/ncrypt/pgpkey.c
@@ -347,7 +347,7 @@ static void pgp_make_entry(char *buf, size_t buflen, struct Menu *menu, int line
   entry.uid = key_table[line];
   entry.num = line + 1;
 
-  mutt_expando_format(buf, buflen, 0, menu->indexwin->cols, NONULL(C_PgpEntryFormat),
+  mutt_expando_format(buf, buflen, 0, menu->win_index->cols, NONULL(C_PgpEntryFormat),
                       pgp_entry_fmt, (unsigned long) &entry, MUTT_FORMAT_ARROWCURSOR);
 }
 

--- a/ncrypt/pgpkey.c
+++ b/ncrypt/pgpkey.c
@@ -347,8 +347,9 @@ static void pgp_make_entry(char *buf, size_t buflen, struct Menu *menu, int line
   entry.uid = key_table[line];
   entry.num = line + 1;
 
-  mutt_expando_format(buf, buflen, 0, menu->win_index->cols, NONULL(C_PgpEntryFormat),
-                      pgp_entry_fmt, (unsigned long) &entry, MUTT_FORMAT_ARROWCURSOR);
+  mutt_expando_format(buf, buflen, 0, menu->win_index->state.cols,
+                      NONULL(C_PgpEntryFormat), pgp_entry_fmt,
+                      (unsigned long) &entry, MUTT_FORMAT_ARROWCURSOR);
 }
 
 /**

--- a/ncrypt/pgpkey.c
+++ b/ncrypt/pgpkey.c
@@ -671,7 +671,37 @@ static struct PgpKeyInfo *pgp_select_key(struct PgpKeyInfo *keys,
   mutt_make_help(buf, sizeof(buf), _("Help"), MENU_PGP, OP_HELP);
   strcat(helpstr, buf);
 
+  struct MuttWindow *dlg =
+      mutt_window_new(MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
+                      MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
+  dlg->type = WT_DIALOG;
+  struct MuttWindow *index =
+      mutt_window_new(MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
+                      MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
+  index->type = WT_INDEX;
+  struct MuttWindow *ibar = mutt_window_new(
+      MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_FIXED, 1, MUTT_WIN_SIZE_UNLIMITED);
+  ibar->type = WT_INDEX_BAR;
+
+  if (C_StatusOnTop)
+  {
+    mutt_window_add_child(dlg, ibar);
+    mutt_window_add_child(dlg, index);
+  }
+  else
+  {
+    mutt_window_add_child(dlg, index);
+    mutt_window_add_child(dlg, ibar);
+  }
+
+  dialog_push(dlg);
+
   menu = mutt_menu_new(MENU_PGP);
+
+  menu->pagelen = index->state.rows;
+  menu->win_index = index;
+  menu->win_ibar = ibar;
+
   menu->max = i;
   menu->menu_make_entry = pgp_make_entry;
   menu->help = helpstr;
@@ -810,6 +840,8 @@ static struct PgpKeyInfo *pgp_select_key(struct PgpKeyInfo *keys,
   mutt_menu_pop_current(menu);
   mutt_menu_free(&menu);
   FREE(&key_table);
+  dialog_pop();
+  mutt_window_free(&dlg);
 
   return kp;
 }

--- a/pager.c
+++ b/pager.c
@@ -2329,10 +2329,10 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
   }
   rd.helpstr = mutt_b2s(&helpstr);
 
-  rd.win_ibar = mutt_window_new();
-  rd.win_index = mutt_window_new();
-  rd.win_pbar = mutt_window_new();
-  rd.win_pager = mutt_window_new();
+  rd.win_ibar = MuttStatusWindow;
+  rd.win_index = MuttIndexWindow;
+  rd.win_pbar = MuttPagerBarWindow;
+  rd.win_pager = MuttPagerWindow;
 
   pager_menu = mutt_menu_new(MENU_PAGER);
   pager_menu->menu_custom_redraw = pager_custom_redraw;
@@ -3590,10 +3590,6 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
   mutt_menu_free(&rd.menu);
 
   mutt_buffer_dealloc(&helpstr);
-  mutt_window_free(&rd.win_ibar);
-  mutt_window_free(&rd.win_index);
-  mutt_window_free(&rd.win_pbar);
-  mutt_window_free(&rd.win_pager);
 
   return (rc != -1) ? rc : 0;
 }

--- a/pager.c
+++ b/pager.c
@@ -2041,8 +2041,8 @@ static void pager_custom_redraw(struct Menu *pager_menu)
         rd->menu->menu_color = index_color;
         rd->menu->max = Context ? Context->mailbox->vcount : 0;
         rd->menu->current = rd->extra->email->vnum;
-        rd->menu->indexwin = rd->index_window;
-        rd->menu->statuswin = rd->index_status_window;
+        rd->menu->win_index = rd->index_window;
+        rd->menu->win_ibar = rd->index_status_window;
       }
 
       mutt_curses_set_color(MT_COLOR_NORMAL);

--- a/pager.c
+++ b/pager.c
@@ -1961,42 +1961,6 @@ static void pager_custom_redraw(struct Menu *pager_menu)
 
     rd->indicator = rd->indexlen / 3;
 
-    mutt_window_copy_size(MuttIndexWindow, rd->win_pager);
-    mutt_window_copy_size(MuttStatusWindow, rd->win_pbar);
-    rd->win_ibar->state.rows = 0;
-    rd->win_index->state.rows = 0;
-
-    if (IsEmail(rd->extra) && (C_PagerIndexLines != 0))
-    {
-      mutt_window_copy_size(MuttIndexWindow, rd->win_index);
-      rd->win_index->state.rows = (rd->indexlen > 0) ? rd->indexlen - 1 : 0;
-
-      if (C_StatusOnTop)
-      {
-        mutt_window_copy_size(MuttStatusWindow, rd->win_ibar);
-
-        mutt_window_copy_size(MuttIndexWindow, rd->win_pbar);
-        rd->win_pbar->state.rows = 1;
-        rd->win_pbar->state.row_offset += rd->win_index->state.rows;
-
-        rd->win_pager->state.rows -=
-            rd->win_index->state.rows + rd->win_pbar->state.rows;
-        rd->win_pager->state.row_offset +=
-            rd->win_index->state.rows + rd->win_pbar->state.rows;
-      }
-      else
-      {
-        mutt_window_copy_size(MuttIndexWindow, rd->win_ibar);
-        rd->win_ibar->state.rows = 1;
-        rd->win_ibar->state.row_offset += rd->win_index->state.rows;
-
-        rd->win_pager->state.rows -=
-            rd->win_index->state.rows + rd->win_ibar->state.rows;
-        rd->win_pager->state.row_offset +=
-            rd->win_index->state.rows + rd->win_ibar->state.rows;
-      }
-    }
-
     if (C_Help)
     {
       mutt_curses_set_color(MT_COLOR_STATUS);
@@ -2287,6 +2251,9 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
     return -1;
   }
   unlink(fname);
+
+  MuttPagerWindow->parent->state.visible = true;
+  mutt_window_reflow(NULL);
 
   /* Initialize variables */
 
@@ -3543,7 +3510,7 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
 
       case OP_SIDEBAR_TOGGLE_VISIBLE:
         bool_str_toggle(Config, "sidebar_visible", NULL);
-        mutt_window_reflow();
+        mutt_window_reflow(NULL);
         break;
 #endif
 
@@ -3590,6 +3557,9 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
   mutt_menu_free(&rd.menu);
 
   mutt_buffer_dealloc(&helpstr);
+
+  MuttPagerWindow->parent->state.visible = false;
+  mutt_window_reflow(NULL);
 
   return (rc != -1) ? rc : 0;
 }

--- a/pager.h
+++ b/pager.h
@@ -69,6 +69,11 @@ struct Pager
   struct Body *body;      ///< Current attachment
   FILE *fp;               ///< Source stream
   struct AttachCtx *actx; ///< Attachment information
+
+  struct MuttWindow *win_ibar;
+  struct MuttWindow *win_index;
+  struct MuttWindow *win_pbar;
+  struct MuttWindow *win_pager;
 };
 
 int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct Pager *extra);

--- a/postpone.c
+++ b/postpone.c
@@ -208,7 +208,7 @@ static void post_make_entry(char *buf, size_t buflen, struct Menu *menu, int lin
 {
   struct Context *ctx = menu->data;
 
-  mutt_make_string_flags(buf, buflen, menu->win_index->cols,
+  mutt_make_string_flags(buf, buflen, menu->win_index->state.cols,
                          NONULL(C_IndexFormat), ctx, ctx->mailbox,
                          ctx->mailbox->emails[line], MUTT_FORMAT_ARROWCURSOR);
 }

--- a/postpone.c
+++ b/postpone.c
@@ -208,7 +208,7 @@ static void post_make_entry(char *buf, size_t buflen, struct Menu *menu, int lin
 {
   struct Context *ctx = menu->data;
 
-  mutt_make_string_flags(buf, buflen, menu->indexwin->cols,
+  mutt_make_string_flags(buf, buflen, menu->win_index->cols,
                          NONULL(C_IndexFormat), ctx, ctx->mailbox,
                          ctx->mailbox->emails[line], MUTT_FORMAT_ARROWCURSOR);
 }

--- a/progress.c
+++ b/progress.c
@@ -61,7 +61,7 @@ static void message_bar(int percent, const char *fmt, ...)
 
   va_list ap;
   char buf[256], buf2[256];
-  int w = (percent * MuttMessageWindow->cols) / 100;
+  int w = (percent * MuttMessageWindow->state.cols) / 100;
   size_t l;
 
   va_start(ap, fmt);
@@ -69,7 +69,7 @@ static void message_bar(int percent, const char *fmt, ...)
   l = mutt_strwidth(buf);
   va_end(ap);
 
-  mutt_simple_format(buf2, sizeof(buf2), 0, MuttMessageWindow->cols - 2,
+  mutt_simple_format(buf2, sizeof(buf2), 0, MuttMessageWindow->state.cols - 2,
                      JUSTIFY_LEFT, 0, buf, sizeof(buf), false);
 
   mutt_window_move(MuttMessageWindow, 0, 0);

--- a/query.c
+++ b/query.c
@@ -326,7 +326,7 @@ static void query_make_entry(char *buf, size_t buflen, struct Menu *menu, int li
   struct QueryEntry *entry = &((struct QueryEntry *) menu->data)[line];
 
   entry->data->num = line;
-  mutt_expando_format(buf, buflen, 0, menu->indexwin->cols, NONULL(C_QueryFormat),
+  mutt_expando_format(buf, buflen, 0, menu->win_index->cols, NONULL(C_QueryFormat),
                       query_format_str, (unsigned long) entry, MUTT_FORMAT_ARROWCURSOR);
 }
 

--- a/query.c
+++ b/query.c
@@ -362,249 +362,248 @@ static void query_menu(char *buf, size_t buflen, struct Query *results, bool ret
     if ((mutt_get_field(_("Query: "), buf, buflen, 0) == 0) && (buf[0] != '\0'))
     {
       results = run_query(buf, 0);
+      if (!results)
+        return;
     }
   }
 
-  if (results)
+  snprintf(title, sizeof(title), _("Query '%s'"), buf);
+
+  menu = mutt_menu_new(MENU_QUERY);
+  menu->menu_make_entry = query_make_entry;
+  menu->menu_search = query_search;
+  menu->menu_tag = query_tag;
+  menu->title = title;
+  char helpstr[1024];
+  menu->help = mutt_compile_help(helpstr, sizeof(helpstr), MENU_QUERY, QueryHelp);
+  mutt_menu_push_current(menu);
+
+  /* count the number of results */
+  for (queryp = results; queryp; queryp = queryp->next)
+    menu->max++;
+
+  query_table = mutt_mem_calloc(menu->max, sizeof(struct QueryEntry));
+  menu->data = query_table;
+
+  queryp = results;
+  for (int i = 0; queryp; queryp = queryp->next, i++)
+    query_table[i].data = queryp;
+
+  int done = 0;
+  while (done == 0)
   {
-    snprintf(title, sizeof(title), _("Query '%s'"), buf);
-
-    menu = mutt_menu_new(MENU_QUERY);
-    menu->menu_make_entry = query_make_entry;
-    menu->menu_search = query_search;
-    menu->menu_tag = query_tag;
-    menu->title = title;
-    char helpstr[1024];
-    menu->help = mutt_compile_help(helpstr, sizeof(helpstr), MENU_QUERY, QueryHelp);
-    mutt_menu_push_current(menu);
-
-    /* count the number of results */
-    for (queryp = results; queryp; queryp = queryp->next)
-      menu->max++;
-
-    query_table = mutt_mem_calloc(menu->max, sizeof(struct QueryEntry));
-    menu->data = query_table;
-
-    queryp = results;
-    for (int i = 0; queryp; queryp = queryp->next, i++)
-      query_table[i].data = queryp;
-
-    int done = 0;
-    while (done == 0)
+    const int op = mutt_menu_loop(menu);
+    switch (op)
     {
-      const int op = mutt_menu_loop(menu);
-      switch (op)
-      {
-        case OP_QUERY_APPEND:
-        case OP_QUERY:
-          if ((mutt_get_field(_("Query: "), buf, buflen, 0) == 0) && (buf[0] != '\0'))
-          {
-            struct Query *newresults = run_query(buf, 0);
-
-            menu->redraw = REDRAW_FULL;
-            if (newresults)
-            {
-              snprintf(title, sizeof(title), _("Query '%s'"), buf);
-
-              if (op == OP_QUERY)
-              {
-                query_free(&results);
-                results = newresults;
-                FREE(&query_table);
-              }
-              else
-              {
-                /* append */
-                for (queryp = results; queryp->next; queryp = queryp->next)
-                  ;
-
-                queryp->next = newresults;
-              }
-
-              menu->current = 0;
-              mutt_menu_pop_current(menu);
-              mutt_menu_free(&menu);
-              menu = mutt_menu_new(MENU_QUERY);
-              menu->menu_make_entry = query_make_entry;
-              menu->menu_search = query_search;
-              menu->menu_tag = query_tag;
-              menu->title = title;
-              menu->help = mutt_compile_help(helpstr, sizeof(helpstr), MENU_QUERY, QueryHelp);
-              mutt_menu_push_current(menu);
-
-              /* count the number of results */
-              for (queryp = results; queryp; queryp = queryp->next)
-                menu->max++;
-
-              if (op == OP_QUERY)
-              {
-                menu->data = query_table =
-                    mutt_mem_calloc(menu->max, sizeof(struct QueryEntry));
-
-                queryp = results;
-                for (int i = 0; queryp; queryp = queryp->next, i++)
-                  query_table[i].data = queryp;
-              }
-              else
-              {
-                bool clear = false;
-
-                /* append */
-                mutt_mem_realloc(&query_table, menu->max * sizeof(struct QueryEntry));
-
-                menu->data = query_table;
-
-                queryp = results;
-                for (int i = 0; queryp; queryp = queryp->next, i++)
-                {
-                  /* once we hit new entries, clear/init the tag */
-                  if (queryp == newresults)
-                    clear = true;
-
-                  query_table[i].data = queryp;
-                  if (clear)
-                    query_table[i].tagged = false;
-                }
-              }
-            }
-          }
-          break;
-
-        case OP_CREATE_ALIAS:
-          if (menu->tagprefix)
-          {
-            struct AddressList naddr = TAILQ_HEAD_INITIALIZER(naddr);
-
-            for (int i = 0; i < menu->max; i++)
-            {
-              if (query_table[i].tagged)
-              {
-                struct AddressList al = TAILQ_HEAD_INITIALIZER(al);
-                if (result_to_addr(&al, query_table[i].data))
-                {
-                  mutt_addrlist_copy(&naddr, &al, false);
-                  mutt_addrlist_clear(&al);
-                }
-              }
-            }
-
-            mutt_alias_create(NULL, &naddr);
-            mutt_addrlist_clear(&naddr);
-          }
-          else
-          {
-            struct AddressList al = TAILQ_HEAD_INITIALIZER(al);
-            if (result_to_addr(&al, query_table[menu->current].data))
-            {
-              mutt_alias_create(NULL, &al);
-              mutt_addrlist_clear(&al);
-            }
-          }
-          break;
-
-        case OP_GENERIC_SELECT_ENTRY:
-          if (retbuf)
-          {
-            done = 2;
-            break;
-          }
-        /* fallthrough */
-        case OP_MAIL:
+      case OP_QUERY_APPEND:
+      case OP_QUERY:
+        if ((mutt_get_field(_("Query: "), buf, buflen, 0) == 0) && (buf[0] != '\0'))
         {
-          struct Email *e = email_new();
-          e->env = mutt_env_new();
-          if (!menu->tagprefix)
-          {
-            struct AddressList al = TAILQ_HEAD_INITIALIZER(al);
-            if (result_to_addr(&al, query_table[menu->current].data))
-            {
-              mutt_addrlist_copy(&e->env->to, &al, false);
-              mutt_addrlist_clear(&al);
-            }
-          }
-          else
-          {
-            for (int i = 0; i < menu->max; i++)
-            {
-              if (query_table[i].tagged)
-              {
-                struct AddressList al = TAILQ_HEAD_INITIALIZER(al);
-                if (result_to_addr(&al, query_table[i].data))
-                {
-                  mutt_addrlist_copy(&e->env->to, &al, false);
-                  mutt_addrlist_clear(&al);
-                }
-              }
-            }
-          }
-          ci_send_message(SEND_NO_FLAGS, e, NULL, Context, NULL);
+          struct Query *newresults = run_query(buf, 0);
+
           menu->redraw = REDRAW_FULL;
-          break;
-        }
-
-        case OP_EXIT:
-          done = 1;
-          break;
-      }
-    }
-
-    /* if we need to return the selected entries */
-    if (retbuf && (done == 2))
-    {
-      bool tagged = false;
-      size_t curpos = 0;
-
-      memset(buf, 0, buflen);
-
-      /* check for tagged entries */
-      for (int i = 0; i < menu->max; i++)
-      {
-        if (query_table[i].tagged)
-        {
-          if (curpos == 0)
+          if (newresults)
           {
-            struct AddressList al = TAILQ_HEAD_INITIALIZER(al);
-            if (result_to_addr(&al, query_table[i].data))
+            snprintf(title, sizeof(title), _("Query '%s'"), buf);
+
+            if (op == OP_QUERY)
             {
-              mutt_addrlist_to_local(&al);
-              tagged = true;
-              mutt_addrlist_write(buf, buflen, &al, false);
-              curpos = mutt_str_strlen(buf);
-              mutt_addrlist_clear(&al);
+              query_free(&results);
+              results = newresults;
+              FREE(&query_table);
+            }
+            else
+            {
+              /* append */
+              for (queryp = results; queryp->next; queryp = queryp->next)
+                ;
+
+              queryp->next = newresults;
+            }
+
+            menu->current = 0;
+            mutt_menu_pop_current(menu);
+            mutt_menu_free(&menu);
+            menu = mutt_menu_new(MENU_QUERY);
+            menu->menu_make_entry = query_make_entry;
+            menu->menu_search = query_search;
+            menu->menu_tag = query_tag;
+            menu->title = title;
+            menu->help = mutt_compile_help(helpstr, sizeof(helpstr), MENU_QUERY, QueryHelp);
+            mutt_menu_push_current(menu);
+
+            /* count the number of results */
+            for (queryp = results; queryp; queryp = queryp->next)
+              menu->max++;
+
+            if (op == OP_QUERY)
+            {
+              menu->data = query_table =
+                  mutt_mem_calloc(menu->max, sizeof(struct QueryEntry));
+
+              queryp = results;
+              for (int i = 0; queryp; queryp = queryp->next, i++)
+                query_table[i].data = queryp;
+            }
+            else
+            {
+              bool clear = false;
+
+              /* append */
+              mutt_mem_realloc(&query_table, menu->max * sizeof(struct QueryEntry));
+
+              menu->data = query_table;
+
+              queryp = results;
+              for (int i = 0; queryp; queryp = queryp->next, i++)
+              {
+                /* once we hit new entries, clear/init the tag */
+                if (queryp == newresults)
+                  clear = true;
+
+                query_table[i].data = queryp;
+                if (clear)
+                  query_table[i].tagged = false;
+              }
             }
           }
-          else if (curpos + 2 < buflen)
+        }
+        break;
+
+      case OP_CREATE_ALIAS:
+        if (menu->tagprefix)
+        {
+          struct AddressList naddr = TAILQ_HEAD_INITIALIZER(naddr);
+
+          for (int i = 0; i < menu->max; i++)
           {
-            struct AddressList al = TAILQ_HEAD_INITIALIZER(al);
-            if (result_to_addr(&al, query_table[i].data))
+            if (query_table[i].tagged)
             {
-              mutt_addrlist_to_local(&al);
-              strcat(buf, ", ");
-              mutt_addrlist_write(buf + curpos + 1, buflen - curpos - 1, &al, false);
-              curpos = mutt_str_strlen(buf);
-              mutt_addrlist_clear(&al);
+              struct AddressList al = TAILQ_HEAD_INITIALIZER(al);
+              if (result_to_addr(&al, query_table[i].data))
+              {
+                mutt_addrlist_copy(&naddr, &al, false);
+                mutt_addrlist_clear(&al);
+              }
+            }
+          }
+
+          mutt_alias_create(NULL, &naddr);
+          mutt_addrlist_clear(&naddr);
+        }
+        else
+        {
+          struct AddressList al = TAILQ_HEAD_INITIALIZER(al);
+          if (result_to_addr(&al, query_table[menu->current].data))
+          {
+            mutt_alias_create(NULL, &al);
+            mutt_addrlist_clear(&al);
+          }
+        }
+        break;
+
+      case OP_GENERIC_SELECT_ENTRY:
+        if (retbuf)
+        {
+          done = 2;
+          break;
+        }
+      /* fallthrough */
+      case OP_MAIL:
+      {
+        struct Email *e = email_new();
+        e->env = mutt_env_new();
+        if (!menu->tagprefix)
+        {
+          struct AddressList al = TAILQ_HEAD_INITIALIZER(al);
+          if (result_to_addr(&al, query_table[menu->current].data))
+          {
+            mutt_addrlist_copy(&e->env->to, &al, false);
+            mutt_addrlist_clear(&al);
+          }
+        }
+        else
+        {
+          for (int i = 0; i < menu->max; i++)
+          {
+            if (query_table[i].tagged)
+            {
+              struct AddressList al = TAILQ_HEAD_INITIALIZER(al);
+              if (result_to_addr(&al, query_table[i].data))
+              {
+                mutt_addrlist_copy(&e->env->to, &al, false);
+                mutt_addrlist_clear(&al);
+              }
             }
           }
         }
+        ci_send_message(SEND_NO_FLAGS, e, NULL, Context, NULL);
+        menu->redraw = REDRAW_FULL;
+        break;
       }
-      /* then enter current message */
-      if (!tagged)
-      {
-        struct AddressList al = TAILQ_HEAD_INITIALIZER(al);
-        if (result_to_addr(&al, query_table[menu->current].data))
-        {
-          mutt_addrlist_to_local(&al);
-          mutt_addrlist_write(buf, buflen, &al, false);
-          mutt_addrlist_clear(&al);
-        }
-      }
-    }
 
-    query_free(&results);
-    FREE(&query_table);
-    mutt_menu_pop_current(menu);
-    mutt_menu_free(&menu);
+      case OP_EXIT:
+        done = 1;
+        break;
+    }
   }
+
+  /* if we need to return the selected entries */
+  if (retbuf && (done == 2))
+  {
+    bool tagged = false;
+    size_t curpos = 0;
+
+    memset(buf, 0, buflen);
+
+    /* check for tagged entries */
+    for (int i = 0; i < menu->max; i++)
+    {
+      if (query_table[i].tagged)
+      {
+        if (curpos == 0)
+        {
+          struct AddressList al = TAILQ_HEAD_INITIALIZER(al);
+          if (result_to_addr(&al, query_table[i].data))
+          {
+            mutt_addrlist_to_local(&al);
+            tagged = true;
+            mutt_addrlist_write(buf, buflen, &al, false);
+            curpos = mutt_str_strlen(buf);
+            mutt_addrlist_clear(&al);
+          }
+        }
+        else if (curpos + 2 < buflen)
+        {
+          struct AddressList al = TAILQ_HEAD_INITIALIZER(al);
+          if (result_to_addr(&al, query_table[i].data))
+          {
+            mutt_addrlist_to_local(&al);
+            strcat(buf, ", ");
+            mutt_addrlist_write(buf + curpos + 1, buflen - curpos - 1, &al, false);
+            curpos = mutt_str_strlen(buf);
+            mutt_addrlist_clear(&al);
+          }
+        }
+      }
+    }
+    /* then enter current message */
+    if (!tagged)
+    {
+      struct AddressList al = TAILQ_HEAD_INITIALIZER(al);
+      if (result_to_addr(&al, query_table[menu->current].data))
+      {
+        mutt_addrlist_to_local(&al);
+        mutt_addrlist_write(buf, buflen, &al, false);
+        mutt_addrlist_clear(&al);
+      }
+    }
+  }
+
+  query_free(&results);
+  FREE(&query_table);
+  mutt_menu_pop_current(menu);
+  mutt_menu_free(&menu);
 }
 
 /**

--- a/query.c
+++ b/query.c
@@ -370,7 +370,37 @@ static void query_menu(char *buf, size_t buflen, struct Query *results, bool ret
 
   snprintf(title, sizeof(title), _("Query '%s'"), buf);
 
+  struct MuttWindow *dlg =
+      mutt_window_new(MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
+                      MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
+  dlg->type = WT_DIALOG;
+  struct MuttWindow *index =
+      mutt_window_new(MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
+                      MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
+  index->type = WT_INDEX;
+  struct MuttWindow *ibar = mutt_window_new(
+      MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_FIXED, 1, MUTT_WIN_SIZE_UNLIMITED);
+  ibar->type = WT_INDEX_BAR;
+
+  if (C_StatusOnTop)
+  {
+    mutt_window_add_child(dlg, ibar);
+    mutt_window_add_child(dlg, index);
+  }
+  else
+  {
+    mutt_window_add_child(dlg, index);
+    mutt_window_add_child(dlg, ibar);
+  }
+
+  dialog_push(dlg);
+
   menu = mutt_menu_new(MENU_QUERY);
+
+  menu->pagelen = index->state.rows;
+  menu->win_index = index;
+  menu->win_ibar = ibar;
+
   menu->menu_make_entry = query_make_entry;
   menu->menu_search = query_search;
   menu->menu_tag = query_tag;
@@ -426,6 +456,11 @@ static void query_menu(char *buf, size_t buflen, struct Query *results, bool ret
             mutt_menu_pop_current(menu);
             mutt_menu_free(&menu);
             menu = mutt_menu_new(MENU_QUERY);
+
+            menu->pagelen = index->state.rows;
+            menu->win_index = index;
+            menu->win_ibar = ibar;
+
             menu->menu_make_entry = query_make_entry;
             menu->menu_search = query_search;
             menu->menu_tag = query_tag;
@@ -605,6 +640,8 @@ static void query_menu(char *buf, size_t buflen, struct Query *results, bool ret
   FREE(&query_table);
   mutt_menu_pop_current(menu);
   mutt_menu_free(&menu);
+  dialog_pop();
+  mutt_window_free(&dlg);
 }
 
 /**

--- a/query.c
+++ b/query.c
@@ -326,8 +326,9 @@ static void query_make_entry(char *buf, size_t buflen, struct Menu *menu, int li
   struct QueryEntry *entry = &((struct QueryEntry *) menu->data)[line];
 
   entry->data->num = line;
-  mutt_expando_format(buf, buflen, 0, menu->win_index->cols, NONULL(C_QueryFormat),
-                      query_format_str, (unsigned long) entry, MUTT_FORMAT_ARROWCURSOR);
+  mutt_expando_format(buf, buflen, 0, menu->win_index->state.cols,
+                      NONULL(C_QueryFormat), query_format_str,
+                      (unsigned long) entry, MUTT_FORMAT_ARROWCURSOR);
 }
 
 /**

--- a/recvattach.c
+++ b/recvattach.c
@@ -1421,7 +1421,37 @@ void mutt_view_attachments(struct Email *e)
   if (!msg)
     return;
 
+  struct MuttWindow *dlg =
+      mutt_window_new(MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
+                      MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
+  dlg->type = WT_DIALOG;
+  struct MuttWindow *index =
+      mutt_window_new(MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
+                      MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
+  index->type = WT_INDEX;
+  struct MuttWindow *ibar = mutt_window_new(
+      MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_FIXED, 1, MUTT_WIN_SIZE_UNLIMITED);
+  ibar->type = WT_INDEX_BAR;
+
+  if (C_StatusOnTop)
+  {
+    mutt_window_add_child(dlg, ibar);
+    mutt_window_add_child(dlg, index);
+  }
+  else
+  {
+    mutt_window_add_child(dlg, index);
+    mutt_window_add_child(dlg, ibar);
+  }
+
+  dialog_push(dlg);
+
   struct Menu *menu = mutt_menu_new(MENU_ATTACH);
+
+  menu->pagelen = index->state.rows;
+  menu->win_index = index;
+  menu->win_ibar = ibar;
+
   menu->title = _("Attachments");
   menu->menu_make_entry = attach_make_entry;
   menu->menu_tag = attach_tag;
@@ -1705,6 +1735,8 @@ void mutt_view_attachments(struct Email *e)
 
         mutt_menu_pop_current(menu);
         mutt_menu_free(&menu);
+        dialog_pop();
+        mutt_window_free(&dlg);
         return;
     }
 

--- a/recvattach.c
+++ b/recvattach.c
@@ -436,9 +436,9 @@ static void attach_make_entry(char *buf, size_t buflen, struct Menu *menu, int l
 {
   struct AttachCtx *actx = menu->data;
 
-  mutt_expando_format(buf, buflen, 0, menu->win_index->cols, NONULL(C_AttachFormat),
-                      attach_format_str, (unsigned long) (actx->idx[actx->v2r[line]]),
-                      MUTT_FORMAT_ARROWCURSOR);
+  mutt_expando_format(buf, buflen, 0, menu->win_index->state.cols,
+                      NONULL(C_AttachFormat), attach_format_str,
+                      (unsigned long) (actx->idx[actx->v2r[line]]), MUTT_FORMAT_ARROWCURSOR);
 }
 
 /**

--- a/recvattach.c
+++ b/recvattach.c
@@ -436,7 +436,7 @@ static void attach_make_entry(char *buf, size_t buflen, struct Menu *menu, int l
 {
   struct AttachCtx *actx = menu->data;
 
-  mutt_expando_format(buf, buflen, 0, menu->indexwin->cols, NONULL(C_AttachFormat),
+  mutt_expando_format(buf, buflen, 0, menu->win_index->cols, NONULL(C_AttachFormat),
                       attach_format_str, (unsigned long) (actx->idx[actx->v2r[line]]),
                       MUTT_FORMAT_ARROWCURSOR);
 }
@@ -1152,7 +1152,7 @@ int mutt_attach_display_loop(struct Menu *menu, int op, struct Email *e,
 
       case OP_VIEW_ATTACH:
         op = mutt_view_attachment(CUR_ATTACH->fp, CUR_ATTACH->content,
-                                  MUTT_VA_REGULAR, e, actx, menu->indexwin);
+                                  MUTT_VA_REGULAR, e, actx, menu->win_index);
         break;
 
       case OP_NEXT_ENTRY:
@@ -1443,13 +1443,13 @@ void mutt_view_attachments(struct Email *e)
     {
       case OP_ATTACH_VIEW_MAILCAP:
         mutt_view_attachment(CUR_ATTACH->fp, CUR_ATTACH->content,
-                             MUTT_VA_MAILCAP, e, actx, menu->indexwin);
+                             MUTT_VA_MAILCAP, e, actx, menu->win_index);
         menu->redraw = REDRAW_FULL;
         break;
 
       case OP_ATTACH_VIEW_TEXT:
         mutt_view_attachment(CUR_ATTACH->fp, CUR_ATTACH->content,
-                             MUTT_VA_AS_TEXT, e, actx, menu->indexwin);
+                             MUTT_VA_AS_TEXT, e, actx, menu->win_index);
         menu->redraw = REDRAW_FULL;
         break;
 

--- a/recvcmd.c
+++ b/recvcmd.c
@@ -242,9 +242,10 @@ void mutt_attach_bounce(struct Mailbox *m, FILE *fp, struct AttachCtx *actx, str
   snprintf(prompt, sizeof(prompt) - 4,
            ngettext("Bounce message to %s?", "Bounce messages to %s?", p), buf);
 
-  if (mutt_strwidth(prompt) > MuttMessageWindow->cols - EXTRA_SPACE)
+  if (mutt_strwidth(prompt) > MuttMessageWindow->state.cols - EXTRA_SPACE)
   {
-    mutt_simple_format(prompt, sizeof(prompt) - 4, 0, MuttMessageWindow->cols - EXTRA_SPACE,
+    mutt_simple_format(prompt, sizeof(prompt) - 4, 0,
+                       MuttMessageWindow->state.cols - EXTRA_SPACE,
                        JUSTIFY_LEFT, 0, prompt, sizeof(prompt), false);
     mutt_str_strcat(prompt, sizeof(prompt), "...?");
   }

--- a/reflow.c
+++ b/reflow.c
@@ -1,0 +1,234 @@
+/**
+ * @file
+ * Window reflowing
+ *
+ * @authors
+ * Copyright (C) 2019 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @page reflow Window reflowing
+ *
+ * Window reflowing
+ */
+
+#include "config.h"
+#include <stddef.h>
+#include "mutt/mutt.h"
+#include "reflow.h"
+#include "mutt_window.h"
+
+/**
+ * window_reflow_horiz - Reflow Windows using all the available horizontal space
+ * @param win Window
+ */
+void window_reflow_horiz(struct MuttWindow *win)
+{
+  if (!win)
+    return;
+
+  int max_count = 0;
+  int space = win->state.cols;
+
+  // Pass one - minimal allocation
+  struct MuttWindow *np = NULL;
+  TAILQ_FOREACH(np, &win->children, entries)
+  {
+    if (!np->state.visible)
+      continue;
+
+    np->old = np->state; // Save the old state for later notifications
+
+    switch (np->size)
+    {
+      case MUTT_WIN_SIZE_FIXED:
+      {
+        const int avail = MIN(space, np->req_cols);
+        np->state.cols = avail;
+        np->state.rows = win->state.rows;
+        space -= avail;
+        break;
+      }
+      case MUTT_WIN_SIZE_MAXIMISE:
+      {
+        np->state.cols = 1;
+        np->state.rows = win->state.rows;
+        max_count++;
+        space -= 1;
+        break;
+      }
+      case MUTT_WIN_SIZE_MINIMISE:
+      {
+        np->state.rows = win->state.rows;
+        np->state.cols = win->state.cols;
+        np->state.row_offset = win->state.row_offset;
+        np->state.col_offset = win->state.col_offset;
+        window_reflow(np);
+        space -= np->state.cols;
+        break;
+      }
+    }
+  }
+
+  // Pass two - sharing
+  if ((max_count > 0) && (space > 0))
+  {
+    int alloc = (space + max_count - 1) / max_count;
+    TAILQ_FOREACH(np, &win->children, entries)
+    {
+      if (space == 0)
+        break;
+      if (!np->state.visible)
+        continue;
+      if (np->size != MUTT_WIN_SIZE_MAXIMISE)
+        continue;
+
+      alloc = MIN(space, alloc);
+      np->state.cols += alloc;
+      space -= alloc;
+    }
+  }
+
+  // Pass three - position and recursion
+  int col = win->state.col_offset;
+  TAILQ_FOREACH(np, &win->children, entries)
+  {
+    if (!np->state.visible)
+      continue;
+
+    np->state.col_offset = col;
+    np->state.row_offset = win->state.row_offset;
+    col += np->state.cols;
+
+    if (np->size != MUTT_WIN_SIZE_MINIMISE)
+      window_reflow(np);
+  }
+
+  if ((space > 0) && (win->size == MUTT_WIN_SIZE_MINIMISE))
+  {
+    win->state.cols -= space;
+  }
+}
+
+/**
+ * window_reflow_vert - Reflow Windows using all the available vertical space
+ * @param win Window
+ */
+void window_reflow_vert(struct MuttWindow *win)
+{
+  if (!win)
+    return;
+
+  int max_count = 0;
+  int space = win->state.rows;
+
+  // Pass one - minimal allocation
+  struct MuttWindow *np = NULL;
+  TAILQ_FOREACH(np, &win->children, entries)
+  {
+    if (!np->state.visible)
+      continue;
+
+    np->old = np->state; // Save the old state for later notifications
+
+    switch (np->size)
+    {
+      case MUTT_WIN_SIZE_FIXED:
+      {
+        const int avail = MIN(space, np->req_rows);
+        np->state.rows = avail;
+        np->state.cols = win->state.cols;
+        space -= avail;
+        break;
+      }
+      case MUTT_WIN_SIZE_MAXIMISE:
+      {
+        np->state.rows = 1;
+        np->state.cols = win->state.cols;
+        max_count++;
+        space -= 1;
+        break;
+      }
+      case MUTT_WIN_SIZE_MINIMISE:
+      {
+        np->state.rows = win->state.rows;
+        np->state.cols = win->state.cols;
+        np->state.row_offset = win->state.row_offset;
+        np->state.col_offset = win->state.col_offset;
+        window_reflow(np);
+        space -= np->state.rows;
+        break;
+      }
+    }
+  }
+
+  // Pass two - sharing
+  if ((max_count > 0) && (space > 0))
+  {
+    int alloc = (space + max_count - 1) / max_count;
+    TAILQ_FOREACH(np, &win->children, entries)
+    {
+      if (space == 0)
+        break;
+      if (!np->state.visible)
+        continue;
+      if (np->size != MUTT_WIN_SIZE_MAXIMISE)
+        continue;
+
+      alloc = MIN(space, alloc);
+      np->state.rows += alloc;
+      space -= alloc;
+    }
+  }
+
+  // Pass three - position and recursion
+  int row = win->state.row_offset;
+  TAILQ_FOREACH(np, &win->children, entries)
+  {
+    if (!np->state.visible)
+      continue;
+
+    np->state.row_offset = row;
+    np->state.col_offset = win->state.col_offset;
+    row += np->state.rows;
+
+    if (np->size != MUTT_WIN_SIZE_MINIMISE)
+      window_reflow(np);
+  }
+
+  if ((space > 0) && (win->size == MUTT_WIN_SIZE_MINIMISE))
+  {
+    win->state.rows -= space;
+  }
+}
+
+/**
+ * window_reflow - Reflow Windows
+ * @param win Root Window
+ *
+ * Using the rules coded into the Windows, such as Fixed or Maximise, allocate
+ * space to a set of nested Windows.
+ */
+void window_reflow(struct MuttWindow *win)
+{
+  if (!win)
+    return;
+  if (win->orient == MUTT_WIN_ORIENT_VERTICAL)
+    window_reflow_vert(win);
+  else
+    window_reflow_horiz(win);
+}

--- a/reflow.h
+++ b/reflow.h
@@ -1,0 +1,30 @@
+/**
+ * @file
+ * Window management
+ *
+ * @authors
+ * Copyright (C) 2018 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MUTT_REFLOW_H
+#define MUTT_REFLOW_H
+
+struct MuttWindow;
+
+void window_reflow(struct MuttWindow *win);
+
+#endif /* MUTT_REFLOW_H */

--- a/remailer.c
+++ b/remailer.c
@@ -515,7 +515,7 @@ static const char *mix_format_str(char *buf, size_t buflen, size_t col, int cols
 static void mix_entry(char *buf, size_t buflen, struct Menu *menu, int num)
 {
   struct Remailer **type2_list = menu->data;
-  mutt_expando_format(buf, buflen, 0, menu->indexwin->cols,
+  mutt_expando_format(buf, buflen, 0, menu->win_index->cols,
                       NONULL(C_MixEntryFormat), mix_format_str,
                       (unsigned long) type2_list[num], MUTT_FORMAT_ARROWCURSOR);
 }
@@ -625,14 +625,14 @@ void mix_make_chain(struct MuttWindow *win, struct ListHead *chainhead, int cols
 
     if (c_redraw)
     {
-      mix_redraw_head(menu->indexwin, chain);
-      mix_redraw_chain(menu->indexwin, type2_list, coords, chain, c_cur);
+      mix_redraw_head(menu->win_index, chain);
+      mix_redraw_chain(menu->win_index, type2_list, coords, chain, c_cur);
       c_redraw = false;
     }
     else if (c_cur != c_old)
     {
-      mix_redraw_ce(menu->indexwin, type2_list, coords, chain, c_old, false);
-      mix_redraw_ce(menu->indexwin, type2_list, coords, chain, c_cur, true);
+      mix_redraw_ce(menu->win_index, type2_list, coords, chain, c_old, false);
+      mix_redraw_ce(menu->win_index, type2_list, coords, chain, c_cur, true);
     }
 
     c_old = c_cur;
@@ -643,9 +643,9 @@ void mix_make_chain(struct MuttWindow *win, struct ListHead *chainhead, int cols
       case OP_REDRAW:
       {
         menu_redraw_status(menu);
-        mix_redraw_head(menu->indexwin, chain);
-        mix_screen_coordinates(menu->indexwin, type2_list, &coords, chain, 0);
-        mix_redraw_chain(menu->indexwin, type2_list, coords, chain, c_cur);
+        mix_redraw_head(menu->win_index, chain);
+        mix_screen_coordinates(menu->win_index, type2_list, &coords, chain, 0);
+        mix_redraw_chain(menu->win_index, type2_list, coords, chain, c_cur);
         menu->pagelen = MIX_VOFFSET - 1;
         break;
       }
@@ -663,7 +663,7 @@ void mix_make_chain(struct MuttWindow *win, struct ListHead *chainhead, int cols
         {
           chain->cl++;
           chain->ch[0] = menu->current;
-          mix_screen_coordinates(menu->indexwin, type2_list, &coords, chain, c_cur);
+          mix_screen_coordinates(menu->win_index, type2_list, &coords, chain, c_cur);
           c_redraw = true;
         }
 
@@ -697,7 +697,7 @@ void mix_make_chain(struct MuttWindow *win, struct ListHead *chainhead, int cols
             chain->ch[i] = chain->ch[i - 1];
 
           chain->ch[c_cur] = menu->current;
-          mix_screen_coordinates(menu->indexwin, type2_list, &coords, chain, c_cur);
+          mix_screen_coordinates(menu->win_index, type2_list, &coords, chain, c_cur);
           c_redraw = true;
         }
         else
@@ -721,7 +721,7 @@ void mix_make_chain(struct MuttWindow *win, struct ListHead *chainhead, int cols
           if ((c_cur == chain->cl) && c_cur)
             c_cur--;
 
-          mix_screen_coordinates(menu->indexwin, type2_list, &coords, chain, c_cur);
+          mix_screen_coordinates(menu->win_index, type2_list, &coords, chain, c_cur);
           c_redraw = true;
         }
         else

--- a/remailer.c
+++ b/remailer.c
@@ -60,8 +60,8 @@ char *C_MixEntryFormat; ///< Config: (mixmaster) printf-like format string for t
 char *C_Mixmaster; ///< Config: (mixmaster) External command to route a mixmaster message
 
 #define MIX_HOFFSET 2
-#define MIX_VOFFSET (win->rows - 4)
-#define MIX_MAXROW (win->rows - 1)
+#define MIX_VOFFSET (win->state.rows - 4)
+#define MIX_MAXROW (win->state.rows - 1)
 
 /**
  * struct Coord - Screen coordinates
@@ -309,7 +309,7 @@ static void mix_screen_coordinates(struct MuttWindow *win, struct Remailer **typ
     short oc = c;
     c += strlen(type2_list[chain->ch[i]]->shortname) + 2;
 
-    if (c >= win->cols)
+    if (c >= win->state.cols)
     {
       oc = MIX_HOFFSET;
       c = MIX_HOFFSET;
@@ -515,7 +515,7 @@ static const char *mix_format_str(char *buf, size_t buflen, size_t col, int cols
 static void mix_entry(char *buf, size_t buflen, struct Menu *menu, int num)
 {
   struct Remailer **type2_list = menu->data;
-  mutt_expando_format(buf, buflen, 0, menu->win_index->cols,
+  mutt_expando_format(buf, buflen, 0, menu->win_index->state.cols,
                       NONULL(C_MixEntryFormat), mix_format_str,
                       (unsigned long) type2_list[num], MUTT_FORMAT_ARROWCURSOR);
 }

--- a/resize.c
+++ b/resize.c
@@ -91,7 +91,8 @@ void mutt_resize_screen(void)
   SLsmg_init_smg();
   stdscr = newwin(0, 0, 0, 0);
   keypad(stdscr, true);
-  mutt_window_reflow();
+  mutt_window_set_root(w.ws_row, w.ws_col);
+  mutt_window_reflow(NULL);
 }
 #else
 /**
@@ -119,6 +120,7 @@ void mutt_resize_screen(void)
   }
 
   resizeterm(screenrows, screencols);
-  mutt_window_reflow();
+  mutt_window_set_root(w.ws_row, w.ws_col);
+  mutt_window_reflow(NULL);
 }
 #endif

--- a/sidebar.c
+++ b/sidebar.c
@@ -979,8 +979,8 @@ void mutt_sb_draw(void)
   int row = 0, col = 0;
   mutt_window_get_coords(win, &row, &col);
 
-  int num_rows = win->rows;
-  int num_cols = win->cols;
+  int num_rows = win->state.rows;
+  int num_cols = win->state.cols;
 
   int div_width = draw_divider(win, num_rows, num_cols);
 

--- a/sidebar.h
+++ b/sidebar.h
@@ -28,6 +28,8 @@
 #include <stdbool.h>
 
 struct Mailbox;
+struct MuttWindow;
+struct NotifyCallback;
 
 /* These Config Variables are only used in sidebar.c */
 extern short C_SidebarComponentDepth;
@@ -39,13 +41,17 @@ extern char *C_SidebarIndentString;
 extern bool  C_SidebarNewMailOnly;
 extern bool  C_SidebarNonEmptyMailboxOnly;
 extern bool  C_SidebarNextNewWrap;
+extern bool  C_SidebarOnRight;
 extern bool  C_SidebarShortPath;
 extern short C_SidebarSortMethod;
+extern bool  C_SidebarVisible;
+extern short C_SidebarWidth;
 
-void mutt_sb_change_mailbox(int op);
-void mutt_sb_draw(void);
-struct Mailbox *mutt_sb_get_highlight(void);
-void mutt_sb_notify_mailbox(struct Mailbox *m, bool created);
-void mutt_sb_set_open_mailbox(struct Mailbox *m);
+void            mutt_sb_change_mailbox  (int op);
+void            mutt_sb_draw            (struct MuttWindow *win);
+struct Mailbox *mutt_sb_get_highlight   (void);
+void            mutt_sb_notify_mailbox  (struct Mailbox *m, bool created);
+int             mutt_sb_observer        (struct NotifyCallback *nc);
+void            mutt_sb_set_open_mailbox(struct Mailbox *m);
 
 #endif /* MUTT_SIDEBAR_H */

--- a/status.c
+++ b/status.c
@@ -408,6 +408,6 @@ static const char *status_format_str(char *buf, size_t buflen, size_t col, int c
  */
 void menu_status_line(char *buf, size_t buflen, struct Menu *menu, const char *p)
 {
-  mutt_expando_format(buf, buflen, 0, menu ? menu->win_ibar->cols : buflen, p,
+  mutt_expando_format(buf, buflen, 0, menu ? menu->win_ibar->state.cols : buflen, p,
                       status_format_str, (unsigned long) menu, MUTT_FORMAT_NO_FLAGS);
 }

--- a/status.c
+++ b/status.c
@@ -408,6 +408,6 @@ static const char *status_format_str(char *buf, size_t buflen, size_t col, int c
  */
 void menu_status_line(char *buf, size_t buflen, struct Menu *menu, const char *p)
 {
-  mutt_expando_format(buf, buflen, 0, menu ? menu->statuswin->cols : buflen, p,
+  mutt_expando_format(buf, buflen, 0, menu ? menu->win_ibar->cols : buflen, p,
                       status_format_str, (unsigned long) menu, MUTT_FORMAT_NO_FLAGS);
 }


### PR DESCRIPTION
These changes start to encapsulate panels/menus as "Dialogs".
(Dialogs will eventually be self-contained and event-driven).

## Visible Changes

These commits change the appearance of the screen.
The two main differences are the **Status Bar** and the **Sidebar**.

The Status Bar is now slightly narrower because it doesn't run under the Sidebar.
That's because the Status Bar is tightly coupled with the Index Panel.

The Sidebar is now only visible when the Index/Pager dialog is active.
It should never have been visible when composing an email, or selecting an alias.

## Code Changes

### No functional changes

These changes do some preliminary tidying in an attempt to make the later commits clearer.

- 4121f6d0f tidy query_menu()
  return early to reduce indent
- 7b9e14121 rename menu members
- 2d06e6a3a rename window members
- 8eabfd587 factor out MuttSidebarWindow
  Pass window as a parameter
- 50d5aa906 window: add states
  Insert wrapper around window state
- c83901898 window: extend MuttWindow
  Add new members
- 8bb6bdf96 window: add helper functions

### Convert to a set of nested Windows

These changes look like a complete mess.
The original code created a few Windows that were continually reused by all the menus in NeoMutt.

The new code has nested Windows, only exposing three of them:

- `MuttHelpWindow` - Help bar at the top of the screen
- `MuttMessageWindow` - Message window / Command entry at the bottom of the screen
- `MuttDialogWindow` - A container which holds a stack of dialogs

Each time NeoMutt wants to show a menu to the user, it constructs a "Dialog" of nested Windows.
The next step is to attach their currently global data to the Window.
This will mean that a second instance of a Dialog would be independent of the first, e.g.

- Index Dialog -\> Compose Dialog -\> Index Dialog

The new file `reflow.c` performs the re-shaping, of Windows to fit the screen.
It **only** relies on settings on the `MuttWindow` to perform its work. e.g.

- `visible = true`
- `MUTT_WIN_ORIENT_VERTICAL`
- `MUTT_WIN_SIZE_FIXED`
- `req_cols = 15`

Commits:

- 5406347bc window: create nested layout
- 1088f9276 window: reflow
- 1338b7726 pager: externalise the Windows
- a0b18282b dialogs
- 3d26edb0b sidebar: split out config

### Upgrade all dialogs to use new Windows

These changes are still a bit verbose, a bit repetitive.
This is because the event loop (`mutt_menu_loop()`) happens **in** the dialog. 
The plan is to move this outside, so that the dialogs simply react to events.

- 5401574cd dialog addrbook
- 9f56e9c70 dialog attach
- 8f015f630 dialog autocrypt
- 7355fa12a dialog browser
- 57c401806 dialog compose
- 8188087dc dialog gnutls
- ddd4480ee dialog history
- d90a6b289 dialog ncrypt 3
- 10aad7a77 dialog postpone
- 7443c5c41 dialog query
- 0ce44dfb8 dialog remailer
- d0ea2b58f dialog ssl

---

![layout](https://flatcap.org/mutt/neomutt24.svg)

- **R** - Root Window
- **D** - Dialogs Container
- **I** - Index Dialog
- **4**,**5**,**6** - Containers for layout

