### PR TITLE
Fix context reinitialization in gpgme decryption

### DIFF
--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -2241,9 +2241,10 @@ static struct Body *decrypt_part(struct Body *a, struct State *s, FILE *fp_out,
   if (r_is_signed)
     *r_is_signed = 0;
 
-  gpgme_ctx_t ctx = create_gpgme_context(is_smime);
-
+  gpgme_ctx_t ctx = NULL;
 restart:
+  ctx = create_gpgme_context(is_smime);
+
   if (a->length < 0)
     return NULL;
   /* Make a data object from the body, create context etc. */


### PR DESCRIPTION
* **What does this PR do?**
In `decrypt_part` the gpgme context was correctly deinitialized before a
retry, but was not reinitialized due to an incorrect label location. This PR 
corrects the label position.

* **What are the relevant issue numbers?**
I'm not aware of relevant issues, but this PR fixes displaying of `smime-type=signed-data` inside of an encrypted envelope (not sure about the technically correct terms here) for me. These types of mails appear to be generated by Evolution and some apple mail client.