### PR TITLE
maildir: sanitize filename before hashing v2

### DIFF
--- a/maildir/shared.c
+++ b/maildir/shared.c
@@ -1143,14 +1143,7 @@ void maildir_canon_filename(struct Buffer *dest, const char *src)
     src = t + 1;
 
   mutt_buffer_strcpy(dest, src);
-  char *u = strchr(dest->data, ',');
-  if (u)
-  {
-    *u = '\0';
-    dest->dptr = u;
-    return;
-  }
-  u = strrchr(dest->data, ':');
+  char *u = strpbrk(dest->data, ",:");
   if (u)
   {
     *u = '\0';


### PR DESCRIPTION
Turns out we cannot stop after detecting ",".
In case <base_filename> did not contain any extra comman separated files
we end up cutting off the flags only.

1581495693.R3771990984008251196.p50:2,S
would end up as
1581495693.R3771990984008251196.p50:2
but it needs to be
1581495693.R3771990984008251196.p50