### PR TITLE
neomutt: don't segfault on missing mailfile when inserting into hcache

### DIFF
--- a/notmuch/mutt_notmuch.c
+++ b/notmuch/mutt_notmuch.c
@@ -967,17 +967,18 @@ static void append_message(header_cache_t *h, struct Mailbox *m,
       FREE(&folder);
     }
 
+    if (!e)
+    {
+      mutt_debug(LL_DEBUG1, "nm: failed to parse message: %s\n", path);
+      goto done;
+    }
+
 #ifdef USE_HCACHE
     mutt_hcache_store(h, newpath ? newpath : path,
                       mutt_str_strlen(newpath ? newpath : path), e, 0);
 #endif
   }
 
-  if (!e)
-  {
-    mutt_debug(LL_DEBUG1, "nm: failed to parse message: %s\n", path);
-    goto done;
-  }
 
   if (init_email(e, newpath ? newpath : path, msg) != 0)
   {


### PR DESCRIPTION
* **What does this PR do?**

Fixes a segfault when neomutt tries to insert a notmuch mail that doesn't exist
into the hcache.

I was previously observing the below crash. I believe it is just an oversight
due to the USE_CACHE ifdef. The error checking had to be moved before the
hcache insert call.

```
$ bt
#0  memcpy (__len=0xa8, __src=0x0, __dest=0x7ffdcc8a8890) at /nix/store/hycbi8v31600cimx211ilj8p922nharl-glibc-2.30-dev/include/bits/string_fortified.h:34
#1  dump (uidvalidity=0x0, off=0x7ffdcc8a8884, e=0x0, hc=0xc18330) at hcache/hcache.c:164
#2  mutt_hcache_store (hc=hc@entry=0xc18330, key=0xc7d820 "/some/path/that/doesn't exist",
    keylen=0x65, e=e@entry=0x0, uidvalidity=uidvalidity@entry=0x0) at hcache/hcache.c:592
#3  0x000000000049d677 in append_message (h=h@entry=0xc18330, m=m@entry=0xc10580, q=q@entry=0xc3f460, msg=msg@entry=0xc0e4b0, dedup=dedup@entry=0x0)
    at notmuch/mutt_notmuch.c:971
#4  0x000000000049dd3c in read_mesgs_query (dedup=0x0, q=0xc3f460, m=0xc10580) at notmuch/mutt_notmuch.c:1125
#5  nm_mbox_open (m=0xc10580) at notmuch/mutt_notmuch.c:2171
#6  0x000000000044ee5e in mx_mbox_open (m=0xc10580, flags=<optimized out>) at mx.c:369
#7  0x000000000043e574 in main (argc=0x1, argv=<optimized out>, envp=<optimized out>) at main.c:1152
#8  0x00007f53c2303d8b in __libc_start_main () from /nix/store/9rabxvqbv0vgjmydiv59wkz768b5fmbc-glibc-2.30/lib/libc.so.6
#9  0x000000000040bf6a in _start () at ../sysdeps/x86_64/start.S:120
```