### PR TITLE
Restore mailbox append flag after mbox_close

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -1145,8 +1145,8 @@ int mutt_save_message(struct Mailbox *m, struct EmailList *el,
     if (mutt_save_message_ctx(en->email, delete_original, decode, decrypt,
                               ctx_save->mailbox) != 0)
     {
-      m_save->append = old_append;
       mx_mbox_close(&ctx_save);
+      m_save->append = old_append;
       goto cleanup;
     }
 #ifdef USE_COMPRESSED
@@ -1201,8 +1201,8 @@ int mutt_save_message(struct Mailbox *m, struct EmailList *el,
 #endif
     if (rc != 0)
     {
-      m_save->append = old_append;
       mx_mbox_close(&ctx_save);
+      m_save->append = old_append;
       goto cleanup;
     }
   }
@@ -1210,8 +1210,8 @@ int mutt_save_message(struct Mailbox *m, struct EmailList *el,
   const bool need_mailbox_cleanup = ((ctx_save->mailbox->magic == MUTT_MBOX) ||
                                      (ctx_save->mailbox->magic == MUTT_MMDF));
 
-  m_save->append = old_append;
   mx_mbox_close(&ctx_save);
+  m_save->append = old_append;
 
   if (need_mailbox_cleanup)
     mutt_mailbox_cleanup(mutt_b2s(buf), &st);

--- a/mx.c
+++ b/mx.c
@@ -556,15 +556,15 @@ static int trash_append(struct Mailbox *m)
       {
         if (mutt_append_message(ctx_trash->mailbox, m, e, MUTT_CM_NO_FLAGS, CH_NO_FLAGS) == -1)
         {
-          m_trash->append = old_append;
           mx_mbox_close(&ctx_trash);
+          m_trash->append = old_append;
           return -1;
         }
       }
     }
 
-    m_trash->append = old_append;
     mx_mbox_close(&ctx_trash);
+    m_trash->append = old_append;
   }
   else
   {


### PR DESCRIPTION
Make calls to mx_mbox_close() and mx_mbox_close() retain the same
value for m->append. This is import for special handling in
mx_mbox_close() of the append case.