### PR TITLE
Fix retrieval of drafts when "postponed" is not in the mailboxes list

### DIFF
--- a/mx.h
+++ b/mx.h
@@ -313,11 +313,12 @@ struct Mailbox *mx_resolve         (const char *path_or_name);
 int             mx_tags_commit     (struct Mailbox *m, struct Email *e, char *tags);
 int             mx_tags_edit       (struct Mailbox *m, const char *tags, char *buf, size_t buflen);
 
-struct Account *mx_ac_find   (struct Mailbox *m);
-struct Mailbox *mx_mbox_find (struct Account *a, const char *path);
-struct Mailbox *mx_mbox_find2(const char *path);
-int             mx_ac_add    (struct Account *a, struct Mailbox *m);
-int             mx_ac_remove (struct Mailbox *m);
+struct Account *mx_ac_find     (struct Mailbox *m);
+struct Mailbox *mx_mbox_find   (struct Account *a, const char *path);
+struct Mailbox *mx_mbox_find2  (const char *path);
+bool            mx_mbox_ac_link(struct Mailbox *m);
+int             mx_ac_add      (struct Account *a, struct Mailbox *m);
+int             mx_ac_remove   (struct Mailbox *m);
 
 int                 mx_access           (const char *path, int flags);
 void                mx_alloc_memory     (struct Mailbox *m);


### PR DESCRIPTION
Incidentally, this also allows to have "postponed" on a different
account.

Fixes #2430