### PR TITLE
index(entire-thread): update current email pointer

### DIFF
--- a/index.c
+++ b/index.c
@@ -2155,6 +2155,7 @@ int mutt_index_menu(struct MuttWindow *dlg)
           }
         }
         oldcount = Context->mailbox->msg_count;
+        e_cur = get_cur_email(Context, menu);
         struct Email *e_oldcur = e_cur;
         if (nm_read_entire_thread(Context->mailbox, e_cur) < 0)
         {


### PR DESCRIPTION
The 'entire-thread' command when executed outside a notmuch mailbox has
two operations:

 1. Create a notmuch mailbox with only the current email.
 2. Use Notmuch to get the thread based on message ID.

Commit e7682da912a64d1fe54b8a126dc072ef1699b5a5, removed the 'CUR_EMAIL'
macro, and replaced all usages with initializing 'e_cur' or 'e_cur' if
initialized within the scope.

However, 'entire-thread' relied on calling the macro twice when in a
non-notmuch mailbox. The first invocation returns the current email in
the non-notmuch mailbox for creating a notmuch mailbox, and the second
invocation returns the current email inside the notmuch mailbox. In
refactoring the macro, 'e_cur' never updates and holds the value of the
non-notmuch mailbox email.

To resolve the issue, update the 'e_cur' variable once we're inside the
notmuch mailbox to have the correct current message.