### PR TITLE
use global ContextList to store Contexts

### DIFF
--- a/context.c
+++ b/context.c
@@ -42,6 +42,8 @@
 #include "sort.h"
 #include "ncrypt/lib.h"
 
+struct ContextList ContextList = STAILQ_HEAD_INITIALIZER(ContextList); ///< List of Contexts
+
 /**
  * ctx_free - Free a Context
  * @param[out] ptr Context to free
@@ -62,6 +64,7 @@ void ctx_free(struct Context **ptr)
   mutt_hash_free(&ctx->thread_hash);
   notify_free(&ctx->notify);
 
+  STAILQ_REMOVE(&ContextList, ctx, Context, entries);
   FREE(ptr);
 }
 

--- a/context.h
+++ b/context.h
@@ -29,6 +29,7 @@
 struct Email;
 struct EmailList;
 struct NotifyCallback;
+extern struct ContextList ContextList;
 
 /**
  * struct Context - The "current" mailbox
@@ -49,7 +50,9 @@ struct Context
 
   struct Mailbox *mailbox;
   struct Notify *notify;             ///< Notifications handler
+  STAILQ_ENTRY(Context) entries;     ///< Linked list
 };
+STAILQ_HEAD(ContextList, Context);
 
 /**
  * struct EventContext - An Event that happened to an Context

--- a/mx.c
+++ b/mx.c
@@ -255,8 +255,21 @@ struct Context *mx_mbox_open(struct Mailbox *m, OpenMailboxFlags flags)
   if (!m)
     return NULL;
 
-  struct Context *ctx = ctx_new();
-  ctx->mailbox = m;
+  struct Context *ctx = NULL, *np = NULL;;
+  STAILQ_FOREACH(np, &ContextList, entries)
+  {
+    if (np->mailbox == m)
+    {
+      ctx = np;
+      break;
+    }
+  }
+  if (!ctx)
+  {
+    ctx = ctx_new();
+    ctx->mailbox = m;
+    STAILQ_INSERT_TAIL(&ContextList, ctx, entries);
+  }
 
   struct EventContext ev_ctx = { ctx };
   notify_send(ctx->notify, NT_CONTEXT, NT_CONTEXT_OPEN, &ev_ctx);


### PR DESCRIPTION
Create a list to be able to store contexts globally.
The functionality will be useful to keep contexts in memory in the
future, instead of creating a new context on every mailbox switch.

No functional changes, just implement the infrastructure.