### PR TITLE
imap: use the connection delimiter if provided

### DIFF
--- a/mutt_config.c
+++ b/mutt_config.c
@@ -1666,9 +1666,9 @@ struct ConfigDef MuttVars[] = {
   { "imap_delim_chars", DT_STRING, &C_ImapDelimChars, IP "/." },
   /*
   ** .pp
-  ** This contains the list of characters which you would like to treat
-  ** as folder separators for displaying IMAP paths. In particular it
-  ** helps in using the "=" shortcut for your \fIfolder\fP variable.
+  ** This contains the list of characters that NeoMutt will use as folder
+  ** separators for IMAP paths, when no separator is provided on the IMAP
+  ** connection.
   */
   { "imap_fetch_chunk_size", DT_LONG|DT_NOT_NEGATIVE, &C_ImapFetchChunkSize, 0 },
   /*


### PR DESCRIPTION
This changes how imap_fix_path understands a delimiter in an IMAP path.
Previously, the first occurrence of any of the characters in
C_ImapDelimChars was taken to be the delimiter for the path. Now, the
server-provided delimiter - if any - always takes precedence.

This makes C_ImapDelimChars a mere fallback.

Fixes #2110
