### PR TITLE
Cache a mailbox's URL

### DIFF
--- a/core/mailbox.c
+++ b/core/mailbox.c
@@ -73,6 +73,7 @@ void mailbox_free(struct Mailbox **ptr)
   cs_subset_free(&m->sub);
   FREE(&m->name);
   FREE(&m->realpath);
+  url_free(&m->url);
   FREE(&m->emails);
   FREE(&m->v2r);
   notify_free(&m->notify);

--- a/core/mailbox.h
+++ b/core/mailbox.h
@@ -82,6 +82,7 @@ struct Mailbox
 {
   struct Buffer pathbuf;
   char *realpath;                     ///< Used for duplicate detection, context comparison, and the sidebar
+  struct Url *url;                    ///< Parsed mailbox URL
   char *name;                         ///< A short name for the Mailbox
   struct ConfigSubset *sub;           ///< Inherited config items
   off_t size;                         ///< Size of the Mailbox

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -1906,8 +1906,9 @@ static int imap_ac_add(struct Account *a, struct Mailbox *m)
 
   if (!m->mdata)
   {
-    struct Url *url = url_parse(mailbox_path(m));
-    struct ImapMboxData *mdata = imap_mdata_new(adata, url->path);
+    if (!m->url)
+      m->url = url_parse(mailbox_path(m));
+    struct ImapMboxData *mdata = imap_mdata_new(adata, m->url->path);
 
     /* fixup path and realpath, mainly to replace / by /INBOX */
     char buf[1024];
@@ -1917,7 +1918,6 @@ static int imap_ac_add(struct Account *a, struct Mailbox *m)
 
     m->mdata = mdata;
     m->free_mdata = imap_mdata_free;
-    url_free(&url);
   }
   return 0;
 }

--- a/mx.c
+++ b/mx.c
@@ -1570,7 +1570,6 @@ struct Mailbox *mx_mbox_find(struct Account *a, const char *path)
 
   struct MailboxNode *np = NULL;
   struct Url *url_p = NULL;
-  struct Url *url_a = NULL;
 
   const bool use_url = (a->type == MUTT_IMAP);
   if (use_url)
@@ -1589,30 +1588,29 @@ struct Mailbox *mx_mbox_find(struct Account *a, const char *path)
       continue;
     }
 
-    url_free(&url_a);
-    url_a = url_parse(np->mailbox->realpath);
-    if (!url_a)
+    if (!np->mailbox->url)
+      np->mailbox->url = url_parse(mailbox_path(np->mailbox));
+    if (!np->mailbox->url)
       continue;
 
-    if (mutt_str_strcasecmp(url_a->host, url_p->host) != 0)
+    if (mutt_str_strcasecmp(np->mailbox->url->host, url_p->host) != 0)
       continue;
-    if (url_p->user && (mutt_str_strcasecmp(url_a->user, url_p->user) != 0))
+    if (url_p->user && (mutt_str_strcasecmp(np->mailbox->url->user, url_p->user) != 0))
       continue;
     if (a->type == MUTT_IMAP)
     {
-      if (imap_mxcmp(url_a->path, url_p->path) == 0)
+      if (imap_mxcmp(np->mailbox->url->path, url_p->path) == 0)
         break;
     }
     else
     {
-      if (mutt_str_strcmp(url_a->path, url_p->path) == 0)
+      if (mutt_str_strcmp(np->mailbox->url->path, url_p->path) == 0)
         break;
     }
   }
 
 done:
   url_free(&url_p);
-  url_free(&url_a);
 
   if (!np)
     return NULL;

--- a/sidebar.c
+++ b/sidebar.c
@@ -837,15 +837,15 @@ static void fill_empty_space(struct MuttWindow *win, int first_row,
 /**
  * imap_is_prefix - Check if folder matches the beginning of mbox
  * @param folder Folder
- * @param mbox   Mailbox path
+ * @param m      Mailbox
  * @param plen   Prefix length
  * @retval true If folder is the prefix of mbox
  */
-static bool imap_is_prefix(const char *folder, const char *mbox, size_t *plen)
+static bool imap_is_prefix(const char *folder, struct Mailbox *m, size_t *plen)
 {
   bool rc = false;
 
-  struct Url *url_m = url_parse(mbox);
+  struct Url *url_m = m->url ? m->url : (m->url = url_parse(mailbox_path(m)));
   struct Url *url_f = url_parse(folder);
   if (!url_m || !url_f)
     goto done;
@@ -869,7 +869,6 @@ static bool imap_is_prefix(const char *folder, const char *mbox, size_t *plen)
   rc = true;
 
 done:
-  url_free(&url_m);
   url_free(&url_f);
 
   return rc;
@@ -965,7 +964,7 @@ static void draw_sidebar(struct MuttWindow *win, int num_rows, int num_cols, int
     bool maildir_is_prefix = false;
     if (m->type == MUTT_IMAP)
     {
-      maildir_is_prefix = imap_is_prefix(C_Folder, mailbox_path(m), &maildirlen);
+      maildir_is_prefix = imap_is_prefix(C_Folder, m, &maildirlen);
     }
     else
     {


### PR DESCRIPTION
In a simple test case involving opening an IMAP account with 39 subscribed mailboxes, this reduces the number to url_parse from 954 to 173.
