### PR TITLE
fix: maildir flag generation

### DIFF
--- a/maildir/maildir.c
+++ b/maildir/maildir.c
@@ -171,9 +171,11 @@ void maildir_gen_flags(char *dest, size_t destlen, struct Email *e)
 {
   *dest = '\0';
 
+  const char *flags = NULL;
+
   struct MaildirEmailData *edata = maildir_edata_get(e);
-  if (!edata)
-    return;
+  if (edata)
+    flags = edata->maildir_flags;
 
   /* The maildir specification requires that all files in the cur
    * subdirectory have the :unique string appended, regardless of whether
@@ -181,13 +183,12 @@ void maildir_gen_flags(char *dest, size_t destlen, struct Email *e)
    * will end up in the cur directory, so we include it in the following
    * test even though there is no associated flag.  */
 
-  if (e->flagged || e->replied || e->read || e->deleted || e->old || edata->maildir_flags)
+  if (e->flagged || e->replied || e->read || e->deleted || e->old || flags)
   {
     char tmp[1024];
-    snprintf(tmp, sizeof(tmp), "%s%s%s%s%s", e->flagged ? "F" : "",
-             e->replied ? "R" : "", e->read ? "S" : "", e->deleted ? "T" : "",
-             NONULL(edata->maildir_flags));
-    if (edata->maildir_flags)
+    snprintf(tmp, sizeof(tmp), "%s%s%s%s%s", e->flagged ? "F" : "", e->replied ? "R" : "",
+             e->read ? "S" : "", e->deleted ? "T" : "", NONULL(flags));
+    if (flags)
       qsort(tmp, strlen(tmp), 1, ch_compare);
     snprintf(dest, destlen, ":2,%s", tmp);
   }


### PR DESCRIPTION
When sending an email, the 'fcc' copy doesn't have a `MaildirEmailData`.

This meant that `maildir_gen_flags()` was failing, so the filename was missing its flags.
Without the flags, NeoMutt thinks it must be a new email.

Fixes: #2587 