### PR TITLE
Partially undo #2317: inform AND fail

### DIFF
--- a/imap/command.c
+++ b/imap/command.c
@@ -1189,6 +1189,7 @@ int imap_cmd_step(struct ImapAccountData *adata)
           adata->lastcmd = (adata->lastcmd + 1) % adata->cmdslots;
         }
         cmd->state = cmd_status(adata->buf);
+        rc = cmd->state;
         if (cmd->state == IMAP_RES_NO || cmd->state == IMAP_RES_BAD)
         {
           mutt_message(_("IMAP command failed: %s"), adata->buf);


### PR DESCRIPTION
Fixes #2331

This is still far from being optimal. The problem is that we end up receiving an error in two cases:

1. interactive case, such as login: here, we really want to know that the login failed so we can e.g., try with the next auth metod.
2. batch, such as STATUS for `mailbox-list`: here, we don't want to fail because some mailbox cannot be STATUS'd and we just want to go on.

With this change, we'd probably go back to square one wrt non-existent subscribed mailboxes. At least we'd have a nice error message, though.