### PR TITLE
quieten gpgme warning

### DIFF
--- a/ncrypt/cryptglue.c
+++ b/ncrypt/cryptglue.c
@@ -122,11 +122,6 @@ void crypt_init(void)
 #ifdef CRYPT_BACKEND_GPGME
     crypto_module_register(&CryptModPgpGpgme);
     crypto_module_register(&CryptModSmimeGpgme);
-#else
-    mutt_message(_("\"crypt_use_gpgme\" set"
-                   " but not built with GPGME support"));
-    if (mutt_any_key_to_continue(NULL) == -1)
-      mutt_exit(1);
 #endif
   }
 


### PR DESCRIPTION
Don't warn the user about gpgme if it isn't built-in.

Fixes: #2174

---

This eliminates the warning and the "Press any key" prompt, however...
The real problem is that many `crypt_*`, `pgp_*` and `smime_*` config variables aren't built conditionally.