### PR TITLE
store: add RocksDB backend

### DIFF
--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -142,13 +142,16 @@ LIBSTOREOBJS+=	store/lmdb.o
 @if HAVE_QDBM
 LIBSTOREOBJS+=	store/qdbm.o
 @endif
+@if HAVE_ROCKSDB
+LIBSTOREOBJS+=	store/rocksdb.o
+@endif
 @if HAVE_TDB
 LIBSTOREOBJS+=	store/tdb.o
 @endif
 @if HAVE_TC
 LIBSTOREOBJS+=	store/tc.o
 @endif
-@if HAVE_BDB || HAVE_GDBM || HAVE_KC || HAVE_LMDB || HAVE_QDBM || HAVE_TDB || HAVE_TC
+@if HAVE_BDB || HAVE_GDBM || HAVE_KC || HAVE_LMDB || HAVE_QDBM || HAVE_ROCKSDB || HAVE_TDB || HAVE_TC
 LIBSTORE=	libstore.a
 LIBSTOREOBJS+=	store/store.o
 CLEANFILES+=	$(LIBSTORE) $(LIBSTOREOBJS)

--- a/auto.def
+++ b/auto.def
@@ -90,6 +90,8 @@ options {
   qdbm=0                    => "Use QDBM for the header cache"
   with-qdbm:path            => "Location of QDBM"
   tdb=0                     => "Use TDB for the header cache"
+  rocksdb=0                 => "Use RocksDB for the header cache"
+  with-rocksdb:path         => "Location of RocksDB"
   with-tdb:path             => "Location of TDB"
   tokyocabinet=0            => "Use TokyoCabinet for the header cache"
   with-tokyocabinet:path    => "Location of TokyoCabinet"
@@ -132,7 +134,7 @@ if {1} {
     autocrypt bdb coverage debug-backtrace debug-graphviz debug-notify
     debug-parse-test debug-window doc everything fmemopen full-doc gdbm gnutls
     gpgme gss homespool idn idn2 inotify kyotocabinet lmdb locales-fix lua lz4
-    mixmaster nls notmuch pgp pkgconf qdbm sasl smime sqlite ssl testing
+    mixmaster nls notmuch pgp pkgconf qdbm rocksdb sasl smime sqlite ssl testing
     tdb tokyocabinet zlib zstd
   } {
     define want-$opt [opt-bool $opt]
@@ -143,7 +145,7 @@ if {1} {
   # a shortcut for "--opt --with-opt=/usr".
   foreach opt {
     bdb gdbm gnutls gpgme gss homespool idn idn2 kyotocabinet lmdb lua lz4 mixmaster
-    ncurses nls notmuch qdbm sasl slang sqlite ssl tdb tokyocabinet zlib zstd
+    ncurses nls notmuch qdbm rocksdb sasl slang sqlite ssl tdb tokyocabinet zlib zstd
   } {
     if {[opt-val with-$opt] ne {}} {
       define want-$opt 1
@@ -359,8 +361,8 @@ set prefix [opt-val with-sysroot][get-define prefix]
 ###############################################################################
 # Everything
 if {[get-define want-everything]} {
-  foreach opt {bdb gdbm gpgme kyotocabinet lmdb lua lz4 notmuch pgp qdbm smime
-               tokyocabinet tdb zlib zstd} {
+  foreach opt {bdb gdbm gpgme kyotocabinet lmdb lua lz4 notmuch pgp rocksdb
+               qdbm smime tokyocabinet tdb zlib zstd} {
     define want-$opt
     append conf_options "--$opt "
   }
@@ -1017,6 +1019,17 @@ if {[get-define want-qdbm]} {
     }
   }
   define-append HCACHE_BACKENDS "qdbm"
+  define USE_HCACHE
+}
+
+###############################################################################
+# Header cache - RocksDB
+if {[get-define want-rocksdb]} {
+  if {![check-inc-and-lib rocksdb [opt-val with-rocksdb $prefix] \
+                          rocksdb/c.h rocksdb_open rocksdb]} {
+    user-error "Unable to find RocksDB"
+  }
+  define-append HCACHE_BACKENDS "rocksdb"
   define USE_HCACHE
 }
 

--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -11811,7 +11811,7 @@ folder-hook imap://user@host2/ 'set folder=imap://host2/ ; set record=+INBOX/Sen
         </para>
         <para>
           Header caching can be enabled by configuring one of the database
-          backends. One of bdb, gdbm, kyotocabinet, lmdb, qdbm, tdb,
+          backends. One of bdb, gdbm, kyotocabinet, lmdb, qdbm, rocksdb, tdb,
           tokyocabinet.
         </para>
         <para>
@@ -11827,7 +11827,14 @@ folder-hook imap://user@host2/ 'set folder=imap://host2/ ; set record=+INBOX/Sen
           be used to specify which backend to use. The list of available
           backends can be specified at configure time with a set of
           --with-&lt;backend&gt; options. Currently, the following backends are
-          supported: bdb, gdbm, kyotocabinet, lmdb, qdbm, tdb, tokyocabinet.
+          supported: bdb, gdbm, kyotocabinet, lmdb, qdbm, rocksdb, tdb,
+          tokyocabinet.
+        </para>
+         <para>
+          Take a look at the benchmark script provided in the following directory:
+          <ulink url="https://github.com/neomutt/neomutt/blob/master/contrib/hcache-bench">contrib/hcache-bench</ulink>
+          of the neomutt sources, there you can find a way of finding the
+          storage backend for your needs.
         </para>
       </sect2>
 

--- a/hcache/hcache.c
+++ b/hcache/hcache.c
@@ -52,7 +52,8 @@
 #include "store/lib.h"
 
 #if !(defined(HAVE_BDB) || defined(HAVE_GDBM) || defined(HAVE_KC) ||           \
-      defined(HAVE_LMDB) || defined(HAVE_QDBM) || defined(HAVE_TC) || defined(HAVE_TDB))
+      defined(HAVE_LMDB) || defined(HAVE_QDBM) || defined(HAVE_ROCKSDB) ||     \
+      defined(HAVE_TC) || defined(HAVE_TDB))
 #error "No hcache backend defined"
 #endif
 

--- a/store/lib.h
+++ b/store/lib.h
@@ -37,15 +37,16 @@
  *
  * @subpage store_store
  *
- * | Name                | File          | Home Page                                 |
- * | :------------------ | :------------ | :---------------------------------------- |
- * | @subpage store_bdb  | store/bdb.c   | https://en.wikipedia.org/wiki/Berkeley_DB |
- * | @subpage store_gdbm | store/gdbm.c  | https://www.gnu.org.ua/software/gdbm/     |
- * | @subpage store_kc   | store/kc.c    | https://fallabs.com/kyotocabinet/         |
- * | @subpage store_lmdb | store/lmdb.c  | https://symas.com/lmdb/                   |
- * | @subpage store_qdbm | store/qdbm.c  | https://fallabs.com/qdbm/                 |
- * | @subpage store_tc   | store/tc.c    | https://tdb.samba.org/                    |
- * | @subpage store_tdb  | store/tdb.c   | https://fallabs.com/tokyocabinet/         |
+ * | Name                   | File            | Home Page                                 |
+ * | :--------------------- | :-------------- | :---------------------------------------- |
+ * | @subpage store_bdb     | store/bdb.c     | https://en.wikipedia.org/wiki/Berkeley_DB |
+ * | @subpage store_gdbm    | store/gdbm.c    | https://www.gnu.org.ua/software/gdbm/     |
+ * | @subpage store_kc      | store/kc.c      | https://fallabs.com/kyotocabinet/         |
+ * | @subpage store_lmdb    | store/lmdb.c    | https://symas.com/lmdb/                   |
+ * | @subpage store_qdbm    | store/qdbm.c    | https://fallabs.com/qdbm/                 |
+ * | @subpage store_rocksdb | store/rocksdb.c | https://rocksdb.org/                      |
+ * | @subpage store_tc      | store/tc.c      | https://tdb.samba.org/                    |
+ * | @subpage store_tdb     | store/tdb.c     | https://fallabs.com/tokyocabinet/         |
  */
 
 #ifndef MUTT_STORE_LIB_H

--- a/store/rocksdb.c
+++ b/store/rocksdb.c
@@ -1,0 +1,186 @@
+/**
+ * @file
+ * RocksDB backend for the key/value Store
+ *
+ * @authors
+ * Copyright (C) 2020 Tino Reichardt <milky-neomutt@mcmilk.de>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @page store_rocksdb RocksDB
+ *
+ * Use the RocksDB - A persistent key-value store for fast storage environments
+ * https://rocksdb.org/
+ */
+
+#include "config.h"
+#include <string.h>
+#include <stddef.h>
+#include <fcntl.h>
+#include <rocksdb/c.h>
+#include <rocksdb/version.h>
+#include "mutt/lib.h"
+#include "lib.h"
+
+/**
+ * struct RocksDB_Ctx - Berkeley DB context
+ */
+struct RocksDB_Ctx
+{
+  rocksdb_t *db;
+  rocksdb_options_t *options;
+  rocksdb_readoptions_t *read_options;
+  rocksdb_writeoptions_t *write_options;
+  char *err;
+};
+
+/**
+ * store_rocksdb_open - Implements StoreOps::open()
+ */
+static void *store_rocksdb_open(const char *path)
+{
+  struct RocksDB_Ctx *ctx = mutt_mem_malloc(sizeof(struct RocksDB_Ctx));
+
+  /* RocksDB store errors in form of strings */
+  ctx->err = NULL;
+
+  /* setup generic options, create new db and limit log to one file */
+  ctx->options = rocksdb_options_create();
+  rocksdb_options_set_create_if_missing(ctx->options, 1);
+  rocksdb_options_set_keep_log_file_num(ctx->options, 1);
+
+  /* setup read options, we verify with checksums */
+  ctx->read_options = rocksdb_readoptions_create();
+  rocksdb_readoptions_set_verify_checksums(ctx->read_options, 1);
+
+  /* setup write options, no sync needed, disable WAL */
+  ctx->write_options = rocksdb_writeoptions_create();
+  rocksdb_writeoptions_set_sync(ctx->write_options, 0);
+  rocksdb_writeoptions_disable_WAL(ctx->write_options, 1);
+
+  rocksdb_options_set_compression(ctx->options, rocksdb_no_compression);
+
+  /* open database and check for error in ctx->error */
+  ctx->db = rocksdb_open(ctx->options, path, &ctx->err);
+  if (ctx->err) {
+    rocksdb_free(ctx->err);
+    FREE(&ctx);
+    return NULL;
+  }
+
+  return ctx;
+}
+
+/**
+ * store_rocksdb_fetch - Implements StoreOps::fetch()
+ */
+static void *store_rocksdb_fetch(void *store, const char *key, size_t keylen, size_t *dlen)
+{
+  if (!store)
+    return NULL;
+
+  struct RocksDB_Ctx *ctx = store;
+
+  void *rv = rocksdb_get(ctx->db, ctx->read_options, key, keylen, dlen, &ctx->err);
+  if (ctx->err) {
+    rocksdb_free(ctx->err);
+    ctx->err = NULL;
+    return NULL;
+  }
+
+  return rv;
+}
+
+/**
+ * store_rocksdb_free - Implements StoreOps::free()
+ */
+static void store_rocksdb_free(void *store, void **data)
+{
+  FREE(data);
+}
+
+/**
+ * store_rocksdb_store - Implements StoreOps::store()
+ */
+static int store_rocksdb_store(void *store, const char *key, size_t keylen, void *data, size_t dlen)
+{
+  if (!store)
+    return -1;
+
+  struct RocksDB_Ctx *ctx = store;
+
+  rocksdb_put(ctx->db, ctx->write_options, key, keylen, data, dlen, &ctx->err);
+  if (ctx->err) {
+    rocksdb_free(ctx->err);
+    ctx->err = NULL;
+    return -1;
+  }
+
+  return 0;
+}
+
+/**
+ * store_rocksdb_delete_record - Implements StoreOps::delete_record()
+ */
+static int store_rocksdb_delete_record(void *store, const char *key, size_t keylen)
+{
+  if (!store)
+    return -1;
+
+  struct RocksDB_Ctx *ctx = store;
+
+  rocksdb_delete(ctx->db, ctx->write_options, key, keylen, &ctx->err);
+  if (ctx->err) {
+    rocksdb_free(ctx->err);
+    ctx->err = NULL;
+    return -1;
+  }
+
+  return 0;
+}
+
+/**
+ * store_rocksdb_close - Implements StoreOps::close()
+ */
+static void store_rocksdb_close(void **ptr)
+{
+  if (!ptr || !*ptr)
+    return;
+
+  struct RocksDB_Ctx *ctx = *ptr;
+
+  /* close database and free resources */
+  rocksdb_close(ctx->db);
+  rocksdb_options_destroy(ctx->options);
+  rocksdb_readoptions_destroy(ctx->read_options);
+  rocksdb_writeoptions_destroy(ctx->write_options);
+
+  FREE(ptr);
+  *ptr = NULL;
+}
+
+/**
+ * store_rocksdb_version - Implements StoreOps::version()
+ */
+static const char *store_rocksdb_version(void)
+{
+  /* return sth. like "RocksDB 6.7.3" */
+  #define RDBVER(major,minor,patch) #major "." #minor "." #patch
+  return "RocksDB " RDBVER(ROCKSDB_MAJOR,ROCKSDB_MINOR,ROCKSDB_PATCH);
+}
+
+STORE_BACKEND_OPS(rocksdb)

--- a/store/store.c
+++ b/store/store.c
@@ -39,6 +39,7 @@ STORE_BACKEND(gdbm)
 STORE_BACKEND(kyotocabinet)
 STORE_BACKEND(lmdb)
 STORE_BACKEND(qdbm)
+STORE_BACKEND(rocksdb)
 STORE_BACKEND(tdb)
 STORE_BACKEND(tokyocabinet)
 #undef STORE_BACKEND
@@ -55,6 +56,9 @@ const struct StoreOps *store_ops[] = {
 #endif
 #ifdef HAVE_QDBM
   &store_qdbm_ops,
+#endif
+#ifdef HAVE_ROCKSDB
+  &store_rocksdb_ops,
 #endif
 #ifdef HAVE_GDBM
   &store_gdbm_ops,


### PR DESCRIPTION
* **What does this PR do?**

This PR will add support for the RocksDB key/value Store backend. The database homepage is located here: https://rocksdb.org/ - and it's stable and fast. I also added a new environment configuration variable called  `$ROCKSDB_COMPRESSION` - I hope this is okay, if not, tell me how I should change the configuration stuff, to fit nicely into neomutt source.

The Documentation is updated, I hope my english is not to bad for that ;)
