### PR TITLE
update_index() never gets called

### DIFF
--- a/imap/imap.c
+++ b/imap/imap.c
@@ -1642,8 +1642,12 @@ out:
  * @param m       Mailbox
  * @param expunge if true do expunge
  * @param close   if true we move imap state to CLOSE
+ * @retval #MUTT_REOPENED  mailbox has been externally modified
+ * @retval #MUTT_NEW_MAIL  new mail has arrived
  * @retval  0 Success
  * @retval -1 Error
+ *
+ * @note The flag retvals come from a call to imap_check_mailbox()
  */
 int imap_sync_mailbox(struct Mailbox *m, bool expunge, bool close)
 {
@@ -1653,6 +1657,7 @@ int imap_sync_mailbox(struct Mailbox *m, bool expunge, bool close)
   struct Email **emails = NULL;
   int oldsort;
   int rc;
+  int check;
 
   struct ImapAccountData *adata = imap_adata_get(m);
   struct ImapMboxData *mdata = imap_mdata_get(m);
@@ -1667,9 +1672,9 @@ int imap_sync_mailbox(struct Mailbox *m, bool expunge, bool close)
    * to be changed. */
   imap_allow_reopen(m);
 
-  rc = imap_check_mailbox(m, false);
-  if (rc < 0)
-    return rc;
+  check = imap_check_mailbox(m, false);
+  if (check < 0)
+    return check;
 
   /* if we are expunging anyway, we can do deleted messages very quickly... */
   if (expunge && (m->rights & MUTT_ACL_DELETE))
@@ -1841,7 +1846,7 @@ int imap_sync_mailbox(struct Mailbox *m, bool expunge, bool close)
   if (C_MessageCacheClean)
     imap_cache_clean(m);
 
-  return 0;
+  return check;
 }
 
 /**

--- a/mx.c
+++ b/mx.c
@@ -575,8 +575,12 @@ static int trash_append(struct Mailbox *m)
 /**
  * mx_mbox_close - Save changes and close mailbox
  * @param[out] ptr Mailbox
+ * @retval #MUTT_REOPENED  mailbox has been externally modified
+ * @retval #MUTT_NEW_MAIL  new mail has arrived
  * @retval  0 Success
  * @retval -1 Failure
+ *
+ * @note The flag retvals come from a call to a backend sync function
  *
  * @note Context will be freed after it's closed
  */
@@ -794,7 +798,10 @@ int mx_mbox_close(struct Context **ptr)
   {
     int check = imap_sync_mailbox(ctx->mailbox, (purge != MUTT_NO), true);
     if (check != 0)
+    {
+      rc = check;
       goto cleanup;
+    }
   }
   else
 #endif
@@ -817,7 +824,10 @@ int mx_mbox_close(struct Context **ptr)
     {
       int check = sync_mailbox(ctx->mailbox, NULL);
       if (check != 0)
+      {
+        rc = check;
         goto cleanup;
+      }
     }
   }
 
@@ -874,8 +884,12 @@ cleanup:
  * mx_mbox_sync - Save changes to mailbox
  * @param[in]  m          Mailbox
  * @param[out] index_hint Currently selected Email
+ * @retval #MUTT_REOPENED  mailbox has been externally modified
+ * @retval #MUTT_NEW_MAIL  new mail has arrived
  * @retval  0 Success
  * @retval -1 Error
+ *
+ * @note The flag retvals come from a call to a backend sync function
  */
 int mx_mbox_sync(struct Mailbox *m, int *index_hint)
 {


### PR DESCRIPTION
Here's the call graph:

<img width="600" src="https://flatcap.org/mutt/2083.svg">

`imap_check_mailbox()` can return `MUTT_NEW_MAIL` or `MUTT_REOPENED`.
Despite what the function comments say, these functions can also return the values above:
- `mx_mbox_close()`
- `mx_mbox_sync()`
- `imap_sync_mailbox()`

Unfortunately, a couple of problems prevent the values being propagated back to the index.

### `mx_mbox_close()`

A recent refactoring meant that return values weren't being propagated.
Commit: 941e39acc fixes that (in this PR).

### `imap_sync_mailbox()`

This function **used** to return the result of `imap_check_mailbox()`.
That was changed by commit: 60270c9fa8

> imap: fixing race when syncing mailbox
> imap_check_mailbox returns a detailed state not only 0/-1.
> imap_sync_mailbox assumes that the function was returning only 0/-1.
> This change fixes that.

```diff
diff --git a/imap/imap.c b/imap/imap.c
@@ -1652,7 +1652,7 @@ int imap_sync_mailbox(struct Mailbox *m, bool expunge, bool close)
   imap_allow_reopen(m);
 
   rc = imap_check_mailbox(m, false);
-  if (rc != 0)
+  if (rc < 0)
     return rc;
 
   /* if we are expunging anyway, we can do deleted messages very quickly... */
```

I need to find out what this was fixing before I can change it back.

Issue: #2083

