### PR TITLE
upstream changes

### DIFF
--- a/autocrypt/autocrypt.c
+++ b/autocrypt/autocrypt.c
@@ -100,6 +100,11 @@ int mutt_autocrypt_init(bool can_create)
     return -1;
 
   OptIgnoreMacroEvents = true;
+  /* The init process can display menus at various points
+   *(e.g. browser, pgp key selection).  This allows the screen to be
+   * autocleared after each menu, so the subsequent prompts can be
+   * read. */
+  OptMenuPopClearScreen = true;
 
   if (autocrypt_dir_init(can_create))
     goto bail;
@@ -111,11 +116,13 @@ int mutt_autocrypt_init(bool can_create)
     goto bail;
 
   OptIgnoreMacroEvents = false;
+  OptMenuPopClearScreen = false;
 
   return 0;
 
 bail:
   OptIgnoreMacroEvents = false;
+  OptMenuPopClearScreen = false;
   C_Autocrypt = false;
   mutt_autocrypt_db_close();
   return -1;

--- a/autocrypt/autocrypt_acct_menu.c
+++ b/autocrypt/autocrypt_acct_menu.c
@@ -68,16 +68,16 @@ static const struct Mapping AutocryptAcctHelp[] = {
      toggle an account active/inactive
      The words here are abbreviated to keep the help line compact.
      It currently has the content:
-     q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Enc  ?:Help
+     q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Encr  ?:Help
   */
   { N_("Tgl Active"), OP_AUTOCRYPT_TOGGLE_ACTIVE },
   /* L10N: Autocrypt Account Menu Help line:
      toggle "prefer-encrypt" on an account
      The words here are abbreviated to keep the help line compact.
      It currently has the content:
-     q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Enc  ?:Help
+     q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Encr  ?:Help
   */
-  { N_("Prf Enc"), OP_AUTOCRYPT_TOGGLE_PREFER },
+  { N_("Prf Encr"), OP_AUTOCRYPT_TOGGLE_PREFER },
   { N_("Help"), OP_HELP },
   { NULL, 0 }
 };

--- a/bcache.c
+++ b/bcache.c
@@ -80,7 +80,7 @@ static int bcache_path(struct ConnAccount *account, const char *mailbox, struct 
 
   struct Buffer *path = mutt_buffer_pool_get();
   struct Buffer *dst = mutt_buffer_pool_get();
-  mutt_buffer_encode_path(path, NONULL(mailbox));
+  mutt_encode_path(path, NONULL(mailbox));
 
   mutt_buffer_printf(dst, "%s/%s%s", C_MessageCachedir, host, mutt_b2s(path));
   if (*(dst->dptr - 1) != '/')

--- a/conn/ssl.c
+++ b/conn/ssl.c
@@ -1366,6 +1366,9 @@ free_ssldata:
  */
 static int ssl_socket_poll(struct Connection *conn, time_t wait_secs)
 {
+  if (!conn)
+    return -1;
+
   if (SSL_has_pending(sockdata(conn)->ssl))
     return 1;
 

--- a/conn/ssl_gnutls.c
+++ b/conn/ssl_gnutls.c
@@ -1173,6 +1173,8 @@ fail:
 static int tls_socket_poll(struct Connection *conn, time_t wait_secs)
 {
   struct TlsSockData *data = conn->sockdata;
+  if (!data)
+    return -1;
 
   if (gnutls_record_check_pending(data->state))
     return 1;

--- a/doc/manual.xml.head
+++ b/doc/manual.xml.head
@@ -8630,16 +8630,19 @@ set index_format="%4C %Z %{%b %d} %-15.15L (%?l?%4l&amp;%4c?)%*  %s"
         <sect3 id="date-absolute">
           <title>Absolute Dates</title>
           <para>
-            Dates <emphasis>must</emphasis> be in DD/MM/YY format (month and
-            year are optional, defaulting to the current month and year). An
+            Dates <emphasis>must</emphasis> be in DD/MM/YY format (month and year
+            are optional, defaulting to the current month and year) or YYYYMMDD.  An
             example of a valid range of dates is:
           </para>
-          <screen>Limit to messages matching: ~d 20/1/95-31/10</screen>
+<screen>
+Limit to messages matching: ~d 20/1/95-31/10
+Limit to messages matching: ~d 19950120-19951031
+</screen>
           <para>
             If you omit the minimum (first) date, and just specify
-            <quote>-DD/MM/YY</quote>, all messages <emphasis>before</emphasis>
-            the given date will be selected. If you omit the maximum (second)
-            date, and specify <quote>DD/MM/YY-</quote>, all messages
+            <quote>-DD/MM/YY</quote> or <quote>-YYYYMMDD</quote>, all messages
+            <emphasis>before</emphasis> the given date will be selected.  If you omit the
+            maximum(second) date, and specify <quote>DD/MM/YY-</quote>, all messages
             <emphasis>after</emphasis> the given date will be selected. If you
             specify a single date with no dash (<quote>-</quote>), only
             messages sent on the given date will be selected.

--- a/doc/neomuttrc.man.head
+++ b/doc/neomuttrc.man.head
@@ -1261,6 +1261,8 @@ Limit to messages matching:
 .IR \fB~d\fP\~20 / 1 / 95 - 31 / 10
 .
 .PP
+Alternatively, you may use \fIYYYYMMDD\fP to specify a date.
+.PP
 When given a two-digit year, NeoMutt will interpret values less than \(lq70\(rq
 as lying in the 21st century (i.e., \(lq38\(rq means 2038 and not 1938, and
 \(lq00\(rq is interpreted as 2000), and values greater than or equal to

--- a/globals.h
+++ b/globals.h
@@ -268,6 +268,7 @@ WHERE bool C_CryptUsePka;                    ///< Config: Use GPGME to use PKA (
 
 WHERE bool C_CryptConfirmhook;               ///< Config: Prompt the user to confirm keys before use
 WHERE bool C_CryptOpportunisticEncrypt;      ///< Config: Enable encryption when the recipient's key is available
+WHERE bool C_CryptOpportunisticEncryptStrongKeys; ///< Config: Enable encryption only when strong a key is available
 WHERE bool C_CryptProtectedHeadersRead;      ///< Config: Display protected headers (Memory Hole) in the pager
 WHERE bool C_CryptProtectedHeadersSave;      ///< Config: Save the cleartext Subject with the headers
 WHERE bool C_CryptProtectedHeadersWrite;     ///< Config: Generate protected header (Memory Hole) for signed and encrypted emails

--- a/hcache/hcache.c
+++ b/hcache/hcache.c
@@ -199,7 +199,7 @@ static void hcache_per_folder(struct Buffer *hcpath, const char *path,
   if (((rc == 0) && !S_ISDIR(sb.st_mode)) || ((rc == -1) && !slash))
   {
     /* An existing file or a non-existing path not ending with a slash */
-    mutt_buffer_encode_path(hcpath, path);
+    mutt_encode_path(hcpath, path);
     return;
   }
 
@@ -223,7 +223,7 @@ static void hcache_per_folder(struct Buffer *hcpath, const char *path,
     mutt_buffer_pool_release(&name);
   }
 
-  mutt_buffer_encode_path(hcpath, mutt_b2s(hcpath));
+  mutt_encode_path(hcpath, mutt_b2s(hcpath));
   create_hcache_dir(mutt_b2s(hcpath));
   mutt_buffer_pool_release(&hcfile);
 }

--- a/hook.c
+++ b/hook.c
@@ -238,11 +238,16 @@ enum CommandResult mutt_parse_hook(struct Buffer *buf, struct Buffer *s,
   else if (data & (MUTT_SEND_HOOK | MUTT_SEND2_HOOK | MUTT_SAVE_HOOK |
                    MUTT_FCC_HOOK | MUTT_MESSAGE_HOOK | MUTT_REPLY_HOOK))
   {
-    pat = mutt_pattern_comp(mutt_b2s(pattern),
-                            (data & (MUTT_SEND_HOOK | MUTT_SEND2_HOOK | MUTT_FCC_HOOK)) ?
-                                MUTT_PC_NO_FLAGS :
-                                MUTT_PC_FULL_MSG,
-                            err);
+    PatternCompFlags comp_flags;
+
+    if (data & (MUTT_SEND2_HOOK))
+      comp_flags = MUTT_PC_SEND_MODE_SEARCH;
+    else if (data & (MUTT_SEND_HOOK | MUTT_FCC_HOOK))
+      comp_flags = MUTT_PC_NO_FLAGS;
+    else
+      comp_flags = MUTT_PC_FULL_MSG;
+
+    pat = mutt_pattern_comp(mutt_b2s(pattern), comp_flags, err);
     if (!pat)
       goto cleanup;
   }

--- a/menu.c
+++ b/menu.c
@@ -1073,8 +1073,15 @@ void mutt_menu_pop_current(struct Menu *menu)
   else
   {
     CurrentMenu = MENU_MAIN;
-    mutt_window_move_abs(0, 0);
-    mutt_window_clrtobot();
+    /* Clearing when NeoMutt exits would be an annoying change in behavior for
+     * those who have disabled alternative screens.  The option is currently
+     * set by autocrypt initialization which mixes menus and prompts outside of
+     * the normal menu system state.  */
+    if (OptMenuPopClearScreen)
+    {
+      mutt_window_move_abs(0, 0);
+      mutt_window_clrtobot();
+    }
   }
 }
 

--- a/mutt_config.c
+++ b/mutt_config.c
@@ -686,6 +686,20 @@ struct ConfigDef MuttVars[] = {
   ** be manually re-enabled in the pgp or smime menus.
   ** (Crypto only)
   */
+  { "crypt_opportunistic_encrypt_strong_keys", DT_BOOL, &C_CryptOpportunisticEncryptStrongKeys, false },
+  /*
+  ** .pp
+  ** When set, this modifies the behavior of $$crypt_opportunistic_encrypt
+  ** to only search for "strong keys", that is, keys with full validity
+  ** according to the web-of-trust algorithm.  A key with marginal or no
+  ** validity will not enable opportunistic encryption.
+  ** .pp
+  ** For S/MIME, the behavior depends on the backend.  Classic S/MIME will
+  ** filter for certificates with the 't'(trusted) flag in the .index file.
+  ** The GPGME backend will use the same filters as with OpenPGP, and depends
+  ** on GPGME's logic for assigning the GPGME_VALIDITY_FULL and
+  ** GPGME_VALIDITY_ULTIMATE validity flag.
+  */
   { "crypt_protected_headers_read", DT_BOOL, &C_CryptProtectedHeadersRead, true },
   /*
   ** .pp

--- a/muttlib.c
+++ b/muttlib.c
@@ -1563,43 +1563,26 @@ const char *mutt_make_version(void)
 }
 
 /**
- * mutt_encode_path - Convert a path into the user's preferred character set
- * @param buf    Buffer for the result
- * @param buflen Length of buffer
- * @param src  Path to convert (OPTIONAL)
- *
- * If `src` is NULL, the path in `buf` will be converted in-place.
- */
-void mutt_encode_path(char *buf, size_t buflen, const char *src)
-{
-  char *p = mutt_str_strdup(src);
-  int rc = mutt_ch_convert_string(&p, C_Charset, "us-ascii", 0);
-  /* 'src' may be NULL, such as when called from the pop3 driver. */
-  size_t len = mutt_str_strfcpy(buf, (rc == 0) ? p : src, buflen);
-
-  /* convert the path to POSIX "Portable Filename Character Set" */
-  for (size_t i = 0; i < len; i++)
-  {
-    if (!isalnum(buf[i]) && !strchr("/.-_", buf[i]))
-    {
-      buf[i] = '_';
-    }
-  }
-  FREE(&p);
-}
-
-/**
- * mutt_buffer_encode_path - Convert a path into the user's preferred character set
+ * mutt_encode_path - Convert a path to 'us-ascii'
  * @param buf Buffer for the result
  * @param src Path to convert (OPTIONAL)
  *
  * If `src` is NULL, the path in `buf` will be converted in-place.
  */
-void mutt_buffer_encode_path(struct Buffer *buf, const char *src)
+void mutt_encode_path(struct Buffer *buf, const char *src)
 {
   char *p = mutt_str_strdup(src);
-  int rc = mutt_ch_convert_string(&p, C_Charset, "utf-8", 0);
-  mutt_buffer_strcpy(buf, (rc == 0) ? NONULL(p) : NONULL(src));
+  int rc = mutt_ch_convert_string(&p, C_Charset, "us-ascii", 0);
+  size_t len = mutt_buffer_strcpy(buf, (rc == 0) ? NONULL(p) : NONULL(src));
+
+  /* convert the path to POSIX "Portable Filename Character Set" */
+  for (size_t i = 0; i < len; i++)
+  {
+    if (!isalnum(buf->data[i]) && !strchr("/.-_", buf->data[i]))
+    {
+      buf->data[i] = '_';
+    }
+  }
   FREE(&p);
 }
 

--- a/muttlib.h
+++ b/muttlib.h
@@ -43,14 +43,13 @@ extern struct Regex *C_GecosMask;
 
 void        mutt_adv_mktemp(struct Buffer *buf);
 void        mutt_buffer_mktemp_full(struct Buffer *buf, const char *prefix, const char *suffix, const char *src, int line);
-void        mutt_buffer_encode_path(struct Buffer *buf, const char *src);
 void        mutt_buffer_expand_path(struct Buffer *buf);
 void        mutt_buffer_expand_path_regex(struct Buffer *buf, bool regex);
 void        mutt_buffer_pretty_mailbox(struct Buffer *s);
 void        mutt_buffer_sanitize_filename (struct Buffer *buf, const char *path, short slash);
 void        mutt_buffer_save_path(struct Buffer *dest, const struct Address *a);
 int         mutt_check_overwrite(const char *attname, const char *path, struct Buffer *fname, enum SaveAttach *opt, char **directory);
-void        mutt_encode_path(char *dest, size_t dlen, const char *src);
+void        mutt_encode_path(struct Buffer *buf, const char *src);
 void        mutt_expando_format(char *buf, size_t buflen, size_t col, int cols, const char *src, format_t *callback, unsigned long data, MuttFormatFlags flags);
 char *      mutt_expand_path(char *s, size_t slen);
 char *      mutt_expand_path_regex(char *buf, size_t buflen, bool regex);

--- a/ncrypt/crypt.c
+++ b/ncrypt/crypt.c
@@ -289,6 +289,12 @@ int mutt_protect(struct Email *e, char *keylist, bool postpone)
 
     mutt_env_free(&e->content->mime_headers);
     e->content->mime_headers = protected_headers;
+    /* Optional part of the draft RFC, but required by Enigmail */
+    mutt_param_set(&e->content->parameter, "protected-headers", "v1");
+  }
+  else
+  {
+    mutt_param_delete(&e->content->parameter, "protected-headers");
   }
 
   /* A note about e->content->mime_headers.  If postpone or send

--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -5059,7 +5059,7 @@ static struct CryptKeyInfo *crypt_getkeybyaddr(struct Address *a,
     {
       if (the_strong_valid_key)
         k = crypt_copy_key(the_strong_valid_key);
-      else if (a_valid_addrmatch_key)
+      else if (a_valid_addrmatch_key && !C_CryptOpportunisticEncryptStrongKeys)
         k = crypt_copy_key(a_valid_addrmatch_key);
       else
         k = NULL;

--- a/ncrypt/pgpkey.c
+++ b/ncrypt/pgpkey.c
@@ -1124,7 +1124,7 @@ struct PgpKeyInfo *pgp_getkeybyaddr(struct Address *a, KeyFlags abilities,
         pgp_remove_key(&matches, the_strong_valid_key);
         k = the_strong_valid_key;
       }
-      else if (a_valid_addrmatch_key)
+      else if (a_valid_addrmatch_key && !C_CryptOpportunisticEncryptStrongKeys)
       {
         pgp_remove_key(&matches, a_valid_addrmatch_key);
         k = a_valid_addrmatch_key;

--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -862,7 +862,7 @@ static struct SmimeKey *smime_get_key_by_addr(char *mailbox, KeyFlags abilities,
     {
       if (trusted_match)
         return_key = smime_copy_key(trusted_match);
-      else if (valid_match)
+      else if (valid_match && !C_CryptOpportunisticEncryptStrongKeys)
         return_key = smime_copy_key(valid_match);
       else
         return_key = NULL;

--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -807,11 +807,11 @@ static struct SmimeKey *smime_get_key_by_hash(char *hash, bool only_public_key)
  * @param mailbox          Email address to match
  * @param abilities        Abilities to match, see #KeyFlags
  * @param only_public_key  If true, only get the public keys
- * @param may_ask          If true, the user may be asked to select a key
+ * @param oppenc_mode      If true, use opportunistic encryption
  * @retval ptr Matching key
  */
 static struct SmimeKey *smime_get_key_by_addr(char *mailbox, KeyFlags abilities,
-                                              bool only_public_key, bool may_ask)
+                                              bool only_public_key, bool oppenc_mode)
 {
   if (!mailbox)
     return NULL;
@@ -858,7 +858,7 @@ static struct SmimeKey *smime_get_key_by_addr(char *mailbox, KeyFlags abilities,
 
   if (matches)
   {
-    if (!may_ask)
+    if (oppenc_mode)
     {
       if (trusted_match)
         return_key = smime_copy_key(trusted_match);
@@ -970,7 +970,7 @@ static void getkeys(char *mailbox)
 {
   char *k = NULL;
 
-  struct SmimeKey *key = smime_get_key_by_addr(mailbox, KEYFLAG_CANENCRYPT, false, true);
+  struct SmimeKey *key = smime_get_key_by_addr(mailbox, KEYFLAG_CANENCRYPT, false, false);
 
   if (!key)
   {
@@ -1076,7 +1076,7 @@ char *smime_class_find_keys(struct AddressList *al, bool oppenc_mode)
   struct Address *a = NULL;
   TAILQ_FOREACH(a, al, entries)
   {
-    key = smime_get_key_by_addr(a->mailbox, KEYFLAG_CANENCRYPT, true, !oppenc_mode);
+    key = smime_get_key_by_addr(a->mailbox, KEYFLAG_CANENCRYPT, true, oppenc_mode);
     if (!key && !oppenc_mode)
     {
       char buf[1024];

--- a/nntp/newsrc.c
+++ b/nntp/newsrc.c
@@ -543,8 +543,13 @@ static void cache_expand(char *dst, size_t dstlen, struct ConnAccount *acct, con
   c = dst + strlen(dst) - 1;
   if (*c == '/')
     *c = '\0';
-  mutt_expand_path(dst, dstlen);
-  mutt_encode_path(dst, dstlen, dst);
+
+  struct Buffer *tmp = mutt_buffer_pool_get();
+  mutt_buffer_addstr(tmp, dst);
+  mutt_buffer_expand_path(tmp);
+  mutt_encode_path(tmp, dst);
+  mutt_str_strfcpy(dst, mutt_b2s(tmp), dstlen);
+  mutt_buffer_pool_release(&tmp);
 }
 
 /**

--- a/options.h
+++ b/options.h
@@ -36,6 +36,7 @@ WHERE bool OptForceRefresh;        ///< (pseudo) refresh even during macros
 WHERE bool OptIgnoreMacroEvents;   ///< (pseudo) don't process macro/push/exec events while set
 WHERE bool OptKeepQuiet;           ///< (pseudo) shut up the message and refresh functions while we are executing an external program
 WHERE bool OptMenuCaller;          ///< (pseudo) tell menu to give caller a take
+WHERE bool OptMenuPopClearScreen;  ///< (pseudo) clear the screen when popping the last menu
 WHERE bool OptMsgErr;              ///< (pseudo) used by mutt_error/mutt_message
 WHERE bool OptNeedRescore;         ///< (pseudo) set when the 'score' command is used
 WHERE bool OptNeedResort;          ///< (pseudo) used to force a re-sort

--- a/pattern.h
+++ b/pattern.h
@@ -42,6 +42,7 @@ typedef uint8_t PatternCompFlags;       ///< Flags for mutt_pattern_comp(), e.g.
 #define MUTT_PC_NO_FLAGS            0   ///< No flags are set
 #define MUTT_PC_FULL_MSG        (1<<0)  ///< Enable body and header matching
 #define MUTT_PC_PATTERN_DYNAMIC (1<<1)  ///< Enable runtime date range evaluation
+#define MUTT_PC_SEND_MODE_SEARCH (1<<2) ///< Allow send-mode body searching
 
 /**
  * struct Pattern - A simple (non-regex) pattern
@@ -56,6 +57,7 @@ struct Pattern
   bool ign_case     : 1;         ///< Ignore case for local string_match searches
   bool is_alias     : 1;         ///< Is there an alias for this Address?
   bool dynamic      : 1;         ///< Evaluate date ranges at run time
+  bool sendmode     : 1;         ///< Evaluate searches in send-mode
   bool is_multi     : 1;         ///< Multiple case (only for ~I pattern now)
   int min;                       ///< Minimum for range checks
   int max;                       ///< Maximum for range checks

--- a/po/bg.po
+++ b/po/bg.po
@@ -253,7 +253,7 @@ msgstr "Изтриване"
 #. toggle an account active/inactive
 #. The words here are abbreviated to keep the help line compact.
 #. It currently has the content:
-#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Enc  ?:Help
+#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Encr  ?:Help
 #.
 #: autocrypt/autocrypt_acct_menu.c:73
 msgid "Tgl Active"
@@ -263,10 +263,10 @@ msgstr ""
 #. toggle "prefer-encrypt" on an account
 #. The words here are abbreviated to keep the help line compact.
 #. It currently has the content:
-#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Enc  ?:Help
+#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Encr  ?:Help
 #.
 #: autocrypt/autocrypt_acct_menu.c:80
-msgid "Prf Enc"
+msgid "Prf Encr"
 msgstr ""
 
 #. L10N:

--- a/po/ca.po
+++ b/po/ca.po
@@ -296,7 +296,7 @@ msgstr "Esborra"
 #. toggle an account active/inactive
 #. The words here are abbreviated to keep the help line compact.
 #. It currently has the content:
-#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Enc  ?:Help
+#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Encr  ?:Help
 #.
 #: autocrypt/autocrypt_acct_menu.c:73
 msgid "Tgl Active"
@@ -306,10 +306,10 @@ msgstr "(Des)Activa"
 #. toggle "prefer-encrypt" on an account
 #. The words here are abbreviated to keep the help line compact.
 #. It currently has the content:
-#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Enc  ?:Help
+#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Encr  ?:Help
 #.
 #: autocrypt/autocrypt_acct_menu.c:80
-msgid "Prf Enc"
+msgid "Prf Encr"
 msgstr "(No)Pref xifrar"
 
 #. L10N:

--- a/po/cs.po
+++ b/po/cs.po
@@ -253,7 +253,7 @@ msgstr "Smazat"
 #. toggle an account active/inactive
 #. The words here are abbreviated to keep the help line compact.
 #. It currently has the content:
-#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Enc  ?:Help
+#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Encr  ?:Help
 #.
 #: autocrypt/autocrypt_acct_menu.c:73
 msgid "Tgl Active"
@@ -263,10 +263,10 @@ msgstr "Prep akt"
 #. toggle "prefer-encrypt" on an account
 #. The words here are abbreviated to keep the help line compact.
 #. It currently has the content:
-#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Enc  ?:Help
+#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Encr  ?:Help
 #.
 #: autocrypt/autocrypt_acct_menu.c:80
-msgid "Prf Enc"
+msgid "Prf Encr"
 msgstr "Pref šif"
 
 #. L10N:

--- a/po/da.po
+++ b/po/da.po
@@ -246,7 +246,7 @@ msgstr "Slet"
 #. toggle an account active/inactive
 #. The words here are abbreviated to keep the help line compact.
 #. It currently has the content:
-#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Enc  ?:Help
+#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Encr  ?:Help
 #.
 #: autocrypt/autocrypt_acct_menu.c:73
 msgid "Tgl Active"
@@ -256,10 +256,10 @@ msgstr "Aktiv til/fra"
 #. toggle "prefer-encrypt" on an account
 #. The words here are abbreviated to keep the help line compact.
 #. It currently has the content:
-#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Enc  ?:Help
+#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Encr  ?:Help
 #.
 #: autocrypt/autocrypt_acct_menu.c:80
-msgid "Prf Enc"
+msgid "Prf Encr"
 msgstr "Foretræk kryptering"
 
 #. L10N:

--- a/po/de.po
+++ b/po/de.po
@@ -249,7 +249,7 @@ msgstr "Löschen"
 #. toggle an account active/inactive
 #. The words here are abbreviated to keep the help line compact.
 #. It currently has the content:
-#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Enc  ?:Help
+#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Encr  ?:Help
 #.
 #: autocrypt/autocrypt_acct_menu.c:73
 msgid "Tgl Active"
@@ -259,10 +259,10 @@ msgstr "AktiviergSetzen"
 #. toggle "prefer-encrypt" on an account
 #. The words here are abbreviated to keep the help line compact.
 #. It currently has the content:
-#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Enc  ?:Help
+#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Encr  ?:Help
 #.
 #: autocrypt/autocrypt_acct_menu.c:80
-msgid "Prf Enc"
+msgid "Prf Encr"
 msgstr "BevorzCodierg"
 
 #. L10N:

--- a/po/el.po
+++ b/po/el.po
@@ -253,7 +253,7 @@ msgstr "Διαγραφή"
 #. toggle an account active/inactive
 #. The words here are abbreviated to keep the help line compact.
 #. It currently has the content:
-#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Enc  ?:Help
+#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Encr  ?:Help
 #.
 #: autocrypt/autocrypt_acct_menu.c:73
 msgid "Tgl Active"
@@ -263,10 +263,10 @@ msgstr ""
 #. toggle "prefer-encrypt" on an account
 #. The words here are abbreviated to keep the help line compact.
 #. It currently has the content:
-#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Enc  ?:Help
+#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Encr  ?:Help
 #.
 #: autocrypt/autocrypt_acct_menu.c:80
-msgid "Prf Enc"
+msgid "Prf Encr"
 msgstr ""
 
 #. L10N:

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -243,7 +243,7 @@ msgstr "Delete"
 #. toggle an account active/inactive
 #. The words here are abbreviated to keep the help line compact.
 #. It currently has the content:
-#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Enc  ?:Help
+#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Encr  ?:Help
 #.
 #: autocrypt/autocrypt_acct_menu.c:73
 msgid "Tgl Active"
@@ -253,11 +253,11 @@ msgstr "Tgl Active"
 #. toggle "prefer-encrypt" on an account
 #. The words here are abbreviated to keep the help line compact.
 #. It currently has the content:
-#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Enc  ?:Help
+#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Encr  ?:Help
 #.
 #: autocrypt/autocrypt_acct_menu.c:80
-msgid "Prf Enc"
-msgstr "Prf Enc"
+msgid "Prf Encr"
+msgstr "Prf Encr"
 
 #. L10N:
 #. Autocrypt Account menu.

--- a/po/eo.po
+++ b/po/eo.po
@@ -248,7 +248,7 @@ msgstr "Forviŝi"
 #. toggle an account active/inactive
 #. The words here are abbreviated to keep the help line compact.
 #. It currently has the content:
-#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Enc  ?:Help
+#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Encr  ?:Help
 #.
 #: autocrypt/autocrypt_acct_menu.c:73
 msgid "Tgl Active"
@@ -258,10 +258,10 @@ msgstr ""
 #. toggle "prefer-encrypt" on an account
 #. The words here are abbreviated to keep the help line compact.
 #. It currently has the content:
-#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Enc  ?:Help
+#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Encr  ?:Help
 #.
 #: autocrypt/autocrypt_acct_menu.c:80
-msgid "Prf Enc"
+msgid "Prf Encr"
 msgstr ""
 
 #. L10N:

--- a/po/es.po
+++ b/po/es.po
@@ -248,7 +248,7 @@ msgstr "Suprimir"
 #. toggle an account active/inactive
 #. The words here are abbreviated to keep the help line compact.
 #. It currently has the content:
-#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Enc  ?:Help
+#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Encr  ?:Help
 #.
 #: autocrypt/autocrypt_acct_menu.c:73
 msgid "Tgl Active"
@@ -258,10 +258,10 @@ msgstr ""
 #. toggle "prefer-encrypt" on an account
 #. The words here are abbreviated to keep the help line compact.
 #. It currently has the content:
-#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Enc  ?:Help
+#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Encr  ?:Help
 #.
 #: autocrypt/autocrypt_acct_menu.c:80
-msgid "Prf Enc"
+msgid "Prf Encr"
 msgstr ""
 
 #. L10N:

--- a/po/et.po
+++ b/po/et.po
@@ -249,7 +249,7 @@ msgstr "Kustuta"
 #. toggle an account active/inactive
 #. The words here are abbreviated to keep the help line compact.
 #. It currently has the content:
-#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Enc  ?:Help
+#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Encr  ?:Help
 #.
 #: autocrypt/autocrypt_acct_menu.c:73
 msgid "Tgl Active"
@@ -259,10 +259,10 @@ msgstr ""
 #. toggle "prefer-encrypt" on an account
 #. The words here are abbreviated to keep the help line compact.
 #. It currently has the content:
-#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Enc  ?:Help
+#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Encr  ?:Help
 #.
 #: autocrypt/autocrypt_acct_menu.c:80
-msgid "Prf Enc"
+msgid "Prf Encr"
 msgstr ""
 
 #. L10N:

--- a/po/eu.po
+++ b/po/eu.po
@@ -248,7 +248,7 @@ msgstr "Ezabatu"
 #. toggle an account active/inactive
 #. The words here are abbreviated to keep the help line compact.
 #. It currently has the content:
-#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Enc  ?:Help
+#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Encr  ?:Help
 #.
 #: autocrypt/autocrypt_acct_menu.c:73
 msgid "Tgl Active"
@@ -258,10 +258,10 @@ msgstr ""
 #. toggle "prefer-encrypt" on an account
 #. The words here are abbreviated to keep the help line compact.
 #. It currently has the content:
-#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Enc  ?:Help
+#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Encr  ?:Help
 #.
 #: autocrypt/autocrypt_acct_menu.c:80
-msgid "Prf Enc"
+msgid "Prf Encr"
 msgstr ""
 
 #. L10N:

--- a/po/fi.po
+++ b/po/fi.po
@@ -254,7 +254,7 @@ msgstr "Poista"
 #. toggle an account active/inactive
 #. The words here are abbreviated to keep the help line compact.
 #. It currently has the content:
-#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Enc  ?:Help
+#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Encr  ?:Help
 #.
 #: autocrypt/autocrypt_acct_menu.c:73
 msgid "Tgl Active"
@@ -264,10 +264,10 @@ msgstr ""
 #. toggle "prefer-encrypt" on an account
 #. The words here are abbreviated to keep the help line compact.
 #. It currently has the content:
-#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Enc  ?:Help
+#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Encr  ?:Help
 #.
 #: autocrypt/autocrypt_acct_menu.c:80
-msgid "Prf Enc"
+msgid "Prf Encr"
 msgstr ""
 
 #. L10N:

--- a/po/fr.po
+++ b/po/fr.po
@@ -265,7 +265,7 @@ msgstr "Retirer"
 #. toggle an account active/inactive
 #. The words here are abbreviated to keep the help line compact.
 #. It currently has the content:
-#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Enc  ?:Help
+#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Encr  ?:Help
 #.
 #: autocrypt/autocrypt_acct_menu.c:73
 msgid "Tgl Active"
@@ -275,10 +275,10 @@ msgstr ""
 #. toggle "prefer-encrypt" on an account
 #. The words here are abbreviated to keep the help line compact.
 #. It currently has the content:
-#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Enc  ?:Help
+#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Encr  ?:Help
 #.
 #: autocrypt/autocrypt_acct_menu.c:80
-msgid "Prf Enc"
+msgid "Prf Encr"
 msgstr ""
 
 #. L10N:

--- a/po/ga.po
+++ b/po/ga.po
@@ -249,7 +249,7 @@ msgstr "Scrios"
 #. toggle an account active/inactive
 #. The words here are abbreviated to keep the help line compact.
 #. It currently has the content:
-#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Enc  ?:Help
+#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Encr  ?:Help
 #.
 #: autocrypt/autocrypt_acct_menu.c:73
 msgid "Tgl Active"
@@ -259,10 +259,10 @@ msgstr ""
 #. toggle "prefer-encrypt" on an account
 #. The words here are abbreviated to keep the help line compact.
 #. It currently has the content:
-#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Enc  ?:Help
+#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Encr  ?:Help
 #.
 #: autocrypt/autocrypt_acct_menu.c:80
-msgid "Prf Enc"
+msgid "Prf Encr"
 msgstr ""
 
 #. L10N:

--- a/po/gl.po
+++ b/po/gl.po
@@ -249,7 +249,7 @@ msgstr "Borrar"
 #. toggle an account active/inactive
 #. The words here are abbreviated to keep the help line compact.
 #. It currently has the content:
-#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Enc  ?:Help
+#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Encr  ?:Help
 #.
 #: autocrypt/autocrypt_acct_menu.c:73
 msgid "Tgl Active"
@@ -259,10 +259,10 @@ msgstr ""
 #. toggle "prefer-encrypt" on an account
 #. The words here are abbreviated to keep the help line compact.
 #. It currently has the content:
-#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Enc  ?:Help
+#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Encr  ?:Help
 #.
 #: autocrypt/autocrypt_acct_menu.c:80
-msgid "Prf Enc"
+msgid "Prf Encr"
 msgstr ""
 
 #. L10N:

--- a/po/hu.po
+++ b/po/hu.po
@@ -250,7 +250,7 @@ msgstr "Törlés"
 #. toggle an account active/inactive
 #. The words here are abbreviated to keep the help line compact.
 #. It currently has the content:
-#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Enc  ?:Help
+#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Encr  ?:Help
 #.
 #: autocrypt/autocrypt_acct_menu.c:73
 msgid "Tgl Active"
@@ -260,10 +260,10 @@ msgstr ""
 #. toggle "prefer-encrypt" on an account
 #. The words here are abbreviated to keep the help line compact.
 #. It currently has the content:
-#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Enc  ?:Help
+#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Encr  ?:Help
 #.
 #: autocrypt/autocrypt_acct_menu.c:80
-msgid "Prf Enc"
+msgid "Prf Encr"
 msgstr ""
 
 #. L10N:

--- a/po/id.po
+++ b/po/id.po
@@ -251,7 +251,7 @@ msgstr "Hapus"
 #. toggle an account active/inactive
 #. The words here are abbreviated to keep the help line compact.
 #. It currently has the content:
-#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Enc  ?:Help
+#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Encr  ?:Help
 #.
 #: autocrypt/autocrypt_acct_menu.c:73
 msgid "Tgl Active"
@@ -261,10 +261,10 @@ msgstr ""
 #. toggle "prefer-encrypt" on an account
 #. The words here are abbreviated to keep the help line compact.
 #. It currently has the content:
-#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Enc  ?:Help
+#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Encr  ?:Help
 #.
 #: autocrypt/autocrypt_acct_menu.c:80
-msgid "Prf Enc"
+msgid "Prf Encr"
 msgstr ""
 
 #. L10N:

--- a/po/it.po
+++ b/po/it.po
@@ -249,7 +249,7 @@ msgstr "Cancella"
 #. toggle an account active/inactive
 #. The words here are abbreviated to keep the help line compact.
 #. It currently has the content:
-#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Enc  ?:Help
+#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Encr  ?:Help
 #.
 #: autocrypt/autocrypt_acct_menu.c:73
 msgid "Tgl Active"
@@ -259,10 +259,10 @@ msgstr ""
 #. toggle "prefer-encrypt" on an account
 #. The words here are abbreviated to keep the help line compact.
 #. It currently has the content:
-#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Enc  ?:Help
+#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Encr  ?:Help
 #.
 #: autocrypt/autocrypt_acct_menu.c:80
-msgid "Prf Enc"
+msgid "Prf Encr"
 msgstr ""
 
 #. L10N:

--- a/po/ja.po
+++ b/po/ja.po
@@ -245,7 +245,7 @@ msgstr "削除"
 #. toggle an account active/inactive
 #. The words here are abbreviated to keep the help line compact.
 #. It currently has the content:
-#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Enc  ?:Help
+#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Encr  ?:Help
 #.
 #: autocrypt/autocrypt_acct_menu.c:73
 msgid "Tgl Active"
@@ -255,10 +255,10 @@ msgstr "有効切替"
 #. toggle "prefer-encrypt" on an account
 #. The words here are abbreviated to keep the help line compact.
 #. It currently has the content:
-#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Enc  ?:Help
+#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Encr  ?:Help
 #.
 #: autocrypt/autocrypt_acct_menu.c:80
-msgid "Prf Enc"
+msgid "Prf Encr"
 msgstr "暗号優先"
 
 #. L10N:

--- a/po/ko.po
+++ b/po/ko.po
@@ -251,7 +251,7 @@ msgstr "삭제"
 #. toggle an account active/inactive
 #. The words here are abbreviated to keep the help line compact.
 #. It currently has the content:
-#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Enc  ?:Help
+#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Encr  ?:Help
 #.
 #: autocrypt/autocrypt_acct_menu.c:73
 msgid "Tgl Active"
@@ -261,10 +261,10 @@ msgstr ""
 #. toggle "prefer-encrypt" on an account
 #. The words here are abbreviated to keep the help line compact.
 #. It currently has the content:
-#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Enc  ?:Help
+#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Encr  ?:Help
 #.
 #: autocrypt/autocrypt_acct_menu.c:80
-msgid "Prf Enc"
+msgid "Prf Encr"
 msgstr ""
 
 #. L10N:

--- a/po/lt.po
+++ b/po/lt.po
@@ -245,7 +245,7 @@ msgstr "Trinti"
 #. toggle an account active/inactive
 #. The words here are abbreviated to keep the help line compact.
 #. It currently has the content:
-#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Enc  ?:Help
+#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Encr  ?:Help
 #.
 #: autocrypt/autocrypt_acct_menu.c:73
 msgid "Tgl Active"
@@ -255,10 +255,10 @@ msgstr "(De)aktyvuoti"
 #. toggle "prefer-encrypt" on an account
 #. The words here are abbreviated to keep the help line compact.
 #. It currently has the content:
-#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Enc  ?:Help
+#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Encr  ?:Help
 #.
 #: autocrypt/autocrypt_acct_menu.c:80
-msgid "Prf Enc"
+msgid "Prf Encr"
 msgstr "Šifr. auto"
 
 #. L10N:

--- a/po/nl.po
+++ b/po/nl.po
@@ -248,7 +248,7 @@ msgstr "Verwijderen"
 #. toggle an account active/inactive
 #. The words here are abbreviated to keep the help line compact.
 #. It currently has the content:
-#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Enc  ?:Help
+#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Encr  ?:Help
 #.
 #: autocrypt/autocrypt_acct_menu.c:73
 msgid "Tgl Active"
@@ -258,10 +258,10 @@ msgstr ""
 #. toggle "prefer-encrypt" on an account
 #. The words here are abbreviated to keep the help line compact.
 #. It currently has the content:
-#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Enc  ?:Help
+#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Encr  ?:Help
 #.
 #: autocrypt/autocrypt_acct_menu.c:80
-msgid "Prf Enc"
+msgid "Prf Encr"
 msgstr ""
 
 #. L10N:

--- a/po/pl.po
+++ b/po/pl.po
@@ -245,7 +245,7 @@ msgstr "Usuń"
 #. toggle an account active/inactive
 #. The words here are abbreviated to keep the help line compact.
 #. It currently has the content:
-#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Enc  ?:Help
+#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Encr  ?:Help
 #.
 #: autocrypt/autocrypt_acct_menu.c:73
 msgid "Tgl Active"
@@ -255,10 +255,10 @@ msgstr ""
 #. toggle "prefer-encrypt" on an account
 #. The words here are abbreviated to keep the help line compact.
 #. It currently has the content:
-#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Enc  ?:Help
+#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Encr  ?:Help
 #.
 #: autocrypt/autocrypt_acct_menu.c:80
-msgid "Prf Enc"
+msgid "Prf Encr"
 msgstr ""
 
 #. L10N:

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -244,7 +244,7 @@ msgstr "Remover"
 #. toggle an account active/inactive
 #. The words here are abbreviated to keep the help line compact.
 #. It currently has the content:
-#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Enc  ?:Help
+#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Encr  ?:Help
 #.
 #: autocrypt/autocrypt_acct_menu.c:73
 msgid "Tgl Active"
@@ -254,10 +254,10 @@ msgstr "Tgl ativo"
 #. toggle "prefer-encrypt" on an account
 #. The words here are abbreviated to keep the help line compact.
 #. It currently has the content:
-#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Enc  ?:Help
+#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Encr  ?:Help
 #.
 #: autocrypt/autocrypt_acct_menu.c:80
-msgid "Prf Enc"
+msgid "Prf Encr"
 msgstr "Prf Crpt"
 
 #. L10N:

--- a/po/ru.po
+++ b/po/ru.po
@@ -248,7 +248,7 @@ msgstr "Удалить"
 #. toggle an account active/inactive
 #. The words here are abbreviated to keep the help line compact.
 #. It currently has the content:
-#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Enc  ?:Help
+#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Encr  ?:Help
 #.
 #: autocrypt/autocrypt_acct_menu.c:73
 msgid "Tgl Active"
@@ -258,10 +258,10 @@ msgstr "Перекл Актив"
 #. toggle "prefer-encrypt" on an account
 #. The words here are abbreviated to keep the help line compact.
 #. It currently has the content:
-#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Enc  ?:Help
+#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Encr  ?:Help
 #.
 #: autocrypt/autocrypt_acct_menu.c:80
-msgid "Prf Enc"
+msgid "Prf Encr"
 msgstr "Предп Шифр"
 
 #. L10N:

--- a/po/sk.po
+++ b/po/sk.po
@@ -248,7 +248,7 @@ msgstr "Zmazať"
 #. toggle an account active/inactive
 #. The words here are abbreviated to keep the help line compact.
 #. It currently has the content:
-#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Enc  ?:Help
+#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Encr  ?:Help
 #.
 #: autocrypt/autocrypt_acct_menu.c:73
 msgid "Tgl Active"
@@ -258,10 +258,10 @@ msgstr ""
 #. toggle "prefer-encrypt" on an account
 #. The words here are abbreviated to keep the help line compact.
 #. It currently has the content:
-#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Enc  ?:Help
+#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Encr  ?:Help
 #.
 #: autocrypt/autocrypt_acct_menu.c:80
-msgid "Prf Enc"
+msgid "Prf Encr"
 msgstr ""
 
 #. L10N:

--- a/po/sv.po
+++ b/po/sv.po
@@ -249,7 +249,7 @@ msgstr "Radera"
 #. toggle an account active/inactive
 #. The words here are abbreviated to keep the help line compact.
 #. It currently has the content:
-#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Enc  ?:Help
+#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Encr  ?:Help
 #.
 #: autocrypt/autocrypt_acct_menu.c:73
 msgid "Tgl Active"
@@ -259,10 +259,10 @@ msgstr ""
 #. toggle "prefer-encrypt" on an account
 #. The words here are abbreviated to keep the help line compact.
 #. It currently has the content:
-#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Enc  ?:Help
+#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Encr  ?:Help
 #.
 #: autocrypt/autocrypt_acct_menu.c:80
-msgid "Prf Enc"
+msgid "Prf Encr"
 msgstr ""
 
 #. L10N:

--- a/po/tr.po
+++ b/po/tr.po
@@ -251,7 +251,7 @@ msgstr "Sil"
 #. toggle an account active/inactive
 #. The words here are abbreviated to keep the help line compact.
 #. It currently has the content:
-#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Enc  ?:Help
+#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Encr  ?:Help
 #.
 #: autocrypt/autocrypt_acct_menu.c:73
 msgid "Tgl Active"
@@ -261,10 +261,10 @@ msgstr ""
 #. toggle "prefer-encrypt" on an account
 #. The words here are abbreviated to keep the help line compact.
 #. It currently has the content:
-#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Enc  ?:Help
+#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Encr  ?:Help
 #.
 #: autocrypt/autocrypt_acct_menu.c:80
-msgid "Prf Enc"
+msgid "Prf Encr"
 msgstr ""
 
 #. L10N:

--- a/po/uk.po
+++ b/po/uk.po
@@ -247,7 +247,7 @@ msgstr "Видал."
 #. toggle an account active/inactive
 #. The words here are abbreviated to keep the help line compact.
 #. It currently has the content:
-#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Enc  ?:Help
+#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Encr  ?:Help
 #.
 #: autocrypt/autocrypt_acct_menu.c:73
 msgid "Tgl Active"
@@ -257,10 +257,10 @@ msgstr "Перем Актив"
 #. toggle "prefer-encrypt" on an account
 #. The words here are abbreviated to keep the help line compact.
 #. It currently has the content:
-#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Enc  ?:Help
+#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Encr  ?:Help
 #.
 #: autocrypt/autocrypt_acct_menu.c:80
-msgid "Prf Enc"
+msgid "Prf Encr"
 msgstr "Перев Шифр"
 
 #. L10N:

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -250,7 +250,7 @@ msgstr "删除"
 #. toggle an account active/inactive
 #. The words here are abbreviated to keep the help line compact.
 #. It currently has the content:
-#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Enc  ?:Help
+#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Encr  ?:Help
 #.
 #: autocrypt/autocrypt_acct_menu.c:73
 msgid "Tgl Active"
@@ -260,10 +260,10 @@ msgstr "启用/禁用"
 #. toggle "prefer-encrypt" on an account
 #. The words here are abbreviated to keep the help line compact.
 #. It currently has the content:
-#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Enc  ?:Help
+#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Encr  ?:Help
 #.
 #: autocrypt/autocrypt_acct_menu.c:80
-msgid "Prf Enc"
+msgid "Prf Encr"
 msgstr "默认开启加密"
 
 #. L10N:

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -251,7 +251,7 @@ msgstr "刪除"
 #. toggle an account active/inactive
 #. The words here are abbreviated to keep the help line compact.
 #. It currently has the content:
-#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Enc  ?:Help
+#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Encr  ?:Help
 #.
 #: autocrypt/autocrypt_acct_menu.c:73
 msgid "Tgl Active"
@@ -261,10 +261,10 @@ msgstr ""
 #. toggle "prefer-encrypt" on an account
 #. The words here are abbreviated to keep the help line compact.
 #. It currently has the content:
-#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Enc  ?:Help
+#. q:Exit  c:Create  D:Delete  a:Tgl Active  p:Prf Encr  ?:Help
 #.
 #: autocrypt/autocrypt_acct_menu.c:80
-msgid "Prf Enc"
+msgid "Prf Encr"
 msgstr ""
 
 #. L10N:

--- a/postpone.c
+++ b/postpone.c
@@ -350,6 +350,18 @@ int mutt_get_postponed(struct Context *ctx, struct Email *hdr,
     return -1;
   }
 
+  /* TODO:
+   * mx_mbox_open() for IMAP leaves IMAP_REOPEN_ALLOW set.  For the
+   * index this is papered-over because it calls mx_check_mailbox()
+   * every event loop(which resets that flag).
+   *
+   * For a stable-branch fix, I'm doing the same here, to prevent
+   * context changes from occuring behind the scenes and causing
+   * segvs, but probably the flag needs to be reset after downloading
+   * headers in imap_open_mailbox().
+   */
+  mx_mbox_check(ctx_post->mailbox, NULL);
+
   if (ctx_post->mailbox->msg_count == 0)
   {
     PostCount = 0;

--- a/send.c
+++ b/send.c
@@ -1653,7 +1653,19 @@ static int save_fcc(struct Email *e, struct Buffer *fcc, struct Body *clear_cont
     }
 
     /* check to see if the user wants copies of all attachments */
+    bool save_atts = true;
     if (e->content->type == TYPE_MULTIPART)
+    {
+      /* In batch mode, save attachments if the quadoption is yes or ask-yes */
+      if (flags & SEND_BATCH)
+      {
+        if ((C_FccAttach == MUTT_NO) || (C_FccAttach == MUTT_ASKNO))
+          save_atts = false;
+      }
+      else if (query_quadoption(C_FccAttach, _("Save attachments in Fcc?")) != MUTT_YES)
+        save_atts = false;
+    }
+    if (!save_atts)
     {
       if ((WithCrypto != 0) && (e->security & (SEC_ENCRYPT | SEC_SIGN | SEC_AUTOCRYPT)) &&
           ((mutt_str_strcmp(e->content->subtype, "encrypted") == 0) ||

--- a/test/pattern/dummy.c
+++ b/test/pattern/dummy.c
@@ -154,3 +154,15 @@ struct Email *mutt_get_virt_email(struct Mailbox *m, int vnum)
 
   return m->emails[inum];
 }
+
+void mutt_buffer_mktemp_full(struct Buffer *buf, const char *prefix,
+                             const char *suffix, const char *src, int line)
+{
+}
+
+int mutt_rfc822_write_header(FILE *fp, struct Envelope *env,
+                             struct Body *attach, int mode,
+                             bool privacy, bool hide_protected_subject)
+{
+  return 0;
+}


### PR DESCRIPTION
This is mostly a mix of small fixes and small features from upstream.

**Small refactor**

For security reasons, commit f5a038e06 changed our copy of `mutt_encode_path()` to use 'us-ascii' and then POSIX-ify the path.
By refactoring `mutt_encode_path()` to use `struct Buffer`, I accidentally undid some of these changes.
This commit restores the safer behaviour.

- 28fe084a0 Convert remaining mutt_encode_path() call to use struct Buffer

**Small fixes**

- 43bf2d2a4 Fix $fcc_attach to not prompt in batch mode
- 99082909c Change "Prf Enc" to "Prf Encr"
- 5e8375687 Fix segv in IMAP postponed menu caused by reopen_allow
- e7187fc67 Add protected-headers="v1" to Content-Type when protecting headers
- 763d252d6 Turn off auto-clear outside of autocrypt initialization
- 74f38dc22 Fix crash when polling a closed ssl connection
- a360a6802 Add $crypt_opportunistic_encrypt_strong_keys config var
- e4892751d Rename smime oppenc mode parameter to get_keys_by_addr()

**Small features**

- 7982acce4 Adding ISO 8601 calendar date
- d384b507f Allow ~b ~B ~h patterns in send2-hook
