### PR TITLE
Issue #2621: Move address config into libaddress

### DIFF
--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -107,7 +107,7 @@ $(PWD)/address:
 ###############################################################################
 # libalias
 LIBALIAS=	libalias.a
-LIBALIASOBJS=	alias/alias.o alias/commands.o alias/dlgalias.o \
+LIBALIASOBJS=	alias/alias.o alias/commands.o alias/config.o alias/dlgalias.o \
 		alias/dlgquery.o alias/gui.o alias/reverse.o
 CLEANFILES+=	$(LIBALIAS) $(LIBALIASOBJS)
 ALLOBJS+=	$(LIBALIASOBJS)

--- a/alias/config.c
+++ b/alias/config.c
@@ -1,0 +1,78 @@
+/**
+ * @file
+ * Config used by libaddress
+ *
+ * @authors
+ * Copyright (C) 2020 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @page alias_config Config used by libaddress
+ *
+ * Config used by libaddress
+ */
+
+#include "config.h"
+#include <config/lib.h>
+#include <stdbool.h>
+
+/**
+ * SortAliasMethods - Sort methods for email aliases
+ */
+const struct Mapping SortAliasMethods[] = {
+  // clang-format off
+  { "address",  SORT_ADDRESS },
+  { "alias",    SORT_ALIAS },
+  { "unsorted", SORT_ORDER },
+  // clang-format on
+  { NULL,       0 },
+};
+
+char *C_AliasFile;   ///< Config: Save new aliases to this file
+char *C_AliasFormat; ///< Config: printf-like format string for the alias menu
+char *C_QueryCommand; ///< Config: External command to query and external address book
+char *C_QueryFormat; ///< Config: printf-like format string for the query menu (address book)
+short C_SortAlias; ///< Config: Sort method for the alias menu
+
+struct ConfigDef AliasVars[] = {
+  // clang-format off
+  { "alias_file", DT_PATH|DT_PATH_FILE, &C_AliasFile, IP "~/.neomuttrc", 0, NULL,
+    "Save new aliases to this file"
+  },
+  { "alias_format", DT_STRING|DT_NOT_EMPTY, &C_AliasFormat, IP "%3n %f%t %-15a %-56r | %c", 0, NULL,
+	"printf-like format string for the alias menu"
+  },
+  { "sort_alias", DT_SORT, &C_SortAlias, SORT_ALIAS, IP SortAliasMethods, NULL,
+    "Sort method for the alias menu"
+  },
+  { "query_command", DT_STRING|DT_COMMAND, &C_QueryCommand, 0, 0, NULL,
+    "External command to query and external address book"
+  },
+  { "query_format", DT_STRING|DT_NOT_EMPTY, &C_QueryFormat, IP "%3c %t %-25.25n %-25.25a | %e", 0, NULL,
+    "printf-like format string for the query menu (address book)"
+  },
+  { NULL, 0, NULL, 0, 0, NULL, NULL },
+  // clang-format on
+};
+
+/**
+ * config_init_alias - Register alias config variables - Implements ::module_init_config_t
+ */
+bool config_init_alias(struct ConfigSet *cs)
+{
+  return cs_register_variables(cs, AliasVars, 0);
+}

--- a/alias/dlgalias.c
+++ b/alias/dlgalias.c
@@ -50,10 +50,6 @@
 #include "muttlib.h"
 #include "opcodes.h"
 
-/* These Config Variables are only used in dlgalias.c */
-char *C_AliasFormat; ///< Config: printf-like format string for the alias menu
-short C_SortAlias;   ///< Config: Sort method for the alias menu
-
 /// Help Bar for the Alias dialog (address book)
 static const struct Mapping AliasHelp[] = {
   // clang-format off

--- a/alias/dlgquery.c
+++ b/alias/dlgquery.c
@@ -51,10 +51,6 @@
 #include "muttlib.h"
 #include "opcodes.h"
 
-/* These Config Variables are only used in dlgquery.c */
-char *C_QueryCommand; ///< Config: External command to query and external address book
-char *C_QueryFormat; ///< Config: printf-like format string for the query menu (address book)
-
 /// Help Bar for the Address Query dialog
 static const struct Mapping QueryHelp[] = {
   // clang-format off

--- a/alias/lib.h
+++ b/alias/lib.h
@@ -29,6 +29,7 @@
  * | :------------------ | :------------------------- |
  * | alias/alias.c       | @subpage alias_alias       |
  * | alias/commands.c    | @subpage alias_commands    |
+ * | alias/config.c      | @subpage alias_config      |
  * | alias/dlgalias.c    | @subpage alias_dlgalias    |
  * | alias/dlgquery.c    | @subpage alias_dlgquery    |
  * | alias/gui.c         | @subpage alias_gui         |
@@ -46,7 +47,10 @@
 struct Address;
 struct AddressList;
 struct Buffer;
+struct ConfigSet;
 struct Envelope;
+
+extern char *C_AliasFile;
 
 /* These Config Variables are only used in dlgalias.c */
 extern char *C_AliasFormat;
@@ -78,5 +82,7 @@ int  query_complete(char *buf, size_t buflen);
 void query_index   (void);
 
 struct Address *alias_reverse_lookup(const struct Address *addr);
+
+bool config_init_alias(struct ConfigSet *cs);
 
 #endif /* MUTT_ALIAS_LIB_H */

--- a/mutt_config.c
+++ b/mutt_config.c
@@ -124,18 +124,6 @@ const struct Mapping SortMethods[] = {
 };
 
 /**
- * SortAliasMethods - Sort methods for email aliases
- */
-const struct Mapping SortAliasMethods[] = {
-  // clang-format off
-  { "address",  SORT_ADDRESS },
-  { "alias",    SORT_ALIAS },
-  { "unsorted", SORT_ORDER },
-  { NULL,       0 },
-  // clang-format on
-};
-
-/**
  * SortBrowserMethods - Sort methods for the folder/dir browser
  */
 const struct Mapping SortBrowserMethods[] = {
@@ -159,12 +147,6 @@ struct ConfigDef MainVars[] = {
   },
   { "abort_key", DT_STRING|DT_NOT_EMPTY, &C_AbortKey, IP "\007", 0, NULL,
     "String representation of key to abort prompts"
-  },
-  { "alias_file", DT_PATH|DT_PATH_FILE, &C_AliasFile, IP "~/.neomuttrc", 0, NULL,
-    "Save new aliases to this file"
-  },
-  { "alias_format", DT_STRING|DT_NOT_EMPTY, &C_AliasFormat, IP "%3n %f%t %-15a %-56r | %c", 0, NULL,
-    "printf-like format string for the alias menu"
   },
   { "allow_ansi", DT_BOOL, &C_AllowAnsi, false, 0, NULL,
     "Allow ANSI colour codes in rich text messages"
@@ -530,12 +512,6 @@ struct ConfigDef MainVars[] = {
   { "prompt_after", DT_BOOL, &C_PromptAfter, true, 0, NULL,
     "Pause after running an external pager"
   },
-  { "query_command", DT_STRING|DT_COMMAND, &C_QueryCommand, 0, 0, NULL,
-    "External command to query and external address book"
-  },
-  { "query_format", DT_STRING|DT_NOT_EMPTY, &C_QueryFormat, IP "%3c %t %-25.25n %-25.25a | %e", 0, NULL,
-    "printf-like format string for the query menu (address book)"
-  },
   { "quit", DT_QUAD, &C_Quit, MUTT_YES, 0, NULL,
     "Prompt before exiting NeoMutt"
   },
@@ -643,9 +619,6 @@ struct ConfigDef MainVars[] = {
   },
   { "sort", DT_SORT|R_INDEX|R_RESORT|DT_SORT_REVERSE, &C_Sort, SORT_DATE, IP SortMethods, pager_validator,
     "Sort method for the index"
-  },
-  { "sort_alias", DT_SORT, &C_SortAlias, SORT_ALIAS, IP SortAliasMethods, NULL,
-    "Sort method for the alias menu"
   },
   { "sort_aux", DT_SORT|DT_SORT_REVERSE|DT_SORT_LAST|R_INDEX|R_RESORT|R_RESORT_SUB, &C_SortAux, SORT_DATE, IP SortAuxMethods, NULL,
     "Secondary sort method for the index"
@@ -803,6 +776,7 @@ static void init_variables(struct ConfigSet *cs)
 {
   // Define the config variables
   config_init_main(cs);
+  CONFIG_INIT_VARS(cs, alias);
 #ifdef USE_AUTOCRYPT
   CONFIG_INIT_VARS(cs, autocrypt);
 #endif

--- a/mutt_globals.h
+++ b/mutt_globals.h
@@ -82,7 +82,6 @@ WHERE struct Address *C_From;                ///< Config: Default 'From' address
 
 WHERE bool C_AbortBackspace;                 ///< Config: Hitting backspace against an empty prompt aborts the prompt
 WHERE char *C_AbortKey;                      ///< Config: String representation of key to abort prompts
-WHERE char *C_AliasFile;                     ///< Config: Save new aliases to this file
 WHERE char *C_Attribution;                   ///< Config: Message to start a reply, "On DATE, PERSON wrote:"
 WHERE char *C_AttributionLocale;             ///< Config: Locale for dates in the attribution message
 WHERE char *C_AttachFormat;                  ///< Config: printf-like format string for the attachment menu


### PR DESCRIPTION
* **What does this PR do?**

This PR moves Address configuration into its own configuration inside `alias`.
Then it is initialized through `CONFIG_INIT_VARS`.

* **What are the relevant issue numbers?**
The relevant issue number is #2621 , being this PR related to the first bullet point.

Hope everything okay. I did test it, everything seems to be working, sorting, alias file, etc.