### PR TITLE
config: add path type

### DIFF
--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -278,7 +278,7 @@ ALLOBJS+=	$(LIBCOREOBJS)
 # libconfig
 LIBCONFIG=	libconfig.a
 LIBCONFIGOBJS=	config/address.o config/bool.o config/dump.o config/enum.o \
-		config/long.o config/mbtable.o config/number.o config/quad.o \
+		config/long.o config/mbtable.o config/number.o config/path.o config/quad.o \
 		config/regex.o config/set.o config/slist.o config/sort.o \
 		config/string.o config/subset.o
 

--- a/compress/compress.c
+++ b/compress/compress.c
@@ -885,7 +885,7 @@ static int comp_path_canon(char *buf, size_t buflen)
   if (!buf)
     return -1;
 
-  mutt_path_canon(buf, buflen, HomeDir);
+  mutt_path_canon(buf, buflen, HomeDir, false);
   return 0;
 }
 
@@ -900,7 +900,7 @@ static int comp_path_pretty(char *buf, size_t buflen, const char *folder)
   if (mutt_path_abbr_folder(buf, buflen, folder))
     return 0;
 
-  if (mutt_path_pretty(buf, buflen, HomeDir))
+  if (mutt_path_pretty(buf, buflen, HomeDir, false))
     return 0;
 
   return -1;
@@ -918,7 +918,7 @@ static int comp_path_parent(char *buf, size_t buflen)
     return 0;
 
   if (buf[0] == '~')
-    mutt_path_canon(buf, buflen, HomeDir);
+    mutt_path_canon(buf, buflen, HomeDir, false);
 
   if (mutt_path_parent(buf, buflen))
     return 0;

--- a/config/dump.c
+++ b/config/dump.c
@@ -202,7 +202,7 @@ bool dump_config(struct ConfigSet *cs, ConfigDumpFlags flags, FILE *fp)
           mutt_buffer_addstr(&value, "***");
         }
 
-        if (IS_PATH(he) && (value.data[0] == '/'))
+        if (((type == DT_PATH) || IS_MAILBOX(he)) && (value.data[0] == '/'))
           mutt_pretty_mailbox(value.data, value.dsize);
 
         if ((type != DT_BOOL) && (type != DT_NUMBER) && (type != DT_LONG) &&
@@ -224,7 +224,7 @@ bool dump_config(struct ConfigSet *cs, ConfigDumpFlags flags, FILE *fp)
           break;          /* LCOV_EXCL_LINE */
         }
 
-        if (IS_PATH(he) && !(he->type & DT_MAILBOX))
+        if (((type == DT_PATH) || IS_MAILBOX(he)) && !(he->type & DT_MAILBOX))
           mutt_pretty_mailbox(initial.data, initial.dsize);
 
         if ((type != DT_BOOL) && (type != DT_NUMBER) && (type != DT_LONG) &&

--- a/config/lib.h
+++ b/config/lib.h
@@ -34,6 +34,7 @@
  * | config/long.c       | @subpage config_long       |
  * | config/mbtable.c    | @subpage config_mbtable    |
  * | config/number.c     | @subpage config_number     |
+ * | config/path.c       | @subpage config_path       |
  * | config/quad.c       | @subpage config_quad       |
  * | config/regex.c      | @subpage config_regex      |
  * | config/set.c        | @subpage config_set        |
@@ -55,6 +56,7 @@
 #include "long.h"
 #include "mbtable.h"
 #include "number.h"
+#include "path.h"
 #include "quad.h"
 #include "regex2.h"
 #include "set.h"

--- a/config/mbtable.c
+++ b/config/mbtable.c
@@ -108,6 +108,7 @@ static int mbtable_string_set(const struct ConfigSet *cs, void *var, struct Conf
   if (!cs || !cdef)
     return CSR_ERR_CODE; /* LCOV_EXCL_LINE */
 
+  /* Store empty strings as NULL */
   if (value && (value[0] == '\0'))
     value = NULL;
 

--- a/config/path.c
+++ b/config/path.c
@@ -56,7 +56,7 @@ static char *path_tidy(const char *path, bool is_dir)
   mutt_str_strfcpy(buf, path, sizeof(buf));
 
   mutt_path_tilde(buf, sizeof(buf), HomeDir);
-  mutt_path_tidy(buf);
+  mutt_path_tidy(buf, is_dir);
 
   return mutt_str_strdup(buf);
 }

--- a/config/path.c
+++ b/config/path.c
@@ -1,0 +1,278 @@
+/**
+ * @file
+ * Type representing a path
+ *
+ * @authors
+ * Copyright (C) 2020 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @page config_path Type: Path
+ *
+ * Type representing a path.
+ */
+
+#include "config.h"
+#include <stddef.h>
+#include <limits.h>
+#include <stdint.h>
+#include "mutt/lib.h"
+#include "path.h"
+#include "set.h"
+#include "types.h"
+
+extern char *HomeDir;
+
+/**
+ * path_tidy - Tidy a path for storage
+ * @param path   Path to be tidied
+ * @param is_dir Is the path a directory?
+ * @retval ptr Tidy path
+ *
+ * Expand `~` and remove junk like `/./`
+ *
+ * @note The caller must free the returned string
+ */
+static char *path_tidy(const char *path, bool is_dir)
+{
+  if (!path || !*path)
+    return NULL;
+
+  char buf[PATH_MAX] = { 0 };
+  mutt_str_strfcpy(buf, path, sizeof(buf));
+
+  mutt_path_tilde(buf, sizeof(buf), HomeDir);
+  mutt_path_tidy(buf);
+
+  return mutt_str_strdup(buf);
+}
+
+/**
+ * path_destroy - Destroy a Path - Implements ::cst_destroy()
+ */
+static void path_destroy(const struct ConfigSet *cs, void *var, const struct ConfigDef *cdef)
+{
+  if (!cs || !var || !cdef)
+    return; /* LCOV_EXCL_LINE */
+
+  const char **str = (const char **) var;
+  if (!*str)
+    return;
+
+  /* Don't free paths from the var definition */
+  if (*(char **) var == (char *) cdef->initial)
+  {
+    *(char **) var = NULL;
+    return;
+  }
+
+  FREE(var);
+}
+
+/**
+ * path_string_set - Set a Path by path - Implements ::cst_string_set()
+ */
+static int path_string_set(const struct ConfigSet *cs, void *var, struct ConfigDef *cdef,
+                           const char *value, struct Buffer *err)
+{
+  if (!cs || !cdef)
+    return CSR_ERR_CODE; /* LCOV_EXCL_LINE */
+
+  /* Store empty paths as NULL */
+  if (value && (value[0] == '\0'))
+    value = NULL;
+
+  if (!value && (cdef->type & DT_NOT_EMPTY))
+  {
+    mutt_buffer_printf(err, _("Option %s may not be empty"), cdef->name);
+    return CSR_ERR_INVALID | CSR_INV_VALIDATOR;
+  }
+
+  int rc = CSR_SUCCESS;
+
+  if (var)
+  {
+    if (mutt_str_strcmp(value, (*(char **) var)) == 0)
+      return CSR_SUCCESS | CSR_SUC_NO_CHANGE;
+
+    if (cdef->validator)
+    {
+      rc = cdef->validator(cs, cdef, (intptr_t) value, err);
+
+      if (CSR_RESULT(rc) != CSR_SUCCESS)
+        return rc | CSR_INV_VALIDATOR;
+    }
+
+    path_destroy(cs, var, cdef);
+
+    char *str = path_tidy(value, cdef->type & DT_PATH_DIR);
+    if (!str)
+      rc |= CSR_SUC_EMPTY;
+
+    *(char **) var = str;
+  }
+  else
+  {
+    /* we're already using the initial value */
+    if (*(char **) cdef->var == (char *) cdef->initial)
+      *(char **) cdef->var = mutt_str_strdup((char *) cdef->initial);
+
+    if (cdef->type & DT_INITIAL_SET)
+      FREE(&cdef->initial);
+
+    cdef->type |= DT_INITIAL_SET;
+    cdef->initial = IP mutt_str_strdup(value);
+  }
+
+  return rc;
+}
+
+/**
+ * path_string_get - Get a Path as a path - Implements ::cst_string_get()
+ */
+static int path_string_get(const struct ConfigSet *cs, void *var,
+                           const struct ConfigDef *cdef, struct Buffer *result)
+{
+  if (!cs || !cdef)
+    return CSR_ERR_CODE; /* LCOV_EXCL_LINE */
+
+  const char *str = NULL;
+
+  if (var)
+    str = *(const char **) var;
+  else
+    str = (char *) cdef->initial;
+
+  if (!str)
+    return CSR_SUCCESS | CSR_SUC_EMPTY; /* empty path */
+
+  mutt_buffer_addstr(result, str);
+  return CSR_SUCCESS;
+}
+
+/**
+ * path_native_set - Set a Path config item by path - Implements ::cst_native_set()
+ */
+static int path_native_set(const struct ConfigSet *cs, void *var,
+                           const struct ConfigDef *cdef, intptr_t value, struct Buffer *err)
+{
+  if (!cs || !var || !cdef)
+    return CSR_ERR_CODE; /* LCOV_EXCL_LINE */
+
+  char *str = (char *) value;
+
+  /* Store empty paths as NULL */
+  if (str && (str[0] == '\0'))
+    value = 0;
+
+  if ((value == 0) && (cdef->type & DT_NOT_EMPTY))
+  {
+    mutt_buffer_printf(err, _("Option %s may not be empty"), cdef->name);
+    return CSR_ERR_INVALID | CSR_INV_VALIDATOR;
+  }
+
+  if (mutt_str_strcmp((const char *) value, (*(char **) var)) == 0)
+    return CSR_SUCCESS | CSR_SUC_NO_CHANGE;
+
+  int rc;
+
+  if (cdef->validator)
+  {
+    rc = cdef->validator(cs, cdef, value, err);
+
+    if (CSR_RESULT(rc) != CSR_SUCCESS)
+      return rc | CSR_INV_VALIDATOR;
+  }
+
+  path_destroy(cs, var, cdef);
+
+  str = path_tidy(str, cdef->type & DT_PATH_DIR);
+  rc = CSR_SUCCESS;
+  if (!str)
+    rc |= CSR_SUC_EMPTY;
+
+  *(const char **) var = str;
+  return rc;
+}
+
+/**
+ * path_native_get - Get a path from a Path config item - Implements ::cst_native_get()
+ */
+static intptr_t path_native_get(const struct ConfigSet *cs, void *var,
+                                const struct ConfigDef *cdef, struct Buffer *err)
+{
+  if (!cs || !var || !cdef)
+    return INT_MIN; /* LCOV_EXCL_LINE */
+
+  const char *str = *(const char **) var;
+
+  return (intptr_t) str;
+}
+
+/**
+ * path_reset - Reset a Path to its initial value - Implements ::cst_reset()
+ */
+static int path_reset(const struct ConfigSet *cs, void *var,
+                      const struct ConfigDef *cdef, struct Buffer *err)
+{
+  if (!cs || !var || !cdef)
+    return CSR_ERR_CODE; /* LCOV_EXCL_LINE */
+
+  int rc = CSR_SUCCESS;
+
+  const char *str = path_tidy((const char *) cdef->initial, cdef->type & DT_PATH_DIR);
+  if (!str)
+    rc |= CSR_SUC_EMPTY;
+
+  if (mutt_str_strcmp(str, (*(char **) var)) == 0)
+  {
+    FREE(&str);
+    return rc | CSR_SUC_NO_CHANGE;
+  }
+
+  if (cdef->validator)
+  {
+    rc = cdef->validator(cs, cdef, cdef->initial, err);
+
+    if (CSR_RESULT(rc) != CSR_SUCCESS)
+    {
+      FREE(&str);
+      return rc | CSR_INV_VALIDATOR;
+    }
+  }
+
+  path_destroy(cs, var, cdef);
+
+  if (!str)
+    rc |= CSR_SUC_EMPTY;
+
+  *(const char **) var = str;
+  return rc;
+}
+
+/**
+ * path_init - Register the Path config type
+ * @param cs Config items
+ */
+void path_init(struct ConfigSet *cs)
+{
+  const struct ConfigSetType cst_path = {
+    "path",          path_string_set, path_string_get, path_native_set,
+    path_native_get, path_reset,      path_destroy,
+  };
+  cs_register_type(cs, DT_PATH, &cst_path);
+}

--- a/config/path.h
+++ b/config/path.h
@@ -1,0 +1,30 @@
+/**
+ * @file
+ * Type representing a path
+ *
+ * @authors
+ * Copyright (C) 2020 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MUTT_CONFIG_PATH_H
+#define MUTT_CONFIG_PATH_H
+
+struct ConfigSet;
+
+void path_init(struct ConfigSet *cs);
+
+#endif /* MUTT_CONFIG_PATH_H */

--- a/config/types.h
+++ b/config/types.h
@@ -28,17 +28,18 @@
 /* Data Types */
 #define DT_ADDRESS   1  ///< e-mail address
 #define DT_BOOL      2  ///< boolean option
-#define DT_ENUM      4  ///< an enumeration
-#define DT_HCACHE    5  ///< header cache backend
-#define DT_LONG      6  ///< a number (long)
-#define DT_MBTABLE   8  ///< multibyte char table
-#define DT_NUMBER    9  ///< a number
-#define DT_QUAD     11  ///< quad-option (no/yes/ask-no/ask-yes)
-#define DT_REGEX    12  ///< regular expressions
-#define DT_SLIST    13  ///< a list of strings
-#define DT_SORT     14  ///< sorting methods
-#define DT_STRING   15  ///< a string
-#define DT_SYNONYM  16  ///< synonym for another variable
+#define DT_ENUM      3  ///< an enumeration
+#define DT_HCACHE    4  ///< header cache backend
+#define DT_LONG      5  ///< a number (long)
+#define DT_MBTABLE   6  ///< multibyte char table
+#define DT_NUMBER    7  ///< a number
+#define DT_PATH      8  ///< a path to a file/directory
+#define DT_QUAD      9  ///< quad-option (no/yes/ask-no/ask-yes)
+#define DT_REGEX    10  ///< regular expressions
+#define DT_SLIST    11  ///< a list of strings
+#define DT_SORT     12  ///< sorting methods
+#define DT_STRING   13  ///< a string
+#define DT_SYNONYM  14  ///< synonym for another variable
 
 #define DTYPE(x) ((x) & 0x1F)  ///< Mask for the Data Type
 
@@ -46,10 +47,11 @@
 #define DT_NOT_NEGATIVE  (1 << 7)  ///< Negative numbers are not allowed
 #define DT_MAILBOX       (1 << 8)  ///< Don't perform path expansions
 #define DT_SENSITIVE     (1 << 9)  ///< Contains sensitive value, e.g. password
-#define DT_PATH          (1 << 10) ///< A pathname
-#define DT_COMMAND       (1 << 11) ///< A command
-#define DT_INHERIT_ACC   (1 << 12) ///< Config item can be Account-specific
-#define DT_INHERIT_MBOX  (1 << 13) ///< Config item can be Mailbox-specific
+#define DT_COMMAND       (1 << 10) ///< A command
+#define DT_INHERIT_ACC   (1 << 11) ///< Config item can be Account-specific
+#define DT_INHERIT_MBOX  (1 << 12) ///< Config item can be Mailbox-specific
+#define DT_PATH_DIR      (1 << 13) ///< Path is a directory
+#define DT_PATH_FILE     (1 << 14) ///< Path is a file
 
 #define IS_SENSITIVE(x) (((x).type & DT_SENSITIVE) == DT_SENSITIVE)
 #define IS_PATH(x)      (((x)->type & (DT_STRING | DT_PATH)) == (DT_STRING | DT_PATH))

--- a/config/types.h
+++ b/config/types.h
@@ -55,6 +55,7 @@
 
 #define IS_SENSITIVE(x) (((x).type & DT_SENSITIVE) == DT_SENSITIVE)
 #define IS_PATH(x)      (((x)->type & (DT_STRING | DT_PATH)) == (DT_STRING | DT_PATH))
+#define IS_MAILBOX(x)   (((x)->type & (DT_STRING | DT_MAILBOX)) == (DT_STRING | DT_MAILBOX))
 #define IS_COMMAND(x)   (((x)->type & (DT_STRING | DT_COMMAND)) == (DT_STRING | DT_COMMAND))
 
 /* subtypes for... */

--- a/config/types.h
+++ b/config/types.h
@@ -54,7 +54,6 @@
 #define DT_PATH_FILE     (1 << 14) ///< Path is a file
 
 #define IS_SENSITIVE(x) (((x).type & DT_SENSITIVE) == DT_SENSITIVE)
-#define IS_PATH(x)      (((x)->type & (DT_STRING | DT_PATH)) == (DT_STRING | DT_PATH))
 #define IS_MAILBOX(x)   (((x)->type & (DT_STRING | DT_MAILBOX)) == (DT_STRING | DT_MAILBOX))
 #define IS_COMMAND(x)   (((x)->type & (DT_STRING | DT_COMMAND)) == (DT_STRING | DT_COMMAND))
 

--- a/init.c
+++ b/init.c
@@ -1555,6 +1555,7 @@ struct ConfigSet *init_config(size_t size)
   long_init(cs);
   mbtable_init(cs);
   number_init(cs);
+  path_init(cs);
   quad_init(cs);
   regex_init(cs);
   slist_init(cs);

--- a/init.c
+++ b/init.c
@@ -1081,7 +1081,7 @@ int mutt_query_variables(struct ListHead *queries)
     }
 
     int type = DTYPE(he->type);
-    if (IS_PATH(he) && !(he->type & DT_MAILBOX))
+    if (type == DT_PATH)
       mutt_pretty_mailbox(value.data, value.dsize);
 
     if ((type != DT_BOOL) && (type != DT_NUMBER) && (type != DT_LONG) && (type != DT_QUAD))

--- a/maildir/shared.c
+++ b/maildir/shared.c
@@ -1655,7 +1655,7 @@ int maildir_path_canon(char *buf, size_t buflen)
   if (!buf)
     return -1;
 
-  mutt_path_canon(buf, buflen, HomeDir);
+  mutt_path_canon(buf, buflen, HomeDir, true);
   return 0;
 }
 
@@ -1670,7 +1670,7 @@ int maildir_path_pretty(char *buf, size_t buflen, const char *folder)
   if (mutt_path_abbr_folder(buf, buflen, folder))
     return 0;
 
-  if (mutt_path_pretty(buf, buflen, HomeDir))
+  if (mutt_path_pretty(buf, buflen, HomeDir, false))
     return 0;
 
   return -1;
@@ -1688,7 +1688,7 @@ int maildir_path_parent(char *buf, size_t buflen)
     return 0;
 
   if (buf[0] == '~')
-    mutt_path_canon(buf, buflen, HomeDir);
+    mutt_path_canon(buf, buflen, HomeDir, true);
 
   if (mutt_path_parent(buf, buflen))
     return 0;

--- a/main.c
+++ b/main.c
@@ -109,34 +109,6 @@ typedef uint8_t CliFlags;         ///< Flags for command line options, e.g. #MUT
 // clang-format on
 
 /**
- * reset_tilde - Temporary measure
- * @param cs Config Set
- */
-static void reset_tilde(struct ConfigSet *cs)
-{
-  static const char *names[] = {
-    "alias_file", "autocrypt_dir", "certificate_file",
-    "debug_file", "folder",        "history_file",
-    "mbox",       "newsrc",        "news_cache_dir",
-    "postponed",  "record",        "signature",
-  };
-
-  struct Buffer value = mutt_buffer_make(256);
-  for (size_t i = 0; i < mutt_array_size(names); i++)
-  {
-    struct HashElem *he = cs_get_elem(cs, names[i]);
-    if (!he)
-      continue;
-    mutt_buffer_reset(&value);
-    cs_he_initial_get(cs, he, &value);
-    mutt_buffer_expand_path_regex(&value, false);
-    cs_he_initial_set(cs, he, value.data, NULL);
-    cs_he_reset(cs, he, NULL);
-  }
-  mutt_buffer_dealloc(&value);
-}
-
-/**
  * mutt_exit - Leave NeoMutt NOW
  * @param code Value to return to the calling environment
  */
@@ -299,9 +271,6 @@ static void init_locale(void)
  */
 static bool get_user_info(struct ConfigSet *cs)
 {
-  mutt_str_replace(&Username, mutt_str_getenv("USER"));
-  mutt_str_replace(&HomeDir, mutt_str_getenv("HOME"));
-
   const char *shell = mutt_str_getenv("SHELL");
   if (shell)
     cs_str_initial_set(cs, "shell", shell, NULL);
@@ -539,6 +508,9 @@ int main(int argc, char *argv[], char *envp[])
     goto main_ok; // TEST04: neomutt -v
   }
 
+  mutt_str_replace(&Username, mutt_str_getenv("USER"));
+  mutt_str_replace(&HomeDir, mutt_str_getenv("HOME"));
+
   cs = init_config(500);
   if (!cs)
     goto main_curses;
@@ -555,8 +527,6 @@ int main(int argc, char *argv[], char *envp[])
     test_parse_set();
     goto main_ok;
   }
-
-  reset_tilde(cs);
 
   if (dfile)
   {

--- a/main.c
+++ b/main.c
@@ -129,7 +129,7 @@ static void reset_tilde(struct ConfigSet *cs)
       continue;
     mutt_buffer_reset(&value);
     cs_he_initial_get(cs, he, &value);
-    mutt_expand_path(value.data, value.dsize);
+    mutt_buffer_expand_path_regex(&value, false);
     cs_he_initial_set(cs, he, value.data, NULL);
     cs_he_reset(cs, he, NULL);
   }

--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -1721,7 +1721,7 @@ static int mbox_path_canon(char *buf, size_t buflen)
   if (!buf)
     return -1;
 
-  mutt_path_canon(buf, buflen, HomeDir);
+  mutt_path_canon(buf, buflen, HomeDir, false);
   return 0;
 }
 
@@ -1736,7 +1736,7 @@ static int mbox_path_pretty(char *buf, size_t buflen, const char *folder)
   if (mutt_path_abbr_folder(buf, buflen, folder))
     return 0;
 
-  if (mutt_path_pretty(buf, buflen, HomeDir))
+  if (mutt_path_pretty(buf, buflen, HomeDir, false))
     return 0;
 
   return -1;
@@ -1754,7 +1754,7 @@ static int mbox_path_parent(char *buf, size_t buflen)
     return 0;
 
   if (buf[0] == '~')
-    mutt_path_canon(buf, buflen, HomeDir);
+    mutt_path_canon(buf, buflen, HomeDir, false);
 
   if (mutt_path_parent(buf, buflen))
     return 0;

--- a/mutt/path.c
+++ b/mutt/path.c
@@ -157,16 +157,17 @@ bool mutt_path_tidy_dotdot(char *buf)
 /**
  * mutt_path_tidy - Remove unnecessary parts of a path
  * @param[in,out] buf Path to modify
+ * @param[in]     is_dir Is the path a directory?
  * @retval true Success
  *
  * Remove unnecessary dots and slashes from a path
  */
-bool mutt_path_tidy(char *buf)
+bool mutt_path_tidy(char *buf, bool is_dir)
 {
   if (!buf || (buf[0] != '/'))
     return false;
 
-  if (!mutt_path_tidy_slash(buf, true))
+  if (!mutt_path_tidy_slash(buf, is_dir))
     return false;
 
   return mutt_path_tidy_dotdot(buf);
@@ -174,19 +175,20 @@ bool mutt_path_tidy(char *buf)
 
 /**
  * mutt_path_pretty - Tidy a filesystem path
- * @param buf    Path to modify
- * @param buflen Length of the buffer
+ * @param buf     Path to modify
+ * @param buflen  Length of the buffer
  * @param homedir Home directory for '~' substitution
+ * @param is_dir  Is the path a directory?
  * @retval true Success
  *
  * Tidy a path and replace a home directory with '~'
  */
-bool mutt_path_pretty(char *buf, size_t buflen, const char *homedir)
+bool mutt_path_pretty(char *buf, size_t buflen, const char *homedir, bool is_dir)
 {
   if (!buf)
     return false;
 
-  mutt_path_tidy(buf);
+  mutt_path_tidy(buf, is_dir);
 
   size_t len = mutt_str_startswith(buf, homedir, CASE_MATCH);
   if (len == 0)
@@ -275,11 +277,12 @@ bool mutt_path_tilde(char *buf, size_t buflen, const char *homedir)
  * @param buf     Path to modify
  * @param buflen  Length of the buffer
  * @param homedir Home directory for '~' substitution
+ * @param is_dir  Is the path a directory?
  * @retval true Success
  *
  * Remove unnecessary dots and slashes from a path and expand '~'.
  */
-bool mutt_path_canon(char *buf, size_t buflen, const char *homedir)
+bool mutt_path_canon(char *buf, size_t buflen, const char *homedir, bool is_dir)
 {
   if (!buf)
     return false;
@@ -312,7 +315,7 @@ bool mutt_path_canon(char *buf, size_t buflen, const char *homedir)
     mutt_str_strfcpy(buf, result, buflen);
   }
 
-  if (!mutt_path_tidy(buf))
+  if (!mutt_path_tidy(buf, is_dir))
     return false;
 
   return true;

--- a/mutt/path.h
+++ b/mutt/path.h
@@ -30,15 +30,15 @@ struct Buffer;
 
 bool        mutt_path_abbr_folder(char *buf, size_t buflen, const char *folder);
 const char *mutt_path_basename(const char *f);
-bool        mutt_path_canon(char *buf, size_t buflen, const char *homedir);
+bool        mutt_path_canon(char *buf, size_t buflen, const char *homedir, bool is_dir);
 char *      mutt_path_concat(char *d, const char *dir, const char *fname, size_t l);
 char *      mutt_path_dirname(const char *path);
 char *      mutt_path_escape(const char *src);
 const char *mutt_path_getcwd(struct Buffer *cwd);
 bool        mutt_path_parent(char *buf, size_t buflen);
-bool        mutt_path_pretty(char *buf, size_t buflen, const char *homedir);
+bool        mutt_path_pretty(char *buf, size_t buflen, const char *homedir, bool is_dir);
 size_t      mutt_path_realpath(char *buf);
-bool        mutt_path_tidy(char *buf);
+bool        mutt_path_tidy(char *buf, bool is_dir);
 bool        mutt_path_tidy_dotdot(char *buf);
 bool        mutt_path_tidy_slash(char *buf, bool is_dir);
 bool        mutt_path_tilde(char *buf, size_t buflen, const char *homedir);

--- a/mutt_config.c
+++ b/mutt_config.c
@@ -128,7 +128,7 @@ struct ConfigDef MuttVars[] = {
   ** check only happens after the \fIfirst\fP edit of the file).  When set
   ** to \fIno\fP, composition will never be aborted.
   */
-  { "alias_file", DT_STRING|DT_PATH, &C_AliasFile, IP "~/.neomuttrc" },
+  { "alias_file", DT_PATH|DT_PATH_FILE, &C_AliasFile, IP "~/.neomuttrc" },
   /*
   ** .pp
   ** The default file in which to save aliases created by the
@@ -285,7 +285,7 @@ struct ConfigDef MuttVars[] = {
   ** .pp
   ** For an explanation of "soft-fill", see the $$index_format documentation.
   */
-  { "attach_save_dir", DT_STRING|DT_PATH, &C_AttachSaveDir, IP "./" },
+  { "attach_save_dir", DT_PATH|DT_PATH_DIR, &C_AttachSaveDir, IP "./" },
   /*
   ** .pp
   ** The directory where attachments are saved.
@@ -372,7 +372,7 @@ struct ConfigDef MuttVars[] = {
   ** .pp
   ** (Autocrypt only)
   */
-  { "autocrypt_dir", DT_STRING|DT_PATH, &C_AutocryptDir, IP "~/.mutt/autocrypt" },
+  { "autocrypt_dir", DT_PATH|DT_PATH_DIR, &C_AutocryptDir, IP "~/.mutt/autocrypt" },
   /*
   ** .pp
   ** This variable sets where autocrypt files are stored, including the GPG
@@ -461,7 +461,7 @@ struct ConfigDef MuttVars[] = {
   */
 #endif
 #ifdef USE_SSL
-  { "certificate_file", DT_STRING|DT_PATH, &C_CertificateFile, IP "~/.mutt_certificates" },
+  { "certificate_file", DT_PATH|DT_PATH_FILE, &C_CertificateFile, IP "~/.mutt_certificates" },
   /*
   ** .pp
   ** This variable specifies the file where the certificates you trust
@@ -845,7 +845,7 @@ struct ConfigDef MuttVars[] = {
   ** rest of the string are expanded in the \fIC\fP locale (that is in US
   ** English).
   */
-  { "debug_file", DT_STRING|DT_PATH, &C_DebugFile, IP "~/.neomuttdebug" },
+  { "debug_file", DT_PATH|DT_PATH_FILE, &C_DebugFile, IP "~/.neomuttdebug" },
   /*
   ** .pp
   ** Debug logging is controlled by the variables \fC$$debug_file\fP and \fC$$debug_level\fP.
@@ -1025,7 +1025,7 @@ struct ConfigDef MuttVars[] = {
   ** misinterpreting the line as a mbox message separator).
   */
 #ifdef USE_SSL_OPENSSL
-  { "entropy_file", DT_STRING|DT_PATH, &C_EntropyFile, 0 },
+  { "entropy_file", DT_PATH|DT_PATH_FILE, &C_EntropyFile, 0 },
   /*
   ** .pp
   ** The file which includes random data that is used to initialize SSL
@@ -1138,7 +1138,7 @@ struct ConfigDef MuttVars[] = {
   ** .pp
   ** If set, flagged messages can't be deleted.
   */
-  { "folder", DT_STRING|DT_PATH|DT_MAILBOX, &C_Folder, IP "~/Mail" },
+  { "folder", DT_STRING|DT_MAILBOX, &C_Folder, IP "~/Mail" },
   /*
   ** .pp
   ** Specifies the default location of your mailboxes.  A "+" or "=" at the
@@ -1377,7 +1377,7 @@ struct ConfigDef MuttVars[] = {
   ** The $$weed setting applies.
   */
 #ifdef USE_HCACHE
-  { "header_cache", DT_STRING|DT_PATH, &C_HeaderCache, 0 },
+  { "header_cache", DT_PATH, &C_HeaderCache, 0 },
   /*
   ** .pp
   ** This variable points to the header cache database. If the path points to
@@ -1496,7 +1496,7 @@ struct ConfigDef MuttVars[] = {
   ** the string history buffer per category. The buffer is cleared each time the
   ** variable is set.
   */
-  { "history_file", DT_STRING|DT_PATH, &C_HistoryFile, IP "~/.mutthistory" },
+  { "history_file", DT_PATH|DT_PATH_FILE, &C_HistoryFile, IP "~/.mutthistory" },
   /*
   ** .pp
   ** The file in which NeoMutt will save its history.
@@ -2083,7 +2083,7 @@ struct ConfigDef MuttVars[] = {
   ** the \fInot\fP operator "!".  Only files whose names match this mask
   ** will be shown. The match is always case-sensitive.
   */
-  { "mbox", DT_STRING|DT_PATH|DT_MAILBOX|R_INDEX|R_PAGER, &C_Mbox, IP "~/mbox" },
+  { "mbox", DT_STRING|DT_MAILBOX|R_INDEX|R_PAGER, &C_Mbox, IP "~/mbox" },
   /*
   ** .pp
   ** This specifies the folder into which read mail in your $$spoolfile
@@ -2129,7 +2129,7 @@ struct ConfigDef MuttVars[] = {
   ** every once in a while, since it can be a little slow
   ** (especially for large folders).
   */
-  { "message_cachedir", DT_STRING|DT_PATH, &C_MessageCachedir, 0 },
+  { "message_cachedir", DT_PATH|DT_PATH_DIR, &C_MessageCachedir, 0 },
   /*
   ** .pp
   ** Set this to a directory and NeoMutt will cache copies of messages from
@@ -2309,7 +2309,7 @@ struct ConfigDef MuttVars[] = {
   ** into this command.
   */
 #ifdef USE_NNTP
-  { "news_cache_dir", DT_STRING|DT_PATH, &C_NewsCacheDir, IP "~/.neomutt" },
+  { "news_cache_dir", DT_PATH|DT_PATH_DIR, &C_NewsCacheDir, IP "~/.neomutt" },
   /*
   ** .pp
   ** This variable pointing to directory where NeoMutt will save cached news
@@ -2333,7 +2333,7 @@ struct ConfigDef MuttVars[] = {
   ** .pp
   ** Character set of newsgroups descriptions.
   */
-  { "newsrc", DT_STRING|DT_PATH, &C_Newsrc, IP "~/.newsrc" },
+  { "newsrc", DT_PATH|DT_PATH_FILE, &C_Newsrc, IP "~/.newsrc" },
   /*
   ** .pp
   ** The file, containing info about subscribed newsgroups - names and
@@ -3131,7 +3131,7 @@ struct ConfigDef MuttVars[] = {
   ** Please use $$pgp_default_key or $$smime_default_key.
   ** (Crypto only)
   */
-  { "postponed", DT_STRING|DT_PATH|DT_MAILBOX|R_INDEX, &C_Postponed, IP "~/postponed" },
+  { "postponed", DT_STRING|DT_MAILBOX|R_INDEX, &C_Postponed, IP "~/postponed" },
   /*
   ** .pp
   ** NeoMutt allows you to indefinitely "$postpone sending a message" which
@@ -3313,7 +3313,7 @@ struct ConfigDef MuttVars[] = {
   ** .pp
   ** Also see $$postponed variable.
   */
-  { "record", DT_STRING|DT_PATH|DT_MAILBOX, &C_Record, IP "~/sent" },
+  { "record", DT_STRING|DT_MAILBOX, &C_Record, IP "~/sent" },
   /*
   ** .pp
   ** This specifies the file into which your outgoing messages should be
@@ -3833,7 +3833,7 @@ struct ConfigDef MuttVars[] = {
   ** unless you really know what you are doing, and are prepared to take
   ** some heat from netiquette guardians.
   */
-  { "signature", DT_STRING|DT_PATH, &C_Signature, IP "~/.signature" },
+  { "signature", DT_PATH|DT_PATH_FILE, &C_Signature, IP "~/.signature" },
   /*
   ** .pp
   ** Specifies the filename of your signature, which is appended to all
@@ -3917,14 +3917,14 @@ struct ConfigDef MuttVars[] = {
   ** \fIset\fP by default.
   ** (S/MIME only)
   */
-  { "smime_ca_location", DT_STRING|DT_PATH, &C_SmimeCaLocation, 0 },
+  { "smime_ca_location", DT_PATH|DT_PATH_FILE, &C_SmimeCaLocation, 0 },
   /*
   ** .pp
   ** This variable contains the name of either a directory, or a file which
   ** contains trusted certificates for use with OpenSSL.
   ** (S/MIME only)
   */
-  { "smime_certificates", DT_STRING|DT_PATH, &C_SmimeCertificates, 0 },
+  { "smime_certificates", DT_PATH|DT_PATH_DIR, &C_SmimeCertificates, 0 },
   /*
   ** .pp
   ** Since for S/MIME there is no pubring/secring as with PGP, NeoMutt has to handle
@@ -4067,7 +4067,7 @@ struct ConfigDef MuttVars[] = {
   ** (S/MIME only)
   */
 #ifdef CRYPT_BACKEND_CLASSIC_SMIME
-  { "smime_keys", DT_STRING|DT_PATH, &C_SmimeKeys, 0 },
+  { "smime_keys", DT_PATH|DT_PATH_DIR, &C_SmimeKeys, 0 },
   /*
   ** .pp
   ** Since for S/MIME there is no pubring/secring as with PGP, NeoMutt has to handle
@@ -4312,7 +4312,7 @@ struct ConfigDef MuttVars[] = {
   ** match will append to the previous, using this variable's value as a
   ** separator.
   */
-  { "spoolfile", DT_STRING|DT_PATH|DT_MAILBOX, &C_Spoolfile, 0 },
+  { "spoolfile", DT_STRING|DT_MAILBOX, &C_Spoolfile, 0 },
   /*
   ** .pp
   ** If your spool mailbox is in a non-default place where NeoMutt can't find
@@ -4324,7 +4324,7 @@ struct ConfigDef MuttVars[] = {
   */
 #ifdef USE_SSL
 #ifdef USE_SSL_GNUTLS
-  { "ssl_ca_certificates_file", DT_STRING|DT_PATH, &C_SslCaCertificatesFile, 0 },
+  { "ssl_ca_certificates_file", DT_PATH|DT_PATH_FILE, &C_SslCaCertificatesFile, 0 },
   /*
   ** .pp
   ** This variable specifies a file containing trusted CA certificates.
@@ -4348,7 +4348,7 @@ struct ConfigDef MuttVars[] = {
   ** syntax and more details. (Note: GnuTLS version 2.1.7 or higher is
   ** required.)
   */
-  { "ssl_client_cert", DT_STRING|DT_PATH, &C_SslClientCert, 0 },
+  { "ssl_client_cert", DT_PATH|DT_PATH_FILE, &C_SslClientCert, 0 },
   /*
   ** .pp
   ** The file containing a client certificate and its associated private
@@ -4651,7 +4651,7 @@ struct ConfigDef MuttVars[] = {
   ** .pp
   ** A value of zero or less will cause NeoMutt to never time out.
   */
-  { "tmpdir", DT_STRING|DT_PATH, &C_Tmpdir, IP "/tmp" },
+  { "tmpdir", DT_PATH|DT_PATH_DIR|DT_NOT_EMPTY, &C_Tmpdir, IP "/tmp" },
   /*
   ** .pp
   ** This variable allows you to specify where NeoMutt will place its
@@ -4675,7 +4675,7 @@ struct ConfigDef MuttVars[] = {
   ** .dt 7 .dd R .dd Your address appears in the "Reply-To:" header field but none of the above applies.
   ** .de
   */
-  { "trash", DT_STRING|DT_PATH|DT_MAILBOX, &C_Trash, 0 },
+  { "trash", DT_STRING|DT_MAILBOX, &C_Trash, 0 },
   /*
   ** .pp
   ** If set, this variable specifies the path of the trash folder where the

--- a/mutt_lua.c
+++ b/mutt_lua.c
@@ -172,6 +172,7 @@ static int lua_mutt_set(lua_State *l)
     case DT_ADDRESS:
     case DT_ENUM:
     case DT_MBTABLE:
+    case DT_PATH:
     case DT_REGEX:
     case DT_SLIST:
     case DT_SORT:
@@ -181,7 +182,7 @@ static int lua_mutt_set(lua_State *l)
       size_t val_size = lua_strlen(l, -1);
       struct Buffer value_buf = mutt_buffer_make(val_size);
       mutt_buffer_strcpy_n(&value_buf, value, val_size);
-      if (IS_PATH(he))
+      if (DTYPE(he->type) == DT_PATH)
         mutt_buffer_expand_path(&value_buf);
 
       int rv = cs_subset_he_string_set(NeoMutt->sub, he, value_buf.data, &err);

--- a/mx.c
+++ b/mx.c
@@ -1435,7 +1435,7 @@ int mx_path_canon(char *buf, size_t buflen, const char *folder, enum MailboxType
 
   if (ops->path_canon(buf, buflen) < 0)
   {
-    mutt_path_canon(buf, buflen, HomeDir);
+    mutt_path_canon(buf, buflen, HomeDir, true);
   }
 
   return 0;

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -22,6 +22,7 @@ config/enum.c
 config/long.c
 config/mbtable.c
 config/number.c
+config/path.c
 config/quad.c
 config/regex.c
 config/set.c

--- a/test/Makefile.autosetup
+++ b/test/Makefile.autosetup
@@ -87,6 +87,7 @@ CONFIG_OBJS	= test/config/account.o \
 		  test/config/long.o \
 		  test/config/mbtable.o \
 		  test/config/number.o \
+		  test/config/path.o \
 		  test/config/quad.o \
 		  test/config/regex.o \
 		  test/config/set.o \

--- a/test/config/dump.c
+++ b/test/config/dump.c
@@ -68,9 +68,9 @@ static struct ConfigDef Vars[] = {
   { "Elderberry", DT_ADDRESS,                        &VarElderberry, IP "elderberry@example.com", 0,            NULL },
   { "Fig",        DT_STRING|DT_COMMAND|DT_NOT_EMPTY, &VarFig,        IP "fig",                    0,            NULL },
   { "Guava",      DT_LONG,                           &VarGuava,      0,                           0,            NULL },
-  { "Hawthorn",   DT_ENUM,                           &VarHawthorn,   1,                           IP &MagicDef, NULL },
+  { "Hawthorn",   DT_ENUM,                           &VarHawthorn,   2,                           IP &MagicDef, NULL },
   { "Ilama",      DT_MBTABLE,                        &VarIlama,      0,                           0,            NULL },
-  { "Jackfruit",  DT_STRING|DT_PATH,                 &VarJackfruit,  IP "/etc/passwd",            0,            NULL },
+  { "Jackfruit",  DT_PATH|DT_PATH_FILE,              &VarJackfruit,  IP "/etc/passwd",            0,            NULL },
   { "Kumquat",    DT_QUAD,                           &VarKumquat,    0,                           0,            NULL },
   { "Lemon",      DT_REGEX,                          &VarLemon,      0,                           0,            NULL },
   { "Mango",      DT_SORT,                           &VarMango,      1,                           0,            NULL },
@@ -189,6 +189,7 @@ struct ConfigSet *create_sample_data(void)
   mbtable_init(cs);
   number_init(cs);
   quad_init(cs);
+  path_init(cs);
   regex_init(cs);
   sort_init(cs);
   string_init(cs);

--- a/test/config/dump.c
+++ b/test/config/dump.c
@@ -188,6 +188,7 @@ struct ConfigSet *create_sample_data(void)
   long_init(cs);
   mbtable_init(cs);
   number_init(cs);
+  path_init(cs);
   quad_init(cs);
   path_init(cs);
   regex_init(cs);

--- a/test/config/path.c
+++ b/test/config/path.c
@@ -1,0 +1,664 @@
+/**
+ * @file
+ * Test code for the Path object
+ *
+ * @authors
+ * Copyright (C) 2020 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define TEST_NO_MAIN
+#include "acutest.h"
+#include "config.h"
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include "mutt/lib.h"
+#include "config/common.h"
+#include "config/lib.h"
+#include "core/lib.h"
+
+static char *VarApple;
+static char *VarBanana;
+static char *VarCherry;
+static char *VarDamson;
+static char *VarElderberry;
+static char *VarFig;
+static char *VarGuava;
+static char *VarHawthorn;
+static char *VarIlama;
+static char *VarJackfruit;
+static char *VarKumquat;
+static char *VarLemon;
+static char *VarMango;
+static char *VarNectarine;
+static char *VarOlive;
+static char *VarPapaya;
+static char *VarQuince;
+static char *VarRaspberry;
+static char *VarStrawberry;
+
+// clang-format off
+static struct ConfigDef Vars[] = {
+  { "Apple",      DT_PATH,              &VarApple,      IP "apple",      0, NULL              }, /* test_initial_values */
+  { "Banana",     DT_PATH,              &VarBanana,     IP "banana",     0, NULL              },
+  { "Cherry",     DT_PATH,              &VarCherry,     IP "cherry",     0, NULL              },
+  { "Damson",     DT_PATH,              &VarDamson,     0,               0, NULL              }, /* test_string_set */
+  { "Elderberry", DT_PATH,              &VarElderberry, IP "elderberry", 0, NULL              },
+  { "Fig",        DT_PATH|DT_NOT_EMPTY, &VarFig,        IP "fig",        0, NULL              },
+  { "Guava",      DT_PATH,              &VarGuava,      0,               0, NULL              }, /* test_string_get */
+  { "Hawthorn",   DT_PATH,              &VarHawthorn,   IP "hawthorn",   0, NULL              },
+  { "Ilama",      DT_PATH,              &VarIlama,      0,               0, NULL              },
+  { "Jackfruit",  DT_PATH,              &VarJackfruit,  0,               0, NULL              }, /* test_native_set */
+  { "Kumquat",    DT_PATH,              &VarKumquat,    IP "kumquat",    0, NULL              },
+  { "Lemon",      DT_PATH|DT_NOT_EMPTY, &VarLemon,      IP "lemon",      0, NULL              },
+  { "Mango",      DT_PATH,              &VarMango,      0,               0, NULL              }, /* test_native_get */
+  { "Nectarine",  DT_PATH,              &VarNectarine,  IP "nectarine",  0, NULL              }, /* test_reset */
+  { "Olive",      DT_PATH,              &VarOlive,      IP "olive",      0, validator_fail    },
+  { "Papaya",     DT_PATH,              &VarPapaya,     IP "papaya",     0, validator_succeed }, /* test_validator */
+  { "Quince",     DT_PATH,              &VarQuince,     IP "quince",     0, validator_warn    },
+  { "Raspberry",  DT_PATH,              &VarRaspberry,  IP "raspberry",  0, validator_fail    },
+  { "Strawberry", DT_PATH,              &VarStrawberry, 0,               0, NULL              }, /* test_inherit */
+  { NULL },
+};
+// clang-format on
+
+static bool test_initial_values(struct ConfigSet *cs, struct Buffer *err)
+{
+  log_line(__func__);
+  TEST_MSG("Apple = %s\n", VarApple);
+  TEST_MSG("Banana = %s\n", VarBanana);
+
+  if (!TEST_CHECK(mutt_str_strcmp(VarApple, "apple") == 0))
+  {
+    TEST_MSG("Error: initial values were wrong\n");
+    return false;
+  }
+
+  if (!TEST_CHECK(mutt_str_strcmp(VarBanana, "banana") == 0))
+  {
+    TEST_MSG("Error: initial values were wrong\n");
+    return false;
+  }
+
+  cs_str_string_set(cs, "Apple", "car", err);
+  cs_str_string_set(cs, "Banana", NULL, err);
+
+  struct Buffer value;
+  mutt_buffer_init(&value);
+  value.dsize = 256;
+  value.data = mutt_mem_calloc(1, value.dsize);
+  mutt_buffer_reset(&value);
+
+  int rc;
+
+  mutt_buffer_reset(&value);
+  rc = cs_str_initial_get(cs, "Apple", &value);
+  if (!TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS))
+  {
+    TEST_MSG("%s\n", value.data);
+    FREE(&value.data);
+    return false;
+  }
+
+  if (!TEST_CHECK(mutt_str_strcmp(value.data, "apple") == 0))
+  {
+    TEST_MSG("Apple's initial value is wrong: '%s'\n", value.data);
+    FREE(&value.data);
+    return false;
+  }
+  TEST_MSG("Apple = '%s'\n", VarApple);
+  TEST_MSG("Apple's initial value is '%s'\n", value.data);
+
+  mutt_buffer_reset(&value);
+  rc = cs_str_initial_get(cs, "Banana", &value);
+  if (!TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS))
+  {
+    TEST_MSG("%s\n", value.data);
+    FREE(&value.data);
+    return false;
+  }
+
+  if (!TEST_CHECK(mutt_str_strcmp(value.data, "banana") == 0))
+  {
+    TEST_MSG("Banana's initial value is wrong: '%s'\n", value.data);
+    FREE(&value.data);
+    return false;
+  }
+  TEST_MSG("Banana = '%s'\n", VarBanana);
+  TEST_MSG("Banana's initial value is '%s'\n", NONULL(value.data));
+
+  mutt_buffer_reset(&value);
+  rc = cs_str_initial_set(cs, "Cherry", "train", &value);
+  if (!TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS))
+  {
+    TEST_MSG("%s\n", value.data);
+    FREE(&value.data);
+    return false;
+  }
+
+  mutt_buffer_reset(&value);
+  rc = cs_str_initial_set(cs, "Cherry", "plane", &value);
+  if (!TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS))
+  {
+    TEST_MSG("%s\n", value.data);
+    FREE(&value.data);
+    return false;
+  }
+
+  mutt_buffer_reset(&value);
+  rc = cs_str_initial_get(cs, "Cherry", &value);
+  if (!TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS))
+  {
+    TEST_MSG("%s\n", value.data);
+    FREE(&value.data);
+    return false;
+  }
+
+  TEST_MSG("Cherry = '%s'\n", VarCherry);
+  TEST_MSG("Cherry's initial value is '%s'\n", NONULL(value.data));
+
+  FREE(&value.data);
+  log_line(__func__);
+  return true;
+}
+
+static bool test_string_set(struct ConfigSet *cs, struct Buffer *err)
+{
+  log_line(__func__);
+
+  const char *valid[] = { "hello", "world", "world", "", NULL };
+  const char *name = "Damson";
+
+  int rc;
+  for (unsigned int i = 0; i < mutt_array_size(valid); i++)
+  {
+    mutt_buffer_reset(err);
+    rc = cs_str_string_set(cs, name, valid[i], err);
+    if (!TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS))
+    {
+      TEST_MSG("%s\n", err->data);
+      return false;
+    }
+
+    if (rc & CSR_SUC_NO_CHANGE)
+    {
+      TEST_MSG("Value of %s wasn't changed\n", name);
+      continue;
+    }
+
+    if (!TEST_CHECK(mutt_str_strcmp(VarDamson, valid[i]) == 0))
+    {
+      TEST_MSG("Value of %s wasn't changed\n", name);
+      return false;
+    }
+    TEST_MSG("%s = '%s', set by '%s'\n", name, NONULL(VarDamson), NONULL(valid[i]));
+    short_line();
+  }
+
+  name = "Fig";
+  mutt_buffer_reset(err);
+  rc = cs_str_string_set(cs, name, "", err);
+  if (TEST_CHECK(CSR_RESULT(rc) != CSR_SUCCESS))
+  {
+    TEST_MSG("Expected error: %s\n", err->data);
+  }
+  else
+  {
+    TEST_MSG("%s\n", err->data);
+    return false;
+  }
+
+  name = "Elderberry";
+  for (unsigned int i = 0; i < mutt_array_size(valid); i++)
+  {
+    short_line();
+    mutt_buffer_reset(err);
+    rc = cs_str_string_set(cs, name, valid[i], err);
+    if (!TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS))
+    {
+      TEST_MSG("%s\n", err->data);
+      return false;
+    }
+
+    if (rc & CSR_SUC_NO_CHANGE)
+    {
+      TEST_MSG("Value of %s wasn't changed\n", name);
+      continue;
+    }
+
+    if (!TEST_CHECK(mutt_str_strcmp(VarElderberry, valid[i]) == 0))
+    {
+      TEST_MSG("Value of %s wasn't changed\n", name);
+      return false;
+    }
+    TEST_MSG("%s = '%s', set by '%s'\n", name, NONULL(VarElderberry), NONULL(valid[i]));
+  }
+
+  log_line(__func__);
+  return true;
+}
+
+static bool test_string_get(struct ConfigSet *cs, struct Buffer *err)
+{
+  log_line(__func__);
+  const char *name = "Guava";
+
+  mutt_buffer_reset(err);
+  int rc = cs_str_string_get(cs, name, err);
+  if (!TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS))
+  {
+    TEST_MSG("Get failed: %s\n", err->data);
+    return false;
+  }
+  TEST_MSG("%s = '%s', '%s'\n", name, NONULL(VarGuava), err->data);
+
+  name = "Hawthorn";
+  mutt_buffer_reset(err);
+  rc = cs_str_string_get(cs, name, err);
+  if (!TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS))
+  {
+    TEST_MSG("Get failed: %s\n", err->data);
+    return false;
+  }
+  TEST_MSG("%s = '%s', '%s'\n", name, NONULL(VarHawthorn), err->data);
+
+  name = "Ilama";
+  rc = cs_str_string_set(cs, name, "ilama", err);
+  if (!TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS))
+    return false;
+
+  mutt_buffer_reset(err);
+  rc = cs_str_string_get(cs, name, err);
+  if (!TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS))
+  {
+    TEST_MSG("Get failed: %s\n", err->data);
+    return false;
+  }
+  TEST_MSG("%s = '%s', '%s'\n", name, NONULL(VarIlama), err->data);
+
+  log_line(__func__);
+  return true;
+}
+
+static bool test_native_set(struct ConfigSet *cs, struct Buffer *err)
+{
+  log_line(__func__);
+
+  const char *valid[] = { "hello", "world", "world", "", NULL };
+  const char *name = "Jackfruit";
+
+  int rc;
+  for (unsigned int i = 0; i < mutt_array_size(valid); i++)
+  {
+    mutt_buffer_reset(err);
+    rc = cs_str_native_set(cs, name, (intptr_t) valid[i], err);
+    if (!TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS))
+    {
+      TEST_MSG("%s\n", err->data);
+      return false;
+    }
+
+    if (rc & CSR_SUC_NO_CHANGE)
+    {
+      TEST_MSG("Value of %s wasn't changed\n", name);
+      continue;
+    }
+
+    if (!TEST_CHECK(mutt_str_strcmp(VarJackfruit, valid[i]) == 0))
+    {
+      TEST_MSG("Value of %s wasn't changed\n", name);
+      return false;
+    }
+    TEST_MSG("%s = '%s', set by '%s'\n", name, NONULL(VarJackfruit), NONULL(valid[i]));
+    short_line();
+  }
+
+  name = "Lemon";
+  mutt_buffer_reset(err);
+  rc = cs_str_native_set(cs, name, (intptr_t) "", err);
+  if (TEST_CHECK(CSR_RESULT(rc) != CSR_SUCCESS))
+  {
+    TEST_MSG("Expected error: %s\n", err->data);
+  }
+  else
+  {
+    TEST_MSG("%s\n", err->data);
+    return false;
+  }
+
+  name = "Kumquat";
+  for (unsigned int i = 0; i < mutt_array_size(valid); i++)
+  {
+    short_line();
+    mutt_buffer_reset(err);
+    rc = cs_str_native_set(cs, name, (intptr_t) valid[i], err);
+    if (!TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS))
+    {
+      TEST_MSG("%s\n", err->data);
+      return false;
+    }
+
+    if (rc & CSR_SUC_NO_CHANGE)
+    {
+      TEST_MSG("Value of %s wasn't changed\n", name);
+      continue;
+    }
+
+    if (!TEST_CHECK(mutt_str_strcmp(VarKumquat, valid[i]) == 0))
+    {
+      TEST_MSG("Value of %s wasn't changed\n", name);
+      return false;
+    }
+    TEST_MSG("%s = '%s', set by '%s'\n", name, NONULL(VarKumquat), NONULL(valid[i]));
+  }
+
+  log_line(__func__);
+  return true;
+}
+
+static bool test_native_get(struct ConfigSet *cs, struct Buffer *err)
+{
+  log_line(__func__);
+  const char *name = "Mango";
+
+  int rc = cs_str_string_set(cs, name, "mango", err);
+  if (!TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS))
+    return false;
+
+  mutt_buffer_reset(err);
+  intptr_t value = cs_str_native_get(cs, name, err);
+  if (!TEST_CHECK(mutt_str_strcmp(VarMango, (char *) value) == 0))
+  {
+    TEST_MSG("Get failed: %s\n", err->data);
+    return false;
+  }
+  TEST_MSG("%s = '%s', '%s'\n", name, VarMango, (char *) value);
+
+  log_line(__func__);
+  return true;
+}
+
+static bool test_reset(struct ConfigSet *cs, struct Buffer *err)
+{
+  log_line(__func__);
+
+  const char *name = "Nectarine";
+  mutt_buffer_reset(err);
+
+  TEST_MSG("Initial: %s = '%s'\n", name, VarNectarine);
+  int rc = cs_str_string_set(cs, name, "hello", err);
+  if (!TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS))
+    return false;
+  TEST_MSG("Set: %s = '%s'\n", name, VarNectarine);
+
+  rc = cs_str_reset(cs, name, err);
+  if (!TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS))
+  {
+    TEST_MSG("%s\n", err->data);
+    return false;
+  }
+
+  if (!TEST_CHECK(mutt_str_strcmp(VarNectarine, "nectarine") == 0))
+  {
+    TEST_MSG("Value of %s wasn't changed\n", name);
+    return false;
+  }
+
+  TEST_MSG("Reset: %s = '%s'\n", name, VarNectarine);
+
+  rc = cs_str_reset(cs, name, err);
+  if (!TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS))
+  {
+    TEST_MSG("%s\n", err->data);
+    return false;
+  }
+
+  name = "Olive";
+  mutt_buffer_reset(err);
+
+  TEST_MSG("Initial: %s = '%s'\n", name, VarOlive);
+  dont_fail = true;
+  rc = cs_str_string_set(cs, name, "hello", err);
+  if (!TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS))
+    return false;
+  TEST_MSG("Set: %s = '%s'\n", name, VarOlive);
+  dont_fail = false;
+
+  rc = cs_str_reset(cs, name, err);
+  if (TEST_CHECK(CSR_RESULT(rc) != CSR_SUCCESS))
+  {
+    TEST_MSG("Expected error: %s\n", err->data);
+  }
+  else
+  {
+    TEST_MSG("%s\n", err->data);
+    return false;
+  }
+
+  if (!TEST_CHECK(mutt_str_strcmp(VarOlive, "hello") == 0))
+  {
+    TEST_MSG("Value of %s changed\n", name);
+    return false;
+  }
+
+  TEST_MSG("Reset: %s = '%s'\n", name, VarOlive);
+
+  log_line(__func__);
+  return true;
+}
+
+static bool test_validator(struct ConfigSet *cs, struct Buffer *err)
+{
+  log_line(__func__);
+
+  const char *name = "Papaya";
+  mutt_buffer_reset(err);
+  int rc = cs_str_string_set(cs, name, "hello", err);
+  if (TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS))
+  {
+    TEST_MSG("%s\n", err->data);
+  }
+  else
+  {
+    TEST_MSG("%s\n", err->data);
+    return false;
+  }
+  TEST_MSG("Path: %s = %s\n", name, VarPapaya);
+
+  mutt_buffer_reset(err);
+  rc = cs_str_native_set(cs, name, IP "world", err);
+  if (TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS))
+  {
+    TEST_MSG("%s\n", err->data);
+  }
+  else
+  {
+    TEST_MSG("%s\n", err->data);
+    return false;
+  }
+  TEST_MSG("Native: %s = %s\n", name, VarPapaya);
+
+  name = "Quince";
+  mutt_buffer_reset(err);
+  rc = cs_str_string_set(cs, name, "hello", err);
+  if (TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS))
+  {
+    TEST_MSG("%s\n", err->data);
+  }
+  else
+  {
+    TEST_MSG("%s\n", err->data);
+    return false;
+  }
+  TEST_MSG("Path: %s = %s\n", name, VarQuince);
+
+  mutt_buffer_reset(err);
+  rc = cs_str_native_set(cs, name, IP "world", err);
+  if (TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS))
+  {
+    TEST_MSG("%s\n", err->data);
+  }
+  else
+  {
+    TEST_MSG("%s\n", err->data);
+    return false;
+  }
+  TEST_MSG("Native: %s = %s\n", name, VarQuince);
+
+  name = "Raspberry";
+  mutt_buffer_reset(err);
+  rc = cs_str_string_set(cs, name, "hello", err);
+  if (TEST_CHECK(CSR_RESULT(rc) != CSR_SUCCESS))
+  {
+    TEST_MSG("Expected error: %s\n", err->data);
+  }
+  else
+  {
+    TEST_MSG("%s\n", err->data);
+    return false;
+  }
+  TEST_MSG("Path: %s = %s\n", name, VarRaspberry);
+
+  mutt_buffer_reset(err);
+  rc = cs_str_native_set(cs, name, IP "world", err);
+  if (TEST_CHECK(CSR_RESULT(rc) != CSR_SUCCESS))
+  {
+    TEST_MSG("Expected error: %s\n", err->data);
+  }
+  else
+  {
+    TEST_MSG("%s\n", err->data);
+    return false;
+  }
+  TEST_MSG("Native: %s = %s\n", name, VarRaspberry);
+
+  log_line(__func__);
+  return true;
+}
+
+static void dump_native(struct ConfigSet *cs, const char *parent, const char *child)
+{
+  intptr_t pval = cs_str_native_get(cs, parent, NULL);
+  intptr_t cval = cs_str_native_get(cs, child, NULL);
+
+  TEST_MSG("%15s = %s\n", parent, (char *) pval);
+  TEST_MSG("%15s = %s\n", child, (char *) cval);
+}
+
+static bool test_inherit(struct ConfigSet *cs, struct Buffer *err)
+{
+  log_line(__func__);
+  bool result = false;
+
+  const char *account = "fruit";
+  const char *parent = "Strawberry";
+  char child[128];
+  snprintf(child, sizeof(child), "%s:%s", account, parent);
+
+  struct ConfigSubset *sub = cs_subset_new(NULL, NULL, NeoMutt->notify);
+  sub->cs = cs;
+  struct Account *a = account_new(account, sub);
+
+  struct HashElem *he = cs_subset_create_inheritance(a->sub, parent);
+  if (!he)
+  {
+    TEST_MSG("Error: %s\n", err->data);
+    goto ti_out;
+  }
+
+  // set parent
+  mutt_buffer_reset(err);
+  int rc = cs_str_string_set(cs, parent, "hello", err);
+  if (CSR_RESULT(rc) != CSR_SUCCESS)
+  {
+    TEST_MSG("Error: %s\n", err->data);
+    goto ti_out;
+  }
+  dump_native(cs, parent, child);
+
+  // set child
+  mutt_buffer_reset(err);
+  rc = cs_str_string_set(cs, child, "world", err);
+  if (CSR_RESULT(rc) != CSR_SUCCESS)
+  {
+    TEST_MSG("Error: %s\n", err->data);
+    goto ti_out;
+  }
+  dump_native(cs, parent, child);
+
+  // reset child
+  mutt_buffer_reset(err);
+  rc = cs_str_reset(cs, child, err);
+  if (CSR_RESULT(rc) != CSR_SUCCESS)
+  {
+    TEST_MSG("Error: %s\n", err->data);
+    goto ti_out;
+  }
+  dump_native(cs, parent, child);
+
+  // reset parent
+  mutt_buffer_reset(err);
+  rc = cs_str_reset(cs, parent, err);
+  if (CSR_RESULT(rc) != CSR_SUCCESS)
+  {
+    TEST_MSG("Error: %s\n", err->data);
+    goto ti_out;
+  }
+  dump_native(cs, parent, child);
+
+  log_line(__func__);
+  result = true;
+ti_out:
+  account_free(&a);
+  cs_subset_free(&sub);
+  return result;
+}
+
+void config_path(void)
+{
+  struct Buffer err;
+  mutt_buffer_init(&err);
+  err.dsize = 256;
+  err.data = mutt_mem_calloc(1, err.dsize);
+  mutt_buffer_reset(&err);
+
+  struct ConfigSet *cs = cs_new(30);
+  NeoMutt = neomutt_new(cs);
+
+  path_init(cs);
+  dont_fail = true;
+  if (!cs_register_variables(cs, Vars, 0))
+    return;
+  dont_fail = false;
+
+  notify_observer_add(NeoMutt->notify, log_observer, 0);
+
+  set_list(cs);
+
+  TEST_CHECK(test_initial_values(cs, &err));
+  TEST_CHECK(test_string_set(cs, &err));
+  TEST_CHECK(test_string_get(cs, &err));
+  TEST_CHECK(test_native_set(cs, &err));
+  TEST_CHECK(test_native_get(cs, &err));
+  TEST_CHECK(test_reset(cs, &err));
+  TEST_CHECK(test_validator(cs, &err));
+  TEST_CHECK(test_inherit(cs, &err));
+
+  neomutt_free(&NeoMutt);
+  cs_free(&cs);
+  FREE(&err.data);
+}

--- a/test/config/path.h
+++ b/test/config/path.h
@@ -1,0 +1,30 @@
+/**
+ * @file
+ * Test code for the Path object
+ *
+ * @authors
+ * Copyright (C) 2020 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _TEST_PATH_H
+#define _TEST_PATH_H
+
+#include <stdbool.h>
+
+void config_path(void);
+
+#endif /* _TEST_PATH_H */

--- a/test/main.c
+++ b/test/main.c
@@ -111,6 +111,7 @@
   NEOMUTT_TEST_ITEM(config_long)                                               \
   NEOMUTT_TEST_ITEM(config_mbtable)                                            \
   NEOMUTT_TEST_ITEM(config_number)                                             \
+  NEOMUTT_TEST_ITEM(config_path)                                               \
   NEOMUTT_TEST_ITEM(config_quad)                                               \
   NEOMUTT_TEST_ITEM(config_regex)                                              \
   NEOMUTT_TEST_ITEM(config_slist)                                              \

--- a/test/path/mutt_path_canon.c
+++ b/test/path/mutt_path_canon.c
@@ -30,6 +30,6 @@ void test_mutt_path_canon(void)
   // bool mutt_path_canon(char *buf, size_t buflen, const char *homedir);
 
   {
-    TEST_CHECK(!mutt_path_canon(NULL, 10, "apple"));
+    TEST_CHECK(!mutt_path_canon(NULL, 10, "apple", true));
   }
 }

--- a/test/path/mutt_path_pretty.c
+++ b/test/path/mutt_path_pretty.c
@@ -30,11 +30,11 @@ void test_mutt_path_pretty(void)
   // bool mutt_path_pretty(char *buf, size_t buflen, const char *homedir);
 
   {
-    TEST_CHECK(!mutt_path_pretty(NULL, 10, "apple"));
+    TEST_CHECK(!mutt_path_pretty(NULL, 10, "apple", true));
   }
 
   {
     char buf[32] = { 0 };
-    TEST_CHECK(!mutt_path_pretty(buf, sizeof(buf), NULL));
+    TEST_CHECK(!mutt_path_pretty(buf, sizeof(buf), NULL, true));
   }
 }

--- a/test/path/mutt_path_tidy.c
+++ b/test/path/mutt_path_tidy.c
@@ -136,7 +136,7 @@ void test_mutt_path_tidy(void)
   // clang-format on
 
   {
-    TEST_CHECK(!mutt_path_tidy(NULL));
+    TEST_CHECK(!mutt_path_tidy(NULL, true));
   }
 
   {
@@ -144,7 +144,7 @@ void test_mutt_path_tidy(void)
     for (size_t i = 0; i < mutt_array_size(tests); i++)
     {
       mutt_str_strfcpy(buf, tests[i][0], sizeof(buf));
-      mutt_path_tidy(buf);
+      mutt_path_tidy(buf, true);
       if (!TEST_CHECK(mutt_str_strcmp(buf, tests[i][1]) == 0))
       {
         TEST_MSG("Input:    %s", tests[i][0]);


### PR DESCRIPTION
Further sub-class some config items:

> alias_file, attach_save_dir, autocrypt_dir, certificate_file, debug_file, entropy_file, header_cache, history_file, message_cachedir, news_cache_dir, newsrc, signature, smime_ca_location, smime_certificates, smime_keys, ssl_ca_certificates_file, ssl_client_cert, tmpdir

Before, they had type `DT_STRING|DT_PATH`.
Even though they were labelled as Paths, they weren't treated any differently from strings.

Now, `DT_PATH` has been promoted to a full type, with sub-types: `DT_PATH_FILE` and `DT_PATH_DIR`.
When config values are stored, they will be tidied: `~` will be expanded, and junk like `//` or `/./` will be removed.

- 9212976282 config: add path type
- 44cc5f73b5 test: add config/path
- 81aef62c5c config: convert path variables
- 34c633d740 propagate is_dir
- 31127e2d49 drop reset_tilde
  A 'temporary' function that expanded `~` in the initial values for config items
