### PR TITLE
config: move functions to avoid dependency problems

### DIFF
--- a/config/dump.c
+++ b/config/dump.c
@@ -92,53 +92,6 @@ size_t pretty_var(const char *str, struct Buffer *buf)
 }
 
 /**
- * elem_list_sort - Sort two HashElem pointers to config
- * @param a First HashElem
- * @param b Second HashElem
- * @retval -1 a precedes b
- * @retval  0 a and b are identical
- * @retval  1 b precedes a
- */
-int elem_list_sort(const void *a, const void *b)
-{
-  if (!a || !b)
-    return 0;
-
-  const struct HashElem *hea = *(struct HashElem const *const *) a;
-  const struct HashElem *heb = *(struct HashElem const *const *) b;
-
-  return mutt_str_strcasecmp(hea->key.strkey, heb->key.strkey);
-}
-
-/**
- * get_elem_list - Create a sorted list of all config items
- * @param cs ConfigSet to read
- * @retval ptr Null-terminated array of HashElem
- */
-struct HashElem **get_elem_list(struct ConfigSet *cs)
-{
-  if (!cs)
-    return NULL;
-
-  struct HashElem **list = mutt_mem_calloc(1024, sizeof(struct HashElem *));
-  size_t index = 0;
-
-  struct HashWalkState walk = { 0 };
-  struct HashElem *he = NULL;
-
-  while ((he = mutt_hash_walk(cs->hash, &walk)))
-  {
-    list[index++] = he;
-    if (index == 1022)
-      break; /* LCOV_EXCL_LINE */
-  }
-
-  qsort(list, index, sizeof(struct HashElem *), elem_list_sort);
-
-  return list;
-}
-
-/**
  * dump_config_neo - Dump the config in the style of NeoMutt
  * @param cs      Config items
  * @param he      HashElem representing config item

--- a/config/dump.h
+++ b/config/dump.h
@@ -45,9 +45,7 @@ typedef uint16_t ConfigDumpFlags;         ///< Flags for dump_config(), e.g. #CS
 
 void              dump_config_neo(struct ConfigSet *cs, struct HashElem *he, struct Buffer *value, struct Buffer *initial, ConfigDumpFlags flags, FILE *fp);
 bool              dump_config(struct ConfigSet *cs, ConfigDumpFlags flags, FILE *fp);
-int               elem_list_sort(const void *a, const void *b);
 size_t            escape_string(struct Buffer *buf, const char *src);
-struct HashElem **get_elem_list(struct ConfigSet *cs);
 size_t            pretty_var(const char *str, struct Buffer *buf);
 
 #endif /* MUTT_CONFIG_DUMP_H */

--- a/config/subset.c
+++ b/config/subset.c
@@ -36,6 +36,53 @@
 #include "set.h"
 
 /**
+ * elem_list_sort - Sort two HashElem pointers to config
+ * @param a First HashElem
+ * @param b Second HashElem
+ * @retval -1 a precedes b
+ * @retval  0 a and b are identical
+ * @retval  1 b precedes a
+ */
+int elem_list_sort(const void *a, const void *b)
+{
+  if (!a || !b)
+    return 0;
+
+  const struct HashElem *hea = *(struct HashElem const *const *) a;
+  const struct HashElem *heb = *(struct HashElem const *const *) b;
+
+  return mutt_str_strcasecmp(hea->key.strkey, heb->key.strkey);
+}
+
+/**
+ * get_elem_list - Create a sorted list of all config items
+ * @param cs ConfigSet to read
+ * @retval ptr Null-terminated array of HashElem
+ */
+struct HashElem **get_elem_list(struct ConfigSet *cs)
+{
+  if (!cs)
+    return NULL;
+
+  struct HashElem **list = mutt_mem_calloc(1024, sizeof(struct HashElem *));
+  size_t index = 0;
+
+  struct HashWalkState walk = { 0 };
+  struct HashElem *he = NULL;
+
+  while ((he = mutt_hash_walk(cs->hash, &walk)))
+  {
+    list[index++] = he;
+    if (index == 1022)
+      break; /* LCOV_EXCL_LINE */
+  }
+
+  qsort(list, index, sizeof(struct HashElem *), elem_list_sort);
+
+  return list;
+}
+
+/**
  * cs_subset_free - Free a Config Subset
  * @param ptr Subset to free
  *

--- a/config/subset.h
+++ b/config/subset.h
@@ -91,4 +91,7 @@ int      cs_subset_str_reset     (const struct ConfigSubset *sub, const char *na
 int      cs_subset_str_string_get(const struct ConfigSubset *sub, const char *name,                    struct Buffer *result);
 int      cs_subset_str_string_set(const struct ConfigSubset *sub, const char *name, const char *value, struct Buffer *err);
 
+int               elem_list_sort(const void *a, const void *b);
+struct HashElem **get_elem_list(struct ConfigSet *cs);
+
 #endif /* MUTT_CONFIG_SUBSET_H */


### PR DESCRIPTION
`elem_list_sort()` and `get_elem_list()` are used by the subset code.
Move them out of dump.c, which has GUI dependencies.

There are no functional changes.