### PR TITLE
refactor: tidy Url usage

### DIFF
--- a/bcache.c
+++ b/bcache.c
@@ -62,7 +62,7 @@ struct BodyCache
 static int bcache_path(struct ConnAccount *account, const char *mailbox, struct BodyCache *bcache)
 {
   char host[256];
-  struct Url url = { U_UNKNOWN };
+  struct Url url = { 0 };
 
   if (!account || !C_MessageCachedir || !bcache)
     return -1;

--- a/email/url.h
+++ b/email/url.h
@@ -76,11 +76,11 @@ struct Url
 };
 
 enum UrlScheme url_check_scheme(const char *s);
-void           url_free        (struct Url **u);
+void           url_free        (struct Url **ptr);
 struct Url    *url_parse       (const char *src);
 int            url_pct_decode  (char *s);
 void           url_pct_encode  (char *buf, size_t buflen, const char *src);
-int            url_tobuffer    (struct Url *u, struct Buffer *dest, int flags);
-int            url_tostring    (struct Url *u, char *buf, size_t buflen, int flags);
+int            url_tobuffer    (struct Url *url, struct Buffer *dest, int flags);
+int            url_tostring    (struct Url *url, char *buf, size_t buflen, int flags);
 
 #endif /* MUTT_EMAIL_URL_H */

--- a/imap/command.c
+++ b/imap/command.c
@@ -662,7 +662,7 @@ static void cmd_parse_lsub(struct ImapAccountData *adata, char *s)
   char buf[256];
   char errstr[256];
   struct Buffer err, token;
-  struct Url url;
+  struct Url url = { 0 };
   struct ImapList list = { 0 };
 
   if (adata->cmdresult)

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -544,7 +544,7 @@ static int complete_hosts(char *buf, size_t buflen)
 #if 0
   TAILQ_FOREACH(conn, mutt_socket_head(), entries)
   {
-    struct Url url;
+    struct Url url = { 0 };
     char urlstr[1024];
 
     if (conn->account.type != MUTT_ACCT_TYPE_IMAP)

--- a/imap/util.c
+++ b/imap/util.c
@@ -438,7 +438,7 @@ header_cache_t *imap_hcache_open(struct ImapAccountData *adata, struct ImapMboxD
   if ((len > 3) && (strcmp(mutt_b2s(mbox) + len - 3, "/..") == 0))
     goto cleanup;
 
-  struct Url url;
+  struct Url url = { 0 };
   mutt_account_tourl(&adata->conn->account, &url);
   url.path = mbox->data;
   url_tobuffer(&url, cachepath, U_PATH);
@@ -708,7 +708,7 @@ int imap_mxcmp(const char *mx1, const char *mx2)
 void imap_pretty_mailbox(char *path, size_t pathlen, const char *folder)
 {
   struct ConnAccount target_conn_account, home_conn_account;
-  struct Url url;
+  struct Url url = { 0 };
   char *delim = NULL;
   int tlen;
   int hlen = 0;
@@ -943,7 +943,7 @@ char *imap_next_word(char *s)
  */
 void imap_qualify_path(char *buf, size_t buflen, struct ConnAccount *conn_account, char *path)
 {
-  struct Url url;
+  struct Url url = { 0 };
   mutt_account_tourl(conn_account, &url);
   url.path = path;
   url_tostring(&url, buf, buflen, 0);

--- a/mutt_socket.c
+++ b/mutt_socket.c
@@ -87,7 +87,7 @@ struct Connection *mutt_conn_new(const struct ConnAccount *account)
 struct Connection *mutt_conn_find(const struct Connection *start,
                                   const struct ConnAccount *account)
 {
-  struct Url url;
+  struct Url url = { 0 };
   char hook[1024];
 
   /* account isn't actually modified, since url isn't either */

--- a/nntp/newsrc.c
+++ b/nntp/newsrc.c
@@ -527,7 +527,7 @@ static void cache_expand(char *dst, size_t dstlen, struct ConnAccount *acct, con
   /* server subdirectory */
   if (acct)
   {
-    struct Url url;
+    struct Url url = { 0 };
 
     mutt_account_tourl(acct, &url);
     url.path = mutt_str_strdup(src);
@@ -555,7 +555,7 @@ static void cache_expand(char *dst, size_t dstlen, struct ConnAccount *acct, con
  */
 void nntp_expand_path(char *buf, size_t buflen, struct ConnAccount *acct)
 {
-  struct Url url;
+  struct Url url = { 0 };
 
   mutt_account_tourl(acct, &url);
   url.path = mutt_str_strdup(buf);
@@ -705,7 +705,7 @@ static void nntp_hcache_namer(const char *path, struct Buffer *dest)
  */
 header_cache_t *nntp_hcache_open(struct NntpMboxData *mdata)
 {
-  struct Url url;
+  struct Url url = { 0 };
   char file[PATH_MAX];
 
   if (!mdata->adata || !mdata->adata->cacheable || !mdata->adata->conn ||
@@ -923,7 +923,7 @@ const char *nntp_format_str(char *buf, size_t buflen, size_t col, int cols, char
   {
     case 'a':
     {
-      struct Url url;
+      struct Url url = { 0 };
       mutt_account_tourl(acct, &url);
       url_tostring(&url, fn, sizeof(fn), U_PATH);
       char *p = strchr(fn, '/');
@@ -953,7 +953,7 @@ const char *nntp_format_str(char *buf, size_t buflen, size_t col, int cols, char
       break;
     case 'S':
     {
-      struct Url url;
+      struct Url url = { 0 };
       mutt_account_tourl(acct, &url);
       url_tostring(&url, fn, sizeof(fn), U_PATH);
       char *p = strchr(fn, ':');

--- a/nntp/nntp.c
+++ b/nntp/nntp.c
@@ -2386,7 +2386,7 @@ static struct Account *nntp_ac_find(struct Account *a, const char *path)
   if (!a || (a->type != MUTT_NNTP) || !path)
     return NULL;
 
-  struct Url url;
+  struct Url url = { 0 };
   char tmp[PATH_MAX];
   mutt_str_strfcpy(tmp, path, sizeof(tmp));
   url_parse(&url, tmp);

--- a/pop/pop.c
+++ b/pop/pop.c
@@ -358,7 +358,7 @@ static header_cache_t *pop_hcache_open(struct PopAccountData *adata, const char 
   if (!adata || !adata->conn)
     return mutt_hcache_open(C_HeaderCache, path, NULL);
 
-  struct Url url;
+  struct Url url = { 0 };
   char p[1024];
 
   mutt_account_tourl(&adata->conn->account, &url);
@@ -818,7 +818,7 @@ static int pop_mbox_open(struct Mailbox *m)
 
   char buf[PATH_MAX];
   struct ConnAccount acct = { { 0 } };
-  struct Url url;
+  struct Url url = { 0 };
 
   if (pop_parse_path(mailbox_path(m), &acct))
   {


### PR DESCRIPTION
`struct Url` contains lots of pointers and a `STAILQ` (for the query strings).
Many of the `Url` uses didn't fully initialise the struct, which could lead to problems.

- Initialise all Urls on the stack
- Add `url_new()`
- Encode '=' too, in `url_pct_encode()`
- Generate query strings in `url_tobuffer()`
- Rename vars to 'url'
