### PR TITLE
fix: mutt_date_add_timeout()

### DIFF
--- a/mutt/date.c
+++ b/mutt/date.c
@@ -636,7 +636,7 @@ time_t mutt_date_parse_imap(const char *s)
  *
  * This will truncate instead of overflowing.
  */
-time_t mutt_date_add_timeout(time_t now, long timeout)
+time_t mutt_date_add_timeout(time_t now, time_t timeout)
 {
   if (timeout < 0)
     return now;

--- a/mutt/date.h
+++ b/mutt/date.h
@@ -47,7 +47,7 @@ struct Tz
   bool zoccident;         ///< True if west of UTC, False if East
 };
 
-time_t    mutt_date_add_timeout(time_t now, long timeout);
+time_t    mutt_date_add_timeout(time_t now, time_t timeout);
 int       mutt_date_check_month(const char *s);
 time_t    mutt_date_epoch(void);
 uint64_t  mutt_date_epoch_ms(void);


### PR DESCRIPTION
Change the `timeout` parameter to be a `time_t`.
On the [x32 arch](https://wiki.debian.org/X32Port), `time_t` is 64-bit and `long` is 32-bit.

This meant that one of the 64-bit test `timeout`s was being truncated to 32-bits making the test fail.

Fixes: #2237 