### PR TITLE
Refactor: Window architecture

### DIFF
--- a/alias/dlgalias.c
+++ b/alias/dlgalias.c
@@ -222,14 +222,10 @@ static void alias_menu(char *buf, size_t buflen, struct AliasMenuData *mdata)
   struct MuttWindow *index =
       mutt_window_new(WT_INDEX, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
-  index->notify = notify_new();
-  notify_set_parent(index->notify, dlg->notify);
 
   struct MuttWindow *ibar =
       mutt_window_new(WT_INDEX_BAR, MUTT_WIN_ORIENT_VERTICAL,
                       MUTT_WIN_SIZE_FIXED, MUTT_WIN_SIZE_UNLIMITED, 1);
-  ibar->notify = notify_new();
-  notify_set_parent(ibar->notify, dlg->notify);
 
   if (C_StatusOnTop)
   {

--- a/alias/dlgquery.c
+++ b/alias/dlgquery.c
@@ -315,19 +315,14 @@ static void query_menu(char *buf, size_t buflen, struct AliasList *all, bool ret
   struct MuttWindow *dlg =
       mutt_window_new(WT_DLG_QUERY, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
-  dlg->notify = notify_new();
 
   struct MuttWindow *index =
       mutt_window_new(WT_INDEX, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
-  index->notify = notify_new();
-  notify_set_parent(index->notify, dlg->notify);
 
   struct MuttWindow *ibar =
       mutt_window_new(WT_INDEX_BAR, MUTT_WIN_ORIENT_VERTICAL,
                       MUTT_WIN_SIZE_FIXED, MUTT_WIN_SIZE_UNLIMITED, 1);
-  ibar->notify = notify_new();
-  notify_set_parent(ibar->notify, dlg->notify);
 
   if (C_StatusOnTop)
   {

--- a/autocrypt/acct_menu.c
+++ b/autocrypt/acct_menu.c
@@ -272,14 +272,10 @@ void mutt_autocrypt_account_menu(void)
   struct MuttWindow *index =
       mutt_window_new(WT_INDEX, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
-  index->notify = notify_new();
-  notify_set_parent(index->notify, dlg->notify);
 
   struct MuttWindow *ibar =
       mutt_window_new(WT_INDEX_BAR, MUTT_WIN_ORIENT_VERTICAL,
                       MUTT_WIN_SIZE_FIXED, MUTT_WIN_SIZE_UNLIMITED, 1);
-  ibar->notify = notify_new();
-  notify_set_parent(ibar->notify, dlg->notify);
 
   if (C_StatusOnTop)
   {

--- a/browser.c
+++ b/browser.c
@@ -1376,19 +1376,14 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
   struct MuttWindow *dlg =
       mutt_window_new(WT_DLG_BROWSER, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
-  dlg->notify = notify_new();
 
   struct MuttWindow *index =
       mutt_window_new(WT_INDEX, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
-  index->notify = notify_new();
-  notify_set_parent(index->notify, dlg->notify);
 
   struct MuttWindow *ibar =
       mutt_window_new(WT_INDEX_BAR, MUTT_WIN_ORIENT_VERTICAL,
                       MUTT_WIN_SIZE_FIXED, MUTT_WIN_SIZE_UNLIMITED, 1);
-  ibar->notify = notify_new();
-  notify_set_parent(ibar->notify, dlg->notify);
 
   if (C_StatusOnTop)
   {

--- a/compose.c
+++ b/compose.c
@@ -1968,11 +1968,9 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur, 
         OptAttachMsg = true;
         mutt_message(_("Tag the messages you want to attach"));
         struct MuttWindow *dlgindex = index_pager_init();
-        notify_observer_add(NeoMutt->notify, mutt_dlgindex_observer, dlgindex);
         dialog_push(dlgindex);
         mutt_index_menu(dlgindex);
         dialog_pop();
-        notify_observer_remove(NeoMutt->notify, mutt_dlgindex_observer, dlgindex);
         index_pager_shutdown(dlgindex);
         mutt_window_free(&dlgindex);
         OptAttachMsg = false;

--- a/compose.c
+++ b/compose.c
@@ -1333,31 +1333,22 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur, 
   struct MuttWindow *dlg =
       mutt_window_new(WT_DLG_COMPOSE, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
-  dlg->notify = notify_new();
 
   struct MuttWindow *envelope =
       mutt_window_new(WT_CUSTOM, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_FIXED,
                       MUTT_WIN_SIZE_UNLIMITED, HDR_ATTACH_TITLE - 1);
-  envelope->notify = notify_new();
-  notify_set_parent(envelope->notify, dlg->notify);
 
   struct MuttWindow *abar =
       mutt_window_new(WT_CUSTOM, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_FIXED,
                       MUTT_WIN_SIZE_UNLIMITED, 1);
-  abar->notify = notify_new();
-  notify_set_parent(abar->notify, dlg->notify);
 
   struct MuttWindow *attach =
       mutt_window_new(WT_INDEX, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
-  attach->notify = notify_new();
-  notify_set_parent(attach->notify, dlg->notify);
 
   struct MuttWindow *ebar =
       mutt_window_new(WT_INDEX_BAR, MUTT_WIN_ORIENT_VERTICAL,
                       MUTT_WIN_SIZE_FIXED, MUTT_WIN_SIZE_UNLIMITED, 1);
-  ebar->notify = notify_new();
-  notify_set_parent(ebar->notify, dlg->notify);
 
   rd->email = e;
   rd->fcc = fcc;

--- a/conn/gui.c
+++ b/conn/gui.c
@@ -60,19 +60,14 @@ int dlg_verify_cert(const char *title, struct ListHead *list, bool allow_always,
   struct MuttWindow *dlg =
       mutt_window_new(WT_DLG_CERTIFICATE, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
-  dlg->notify = notify_new();
 
   struct MuttWindow *index =
       mutt_window_new(WT_INDEX, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
-  index->notify = notify_new();
-  notify_set_parent(index->notify, dlg->notify);
 
   struct MuttWindow *ibar =
       mutt_window_new(WT_INDEX_BAR, MUTT_WIN_ORIENT_VERTICAL,
                       MUTT_WIN_SIZE_FIXED, MUTT_WIN_SIZE_UNLIMITED, 1);
-  ibar->notify = notify_new();
-  notify_set_parent(ibar->notify, dlg->notify);
 
   if (C_StatusOnTop)
   {

--- a/core/account.c
+++ b/core/account.c
@@ -49,7 +49,6 @@ struct Account *account_new(const char *name, struct ConfigSubset *sub)
 
   STAILQ_INIT(&a->mailboxes);
   a->notify = notify_new();
-  notify_set_parent(a->notify, NeoMutt->notify);
   a->name = mutt_str_dup(name);
   a->sub = cs_subset_new(name, sub, a->notify);
   a->sub->cs = sub->cs;
@@ -106,6 +105,7 @@ bool account_mailbox_remove(struct Account *a, struct Mailbox *m)
     {
       struct EventMailbox ev_m = { m };
       notify_send(a->notify, NT_MAILBOX, NT_MAILBOX_REMOVE, &ev_m);
+      notify_set_parent(a->notify, NULL);
       STAILQ_REMOVE(&a->mailboxes, np, MailboxNode, entries);
       if (!m)
         mailbox_free(&np->mailbox);

--- a/core/mailbox.h
+++ b/core/mailbox.h
@@ -158,12 +158,14 @@ enum NotifyMailbox
 {
   NT_MAILBOX_ADD = 1, ///< A new Mailbox has been created
   NT_MAILBOX_REMOVE,  ///< A Mailbox is about to be destroyed
+  NT_MAILBOX_CHANGED, ///< Mailbox data has changed
 
   /* These don't really belong here as they are tied to GUI operations.
    * Eventually, they'll be eliminated. */
   NT_MAILBOX_CLOSED,  ///< Mailbox was closed
   NT_MAILBOX_INVALID, ///< Email list was changed
   NT_MAILBOX_RESORT,  ///< Email list needs resorting
+  NT_MAILBOX_SWITCH,  ///< Current Mailbox has changed
   NT_MAILBOX_UPDATE,  ///< Update internal tables
   NT_MAILBOX_UNTAG,   ///< Clear the 'last-tagged' pointer
 };

--- a/core/neomutt.c
+++ b/core/neomutt.c
@@ -116,7 +116,9 @@ bool neomutt_account_remove(struct NeoMutt *n, struct Account *a)
     {
       struct EventAccount ev_a = { np };
       notify_send(n->notify, NT_ACCOUNT, NT_ACCOUNT_REMOVE, &ev_a);
+
       TAILQ_REMOVE(&n->accounts, np, entries);
+      notify_set_parent(n->notify, NULL);
       account_free(&np);
       result = true;
       if (a)

--- a/gui/curs_lib.c
+++ b/gui/curs_lib.c
@@ -672,19 +672,14 @@ int mutt_do_pager(const char *banner, const char *tempfile, PagerFlags do_color,
   struct MuttWindow *dlg =
       mutt_window_new(WT_DLG_DO_PAGER, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
-  dlg->notify = notify_new();
 
   struct MuttWindow *pager =
       mutt_window_new(WT_PAGER, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
-  pager->notify = notify_new();
-  notify_set_parent(pager->notify, dlg->notify);
 
   struct MuttWindow *pbar =
       mutt_window_new(WT_PAGER_BAR, MUTT_WIN_ORIENT_VERTICAL,
                       MUTT_WIN_SIZE_FIXED, MUTT_WIN_SIZE_UNLIMITED, 1);
-  pbar->notify = notify_new();
-  notify_set_parent(pbar->notify, dlg->notify);
 
   if (C_StatusOnTop)
   {

--- a/gui/mutt_window.c
+++ b/gui/mutt_window.c
@@ -739,3 +739,59 @@ void dialog_pop(void)
   debug_win_dump();
 #endif
 }
+
+/**
+ * window_recalc - Recalculate a tree of Windows
+ * @param win Window to start at
+ */
+void window_recalc(struct MuttWindow *win)
+{
+  if (!win)
+    return;
+
+  if (win->recalc)
+    win->recalc(win, false);
+
+  struct MuttWindow *np = NULL;
+  TAILQ_FOREACH(np, &win->children, entries)
+  {
+    if (np->recalc)
+      np->recalc(np, false);
+  }
+}
+
+/**
+ * window_repaint - Repaint a tree of Windows
+ * @param win Window to start at
+ */
+void window_repaint(struct MuttWindow *win)
+{
+  if (!win)
+    return;
+
+  if (win->repaint)
+    win->repaint(win, false);
+
+  struct MuttWindow *np = NULL;
+  TAILQ_FOREACH(np, &win->children, entries)
+  {
+    if (np->repaint)
+      np->repaint(np, false);
+  }
+}
+
+/**
+ * window_redraw - Reflow, recalc and repaint a tree of Windows
+ * @param win Window to start at
+ */
+void window_redraw(struct MuttWindow *win)
+{
+  if (!win)
+    return;
+
+  window_reflow(win);
+  window_notify_all(win);
+
+  window_recalc(win);
+  window_repaint(win);
+}

--- a/gui/mutt_window.c
+++ b/gui/mutt_window.c
@@ -567,6 +567,24 @@ void mutt_window_add_child(struct MuttWindow *parent, struct MuttWindow *child)
 }
 
 /**
+ * mutt_window_remove_child - Remove a child from a Window
+ * @param parent Window to remove from
+ * @param child  Window to remove
+ */
+struct MuttWindow *mutt_window_remove_child(struct MuttWindow *parent, struct MuttWindow *child)
+{
+  if (!parent || !child)
+    return NULL;
+
+  TAILQ_REMOVE(&parent->children, child, entries);
+  child->parent = NULL;
+
+  notify_set_parent(child->notify, NULL);
+
+  return child;
+}
+
+/**
  * mutt_winlist_free - Free a tree of Windows
  * @param head WindowList to free
  */

--- a/gui/mutt_window.c
+++ b/gui/mutt_window.c
@@ -155,6 +155,9 @@ void mutt_window_free(struct MuttWindow **ptr)
 
   struct MuttWindow *win = *ptr;
 
+  struct EventWindow ev_w = { win, WN_NO_FLAGS };
+  notify_send(win->notify, NT_WINDOW, NT_WINDOW_DELETE, &ev_w);
+
   mutt_winlist_free(&win->children);
 
   if (win->wdata && win->wdata_free)
@@ -564,6 +567,9 @@ void mutt_window_add_child(struct MuttWindow *parent, struct MuttWindow *child)
   child->parent = parent;
 
   notify_set_parent(child->notify, parent->notify);
+
+  struct EventWindow ev_w = { child, WN_NO_FLAGS };
+  notify_send(child->notify, NT_WINDOW, NT_WINDOW_NEW, &ev_w);
 }
 
 /**
@@ -575,6 +581,9 @@ struct MuttWindow *mutt_window_remove_child(struct MuttWindow *parent, struct Mu
 {
   if (!parent || !child)
     return NULL;
+
+  struct EventWindow ev_w = { child, WN_NO_FLAGS };
+  notify_send(child->notify, NT_WINDOW, NT_WINDOW_DELETE, &ev_w);
 
   TAILQ_REMOVE(&parent->children, child, entries);
   child->parent = NULL;
@@ -719,6 +728,11 @@ void dialog_push(struct MuttWindow *dlg)
 
   TAILQ_INSERT_TAIL(&MuttDialogWindow->children, dlg, entries);
   notify_set_parent(dlg->notify, MuttDialogWindow->notify);
+
+  // Notify the world, allowing plugins to integrate
+  struct EventWindow ev_w = { dlg, WN_VISIBLE };
+  notify_send(dlg->notify, NT_WINDOW, NT_WINDOW_DIALOG, &ev_w);
+
   dlg->state.visible = true;
   dlg->parent = MuttDialogWindow;
   mutt_window_reflow(MuttDialogWindow);
@@ -741,6 +755,10 @@ void dialog_pop(void)
   struct MuttWindow *last = TAILQ_LAST(&MuttDialogWindow->children, MuttWindowList);
   if (!last)
     return;
+
+  // Notify the world, allowing plugins to clean up
+  struct EventWindow ev_w = { last, WN_HIDDEN };
+  notify_send(last->notify, NT_WINDOW, NT_WINDOW_DIALOG, &ev_w);
 
   last->state.visible = false;
   last->parent = NULL;

--- a/gui/mutt_window.h
+++ b/gui/mutt_window.h
@@ -194,6 +194,7 @@ void               mutt_window_init               (void);
 struct MuttWindow *mutt_window_new                (enum WindowType type, enum MuttWindowOrientation orient, enum MuttWindowSize size, int cols, int rows);
 void               mutt_window_reflow             (struct MuttWindow *win);
 void               mutt_window_reflow_message_rows(int mw_rows);
+struct MuttWindow *mutt_window_remove_child       (struct MuttWindow *parent, struct MuttWindow *child);
 void               mutt_window_set_root           (int cols, int rows);
 int                mutt_window_wrap_cols          (int width, short wrap);
 

--- a/index.c
+++ b/index.c
@@ -4187,6 +4187,8 @@ void index_pager_shutdown(struct MuttWindow *dlg)
     return;
 
   notify_observer_remove(NeoMutt->notify, sb_observer, win_sidebar);
+
+  notify_observer_remove(NeoMutt->notify, mutt_dlgindex_observer, dlg);
 }
 
 /**

--- a/index.c
+++ b/index.c
@@ -4066,14 +4066,10 @@ static struct MuttWindow *create_panel_index(struct MuttWindow *parent, bool sta
   struct MuttWindow *win_index =
       mutt_window_new(WT_INDEX, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
-  win_index->notify = notify_new();
-  notify_set_parent(win_index->notify, parent->notify);
 
   struct MuttWindow *win_ibar =
       mutt_window_new(WT_INDEX_BAR, MUTT_WIN_ORIENT_VERTICAL,
                       MUTT_WIN_SIZE_FIXED, MUTT_WIN_SIZE_UNLIMITED, 1);
-  win_ibar->notify = notify_new();
-  notify_set_parent(win_ibar->notify, parent->notify);
 
   if (status_on_top)
   {
@@ -4106,15 +4102,11 @@ static struct MuttWindow *create_panel_pager(struct MuttWindow *parent, bool sta
       mutt_window_new(WT_PAGER, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
   win_pager->state.visible = false;
-  win_pager->notify = notify_new();
-  notify_set_parent(win_pager->notify, parent->notify);
 
   struct MuttWindow *win_pbar =
       mutt_window_new(WT_PAGER_BAR, MUTT_WIN_ORIENT_VERTICAL,
                       MUTT_WIN_SIZE_FIXED, MUTT_WIN_SIZE_UNLIMITED, 1);
   win_pbar->state.visible = false;
-  win_pbar->notify = notify_new();
-  notify_set_parent(win_pbar->notify, parent->notify);
 
   if (status_on_top)
   {
@@ -4141,8 +4133,6 @@ static struct MuttWindow *create_panel_sidebar(struct MuttWindow *parent)
       mutt_window_new(WT_SIDEBAR, MUTT_WIN_ORIENT_HORIZONTAL, MUTT_WIN_SIZE_FIXED,
                       C_SidebarWidth, MUTT_WIN_SIZE_UNLIMITED);
   win_sidebar->state.visible = C_SidebarVisible && (C_SidebarWidth > 0);
-  win_sidebar->notify = notify_new();
-  notify_set_parent(win_sidebar->notify, parent->notify);
 
   return win_sidebar;
 }
@@ -4156,7 +4146,6 @@ struct MuttWindow *index_pager_init(void)
   struct MuttWindow *dlg =
       mutt_window_new(WT_DLG_INDEX, MUTT_WIN_ORIENT_HORIZONTAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
-  dlg->notify = notify_new();
   notify_observer_add(NeoMutt->notify, mutt_dlgindex_observer, dlg);
 
   struct MuttWindow *win_sidebar = create_panel_sidebar(dlg);

--- a/main.c
+++ b/main.c
@@ -1221,11 +1221,9 @@ int main(int argc, char *argv[], char *envp[])
       sb_set_open_mailbox(Context ? Context->mailbox : NULL);
 #endif
       struct MuttWindow *dlg = index_pager_init();
-      notify_observer_add(NeoMutt->notify, mutt_dlgindex_observer, dlg);
       dialog_push(dlg);
       mutt_index_menu(dlg);
       dialog_pop();
-      notify_observer_remove(NeoMutt->notify, mutt_dlgindex_observer, dlg);
       index_pager_shutdown(dlg);
       mutt_window_free(&dlg);
       ctx_free(&Context);

--- a/mutt/notify.c
+++ b/mutt/notify.c
@@ -81,7 +81,7 @@ void notify_free(struct Notify **ptr)
  */
 void notify_set_parent(struct Notify *notify, struct Notify *parent)
 {
-  if (!notify || !parent)
+  if (!notify)
     return;
 
   notify->parent = parent;

--- a/mutt_history.c
+++ b/mutt_history.c
@@ -104,19 +104,14 @@ static void history_menu(char *buf, size_t buflen, char **matches, int match_cou
   struct MuttWindow *dlg =
       mutt_window_new(WT_DLG_HISTORY, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
-  dlg->notify = notify_new();
 
   struct MuttWindow *index =
       mutt_window_new(WT_INDEX, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
-  index->notify = notify_new();
-  notify_set_parent(index->notify, dlg->notify);
 
   struct MuttWindow *ibar =
       mutt_window_new(WT_INDEX_BAR, MUTT_WIN_ORIENT_VERTICAL,
                       MUTT_WIN_SIZE_FIXED, MUTT_WIN_SIZE_UNLIMITED, 1);
-  ibar->notify = notify_new();
-  notify_set_parent(ibar->notify, dlg->notify);
 
   if (C_StatusOnTop)
   {

--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -4791,19 +4791,14 @@ static struct CryptKeyInfo *crypt_select_key(struct CryptKeyInfo *keys,
   struct MuttWindow *dlg =
       mutt_window_new(WT_DLG_CRYPT_GPGME, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
-  dlg->notify = notify_new();
 
   struct MuttWindow *index =
       mutt_window_new(WT_INDEX, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
-  index->notify = notify_new();
-  notify_set_parent(index->notify, dlg->notify);
 
   struct MuttWindow *ibar =
       mutt_window_new(WT_INDEX_BAR, MUTT_WIN_ORIENT_VERTICAL,
                       MUTT_WIN_SIZE_FIXED, MUTT_WIN_SIZE_UNLIMITED, 1);
-  ibar->notify = notify_new();
-  notify_set_parent(ibar->notify, dlg->notify);
 
   if (C_StatusOnTop)
   {

--- a/ncrypt/pgpkey.c
+++ b/ncrypt/pgpkey.c
@@ -673,19 +673,14 @@ static struct PgpKeyInfo *pgp_select_key(struct PgpKeyInfo *keys,
   struct MuttWindow *dlg =
       mutt_window_new(WT_DLG_PGP, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
-  dlg->notify = notify_new();
 
   struct MuttWindow *index =
       mutt_window_new(WT_INDEX, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
-  index->notify = notify_new();
-  notify_set_parent(index->notify, dlg->notify);
 
   struct MuttWindow *ibar =
       mutt_window_new(WT_INDEX_BAR, MUTT_WIN_ORIENT_VERTICAL,
                       MUTT_WIN_SIZE_FIXED, MUTT_WIN_SIZE_UNLIMITED, 1);
-  ibar->notify = notify_new();
-  notify_set_parent(ibar->notify, dlg->notify);
 
   if (C_StatusOnTop)
   {

--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -581,19 +581,14 @@ static struct SmimeKey *smime_select_key(struct SmimeKey *keys, char *query)
   struct MuttWindow *dlg =
       mutt_window_new(WT_DLG_SMIME, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
-  dlg->notify = notify_new();
 
   struct MuttWindow *index =
       mutt_window_new(WT_INDEX, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
-  index->notify = notify_new();
-  notify_set_parent(index->notify, dlg->notify);
 
   struct MuttWindow *ibar =
       mutt_window_new(WT_INDEX_BAR, MUTT_WIN_ORIENT_VERTICAL,
                       MUTT_WIN_SIZE_FIXED, MUTT_WIN_SIZE_UNLIMITED, 1);
-  ibar->notify = notify_new();
-  notify_set_parent(ibar->notify, dlg->notify);
 
   if (C_StatusOnTop)
   {

--- a/postpone.c
+++ b/postpone.c
@@ -227,19 +227,14 @@ static struct Email *select_msg(struct Context *ctx)
   struct MuttWindow *dlg =
       mutt_window_new(WT_DLG_POSTPONE, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
-  dlg->notify = notify_new();
 
   struct MuttWindow *index =
       mutt_window_new(WT_INDEX, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
-  index->notify = notify_new();
-  notify_set_parent(index->notify, dlg->notify);
 
   struct MuttWindow *ibar =
       mutt_window_new(WT_INDEX_BAR, MUTT_WIN_ORIENT_VERTICAL,
                       MUTT_WIN_SIZE_FIXED, MUTT_WIN_SIZE_UNLIMITED, 1);
-  ibar->notify = notify_new();
-  notify_set_parent(ibar->notify, dlg->notify);
 
   if (C_StatusOnTop)
   {

--- a/recvattach.c
+++ b/recvattach.c
@@ -1430,19 +1430,14 @@ void mutt_view_attachments(struct Email *e)
   struct MuttWindow *dlg =
       mutt_window_new(WT_DLG_ATTACH, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
-  dlg->notify = notify_new();
 
   struct MuttWindow *index =
       mutt_window_new(WT_INDEX, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
-  index->notify = notify_new();
-  notify_set_parent(index->notify, dlg->notify);
 
   struct MuttWindow *ibar =
       mutt_window_new(WT_INDEX_BAR, MUTT_WIN_ORIENT_VERTICAL,
                       MUTT_WIN_SIZE_FIXED, MUTT_WIN_SIZE_UNLIMITED, 1);
-  ibar->notify = notify_new();
-  notify_set_parent(ibar->notify, dlg->notify);
 
   if (C_StatusOnTop)
   {

--- a/remailer.c
+++ b/remailer.c
@@ -640,19 +640,14 @@ void mix_make_chain(struct MuttWindow *win, struct ListHead *chainhead, int cols
   struct MuttWindow *dlg =
       mutt_window_new(WT_DLG_REMAILER, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
-  dlg->notify = notify_new();
 
   struct MuttWindow *index =
       mutt_window_new(WT_INDEX, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
-  index->notify = notify_new();
-  notify_set_parent(index->notify, dlg->notify);
 
   struct MuttWindow *ibar =
       mutt_window_new(WT_INDEX_BAR, MUTT_WIN_ORIENT_VERTICAL,
                       MUTT_WIN_SIZE_FIXED, MUTT_WIN_SIZE_UNLIMITED, 1);
-  ibar->notify = notify_new();
-  notify_set_parent(ibar->notify, dlg->notify);
 
   if (C_StatusOnTop)
   {


### PR DESCRIPTION
These small changes pave the way for a bigger reorganisation.

Currently, there's **lots** of code which **tells** various components to update themselves.
e.g.  The Index to Sidebar:
- `mutt_index_menu()`
- `index_custom_redraw()`
- `menu_redraw_sidebar()`
- `sb_draw()`

Ideally, the Index should be unaware of the Sidebar.
The Sidebar should observe Events, such as "Mailbox opened", "Window resized", and update itself.

These changes help the first step, the setting up of a Window.

- 4a39262b95 move notify setup
  All Windows will have a Notify (before, some containers were skipped)

- 98246bb743 start redraw framework
  Windows can support `recalc()` and `repaint()` methods

- da87d7ca45 add remove_child()
  For symmetry with `mutt_window_add_child()`

- 3e81566bc3 organise notifications
  Add notifications for Window creation, deletion