### PR TITLE
add Number of old messages to sidebar_format

### DIFF
--- a/doc/manual.xml.head
+++ b/doc/manual.xml.head
@@ -793,6 +793,20 @@ set sidebar_divider_char = '│'          <emphasis role="comment"># Pretty line
                     </entry>
                   </row>
                   <row>
+                    <entry>%o</entry>
+                    <entry>* †</entry>
+                    <entry>
+                      Number of old unread messages in the mailbox
+                    </entry>
+                  </row>
+                  <row>
+                    <entry>%r</entry>
+                    <entry>* †</entry>
+                    <entry>
+                      Number of read messages in the mailbox
+                    </entry>
+                  </row>
+                  <row>
                     <entry>%S</entry>
                     <entry>* †</entry>
                     <entry>
@@ -804,6 +818,13 @@ set sidebar_divider_char = '│'          <emphasis role="comment"># Pretty line
                     <entry>* ‡</entry>
                     <entry>
                       Number of tagged messages
+                    </entry>
+                  </row>
+                  <row>
+                    <entry>%Z</entry>
+                    <entry>* †</entry>
+                    <entry>
+                      Number of new messages in the mailbox (unread, unseen)
                     </entry>
                   </row>
                   <row>

--- a/doc/manual.xml.head
+++ b/doc/manual.xml.head
@@ -767,7 +767,7 @@ set sidebar_divider_char = '│'          <emphasis role="comment"># Pretty line
                     <entry>%F</entry>
                     <entry>* †</entry>
                     <entry>
-                      Number of Flagged messages in the mailbox
+                      Number of flagged messages in the mailbox
                     </entry>
                   </row>
                   <row>
@@ -782,21 +782,21 @@ set sidebar_divider_char = '│'          <emphasis role="comment"># Pretty line
                     <entry>*</entry>
                     <entry>
                       If there's new mail, display <quote>N</quote>, otherwise
-                      nothing
+                      <quote> </quote> (space).
                     </entry>
                   </row>
                   <row>
                     <entry>%N</entry>
                     <entry>* †</entry>
                     <entry>
-                      Number of New messages in the mailbox
+                      Number of unread messages in the mailbox (seen or unseen)
                     </entry>
                   </row>
                   <row>
                     <entry>%o</entry>
                     <entry>* †</entry>
                     <entry>
-                      Number of old unread messages in the mailbox
+                      Number of old messages in the mailbox (unread, but seen)
                     </entry>
                   </row>
                   <row>
@@ -817,7 +817,14 @@ set sidebar_divider_char = '│'          <emphasis role="comment"># Pretty line
                     <entry>%t</entry>
                     <entry>* ‡</entry>
                     <entry>
-                      Number of tagged messages
+                      Number of tagged messages in the mailbox
+                    </entry>
+                  </row>
+                  <row>
+                    <entry>%Z</entry>
+                    <entry>* †</entry>
+                    <entry>
+                      Number of new messages in the mailbox (unread, unseen)
                     </entry>
                   </row>
                   <row>
@@ -1079,6 +1086,7 @@ sidebar_whitelist fruit fruit/apple     <emphasis role="comment"># Always displa
 color sidebar_indicator default color17     <emphasis role="comment"># Dark blue background</emphasis>
 color sidebar_highlight white   color238    <emphasis role="comment"># Grey background</emphasis>
 color sidebar_spoolfile yellow  default     <emphasis role="comment"># Yellow</emphasis>
+color sidebar_unread    cyan    default     <emphasis role="comment"># Light blue</emphasis>
 color sidebar_new       green   default     <emphasis role="comment"># Green</emphasis>
 color sidebar_ordinary  default default     <emphasis role="comment"># Default colors</emphasis>
 color sidebar_flagged   red     default     <emphasis role="comment"># Red</emphasis>
@@ -1115,11 +1123,6 @@ color sidebar_divider   color8  default     <emphasis role="comment"># Dark grey
                 </row>
                 <row>
                   <entry></entry>
-                  <entry><literal>sidebar_spoolfile</literal></entry>
-                  <entry>Mailbox is the spoolfile (receives incoming mail)</entry>
-                </row>
-                <row>
-                  <entry></entry>
                   <entry><literal>sidebar_new</literal></entry>
                   <entry>Mailbox contains new mail</entry>
                 </row>
@@ -1132,6 +1135,11 @@ color sidebar_divider   color8  default     <emphasis role="comment"># Dark grey
                   <entry></entry>
                   <entry><literal>sidebar_flagged</literal></entry>
                   <entry>Mailbox contains flagged mail</entry>
+                </row>
+                <row>
+                  <entry></entry>
+                  <entry><literal>sidebar_spoolfile</literal></entry>
+                  <entry>Mailbox is the spoolfile (receives incoming mail)</entry>
                 </row>
                 <row>
                   <entry>Lowest</entry>
@@ -16065,6 +16073,11 @@ set sort_browser="reverse-size"
             </thead>
             <tbody>
               <row>
+                <entry><literal>sidebar_component_depth</literal></entry>
+                <entry>number</entry>
+                <entry><literal>0</literal></entry>
+              </row>
+              <row>
                 <entry><literal>sidebar_delim_chars</literal></entry>
                 <entry>string</entry>
                 <entry><literal>/.</literal></entry>
@@ -16099,6 +16112,11 @@ set sort_browser="reverse-size"
                 <entry><literal>no</literal></entry>
               </row>
               <row>
+                <entry><literal>sidebar_non_empty_mailbox_only</literal></entry>
+                <entry>boolean</entry>
+                <entry><literal>no</literal></entry>
+              </row>
+              <row>
                 <entry><literal>sidebar_on_right</literal></entry>
                 <entry>boolean</entry>
                 <entry><literal>no</literal></entry>
@@ -16107,11 +16125,6 @@ set sort_browser="reverse-size"
                 <entry><literal>sidebar_short_path</literal></entry>
                 <entry>boolean</entry>
                 <entry><literal>no</literal></entry>
-              </row>
-              <row>
-                <entry><literal>sidebar_component_depth</literal></entry>
-                <entry>number</entry>
-                <entry><literal>0</literal></entry>
               </row>
               <row>
                 <entry><literal>sidebar_sort_method</literal></entry>
@@ -16339,6 +16352,10 @@ set sort_browser="reverse-size"
                 <entry>Total number of messages</entry>
               </row>
               <row>
+                <entry><literal>desc</literal></entry>
+                <entry>Descriptive name of the mailbox</entry>
+              </row>
+              <row>
                 <entry><literal>flagged</literal></entry>
                 <entry>Number of flagged messages</entry>
               </row>
@@ -16399,6 +16416,8 @@ set sidebar_indent_string = '  '
 set sidebar_new_mail_only = no
 <emphasis role="comment"># Any mailboxes that are whitelisted will always be visible, even if the</emphasis>
 <emphasis role="comment"># sidebar_new_mail_only option is enabled.</emphasis>
+set sidebar_non_empty_mailbox_only = no
+<emphasis role="comment"># Only show mailboxes that contain some mail</emphasis>
 sidebar_whitelist '/home/user/mailbox1'
 sidebar_whitelist '/home/user/mailbox2'
 <emphasis role="comment"># When searching for mailboxes containing new mail, should the search wrap</emphasis>
@@ -16451,6 +16470,8 @@ bind index,pager B sidebar-toggle-visible
 <emphasis role="comment"># Color of the current, open, mailbox</emphasis>
 <emphasis role="comment"># Note: This is a general NeoMutt option which colors all selected items.</emphasis>
 color indicator cyan black
+<emphasis role="comment"># Sidebar-specific color of the selected item</emphasis>
+color sidebar_indicator cyan black
 <emphasis role="comment"># Color of the highlighted, but not open, mailbox.</emphasis>
 color sidebar_highlight black color8
 <emphasis role="comment"># Color of the divider separating the Sidebar from NeoMutt panels</emphasis>
@@ -16461,6 +16482,10 @@ color sidebar_flagged red black
 color sidebar_new green black
 <emphasis role="comment"># Color to give mailboxes containing no new/flagged mail, etc.</emphasis>
 color sidebar_ordinary color245 default
+<emphasis role="comment"># Color to give the spoolfile mailbox</emphasis>
+color sidebar_spoolfile color207 default
+<emphasis role="comment"># Color to give mailboxes containing no unread mail</emphasis>
+color sidebar_unread color136 default
 <emphasis role="comment"># --------------------------------------------------------------------------</emphasis>
 
 <emphasis role="comment"># vim: syntax=neomuttrc</emphasis>

--- a/mutt_config.c
+++ b/mutt_config.c
@@ -1141,24 +1141,24 @@ struct ConfigDef MuttVars[] = {
   ** personal taste.  This string is similar to $$index_format, but has
   ** its own set of \fCprintf(3)\fP-like sequences:
   ** .dl
-  ** .dt %C  .dd Current file number
-  ** .dt %d  .dd Date/time folder was last modified
-  ** .dt %D  .dd Date/time folder was last modified using $$date_format.
-  ** .dt %f  .dd Filename ("/" is appended to directory names,
-  **             "@" to symbolic links and "*" to executable files)
-  ** .dt %F  .dd File permissions
-  ** .dt %g  .dd Group name (or numeric gid, if missing)
-  ** .dt %i  .dd Description of the folder
-  ** .dt %l  .dd Number of hard links
-  ** .dt %m  .dd Number of messages in the mailbox *
-  ** .dt %n  .dd Number of unread messages in the mailbox *
-  ** .dt %N  .dd "N" if mailbox has new mail, blank otherwise
-  ** .dt %s  .dd Size in bytes (see $formatstrings-size)
-  ** .dt %t  .dd "*" if the file is tagged, blank otherwise
-  ** .dt %u  .dd Owner name (or numeric uid, if missing)
-  ** .dt %>X .dd Right justify the rest of the string and pad with character "X"
-  ** .dt %|X .dd Pad to the end of the line with character "X"
-  ** .dt %*X .dd Soft-fill with character "X" as pad
+  ** .dt %C  .dd   .dd Current file number
+  ** .dt %d  .dd   .dd Date/time folder was last modified
+  ** .dt %D  .dd   .dd Date/time folder was last modified using $$date_format.
+  ** .dt %f  .dd   .dd Filename ("/" is appended to directory names,
+  **                   "@" to symbolic links and "*" to executable files)
+  ** .dt %F  .dd   .dd File permissions
+  ** .dt %g  .dd   .dd Group name (or numeric gid, if missing)
+  ** .dt %i  .dd   .dd Description of the folder
+  ** .dt %l  .dd   .dd Number of hard links
+  ** .dt %m  .dd * .dd Number of messages in the mailbox
+  ** .dt %n  .dd * .dd Number of unread messages in the mailbox
+  ** .dt %N  .dd   .dd "N" if mailbox has new mail, blank otherwise
+  ** .dt %s  .dd   .dd Size in bytes (see $formatstrings-size)
+  ** .dt %t  .dd   .dd "*" if the file is tagged, blank otherwise
+  ** .dt %u  .dd   .dd Owner name (or numeric uid, if missing)
+  ** .dt %>X .dd   .dd Right justify the rest of the string and pad with character "X"
+  ** .dt %|X .dd   .dd Pad to the end of the line with character "X"
+  ** .dt %*X .dd   .dd Soft-fill with character "X" as pad
   ** .de
   ** .pp
   ** For an explanation of "soft-fill", see the $$index_format documentation.
@@ -3213,14 +3213,14 @@ struct ConfigDef MuttVars[] = {
   ** This variable describes the format of the "query" menu. The
   ** following \fCprintf(3)\fP-style sequences are understood:
   ** .dl
-  ** .dt %a  .dd Destination address
-  ** .dt %c  .dd Current entry number
-  ** .dt %e  .dd Extra information *
-  ** .dt %n  .dd Destination name
-  ** .dt %t  .dd "*" if current entry is tagged, a space otherwise
-  ** .dt %>X .dd Right justify the rest of the string and pad with "X"
-  ** .dt %|X .dd Pad to the end of the line with "X"
-  ** .dt %*X .dd Soft-fill with character "X" as pad
+  ** .dt %a  .dd   .dd Destination address
+  ** .dt %c  .dd   .dd Current entry number
+  ** .dt %e  .dd * .dd Extra information
+  ** .dt %n  .dd   .dd Destination name
+  ** .dt %t  .dd   .dd "*" if current entry is tagged, a space otherwise
+  ** .dt %>X .dd   .dd Right justify the rest of the string and pad with "X"
+  ** .dt %|X .dd   .dd Pad to the end of the line with "X"
+  ** .dt %*X .dd   .dd Soft-fill with character "X" as pad
   ** .de
   ** .pp
   ** For an explanation of "soft-fill", see the $$index_format documentation.
@@ -3684,25 +3684,29 @@ struct ConfigDef MuttVars[] = {
   ** similar to $$index_format, but has its own set of \fCprintf(3)\fP-like
   ** sequences:
   ** .dl
-  ** .dt %B  .dd Name of the mailbox
-  ** .dt %D  .dd Description of the mailbox
-  ** .dt %S  .dd * Size of mailbox (total number of messages)
-  ** .dt %N  .dd * Number of unread messages in the mailbox
-  ** .dt %n  .dd N if mailbox has new mail, blank otherwise
-  ** .dt %F  .dd * Number of Flagged messages in the mailbox
-  ** .dt %!  .dd "!" : one flagged message;
-  **             "!!" : two flagged messages;
-  **             "n!" : n flagged messages (for n > 2).
-  **             Otherwise prints nothing.
-  ** .dt %d  .dd * @ Number of deleted messages
-  ** .dt %L  .dd * @ Number of messages after limiting
-  ** .dt %t  .dd * @ Number of tagged messages
-  ** .dt %>X .dd right justify the rest of the string and pad with "X"
-  ** .dt %|X .dd pad to the end of the line with "X"
-  ** .dt %*X .dd soft-fill with character "X" as pad
+  ** .dt %B .dd     .dd Name of the mailbox
+  ** .dt %d .dd * @ .dd Number of deleted messages in the mailbox
+  ** .dt %D .dd     .dd Descriptive name of the mailbox
+  ** .dt %F .dd *   .dd Number of flagged messages in the mailbox
+  ** .dt %L .dd * @ .dd Number of messages after limiting
+  ** .dt %n .dd     .dd 'N' if mailbox has new mail, ' ' (space) otherwise
+  ** .dt %N .dd *   .dd Number of unread messages in the mailbox (seen or unseen)
+  ** .dt %o .dd *   .dd Number of old messages in the mailbox (unread, seen)
+  ** .dt %r .dd *   .dd Number of read messages in the mailbox (read, seen)
+  ** .dt %S .dd *   .dd Size of mailbox (total number of messages)
+  ** .dt %t .dd * @ .dd Number of tagged messages in the mailbox
+  ** .dt %Z .dd *   .dd Number of new messages in the mailbox (unread, unseen)
+  ** .dt %! .dd     .dd "!" : one flagged message;
+  **                    "!!" : two flagged messages;
+  **                    "n!" : n flagged messages (for n > 2).
+  **                    Otherwise prints nothing.
+  ** .dt %>X .dd .dd Right justify the rest of the string and pad with "X"
+  ** .dt %|X .dd .dd Pad to the end of the line with "X"
+  ** .dt %*X .dd .dd Soft-fill with character "X" as pad
   ** .de
   ** .pp
   ** * = Can be optionally printed if nonzero
+  ** .pp
   ** @ = Only applicable to the current folder
   ** .pp
   ** In order to use %S, %N, %F, and %!, $$mail_check_stats must
@@ -3725,13 +3729,6 @@ struct ConfigDef MuttVars[] = {
   ** .pp
   ** \fBSee also:\fP $$sidebar_whitelist, $$sidebar_non_empty_mailbox_only.
   */
-  { "sidebar_non_empty_mailbox_only", DT_BOOL|R_SIDEBAR, &C_SidebarNonEmptyMailboxOnly, false },
-  /*
-  ** .pp
-  ** When set, the sidebar will only display mailboxes that contain one or more mails.
-  ** .pp
-  ** \fBSee also:\fP $$sidebar_new_mail_only, $$sidebar_whitelist.
-  */
   { "sidebar_next_new_wrap", DT_BOOL, &C_SidebarNextNewWrap, false },
   /*
   ** .pp
@@ -3739,6 +3736,13 @@ struct ConfigDef MuttVars[] = {
   ** the list of mailboxes, but wrap around to the beginning. The
   ** \fC<sidebar-prev-new>\fP command is similarly affected, wrapping around to
   ** the end of the list.
+  */
+  { "sidebar_non_empty_mailbox_only", DT_BOOL|R_SIDEBAR, &C_SidebarNonEmptyMailboxOnly, false },
+  /*
+  ** .pp
+  ** When set, the sidebar will only display mailboxes that contain one or more mails.
+  ** .pp
+  ** \fBSee also:\fP $$sidebar_new_mail_only, $$sidebar_whitelist.
   */
   { "sidebar_on_right", DT_BOOL|R_INDEX|R_PAGER|R_REFLOW, &C_SidebarOnRight, false },
   /*
@@ -4472,33 +4476,33 @@ struct ConfigDef MuttVars[] = {
   ** menu.  This string is similar to $$index_format, but has its own
   ** set of \fCprintf(3)\fP-like sequences:
   ** .dl
-  ** .dt %b  .dd Number of mailboxes with new mail *
-  ** .dt %d  .dd Number of deleted messages *
-  ** .dt %D  .dd Description of the mailbox
-  ** .dt %f  .dd The full pathname of the current mailbox
-  ** .dt %F  .dd Number of flagged messages *
-  ** .dt %h  .dd Local hostname
-  ** .dt %l  .dd Size (in bytes) of the current mailbox (see $formatstrings-size) *
-  ** .dt %L  .dd Size (in bytes) of the messages shown
-  **             (i.e., which match the current limit) (see $formatstrings-size) *
-  ** .dt %m  .dd The number of messages in the mailbox *
-  ** .dt %M  .dd The number of messages shown (i.e., which match the current limit) *
-  ** .dt %n  .dd Number of new messages in the mailbox *
-  ** .dt %o  .dd Number of old unread messages *
-  ** .dt %p  .dd Number of postponed messages *
-  ** .dt %P  .dd Percentage of the way through the index
-  ** .dt %r  .dd Modified/read-only/won't-write/attach-message indicator,
-  **             According to $$status_chars
-  ** .dt %R  .dd Number of read messages *
-  ** .dt %s  .dd Current sorting mode ($$sort)
-  ** .dt %S  .dd Current aux sorting method ($$sort_aux)
-  ** .dt %t  .dd Number of tagged messages *
-  ** .dt %u  .dd Number of unread messages *
-  ** .dt %v  .dd NeoMutt version string
-  ** .dt %V  .dd Currently active limit pattern, if any *
-  ** .dt %>X .dd Right justify the rest of the string and pad with "X"
-  ** .dt %|X .dd Pad to the end of the line with "X"
-  ** .dt %*X .dd Soft-fill with character "X" as pad
+  ** .dt %b  .dd * .dd Number of mailboxes with new mail
+  ** .dt %d  .dd * .dd Number of deleted messages
+  ** .dt %D  .dd   .dd Description of the mailbox
+  ** .dt %f  .dd   .dd The full pathname of the current mailbox
+  ** .dt %F  .dd * .dd Number of flagged messages
+  ** .dt %h  .dd   .dd Local hostname
+  ** .dt %l  .dd * .dd Size (in bytes) of the current mailbox (see $formatstrings-size)
+  ** .dt %L  .dd * .dd Size (in bytes) of the messages shown
+  **                   (i.e., which match the current limit) (see $formatstrings-size)
+  ** .dt %m  .dd * .dd The number of messages in the mailbox
+  ** .dt %M  .dd * .dd The number of messages shown (i.e., which match the current limit)
+  ** .dt %n  .dd * .dd Number of new messages in the mailbox (unread, unseen)
+  ** .dt %o  .dd * .dd Number of old messages in the mailbox (unread, seen)
+  ** .dt %p  .dd * .dd Number of postponed messages
+  ** .dt %P  .dd   .dd Percentage of the way through the index
+  ** .dt %r  .dd   .dd Modified/read-only/won't-write/attach-message indicator,
+  **                   According to $$status_chars
+  ** .dt %R  .dd * .dd Number of read messages in the mailbox (read, seen)
+  ** .dt %s  .dd   .dd Current sorting mode ($$sort)
+  ** .dt %S  .dd   .dd Current aux sorting method ($$sort_aux)
+  ** .dt %t  .dd * .dd Number of tagged messages in the mailbox
+  ** .dt %u  .dd * .dd Number of unread messages in the mailbox (seen or unseen)
+  ** .dt %v  .dd   .dd NeoMutt version string
+  ** .dt %V  .dd * .dd Currently active limit pattern, if any
+  ** .dt %>X .dd   .dd Right justify the rest of the string and pad with "X"
+  ** .dt %|X .dd   .dd Pad to the end of the line with "X"
+  ** .dt %*X .dd   .dd Soft-fill with character "X" as pad
   ** .de
   ** .pp
   ** For an explanation of "soft-fill", see the $$index_format documentation.

--- a/sidebar.c
+++ b/sidebar.c
@@ -105,10 +105,13 @@ enum DivType
  * | \%d     | Number of deleted messages
  * | \%F     | Number of Flagged messages in the mailbox
  * | \%L     | Number of messages after limiting
- * | \%n     | N if mailbox has new mail, blank otherwise
+ * | \%n     | 'N' if mailbox has new mail, ' ' (space) otherwise
  * | \%N     | Number of unread messages in the mailbox
+ * | \%o     | Number of old unread messages in the mailbox
+ * | \%r     | Number of read messages in the mailbox
  * | \%S     | Size of mailbox (total number of messages)
  * | \%t     | Number of tagged messages
+ * | \%Z     | Number of new unseen messages in the mailbox
  */
 static const char *sidebar_format_str(char *buf, size_t buflen, size_t col, int cols,
                                       char op, const char *src, const char *prec,
@@ -195,6 +198,26 @@ static const char *sidebar_format_str(char *buf, size_t buflen, size_t col, int 
         optional = false;
       break;
 
+    case 'o':
+      if (!optional)
+      {
+        snprintf(fmt, sizeof(fmt), "%%%sd", prec);
+        snprintf(buf, buflen, fmt, m->msg_unread - m->msg_new);
+      }
+      else if ((c && (Context->mailbox->msg_unread - Context->mailbox->msg_new) == 0) || !c)
+        optional = false;
+      break;
+
+    case 'r':
+      if (!optional)
+      {
+        snprintf(fmt, sizeof(fmt), "%%%sd", prec);
+        snprintf(buf, buflen, fmt, m->msg_count - m->msg_unread);
+      }
+      else if ((c && (Context->mailbox->msg_count - Context->mailbox->msg_unread) == 0) || !c)
+        optional = false;
+      break;
+
     case 'S':
       if (!optional)
       {
@@ -212,6 +235,16 @@ static const char *sidebar_format_str(char *buf, size_t buflen, size_t col, int 
         snprintf(buf, buflen, fmt, c ? Context->mailbox->msg_tagged : 0);
       }
       else if ((c && (Context->mailbox->msg_tagged == 0)) || !c)
+        optional = false;
+      break;
+
+    case 'Z':
+      if (!optional)
+      {
+        snprintf(fmt, sizeof(fmt), "%%%sd", prec);
+        snprintf(buf, buflen, fmt, m->msg_new);
+      }
+      else if ((c && (Context->mailbox->msg_new) == 0) || !c)
         optional = false;
       break;
 


### PR DESCRIPTION
* **What does this PR do?**
Adds number of old messages as `%o` to `sidebar_format` variable.
Counting behaves the same like for `%o` in `status_format`

* **Screenshots (if relevant)**
[![asciicast](https://asciinema.org/a/WiOjaa5g9QumpUrGfCjrtyTqu.svg)](https://asciinema.org/a/WiOjaa5g9QumpUrGfCjrtyTqu)

* **Example**
Initial state: there are 8 unread messages in a mailbox: 5 new (unread, not seen), 3 old (unread, already seen)

| first time visit | %N | %o |revisiting mailbox | %N | %o |
| ---                    | ---  | --- |---                    | ---  | --- |
| mark_old=yes |     8 |    3 | mark_old=yes |     8 |    8 | 
| mark_old=no  |     8 | N/A |mark_old=no  |     8 | N/A |