### PR TITLE
Light refactoring in preparation for the path changes

### DIFF
--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -62,7 +62,7 @@ ALL_FILES!=	(cd $(SRCDIR) && git ls-files 2>/dev/null) || true
 # neomutt
 NEOMUTT=	neomutt$(EXEEXT)
 NEOMUTTOBJS=	addrbook.o alias.o bcache.o browser.o commands.o \
-		complete.o compose.o compress.o conststrings.o context.o copy.o \
+		complete.o compose.o conststrings.o context.o copy.o \
 		edit.o editmsg.o enriched.o enter.o flags.o functions.o \
 		git_ver.o handler.o hdrline.o help.o hook.o icommands.o index.o init.o \
 		keymap.o mailcap.o main.o menu.o mutt_account.o mutt_attach.o \
@@ -120,6 +120,14 @@ LIBNNTPOBJS=	nntp/browse.o nntp/complete.o nntp/newsrc.o nntp/nntp.o
 CLEANFILES+=	$(LIBNNTP) $(LIBNNTPOBJS)
 MUTTLIBS+=	$(LIBNNTP)
 ALLOBJS+=	$(LIBNNTPOBJS)
+
+###############################################################################
+# libcompress
+LIBCOMPRESS=	libcompress.a
+LIBCOMPRESSOBJS=compress/compress.o
+CLEANFILES+=	$(LIBCOMPRESS) $(LIBCOMPRESSOBJS)
+MUTTLIBS+=	$(LIBCOMPRESS)
+ALLOBJS+=	$(LIBCOMPRESSOBJS)
 
 ###############################################################################
 # libgui
@@ -371,6 +379,13 @@ $(LIBNNTP): $(PWD)/nntp $(LIBNNTPOBJS)
 	$(RANLIB) $@
 $(PWD)/nntp:
 	$(MKDIR_P) $(PWD)/nntp
+
+# libcompress
+$(LIBCOMPRESS): $(PWD)/compress $(LIBCOMPRESSOBJS)
+	$(AR) cr $@ $(LIBCOMPRESSOBJS)
+	$(RANLIB) $@
+$(PWD)/compress:
+	$(MKDIR_P) $(PWD)/compress
 
 # libgui
 $(LIBGUI): $(PWD)/gui $(LIBGUIOBJS)

--- a/browser.c
+++ b/browser.c
@@ -1321,7 +1321,7 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
         {
           /* If browsing in "local"-mode, than we chose to define LastDir to
            * MailDir */
-          switch (mx_path_probe(CurrentFolder, NULL))
+          switch (mx_path_probe(CurrentFolder))
           {
             case MUTT_IMAP:
             case MUTT_MAILDIR:
@@ -1472,7 +1472,7 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
                                     state.entry[menu->current].name);
           }
 
-          enum MailboxType magic = mx_path_probe(mutt_b2s(buf), NULL);
+          enum MailboxType magic = mx_path_probe(mutt_b2s(buf));
           if ((op == OP_DESCEND_DIRECTORY) || (magic == MUTT_MAILBOX_ERROR) ||
               (magic == MUTT_UNKNOWN)
 #ifdef USE_IMAP

--- a/compose.c
+++ b/compose.c
@@ -1710,7 +1710,7 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur, 
 #ifdef USE_NNTP
             if (!OptNews && (nntp_path_probe(mutt_b2s(&fname), NULL) != MUTT_NNTP))
 #endif
-              if (mx_path_probe(mutt_b2s(&fname), NULL) != MUTT_NOTMUCH)
+              if (mx_path_probe(mutt_b2s(&fname)) != MUTT_NOTMUCH)
               {
                 /* check to make sure the file exists and is readable */
                 if (access(mutt_b2s(&fname), R_OK) == -1)

--- a/compress/compress.c
+++ b/compress/compress.c
@@ -942,6 +942,7 @@ struct MxOps MxCompOps = {
   .mbox_open        = comp_mbox_open,
   .mbox_open_append = comp_mbox_open_append,
   .mbox_check       = comp_mbox_check,
+  .mbox_check_stats = NULL,
   .mbox_sync        = comp_mbox_sync,
   .mbox_close       = comp_mbox_close,
   .msg_open         = comp_msg_open,

--- a/compress/compress.c
+++ b/compress/compress.c
@@ -450,7 +450,7 @@ static int comp_mbox_open(struct Mailbox *m)
 
   unlock_realpath(m);
 
-  m->magic = mx_path_probe(mailbox_path(m), NULL);
+  m->magic = mx_path_probe(mailbox_path(m));
   if (m->magic == MUTT_UNKNOWN)
   {
     mutt_error(_("Can't identify the contents of the compressed file"));
@@ -520,7 +520,7 @@ static int comp_mbox_open_append(struct Mailbox *m, OpenMailboxFlags flags)
       mutt_error(_("Compress command failed: %s"), ci->cmd_open);
       goto cmoa_fail2;
     }
-    m->magic = mx_path_probe(mailbox_path(m), NULL);
+    m->magic = mx_path_probe(mailbox_path(m));
   }
   else
     m->magic = C_MboxType;
@@ -936,6 +936,7 @@ static int comp_path_parent(char *buf, size_t buflen)
 struct MxOps MxCompOps = {
   .magic            = MUTT_COMPRESSED,
   .name             = "compressed",
+  .is_local         = true,
   .ac_find          = comp_ac_find,
   .ac_add           = comp_ac_add,
   .mbox_open        = comp_mbox_open,

--- a/compress/compress.c
+++ b/compress/compress.c
@@ -41,7 +41,7 @@
 #include "mutt/lib.h"
 #include "core/lib.h"
 #include "gui/lib.h"
-#include "compress.h"
+#include "lib.h"
 #include "format_flags.h"
 #include "globals.h"
 #include "hook.h"

--- a/compress/lib.h
+++ b/compress/lib.h
@@ -21,8 +21,8 @@
  * this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef MUTT_COMPRESS_H
-#define MUTT_COMPRESS_H
+#ifndef MUTT_COMPRESS_LIB_H
+#define MUTT_COMPRESS_LIB_H
 
 #include <stdbool.h>
 #include <stdio.h>
@@ -52,4 +52,4 @@ int mutt_comp_valid_command(const char *cmd);
 
 extern struct MxOps MxCompOps;
 
-#endif /* MUTT_COMPRESS_H */
+#endif /* MUTT_COMPRESS_LIB_H */

--- a/hook.c
+++ b/hook.c
@@ -51,7 +51,7 @@
 #include "pattern.h"
 #include "ncrypt/lib.h"
 #ifdef USE_COMPRESSED
-#include "compress.h"
+#include "compress/lib.h"
 #endif
 
 /* These Config Variables are only used in hook.c */

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -2591,6 +2591,7 @@ static int imap_path_parent(char *buf, size_t buflen)
 struct MxOps MxImapOps = {
   .magic            = MUTT_IMAP,
   .name             = "imap",
+  .is_local         = false,
   .ac_find          = imap_ac_find,
   .ac_add           = imap_ac_add,
   .mbox_open        = imap_mbox_open,

--- a/imap/util.c
+++ b/imap/util.c
@@ -264,13 +264,11 @@ struct ImapMboxData *imap_mdata_get(struct Mailbox *m)
  */
 void imap_get_parent(const char *mbox, char delim, char *buf, size_t buflen)
 {
-  int n;
-
   /* Make a copy of the mailbox name, but only if the pointers are different */
   if (mbox != buf)
     mutt_str_strfcpy(buf, mbox, buflen);
 
-  n = mutt_str_strlen(buf);
+  int n = mutt_str_strlen(buf);
 
   /* Let's go backwards until the next delimiter
    *
@@ -281,7 +279,7 @@ void imap_get_parent(const char *mbox, char delim, char *buf, size_t buflen)
    *
    * If buf == '/', then n-- => n == 0, so the loop ends
    * immediately */
-  for (n--; n >= 0 && buf[n] != delim; n--)
+  for (n--; (n >= 0) && (buf[n] != delim); n--)
     ;
 
   /* We stopped before the beginning. There is a trailing slash.  */
@@ -626,20 +624,20 @@ int imap_parse_path(const char *path, struct ConnAccount *cac, char *mailbox, si
 {
   static unsigned short ImapPort = 0;
   static unsigned short ImapsPort = 0;
-  struct servent *service = NULL;
 
   if (ImapPort == 0)
   {
-    service = getservbyname("imap", "tcp");
+    struct servent *service = getservbyname("imap", "tcp");
     if (service)
       ImapPort = ntohs(service->s_port);
     else
       ImapPort = IMAP_PORT;
     mutt_debug(LL_DEBUG3, "Using default IMAP port %d\n", ImapPort);
   }
+
   if (ImapsPort == 0)
   {
-    service = getservbyname("imaps", "tcp");
+    struct servent *service = getservbyname("imaps", "tcp");
     if (service)
       ImapsPort = ntohs(service->s_port);
     else

--- a/index.c
+++ b/index.c
@@ -698,7 +698,7 @@ static int main_change_folder(struct Menu *menu, int op, struct Mailbox *m,
     mx_path_canon(buf, buflen, C_Folder, NULL);
   }
 
-  enum MailboxType magic = mx_path_probe(buf, NULL);
+  enum MailboxType magic = mx_path_probe(buf);
   if ((magic == MUTT_MAILBOX_ERROR) || (magic == MUTT_UNKNOWN))
   {
     // Try to see if the buffer matches a description before we bail.

--- a/maildir/maildir.c
+++ b/maildir/maildir.c
@@ -707,6 +707,7 @@ static enum MailboxType maildir_path_probe(const char *path, const struct stat *
 struct MxOps MxMaildirOps = {
   .magic            = MUTT_MAILDIR,
   .name             = "maildir",
+  .is_local         = true,
   .ac_find          = maildir_ac_find,
   .ac_add           = maildir_ac_add,
   .mbox_open        = maildir_mbox_open,

--- a/maildir/mh.c
+++ b/maildir/mh.c
@@ -814,6 +814,7 @@ static enum MailboxType mh_path_probe(const char *path, const struct stat *st)
 struct MxOps MxMhOps = {
   .magic            = MUTT_MH,
   .name             = "mh",
+  .is_local         = true,
   .ac_find          = maildir_ac_find,
   .ac_add           = maildir_ac_add,
   .mbox_open        = mh_mbox_open,

--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -817,7 +817,7 @@ bool mbox_test_new_folder(const char *path)
 {
   bool rc = false;
 
-  enum MailboxType magic = mx_path_probe(path, NULL);
+  enum MailboxType magic = mx_path_probe(path);
 
   if ((magic != MUTT_MBOX) && (magic != MUTT_MMDF))
     return false;
@@ -1848,6 +1848,7 @@ static int mbox_mbox_check_stats(struct Mailbox *m, int flags)
 struct MxOps MxMboxOps = {
   .magic            = MUTT_MBOX,
   .name             = "mbox",
+  .is_local         = true,
   .ac_find          = mbox_ac_find,
   .ac_add           = mbox_ac_add,
   .mbox_open        = mbox_mbox_open,
@@ -1876,6 +1877,7 @@ struct MxOps MxMboxOps = {
 struct MxOps MxMmdfOps = {
   .magic            = MUTT_MMDF,
   .name             = "mmdf",
+  .is_local         = true,
   .ac_find          = mbox_ac_find,
   .ac_add           = mbox_ac_add,
   .mbox_open        = mbox_mbox_open,

--- a/mutt/path.c
+++ b/mutt/path.c
@@ -45,12 +45,13 @@
 
 /**
  * mutt_path_tidy_slash - Remove unnecessary slashes and dots
- * @param[in,out] buf Path to modify
+ * @param[in,out] buf    Path to modify
+ * @param[in]     is_dir Should a trailing / be removed?
  * @retval true Success
  *
  * Collapse repeated '//' and '/./'
  */
-bool mutt_path_tidy_slash(char *buf)
+bool mutt_path_tidy_slash(char *buf, bool is_dir)
 {
   if (!buf)
     return false;
@@ -86,7 +87,7 @@ bool mutt_path_tidy_slash(char *buf)
   }
 
   /* Strip a trailing / as long as it's not the only character */
-  if ((w > (buf + 1)) && (w[-1] == '/'))
+  if (is_dir && (w > (buf + 1)) && (w[-1] == '/'))
     w--;
 
   *w = '\0';
@@ -165,7 +166,7 @@ bool mutt_path_tidy(char *buf)
   if (!buf || (buf[0] != '/'))
     return false;
 
-  if (!mutt_path_tidy_slash(buf))
+  if (!mutt_path_tidy_slash(buf, true))
     return false;
 
   return mutt_path_tidy_dotdot(buf);

--- a/mutt/path.h
+++ b/mutt/path.h
@@ -41,6 +41,7 @@ size_t      mutt_path_realpath(char *buf);
 bool        mutt_path_tidy(char *buf);
 bool        mutt_path_tidy_dotdot(char *buf);
 bool        mutt_path_tidy_slash(char *buf, bool is_dir);
+bool        mutt_path_tilde(char *buf, size_t buflen, const char *homedir);
 bool        mutt_path_to_absolute(char *path, const char *reference);
 
 #endif /* MUTT_LIB_PATH_H */

--- a/mutt/path.h
+++ b/mutt/path.h
@@ -40,7 +40,7 @@ bool        mutt_path_pretty(char *buf, size_t buflen, const char *homedir);
 size_t      mutt_path_realpath(char *buf);
 bool        mutt_path_tidy(char *buf);
 bool        mutt_path_tidy_dotdot(char *buf);
-bool        mutt_path_tidy_slash(char *buf);
+bool        mutt_path_tidy_slash(char *buf, bool is_dir);
 bool        mutt_path_to_absolute(char *path, const char *reference);
 
 #endif /* MUTT_LIB_PATH_H */

--- a/mutt/string.c
+++ b/mutt/string.c
@@ -500,7 +500,7 @@ void mutt_str_adjust(char **p)
 }
 
 /**
- * mutt_str_strlower - convert all characters in the string to lowercase
+ * mutt_str_strlower - Convert all characters in the string to lowercase
  * @param s String to lowercase
  * @retval ptr Lowercase string
  *
@@ -520,6 +520,29 @@ char *mutt_str_strlower(char *s)
   }
 
   return s;
+}
+
+/**
+ * mutt_str_strnlower - Convert some characters in the string to lowercase
+ * @param str String to lowercase
+ * @param num Maximum number of characters to lowercase
+ * @retval ptr Lowercase string
+ *
+ * The string is transformed in place.
+ */
+char *mutt_str_strnlower(char *str, size_t num)
+{
+  if (!str)
+    return NULL;
+
+  for (size_t i = 0; i < num; i++)
+  {
+    if (str[i] == '\0')
+      break;
+    str[i] = tolower((unsigned char) str[i]);
+  }
+
+  return str;
 }
 
 /**

--- a/mutt/string2.h
+++ b/mutt/string2.h
@@ -104,6 +104,7 @@ size_t      mutt_str_strfcpy(char *dest, const char *src, size_t dsize);
 const char *mutt_str_stristr(const char *haystack, const char *needle);
 size_t      mutt_str_strlen(const char *a);
 char *      mutt_str_strlower(char *s);
+char *      mutt_str_strnlower(char *str, size_t num);
 int         mutt_str_strncasecmp(const char *a, const char *b, size_t l);
 char *      mutt_str_strncat(char *d, size_t l, const char *s, size_t sl);
 int         mutt_str_strncmp(const char *a, const char *b, size_t l);

--- a/mutt_mailbox.c
+++ b/mutt_mailbox.c
@@ -43,7 +43,7 @@ static void mailbox_check(struct Mailbox *m_cur, struct Mailbox *m_check,
   int orig_flagged = m_check->msg_flagged;
 #endif
 
-  enum MailboxType mb_magic = mx_path_probe(mailbox_path(m_check), NULL);
+  enum MailboxType mb_magic = mx_path_probe(mailbox_path(m_check));
 
   if ((m_cur == m_check) && C_MailCheckRecent)
     m_check->has_new = false;
@@ -60,7 +60,7 @@ static void mailbox_check(struct Mailbox *m_cur, struct Mailbox *m_check,
       if ((stat(mailbox_path(m_check), &sb) != 0) ||
           ((m_check->magic == MUTT_UNKNOWN) && S_ISREG(sb.st_mode) && (sb.st_size == 0)) ||
           ((m_check->magic == MUTT_UNKNOWN) &&
-           ((m_check->magic = mx_path_probe(mailbox_path(m_check), NULL)) <= 0)))
+           ((m_check->magic = mx_path_probe(mailbox_path(m_check))) <= 0)))
       {
         /* if the mailbox still doesn't exist, set the newly created flag to be
          * ready for when it does. */

--- a/muttlib.c
+++ b/muttlib.c
@@ -199,7 +199,7 @@ void mutt_buffer_expand_path_regex(struct Buffer *buf, bool regex)
       case '=':
       case '+':
       {
-        enum MailboxType mb_type = mx_path_probe(C_Folder, NULL);
+        enum MailboxType mb_type = mx_path_probe(C_Folder);
 
         /* if folder = {host} or imap[s]://host/: don't append slash */
         if ((mb_type == MUTT_IMAP) && ((C_Folder[strlen(C_Folder) - 1] == '}') ||
@@ -1448,7 +1448,7 @@ int mutt_save_confirm(const char *s, struct stat *st)
 {
   int ret = 0;
 
-  enum MailboxType magic = mx_path_probe(s, NULL);
+  enum MailboxType magic = mx_path_probe(s);
 
 #ifdef USE_POP
   if (magic == MUTT_POP)
@@ -1636,7 +1636,7 @@ int mutt_set_xdg_path(enum XdgType type, char *buf, size_t bufsize)
  */
 void mutt_get_parent_path(const char *path, char *buf, size_t buflen)
 {
-  enum MailboxType mb_magic = mx_path_probe(path, NULL);
+  enum MailboxType mb_magic = mx_path_probe(path);
 
   if (mb_magic == MUTT_IMAP)
     imap_get_parent_path(path, buf, buflen);

--- a/mx.c
+++ b/mx.c
@@ -193,7 +193,7 @@ static int mx_open_mailbox_append(struct Mailbox *m, OpenMailboxFlags flags)
   m->append = true;
   if ((m->magic == MUTT_UNKNOWN) || (m->magic == MUTT_MAILBOX_ERROR))
   {
-    m->magic = mx_path_probe(mailbox_path(m), NULL);
+    m->magic = mx_path_probe(mailbox_path(m));
 
     if (m->magic == MUTT_UNKNOWN)
     {
@@ -326,7 +326,7 @@ struct Context *mx_mbox_open(struct Mailbox *m, OpenMailboxFlags flags)
 
   if (m->magic == MUTT_UNKNOWN)
   {
-    m->magic = mx_path_probe(mailbox_path(m), NULL);
+    m->magic = mx_path_probe(mailbox_path(m));
     m->mx_ops = mx_get_ops(m->magic);
   }
 
@@ -1223,7 +1223,7 @@ void mx_alloc_memory(struct Mailbox *m)
  */
 int mx_check_empty(const char *path)
 {
-  switch (mx_path_probe(path, NULL))
+  switch (mx_path_probe(path))
   {
     case MUTT_MBOX:
     case MUTT_MMDF:
@@ -1304,59 +1304,39 @@ bool mx_tags_is_supported(struct Mailbox *m)
 
 /**
  * mx_path_probe - Find a mailbox that understands a path
- * @param[in]  path  Path to examine
- * @param[out] st    stat buffer (OPTIONAL, for local mailboxes)
+ * @param path Path to examine
  * @retval num Type, e.g. #MUTT_IMAP
  */
-enum MailboxType mx_path_probe(const char *path, struct stat *st)
+enum MailboxType mx_path_probe(const char *path)
 {
   if (!path)
     return MUTT_UNKNOWN;
 
-  static const struct MxOps *no_stat[] = {
-#ifdef USE_IMAP
-    &MxImapOps,
-#endif
-#ifdef USE_NOTMUCH
-    &MxNotmuchOps,
-#endif
-#ifdef USE_POP
-    &MxPopOps,
-#endif
-#ifdef USE_NNTP
-    &MxNntpOps,
-#endif
-  };
-
-  static const struct MxOps *with_stat[] = {
-    &MxMaildirOps, &MxMboxOps, &MxMhOps, &MxMmdfOps,
-#ifdef USE_COMPRESSED
-    &MxCompOps,
-#endif
-  };
-
   enum MailboxType rc;
 
-  for (size_t i = 0; i < mutt_array_size(no_stat); i++)
+  // First, search the non-local Mailbox types (is_local == false)
+  for (const struct MxOps **ops = mx_ops; *ops; ops++)
   {
-    rc = no_stat[i]->path_probe(path, NULL);
+    if ((*ops)->is_local)
+      continue;
+    rc = (*ops)->path_probe(path, NULL);
     if (rc != MUTT_UNKNOWN)
       return rc;
   }
 
-  struct stat st2 = { 0 };
-  if (!st)
-    st = &st2;
-
-  if (stat(path, st) != 0)
+  struct stat st = { 0 };
+  if (stat(path, &st) != 0)
   {
     mutt_debug(LL_DEBUG1, "unable to stat %s: %s (errno %d)\n", path, strerror(errno), errno);
     return MUTT_UNKNOWN;
   }
 
-  for (size_t i = 0; i < mutt_array_size(with_stat); i++)
+  // Next, search the local Mailbox types (is_local == true)
+  for (const struct MxOps **ops = mx_ops; *ops; ops++)
   {
-    rc = with_stat[i]->path_probe(path, st);
+    if (!(*ops)->is_local)
+      continue;
+    rc = (*ops)->path_probe(path, &st);
     if (rc != MUTT_UNKNOWN)
       return rc;
   }
@@ -1446,7 +1426,7 @@ int mx_path_canon(char *buf, size_t buflen, const char *folder, enum MailboxType
   // if (!folder) //XXX - use inherited version, or pass NULL to backend?
   //   return -1;
 
-  enum MailboxType magic2 = mx_path_probe(buf, NULL);
+  enum MailboxType magic2 = mx_path_probe(buf);
   if (magic)
     *magic = magic2;
   const struct MxOps *ops = mx_get_ops(magic2);
@@ -1498,7 +1478,7 @@ int mx_path_canon2(struct Mailbox *m, const char *folder)
  */
 int mx_path_pretty(char *buf, size_t buflen, const char *folder)
 {
-  enum MailboxType magic = mx_path_probe(buf, NULL);
+  enum MailboxType magic = mx_path_probe(buf);
   const struct MxOps *ops = mx_get_ops(magic);
   if (!ops)
     return -1;

--- a/mx.c
+++ b/mx.c
@@ -59,7 +59,7 @@
 #include "maildir/lib.h"
 #include "mbox/lib.h"
 #ifdef USE_COMPRESSED
-#include "compress.h"
+#include "compress/lib.h"
 #endif
 #ifdef USE_IMAP
 #include "imap/lib.h"

--- a/mx.c
+++ b/mx.c
@@ -103,7 +103,7 @@ struct EnumDef MagicDef = {
 /**
  * mx_ops - All the Mailbox backends
  */
-static const struct MxOps *mx_ops[] = {
+const struct MxOps *mx_ops[] = {
 /* These mailboxes can be recognised by their Url scheme */
 #ifdef USE_IMAP
   &MxImapOps,

--- a/mx.h
+++ b/mx.h
@@ -104,6 +104,7 @@ struct MxOps
 {
   enum MailboxType magic; ///< Mailbox type, e.g. #MUTT_IMAP
   const char *name;       ///< Mailbox name, e.g. "imap"
+  bool is_local;          ///< True, if Mailbox type has local files/dirs
 
   /**
    * ac_find - Find an Account that matches a Mailbox path
@@ -287,7 +288,7 @@ int             mx_path_canon      (char *buf, size_t buflen, const char *folder
 int             mx_path_canon2     (struct Mailbox *m, const char *folder);
 int             mx_path_parent     (char *buf, size_t buflen);
 int             mx_path_pretty     (char *buf, size_t buflen, const char *folder);
-enum MailboxType mx_path_probe     (const char *path, struct stat *st);
+enum MailboxType mx_path_probe     (const char *path);
 struct Mailbox *mx_path_resolve    (const char *path);
 int             mx_tags_commit     (struct Mailbox *m, struct Email *e, char *tags);
 int             mx_tags_edit       (struct Mailbox *m, const char *tags, char *buf, size_t buflen);

--- a/mx.h
+++ b/mx.h
@@ -36,6 +36,8 @@ struct Email;
 struct Context;
 struct stat;
 
+extern const struct MxOps *mx_ops[];
+
 /* These Config Variables are only used in mx.c */
 extern unsigned char C_CatchupNewsgroup;
 extern bool          C_KeepFlagged;

--- a/nntp/nntp.c
+++ b/nntp/nntp.c
@@ -2889,6 +2889,7 @@ struct MxOps MxNntpOps = {
   .mbox_open        = nntp_mbox_open,
   .mbox_open_append = NULL,
   .mbox_check       = nntp_mbox_check,
+  .mbox_check_stats = NULL,
   .mbox_sync        = nntp_mbox_sync,
   .mbox_close       = nntp_mbox_close,
   .msg_open         = nntp_msg_open,

--- a/nntp/nntp.c
+++ b/nntp/nntp.c
@@ -2883,6 +2883,7 @@ static int nntp_path_parent(char *buf, size_t buflen)
 struct MxOps MxNntpOps = {
   .magic            = MUTT_NNTP,
   .name             = "nntp",
+  .is_local         = false,
   .ac_find          = nntp_ac_find,
   .ac_add           = nntp_ac_add,
   .mbox_open        = nntp_mbox_open,

--- a/notmuch/mutt_notmuch.c
+++ b/notmuch/mutt_notmuch.c
@@ -2590,6 +2590,7 @@ static int nm_path_parent(char *buf, size_t buflen)
 struct MxOps MxNotmuchOps = {
   .magic            = MUTT_NOTMUCH,
   .name             = "notmuch",
+  .is_local         = false,
   .ac_find          = nm_ac_find,
   .ac_add           = nm_ac_add,
   .mbox_open        = nm_mbox_open,

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -14,7 +14,7 @@ commands.c
 command_parse.c
 complete.c
 compose.c
-compress.c
+compress/compress.c
 config/address.c
 config/bool.c
 config/dump.c

--- a/pop/pop.c
+++ b/pop/pop.c
@@ -1285,6 +1285,7 @@ struct MxOps MxPopOps = {
   .mbox_open        = pop_mbox_open,
   .mbox_open_append = NULL,
   .mbox_check       = pop_mbox_check,
+  .mbox_check_stats = NULL,
   .mbox_sync        = pop_mbox_sync,
   .mbox_close       = pop_mbox_close,
   .msg_open         = pop_msg_open,

--- a/pop/pop.c
+++ b/pop/pop.c
@@ -1279,6 +1279,7 @@ static int pop_path_parent(char *buf, size_t buflen)
 struct MxOps MxPopOps = {
   .magic            = MUTT_POP,
   .name             = "pop",
+  .is_local         = false,
   .ac_find          = pop_ac_find,
   .ac_add           = pop_ac_add,
   .mbox_open        = pop_mbox_open,

--- a/test/path/mutt_path_tidy_slash.c
+++ b/test/path/mutt_path_tidy_slash.c
@@ -60,7 +60,7 @@ void test_mutt_path_tidy_slash(void)
   // clang-format on
 
   {
-    TEST_CHECK(!mutt_path_tidy_slash(NULL));
+    TEST_CHECK(!mutt_path_tidy_slash(NULL, true));
   }
 
   {
@@ -68,7 +68,7 @@ void test_mutt_path_tidy_slash(void)
     for (size_t i = 0; i < mutt_array_size(tests); i++)
     {
       mutt_str_strfcpy(buf, tests[i][0], sizeof(buf));
-      mutt_path_tidy_slash(buf);
+      mutt_path_tidy_slash(buf, true);
       if (!TEST_CHECK(mutt_str_strcmp(buf, tests[i][1]) == 0))
       {
         TEST_MSG("Input:    %s", tests[i][0]);


### PR DESCRIPTION
This is a mixed bag of minor refactoring.
All low impact and low urgency.

- 00f5f06aa7 create libcompress
- 21bfa9fceb add mutt_str_strnlower()
- 1793aacb00 refactor: mutt_path_tidy_slash()
- 3eb9b0b2ed imap: tidy code
- 06428cb4c9 mxapi: tidy stat(2) usage
- 37dfd38e69 mxapi: add missing prototypes
- 6f411b96a1 libmutt: split tilde from canon
