### PR TITLE
build: Add the Address Sanitizer

### DIFF
--- a/auto.def
+++ b/auto.def
@@ -113,8 +113,9 @@ options {
 # Misc
   include-path-in-cflags=1  => "Remove include paths from CFLAGS in the output of neomutt -v"
 # Testing
-  testing=0                 => "Enable Unit Testing"
+  asan=0                    => "Enable the Address Sanitizer"
   coverage=0                => "Enable Coverage Testing"
+  testing=0                 => "Enable Unit Testing"
 # Configure with pkg-config
   pkgconf=0                 => "Use pkg-config during configure"
 # Enable all options
@@ -136,7 +137,7 @@ options {
 if {1} {
   # Keep sorted, please.
   foreach opt {
-    autocrypt bdb coverage debug-backtrace debug-graphviz debug-notify
+    asan autocrypt bdb coverage debug-backtrace debug-graphviz debug-notify
     debug-parse-test debug-window doc everything fmemopen full-doc gdbm gnutls
     gpgme gss homespool idn idn2 include-path-in-cflags inotify kyotocabinet
     lmdb locales-fix lua lz4 mixmaster nls notmuch pcre2 pgp pkgconf qdbm
@@ -564,14 +565,6 @@ if {[get-define want-sasl]} {
       user-error "Unable to find SASL"
     }
   }
-}
-
-###############################################################################
-# Coverage Testing
-if {[get-define want-coverage]} {
-  define ENABLE_COVERAGE
-  define-append CFLAGS -fprofile-arcs -ftest-coverage
-  define-append LDFLAGS -fprofile-arcs -ftest-coverage
 }
 
 ###############################################################################
@@ -1211,6 +1204,26 @@ if {[get-define want-debug-parse-test]} {
 # Windows dump
 if {[get-define want-debug-window]} {
   define USE_DEBUG_WINDOW 1
+}
+
+###############################################################################
+# Address Sanitizer
+if {[get-define want-asan]} {
+  msg-checking "Checking for ASAN..."
+  if {![cctest -link 1 -cflags -fsanitize=address]} {
+    user-error "Unable to compile with -fsanitize=address"
+  }
+  msg-result "yes"
+  define-append CFLAGS -fsanitize=address
+  define-append LDFLAGS -fsanitize=address
+}
+
+###############################################################################
+# Coverage Testing
+if {[get-define want-coverage]} {
+  define ENABLE_COVERAGE
+  define-append CFLAGS -fprofile-arcs -ftest-coverage
+  define-append LDFLAGS -fprofile-arcs -ftest-coverage
 }
 
 ###############################################################################


### PR DESCRIPTION
I'm not sure why we didn't think to add this sooner.

However, I couldn't figure out how to check if ASAN was actually installed.

I tried:
```
if [cc-with { -libs -fsanitize=address }] {
```
and
```
if [cctest -link 1 -libs -fsanitize=address] { 
```

Nothing quite worked.
Those that didn't fail, also meant that all the later checks had the Sanitizer compiles flags, too.