### PR TITLE
Window notifications

### DIFF
--- a/addrbook.c
+++ b/addrbook.c
@@ -242,17 +242,30 @@ void mutt_alias_menu(char *buf, size_t buflen, struct AliasList *aliases)
   struct MuttWindow *dlg =
       mutt_window_new(MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
-#ifdef USE_DEBUG_WINDOW
-  dlg->name = "aliases";
-#endif
   dlg->type = WT_DIALOG;
+  dlg->notify = notify_new();
+#ifdef USE_DEBUG_WINDOW
+  dlg->name = "alias dialog";
+#endif
+
   struct MuttWindow *index =
       mutt_window_new(MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
   index->type = WT_INDEX;
+  index->notify = notify_new();
+  notify_set_parent(index->notify, dlg->notify);
+#ifdef USE_DEBUG_WINDOW
+  index->name = "alias";
+#endif
+
   struct MuttWindow *ibar = mutt_window_new(
       MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_FIXED, 1, MUTT_WIN_SIZE_UNLIMITED);
   ibar->type = WT_INDEX_BAR;
+  ibar->notify = notify_new();
+  notify_set_parent(ibar->notify, dlg->notify);
+#ifdef USE_DEBUG_WINDOW
+  ibar->name = "alias bar";
+#endif
 
   if (C_StatusOnTop)
   {

--- a/autocrypt/acct_menu.c
+++ b/autocrypt/acct_menu.c
@@ -267,17 +267,30 @@ void mutt_autocrypt_account_menu(void)
   struct MuttWindow *dlg =
       mutt_window_new(MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
-#ifdef USE_DEBUG_WINDOW
-  dlg->name = "autocrypt";
-#endif
   dlg->type = WT_DIALOG;
+  dlg->notify = notify_new();
+#ifdef USE_DEBUG_WINDOW
+  dlg->name = "autocrypt dialog";
+#endif
+
   struct MuttWindow *index =
       mutt_window_new(MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
   index->type = WT_INDEX;
+  index->notify = notify_new();
+  notify_set_parent(index->notify, dlg->notify);
+#ifdef USE_DEBUG_WINDOW
+  index->name = "autocrypt";
+#endif
+
   struct MuttWindow *ibar = mutt_window_new(
       MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_FIXED, 1, MUTT_WIN_SIZE_UNLIMITED);
   ibar->type = WT_INDEX_BAR;
+  ibar->notify = notify_new();
+  notify_set_parent(ibar->notify, dlg->notify);
+#ifdef USE_DEBUG_WINDOW
+  ibar->name = "autocrypt bar";
+#endif
 
   if (C_StatusOnTop)
   {

--- a/browser.c
+++ b/browser.c
@@ -1373,17 +1373,30 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
   struct MuttWindow *dlg =
       mutt_window_new(MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
-#ifdef USE_DEBUG_WINDOW
-  dlg->name = "browser";
-#endif
   dlg->type = WT_DIALOG;
+  dlg->notify = notify_new();
+#ifdef USE_DEBUG_WINDOW
+  dlg->name = "browser dialog";
+#endif
+
   struct MuttWindow *index =
       mutt_window_new(MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
   index->type = WT_INDEX;
+  index->notify = notify_new();
+  notify_set_parent(index->notify, dlg->notify);
+#ifdef USE_DEBUG_WINDOW
+  index->name = "browser";
+#endif
+
   struct MuttWindow *ibar = mutt_window_new(
       MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_FIXED, 1, MUTT_WIN_SIZE_UNLIMITED);
   ibar->type = WT_INDEX_BAR;
+  ibar->notify = notify_new();
+  notify_set_parent(ibar->notify, dlg->notify);
+#ifdef USE_DEBUG_WINDOW
+  ibar->name = "browser bar";
+#endif
 
   if (C_StatusOnTop)
   {

--- a/compose.c
+++ b/compose.c
@@ -1337,28 +1337,49 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur, 
   struct MuttWindow *dlg =
       mutt_window_new(MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
-#ifdef USE_DEBUG_WINDOW
-  dlg->name = "compose";
-#endif
   dlg->type = WT_DIALOG;
+  dlg->notify = notify_new();
+#ifdef USE_DEBUG_WINDOW
+  dlg->name = "compose dialog";
+#endif
 
   struct MuttWindow *envelope =
       mutt_window_new(MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_FIXED,
                       HDR_ATTACH_TITLE - 1, MUTT_WIN_SIZE_UNLIMITED);
   envelope->type = WT_PAGER;
+  envelope->notify = notify_new();
+  notify_set_parent(envelope->notify, dlg->notify);
+#ifdef USE_DEBUG_WINDOW
+  envelope->name = "envelope";
+#endif
 
   struct MuttWindow *abar = mutt_window_new(
       MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_FIXED, 1, MUTT_WIN_SIZE_UNLIMITED);
   abar->type = WT_PAGER_BAR;
+  abar->notify = notify_new();
+  notify_set_parent(abar->notify, dlg->notify);
+#ifdef USE_DEBUG_WINDOW
+  abar->name = "attach bar";
+#endif
 
   struct MuttWindow *attach =
       mutt_window_new(MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
   attach->type = WT_INDEX;
+  attach->notify = notify_new();
+  notify_set_parent(attach->notify, dlg->notify);
+#ifdef USE_DEBUG_WINDOW
+  attach->name = "attach";
+#endif
 
   struct MuttWindow *ebar = mutt_window_new(
       MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_FIXED, 1, MUTT_WIN_SIZE_UNLIMITED);
   ebar->type = WT_INDEX_BAR;
+  ebar->notify = notify_new();
+  notify_set_parent(ebar->notify, dlg->notify);
+#ifdef USE_DEBUG_WINDOW
+  ebar->name = "envelope bar";
+#endif
 
   rd->email = e;
   rd->fcc = fcc;

--- a/compose.c
+++ b/compose.c
@@ -1973,14 +1973,14 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur, 
         Context = ctx;
         OptAttachMsg = true;
         mutt_message(_("Tag the messages you want to attach"));
-        struct MuttWindow *dlg_index = index_pager_init();
-        notify_observer_add(NeoMutt->notify, mutt_dlg_index_observer, dlg_index);
-        dialog_push(dlg_index);
-        mutt_index_menu(dlg_index);
+        struct MuttWindow *dlgindex = index_pager_init();
+        notify_observer_add(NeoMutt->notify, mutt_dlgindex_observer, dlgindex);
+        dialog_push(dlgindex);
+        mutt_index_menu(dlgindex);
         dialog_pop();
-        notify_observer_remove(NeoMutt->notify, mutt_dlg_index_observer, dlg_index);
-        index_pager_shutdown(dlg_index);
-        mutt_window_free(&dlg_index);
+        notify_observer_remove(NeoMutt->notify, mutt_dlgindex_observer, dlgindex);
+        index_pager_shutdown(dlgindex);
+        mutt_window_free(&dlgindex);
         OptAttachMsg = false;
 
         if (!Context)

--- a/conn/gui.c
+++ b/conn/gui.c
@@ -60,17 +60,30 @@ int dlg_verify_cert(const char *title, struct ListHead *list, bool allow_always,
   struct MuttWindow *dlg =
       mutt_window_new(MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
-#ifdef USE_DEBUG_WINDOW
-  dlg->name = "certificate";
-#endif
   dlg->type = WT_DIALOG;
+  dlg->notify = notify_new();
+#ifdef USE_DEBUG_WINDOW
+  dlg->name = "certificate dialog";
+#endif
+
   struct MuttWindow *index =
       mutt_window_new(MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
   index->type = WT_INDEX;
+  index->notify = notify_new();
+  notify_set_parent(index->notify, dlg->notify);
+#ifdef USE_DEBUG_WINDOW
+  index->name = "certificate";
+#endif
+
   struct MuttWindow *ibar = mutt_window_new(
       MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_FIXED, 1, MUTT_WIN_SIZE_UNLIMITED);
   ibar->type = WT_INDEX_BAR;
+  ibar->notify = notify_new();
+  notify_set_parent(ibar->notify, dlg->notify);
+#ifdef USE_DEBUG_WINDOW
+  ibar->name = "certificate bar";
+#endif
 
   if (C_StatusOnTop)
   {

--- a/gui/curs_lib.c
+++ b/gui/curs_lib.c
@@ -672,17 +672,30 @@ int mutt_do_pager(const char *banner, const char *tempfile, PagerFlags do_color,
   struct MuttWindow *dlg =
       mutt_window_new(MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
-#ifdef USE_DEBUG_WINDOW
-  dlg->name = "do-pager";
-#endif
+  dlg->notify = notify_new();
   dlg->type = WT_DIALOG;
+#ifdef USE_DEBUG_WINDOW
+  dlg->name = "do-pager dialog";
+#endif
+
   struct MuttWindow *pager =
       mutt_window_new(MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
   pager->type = WT_PAGER;
+  pager->notify = notify_new();
+  notify_set_parent(pager->notify, dlg->notify);
+#ifdef USE_DEBUG_WINDOW
+  pager->name = "pager";
+#endif
+
   struct MuttWindow *pbar = mutt_window_new(
       MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_FIXED, 1, MUTT_WIN_SIZE_UNLIMITED);
   pbar->type = WT_PAGER_BAR;
+  pbar->notify = notify_new();
+  notify_set_parent(pbar->notify, dlg->notify);
+#ifdef USE_DEBUG_WINDOW
+  pbar->name = "pager bar";
+#endif
 
   if (C_StatusOnTop)
   {

--- a/gui/mutt_window.c
+++ b/gui/mutt_window.c
@@ -241,16 +241,39 @@ void mutt_window_init(void)
 
   RootWindow = mutt_window_new(MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_FIXED, 0, 0);
   RootWindow->type = WT_ROOT;
+  RootWindow->notify = notify_new();
+  notify_set_parent(RootWindow->notify, NeoMutt->notify);
+#ifdef USE_DEBUG_WINDOW
+  RootWindow->name = "root";
+#endif
+
   MuttHelpWindow = mutt_window_new(MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_FIXED,
                                    1, MUTT_WIN_SIZE_UNLIMITED);
   MuttHelpWindow->type = WT_HELP_BAR;
   MuttHelpWindow->state.visible = C_Help;
+  MuttHelpWindow->notify = notify_new();
+  notify_set_parent(MuttHelpWindow->notify, RootWindow->notify);
+#ifdef USE_DEBUG_WINDOW
+  MuttHelpWindow->name = "help bar";
+#endif
+
   MuttDialogWindow = mutt_window_new(MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                                      MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
   MuttDialogWindow->type = WT_ALL_DIALOGS;
+  MuttDialogWindow->notify = notify_new();
+  notify_set_parent(MuttDialogWindow->notify, RootWindow->notify);
+#ifdef USE_DEBUG_WINDOW
+  MuttDialogWindow->name = "all dialogs";
+#endif
+
   MuttMessageWindow = mutt_window_new(MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_FIXED,
                                       1, MUTT_WIN_SIZE_UNLIMITED);
   MuttMessageWindow->type = WT_MESSAGE;
+  MuttMessageWindow->notify = notify_new();
+  notify_set_parent(MuttMessageWindow->notify, RootWindow->notify);
+#ifdef USE_DEBUG_WINDOW
+  MuttMessageWindow->name = "message";
+#endif
 
   if (C_StatusOnTop)
   {
@@ -612,6 +635,7 @@ void dialog_push(struct MuttWindow *dlg)
     last->state.visible = false;
 
   TAILQ_INSERT_TAIL(&MuttDialogWindow->children, dlg, entries);
+  notify_set_parent(dlg->notify, MuttDialogWindow->notify);
   dlg->state.visible = true;
   mutt_window_reflow(MuttDialogWindow);
 #ifdef USE_DEBUG_WINDOW

--- a/gui/mutt_window.c
+++ b/gui/mutt_window.c
@@ -46,6 +46,25 @@ struct MuttWindow *MuttHelpWindow = NULL;    ///< Help Window
 struct MuttWindow *MuttMessageWindow = NULL; ///< Message Window
 
 /**
+ * window_set_visible - Set a Window (and its children) visible or hidden
+ * @param win     Window
+ * @param visible If true, make Window visible, otherwise hidden
+ */
+void window_set_visible(struct MuttWindow *win, bool visible)
+{
+  if (!win)
+    win = RootWindow;
+
+  win->state.visible = visible;
+
+  struct MuttWindow *np = NULL;
+  TAILQ_FOREACH(np, &win->children, entries)
+  {
+    window_set_visible(np, visible);
+  }
+}
+
+/**
  * mutt_window_new - Create a new Window
  * @param orient Window orientation, e.g. #MUTT_WIN_ORIENT_VERTICAL
  * @param size   Window size, e.g. #MUTT_WIN_SIZE_MAXIMISE

--- a/gui/mutt_window.h
+++ b/gui/mutt_window.h
@@ -110,6 +110,39 @@ struct MuttWindow
 #endif
 };
 
+typedef uint8_t WindowNotifyFlags; ///< Changes to a MuttWindow
+#define WN_NO_FLAGS        0       ///< No flags are set
+#define WN_TALLER    (1 << 0)      ///< Window became taller
+#define WN_SHORTER   (1 << 1)      ///< Window became shorter
+#define WN_WIDER     (1 << 2)      ///< Window became wider
+#define WN_NARROWER  (1 << 3)      ///< Window became narrower
+#define WN_MOVED     (1 << 4)      ///< Window moved
+#define WN_VISIBLE   (1 << 5)      ///< Window became visible
+#define WN_HIDDEN    (1 << 6)      ///< Window became hidden
+
+/**
+ * struct EventWindow - An Event that happened to a Window
+ *
+ * Observers of EventWindow will be passed a type of #NT_WINDOW and a subtype
+ * of #NotifyWindow.
+ * 
+ */
+struct EventWindow
+{
+  struct MuttWindow *win;  ///< Window that changed
+  WindowNotifyFlags flags; ///< Attributes of Window that changed
+};
+
+/**
+ * enum NotifyWindow - Window notification types
+ *
+ * These are associated with Event type #NT_INDEX.
+ */
+enum NotifyWindow
+{
+  NT_WINDOW_STATE = 1, ///< Window state has changed, e.g. #WN_VISIBLE
+};
+
 extern struct MuttWindow *MuttDialogWindow;
 extern struct MuttWindow *MuttHelpWindow;
 extern struct MuttWindow *MuttMessageWindow;
@@ -144,6 +177,7 @@ bool mutt_window_is_visible(struct MuttWindow *win);
 void mutt_winlist_free       (struct MuttWindowList *head);
 struct MuttWindow *mutt_window_find(struct MuttWindow *root, enum WindowType type);
 struct MuttWindow *mutt_window_dialog(struct MuttWindow *win);
+void window_notify_all(struct MuttWindow *win);
 void window_set_visible(struct MuttWindow *win, bool visible);
 
 void dialog_pop(void);

--- a/gui/mutt_window.h
+++ b/gui/mutt_window.h
@@ -144,6 +144,7 @@ bool mutt_window_is_visible(struct MuttWindow *win);
 void mutt_winlist_free       (struct MuttWindowList *head);
 struct MuttWindow *mutt_window_find(struct MuttWindow *root, enum WindowType type);
 struct MuttWindow *mutt_window_dialog(struct MuttWindow *win);
+void window_set_visible(struct MuttWindow *win, bool visible);
 
 void dialog_pop(void);
 void dialog_push(struct MuttWindow *dlg);

--- a/gui/mutt_window.h
+++ b/gui/mutt_window.h
@@ -100,6 +100,8 @@ struct MuttWindow
   struct MuttWindow *parent;         ///< Parent Window
   struct MuttWindowList children;    ///< Children Windows
 
+  struct Notify *notify;             ///< Notifications system
+
   enum WindowType type;              ///< Window type, e.g. #WT_SIDEBAR
   void *wdata;                       ///< Private data
   void (*free_wdata)(struct MuttWindow *win, void **ptr); ///< Callback function to free private data

--- a/gui/reflow.c
+++ b/gui/reflow.c
@@ -51,8 +51,6 @@ static void window_reflow_horiz(struct MuttWindow *win)
     if (!np->state.visible)
       continue;
 
-    np->old = np->state; // Save the old state for later notifications
-
     switch (np->size)
     {
       case MUTT_WIN_SIZE_FIXED:
@@ -142,8 +140,6 @@ static void window_reflow_vert(struct MuttWindow *win)
   {
     if (!np->state.visible)
       continue;
-
-    np->old = np->state; // Save the old state for later notifications
 
     switch (np->size)
     {

--- a/index.c
+++ b/index.c
@@ -4154,9 +4154,9 @@ void index_pager_shutdown(struct MuttWindow *dlg)
 }
 
 /**
- * mutt_dlg_index_observer - Listen for config changes affecting the Index/Pager - Implements ::observer_t
+ * mutt_dlgindex_observer - Listen for config changes affecting the Index/Pager - Implements ::observer_t
  */
-int mutt_dlg_index_observer(struct NotifyCallback *nc)
+int mutt_dlgindex_observer(struct NotifyCallback *nc)
 {
   if (!nc->event_data || !nc->global_data)
     return -1;

--- a/index.c
+++ b/index.c
@@ -4054,48 +4054,87 @@ struct MuttWindow *index_pager_init(void)
       mutt_window_new(MUTT_WIN_ORIENT_HORIZONTAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
   dlg->type = WT_DIALOG;
+  dlg->notify = notify_new();
+  notify_observer_add(NeoMutt->notify, mutt_dlgindex_observer, dlg);
 #ifdef USE_DEBUG_WINDOW
-  dlg->name = "index";
+  dlg->name = "index dialog";
 #endif
-  struct MuttWindow *cont_right =
-      mutt_window_new(MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
-                      MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
-  cont_right->type = WT_CONTAINER;
-  struct MuttWindow *panel_index =
-      mutt_window_new(MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
-                      MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
-#ifdef USE_DEBUG_WINDOW
-  panel_index->name = "index panel";
-#endif
-  panel_index->type = WT_CONTAINER;
-  struct MuttWindow *panel_pager =
-      mutt_window_new(MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
-                      MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
-#ifdef USE_DEBUG_WINDOW
-  panel_pager->name = "pager panel";
-#endif
-  panel_pager->type = WT_CONTAINER;
-  panel_pager->state.visible = false; // The Pager and Pager Bar are initially hidden
 
-  struct MuttWindow *win_index =
-      mutt_window_new(MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
-                      MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
-  win_index->type = WT_INDEX;
-  struct MuttWindow *win_pbar = mutt_window_new(
-      MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_FIXED, 1, MUTT_WIN_SIZE_UNLIMITED);
-  win_pbar->type = WT_PAGER_BAR;
-  struct MuttWindow *win_pager =
-      mutt_window_new(MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
-                      MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
-  win_pager->type = WT_PAGER;
   struct MuttWindow *win_sidebar =
       mutt_window_new(MUTT_WIN_ORIENT_HORIZONTAL, MUTT_WIN_SIZE_FIXED,
                       MUTT_WIN_SIZE_UNLIMITED, C_SidebarWidth);
   win_sidebar->type = WT_SIDEBAR;
   win_sidebar->state.visible = C_SidebarVisible && (C_SidebarWidth > 0);
+  win_sidebar->notify = notify_new();
+  notify_set_parent(win_sidebar->notify, dlg->notify);
+#ifdef USE_DEBUG_WINDOW
+  win_sidebar->name = "sidebar";
+#endif
+
+  struct MuttWindow *cont_right =
+      mutt_window_new(MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
+                      MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
+  cont_right->type = WT_CONTAINER;
+#ifdef USE_DEBUG_WINDOW
+  cont_right->name = "index container";
+#endif
+
+  struct MuttWindow *panel_index =
+      mutt_window_new(MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
+                      MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
+  panel_index->type = WT_CONTAINER;
+#ifdef USE_DEBUG_WINDOW
+  panel_index->name = "index panel";
+#endif
+
+  struct MuttWindow *win_index =
+      mutt_window_new(MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
+                      MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
+  win_index->type = WT_INDEX;
+  win_index->notify = notify_new();
+  notify_set_parent(win_index->notify, dlg->notify);
+#ifdef USE_DEBUG_WINDOW
+  win_index->name = "index";
+#endif
+
   struct MuttWindow *win_ibar = mutt_window_new(
       MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_FIXED, 1, MUTT_WIN_SIZE_UNLIMITED);
   win_ibar->type = WT_INDEX_BAR;
+  win_ibar->notify = notify_new();
+  notify_set_parent(win_ibar->notify, dlg->notify);
+#ifdef USE_DEBUG_WINDOW
+  win_ibar->name = "index bar";
+#endif
+
+  struct MuttWindow *panel_pager =
+      mutt_window_new(MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
+                      MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
+  panel_pager->type = WT_CONTAINER;
+  panel_pager->state.visible = false; // The Pager and Pager Bar are initially hidden
+#ifdef USE_DEBUG_WINDOW
+  panel_pager->name = "pager panel";
+#endif
+
+  struct MuttWindow *win_pager =
+      mutt_window_new(MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
+                      MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
+  win_pager->type = WT_PAGER;
+  win_pager->state.visible = false;
+  win_pager->notify = notify_new();
+  notify_set_parent(win_pager->notify, dlg->notify);
+#ifdef USE_DEBUG_WINDOW
+  win_pager->name = "pager";
+#endif
+
+  struct MuttWindow *win_pbar = mutt_window_new(
+      MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_FIXED, 1, MUTT_WIN_SIZE_UNLIMITED);
+  win_pbar->type = WT_PAGER_BAR;
+  win_pbar->state.visible = false;
+  win_pbar->notify = notify_new();
+  notify_set_parent(win_pbar->notify, dlg->notify);
+#ifdef USE_DEBUG_WINDOW
+  win_pbar->name = "pager bar";
+#endif
 
   if (C_SidebarOnRight)
   {

--- a/index.h
+++ b/index.h
@@ -51,6 +51,6 @@ void mutt_set_header_color(struct Mailbox *m, struct Email *e);
 void update_index(struct Menu *menu, struct Context *ctx, int check, int oldcount, int index_hint);
 struct MuttWindow *index_pager_init(void);
 void index_pager_shutdown(struct MuttWindow *dlg);
-int mutt_dlg_index_observer(struct NotifyCallback *nc);
+int mutt_dlgindex_observer(struct NotifyCallback *nc);
 
 #endif /* MUTT_INDEX_H */

--- a/main.c
+++ b/main.c
@@ -1190,11 +1190,11 @@ int main(int argc, char *argv[], char *envp[])
       mutt_sb_set_open_mailbox(Context ? Context->mailbox : NULL);
 #endif
       struct MuttWindow *dlg = index_pager_init();
-      notify_observer_add(NeoMutt->notify, mutt_dlg_index_observer, dlg);
+      notify_observer_add(NeoMutt->notify, mutt_dlgindex_observer, dlg);
       dialog_push(dlg);
       mutt_index_menu(dlg);
       dialog_pop();
-      notify_observer_remove(NeoMutt->notify, mutt_dlg_index_observer, dlg);
+      notify_observer_remove(NeoMutt->notify, mutt_dlgindex_observer, dlg);
       index_pager_shutdown(dlg);
       mutt_window_free(&dlg);
       ctx_free(&Context);

--- a/mutt/notify_type.h
+++ b/mutt/notify_type.h
@@ -36,6 +36,7 @@ enum NotifyType
   NT_EMAIL,   ///< Email has changed
   NT_GLOBAL,  ///< Not object-related
   NT_MAILBOX, ///< Mailbox has changed
+  NT_WINDOW,  ///< MuttWindow has changed
 };
 
 #endif /* MUTT_LIB_NOTIFY_TYPE_H */

--- a/mutt_history.c
+++ b/mutt_history.c
@@ -103,17 +103,30 @@ static void history_menu(char *buf, size_t buflen, char **matches, int match_cou
   struct MuttWindow *dlg =
       mutt_window_new(MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
-#ifdef USE_DEBUG_WINDOW
-  dlg->name = "history";
-#endif
   dlg->type = WT_DIALOG;
+  dlg->notify = notify_new();
+#ifdef USE_DEBUG_WINDOW
+  dlg->name = "history dialog";
+#endif
+
   struct MuttWindow *index =
       mutt_window_new(MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
   index->type = WT_INDEX;
+  index->notify = notify_new();
+  notify_set_parent(index->notify, dlg->notify);
+#ifdef USE_DEBUG_WINDOW
+  index->name = "history";
+#endif
+
   struct MuttWindow *ibar = mutt_window_new(
       MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_FIXED, 1, MUTT_WIN_SIZE_UNLIMITED);
   ibar->type = WT_INDEX_BAR;
+  ibar->notify = notify_new();
+  notify_set_parent(ibar->notify, dlg->notify);
+#ifdef USE_DEBUG_WINDOW
+  ibar->name = "history bar";
+#endif
 
   if (C_StatusOnTop)
   {

--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -4788,17 +4788,30 @@ static struct CryptKeyInfo *crypt_select_key(struct CryptKeyInfo *keys,
   struct MuttWindow *dlg =
       mutt_window_new(MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
-#ifdef USE_DEBUG_WINDOW
-  dlg->name = "crypt-gpgme";
-#endif
   dlg->type = WT_DIALOG;
+  dlg->notify = notify_new();
+#ifdef USE_DEBUG_WINDOW
+  dlg->name = "crypt-gpgme dialog";
+#endif
+
   struct MuttWindow *index =
       mutt_window_new(MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
   index->type = WT_INDEX;
+  index->notify = notify_new();
+  notify_set_parent(index->notify, dlg->notify);
+#ifdef USE_DEBUG_WINDOW
+  index->name = "crypt-gpgme";
+#endif
+
   struct MuttWindow *ibar = mutt_window_new(
       MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_FIXED, 1, MUTT_WIN_SIZE_UNLIMITED);
   ibar->type = WT_INDEX_BAR;
+  ibar->notify = notify_new();
+  notify_set_parent(ibar->notify, dlg->notify);
+#ifdef USE_DEBUG_WINDOW
+  ibar->name = "crypt-gpgme bar";
+#endif
 
   if (C_StatusOnTop)
   {

--- a/ncrypt/pgpkey.c
+++ b/ncrypt/pgpkey.c
@@ -676,17 +676,30 @@ static struct PgpKeyInfo *pgp_select_key(struct PgpKeyInfo *keys,
   struct MuttWindow *dlg =
       mutt_window_new(MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
-#ifdef USE_DEBUG_WINDOW
-  dlg->name = "pgp";
-#endif
   dlg->type = WT_DIALOG;
+  dlg->notify = notify_new();
+#ifdef USE_DEBUG_WINDOW
+  dlg->name = "pgp dialog";
+#endif
+
   struct MuttWindow *index =
       mutt_window_new(MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
   index->type = WT_INDEX;
+  index->notify = notify_new();
+  notify_set_parent(index->notify, dlg->notify);
+#ifdef USE_DEBUG_WINDOW
+  index->name = "pgp";
+#endif
+
   struct MuttWindow *ibar = mutt_window_new(
       MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_FIXED, 1, MUTT_WIN_SIZE_UNLIMITED);
   ibar->type = WT_INDEX_BAR;
+  ibar->notify = notify_new();
+  notify_set_parent(ibar->notify, dlg->notify);
+#ifdef USE_DEBUG_WINDOW
+  ibar->name = "pgp bar";
+#endif
 
   if (C_StatusOnTop)
   {

--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -580,17 +580,30 @@ static struct SmimeKey *smime_select_key(struct SmimeKey *keys, char *query)
   struct MuttWindow *dlg =
       mutt_window_new(MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
-#ifdef USE_DEBUG_WINDOW
-  dlg->name = "smime";
-#endif
+  dlg->notify = notify_new();
   dlg->type = WT_DIALOG;
+#ifdef USE_DEBUG_WINDOW
+  dlg->name = "smime dialog";
+#endif
+
   struct MuttWindow *index =
       mutt_window_new(MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
   index->type = WT_INDEX;
+  index->notify = notify_new();
+  notify_set_parent(index->notify, dlg->notify);
+#ifdef USE_DEBUG_WINDOW
+  index->name = "smime";
+#endif
+
   struct MuttWindow *ibar = mutt_window_new(
       MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_FIXED, 1, MUTT_WIN_SIZE_UNLIMITED);
   ibar->type = WT_INDEX_BAR;
+  ibar->notify = notify_new();
+  notify_set_parent(ibar->notify, dlg->notify);
+#ifdef USE_DEBUG_WINDOW
+  ibar->name = "smime bar";
+#endif
 
   if (C_StatusOnTop)
   {

--- a/pager.c
+++ b/pager.c
@@ -2253,9 +2253,9 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
     rd.extra->win_index->size = MUTT_WIN_SIZE_FIXED;
     rd.extra->win_index->req_rows = index_space;
     rd.extra->win_index->parent->size = MUTT_WIN_SIZE_MINIMISE;
-    rd.extra->win_index->parent->state.visible = (index_space > 0);
+    window_set_visible(rd.extra->win_index->parent, (index_space > 0));
   }
-  rd.extra->win_pager->parent->state.visible = true;
+  window_set_visible(rd.extra->win_pager->parent, true);
   rd.extra->win_pager->size = MUTT_WIN_SIZE_MAXIMISE;
   mutt_window_reflow(mutt_window_dialog(rd.extra->win_pager));
 
@@ -3571,13 +3571,13 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
 
   if (rd.extra->win_index)
   {
-    rd.extra->win_index->parent->state.visible = true;
     rd.extra->win_index->size = MUTT_WIN_SIZE_MAXIMISE;
     rd.extra->win_index->req_rows = MUTT_WIN_SIZE_UNLIMITED;
     rd.extra->win_index->parent->size = MUTT_WIN_SIZE_MAXIMISE;
     rd.extra->win_index->parent->req_rows = MUTT_WIN_SIZE_UNLIMITED;
+    window_set_visible(rd.extra->win_index->parent, true);
   }
-  rd.extra->win_pager->parent->state.visible = false;
+  window_set_visible(rd.extra->win_pager->parent, false);
   mutt_window_reflow(mutt_window_dialog(rd.extra->win_pager));
 
   return (rc != -1) ? rc : 0;

--- a/postpone.c
+++ b/postpone.c
@@ -227,17 +227,30 @@ static struct Email *select_msg(struct Context *ctx)
   struct MuttWindow *dlg =
       mutt_window_new(MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
-#ifdef USE_DEBUG_WINDOW
-  dlg->name = "postpone";
-#endif
   dlg->type = WT_DIALOG;
+  dlg->notify = notify_new();
+#ifdef USE_DEBUG_WINDOW
+  dlg->name = "postpone dialog";
+#endif
+
   struct MuttWindow *index =
       mutt_window_new(MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
   index->type = WT_INDEX;
+  index->notify = notify_new();
+  notify_set_parent(index->notify, dlg->notify);
+#ifdef USE_DEBUG_WINDOW
+  index->name = "postpone";
+#endif
+
   struct MuttWindow *ibar = mutt_window_new(
       MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_FIXED, 1, MUTT_WIN_SIZE_UNLIMITED);
   ibar->type = WT_INDEX_BAR;
+  ibar->notify = notify_new();
+  notify_set_parent(ibar->notify, dlg->notify);
+#ifdef USE_DEBUG_WINDOW
+  ibar->name = "postpone bar";
+#endif
 
   if (C_StatusOnTop)
   {

--- a/query.c
+++ b/query.c
@@ -375,17 +375,30 @@ static void query_menu(char *buf, size_t buflen, struct Query *results, bool ret
   struct MuttWindow *dlg =
       mutt_window_new(MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
-#ifdef USE_DEBUG_WINDOW
-  dlg->name = "query";
-#endif
   dlg->type = WT_DIALOG;
+  dlg->notify = notify_new();
+#ifdef USE_DEBUG_WINDOW
+  dlg->name = "query dialog";
+#endif
+
   struct MuttWindow *index =
       mutt_window_new(MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
   index->type = WT_INDEX;
+  index->notify = notify_new();
+  notify_set_parent(index->notify, dlg->notify);
+#ifdef USE_DEBUG_WINDOW
+  index->name = "query";
+#endif
+
   struct MuttWindow *ibar = mutt_window_new(
       MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_FIXED, 1, MUTT_WIN_SIZE_UNLIMITED);
   ibar->type = WT_INDEX_BAR;
+  ibar->notify = notify_new();
+  notify_set_parent(ibar->notify, dlg->notify);
+#ifdef USE_DEBUG_WINDOW
+  ibar->name = "query bar";
+#endif
 
   if (C_StatusOnTop)
   {

--- a/recvattach.c
+++ b/recvattach.c
@@ -1433,17 +1433,30 @@ void mutt_view_attachments(struct Email *e)
   struct MuttWindow *dlg =
       mutt_window_new(MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
-#ifdef USE_DEBUG_WINDOW
-  dlg->name = "attach";
-#endif
   dlg->type = WT_DIALOG;
+  dlg->notify = notify_new();
+#ifdef USE_DEBUG_WINDOW
+  dlg->name = "attach dialog";
+#endif
+
   struct MuttWindow *index =
       mutt_window_new(MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
   index->type = WT_INDEX;
+  index->notify = notify_new();
+  notify_set_parent(index->notify, dlg->notify);
+#ifdef USE_DEBUG_WINDOW
+  dlg->name = "attach";
+#endif
+
   struct MuttWindow *ibar = mutt_window_new(
       MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_FIXED, 1, MUTT_WIN_SIZE_UNLIMITED);
   ibar->type = WT_INDEX_BAR;
+  ibar->notify = notify_new();
+  notify_set_parent(ibar->notify, dlg->notify);
+#ifdef USE_DEBUG_WINDOW
+  dlg->name = "attach bar";
+#endif
 
   if (C_StatusOnTop)
   {

--- a/remailer.c
+++ b/remailer.c
@@ -640,17 +640,30 @@ void mix_make_chain(struct MuttWindow *win, struct ListHead *chainhead, int cols
   struct MuttWindow *dlg =
       mutt_window_new(MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
-#ifdef USE_DEBUG_WINDOW
-  dlg->name = "remailer";
-#endif
   dlg->type = WT_DIALOG;
+  dlg->notify = notify_new();
+#ifdef USE_DEBUG_WINDOW
+  dlg->name = "remailer dialog";
+#endif
+
   struct MuttWindow *index =
       mutt_window_new(MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
   index->type = WT_INDEX;
+  index->notify = notify_new();
+  notify_set_parent(index->notify, dlg->notify);
+#ifdef USE_DEBUG_WINDOW
+  index->name = "remailier";
+#endif
+
   struct MuttWindow *ibar = mutt_window_new(
       MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_FIXED, 1, MUTT_WIN_SIZE_UNLIMITED);
   ibar->type = WT_INDEX_BAR;
+  ibar->notify = notify_new();
+  notify_set_parent(ibar->notify, dlg->notify);
+#ifdef USE_DEBUG_WINDOW
+  ibar->name = "remailer bar";
+#endif
 
   if (C_StatusOnTop)
   {

--- a/resize.c
+++ b/resize.c
@@ -92,7 +92,7 @@ void mutt_resize_screen(void)
   stdscr = newwin(0, 0, 0, 0);
   keypad(stdscr, true);
   mutt_window_set_root(SLtt_Screen_Rows, SLtt_Screen_Cols);
-  mutt_window_reflow(NULL);
+  window_notify_all(NULL);
 }
 #else
 /**
@@ -121,6 +121,6 @@ void mutt_resize_screen(void)
 
   resizeterm(screenrows, screencols);
   mutt_window_set_root(screenrows, screencols);
-  mutt_window_reflow(NULL);
+  window_notify_all(NULL);
 }
 #endif

--- a/sidebar.c
+++ b/sidebar.c
@@ -1382,7 +1382,7 @@ int mutt_sb_observer(struct NotifyCallback *nc)
 
   if (win->state.visible == !C_SidebarVisible)
   {
-    win->state.visible = C_SidebarVisible;
+    window_set_visible(win, C_SidebarVisible);
     repaint = true;
   }
 


### PR DESCRIPTION
In ["Event-Driven Sidebar"](https://neomutt.org/dev/roadmap/event-sidebar), I map out the route to splitting up the Windows and encapsulating them.
Many of the required notifications, e.g. Config, Colour, are already in place.
This PR adds Window notifications.

- e0ecb92ada window: rename dlg_index
  unify naming

- c17e983be4 window: name and notify
  ensure all user-visible windows are named (debug only) and have notifications support

- 3ebcd28900 window: set_visible
  helper function to make a window (and its children) visible or hidden

- a459d75001 notify: windows
  send out notifications on window changes

- 0fa17ab368 debug: notify windows
  update debugging to dump all window events

---

The debug logging looks like this:
```
[pager] visible 
[pager bar] visible 
[index] taller [10->39] 
[index bar] moved (C20,R10)->(C20,R39) 
```
