### PR TITLE
feat: open neomutt with mailbox name

### DIFF
--- a/main.c
+++ b/main.c
@@ -1196,7 +1196,7 @@ int main(int argc, char *argv[], char *envp[])
     notify_send(NeoMutt->notify, NT_GLOBAL, NT_GLOBAL_STARTUP, NULL);
 
     repeat_error = true;
-    struct Mailbox *m = mx_path_resolve(mutt_b2s(&folder));
+    struct Mailbox *m = mx_resolve(mutt_b2s(&folder));
     Context = mx_mbox_open(m, ((flags & MUTT_CLI_RO) || C_ReadOnly) ? MUTT_READONLY : MUTT_OPEN_NO_FLAGS);
     if (!Context)
     {

--- a/mx.h
+++ b/mx.h
@@ -309,6 +309,7 @@ int             mx_path_parent     (char *buf, size_t buflen);
 int             mx_path_pretty     (char *buf, size_t buflen, const char *folder);
 enum MailboxType mx_path_probe     (const char *path);
 struct Mailbox *mx_path_resolve    (const char *path);
+struct Mailbox *mx_resolve         (const char *path_or_name);
 int             mx_tags_commit     (struct Mailbox *m, struct Email *e, char *tags);
 int             mx_tags_edit       (struct Mailbox *m, const char *tags, char *buf, size_t buflen);
 


### PR DESCRIPTION
Allow opening neomutt with a mailbox name with `neomutt -f <name>` if
name exists in the user's configuration.

To support this behavior, introduce 4 new functions to provide a new
high-level abstraction for finding mailboxes and lower-level
name-specific functionality.

 - mx_resolve() - Find a mailbox by checking name then path.
 - mx_name_resolve() - Resolve a mailbox by name.
 - mx_mbox_find_by_name() - Search all accounts for Mailbox with name.
 - mx_mbox_find_by_name_acc() - Search a specific account for Mailbox.

Since 'mx_resolve()' is a new high-level abstraction for finding a
mailbox, replace call 'mx_path_resolve()' with 'mx_resolve()' in
'main.c'. The initial mailbox open only needs a Mailbox struct.

Closes #2101