### PR TITLE
fix command line sending

### DIFF
--- a/main.c
+++ b/main.c
@@ -990,16 +990,9 @@ int main(int argc, char *argv[], char *envp[])
       mutt_list_free(&attach);
     }
 
-    if (isatty(0))
-    {
-      rv = ci_send_message(sendflags, e, bodyfile, NULL, NULL);
-      /* We WANT the "Mail sent." and any possible, later error */
-      log_queue_empty();
-    }
-    else
-    {
-      mutt_error(_("Error initializing terminal"));
-    }
+    rv = ci_send_message(sendflags, e, bodyfile, NULL, NULL);
+    /* We WANT the "Mail sent." and any possible, later error */
+    log_queue_empty();
     if (ErrorBufMessage)
       mutt_message("%s", ErrorBuf);
 

--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -1398,7 +1398,7 @@ static int mbox_mbox_sync(struct Mailbox *m, int *index_hint)
       if (ferror(adata->fp))
         i = -1;
     }
-    if (i == 0)
+    if (i >= 0)
     {
       m->size = ftello(adata->fp); /* update the mailbox->size of the mailbox */
       if ((m->size < 0) || (ftruncate(fileno(adata->fp), m->size) != 0))

--- a/mutt/file.c
+++ b/mutt/file.c
@@ -265,7 +265,7 @@ int mutt_file_copy_bytes(FILE *fp_in, FILE *fp_out, size_t size)
  * mutt_file_copy_stream - Copy the contents of one file into another
  * @param fp_in  Source file
  * @param fp_out Destination file
- * @retval  0 Success
+ * @retval  n Success, number of bytes copied
  * @retval -1 Error, see errno
  */
 int mutt_file_copy_stream(FILE *fp_in, FILE *fp_out)
@@ -273,6 +273,7 @@ int mutt_file_copy_stream(FILE *fp_in, FILE *fp_out)
   if (!fp_in || !fp_out)
     return -1;
 
+  size_t total = 0;
   size_t l;
   char buf[1024];
 
@@ -280,11 +281,12 @@ int mutt_file_copy_stream(FILE *fp_in, FILE *fp_out)
   {
     if (fwrite(buf, 1, l, fp_out) != l)
       return -1;
+    total += l;
   }
 
   if (fflush(fp_out) != 0)
     return -1;
-  return 0;
+  return total;
 }
 
 /**

--- a/send.c
+++ b/send.c
@@ -2166,7 +2166,10 @@ int ci_send_message(SendFlags flags, struct Email *e_templ, const char *tempfile
       process_user_header(e_templ->env);
 
     if (flags & SEND_BATCH)
-      mutt_file_copy_stream(stdin, fp_tmp);
+    {
+      if (mutt_file_copy_stream(stdin, fp_tmp) < 1)
+        goto cleanup;
+    }
 
     if (C_SigOnTop && !(flags & (SEND_MAILX | SEND_KEY | SEND_BATCH)) &&
         C_Editor && (mutt_str_strcmp(C_Editor, "builtin") != 0))

--- a/sendlib.c
+++ b/sendlib.c
@@ -3444,8 +3444,11 @@ int mutt_write_fcc(const char *path, struct Email *e, const char *msgid,
     if (mutt_file_fclose(&fp_tmp) != 0)
       rc = -1;
     /* if there was an error, leave the temp version */
-    if (rc == 0)
+    if (rc >= 0)
+    {
       unlink(mutt_b2s(tempfile));
+      rc = 0;
+    }
   }
   else
   {


### PR DESCRIPTION
Commit 331702b6 was created to fix issue #2138.
Unfortunately, that broke sending email from the command line.

Rather than check for a tty on stdin, count how many bytes are available.
If there is none, abort.

Fixes: #2176