### PR TITLE
lib: move zstrm to libconn

### DIFF
--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -85,9 +85,6 @@ NEOMUTTOBJS+=	mutt_lua.o
 @if USE_INOTIFY
 NEOMUTTOBJS+=	monitor.o
 @endif
-@if USE_ZLIB
-NEOMUTTOBJS+=	mutt_zstrm.o
-@endif
 
 CLEANFILES+=	$(NEOMUTT) $(NEOMUTTOBJS)
 ALLOBJS+=	$(NEOMUTTOBJS)
@@ -241,6 +238,9 @@ LIBCONNOBJS+=	conn/gnutls.o
 @endif
 @if USE_SSL_OPENSSL
 LIBCONNOBJS+=	conn/openssl.o
+@endif
+@if USE_ZLIB
+LIBCONNOBJS+=	conn/zstrm.o
 @endif
 CLEANFILES+=	$(LIBCONN) $(LIBCONNOBJS)
 MUTTLIBS+=	$(LIBCONN)

--- a/conn/lib.h
+++ b/conn/lib.h
@@ -38,6 +38,7 @@
  * | conn/sasl_plain.c   | @subpage conn_sasl_plain |
  * | conn/socket.c       | @subpage conn_socket     |
  * | conn/tunnel.c       | @subpage conn_tunnel     |
+ * | conn/zstrm.c        | @subpage conn_zstrm      |
  */
 
 #ifndef MUTT_CONN_LIB_H
@@ -53,6 +54,9 @@
 #include "socket.h"
 #ifdef USE_SASL
 #include "sasl.h"
+#endif
+#ifdef USE_ZLIB
+#include "zstrm.h"
 #endif
 // IWYU pragma: end_exports
 

--- a/conn/zstrm.c
+++ b/conn/zstrm.c
@@ -33,7 +33,7 @@
 #include <zlib.h>
 #include "mutt/lib.h"
 #include "conn/lib.h"
-#include "mutt_zstrm.h"
+#include "zstrm.h"
 
 /**
  * struct ZstrmDirection - A stream of data being (de-)compressed

--- a/conn/zstrm.h
+++ b/conn/zstrm.h
@@ -19,11 +19,11 @@
  * this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef MUTT_ZSTRM_H
-#define MUTT_ZSTRM_H
+#ifndef MUTT_CONN_ZSTRM_H
+#define MUTT_CONN_ZSTRM_H
 
 struct Connection;
 
 void mutt_zstrm_wrap_conn(struct Connection *conn);
 
-#endif /* MUTT_ZSTRM_H */
+#endif /* MUTT_CONN_ZSTRM_H */

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -60,9 +60,6 @@
 #ifdef ENABLE_NLS
 #include <libintl.h>
 #endif
-#ifdef USE_ZLIB
-#include "mutt_zstrm.h"
-#endif
 
 struct stat;
 


### PR DESCRIPTION
The zstrm code creates a compressed wrapper around a Connection.