### PR TITLE
Allow controlling the "abort on backspace" feature

### DIFF
--- a/enter.c
+++ b/enter.c
@@ -304,7 +304,7 @@ int mutt_enter_string_full(char *buf, size_t buflen, int col,
           if (state->curpos == 0)
           {
             // Pressing backspace when no text is in the command prompt should exit the prompt
-            if (state->lastchar == 0)
+            if (C_AbortBackspace && (state->lastchar == 0))
               goto bye;
             // Pressing backspace with text in the command prompt should just beep
             mutt_beep(false);

--- a/globals.h
+++ b/globals.h
@@ -93,6 +93,7 @@ WHERE char *AutocryptDefaultKey; ///< Autocrypt default key id (used for postpon
 WHERE struct Address *C_EnvelopeFromAddress; ///< Config: Manually set the sender for outgoing messages
 WHERE struct Address *C_From;                ///< Config: Default 'From' address to use, if isn't otherwise set
 
+WHERE bool C_AbortBackspace;                 ///< Config: Hitting backspace against an empty prompt aborts the prompt
 WHERE char *C_AbortKeyStr;                   ///< Config: String representation of key to abort prompts
 WHERE char *C_AliasFile;                     ///< Config: Save new aliases to this file
 WHERE char *C_Attribution;                   ///< Config: Message to start a reply, "On DATE, PERSON wrote:"

--- a/mutt_config.c
+++ b/mutt_config.c
@@ -95,6 +95,12 @@ bool C_IgnoreLinearWhiteSpace = false;
 struct ConfigDef MuttVars[] = {
   /*++*/
 
+  { "abort_backspace", DT_BOOL, &C_AbortBackspace, true },
+  /*
+   ** .pp
+   ** If \fIset\fP, hitting backspace against an empty prompt aborts the
+   ** prompt.
+   */
   { "abort_key", DT_STRING|DT_NOT_EMPTY, &C_AbortKeyStr, IP "\007" },
   /*
   ** .pp


### PR DESCRIPTION
Fixes #2002

I have to admit I don't like the new behaviour either, I'm too used to hit backspace many time as a kill-line (yes I know shortcuts exist). Also, we have ctrl-g to abort a prompt. Let's at least allow users to opt-in / out.