### PR TITLE
Inform but don't fail on IMAP NO/BAD responses

### DIFF
--- a/imap/command.c
+++ b/imap/command.c
@@ -1189,9 +1189,10 @@ int imap_cmd_step(struct ImapAccountData *adata)
           adata->lastcmd = (adata->lastcmd + 1) % adata->cmdslots;
         }
         cmd->state = cmd_status(adata->buf);
-        /* bogus - we don't know which command result to return here. Caller
-         * should provide a tag. */
-        rc = cmd->state;
+        if (cmd->state == IMAP_RES_NO)
+        {
+          mutt_message(_("IMAP command failed: %s"), adata->buf);
+        }
       }
       else
         stillrunning++;

--- a/imap/command.c
+++ b/imap/command.c
@@ -1189,7 +1189,7 @@ int imap_cmd_step(struct ImapAccountData *adata)
           adata->lastcmd = (adata->lastcmd + 1) % adata->cmdslots;
         }
         cmd->state = cmd_status(adata->buf);
-        if (cmd->state == IMAP_RES_NO)
+        if (cmd->state == IMAP_RES_NO || cmd->state == IMAP_RES_BAD)
         {
           mutt_message(_("IMAP command failed: %s"), adata->buf);
         }


### PR DESCRIPTION
Issue #2303

This is a first approach a fixing the issue. Instead of returning an error that ultimately ends up being handled as a fatal error + mailbox close, let's just show a message to inform the user that one of the IMAP commands has failed.
```
IMAP command failed: a0306 NO Mailbox doesn't exist: FooBar (0.001 + 0.000 secs).
```

I cannot foresee all implications of not returning an error, but at least we'd get some feedback and data to work on.