### PR TITLE
libmutt: fix segfault when alias lookup returns NULL

### DIFF
--- a/muttlib.c
+++ b/muttlib.c
@@ -223,7 +223,7 @@ void mutt_buffer_expand_path_regex(struct Buffer *buf, bool regex)
       case '@':
       {
         struct AddressList *al = mutt_alias_lookup(s + 1);
-        if (!TAILQ_EMPTY(al))
+        if (al && !TAILQ_EMPTY(al))
         {
           struct Email *e = email_new();
           e->env = mutt_env_new();

--- a/mx.c
+++ b/mx.c
@@ -1406,7 +1406,7 @@ int mx_path_canon(char *buf, size_t buflen, const char *folder, enum MailboxType
     {
       /* elm compatibility, @ expands alias to user name */
       struct AddressList *al = mutt_alias_lookup(buf + 1);
-      if (TAILQ_EMPTY(al))
+      if (!al || TAILQ_EMPTY(al))
         break;
 
       struct Email *e = email_new();


### PR DESCRIPTION
`mutt_alias_lookup` is allowed to return NULL and thus we should try to
handle that case.

I have a macro in my neomutt configuration that is being rendered and
the template file contains placeholders like `@notmuchmutt@`. That
placeholder is then replaced with the path to the notmuch-mutt script. I
had a typo in the file so some occurrences were not being replaced
properly. Thus neomutt tried to use the `mutt_alias_lookup` function on
the string (since it contained the at-sign). That function did return
NULL and in the neomutt code we are then dereferencing `al` by using
`TAILQ_EMPTY`.

By properly checking if the `mutt_alias_lookup` invocation actually
returned something non-NULL we can work around this.