### PR TITLE
Avoid opening the same hcache file twice

### DIFF
--- a/imap/imap.c
+++ b/imap/imap.c
@@ -644,7 +644,7 @@ void imap_expunge_mailbox(struct Mailbox *m)
   struct Email *e = NULL;
 
 #ifdef USE_HCACHE
-  mdata->hcache = imap_hcache_open(adata, mdata);
+  imap_hcache_open(adata, mdata);
 #endif
 
   for (int i = 0; i < m->msg_count; i++)
@@ -1532,7 +1532,7 @@ int imap_sync_mailbox(struct Mailbox *m, bool expunge, bool close)
   }
 
 #ifdef USE_HCACHE
-  mdata->hcache = imap_hcache_open(adata, mdata);
+  imap_hcache_open(adata, mdata);
 #endif
 
   /* save messages with real (non-flag) changes */

--- a/imap/message.c
+++ b/imap/message.c
@@ -1017,7 +1017,7 @@ static int read_headers_condstore_qresync_updates(struct ImapAccountData *adata,
     m->msg_flagged = 0;
     m->changed = 0;
 
-    mdata->hcache = imap_hcache_open(adata, mdata);
+    imap_hcache_open(adata, mdata);
     mdata->reopen &= ~IMAP_EXPUNGE_PENDING;
   }
 
@@ -1320,7 +1320,7 @@ int imap_read_headers(struct Mailbox *m, unsigned int msn_begin,
   mdata->new_mail_count = 0;
 
 #ifdef USE_HCACHE
-  mdata->hcache = imap_hcache_open(adata, mdata);
+  imap_hcache_open(adata, mdata);
 
   if (mdata->hcache && initial_download)
   {
@@ -2120,7 +2120,7 @@ int imap_msg_save_hcache(struct Mailbox *m, struct Email *e)
   if (mdata->hcache)
     close_hc = false;
   else
-    mdata->hcache = imap_hcache_open(adata, mdata);
+    imap_hcache_open(adata, mdata);
   rc = imap_hcache_put(mdata, e);
   if (close_hc)
     imap_hcache_close(mdata);

--- a/imap/private.h
+++ b/imap/private.h
@@ -302,7 +302,7 @@ int imap_msg_save_hcache(struct Mailbox *m, struct Email *e);
 struct ImapAccountData *imap_adata_get(struct Mailbox *m);
 struct ImapMboxData *imap_mdata_get(struct Mailbox *m);
 #ifdef USE_HCACHE
-header_cache_t *imap_hcache_open(struct ImapAccountData *adata, struct ImapMboxData *mdata);
+void imap_hcache_open(struct ImapAccountData *adata, struct ImapMboxData *mdata);
 void imap_hcache_close(struct ImapMboxData *mdata);
 struct Email *imap_hcache_get(struct ImapMboxData *mdata, unsigned int uid);
 int imap_hcache_put(struct ImapMboxData *mdata, struct Email *e);


### PR DESCRIPTION
The IMAP backend could end up opening the same header-cache file twice. This is not supported at least by LMDB. Make sure we cache the hcache handle and reuse it if needed.