### PR TITLE
Refactor unsafe TAILQ returns

### DIFF
--- a/browser.c
+++ b/browser.c
@@ -775,7 +775,8 @@ static int examine_directory(struct Menu *menu, struct BrowserState *state,
 
     init_state(state, menu);
 
-    struct MailboxList ml = neomutt_mailboxlist_get_all(NeoMutt, MUTT_MAILBOX_ANY);
+    struct MailboxList ml = STAILQ_HEAD_INITIALIZER(ml);
+    neomutt_mailboxlist_get_all(&ml, NeoMutt, MUTT_MAILBOX_ANY);
     while ((de = readdir(dp)))
     {
       if (mutt_str_strcmp(de->d_name, ".") == 0)
@@ -866,7 +867,8 @@ static int examine_mailboxes(struct Menu *menu, struct BrowserState *state)
     md = mutt_buffer_pool_get();
     mutt_mailbox_check(Context ? Context->mailbox : NULL, 0);
 
-    struct MailboxList ml = neomutt_mailboxlist_get_all(NeoMutt, MUTT_MAILBOX_ANY);
+    struct MailboxList ml = STAILQ_HEAD_INITIALIZER(ml);
+    neomutt_mailboxlist_get_all(&ml, NeoMutt, MUTT_MAILBOX_ANY);
     struct MailboxNode *np = NULL;
     STAILQ_FOREACH(np, &ml, entries)
     {

--- a/command_parse.c
+++ b/command_parse.c
@@ -1921,7 +1921,8 @@ enum CommandResult parse_unmailboxes(struct Buffer *buf, struct Buffer *s,
       tmp_valid = true;
     }
 
-    struct MailboxList ml = neomutt_mailboxlist_get_all(NeoMutt, MUTT_MAILBOX_ANY);
+    struct MailboxList ml = STAILQ_HEAD_INITIALIZER(ml);
+    neomutt_mailboxlist_get_all(&ml, NeoMutt, MUTT_MAILBOX_ANY);
     struct MailboxNode *np = NULL;
     struct MailboxNode *nptmp = NULL;
     STAILQ_FOREACH_SAFE(np, &ml, entries, nptmp)

--- a/core/mailbox.c
+++ b/core/mailbox.c
@@ -96,7 +96,8 @@ struct Mailbox *mailbox_find(const char *path)
   if (stat(path, &sb) != 0)
     return NULL;
 
-  struct MailboxList ml = neomutt_mailboxlist_get_all(NeoMutt, MUTT_MAILBOX_ANY);
+  struct MailboxList ml = STAILQ_HEAD_INITIALIZER(ml);
+  neomutt_mailboxlist_get_all(&ml, NeoMutt, MUTT_MAILBOX_ANY);
   struct MailboxNode *np = NULL;
   struct Mailbox *m = NULL;
   STAILQ_FOREACH(np, &ml, entries)
@@ -126,7 +127,8 @@ struct Mailbox *mailbox_find_name(const char *name)
   if (!name)
     return NULL;
 
-  struct MailboxList ml = neomutt_mailboxlist_get_all(NeoMutt, MUTT_MAILBOX_ANY);
+  struct MailboxList ml = STAILQ_HEAD_INITIALIZER(ml);
+  neomutt_mailboxlist_get_all(&ml, NeoMutt, MUTT_MAILBOX_ANY);
   struct MailboxNode *np = NULL;
   struct Mailbox *m = NULL;
   STAILQ_FOREACH(np, &ml, entries)

--- a/core/neomutt.c
+++ b/core/neomutt.c
@@ -148,18 +148,20 @@ void neomutt_mailboxlist_clear(struct MailboxList *ml)
 
 /**
  * neomutt_mailboxlist_get_all - Get a List of all Mailboxes
+ * @param head List to store the Mailboxes
  * @param n    NeoMutt
  * @param type Type of Account to match, see #MailboxType
- * @retval obj List of Mailboxes
+ * @retval num Number of Mailboxes in the List
  *
  * @note If type is #MUTT_MAILBOX_ANY then all Mailbox types will be matched
  */
-struct MailboxList neomutt_mailboxlist_get_all(struct NeoMutt *n, enum MailboxType type)
+size_t neomutt_mailboxlist_get_all(struct MailboxList *head, struct NeoMutt *n,
+                                   enum MailboxType type)
 {
-  struct MailboxList ml = STAILQ_HEAD_INITIALIZER(ml);
   if (!n)
-    return ml;
+    return 0;
 
+  size_t count = 0;
   struct Account *a = NULL;
   struct MailboxNode *mn = NULL;
 
@@ -172,9 +174,10 @@ struct MailboxList neomutt_mailboxlist_get_all(struct NeoMutt *n, enum MailboxTy
     {
       struct MailboxNode *mn2 = mutt_mem_calloc(1, sizeof(*mn2));
       mn2->mailbox = mn->mailbox;
-      STAILQ_INSERT_TAIL(&ml, mn2, entries);
+      STAILQ_INSERT_TAIL(head, mn2, entries);
+      count++;
     }
   }
 
-  return ml;
+  return count;
 }

--- a/core/neomutt.h
+++ b/core/neomutt.h
@@ -56,7 +56,7 @@ bool            neomutt_account_remove(struct NeoMutt *n, struct Account *a);
 void            neomutt_free          (struct NeoMutt **ptr);
 struct NeoMutt *neomutt_new           (struct ConfigSet *cs);
 
-void               neomutt_mailboxlist_clear  (struct MailboxList *ml);
-struct MailboxList neomutt_mailboxlist_get_all(struct NeoMutt *n, enum MailboxType type);
+void   neomutt_mailboxlist_clear  (struct MailboxList *ml);
+size_t neomutt_mailboxlist_get_all(struct MailboxList *head, struct NeoMutt *n, enum MailboxType type);
 
 #endif /* MUTT_CORE_NEOMUTT_H */

--- a/email/rfc2231.c
+++ b/email/rfc2231.c
@@ -319,20 +319,19 @@ void rfc2231_decode_parameters(struct ParameterList *pl)
 
 /**
  * rfc2231_encode_string - Encode a string to be suitable for an RFC2231 header
+ * @param head      String encoded as a ParameterList, empty on error
  * @param attribute Name of attribute to encode
  * @param value     Value of attribute to encode
- * @retval obj String encoded as a ParameterList, empty on error
+ * @retval num Number of Parameters in the List
  *
  * If the value is large, the list will contain continuation lines.
  */
-struct ParameterList rfc2231_encode_string(const char *attribute, char *value)
+size_t rfc2231_encode_string(struct ParameterList *head, const char *attribute, char *value)
 {
-  struct ParameterList pl;
-  TAILQ_INIT(&pl);
-
   if (!attribute || !value)
-    return pl;
+    return 0;
 
+  size_t count = 0;
   bool encode = false;
   bool add_quotes = false;
   bool free_src_value = false;
@@ -428,7 +427,8 @@ struct ParameterList rfc2231_encode_string(const char *attribute, char *value)
   while (*cur)
   {
     current = mutt_param_new();
-    TAILQ_INSERT_TAIL(&pl, current, entries);
+    TAILQ_INSERT_TAIL(head, current, entries);
+    count++;
 
     mutt_buffer_strcpy(cur_attribute, attribute);
     if (split)
@@ -477,5 +477,5 @@ struct ParameterList rfc2231_encode_string(const char *attribute, char *value)
   if (free_src_value)
     FREE(&src_value);
 
-  return pl;
+  return count;
 }

--- a/email/rfc2231.h
+++ b/email/rfc2231.h
@@ -30,7 +30,7 @@ struct ParameterList;
 /* These Config Variables are only used in rfc2231.c */
 extern bool C_Rfc2047Parameters;
 
-void                 rfc2231_decode_parameters(struct ParameterList *pl);
-struct ParameterList rfc2231_encode_string    (const char *attribute, char *value);
+void   rfc2231_decode_parameters(struct ParameterList *pl);
+size_t rfc2231_encode_string    (struct ParameterList *head, const char *attribute, char *value);
 
 #endif /* MUTT_EMAIL_RFC2231_H */

--- a/email/tags.c
+++ b/email/tags.c
@@ -189,7 +189,8 @@ bool driver_tags_replace(struct TagList *head, char *tags)
 
   if (tags)
   {
-    struct ListHead hsplit = mutt_list_str_split(tags, ' ');
+    struct ListHead hsplit = STAILQ_HEAD_INITIALIZER(hsplit);
+    mutt_list_str_split(&hsplit, tags, ' ');
     struct ListNode *np = NULL;
     STAILQ_FOREACH(np, &hsplit, entries)
     {

--- a/imap/browse.c
+++ b/imap/browse.c
@@ -112,7 +112,8 @@ static void add_folder(char delim, char *folder, bool noselect, bool noinferiors
   (state->entry)[state->entrylen].selectable = !noselect;
   (state->entry)[state->entrylen].inferiors = !noinferiors;
 
-  struct MailboxList ml = neomutt_mailboxlist_get_all(NeoMutt, MUTT_MAILBOX_ANY);
+  struct MailboxList ml = STAILQ_HEAD_INITIALIZER(ml);
+  neomutt_mailboxlist_get_all(&ml, NeoMutt, MUTT_MAILBOX_ANY);
   struct MailboxNode *np = NULL;
   STAILQ_FOREACH(np, &ml, entries)
   {
@@ -206,7 +207,8 @@ int imap_browse(const char *path, struct BrowserState *state)
   C_ImapCheckSubscribed = false;
 
   // Pick first mailbox connected to the same server
-  struct MailboxList ml = neomutt_mailboxlist_get_all(NeoMutt, MUTT_IMAP);
+  struct MailboxList ml = STAILQ_HEAD_INITIALIZER(ml);
+  neomutt_mailboxlist_get_all(&ml, NeoMutt, MUTT_IMAP);
   struct MailboxNode *np = NULL;
   STAILQ_FOREACH(np, &ml, entries)
   {

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -372,7 +372,8 @@ static int complete_hosts(char *buf, size_t buflen)
   size_t matchlen;
 
   matchlen = mutt_str_strlen(buf);
-  struct MailboxList ml = neomutt_mailboxlist_get_all(NeoMutt, MUTT_MAILBOX_ANY);
+  struct MailboxList ml = STAILQ_HEAD_INITIALIZER(ml);
+  neomutt_mailboxlist_get_all(&ml, NeoMutt, MUTT_MAILBOX_ANY);
   struct MailboxNode *np = NULL;
   STAILQ_FOREACH(np, &ml, entries)
   {

--- a/init.c
+++ b/init.c
@@ -952,7 +952,8 @@ int mutt_init(struct ConfigSet *cs, bool skip_sys_rc, struct ListHead *commands)
   if (C_VirtualSpoolfile)
   {
     /* Find the first virtual folder and open it */
-    struct MailboxList ml = neomutt_mailboxlist_get_all(NeoMutt, MUTT_NOTMUCH);
+    struct MailboxList ml = STAILQ_HEAD_INITIALIZER(ml);
+    neomutt_mailboxlist_get_all(&ml, NeoMutt, MUTT_NOTMUCH);
     struct MailboxNode *mp = STAILQ_FIRST(&ml);
     if (mp)
       cs_str_string_set(cs, "spoolfile", mailbox_path(mp->mailbox), NULL);

--- a/mutt/list.c
+++ b/mutt/list.c
@@ -240,23 +240,25 @@ bool mutt_list_compare(const struct ListHead *ah, const struct ListHead *bh)
 
 /**
  * mutt_list_str_split - Split a string into a list using a separator char
- * @param src String to split
- * @param sep Word separator
+ * @param head List to add to
+ * @param src  String to split
+ * @param sep  Word separator
+ * @retval num Number of items in list
  */
-struct ListHead mutt_list_str_split(const char *src, char sep)
+size_t mutt_list_str_split(struct ListHead *head, const char *src, char sep)
 {
-  struct ListHead head = STAILQ_HEAD_INITIALIZER(head);
-
   if (!src || !*src)
-    return head;
+    return 0;
 
+  size_t count = 0;
   while (true)
   {
     const char *start = src;
     while (*src && (*src != sep))
       src++;
 
-    mutt_list_insert_tail(&head, mutt_str_substr_dup(start, src));
+    mutt_list_insert_tail(head, mutt_str_substr_dup(start, src));
+    count++;
 
     if (!*src)
       break;
@@ -264,5 +266,5 @@ struct ListHead mutt_list_str_split(const char *src, char sep)
     src++;
   }
 
-  return head;
+  return count;
 }

--- a/mutt/list.h
+++ b/mutt/list.h
@@ -52,6 +52,6 @@ struct ListNode *mutt_list_insert_after(struct ListHead *h, struct ListNode *n, 
 struct ListNode *mutt_list_insert_head(struct ListHead *h, char *s);
 struct ListNode *mutt_list_insert_tail(struct ListHead *h, char *s);
 bool             mutt_list_match(const char *s, struct ListHead *h);
-struct ListHead  mutt_list_str_split(const char *src, char sep);
+size_t           mutt_list_str_split(struct ListHead *head, const char *src, char sep);
 
 #endif /* MUTT_LIB_LIST_H */

--- a/mutt_mailbox.c
+++ b/mutt_mailbox.c
@@ -193,7 +193,8 @@ int mutt_mailbox_check(struct Mailbox *m_cur, int force)
     contex_sb.st_ino = 0;
   }
 
-  struct MailboxList ml = neomutt_mailboxlist_get_all(NeoMutt, MUTT_MAILBOX_ANY);
+  struct MailboxList ml = STAILQ_HEAD_INITIALIZER(ml);
+  neomutt_mailboxlist_get_all(&ml, NeoMutt, MUTT_MAILBOX_ANY);
   struct MailboxNode *np = NULL;
   STAILQ_FOREACH(np, &ml, entries)
   {
@@ -239,7 +240,8 @@ bool mutt_mailbox_list(void)
 
   mailboxlist[0] = '\0';
   pos += strlen(strncat(mailboxlist, _("New mail in "), sizeof(mailboxlist) - 1 - pos));
-  struct MailboxList ml = neomutt_mailboxlist_get_all(NeoMutt, MUTT_MAILBOX_ANY);
+  struct MailboxList ml = STAILQ_HEAD_INITIALIZER(ml);
+  neomutt_mailboxlist_get_all(&ml, NeoMutt, MUTT_MAILBOX_ANY);
   struct MailboxNode *np = NULL;
   STAILQ_FOREACH(np, &ml, entries)
   {
@@ -326,7 +328,8 @@ struct Mailbox *mutt_mailbox_next(struct Mailbox *m_cur, struct Buffer *s)
     bool found = false;
     for (int pass = 0; pass < 2; pass++)
     {
-      struct MailboxList ml = neomutt_mailboxlist_get_all(NeoMutt, MUTT_MAILBOX_ANY);
+      struct MailboxList ml = STAILQ_HEAD_INITIALIZER(ml);
+      neomutt_mailboxlist_get_all(&ml, NeoMutt, MUTT_MAILBOX_ANY);
       struct MailboxNode *np = NULL;
       STAILQ_FOREACH(np, &ml, entries)
       {

--- a/sendlib.c
+++ b/sendlib.c
@@ -419,7 +419,8 @@ int mutt_write_mime_header(struct Body *a, FILE *fp)
       if (!np->attribute || !np->value)
         continue;
 
-      struct ParameterList pl_conts = rfc2231_encode_string(np->attribute, np->value);
+      struct ParameterList pl_conts = TAILQ_HEAD_INITIALIZER(pl_conts);
+      rfc2231_encode_string(&pl_conts, np->attribute, np->value);
       struct Parameter *cont = NULL;
       TAILQ_FOREACH(cont, &pl_conts, entries)
       {
@@ -486,7 +487,8 @@ int mutt_write_mime_header(struct Body *a, FILE *fp)
           else
             t = fn;
 
-          struct ParameterList pl_conts = rfc2231_encode_string("filename", t);
+          struct ParameterList pl_conts = TAILQ_HEAD_INITIALIZER(pl_conts);
+          rfc2231_encode_string(&pl_conts, "filename", t);
           struct Parameter *cont = NULL;
           TAILQ_FOREACH(cont, &pl_conts, entries)
           {

--- a/sidebar.c
+++ b/sidebar.c
@@ -445,7 +445,8 @@ static void unsort_entries(void)
 {
   int i = 0;
 
-  struct MailboxList ml = neomutt_mailboxlist_get_all(NeoMutt, MUTT_MAILBOX_ANY);
+  struct MailboxList ml = STAILQ_HEAD_INITIALIZER(ml);
+  neomutt_mailboxlist_get_all(&ml, NeoMutt, MUTT_MAILBOX_ANY);
   struct MailboxNode *np = NULL;
   STAILQ_FOREACH(np, &ml, entries)
   {
@@ -1170,7 +1171,8 @@ void sb_draw(struct MuttWindow *win)
 
   if (!Entries)
   {
-    struct MailboxList ml = neomutt_mailboxlist_get_all(NeoMutt, MUTT_MAILBOX_ANY);
+    struct MailboxList ml = STAILQ_HEAD_INITIALIZER(ml);
+    neomutt_mailboxlist_get_all(&ml, NeoMutt, MUTT_MAILBOX_ANY);
     struct MailboxNode *np = NULL;
     STAILQ_FOREACH(np, &ml, entries)
     {

--- a/test/list/mutt_list_str_split.c
+++ b/test/list/mutt_list_str_split.c
@@ -44,10 +44,12 @@ void print_compared_list(struct ListHead expected, struct ListHead actual)
 
 void test_mutt_list_str_split(void)
 {
-  // struct ListHead mutt_list_str_split(const char *src, char sep);
+  // size_t mutt_list_str_split(struct ListHead *head, const char *src, char sep);
 
   {
-    struct ListHead head = mutt_list_str_split(NULL, ',');
+    struct ListHead head = STAILQ_HEAD_INITIALIZER(head);
+    size_t count = mutt_list_str_split(&head, NULL, ',');
+    TEST_CHECK(count == 0);
     TEST_CHECK(STAILQ_EMPTY(&head));
   }
 
@@ -60,32 +62,43 @@ void test_mutt_list_str_split(void)
   char *empty = "";
 
   { // Check NULL conditions
-    struct ListHead retval1 = mutt_list_str_split(NULL, ' ');
-    struct ListHead retval2 = mutt_list_str_split(empty, ' ');
+    size_t count = 0;
 
-    if (!TEST_CHECK(STAILQ_EMPTY(&retval1)))
+    struct ListHead retval1 = STAILQ_HEAD_INITIALIZER(retval1);
+    count = mutt_list_str_split(&retval1, NULL, ' ');
+    if (!TEST_CHECK(STAILQ_EMPTY(&retval1)) || (count != 0))
       TEST_MSG("Expected: empty");
-    if (!TEST_CHECK(STAILQ_EMPTY(&retval2)))
+
+    struct ListHead retval2 = STAILQ_HEAD_INITIALIZER(retval2);
+    count = mutt_list_str_split(&retval2, empty, ' ');
+    if (!TEST_CHECK(STAILQ_EMPTY(&retval2)) || (count != 0))
       TEST_MSG("Expected: empty");
   }
 
   { // Check different words
-    struct ListHead retval1 = mutt_list_str_split(one_word, ' ');
-    struct ListHead retval2 = mutt_list_str_split(two_words, ' ');
-    struct ListHead retval3 = mutt_list_str_split(words, ' ');
-    struct ListHead retval4 = mutt_list_str_split(ending_sep, ' ');
-    struct ListHead retval5 = mutt_list_str_split(starting_sep, ' ');
-    struct ListHead retval6 = mutt_list_str_split(other_sep, ',');
+    struct ListHead retval1 = STAILQ_HEAD_INITIALIZER(retval1);
+    struct ListHead retval2 = STAILQ_HEAD_INITIALIZER(retval2);
+    struct ListHead retval3 = STAILQ_HEAD_INITIALIZER(retval3);
+    struct ListHead retval4 = STAILQ_HEAD_INITIALIZER(retval4);
+    struct ListHead retval5 = STAILQ_HEAD_INITIALIZER(retval5);
+    struct ListHead retval6 = STAILQ_HEAD_INITIALIZER(retval6);
+
+    size_t count1 = mutt_list_str_split(&retval1, one_word, ' ');
+    size_t count2 = mutt_list_str_split(&retval2, two_words, ' ');
+    size_t count3 = mutt_list_str_split(&retval3, words, ' ');
+    size_t count4 = mutt_list_str_split(&retval4, ending_sep, ' ');
+    size_t count5 = mutt_list_str_split(&retval5, starting_sep, ' ');
+    size_t count6 = mutt_list_str_split(&retval6, other_sep, ',');
 
     struct ListHead expectedval1 = STAILQ_HEAD_INITIALIZER(expectedval1);
     mutt_list_insert_tail(&expectedval1, "hello");
-    if (!TEST_CHECK(mutt_list_compare(&expectedval1, &retval1)))
+    if (!TEST_CHECK(mutt_list_compare(&expectedval1, &retval1)) || (count1 != 1))
       print_compared_list(expectedval1, retval1);
 
     struct ListHead expectedval2 = STAILQ_HEAD_INITIALIZER(expectedval2);
     mutt_list_insert_tail(&expectedval2, "hello");
     mutt_list_insert_tail(&expectedval2, "world");
-    if (!TEST_CHECK(mutt_list_compare(&expectedval2, &retval2)))
+    if (!TEST_CHECK(mutt_list_compare(&expectedval2, &retval2)) || (count2 != 2))
       print_compared_list(expectedval2, retval2);
 
     struct ListHead expectedval3 = STAILQ_HEAD_INITIALIZER(expectedval3);
@@ -94,27 +107,27 @@ void test_mutt_list_str_split(void)
     mutt_list_insert_tail(&expectedval3, "world!");
     mutt_list_insert_tail(&expectedval3, "what's");
     mutt_list_insert_tail(&expectedval3, "up?");
-    if (!TEST_CHECK(mutt_list_compare(&expectedval3, &retval3)))
+    if (!TEST_CHECK(mutt_list_compare(&expectedval3, &retval3)) || (count3 != 5))
       print_compared_list(expectedval3, retval3);
 
     struct ListHead expectedval4 = STAILQ_HEAD_INITIALIZER(expectedval4);
     mutt_list_insert_tail(&expectedval4, "hello");
     mutt_list_insert_tail(&expectedval4, "world");
     mutt_list_insert_tail(&expectedval4, "");
-    if (!TEST_CHECK(mutt_list_compare(&expectedval4, &retval4)))
+    if (!TEST_CHECK(mutt_list_compare(&expectedval4, &retval4)) || (count4 != 3))
       print_compared_list(expectedval4, retval4);
 
     struct ListHead expectedval5 = STAILQ_HEAD_INITIALIZER(expectedval5);
     mutt_list_insert_tail(&expectedval5, "");
     mutt_list_insert_tail(&expectedval5, "hello");
     mutt_list_insert_tail(&expectedval5, "world");
-    if (!TEST_CHECK(mutt_list_compare(&expectedval5, &retval5)))
+    if (!TEST_CHECK(mutt_list_compare(&expectedval5, &retval5)) || (count5 != 3))
       print_compared_list(expectedval5, retval5);
 
     struct ListHead expectedval6 = STAILQ_HEAD_INITIALIZER(expectedval6);
     mutt_list_insert_tail(&expectedval6, "hello");
     mutt_list_insert_tail(&expectedval6, "world");
-    if (!TEST_CHECK(mutt_list_compare(&expectedval6, &retval6)))
+    if (!TEST_CHECK(mutt_list_compare(&expectedval6, &retval6)) || (count6 != 2))
       print_compared_list(expectedval6, retval6);
 
     mutt_list_free(&retval1);

--- a/test/neo/neomutt_mailboxlist_get_all.c
+++ b/test/neo/neomutt_mailboxlist_get_all.c
@@ -28,10 +28,12 @@
 
 void test_neomutt_mailboxlist_get_all(void)
 {
-  // struct MailboxList neomutt_mailboxlist_get_all(struct NeoMutt *n, enum MailboxType magic);
+  // size_t neomutt_mailboxlist_get_all(struct MailboxList *head, struct NeoMutt *n, enum MailboxType magic);
 
   {
-    struct MailboxList ml = neomutt_mailboxlist_get_all(NULL, MUTT_MAILDIR);
+    struct MailboxList ml = STAILQ_HEAD_INITIALIZER(ml);
+    size_t count = neomutt_mailboxlist_get_all(&ml, NULL, MUTT_MAILDIR);
+    TEST_CHECK(count == 0);
     TEST_CHECK(STAILQ_EMPTY(&ml) == true);
   }
 }

--- a/test/rfc2231/rfc2231_encode_string.c
+++ b/test/rfc2231/rfc2231_encode_string.c
@@ -29,15 +29,19 @@
 
 void test_rfc2231_encode_string(void)
 {
-  // struct ParameterList rfc2231_encode_string(const char *attribute, char *value);
+  // size_t rfc2231_encode_string(struct ParameterList *head, const char *attribute, char *value);
 
   {
-    struct ParameterList apple = rfc2231_encode_string(NULL, "apple");
+    struct ParameterList apple = TAILQ_HEAD_INITIALIZER(apple);
+    size_t count = rfc2231_encode_string(&apple, NULL, "apple");
+    TEST_CHECK(count == 0);
     TEST_CHECK(TAILQ_EMPTY(&apple));
   }
 
   {
-    struct ParameterList banana = rfc2231_encode_string("banana", NULL);
+    struct ParameterList banana = TAILQ_HEAD_INITIALIZER(banana);
+    size_t count = rfc2231_encode_string(&banana, "banana", NULL);
+    TEST_CHECK(count == 0);
     TEST_CHECK(TAILQ_EMPTY(&banana));
   }
 }


### PR DESCRIPTION
These commits don't change the behaviour of the functions, just the manner in which they return a list.

Refactor: `neomutt_mailboxlist_get_all()`, `rfc2231_encode_string()` and `mutt_list_str_split()`.

They used to allocate a TAILQ on the stack, then return the object.
This leads to a bug when the List is returned empty.

The functions now add their results to a List passed in as a parameter.

---

When the STAILQ is initialised, `stqh_last` is set to the address of    
`stqh_first` which equates to the address of the STAILQ itself.    
The STAILQ is on the stack.    
    
If the function returned without adding anything to the STAILQ, the    
`stqh_last` pointer would now be invalid, pointing to the now-dead stack. 
