### PR TITLE
move random functions to libmutt

### DIFF
--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -390,7 +390,7 @@ LIBMUTTOBJS=	mutt/base64.o mutt/buffer.o mutt/charset.o mutt/date.o \
 		mutt/envlist.o mutt/exit.o mutt/file.o mutt/filter.o \
 		mutt/hash.o mutt/list.o mutt/logging.o mutt/mapping.o \
 		mutt/mbyte.o mutt/md5.o mutt/memory.o mutt/notify.o \
-		mutt/path.o mutt/pool.o mutt/prex.o mutt/regex.o \
+		mutt/path.o mutt/pool.o mutt/prex.o mutt/random.o mutt/regex.o \
 		mutt/signal.o mutt/slist.o mutt/string.o
 CLEANFILES+=	$(LIBMUTT) $(LIBMUTTOBJS)
 ALLOBJS+=	$(LIBMUTTOBJS)

--- a/auto.def
+++ b/auto.def
@@ -319,6 +319,7 @@ if {1} {
     ioctl.h \
     sys/ioctl.h \
     syscall.h \
+    sys/random.h \
     sys/syscall.h \
     sysexits.h
 
@@ -327,6 +328,7 @@ if {1} {
     fgetc_unlocked \
     futimens \
     getaddrinfo \
+    getrandom \
     getsid \
     iswblank \
     mkdtemp \

--- a/main.c
+++ b/main.c
@@ -409,10 +409,6 @@ int main(int argc, char *argv[], char *envp[])
 
   init_locale();
 
-  int out = 0;
-  if (mutt_randbuf(&out, sizeof(out)) < 0)
-    goto main_exit; // TEST02: neomutt (as root on non-Linux OS, rename /dev/urandom)
-
   umask(077);
 
   mutt_envlist_init(envp);

--- a/mutt/lib.h
+++ b/mutt/lib.h
@@ -47,6 +47,7 @@
  * | mutt/path.c      | @subpage path      |
  * | mutt/pool.c      | @subpage pool      |
  * | mutt/prex.c      | @subpage prex      |
+ * | mutt/random.c    | @subpage random    |
  * | mutt/regex.c     | @subpage regex     |
  * | mutt/slist.c     | @subpage slist     |
  * | mutt/signal.c    | @subpage signal    |
@@ -83,6 +84,7 @@
 #include "pool.h"
 #include "prex.h"
 #include "queue.h"
+#include "random.h"
 #include "regex3.h"
 #include "signal2.h"
 #include "slist.h"

--- a/mutt/random.c
+++ b/mutt/random.c
@@ -1,0 +1,135 @@
+/**
+ * @file
+ * Random number/string functions
+ *
+ * @authors
+ * Copyright (C) 2020 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @page random Random number/string functions
+ *
+ * Random number/string functions
+ */
+
+#include "config.h"
+#include <stddef.h>
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include "exit.h"
+#include "logging.h"
+#include "message.h"
+#ifdef HAVE_SYS_RANDOM_H
+#include "sys/random.h"
+#endif
+
+static FILE *fp_random;
+
+static const unsigned char base32[] = "abcdefghijklmnopqrstuvwxyz234567";
+
+/**
+ * mutt_randbuf - Fill a buffer with randomness
+ * @param buf    Buffer for result
+ * @param buflen Size of buffer
+ * @retval  0 Success
+ * @retval -1 Error
+ */
+static int mutt_randbuf(void *buf, size_t buflen)
+{
+  if (buflen > 1048576)
+  {
+    mutt_error(_("mutt_randbuf buflen=%zu"), buflen);
+    return -1;
+  }
+
+#ifdef HAVE_GETRANDOM
+  ssize_t ret;
+  ssize_t count = 0;
+  do
+  {
+    // getrandom() can return less than requested if there's insufficient
+    // entropy or it's interrupted by a signal.
+    ret = getrandom((char *) buf + count, buflen - count, 0);
+    if (ret > 0)
+      count += ret;
+  } while (((ret >= 0) && (count < buflen)) || ((ret == -1) && (errno == EINTR)));
+  if (count == buflen)
+    return 0;
+#endif
+  /* let's try urandom in case we're on an old kernel, or the user has
+   * configured selinux, seccomp or something to not allow getrandom */
+  if (!fp_random)
+  {
+    fp_random = fopen("/dev/urandom", "rb");
+    if (!fp_random)
+    {
+      mutt_error(_("open /dev/urandom: %s"), strerror(errno));
+      return -1;
+    }
+    setbuf(fp_random, NULL);
+  }
+  if (fread(buf, 1, buflen, fp_random) != buflen)
+  {
+    mutt_error(_("read /dev/urandom: %s"), strerror(errno));
+    return -1;
+  }
+
+  return 0;
+}
+
+/**
+ * mutt_rand_base32 - Fill a buffer with a base32-encoded random string
+ * @param buf    Buffer for result
+ * @param buflen Length of buffer
+ */
+void mutt_rand_base32(char *buf, size_t buflen)
+{
+  uint8_t *p = (uint8_t *) buf;
+
+  if (mutt_randbuf(p, buflen) < 0)
+    mutt_exit(1);
+  for (size_t pos = 0; pos < buflen; pos++)
+    p[pos] = base32[p[pos] % 32];
+}
+
+/**
+ * mutt_rand32 - Create a 32-bit random number
+ * @retval num Random number
+ */
+uint32_t mutt_rand32(void)
+{
+  uint32_t num = 0;
+
+  if (mutt_randbuf(&num, sizeof(num)) < 0)
+    mutt_exit(1);
+  return num;
+}
+
+/**
+ * mutt_rand64 - Create a 64-bit random number
+ * @retval num Random number
+ */
+uint64_t mutt_rand64(void)
+{
+  uint64_t num = 0;
+
+  if (mutt_randbuf(&num, sizeof(num)) < 0)
+    mutt_exit(1);
+  return num;
+}

--- a/mutt/random.h
+++ b/mutt/random.h
@@ -1,0 +1,33 @@
+/**
+ * @file
+ * Random number/string functions
+ *
+ * @authors
+ * Copyright (C) 2020 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MUTT_LIB_RANDOM_H
+#define MUTT_LIB_RANDOM_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+uint32_t mutt_rand32(void);
+uint64_t mutt_rand64(void);
+void     mutt_rand_base32(char *buf, size_t buflen);
+
+#endif /* MUTT_LIB_RANDOM_H */

--- a/muttlib.h
+++ b/muttlib.h
@@ -62,10 +62,6 @@ void        mutt_mktemp_full(char *s, size_t slen, const char *prefix, const cha
 bool        mutt_needs_mailcap(struct Body *m);
 FILE *      mutt_open_read(const char *path, pid_t *thepid);
 void        mutt_pretty_mailbox(char *buf, size_t buflen);
-uint32_t    mutt_rand32(void);
-uint64_t    mutt_rand64(void);
-void        mutt_rand_base32(void *out, size_t len);
-int         mutt_randbuf(void *out, size_t len);
 void        mutt_safe_path(struct Buffer *dest, const struct Address *a);
 int         mutt_save_confirm(const char *s, struct stat *st);
 void        mutt_save_path(char *d, size_t dsize, const struct Address *a);

--- a/sendlib.c
+++ b/sendlib.c
@@ -2569,7 +2569,7 @@ const char *mutt_fqdn(bool may_hide_host)
 static char *gen_msgid(void)
 {
   char buf[128];
-  unsigned char rndid[MUTT_RANDTAG_LEN + 1];
+  char rndid[MUTT_RANDTAG_LEN + 1];
 
   mutt_rand_base32(rndid, sizeof(rndid) - 1);
   rndid[MUTT_RANDTAG_LEN] = 0;


### PR DESCRIPTION
These four functions have no dependencies and wide usage, so they belong in the library:

- `mutt_rand32()`
- `mutt_rand64()`
- `mutt_rand_base32()`
- `mutt_randbuf()`

Also change the preferred random method from a Linux syscall, to `getrandom(2)` (available on Linux and BSD).