### PR TITLE
mh: fix creating new mailbox

### DIFF
--- a/maildir/mh.c
+++ b/maildir/mh.c
@@ -559,12 +559,10 @@ static int mh_mbox_open_append(struct Mailbox *m, OpenMailboxFlags flags)
   if (!m)
     return -1;
 
-  if (!(flags & MUTT_APPENDNEW))
-  {
+  if (!(flags & (MUTT_APPENDNEW | MUTT_NEWFOLDER)))
     return 0;
-  }
 
-  if (mkdir(mailbox_path(m), S_IRWXU))
+  if (mutt_file_mkdir(mailbox_path(m), S_IRWXU))
   {
     mutt_perror(mailbox_path(m));
     return -1;


### PR DESCRIPTION
Fixes: #2324 

- Check for either new folder flags
- Use `mutt_file_mkdir()` in case dir already exists
