### PR TITLE
compose(attach-message): support notmuch backend

### DIFF
--- a/compose.c
+++ b/compose.c
@@ -1710,11 +1710,14 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur, 
 #ifdef USE_NNTP
             if (!OptNews && (nntp_path_probe(mutt_b2s(&fname), NULL) != MUTT_NNTP))
 #endif
-              /* check to make sure the file exists and is readable */
-              if (access(mutt_b2s(&fname), R_OK) == -1)
+              if (mx_path_probe(mutt_b2s(&fname), NULL) != MUTT_NOTMUCH)
               {
-                mutt_perror(mutt_b2s(&fname));
-                break;
+                /* check to make sure the file exists and is readable */
+                if (access(mutt_b2s(&fname), R_OK) == -1)
+                {
+                  mutt_perror(mutt_b2s(&fname));
+                  break;
+                }
               }
 
         menu->redraw = REDRAW_FULL;


### PR DESCRIPTION
Exclude the notmuch backend from the 'attach-message' command's
filesystem check. This check applies to all backends except remote
backends (IMAP, POP, NNTP.) The notmuch backend functions similar to a
remote backend, communicating through a protocol. As such, Neomutt
checks for a notmuch mailbox on disk and fails when it cannot find one.

Fixes #2062 

This portion of `compose.c` needs to be refactored to support the MX api, 
but that's outside the scope of this PR. 