### PR TITLE
imap: fix crash in cmd_parse_expunge()

### DIFF
--- a/context.c
+++ b/context.c
@@ -38,6 +38,7 @@
 #include "mx.h"
 #include "score.h"
 #include "sort.h"
+#include "imap/lib.h"
 #include "maildir/lib.h"
 #include "ncrypt/lib.h"
 #include "pattern/lib.h"
@@ -279,6 +280,12 @@ void ctx_update_tables(struct Context *ctx, bool committing)
       if (m->id_hash && m->emails[i]->env->message_id)
         mutt_hash_delete(m->id_hash, m->emails[i]->env->message_id, m->emails[i]);
       mutt_label_hash_remove(m, m->emails[i]);
+
+#ifdef USE_IMAP
+      if (m->type == MUTT_IMAP)
+        imap_notify_delete_email(m, m->emails[i]);
+#endif
+
       email_free(&m->emails[i]);
     }
   }

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -621,6 +621,32 @@ int imap_read_literal(FILE *fp, struct ImapAccountData *adata,
 }
 
 /**
+ * imap_notify_delete_email - Inform IMAP that an Email has been deleted
+ * @param m Mailbox
+ * @param e Email
+ */
+void imap_notify_delete_email(struct Mailbox *m, struct Email *e)
+{
+  struct ImapMboxData *mdata = imap_mdata_get(m);
+  struct ImapEmailData *edata = imap_edata_get(e);
+
+  if (!mdata || !edata)
+    return;
+
+  int msn = edata->msn;
+  if ((msn < 1) || (msn > mdata->max_msn))
+  {
+    mutt_debug(LL_DEBUG3, "MSN %d out of range (max %d)\n", msn, mdata->max_msn);
+    return;
+  }
+
+  mutt_debug(LL_DEBUG3, "Clearing msn_index: value = %p, email = %p\n",
+             mdata->msn_index[msn - 1], e);
+  mdata->msn_index[msn - 1] = NULL;
+  edata->msn = 0;
+}
+
+/**
  * imap_expunge_mailbox - Purge messages from the server
  * @param m Mailbox
  *

--- a/imap/lib.h
+++ b/imap/lib.h
@@ -83,6 +83,7 @@ int imap_complete(char *buf, size_t buflen, const char *path);
 int imap_fast_trash(struct Mailbox *m, char *dest);
 enum MailboxType imap_path_probe(const char *path, const struct stat *st);
 int imap_path_canon(char *buf, size_t buflen);
+void imap_notify_delete_email(struct Mailbox *m, struct Email *e);
 
 extern struct MxOps MxImapOps;
 


### PR DESCRIPTION
The Mailbox and Imap keep separate lists of Emails:
- `Mailbox.emails[]`
- `ImapMboxData.msn_index[]`

When `ctx_update_tables()` deletes an Email, it's vital to tell Imap so its pointers aren't invalidated.

Fixes: #2549
