### PR TITLE
Refactor the Compose screen

### DIFF
--- a/address/address.c
+++ b/address/address.c
@@ -1181,6 +1181,30 @@ size_t mutt_addrlist_write(const struct AddressList *al, char *buf, size_t bufle
 }
 
 /**
+ * mutt_addrlist_write_list - Write Addresses to a List
+ * @param al   AddressList to write
+ * @param list List for the Addresses
+ * @retval num Number of addresses written
+ */
+size_t mutt_addrlist_write_list(const struct AddressList *al, struct ListHead *list)
+{
+  if (!al || !list)
+    return 0;
+
+  char addr[256];
+  size_t count = 0;
+  struct Address *a = NULL;
+  TAILQ_FOREACH(a, al, entries)
+  {
+    mutt_addr_write(addr, sizeof(addr), a, true);
+    mutt_list_insert_tail(list, strdup(addr));
+    count++;
+  }
+
+  return count;
+}
+
+/**
  * mutt_addr_to_intl - Convert an Address to Punycode
  * @param a Address to convert
  * @retval bool True on success, false otherwise

--- a/address/address.h
+++ b/address/address.h
@@ -93,5 +93,6 @@ bool   mutt_addrlist_search      (const struct AddressList *haystack, const stru
 int    mutt_addrlist_to_intl     (struct AddressList *al, char **err);
 int    mutt_addrlist_to_local    (struct AddressList *al);
 size_t mutt_addrlist_write       (const struct AddressList *al, char *buf, size_t buflen, bool display);
+size_t mutt_addrlist_write_list  (const struct AddressList *al, struct ListHead *list);
 
 #endif /* MUTT_EMAIL_ADDRESS_H */

--- a/compose.c
+++ b/compose.c
@@ -790,22 +790,30 @@ static int draw_envelope_addr(int field, struct AddressList *al,
   try_again:
     more_len = snprintf(more, sizeof(more),
                         ngettext("(+%d more)", "(+%d more)", count), count);
+    mutt_debug(LL_DEBUG3, "text: '%s'  len: %d\n", more, more_len);
 
     int reserve = ((count > 0) && (lines_used == max_lines)) ? more_len : 0;
+    mutt_debug(LL_DEBUG3, "processing: %s (al:%ld, wl:%d, r:%d, lu:%ld)\n",
+               np->data, addr_len, width_left, reserve, lines_used);
     if (addr_len >= (width_left - reserve))
     {
+      mutt_debug(LL_DEBUG3, "not enough space\n");
       if (lines_used == max_lines)
       {
+        mutt_debug(LL_DEBUG3, "no more lines\n");
+        mutt_debug(LL_DEBUG3, "truncating: %s\n", np->data);
         mutt_paddstr(width_left, np->data);
         break;
       }
 
       if (width_left == (win->state.cols - MaxHeaderWidth))
       {
+        mutt_debug(LL_DEBUG3, "couldn't print: %s\n", np->data);
         mutt_paddstr(width_left, np->data);
         break;
       }
 
+      mutt_debug(LL_DEBUG3, "start a new line\n");
       mutt_window_clrtoeol(win);
       row++;
       lines_used++;
@@ -816,10 +824,13 @@ static int draw_envelope_addr(int field, struct AddressList *al,
 
     if (addr_len < width_left)
     {
+      mutt_debug(LL_DEBUG3, "space for: %s\n", np->data);
       mutt_window_addstr(np->data);
       mutt_window_addstr(sep);
       width_left -= addr_len;
     }
+    mutt_debug(LL_DEBUG3, "%ld addresses remaining\n", count);
+    mutt_debug(LL_DEBUG3, "%ld lines remaining\n", max_lines - lines_used);
   }
   mutt_list_free(&list);
 
@@ -829,6 +840,7 @@ static int draw_envelope_addr(int field, struct AddressList *al,
     mutt_curses_set_color(MT_COLOR_BOLD);
     mutt_window_addstr(more);
     mutt_curses_set_color(MT_COLOR_NORMAL);
+    mutt_debug(LL_DEBUG3, "%ld more (len %d)\n", count, more_len);
   }
   else
   {
@@ -841,6 +853,7 @@ static int draw_envelope_addr(int field, struct AddressList *al,
     mutt_window_clrtoeol(win);
   }
 
+  mutt_debug(LL_DEBUG3, "used %d lines\n", lines_used);
   return lines_used;
 }
 

--- a/compose.c
+++ b/compose.c
@@ -629,19 +629,18 @@ cleanup:
  * draw_envelope_addr - Write addresses to the compose window
  * @param line Line to write to (index into Prompts)
  * @param al   Address list to write
- * @param rd  Email and other compose data
+ * @param win  Window
  */
-static void draw_envelope_addr(int line, struct AddressList *al, struct ComposeRedrawData *rd)
+static void draw_envelope_addr(int line, struct AddressList *al, struct MuttWindow *win)
 {
   char buf[1024];
 
   buf[0] = '\0';
   mutt_addrlist_write(al, buf, sizeof(buf), true);
   mutt_curses_set_color(MT_COLOR_COMPOSE_HEADER);
-  mutt_window_mvprintw(rd->win_envelope, line, 0, "%*s", HeaderPadding[line],
-                       _(Prompts[line]));
+  mutt_window_mvprintw(win, line, 0, "%*s", HeaderPadding[line], _(Prompts[line]));
   mutt_curses_set_color(MT_COLOR_NORMAL);
-  mutt_paddstr(W, buf);
+  mutt_paddstr(win->state.cols - MaxHeaderWidth, buf);
 }
 
 /**
@@ -653,7 +652,7 @@ static void draw_envelope(struct ComposeRedrawData *rd)
   struct Email *e = rd->email;
   const char *fcc = mutt_b2s(rd->fcc);
 
-  draw_envelope_addr(HDR_FROM, &e->env->from, rd);
+  draw_envelope_addr(HDR_FROM, &e->env->from, rd->win_envelope);
 
 #ifdef USE_NNTP
   if (OptNewsSend)
@@ -674,9 +673,9 @@ static void draw_envelope(struct ComposeRedrawData *rd)
   else
 #endif
   {
-    draw_envelope_addr(HDR_TO, &e->env->to, rd);
-    draw_envelope_addr(HDR_CC, &e->env->cc, rd);
-    draw_envelope_addr(HDR_BCC, &e->env->bcc, rd);
+    draw_envelope_addr(HDR_TO, &e->env->to, rd->win_envelope);
+    draw_envelope_addr(HDR_CC, &e->env->cc, rd->win_envelope);
+    draw_envelope_addr(HDR_BCC, &e->env->bcc, rd->win_envelope);
   }
 
   mutt_curses_set_color(MT_COLOR_COMPOSE_HEADER);
@@ -685,7 +684,7 @@ static void draw_envelope(struct ComposeRedrawData *rd)
   mutt_curses_set_color(MT_COLOR_NORMAL);
   mutt_paddstr(W, NONULL(e->env->subject));
 
-  draw_envelope_addr(HDR_REPLYTO, &e->env->reply_to, rd);
+  draw_envelope_addr(HDR_REPLYTO, &e->env->reply_to, rd->win_envelope);
 
   mutt_curses_set_color(MT_COLOR_COMPOSE_HEADER);
   mutt_window_mvprintw(rd->win_envelope, HDR_FCC, 0, "%*s",

--- a/compose.c
+++ b/compose.c
@@ -703,36 +703,29 @@ static void draw_envelope(struct ComposeRedrawData *rd)
 
 /**
  * edit_address_list - Let the user edit the address list
- * @param[in]     line Index into the Prompts lists
- * @param[in,out] al   AddressList to edit
- * @param[in]     win  Window
+ * @param[in]     field Field to edit, e.g. #HDR_FROM
+ * @param[in,out] al    AddressList to edit
  */
-static void edit_address_list(int line, struct AddressList *al, struct MuttWindow *win)
+static void edit_address_list(int field, struct AddressList *al)
 {
   char buf[8192] = { 0 }; /* needs to be large for alias expansion */
-  char *err = NULL;
 
   mutt_addrlist_to_local(al);
   mutt_addrlist_write(al, buf, sizeof(buf), false);
-  if (mutt_get_field(_(Prompts[line]), buf, sizeof(buf), MUTT_ALIAS) == 0)
+  if (mutt_get_field(_(Prompts[field]), buf, sizeof(buf), MUTT_ALIAS) == 0)
   {
     mutt_addrlist_clear(al);
     mutt_addrlist_parse2(al, buf);
     mutt_expand_aliases(al);
   }
 
+  char *err = NULL;
   if (mutt_addrlist_to_intl(al, &err) != 0)
   {
     mutt_error(_("Bad IDN: '%s'"), err);
     mutt_refresh();
     FREE(&err);
   }
-
-  /* redraw the expanded list so the user can see the result */
-  buf[0] = '\0';
-  mutt_addrlist_write(al, buf, sizeof(buf), true);
-  mutt_window_move(win, line, MaxHeaderWidth);
-  mutt_paddstr(win->state.cols - MaxHeaderWidth, buf);
 }
 
 /**
@@ -1205,7 +1198,7 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur, 
     switch (op)
     {
       case OP_COMPOSE_EDIT_FROM:
-        edit_address_list(HDR_FROM, &e->env->from, rd->win_envelope);
+        edit_address_list(HDR_FROM, &e->env->from);
         update_crypt_info(rd);
         mutt_message_hook(NULL, e, MUTT_SEND2_HOOK);
         break;
@@ -1215,7 +1208,7 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur, 
         if (news)
           break;
 #endif
-        edit_address_list(HDR_TO, &e->env->to, rd->win_envelope);
+        edit_address_list(HDR_TO, &e->env->to);
         update_crypt_info(rd);
         mutt_message_hook(NULL, e, MUTT_SEND2_HOOK);
         break;
@@ -1225,7 +1218,7 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur, 
         if (news)
           break;
 #endif
-        edit_address_list(HDR_BCC, &e->env->bcc, rd->win_envelope);
+        edit_address_list(HDR_BCC, &e->env->bcc);
         update_crypt_info(rd);
         mutt_message_hook(NULL, e, MUTT_SEND2_HOOK);
         break;
@@ -1235,7 +1228,7 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur, 
         if (news)
           break;
 #endif
-        edit_address_list(HDR_CC, &e->env->cc, rd->win_envelope);
+        edit_address_list(HDR_CC, &e->env->cc);
         update_crypt_info(rd);
         mutt_message_hook(NULL, e, MUTT_SEND2_HOOK);
         break;
@@ -1314,7 +1307,7 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur, 
         break;
 
       case OP_COMPOSE_EDIT_REPLY_TO:
-        edit_address_list(HDR_REPLYTO, &e->env->reply_to, rd->win_envelope);
+        edit_address_list(HDR_REPLYTO, &e->env->reply_to);
         mutt_message_hook(NULL, e, MUTT_SEND2_HOOK);
         break;
 

--- a/compose.c
+++ b/compose.c
@@ -654,16 +654,9 @@ static void draw_envelope(struct ComposeRedrawData *rd)
   const char *fcc = mutt_b2s(rd->fcc);
 
   draw_envelope_addr(HDR_FROM, &e->env->from, rd);
+
 #ifdef USE_NNTP
-  if (!OptNewsSend)
-  {
-#endif
-    draw_envelope_addr(HDR_TO, &e->env->to, rd);
-    draw_envelope_addr(HDR_CC, &e->env->cc, rd);
-    draw_envelope_addr(HDR_BCC, &e->env->bcc, rd);
-#ifdef USE_NNTP
-  }
-  else
+  if (OptNewsSend)
   {
     mutt_window_mvprintw(rd->win_envelope, HDR_TO, 0, "%*s",
                          HeaderPadding[HDR_NEWSGROUPS], Prompts[HDR_NEWSGROUPS]);
@@ -678,7 +671,13 @@ static void draw_envelope(struct ComposeRedrawData *rd)
       mutt_paddstr(W, NONULL(e->env->x_comment_to));
     }
   }
+  else
 #endif
+  {
+    draw_envelope_addr(HDR_TO, &e->env->to, rd);
+    draw_envelope_addr(HDR_CC, &e->env->cc, rd);
+    draw_envelope_addr(HDR_BCC, &e->env->bcc, rd);
+  }
 
   mutt_curses_set_color(MT_COLOR_COMPOSE_HEADER);
   mutt_window_mvprintw(rd->win_envelope, HDR_SUBJECT, 0, "%*s",

--- a/compose.c
+++ b/compose.c
@@ -159,9 +159,6 @@ enum HeaderField
 int HeaderPadding[HDR_ATTACH_TITLE] = { 0 };
 int MaxHeaderWidth = 0;
 
-#define HDR_XOFFSET MaxHeaderWidth
-#define W (rd->win_envelope->state.cols - MaxHeaderWidth)
-
 static const char *const Prompts[] = {
   /* L10N: Compose menu field.  May not want to translate. */
   N_("From: "),
@@ -666,13 +663,13 @@ static void draw_envelope(struct ComposeRedrawData *rd)
   if (OptNewsSend)
   {
     draw_header(rd->win_envelope, HDR_NEWSGROUPS, HDR_NEWSGROUPS);
-    mutt_paddstr(W, NONULL(e->env->newsgroups));
+    mutt_paddstr(rd->win_envelope->state.cols - MaxHeaderWidth, NONULL(e->env->newsgroups));
     draw_header(rd->win_envelope, HDR_FOLLOWUPTO, HDR_FOLLOWUPTO);
-    mutt_paddstr(W, NONULL(e->env->followup_to));
+    mutt_paddstr(rd->win_envelope->state.cols - MaxHeaderWidth, NONULL(e->env->followup_to));
     if (C_XCommentTo)
     {
       draw_header(rd->win_envelope, HDR_XCOMMENTTO, HDR_XCOMMENTTO);
-      mutt_paddstr(W, NONULL(e->env->x_comment_to));
+      mutt_paddstr(rd->win_envelope->state.cols - MaxHeaderWidth, NONULL(e->env->x_comment_to));
     }
   }
   else
@@ -684,12 +681,12 @@ static void draw_envelope(struct ComposeRedrawData *rd)
   }
 
   draw_header(rd->win_envelope, HDR_SUBJECT, HDR_SUBJECT);
-  mutt_paddstr(W, NONULL(e->env->subject));
+  mutt_paddstr(rd->win_envelope->state.cols - MaxHeaderWidth, NONULL(e->env->subject));
 
   draw_envelope_addr(HDR_REPLYTO, &e->env->reply_to, rd->win_envelope);
 
   draw_header(rd->win_envelope, HDR_FCC, HDR_FCC);
-  mutt_paddstr(W, fcc);
+  mutt_paddstr(rd->win_envelope->state.cols - MaxHeaderWidth, fcc);
 
   if (WithCrypto)
     redraw_crypt_lines(rd);
@@ -734,7 +731,7 @@ static void edit_address_list(int line, struct AddressList *al, struct MuttWindo
   /* redraw the expanded list so the user can see the result */
   buf[0] = '\0';
   mutt_addrlist_write(al, buf, sizeof(buf), true);
-  mutt_window_move(win, line, HDR_XOFFSET);
+  mutt_window_move(win, line, MaxHeaderWidth);
   mutt_paddstr(win->state.cols - MaxHeaderWidth, buf);
 }
 
@@ -1254,9 +1251,9 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur, 
         if (mutt_get_field(Prompts[HDR_NEWSGROUPS], buf, sizeof(buf), MUTT_COMP_NO_FLAGS) == 0)
         {
           mutt_str_replace(&e->env->newsgroups, buf);
-          mutt_window_move(rd->win_envelope, HDR_TO, HDR_XOFFSET);
+          mutt_window_move(rd->win_envelope, HDR_TO, MaxHeaderWidth);
           if (e->env->newsgroups)
-            mutt_paddstr(W, e->env->newsgroups);
+            mutt_paddstr(rd->win_envelope->state.cols - MaxHeaderWidth, e->env->newsgroups);
           else
             mutt_window_clrtoeol(rd->win_envelope);
         }
@@ -1272,9 +1269,9 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur, 
         if (mutt_get_field(Prompts[HDR_FOLLOWUPTO], buf, sizeof(buf), MUTT_COMP_NO_FLAGS) == 0)
         {
           mutt_str_replace(&e->env->followup_to, buf);
-          mutt_window_move(rd->win_envelope, HDR_CC, HDR_XOFFSET);
+          mutt_window_move(rd->win_envelope, HDR_CC, MaxHeaderWidth);
           if (e->env->followup_to)
-            mutt_paddstr(W, e->env->followup_to);
+            mutt_paddstr(rd->win_envelope->state.cols - MaxHeaderWidth, e->env->followup_to);
           else
             mutt_window_clrtoeol(rd->win_envelope);
         }
@@ -1290,9 +1287,9 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur, 
         if (mutt_get_field(Prompts[HDR_XCOMMENTTO], buf, sizeof(buf), MUTT_COMP_NO_FLAGS) == 0)
         {
           mutt_str_replace(&e->env->x_comment_to, buf);
-          mutt_window_move(rd->win_envelope, HDR_BCC, HDR_XOFFSET);
+          mutt_window_move(rd->win_envelope, HDR_BCC, MaxHeaderWidth);
           if (e->env->x_comment_to)
-            mutt_paddstr(W, e->env->x_comment_to);
+            mutt_paddstr(rd->win_envelope->state.cols - MaxHeaderWidth, e->env->x_comment_to);
           else
             mutt_window_clrtoeol(rd->win_envelope);
         }
@@ -1307,9 +1304,9 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur, 
         if (mutt_get_field(Prompts[HDR_SUBJECT], buf, sizeof(buf), MUTT_COMP_NO_FLAGS) == 0)
         {
           mutt_str_replace(&e->env->subject, buf);
-          mutt_window_move(rd->win_envelope, HDR_SUBJECT, HDR_XOFFSET);
+          mutt_window_move(rd->win_envelope, HDR_SUBJECT, MaxHeaderWidth);
           if (e->env->subject)
-            mutt_paddstr(W, e->env->subject);
+            mutt_paddstr(rd->win_envelope->state.cols - MaxHeaderWidth, e->env->subject);
           else
             mutt_window_clrtoeol(rd->win_envelope);
         }
@@ -1327,8 +1324,8 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur, 
         {
           mutt_buffer_copy(fcc, &fname);
           mutt_buffer_pretty_mailbox(fcc);
-          mutt_window_move(rd->win_envelope, HDR_FCC, HDR_XOFFSET);
-          mutt_paddstr(W, mutt_b2s(fcc));
+          mutt_window_move(rd->win_envelope, HDR_FCC, MaxHeaderWidth);
+          mutt_paddstr(rd->win_envelope->state.cols - MaxHeaderWidth, mutt_b2s(fcc));
           fcc_set = true;
         }
         mutt_message_hook(NULL, e, MUTT_SEND2_HOOK);

--- a/compose.c
+++ b/compose.c
@@ -710,9 +710,9 @@ static void draw_envelope(struct ComposeRedrawData *rd)
  * edit_address_list - Let the user edit the address list
  * @param[in]     line Index into the Prompts lists
  * @param[in,out] al   AddressList to edit
- * @param rd  Email and other compose data
+ * @param[in]     win  Window
  */
-static void edit_address_list(int line, struct AddressList *al, struct ComposeRedrawData *rd)
+static void edit_address_list(int line, struct AddressList *al, struct MuttWindow *win)
 {
   char buf[8192] = { 0 }; /* needs to be large for alias expansion */
   char *err = NULL;
@@ -736,8 +736,8 @@ static void edit_address_list(int line, struct AddressList *al, struct ComposeRe
   /* redraw the expanded list so the user can see the result */
   buf[0] = '\0';
   mutt_addrlist_write(al, buf, sizeof(buf), true);
-  mutt_window_move(rd->win_envelope, line, HDR_XOFFSET);
-  mutt_paddstr(W, buf);
+  mutt_window_move(win, line, HDR_XOFFSET);
+  mutt_paddstr(win->state.cols - MaxHeaderWidth, buf);
 }
 
 /**
@@ -1210,7 +1210,7 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur, 
     switch (op)
     {
       case OP_COMPOSE_EDIT_FROM:
-        edit_address_list(HDR_FROM, &e->env->from, rd);
+        edit_address_list(HDR_FROM, &e->env->from, rd->win_envelope);
         update_crypt_info(rd);
         mutt_message_hook(NULL, e, MUTT_SEND2_HOOK);
         break;
@@ -1220,7 +1220,7 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur, 
         if (news)
           break;
 #endif
-        edit_address_list(HDR_TO, &e->env->to, rd);
+        edit_address_list(HDR_TO, &e->env->to, rd->win_envelope);
         update_crypt_info(rd);
         mutt_message_hook(NULL, e, MUTT_SEND2_HOOK);
         break;
@@ -1230,7 +1230,7 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur, 
         if (news)
           break;
 #endif
-        edit_address_list(HDR_BCC, &e->env->bcc, rd);
+        edit_address_list(HDR_BCC, &e->env->bcc, rd->win_envelope);
         update_crypt_info(rd);
         mutt_message_hook(NULL, e, MUTT_SEND2_HOOK);
         break;
@@ -1240,7 +1240,7 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur, 
         if (news)
           break;
 #endif
-        edit_address_list(HDR_CC, &e->env->cc, rd);
+        edit_address_list(HDR_CC, &e->env->cc, rd->win_envelope);
         update_crypt_info(rd);
         mutt_message_hook(NULL, e, MUTT_SEND2_HOOK);
         break;
@@ -1319,7 +1319,7 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur, 
         break;
 
       case OP_COMPOSE_EDIT_REPLY_TO:
-        edit_address_list(HDR_REPLYTO, &e->env->reply_to, rd);
+        edit_address_list(HDR_REPLYTO, &e->env->reply_to, rd->win_envelope);
         mutt_message_hook(NULL, e, MUTT_SEND2_HOOK);
         break;
 

--- a/compose.c
+++ b/compose.c
@@ -887,7 +887,6 @@ static void compose_custom_redraw(struct Menu *menu)
   {
     menu_redraw_full(menu);
     draw_envelope(rd);
-    menu->offset = 0;
     menu->pagelen = menu->win_index->state.rows;
   }
 
@@ -1182,7 +1181,6 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur, 
   menu->win_index = attach;
   menu->win_ibar = ebar;
 
-  menu->offset = 0;
   menu->make_entry = snd_make_entry;
   menu->tag = attach_tag;
 #ifdef USE_NNTP

--- a/index.c
+++ b/index.c
@@ -1328,12 +1328,12 @@ int mutt_index_menu(struct MuttWindow *dlg)
         menu->oldcurrent = -1;
 
       if (C_ArrowCursor)
-        mutt_window_move(menu->win_index, menu->current - menu->top + menu->offset, 2);
+        mutt_window_move(menu->win_index, menu->current - menu->top, 2);
       else if (C_BrailleFriendly)
-        mutt_window_move(menu->win_index, menu->current - menu->top + menu->offset, 0);
+        mutt_window_move(menu->win_index, menu->current - menu->top, 0);
       else
       {
-        mutt_window_move(menu->win_index, menu->current - menu->top + menu->offset,
+        mutt_window_move(menu->win_index, menu->current - menu->top,
                          menu->win_index->state.cols - 1);
       }
       mutt_refresh();

--- a/menu.c
+++ b/menu.c
@@ -364,7 +364,6 @@ void menu_redraw_full(struct Menu *menu)
     mutt_paddstr(MuttHelpWindow->state.cols, menu->help);
     mutt_curses_set_color(MT_COLOR_NORMAL);
   }
-  menu->offset = 0;
   menu->pagelen = menu->win_index->state.rows;
 
   mutt_show_error();
@@ -425,7 +424,7 @@ void menu_redraw_index(struct Menu *menu)
       menu_pad_string(menu, buf, sizeof(buf));
 
       mutt_curses_set_attr(attr);
-      mutt_window_move(menu->win_index, i - menu->top + menu->offset, 0);
+      mutt_window_move(menu->win_index, i - menu->top, 0);
       do_color = true;
 
       if (i == menu->current)
@@ -449,7 +448,7 @@ void menu_redraw_index(struct Menu *menu)
     else
     {
       mutt_curses_set_color(MT_COLOR_NORMAL);
-      mutt_window_clearline(menu->win_index, i - menu->top + menu->offset);
+      mutt_window_clearline(menu->win_index, i - menu->top);
     }
   }
   mutt_curses_set_color(MT_COLOR_NORMAL);
@@ -475,7 +474,7 @@ void menu_redraw_motion(struct Menu *menu)
    * generate status messages.  So we want to call it *before* we
    * position the cursor for drawing. */
   const int old_color = menu->color(menu->oldcurrent);
-  mutt_window_move(menu->win_index, menu->oldcurrent + menu->offset - menu->top, 0);
+  mutt_window_move(menu->win_index, menu->oldcurrent - menu->top, 0);
   mutt_curses_set_attr(old_color);
 
   if (C_ArrowCursor)
@@ -488,15 +487,14 @@ void menu_redraw_motion(struct Menu *menu)
     {
       make_entry(buf, sizeof(buf), menu, menu->oldcurrent);
       menu_pad_string(menu, buf, sizeof(buf));
-      mutt_window_move(menu->win_index, menu->oldcurrent + menu->offset - menu->top,
+      mutt_window_move(menu->win_index, menu->oldcurrent - menu->top,
                        mutt_strwidth(C_ArrowString) + 1);
       print_enriched_string(menu->oldcurrent, old_color, (unsigned char *) buf, true);
     }
 
     /* now draw it in the new location */
     mutt_curses_set_color(MT_COLOR_INDICATOR);
-    mutt_window_mvaddstr(menu->win_index, menu->current + menu->offset - menu->top,
-                         0, C_ArrowString);
+    mutt_window_mvaddstr(menu->win_index, menu->current - menu->top, 0, C_ArrowString);
   }
   else
   {
@@ -510,7 +508,7 @@ void menu_redraw_motion(struct Menu *menu)
     make_entry(buf, sizeof(buf), menu, menu->current);
     menu_pad_string(menu, buf, sizeof(buf));
     mutt_curses_set_color(MT_COLOR_INDICATOR);
-    mutt_window_move(menu->win_index, menu->current + menu->offset - menu->top, 0);
+    mutt_window_move(menu->win_index, menu->current - menu->top, 0);
     print_enriched_string(menu->current, cur_color, (unsigned char *) buf, false);
   }
   menu->redraw &= REDRAW_STATUS;
@@ -526,7 +524,7 @@ void menu_redraw_current(struct Menu *menu)
   char buf[1024];
   int attr = menu->color(menu->current);
 
-  mutt_window_move(menu->win_index, menu->current + menu->offset - menu->top, 0);
+  mutt_window_move(menu->win_index, menu->current - menu->top, 0);
   make_entry(buf, sizeof(buf), menu, menu->current);
   menu_pad_string(menu, buf, sizeof(buf));
 
@@ -980,7 +978,6 @@ struct Menu *mutt_menu_new(enum MenuType type)
   menu->type = type;
   menu->current = 0;
   menu->top = 0;
-  menu->offset = 0;
   menu->redraw = REDRAW_FULL;
   menu->color = default_color;
   menu->search = generic_search;
@@ -1386,12 +1383,12 @@ int mutt_menu_loop(struct Menu *menu)
 
     /* move the cursor out of the way */
     if (C_ArrowCursor)
-      mutt_window_move(menu->win_index, menu->current - menu->top + menu->offset, 2);
+      mutt_window_move(menu->win_index, menu->current - menu->top, 2);
     else if (C_BrailleFriendly)
-      mutt_window_move(menu->win_index, menu->current - menu->top + menu->offset, 0);
+      mutt_window_move(menu->win_index, menu->current - menu->top, 0);
     else
     {
-      mutt_window_move(menu->win_index, menu->current - menu->top + menu->offset,
+      mutt_window_move(menu->win_index, menu->current - menu->top,
                        menu->win_index->state.cols - 1);
     }
 

--- a/mutt_menu.h
+++ b/mutt_menu.h
@@ -88,7 +88,6 @@ struct Menu
   int max;                ///< Number of entries in the menu
   MuttRedrawFlags redraw; ///< When to redraw the screen
   enum MenuType type;     ///< Menu definition for keymap entries
-  int offset;             ///< Row offset within the window to start the index
   int pagelen;            ///< Number of entries per screen
   bool tagprefix : 1;
   bool is_mailbox_list : 1;


### PR DESCRIPTION
- Compose dialog uses multiple Windows
- `To:`, `Cc:` and `Bcc:` fields now span up to 5 lines
- `To:`, `Cc:` and `Bcc:` fields are now wrapped at address boundaries
- `To:`, `Cc:` and `Bcc:` fields indicate overflow with `(+3 more)`
- Truly fluid layout -- expand Envelope section to fit contents

---

Sample data: https://gist.github.com/flatcap/dfe02d1c71f080ca1de48409f8be0bad

```
neomutt -n -d1 -F names.rc -F auto.rc -f /dev/null
```

Press <kbd>F1</kbd> to open the compose menu.