### PR TITLE
Check size of long using LONG_MAX instead of __WORDSIZE

### DIFF
--- a/test/string/mutt_str_atol.c
+++ b/test/string/mutt_str_atol.c
@@ -25,6 +25,7 @@
 #include "acutest.h"
 #include <limits.h>
 #include "mutt/lib.h"
+#include "test_common.h"
 
 struct TestValue
 {
@@ -43,7 +44,7 @@ static const struct TestValue tests[] = {
   { " 3",                   0,  3 },
   { " 3",                   0,  3 },
 
-#if (__WORDSIZE == 64)
+#if LONG_IS_64
   { "9223372036854775805",  0,  9223372036854775805 },
   { "9223372036854775806",  0,  9223372036854775806 },
   { "9223372036854775807",  0,  LONG_MAX },
@@ -59,7 +60,7 @@ static const struct TestValue tests[] = {
   { " -3",                  0,  -3 },
   { " -3",                  0,  -3 },
 
-#if (__WORDSIZE == 64)
+#if LONG_IS_64
   { "-9223372036854775806", 0,  -9223372036854775806 },
   { "-9223372036854775807", 0,  -9223372036854775807 },
   { "-9223372036854775808", 0,  LONG_MIN },
@@ -69,7 +70,7 @@ static const struct TestValue tests[] = {
   { "-2147483648",          0,  LONG_MIN },
 #endif
 
-#if (__WORDSIZE == 64)
+#if LONG_IS_64
   // Out of range tests
   { "9223372036854775808",  -2, LONG_MAX },
   { "9223372036854775809",  -2, LONG_MAX },

--- a/test/string/mutt_str_atoui.c
+++ b/test/string/mutt_str_atoui.c
@@ -25,6 +25,7 @@
 #include "acutest.h"
 #include <limits.h>
 #include "mutt/lib.h"
+#include "test_common.h"
 
 struct TestValue
 {
@@ -48,7 +49,7 @@ static const struct TestValue tests[] = {
   { "4294967295",  0,    4294967295 },
 
   // Out of range tests
-#if (__WORDSIZE == 64)
+#if LONG_IS_64
   { "4294967296",  -2,   0 },
   { "4294967297",  -2,   0 },
   { "4294967298",  -2,   0 },
@@ -60,7 +61,7 @@ static const struct TestValue tests[] = {
   { "18446744073709551616", -1, 0 },
 
   // Invalid tests
-#if (__WORDSIZE == 64)
+#if LONG_IS_64
   { "-3",          -2,   0 },
   { " -3",         -2,   0 },
   { "  -3",        -2,   0 },

--- a/test/string/mutt_str_atoul.c
+++ b/test/string/mutt_str_atoul.c
@@ -25,6 +25,7 @@
 #include "acutest.h"
 #include <limits.h>
 #include "mutt/lib.h"
+#include "test_common.h"
 
 struct TestValue
 {
@@ -43,7 +44,7 @@ static const struct TestValue tests[] = {
   { " 3",  0, 3 },
   { "  3", 0, 3 },
 
-#if (__WORDSIZE == 64)
+#if LONG_IS_64
   { "18446744073709551613",  0, 18446744073709551613UL },
   { "18446744073709551614",  0, 18446744073709551614UL },
   { "18446744073709551615",  0, 18446744073709551615UL },
@@ -53,7 +54,7 @@ static const struct TestValue tests[] = {
   { "4294967295",            0, 4294967295UL },
 #endif
 
-#if (__WORDSIZE == 64)
+#if LONG_IS_64
   // Out of range tests
   { "18446744073709551616", -1, ULONG_MAX },
   { "18446744073709551617", -1, ULONG_MAX },
@@ -66,7 +67,7 @@ static const struct TestValue tests[] = {
 #endif
 
   // Invalid tests
-#if (__WORDSIZE == 64)
+#if LONG_IS_64
   { "-3",          0,    18446744073709551613UL },
   { " -3",         0,    18446744073709551613UL },
   { "  -3",        0,    18446744073709551613UL },

--- a/test/test_common.h
+++ b/test/test_common.h
@@ -39,4 +39,6 @@ void test_init(void);
     }                                                                          \
   } while (false)
 
+#define LONG_IS_64 (LONG_MAX == 9223372036854775807)
+
 #endif /* TEST_TEST_COMMON_H */


### PR DESCRIPTION
Fixes #2344
