### PR TITLE
refactor: imap's cmd_parse_status()

### DIFF
--- a/imap/command.c
+++ b/imap/command.c
@@ -781,6 +781,28 @@ static void cmd_parse_search(struct ImapAccountData *adata, const char *s)
 }
 
 /**
+ * find_mailbox - Find a Mailbox by its name
+ * @param adata Imap Account data
+ * @param name  Mailbox to find
+ * @retval ptr Mailbox
+ */
+static struct Mailbox *find_mailbox(struct ImapAccountData *adata, const char *name)
+{
+  if (!adata || !adata->account || !name)
+    return NULL;
+
+  struct MailboxNode *np = NULL;
+  STAILQ_FOREACH(np, &adata->account->mailboxes, entries)
+  {
+    struct ImapMboxData *mdata = imap_mdata_get(np->mailbox);
+    if (mutt_str_strcmp(name, mdata->name) == 0)
+      return np->mailbox;
+  }
+
+  return NULL;
+}
+
+/**
  * cmd_parse_status - Parse status from server
  * @param adata Imap Account data
  * @param s     Command string with status info
@@ -822,13 +844,7 @@ static void cmd_parse_status(struct ImapAccountData *adata, char *s)
     imap_unmunge_mbox_name(adata->unicode, mailbox);
   }
 
-  struct Url url;
-  mutt_account_tourl(&adata->conn_account, &url);
-  url.path = mailbox;
-  char path[PATH_MAX];
-  url_tostring(&url, path, sizeof(path), 0);
-
-  struct Mailbox *m = mx_mbox_find2(path);
+  struct Mailbox *m = find_mailbox(adata, mailbox);
   struct ImapMboxData *mdata = imap_mdata_get(m);
   if (!mdata)
   {

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -1879,7 +1879,7 @@ static int imap_ac_add(struct Account *a, struct Mailbox *m)
     if (imap_parse_path(mailbox_path(m), &conn_account, mailbox, sizeof(mailbox)) < 0)
       return -1;
 
-    adata = imap_adata_new();
+    adata = imap_adata_new(a);
     adata->conn_account = conn_account;
     adata->conn = mutt_conn_new(&conn_account);
     if (!adata->conn)

--- a/imap/imap_private.h
+++ b/imap/imap_private.h
@@ -203,6 +203,7 @@ struct ImapAccountData
 
   char delim;
   struct Mailbox *mailbox;     /* Current selected mailbox */
+  struct Account *account;     ///< Parent Account
 };
 
 /**
@@ -311,7 +312,7 @@ char *imap_hcache_get_uid_seqset(struct ImapMboxData *mdata);
 
 enum QuadOption imap_continue(const char *msg, const char *resp);
 void imap_error(const char *where, const char *msg);
-struct ImapAccountData *imap_adata_new(void);
+struct ImapAccountData *imap_adata_new(struct Account *a);
 void imap_adata_free(void **ptr);
 struct ImapMboxData *imap_mdata_new(struct ImapAccountData *adata, const char* name);
 void imap_mdata_free(void **ptr);

--- a/imap/util.c
+++ b/imap/util.c
@@ -92,9 +92,11 @@ void imap_adata_free(void **ptr)
  * imap_adata_new - Allocate and initialise a new ImapAccountData structure
  * @retval ptr New ImapAccountData
  */
-struct ImapAccountData *imap_adata_new(void)
+struct ImapAccountData *imap_adata_new(struct Account *a)
 {
   struct ImapAccountData *adata = mutt_mem_calloc(1, sizeof(struct ImapAccountData));
+  adata->account = a;
+
   static unsigned char new_seqid = 'a';
 
   adata->seqid = new_seqid;


### PR DESCRIPTION
Tidy the code handling IMAP's response to a 'STATUS' command.

- 76e4fea50 tidy: cmd_parse_status()
- 555ba4dba add Account to ImapAccountData
- 9823f67fe lookup a Mailbox internally

When we get an untagged response from the server, we need to lookup the Mailbox.
We know the Account and have the Mailbox name from the server.

The MXAPI lookup functions perform a lot of unnecessary work searching through
all the Accounts, turning the Mailbox path into a URL and canonicalising it.