### PR TITLE
Live Sorting in Address Book

### DIFF
--- a/alias/dlgalias.c
+++ b/alias/dlgalias.c
@@ -246,11 +246,8 @@ static void dlg_select_alias(char *buf, size_t buflen, struct AliasMenuData *mda
 
   mutt_menu_push_current(menu);
 
-  if ((C_SortAlias & SORT_MASK) != SORT_ORDER)
-  {
-    qsort(mdata->av, mdata->num_views, sizeof(struct AliasView *),
-          ((C_SortAlias & SORT_MASK) == SORT_ADDRESS) ? alias_sort_address : alias_sort_name);
-  }
+  qsort(mdata->av, mdata->num_views, sizeof(struct AliasView *),
+        alias_get_sort_function(C_SortAlias));
 
   for (int i = 0; i < menu->max; i++)
     mdata->av[i]->num = i;

--- a/alias/dlgalias.c
+++ b/alias/dlgalias.c
@@ -145,9 +145,9 @@ static int alias_tag(struct Menu *menu, int sel, int act)
 }
 
 /**
- * alias_data_observer - Listen for data changes affecting the Alias menu - Implements ::observer_t
+ * alias_alias_observer - Listen for data changes affecting the Alias menu - Implements ::observer_t
  */
-static int alias_data_observer(struct NotifyCallback *nc)
+static int alias_alias_observer(struct NotifyCallback *nc)
 {
   if (!nc->event_data || !nc->global_data)
     return -1;
@@ -171,6 +171,29 @@ static int alias_data_observer(struct NotifyCallback *nc)
 
   menu->max = mdata->num_views;
   menu->redraw = REDRAW_FULL;
+  return 0;
+}
+
+/**
+ * alias_config_observer - Listen for `sort_alias` configuration changes and reorders alias list - Implements ::observer_t
+ */
+static int alias_config_observer(struct NotifyCallback *nc)
+{
+  if (!nc->event_data)
+    return -1;
+  if (nc->event_type != NT_CONFIG)
+    return 0;
+
+  struct EventConfig *ec = nc->event_data;
+
+  if (!mutt_str_equal(ec->name, "sort_alias"))
+    return 0;
+
+  struct AliasMenuData *mdata = nc->global_data;
+
+  qsort(mdata->av, mdata->num_views, sizeof(struct AliasView *),
+        ((C_SortAlias & SORT_MASK) == SORT_ADDRESS) ? alias_sort_address : alias_sort_name);
+
   return 0;
 }
 
@@ -202,7 +225,9 @@ static void dlg_select_alias(char *buf, size_t buflen, struct AliasMenuData *mda
   menu->max = mdata->num_views;
   menu->mdata = mdata;
 
-  notify_observer_add(NeoMutt->notify, NT_ALIAS, alias_data_observer, menu);
+  notify_observer_add(NeoMutt->notify, NT_ALIAS, alias_alias_observer, menu);
+  notify_observer_add(NeoMutt->notify, NT_CONFIG, alias_config_observer, mdata);
+
   mutt_menu_push_current(menu);
 
   if ((C_SortAlias & SORT_MASK) != SORT_ORDER)
@@ -265,7 +290,9 @@ static void dlg_select_alias(char *buf, size_t buflen, struct AliasMenuData *mda
     mutt_addrlist_write(&mdata->av[t]->alias->addr, buf, buflen, true);
   }
 
-  notify_observer_remove(NeoMutt->notify, alias_data_observer, menu);
+  notify_observer_remove(NeoMutt->notify, alias_alias_observer, menu);
+  notify_observer_remove(NeoMutt->notify, alias_config_observer, mdata);
+
   mutt_menu_pop_current(menu);
   mutt_menu_free(&menu);
   dialog_destroy_simple_index(&dlg);

--- a/alias/dlgalias.c
+++ b/alias/dlgalias.c
@@ -199,6 +199,20 @@ static int alias_config_observer(struct NotifyCallback *nc)
 }
 
 /**
+ * alias_color_observer - Listen for color configuration changes and refresh the menu - Implements ::observer_t
+ */
+static int alias_color_observer(struct NotifyCallback *nc)
+{
+  if ((nc->event_type != NT_COLOR) || !nc->event_data || !nc->global_data)
+    return -1;
+
+  struct Menu *menu = nc->global_data;
+  menu->redraw = REDRAW_FULL;
+
+  return 0;
+}
+
+/**
  * dlg_select_alias - Display a menu of Aliases
  * @param buf    Buffer for expanded aliases
  * @param buflen Length of buffer
@@ -228,6 +242,7 @@ static void dlg_select_alias(char *buf, size_t buflen, struct AliasMenuData *mda
 
   notify_observer_add(NeoMutt->notify, NT_ALIAS, alias_alias_observer, menu);
   notify_observer_add(NeoMutt->notify, NT_CONFIG, alias_config_observer, mdata);
+  notify_observer_add(NeoMutt->notify, NT_COLOR, alias_color_observer, menu);
 
   mutt_menu_push_current(menu);
 
@@ -336,6 +351,7 @@ static void dlg_select_alias(char *buf, size_t buflen, struct AliasMenuData *mda
 
   notify_observer_remove(NeoMutt->notify, alias_alias_observer, menu);
   notify_observer_remove(NeoMutt->notify, alias_config_observer, mdata);
+  notify_observer_remove(NeoMutt->notify, alias_color_observer, menu);
 
   mutt_menu_pop_current(menu);
   mutt_menu_free(&menu);

--- a/alias/gui.c
+++ b/alias/gui.c
@@ -35,6 +35,7 @@
 #include "gui.h"
 #include "lib.h"
 #include "alias.h"
+#include "sort.h"
 
 #define RSORT(num) ((C_SortAlias & SORT_REVERSE) ? -num : num)
 
@@ -100,6 +101,19 @@ int alias_sort_address(const void *a, const void *b)
 }
 
 /**
+ * alias_sort_unsort - Compare two Aliases by their original configuration position - Implements ::sort_t
+ */
+int alias_sort_unsort(const void *a, const void *b)
+{
+  const struct AliasView *av_a = *(struct AliasView const *const *) a;
+  const struct AliasView *av_b = *(struct AliasView const *const *) b;
+
+  int r = (av_a->orig_seq - av_b->orig_seq);
+
+  return RSORT(r);
+}
+
+/**
  * alias_view_free - Free an AliasView
  * @param[out] ptr AliasView to free
  *
@@ -124,6 +138,25 @@ static void alias_view_free(struct AliasView **ptr)
 static struct AliasView *alias_view_new(void)
 {
   return mutt_mem_calloc(1, sizeof(struct AliasView));
+}
+
+/**
+ * alias_get_sort_function - Sorting function decision logic
+ * @param sort Sort method, e.g. #SORT_ALIAS
+ */
+sort_t alias_get_sort_function(short sort)
+{
+  switch ((C_SortAlias & SORT_MASK))
+  {
+    case SORT_ALIAS:
+      return alias_sort_name;
+    case SORT_ADDRESS:
+      return alias_sort_address;
+    case SORT_ORDER:
+      return alias_sort_unsort;
+    default:
+      return alias_sort_name;
+  }
 }
 
 /**
@@ -185,6 +218,7 @@ int menu_data_alias_add(struct AliasMenuData *mdata, struct Alias *alias)
   if (!mdata || !alias)
     return -1;
 
+  static int config_index = 0;
   const int chunk_size = 256;
 
   if (mdata->num_views >= mdata->max_views)
@@ -198,6 +232,7 @@ int menu_data_alias_add(struct AliasMenuData *mdata, struct Alias *alias)
 
   struct AliasView *av = alias_view_new();
   av->alias = alias;
+  av->orig_seq = config_index++;
 
   mdata->av[mdata->num_views] = av;
   mdata->num_views++;
@@ -243,12 +278,10 @@ int menu_data_alias_delete(struct AliasMenuData *mdata, struct Alias *alias)
  */
 void menu_data_sort(struct AliasMenuData *mdata)
 {
-  if ((C_SortAlias & SORT_MASK) != SORT_ORDER)
-  {
-    qsort(mdata->av, mdata->num_views, sizeof(struct AliasView *),
-          ((C_SortAlias & SORT_MASK) == SORT_ADDRESS) ? alias_sort_address : alias_sort_name);
-  }
+  qsort(mdata->av, mdata->num_views, sizeof(struct AliasView *),
+        alias_get_sort_function(C_SortAlias));
 
+  // Reset the index numbers
   for (int i = 0; i < mdata->num_views; i++)
     mdata->av[i]->num = i;
 }

--- a/alias/gui.c
+++ b/alias/gui.c
@@ -51,7 +51,7 @@ int alias_sort_name(const void *a, const void *b)
   const struct AliasView *av_a = *(struct AliasView const *const *) a;
   const struct AliasView *av_b = *(struct AliasView const *const *) b;
 
-  int r = mutt_istr_cmp(av_a->alias->name, av_b->alias->name);
+  int r = mutt_str_coll(av_a->alias->name, av_b->alias->name);
 
   return RSORT(r);
 }
@@ -85,14 +85,14 @@ int alias_sort_address(const void *a, const void *b)
     if (addr_a && addr_a->personal)
     {
       if (addr_b && addr_b->personal)
-        r = mutt_istr_cmp(addr_a->personal, addr_b->personal);
+        r = mutt_str_coll(addr_a->personal, addr_b->personal);
       else
         r = 1;
     }
     else if (addr_b && addr_b->personal)
       r = -1;
     else if (addr_a && addr_b)
-      r = mutt_istr_cmp(addr_a->mailbox, addr_b->mailbox);
+      r = mutt_str_coll(addr_a->mailbox, addr_b->mailbox);
     else
       r = 0;
   }

--- a/alias/gui.h
+++ b/alias/gui.h
@@ -24,6 +24,7 @@
 #define MUTT_ALIAS_GUI_H
 
 #include <stdbool.h>
+#include "sort.h"
 
 struct Alias;
 
@@ -33,6 +34,7 @@ struct Alias;
 struct AliasView
 {
   int num;             ///< Index number in list
+  int orig_seq;        ///< Sequence in alias config file
   bool is_tagged;      ///< Is it tagged?
   bool is_deleted;     ///< Is it deleted?
   struct Alias *alias; ///< Alias
@@ -56,7 +58,10 @@ int  menu_data_alias_add   (struct AliasMenuData *mdata, struct Alias *alias);
 int  menu_data_alias_delete(struct AliasMenuData *mdata, struct Alias *alias);
 void menu_data_sort        (struct AliasMenuData *mdata);
 
+sort_t alias_get_sort_function(short sort);
+
 int alias_sort_address(const void *a, const void *b);
 int alias_sort_name   (const void *a, const void *b);
+int alias_sort_unsort (const void *a, const void *b);
 
 #endif /* MUTT_ALIAS_GUI_H */

--- a/functions.c
+++ b/functions.c
@@ -532,6 +532,8 @@ const struct Binding OpPost[] = { /* map: postpone */
  */
 const struct Binding OpAlias[] = { /* map: alias */
   { "delete-entry",          OP_DELETE,                      "d" },
+  { "sort-alias",            OP_SORT,                        "o" },
+  { "sort-alias-reverse",    OP_SORT_REVERSE,                "O" },
   { "undelete-entry",        OP_UNDELETE,                    "u" },
   { NULL,                    0,                              NULL },
 };


### PR DESCRIPTION
* **What does this PR do?**
This PR adds the capability of the address book screen to update  on `$sort_alias` configuration changes.

* **Does this PR meet the acceptance criteria?** (This is just a reminder for you,
  this section can be removed if you fulfill it.)

   - Documentation created/updated (you have to edit
     [doc/manual.xml.head](https://www.github.com/neomutt/neomutt/blob/master/doc/manual.xml.head)
     for that)

   - All builds and tests are passing

   - Added [doxygen code documentation](https://neomutt.org/dev/doxygen)
     [syntax](http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html)

   - Code follows the [style guide](https://neomutt.org/dev/coding-style)

I don't think it does meet the acceptance criteria. What does need to be documented here?

* **What are the relevant issue numbers?**
The relevant issue number is #2589 .