### PR TITLE
Fix and improve `change-folder` behavior

### DIFF
--- a/mutt_mailbox.c
+++ b/mutt_mailbox.c
@@ -333,8 +333,6 @@ struct Mailbox *mutt_mailbox_next(struct Mailbox *m_cur, struct Buffer *s)
       struct MailboxNode *np = NULL;
       STAILQ_FOREACH(np, &ml, entries)
       {
-        if (np->mailbox->type == MUTT_NOTMUCH) /* only match real mailboxes */
-          continue;
         mutt_buffer_expand_path(&np->mailbox->pathbuf);
         if ((found || (pass > 0)) && np->mailbox->has_new)
         {

--- a/mutt_mailbox.c
+++ b/mutt_mailbox.c
@@ -323,7 +323,7 @@ struct Mailbox *mutt_mailbox_next(struct Mailbox *m_cur, struct Buffer *s)
 {
   mutt_buffer_expand_path(s);
 
-  if (mutt_mailbox_check(m_cur, 0) > 0)
+  if (m_cur)
   {
     bool found = false;
     for (int pass = 0; pass < 2; pass++)

--- a/mutt_mailbox.c
+++ b/mutt_mailbox.c
@@ -334,7 +334,7 @@ struct Mailbox *mutt_mailbox_next(struct Mailbox *m_cur, struct Buffer *s)
       STAILQ_FOREACH(np, &ml, entries)
       {
         mutt_buffer_expand_path(&np->mailbox->pathbuf);
-        if ((found || (pass > 0)) && np->mailbox->has_new)
+        if ((found || (pass > 0)) && np->mailbox->msg_unread != 0)
         {
           // If there's a mailbox name, use it over path.
           if (np->mailbox->name)

--- a/mutt_mailbox.c
+++ b/mutt_mailbox.c
@@ -336,7 +336,12 @@ struct Mailbox *mutt_mailbox_next(struct Mailbox *m_cur, struct Buffer *s)
         mutt_buffer_expand_path(&np->mailbox->pathbuf);
         if ((found || (pass > 0)) && np->mailbox->has_new)
         {
-          mutt_buffer_strcpy(s, mailbox_path(np->mailbox));
+          // If there's a mailbox name, use it over path.
+          if (np->mailbox->name)
+            mutt_buffer_strcpy(s, np->mailbox->name);
+          else
+            mutt_buffer_strcpy(s, mailbox_path(np->mailbox));
+
           mutt_buffer_pretty_mailbox(s);
           struct Mailbox *m_result = np->mailbox;
           neomutt_mailboxlist_clear(&ml);


### PR DESCRIPTION
This pull request includes four distinct changes (1 bug fix, 3 user experience improvements):
1. Removes restriction that limits suggestions to non-notmuch mailboxes.
    Fixes #1982
2. Prefers names over paths if available.
3. Removes restriction for suggestions appearing only if current mailbox had new mail.
4. Suggests mailboxes with unread mail instead of new mail. New mails aren't guaranteed to be unread so it'd be weird to suggest a mailbox without unread  messages.