### PR TITLE
Issue #2621: Add patterns to alias/query

### DIFF
--- a/alias/dlgalias.c
+++ b/alias/dlgalias.c
@@ -41,6 +41,7 @@
 #include "gui/lib.h"
 #include "mutt.h"
 #include "lib.h"
+#include "pattern/lib.h"
 #include "alias.h"
 #include "format_flags.h"
 #include "gui.h"
@@ -195,6 +196,7 @@ static void dlg_select_alias(char *buf, size_t buflen, struct AliasMenuData *mda
   dlg->help_menu = MENU_ALIAS;
 
   menu->make_entry = alias_make_entry;
+  menu->custom_search = true;
   menu->tag = alias_tag;
   menu->title = _("Aliases");
   menu->max = ARRAY_SIZE(mdata);
@@ -284,6 +286,17 @@ static void dlg_select_alias(char *buf, size_t buflen, struct AliasMenuData *mda
 
         break;
       }
+      case OP_SEARCH_REVERSE:
+      case OP_SEARCH_NEXT:
+      case OP_SEARCH_OPPOSITE:
+      case OP_SEARCH:
+        menu->current = mutt_search_alias_command(menu, menu->current, op);
+        if (menu->current == -1)
+          menu->current = menu->oldcurrent;
+        else
+          menu->redraw |= REDRAW_MOTION;
+        break;
+
       case OP_GENERIC_SELECT_ENTRY:
         t = menu->current;
         if (t >= ARRAY_SIZE(mdata))

--- a/alias/dlgquery.c
+++ b/alias/dlgquery.c
@@ -40,6 +40,7 @@
 #include "gui/lib.h"
 #include "mutt.h"
 #include "lib.h"
+#include "pattern/lib.h"
 #include "send/lib.h"
 #include "alias.h"
 #include "format_flags.h"
@@ -321,6 +322,7 @@ static void dlg_select_query(char *buf, size_t buflen, struct AliasList *all, bo
 
   menu->make_entry = query_make_entry;
   menu->search = query_search;
+  menu->custom_search = true;
   menu->tag = query_tag;
   menu->title = title;
   menu->max = ARRAY_SIZE(&mdata);
@@ -488,6 +490,18 @@ static void dlg_select_query(char *buf, size_t buflen, struct AliasList *all, bo
 
         break;
       }
+
+      case OP_SEARCH_REVERSE:
+      case OP_SEARCH_NEXT:
+      case OP_SEARCH_OPPOSITE:
+      case OP_SEARCH:
+        menu->current = mutt_search_alias_command(menu, menu->current, op);
+        if (menu->current == -1)
+          menu->current = menu->oldcurrent;
+        else
+          menu->redraw |= REDRAW_MOTION;
+        break;
+
       case OP_EXIT:
         done = 1;
         break;

--- a/alias/gui.h
+++ b/alias/gui.h
@@ -34,11 +34,13 @@ struct Alias;
  */
 struct AliasView
 {
-  int num;             ///< Index number in list
-  int orig_seq;        ///< Sequence in alias config file
-  bool is_tagged;      ///< Is it tagged?
-  bool is_deleted;     ///< Is it deleted?
-  struct Alias *alias; ///< Alias
+  int num;              ///< Index number in list
+  int orig_seq;         ///< Sequence in alias config file
+  bool is_searched : 1; ///< Alias has been searched
+  bool is_matched  : 1; ///< Search matches this Alias
+  bool is_tagged   : 1; ///< Is it tagged?
+  bool is_deleted  : 1; ///< Is it deleted?
+  struct Alias *alias;  ///< Alias
 };
 
 ARRAY_HEAD(AliasMenuData, struct AliasView);

--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -7890,7 +7890,7 @@ set index_format="%4C %Z %{%b %d} %-15.15L (%?l?%4l&amp;%4c?)%*  %s"
           (<literal>limit</literal>, <literal>tag-pattern</literal>,
           <literal>delete-pattern</literal>, etc.).
           <xref linkend="tab-patterns" /> shows several ways to select
-          messages.
+          messages while <xref linkend="tab-patterns-alias" /> shows ways of selecting aliases.
         </para>
 
         <table id="tab-patterns">
@@ -8394,6 +8394,46 @@ set index_format="%4C %Z %{%b %d} %-15.15L (%?l?%4l&amp;%4c?)%*  %s"
             </tbody>
           </tgroup>
         </table>
+
+        <table id="tab-patterns-alias">
+          <title>Alias pattern modifiers</title>
+          <tgroup cols="3">
+            <thead>
+              <row>
+                <entry>Pattern modifier</entry>
+                <entry>Notes</entry>
+                <entry>Description</entry>
+              </row>
+            </thead>
+            <tbody>
+              <row>
+                <entry>~c <emphasis>EXPR</emphasis></entry>
+                <entry></entry>
+                <entry>
+                  aliases which contain <emphasis>EXPR</emphasis> in the
+                  alias comment
+                </entry>
+              </row>
+              <row>
+                <entry>~f <emphasis>EXPR</emphasis></entry>
+                <entry></entry>
+                <entry>
+                  aliases which contain <emphasis>EXPR</emphasis> in the
+                  alias name (<emphasis>From</emphasis> part of alias)
+                </entry>
+              </row>
+              <row>
+                <entry>~t <emphasis>EXPR</emphasis></entry>
+                <entry></entry>
+                <entry>
+                  aliases which contain <emphasis>EXPR</emphasis> in the
+                  alias address (<emphasis>To</emphasis> part of alias)
+                </entry>
+              </row>
+            </tbody>
+          </tgroup>
+        </table>
+
         <para>
           Where <emphasis>EXPR</emphasis> is a
           <link linkend="regex">regular expression</link>, and

--- a/pattern/lib.h
+++ b/pattern/lib.h
@@ -45,10 +45,12 @@
 #include "mutt/lib.h"
 #include "mutt.h"
 
+struct AliasView;
 struct ConfigSet;
 struct Email;
 struct Envelope;
 struct Mailbox;
+struct Menu;
 
 /* These Config Variables are only used in pattern.c */
 extern bool C_ThoroughSearch;
@@ -167,8 +169,11 @@ enum PatternType
   MUTT_PAT_MAX,
 };
 
-int mutt_pattern_exec(struct Pattern *pat, PatternExecFlags flags,
-                      struct Mailbox *m, struct Email *e, struct PatternCache *cache);
+int mutt_pattern_exec(struct Pattern *pat, PatternExecFlags flags, struct Mailbox *m,
+                      struct Email *e, struct PatternCache *cache);
+int mutt_pattern_alias_exec(struct Pattern *pat, PatternExecFlags flags,
+                            struct AliasView *av, struct PatternCache *cache);
+
 struct PatternList *mutt_pattern_comp(const char *s, PatternCompFlags flags, struct Buffer *err);
 void mutt_check_simple(struct Buffer *s, const char *simple);
 void mutt_pattern_free(struct PatternList **pat);
@@ -179,6 +184,7 @@ int mutt_is_list_recipient(bool all_addr, struct Envelope *e);
 int mutt_is_subscribed_list_recipient(bool all_addr, struct Envelope *e);
 int mutt_pattern_func(int op, char *prompt);
 int mutt_search_command(struct Mailbox *mailbox, int cur, int op);
+int mutt_search_alias_command(struct Menu *menu, int cur, int op);
 
 bool mutt_limit_current_thread(struct Email *e);
 bool config_init_pattern(struct ConfigSet *cs);


### PR DESCRIPTION
* **What does this PR do?**

This PR adds the possibility of using patterns (e.g.: `~b EXPR` to search comments`) in the Alias and Query menus.
In this PR there are three different patterns that can be used:

- `~f EXPR` - Alias
- `~t EXPR` - Address
- `~b EXPR` - Comment

* **What are the relevant issue numbers?**
The relevant issue number where this was discussed is #2621.