### PR TITLE
fix tagged message count

### DIFF
--- a/context.c
+++ b/context.c
@@ -179,6 +179,8 @@ void ctx_update(struct Context *ctx)
       m->msg_flagged++;
     if (e->deleted)
       m->msg_deleted++;
+    if (e->tagged)
+      m->msg_tagged++;
     if (!e->read)
     {
       m->msg_unread++;


### PR DESCRIPTION
Fixes: #2333 

After editing a message, NeoMutt performs a 'new mail' update, which wipes and recalculates the Mailbox stats.
One of these numbers, `Mailbox->msg_tagged` wasn't getting updated, so `<tag-prefix>` failed thinking there weren't any tagged messages.