### PR TITLE
Don't crash with no Context and no explicit folder

### DIFF
--- a/main.c
+++ b/main.c
@@ -1224,7 +1224,7 @@ int main(int argc, char *argv[], char *envp[])
       struct MuttWindow *dlg = index_pager_init();
       dialog_push(dlg);
 
-      struct EventMailbox em = { Context->mailbox };
+      struct EventMailbox em = { Context ? Context->mailbox : NULL };
       notify_send(dlg->notify, NT_MAILBOX, NT_MAILBOX_SWITCH, &em);
 
       mutt_index_menu(dlg);


### PR DESCRIPTION
* **What does this PR do?**

Fix neomutt not getting past startup:
```
nabijaczleweli@tarta:~/uwu/neomutt$ gdb ./neomutt
GNU gdb (Debian 8.2.1-2+b3) 8.2.1
Copyright (C) 2018 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Type "show copying" and "show warranty" for details.
This GDB was configured as "x86_64-linux-gnu".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<http://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
    <http://www.gnu.org/software/gdb/documentation/>.

For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from ./neomutt...done.
(gdb) run
Starting program: /home/nabijaczleweli/uwu/neomutt/neomutt
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
[Detaching after fork from child process 32355]
[Detaching after fork from child process 32357]
[Detaching after fork from child process 32358]
[Detaching after fork from child process 32360]
[Detaching after fork from child process 32362]
[Detaching after fork from child process 32364]
[Detaching after fork from child process 32366]

Program received signal SIGSEGV, Segmentation fault.
0x000000000043b9ce in main (argc=1, argv=0x7fffffffe4b8, envp=<optimized out>) at main.c:1227
1227          struct EventMailbox em = { Context->mailbox };
(gdb) bt
#0  0x000000000043b9ce in main (argc=1, argv=0x7fffffffe4b8, envp=<optimized out>) at main.c:1227
(gdb) p Context
$1 = (struct Context *) 0x0
(gdb) quit
A debugging session is active.

        Inferior 1 [process 32349] will be killed.

Quit anyway? (y or n) y
nabijaczleweli@tarta:~/uwu/neomutt$ git log -1
commit 758d453f0326ee1e8f6b69931277820117e62c88 (HEAD -> foreshorten)
Merge: e06857660 ee046a3c8
Author: Richard Russon <rich@flatcap.org>
Date:   Wed Aug 26 20:51:05 2020 +0100

    merge: Live sorting of the Address Book

     * add sort_alias config observer for alias list
     * use collation sort in alias alias/address sorting
     * add sort/rev-sort menu to the Address Book
     * add color observer for alias list
     * add alias unsorting function
```