### PR TITLE
Add abort_key config option

### DIFF
--- a/globals.h
+++ b/globals.h
@@ -93,6 +93,7 @@ WHERE char *AutocryptDefaultKey; ///< Autocrypt default key id (used for postpon
 WHERE struct Address *C_EnvelopeFromAddress; ///< Config: Manually set the sender for outgoing messages
 WHERE struct Address *C_From;                ///< Config: Default 'From' address to use, if isn't otherwise set
 
+WHERE char *C_AbortKeyStr;                   ///< Config: String representation of key to abort prompts
 WHERE char *C_AliasFile;                     ///< Config: Save new aliases to this file
 WHERE char *C_Attribution;                   ///< Config: Message to start a reply, "On DATE, PERSON wrote:"
 WHERE char *C_AttributionLocale;             ///< Config: Locale for dates in the attribution message

--- a/gui/curs_lib.c
+++ b/gui/curs_lib.c
@@ -51,6 +51,7 @@
 #include "color.h"
 #include "enter_state.h"
 #include "globals.h"
+#include "keymap.h"
 #include "mutt_curses.h"
 #include "mutt_logging.h"
 #include "mutt_menu.h"
@@ -239,7 +240,7 @@ struct KeyEvent mutt_getch(void)
 
   ret.ch = ch;
   ret.op = 0;
-  return (ch == ctrl('G')) ? err : ret;
+  return (ch == AbortKey) ? err : ret;
 }
 
 /**

--- a/keymap.h
+++ b/keymap.h
@@ -98,6 +98,8 @@ struct Keymap *km_find_func(enum MenuType menu, int func);
 void km_init(void);
 void km_error_key(enum MenuType menu);
 void mutt_what_key(void);
+void mutt_init_abort_key(void);
+int mutt_abort_key_config_observer(struct NotifyCallback *nc);
 
 enum CommandResult km_bind(char *s, enum MenuType menu, int op, char *macro, char *desc);
 int km_dokey(enum MenuType menu);
@@ -105,6 +107,7 @@ int km_dokey(enum MenuType menu);
 extern struct Keymap *Keymaps[]; ///< Array of Keymap keybindings, one for each Menu
 
 extern int LastKey; ///< Last real key pressed, recorded by dokey()
+extern keycode_t AbortKey; ///< key to abort edits etc, normally Ctrl-G
 
 extern const struct Mapping Menus[];
 

--- a/main.c
+++ b/main.c
@@ -604,6 +604,8 @@ int main(int argc, char *argv[], char *envp[])
   if (rc2 != 0)
     goto main_curses;
 
+  mutt_init_abort_key();
+
   /* The command line overrides the config */
   if (dlevel)
     cs_str_reset(cs, "debug_level", NULL);
@@ -742,6 +744,7 @@ int main(int argc, char *argv[], char *envp[])
   notify_observer_add(NeoMutt->notify, mutt_log_observer, NULL);
   notify_observer_add(NeoMutt->notify, mutt_menu_config_observer, NULL);
   notify_observer_add(NeoMutt->notify, mutt_reply_observer, NULL);
+  notify_observer_add(NeoMutt->notify, mutt_abort_key_config_observer, NULL);
   if (Colors)
     notify_observer_add(Colors->notify, mutt_menu_color_observer, NULL);
 

--- a/mutt_config.c
+++ b/mutt_config.c
@@ -95,6 +95,26 @@ bool C_IgnoreLinearWhiteSpace = false;
 struct ConfigDef MuttVars[] = {
   /*++*/
 
+  { "abort_key", DT_STRING|DT_NOT_EMPTY, &C_AbortKeyStr, IP "\007" },
+  /*
+  ** .pp
+  ** Specifies the key that can be used to abort prompts.  The format is the
+  ** same as used in "bind" commands.  The default is equivalent to "\G".
+  ** Note that the specified key should not be used in other bindings, as the
+  ** abort operation has higher precedence and the binding will not have the
+  ** desired effect.
+  ** .pp
+  ** Example:
+  ** .ts
+  ** set abort_key = "<Esc>"
+  ** .te
+  ** .pp
+  ** Please note that when using <Esc> as the abort key, you may also want to
+  ** set the environment variable ESCDELAY to a low value or even 0 which will
+  ** reduce the time that ncurses waits to distinguish singular <Esc> key
+  ** presses from the start of a terminal escape sequence. The default time is
+  ** 1000 milliseconds and thus quite noticeable.
+  */
   { "abort_noattach", DT_QUAD, &C_AbortNoattach, MUTT_NO },
   /*
   ** .pp


### PR DESCRIPTION
* **What does this PR do?**
This PR adds the "abort_key" config option which can be used to change the key
used to abort prompts (previously unchangeable, now per default Ctrl-G). The
key can specified in the same format as bind/macro commands.

In contrast to previous work (see #1510) this PR replaces the code that previously explicitly checks for the keycode of Ctrl-G with checks against the keycode of the key specified by the newly introduced config option `abort_key`.  I propose this solution because I am under the impression that this abort behaviour is so low-level that it cannot be handled via an <abort> command that could be assigned using `bind`.

It should probably also be noted that this PR does not include any changes to the ncurses ESCDELAY (changable via environment variable or `set_escdelay`) to make using `Esc` as an abort key nicer to use. This is because the delay issue is (at least at its core) not related and it can be worked around by the user by starting neomutt using `ESCDELAY=0 neomutt`.

* **What are the relevant issue numbers?**
#1510, in principle also #1511, but this requires may more work, because Ctrl-C raises a SIGINT instead of being handled by the "normal" input system, I think.

Due to me not really being familiar with the code base, for some of these changes I was not sure where to best put them. (See for example mutt_init_abort_key which must happen after config parsing, in contrast to other keymap related initialization which apparently has to be performed before ncurses initialization.) Let me know if you have any thoughts on this.
