### PR TITLE
Fix ability to specify user/login in url for smtp

### DIFF
--- a/smtp.c
+++ b/smtp.c
@@ -365,6 +365,15 @@ static int smtp_fill_account(struct ConnAccount *cac)
     return -1;
   }
 
+  // If we set the user from the url, we also have to set the login now,
+  // because later attempts will only try to read from C_SmtpUser via
+  // `smpt_get_field` which may not be set.
+  if ((cac->flags & MUTT_ACCT_USER) && !(cac->flags & MUTT_ACCT_LOGIN))
+  {
+    mutt_str_strfcpy(cac->login, cac->user, sizeof(cac->login));
+    cac->flags |= MUTT_ACCT_LOGIN;
+  }
+
   if (url->scheme == U_SMTPS)
     cac->flags |= MUTT_ACCT_SSL;
 


### PR DESCRIPTION

* **What does this PR do?**
Even though user was correctly extracted from the smtp url, the login
was always read from the config variable, as it was never set before.
Now, immediately after extracting info from the url we copy the smtp
user to the login field if the user was set, but login wasn't.


* **What are the relevant issue numbers?**
I'm not aware of relevant issues. However, on current master I cannot send mails via the builtin smtp because of the described issue. On the most recent release (20191207) this still works. I suspect this broke during a refactoring/introduction of the `smtp_user` configuration option.
