### PR TITLE
notmuch: change uri to url

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -86,7 +86,7 @@ yyyy-mm-dd
   - fix crash in mutt_extract_token()
   - force a screen refresh
   - fix crash sending message from command line
-  - notmuch: use nm_default_uri if no mailbox data
+  - notmuch: use nm_default_url if no mailbox data
   - fix forward attachments
   - fix: vfprintf undefined behaviour in body_handler
   - Fix relative symlink resolution
@@ -758,7 +758,7 @@ yyyy-mm-dd
   - Fix nntp group selection
   - Fix status color
   - Tidy up S/MIME contrib
-  - Do not try to create Maildir if it is an NNTP URI
+  - Do not try to create Maildir if it is an NNTP URL
   - Fix missing NONULL for mutt.set() in Lua
 * Translations
   - Fix German PGP shortkeys

--- a/doc/manual.xml.head
+++ b/doc/manual.xml.head
@@ -15172,8 +15172,8 @@ color index_tags green default
       <sect2 id="notmuch-using">
         <title>Using Notmuch</title>
 
-        <sect3 id="notmuch-folder-uri">
-          <title>Folders URI</title>
+        <sect3 id="notmuch-folder-url">
+          <title>Folders URL</title>
           <para>
             <emphasis role="bold">notmuch://[&lt;path&gt;][?&lt;item&gt;=&lt;name&gt;[&amp; ...]]</emphasis>
           </para>
@@ -15186,12 +15186,12 @@ color index_tags green default
           </para>
           <para>
             If the "&lt;path&gt;" is not defined then
-            <literal>$nm_default_uri</literal> or <literal>$folder</literal> is
+            <literal>$nm_default_url</literal> or <literal>$folder</literal> is
             used, for example:
           </para>
 
 <screen>
-set nm_default_uri = "notmuch:///home/foo/maildir"
+set nm_default_url = "notmuch:///home/foo/maildir"
 virtual-mailboxes "My INBOX" "notmuch://?query=tag:inbox"
 </screen>
 
@@ -15207,7 +15207,7 @@ virtual-mailboxes "My INBOX" "notmuch://?query=tag:inbox"
             operators (<quote>and</quote>/<quote>or</quote>) in your queries.
           </para>
           <para>
-            Note that proper URI should not contain blank space and all
+            Note that proper URL should not contain blank space and all
             <quote>bad</quote> chars should be encoded, for example
           </para>
           <para>
@@ -15351,7 +15351,7 @@ virtual-mailboxes "My INBOX" "notmuch://?query=tag:inbox"
                 <entry></entry>
               </row>
               <row>
-                <entry><literal>nm_default_uri</literal></entry>
+                <entry><literal>nm_default_url</literal></entry>
                 <entry>string</entry>
                 <entry>(empty)</entry>
                 <entry></entry>
@@ -15440,7 +15440,7 @@ virtual-mailboxes "My INBOX" "notmuch://?query=tag:inbox"
                 <entry>
                   switch to another virtual folder, a new folder maybe be
                   specified by vfolder description (see virtual-mailboxes) or
-                  URI. the default is next vfolder with unread messages
+                  URL. the default is next vfolder with unread messages
                 </entry>
               </row>
               <row>
@@ -15505,14 +15505,14 @@ virtual-mailboxes "My INBOX" "notmuch://?query=tag:inbox"
           <arg choice="plain">
             <replaceable class="parameter">description</replaceable>
             <arg choice="plain">
-              <replaceable class="parameter">notmuch-URI</replaceable>
+              <replaceable class="parameter">notmuch-URL</replaceable>
             </arg>
           </arg>
           <group choice="req" rep="repeat">
             <arg choice="plain">
               <replaceable class="parameter">description</replaceable>
               <arg choice="plain">
-                <replaceable class="parameter">notmuch-URI</replaceable>
+                <replaceable class="parameter">notmuch-URL</replaceable>
               </arg>
             </arg>
           </group>
@@ -15563,7 +15563,7 @@ virtual-mailboxes "My INBOX" "notmuch://?query=tag:inbox"
 set nm_db_limit = 0
 <emphasis role="comment"># This variable specifies the default Notmuch database in format:</emphasis>
 <emphasis role="comment"># notmuch://&lt;absolute path&gt;</emphasis>
-set nm_default_uri = ""
+set nm_default_url = ""
 <emphasis role="comment"># The messages tagged with these tags are excluded and not loaded</emphasis>
 <emphasis role="comment"># from notmuch DB to NeoMutt unless specified explicitly.</emphasis>
 set nm_exclude_tags = ""
@@ -15620,7 +15620,7 @@ bind index &gt; vfolder-window-forward
 <emphasis role="comment"># --------------------------------------------------------------------------</emphasis>
 <emphasis role="comment"># COMMANDS – shown with an example</emphasis>
 <emphasis role="comment"># --------------------------------------------------------------------------</emphasis>
-<emphasis role="comment"># virtual-mailboxes description notmuch-URI { description notmuch-URI ...}</emphasis>
+<emphasis role="comment"># virtual-mailboxes description notmuch-URL { description notmuch-URL ...}</emphasis>
 <emphasis role="comment"># virtual-mailboxes "Climbing" "notmuch://?query=climbing"</emphasis>
 <emphasis role="comment"># unvirtual-mailboxes { * | mailbox ...}</emphasis>
 <emphasis role="comment">#</emphasis>

--- a/email/email_globals.h
+++ b/email/email_globals.h
@@ -39,7 +39,7 @@ extern struct ListHead Ignore;              ///< List of header patterns to igno
 extern struct RegexList NoSpamList;         ///< List of regexes to whitelist non-spam emails
 extern struct ReplaceList SpamList;         ///< List of regexes and patterns to match spam emails
 extern struct ListHead UnIgnore;            ///< List of header patterns to unignore (see)
-extern struct ListHead MailToAllow;         ///< List of permitted fields in a mailto: uri
+extern struct ListHead MailToAllow;         ///< List of permitted fields in a mailto: url
 extern struct Hash *AutoSubscribeCache;     ///< Hash table of auto-subscribed mailing lists
 extern struct RegexList UnSubscribedLists;  ///< List of regexes to blacklist false matches in SubscribedLists
 extern struct RegexList MailLists;          ///< List of regexes to match mailing lists

--- a/email/parse.c
+++ b/email/parse.c
@@ -59,7 +59,7 @@
 
 /**
  * mutt_auto_subscribe - Check if user is subscribed to mailing list
- * @param mailto URI of mailing list subscribe
+ * @param mailto URL of mailing list subscribe
  */
 void mutt_auto_subscribe(const char *mailto)
 {

--- a/index.c
+++ b/index.c
@@ -2120,7 +2120,7 @@ int mutt_index_menu(struct MuttWindow *dlg)
           mutt_str_strcat(buf, sizeof(buf), (e_cur->env->message_id) + msg_id_offset);
           if (buf[strlen(buf) - 1] == '>')
             buf[strlen(buf) - 1] = '\0';
-          if (!nm_uri_from_query(Context->mailbox, buf, sizeof(buf)))
+          if (!nm_url_from_query(Context->mailbox, buf, sizeof(buf)))
           {
             mutt_message(_("Failed to create query, aborting"));
             break;
@@ -2297,7 +2297,7 @@ int mutt_index_menu(struct MuttWindow *dlg)
         // Keep copy of user's querying to name mailbox.
         char *query_unencoded = mutt_str_strdup(buf);
 
-        if (nm_uri_from_query(NULL, buf, sizeof(buf)))
+        if (nm_url_from_query(NULL, buf, sizeof(buf)))
         {
           // Create mailbox and set name.
           struct Mailbox *m_new_vfolder = mx_path_resolve(buf);
@@ -2331,7 +2331,7 @@ int mutt_index_menu(struct MuttWindow *dlg)
         }
         nm_query_window_backward();
         mutt_str_strfcpy(buf, C_NmQueryWindowCurrentSearch, sizeof(buf));
-        if (!nm_uri_from_query(Context->mailbox, buf, sizeof(buf)))
+        if (!nm_url_from_query(Context->mailbox, buf, sizeof(buf)))
           mutt_message(_("Failed to create query, aborting"));
         else
           main_change_folder(menu, op, NULL, buf, sizeof(buf), &oldcount, &index_hint, NULL);
@@ -2352,7 +2352,7 @@ int mutt_index_menu(struct MuttWindow *dlg)
         }
         nm_query_window_forward();
         mutt_str_strfcpy(buf, C_NmQueryWindowCurrentSearch, sizeof(buf));
-        if (!nm_uri_from_query(Context->mailbox, buf, sizeof(buf)))
+        if (!nm_url_from_query(Context->mailbox, buf, sizeof(buf)))
           mutt_message(_("Failed to create query, aborting"));
         else
         {

--- a/mutt_config.c
+++ b/mutt_config.c
@@ -2356,7 +2356,7 @@ struct ConfigDef MuttVars[] = {
   ** .pp
   ** This variable specifies the default limit used in notmuch queries.
   */
-  { "nm_default_uri", DT_STRING, &C_NmDefaultUri, 0 },
+  { "nm_default_url", DT_STRING, &C_NmDefaultUrl, 0 },
   /*
   ** .pp
   ** This variable specifies the default Notmuch database in format
@@ -4922,6 +4922,7 @@ struct ConfigDef MuttVars[] = {
   { "indent_str",             DT_SYNONYM, NULL, IP "indent_string",            },
   { "mime_fwd",               DT_SYNONYM, NULL, IP "mime_forward",             },
   { "msg_format",             DT_SYNONYM, NULL, IP "message_format",           },
+  { "nm_default_uri",         DT_SYNONYM, NULL, IP "nm_default_url"            },
   { "pgp_autoencrypt",        DT_SYNONYM, NULL, IP "crypt_autoencrypt",        },
   { "pgp_autosign",           DT_SYNONYM, NULL, IP "crypt_autosign",           },
   { "pgp_auto_traditional",   DT_SYNONYM, NULL, IP "pgp_replyinline",          },

--- a/nntp/newsrc.c
+++ b/nntp/newsrc.c
@@ -1000,7 +1000,7 @@ static const char *nntp_get_field(enum ConnAccountField field)
 /**
  * nntp_select_server - Open a connection to an NNTP server
  * @param m          Mailbox
- * @param server     Server URI
+ * @param server     Server URL
  * @param leave_lock Leave the server locked?
  * @retval ptr  NNTP server
  * @retval NULL Error

--- a/notmuch/lib.h
+++ b/notmuch/lib.h
@@ -45,7 +45,7 @@ struct stat;
 
 /* These Config Variables are only used in notmuch/mutt_notmuch.c */
 extern int   C_NmDbLimit;
-extern char *C_NmDefaultUri;
+extern char *C_NmDefaultUrl;
 extern char *C_NmExcludeTags;
 extern int   C_NmOpenTimeout;
 extern char *C_NmQueryType;
@@ -71,6 +71,6 @@ void  nm_query_window_forward    (void);
 int   nm_read_entire_thread      (struct Mailbox *m, struct Email *e);
 int   nm_record_message          (struct Mailbox *m, char *path, struct Email *e);
 int   nm_update_filename         (struct Mailbox *m, const char *old_file, const char *new_file, struct Email *e);
-char *nm_uri_from_query          (struct Mailbox *m, char *buf, size_t buflen);
+char *nm_url_from_query          (struct Mailbox *m, char *buf, size_t buflen);
 
 #endif /* MUTT_NOTMUCH_LIB_H */

--- a/notmuch/nm_db.c
+++ b/notmuch/nm_db.c
@@ -46,7 +46,7 @@
  * @param m Mailbox
  * @retval ptr Filename
  *
- * @note The return value is a pointer into the #C_NmDefaultUri global variable.
+ * @note The return value is a pointer into the #C_NmDefaultUrl global variable.
  *       If that variable changes, the result will be invalid.
  *       It must not be freed.
  */
@@ -58,7 +58,7 @@ const char *nm_db_get_filename(struct Mailbox *m)
   if (mdata && mdata->db_url && mdata->db_url->path)
     db_filename = mdata->db_url->path;
   else
-    db_filename = C_NmDefaultUri;
+    db_filename = C_NmDefaultUrl;
 
   if (!db_filename && !C_Folder)
     return NULL;
@@ -67,7 +67,7 @@ const char *nm_db_get_filename(struct Mailbox *m)
     db_filename = C_Folder;
 
   if (nm_path_probe(db_filename, NULL) == MUTT_NOTMUCH)
-    db_filename += NmUriProtocolLen;
+    db_filename += NmUrlProtocolLen;
 
   mutt_debug(LL_DEBUG2, "nm: db filename '%s'\n", db_filename);
   return db_filename;

--- a/notmuch/notmuch_private.h
+++ b/notmuch/notmuch_private.h
@@ -40,7 +40,7 @@
    (LIBNOTMUCH_MAJOR_VERSION == (major) &&                                        \
     LIBNOTMUCH_MINOR_VERSION == (minor) && LIBNOTMUCH_MICRO_VERSION >= (micro)))
 
-extern const int NmUriProtocolLen;
+extern const int NmUrlProtocolLen;
 
 /**
  * struct NmAccountData - Notmuch-specific Account data - @extends Account
@@ -109,6 +109,6 @@ void                  nm_edata_free(void **ptr);
 struct NmEmailData *  nm_edata_new (void);
 void                  nm_mdata_free(void **ptr);
 struct NmMboxData *   nm_mdata_get (struct Mailbox *m);
-struct NmMboxData *   nm_mdata_new (const char *uri);
+struct NmMboxData *   nm_mdata_new (const char *url);
 
 #endif /* MUTT_NOTMUCH_NOTMUCH_PRIVATE_H */

--- a/po/bg.po
+++ b/po/bg.po
@@ -5135,7 +5135,7 @@ msgstr ""
 
 #: notmuch/mutt_notmuch.c:219 notmuch/mutt_notmuch.c:1939
 #, c-format
-msgid "failed to parse notmuch uri: %s"
+msgid "failed to parse notmuch url: %s"
 msgstr ""
 
 #: notmuch/mutt_notmuch.c:449

--- a/po/ca.po
+++ b/po/ca.po
@@ -5295,7 +5295,7 @@ msgstr ""
 # Es refereix a l’esquema d’URL.  ivb
 #: notmuch/mutt_notmuch.c:219 notmuch/mutt_notmuch.c:1939
 #, fuzzy, c-format
-msgid "failed to parse notmuch uri: %s"
+msgid "failed to parse notmuch url: %s"
 msgstr "No s’ha pogut interpretar l’enllaç de tipus «mailto:».\n"
 
 #: notmuch/mutt_notmuch.c:449

--- a/po/cs.po
+++ b/po/cs.po
@@ -5017,8 +5017,8 @@ msgstr "Rozebrání dotazu pro notmuch se nezdařilo: %s"
 
 #: notmuch/mutt_notmuch.c:219 notmuch/mutt_notmuch.c:1939
 #, c-format
-msgid "failed to parse notmuch uri: %s"
-msgstr "rozebrání URI pro notmuch se nezdařilo: %s"
+msgid "failed to parse notmuch url: %s"
+msgstr "rozebrání URL pro notmuch se nezdařilo: %s"
 
 #: notmuch/mutt_notmuch.c:449
 msgid "Invalid nm_query_window_timebase value (valid values are: hour, day, week, month or year)"

--- a/po/da.po
+++ b/po/da.po
@@ -5001,7 +5001,7 @@ msgstr ""
 
 #: notmuch/mutt_notmuch.c:219 notmuch/mutt_notmuch.c:1939
 #, fuzzy, c-format
-msgid "failed to parse notmuch uri: %s"
+msgid "failed to parse notmuch url: %s"
 msgstr "Kunne ikke fortolke mailto:-link\n"
 
 #: notmuch/mutt_notmuch.c:449

--- a/po/de.po
+++ b/po/de.po
@@ -4986,8 +4986,8 @@ msgstr "Fehler beim Verwenden von Notmuch-Anfrage-Typ: %s"
 
 #: notmuch/mutt_notmuch.c:219 notmuch/mutt_notmuch.c:1939
 #, c-format
-msgid "failed to parse notmuch uri: %s"
-msgstr "Fehler beim Verwenden von Notmuch-URI: %s"
+msgid "failed to parse notmuch url: %s"
+msgstr "Fehler beim Verwenden von Notmuch-URL: %s"
 
 #: notmuch/mutt_notmuch.c:449
 msgid "Invalid nm_query_window_timebase value (valid values are: hour, day, week, month or year)"

--- a/po/el.po
+++ b/po/el.po
@@ -5145,7 +5145,7 @@ msgstr ""
 
 #: notmuch/mutt_notmuch.c:219 notmuch/mutt_notmuch.c:1939
 #, c-format
-msgid "failed to parse notmuch uri: %s"
+msgid "failed to parse notmuch url: %s"
 msgstr ""
 
 #: notmuch/mutt_notmuch.c:449

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -4978,8 +4978,8 @@ msgstr "failed to parse notmuch query type: %s"
 
 #: notmuch/mutt_notmuch.c:219 notmuch/mutt_notmuch.c:1939
 #, c-format
-msgid "failed to parse notmuch uri: %s"
-msgstr "failed to parse notmuch uri: %s"
+msgid "failed to parse notmuch url: %s"
+msgstr "failed to parse notmuch url: %s"
 
 #: notmuch/mutt_notmuch.c:449
 msgid "Invalid nm_query_window_timebase value (valid values are: hour, day, week, month or year)"

--- a/po/eo.po
+++ b/po/eo.po
@@ -5031,7 +5031,7 @@ msgstr ""
 
 #: notmuch/mutt_notmuch.c:219 notmuch/mutt_notmuch.c:1939
 #, fuzzy, c-format
-msgid "failed to parse notmuch uri: %s"
+msgid "failed to parse notmuch url: %s"
 msgstr "Malsukcesis analizi 'mailto:'-ligon\n"
 
 #: notmuch/mutt_notmuch.c:449

--- a/po/es.po
+++ b/po/es.po
@@ -5054,8 +5054,8 @@ msgstr "fallo al interpretar tipo de petición notmuch: %s"
 
 #: notmuch/mutt_notmuch.c:219 notmuch/mutt_notmuch.c:1939
 #, c-format
-msgid "failed to parse notmuch uri: %s"
-msgstr "fallo al interpretar uri nontmuch: %s"
+msgid "failed to parse notmuch url: %s"
+msgstr "fallo al interpretar url nontmuch: %s"
 
 #: notmuch/mutt_notmuch.c:449
 msgid "Invalid nm_query_window_timebase value (valid values are: hour, day, week, month or year)"

--- a/po/et.po
+++ b/po/et.po
@@ -5133,7 +5133,7 @@ msgstr ""
 
 #: notmuch/mutt_notmuch.c:219 notmuch/mutt_notmuch.c:1939
 #, c-format
-msgid "failed to parse notmuch uri: %s"
+msgid "failed to parse notmuch url: %s"
 msgstr ""
 
 #: notmuch/mutt_notmuch.c:449

--- a/po/eu.po
+++ b/po/eu.po
@@ -5093,7 +5093,7 @@ msgstr ""
 
 #: notmuch/mutt_notmuch.c:219 notmuch/mutt_notmuch.c:1939
 #, fuzzy, c-format
-msgid "failed to parse notmuch uri: %s"
+msgid "failed to parse notmuch url: %s"
 msgstr "Huts maito: lotura analizatzean\n"
 
 #: notmuch/mutt_notmuch.c:449

--- a/po/fi.po
+++ b/po/fi.po
@@ -4999,7 +4999,7 @@ msgstr "ei voitu jäsentää notmuch-haun tyyppiä: %s"
 
 #: notmuch/mutt_notmuch.c:219 notmuch/mutt_notmuch.c:1939
 #, c-format
-msgid "failed to parse notmuch uri: %s"
+msgid "failed to parse notmuch url: %s"
 msgstr "Nomuch-URIn jäsennys ei onnistunut: %s"
 
 #: notmuch/mutt_notmuch.c:449

--- a/po/fr.po
+++ b/po/fr.po
@@ -5221,7 +5221,7 @@ msgstr ""
 
 #: notmuch/mutt_notmuch.c:219 notmuch/mutt_notmuch.c:1939
 #, fuzzy, c-format
-msgid "failed to parse notmuch uri: %s"
+msgid "failed to parse notmuch url: %s"
 msgstr "Impossible d'analyser le lien mailto:\n"
 
 #: notmuch/mutt_notmuch.c:449

--- a/po/ga.po
+++ b/po/ga.po
@@ -5153,7 +5153,7 @@ msgstr ""
 
 #: notmuch/mutt_notmuch.c:219 notmuch/mutt_notmuch.c:1939
 #, c-format
-msgid "failed to parse notmuch uri: %s"
+msgid "failed to parse notmuch url: %s"
 msgstr ""
 
 #: notmuch/mutt_notmuch.c:449

--- a/po/gl.po
+++ b/po/gl.po
@@ -5183,7 +5183,7 @@ msgstr ""
 
 #: notmuch/mutt_notmuch.c:219 notmuch/mutt_notmuch.c:1939
 #, c-format
-msgid "failed to parse notmuch uri: %s"
+msgid "failed to parse notmuch url: %s"
 msgstr ""
 
 #: notmuch/mutt_notmuch.c:449

--- a/po/hu.po
+++ b/po/hu.po
@@ -5135,7 +5135,7 @@ msgstr ""
 
 #: notmuch/mutt_notmuch.c:219 notmuch/mutt_notmuch.c:1939
 #, c-format
-msgid "failed to parse notmuch uri: %s"
+msgid "failed to parse notmuch url: %s"
 msgstr ""
 
 #: notmuch/mutt_notmuch.c:449

--- a/po/id.po
+++ b/po/id.po
@@ -5075,7 +5075,7 @@ msgstr ""
 
 #: notmuch/mutt_notmuch.c:219 notmuch/mutt_notmuch.c:1939
 #, fuzzy, c-format
-msgid "failed to parse notmuch uri: %s"
+msgid "failed to parse notmuch url: %s"
 msgstr "SASL gagal membaca alamat IP lokal"
 
 #: notmuch/mutt_notmuch.c:449

--- a/po/it.po
+++ b/po/it.po
@@ -5070,7 +5070,7 @@ msgstr ""
 
 #: notmuch/mutt_notmuch.c:219 notmuch/mutt_notmuch.c:1939
 #, fuzzy, c-format
-msgid "failed to parse notmuch uri: %s"
+msgid "failed to parse notmuch url: %s"
 msgstr "Impossibile analizzare il collegamento mailto:\n"
 
 #: notmuch/mutt_notmuch.c:449

--- a/po/ja.po
+++ b/po/ja.po
@@ -5006,7 +5006,7 @@ msgstr "notmuch クエリをパースするのに失敗: %s"
 
 #: notmuch/mutt_notmuch.c:219 notmuch/mutt_notmuch.c:1939
 #, fuzzy, c-format
-msgid "failed to parse notmuch uri: %s"
+msgid "failed to parse notmuch url: %s"
 msgstr "\"mailto:\" リンクの解析に失敗\n"
 
 #: notmuch/mutt_notmuch.c:449

--- a/po/ko.po
+++ b/po/ko.po
@@ -5127,7 +5127,7 @@ msgstr ""
 
 #: notmuch/mutt_notmuch.c:219 notmuch/mutt_notmuch.c:1939
 #, c-format
-msgid "failed to parse notmuch uri: %s"
+msgid "failed to parse notmuch url: %s"
 msgstr ""
 
 #: notmuch/mutt_notmuch.c:449

--- a/po/lt.po
+++ b/po/lt.po
@@ -5001,8 +5001,8 @@ msgstr "nepavyko išanalizuoti notmuch užklausos tipo: %s"
 
 #: notmuch/mutt_notmuch.c:219 notmuch/mutt_notmuch.c:1939
 #, c-format
-msgid "failed to parse notmuch uri: %s"
-msgstr "nepavyko išanalizuoti notmuch uri: %s"
+msgid "failed to parse notmuch url: %s"
+msgstr "nepavyko išanalizuoti notmuch url: %s"
 
 #: notmuch/mutt_notmuch.c:449
 msgid "Invalid nm_query_window_timebase value (valid values are: hour, day, week, month or year)"

--- a/po/nl.po
+++ b/po/nl.po
@@ -5043,8 +5043,8 @@ msgstr ""
 
 #: notmuch/mutt_notmuch.c:219 notmuch/mutt_notmuch.c:1939
 #, fuzzy, c-format
-msgid "failed to parse notmuch uri: %s"
-msgstr "Kan 'notmuch uri' niet verwerken: %s"
+msgid "failed to parse notmuch url: %s"
+msgstr "Kan 'notmuch url' niet verwerken: %s"
 
 #: notmuch/mutt_notmuch.c:449
 msgid "Invalid nm_query_window_timebase value (valid values are: hour, day, week, month or year)"

--- a/po/pl.po
+++ b/po/pl.po
@@ -4943,8 +4943,8 @@ msgstr ""
 
 #: notmuch/mutt_notmuch.c:219 notmuch/mutt_notmuch.c:1939
 #, c-format
-msgid "failed to parse notmuch uri: %s"
-msgstr "nie udane dopasowanie notmuch uri: %s"
+msgid "failed to parse notmuch url: %s"
+msgstr "nie udane dopasowanie notmuch url: %s"
 
 #: notmuch/mutt_notmuch.c:449
 msgid "Invalid nm_query_window_timebase value (valid values are: hour, day, week, month or year)"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -4973,8 +4973,8 @@ msgstr "falha ao interpretar consulta do tipo notmuch: %s"
 
 #: notmuch/mutt_notmuch.c:219 notmuch/mutt_notmuch.c:1939
 #, c-format
-msgid "failed to parse notmuch uri: %s"
-msgstr "falha ao interpretar uri do notmuch: %s"
+msgid "failed to parse notmuch url: %s"
+msgstr "falha ao interpretar url do notmuch: %s"
 
 #: notmuch/mutt_notmuch.c:449
 msgid "Invalid nm_query_window_timebase value (valid values are: hour, day, week, month or year)"

--- a/po/ru.po
+++ b/po/ru.po
@@ -5041,7 +5041,7 @@ msgstr ""
 
 #: notmuch/mutt_notmuch.c:219 notmuch/mutt_notmuch.c:1939
 #, fuzzy, c-format
-msgid "failed to parse notmuch uri: %s"
+msgid "failed to parse notmuch url: %s"
 msgstr "Не удалось распознать ссылку mailto:\n"
 
 #: notmuch/mutt_notmuch.c:449

--- a/po/sk.po
+++ b/po/sk.po
@@ -5106,7 +5106,7 @@ msgstr ""
 
 #: notmuch/mutt_notmuch.c:219 notmuch/mutt_notmuch.c:1939
 #, c-format
-msgid "failed to parse notmuch uri: %s"
+msgid "failed to parse notmuch url: %s"
 msgstr ""
 
 #: notmuch/mutt_notmuch.c:449

--- a/po/sv.po
+++ b/po/sv.po
@@ -5097,7 +5097,7 @@ msgstr ""
 
 #: notmuch/mutt_notmuch.c:219 notmuch/mutt_notmuch.c:1939
 #, fuzzy, c-format
-msgid "failed to parse notmuch uri: %s"
+msgid "failed to parse notmuch url: %s"
 msgstr "Misslyckades att tolka mailto:-länk\n"
 
 #: notmuch/mutt_notmuch.c:449

--- a/po/tr.po
+++ b/po/tr.po
@@ -5045,7 +5045,7 @@ msgstr ""
 
 #: notmuch/mutt_notmuch.c:219 notmuch/mutt_notmuch.c:1939
 #, c-format
-msgid "failed to parse notmuch uri: %s"
+msgid "failed to parse notmuch url: %s"
 msgstr ""
 
 #: notmuch/mutt_notmuch.c:449

--- a/po/uk.po
+++ b/po/uk.po
@@ -5034,7 +5034,7 @@ msgstr ""
 
 #: notmuch/mutt_notmuch.c:219 notmuch/mutt_notmuch.c:1939
 #, fuzzy, c-format
-msgid "failed to parse notmuch uri: %s"
+msgid "failed to parse notmuch url: %s"
 msgstr "Неможливо розібрати почилання mailto:\n"
 
 #: notmuch/mutt_notmuch.c:449

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -4965,8 +4965,8 @@ msgstr "无法解析 notmuch 查询类型：%s"
 
 #: notmuch/mutt_notmuch.c:219 notmuch/mutt_notmuch.c:1939
 #, c-format
-msgid "failed to parse notmuch uri: %s"
-msgstr "无法解析 notmuch 查询 URI：%s"
+msgid "failed to parse notmuch url: %s"
+msgstr "无法解析 notmuch 查询 URL：%s"
 
 #: notmuch/mutt_notmuch.c:449
 msgid "Invalid nm_query_window_timebase value (valid values are: hour, day, week, month or year)"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -5168,7 +5168,7 @@ msgstr ""
 
 #: notmuch/mutt_notmuch.c:219 notmuch/mutt_notmuch.c:1939
 #, c-format
-msgid "failed to parse notmuch uri: %s"
+msgid "failed to parse notmuch url: %s"
 msgstr ""
 
 #: notmuch/mutt_notmuch.c:449


### PR DESCRIPTION
Change all the '**URI**' references to '**URL**'

For a description of the differences, see: https://www.java67.com/2013/01/difference-between-url-uri-and-urn.html

All the **URI**s in NeoMutt are qualified with a scheme, e.g. `notmuch://`
This makes them **URL**s, which is also a more well-known term.

This PR changes one config variable: `nm_default_uri` to `nm_default_url` (but adds a synonym for backwards compatibility)
There are no functional changes to the code.

This PR only affects the Notmuch backend, so @Austin-Ray you get the right of veto.
If you're not happy, I'll just drop the change.