### PR TITLE
Resolve symlinks only when necessary

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -1119,6 +1119,7 @@ int mutt_save_message(struct Mailbox *m, struct EmailList *el,
   }
 #endif
 
+  mutt_file_resolve_symlink(buf);
   struct Mailbox *m_save = mx_path_resolve(mutt_b2s(buf));
   bool old_append = m_save->append;
   struct Context *ctx_save = mx_mbox_open(m_save, MUTT_NEWFOLDER);

--- a/mutt/file.c
+++ b/mutt/file.c
@@ -1603,3 +1603,21 @@ int mutt_file_stat_compare(struct stat *sba, enum MuttStatType sba_type,
   mutt_file_get_stat_timespec(&b, sbb, sbb_type);
   return mutt_file_timespec_compare(&a, &b);
 }
+
+/**
+ * mutt_file_resolve_symlink - Resolve a symlink in place
+ * @param buf Input/output path
+ */
+void mutt_file_resolve_symlink(struct Buffer *buf)
+{
+  struct stat st;
+  int rc = lstat(mutt_b2s(buf), &st);
+  if ((rc != -1) && S_ISLNK(st.st_mode))
+  {
+    char path[PATH_MAX];
+    if (realpath(mutt_b2s(buf), path))
+    {
+      mutt_buffer_strcpy(buf, path);
+    }
+  }
+}

--- a/mutt/file.h
+++ b/mutt/file.h
@@ -121,6 +121,7 @@ void        mutt_file_touch_atime(int fd);
 void        mutt_file_unlink(const char *s);
 void        mutt_file_unlink_empty(const char *path);
 int         mutt_file_unlock(int fd);
+void        mutt_file_resolve_symlink(struct Buffer *buf);
 
 void        mutt_buffer_quote_filename(struct Buffer *buf, const char *filename, bool add_outer);
 void        mutt_buffer_file_expand_fmt_quote(struct Buffer *dest, const char *fmt, const char *src);

--- a/muttlib.c
+++ b/muttlib.c
@@ -316,21 +316,7 @@ void mutt_buffer_expand_path_regex(struct Buffer *buf, bool regex)
    * folders. May possibly fail, in which case buf should be the same. */
   if (imap_path_probe(mutt_b2s(buf), NULL) == MUTT_IMAP)
     imap_expand_path(buf);
-  else
 #endif
-  {
-    /* Resolve symbolic links */
-    struct stat st;
-    int rc = lstat(mutt_b2s(buf), &st);
-    if ((rc != -1) && S_ISLNK(st.st_mode))
-    {
-      char path[PATH_MAX];
-      if (realpath(mutt_b2s(buf), path))
-      {
-        mutt_buffer_strcpy(buf, path);
-      }
-    }
-  }
 }
 
 /**


### PR DESCRIPTION
This partially undoes ad00c1bf, which added symlink resolution to all
path expansions. It turnes out that broke attaching files via symlinks
because symlink resolution happens too early causing the attachment name
to reflect the actual target instead of the symlink (see #2168).

This commit adds a new API mutt_file_resolve_symlink and calls it where
needed. Right now, the only place I am aware of is when selecting a
target for saving a message.

Fixes #2168
