### PR TITLE
Make the Sidebar more independent

### DIFF
--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -484,7 +484,7 @@ $(PWD)/send:
 @if USE_SIDEBAR
 LIBSIDEBAR=	libsidebar.a
 LIBSIDEBAROBJS=	sidebar/sidebar.o sidebar/commands.o sidebar/functions.o \
-		sidebar/observer.o
+		sidebar/observer.o sidebar/wdata.o
 CLEANFILES+=	$(LIBSIDEBAR) $(LIBSIDEBAROBJS)
 ALLOBJS+=	$(LIBSIDEBAROBJS)
 

--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -73,8 +73,7 @@ NEOMUTTOBJS=	browser.o commands.o command_parse.o \
 		mutt_parse.o mutt_signal.o mutt_socket.o mutt_thread.o mx.o \
 		myvar.o opcodes.o pager.o pattern.o postpone.o progress.o \
 		recvattach.o recvcmd.o resize.o rfc3676.o score.o \
-		sidebar.o sort.o state.o status.o \
-		system.o version.o
+		sort.o state.o status.o system.o version.o
 
 @if !HAVE_WCSCASECMP
 NEOMUTTOBJS+=	wcscasecmp.o
@@ -481,6 +480,22 @@ $(PWD)/send:
 	$(MKDIR_P) $(PWD)/send
 
 ###############################################################################
+# libsidebar
+@if USE_SIDEBAR
+LIBSIDEBAR=	libsidebar.a
+LIBSIDEBAROBJS=	sidebar/sidebar.o sidebar/commands.o sidebar/functions.o \
+		sidebar/observer.o
+CLEANFILES+=	$(LIBSIDEBAR) $(LIBSIDEBAROBJS)
+ALLOBJS+=	$(LIBSIDEBAROBJS)
+
+$(LIBSIDEBAR): $(PWD)/sidebar $(LIBSIDEBAROBJS)
+	$(AR) cr $@ $(LIBSIDEBAROBJS)
+	$(RANLIB) $@
+$(PWD)/sidebar:
+	$(MKDIR_P) $(PWD)/sidebar
+@endif
+
+###############################################################################
 # libstore
 @if HAVE_BDB
 LIBSTOREOBJS+=	store/bdb.o
@@ -545,9 +560,9 @@ $(ALLOBJS):
 MUTTLIBS+=	$(LIBAUTOCRYPT) $(LIBPOP) $(LIBNNTP) $(LIBCOMPMBOX) \
 		$(LIBSTORE) $(LIBGUI) $(LIBDEBUG) $(LIBMBOX) $(LIBNOTMUCH) \
 		$(LIBMAILDIR) $(LIBNCRYPT) $(LIBIMAP) $(LIBCONN) $(LIBHCACHE) \
-		$(LIBCOMPRESS) $(LIBBCACHE) $(LIBHISTORY) $(LIBALIAS) \
-		$(LIBSEND) $(LIBCORE) $(LIBCONFIG) $(LIBEMAIL) $(LIBADDRESS) \
-		$(LIBMUTT)
+		$(LIBCOMPRESS) $(LIBSIDEBAR) $(LIBBCACHE) $(LIBHISTORY) \
+		$(LIBALIAS) $(LIBSEND) $(LIBCORE) $(LIBCONFIG) $(LIBEMAIL) \
+		$(LIBADDRESS) $(LIBMUTT)
 
 # neomutt
 $(NEOMUTT): $(GENERATED) $(NEOMUTTOBJS) $(MUTTLIBS)

--- a/command_parse.c
+++ b/command_parse.c
@@ -945,7 +945,10 @@ enum CommandResult parse_mailboxes(struct Buffer *buf, struct Buffer *s,
 #ifdef USE_SIDEBAR
         if (show || rename)
         {
-          sb_notify_mailbox(m_old, show ? SBN_CREATED : SBN_RENAMED);
+          struct MuttWindow *dlg = TAILQ_LAST(&MuttDialogWindow->children, MuttWindowList);
+          struct MuttWindow *win_sidebar = mutt_window_find(dlg, WT_SIDEBAR);
+          if (win_sidebar)
+            sb_notify_mailbox(win_sidebar, m_old, show ? SBN_CREATED : SBN_RENAMED);
         }
 #endif
         mailbox_free(&m);
@@ -972,7 +975,10 @@ enum CommandResult parse_mailboxes(struct Buffer *buf, struct Buffer *s,
     }
 
 #ifdef USE_SIDEBAR
-    sb_notify_mailbox(m, SBN_CREATED);
+    struct MuttWindow *dlg = TAILQ_LAST(&MuttDialogWindow->children, MuttWindowList);
+    struct MuttWindow *win_sidebar = mutt_window_find(dlg, WT_SIDEBAR);
+    if (win_sidebar)
+      sb_notify_mailbox(win_sidebar, m, SBN_CREATED);
 #endif
 #ifdef USE_INOTIFY
     mutt_monitor_add(m);
@@ -1932,7 +1938,10 @@ enum CommandResult parse_unmailboxes(struct Buffer *buf, struct Buffer *s,
       }
 
 #ifdef USE_SIDEBAR
-      sb_notify_mailbox(np->mailbox, SBN_DELETED);
+      struct MuttWindow *dlg = TAILQ_LAST(&MuttDialogWindow->children, MuttWindowList);
+      struct MuttWindow *win_sidebar = mutt_window_find(dlg, WT_SIDEBAR);
+      if (win_sidebar)
+        sb_notify_mailbox(win_sidebar, np->mailbox, SBN_DELETED);
 #endif
 #ifdef USE_INOTIFY
       mutt_monitor_remove(np->mailbox);

--- a/command_parse.c
+++ b/command_parse.c
@@ -56,9 +56,11 @@
 #include "mx.h"
 #include "myvar.h"
 #include "options.h"
-#include "sidebar.h"
 #include "version.h"
 #include "imap/lib.h"
+#ifdef USE_SIDEBAR
+#include "sidebar/lib.h"
+#endif
 #ifdef ENABLE_NLS
 #include <libintl.h>
 #endif
@@ -1022,54 +1024,6 @@ enum CommandResult parse_my_hdr(struct Buffer *buf, struct Buffer *s,
 
   return MUTT_CMD_SUCCESS;
 }
-
-#ifdef USE_SIDEBAR
-/**
- * parse_path_list - Parse the 'sidebar_whitelist' command - Implements Command::parse()
- */
-enum CommandResult parse_path_list(struct Buffer *buf, struct Buffer *s,
-                                   intptr_t data, struct Buffer *err)
-{
-  struct Buffer *path = mutt_buffer_pool_get();
-
-  do
-  {
-    mutt_extract_token(path, s, MUTT_TOKEN_BACKTICK_VARS);
-    mutt_buffer_expand_path(path);
-    add_to_stailq((struct ListHead *) data, mutt_b2s(path));
-  } while (MoreArgs(s));
-  mutt_buffer_pool_release(&path);
-
-  return MUTT_CMD_SUCCESS;
-}
-#endif
-
-#ifdef USE_SIDEBAR
-/**
- * parse_path_unlist - Parse the 'unsidebar_whitelist' command - Implements Command::parse()
- */
-enum CommandResult parse_path_unlist(struct Buffer *buf, struct Buffer *s,
-                                     intptr_t data, struct Buffer *err)
-{
-  struct Buffer *path = mutt_buffer_pool_get();
-
-  do
-  {
-    mutt_extract_token(path, s, MUTT_TOKEN_BACKTICK_VARS);
-    /* Check for deletion of entire list */
-    if (mutt_str_equal(mutt_b2s(path), "*"))
-    {
-      mutt_list_free((struct ListHead *) data);
-      break;
-    }
-    mutt_buffer_expand_path(path);
-    remove_from_stailq((struct ListHead *) data, mutt_b2s(path));
-  } while (MoreArgs(s));
-  mutt_buffer_pool_release(&path);
-
-  return MUTT_CMD_SUCCESS;
-}
-#endif
 
 /**
  * parse_set - Parse the 'set' family of commands - Implements Command::parse()

--- a/command_parse.h
+++ b/command_parse.h
@@ -41,10 +41,6 @@ enum CommandResult parse_ignore          (struct Buffer *buf, struct Buffer *s, 
 enum CommandResult parse_lists           (struct Buffer *buf, struct Buffer *s, intptr_t data, struct Buffer *err);
 enum CommandResult parse_mailboxes       (struct Buffer *buf, struct Buffer *s, intptr_t data, struct Buffer *err);
 enum CommandResult parse_my_hdr          (struct Buffer *buf, struct Buffer *s, intptr_t data, struct Buffer *err);
-#ifdef USE_SIDEBAR
-enum CommandResult parse_path_list       (struct Buffer *buf, struct Buffer *s, intptr_t data, struct Buffer *err);
-enum CommandResult parse_path_unlist     (struct Buffer *buf, struct Buffer *s, intptr_t data, struct Buffer *err);
-#endif
 enum CommandResult parse_set             (struct Buffer *buf, struct Buffer *s, intptr_t data, struct Buffer *err);
 enum CommandResult parse_setenv          (struct Buffer *buf, struct Buffer *s, intptr_t data, struct Buffer *err);
 enum CommandResult parse_source          (struct Buffer *buf, struct Buffer *s, intptr_t data, struct Buffer *err);

--- a/index.c
+++ b/index.c
@@ -4106,21 +4106,6 @@ static struct MuttWindow *create_panel_pager(struct MuttWindow *parent, bool sta
 }
 
 /**
- * create_panel_sidebar - Create the Sidebar Window
- * @param parent Parent Window
- * @retval ptr Window
- */
-static struct MuttWindow *create_panel_sidebar(struct MuttWindow *parent)
-{
-  struct MuttWindow *win_sidebar =
-      mutt_window_new(WT_SIDEBAR, MUTT_WIN_ORIENT_HORIZONTAL, MUTT_WIN_SIZE_FIXED,
-                      C_SidebarWidth, MUTT_WIN_SIZE_UNLIMITED);
-  win_sidebar->state.visible = C_SidebarVisible && (C_SidebarWidth > 0);
-
-  return win_sidebar;
-}
-
-/**
  * index_pager_init - Allocate the Windows for the Index/Pager
  * @retval ptr Dialog containing nested Windows
  */
@@ -4131,27 +4116,8 @@ struct MuttWindow *index_pager_init(void)
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
   notify_observer_add(NeoMutt->notify, mutt_dlgindex_observer, dlg);
 
-  struct MuttWindow *win_sidebar = create_panel_sidebar(dlg);
-
-  struct MuttWindow *cont_right =
-      mutt_window_new(WT_CONTAINER, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
-                      MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
-
-  if (C_SidebarOnRight)
-  {
-    mutt_window_add_child(dlg, cont_right);
-    mutt_window_add_child(dlg, win_sidebar);
-  }
-  else
-  {
-    mutt_window_add_child(dlg, win_sidebar);
-    mutt_window_add_child(dlg, cont_right);
-  }
-
-  mutt_window_add_child(cont_right, create_panel_index(cont_right, C_StatusOnTop));
-  mutt_window_add_child(cont_right, create_panel_pager(cont_right, C_StatusOnTop));
-
-  notify_observer_add(NeoMutt->notify, sb_observer, win_sidebar);
+  mutt_window_add_child(dlg, create_panel_index(dlg, C_StatusOnTop));
+  mutt_window_add_child(dlg, create_panel_pager(dlg, C_StatusOnTop));
 
   return dlg;
 }
@@ -4162,15 +4128,6 @@ struct MuttWindow *index_pager_init(void)
  */
 void index_pager_shutdown(struct MuttWindow *dlg)
 {
-  if (!dlg)
-    return;
-
-  struct MuttWindow *win_sidebar = mutt_window_find(dlg, WT_SIDEBAR);
-  if (!win_sidebar)
-    return;
-
-  notify_observer_remove(NeoMutt->notify, sb_observer, win_sidebar);
-
   notify_observer_remove(NeoMutt->notify, mutt_dlgindex_observer, dlg);
 }
 

--- a/index.c
+++ b/index.c
@@ -73,7 +73,7 @@
 #include "ncrypt/lib.h"
 #include "send/lib.h"
 #ifdef USE_SIDEBAR
-#include "sidebar.h"
+#include "sidebar/lib.h"
 #endif
 #ifdef USE_POP
 #include "pop/lib.h"

--- a/index.c
+++ b/index.c
@@ -795,7 +795,9 @@ static void change_folder_mailbox(struct Menu *menu, struct Mailbox *m, int *old
     collapse_all(Context, menu, 0);
 
 #ifdef USE_SIDEBAR
-  sb_set_open_mailbox(Context ? Context->mailbox : NULL);
+  struct MuttWindow *dlg = mutt_window_dialog(menu->win_index);
+  struct MuttWindow *win_sidebar = mutt_window_find(dlg, WT_SIDEBAR);
+  sb_set_open_mailbox(win_sidebar, Context ? Context->mailbox : NULL);
 #endif
 
   mutt_clear_error();
@@ -2405,8 +2407,11 @@ int mutt_index_menu(struct MuttWindow *dlg)
 
 #ifdef USE_SIDEBAR
       case OP_SIDEBAR_OPEN:
-        change_folder_mailbox(menu, sb_get_highlight(), &oldcount, &cur, false);
+      {
+        struct MuttWindow *win_sidebar = mutt_window_find(dlg, WT_SIDEBAR);
+        change_folder_mailbox(menu, sb_get_highlight(win_sidebar), &oldcount, &cur, false);
         break;
+      }
 #endif
 
       case OP_MAIN_NEXT_UNREAD_MAILBOX:
@@ -3924,8 +3929,13 @@ int mutt_index_menu(struct MuttWindow *dlg)
       case OP_SIDEBAR_PAGE_UP:
       case OP_SIDEBAR_PREV:
       case OP_SIDEBAR_PREV_NEW:
-        sb_change_mailbox(op);
+      {
+        struct MuttWindow *win_sidebar = mutt_window_find(dlg, WT_SIDEBAR);
+        if (!win_sidebar)
+          break;
+        sb_change_mailbox(win_sidebar, op);
         break;
+      }
 
       case OP_SIDEBAR_TOGGLE_VISIBLE:
         bool_str_toggle(NeoMutt->sub, "sidebar_visible", NULL);

--- a/init.c
+++ b/init.c
@@ -65,6 +65,9 @@
 #include "compress/lib.h"
 #include "history/lib.h"
 #include "store/lib.h"
+#ifdef USE_SIDEBAR
+#include "sidebar/lib.h"
+#endif
 #ifdef USE_HCACHE
 #include "hcache/lib.h"
 #endif

--- a/init.c
+++ b/init.c
@@ -656,6 +656,9 @@ void mutt_opts_free(void)
   clear_source_stack();
 
   alias_shutdown();
+#ifdef USE_SIDEBAR
+  sb_shutdown();
+#endif
 
   mutt_regexlist_free(&Alternates);
   mutt_regexlist_free(&MailLists);
@@ -677,9 +680,6 @@ void mutt_opts_free(void)
   mutt_list_free(&MailToAllow);
   mutt_list_free(&MimeLookupList);
   mutt_list_free(&Muttrc);
-#ifdef USE_SIDEBAR
-  mutt_list_free(&SidebarWhitelist);
-#endif
   mutt_list_free(&UnIgnore);
   mutt_list_free(&UserHeader);
 
@@ -748,6 +748,9 @@ int mutt_init(struct ConfigSet *cs, bool skip_sys_rc, struct ListHead *commands)
   TagFormats = mutt_hash_new(64, MUTT_HASH_NO_FLAGS);
 
   mutt_menu_init();
+#ifdef USE_SIDEBAR
+  sb_init();
+#endif
 
   snprintf(AttachmentMarker, sizeof(AttachmentMarker), "\033]9;%" PRIu64 "\a", // Escape
            mutt_rand64());

--- a/main.c
+++ b/main.c
@@ -1209,11 +1209,12 @@ int main(int argc, char *argv[], char *envp[])
     }
     if (Context || !explicit_folder)
     {
-#ifdef USE_SIDEBAR
-      sb_set_open_mailbox(Context ? Context->mailbox : NULL);
-#endif
       struct MuttWindow *dlg = index_pager_init();
       dialog_push(dlg);
+#ifdef USE_SIDEBAR
+      struct MuttWindow *win_sidebar = mutt_window_find(dlg, WT_SIDEBAR);
+      sb_set_open_mailbox(win_sidebar, Context ? Context->mailbox : NULL);
+#endif
       mutt_index_menu(dlg);
       dialog_pop();
       index_pager_shutdown(dlg);

--- a/main.c
+++ b/main.c
@@ -79,7 +79,7 @@
 #include <libintl.h>
 #endif
 #ifdef USE_SIDEBAR
-#include "sidebar.h"
+#include "sidebar/lib.h"
 #endif
 #ifdef USE_IMAP
 #include "imap/lib.h"

--- a/menu.c
+++ b/menu.c
@@ -49,7 +49,7 @@
 #include "pattern.h"
 #include "protos.h"
 #ifdef USE_SIDEBAR
-#include "sidebar.h"
+#include "sidebar/lib.h"
 #endif
 
 /* These Config Variables are only used in menu.c */

--- a/mutt_commands.c
+++ b/mutt_commands.c
@@ -42,6 +42,9 @@
 #include "mutt_globals.h"
 #include "mutt_lua.h"
 #include "score.h"
+#ifdef USE_SIDEBAR
+#include "sidebar/lib.h"
+#endif
 
 // clang-format off
 const struct Command Commands[] = {
@@ -108,7 +111,7 @@ const struct Command Commands[] = {
   { "setenv",              parse_setenv,           MUTT_SET_SET },
   { "shutdown-hook",       mutt_parse_hook,        MUTT_SHUTDOWN_HOOK | MUTT_GLOBAL_HOOK },
 #ifdef USE_SIDEBAR
-  { "sidebar_whitelist",   parse_path_list,        IP &SidebarWhitelist },
+  { "sidebar_whitelist",   sb_parse_whitelist,     0 },
 #endif
   { "source",              parse_source,           0 },
   { "spam",                parse_spam_list,        MUTT_SPAM },
@@ -146,7 +149,7 @@ const struct Command Commands[] = {
   { "unset",               parse_set,              MUTT_SET_UNSET },
   { "unsetenv",            parse_setenv,           MUTT_SET_UNSET },
 #ifdef USE_SIDEBAR
-  { "unsidebar_whitelist", parse_path_unlist,      IP &SidebarWhitelist },
+  { "unsidebar_whitelist", sb_parse_unwhitelist,   0 },
 #endif
   { "unsubjectrx",         parse_unsubjectrx_list, 0 },
   { "unsubscribe",         parse_unsubscribe,      0 },

--- a/mutt_config.c
+++ b/mutt_config.c
@@ -66,7 +66,6 @@
 #include "remailer.h"
 #include "rfc3676.h"
 #include "score.h"
-#include "sidebar.h"
 #include "sort.h"
 #include "status.h"
 #include "bcache/lib.h"
@@ -79,6 +78,9 @@
 #include "notmuch/lib.h"
 #include "pop/lib.h"
 #include "send/lib.h"
+#ifdef USE_SIDEBAR
+#include "sidebar/lib.h"
+#endif
 #endif
 
 #ifndef ISPELL

--- a/mutt_globals.h
+++ b/mutt_globals.h
@@ -65,9 +65,6 @@ WHERE struct ListHead AutoViewList INITVAL(STAILQ_HEAD_INITIALIZER(AutoViewList)
 WHERE struct ListHead HeaderOrderList INITVAL(STAILQ_HEAD_INITIALIZER(HeaderOrderList));           ///< List of header fields in the order they should be displayed
 WHERE struct ListHead MimeLookupList INITVAL(STAILQ_HEAD_INITIALIZER(MimeLookupList));             ///< List of mime types that that shouldn't use the mailcap entry
 WHERE struct ListHead Muttrc INITVAL(STAILQ_HEAD_INITIALIZER(Muttrc));                             ///< List of config files to read
-#ifdef USE_SIDEBAR
-WHERE struct ListHead SidebarWhitelist INITVAL(STAILQ_HEAD_INITIALIZER(SidebarWhitelist));         ///< List of mailboxes to always display in the sidebar
-#endif
 WHERE struct ListHead TempAttachmentsList INITVAL(STAILQ_HEAD_INITIALIZER(TempAttachmentsList));   ///< List of temporary files for displaying attachments
 WHERE struct ListHead UserHeader INITVAL(STAILQ_HEAD_INITIALIZER(UserHeader));                     ///< List of custom headers to add to outgoing emails
 

--- a/pager.c
+++ b/pager.c
@@ -70,7 +70,7 @@
 #include "ncrypt/lib.h"
 #include "send/lib.h"
 #ifdef USE_SIDEBAR
-#include "sidebar.h"
+#include "sidebar/lib.h"
 #endif
 #ifdef USE_NNTP
 #include "nntp/lib.h"

--- a/pager.c
+++ b/pager.c
@@ -3509,8 +3509,14 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
       case OP_SIDEBAR_PAGE_UP:
       case OP_SIDEBAR_PREV:
       case OP_SIDEBAR_PREV_NEW:
-        sb_change_mailbox(ch);
+      {
+        struct MuttWindow *win_sidebar =
+            mutt_window_find(mutt_window_dialog(rd.extra->win_pager), WT_SIDEBAR);
+        if (!win_sidebar)
+          break;
+        sb_change_mailbox(win_sidebar, ch);
         break;
+      }
 
       case OP_SIDEBAR_TOGGLE_VISIBLE:
         bool_str_toggle(NeoMutt->sub, "sidebar_visible", NULL);

--- a/sidebar/commands.c
+++ b/sidebar/commands.c
@@ -28,6 +28,7 @@
 
 #include "config.h"
 #include <stdint.h>
+#include "private.h"
 #include "mutt/lib.h"
 #include "mutt.h"
 #include "lib.h"

--- a/sidebar/commands.c
+++ b/sidebar/commands.c
@@ -1,0 +1,80 @@
+/**
+ * @file
+ * Sidebar commands
+ *
+ * @authors
+ * Copyright (C) 2020 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @page sidebar_commands Sidebar commands
+ *
+ * Sidebar commands
+ */
+
+#include "config.h"
+#include <stdint.h>
+#include "mutt/lib.h"
+#include "mutt.h"
+#include "lib.h"
+#include "init.h"
+#include "mutt_commands.h"
+#include "muttlib.h"
+
+/**
+ * sb_parse_whitelist - Parse the 'sidebar_whitelist' command - Implements Command::parse()
+ */
+enum CommandResult sb_parse_whitelist(struct Buffer *buf, struct Buffer *s,
+                                      intptr_t data, struct Buffer *err)
+{
+  struct Buffer *path = mutt_buffer_pool_get();
+
+  do
+  {
+    mutt_extract_token(path, s, MUTT_TOKEN_BACKTICK_VARS);
+    mutt_buffer_expand_path(path);
+    add_to_stailq(&SidebarWhitelist, mutt_b2s(path));
+  } while (MoreArgs(s));
+  mutt_buffer_pool_release(&path);
+
+  return MUTT_CMD_SUCCESS;
+}
+
+/**
+ * sb_parse_unwhitelist - Parse the 'unsidebar_whitelist' command - Implements Command::parse()
+ */
+enum CommandResult sb_parse_unwhitelist(struct Buffer *buf, struct Buffer *s,
+                                        intptr_t data, struct Buffer *err)
+{
+  struct Buffer *path = mutt_buffer_pool_get();
+
+  do
+  {
+    mutt_extract_token(path, s, MUTT_TOKEN_BACKTICK_VARS);
+    /* Check for deletion of entire list */
+    if (mutt_str_equal(mutt_b2s(path), "*"))
+    {
+      mutt_list_free(&SidebarWhitelist);
+      break;
+    }
+    mutt_buffer_expand_path(path);
+    remove_from_stailq(&SidebarWhitelist, mutt_b2s(path));
+  } while (MoreArgs(s));
+  mutt_buffer_pool_release(&path);
+
+  return MUTT_CMD_SUCCESS;
+}

--- a/sidebar/functions.c
+++ b/sidebar/functions.c
@@ -1,0 +1,289 @@
+/**
+ * @file
+ * Sidebar functions
+ *
+ * @authors
+ * Copyright (C) 2020 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @page sidebar_functions Sidebar functions
+ *
+ * Sidebar functions
+ */
+
+#include "config.h"
+#include <stdbool.h>
+#include "private.h"
+#include "core/lib.h"
+#include "lib.h"
+#include "mutt_menu.h"
+#include "opcodes.h"
+
+/**
+ * select_next - Selects the next unhidden mailbox
+ * @retval true  Success
+ * @retval false Failure
+ */
+bool select_next(void)
+{
+  if ((EntryCount == 0) || (HilIndex < 0))
+    return false;
+
+  int entry = HilIndex;
+
+  do
+  {
+    entry++;
+    if (entry == EntryCount)
+      return false;
+  } while (Entries[entry]->is_hidden);
+
+  HilIndex = entry;
+  return true;
+}
+
+/**
+ * select_next_new - Selects the next new mailbox
+ * @retval true  Success
+ * @retval false Failure
+ *
+ * Search down the list of mail folders for one containing new mail.
+ */
+static bool select_next_new(void)
+{
+  if ((EntryCount == 0) || (HilIndex < 0))
+    return false;
+
+  int entry = HilIndex;
+
+  do
+  {
+    entry++;
+    if (entry == EntryCount)
+    {
+      if (C_SidebarNextNewWrap)
+        entry = 0;
+      else
+        return false;
+    }
+    if (entry == HilIndex)
+      return false;
+  } while (!Entries[entry]->mailbox->has_new && (Entries[entry]->mailbox->msg_unread == 0));
+
+  HilIndex = entry;
+  return true;
+}
+
+/**
+ * select_prev - Selects the previous unhidden mailbox
+ * @retval true  Success
+ * @retval false Failure
+ */
+static bool select_prev(void)
+{
+  if ((EntryCount == 0) || (HilIndex < 0))
+    return false;
+
+  int entry = HilIndex;
+
+  do
+  {
+    entry--;
+    if (entry < 0)
+      return false;
+  } while (Entries[entry]->is_hidden);
+
+  HilIndex = entry;
+  return true;
+}
+
+/**
+ * select_prev_new - Selects the previous new mailbox
+ * @retval true  Success
+ * @retval false Failure
+ *
+ * Search up the list of mail folders for one containing new mail.
+ */
+static bool select_prev_new(void)
+{
+  if ((EntryCount == 0) || (HilIndex < 0))
+    return false;
+
+  int entry = HilIndex;
+
+  do
+  {
+    entry--;
+    if (entry < 0)
+    {
+      if (C_SidebarNextNewWrap)
+        entry = EntryCount - 1;
+      else
+        return false;
+    }
+    if (entry == HilIndex)
+      return false;
+  } while (!Entries[entry]->mailbox->has_new && (Entries[entry]->mailbox->msg_unread == 0));
+
+  HilIndex = entry;
+  return true;
+}
+
+/**
+ * select_page_down - Selects the first entry in the next page of mailboxes
+ * @retval true  Success
+ * @retval false Failure
+ */
+static bool select_page_down(void)
+{
+  if ((EntryCount == 0) || (BotIndex < 0))
+    return false;
+
+  int orig_hil_index = HilIndex;
+
+  HilIndex = BotIndex;
+  select_next();
+  /* If the rest of the entries are hidden, go up to the last unhidden one */
+  if (Entries[HilIndex]->is_hidden)
+    select_prev();
+
+  return (orig_hil_index != HilIndex);
+}
+
+/**
+ * select_page_up - Selects the last entry in the previous page of mailboxes
+ * @retval true  Success
+ * @retval false Failure
+ */
+static bool select_page_up(void)
+{
+  if ((EntryCount == 0) || (TopIndex < 0))
+    return false;
+
+  int orig_hil_index = HilIndex;
+
+  HilIndex = TopIndex;
+  select_prev();
+  /* If the rest of the entries are hidden, go down to the last unhidden one */
+  if (Entries[HilIndex]->is_hidden)
+    select_next();
+
+  return (orig_hil_index != HilIndex);
+}
+
+/**
+ * select_first - Selects the first unhidden mailbox
+ * @retval true  Success
+ * @retval false Failure
+ */
+static bool select_first(void)
+{
+  if ((EntryCount == 0) || (HilIndex < 0))
+    return false;
+
+  int orig_hil_index = HilIndex;
+
+  HilIndex = 0;
+  if (Entries[HilIndex]->is_hidden)
+    if (!select_next())
+      HilIndex = orig_hil_index;
+
+  return (orig_hil_index != HilIndex);
+}
+
+/**
+ * select_last - Selects the last unhidden mailbox
+ * @retval true  Success
+ * @retval false Failure
+ */
+static bool select_last(void)
+{
+  if ((EntryCount == 0) || (HilIndex < 0))
+    return false;
+
+  int orig_hil_index = HilIndex;
+
+  HilIndex = EntryCount;
+  if (!select_prev())
+    HilIndex = orig_hil_index;
+
+  return (orig_hil_index != HilIndex);
+}
+
+/**
+ * sb_change_mailbox - Change the selected mailbox
+ * @param op Operation code
+ *
+ * Change the selected mailbox, e.g. "Next mailbox", "Previous Mailbox
+ * with new mail". The operations are listed in opcodes.h.
+ *
+ * If the operation is successful, HilMailbox will be set to the new mailbox.
+ * This function only *selects* the mailbox, doesn't *open* it.
+ *
+ * Allowed values are: OP_SIDEBAR_FIRST, OP_SIDEBAR_LAST,
+ * OP_SIDEBAR_NEXT, OP_SIDEBAR_NEXT_NEW,
+ * OP_SIDEBAR_PAGE_DOWN, OP_SIDEBAR_PAGE_UP, OP_SIDEBAR_PREV,
+ * OP_SIDEBAR_PREV_NEW.
+ */
+void sb_change_mailbox(int op)
+{
+  if (!C_SidebarVisible)
+    return;
+
+  if (HilIndex < 0) /* It'll get reset on the next draw */
+    return;
+
+  switch (op)
+  {
+    case OP_SIDEBAR_FIRST:
+      if (!select_first())
+        return;
+      break;
+    case OP_SIDEBAR_LAST:
+      if (!select_last())
+        return;
+      break;
+    case OP_SIDEBAR_NEXT:
+      if (!select_next())
+        return;
+      break;
+    case OP_SIDEBAR_NEXT_NEW:
+      if (!select_next_new())
+        return;
+      break;
+    case OP_SIDEBAR_PAGE_DOWN:
+      if (!select_page_down())
+        return;
+      break;
+    case OP_SIDEBAR_PAGE_UP:
+      if (!select_page_up())
+        return;
+      break;
+    case OP_SIDEBAR_PREV:
+      if (!select_prev())
+        return;
+      break;
+    case OP_SIDEBAR_PREV_NEW:
+      if (!select_prev_new())
+        return;
+      break;
+    default:
+      return;
+  }
+  mutt_menu_set_current_redraw(REDRAW_SIDEBAR);
+}

--- a/sidebar/lib.h
+++ b/sidebar/lib.h
@@ -67,8 +67,9 @@ bool            select_next        (void);
 void            sb_draw            (struct MuttWindow *win);
 struct Mailbox *sb_get_highlight   (void);
 void            sb_notify_mailbox  (struct Mailbox *m, enum SidebarNotification sbn);
-int             sb_observer        (struct NotifyCallback *nc);
 void            sb_set_open_mailbox(struct Mailbox *m);
+void            sb_win_init        (struct MuttWindow *dlg);
+void            sb_win_shutdown    (struct MuttWindow *dlg);
 
 enum CommandResult sb_parse_unwhitelist(struct Buffer *buf, struct Buffer *s, intptr_t data, struct Buffer *err);
 enum CommandResult sb_parse_whitelist  (struct Buffer *buf, struct Buffer *s, intptr_t data, struct Buffer *err);

--- a/sidebar/lib.h
+++ b/sidebar/lib.h
@@ -49,7 +49,8 @@ extern short C_SidebarSortMethod;
 extern bool  C_SidebarVisible;
 extern short C_SidebarWidth;
 
-extern struct ListHead SidebarWhitelist;
+void sb_init    (void);
+void sb_shutdown(void);
 
 /**
  * enum SidebarNotification - what happened to a mailbox

--- a/sidebar/lib.h
+++ b/sidebar/lib.h
@@ -5,7 +5,7 @@
  * @authors
  * Copyright (C) 2004 Justin Hibbits <jrh29@po.cwru.edu>
  * Copyright (C) 2004 Thomer M. Gil <mutt@thomer.com>
- * Copyright (C) 2015-2016 Richard Russon <rich@flatcap.org>
+ * Copyright (C) 2015-2020 Richard Russon <rich@flatcap.org>
  *
  * @copyright
  * This program is free software: you can redistribute it and/or modify it under
@@ -22,14 +22,16 @@
  * this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef MUTT_SIDEBAR_H
-#define MUTT_SIDEBAR_H
+#ifndef MUTT_SIDEBAR_LIB_H
+#define MUTT_SIDEBAR_LIB_H
 
 #include <stdbool.h>
+#include <stdint.h>
+#include "mutt/lib.h"
+#include "mutt_commands.h"
 
 struct Mailbox;
 struct MuttWindow;
-struct NotifyCallback;
 
 /* These Config Variables are only used in sidebar.c */
 extern short C_SidebarComponentDepth;
@@ -47,6 +49,7 @@ extern short C_SidebarSortMethod;
 extern bool  C_SidebarVisible;
 extern short C_SidebarWidth;
 
+extern struct ListHead SidebarWhitelist;
 
 /**
  * enum SidebarNotification - what happened to a mailbox
@@ -59,10 +62,14 @@ enum SidebarNotification
 };
 
 void            sb_change_mailbox  (int op);
+bool            select_next        (void);
 void            sb_draw            (struct MuttWindow *win);
 struct Mailbox *sb_get_highlight   (void);
 void            sb_notify_mailbox  (struct Mailbox *m, enum SidebarNotification sbn);
 int             sb_observer        (struct NotifyCallback *nc);
 void            sb_set_open_mailbox(struct Mailbox *m);
 
-#endif /* MUTT_SIDEBAR_H */
+enum CommandResult sb_parse_unwhitelist(struct Buffer *buf, struct Buffer *s, intptr_t data, struct Buffer *err);
+enum CommandResult sb_parse_whitelist  (struct Buffer *buf, struct Buffer *s, intptr_t data, struct Buffer *err);
+
+#endif /* MUTT_SIDEBAR_LIB_H */

--- a/sidebar/lib.h
+++ b/sidebar/lib.h
@@ -28,6 +28,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include "mutt/lib.h"
+#include "gui/lib.h"
 #include "mutt_commands.h"
 
 struct Mailbox;
@@ -62,16 +63,14 @@ enum SidebarNotification
   SBN_RENAMED  ///< An existing mailbox was renamed
 };
 
-void            sb_change_mailbox  (int op);
-bool            select_next        (void);
-void            sb_draw            (struct MuttWindow *win);
-struct Mailbox *sb_get_highlight   (void);
-void            sb_notify_mailbox  (struct Mailbox *m, enum SidebarNotification sbn);
-void            sb_set_open_mailbox(struct Mailbox *m);
-void            sb_win_init        (struct MuttWindow *dlg);
-void            sb_win_shutdown    (struct MuttWindow *dlg);
+void            sb_change_mailbox(struct MuttWindow *win, int op);
+struct Mailbox *sb_get_highlight (struct MuttWindow *win);
 
 enum CommandResult sb_parse_unwhitelist(struct Buffer *buf, struct Buffer *s, intptr_t data, struct Buffer *err);
 enum CommandResult sb_parse_whitelist  (struct Buffer *buf, struct Buffer *s, intptr_t data, struct Buffer *err);
+
+void sb_notify_mailbox  (struct MuttWindow *win, struct Mailbox *m, enum SidebarNotification sbn);
+void sb_draw            (struct MuttWindow *win);
+void sb_set_open_mailbox(struct MuttWindow *win, struct Mailbox *m);
 
 #endif /* MUTT_SIDEBAR_LIB_H */

--- a/sidebar/observer.c
+++ b/sidebar/observer.c
@@ -1,0 +1,88 @@
+/**
+ * @file
+ * Sidebar observers
+ *
+ * @authors
+ * Copyright (C) 2020 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @page sidebar_observers Sidebar observers
+ *
+ * Sidebar observers
+ */
+
+#include "config.h"
+#include <stdbool.h>
+#include "mutt/lib.h"
+#include "config/lib.h"
+#include "gui/lib.h"
+#include "lib.h"
+#include "mutt_menu.h"
+
+/**
+ * sb_observer - Listen for config changes affecting the sidebar - Implements ::observer_t
+ * @param nc Notification data
+ * @retval bool True, if successful
+ */
+int sb_observer(struct NotifyCallback *nc)
+{
+  if (!nc->event_data || !nc->global_data)
+    return -1;
+  if (nc->event_type != NT_CONFIG)
+    return 0;
+
+  struct MuttWindow *win = nc->global_data;
+  struct EventConfig *ec = nc->event_data;
+
+  if (!mutt_strn_equal(ec->name, "sidebar_", 8))
+    return 0;
+
+  bool repaint = false;
+
+  if (win->state.visible != C_SidebarVisible)
+  {
+    window_set_visible(win, C_SidebarVisible);
+    repaint = true;
+  }
+
+  if (win->req_cols != C_SidebarWidth)
+  {
+    win->req_cols = C_SidebarWidth;
+    repaint = true;
+  }
+
+  struct MuttWindow *parent = win->parent;
+  struct MuttWindow *first = TAILQ_FIRST(&parent->children);
+
+  if ((C_SidebarOnRight && (first == win)) || (!C_SidebarOnRight && (first != win)))
+  {
+    // Swap the Sidebar and the Container of the Index/Pager
+    TAILQ_REMOVE(&parent->children, first, entries);
+    TAILQ_INSERT_TAIL(&parent->children, first, entries);
+    repaint = true;
+  }
+
+  if (repaint)
+  {
+    mutt_debug(LL_NOTIFY, "repaint sidebar\n");
+    mutt_window_reflow(MuttDialogWindow);
+    mutt_menu_set_current_redraw_full();
+  }
+
+  return 0;
+}

--- a/sidebar/observer.c
+++ b/sidebar/observer.c
@@ -86,3 +86,23 @@ int sb_observer(struct NotifyCallback *nc)
 
   return 0;
 }
+
+/**
+ * sb_insertion_observer - Listen for new Dialogs - Implements ::observer_t
+ */
+int sb_insertion_observer(struct NotifyCallback *nc)
+{
+  if ((nc->event_type != NT_WINDOW) || (nc->event_subtype != NT_WINDOW_DIALOG))
+    return 0;
+
+  struct EventWindow *ew = nc->event_data;
+  if (ew->win->type != WT_DLG_INDEX)
+    return 0;
+
+  if (ew->flags & WN_VISIBLE)
+    sb_win_init(ew->win);
+  else if (ew->flags & WN_HIDDEN)
+    sb_win_shutdown(ew->win);
+
+  return 0;
+}

--- a/sidebar/observer.c
+++ b/sidebar/observer.c
@@ -28,6 +28,7 @@
 
 #include "config.h"
 #include <stdbool.h>
+#include "private.h"
 #include "mutt/lib.h"
 #include "config/lib.h"
 #include "gui/lib.h"

--- a/sidebar/private.h
+++ b/sidebar/private.h
@@ -1,0 +1,63 @@
+/**
+ * @file
+ * GUI display the mailboxes in a side panel
+ *
+ * @authors
+ * Copyright (C) 2020 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MUTT_SIDEBAR_SIDEBAR_PRIVATE_H
+#define MUTT_SIDEBAR_SIDEBAR_PRIVATE_H
+
+#include <stdbool.h>
+
+struct NotifyCallback;
+
+extern int EntryCount;
+extern int EntryLen;
+extern struct SbEntry **Entries;
+
+extern int TopIndex;
+extern int OpnIndex;
+extern int HilIndex;
+extern int BotIndex;
+
+/**
+ * struct SbEntry - Info about folders in the sidebar
+ */
+struct SbEntry
+{
+  char box[256];           ///< Mailbox path (possibly abbreviated)
+  int depth;               ///< Indentation depth
+  struct Mailbox *mailbox; ///< Mailbox this represents
+  bool is_hidden;          ///< Don't show, e.g. $sidebar_new_mail_only
+};
+
+/**
+ * enum DivType - Source of the sidebar divider character
+ */
+enum DivType
+{
+  SB_DIV_USER,  ///< User configured using $sidebar_divider_char
+  SB_DIV_ASCII, ///< An ASCII vertical bar (pipe)
+  SB_DIV_UTF8,  ///< A unicode line-drawing character
+};
+
+// observer.c
+int sb_observer(struct NotifyCallback *nc);
+
+#endif /* MUTT_SIDEBAR_SIDEBAR_PRIVATE_H */

--- a/sidebar/private.h
+++ b/sidebar/private.h
@@ -27,6 +27,8 @@
 
 struct NotifyCallback;
 
+extern struct ListHead SidebarWhitelist;
+
 extern int EntryCount;
 extern int EntryLen;
 extern struct SbEntry **Entries;

--- a/sidebar/private.h
+++ b/sidebar/private.h
@@ -60,6 +60,7 @@ enum DivType
 };
 
 // observer.c
+int sb_insertion_observer(struct NotifyCallback *nc);
 int sb_observer(struct NotifyCallback *nc);
 
 #endif /* MUTT_SIDEBAR_SIDEBAR_PRIVATE_H */

--- a/sidebar/private.h
+++ b/sidebar/private.h
@@ -24,20 +24,11 @@
 #define MUTT_SIDEBAR_SIDEBAR_PRIVATE_H
 
 #include <stdbool.h>
+#include "gui/lib.h"
 
-struct MuttWindow;
 struct NotifyCallback;
 
 extern struct ListHead SidebarWhitelist;
-
-extern int EntryCount;
-extern int EntryLen;
-extern struct SbEntry **Entries;
-
-extern int TopIndex;
-extern int OpnIndex;
-extern int HilIndex;
-extern int BotIndex;
 
 /**
  * struct SbEntry - Info about folders in the sidebar
@@ -48,6 +39,7 @@ struct SbEntry
   int depth;               ///< Indentation depth
   struct Mailbox *mailbox; ///< Mailbox this represents
   bool is_hidden;          ///< Don't show, e.g. $sidebar_new_mail_only
+  enum ColorId color;      ///< Colour to use
 };
 
 /**
@@ -79,6 +71,11 @@ struct SidebarWindowData
   short divider_width;       ///< Width of the divider in screen columns
   enum DivType divider_type; ///< Type of divider, e.g. #SB_DIV_UTF8
 };
+
+// sidebar.c
+void sb_win_init        (struct MuttWindow *dlg);
+void sb_win_shutdown    (struct MuttWindow *dlg);
+bool select_next        (struct SidebarWindowData *wdata);
 
 // observer.c
 int sb_insertion_observer(struct NotifyCallback *nc);

--- a/sidebar/private.h
+++ b/sidebar/private.h
@@ -25,6 +25,7 @@
 
 #include <stdbool.h>
 
+struct MuttWindow;
 struct NotifyCallback;
 
 extern struct ListHead SidebarWhitelist;
@@ -59,8 +60,33 @@ enum DivType
   SB_DIV_UTF8,  ///< A unicode line-drawing character
 };
 
+/**
+ * struct SidebarWindowData - Sidebar private Window data - @extends MuttWindow
+ */
+struct SidebarWindowData
+{
+  struct SbEntry **entries; ///< Items to display in the sidebar
+  int entry_count;          ///< Number of items in entries
+  int entry_max;            ///< Size of the entries array
+
+  int top_index; ///< First mailbox visible in sidebar
+  int opn_index; ///< Current (open) mailbox
+  int hil_index; ///< Highlighted mailbox
+  int bot_index; ///< Last mailbox visible in sidebar
+
+  short previous_sort; ///< sidebar_sort_method
+
+  short divider_width;       ///< Width of the divider in screen columns
+  enum DivType divider_type; ///< Type of divider, e.g. #SB_DIV_UTF8
+};
+
 // observer.c
 int sb_insertion_observer(struct NotifyCallback *nc);
 int sb_observer(struct NotifyCallback *nc);
+
+// wdata.c
+void                      sb_wdata_free(struct MuttWindow *win, void **ptr);
+struct SidebarWindowData *sb_wdata_new(void);
+struct SidebarWindowData *sb_wdata_get(struct MuttWindow *win);
 
 #endif /* MUTT_SIDEBAR_SIDEBAR_PRIVATE_H */

--- a/sidebar/sidebar.c
+++ b/sidebar/sidebar.c
@@ -1088,3 +1088,23 @@ void sb_draw(struct MuttWindow *win)
   draw_sidebar(win, num_rows, num_cols, div_width);
   mutt_window_move(win, col, row);
 }
+
+/**
+ * sb_init - Set up the Sidebar
+ */
+void sb_init(void)
+{
+  // Soon this will initialise the Sidebar's:
+  // - Colours
+  // - Commands
+  // - Config
+  // - Functions
+}
+
+/**
+ * sb_shutdown - Clean up the Sidebar
+ */
+void sb_shutdown(void)
+{
+  mutt_list_free(&SidebarWhitelist);
+}

--- a/sidebar/sidebar.c
+++ b/sidebar/sidebar.c
@@ -66,18 +66,6 @@ short C_SidebarWidth;      ///< Config: (sidebar) Width of the sidebar
 
 struct ListHead SidebarWhitelist = STAILQ_HEAD_INITIALIZER(SidebarWhitelist); ///< List of mailboxes to always display in the sidebar
 
-int EntryCount = 0;
-int EntryLen = 0;
-struct SbEntry **Entries = NULL;
-
-int TopIndex = -1; ///< First mailbox visible in sidebar
-int OpnIndex = -1; ///< Current (open) mailbox
-int HilIndex = -1; ///< Highlighted mailbox
-int BotIndex = -1; ///< Last mailbox visible in sidebar
-
-/* Previous values for some sidebar config */
-short PreviousSort = SORT_ORDER; /* sidebar_sort_method */
-
 /**
  * add_indent - Generate the needed indentation
  * @param buf    Output bufer
@@ -372,7 +360,7 @@ static int cb_qsort_sbe(const void *a, const void *b)
 /**
  * update_entries_visibility - Should a SbEntry be displayed in the sidebar?
  *
- * For each SbEntry in the Entries array, check whether we should display it.
+ * For each SbEntry in the entries array, check whether we should display it.
  * This is determined by several criteria.  If the Mailbox:
  * * is the currently open mailbox
  * * is the currently highlighted mailbox
@@ -380,7 +368,7 @@ static int cb_qsort_sbe(const void *a, const void *b)
  * * has flagged messages
  * * is whitelisted
  */
-static void update_entries_visibility(void)
+static void update_entries_visibility(struct SidebarWindowData *wdata)
 {
   /* Aliases for readability */
   const bool new_only = C_SidebarNewMailOnly;
@@ -390,16 +378,16 @@ static void update_entries_visibility(void)
   /* Take the fast path if there is no need to test visibilities */
   if (!new_only && !non_empty_only)
   {
-    for (int i = 0; i < EntryCount; i++)
+    for (int i = 0; i < wdata->entry_count; i++)
     {
-      Entries[i]->is_hidden = false;
+      wdata->entries[i]->is_hidden = false;
     }
     return;
   }
 
-  for (int i = 0; i < EntryCount; i++)
+  for (int i = 0; i < wdata->entry_count; i++)
   {
-    sbe = Entries[i];
+    sbe = wdata->entries[i];
 
     sbe->is_hidden = false;
 
@@ -416,12 +404,12 @@ static void update_entries_visibility(void)
       continue;
     }
 
-    if (non_empty_only && (i != OpnIndex) && (sbe->mailbox->msg_count == 0))
+    if (non_empty_only && (i != wdata->opn_index) && (sbe->mailbox->msg_count == 0))
     {
       sbe->is_hidden = true;
     }
 
-    if (new_only && (i != OpnIndex) && (sbe->mailbox->msg_unread == 0) &&
+    if (new_only && (i != wdata->opn_index) && (sbe->mailbox->msg_unread == 0) &&
         (sbe->mailbox->msg_flagged == 0) && !sbe->mailbox->has_new)
     {
       sbe->is_hidden = true;
@@ -430,9 +418,9 @@ static void update_entries_visibility(void)
 }
 
 /**
- * unsort_entries - Restore Entries array order to match Mailbox list order
+ * unsort_entries - Restore wdata->entries array order to match Mailbox list order
  */
-static void unsort_entries(void)
+static void unsort_entries(struct SidebarWindowData *wdata)
 {
   int i = 0;
 
@@ -441,19 +429,19 @@ static void unsort_entries(void)
   struct MailboxNode *np = NULL;
   STAILQ_FOREACH(np, &ml, entries)
   {
-    if (i >= EntryCount)
+    if (i >= wdata->entry_count)
       break;
 
     int j = i;
-    while ((j < EntryCount) && (Entries[j]->mailbox != np->mailbox))
+    while ((j < wdata->entry_count) && (wdata->entries[j]->mailbox != np->mailbox))
       j++;
-    if (j < EntryCount)
+    if (j < wdata->entry_count)
     {
       if (j != i)
       {
-        struct SbEntry *tmp = Entries[i];
-        Entries[i] = Entries[j];
-        Entries[j] = tmp;
+        struct SbEntry *tmp = wdata->entries[i];
+        wdata->entries[i] = wdata->entries[j];
+        wdata->entries[j] = tmp;
       }
       i++;
     }
@@ -462,28 +450,29 @@ static void unsort_entries(void)
 }
 
 /**
- * sort_entries - Sort Entries array
+ * sort_entries - Sort wdata->entries array
  *
- * Sort the Entries array according to the current sort config
+ * Sort the wdata->entries array according to the current sort config
  * option "sidebar_sort_method". This calls qsort to do the work which calls our
  * callback function "cb_qsort_sbe".
  *
  * Once sorted, the prev/next links will be reconstructed.
  */
-static void sort_entries(void)
+static void sort_entries(struct SidebarWindowData *wdata)
 {
   enum SortType ssm = (C_SidebarSortMethod & SORT_MASK);
 
   /* These are the only sort methods we understand */
   if ((ssm == SORT_COUNT) || (ssm == SORT_UNREAD) || (ssm == SORT_FLAGGED) || (ssm == SORT_PATH))
-    qsort(Entries, EntryCount, sizeof(*Entries), cb_qsort_sbe);
-  else if ((ssm == SORT_ORDER) && (C_SidebarSortMethod != PreviousSort))
-    unsort_entries();
+    qsort(wdata->entries, wdata->entry_count, sizeof(*wdata->entries), cb_qsort_sbe);
+  else if ((ssm == SORT_ORDER) && (C_SidebarSortMethod != wdata->previous_sort))
+    unsort_entries(wdata);
 }
 
 /**
  * prepare_sidebar - Prepare the list of SbEntry's for the sidebar display
- * @param page_size  The number of lines on a page
+ * @param wdata     Sidebar data
+ * @param page_size Number of lines on a page
  * @retval false No, don't draw the sidebar
  * @retval true  Yes, draw the sidebar
  *
@@ -493,55 +482,58 @@ static void sort_entries(void)
  * This is a lot of work to do each refresh, but there are many things that
  * can change outside of the sidebar that we don't hear about.
  */
-static bool prepare_sidebar(int page_size)
+static bool prepare_sidebar(struct SidebarWindowData *wdata, int page_size)
 {
-  if ((EntryCount == 0) || (page_size <= 0))
+  if ((wdata->entry_count == 0) || (page_size <= 0))
     return false;
 
-  const struct SbEntry *opn_entry = (OpnIndex >= 0) ? Entries[OpnIndex] : NULL;
-  const struct SbEntry *hil_entry = (HilIndex >= 0) ? Entries[HilIndex] : NULL;
+  const struct SbEntry *opn_entry =
+      (wdata->opn_index >= 0) ? wdata->entries[wdata->opn_index] : NULL;
+  const struct SbEntry *hil_entry =
+      (wdata->hil_index >= 0) ? wdata->entries[wdata->hil_index] : NULL;
 
-  update_entries_visibility();
-  sort_entries();
+  update_entries_visibility(wdata);
+  sort_entries(wdata);
 
-  for (int i = 0; i < EntryCount; i++)
+  for (int i = 0; i < wdata->entry_count; i++)
   {
-    if (opn_entry == Entries[i])
-      OpnIndex = i;
-    if (hil_entry == Entries[i])
-      HilIndex = i;
+    if (opn_entry == wdata->entries[i])
+      wdata->opn_index = i;
+    if (hil_entry == wdata->entries[i])
+      wdata->hil_index = i;
   }
 
-  if ((HilIndex < 0) || Entries[HilIndex]->is_hidden || (C_SidebarSortMethod != PreviousSort))
+  if ((wdata->hil_index < 0) || wdata->entries[wdata->hil_index]->is_hidden ||
+      (C_SidebarSortMethod != wdata->previous_sort))
   {
-    if (OpnIndex >= 0)
-      HilIndex = OpnIndex;
+    if (wdata->opn_index >= 0)
+      wdata->hil_index = wdata->opn_index;
     else
     {
-      HilIndex = 0;
-      if (Entries[HilIndex]->is_hidden)
-        select_next();
+      wdata->hil_index = 0;
+      if (wdata->entries[wdata->hil_index]->is_hidden)
+        select_next(wdata);
     }
   }
 
-  /* Set the Top and Bottom to frame the HilIndex in groups of page_size */
+  /* Set the Top and Bottom to frame the wdata->hil_index in groups of page_size */
 
   /* If C_SidebarNewMailOnly or C_SidebarNonEmptyMailboxOnly is set, some entries
    * may be hidden so we need to scan for the framing interval */
   if (C_SidebarNewMailOnly || C_SidebarNonEmptyMailboxOnly)
   {
-    TopIndex = -1;
-    BotIndex = -1;
-    while (BotIndex < HilIndex)
+    wdata->top_index = -1;
+    wdata->bot_index = -1;
+    while (wdata->bot_index < wdata->hil_index)
     {
-      TopIndex = BotIndex + 1;
+      wdata->top_index = wdata->bot_index + 1;
       int page_entries = 0;
       while (page_entries < page_size)
       {
-        BotIndex++;
-        if (BotIndex >= EntryCount)
+        wdata->bot_index++;
+        if (wdata->bot_index >= wdata->entry_count)
           break;
-        if (!Entries[BotIndex]->is_hidden)
+        if (!wdata->entries[wdata->bot_index]->is_hidden)
           page_entries++;
       }
     }
@@ -549,22 +541,23 @@ static bool prepare_sidebar(int page_size)
   /* Otherwise we can just calculate the interval */
   else
   {
-    TopIndex = (HilIndex / page_size) * page_size;
-    BotIndex = TopIndex + page_size - 1;
+    wdata->top_index = (wdata->hil_index / page_size) * page_size;
+    wdata->bot_index = wdata->top_index + page_size - 1;
   }
 
-  if (BotIndex > (EntryCount - 1))
-    BotIndex = EntryCount - 1;
+  if (wdata->bot_index > (wdata->entry_count - 1))
+    wdata->bot_index = wdata->entry_count - 1;
 
-  PreviousSort = C_SidebarSortMethod;
+  wdata->previous_sort = C_SidebarSortMethod;
   return true;
 }
 
 /**
  * draw_divider - Draw a line between the sidebar and the rest of neomutt
- * @param win        Window to draw on
- * @param num_rows   Height of the Sidebar
- * @param num_cols   Width of the Sidebar
+ * @param wdata    Sidebar data
+ * @param win      Window to draw on
+ * @param num_rows Height of the Sidebar
+ * @param num_cols Width of the Sidebar
  * @retval 0   Empty string
  * @retval num Character occupies n screen columns
  *
@@ -575,26 +568,26 @@ static bool prepare_sidebar(int page_size)
  * If the user hasn't set $sidebar_divider_char we pick a character for them,
  * respecting the value of $ascii_chars.
  */
-static int draw_divider(struct MuttWindow *win, int num_rows, int num_cols)
+static int draw_divider(struct SidebarWindowData *wdata, struct MuttWindow *win,
+                        int num_rows, int num_cols)
 {
   if ((num_rows < 1) || (num_cols < 1))
     return 0;
 
-  int delim_len;
   enum DivType altchar = SB_DIV_UTF8;
 
   /* Calculate the width of the delimiter in screen cells */
-  delim_len = mutt_strwidth(C_SidebarDividerChar);
-  if (delim_len < 0)
+  wdata->divider_width = mutt_strwidth(C_SidebarDividerChar);
+  if (wdata->divider_width < 0)
   {
-    delim_len = 1; /* Bad character */
+    wdata->divider_width = 1; /* Bad character */
   }
-  else if (delim_len == 0)
+  else if (wdata->divider_width == 0)
   {
     if (C_SidebarDividerChar)
       return 0; /* User has set empty string */
 
-    delim_len = 1; /* Unset variable */
+    wdata->divider_width = 1; /* Unset variable */
   }
   else
   {
@@ -610,24 +603,24 @@ static int draw_divider(struct MuttWindow *win, int num_rows, int num_cols)
     }
     else if (C_SidebarDividerChar)
     {
-      for (int i = 0; i < delim_len; i++)
+      for (int i = 0; i < wdata->divider_width; i++)
       {
         if (C_SidebarDividerChar[i] & ~0x7F) /* high-bit is set */
         {
           altchar = SB_DIV_ASCII;
-          delim_len = 1;
+          wdata->divider_width = 1;
           break;
         }
       }
     }
   }
 
-  if (delim_len > num_cols)
+  if (wdata->divider_width > num_cols)
     return 0;
 
   mutt_curses_set_color(MT_COLOR_SIDEBAR_DIVIDER);
 
-  int col = C_SidebarOnRight ? 0 : (C_SidebarWidth - delim_len);
+  int col = C_SidebarOnRight ? 0 : (C_SidebarWidth - wdata->divider_width);
 
   for (int i = 0; i < num_rows; i++)
   {
@@ -647,7 +640,7 @@ static int draw_divider(struct MuttWindow *win, int num_rows, int num_cols)
     }
   }
 
-  return delim_len;
+  return wdata->divider_width;
 }
 
 /**
@@ -817,10 +810,11 @@ static int calc_path_depth(const char *mbox, const char *delims, const char **la
 
 /**
  * draw_sidebar - Write out a list of mailboxes, in a panel
- * @param win        Window to draw on
- * @param num_rows   Height of the Sidebar
- * @param num_cols   Width of the Sidebar
- * @param div_width  Width in screen characters taken by the divider
+ * @param wdata     Sidebar data
+ * @param win       Window to draw on
+ * @param num_rows  Height of the Sidebar
+ * @param num_cols  Width of the Sidebar
+ * @param div_width Width in screen characters taken by the divider
  *
  * Display a list of mailboxes in a panel on the left.  What's displayed will
  * depend on our index markers: TopMailbox, OpnMailbox, HilMailbox, BotMailbox.
@@ -836,30 +830,32 @@ static int calc_path_depth(const char *mbox, const char *delims, const char **la
  * "sidebar_indent_string" and sorted: "sidebar_sort_method".  Finally, they're
  * trimmed to fit the available space.
  */
-static void draw_sidebar(struct MuttWindow *win, int num_rows, int num_cols, int div_width)
+static void draw_sidebar(struct SidebarWindowData *wdata, struct MuttWindow *win,
+                         int num_rows, int num_cols, int div_width)
 {
   struct SbEntry *entry = NULL;
   struct Mailbox *m = NULL;
-  if (TopIndex < 0)
+  if (wdata->top_index < 0)
     return;
 
   int w = MIN(num_cols, (C_SidebarWidth - div_width));
   int row = 0;
-  for (int entryidx = TopIndex; (entryidx < EntryCount) && (row < num_rows); entryidx++)
+  for (int entryidx = wdata->top_index;
+       (entryidx < wdata->entry_count) && (row < num_rows); entryidx++)
   {
-    entry = Entries[entryidx];
+    entry = wdata->entries[entryidx];
     if (entry->is_hidden)
       continue;
     m = entry->mailbox;
 
-    if (entryidx == OpnIndex)
+    if (entryidx == wdata->opn_index)
     {
       if ((Colors->defs[MT_COLOR_SIDEBAR_INDICATOR] != 0))
         mutt_curses_set_color(MT_COLOR_SIDEBAR_INDICATOR);
       else
         mutt_curses_set_color(MT_COLOR_INDICATOR);
     }
-    else if (entryidx == HilIndex)
+    else if (entryidx == wdata->hil_index)
       mutt_curses_set_color(MT_COLOR_SIDEBAR_HIGHLIGHT);
     else if (m->has_new)
       mutt_curses_set_color(MT_COLOR_SIDEBAR_NEW);
@@ -935,37 +931,41 @@ static void draw_sidebar(struct MuttWindow *win, int num_rows, int num_cols, int
  * sb_get_highlight - Get the Mailbox that's highlighted in the sidebar
  * @retval ptr Mailbox
  */
-struct Mailbox *sb_get_highlight(void)
+struct Mailbox *sb_get_highlight(struct MuttWindow *win)
 {
   if (!C_SidebarVisible)
     return NULL;
 
-  if ((EntryCount == 0) || (HilIndex < 0))
+  struct SidebarWindowData *wdata = sb_wdata_get(win);
+  if ((wdata->entry_count == 0) || (wdata->hil_index < 0))
     return NULL;
 
-  return Entries[HilIndex]->mailbox;
+  return wdata->entries[wdata->hil_index]->mailbox;
 }
 
 /**
  * sb_set_open_mailbox - Set the 'open' Mailbox
- * @param m Mailbox
+ * @param win Sidebar Window
+ * @param m   Mailbox
  *
  * Search through the list of mailboxes.
  * If a Mailbox has a matching path, set OpnMailbox to it.
  */
-void sb_set_open_mailbox(struct Mailbox *m)
+void sb_set_open_mailbox(struct MuttWindow *win, struct Mailbox *m)
 {
-  OpnIndex = -1;
+  struct SidebarWindowData *wdata = sb_wdata_get(win);
+
+  wdata->opn_index = -1;
 
   if (!m)
     return;
 
-  for (int entry = 0; entry < EntryCount; entry++)
+  for (int entry = 0; entry < wdata->entry_count; entry++)
   {
-    if (mutt_str_equal(Entries[entry]->mailbox->realpath, m->realpath))
+    if (mutt_str_equal(wdata->entries[entry]->mailbox->realpath, m->realpath))
     {
-      OpnIndex = entry;
-      HilIndex = entry;
+      wdata->opn_index = entry;
+      wdata->hil_index = entry;
       break;
     }
   }
@@ -973,6 +973,7 @@ void sb_set_open_mailbox(struct Mailbox *m)
 
 /**
  * sb_notify_mailbox - The state of a Mailbox is about to change
+ * @param win Sidebar Window
  * @param m   Folder
  * @param sbn What happened to the mailbox
  *
@@ -983,60 +984,61 @@ void sb_set_open_mailbox(struct Mailbox *m)
  *
  * Before a deletion, check that our pointers won't be invalidated.
  */
-void sb_notify_mailbox(struct Mailbox *m, enum SidebarNotification sbn)
+void sb_notify_mailbox(struct MuttWindow *win, struct Mailbox *m, enum SidebarNotification sbn)
 {
   if (!m)
     return;
 
+  struct SidebarWindowData *wdata = sb_wdata_get(win);
   /* Any new/deleted mailboxes will cause a refresh.  As long as
    * they're valid, our pointers will be updated in prepare_sidebar() */
 
   if (sbn == SBN_CREATED)
   {
-    if (EntryCount >= EntryLen)
+    if (wdata->entry_count >= wdata->entry_max)
     {
-      EntryLen += 10;
-      mutt_mem_realloc(&Entries, EntryLen * sizeof(struct SbEntry *));
+      wdata->entry_max += 10;
+      mutt_mem_realloc(&wdata->entries, wdata->entry_max * sizeof(struct SbEntry *));
     }
-    Entries[EntryCount] = mutt_mem_calloc(1, sizeof(struct SbEntry));
-    Entries[EntryCount]->mailbox = m;
+    wdata->entries[wdata->entry_count] = mutt_mem_calloc(1, sizeof(struct SbEntry));
+    wdata->entries[wdata->entry_count]->mailbox = m;
 
-    if (TopIndex < 0)
-      TopIndex = EntryCount;
-    if (BotIndex < 0)
-      BotIndex = EntryCount;
-    if ((OpnIndex < 0) && Context &&
+    if (wdata->top_index < 0)
+      wdata->top_index = wdata->entry_count;
+    if (wdata->bot_index < 0)
+      wdata->bot_index = wdata->entry_count;
+    if ((wdata->opn_index < 0) && Context &&
         mutt_str_equal(m->realpath, Context->mailbox->realpath))
     {
-      OpnIndex = EntryCount;
+      wdata->opn_index = wdata->entry_count;
     }
 
-    EntryCount++;
+    wdata->entry_count++;
   }
   else if (sbn == SBN_DELETED)
   {
     int del_index;
-    for (del_index = 0; del_index < EntryCount; del_index++)
-      if (Entries[del_index]->mailbox == m)
+    for (del_index = 0; del_index < wdata->entry_count; del_index++)
+      if (wdata->entries[del_index]->mailbox == m)
         break;
-    if (del_index == EntryCount)
+    if (del_index == wdata->entry_count)
       return;
-    FREE(&Entries[del_index]);
-    EntryCount--;
+    FREE(&wdata->entries[del_index]);
+    wdata->entry_count--;
 
-    if ((TopIndex > del_index) || (TopIndex == EntryCount))
-      TopIndex--;
-    if (OpnIndex == del_index)
-      OpnIndex = -1;
-    else if (OpnIndex > del_index)
-      OpnIndex--;
-    if ((HilIndex > del_index) || (HilIndex == EntryCount))
-      HilIndex--;
-    if ((BotIndex > del_index) || (BotIndex == EntryCount))
-      BotIndex--;
+    if ((wdata->top_index > del_index) || (wdata->top_index == wdata->entry_count))
+      wdata->top_index--;
+    if (wdata->opn_index == del_index)
+      wdata->opn_index = -1;
+    else if (wdata->opn_index > del_index)
+      wdata->opn_index--;
+    if ((wdata->hil_index > del_index) || (wdata->hil_index == wdata->entry_count))
+      wdata->hil_index--;
+    if ((wdata->bot_index > del_index) || (wdata->bot_index == wdata->entry_count))
+      wdata->bot_index--;
 
-    for (; del_index < EntryCount; del_index++)
-      Entries[del_index] = Entries[del_index + 1];
+    for (; del_index < wdata->entry_count; del_index++)
+      wdata->entries[del_index] = wdata->entries[del_index + 1];
   }
 
   // otherwise, we just need to redraw
@@ -1059,33 +1061,36 @@ void sb_draw(struct MuttWindow *win)
   if (!mutt_window_is_visible(win))
     return;
 
+  struct SidebarWindowData *wdata = sb_wdata_get(win);
+
   int col = 0, row = 0;
   mutt_window_get_coords(win, &col, &row);
 
   int num_rows = win->state.rows;
   int num_cols = win->state.cols;
 
-  int div_width = draw_divider(win, num_rows, num_cols);
+  draw_divider(wdata, win, num_rows, num_cols);
 
-  if (!Entries)
+  if (!wdata->entries)
   {
     struct MailboxList ml = STAILQ_HEAD_INITIALIZER(ml);
     neomutt_mailboxlist_get_all(&ml, NeoMutt, MUTT_MAILBOX_ANY);
     struct MailboxNode *np = NULL;
     STAILQ_FOREACH(np, &ml, entries)
     {
-      sb_notify_mailbox(np->mailbox, SBN_CREATED);
+      if (!(np->mailbox->flags & MB_HIDDEN))
+        sb_notify_mailbox(win, np->mailbox, SBN_CREATED);
     }
     neomutt_mailboxlist_clear(&ml);
   }
 
-  if (!prepare_sidebar(num_rows))
+  if (!prepare_sidebar(wdata, num_rows))
   {
-    fill_empty_space(win, 0, num_rows, div_width, num_cols - div_width);
+    fill_empty_space(win, 0, num_rows, wdata->divider_width, num_cols - wdata->divider_width);
     return;
   }
 
-  draw_sidebar(win, num_rows, num_cols, div_width);
+  draw_sidebar(wdata, win, num_rows, num_cols, wdata->divider_width);
   mutt_window_move(win, col, row);
 }
 
@@ -1114,6 +1119,8 @@ void sb_win_init(struct MuttWindow *dlg)
       mutt_window_new(WT_SIDEBAR, MUTT_WIN_ORIENT_HORIZONTAL, MUTT_WIN_SIZE_FIXED,
                       C_SidebarWidth, MUTT_WIN_SIZE_UNLIMITED);
   win_sidebar->state.visible = C_SidebarVisible && (C_SidebarWidth > 0);
+  win_sidebar->wdata = sb_wdata_new();
+  win_sidebar->wdata_free = sb_wdata_free;
 
   if (C_SidebarOnRight)
   {

--- a/sidebar/wdata.c
+++ b/sidebar/wdata.c
@@ -1,0 +1,74 @@
+/**
+ * @file
+ * Sidebar Window data
+ *
+ * @authors
+ * Copyright (C) 2020 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @page sidebar_wdata Sidebar Window data
+ *
+ * Sidebar Window data
+ */
+
+#include "config.h"
+#include <stddef.h>
+#include "private.h"
+#include "mutt/lib.h"
+#include "gui/lib.h"
+
+/**
+ * sb_wdata_new - Create new Window data for the Sidebar
+ * @retval ptr New Window data
+ */
+struct SidebarWindowData *sb_wdata_new(void)
+{
+  return mutt_mem_calloc(1, sizeof(struct SidebarWindowData));
+}
+
+/**
+ * sb_wdata_free - Free Sidebar Window data
+ * @param win Sidebar Window
+ * @param ptr Window data to free
+ */
+void sb_wdata_free(struct MuttWindow *win, void **ptr)
+{
+  if (!ptr || !*ptr)
+    return;
+
+  struct SidebarWindowData *wdata = *ptr;
+
+  for (size_t i = 0; i < wdata->entry_count; i++)
+    FREE(&wdata->entries[i]);
+
+  FREE(&wdata->entries);
+
+  FREE(ptr);
+}
+
+/**
+ * sb_wdata_get - Get the Sidebar data for this window
+ * @param win Window
+ */
+struct SidebarWindowData *sb_wdata_get(struct MuttWindow *win)
+{
+  if (!win || (win->type != WT_SIDEBAR))
+    return NULL;
+
+  return win->wdata;
+}


### PR DESCRIPTION
This PR reorganises the Sidebar to make it more like a plugin.

Currently, the Index and other components, **drive** the Sidebar by calling functions.
Ideally, the Sidebar, once initialised, should **react** to Events.
This is a step in that direction.

To the user, there should be no visible change.

- b14846f55f create library
  Move the source into `sidebar/`

- 73550c61f7 `init()`, `shutdown()`
  Create the 'plugin' setup for the Sidebar

- 6d5092181e decouple from index
  Move the Sidebar creation out of the Index
  The Sidebar observes the creation of the Index Dialog, then inserts itself

- 2be08eda3c add window data
  Create a place for the Sidebar-specific data
  The SidebarWindowData will be attached to the Sidebar Window

- c0218a8b32 encapsulate data
  Wrap the Sidebar globals and move them to Window-data