### PR TITLE
IMAP: add support for COMPRESS=DEFLATE, RFC4978

### DIFF
--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -85,6 +85,9 @@ NEOMUTTOBJS+=	mutt_lua.o
 @if USE_INOTIFY
 NEOMUTTOBJS+=	monitor.o
 @endif
+@if USE_ZLIB
+NEOMUTTOBJS+=	mutt_zstrm.o
+@endif
 
 CLEANFILES+=	$(NEOMUTT) $(NEOMUTTOBJS)
 ALLOBJS+=	$(NEOMUTTOBJS)

--- a/auto.def
+++ b/auto.def
@@ -94,6 +94,9 @@ options {
 # sqlite
   sqlite=0                  => "Enable SQLite support"
   with-sqlite:path          => "Location of sqlite"
+# zlib
+  zlib=0                    => "Enable zlib support"
+  with-zlib:path            => "Location of zlib"
 # Debug options
   backtrace=0               => "DEBUG: Enable backtrace support with libunwind"
   with-backtrace:path       => "Location of libunwind"
@@ -119,7 +122,7 @@ if {1} {
     autocrypt backtrace bdb coverage doc everything fmemopen full-doc gdbm
     gnutls gpgme gss homespool idn idn2 inotify kyotocabinet lmdb locales-fix
     lua mixmaster nls notmuch pgp pkgconf qdbm sasl smime sqlite ssl testing
-    tokyocabinet
+    tokyocabinet zlib
   } {
     define want-$opt [opt-bool $opt]
   }
@@ -129,7 +132,7 @@ if {1} {
   # a shortcut for "--opt --with-opt=/usr".
   foreach opt {
     bdb gdbm gnutls gpgme gss homespool idn idn2 kyotocabinet lmdb lua mixmaster
-    ncurses nls notmuch qdbm sasl slang sqlite ssl tokyocabinet
+    ncurses nls notmuch qdbm sasl slang sqlite ssl tokyocabinet zlib
   } {
     if {[opt-val with-$opt] ne {}} {
       define want-$opt 1
@@ -635,6 +638,16 @@ if {[get-define want-sqlite]} {
     user-error "Unable to find SQLite"
   }
   define USE_SQLITE
+}
+
+###############################################################################
+# zlib Support
+if {[get-define want-zlib]} {
+  if {![check-inc-and-lib zlib [opt-val with-zlib $prefix] \
+                          zlib.h deflate z]} {
+    user-error "Unable to find zlib"
+  }
+  define USE_ZLIB
 }
 
 ###############################################################################

--- a/doc/makedoc_defs.h
+++ b/doc/makedoc_defs.h
@@ -90,6 +90,9 @@
 #ifndef USE_AUTOCRYPT
 #define USE_AUTOCRYPT
 #endif
+#ifndef USE_ZLIB
+#define USE_ZLIB
+#endif
 #endif
 
 #endif /* _MUTT_MAKEDOC_DEFS_H */

--- a/doc/manual.xml.head
+++ b/doc/manual.xml.head
@@ -17505,9 +17505,18 @@ folder-hook ^pop 'set read_inc=1'
         will be gone for the next session.)
       </para>
       <para>
-        To improve performance and permanently cache whole messages, please
-        refer to NeoMutt's so-called
-        <link linkend="body-caching">body caching</link> for details.
+        To improve performance and permanently cache whole messages and
+        headers, please refer to <link linkend="body-caching">body caching</link>
+        and <link linkend="header-caching">header caching</link> for details.
+      </para>
+      <para>
+        Additionally, it may be worth trying some of Mutt's experimental
+        features.  <link linkend="imap-qresync">$imap_qresync</link> (which
+        requires header caching) can provide a huge speed boost opening
+        mailboxes if your IMAP server supports it.
+        <link linkend="imap-deflate">$imap_deflate</link> enables compression,
+        which can also noticeably reduce download time for large mailboxes and
+        messages.
       </para>
     </sect1>
 

--- a/imap/command.c
+++ b/imap/command.c
@@ -62,12 +62,25 @@ bool C_ImapServernoise; ///< Config: (imap) Display server warnings as error mes
  * @note This must be kept in the same order as ImapCaps.
  */
 static const char *const Capabilities[] = {
-  "IMAP4",       "IMAP4rev1",      "STATUS",
-  "ACL",         "NAMESPACE",      "AUTH=CRAM-MD5",
-  "AUTH=GSSAPI", "AUTH=ANONYMOUS", "AUTH=OAUTHBEARER",
-  "STARTTLS",    "LOGINDISABLED",  "IDLE",
-  "SASL-IR",     "ENABLE",         "CONDSTORE",
-  "QRESYNC",     "LIST-EXTENDED",  "X-GM-EXT-1",
+  "IMAP4",
+  "IMAP4rev1",
+  "STATUS",
+  "ACL",
+  "NAMESPACE",
+  "AUTH=CRAM-MD5",
+  "AUTH=GSSAPI",
+  "AUTH=ANONYMOUS",
+  "AUTH=OAUTHBEARER",
+  "STARTTLS",
+  "LOGINDISABLED",
+  "IDLE",
+  "SASL-IR",
+  "ENABLE",
+  "CONDSTORE",
+  "QRESYNC",
+  "LIST-EXTENDED",
+  "COMPRESS=DEFLATE",
+  "X-GM-EXT-1",
   NULL,
 };
 

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -60,10 +60,16 @@
 #ifdef ENABLE_NLS
 #include <libintl.h>
 #endif
+#ifdef USE_ZLIB
+#include "mutt_zstrm.h"
+#endif
 
 struct stat;
 
 /* These Config Variables are only used in imap/imap.c */
+#ifdef USE_ZLIB
+bool C_ImapDeflate; ///< Config: (imap) Compress network traffic
+#endif
 bool C_ImapIdle; ///< Config: (imap) Use the IMAP IDLE extension to check for new mail
 bool C_ImapRfc5161; ///< Config: (imap) Use the IMAP ENABLE extension to select capabilities
 
@@ -1980,6 +1986,15 @@ int imap_login(struct ImapAccountData *adata)
   {
     /* capabilities may have changed */
     imap_exec(adata, "CAPABILITY", IMAP_CMD_QUEUE);
+
+#ifdef USE_ZLIB
+    /* RFC4978 */
+    if ((adata->capabilities & IMAP_CAP_COMPRESS) && C_ImapDeflate &&
+        (imap_exec(adata, "COMPRESS DEFLATE", IMAP_CMD_PASS) == IMAP_EXEC_SUCCESS))
+    {
+      mutt_zstrm_wrap_conn(adata->conn);
+    }
+#endif
 
     /* enable RFC6855, if the server supports that */
     if (C_ImapRfc5161 && (adata->capabilities & IMAP_CAP_ENABLE))

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -1985,7 +1985,7 @@ int imap_login(struct ImapAccountData *adata)
   if (adata->state == IMAP_AUTHENTICATED)
   {
     /* capabilities may have changed */
-    imap_exec(adata, "CAPABILITY", IMAP_CMD_QUEUE);
+    imap_exec(adata, "CAPABILITY", IMAP_CMD_PASS);
 
 #ifdef USE_ZLIB
     /* RFC4978 */

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -1992,6 +1992,7 @@ int imap_login(struct ImapAccountData *adata)
     if ((adata->capabilities & IMAP_CAP_COMPRESS) && C_ImapDeflate &&
         (imap_exec(adata, "COMPRESS DEFLATE", IMAP_CMD_PASS) == IMAP_EXEC_SUCCESS))
     {
+      mutt_debug(LL_DEBUG2, "IMAP compression is enabled on connection to %s\n", adata->conn->account.host);
       mutt_zstrm_wrap_conn(adata->conn);
     }
 #endif

--- a/imap/imap.h
+++ b/imap/imap.h
@@ -65,6 +65,9 @@ struct stat;
 extern struct Slist *C_ImapAuthenticators;
 
 /* These Config Variables are only used in imap/imap.c */
+#ifdef USE_ZLIB
+extern bool C_ImapDeflate;
+#endif
 extern bool C_ImapIdle;
 extern bool C_ImapRfc5161;
 

--- a/imap/imap_private.h
+++ b/imap/imap_private.h
@@ -134,9 +134,10 @@ typedef uint32_t ImapCapFlags;              ///< Flags, e.g. #IMAP_CAP_IMAP4
 #define IMAP_CAP_CONDSTORE        (1 << 14) ///< RFC7162
 #define IMAP_CAP_QRESYNC          (1 << 15) ///< RFC7162
 #define IMAP_CAP_LIST_EXTENDED    (1 << 16) ///< RFC5258: IMAP4 LIST Command Extensions
-#define IMAP_CAP_X_GM_EXT_1       (1 << 17) ///< https://developers.google.com/gmail/imap/imap-extensions
+#define IMAP_CAP_COMPRESS         (1 << 17) ///< RFC4978: COMPRESS=DEFLATE
+#define IMAP_CAP_X_GM_EXT_1       (1 << 18) ///< https://developers.google.com/gmail/imap/imap-extensions
 
-#define IMAP_CAP_ALL             ((1 << 18) - 1)
+#define IMAP_CAP_ALL             ((1 << 19) - 1)
 
 /**
  * struct ImapList - Items in an IMAP browser

--- a/mutt_config.c
+++ b/mutt_config.c
@@ -1597,6 +1597,17 @@ struct ConfigDef MuttVars[] = {
   ** those, and displays worse performance when enabled.  Your
   ** mileage may vary.
   */
+#ifdef USE_ZLIB
+  { "imap_deflate", DT_BOOL, &C_ImapDeflate, true },
+  /*
+  ** .pp
+  ** When \fIset\fP, mutt will use the COMPRESS=DEFLATE extension (RFC4978)
+  ** if advertised by the server.
+  ** .pp
+  ** In general a good compression efficiency can be achieved, which
+  ** speeds up reading large mailboxes also on fairly good connections.
+  */
+#endif
   { "imap_delim_chars", DT_STRING, &C_ImapDelimChars, IP "/." },
   /*
   ** .pp

--- a/mutt_zstrm.c
+++ b/mutt_zstrm.c
@@ -1,6 +1,6 @@
 /**
  * @file
- * IMAP traffic compression
+ * Zlib compression of network traffic
  *
  * Copyright(C) 2019 Fabian Groffen <grobian@gentoo.org>
  *
@@ -19,6 +19,12 @@
  * this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+/**
+ * @page zlib Zlib compression of network traffic
+ *
+ * Zlib compression of network traffic
+ */
+
 #include "config.h"
 #include <errno.h>
 #include <string.h>
@@ -28,59 +34,84 @@
 #include "mutt_zstrm.h"
 #include "mutt_socket.h"
 
-typedef struct
+/**
+ * struct ZstrmDirection - A stream of data being (de-)compressed
+ */
+struct ZstrmDirection
 {
-  struct zstrm_direction
-  {
-    z_stream z;
-    char *buf;
-    unsigned int len;
-    unsigned int pos;
-    unsigned int conn_eof : 1;
-    unsigned int stream_eof : 1;
-  } read, write;
+  z_stream z;          ///< zlib compression handle
+  char *buf;           ///< Buffer for data being (de-)compressed
+  unsigned int len;    ///< Length of data
+  unsigned int pos;    ///< Current position
+  bool conn_eof   : 1; ///< Connection end-of-file reached
+  bool stream_eof : 1; ///< Stream end-of-file reached
+};
 
-  /* underlying stream */
-  struct Connection next_conn;
-} zstrmctx;
-
-/* simple wrapper functions to match zlib interface for calling
- * malloc/free */
-static void *mutt_zstrm_malloc(void *op, unsigned int sze, unsigned int v)
+/**
+ * struct ZstrmContext - Data compression layer
+ */
+struct ZstrmContext
 {
-  return mutt_mem_calloc(sze, v);
+  struct ZstrmDirection read;  ///< Data being read and de-compressed
+  struct ZstrmDirection write; ///< Data being compressed and written
+  struct Connection next_conn; ///< Underlying stream
+};
+
+/**
+ * zstrm_malloc - Redirector function for zlib's malloc()
+ * @param opaque Opaque zlib handle
+ * @param items  Number of blocks
+ * @param size   Size of blocks
+ * @retval ptr Memory on the heap
+ */
+static void *zstrm_malloc(void *opaque, unsigned int items, unsigned int size)
+{
+  return mutt_mem_calloc(items, size);
 }
 
-static void mutt_zstrm_free(void *op, void *ptr)
+/**
+ * zstrm_free - Redirector function for zlib's free()
+ * @param opaque  Opaque zlib handle
+ * @param address Memory to free
+ */
+static void zstrm_free(void *opaque, void *address)
 {
-  FREE(&ptr);
+  FREE(&address);
 }
 
-static int mutt_zstrm_open(struct Connection *conn)
+/**
+ * zstrm_open - Open a socket - Implements Connection::conn_open()
+ * @retval -1 Always
+ *
+ * Cannot open a zlib connection, must wrap an existing one
+ */
+static int zstrm_open(struct Connection *conn)
 {
-  /* cannot open a zlib connection, must wrap an existing one */
   return -1;
 }
 
-static int mutt_zstrm_close(struct Connection *conn)
+/**
+ * zstrm_close - Close a socket - Implements Connection::conn_close()
+ */
+static int zstrm_close(struct Connection *conn)
 {
-  zstrmctx *zctx = conn->sockdata;
+  struct ZstrmContext *zctx = conn->sockdata;
+
   int rc = zctx->next_conn.conn_close(&zctx->next_conn);
 
-  mutt_debug(LL_DEBUG4,
-             "zstrm_close: read %llu->%llu (%.1fx) "
-             "wrote %llu<-%llu (%.1fx)\n",
+  mutt_debug(LL_DEBUG5, "read %llu->%llu (%.1fx) wrote %llu<-%llu (%.1fx)\n",
              zctx->read.z.total_in, zctx->read.z.total_out,
              (float) zctx->read.z.total_out / (float) zctx->read.z.total_in,
              zctx->write.z.total_in, zctx->write.z.total_out,
              (float) zctx->write.z.total_in / (float) zctx->write.z.total_out);
 
-  conn->sockdata   = zctx->next_conn.sockdata;
-  conn->conn_open  = zctx->next_conn.conn_open;
+  // Restore the Connection's original functions
+  conn->sockdata = zctx->next_conn.sockdata;
+  conn->conn_open = zctx->next_conn.conn_open;
   conn->conn_close = zctx->next_conn.conn_close;
-  conn->conn_read  = zctx->next_conn.conn_read;
+  conn->conn_read = zctx->next_conn.conn_read;
   conn->conn_write = zctx->next_conn.conn_write;
-  conn->conn_poll  = zctx->next_conn.conn_poll;
+  conn->conn_poll = zctx->next_conn.conn_poll;
 
   inflateEnd(&zctx->read.z);
   deflateEnd(&zctx->write.z);
@@ -91,31 +122,30 @@ static int mutt_zstrm_close(struct Connection *conn)
   return rc;
 }
 
-static int mutt_zstrm_read(struct Connection *conn, char *buf, size_t len)
+/**
+ * zstrm_read - Read compressed data from a socket - Implements Connection::conn_read()
+ */
+static int zstrm_read(struct Connection *conn, char *buf, size_t len)
 {
-  zstrmctx *zctx = conn->sockdata;
+  struct ZstrmContext *zctx = conn->sockdata;
   int rc = 0;
-  int zrc;
+  int zrc = 0;
 
 retry:
   if (zctx->read.stream_eof)
     return 0;
 
-  /* when avail_out was 0 on last call, we need to call inflate again,
-   * because more data might be available using the current input, so
-   * avoid callling read on the underlying stream in that case (for it
-   * might block) */
-  if (zctx->read.pos == 0 && !zctx->read.conn_eof)
+  /* when avail_out was 0 on last call, we need to call inflate again, because
+   * more data might be available using the current input, so avoid callling
+   * read on the underlying stream in that case (for it might block) */
+  if ((zctx->read.pos == 0) && !zctx->read.conn_eof)
   {
     rc = zctx->next_conn.conn_read(&zctx->next_conn, zctx->read.buf, zctx->read.len);
-    mutt_debug(LL_DEBUG4,
-               "zstrm_read: consuming data from next "
-               "stream: %d bytes\n",
-               rc);
+    mutt_debug(LL_DEBUG5, "consuming data from next stream: %d bytes\n", rc);
     if (rc < 0)
       return rc;
     else if (rc == 0)
-      zctx->read.conn_eof = 1;
+      zctx->read.conn_eof = true;
     else
       zctx->read.pos += rc;
   }
@@ -126,9 +156,8 @@ retry:
   zctx->read.z.next_out = (Bytef *) buf;
 
   zrc = inflate(&zctx->read.z, Z_SYNC_FLUSH);
-  mutt_debug(LL_DEBUG4,
-             "zstrm_read: rc=%d, "
-             "consumed %u/%u bytes, produced %u/%u bytes\n",
+  mutt_debug(LL_DEBUG5,
+             "rc=%d, consumed %u/%u bytes, produced %u/%u bytes\n",
              zrc, zctx->read.pos - zctx->read.z.avail_in, zctx->read.pos,
              len - zctx->read.z.avail_out, len);
 
@@ -146,27 +175,29 @@ retry:
       if (zrc == 0)
       {
         /* there was progress, so must have been reading input */
-        mutt_debug(LL_DEBUG4, "zstrm_read: inflate just consumed\n");
+        mutt_debug(LL_DEBUG5, "inflate just consumed\n");
         goto retry;
       }
       break;
+
     case Z_STREAM_END: /* everything flushed, nothing remaining */
-      mutt_debug(LL_DEBUG4, "zstrm_read: inflate returned Z_STREAM_END.\n");
+      mutt_debug(LL_DEBUG5, "inflate returned Z_STREAM_END.\n");
       zrc = len - zctx->read.z.avail_out; /* "returned" bytes */
-      zctx->read.stream_eof = 1;
+      zctx->read.stream_eof = true;
       break;
+
     case Z_BUF_ERROR: /* no progress was possible */
       if (!zctx->read.conn_eof)
       {
-        mutt_debug(LL_DEBUG5,
-                   "zstrm_read: inflate returned Z_BUF_ERROR. retrying.\n");
+        mutt_debug(LL_DEBUG5, "inflate returned Z_BUF_ERROR. retrying.\n");
         goto retry;
       }
       zrc = 0;
       break;
+
     default:
       /* bail on other rcs, such as Z_DATA_ERROR, or Z_MEM_ERROR */
-      mutt_debug(LL_DEBUG4, "zstrm_read: inflate returned %d. aborting.\n", zrc);
+      mutt_debug(LL_DEBUG5, "inflate returned %d. aborting.\n", zrc);
       zrc = -1;
       break;
   }
@@ -174,26 +205,30 @@ retry:
   return zrc;
 }
 
-static int mutt_zstrm_poll(struct Connection *conn, time_t wait_secs)
+/**
+ * zstrm_poll - Checks whether reads would block - Implements Connection::conn_poll()
+ */
+static int zstrm_poll(struct Connection *conn, time_t wait_secs)
 {
-  zstrmctx *zctx = conn->sockdata;
+  struct ZstrmContext *zctx = conn->sockdata;
 
-  mutt_debug(LL_DEBUG4, "zstrm_poll: %s\n",
-             zctx->read.z.avail_out == 0 || zctx->read.pos > 0 ?
+  mutt_debug(LL_DEBUG5, "%s\n",
+             (zctx->read.z.avail_out == 0) || (zctx->read.pos > 0) ?
                  "last read wrote full buffer" :
                  "falling back on next stream");
-  if (zctx->read.z.avail_out == 0 || zctx->read.pos > 0)
+  if ((zctx->read.z.avail_out == 0) || (zctx->read.pos > 0))
     return 1;
-  else
-    return zctx->next_conn.conn_poll(&zctx->next_conn, wait_secs);
+
+  return zctx->next_conn.conn_poll(&zctx->next_conn, wait_secs);
 }
 
-static int mutt_zstrm_write(struct Connection *conn, const char *buf, size_t count)
+/**
+ * zstrm_write - Write compressed data to a socket - Implements Connection::conn_write()
+ */
+static int zstrm_write(struct Connection *conn, const char *buf, size_t count)
 {
-  zstrmctx *zctx = conn->sockdata;
+  struct ZstrmContext *zctx = conn->sockdata;
   int rc;
-  int zrc;
-  char *wbufp;
 
   zctx->write.z.avail_in = (uInt) count;
   zctx->write.z.next_in = (Bytef *) buf;
@@ -202,18 +237,18 @@ static int mutt_zstrm_write(struct Connection *conn, const char *buf, size_t cou
 
   do
   {
-    zrc = deflate(&zctx->write.z, Z_PARTIAL_FLUSH);
+    int zrc = deflate(&zctx->write.z, Z_PARTIAL_FLUSH);
     if (zrc == Z_OK)
     {
       /* push out produced data to the underlying stream */
       zctx->write.pos = zctx->write.len - zctx->write.z.avail_out;
-      wbufp = zctx->write.buf;
-      mutt_debug(LL_DEBUG4, "zstrm_write: deflate consumed %d/%d bytes\n",
+      char *wbufp = zctx->write.buf;
+      mutt_debug(LL_DEBUG5, "deflate consumed %d/%d bytes\n",
                  count - zctx->write.z.avail_in, count);
       while (zctx->write.pos > 0)
       {
         rc = zctx->next_conn.conn_write(&zctx->next_conn, wbufp, zctx->write.pos);
-        mutt_debug(LL_DEBUG4, "zstrm_write: next stream wrote: %d bytes\n", rc);
+        mutt_debug(LL_DEBUG5, "next stream wrote: %d bytes\n", rc);
         if (rc < 0)
           return -1; /* we can't recover from write failure */
 
@@ -224,7 +259,7 @@ static int mutt_zstrm_write(struct Connection *conn, const char *buf, size_t cou
       /* see if there's more for us to do, retry if the output buffer
        * was full (there may be something in zlib buffers), and retry
        * when there is still available input data */
-      if (zctx->write.z.avail_out != 0 && zctx->write.z.avail_in == 0)
+      if ((zctx->write.z.avail_out != 0) && (zctx->write.z.avail_in == 0))
         break;
 
       zctx->write.z.avail_out = (uInt) zctx->write.len;
@@ -236,17 +271,24 @@ static int mutt_zstrm_write(struct Connection *conn, const char *buf, size_t cou
        * according to the docs */
       return -1;
     }
-  } while (1);
+  } while (true);
 
   rc = (int) count;
-  return rc <= 0 ? 1 : rc; /* avoid wrong behaviour due to overflow */
+  return (rc <= 0) ? 1 : rc; /* avoid wrong behaviour due to overflow */
 }
 
+/**
+ * mutt_zstrm_wrap_conn - Wrap a compression layer around a Connection
+ * @param conn Connection to wrap
+ *
+ * Replace the read/write functions with our compression functions.
+ * After reading from the socket, we decompress and pass on the data.
+ * Before writing to a socket, we compress the data.
+ */
 void mutt_zstrm_wrap_conn(struct Connection *conn)
 {
-  zstrmctx *zctx;
+  struct ZstrmContext *zctx = mutt_mem_calloc(1, sizeof(struct ZstrmContext));
 
-  zctx = (zstrmctx *) mutt_mem_calloc(1, sizeof(zstrmctx));
   /* store wrapped stream as next stream */
   zctx->next_conn.fd = conn->fd;
   zctx->next_conn.sockdata = conn->sockdata;
@@ -257,12 +299,12 @@ void mutt_zstrm_wrap_conn(struct Connection *conn)
   zctx->next_conn.conn_poll = conn->conn_poll;
 
   /* replace connection with our wrappers, where appropriate */
-  conn->sockdata = (void *) zctx;
-  conn->conn_open = mutt_zstrm_open;
-  conn->conn_read = mutt_zstrm_read;
-  conn->conn_write = mutt_zstrm_write;
-  conn->conn_close = mutt_zstrm_close;
-  conn->conn_poll = mutt_zstrm_poll;
+  conn->sockdata = zctx;
+  conn->conn_open = zstrm_open;
+  conn->conn_read = zstrm_read;
+  conn->conn_write = zstrm_write;
+  conn->conn_close = zstrm_close;
+  conn->conn_poll = zstrm_poll;
 
   /* allocate/setup (de)compression buffers */
   zctx->read.len = 8192;
@@ -273,13 +315,13 @@ void mutt_zstrm_wrap_conn(struct Connection *conn)
   zctx->write.pos = 0;
 
   /* initialise zlib for inflate and deflate for RFC4978 */
-  zctx->read.z.zalloc = mutt_zstrm_malloc;
-  zctx->read.z.zfree = mutt_zstrm_free;
+  zctx->read.z.zalloc = zstrm_malloc;
+  zctx->read.z.zfree = zstrm_free;
   zctx->read.z.opaque = NULL;
   zctx->read.z.avail_out = zctx->read.len;
   inflateInit2(&zctx->read.z, -15);
-  zctx->write.z.zalloc = mutt_zstrm_malloc;
-  zctx->write.z.zfree = mutt_zstrm_free;
+  zctx->write.z.zalloc = zstrm_malloc;
+  zctx->write.z.zfree = zstrm_free;
   zctx->write.z.opaque = NULL;
   zctx->write.z.avail_out = zctx->write.len;
   deflateInit2(&zctx->write.z, Z_DEFAULT_COMPRESSION, Z_DEFLATED, -15, 8, Z_DEFAULT_STRATEGY);

--- a/mutt_zstrm.c
+++ b/mutt_zstrm.c
@@ -75,6 +75,13 @@ static int mutt_zstrm_close(struct Connection *conn)
              zctx->write.z.total_in, zctx->write.z.total_out,
              (float) zctx->write.z.total_in / (float) zctx->write.z.total_out);
 
+  conn->sockdata   = zctx->next_conn.sockdata;
+  conn->conn_open  = zctx->next_conn.conn_open;
+  conn->conn_close = zctx->next_conn.conn_close;
+  conn->conn_read  = zctx->next_conn.conn_read;
+  conn->conn_write = zctx->next_conn.conn_write;
+  conn->conn_poll  = zctx->next_conn.conn_poll;
+
   inflateEnd(&zctx->read.z);
   deflateEnd(&zctx->write.z);
   FREE(&zctx->read.buf);

--- a/mutt_zstrm.c
+++ b/mutt_zstrm.c
@@ -1,0 +1,289 @@
+/**
+ * @file
+ * IMAP traffic compression
+ *
+ * Copyright(C) 2019 Fabian Groffen <grobian@gentoo.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+#include <errno.h>
+#include <string.h>
+#include <zlib.h>
+#include "conn/conn.h"
+#include "mutt.h"
+#include "mutt_zstrm.h"
+#include "mutt_socket.h"
+
+typedef struct
+{
+  struct zstrm_direction
+  {
+    z_stream z;
+    char *buf;
+    unsigned int len;
+    unsigned int pos;
+    unsigned char has_pending : 1;
+    unsigned char is_eof : 1;
+  } read, write;
+
+  /* underlying stream */
+  struct Connection next_conn;
+} zstrmctx;
+
+/* simple wrapper functions to match zlib interface for calling
+ * malloc/free */
+static void *mutt_zstrm_malloc(void *op, unsigned int sze, unsigned int v)
+{
+  (void) op;
+
+  return mutt_mem_calloc(sze, v);
+}
+
+static void mutt_zstrm_free(void *op, void *ptr)
+{
+  (void) op;
+
+  FREE(&ptr);
+}
+
+static int mutt_zstrm_open(struct Connection *conn)
+{
+  /* cannot open a zlib connection, must wrap an existing one */
+  return -1;
+}
+
+static int mutt_zstrm_close(struct Connection *conn)
+{
+  zstrmctx *zctx = conn->sockdata;
+  int rc = zctx->next_conn.conn_close(&zctx->next_conn);
+
+  mutt_debug(LL_DEBUG4,
+             "zstrm_close: read %llu->%llu(%.1fx) "
+             "wrote %llu<-%llu(%.1fx)\n",
+             zctx->read.z.total_in, zctx->read.z.total_out,
+             (float) zctx->read.z.total_out / (float) zctx->read.z.total_in,
+             zctx->write.z.total_in, zctx->write.z.total_out,
+             (float) zctx->write.z.total_in / (float) zctx->write.z.total_out);
+
+  inflateEnd(&zctx->read.z);
+  deflateEnd(&zctx->write.z);
+  FREE(&zctx->read.buf);
+  FREE(&zctx->write.buf);
+  FREE(&zctx);
+
+  return rc;
+}
+
+static int mutt_zstrm_read(struct Connection *conn, char *buf, size_t len)
+{
+  zstrmctx *zctx = conn->sockdata;
+  int rc = 0;
+  int zrc;
+  int inflatemode = Z_SYNC_FLUSH;
+
+  /* shortcut end of stream call */
+  if (zctx->read.has_pending == 1 && zctx->read.is_eof == 1)
+  {
+    /* next read will yield an error */
+    zctx->read.has_pending = 0;
+    zctx->read.is_eof = 0;
+    return 0;
+  }
+
+  /* when avail_out was 0 on last call, we need to call inflate again,
+   * because more data might be available using the current input, so
+   * avoid callling read on the underlying stream in that case(for it
+   * might block) */
+  if (zctx->read.has_pending == 0 && zctx->read.pos == 0)
+  {
+    rc = zctx->next_conn.conn_read(&zctx->next_conn, zctx->read.buf, zctx->read.len);
+    mutt_debug(LL_DEBUG4,
+               "zstrm_read: consuming data from next "
+               "stream: %d bytes\n",
+               rc);
+    /* error or end of stream? ensure zlib flushes whatever it can */
+    if (rc <= 0)
+      inflatemode = Z_FINISH;
+    else
+      zctx->read.pos += rc;
+  }
+
+  zctx->read.z.avail_in = (uInt) zctx->read.pos;
+  zctx->read.z.next_in = (Bytef *) zctx->read.buf;
+  zctx->read.z.avail_out = (uInt) len;
+  zctx->read.z.next_out = (Bytef *) buf;
+
+  zrc = inflate(&zctx->read.z, inflatemode);
+  mutt_debug(LL_DEBUG4,
+             "zstrm_read: rc=%d, "
+             "consumed %u/%u bytes, produced %u/%u bytes\n",
+             zrc, zctx->read.pos - zctx->read.z.avail_in, zctx->read.pos,
+             len - zctx->read.z.avail_out, len);
+
+  /* shift any remaining input data to the front of the buffer */
+  if ((Bytef *) zctx->read.buf != zctx->read.z.next_in)
+  {
+    memmove(zctx->read.buf, zctx->read.z.next_in, zctx->read.z.avail_in);
+    zctx->read.pos = zctx->read.z.avail_in;
+  }
+
+  switch (zrc)
+  {
+    case Z_OK:                            /* progress has been made */
+      zrc = len - zctx->read.z.avail_out; /* "returned" bytes */
+      if (zrc == 0)
+      {
+        /* there was progress, so must have been reading input */
+        mutt_debug(LL_DEBUG4, "zstrm_read: inflate just consumed\n");
+        /* re-call ourselves to read more bytes */
+        zctx->read.has_pending = 0; /* trigger a read */
+        return mutt_zstrm_read(conn, buf, len);
+      }
+      break;
+    case Z_STREAM_END: /* everything flushed, nothing remaining */
+      zrc = len - zctx->read.z.avail_out; /* "returned" bytes */
+      zctx->read.has_pending = 1;
+      zctx->read.is_eof = 1;
+      break;
+    case Z_DATA_ERROR: /* corrupt input */
+      /* zlib can inflateSync here, but do we really want to skip bytes
+       * at this point? it may horribly mess up a protocol flow, so
+       * throw an error instead */
+      return -1;
+    case Z_MEM_ERROR: /* out of memory -- shouldn't happen with mutt_mem_malloc */
+      errno = ENOMEM;
+      return -1;
+    case Z_BUF_ERROR: /* output buffer full or nothing to read */
+      /* since every call has an empty output buffer, this scenario
+       * means we read nothing, so retry reading */
+      zctx->read.has_pending = 0; /* trigger a read */
+      return mutt_zstrm_read(conn, buf, len);
+  }
+
+  return zrc;
+}
+
+static int mutt_zstrm_poll(struct Connection *conn, time_t wait_secs)
+{
+  zstrmctx *zctx = conn->sockdata;
+
+  mutt_debug(LL_DEBUG4, "zstrm_poll: %s\n",
+             zctx->read.z.avail_out == 0 || zctx->read.pos > 0 ?
+                 "last read wrote full buffer" :
+                 "falling back on next stream");
+  if (zctx->read.z.avail_out == 0 || zctx->read.pos > 0)
+    return 1;
+  else
+    return zctx->next_conn.conn_poll(&zctx->next_conn, wait_secs);
+}
+
+static int mutt_zstrm_write(struct Connection *conn, const char *buf, size_t count)
+{
+  zstrmctx *zctx = conn->sockdata;
+  int rc;
+  int zrc;
+  char *wbufp;
+
+  zctx->write.z.avail_in = (uInt) count;
+  zctx->write.z.next_in = (Bytef *) buf;
+  zctx->write.z.avail_out = (uInt) zctx->write.len;
+  zctx->write.z.next_out = (Bytef *) zctx->write.buf;
+
+  do
+  {
+    zrc = deflate(&zctx->write.z, Z_PARTIAL_FLUSH);
+    if (zrc == Z_OK)
+    {
+      /* push out produced data to the underlying stream */
+      zctx->write.pos = zctx->write.len - zctx->write.z.avail_out;
+      wbufp = zctx->write.buf;
+      mutt_debug(LL_DEBUG4, "zstrm_write: deflate consumed %d/%d bytes\n",
+                 count - zctx->write.z.avail_in, count);
+      while (zctx->write.pos > 0)
+      {
+        rc = zctx->next_conn.conn_write(&zctx->next_conn, wbufp, zctx->write.pos);
+        mutt_debug(LL_DEBUG4, "zstrm_write: next stream wrote: %d bytes\n", rc);
+        if (rc < 0)
+          return -1; /* we can't recover from write failure */
+
+        wbufp += rc;
+        zctx->write.pos -= rc;
+      }
+
+      /* see if there's more for us to do, retry if the output buffer
+       * was full(there may be something in zlib buffers), and retry
+       * when there is still available input data */
+      if (zctx->write.z.avail_out != 0 && zctx->write.z.avail_in == 0)
+        break;
+
+      zctx->write.z.avail_out = (uInt) zctx->write.len;
+      zctx->write.z.next_out = (Bytef *) zctx->write.buf;
+    }
+    else
+    {
+      /* compression went wrong, but this is basically impossible
+       * according to the docs */
+      return -1;
+    }
+  } while (1);
+
+  rc = (int) count;
+  return rc <= 0 ? 1 : rc; /* avoid wrong behaviour due to overflow */
+}
+
+void mutt_zstrm_wrap_conn(struct Connection *conn)
+{
+  zstrmctx *zctx;
+
+  zctx = (zstrmctx *) mutt_mem_calloc(1, sizeof(zstrmctx));
+  /* store wrapped stream as next stream */
+  zctx->next_conn.fd = conn->fd;
+  zctx->next_conn.sockdata = conn->sockdata;
+  zctx->next_conn.conn_open = conn->conn_open;
+  zctx->next_conn.conn_close = conn->conn_close;
+  zctx->next_conn.conn_read = conn->conn_read;
+  zctx->next_conn.conn_write = conn->conn_write;
+  zctx->next_conn.conn_poll = conn->conn_poll;
+
+  /* replace connection with our wrappers, where appropriate */
+  conn->sockdata = (void *) zctx;
+  conn->conn_open = mutt_zstrm_open;
+  conn->conn_read = mutt_zstrm_read;
+  conn->conn_write = mutt_zstrm_write;
+  conn->conn_close = mutt_zstrm_close;
+  conn->conn_poll = mutt_zstrm_poll;
+
+  /* allocate/setup(de)compression buffers */
+  zctx->read.len = 8192;
+  zctx->read.buf = mutt_mem_malloc(zctx->read.len);
+  zctx->read.pos = 0;
+  zctx->write.len = 8192;
+  zctx->write.buf = mutt_mem_malloc(zctx->write.len);
+  zctx->write.pos = 0;
+
+  /* initialise zlib for inflate and deflate for RFC4978 */
+  zctx->read.z.zalloc = mutt_zstrm_malloc;
+  zctx->read.z.zfree = mutt_zstrm_free;
+  zctx->read.z.opaque = NULL;
+  zctx->read.z.avail_out = zctx->read.len;
+  inflateInit2(&zctx->read.z, -15);
+  zctx->write.z.zalloc = mutt_zstrm_malloc;
+  zctx->write.z.zfree = mutt_zstrm_free;
+  zctx->write.z.opaque = NULL;
+  zctx->write.z.avail_out = zctx->write.len;
+  deflateInit2(&zctx->write.z, Z_DEFAULT_COMPRESSION, Z_DEFLATED, -15, 8, Z_DEFAULT_STRATEGY);
+}

--- a/mutt_zstrm.h
+++ b/mutt_zstrm.h
@@ -1,0 +1,29 @@
+/**
+ * @file
+ * IMAP traffic compression
+ *
+ * Copyright(C) 2019 Fabian Groffen <grobian@gentoo.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MUTT_ZSTRM_H
+#define MUTT_ZSTRM_H
+
+struct Connection;
+
+void mutt_zstrm_wrap_conn(struct Connection *conn);
+
+#endif /* MUTT_ZSTRM_H */

--- a/mutt_zstrm.h
+++ b/mutt_zstrm.h
@@ -1,6 +1,6 @@
 /**
  * @file
- * IMAP traffic compression
+ * Zlib compression of network traffic
  *
  * Copyright(C) 2019 Fabian Groffen <grobian@gentoo.org>
  *

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -147,6 +147,7 @@ mutt_parse.c
 mutt_signal.c
 mutt_socket.c
 mutt_thread.c
+mutt_zstrm.c
 mx.c
 myvar.c
 ncrypt/crypt.c

--- a/version.c
+++ b/version.c
@@ -299,6 +299,11 @@ static struct CompileOptions comp_opts[] = {
 #else
   { "typeahead", 0 },
 #endif
+#ifdef USE_ZLIB
+  { "zlib", 1 },
+#else
+  { "zlib", 0 },
+#endif
   { NULL, 0 },
 };
 


### PR DESCRIPTION
Add a (de-)compression layer to the IMAP connection.
This feature uses zlib to compress data to/from an IMAP server.

When logging is enabled at level 5, it logs statistics on close.

> **zstrm_close() read 4055362 -\> 35314609 (8.7x) wrote 215993 \<- 18071 (12.0x)**

Enable with:
- `./configure --zlib`
- `set imap_deflate = yes` (default)