### PR TITLE
notmuch: improve synchronization with neomutt

### DIFF
--- a/notmuch/notmuch.c
+++ b/notmuch/notmuch.c
@@ -2369,6 +2369,7 @@ static int nm_mbox_sync(struct Mailbox *m)
 
   struct HeaderCache *h = nm_hcache_open(m);
 
+  int mh_sync_errors = 0;
   for (int i = 0; i < m->msg_count; i++)
   {
     char old_file[PATH_MAX], new_file[PATH_MAX];
@@ -2400,7 +2401,10 @@ static int nm_mbox_sync(struct Mailbox *m)
     m->type = MUTT_NOTMUCH;
 
     if (rc)
-      break;
+    {
+      mh_sync_errors += 1;
+      continue;
+    }
 
     if (!e->deleted)
       email_get_fullpath(e, new_file, sizeof(new_file));
@@ -2415,6 +2419,10 @@ static int nm_mbox_sync(struct Mailbox *m)
 
     FREE(&edata->oldpath);
   }
+
+  if (mh_sync_errors > 0)
+    mutt_error(
+        _("Unable to sync %d messages due to external mailbox modification"), mh_sync_errors);
 
   mutt_buffer_strcpy(&m->pathbuf, url);
   m->type = MUTT_NOTMUCH;

--- a/notmuch/notmuch.c
+++ b/notmuch/notmuch.c
@@ -2418,6 +2418,22 @@ static int nm_mbox_sync(struct Mailbox *m)
     mutt_buffer_strcpy(&m->pathbuf, edata->folder);
     m->type = edata->type;
     rc = mh_sync_mailbox_message(m, i, h);
+
+    // Syncing file failed, query notmuch for new filepath.
+    if (rc)
+    {
+      notmuch_database_t *db = nm_db_get(m, true);
+      if (db)
+      {
+        notmuch_message_t *msg = get_nm_message(db, e);
+
+        sync_email_path_with_nm(e, msg);
+
+        rc = mh_sync_mailbox_message(m, i, h);
+      }
+      nm_db_release(m);
+    }
+
     mutt_buffer_strcpy(&m->pathbuf, url);
     m->type = MUTT_NOTMUCH;
 


### PR DESCRIPTION
* **What does this PR do?**

This pull request contains three distinct changes (please don't squash):

 1. Don't lock up Neomutt if it can't sync a Notmuch mailbox. Syncing may fail if Neomutt and Notmuch go out-of-sync. Instead of leaving users in an situation that requires a significant effort to fix the syncing issue, sync what's possible then notify user. This is not an optimal solution, but the user experience is enhanced until root cause is tracked down. Otherwise, users have to exit the mailbox without saving or undo their changes to the mailbox.

 2. Update the email's path immediately after modifying tags. This ensures Neomutt and Notmuch stay more in-sync.

 3. Query Notmuch for email's filepath if Neomutt thinks it doesn't exist. External modification with `notmuch` may cause Neomutt to go out of sync with Notmuch, particularly if files are moved from underneath Neomutt. Since Notmuch is our source of truth, the email will be in there. If it's not in Notmuch then there's not much we can do while in a Notmuch mailbox. 

* **What are the relevant issue numbers?**
Closes #1826
Closes #1975