### PR TITLE
Add tests for the use cases in #2276

### DIFF
--- a/test/url/url_parse.c
+++ b/test/url/url_parse.c
@@ -143,7 +143,28 @@ static struct UrlTest test[] = {
       0,
       "[GMail]/Sent messages"
     }
-  }
+  },
+  {
+    /* Invalid fragment (#) character, see also
+     * https://github.com/neomutt/neomutt/issues/2276 */
+    "mailto:a@b?subject=#",
+    false,
+  },
+  {
+    /* Correctly escaped fragment (#) chracter, see also
+     * https://github.com/neomutt/neomutt/issues/2276 */
+    "mailto:a@b?subject=%23",
+    true,
+    {
+      U_MAILTO,
+      NULL,
+      NULL,
+      NULL,
+      0,
+      "a@b"
+    },
+    "subject|#|"
+  },
 };
 // clang-format on
 


### PR DESCRIPTION
* Test that we do not parse mailto URIs with fragment (#) chars in their query values. This is illegal according to https://tools.ietf.org/html/rfc6068#section-2.
* Test that we can parse such an URI when the fragment (#) char is properly %-encoded.