### PR TITLE
config: add $smtp_user

### DIFF
--- a/globals.h
+++ b/globals.h
@@ -139,6 +139,7 @@ WHERE char *C_Realname;                      ///< Config: Real name of the user
 WHERE char *C_Shell;                         ///< Config: External command to run subshells in
 WHERE char *C_SimpleSearch;                  ///< Config: Pattern to search for when search doesn't contain ~'s
 #ifdef USE_SMTP
+WHERE char *C_SmtpUser;                      ///< Config: (smtp) Username for the SMTP server
 WHERE char *C_SmtpUrl;                       ///< Config: (smtp) Url of the SMTP server
 #endif /* USE_SMTP */
 WHERE char *C_Spoolfile;                     ///< Config: Inbox

--- a/mutt_account.c
+++ b/mutt_account.c
@@ -50,6 +50,7 @@ char *C_PopPass; ///< Config: (pop) Password of the POP server
 char *C_PopUser; ///< Config: (pop) Username of the POP server
 char *C_SmtpOauthRefreshCommand; ///< Config: (smtp) External command to generate OAUTH refresh token
 char *C_SmtpPass; ///< Config: (smtp) Password for the SMTP server
+char *C_SmtpUser; ///< Config: (smtp) Username for the SMTP server
 
 /**
  * mutt_account_fromurl - Fill ConnAccount with information from url
@@ -175,6 +176,10 @@ int mutt_account_getuser(struct ConnAccount *account)
 #ifdef USE_NNTP
   else if ((account->type == MUTT_ACCT_TYPE_NNTP) && C_NntpUser)
     mutt_str_strfcpy(account->user, C_NntpUser, sizeof(account->user));
+#endif
+#ifdef USE_SMTP
+  else if ((account->type == MUTT_ACCT_TYPE_SMTP) && C_SmtpUser)
+    mutt_str_strfcpy(account->user, C_SmtpUser, sizeof(account->user));
 #endif
   else if (OptNoCurses)
     return -1;

--- a/mutt_config.c
+++ b/mutt_config.c
@@ -4168,6 +4168,13 @@ struct ConfigDef MuttVars[] = {
   ** fairly secure machine, because the superuser can read your neomuttrc even
   ** if you are the only one who can read the file.
   */
+  { "smtp_user", DT_STRING|DT_SENSITIVE, &C_SmtpUser, 0 },
+  /*
+  ** .pp
+  ** The username for the SMTP server.
+  ** .pp
+  ** This variable defaults to your user name on the local machine.
+  */
   { "smtp_url", DT_STRING|DT_SENSITIVE, &C_SmtpUrl, 0 },
   /*
   ** .pp


### PR DESCRIPTION
Add the missing $smtp_user config variable.
This brings SMTP into line with IMAP and POP.
