### PR TITLE
Check for missing attachments in alternative parts

### DIFF
--- a/recvattach.c
+++ b/recvattach.c
@@ -375,7 +375,7 @@ const char *attach_format_str(char *buf, size_t buflen, size_t col, int cols, ch
     case 's':
     {
       size_t l;
-      if (flags & MUTT_FORMAT_STAT_FILE)
+      if (aptr->content->filename && (flags & MUTT_FORMAT_STAT_FILE))
       {
         struct stat st;
         stat(aptr->content->filename, &st);

--- a/send/sendlib.c
+++ b/send/sendlib.c
@@ -478,6 +478,8 @@ struct Content *mutt_get_content_info(const char *fname, struct Body *b,
 
   if (b && !fname)
     fname = b->filename;
+  if (!fname)
+    return NULL;
 
   if (stat(fname, &sb) == -1)
   {


### PR DESCRIPTION
Also, fix a failing stat(2) on the parent part, which doesn't have a
filename.

This unveils another problem: going back to the main loop in
mutt_send_message causes the alternative group to break. Trying to
recreate the group generates a new "unknown alternative group" part.
I think that's common to any code-path that does a goto main_loop in
mutt_send_message.

Fixes #2435