### PR TITLE
fix(sidebar): use abbreviated path if possible

### DIFF
--- a/sidebar.c
+++ b/sidebar.c
@@ -1091,9 +1091,10 @@ static void draw_sidebar(struct MuttWindow *win, int num_rows, int num_cols, int
       m->msg_flagged = Context->mailbox->msg_flagged;
     }
 
+    const char *full_path = mailbox_path(m);
     display = m->name;
     if (!display)
-      display = mailbox_path(m);
+      display = full_path;
 
     const char *abbr = m->name;
     if (!abbr)
@@ -1113,7 +1114,9 @@ static void draw_sidebar(struct MuttWindow *win, int num_rows, int num_cols, int
 
     mutt_buffer_reset(&result);
 
-    if (C_SidebarFolderIndent)
+    // Don't indent if we were unable to create an abbreviation.
+    // Otherwise, the full path will be indent, and it looks unusual.
+    if (C_SidebarFolderIndent && mutt_str_strncmp(display, full_path, sizeof(display)))
     {
       if (C_SidebarComponentDepth > 0)
         depth -= C_SidebarComponentDepth;

--- a/sidebar.c
+++ b/sidebar.c
@@ -1101,6 +1101,10 @@ static void draw_sidebar(struct MuttWindow *win, int num_rows, int num_cols, int
     if (!abbr)
       abbr = abbrev_url(display, m->type);
 
+    // Use the abbreviation if we have one. The full path is not preferable.
+    if (abbr)
+      display = abbr;
+
     const char *last_part = abbr;
     int depth = calc_path_depth(abbr, C_SidebarDelimChars, &last_part);
 

--- a/sidebar.c
+++ b/sidebar.c
@@ -1109,14 +1109,19 @@ static void draw_sidebar(struct MuttWindow *win, int num_rows, int num_cols, int
     const char *last_part = abbr;
     int depth = calc_path_depth(abbr, C_SidebarDelimChars, &last_part);
 
+    // At this point, we don't have an abbreviation so let's keep track
+    // before using short path.
+    bool no_abbr = mutt_str_strncmp(display, full_path, sizeof(display));
     if (C_SidebarShortPath)
+    {
       display = last_part;
+    }
 
     mutt_buffer_reset(&result);
 
     // Don't indent if we were unable to create an abbreviation.
     // Otherwise, the full path will be indent, and it looks unusual.
-    if (C_SidebarFolderIndent && mutt_str_strncmp(display, full_path, sizeof(display)))
+    if (C_SidebarFolderIndent && no_abbr)
     {
       if (C_SidebarComponentDepth > 0)
         depth -= C_SidebarComponentDepth;


### PR DESCRIPTION
## Please wait for confirmation in #2293 that this works before merging

After the refactor in commit d77c704ceb85f34061e1333ab9c8eb5a264a0685,
the sidebar only displays a mailbox's full path/URI except in the case
of 'sidebar_short_path'. The full path/URI is not preferable for end
users.

What broke during the refactor is how the variable 'display' is updated.
It's initialized to a mailbox's full path/URI and only updated if using
'sidebar_short_path'. However, after initialization, an abbreviation is
calculated to remove the 'folder' or protocol.

To resolve this issue, if there's an abbreviation, store it in the
'display' variable.

Fixes #2293

* **Screenshots (if relevant)**
Using minimal config (`test/test` is just an empty file):
```
set folder="~/mail/austin@austinray.io"
set sidebar_visible=yes
unmailboxes *
mailboxes =INBOX =test/test
```

![image](https://user-images.githubusercontent.com/1640737/80552744-8ef86f80-8995-11ea-9712-2995fa328112.png)


