### PR TITLE
acutest updates

### DIFF
--- a/test/acutest.h
+++ b/test/acutest.h
@@ -925,6 +925,26 @@ test_error_(const char* fmt, ...)
     }
 }
 
+/* This is called just before each test */
+static void
+test_init_(const char *test_name)
+{
+#ifdef TEST_INIT
+  TEST_INIT
+  ; /* Allow for a single unterminated function call */
+#endif
+}
+
+/* This is called after each test */
+static void
+test_fini_(const char *test_name)
+{
+#ifdef TEST_FINI
+  TEST_FINI
+  ; /* Allow for a single unterminated function call */
+#endif
+}
+
 /* Call directly the given test unit function. */
 static int
 test_do_run_(const struct test_* test, int index)
@@ -936,13 +956,13 @@ test_do_run_(const struct test_* test, int index)
     test_current_already_logged_ = 0;
     test_cond_failed_ = 0;
 
-    test_begin_test_line_(test);
-
 #ifdef __cplusplus
     try {
 #endif
+        test_init_(test->name);
+        test_begin_test_line_(test);
 
-        /* This is good to do for case the test unit e.g. crashes. */
+        /* This is good to do in case the test unit crashes. */
         fflush(stdout);
         fflush(stderr);
 
@@ -988,6 +1008,7 @@ aborted:
             test_finish_test_line_(0);
         }
 
+        test_fini_(test->name);
         test_case_(NULL);
         test_current_unit_ = NULL;
         return (test_current_failures_ == 0) ? 0 : -1;

--- a/test/common.c
+++ b/test/common.c
@@ -23,6 +23,7 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
+#include <locale.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -40,7 +41,7 @@ void test_gen_path(char *buf, size_t buflen, const char *fmt)
   snprintf(buf, buflen, NONULL(fmt), NONULL(get_test_dir()));
 }
 
-void test_common(void)
+void test_init(void)
 {
   const char *path = get_test_dir();
   bool success = false;
@@ -71,8 +72,18 @@ void test_common(void)
     TEST_MSG("Test dir '%s' isn't a directory\n", path);
     goto done;
   }
+
+  if (!TEST_CHECK((setlocale(LC_ALL, "en_US.UTF-8") != NULL) ||
+                  (setlocale(LC_ALL, "C.UTF-8") != NULL)))
+  {
+    TEST_MSG("Can't set locale to (en_US|C).UTF-8");
+    goto done;
+  }
+
   success = true;
 done:
   if (!success)
     TEST_MSG("See: https://github.com/neomutt/neomutt-test-files#test-files\n");
 }
+
+

--- a/test/common.c
+++ b/test/common.c
@@ -73,10 +73,9 @@ void test_init(void)
     goto done;
   }
 
-  if (!TEST_CHECK((setlocale(LC_ALL, "en_US.UTF-8") != NULL) ||
-                  (setlocale(LC_ALL, "C.UTF-8") != NULL)))
+  if (!TEST_CHECK(setlocale(LC_ALL, "C.UTF-8") != NULL))
   {
-    TEST_MSG("Can't set locale to (en_US|C).UTF-8");
+    TEST_MSG("Can't set locale to C.UTF-8");
     goto done;
   }
 

--- a/test/main.c
+++ b/test/main.c
@@ -22,14 +22,14 @@
  */
 
 #include "config.h"
+#include "test_common.h"
+#define TEST_INIT test_init()
 #include "acutest.h"
 
 /******************************************************************************
  * Add your test cases to this list.
  *****************************************************************************/
 #define NEOMUTT_TEST_LIST                                                      \
-  NEOMUTT_TEST_ITEM(test_common)                                               \
-                                                                               \
   /* account */                                                                \
   NEOMUTT_TEST_ITEM(test_account_free)                                         \
   NEOMUTT_TEST_ITEM(test_account_mailbox_add)                                  \

--- a/test/rfc2047/rfc2047_decode.c
+++ b/test/rfc2047/rfc2047_decode.c
@@ -32,12 +32,6 @@ void test_rfc2047_decode(void)
 {
   // void rfc2047_decode(char **pd);
 
-  if (!TEST_CHECK((setlocale(LC_ALL, "en_US.UTF-8") != NULL) ||
-                  (setlocale(LC_ALL, "C.UTF-8") != NULL)))
-  {
-    TEST_MSG("Cannot set locale to (en_US|C).UTF-8");
-    return;
-  }
   char *previous_charset = C_Charset;
   C_Charset = "utf-8";
 

--- a/test/rfc2047/rfc2047_encode.c
+++ b/test/rfc2047/rfc2047_encode.c
@@ -32,12 +32,6 @@ void test_rfc2047_encode(void)
 {
   // void rfc2047_encode(char **pd, const char *specials, int col, const char *charsets);
 
-  if (!TEST_CHECK((setlocale(LC_ALL, "en_US.UTF-8") != NULL) ||
-                  (setlocale(LC_ALL, "C.UTF-8") != NULL)))
-  {
-    TEST_MSG("Cannot set locale to (en_US|C).UTF-8");
-    return;
-  }
   char *previous_charset = C_Charset;
   C_Charset = "utf-8";
 

--- a/test/test_common.h
+++ b/test/test_common.h
@@ -23,10 +23,10 @@
 #ifndef TEST_TEST_COMMON_H
 #define TEST_TEST_COMMON_H
 
-#include "acutest.h"
 #include <stdio.h>
 #include "mutt/lib.h"
 
 void test_gen_path(char *buf, size_t buflen, const char *fmt);
+void test_init(void);
 
 #endif /* TEST_TEST_COMMON_H */

--- a/test/url/url_parse.c
+++ b/test/url/url_parse.c
@@ -23,7 +23,6 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include <locale.h>
 #include "mutt/lib.h"
 #include "address/lib.h"
 #include "email/lib.h"
@@ -228,9 +227,6 @@ void check_query_string(const char *exp, const struct UrlQueryList *act)
 
 void test_url_parse(void)
 {
-  // let's pick a utf-8 locale, since we're also parsing utf-8 text */
-  setlocale(LC_ALL, "en_US.UTF-8");
-
   // struct Url *url_parse(const char *src);
 
   {


### PR DESCRIPTION
- Update to [latest acutest.h](https://github.com/mity/acutest/commit/cde0c8e699c843b70c978a1b66a11b346c933957)
- Use the `test_init()` function for all tests:
  - Check `$NEOMUTT_TEST_DIR` is set
  - Set the locale to `en_US.UTF-8` or `C.UTF-8`

Fixes: #2309