### PR TITLE
Address Book tweaks

### DIFF
--- a/addrbook.c
+++ b/addrbook.c
@@ -74,7 +74,7 @@ static const char *alias_format_str(char *buf, size_t buflen, size_t col, int co
                                     const char *if_str, const char *else_str,
                                     unsigned long data, MuttFormatFlags flags)
 {
-  char fmt[128], addr[128];
+  char fmt[128], addr[1024];
   struct Alias *alias = (struct Alias *) data;
 
   switch (op)
@@ -93,8 +93,7 @@ static const char *alias_format_str(char *buf, size_t buflen, size_t col, int co
     case 'r':
       addr[0] = '\0';
       mutt_addrlist_write(&alias->addr, addr, sizeof(addr), true);
-      snprintf(fmt, sizeof(fmt), "%%%ss", prec);
-      snprintf(buf, buflen, fmt, addr);
+      mutt_format_s(buf, buflen, prec, addr);
       break;
     case 't':
       buf[0] = alias->tagged ? '*' : ' ';

--- a/addrbook.c
+++ b/addrbook.c
@@ -64,6 +64,7 @@ static const struct Mapping AliasHelp[] = {
  * | Expando | Description
  * |:--------|:--------------------------------------------------------
  * | \%a     | Alias name
+ * | \%c     | Comments
  * | \%f     | Flags - currently, a 'd' for an alias marked for deletion
  * | \%n     | Index number
  * | \%r     | Address which alias expands to
@@ -81,6 +82,9 @@ static const char *alias_format_str(char *buf, size_t buflen, size_t col, int co
   {
     case 'a':
       mutt_format_s(buf, buflen, prec, alias->name);
+      break;
+    case 'c':
+      mutt_format_s(buf, buflen, prec, alias->comment);
       break;
     case 'f':
       snprintf(fmt, sizeof(fmt), "%%%ss", prec);

--- a/alias.c
+++ b/alias.c
@@ -751,6 +751,7 @@ void mutt_alias_free(struct Alias **ptr)
 
   mutt_alias_delete_reverse(a);
   FREE(&a->name);
+  FREE(&a->comment);
   mutt_addrlist_clear(&(a->addr));
   FREE(ptr);
 }

--- a/alias.c
+++ b/alias.c
@@ -473,8 +473,20 @@ retry_name:
   mutt_str_replace(&TAILQ_FIRST(&alias->addr)->personal, buf);
 
   buf[0] = '\0';
+  if (mutt_get_field(_("Comment: "), buf, sizeof(buf), MUTT_COMP_NO_FLAGS) == 0)
+    mutt_str_replace(&alias->comment, buf);
+
+  buf[0] = '\0';
   mutt_addrlist_write(&alias->addr, buf, sizeof(buf), true);
-  snprintf(prompt, sizeof(prompt), _("[%s = %s] Accept?"), alias->name, buf);
+  if (alias->comment)
+  {
+    snprintf(prompt, sizeof(prompt), "[%s = %s # %s] %s", alias->name, buf,
+             alias->comment, _("Accept?"));
+  }
+  else
+  {
+    snprintf(prompt, sizeof(prompt), "[%s = %s] %s", alias->name, buf, _("Accept?"));
+  }
   if (mutt_yesorno(prompt, MUTT_YES) != MUTT_YES)
   {
     mutt_alias_free(&alias);
@@ -485,7 +497,7 @@ retry_name:
   TAILQ_INSERT_TAIL(&Aliases, alias, entries);
 
   mutt_str_strfcpy(buf, C_AliasFile, sizeof(buf));
-  if (mutt_get_field(_("Save to file: "), buf, sizeof(buf), MUTT_FILE) != 0)
+  if (mutt_get_field(_("Save to file: "), buf, sizeof(buf), MUTT_FILE | MUTT_CLEAR) != 0)
     return;
   mutt_expand_path(buf, sizeof(buf));
   FILE *fp_alias = fopen(buf, "a+");
@@ -524,6 +536,8 @@ retry_name:
   mutt_addrlist_write(&alias->addr, buf, sizeof(buf), false);
   recode_buf(buf, sizeof(buf));
   write_safe_address(fp_alias, buf);
+  if (alias->comment)
+    fprintf(fp_alias, " # %s", alias->comment);
   fputc('\n', fp_alias);
   if (mutt_file_fsync_close(&fp_alias) != 0)
     mutt_perror(_("Trouble adding alias"));

--- a/alias.h
+++ b/alias.h
@@ -38,10 +38,12 @@ struct Alias
 {
   char *name;                 ///< Short name
   struct AddressList addr;    ///< List of Addresses the Alias expands to
+  char *comment;              ///< Free-form comment string
+  TAILQ_ENTRY(Alias) entries; ///< Linked list
+
   bool tagged;                ///< Is it tagged?
   bool del;                   ///< Is it deleted?
   short num;                  ///< Index number in list
-  TAILQ_ENTRY(Alias) entries; ///< Linked list
 };
 TAILQ_HEAD(AliasList, Alias);
 

--- a/command_parse.c
+++ b/command_parse.c
@@ -643,6 +643,13 @@ enum CommandResult parse_alias(struct Buffer *buf, struct Buffer *s,
     }
   }
   mutt_grouplist_destroy(&gl);
+  if (!MoreArgs(s) && (s->dptr[0] == '#'))
+  {
+    char *comment = s->dptr + 1;
+    SKIPWS(comment);
+    tmp->comment = mutt_str_strdup(comment);
+  }
+
   return MUTT_CMD_SUCCESS;
 
 bail:

--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -3987,6 +3987,9 @@ alternates -group me -group work address3
         <arg choice="opt" rep="repeat">
           <replaceable class="parameter">, address</replaceable>
         </arg>
+        <arg choice="opt">
+          <replaceable class="parameter"># comment</replaceable>
+        </arg>
         <command>unalias</command>
         <arg choice="opt" rep="repeat">
           <option>-group</option>
@@ -4023,8 +4026,13 @@ alternates -group me -group work address3
       </para>
 
 <screen>
-alias muttdude me@cs.hmc.edu (Michael Elkins)
-alias theguys manny, moe, jack
+<emphasis role="comment"># Some aliases, one with a comment</emphasis>
+alias alan   Alan Jones &lt;alan@example.com&gt;
+alias briony Briony Williams &lt;bw@example.com&gt;
+alias jim    James Smith &lt;js@example.com&gt; <emphasis role="comment"># Pointy-haired boss</emphasis>
+
+<emphasis role="comment"># An alias that references two other aliases</emphasis>
+alias friends alan, briony
 </screen>
 
       <para>

--- a/mutt_config.c
+++ b/mutt_config.c
@@ -186,6 +186,7 @@ struct ConfigDef MuttVars[] = {
   ** following \fCprintf(3)\fP-style sequences are available:
   ** .dl
   ** .dt %a  .dd Alias name
+  ** .dt %c  .dd Comment
   ** .dt %f  .dd Flags - currently, a "d" for an alias marked for deletion
   ** .dt %n  .dd Index number
   ** .dt %r  .dd Address which alias expands to

--- a/mutt_config.c
+++ b/mutt_config.c
@@ -179,7 +179,7 @@ struct ConfigDef MuttVars[] = {
   ** The default for this option is the currently used neomuttrc file, or
   ** "~/.neomuttrc" if no user neomuttrc was found.
   */
-  { "alias_format", DT_STRING|DT_NOT_EMPTY, &C_AliasFormat, IP "%4n %2f %t %-10a   %r" },
+  { "alias_format", DT_STRING|DT_NOT_EMPTY, &C_AliasFormat, IP "%3n %f%t %-15a %-56r | %c" },
   /*
   ** .pp
   ** Specifies the format of the data displayed for the "$alias" menu.  The

--- a/po/bg.po
+++ b/po/bg.po
@@ -84,8 +84,8 @@ msgstr "Име:"
 
 #: alias.c:477
 #, c-format
-msgid "[%s = %s] Accept?"
-msgstr "[%s = %s] Запис?"
+msgid "Accept?"
+msgstr "Запис?"
 
 #: alias.c:488 recvattach.c:531 recvattach.c:553 recvattach.c:567
 #: recvattach.c:582 recvattach.c:681

--- a/po/ca.po
+++ b/po/ca.po
@@ -129,8 +129,8 @@ msgstr "Nom personal: "
 
 #: alias.c:477
 #, c-format
-msgid "[%s = %s] Accept?"
-msgstr "Voleu acceptar «%s» com a àlies de «%s»?"
+msgid "Accept?"
+msgstr "Voleu acceptar?"
 
 #: alias.c:488 recvattach.c:531 recvattach.c:553 recvattach.c:567
 #: recvattach.c:582 recvattach.c:681

--- a/po/cs.po
+++ b/po/cs.po
@@ -92,8 +92,8 @@ msgstr "Vlastní jméno: "
 
 #: alias.c:477
 #, c-format
-msgid "[%s = %s] Accept?"
-msgstr "[%s = %s] Přijmout?"
+msgid "Accept?"
+msgstr "Přijmout?"
 
 #: alias.c:488 recvattach.c:531 recvattach.c:553 recvattach.c:567
 #: recvattach.c:582 recvattach.c:681

--- a/po/da.po
+++ b/po/da.po
@@ -82,8 +82,8 @@ msgstr "Navn: "
 
 #: alias.c:477
 #, c-format
-msgid "[%s = %s] Accept?"
-msgstr "[%s = %s] O.k.?"
+msgid "Accept?"
+msgstr "O.k.?"
 
 #: alias.c:488 recvattach.c:531 recvattach.c:553 recvattach.c:567
 #: recvattach.c:582 recvattach.c:681

--- a/po/de.po
+++ b/po/de.po
@@ -86,8 +86,8 @@ msgstr "Ihr Name: "
 
 #: alias.c:477
 #, c-format
-msgid "[%s = %s] Accept?"
-msgstr "[%s = %s] Akzeptieren?"
+msgid "Accept?"
+msgstr "Akzeptieren?"
 
 #: alias.c:488 recvattach.c:531 recvattach.c:553 recvattach.c:567
 #: recvattach.c:582 recvattach.c:681

--- a/po/el.po
+++ b/po/el.po
@@ -84,8 +84,8 @@ msgstr "Προσωπικό Όνομα: "
 
 #: alias.c:477
 #, c-format
-msgid "[%s = %s] Accept?"
-msgstr "[%s = %s] Δέχεστε;"
+msgid "Accept?"
+msgstr "Δέχεστε;"
 
 #: alias.c:488 recvattach.c:531 recvattach.c:553 recvattach.c:567
 #: recvattach.c:582 recvattach.c:681

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -80,8 +80,8 @@ msgstr "Personal name: "
 
 #: alias.c:477
 #, c-format
-msgid "[%s = %s] Accept?"
-msgstr "[%s = %s] Accept?"
+msgid "Accept?"
+msgstr "Accept?"
 
 #: alias.c:488 recvattach.c:531 recvattach.c:553 recvattach.c:567
 #: recvattach.c:582 recvattach.c:681

--- a/po/eo.po
+++ b/po/eo.po
@@ -81,8 +81,8 @@ msgstr "Plena nomo: "
 
 #: alias.c:477
 #, c-format
-msgid "[%s = %s] Accept?"
-msgstr "[%s = %s] Ĉu akcepti?"
+msgid "Accept?"
+msgstr "Ĉu akcepti?"
 
 #: alias.c:488 recvattach.c:531 recvattach.c:553 recvattach.c:567
 #: recvattach.c:582 recvattach.c:681

--- a/po/es.po
+++ b/po/es.po
@@ -83,8 +83,8 @@ msgstr "Nombre: "
 
 #: alias.c:477
 #, c-format
-msgid "[%s = %s] Accept?"
-msgstr "[%s = %s] ¿Aceptar?"
+msgid "Accept?"
+msgstr "¿Aceptar?"
 
 #: alias.c:488 recvattach.c:531 recvattach.c:553 recvattach.c:567
 #: recvattach.c:582 recvattach.c:681

--- a/po/et.po
+++ b/po/et.po
@@ -80,8 +80,8 @@ msgstr "Isiku nimi: "
 
 #: alias.c:477
 #, c-format
-msgid "[%s = %s] Accept?"
-msgstr "[%s = %s] Nõus?"
+msgid "Accept?"
+msgstr "Nõus?"
 
 #: alias.c:488 recvattach.c:531 recvattach.c:553 recvattach.c:567
 #: recvattach.c:582 recvattach.c:681

--- a/po/eu.po
+++ b/po/eu.po
@@ -81,8 +81,8 @@ msgstr "Pertsona izena: "
 
 #: alias.c:477
 #, c-format
-msgid "[%s = %s] Accept?"
-msgstr "[%s = %s] Onartu?"
+msgid "Accept?"
+msgstr "Onartu?"
 
 #: alias.c:488 recvattach.c:531 recvattach.c:553 recvattach.c:567
 #: recvattach.c:582 recvattach.c:681

--- a/po/fi.po
+++ b/po/fi.po
@@ -88,8 +88,8 @@ msgstr "Henkilönnimi: "
 
 #: alias.c:477
 #, c-format
-msgid "[%s = %s] Accept?"
-msgstr "[%s = %s] Hyväksytäänkö?"
+msgid "Accept?"
+msgstr "Hyväksytäänkö?"
 
 #: alias.c:488 recvattach.c:531 recvattach.c:553 recvattach.c:567
 #: recvattach.c:582 recvattach.c:681

--- a/po/fr.po
+++ b/po/fr.po
@@ -96,8 +96,8 @@ msgstr "Nom de la personne : "
 # , c-format
 #: alias.c:477
 #, c-format
-msgid "[%s = %s] Accept?"
-msgstr "[%s = %s] Accepter?"
+msgid "Accept?"
+msgstr "Accepter?"
 
 #: alias.c:488 recvattach.c:531 recvattach.c:553 recvattach.c:567
 #: recvattach.c:582 recvattach.c:681

--- a/po/ga.po
+++ b/po/ga.po
@@ -80,8 +80,8 @@ msgstr "Ainm pearsanta: "
 
 #: alias.c:477
 #, c-format
-msgid "[%s = %s] Accept?"
-msgstr "[%s = %s] Glac Leis?"
+msgid "Accept?"
+msgstr "Glac Leis?"
 
 #: alias.c:488 recvattach.c:531 recvattach.c:553 recvattach.c:567
 #: recvattach.c:582 recvattach.c:681

--- a/po/gl.po
+++ b/po/gl.po
@@ -80,8 +80,8 @@ msgstr "Nome persoal: "
 
 #: alias.c:477
 #, c-format
-msgid "[%s = %s] Accept?"
-msgstr "[%s = %s] ¿Aceptar?"
+msgid "Accept?"
+msgstr "¿Aceptar?"
 
 #: alias.c:488 recvattach.c:531 recvattach.c:553 recvattach.c:567
 #: recvattach.c:582 recvattach.c:681

--- a/po/hu.po
+++ b/po/hu.po
@@ -81,8 +81,8 @@ msgstr "Név: "
 
 #: alias.c:477
 #, c-format
-msgid "[%s = %s] Accept?"
-msgstr "[%s = %s] Rendben?"
+msgid "Accept?"
+msgstr "Rendben?"
 
 #: alias.c:488 recvattach.c:531 recvattach.c:553 recvattach.c:567
 #: recvattach.c:582 recvattach.c:681

--- a/po/id.po
+++ b/po/id.po
@@ -82,8 +82,8 @@ msgstr "Nama lengkap: "
 
 #: alias.c:477
 #, c-format
-msgid "[%s = %s] Accept?"
-msgstr "[%s = %s] Sudah betul?"
+msgid "Accept?"
+msgstr "Sudah betul?"
 
 #: alias.c:488 recvattach.c:531 recvattach.c:553 recvattach.c:567
 #: recvattach.c:582 recvattach.c:681

--- a/po/it.po
+++ b/po/it.po
@@ -82,8 +82,8 @@ msgstr "Nome della persona: "
 
 #: alias.c:477
 #, c-format
-msgid "[%s = %s] Accept?"
-msgstr "[%s = %s] Confermare?"
+msgid "Accept?"
+msgstr "Confermare?"
 
 #: alias.c:488 recvattach.c:531 recvattach.c:553 recvattach.c:567
 #: recvattach.c:582 recvattach.c:681

--- a/po/ja.po
+++ b/po/ja.po
@@ -81,8 +81,8 @@ msgstr "個人名: "
 
 #: alias.c:477
 #, c-format
-msgid "[%s = %s] Accept?"
-msgstr "[%s = %s] 了解?"
+msgid "Accept?"
+msgstr "了解?"
 
 #: alias.c:488 recvattach.c:531 recvattach.c:553 recvattach.c:567
 #: recvattach.c:582 recvattach.c:681

--- a/po/ko.po
+++ b/po/ko.po
@@ -82,8 +82,8 @@ msgstr "이름: "
 
 #: alias.c:477
 #, c-format
-msgid "[%s = %s] Accept?"
-msgstr "[%s = %s] 추가할까요?"
+msgid "Accept?"
+msgstr "추가할까요?"
 
 #: alias.c:488 recvattach.c:531 recvattach.c:553 recvattach.c:567
 #: recvattach.c:582 recvattach.c:681

--- a/po/lt.po
+++ b/po/lt.po
@@ -82,8 +82,8 @@ msgstr "Asmens vardas: "
 
 #: alias.c:477
 #, c-format
-msgid "[%s = %s] Accept?"
-msgstr "[%s = %s] Tinka?"
+msgid "Accept?"
+msgstr "Tinka?"
 
 #: alias.c:488 recvattach.c:531 recvattach.c:553 recvattach.c:567
 #: recvattach.c:582 recvattach.c:681

--- a/po/nl.po
+++ b/po/nl.po
@@ -81,8 +81,8 @@ msgstr "Naam: "
 
 #: alias.c:477
 #, c-format
-msgid "[%s = %s] Accept?"
-msgstr "[%s = %s] Accepteren?"
+msgid "Accept?"
+msgstr "Accepteren?"
 
 #: alias.c:488 recvattach.c:531 recvattach.c:553 recvattach.c:567
 #: recvattach.c:582 recvattach.c:681

--- a/po/pl.po
+++ b/po/pl.po
@@ -82,8 +82,8 @@ msgstr "Nazwisko: "
 
 #: alias.c:477
 #, c-format
-msgid "[%s = %s] Accept?"
-msgstr "[%s = %s] Potwierdzasz?"
+msgid "Accept?"
+msgstr "Potwierdzasz?"
 
 #: alias.c:488 recvattach.c:531 recvattach.c:553 recvattach.c:567
 #: recvattach.c:582 recvattach.c:681

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -81,8 +81,8 @@ msgstr "Nome:"
 
 #: alias.c:477
 #, c-format
-msgid "[%s = %s] Accept?"
-msgstr "[%s =%s] Aceita?"
+msgid "Accept?"
+msgstr "Aceita?"
 
 #: alias.c:488 recvattach.c:531 recvattach.c:553 recvattach.c:567
 #: recvattach.c:582 recvattach.c:681

--- a/po/ru.po
+++ b/po/ru.po
@@ -85,8 +85,8 @@ msgstr "Полное имя: "
 
 #: alias.c:477
 #, c-format
-msgid "[%s = %s] Accept?"
-msgstr "[%s = %s] Принять?"
+msgid "Accept?"
+msgstr "Принять?"
 
 #: alias.c:488 recvattach.c:531 recvattach.c:553 recvattach.c:567
 #: recvattach.c:582 recvattach.c:681

--- a/po/sk.po
+++ b/po/sk.po
@@ -81,8 +81,8 @@ msgstr "Vlastné meno: "
 
 #: alias.c:477
 #, c-format
-msgid "[%s = %s] Accept?"
-msgstr "[%s = %s] Akceptovať?"
+msgid "Accept?"
+msgstr "Akceptovať?"
 
 #: alias.c:488 recvattach.c:531 recvattach.c:553 recvattach.c:567
 #: recvattach.c:582 recvattach.c:681

--- a/po/sv.po
+++ b/po/sv.po
@@ -80,8 +80,8 @@ msgstr "Namn: "
 
 #: alias.c:477
 #, c-format
-msgid "[%s = %s] Accept?"
-msgstr "[%s = %s] Godkänn?"
+msgid "Accept?"
+msgstr "Godkänn?"
 
 #: alias.c:488 recvattach.c:531 recvattach.c:553 recvattach.c:567
 #: recvattach.c:582 recvattach.c:681

--- a/po/tr.po
+++ b/po/tr.po
@@ -82,8 +82,8 @@ msgstr "Kişisel isim: "
 
 #: alias.c:477
 #, c-format
-msgid "[%s = %s] Accept?"
-msgstr "[%s = %s] Kabul?"
+msgid "Accept?"
+msgstr "Kabul?"
 
 #: alias.c:488 recvattach.c:531 recvattach.c:553 recvattach.c:567
 #: recvattach.c:582 recvattach.c:681

--- a/po/uk.po
+++ b/po/uk.po
@@ -82,8 +82,8 @@ msgstr "Повне ім’я: "
 
 #: alias.c:477
 #, c-format
-msgid "[%s = %s] Accept?"
-msgstr "[%s = %s] Вірно?"
+msgid "Accept?"
+msgstr "Вірно?"
 
 #: alias.c:488 recvattach.c:531 recvattach.c:553 recvattach.c:567
 #: recvattach.c:582 recvattach.c:681

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -87,8 +87,8 @@ msgstr "个人姓名："
 
 #: alias.c:477
 #, c-format
-msgid "[%s = %s] Accept?"
-msgstr "[%s = %s] 接受?"
+msgid "Accept?"
+msgstr "接受?"
 
 #: alias.c:488 recvattach.c:531 recvattach.c:553 recvattach.c:567
 #: recvattach.c:582 recvattach.c:681

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -82,8 +82,8 @@ msgstr "個人姓名："
 
 #: alias.c:477
 #, c-format
-msgid "[%s = %s] Accept?"
-msgstr "[%s = %s] 接受?"
+msgid "Accept?"
+msgstr "接受?"
 
 #: alias.c:488 recvattach.c:531 recvattach.c:553 recvattach.c:567
 #: recvattach.c:582 recvattach.c:681


### PR DESCRIPTION
Three simple commits to improve the Address Book.

- ace468d9f fix formatting of address
  Bug-fix: Names with accented characters had the wrong width

- a6184dd6c add comment field
  Add a free-form comment field, after `# `, at the end of an alias,
  e.g.  `alias jim James Smith <js@example.com> # Pointy-haired boss`
  Plus an expando `%c` to display it.

- f8e7a1a3e add comment to alias_format
  Adjust the default `$alias_format` to include the comment expando.
  Priority has been given to the existing fields.
  Note: On an 80-char screen, the comment won't be visible.

- 3cd5411a0 alias: add option to save comment
  When saving an alias, allow an optional comment field