### PR TITLE
Unify unmailboxes and unvirtual-mailboxes commands

### DIFF
--- a/mutt_commands.c
+++ b/mutt_commands.c
@@ -149,8 +149,8 @@ const struct Command Commands[] = {
   { "unsubscribe-from",    parse_unsubscribe_from, 0 },
 #endif
 #ifdef USE_NOTMUCH
-  { "unvirtual-mailboxes", parse_unmailboxes,      MUTT_VIRTUAL },
-  { "virtual-mailboxes",   parse_mailboxes,        MUTT_VIRTUAL | MUTT_NAMED },
+  { "unvirtual-mailboxes", parse_unmailboxes,      0 },
+  { "virtual-mailboxes",   parse_mailboxes,        MUTT_NAMED },
 #endif
   { NULL,                  NULL,                   0 },
 };

--- a/mutt_commands.h
+++ b/mutt_commands.h
@@ -71,7 +71,6 @@ enum MuttSetCommand
 
 /* parameter to parse_mailboxes */
 #define MUTT_NAMED   (1 << 0)
-#define MUTT_VIRTUAL (1 << 1)
 
 extern const struct Command Commands[];
 


### PR DESCRIPTION
* **What does this PR do?**
`unmailboxes *` didn't consider virtual mailboxes (at least those defined by named-mailboxes)

I tested both unvirtual-mailboxes and unmailboxes commands. I have mailboxes defined as `named-mailboxes name mailbox`, where mailbox is maildir, mbox and notmuch query.
```
unmailboxes *
unmailboxes name
unmailboxes /path/to/mailbox

unvirtual-mailboxes *
unvirtual-mailboxes name
unvirtual-mailboxes /path/to/mailbox
```

All tested cases behaves as expected.