### PR TITLE
Make sure buffers are initialized on error

### DIFF
--- a/index.c
+++ b/index.c
@@ -825,6 +825,8 @@ static int main_change_folder(struct Menu *menu, int op, struct Mailbox *m,
  */
 void index_make_entry(char *buf, size_t buflen, struct Menu *menu, int line)
 {
+  buf[0] = '\0';
+
   if (!Context || !Context->mailbox || !menu || (line < 0) ||
       (line >= Context->mailbox->email_max))
     return;
@@ -927,7 +929,7 @@ int index_color(int line)
  */
 void mutt_draw_statusline(int cols, const char *buf, size_t buflen)
 {
-  if (!buf)
+  if (!buf || !stdscr)
     return;
 
   size_t i = 0;
@@ -942,9 +944,6 @@ void mutt_draw_statusline(int cols, const char *buf, size_t buflen)
     int first;
     int last;
   } *syntax = NULL;
-
-  if (!buf || !stdscr)
-    return;
 
   do
   {

--- a/sidebar.c
+++ b/sidebar.c
@@ -294,10 +294,13 @@ static const char *sidebar_format_str(char *buf, size_t buflen, size_t col, int 
 static void make_sidebar_entry(char *buf, size_t buflen, int width,
                                const char *box, struct SbEntry *sbe)
 {
-  if (!buf || !box || !sbe)
+  if (!buf)
     return;
 
-  mutt_str_strfcpy(sbe->box, box, sizeof(sbe->box));
+  if (box && sbe)
+    mutt_str_strfcpy(sbe->box, box, sizeof(sbe->box));
+  else
+    buf[0] = '\0';
 
   mutt_expando_format(buf, buflen, 0, width, NONULL(C_SidebarFormat),
                       sidebar_format_str, (unsigned long) sbe, MUTT_FORMAT_NO_FLAGS);


### PR DESCRIPTION
Because of lack of proper error propagation functions could return
without touching `buf`.

* **What does this PR do?**
Initializes such buffers.

* **What are the relevant issue numbers?**
Fixes #2145. (And absolutely not sure, but maybe #2110 (at least the garbage).)
