### PR TITLE
alias: fix simple searches

### DIFF
--- a/pattern/exec.c
+++ b/pattern/exec.c
@@ -339,7 +339,7 @@ static int perform_alias_or(struct PatternList *pat, PatternExecFlags flags,
 }
 
 /**
- * match_addrlist - Match a Pattern against and Address list
+ * match_addrlist - Match a Pattern against an Address list
  * @param pat            Pattern to find
  * @param match_personal If true, also match the pattern against the real name
  * @param n              Number of Addresses supplied

--- a/pattern/pattern.c
+++ b/pattern/pattern.c
@@ -518,7 +518,7 @@ int mutt_search_command(struct Mailbox *mailbox, int cur, int op)
 }
 
 /**
- * mutt_search_command - Perform a search
+ * mutt_search_alias_command - Perform a search
  * @param menu Menu to search through
  * @param cur  Index number of current alias
  * @param op   Operation to perform, e.g. OP_SEARCH_NEXT
@@ -553,7 +553,7 @@ int mutt_search_alias_command(struct Menu *menu, int cur, int op)
      * $simple_search has changed while we were searching */
     struct Buffer *tmp = mutt_buffer_pool_get();
     mutt_buffer_strcpy(tmp, buf);
-    mutt_check_simple(tmp, NONULL(C_SimpleSearch));
+    mutt_check_simple(tmp, "~f %s | ~t %s | ~c %s");
 
     if (!SearchPattern || !mutt_str_equal(mutt_b2s(tmp), LastSearchExpn))
     {


### PR DESCRIPTION
I've changed the "simple search" case for Aliases..

If the user doesn't put a pattern in the search, the code used `C_SimpleSearch` to expand the pattern.
Unfortunately, that isn't meaningful for Aliases (wrong `~` patterns).

It now expands to `~f %s | ~t %s | ~c %s`

This is hard-coded to match on **any** Alias field.
I'm not sure if it's worth making this into a config variable.

Any thoughts?