### PR TITLE
Libcompress update

### DIFF
--- a/compress/lib.h
+++ b/compress/lib.h
@@ -3,7 +3,7 @@
  * API for the header cache compression
  *
  * @authors
- * Copyright (C) 2019 Tino Reichardt <milky-neomutt@mcmilk.de>
+ * Copyright (C) 2019-2020 Tino Reichardt <milky-neomutt@mcmilk.de>
  *
  * @copyright
  * This program is free software: you can redistribute it and/or modify it under
@@ -32,6 +32,10 @@
  * | compress/lz4.c      | @subpage compress_lz4  |
  * | compress/zlib.c     | @subpage compress_zlib |
  * | compress/zstd.c     | @subpage compress_zstd |
+ *
+ * Usage with Compression Level set to X:
+ * - open(level X) -> N times compress() -> close()
+ * - open(level X) -> N times decompress() -> close()
  */
 
 #ifndef MUTT_COMPRESS_LIB_H
@@ -48,10 +52,11 @@ struct ComprOps
 
   /**
    * open - Open a compression context
+   * @param[in]  level The compression level
    * @retval ptr  Success, backend-specific context
    * @retval NULL Otherwise
    */
-  void *(*open)(void);
+  void *(*open)(short level);
 
   /**
    * compress - Compress header cache data

--- a/doc/manual.xml.head
+++ b/doc/manual.xml.head
@@ -13487,11 +13487,6 @@ shutdown-hook 'exec sync-mailbox'
                 <entry>number</entry>
                 <entry><literal>1</literal></entry>
               </row>
-              <row>
-                <entry><literal>header_cache_compress_dictionary</literal></entry>
-                <entry>string</entry>
-                <entry><literal>~/.dictionary</literal></entry>
-              </row>
             </tbody>
           </tgroup>
         </table>
@@ -13536,23 +13531,6 @@ shutdown-hook 'exec sync-mailbox'
               </tbody>
             </tgroup>
           </table>
-        </para>
-        <para>
-          The <literal>header_cache_compress_dictionary</literal> is a special
-          option for the <literal>zstd</literal> compression method. On a lot
-          small files, this compression method can be trained for some level by
-          using a command like this for e.g. level 3:
-        </para>
-<screen>
-zstd --train -3 -r cur new tmp -o dict-level-3
-</screen>
-        <para>
-          This command will create an file called <literal>dict-level-3</literal>,
-          which should be put to the path given in the
-          <literal>header_cache_compress_dictionary</literal> variable. The
-          speed and space gain can be huge, when using zstd dictionaries.  See
-          <ulink url="https://github.com/facebook/zstd">https://github.com/facebook/zstd</ulink>
-          for more information about this.
         </para>
       </sect2>
       <sect2 id="hccompress-neomuttrc">

--- a/hcache/lib.h
+++ b/hcache/lib.h
@@ -7,6 +7,7 @@
  * Copyright (C) 2004 Tobias Werth <sitowert@stud.uni-erlangen.de>
  * Copyright (C) 2004 Brian Fundakowski Feldman <green@FreeBSD.org>
  * Copyright (C) 2016 Pietro Cerutti <gahr@gahr.ch>
+ * Copyright (C) 2020 Tino Reichardt <milky-neomutt@mcmilk.de>
  *
  * @copyright
  * This program is free software: you can redistribute it and/or modify it under
@@ -71,7 +72,6 @@ struct EmailCache
   unsigned int crc;
   void *ctx;
   void *cctx;
-  void *ondisk;
 };
 
 typedef struct EmailCache header_cache_t;
@@ -95,7 +95,6 @@ typedef void (*hcache_namer_t)(const char *path, struct Buffer *dest);
 
 /* These Config Variables are only used in hcache/hcache.c */
 extern char *C_HeaderCacheBackend;
-extern char *C_HeaderCacheCompressDictionary;
 extern short C_HeaderCacheCompressLevel;
 extern char *C_HeaderCacheCompressMethod;
 

--- a/mutt_config.c
+++ b/mutt_config.c
@@ -1459,14 +1459,6 @@ struct ConfigDef MuttVars[] = {
   */
 #endif /* HAVE_GDBM || HAVE_BDB */
 #if defined(USE_HCACHE_COMPRESSION)
-#ifdef HAVE_ZSTD
-  { "header_cache_compress_dictionary", DT_STRING|DT_PATH, &C_HeaderCacheCompressDictionary, IP "~/.dictionary" },
-  /*
-  ** .pp
-  ** When NeoMutt is compiled with zstd, the header cache backend can be used together
-  ** with a dictionary to achieve better compression on the cache files.
-  */
-#endif /* HAVE_ZSTD */
   { "header_cache_compress_level", DT_NUMBER|DT_NOT_NEGATIVE, &C_HeaderCacheCompressLevel, 1 },
   /*
   ** .pp


### PR DESCRIPTION
* **What does this PR do?**
This PR will externalise the two config variables `C_HeaderCacheCompressLevel` and `C_HeaderCacheCompressDictionary` from libcompress. The library itself gets 2 new functions for this:

1. set_level()
2. set_dictionary()

The two are only called once before compress()
If the default compression level is okay, the calling of these functions is not needed.
