### PR TITLE
Refactor libsend's config

### DIFF
--- a/config/set.h
+++ b/config/set.h
@@ -53,8 +53,6 @@ struct HashElem;
 
 #define IP (intptr_t)
 
-#define CS_REG_DISABLED (1 << 0)
-
 /**
  * struct ConfigDef - Config item definition
  *

--- a/config/set.h
+++ b/config/set.h
@@ -76,6 +76,8 @@ struct ConfigDef
    * @retval #CSR_ERR_INVALID Failure
    */
   int (*validator)(const struct ConfigSet *cs, const struct ConfigDef *cdef, intptr_t value, struct Buffer *err);
+
+  const char *docs; ///< One-liner description
 };
 
 /**

--- a/config/types.h
+++ b/config/types.h
@@ -80,6 +80,7 @@ typedef uint32_t ConfigRedrawFlags; ///< Flags for redraw/resort, e.g. #R_INDEX
 #define DT_INHERITED    (1 << 28)  ///< Config item is inherited
 #define DT_INITIAL_SET  (1 << 29)  ///< Config item must have its initial value freed
 #define DT_DISABLED     (1 << 30)  ///< Config item is disabled
-#define DT_MY_CONFIG    (1 << 31)  ///< Config item is a "my_" variable
+// #define DT_MY_CONFIG    (1 << 31)  ///< Config item is a "my_" variable
+#define DT_NO_VARIABLE  (1 << 31)  ///< Config item doesn't have a backing global variable
 
 #endif /* MUTT_CONFIG_TYPES_H */

--- a/index.c
+++ b/index.c
@@ -34,6 +34,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
+#include <sys/types.h>
 #include "mutt/lib.h"
 #include "config/lib.h"
 #include "email/lib.h"
@@ -51,7 +52,6 @@
 #include "hdrline.h"
 #include "helpbar.h"
 #include "hook.h"
-#include "init.h"
 #include "keymap.h"
 #include "mutt_globals.h"
 #include "mutt_header.h"

--- a/init.c
+++ b/init.c
@@ -63,7 +63,6 @@
 #include "sort.h"
 #include "autocrypt/lib.h"
 #include "compress/lib.h"
-#include "hcache/lib.h"
 #include "history/lib.h"
 #include "imap/lib.h"
 #include "maildir/lib.h"

--- a/init.h
+++ b/init.h
@@ -28,12 +28,13 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <stdint.h>
-#include "config/lib.h"
 #include "mutt.h"
 #include "hook.h"
 #include "mutt_commands.h"
 
 struct Buffer;
+struct ConfigDef;
+struct ConfigSet;
 struct ListHead;
 
 int charset_validator    (const struct ConfigSet *cs, const struct ConfigDef *cdef, intptr_t value, struct Buffer *err);

--- a/mutt_config.c
+++ b/mutt_config.c
@@ -64,8 +64,6 @@
 #include "sort.h"
 #include "status.h"
 #include "bcache/lib.h"
-#include "maildir/lib.h"
-#include "ncrypt/lib.h"
 #include "pattern/lib.h"
 
 #ifndef ISPELL

--- a/mutt_globals.h
+++ b/mutt_globals.h
@@ -27,7 +27,6 @@
 #include <signal.h> // IWYU pragma: keep
 #include <stdbool.h>
 #include "mutt/lib.h"
-#include "alias/lib.h"
 #include "keymap.h"
 #include "where.h"
 

--- a/recvattach.c
+++ b/recvattach.c
@@ -48,7 +48,6 @@
 #include "hdrline.h"
 #include "helpbar.h"
 #include "hook.h"
-#include "init.h"
 #include "keymap.h"
 #include "mailcap.h"
 #include "mutt_attach.h"

--- a/send/config.c
+++ b/send/config.c
@@ -34,78 +34,6 @@
 #include "mutt/lib.h"
 #include "init.h"
 
-// clang-format off
-unsigned char C_AbortNoattach;                    ///< Config: Abort sending the email if attachments are missing
-struct Regex *C_AbortNoattachRegex = NULL;        ///< Config: Regex to match text indicating attachments are expected
-unsigned char C_AbortNosubject;                   ///< Config: Abort creating the email if subject is missing
-unsigned char C_AbortUnmodified;                  ///< Config: Abort the sending if the message hasn't been edited
-bool          C_Allow8bit;                        ///< Config: Allow 8-bit messages, don't use quoted-printable or base64
-bool          C_AskFollowUp;                      ///< Config: (nntp) Ask the user for follow-up groups before editing
-bool          C_AskXCommentTo;                    ///< Config: (nntp) Ask the user for the 'X-Comment-To' field before editing
-char *        C_AttachCharset = NULL;             ///< Config: When attaching files, use one of these character sets
-bool          C_BounceDelivered;                  ///< Config: Add 'Delivered-To' to bounced messages
-char *        C_ContentType = NULL;               ///< Config: Default "Content-Type" for newly composed messages
-bool          C_CryptAutoencrypt;                 ///< Config: Automatically PGP encrypt all outgoing mail
-bool          C_CryptAutopgp;                     ///< Config: Allow automatic PGP functions
-bool          C_CryptAutosign;                    ///< Config: Automatically PGP sign all outgoing mail
-bool          C_CryptAutosmime;                   ///< Config: Allow automatic SMIME functions
-bool          C_CryptReplyencrypt;                ///< Config: Encrypt replies to encrypted messages
-bool          C_CryptReplysign;                   ///< Config: Sign replies to signed messages
-bool          C_CryptReplysignencrypted;          ///< Config: Sign replies to encrypted messages
-char *        C_DsnNotify = NULL;                 ///< Config: Request notification for message delivery or delay
-char *        C_DsnReturn = NULL;                 ///< Config: What to send as a notification of message delivery or delay
-char *        C_EmptySubject = NULL;              ///< Config: Subject to use when replying to an email with none
-bool          C_EncodeFrom;                       ///< Config: Encode 'From ' as 'quote-printable' at the beginning of lines
-bool          C_FastReply;                        ///< Config: Don't prompt for the recipients and subject when replying/forwarding
-unsigned char C_FccAttach;                        ///< Config: Save send message with all their attachments
-bool          C_FccBeforeSend;                    ///< Config: Save FCCs before sending the message
-bool          C_FccClear;                         ///< Config: Save sent messages unencrypted and unsigned
-bool          C_FollowupTo;                       ///< Config: Add the 'Mail-Followup-To' header is generated when sending mail
-char *        C_ForwardAttributionIntro = NULL;   ///< Config: Prefix message for forwarded messages
-char *        C_ForwardAttributionTrailer = NULL; ///< Config: Suffix message for forwarded messages
-bool          C_ForwardDecrypt;                   ///< Config: Decrypt the message when forwarding it
-unsigned char C_ForwardEdit;                      ///< Config: Automatically start the editor when forwarding a message
-char *        C_ForwardFormat = NULL;             ///< Config: printf-like format string to control the subject when forwarding a message
-bool          C_ForwardReferences;                ///< Config: Set the 'In-Reply-To' and 'References' headers when forwarding a message
-bool          C_Hdrs;                             ///< Config: Add custom headers to outgoing mail
-bool          C_HiddenHost;                       ///< Config: Don't use the hostname, just the domain, when generating the message id
-unsigned char C_HonorFollowupTo;                  ///< Config: Honour the 'Mail-Followup-To' header when group replying
-bool          C_IgnoreListReplyTo;                ///< Config: Ignore the 'Reply-To' header when using `<reply>` on a mailing list
-unsigned char C_Include;                          ///< Config: Include a copy of the email that's being replied to
-char *        C_Inews = NULL;                     ///< Config: (nntp) External command to post news articles
-bool          C_Metoo;                            ///< Config: Remove the user's address from the list of recipients
-bool          C_MimeForwardDecode;                ///< Config: Decode the forwarded message before attaching it
-bool          C_MimeSubject;                      ///< Config: (nntp) Encode the article subject in base64
-char *        C_MimeTypeQueryCommand = NULL;      ///< Config: External command to determine the MIME type of an attachment
-bool          C_MimeTypeQueryFirst;               ///< Config: Run the #C_MimeTypeQueryCommand before the mime.types lookup
-bool          C_NmRecord;                         ///< Config: (notmuch) If the 'record' mailbox (sent mail) should be indexed
-bool          C_PgpReplyinline;                   ///< Config: Reply using old-style inline PGP messages (not recommended)
-char *        C_PostIndentString = NULL;          ///< Config: Suffix message to add after reply text
-char *        C_PostponeEncryptAs = NULL;         ///< Config: Fallback encryption key for postponed messages
-bool          C_PostponeEncrypt;                  ///< Config: Self-encrypt postponed messages
-unsigned char C_Recall;                           ///< Config: Recall postponed mesaages when asked to compose a message
-bool          C_ReplySelf;                        ///< Config: Really reply to yourself, when replying to your own email
-unsigned char C_ReplyTo;                          ///< Config: Address to use as a 'Reply-To' header
-bool          C_ReplyWithXorig;                   ///< Config: Create 'From' header from 'X-Original-To' header
-bool          C_ReverseName;                      ///< Config: Set the 'From' from the address the email was sent to
-bool          C_ReverseRealname;                  ///< Config: Set the 'From' from the full 'To' address the email was sent to
-char *        C_Sendmail = NULL;                  ///< Config: External command to send email
-short         C_SendmailWait;                     ///< Config: Time to wait for sendmail to finish
-bool          C_SigDashes;                        ///< Config: Insert '-- ' before the signature
-char *        C_Signature = NULL;                 ///< Config: File containing a signature to append to all mail
-bool          C_SigOnTop;                         ///< Config: Insert the signature before the quoted text
-struct Slist *C_SmtpAuthenticators = NULL;        ///< Config: (smtp) List of allowed authentication methods
-char *        C_SmtpOauthRefreshCommand = NULL;   ///< Config: (smtp) External command to generate OAUTH refresh token
-char *        C_SmtpPass = NULL;                  ///< Config: (smtp) Password for the SMTP server
-char *        C_SmtpUrl = NULL;                   ///< Config: (smtp) Url of the SMTP server
-char *        C_SmtpUser = NULL;                  ///< Config: (smtp) Username for the SMTP server
-bool          C_Use8bitmime;                      ///< Config: Use 8-bit messages and ESMTP to send messages
-bool          C_UseEnvelopeFrom;                  ///< Config: Set the envelope sender of the message
-bool          C_UseFrom;                          ///< Config: Set the 'From' header for outgoing mail
-bool          C_UserAgent;                        ///< Config: Add a 'User-Agent' head to outgoing mail
-short         C_WrapHeaders;                      ///< Config: Width to wrap headers in outgoing messages
-// clang-format on
-
 /**
  * wrapheaders_validator - Validate the "wrap_headers" config variable - Implements ConfigDef::validator()
  */
@@ -126,83 +54,83 @@ int wrapheaders_validator(const struct ConfigSet *cs, const struct ConfigDef *cd
 
 // clang-format off
 struct ConfigDef SendVars[] = {
-  { "abort_noattach",              DT_QUAD,                           &C_AbortNoattach,             MUTT_NO },
-  { "abort_noattach_regex",        DT_REGEX,                          &C_AbortNoattachRegex,        IP "\\<(attach|attached|attachments?)\\>" },
-  { "abort_nosubject",             DT_QUAD,                           &C_AbortNosubject,            MUTT_ASKYES },
-  { "abort_unmodified",            DT_QUAD,                           &C_AbortUnmodified,           MUTT_YES },
-  { "allow_8bit",                  DT_BOOL,                           &C_Allow8bit,                 true },
-  { "ask_follow_up",               DT_BOOL,                           &C_AskFollowUp,               false },
+  { "abort_noattach",              DT_QUAD,                           NULL, MUTT_NO },
+  { "abort_noattach_regex",        DT_REGEX,                          NULL, IP "\\<(attach|attached|attachments?)\\>" },
+  { "abort_nosubject",             DT_QUAD,                           NULL, MUTT_ASKYES },
+  { "abort_unmodified",            DT_QUAD,                           NULL, MUTT_YES },
+  { "allow_8bit",                  DT_BOOL,                           NULL, true },
+  { "ask_follow_up",               DT_BOOL,                           NULL, false },
 #ifdef USE_NNTP
-  { "ask_x_comment_to",            DT_BOOL,                           &C_AskXCommentTo,             false },
+  { "ask_x_comment_to",            DT_BOOL,                           NULL, false },
 #endif
-  { "attach_charset",              DT_STRING,                         &C_AttachCharset,             0, 0, charset_validator },
-  { "bounce_delivered",            DT_BOOL,                           &C_BounceDelivered,           true },
-  { "content_type",                DT_STRING,                         &C_ContentType,               IP "text/plain" },
-  { "crypt_autoencrypt",           DT_BOOL,                           &C_CryptAutoencrypt,          false },
-  { "crypt_autopgp",               DT_BOOL,                           &C_CryptAutopgp,              true },
-  { "crypt_autosign",              DT_BOOL,                           &C_CryptAutosign,             false },
-  { "crypt_autosmime",             DT_BOOL,                           &C_CryptAutosmime,            true },
-  { "crypt_replyencrypt",          DT_BOOL,                           &C_CryptReplyencrypt,         true },
-  { "crypt_replysign",             DT_BOOL,                           &C_CryptReplysign,            false },
-  { "crypt_replysignencrypted",    DT_BOOL,                           &C_CryptReplysignencrypted,   false },
-  { "dsn_notify",                  DT_STRING,                         &C_DsnNotify,                 0 },
-  { "dsn_return",                  DT_STRING,                         &C_DsnReturn,                 0 },
-  { "empty_subject",               DT_STRING,                         &C_EmptySubject,              IP "Re: your mail" },
-  { "encode_from",                 DT_BOOL,                           &C_EncodeFrom,                false },
-  { "fast_reply",                  DT_BOOL,                           &C_FastReply,                 false },
-  { "fcc_attach",                  DT_QUAD,                           &C_FccAttach,                 MUTT_YES },
-  { "fcc_before_send",             DT_BOOL,                           &C_FccBeforeSend,             false },
-  { "fcc_clear",                   DT_BOOL,                           &C_FccClear,                  false },
-  { "followup_to",                 DT_BOOL,                           &C_FollowupTo,                true },
-  { "forward_attribution_intro",   DT_STRING,                         &C_ForwardAttributionIntro,   IP "----- Forwarded message from %f -----" },
-  { "forward_attribution_trailer", DT_STRING,                         &C_ForwardAttributionTrailer, IP "----- End forwarded message -----" },
-  { "forward_decrypt",             DT_BOOL,                           &C_ForwardDecrypt,            true },
-  { "forward_edit",                DT_QUAD,                           &C_ForwardEdit,               MUTT_YES },
-  { "forward_format",              DT_STRING|DT_NOT_EMPTY,            &C_ForwardFormat,             IP "[%a: %s]" },
-  { "forward_references",          DT_BOOL,                           &C_ForwardReferences,         false },
-  { "hdrs",                        DT_BOOL,                           &C_Hdrs,                      true },
-  { "hidden_host",                 DT_BOOL,                           &C_HiddenHost,                false },
-  { "honor_followup_to",           DT_QUAD,                           &C_HonorFollowupTo,           MUTT_YES },
-  { "ignore_list_reply_to",        DT_BOOL,                           &C_IgnoreListReplyTo,         false },
-  { "include",                     DT_QUAD,                           &C_Include,                   MUTT_ASKYES },
+  { "attach_charset",              DT_STRING,                         NULL, 0, 0, charset_validator },
+  { "bounce_delivered",            DT_BOOL,                           NULL, true },
+  { "content_type",                DT_STRING,                         NULL, IP "text/plain" },
+  { "crypt_autoencrypt",           DT_BOOL,                           NULL, false },
+  { "crypt_autopgp",               DT_BOOL,                           NULL, true },
+  { "crypt_autosign",              DT_BOOL,                           NULL, false },
+  { "crypt_autosmime",             DT_BOOL,                           NULL, true },
+  { "crypt_replyencrypt",          DT_BOOL,                           NULL, true },
+  { "crypt_replysign",             DT_BOOL,                           NULL, false },
+  { "crypt_replysignencrypted",    DT_BOOL,                           NULL, false },
+  { "dsn_notify",                  DT_STRING,                         NULL, 0 },
+  { "dsn_return",                  DT_STRING,                         NULL, 0 },
+  { "empty_subject",               DT_STRING,                         NULL, IP "Re: your mail" },
+  { "encode_from",                 DT_BOOL,                           NULL, false },
+  { "fast_reply",                  DT_BOOL,                           NULL, false },
+  { "fcc_attach",                  DT_QUAD,                           NULL, MUTT_YES },
+  { "fcc_before_send",             DT_BOOL,                           NULL, false },
+  { "fcc_clear",                   DT_BOOL,                           NULL, false },
+  { "followup_to",                 DT_BOOL,                           NULL, true },
+  { "forward_attribution_intro",   DT_STRING,                         NULL, IP "----- Forwarded message from %f -----" },
+  { "forward_attribution_trailer", DT_STRING,                         NULL, IP "----- End forwarded message -----" },
+  { "forward_decrypt",             DT_BOOL,                           NULL, true },
+  { "forward_edit",                DT_QUAD,                           NULL, MUTT_YES },
+  { "forward_format",              DT_STRING|DT_NOT_EMPTY,            NULL, IP "[%a: %s]" },
+  { "forward_references",          DT_BOOL,                           NULL, false },
+  { "hdrs",                        DT_BOOL,                           NULL, true },
+  { "hidden_host",                 DT_BOOL,                           NULL, false },
+  { "honor_followup_to",           DT_QUAD,                           NULL, MUTT_YES },
+  { "ignore_list_reply_to",        DT_BOOL,                           NULL, false },
+  { "include",                     DT_QUAD,                           NULL, MUTT_ASKYES },
 #ifdef USE_NNTP
-  { "inews",                       DT_STRING|DT_COMMAND,              &C_Inews,                     0 },
+  { "inews",                       DT_STRING|DT_COMMAND,              NULL, 0 },
 #endif
-  { "metoo",                       DT_BOOL,                           &C_Metoo,                     false },
-  { "mime_forward_decode",         DT_BOOL,                           &C_MimeForwardDecode,         false },
+  { "metoo",                       DT_BOOL,                           NULL, false },
+  { "mime_forward_decode",         DT_BOOL,                           NULL, false },
 #ifdef USE_NNTP
-  { "mime_subject",                DT_BOOL,                           &C_MimeSubject,               true },
+  { "mime_subject",                DT_BOOL,                           NULL, true },
 #endif
-  { "mime_type_query_command",     DT_STRING|DT_COMMAND,              &C_MimeTypeQueryCommand,      0 },
-  { "mime_type_query_first",       DT_BOOL,                           &C_MimeTypeQueryFirst,        false },
-  { "nm_record",                   DT_BOOL,                           &C_NmRecord,                  false },
-  { "pgp_replyinline",             DT_BOOL,                           &C_PgpReplyinline,            false },
-  { "post_indent_string",          DT_STRING,                         &C_PostIndentString,          0 },
-  { "postpone_encrypt",            DT_BOOL,                           &C_PostponeEncrypt,           false },
-  { "postpone_encrypt_as",         DT_STRING,                         &C_PostponeEncryptAs,         0 },
-  { "recall",                      DT_QUAD,                           &C_Recall,                    MUTT_ASKYES },
-  { "reply_self",                  DT_BOOL,                           &C_ReplySelf,                 false },
-  { "reply_to",                    DT_QUAD,                           &C_ReplyTo,                   MUTT_ASKYES },
-  { "reply_with_xorig",            DT_BOOL,                           &C_ReplyWithXorig,            false },
-  { "reverse_name",                DT_BOOL|R_INDEX|R_PAGER,           &C_ReverseName,               false },
-  { "reverse_realname",            DT_BOOL|R_INDEX|R_PAGER,           &C_ReverseRealname,           true },
-  { "sendmail",                    DT_STRING|DT_COMMAND,              &C_Sendmail,                  IP SENDMAIL " -oem -oi" },
-  { "sendmail_wait",               DT_NUMBER,                         &C_SendmailWait,              0 },
-  { "sig_dashes",                  DT_BOOL,                           &C_SigDashes,                 true },
-  { "sig_on_top",                  DT_BOOL,                           &C_SigOnTop,                  false },
-  { "signature",                   DT_PATH|DT_PATH_FILE,              &C_Signature,                 IP "~/.signature" },
+  { "mime_type_query_command",     DT_STRING|DT_COMMAND,              NULL, 0 },
+  { "mime_type_query_first",       DT_BOOL,                           NULL, false },
+  { "nm_record",                   DT_BOOL,                           NULL, false },
+  { "pgp_replyinline",             DT_BOOL,                           NULL, false },
+  { "post_indent_string",          DT_STRING,                         NULL, 0 },
+  { "postpone_encrypt",            DT_BOOL,                           NULL, false },
+  { "postpone_encrypt_as",         DT_STRING,                         NULL, 0 },
+  { "recall",                      DT_QUAD,                           NULL, MUTT_ASKYES },
+  { "reply_self",                  DT_BOOL,                           NULL, false },
+  { "reply_to",                    DT_QUAD,                           NULL, MUTT_ASKYES },
+  { "reply_with_xorig",            DT_BOOL,                           NULL, false },
+  { "reverse_name",                DT_BOOL|R_INDEX|R_PAGER,           NULL, false },
+  { "reverse_realname",            DT_BOOL|R_INDEX|R_PAGER,           NULL, true },
+  { "sendmail",                    DT_STRING|DT_COMMAND,              NULL, IP SENDMAIL " -oem -oi" },
+  { "sendmail_wait",               DT_NUMBER,                         NULL, 0 },
+  { "sig_dashes",                  DT_BOOL,                           NULL, true },
+  { "sig_on_top",                  DT_BOOL,                           NULL, false },
+  { "signature",                   DT_PATH|DT_PATH_FILE,              NULL, IP "~/.signature" },
 #ifdef USE_SMTP
-  { "smtp_authenticators",         DT_SLIST|SLIST_SEP_COLON,          &C_SmtpAuthenticators,        0 },
-  { "smtp_oauth_refresh_command",  DT_STRING|DT_COMMAND|DT_SENSITIVE, &C_SmtpOauthRefreshCommand,   0 },
-  { "smtp_pass",                   DT_STRING|DT_SENSITIVE,            &C_SmtpPass,                  0 },
-  { "smtp_user",                   DT_STRING|DT_SENSITIVE,            &C_SmtpUser,                  0 },
-  { "smtp_url",                    DT_STRING|DT_SENSITIVE,            &C_SmtpUrl,                   0 },
+  { "smtp_authenticators",         DT_SLIST|SLIST_SEP_COLON,          NULL, 0 },
+  { "smtp_oauth_refresh_command",  DT_STRING|DT_COMMAND|DT_SENSITIVE, NULL, 0 },
+  { "smtp_pass",                   DT_STRING|DT_SENSITIVE,            NULL, 0 },
+  { "smtp_user",                   DT_STRING|DT_SENSITIVE,            NULL, 0 },
+  { "smtp_url",                    DT_STRING|DT_SENSITIVE,            NULL, 0 },
 #endif
-  { "use_8bitmime",                DT_BOOL,                           &C_Use8bitmime,               false },
-  { "use_envelope_from",           DT_BOOL,                           &C_UseEnvelopeFrom,           false },
-  { "use_from",                    DT_BOOL,                           &C_UseFrom,                   true },
-  { "user_agent",                  DT_BOOL,                           &C_UserAgent,                 false },
-  { "wrap_headers",                DT_NUMBER|DT_NOT_NEGATIVE|R_PAGER, &C_WrapHeaders,               78, 0, wrapheaders_validator },
+  { "use_8bitmime",                DT_BOOL,                           NULL, false },
+  { "use_envelope_from",           DT_BOOL,                           NULL, false },
+  { "use_from",                    DT_BOOL,                           NULL, true },
+  { "user_agent",                  DT_BOOL,                           NULL, false },
+  { "wrap_headers",                DT_NUMBER|DT_NOT_NEGATIVE|R_PAGER, NULL, 78, 0, wrapheaders_validator },
 
   { "abort_noattach_regexp",  DT_SYNONYM, NULL, IP "abort_noattach_regex",     },
   { "attach_keyword",         DT_SYNONYM, NULL, IP "abort_noattach_regex",     },
@@ -225,5 +153,5 @@ struct ConfigDef SendVars[] = {
  */
 bool config_init_send(struct ConfigSet *cs)
 {
-  return cs_register_variables(cs, SendVars, 0);
+  return cs_register_variables(cs, SendVars, DT_NO_VARIABLE);
 }

--- a/send/config.c
+++ b/send/config.c
@@ -55,219 +55,219 @@ int wrapheaders_validator(const struct ConfigSet *cs, const struct ConfigDef *cd
 // clang-format off
 struct ConfigDef SendVars[] = {
   { "abort_noattach", DT_QUAD, NULL, MUTT_NO, 0, NULL,
-    "Abort sending the email if attachments are missing"
+    N_("Abort sending the email if attachments are missing")
   },
   { "abort_noattach_regex", DT_REGEX, NULL, IP "\\<(attach|attached|attachments?)\\>", 0, NULL,
-    "Regex to match text indicating attachments are expected"
+    N_("Regex to match text indicating attachments are expected")
   },
   { "abort_nosubject", DT_QUAD, NULL, MUTT_ASKYES, 0, NULL,
-    "Abort creating the email if subject is missing"
+    N_("Abort creating the email if subject is missing")
   },
   { "abort_unmodified", DT_QUAD, NULL, MUTT_YES, 0, NULL,
-    "Abort the sending if the message hasn't been edited"
+    N_("Abort the sending if the message hasn't been edited")
   },
   { "allow_8bit", DT_BOOL, NULL, true, 0, NULL,
-    "Allow 8-bit messages, don't use quoted-printable or base64"
+    N_("Allow 8-bit messages, don't use quoted-printable or base64")
   },
   { "ask_follow_up", DT_BOOL, NULL, false, 0, NULL,
-    "(nntp) Ask the user for follow-up groups before editing"
+    N_("(nntp) Ask the user for follow-up groups before editing")
   },
 #ifdef USE_NNTP
   { "ask_x_comment_to", DT_BOOL, NULL, false, 0, NULL,
-    "(nntp) Ask the user for the 'X-Comment-To' field before editing"
+    N_("(nntp) Ask the user for the 'X-Comment-To' field before editing")
   },
 #endif
   { "attach_charset", DT_STRING, NULL, 0, 0, charset_validator,
-    "When attaching files, use one of these character sets"
+    N_("When attaching files, use one of these character sets")
   },
   { "bounce_delivered", DT_BOOL, NULL, true, 0, NULL,
-    "Add 'Delivered-To' to bounced messages"
+    N_("Add 'Delivered-To' to bounced messages")
   },
   { "content_type", DT_STRING, NULL, IP "text/plain", 0, NULL,
-    "Default 'Content-Type' for newly composed messages"
+    N_("Default 'Content-Type' for newly composed messages")
   },
   { "crypt_autoencrypt", DT_BOOL, NULL, false, 0, NULL,
-    "Automatically PGP encrypt all outgoing mail"
+    N_("Automatically PGP encrypt all outgoing mail")
   },
   { "crypt_autopgp", DT_BOOL, NULL, true, 0, NULL,
-    "Allow automatic PGP functions"
+    N_("Allow automatic PGP functions")
   },
   { "crypt_autosign", DT_BOOL, NULL, false, 0, NULL,
-    "Automatically PGP sign all outgoing mail"
+    N_("Automatically PGP sign all outgoing mail")
   },
   { "crypt_autosmime", DT_BOOL, NULL, true, 0, NULL,
-    "Allow automatic SMIME functions"
+    N_("Allow automatic SMIME functions")
   },
   { "crypt_replyencrypt", DT_BOOL, NULL, true, 0, NULL,
-    "Encrypt replies to encrypted messages"
+    N_("Encrypt replies to encrypted messages")
   },
   { "crypt_replysign", DT_BOOL, NULL, false, 0, NULL,
-    "Sign replies to signed messages"
+    N_("Sign replies to signed messages")
   },
   { "crypt_replysignencrypted", DT_BOOL, NULL, false, 0, NULL,
-    "Sign replies to encrypted messages"
+    N_("Sign replies to encrypted messages")
   },
   { "dsn_notify", DT_STRING, NULL, 0, 0, NULL,
-    "Request notification for message delivery or delay"
+    N_("Request notification for message delivery or delay")
   },
   { "dsn_return", DT_STRING, NULL, 0, 0, NULL,
-    "What to send as a notification of message delivery or delay"
+    N_("What to send as a notification of message delivery or delay")
   },
   { "empty_subject", DT_STRING, NULL, IP "Re: your mail", 0, NULL,
-    "Subject to use when replying to an email with none"
+    N_("Subject to use when replying to an email with none")
   },
   { "encode_from", DT_BOOL, NULL, false, 0, NULL,
-    "Encode 'From ' as 'quote-printable' at the beginning of lines"
+    N_("Encode 'From ' as 'quote-printable' at the beginning of lines")
   },
   { "fast_reply", DT_BOOL, NULL, false, 0, NULL,
-    "Don't prompt for the recipients and subject when replying/forwarding"
+    N_("Don't prompt for the recipients and subject when replying/forwarding")
   },
   { "fcc_attach", DT_QUAD, NULL, MUTT_YES, 0, NULL,
-    "Save send message with all their attachments"
+    N_("Save send message with all their attachments")
   },
   { "fcc_before_send", DT_BOOL, NULL, false, 0, NULL,
-    "Save FCCs before sending the message"
+    N_("Save FCCs before sending the message")
   },
   { "fcc_clear", DT_BOOL, NULL, false, 0, NULL,
-    "Save sent messages unencrypted and unsigned"
+    N_("Save sent messages unencrypted and unsigned")
   },
   { "followup_to", DT_BOOL, NULL, true, 0, NULL,
-    "Add the 'Mail-Followup-To' header is generated when sending mail"
+    N_("Add the 'Mail-Followup-To' header is generated when sending mail")
   },
   { "forward_attribution_intro", DT_STRING, NULL, IP "----- Forwarded message from %f -----", 0, NULL,
-    "Prefix message for forwarded messages"
+    N_("Prefix message for forwarded messages")
   },
   { "forward_attribution_trailer", DT_STRING, NULL, IP "----- End forwarded message -----", 0, NULL,
-    "Suffix message for forwarded messages"
+    N_("Suffix message for forwarded messages")
   },
   { "forward_decrypt", DT_BOOL, NULL, true, 0, NULL,
-    "Decrypt the message when forwarding it"
+    N_("Decrypt the message when forwarding it")
   },
   { "forward_edit", DT_QUAD, NULL, MUTT_YES, 0, NULL,
-    "Automatically start the editor when forwarding a message"
+    N_("Automatically start the editor when forwarding a message")
   },
   { "forward_format", DT_STRING|DT_NOT_EMPTY, NULL, IP "[%a: %s]", 0, NULL,
-    "printf-like format string to control the subject when forwarding a message"
+    N_("printf-like format string to control the subject when forwarding a message")
   },
   { "forward_references", DT_BOOL, NULL, false, 0, NULL,
-    "Set the 'In-Reply-To' and 'References' headers when forwarding a message"
+    N_("Set the 'In-Reply-To' and 'References' headers when forwarding a message")
   },
   { "hdrs", DT_BOOL, NULL, true, 0, NULL,
-    "Add custom headers to outgoing mail"
+    N_("Add custom headers to outgoing mail")
   },
   { "hidden_host", DT_BOOL, NULL, false, 0, NULL,
-    "Don't use the hostname, just the domain, when generating the message id"
+    N_("Don't use the hostname, just the domain, when generating the message id")
   },
   { "honor_followup_to", DT_QUAD, NULL, MUTT_YES, 0, NULL,
-    "Honour the 'Mail-Followup-To' header when group replying"
+    N_("Honour the 'Mail-Followup-To' header when group replying")
   },
   { "ignore_list_reply_to", DT_BOOL, NULL, false, 0, NULL,
-    "Ignore the 'Reply-To' header when using `<reply>` on a mailing list"
+    N_("Ignore the 'Reply-To' header when using `<reply>` on a mailing list")
   },
   { "include", DT_QUAD, NULL, MUTT_ASKYES, 0, NULL,
-    "Include a copy of the email that's being replied to"
+    N_("Include a copy of the email that's being replied to")
   },
 #ifdef USE_NNTP
   { "inews", DT_STRING|DT_COMMAND, NULL, 0, 0, NULL,
-    "(nntp) External command to post news articles"
+    N_("(nntp) External command to post news articles")
   },
 #endif
   { "metoo", DT_BOOL, NULL, false, 0, NULL,
-    "Remove the user's address from the list of recipients"
+    N_("Remove the user's address from the list of recipients")
   },
   { "mime_forward_decode", DT_BOOL, NULL, false, 0, NULL,
-    "Decode the forwarded message before attaching it"
+    N_("Decode the forwarded message before attaching it")
   },
 #ifdef USE_NNTP
   { "mime_subject", DT_BOOL, NULL, true, 0, NULL,
-    "(nntp) Encode the article subject in base64"
+    N_("(nntp) Encode the article subject in base64")
   },
 #endif
   { "mime_type_query_command", DT_STRING|DT_COMMAND, NULL, 0, 0, NULL,
-    "External command to determine the MIME type of an attachment"
+    N_("External command to determine the MIME type of an attachment")
   },
   { "mime_type_query_first", DT_BOOL, NULL, false, 0, NULL,
-    "Run the #C_MimeTypeQueryCommand before the mime.types lookup"
+    N_("Run the #C_MimeTypeQueryCommand before the mime.types lookup")
   },
   { "nm_record", DT_BOOL, NULL, false, 0, NULL,
-    "(notmuch) If the 'record' mailbox (sent mail) should be indexed"
+    N_("(notmuch) If the 'record' mailbox (sent mail) should be indexed")
   },
   { "pgp_replyinline", DT_BOOL, NULL, false, 0, NULL,
-    "Reply using old-style inline PGP messages (not recommended)"
+    N_("Reply using old-style inline PGP messages (not recommended)")
   },
   { "post_indent_string", DT_STRING, NULL, 0, 0, NULL,
-    "Suffix message to add after reply text"
+    N_("Suffix message to add after reply text")
   },
   { "postpone_encrypt", DT_BOOL, NULL, false, 0, NULL,
-    "Self-encrypt postponed messages"
+    N_("Self-encrypt postponed messages")
   },
   { "postpone_encrypt_as", DT_STRING, NULL, 0, 0, NULL,
-    "Fallback encryption key for postponed messages"
+    N_("Fallback encryption key for postponed messages")
   },
   { "recall", DT_QUAD, NULL, MUTT_ASKYES, 0, NULL,
-    "Recall postponed mesaages when asked to compose a message"
+    N_("Recall postponed mesaages when asked to compose a message")
   },
   { "reply_self", DT_BOOL, NULL, false, 0, NULL,
-    "Really reply to yourself, when replying to your own email"
+    N_("Really reply to yourself, when replying to your own email")
   },
   { "reply_to", DT_QUAD, NULL, MUTT_ASKYES, 0, NULL,
-    "Address to use as a 'Reply-To' header"
+    N_("Address to use as a 'Reply-To' header")
   },
   { "reply_with_xorig", DT_BOOL, NULL, false, 0, NULL,
-    "Create 'From' header from 'X-Original-To' header"
+    N_("Create 'From' header from 'X-Original-To' header")
   },
   { "reverse_name", DT_BOOL|R_INDEX|R_PAGER, NULL, false, 0, NULL,
-    "Set the 'From' from the address the email was sent to"
+    N_("Set the 'From' from the address the email was sent to")
   },
   { "reverse_realname", DT_BOOL|R_INDEX|R_PAGER, NULL, true, 0, NULL,
-    "Set the 'From' from the full 'To' address the email was sent to"
+    N_("Set the 'From' from the full 'To' address the email was sent to")
   },
   { "sendmail", DT_STRING|DT_COMMAND, NULL, IP SENDMAIL " -oem -oi", 0, NULL,
-    "External command to send email"
+    N_("External command to send email")
   },
   { "sendmail_wait", DT_NUMBER, NULL, 0, 0, NULL,
-    "Time to wait for sendmail to finish"
+    N_("Time to wait for sendmail to finish")
   },
   { "sig_dashes", DT_BOOL, NULL, true, 0, NULL,
-    "Insert '-- ' before the signature"
+    N_("Insert '-- ' before the signature")
   },
   { "sig_on_top", DT_BOOL, NULL, false, 0, NULL,
-    "Insert the signature before the quoted text"
+    N_("Insert the signature before the quoted text")
   },
   { "signature", DT_PATH|DT_PATH_FILE, NULL, IP "~/.signature", 0, NULL,
-    "File containing a signature to append to all mail"
+    N_("File containing a signature to append to all mail")
   },
 #ifdef USE_SMTP
   { "smtp_authenticators", DT_SLIST|SLIST_SEP_COLON, NULL, 0, 0, NULL,
-    "(smtp) List of allowed authentication methods"
+    N_("(smtp) List of allowed authentication methods")
   },
   { "smtp_oauth_refresh_command", DT_STRING|DT_COMMAND|DT_SENSITIVE, NULL, 0, 0, NULL,
-    "(smtp) External command to generate OAUTH refresh token"
+    N_("(smtp) External command to generate OAUTH refresh token")
   },
   { "smtp_pass", DT_STRING|DT_SENSITIVE, NULL, 0, 0, NULL,
-    "(smtp) Password for the SMTP server"
+    N_("(smtp) Password for the SMTP server")
   },
   { "smtp_user", DT_STRING|DT_SENSITIVE, NULL, 0, 0, NULL,
-    "(smtp) Username for the SMTP server"
+    N_("(smtp) Username for the SMTP server")
   },
   { "smtp_url", DT_STRING|DT_SENSITIVE, NULL, 0, 0, NULL,
-    "(smtp) Url of the SMTP server"
+    N_("(smtp) Url of the SMTP server")
   },
 #endif
   { "use_8bitmime", DT_BOOL, NULL, false, 0, NULL,
-    "Use 8-bit messages and ESMTP to send messages"
+    N_("Use 8-bit messages and ESMTP to send messages")
   },
   { "use_envelope_from", DT_BOOL, NULL, false, 0, NULL,
-    "Set the envelope sender of the message"
+    N_("Set the envelope sender of the message")
   },
   { "use_from", DT_BOOL, NULL, true, 0, NULL,
-    "Set the 'From' header for outgoing mail"
+    N_("Set the 'From' header for outgoing mail")
   },
   { "user_agent", DT_BOOL, NULL, false, 0, NULL,
-    "Add a 'User-Agent' head to outgoing mail"
+    N_("Add a 'User-Agent' head to outgoing mail")
   },
   { "wrap_headers", DT_NUMBER|DT_NOT_NEGATIVE|R_PAGER, NULL, 78, 0, wrapheaders_validator,
-    "Width to wrap headers in outgoing messages"
+    N_("Width to wrap headers in outgoing messages")
   },
 
   { "abort_noattach_regexp",  DT_SYNONYM, NULL, IP "abort_noattach_regex",     },

--- a/send/config.c
+++ b/send/config.c
@@ -54,83 +54,221 @@ int wrapheaders_validator(const struct ConfigSet *cs, const struct ConfigDef *cd
 
 // clang-format off
 struct ConfigDef SendVars[] = {
-  { "abort_noattach",              DT_QUAD,                           NULL, MUTT_NO },
-  { "abort_noattach_regex",        DT_REGEX,                          NULL, IP "\\<(attach|attached|attachments?)\\>" },
-  { "abort_nosubject",             DT_QUAD,                           NULL, MUTT_ASKYES },
-  { "abort_unmodified",            DT_QUAD,                           NULL, MUTT_YES },
-  { "allow_8bit",                  DT_BOOL,                           NULL, true },
-  { "ask_follow_up",               DT_BOOL,                           NULL, false },
+  { "abort_noattach", DT_QUAD, NULL, MUTT_NO, 0, NULL,
+    "Abort sending the email if attachments are missing"
+  },
+  { "abort_noattach_regex", DT_REGEX, NULL, IP "\\<(attach|attached|attachments?)\\>", 0, NULL,
+    "Regex to match text indicating attachments are expected"
+  },
+  { "abort_nosubject", DT_QUAD, NULL, MUTT_ASKYES, 0, NULL,
+    "Abort creating the email if subject is missing"
+  },
+  { "abort_unmodified", DT_QUAD, NULL, MUTT_YES, 0, NULL,
+    "Abort the sending if the message hasn't been edited"
+  },
+  { "allow_8bit", DT_BOOL, NULL, true, 0, NULL,
+    "Allow 8-bit messages, don't use quoted-printable or base64"
+  },
+  { "ask_follow_up", DT_BOOL, NULL, false, 0, NULL,
+    "(nntp) Ask the user for follow-up groups before editing"
+  },
 #ifdef USE_NNTP
-  { "ask_x_comment_to",            DT_BOOL,                           NULL, false },
+  { "ask_x_comment_to", DT_BOOL, NULL, false, 0, NULL,
+    "(nntp) Ask the user for the 'X-Comment-To' field before editing"
+  },
 #endif
-  { "attach_charset",              DT_STRING,                         NULL, 0, 0, charset_validator },
-  { "bounce_delivered",            DT_BOOL,                           NULL, true },
-  { "content_type",                DT_STRING,                         NULL, IP "text/plain" },
-  { "crypt_autoencrypt",           DT_BOOL,                           NULL, false },
-  { "crypt_autopgp",               DT_BOOL,                           NULL, true },
-  { "crypt_autosign",              DT_BOOL,                           NULL, false },
-  { "crypt_autosmime",             DT_BOOL,                           NULL, true },
-  { "crypt_replyencrypt",          DT_BOOL,                           NULL, true },
-  { "crypt_replysign",             DT_BOOL,                           NULL, false },
-  { "crypt_replysignencrypted",    DT_BOOL,                           NULL, false },
-  { "dsn_notify",                  DT_STRING,                         NULL, 0 },
-  { "dsn_return",                  DT_STRING,                         NULL, 0 },
-  { "empty_subject",               DT_STRING,                         NULL, IP "Re: your mail" },
-  { "encode_from",                 DT_BOOL,                           NULL, false },
-  { "fast_reply",                  DT_BOOL,                           NULL, false },
-  { "fcc_attach",                  DT_QUAD,                           NULL, MUTT_YES },
-  { "fcc_before_send",             DT_BOOL,                           NULL, false },
-  { "fcc_clear",                   DT_BOOL,                           NULL, false },
-  { "followup_to",                 DT_BOOL,                           NULL, true },
-  { "forward_attribution_intro",   DT_STRING,                         NULL, IP "----- Forwarded message from %f -----" },
-  { "forward_attribution_trailer", DT_STRING,                         NULL, IP "----- End forwarded message -----" },
-  { "forward_decrypt",             DT_BOOL,                           NULL, true },
-  { "forward_edit",                DT_QUAD,                           NULL, MUTT_YES },
-  { "forward_format",              DT_STRING|DT_NOT_EMPTY,            NULL, IP "[%a: %s]" },
-  { "forward_references",          DT_BOOL,                           NULL, false },
-  { "hdrs",                        DT_BOOL,                           NULL, true },
-  { "hidden_host",                 DT_BOOL,                           NULL, false },
-  { "honor_followup_to",           DT_QUAD,                           NULL, MUTT_YES },
-  { "ignore_list_reply_to",        DT_BOOL,                           NULL, false },
-  { "include",                     DT_QUAD,                           NULL, MUTT_ASKYES },
+  { "attach_charset", DT_STRING, NULL, 0, 0, charset_validator,
+    "When attaching files, use one of these character sets"
+  },
+  { "bounce_delivered", DT_BOOL, NULL, true, 0, NULL,
+    "Add 'Delivered-To' to bounced messages"
+  },
+  { "content_type", DT_STRING, NULL, IP "text/plain", 0, NULL,
+    "Default 'Content-Type' for newly composed messages"
+  },
+  { "crypt_autoencrypt", DT_BOOL, NULL, false, 0, NULL,
+    "Automatically PGP encrypt all outgoing mail"
+  },
+  { "crypt_autopgp", DT_BOOL, NULL, true, 0, NULL,
+    "Allow automatic PGP functions"
+  },
+  { "crypt_autosign", DT_BOOL, NULL, false, 0, NULL,
+    "Automatically PGP sign all outgoing mail"
+  },
+  { "crypt_autosmime", DT_BOOL, NULL, true, 0, NULL,
+    "Allow automatic SMIME functions"
+  },
+  { "crypt_replyencrypt", DT_BOOL, NULL, true, 0, NULL,
+    "Encrypt replies to encrypted messages"
+  },
+  { "crypt_replysign", DT_BOOL, NULL, false, 0, NULL,
+    "Sign replies to signed messages"
+  },
+  { "crypt_replysignencrypted", DT_BOOL, NULL, false, 0, NULL,
+    "Sign replies to encrypted messages"
+  },
+  { "dsn_notify", DT_STRING, NULL, 0, 0, NULL,
+    "Request notification for message delivery or delay"
+  },
+  { "dsn_return", DT_STRING, NULL, 0, 0, NULL,
+    "What to send as a notification of message delivery or delay"
+  },
+  { "empty_subject", DT_STRING, NULL, IP "Re: your mail", 0, NULL,
+    "Subject to use when replying to an email with none"
+  },
+  { "encode_from", DT_BOOL, NULL, false, 0, NULL,
+    "Encode 'From ' as 'quote-printable' at the beginning of lines"
+  },
+  { "fast_reply", DT_BOOL, NULL, false, 0, NULL,
+    "Don't prompt for the recipients and subject when replying/forwarding"
+  },
+  { "fcc_attach", DT_QUAD, NULL, MUTT_YES, 0, NULL,
+    "Save send message with all their attachments"
+  },
+  { "fcc_before_send", DT_BOOL, NULL, false, 0, NULL,
+    "Save FCCs before sending the message"
+  },
+  { "fcc_clear", DT_BOOL, NULL, false, 0, NULL,
+    "Save sent messages unencrypted and unsigned"
+  },
+  { "followup_to", DT_BOOL, NULL, true, 0, NULL,
+    "Add the 'Mail-Followup-To' header is generated when sending mail"
+  },
+  { "forward_attribution_intro", DT_STRING, NULL, IP "----- Forwarded message from %f -----", 0, NULL,
+    "Prefix message for forwarded messages"
+  },
+  { "forward_attribution_trailer", DT_STRING, NULL, IP "----- End forwarded message -----", 0, NULL,
+    "Suffix message for forwarded messages"
+  },
+  { "forward_decrypt", DT_BOOL, NULL, true, 0, NULL,
+    "Decrypt the message when forwarding it"
+  },
+  { "forward_edit", DT_QUAD, NULL, MUTT_YES, 0, NULL,
+    "Automatically start the editor when forwarding a message"
+  },
+  { "forward_format", DT_STRING|DT_NOT_EMPTY, NULL, IP "[%a: %s]", 0, NULL,
+    "printf-like format string to control the subject when forwarding a message"
+  },
+  { "forward_references", DT_BOOL, NULL, false, 0, NULL,
+    "Set the 'In-Reply-To' and 'References' headers when forwarding a message"
+  },
+  { "hdrs", DT_BOOL, NULL, true, 0, NULL,
+    "Add custom headers to outgoing mail"
+  },
+  { "hidden_host", DT_BOOL, NULL, false, 0, NULL,
+    "Don't use the hostname, just the domain, when generating the message id"
+  },
+  { "honor_followup_to", DT_QUAD, NULL, MUTT_YES, 0, NULL,
+    "Honour the 'Mail-Followup-To' header when group replying"
+  },
+  { "ignore_list_reply_to", DT_BOOL, NULL, false, 0, NULL,
+    "Ignore the 'Reply-To' header when using `<reply>` on a mailing list"
+  },
+  { "include", DT_QUAD, NULL, MUTT_ASKYES, 0, NULL,
+    "Include a copy of the email that's being replied to"
+  },
 #ifdef USE_NNTP
-  { "inews",                       DT_STRING|DT_COMMAND,              NULL, 0 },
+  { "inews", DT_STRING|DT_COMMAND, NULL, 0, 0, NULL,
+    "(nntp) External command to post news articles"
+  },
 #endif
-  { "metoo",                       DT_BOOL,                           NULL, false },
-  { "mime_forward_decode",         DT_BOOL,                           NULL, false },
+  { "metoo", DT_BOOL, NULL, false, 0, NULL,
+    "Remove the user's address from the list of recipients"
+  },
+  { "mime_forward_decode", DT_BOOL, NULL, false, 0, NULL,
+    "Decode the forwarded message before attaching it"
+  },
 #ifdef USE_NNTP
-  { "mime_subject",                DT_BOOL,                           NULL, true },
+  { "mime_subject", DT_BOOL, NULL, true, 0, NULL,
+    "(nntp) Encode the article subject in base64"
+  },
 #endif
-  { "mime_type_query_command",     DT_STRING|DT_COMMAND,              NULL, 0 },
-  { "mime_type_query_first",       DT_BOOL,                           NULL, false },
-  { "nm_record",                   DT_BOOL,                           NULL, false },
-  { "pgp_replyinline",             DT_BOOL,                           NULL, false },
-  { "post_indent_string",          DT_STRING,                         NULL, 0 },
-  { "postpone_encrypt",            DT_BOOL,                           NULL, false },
-  { "postpone_encrypt_as",         DT_STRING,                         NULL, 0 },
-  { "recall",                      DT_QUAD,                           NULL, MUTT_ASKYES },
-  { "reply_self",                  DT_BOOL,                           NULL, false },
-  { "reply_to",                    DT_QUAD,                           NULL, MUTT_ASKYES },
-  { "reply_with_xorig",            DT_BOOL,                           NULL, false },
-  { "reverse_name",                DT_BOOL|R_INDEX|R_PAGER,           NULL, false },
-  { "reverse_realname",            DT_BOOL|R_INDEX|R_PAGER,           NULL, true },
-  { "sendmail",                    DT_STRING|DT_COMMAND,              NULL, IP SENDMAIL " -oem -oi" },
-  { "sendmail_wait",               DT_NUMBER,                         NULL, 0 },
-  { "sig_dashes",                  DT_BOOL,                           NULL, true },
-  { "sig_on_top",                  DT_BOOL,                           NULL, false },
-  { "signature",                   DT_PATH|DT_PATH_FILE,              NULL, IP "~/.signature" },
+  { "mime_type_query_command", DT_STRING|DT_COMMAND, NULL, 0, 0, NULL,
+    "External command to determine the MIME type of an attachment"
+  },
+  { "mime_type_query_first", DT_BOOL, NULL, false, 0, NULL,
+    "Run the #C_MimeTypeQueryCommand before the mime.types lookup"
+  },
+  { "nm_record", DT_BOOL, NULL, false, 0, NULL,
+    "(notmuch) If the 'record' mailbox (sent mail) should be indexed"
+  },
+  { "pgp_replyinline", DT_BOOL, NULL, false, 0, NULL,
+    "Reply using old-style inline PGP messages (not recommended)"
+  },
+  { "post_indent_string", DT_STRING, NULL, 0, 0, NULL,
+    "Suffix message to add after reply text"
+  },
+  { "postpone_encrypt", DT_BOOL, NULL, false, 0, NULL,
+    "Self-encrypt postponed messages"
+  },
+  { "postpone_encrypt_as", DT_STRING, NULL, 0, 0, NULL,
+    "Fallback encryption key for postponed messages"
+  },
+  { "recall", DT_QUAD, NULL, MUTT_ASKYES, 0, NULL,
+    "Recall postponed mesaages when asked to compose a message"
+  },
+  { "reply_self", DT_BOOL, NULL, false, 0, NULL,
+    "Really reply to yourself, when replying to your own email"
+  },
+  { "reply_to", DT_QUAD, NULL, MUTT_ASKYES, 0, NULL,
+    "Address to use as a 'Reply-To' header"
+  },
+  { "reply_with_xorig", DT_BOOL, NULL, false, 0, NULL,
+    "Create 'From' header from 'X-Original-To' header"
+  },
+  { "reverse_name", DT_BOOL|R_INDEX|R_PAGER, NULL, false, 0, NULL,
+    "Set the 'From' from the address the email was sent to"
+  },
+  { "reverse_realname", DT_BOOL|R_INDEX|R_PAGER, NULL, true, 0, NULL,
+    "Set the 'From' from the full 'To' address the email was sent to"
+  },
+  { "sendmail", DT_STRING|DT_COMMAND, NULL, IP SENDMAIL " -oem -oi", 0, NULL,
+    "External command to send email"
+  },
+  { "sendmail_wait", DT_NUMBER, NULL, 0, 0, NULL,
+    "Time to wait for sendmail to finish"
+  },
+  { "sig_dashes", DT_BOOL, NULL, true, 0, NULL,
+    "Insert '-- ' before the signature"
+  },
+  { "sig_on_top", DT_BOOL, NULL, false, 0, NULL,
+    "Insert the signature before the quoted text"
+  },
+  { "signature", DT_PATH|DT_PATH_FILE, NULL, IP "~/.signature", 0, NULL,
+    "File containing a signature to append to all mail"
+  },
 #ifdef USE_SMTP
-  { "smtp_authenticators",         DT_SLIST|SLIST_SEP_COLON,          NULL, 0 },
-  { "smtp_oauth_refresh_command",  DT_STRING|DT_COMMAND|DT_SENSITIVE, NULL, 0 },
-  { "smtp_pass",                   DT_STRING|DT_SENSITIVE,            NULL, 0 },
-  { "smtp_user",                   DT_STRING|DT_SENSITIVE,            NULL, 0 },
-  { "smtp_url",                    DT_STRING|DT_SENSITIVE,            NULL, 0 },
+  { "smtp_authenticators", DT_SLIST|SLIST_SEP_COLON, NULL, 0, 0, NULL,
+    "(smtp) List of allowed authentication methods"
+  },
+  { "smtp_oauth_refresh_command", DT_STRING|DT_COMMAND|DT_SENSITIVE, NULL, 0, 0, NULL,
+    "(smtp) External command to generate OAUTH refresh token"
+  },
+  { "smtp_pass", DT_STRING|DT_SENSITIVE, NULL, 0, 0, NULL,
+    "(smtp) Password for the SMTP server"
+  },
+  { "smtp_user", DT_STRING|DT_SENSITIVE, NULL, 0, 0, NULL,
+    "(smtp) Username for the SMTP server"
+  },
+  { "smtp_url", DT_STRING|DT_SENSITIVE, NULL, 0, 0, NULL,
+    "(smtp) Url of the SMTP server"
+  },
 #endif
-  { "use_8bitmime",                DT_BOOL,                           NULL, false },
-  { "use_envelope_from",           DT_BOOL,                           NULL, false },
-  { "use_from",                    DT_BOOL,                           NULL, true },
-  { "user_agent",                  DT_BOOL,                           NULL, false },
-  { "wrap_headers",                DT_NUMBER|DT_NOT_NEGATIVE|R_PAGER, NULL, 78, 0, wrapheaders_validator },
+  { "use_8bitmime", DT_BOOL, NULL, false, 0, NULL,
+    "Use 8-bit messages and ESMTP to send messages"
+  },
+  { "use_envelope_from", DT_BOOL, NULL, false, 0, NULL,
+    "Set the envelope sender of the message"
+  },
+  { "use_from", DT_BOOL, NULL, true, 0, NULL,
+    "Set the 'From' header for outgoing mail"
+  },
+  { "user_agent", DT_BOOL, NULL, false, 0, NULL,
+    "Add a 'User-Agent' head to outgoing mail"
+  },
+  { "wrap_headers", DT_NUMBER|DT_NOT_NEGATIVE|R_PAGER, NULL, 78, 0, wrapheaders_validator,
+    "Width to wrap headers in outgoing messages"
+  },
 
   { "abort_noattach_regexp",  DT_SYNONYM, NULL, IP "abort_noattach_regex",     },
   { "attach_keyword",         DT_SYNONYM, NULL, IP "abort_noattach_regex",     },
@@ -144,7 +282,7 @@ struct ConfigDef SendVars[] = {
   { "pgp_replysign",          DT_SYNONYM, NULL, IP "crypt_replysign",          },
   { "pgp_replysignencrypted", DT_SYNONYM, NULL, IP "crypt_replysignencrypted", },
   { "post_indent_str",        DT_SYNONYM, NULL, IP "post_indent_string",       },
-  { NULL, 0, NULL, 0, 0, NULL },
+  { NULL, 0, NULL, 0, 0, NULL, NULL },
 };
 // clang-format on
 

--- a/test/Makefile.autosetup
+++ b/test/Makefile.autosetup
@@ -121,7 +121,8 @@ CONFIG_OBJS	= test/config/account.o \
 		  test/config/sort.o \
 		  test/config/string.o \
 		  test/config/subset.o \
-		  test/config/synonym.o
+		  test/config/synonym.o \
+		  test/config/variable.o
 
 DATE_OBJS	= test/date/mutt_date_add_timeout.o \
 		  test/date/mutt_date_check_month.o \

--- a/test/config/variable.c
+++ b/test/config/variable.c
@@ -1,0 +1,137 @@
+/**
+ * @file
+ * Test code for the ConfigSet object
+ *
+ * @authors
+ * Copyright (C) 2020 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define TEST_NO_MAIN
+#include "config.h"
+#include "acutest.h"
+#include <limits.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include "mutt/lib.h"
+#include "config/common.h"
+#include "config/lib.h"
+#include "core/lib.h"
+
+// clang-format off
+static struct ConfigDef Vars[] = {
+  { "Apple",  DT_STRING, NULL, IP "hello", 0, NULL },
+  { "Banana", DT_NUMBER, NULL, 42,         0, NULL },
+  { NULL },
+};
+// clang-format on
+
+void test_config_variable(void)
+{
+  log_line(__func__);
+
+  struct Buffer err;
+  mutt_buffer_init(&err);
+  err.dsize = 256;
+  err.data = mutt_mem_calloc(1, err.dsize);
+  mutt_buffer_reset(&err);
+
+  struct ConfigSet *cs = cs_new(30);
+  if (!TEST_CHECK(cs != NULL))
+    return;
+
+  number_init(cs);
+  string_init(cs);
+
+  if (!TEST_CHECK(cs_register_variables(cs, Vars, DT_NO_VARIABLE)))
+    return;
+
+  const char *name = "Apple";
+  int result = cs_str_string_set(cs, name, "world", &err);
+  if (!TEST_CHECK(CSR_RESULT(result) == CSR_SUCCESS))
+  {
+    TEST_MSG("Error: %s\n", err.data);
+    return;
+  }
+
+  mutt_buffer_reset(&err);
+  result = cs_str_reset(cs, name, &err);
+  if (!TEST_CHECK(CSR_RESULT(result) == CSR_SUCCESS))
+  {
+    TEST_MSG("Error: %s\n", err.data);
+    return;
+  }
+
+  struct HashElem *he = cs_get_elem(cs, name);
+  if (!TEST_CHECK(he != NULL))
+    return;
+
+  mutt_buffer_reset(&err);
+  result = cs_he_string_get(cs, he, &err);
+  if (!TEST_CHECK(CSR_RESULT(result) == CSR_SUCCESS))
+  {
+    TEST_MSG("Error: %s\n", err.data);
+    return;
+  }
+
+  mutt_buffer_reset(&err);
+  result = cs_he_native_set(cs, he, IP "foo", &err);
+  if (!TEST_CHECK(CSR_RESULT(result) == CSR_SUCCESS))
+  {
+    TEST_MSG("Error: %s\n", err.data);
+    return;
+  }
+
+  mutt_buffer_reset(&err);
+  result = cs_str_native_set(cs, name, IP "bar", &err);
+  if (!TEST_CHECK(CSR_RESULT(result) == CSR_SUCCESS))
+  {
+    TEST_MSG("Error: %s\n", err.data);
+    return;
+  }
+
+  mutt_buffer_reset(&err);
+  intptr_t value = cs_he_native_get(cs, he, &err);
+  if (!TEST_CHECK(mutt_str_equal((const char *) value, "bar")))
+  {
+    TEST_MSG("Error: %s\n", err.data);
+    return;
+  }
+
+  name = "Banana";
+  he = cs_get_elem(cs, name);
+  if (!TEST_CHECK(he != NULL))
+    return;
+
+  result = cs_he_string_plus_equals(cs, he, "23", &err);
+  if (!TEST_CHECK(CSR_RESULT(result) == CSR_SUCCESS))
+  {
+    TEST_MSG("Error: %s\n", err.data);
+    return;
+  }
+
+  result = cs_he_string_minus_equals(cs, he, "56", &err);
+  if (!TEST_CHECK(CSR_RESULT(result) == CSR_SUCCESS))
+  {
+    TEST_MSG("Error: %s\n", err.data);
+    return;
+  }
+
+  cs_free(&cs);
+  FREE(&err.data);
+  log_line(__func__);
+}

--- a/test/main.c
+++ b/test/main.c
@@ -151,6 +151,7 @@
   NEOMUTT_TEST_ITEM(test_config_string)                                        \
   NEOMUTT_TEST_ITEM(test_config_subset)                                        \
   NEOMUTT_TEST_ITEM(test_config_synonym)                                       \
+  NEOMUTT_TEST_ITEM(test_config_variable)                                      \
                                                                                \
   /* date */                                                                   \
   NEOMUTT_TEST_ITEM(test_mutt_date_add_timeout)                                \


### PR DESCRIPTION
The first two commits are part of a large plan to de-centralise the config system.
This will allow Account- and Mailbox-specific config.

The third commit adds a one-line description to each of libsend's config.
This isn't used, but in future would allow context-sensitive help.
Also, it could be added as a comment when dumping config (e.g. `neomutt -D -H`).

@neomutt/translators
The final commit adds gettext (translation) support to the docs.
Translating the online help would be great, but it puts a large burden on the translators.
(There are currently 454 config variables)

---

- f250f4a26 config: no variable
  Allow config items to have **NO** global variable backing them

- 4afc525a3 send: no variable
  Convert libsend to have no global config variables

- 43d75041c config: add docs
  Add one-liner description to all of libsend's config items

- b36b3c46d config: translate one-liner docs
  Add gettext translation support for one-liner docs

---

The config definitions now look like:

```c
{ "attach_charset", DT_STRING, NULL, 0, 0, charset_validator,
  N_("When attaching files, use one of these character sets")
},
{ "forward_decrypt", DT_BOOL, NULL, true, 0, NULL,
  N_("Decrypt the message when forwarding it")
},
```

When all the config global variables are eliminated, the `NULL` (at position 3) can be eliminated, too.

