### PR TITLE
add docs to config items

### DIFF
--- a/autocrypt/config.c
+++ b/autocrypt/config.c
@@ -43,15 +43,23 @@ char *AutocryptSignAs;     ///< Autocrypt Key id to sign as
 char *AutocryptDefaultKey; ///< Autocrypt default key id (used for postponing messages)
 // clang-format on
 
-// clang-format off
 struct ConfigDef AutocryptVars[] = {
-  { "autocrypt",             DT_BOOL,             &C_Autocrypt,           false },
-  { "autocrypt_acct_format", DT_STRING|R_MENU,    &C_AutocryptAcctFormat, IP "%4n %-30a %20p %10s" },
-  { "autocrypt_dir",         DT_PATH|DT_PATH_DIR, &C_AutocryptDir,        IP "~/.mutt/autocrypt" },
-  { "autocrypt_reply",       DT_BOOL,             &C_AutocryptReply,      true },
-  { NULL, 0, NULL, 0, 0, NULL },
+  // clang-format off
+  { "autocrypt", DT_BOOL, &C_Autocrypt, false, 0, NULL,
+    "Enables the Autocrypt feature"
+  },
+  { "autocrypt_acct_format", DT_STRING|R_MENU, &C_AutocryptAcctFormat, IP "%4n %-30a %20p %10s", 0, NULL,
+    "Format of the autocrypt account menu"
+  },
+  { "autocrypt_dir", DT_PATH|DT_PATH_DIR, &C_AutocryptDir, IP "~/.mutt/autocrypt", 0, NULL,
+    "Location of autocrypt files, including the GPG keyring and SQLite database"
+  },
+  { "autocrypt_reply", DT_BOOL, &C_AutocryptReply, true, 0, NULL,
+    "Replying to an autocrypt email automatically enables autocrypt in the reply"
+  },
+  { NULL, 0, NULL, 0, 0, NULL, NULL },
+  // clang-format on
 };
-// clang-format on
 
 /**
  * config_init_autocrypt - Register autocrypt config variables

--- a/config/dump.c
+++ b/config/dump.c
@@ -113,7 +113,9 @@ void dump_config_neo(struct ConfigSet *cs, struct HashElem *he, struct Buffer *v
 
   if ((flags & CS_DUMP_ONLY_CHANGED) &&
       (!initial || mutt_str_equal(value->data, initial->data)))
+  {
     return;
+  }
 
   if (he->type == DT_SYNONYM)
   {
@@ -121,6 +123,12 @@ void dump_config_neo(struct ConfigSet *cs, struct HashElem *he, struct Buffer *v
     const char *syn = (const char *) cdef->initial;
     fprintf(fp, "# synonym: %s -> %s\n", name, syn);
     return;
+  }
+
+  if (flags & CS_DUMP_SHOW_DOCS)
+  {
+    const struct ConfigDef *cdef = he->data;
+    fprintf(fp, "# %s\n", cdef->docs);
   }
 
   bool show_name = !(flags & CS_DUMP_HIDE_NAME);
@@ -143,6 +151,9 @@ void dump_config_neo(struct ConfigSet *cs, struct HashElem *he, struct Buffer *v
     if (cst)
       fprintf(fp, "# %s %s %s\n", cst->name, name, value->data);
   }
+
+  if (flags & CS_DUMP_SHOW_DOCS)
+    fprintf(fp, "\n");
 }
 
 /**

--- a/config/dump.h
+++ b/config/dump.h
@@ -42,6 +42,7 @@ typedef uint16_t ConfigDumpFlags;         ///< Flags for dump_config(), e.g. #CS
 #define CS_DUMP_SHOW_DISABLED   (1 << 6)  ///< Show disabled config items, too
 #define CS_DUMP_SHOW_SYNONYMS   (1 << 7)  ///< Show synonyms and the config items they're linked to
 #define CS_DUMP_SHOW_DEPRECATED (1 << 8)  ///< Show config items that aren't used any more
+#define CS_DUMP_SHOW_DOCS       (1 << 9)  ///< Show one-liner documentation for the config item
 
 void              dump_config_neo(struct ConfigSet *cs, struct HashElem *he, struct Buffer *value, struct Buffer *initial, ConfigDumpFlags flags, FILE *fp);
 bool              dump_config(struct ConfigSet *cs, ConfigDumpFlags flags, FILE *fp);

--- a/config/set.h
+++ b/config/set.h
@@ -76,6 +76,8 @@ struct ConfigDef
    * @retval #CSR_ERR_INVALID Failure
    */
   int (*validator)(const struct ConfigSet *cs, const struct ConfigDef *cdef, intptr_t value, struct Buffer *err);
+
+  const char *docs; ///< One-liner description
 };
 
 /**

--- a/conn/config.c
+++ b/conn/config.c
@@ -68,54 +68,100 @@ bool          C_UseIpv6;                ///< Config: Lookup IPv6 addresses when 
 #endif
 // clang-format on
 
-// clang-format off
 struct ConfigDef ConnVars[] = {
+  // clang-format off
 #ifdef USE_SSL
-  { "certificate_file",          DT_PATH|DT_PATH_FILE,      &C_CertificateFile,        IP "~/.mutt_certificates" },
+  { "certificate_file", DT_PATH|DT_PATH_FILE, &C_CertificateFile, IP "~/.mutt_certificates", 0, NULL,
+    "File containing trusted certificates"
+  },
 #endif
-  { "connect_timeout",           DT_NUMBER,                 &C_ConnectTimeout,         30 },
+  { "connect_timeout", DT_NUMBER, &C_ConnectTimeout, 30, 0, NULL,
+    "Timeout for making network connections (-1 to wait indefinitely)"
+  },
 #ifdef USE_SSL_OPENSSL
-  { "entropy_file",              DT_PATH|DT_PATH_FILE,      &C_EntropyFile,            0 },
+  { "entropy_file", DT_PATH|DT_PATH_FILE, &C_EntropyFile, 0, 0, NULL,
+    "(ssl) File/device containing random data to initialise SSL"
+  },
 #endif
-  { "preconnect",                DT_STRING,                 &C_Preconnect,             0 },
+  { "preconnect", DT_STRING, &C_Preconnect, 0, 0, NULL,
+    "(socket) External command to run prior to opening a socket"
+  },
 #ifdef USE_SSL
 #ifdef USE_SSL_GNUTLS
-  { "ssl_ca_certificates_file",  DT_PATH|DT_PATH_FILE,      &C_SslCaCertificatesFile,  0 },
+  { "ssl_ca_certificates_file", DT_PATH|DT_PATH_FILE, &C_SslCaCertificatesFile, 0, 0, NULL,
+    "File containing trusted CA certificates"
+  },
 #endif
-  { "ssl_ciphers",               DT_STRING,                 &C_SslCiphers,             0 },
-  { "ssl_client_cert",           DT_PATH|DT_PATH_FILE,      &C_SslClientCert,          0 },
-  { "ssl_force_tls",             DT_BOOL,                   &C_SslForceTls,            false },
+  { "ssl_ciphers", DT_STRING, &C_SslCiphers, 0, 0, NULL,
+    "Ciphers to use when using SSL"
+  },
+  { "ssl_client_cert", DT_PATH|DT_PATH_FILE, &C_SslClientCert, 0, 0, NULL,
+    "File containing client certificates"
+  },
+  { "ssl_force_tls", DT_BOOL, &C_SslForceTls, false, 0, NULL,
+    "(ssl) Require TLS encryption for all connections"
+  },
 #ifdef USE_SSL_GNUTLS
-  { "ssl_min_dh_prime_bits",     DT_NUMBER|DT_NOT_NEGATIVE, &C_SslMinDhPrimeBits,      0 },
+  { "ssl_min_dh_prime_bits", DT_NUMBER|DT_NOT_NEGATIVE, &C_SslMinDhPrimeBits, 0, 0, NULL,
+    "Minimum keysize for Diffie-Hellman key exchange"
+  },
 #endif
-  { "ssl_starttls",              DT_QUAD,                   &C_SslStarttls,            MUTT_YES },
+  { "ssl_starttls", DT_QUAD, &C_SslStarttls, MUTT_YES, 0, NULL,
+    "(ssl) Use STARTTLS on servers advertising the capability"
+  },
 #ifdef USE_SSL_OPENSSL
-  { "ssl_use_sslv2",             DT_BOOL,                   &C_SslUseSslv2,            false },
+  { "ssl_use_sslv2", DT_BOOL, &C_SslUseSslv2, false, 0, NULL,
+    "(ssl) INSECURE: Use SSLv2 for authentication"
+  },
 #endif
-  { "ssl_use_sslv3",             DT_BOOL,                   &C_SslUseSslv3,            false },
-  { "ssl_use_tlsv1",             DT_BOOL,                   &C_SslUseTlsv1,            false },
-  { "ssl_use_tlsv1_1",           DT_BOOL,                   &C_SslUseTlsv11,           false },
-  { "ssl_use_tlsv1_2",           DT_BOOL,                   &C_SslUseTlsv12,           true },
-  { "ssl_use_tlsv1_3",           DT_BOOL,                   &C_SslUseTlsv13,           true },
+  { "ssl_use_sslv3", DT_BOOL, &C_SslUseSslv3, false, 0, NULL,
+    "(ssl) INSECURE: Use SSLv3 for authentication"
+  },
+  { "ssl_use_tlsv1", DT_BOOL, &C_SslUseTlsv1, false, 0, NULL,
+    "(ssl) Use TLSv1 for authentication"
+  },
+  { "ssl_use_tlsv1_1", DT_BOOL, &C_SslUseTlsv11, false, 0, NULL,
+    "(ssl) Use TLSv1.1 for authentication"
+  },
+  { "ssl_use_tlsv1_2", DT_BOOL, &C_SslUseTlsv12, true, 0, NULL,
+    "(ssl) Use TLSv1.2 for authentication"
+  },
+  { "ssl_use_tlsv1_3", DT_BOOL, &C_SslUseTlsv13, true, 0, NULL,
+    "(ssl) Use TLSv1.3 for authentication"
+  },
 #ifdef USE_SSL_OPENSSL
-  { "ssl_usesystemcerts",        DT_BOOL,                   &C_SslUsesystemcerts,      true },
+  { "ssl_usesystemcerts", DT_BOOL, &C_SslUsesystemcerts, true, 0, NULL,
+    "(ssl) Use CA certificates in the system-wide store"
+  },
 #endif
-  { "ssl_verify_dates",          DT_BOOL,                   &C_SslVerifyDates,         true },
-  { "ssl_verify_host",           DT_BOOL,                   &C_SslVerifyHost,          true },
+  { "ssl_verify_dates", DT_BOOL, &C_SslVerifyDates, true, 0, NULL,
+    "(ssl) Verify the dates on the server certificate"
+  },
+  { "ssl_verify_host", DT_BOOL, &C_SslVerifyHost, true, 0, NULL,
+    "(ssl) Verify the server's hostname against the certificate"
+  },
 #ifdef USE_SSL_OPENSSL
 #ifdef HAVE_SSL_PARTIAL_CHAIN
-  { "ssl_verify_partial_chains", DT_BOOL,                   &C_SslVerifyPartialChains, false },
+  { "ssl_verify_partial_chains", DT_BOOL, &C_SslVerifyPartialChains, false, 0, NULL,
+    "(ssl) Allow verification using partial certificate chains"
+  },
 #endif
 #endif
 #endif
-  { "tunnel",                    DT_STRING|DT_COMMAND,      &C_Tunnel,                 0 },
-  { "tunnel_is_secure",          DT_BOOL,                   &C_TunnelIsSecure,         true },
+  { "tunnel", DT_STRING|DT_COMMAND, &C_Tunnel, 0, 0, NULL,
+    "Shell command to establish a tunnel"
+  },
+  { "tunnel_is_secure", DT_BOOL, &C_TunnelIsSecure, true, 0, NULL,
+    "Assume a tunneled connection is secure"
+  },
 #ifdef HAVE_GETADDRINFO
-  { "use_ipv6",                  DT_BOOL,                   &C_UseIpv6,                true },
+  { "use_ipv6", DT_BOOL, &C_UseIpv6, true, 0, NULL,
+    "Lookup IPv6 addresses when making connections"
+  },
 #endif
-  { NULL, 0, NULL, 0, 0, NULL },
+  { NULL, 0, NULL, 0, 0, NULL, NULL },
+  // clang-format on
 };
-// clang-format on
 
 /**
  * config_init_conn - Register conn config variables

--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -18004,6 +18004,12 @@ neomutt -a image.jpg *.png -- address1 address2
               </entry>
             </row>
             <row>
+              <entry>-D -O</entry>
+              <entry>
+                Like <emphasis role="bold">-D</emphasis>, but show one-liner documentation
+              </entry>
+            </row>
+            <row>
               <entry>-D -S</entry>
               <entry>
                 Like <emphasis role="bold">-D</emphasis>, but hide the value of

--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -18133,7 +18133,8 @@ neomutt -a image.jpg *.png -- address1 address2
               <entry>
                 Query a configuration <literal>variable</literal> and print its
                 value to stdout (after the config has been read and any
-                commands executed)
+                commands executed).  Adding <literal>-O</literal> will display
+                one-liner documentation.
               </entry>
             </row>
             <row>

--- a/hcache/config.c
+++ b/hcache/config.c
@@ -48,24 +48,34 @@ bool C_HeaderCacheCompress = false;
 long C_HeaderCachePagesize = 0;
 #endif
 
-// clang-format off
 struct ConfigDef HcacheVars[] = {
-  { "header_cache",                 DT_PATH,                   &C_HeaderCache,               0 },
-  { "header_cache_backend",         DT_STRING,                 &C_HeaderCacheBackend,        0, 0, hcache_validator },
+  // clang-format off
+  { "header_cache", DT_PATH, &C_HeaderCache, 0, 0, NULL,
+    "(hcache) Directory/file for the header cache database"
+  },
+  { "header_cache_backend", DT_STRING, &C_HeaderCacheBackend, 0, 0, hcache_validator,
+    "(hcache) Header cache backend to use"
+  },
 #if defined(USE_HCACHE_COMPRESSION)
-  { "header_cache_compress_level",  DT_NUMBER|DT_NOT_NEGATIVE, &C_HeaderCacheCompressLevel,  1, 0, compress_level_validator },
-  { "header_cache_compress_method", DT_STRING,                 &C_HeaderCacheCompressMethod, 0, 0, compress_method_validator },
-  { "maildir_header_cache_verify",  DT_BOOL,                   &C_MaildirHeaderCacheVerify,  true },
+  { "header_cache_compress_level", DT_NUMBER|DT_NOT_NEGATIVE, &C_HeaderCacheCompressLevel, 1, 0, compress_level_validator,
+    "(hcache) Level of compression for method"
+  },
+  { "header_cache_compress_method", DT_STRING, &C_HeaderCacheCompressMethod, 0, 0, compress_method_validator,
+    "(hcache) Enable generic hcache database compression"
+  },
+  { "maildir_header_cache_verify", DT_BOOL, &C_MaildirHeaderCacheVerify, true, 0, NULL,
+    "(hcache) Check for maildir changes when opening mailbox"
+  },
 #endif
 #if defined(HAVE_QDBM) || defined(HAVE_TC) || defined(HAVE_KC)
-  { "header_cache_compress",     DT_DEPRECATED|DT_BOOL,            &C_HeaderCacheCompress,    false   },
+  { "header_cache_compress", DT_DEPRECATED|DT_BOOL, &C_HeaderCacheCompress, false, 0, NULL, NULL },
 #endif
 #if defined(HAVE_GDBM) || defined(HAVE_BDB)
-  { "header_cache_pagesize",     DT_DEPRECATED|DT_LONG,            &C_HeaderCachePagesize,    0       },
+  { "header_cache_pagesize", DT_DEPRECATED|DT_LONG, &C_HeaderCachePagesize, 0, 0, NULL, NULL },
 #endif
-  { NULL, 0, NULL, 0, 0, NULL },
+  { NULL, 0, NULL, 0, 0, NULL, NULL },
+  // clang-format on
 };
-// clang-format on
 
 /**
  * config_init_hcache - Register hcache config variables

--- a/helpbar/config.c
+++ b/helpbar/config.c
@@ -31,12 +31,14 @@
 #include <stdbool.h>
 #include "config/lib.h"
 
-// clang-format off
 struct ConfigDef HelpbarVars[] = {
-  { "help", DT_BOOL|R_REFLOW, NULL, true },
-  { NULL, 0, NULL, 0, 0, NULL },
+  // clang-format off
+  { "help", DT_BOOL|R_REFLOW, NULL, true, 0, NULL,
+    "Display a help line with common key bindings"
+  },
+  { NULL, 0, NULL, 0, 0, NULL, NULL },
+  // clang-format on
 };
-// clang-format on
 
 /**
  * config_init_helpbar - Register helpbar config variables

--- a/history/config.c
+++ b/history/config.c
@@ -39,15 +39,23 @@ bool  C_HistoryRemoveDups;  ///< Config: Remove duplicate entries from the histo
 short C_SaveHistory;        ///< Config: Number of history entries to save per category
 // clang-format on
 
-// clang-format off
 struct ConfigDef HistoryVars[] = {
-  { "history",             DT_NUMBER|DT_NOT_NEGATIVE, &C_History,           10 },
-  { "history_file",        DT_PATH|DT_PATH_FILE,      &C_HistoryFile,       IP "~/.mutthistory" },
-  { "history_remove_dups", DT_BOOL,                   &C_HistoryRemoveDups, false },
-  { "save_history",        DT_NUMBER|DT_NOT_NEGATIVE, &C_SaveHistory,       0 },
-  { NULL, 0, NULL, 0, 0, NULL },
+  // clang-format off
+  { "history", DT_NUMBER|DT_NOT_NEGATIVE, &C_History, 10, 0, NULL,
+    "Number of history entries to keep in memory per category"
+  },
+  { "history_file", DT_PATH|DT_PATH_FILE, &C_HistoryFile, IP "~/.mutthistory", 0, NULL,
+    "File to save history in"
+  },
+  { "history_remove_dups", DT_BOOL, &C_HistoryRemoveDups, false, 0, NULL,
+    "Remove duplicate entries from the history"
+  },
+  { "save_history", DT_NUMBER|DT_NOT_NEGATIVE, &C_SaveHistory, 0, 0, NULL,
+    "Number of history entries to save per category"
+  },
+  { NULL, 0, NULL, 0, 0, NULL, NULL },
+  // clang-format on
 };
-// clang-format on
 
 /**
  * config_init_history - Register history config variables

--- a/imap/config.c
+++ b/imap/config.c
@@ -58,34 +58,76 @@ bool          C_ImapServernoise;         ///< Config: (imap) Display server warn
 char *        C_ImapUser;                ///< Config: (imap) Username for the IMAP server
 // clang-format on
 
-// clang-format off
 struct ConfigDef ImapVars[] = {
-  { "imap_check_subscribed",      DT_BOOL,                           &C_ImapCheckSubscribed,     false },
-  { "imap_condstore",             DT_BOOL,                           &C_ImapCondstore,           false },
+  // clang-format off
+  { "imap_check_subscribed", DT_BOOL, &C_ImapCheckSubscribed, false, 0, NULL,
+    "(imap) When opening a mailbox, ask the server for a list of subscribed folders"
+  },
+  { "imap_condstore", DT_BOOL, &C_ImapCondstore, false, 0, NULL,
+    "(imap) Enable the CONDSTORE extension"
+  },
 #ifdef USE_ZLIB
-  { "imap_deflate",               DT_BOOL,                           &C_ImapDeflate,             true },
+  { "imap_deflate", DT_BOOL, &C_ImapDeflate, true, 0, NULL,
+    "(imap) Compress network traffic"
+  },
 #endif
-  { "imap_authenticators",        DT_SLIST|SLIST_SEP_COLON,          &C_ImapAuthenticators,      0 },
-  { "imap_delim_chars",           DT_STRING,                         &C_ImapDelimChars,          IP "/." },
-  { "imap_fetch_chunk_size",      DT_LONG|DT_NOT_NEGATIVE,           &C_ImapFetchChunkSize,      0 },
-  { "imap_headers",               DT_STRING|R_INDEX,                 &C_ImapHeaders,             0 },
-  { "imap_idle",                  DT_BOOL,                           &C_ImapIdle,                false },
-  { "imap_login",                 DT_STRING|DT_SENSITIVE,            &C_ImapLogin,               0 },
-  { "imap_oauth_refresh_command", DT_STRING|DT_COMMAND|DT_SENSITIVE, &C_ImapOauthRefreshCommand, 0 },
-  { "imap_pass",                  DT_STRING|DT_SENSITIVE,            &C_ImapPass,                0 },
-  { "imap_pipeline_depth",        DT_NUMBER|DT_NOT_NEGATIVE,         &C_ImapPipelineDepth,       15 },
-  { "imap_rfc5161",               DT_BOOL,                           &C_ImapRfc5161,             true },
-  { "imap_servernoise",           DT_BOOL,                           &C_ImapServernoise,         true },
-  { "imap_keepalive",             DT_NUMBER|DT_NOT_NEGATIVE,         &C_ImapKeepalive,           300 },
-  { "imap_list_subscribed",       DT_BOOL,                           &C_ImapListSubscribed,      false },
-  { "imap_passive",               DT_BOOL,                           &C_ImapPassive,             true },
-  { "imap_peek",                  DT_BOOL,                           &C_ImapPeek,                true },
-  { "imap_poll_timeout",          DT_NUMBER|DT_NOT_NEGATIVE,         &C_ImapPollTimeout,         15 },
-  { "imap_qresync",               DT_BOOL,                           &C_ImapQresync,             false },
-  { "imap_user",                  DT_STRING|DT_SENSITIVE,            &C_ImapUser,                0 },
-  { NULL, 0, NULL, 0, 0, NULL },
+  { "imap_authenticators", DT_SLIST|SLIST_SEP_COLON, &C_ImapAuthenticators, 0, 0, NULL,
+    "(imap) List of allowed IMAP authentication methods"
+  },
+  { "imap_delim_chars", DT_STRING, &C_ImapDelimChars, IP "/.", 0, NULL,
+    "(imap) Characters that denote separators in IMAP folders"
+  },
+  { "imap_fetch_chunk_size", DT_LONG|DT_NOT_NEGATIVE, &C_ImapFetchChunkSize, 0, 0, NULL,
+    "(imap) Download headers in blocks of this size"
+  },
+  { "imap_headers", DT_STRING|R_INDEX, &C_ImapHeaders, 0, 0, NULL,
+    "(imap) Additional email headers to download when getting index"
+  },
+  { "imap_idle", DT_BOOL, &C_ImapIdle, false, 0, NULL,
+    "(imap) Use the IMAP IDLE extension to check for new mail"
+  },
+  { "imap_login", DT_STRING|DT_SENSITIVE, &C_ImapLogin, 0, 0, NULL,
+    "(imap) Login name for the IMAP server (defaults to #C_ImapUser)"
+  },
+  { "imap_oauth_refresh_command", DT_STRING|DT_COMMAND|DT_SENSITIVE, &C_ImapOauthRefreshCommand, 0, 0, NULL,
+    "(imap) External command to generate OAUTH refresh token"
+  },
+  { "imap_pass", DT_STRING|DT_SENSITIVE, &C_ImapPass, 0, 0, NULL,
+    "(imap) Password for the IMAP server"
+  },
+  { "imap_pipeline_depth", DT_NUMBER|DT_NOT_NEGATIVE, &C_ImapPipelineDepth, 15, 0, NULL,
+    "(imap) Number of IMAP commands that may be queued up"
+  },
+  { "imap_rfc5161", DT_BOOL, &C_ImapRfc5161, true, 0, NULL,
+    "(imap) Use the IMAP ENABLE extension to select capabilities"
+  },
+  { "imap_servernoise", DT_BOOL, &C_ImapServernoise, true, 0, NULL,
+    "(imap) Display server warnings as error messages"
+  },
+  { "imap_keepalive", DT_NUMBER|DT_NOT_NEGATIVE, &C_ImapKeepalive, 300, 0, NULL,
+    "(imap) Time to wait before polling an open IMAP connection"
+  },
+  { "imap_list_subscribed", DT_BOOL, &C_ImapListSubscribed, false, 0, NULL,
+    "(imap) When browsing a mailbox, only display subscribed folders"
+  },
+  { "imap_passive", DT_BOOL, &C_ImapPassive, true, 0, NULL,
+    "(imap) Reuse an existing IMAP connection to check for new mail"
+  },
+  { "imap_peek", DT_BOOL, &C_ImapPeek, true, 0, NULL,
+    "(imap) Don't mark messages as read when fetching them from the server"
+  },
+  { "imap_poll_timeout", DT_NUMBER|DT_NOT_NEGATIVE, &C_ImapPollTimeout, 15, 0, NULL,
+    "(imap) Maximum time to wait for a server response"
+  },
+  { "imap_qresync", DT_BOOL, &C_ImapQresync, false, 0, NULL,
+    "(imap) Enable the QRESYNC extension"
+  },
+  { "imap_user", DT_STRING|DT_SENSITIVE, &C_ImapUser, 0, 0, NULL,
+    "(imap) Username for the IMAP server"
+  },
+  { NULL, 0, NULL, 0, 0, NULL, NULL },
+  // clang-format on
 };
-// clang-format on
 
 /**
  * config_init_imap - Register imap config variables

--- a/init.c
+++ b/init.c
@@ -1067,11 +1067,12 @@ enum CommandResult mutt_parse_rc_line(const char *line, struct Buffer *err)
 
 /**
  * mutt_query_variables - Implement the -Q command line flag
- * @param queries List of query strings
+ * @param queries   List of query strings
+ * @param show_docs If true, show one-liner docs for the config item
  * @retval 0 Success, all queries exist
  * @retval 1 Error
  */
-int mutt_query_variables(struct ListHead *queries)
+int mutt_query_variables(struct ListHead *queries, bool show_docs)
 {
   struct Buffer value = mutt_buffer_make(256);
   struct Buffer tmp = mutt_buffer_make(256);
@@ -1107,7 +1108,7 @@ int mutt_query_variables(struct ListHead *queries)
       mutt_buffer_strcpy(&value, tmp.data);
     }
 
-    dump_config_neo(NeoMutt->sub->cs, he, &value, NULL, CS_DUMP_NO_FLAGS, stdout);
+    dump_config_neo(NeoMutt->sub->cs, he, &value, NULL, show_docs ? CS_DUMP_SHOW_DOCS : CS_DUMP_NO_FLAGS, stdout);
   }
 
   mutt_buffer_dealloc(&value);

--- a/init.h
+++ b/init.h
@@ -62,7 +62,7 @@ bool                  mutt_nm_tag_complete   (char *buf, size_t buflen, int numt
 void                  mutt_opts_free         (void);
 enum CommandResult    mutt_parse_rc_buffer   (struct Buffer *line, struct Buffer *token, struct Buffer *err);
 enum CommandResult    mutt_parse_rc_line     (const char *line, struct Buffer *err);
-int                   mutt_query_variables   (struct ListHead *queries);
+int                   mutt_query_variables   (struct ListHead *queries, bool show_docs);
 int                   mutt_var_value_complete(char *buf, size_t buflen, int pos);
 
 #endif /* MUTT_INIT_H */

--- a/maildir/config.c
+++ b/maildir/config.c
@@ -42,18 +42,32 @@ char *C_MhSeqReplied;    ///< Config: MH sequence to tag replied messages
 char *C_MhSeqUnseen;     ///< Config: MH sequence for unseen messages
 // clang-format on
 
-// clang-format off
 struct ConfigDef MaildirVars[] = {
-  { "check_new",         DT_BOOL,   &C_CheckNew,        true },
-  { "maildir_check_cur", DT_BOOL,   &C_MaildirCheckCur, false },
-  { "maildir_trash",     DT_BOOL,   &C_MaildirTrash,    false },
-  { "mh_purge",          DT_BOOL,   &C_MhPurge,         false },
-  { "mh_seq_flagged",    DT_STRING, &C_MhSeqFlagged,    IP "flagged" },
-  { "mh_seq_replied",    DT_STRING, &C_MhSeqReplied,    IP "replied" },
-  { "mh_seq_unseen",     DT_STRING, &C_MhSeqUnseen,     IP "unseen" },
-  { NULL, 0, NULL, 0, 0, NULL },
+  // clang-format off
+  { "check_new", DT_BOOL, &C_CheckNew, true, 0, NULL,
+    "(maildir,mh) Check for new mail while the mailbox is open"
+  },
+  { "maildir_check_cur", DT_BOOL, &C_MaildirCheckCur, false, 0, NULL,
+    "Check both 'new' and 'cur' directories for new mail"
+  },
+  { "maildir_trash", DT_BOOL, &C_MaildirTrash, false, 0, NULL,
+    "Use the maildir 'trashed' flag, rather than deleting"
+  },
+  { "mh_purge", DT_BOOL, &C_MhPurge, false, 0, NULL,
+    "Really delete files in MH mailboxes"
+  },
+  { "mh_seq_flagged", DT_STRING, &C_MhSeqFlagged, IP "flagged", 0, NULL,
+    "MH sequence for flagged message"
+  },
+  { "mh_seq_replied", DT_STRING, &C_MhSeqReplied, IP "replied", 0, NULL,
+    "MH sequence to tag replied messages"
+  },
+  { "mh_seq_unseen", DT_STRING, &C_MhSeqUnseen, IP "unseen", 0, NULL,
+    "MH sequence for unseen messages"
+  },
+  { NULL, 0, NULL, 0, 0, NULL, NULL },
+  // clang-format on
 };
-// clang-format on
 
 /**
  * config_init_maildir - Register maildir config variables

--- a/main.c
+++ b/main.c
@@ -199,6 +199,7 @@ static void usage(void)
          "  -p            Resume a prior postponed message, if any\n"
          "  -Q <variable> Query a configuration variable and print its value to stdout\n"
          "                (after the config has been read and any commands executed)\n"
+         "                Add -O for one-liner documentation\n"
          "  -R            Open mailbox in read-only mode\n"
          "  -s <subject>  Specify a subject (must be enclosed in quotes if it has spaces)\n"
          "  -v            Print the NeoMutt version and compile-time definitions and exit\n"
@@ -716,7 +717,7 @@ int main(int argc, char *argv[], char *envp[])
 
   if (!STAILQ_EMPTY(&queries))
   {
-    rc = mutt_query_variables(&queries);
+    rc = mutt_query_variables(&queries, one_liner);
     goto main_curses;
   }
 

--- a/main.c
+++ b/main.c
@@ -179,6 +179,7 @@ static void usage(void)
          "  -b <address>  Specify a blind carbon copy (Bcc) recipient\n"
          "  -c <address>  Specify a carbon copy (Cc) recipient\n"
          "  -D            Dump all config variables as 'name=value' pairs to stdout\n"
+         "  -D -O         Like -D, but show one-liner documentation\n"
          "  -D -S         Like -D, but hide the value of sensitive variables\n"
          "  -d <level>    Log debugging output to a file (default is \"~/.neomuttdebug0\")\n"
          "                The level can range from 1-5 and affects verbosity\n"
@@ -383,6 +384,7 @@ int main(int argc, char *argv[], char *envp[])
   int i;
   bool explicit_folder = false;
   bool dump_variables = false;
+  bool one_liner = false;
   bool hide_sensitive = false;
   bool batch_mode = false;
   bool edit_infile = false;
@@ -434,7 +436,7 @@ int main(int argc, char *argv[], char *envp[])
     }
 
     /* USE_NNTP 'g:G' */
-    i = getopt(argc, argv, "+A:a:Bb:F:f:c:Dd:l:Ee:g:GH:i:hm:npQ:RSs:TvxyzZ");
+    i = getopt(argc, argv, "+A:a:Bb:F:f:c:Dd:l:Ee:g:GH:i:hm:nOpQ:RSs:TvxyzZ");
     if (i != EOF)
     {
       switch (i)
@@ -495,6 +497,9 @@ int main(int argc, char *argv[], char *envp[])
           break;
         case 'n':
           flags |= MUTT_CLI_NOSYSRC;
+          break;
+        case 'O':
+          one_liner = true;
           break;
         case 'p':
           sendflags |= SEND_POSTPONED;
@@ -717,7 +722,12 @@ int main(int argc, char *argv[], char *envp[])
 
   if (dump_variables)
   {
-    dump_config(cs, hide_sensitive ? CS_DUMP_HIDE_SENSITIVE : CS_DUMP_NO_FLAGS, stdout);
+    ConfigDumpFlags cdflags = CS_DUMP_NO_FLAGS;
+    if (hide_sensitive)
+      cdflags |= CS_DUMP_HIDE_SENSITIVE;
+    if (one_liner)
+      cdflags |= CS_DUMP_SHOW_DOCS;
+    dump_config(cs, cdflags, stdout);
     goto main_ok; // TEST18: neomutt -D
   }
 

--- a/mbox/config.c
+++ b/mbox/config.c
@@ -35,12 +35,14 @@
 bool C_CheckMboxSize; ///< Config: (mbox,mmdf) Use mailbox size as an indicator of new mail
 // clang-format on
 
-// clang-format off
 struct ConfigDef MboxVars[] = {
-  { "check_mbox_size", DT_BOOL, &C_CheckMboxSize, false },
-  { NULL, 0, NULL, 0, 0, NULL },
+  // clang-format off
+  { "check_mbox_size", DT_BOOL, &C_CheckMboxSize, false, 0, NULL,
+    "(mbox,mmdf) Use mailbox size as an indicator of new mail"
+  },
+  { NULL, 0, NULL, 0, 0, NULL, NULL },
+  // clang-format on
 };
-// clang-format on
 
 /**
  * config_init_mbox - Register mbox config variables

--- a/mutt_config.c
+++ b/mutt_config.c
@@ -74,228 +74,618 @@
 char *C_Escape = NULL;
 bool C_IgnoreLinearWhiteSpace = false;
 
-// clang-format off
 struct ConfigDef MainVars[] = {
-  { "abort_backspace", DT_BOOL, &C_AbortBackspace, true },
-  { "abort_key", DT_STRING|DT_NOT_EMPTY, &C_AbortKey, IP "\007" },
-  { "alias_file", DT_PATH|DT_PATH_FILE, &C_AliasFile, IP "~/.neomuttrc" },
-  { "alias_format", DT_STRING|DT_NOT_EMPTY, &C_AliasFormat, IP "%3n %f%t %-15a %-56r | %c" },
-  { "allow_ansi", DT_BOOL, &C_AllowAnsi, false },
-  { "arrow_cursor", DT_BOOL|R_MENU, &C_ArrowCursor, false },
-  { "arrow_string", DT_STRING|DT_NOT_EMPTY, &C_ArrowString, IP "->" },
-  { "ascii_chars", DT_BOOL|R_INDEX|R_PAGER, &C_AsciiChars, false },
-  { "askbcc", DT_BOOL, &C_Askbcc, false },
-  { "askcc", DT_BOOL, &C_Askcc, false },
-  { "assumed_charset", DT_STRING, &C_AssumedCharset, 0, 0, charset_validator },
-  { "attach_format", DT_STRING|DT_NOT_EMPTY, &C_AttachFormat, IP "%u%D%I %t%4n %T%.40d%> [%.7m/%.10M, %.6e%?C?, %C?, %s] " },
-  { "attach_save_dir", DT_PATH|DT_PATH_DIR, &C_AttachSaveDir, IP "./" },
-  { "attach_save_without_prompting", DT_BOOL, &C_AttachSaveWithoutPrompting, false },
-  { "attach_sep", DT_STRING, &C_AttachSep, IP "\n" },
-  { "attach_split", DT_BOOL, &C_AttachSplit, true },
-  { "attribution", DT_STRING, &C_Attribution, IP "On %d, %n wrote:" },
-  { "attribution_locale", DT_STRING, &C_AttributionLocale, 0 },
-  { "auto_subscribe", DT_BOOL, &C_AutoSubscribe, false },
-  { "auto_tag", DT_BOOL, &C_AutoTag, false },
-  { "autoedit", DT_BOOL, &C_Autoedit, false },
-  { "beep", DT_BOOL, &C_Beep, true },
-  { "beep_new", DT_BOOL, &C_BeepNew, false },
-  { "bounce", DT_QUAD, &C_Bounce, MUTT_ASKYES },
-  { "braille_friendly", DT_BOOL, &C_BrailleFriendly, false },
-  { "browser_abbreviate_mailboxes", DT_BOOL, &C_BrowserAbbreviateMailboxes, true },
-  { "change_folder_next", DT_BOOL, &C_ChangeFolderNext, false },
-  { "charset", DT_STRING|DT_NOT_EMPTY, &C_Charset, 0, 0, charset_validator },
-  { "collapse_all", DT_BOOL, &C_CollapseAll, false },
-  { "collapse_flagged", DT_BOOL, &C_CollapseFlagged, true },
-  { "collapse_unread", DT_BOOL, &C_CollapseUnread, true },
-  { "compose_format", DT_STRING|R_MENU, &C_ComposeFormat, IP "-- NeoMutt: Compose  [Approx. msg size: %l   Atts: %a]%>-" },
-  { "config_charset", DT_STRING, &C_ConfigCharset, 0, 0, charset_validator },
-  { "confirmappend", DT_BOOL, &C_Confirmappend, true },
-  { "confirmcreate", DT_BOOL, &C_Confirmcreate, true },
-  { "copy", DT_QUAD, &C_Copy, MUTT_YES },
-  { "copy_decode_weed", DT_BOOL, &C_CopyDecodeWeed, false },
-  { "crypt_chars", DT_MBTABLE|R_INDEX|R_PAGER, &C_CryptChars, IP "SPsK " },
-  { "date_format", DT_STRING|DT_NOT_EMPTY|R_MENU, &C_DateFormat, IP "!%a, %b %d, %Y at %I:%M:%S%p %Z" },
-  { "debug_file", DT_PATH|DT_PATH_FILE, &C_DebugFile, IP "~/.neomuttdebug" },
-  { "debug_level", DT_NUMBER, &C_DebugLevel, 0, 0, level_validator },
-  { "default_hook", DT_STRING, &C_DefaultHook, IP "~f %s !~P | (~P ~C %s)" },
-  { "delete", DT_QUAD, &C_Delete, MUTT_ASKYES },
-  { "delete_untag", DT_BOOL, &C_DeleteUntag, true },
-  { "digest_collapse", DT_BOOL, &C_DigestCollapse, true },
-  { "display_filter", DT_STRING|DT_COMMAND|R_PAGER, &C_DisplayFilter, 0 },
-  { "duplicate_threads", DT_BOOL|R_RESORT|R_RESORT_INIT|R_INDEX, &C_DuplicateThreads, true, 0, pager_validator },
-  { "edit_headers", DT_BOOL, &C_EditHeaders, false },
-  { "editor", DT_STRING|DT_NOT_EMPTY|DT_COMMAND, &C_Editor, IP "vi" },
-  { "flag_chars", DT_MBTABLE|R_INDEX|R_PAGER, &C_FlagChars, IP "*!DdrONon- " },
-  { "flag_safe", DT_BOOL, &C_FlagSafe, false },
-  { "folder", DT_STRING|DT_MAILBOX, &C_Folder, IP "~/Mail" },
-  { "folder_format", DT_STRING|DT_NOT_EMPTY|R_MENU, &C_FolderFormat, IP "%2C %t %N %F %2l %-8.8u %-8.8g %8s %d %i" },
-  { "force_name", DT_BOOL, &C_ForceName, false },
-  { "forward_attachments", DT_QUAD, &C_ForwardAttachments, MUTT_ASKYES },
-  { "forward_decode", DT_BOOL, &C_ForwardDecode, true },
-  { "forward_quote", DT_BOOL, &C_ForwardQuote, false },
-  { "from", DT_ADDRESS, &C_From, 0 },
-  { "from_chars", DT_MBTABLE|R_INDEX|R_PAGER, &C_FromChars, 0 },
-  { "gecos_mask", DT_REGEX, &C_GecosMask, IP "^[^,]*" },
-  { "header", DT_BOOL, &C_Header, false },
-  { "header_color_partial", DT_BOOL|R_PAGER_FLOW, &C_HeaderColorPartial, false },
-  { "hidden_tags", DT_SLIST|SLIST_SEP_COMMA, &C_HiddenTags, IP "unread,draft,flagged,passed,replied,attachment,signed,encrypted" },
-  { "hide_limited", DT_BOOL|R_TREE|R_INDEX, &C_HideLimited, false },
-  { "hide_missing", DT_BOOL|R_TREE|R_INDEX, &C_HideMissing, true },
-  { "hide_thread_subject", DT_BOOL|R_TREE|R_INDEX, &C_HideThreadSubject, true },
-  { "hide_top_limited", DT_BOOL|R_TREE|R_INDEX, &C_HideTopLimited, false },
-  { "hide_top_missing", DT_BOOL|R_TREE|R_INDEX, &C_HideTopMissing, true },
-  { "honor_disposition", DT_BOOL, &C_HonorDisposition, false },
-  { "hostname", DT_STRING, &C_Hostname, 0 },
+  // clang-format off
+  { "abort_backspace", DT_BOOL, &C_AbortBackspace, true, 0, NULL,
+    "Hitting backspace against an empty prompt aborts the prompt"
+  },
+  { "abort_key", DT_STRING|DT_NOT_EMPTY, &C_AbortKey, IP "\007", 0, NULL,
+    "String representation of key to abort prompts"
+  },
+  { "alias_file", DT_PATH|DT_PATH_FILE, &C_AliasFile, IP "~/.neomuttrc", 0, NULL,
+    "Save new aliases to this file"
+  },
+  { "alias_format", DT_STRING|DT_NOT_EMPTY, &C_AliasFormat, IP "%3n %f%t %-15a %-56r | %c", 0, NULL,
+    "printf-like format string for the alias menu"
+  },
+  { "allow_ansi", DT_BOOL, &C_AllowAnsi, false, 0, NULL,
+    "Allow ANSI colour codes in rich text messages"
+  },
+  { "arrow_cursor", DT_BOOL|R_MENU, &C_ArrowCursor, false, 0, NULL,
+    "Use an arrow '->' instead of highlighting in the index"
+  },
+  { "arrow_string", DT_STRING|DT_NOT_EMPTY, &C_ArrowString, IP "->", 0, NULL,
+    "Use an custom string for arrow_cursor"
+  },
+  { "ascii_chars", DT_BOOL|R_INDEX|R_PAGER, &C_AsciiChars, false, 0, NULL,
+    "Use plain ASCII characters, when drawing email threads"
+  },
+  { "askbcc", DT_BOOL, &C_Askbcc, false, 0, NULL,
+    "Ask the user for the blind-carbon-copy recipients"
+  },
+  { "askcc", DT_BOOL, &C_Askcc, false, 0, NULL,
+    "Ask the user for the carbon-copy recipients"
+  },
+  { "assumed_charset", DT_STRING, &C_AssumedCharset, 0, 0, charset_validator,
+    "If a message is missing a character set, assume this character set"
+  },
+  { "attach_format", DT_STRING|DT_NOT_EMPTY, &C_AttachFormat, IP "%u%D%I %t%4n %T%.40d%> [%.7m/%.10M, %.6e%?C?, %C?, %s] ", 0, NULL,
+    "printf-like format string for the attachment menu"
+  },
+  { "attach_save_dir", DT_PATH|DT_PATH_DIR, &C_AttachSaveDir, IP "./", 0, NULL,
+    "Default directory where attachments are saved"
+  },
+  { "attach_save_without_prompting", DT_BOOL, &C_AttachSaveWithoutPrompting, false, 0, NULL,
+    "If true, then don't prompt to save"
+  },
+  { "attach_sep", DT_STRING, &C_AttachSep, IP "\n", 0, NULL,
+    "Separator to add between saved/printed/piped attachments"
+  },
+  { "attach_split", DT_BOOL, &C_AttachSplit, true, 0, NULL,
+    "Save/print/pipe tagged messages individually"
+  },
+  { "attribution", DT_STRING, &C_Attribution, IP "On %d, %n wrote:", 0, NULL,
+    "Message to start a reply, 'On DATE, PERSON wrote:'"
+  },
+  { "attribution_locale", DT_STRING, &C_AttributionLocale, 0, 0, NULL,
+    "Locale for dates in the attribution message"
+  },
+  { "auto_subscribe", DT_BOOL, &C_AutoSubscribe, false, 0, NULL,
+    "Automatically check if the user is subscribed to a mailing list"
+  },
+  { "auto_tag", DT_BOOL, &C_AutoTag, false, 0, NULL,
+    "Automatically apply actions to all tagged messages"
+  },
+  { "autoedit", DT_BOOL, &C_Autoedit, false, 0, NULL,
+    "Skip the initial compose menu and edit the email"
+  },
+  { "beep", DT_BOOL, &C_Beep, true, 0, NULL,
+    "Make a noise when an error occurs"
+  },
+  { "beep_new", DT_BOOL, &C_BeepNew, false, 0, NULL,
+    "Make a noise when new mail arrives"
+  },
+  { "bounce", DT_QUAD, &C_Bounce, MUTT_ASKYES, 0, NULL,
+    "Confirm before bouncing a message"
+  },
+  { "braille_friendly", DT_BOOL, &C_BrailleFriendly, false, 0, NULL,
+    "Move the cursor to the beginning of the line"
+  },
+  { "browser_abbreviate_mailboxes", DT_BOOL, &C_BrowserAbbreviateMailboxes, true, 0, NULL,
+    "Abbreviate mailboxes using '~' and '=' in the browser"
+  },
+  { "change_folder_next", DT_BOOL, &C_ChangeFolderNext, false, 0, NULL,
+    "Suggest the next folder, rather than the first when using '<change-folder>'"
+  },
+  { "charset", DT_STRING|DT_NOT_EMPTY, &C_Charset, 0, 0, charset_validator,
+    "Default character set for displaying text on screen"
+  },
+  { "collapse_all", DT_BOOL, &C_CollapseAll, false, 0, NULL,
+    "Collapse all threads when entering a folder"
+  },
+  { "collapse_flagged", DT_BOOL, &C_CollapseFlagged, true, 0, NULL,
+    "Prevent the collapse of threads with flagged emails"
+  },
+  { "collapse_unread", DT_BOOL, &C_CollapseUnread, true, 0, NULL,
+    "Prevent the collapse of threads with unread emails"
+  },
+  { "compose_format", DT_STRING|R_MENU, &C_ComposeFormat, IP "-- NeoMutt: Compose  [Approx. msg size: %l   Atts: %a]%>-", 0, NULL,
+    "printf-like format string for the Compose panel's status bar"
+  },
+  { "config_charset", DT_STRING, &C_ConfigCharset, 0, 0, charset_validator,
+    "Character set that the config files are in"
+  },
+  { "confirmappend", DT_BOOL, &C_Confirmappend, true, 0, NULL,
+    "Confirm before appending emails to a mailbox"
+  },
+  { "confirmcreate", DT_BOOL, &C_Confirmcreate, true, 0, NULL,
+    "Confirm before creating a new mailbox"
+  },
+  { "copy", DT_QUAD, &C_Copy, MUTT_YES, 0, NULL,
+    "Save outgoing emails to $record"
+  },
+  { "copy_decode_weed", DT_BOOL, &C_CopyDecodeWeed, false, 0, NULL,
+    "Controls whether to weed headers when copying or saving emails"
+  },
+  { "crypt_chars", DT_MBTABLE|R_INDEX|R_PAGER, &C_CryptChars, IP "SPsK ", 0, NULL,
+    "User-configurable crypto flags: signed, encrypted etc."
+  },
+  { "date_format", DT_STRING|DT_NOT_EMPTY|R_MENU, &C_DateFormat, IP "!%a, %b %d, %Y at %I:%M:%S%p %Z", 0, NULL,
+    "strftime format string for the `%d` expando"
+  },
+  { "debug_file", DT_PATH|DT_PATH_FILE, &C_DebugFile, IP "~/.neomuttdebug", 0, NULL,
+    "File to save debug logs"
+  },
+  { "debug_level", DT_NUMBER, &C_DebugLevel, 0, 0, level_validator,
+    "Logging level for debug logs"
+  },
+  { "default_hook", DT_STRING, &C_DefaultHook, IP "~f %s !~P | (~P ~C %s)", 0, NULL,
+    "Pattern to use for hooks that only have a simple regex"
+  },
+  { "delete", DT_QUAD, &C_Delete, MUTT_ASKYES, 0, NULL,
+    "Really delete messages, when the mailbox is closed"
+  },
+  { "delete_untag", DT_BOOL, &C_DeleteUntag, true, 0, NULL,
+    "Untag messages when they are marked for deletion"
+  },
+  { "digest_collapse", DT_BOOL, &C_DigestCollapse, true, 0, NULL,
+    "Hide the subparts of a multipart/digest"
+  },
+  { "display_filter", DT_STRING|DT_COMMAND|R_PAGER, &C_DisplayFilter, 0, 0, NULL,
+    "External command to pre-process an email before display"
+  },
+  { "duplicate_threads", DT_BOOL|R_RESORT|R_RESORT_INIT|R_INDEX, &C_DuplicateThreads, true, 0, pager_validator,
+    "Highlight messages with duplicated message IDs"
+  },
+  { "edit_headers", DT_BOOL, &C_EditHeaders, false, 0, NULL,
+    "Let the user edit the email headers whilst editing an email"
+  },
+  { "editor", DT_STRING|DT_NOT_EMPTY|DT_COMMAND, &C_Editor, IP "vi", 0, NULL,
+    "External command to use as an email editor"
+  },
+  { "flag_chars", DT_MBTABLE|R_INDEX|R_PAGER, &C_FlagChars, IP "*!DdrONon- ", 0, NULL,
+    "User-configurable index flags: tagged, new, etc"
+  },
+  { "flag_safe", DT_BOOL, &C_FlagSafe, false, 0, NULL,
+    "Protect flagged messages from deletion"
+  },
+  { "folder", DT_STRING|DT_MAILBOX, &C_Folder, IP "~/Mail", 0, NULL,
+    "Base folder for a set of mailboxes"
+  },
+  { "folder_format", DT_STRING|DT_NOT_EMPTY|R_MENU, &C_FolderFormat, IP "%2C %t %N %F %2l %-8.8u %-8.8g %8s %d %i", 0, NULL,
+    "printf-like format string for the browser's display of folders"
+  },
+  { "force_name", DT_BOOL, &C_ForceName, false, 0, NULL,
+    "Save outgoing mail in a folder of their name"
+  },
+  { "forward_attachments", DT_QUAD, &C_ForwardAttachments, MUTT_ASKYES, 0, NULL,
+    "Forward attachments when forwarding a message"
+  },
+  { "forward_decode", DT_BOOL, &C_ForwardDecode, true, 0, NULL,
+    "Decode the message when forwarding it"
+  },
+  { "forward_quote", DT_BOOL, &C_ForwardQuote, false, 0, NULL,
+    "Automatically quote a forwarded message using #C_IndentString"
+  },
+  { "from", DT_ADDRESS, &C_From, 0, 0, NULL,
+    "Default 'From' address to use, if isn't otherwise set"
+  },
+  { "from_chars", DT_MBTABLE|R_INDEX|R_PAGER, &C_FromChars, 0, 0, NULL,
+    "User-configurable index flags: to address, cc address, etc"
+  },
+  { "gecos_mask", DT_REGEX, &C_GecosMask, IP "^[^,]*", 0, NULL,
+    "Regex for parsing GECOS field of /etc/passwd"
+  },
+  { "header", DT_BOOL, &C_Header, false, 0, NULL,
+    "Include the message headers in the reply email (Weed applies)"
+  },
+  { "header_color_partial", DT_BOOL|R_PAGER_FLOW, &C_HeaderColorPartial, false, 0, NULL,
+    "Only colour the part of the header matching the regex"
+  },
+  { "hidden_tags", DT_SLIST|SLIST_SEP_COMMA, &C_HiddenTags, IP "unread,draft,flagged,passed,replied,attachment,signed,encrypted", 0, NULL,
+    "Tags that shouldn't be displayed on screen"
+  },
+  { "hide_limited", DT_BOOL|R_TREE|R_INDEX, &C_HideLimited, false, 0, NULL,
+    "Don't indicate hidden messages, in the thread tree"
+  },
+  { "hide_missing", DT_BOOL|R_TREE|R_INDEX, &C_HideMissing, true, 0, NULL,
+    "Don't indicate missing messages, in the thread tree"
+  },
+  { "hide_thread_subject", DT_BOOL|R_TREE|R_INDEX, &C_HideThreadSubject, true, 0, NULL,
+    "Hide subjects that are similar to that of the parent message"
+  },
+  { "hide_top_limited", DT_BOOL|R_TREE|R_INDEX, &C_HideTopLimited, false, 0, NULL,
+    "Don't indicate hidden top message, in the thread tree"
+  },
+  { "hide_top_missing", DT_BOOL|R_TREE|R_INDEX, &C_HideTopMissing, true, 0, NULL,
+    "Don't indicate missing top message, in the thread tree"
+  },
+  { "honor_disposition", DT_BOOL, &C_HonorDisposition, false, 0, NULL,
+    "Don't display MIME parts inline if they have a disposition of 'attachment'"
+  },
+  { "hostname", DT_STRING, &C_Hostname, 0, 0, NULL,
+    "Fully-qualified domain name of this machine"
+  },
 #ifdef HAVE_LIBIDN
-  { "idn_decode", DT_BOOL|R_MENU, &C_IdnDecode, true },
-  { "idn_encode", DT_BOOL|R_MENU, &C_IdnEncode, true },
+  { "idn_decode", DT_BOOL|R_MENU, &C_IdnDecode, true, 0, NULL,
+    "(idn) Decode international domain names"
+  },
+  { "idn_encode", DT_BOOL|R_MENU, &C_IdnEncode, true, 0, NULL,
+    "(idn) Encode international domain names"
+  },
 #endif
-  { "implicit_autoview", DT_BOOL, &C_ImplicitAutoview, false },
-  { "include_encrypted", DT_BOOL, &C_IncludeEncrypted, false },
-  { "include_onlyfirst", DT_BOOL, &C_IncludeOnlyfirst, false },
-  { "indent_string", DT_STRING, &C_IndentString, IP "> " },
-  { "index_format", DT_STRING|DT_NOT_EMPTY|R_INDEX|R_PAGER, &C_IndexFormat, IP "%4C %Z %{%b %d} %-15.15L (%?l?%4l&%4c?) %s" },
-  { "ispell", DT_STRING|DT_COMMAND, &C_Ispell, IP ISPELL },
-  { "keep_flagged", DT_BOOL, &C_KeepFlagged, false },
-  { "mail_check", DT_NUMBER|DT_NOT_NEGATIVE, &C_MailCheck, 5 },
-  { "mail_check_recent", DT_BOOL, &C_MailCheckRecent, true },
-  { "mail_check_stats", DT_BOOL, &C_MailCheckStats, false },
-  { "mail_check_stats_interval", DT_NUMBER|DT_NOT_NEGATIVE, &C_MailCheckStatsInterval, 60 },
-  { "mailcap_path", DT_SLIST|SLIST_SEP_COLON, &C_MailcapPath, IP "~/.mailcap:" PKGDATADIR "/mailcap:" SYSCONFDIR "/mailcap:/etc/mailcap:/usr/etc/mailcap:/usr/local/etc/mailcap" },
-  { "mailcap_sanitize", DT_BOOL, &C_MailcapSanitize, true },
-  { "mark_macro_prefix", DT_STRING, &C_MarkMacroPrefix, IP "'" },
-  { "mark_old", DT_BOOL|R_INDEX|R_PAGER, &C_MarkOld, true },
-  { "markers", DT_BOOL|R_PAGER_FLOW, &C_Markers, true },
-  { "mask", DT_REGEX|DT_REGEX_MATCH_CASE|DT_REGEX_ALLOW_NOT|DT_REGEX_NOSUB, &C_Mask, IP "!^\\.[^.]" },
-  { "mbox", DT_STRING|DT_MAILBOX|R_INDEX|R_PAGER, &C_Mbox, IP "~/mbox" },
-  { "mbox_type", DT_ENUM, &C_MboxType, MUTT_MBOX, IP &MboxTypeDef },
-  { "menu_context", DT_NUMBER|DT_NOT_NEGATIVE, &C_MenuContext, 0 },
-  { "menu_move_off", DT_BOOL, &C_MenuMoveOff, true },
-  { "menu_scroll", DT_BOOL, &C_MenuScroll, false },
-  { "message_cache_clean", DT_BOOL, &C_MessageCacheClean, false },
-  { "message_cachedir", DT_PATH|DT_PATH_DIR, &C_MessageCachedir, 0 },
-  { "message_format", DT_STRING|DT_NOT_EMPTY, &C_MessageFormat, IP "%s" },
-  { "meta_key", DT_BOOL, &C_MetaKey, false },
-  { "mime_forward", DT_QUAD, &C_MimeForward, MUTT_NO },
-  { "mime_forward_rest", DT_QUAD, &C_MimeForwardRest, MUTT_YES },
+  { "implicit_autoview", DT_BOOL, &C_ImplicitAutoview, false, 0, NULL,
+    "Display MIME attachments inline if a 'copiousoutput' mailcap entry exists"
+  },
+  { "include_encrypted", DT_BOOL, &C_IncludeEncrypted, false, 0, NULL,
+    "Whether to include encrypted content when replying"
+  },
+  { "include_onlyfirst", DT_BOOL, &C_IncludeOnlyfirst, false, 0, NULL,
+    "Only include the first attachment when replying"
+  },
+  { "indent_string", DT_STRING, &C_IndentString, IP "> ", 0, NULL,
+    "String used to indent 'reply' text"
+  },
+  { "index_format", DT_STRING|DT_NOT_EMPTY|R_INDEX|R_PAGER, &C_IndexFormat, IP "%4C %Z %{%b %d} %-15.15L (%?l?%4l&%4c?) %s", 0, NULL,
+    "printf-like format string for the index menu (emails)"
+  },
+  { "ispell", DT_STRING|DT_COMMAND, &C_Ispell, IP ISPELL, 0, NULL,
+    "External command to perform spell-checking"
+  },
+  { "keep_flagged", DT_BOOL, &C_KeepFlagged, false, 0, NULL,
+    "Don't move flagged messages from #C_Spoolfile to #C_Mbox"
+  },
+  { "mail_check", DT_NUMBER|DT_NOT_NEGATIVE, &C_MailCheck, 5, 0, NULL,
+    "Number of seconds before NeoMutt checks for new mail"
+  },
+  { "mail_check_recent", DT_BOOL, &C_MailCheckRecent, true, 0, NULL,
+    "Notify the user about new mail since the last time the mailbox was opened"
+  },
+  { "mail_check_stats", DT_BOOL, &C_MailCheckStats, false, 0, NULL,
+    "Periodically check for new mail"
+  },
+  { "mail_check_stats_interval", DT_NUMBER|DT_NOT_NEGATIVE, &C_MailCheckStatsInterval, 60, 0, NULL,
+    "How often to check for new mail"
+  },
+  { "mailcap_path", DT_SLIST|SLIST_SEP_COLON, &C_MailcapPath, IP "~/.mailcap:" PKGDATADIR "/mailcap:" SYSCONFDIR "/mailcap:/etc/mailcap:/usr/etc/mailcap:/usr/local/etc/mailcap", 0, NULL,
+    "Colon-separated list of mailcap files"
+  },
+  { "mailcap_sanitize", DT_BOOL, &C_MailcapSanitize, true, 0, NULL,
+    "Restrict the possible characters in mailcap expandos"
+  },
+  { "mark_macro_prefix", DT_STRING, &C_MarkMacroPrefix, IP "'", 0, NULL,
+    "Prefix for macros using '<mark-message>'"
+  },
+  { "mark_old", DT_BOOL|R_INDEX|R_PAGER, &C_MarkOld, true, 0, NULL,
+    "Mark new emails as old when leaving the mailbox"
+  },
+  { "markers", DT_BOOL|R_PAGER_FLOW, &C_Markers, true, 0, NULL,
+    "Display a '+' at the beginning of wrapped lines in the pager"
+  },
+  { "mask", DT_REGEX|DT_REGEX_MATCH_CASE|DT_REGEX_ALLOW_NOT|DT_REGEX_NOSUB, &C_Mask, IP "!^\\.[^.]", 0, NULL,
+    "Only display files/dirs matching this regex in the browser"
+  },
+  { "mbox", DT_STRING|DT_MAILBOX|R_INDEX|R_PAGER, &C_Mbox, IP "~/mbox", 0, NULL,
+    "Folder that receives read emails (see Move)"
+  },
+  { "mbox_type", DT_ENUM, &C_MboxType, MUTT_MBOX, IP &MboxTypeDef, NULL,
+    "Default type for creating new mailboxes"
+  },
+  { "menu_context", DT_NUMBER|DT_NOT_NEGATIVE, &C_MenuContext, 0, 0, NULL,
+    "Number of lines of overlap when changing pages in the index"
+  },
+  { "menu_move_off", DT_BOOL, &C_MenuMoveOff, true, 0, NULL,
+    "Allow the last menu item to move off the bottom of the screen"
+  },
+  { "menu_scroll", DT_BOOL, &C_MenuScroll, false, 0, NULL,
+    "Scroll the menu/index by one line, rather than a page"
+  },
+  { "message_cache_clean", DT_BOOL, &C_MessageCacheClean, false, 0, NULL,
+    "(imap/pop) Clean out obsolete entries from the message cache"
+  },
+  { "message_cachedir", DT_PATH|DT_PATH_DIR, &C_MessageCachedir, 0, 0, NULL,
+    "(imap/pop) Directory for the message cache"
+  },
+  { "message_format", DT_STRING|DT_NOT_EMPTY, &C_MessageFormat, IP "%s", 0, NULL,
+    "printf-like format string for listing attached messages"
+  },
+  { "meta_key", DT_BOOL, &C_MetaKey, false, 0, NULL,
+    "Interpret 'ALT-x' as 'ESC-x'"
+  },
+  { "mime_forward", DT_QUAD, &C_MimeForward, MUTT_NO, 0, NULL,
+    "Forward a message as a 'message/RFC822' MIME part"
+  },
+  { "mime_forward_rest", DT_QUAD, &C_MimeForwardRest, MUTT_YES, 0, NULL,
+    "Forward all attachments, even if they can't be decoded"
+  },
 #ifdef MIXMASTER
-  { "mix_entry_format", DT_STRING|DT_NOT_EMPTY, &C_MixEntryFormat, IP "%4n %c %-16s %a" },
-  { "mixmaster", DT_STRING|DT_COMMAND, &C_Mixmaster, IP MIXMASTER },
+  { "mix_entry_format", DT_STRING|DT_NOT_EMPTY, &C_MixEntryFormat, IP "%4n %c %-16s %a", 0, NULL,
+    "(mixmaster) printf-like format string for the mixmaster chain"
+  },
+  { "mixmaster", DT_STRING|DT_COMMAND, &C_Mixmaster, IP MIXMASTER, 0, NULL,
+    "(mixmaster) External command to route a mixmaster message"
+  },
 #endif
-  { "move", DT_QUAD, &C_Move, MUTT_NO },
-  { "narrow_tree", DT_BOOL|R_TREE|R_INDEX, &C_NarrowTree, false },
-  { "net_inc", DT_NUMBER|DT_NOT_NEGATIVE, &C_NetInc, 10 },
-  { "new_mail_command", DT_STRING|DT_COMMAND, &C_NewMailCommand, 0 },
-  { "pager", DT_STRING|DT_COMMAND, &C_Pager, IP "builtin" },
-  { "pager_context", DT_NUMBER|DT_NOT_NEGATIVE, &C_PagerContext, 0 },
-  { "pager_format", DT_STRING|R_PAGER, &C_PagerFormat, IP "-%Z- %C/%m: %-20.20n   %s%*  -- (%P)" },
-  { "pager_index_lines", DT_NUMBER|DT_NOT_NEGATIVE|R_PAGER|R_REFLOW, &C_PagerIndexLines, 0 },
-  { "pager_stop", DT_BOOL, &C_PagerStop, false },
-  { "pipe_decode", DT_BOOL, &C_PipeDecode, false },
-  { "pipe_decode_weed", DT_BOOL, &C_PipeDecodeWeed, true },
-  { "pipe_sep", DT_STRING, &C_PipeSep, IP "\n" },
-  { "pipe_split", DT_BOOL, &C_PipeSplit, false },
-  { "postpone", DT_QUAD, &C_Postpone, MUTT_ASKYES },
-  { "postponed", DT_STRING|DT_MAILBOX|R_INDEX, &C_Postponed, IP "~/postponed" },
-  { "preferred_languages", DT_SLIST|SLIST_SEP_COMMA, &C_PreferredLanguages, 0 },
-  { "print", DT_QUAD, &C_Print, MUTT_ASKNO },
-  { "print_command", DT_STRING|DT_COMMAND, &C_PrintCommand, IP "lpr" },
-  { "print_decode", DT_BOOL, &C_PrintDecode, true },
-  { "print_decode_weed", DT_BOOL, &C_PrintDecodeWeed, true },
-  { "print_split", DT_BOOL, &C_PrintSplit, false },
-  { "prompt_after", DT_BOOL, &C_PromptAfter, true },
-  { "query_command", DT_STRING|DT_COMMAND, &C_QueryCommand, 0 },
-  { "query_format", DT_STRING|DT_NOT_EMPTY, &C_QueryFormat, IP "%3c %t %-25.25n %-25.25a | %e" },
-  { "quit", DT_QUAD, &C_Quit, MUTT_YES },
-  { "quote_regex", DT_REGEX|R_PAGER, &C_QuoteRegex, IP "^([ \t]*[|>:}#])+" },
-  { "read_inc", DT_NUMBER|DT_NOT_NEGATIVE, &C_ReadInc, 10 },
-  { "read_only", DT_BOOL, &C_ReadOnly, false },
-  { "realname", DT_STRING|R_INDEX|R_PAGER, &C_Realname, 0 },
-  { "record", DT_STRING|DT_MAILBOX, &C_Record, IP "~/sent" },
-  { "reflow_space_quotes", DT_BOOL, &C_ReflowSpaceQuotes, true },
-  { "reflow_text", DT_BOOL, &C_ReflowText, true },
-  { "reflow_wrap", DT_NUMBER, &C_ReflowWrap, 78 },
-  { "reply_regex", DT_REGEX|R_INDEX|R_RESORT, &C_ReplyRegex, IP "^((re|aw|sv)(\\[[0-9]+\\])*:[ \t]*)*", 0, reply_validator },
-  { "resolve", DT_BOOL, &C_Resolve, true },
-  { "resume_draft_files", DT_BOOL, &C_ResumeDraftFiles, false },
-  { "resume_edited_draft_files", DT_BOOL, &C_ResumeEditedDraftFiles, true },
-  { "reverse_alias", DT_BOOL|R_INDEX|R_PAGER, &C_ReverseAlias, false },
-  { "rfc2047_parameters", DT_BOOL, &C_Rfc2047Parameters, false },
-  { "save_address", DT_BOOL, &C_SaveAddress, false },
-  { "save_empty", DT_BOOL, &C_SaveEmpty, true },
-  { "save_name", DT_BOOL, &C_SaveName, false },
-  { "score", DT_BOOL, &C_Score, true },
-  { "score_threshold_delete", DT_NUMBER, &C_ScoreThresholdDelete, -1 },
-  { "score_threshold_flag", DT_NUMBER, &C_ScoreThresholdFlag, 9999 },
-  { "score_threshold_read", DT_NUMBER, &C_ScoreThresholdRead, -1 },
-  { "search_context", DT_NUMBER|DT_NOT_NEGATIVE, &C_SearchContext, 0 },
-  { "send_charset", DT_STRING, &C_SendCharset, IP "us-ascii:iso-8859-1:utf-8", 0, charset_validator },
-  { "shell", DT_STRING|DT_COMMAND, &C_Shell, IP "/bin/sh" },
-  { "show_multipart_alternative", DT_STRING, &C_ShowMultipartAlternative, 0, 0, multipart_validator },
-  { "simple_search", DT_STRING, &C_SimpleSearch, IP "~f %s | ~s %s" },
-  { "size_show_bytes", DT_BOOL|R_MENU, &C_SizeShowBytes, false },
-  { "size_show_fractions", DT_BOOL|R_MENU, &C_SizeShowFractions, true },
-  { "size_show_mb", DT_BOOL|R_MENU, &C_SizeShowMb, true },
-  { "size_units_on_left", DT_BOOL|R_MENU, &C_SizeUnitsOnLeft, false },
-  { "skip_quoted_offset", DT_NUMBER|DT_NOT_NEGATIVE, &C_SkipQuotedOffset, 0 },
-  { "sleep_time", DT_NUMBER|DT_NOT_NEGATIVE, &C_SleepTime, 1 },
-  { "smart_wrap", DT_BOOL|R_PAGER_FLOW, &C_SmartWrap, true },
-  { "smileys", DT_REGEX|R_PAGER, &C_Smileys, IP "(>From )|(:[-^]?[][)(><}{|/DP])" },
-  { "sort", DT_SORT|R_INDEX|R_RESORT, &C_Sort, SORT_DATE, 0, pager_validator },
-  { "sort_alias", DT_SORT|DT_SORT_ALIAS, &C_SortAlias, SORT_ALIAS },
-  { "sort_aux", DT_SORT|DT_SORT_AUX|R_INDEX|R_RESORT|R_RESORT_SUB, &C_SortAux, SORT_DATE },
-  { "sort_browser", DT_SORT|DT_SORT_BROWSER, &C_SortBrowser, SORT_ALPHA },
-  { "sort_re", DT_BOOL|R_INDEX|R_RESORT|R_RESORT_INIT, &C_SortRe, true, 0, pager_validator },
-  { "spam_separator", DT_STRING, &C_SpamSeparator, IP "," },
-  { "spoolfile", DT_STRING|DT_MAILBOX, &C_Spoolfile, 0 },
-  { "status_chars", DT_MBTABLE|R_INDEX|R_PAGER, &C_StatusChars, IP "-*%A" },
-  { "status_format", DT_STRING|R_INDEX|R_PAGER, &C_StatusFormat, IP "-%r-NeoMutt: %D [Msgs:%?M?%M/?%m%?n? New:%n?%?o? Old:%o?%?d? Del:%d?%?F? Flag:%F?%?t? Tag:%t?%?p? Post:%p?%?b? Inc:%b?%?l? %l?]---(%s/%S)-%>-(%P)---" },
-  { "status_on_top", DT_BOOL|R_REFLOW, &C_StatusOnTop, false },
-  { "strict_threads", DT_BOOL|R_RESORT|R_RESORT_INIT|R_INDEX, &C_StrictThreads, false, 0, pager_validator },
-  { "suspend", DT_BOOL, &C_Suspend, true },
-  { "text_flowed", DT_BOOL, &C_TextFlowed, false },
-  { "thread_received", DT_BOOL|R_RESORT|R_RESORT_INIT|R_INDEX, &C_ThreadReceived, false, 0, pager_validator },
-  { "tilde", DT_BOOL|R_PAGER, &C_Tilde, false },
-  { "time_inc", DT_NUMBER|DT_NOT_NEGATIVE, &C_TimeInc, 0 },
-  { "timeout", DT_NUMBER|DT_NOT_NEGATIVE, &C_Timeout, 600 },
-  { "tmpdir", DT_PATH|DT_PATH_DIR|DT_NOT_EMPTY, &C_Tmpdir, IP "/tmp" },
-  { "toggle_quoted_show_levels", DT_NUMBER|DT_NOT_NEGATIVE, &C_ToggleQuotedShowLevels, 0 },
-  { "to_chars", DT_MBTABLE|R_INDEX|R_PAGER, &C_ToChars, IP " +TCFLR" },
-  { "trash", DT_STRING|DT_MAILBOX, &C_Trash, 0 },
-  { "ts_enabled", DT_BOOL|R_INDEX|R_PAGER, &C_TsEnabled, false },
-  { "ts_icon_format", DT_STRING|R_INDEX|R_PAGER, &C_TsIconFormat, IP "M%?n?AIL&ail?" },
-  { "ts_status_format", DT_STRING|R_INDEX|R_PAGER, &C_TsStatusFormat, IP "NeoMutt with %?m?%m messages&no messages?%?n? [%n NEW]?" },
-  { "uncollapse_jump", DT_BOOL, &C_UncollapseJump, false },
-  { "uncollapse_new", DT_BOOL, &C_UncollapseNew, true },
-  { "use_domain", DT_BOOL, &C_UseDomain, true },
-  { "visual", DT_STRING|DT_COMMAND, &C_Visual, IP "vi" },
-  { "wait_key", DT_BOOL, &C_WaitKey, true },
-  { "weed", DT_BOOL, &C_Weed, true },
-  { "wrap", DT_NUMBER|R_PAGER_FLOW, &C_Wrap, 0 },
-  { "wrap_search", DT_BOOL, &C_WrapSearch, true },
-  { "write_bcc", DT_BOOL, &C_WriteBcc, false },
-  { "write_inc", DT_NUMBER|DT_NOT_NEGATIVE, &C_WriteInc, 10 },
+  { "move", DT_QUAD, &C_Move, MUTT_NO, 0, NULL,
+    "Move emails from #C_Spoolfile to #C_Mbox when read"
+  },
+  { "narrow_tree", DT_BOOL|R_TREE|R_INDEX, &C_NarrowTree, false, 0, NULL,
+    "Draw a narrower thread tree in the index"
+  },
+  { "net_inc", DT_NUMBER|DT_NOT_NEGATIVE, &C_NetInc, 10, 0, NULL,
+    "(socket) Update the progress bar after this many KB sent/received (0 to disable)"
+  },
+  { "new_mail_command", DT_STRING|DT_COMMAND, &C_NewMailCommand, 0, 0, NULL,
+    "External command to run when new mail arrives"
+  },
+  { "pager", DT_STRING|DT_COMMAND, &C_Pager, IP "builtin", 0, NULL,
+    "External command for viewing messages, or 'builtin' to use NeoMutt's"
+  },
+  { "pager_context", DT_NUMBER|DT_NOT_NEGATIVE, &C_PagerContext, 0, 0, NULL,
+    "Number of lines of overlap when changing pages in the pager"
+  },
+  { "pager_format", DT_STRING|R_PAGER, &C_PagerFormat, IP "-%Z- %C/%m: %-20.20n   %s%*  -- (%P)", 0, NULL,
+    "printf-like format string for the pager's status bar"
+  },
+  { "pager_index_lines", DT_NUMBER|DT_NOT_NEGATIVE|R_PAGER|R_REFLOW, &C_PagerIndexLines, 0, 0, NULL,
+    "Number of index lines to display above the pager"
+  },
+  { "pager_stop", DT_BOOL, &C_PagerStop, false, 0, NULL,
+    "Don't automatically open the next message when at the end of a message"
+  },
+  { "pipe_decode", DT_BOOL, &C_PipeDecode, false, 0, NULL,
+    "Decode the message when piping it"
+  },
+  { "pipe_decode_weed", DT_BOOL, &C_PipeDecodeWeed, true, 0, NULL,
+    "Control whether to weed headers when piping an email"
+  },
+  { "pipe_sep", DT_STRING, &C_PipeSep, IP "\n", 0, NULL,
+    "Separator to add between multiple piped messages"
+  },
+  { "pipe_split", DT_BOOL, &C_PipeSplit, false, 0, NULL,
+    "Run the pipe command on each message separately"
+  },
+  { "postpone", DT_QUAD, &C_Postpone, MUTT_ASKYES, 0, NULL,
+    "Save messages to the #C_Postponed folder"
+  },
+  { "postponed", DT_STRING|DT_MAILBOX|R_INDEX, &C_Postponed, IP "~/postponed", 0, NULL,
+    "Folder to store postponed messages"
+  },
+  { "preferred_languages", DT_SLIST|SLIST_SEP_COMMA, &C_PreferredLanguages, 0, 0, NULL,
+    "Preferred languages for multilingual MIME"
+  },
+  { "print", DT_QUAD, &C_Print, MUTT_ASKNO, 0, NULL,
+    "Confirm before printing a message"
+  },
+  { "print_command", DT_STRING|DT_COMMAND, &C_PrintCommand, IP "lpr", 0, NULL,
+    "External command to print a message"
+  },
+  { "print_decode", DT_BOOL, &C_PrintDecode, true, 0, NULL,
+    "Decode message before printing it"
+  },
+  { "print_decode_weed", DT_BOOL, &C_PrintDecodeWeed, true, 0, NULL,
+    "Control whether to weed headers when printing an email "
+  },
+  { "print_split", DT_BOOL, &C_PrintSplit, false, 0, NULL,
+    "Print multiple messages separately"
+  },
+  { "prompt_after", DT_BOOL, &C_PromptAfter, true, 0, NULL,
+    "Pause after running an external pager"
+  },
+  { "query_command", DT_STRING|DT_COMMAND, &C_QueryCommand, 0, 0, NULL,
+    "External command to query and external address book"
+  },
+  { "query_format", DT_STRING|DT_NOT_EMPTY, &C_QueryFormat, IP "%3c %t %-25.25n %-25.25a | %e", 0, NULL,
+    "printf-like format string for the query menu (address book)"
+  },
+  { "quit", DT_QUAD, &C_Quit, MUTT_YES, 0, NULL,
+    "Prompt before exiting NeoMutt"
+  },
+  { "quote_regex", DT_REGEX|R_PAGER, &C_QuoteRegex, IP "^([ \t]*[|>:}#])+", 0, NULL,
+    "Regex to match quoted text in a reply"
+  },
+  { "read_inc", DT_NUMBER|DT_NOT_NEGATIVE, &C_ReadInc, 10, 0, NULL,
+    "Update the progress bar after this many records read (0 to disable)"
+  },
+  { "read_only", DT_BOOL, &C_ReadOnly, false, 0, NULL,
+    "Open folders in read-only mode"
+  },
+  { "realname", DT_STRING|R_INDEX|R_PAGER, &C_Realname, 0, 0, NULL,
+    "Real name of the user"
+  },
+  { "record", DT_STRING|DT_MAILBOX, &C_Record, IP "~/sent", 0, NULL,
+    "Folder to save 'sent' messages"
+  },
+  { "reflow_space_quotes", DT_BOOL, &C_ReflowSpaceQuotes, true, 0, NULL,
+    "Insert spaces into reply quotes for 'format=flowed' messages"
+  },
+  { "reflow_text", DT_BOOL, &C_ReflowText, true, 0, NULL,
+    "Reformat paragraphs of 'format=flowed' text"
+  },
+  { "reflow_wrap", DT_NUMBER, &C_ReflowWrap, 78, 0, NULL,
+    "Maximum paragraph width for reformatting 'format=flowed' text"
+  },
+  { "reply_regex", DT_REGEX|R_INDEX|R_RESORT, &C_ReplyRegex, IP "^((re|aw|sv)(\\[[0-9]+\\])*:[ \t]*)*", 0, reply_validator,
+    "Regex to match message reply subjects like 're: '"
+  },
+  { "resolve", DT_BOOL, &C_Resolve, true, 0, NULL,
+    "Move to the next email whenever a command modifies an email"
+  },
+  { "resume_draft_files", DT_BOOL, &C_ResumeDraftFiles, false, 0, NULL,
+    "Process draft files like postponed messages"
+  },
+  { "resume_edited_draft_files", DT_BOOL, &C_ResumeEditedDraftFiles, true, 0, NULL,
+    "Resume editing previously saved draft files"
+  },
+  { "reverse_alias", DT_BOOL|R_INDEX|R_PAGER, &C_ReverseAlias, false, 0, NULL,
+    "Display the alias in the index, rather than the message's sender"
+  },
+  { "rfc2047_parameters", DT_BOOL, &C_Rfc2047Parameters, false, 0, NULL,
+    "Decode RFC2047-encoded MIME parameters"
+  },
+  { "save_address", DT_BOOL, &C_SaveAddress, false, 0, NULL,
+    "Use sender's full address as a default save folder"
+  },
+  { "save_empty", DT_BOOL, &C_SaveEmpty, true, 0, NULL,
+    "(mbox,mmdf) Preserve empty mailboxes"
+  },
+  { "save_name", DT_BOOL, &C_SaveName, false, 0, NULL,
+    "Save outgoing message to mailbox of recipient's name if it exists"
+  },
+  { "score", DT_BOOL, &C_Score, true, 0, NULL,
+    "Use message scoring"
+  },
+  { "score_threshold_delete", DT_NUMBER, &C_ScoreThresholdDelete, -1, 0, NULL,
+    "Messages with a lower score will be automatically deleted"
+  },
+  { "score_threshold_flag", DT_NUMBER, &C_ScoreThresholdFlag, 9999, 0, NULL,
+    "Messages with a greater score will be automatically flagged"
+  },
+  { "score_threshold_read", DT_NUMBER, &C_ScoreThresholdRead, -1, 0, NULL,
+    "Messages with a lower score will be automatically marked read"
+  },
+  { "search_context", DT_NUMBER|DT_NOT_NEGATIVE, &C_SearchContext, 0, 0, NULL,
+    "Context to display around search matches"
+  },
+  { "send_charset", DT_STRING, &C_SendCharset, IP "us-ascii:iso-8859-1:utf-8", 0, charset_validator,
+    "Character sets for outgoing mail"
+  },
+  { "shell", DT_STRING|DT_COMMAND, &C_Shell, IP "/bin/sh", 0, NULL,
+    "External command to run subshells in"
+  },
+  { "show_multipart_alternative", DT_STRING, &C_ShowMultipartAlternative, 0, 0, multipart_validator,
+    "How to display 'multipart/alternative' MIME parts"
+  },
+  { "simple_search", DT_STRING, &C_SimpleSearch, IP "~f %s | ~s %s", 0, NULL,
+    "Pattern to search for when search doesn't contain ~'s"
+  },
+  { "size_show_bytes", DT_BOOL|R_MENU, &C_SizeShowBytes, false, 0, NULL,
+    "Show smaller sizes in bytes"
+  },
+  { "size_show_fractions", DT_BOOL|R_MENU, &C_SizeShowFractions, true, 0, NULL,
+    "Show size fractions with a single decimal place"
+  },
+  { "size_show_mb", DT_BOOL|R_MENU, &C_SizeShowMb, true, 0, NULL,
+    "Show sizes in megabytes for sizes greater than 1 megabyte"
+  },
+  { "size_units_on_left", DT_BOOL|R_MENU, &C_SizeUnitsOnLeft, false, 0, NULL,
+    "Show the units as a prefix to the size"
+  },
+  { "skip_quoted_offset", DT_NUMBER|DT_NOT_NEGATIVE, &C_SkipQuotedOffset, 0, 0, NULL,
+    "Lines of context to show when skipping quoted text"
+  },
+  { "sleep_time", DT_NUMBER|DT_NOT_NEGATIVE, &C_SleepTime, 1, 0, NULL,
+    "Time to pause after certain info messages"
+  },
+  { "smart_wrap", DT_BOOL|R_PAGER_FLOW, &C_SmartWrap, true, 0, NULL,
+    "Wrap text at word boundaries"
+  },
+  { "smileys", DT_REGEX|R_PAGER, &C_Smileys, IP "(>From )|(:[-^]?[][)(><}{|/DP])", 0, NULL,
+    "Regex to match smileys to prevent mistakes when quoting text"
+  },
+  { "sort", DT_SORT|R_INDEX|R_RESORT, &C_Sort, SORT_DATE, 0, pager_validator,
+    "Sort method for the index"
+  },
+  { "sort_alias", DT_SORT|DT_SORT_ALIAS, &C_SortAlias, SORT_ALIAS, 0, NULL,
+    "Sort method for the alias menu"
+  },
+  { "sort_aux", DT_SORT|DT_SORT_AUX|R_INDEX|R_RESORT|R_RESORT_SUB, &C_SortAux, SORT_DATE, 0, NULL,
+    "Secondary sort method for the index"
+  },
+  { "sort_browser", DT_SORT|DT_SORT_BROWSER, &C_SortBrowser, SORT_ALPHA, 0, NULL,
+    "Sort method for the browser"
+  },
+  { "sort_re", DT_BOOL|R_INDEX|R_RESORT|R_RESORT_INIT, &C_SortRe, true, 0, pager_validator,
+    "Sort method for the sidebar"
+  },
+  { "spam_separator", DT_STRING, &C_SpamSeparator, IP ",", 0, NULL,
+    "Separator for multiple spam headers"
+  },
+  { "spoolfile", DT_STRING|DT_MAILBOX, &C_Spoolfile, 0, 0, NULL,
+    "Inbox"
+  },
+  { "status_chars", DT_MBTABLE|R_INDEX|R_PAGER, &C_StatusChars, IP "-*%A", 0, NULL,
+    "Indicator characters for the status bar"
+  },
+  { "status_format", DT_STRING|R_INDEX|R_PAGER, &C_StatusFormat, IP "-%r-NeoMutt: %D [Msgs:%?M?%M/?%m%?n? New:%n?%?o? Old:%o?%?d? Del:%d?%?F? Flag:%F?%?t? Tag:%t?%?p? Post:%p?%?b? Inc:%b?%?l? %l?]---(%s/%S)-%>-(%P)---", 0, NULL,
+    "printf-like format string for the index's status line"
+  },
+  { "status_on_top", DT_BOOL|R_REFLOW, &C_StatusOnTop, false, 0, NULL,
+    "Display the status bar at the top"
+  },
+  { "strict_threads", DT_BOOL|R_RESORT|R_RESORT_INIT|R_INDEX, &C_StrictThreads, false, 0, pager_validator,
+    "Thread messages using 'In-Reply-To' and 'References' headers"
+  },
+  { "suspend", DT_BOOL, &C_Suspend, true, 0, NULL,
+    "Allow the user to suspend NeoMutt using '^Z'"
+  },
+  { "text_flowed", DT_BOOL, &C_TextFlowed, false, 0, NULL,
+    "Generate 'format=flowed' messages"
+  },
+  { "thread_received", DT_BOOL|R_RESORT|R_RESORT_INIT|R_INDEX, &C_ThreadReceived, false, 0, pager_validator,
+    "Sort threaded messages by their received date"
+  },
+  { "tilde", DT_BOOL|R_PAGER, &C_Tilde, false, 0, NULL,
+    "Character to pad blank lines in the pager"
+  },
+  { "time_inc", DT_NUMBER|DT_NOT_NEGATIVE, &C_TimeInc, 0, 0, NULL,
+    "Frequency of progress bar updates (milliseconds)"
+  },
+  { "timeout", DT_NUMBER|DT_NOT_NEGATIVE, &C_Timeout, 600, 0, NULL,
+    "Time to wait for user input in menus"
+  },
+  { "tmpdir", DT_PATH|DT_PATH_DIR|DT_NOT_EMPTY, &C_Tmpdir, IP "/tmp", 0, NULL,
+    "Directory for temporary files"
+  },
+  { "toggle_quoted_show_levels", DT_NUMBER|DT_NOT_NEGATIVE, &C_ToggleQuotedShowLevels, 0, 0, NULL,
+    "Number of quote levels to show with toggle-quoted"
+  },
+  { "to_chars", DT_MBTABLE|R_INDEX|R_PAGER, &C_ToChars, IP " +TCFLR", 0, NULL,
+    "Indicator characters for the 'To' field in the index"
+  },
+  { "trash", DT_STRING|DT_MAILBOX, &C_Trash, 0, 0, NULL,
+    "Folder to put deleted emails"
+  },
+  { "ts_enabled", DT_BOOL|R_INDEX|R_PAGER, &C_TsEnabled, false, 0, NULL,
+    "Allow NeoMutt to set the terminal status line and icon"
+  },
+  { "ts_icon_format", DT_STRING|R_INDEX|R_PAGER, &C_TsIconFormat, IP "M%?n?AIL&ail?", 0, NULL,
+    "printf-like format string for the terminal's icon title"
+  },
+  { "ts_status_format", DT_STRING|R_INDEX|R_PAGER, &C_TsStatusFormat, IP "NeoMutt with %?m?%m messages&no messages?%?n? [%n NEW]?", 0, NULL,
+    "printf-like format string for the terminal's status (window title)"
+  },
+  { "uncollapse_jump", DT_BOOL, &C_UncollapseJump, false, 0, NULL,
+    "When opening a thread, jump to the next unread message"
+  },
+  { "uncollapse_new", DT_BOOL, &C_UncollapseNew, true, 0, NULL,
+    "Open collapsed threads when new mail arrives"
+  },
+  { "use_domain", DT_BOOL, &C_UseDomain, true, 0, NULL,
+    "Qualify local addresses using this domain"
+  },
+  { "visual", DT_STRING|DT_COMMAND, &C_Visual, IP "vi", 0, NULL,
+    "Editor to use when '~v' is given in the built-in editor"
+  },
+  { "wait_key", DT_BOOL, &C_WaitKey, true, 0, NULL,
+    "Prompt to press a key after running external commands"
+  },
+  { "weed", DT_BOOL, &C_Weed, true, 0, NULL,
+    "Filter headers when displaying/forwarding/printing/replying"
+  },
+  { "wrap", DT_NUMBER|R_PAGER_FLOW, &C_Wrap, 0, 0, NULL,
+    "Width to wrap text in the pager"
+  },
+  { "wrap_search", DT_BOOL, &C_WrapSearch, true, 0, NULL,
+    "Wrap around when the search hits the end"
+  },
+  { "write_bcc", DT_BOOL, &C_WriteBcc, false, 0, NULL,
+    "Write out the 'Bcc' field when preparing to send a mail"
+  },
+  { "write_inc", DT_NUMBER|DT_NOT_NEGATIVE, &C_WriteInc, 10, 0, NULL,
+    "Update the progress bar after this many records written (0 to disable)"
+  },
+
   { "escape", DT_DEPRECATED|DT_STRING, &C_Escape, IP "~" },
+  { "ignore_linear_white_space", DT_DEPRECATED|DT_BOOL, &C_IgnoreLinearWhiteSpace, false },
 
-  { "ignore_linear_white_space", DT_DEPRECATED|DT_BOOL,            &C_IgnoreLinearWhiteSpace, false   },
+  { "edit_hdrs",        DT_SYNONYM, NULL, IP "edit_headers",     },
+  { "forw_decode",      DT_SYNONYM, NULL, IP "forward_decode",   },
+  { "forw_quote",       DT_SYNONYM, NULL, IP "forward_quote",    },
+  { "hdr_format",       DT_SYNONYM, NULL, IP "index_format",     },
+  { "indent_str",       DT_SYNONYM, NULL, IP "indent_string",    },
+  { "mime_fwd",         DT_SYNONYM, NULL, IP "mime_forward",     },
+  { "msg_format",       DT_SYNONYM, NULL, IP "message_format",   },
+  { "print_cmd",        DT_SYNONYM, NULL, IP "print_command",    },
+  { "quote_regexp",     DT_SYNONYM, NULL, IP "quote_regex",      },
+  { "reply_regexp",     DT_SYNONYM, NULL, IP "reply_regex",      },
+  { "xterm_icon",       DT_SYNONYM, NULL, IP "ts_icon_format",   },
+  { "xterm_set_titles", DT_SYNONYM, NULL, IP "ts_enabled",       },
+  { "xterm_title",      DT_SYNONYM, NULL, IP "ts_status_format", },
 
-  { "edit_hdrs",              DT_SYNONYM, NULL, IP "edit_headers",             },
-  { "forw_decode",            DT_SYNONYM, NULL, IP "forward_decode",           },
-  { "forw_quote",             DT_SYNONYM, NULL, IP "forward_quote",            },
-  { "hdr_format",             DT_SYNONYM, NULL, IP "index_format",             },
-  { "indent_str",             DT_SYNONYM, NULL, IP "indent_string",            },
-  { "mime_fwd",               DT_SYNONYM, NULL, IP "mime_forward",             },
-  { "msg_format",             DT_SYNONYM, NULL, IP "message_format",           },
-  { "print_cmd",              DT_SYNONYM, NULL, IP "print_command",            },
-  { "quote_regexp",           DT_SYNONYM, NULL, IP "quote_regex",              },
-  { "reply_regexp",           DT_SYNONYM, NULL, IP "reply_regex",              },
-  { "xterm_icon",             DT_SYNONYM, NULL, IP "ts_icon_format",           },
-  { "xterm_set_titles",       DT_SYNONYM, NULL, IP "ts_enabled",               },
-  { "xterm_title",            DT_SYNONYM, NULL, IP "ts_status_format",         },
-
-  { NULL, 0, NULL, 0, 0, NULL },
+  { NULL, 0, NULL, 0, 0, NULL, NULL },
+  // clang-format on
 };
-// clang-format on
 
 /**
  * config_init_main - Register main config variables

--- a/ncrypt/config.c
+++ b/ncrypt/config.c
@@ -108,99 +108,230 @@ bool            C_PgpAutoDecode;                       ///< Config: Automaticall
 unsigned char   C_CryptVerifySig;                      ///< Config: Verify PGP or SMIME signatures
 // clang-format on
 
-// clang-format off
 struct ConfigDef NcryptVars[] = {
-  { "crypt_confirmhook",                       DT_BOOL,                   &C_CryptConfirmhook,                    true },
-  { "crypt_opportunistic_encrypt",             DT_BOOL,                   &C_CryptOpportunisticEncrypt,           false },
-  { "crypt_opportunistic_encrypt_strong_keys", DT_BOOL,                   &C_CryptOpportunisticEncryptStrongKeys, false },
-  { "crypt_protected_headers_read",            DT_BOOL,                   &C_CryptProtectedHeadersRead,           true },
-  { "crypt_protected_headers_subject",         DT_STRING,                 &C_CryptProtectedHeadersSubject,        IP "..." },
-  { "crypt_protected_headers_write",           DT_BOOL,                   &C_CryptProtectedHeadersWrite,          false },
-  { "crypt_timestamp",                         DT_BOOL,                   &C_CryptTimestamp,                      true },
+  // clang-format off
+  { "crypt_confirmhook", DT_BOOL, &C_CryptConfirmhook, true, 0, NULL,
+    "Prompt the user to confirm keys before use"
+  },
+  { "crypt_opportunistic_encrypt", DT_BOOL, &C_CryptOpportunisticEncrypt, false, 0, NULL,
+    "Enable encryption when the recipient's key is available"
+  },
+  { "crypt_opportunistic_encrypt_strong_keys", DT_BOOL, &C_CryptOpportunisticEncryptStrongKeys, false, 0, NULL,
+    "Enable encryption only when strong a key is available"
+  },
+  { "crypt_protected_headers_read", DT_BOOL, &C_CryptProtectedHeadersRead, true, 0, NULL,
+    "Display protected headers (Memory Hole) in the pager"
+  },
+  { "crypt_protected_headers_subject", DT_STRING, &C_CryptProtectedHeadersSubject, IP "...", 0, NULL,
+    "Use this as the subject for encrypted emails"
+  },
+  { "crypt_protected_headers_write", DT_BOOL, &C_CryptProtectedHeadersWrite, false, 0, NULL,
+    "Generate protected header (Memory Hole) for signed and encrypted emails"
+  },
+  { "crypt_timestamp", DT_BOOL, &C_CryptTimestamp, true, 0, NULL,
+    "Add a timestamp to PGP or SMIME output to prevent spoofing"
+  },
 #ifdef CRYPT_BACKEND_GPGME
-  { "crypt_use_gpgme",                         DT_BOOL,                   &C_CryptUseGpgme,                       true },
-  { "crypt_use_pka",                           DT_BOOL,                   &C_CryptUsePka,                         false },
+  { "crypt_use_gpgme", DT_BOOL, &C_CryptUseGpgme, true, 0, NULL,
+    "Use GPGME crypto backend"
+  },
+  { "crypt_use_pka", DT_BOOL, &C_CryptUsePka, false, 0, NULL,
+    "Use GPGME to use PKA (lookup PGP keys using DNS)"
+  },
 #endif
-  { "envelope_from_address",                   DT_ADDRESS,                &C_EnvelopeFromAddress,                 0 },
-  { "pgp_autoinline",                          DT_BOOL,                   &C_PgpAutoinline,                       false },
+  { "envelope_from_address", DT_ADDRESS, &C_EnvelopeFromAddress, 0, 0, NULL,
+    "Manually set the sender for outgoing messages"
+  },
+  { "pgp_autoinline", DT_BOOL, &C_PgpAutoinline, false, 0, NULL,
+    "Use old-style inline PGP messages (not recommended)"
+  },
 #ifdef CRYPT_BACKEND_CLASSIC_PGP
-  { "pgp_check_exit",                          DT_BOOL,                   &C_PgpCheckExit,                        true },
-  { "pgp_check_gpg_decrypt_status_fd",         DT_BOOL,                   &C_PgpCheckGpgDecryptStatusFd,          true },
-  { "pgp_clearsign_command",                   DT_STRING|DT_COMMAND,      &C_PgpClearsignCommand,                 0 },
-  { "pgp_decode_command",                      DT_STRING|DT_COMMAND,      &C_PgpDecodeCommand,                    0 },
-  { "pgp_decrypt_command",                     DT_STRING|DT_COMMAND,      &C_PgpDecryptCommand,                   0 },
-  { "pgp_decryption_okay",                     DT_REGEX,                  &C_PgpDecryptionOkay,                   0 },
+  { "pgp_check_exit", DT_BOOL, &C_PgpCheckExit, true, 0, NULL,
+    "Check the exit code of PGP subprocess"
+  },
+  { "pgp_check_gpg_decrypt_status_fd", DT_BOOL, &C_PgpCheckGpgDecryptStatusFd, true, 0, NULL,
+    "File descriptor used for status info"
+  },
+  { "pgp_clearsign_command", DT_STRING|DT_COMMAND, &C_PgpClearsignCommand, 0, 0, NULL,
+    "(pgp) External command to inline-sign a message"
+  },
+  { "pgp_decode_command", DT_STRING|DT_COMMAND, &C_PgpDecodeCommand, 0, 0, NULL,
+    "(pgp) External command to decode a PGP attachment"
+  },
+  { "pgp_decrypt_command", DT_STRING|DT_COMMAND, &C_PgpDecryptCommand, 0, 0, NULL,
+    "(pgp) External command to decrypt a PGP message"
+  },
+  { "pgp_decryption_okay", DT_REGEX, &C_PgpDecryptionOkay, 0, 0, NULL,
+    "Text indicating a successful decryption"
+  },
 #endif
-  { "pgp_default_key",                         DT_STRING,                 &C_PgpDefaultKey,                       0 },
+  { "pgp_default_key", DT_STRING, &C_PgpDefaultKey, 0, 0, NULL,
+    "Default key to use for PGP operations"
+  },
 #ifdef CRYPT_BACKEND_CLASSIC_PGP
-  { "pgp_encrypt_only_command",                DT_STRING|DT_COMMAND,      &C_PgpEncryptOnlyCommand,               0 },
-  { "pgp_encrypt_sign_command",                DT_STRING|DT_COMMAND,      &C_PgpEncryptSignCommand,               0 },
+  { "pgp_encrypt_only_command", DT_STRING|DT_COMMAND, &C_PgpEncryptOnlyCommand, 0, 0, NULL,
+    "(pgp) External command to encrypt, but not sign a message"
+  },
+  { "pgp_encrypt_sign_command", DT_STRING|DT_COMMAND, &C_PgpEncryptSignCommand, 0, 0, NULL,
+    "(pgp) External command to encrypt and sign a message"
+  },
 #endif
-  { "pgp_entry_format",                        DT_STRING|DT_NOT_EMPTY,    &C_PgpEntryFormat,                      IP "%4n %t%f %4l/0x%k %-4a %2c %u" },
+  { "pgp_entry_format", DT_STRING|DT_NOT_EMPTY, &C_PgpEntryFormat, IP "%4n %t%f %4l/0x%k %-4a %2c %u", 0, NULL,
+    "printf-like format string for the PGP key selection menu"
+  },
 #ifdef CRYPT_BACKEND_CLASSIC_PGP
-  { "pgp_export_command",                      DT_STRING|DT_COMMAND,      &C_PgpExportCommand,                    0 },
-  { "pgp_getkeys_command",                     DT_STRING|DT_COMMAND,      &C_PgpGetkeysCommand,                   0 },
-  { "pgp_good_sign",                           DT_REGEX,                  &C_PgpGoodSign,                         0 },
+  { "pgp_export_command", DT_STRING|DT_COMMAND, &C_PgpExportCommand, 0, 0, NULL,
+    "(pgp) External command to export a public key from the user's keyring"
+  },
+  { "pgp_getkeys_command", DT_STRING|DT_COMMAND, &C_PgpGetkeysCommand, 0, 0, NULL,
+    "(pgp) External command to download a key for an email address"
+  },
+  { "pgp_good_sign", DT_REGEX, &C_PgpGoodSign, 0, 0, NULL,
+    "Text indicating a good signature"
+  },
 #endif
-  { "pgp_ignore_subkeys",                      DT_BOOL,                   &C_PgpIgnoreSubkeys,                    true },
+  { "pgp_ignore_subkeys", DT_BOOL, &C_PgpIgnoreSubkeys, true, 0, NULL,
+    "Only use the principal PGP key"
+  },
 #ifdef CRYPT_BACKEND_CLASSIC_PGP
-  { "pgp_import_command",                      DT_STRING|DT_COMMAND,      &C_PgpImportCommand,                    0 },
-  { "pgp_list_pubring_command",                DT_STRING|DT_COMMAND,      &C_PgpListPubringCommand,               0 },
-  { "pgp_list_secring_command",                DT_STRING|DT_COMMAND,      &C_PgpListSecringCommand,               0 },
+  { "pgp_import_command", DT_STRING|DT_COMMAND, &C_PgpImportCommand, 0, 0, NULL,
+    "(pgp) External command to import a key into the user's keyring"
+  },
+  { "pgp_list_pubring_command", DT_STRING|DT_COMMAND, &C_PgpListPubringCommand, 0, 0, NULL,
+    "(pgp) External command to list the public keys in a user's keyring"
+  },
+  { "pgp_list_secring_command", DT_STRING|DT_COMMAND, &C_PgpListSecringCommand, 0, 0, NULL,
+    "(pgp) External command to list the private keys in a user's keyring"
+  },
 #endif
-  { "pgp_long_ids",                            DT_BOOL,                   &C_PgpLongIds,                          true },
-  { "pgp_mime_auto",                           DT_QUAD,                   &C_PgpMimeAuto,                         MUTT_ASKYES },
-  { "pgp_retainable_sigs",                     DT_BOOL,                   &C_PgpRetainableSigs,                   false },
-  { "pgp_self_encrypt",                        DT_BOOL,                   &C_PgpSelfEncrypt,                      true },
-  { "pgp_show_unusable",                       DT_BOOL,                   &C_PgpShowUnusable,                     true },
-  { "pgp_sign_as",                             DT_STRING,                 &C_PgpSignAs,                           0 },
+  { "pgp_long_ids", DT_BOOL, &C_PgpLongIds, true, 0, NULL,
+    "Display long PGP key IDs to the user"
+  },
+  { "pgp_mime_auto", DT_QUAD, &C_PgpMimeAuto, MUTT_ASKYES, 0, NULL,
+    "Prompt the user to use MIME if inline PGP fails"
+  },
+  { "pgp_retainable_sigs", DT_BOOL, &C_PgpRetainableSigs, false, 0, NULL,
+    "Create nested multipart/signed or encrypted messages"
+  },
+  { "pgp_self_encrypt", DT_BOOL, &C_PgpSelfEncrypt, true, 0, NULL,
+    "Encrypted messages will also be encrypted to C_PgpDefaultKey too"
+  },
+  { "pgp_show_unusable", DT_BOOL, &C_PgpShowUnusable, true, 0, NULL,
+    "Show non-usable keys in the key selection"
+  },
+  { "pgp_sign_as", DT_STRING, &C_PgpSignAs, 0, 0, NULL,
+    "Use this alternative key for signing messages"
+  },
 #ifdef CRYPT_BACKEND_CLASSIC_PGP
-  { "pgp_sign_command",                        DT_STRING|DT_COMMAND,      &C_PgpSignCommand,                      0 },
+  { "pgp_sign_command", DT_STRING|DT_COMMAND, &C_PgpSignCommand, 0, 0, NULL,
+    "(pgp) External command to create a detached PGP signature"
+  },
 #endif
-  { "pgp_sort_keys",                           DT_SORT|DT_SORT_KEYS,      &C_PgpSortKeys,                         SORT_ADDRESS },
-  { "pgp_strict_enc",                          DT_BOOL,                   &C_PgpStrictEnc,                        true },
+  { "pgp_sort_keys", DT_SORT|DT_SORT_KEYS, &C_PgpSortKeys, SORT_ADDRESS, 0, NULL,
+    "Sort order for PGP keys"
+  },
+  { "pgp_strict_enc", DT_BOOL, &C_PgpStrictEnc, true, 0, NULL,
+    "Encode PGP signed messages with quoted-printable (don't unset)"
+  },
 #ifdef CRYPT_BACKEND_CLASSIC_PGP
-  { "pgp_timeout",                             DT_LONG|DT_NOT_NEGATIVE,   &C_PgpTimeout,                          300 },
-  { "pgp_use_gpg_agent",                       DT_BOOL,                   &C_PgpUseGpgAgent,                      true },
-  { "pgp_verify_command",                      DT_STRING|DT_COMMAND,      &C_PgpVerifyCommand,                    0 },
-  { "pgp_verify_key_command",                  DT_STRING|DT_COMMAND,      &C_PgpVerifyKeyCommand,                 0 },
+  { "pgp_timeout", DT_LONG|DT_NOT_NEGATIVE, &C_PgpTimeout, 300, 0, NULL,
+    "Time in seconds to cache a passphrase"
+  },
+  { "pgp_use_gpg_agent", DT_BOOL, &C_PgpUseGpgAgent, true, 0, NULL,
+    "Use a PGP agent for caching passwords"
+  },
+  { "pgp_verify_command", DT_STRING|DT_COMMAND, &C_PgpVerifyCommand, 0, 0, NULL,
+    "(pgp) External command to verify PGP signatures"
+  },
+  { "pgp_verify_key_command", DT_STRING|DT_COMMAND, &C_PgpVerifyKeyCommand, 0, 0, NULL,
+    "(pgp) External command to verify key information"
+  },
 #endif
 #ifdef CRYPT_BACKEND_CLASSIC_SMIME
-  { "smime_ask_cert_label",                    DT_BOOL,                   &C_SmimeAskCertLabel,                   true },
-  { "smime_ca_location",                       DT_PATH|DT_PATH_FILE,      &C_SmimeCaLocation,                     0 },
-  { "smime_certificates",                      DT_PATH|DT_PATH_DIR,       &C_SmimeCertificates,                   0 },
-  { "smime_decrypt_command",                   DT_STRING|DT_COMMAND,      &C_SmimeDecryptCommand,                 0 },
-  { "smime_decrypt_use_default_key",           DT_BOOL,                   &C_SmimeDecryptUseDefaultKey,           true },
+  { "smime_ask_cert_label", DT_BOOL, &C_SmimeAskCertLabel, true, 0, NULL,
+    "Prompt the user for a label for SMIME certificates"
+  },
+  { "smime_ca_location", DT_PATH|DT_PATH_FILE, &C_SmimeCaLocation, 0, 0, NULL,
+    "File containing trusted certificates"
+  },
+  { "smime_certificates", DT_PATH|DT_PATH_DIR, &C_SmimeCertificates, 0, 0, NULL,
+    "File containing user's public certificates"
+  },
+  { "smime_decrypt_command", DT_STRING|DT_COMMAND, &C_SmimeDecryptCommand, 0, 0, NULL,
+    "(smime) External command to decrypt an SMIME message"
+  },
+  { "smime_decrypt_use_default_key", DT_BOOL, &C_SmimeDecryptUseDefaultKey, true, 0, NULL,
+    "Use the default key for decryption"
+  },
 #endif
-  { "smime_default_key",                       DT_STRING,                 &C_SmimeDefaultKey,                     0 },
+  { "smime_default_key", DT_STRING, &C_SmimeDefaultKey, 0, 0, NULL,
+    "Default key for SMIME operations"
+  },
 #ifdef CRYPT_BACKEND_CLASSIC_SMIME
-  { "smime_encrypt_command",                   DT_STRING|DT_COMMAND,      &C_SmimeEncryptCommand,                 0 },
+  { "smime_encrypt_command", DT_STRING|DT_COMMAND, &C_SmimeEncryptCommand, 0, 0, NULL,
+    "(smime) External command to encrypt a message"
+  },
 #endif
-  { "smime_encrypt_with",                      DT_STRING,                 &C_SmimeEncryptWith,                    IP "aes256" },
+  { "smime_encrypt_with", DT_STRING, &C_SmimeEncryptWith, IP "aes256", 0, NULL,
+    "Algorithm for encryption"
+  },
 #ifdef CRYPT_BACKEND_CLASSIC_SMIME
-  { "smime_get_cert_command",                  DT_STRING|DT_COMMAND,      &C_SmimeGetCertCommand,                 0 },
-  { "smime_get_cert_email_command",            DT_STRING|DT_COMMAND,      &C_SmimeGetCertEmailCommand,            0 },
-  { "smime_get_signer_cert_command",           DT_STRING|DT_COMMAND,      &C_SmimeGetSignerCertCommand,           0 },
-  { "smime_import_cert_command",               DT_STRING|DT_COMMAND,      &C_SmimeImportCertCommand,              0 },
+  { "smime_get_cert_command", DT_STRING|DT_COMMAND, &C_SmimeGetCertCommand, 0, 0, NULL,
+    "(smime) External command to extract a certificate from a message"
+  },
+  { "smime_get_cert_email_command", DT_STRING|DT_COMMAND, &C_SmimeGetCertEmailCommand, 0, 0, NULL,
+    "(smime) External command to get a certificate for an email"
+  },
+  { "smime_get_signer_cert_command", DT_STRING|DT_COMMAND, &C_SmimeGetSignerCertCommand, 0, 0, NULL,
+    "(smime) External command to extract a certificate from an email"
+  },
+  { "smime_import_cert_command", DT_STRING|DT_COMMAND, &C_SmimeImportCertCommand, 0, 0, NULL,
+    "(smime) External command to import a certificate"
+  },
 #endif
 #ifdef CRYPT_BACKEND_CLASSIC_SMIME
-  { "smime_keys",                              DT_PATH|DT_PATH_DIR,       &C_SmimeKeys,                           0 },
-  { "smime_pk7out_command",                    DT_STRING|DT_COMMAND,      &C_SmimePk7outCommand,                  0 },
+  { "smime_keys", DT_PATH|DT_PATH_DIR, &C_SmimeKeys, 0, 0, NULL,
+    "File containing user's private certificates"
+  },
+  { "smime_pk7out_command", DT_STRING|DT_COMMAND, &C_SmimePk7outCommand, 0, 0, NULL,
+    "(smime) External command to extract a public certificate"
+  },
 #endif
-  { "smime_self_encrypt",                      DT_BOOL,                   &C_SmimeSelfEncrypt,                    true },
-  { "smime_sign_as",                           DT_STRING,                 &C_SmimeSignAs,                         0 },
+  { "smime_self_encrypt", DT_BOOL, &C_SmimeSelfEncrypt, true, 0, NULL,
+    "Encrypted messages will also be encrypt to C_SmimeDefaultKey too"
+  },
+  { "smime_sign_as", DT_STRING, &C_SmimeSignAs, 0, 0, NULL,
+    "Use this alternative key for signing messages"
+  },
 #ifdef CRYPT_BACKEND_CLASSIC_SMIME
-  { "smime_sign_command",                      DT_STRING|DT_COMMAND,      &C_SmimeSignCommand,                    0 },
-  { "smime_sign_digest_alg",                   DT_STRING,                 &C_SmimeSignDigestAlg,                  IP "sha256" },
-  { "smime_timeout",                           DT_NUMBER|DT_NOT_NEGATIVE, &C_SmimeTimeout,                        300 },
-  { "smime_verify_command",                    DT_STRING|DT_COMMAND,      &C_SmimeVerifyCommand,                  0 },
-  { "smime_verify_opaque_command",             DT_STRING|DT_COMMAND,      &C_SmimeVerifyOpaqueCommand,            0 },
+  { "smime_sign_command", DT_STRING|DT_COMMAND, &C_SmimeSignCommand, 0, 0, NULL,
+    "(smime) External command to sign a message"
+  },
+  { "smime_sign_digest_alg", DT_STRING, &C_SmimeSignDigestAlg, IP "sha256", 0, NULL,
+    "Digest algorithm"
+  },
+  { "smime_timeout", DT_NUMBER|DT_NOT_NEGATIVE, &C_SmimeTimeout, 300, 0, NULL,
+    "Time in seconds to cache a passphrase"
+  },
+  { "smime_verify_command", DT_STRING|DT_COMMAND, &C_SmimeVerifyCommand, 0, 0, NULL,
+    "(smime) External command to verify a signed message"
+  },
+  { "smime_verify_opaque_command", DT_STRING|DT_COMMAND, &C_SmimeVerifyOpaqueCommand, 0, 0, NULL,
+    "(smime) External command to verify a signature"
+  },
 #endif
-
-  { "smime_is_default",                        DT_BOOL,                   &C_SmimeIsDefault,                      false },
-  { "pgp_auto_decode",                         DT_BOOL,                   &C_PgpAutoDecode,                       false },
-  { "crypt_verify_sig",                        DT_QUAD,                   &C_CryptVerifySig,                      MUTT_YES },
-  { "crypt_protected_headers_save",            DT_BOOL,                   &C_CryptProtectedHeadersSave,           false },
+  { "smime_is_default", DT_BOOL, &C_SmimeIsDefault, false, 0, NULL,
+    "Use SMIME rather than PGP by default"
+  },
+  { "pgp_auto_decode", DT_BOOL, &C_PgpAutoDecode, false, 0, NULL,
+    "Automatically decrypt PGP messages"
+  },
+  { "crypt_verify_sig", DT_QUAD, &C_CryptVerifySig, MUTT_YES, 0, NULL,
+    "Verify PGP or SMIME signatures"
+  },
+  { "crypt_protected_headers_save", DT_BOOL, &C_CryptProtectedHeadersSave, false, 0, NULL,
+    "Save the cleartext Subject with the headers"
+  },
 
   { "pgp_create_traditional", DT_SYNONYM, NULL, IP "pgp_autoinline",    },
   { "pgp_self_encrypt_as",    DT_SYNONYM, NULL, IP "pgp_default_key",   },
@@ -210,9 +341,9 @@ struct ConfigDef NcryptVars[] = {
   { "pgp_encrypt_self",   DT_DEPRECATED|DT_QUAD, &C_PgpEncryptSelf,   MUTT_NO },
   { "smime_encrypt_self", DT_DEPRECATED|DT_QUAD, &C_SmimeEncryptSelf, MUTT_NO },
 
-  { NULL, 0, NULL, 0, 0, NULL },
+  { NULL, 0, NULL, 0, 0, NULL, NULL },
+  // clang-format on
 };
-// clang-format on
 
 /**
  * config_init_ncrypt - Register ncrypt config variables

--- a/nntp/config.c
+++ b/nntp/config.c
@@ -55,30 +55,68 @@ bool          C_ShowOnlyUnread;      ///< Config: (nntp) Only show subscribed ne
 bool          C_XCommentTo;          ///< Config: (nntp) Add 'X-Comment-To' header that contains article author
 // clang-format on
 
-// clang-format off
 struct ConfigDef NntpVars[] = {
-  { "catchup_newsgroup",     DT_QUAD,                                &C_CatchupNewsgroup,    MUTT_ASKYES },
-  { "followup_to_poster",    DT_QUAD,                                &C_FollowupToPoster,    MUTT_ASKYES },
-  { "group_index_format",    DT_STRING|DT_NOT_EMPTY|R_INDEX|R_PAGER, &C_GroupIndexFormat,    IP "%4C %M%N %5s  %-45.45f %d" },
-  { "newsgroups_charset",    DT_STRING,                              &C_NewsgroupsCharset,   IP "utf-8", 0, charset_validator },
-  { "newsrc",                DT_PATH|DT_PATH_FILE,                   &C_Newsrc,              IP "~/.newsrc" },
-  { "news_cache_dir",        DT_PATH|DT_PATH_DIR,                    &C_NewsCacheDir,        IP "~/.neomutt" },
-  { "news_server",           DT_STRING,                              &C_NewsServer,          0 },
-  { "nntp_authenticators",   DT_STRING,                              &C_NntpAuthenticators,  0 },
-  { "nntp_context",          DT_NUMBER|DT_NOT_NEGATIVE,              &C_NntpContext,         1000 },
-  { "nntp_listgroup",        DT_BOOL,                                &C_NntpListgroup,       true },
-  { "nntp_load_description", DT_BOOL,                                &C_NntpLoadDescription, true },
-  { "nntp_pass",             DT_STRING|DT_SENSITIVE,                 &C_NntpPass,            0 },
-  { "nntp_poll",             DT_NUMBER|DT_NOT_NEGATIVE,              &C_NntpPoll,            60 },
-  { "nntp_user",             DT_STRING|DT_SENSITIVE,                 &C_NntpUser,            0 },
-  { "post_moderated",        DT_QUAD,                                &C_PostModerated,       MUTT_ASKYES },
-  { "save_unsubscribed",     DT_BOOL,                                &C_SaveUnsubscribed,    false },
-  { "show_new_news",         DT_BOOL,                                &C_ShowNewNews,         true },
-  { "show_only_unread",      DT_BOOL,                                &C_ShowOnlyUnread,      false },
-  { "x_comment_to",          DT_BOOL,                                &C_XCommentTo,          false },
-  { NULL, 0, NULL, 0, 0, NULL },
+  // clang-format off
+  { "catchup_newsgroup", DT_QUAD, &C_CatchupNewsgroup, MUTT_ASKYES, 0, NULL,
+    "(nntp) Mark all articles as read when leaving a newsgroup"
+  },
+  { "followup_to_poster", DT_QUAD, &C_FollowupToPoster, MUTT_ASKYES, 0, NULL,
+    "(nntp) Reply to the poster if 'poster' is in the 'Followup-To' header"
+  },
+  { "group_index_format", DT_STRING|DT_NOT_EMPTY|R_INDEX|R_PAGER, &C_GroupIndexFormat, IP "%4C %M%N %5s  %-45.45f %d", 0, NULL,
+    "(nntp) printf-like format string for the browser's display of newsgroups"
+  },
+  { "newsgroups_charset", DT_STRING, &C_NewsgroupsCharset, IP "utf-8", 0, charset_validator,
+    "(nntp) Character set of newsgroups' descriptions"
+  },
+  { "newsrc", DT_PATH|DT_PATH_FILE, &C_Newsrc, IP "~/.newsrc", 0, NULL,
+    "(nntp) File containing list of subscribed newsgroups"
+  },
+  { "news_cache_dir", DT_PATH|DT_PATH_DIR, &C_NewsCacheDir, IP "~/.neomutt", 0, NULL,
+    "(nntp) Directory for cached news articles"
+  },
+  { "news_server", DT_STRING, &C_NewsServer, 0, 0, NULL,
+    "(nntp) Url of the news server"
+  },
+  { "nntp_authenticators", DT_STRING, &C_NntpAuthenticators, 0, 0, NULL,
+    "(nntp) Allowed authentication methods"
+  },
+  { "nntp_context", DT_NUMBER|DT_NOT_NEGATIVE, &C_NntpContext, 1000, 0, NULL,
+    "(nntp) Maximum number of articles to list (0 for all articles)"
+  },
+  { "nntp_listgroup", DT_BOOL, &C_NntpListgroup, true, 0, NULL,
+    "(nntp) Check all articles when opening a newsgroup"
+  },
+  { "nntp_load_description", DT_BOOL, &C_NntpLoadDescription, true, 0, NULL,
+    "(nntp) Load descriptions for newsgroups when adding to the list"
+  },
+  { "nntp_pass", DT_STRING|DT_SENSITIVE, &C_NntpPass, 0, 0, NULL,
+    "(nntp) Password for the news server"
+  },
+  { "nntp_poll", DT_NUMBER|DT_NOT_NEGATIVE, &C_NntpPoll, 60, 0, NULL,
+    "(nntp) Interval between checks for new posts"
+  },
+  { "nntp_user", DT_STRING|DT_SENSITIVE, &C_NntpUser, 0, 0, NULL,
+    "(nntp) Username for the news server"
+  },
+  { "post_moderated", DT_QUAD, &C_PostModerated, MUTT_ASKYES, 0, NULL,
+    "(nntp) Allow posting to moderated newsgroups"
+  },
+  { "save_unsubscribed", DT_BOOL, &C_SaveUnsubscribed, false, 0, NULL,
+    "(nntp) Save a list of unsubscribed newsgroups to the 'newsrc'"
+  },
+  { "show_new_news", DT_BOOL, &C_ShowNewNews, true, 0, NULL,
+    "(nntp) Check for new newsgroups when entering the browser"
+  },
+  { "show_only_unread", DT_BOOL, &C_ShowOnlyUnread, false, 0, NULL,
+    "(nntp) Only show subscribed newsgroups with unread articles"
+  },
+  { "x_comment_to", DT_BOOL, &C_XCommentTo, false, 0, NULL,
+    "(nntp) Add 'X-Comment-To' header that contains article author"
+  },
+  { NULL, 0, NULL, 0, 0, NULL, NULL },
+  // clang-format on
 };
-// clang-format on
 
 /**
  * config_init_nntp - Register nntp config variables

--- a/notmuch/config.c
+++ b/notmuch/config.c
@@ -50,28 +50,58 @@ char *C_VfolderFormat;                ///< Config: (notmuch) printf-like format 
 bool  C_VirtualSpoolfile;             ///< Config: (notmuch) Use the first virtual mailbox as a spool file
 // clang-format on
 
-// clang-format off
 struct ConfigDef NotmuchVars[] = {
-  { "nm_db_limit",                      DT_NUMBER|DT_NOT_NEGATIVE,      &C_NmDbLimit,                    0 },
-  { "nm_default_url",                   DT_STRING,                      &C_NmDefaultUrl,                 0 },
-  { "nm_exclude_tags",                  DT_STRING,                      &C_NmExcludeTags,                0 },
-  { "nm_flagged_tag",                   DT_STRING,                      &C_NmFlaggedTag,                 IP "flagged" },
-  { "nm_open_timeout",                  DT_NUMBER|DT_NOT_NEGATIVE,      &C_NmOpenTimeout,                5 },
-  { "nm_query_type",                    DT_STRING,                      &C_NmQueryType,                  IP "messages" },
-  { "nm_query_window_current_position", DT_NUMBER,                      &C_NmQueryWindowCurrentPosition, 0 },
-  { "nm_query_window_current_search",   DT_STRING,                      &C_NmQueryWindowCurrentSearch,   0 },
-  { "nm_query_window_duration",         DT_NUMBER|DT_NOT_NEGATIVE,      &C_NmQueryWindowDuration,        0 },
-  { "nm_query_window_timebase",         DT_STRING,                      &C_NmQueryWindowTimebase,        IP "week" },
-  { "nm_record_tags",                   DT_STRING,                      &C_NmRecordTags,                 0 },
-  { "nm_replied_tag",                   DT_STRING,                      &C_NmRepliedTag,                 IP "replied" },
-  { "nm_unread_tag",                    DT_STRING,                      &C_NmUnreadTag,                  IP "unread" },
-  { "vfolder_format",                   DT_STRING|DT_NOT_EMPTY|R_INDEX, &C_VfolderFormat,                IP "%2C %?n?%4n/&     ?%4m %f" },
-  { "virtual_spoolfile",                DT_BOOL,                        &C_VirtualSpoolfile,             false },
+  // clang-format off
+  { "nm_db_limit", DT_NUMBER|DT_NOT_NEGATIVE, &C_NmDbLimit, 0, 0, NULL,
+    "(notmuch) Default limit for Notmuch queries"
+  },
+  { "nm_default_url", DT_STRING, &C_NmDefaultUrl, 0, 0, NULL,
+    "(notmuch) Path to the Notmuch database"
+  },
+  { "nm_exclude_tags", DT_STRING, &C_NmExcludeTags, 0, 0, NULL,
+    "(notmuch) Exclude messages with these tags"
+  },
+  { "nm_flagged_tag", DT_STRING, &C_NmFlaggedTag, IP "flagged", 0, NULL,
+    "(notmuch) Tag to use for flagged messages"
+  },
+  { "nm_open_timeout", DT_NUMBER|DT_NOT_NEGATIVE, &C_NmOpenTimeout, 5, 0, NULL,
+    "(notmuch) Database timeout"
+  },
+  { "nm_query_type", DT_STRING, &C_NmQueryType, IP "messages", 0, NULL,
+    "(notmuch) Default query type: 'threads' or 'messages'"
+  },
+  { "nm_query_window_current_position", DT_NUMBER, &C_NmQueryWindowCurrentPosition, 0, 0, NULL,
+    "(notmuch) Position of current search window"
+  },
+  { "nm_query_window_current_search", DT_STRING, &C_NmQueryWindowCurrentSearch, 0, 0, NULL,
+    "(notmuch) Current search parameters"
+  },
+  { "nm_query_window_duration", DT_NUMBER|DT_NOT_NEGATIVE, &C_NmQueryWindowDuration, 0, 0, NULL,
+    "(notmuch) Time duration of the current search window"
+  },
+  { "nm_query_window_timebase", DT_STRING, &C_NmQueryWindowTimebase, IP "week", 0, NULL,
+    "(notmuch) Units for the time duration"
+  },
+  { "nm_record_tags", DT_STRING, &C_NmRecordTags, 0, 0, NULL,
+    "(notmuch) Tags to apply to the 'record' mailbox (sent mail)"
+  },
+  { "nm_replied_tag", DT_STRING, &C_NmRepliedTag, IP "replied", 0, NULL,
+    "(notmuch) Tag to use for replied messages"
+  },
+  { "nm_unread_tag", DT_STRING, &C_NmUnreadTag, IP "unread", 0, NULL,
+    "(notmuch) Tag to use for unread messages"
+  },
+  { "vfolder_format", DT_STRING|DT_NOT_EMPTY|R_INDEX, &C_VfolderFormat, IP "%2C %?n?%4n/&     ?%4m %f", 0, NULL,
+    "(notmuch) printf-like format string for the browser's display of virtual folders"
+  },
+  { "virtual_spoolfile", DT_BOOL, &C_VirtualSpoolfile, false, 0, NULL,
+    "(notmuch) Use the first virtual mailbox as a spool file"
+  },
 
   { "nm_default_uri", DT_SYNONYM, NULL, IP "nm_default_url" },
-  { NULL, 0, NULL, 0, 0, NULL },
+  { NULL, 0, NULL, 0, 0, NULL, NULL },
+  // clang-format on
 };
-// clang-format on
 
 /**
  * config_init_notmuch - Register notmuch config variables

--- a/pattern/config.c
+++ b/pattern/config.c
@@ -37,14 +37,20 @@ char *C_PatternFormat = NULL;         ///< Config: printf-like format string for
 bool  C_ThoroughSearch;               ///< Config: Decode headers and messages before searching them
 // clang-format on
 
-// clang-format off
 struct ConfigDef PatternVars[] = {
-  { "external_search_command", DT_STRING|DT_COMMAND, &C_ExternalSearchCommand, 0 },
-  { "pattern_format", DT_STRING, &C_PatternFormat, IP "%2n %-15e  %d" },
-  { "thorough_search", DT_BOOL, &C_ThoroughSearch, true },
-  { NULL, 0, NULL, 0, 0, NULL },
+  // clang-format off
+  { "external_search_command", DT_STRING|DT_COMMAND, &C_ExternalSearchCommand, 0, 0, NULL,
+    "External search command"
+  },
+  { "pattern_format", DT_STRING, &C_PatternFormat, IP "%2n %-15e  %d", 0, NULL,
+    "printf-like format string for the pattern completion menu"
+  },
+  { "thorough_search", DT_BOOL, &C_ThoroughSearch, true, 0, NULL,
+    "Decode headers and messages before searching them"
+  },
+  { NULL, 0, NULL, 0, 0, NULL, NULL },
+  // clang-format on
 };
-// clang-format on
 
 /**
  * config_init_pattern - Register pattern config variables

--- a/pop/config.c
+++ b/pop/config.c
@@ -45,21 +45,41 @@ unsigned char C_PopReconnect;           ///< Config: (pop) Reconnect to the serv
 char *        C_PopUser;                ///< Config: (pop) Username of the POP server
 // clang-format on
 
-// clang-format off
 struct ConfigDef PopVars[] = {
-  { "pop_auth_try_all",          DT_BOOL,                           &C_PopAuthTryAll,          true },
-  { "pop_authenticators",        DT_SLIST|SLIST_SEP_COLON,          &C_PopAuthenticators,      0 },
-  { "pop_checkinterval",         DT_NUMBER|DT_NOT_NEGATIVE,         &C_PopCheckinterval,       60 },
-  { "pop_delete",                DT_QUAD,                           &C_PopDelete,              MUTT_ASKNO },
-  { "pop_host",                  DT_STRING,                         &C_PopHost,                0 },
-  { "pop_last",                  DT_BOOL,                           &C_PopLast,                false },
-  { "pop_oauth_refresh_command", DT_STRING|DT_COMMAND|DT_SENSITIVE, &C_PopOauthRefreshCommand, 0 },
-  { "pop_pass",                  DT_STRING|DT_SENSITIVE,            &C_PopPass,                0 },
-  { "pop_reconnect",             DT_QUAD,                           &C_PopReconnect,           MUTT_ASKYES },
-  { "pop_user",                  DT_STRING|DT_SENSITIVE,            &C_PopUser,                0 },
-  { NULL, 0, NULL, 0, 0, NULL },
+  // clang-format off
+  { "pop_auth_try_all", DT_BOOL, &C_PopAuthTryAll, true, 0, NULL,
+    "(pop) Try all available authentication methods"
+  },
+  { "pop_authenticators", DT_SLIST|SLIST_SEP_COLON, &C_PopAuthenticators, 0, 0, NULL,
+    "(pop) List of allowed authentication methods"
+  },
+  { "pop_checkinterval", DT_NUMBER|DT_NOT_NEGATIVE, &C_PopCheckinterval, 60, 0, NULL,
+    "(pop) Interval between checks for new mail"
+  },
+  { "pop_delete", DT_QUAD, &C_PopDelete, MUTT_ASKNO, 0, NULL,
+    "(pop) After downloading POP messages, delete them on the server"
+  },
+  { "pop_host", DT_STRING, &C_PopHost, 0, 0, NULL,
+    "(pop) Url of the POP server"
+  },
+  { "pop_last", DT_BOOL, &C_PopLast, false, 0, NULL,
+    "(pop) Use the 'LAST' command to fetch new mail"
+  },
+  { "pop_oauth_refresh_command", DT_STRING|DT_COMMAND|DT_SENSITIVE, &C_PopOauthRefreshCommand, 0, 0, NULL,
+    "(pop) External command to generate OAUTH refresh token"
+  },
+  { "pop_pass", DT_STRING|DT_SENSITIVE, &C_PopPass, 0, 0, NULL,
+    "(pop) Password of the POP server"
+  },
+  { "pop_reconnect", DT_QUAD, &C_PopReconnect, MUTT_ASKYES, 0, NULL,
+    "(pop) Reconnect to the server is the connection is lost"
+  },
+  { "pop_user", DT_STRING|DT_SENSITIVE, &C_PopUser, 0, 0, NULL,
+    "(pop) Username of the POP server"
+  },
+  { NULL, 0, NULL, 0, 0, NULL, NULL },
+  // clang-format on
 };
-// clang-format on
 
 /**
  * config_init_pop - Register pop config variables

--- a/send/config.c
+++ b/send/config.c
@@ -52,85 +52,223 @@ int wrapheaders_validator(const struct ConfigSet *cs, const struct ConfigDef *cd
   return CSR_ERR_INVALID;
 }
 
-// clang-format off
 struct ConfigDef SendVars[] = {
-  { "abort_noattach",              DT_QUAD,                           NULL, MUTT_NO },
-  { "abort_noattach_regex",        DT_REGEX,                          NULL, IP "\\<(attach|attached|attachments?)\\>" },
-  { "abort_nosubject",             DT_QUAD,                           NULL, MUTT_ASKYES },
-  { "abort_unmodified",            DT_QUAD,                           NULL, MUTT_YES },
-  { "allow_8bit",                  DT_BOOL,                           NULL, true },
-  { "ask_follow_up",               DT_BOOL,                           NULL, false },
+  // clang-format off
+  { "abort_noattach", DT_QUAD, NULL, MUTT_NO, 0, NULL,
+    "Abort sending the email if attachments are missing"
+  },
+  { "abort_noattach_regex", DT_REGEX, NULL, IP "\\<(attach|attached|attachments?)\\>", 0, NULL,
+    "Regex to match text indicating attachments are expected"
+  },
+  { "abort_nosubject", DT_QUAD, NULL, MUTT_ASKYES, 0, NULL,
+    "Abort creating the email if subject is missing"
+  },
+  { "abort_unmodified", DT_QUAD, NULL, MUTT_YES, 0, NULL,
+    "Abort the sending if the message hasn't been edited"
+  },
+  { "allow_8bit", DT_BOOL, NULL, true, 0, NULL,
+    "Allow 8-bit messages, don't use quoted-printable or base64"
+  },
+  { "ask_follow_up", DT_BOOL, NULL, false, 0, NULL,
+    "(nntp) Ask the user for follow-up groups before editing"
+  },
 #ifdef USE_NNTP
-  { "ask_x_comment_to",            DT_BOOL,                           NULL, false },
+  { "ask_x_comment_to", DT_BOOL, NULL, false, 0, NULL,
+    "(nntp) Ask the user for the 'X-Comment-To' field before editing"
+  },
 #endif
-  { "attach_charset",              DT_STRING,                         NULL, 0, 0, charset_validator },
-  { "bounce_delivered",            DT_BOOL,                           NULL, true },
-  { "content_type",                DT_STRING,                         NULL, IP "text/plain" },
-  { "crypt_autoencrypt",           DT_BOOL,                           NULL, false },
-  { "crypt_autopgp",               DT_BOOL,                           NULL, true },
-  { "crypt_autosign",              DT_BOOL,                           NULL, false },
-  { "crypt_autosmime",             DT_BOOL,                           NULL, true },
-  { "crypt_replyencrypt",          DT_BOOL,                           NULL, true },
-  { "crypt_replysign",             DT_BOOL,                           NULL, false },
-  { "crypt_replysignencrypted",    DT_BOOL,                           NULL, false },
-  { "dsn_notify",                  DT_STRING,                         NULL, 0 },
-  { "dsn_return",                  DT_STRING,                         NULL, 0 },
-  { "empty_subject",               DT_STRING,                         NULL, IP "Re: your mail" },
-  { "encode_from",                 DT_BOOL,                           NULL, false },
-  { "fast_reply",                  DT_BOOL,                           NULL, false },
-  { "fcc_attach",                  DT_QUAD,                           NULL, MUTT_YES },
-  { "fcc_before_send",             DT_BOOL,                           NULL, false },
-  { "fcc_clear",                   DT_BOOL,                           NULL, false },
-  { "followup_to",                 DT_BOOL,                           NULL, true },
-  { "forward_attribution_intro",   DT_STRING,                         NULL, IP "----- Forwarded message from %f -----" },
-  { "forward_attribution_trailer", DT_STRING,                         NULL, IP "----- End forwarded message -----" },
-  { "forward_decrypt",             DT_BOOL,                           NULL, true },
-  { "forward_edit",                DT_QUAD,                           NULL, MUTT_YES },
-  { "forward_format",              DT_STRING|DT_NOT_EMPTY,            NULL, IP "[%a: %s]" },
-  { "forward_references",          DT_BOOL,                           NULL, false },
-  { "hdrs",                        DT_BOOL,                           NULL, true },
-  { "hidden_host",                 DT_BOOL,                           NULL, false },
-  { "honor_followup_to",           DT_QUAD,                           NULL, MUTT_YES },
-  { "ignore_list_reply_to",        DT_BOOL,                           NULL, false },
-  { "include",                     DT_QUAD,                           NULL, MUTT_ASKYES },
+  { "attach_charset", DT_STRING, NULL, 0, 0, charset_validator,
+    "When attaching files, use one of these character sets"
+  },
+  { "bounce_delivered", DT_BOOL, NULL, true, 0, NULL,
+    "Add 'Delivered-To' to bounced messages"
+  },
+  { "content_type", DT_STRING, NULL, IP "text/plain", 0, NULL,
+    "Default 'Content-Type' for newly composed messages"
+  },
+  { "crypt_autoencrypt", DT_BOOL, NULL, false, 0, NULL,
+    "Automatically PGP encrypt all outgoing mail"
+  },
+  { "crypt_autopgp", DT_BOOL, NULL, true, 0, NULL,
+    "Allow automatic PGP functions"
+  },
+  { "crypt_autosign", DT_BOOL, NULL, false, 0, NULL,
+    "Automatically PGP sign all outgoing mail"
+  },
+  { "crypt_autosmime", DT_BOOL, NULL, true, 0, NULL,
+    "Allow automatic SMIME functions"
+  },
+  { "crypt_replyencrypt", DT_BOOL, NULL, true, 0, NULL,
+    "Encrypt replies to encrypted messages"
+  },
+  { "crypt_replysign", DT_BOOL, NULL, false, 0, NULL,
+    "Sign replies to signed messages"
+  },
+  { "crypt_replysignencrypted", DT_BOOL, NULL, false, 0, NULL,
+    "Sign replies to encrypted messages"
+  },
+  { "dsn_notify", DT_STRING, NULL, 0, 0, NULL,
+    "Request notification for message delivery or delay"
+  },
+  { "dsn_return", DT_STRING, NULL, 0, 0, NULL,
+    "What to send as a notification of message delivery or delay"
+  },
+  { "empty_subject", DT_STRING, NULL, IP "Re: your mail", 0, NULL,
+    "Subject to use when replying to an email with none"
+  },
+  { "encode_from", DT_BOOL, NULL, false, 0, NULL,
+    "Encode 'From ' as 'quote-printable' at the beginning of lines"
+  },
+  { "fast_reply", DT_BOOL, NULL, false, 0, NULL,
+    "Don't prompt for the recipients and subject when replying/forwarding"
+  },
+  { "fcc_attach", DT_QUAD, NULL, MUTT_YES, 0, NULL,
+    "Save send message with all their attachments"
+  },
+  { "fcc_before_send", DT_BOOL, NULL, false, 0, NULL,
+    "Save FCCs before sending the message"
+  },
+  { "fcc_clear", DT_BOOL, NULL, false, 0, NULL,
+    "Save sent messages unencrypted and unsigned"
+  },
+  { "followup_to", DT_BOOL, NULL, true, 0, NULL,
+    "Add the 'Mail-Followup-To' header is generated when sending mail"
+  },
+  { "forward_attribution_intro", DT_STRING, NULL, IP "----- Forwarded message from %f -----", 0, NULL,
+    "Prefix message for forwarded messages"
+  },
+  { "forward_attribution_trailer", DT_STRING, NULL, IP "----- End forwarded message -----", 0, NULL,
+    "Suffix message for forwarded messages"
+  },
+  { "forward_decrypt", DT_BOOL, NULL, true, 0, NULL,
+    "Decrypt the message when forwarding it"
+  },
+  { "forward_edit", DT_QUAD, NULL, MUTT_YES, 0, NULL,
+    "Automatically start the editor when forwarding a message"
+  },
+  { "forward_format", DT_STRING|DT_NOT_EMPTY, NULL, IP "[%a: %s]", 0, NULL,
+    "printf-like format string to control the subject when forwarding a message"
+  },
+  { "forward_references", DT_BOOL, NULL, false, 0, NULL,
+    "Set the 'In-Reply-To' and 'References' headers when forwarding a message"
+  },
+  { "hdrs", DT_BOOL, NULL, true, 0, NULL,
+    "Add custom headers to outgoing mail"
+  },
+  { "hidden_host", DT_BOOL, NULL, false, 0, NULL,
+    "Don't use the hostname, just the domain, when generating the message id"
+  },
+  { "honor_followup_to", DT_QUAD, NULL, MUTT_YES, 0, NULL,
+    "Honour the 'Mail-Followup-To' header when group replying"
+  },
+  { "ignore_list_reply_to", DT_BOOL, NULL, false, 0, NULL,
+    "Ignore the 'Reply-To' header when using `<reply>` on a mailing list"
+  },
+  { "include", DT_QUAD, NULL, MUTT_ASKYES, 0, NULL,
+    "Include a copy of the email that's being replied to"
+  },
 #ifdef USE_NNTP
-  { "inews",                       DT_STRING|DT_COMMAND,              NULL, 0 },
+  { "inews", DT_STRING|DT_COMMAND, NULL, 0, 0, NULL,
+    "(nntp) External command to post news articles"
+  },
 #endif
-  { "metoo",                       DT_BOOL,                           NULL, false },
-  { "mime_forward_decode",         DT_BOOL,                           NULL, false },
+  { "metoo", DT_BOOL, NULL, false, 0, NULL,
+    "Remove the user's address from the list of recipients"
+  },
+  { "mime_forward_decode", DT_BOOL, NULL, false, 0, NULL,
+    "Decode the forwarded message before attaching it"
+  },
 #ifdef USE_NNTP
-  { "mime_subject",                DT_BOOL,                           NULL, true },
+  { "mime_subject", DT_BOOL, NULL, true, 0, NULL,
+    "(nntp) Encode the article subject in base64"
+  },
 #endif
-  { "mime_type_query_command",     DT_STRING|DT_COMMAND,              NULL, 0 },
-  { "mime_type_query_first",       DT_BOOL,                           NULL, false },
-  { "nm_record",                   DT_BOOL,                           NULL, false },
-  { "pgp_replyinline",             DT_BOOL,                           NULL, false },
-  { "post_indent_string",          DT_STRING,                         NULL, 0 },
-  { "postpone_encrypt",            DT_BOOL,                           NULL, false },
-  { "postpone_encrypt_as",         DT_STRING,                         NULL, 0 },
-  { "recall",                      DT_QUAD,                           NULL, MUTT_ASKYES },
-  { "reply_self",                  DT_BOOL,                           NULL, false },
-  { "reply_to",                    DT_QUAD,                           NULL, MUTT_ASKYES },
-  { "reply_with_xorig",            DT_BOOL,                           NULL, false },
-  { "reverse_name",                DT_BOOL|R_INDEX|R_PAGER,           NULL, false },
-  { "reverse_realname",            DT_BOOL|R_INDEX|R_PAGER,           NULL, true },
-  { "sendmail",                    DT_STRING|DT_COMMAND,              NULL, IP SENDMAIL " -oem -oi" },
-  { "sendmail_wait",               DT_NUMBER,                         NULL, 0 },
-  { "sig_dashes",                  DT_BOOL,                           NULL, true },
-  { "sig_on_top",                  DT_BOOL,                           NULL, false },
-  { "signature",                   DT_PATH|DT_PATH_FILE,              NULL, IP "~/.signature" },
+  { "mime_type_query_command", DT_STRING|DT_COMMAND, NULL, 0, 0, NULL,
+    "External command to determine the MIME type of an attachment"
+  },
+  { "mime_type_query_first", DT_BOOL, NULL, false, 0, NULL,
+    "Run the #C_MimeTypeQueryCommand before the mime.types lookup"
+  },
+  { "nm_record", DT_BOOL, NULL, false, 0, NULL,
+    "(notmuch) If the 'record' mailbox (sent mail) should be indexed"
+  },
+  { "pgp_replyinline", DT_BOOL, NULL, false, 0, NULL,
+    "Reply using old-style inline PGP messages (not recommended)"
+  },
+  { "post_indent_string", DT_STRING, NULL, 0, 0, NULL,
+    "Suffix message to add after reply text"
+  },
+  { "postpone_encrypt", DT_BOOL, NULL, false, 0, NULL,
+    "Self-encrypt postponed messages"
+  },
+  { "postpone_encrypt_as", DT_STRING, NULL, 0, 0, NULL,
+    "Fallback encryption key for postponed messages"
+  },
+  { "recall", DT_QUAD, NULL, MUTT_ASKYES, 0, NULL,
+    "Recall postponed mesaages when asked to compose a message"
+  },
+  { "reply_self", DT_BOOL, NULL, false, 0, NULL,
+    "Really reply to yourself, when replying to your own email"
+  },
+  { "reply_to", DT_QUAD, NULL, MUTT_ASKYES, 0, NULL,
+    "Address to use as a 'Reply-To' header"
+  },
+  { "reply_with_xorig", DT_BOOL, NULL, false, 0, NULL,
+    "Create 'From' header from 'X-Original-To' header"
+  },
+  { "reverse_name", DT_BOOL|R_INDEX|R_PAGER, NULL, false, 0, NULL,
+    "Set the 'From' from the address the email was sent to"
+  },
+  { "reverse_realname", DT_BOOL|R_INDEX|R_PAGER, NULL, true, 0, NULL,
+    "Set the 'From' from the full 'To' address the email was sent to"
+  },
+  { "sendmail", DT_STRING|DT_COMMAND, NULL, IP SENDMAIL " -oem -oi", 0, NULL,
+    "External command to send email"
+  },
+  { "sendmail_wait", DT_NUMBER, NULL, 0, 0, NULL,
+    "Time to wait for sendmail to finish"
+  },
+  { "sig_dashes", DT_BOOL, NULL, true, 0, NULL,
+    "Insert '-- ' before the signature"
+  },
+  { "sig_on_top", DT_BOOL, NULL, false, 0, NULL,
+    "Insert the signature before the quoted text"
+  },
+  { "signature", DT_PATH|DT_PATH_FILE, NULL, IP "~/.signature", 0, NULL,
+    "File containing a signature to append to all mail"
+  },
 #ifdef USE_SMTP
-  { "smtp_authenticators",         DT_SLIST|SLIST_SEP_COLON,          NULL, 0 },
-  { "smtp_oauth_refresh_command",  DT_STRING|DT_COMMAND|DT_SENSITIVE, NULL, 0 },
-  { "smtp_pass",                   DT_STRING|DT_SENSITIVE,            NULL, 0 },
-  { "smtp_user",                   DT_STRING|DT_SENSITIVE,            NULL, 0 },
-  { "smtp_url",                    DT_STRING|DT_SENSITIVE,            NULL, 0 },
+  { "smtp_authenticators", DT_SLIST|SLIST_SEP_COLON, NULL, 0, 0, NULL,
+    "(smtp) List of allowed authentication methods"
+  },
+  { "smtp_oauth_refresh_command", DT_STRING|DT_COMMAND|DT_SENSITIVE, NULL, 0, 0, NULL,
+    "(smtp) External command to generate OAUTH refresh token"
+  },
+  { "smtp_pass", DT_STRING|DT_SENSITIVE, NULL, 0, 0, NULL,
+    "(smtp) Password for the SMTP server"
+  },
+  { "smtp_user", DT_STRING|DT_SENSITIVE, NULL, 0, 0, NULL,
+    "(smtp) Username for the SMTP server"
+  },
+  { "smtp_url", DT_STRING|DT_SENSITIVE, NULL, 0, 0, NULL,
+    "(smtp) Url of the SMTP server"
+  },
 #endif
-  { "use_8bitmime",                DT_BOOL,                           NULL, false },
-  { "use_envelope_from",           DT_BOOL,                           NULL, false },
-  { "use_from",                    DT_BOOL,                           NULL, true },
-  { "user_agent",                  DT_BOOL,                           NULL, false },
-  { "wrap_headers",                DT_NUMBER|DT_NOT_NEGATIVE|R_PAGER, NULL, 78, 0, wrapheaders_validator },
+  { "use_8bitmime", DT_BOOL, NULL, false, 0, NULL,
+    "Use 8-bit messages and ESMTP to send messages"
+  },
+  { "use_envelope_from", DT_BOOL, NULL, false, 0, NULL,
+    "Set the envelope sender of the message"
+  },
+  { "use_from", DT_BOOL, NULL, true, 0, NULL,
+    "Set the 'From' header for outgoing mail"
+  },
+  { "user_agent", DT_BOOL, NULL, false, 0, NULL,
+    "Add a 'User-Agent' head to outgoing mail"
+  },
+  { "wrap_headers", DT_NUMBER|DT_NOT_NEGATIVE|R_PAGER, NULL, 78, 0, wrapheaders_validator,
+    "Width to wrap headers in outgoing messages"
+  },
 
   { "abort_noattach_regexp",  DT_SYNONYM, NULL, IP "abort_noattach_regex",     },
   { "attach_keyword",         DT_SYNONYM, NULL, IP "abort_noattach_regex",     },
@@ -144,9 +282,9 @@ struct ConfigDef SendVars[] = {
   { "pgp_replysign",          DT_SYNONYM, NULL, IP "crypt_replysign",          },
   { "pgp_replysignencrypted", DT_SYNONYM, NULL, IP "crypt_replysignencrypted", },
   { "post_indent_str",        DT_SYNONYM, NULL, IP "post_indent_string",       },
-  { NULL, 0, NULL, 0, 0, NULL },
+  { NULL, 0, NULL, 0, 0, NULL, NULL },
+  // clang-format on
 };
-// clang-format on
 
 /**
  * config_init_send - Register send config variables

--- a/sidebar/config.c
+++ b/sidebar/config.c
@@ -49,25 +49,53 @@ bool  C_SidebarVisible;             ///< Config: (sidebar) Show the sidebar
 short C_SidebarWidth;               ///< Config: (sidebar) Width of the sidebar
 // clang-format on
 
-// clang-format off
 struct ConfigDef SidebarVars[] = {
-  { "sidebar_component_depth",        DT_NUMBER|R_SIDEBAR,                &C_SidebarComponentDepth,      0 },
-  { "sidebar_delim_chars",            DT_STRING|R_SIDEBAR,                &C_SidebarDelimChars,          IP "/." },
-  { "sidebar_divider_char",           DT_STRING|R_SIDEBAR,                &C_SidebarDividerChar,         0 },
-  { "sidebar_folder_indent",          DT_BOOL|R_SIDEBAR,                  &C_SidebarFolderIndent,        false },
-  { "sidebar_format",                 DT_STRING|DT_NOT_EMPTY|R_SIDEBAR,   &C_SidebarFormat,              IP "%D%*  %n" },
-  { "sidebar_indent_string",          DT_STRING|R_SIDEBAR,                &C_SidebarIndentString,        IP "  " },
-  { "sidebar_new_mail_only",          DT_BOOL|R_SIDEBAR,                  &C_SidebarNewMailOnly,         false },
-  { "sidebar_next_new_wrap",          DT_BOOL,                            &C_SidebarNextNewWrap,         false },
-  { "sidebar_non_empty_mailbox_only", DT_BOOL|R_SIDEBAR,                  &C_SidebarNonEmptyMailboxOnly, false },
-  { "sidebar_on_right",               DT_BOOL|R_INDEX|R_PAGER|R_REFLOW,   &C_SidebarOnRight,             false },
-  { "sidebar_short_path",             DT_BOOL|R_SIDEBAR,                  &C_SidebarShortPath,           false },
-  { "sidebar_sort_method",            DT_SORT|DT_SORT_SIDEBAR|R_SIDEBAR,  &C_SidebarSortMethod,          SORT_ORDER },
-  { "sidebar_visible",                DT_BOOL|R_REFLOW,                   &C_SidebarVisible,             false },
-  { "sidebar_width",                  DT_NUMBER|DT_NOT_NEGATIVE|R_REFLOW, &C_SidebarWidth,               30 },
-  { NULL, 0, NULL, 0, 0, NULL },
+  // clang-format off
+  { "sidebar_component_depth", DT_NUMBER|R_SIDEBAR, &C_SidebarComponentDepth, 0, 0, NULL,
+    "(sidebar) Strip leading path components from sidebar folders"
+  },
+  { "sidebar_delim_chars", DT_STRING|R_SIDEBAR, &C_SidebarDelimChars, IP "/.", 0, NULL,
+    "(sidebar) Characters that separate nested folders"
+  },
+  { "sidebar_divider_char", DT_STRING|R_SIDEBAR, &C_SidebarDividerChar, 0, 0, NULL,
+    "(sidebar) Character to draw between the sidebar and index"
+  },
+  { "sidebar_folder_indent", DT_BOOL|R_SIDEBAR, &C_SidebarFolderIndent, false, 0, NULL,
+    "(sidebar) Indent nested folders"
+  },
+  { "sidebar_format", DT_STRING|DT_NOT_EMPTY|R_SIDEBAR, &C_SidebarFormat, IP "%D%*  %n", 0, NULL,
+    "(sidebar) printf-like format string for the sidebar panel"
+  },
+  { "sidebar_indent_string", DT_STRING|R_SIDEBAR, &C_SidebarIndentString, IP "  ", 0, NULL,
+    "(sidebar) Indent nested folders using this string"
+  },
+  { "sidebar_new_mail_only", DT_BOOL|R_SIDEBAR, &C_SidebarNewMailOnly, false, 0, NULL,
+    "(sidebar) Only show folders with new/flagged mail"
+  },
+  { "sidebar_next_new_wrap", DT_BOOL, &C_SidebarNextNewWrap, false, 0, NULL,
+    "(sidebar) Wrap around when searching for the next mailbox with new mail"
+  },
+  { "sidebar_non_empty_mailbox_only", DT_BOOL|R_SIDEBAR, &C_SidebarNonEmptyMailboxOnly, false, 0, NULL,
+    "(sidebar) Only show folders with a non-zero number of mail"
+  },
+  { "sidebar_on_right", DT_BOOL|R_INDEX|R_PAGER|R_REFLOW, &C_SidebarOnRight, false, 0, NULL,
+    "(sidebar) Display the sidebar on the right"
+  },
+  { "sidebar_short_path", DT_BOOL|R_SIDEBAR, &C_SidebarShortPath, false, 0, NULL,
+    "(sidebar) Abbreviate the paths using the #C_Folder variable"
+  },
+  { "sidebar_sort_method", DT_SORT|DT_SORT_SIDEBAR|R_SIDEBAR, &C_SidebarSortMethod, SORT_ORDER, 0, NULL,
+    "(sidebar) Method to sort the sidebar"
+  },
+  { "sidebar_visible", DT_BOOL|R_REFLOW, &C_SidebarVisible, false, 0, NULL,
+    "(sidebar) Show the sidebar"
+  },
+  { "sidebar_width", DT_NUMBER|DT_NOT_NEGATIVE|R_REFLOW, &C_SidebarWidth, 30, 0, NULL,
+    "(sidebar) Width of the sidebar"
+  },
+  { NULL, 0, NULL, 0, 0, NULL, NULL },
+  // clang-format on
 };
-// clang-format on
 
 /**
  * config_init_sidebar - Register sidebar config variables


### PR DESCRIPTION
This trivial PR adds one-liner help to all the config items.

The docs can be viewed from the command line:
- `neomutt -D -O` (or `-DO`) - view all config
- `neomutt -O -Q name` - for a single config item

```sh
# Editor to use when '~v' is given in the built-in editor
set visual = "/usr/bin/nvim"

# Prompt to press a key after running external commands
set wait_key = no

# Filter headers when displaying/forwarding/printing/replying
set weed = yes
```