### PR TITLE
correct variable sizes

### DIFF
--- a/conn/raw.c
+++ b/conn/raw.c
@@ -328,14 +328,13 @@ int raw_socket_write(struct Connection *conn, const char *buf, size_t count)
  */
 int raw_socket_poll(struct Connection *conn, time_t wait_secs)
 {
-  fd_set rfds;
-  unsigned long wait_millis;
-  struct timeval tv;
-
   if (conn->fd < 0)
     return -1;
 
-  wait_millis = wait_secs * 1000UL;
+  fd_set rfds;
+  struct timeval tv;
+
+  uint64_t wait_millis = wait_secs * 1000UL;
 
   while (true)
   {
@@ -345,9 +344,9 @@ int raw_socket_poll(struct Connection *conn, time_t wait_secs)
     FD_ZERO(&rfds);
     FD_SET(conn->fd, &rfds);
 
-    size_t pre_t = mutt_date_epoch_ms();
+    uint64_t pre_t = mutt_date_epoch_ms();
     const int rc = select(conn->fd + 1, &rfds, NULL, NULL, &tv);
-    size_t post_t = mutt_date_epoch_ms();
+    uint64_t post_t = mutt_date_epoch_ms();
 
     if ((rc > 0) || ((rc < 0) && (errno != EINTR)))
       return rc;

--- a/hcache/hcachever.sh
+++ b/hcache/hcachever.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-BASEVERSION=4
+BASEVERSION=5
 STRUCTURES="Address Body Buffer Email Envelope ListNode Parameter"
 
 cleanstruct () {

--- a/hcache/lib.h
+++ b/hcache/lib.h
@@ -95,9 +95,9 @@ typedef struct EmailCache header_cache_t;
  */
 struct HCacheEntry
 {
-  size_t uidvalidity;  ///< IMAP-specific UIDVALIDITY
-  unsigned int crc;    ///< CRC of Email/Body/etc structs
-  struct Email *email; ///< Retrieved email
+  uint32_t uidvalidity; ///< IMAP-specific UIDVALIDITY
+  unsigned int crc;     ///< CRC of Email/Body/etc structs
+  struct Email *email;  ///< Retrieved email
 };
 
 /**
@@ -140,7 +140,7 @@ void mutt_hcache_close(header_cache_t *hc);
  * @retval num Generic or backend-specific error code otherwise
  */
 int mutt_hcache_store(header_cache_t *hc, const char *key, size_t keylen,
-                      struct Email *e, unsigned int uidvalidity);
+                      struct Email *e, uint32_t uidvalidity);
 
 /**
  * mutt_hcache_fetch - fetch and validate a  message's header from the cache
@@ -154,7 +154,7 @@ int mutt_hcache_store(header_cache_t *hc, const char *key, size_t keylen,
  * @note This function performs a check on the validity of the data found by
  *       comparing it with the crc value of the header_cache_t structure.
  */
-struct HCacheEntry mutt_hcache_fetch(header_cache_t *hc, const char *key, size_t keylen, unsigned int uidvalidity);
+struct HCacheEntry mutt_hcache_fetch(header_cache_t *hc, const char *key, size_t keylen, uint32_t uidvalidity);
 
 int mutt_hcache_store_raw(header_cache_t *hc, const char *key, size_t keylen,
                           void *data, size_t dlen);

--- a/hcache/serialize.c
+++ b/hcache/serialize.c
@@ -72,17 +72,17 @@ unsigned char *serial_dump_int(unsigned int i, unsigned char *d, int *off)
 }
 
 /**
- * serial_dump_size_t - Pack a size_t into a binary blob
- * @param s   Size_t to save
+ * serial_dump_uint32_t - Pack a uint32_t into a binary blob
+ * @param s   uint32_t to save
  * @param d   Binary blob to add to
  * @param off Offset into the blob
  * @retval ptr End of the newly packed binary
  */
-unsigned char *serial_dump_size_t(size_t s, unsigned char *d, int *off)
+unsigned char *serial_dump_uint32_t(uint32_t s, unsigned char *d, int *off)
 {
-  lazy_realloc(&d, *off + sizeof(size_t));
-  memcpy(d + *off, &s, sizeof(size_t));
-  (*off) += sizeof(size_t);
+  lazy_realloc(&d, *off + sizeof(uint32_t));
+  memcpy(d + *off, &s, sizeof(uint32_t));
+  (*off) += sizeof(uint32_t);
 
   return d;
 }
@@ -100,15 +100,15 @@ void serial_restore_int(unsigned int *i, const unsigned char *d, int *off)
 }
 
 /**
- * serial_restore_size_t - Unpack an size_t from a binary blob
- * @param s   Size_t to write to
+ * serial_restore_uint32_t - Unpack an uint32_t from a binary blob
+ * @param s   uint32_t to write to
  * @param d   Binary blob to read from
  * @param off Offset into the blob
  */
-void serial_restore_size_t(size_t *s, const unsigned char *d, int *off)
+void serial_restore_uint32_t(uint32_t *s, const unsigned char *d, int *off)
 {
-  memcpy(s, d + *off, sizeof(size_t));
-  (*off) += sizeof(size_t);
+  memcpy(s, d + *off, sizeof(uint32_t));
+  (*off) += sizeof(uint32_t);
 }
 
 /**

--- a/hcache/serialize.h
+++ b/hcache/serialize.h
@@ -44,7 +44,7 @@ unsigned char *serial_dump_char     (char *c,                  unsigned char *d,
 unsigned char *serial_dump_char_size(char *c, ssize_t size,    unsigned char *d, int *off, bool convert);
 unsigned char *serial_dump_envelope (struct Envelope *e,       unsigned char *d, int *off, bool convert);
 unsigned char *serial_dump_int      (unsigned int i,           unsigned char *d, int *off);
-unsigned char *serial_dump_size_t   (size_t s,                 unsigned char *d, int *off);
+unsigned char *serial_dump_uint32_t (uint32_t s,               unsigned char *d, int *off);
 unsigned char *serial_dump_parameter(struct ParameterList *pl, unsigned char *d, int *off, bool convert);
 unsigned char *serial_dump_stailq   (struct ListHead *l,       unsigned char *d, int *off, bool convert);
 
@@ -54,7 +54,7 @@ void serial_restore_buffer   (struct Buffer *buf,       const unsigned char *d, 
 void serial_restore_char     (char **c,                 const unsigned char *d, int *off, bool convert);
 void serial_restore_envelope (struct Envelope *e,       const unsigned char *d, int *off, bool convert);
 void serial_restore_int      (unsigned int *i,          const unsigned char *d, int *off);
-void serial_restore_size_t   (size_t *s,                const unsigned char *d, int *off);
+void serial_restore_uint32_t (uint32_t *s,              const unsigned char *d, int *off);
 void serial_restore_parameter(struct ParameterList *pl, const unsigned char *d, int *off, bool convert);
 void serial_restore_stailq   (struct ListHead *l,       const unsigned char *d, int *off, bool convert);
 

--- a/imap/command.c
+++ b/imap/command.c
@@ -863,7 +863,7 @@ static void cmd_parse_status(struct ImapAccountData *adata, char *s)
     mutt_debug(LL_DEBUG3, "Received status for an unexpected mailbox: %s\n", mailbox);
     return;
   }
-  unsigned int olduv = mdata->uidvalidity;
+  uint32_t olduv = mdata->uidvalidity;
   unsigned int oldun = mdata->uid_next;
 
   if (*s++ != '(')

--- a/imap/imap_private.h
+++ b/imap/imap_private.h
@@ -225,7 +225,7 @@ struct ImapMboxData
 
   // IMAP STATUS information
   struct ListHead flags;
-  unsigned int uidvalidity;
+  uint32_t uidvalidity;
   unsigned int uid_next;
   unsigned long long modseq;
   unsigned int messages;

--- a/imap/message.c
+++ b/imap/message.c
@@ -200,7 +200,8 @@ static int msg_cache_commit(struct Mailbox *m, struct Email *e)
  */
 static int msg_cache_clean_cb(const char *id, struct BodyCache *bcache, void *data)
 {
-  unsigned int uv, uid;
+  uint32_t uv;
+  unsigned int uid;
   struct ImapMboxData *mdata = data;
 
   if (sscanf(id, "%u-%u", &uv, &uid) != 2)
@@ -1343,7 +1344,7 @@ int imap_read_headers(struct Mailbox *m, unsigned int msn_begin,
         has_qresync = true;
     }
 
-    if (uidvalidity && uid_next && (*(unsigned int *) uidvalidity == mdata->uidvalidity))
+    if (uidvalidity && uid_next && (*(uint32_t *) uidvalidity == mdata->uidvalidity))
     {
       size_t dlen2 = 0;
       evalhc = true;

--- a/imap/util.c
+++ b/imap/util.c
@@ -197,7 +197,7 @@ struct ImapMboxData *imap_mdata_new(struct ImapAccountData *adata, const char *n
     unsigned long long *modseq = mutt_hcache_fetch_raw(hc, "/MODSEQ", 7, &dlen);
     if (uidvalidity)
     {
-      mdata->uidvalidity = *(unsigned int *) uidvalidity;
+      mdata->uidvalidity = *(uint32_t *) uidvalidity;
       mdata->uid_next = uidnext ? *(unsigned int *) uidnext : 0;
       mdata->modseq = modseq ? *modseq : 0;
       mutt_debug(LL_DEBUG3, "hcache uidvalidity %u, uidnext %u, modseq %llu\n",
@@ -506,7 +506,7 @@ struct Email *imap_hcache_get(struct ImapMboxData *mdata, unsigned int uid)
       mutt_hcache_fetch(mdata->hcache, key, mutt_str_strlen(key), mdata->uidvalidity);
   if (!hce.email && hce.uidvalidity)
   {
-    mutt_debug(LL_DEBUG3, "hcache uidvalidity mismatch: %zu\n", hce.uidvalidity);
+    mutt_debug(LL_DEBUG3, "hcache uidvalidity mismatch: %u\n", hce.uidvalidity);
   }
 
   return hce.email;

--- a/maildir/shared.c
+++ b/maildir/shared.c
@@ -737,7 +737,7 @@ void maildir_delayed_parsing(struct Mailbox *m, struct Maildir **md, struct Prog
     }
     struct HCacheEntry hce = mutt_hcache_fetch(hc, key, keylen, 0);
 
-    if (hce.email && (rc == 0) && (lastchanged.st_mtime <= (hce.uidvalidity / 1000)))
+    if (hce.email && (rc == 0) && (lastchanged.st_mtime <= hce.uidvalidity))
     {
       hce.email->old = p->email->old;
       hce.email->path = mutt_str_strdup(p->email->path);

--- a/mutt_logging.c
+++ b/mutt_logging.c
@@ -43,7 +43,7 @@
 #include "muttlib.h"
 #include "options.h"
 
-size_t LastError = 0; ///< Time of the last error message (in milliseconds since the Unix epoch)
+uint64_t LastError = 0; ///< Time of the last error message (in milliseconds since the Unix epoch)
 
 short C_DebugLevel = 0;   ///< Config: Logging level for debug logs
 char *C_DebugFile = NULL; ///< Config: File to save debug logs
@@ -59,8 +59,8 @@ const int NumOfLogs = 5;  ///< How many log files to rotate
  */
 static void error_pause(void)
 {
-  const size_t elapsed = mutt_date_epoch_ms() - LastError;
-  const size_t sleep = C_SleepTime * S_TO_MS;
+  const uint64_t elapsed = mutt_date_epoch_ms() - LastError;
+  const uint64_t sleep = C_SleepTime * S_TO_MS;
   if ((LastError == 0) || (elapsed >= sleep))
     return;
 

--- a/progress.c
+++ b/progress.c
@@ -214,7 +214,7 @@ void mutt_progress_update(struct Progress *progress, size_t pos, int percent)
   if (OptNoCurses)
     return;
 
-  const size_t now = mutt_date_epoch_ms();
+  const uint64_t now = mutt_date_epoch_ms();
 
   const bool update = (pos == 0) /* always show the first update */ ||
                       (progress_pos_needs_update(progress, pos) &&

--- a/progress.h
+++ b/progress.h
@@ -53,7 +53,7 @@ struct Progress
   size_t pos;
   size_t size;
   size_t inc;
-  long timestamp;
+  uint64_t timestamp;
   bool is_bytes;
 };
 


### PR DESCRIPTION
- `mutt_date_epoch_ms()`
  Ensure variables are 64-bit (even on 32-bit arches)

- IMAP `UIDVALIDITY` is 32-bit
  shrink variables to match

- Bump hcache version
  The `UIDVALIDITY` change affects all records in the header cache