### PR TITLE
Fix commands that don’t need to have a non-empty mailbox to be valid

### DIFF
--- a/index.c
+++ b/index.c
@@ -1642,7 +1642,7 @@ int mutt_index_menu(struct MuttWindow *dlg)
       case OP_JUMP:
       {
         int msg_num = 0;
-        if (!prereq(Context, menu, CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE))
+        if (!prereq(Context, menu, CHECK_IN_MAILBOX))
           break;
         if (isdigit(LastKey))
           mutt_unget_event(LastKey, 0);
@@ -1686,8 +1686,7 @@ int mutt_index_menu(struct MuttWindow *dlg)
          */
 
       case OP_MAIN_DELETE_PATTERN:
-        if (!prereq(Context, menu,
-                    CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE | CHECK_READONLY | CHECK_ATTACH))
+        if (!prereq(Context, menu, CHECK_IN_MAILBOX | CHECK_READONLY | CHECK_ATTACH))
         {
           break;
         }
@@ -1852,11 +1851,17 @@ int mutt_index_menu(struct MuttWindow *dlg)
         menu->redraw = REDRAW_FULL;
         break;
 
-      case OP_SEARCH:
+      // Initiating a search can happen on an empty mailbox, but
+      // searching for next/previous/... needs to be on a message and
+      // thus a non-empty mailbox
       case OP_SEARCH_REVERSE:
       case OP_SEARCH_NEXT:
       case OP_SEARCH_OPPOSITE:
         if (!prereq(Context, menu, CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE))
+          break;
+        /* fallthrough */
+      case OP_SEARCH:
+        if (!prereq(Context, menu, CHECK_IN_MAILBOX))
           break;
         menu->current = mutt_search_command(menu->current, op);
         if (menu->current == -1)
@@ -1926,14 +1931,14 @@ int mutt_index_menu(struct MuttWindow *dlg)
       }
 
       case OP_MAIN_TAG_PATTERN:
-        if (!prereq(Context, menu, CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE))
+        if (!prereq(Context, menu, CHECK_IN_MAILBOX))
           break;
         mutt_pattern_func(MUTT_TAG, _("Tag messages matching: "));
         menu->redraw |= REDRAW_INDEX | REDRAW_STATUS;
         break;
 
       case OP_MAIN_UNDELETE_PATTERN:
-        if (!prereq(Context, menu, CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE | CHECK_READONLY))
+        if (!prereq(Context, menu, CHECK_IN_MAILBOX | CHECK_READONLY))
           break;
         /* L10N: CHECK_ACL */
         /* L10N: Due to the implementation details we do not know whether we
@@ -1950,7 +1955,7 @@ int mutt_index_menu(struct MuttWindow *dlg)
         break;
 
       case OP_MAIN_UNTAG_PATTERN:
-        if (!prereq(Context, menu, CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE))
+        if (!prereq(Context, menu, CHECK_IN_MAILBOX))
           break;
         if (mutt_pattern_func(MUTT_UNTAG, _("Untag messages matching: ")) == 0)
           menu->redraw |= REDRAW_INDEX | REDRAW_STATUS;
@@ -3189,7 +3194,7 @@ int mutt_index_menu(struct MuttWindow *dlg)
       }
 
       case OP_MAIN_COLLAPSE_ALL:
-        if (!prereq(Context, menu, CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE))
+        if (!prereq(Context, menu, CHECK_IN_MAILBOX))
           break;
 
         if ((C_Sort & SORT_MASK) != SORT_THREADS)


### PR DESCRIPTION
Some commands act on the whole mailbox (tag-pattern, delete-pattern,
search), and even though they don’t do anything when the mailbox is
empty, there is no reason to fail when it happens. This commit removes
the check that the mailbox is non-empty before doing said actions.

- [ ] All builds and tests are passing

This PR partially solved the issue of failing macros. It solves all cases where an existant message is not required, but it doesn’t handle cases where a macro would take both a user input AND a current message.
The functions I identified from that last case are:
- compose-to-sender (may not have a solution since a pre-input contains element from the selected message)
- edit-type (same)
- set-flag/clear-flag
