### PR TITLE
docs: make header cache config more explicit

### DIFF
--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -11887,8 +11887,8 @@ folder-hook imap://user@host2/ 'set folder=imap://host2/ ; set record=+INBOX/Sen
         </para>
         <para>
           Additionally,
-          <link linkend="header-cache-backend">$header_cache_backend</link> can
-          be used to specify which backend to use. The list of available
+          <link linkend="header-cache-backend">$header_cache_backend</link> must
+          be set to specify which backend to use. The list of available
           backends can be specified at configure time with a set of
           --with-&lt;backend&gt; options. Currently, the following backends are
           supported: bdb, gdbm, kyotocabinet, lmdb, qdbm, rocksdb, tdb,

--- a/mutt_config.c
+++ b/mutt_config.c
@@ -1442,7 +1442,8 @@ struct ConfigDef MuttVars[] = {
   { "header_cache_backend", DT_STRING, &C_HeaderCacheBackend, 0, 0, hcache_validator },
   /*
   ** .pp
-  ** This variable specifies the header cache backend.
+  ** This variable specifies the header cache backend.  By default it is
+  ** \fIunset\fP so no header caching will be used.
   */
 #if defined(USE_HCACHE_COMPRESSION)
   { "header_cache_compress_level", DT_NUMBER|DT_NOT_NEGATIVE, &C_HeaderCacheCompressLevel, 1 },


### PR DESCRIPTION
Keeping header_cache_backend unset disables use of header caching, which
is surprising; document that.

It might be nicer to fall back to one of the compiled-in backends, if
there's one.

* **What does this PR do?**

Fixes documentation.

* **Screenshots (if relevant)**

* **Does this PR meet the acceptance criteria?** (This is just a reminder for you,
  this section can be removed if you fulfill it.)

   - Documentation created/updated (you have to edit
     [doc/manual.xml.head](https://www.github.com/neomutt/neomutt/blob/master/doc/manual.xml.head)
     for that)

   - All builds and tests are passing

   - Added [doxygen code documentation](https://neomutt.org/dev/doxygen)
     [syntax](http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html)

   - Code follows the [style guide](https://neomutt.org/dev/coding-style)

* **What are the relevant issue numbers?**
