### PR TITLE
Track currently selected email by msgid

### DIFF
--- a/compmbox/compress.c
+++ b/compmbox/compress.c
@@ -557,7 +557,6 @@ cmoa_fail1:
 /**
  * comp_mbox_check - Check for new mail - Implements MxOps::mbox_check()
  * @param m          Mailbox
- * @param index_hint Currently selected mailbox
  * @retval 0              Mailbox OK
  * @retval #MUTT_REOPENED The mailbox was closed and reopened
  * @retval -1             Mailbox bad
@@ -569,7 +568,7 @@ cmoa_fail1:
  *
  * The return codes are picked to match mx_mbox_check().
  */
-static int comp_mbox_check(struct Mailbox *m, int *index_hint)
+static int comp_mbox_check(struct Mailbox *m)
 {
   if (!m || !m->compress_info)
     return -1;
@@ -596,7 +595,7 @@ static int comp_mbox_check(struct Mailbox *m, int *index_hint)
   if (rc == 0)
     return -1;
 
-  return ops->mbox_check(m, index_hint);
+  return ops->mbox_check(m);
 }
 
 /**
@@ -605,7 +604,7 @@ static int comp_mbox_check(struct Mailbox *m, int *index_hint)
  * Changes in NeoMutt only affect the tmp file.
  * Calling comp_mbox_sync() will commit them to the compressed file.
  */
-static int comp_mbox_sync(struct Mailbox *m, int *index_hint)
+static int comp_mbox_sync(struct Mailbox *m)
 {
   if (!m || !m->compress_info)
     return -1;
@@ -628,11 +627,11 @@ static int comp_mbox_sync(struct Mailbox *m, int *index_hint)
     return -1;
   }
 
-  int rc = comp_mbox_check(m, index_hint);
+  int rc = comp_mbox_check(m);
   if (rc != 0)
     goto sync_cleanup;
 
-  rc = ops->mbox_sync(m, index_hint);
+  rc = ops->mbox_sync(m);
   if (rc != 0)
     goto sync_cleanup;
 

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -2102,12 +2102,11 @@ static int imap_mbox_open_append(struct Mailbox *m, OpenMailboxFlags flags)
 
 /**
  * imap_mbox_check - Check for new mail - Implements MxOps::mbox_check()
- * @param m          Mailbox
- * @param index_hint Remember our place in the index
+ * @param m           Mailbox
  * @retval >0 Success, e.g. #MUTT_REOPENED
  * @retval -1 Failure
  */
-static int imap_mbox_check(struct Mailbox *m, int *index_hint)
+static int imap_mbox_check(struct Mailbox *m)
 {
   if (!m)
     return -1;

--- a/index.h
+++ b/index.h
@@ -48,7 +48,7 @@ void index_make_entry(char *buf, size_t buflen, struct Menu *menu, int line);
 void mutt_draw_statusline(int cols, const char *buf, size_t buflen);
 int  mutt_index_menu(struct MuttWindow *dlg);
 void mutt_set_header_color(struct Mailbox *m, struct Email *e);
-void update_index(struct Menu *menu, struct Context *ctx, int check, int oldcount, int index_hint);
+void update_index(struct Menu *menu, struct Context *ctx, int check, int oldcount, const char *curr_msgid);
 struct MuttWindow *index_pager_init(void);
 void index_pager_shutdown(struct MuttWindow *dlg);
 int mutt_dlgindex_observer(struct NotifyCallback *nc);

--- a/maildir/maildir.c
+++ b/maildir/maildir.c
@@ -364,7 +364,7 @@ static int maildir_mbox_open_append(struct Mailbox *m, OpenMailboxFlags flags)
  * already knew about.  We don't treat either subdirectory differently, as mail
  * could be copied directly into the cur directory from another agent.
  */
-int maildir_mbox_check(struct Mailbox *m, int *index_hint)
+int maildir_mbox_check(struct Mailbox *m)
 {
   if (!m)
     return -1;

--- a/maildir/mh.c
+++ b/maildir/mh.c
@@ -590,7 +590,7 @@ static int mh_mbox_open_append(struct Mailbox *m, OpenMailboxFlags flags)
  *
  * Don't change this code unless you _really_ understand what happens.
  */
-int mh_mbox_check(struct Mailbox *m, int *index_hint)
+int mh_mbox_check(struct Mailbox *m)
 {
   if (!m)
     return -1;

--- a/maildir/private.h
+++ b/maildir/private.h
@@ -75,13 +75,13 @@ struct MhSequences
 /* MXAPI shared functions */
 int             maildir_ac_add     (struct Account *a, struct Mailbox *m);
 struct Account *maildir_ac_find    (struct Account *a, const char *path);
-int             maildir_mbox_check (struct Mailbox *m, int *index_hint);
+int             maildir_mbox_check (struct Mailbox *m);
 int             maildir_path_canon (char *buf, size_t buflen);
 int             maildir_path_parent(char *buf, size_t buflen);
 int             maildir_path_pretty(char *buf, size_t buflen, const char *folder);
-int             mh_mbox_check      (struct Mailbox *m, int *index_hint);
+int             mh_mbox_check      (struct Mailbox *m);
 int             mh_mbox_close      (struct Mailbox *m);
-int             mh_mbox_sync       (struct Mailbox *m, int *index_hint);
+int             mh_mbox_sync       (struct Mailbox *m);
 int             mh_msg_close       (struct Mailbox *m, struct Message *msg);
 int             mh_msg_save_hcache (struct Mailbox *m, struct Email *e);
 

--- a/maildir/shared.c
+++ b/maildir/shared.c
@@ -1698,7 +1698,7 @@ int maildir_path_parent(char *buf, size_t buflen)
  *
  * @note The flag retvals come from a call to a backend sync function
  */
-int mh_mbox_sync(struct Mailbox *m, int *index_hint)
+int mh_mbox_sync(struct Mailbox *m)
 {
   if (!m)
     return -1;
@@ -1709,9 +1709,9 @@ int mh_mbox_sync(struct Mailbox *m, int *index_hint)
   int check;
 
   if (m->type == MUTT_MH)
-    check = mh_mbox_check(m, index_hint);
+    check = mh_mbox_check(m);
   else
-    check = maildir_mbox_check(m, index_hint);
+    check = maildir_mbox_check(m);
 
   if (check < 0)
     return check;

--- a/mutt/string.c
+++ b/mutt/string.c
@@ -439,6 +439,7 @@ char *mutt_strn_cat(char *d, size_t l, const char *s, size_t sl)
  * mutt_str_replace - Replace one string with another
  * @param[out] p String to replace
  * @param[in]  s New string
+ * @retval ptr Replaced string
  *
  * This function free()s the original string, strdup()s the new string and
  * overwrites the pointer to the first string.
@@ -447,13 +448,14 @@ char *mutt_strn_cat(char *d, size_t l, const char *s, size_t sl)
  *
  * @note Free *p afterwards to handle the case that *p and s reference the same memory
  */
-void mutt_str_replace(char **p, const char *s)
+char *mutt_str_replace(char **p, const char *s)
 {
   if (!p)
-    return;
+    return NULL;
   const char *tmp = *p;
   *p = mutt_str_dup(s);
   FREE(&tmp);
+  return *p;
 }
 
 /**

--- a/mutt/string2.h
+++ b/mutt/string2.h
@@ -75,7 +75,7 @@ size_t      mutt_str_lws_len(const char *s, size_t n);
 size_t      mutt_str_lws_rlen(const char *s, size_t n);
 const char *mutt_str_next_word(const char *s);
 void        mutt_str_remove_trailing_ws(char *s);
-void        mutt_str_replace(char **p, const char *s);
+char *      mutt_str_replace(char **p, const char *s);
 char *      mutt_str_skip_email_wsp(const char *s);
 char *      mutt_str_skip_whitespace(const char *p);
 const char *mutt_str_sysexit(int e);

--- a/mutt_header.c
+++ b/mutt_header.c
@@ -107,8 +107,7 @@ static bool label_message(struct Mailbox *m, struct Email *e, char *new_label)
 
   if (e->env->x_label)
     label_ref_dec(m, e->env->x_label);
-  mutt_str_replace(&e->env->x_label, new_label);
-  if (e->env->x_label)
+  if (mutt_str_replace(&e->env->x_label, new_label))
     label_ref_inc(m, e->env->x_label);
 
   e->changed = true;

--- a/mx.h
+++ b/mx.h
@@ -147,11 +147,10 @@ struct MxOps
   /**
    * mbox_check - Check for new mail
    * @param m          Mailbox
-   * @param index_hint Remember our place in the index
    * @retval >0 Success, e.g. #MUTT_REOPENED
    * @retval -1 Error
    */
-  int (*mbox_check)      (struct Mailbox *m, int *index_hint);
+  int (*mbox_check)      (struct Mailbox *m);
 
   /**
    * mbox_check_stats - Check the Mailbox statistics
@@ -166,11 +165,10 @@ struct MxOps
   /**
    * mbox_sync - Save changes to the Mailbox
    * @param m          Mailbox to sync
-   * @param index_hint Remember our place in the index
    * @retval  0 Success
    * @retval -1 Failure
    */
-  int (*mbox_sync)       (struct Mailbox *m, int *index_hint);
+  int (*mbox_sync)       (struct Mailbox *m);
 
   /**
    * mbox_close - Close a Mailbox
@@ -294,11 +292,11 @@ struct MxOps
 };
 
 /* Wrappers for the Mailbox API, see MxOps */
-int             mx_mbox_check      (struct Mailbox *m, int *index_hint);
+int             mx_mbox_check      (struct Mailbox *m);
 int             mx_mbox_check_stats(struct Mailbox *m, int flags);
 int             mx_mbox_close      (struct Context **ptr);
 struct Context *mx_mbox_open       (struct Mailbox *m, OpenMailboxFlags flags);
-int             mx_mbox_sync       (struct Mailbox *m, int *index_hint);
+int             mx_mbox_sync       (struct Mailbox *m);
 int             mx_msg_close       (struct Mailbox *m, struct Message **msg);
 int             mx_msg_commit      (struct Mailbox *m, struct Message *msg);
 struct Message *mx_msg_open_new    (struct Mailbox *m, struct Email *e, MsgOpenFlags flags);

--- a/nntp/nntp.c
+++ b/nntp/nntp.c
@@ -2578,13 +2578,12 @@ static int nntp_mbox_open(struct Mailbox *m)
 /**
  * nntp_mbox_check - Check for new mail - Implements MxOps::mbox_check()
  * @param m          Mailbox
- * @param index_hint Current message (UNUSED)
  * @retval #MUTT_REOPENED Articles have been renumbered or removed from server
  * @retval #MUTT_NEW_MAIL New articles found
  * @retval  0             No change
  * @retval -1             Lost connection
  */
-static int nntp_mbox_check(struct Mailbox *m, int *index_hint)
+static int nntp_mbox_check(struct Mailbox *m)
 {
   if (!m)
     return -1;
@@ -2604,7 +2603,7 @@ static int nntp_mbox_check(struct Mailbox *m, int *index_hint)
  *
  * @note May also return values from check_mailbox()
  */
-static int nntp_mbox_sync(struct Mailbox *m, int *index_hint)
+static int nntp_mbox_sync(struct Mailbox *m)
 {
   if (!m)
     return -1;

--- a/notmuch/notmuch.c
+++ b/notmuch/notmuch.c
@@ -2196,14 +2196,13 @@ static int nm_mbox_open(struct Mailbox *m)
 /**
  * nm_mbox_check - Check for new mail - Implements MxOps::mbox_check()
  * @param m           Mailbox
- * @param index_hint  Remember our place in the index
  * @retval -1 Error
  * @retval  0 Success
  * @retval #MUTT_NEW_MAIL New mail has arrived
  * @retval #MUTT_REOPENED Mailbox closed and reopened
  * @retval #MUTT_FLAGS    Flags have changed
  */
-static int nm_mbox_check(struct Mailbox *m, int *index_hint)
+static int nm_mbox_check(struct Mailbox *m)
 {
   if (!m)
     return -1;
@@ -2335,7 +2334,7 @@ done:
 /**
  * nm_mbox_sync - Save changes to the Mailbox - Implements MxOps::mbox_sync()
  */
-static int nm_mbox_sync(struct Mailbox *m, int *index_hint)
+static int nm_mbox_sync(struct Mailbox *m)
 {
   if (!m)
     return -1;

--- a/pager.c
+++ b/pager.c
@@ -2351,10 +2351,9 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
 
     if (Context && Context->mailbox && !OptAttachMsg)
     {
-      int index_hint = 0; /* used to restore cursor position */
       int oldcount = Context->mailbox->msg_count;
       /* check for new mail */
-      int check = mx_mbox_check(Context->mailbox, &index_hint);
+      int check = mx_mbox_check(Context->mailbox);
       if (check < 0)
       {
         if (!Context->mailbox || mutt_buffer_is_empty(&Context->mailbox->pathbuf))
@@ -2395,11 +2394,9 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
             if (!e)
               continue;
 
-            index_hint = e->index;
-
             bool verbose = Context->mailbox->verbose;
             Context->mailbox->verbose = false;
-            update_index(rd.menu, Context, check, oldcount, index_hint);
+            update_index(rd.menu, Context, check, oldcount, e->env->message_id);
             Context->mailbox->verbose = verbose;
 
             rd.menu->max = Context->mailbox->vcount;

--- a/pop/pop.c
+++ b/pop/pop.c
@@ -881,7 +881,7 @@ static int pop_mbox_open(struct Mailbox *m)
 /**
  * pop_mbox_check - Check for new mail - Implements MxOps::mbox_check()
  */
-static int pop_mbox_check(struct Mailbox *m, int *index_hint)
+static int pop_mbox_check(struct Mailbox *m)
 {
   if (!m)
     return -1;
@@ -922,7 +922,7 @@ static int pop_mbox_check(struct Mailbox *m, int *index_hint)
  *
  * Update POP mailbox, delete messages from server
  */
-static int pop_mbox_sync(struct Mailbox *m, int *index_hint)
+static int pop_mbox_sync(struct Mailbox *m)
 {
   if (!m)
     return -1;

--- a/postpone.c
+++ b/postpone.c
@@ -359,7 +359,7 @@ int mutt_get_postponed(struct Context *ctx, struct Email *hdr,
    * segvs, but probably the flag needs to be reset after downloading
    * headers in imap_open_mailbox().
    */
-  mx_mbox_check(ctx_post->mailbox, NULL);
+  mx_mbox_check(ctx_post->mailbox);
 
   if (ctx_post->mailbox->msg_count == 0)
   {


### PR DESCRIPTION
This PR gets rid of the ugly `index_hint` variable that was passed around into the mx API. Now the index uses the selected email's message id to keep track of the cursor position and to refresh itself when the selected mailbox changes. 

Accidentally, this fixes an issue whereas the cursor position in the index was wrongly reset after an email disappeared (e.g., because it was deleted from another client).