### PR TITLE
Add validators for {imap,smtp,pop,nntp}_authenticators

### DIFF
--- a/conn/sasl.c
+++ b/conn/sasl.c
@@ -96,6 +96,15 @@ struct SaslSockData
   int (*close)(struct Connection *conn);
 };
 
+/**
+ * sasl_authenticators - Authenticaion methods supported by Cyrus SASL
+ */
+static const char *const sasl_authenticators[] = {
+  "ANONYMOUS", "CRAM-MD5",   "DIGEST-MD5",  "EXTERNAL", "G2",
+  "GSSAPI",    "GSS-SPNEGO", "KERBEROS_V4", "LOGIN",    "NTLM",
+  "OTP",       "PASSDSS",    "PLAIN",       "SCRAM",    "SRP"
+};
+
 /* arbitrary. SASL will probably use a smaller buffer anyway. OTOH it's
  * been a while since I've had access to an SASL server which negotiated
  * a protection buffer. */
@@ -106,6 +115,23 @@ struct SaslSockData
 static sasl_callback_t MuttSaslCallbacks[5];
 
 static sasl_secret_t *secret_ptr = NULL;
+
+/**
+ * sasl_auth_validator - Validate an auth method against Cyrus SASL methods
+ * @param authenticator Name of the authenticator to validate
+ * @retval bool True if argument matches an accepted auth method
+ */
+bool sasl_auth_validator(const char *authenticator)
+{
+  for (size_t i = 0; i < mutt_array_size(sasl_authenticators); i++)
+  {
+    const char *auth = sasl_authenticators[i];
+    if (mutt_istr_equal(auth, authenticator))
+      return true;
+  }
+
+  return false;
+}
 
 /**
  * getnameinfo_err - Convert a getaddrinfo() error code into an SASL error code

--- a/conn/sasl.h
+++ b/conn/sasl.h
@@ -26,8 +26,11 @@
 #define MUTT_CONN_SASL_H
 
 #include <sasl/sasl.h>
+#include <stdbool.h>
 
 struct Connection;
+
+bool sasl_auth_validator(const char *authenticator);
 
 int  mutt_sasl_client_new(struct Connection *conn, sasl_conn_t **saslconn);
 void mutt_sasl_done      (void);

--- a/imap/auth.c
+++ b/imap/auth.c
@@ -55,7 +55,9 @@ struct ImapAuth
  * imap_authenticators - Accepted authentication methods
  */
 static const struct ImapAuth imap_authenticators[] = {
-  { imap_auth_oauth, "oauthbearer" }, { imap_auth_plain, "plain" },
+  // clang-format off
+  { imap_auth_oauth, "oauthbearer" },
+  { imap_auth_plain, "plain" },
 #ifdef USE_SASL
   { imap_auth_sasl, NULL },
 #else
@@ -69,7 +71,28 @@ static const struct ImapAuth imap_authenticators[] = {
   { imap_auth_cram_md5, "cram-md5" },
 #endif
   { imap_auth_login, "login" },
+  // clang-format on
 };
+
+/**
+ * imap_auth_is_valid - Check if string is a valid imap authentication method
+ * @param authenticator Authenticator string to check
+ * @retval bool True if argument is a valid auth method
+ *
+ * Validate whether an input string is an accepted imap authentication method as
+ * defined by #imap_authenticators.
+ */
+bool imap_auth_is_valid(const char *authenticator)
+{
+  for (size_t i = 0; i < mutt_array_size(imap_authenticators); i++)
+  {
+    const struct ImapAuth *auth = &imap_authenticators[i];
+    if (auth->method && mutt_istr_equal(auth->method, authenticator))
+      return true;
+  }
+
+  return false;
+}
 
 /**
  * imap_authenticate - Authenticate to an IMAP server

--- a/imap/auth.h
+++ b/imap/auth.h
@@ -40,6 +40,8 @@ enum ImapAuthRes
   IMAP_AUTH_UNAVAIL,     ///< Authentication method not permitted
 };
 
+bool imap_auth_is_valid(const char *authenticator);
+
 /* external authenticator prototypes */
 enum ImapAuthRes imap_auth_plain(struct ImapAccountData *adata, const char *method);
 #ifndef USE_SASL

--- a/pop/auth.c
+++ b/pop/auth.c
@@ -377,13 +377,40 @@ static enum PopAuthRes pop_auth_oauth(struct PopAccountData *adata, const char *
   return POP_A_FAILURE;
 }
 
+/**
+ * pop_authenticators - Accepted authentication methods
+ */
 static const struct PopAuth pop_authenticators[] = {
+  // clang-format off
   { pop_auth_oauth, "oauthbearer" },
 #ifdef USE_SASL
   { pop_auth_sasl, NULL },
 #endif
-  { pop_auth_apop, "apop" },         { pop_auth_user, "user" }, { NULL, NULL },
+  { pop_auth_apop, "apop" },
+  { pop_auth_user, "user" },
+  { NULL, NULL },
+  // clang-format on
 };
+
+/**
+ * pop_auth_is_valid - Check if string is a valid pop authentication method
+ * @param authenticator Authenticator string to check
+ * @retval bool True if argument is a valid auth method
+ *
+ * Validate whether an input string is an accepted pop authentication method as
+ * defined by #pop_authenticators.
+ */
+bool pop_auth_is_valid(const char *authenticator)
+{
+  for (size_t i = 0; i < mutt_array_size(pop_authenticators); i++)
+  {
+    const struct PopAuth *auth = &pop_authenticators[i];
+    if (auth->method && mutt_istr_equal(auth->method, authenticator))
+      return true;
+  }
+
+  return false;
+}
 
 /**
  * pop_authenticate - Authenticate with a POP server
@@ -406,7 +433,7 @@ int pop_authenticate(struct PopAccountData *adata)
     return -3;
   }
 
-  if (C_PopAuthenticators)
+  if (C_PopAuthenticators && (C_PopAuthenticators->count > 0))
   {
     /* Try user-specified list of authentication methods */
     struct ListNode *np = NULL;

--- a/pop/private.h
+++ b/pop/private.h
@@ -137,6 +137,7 @@ extern unsigned char C_PopReconnect;
 extern char *        C_PopUser;
 
 /* pop_auth.c */
+bool pop_auth_is_valid(const char *authenticator);
 int pop_authenticate(struct PopAccountData *adata);
 void pop_apop_timestamp(struct PopAccountData *adata, char *buf);
 

--- a/send/smtp.h
+++ b/send/smtp.h
@@ -31,6 +31,7 @@
 struct AddressList;
 struct ConfigSubset;
 
+bool smtp_auth_is_valid(const char *authenticator);
 int mutt_smtp_send(const struct AddressList *from, const struct AddressList *to,
                    const struct AddressList *cc, const struct AddressList *bcc,
                    const char *msgfile, bool eightbit, struct ConfigSubset *sub);


### PR DESCRIPTION
* **What does this PR do?**

Adds validators to {imap,pop,smtp,nntp}_authenticators config variables. This also includes some refactoring of code in some files.

* **What are the relevant issue numbers?**

#2583 .

* **Things to Review**

Obviously the whole commit should be looked at for errors etc. but here are the key areas I would like input/confirmation on:

1. **Placement of function declarations**: `bool {imap,pop,smtp,nntp}_auth_is_valid()` functions are placed in .h files to make them visible to the validator functions. I just want to make sure they're not wandering in the wrong places :).

2. **Changes in `smtp/`**: Namely, I added a SmtpAuth multiplexor (similar to imap and pop's) and slightly modified `smtp_auth()` and `smtp_auth_sasl()`. I tested them and they work fine, but I want to emphasize the change and make sure it gets an okay.

3. **Changes in `nntp/`**: Most notably, I changed the nntp_authenticator config variable's data type to SLIST (was just string prev.) to mirror the other authenticators. This might have effects on the `nntp_auth()` backend (which needs an overhaul, anyway) that I was not able to test.