### PR TITLE
Fix: redrawing of pager_index_lines

### DIFF
--- a/debug/window.c
+++ b/debug/window.c
@@ -56,7 +56,7 @@ static void win_dump(struct MuttWindow *win, int indent)
   bool visible = mutt_window_is_visible(win);
 
   mutt_debug(LL_DEBUG1, "%*s%s[%d,%d] %s-%c \033[1;33m%s\033[0m (%d,%d)%s\n",
-             indent, "", visible ? "" : "\033[1;30m", win->state.col_offset,
+             indent, "", visible ? "✓" : "✗\033[1;30m", win->state.col_offset,
              win->state.row_offset, win_size(win),
              (win->orient == MUTT_WIN_ORIENT_VERTICAL) ? 'V' : 'H', win_name(win),
              win->state.cols, win->state.rows, visible ? "" : "\033[0m");

--- a/docs/config.c
+++ b/docs/config.c
@@ -2734,12 +2734,9 @@
 ** folder, will be roughly one third of the way down this mini-index,
 ** giving the reader the context of a few messages before and after the
 ** message.  This is useful, for example, to determine how many messages
-** remain to be read in the current thread.  One of the lines is reserved
-** for the status bar from the index, so a setting of 6
-** will only show 5 lines of the actual index.  A value of 0 results in
-** no index being shown.  If the number of messages in the current folder
-** is less than $$pager_index_lines, then the index will only use as
-** many lines as it needs.
+** remain to be read in the current thread.  A value of 0 results in no index
+** being shown.  If the number of messages in the current folder is less than
+** $$pager_index_lines, then the index will only use as many lines as it needs.
 */
 
 { "pager_stop", DT_BOOL, false },

--- a/index.c
+++ b/index.c
@@ -4093,12 +4093,10 @@ static struct MuttWindow *create_panel_pager(struct MuttWindow *parent, bool sta
   struct MuttWindow *win_pager =
       mutt_window_new(WT_PAGER, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
-  win_pager->state.visible = false;
 
   struct MuttWindow *win_pbar =
       mutt_window_new(WT_PAGER_BAR, MUTT_WIN_ORIENT_VERTICAL,
                       MUTT_WIN_SIZE_FIXED, MUTT_WIN_SIZE_UNLIMITED, 1);
-  win_pbar->state.visible = false;
 
   if (status_on_top)
   {

--- a/test/Makefile.autosetup
+++ b/test/Makefile.autosetup
@@ -224,7 +224,8 @@ GROUP_OBJS	= test/group/mutt_group_match.o \
 		  test/group/mutt_grouplist_remove_regex.o \
 		  test/group/mutt_pattern_group.o
 
-GUI_OBJS	= test/gui/reflow.o
+GUI_OBJS	= test/gui/reflow.o \
+		  test/gui/visible.o
 
 HASH_OBJS	= test/hash/mutt_hash_delete.o \
 		  test/hash/mutt_hash_find.o \

--- a/test/gui/visible.c
+++ b/test/gui/visible.c
@@ -1,0 +1,164 @@
+/**
+ * @file
+ * Test code for Window visibility notification)
+ *
+ * @authors
+ * Copyright (C) 2020 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define TEST_NO_MAIN
+#include "config.h"
+#include "acutest.h"
+#include <stdint.h>
+#include "mutt/lib.h"
+#include "gui/mutt_window.h"
+#include "gui/reflow.h"
+
+enum TestEvent
+{
+  TE_NONE,
+  TE_VISIBLE,
+  TE_HIDDEN,
+};
+
+struct TestVisible
+{
+  bool parent_before;
+  bool parent_after;
+  enum TestEvent parent_expected;
+
+  bool child_before;
+  bool child_after;
+  enum TestEvent child_expected;
+};
+
+struct NotifyCatcher
+{
+  enum TestEvent parent_received;
+  enum TestEvent child_received;
+};
+
+const char *event_name(enum TestEvent event)
+{
+  switch (event)
+  {
+    case TE_NONE:
+      return "NONE";
+    case TE_VISIBLE:
+      return "VISIBLE";
+    case TE_HIDDEN:
+      return "HIDDEN";
+  }
+  return "UNKNOWN";
+}
+
+int visible_observer(struct NotifyCallback *nc)
+{
+  if (!nc->event_data || !nc->global_data)
+    return -1;
+  if (nc->event_type != NT_WINDOW)
+    return 0;
+
+  struct EventWindow *ew = nc->event_data;
+  struct NotifyCatcher *results = nc->global_data;
+
+  if (ew->win->type == WT_ROOT)
+  {
+    if (ew->flags & WN_VISIBLE)
+      results->parent_received = TE_VISIBLE;
+    else if (ew->flags & WN_HIDDEN)
+      results->parent_received = TE_HIDDEN;
+  }
+  else if (ew->win->type == WT_DLG_INDEX)
+  {
+    if (ew->flags & WN_VISIBLE)
+      results->child_received = TE_VISIBLE;
+    else if (ew->flags & WN_HIDDEN)
+      results->child_received = TE_HIDDEN;
+  }
+
+  return 0;
+}
+
+void test_window_visible(void)
+{
+  static const struct TestVisible tests[] = {
+    // clang-format off
+    { false, false, TE_NONE,    false, false, TE_NONE    },
+    { false, false, TE_NONE,    false, true,  TE_NONE    },
+    { false, false, TE_NONE,    true,  false, TE_NONE    },
+    { false, false, TE_NONE,    true,  true,  TE_NONE    },
+
+    { false, true,  TE_VISIBLE, false, false, TE_NONE    },
+    { false, true,  TE_VISIBLE, false, true,  TE_VISIBLE },
+    { false, true,  TE_VISIBLE, true,  false, TE_NONE    },
+    { false, true,  TE_VISIBLE, true,  true,  TE_VISIBLE },
+
+    { true,  false, TE_HIDDEN,  false, false, TE_NONE    },
+    { true,  false, TE_HIDDEN,  false, true,  TE_NONE    },
+    { true,  false, TE_HIDDEN,  true,  false, TE_HIDDEN  },
+    { true,  false, TE_HIDDEN,  true,  true,  TE_HIDDEN  },
+
+    { true,  true,  TE_NONE,    false, false, TE_NONE    },
+    { true,  true,  TE_NONE,    false, true,  TE_VISIBLE },
+    { true,  true,  TE_NONE,    true,  false, TE_HIDDEN  },
+    { true,  true,  TE_NONE,    true,  true,  TE_NONE    },
+    // clang-format on
+  };
+
+  struct MuttWindow *parent = mutt_window_new(WT_ROOT, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_FIXED, 80, 24);
+  struct MuttWindow *child = mutt_window_new(WT_DLG_INDEX, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_FIXED, 60, 20);
+
+  TEST_CHECK(parent != NULL);
+  TEST_CHECK(child != NULL);
+
+  mutt_window_add_child(parent, child);
+
+  struct NotifyCatcher results;
+
+  notify_observer_add(parent->notify, visible_observer, &results);
+
+  for (size_t i = 0; i < mutt_array_size(tests); i++)
+  {
+    parent->old.visible   = tests[i].parent_before;
+    parent->state.visible = tests[i].parent_after;
+    child->old.visible    = tests[i].child_before;
+    child->state.visible  = tests[i].child_after;
+
+    results.parent_received = TE_NONE;
+    results.child_received = TE_NONE;
+
+    TEST_CASE_("%ld: P%d->%d, C%d->%d", i, tests[i].parent_before, tests[i].parent_after, tests[i].child_before, tests[i].child_after);
+    mutt_window_reflow(parent);
+
+    if (!TEST_CHECK(tests[i].parent_expected == results.parent_received))
+    {
+      TEST_MSG("Expected: %s", event_name(tests[i].parent_expected));
+      TEST_MSG("Actual:   %s", event_name(results.parent_received));
+    }
+
+    if (!TEST_CHECK(tests[i].child_expected == results.child_received))
+    {
+      TEST_MSG("Expected: %s", event_name(tests[i].child_expected));
+      TEST_MSG("Actual:   %s", event_name(results.child_received));
+    }
+  }
+
+  notify_observer_remove(parent->notify, visible_observer, &results);
+
+  mutt_window_free(&parent);
+}

--- a/test/main.c
+++ b/test/main.c
@@ -261,6 +261,7 @@
                                                                                \
   /* gui */                                                                    \
   NEOMUTT_TEST_ITEM(test_window_reflow)                                        \
+  NEOMUTT_TEST_ITEM(test_window_visible)                                       \
                                                                                \
   /* hash */                                                                   \
   NEOMUTT_TEST_ITEM(test_mutt_hash_delete)                                     \


### PR DESCRIPTION
Fixes: #2426

**To reproduce**:

- `set pager_index_lines = 0`
- Open email in pager
- `set pager_index_lines = 5`

**Expected**:
- 5 lines of index displayed at top of screen

**Actual**:
- A line of index would be displayed at the bottom of the screen.

---

To hide some windows (e.g. Index, Index bar), simply hide one of their parents.
Before, I was **hiding** each, but only **showing** the parent.
