### PR TITLE
abort if run without a terminal

### DIFF
--- a/main.c
+++ b/main.c
@@ -1010,9 +1010,16 @@ int main(int argc, char *argv[], char *envp[])
       mutt_list_free(&attach);
     }
 
-    rv = ci_send_message(sendflags, e, bodyfile, NULL, NULL);
-    /* We WANT the "Mail sent." and any possible, later error */
-    log_queue_empty();
+    if (isatty(0))
+    {
+      rv = ci_send_message(sendflags, e, bodyfile, NULL, NULL);
+      /* We WANT the "Mail sent." and any possible, later error */
+      log_queue_empty();
+    }
+    else
+    {
+      mutt_error(_("Error initializing terminal"));
+    }
     if (ErrorBufMessage)
       mutt_message("%s", ErrorBuf);
 


### PR DESCRIPTION
Fixes: #2138

If NeoMutt is run **with** a `mailto` link, but **without** a terminal, e.g. from `xdg-open`,
then NeoMutt sends an empty email.  It doesn't give the user a chance to edit anything.

- Check we have a tty
- Make sure we log an error if we don't