### PR TITLE
browser: fix hidden mailboxes

### DIFF
--- a/browser.c
+++ b/browser.c
@@ -1371,19 +1371,6 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
 
   mutt_buffer_reset(file);
 
-  if (mailbox)
-  {
-    examine_mailboxes(NULL, &state);
-  }
-  else
-#ifdef USE_IMAP
-      if (!state.imap_browse)
-#endif
-  {
-    if (examine_directory(NULL, &state, mutt_b2s(&LastDir), mutt_b2s(prefix)) == -1)
-      goto bail;
-  }
-
   struct MuttWindow *dlg =
       mutt_window_new(MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
@@ -1432,6 +1419,19 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
 #endif
                                            FolderHelp);
   mutt_menu_push_current(menu);
+
+  if (mailbox)
+  {
+    examine_mailboxes(NULL, &state);
+  }
+  else
+#ifdef USE_IMAP
+      if (!state.imap_browse)
+#endif
+  {
+    if (examine_directory(menu, &state, mutt_b2s(&LastDir), mutt_b2s(prefix)) == -1)
+      goto bail;
+  }
 
   init_menu(&state, menu, title, sizeof(title), mailbox);
 


### PR DESCRIPTION
Rearrange `mutt_buffer_select_file()` so that we can pass a Menu to `examine_directory()`.

Fixes: #2199