### PR TITLE
Refactor the Color Event

### DIFF
--- a/debug/notify.c
+++ b/debug/notify.c
@@ -175,23 +175,24 @@ static void notify_dump_color(struct NotifyCallback *nc)
   const char *color = NULL;
   const char *scope = "";
 
-  if (nc->event_subtype == MT_COLOR_MAX)
+  if (ev_c->color == MT_COLOR_MAX)
     color = "ALL";
 
   if (!color)
-    color = mutt_map_get_name(nc->event_subtype, Fields);
+    color = mutt_map_get_name(ev_c->color, Fields);
 
   if (!color)
   {
-    color = mutt_map_get_name(nc->event_subtype, ComposeFields);
+    color = mutt_map_get_name(ev_c->color, ComposeFields);
     scope = "compose ";
   }
 
   if (!color)
     color = "UNKNOWN";
 
-  mutt_debug(LL_DEBUG1, "\tColor: %s %s%s (%d)\n", ev_c->set ? "set" : "reset",
-             scope, color, nc->event_subtype);
+  mutt_debug(LL_DEBUG1, "\tColor: %s %s%s (%d)\n",
+             (nc->event_subtype == NT_COLOR_SET) ? "set" : "reset", scope,
+             color, ev_c->color);
 }
 
 static void notify_dump_command(struct NotifyCallback *nc)

--- a/gui/color.c
+++ b/gui/color.c
@@ -824,8 +824,8 @@ static enum CommandResult parse_uncolor(struct Buffer *buf, struct Buffer *s,
   if (mutt_str_equal(buf->data, "*"))
   {
     colors_clear(c);
-    struct EventColor ec = { false }; // Color reset/removed
-    notify_send(c->notify, NT_COLOR, MT_COLOR_MAX, &ec);
+    struct EventColor ec = { MT_COLOR_MAX }; 
+    notify_send(c->notify, NT_COLOR, NT_COLOR_RESET, &ec);
     return MUTT_CMD_SUCCESS;
   }
 
@@ -856,8 +856,8 @@ static enum CommandResult parse_uncolor(struct Buffer *buf, struct Buffer *s,
     // Simple colours
     c->defs[object] = A_NORMAL;
 
-    struct EventColor ec = { false }; // Color reset/removed
-    notify_send(c->notify, NT_COLOR, object, &ec);
+    struct EventColor ec = { object };
+    notify_send(c->notify, NT_COLOR, NT_COLOR_RESET, &ec);
     return MUTT_CMD_SUCCESS;
   }
 
@@ -906,8 +906,8 @@ static enum CommandResult parse_uncolor(struct Buffer *buf, struct Buffer *s,
 
   if (changed)
   {
-    struct EventColor ec = { false }; // Color reset/removed
-    notify_send(c->notify, NT_COLOR, object, &ec);
+    struct EventColor ec = { object };
+    notify_send(c->notify, NT_COLOR, NT_COLOR_RESET, &ec);
   }
 
   return MUTT_CMD_SUCCESS;
@@ -1331,8 +1331,8 @@ static enum CommandResult parse_color(struct Colors *c, struct Buffer *buf, stru
 
   if (rc == MUTT_CMD_SUCCESS)
   {
-    struct EventColor ec = { true }; // Color set/added
-    notify_send(c->notify, NT_COLOR, object, &ec);
+    struct EventColor ec = { object };
+    notify_send(c->notify, NT_COLOR, NT_COLOR_SET, &ec);
   }
 
   return rc;

--- a/gui/color.h
+++ b/gui/color.h
@@ -152,12 +152,24 @@ struct Colors
 /**
  * struct EventColor - An Event that happened to a Colour
  *
- * Observers will be passed a type of #NT_COLOR and a subtype which
- * describes the colour that changed, e.g. #MT_COLOR_SIDEBAR_HIGHLIGHT.
+ * Observers will be passed a type of #NT_COLOR and a subtype of 
+ * #NT_COLOR_SET or #NT_COLOR_RESET with a struct which
+ * describes the colour, e.g. #MT_COLOR_SIDEBAR_HIGHLIGHT.
  */
 struct EventColor
 {
-  bool set; ///< True if a colour has been set/added, false if reset/deleted
+  enum ColorId color;
+};
+
+/**
+ * enum NotifyColor - Types of Color Event
+ *
+ * Observers of #NT_COLOR will be passed an #EventColor.
+ */
+enum NotifyColor
+{
+  NT_COLOR_SET = 1, ///< A new Color has been set
+  NT_COLOR_RESET,   ///< Color has been reset/removed
 };
 
 int  mutt_color_alloc  (struct Colors *c, uint32_t fg,      uint32_t bg);

--- a/helpbar/helpbar.c
+++ b/helpbar/helpbar.c
@@ -188,10 +188,12 @@ static int helpbar_binding_observer(struct NotifyCallback *nc)
  */
 static int helpbar_color_observer(struct NotifyCallback *nc)
 {
+  struct EventColor *ev_c = nc->event_data;
+
   if ((nc->event_type != NT_COLOR) || !nc->event_data || !nc->global_data)
     return -1;
 
-  if (nc->event_subtype != MT_COLOR_STATUS)
+  if (ev_c->color != MT_COLOR_STATUS)
     return 0;
 
   struct MuttWindow *win_helpbar = nc->global_data;

--- a/menu.c
+++ b/menu.c
@@ -1561,24 +1561,24 @@ int mutt_menu_color_observer(struct NotifyCallback *nc)
   if (nc->event_type != NT_CONFIG)
     return 0;
 
-  int s = nc->event_subtype;
+  struct EventColor *ev_c = nc->event_data;
 
-  bool simple = (s == MT_COLOR_INDEX_COLLAPSED) || (s == MT_COLOR_INDEX_DATE) ||
-                (s == MT_COLOR_INDEX_LABEL) || (s == MT_COLOR_INDEX_NUMBER) ||
-                (s == MT_COLOR_INDEX_SIZE) || (s == MT_COLOR_INDEX_TAGS);
-  bool lists = (s == MT_COLOR_ATTACH_HEADERS) || (s == MT_COLOR_BODY) ||
-               (s == MT_COLOR_HEADER) || (s == MT_COLOR_INDEX) ||
-               (s == MT_COLOR_INDEX_AUTHOR) || (s == MT_COLOR_INDEX_FLAGS) ||
-               (s == MT_COLOR_INDEX_SUBJECT) || (s == MT_COLOR_INDEX_TAG);
+  int c = ev_c->color;
+
+  bool simple = (c == MT_COLOR_INDEX_COLLAPSED) || (c == MT_COLOR_INDEX_DATE) ||
+                (c == MT_COLOR_INDEX_LABEL) || (c == MT_COLOR_INDEX_NUMBER) ||
+                (c == MT_COLOR_INDEX_SIZE) || (c == MT_COLOR_INDEX_TAGS);
+  bool lists = (c == MT_COLOR_ATTACH_HEADERS) || (c == MT_COLOR_BODY) ||
+               (c == MT_COLOR_HEADER) || (c == MT_COLOR_INDEX) ||
+               (c == MT_COLOR_INDEX_AUTHOR) || (c == MT_COLOR_INDEX_FLAGS) ||
+               (c == MT_COLOR_INDEX_SUBJECT) || (c == MT_COLOR_INDEX_TAG);
 
   // The changes aren't relevant to the index menu
   if (!simple && !lists)
     return 0;
 
-  struct EventColor *ec = nc->event_data;
-
   // Colour deleted from a list
-  if (!ec->set && lists && Context && Context->mailbox)
+  if ((nc->event_subtype == NT_COLOR_RESET) && lists && Context && Context->mailbox)
   {
     struct Mailbox *m = Context->mailbox;
     // Force re-caching of index colors

--- a/sidebar/observer.c
+++ b/sidebar/observer.c
@@ -198,9 +198,10 @@ static int sb_color_observer(struct NotifyCallback *nc)
   if ((nc->event_type != NT_COLOR) || !nc->event_data || !nc->global_data)
     return -1;
 
+  struct EventColor *ev_c = nc->event_data;
   struct MuttWindow *win = nc->global_data;
 
-  enum ColorId color = nc->event_subtype;
+  enum ColorId color = ev_c->color;
 
   switch (color)
   {


### PR DESCRIPTION
* **What does this PR do?**

Refactor the Color Event so that it works like the other Event notifications.
The Color Event now has two subtypes `#NT_COLOR_SET` and `#NT_COLOR_RESET` and passes the actual color in the Event data struct (instead as the subtype).

* **What are the relevant issue numbers?**

#2640 