### PR TITLE
oauth: if 'login' name isn't available use 'user'

### DIFF
--- a/conn/connaccount.c
+++ b/conn/connaccount.c
@@ -82,6 +82,11 @@ int mutt_account_getlogin(struct ConnAccount *cac)
     return -1;
 
   const char *login = cac->get_field(MUTT_CA_LOGIN);
+  if (!login && (mutt_account_getuser(cac) == 0))
+  {
+    login = cac->user;
+  }
+
   if (!login)
   {
     mutt_debug(LL_DEBUG1, "Couldn't get user info\n");


### PR DESCRIPTION
Oauth uses `$imap_login` to create its token.  If that doesn't exist, it tries `$imap_user`.
The delegation wasn't happening correctly, causing the connection to fail.

Fixes: #2130
