### PR TITLE
Fix progress percentage when syncing large mboxes

### DIFF
--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -1285,7 +1285,7 @@ static int mbox_mbox_sync(struct Mailbox *m, int *index_hint)
   for (i = first, j = 0; i < m->msg_count; i++)
   {
     if (m->verbose)
-      mutt_progress_update(&progress, i, (int) (ftello(adata->fp) / (m->size / 100 + 1)));
+      mutt_progress_update(&progress, i, i / (m->msg_count / 100 + 1));
     /* back up some information which is needed to restore offsets when
      * something fails.  */
 


### PR DESCRIPTION
* **What does this PR do?**

Use the message count for calculating the percentage for syncing mbox mailboxes instead of `ftello()` which was always zero.

* **Screenshots (if relevant)**

![syncing, 64951/224036 (28%)](https://user-images.githubusercontent.com/6709544/85922442-9350e400-b883-11ea-8b32-a65edc1a2ed5.png)

* **What are the relevant issue numbers?**

Closes #2383