### PR TITLE
Check folder against spoolfile by simple string comparison first

### DIFF
--- a/mx.c
+++ b/mx.c
@@ -155,6 +155,9 @@ const struct MxOps *mx_get_ops(enum MailboxType type)
  */
 static bool mutt_is_spool(const char *str)
 {
+  if (mutt_str_equal(str, C_Spoolfile))
+    return true;
+
   struct Url *ua = url_parse(str);
   struct Url *ub = url_parse(C_Spoolfile);
 


### PR DESCRIPTION
This fixes the comparison when folder and spoolfile are local mailboxes
(simple filesystem paths), for which url_parse fails.

Fixes #2402
