### PR TITLE
change travis-ci.org to travis-ci.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 [![Contributors](https://img.shields.io/badge/Contributors-181-orange.svg)](https://github.com/neomutt/neomutt/blob/master/AUTHORS.md "All of NeoMutt's Contributors")
 [![Release](https://img.shields.io/github/release/neomutt/neomutt.svg)](https://github.com/neomutt/neomutt/releases/latest "Latest Release Notes")
 [![License: GPL v2](https://img.shields.io/badge/License-GPL%20v2-blue.svg)](https://github.com/neomutt/neomutt/blob/master/COPYRIGHT.md "Copyright Statement")
-[![Code build](https://img.shields.io/travis/neomutt/neomutt.svg?label=code)](https://travis-ci.org/neomutt/neomutt "Latest Automatic Code Build")
+[![Code build](https://img.shields.io/travis/neomutt/neomutt.svg?label=code)](https://travis-ci.com/neomutt/neomutt "Latest Automatic Code Build")
 [![Coverity Scan](https://img.shields.io/coverity/scan/8495.svg)](https://scan.coverity.com/projects/neomutt-neomutt "Latest Code Static Analysis")
-[![Website build](https://img.shields.io/travis/neomutt/neomutt.github.io.svg?label=website)](https://travis-ci.org/neomutt/neomutt.github.io "Latest Website Test")
+[![Website build](https://img.shields.io/travis/neomutt/neomutt.github.io.svg?label=website)](https://travis-ci.com/neomutt/neomutt.github.io "Latest Website Test")
 
 ## What is NeoMutt?
 


### PR DESCRIPTION
shields.io images aren't loading properly.

From IRC several days ago:
```
2020-03-26 15:48:19     flatcap hmm... Travis has prompted me to 'migrate' things from travis-ci.org to .com ...
```