### PR TITLE
Fix function declaration of mutt_window_get_coords

### DIFF
--- a/gui/mutt_window.h
+++ b/gui/mutt_window.h
@@ -117,7 +117,7 @@ void               mutt_window_add_child          (struct MuttWindow *parent, st
 void               mutt_window_copy_size          (const struct MuttWindow *win_src, struct MuttWindow *win_dst);
 void               mutt_window_free               (struct MuttWindow **ptr);
 void               mutt_window_free_all           (void);
-void               mutt_window_get_coords         (struct MuttWindow *win, int *col, int *row);
+void               mutt_window_get_coords         (struct MuttWindow *win, int *row, int *col);
 void               mutt_window_init               (void);
 struct MuttWindow *mutt_window_new                (enum MuttWindowOrientation orient, enum MuttWindowSize size, int rows, int cols);
 void               mutt_window_reflow             (struct MuttWindow *win);


### PR DESCRIPTION
The function declaration had a different meaning compared to the
function definition, as `row` and `col` where swapped.

As the row and column have the same type, it did not cause a linking
error.
Apparently all the places where `mutt_window_get_coords` has been used,
it has been used consistently, so just changing the definition is
enough.