### PR TITLE
support sort_th for sub thread

### DIFF
--- a/config/sort2.h
+++ b/config/sort2.h
@@ -47,6 +47,7 @@ extern const struct Mapping SortSidebarMethods[];
  */
 enum SortType
 {
+  SORT_DUMMY	=  0, ///< Don't use any sort mechanism
   SORT_DATE     =  1, ///< Sort by the date the email was sent
   SORT_SIZE     =  2, ///< Sort by the size of the email
   SORT_ALPHA    =  3, ///< Required by makedoc.c

--- a/mutt_config.c
+++ b/mutt_config.c
@@ -578,6 +578,9 @@ struct ConfigDef MainVars[] = {
   { "sort_re", DT_BOOL|R_INDEX|R_RESORT|R_RESORT_INIT, &C_SortRe, true, 0, pager_validator,
     "Sort method for the sidebar"
   },
+  { "sort_th", DT_SORT|DT_SORT_AUX|R_INDEX|R_RESORT|R_RESORT_SUB, &C_SortTh, SORT_DATE, 0, NULL,
+    "Sort for subthread"
+  },
   { "spam_separator", DT_STRING, &C_SpamSeparator, IP ",", 0, NULL,
     "Separator for multiple spam headers"
   },

--- a/mutt_config.c
+++ b/mutt_config.c
@@ -578,7 +578,7 @@ struct ConfigDef MainVars[] = {
   { "sort_re", DT_BOOL|R_INDEX|R_RESORT|R_RESORT_INIT, &C_SortRe, true, 0, pager_validator,
     "Sort method for the sidebar"
   },
-  { "sort_th", DT_SORT|DT_SORT_AUX|R_INDEX|R_RESORT|R_RESORT_SUB, &C_SortTh, SORT_DATE, 0, NULL,
+  { "sort_th", DT_SORT|DT_SORT_AUX|R_INDEX|R_RESORT|R_RESORT_SUB, &C_SortTh, SORT_DUMMY, 0, NULL,
     "Sort for subthread"
   },
   { "spam_separator", DT_STRING, &C_SpamSeparator, IP ",", 0, NULL,

--- a/mutt_thread.c
+++ b/mutt_thread.c
@@ -703,8 +703,8 @@ struct MuttThread *mutt_sort_subthreads(struct MuttThread *thread, bool init)
   if (compare_threads(NULL, NULL) == 0)
     return thread;
 
-  if (compare_subthreads(NULL, NULL) == 0)
-    return thread;
+  if ((compare_subthreads(NULL, NULL) == 0) && (C_SortTh != SORT_DUMMY))
+	  return thread;
 
   top = thread;
 
@@ -753,7 +753,7 @@ struct MuttThread *mutt_sort_subthreads(struct MuttThread *thread, bool init)
           array[i] = thread;
         }
 
-        if (array[0]->parent)
+        if ((array[0]->parent) && (C_SortTh != SORT_DUMMY))
           qsort((void *) array, i, sizeof(struct MuttThread *), *compare_subthreads);
         else
           qsort((void *) array, i, sizeof(struct MuttThread *), *compare_threads);

--- a/sort.h
+++ b/sort.h
@@ -57,5 +57,6 @@ const char *mutt_get_name(const struct Address *a);
 /* These variables are backing for config items */
 WHERE short C_Sort;    ///< Config: Sort method for the index
 WHERE short C_SortAux; ///< Config: Secondary sort method for the index
+WHERE short C_SortTh;  ///< Config: Sort for subthread
 
 #endif /* MUTT_SORT_H */


### PR DESCRIPTION
* **What does this PR do?**
When sort = threads, then top threads and sub threads will sort by
sort_aux.

But, i want top threads sort by reverse-date, and the sub threads
under one thread sort by date. So I add sort_th to do this.

* **Screenshots (if relevant)**

* **Does this PR meet the acceptance criteria?** (This is just a reminder for you,
  this section can be removed if you fulfill it.)

   - Documentation created/updated (you have to edit
     [doc/manual.xml.head](https://www.github.com/neomutt/neomutt/blob/master/doc/manual.xml.head)
     for that)

   - All builds and tests are passing

   - Added [doxygen code documentation](https://neomutt.org/dev/doxygen)
     [syntax](http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html)

   - Code follows the [style guide](https://neomutt.org/dev/coding-style)

* **What are the relevant issue numbers?**
#2342