### PR TITLE
Fix tracking the current email in the index

### DIFF
--- a/email/email.c
+++ b/email/email.c
@@ -71,12 +71,15 @@ void email_free(struct Email **ptr)
  */
 struct Email *email_new(void)
 {
+  static size_t sequence = 0;
+
   struct Email *e = mutt_mem_calloc(1, sizeof(struct Email));
 #ifdef MIXMASTER
   STAILQ_INIT(&e->chain);
 #endif
   STAILQ_INIT(&e->tags);
   e->visible = true;
+  e->sequence = sequence++;
   return e;
 }
 

--- a/email/email.h
+++ b/email/email.h
@@ -96,6 +96,8 @@ struct Email
 
   short attach_total;          ///< Number of qualifying attachments in message, if attach_valid
 
+  size_t sequence;             ///< Sequence number assigned on creation
+
 #ifdef MIXMASTER
   struct ListHead chain;       ///< Mixmaster chain
 #endif
@@ -106,7 +108,7 @@ struct Email
 
   struct TagList tags;         ///< For drivers that support server tagging
 
-  void *edata;                    ///< Driver-specific data
+  void *edata;                 ///< Driver-specific data
 
   /**
    * edata_free - Free the private data attached to the Email
@@ -114,7 +116,7 @@ struct Email
    */
   void (*edata_free)(void **ptr);
 
-  struct Notify *notify;          ///< Notifications handler
+  struct Notify *notify;       ///< Notifications handler
 };
 
 /**

--- a/hcache/hcache.c
+++ b/hcache/hcache.c
@@ -118,6 +118,7 @@ static void *dump(struct HeaderCache *hc, const struct Email *e, int *off, uint3
   e_dump.path = NULL;
   e_dump.tree = NULL;
   e_dump.thread = NULL;
+  e_dump.sequence = 0;
   STAILQ_INIT(&e_dump.tags);
 #ifdef MIXMASTER
   STAILQ_INIT(&e_dump.chain);
@@ -153,8 +154,10 @@ static struct Email *restore(const unsigned char *d)
   /* skip crc */
   off += sizeof(unsigned int);
 
+  size_t sequence = e->sequence;
   memcpy(e, d + off, sizeof(struct Email));
   off += sizeof(struct Email);
+  e->sequence = sequence;
 
   STAILQ_INIT(&e->tags);
 #ifdef MIXMASTER

--- a/index.c
+++ b/index.c
@@ -1225,21 +1225,17 @@ int mutt_index_menu(struct MuttWindow *dlg)
       OptRedrawTree = false;
     }
 
-    if (Context)
-      Context->menu = menu;
-
-    if (Context && Context->mailbox && !attach_msg)
+    if (Context && Context->mailbox)
     {
+      Context->menu = menu;
       /* check for new mail in the mailbox.  If nonzero, then something has
        * changed about the file (either we got new mail or the file was
        * modified underneath us.) */
       int check = mx_mbox_check(Context->mailbox);
 
-      set_current_email(&cur, mutt_get_virt_email(Context->mailbox, menu->current));
-
       if (check < 0)
       {
-        if (!Context->mailbox || (mutt_buffer_is_empty(&Context->mailbox->pathbuf)))
+        if (mutt_buffer_is_empty(&Context->mailbox->pathbuf))
         {
           /* fatal error occurred */
           ctx_free(&Context);
@@ -1279,32 +1275,26 @@ int mutt_index_menu(struct MuttWindow *dlg)
           }
         }
         else if (check == MUTT_FLAGS)
+        {
           mutt_message(_("Mailbox was externally modified"));
+        }
 
         /* avoid the message being overwritten by mailbox */
         do_mailbox_notify = false;
 
-        if (Context && Context->mailbox)
-        {
-          bool verbose = Context->mailbox->verbose;
-          Context->mailbox->verbose = false;
-          update_index(menu, Context, check, oldcount, &cur);
-          Context->mailbox->verbose = verbose;
-          menu->max = Context->mailbox->vcount;
-        }
-        else
-        {
-          menu->max = 0;
-        }
-
+        bool verbose = Context->mailbox->verbose;
+        Context->mailbox->verbose = false;
+        update_index(menu, Context, check, oldcount, &cur);
+        Context->mailbox->verbose = verbose;
+        menu->max = Context->mailbox->vcount;
         menu->redraw = REDRAW_FULL;
-
         OptSearchInvalid = true;
       }
-    }
-    else if (Context)
-    {
-      set_current_email(&cur, mutt_get_virt_email(Context->mailbox, menu->current));
+
+      if (Context)
+      {
+        set_current_email(&cur, mutt_get_virt_email(Context->mailbox, menu->current));
+      }
     }
 
     if (!attach_msg)


### PR DESCRIPTION
* b3f077a : use an incrementing sequence number to track emails
* c3c5688 : fix index tracking so the current email is not set too early

Fixes #2588