### PR TITLE
Refactor: Help Bar generation

### DIFF
--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -66,7 +66,7 @@ NEOMUTT=	neomutt$(EXEEXT)
 NEOMUTTOBJS=	browser.o commands.o command_parse.o \
 		complete.o compose.o conststrings.o context.o copy.o \
 		editmsg.o enriched.o enter.o flags.o functions.o git_ver.o \
-		handler.o hdrline.o help.o helpbar.o hook.o icommands.o index.o init.o \
+		handler.o hdrline.o help.o hook.o icommands.o index.o init.o \
 		keymap.o mailcap.o maillist.o main.o menu.o muttlib.o mutt_account.o \
 		mutt_attach.o mutt_body.o mutt_commands.o mutt_config.o \
 		mutt_header.o mutt_history.o mutt_logging.o mutt_mailbox.o \
@@ -322,6 +322,19 @@ $(PWD)/hcache:
 @endif
 
 ###############################################################################
+# libhelpbar
+LIBHELPBAR=	libhelpbar.a
+LIBHELPBAROBJS=	helpbar/helpbar.o
+CLEANFILES+=	$(LIBHELPBAR) $(LIBHELPBAROBJS)
+ALLOBJS+=	$(LIBHELPBAROBJS)
+
+$(LIBHELPBAR): $(PWD)/helpbar $(LIBHELPBAROBJS)
+	$(AR) cr $@ $(LIBHELPBAROBJS)
+	$(RANLIB) $@
+$(PWD)/helpbar:
+	$(MKDIR_P) $(PWD)/helpbar
+
+###############################################################################
 # libhistory
 LIBHISTORY=	libhistory.a
 LIBHISTORYOBJS=	history/config.o history/dlghistory.o history/history.o
@@ -575,7 +588,7 @@ $(ALLOBJS):
 # The order of these libraries depends on their dependencies.
 # The libraries with the most dependencies will come first.
 MUTTLIBS+=	$(LIBAUTOCRYPT) $(LIBPOP) $(LIBNNTP) $(LIBCOMPMBOX) \
-		$(LIBSTORE) $(LIBPATTERN) $(LIBGUI) $(LIBDEBUG) $(LIBMBOX) \
+		$(LIBSTORE) $(LIBPATTERN) $(LIBGUI) $(LIBHELPBAR) $(LIBDEBUG) $(LIBMBOX) \
 		$(LIBNOTMUCH) $(LIBMAILDIR) $(LIBNCRYPT) $(LIBIMAP) $(LIBCONN) \
 		$(LIBHCACHE)  $(LIBCOMPRESS) $(LIBSIDEBAR) $(LIBBCACHE) \
 		$(LIBHISTORY) $(LIBALIAS) $(LIBSEND) $(LIBCORE) $(LIBCONFIG) \

--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -324,7 +324,7 @@ $(PWD)/hcache:
 ###############################################################################
 # libhelpbar
 LIBHELPBAR=	libhelpbar.a
-LIBHELPBAROBJS=	helpbar/config.o helpbar/helpbar.o
+LIBHELPBAROBJS=	helpbar/config.o helpbar/helpbar.o helpbar/wdata.o
 CLEANFILES+=	$(LIBHELPBAR) $(LIBHELPBAROBJS)
 ALLOBJS+=	$(LIBHELPBAROBJS)
 

--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -324,7 +324,7 @@ $(PWD)/hcache:
 ###############################################################################
 # libhelpbar
 LIBHELPBAR=	libhelpbar.a
-LIBHELPBAROBJS=	helpbar/helpbar.o
+LIBHELPBAROBJS=	helpbar/config.o helpbar/helpbar.o
 CLEANFILES+=	$(LIBHELPBAR) $(LIBHELPBAROBJS)
 ALLOBJS+=	$(LIBHELPBAROBJS)
 

--- a/alias/dlgalias.c
+++ b/alias/dlgalias.c
@@ -44,7 +44,6 @@
 #include "alias.h"
 #include "format_flags.h"
 #include "gui.h"
-#include "helpbar.h"
 #include "keymap.h"
 #include "mutt_globals.h"
 #include "mutt_menu.h"
@@ -191,15 +190,15 @@ static void alias_menu(char *buf, size_t buflen, struct AliasMenuData *mdata)
 
   int t = -1;
   bool done = false;
-  char helpstr[1024];
 
   struct Menu *menu = mutt_menu_new(MENU_ALIAS);
   struct MuttWindow *dlg = dialog_create_simple_index(menu, WT_DLG_ALIAS);
+  dlg->help_data = AliasHelp;
+  dlg->help_menu = MENU_ALIAS;
 
   menu->make_entry = alias_make_entry;
   menu->tag = alias_tag;
   menu->title = _("Aliases");
-  menu->help = mutt_compile_help(helpstr, sizeof(helpstr), MENU_ALIAS, AliasHelp);
   menu->max = mdata->num_views;
   menu->mdata = mdata;
 

--- a/alias/dlgquery.c
+++ b/alias/dlgquery.c
@@ -43,7 +43,6 @@
 #include "alias.h"
 #include "format_flags.h"
 #include "gui.h"
-#include "helpbar.h"
 #include "keymap.h"
 #include "mutt_globals.h"
 #include "mutt_logging.h"
@@ -319,13 +318,13 @@ static void query_menu(char *buf, size_t buflen, struct AliasList *all, bool ret
 
   menu = mutt_menu_new(MENU_QUERY);
   struct MuttWindow *dlg = dialog_create_simple_index(menu, WT_DLG_QUERY);
+  dlg->help_data = QueryHelp;
+  dlg->help_menu = MENU_QUERY;
 
   menu->make_entry = query_make_entry;
   menu->search = query_search;
   menu->tag = query_tag;
   menu->title = title;
-  char helpstr[1024];
-  menu->help = mutt_compile_help(helpstr, sizeof(helpstr), MENU_QUERY, QueryHelp);
   menu->max = mdata->num_views;
   menu->mdata = mdata;
   mutt_menu_push_current(menu);

--- a/autocrypt/dlgautocrypt.c
+++ b/autocrypt/dlgautocrypt.c
@@ -37,7 +37,6 @@
 #include "gui/lib.h"
 #include "mutt.h"
 #include "format_flags.h"
-#include "helpbar.h"
 #include "keymap.h"
 #include "mutt_globals.h"
 #include "mutt_menu.h"
@@ -181,8 +180,6 @@ static struct Menu *create_menu(void)
   /* menu->tag = account_tag; */
   // L10N: Autocrypt Account Management Menu title
   menu->title = _("Autocrypt Accounts");
-  char *helpstr = mutt_mem_malloc(256);
-  menu->help = mutt_compile_help(helpstr, 256, MENU_AUTOCRYPT_ACCT, AutocryptAcctHelp);
 
   struct AccountEntry *entries =
       mutt_mem_calloc(num_accounts, sizeof(struct AccountEntry));
@@ -224,7 +221,6 @@ static void menu_free(struct Menu **menu)
   FREE(&(*menu)->mdata);
 
   mutt_menu_pop_current(*menu);
-  FREE(&(*menu)->help);
   mutt_menu_free(menu);
 }
 
@@ -274,6 +270,8 @@ void mutt_autocrypt_account_menu(void)
     return;
 
   struct MuttWindow *dlg = dialog_create_simple_index(menu, WT_DLG_AUTOCRYPT);
+  dlg->help_data = AutocryptAcctHelp;
+  dlg->help_menu = MENU_AUTOCRYPT_ACCT;
 
   bool done = false;
   while (!done)
@@ -292,6 +290,8 @@ void mutt_autocrypt_account_menu(void)
         dialog_destroy_simple_index(&dlg);
         menu = create_menu();
         dlg = dialog_create_simple_index(menu, WT_DLG_AUTOCRYPT);
+        dlg->help_data = AutocryptAcctHelp;
+        dlg->help_menu = MENU_AUTOCRYPT_ACCT;
         break;
 
       case OP_AUTOCRYPT_DELETE_ACCT:
@@ -313,6 +313,8 @@ void mutt_autocrypt_account_menu(void)
           dialog_destroy_simple_index(&dlg);
           menu = create_menu();
           dlg = dialog_create_simple_index(menu, WT_DLG_AUTOCRYPT);
+          dlg->help_data = AutocryptAcctHelp;
+          dlg->help_menu = MENU_AUTOCRYPT_ACCT;
         }
         break;
       }

--- a/browser.c
+++ b/browser.c
@@ -48,7 +48,6 @@
 #include "browser.h"
 #include "context.h"
 #include "format_flags.h"
-#include "helpbar.h"
 #include "keymap.h"
 #include "mutt_attach.h"
 #include "mutt_globals.h"
@@ -1159,7 +1158,6 @@ void mutt_browser_select_dir(const char *f)
 void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
                              char ***files, int *numfiles)
 {
-  char helpstr[1024];
   char title[256];
   struct BrowserState state = { 0 };
   struct Menu *menu = NULL;
@@ -1349,17 +1347,20 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
   menu = mutt_menu_new(MENU_FOLDER);
   struct MuttWindow *dlg = dialog_create_simple_index(menu, WT_DLG_BROWSER);
 
+#ifdef USE_NNTP
+  if (OptNews)
+    dlg->help_data = FolderNewsHelp;
+  else
+#endif
+    dlg->help_data = FolderHelp;
+  dlg->help_menu = MENU_FOLDER;
+
   menu->make_entry = folder_make_entry;
   menu->search = select_file_search;
   menu->title = title;
   if (multiple)
     menu->tag = file_tag;
 
-  menu->help = mutt_compile_help(helpstr, sizeof(helpstr), MENU_FOLDER,
-#ifdef USE_NNTP
-                                 OptNews ? FolderNewsHelp :
-#endif
-                                           FolderHelp);
   mutt_menu_push_current(menu);
 
   if (mailbox)

--- a/commands.c
+++ b/commands.c
@@ -873,6 +873,7 @@ void mutt_enter_command(void)
 {
   char buf[1024] = { 0 };
 
+  window_set_focus(MessageWindow);
   /* if enter is pressed after : with no command, just return */
   if ((mutt_get_field(":", buf, sizeof(buf), MUTT_COMMAND) != 0) || (buf[0] == '\0'))
     return;

--- a/commands.c
+++ b/commands.c
@@ -874,6 +874,7 @@ void mutt_enter_command(void)
   char buf[1024] = { 0 };
 
   window_set_focus(MessageWindow);
+  window_redraw(RootWindow, true);
   /* if enter is pressed after : with no command, just return */
   if ((mutt_get_field(":", buf, sizeof(buf), MUTT_COMMAND) != 0) || (buf[0] == '\0'))
     return;

--- a/compose.c
+++ b/compose.c
@@ -51,7 +51,6 @@
 #include "commands.h"
 #include "context.h"
 #include "format_flags.h"
-#include "helpbar.h"
 #include "hook.h"
 #include "index.h"
 #include "init.h"
@@ -1318,7 +1317,6 @@ static int mutt_dlg_compose_observer(struct NotifyCallback *nc)
  */
 int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur, int flags)
 {
-  char helpstr[1024]; // This isn't copied by the help bar
   char buf[PATH_MAX];
   int rc = -1;
   bool loop = true;
@@ -1381,6 +1379,14 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur, 
   notify_observer_add(NeoMutt->notify, mutt_dlg_compose_observer, dlg);
   dialog_push(dlg);
 
+#ifdef USE_NNTP
+  if (news)
+    dlg->help_data = ComposeNewsHelp;
+  else
+#endif
+    dlg->help_data = ComposeHelp;
+  dlg->help_menu = MENU_COMPOSE;
+
   envelope->req_rows = calc_envelope(rd);
   mutt_window_reflow(dlg);
 
@@ -1392,12 +1398,6 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur, 
 
   menu->make_entry = snd_make_entry;
   menu->tag = attach_tag;
-#ifdef USE_NNTP
-  if (news)
-    menu->help = mutt_compile_help(helpstr, sizeof(helpstr), MENU_COMPOSE, ComposeNewsHelp);
-  else
-#endif
-    menu->help = mutt_compile_help(helpstr, sizeof(helpstr), MENU_COMPOSE, ComposeHelp);
   menu->custom_redraw = compose_custom_redraw;
   menu->redraw_data = rd;
   mutt_menu_push_current(menu);

--- a/conn/dlgverifycert.c
+++ b/conn/dlgverifycert.c
@@ -32,7 +32,6 @@
 #include "mutt/lib.h"
 #include "gui/lib.h"
 #include "lib.h"
-#include "helpbar.h"
 #include "keymap.h"
 #include "mutt_globals.h"
 #include "mutt_menu.h"
@@ -71,6 +70,8 @@ int dlg_verify_cert(const char *title, struct ListHead *list, bool allow_always,
 {
   struct Menu *menu = mutt_menu_new(MENU_GENERIC);
   struct MuttWindow *dlg = dialog_create_simple_index(menu, WT_DLG_CERTIFICATE);
+  dlg->help_data = VerifyHelp;
+  dlg->help_menu = MENU_GENERIC;
 
   mutt_menu_push_current(menu);
 
@@ -120,9 +121,6 @@ int dlg_verify_cert(const char *title, struct ListHead *list, bool allow_always,
       menu->keys = _("ro");
     }
   }
-
-  char helpstr[1024] = { 0 };
-  menu->help = mutt_compile_help(helpstr, sizeof(helpstr), MENU_GENERIC, VerifyHelp);
 
   bool old_ime = OptIgnoreMacroEvents;
   OptIgnoreMacroEvents = true;

--- a/gui/curs_lib.c
+++ b/gui/curs_lib.c
@@ -700,6 +700,7 @@ int mutt_do_pager(const char *banner, const char *tempfile, PagerFlags do_color,
   struct MuttWindow *pager =
       mutt_window_new(WT_PAGER, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
+  dlg->focus = pager;
 
   struct MuttWindow *pbar =
       mutt_window_new(WT_PAGER_BAR, MUTT_WIN_ORIENT_VERTICAL,

--- a/gui/dialog.c
+++ b/gui/dialog.c
@@ -82,6 +82,8 @@ void dialog_push(struct MuttWindow *dlg)
   dlg->state.visible = true;
   dlg->parent = AllDialogsWindow;
   mutt_window_reflow(AllDialogsWindow);
+  window_set_focus(dlg);
+
 #ifdef USE_DEBUG_WINDOW
   debug_win_dump();
 #endif
@@ -116,6 +118,7 @@ void dialog_pop(void)
     last->state.visible = true;
     mutt_window_reflow(AllDialogsWindow);
   }
+  window_set_focus(last);
   mutt_menu_set_current_redraw(REDRAW_FULL);
 #ifdef USE_DEBUG_WINDOW
   debug_win_dump();
@@ -171,6 +174,7 @@ struct MuttWindow *dialog_create_simple_index(struct Menu *menu, enum WindowType
   struct MuttWindow *index =
       mutt_window_new(WT_INDEX, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
+  dlg->focus = index;
 
   struct MuttWindow *ibar =
       mutt_window_new(WT_INDEX_BAR, MUTT_WIN_ORIENT_VERTICAL,

--- a/gui/mutt_window.c
+++ b/gui/mutt_window.c
@@ -39,6 +39,7 @@
 #include "mutt_menu.h"
 #include "options.h"
 #include "reflow.h"
+#include "helpbar/lib.h"
 
 struct MuttWindow *RootWindow = NULL;       ///< Parent of all Windows
 struct MuttWindow *AllDialogsWindow = NULL; ///< Parent of all Dialogs
@@ -347,9 +348,7 @@ void mutt_window_init(void)
       mutt_window_new(WT_ROOT, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_FIXED, 0, 0);
   notify_set_parent(RootWindow->notify, NeoMutt->notify);
 
-  HelpBarWindow = mutt_window_new(WT_HELP_BAR, MUTT_WIN_ORIENT_VERTICAL,
-                                  MUTT_WIN_SIZE_FIXED, MUTT_WIN_SIZE_UNLIMITED, 1);
-  HelpBarWindow->state.visible = C_Help;
+  HelpBarWindow = helpbar_create();
 
   AllDialogsWindow = mutt_window_new(WT_ALL_DIALOGS, MUTT_WIN_ORIENT_VERTICAL,
                                      MUTT_WIN_SIZE_MAXIMISE, MUTT_WIN_SIZE_UNLIMITED,

--- a/gui/mutt_window.c
+++ b/gui/mutt_window.c
@@ -37,6 +37,7 @@
 #include "mutt_curses.h"
 #include "mutt_globals.h"
 #include "mutt_menu.h"
+#include "opcodes.h"
 #include "options.h"
 #include "reflow.h"
 #include "helpbar/lib.h"
@@ -44,6 +45,21 @@
 struct MuttWindow *RootWindow = NULL;       ///< Parent of all Windows
 struct MuttWindow *AllDialogsWindow = NULL; ///< Parent of all Dialogs
 struct MuttWindow *MessageWindow = NULL;    ///< Message Window, ":set", etc
+
+/// Help Bar for the Command Line Editor
+static const struct Mapping EditorHelp[] = {
+  // clang-format off
+  { N_("Complete"),    OP_EDITOR_COMPLETE },
+  { N_("Hist Up"),     OP_EDITOR_HISTORY_UP },
+  { N_("Hist Down"),   OP_EDITOR_HISTORY_DOWN },
+  { N_("Hist Search"), OP_EDITOR_HISTORY_SEARCH },
+  { N_("Begin Line"),  OP_EDITOR_BOL },
+  { N_("End Line"),    OP_EDITOR_EOL },
+  { N_("Kill Line"),   OP_EDITOR_KILL_LINE },
+  { N_("Kill Word"),   OP_EDITOR_KILL_WORD },
+  { NULL, 0 },
+  // clang-format off
+};
 
 /**
  * window_was_visible - Was the Window visible?
@@ -347,6 +363,8 @@ void mutt_window_init(void)
 
   MessageWindow = mutt_window_new(WT_MESSAGE, MUTT_WIN_ORIENT_VERTICAL,
                                   MUTT_WIN_SIZE_FIXED, MUTT_WIN_SIZE_UNLIMITED, 1);
+  MessageWindow->help_data = EditorHelp;
+  MessageWindow->help_menu = MENU_EDITOR;
 
   if (C_StatusOnTop)
   {

--- a/gui/mutt_window.c
+++ b/gui/mutt_window.c
@@ -273,7 +273,7 @@ static int mutt_dlg_rootwin_observer(struct NotifyCallback *nc)
 
   if (mutt_str_equal(ec->name, "help"))
   {
-    HelpBarWindow->state.visible = C_Help;
+    HelpBarWindow->state.visible = cs_subset_bool(NeoMutt->sub, "help");
     goto reflow;
   }
 

--- a/gui/mutt_window.c
+++ b/gui/mutt_window.c
@@ -43,7 +43,6 @@
 
 struct MuttWindow *RootWindow = NULL;       ///< Parent of all Windows
 struct MuttWindow *AllDialogsWindow = NULL; ///< Parent of all Dialogs
-struct MuttWindow *HelpBarWindow = NULL;    ///< Help Bar Window, "?:Help", etc
 struct MuttWindow *MessageWindow = NULL;    ///< Message Window, ":set", etc
 
 /**
@@ -271,12 +270,6 @@ static int mutt_dlg_rootwin_observer(struct NotifyCallback *nc)
   struct EventConfig *ec = nc->event_data;
   struct MuttWindow *root_win = nc->global_data;
 
-  if (mutt_str_equal(ec->name, "help"))
-  {
-    HelpBarWindow->state.visible = cs_subset_bool(NeoMutt->sub, "help");
-    goto reflow;
-  }
-
   if (mutt_str_equal(ec->name, "status_on_top"))
   {
     struct MuttWindow *first = TAILQ_FIRST(&root_win->children);
@@ -295,7 +288,6 @@ static int mutt_dlg_rootwin_observer(struct NotifyCallback *nc)
     }
   }
 
-reflow:
   mutt_window_reflow(root_win);
   return 0;
 }
@@ -308,7 +300,6 @@ void mutt_window_free_all(void)
   if (NeoMutt)
     notify_observer_remove(NeoMutt->notify, mutt_dlg_rootwin_observer, RootWindow);
   AllDialogsWindow = NULL;
-  HelpBarWindow = NULL;
   MessageWindow = NULL;
   mutt_window_free(&RootWindow);
 }
@@ -348,7 +339,7 @@ void mutt_window_init(void)
       mutt_window_new(WT_ROOT, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_FIXED, 0, 0);
   notify_set_parent(RootWindow->notify, NeoMutt->notify);
 
-  HelpBarWindow = helpbar_create();
+  struct MuttWindow *win_helpbar = helpbar_create();
 
   AllDialogsWindow = mutt_window_new(WT_ALL_DIALOGS, MUTT_WIN_ORIENT_VERTICAL,
                                      MUTT_WIN_SIZE_MAXIMISE, MUTT_WIN_SIZE_UNLIMITED,
@@ -360,11 +351,11 @@ void mutt_window_init(void)
   if (C_StatusOnTop)
   {
     mutt_window_add_child(RootWindow, AllDialogsWindow);
-    mutt_window_add_child(RootWindow, HelpBarWindow);
+    mutt_window_add_child(RootWindow, win_helpbar);
   }
   else
   {
-    mutt_window_add_child(RootWindow, HelpBarWindow);
+    mutt_window_add_child(RootWindow, win_helpbar);
     mutt_window_add_child(RootWindow, AllDialogsWindow);
   }
 

--- a/gui/mutt_window.h
+++ b/gui/mutt_window.h
@@ -131,6 +131,8 @@ struct MuttWindow
   struct Notify *notify;             ///< Notifications system
 
   struct MuttWindow *focus;          ///< Focussed Window
+  int help_menu;                     ///< Menu for key bindings, e.g. #MENU_PAGER
+  const struct Mapping *help_data;   ///< Data for the Help Bar
 
   enum WindowType type;              ///< Window type, e.g. #WT_SIDEBAR
   void *wdata;                       ///< Private data
@@ -186,6 +188,7 @@ struct EventWindow
   WindowNotifyFlags flags; ///< Attributes of Window that changed
 };
 
+extern struct MuttWindow *RootWindow;
 extern struct MuttWindow *AllDialogsWindow;
 extern struct MuttWindow *HelpBarWindow;
 extern struct MuttWindow *MessageWindow;

--- a/gui/mutt_window.h
+++ b/gui/mutt_window.h
@@ -190,7 +190,6 @@ struct EventWindow
 
 extern struct MuttWindow *RootWindow;
 extern struct MuttWindow *AllDialogsWindow;
-extern struct MuttWindow *HelpBarWindow;
 extern struct MuttWindow *MessageWindow;
 
 // Functions that deal with the Window

--- a/gui/mutt_window.h
+++ b/gui/mutt_window.h
@@ -130,6 +130,8 @@ struct MuttWindow
 
   struct Notify *notify;             ///< Notifications system
 
+  struct MuttWindow *focus;          ///< Focussed Window
+
   enum WindowType type;              ///< Window type, e.g. #WT_SIDEBAR
   void *wdata;                       ///< Private data
   void (*wdata_free)(struct MuttWindow *win, void **ptr); ///< Callback function to free private data
@@ -172,6 +174,7 @@ enum NotifyWindow
   NT_WINDOW_DELETE,  ///< Window is about to be deleted
   NT_WINDOW_STATE,   ///< Window state has changed, e.g. #WN_VISIBLE
   NT_WINDOW_DIALOG,  ///< A new Dialog Window has been created, e.g. #WT_DLG_INDEX
+  NT_WINDOW_FOCUS,   ///< Window focus has changed
 };
 
 /**
@@ -218,6 +221,8 @@ void               mutt_winlist_free (struct MuttWindowList *head);
 struct MuttWindow *mutt_window_find  (struct MuttWindow *root, enum WindowType type);
 void               window_notify_all (struct MuttWindow *win);
 void               window_set_visible(struct MuttWindow *win, bool visible);
+void               window_set_focus  (struct MuttWindow *win);
+struct MuttWindow *window_get_focus  (void);
 
 void window_redraw(struct MuttWindow *win, bool force);
 

--- a/helpbar/config.c
+++ b/helpbar/config.c
@@ -1,7 +1,6 @@
 /**
  * @file
- * Help Bar
- * Convenience wrapper for the Help Bar headers
+ * Config used by Help Bar
  *
  * @authors
  * Copyright (C) 2020 Richard Russon <rich@flatcap.org>
@@ -22,20 +21,27 @@
  */
 
 /**
- * @page helpbar Convenience wrapper for the Help Bar headers
+ * @page helpbar_config Config used by Help Bar
  *
- * Convenience wrapper for the Help Bar headers
+ * Config used by Help Bar
  */
 
-#ifndef MUTT_HELPBAR_LIB_H
-#define MUTT_HELPBAR_LIB_H
-
+#include "config.h"
+#include <stddef.h>
 #include <stdbool.h>
+#include "config/lib.h"
 
-struct ConfigSet;
+// clang-format off
+struct ConfigDef HelpbarVars[] = {
+  { "help", DT_BOOL|R_REFLOW, NULL, true },
+  { NULL, 0, NULL, 0, 0, NULL },
+};
+// clang-format on
 
-struct MuttWindow *helpbar_create(void);
-
-bool config_init_helpbar(struct ConfigSet *cs);
-
-#endif /* MUTT_HELPBAR_LIB_H */
+/**
+ * config_init_helpbar - Register helpbar config variables
+ */
+bool config_init_helpbar(struct ConfigSet *cs)
+{
+  return cs_register_variables(cs, HelpbarVars, DT_NO_VARIABLE);
+}

--- a/helpbar/helpbar.c
+++ b/helpbar/helpbar.c
@@ -30,7 +30,9 @@
 #include <stddef.h>
 #include <stdio.h>
 #include "mutt/lib.h"
+#include "gui/lib.h"
 #include "keymap.h"
+#include "mutt_globals.h"
 
 /**
  * make_help - Create one entry for the help bar
@@ -84,4 +86,18 @@ char *mutt_compile_help(char *buf, size_t buflen, enum MenuType menu,
     buflen -= len;
   }
   return buf;
+}
+
+/**
+ * helpbar_create - Create the Help Bar Window
+ * @retval ptr New Window
+ */
+struct MuttWindow *helpbar_create(void)
+{
+  struct MuttWindow *win =
+      mutt_window_new(WT_HELP_BAR, MUTT_WIN_ORIENT_VERTICAL,
+                      MUTT_WIN_SIZE_FIXED, MUTT_WIN_SIZE_UNLIMITED, 1);
+  win->state.visible = C_Help;
+
+  return win;
 }

--- a/helpbar/helpbar.c
+++ b/helpbar/helpbar.c
@@ -1,6 +1,6 @@
 /**
  * @file
- * Help bar
+ * Help Bar
  *
  * @authors
  * Copyright (C) 2020 Richard Russon <rich@flatcap.org>
@@ -21,9 +21,9 @@
  */
 
 /**
- * @page helpbar Help bar
+ * @page helpbar_helpbar Help Bar
  *
- * Help bar
+ * Help Bar
  */
 
 #include "config.h"

--- a/helpbar/helpbar.c
+++ b/helpbar/helpbar.c
@@ -29,6 +29,7 @@
 #include "config.h"
 #include <stddef.h>
 #include <stdio.h>
+#include "private.h"
 #include "mutt/lib.h"
 #include "config/lib.h"
 #include "core/lib.h"
@@ -99,6 +100,9 @@ struct MuttWindow *helpbar_create(void)
       mutt_window_new(WT_HELP_BAR, MUTT_WIN_ORIENT_VERTICAL,
                       MUTT_WIN_SIZE_FIXED, MUTT_WIN_SIZE_UNLIMITED, 1);
   win->state.visible = cs_subset_bool(NeoMutt->sub, "help");
+
+  win->wdata = helpbar_wdata_new();
+  win->wdata_free = helpbar_wdata_free;
 
   return win;
 }

--- a/helpbar/helpbar.c
+++ b/helpbar/helpbar.c
@@ -30,9 +30,10 @@
 #include <stddef.h>
 #include <stdio.h>
 #include "mutt/lib.h"
+#include "config/lib.h"
+#include "core/lib.h"
 #include "gui/lib.h"
 #include "keymap.h"
-#include "mutt_globals.h"
 
 /**
  * make_help - Create one entry for the help bar
@@ -97,7 +98,7 @@ struct MuttWindow *helpbar_create(void)
   struct MuttWindow *win =
       mutt_window_new(WT_HELP_BAR, MUTT_WIN_ORIENT_VERTICAL,
                       MUTT_WIN_SIZE_FIXED, MUTT_WIN_SIZE_UNLIMITED, 1);
-  win->state.visible = C_Help;
+  win->state.visible = cs_subset_bool(NeoMutt->sub, "help");
 
   return win;
 }

--- a/helpbar/lib.h
+++ b/helpbar/lib.h
@@ -1,6 +1,7 @@
 /**
  * @file
- * Help bar
+ * Help Bar
+ * Convenience wrapper for the Help Bar headers
  *
  * @authors
  * Copyright (C) 2020 Richard Russon <rich@flatcap.org>
@@ -20,8 +21,14 @@
  * this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef MUTT_HELPBAR_H
-#define MUTT_HELPBAR_H
+/**
+ * @page helpbar Convenience wrapper for the Help Bar headers
+ *
+ * Convenience wrapper for the Help Bar headers
+ */
+
+#ifndef MUTT_HELPBAR_LIB_H
+#define MUTT_HELPBAR_LIB_H
 
 #include <stddef.h>
 #include "keymap.h"
@@ -30,4 +37,4 @@ struct Mapping;
 
 char *mutt_compile_help(char *buf, size_t buflen, enum MenuType menu, const struct Mapping *items);
 
-#endif /* MUTT_HELPBAR_H */
+#endif /* MUTT_HELPBAR_LIB_H */

--- a/helpbar/lib.h
+++ b/helpbar/lib.h
@@ -30,11 +30,6 @@
 #ifndef MUTT_HELPBAR_LIB_H
 #define MUTT_HELPBAR_LIB_H
 
-#include <stddef.h>
-#include "keymap.h"
-
-struct Mapping;
-
-char *mutt_compile_help(char *buf, size_t buflen, enum MenuType menu, const struct Mapping *items);
+struct MuttWindow *helpbar_create(void);
 
 #endif /* MUTT_HELPBAR_LIB_H */

--- a/helpbar/private.h
+++ b/helpbar/private.h
@@ -1,0 +1,44 @@
+/**
+ * @file
+ * Shared constants/structs that are private to the Help Bar
+ *
+ * @authors
+ * Copyright (C) 2020 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MUTT_HELPBAR_PRIVATE_H
+#define MUTT_HELPBAR_PRIVATE_H
+
+struct MuttWindow;
+
+/**
+ * struct HelpbarWindowData - Help Bar Window data
+ *
+ * This is used to cache the data to generate the Help Bar text.
+ */
+struct HelpbarWindowData
+{
+  int                   help_menu; ///< Menu for key bindings, e.g. #MENU_PAGER
+  const struct Mapping *help_data; ///< Data for the Help Bar
+  char *                help_str;  ///< Formatted Help Bar string
+};
+
+void                      helpbar_wdata_free(struct MuttWindow *win, void **ptr);
+struct HelpbarWindowData *helpbar_wdata_get (struct MuttWindow *win);
+struct HelpbarWindowData *helpbar_wdata_new (void);
+
+#endif /* MUTT_HELPBAR_PRIVATE_H */

--- a/helpbar/wdata.c
+++ b/helpbar/wdata.c
@@ -1,0 +1,72 @@
+/**
+ * @file
+ * Help Bar Window data
+ *
+ * @authors
+ * Copyright (C) 2020 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @page helpbar_wdata Help Bar Window data
+ *
+ * Help Bar Window data
+ */
+
+#include "config.h"
+#include <stddef.h>
+#include "private.h"
+#include "mutt/lib.h"
+#include "gui/lib.h"
+
+/**
+ * helpbar_wdata_new - Create new Window data for the Helpbar
+ * @retval ptr New Window data
+ */
+struct HelpbarWindowData *helpbar_wdata_new(void)
+{
+  return mutt_mem_calloc(1, sizeof(struct HelpbarWindowData));
+}
+
+/**
+ * helpbar_wdata_free - Free Helpbar Window data
+ * @param win Helpbar Window
+ * @param ptr Window data to free
+ */
+void helpbar_wdata_free(struct MuttWindow *win, void **ptr)
+{
+  if (!ptr || !*ptr)
+    return;
+
+  struct HelpbarWindowData *wdata = *ptr;
+
+  // We don't own the help_data
+  FREE(&wdata->help_str);
+
+  FREE(ptr);
+}
+
+/**
+ * helpbar_wdata_get - Get the Helpbar data for this window
+ * @param win Window
+ */
+struct HelpbarWindowData *helpbar_wdata_get(struct MuttWindow *win)
+{
+  if (!win || (win->type != WT_HELP_BAR))
+    return NULL;
+
+  return win->wdata;
+}

--- a/history/dlghistory.c
+++ b/history/dlghistory.c
@@ -34,7 +34,6 @@
 #include "gui/lib.h"
 #include "mutt.h"
 #include "format_flags.h"
-#include "helpbar.h"
 #include "keymap.h"
 #include "mutt_menu.h"
 #include "muttlib.h"
@@ -97,17 +96,17 @@ static void history_make_entry(char *buf, size_t buflen, struct Menu *menu, int 
 void history_menu(char *buf, size_t buflen, char **matches, int match_count)
 {
   bool done = false;
-  char helpstr[1024];
   char title[256];
 
   snprintf(title, sizeof(title), _("History '%s'"), buf);
 
   struct Menu *menu = mutt_menu_new(MENU_GENERIC);
   struct MuttWindow *dlg = dialog_create_simple_index(menu, WT_DLG_HISTORY);
+  dlg->help_data = HistoryHelp;
+  dlg->help_menu = MENU_GENERIC;
 
   menu->make_entry = history_make_entry;
   menu->title = title;
-  menu->help = mutt_compile_help(helpstr, sizeof(helpstr), MENU_GENERIC, HistoryHelp);
   mutt_menu_push_current(menu);
 
   menu->max = match_count;

--- a/index.c
+++ b/index.c
@@ -2615,6 +2615,7 @@ int mutt_index_menu(struct MuttWindow *dlg)
 
         op = mutt_display_message(win_index, win_ibar, win_pager, win_pbar,
                                   Context->mailbox, cur.e);
+        window_set_focus(win_index);
         if (op < 0)
         {
           OptNeedResort = false;
@@ -3405,6 +3406,7 @@ int mutt_index_menu(struct MuttWindow *dlg)
 
       case OP_ENTER_COMMAND:
         mutt_enter_command();
+        window_set_focus(win_index);
         if (Context)
           mutt_check_rescore(Context->mailbox);
         break;
@@ -4061,10 +4063,12 @@ static struct MuttWindow *create_panel_index(struct MuttWindow *parent, bool sta
   struct MuttWindow *panel_index =
       mutt_window_new(WT_CONTAINER, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
+  parent->focus = panel_index;
 
   struct MuttWindow *win_index =
       mutt_window_new(WT_INDEX, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
+  panel_index->focus = win_index;
 
   struct MuttWindow *win_ibar =
       mutt_window_new(WT_INDEX_BAR, MUTT_WIN_ORIENT_VERTICAL,
@@ -4100,6 +4104,7 @@ static struct MuttWindow *create_panel_pager(struct MuttWindow *parent, bool sta
   struct MuttWindow *win_pager =
       mutt_window_new(WT_PAGER, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
+  panel_pager->focus = win_pager;
 
   struct MuttWindow *win_pbar =
       mutt_window_new(WT_PAGER_BAR, MUTT_WIN_ORIENT_VERTICAL,

--- a/index.c
+++ b/index.c
@@ -49,7 +49,6 @@
 #include "context.h"
 #include "format_flags.h"
 #include "hdrline.h"
-#include "helpbar.h"
 #include "hook.h"
 #include "init.h"
 #include "keymap.h"
@@ -1179,7 +1178,7 @@ static void index_custom_redraw(struct Menu *menu)
  */
 int mutt_index_menu(struct MuttWindow *dlg)
 {
-  char buf[PATH_MAX], helpstr[1024];
+  char buf[PATH_MAX];
   int op = OP_NULL;
   bool done = false; /* controls when to exit the "event" loop */
   bool tag = false;  /* has the tag-prefix command been pressed? */
@@ -1196,6 +1195,14 @@ int mutt_index_menu(struct MuttWindow *dlg)
   struct MuttWindow *win_pager = mutt_window_find(dlg, WT_PAGER);
   struct MuttWindow *win_pbar = mutt_window_find(dlg, WT_PAGER_BAR);
 
+#ifdef USE_NNTP
+  if (Context && Context->mailbox && (Context->mailbox->type == MUTT_NNTP))
+    dlg->help_data = IndexNewsHelp;
+  else
+#endif
+    dlg->help_data = IndexHelp;
+  dlg->help_menu = MENU_MAIN;
+
   struct Menu *menu = mutt_menu_new(MENU_MAIN);
   menu->pagelen = win_index->state.rows;
   menu->win_index = win_index;
@@ -1204,13 +1211,6 @@ int mutt_index_menu(struct MuttWindow *dlg)
   menu->make_entry = index_make_entry;
   menu->color = index_color;
   menu->current = ci_first_message(Context);
-  menu->help = mutt_compile_help(
-      helpstr, sizeof(helpstr), MENU_MAIN,
-#ifdef USE_NNTP
-      (Context && Context->mailbox && (Context->mailbox->type == MUTT_NNTP)) ?
-          IndexNewsHelp :
-#endif
-          IndexHelp);
   menu->custom_redraw = index_custom_redraw;
   mutt_menu_push_current(menu);
   mutt_window_reflow(NULL);
@@ -1376,6 +1376,7 @@ int mutt_index_menu(struct MuttWindow *dlg)
     else
     {
       index_custom_redraw(menu);
+      window_redraw(RootWindow, true);
 
       /* give visual indication that the next command is a tag- command */
       if (tag)
@@ -2569,7 +2570,7 @@ int mutt_index_menu(struct MuttWindow *dlg)
           change_folder_string(menu, folderbuf->data, folderbuf->dsize,
                                &oldcount, &cur, &pager_return, read_only);
         }
-        menu->help = mutt_compile_help(helpstr, sizeof(helpstr), MENU_MAIN, IndexNewsHelp);
+        dlg->help_data = IndexNewsHelp;
 
       changefoldercleanup2:
         mutt_buffer_pool_release(&folderbuf);

--- a/init.c
+++ b/init.c
@@ -64,6 +64,7 @@
 #include "autocrypt/lib.h"
 #include "compress/lib.h"
 #include "hcache/lib.h"
+#include "helpbar/lib.h"
 #include "history/lib.h"
 #include "imap/lib.h"
 #include "maildir/lib.h"
@@ -1553,14 +1554,23 @@ struct ConfigSet *init_config(size_t size)
   typedef bool (*config_init_t)(struct ConfigSet * cs);
 
   static config_init_t config_list[] = {
-    config_init_main,    config_init_autocrypt,
-    config_init_conn,    config_init_hcache,
-    config_init_history, config_init_imap,
-    config_init_maildir, config_init_mbox,
-    config_init_ncrypt,  config_init_nntp,
-    config_init_notmuch, config_init_pattern,
-    config_init_pop,     config_init_send,
-    config_init_sidebar, NULL,
+    config_init_main,
+    config_init_autocrypt,
+    config_init_conn,
+    config_init_hcache,
+    config_init_helpbar,
+    config_init_history,
+    config_init_imap,
+    config_init_maildir,
+    config_init_mbox,
+    config_init_ncrypt,
+    config_init_nntp,
+    config_init_notmuch,
+    config_init_pattern,
+    config_init_pop,
+    config_init_send,
+    config_init_sidebar,
+    NULL,
   };
 
   struct ConfigSet *cs = cs_new(size);

--- a/menu.c
+++ b/menu.c
@@ -1519,6 +1519,7 @@ int mutt_menu_loop(struct Menu *menu)
 
       case OP_ENTER_COMMAND:
         mutt_enter_command();
+        window_set_focus(menu->win_index);
         break;
 
       case OP_TAG:

--- a/menu.c
+++ b/menu.c
@@ -355,13 +355,7 @@ void menu_redraw_full(struct Menu *menu)
   mutt_window_move_abs(0, 0);
   mutt_window_clrtobot();
 
-  if (C_Help)
-  {
-    mutt_curses_set_color(MT_COLOR_STATUS);
-    mutt_window_move(HelpBarWindow, 0, 0);
-    mutt_paddstr(HelpBarWindow->state.cols, menu->help);
-    mutt_curses_set_color(MT_COLOR_NORMAL);
-  }
+  window_redraw(RootWindow, true);
   menu->pagelen = menu->win_index->state.rows;
 
   mutt_show_error();
@@ -1520,6 +1514,7 @@ int mutt_menu_loop(struct Menu *menu)
       case OP_ENTER_COMMAND:
         mutt_enter_command();
         window_set_focus(menu->win_index);
+        window_redraw(RootWindow, false);
         break;
 
       case OP_TAG:

--- a/mutt_config.c
+++ b/mutt_config.c
@@ -140,7 +140,6 @@ struct ConfigDef MainVars[] = {
   { "gecos_mask", DT_REGEX, &C_GecosMask, IP "^[^,]*" },
   { "header", DT_BOOL, &C_Header, false },
   { "header_color_partial", DT_BOOL|R_PAGER_FLOW, &C_HeaderColorPartial, false },
-  { "help", DT_BOOL|R_REFLOW, &C_Help, true },
   { "hidden_tags", DT_SLIST|SLIST_SEP_COMMA, &C_HiddenTags, IP "unread,draft,flagged,passed,replied,attachment,signed,encrypted" },
   { "hide_limited", DT_BOOL|R_TREE|R_INDEX, &C_HideLimited, false },
   { "hide_missing", DT_BOOL|R_TREE|R_INDEX, &C_HideMissing, true },

--- a/mutt_globals.h
+++ b/mutt_globals.h
@@ -150,7 +150,6 @@ WHERE bool C_FlagSafe;                       ///< Config: Protect flagged messag
 WHERE bool C_ForwardDecode;                  ///< Config: Decode the message when forwarding it
 WHERE bool C_ForwardQuote;                   ///< Config: Automatically quote a forwarded message using #C_IndentString
 WHERE bool C_Header;                         ///< Config: Include the message headers in the reply email (Weed applies)
-WHERE bool C_Help;                           ///< Config: Display a help line with common key bindings
 WHERE bool C_MailCheckRecent;                ///< Config: Notify the user about new mail since the last time the mailbox was opened
 WHERE bool C_Markers;                        ///< Config: Display a '+' at the beginning of wrapped lines in the pager
 WHERE bool C_PipeDecodeWeed;                 ///< Config: Control whether to weed headers when piping an email

--- a/mutt_menu.h
+++ b/mutt_menu.h
@@ -80,7 +80,6 @@ enum TreeChar
 struct Menu
 {
   const char *title;      ///< Title of this menu
-  const char *help;       ///< Quickref for the current menu
   void *mdata;            ///< Extra data for the current menu
   int current;            ///< Current entry
   int max;                ///< Number of entries in the menu

--- a/ncrypt/dlggpgme.c
+++ b/ncrypt/dlggpgme.c
@@ -45,7 +45,6 @@
 #include "gui/lib.h"
 #include "crypt_gpgme.h"
 #include "format_flags.h"
-#include "helpbar.h"
 #include "keymap.h"
 #include "mutt_logging.h"
 #include "mutt_menu.h"
@@ -1200,7 +1199,7 @@ struct CryptKeyInfo *crypt_select_key(struct CryptKeyInfo *keys, struct Address 
   int keymax;
   int i;
   bool done = false;
-  char helpstr[1024], buf[1024];
+  char buf[1024];
   struct CryptKeyInfo *k = NULL;
   int (*f)(const void *, const void *);
   enum MenuType menu_to_use = MENU_GENERIC;
@@ -1258,15 +1257,13 @@ struct CryptKeyInfo *crypt_select_key(struct CryptKeyInfo *keys, struct Address 
   else if (app & APPLICATION_SMIME)
     menu_to_use = MENU_KEY_SELECT_SMIME;
 
-  helpstr[0] = '\0';
-  mutt_compile_help(helpstr, sizeof(helpstr), menu_to_use, GpgmeHelp);
-
   struct Menu *menu = mutt_menu_new(menu_to_use);
   struct MuttWindow *dlg = dialog_create_simple_index(menu, WT_DLG_CRYPT_GPGME);
+  dlg->help_data = GpgmeHelp;
+  dlg->help_menu = menu_to_use;
 
   menu->max = i;
   menu->make_entry = crypt_make_entry;
-  menu->help = helpstr;
   menu->mdata = key_table;
   mutt_menu_push_current(menu);
 

--- a/ncrypt/dlgpgp.c
+++ b/ncrypt/dlgpgp.c
@@ -36,7 +36,6 @@
 #include "address/lib.h"
 #include "gui/lib.h"
 #include "format_flags.h"
-#include "helpbar.h"
 #include "mutt_logging.h"
 #include "mutt_menu.h"
 #include "muttlib.h"
@@ -473,7 +472,7 @@ struct PgpKeyInfo *pgp_select_key(struct PgpKeyInfo *keys, struct Address *p, co
   struct Menu *menu = NULL;
   int i;
   bool done = false;
-  char helpstr[1024], buf[1024], tmpbuf[256];
+  char buf[1024], tmpbuf[256];
   char cmd[1024];
   struct PgpKeyInfo *kp = NULL;
   struct PgpUid *a = NULL;
@@ -534,15 +533,13 @@ struct PgpKeyInfo *pgp_select_key(struct PgpKeyInfo *keys, struct Address *p, co
   }
   qsort(key_table, i, sizeof(struct PgpUid *), f);
 
-  helpstr[0] = '\0';
-  mutt_compile_help(helpstr, sizeof(helpstr), MENU_PGP, PgpHelp);
-
   menu = mutt_menu_new(MENU_PGP);
   struct MuttWindow *dlg = dialog_create_simple_index(menu, WT_DLG_PGP);
+  dlg->help_data = PgpHelp;
+  dlg->help_menu = MENU_PGP;
 
   menu->max = i;
   menu->make_entry = pgp_make_entry;
-  menu->help = helpstr;
   menu->mdata = key_table;
   mutt_menu_push_current(menu);
 

--- a/ncrypt/dlgsmime.c
+++ b/ncrypt/dlgsmime.c
@@ -33,7 +33,6 @@
 #include "mutt/lib.h"
 #include "config/lib.h"
 #include "gui/lib.h"
-#include "helpbar.h"
 #include "keymap.h"
 #include "mutt_logging.h"
 #include "mutt_menu.h"
@@ -161,7 +160,6 @@ struct SmimeKey *smime_select_key(struct SmimeKey *keys, char *query)
   int table_index = 0;
   struct SmimeKey *key = NULL;
   struct SmimeKey *selected_key = NULL;
-  char helpstr[1024];
   char buf[1024];
   char title[256];
   struct Menu *menu = NULL;
@@ -181,16 +179,13 @@ struct SmimeKey *smime_select_key(struct SmimeKey *keys, char *query)
 
   snprintf(title, sizeof(title), _("S/MIME certificates matching \"%s\""), query);
 
-  /* Make Helpstring */
-  helpstr[0] = '\0';
-  mutt_compile_help(helpstr, sizeof(helpstr), MENU_SMIME, SmimeHelp);
-
   menu = mutt_menu_new(MENU_SMIME);
   struct MuttWindow *dlg = dialog_create_simple_index(menu, WT_DLG_SMIME);
+  dlg->help_data = SmimeHelp;
+  dlg->help_menu = MENU_SMIME;
 
   menu->max = table_index;
   menu->make_entry = smime_make_entry;
-  menu->help = helpstr;
   menu->mdata = table;
   menu->title = title;
   mutt_menu_push_current(menu);

--- a/pager.c
+++ b/pager.c
@@ -49,7 +49,6 @@
 #include "context.h"
 #include "format_flags.h"
 #include "hdrline.h"
-#include "helpbar.h"
 #include "hook.h"
 #include "index.h"
 #include "init.h"
@@ -193,7 +192,6 @@ struct PagerRedrawData
   PagerFlags search_flag;
   bool search_back;
   const char *banner;
-  const char *helpstr;
   char *searchbuf;
   struct Line *line_info;
   FILE *fp;
@@ -2008,14 +2006,6 @@ static void pager_custom_redraw(struct Menu *pager_menu)
 
     rd->indicator = rd->indexlen / 3;
 
-    if (C_Help)
-    {
-      mutt_curses_set_color(MT_COLOR_STATUS);
-      mutt_window_move(HelpBarWindow, 0, 0);
-      mutt_paddstr(HelpBarWindow->state.cols, rd->helpstr);
-      mutt_curses_set_color(MT_COLOR_NORMAL);
-    }
-
     if (Resize)
     {
       rd->search_compiled = Resize->search_compiled;
@@ -2265,7 +2255,6 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
   bool first = true;
   int searchctx = 0;
   bool wrapped = false;
-  char helpstr[1024] = { 0 };
 
   struct Menu *pager_menu = NULL;
   int old_PagerIndexLines; /* some people want to resize it while inside the pager */
@@ -2334,27 +2323,6 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
     (rd.line_info[i].syntax)[0].last = -1;
   }
 
-  if (IsEmail(extra))
-  {
-    // Viewing a Mailbox
-#ifdef USE_NNTP
-    if (Context && (Context->mailbox->type == MUTT_NNTP))
-      mutt_compile_help(helpstr, sizeof(helpstr), MENU_PAGER, PagerNewsHelp);
-    else
-#endif
-      mutt_compile_help(helpstr, sizeof(helpstr), MENU_PAGER, PagerNormalHelp);
-  }
-  else
-  {
-    // Viewing Help
-    if (InHelp)
-      mutt_compile_help(helpstr, sizeof(helpstr), MENU_PAGER, PagerHelpHelp);
-    else
-      mutt_compile_help(helpstr, sizeof(helpstr), MENU_PAGER, PagerHelp);
-  }
-
-  rd.helpstr = helpstr;
-
   pager_menu = mutt_menu_new(MENU_PAGER);
   pager_menu->pagelen = extra->win_pager->state.rows;
   pager_menu->win_index = extra->win_pager;
@@ -2363,6 +2331,26 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
   pager_menu->custom_redraw = pager_custom_redraw;
   pager_menu->redraw_data = &rd;
   mutt_menu_push_current(pager_menu);
+
+  if (IsEmail(extra))
+  {
+    // Viewing a Mailbox
+#ifdef USE_NNTP
+    if (Context && (Context->mailbox->type == MUTT_NNTP))
+      extra->win_pager->help_data = PagerNewsHelp;
+    else
+#endif
+      extra->win_pager->help_data = PagerNormalHelp;
+  }
+  else
+  {
+    // Viewing Help
+    if (InHelp)
+      extra->win_pager->help_data = PagerHelpHelp;
+    else
+      extra->win_pager->help_data = PagerHelp;
+  }
+  extra->win_pager->help_menu = MENU_PAGER;
   window_set_focus(extra->win_pager);
 
   while (ch != -1)
@@ -2370,6 +2358,7 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
     mutt_curses_set_cursor(MUTT_CURSOR_INVISIBLE);
 
     pager_custom_redraw(pager_menu);
+    window_redraw(RootWindow, true);
 
     if (C_BrailleFriendly)
     {

--- a/pager.c
+++ b/pager.c
@@ -2363,6 +2363,7 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
   pager_menu->custom_redraw = pager_custom_redraw;
   pager_menu->redraw_data = &rd;
   mutt_menu_push_current(pager_menu);
+  window_set_focus(extra->win_pager);
 
   while (ch != -1)
   {
@@ -3131,6 +3132,7 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         old_PagerIndexLines = C_PagerIndexLines;
 
         mutt_enter_command();
+        window_set_focus(rd.extra->win_pager);
         pager_menu->redraw = REDRAW_FULL;
 
         if (OptNeedResort)

--- a/pattern/dlgpattern.c
+++ b/pattern/dlgpattern.c
@@ -39,7 +39,6 @@
 #include "gui/lib.h"
 #include "mutt.h"
 #include "format_flags.h"
-#include "helpbar.h"
 #include "keymap.h"
 #include "mutt_globals.h"
 #include "mutt_menu.h"
@@ -140,9 +139,6 @@ static struct Menu *create_pattern_menu(void)
 
   // L10N: Pattern completion menu title
   menu->title = _("Patterns");
-  char *helpstr = mutt_mem_malloc(256);
-  menu->help = mutt_compile_help(helpstr, 256, MENU_GENERIC, PatternHelp);
-
   menu->mdata = entries = mutt_mem_calloc(num_entries, sizeof(struct PatternEntry));
   menu->max = num_entries;
 
@@ -257,7 +253,6 @@ static void free_pattern_menu(struct Menu **ptr)
   }
   FREE(&menu->mdata);
 
-  FREE(&menu->help);
   mutt_menu_free(ptr);
 }
 
@@ -271,6 +266,8 @@ bool mutt_ask_pattern(char *buf, size_t buflen)
 {
   struct Menu *menu = create_pattern_menu();
   struct MuttWindow *dlg = dialog_create_simple_index(menu, WT_DLG_PATTERN);
+  dlg->help_data = PatternHelp;
+  dlg->help_menu = MENU_GENERIC;
 
   bool rc = false;
   bool done = false;

--- a/postpone.c
+++ b/postpone.c
@@ -44,7 +44,6 @@
 #include "format_flags.h"
 #include "handler.h"
 #include "hdrline.h"
-#include "helpbar.h"
 #include "keymap.h"
 #include "mutt_globals.h"
 #include "mutt_logging.h"
@@ -225,16 +224,16 @@ static struct Email *select_msg(struct Context *ctx)
 {
   int r = -1;
   bool done = false;
-  char helpstr[1024];
 
   struct Menu *menu = mutt_menu_new(MENU_POSTPONE);
   struct MuttWindow *dlg = dialog_create_simple_index(menu, WT_DLG_POSTPONE);
+  dlg->help_data = PostponeHelp;
+  dlg->help_menu = MENU_POSTPONE;
 
   menu->make_entry = post_make_entry;
   menu->max = ctx->mailbox->msg_count;
   menu->title = _("Postponed Messages");
   menu->mdata = ctx;
-  menu->help = mutt_compile_help(helpstr, sizeof(helpstr), MENU_POSTPONE, PostponeHelp);
   mutt_menu_push_current(menu);
 
   /* The postponed mailbox is setup to have sorting disabled, but the global

--- a/recvattach.c
+++ b/recvattach.c
@@ -46,7 +46,6 @@
 #include "format_flags.h"
 #include "handler.h"
 #include "hdrline.h"
-#include "helpbar.h"
 #include "hook.h"
 #include "init.h"
 #include "keymap.h"
@@ -1545,7 +1544,6 @@ static void attach_collapse(struct AttachCtx *actx, struct Menu *menu)
  */
 void mutt_view_attachments(struct Email *e)
 {
-  char helpstr[1024];
   int op = OP_NULL;
 
   struct Mailbox *m = Context ? Context->mailbox : NULL;
@@ -1561,11 +1559,12 @@ void mutt_view_attachments(struct Email *e)
 
   struct Menu *menu = mutt_menu_new(MENU_ATTACH);
   struct MuttWindow *dlg = dialog_create_simple_index(menu, WT_DLG_ATTACH);
+  dlg->help_data = AttachHelp;
+  dlg->help_menu = MENU_ATTACH;
 
   menu->title = _("Attachments");
   menu->make_entry = attach_make_entry;
   menu->tag = attach_tag;
-  menu->help = mutt_compile_help(helpstr, sizeof(helpstr), MENU_ATTACH, AttachHelp);
   mutt_menu_push_current(menu);
 
   struct AttachCtx *actx = mutt_actx_new();
@@ -1577,6 +1576,7 @@ void mutt_view_attachments(struct Email *e)
   {
     if (op == OP_NULL)
       op = mutt_menu_loop(menu);
+    window_redraw(dlg, true);
     if (!Context)
       return;
     switch (op)

--- a/remailer.c
+++ b/remailer.c
@@ -41,7 +41,6 @@
 #include "gui/lib.h"
 #include "mutt.h"
 #include "format_flags.h"
-#include "helpbar.h"
 #include "keymap.h"
 #include "mutt_globals.h"
 #include "mutt_menu.h"
@@ -584,7 +583,6 @@ void mix_make_chain(struct MuttWindow *win, struct ListHead *chainhead, int cols
   struct Coord *coords = NULL;
 
   struct Menu *menu = NULL;
-  char helpstr[1024];
   bool loop = true;
 
   char *t = NULL;
@@ -616,13 +614,14 @@ void mix_make_chain(struct MuttWindow *win, struct ListHead *chainhead, int cols
 
   menu = mutt_menu_new(MENU_MIX);
   struct MuttWindow *dlg = dialog_create_simple_index(menu, WT_DLG_REMAILER);
+  dlg->help_data = RemailerHelp;
+  dlg->help_menu = MENU_MIX;
 
   menu->max = ttll;
   menu->make_entry = mix_make_entry;
   menu->tag = NULL;
   menu->title = _("Select a remailer chain");
   menu->mdata = type2_list;
-  menu->help = mutt_compile_help(helpstr, sizeof(helpstr), MENU_MIX, RemailerHelp);
   menu->pagelen = MIX_VOFFSET - 1;
   mutt_menu_push_current(menu);
 

--- a/sidebar/sidebar.c
+++ b/sidebar/sidebar.c
@@ -1099,9 +1099,11 @@ void sb_win_init(struct MuttWindow *dlg)
   struct MuttWindow *cont_right =
       mutt_window_new(WT_CONTAINER, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
+  dlg->focus = cont_right;
 
   mutt_window_add_child(cont_right, index_panel);
   mutt_window_add_child(cont_right, pager_panel);
+  cont_right->focus = index_panel;
 
   struct MuttWindow *win_sidebar =
       mutt_window_new(WT_SIDEBAR, MUTT_WIN_ORIENT_HORIZONTAL, MUTT_WIN_SIZE_FIXED,

--- a/test/pattern/dummy.c
+++ b/test/pattern/dummy.c
@@ -33,6 +33,7 @@ struct Buffer;
 struct Email;
 struct EnterState;
 struct Envelope;
+struct Keymap;
 struct Mailbox;
 struct Message;
 struct Pager;
@@ -212,14 +213,18 @@ void mutt_resize_screen(void)
 {
 }
 
-char *mutt_compile_help(char *buf, size_t buflen, enum MenuType menu,
-                        const struct Mapping *items)
-{
-  return NULL;
-}
-
 void mutt_menu_push_current(struct Menu *menu)
 {
+}
+
+int km_expand_key(char *s, size_t len, struct Keymap *map)
+{
+  return 0;
+}
+
+struct Keymap *km_find_func(enum MenuType menu, int func)
+{
+  return NULL;
 }
 
 struct EnterState *mutt_enter_state_new(void)


### PR DESCRIPTION
This PR changes how the Help Bar is generated (one-liner at the top of the screen).

- 29ffcd151 window: define a Window focus
- 3c6c7936c move help data to window
- 61a2eec6d create libhelpbar
- 16da23a1d helpbar: delegate window creation
- 698211edb helpbar: manage own config
- 164da02cd helpbar: add window data
- b600f7275 helpbar: recalc/repaint
- d9e1b07e6 helpbar: add observers
- 5bf245dc4 editor: add help

--------------------------------------------------------------------------------

## Changes

Visually, there are a few small changes:
- Display is tidier when a function isn't bound to a key
- Help Bar works in the Command Line Editor
- Changing a key binding will update the Help Bar

Internally, the code has been restructured to be a passive observer of events.

Before, many parts of the code would be responsible for checking if `$help`
were enabled, generating the help string, padding it and writing it to the
global Window, `HelpBarWindow`.

Now, that is managed by the passive Help Bar Window.
A Window simply adds the help strings to the Window and the Help Bar will do the rest.

In order to know **which** Window is active, we introduce the idea of _focus_.
From the `RootWindow` down, each Window can define one of its children as focussed.

--------------------------------------------------------------------------------

## Anatomy of a Passive Window

The Help Bar Window, only exposes two functions:
- `config_init_helpbar()` - Define the config variable
- `helpbar_create()` - Create the Window

It also defines two Window functions:
- `helpbar_recalc()` - Recalculate the display string
- `helpbar_repaint()` - Display the string

Everything else is controlled by receiving Events.
It observes:

- `NT_BINDING`
  - `NT_BINDING_NEW`
  - `NT_BINDING_DELETED`
  - `NT_BINDING_DELETE_ALL`

Changes to the key bindings cause the Help Bar to set `WA_RECALC`.

- `NT_COLOR`
  - `MT_COLOR_STATUS`

Change to `color status` causes the Help Bar to set `WA_REPAINT`.

- `NT_CONFIG`
  - `$help`

Change to `$help` causes the Help Bar to set `WA_REFLOW` on its parent.

- `NT_WINDOW`
  - `NT_WINDOW_FOCUS`
  - `NT_WINDOW_DELETE`

A change of focus causes the Help Bar to set `WA_RECALC`.
When the Window is deleted, the Help Bar unregisters its observer and cleans up.
(This works as a destuctor)

At the beginning of the next display loop, `window_redraw()` is called.
As necessary, it will:
- Reflow Windows
- Call `recalc()` on Windows
- Call `repaint()` on Windows