### PR TITLE
fix(sidebar): use %D in default format

### DIFF
--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -693,7 +693,7 @@ set sidebar_divider_char = '│'          <emphasis role="comment"># Pretty line
               <link linkend="formatstrings-conditionals">conditionals</link>.
             </para>
             <para>
-              The default value is: <literal>%B%* %n</literal>
+              The default value is: <literal>%D%* %n</literal>
             </para>
             <para>
               A more detailed value is:
@@ -16375,7 +16375,7 @@ set sort_browser="reverse-size"
               <row>
                 <entry><literal>sidebar_format</literal></entry>
                 <entry>string</entry>
-                <entry><literal>%B%* %n</literal></entry>
+                <entry><literal>%D%* %n</literal></entry>
               </row>
               <row>
                 <entry><literal>sidebar_indent_string</literal></entry>

--- a/mutt_config.c
+++ b/mutt_config.c
@@ -3735,7 +3735,7 @@ struct ConfigDef MuttVars[] = {
   ** .pp
   ** \fBSee also:\fP $$sidebar_short_path, $$sidebar_indent_string, $$sidebar_delim_chars.
   */
-  { "sidebar_format", DT_STRING|DT_NOT_EMPTY|R_SIDEBAR, &C_SidebarFormat, IP "%B%*  %n" },
+  { "sidebar_format", DT_STRING|DT_NOT_EMPTY|R_SIDEBAR, &C_SidebarFormat, IP "%D%*  %n" },
   /*
   ** .pp
   ** This variable allows you to customize the sidebar display. This string is


### PR DESCRIPTION
The current default `sidebar_format` uses `%B`, which displays the
mailbox path. Replace `%B` with `%D` to display mailbox names if user
uses named-mailboxes or virtual-mailboxes declarations.

With changes in #2389 stopping the sidebar from always displaying names,
despite `%B`, for named and virtual mailboxes, users will no
longer see the names. The current default forces named and virtual
mailbox users to update the default to see the names. This is
undesirable as those feature appears broken with default settings.

---

With minimal config:

```
set folder="~/mail"
set sidebar_visible=yes
named-mailboxes "Mailbox" "notmuch://?query=tag:inbox"
```

Before:

![image](https://user-images.githubusercontent.com/1640737/86307223-3dae6b80-bbe4-11ea-9d5e-a0dff883143f.png)

After:
![image](https://user-images.githubusercontent.com/1640737/86307381-a4cc2000-bbe4-11ea-990f-dc065c23d73e.png)


Additionally, we should aware of #2389 will require all existing notmuch users with custom sidebar formats to update as they probably don't use `%D` in it. ca381a9b38f29332244ba3356e0b30009f785b3b  added `%D` so sidebar had the `%B` exception for notmuch. Let's make sure to add that notice in the release notes.