### PR TITLE
add error for CLI empty emails

### DIFF
--- a/send.c
+++ b/send.c
@@ -2166,7 +2166,11 @@ int mutt_send_message(SendFlags flags, struct Email *e_templ, const char *tempfi
     if (flags & SEND_BATCH)
     {
       if (mutt_file_copy_stream(stdin, fp_tmp) < 1)
+      {
+        mutt_error(_("Refusing to send an empty email"));
+        mutt_message(_("Try: echo | neomutt -s 'subject' user@example.com"));
         goto cleanup;
+      }
     }
 
     if (C_SigOnTop && !(flags & (SEND_MAILX | SEND_KEY | SEND_BATCH)) &&


### PR DESCRIPTION
Issue #2243 wants to send empty emails, but that conflicts with issue 2138
where empty emails were being sent by mistake.

For now, disallow: `neomutt user@example.com < /dev/null`
in favour of:      `echo | neomutt user@example.com`

Add an error message to suggest this behaviour.

> Refusing to send an empty email
> Try: `echo | neomutt -s 'subject' user@example.com`

Closes: #2243 