### PR TITLE
Query Live Sorting

### DIFF
--- a/alias/dlgalias.c
+++ b/alias/dlgalias.c
@@ -177,42 +177,6 @@ static int alias_alias_observer(struct NotifyCallback *nc)
 }
 
 /**
- * alias_config_observer - Listen for `sort_alias` configuration changes and reorders alias list - Implements ::observer_t
- */
-static int alias_config_observer(struct NotifyCallback *nc)
-{
-  if (!nc->event_data)
-    return -1;
-  if (nc->event_type != NT_CONFIG)
-    return 0;
-
-  struct EventConfig *ec = nc->event_data;
-
-  if (!mutt_str_equal(ec->name, "sort_alias"))
-    return 0;
-
-  struct AliasMenuData *mdata = nc->global_data;
-
-  menu_data_sort(mdata);
-
-  return 0;
-}
-
-/**
- * alias_color_observer - Listen for color configuration changes and refresh the menu - Implements ::observer_t
- */
-static int alias_color_observer(struct NotifyCallback *nc)
-{
-  if ((nc->event_type != NT_COLOR) || !nc->event_data || !nc->global_data)
-    return -1;
-
-  struct Menu *menu = nc->global_data;
-  menu->redraw = REDRAW_FULL;
-
-  return 0;
-}
-
-/**
  * dlg_select_alias - Display a menu of Aliases
  * @param buf    Buffer for expanded aliases
  * @param buflen Length of buffer

--- a/alias/gui.c
+++ b/alias/gui.c
@@ -35,6 +35,7 @@
 #include "gui.h"
 #include "lib.h"
 #include "alias.h"
+#include "mutt_menu.h"
 #include "sort.h"
 
 #define RSORT(num) ((C_SortAlias & SORT_REVERSE) ? -num : num)
@@ -109,6 +110,42 @@ int alias_sort_unsort(const void *a, const void *b)
   int r = (av_a->orig_seq - av_b->orig_seq);
 
   return RSORT(r);
+}
+
+/**
+ * alias_config_observer - Listen for `sort_alias` configuration changes and reorders menu items accordingly
+ */
+int alias_config_observer(struct NotifyCallback *nc)
+{
+  if (!nc->event_data)
+    return -1;
+  if (nc->event_type != NT_CONFIG)
+    return 0;
+
+  struct EventConfig *ec = nc->event_data;
+
+  if (!mutt_str_equal(ec->name, "sort_alias"))
+    return 0;
+
+  struct AliasMenuData *mdata = nc->global_data;
+
+  menu_data_sort(mdata);
+
+  return 0;
+}
+
+/**
+ * alias_color_observer - Listen for color configuration changes and refreshes the menu
+ */
+int alias_color_observer(struct NotifyCallback *nc)
+{
+  if ((nc->event_type != NT_COLOR) || !nc->event_data || !nc->global_data)
+    return -1;
+
+  struct Menu *menu = nc->global_data;
+  menu->redraw = REDRAW_FULL;
+
+  return 0;
 }
 
 /**

--- a/alias/gui.h
+++ b/alias/gui.h
@@ -43,6 +43,9 @@ struct AliasView
 
 ARRAY_HEAD(AliasMenuData, struct AliasView);
 
+int alias_config_observer(struct NotifyCallback *nc);
+int alias_color_observer (struct NotifyCallback *nc);
+
 int  menu_data_alias_add   (struct AliasMenuData *mdata, struct Alias *alias);
 int  menu_data_alias_delete(struct AliasMenuData *mdata, struct Alias *alias);
 void menu_data_sort        (struct AliasMenuData *mdata);

--- a/functions.c
+++ b/functions.c
@@ -599,6 +599,8 @@ const struct Binding OpQuery[] = { /* map: query */
   { "mail",                  OP_MAIL,                        "m" },
   { "query",                 OP_QUERY,                       "Q" },
   { "query-append",          OP_QUERY_APPEND,                "A" },
+  { "sort",                  OP_SORT,                        "o" },
+  { "sort-reverse",          OP_SORT_REVERSE,                "O" },
   { NULL,                    0,                              NULL },
 };
 


### PR DESCRIPTION
* **What does this PR do?**

Just like the Address Book Live Sorting PR, this one adds Sort and Reverse Sort functions to the Query window, where the user is able to sort the information by alias and address. It is also possible to "unsort".

A lot of the code from the PR mentioned above was reused.

I also took the liberty of putting the `alias_sort_observer` and the `alias_color_observer` functions into `alias/gui.c`, since they are both used by `dlgalias.c` and `dlgquery.c`.

* **What are the relevant issue numbers?**

There is no relevant issue number. (Is it needed?)