### PR TITLE
Optimize checking for the current email in the index

### DIFF
--- a/index.c
+++ b/index.c
@@ -603,15 +603,50 @@ static void update_index_unthreaded(struct Context *ctx, int check, int oldcount
 }
 
 /**
+ * struct CurrentEmail - Keep track of the currently selected Email
+ */
+struct CurrentEmail
+{
+  time_t received;  ///< From Email.received
+  char *message_id; ///< From Email.Envelope.message_id
+};
+
+/**
+ * is_current_email - Check whether an email is the currently selected Email
+ * @param cur  Currently selected Email
+ * @param e    Email to check
+ * @retval true e is current
+ * @retval false e is not current
+ */
+static bool is_current_email(const struct CurrentEmail *cur, const struct Email *e)
+{
+  return (e->received == cur->received) &&
+         mutt_str_equal(e->env->message_id, cur->message_id);
+}
+
+/**
+ * set_current_email - Keep track of the currently selected Email
+ * @param cur Currently selected Email
+ * @param e   Email to set as current
+ */
+static void set_current_email(struct CurrentEmail *cur, const struct Email *e)
+{
+  *cur = (struct CurrentEmail){
+    .received = e ? e->received : 0,
+    .message_id = mutt_str_replace(&cur->message_id, e ? e->env->message_id : NULL),
+  };
+}
+
+/**
  * update_index - Update the index
  * @param menu       Current Menu
  * @param ctx        Mailbox
  * @param check      Flags, e.g. #MUTT_REOPENED
  * @param oldcount   How many items are currently in the index
- * @param curr_msgid Remember our place in the index
+ * @param cur        Remember our place in the index
  */
-void update_index(struct Menu *menu, struct Context *ctx, int check,
-                  int oldcount, const char *curr_msgid)
+static void update_index(struct Menu *menu, struct Context *ctx, int check,
+                         int oldcount, const struct CurrentEmail *cur)
 {
   if (!menu || !ctx)
     return;
@@ -630,7 +665,7 @@ void update_index(struct Menu *menu, struct Context *ctx, int check,
       struct Email *e = mutt_get_virt_email(ctx->mailbox, i);
       if (!e)
         continue;
-      if (mutt_str_equal(e->env->message_id, curr_msgid))
+      if (is_current_email(cur, e))
       {
         menu->current = i;
         break;
@@ -640,6 +675,24 @@ void update_index(struct Menu *menu, struct Context *ctx, int check,
 
   if (menu->current < 0)
     menu->current = ci_first_message(Context);
+}
+
+/**
+ * mutt_update_index - Update the index
+ * @param menu      Current Menu
+ * @param ctx       Mailbox
+ * @param check     Flags, e.g. #MUTT_REOPENED
+ * @param oldcount  How many items are currently in the index
+ * @param cur_email Currently selected email
+ *
+ * @note cur_email cannot be NULL
+ */
+void mutt_update_index(struct Menu *menu, struct Context *ctx, int check,
+                       int oldcount, const struct Email *cur_email)
+{
+  struct CurrentEmail se = { .received = cur_email->received,
+                              .message_id = cur_email->env->message_id };
+  update_index(menu, ctx, check, oldcount, &se);
 }
 
 /**
@@ -664,14 +717,14 @@ static int mailbox_index_observer(struct NotifyCallback *nc)
 
 /**
  * change_folder_mailbox - Change to a different Mailbox by pointer
- * @param menu       Current Menu
- * @param m          Mailbox
- * @param oldcount   How many items are currently in the index
- * @param curr_msgid Remember our place in the index
- * @param read_only  Open Mailbox in read-only mode
+ * @param menu      Current Menu
+ * @param m         Mailbox
+ * @param oldcount  How many items are currently in the index
+ * @param cur       Remember our place in the index
+ * @param read_only Open Mailbox in read-only mode
  */
 static void change_folder_mailbox(struct Menu *menu, struct Mailbox *m, int *oldcount,
-                                  const char *curr_msgid, bool read_only)
+                                  const struct CurrentEmail *cur, bool read_only)
 {
   if (!m)
     return;
@@ -702,7 +755,7 @@ static void change_folder_mailbox(struct Menu *menu, struct Mailbox *m, int *old
         mutt_monitor_add(NULL);
 #endif
       if ((check == MUTT_NEW_MAIL) || (check == MUTT_REOPENED))
-        update_index(menu, Context, check, *oldcount, curr_msgid);
+        update_index(menu, Context, check, *oldcount, cur);
 
       FREE(&new_last_folder);
       OptSearchInvalid = true;
@@ -767,16 +820,16 @@ static void change_folder_mailbox(struct Menu *menu, struct Mailbox *m, int *old
 #ifdef USE_NOTMUCH
 /**
  * change_folder_notmuch - Change to a different Notmuch Mailbox by string
- * @param menu       Current Menu
- * @param buf        Folder to change to
- * @param buflen     Length of buffer
- * @param oldcount   How many items are currently in the index
- * @param curr_msgid Remember our place in the index
- * @param read_only  Open Mailbox in read-only mode
+ * @param menu      Current Menu
+ * @param buf       Folder to change to
+ * @param buflen    Length of buffer
+ * @param oldcount  How many items are currently in the index
+ * @param cur       Remember our place in the index
+ * @param read_only Open Mailbox in read-only mode
  */
 static struct Mailbox *change_folder_notmuch(struct Menu *menu, char *buf,
                                              int buflen, int *oldcount,
-                                             const char *curr_msgid, bool read_only)
+                                             const struct CurrentEmail *cur, bool read_only)
 {
   if (!nm_url_from_query(NULL, buf, buflen))
   {
@@ -785,23 +838,23 @@ static struct Mailbox *change_folder_notmuch(struct Menu *menu, char *buf,
   }
 
   struct Mailbox *m_query = mx_path_resolve(buf);
-  change_folder_mailbox(menu, m_query, oldcount, curr_msgid, read_only);
+  change_folder_mailbox(menu, m_query, oldcount, cur, read_only);
   return m_query;
 }
 #endif
 
 /**
  * change_folder_string - Change to a different Mailbox by string
- * @param menu       Current Menu
- * @param buf        Folder to change to
- * @param buflen     Length of buffer
- * @param oldcount   How many items are currently in the index
- * @param curr_msgid Remember our place in the index
+ * @param menu         Current Menu
+ * @param buf          Folder to change to
+ * @param buflen       Length of buffer
+ * @param oldcount     How many items are currently in the index
+ * @param cur          Remember our place in the index
  * @param pager_return Return to the pager afterwards
- * @param read_only  Open Mailbox in read-only mode
+ * @param read_only    Open Mailbox in read-only mode
  */
 static void change_folder_string(struct Menu *menu, char *buf, size_t buflen,
-                                 int *oldcount, const char *curr_msgid,
+                                 int *oldcount, const struct CurrentEmail *cur,
                                  bool *pager_return, bool read_only)
 {
 #ifdef USE_NNTP
@@ -823,7 +876,7 @@ static void change_folder_string(struct Menu *menu, char *buf, size_t buflen,
     struct Mailbox *m = mailbox_find_name(buf);
     if (m)
     {
-      change_folder_mailbox(menu, m, oldcount, curr_msgid, read_only);
+      change_folder_mailbox(menu, m, oldcount, cur, read_only);
       *pager_return = false;
     }
     else
@@ -835,7 +888,7 @@ static void change_folder_string(struct Menu *menu, char *buf, size_t buflen,
   *pager_return = false;
 
   struct Mailbox *m = mx_path_resolve(buf);
-  change_folder_mailbox(menu, m, oldcount, curr_msgid, read_only);
+  change_folder_mailbox(menu, m, oldcount, cur, read_only);
 }
 
 /**
@@ -1137,7 +1190,7 @@ int mutt_index_menu(struct MuttWindow *dlg)
   bool tag = false;  /* has the tag-prefix command been pressed? */
   int newcount = -1;
   int oldcount = -1;
-  char *curr_msgid = NULL; /* used to restore cursor position */
+  struct CurrentEmail cur = { 0 };
   bool do_mailbox_notify = true;
   int close = 0; /* did we OP_QUIT or OP_EXIT out of this menu? */
   int attach_msg = OptAttachMsg;
@@ -1219,7 +1272,7 @@ int mutt_index_menu(struct MuttWindow *dlg)
        * modified underneath us.) */
 
       struct Email *e_cur = get_cur_email(Context, menu);
-      mutt_str_replace(&curr_msgid, e_cur ? e_cur->env->message_id : NULL);
+      set_current_email(&cur, e_cur);
 
       int check = mx_mbox_check(Context->mailbox);
       if (check < 0)
@@ -1272,7 +1325,7 @@ int mutt_index_menu(struct MuttWindow *dlg)
         {
           bool verbose = Context->mailbox->verbose;
           Context->mailbox->verbose = false;
-          update_index(menu, Context, check, oldcount, curr_msgid);
+          update_index(menu, Context, check, oldcount, &cur);
           Context->mailbox->verbose = verbose;
           menu->max = Context->mailbox->vcount;
         }
@@ -1861,7 +1914,7 @@ int mutt_index_menu(struct MuttWindow *dlg)
           else
           {
             if ((check == MUTT_NEW_MAIL) || (check == MUTT_REOPENED))
-              update_index(menu, Context, check, oldcount, curr_msgid);
+              update_index(menu, Context, check, oldcount, &cur);
 
             menu->redraw = REDRAW_FULL; /* new mail arrived? */
             OptSearchInvalid = true;
@@ -2009,7 +2062,7 @@ int mutt_index_menu(struct MuttWindow *dlg)
           if (check != 0)
           {
             if ((check == MUTT_NEW_MAIL) || (check == MUTT_REOPENED))
-              update_index(menu, Context, check, oldcount, curr_msgid);
+              update_index(menu, Context, check, oldcount, &cur);
             OptSearchInvalid = true;
             menu->redraw = REDRAW_FULL;
             break;
@@ -2068,7 +2121,7 @@ int mutt_index_menu(struct MuttWindow *dlg)
             OptSearchInvalid = true;
           }
           else if ((check == MUTT_NEW_MAIL) || (check == MUTT_REOPENED))
-            update_index(menu, Context, check, oc, curr_msgid);
+            update_index(menu, Context, check, oc, &cur);
 
           /* do a sanity check even if mx_mbox_sync failed.  */
 
@@ -2144,7 +2197,7 @@ int mutt_index_menu(struct MuttWindow *dlg)
           if (buf[strlen(buf) - 1] == '>')
             buf[strlen(buf) - 1] = '\0';
 
-          change_folder_notmuch(menu, buf, sizeof(buf), &oldcount, curr_msgid, false);
+          change_folder_notmuch(menu, buf, sizeof(buf), &oldcount, &cur, false);
 
           // If notmuch doesn't contain the message, we're left in an empty
           // vfolder. No messages are found, but nm_read_entire_thread assumes
@@ -2318,7 +2371,7 @@ int mutt_index_menu(struct MuttWindow *dlg)
         char *query_unencoded = mutt_str_dup(buf);
 
         struct Mailbox *m_query =
-            change_folder_notmuch(menu, buf, sizeof(buf), &oldcount, curr_msgid,
+            change_folder_notmuch(menu, buf, sizeof(buf), &oldcount, &cur,
                                   (op == OP_MAIN_VFOLDER_FROM_QUERY_READONLY));
         if (m_query)
         {
@@ -2349,7 +2402,7 @@ int mutt_index_menu(struct MuttWindow *dlg)
         }
         nm_query_window_backward();
         mutt_str_copy(buf, C_NmQueryWindowCurrentSearch, sizeof(buf));
-        change_folder_notmuch(menu, buf, sizeof(buf), &oldcount, curr_msgid, false);
+        change_folder_notmuch(menu, buf, sizeof(buf), &oldcount, &cur, false);
         break;
       }
 
@@ -2369,14 +2422,14 @@ int mutt_index_menu(struct MuttWindow *dlg)
         }
         nm_query_window_forward();
         mutt_str_copy(buf, C_NmQueryWindowCurrentSearch, sizeof(buf));
-        change_folder_notmuch(menu, buf, sizeof(buf), &oldcount, curr_msgid, false);
+        change_folder_notmuch(menu, buf, sizeof(buf), &oldcount, &cur, false);
         break;
       }
 #endif
 
 #ifdef USE_SIDEBAR
       case OP_SIDEBAR_OPEN:
-        change_folder_mailbox(menu, sb_get_highlight(), &oldcount, curr_msgid, false);
+        change_folder_mailbox(menu, sb_get_highlight(), &oldcount, &cur, false);
         break;
 #endif
 
@@ -2398,7 +2451,7 @@ int mutt_index_menu(struct MuttWindow *dlg)
           break;
         }
 
-        change_folder_mailbox(menu, m, &oldcount, curr_msgid, false);
+        change_folder_mailbox(menu, m, &oldcount, &cur, false);
         break;
       }
 
@@ -2449,13 +2502,13 @@ int mutt_index_menu(struct MuttWindow *dlg)
         struct Mailbox *m = mx_mbox_find2(mutt_b2s(folderbuf));
         if (m)
         {
-          change_folder_mailbox(menu, m, &oldcount, curr_msgid, read_only);
+          change_folder_mailbox(menu, m, &oldcount, &cur, read_only);
           pager_return = false;
         }
         else
         {
           change_folder_string(menu, folderbuf->data, folderbuf->dsize,
-                               &oldcount, curr_msgid, &pager_return, read_only);
+                               &oldcount, &cur, &pager_return, read_only);
         }
 
       changefoldercleanup:
@@ -2521,13 +2574,13 @@ int mutt_index_menu(struct MuttWindow *dlg)
         struct Mailbox *m = mx_mbox_find2(mutt_b2s(folderbuf));
         if (m)
         {
-          change_folder_mailbox(menu, m, &oldcount, curr_msgid, read_only);
+          change_folder_mailbox(menu, m, &oldcount, &cur, read_only);
           pager_return = false;
         }
         else
         {
           change_folder_string(menu, folderbuf->data, folderbuf->dsize,
-                               &oldcount, curr_msgid, &pager_return, read_only);
+                               &oldcount, &cur, &pager_return, read_only);
         }
         menu->help = mutt_compile_help(helpstr, sizeof(helpstr), MENU_MAIN, IndexNewsHelp);
 
@@ -2575,7 +2628,7 @@ int mutt_index_menu(struct MuttWindow *dlg)
         e_cur = get_cur_email(Context, menu);
         if (!e_cur)
           break;
-        mutt_str_replace(&curr_msgid, e_cur->env->message_id);
+        set_current_email(&cur, e_cur);
 
         op = mutt_display_message(win_index, win_ibar, win_pager, win_pbar,
                                   Context->mailbox, e_cur);
@@ -2591,7 +2644,7 @@ int mutt_index_menu(struct MuttWindow *dlg)
         in_pager = true;
         menu->oldcurrent = menu->current;
         if (Context && Context->mailbox)
-          update_index(menu, Context, MUTT_NEW_MAIL, Context->mailbox->msg_count, curr_msgid);
+          update_index(menu, Context, MUTT_NEW_MAIL, Context->mailbox->msg_count, &cur);
         continue;
       }
 
@@ -2869,44 +2922,44 @@ int mutt_index_menu(struct MuttWindow *dlg)
         int first_new = -1;
 
         const int saved_current = menu->current;
-        int cur = menu->current;
+        int mcur = menu->current;
         menu->current = -1;
         for (size_t i = 0; i != Context->mailbox->vcount; i++)
         {
           if ((op == OP_MAIN_NEXT_NEW) || (op == OP_MAIN_NEXT_UNREAD) ||
               (op == OP_MAIN_NEXT_NEW_THEN_UNREAD))
           {
-            cur++;
-            if (cur > (Context->mailbox->vcount - 1))
+            mcur++;
+            if (mcur > (Context->mailbox->vcount - 1))
             {
-              cur = 0;
+              mcur = 0;
             }
           }
           else
           {
-            cur--;
-            if (cur < 0)
+            mcur--;
+            if (mcur < 0)
             {
-              cur = Context->mailbox->vcount - 1;
+              mcur = Context->mailbox->vcount - 1;
             }
           }
 
-          struct Email *e = mutt_get_virt_email(Context->mailbox, cur);
+          struct Email *e = mutt_get_virt_email(Context->mailbox, mcur);
           if (!e)
             break;
           if (e->collapsed && ((C_Sort & SORT_MASK) == SORT_THREADS))
           {
             if ((UNREAD(e) != 0) && (first_unread == -1))
-              first_unread = cur;
+              first_unread = mcur;
             if ((UNREAD(e) == 1) && (first_new == -1))
-              first_new = cur;
+              first_new = mcur;
           }
           else if (!e->deleted && !e->read)
           {
             if (first_unread == -1)
-              first_unread = cur;
+              first_unread = mcur;
             if (!e->old && (first_new == -1))
-              first_new = cur;
+              first_new = mcur;
           }
 
           if (((op == OP_MAIN_NEXT_UNREAD) || (op == OP_MAIN_PREV_UNREAD)) &&
@@ -3975,7 +4028,7 @@ int mutt_index_menu(struct MuttWindow *dlg)
 
   mutt_menu_pop_current(menu);
   mutt_menu_free(&menu);
-  FREE(&curr_msgid);
+  FREE(&cur.message_id);
   return close;
 }
 

--- a/index.h
+++ b/index.h
@@ -48,7 +48,7 @@ void index_make_entry(char *buf, size_t buflen, struct Menu *menu, int line);
 void mutt_draw_statusline(int cols, const char *buf, size_t buflen);
 int  mutt_index_menu(struct MuttWindow *dlg);
 void mutt_set_header_color(struct Mailbox *m, struct Email *e);
-void update_index(struct Menu *menu, struct Context *ctx, int check, int oldcount, const char *curr_msgid);
+void mutt_update_index(struct Menu *menu, struct Context *ctx, int check, int oldcount, const struct Email *curr_email);
 struct MuttWindow *index_pager_init(void);
 void index_pager_shutdown(struct MuttWindow *dlg);
 int mutt_dlgindex_observer(struct NotifyCallback *nc);

--- a/pager.c
+++ b/pager.c
@@ -2396,7 +2396,7 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
 
             bool verbose = Context->mailbox->verbose;
             Context->mailbox->verbose = false;
-            update_index(rd.menu, Context, check, oldcount, e->env->message_id);
+            mutt_update_index(rd.menu, Context, check, oldcount, e);
             Context->mailbox->verbose = verbose;
 
             rd.menu->max = Context->mailbox->vcount;


### PR DESCRIPTION
This introduces a SelectedEmail struct to keep track of both the receive
time and the message id of the currently selected email. This way, when
the index is resorted, we first check for timestamps and only use string
comparison if the timestamps match. That should make the checking
faster.
