### PR TITLE
Allow spaces and square brackets in paths (e.g., [Gmail]/Sent messages)

### DIFF
--- a/mutt/prex.c
+++ b/mutt/prex.c
@@ -65,31 +65,31 @@ static struct PrexStorage *prex(enum Prex which)
       PREX_URL,
       PREX_URL_MATCH_MAX,
       /* Spec: https://tools.ietf.org/html/rfc3986#section-3 */
-#define UNR_PCTENC_SUBDEL "-a-zA-Z0-9._~%!$&'()*+,;="
-#define PATH ":@/"
+#define UNR_PCTENC_SUBDEL "][a-zA-Z0-9._~%!$&'()*+,;="
+#define PATH ":@/ "
       "^([a-zA-Z][-+.a-zA-Z0-9]+):"                // . scheme
       "("                                          // . rest
         "("                                        // . . authority + path
                                                    // . . or path only
           "(//"                                    // . . . authority + path
             "("                                    // . . . . user info
-              "([" UNR_PCTENC_SUBDEL "@]*)"        // . . . . . user name + '@'
-              "(:([" UNR_PCTENC_SUBDEL "]*))?"     // . . . . . password
+              "([" UNR_PCTENC_SUBDEL "@-]*)"        // . . . . . user name + '@'
+              "(:([" UNR_PCTENC_SUBDEL "-]*))?"     // . . . . . password
             "@)?"
             "("                                    // . . . . host
-              "([" UNR_PCTENC_SUBDEL "]*)"         // . . . . . host name
+              "([" UNR_PCTENC_SUBDEL "-]*)"         // . . . . . host name
               "|"
               "(\\[[a-zA-Z0-9:.]+\\])"             // . . . . . IPv4 or IPv6
             ")"
             "(:([0-9]+))?"                         // . . . . port
-            "(/([" UNR_PCTENC_SUBDEL PATH "]*))?"  // . . . . path
+            "(/([" UNR_PCTENC_SUBDEL PATH "-]*))?"  // . . . . path
           ")"
           "|"
           "("                                      // . . . path only
-            "[" UNR_PCTENC_SUBDEL PATH "]*"        // . . . . path
+            "[" UNR_PCTENC_SUBDEL PATH "-]*"        // . . . . path
           ")"
         ")"
-        "(\\?([" UNR_PCTENC_SUBDEL PATH " ?]*))?"  // . . query + ' ' and '?'
+        "(\\?([" UNR_PCTENC_SUBDEL PATH "?-]*))?"  // . . query + ' ' and '?'
       ")$"
 #undef PATH
 #undef UNR_PCTENC_SUBDEL

--- a/test/url/url_parse.c
+++ b/test/url/url_parse.c
@@ -132,6 +132,18 @@ static struct UrlTest test[] = {
     },
     "type|messages|query|tag:inbox|",
   },
+  {
+    "imaps://gmail.com/[GMail]/Sent messages",
+    true,
+    {
+      U_IMAPS,
+      NULL,
+      NULL,
+      "gmail.com",
+      0,
+      "[GMail]/Sent messages"
+    }
+  }
 };
 // clang-format on
 


### PR DESCRIPTION
Fixes #2226
Fixes #2225