### PR TITLE
Zstandard out of memory fix #2163

### DIFF
--- a/hcache/compr_lz4.c
+++ b/hcache/compr_lz4.c
@@ -70,7 +70,7 @@ static void *compr_lz4_compress(void *cctx, const char *data, size_t dlen, size_
   /* int LZ4_compress_fast(const char* src, char* dst, int srcSize, int dstCapacity, int acceleration); */
   *clen = LZ4_compress_fast(data, cbuf + 4, datalen, len, C_HeaderCacheCompressLevel);
   if (*clen < 0)
-    mutt_error("LZ4_compress_fast() failed!");
+    return NULL;
   *clen += 4;
 
   /* safe ulen to first 4 bytes */
@@ -107,7 +107,7 @@ static void *compr_lz4_decompress(void *cctx, const char *cbuf, size_t clen)
   const char *data = cbuf;
   int ret = LZ4_decompress_safe(data + 4, ubuf, clen - 4, ulen);
   if (ret < 0)
-    mutt_error("LZ4_decompress_safe() failed!");
+    return NULL;
 
   return ubuf;
 }

--- a/hcache/compr_zlib.c
+++ b/hcache/compr_zlib.c
@@ -70,7 +70,7 @@ static void *compr_zlib_compress(void *cctx, const char *data, size_t dlen, size
   const void *ubuf = data;
   int rc = compress2(cbuf, &len, ubuf, dlen, C_HeaderCacheCompressLevel);
   if (rc != Z_OK)
-    mutt_error("Zlib compress2() failed!");
+    return NULL;
   *clen = len + 4;
 
   /* safe ulen to first 4 bytes */
@@ -107,7 +107,7 @@ static void *compr_zlib_decompress(void *cctx, const char *cbuf, size_t clen)
   cs = (const unsigned char *) cbuf;
   int ret = uncompress(ubuf, &ulen, cs + 4, clen - 4);
   if (ret != Z_OK)
-    mutt_error("Zlib uncompress() failed!");
+    return NULL;
 
   return ubuf;
 }

--- a/hcache/compr_zstd.c
+++ b/hcache/compr_zstd.c
@@ -98,7 +98,7 @@ static void *compr_zstd_compress(void *cctx, const char *data, size_t dlen, size
 
   size_t ret;
   size_t len = ZSTD_compressBound(dlen);
-  mutt_mem_realloc(&ctx->buf, len);
+  mutt_mem_realloc_msg(&ctx->buf, len, _("Out of memory, please use smaller Levels for Zstandard or take LZ4."));
 
   if (ctx->cdict)
     ret = ZSTD_compress_usingCDict(ctx->cctx, ctx->buf, len, data, dlen, ctx->cdict);

--- a/hcache/compr_zstd.c
+++ b/hcache/compr_zstd.c
@@ -91,7 +91,7 @@ static void *compr_zstd_open(void)
  */
 static void *compr_zstd_compress(void *cctx, const char *data, size_t dlen, size_t *clen)
 {
-  if (!cctx || (dlen < 10))
+  if (!cctx)
     return NULL;
 
   struct ComprZstdCtx *ctx = cctx;
@@ -106,7 +106,7 @@ static void *compr_zstd_compress(void *cctx, const char *data, size_t dlen, size
     ret = ZSTD_compressCCtx(ctx->cctx, ctx->buf, len, data, dlen, C_HeaderCacheCompressLevel);
 
   if (ZSTD_isError(ret))
-    mutt_error("ZSTD_compress() failed!");
+    return NULL;
 
   *clen = ret;
 
@@ -120,6 +120,9 @@ static void *compr_zstd_decompress(void *cctx, const char *cbuf, size_t clen)
 {
   struct ComprZstdCtx *ctx = cctx;
 
+  if (!cctx || clen < 8)
+    return NULL;
+
   size_t ret;
   size_t len = ZSTD_getFrameContentSize(cbuf, clen);
   mutt_mem_realloc(&ctx->buf, len);
@@ -130,7 +133,7 @@ static void *compr_zstd_decompress(void *cctx, const char *cbuf, size_t clen)
     ret = ZSTD_decompressDCtx(ctx->dctx, ctx->buf, len, cbuf, clen);
 
   if (ZSTD_isError(ret))
-    mutt_error("ZSTD_decompress() failed!");
+    return NULL;
 
   return ctx->buf;
 }

--- a/hcache/lib.h
+++ b/hcache/lib.h
@@ -173,6 +173,9 @@ int mutt_hcache_delete_header(header_cache_t *hc, const char *key, size_t keylen
  * @note The returned string must be free'd by the caller
  */
 const char *mutt_hcache_backend_list(void);
+#ifdef USE_HCACHE_COMPRESSION
+const char *mutt_hcache_compress_list(void);
+#endif
 
 bool mutt_hcache_is_valid_backend(const char *s);
 bool mutt_hcache_is_valid_compression(const char *s);

--- a/mutt/memory.c
+++ b/mutt/memory.c
@@ -105,13 +105,14 @@ void *mutt_mem_malloc(size_t size)
  * mutt_mem_realloc - Resize a block of memory on the heap
  * @param ptr Memory block to resize
  * @param size New size
+ * @param msg Message to be displayed before exiting
  *
  * @note This function will never return NULL.
  *       It will print an error and exit the program.
  *
  * If the new size is zero, the block will be freed.
  */
-void mutt_mem_realloc(void *ptr, size_t size)
+void mutt_mem_realloc_msg(void *ptr, size_t size, const char *msg)
 {
   if (!ptr)
     return;
@@ -131,9 +132,24 @@ void mutt_mem_realloc(void *ptr, size_t size)
   void *r = realloc(*p, size);
   if (!r)
   {
-    mutt_error(_("Out of memory"));
+    mutt_error(msg);
     mutt_exit(1);
   }
 
   *p = r;
+}
+
+/**
+ * mutt_mem_realloc - Resize a block of memory on the heap
+ * @param ptr Memory block to resize
+ * @param size New size
+ *
+ * @note This function will never return NULL.
+ *       It will print an error and exit the program.
+ *
+ * If the new size is zero, the block will be freed.
+ */
+void mutt_mem_realloc(void *ptr, size_t size)
+{
+  mutt_mem_realloc_msg(ptr, size, _("Out of memory"));
 }

--- a/mutt/memory.h
+++ b/mutt/memory.h
@@ -36,6 +36,7 @@ void *mutt_mem_calloc(size_t nmemb, size_t size);
 void  mutt_mem_free(void *ptr);
 void *mutt_mem_malloc(size_t size);
 void  mutt_mem_realloc(void *ptr, size_t size);
+void  mutt_mem_realloc_msg(void *ptr, size_t size, const char *emsg);
 
 #define FREE(x) mutt_mem_free(x)
 

--- a/version.c
+++ b/version.c
@@ -51,6 +51,7 @@
 const char *mutt_make_version(void);
 /* #include "hcache/lib.h" */
 const char *mutt_hcache_backend_list(void);
+const char *mutt_hcache_compress_list(void);
 
 const int SCREEN_WIDTH = 80;
 
@@ -450,6 +451,11 @@ void print_version(FILE *fp)
   const char *backends = mutt_hcache_backend_list();
   fprintf(fp, "\nhcache backends: %s", backends);
   FREE(&backends);
+#ifdef USE_HCACHE_COMPRESSION
+  backends = mutt_hcache_compress_list();
+  fprintf(fp, "\nhcache compression: %s", backends);
+  FREE(&backends);
+#endif
 #endif
 
   rstrip_in_place((char *) configure_options);


### PR DESCRIPTION
* **What does this PR do?**

NeoMutt should abort and print a message with the error... this is done by this fix now.
