### PR TITLE
Add missing commands for unbind and unmacro to neomuttrc manges

### DIFF
--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -4136,8 +4136,8 @@ set alias_file=~/.mail_aliases
       </para>
       <note>
         <para>
-          Missing key sequence in unmacro command means unmacro all macros in menus
-          given in <emphasis>menu</emphasis>.
+          Missing key sequence in unbind command means unibind all bindings in menus
+          given in <emphasis>map</emphasis>.
         </para>
       </note>
       <anchor id="maps" />

--- a/docs/neomuttrc.man.head
+++ b/docs/neomuttrc.man.head
@@ -189,6 +189,7 @@ A \fImime-subtype\fP of \(lq\fB*\fP\(rq matches any
 .PP
 .nf
 \fBbind\fP \fImap\fP[\fB,\fP\fImap\fP ... ] \fIkey\fP \fIfunction\fP
+\fBunbind\fP { \fB*\fP | \fImap\fP | [\fB,\fP\fImap\fP...]} [ \fIkey\fP ]
 .fi
 .IP
 This command allows you to change the default or define additional key bindings
@@ -208,6 +209,8 @@ symbolic names for the keys on your keyboard.
 .IP
 \fIfunction\fP specifies which action to take when key is pressed. Note that
 the function name is to be specified without angle brackets.
+.IP
+Missing key sequence in \fBunbind\fP command means unbind all bindings in menus given in \fImap\fP .
 .IP
 For more information on keys and functions, please consult the NeoMutt manual.
 .
@@ -488,6 +491,7 @@ The \fB\-group\fP flag adds all of the subsequent regular expressions to the
 .PP
 .nf
 \fBmacro\fP \fImenu\fP[\fB,\fP\fImenu\fP ... ] \fIkey\fP \fIsequence\fP [ \fIdescription\fP ]
+\fBunmacro\fP { \fB*\fP | \fImenu\fP | [\fB,\fP\fImenu\fP...]} [ \fIkey\fP ]
 .fi
 .IP
 This command binds the given \fIsequence\fP of keys to the given \fIkey\fP in
@@ -496,6 +500,8 @@ command above. To specify multiple menus, put only a comma between the menus.
 .IP
 Optionally you can specify a descriptive text after \fIsequence\fP, which is
 shown in the help screens if they contain a \fIdescription\fP.
+.IP
+Missing key sequence in \fBunmacro\fP command means unmacro all macros in menus given in \fImenu\fP.
 .
 .PP
 .nf


### PR DESCRIPTION
* **What does this PR do?**
Adds missing `unbind` and `unmacro` commands to neomuttrc(5) man pages.

Also fixes namings for **map** vs **menu** for `unmacro` to match marco
desciption in NeoMutt manual.

* **Screenshots (if relevant)**

* **Does this PR meet the acceptance criteria?** (This is just a reminder for you,
  this section can be removed if you fulfill it.)

   - Documentation created/updated (you have to edit
     [doc/manual.xml.head](https://www.github.com/neomutt/neomutt/blob/master/doc/manual.xml.head)
     for that)
should have been already added in #1599 

   - All builds and tests are passing

   - Added [doxygen code documentation](https://neomutt.org/dev/doxygen)
     [syntax](http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html)
No code added, no need to

   - Code follows the [style guide](https://neomutt.org/dev/coding-style)

* **What are the relevant issue numbers?**
