### PR TITLE
Rename Quiet to Verbose

### DIFF
--- a/compmbox/compress.c
+++ b/compmbox/compress.c
@@ -301,7 +301,7 @@ static int execute_command(struct Mailbox *m, const char *command, const char *p
   if (!m || !command || !progress)
     return 0;
 
-  if (!m->quiet)
+  if (m->verbose)
     mutt_message(progress, m->realpath);
 
   int rc = 1;

--- a/core/mailbox.h
+++ b/core/mailbox.h
@@ -115,7 +115,7 @@ struct Mailbox
   bool dontwrite              : 1;    ///< Don't write the mailbox on close
   bool first_check_stats_done : 1;    ///< True when the check have been done at least on time
   bool peekonly               : 1;    ///< Just taking a glance, revert atime
-  bool quiet                  : 1;    ///< Inhibit status messages?
+  bool verbose                : 1;    ///< Display status messages?
   bool readonly               : 1;    ///< Don't allow changes to the mailbox
 
   AclFlags rights;                    ///< ACL bits, see #AclFlags

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -1584,7 +1584,7 @@ int imap_fast_trash(struct Mailbox *m, char *dest)
       mutt_debug(LL_DEBUG1, "could not queue copy\n");
       goto out;
     }
-    else if (!m->quiet)
+    else if (m->verbose)
     {
       mutt_message(ngettext("Copying %d message to %s...", "Copying %d messages to %s...", rc),
                    rc, dest_mdata->name);
@@ -1692,7 +1692,7 @@ int imap_sync_mailbox(struct Mailbox *m, bool expunge, bool close)
         if (e->deleted && e->changed)
           e->active = false;
       }
-      if (!m->quiet)
+      if (m->verbose)
       {
         mutt_message(ngettext("Marking %d message deleted...",
                               "Marking %d messages deleted...", rc),
@@ -1732,7 +1732,7 @@ int imap_sync_mailbox(struct Mailbox *m, bool expunge, bool close)
       if ((e->env && e->env->changed) || e->attach_del)
       {
         /* L10N: The plural is chosen by the last %d, i.e. the total number */
-        if (!m->quiet)
+        if (m->verbose)
         {
           mutt_message(ngettext("Saving changed message... [%d/%d]",
                                 "Saving changed messages... [%d/%d]", m->msg_count),
@@ -1823,7 +1823,7 @@ int imap_sync_mailbox(struct Mailbox *m, bool expunge, bool close)
   /* We must send an EXPUNGE command if we're not closing. */
   if (expunge && !close && (m->rights & MUTT_ACL_DELETE))
   {
-    if (!m->quiet)
+    if (m->verbose)
       mutt_message(_("Expunging messages from server..."));
     /* Set expunge bit so we don't get spurious reopened messages */
     mdata->reopen |= IMAP_EXPUNGE_EXPECTED;
@@ -2064,7 +2064,7 @@ static int imap_mbox_open(struct Mailbox *m)
   m->rights = 0;
   mdata->new_mail_count = 0;
 
-  if (!m->quiet)
+  if (m->verbose)
     mutt_message(_("Selecting %s..."), mdata->name);
 
   /* pipeline ACL test */

--- a/imap/message.c
+++ b/imap/message.c
@@ -736,7 +736,7 @@ static int read_headers_normal_eval_cache(struct ImapAccountData *adata,
   struct ImapMboxData *mdata = imap_mdata_get(m);
   int idx = m->msg_count;
 
-  if (!m->quiet)
+  if (m->verbose)
   {
     /* L10N: Comparing the cached data with the IMAP server's data */
     mutt_progress_init(&progress, _("Evaluating cache..."), MUTT_PROGRESS_READ, msn_end);
@@ -758,7 +758,7 @@ static int read_headers_normal_eval_cache(struct ImapAccountData *adata,
     if (SigInt && query_abort_header_download(adata))
       return -1;
 
-    if (!m->quiet)
+    if (m->verbose)
       mutt_progress_update(&progress, msgno, -1);
 
     memset(&h, 0, sizeof(h));
@@ -950,7 +950,7 @@ static int read_headers_condstore_qresync_updates(struct ImapAccountData *adata,
   struct Mailbox *m = adata->mailbox;
   struct ImapMboxData *mdata = imap_mdata_get(m);
 
-  if (!m->quiet)
+  if (m->verbose)
   {
     /* L10N: Fetching IMAP flag changes, using the CONDSTORE extension */
     mutt_progress_init(&progress, _("Fetching flag updates..."), MUTT_PROGRESS_READ, msn_end);
@@ -967,7 +967,7 @@ static int read_headers_condstore_qresync_updates(struct ImapAccountData *adata,
     if (SigInt && query_abort_header_download(adata))
       return -1;
 
-    if (!m->quiet)
+    if (m->verbose)
       mutt_progress_update(&progress, msgno, -1);
 
     /* cmd_parse_fetch will update the flags */
@@ -1103,7 +1103,7 @@ static int read_headers_fetch_new(struct Mailbox *m, unsigned int msn_begin,
   unlink(mutt_b2s(tempfile));
   mutt_buffer_pool_release(&tempfile);
 
-  if (!m->quiet)
+  if (m->verbose)
   {
     mutt_progress_init(&progress, _("Fetching message headers..."),
                        MUTT_PROGRESS_READ, msn_end);
@@ -1136,7 +1136,7 @@ static int read_headers_fetch_new(struct Mailbox *m, unsigned int msn_begin,
       if (initial_download && SigInt && query_abort_header_download(adata))
         goto bail;
 
-      if (!m->quiet)
+      if (m->verbose)
         mutt_progress_update(&progress, msgno, -1);
 
       rewind(fp);
@@ -1509,7 +1509,7 @@ int imap_append_message(struct Mailbox *m, struct Message *msg)
   }
   rewind(fp);
 
-  if (!m->quiet)
+  if (m->verbose)
     mutt_progress_init(&progress, _("Uploading message..."), MUTT_PROGRESS_NET, len);
 
   mutt_date_make_imap(internaldate, sizeof(internaldate), msg->received);
@@ -1551,7 +1551,7 @@ int imap_append_message(struct Mailbox *m, struct Message *msg)
       sent += len;
       if (flush_buffer(buf, &len, adata->conn) < 0)
         goto fail;
-      if (!m->quiet)
+      if (m->verbose)
         mutt_progress_update(&progress, sent, -1);
     }
   }
@@ -1918,7 +1918,7 @@ int imap_msg_open(struct Mailbox *m, struct Message *msg, int msgno)
 
   /* This function is called in a few places after endwin()
    * e.g. mutt_pipe_message(). */
-  output_progress = !isendwin() && !m->quiet;
+  output_progress = !isendwin() && m->verbose;
   if (output_progress)
     mutt_message(_("Fetching message..."));
 

--- a/index.c
+++ b/index.c
@@ -1266,10 +1266,10 @@ int mutt_index_menu(struct MuttWindow *dlg)
 
         if (Context && Context->mailbox)
         {
-          bool q = Context->mailbox->quiet;
-          Context->mailbox->quiet = true;
+          bool verbose = Context->mailbox->verbose;
+          Context->mailbox->verbose = false;
           update_index(menu, Context, check, oldcount, index_hint);
-          Context->mailbox->quiet = q;
+          Context->mailbox->verbose = verbose;
           menu->max = Context->mailbox->vcount;
         }
         else
@@ -1600,12 +1600,12 @@ int mutt_index_menu(struct MuttWindow *dlg)
         if (Context->mailbox->msg_count > oldmsgcount)
         {
           struct Email *e_oldcur = get_cur_email(Context, menu);
-          bool quiet = Context->mailbox->quiet;
+          bool verbose = Context->mailbox->verbose;
 
           if (rc < 0)
-            Context->mailbox->quiet = true;
+            Context->mailbox->verbose = false;
           mutt_sort_headers(Context, (op == OP_RECONSTRUCT_THREAD));
-          Context->mailbox->quiet = quiet;
+          Context->mailbox->verbose = verbose;
 
           /* Similar to OP_MAIN_ENTIRE_THREAD, keep displaying the old message, but
             * update the index */
@@ -2222,7 +2222,7 @@ int mutt_index_menu(struct MuttWindow *dlg)
         {
           struct Progress progress;
 
-          if (!m->quiet)
+          if (m->verbose)
           {
             mutt_progress_init(&progress, _("Update tags..."),
                                MUTT_PROGRESS_WRITE, m->msg_tagged);
@@ -2240,7 +2240,7 @@ int mutt_index_menu(struct MuttWindow *dlg)
             if (!message_is_tagged(Context, e))
               continue;
 
-            if (!m->quiet)
+            if (m->verbose)
               mutt_progress_update(&progress, ++px, -1);
             mx_tags_commit(m, e, buf);
             if (op == OP_MAIN_MODIFY_TAGS_THEN_HIDE)

--- a/maildir/shared.c
+++ b/maildir/shared.c
@@ -380,7 +380,7 @@ int maildir_parse_dir(struct Mailbox *m, struct Maildir ***last,
     if (count)
     {
       (*count)++;
-      if (!m->quiet && progress)
+      if (m->verbose && progress)
         mutt_progress_update(progress, *count, -1);
     }
 
@@ -696,7 +696,7 @@ void maildir_delayed_parsing(struct Mailbox *m, struct Maildir **md, struct Prog
       continue;
     }
 
-    if (!m->quiet && progress)
+    if (m->verbose && progress)
       mutt_progress_update(progress, count, -1);
 
     if (!sort)
@@ -795,7 +795,7 @@ int mh_read_dir(struct Mailbox *m, const char *subdir)
   struct Maildir **last = NULL;
   struct Progress progress;
 
-  if (!m->quiet)
+  if (m->verbose)
   {
     char msg[PATH_MAX];
     snprintf(msg, sizeof(msg), _("Scanning %s..."), mailbox_path(m));
@@ -818,7 +818,7 @@ int mh_read_dir(struct Mailbox *m, const char *subdir)
   if (maildir_parse_dir(m, &last, subdir, &count, &progress) < 0)
     return -1;
 
-  if (!m->quiet)
+  if (m->verbose)
   {
     char msg[PATH_MAX];
     snprintf(msg, sizeof(msg), _("Reading %s..."), mailbox_path(m));
@@ -1721,7 +1721,7 @@ int mh_mbox_sync(struct Mailbox *m, int *index_hint)
     hc = mutt_hcache_open(C_HeaderCache, mailbox_path(m), NULL);
 #endif
 
-  if (!m->quiet)
+  if (m->verbose)
   {
     char msg[PATH_MAX];
     snprintf(msg, sizeof(msg), _("Writing %s..."), mailbox_path(m));
@@ -1730,7 +1730,7 @@ int mh_mbox_sync(struct Mailbox *m, int *index_hint)
 
   for (i = 0; i < m->msg_count; i++)
   {
-    if (!m->quiet)
+    if (m->verbose)
       mutt_progress_update(&progress, i, -1);
 
     if (mh_sync_mailbox_message(m, i, hc) == -1)

--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -212,7 +212,7 @@ static int mmdf_parse_mailbox(struct Mailbox *m)
 
   buf[sizeof(buf) - 1] = '\0';
 
-  if (!m->quiet)
+  if (m->verbose)
   {
     char msg[PATH_MAX];
     snprintf(msg, sizeof(msg), _("Reading %s..."), mailbox_path(m));
@@ -234,7 +234,7 @@ static int mmdf_parse_mailbox(struct Mailbox *m)
         return -1;
 
       count++;
-      if (!m->quiet)
+      if (m->verbose)
         mutt_progress_update(&progress, count, (int) (loc / (m->size / 100 + 1)));
 
       if (m->msg_count == m->email_max)
@@ -378,7 +378,7 @@ static int mbox_parse_mailbox(struct Mailbox *m)
   if (!m->readonly)
     m->readonly = access(mailbox_path(m), W_OK) ? true : false;
 
-  if (!m->quiet)
+  if (m->verbose)
   {
     char msg[PATH_MAX];
     snprintf(msg, sizeof(msg), _("Reading %s..."), mailbox_path(m));
@@ -406,7 +406,7 @@ static int mbox_parse_mailbox(struct Mailbox *m)
 
       count++;
 
-      if (!m->quiet)
+      if (m->verbose)
       {
         mutt_progress_update(&progress, count,
                              (int) (ftello(adata->fp) / (m->size / 100 + 1)));
@@ -556,7 +556,7 @@ static int reopen_mailbox(struct Mailbox *m, int *index_hint)
   int rc = -1;
 
   /* silent operations */
-  m->quiet = true;
+  m->verbose = false;
 
   /* our heuristics require the old mailbox to be unsorted */
   if (C_Sort != SORT_ORDER)
@@ -629,7 +629,7 @@ static int reopen_mailbox(struct Mailbox *m, int *index_hint)
       email_free(&(e_old[i]));
     FREE(&e_old);
 
-    m->quiet = false;
+    m->verbose = true;
     return -1;
   }
 
@@ -710,7 +710,7 @@ static int reopen_mailbox(struct Mailbox *m, int *index_hint)
   }
 
   mailbox_changed(m, NT_MAILBOX_UPDATE);
-  m->quiet = false;
+  m->verbose = true;
 
   return (m->changed || msg_mod) ? MUTT_REOPENED : MUTT_NEW_MAIL;
 }
@@ -1277,7 +1277,7 @@ static int mbox_mbox_sync(struct Mailbox *m, int *index_hint)
   new_offset = mutt_mem_calloc(m->msg_count - first, sizeof(struct MUpdate));
   old_offset = mutt_mem_calloc(m->msg_count - first, sizeof(struct MUpdate));
 
-  if (!m->quiet)
+  if (m->verbose)
   {
     char msg[PATH_MAX];
     snprintf(msg, sizeof(msg), _("Writing %s..."), mailbox_path(m));
@@ -1286,7 +1286,7 @@ static int mbox_mbox_sync(struct Mailbox *m, int *index_hint)
 
   for (i = first, j = 0; i < m->msg_count; i++)
   {
-    if (!m->quiet)
+    if (m->verbose)
       mutt_progress_update(&progress, i, (int) (ftello(adata->fp) / (m->size / 100 + 1)));
     /* back up some information which is needed to restore offsets when
      * something fails.  */
@@ -1398,7 +1398,7 @@ static int mbox_mbox_sync(struct Mailbox *m, int *index_hint)
     {
       /* copy the temp mailbox back into place starting at the first
        * change/deleted message */
-      if (!m->quiet)
+      if (m->verbose)
         mutt_message(_("Committing changes..."));
       i = mutt_file_copy_stream(fp, adata->fp);
 

--- a/mx.c
+++ b/mx.c
@@ -301,7 +301,7 @@ struct Context *mx_mbox_open(struct Mailbox *m, OpenMailboxFlags flags)
   ctx->msg_not_read_yet = -1;
   ctx->collapsed = false;
 
-  m->quiet = (flags & MUTT_QUIET);
+  m->verbose = !(flags & MUTT_QUIET);
   if (flags & MUTT_READONLY)
     m->readonly = true;
   m->peekonly = (flags & MUTT_PEEK);
@@ -349,7 +349,7 @@ struct Context *mx_mbox_open(struct Mailbox *m, OpenMailboxFlags flags)
    * flag to indicate that we should really refresh the screen.  */
   OptForceRefresh = true;
 
-  if (!m->quiet)
+  if (m->verbose)
     mutt_message(_("Reading %s..."), mailbox_path(m));
 
   // Clear out any existing emails
@@ -380,7 +380,7 @@ struct Context *mx_mbox_open(struct Mailbox *m, OpenMailboxFlags flags)
       OptSortSubthreads = false;
       OptNeedRescore = false;
     }
-    if (!m->quiet)
+    if (m->verbose)
       mutt_clear_error();
     if (rc == -2)
     {
@@ -455,7 +455,7 @@ static int sync_mailbox(struct Mailbox *m, int *index_hint)
   if (!m || !m->mx_ops || !m->mx_ops->mbox_sync)
     return -1;
 
-  if (!m->quiet)
+  if (m->verbose)
   {
     /* L10N: Displayed before/as a mailbox is being synced */
     mutt_message(_("Writing %s..."), mailbox_path(m));
@@ -465,7 +465,7 @@ static int sync_mailbox(struct Mailbox *m, int *index_hint)
   if (rc != 0)
   {
     mutt_debug(LL_DEBUG2, "mbox_sync returned: %d\n", rc);
-    if ((rc < 0) && !m->quiet)
+    if ((rc < 0) && m->verbose)
     {
       /* L10N: Displayed if a mailbox sync fails */
       mutt_error(_("Unable to write %s"), mailbox_path(m));
@@ -710,7 +710,7 @@ int mx_mbox_close(struct Context **ptr)
 
   if (move_messages)
   {
-    if (!m->quiet)
+    if (m->verbose)
       mutt_message(_("Moving read messages to %s..."), mutt_b2s(mbox));
 
 #ifdef USE_IMAP
@@ -781,7 +781,7 @@ int mx_mbox_close(struct Context **ptr)
   }
   else if (!m->changed && (m->msg_deleted == 0))
   {
-    if (!m->quiet)
+    if (m->verbose)
       mutt_message(_("Mailbox is unchanged"));
     if ((m->type == MUTT_MBOX) || (m->type == MUTT_MMDF))
       mbox_reset_atime(m, NULL);
@@ -838,7 +838,7 @@ int mx_mbox_close(struct Context **ptr)
     }
   }
 
-  if (!m->quiet)
+  if (m->verbose)
   {
     if (move_messages)
     {
@@ -926,7 +926,7 @@ int mx_mbox_sync(struct Mailbox *m, int *index_hint)
 
   if (!m->changed && (m->msg_deleted == 0))
   {
-    if (!m->quiet)
+    if (m->verbose)
       mutt_message(_("Mailbox is unchanged"));
     return 0;
   }
@@ -985,13 +985,13 @@ int mx_mbox_sync(struct Mailbox *m, int *index_hint)
 #ifdef USE_IMAP
     if ((m->type == MUTT_IMAP) && !purge)
     {
-      if (!m->quiet)
+      if (m->verbose)
         mutt_message(_("Mailbox checkpointed"));
     }
     else
 #endif
     {
-      if (!m->quiet)
+      if (m->verbose)
         mutt_message(_("%d kept, %d deleted"), msgcount - deleted, deleted);
     }
 

--- a/nntp/nntp.c
+++ b/nntp/nntp.c
@@ -1131,7 +1131,7 @@ static int parse_overview_line(char *line, void *data)
   if (!fc->messages[anum - fc->first])
   {
     /* progress */
-    if (!m->quiet)
+    if (m->verbose)
       mutt_progress_update(&fc->progress, anum - fc->first + 1, -1);
     return 0;
   }
@@ -1242,7 +1242,7 @@ static int parse_overview_line(char *line, void *data)
     email_free(&e);
 
   /* progress */
-  if (!m->quiet)
+  if (m->verbose)
     mutt_progress_update(&fc->progress, anum - fc->first + 1, -1);
   return 0;
 }
@@ -1287,7 +1287,7 @@ static int nntp_fetch_headers(struct Mailbox *m, void *hc, anum_t first, anum_t 
   /* fetch list of articles */
   if (C_NntpListgroup && mdata->adata->hasLISTGROUP && !mdata->deleted)
   {
-    if (!m->quiet)
+    if (m->verbose)
       mutt_message(_("Fetching list of articles..."));
     if (mdata->adata->hasLISTGROUPrange)
       snprintf(buf, sizeof(buf), "LISTGROUP %s %u-%u\r\n", mdata->group, first, last);
@@ -1329,14 +1329,14 @@ static int nntp_fetch_headers(struct Mailbox *m, void *hc, anum_t first, anum_t 
   }
 
   /* fetching header from cache or server, or fallback to fetch overview */
-  if (!m->quiet)
+  if (m->verbose)
   {
     mutt_progress_init(&fc.progress, _("Fetching message headers..."),
                        MUTT_PROGRESS_READ, last - first + 1);
   }
   for (current = first; current <= last && rc == 0; current++)
   {
-    if (!m->quiet)
+    if (m->verbose)
       mutt_progress_update(&fc.progress, current - first + 1, -1);
 
 #ifdef USE_HCACHE
@@ -1707,8 +1707,8 @@ static int check_mailbox(struct Mailbox *m)
   if (mdata->last_message > mdata->last_loaded)
   {
     int oldmsgcount = m->msg_count;
-    bool quiet = m->quiet;
-    m->quiet = true;
+    bool verbose = m->verbose;
+    m->verbose = false;
 #ifdef USE_HCACHE
     if (!hc)
     {
@@ -1718,7 +1718,7 @@ static int check_mailbox(struct Mailbox *m)
 #endif
     int old_msg_count = m->msg_count;
     rc2 = nntp_fetch_headers(m, hc, mdata->last_loaded + 1, mdata->last_message, false);
-    m->quiet = quiet;
+    m->verbose = verbose;
     if (rc2 == 0)
     {
       if (m->msg_count > old_msg_count)
@@ -2304,7 +2304,6 @@ int nntp_check_children(struct Mailbox *m, const char *msgid)
   struct ChildCtx cc;
   char buf[256];
   int rc;
-  bool quiet;
   void *hc = NULL;
 
   if (!mdata || !mdata->adata)
@@ -2339,8 +2338,8 @@ int nntp_check_children(struct Mailbox *m, const char *msgid)
   }
 
   /* fetch all found messages */
-  quiet = m->quiet;
-  m->quiet = true;
+  bool verbose = m->verbose;
+  m->verbose = false;
 #ifdef USE_HCACHE
   hc = nntp_hcache_open(mdata);
 #endif
@@ -2357,7 +2356,7 @@ int nntp_check_children(struct Mailbox *m, const char *msgid)
 #ifdef USE_HCACHE
   mutt_hcache_close(hc);
 #endif
-  m->quiet = quiet;
+  m->verbose = verbose;
   FREE(&cc.child);
   return (rc < 0) ? -1 : 0;
 }

--- a/notmuch/mutt_notmuch.c
+++ b/notmuch/mutt_notmuch.c
@@ -826,7 +826,7 @@ static const char *get_message_last_filename(notmuch_message_t *msg)
  */
 static void progress_reset(struct Mailbox *m)
 {
-  if (m->quiet)
+  if (!m->verbose)
     return;
 
   struct NmMboxData *mdata = nm_mdata_get(m);
@@ -849,7 +849,7 @@ static void progress_update(struct Mailbox *m, notmuch_query_t *q)
 {
   struct NmMboxData *mdata = nm_mdata_get(m);
 
-  if (m->quiet || !mdata || mdata->noprogress)
+  if (!m->verbose || !mdata || mdata->noprogress)
     return;
 
   if (!mdata->progress_ready && q)
@@ -2348,7 +2348,7 @@ static int nm_mbox_sync(struct Mailbox *m, int *index_hint)
 
   mutt_debug(LL_DEBUG1, "nm: sync start\n");
 
-  if (!m->quiet)
+  if (m->verbose)
   {
     /* all is in this function so we don't use data->progress here */
     char msg[PATH_MAX];
@@ -2367,7 +2367,7 @@ static int nm_mbox_sync(struct Mailbox *m, int *index_hint)
 
     struct NmEmailData *edata = e->edata;
 
-    if (!m->quiet)
+    if (m->verbose)
       mutt_progress_update(&progress, i, -1);
 
     *old_file = '\0';

--- a/pager.c
+++ b/pager.c
@@ -2397,10 +2397,10 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
 
             index_hint = e->index;
 
-            bool q = Context->mailbox->quiet;
-            Context->mailbox->quiet = true;
+            bool verbose = Context->mailbox->verbose;
+            Context->mailbox->verbose = false;
             update_index(rd.menu, Context, check, oldcount, index_hint);
-            Context->mailbox->quiet = q;
+            Context->mailbox->verbose = verbose;
 
             rd.menu->max = Context->mailbox->vcount;
 

--- a/pop/pop.c
+++ b/pop/pop.c
@@ -422,7 +422,7 @@ static int pop_fetch_headers(struct Mailbox *m)
     }
   }
 
-  if (!m->quiet)
+  if (m->verbose)
   {
     mutt_progress_init(&progress, _("Fetching message headers..."),
                        MUTT_PROGRESS_READ, new_count - old_count);
@@ -451,7 +451,7 @@ static int pop_fetch_headers(struct Mailbox *m)
     bool hcached = false;
     for (i = old_count; i < new_count; i++)
     {
-      if (!m->quiet)
+      if (m->verbose)
         mutt_progress_update(&progress, i + 1 - old_count, -1);
       struct PopEmailData *edata = pop_edata_get(m->emails[i]);
 #ifdef USE_HCACHE
@@ -963,7 +963,7 @@ static int pop_mbox_sync(struct Mailbox *m, int *index_hint)
       if (m->emails[i]->deleted && (edata->refno != -1))
       {
         j++;
-        if (!m->quiet)
+        if (m->verbose)
           mutt_progress_update(&progress, j, -1);
         snprintf(buf, sizeof(buf), "DELE %d\r\n", edata->refno);
         rc = pop_query(adata, buf, sizeof(buf));

--- a/query.c
+++ b/query.c
@@ -144,11 +144,11 @@ static void query_free(struct Query **query)
 
 /**
  * run_query - Run an external program to find Addresses
- * @param s     String to match
- * @param quiet If true, don't print progress messages
+ * @param s       String to match
+ * @param verbose If true, print progress messages
  * @retval ptr Query List of results
  */
-static struct Query *run_query(char *s, bool quiet)
+static struct Query *run_query(char *s, bool verbose)
 {
   FILE *fp = NULL;
   struct Query *first = NULL;
@@ -172,7 +172,7 @@ static struct Query *run_query(char *s, bool quiet)
   }
   mutt_buffer_pool_release(&cmd);
 
-  if (!quiet)
+  if (verbose)
     mutt_message(_("Waiting for response..."));
 
   /* The query protocol first reads one NL-terminated line. If an error
@@ -210,12 +210,12 @@ static struct Query *run_query(char *s, bool quiet)
   if (filter_wait(pid))
   {
     mutt_debug(LL_DEBUG1, "Error: %s\n", msg);
-    if (!quiet)
+    if (verbose)
       mutt_error("%s", msg);
   }
   else
   {
-    if (!quiet)
+    if (verbose)
       mutt_message("%s", msg);
   }
   FREE(&msg);
@@ -363,7 +363,7 @@ static void query_menu(char *buf, size_t buflen, struct Query *results, bool ret
     if ((mutt_get_field(_("Query: "), buf, buflen, MUTT_COMP_NO_FLAGS) == 0) &&
         (buf[0] != '\0'))
     {
-      results = run_query(buf, false);
+      results = run_query(buf, true);
       if (!results)
         return;
     }
@@ -451,7 +451,7 @@ static void query_menu(char *buf, size_t buflen, struct Query *results, bool ret
           break;
         }
 
-        struct Query *newresults = run_query(buf, false);
+        struct Query *newresults = run_query(buf, true);
 
         menu->redraw = REDRAW_FULL;
         if (newresults)
@@ -678,7 +678,7 @@ int mutt_query_complete(char *buf, size_t buflen)
     return 0;
   }
 
-  struct Query *results = run_query(buf, true);
+  struct Query *results = run_query(buf, false);
   if (results)
   {
     /* only one response? */

--- a/sort.c
+++ b/sort.c
@@ -383,7 +383,7 @@ void mutt_sort_headers(struct Context *ctx, bool init)
     return; /* nothing to do! */
   }
 
-  if (!m->quiet)
+  if (m->verbose)
     mutt_message(_("Sorting mailbox..."));
 
   if (OptNeedRescore && C_Score)
@@ -468,6 +468,6 @@ void mutt_sort_headers(struct Context *ctx, bool init)
     mutt_set_vnum(ctx);
   }
 
-  if (!m->quiet)
+  if (m->verbose)
     mutt_clear_error();
 }


### PR DESCRIPTION
Invert the `Mailbox->quiet` logic to reduce the number of negative `if`s.

There are ~60 uses of the `quiet` flag, but the vast majority are of the form:

```c
if (!m->quiet)
  mutt_message();
```

This is replaced by:

```c
if (m->verbose)
  mutt_message();
```

---

Ultimately, this flag shouldn't be part of `Mailbox` but removing it will take some time.