### PR TITLE
maildir: Don't error on new mail

### DIFF
--- a/mx.c
+++ b/mx.c
@@ -460,10 +460,14 @@ static int sync_mailbox(struct Mailbox *m, int *index_hint)
   }
 
   int rc = m->mx_ops->mbox_sync(m, index_hint);
-  if ((rc != 0) && !m->quiet)
+  if (rc != 0)
   {
-    /* L10N: Displayed if a mailbox sync fails */
-    mutt_error(_("Unable to write %s"), mailbox_path(m));
+    mutt_debug(LL_DEBUG2, "mbox_sync returned: %d\n", rc);
+    if ((rc < 0) && !m->quiet)
+    {
+      /* L10N: Displayed if a mailbox sync fails */
+      mutt_error(_("Unable to write %s"), mailbox_path(m));
+    }
   }
 
   return rc;


### PR DESCRIPTION
This was reported by 'swivel' on IRC.

Call tree:
- `sync_mailbox()`
- `MxOps::mbox_sync()`
- `mh_mbox_sync()`
- `maildir_mbox_check()`

Besides 0 and -1, `maildir_mbox_check()` can also return flags such as
`MUTT_NEW_MAIL`.  These get returned to `sync_mailbox()` which thinks
that non-zero must mean error.

Log any non-zero returns, but only error on negative values.