### PR TITLE
test: add test files

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,8 +5,9 @@ task:
   only_if: $CIRRUS_BRANCH == "master" || $CIRRUS_PR != ""
   skip: $CIRRUS_PR_DRAFT == "true"
   env:
+    CIRRUS_CLONE_DEPTH: 3
     PKG_COMMON:
-      cyrus-sasl db5 docbook-xsl gdbm gettext-tools gpgme iconv jimtcl
+      cyrus-sasl db5 docbook-xsl gdbm gettext-tools git gpgme iconv jimtcl
       kyotocabinet libgpg-error libidn2 libxslt lmdb lua53 lynx notmuch pkgconf
       qdbm tdb tokyocabinet urlview
     CONFIGURE_COMMON:
@@ -15,6 +16,7 @@ task:
       --locales-fix --lua --mixmaster --notmuch --pkgconf --qdbm --sasl
       --tdb --testing --tokyocabinet --with-domain=example.com
       --with-lock=flock --zlib
+    NEOMUTT_TEST_DIR: ${CIRRUS_WORKING_DIR}/test-files
   matrix:
     - name: FreeBSD / OpenSSL
       install_script: pkg install -y ${PKG_COMMON} openssl
@@ -23,7 +25,10 @@ task:
       install_script: pkg install -y ${PKG_COMMON} libressl
       configure_script: ./configure ${CONFIGURE_COMMON} --ssl
     - name: FreeBSD / GnuTLS
-      install_script: pkg install -y ${PKG_COMMON} gnutls
+      install_script:
+        - pkg install -y ${PKG_COMMON} gnutls
+        - git clone --depth 1 https://github.com/neomutt/neomutt-test-files.git ${NEOMUTT_TEST_DIR}
+        - (cd ${NEOMUTT_TEST_DIR} && ./setup.sh)
       configure_script: ./configure ${CONFIGURE_COMMON} --gnutls
     - name: FreeBSD / S-Lang
       install_script: pkg install -y ${PKG_COMMON} libslang2

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,30 +8,46 @@ task:
     CIRRUS_CLONE_DEPTH: 3
     PKG_COMMON:
       cyrus-sasl db5 docbook-xsl gdbm gettext-tools git gpgme iconv jimtcl
-      kyotocabinet libgpg-error libidn2 libxslt lmdb lua53 lynx notmuch pkgconf
-      qdbm tdb tokyocabinet urlview
+      kyotocabinet libgpg-error libidn2 liblz4 libxslt lmdb lua53 lynx notmuch
+      pkgconf qdbm tdb tokyocabinet urlview zstd
     CONFIGURE_COMMON:
       --autocrypt --bdb --disable-idn --disable-inotify --fmemopen --full-doc
-      --gdbm --gpgme --gss --homespool --idn2 --kyotocabinet --lmdb
-      --locales-fix --lua --mixmaster --notmuch --pkgconf --qdbm --sasl
-      --tdb --testing --tokyocabinet --with-domain=example.com
-      --with-lock=flock --zlib
-    NEOMUTT_TEST_DIR: ${CIRRUS_WORKING_DIR}/test-files
+      --gdbm --gpgme --gss --homespool --idn2 --kyotocabinet --lmdb --locales-fix
+      --lua --lz4 --mixmaster --notmuch --pkgconf --qdbm --sasl --tdb
+      --tokyocabinet --with-domain=example.com --with-lock=flock --zlib --zstd
   matrix:
+    - name: FreeBSD / Test
+      env:
+        NEOMUTT_TEST_DIR: ${CIRRUS_WORKING_DIR}/test-files
+      install_script:
+        - pkg install -y ${PKG_COMMON}
+        - git clone --depth 1 https://github.com/neomutt/neomutt-test-files.git ${NEOMUTT_TEST_DIR}
+        - (cd ${NEOMUTT_TEST_DIR} && ./setup.sh)
+      configure_script: ./configure --disable-doc --disable-idn --idn2 --testing
+      build_script: make
+      version_script: ./neomutt -v
+      test_script: make test
+
     - name: FreeBSD / OpenSSL
       install_script: pkg install -y ${PKG_COMMON} openssl
       configure_script: ./configure ${CONFIGURE_COMMON} --ssl
+      build_script: make
+      version_script: ./neomutt -v
+
     - name: FreeBSD / LibreSSL
       install_script: pkg install -y ${PKG_COMMON} libressl
       configure_script: ./configure ${CONFIGURE_COMMON} --ssl
+      build_script: make
+      version_script: ./neomutt -v
+
     - name: FreeBSD / GnuTLS
-      install_script:
-        - pkg install -y ${PKG_COMMON} gnutls
-        - git clone --depth 1 https://github.com/neomutt/neomutt-test-files.git ${NEOMUTT_TEST_DIR}
-        - (cd ${NEOMUTT_TEST_DIR} && ./setup.sh)
+      install_script: pkg install -y ${PKG_COMMON} gnutls
       configure_script: ./configure ${CONFIGURE_COMMON} --gnutls
+      build_script: make
+      version_script: ./neomutt -v
+
     - name: FreeBSD / S-Lang
       install_script: pkg install -y ${PKG_COMMON} libslang2
       configure_script: ./configure ${CONFIGURE_COMMON} --with-ui=slang
-  build_script: make
-  test_script: make test
+      build_script: make
+      version_script: ./neomutt -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ git:
 
 install:
   - git clone --depth 1 https://github.com/neomutt/travis-build.git ~/config
+  - git clone --depth 1 https://github.com/neomutt/neomutt-test-files.git ~/test-files
 
 before_script:
   - ccache --zero-stats
@@ -52,6 +53,8 @@ before_script:
   - export -f travis_nanoseconds
   - export -f travis_time_finish
   - export -f travis_time_start
+  - export NEOMUTT_TEST_DIR="$HOME/test-files"
+  - (cd ~/test-files && ./setup.sh)
 
 script:
   - ~/config/build

--- a/test/Makefile.autosetup
+++ b/test/Makefile.autosetup
@@ -180,6 +180,7 @@ FILE_OBJS	= test/file/common.o \
 		  test/file/mutt_file_read_keyword.o \
 		  test/file/mutt_file_read_line.o \
 		  test/file/mutt_file_rename.o \
+		  test/file/mutt_file_resolve_symlink.o \
 		  test/file/mutt_file_rmtree.o \
 		  test/file/mutt_file_safe_rename.o \
 		  test/file/mutt_file_sanitize_filename.o \

--- a/test/file/common.c
+++ b/test/file/common.c
@@ -68,3 +68,19 @@ void file_tear_down(FILE *fp, const char *funcname)
   if (res == EOF)
     TEST_MSG("Failed to tear down test %s", funcname);
 }
+
+static const char *get_test_path(void)
+{
+  static const char *path = NULL;
+  if (!path)
+    path = mutt_str_getenv("NEOMUTT_TEST_DIR");
+  if (!path)
+    path = "";
+
+  return path;
+}
+
+void test_gen_path(char *buf, size_t buflen, const char *fmt)
+{
+  snprintf(buf, buflen, NONULL(fmt), get_test_path());
+}

--- a/test/file/common.h
+++ b/test/file/common.h
@@ -37,4 +37,13 @@ size_t file_num_test_lines(void);
 #define SET_UP() (file_set_up(__func__))
 #define TEAR_DOWN(fp) (file_tear_down((fp), __func__))
 
+struct TestValue
+{
+  char *first;
+  char *second;
+  int retval;
+};
+
+void test_gen_path(char *buf, size_t buflen, const char *fmt);
+
 #endif /* TEST_FILE_COMMON_H */

--- a/test/file/mutt_file_check_empty.c
+++ b/test/file/mutt_file_check_empty.c
@@ -24,6 +24,7 @@
 #include "acutest.h"
 #include "config.h"
 #include "mutt/lib.h"
+#include "common.h"
 
 void test_mutt_file_check_empty(void)
 {
@@ -31,5 +32,28 @@ void test_mutt_file_check_empty(void)
 
   {
     TEST_CHECK(mutt_file_check_empty(NULL) != 0);
+  }
+
+  // clang-format off
+  static struct TestValue tests[] = {
+    { NULL,                      NULL, -1 }, // Invalid
+    { "",                        NULL, -1 }, // Invalid
+    { "%s/file/empty",           NULL,  1 }, // Empty file
+    { "%s/file/empty_symlink",   NULL,  1 }, // Symlink
+    { "%s/file/size",            NULL,  0 }, // Non-empty file
+    { "%s/file/missing_symlink", NULL, -1 }, // Broken symlink
+    { "%s/file/missing",         NULL, -1 }, // Missing file
+  };
+  // clang-format on
+
+  char first[256] = { 0 };
+  int rc;
+  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  {
+    test_gen_path(first, sizeof(first), tests[i].first);
+
+    TEST_CASE(first);
+    rc = mutt_file_check_empty(first);
+    TEST_CHECK(rc == tests[i].retval);
   }
 }

--- a/test/file/mutt_file_chmod.c
+++ b/test/file/mutt_file_chmod.c
@@ -23,13 +23,58 @@
 #define TEST_NO_MAIN
 #include "acutest.h"
 #include "config.h"
+#include <fcntl.h>
+#include <sys/stat.h>
 #include "mutt/lib.h"
+#include "common.h"
 
 void test_mutt_file_chmod(void)
 {
   // int mutt_file_chmod(const char *path, mode_t mode);
 
+  // clang-format off
+  static struct TestValue tests_fail[] = {
+    { NULL,                      }, // Invalid
+    { "",                        }, // Invalid
+    { "%s/file/missing",         }, // Missing file
+    { "%s/file/missing_symlink", }, // Broken symlink
+  };
+  // clang-format on
+
+  char first[256] = { 0 };
+  int rc;
+
+  for (size_t i = 0; i < mutt_array_size(tests_fail); i++)
   {
-    TEST_CHECK(mutt_file_chmod(NULL, 0) != 0);
+    test_gen_path(first, sizeof(first), tests_fail[i].first);
+
+    TEST_CASE(first);
+    rc = mutt_file_chmod(first, S_IRUSR | S_IWUSR);
+    TEST_CHECK(rc == -1);
+  }
+
+  // clang-format off
+  static struct TestValue tests_succeed[] = {
+    { "%s/file/chmod",         NULL, 0640 }, // Real file
+    { "%s/file/chmod_symlink", NULL, 0640 }, // Symlink
+  };
+  // clang-format on
+
+  struct stat st;
+  for (size_t i = 0; i < mutt_array_size(tests_succeed); i++)
+  {
+    test_gen_path(first, sizeof(first), tests_succeed[i].first);
+
+    TEST_CASE(first);
+
+    TEST_CHECK(chmod(first, 0000) == 0);
+    rc = mutt_file_chmod(first, tests_succeed[i].retval);
+    TEST_CHECK(rc == 0);
+    TEST_CHECK(stat(first, &st) == 0);
+    if (!TEST_CHECK((st.st_mode & 0777) == tests_succeed[i].retval))
+    {
+      TEST_MSG("Expected: %o", tests_succeed[i].retval);
+      TEST_MSG("Actual:   %o", (st.st_mode & 0777));
+    }
   }
 }

--- a/test/file/mutt_file_chmod_add.c
+++ b/test/file/mutt_file_chmod_add.c
@@ -23,13 +23,68 @@
 #define TEST_NO_MAIN
 #include "acutest.h"
 #include "config.h"
+#include <fcntl.h>
+#include <sys/stat.h>
 #include "mutt/lib.h"
+#include "common.h"
 
 void test_mutt_file_chmod_add(void)
 {
   // int mutt_file_chmod_add(const char *path, mode_t mode);
 
+  // clang-format off
+  static struct TestValue tests_fail[] = {
+    { NULL,                      }, // Invalid
+    { "",                        }, // Invalid
+    { "%s/file/missing",         }, // Missing file
+    { "%s/file/missing_symlink", }, // Broken symlink
+  };
+  // clang-format on
+
+  char first[256] = { 0 };
+  int rc;
+
+  for (size_t i = 0; i < mutt_array_size(tests_fail); i++)
   {
-    TEST_CHECK(mutt_file_chmod_add(NULL, 0) != 0);
+    test_gen_path(first, sizeof(first), tests_fail[i].first);
+
+    TEST_CASE(first);
+    rc = mutt_file_chmod_add(first, S_IRUSR | S_IWUSR);
+    TEST_CHECK(rc == -1);
+  }
+
+  // clang-format off
+  static struct TestValue tests_succeed[] = {
+    { "%s/file/chmod",         NULL, 0666 }, // Real file
+    { "%s/file/chmod_symlink", NULL, 0666 }, // Symlink
+  };
+  // clang-format on
+
+  struct stat st;
+  for (size_t i = 0; i < mutt_array_size(tests_succeed); i++)
+  {
+    test_gen_path(first, sizeof(first), tests_succeed[i].first);
+
+    TEST_CASE(first);
+
+    TEST_CHECK(chmod(first, 0444) == 0);
+    rc = mutt_file_chmod_add(first, 0222);
+    TEST_CHECK(rc == 0);
+    TEST_CHECK(stat(first, &st) == 0);
+    if (!TEST_CHECK((st.st_mode & 0777) == tests_succeed[i].retval))
+    {
+      TEST_MSG("Expected: %o", tests_succeed[i].retval);
+      TEST_MSG("Actual:   %o", (st.st_mode & 0777));
+    }
+
+    TEST_CHECK(chmod(first, 0666) == 0);
+    rc = mutt_file_chmod_add(first, 0222);
+    TEST_CHECK(rc == 0);
+    TEST_CHECK(stat(first, &st) == 0);
+    if (!TEST_CHECK((st.st_mode & 0777) == tests_succeed[i].retval))
+    {
+      TEST_MSG("Expected: %o", tests_succeed[i].retval);
+      TEST_MSG("Actual:   %o", (st.st_mode & 0777));
+    }
   }
 }

--- a/test/file/mutt_file_chmod_add_stat.c
+++ b/test/file/mutt_file_chmod_add_stat.c
@@ -23,8 +23,10 @@
 #define TEST_NO_MAIN
 #include "acutest.h"
 #include "config.h"
+#include <fcntl.h>
 #include <sys/stat.h>
 #include "mutt/lib.h"
+#include "common.h"
 
 void test_mutt_file_chmod_add_stat(void)
 {
@@ -37,5 +39,45 @@ void test_mutt_file_chmod_add_stat(void)
 
   {
     TEST_CHECK(mutt_file_chmod_add_stat("apple", 0, NULL) != 0);
+  }
+
+  char first[256] = { 0 };
+  int rc;
+
+  // clang-format off
+  static struct TestValue tests[] = {
+    { "%s/file/chmod",         NULL, 0666 }, // Real file
+    { "%s/file/chmod_symlink", NULL, 0666 }, // Symlink
+  };
+  // clang-format on
+
+  struct stat st;
+  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  {
+    test_gen_path(first, sizeof(first), tests[i].first);
+
+    TEST_CASE(first);
+
+    TEST_CHECK(chmod(first, 0444) == 0);
+    TEST_CHECK(stat(first, &st) == 0);
+    rc = mutt_file_chmod_add_stat(first, 0222, &st);
+    TEST_CHECK(rc == 0);
+    TEST_CHECK(stat(first, &st) == 0);
+    if (!TEST_CHECK((st.st_mode & 0777) == tests[i].retval))
+    {
+      TEST_MSG("Expected: %o", tests[i].retval);
+      TEST_MSG("Actual:   %o", (st.st_mode & 0777));
+    }
+
+    TEST_CHECK(chmod(first, 0666) == 0);
+    TEST_CHECK(stat(first, &st) == 0);
+    rc = mutt_file_chmod_add_stat(first, 0222, &st);
+    TEST_CHECK(rc == 0);
+    TEST_CHECK(stat(first, &st) == 0);
+    if (!TEST_CHECK((st.st_mode & 0777) == tests[i].retval))
+    {
+      TEST_MSG("Expected: %o", tests[i].retval);
+      TEST_MSG("Actual:   %o", (st.st_mode & 0777));
+    }
   }
 }

--- a/test/file/mutt_file_chmod_rm.c
+++ b/test/file/mutt_file_chmod_rm.c
@@ -23,13 +23,68 @@
 #define TEST_NO_MAIN
 #include "acutest.h"
 #include "config.h"
+#include <fcntl.h>
+#include <sys/stat.h>
 #include "mutt/lib.h"
+#include "common.h"
 
 void test_mutt_file_chmod_rm(void)
 {
   // int mutt_file_chmod_rm(const char *path, mode_t mode);
 
+  // clang-format off
+  static struct TestValue tests_fail[] = {
+    { NULL,                      }, // Invalid
+    { "",                        }, // Invalid
+    { "%s/file/missing",         }, // Missing file
+    { "%s/file/missing_symlink", }, // Broken symlink
+  };
+  // clang-format on
+
+  char first[256] = { 0 };
+  int rc;
+
+  for (size_t i = 0; i < mutt_array_size(tests_fail); i++)
   {
-    TEST_CHECK(mutt_file_chmod_rm(NULL, 0) != 0);
+    test_gen_path(first, sizeof(first), tests_fail[i].first);
+
+    TEST_CASE(first);
+    rc = mutt_file_chmod_rm(first, S_IRUSR | S_IWUSR);
+    TEST_CHECK(rc == -1);
+  }
+
+  // clang-format off
+  static struct TestValue tests_succeed[] = {
+    { "%s/file/chmod",         NULL, 0444 }, // Real file
+    { "%s/file/chmod_symlink", NULL, 0444 }, // Symlink
+  };
+  // clang-format on
+
+  struct stat st;
+  for (size_t i = 0; i < mutt_array_size(tests_succeed); i++)
+  {
+    test_gen_path(first, sizeof(first), tests_succeed[i].first);
+
+    TEST_CASE(first);
+
+    TEST_CHECK(chmod(first, 0666) == 0);
+    rc = mutt_file_chmod_rm(first, 0222);
+    TEST_CHECK(rc == 0);
+    TEST_CHECK(stat(first, &st) == 0);
+    if (!TEST_CHECK((st.st_mode & 0777) == tests_succeed[i].retval))
+    {
+      TEST_MSG("Expected: %o", tests_succeed[i].retval);
+      TEST_MSG("Actual:   %o", (st.st_mode & 0777));
+    }
+
+    TEST_CHECK(chmod(first, 0444) == 0);
+    rc = mutt_file_chmod_rm(first, 0222);
+    TEST_CHECK(rc == 0);
+    TEST_CHECK(stat(first, &st) == 0);
+    if (!TEST_CHECK((st.st_mode & 0777) == tests_succeed[i].retval))
+    {
+      TEST_MSG("Expected: %o", tests_succeed[i].retval);
+      TEST_MSG("Actual:   %o", (st.st_mode & 0777));
+    }
   }
 }

--- a/test/file/mutt_file_chmod_rm_stat.c
+++ b/test/file/mutt_file_chmod_rm_stat.c
@@ -23,8 +23,10 @@
 #define TEST_NO_MAIN
 #include "acutest.h"
 #include "config.h"
+#include <fcntl.h>
 #include <sys/stat.h>
 #include "mutt/lib.h"
+#include "common.h"
 
 void test_mutt_file_chmod_rm_stat(void)
 {
@@ -37,5 +39,45 @@ void test_mutt_file_chmod_rm_stat(void)
 
   {
     TEST_CHECK(mutt_file_chmod_rm_stat("apple", 0, NULL) != 0);
+  }
+
+  char first[256] = { 0 };
+  int rc;
+
+  // clang-format off
+  static struct TestValue tests[] = {
+    { "%s/file/chmod",         NULL, 0444 }, // Real file
+    { "%s/file/chmod_symlink", NULL, 0444 }, // Symlink
+  };
+  // clang-format on
+
+  struct stat st;
+  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  {
+    test_gen_path(first, sizeof(first), tests[i].first);
+
+    TEST_CASE(first);
+
+    TEST_CHECK(chmod(first, 0666) == 0);
+    TEST_CHECK(stat(first, &st) == 0);
+    rc = mutt_file_chmod_rm_stat(first, 0222, &st);
+    TEST_CHECK(rc == 0);
+    TEST_CHECK(stat(first, &st) == 0);
+    if (!TEST_CHECK((st.st_mode & 0777) == tests[i].retval))
+    {
+      TEST_MSG("Expected: %o", tests[i].retval);
+      TEST_MSG("Actual:   %o", (st.st_mode & 0777));
+    }
+
+    TEST_CHECK(chmod(first, 0444) == 0);
+    TEST_CHECK(stat(first, &st) == 0);
+    rc = mutt_file_chmod_rm_stat(first, 0222, &st);
+    TEST_CHECK(rc == 0);
+    TEST_CHECK(stat(first, &st) == 0);
+    if (!TEST_CHECK((st.st_mode & 0777) == tests[i].retval))
+    {
+      TEST_MSG("Expected: %o", tests[i].retval);
+      TEST_MSG("Actual:   %o", (st.st_mode & 0777));
+    }
   }
 }

--- a/test/file/mutt_file_get_size.c
+++ b/test/file/mutt_file_get_size.c
@@ -24,12 +24,31 @@
 #include "acutest.h"
 #include "config.h"
 #include "mutt/lib.h"
+#include "common.h"
 
 void test_mutt_file_get_size(void)
 {
   // long mutt_file_get_size(const char *path);
 
+  // clang-format off
+  static struct TestValue tests[] = {
+    { NULL,                      "Invalid",        0,    },
+    { "%s/file/size",            "Real path",      1234, },
+    { "%s/file/size_symlink",    "Symlink",        1234, },
+    { "%s/file/missing_symlink", "Broken symlink", 0,    },
+    { "%s/file/missing",         "Missing",        0,    },
+  };
+  // clang-format on
+
+  char first[256] = { 0 };
+
+  int rc;
+  for (size_t i = 0; i < mutt_array_size(tests); i++)
   {
-    TEST_CHECK(mutt_file_get_size(NULL) == 0);
+    test_gen_path(first, sizeof(first), tests[i].first);
+
+    TEST_CASE(tests[i].second);
+    rc = mutt_file_get_size(first);
+    TEST_CHECK(rc == tests[i].retval);
   }
 }

--- a/test/file/mutt_file_lock.c
+++ b/test/file/mutt_file_lock.c
@@ -28,4 +28,8 @@
 void test_mutt_file_lock(void)
 {
   // int mutt_file_lock(int fd, bool excl, bool timeout);
+
+  {
+    TEST_CHECK(mutt_file_lock(0, false, false) == 0);
+  }
 }

--- a/test/file/mutt_file_quote_filename.c
+++ b/test/file/mutt_file_quote_filename.c
@@ -24,10 +24,19 @@
 #include "acutest.h"
 #include "config.h"
 #include "mutt/lib.h"
+#include "common.h"
 
 void test_mutt_file_quote_filename(void)
 {
   // size_t mutt_file_quote_filename(const char *filename, char *buf, size_t buflen);
+
+  // clang-format off
+  static struct TestValue tests[] = {
+    { "plain",  "'plain'",       7 },
+    { "ba`ck",  "'ba'\\`'ck'",  10 },
+    { "qu'ote", "'qu'\\''ote'", 11 },
+  };
+  // clang-format on
 
   {
     char buf[32] = { 0 };
@@ -36,5 +45,23 @@ void test_mutt_file_quote_filename(void)
 
   {
     TEST_CHECK(mutt_file_quote_filename("apple", NULL, 10) == 0);
+  }
+
+  int rc;
+  char buf[256];
+  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  {
+    TEST_CASE(tests[i].first);
+    memset(buf, 0, sizeof(buf));
+    rc = mutt_file_quote_filename(tests[i].first, buf, sizeof(buf));
+    if (!TEST_CHECK(rc == tests[i].retval) ||
+        !TEST_CHECK(mutt_str_strcmp(buf, tests[i].second) == 0))
+    {
+      TEST_MSG("Expected: %d", tests[i].retval);
+      TEST_MSG("Actual:   %d", rc);
+      TEST_MSG("Original: %s", tests[i].first);
+      TEST_MSG("Expected: %s", tests[i].second);
+      TEST_MSG("Actual:   %s", buf);
+    }
   }
 }

--- a/test/file/mutt_file_resolve_symlink.c
+++ b/test/file/mutt_file_resolve_symlink.c
@@ -1,9 +1,9 @@
 /**
  * @file
- * Test code for mutt_file_unlock()
+ * Test code for mutt_file_resolve_symlink()
  *
  * @authors
- * Copyright (C) 2019 Richard Russon <rich@flatcap.org>
+ * Copyright (C) 2020 Richard Russon <rich@flatcap.org>
  *
  * @copyright
  * This program is free software: you can redistribute it and/or modify it under
@@ -25,11 +25,14 @@
 #include "config.h"
 #include "mutt/lib.h"
 
-void test_mutt_file_unlock(void)
+void test_mutt_file_resolve_symlink(void)
 {
-  // int mutt_file_unlock(int fd);
+  // void mutt_file_resolve_symlink(struct Buffer *buf);
 
   {
-    TEST_CHECK(mutt_file_unlock(0) == 0);
+    struct Buffer file = mutt_buffer_make(0);
+    mutt_file_resolve_symlink(&file);
+    TEST_CHECK_(1, "mutt_file_resolve_symlink(&file)");
+    mutt_buffer_dealloc(&file);
   }
 }

--- a/test/file/mutt_file_resolve_symlink.c
+++ b/test/file/mutt_file_resolve_symlink.c
@@ -52,7 +52,7 @@ void test_mutt_file_resolve_symlink(void)
     test_gen_path(second, sizeof(second), tests[i].second);
     mutt_buffer_strcpy(&result, first);
 
-    TEST_CASE(tests[i].first);
+    TEST_CASE(first);
     mutt_file_resolve_symlink(&result);
     if (!TEST_CHECK(mutt_str_strcmp(mutt_b2s(&result), second) == 0))
     {

--- a/test/file/mutt_file_stat_compare.c
+++ b/test/file/mutt_file_stat_compare.c
@@ -25,10 +25,20 @@
 #include "config.h"
 #include <sys/stat.h>
 #include "mutt/lib.h"
+#include "common.h"
 
 void test_mutt_file_stat_compare(void)
 {
   // int mutt_file_stat_compare(struct stat *sba, enum MuttStatType sba_type, struct stat *sbb, enum MuttStatType sbb_type);
+
+  // clang-format off
+  static struct TestValue tests[] = {
+    { "%s/file/stat/old",   "%s/file/stat/same1", -1 },
+    { "%s/file/stat/same1", "%s/file/stat/same2",  0 },
+    { "%s/file/stat/same2", "%s/file/stat/same1",  0 },
+    { "%s/file/stat/new",   "%s/file/stat/same2",  1 },
+  };
+  // clang-format on
 
   {
     struct stat stat = { 0 };
@@ -38,5 +48,29 @@ void test_mutt_file_stat_compare(void)
   {
     struct stat stat = { 0 };
     TEST_CHECK(mutt_file_stat_compare(&stat, 0, NULL, 0) == 0);
+  }
+
+  int rc;
+  struct stat st1;
+  struct stat st2;
+  char first[256] = { 0 };
+  char second[256] = { 0 };
+  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  {
+    memset(&st1, 0, sizeof(st1));
+    memset(&st2, 0, sizeof(st2));
+    test_gen_path(first, sizeof(first), tests[i].first);
+    test_gen_path(second, sizeof(second), tests[i].second);
+
+    TEST_CASE(first);
+    TEST_CHECK(stat(first, &st1) == 0);
+    TEST_CHECK(stat(second, &st2) == 0);
+
+    rc = mutt_file_stat_compare(&st1, MUTT_STAT_MTIME, &st2, MUTT_STAT_MTIME);
+    if (!TEST_CHECK(rc == tests[i].retval))
+    {
+      TEST_MSG("Expected: %d", tests[i].retval);
+      TEST_MSG("Actual:   %d", rc);
+    }
   }
 }

--- a/test/file/mutt_file_touch_atime.c
+++ b/test/file/mutt_file_touch_atime.c
@@ -28,4 +28,9 @@
 void test_mutt_file_touch_atime(void)
 {
   // void mutt_file_touch_atime(int fd);
+
+  {
+    mutt_file_touch_atime(0);
+    TEST_CHECK_(1, "mutt_file_touch_atime(0)");
+  }
 }

--- a/test/main.c
+++ b/test/main.c
@@ -219,6 +219,7 @@
   NEOMUTT_TEST_ITEM(test_mutt_file_read_keyword)                               \
   NEOMUTT_TEST_ITEM(test_mutt_file_read_line)                                  \
   NEOMUTT_TEST_ITEM(test_mutt_file_rename)                                     \
+  NEOMUTT_TEST_ITEM(test_mutt_file_resolve_symlink)                            \
   NEOMUTT_TEST_ITEM(test_mutt_file_rmtree)                                     \
   NEOMUTT_TEST_ITEM(test_mutt_file_safe_rename)                                \
   NEOMUTT_TEST_ITEM(test_mutt_file_sanitize_filename)                          \


### PR DESCRIPTION
The tests aren't very exciting, they simply cover functions from `mutt/file.c`

The tricky part is the test files required for these functions.
They live in the [neomutt-test-files](https://github.com/neomutt/neomutt-test-files) repo.

First, Travis/Cirrus clones the repo.
The location is passed to `neomutt-test` using an environment variable `$NEOMUTT_TEST_DIR`
(we can't pass parameters to the Acutest program)

Most of the functions being tested are expecting a fully-qualified path.
The test function expands a template, "%s/file/empty", using the environment variable, and tests a function with the result.