### PR TITLE
maildir_mbox_check_stats should only update mailbox stats if requested

### DIFF
--- a/maildir/maildir.c
+++ b/maildir/maildir.c
@@ -547,13 +547,16 @@ static int maildir_mbox_check_stats(struct Mailbox *m, int flags)
   if (!m)
     return -1;
 
-  bool check_stats = true;
+  bool check_stats = flags;
   bool check_new = true;
 
-  m->msg_count = 0;
-  m->msg_unread = 0;
-  m->msg_flagged = 0;
-  m->msg_new = 0;
+  if (check_stats)
+  {
+    m->msg_count = 0;
+    m->msg_unread = 0;
+    m->msg_flagged = 0;
+    m->msg_new = 0;
+  }
 
   maildir_check_dir(m, "new", check_new, check_stats);
 


### PR DESCRIPTION
Currently maildir_mbox_check_stats always updates the statistics. This
should only happen when "mail_check_stats" is set to "yes".

Call chain:
mutt_mailbox_check()
->mailbox_check()
  ->mx_mbox_check_stats()
    ->maildir_mbox_check_stats()