### PR TITLE
Adjust the edata use in Maildir and Notmuch

### DIFF
--- a/debug/graphviz.c
+++ b/debug/graphviz.c
@@ -54,7 +54,7 @@
 // #define GV_HIDE_CONFIG
 // #define GV_HIDE_MDATA
 
-static void dot_email(FILE *fp, const struct Email *e, struct ListHead *links);
+static void dot_email(FILE *fp, struct Email *e, struct ListHead *links);
 static void dot_envelope(FILE *fp, const struct Envelope *env, struct ListHead *links);
 
 const char *get_content_type(enum ContentType type)
@@ -1283,7 +1283,7 @@ static void dot_envelope(FILE *fp, const struct Envelope *env, struct ListHead *
   mutt_buffer_dealloc(&buf);
 }
 
-static void dot_email(FILE *fp, const struct Email *e, struct ListHead *links)
+static void dot_email(FILE *fp, struct Email *e, struct ListHead *links)
 {
   struct Buffer buf = mutt_buffer_make(256);
   char arr[256];
@@ -1349,7 +1349,8 @@ static void dot_email(FILE *fp, const struct Email *e, struct ListHead *links)
   dot_type_number(fp, "score", e->score);
   dot_type_number(fp, "attach_total", e->attach_total);
 
-  dot_type_string(fp, "maildir_flags", e->maildir_flags, false);
+  struct MaildirEmailData *edata = maildir_edata_get(e);
+  dot_type_string(fp, "maildir_flags", edata->maildir_flags, false);
 
   if (e->date_sent != 0)
   {
@@ -1399,7 +1400,7 @@ static void dot_email(FILE *fp, const struct Email *e, struct ListHead *links)
   mutt_buffer_dealloc(&buf);
 }
 
-void dump_graphviz_email(const struct Email *e)
+void dump_graphviz_email(struct Email *e)
 {
   char name[256] = { 0 };
   struct ListHead links = STAILQ_HEAD_INITIALIZER(links);

--- a/debug/lib.h
+++ b/debug/lib.h
@@ -52,7 +52,7 @@ const char *win_name(const struct MuttWindow *win);
 // Graphviz
 void        add_flag               (struct Buffer *buf, bool is_set, const char *name);
 void        dump_graphviz          (const char *title);
-void        dump_graphviz_email    (const struct Email *e);
+void        dump_graphviz_email    (struct Email *e);
 const char *get_content_disposition(enum ContentDisposition disp);
 const char *get_content_encoding   (enum ContentEncoding enc);
 const char *get_content_type       (enum ContentType type);

--- a/email/email.c
+++ b/email/email.c
@@ -34,6 +34,8 @@
 #include "envelope.h"
 #include "tags.h"
 
+void nm_edata_free(void **ptr);
+
 /**
  * email_free - Free an Email
  * @param[out] ptr Email to free
@@ -55,6 +57,9 @@ void email_free(struct Email **ptr)
   FREE(&e->path);
 #ifdef MIXMASTER
   mutt_list_free(&e->chain);
+#endif
+#ifdef USE_NOTMUCH
+  nm_edata_free(&e->nm_edata);
 #endif
   driver_tags_free(&e->tags);
 

--- a/email/email.c
+++ b/email/email.c
@@ -52,7 +52,6 @@ void email_free(struct Email **ptr)
 
   mutt_env_free(&e->env);
   mutt_body_free(&e->content);
-  FREE(&e->maildir_flags);
   FREE(&e->tree);
   FREE(&e->path);
 #ifdef MIXMASTER

--- a/email/email.h
+++ b/email/email.h
@@ -100,6 +100,10 @@ struct Email
   struct ListHead chain;       ///< Mixmaster chain
 #endif
 
+#ifdef USE_NOTMUCH
+  void *nm_edata;              ///< Notmuch private data
+#endif
+
   struct TagList tags;         ///< For drivers that support server tagging
 
   char *maildir_flags;         ///< Unknown maildir flags

--- a/email/email.h
+++ b/email/email.h
@@ -106,8 +106,6 @@ struct Email
 
   struct TagList tags;         ///< For drivers that support server tagging
 
-  char *maildir_flags;         ///< Unknown maildir flags
-
   void *edata;                    ///< Driver-specific data
   void (*edata_free)(void **ptr); ///< Driver-specific data free function
   struct Notify *notify;          ///< Notifications handler

--- a/hcache/hcache.c
+++ b/hcache/hcache.c
@@ -129,7 +129,6 @@ static void *dump(struct HeaderCache *hc, const struct Email *e, int *off, uint3
 
   d = serial_dump_envelope(e_dump.env, d, off, convert);
   d = serial_dump_body(e_dump.content, d, off, convert);
-  d = serial_dump_char(e_dump.maildir_flags, d, off, convert);
 
   return d;
 }
@@ -167,8 +166,6 @@ static struct Email *restore(const unsigned char *d)
 
   e->content = mutt_body_new();
   serial_restore_body(e->content, d, &off, convert);
-
-  serial_restore_char(&e->maildir_flags, d, &off, convert);
 
   return e;
 }

--- a/hcache/hcachever.sh
+++ b/hcache/hcachever.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-BASEVERSION=5
+BASEVERSION=6
 STRUCTURES="Address Body Buffer Email Envelope ListNode Parameter"
 
 cleanstruct () {

--- a/maildir/maildir.c
+++ b/maildir/maildir.c
@@ -171,18 +171,22 @@ void maildir_gen_flags(char *dest, size_t destlen, struct Email *e)
 {
   *dest = '\0';
 
+  struct MaildirEmailData *edata = maildir_edata_get(e);
+  if (!edata)
+    return;
+
   /* The maildir specification requires that all files in the cur
    * subdirectory have the :unique string appended, regardless of whether
    * or not there are any flags.  If .old is set, we know that this message
    * will end up in the cur directory, so we include it in the following
    * test even though there is no associated flag.  */
 
-  if (e && (e->flagged || e->replied || e->read || e->deleted || e->old || e->maildir_flags))
+  if (e->flagged || e->replied || e->read || e->deleted || e->old || edata->maildir_flags)
   {
     char tmp[1024];
     snprintf(tmp, sizeof(tmp), "%s%s%s%s%s", e->flagged ? "F" : "", e->replied ? "R" : "",
-             e->read ? "S" : "", e->deleted ? "T" : "", NONULL(e->maildir_flags));
-    if (e->maildir_flags)
+             e->read ? "S" : "", e->deleted ? "T" : "", NONULL(edata->maildir_flags));
+    if (edata->maildir_flags)
       qsort(tmp, strlen(tmp), 1, ch_compare);
     snprintf(dest, destlen, ":2,%s", tmp);
   }

--- a/maildir/private.h
+++ b/maildir/private.h
@@ -37,6 +37,14 @@ struct Message;
 struct Progress;
 
 /**
+ * struct MaildirEmailData - Maildir-specific Email data - @extends Email
+ */
+struct MaildirEmailData
+{
+  char *maildir_flags; ///< Unknown Maildir flags
+};
+
+/**
  * struct MaildirMboxData - Maildir-specific Mailbox data - @extends Mailbox
  */
 struct MaildirMboxData
@@ -95,6 +103,9 @@ int             mh_msg_save_hcache (struct Mailbox *m, struct Email *e);
 
 /* Maildir/MH shared functions */
 void                    maildir_canon_filename (struct Buffer *dest, const char *src);
+void                    maildir_edata_free     (void **ptr);
+struct MaildirEmailData *maildir_edata_get     (struct Email *e);
+struct MaildirEmailData *maildir_edata_new     (void);
 void                    maildir_delayed_parsing(struct Mailbox *m, struct Maildir **md, struct Progress *progress);
 size_t                  maildir_hcache_keylen  (const char *fn);
 struct MaildirMboxData *maildir_mdata_get      (struct Mailbox *m);

--- a/maildir/shared.c
+++ b/maildir/shared.c
@@ -64,6 +64,42 @@
 #define INS_SORT_THRESHOLD 6
 
 /**
+ * maildir_edata_free - Free data attached to the Email
+ * @param[out] ptr Maildir data
+ */
+void maildir_edata_free(void **ptr)
+{
+  if (!ptr || !*ptr)
+    return;
+
+  // struct MaildirEmailData *edata = *ptr;
+
+  FREE(ptr);
+}
+
+/**
+ * maildir_edata_new - Create a new MaildirEmailData object
+ * @retval ptr New MaildirEmailData struct
+ */
+struct MaildirEmailData *maildir_edata_new(void)
+{
+  struct MaildirEmailData *edata = mutt_mem_calloc(1, sizeof(struct MaildirEmailData));
+  return edata;
+}
+
+/**
+ * maildir_edata_get - Get the private data for this Email
+ * @param e Email
+ * @retval ptr MaildirEmailData
+ */
+struct MaildirEmailData *maildir_edata_get(struct Email *e)
+{
+  if (!e)
+    return NULL;
+  return e->edata;
+}
+
+/**
  * maildir_mdata_free - Free data attached to the Mailbox
  * @param[out] ptr Maildir data
  */

--- a/notmuch/notmuch.c
+++ b/notmuch/notmuch.c
@@ -268,7 +268,7 @@ struct NmEmailData *nm_edata_get(struct Email *e)
   if (!e)
     return NULL;
 
-  return e->edata;
+  return e->nm_edata;
 }
 
 /**
@@ -775,8 +775,7 @@ static int init_email(struct Email *e, const char *path, notmuch_message_t *msg)
     return 0;
 
   struct NmEmailData *edata = nm_edata_new();
-  e->edata = edata;
-  e->edata_free = nm_edata_free;
+  e->nm_edata = edata;
 
   /* Notmuch ensures that message Id exists (if not notmuch Notmuch will
    * generate an ID), so it's more safe than use neomutt Email->env->id */

--- a/notmuch/notmuch.c
+++ b/notmuch/notmuch.c
@@ -239,10 +239,12 @@ void nm_edata_free(void **ptr)
     return;
 
   struct NmEmailData *edata = *ptr;
+
   mutt_debug(LL_DEBUG2, "nm: freeing email %p\n", (void *) edata);
   FREE(&edata->folder);
   FREE(&edata->oldpath);
   FREE(&edata->virtual_id);
+
   FREE(ptr);
 }
 
@@ -253,6 +255,20 @@ void nm_edata_free(void **ptr)
 struct NmEmailData *nm_edata_new(void)
 {
   return mutt_mem_calloc(1, sizeof(struct NmEmailData));
+}
+
+/**
+ * nm_edata_get - Get the Notmuch Email data
+ * @param e Email
+ * @retval ptr  Success
+ * @retval NULL Error
+ */
+struct NmEmailData *nm_edata_get(struct Email *e)
+{
+  if (!e)
+    return NULL;
+
+  return e->edata;
 }
 
 /**
@@ -311,7 +327,11 @@ static int init_mailbox(struct Mailbox *m)
  */
 static char *email_get_id(struct Email *e)
 {
-  return (e && e->edata) ? ((struct NmEmailData *) e->edata)->virtual_id : NULL;
+  struct NmEmailData *edata = nm_edata_get(e);
+  if (!edata)
+    return NULL;
+
+  return edata->virtual_id;
 }
 
 /**
@@ -617,7 +637,7 @@ err:
  */
 static int update_email_tags(struct Email *e, notmuch_message_t *msg)
 {
-  struct NmEmailData *edata = e->edata;
+  struct NmEmailData *edata = nm_edata_get(e);
   char *new_tags = NULL;
   char *old_tags = NULL;
 
@@ -667,7 +687,7 @@ static int update_email_tags(struct Email *e, notmuch_message_t *msg)
  */
 static int update_message_path(struct Email *e, const char *path)
 {
-  struct NmEmailData *edata = e->edata;
+  struct NmEmailData *edata = nm_edata_get(e);
 
   mutt_debug(LL_DEBUG2, "nm: path update requested path=%s, (%s)\n", path, edata->virtual_id);
 
@@ -751,7 +771,7 @@ static char *nm2mutt_message_id(const char *id)
  */
 static int init_email(struct Email *e, const char *path, notmuch_message_t *msg)
 {
-  if (e->edata)
+  if (nm_edata_get(e))
     return 0;
 
   struct NmEmailData *edata = nm_edata_new();
@@ -763,7 +783,7 @@ static int init_email(struct Email *e, const char *path, notmuch_message_t *msg)
   const char *id = notmuch_message_get_message_id(msg);
   edata->virtual_id = mutt_str_dup(id);
 
-  mutt_debug(LL_DEBUG2, "nm: [e=%p, edata=%p] (%s)\n", (void *) e, (void *) e->edata, id);
+  mutt_debug(LL_DEBUG2, "nm: [e=%p, edata=%p] (%s)\n", (void *) e, (void *) edata, id);
 
   char *nm_msg_id = nm2mutt_message_id(id);
   if (!e->env->message_id)
@@ -982,8 +1002,7 @@ static void append_message(struct HeaderCache *h, struct Mailbox *m,
   if (newpath)
   {
     /* remember that file has been moved -- nm_mbox_sync() will update the DB */
-    struct NmEmailData *edata = e->edata;
-
+    struct NmEmailData *edata = nm_edata_get(e);
     if (edata)
     {
       mutt_debug(LL_DEBUG1, "nm: remember obsolete path: %s\n", path);
@@ -1620,7 +1639,11 @@ static unsigned int count_query(notmuch_database_t *db, const char *qstr, int li
  */
 char *nm_email_get_folder(struct Email *e)
 {
-  return (e && e->edata) ? ((struct NmEmailData *) e->edata)->folder : NULL;
+  struct NmEmailData *edata = nm_edata_get(e);
+  if (!edata)
+    return NULL;
+
+  return edata->folder;
 }
 
 /**
@@ -1887,7 +1910,7 @@ int nm_update_filename(struct Mailbox *m, const char *old_file,
   if (!mdata || !new_file)
     return -1;
 
-  if (!old_file && e && e->edata)
+  if (!old_file && nm_edata_get(e))
   {
     email_get_fullpath(e, buf, sizeof(buf));
     old_file = buf;
@@ -2354,7 +2377,7 @@ static int nm_mbox_sync(struct Mailbox *m)
     if (!e)
       break;
 
-    struct NmEmailData *edata = e->edata;
+    struct NmEmailData *edata = nm_edata_get(e);
 
     if (m->verbose)
       mutt_progress_update(&progress, i, -1);

--- a/notmuch/private.h
+++ b/notmuch/private.h
@@ -122,6 +122,7 @@ void                  nm_adata_free(void **ptr);
 struct NmAccountData *nm_adata_get (struct Mailbox *m);
 struct NmAccountData *nm_adata_new (void);
 void                  nm_edata_free(void **ptr);
+struct NmEmailData *  nm_edata_get (struct Email *e);
 struct NmEmailData *  nm_edata_new (void);
 void                  nm_mdata_free(void **ptr);
 struct NmMboxData *   nm_mdata_get (struct Mailbox *m);

--- a/test/email/common.c
+++ b/test/email/common.c
@@ -32,3 +32,7 @@ int mutt_autocrypt_process_autocrypt_header(struct Email *e, struct Envelope *en
 {
   return -1;
 }
+
+void nm_edata_free(void **ptr)
+{
+}


### PR DESCRIPTION
This PR is a little sleight-of-hand.

It has no visible change to the user (and barely any for the developer).

**Note**: This change alters the header caching.
  `maildir_flags` used to be cached (unnecessarily, as they're rebuilt from the filename)

---

[`struct Email`](https://github.com/neomutt/neomutt/blob/master/email/email.h#L37) has an [`edata`](https://github.com/neomutt/neomutt/blob/master/email/email.h#L107) member where backends can store private Email data.

This `edata` is used by Notmuch which means that Maildir can't use it (as the two backends share Emails).

This PR swaps the priorities around.
Maildir, as the base, gets to use `edata`, whilst Notmuch uses a private member in Email.

---

- 4e1b4a68d notmuch: hide details of edata
  Use a helper, `nm_edata_get()` rather than `edata` directly

- 5e40ea750 notmuch: move edata to Email->nm_edata
  Use a private data member, `Email.nm_edata`, rather than `edata`

- 5139c1f62 maildir: add MaildirEmailData
  New wrapper

- bb2a1a2de maildir: use MaildirEmailData
  Move Maildir private data into wrapper

---

In the near future, Maildir will get refactored.
It doesn't look like the other backends; it doesn't work like the other backends.
This PR will help in that transformation.

In the more distant future, I'd like to refactor Notmuch.
Currently, it's a hybrid.  Some work can be delegated to Maildir, some it does itself.
It has to understand quite a lot about Maildir, to work.
The ideal situation is that Notmuch becomes a layer on top of multiple Maildir mailboxes.
It won't need to know about Maildir config, or the header cache, that will be Maildir's job.
(A plan is starting to form :-)