### PR TITLE
notify: split into multiple handlers

### DIFF
--- a/alias/dlgalias.c
+++ b/alias/dlgalias.c
@@ -202,7 +202,7 @@ static void alias_menu(char *buf, size_t buflen, struct AliasMenuData *mdata)
   menu->max = mdata->num_views;
   menu->mdata = mdata;
 
-  notify_observer_add(NeoMutt->notify, alias_data_observer, menu);
+  notify_observer_add(NeoMutt->notify, NT_ALIAS, alias_data_observer, menu);
   mutt_menu_push_current(menu);
 
   if ((C_SortAlias & SORT_MASK) != SORT_ORDER)

--- a/compose.c
+++ b/compose.c
@@ -1376,7 +1376,7 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur, 
     mutt_window_add_child(dlg, ebar);
   }
 
-  notify_observer_add(NeoMutt->notify, mutt_dlg_compose_observer, dlg);
+  notify_observer_add(NeoMutt->notify, NT_CONFIG, mutt_dlg_compose_observer, dlg);
   dialog_push(dlg);
 
 #ifdef USE_NNTP

--- a/gui/curs_lib.c
+++ b/gui/curs_lib.c
@@ -717,7 +717,7 @@ int mutt_do_pager(const char *banner, const char *tempfile, PagerFlags do_color,
     mutt_window_add_child(dlg, pbar);
   }
 
-  notify_observer_add(NeoMutt->notify, mutt_dlg_dopager_observer, dlg);
+  notify_observer_add(NeoMutt->notify, NT_CONFIG, mutt_dlg_dopager_observer, dlg);
   dialog_push(dlg);
 
   info->win_ibar = NULL;

--- a/gui/dialog.c
+++ b/gui/dialog.c
@@ -196,7 +196,7 @@ struct MuttWindow *dialog_create_simple_index(struct Menu *menu, enum WindowType
   menu->win_index = index;
   menu->win_ibar = ibar;
 
-  notify_observer_add(NeoMutt->notify, dialog_config_observer, dlg);
+  notify_observer_add(NeoMutt->notify, NT_CONFIG, dialog_config_observer, dlg);
   dialog_push(dlg);
 
   return dlg;

--- a/gui/mutt_window.c
+++ b/gui/mutt_window.c
@@ -378,7 +378,7 @@ void mutt_window_init(void)
   }
 
   mutt_window_add_child(RootWindow, MessageWindow);
-  notify_observer_add(NeoMutt->notify, mutt_dlg_rootwin_observer, RootWindow);
+  notify_observer_add(NeoMutt->notify, NT_CONFIG, mutt_dlg_rootwin_observer, RootWindow);
 }
 
 /**

--- a/index.c
+++ b/index.c
@@ -762,7 +762,7 @@ static void change_folder_mailbox(struct Menu *menu, struct Mailbox *m, int *old
   /* If the `folder-hook` were to call `unmailboxes`, then the Mailbox (`m`)
    * could be deleted, leaving `m` dangling. */
   // TODO: Refactor this function to avoid the need for an observer
-  notify_observer_add(m->notify, mailbox_index_observer, &m);
+  notify_observer_add(m->notify, NT_MAILBOX, mailbox_index_observer, &m);
   char *dup_path = mutt_str_dup(mailbox_path(m));
 
   mutt_folder_hook(mailbox_path(m), m ? m->name : NULL);
@@ -4134,7 +4134,7 @@ struct MuttWindow *index_pager_init(void)
   struct MuttWindow *dlg =
       mutt_window_new(WT_DLG_INDEX, MUTT_WIN_ORIENT_HORIZONTAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
-  notify_observer_add(NeoMutt->notify, mutt_dlgindex_observer, dlg);
+  notify_observer_add(NeoMutt->notify, NT_CONFIG, mutt_dlgindex_observer, dlg);
 
   mutt_window_add_child(dlg, create_panel_index(dlg, C_StatusOnTop));
   mutt_window_add_child(dlg, create_panel_pager(dlg, C_StatusOnTop));

--- a/main.c
+++ b/main.c
@@ -568,7 +568,7 @@ int main(int argc, char *argv[], char *envp[])
   NeoMutt = neomutt_new(cs);
 
 #ifdef USE_DEBUG_NOTIFY
-  notify_observer_add(NeoMutt->notify, debug_notify_observer, NULL);
+  notify_observer_add(NeoMutt->notify, NT_ALL, debug_notify_observer, NULL);
 #endif
 
   if (!get_user_info(cs))
@@ -807,13 +807,13 @@ int main(int argc, char *argv[], char *envp[])
     goto main_ok; // TEST22: neomutt -B
   }
 
-  notify_observer_add(NeoMutt->notify, mutt_hist_observer, NULL);
-  notify_observer_add(NeoMutt->notify, mutt_log_observer, NULL);
-  notify_observer_add(NeoMutt->notify, mutt_menu_config_observer, NULL);
-  notify_observer_add(NeoMutt->notify, mutt_reply_observer, NULL);
-  notify_observer_add(NeoMutt->notify, mutt_abort_key_config_observer, NULL);
+  notify_observer_add(NeoMutt->notify, NT_CONFIG, mutt_hist_observer, NULL);
+  notify_observer_add(NeoMutt->notify, NT_CONFIG, mutt_log_observer, NULL);
+  notify_observer_add(NeoMutt->notify, NT_CONFIG, mutt_menu_config_observer, NULL);
+  notify_observer_add(NeoMutt->notify, NT_CONFIG, mutt_reply_observer, NULL);
+  notify_observer_add(NeoMutt->notify, NT_CONFIG, mutt_abort_key_config_observer, NULL);
   if (Colors)
-    notify_observer_add(Colors->notify, mutt_menu_color_observer, NULL);
+    notify_observer_add(Colors->notify, NT_CONFIG, mutt_menu_color_observer, NULL);
 
   if (sendflags & SEND_POSTPONED)
   {

--- a/mutt/notify.c
+++ b/mutt/notify.c
@@ -158,6 +158,7 @@ bool notify_send(struct Notify *notify, enum NotifyType event_type,
 /**
  * notify_observer_add - Add an observer to an object
  * @param notify      Notification handler
+ * @param type        Notification type to observe, e.g. #NT_WINDOW
  * @param callback    Function to call on a matching event, see ::observer_t
  * @param global_data Private data associated with the observer
  * @retval true If successful
@@ -165,7 +166,8 @@ bool notify_send(struct Notify *notify, enum NotifyType event_type,
  * New observers are added to the front of the list, giving them higher
  * priority than existing observers.
  */
-bool notify_observer_add(struct Notify *notify, observer_t callback, void *global_data)
+bool notify_observer_add(struct Notify *notify, enum NotifyType type,
+                         observer_t callback, void *global_data)
 {
   if (!notify || !callback)
     return false;

--- a/mutt/notify.h
+++ b/mutt/notify.h
@@ -34,7 +34,7 @@ void notify_free(struct Notify **ptr);
 void notify_set_parent(struct Notify *notify, struct Notify *parent);
 
 bool notify_send(struct Notify *notify, enum NotifyType event_type, int event_subtype, void *event_data);
-bool notify_observer_add(struct Notify *notify, observer_t callback, void *global_data);
+bool notify_observer_add(struct Notify *notify, enum NotifyType type, observer_t callback, void *global_data);
 bool notify_observer_remove(struct Notify *notify, observer_t callback, void *global_data);
 void notify_observer_remove_all(struct Notify *notify);
 

--- a/mutt/notify_type.h
+++ b/mutt/notify_type.h
@@ -30,6 +30,7 @@
  */
 enum NotifyType
 {
+  NT_ALL = 0, ///< Register for all notifications
   NT_ACCOUNT, ///< Account has changed,         #NotifyAccount, #EventAccount
   NT_COLOR,   ///< Colour has changed,          #ColorId,       #EventColor
   NT_COMMAND, ///< A Command has been executed, #Command

--- a/mutt/observer.h
+++ b/mutt/observer.h
@@ -58,6 +58,7 @@ typedef int (*observer_t)(struct NotifyCallback *nc);
  */
 struct Observer
 {
+  enum NotifyType type;  ///< Notification type to observe, e.g. #NT_WINDOW
   observer_t callback;   ///< Callback function for events
   void *global_data;     ///< Private data to pass to callback
 };

--- a/mx.c
+++ b/mx.c
@@ -312,7 +312,7 @@ struct Context *mx_mbox_open(struct Mailbox *m, OpenMailboxFlags flags)
   notify_send(ctx->notify, NT_CONTEXT, NT_CONTEXT_OPEN, &ev_ctx);
 
   // If the Mailbox is closed, Context->mailbox must be set to NULL
-  notify_observer_add(m->notify, ctx_mailbox_observer, ctx);
+  notify_observer_add(m->notify, NT_MAILBOX, ctx_mailbox_observer, ctx);
 
   if ((m->type == MUTT_UNKNOWN) && (flags & (MUTT_NEWFOLDER | MUTT_APPEND)))
   {

--- a/sidebar/sidebar.c
+++ b/sidebar/sidebar.c
@@ -1123,7 +1123,7 @@ void sb_win_init(struct MuttWindow *dlg)
     mutt_window_add_child(dlg, cont_right);
   }
 
-  notify_observer_add(NeoMutt->notify, sb_observer, win_sidebar);
+  notify_observer_add(NeoMutt->notify, NT_CONFIG, sb_observer, win_sidebar);
 }
 
 /**
@@ -1151,7 +1151,7 @@ void sb_init(void)
   // - Functions
 
   // Listen for dialog creation events
-  notify_observer_add(NeoMutt->notify, sb_insertion_observer, NULL);
+  notify_observer_add(NeoMutt->notify, NT_WINDOW, sb_insertion_observer, NULL);
 }
 
 /**

--- a/test/config/account.c
+++ b/test/config/account.c
@@ -63,7 +63,7 @@ void test_config_account(void)
 
   set_list(cs);
 
-  notify_observer_add(NeoMutt->notify, log_observer, 0);
+  notify_observer_add(NeoMutt->notify, NT_CONFIG, log_observer, 0);
 
   const char *account = "damaged";
   const char *parent = "Pineapple";

--- a/test/config/address.c
+++ b/test/config/address.c
@@ -618,7 +618,7 @@ void test_config_address(void)
     return;
   dont_fail = false;
 
-  notify_observer_add(NeoMutt->notify, log_observer, 0);
+  notify_observer_add(NeoMutt->notify, NT_CONFIG, log_observer, 0);
 
   set_list(cs);
 

--- a/test/config/bool.c
+++ b/test/config/bool.c
@@ -786,7 +786,7 @@ void test_config_bool(void)
     return;
   dont_fail = false;
 
-  notify_observer_add(NeoMutt->notify, log_observer, 0);
+  notify_observer_add(NeoMutt->notify, NT_CONFIG, log_observer, 0);
 
   set_list(cs);
 

--- a/test/config/enum.c
+++ b/test/config/enum.c
@@ -670,7 +670,7 @@ void test_config_enum(void)
   if (!cs_register_variables(cs, Vars, 0))
     return;
 
-  notify_observer_add(NeoMutt->notify, log_observer, 0);
+  notify_observer_add(NeoMutt->notify, NT_CONFIG, log_observer, 0);
 
   set_list(cs);
 

--- a/test/config/initial.c
+++ b/test/config/initial.c
@@ -104,7 +104,7 @@ void test_config_initial(void)
   if (!cs_register_variables(cs, Vars, 0))
     return;
 
-  notify_observer_add(NeoMutt->notify, log_observer, 0);
+  notify_observer_add(NeoMutt->notify, NT_CONFIG, log_observer, 0);
 
   set_list(cs);
 

--- a/test/config/long.c
+++ b/test/config/long.c
@@ -813,7 +813,7 @@ void test_config_long(void)
     return;
   dont_fail = false;
 
-  notify_observer_add(NeoMutt->notify, log_observer, 0);
+  notify_observer_add(NeoMutt->notify, NT_CONFIG, log_observer, 0);
 
   set_list(cs);
 

--- a/test/config/mbtable.c
+++ b/test/config/mbtable.c
@@ -634,7 +634,7 @@ void test_config_mbtable(void)
     return;
   dont_fail = false;
 
-  notify_observer_add(NeoMutt->notify, log_observer, 0);
+  notify_observer_add(NeoMutt->notify, NT_CONFIG, log_observer, 0);
 
   set_list(cs);
 

--- a/test/config/number.c
+++ b/test/config/number.c
@@ -895,7 +895,7 @@ void test_config_number(void)
     return;
   dont_fail = false;
 
-  notify_observer_add(NeoMutt->notify, log_observer, 0);
+  notify_observer_add(NeoMutt->notify, NT_CONFIG, log_observer, 0);
 
   set_list(cs);
 

--- a/test/config/path.c
+++ b/test/config/path.c
@@ -654,7 +654,7 @@ void test_config_path(void)
     return;
   dont_fail = false;
 
-  notify_observer_add(NeoMutt->notify, log_observer, 0);
+  notify_observer_add(NeoMutt->notify, NT_CONFIG, log_observer, 0);
 
   set_list(cs);
 

--- a/test/config/quad.c
+++ b/test/config/quad.c
@@ -724,7 +724,7 @@ void test_config_quad(void)
     return;
   dont_fail = false;
 
-  notify_observer_add(NeoMutt->notify, log_observer, 0);
+  notify_observer_add(NeoMutt->notify, NT_CONFIG, log_observer, 0);
 
   set_list(cs);
 

--- a/test/config/regex.c
+++ b/test/config/regex.c
@@ -694,7 +694,7 @@ void test_config_regex(void)
     return;
   dont_fail = false;
 
-  notify_observer_add(NeoMutt->notify, log_observer, 0);
+  notify_observer_add(NeoMutt->notify, NT_CONFIG, log_observer, 0);
 
   set_list(cs);
 

--- a/test/config/slist.c
+++ b/test/config/slist.c
@@ -914,7 +914,7 @@ bool slist_test_separator(struct ConfigDef Vars[], struct Buffer *err)
   if (!cs_register_variables(cs, Vars, 0))
     return false;
 
-  notify_observer_add(NeoMutt->notify, log_observer, 0);
+  notify_observer_add(NeoMutt->notify, NT_CONFIG, log_observer, 0);
 
   set_list(cs);
 
@@ -959,7 +959,7 @@ void test_config_slist(void)
     return;
   dont_fail = false;
 
-  notify_observer_add(NeoMutt->notify, log_observer, 0);
+  notify_observer_add(NeoMutt->notify, NT_CONFIG, log_observer, 0);
 
   TEST_CHECK(test_native_set(cs, &err));
   TEST_CHECK(test_native_get(cs, &err));

--- a/test/config/sort.c
+++ b/test/config/sort.c
@@ -740,7 +740,7 @@ void test_config_sort(void)
     return;
   dont_fail = false;
 
-  notify_observer_add(NeoMutt->notify, log_observer, 0);
+  notify_observer_add(NeoMutt->notify, NT_CONFIG, log_observer, 0);
 
   set_list(cs);
 

--- a/test/config/string.c
+++ b/test/config/string.c
@@ -645,7 +645,7 @@ void test_config_string(void)
     return;
   dont_fail = false;
 
-  notify_observer_add(NeoMutt->notify, log_observer, 0);
+  notify_observer_add(NeoMutt->notify, NT_CONFIG, log_observer, 0);
 
   set_list(cs);
 

--- a/test/config/synonym.c
+++ b/test/config/synonym.c
@@ -203,7 +203,7 @@ void test_config_synonym(void)
 
   TEST_MSG("Expected error\n");
 
-  notify_observer_add(NeoMutt->notify, log_observer, 0);
+  notify_observer_add(NeoMutt->notify, NT_CONFIG, log_observer, 0);
 
   set_list(cs);
 

--- a/test/gui/visible.c
+++ b/test/gui/visible.c
@@ -132,7 +132,7 @@ void test_window_visible(void)
 
   struct NotifyCatcher results;
 
-  notify_observer_add(parent->notify, visible_observer, &results);
+  notify_observer_add(parent->notify, NT_WINDOW, visible_observer, &results);
 
   for (size_t i = 0; i < mutt_array_size(tests); i++)
   {

--- a/test/notify/notify_observer_add.c
+++ b/test/notify/notify_observer_add.c
@@ -27,5 +27,5 @@
 
 void test_notify_observer_add(void)
 {
-  // bool notify_observer_add(struct Notify *notify, observer_t callback, void *global_data);
+  // bool notify_observer_add(struct Notify *notify, NotifyType type, observer_t callback, void *global_data);
 }


### PR DESCRIPTION
Change the Observers to register their interest in specific events.

This adds a little complexity to the notification system, but
reduces the number of unwanted notifications received by the observers.

---

The alternative would be to have the observers to use bitfields to register **multiple** interest (one for each notification type)
See #2559 
