### PR TITLE
add 'arrow_string' config variable

### DIFF
--- a/globals.h
+++ b/globals.h
@@ -192,6 +192,7 @@ WHERE unsigned char C_FollowupToPoster;      ///< Config: (nntp) Reply to the po
 #endif
 
 WHERE bool C_ArrowCursor;                    ///< Config: Use an arrow '->' instead of highlighting in the index
+WHERE char *C_ArrowString;                   ///< Config: Use an custom string for arrow_cursor
 WHERE bool C_AsciiChars;                     ///< Config: Use plain ASCII characters, when drawing email threads
 WHERE bool C_Askbcc;                         ///< Config: Ask the user for the blind-carbon-copy recipients
 WHERE bool C_Askcc;                          ///< Config: Ask the user for the carbon-copy recipients

--- a/menu.c
+++ b/menu.c
@@ -337,7 +337,7 @@ static void menu_make_entry(char *buf, size_t buflen, struct Menu *menu, int i)
 static void menu_pad_string(struct Menu *menu, char *buf, size_t buflen)
 {
   char *scratch = mutt_str_strdup(buf);
-  int shift = C_ArrowCursor ? 3 : 0;
+  int shift = C_ArrowCursor ? mutt_strwidth(C_ArrowString) + 1 : 0;
   int cols = menu->win_index->state.cols - shift;
 
   mutt_simple_format(buf, buflen, cols, cols, JUSTIFY_LEFT, ' ', scratch,
@@ -433,7 +433,7 @@ void menu_redraw_index(struct Menu *menu)
         mutt_curses_set_color(MT_COLOR_INDICATOR);
         if (C_ArrowCursor)
         {
-          mutt_window_addstr("->");
+          mutt_window_addstr(C_ArrowString);
           mutt_curses_set_attr(attr);
           mutt_window_addch(' ');
         }
@@ -441,7 +441,8 @@ void menu_redraw_index(struct Menu *menu)
           do_color = false;
       }
       else if (C_ArrowCursor)
-        mutt_window_addstr("   ");
+        /* Print space chars to match the screen width of C_ArrowString */
+        mutt_window_printf("%*s", mutt_strwidth(C_ArrowString) + 1, "");
 
       print_enriched_string(i, attr, (unsigned char *) buf, do_color);
     }
@@ -479,20 +480,21 @@ void menu_redraw_motion(struct Menu *menu)
 
   if (C_ArrowCursor)
   {
-    /* clear the pointer */
-    mutt_window_addstr("  ");
+    /* clear the arrow */
+    /* Print space chars to match the screen width of C_ArrowString */
+    mutt_window_printf("%*s", mutt_strwidth(C_ArrowString) + 1, "");
 
     if (menu->redraw & REDRAW_MOTION_RESYNC)
     {
       menu_make_entry(buf, sizeof(buf), menu, menu->oldcurrent);
       menu_pad_string(menu, buf, sizeof(buf));
-      mutt_window_move(menu->win_index, menu->oldcurrent + menu->offset - menu->top, 3);
+      mutt_window_move(menu->win_index, menu->oldcurrent + menu->offset - menu->top, mutt_strwidth(C_ArrowString) + 1);
       print_enriched_string(menu->oldcurrent, old_color, (unsigned char *) buf, true);
     }
 
     /* now draw it in the new location */
     mutt_curses_set_color(MT_COLOR_INDICATOR);
-    mutt_window_mvaddstr(menu->win_index, menu->current + menu->offset - menu->top, 0, "->");
+    mutt_window_mvaddstr(menu->win_index, menu->current + menu->offset - menu->top, 0, C_ArrowString);
   }
   else
   {
@@ -529,7 +531,7 @@ void menu_redraw_current(struct Menu *menu)
   mutt_curses_set_color(MT_COLOR_INDICATOR);
   if (C_ArrowCursor)
   {
-    mutt_window_addstr("->");
+    mutt_window_addstr(C_ArrowString);
     mutt_curses_set_attr(attr);
     mutt_window_addch(' ');
     menu_pad_string(menu, buf, sizeof(buf));

--- a/mutt_config.c
+++ b/mutt_config.c
@@ -215,6 +215,12 @@ struct ConfigDef MuttVars[] = {
   ** be redrawn on the screen when moving to the next or previous entries
   ** in the menu.
   */
+
+  { "arrow_string", DT_STRING|DT_NOT_EMPTY, &C_ArrowString, IP "->" },
+  /*
+  ** .pp
+  ** Specifies the string of arrow_cursor when arrow_cursor enabled.
+  */
   { "ascii_chars", DT_BOOL|R_INDEX|R_PAGER, &C_AsciiChars, false },
   /*
   ** .pp

--- a/muttlib.c
+++ b/muttlib.c
@@ -891,7 +891,7 @@ void mutt_expando_format(char *buf, size_t buflen, size_t col, int cols, const c
 
   prefix[0] = '\0';
   buflen--; /* save room for the terminal \0 */
-  wlen = ((flags & MUTT_FORMAT_ARROWCURSOR) && C_ArrowCursor) ? 3 : 0;
+  wlen = ((flags & MUTT_FORMAT_ARROWCURSOR) && C_ArrowCursor) ? mutt_strwidth(C_ArrowString) + 1 : 0;
   col += wlen;
 
   if ((flags & MUTT_FORMAT_NOFILTER) == 0)
@@ -1240,7 +1240,7 @@ void mutt_expando_format(char *buf, size_t buflen, size_t col, int cols, const c
           }
           else if (soft)
           {
-            int offset = ((flags & MUTT_FORMAT_ARROWCURSOR) && C_ArrowCursor) ? 3 : 0;
+            int offset = ((flags & MUTT_FORMAT_ARROWCURSOR) && C_ArrowCursor) ? mutt_strwidth(C_ArrowString) + 1 : 0;
             int avail_cols = (cols > offset) ? (cols - offset) : 0;
             /* \0-terminate buf for length computation in mutt_wstr_trunc() */
             *wptr = '\0';


### PR DESCRIPTION
* **What does this PR do?**
Adds new config option `arrow_string` which changes default `->` arrow_cursor

* **Screenshots (if relevant)**

* **Does this PR meet the acceptance criteria?** (This is just a reminder for you,
  this section can be removed if you fulfill it.)

   - Documentation created/updated (you have to edit
     [doc/manual.xml.head](https://www.github.com/neomutt/neomutt/blob/master/doc/manual.xml.head)
     for that)

        Actually I haven't found anything even about arrow_curor in manual.xml.head.

   - All builds and tests are passing

   - Added [doxygen code documentation](https://neomutt.org/dev/doxygen)
     [syntax](http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html)
no need for that
   - Code follows the [style guide](https://neomutt.org/dev/coding-style)