### PR TITLE
Fix sidebar on new/removed mailboxes

### DIFF
--- a/command_parse.c
+++ b/command_parse.c
@@ -1978,11 +1978,17 @@ enum CommandResult parse_unmailboxes(struct Buffer *buf, struct Buffer *s,
 #ifdef USE_INOTIFY
       mutt_monitor_remove(np->mailbox);
 #endif
+      np->mailbox->flags = MB_HIDDEN;
       if (Context && (Context->mailbox == np->mailbox))
-        ctx_free(&Context);
-
-      account_mailbox_remove(np->mailbox->account, np->mailbox);
-      mailbox_free(&np->mailbox);
+      {
+        struct EventMailbox em = { NULL };
+        notify_send(NeoMutt->notify, NT_MAILBOX, NT_MAILBOX_SWITCH, &em);
+      }
+      else
+      {
+        account_mailbox_remove(np->mailbox->account, np->mailbox);
+        mailbox_free(&np->mailbox);
+      }
     }
     neomutt_mailboxlist_clear(&ml);
   }

--- a/command_parse.c
+++ b/command_parse.c
@@ -1979,14 +1979,10 @@ enum CommandResult parse_unmailboxes(struct Buffer *buf, struct Buffer *s,
       mutt_monitor_remove(np->mailbox);
 #endif
       if (Context && (Context->mailbox == np->mailbox))
-      {
-        np->mailbox->flags |= MB_HIDDEN;
-      }
-      else
-      {
-        account_mailbox_remove(np->mailbox->account, np->mailbox);
-        mailbox_free(&np->mailbox);
-      }
+        ctx_free(&Context);
+
+      account_mailbox_remove(np->mailbox->account, np->mailbox);
+      mailbox_free(&np->mailbox);
     }
     neomutt_mailboxlist_clear(&ml);
   }

--- a/core/account.c
+++ b/core/account.c
@@ -105,7 +105,6 @@ bool account_mailbox_remove(struct Account *a, struct Mailbox *m)
     {
       struct EventMailbox ev_m = { m };
       notify_send(a->notify, NT_MAILBOX, NT_MAILBOX_REMOVE, &ev_m);
-      notify_set_parent(a->notify, NULL);
       STAILQ_REMOVE(&a->mailboxes, np, MailboxNode, entries);
       if (!m)
         mailbox_free(&np->mailbox);

--- a/index.c
+++ b/index.c
@@ -3389,6 +3389,7 @@ int mutt_index_menu(struct MuttWindow *dlg)
         window_set_focus(win_index);
         if (Context)
           mutt_check_rescore(Context->mailbox);
+        menu->redraw = REDRAW_FULL;
         break;
 
       case OP_EDIT_OR_VIEW_RAW_MESSAGE:

--- a/index.c
+++ b/index.c
@@ -1876,11 +1876,10 @@ int mutt_index_menu(struct MuttWindow *dlg)
 
           oldcount = (Context && Context->mailbox) ? Context->mailbox->msg_count : 0;
 
-          struct EventMailbox em = { Context ? Context->mailbox : NULL };
-          notify_send(dlg->notify, NT_MAILBOX, NT_MAILBOX_SWITCH, &em);
-
           if (!Context || ((check = mx_mbox_close(&Context)) == 0))
+          {
             done = true;
+          }
           else
           {
             if ((check == MUTT_NEW_MAIL) || (check == MUTT_REOPENED))

--- a/sidebar/functions.c
+++ b/sidebar/functions.c
@@ -109,7 +109,7 @@ static bool select_next_new(struct SidebarWindowData *wdata, bool next_new_wrap)
  * @param wdata Sidebar data
  * @retval bool true if the selection changed
  */
-static bool select_prev(struct SidebarWindowData *wdata)
+bool select_prev(struct SidebarWindowData *wdata)
 {
   if (ARRAY_EMPTY(&wdata->entries) || (wdata->hil_index < 0))
     return false;

--- a/sidebar/observer.c
+++ b/sidebar/observer.c
@@ -176,6 +176,14 @@ static int sb_account_observer(struct NotifyCallback *nc)
     return -1;
 
   struct MuttWindow *win = nc->global_data;
+  struct SidebarWindowData *wdata = sb_wdata_get(win);
+  struct EventAccount *ea = nc->event_data;
+
+  struct MailboxNode *np = NULL;
+  STAILQ_FOREACH(np, &ea->account->mailboxes, entries)
+  {
+    sb_add_mailbox(wdata, np->mailbox);
+  }
 
   mutt_debug(LL_NOTIFY, "account\n");
   win->actions |= WA_RECALC;

--- a/sidebar/observer.c
+++ b/sidebar/observer.c
@@ -162,7 +162,7 @@ static void sb_init_data(struct MuttWindow *win)
   STAILQ_FOREACH(np, &ml, entries)
   {
     if (!(np->mailbox->flags & MB_HIDDEN))
-      sb_notify_mailbox(wdata, np->mailbox);
+      sb_add_mailbox(wdata, np->mailbox);
   }
   neomutt_mailboxlist_clear(&ml);
 }
@@ -325,84 +325,20 @@ static int sb_mailbox_observer(struct NotifyCallback *nc)
 
   struct MuttWindow *win = nc->global_data;
 
+  struct SidebarWindowData *wdata = sb_wdata_get(win);
+  struct EventMailbox *em = nc->event_data;
+
   if (nc->event_subtype == NT_MAILBOX_SWITCH)
   {
-    struct SidebarWindowData *wdata = sb_wdata_get(win);
-    struct EventMailbox *em = nc->event_data;
-
-    wdata->opn_index = -1;
-
-    if (em->mailbox)
-    {
-      struct SbEntry **sbep = NULL;
-      ARRAY_FOREACH(sbep, &wdata->entries)
-      {
-        if (mutt_str_equal((*sbep)->mailbox->realpath, em->mailbox->realpath))
-        {
-          wdata->opn_index = ARRAY_FOREACH_IDX;
-          wdata->hil_index = ARRAY_FOREACH_IDX;
-          break;
-        }
-      }
-    }
+    sb_set_current_mailbox(wdata, em->mailbox);
   }
   else if (nc->event_subtype == NT_MAILBOX_ADD)
   {
-    struct SidebarWindowData *wdata = sb_wdata_get(win);
-    struct EventMailbox *em = nc->event_data;
-
-    sb_notify_mailbox(wdata, em->mailbox);
+    sb_add_mailbox(wdata, em->mailbox);
   }
   else if (nc->event_subtype == NT_MAILBOX_REMOVE)
   {
-    struct SidebarWindowData *wdata = sb_wdata_get(win);
-    struct EventMailbox *em = nc->event_data;
-
-    struct SbEntry **sbep = NULL;
-    ARRAY_FOREACH(sbep, &wdata->entries)
-    {
-      if (mutt_str_equal((*sbep)->mailbox->realpath, em->mailbox->realpath))
-      {
-        struct SbEntry *sbe_remove = *sbep;
-        ARRAY_REMOVE(&wdata->entries, sbep);
-        FREE(&sbe_remove);
-
-        if (wdata->opn_index == ARRAY_FOREACH_IDX)
-        {
-          // Open item was deleted
-          wdata->opn_index = -1;
-        }
-        else if (wdata->opn_index > ARRAY_FOREACH_IDX)
-        {
-          // Open item is still visible, so adjust the index
-          wdata->opn_index--;
-        }
-
-        if (wdata->hil_index == ARRAY_FOREACH_IDX)
-        {
-          // If possible, keep the highlight where it is
-          struct SbEntry **sbep_cur = ARRAY_GET(&wdata->entries, ARRAY_FOREACH_IDX);
-          if (!sbep_cur)
-          {
-            // The last entry was deleted, so backtrack
-            select_prev(wdata);
-          }
-          else if ((*sbep)->is_hidden)
-          {
-            // Find the next unhidden entry, or the previous
-            if (!select_next(wdata))
-              if (!select_prev(wdata))
-                wdata->hil_index = -1;
-          }
-        }
-        else if (wdata->hil_index > ARRAY_FOREACH_IDX)
-        {
-          // Highlighted item is still visible, so adjust the index
-          wdata->hil_index--;
-        }
-        break;
-      }
-    }
+    sb_remove_mailbox(wdata, em->mailbox);
   }
 
   mutt_debug(LL_NOTIFY, "mailbox\n");

--- a/sidebar/private.h
+++ b/sidebar/private.h
@@ -89,7 +89,9 @@ extern bool  C_SidebarVisible;
 extern short C_SidebarWidth;
 
 // sidebar.c
-void sb_notify_mailbox  (struct SidebarWindowData *wdata, struct Mailbox *m);
+void sb_add_mailbox        (struct SidebarWindowData *wdata, struct Mailbox *m);
+void sb_remove_mailbox     (struct SidebarWindowData *wdata, struct Mailbox *m);
+void sb_set_current_mailbox(struct SidebarWindowData *wdata, struct Mailbox *m);
 
 // functions.c
 bool select_next(struct SidebarWindowData *wdata);

--- a/sidebar/private.h
+++ b/sidebar/private.h
@@ -89,8 +89,11 @@ extern bool  C_SidebarVisible;
 extern short C_SidebarWidth;
 
 // sidebar.c
-bool select_next        (struct SidebarWindowData *wdata);
 void sb_notify_mailbox  (struct SidebarWindowData *wdata, struct Mailbox *m);
+
+// functions.c
+bool select_next(struct SidebarWindowData *wdata);
+bool select_prev(struct SidebarWindowData *wdata);
 
 // observer.c
 int sb_insertion_observer(struct NotifyCallback *nc);

--- a/sidebar/sidebar.c
+++ b/sidebar/sidebar.c
@@ -52,10 +52,14 @@ struct Mailbox *sb_get_highlight(struct MuttWindow *win)
     return NULL;
 
   struct SidebarWindowData *wdata = sb_wdata_get(win);
-  if (ARRAY_EMPTY(&wdata->entries) || (wdata->hil_index < 0))
+  if (wdata->hil_index < 0)
     return NULL;
 
-  return (*ARRAY_GET(&wdata->entries, wdata->hil_index))->mailbox;
+  struct SbEntry **sbep = ARRAY_GET(&wdata->entries, wdata->hil_index);
+  if (!sbep)
+    return NULL;
+
+  return (*sbep)->mailbox;
 }
 
 /**
@@ -114,7 +118,7 @@ void sb_remove_mailbox(struct SidebarWindowData *wdata, struct Mailbox *m)
         // Open item was deleted
         wdata->opn_index = -1;
       }
-      else if (wdata->opn_index > ARRAY_FOREACH_IDX)
+      else if ((wdata->opn_index > 0) && (wdata->opn_index > ARRAY_FOREACH_IDX))
       {
         // Open item is still visible, so adjust the index
         wdata->opn_index--;
@@ -137,7 +141,7 @@ void sb_remove_mailbox(struct SidebarWindowData *wdata, struct Mailbox *m)
               wdata->hil_index = -1;
         }
       }
-      else if (wdata->hil_index > ARRAY_FOREACH_IDX)
+      else if ((wdata->hil_index > 0) && (wdata->hil_index > ARRAY_FOREACH_IDX))
       {
         // Highlighted item is still visible, so adjust the index
         wdata->hil_index--;

--- a/sidebar/sidebar.c
+++ b/sidebar/sidebar.c
@@ -59,11 +59,14 @@ struct Mailbox *sb_get_highlight(struct MuttWindow *win)
 }
 
 /**
- * sb_notify_mailbox - The state of a Mailbox is about to change
+ * sb_add_mailbox - Add a Mailbox to the Sidebar
  * @param wdata Sidebar data
- * @param m     Mailbox
+ * @param m     Mailbox to add
+ *
+ * The Sidebar will be re-sorted, and the indices updated, when sb_recalc() is
+ * called.
  */
-void sb_notify_mailbox(struct SidebarWindowData *wdata, struct Mailbox *m)
+void sb_add_mailbox(struct SidebarWindowData *wdata, struct Mailbox *m)
 {
   static int seq_unsorted = 1;
 
@@ -88,6 +91,85 @@ void sb_notify_mailbox(struct SidebarWindowData *wdata, struct Mailbox *m)
   }
 
   ARRAY_ADD(&wdata->entries, entry);
+}
+
+/**
+ * sb_remove_mailbox - Remove a Mailbox from the Sidebar
+ * @param wdata Sidebar data
+ * @param m     Mailbox to remove
+ */
+void sb_remove_mailbox(struct SidebarWindowData *wdata, struct Mailbox *m)
+{
+  struct SbEntry **sbep = NULL;
+  ARRAY_FOREACH(sbep, &wdata->entries)
+  {
+    if (mutt_str_equal((*sbep)->mailbox->realpath, m->realpath))
+    {
+      struct SbEntry *sbe_remove = *sbep;
+      ARRAY_REMOVE(&wdata->entries, sbep);
+      FREE(&sbe_remove);
+
+      if (wdata->opn_index == ARRAY_FOREACH_IDX)
+      {
+        // Open item was deleted
+        wdata->opn_index = -1;
+      }
+      else if (wdata->opn_index > ARRAY_FOREACH_IDX)
+      {
+        // Open item is still visible, so adjust the index
+        wdata->opn_index--;
+      }
+
+      if (wdata->hil_index == ARRAY_FOREACH_IDX)
+      {
+        // If possible, keep the highlight where it is
+        struct SbEntry **sbep_cur = ARRAY_GET(&wdata->entries, ARRAY_FOREACH_IDX);
+        if (!sbep_cur)
+        {
+          // The last entry was deleted, so backtrack
+          select_prev(wdata);
+        }
+        else if ((*sbep)->is_hidden)
+        {
+          // Find the next unhidden entry, or the previous
+          if (!select_next(wdata))
+            if (!select_prev(wdata))
+              wdata->hil_index = -1;
+        }
+      }
+      else if (wdata->hil_index > ARRAY_FOREACH_IDX)
+      {
+        // Highlighted item is still visible, so adjust the index
+        wdata->hil_index--;
+      }
+      break;
+    }
+  }
+}
+
+/**
+ * sb_set_current_mailbox - Set the current Mailbox
+ * @param wdata Sidebar data
+ * @param m     Mailbox
+ */
+void sb_set_current_mailbox(struct SidebarWindowData *wdata, struct Mailbox *m)
+{
+  wdata->opn_index = -1;
+
+  struct SbEntry **sbep = NULL;
+  ARRAY_FOREACH(sbep, &wdata->entries)
+  {
+    if (m)
+    {
+      if (mutt_str_equal((*sbep)->mailbox->realpath, m->realpath))
+      {
+        wdata->opn_index = ARRAY_FOREACH_IDX;
+        wdata->hil_index = ARRAY_FOREACH_IDX;
+        break;
+      }
+    }
+    (*sbep)->is_hidden = ((*sbep)->mailbox->flags & MB_HIDDEN);
+  }
 }
 
 /**

--- a/sidebar/window.c
+++ b/sidebar/window.c
@@ -475,17 +475,6 @@ static void update_entries_visibility(struct SidebarWindowData *wdata)
   const bool non_empty_only = C_SidebarNonEmptyMailboxOnly;
   struct SbEntry *sbe = NULL;
 
-  /* Take the fast path if there is no need to test visibilities */
-  if (!new_only && !non_empty_only)
-  {
-    struct SbEntry **sbep = NULL;
-    ARRAY_FOREACH(sbep, &wdata->entries)
-    {
-      (*sbep)->is_hidden = false;
-    }
-    return;
-  }
-
   struct SbEntry **sbep = NULL;
   ARRAY_FOREACH(sbep, &wdata->entries)
   {
@@ -493,6 +482,12 @@ static void update_entries_visibility(struct SidebarWindowData *wdata)
     sbe = *sbep;
 
     sbe->is_hidden = false;
+
+    if (sbe->mailbox->flags & MB_HIDDEN)
+    {
+      sbe->is_hidden = true;
+      continue;
+    }
 
     if (Context && mutt_str_equal(sbe->mailbox->realpath, Context->mailbox->realpath))
     {
@@ -538,27 +533,28 @@ static bool prepare_sidebar(struct SidebarWindowData *wdata, int page_size)
   if (ARRAY_EMPTY(&wdata->entries) || (page_size <= 0))
     return false;
 
-  const struct SbEntry *opn_entry =
-      (wdata->opn_index >= 0) ? *ARRAY_GET(&wdata->entries, wdata->opn_index) : NULL;
-  const struct SbEntry *hil_entry =
-      (wdata->hil_index >= 0) ? *ARRAY_GET(&wdata->entries, wdata->hil_index) : NULL;
+  struct SbEntry **sbep = NULL;
+
+  sbep = (wdata->opn_index >= 0) ? ARRAY_GET(&wdata->entries, wdata->opn_index) : NULL;
+  const struct SbEntry *opn_entry = sbep ? *sbep : NULL;
+  sbep = (wdata->hil_index >= 0) ? ARRAY_GET(&wdata->entries, wdata->hil_index) : NULL;
+  const struct SbEntry *hil_entry = sbep ? *sbep : NULL;
 
   update_entries_visibility(wdata);
   sb_sort_entries(wdata, C_SidebarSortMethod);
 
   if (opn_entry || hil_entry)
   {
-    struct SbEntry **sbep = NULL;
     ARRAY_FOREACH(sbep, &wdata->entries)
     {
-      if (opn_entry == *sbep)
+      if ((opn_entry == *sbep) && ((*sbep)->mailbox->flags != MB_HIDDEN))
         wdata->opn_index = ARRAY_FOREACH_IDX;
-      if (hil_entry == *sbep)
+      if ((hil_entry == *sbep) && ((*sbep)->mailbox->flags != MB_HIDDEN))
         wdata->hil_index = ARRAY_FOREACH_IDX;
     }
   }
 
-  if ((wdata->hil_index < 0) || hil_entry->is_hidden ||
+  if ((wdata->hil_index < 0) || (hil_entry && hil_entry->is_hidden) ||
       (C_SidebarSortMethod != wdata->previous_sort))
   {
     if (wdata->opn_index >= 0)

--- a/sidebar/window.c
+++ b/sidebar/window.c
@@ -633,7 +633,10 @@ int sb_recalc(struct MuttWindow *win)
   }
 
   if (!prepare_sidebar(wdata, win->state.rows))
+  {
+    win->actions |= WA_REPAINT;
     return 0;
+  }
 
   int num_rows = win->state.rows;
   int num_cols = win->state.cols;
@@ -793,32 +796,32 @@ int sb_repaint(struct MuttWindow *win)
 
   struct SidebarWindowData *wdata = sb_wdata_get(win);
 
-  if (wdata->top_index < 0)
-    return 0;
-
   int row = 0;
   int num_rows = win->state.rows;
   int num_cols = win->state.cols;
 
-  int col = 0;
-  if (C_SidebarOnRight)
-    col = wdata->divider_width;
-
-  struct SbEntry **sbep = NULL;
-  ARRAY_FOREACH_FROM(sbep, &wdata->entries, wdata->top_index)
+  if (wdata->top_index >= 0)
   {
-    if (row >= num_rows)
-      break;
+    int col = 0;
+    if (C_SidebarOnRight)
+      col = wdata->divider_width;
 
-    if ((*sbep)->is_hidden)
-      continue;
+    struct SbEntry **sbep = NULL;
+    ARRAY_FOREACH_FROM(sbep, &wdata->entries, wdata->top_index)
+    {
+      if (row >= num_rows)
+        break;
 
-    struct SbEntry *entry = (*sbep);
-    mutt_window_move(win, col, row);
-    mutt_curses_set_color(entry->color);
-    mutt_window_printf("%s", entry->display);
-    mutt_refresh();
-    row++;
+      if ((*sbep)->is_hidden)
+        continue;
+
+      struct SbEntry *entry = (*sbep);
+      mutt_window_move(win, col, row);
+      mutt_curses_set_color(entry->color);
+      mutt_window_printf("%s", entry->display);
+      mutt_refresh();
+      row++;
+    }
   }
 
   fill_empty_space(win, row, num_rows - row, wdata->divider_width,

--- a/sidebar/window.c
+++ b/sidebar/window.c
@@ -627,7 +627,7 @@ int sb_recalc(struct MuttWindow *win)
     STAILQ_FOREACH(np, &ml, entries)
     {
       if (!(np->mailbox->flags & MB_HIDDEN))
-        sb_notify_mailbox(wdata, np->mailbox);
+        sb_add_mailbox(wdata, np->mailbox);
     }
     neomutt_mailboxlist_clear(&ml);
   }


### PR DESCRIPTION
After the refactor 093f19824, the Sidebar was ignoring notifications about new or removed mailboxes.

- Handle new Mailboxes
- Handle removed Mailboxes
- Ensure painting is done when there are only hidden Mailboxes
- Refactor for clarity
