### PR TITLE
Add support for using PCRE2

### DIFF
--- a/browser.c
+++ b/browser.c
@@ -33,7 +33,6 @@
 #include <limits.h>
 #include <locale.h>
 #include <pwd.h>
-#include <regex.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/command_parse.c
+++ b/command_parse.c
@@ -30,7 +30,6 @@
 #include "config.h"
 #include <errno.h>
 #include <limits.h>
-#include <regex.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <string.h>

--- a/commands.c
+++ b/commands.c
@@ -31,7 +31,6 @@
 #include "config.h"
 #include <errno.h>
 #include <limits.h>
-#include <regex.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <string.h>

--- a/config/regex.c
+++ b/config/regex.c
@@ -29,7 +29,6 @@
 #include "config.h"
 #include <stddef.h>
 #include <limits.h>
-#include <regex.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include "mutt/lib.h"

--- a/config/regex2.h
+++ b/config/regex2.h
@@ -23,7 +23,7 @@
 #ifndef MUTT_CONFIG_REGEX_H
 #define MUTT_CONFIG_REGEX_H
 
-#include <regex.h>
+#include "mutt/regex3.h"
 
 struct Buffer;
 struct ConfigSet;

--- a/conn/gnutls.c
+++ b/conn/gnutls.c
@@ -30,7 +30,6 @@
 #include "config.h"
 #include <gnutls/gnutls.h>
 #include <gnutls/x509.h>
-#include <regex.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <string.h>

--- a/email/parse.c
+++ b/email/parse.c
@@ -29,7 +29,6 @@
 
 #include "config.h"
 #include <ctype.h>
-#include <regex.h>
 #include <string.h>
 #include <time.h>
 #include "mutt/lib.h"

--- a/gui/color.c
+++ b/gui/color.c
@@ -27,7 +27,6 @@
  */
 
 #include "config.h"
-#include <regex.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/gui/color.h
+++ b/gui/color.h
@@ -24,7 +24,6 @@
 #define MUTT_COLOR_H
 
 #include "config.h"
-#include <regex.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include "mutt/lib.h"

--- a/gui/curs_lib.c
+++ b/gui/curs_lib.c
@@ -34,7 +34,6 @@
 #include <fcntl.h>
 #include <langinfo.h>
 #include <limits.h>
-#include <regex.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/hook.c
+++ b/hook.c
@@ -29,7 +29,6 @@
 
 #include "config.h"
 #include <limits.h>
-#include <regex.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <string.h>

--- a/index.c
+++ b/index.c
@@ -30,7 +30,6 @@
 #include <assert.h>
 #include <ctype.h>
 #include <limits.h>
-#include <regex.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>

--- a/menu.c
+++ b/menu.c
@@ -27,7 +27,6 @@
  */
 
 #include "config.h"
-#include <regex.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <string.h>

--- a/mutt/charset.c
+++ b/mutt/charset.c
@@ -32,7 +32,6 @@
 #include <iconv.h>
 #include <langinfo.h>
 #include <limits.h>
-#include <regex.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <string.h>

--- a/mutt/prex.h
+++ b/mutt/prex.h
@@ -23,7 +23,7 @@
 #ifndef MUTT_LIB_PREX_H
 #define MUTT_LIB_PREX_H
 
-#include <regex.h>
+#include "regex3.h"
 
 /**
  * enum Prex - Predefined list of regular expressions

--- a/mutt/regex.c
+++ b/mutt/regex.c
@@ -29,7 +29,6 @@
 
 #include "config.h"
 #include <ctype.h>
-#include <regex.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/mutt/regex3.h
+++ b/mutt/regex3.h
@@ -24,7 +24,16 @@
 #define MUTT_LIB_REGEX_H
 
 #include <stddef.h>
+#include "config.h"
+#ifdef HAVE_PCRE2
+#include <pcre2posix.h>
+#define regcomp pcre2_regcomp
+#define regexec pcre2_regexec
+#define regfree pcre2_regfree
+#define regerror pcre2_regerror
+#else
 #include <regex.h>
+#endif
 #include <stdbool.h>
 #include "queue.h"
 

--- a/mutt/regex3.h
+++ b/mutt/regex3.h
@@ -25,7 +25,7 @@
 
 #include <stddef.h>
 #include "config.h"
-#ifdef HAVE_PCRE2
+#if defined(HAVE_PCRE2) && defined(NEOMUTT_USE_PCRE2_FOR_EVERYTHING)
 #include <pcre2posix.h>
 #define regcomp pcre2_regcomp
 #define regexec pcre2_regexec

--- a/mutt_menu.h
+++ b/mutt_menu.h
@@ -24,11 +24,11 @@
 #define MUTT_MENU_H
 
 #include "config.h"
-#include <regex.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include "keymap.h"
+#include "mutt/regex3.h"
 
 struct NotifyCallback;
 

--- a/mutt_parse.c
+++ b/mutt_parse.c
@@ -27,7 +27,6 @@
  */
 
 #include "config.h"
-#include <regex.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include "mutt/lib.h"

--- a/mutt_parse.h
+++ b/mutt_parse.h
@@ -23,7 +23,6 @@
 #ifndef MUTT_MUTT_PARSE_H
 #define MUTT_MUTT_PARSE_H
 
-#include <regex.h>
 #include "mutt/lib.h"
 #include "email/lib.h"
 

--- a/muttlib.c
+++ b/muttlib.c
@@ -34,7 +34,6 @@
 #include <inttypes.h>
 #include <limits.h>
 #include <pwd.h>
-#include <regex.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>

--- a/pager.c
+++ b/pager.c
@@ -31,7 +31,6 @@
 #include <errno.h>
 #include <inttypes.h> // IWYU pragma: keep
 #include <limits.h>
-#include <regex.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>

--- a/pattern.c
+++ b/pattern.c
@@ -30,7 +30,6 @@
 #include "config.h"
 #include <stddef.h>
 #include <ctype.h>
-#include <regex.h>
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdio.h>

--- a/pattern.h
+++ b/pattern.h
@@ -25,7 +25,6 @@
 #define MUTT_PATTERN_H
 
 #include "config.h"
-#include <regex.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include "mutt/lib.h"

--- a/protos.h
+++ b/protos.h
@@ -26,12 +26,12 @@
 
 #include "config.h"
 #include <stddef.h>
-#include <regex.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include "mutt.h"
 #include "keymap.h"
 #include "ncrypt/lib.h"
+#include "mutt/regex3.h"
 
 struct Buffer;
 struct Context;

--- a/query.c
+++ b/query.c
@@ -28,7 +28,6 @@
  */
 
 #include "config.h"
-#include <regex.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <string.h>


### PR DESCRIPTION
This uses the PCRE2's POSIX compatibility API. Beacuse structure names
are the same as POSIX's as exposed in <regex.h>, all regex clients have
been changed to include mutt/regex3.h instead of the native <regex.h>
header.