### PR TITLE
Tidy API functions

### DIFF
--- a/addrbook.c
+++ b/addrbook.c
@@ -186,7 +186,7 @@ static int alias_sort_address(const void *a, const void *b)
 }
 
 /**
- * mutt_dlg_alias_observer - Listen for config changes affecting the Alias menu - Implements ::observer_t()
+ * mutt_dlg_alias_observer - Listen for config changes affecting the Alias menu - Implements ::observer_t
  */
 static int mutt_dlg_alias_observer(struct NotifyCallback *nc)
 {

--- a/addrbook.c
+++ b/addrbook.c
@@ -106,7 +106,7 @@ static const char *alias_format_str(char *buf, size_t buflen, size_t col, int co
 }
 
 /**
- * alias_make_entry - Format a menu item for the alias list - Implements Menu::menu_make_entry()
+ * alias_make_entry - Format a menu item for the alias list - Implements Menu::make_entry()
  */
 static void alias_make_entry(char *buf, size_t buflen, struct Menu *menu, int line)
 {
@@ -117,7 +117,7 @@ static void alias_make_entry(char *buf, size_t buflen, struct Menu *menu, int li
 }
 
 /**
- * alias_tag - Tag some aliases - Implements Menu::menu_tag()
+ * alias_tag - Tag some aliases - Implements Menu::tag()
  */
 static int alias_tag(struct Menu *menu, int sel, int act)
 {
@@ -274,8 +274,8 @@ void mutt_alias_menu(char *buf, size_t buflen, struct AliasList *aliases)
   menu->win_index = index;
   menu->win_ibar = ibar;
 
-  menu->menu_make_entry = alias_make_entry;
-  menu->menu_tag = alias_tag;
+  menu->make_entry = alias_make_entry;
+  menu->tag = alias_tag;
   menu->title = _("Aliases");
   menu->help = mutt_compile_help(helpstr, sizeof(helpstr), MENU_ALIAS, AliasHelp);
   mutt_menu_push_current(menu);

--- a/autocrypt/autocrypt_acct_menu.c
+++ b/autocrypt/autocrypt_acct_menu.c
@@ -148,13 +148,13 @@ static const char *account_format_str(char *dest, size_t destlen, size_t col, in
 }
 
 /**
- * account_entry - Create a line for the Autocrypt account menu
+ * account_make_entry - Create a line for the Autocrypt account menu - Implements Menu::make_entry()
  * @param buf    Buffer to save the string
  * @param buflen Length of the buffer
  * @param menu   Menu to use
  * @param num    Line in the Menu
  */
-static void account_entry(char *buf, size_t buflen, struct Menu *menu, int num)
+static void account_make_entry(char *buf, size_t buflen, struct Menu *menu, int num)
 {
   struct AccountEntry *entry = &((struct AccountEntry *) menu->data)[num];
 
@@ -176,7 +176,7 @@ static struct Menu *create_menu(void)
     return NULL;
 
   struct Menu *menu = mutt_menu_new(MENU_AUTOCRYPT_ACCT);
-  menu->menu_make_entry = account_entry;
+  menu->make_entry = account_make_entry;
   /* menu->tag = account_tag; */
   // L10N: Autocrypt Account Management Menu title
   menu->title = _("Autocrypt Accounts");

--- a/browser.c
+++ b/browser.c
@@ -1146,7 +1146,7 @@ void mutt_browser_select_dir(const char *f)
 }
 
 /**
- * mutt_dlg_browser_observer - Listen for config changes affecting the Browser menu - Implements ::observer_t()
+ * mutt_dlg_browser_observer - Listen for config changes affecting the Browser menu - Implements ::observer_t
  */
 static int mutt_dlg_browser_observer(struct NotifyCallback *nc)
 {

--- a/browser.c
+++ b/browser.c
@@ -933,7 +933,7 @@ static int examine_mailboxes(struct Menu *menu, struct BrowserState *state)
 }
 
 /**
- * select_file_search - Menu search callback for matching files - Implements Menu::menu_search()
+ * select_file_search - Menu search callback for matching files - Implements Menu::search()
  */
 static int select_file_search(struct Menu *menu, regex_t *rx, int line)
 {
@@ -948,7 +948,7 @@ static int select_file_search(struct Menu *menu, regex_t *rx, int line)
 }
 
 /**
- * folder_make_entry - Format a menu item for the folder browser - Implements Menu::menu_make_entry()
+ * folder_make_entry - Format a menu item for the folder browser - Implements Menu::make_entry()
  */
 static void folder_make_entry(char *buf, size_t buflen, struct Menu *menu, int line)
 {
@@ -1106,7 +1106,7 @@ static void init_menu(struct BrowserState *state, struct Menu *menu,
 }
 
 /**
- * file_tag - Tag an entry in the menu - Implements Menu::menu_tag()
+ * file_tag - Tag an entry in the menu - Implements Menu::tag()
  */
 static int file_tag(struct Menu *menu, int sel, int act)
 {
@@ -1419,12 +1419,12 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
   menu->win_index = index;
   menu->win_ibar = ibar;
 
-  menu->menu_make_entry = folder_make_entry;
-  menu->menu_search = select_file_search;
+  menu->make_entry = folder_make_entry;
+  menu->search = select_file_search;
   menu->title = title;
   menu->data = state.entry;
   if (multiple)
-    menu->menu_tag = file_tag;
+    menu->tag = file_tag;
 
   menu->help = mutt_compile_help(helpstr, sizeof(helpstr), MENU_FOLDER,
 #ifdef USE_NNTP

--- a/command_parse.c
+++ b/command_parse.c
@@ -81,7 +81,7 @@ enum GroupState
 };
 
 /**
- * parse_unreplace_list - Remove a string replacement rule - Implements ::command_t
+ * parse_unreplace_list - Remove a string replacement rule - Implements Command::parse()
  */
 static enum CommandResult parse_unreplace_list(struct Buffer *buf, struct Buffer *s,
                                                unsigned long data, struct Buffer *err)
@@ -208,7 +208,7 @@ static void clear_subject_mods(void)
 }
 
 /**
- * parse_replace_list - Parse a string replacement rule - Implements ::command_t
+ * parse_replace_list - Parse a string replacement rule - Implements Command::parse()
  */
 static enum CommandResult parse_replace_list(struct Buffer *buf, struct Buffer *s,
                                              unsigned long data, struct Buffer *err)
@@ -561,7 +561,7 @@ int source_rc(const char *rcfile_path, struct Buffer *err)
 }
 
 /**
- * parse_alias - Parse the 'alias' command - Implements ::command_t
+ * parse_alias - Parse the 'alias' command - Implements Command::parse()
  */
 enum CommandResult parse_alias(struct Buffer *buf, struct Buffer *s,
                                unsigned long data, struct Buffer *err)
@@ -646,7 +646,7 @@ bail:
 }
 
 /**
- * parse_alternates - Parse the 'alternates' command - Implements ::command_t
+ * parse_alternates - Parse the 'alternates' command - Implements Command::parse()
  */
 enum CommandResult parse_alternates(struct Buffer *buf, struct Buffer *s,
                                     unsigned long data, struct Buffer *err)
@@ -680,7 +680,7 @@ bail:
 }
 
 /**
- * parse_attachments - Parse the 'attachments' command - Implements ::command_t
+ * parse_attachments - Parse the 'attachments' command - Implements Command::parse()
  */
 enum CommandResult parse_attachments(struct Buffer *buf, struct Buffer *s,
                                      unsigned long data, struct Buffer *err)
@@ -741,7 +741,7 @@ enum CommandResult parse_attachments(struct Buffer *buf, struct Buffer *s,
 }
 
 /**
- * parse_echo - Parse the 'echo' command - Implements ::command_t
+ * parse_echo - Parse the 'echo' command - Implements Command::parse()
  */
 enum CommandResult parse_echo(struct Buffer *buf, struct Buffer *s,
                               unsigned long data, struct Buffer *err)
@@ -761,7 +761,7 @@ enum CommandResult parse_echo(struct Buffer *buf, struct Buffer *s,
 }
 
 /**
- * parse_finish - Parse the 'finish' command - Implements ::command_t
+ * parse_finish - Parse the 'finish' command - Implements Command::parse()
  * @retval  #MUTT_CMD_FINISH Stop processing the current file
  * @retval  #MUTT_CMD_WARNING Failed
  *
@@ -780,7 +780,7 @@ enum CommandResult parse_finish(struct Buffer *buf, struct Buffer *s,
 }
 
 /**
- * parse_group - Parse the 'group' and 'ungroup' commands - Implements ::command_t
+ * parse_group - Parse the 'group' and 'ungroup' commands - Implements Command::parse()
  */
 enum CommandResult parse_group(struct Buffer *buf, struct Buffer *s,
                                unsigned long data, struct Buffer *err)
@@ -866,7 +866,7 @@ warn:
 }
 
 /**
- * parse_ifdef - Parse the 'ifdef' and 'ifndef' commands - Implements ::command_t
+ * parse_ifdef - Parse the 'ifdef' and 'ifndef' commands - Implements Command::parse()
  *
  * The 'ifdef' command allows conditional elements in the config file.
  * If a given variable, function, command or compile-time symbol exists, then
@@ -917,7 +917,7 @@ enum CommandResult parse_ifdef(struct Buffer *buf, struct Buffer *s,
 }
 
 /**
- * parse_ignore - Parse the 'ignore' command - Implements ::command_t
+ * parse_ignore - Parse the 'ignore' command - Implements Command::parse()
  */
 enum CommandResult parse_ignore(struct Buffer *buf, struct Buffer *s,
                                 unsigned long data, struct Buffer *err)
@@ -933,7 +933,7 @@ enum CommandResult parse_ignore(struct Buffer *buf, struct Buffer *s,
 }
 
 /**
- * parse_lists - Parse the 'lists' command - Implements ::command_t
+ * parse_lists - Parse the 'lists' command - Implements Command::parse()
  */
 enum CommandResult parse_lists(struct Buffer *buf, struct Buffer *s,
                                unsigned long data, struct Buffer *err)
@@ -965,7 +965,7 @@ bail:
 }
 
 /**
- * parse_mailboxes - Parse the 'mailboxes' command - Implements ::command_t
+ * parse_mailboxes - Parse the 'mailboxes' command - Implements Command::parse()
  *
  * This is also used by 'virtual-mailboxes'.
  */
@@ -1061,7 +1061,7 @@ enum CommandResult parse_mailboxes(struct Buffer *buf, struct Buffer *s,
 }
 
 /**
- * parse_my_hdr - Parse the 'my_hdr' command - Implements ::command_t
+ * parse_my_hdr - Parse the 'my_hdr' command - Implements Command::parse()
  */
 enum CommandResult parse_my_hdr(struct Buffer *buf, struct Buffer *s,
                                 unsigned long data, struct Buffer *err)
@@ -1106,7 +1106,7 @@ enum CommandResult parse_my_hdr(struct Buffer *buf, struct Buffer *s,
 
 #ifdef USE_SIDEBAR
 /**
- * parse_path_list - Parse the 'sidebar_whitelist' command - Implements ::command_t
+ * parse_path_list - Parse the 'sidebar_whitelist' command - Implements Command::parse()
  */
 enum CommandResult parse_path_list(struct Buffer *buf, struct Buffer *s,
                                    unsigned long data, struct Buffer *err)
@@ -1127,7 +1127,7 @@ enum CommandResult parse_path_list(struct Buffer *buf, struct Buffer *s,
 
 #ifdef USE_SIDEBAR
 /**
- * parse_path_unlist - Parse the 'unsidebar_whitelist' command - Implements ::command_t
+ * parse_path_unlist - Parse the 'unsidebar_whitelist' command - Implements Command::parse()
  */
 enum CommandResult parse_path_unlist(struct Buffer *buf, struct Buffer *s,
                                      unsigned long data, struct Buffer *err)
@@ -1153,7 +1153,7 @@ enum CommandResult parse_path_unlist(struct Buffer *buf, struct Buffer *s,
 #endif
 
 /**
- * parse_set - Parse the 'set' family of commands - Implements ::command_t
+ * parse_set - Parse the 'set' family of commands - Implements Command::parse()
  *
  * This is used by 'reset', 'set', 'toggle' and 'unset'.
  */
@@ -1477,7 +1477,7 @@ enum CommandResult parse_set(struct Buffer *buf, struct Buffer *s,
 }
 
 /**
- * parse_setenv - Parse the 'setenv' and 'unsetenv' commands - Implements ::command_t
+ * parse_setenv - Parse the 'setenv' and 'unsetenv' commands - Implements Command::parse()
  */
 enum CommandResult parse_setenv(struct Buffer *buf, struct Buffer *s,
                                 unsigned long data, struct Buffer *err)
@@ -1560,7 +1560,7 @@ enum CommandResult parse_setenv(struct Buffer *buf, struct Buffer *s,
 }
 
 /**
- * parse_source - Parse the 'source' command - Implements ::command_t
+ * parse_source - Parse the 'source' command - Implements Command::parse()
  */
 enum CommandResult parse_source(struct Buffer *buf, struct Buffer *s,
                                 unsigned long data, struct Buffer *err)
@@ -1589,7 +1589,7 @@ enum CommandResult parse_source(struct Buffer *buf, struct Buffer *s,
 }
 
 /**
- * parse_spam_list - Parse the 'spam' and 'nospam' commands - Implements ::command_t
+ * parse_spam_list - Parse the 'spam' and 'nospam' commands - Implements Command::parse()
  */
 enum CommandResult parse_spam_list(struct Buffer *buf, struct Buffer *s,
                                    unsigned long data, struct Buffer *err)
@@ -1665,7 +1665,7 @@ enum CommandResult parse_spam_list(struct Buffer *buf, struct Buffer *s,
 }
 
 /**
- * parse_stailq - Parse a list command - Implements ::command_t
+ * parse_stailq - Parse a list command - Implements Command::parse()
  *
  * This is used by 'alternative_order', 'auto_view' and several others.
  */
@@ -1682,7 +1682,7 @@ enum CommandResult parse_stailq(struct Buffer *buf, struct Buffer *s,
 }
 
 /**
- * parse_subjectrx_list - Parse the 'subjectrx' command - Implements ::command_t
+ * parse_subjectrx_list - Parse the 'subjectrx' command - Implements Command::parse()
  */
 enum CommandResult parse_subjectrx_list(struct Buffer *buf, struct Buffer *s,
                                         unsigned long data, struct Buffer *err)
@@ -1696,7 +1696,7 @@ enum CommandResult parse_subjectrx_list(struct Buffer *buf, struct Buffer *s,
 }
 
 /**
- * parse_subscribe - Parse the 'subscribe' command - Implements ::command_t
+ * parse_subscribe - Parse the 'subscribe' command - Implements Command::parse()
  */
 enum CommandResult parse_subscribe(struct Buffer *buf, struct Buffer *s,
                                    unsigned long data, struct Buffer *err)
@@ -1731,7 +1731,7 @@ bail:
 
 #ifdef USE_IMAP
 /**
- * parse_subscribe_to - Parse the 'subscribe-to' command - Implements ::command_t
+ * parse_subscribe_to - Parse the 'subscribe-to' command - Implements Command::parse()
  *
  * The 'subscribe-to' command allows to subscribe to an IMAP-Mailbox.
  * Patterns are not supported.
@@ -1778,7 +1778,7 @@ enum CommandResult parse_subscribe_to(struct Buffer *buf, struct Buffer *s,
 #endif
 
 /**
- * parse_tag_formats - Parse the 'tag-formats' command - Implements ::command_t
+ * parse_tag_formats - Parse the 'tag-formats' command - Implements Command::parse()
  */
 enum CommandResult parse_tag_formats(struct Buffer *buf, struct Buffer *s,
                                      unsigned long data, struct Buffer *err)
@@ -1817,7 +1817,7 @@ enum CommandResult parse_tag_formats(struct Buffer *buf, struct Buffer *s,
 }
 
 /**
- * parse_tag_transforms - Parse the 'tag-transforms' command - Implements ::command_t
+ * parse_tag_transforms - Parse the 'tag-transforms' command - Implements Command::parse()
  */
 enum CommandResult parse_tag_transforms(struct Buffer *buf, struct Buffer *s,
                                         unsigned long data, struct Buffer *err)
@@ -1856,7 +1856,7 @@ enum CommandResult parse_tag_transforms(struct Buffer *buf, struct Buffer *s,
 }
 
 /**
- * parse_unalias - Parse the 'unalias' command - Implements ::command_t
+ * parse_unalias - Parse the 'unalias' command - Implements Command::parse()
  */
 enum CommandResult parse_unalias(struct Buffer *buf, struct Buffer *s,
                                  unsigned long data, struct Buffer *err)
@@ -1906,7 +1906,7 @@ enum CommandResult parse_unalias(struct Buffer *buf, struct Buffer *s,
 }
 
 /**
- * parse_unalternates - Parse the 'unalternates' command - Implements ::command_t
+ * parse_unalternates - Parse the 'unalternates' command - Implements Command::parse()
  */
 enum CommandResult parse_unalternates(struct Buffer *buf, struct Buffer *s,
                                       unsigned long data, struct Buffer *err)
@@ -1929,7 +1929,7 @@ enum CommandResult parse_unalternates(struct Buffer *buf, struct Buffer *s,
 }
 
 /**
- * parse_unattachments - Parse the 'unattachments' command - Implements ::command_t
+ * parse_unattachments - Parse the 'unattachments' command - Implements Command::parse()
  */
 enum CommandResult parse_unattachments(struct Buffer *buf, struct Buffer *s,
                                        unsigned long data, struct Buffer *err)
@@ -1987,7 +1987,7 @@ enum CommandResult parse_unattachments(struct Buffer *buf, struct Buffer *s,
 }
 
 /**
- * parse_unignore - Parse the 'unignore' command - Implements ::command_t
+ * parse_unignore - Parse the 'unignore' command - Implements Command::parse()
  */
 enum CommandResult parse_unignore(struct Buffer *buf, struct Buffer *s,
                                   unsigned long data, struct Buffer *err)
@@ -2007,7 +2007,7 @@ enum CommandResult parse_unignore(struct Buffer *buf, struct Buffer *s,
 }
 
 /**
- * parse_unlists - Parse the 'unlists' command - Implements ::command_t
+ * parse_unlists - Parse the 'unlists' command - Implements Command::parse()
  */
 enum CommandResult parse_unlists(struct Buffer *buf, struct Buffer *s,
                                  unsigned long data, struct Buffer *err)
@@ -2030,7 +2030,7 @@ enum CommandResult parse_unlists(struct Buffer *buf, struct Buffer *s,
 }
 
 /**
- * parse_unmailboxes - Parse the 'unmailboxes' command - Implements ::command_t
+ * parse_unmailboxes - Parse the 'unmailboxes' command - Implements Command::parse()
  *
  * This is also used by 'unvirtual-mailboxes'
  */
@@ -2090,7 +2090,7 @@ enum CommandResult parse_unmailboxes(struct Buffer *buf, struct Buffer *s,
 }
 
 /**
- * parse_unmy_hdr - Parse the 'unmy_hdr' command - Implements ::command_t
+ * parse_unmy_hdr - Parse the 'unmy_hdr' command - Implements Command::parse()
  */
 enum CommandResult parse_unmy_hdr(struct Buffer *buf, struct Buffer *s,
                                   unsigned long data, struct Buffer *err)
@@ -2125,7 +2125,7 @@ enum CommandResult parse_unmy_hdr(struct Buffer *buf, struct Buffer *s,
 }
 
 /**
- * parse_unstailq - Parse an unlist command - Implements ::command_t
+ * parse_unstailq - Parse an unlist command - Implements Command::parse()
  *
  * This is used by 'unalternative_order', 'unauto_view' and several others.
  */
@@ -2148,7 +2148,7 @@ enum CommandResult parse_unstailq(struct Buffer *buf, struct Buffer *s,
 }
 
 /**
- * parse_unsubjectrx_list - Parse the 'unsubjectrx' command - Implements ::command_t
+ * parse_unsubjectrx_list - Parse the 'unsubjectrx' command - Implements Command::parse()
  */
 enum CommandResult parse_unsubjectrx_list(struct Buffer *buf, struct Buffer *s,
                                           unsigned long data, struct Buffer *err)
@@ -2162,7 +2162,7 @@ enum CommandResult parse_unsubjectrx_list(struct Buffer *buf, struct Buffer *s,
 }
 
 /**
- * parse_unsubscribe - Parse the 'unsubscribe' command - Implements ::command_t
+ * parse_unsubscribe - Parse the 'unsubscribe' command - Implements Command::parse()
  */
 enum CommandResult parse_unsubscribe(struct Buffer *buf, struct Buffer *s,
                                      unsigned long data, struct Buffer *err)
@@ -2185,7 +2185,7 @@ enum CommandResult parse_unsubscribe(struct Buffer *buf, struct Buffer *s,
 
 #ifdef USE_IMAP
 /**
- * parse_unsubscribe_from - Parse the 'unsubscribe-from' command - Implements ::command_t
+ * parse_unsubscribe_from - Parse the 'unsubscribe-from' command - Implements Command::parse()
  *
  * The 'unsubscribe-from' command allows to unsubscribe from an IMAP-Mailbox.
  * Patterns are not supported.

--- a/compose.c
+++ b/compose.c
@@ -309,7 +309,7 @@ static void init_header_padding(void)
 }
 
 /**
- * snd_make_entry - Format a menu item for the attachment list - Implements Menu::menu_make_entry()
+ * snd_make_entry - Format a menu item for the attachment list - Implements Menu::make_entry()
  */
 static void snd_make_entry(char *buf, size_t buflen, struct Menu *menu, int line)
 {
@@ -886,7 +886,7 @@ static void update_idx(struct Menu *menu, struct AttachCtx *actx, struct AttachP
 }
 
 /**
- * compose_custom_redraw - Redraw the compose menu - Implements Menu::menu_custom_redraw()
+ * compose_custom_redraw - Redraw the compose menu - Implements Menu::custom_redraw()
  */
 static void compose_custom_redraw(struct Menu *menu)
 {
@@ -1177,15 +1177,15 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur, 
   menu->win_ibar = ibar;
 
   menu->offset = HDR_ATTACH;
-  menu->menu_make_entry = snd_make_entry;
-  menu->menu_tag = attach_tag;
+  menu->make_entry = snd_make_entry;
+  menu->tag = attach_tag;
 #ifdef USE_NNTP
   if (news)
     menu->help = mutt_compile_help(helpstr, sizeof(helpstr), MENU_COMPOSE, ComposeNewsHelp);
   else
 #endif
     menu->help = mutt_compile_help(helpstr, sizeof(helpstr), MENU_COMPOSE, ComposeHelp);
-  menu->menu_custom_redraw = compose_custom_redraw;
+  menu->custom_redraw = compose_custom_redraw;
   menu->redraw_data = rd;
   mutt_menu_push_current(menu);
 

--- a/compose.c
+++ b/compose.c
@@ -1083,7 +1083,7 @@ static void compose_status_line(char *buf, size_t buflen, size_t col, int cols,
 }
 
 /**
- * mutt_dlg_compose_observer - Listen for config changes affecting the Compose menu - Implements ::observer_t()
+ * mutt_dlg_compose_observer - Listen for config changes affecting the Compose menu - Implements ::observer_t
  */
 static int mutt_dlg_compose_observer(struct NotifyCallback *nc)
 {

--- a/config/address.c
+++ b/config/address.c
@@ -39,7 +39,7 @@
 #include "types.h"
 
 /**
- * address_destroy - Destroy an Address object - Implements ::cst_destroy()
+ * address_destroy - Destroy an Address object - Implements ConfigSetType::destroy()
  */
 static void address_destroy(const struct ConfigSet *cs, void *var, const struct ConfigDef *cdef)
 {
@@ -54,7 +54,7 @@ static void address_destroy(const struct ConfigSet *cs, void *var, const struct 
 }
 
 /**
- * address_string_set - Set an Address by string - Implements ::cst_string_set()
+ * address_string_set - Set an Address by string - Implements ConfigSetType::string_set()
  */
 static int address_string_set(const struct ConfigSet *cs, void *var, struct ConfigDef *cdef,
                               const char *value, struct Buffer *err)
@@ -111,7 +111,7 @@ static int address_string_set(const struct ConfigSet *cs, void *var, struct Conf
 }
 
 /**
- * address_string_get - Get an Address as a string - Implements ::cst_string_get()
+ * address_string_get - Get an Address as a string - Implements ConfigSetType::string_get()
  */
 static int address_string_get(const struct ConfigSet *cs, void *var,
                               const struct ConfigDef *cdef, struct Buffer *result)
@@ -160,7 +160,7 @@ static struct Address *address_dup(struct Address *addr)
 }
 
 /**
- * address_native_set - Set an Address config item by Address object - Implements ::cst_native_set()
+ * address_native_set - Set an Address config item by Address object - Implements ConfigSetType::native_set()
  */
 static int address_native_set(const struct ConfigSet *cs, void *var,
                               const struct ConfigDef *cdef, intptr_t value,
@@ -192,7 +192,7 @@ static int address_native_set(const struct ConfigSet *cs, void *var,
 }
 
 /**
- * address_native_get - Get an Address object from an Address config item - Implements ::cst_native_get()
+ * address_native_get - Get an Address object from an Address config item - Implements ConfigSetType::native_get()
  */
 static intptr_t address_native_get(const struct ConfigSet *cs, void *var,
                                    const struct ConfigDef *cdef, struct Buffer *err)
@@ -206,7 +206,7 @@ static intptr_t address_native_get(const struct ConfigSet *cs, void *var,
 }
 
 /**
- * address_reset - Reset an Address to its initial value - Implements ::cst_reset()
+ * address_reset - Reset an Address to its initial value - Implements ConfigSetType::reset()
  */
 static int address_reset(const struct ConfigSet *cs, void *var,
                          const struct ConfigDef *cdef, struct Buffer *err)

--- a/config/bool.c
+++ b/config/bool.c
@@ -47,7 +47,7 @@ const char *BoolValues[] = {
 };
 
 /**
- * bool_string_set - Set a Bool by string - Implements ::cst_string_set()
+ * bool_string_set - Set a Bool by string - Implements ConfigSetType::string_set()
  */
 static int bool_string_set(const struct ConfigSet *cs, void *var, struct ConfigDef *cdef,
                            const char *value, struct Buffer *err)
@@ -95,7 +95,7 @@ static int bool_string_set(const struct ConfigSet *cs, void *var, struct ConfigD
 }
 
 /**
- * bool_string_get - Get a Bool as a string - Implements ::cst_string_get()
+ * bool_string_get - Get a Bool as a string - Implements ConfigSetType::string_get()
  */
 static int bool_string_get(const struct ConfigSet *cs, void *var,
                            const struct ConfigDef *cdef, struct Buffer *result)
@@ -118,7 +118,7 @@ static int bool_string_get(const struct ConfigSet *cs, void *var,
 }
 
 /**
- * bool_native_set - Set a Bool config item by bool - Implements ::cst_native_set()
+ * bool_native_set - Set a Bool config item by bool - Implements ConfigSetType::native_set()
  */
 static int bool_native_set(const struct ConfigSet *cs, void *var,
                            const struct ConfigDef *cdef, intptr_t value, struct Buffer *err)
@@ -148,7 +148,7 @@ static int bool_native_set(const struct ConfigSet *cs, void *var,
 }
 
 /**
- * bool_native_get - Get a bool from a Bool config item - Implements ::cst_native_get()
+ * bool_native_get - Get a bool from a Bool config item - Implements ConfigSetType::native_get()
  */
 static intptr_t bool_native_get(const struct ConfigSet *cs, void *var,
                                 const struct ConfigDef *cdef, struct Buffer *err)
@@ -160,7 +160,7 @@ static intptr_t bool_native_get(const struct ConfigSet *cs, void *var,
 }
 
 /**
- * bool_reset - Reset a Bool to its initial value - Implements ::cst_reset()
+ * bool_reset - Reset a Bool to its initial value - Implements ConfigSetType::reset()
  */
 static int bool_reset(const struct ConfigSet *cs, void *var,
                       const struct ConfigDef *cdef, struct Buffer *err)

--- a/config/long.c
+++ b/config/long.c
@@ -36,7 +36,7 @@
 #include "types.h"
 
 /**
- * long_string_set - Set a Long by string - Implements ::cst_string_set()
+ * long_string_set - Set a Long by string - Implements ConfigSetType::string_set()
  */
 static int long_string_set(const struct ConfigSet *cs, void *var, struct ConfigDef *cdef,
                            const char *value, struct Buffer *err)
@@ -81,7 +81,7 @@ static int long_string_set(const struct ConfigSet *cs, void *var, struct ConfigD
 }
 
 /**
- * long_string_get - Get a Long as a string - Implements ::cst_string_get()
+ * long_string_get - Get a Long as a string - Implements ConfigSetType::string_get()
  */
 static int long_string_get(const struct ConfigSet *cs, void *var,
                            const struct ConfigDef *cdef, struct Buffer *result)
@@ -101,7 +101,7 @@ static int long_string_get(const struct ConfigSet *cs, void *var,
 }
 
 /**
- * long_native_set - Set a Long config item by int - Implements ::cst_native_set()
+ * long_native_set - Set a Long config item by int - Implements ConfigSetType::native_set()
  */
 static int long_native_set(const struct ConfigSet *cs, void *var,
                            const struct ConfigDef *cdef, intptr_t value, struct Buffer *err)
@@ -131,7 +131,7 @@ static int long_native_set(const struct ConfigSet *cs, void *var,
 }
 
 /**
- * long_native_get - Get an int from a Long config item - Implements ::cst_native_get()
+ * long_native_get - Get an int from a Long config item - Implements ConfigSetType::native_get()
  */
 static intptr_t long_native_get(const struct ConfigSet *cs, void *var,
                                 const struct ConfigDef *cdef, struct Buffer *err)
@@ -143,7 +143,7 @@ static intptr_t long_native_get(const struct ConfigSet *cs, void *var,
 }
 
 /**
- * long_reset - Reset a Long to its initial value - Implements ::cst_reset()
+ * long_reset - Reset a Long to its initial value - Implements ConfigSetType::reset()
  */
 static int long_reset(const struct ConfigSet *cs, void *var,
                       const struct ConfigDef *cdef, struct Buffer *err)

--- a/config/mbtable.c
+++ b/config/mbtable.c
@@ -85,7 +85,7 @@ struct MbTable *mbtable_parse(const char *s)
 }
 
 /**
- * mbtable_destroy - Destroy an MbTable object - Implements ::cst_destroy()
+ * mbtable_destroy - Destroy an MbTable object - Implements ConfigSetType::destroy()
  */
 static void mbtable_destroy(const struct ConfigSet *cs, void *var, const struct ConfigDef *cdef)
 {
@@ -100,7 +100,7 @@ static void mbtable_destroy(const struct ConfigSet *cs, void *var, const struct 
 }
 
 /**
- * mbtable_string_set - Set a MbTable by string - Implements ::cst_string_set()
+ * mbtable_string_set - Set a MbTable by string - Implements ConfigSetType::string_set()
  */
 static int mbtable_string_set(const struct ConfigSet *cs, void *var, struct ConfigDef *cdef,
                               const char *value, struct Buffer *err)
@@ -155,7 +155,7 @@ static int mbtable_string_set(const struct ConfigSet *cs, void *var, struct Conf
 }
 
 /**
- * mbtable_string_get - Get a MbTable as a string - Implements ::cst_string_get()
+ * mbtable_string_get - Get a MbTable as a string - Implements ConfigSetType::string_get()
  */
 static int mbtable_string_get(const struct ConfigSet *cs, void *var,
                               const struct ConfigDef *cdef, struct Buffer *result)
@@ -197,7 +197,7 @@ static struct MbTable *mbtable_dup(struct MbTable *table)
 }
 
 /**
- * mbtable_native_set - Set a MbTable config item by MbTable object - Implements ::cst_native_set()
+ * mbtable_native_set - Set a MbTable config item by MbTable object - Implements ConfigSetType::native_set()
  */
 static int mbtable_native_set(const struct ConfigSet *cs, void *var,
                               const struct ConfigDef *cdef, intptr_t value,
@@ -229,7 +229,7 @@ static int mbtable_native_set(const struct ConfigSet *cs, void *var,
 }
 
 /**
- * mbtable_native_get - Get an MbTable object from a MbTable config item - Implements ::cst_native_get()
+ * mbtable_native_get - Get an MbTable object from a MbTable config item - Implements ConfigSetType::native_get()
  */
 static intptr_t mbtable_native_get(const struct ConfigSet *cs, void *var,
                                    const struct ConfigDef *cdef, struct Buffer *err)
@@ -243,7 +243,7 @@ static intptr_t mbtable_native_get(const struct ConfigSet *cs, void *var,
 }
 
 /**
- * mbtable_reset - Reset an MbTable to its initial value - Implements ::cst_reset()
+ * mbtable_reset - Reset an MbTable to its initial value - Implements ConfigSetType::reset()
  */
 static int mbtable_reset(const struct ConfigSet *cs, void *var,
                          const struct ConfigDef *cdef, struct Buffer *err)

--- a/config/number.c
+++ b/config/number.c
@@ -36,7 +36,7 @@
 #include "types.h"
 
 /**
- * number_string_set - Set a Number by string - Implements ::cst_string_set()
+ * number_string_set - Set a Number by string - Implements ConfigSetType::string_set()
  */
 static int number_string_set(const struct ConfigSet *cs, void *var, struct ConfigDef *cdef,
                              const char *value, struct Buffer *err)
@@ -93,7 +93,7 @@ static int number_string_set(const struct ConfigSet *cs, void *var, struct Confi
 }
 
 /**
- * number_string_get - Get a Number as a string - Implements ::cst_string_get()
+ * number_string_get - Get a Number as a string - Implements ConfigSetType::string_get()
  */
 static int number_string_get(const struct ConfigSet *cs, void *var,
                              const struct ConfigDef *cdef, struct Buffer *result)
@@ -113,7 +113,7 @@ static int number_string_get(const struct ConfigSet *cs, void *var,
 }
 
 /**
- * number_native_set - Set a Number config item by int - Implements ::cst_native_set()
+ * number_native_set - Set a Number config item by int - Implements ConfigSetType::native_set()
  */
 static int number_native_set(const struct ConfigSet *cs, void *var,
                              const struct ConfigDef *cdef, intptr_t value,
@@ -150,7 +150,7 @@ static int number_native_set(const struct ConfigSet *cs, void *var,
 }
 
 /**
- * number_native_get - Get an int from a Number config item - Implements ::cst_native_get()
+ * number_native_get - Get an int from a Number config item - Implements ConfigSetType::native_get()
  */
 static intptr_t number_native_get(const struct ConfigSet *cs, void *var,
                                   const struct ConfigDef *cdef, struct Buffer *err)
@@ -162,7 +162,7 @@ static intptr_t number_native_get(const struct ConfigSet *cs, void *var,
 }
 
 /**
- * number_reset - Reset a Number to its initial value - Implements ::cst_reset()
+ * number_reset - Reset a Number to its initial value - Implements ConfigSetType::reset()
  */
 static int number_reset(const struct ConfigSet *cs, void *var,
                         const struct ConfigDef *cdef, struct Buffer *err)

--- a/config/path.c
+++ b/config/path.c
@@ -63,7 +63,7 @@ static char *path_tidy(const char *path, bool is_dir)
 }
 
 /**
- * path_destroy - Destroy a Path - Implements ::cst_destroy()
+ * path_destroy - Destroy a Path - Implements ConfigSetType::destroy()
  */
 static void path_destroy(const struct ConfigSet *cs, void *var, const struct ConfigDef *cdef)
 {
@@ -85,7 +85,7 @@ static void path_destroy(const struct ConfigSet *cs, void *var, const struct Con
 }
 
 /**
- * path_string_set - Set a Path by path - Implements ::cst_string_set()
+ * path_string_set - Set a Path by path - Implements ConfigSetType::string_set()
  */
 static int path_string_set(const struct ConfigSet *cs, void *var, struct ConfigDef *cdef,
                            const char *value, struct Buffer *err)
@@ -143,7 +143,7 @@ static int path_string_set(const struct ConfigSet *cs, void *var, struct ConfigD
 }
 
 /**
- * path_string_get - Get a Path as a path - Implements ::cst_string_get()
+ * path_string_get - Get a Path as a path - Implements ConfigSetType::string_get()
  */
 static int path_string_get(const struct ConfigSet *cs, void *var,
                            const struct ConfigDef *cdef, struct Buffer *result)
@@ -166,7 +166,7 @@ static int path_string_get(const struct ConfigSet *cs, void *var,
 }
 
 /**
- * path_native_set - Set a Path config item by path - Implements ::cst_native_set()
+ * path_native_set - Set a Path config item by path - Implements ConfigSetType::native_set()
  */
 static int path_native_set(const struct ConfigSet *cs, void *var,
                            const struct ConfigDef *cdef, intptr_t value, struct Buffer *err)
@@ -211,7 +211,7 @@ static int path_native_set(const struct ConfigSet *cs, void *var,
 }
 
 /**
- * path_native_get - Get a path from a Path config item - Implements ::cst_native_get()
+ * path_native_get - Get a path from a Path config item - Implements ConfigSetType::native_get()
  */
 static intptr_t path_native_get(const struct ConfigSet *cs, void *var,
                                 const struct ConfigDef *cdef, struct Buffer *err)
@@ -225,7 +225,7 @@ static intptr_t path_native_get(const struct ConfigSet *cs, void *var,
 }
 
 /**
- * path_reset - Reset a Path to its initial value - Implements ::cst_reset()
+ * path_reset - Reset a Path to its initial value - Implements ConfigSetType::reset()
  */
 static int path_reset(const struct ConfigSet *cs, void *var,
                       const struct ConfigDef *cdef, struct Buffer *err)

--- a/config/quad.c
+++ b/config/quad.c
@@ -46,7 +46,7 @@ const char *QuadValues[] = {
 };
 
 /**
- * quad_string_set - Set a Quad-option by string - Implements ::cst_string_set()
+ * quad_string_set - Set a Quad-option by string - Implements ConfigSetType::string_set()
  */
 static int quad_string_set(const struct ConfigSet *cs, void *var, struct ConfigDef *cdef,
                            const char *value, struct Buffer *err)
@@ -94,7 +94,7 @@ static int quad_string_set(const struct ConfigSet *cs, void *var, struct ConfigD
 }
 
 /**
- * quad_string_get - Get a Quad-option as a string - Implements ::cst_string_get()
+ * quad_string_get - Get a Quad-option as a string - Implements ConfigSetType::string_get()
  */
 static int quad_string_get(const struct ConfigSet *cs, void *var,
                            const struct ConfigDef *cdef, struct Buffer *result)
@@ -120,7 +120,7 @@ static int quad_string_get(const struct ConfigSet *cs, void *var,
 }
 
 /**
- * quad_native_set - Set a Quad-option config item by int - Implements ::cst_native_set()
+ * quad_native_set - Set a Quad-option config item by int - Implements ConfigSetType::native_set()
  */
 static int quad_native_set(const struct ConfigSet *cs, void *var,
                            const struct ConfigDef *cdef, intptr_t value, struct Buffer *err)
@@ -150,7 +150,7 @@ static int quad_native_set(const struct ConfigSet *cs, void *var,
 }
 
 /**
- * quad_native_get - Get an int object from a Quad-option config item - Implements ::cst_native_get()
+ * quad_native_get - Get an int object from a Quad-option config item - Implements ConfigSetType::native_get()
  */
 static intptr_t quad_native_get(const struct ConfigSet *cs, void *var,
                                 const struct ConfigDef *cdef, struct Buffer *err)
@@ -162,7 +162,7 @@ static intptr_t quad_native_get(const struct ConfigSet *cs, void *var,
 }
 
 /**
- * quad_reset - Reset a Quad-option to its initial value - Implements ::cst_reset()
+ * quad_reset - Reset a Quad-option to its initial value - Implements ConfigSetType::reset()
  */
 static int quad_reset(const struct ConfigSet *cs, void *var,
                       const struct ConfigDef *cdef, struct Buffer *err)

--- a/config/regex.c
+++ b/config/regex.c
@@ -54,7 +54,7 @@ void regex_free(struct Regex **r)
 }
 
 /**
- * regex_destroy - Destroy a Regex object - Implements ::cst_destroy()
+ * regex_destroy - Destroy a Regex object - Implements ConfigSetType::destroy()
  */
 static void regex_destroy(const struct ConfigSet *cs, void *var, const struct ConfigDef *cdef)
 {
@@ -113,7 +113,7 @@ struct Regex *regex_new(const char *str, int flags, struct Buffer *err)
 }
 
 /**
- * regex_string_set - Set a Regex by string - Implements ::cst_string_set()
+ * regex_string_set - Set a Regex by string - Implements ConfigSetType::string_set()
  */
 static int regex_string_set(const struct ConfigSet *cs, void *var, struct ConfigDef *cdef,
                             const char *value, struct Buffer *err)
@@ -173,7 +173,7 @@ static int regex_string_set(const struct ConfigSet *cs, void *var, struct Config
 }
 
 /**
- * regex_string_get - Get a Regex as a string - Implements ::cst_string_get()
+ * regex_string_get - Get a Regex as a string - Implements ConfigSetType::string_get()
  */
 static int regex_string_get(const struct ConfigSet *cs, void *var,
                             const struct ConfigDef *cdef, struct Buffer *result)
@@ -202,7 +202,7 @@ static int regex_string_get(const struct ConfigSet *cs, void *var,
 }
 
 /**
- * regex_native_set - Set a Regex config item by Regex object - Implements ::cst_native_set()
+ * regex_native_set - Set a Regex config item by Regex object - Implements ConfigSetType::native_set()
  */
 static int regex_native_set(const struct ConfigSet *cs, void *var,
                             const struct ConfigDef *cdef, intptr_t value, struct Buffer *err)
@@ -246,7 +246,7 @@ static int regex_native_set(const struct ConfigSet *cs, void *var,
 }
 
 /**
- * regex_native_get - Get a Regex object from a Regex config item - Implements ::cst_native_get()
+ * regex_native_get - Get a Regex object from a Regex config item - Implements ConfigSetType::native_get()
  */
 static intptr_t regex_native_get(const struct ConfigSet *cs, void *var,
                                  const struct ConfigDef *cdef, struct Buffer *err)
@@ -260,7 +260,7 @@ static intptr_t regex_native_get(const struct ConfigSet *cs, void *var,
 }
 
 /**
- * regex_reset - Reset a Regex to its initial value - Implements ::cst_reset()
+ * regex_reset - Reset a Regex to its initial value - Implements ConfigSetType::reset()
  */
 static int regex_reset(const struct ConfigSet *cs, void *var,
                        const struct ConfigDef *cdef, struct Buffer *err)

--- a/config/set.h
+++ b/config/set.h
@@ -52,16 +52,6 @@ struct ConfigDef;
 #define CSR_RESULT(x) ((x) & CSR_RESULT_MASK)
 
 /**
- * typedef cs_validator - Validate a config variable
- * @param cs    Config items
- * @param cdef  Config definition
- * @param value Native value
- * @param err   Message for the user
- * @retval #CSR_SUCCESS     Success
- * @retval #CSR_ERR_INVALID Failure
- */
-typedef int (*cs_validator)(const struct ConfigSet *cs, const struct ConfigDef *cdef, intptr_t value, struct Buffer *err);
-/**
  * typedef cst_string_set - Set a config item by string
  * @param cs    Config items
  * @param var   Variable to set
@@ -137,7 +127,17 @@ struct ConfigDef
   void         *var;       ///< Pointer to the global variable
   intptr_t      initial;   ///< Initial value
   intptr_t      data;      ///< Extra variable data
-  cs_validator  validator; ///< Validator callback function
+
+  /**
+   * validator - Validate a config variable
+   * @param cs    Config items
+   * @param cdef  Config definition
+   * @param value Native value
+   * @param err   Message for the user
+   * @retval #CSR_SUCCESS     Success
+   * @retval #CSR_ERR_INVALID Failure
+   */
+  int (*validator)(const struct ConfigSet *cs, const struct ConfigDef *cdef, intptr_t value, struct Buffer *err);
 };
 
 /**

--- a/config/set.h
+++ b/config/set.h
@@ -51,66 +51,6 @@ struct ConfigDef;
 #define CSR_RESULT_MASK 0x0F
 #define CSR_RESULT(x) ((x) & CSR_RESULT_MASK)
 
-/**
- * typedef cst_string_set - Set a config item by string
- * @param cs    Config items
- * @param var   Variable to set
- * @param cdef  Variable definition
- * @param value Value to set
- * @param err   Buffer for error messages
- * @retval num Result, e.g. #CSR_SUCCESS
- *
- * If var is NULL, then the config item's initial value will be set.
- */
-typedef int (*cst_string_set)(const struct ConfigSet *cs, void *var, struct ConfigDef *cdef, const char *value, struct Buffer *err);
-/**
- * typedef cst_string_get - Get a config item as a string
- * @param cs     Config items
- * @param var    Variable to get
- * @param cdef   Variable definition
- * @param result Buffer for results or error messages
- * @retval num Result, e.g. #CSR_SUCCESS
- *
- * If var is NULL, then the config item's initial value will be returned.
- */
-typedef int (*cst_string_get)(const struct ConfigSet *cs, void *var, const struct ConfigDef *cdef, struct Buffer *result);
-/**
- * typedef cst_native_set - Set a config item by string
- * @param cs    Config items
- * @param var   Variable to set
- * @param cdef  Variable definition
- * @param value Native pointer/value to set
- * @param err   Buffer for error messages
- * @retval num Result, e.g. #CSR_SUCCESS
- */
-typedef int (*cst_native_set)(const struct ConfigSet *cs, void *var, const struct ConfigDef *cdef, intptr_t value, struct Buffer *err);
-/**
- * typedef cst_native_get - Get a string from a config item
- * @param cs   Config items
- * @param var  Variable to get
- * @param cdef Variable definition
- * @param err  Buffer for error messages
- * @retval intptr_t Config item string
- * @retval INT_MIN  Error
- */
-typedef intptr_t (*cst_native_get)(const struct ConfigSet *cs, void *var, const struct ConfigDef *cdef, struct Buffer *err);
-/**
- * typedef cst_reset - Reset a config item to its initial value
- * @param cs   Config items
- * @param var  Variable to reset
- * @param cdef Variable definition
- * @param err  Buffer for error messages
- * @retval num Result, e.g. #CSR_SUCCESS
- */
-typedef int (*cst_reset)(const struct ConfigSet *cs, void *var, const struct ConfigDef *cdef, struct Buffer *err);
-/**
- * typedef cst_destroy - Destroy a config item
- * @param cs   Config items
- * @param var  Variable to destroy
- * @param cdef Variable definition
- */
-typedef void (*cst_destroy)(const struct ConfigSet *cs, void *var, const struct ConfigDef *cdef);
-
 #define IP (intptr_t)
 
 #define CS_REG_DISABLED (1 << 0)
@@ -148,12 +88,71 @@ struct ConfigDef
 struct ConfigSetType
 {
   const char *name;          ///< Name of the type, e.g. "String"
-  cst_string_set string_set; ///< Convert the variable to a string
-  cst_string_get string_get; ///< Initialise a variable from a string
-  cst_native_set native_set; ///< Set the variable using a C-native type
-  cst_native_get native_get; ///< Get the variable's value as a C-native type
-  cst_reset reset;           ///< Reset the variable to its initial, or parent, value
-  cst_destroy destroy;       ///< Free the resources for a variable
+
+  /**
+   * string_set - Set a config item by string
+   * @param cs    Config items
+   * @param var   Variable to set
+   * @param cdef  Variable definition
+   * @param value Value to set
+   * @param err   Buffer for error messages
+   * @retval num Result, e.g. #CSR_SUCCESS
+   *
+   * If var is NULL, then the config item's initial value will be set.
+   */
+  int (*string_set)(const struct ConfigSet *cs, void *var, struct ConfigDef *cdef, const char *value, struct Buffer *err);
+
+  /**
+   * string_get - Get a config item as a string
+   * @param cs     Config items
+   * @param var    Variable to get
+   * @param cdef   Variable definition
+   * @param result Buffer for results or error messages
+   * @retval num Result, e.g. #CSR_SUCCESS
+   *
+   * If var is NULL, then the config item's initial value will be returned.
+   */
+  int (*string_get)(const struct ConfigSet *cs, void *var, const struct ConfigDef *cdef, struct Buffer *result);
+
+  /**
+   * native_set - Set a config item by string
+   * @param cs    Config items
+   * @param var   Variable to set
+   * @param cdef  Variable definition
+   * @param value Native pointer/value to set
+   * @param err   Buffer for error messages
+   * @retval num Result, e.g. #CSR_SUCCESS
+   */
+  int (*native_set)(const struct ConfigSet *cs, void *var, const struct ConfigDef *cdef, intptr_t value, struct Buffer *err);
+
+  /**
+   * native_get - Get a string from a config item
+   * @param cs   Config items
+   * @param var  Variable to get
+   * @param cdef Variable definition
+   * @param err  Buffer for error messages
+   * @retval intptr_t Config item string
+   * @retval INT_MIN  Error
+   */
+  intptr_t (*native_get)(const struct ConfigSet *cs, void *var, const struct ConfigDef *cdef, struct Buffer *err);
+
+  /**
+   * reset - Reset a config item to its initial value
+   * @param cs   Config items
+   * @param var  Variable to reset
+   * @param cdef Variable definition
+   * @param err  Buffer for error messages
+   * @retval num Result, e.g. #CSR_SUCCESS
+   */
+  int (*reset)(const struct ConfigSet *cs, void *var, const struct ConfigDef *cdef, struct Buffer *err);
+
+  /**
+   * destroy - Destroy a config item
+   * @param cs   Config items
+   * @param var  Variable to destroy
+   * @param cdef Variable definition
+   */
+  void (*destroy)(const struct ConfigSet *cs, void *var, const struct ConfigDef *cdef);
 };
 
 /**

--- a/config/sort.c
+++ b/config/sort.c
@@ -129,7 +129,7 @@ const struct Mapping SortSidebarMethods[] = {
 // clang-format on
 
 /**
- * sort_string_set - Set a Sort by string - Implements ::cst_string_set()
+ * sort_string_set - Set a Sort by string - Implements ConfigSetType::string_set()
  */
 static int sort_string_set(const struct ConfigSet *cs, void *var, struct ConfigDef *cdef,
                            const char *value, struct Buffer *err)
@@ -219,7 +219,7 @@ static int sort_string_set(const struct ConfigSet *cs, void *var, struct ConfigD
 }
 
 /**
- * sort_string_get - Get a Sort as a string - Implements ::cst_string_get()
+ * sort_string_get - Get a Sort as a string - Implements ConfigSetType::string_get()
  */
 static int sort_string_get(const struct ConfigSet *cs, void *var,
                            const struct ConfigDef *cdef, struct Buffer *result)
@@ -281,7 +281,7 @@ static int sort_string_get(const struct ConfigSet *cs, void *var,
 }
 
 /**
- * sort_native_set - Set a Sort config item by int - Implements ::cst_native_set()
+ * sort_native_set - Set a Sort config item by int - Implements ConfigSetType::native_set()
  */
 static int sort_native_set(const struct ConfigSet *cs, void *var,
                            const struct ConfigDef *cdef, intptr_t value, struct Buffer *err)
@@ -339,7 +339,7 @@ static int sort_native_set(const struct ConfigSet *cs, void *var,
 }
 
 /**
- * sort_native_get - Get an int from a Sort config item - Implements ::cst_native_get()
+ * sort_native_get - Get an int from a Sort config item - Implements ConfigSetType::native_get()
  */
 static intptr_t sort_native_get(const struct ConfigSet *cs, void *var,
                                 const struct ConfigDef *cdef, struct Buffer *err)
@@ -351,7 +351,7 @@ static intptr_t sort_native_get(const struct ConfigSet *cs, void *var,
 }
 
 /**
- * sort_reset - Reset a Sort to its initial value - Implements ::cst_reset()
+ * sort_reset - Reset a Sort to its initial value - Implements ConfigSetType::reset()
  */
 static int sort_reset(const struct ConfigSet *cs, void *var,
                       const struct ConfigDef *cdef, struct Buffer *err)

--- a/config/string.c
+++ b/config/string.c
@@ -36,7 +36,7 @@
 #include "types.h"
 
 /**
- * string_destroy - Destroy a String - Implements ::cst_destroy()
+ * string_destroy - Destroy a String - Implements ConfigSetType::destroy()
  */
 static void string_destroy(const struct ConfigSet *cs, void *var, const struct ConfigDef *cdef)
 {
@@ -58,7 +58,7 @@ static void string_destroy(const struct ConfigSet *cs, void *var, const struct C
 }
 
 /**
- * string_string_set - Set a String by string - Implements ::cst_string_set()
+ * string_string_set - Set a String by string - Implements ConfigSetType::string_set()
  */
 static int string_string_set(const struct ConfigSet *cs, void *var, struct ConfigDef *cdef,
                              const char *value, struct Buffer *err)
@@ -116,7 +116,7 @@ static int string_string_set(const struct ConfigSet *cs, void *var, struct Confi
 }
 
 /**
- * string_string_get - Get a String as a string - Implements ::cst_string_get()
+ * string_string_get - Get a String as a string - Implements ConfigSetType::string_get()
  */
 static int string_string_get(const struct ConfigSet *cs, void *var,
                              const struct ConfigDef *cdef, struct Buffer *result)
@@ -139,7 +139,7 @@ static int string_string_get(const struct ConfigSet *cs, void *var,
 }
 
 /**
- * string_native_set - Set a String config item by string - Implements ::cst_native_set()
+ * string_native_set - Set a String config item by string - Implements ConfigSetType::native_set()
  */
 static int string_native_set(const struct ConfigSet *cs, void *var,
                              const struct ConfigDef *cdef, intptr_t value,
@@ -185,7 +185,7 @@ static int string_native_set(const struct ConfigSet *cs, void *var,
 }
 
 /**
- * string_native_get - Get a string from a String config item - Implements ::cst_native_get()
+ * string_native_get - Get a string from a String config item - Implements ConfigSetType::native_get()
  */
 static intptr_t string_native_get(const struct ConfigSet *cs, void *var,
                                   const struct ConfigDef *cdef, struct Buffer *err)
@@ -199,7 +199,7 @@ static intptr_t string_native_get(const struct ConfigSet *cs, void *var,
 }
 
 /**
- * string_reset - Reset a String to its initial value - Implements ::cst_reset()
+ * string_reset - Reset a String to its initial value - Implements ConfigSetType::reset()
  */
 static int string_reset(const struct ConfigSet *cs, void *var,
                         const struct ConfigDef *cdef, struct Buffer *err)

--- a/conn/conn_raw.c
+++ b/conn/conn_raw.c
@@ -117,7 +117,7 @@ static int socket_connect(int fd, struct sockaddr *sa)
 }
 
 /**
- * raw_socket_open - Open a socket - Implements Connection::conn_open()
+ * raw_socket_open - Open a socket - Implements Connection::open()
  */
 int raw_socket_open(struct Connection *conn)
 {
@@ -265,7 +265,7 @@ int raw_socket_open(struct Connection *conn)
 }
 
 /**
- * raw_socket_read - Read data from a socket - Implements Connection::conn_read()
+ * raw_socket_read - Read data from a socket - Implements Connection::read()
  */
 int raw_socket_read(struct Connection *conn, char *buf, size_t count)
 {
@@ -295,7 +295,7 @@ int raw_socket_read(struct Connection *conn, char *buf, size_t count)
 }
 
 /**
- * raw_socket_write - Write data to a socket - Implements Connection::conn_write()
+ * raw_socket_write - Write data to a socket - Implements Connection::write()
  */
 int raw_socket_write(struct Connection *conn, const char *buf, size_t count)
 {
@@ -325,7 +325,7 @@ int raw_socket_write(struct Connection *conn, const char *buf, size_t count)
 }
 
 /**
- * raw_socket_poll - Checks whether reads would block - Implements Connection::conn_poll()
+ * raw_socket_poll - Checks whether reads would block - Implements Connection::poll()
  */
 int raw_socket_poll(struct Connection *conn, time_t wait_secs)
 {
@@ -364,7 +364,7 @@ int raw_socket_poll(struct Connection *conn, time_t wait_secs)
 }
 
 /**
- * raw_socket_close - Close a socket - Implements Connection::conn_close()
+ * raw_socket_close - Close a socket - Implements Connection::close()
  */
 int raw_socket_close(struct Connection *conn)
 {

--- a/conn/connaccount.h
+++ b/conn/connaccount.h
@@ -37,13 +37,6 @@ enum ConnAccountField
   MUTT_CA_OAUTH_CMD, ///< OAuth refresh command
 };
 
-/**
- * typedef ca_get_field_t - Prototype for a function to get some login credentials
- * @param field Field to get, e.g. #MUTT_CA_PASS
- * @retval ptr Requested string
- */
-typedef const char *(*ca_get_field_t)(enum ConnAccountField field);
-
 typedef uint8_t MuttAccountFlags;     ///< Flags, Which ConnAccount fields are initialised, e.g. #MUTT_ACCT_PORT
 #define MUTT_ACCT_NO_FLAGS        0   ///< No flags are set
 #define MUTT_ACCT_PORT      (1 << 0)  ///< Port field has been set
@@ -66,7 +59,12 @@ struct ConnAccount
   MuttAccountFlags flags; ///< Which fields are initialised, e.g. #MUTT_ACCT_USER
   const char *service;    ///< Name of the service, e.g. "imap"
 
-  ca_get_field_t get_field; ///< Function to get some data
+  /**
+   * get_field - Function to get some login credentials
+   * @param field Field to get, e.g. #MUTT_CA_PASS
+   * @retval ptr Requested string
+   */
+  const char *(*get_field)(enum ConnAccountField field);
 };
 
 int   mutt_account_getlogin      (struct ConnAccount *account);

--- a/conn/connection.h
+++ b/conn/connection.h
@@ -45,46 +45,46 @@ struct Connection
   void *sockdata;
 
   /**
-   * conn_open - Open a socket Connection
+   * open - Open a socket Connection
    * @param conn Connection to a server
    * @retval  0 Success
    * @retval -1 Error
    */
-  int (*conn_open) (struct Connection *conn);
+  int (*open) (struct Connection *conn);
   /**
-   * conn_read - Read from a socket Connection
+   * read - Read from a socket Connection
    * @param conn  Connection to a server
    * @param buf   Buffer to store the data
    * @param count Number of bytes to read
    * @retval >0 Success, number of bytes read
    * @retval -1 Error, see errno
    */
-  int (*conn_read) (struct Connection *conn, char *buf, size_t count);
+  int (*read) (struct Connection *conn, char *buf, size_t count);
   /**
-   * conn_write - Write to a socket Connection
+   * write - Write to a socket Connection
    * @param conn  Connection to a server
    * @param buf   Buffer to read into
    * @param count Number of bytes to read
    * @retval >0 Success, number of bytes written
    * @retval -1 Error, see errno
    */
-  int (*conn_write)(struct Connection *conn, const char *buf, size_t count);
+  int (*write)(struct Connection *conn, const char *buf, size_t count);
   /**
-   * conn_poll - Check whether a socket read would block
+   * poll - Check whether a socket read would block
    * @param conn Connection to a server
    * @param wait_secs How long to wait for a response
    * @retval >0 There is data to read
    * @retval  0 Read would block
    * @retval -1 Connection doesn't support polling
    */
-  int (*conn_poll) (struct Connection *conn, time_t wait_secs);
+  int (*poll) (struct Connection *conn, time_t wait_secs);
   /**
-   * conn_close - Close a socket Connection
+   * close - Close a socket Connection
    * @param conn Connection to a server
    * @retval  0 Success
    * @retval -1 Error, see errno
    */
-  int (*conn_close)(struct Connection *conn);
+  int (*close)(struct Connection *conn);
 };
 
 #endif /* MUTT_CONN_CONNECTION_H */

--- a/conn/sasl.c
+++ b/conn/sasl.c
@@ -346,7 +346,7 @@ static sasl_callback_t *mutt_sasl_get_callbacks(struct ConnAccount *cac)
 }
 
 /**
- * mutt_sasl_conn_open - empty wrapper for underlying open function - Implements Connection::conn_open()
+ * mutt_sasl_conn_open - empty wrapper for underlying open function - Implements Connection::open()
  *
  * We don't know in advance that a connection will use SASL, so we replace
  * conn's methods with sasl methods when authentication is successful, using
@@ -363,7 +363,7 @@ static int mutt_sasl_conn_open(struct Connection *conn)
 }
 
 /**
- * mutt_sasl_conn_close - close SASL connection - Implements Connection::conn_close()
+ * mutt_sasl_conn_close - close SASL connection - Implements Connection::close()
  *
  * Calls underlying close function and disposes of the sasl_conn_t object, then
  * restores connection to pre-sasl state
@@ -374,24 +374,24 @@ static int mutt_sasl_conn_close(struct Connection *conn)
 
   /* restore connection's underlying methods */
   conn->sockdata = sasldata->sockdata;
-  conn->conn_open = sasldata->msasl_open;
-  conn->conn_read = sasldata->msasl_read;
-  conn->conn_write = sasldata->msasl_write;
-  conn->conn_poll = sasldata->msasl_poll;
-  conn->conn_close = sasldata->msasl_close;
+  conn->open = sasldata->msasl_open;
+  conn->read = sasldata->msasl_read;
+  conn->write = sasldata->msasl_write;
+  conn->poll = sasldata->msasl_poll;
+  conn->close = sasldata->msasl_close;
 
   /* release sasl resources */
   sasl_dispose(&sasldata->saslconn);
   FREE(&sasldata);
 
   /* call underlying close */
-  int rc = (conn->conn_close)(conn);
+  int rc = conn->close(conn);
 
   return rc;
 }
 
 /**
- * mutt_sasl_conn_read - Read data from an SASL connection - Implements Connection::conn_read()
+ * mutt_sasl_conn_read - Read data from an SASL connection - Implements Connection::read()
  */
 static int mutt_sasl_conn_read(struct Connection *conn, char *buf, size_t count)
 {
@@ -455,7 +455,7 @@ out:
 }
 
 /**
- * mutt_sasl_conn_write - Write to an SASL connection - Implements Connection::conn_write()
+ * mutt_sasl_conn_write - Write to an SASL connection - Implements Connection::write()
  */
 static int mutt_sasl_conn_write(struct Connection *conn, const char *buf, size_t count)
 {
@@ -505,7 +505,7 @@ fail:
 }
 
 /**
- * mutt_sasl_conn_poll - Check an SASL connection for data - Implements Connection::conn_poll()
+ * mutt_sasl_conn_poll - Check an SASL connection for data - Implements Connection::poll()
  */
 static int mutt_sasl_conn_poll(struct Connection *conn, time_t wait_secs)
 {
@@ -681,19 +681,19 @@ void mutt_sasl_setup_conn(struct Connection *conn, sasl_conn_t *saslconn)
 
   /* preserve old functions */
   sasldata->sockdata = conn->sockdata;
-  sasldata->msasl_open = conn->conn_open;
-  sasldata->msasl_read = conn->conn_read;
-  sasldata->msasl_write = conn->conn_write;
-  sasldata->msasl_poll = conn->conn_poll;
-  sasldata->msasl_close = conn->conn_close;
+  sasldata->msasl_open = conn->open;
+  sasldata->msasl_read = conn->read;
+  sasldata->msasl_write = conn->write;
+  sasldata->msasl_poll = conn->poll;
+  sasldata->msasl_close = conn->close;
 
   /* and set up new functions */
   conn->sockdata = sasldata;
-  conn->conn_open = mutt_sasl_conn_open;
-  conn->conn_read = mutt_sasl_conn_read;
-  conn->conn_write = mutt_sasl_conn_write;
-  conn->conn_poll = mutt_sasl_conn_poll;
-  conn->conn_close = mutt_sasl_conn_close;
+  conn->open = mutt_sasl_conn_open;
+  conn->read = mutt_sasl_conn_read;
+  conn->write = mutt_sasl_conn_write;
+  conn->poll = mutt_sasl_conn_poll;
+  conn->close = mutt_sasl_conn_close;
 }
 
 /**

--- a/conn/sasl.h
+++ b/conn/sasl.h
@@ -50,13 +50,32 @@ struct SaslSockData
   unsigned int blen;
   unsigned int bpos;
 
-  /* underlying socket data */
-  void *sockdata;
-  int (*msasl_open) (struct Connection *conn);
-  int (*msasl_close)(struct Connection *conn);
-  int (*msasl_read) (struct Connection *conn, char *buf, size_t len);
-  int (*msasl_write)(struct Connection *conn, const char *buf, size_t count);
-  int (*msasl_poll) (struct Connection *conn, time_t wait_secs);
+  void *sockdata; ///< Underlying socket data
+
+  /**
+   * open - Open a socket Connection - Implements Connection::open()
+   */
+  int (*open) (struct Connection *conn);
+
+  /**
+   * read - Read from a socket Connection - Implements Connection::read()
+   */
+  int (*read) (struct Connection *conn, char *buf, size_t count);
+
+  /**
+   * write - Write to a socket Connection - Implements Connection::write()
+   */
+  int (*write)(struct Connection *conn, const char *buf, size_t count);
+
+  /**
+   * poll - Check whether a socket read would block - Implements Connection::poll()
+   */
+  int (*poll) (struct Connection *conn, time_t wait_secs);
+
+  /**
+   * close - Close a socket Connection - Implements Connection::close()
+   */
+  int (*close)(struct Connection *conn);
 };
 
 #endif /* MUTT_CONN_SASL_H */

--- a/conn/socket.c
+++ b/conn/socket.c
@@ -78,7 +78,7 @@ int mutt_socket_open(struct Connection *conn)
   if (socket_preconnect())
     return -1;
 
-  rc = conn->conn_open(conn);
+  rc = conn->open(conn);
 
   mutt_debug(LL_DEBUG2, "Connected to %s:%d on fd=%d\n", conn->account.host,
              conn->account.port, conn->fd);
@@ -102,7 +102,7 @@ int mutt_socket_close(struct Connection *conn)
   if (conn->fd < 0)
     mutt_debug(LL_DEBUG1, "Attempt to close closed connection\n");
   else
-    rc = conn->conn_close(conn);
+    rc = conn->close(conn);
 
   conn->fd = -1;
   conn->ssf = 0;
@@ -122,7 +122,7 @@ int mutt_socket_close(struct Connection *conn)
  */
 int mutt_socket_read(struct Connection *conn, char *buf, size_t len)
 {
-  return conn->conn_read(conn, buf, len);
+  return conn->read(conn, buf, len);
 }
 
 /**
@@ -135,7 +135,7 @@ int mutt_socket_read(struct Connection *conn, char *buf, size_t len)
  */
 int mutt_socket_write(struct Connection *conn, const char *buf, size_t len)
 {
-  return conn->conn_write(conn, buf, len);
+  return conn->write(conn, buf, len);
 }
 
 /**
@@ -161,7 +161,7 @@ int mutt_socket_write_d(struct Connection *conn, const char *buf, int len, int d
 
   while (sent < len)
   {
-    const int rc = conn->conn_write(conn, buf + sent, len - sent);
+    const int rc = conn->write(conn, buf + sent, len - sent);
     if (rc < 0)
     {
       mutt_debug(LL_DEBUG1, "error writing (%s), closing socket\n", strerror(errno));
@@ -192,8 +192,8 @@ int mutt_socket_poll(struct Connection *conn, time_t wait_secs)
   if (conn->bufpos < conn->available)
     return conn->available - conn->bufpos;
 
-  if (conn->conn_poll)
-    return conn->conn_poll(conn, wait_secs);
+  if (conn->poll)
+    return conn->poll(conn, wait_secs);
 
   return -1;
 }
@@ -210,7 +210,7 @@ int mutt_socket_readchar(struct Connection *conn, char *c)
   if (conn->bufpos >= conn->available)
   {
     if (conn->fd >= 0)
-      conn->available = conn->conn_read(conn, conn->inbuf, sizeof(conn->inbuf));
+      conn->available = conn->read(conn, conn->inbuf, sizeof(conn->inbuf));
     else
     {
       mutt_debug(LL_DEBUG1, "attempt to read from closed connection\n");
@@ -293,11 +293,11 @@ struct Connection *mutt_socket_new(enum ConnectionType type)
   }
   else
   {
-    conn->conn_read = raw_socket_read;
-    conn->conn_write = raw_socket_write;
-    conn->conn_open = raw_socket_open;
-    conn->conn_close = raw_socket_close;
-    conn->conn_poll = raw_socket_poll;
+    conn->read = raw_socket_read;
+    conn->write = raw_socket_write;
+    conn->open = raw_socket_open;
+    conn->close = raw_socket_close;
+    conn->poll = raw_socket_poll;
   }
 
   return conn;

--- a/conn/ssl.c
+++ b/conn/ssl.c
@@ -361,7 +361,7 @@ static int ssl_passwd_cb(char *buf, int buflen, int rwflag, void *userdata)
 }
 
 /**
- * ssl_socket_open_err - Error callback for opening an SSL connection - Implements Connection::conn_open()
+ * ssl_socket_open_err - Error callback for opening an SSL connection - Implements Connection::open()
  * @retval -1 Always
  */
 static int ssl_socket_open_err(struct Connection *conn)
@@ -626,15 +626,15 @@ static void ssl_get_client_cert(struct SslSockData *ssldata, struct Connection *
 }
 
 /**
- * ssl_socket_close_and_restore - Close an SSL Connection and restore Connection callbacks - Implements Connection::conn_close()
+ * ssl_socket_close_and_restore - Close an SSL Connection and restore Connection callbacks - Implements Connection::close()
  */
 static int ssl_socket_close_and_restore(struct Connection *conn)
 {
   int rc = ssl_socket_close(conn);
-  conn->conn_read = raw_socket_read;
-  conn->conn_write = raw_socket_write;
-  conn->conn_close = raw_socket_close;
-  conn->conn_poll = raw_socket_poll;
+  conn->read = raw_socket_read;
+  conn->write = raw_socket_write;
+  conn->close = raw_socket_close;
+  conn->poll = raw_socket_poll;
 
   return rc;
 }
@@ -1364,7 +1364,7 @@ free_ssldata:
 }
 
 /**
- * ssl_socket_poll - Check whether a socket read would block - Implements Connection::conn_poll()
+ * ssl_socket_poll - Check whether a socket read would block - Implements Connection::poll()
  */
 static int ssl_socket_poll(struct Connection *conn, time_t wait_secs)
 {
@@ -1378,7 +1378,7 @@ static int ssl_socket_poll(struct Connection *conn, time_t wait_secs)
 }
 
 /**
- * ssl_socket_open - Open an SSL socket - Implements Connection::conn_open()
+ * ssl_socket_open - Open an SSL socket - Implements Connection::open()
  */
 static int ssl_socket_open(struct Connection *conn)
 {
@@ -1393,7 +1393,7 @@ static int ssl_socket_open(struct Connection *conn)
 }
 
 /**
- * ssl_socket_read - Read data from an SSL socket - Implements Connection::conn_read()
+ * ssl_socket_read - Read data from an SSL socket - Implements Connection::read()
  */
 static int ssl_socket_read(struct Connection *conn, char *buf, size_t count)
 {
@@ -1415,7 +1415,7 @@ static int ssl_socket_read(struct Connection *conn, char *buf, size_t count)
 }
 
 /**
- * ssl_socket_write - Write data to an SSL socket - Implements Connection::conn_write()
+ * ssl_socket_write - Write data to an SSL socket - Implements Connection::write()
  */
 static int ssl_socket_write(struct Connection *conn, const char *buf, size_t count)
 {
@@ -1436,7 +1436,7 @@ static int ssl_socket_write(struct Connection *conn, const char *buf, size_t cou
 }
 
 /**
- * ssl_socket_close - Close an SSL connection - Implements Connection::conn_close()
+ * ssl_socket_close - Close an SSL connection - Implements Connection::close()
  */
 static int ssl_socket_close(struct Connection *conn)
 {
@@ -1471,10 +1471,10 @@ int mutt_ssl_starttls(struct Connection *conn)
   int rc = ssl_setup(conn);
 
   /* hmm. watch out if we're starting TLS over any method other than raw. */
-  conn->conn_read = ssl_socket_read;
-  conn->conn_write = ssl_socket_write;
-  conn->conn_close = ssl_socket_close_and_restore;
-  conn->conn_poll = ssl_socket_poll;
+  conn->read = ssl_socket_read;
+  conn->write = ssl_socket_write;
+  conn->close = ssl_socket_close_and_restore;
+  conn->poll = ssl_socket_poll;
 
   return rc;
 }
@@ -1489,15 +1489,15 @@ int mutt_ssl_socket_setup(struct Connection *conn)
 {
   if (ssl_init() < 0)
   {
-    conn->conn_open = ssl_socket_open_err;
+    conn->open = ssl_socket_open_err;
     return -1;
   }
 
-  conn->conn_open = ssl_socket_open;
-  conn->conn_read = ssl_socket_read;
-  conn->conn_write = ssl_socket_write;
-  conn->conn_poll = ssl_socket_poll;
-  conn->conn_close = ssl_socket_close;
+  conn->open = ssl_socket_open;
+  conn->read = ssl_socket_read;
+  conn->write = ssl_socket_write;
+  conn->poll = ssl_socket_poll;
+  conn->close = ssl_socket_close;
 
   return 0;
 }

--- a/conn/ssl_gnutls.c
+++ b/conn/ssl_gnutls.c
@@ -116,17 +116,17 @@ static int tls_init(void)
 }
 
 /**
- * tls_starttls_close - Close a TLS connection - Implements Connection::conn_close()
+ * tls_starttls_close - Close a TLS connection - Implements Connection::close()
  */
 static int tls_starttls_close(struct Connection *conn)
 {
   int rc;
 
   rc = tls_socket_close(conn);
-  conn->conn_read = raw_socket_read;
-  conn->conn_write = raw_socket_write;
-  conn->conn_close = raw_socket_close;
-  conn->conn_poll = raw_socket_poll;
+  conn->read = raw_socket_read;
+  conn->write = raw_socket_write;
+  conn->close = raw_socket_close;
+  conn->poll = raw_socket_poll;
 
   return rc;
 }
@@ -1170,7 +1170,7 @@ fail:
 }
 
 /**
- * tls_socket_poll - Check whether a socket read would block - Implements Connection::conn_poll()
+ * tls_socket_poll - Check whether a socket read would block - Implements Connection::poll()
  */
 static int tls_socket_poll(struct Connection *conn, time_t wait_secs)
 {
@@ -1185,7 +1185,7 @@ static int tls_socket_poll(struct Connection *conn, time_t wait_secs)
 }
 
 /**
- * tls_socket_open - Open a TLS socket - Implements Connection::conn_open()
+ * tls_socket_open - Open a TLS socket - Implements Connection::open()
  */
 static int tls_socket_open(struct Connection *conn)
 {
@@ -1202,7 +1202,7 @@ static int tls_socket_open(struct Connection *conn)
 }
 
 /**
- * tls_socket_read - Read data from a TLS socket - Implements Connection::conn_read()
+ * tls_socket_read - Read data from a TLS socket - Implements Connection::read()
  */
 static int tls_socket_read(struct Connection *conn, char *buf, size_t count)
 {
@@ -1229,7 +1229,7 @@ static int tls_socket_read(struct Connection *conn, char *buf, size_t count)
 }
 
 /**
- * tls_socket_write - Write data to a TLS socket - Implements Connection::conn_write()
+ * tls_socket_write - Write data to a TLS socket - Implements Connection::write()
  */
 static int tls_socket_write(struct Connection *conn, const char *buf, size_t count)
 {
@@ -1263,7 +1263,7 @@ static int tls_socket_write(struct Connection *conn, const char *buf, size_t cou
 }
 
 /**
- * tls_socket_close - Close a TLS socket - Implements Connection::conn_close()
+ * tls_socket_close - Close a TLS socket - Implements Connection::close()
  */
 static int tls_socket_close(struct Connection *conn)
 {
@@ -1298,11 +1298,11 @@ int mutt_ssl_socket_setup(struct Connection *conn)
   if (tls_init() < 0)
     return -1;
 
-  conn->conn_open = tls_socket_open;
-  conn->conn_read = tls_socket_read;
-  conn->conn_write = tls_socket_write;
-  conn->conn_close = tls_socket_close;
-  conn->conn_poll = tls_socket_poll;
+  conn->open = tls_socket_open;
+  conn->read = tls_socket_read;
+  conn->write = tls_socket_write;
+  conn->close = tls_socket_close;
+  conn->poll = tls_socket_poll;
 
   return 0;
 }
@@ -1321,10 +1321,10 @@ int mutt_ssl_starttls(struct Connection *conn)
   if (tls_negotiate(conn) < 0)
     return -1;
 
-  conn->conn_read = tls_socket_read;
-  conn->conn_write = tls_socket_write;
-  conn->conn_close = tls_starttls_close;
-  conn->conn_poll = tls_socket_poll;
+  conn->read = tls_socket_read;
+  conn->write = tls_socket_write;
+  conn->close = tls_starttls_close;
+  conn->poll = tls_socket_poll;
 
   return 0;
 }

--- a/conn/tunnel.c
+++ b/conn/tunnel.c
@@ -53,7 +53,7 @@ struct TunnelSockData
 };
 
 /**
- * tunnel_socket_open - Open a tunnel socket - Implements Connection::conn_open()
+ * tunnel_socket_open - Open a tunnel socket - Implements Connection::open()
  */
 static int tunnel_socket_open(struct Connection *conn)
 {
@@ -132,7 +132,7 @@ static int tunnel_socket_open(struct Connection *conn)
 }
 
 /**
- * tunnel_socket_read - Read data from a tunnel socket - Implements Connection::conn_read()
+ * tunnel_socket_read - Read data from a tunnel socket - Implements Connection::read()
  */
 static int tunnel_socket_read(struct Connection *conn, char *buf, size_t count)
 {
@@ -154,7 +154,7 @@ static int tunnel_socket_read(struct Connection *conn, char *buf, size_t count)
 }
 
 /**
- * tunnel_socket_write - Write data to a tunnel socket - Implements Connection::conn_write()
+ * tunnel_socket_write - Write data to a tunnel socket - Implements Connection::write()
  */
 static int tunnel_socket_write(struct Connection *conn, const char *buf, size_t count)
 {
@@ -182,7 +182,7 @@ static int tunnel_socket_write(struct Connection *conn, const char *buf, size_t 
 }
 
 /**
- * tunnel_socket_poll - Checks whether tunnel reads would block - Implements Connection::conn_poll()
+ * tunnel_socket_poll - Checks whether tunnel reads would block - Implements Connection::poll()
  */
 static int tunnel_socket_poll(struct Connection *conn, time_t wait_secs)
 {
@@ -199,7 +199,7 @@ static int tunnel_socket_poll(struct Connection *conn, time_t wait_secs)
 }
 
 /**
- * tunnel_socket_close - Close a tunnel socket - Implements Connection::conn_close()
+ * tunnel_socket_close - Close a tunnel socket - Implements Connection::close()
  */
 static int tunnel_socket_close(struct Connection *conn)
 {
@@ -232,9 +232,9 @@ static int tunnel_socket_close(struct Connection *conn)
  */
 void mutt_tunnel_socket_setup(struct Connection *conn)
 {
-  conn->conn_open = tunnel_socket_open;
-  conn->conn_close = tunnel_socket_close;
-  conn->conn_read = tunnel_socket_read;
-  conn->conn_write = tunnel_socket_write;
-  conn->conn_poll = tunnel_socket_poll;
+  conn->open = tunnel_socket_open;
+  conn->close = tunnel_socket_close;
+  conn->read = tunnel_socket_read;
+  conn->write = tunnel_socket_write;
+  conn->poll = tunnel_socket_poll;
 }

--- a/core/account.h
+++ b/core/account.h
@@ -35,14 +35,14 @@ struct ConfigSubset;
  */
 struct Account
 {
-  enum MailboxType magic;       ///< Type of Mailboxes this Account contains
-  char *name;                   ///< Name of Account
-  struct ConfigSubset *sub;     ///< Inherited config items
-  struct MailboxList mailboxes; ///< List of Mailboxes
-  struct Notify *notify;        ///< Notifications handler
-  void *adata;                  ///< Private data (for Mailbox backends)
-  void (*free_adata)(void **);  ///< Callback function to free private data
-  TAILQ_ENTRY(Account) entries; ///< Linked list of Accounts
+  enum MailboxType magic;         ///< Type of Mailboxes this Account contains
+  char *name;                     ///< Name of Account
+  struct ConfigSubset *sub;       ///< Inherited config items
+  struct MailboxList mailboxes;   ///< List of Mailboxes
+  struct Notify *notify;          ///< Notifications handler
+  void *adata;                    ///< Private data (for Mailbox backends)
+  void (*free_adata)(void **ptr); ///< Callback function to free private data
+  TAILQ_ENTRY(Account) entries;   ///< Linked list of Accounts
 };
 TAILQ_HEAD(AccountList, Account);
 

--- a/core/mailbox.h
+++ b/core/mailbox.h
@@ -134,7 +134,7 @@ struct Mailbox
   int flags;                          ///< e.g. #MB_NORMAL
 
   void *mdata;                        ///< Driver specific data
-  void (*free_mdata)(void **);        ///< Driver-specific data free function
+  void (*free_mdata)(void **ptr);     ///< Driver-specific data free function
 
   struct Notify *notify;              ///< Notifications handler
 };

--- a/email/email.h
+++ b/email/email.h
@@ -103,9 +103,9 @@ struct Email
 
   char *maildir_flags;         ///< Unknown maildir flags
 
-  void *edata;                 ///< Driver-specific data
-  void (*free_edata)(void **); ///< Driver-specific data free function
-  struct Notify *notify;       ///< Notifications handler
+  void *edata;                    ///< Driver-specific data
+  void (*free_edata)(void **ptr); ///< Driver-specific data free function
+  struct Notify *notify;          ///< Notifications handler
 };
 
 /**

--- a/format_flags.h
+++ b/format_flags.h
@@ -58,9 +58,9 @@ typedef uint8_t MuttFormatFlags;         ///< Flags for mutt_expando_format(), e
  * |:--------|:-----------
  * | \%t     | Title
  */
-typedef const char *format_t(char *buf, size_t buflen, size_t col, int cols,
-                             char op, const char *src, const char *prec,
-                             const char *if_str, const char *else_str,
-                             unsigned long data, MuttFormatFlags flags);
+typedef const char *(format_t)(char *buf, size_t buflen, size_t col, int cols,
+                               char op, const char *src, const char *prec,
+                               const char *if_str, const char *else_str,
+                               unsigned long data, MuttFormatFlags flags);
 
 #endif /* MUTT_FORMAT_FLAGS_H */

--- a/gui/color.c
+++ b/gui/color.c
@@ -918,7 +918,7 @@ static enum CommandResult parse_uncolor(struct Buffer *buf, struct Buffer *s,
 
 #ifdef HAVE_COLOR
 /**
- * mutt_parse_uncolor - Parse the 'uncolor' command - Implements ::command_t
+ * mutt_parse_uncolor - Parse the 'uncolor' command - Implements Command::parse()
  */
 enum CommandResult mutt_parse_uncolor(struct Buffer *buf, struct Buffer *s,
                                       unsigned long data, struct Buffer *err)
@@ -928,7 +928,7 @@ enum CommandResult mutt_parse_uncolor(struct Buffer *buf, struct Buffer *s,
 #endif
 
 /**
- * mutt_parse_unmono - Parse the 'unmono' command - Implements ::command_t
+ * mutt_parse_unmono - Parse the 'unmono' command - Implements Command::parse()
  */
 enum CommandResult mutt_parse_unmono(struct Buffer *buf, struct Buffer *s,
                                      unsigned long data, struct Buffer *err)
@@ -1350,7 +1350,7 @@ static enum CommandResult parse_color(struct Colors *c, struct Buffer *buf, stru
 
 #ifdef HAVE_COLOR
 /**
- * mutt_parse_color - Parse the 'color' command - Implements ::command_t
+ * mutt_parse_color - Parse the 'color' command - Implements Command::parse()
  */
 enum CommandResult mutt_parse_color(struct Buffer *buf, struct Buffer *s,
                                     unsigned long data, struct Buffer *err)
@@ -1366,7 +1366,7 @@ enum CommandResult mutt_parse_color(struct Buffer *buf, struct Buffer *s,
 #endif
 
 /**
- * mutt_parse_mono - Parse the 'mono' command - Implements ::command_t
+ * mutt_parse_mono - Parse the 'mono' command - Implements Command::parse()
  */
 enum CommandResult mutt_parse_mono(struct Buffer *buf, struct Buffer *s,
                                    unsigned long data, struct Buffer *err)

--- a/gui/curs_lib.c
+++ b/gui/curs_lib.c
@@ -622,7 +622,7 @@ int mutt_any_key_to_continue(const char *s)
 }
 
 /**
- * mutt_dlg_dopager_observer - Listen for config changes affecting the dopager menus - Implements ::observer_t()
+ * mutt_dlg_dopager_observer - Listen for config changes affecting the dopager menus - Implements ::observer_t
  */
 static int mutt_dlg_dopager_observer(struct NotifyCallback *nc)
 {

--- a/gui/mutt_window.c
+++ b/gui/mutt_window.c
@@ -154,7 +154,7 @@ void mutt_window_clrtoeol(struct MuttWindow *win)
 }
 
 /**
- * mutt_dlg_rootwin_observer - Listen for config changes affecting the Root Window - Implements ::observer_t()
+ * mutt_dlg_rootwin_observer - Listen for config changes affecting the Root Window - Implements ::observer_t
  */
 static int mutt_dlg_rootwin_observer(struct NotifyCallback *nc)
 {

--- a/gui/mutt_window.h
+++ b/gui/mutt_window.h
@@ -102,7 +102,7 @@ struct MuttWindow
 
   enum WindowType type;              ///< Window type, e.g. #WT_SIDEBAR
   void *wdata;                       ///< Private data
-  void (*free_wdata)(struct MuttWindow *win, void **); ///< Callback function to free private data
+  void (*free_wdata)(struct MuttWindow *win, void **ptr); ///< Callback function to free private data
 #ifdef USE_DEBUG_WINDOW
   const char *name;
 #endif

--- a/hcache/backend.h
+++ b/hcache/backend.h
@@ -33,10 +33,8 @@
  */
 struct HcacheOps
 {
-  /**
-   * name - Backend name
-   */
-  const char *name;
+  const char *name; ///< Header cache name
+
   /**
    * open - backend-specific routing to open the header cache database
    * @param path The path to the database file
@@ -50,6 +48,7 @@ struct HcacheOps
    * all other backend-specific functions (see below).
    */
   void *(*open)(const char *path);
+
   /**
    * fetch - backend-specific routine to fetch a message's headers
    * @param ctx    The backend-specific context retrieved via open()
@@ -59,12 +58,14 @@ struct HcacheOps
    * @retval NULL Otherwise
    */
   void *(*fetch)(void *ctx, const char *key, size_t keylen, size_t *dlen);
+
   /**
    * free - backend-specific routine to free fetched data
    * @param[in]  ctx The backend-specific context retrieved via open()
    * @param[out] data A pointer to the data got with fetch() or fetch_raw()
    */
   void (*free)(void *ctx, void **data);
+
   /**
    * store - backend-specific routine to store a message's headers
    * @param ctx     The backend-specific context retrieved via open()
@@ -76,6 +77,7 @@ struct HcacheOps
    * @retval num Error, a backend-specific error code
    */
   int (*store)(void *ctx, const char *key, size_t keylen, void *data, size_t datalen);
+
   /**
    * delete_header - backend-specific routine to delete a message's headers
    * @param ctx    The backend-specific context retrieved via open()
@@ -85,6 +87,7 @@ struct HcacheOps
    * @retval num Error, a backend-specific error code
    */
   int (*delete_header)(void *ctx, const char *key, size_t keylen);
+
   /**
    * close - backend-specific routine to close a context
    * @param[out] ctx The backend-specific context retrieved via open()
@@ -94,6 +97,7 @@ struct HcacheOps
    * to the context, so that FREE can be invoked on it.
    */
   void (*close)(void **ctx);
+
   /**
    * backend - backend-specific identification string
    * @retval ptr String describing the currently used hcache backend

--- a/hcache/compr.h
+++ b/hcache/compr.h
@@ -30,10 +30,7 @@
  */
 struct ComprOps
 {
-  /**
-   * name - Backend name
-   */
-  const char *name;
+  const char *name; ///< Compression name
 
   /**
    * open - Open a compression context

--- a/hdrline.c
+++ b/hdrline.c
@@ -107,7 +107,7 @@ enum FieldType
 };
 
 /**
- * mutt_is_mail_list - Is this the email address of a mailing list?
+ * mutt_is_mail_list - Is this the email address of a mailing list? - Implements ::addr_predicate_t
  * @param addr Address to test
  * @retval true If it's a mailing list
  */
@@ -119,7 +119,7 @@ bool mutt_is_mail_list(const struct Address *addr)
 }
 
 /**
- * mutt_is_subscribed_list - Is this the email address of a user-subscribed mailing list?
+ * mutt_is_subscribed_list - Is this the email address of a user-subscribed mailing list? - Implements ::addr_predicate_t
  * @param addr Address to test
  * @retval true If it's a subscribed mailing list
  */

--- a/hook.c
+++ b/hook.c
@@ -79,7 +79,7 @@ static struct Hash *IdxFmtHooks = NULL;
 static HookFlags current_hook_type = MUTT_HOOK_NO_FLAGS;
 
 /**
- * mutt_parse_hook - Parse the 'hook' family of commands - Implements ::command_t
+ * mutt_parse_hook - Parse the 'hook' family of commands - Implements Command::parse()
  *
  * This is used by 'account-hook', 'append-hook' and many more.
  */
@@ -350,7 +350,7 @@ static void delete_idxfmt_hooks(void)
 }
 
 /**
- * mutt_parse_idxfmt_hook - Parse the 'index-format-hook' command - Implements ::command_t
+ * mutt_parse_idxfmt_hook - Parse the 'index-format-hook' command - Implements Command::parse()
  */
 enum CommandResult mutt_parse_idxfmt_hook(struct Buffer *buf, struct Buffer *s,
                                           unsigned long data, struct Buffer *err)
@@ -452,7 +452,7 @@ out:
 }
 
 /**
- * mutt_parse_unhook - Parse the 'unhook' command - Implements ::command_t
+ * mutt_parse_unhook - Parse the 'unhook' command - Implements Command::parse()
  */
 enum CommandResult mutt_parse_unhook(struct Buffer *buf, struct Buffer *s,
                                      unsigned long data, struct Buffer *err)

--- a/hook.c
+++ b/hook.c
@@ -321,7 +321,7 @@ void mutt_delete_hooks(HookFlags type)
 }
 
 /**
- * delete_idxfmt_hooklist - Delete a index-format-hook from the Hash Table
+ * delete_idxfmt_hooklist - Delete a index-format-hook from the Hash Table - Implements ::hashelem_free_t
  * @param type Type of Hash Element
  * @param obj  Pointer to Hashed object
  * @param data Private data

--- a/icommands.c
+++ b/icommands.c
@@ -95,7 +95,7 @@ enum CommandResult mutt_parse_icommand(/* const */ char *line, struct Buffer *er
     if (mutt_str_strcmp(token->data, ICommandList[i].name) != 0)
       continue;
 
-    rc = ICommandList[i].func(token, &expn, ICommandList[i].data, err);
+    rc = ICommandList[i].parse(token, &expn, ICommandList[i].data, err);
     if (rc != 0)
       goto finish;
 
@@ -226,7 +226,7 @@ static void dump_all_menus(struct Buffer *buf, bool bind)
 }
 
 /**
- * icmd_bind - Parse 'bind' and 'macro' commands - Implements ::icommand_t
+ * icmd_bind - Parse 'bind' and 'macro' commands - Implements ICommand::parse()
  */
 static enum CommandResult icmd_bind(struct Buffer *buf, struct Buffer *s,
                                     unsigned long data, struct Buffer *err)
@@ -302,7 +302,7 @@ static enum CommandResult icmd_bind(struct Buffer *buf, struct Buffer *s,
 }
 
 /**
- * icmd_set - Parse 'set' command to display config - Implements ::icommand_t
+ * icmd_set - Parse 'set' command to display config - Implements ICommand::parse()
  */
 static enum CommandResult icmd_set(struct Buffer *buf, struct Buffer *s,
                                    unsigned long data, struct Buffer *err)
@@ -345,7 +345,7 @@ static enum CommandResult icmd_set(struct Buffer *buf, struct Buffer *s,
 }
 
 /**
- * icmd_version - Parse 'version' command - Implements ::icommand_t
+ * icmd_version - Parse 'version' command - Implements ICommand::parse()
  */
 static enum CommandResult icmd_version(struct Buffer *buf, struct Buffer *s,
                                        unsigned long data, struct Buffer *err)

--- a/icommands.h
+++ b/icommands.h
@@ -29,22 +29,22 @@
 struct Buffer;
 
 /**
- * typedef icommand_t - Prototype for information commands
- * @param buf  Command
- * @param s    Entire command line
- * @param data Private data to pass to parse function
- * @param err  Buffer for error messages
- * @retval #CommandResult Result, e.g. #MUTT_CMD_SUCCESS
- */
-typedef enum CommandResult (*icommand_t)(struct Buffer *buf, struct Buffer *s, unsigned long data, struct Buffer *err);
-
-/**
  * struct ICommand - An Informational Command
  */
 struct ICommand
 {
-  char *name;         ///< Name of the command
-  icommand_t func;    ///< Function to parse the command
+  char *name; ///< Name of the command
+
+  /**
+   * parse - Function to parse information commands
+   * @param buf  Command
+   * @param s    Entire command line
+   * @param data Private data to pass to parse function
+   * @param err  Buffer for error messages
+   * @retval #CommandResult Result, e.g. #MUTT_CMD_SUCCESS
+   */
+  enum CommandResult (*parse)(struct Buffer *buf, struct Buffer *s, unsigned long data, struct Buffer *err);
+
   unsigned long data; ///< Private data to pass to the command
 };
 

--- a/imap/auth.c
+++ b/imap/auth.c
@@ -38,6 +38,23 @@
 struct Slist *C_ImapAuthenticators; ///< Config: (imap) List of allowed IMAP authentication methods
 
 /**
+ * struct ImapAuth - IMAP authentication multiplexor
+ */
+struct ImapAuth
+{
+  /**
+   * authenticate - Authenticate an IMAP connection
+   * @param adata Imap Account data
+   * @param method Use this named method, or any available method if NULL
+   * @retval #ImapAuthRes Result, e.g. #IMAP_AUTH_SUCCESS
+   */
+  enum ImapAuthRes (*authenticate)(struct ImapAccountData *adata, const char *method);
+
+  const char *method; ///< Name of authentication method supported, NULL means variable.
+      ///< If this is not null, authenticate may ignore the second parameter.
+};
+
+/**
  * imap_authenticators - Accepted authentication methods
  */
 static const struct ImapAuth imap_authenticators[] = {

--- a/imap/auth.h
+++ b/imap/auth.h
@@ -40,18 +40,6 @@ enum ImapAuthRes
   IMAP_AUTH_UNAVAIL,     ///< Authentication method not permitted
 };
 
-/**
- * struct ImapAuth - IMAP authentication multiplexor
- */
-struct ImapAuth
-{
-  /* do authentication, using named method or any available if method is NULL */
-  enum ImapAuthRes (*authenticate)(struct ImapAccountData *adata, const char *method);
-  /* name of authentication method supported, NULL means variable. If this
-   * is not null, authenticate may ignore the second parameter. */
-  const char *method;
-};
-
 /* external authenticator prototypes */
 enum ImapAuthRes imap_auth_plain(struct ImapAccountData *adata, const char *method);
 #ifndef USE_SASL

--- a/imap/auth_anon.c
+++ b/imap/auth_anon.c
@@ -34,7 +34,7 @@
 #include "mutt_socket.h"
 
 /**
- * imap_auth_anon - Authenticate anonymously
+ * imap_auth_anon - Authenticate anonymously - Implements ImapAuth::authenticate()
  * @param adata Imap Account data
  * @param method Name of this authentication method
  * @retval #ImapAuthRes Result, e.g. #IMAP_AUTH_SUCCESS

--- a/imap/auth_cram.c
+++ b/imap/auth_cram.c
@@ -89,7 +89,7 @@ static void hmac_md5(const char *password, char *challenge, unsigned char *respo
 }
 
 /**
- * imap_auth_cram_md5 - Authenticate using CRAM-MD5
+ * imap_auth_cram_md5 - Authenticate using CRAM-MD5 - Implements ImapAuth::authenticate()
  * @param adata Imap Account data
  * @param method Name of this authentication method
  * @retval #ImapAuthRes Result, e.g. #IMAP_AUTH_SUCCESS

--- a/imap/auth_gss.c
+++ b/imap/auth_gss.c
@@ -98,7 +98,7 @@ static void print_gss_error(OM_uint32 err_maj, OM_uint32 err_min)
 }
 
 /**
- * imap_auth_gss - GSS Authentication support
+ * imap_auth_gss - GSS Authentication support - Implements ImapAuth::authenticate()
  * @param adata Imap Account data
  * @param method Name of this authentication method
  * @retval #ImapAuthRes Result, e.g. #IMAP_AUTH_SUCCESS

--- a/imap/auth_login.c
+++ b/imap/auth_login.c
@@ -36,7 +36,7 @@
 #include "mutt_logging.h"
 
 /**
- * imap_auth_login - Plain LOGIN support
+ * imap_auth_login - Plain LOGIN support - Implements ImapAuth::authenticate()
  * @param adata Imap Account data
  * @param method Name of this authentication method
  * @retval #ImapAuthRes Result, e.g. #IMAP_AUTH_SUCCESS

--- a/imap/auth_oauth.c
+++ b/imap/auth_oauth.c
@@ -38,9 +38,9 @@
 #include "mutt_socket.h"
 
 /**
- * imap_auth_oauth - Authenticate an IMAP connection using OAUTHBEARER
+ * imap_auth_oauth - Authenticate an IMAP connection using OAUTHBEARER - Implements ImapAuth::authenticate()
  * @param adata Imap Account data
- * @param method Name of this authentication method (UNUSED)
+ * @param method Name of this authentication method
  * @retval num Result, e.g. #IMAP_AUTH_SUCCESS
  */
 enum ImapAuthRes imap_auth_oauth(struct ImapAccountData *adata, const char *method)

--- a/imap/auth_plain.c
+++ b/imap/auth_plain.c
@@ -36,7 +36,7 @@
 #include "mutt_socket.h"
 
 /**
- * imap_auth_plain - SASL PLAIN support
+ * imap_auth_plain - SASL PLAIN support - Implements ImapAuth::authenticate()
  * @param adata Imap Account data
  * @param method Name of this authentication method
  * @retval #ImapAuthRes Result, e.g. #IMAP_AUTH_SUCCESS

--- a/imap/auth_sasl.c
+++ b/imap/auth_sasl.c
@@ -40,7 +40,7 @@
 #include "mutt_socket.h"
 
 /**
- * imap_auth_sasl - Default authenticator if available
+ * imap_auth_sasl - Default authenticator if available - Implements ImapAuth::authenticate()
  * @param adata Imap Account data
  * @param method Name of this authentication method
  * @retval #ImapAuthRes Result, e.g. #IMAP_AUTH_SUCCESS

--- a/imap/util.c
+++ b/imap/util.c
@@ -83,8 +83,8 @@ void imap_adata_free(void **ptr)
 
   if (adata->conn)
   {
-    if (adata->conn->conn_close)
-      adata->conn->conn_close(adata->conn);
+    if (adata->conn->close)
+      adata->conn->close(adata->conn);
     FREE(&adata->conn);
   }
 

--- a/imap/util.c
+++ b/imap/util.c
@@ -344,7 +344,7 @@ void imap_clean_path(char *path, size_t plen)
 }
 
 /**
- * imap_get_field - Get connection login credentials - Implements ::ca_get_field_t
+ * imap_get_field - Get connection login credentials - Implements ConnAccount::get_field()
  */
 static const char *imap_get_field(enum ConnAccountField field)
 {

--- a/index.c
+++ b/index.c
@@ -822,7 +822,7 @@ static int main_change_folder(struct Menu *menu, int op, struct Mailbox *m,
 }
 
 /**
- * index_make_entry - Format a menu item for the index list - Implements Menu::menu_make_entry()
+ * index_make_entry - Format a menu item for the index list - Implements Menu::make_entry()
  */
 void index_make_entry(char *buf, size_t buflen, struct Menu *menu, int line)
 {
@@ -896,7 +896,7 @@ void index_make_entry(char *buf, size_t buflen, struct Menu *menu, int line)
 }
 
 /**
- * index_color - Calculate the colour for a line of the index - Implements Menu::menu_color()
+ * index_color - Calculate the colour for a line of the index - Implements Menu::color()
  */
 int index_color(int line)
 {
@@ -1053,7 +1053,7 @@ dsl_finish:
 }
 
 /**
- * index_custom_redraw - Redraw the index - Implements Menu::menu_custom_redraw()
+ * index_custom_redraw - Redraw the index - Implements Menu::custom_redraw()
  */
 static void index_custom_redraw(struct Menu *menu)
 {
@@ -1138,8 +1138,8 @@ int mutt_index_menu(struct MuttWindow *dlg)
   menu->win_index = win_index;
   menu->win_ibar = win_ibar;
 
-  menu->menu_make_entry = index_make_entry;
-  menu->menu_color = index_color;
+  menu->make_entry = index_make_entry;
+  menu->color = index_color;
   menu->current = ci_first_message(Context);
   menu->help = mutt_compile_help(
       helpstr, sizeof(helpstr), MENU_MAIN,
@@ -1148,7 +1148,7 @@ int mutt_index_menu(struct MuttWindow *dlg)
           IndexNewsHelp :
 #endif
           IndexHelp);
-  menu->menu_custom_redraw = index_custom_redraw;
+  menu->custom_redraw = index_custom_redraw;
   mutt_menu_push_current(menu);
   mutt_window_reflow(NULL);
 

--- a/index.c
+++ b/index.c
@@ -652,7 +652,7 @@ void update_index(struct Menu *menu, struct Context *ctx, int check, int oldcoun
 }
 
 /**
- * mailbox_index_observer - Listen for Mailbox changes - Implements ::observer_t()
+ * mailbox_index_observer - Listen for Mailbox changes - Implements ::observer_t
  *
  * If a Mailbox is closed, then set a pointer to NULL.
  */
@@ -3967,7 +3967,7 @@ void mutt_set_header_color(struct Mailbox *m, struct Email *e)
 }
 
 /**
- * mutt_reply_observer - Listen for config changes to "reply_regex" - Implements ::observer_t()
+ * mutt_reply_observer - Listen for config changes to "reply_regex" - Implements ::observer_t
  */
 int mutt_reply_observer(struct NotifyCallback *nc)
 {
@@ -4119,7 +4119,7 @@ void index_pager_shutdown(struct MuttWindow *dlg)
 }
 
 /**
- * mutt_dlg_index_observer - Listen for config changes affecting the Index/Pager - Implements ::observer_t()
+ * mutt_dlg_index_observer - Listen for config changes affecting the Index/Pager - Implements ::observer_t
  */
 int mutt_dlg_index_observer(struct NotifyCallback *nc)
 {

--- a/init.c
+++ b/init.c
@@ -713,7 +713,7 @@ HookFlags mutt_get_hook_type(const char *name)
 {
   for (const struct Command *c = Commands; c->name; c++)
   {
-    if (((c->func == mutt_parse_hook) || (c->func == mutt_parse_idxfmt_hook)) &&
+    if (((c->parse == mutt_parse_hook) || (c->parse == mutt_parse_idxfmt_hook)) &&
         (mutt_str_strcasecmp(c->name, name) == 0))
     {
       return c->data;
@@ -1015,7 +1015,7 @@ enum CommandResult mutt_parse_rc_line(/* const */ char *line,
     {
       if (mutt_str_strcmp(token->data, Commands[i].name) == 0)
       {
-        rc = Commands[i].func(token, &expn, Commands[i].data, err);
+        rc = Commands[i].parse(token, &expn, Commands[i].data, err);
         if (rc != MUTT_CMD_SUCCESS)
         {              /* -1 Error, +1 Finish */
           goto finish; /* Propagate return code */

--- a/init.c
+++ b/init.c
@@ -1560,7 +1560,7 @@ struct ConfigSet *init_config(size_t size)
 }
 
 /**
- * charset_validator - Validate the "charset" config variable - Implements ::cs_validator()
+ * charset_validator - Validate the "charset" config variable - Implements ConfigDef::validator()
  */
 int charset_validator(const struct ConfigSet *cs, const struct ConfigDef *cdef,
                       intptr_t value, struct Buffer *err)
@@ -1600,7 +1600,7 @@ int charset_validator(const struct ConfigSet *cs, const struct ConfigDef *cdef,
 
 #ifdef USE_HCACHE
 /**
- * hcache_validator - Validate the "header_cache_backend" config variable - Implements ::cs_validator()
+ * hcache_validator - Validate the "header_cache_backend" config variable - Implements ConfigDef::validator()
  */
 int hcache_validator(const struct ConfigSet *cs, const struct ConfigDef *cdef,
                      intptr_t value, struct Buffer *err)
@@ -1619,7 +1619,7 @@ int hcache_validator(const struct ConfigSet *cs, const struct ConfigDef *cdef,
 
 #ifdef USE_HCACHE_COMPRESSION
 /**
- * compress_validator - Validate the "header_cache_compress_method" config variable - Implements ::cs_validator()
+ * compress_validator - Validate the "header_cache_compress_method" config variable - Implements ConfigDef::validator()
  */
 int compress_validator(const struct ConfigSet *cs, const struct ConfigDef *cdef,
                        intptr_t value, struct Buffer *err)
@@ -1639,7 +1639,7 @@ int compress_validator(const struct ConfigSet *cs, const struct ConfigDef *cdef,
 #endif /* USE_HCACHE */
 
 /**
- * pager_validator - Check for config variables that can't be set from the pager - Implements ::cs_validator()
+ * pager_validator - Check for config variables that can't be set from the pager - Implements ConfigDef::validator()
  */
 int pager_validator(const struct ConfigSet *cs, const struct ConfigDef *cdef,
                     intptr_t value, struct Buffer *err)
@@ -1655,7 +1655,7 @@ int pager_validator(const struct ConfigSet *cs, const struct ConfigDef *cdef,
 }
 
 /**
- * multipart_validator - Validate the "show_multipart_alternative" config variable - Implements ::cs_validator()
+ * multipart_validator - Validate the "show_multipart_alternative" config variable - Implements ConfigDef::validator()
  */
 int multipart_validator(const struct ConfigSet *cs, const struct ConfigDef *cdef,
                         intptr_t value, struct Buffer *err)
@@ -1673,7 +1673,7 @@ int multipart_validator(const struct ConfigSet *cs, const struct ConfigDef *cdef
 }
 
 /**
- * reply_validator - Validate the "reply_regex" config variable - Implements ::cs_validator()
+ * reply_validator - Validate the "reply_regex" config variable - Implements ConfigDef::validator()
  */
 int reply_validator(const struct ConfigSet *cs, const struct ConfigDef *cdef,
                     intptr_t value, struct Buffer *err)
@@ -1690,7 +1690,7 @@ int reply_validator(const struct ConfigSet *cs, const struct ConfigDef *cdef,
 }
 
 /**
- * wrapheaders_validator - Validate the "wrap_headers" config variable - Implements ::cs_validator()
+ * wrapheaders_validator - Validate the "wrap_headers" config variable - Implements ConfigDef::validator()
  */
 int wrapheaders_validator(const struct ConfigSet *cs, const struct ConfigDef *cdef,
                           intptr_t value, struct Buffer *err)

--- a/keymap.c
+++ b/keymap.c
@@ -1147,7 +1147,7 @@ void km_error_key(enum MenuType menu)
 }
 
 /**
- * mutt_parse_push - Parse the 'push' command - Implements ::command_t
+ * mutt_parse_push - Parse the 'push' command - Implements Command::parse()
  */
 enum CommandResult mutt_parse_push(struct Buffer *buf, struct Buffer *s,
                                    unsigned long data, struct Buffer *err)
@@ -1308,7 +1308,7 @@ const struct Binding *km_get_table(enum MenuType menu)
 }
 
 /**
- * mutt_parse_bind - Parse the 'bind' command - Implements ::command_t
+ * mutt_parse_bind - Parse the 'bind' command - Implements Command::parse()
  *
  * bind menu-name `<key_sequence>` function-name
  */
@@ -1444,7 +1444,7 @@ static void km_unbind_all(struct Keymap **map, unsigned long mode)
 }
 
 /**
- * mutt_parse_unbind - Parse the 'unbind' command - Implements ::command_t
+ * mutt_parse_unbind - Parse the 'unbind' command - Implements Command::parse()
  *
  * Command unbinds:
  * - one binding in one menu-name
@@ -1514,7 +1514,7 @@ enum CommandResult mutt_parse_unbind(struct Buffer *buf, struct Buffer *s,
 }
 
 /**
- * mutt_parse_macro - Parse the 'macro' command - Implements ::command_t
+ * mutt_parse_macro - Parse the 'macro' command - Implements Command::parse()
  *
  * macro `<menu>` `<key>` `<macro>` `<description>`
  */
@@ -1570,7 +1570,7 @@ enum CommandResult mutt_parse_macro(struct Buffer *buf, struct Buffer *s,
 }
 
 /**
- * mutt_parse_exec - Parse the 'exec' command - Implements ::command_t
+ * mutt_parse_exec - Parse the 'exec' command - Implements Command::parse()
  */
 enum CommandResult mutt_parse_exec(struct Buffer *buf, struct Buffer *s,
                                    unsigned long data, struct Buffer *err)

--- a/keymap.c
+++ b/keymap.c
@@ -841,7 +841,7 @@ void mutt_init_abort_key(void)
 }
 
 /**
- * mutt_abort_key_config_observer - Listen for abort_key config changes - Implements ::observer_t()
+ * mutt_abort_key_config_observer - Listen for abort_key config changes - Implements ::observer_t
  */
 int mutt_abort_key_config_observer(struct NotifyCallback *nc)
 {

--- a/menu.c
+++ b/menu.c
@@ -309,13 +309,13 @@ static void print_enriched_string(int index, int attr, unsigned char *s, bool do
 }
 
 /**
- * menu_make_entry - Create string to display in a Menu (the index)
+ * make_entry - Create string to display in a Menu (the index)
  * @param buf    Buffer for the result
  * @param buflen Length of the buffer
  * @param menu Current Menu
  * @param i    Selected item
  */
-static void menu_make_entry(char *buf, size_t buflen, struct Menu *menu, int i)
+static void make_entry(char *buf, size_t buflen, struct Menu *menu, int i)
 {
   if (menu->dialog)
   {
@@ -323,7 +323,7 @@ static void menu_make_entry(char *buf, size_t buflen, struct Menu *menu, int i)
     menu->current = -1; /* hide menubar */
   }
   else
-    menu->menu_make_entry(buf, buflen, menu, i);
+    menu->make_entry(buf, buflen, menu, i);
 }
 
 /**
@@ -419,9 +419,9 @@ void menu_redraw_index(struct Menu *menu)
   {
     if (i < menu->max)
     {
-      attr = menu->menu_color(i);
+      attr = menu->color(i);
 
-      menu_make_entry(buf, sizeof(buf), menu, i);
+      make_entry(buf, sizeof(buf), menu, i);
       menu_pad_string(menu, buf, sizeof(buf));
 
       mutt_curses_set_attr(attr);
@@ -474,7 +474,7 @@ void menu_redraw_motion(struct Menu *menu)
    * over imap (if matching against ~h for instance).  This can
    * generate status messages.  So we want to call it *before* we
    * position the cursor for drawing. */
-  const int old_color = menu->menu_color(menu->oldcurrent);
+  const int old_color = menu->color(menu->oldcurrent);
   mutt_window_move(menu->win_index, menu->oldcurrent + menu->offset - menu->top, 0);
   mutt_curses_set_attr(old_color);
 
@@ -486,7 +486,7 @@ void menu_redraw_motion(struct Menu *menu)
 
     if (menu->redraw & REDRAW_MOTION_RESYNC)
     {
-      menu_make_entry(buf, sizeof(buf), menu, menu->oldcurrent);
+      make_entry(buf, sizeof(buf), menu, menu->oldcurrent);
       menu_pad_string(menu, buf, sizeof(buf));
       mutt_window_move(menu->win_index, menu->oldcurrent + menu->offset - menu->top,
                        mutt_strwidth(C_ArrowString) + 1);
@@ -501,13 +501,13 @@ void menu_redraw_motion(struct Menu *menu)
   else
   {
     /* erase the current indicator */
-    menu_make_entry(buf, sizeof(buf), menu, menu->oldcurrent);
+    make_entry(buf, sizeof(buf), menu, menu->oldcurrent);
     menu_pad_string(menu, buf, sizeof(buf));
     print_enriched_string(menu->oldcurrent, old_color, (unsigned char *) buf, true);
 
     /* now draw the new one to reflect the change */
-    const int cur_color = menu->menu_color(menu->current);
-    menu_make_entry(buf, sizeof(buf), menu, menu->current);
+    const int cur_color = menu->color(menu->current);
+    make_entry(buf, sizeof(buf), menu, menu->current);
     menu_pad_string(menu, buf, sizeof(buf));
     mutt_curses_set_color(MT_COLOR_INDICATOR);
     mutt_window_move(menu->win_index, menu->current + menu->offset - menu->top, 0);
@@ -524,10 +524,10 @@ void menu_redraw_motion(struct Menu *menu)
 void menu_redraw_current(struct Menu *menu)
 {
   char buf[1024];
-  int attr = menu->menu_color(menu->current);
+  int attr = menu->color(menu->current);
 
   mutt_window_move(menu->win_index, menu->current + menu->offset - menu->top, 0);
-  menu_make_entry(buf, sizeof(buf), menu, menu->current);
+  make_entry(buf, sizeof(buf), menu, menu->current);
   menu_pad_string(menu, buf, sizeof(buf));
 
   mutt_curses_set_color(MT_COLOR_INDICATOR);
@@ -941,7 +941,7 @@ static void menu_prev_entry(struct Menu *menu)
 }
 
 /**
- * default_color - Get the default colour for a line of the menu - Implements Menu::menu_color()
+ * default_color - Get the default colour for a line of the menu - Implements Menu::color()
  */
 static int default_color(int line)
 {
@@ -949,13 +949,13 @@ static int default_color(int line)
 }
 
 /**
- * generic_search - Search a menu for a item matching a regex - Implements Menu::menu_search()
+ * generic_search - Search a menu for a item matching a regex - Implements Menu::search()
  */
 static int generic_search(struct Menu *menu, regex_t *rx, int line)
 {
   char buf[1024];
 
-  menu_make_entry(buf, sizeof(buf), menu, line);
+  make_entry(buf, sizeof(buf), menu, line);
   return regexec(rx, buf, 0, NULL, 0);
 }
 
@@ -982,8 +982,8 @@ struct Menu *mutt_menu_new(enum MenuType type)
   menu->top = 0;
   menu->offset = 0;
   menu->redraw = REDRAW_FULL;
-  menu->menu_color = default_color;
-  menu->menu_search = generic_search;
+  menu->color = default_color;
+  menu->search = generic_search;
 
   return menu;
 }
@@ -1154,13 +1154,13 @@ void mutt_menu_current_redraw(void)
 }
 
 /**
- * menu_search - Search a menu
+ * search - Search a menu
  * @param menu Menu to search
  * @param op   Search operation, e.g. OP_SEARCH_NEXT
  * @retval >=0 Index of matching item
  * @retval -1  Search failed, or was cancelled
  */
-static int menu_search(struct Menu *menu, int op)
+static int search(struct Menu *menu, int op)
 {
   int rc = 0, wrap = 0;
   int search_dir;
@@ -1212,7 +1212,7 @@ search_next:
     mutt_message(_("Search wrapped to top"));
   while ((rc >= 0) && (rc < menu->max))
   {
-    if (menu->menu_search(menu, &re, rc) == 0)
+    if (menu->search(menu, &re, rc) == 0)
     {
       regfree(&re);
       return rc;
@@ -1303,9 +1303,9 @@ static int menu_dialog_dokey(struct Menu *menu, int *ip)
  */
 int menu_redraw(struct Menu *menu)
 {
-  if (menu->menu_custom_redraw)
+  if (menu->custom_redraw)
   {
-    menu->menu_custom_redraw(menu);
+    menu->custom_redraw(menu);
     return OP_NULL;
   }
 
@@ -1508,10 +1508,10 @@ int mutt_menu_loop(struct Menu *menu)
       case OP_SEARCH_REVERSE:
       case OP_SEARCH_NEXT:
       case OP_SEARCH_OPPOSITE:
-        if (menu->menu_search && !menu->dialog) /* Searching dialogs won't work */
+        if (menu->search && !menu->dialog) /* Searching dialogs won't work */
         {
           menu->oldcurrent = menu->current;
-          menu->current = menu_search(menu, i);
+          menu->current = search(menu, i);
           if (menu->current != -1)
             menu->redraw = REDRAW_MOTION;
           else
@@ -1533,17 +1533,17 @@ int mutt_menu_loop(struct Menu *menu)
         break;
 
       case OP_TAG:
-        if (menu->menu_tag && !menu->dialog)
+        if (menu->tag && !menu->dialog)
         {
           if (menu->tagprefix && !C_AutoTag)
           {
             for (i = 0; i < menu->max; i++)
-              menu->tagged += menu->menu_tag(menu, i, 0);
+              menu->tagged += menu->tag(menu, i, 0);
             menu->redraw |= REDRAW_INDEX;
           }
           else if (menu->max)
           {
-            int j = menu->menu_tag(menu, menu->current, -1);
+            int j = menu->tag(menu, menu->current, -1);
             menu->tagged += j;
             if (j && C_Resolve && (menu->current < menu->max - 1))
             {

--- a/menu.c
+++ b/menu.c
@@ -1599,7 +1599,7 @@ int mutt_menu_loop(struct Menu *menu)
 }
 
 /**
- * mutt_menu_color_observer - Listen for colour changes affecting the menu - Implements ::observer_t()
+ * mutt_menu_color_observer - Listen for colour changes affecting the menu - Implements ::observer_t
  */
 int mutt_menu_color_observer(struct NotifyCallback *nc)
 {
@@ -1643,7 +1643,7 @@ int mutt_menu_color_observer(struct NotifyCallback *nc)
 }
 
 /**
- * mutt_menu_config_observer - Listen for config changes affecting the menu - Implements ::observer_t()
+ * mutt_menu_config_observer - Listen for config changes affecting the menu - Implements ::observer_t
  */
 int mutt_menu_config_observer(struct NotifyCallback *nc)
 {

--- a/mutt/hash.c
+++ b/mutt/hash.c
@@ -37,7 +37,7 @@
 #define SOME_PRIME 149711
 
 /**
- * gen_string_hash - Generate a hash from a string
+ * gen_string_hash - Generate a hash from a string - Implements Hash::gen_hash()
  * @param key String key
  * @param n   Number of elements in the Hash table
  * @retval num Cryptographic hash of the string
@@ -55,7 +55,7 @@ static size_t gen_string_hash(union HashKey key, size_t n)
 }
 
 /**
- * cmp_string_key - Compare two string keys
+ * cmp_string_key - Compare two string keys - Implements Hash::cmp_key()
  * @param a First key to compare
  * @param b Second key to compare
  * @retval -1 a precedes b
@@ -68,7 +68,7 @@ static int cmp_string_key(union HashKey a, union HashKey b)
 }
 
 /**
- * gen_case_string_hash - Generate a hash from a string (ignore the case)
+ * gen_case_string_hash - Generate a hash from a string (ignore the case) - Implements Hash::gen_hash()
  * @param key String key
  * @param n   Number of elements in the Hash table
  * @retval num Cryptographic hash of the string
@@ -86,7 +86,7 @@ static size_t gen_case_string_hash(union HashKey key, size_t n)
 }
 
 /**
- * cmp_case_string_key - Compare two string keys (ignore case)
+ * cmp_case_string_key - Compare two string keys (ignore case) - Implements Hash::cmp_key()
  * @param a First key to compare
  * @param b Second key to compare
  * @retval -1 a precedes b
@@ -99,7 +99,7 @@ static int cmp_case_string_key(union HashKey a, union HashKey b)
 }
 
 /**
- * gen_int_hash - Generate a hash from an integer
+ * gen_int_hash - Generate a hash from an integer - Implements Hash::gen_hash()
  * @param key Integer key
  * @param n   Number of elements in the Hash table
  * @retval num Cryptographic hash of the integer
@@ -110,7 +110,7 @@ static size_t gen_int_hash(union HashKey key, size_t n)
 }
 
 /**
- * cmp_int_key - Compare two integer keys
+ * cmp_int_key - Compare two integer keys - Implements Hash::cmp_key()
  * @param a First key to compare
  * @param b Second key to compare
  * @retval -1 a precedes b

--- a/mutt_commands.h
+++ b/mutt_commands.h
@@ -39,22 +39,22 @@ enum CommandResult
 };
 
 /**
- * typedef command_t - Prototype for a function to parse a command
- * @param buf  Temporary Buffer space
- * @param s    Buffer containing string to be parsed
- * @param data Flags associated with the command
- * @param err  Buffer for error messages
- * @retval #CommandResult Result e.g. #MUTT_CMD_SUCCESS
- */
-typedef enum CommandResult (*command_t)(struct Buffer *buf, struct Buffer *s, unsigned long data, struct Buffer *err);
-
-/**
  * struct Command - A user-callable command
  */
 struct Command
 {
   const char *name; ///< Name of the command
-  command_t func;   ///< Function to parse the command
+
+  /**
+   * parse - Function to parse a command
+   * @param buf  Temporary Buffer space
+   * @param s    Buffer containing string to be parsed
+   * @param data Flags associated with the command
+   * @param err  Buffer for error messages
+   * @retval #CommandResult Result e.g. #MUTT_CMD_SUCCESS
+   */
+  enum CommandResult (*parse)(struct Buffer *buf, struct Buffer *s, unsigned long data, struct Buffer *err);
+
   intptr_t data;    ///< Data or flags to pass to the command
 };
 

--- a/mutt_history.c
+++ b/mutt_history.c
@@ -74,7 +74,7 @@ static const char *history_format_str(char *buf, size_t buflen, size_t col, int 
 }
 
 /**
- * history_make_entry - Format a menu item for the history list - Implements Menu::menu_make_entry()
+ * history_make_entry - Format a menu item for the history list - Implements Menu::make_entry()
  */
 static void history_make_entry(char *buf, size_t buflen, struct Menu *menu, int line)
 {
@@ -133,7 +133,7 @@ static void history_menu(char *buf, size_t buflen, char **matches, int match_cou
   menu->win_index = index;
   menu->win_ibar = ibar;
 
-  menu->menu_make_entry = history_make_entry;
+  menu->make_entry = history_make_entry;
   menu->title = title;
   menu->help = mutt_compile_help(helpstr, sizeof(helpstr), MENU_GENERIC, HistoryHelp);
   mutt_menu_push_current(menu);

--- a/mutt_history.c
+++ b/mutt_history.c
@@ -182,7 +182,7 @@ void mutt_hist_complete(char *buf, size_t buflen, enum HistoryClass hclass)
 }
 
 /**
- * mutt_hist_observer - Listen for config changes affecting the history - Implements ::observer_t()
+ * mutt_hist_observer - Listen for config changes affecting the history - Implements ::observer_t
  */
 int mutt_hist_observer(struct NotifyCallback *nc)
 {

--- a/mutt_logging.c
+++ b/mutt_logging.c
@@ -318,7 +318,7 @@ int level_validator(const struct ConfigSet *cs, const struct ConfigDef *cdef,
 }
 
 /**
- * mutt_log_observer - Listen for config changes affecting the log file - Implements ::observer_t()
+ * mutt_log_observer - Listen for config changes affecting the log file - Implements ::observer_t
  */
 int mutt_log_observer(struct NotifyCallback *nc)
 {

--- a/mutt_logging.c
+++ b/mutt_logging.c
@@ -297,7 +297,7 @@ int mutt_log_start(void)
 }
 
 /**
- * level_validator - Validate the "debug_level" config variable
+ * level_validator - Validate the "debug_level" config variable - Implements ConfigDef::validator()
  * @param cs    Config items
  * @param cdef  Config definition
  * @param value Native value

--- a/mutt_lua.c
+++ b/mutt_lua.c
@@ -118,7 +118,7 @@ static int lua_mutt_call(lua_State *l)
   expn.dptr = buf;
   expn.dsize = mutt_str_strlen(buf);
 
-  if (cmd->func(token, &expn, cmd->data, err))
+  if (cmd->parse(token, &expn, cmd->data, err))
   {
     luaL_error(l, "NeoMutt error: %s", mutt_b2s(err));
     rc = -1;
@@ -442,7 +442,7 @@ static bool lua_init(lua_State **l)
 }
 
 /**
- * mutt_lua_parse - Parse the 'lua' command - Implements ::command_t
+ * mutt_lua_parse - Parse the 'lua' command - Implements Command::parse()
  */
 enum CommandResult mutt_lua_parse(struct Buffer *buf, struct Buffer *s,
                                   unsigned long data, struct Buffer *err)
@@ -464,7 +464,7 @@ enum CommandResult mutt_lua_parse(struct Buffer *buf, struct Buffer *s,
 }
 
 /**
- * mutt_lua_source_file - Parse the 'lua-source' command - Implements ::command_t
+ * mutt_lua_source_file - Parse the 'lua-source' command - Implements Command::parse()
  */
 enum CommandResult mutt_lua_source_file(struct Buffer *buf, struct Buffer *s,
                                         unsigned long data, struct Buffer *err)

--- a/mutt_menu.h
+++ b/mutt_menu.h
@@ -111,42 +111,47 @@ struct Menu
   int tagged;             ///< Number of tagged entries
 
   /**
-   * menu_make_entry - Format a item for a menu
+   * make_entry - Format a item for a menu
    * @param[out] buf    Buffer in which to save string
    * @param[in]  buflen Buffer length
    * @param[in]  menu   Menu containing items
    * @param[in]  line   Menu line number
    */
-  void (*menu_make_entry)(char *buf, size_t buflen, struct Menu *menu, int line);
+  void (*make_entry)(char *buf, size_t buflen, struct Menu *menu, int line);
+
   /**
-   * menu_search - Search a menu for a item matching a regex
+   * search - Search a menu for a item matching a regex
    * @param menu Menu to search
    * @param rx   Regex to match
    * @param line Menu entry to match
    * @retval  0 Success
    * @retval >0 Error, e.g. REG_NOMATCH
    */
-  int (*menu_search)(struct Menu *menu, regex_t *rx, int line);
+  int (*search)(struct Menu *menu, regex_t *rx, int line);
+
   /**
-   * menu_tag - Tag some menu items
+   * tag - Tag some menu items
    * @param menu Menu to tag
    * @param sel  Current selection
    * @param act  Action: 0 untag, 1 tag, -1 toggle
    * @retval num Net change in number of tagged attachments
    */
-  int (*menu_tag)(struct Menu *menu, int sel, int act);
+  int (*tag)(struct Menu *menu, int sel, int act);
+
   /**
-   * menu_color - Calculate the colour for a line of the menu
+   * color - Calculate the colour for a line of the menu
    * @param line Menu line number
    * @retval >0 Colour pair in an integer
    * @retval  0 No colour
    */
-  int (*menu_color)(int line);
+  int (*color)(int line);
+
   /**
-   * menu_custom_redraw - Redraw the menu
+   * custom_redraw - Redraw the menu
    * @param menu Menu to redraw
    */
-  void (*menu_custom_redraw)(struct Menu *menu);
+  void (*custom_redraw)(struct Menu *menu);
+
   void *redraw_data;
 };
 

--- a/mutt_signal.c
+++ b/mutt_signal.c
@@ -40,7 +40,7 @@
 static int IsEndwin = 0;
 
 /**
- * curses_signal_handler - Catch signals and relay the info to the main program
+ * curses_signal_handler - Catch signals and relay the info to the main program - Implements ::sig_handler_t
  * @param sig Signal number, e.g. SIGINT
  */
 static void curses_signal_handler(int sig)
@@ -80,7 +80,7 @@ static void curses_signal_handler(int sig)
 }
 
 /**
- * curses_exit_handler - Notify the user and shutdown gracefully
+ * curses_exit_handler - Notify the user and shutdown gracefully - Implements ::sig_handler_t
  * @param sig Signal number, e.g. SIGTERM
  */
 static void curses_exit_handler(int sig)
@@ -92,7 +92,7 @@ static void curses_exit_handler(int sig)
 }
 
 /**
- * curses_segv_handler - Catch a segfault and print a backtrace
+ * curses_segv_handler - Catch a segfault and print a backtrace - Implements ::sig_handler_t
  * @param sig Signal number, e.g. SIGSEGV
  */
 static void curses_segv_handler(int sig)

--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -3641,7 +3641,7 @@ static const char *crypt_format_str(char *buf, size_t buflen, size_t col, int co
 }
 
 /**
- * crypt_make_entry - Format a menu item for the key selection list - Implements Menu::menu_make_entry()
+ * crypt_make_entry - Format a menu item for the key selection list - Implements Menu::make_entry()
  */
 static void crypt_make_entry(char *buf, size_t buflen, struct Menu *menu, int line)
 {
@@ -4819,7 +4819,7 @@ static struct CryptKeyInfo *crypt_select_key(struct CryptKeyInfo *keys,
   menu->win_ibar = ibar;
 
   menu->max = i;
-  menu->menu_make_entry = crypt_make_entry;
+  menu->make_entry = crypt_make_entry;
   menu->help = helpstr;
   menu->data = key_table;
   mutt_menu_push_current(menu);

--- a/ncrypt/crypt_mod.h
+++ b/ncrypt/crypt_mod.h
@@ -48,11 +48,13 @@ struct CryptModuleSpecs
   /**
    * init - Initialise the crypto module
    */
-  void         (*init)(void);
+  void (*init)(void);
+
   /**
    * void_passphrase - Forget the cached passphrase
    */
-  void         (*void_passphrase)(void);
+  void (*void_passphrase)(void);
+
   /**
    * valid_passphrase - Ensure we have a valid passphrase
    * @retval true  Success
@@ -61,7 +63,8 @@ struct CryptModuleSpecs
    * If the passphrase is within the expiry time (backend-specific), use it.
    * If not prompt the user again.
    */
-  bool         (*valid_passphrase)(void);
+  bool (*valid_passphrase)(void);
+
   /**
    * decrypt_mime - Decrypt an encrypted MIME part
    * @param[in]  fp_in  File containing the encrypted part
@@ -71,7 +74,8 @@ struct CryptModuleSpecs
    * @retval  0 Success
    * @retval -1 Failure
    */
-  int          (*decrypt_mime)(FILE *fp_in, FILE **fp_out, struct Body *b, struct Body **cur);
+  int (*decrypt_mime)(FILE *fp_in, FILE **fp_out, struct Body *b, struct Body **cur);
+
   /**
    * application_handler - Manage the MIME type "application/pgp" or "application/smime"
    * @param m Body of the email
@@ -79,7 +83,8 @@ struct CryptModuleSpecs
    * @retval 0 Success
    * @retval -1 Error
    */
-  int          (*application_handler)(struct Body *m, struct State *s);
+  int (*application_handler)(struct Body *m, struct State *s);
+
   /**
    * encrypted_handler - Manage a PGP or S/MIME encrypted MIME part
    * @param m Body of the email
@@ -87,7 +92,8 @@ struct CryptModuleSpecs
    * @retval 0 Success
    * @retval -1 Error
    */
-  int          (*encrypted_handler)(struct Body *m, struct State *s);
+  int (*encrypted_handler)(struct Body *m, struct State *s);
+
   /**
    * find_keys - Find the keyids of the recipients of a message
    * @param addrlist    Address List
@@ -98,7 +104,8 @@ struct CryptModuleSpecs
    * If oppenc_mode is true, only keys that can be determined without prompting
    * will be used.
    */
-  char *       (*find_keys)(struct AddressList *addrlist, bool oppenc_mode);
+  char *(*find_keys)(struct AddressList *addrlist, bool oppenc_mode);
+
   /**
    * sign_message - Cryptographically sign the Body of a message
    * @param a Body of the message
@@ -107,6 +114,7 @@ struct CryptModuleSpecs
    * @retval NULL Error
    */
   struct Body *(*sign_message)(struct Body *a, const struct AddressList *from);
+
   /**
    * verify_one - Check a signed MIME part against a signature
    * @param sigbdy Body of the signed mail
@@ -115,18 +123,20 @@ struct CryptModuleSpecs
    * @retval  0 Success
    * @retval -1 Error
    */
-  int          (*verify_one)(struct Body *sigbdy, struct State *s, const char *tempf);
+  int (*verify_one)(struct Body *sigbdy, struct State *s, const char *tempf);
+
   /**
    * send_menu - Ask the user whether to sign and/or encrypt the email
    * @param e Email
    * @retval num Flags, e.g. #APPLICATION_PGP | #SEC_ENCRYPT
    */
-  int          (*send_menu)(struct Email *e);
+  int (*send_menu)(struct Email *e);
+
   /**
    * set_sender - Set the sender of the email
    * @param sender Email address
    */
-  void         (*set_sender)(const char *sender);
+  void (*set_sender)(const char *sender);
 
   /**
    * pgp_encrypt_message - PGP encrypt an email
@@ -139,14 +149,15 @@ struct CryptModuleSpecs
    *
    * Encrypt the mail body to all the given keys.
    */
-  struct Body *(*pgp_encrypt_message)(struct Body *a, char *keylist, bool sign,
-                                     const struct AddressList *from);
+    struct Body *(*pgp_encrypt_message)(struct Body *a, char *keylist, bool sign, const struct AddressList *from);
+
   /**
    * pgp_make_key_attachment - Generate a public key attachment
    * @retval ptr  New Body containing the attachment
    * @retval NULL Error
    */
   struct Body *(*pgp_make_key_attachment)(void);
+
   /**
    * pgp_check_traditional - Look for inline (non-MIME) PGP content
    * @param fp       File pointer to the current attachment
@@ -155,7 +166,8 @@ struct CryptModuleSpecs
    * @retval 1 It's an inline PGP email
    * @retval 0 It's not inline, or an error
    */
-  int          (*pgp_check_traditional)(FILE *fp, struct Body *b, bool just_one);
+  int (*pgp_check_traditional)(FILE *fp, struct Body *b, bool just_one);
+
   /**
    * pgp_traditional_encryptsign - Create an inline PGP encrypted, signed email
    * @param a       Body of the email
@@ -165,28 +177,32 @@ struct CryptModuleSpecs
    * @retval NULL Error
    */
   struct Body *(*pgp_traditional_encryptsign)(struct Body *a, SecurityFlags flags, char *keylist);
+
   /**
    * pgp_invoke_getkeys - Run a command to download a PGP key
    * @param addr Address to search for
    */
-  void         (*pgp_invoke_getkeys)(struct Address *addr);
+  void (*pgp_invoke_getkeys)(struct Address *addr);
+
   /**
    * pgp_invoke_import - Import a key from a message into the user's public key ring
    * @param fname File containing the message
    */
-  void         (*pgp_invoke_import)(const char *fname);
+  void (*pgp_invoke_import)(const char *fname);
+
   /**
    * pgp_extract_key_from_attachment - Extract PGP key from an attachment
    * @param fp  File containing email
    * @param top Body of the email
    */
-  void         (*pgp_extract_key_from_attachment)(FILE *fp, struct Body *top);
+  void (*pgp_extract_key_from_attachment)(FILE *fp, struct Body *top);
 
   /**
    * smime_getkeys - Get the S/MIME keys required to encrypt this email
    * @param env Envelope of the email
    */
-  void         (*smime_getkeys)(struct Envelope *env);
+  void (*smime_getkeys)(struct Envelope *env);
+
   /**
    * smime_verify_sender - Does the sender match the certificate?
    * @param m Mailbox
@@ -194,7 +210,8 @@ struct CryptModuleSpecs
    * @retval 0 Success
    * @retval 1 Failure
    */
-  int          (*smime_verify_sender)(struct Mailbox *m, struct Email *e);
+  int (*smime_verify_sender)(struct Mailbox *m, struct Email *e);
+
   /**
    * smime_build_smime_entity - Encrypt the email body to all recipients
    * @param a        Body of email
@@ -203,12 +220,13 @@ struct CryptModuleSpecs
    * @retval NULL Error
    */
   struct Body *(*smime_build_smime_entity)(struct Body *a, char *certlist);
+
   /**
    * smime_invoke_import - Add a certificate and update index file (externally)
    * @param infile  File containing certificate
    * @param mailbox Mailbox
    */
-  void         (*smime_invoke_import)(const char *infile, const char *mailbox);
+  void (*smime_invoke_import)(const char *infile, const char *mailbox);
 };
 
 /* High Level crypto module interface */

--- a/ncrypt/pgpkey.c
+++ b/ncrypt/pgpkey.c
@@ -339,7 +339,7 @@ static const char *pgp_entry_fmt(char *buf, size_t buflen, size_t col, int cols,
 }
 
 /**
- * pgp_make_entry - Format a menu item for the pgp key list - Implements Menu::menu_make_entry()
+ * pgp_make_entry - Format a menu item for the pgp key list - Implements Menu::make_entry()
  */
 static void pgp_make_entry(char *buf, size_t buflen, struct Menu *menu, int line)
 {
@@ -708,7 +708,7 @@ static struct PgpKeyInfo *pgp_select_key(struct PgpKeyInfo *keys,
   menu->win_ibar = ibar;
 
   menu->max = i;
-  menu->menu_make_entry = pgp_make_entry;
+  menu->make_entry = pgp_make_entry;
   menu->help = helpstr;
   menu->data = key_table;
   mutt_menu_push_current(menu);

--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -445,7 +445,7 @@ static char *smime_key_flags(KeyFlags flags)
 }
 
 /**
- * smime_make_entry - Format a menu item for the smime key list - Implements Menu::menu_make_entry()
+ * smime_make_entry - Format a menu item for the smime key list - Implements Menu::make_entry()
  */
 static void smime_make_entry(char *buf, size_t buflen, struct Menu *menu, int line)
 {
@@ -592,7 +592,7 @@ static struct SmimeKey *smime_select_key(struct SmimeKey *keys, char *query)
   menu->win_ibar = ibar;
 
   menu->max = table_index;
-  menu->menu_make_entry = smime_make_entry;
+  menu->make_entry = smime_make_entry;
   menu->help = helpstr;
   menu->data = table;
   menu->title = title;

--- a/nntp/newsrc.c
+++ b/nntp/newsrc.c
@@ -979,7 +979,7 @@ const char *nntp_format_str(char *buf, size_t buflen, size_t col, int cols, char
 }
 
 /**
- * nntp_get_field - Get connection login credentials - Implements ::ca_get_field_t
+ * nntp_get_field - Get connection login credentials - Implements ConnAccount::get_field()
  */
 static const char *nntp_get_field(enum ConnAccountField field)
 {

--- a/pager.c
+++ b/pager.c
@@ -1927,7 +1927,7 @@ void mutt_clear_pager_position(void)
 }
 
 /**
- * pager_custom_redraw - Redraw the pager window - Implements Menu::menu_custom_redraw()
+ * pager_custom_redraw - Redraw the pager window - Implements Menu::custom_redraw()
  */
 static void pager_custom_redraw(struct Menu *pager_menu)
 {
@@ -1994,8 +1994,8 @@ static void pager_custom_redraw(struct Menu *pager_menu)
         /* only allocate the space if/when we need the index.
          * Initialise the menu as per the main index */
         rd->menu = mutt_menu_new(MENU_MAIN);
-        rd->menu->menu_make_entry = index_make_entry;
-        rd->menu->menu_color = index_color;
+        rd->menu->make_entry = index_make_entry;
+        rd->menu->color = index_color;
         rd->menu->max = Context ? Context->mailbox->vcount : 0;
         rd->menu->current = rd->extra->email->vnum;
         rd->menu->win_index = rd->extra->win_index;
@@ -2306,7 +2306,7 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
   pager_menu->win_index = extra->win_pager;
   pager_menu->win_ibar = extra->win_pbar;
 
-  pager_menu->menu_custom_redraw = pager_custom_redraw;
+  pager_menu->custom_redraw = pager_custom_redraw;
   pager_menu->redraw_data = &rd;
   mutt_menu_push_current(pager_menu);
 

--- a/pattern.c
+++ b/pattern.c
@@ -162,17 +162,6 @@ enum RangeSide
 };
 
 /**
- * typedef pattern_eat_t - Parse a pattern
- * @param pat   Pattern to store the results in
- * @param flags Flags, e.g. #MUTT_PC_PATTERN_DYNAMIC
- * @param s     String to parse
- * @param err   Buffer for error messages
- * @retval true If the pattern was read successfully
- */
-typedef bool pattern_eat_t(struct Pattern *pat, int flags, struct Buffer *s,
-                           struct Buffer *err);
-
-/**
  * struct PatternFlags - Mapping between user character and internal constant
  */
 struct PatternFlags
@@ -180,7 +169,16 @@ struct PatternFlags
   int tag;   ///< Character used to represent this operation, e.g. 'A' for '~A'
   int op;    ///< Operation to perform, e.g. #MUTT_PAT_SCORE
   int flags; ///< Pattern flags, e.g. #MUTT_PC_FULL_MSG
-  pattern_eat_t *eat_arg; ///< Callback function to parse the argument
+
+  /**
+   * eat_arg - Function to parse a pattern
+   * @param pat   Pattern to store the results in
+   * @param flags Flags, e.g. #MUTT_PC_PATTERN_DYNAMIC
+   * @param s     String to parse
+   * @param err   Buffer for error messages
+   * @retval true If the pattern was read successfully
+   */
+  bool (*eat_arg)(struct Pattern *pat, int flags, struct Buffer *s, struct Buffer *err);
 };
 
 // clang-format off
@@ -210,7 +208,7 @@ static char LastSearchExpn[1024] = { 0 }; ///< expanded version of LastSearch
 typedef bool (*addr_predicate_t)(const struct Address *a);
 
 /**
- * eat_regex - Parse a regex - Implements ::pattern_eat_t
+ * eat_regex - Parse a regex - Implements Pattern::eat_arg()
  */
 static bool eat_regex(struct Pattern *pat, int flags, struct Buffer *s, struct Buffer *err)
 {
@@ -278,7 +276,7 @@ static bool add_query_msgid(char *line, int line_num, void *user_data)
 }
 
 /**
- * eat_query - Parse a query for an external search program - Implements ::pattern_eat_t
+ * eat_query - Parse a query for an external search program - Implements Pattern::eat_arg()
  */
 static bool eat_query(struct Pattern *pat, int flags, struct Buffer *s, struct Buffer *err)
 {
@@ -746,7 +744,7 @@ static bool eval_date_minmax(struct Pattern *pat, const char *s, struct Buffer *
 }
 
 /**
- * eat_range - Parse a number range - Implements ::pattern_eat_t
+ * eat_range - Parse a number range - Implements Pattern::eat_arg()
  */
 static bool eat_range(struct Pattern *pat, int flags, struct Buffer *s, struct Buffer *err)
 {
@@ -1030,7 +1028,7 @@ static int eat_range_by_regex(struct Pattern *pat, struct Buffer *s, int kind,
 }
 
 /**
- * eat_message_range - Parse a range of message numbers - Implements ::pattern_eat_t
+ * eat_message_range - Parse a range of message numbers - Implements Pattern::eat_arg()
  */
 static bool eat_message_range(struct Pattern *pat, int flags, struct Buffer *s,
                               struct Buffer *err)
@@ -1074,7 +1072,7 @@ static bool eat_message_range(struct Pattern *pat, int flags, struct Buffer *s,
 }
 
 /**
- * eat_date - Parse a date pattern - Implements ::pattern_eat_t
+ * eat_date - Parse a date pattern - Implements Pattern::eat_arg()
  */
 static bool eat_date(struct Pattern *pat, int flags, struct Buffer *s, struct Buffer *err)
 {

--- a/pop/pop_lib.c
+++ b/pop/pop_lib.c
@@ -57,7 +57,7 @@ unsigned char C_PopReconnect; ///< Config: (pop) Reconnect to the server is the 
 char *C_PopUser; ///< Config: (pop) Username of the POP server
 
 /**
- * pop_get_field - Get connection login credentials - Implements ::ca_get_field_t
+ * pop_get_field - Get connection login credentials - Implements ConnAccount::get_field()
  */
 const char *pop_get_field(enum ConnAccountField field)
 {

--- a/pop/pop_private.h
+++ b/pop/pop_private.h
@@ -113,11 +113,16 @@ struct PopEmailData
  */
 struct PopAuth
 {
-  /* do authentication, using named method or any available if method is NULL */
-  enum PopAuthRes (*authenticate)(struct PopAccountData *, const char *);
-  /* name of authentication method supported, NULL means variable. If this
-   * is not null, authenticate may ignore the second parameter. */
-  const char *method;
+  /**
+   * authenticate - Authenticate a POP connection
+   * @param adata Pop Account data
+   * @param method Use this named method, or any available method if NULL
+   * @retval #ImapAuthRes Result, e.g. #IMAP_AUTH_SUCCESS
+   */
+  enum PopAuthRes (*authenticate)(struct PopAccountData *adata, const char *method);
+
+  const char *method; ///< Name of authentication method supported, NULL means variable.
+                      ///< If this is not null, authenticate may ignore the second parameter.
 };
 
 /* pop_auth.c */

--- a/postpone.c
+++ b/postpone.c
@@ -202,7 +202,7 @@ void mutt_update_num_postponed(void)
 }
 
 /**
- * post_make_entry - Format a menu item for the email list - Implements Menu::menu_make_entry()
+ * post_make_entry - Format a menu item for the email list - Implements Menu::make_entry()
  */
 static void post_make_entry(char *buf, size_t buflen, struct Menu *menu, int line)
 {
@@ -258,7 +258,7 @@ static struct Email *select_msg(struct Context *ctx)
   menu->win_index = index;
   menu->win_ibar = ibar;
 
-  menu->menu_make_entry = post_make_entry;
+  menu->make_entry = post_make_entry;
   menu->max = ctx->mailbox->msg_count;
   menu->title = _("Postponed Messages");
   menu->data = ctx;

--- a/query.c
+++ b/query.c
@@ -226,7 +226,7 @@ static struct Query *run_query(char *s, int quiet)
 }
 
 /**
- * query_search - Search a Address menu item - Implements Menu::menu_search()
+ * query_search - Search a Address menu item - Implements Menu::search()
  *
  * Try to match various Address fields.
  */
@@ -321,7 +321,7 @@ static const char *query_format_str(char *buf, size_t buflen, size_t col, int co
 }
 
 /**
- * query_make_entry - Format a menu item for the query list - Implements Menu::menu_make_entry()
+ * query_make_entry - Format a menu item for the query list - Implements Menu::make_entry()
  */
 static void query_make_entry(char *buf, size_t buflen, struct Menu *menu, int line)
 {
@@ -334,7 +334,7 @@ static void query_make_entry(char *buf, size_t buflen, struct Menu *menu, int li
 }
 
 /**
- * query_tag - Tag an entry in the Query Menu - Implements Menu::menu_tag()
+ * query_tag - Tag an entry in the Query Menu - Implements Menu::tag()
  */
 static int query_tag(struct Menu *menu, int sel, int act)
 {
@@ -407,9 +407,9 @@ static void query_menu(char *buf, size_t buflen, struct Query *results, bool ret
   menu->win_index = index;
   menu->win_ibar = ibar;
 
-  menu->menu_make_entry = query_make_entry;
-  menu->menu_search = query_search;
-  menu->menu_tag = query_tag;
+  menu->make_entry = query_make_entry;
+  menu->search = query_search;
+  menu->tag = query_tag;
   menu->title = title;
   char helpstr[1024];
   menu->help = mutt_compile_help(helpstr, sizeof(helpstr), MENU_QUERY, QueryHelp);
@@ -468,9 +468,9 @@ static void query_menu(char *buf, size_t buflen, struct Query *results, bool ret
             menu->win_index = index;
             menu->win_ibar = ibar;
 
-            menu->menu_make_entry = query_make_entry;
-            menu->menu_search = query_search;
-            menu->menu_tag = query_tag;
+            menu->make_entry = query_make_entry;
+            menu->search = query_search;
+            menu->tag = query_tag;
             menu->title = title;
             menu->help = mutt_compile_help(helpstr, sizeof(helpstr), MENU_QUERY, QueryHelp);
             mutt_menu_push_current(menu);

--- a/recvattach.c
+++ b/recvattach.c
@@ -433,7 +433,7 @@ const char *attach_format_str(char *buf, size_t buflen, size_t col, int cols,
 }
 
 /**
- * attach_make_entry - Format a menu item for the attachment list - Implements Menu::menu_make_entry()
+ * attach_make_entry - Format a menu item for the attachment list - Implements Menu::make_entry()
  */
 static void attach_make_entry(char *buf, size_t buflen, struct Menu *menu, int line)
 {
@@ -445,7 +445,7 @@ static void attach_make_entry(char *buf, size_t buflen, struct Menu *menu, int l
 }
 
 /**
- * attach_tag - Tag an attachment - Implements Menu::menu_tag()
+ * attach_tag - Tag an attachment - Implements Menu::tag()
  */
 int attach_tag(struct Menu *menu, int sel, int act)
 {
@@ -1459,8 +1459,8 @@ void mutt_view_attachments(struct Email *e)
   menu->win_ibar = ibar;
 
   menu->title = _("Attachments");
-  menu->menu_make_entry = attach_make_entry;
-  menu->menu_tag = attach_tag;
+  menu->make_entry = attach_make_entry;
+  menu->tag = attach_tag;
   menu->help = mutt_compile_help(helpstr, sizeof(helpstr), MENU_ATTACH, AttachHelp);
   mutt_menu_push_current(menu);
 

--- a/remailer.c
+++ b/remailer.c
@@ -508,13 +508,13 @@ static const char *mix_format_str(char *buf, size_t buflen, size_t col, int cols
 }
 
 /**
- * mix_entry - Format a menu item for the mixmaster chain list
+ * mix_make_entry - Format a menu item for the mixmaster chain list - Implements Menu::make_entry()
  * @param[out] buf    Buffer in which to save string
  * @param[in]  buflen Buffer length
  * @param[in]  menu   Menu containing aliases
  * @param[in]  num    Index into the menu
  */
-static void mix_entry(char *buf, size_t buflen, struct Menu *menu, int num)
+static void mix_make_entry(char *buf, size_t buflen, struct Menu *menu, int num)
 {
   struct Remailer **type2_list = menu->data;
   mutt_expando_format(buf, buflen, 0, menu->win_index->state.cols,
@@ -672,8 +672,8 @@ void mix_make_chain(struct MuttWindow *win, struct ListHead *chainhead, int cols
   menu->win_ibar = ibar;
 
   menu->max = ttll;
-  menu->menu_make_entry = mix_entry;
-  menu->menu_tag = NULL;
+  menu->make_entry = mix_make_entry;
+  menu->tag = NULL;
   menu->title = _("Select a remailer chain");
   menu->data = type2_list;
   menu->help = mutt_compile_help(helpstr, sizeof(helpstr), MENU_MIX, RemailerHelp);

--- a/remailer.c
+++ b/remailer.c
@@ -561,7 +561,7 @@ static int mix_chain_add(struct MixChain *chain, const char *s, struct Remailer 
 }
 
 /**
- * mutt_dlg_mixmaster_observer - Listen for config changes affecting the Mixmaster menu - Implements ::observer_t()
+ * mutt_dlg_mixmaster_observer - Listen for config changes affecting the Mixmaster menu - Implements ::observer_t
  */
 static int mutt_dlg_mixmaster_observer(struct NotifyCallback *nc)
 {

--- a/score.c
+++ b/score.c
@@ -97,7 +97,7 @@ void mutt_check_rescore(struct Mailbox *m)
 }
 
 /**
- * mutt_parse_score - Parse the 'score' command - Implements ::command_t
+ * mutt_parse_score - Parse the 'score' command - Implements Command::parse()
  */
 enum CommandResult mutt_parse_score(struct Buffer *buf, struct Buffer *s,
                                     unsigned long data, struct Buffer *err)
@@ -201,7 +201,7 @@ void mutt_score_message(struct Mailbox *m, struct Email *e, bool upd_mbox)
 }
 
 /**
- * mutt_parse_unscore - Parse the 'unscore' command - Implements ::command_t
+ * mutt_parse_unscore - Parse the 'unscore' command - Implements Command::parse()
  */
 enum CommandResult mutt_parse_unscore(struct Buffer *buf, struct Buffer *s,
                                       unsigned long data, struct Buffer *err)

--- a/sidebar.c
+++ b/sidebar.c
@@ -1203,7 +1203,7 @@ void mutt_sb_notify_mailbox(struct Mailbox *m, bool created)
 }
 
 /**
- * mutt_sb_observer - Listen for config changes affecting the sidebar - Implements ::observer_t()
+ * mutt_sb_observer - Listen for config changes affecting the sidebar - Implements ::observer_t
  * @param nc Notification data
  * @retval bool True, if successful
  */

--- a/smtp.c
+++ b/smtp.c
@@ -323,7 +323,7 @@ static bool addresses_use_unicode(const struct AddressList *al)
 }
 
 /**
- * smtp_get_field - Get connection login credentials - Implements ::ca_get_field_t
+ * smtp_get_field - Get connection login credentials - Implements ConnAccount::get_field()
  */
 static const char *smtp_get_field(enum ConnAccountField field)
 {


### PR DESCRIPTION
There are no functional changes.

- tidy existing api functions
  Add comments, add missing parameter names

**tidy**: add/fix comments

- `struct CryptModuleSpecs`
- `struct Hash`
- `struct HcacheOps`
- `struct ImapAuth`
- `struct Observer`
- `struct PopAuth`

**abbreviate**: remove prefix from functions, e.g. `conn->conn_poll()` becomes `conn->poll()`
The objects are already well-named, so this reduces some duplication.

- `struct Connection`
- `struct Menu`
- `struct SaslSockData`

**fold**: Eliminate lots of single-use typedefs
Rather than `typedef`ing a function only to use it in a `struct`, move the function into the `struct`.

- `struct Command`
- `struct ConfigDef`
- `struct ConfigSetType`
- `struct ConnAccount`
- `struct ICommand`
- `struct Pattern`

