### PR TITLE
Add += and -= to a config system

### DIFF
--- a/command_parse.c
+++ b/command_parse.c
@@ -1122,7 +1122,7 @@ enum CommandResult parse_set(struct Buffer *buf, struct Buffer *s,
     }
 
     /* get the variable name */
-    mutt_extract_token(buf, s, MUTT_TOKEN_EQUAL | MUTT_TOKEN_QUESTION);
+    mutt_extract_token(buf, s, MUTT_TOKEN_EQUAL | MUTT_TOKEN_QUESTION | MUTT_TOKEN_PLUS | MUTT_TOKEN_MINUS);
 
     bool bq = false;
     bool equals = false;

--- a/command_parse.c
+++ b/command_parse.c
@@ -1126,6 +1126,8 @@ enum CommandResult parse_set(struct Buffer *buf, struct Buffer *s,
 
     bool bq = false;
     bool equals = false;
+    bool increment = false;
+    bool decrement = false;
 
     struct HashElem *he = NULL;
     bool my = mutt_str_startswith(buf->data, "my_", CASE_MATCH);
@@ -1174,6 +1176,33 @@ enum CommandResult parse_set(struct Buffer *buf, struct Buffer *s,
 
       query = true;
       s->dptr++;
+    }
+    else if (*s->dptr == '+' || *s->dptr == '-')
+    {
+      if (prefix)
+      {
+        mutt_buffer_printf(err, "ERR04 can't use prefix when incrementing or "
+                                "decrementing a variable");
+        return MUTT_CMD_WARNING;
+      }
+
+      if (reset || unset || inv)
+      {
+        mutt_buffer_printf(err, "ERR05 can't set a variable with the '%s' command",
+                           set_commands[data]);
+        return MUTT_CMD_WARNING;
+      }
+      if (*s->dptr == '+')
+        increment = true;
+      else
+        decrement = true;
+
+      s->dptr++;
+      if (*s->dptr == '=')
+      {
+        equals = true;
+        s->dptr++;
+      }
     }
     else if (*s->dptr == '=')
     {
@@ -1303,8 +1332,18 @@ enum CommandResult parse_set(struct Buffer *buf, struct Buffer *s,
             mutt_buffer_addstr(buf, mutt_b2s(&scratch));
             mutt_buffer_dealloc(&scratch);
           }
-
-          rc = cs_subset_he_string_set(NeoMutt->sub, he, buf->data, err);
+          if (increment)
+          {
+            rc = cs_subset_he_string_plus_equals(NeoMutt->sub, he, buf->data, err);
+          }
+          else if (decrement)
+          {
+            rc = cs_subset_he_string_minus_equals(NeoMutt->sub, he, buf->data, err);
+          }
+          else
+          {
+            rc = cs_subset_he_string_set(NeoMutt->sub, he, buf->data, err);
+          }
           if (CSR_RESULT(rc) != CSR_SUCCESS)
             return MUTT_CMD_ERROR;
         }

--- a/config/address.c
+++ b/config/address.c
@@ -231,8 +231,14 @@ static int address_reset(const struct ConfigSet *cs, void *var,
 void address_init(struct ConfigSet *cs)
 {
   const struct ConfigSetType cst_address = {
-    "address",          address_string_set, address_string_get,
-    address_native_set, address_native_get, address_reset,
+    "address",
+    address_string_set,
+    address_string_get,
+    address_native_set,
+    address_native_get,
+    NULL, // string_plus_equals
+    NULL, // string_minus_equals
+    address_reset,
     address_destroy,
   };
   cs_register_type(cs, DT_ADDRESS, &cst_address);

--- a/config/bool.c
+++ b/config/bool.c
@@ -183,8 +183,10 @@ void bool_init(struct ConfigSet *cs)
     bool_string_get,
     bool_native_set,
     bool_native_get,
+    NULL, // string_plus_equals
+    NULL, // string_minus_equals
     bool_reset,
-    NULL,
+    NULL, // destroy
   };
   cs_register_type(cs, DT_BOOL, &cst_bool);
 }

--- a/config/enum.c
+++ b/config/enum.c
@@ -223,8 +223,10 @@ void enum_init(struct ConfigSet *cs)
     enum_string_get,
     enum_native_set,
     enum_native_get,
+    NULL, // string_plus_equals
+    NULL, // string_minus_equals
     enum_reset,
-    NULL,
+    NULL, // destroy
   };
   cs_register_type(cs, DT_ENUM, &cst_enum);
 }

--- a/config/long.c
+++ b/config/long.c
@@ -169,8 +169,10 @@ void long_init(struct ConfigSet *cs)
     long_string_get,
     long_native_set,
     long_native_get,
+    NULL, // string_plus_equals
+    NULL, // string_minus_equals
     long_reset,
-    NULL,
+    NULL, // destroy
   };
   cs_register_type(cs, DT_LONG, &cst_long);
 }

--- a/config/long.c
+++ b/config/long.c
@@ -41,10 +41,16 @@
 static int long_string_set(const struct ConfigSet *cs, void *var, struct ConfigDef *cdef,
                            const char *value, struct Buffer *err)
 {
-  long num = 0;
-  if (!value || (value[0] == '\0') || (mutt_str_atol(value, &num) < 0))
+  if (!value || !value[0])
   {
-    mutt_buffer_printf(err, _("Invalid long: %s"), NONULL(value));
+    mutt_buffer_printf(err, _("Option %s may not be empty"), cdef->name);
+    return CSR_ERR_INVALID | CSR_INV_TYPE;
+  }
+
+  long num = 0;
+  if (mutt_str_atol(value, &num) < 0)
+  {
+    mutt_buffer_printf(err, _("Invalid long: %s"), value);
     return CSR_ERR_INVALID | CSR_INV_TYPE;
   }
 

--- a/config/mbtable.c
+++ b/config/mbtable.c
@@ -276,8 +276,14 @@ static int mbtable_reset(const struct ConfigSet *cs, void *var,
 void mbtable_init(struct ConfigSet *cs)
 {
   const struct ConfigSetType cst_mbtable = {
-    "mbtable",          mbtable_string_set, mbtable_string_get,
-    mbtable_native_set, mbtable_native_get, mbtable_reset,
+    "mbtable",
+    mbtable_string_set,
+    mbtable_string_get,
+    mbtable_native_set,
+    mbtable_native_get,
+    NULL, // string_plus_equals
+    NULL, // string_minus_equals
+    mbtable_reset,
     mbtable_destroy,
   };
   cs_register_type(cs, DT_MBTABLE, &cst_mbtable);

--- a/config/number.c
+++ b/config/number.c
@@ -182,8 +182,10 @@ void number_init(struct ConfigSet *cs)
     number_string_get,
     number_native_set,
     number_native_get,
+    NULL, // string_plus_equals
+    NULL, // string_minus_equals
     number_reset,
-    NULL,
+    NULL, // destroy
   };
   cs_register_type(cs, DT_NUMBER, &cst_number);
 }

--- a/config/path.c
+++ b/config/path.c
@@ -243,8 +243,15 @@ static int path_reset(const struct ConfigSet *cs, void *var,
 void path_init(struct ConfigSet *cs)
 {
   const struct ConfigSetType cst_path = {
-    "path",          path_string_set, path_string_get, path_native_set,
-    path_native_get, path_reset,      path_destroy,
+    "path",
+    path_string_set,
+    path_string_get,
+    path_native_set,
+    path_native_get,
+    NULL, // string_plus_equals
+    NULL, // string_minus_equals
+    path_reset,
+    path_destroy,
   };
   cs_register_type(cs, DT_PATH, &cst_path);
 }

--- a/config/quad.c
+++ b/config/quad.c
@@ -185,8 +185,10 @@ void quad_init(struct ConfigSet *cs)
     quad_string_get,
     quad_native_set,
     quad_native_get,
+    NULL, // string_plus_equals
+    NULL, // string_minus_equals
     quad_reset,
-    NULL,
+    NULL, // destroy
   };
   cs_register_type(cs, DT_QUAD, &cst_quad);
 }

--- a/config/regex.c
+++ b/config/regex.c
@@ -297,8 +297,15 @@ static int regex_reset(const struct ConfigSet *cs, void *var,
 void regex_init(struct ConfigSet *cs)
 {
   const struct ConfigSetType cst_regex = {
-    "regex",          regex_string_set, regex_string_get, regex_native_set,
-    regex_native_get, regex_reset,      regex_destroy,
+    "regex",
+    regex_string_set,
+    regex_string_get,
+    regex_native_set,
+    regex_native_get,
+    NULL, // string_plus_equals
+    NULL, // string_minus_equals
+    regex_reset,
+    regex_destroy,
   };
   cs_register_type(cs, DT_REGEX, &cst_regex);
 }

--- a/config/set.h
+++ b/config/set.h
@@ -242,20 +242,24 @@ bool             cs_register_variables(const struct ConfigSet *cs, struct Config
 struct HashElem *cs_inherit_variable  (const struct ConfigSet *cs, struct HashElem *parent, const char *name);
 void             cs_uninherit_variable(const struct ConfigSet *cs, const char *name);
 
-int      cs_he_initial_get (const struct ConfigSet *cs, struct HashElem *he,                    struct Buffer *result);
-int      cs_he_initial_set (const struct ConfigSet *cs, struct HashElem *he, const char *value, struct Buffer *err);
-intptr_t cs_he_native_get  (const struct ConfigSet *cs, struct HashElem *he,                    struct Buffer *err);
-int      cs_he_native_set  (const struct ConfigSet *cs, struct HashElem *he, intptr_t value,    struct Buffer *err);
-int      cs_he_reset       (const struct ConfigSet *cs, struct HashElem *he,                    struct Buffer *err);
-int      cs_he_string_get  (const struct ConfigSet *cs, struct HashElem *he,                    struct Buffer *result);
-int      cs_he_string_set  (const struct ConfigSet *cs, struct HashElem *he, const char *value, struct Buffer *err);
+int      cs_he_initial_get         (const struct ConfigSet *cs, struct HashElem *he,                    struct Buffer *result);
+int      cs_he_initial_set         (const struct ConfigSet *cs, struct HashElem *he, const char *value, struct Buffer *err);
+intptr_t cs_he_native_get          (const struct ConfigSet *cs, struct HashElem *he,                    struct Buffer *err);
+int      cs_he_native_set          (const struct ConfigSet *cs, struct HashElem *he, intptr_t value,    struct Buffer *err);
+int      cs_he_reset               (const struct ConfigSet *cs, struct HashElem *he,                    struct Buffer *err);
+int      cs_he_string_get          (const struct ConfigSet *cs, struct HashElem *he,                    struct Buffer *result);
+int      cs_he_string_minus_equals (const struct ConfigSet *cs, struct HashElem *he, const char *value, struct Buffer *err);
+int      cs_he_string_plus_equals  (const struct ConfigSet *cs, struct HashElem *he, const char *value, struct Buffer *err);
+int      cs_he_string_set          (const struct ConfigSet *cs, struct HashElem *he, const char *value, struct Buffer *err);
 
-int      cs_str_initial_get(const struct ConfigSet *cs, const char *name,                       struct Buffer *result);
-int      cs_str_initial_set(const struct ConfigSet *cs, const char *name,    const char *value, struct Buffer *err);
-intptr_t cs_str_native_get (const struct ConfigSet *cs, const char *name,                       struct Buffer *err);
-int      cs_str_native_set (const struct ConfigSet *cs, const char *name,    intptr_t value,    struct Buffer *err);
-int      cs_str_reset      (const struct ConfigSet *cs, const char *name,                       struct Buffer *err);
-int      cs_str_string_get (const struct ConfigSet *cs, const char *name,                       struct Buffer *result);
-int      cs_str_string_set (const struct ConfigSet *cs, const char *name,    const char *value, struct Buffer *err);
+int      cs_str_initial_get        (const struct ConfigSet *cs, const char *name,                       struct Buffer *result);
+int      cs_str_initial_set        (const struct ConfigSet *cs, const char *name,    const char *value, struct Buffer *err);
+intptr_t cs_str_native_get         (const struct ConfigSet *cs, const char *name,                       struct Buffer *err);
+int      cs_str_native_set         (const struct ConfigSet *cs, const char *name,    intptr_t value,    struct Buffer *err);
+int      cs_str_reset              (const struct ConfigSet *cs, const char *name,                       struct Buffer *err);
+int      cs_str_string_get         (const struct ConfigSet *cs, const char *name,                       struct Buffer *result);
+int      cs_str_string_minus_equals(const struct ConfigSet *cs, const char *name,    const char *value, struct Buffer *err);
+int      cs_str_string_plus_equals (const struct ConfigSet *cs, const char *name,    const char *value, struct Buffer *err);
+int      cs_str_string_set         (const struct ConfigSet *cs, const char *name,    const char *value, struct Buffer *err);
 
 #endif /* MUTT_CONFIG_SET_H */

--- a/config/set.h
+++ b/config/set.h
@@ -46,6 +46,7 @@ struct HashElem;
 /* Flags for CSR_INVALID */
 #define CSR_INV_TYPE      (1 << 4) ///< Value is not valid for the type
 #define CSR_INV_VALIDATOR (1 << 5) ///< Value was rejected by the validator
+#define CSV_INV_NOT_IMPL  (1 << 6) ///< Operation not permitted for the type
 
 #define CSR_RESULT_MASK 0x0F
 #define CSR_RESULT(x) ((x) & CSR_RESULT_MASK)
@@ -153,6 +154,38 @@ struct ConfigSetType
    * - @a cdef is not NULL
    */
   intptr_t (*native_get)(const struct ConfigSet *cs, void *var, const struct ConfigDef *cdef, struct Buffer *err);
+
+  /**
+   * string_plus_equals - Add to a config item by string
+   * @param cs    Config items
+   * @param var   Variable to set
+   * @param cdef  Variable definition
+   * @param value Value to set
+   * @param err   Buffer for error messages (may be NULL)
+   * @retval num Result, e.g. #CSR_SUCCESS
+   *
+   * **Contract**
+   * - @a cs   is not NULL
+   * - @a var  is not NULL
+   * - @a cdef is not NULL
+   */
+  int (*string_plus_equals)(const struct ConfigSet *cs, void *var, const struct ConfigDef *cdef, const char *value, struct Buffer *err);
+
+  /**
+   * string_minus_equals - Remove from a config item as a string
+   * @param cs    Config items
+   * @param var   Variable to set
+   * @param cdef  Variable definition
+   * @param value Value to set
+   * @param err   Buffer for error messages (may be NULL)
+   * @retval num Result, e.g. #CSR_SUCCESS
+   *
+   * **Contract**
+   * - @a cs   is not NULL
+   * - @a var  is not NULL
+   * - @a cdef is not NULL
+   */
+  int (*string_minus_equals)(const struct ConfigSet *cs, void *var, const struct ConfigDef *cdef, const char *value, struct Buffer *err);
 
   /**
    * reset - Reset a config item to its initial value

--- a/config/slist.c
+++ b/config/slist.c
@@ -267,8 +267,15 @@ static int slist_reset(const struct ConfigSet *cs, void *var,
 void slist_init(struct ConfigSet *cs)
 {
   const struct ConfigSetType cst_slist = {
-    "slist",          slist_string_set, slist_string_get, slist_native_set,
-    slist_native_get, slist_reset,      slist_destroy,
+    "slist",
+    slist_string_set,
+    slist_string_get,
+    slist_native_set,
+    slist_native_get,
+    NULL, // string_plus_equals
+    NULL, // string_minus_equals
+    slist_reset,
+    slist_destroy,
   };
   cs_register_type(cs, DT_SLIST, &cst_slist);
 }

--- a/config/sort.c
+++ b/config/sort.c
@@ -371,8 +371,10 @@ void sort_init(struct ConfigSet *cs)
     sort_string_get,
     sort_native_set,
     sort_native_get,
+    NULL, // string_plus_equals
+    NULL, // string_minus_equals
     sort_reset,
-    NULL,
+    NULL, // destroy
   };
   cs_register_type(cs, DT_SORT, &cst_sort);
 }

--- a/config/string.c
+++ b/config/string.c
@@ -222,8 +222,15 @@ static int string_reset(const struct ConfigSet *cs, void *var,
 void string_init(struct ConfigSet *cs)
 {
   const struct ConfigSetType cst_string = {
-    "string",          string_string_set, string_string_get, string_native_set,
-    string_native_get, string_reset,      string_destroy,
+    "string",
+    string_string_set,
+    string_string_get,
+    string_native_set,
+    string_native_get,
+    NULL, // string_plus_equals
+    NULL, // string_minus_equals
+    string_reset,
+    string_destroy,
   };
   cs_register_type(cs, DT_STRING, &cst_string);
 }

--- a/config/subset.c
+++ b/config/subset.c
@@ -399,3 +399,79 @@ int cs_subset_str_string_set(const struct ConfigSubset *sub, const char *name,
 
   return cs_subset_he_string_set(sub, he, value, err);
 }
+
+/**
+ * cs_subset_he_string_plus_equals - Add to a config item by string
+ * @param sub   Config Subset
+ * @param he    HashElem representing config item
+ * @param value Value to set
+ * @param err   Buffer for error messages
+ * @retval num Result, e.g. #CSR_SUCCESS
+ */
+int cs_subset_he_string_plus_equals(const struct ConfigSubset *sub, struct HashElem *he,
+                                    const char *value, struct Buffer *err)
+{
+  if (!sub)
+    return CSR_ERR_CODE;
+
+  int rc = cs_he_string_plus_equals(sub->cs, he, value, err);
+
+  if ((CSR_RESULT(rc) == CSR_SUCCESS) && !(rc & CSR_SUC_NO_CHANGE))
+    cs_subset_notify_observers(sub, he, NT_CONFIG_SET);
+
+  return rc;
+}
+
+/**
+ * cs_subset_str_string_plus_equals - Add to a config item by string
+ * @param sub   Config Subset
+ * @param name  Name of config item
+ * @param value Value to set
+ * @param err   Buffer for error messages
+ * @retval num Result, e.g. #CSR_SUCCESS
+ */
+int cs_subset_str_string_plus_equals(const struct ConfigSubset *sub, const char *name,
+                                     const char *value, struct Buffer *err)
+{
+  struct HashElem *he = cs_subset_create_inheritance(sub, name);
+
+  return cs_subset_he_string_plus_equals(sub, he, value, err);
+}
+
+/**
+ * cs_subset_he_string_minus_equals - Remove from a config item by string
+ * @param sub   Config Subset
+ * @param he    HashElem representing config item
+ * @param value Value to set
+ * @param err   Buffer for error messages
+ * @retval num Result, e.g. #CSR_SUCCESS
+ */
+int cs_subset_he_string_minus_equals(const struct ConfigSubset *sub, struct HashElem *he,
+                                     const char *value, struct Buffer *err)
+{
+  if (!sub)
+    return CSR_ERR_CODE;
+
+  int rc = cs_he_string_minus_equals(sub->cs, he, value, err);
+
+  if ((CSR_RESULT(rc) == CSR_SUCCESS) && !(rc & CSR_SUC_NO_CHANGE))
+    cs_subset_notify_observers(sub, he, NT_CONFIG_SET);
+
+  return rc;
+}
+
+/**
+ * cs_subset_str_string_minus_equals - Remove from a config item by string
+ * @param sub   Config Subset
+ * @param name  Name of config item
+ * @param value Value to set
+ * @param err   Buffer for error messages
+ * @retval num Result, e.g. #CSR_SUCCESS
+ */
+int cs_subset_str_string_minus_equals(const struct ConfigSubset *sub, const char *name,
+                                      const char *value, struct Buffer *err)
+{
+  struct HashElem *he = cs_subset_create_inheritance(sub, name);
+
+  return cs_subset_he_string_minus_equals(sub, he, value, err);
+}

--- a/config/subset.h
+++ b/config/subset.h
@@ -81,17 +81,21 @@ struct HashElem *cs_subset_create_inheritance(const struct ConfigSubset *sub, co
 struct HashElem *cs_subset_lookup            (const struct ConfigSubset *sub, const char *name);
 void             cs_subset_notify_observers  (const struct ConfigSubset *sub, struct HashElem *he, enum NotifyConfig ev);
 
-intptr_t cs_subset_he_native_get(const struct ConfigSubset *sub, struct HashElem *he,                    struct Buffer *err);
-int      cs_subset_he_native_set(const struct ConfigSubset *sub, struct HashElem *he, intptr_t value,    struct Buffer *err);
-int      cs_subset_he_reset     (const struct ConfigSubset *sub, struct HashElem *he,                    struct Buffer *err);
-int      cs_subset_he_string_get(const struct ConfigSubset *sub, struct HashElem *he,                    struct Buffer *result);
-int      cs_subset_he_string_set(const struct ConfigSubset *sub, struct HashElem *he, const char *value, struct Buffer *err);
+intptr_t cs_subset_he_native_get          (const struct ConfigSubset *sub, struct HashElem *he,                    struct Buffer *err);
+int      cs_subset_he_native_set          (const struct ConfigSubset *sub, struct HashElem *he, intptr_t value,    struct Buffer *err);
+int      cs_subset_he_reset               (const struct ConfigSubset *sub, struct HashElem *he,                    struct Buffer *err);
+int      cs_subset_he_string_get          (const struct ConfigSubset *sub, struct HashElem *he,                    struct Buffer *result);
+int      cs_subset_he_string_minus_equals (const struct ConfigSubset *sub, struct HashElem *he, const char *value, struct Buffer *err);
+int      cs_subset_he_string_plus_equals  (const struct ConfigSubset *sub, struct HashElem *he, const char *value, struct Buffer *err);
+int      cs_subset_he_string_set          (const struct ConfigSubset *sub, struct HashElem *he, const char *value, struct Buffer *err);
 
-intptr_t cs_subset_str_native_get(const struct ConfigSubset *sub, const char *name,                    struct Buffer *err);
-int      cs_subset_str_native_set(const struct ConfigSubset *sub, const char *name, intptr_t value,    struct Buffer *err);
-int      cs_subset_str_reset     (const struct ConfigSubset *sub, const char *name,                    struct Buffer *err);
-int      cs_subset_str_string_get(const struct ConfigSubset *sub, const char *name,                    struct Buffer *result);
-int      cs_subset_str_string_set(const struct ConfigSubset *sub, const char *name, const char *value, struct Buffer *err);
+intptr_t cs_subset_str_native_get         (const struct ConfigSubset *sub, const char *name,                       struct Buffer *err);
+int      cs_subset_str_native_set         (const struct ConfigSubset *sub, const char *name,    intptr_t value,    struct Buffer *err);
+int      cs_subset_str_reset              (const struct ConfigSubset *sub, const char *name,                       struct Buffer *err);
+int      cs_subset_str_string_get         (const struct ConfigSubset *sub, const char *name,                       struct Buffer *result);
+int      cs_subset_str_string_minus_equals(const struct ConfigSubset *sub, const char *name,    const char *value, struct Buffer *err);
+int      cs_subset_str_string_plus_equals (const struct ConfigSubset *sub, const char *name,    const char *value, struct Buffer *err);
+int      cs_subset_str_string_set         (const struct ConfigSubset *sub, const char *name,    const char *value, struct Buffer *err);
 
 int               elem_list_sort(const void *a, const void *b);
 struct HashElem **get_elem_list(struct ConfigSet *cs);

--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -6725,8 +6725,18 @@ set spam_separator=", "
               </group>
               <replaceable class="parameter">variable</replaceable>
             </arg>
+          </group>
+          <arg choice="opt" rep="repeat"></arg>
+          <command>set</command>
+          <group choice="req">
             <arg choice="plain">
               <replaceable class="parameter">variable=value</replaceable>
+            </arg>
+            <arg choice="plain">
+              <replaceable class="parameter">variable+=increment</replaceable>
+            </arg>
+            <arg choice="plain">
+              <replaceable class="parameter">variable-=decrement</replaceable>
             </arg>
           </group>
           <arg choice="opt" rep="repeat"></arg>
@@ -6759,7 +6769,9 @@ set spam_separator=", "
           quadoption. <emphasis>boolean</emphasis> variables can be
           <emphasis>set</emphasis> (true) or <emphasis>unset</emphasis>
           (false). <emphasis>number</emphasis> variables can be assigned
-          a positive integer value. <emphasis>string</emphasis> variables
+          a positive integer value. Value of number variables can be
+          incremented <emphasis>+=</emphasis> and decremented
+          <emphasis>-=</emphasis>. <emphasis>string</emphasis> variables
           consist of any number of printable characters and must be enclosed in
           quotes if they contain spaces or tabs. You may also use the escape
           sequences <quote>\n</quote> and <quote>\t</quote> for newline and

--- a/docs/neomuttrc.man.head
+++ b/docs/neomuttrc.man.head
@@ -691,7 +691,8 @@ the list of all score entries.
 .
 .PP
 .nf
-\fBset\fP { [ \fBno\fP | \fBinv\fP | \fB&\fP | \fB?\fP ]\fIvariable\fP | \fIvariable\fP=\fIvalue\fP } [ ... ]
+\fBset\fP { [ \fBno\fP | \fBinv\fP | \fB&\fP | \fB?\fP ]\fIvariable\fP } [ ... ]
+\fBset\fP { \fIvariable\fP=\fIvalue\fP | \fIvariable+=increment\fP | \fIvariable-=decrement\fP } [ ... ]
 \fBunset\fP \fIvariable\fP  [ \fIvariable\fP ... ]
 \fBreset\fP \fIvariable\fP  [ \fIvariable\fP ... ]
 \fBtoggle\fP \fIvariable\fP [ \fIvariable\fP ... ]
@@ -702,7 +703,8 @@ These commands are used to set and manipulate configuration \fIvariable\fPs.
 NeoMutt knows four basic types of \fIvariable\fPs: boolean, number, string and
 quadoption. Boolean \fIvariable\fPs can be \fBset\fP (true), \fBunset\fP
 (false), or \fBtoggle\fPd. Number \fIvariable\fPs can be assigned a positive
-integer \fIvalue\fP.
+integer \fIvalue\fP. Value of number \fIvariable\fPs can be incremented "\fB+=\fP"
+and decremented "\fB-=\fP".
 .IP
 String \fIvariable\fPs consist of any number of printable characters and must
 be enclosed in quotes if they contain spaces or tabs. You may also use the

--- a/init.c
+++ b/init.c
@@ -430,6 +430,8 @@ int mutt_extract_token(struct Buffer *dest, struct Buffer *tok, TokenFlags flags
     {
       if ((IS_SPACE(ch) && !(flags & MUTT_TOKEN_SPACE)) ||
           ((ch == '#') && !(flags & MUTT_TOKEN_COMMENT)) ||
+          ((ch == '+') && (flags & MUTT_TOKEN_PLUS)) ||
+          ((ch == '-') && (flags & MUTT_TOKEN_MINUS)) ||
           ((ch == '=') && (flags & MUTT_TOKEN_EQUAL)) ||
           ((ch == '?') && (flags & MUTT_TOKEN_QUESTION)) ||
           ((ch == ';') && !(flags & MUTT_TOKEN_SEMICOLON)) ||

--- a/mutt.h
+++ b/mutt.h
@@ -78,6 +78,8 @@ typedef uint16_t TokenFlags;               ///< Flags for mutt_extract_token(), 
 #define MUTT_TOKEN_BACKTICK_VARS (1 << 7)  ///< Expand variables within backticks
 #define MUTT_TOKEN_NOSHELL       (1 << 8)  ///< Don't expand environment variables
 #define MUTT_TOKEN_QUESTION      (1 << 9)  ///< Treat '?' as a special
+#define MUTT_TOKEN_PLUS          (1 << 10)  ///< Treat '+' as a special
+#define MUTT_TOKEN_MINUS         (1 << 11)  ///< Treat '-' as a special
 
 /**
  * enum MessageType - To set flags or match patterns

--- a/test/config/number.c
+++ b/test/config/number.c
@@ -357,6 +357,159 @@ static bool test_native_get(struct ConfigSet *cs, struct Buffer *err)
   return true;
 }
 
+static bool test_string_plus_equals(struct ConfigSet *cs, struct Buffer *err)
+{
+  log_line(__func__);
+
+  const char *valid[] = { "-123", "0", "-42", "456" };
+  int numbers[] = { -165, -42, -84, 414 };
+  const char *invalid[] = { "-33183", "111132868", "junk", "", NULL };
+  const char *name = "Damson";
+
+  int rc;
+  for (unsigned int i = 0; i < mutt_array_size(valid); i++)
+  {
+    VarDamson = -42;
+
+    TEST_MSG("Increasing %s with initial value %d by %s\n", name, VarDamson, valid[i]);
+    mutt_buffer_reset(err);
+    rc = cs_str_string_plus_equals(cs, name, valid[i], err);
+    if (!TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS))
+    {
+      TEST_MSG("%s\n", err->data);
+      return false;
+    }
+
+    if (rc & CSR_SUC_NO_CHANGE)
+    {
+      TEST_MSG("Value of %s wasn't changed\n", name);
+      continue;
+    }
+
+    if (!TEST_CHECK(VarDamson == numbers[i]))
+    {
+      TEST_MSG("Value of %s wasn't changed\n", name);
+      return false;
+    }
+    TEST_MSG("%s = %d, set by '%s'\n", name, VarDamson, valid[i]);
+    short_line();
+  }
+
+  for (unsigned int i = 0; i < mutt_array_size(invalid); i++)
+  {
+    TEST_MSG("Increasing %s with initial value %d by %s\n", name, VarDamson,
+             NONULL(invalid[i]));
+    mutt_buffer_reset(err);
+    rc = cs_str_string_plus_equals(cs, name, invalid[i], err);
+    if (TEST_CHECK(CSR_RESULT(rc) != CSR_SUCCESS))
+    {
+      TEST_MSG("Expected error: %s\n", err->data);
+    }
+    else
+    {
+      TEST_MSG("%s = %d, set by '%s'\n", name, VarDamson, invalid[i]);
+      TEST_MSG("This test should have failed\n");
+      return false;
+    }
+    short_line();
+  }
+
+  name = "Elderberry";
+  mutt_buffer_reset(err);
+  TEST_MSG("Increasing %s by %s\n", name, "-42");
+  rc = cs_str_string_plus_equals(cs, name, "-42", err);
+  if (TEST_CHECK(CSR_RESULT(rc) != CSR_SUCCESS))
+  {
+    TEST_MSG("Expected error: %s\n", err->data);
+  }
+  else
+  {
+    TEST_MSG("This test should have failed\n");
+    return false;
+  }
+
+  log_line(__func__);
+  return true;
+}
+
+static bool test_string_minus_equals(struct ConfigSet *cs, struct Buffer *err)
+{
+  log_line(__func__);
+
+  const char *valid[] = { "-123", "0", "-42", "456" };
+  int numbers[] = { 81, -42, 0, -498 };
+  const char *invalid[] = { "32271",
+                            "-1844674407370955161000005"
+                            "junk",
+                            "", NULL };
+  const char *name = "Damson";
+
+  int rc;
+  for (unsigned int i = 0; i < mutt_array_size(valid); i++)
+  {
+    VarDamson = -42;
+
+    TEST_MSG("Decreasing %s with initial value %d by %s\n", name, VarDamson, valid[i]);
+    mutt_buffer_reset(err);
+    rc = cs_str_string_minus_equals(cs, name, valid[i], err);
+    if (!TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS))
+    {
+      TEST_MSG("%s\n", err->data);
+      return false;
+    }
+
+    if (rc & CSR_SUC_NO_CHANGE)
+    {
+      TEST_MSG("Value of %s wasn't changed\n", name);
+      continue;
+    }
+
+    if (!TEST_CHECK(VarDamson == numbers[i]))
+    {
+      TEST_MSG("Value of %s wasn't changed\n", name);
+      return false;
+    }
+    TEST_MSG("%s = %d, set by '%s'\n", name, VarDamson, valid[i]);
+    short_line();
+  }
+
+  for (unsigned int i = 0; i < mutt_array_size(invalid); i++)
+  {
+    TEST_MSG("Decreasing %s with initial value %d by %s\n", name, VarDamson,
+             NONULL(invalid[i]));
+    mutt_buffer_reset(err);
+    rc = cs_str_string_minus_equals(cs, name, invalid[i], err);
+    if (TEST_CHECK(CSR_RESULT(rc) != CSR_SUCCESS))
+    {
+      TEST_MSG("Expected error: %s\n", err->data);
+    }
+    else
+    {
+      TEST_MSG("%s = %d, decreased by '%s'\n", name, VarDamson, invalid[i]);
+      TEST_MSG("This test should have failed\n");
+      return false;
+    }
+    short_line();
+  }
+
+  name = "Elderberry";
+  mutt_buffer_reset(err);
+  TEST_MSG("Increasing %s by %s\n", name, "42");
+  rc = cs_str_string_minus_equals(cs, name, "42", err);
+  if (TEST_CHECK(CSR_RESULT(rc) != CSR_SUCCESS))
+  {
+    TEST_MSG("Expected error: %s\n", err->data);
+  }
+  else
+  {
+    TEST_MSG("This test should have failed\n");
+    return false;
+  }
+
+  log_line(__func__);
+  return true;
+}
+
 static bool test_reset(struct ConfigSet *cs, struct Buffer *err)
 {
   log_line(__func__);
@@ -451,6 +604,38 @@ static bool test_validator(struct ConfigSet *cs, struct Buffer *err)
   TEST_MSG("Native: %s = %d\n", name, VarLemon);
   short_line();
 
+  VarLemon = 456;
+  mutt_buffer_reset(err);
+  rc = cs_str_string_plus_equals(cs, name, "123", err);
+  if (TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS))
+  {
+    TEST_MSG("%s\n", err->data);
+  }
+  else
+  {
+    TEST_MSG("%s\n", err->data);
+    return false;
+  }
+  TEST_CHECK(VarLemon == 579);
+  TEST_MSG("PlusEquals: %s = %d\n", name, VarLemon);
+  short_line();
+
+  VarLemon = 456;
+  mutt_buffer_reset(err);
+  rc = cs_str_string_minus_equals(cs, name, "123", err);
+  if (TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS))
+  {
+    TEST_MSG("%s\n", err->data);
+  }
+  else
+  {
+    TEST_MSG("%s\n", err->data);
+    return false;
+  }
+  TEST_CHECK(VarLemon == 333);
+  TEST_MSG("MinusEquals: %s = %d\n", name, VarLemon);
+  short_line();
+
   name = "Mango";
   VarMango = 123;
   mutt_buffer_reset(err);
@@ -527,6 +712,38 @@ static bool test_validator(struct ConfigSet *cs, struct Buffer *err)
     return false;
   }
   TEST_MSG("Native: %s = %d\n", name, VarNectarine);
+  short_line();
+
+  VarNectarine = 456;
+  mutt_buffer_reset(err);
+  rc = cs_str_string_plus_equals(cs, name, "123", err);
+  if (TEST_CHECK(CSR_RESULT(rc) != CSR_SUCCESS))
+  {
+    TEST_MSG("Expected error: %s\n", err->data);
+  }
+  else
+  {
+    TEST_MSG("%s\n", err->data);
+    return false;
+  }
+  TEST_CHECK(VarNectarine == 456);
+  TEST_MSG("PlusEquals: %s = %d\n", name, VarNectarine);
+  short_line();
+
+  VarNectarine = 456;
+  mutt_buffer_reset(err);
+  rc = cs_str_string_minus_equals(cs, name, "123", err);
+  if (TEST_CHECK(CSR_RESULT(rc) != CSR_SUCCESS))
+  {
+    TEST_MSG("Expected error: %s\n", err->data);
+  }
+  else
+  {
+    TEST_MSG("%s\n", err->data);
+    return false;
+  }
+  TEST_CHECK(VarNectarine == 456);
+  TEST_MSG("MinusEquals: %s = %d\n", name, VarNectarine);
 
   log_line(__func__);
   return true;
@@ -605,6 +822,53 @@ static bool test_inherit(struct ConfigSet *cs, struct Buffer *err)
     goto ti_out;
   }
   dump_native(cs, parent, child);
+  short_line();
+
+  // plus_equals parent
+  VarOlive = 123;
+  mutt_buffer_reset(err);
+  rc = cs_str_string_plus_equals(cs, parent, "456", err);
+  if (!TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS))
+  {
+    TEST_MSG("Error: %s\n", err->data);
+    goto ti_out;
+  }
+  dump_native(cs, parent, child);
+  short_line();
+
+  // plus_equals child
+  mutt_buffer_reset(err);
+  rc = cs_str_string_plus_equals(cs, child, "-99", err);
+  if (!TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS))
+  {
+    TEST_MSG("Error: %s\n", err->data);
+    goto ti_out;
+  }
+  dump_native(cs, parent, child);
+  short_line();
+
+  // minus_equals parent
+  VarOlive = 123;
+  mutt_buffer_reset(err);
+  rc = cs_str_string_minus_equals(cs, parent, "456", err);
+  if (!TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS))
+  {
+    TEST_MSG("Error: %s\n", err->data);
+    goto ti_out;
+  }
+  dump_native(cs, parent, child);
+  short_line();
+
+  // minus_equals child
+  mutt_buffer_reset(err);
+  rc = cs_str_string_minus_equals(cs, child, "-99", err);
+  if (!TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS))
+  {
+    TEST_MSG("Error: %s\n", err->data);
+    goto ti_out;
+  }
+  dump_native(cs, parent, child);
+  short_line();
 
   log_line(__func__);
   result = true;
@@ -638,6 +902,8 @@ void test_config_number(void)
   TEST_CHECK(test_initial_values(cs, &err));
   TEST_CHECK(test_string_set(cs, &err));
   TEST_CHECK(test_string_get(cs, &err));
+  TEST_CHECK(test_string_plus_equals(cs, &err));
+  TEST_CHECK(test_string_minus_equals(cs, &err));
   TEST_CHECK(test_native_set(cs, &err));
   TEST_CHECK(test_native_get(cs, &err));
   TEST_CHECK(test_reset(cs, &err));

--- a/test/config/set.c
+++ b/test/config/set.c
@@ -67,6 +67,18 @@ static intptr_t dummy_native_get(const struct ConfigSet *cs, void *var,
   return INT_MIN;
 }
 
+int dummy_plus_equals(const struct ConfigSet *cs, void *var, const struct ConfigDef *cdef,
+                      const char *value, struct Buffer *err)
+{
+  return CSR_ERR_CODE;
+}
+
+int dummy_minus_equals(const struct ConfigSet *cs, void *var, const struct ConfigDef *cdef,
+                       const char *value, struct Buffer *err)
+{
+  return CSR_ERR_CODE;
+}
+
 static int dummy_reset(const struct ConfigSet *cs, void *var,
                        const struct ConfigDef *cdef, struct Buffer *err)
 {
@@ -237,8 +249,9 @@ void test_config_set(void)
   }
 
   const struct ConfigSetType cst_dummy2 = {
-    "dummy2",         dummy_string_set, dummy_string_get, dummy_native_set,
-    dummy_native_get, dummy_reset,      dummy_destroy,
+    "dummy2",           dummy_string_set, dummy_string_get,
+    dummy_native_set,   dummy_native_get, dummy_plus_equals,
+    dummy_minus_equals, dummy_reset,      dummy_destroy,
   };
 
   if (TEST_CHECK(!cs_register_type(cs, 25, &cst_dummy2)))

--- a/test/config/set.c
+++ b/test/config/set.c
@@ -175,6 +175,22 @@ bool degenerate_tests(struct ConfigSet *cs)
     return false;
   if (!TEST_CHECK(cs_str_string_set(cs, NULL, "42", NULL) != CSR_SUCCESS))
     return false;
+  if (!TEST_CHECK(cs_he_string_plus_equals(NULL, he, "42", NULL) != CSR_SUCCESS))
+    return false;
+  if (!TEST_CHECK(cs_he_string_plus_equals(cs, NULL, "42", NULL) != CSR_SUCCESS))
+    return false;
+  if (!TEST_CHECK(cs_str_string_plus_equals(NULL, "apple", "42", NULL) != CSR_SUCCESS))
+    return false;
+  if (!TEST_CHECK(cs_str_string_plus_equals(cs, NULL, "42", NULL) != CSR_SUCCESS))
+    return false;
+  if (!TEST_CHECK(cs_he_string_minus_equals(NULL, he, "42", NULL) != CSR_SUCCESS))
+    return false;
+  if (!TEST_CHECK(cs_he_string_minus_equals(cs, NULL, "42", NULL) != CSR_SUCCESS))
+    return false;
+  if (!TEST_CHECK(cs_str_string_minus_equals(NULL, "apple", "42", NULL) != CSR_SUCCESS))
+    return false;
+  if (!TEST_CHECK(cs_str_string_minus_equals(cs, NULL, "42", NULL) != CSR_SUCCESS))
+    return false;
   if (!TEST_CHECK(cs_he_string_get(NULL, he, NULL) != CSR_SUCCESS))
     return false;
   if (!TEST_CHECK(cs_he_string_get(cs, NULL, NULL) != CSR_SUCCESS))
@@ -198,8 +214,16 @@ bool degenerate_tests(struct ConfigSet *cs)
 bool invalid_tests(struct ConfigSet *cs)
 {
   struct HashElem *he = cs_get_elem(cs, "Banana");
+
+  // Boolean doesn't support +=/-=
+  if (!TEST_CHECK(cs_he_string_plus_equals(cs, he, "42", NULL) != CSR_SUCCESS))
+    return false;
+  if (!TEST_CHECK(cs_he_string_minus_equals(cs, he, "42", NULL) != CSR_SUCCESS))
+    return false;
+
   he->type = 30;
 
+  // Unknown type
   if (!TEST_CHECK(cs_he_initial_set(cs, he, "42", NULL) != CSR_SUCCESS))
     return false;
   if (!TEST_CHECK(cs_he_initial_get(cs, he, NULL) != CSR_SUCCESS))
@@ -213,6 +237,10 @@ bool invalid_tests(struct ConfigSet *cs)
   if (!TEST_CHECK(cs_he_native_get(cs, he, NULL) != CSR_SUCCESS))
     return false;
   if (!TEST_CHECK(cs_str_native_set(cs, "apple", 42, NULL) != CSR_SUCCESS))
+    return false;
+  if (!TEST_CHECK(cs_he_string_plus_equals(cs, he, "42", NULL) != CSR_SUCCESS))
+    return false;
+  if (!TEST_CHECK(cs_he_string_minus_equals(cs, he, "42", NULL) != CSR_SUCCESS))
     return false;
 
   return true;
@@ -285,6 +313,28 @@ void test_config_set(void)
 
   const char *name = "Unknown";
   int result = cs_str_string_set(cs, name, "hello", &err);
+  if (TEST_CHECK(CSR_RESULT(result) == CSR_ERR_UNKNOWN))
+  {
+    TEST_MSG("Expected error: Unknown var '%s'\n", name);
+  }
+  else
+  {
+    TEST_MSG("This should have failed 1\n");
+    return;
+  }
+
+  result = cs_str_string_plus_equals(cs, name, "42", &err);
+  if (TEST_CHECK(CSR_RESULT(result) == CSR_ERR_UNKNOWN))
+  {
+    TEST_MSG("Expected error: Unknown var '%s'\n", name);
+  }
+  else
+  {
+    TEST_MSG("This should have failed 1\n");
+    return;
+  }
+
+  result = cs_str_string_minus_equals(cs, name, "42", &err);
   if (TEST_CHECK(CSR_RESULT(result) == CSR_ERR_UNKNOWN))
   {
     TEST_MSG("Expected error: Unknown var '%s'\n", name);

--- a/test/config/subset.c
+++ b/test/config/subset.c
@@ -195,6 +195,60 @@ void test_config_subset(void)
   }
 
   mutt_buffer_reset(&err);
+  expected = "142";
+  rc = cs_subset_he_string_plus_equals(NULL, NULL, expected, &err);
+  if (!TEST_CHECK(CSR_RESULT(rc) != CSR_SUCCESS))
+  {
+    TEST_MSG("This test should have failed\n");
+    return;
+  }
+
+  mutt_buffer_reset(&err);
+  expected = "678";
+  rc = cs_subset_he_string_plus_equals(NeoMutt->sub, he, expected, &err);
+  if (!TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS))
+  {
+    TEST_MSG("cs_subset_he_string_plus_equals failed\n");
+    return;
+  }
+
+  mutt_buffer_reset(&err);
+  expected = "678";
+  rc = cs_subset_str_string_plus_equals(NeoMutt->sub, name, expected, &err);
+  if (!TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS))
+  {
+    TEST_MSG("cs_subset_str_string_plus_equals failed\n");
+    return;
+  }
+
+  mutt_buffer_reset(&err);
+  expected = "142";
+  rc = cs_subset_he_string_minus_equals(NULL, NULL, expected, &err);
+  if (!TEST_CHECK(CSR_RESULT(rc) != CSR_SUCCESS))
+  {
+    TEST_MSG("This test should have failed\n");
+    return;
+  }
+
+  mutt_buffer_reset(&err);
+  expected = "678";
+  rc = cs_subset_he_string_minus_equals(NeoMutt->sub, he, expected, &err);
+  if (!TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS))
+  {
+    TEST_MSG("cs_subset_he_string_minus_equals failed\n");
+    return;
+  }
+
+  mutt_buffer_reset(&err);
+  expected = "678";
+  rc = cs_subset_str_string_minus_equals(NeoMutt->sub, name, expected, &err);
+  if (!TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS))
+  {
+    TEST_MSG("cs_subset_str_string_minus_equals failed\n");
+    return;
+  }
+
+  mutt_buffer_reset(&err);
   rc = cs_subset_he_reset(NULL, NULL, &err);
   if (!TEST_CHECK(CSR_RESULT(rc) != CSR_SUCCESS))
   {


### PR DESCRIPTION
* **What does this PR do?**
Implements **+=** and **-=** operators to the config system.

- WIP in command_parse.c
- need to separate the addition substraction logic to a separate functions.

Remaining tasks:
```
flatcap | jindraj: [devel/config-increments]  It works!  Yeah!  So the next step is to
          add plus_equals() minus_equals() to the ConfigSetType
flatcap | you'll need some glue functions in config/set.c and config/subset.c
flatcap | then you can change parse_set() to allow/disallow +=,-= based on the support
          (and get them to do the work)
```

**To do**:

- [x] copy code to long
- [x] prevent non-numeric types crashing
- [x] allow `set config+=10` with no spaces
- [x] documentation
- [x] tests
    - [x] positive numbers
    - [x] negative numbers
    - [x] overflow
    - [x] underflow
    - [x] junk (non-numbers)
    - [x] empty

#243 + #2236 (dup)
