### PR TITLE
Avoid crashing / handle UTF-8 URL paths

### DIFF
--- a/imap/imap.c
+++ b/imap/imap.c
@@ -1858,6 +1858,8 @@ static struct Account *imap_ac_find(struct Account *a, const char *path)
     return NULL;
 
   struct Url *url = url_parse(path);
+  if (!url)
+    return NULL;
 
   struct ImapAccountData *adata = a->adata;
   struct ConnAccount *cac = &adata->conn->account;

--- a/test/url/url_parse.c
+++ b/test/url/url_parse.c
@@ -23,6 +23,7 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
+#include <locale.h>
 #include "mutt/lib.h"
 #include "address/lib.h"
 #include "email/lib.h"
@@ -165,6 +166,19 @@ static struct UrlTest test[] = {
     },
     "subject|#|"
   },
+  {
+    /* UTF-8 mailbox name */
+    "imaps://foobar@gmail.com@imap.gmail.com/Отправленные письма",
+    true,
+    {
+      U_IMAPS,
+      "foobar@gmail.com",
+      NULL,
+      "imap.gmail.com",
+      0,
+      "Отправленные письма"
+    }
+  }
 };
 // clang-format on
 
@@ -205,6 +219,9 @@ void check_query_string(const char *exp, const struct UrlQueryList *act)
 
 void test_url_parse(void)
 {
+  // let's pick a utf-8 locale, since we're also parsing utf-8 text */
+  setlocale(LC_ALL, "en_US.UTF-8");
+
   // struct Url *url_parse(const char *src);
 
   {

--- a/version.c
+++ b/version.c
@@ -53,6 +53,10 @@
 #ifdef USE_SSL_GNUTLS
 #include <gnutls/gnutls.h>
 #endif
+#ifdef HAVE_PCRE2
+#define PCRE2_CODE_UNIT_WIDTH 8
+#include <pcre2.h>
+#endif
 
 /* #include "muttlib.h" */
 const char *mutt_make_version(void);
@@ -289,10 +293,16 @@ static struct CompileOptions comp_opts[] = {
 #ifdef USE_DEBUG_PARSE_TEST
   { "parse-test", 2 },
 #endif
+#ifdef HAVE_PCRE2
+  { "pcre2", 1 },
+#endif
 #ifdef CRYPT_BACKEND_CLASSIC_PGP
   { "pgp", 1 },
 #else
   { "pgp", 0 },
+#endif
+#ifndef HAVE_PCRE2
+  { "regex", 1 },
 #endif
 #ifdef USE_SASL
   { "sasl", 1 },
@@ -486,6 +496,14 @@ void print_version(FILE *fp)
 #ifdef HAVE_NOTMUCH
   fprintf(fp, "\nlibnotmuch: %d.%d.%d", LIBNOTMUCH_MAJOR_VERSION,
           LIBNOTMUCH_MINOR_VERSION, LIBNOTMUCH_MICRO_VERSION);
+#endif
+
+#ifdef HAVE_PCRE2
+  {
+    char version[24];
+    pcre2_config(PCRE2_CONFIG_VERSION, version);
+    fprintf(fp, "\nPCRE2: %s", version);
+  }
 #endif
 
 #ifdef USE_HCACHE


### PR DESCRIPTION
`[:alnum:]` doesn't match characters outside of ASCII. Let's use `\p{L}\p{N}` (letters and numbers) instead. This only matches a subset of printable characters, but should be enough for most cases (UTF-8 IMAP mailbox names).

Fixes #2283