### PR TITLE
Convert libsend to use Config functions

### DIFF
--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -188,7 +188,7 @@ $(PWD)/compress:
 ###############################################################################
 # libconfig
 LIBCONFIG=	libconfig.a
-LIBCONFIGOBJS=	config/address.o config/bool.o config/dump.o config/enum.o \
+LIBCONFIGOBJS=	config/address.o config/bool.o config/dump.o config/enum.o config/helpers.o \
 		config/long.o config/mbtable.o config/number.o config/path.o config/quad.o \
 		config/regex.o config/set.o config/slist.o config/sort.o \
 		config/string.o config/subset.o

--- a/alias/alias.c
+++ b/alias/alias.c
@@ -168,7 +168,7 @@ static void expand_aliases_r(struct AddressList *al, struct ListHead *expn)
   }
 
   const char *fqdn = NULL;
-  if (C_UseDomain && (fqdn = mutt_fqdn(true)))
+  if (C_UseDomain && (fqdn = mutt_fqdn(true, NeoMutt->sub)))
   {
     /* now qualify all local addresses */
     mutt_addrlist_qualify(al, fqdn);
@@ -565,13 +565,13 @@ bool mutt_addr_is_user(const struct Address *addr)
     mutt_debug(LL_DEBUG5, "#2 yes, %s = %s @ %s\n", addr->mailbox, Username, ShortHostname);
     return true;
   }
-  const char *fqdn = mutt_fqdn(false);
+  const char *fqdn = mutt_fqdn(false, NeoMutt->sub);
   if (string_is_address(addr->mailbox, Username, fqdn))
   {
     mutt_debug(LL_DEBUG5, "#3 yes, %s = %s @ %s\n", addr->mailbox, Username, NONULL(fqdn));
     return true;
   }
-  fqdn = mutt_fqdn(true);
+  fqdn = mutt_fqdn(true, NeoMutt->sub);
   if (string_is_address(addr->mailbox, Username, fqdn))
   {
     mutt_debug(LL_DEBUG5, "#4 yes, %s = %s @ %s\n", addr->mailbox, Username, NONULL(fqdn));

--- a/alias/dlgquery.c
+++ b/alias/dlgquery.c
@@ -36,6 +36,7 @@
 #include "mutt/lib.h"
 #include "address/lib.h"
 #include "email/lib.h"
+#include "core/lib.h"
 #include "gui/lib.h"
 #include "mutt.h"
 #include "lib.h"
@@ -461,7 +462,7 @@ static void query_menu(char *buf, size_t buflen, struct AliasList *all, bool ret
             mutt_addrlist_clear(&al);
           }
         }
-        mutt_send_message(SEND_NO_FLAGS, e, NULL, Context, NULL);
+        mutt_send_message(SEND_NO_FLAGS, e, NULL, Context, NULL, NeoMutt->sub);
         menu->redraw = REDRAW_FULL;
         break;
       }

--- a/browser.c
+++ b/browser.c
@@ -2058,7 +2058,7 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
 
           mutt_path_concat(buf2, mutt_b2s(&LastDir),
                            state.entry[menu->current].name, sizeof(buf2));
-          struct Body *b = mutt_make_file_attach(buf2);
+          struct Body *b = mutt_make_file_attach(buf2, NeoMutt->sub);
           if (b)
           {
             mutt_view_attachment(NULL, b, MUTT_VA_REGULAR, NULL, NULL, menu->win_index);

--- a/commands.c
+++ b/commands.c
@@ -498,7 +498,7 @@ void ci_bounce_message(struct Mailbox *m, struct EmailList *el)
       break;
     }
 
-    rc = mutt_bounce_message(msg->fp, en->email, &al);
+    rc = mutt_bounce_message(msg->fp, en->email, &al, NeoMutt->sub);
     mx_msg_close(m, &msg);
 
     if (rc < 0)

--- a/config/helpers.c
+++ b/config/helpers.c
@@ -1,0 +1,232 @@
+/**
+ * @file
+ * Helper functions to get config values
+ *
+ * @authors
+ * Copyright (C) 2020 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @page config_helpers Helper functions to get config values
+ *
+ * Helper functions to get config values
+ */
+
+#include "config.h"
+#include <assert.h>
+#include <limits.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include "mutt/lib.h"
+#include "quad.h"
+#include "subset.h"
+#include "types.h"
+
+/**
+ * cs_subset_address - Get an Address config item by name
+ * @param sub   Config Subset
+ * @param name  Name of config item
+ * @retval ptr  Address
+ * @retval NULL Empty address
+ */
+const struct Address *cs_subset_address(const struct ConfigSubset *sub, const char *name)
+{
+  assert(sub && name);
+
+  struct HashElem *he = cs_subset_create_inheritance(sub, name);
+  assert(he);
+
+  assert(DTYPE(he->type) == DT_ADDRESS);
+
+  intptr_t value = cs_subset_he_native_get(sub, he, NULL);
+  assert(value != INT_MIN);
+
+  return (const struct Address *) value;
+}
+
+/**
+ * cs_subset_bool - Get a boolean config item by name
+ * @param sub   Config Subset
+ * @param name  Name of config item
+ * @retval bool  Boolean
+ */
+bool cs_subset_bool(const struct ConfigSubset *sub, const char *name)
+{
+  assert(sub && name);
+
+  struct HashElem *he = cs_subset_create_inheritance(sub, name);
+  assert(he);
+
+  assert (DTYPE(he->type) == DT_BOOL);
+
+  intptr_t value = cs_subset_he_native_get(sub, he, false);
+  assert(value != INT_MIN);
+
+  return (bool) value;
+}
+
+/**
+ * cs_subset_long - Get a long config item by name
+ * @param sub   Config Subset
+ * @param name  Name of config item
+ * @retval num Long value
+ */
+long cs_subset_long(const struct ConfigSubset *sub, const char *name)
+{
+  assert(sub && name);
+
+  struct HashElem *he = cs_subset_create_inheritance(sub, name);
+  assert(he);
+
+  assert (DTYPE(he->type) == DT_LONG);
+
+  intptr_t value = cs_subset_he_native_get(sub, he, 0);
+  assert(value != INT_MIN);
+
+  return (long) value;
+}
+
+/**
+ * cs_subset_number - Get a number config item by name
+ * @param sub   Config Subset
+ * @param name  Name of config item
+ * @retval num Number
+ */
+short cs_subset_number(const struct ConfigSubset *sub, const char *name)
+{
+  assert(sub && name);
+
+  struct HashElem *he = cs_subset_create_inheritance(sub, name);
+  assert(he);
+
+  assert (DTYPE(he->type) == DT_NUMBER);
+
+  intptr_t value = cs_subset_he_native_get(sub, he, 0);
+  assert(value != INT_MIN);
+
+  return (short) value;
+}
+
+/**
+ * cs_subset_path - Get a path config item by name
+ * @param sub   Config Subset
+ * @param name  Name of config item
+ * @retval ptr  Path
+ * @retval NULL Empty path
+ */
+const char *cs_subset_path(const struct ConfigSubset *sub, const char *name)
+{
+  assert(sub && name);
+
+  struct HashElem *he = cs_subset_create_inheritance(sub, name);
+  assert(he);
+
+  assert (DTYPE(he->type) == DT_PATH);
+
+  intptr_t value = cs_subset_he_native_get(sub, he, NULL);
+  assert(value != INT_MIN);
+
+  return (const char *) value;
+}
+
+/**
+ * cs_subset_quad - Get a quad-value config item by name
+ * @param sub   Config Subset
+ * @param name  Name of config item
+ * @retval num Quad-value
+ */
+enum QuadOption cs_subset_quad(const struct ConfigSubset *sub, const char *name)
+{
+  assert(sub && name);
+
+  struct HashElem *he = cs_subset_create_inheritance(sub, name);
+  assert(he);
+
+  assert (DTYPE(he->type) == DT_QUAD);
+
+  intptr_t value = cs_subset_he_native_get(sub, he, NULL);
+  assert(value != INT_MIN);
+
+  return (enum QuadOption) value;
+}
+
+/**
+ * cs_subset_regex - Get a regex config item by name
+ * @param sub   Config Subset
+ * @param name  Name of config item
+ * @retval ptr  Regex
+ * @retval NULL Empty regex
+ */
+const struct Regex *cs_subset_regex(const struct ConfigSubset *sub, const char *name)
+{
+  assert(sub && name);
+
+  struct HashElem *he = cs_subset_create_inheritance(sub, name);
+  assert(he);
+
+  assert (DTYPE(he->type) == DT_REGEX);
+
+  intptr_t value = cs_subset_he_native_get(sub, he, NULL);
+  assert(value != INT_MIN);
+
+  return (const struct Regex *) value;
+}
+
+/**
+ * cs_subset_slist - Get a string-list config item by name
+ * @param sub   Config Subset
+ * @param name  Name of config item
+ * @retval ptr  String list
+ * @retval NULL Empty string list
+ */
+const struct Slist *cs_subset_slist(const struct ConfigSubset *sub, const char *name)
+{
+  assert(sub && name);
+
+  struct HashElem *he = cs_subset_create_inheritance(sub, name);
+  assert(he);
+
+  assert (DTYPE(he->type) == DT_SLIST);
+
+  intptr_t value = cs_subset_he_native_get(sub, he, NULL);
+  assert(value != INT_MIN);
+
+  return (const struct Slist *) value;
+}
+
+/**
+ * cs_subset_string - Get a string config item by name
+ * @param sub   Config Subset
+ * @param name  Name of config item
+ * @retval ptr  String
+ * @retval NULL Empty string
+ */
+const char *cs_subset_string(const struct ConfigSubset *sub, const char *name)
+{
+  assert(sub && name);
+
+  struct HashElem *he = cs_subset_create_inheritance(sub, name);
+  assert(he);
+
+  assert (DTYPE(he->type) == DT_STRING);
+
+  intptr_t value = cs_subset_he_native_get(sub, he, NULL);
+  assert(value != INT_MIN);
+
+  return (const char *) value;
+}

--- a/config/helpers.h
+++ b/config/helpers.h
@@ -1,0 +1,41 @@
+/**
+ * @file
+ * Helper functions to get config values
+ *
+ * @authors
+ * Copyright (C) 2020 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MUTT_CONFIG_HELPERS_H
+#define MUTT_CONFIG_HELPERS_H
+
+#include "quad.h"
+
+struct ConfigSubset;
+
+const struct Address *cs_subset_address(const struct ConfigSubset *sub, const char *name);
+bool                  cs_subset_bool   (const struct ConfigSubset *sub, const char *name);
+long                  cs_subset_long   (const struct ConfigSubset *sub, const char *name);
+short                 cs_subset_number (const struct ConfigSubset *sub, const char *name);
+const char *          cs_subset_path   (const struct ConfigSubset *sub, const char *name);
+enum QuadOption       cs_subset_quad   (const struct ConfigSubset *sub, const char *name);
+const struct Regex *  cs_subset_regex  (const struct ConfigSubset *sub, const char *name);
+const struct Slist *  cs_subset_slist  (const struct ConfigSubset *sub, const char *name);
+const char *          cs_subset_string (const struct ConfigSubset *sub, const char *name);
+
+#endif /* MUTT_CONFIG_HELPERS_H */
+

--- a/config/lib.h
+++ b/config/lib.h
@@ -31,6 +31,7 @@
  * | config/bool.c       | @subpage config_bool       |
  * | config/dump.c       | @subpage config_dump       |
  * | config/enum.c       | @subpage config_enum       |
+ * | config/helpers.c    | @subpage config_helpers    |
  * | config/long.c       | @subpage config_long       |
  * | config/mbtable.c    | @subpage config_mbtable    |
  * | config/number.c     | @subpage config_number     |
@@ -52,6 +53,7 @@
 #include "bool.h"
 #include "dump.h"
 #include "enum.h"
+#include "helpers.h"
 #include "inheritance.h"
 #include "long.h"
 #include "mbtable.h"

--- a/config/mbtable.c
+++ b/config/mbtable.c
@@ -61,7 +61,7 @@ struct MbTable *mbtable_parse(const char *s)
 
   t->orig_str = mutt_str_dup(s);
   /* This could be more space efficient.  However, being used on tiny
-   * strings (C_ToChars and C_StatusChars), the overhead is not great. */
+   * strings (`$to_chars` and `$status_chars`), the overhead is not great. */
   t->chars = mutt_mem_calloc(slen, sizeof(char *));
   t->segmented_str = mutt_mem_calloc(slen * 2, sizeof(char));
   d = t->segmented_str;

--- a/copy.c
+++ b/copy.c
@@ -356,7 +356,8 @@ int mutt_copy_hdr(FILE *fp_in, FILE *fp_out, LOFF_T off_start, LOFF_T off_end,
         const char *pre = (chflags & CH_PREFIX) ? prefix : NULL;
         wraplen = mutt_window_wrap_cols(wraplen, C_Wrap);
 
-        if (mutt_write_one_header(fp_out, 0, headers[x], pre, wraplen, chflags) == -1)
+        if (mutt_write_one_header(fp_out, 0, headers[x], pre, wraplen, chflags,
+                                  NeoMutt->sub) == -1)
         {
           error = true;
           break;
@@ -440,7 +441,7 @@ int mutt_copy_header(FILE *fp_in, struct Email *e, FILE *fp_out,
   if ((chflags & CH_UPDATE_REFS) && !STAILQ_EMPTY(&e->env->references))
   {
     fputs("References:", fp_out);
-    mutt_write_references(&e->env->references, fp_out, 0);
+    mutt_write_references(&e->env->references, fp_out, 0, NeoMutt->sub);
     fputc('\n', fp_out);
   }
 
@@ -510,8 +511,9 @@ int mutt_copy_header(FILE *fp_in, struct Email *e, FILE *fp_out,
       temp_hdr = mutt_str_dup(temp_hdr);
       rfc2047_encode(&temp_hdr, NULL, sizeof("X-Label:"), C_SendCharset);
     }
-    if (mutt_write_one_header(fp_out, "X-Label", temp_hdr, (chflags & CH_PREFIX) ? prefix : 0,
-                              mutt_window_wrap_cols(wraplen, C_Wrap), chflags) == -1)
+    if (mutt_write_one_header(
+            fp_out, "X-Label", temp_hdr, (chflags & CH_PREFIX) ? prefix : 0,
+            mutt_window_wrap_cols(wraplen, C_Wrap), chflags, NeoMutt->sub) == -1)
     {
       return -1;
     }
@@ -529,8 +531,9 @@ int mutt_copy_header(FILE *fp_in, struct Email *e, FILE *fp_out,
       temp_hdr = mutt_str_dup(temp_hdr);
       rfc2047_encode(&temp_hdr, NULL, sizeof("Subject:"), C_SendCharset);
     }
-    if (mutt_write_one_header(fp_out, "Subject", temp_hdr, (chflags & CH_PREFIX) ? prefix : 0,
-                              mutt_window_wrap_cols(wraplen, C_Wrap), chflags) == -1)
+    if (mutt_write_one_header(
+            fp_out, "Subject", temp_hdr, (chflags & CH_PREFIX) ? prefix : 0,
+            mutt_window_wrap_cols(wraplen, C_Wrap), chflags, NeoMutt->sub) == -1)
     {
       return -1;
     }
@@ -753,7 +756,7 @@ int mutt_copy_message_fp(FILE *fp_out, FILE *fp_in, struct Email *e,
       return -1;
     }
 
-    mutt_write_mime_header(cur, fp_out);
+    mutt_write_mime_header(cur, fp_out, NeoMutt->sub);
     fputc('\n', fp_out);
 
     if (fseeko(fp, cur->offset, SEEK_SET) < 0)

--- a/index.c
+++ b/index.c
@@ -1986,7 +1986,7 @@ int mutt_index_menu(struct MuttWindow *dlg)
         struct EmailList el = STAILQ_HEAD_INITIALIZER(el);
         struct Email *e_cur = get_cur_email(Context, menu);
         el_add_tagged(&el, Context, e_cur, tag);
-        mutt_send_message(SEND_TO_SENDER, NULL, NULL, Context, &el);
+        mutt_send_message(SEND_TO_SENDER, NULL, NULL, Context, &el, NeoMutt->sub);
         emaillist_clear(&el);
         menu->redraw = REDRAW_FULL;
         break;
@@ -3447,7 +3447,7 @@ int mutt_index_menu(struct MuttWindow *dlg)
         {
           mutt_check_traditional_pgp(&el, &menu->redraw);
         }
-        mutt_send_message(SEND_FORWARD, NULL, NULL, Context, &el);
+        mutt_send_message(SEND_FORWARD, NULL, NULL, Context, &el, NeoMutt->sub);
         emaillist_clear(&el);
         menu->redraw = REDRAW_FULL;
         break;
@@ -3476,7 +3476,7 @@ int mutt_index_menu(struct MuttWindow *dlg)
         {
           mutt_check_traditional_pgp(&el, &menu->redraw);
         }
-        mutt_send_message(replyflags, NULL, NULL, Context, &el);
+        mutt_send_message(replyflags, NULL, NULL, Context, &el, NeoMutt->sub);
         emaillist_clear(&el);
         menu->redraw = REDRAW_FULL;
         break;
@@ -3525,7 +3525,8 @@ int mutt_index_menu(struct MuttWindow *dlg)
         {
           mutt_check_traditional_pgp(&el, &menu->redraw);
         }
-        mutt_send_message(SEND_REPLY | SEND_LIST_REPLY, NULL, NULL, Context, &el);
+        mutt_send_message(SEND_REPLY | SEND_LIST_REPLY, NULL, NULL, Context,
+                          &el, NeoMutt->sub);
         emaillist_clear(&el);
         menu->redraw = REDRAW_FULL;
         break;
@@ -3534,7 +3535,7 @@ int mutt_index_menu(struct MuttWindow *dlg)
       case OP_MAIL:
         if (!prereq(Context, menu, CHECK_ATTACH))
           break;
-        mutt_send_message(SEND_NO_FLAGS, NULL, NULL, Context, NULL);
+        mutt_send_message(SEND_NO_FLAGS, NULL, NULL, Context, NULL, NeoMutt->sub);
         menu->redraw = REDRAW_FULL;
         break;
 
@@ -3543,7 +3544,7 @@ int mutt_index_menu(struct MuttWindow *dlg)
           break;
         if (!prereq(Context, menu, CHECK_ATTACH))
           break;
-        mutt_send_message(SEND_KEY, NULL, NULL, NULL, NULL);
+        mutt_send_message(SEND_KEY, NULL, NULL, NULL, NULL, NeoMutt->sub);
         menu->redraw = REDRAW_FULL;
         break;
 
@@ -3709,7 +3710,7 @@ int mutt_index_menu(struct MuttWindow *dlg)
       case OP_RECALL_MESSAGE:
         if (!prereq(Context, menu, CHECK_ATTACH))
           break;
-        mutt_send_message(SEND_POSTPONED, NULL, NULL, Context, NULL);
+        mutt_send_message(SEND_POSTPONED, NULL, NULL, Context, NULL, NeoMutt->sub);
         menu->redraw = REDRAW_FULL;
         break;
 
@@ -3726,13 +3727,13 @@ int mutt_index_menu(struct MuttWindow *dlg)
             if (!e)
               break;
             if (message_is_tagged(Context, e))
-              mutt_resend_message(NULL, Context, e);
+              mutt_resend_message(NULL, Context, e, NeoMutt->sub);
           }
         }
         else
         {
           struct Email *e_cur = get_cur_email(Context, menu);
-          mutt_resend_message(NULL, Context, e_cur);
+          mutt_resend_message(NULL, Context, e_cur, NeoMutt->sub);
         }
 
         menu->redraw = REDRAW_FULL;
@@ -3763,7 +3764,7 @@ int mutt_index_menu(struct MuttWindow *dlg)
             break;
           }
           if (op == OP_POST)
-            mutt_send_message(SEND_NEWS, NULL, NULL, Context, NULL);
+            mutt_send_message(SEND_NEWS, NULL, NULL, Context, NULL, NeoMutt->sub);
           else
           {
             if (!prereq(Context, menu, CHECK_IN_MAILBOX | CHECK_MSGCOUNT))
@@ -3771,7 +3772,7 @@ int mutt_index_menu(struct MuttWindow *dlg)
             struct EmailList el = STAILQ_HEAD_INITIALIZER(el);
             el_add_tagged(&el, Context, e_cur, tag);
             mutt_send_message(((op == OP_FOLLOWUP) ? SEND_REPLY : SEND_FORWARD) | SEND_NEWS,
-                              NULL, NULL, Context, &el);
+                              NULL, NULL, Context, &el, NeoMutt->sub);
             emaillist_clear(&el);
           }
           menu->redraw = REDRAW_FULL;
@@ -3793,7 +3794,7 @@ int mutt_index_menu(struct MuttWindow *dlg)
         {
           mutt_check_traditional_pgp(&el, &menu->redraw);
         }
-        mutt_send_message(SEND_REPLY, NULL, NULL, Context, &el);
+        mutt_send_message(SEND_REPLY, NULL, NULL, Context, &el, NeoMutt->sub);
         emaillist_clear(&el);
         menu->redraw = REDRAW_FULL;
         break;

--- a/main.c
+++ b/main.c
@@ -808,7 +808,7 @@ int main(int argc, char *argv[], char *envp[])
   {
     if (!OptNoCurses)
       mutt_flushinp();
-    if (mutt_send_message(SEND_POSTPONED, NULL, NULL, NULL, NULL) == 0)
+    if (mutt_send_message(SEND_POSTPONED, NULL, NULL, NULL, NULL, NeoMutt->sub) == 0)
       rc = 0;
     // TEST23: neomutt -p (postponed message, cancel)
     // TEST24: neomutt -p (no postponed message)
@@ -1018,12 +1018,12 @@ int main(int argc, char *argv[], char *envp[])
       {
         if (b)
         {
-          b->next = mutt_make_file_attach(np->data);
+          b->next = mutt_make_file_attach(np->data, NeoMutt->sub);
           b = b->next;
         }
         else
         {
-          b = mutt_make_file_attach(np->data);
+          b = mutt_make_file_attach(np->data, NeoMutt->sub);
           e->content = b;
         }
         if (!b)
@@ -1037,7 +1037,7 @@ int main(int argc, char *argv[], char *envp[])
       mutt_list_free(&attach);
     }
 
-    rv = mutt_send_message(sendflags, e, bodyfile, NULL, NULL);
+    rv = mutt_send_message(sendflags, e, bodyfile, NULL, NULL, NeoMutt->sub);
     /* We WANT the "Mail sent." and any possible, later error */
     log_queue_empty();
     if (ErrorBufMessage)
@@ -1069,18 +1069,19 @@ int main(int argc, char *argv[], char *envp[])
         {
           if (e->content->next)
             e->content = mutt_make_multipart(e->content);
-          mutt_encode_descriptions(e->content, true);
-          mutt_prepare_envelope(e->env, false);
+          mutt_encode_descriptions(e->content, true, NeoMutt->sub);
+          mutt_prepare_envelope(e->env, false, NeoMutt->sub);
           mutt_env_to_intl(e->env, NULL, NULL);
         }
 
         mutt_rfc822_write_header(
             fp_out, e->env, e->content, MUTT_WRITE_HEADER_POSTPONE, false,
-            C_CryptProtectedHeadersRead && mutt_should_hide_protected_subject(e));
+            C_CryptProtectedHeadersRead && mutt_should_hide_protected_subject(e),
+            NeoMutt->sub);
         if (C_ResumeEditedDraftFiles)
           fprintf(fp_out, "X-Mutt-Resume-Draft: 1\n");
         fputc('\n', fp_out);
-        if ((mutt_write_mime_body(e->content, fp_out) == -1))
+        if ((mutt_write_mime_body(e->content, fp_out, NeoMutt->sub) == -1))
         {
           mutt_file_fclose(&fp_out);
           email_free(&e);

--- a/mutt/charset.c
+++ b/mutt/charset.c
@@ -303,7 +303,7 @@ static const char *lookup_charset(enum LookupType type, const char *cs)
  * @retval 0  Success
  * @retval -1 Error
  *
- * Work through #C_AssumedCharset looking for a character set conversion that
+ * Work through `$assumed_charset` looking for a character set conversion that
  * works.  Failing that, try mutt_ch_get_default_charset().
  */
 int mutt_ch_convert_nonmime_string(char **ps)

--- a/mutt_header.c
+++ b/mutt_header.c
@@ -184,7 +184,8 @@ void mutt_edit_headers(const char *editor, const char *body, struct Email *e,
   }
 
   mutt_env_to_local(e->env);
-  mutt_rfc822_write_header(fp_out, e->env, NULL, MUTT_WRITE_HEADER_EDITHDRS, false, false);
+  mutt_rfc822_write_header(fp_out, e->env, NULL, MUTT_WRITE_HEADER_EDITHDRS,
+                           false, false, NeoMutt->sub);
   fputc('\n', fp_out); /* tie off the header. */
 
   /* now copy the body of the message. */
@@ -314,7 +315,7 @@ void mutt_edit_headers(const char *editor, const char *body, struct Email *e,
         p = mutt_str_skip_email_wsp(p);
 
         mutt_buffer_expand_path(path);
-        body2 = mutt_make_file_attach(mutt_b2s(path));
+        body2 = mutt_make_file_attach(mutt_b2s(path), NeoMutt->sub);
         if (body2)
         {
           body2->description = mutt_str_dup(p);

--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -52,6 +52,7 @@
 #include "address/lib.h"
 #include "config/lib.h"
 #include "email/lib.h"
+#include "core/lib.h"
 #include "alias/lib.h"
 #include "gui/lib.h"
 #include "mutt.h"
@@ -862,9 +863,9 @@ static gpgme_data_t body_to_data_object(struct Body *a, bool convert)
     goto cleanup;
   }
 
-  mutt_write_mime_header(a, fp_tmp);
+  mutt_write_mime_header(a, fp_tmp, NeoMutt->sub);
   fputc('\n', fp_tmp);
-  mutt_write_mime_body(a, fp_tmp);
+  mutt_write_mime_body(a, fp_tmp, NeoMutt->sub);
 
   if (convert)
   {
@@ -5246,7 +5247,7 @@ static char *find_keys(struct AddressList *addrlist, unsigned int app, bool oppe
   size_t keylist_used = 0;
   struct Address *p = NULL;
   struct CryptKeyInfo *k_info = NULL;
-  const char *fqdn = mutt_fqdn(true);
+  const char *fqdn = mutt_fqdn(true, NeoMutt->sub);
   char buf[1024];
   int forced_valid;
   bool key_selected;
@@ -5511,7 +5512,7 @@ struct Body *pgp_gpgme_make_key_attachment(void)
      but it may be safer to keep it untranslated. */
   snprintf(buf, sizeof(buf), _("PGP Key 0x%s"), crypt_keyid(key));
   att->description = mutt_str_dup(buf);
-  mutt_update_encoding(att);
+  mutt_update_encoding(att, NeoMutt->sub);
 
   stat(tempf, &sb);
   att->length = sb.st_size;

--- a/ncrypt/pgp.c
+++ b/ncrypt/pgp.c
@@ -44,6 +44,7 @@
 #include "address/lib.h"
 #include "config/lib.h"
 #include "email/lib.h"
+#include "core/lib.h"
 #include "gui/lib.h"
 #include "mutt.h"
 #include "lib.h"
@@ -1317,9 +1318,9 @@ struct Body *pgp_class_sign_message(struct Body *a, const struct AddressList *fr
     goto cleanup;
   }
 
-  mutt_write_mime_header(a, fp_signed);
+  mutt_write_mime_header(a, fp_signed, NeoMutt->sub);
   fputc('\n', fp_signed);
-  mutt_write_mime_body(a, fp_signed);
+  mutt_write_mime_body(a, fp_signed, NeoMutt->sub);
   mutt_file_fclose(&fp_signed);
 
   pid = pgp_invoke_sign(&fp_pgp_in, &fp_pgp_out, &fp_pgp_err, -1, -1, -1,
@@ -1427,7 +1428,7 @@ char *pgp_class_find_keys(struct AddressList *addrlist, bool oppenc_mode)
   size_t keylist_used = 0;
   struct Address *p = NULL;
   struct PgpKeyInfo *k_info = NULL;
-  const char *fqdn = mutt_fqdn(true);
+  const char *fqdn = mutt_fqdn(true, NeoMutt->sub);
   char buf[1024];
   bool key_selected;
   struct AddressList hookal = TAILQ_HEAD_INITIALIZER(hookal);
@@ -1582,9 +1583,9 @@ struct Body *pgp_class_encrypt_message(struct Body *a, char *keylist, bool sign,
   if (sign)
     crypt_convert_to_7bit(a);
 
-  mutt_write_mime_header(a, fp_tmp);
+  mutt_write_mime_header(a, fp_tmp, NeoMutt->sub);
   fputc('\n', fp_tmp);
-  mutt_write_mime_body(a, fp_tmp);
+  mutt_write_mime_body(a, fp_tmp, NeoMutt->sub);
   mutt_file_fclose(&fp_tmp);
 
   pid = pgp_invoke_encrypt(&fp_pgp_in, NULL, NULL, -1, fileno(fp_out),

--- a/ncrypt/pgpkey.c
+++ b/ncrypt/pgpkey.c
@@ -42,6 +42,7 @@
 #include "address/lib.h"
 #include "config/lib.h"
 #include "email/lib.h"
+#include "core/lib.h"
 #include "gui/lib.h"
 #include "mutt.h"
 #include "pgpkey.h"
@@ -969,7 +970,7 @@ struct Body *pgp_class_make_key_attachment(void)
   att->subtype = mutt_str_dup("pgp-keys");
   snprintf(buf, sizeof(buf), _("PGP Key %s"), tmp);
   att->description = mutt_str_dup(buf);
-  mutt_update_encoding(att);
+  mutt_update_encoding(att, NeoMutt->sub);
 
   stat(mutt_b2s(tempf), &sb);
   att->length = sb.st_size;

--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -1048,7 +1048,7 @@ void smime_class_getkeys(struct Envelope *env)
     }
   }
 
-  struct Address *f = mutt_default_from();
+  struct Address *f = mutt_default_from(NeoMutt->sub);
   getkeys(f->mailbox);
   mutt_addr_free(&f);
 }
@@ -1621,9 +1621,9 @@ struct Body *smime_class_build_smime_entity(struct Body *a, char *certlist)
   }
 
   /* write a MIME entity */
-  mutt_write_mime_header(a, fp_tmp);
+  mutt_write_mime_header(a, fp_tmp, NeoMutt->sub);
   fputc('\n', fp_tmp);
-  mutt_write_mime_body(a, fp_tmp);
+  mutt_write_mime_body(a, fp_tmp, NeoMutt->sub);
   mutt_file_fclose(&fp_tmp);
 
   pid = smime_invoke_encrypt(&fp_smime_in, NULL, NULL, -1, fileno(fp_out),
@@ -1773,9 +1773,9 @@ struct Body *smime_class_sign_message(struct Body *a, const struct AddressList *
     goto cleanup;
   }
 
-  mutt_write_mime_header(a, fp_sign);
+  mutt_write_mime_header(a, fp_sign, NeoMutt->sub);
   fputc('\n', fp_sign);
-  mutt_write_mime_body(a, fp_sign);
+  mutt_write_mime_body(a, fp_sign, NeoMutt->sub);
   mutt_file_fclose(&fp_sign);
 
   mutt_buffer_printf(&SmimeKeyToUse, "%s/%s", NONULL(C_SmimeKeys), signas);

--- a/pager.c
+++ b/pager.c
@@ -2945,7 +2945,7 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         if (IsMsgAttach(extra))
           mutt_attach_resend(extra->fp, extra->actx, extra->body);
         else
-          mutt_resend_message(NULL, extra->ctx, extra->email);
+          mutt_resend_message(NULL, extra->ctx, extra->email, NeoMutt->sub);
         pager_menu->redraw = REDRAW_FULL;
         break;
 
@@ -2958,7 +2958,7 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         {
           struct EmailList el = STAILQ_HEAD_INITIALIZER(el);
           emaillist_add_email(&el, extra->email);
-          mutt_send_message(SEND_TO_SENDER, NULL, NULL, extra->ctx, &el);
+          mutt_send_message(SEND_TO_SENDER, NULL, NULL, extra->ctx, &el, NeoMutt->sub);
           emaillist_clear(&el);
         }
         pager_menu->redraw = REDRAW_FULL;
@@ -3143,7 +3143,7 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
       case OP_MAIL:
         CHECK_MODE(IsEmail(extra) && !IsAttach(extra));
         CHECK_ATTACH;
-        mutt_send_message(SEND_NO_FLAGS, NULL, NULL, extra->ctx, NULL);
+        mutt_send_message(SEND_NO_FLAGS, NULL, NULL, extra->ctx, NULL, NeoMutt->sub);
         pager_menu->redraw = REDRAW_FULL;
         break;
 
@@ -3156,7 +3156,7 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         {
           break;
         }
-        mutt_send_message(SEND_NEWS, NULL, NULL, extra->ctx, NULL);
+        mutt_send_message(SEND_NEWS, NULL, NULL, extra->ctx, NULL, NeoMutt->sub);
         pager_menu->redraw = REDRAW_FULL;
         break;
 
@@ -3174,7 +3174,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         {
           struct EmailList el = STAILQ_HEAD_INITIALIZER(el);
           emaillist_add_email(&el, extra->email);
-          mutt_send_message(SEND_NEWS | SEND_FORWARD, NULL, NULL, extra->ctx, &el);
+          mutt_send_message(SEND_NEWS | SEND_FORWARD, NULL, NULL, extra->ctx,
+                            &el, NeoMutt->sub);
           emaillist_clear(&el);
         }
         pager_menu->redraw = REDRAW_FULL;
@@ -3207,7 +3208,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
           {
             struct EmailList el = STAILQ_HEAD_INITIALIZER(el);
             emaillist_add_email(&el, extra->email);
-            mutt_send_message(SEND_NEWS | SEND_REPLY, NULL, NULL, extra->ctx, &el);
+            mutt_send_message(SEND_NEWS | SEND_REPLY, NULL, NULL, extra->ctx,
+                              &el, NeoMutt->sub);
             emaillist_clear(&el);
           }
           pager_menu->redraw = REDRAW_FULL;
@@ -3237,7 +3239,7 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         {
           struct EmailList el = STAILQ_HEAD_INITIALIZER(el);
           emaillist_add_email(&el, extra->email);
-          mutt_send_message(replyflags, NULL, NULL, extra->ctx, &el);
+          mutt_send_message(replyflags, NULL, NULL, extra->ctx, &el, NeoMutt->sub);
           emaillist_clear(&el);
         }
         pager_menu->redraw = REDRAW_FULL;
@@ -3250,7 +3252,7 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         CHECK_ATTACH;
         struct EmailList el = STAILQ_HEAD_INITIALIZER(el);
         emaillist_add_email(&el, extra->email);
-        mutt_send_message(SEND_POSTPONED, NULL, NULL, extra->ctx, &el);
+        mutt_send_message(SEND_POSTPONED, NULL, NULL, extra->ctx, &el, NeoMutt->sub);
         emaillist_clear(&el);
         pager_menu->redraw = REDRAW_FULL;
         break;
@@ -3265,7 +3267,7 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         {
           struct EmailList el = STAILQ_HEAD_INITIALIZER(el);
           emaillist_add_email(&el, extra->email);
-          mutt_send_message(SEND_FORWARD, NULL, NULL, extra->ctx, &el);
+          mutt_send_message(SEND_FORWARD, NULL, NULL, extra->ctx, &el, NeoMutt->sub);
           emaillist_clear(&el);
         }
         pager_menu->redraw = REDRAW_FULL;
@@ -3442,7 +3444,7 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         CHECK_ATTACH;
         struct EmailList el = STAILQ_HEAD_INITIALIZER(el);
         emaillist_add_email(&el, extra->email);
-        mutt_send_message(SEND_KEY, NULL, NULL, extra->ctx, &el);
+        mutt_send_message(SEND_KEY, NULL, NULL, extra->ctx, &el, NeoMutt->sub);
         emaillist_clear(&el);
         pager_menu->redraw = REDRAW_FULL;
         break;

--- a/pattern.c
+++ b/pattern.c
@@ -2063,7 +2063,8 @@ static int msg_search_sendmode(struct Email *e, struct Pattern *pat)
       return 0;
     }
 
-    mutt_rfc822_write_header(fp, e->env, e->content, MUTT_WRITE_HEADER_POSTPONE, false, false);
+    mutt_rfc822_write_header(fp, e->env, e->content, MUTT_WRITE_HEADER_POSTPONE,
+                             false, false, NeoMutt->sub);
     fflush(fp);
     fseek(fp, 0, 0);
 

--- a/recvattach.c
+++ b/recvattach.c
@@ -787,7 +787,7 @@ static void query_pipe_attachment(const char *command, FILE *fp, struct Body *bo
     {
       mutt_file_unlink(body->filename);
       mutt_file_rename(tfile, body->filename);
-      mutt_update_encoding(body);
+      mutt_update_encoding(body, NeoMutt->sub);
       mutt_message(_("Attachment filtered"));
     }
   }

--- a/remailer.c
+++ b/remailer.c
@@ -876,7 +876,7 @@ int mix_check_message(struct Email *e)
 
   if (need_hostname)
   {
-    const char *fqdn = mutt_fqdn(true);
+    const char *fqdn = mutt_fqdn(true, NeoMutt->sub);
     if (!fqdn)
     {
       mutt_error(_("Please set the hostname variable to a proper value when "

--- a/send/body.c
+++ b/send/body.c
@@ -305,12 +305,13 @@ static bool write_as_text_part(struct Body *b)
 
 /**
  * mutt_write_mime_body - Write a MIME part
- * @param a  Body to use
- * @param fp File to write to
+ * @param a   Body to use
+ * @param fp  File to write to
+ * @param sub Config Subset
  * @retval  0 Success
  * @retval -1 Failure
  */
-int mutt_write_mime_body(struct Body *a, FILE *fp)
+int mutt_write_mime_body(struct Body *a, FILE *fp, struct ConfigSubset *sub)
 {
   FILE *fp_in = NULL;
   struct FgetConv *fc = NULL;
@@ -331,10 +332,10 @@ int mutt_write_mime_body(struct Body *a, FILE *fp)
     for (struct Body *t = a->parts; t; t = t->next)
     {
       fprintf(fp, "\n--%s\n", boundary);
-      if (mutt_write_mime_header(t, fp) == -1)
+      if (mutt_write_mime_header(t, fp, sub) == -1)
         return -1;
       fputc('\n', fp);
-      if (mutt_write_mime_body(t, fp) == -1)
+      if (mutt_write_mime_body(t, fp, sub) == -1)
         return -1;
     }
     fprintf(fp, "\n--%s--\n", boundary);

--- a/send/body.h
+++ b/send/body.h
@@ -26,7 +26,8 @@
 #include <stdio.h>
 
 struct Body;
+struct ConfigSubset;
 
-int mutt_write_mime_body(struct Body *a, FILE *fp);
+int mutt_write_mime_body(struct Body *a, FILE *fp, struct ConfigSubset *sub);
 
 #endif /* MUTT_SEND_BODY_H */

--- a/send/header.h
+++ b/send/header.h
@@ -28,6 +28,7 @@
 #include <stdio.h>
 
 struct Body;
+struct ConfigSubset;
 struct Envelope;
 struct ListHead;
 
@@ -43,9 +44,9 @@ enum MuttWriteHeaderMode
   MUTT_WRITE_HEADER_MIME,     ///< Write protected headers
 };
 
-int  mutt_rfc822_write_header(FILE *fp, struct Envelope *env, struct Body *attach, enum MuttWriteHeaderMode mode, bool privacy, bool hide_protected_subject);
-int  mutt_write_mime_header(struct Body *a, FILE *fp);
-int  mutt_write_one_header(FILE *fp, const char *tag, const char *value, const char *pfx, int wraplen, CopyHeaderFlags chflags);
-void mutt_write_references(const struct ListHead *r, FILE *fp, size_t trim);
+int  mutt_rfc822_write_header(FILE *fp, struct Envelope *env, struct Body *attach, enum MuttWriteHeaderMode mode, bool privacy, bool hide_protected_subject, struct ConfigSubset *sub);
+int  mutt_write_mime_header(struct Body *a, FILE *fp, struct ConfigSubset *sub);
+int  mutt_write_one_header(FILE *fp, const char *tag, const char *value, const char *pfx, int wraplen, CopyHeaderFlags chflags, struct ConfigSubset *sub);
+void mutt_write_references(const struct ListHead *r, FILE *fp, size_t trim, struct ConfigSubset *sub);
 
 #endif /* MUTT_SEND_HEADER_H */

--- a/send/send.h
+++ b/send/send.h
@@ -29,6 +29,7 @@
 
 struct AddressList;
 struct Body;
+struct ConfigSubset;
 struct Context;
 struct Email;
 struct EmailList;
@@ -52,20 +53,20 @@ typedef uint16_t SendFlags;             ///< Flags for mutt_send_message(), e.g.
 #define SEND_GROUP_CHAT_REPLY (1 << 12) ///< Reply to all recipients preserving To/Cc
 #define SEND_NEWS             (1 << 13) ///< Reply to a news article
 
-void            mutt_add_to_reference_headers(struct Envelope *env, struct Envelope *curenv);
-struct Address *mutt_default_from(void);
+void            mutt_add_to_reference_headers(struct Envelope *env, struct Envelope *curenv, struct ConfigSubset *sub);
+struct Address *mutt_default_from(struct ConfigSubset *sub);
 int             mutt_edit_address(struct AddressList *al, const char *field, bool expand_aliases);
-void            mutt_encode_descriptions(struct Body *b, bool recurse);
-int             mutt_fetch_recips(struct Envelope *out, struct Envelope *in, SendFlags flags);
-void            mutt_fix_reply_recipients(struct Envelope *env);
-void            mutt_forward_intro(struct Mailbox *m, struct Email *e, FILE *fp);
-void            mutt_forward_trailer(struct Mailbox *m, struct Email *e, FILE *fp);
-void            mutt_make_attribution(struct Mailbox *m, struct Email *e, FILE *fp_out);
-void            mutt_make_forward_subject(struct Envelope *env, struct Mailbox *m, struct Email *e);
-void            mutt_make_misc_reply_headers(struct Envelope *env, struct Envelope *curenv);
-void            mutt_make_post_indent(struct Mailbox *m, struct Email *e, FILE *fp_out);
-int             mutt_resend_message(FILE *fp, struct Context *ctx, struct Email *e_cur);
-int             mutt_send_message(SendFlags flags, struct Email *e_templ, const char *tempfile, struct Context *ctx, struct EmailList *el);
-void            mutt_set_followup_to(struct Envelope *e);
+void            mutt_encode_descriptions(struct Body *b, bool recurse, struct ConfigSubset *sub);
+int             mutt_fetch_recips(struct Envelope *out, struct Envelope *in, SendFlags flags, struct ConfigSubset *sub);
+void            mutt_fix_reply_recipients(struct Envelope *env, struct ConfigSubset *sub);
+void            mutt_forward_intro(struct Mailbox *m, struct Email *e, FILE *fp, struct ConfigSubset *sub);
+void            mutt_forward_trailer(struct Mailbox *m, struct Email *e, FILE *fp, struct ConfigSubset *sub);
+void            mutt_make_attribution(struct Mailbox *m, struct Email *e, FILE *fp_out, struct ConfigSubset *sub);
+void            mutt_make_forward_subject(struct Envelope *env, struct Mailbox *m, struct Email *e, struct ConfigSubset *sub);
+void            mutt_make_misc_reply_headers(struct Envelope *env, struct Envelope *curenv, struct ConfigSubset *sub);
+void            mutt_make_post_indent(struct Mailbox *m, struct Email *e, FILE *fp_out, struct ConfigSubset *sub);
+int             mutt_resend_message(FILE *fp, struct Context *ctx, struct Email *e_cur, struct ConfigSubset *sub);
+int             mutt_send_message(SendFlags flags, struct Email *e_templ, const char *tempfile, struct Context *ctx, struct EmailList *el, struct ConfigSubset *sub);
+void            mutt_set_followup_to(struct Envelope *env, struct ConfigSubset *sub);
 
 #endif /* MUTT_SEND_H */

--- a/send/sendlib.h
+++ b/send/sendlib.h
@@ -29,22 +29,23 @@
 #include "email/lib.h"
 
 struct AddressList;
+struct ConfigSubset;
 struct Mailbox;
 
 #define MUTT_RANDTAG_LEN 16
 
-int              mutt_bounce_message(FILE *fp, struct Email *e, struct AddressList *to);
-const char *     mutt_fqdn(bool may_hide_host);
-struct Content * mutt_get_content_info(const char *fname, struct Body *b);
+int              mutt_bounce_message(FILE *fp, struct Email *e, struct AddressList *to, struct ConfigSubset *sub);
+const char *     mutt_fqdn(bool may_hide_host, const struct ConfigSubset *sub);
+struct Content * mutt_get_content_info(const char *fname, struct Body *b, struct ConfigSubset *sub);
 enum ContentType mutt_lookup_mime_type(struct Body *att, const char *path);
-struct Body *    mutt_make_file_attach(const char *path);
-struct Body *    mutt_make_message_attach(struct Mailbox *m, struct Email *e, bool attach_msg);
-void             mutt_message_to_7bit(struct Body *a, FILE *fp);
-void             mutt_prepare_envelope(struct Envelope *env, bool final);
+struct Body *    mutt_make_file_attach(const char *path, struct ConfigSubset *sub);
+struct Body *    mutt_make_message_attach(struct Mailbox *m, struct Email *e, bool attach_msg, struct ConfigSubset *sub);
+void             mutt_message_to_7bit(struct Body *a, FILE *fp, struct ConfigSubset *sub);
+void             mutt_prepare_envelope(struct Envelope *env, bool final, struct ConfigSubset *sub);
 void             mutt_stamp_attachment(struct Body *a);
 void             mutt_unprepare_envelope(struct Envelope *env);
-void             mutt_update_encoding(struct Body *a);
-int              mutt_write_fcc(const char *path, struct Email *e, const char *msgid, bool post, const char *fcc, char **finalpath);
-int              mutt_write_multiple_fcc(const char *path, struct Email *e, const char *msgid, bool post, char *fcc, char **finalpath);
+void             mutt_update_encoding(struct Body *a, struct ConfigSubset *sub);
+int              mutt_write_fcc(const char *path, struct Email *e, const char *msgid, bool post, const char *fcc, char **finalpath, struct ConfigSubset *sub);
+int              mutt_write_multiple_fcc(const char *path, struct Email *e, const char *msgid, bool post, char *fcc, char **finalpath, struct ConfigSubset *sub);
 
 #endif /* MUTT_SEND_SENDLIB_H */

--- a/send/sendmail.c
+++ b/send/sendmail.c
@@ -55,6 +55,8 @@
 #define EX_OK 0
 #endif
 
+struct ConfigSubset;
+
 SIG_ATOMIC_VOLATILE_T SigAlrm; ///< true after SIGALRM is received
 
 /**
@@ -302,12 +304,13 @@ static char **add_option(char **args, size_t *argslen, size_t *argsmax, char *s)
  * @param bcc      Recipients
  * @param msg      File containing message
  * @param eightbit Message contains 8bit chars
+ * @param sub      Config Subset
  * @retval  0 Success
  * @retval -1 Failure
  */
 int mutt_invoke_sendmail(struct AddressList *from, struct AddressList *to,
                          struct AddressList *cc, struct AddressList *bcc,
-                         const char *msg, bool eightbit)
+                         const char *msg, bool eightbit, struct ConfigSubset *sub)
 {
   char *ps = NULL, *path = NULL, *s = NULL, *childout = NULL;
   char **args = NULL;

--- a/send/sendmail.h
+++ b/send/sendmail.h
@@ -26,9 +26,10 @@
 #include <stdbool.h>
 
 struct AddressList;
+struct ConfigSubset;
 
 int mutt_invoke_sendmail(struct AddressList *from, struct AddressList *to,
                          struct AddressList *cc, struct AddressList *bcc,
-                         const char *msg, bool eightbit);
+                         const char *msg, bool eightbit, struct ConfigSubset *sub);
 
 #endif /* MUTT_SEND_SENDMAIL_H */

--- a/send/smtp.c
+++ b/send/smtp.c
@@ -720,12 +720,13 @@ static int smtp_open(struct SmtpAccountData *adata, bool esmtp)
  * @param bcc      Bcc Address
  * @param msgfile  Message to send to the server
  * @param eightbit If true, try for an 8-bit friendly connection
+ * @param sub      Config Subset
  * @retval  0 Success
  * @retval -1 Error
  */
 int mutt_smtp_send(const struct AddressList *from, const struct AddressList *to,
                    const struct AddressList *cc, const struct AddressList *bcc,
-                   const char *msgfile, bool eightbit)
+                   const char *msgfile, bool eightbit, struct ConfigSubset *sub)
 {
   struct SmtpAccountData adata = { 0 };
   struct ConnAccount cac = { { 0 } };
@@ -733,7 +734,7 @@ int mutt_smtp_send(const struct AddressList *from, const struct AddressList *to,
   char buf[1024];
   int rc = -1;
 
-  adata.fqdn = mutt_fqdn(false);
+  adata.fqdn = mutt_fqdn(false, sub);
   if (!adata.fqdn)
     adata.fqdn = NONULL(ShortHostname);
 

--- a/send/smtp.c
+++ b/send/smtp.c
@@ -98,6 +98,7 @@ struct SmtpAccountData
   const char *auth_mechs;    ///< Allowed authorisation mechanisms
   SmtpCapFlags capabilities; ///< Server capabilities
   struct Connection *conn;   ///< Server Connection
+  const char *fqdn;          ///< Fully-qualified domain name
 };
 
 /**
@@ -377,12 +378,8 @@ static int smtp_helo(struct SmtpAccountData *adata, bool esmtp)
 #endif
   }
 
-  const char *fqdn = mutt_fqdn(false);
-  if (!fqdn)
-    fqdn = NONULL(ShortHostname);
-
   char buf[1024];
-  snprintf(buf, sizeof(buf), "%s %s\r\n", esmtp ? "EHLO" : "HELO", fqdn);
+  snprintf(buf, sizeof(buf), "%s %s\r\n", esmtp ? "EHLO" : "HELO", adata->fqdn);
   /* XXX there should probably be a wrapper in mutt_socket.c that
    * repeatedly calls adata->conn->write until all data is sent.  This
    * currently doesn't check for a short write.  */
@@ -735,6 +732,10 @@ int mutt_smtp_send(const struct AddressList *from, const struct AddressList *to,
   const char *envfrom = NULL;
   char buf[1024];
   int rc = -1;
+
+  adata.fqdn = mutt_fqdn(false);
+  if (!adata.fqdn)
+    adata.fqdn = NONULL(ShortHostname);
 
   /* it might be better to synthesize an envelope from from user and host
    * but this condition is most likely arrived at accidentally */

--- a/send/smtp.h
+++ b/send/smtp.h
@@ -29,10 +29,11 @@
 
 #ifdef USE_SMTP
 struct AddressList;
+struct ConfigSubset;
 
 int mutt_smtp_send(const struct AddressList *from, const struct AddressList *to,
                    const struct AddressList *cc, const struct AddressList *bcc,
-                   const char *msgfile, bool eightbit);
+                   const char *msgfile, bool eightbit, struct ConfigSubset *sub);
 #endif
 
 #endif /* MUTT_SEND_SMTP_H */


### PR DESCRIPTION
Use the Config functions to get values from a ConfigSubset, rather than using the global variables.
This conversion is a step towards supporting Account- and Mailbox-specific config.

- 0626b7e1bd smtp: pass SmtpAccountData
- 08bc84627a smtp: move mutt_fqdn() to mutt_smtp_send()

  First, fix a couple of problems in the SMTP code.

  When NeoMutt creates an SMTP connection, it shares some data with other functions.
  Pass that data in `struct SmtpAccountData`, rather than using global variables.

  To send email, NeoMutt needs to use the hostname.
  Calculating the hostname requires some business logic (a fallback to the `Hostname` global variable).
  Move that logic to the top-level function `mutt_smtp_send()`.

- 4226a4e88a send: add ConfigSubset param to functions

  This large commit simply adds a `struct ConfigSet *sub` parameter to a LOT of functions.
  The actual value for this parameter is defaulted to `Neomutt->sub` outside of libsend.

- 2bf70925e6 config: add Config helpers

  Create functions to assist in getting Config values from a ConfigSubset.

- fd3e1c538b send: get Config from a ConfigSubset

  Eliminate all Config variables from libsend, using the Config helper functions.

## Code Conventions

Each conversion follows the same pattern:
Global Config variable `C_SendCharset` becomes local `c_send_charset`.

```diff
- function(C_SendCharset);
+ const char *c_send_charset = cs_subset_string(sub, "send_charset");
+ function(c_send_charset);
```

The local variables are declared const as they should not be altered.

## Notes

### Globals

The global variables still have a few footholds in the send code.

### Safety

The helper functions use the Config variable's name to get the value.
As long as this name is correct and isn't disabled, then NeoMutt should work.

The helper functions perform a lot of checking, for now, to make sure they return the right value.

**Note**: There's no error checking on the caller side.
  If there's an error, the helper will return a "sensible" default value.

### Setting values

In >5000 lines of send code, there's only one place where a config value gets set: `invoke_mta()`.
That case is just down to poor design: set value; do something; restore value.

### Testing

Using a simple test program, it's now possible to send an email using smtp.

