### PR TITLE
sidebar: support indenting and shortening of names

### DIFF
--- a/sidebar.c
+++ b/sidebar.c
@@ -978,14 +978,17 @@ static void draw_sidebar(struct MuttWindow *win, int num_rows, int num_cols, int
       }
     }
 
+    if (m->name)
+      maildir_is_prefix = false;
+
     /* calculate depth of current folder and generate its display name with indented spaces */
     int sidebar_folder_depth = 0;
-    const char *sidebar_folder_name = NULL;
+    const char *sidebar_folder_name = m->name ? m->name : mailbox_path(m);
     struct Buffer *short_folder_name = NULL;
+
     if (C_SidebarShortPath)
     {
       /* disregard a trailing separator, so strlen() - 2 */
-      sidebar_folder_name = mailbox_path(m);
       for (int i = mutt_str_strlen(sidebar_folder_name) - 2; i >= 0; i--)
       {
         if (C_SidebarDelimChars && strchr(C_SidebarDelimChars, sidebar_folder_name[i]))
@@ -997,7 +1000,7 @@ static void draw_sidebar(struct MuttWindow *win, int num_rows, int num_cols, int
     }
     else if ((C_SidebarComponentDepth > 0) && C_SidebarDelimChars)
     {
-      sidebar_folder_name = mailbox_path(m) + maildir_is_prefix * (maildirlen + 1);
+      sidebar_folder_name += maildir_is_prefix * (maildirlen + 1);
       for (int i = 0; i < C_SidebarComponentDepth; i++)
       {
         char *chars_after_delim = strpbrk(sidebar_folder_name, C_SidebarDelimChars);
@@ -1008,16 +1011,12 @@ static void draw_sidebar(struct MuttWindow *win, int num_rows, int num_cols, int
       }
     }
     else
-      sidebar_folder_name = mailbox_path(m) + maildir_is_prefix * (maildirlen + 1);
+      sidebar_folder_name += maildir_is_prefix * (maildirlen + 1);
 
-    if (m->name)
-    {
-      sidebar_folder_name = m->name;
-    }
-    else if (maildir_is_prefix && C_SidebarFolderIndent)
+    if ((m->name || maildir_is_prefix) && C_SidebarFolderIndent)
     {
       int lastsep = 0;
-      const char *tmp_folder_name = mailbox_path(m) + maildirlen + 1;
+      const char *tmp_folder_name = m->name ? m->name : mailbox_path(m) + maildirlen + 1;
       int tmplen = (int) mutt_str_strlen(tmp_folder_name) - 1;
       for (int i = 0; i < tmplen; i++)
       {


### PR DESCRIPTION
Sidebar folder indenting and shortening only work on a mailbox's path.
However, the sidebar will always use a mailbox's name so indenting and
shortening does not work for 'virtual-mailboxes' or 'named-mailboxes'.

To support these operations, extend the indentation and shorten code to
use the name if it exists. This behavior is an extension of the current
behavior of names taking presidence.

Now the sidebar behaves more consistently across all mailbox types.

Closes #1594

* **Screenshots (if relevant)**

Using the configuration in #1594, here's a comparison:

master

![image](https://user-images.githubusercontent.com/1640737/77494411-0d547580-6e1c-11ea-837b-a109f27ba8f1.png)

this branch:

![image](https://user-images.githubusercontent.com/1640737/77494442-1fceaf00-6e1c-11ea-86b2-80bc013ed3ff.png)



