### PR TITLE
Correctly parse escaped characters in header phrases

### DIFF
--- a/address/address.c
+++ b/address/address.c
@@ -560,8 +560,12 @@ int mutt_addrlist_parse(struct AddressList *al, const char *s)
       default:
         if ((phraselen != 0) && (phraselen < (sizeof(phrase) - 1)) && ws_pending)
           phrase[phraselen++] = ' ';
-        *s == '\\' && (phrase[phraselen++] = (s++, *s++));
-
+        if (*s == '\\')
+        {
+          s++;
+          phrase[phraselen++] = *s;
+          s++;
+        }
         s = next_token(s, phrase, &phraselen, sizeof(phrase) - 1);
         if (!s)
         {

--- a/address/address.c
+++ b/address/address.c
@@ -560,6 +560,8 @@ int mutt_addrlist_parse(struct AddressList *al, const char *s)
       default:
         if ((phraselen != 0) && (phraselen < (sizeof(phrase) - 1)) && ws_pending)
           phrase[phraselen++] = ' ';
+        *s == '\\' && (phrase[phraselen++] = (s++, *s++));
+
         s = next_token(s, phrase, &phraselen, sizeof(phrase) - 1);
         if (!s)
         {

--- a/test/address/mutt_addrlist_parse.c
+++ b/test/address/mutt_addrlist_parse.c
@@ -94,4 +94,14 @@ void test_mutt_addrlist_parse(void)
     TEST_CHECK(a == NULL);
     mutt_addrlist_clear(&alist);
   }
+
+  {
+    struct AddressList alist = TAILQ_HEAD_INITIALIZER(alist);
+    int parsed = mutt_addrlist_parse(
+        &alist, "Foo \\(Bar\\) <foo@bar.baz>");
+    TEST_CHECK(parsed == 1);
+    const struct Address *a = TAILQ_FIRST(&alist);
+    TEST_CHECK_STR_EQ("Foo (Bar)", a->personal);
+    TEST_CHECK_STR_EQ("foo@bar.baz", a->mailbox);
+  }
 }

--- a/test/address/mutt_addrlist_parse.c
+++ b/test/address/mutt_addrlist_parse.c
@@ -97,8 +97,7 @@ void test_mutt_addrlist_parse(void)
 
   {
     struct AddressList alist = TAILQ_HEAD_INITIALIZER(alist);
-    int parsed = mutt_addrlist_parse(
-        &alist, "Foo \\(Bar\\) <foo@bar.baz>");
+    int parsed = mutt_addrlist_parse(&alist, "Foo \\(Bar\\) <foo@bar.baz>");
     TEST_CHECK(parsed == 1);
     const struct Address *a = TAILQ_FIRST(&alist);
     TEST_CHECK_STR_EQ("Foo (Bar)", a->personal);


### PR DESCRIPTION
Fixes #2291