### PR TITLE
Devel/commands refactor

### DIFF
--- a/compmbox/compress.c
+++ b/compmbox/compress.c
@@ -44,12 +44,29 @@
 #include "lib.h"
 #include "format_flags.h"
 #include "hook.h"
+#include "mutt_commands.h"
 #include "mutt_globals.h"
 #include "muttlib.h"
 #include "mx.h"
 #include "protos.h"
 
 struct Email;
+
+const struct Command comp_commands[] = {
+  // clang-format off
+  { "append-hook", mutt_parse_hook, MUTT_APPEND_HOOK },
+  { "close-hook",  mutt_parse_hook, MUTT_CLOSE_HOOK },
+  { "open-hook",   mutt_parse_hook, MUTT_OPEN_HOOK },
+  // clang-format on
+};
+
+/**
+ * mutt_comp_init - Setup feature commands
+ */
+void mutt_comp_init(void)
+{
+  COMMANDS_REGISTER(comp_commands);
+}
 
 /**
  * lock_realpath - Try to lock the ctx->realpath

--- a/compmbox/lib.h
+++ b/compmbox/lib.h
@@ -56,6 +56,7 @@ struct CompressInfo
   FILE *fp_lock;                 ///< fp used for locking
 };
 
+void mutt_comp_init(void);
 bool mutt_comp_can_append(struct Mailbox *m);
 bool mutt_comp_can_read(const char *path);
 int  mutt_comp_valid_command(const char *cmd);

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -47,6 +47,7 @@
 #include "bcache/lib.h"
 #include "pattern/lib.h"
 #include "auth.h"
+#include "command_parse.h"
 #include "commands.h"
 #include "hook.h"
 #include "init.h"
@@ -64,6 +65,21 @@
 #endif
 
 struct stat;
+
+const struct Command imap_commands[] = {
+  // clang-format off
+  { "subscribe-to",     parse_subscribe_to,     0 },
+  { "unsubscribe-from", parse_unsubscribe_from, 0 },
+  // clang-format on
+};
+
+/**
+ * imap_init - Setup feature commands
+ */
+void imap_init(void)
+{
+  COMMANDS_REGISTER(imap_commands);
+}
 
 /**
  * check_capabilities - Make sure we can log in to this server

--- a/imap/lib.h
+++ b/imap/lib.h
@@ -73,6 +73,7 @@ extern bool  C_ImapPassive;
 extern bool  C_ImapPeek;
 
 /* imap.c */
+void imap_init(void);
 int imap_access(const char *path);
 int imap_check_mailbox(struct Mailbox *m, bool force);
 int imap_delete_mailbox(struct Mailbox *m, char *path);

--- a/init.c
+++ b/init.c
@@ -59,6 +59,9 @@
 #include "keymap.h"
 #include "mutt_commands.h"
 #include "mutt_globals.h"
+#ifdef USE_LUA
+#include "mutt_lua.h"
+#endif
 #include "mutt_menu.h"
 #include "mutt_parse.h"
 #include "muttlib.h"
@@ -68,6 +71,12 @@
 #include "sort.h"
 #ifdef USE_SIDEBAR
 #include "sidebar/lib.h"
+#endif
+#ifdef USE_COMP_MBOX
+#include "compmbox/lib.h"
+#endif
+#ifdef USE_IMAP
+#include "imap/lib.h"
 #endif
 
 /* Initial string that starts completion. No telling how much the user has
@@ -375,35 +384,6 @@ static bool get_hostname(struct ConfigSet *cs)
 }
 
 /**
- * mutt_command_get - Get a Command by its name
- * @param s Command string to lookup
- * @retval ptr  Success, Command
- * @retval NULL Error, no such command
- */
-const struct Command *mutt_command_get(const char *s)
-{
-  for (int i = 0; Commands[i].name; i++)
-    if (mutt_str_equal(s, Commands[i].name))
-      return &Commands[i];
-  return NULL;
-}
-
-#ifdef USE_LUA
-/**
- * mutt_commands_apply - Run a callback function on every Command
- * @param data        Data to pass to the callback function
- * @param application Callback function
- *
- * This is used by Lua to expose all of NeoMutt's Commands.
- */
-void mutt_commands_apply(void *data, void (*application)(void *, const struct Command *))
-{
-  for (int i = 0; Commands[i].name; i++)
-    application(data, &Commands[i]);
-}
-#endif
-
-/**
  * mutt_extract_token - Extract one token from a string
  * @param dest  Buffer for the result
  * @param tok   Buffer containing tokens
@@ -703,6 +683,7 @@ void mutt_opts_free(void)
   mutt_keys_free();
 
   mutt_regexlist_free(&NoSpamList);
+  mutt_commands_free();
 }
 
 /**
@@ -713,12 +694,13 @@ void mutt_opts_free(void)
  */
 HookFlags mutt_get_hook_type(const char *name)
 {
-  for (const struct Command *c = Commands; c->name; c++)
+  struct Command *c = NULL;
+  for (size_t i = 0, size = mutt_commands_array(&c); i < size; i++)
   {
-    if (((c->parse == mutt_parse_hook) || (c->parse == mutt_parse_idxfmt_hook)) &&
-        mutt_istr_equal(c->name, name))
+    if (((c[i].parse == mutt_parse_hook) || (c[i].parse == mutt_parse_idxfmt_hook)) &&
+        mutt_istr_equal(c[i].name, name))
     {
-      return c->data;
+      return c[i].data;
     }
   }
   return MUTT_HOOK_NO_FLAGS;
@@ -741,12 +723,25 @@ int mutt_init(struct ConfigSet *cs, bool skip_sys_rc, struct ListHead *commands)
 
   mutt_grouplist_init();
   alias_init();
+  mutt_commands_init();
+#ifdef USE_COMP_MBOX
+  mutt_comp_init();
+#endif
+#ifdef USE_IMAP
+  imap_init();
+#endif
+#ifdef USE_LUA
+  mutt_lua_init();
+#endif
   TagTransforms = mutt_hash_new(64, MUTT_HASH_STRCASECMP);
   TagFormats = mutt_hash_new(64, MUTT_HASH_NO_FLAGS);
 
   mutt_menu_init();
 #ifdef USE_SIDEBAR
   sb_init();
+#endif
+#ifdef USE_NOTMUCH
+  nm_init();
 #endif
 
   snprintf(AttachmentMarker, sizeof(AttachmentMarker), "\033]9;%" PRIu64 "\a", // Escape
@@ -989,7 +984,6 @@ enum CommandResult mutt_parse_rc_buffer(struct Buffer *line,
   if (mutt_buffer_len(line) == 0)
     return 0;
 
-  int i;
   enum CommandResult rc = MUTT_CMD_SUCCESS;
 
   mutt_buffer_reset(err);
@@ -1008,20 +1002,24 @@ enum CommandResult mutt_parse_rc_buffer(struct Buffer *line,
       continue;
     }
     mutt_extract_token(token, line, MUTT_TOKEN_NO_FLAGS);
-    for (i = 0; Commands[i].name; i++)
+
+    struct Command *cmd = NULL;
+    size_t size = mutt_commands_array(&cmd);
+    size_t i;
+    for (i = 0; i < size; i++)
     {
-      if (mutt_str_equal(token->data, Commands[i].name))
+      if (mutt_str_equal(token->data, cmd[i].name))
       {
-        rc = Commands[i].parse(token, line, Commands[i].data, err);
+        rc = cmd[i].parse(token, line, cmd[i].data, err);
         if (rc != MUTT_CMD_SUCCESS)
         {              /* -1 Error, +1 Finish */
           goto finish; /* Propagate return code */
         }
-        notify_send(NeoMutt->notify, NT_COMMAND, i, (void *) &Commands[i]);
+        notify_send(NeoMutt->notify, NT_COMMAND, i, (void *) cmd);
         break; /* Continue with next command */
       }
     }
-    if (!Commands[i].name)
+    if (i == size)
     {
       mutt_buffer_printf(err, _("%s: unknown command"), NONULL(token->data));
       rc = MUTT_CMD_ERROR;
@@ -1128,7 +1126,6 @@ int mutt_query_variables(struct ListHead *queries, bool show_docs)
 int mutt_command_complete(char *buf, size_t buflen, int pos, int numtabs)
 {
   char *pt = buf;
-  int num;
   int spaces; /* keep track of the number of leading spaces on the line */
   struct MyVar *myv = NULL;
 
@@ -1148,8 +1145,10 @@ int mutt_command_complete(char *buf, size_t buflen, int pos, int numtabs)
       mutt_str_copy(UserTyped, pt, sizeof(UserTyped));
       memset(Matches, 0, MatchesListsize);
       memset(Completed, 0, sizeof(Completed));
-      for (num = 0; Commands[num].name; num++)
-        candidate(UserTyped, Commands[num].name, Completed, sizeof(Completed));
+
+      struct Command *c = NULL;
+      for (size_t num = 0, size = mutt_commands_array(&c); num < size; num++)
+        candidate(UserTyped, c[num].name, Completed, sizeof(Completed));
       matches_ensure_morespace(NumMatched);
       Matches[NumMatched++] = UserTyped;
 
@@ -1184,7 +1183,7 @@ int mutt_command_complete(char *buf, size_t buflen, int pos, int numtabs)
     /* loop through all the possible prefixes (no, inv, ...) */
     if (mutt_str_startswith(buf, "set"))
     {
-      for (num = 0; prefixes[num]; num++)
+      for (int num = 0; prefixes[num]; num++)
       {
         if (mutt_str_startswith(pt, prefixes[num]))
         {
@@ -1259,13 +1258,13 @@ int mutt_command_complete(char *buf, size_t buflen, int pos, int numtabs)
       mutt_str_copy(UserTyped, pt, sizeof(UserTyped));
       memset(Matches, 0, MatchesListsize);
       memset(Completed, 0, sizeof(Completed));
-      for (num = 0; menu[num].name; num++)
+      for (int num = 0; menu[num].name; num++)
         candidate(UserTyped, menu[num].name, Completed, sizeof(Completed));
       /* try the generic menu */
       if ((Completed[0] == '\0') && (CurrentMenu != MENU_PAGER))
       {
         menu = OpGeneric;
-        for (num = 0; menu[num].name; num++)
+        for (int num = 0; menu[num].name; num++)
           candidate(UserTyped, menu[num].name, Completed, sizeof(Completed));
       }
       matches_ensure_morespace(NumMatched);

--- a/init.h
+++ b/init.h
@@ -38,8 +38,6 @@ struct ListHead;
 
 struct ConfigSet *    init_config            (size_t size);
 int                   mutt_command_complete  (char *buf, size_t buflen, int pos, int numtabs);
-const struct Command *mutt_command_get       (const char *s);
-void                  mutt_commands_apply    (void *data, void (*application)(void *, const struct Command *));
 int                   mutt_extract_token     (struct Buffer *dest, struct Buffer *tok, TokenFlags flags);
 HookFlags             mutt_get_hook_type     (const char *name);
 int                   mutt_init              (struct ConfigSet *cs, bool skip_sys_rc, struct ListHead *commands);

--- a/mutt_commands.c
+++ b/mutt_commands.c
@@ -46,23 +46,17 @@
 #include "sidebar/lib.h"
 #endif
 
-// clang-format off
-const struct Command Commands[] = {
+const struct Command mutt_commands[] = {
+  // clang-format off
   { "account-hook",        mutt_parse_hook,        MUTT_ACCOUNT_HOOK },
   { "alias",               parse_alias,            0 },
   { "alternates",          parse_alternates,       0 },
   { "alternative_order",   parse_stailq,           IP &AlternativeOrderList },
-#ifdef USE_COMP_MBOX
-  { "append-hook",         mutt_parse_hook,        MUTT_APPEND_HOOK },
-#endif
   { "attachments",         parse_attachments,      0 },
   { "auto_view",           parse_stailq,           IP &AutoViewList },
   { "bind",                mutt_parse_bind,        0 },
   { "cd",                  parse_cd,               0 },
   { "charset-hook",        mutt_parse_hook,        MUTT_CHARSET_HOOK },
-#ifdef USE_COMP_MBOX
-  { "close-hook",          mutt_parse_hook,        MUTT_CLOSE_HOOK },
-#endif
 #ifdef HAVE_COLOR
   { "color",               mutt_parse_color,       0 },
 #endif
@@ -81,10 +75,6 @@ const struct Command Commands[] = {
   { "ignore",              parse_ignore,           0 },
   { "index-format-hook",   mutt_parse_idxfmt_hook, 0 },
   { "lists",               parse_lists,            0 },
-#ifdef USE_LUA
-  { "lua",                 mutt_lua_parse,         0 },
-  { "lua-source",          mutt_lua_source_file,   0 },
-#endif
   { "macro",               mutt_parse_macro,       0 },
   { "mailboxes",           parse_mailboxes,        0 },
   { "mailto_allow",        parse_stailq,           IP &MailToAllow },
@@ -95,9 +85,6 @@ const struct Command Commands[] = {
   { "my_hdr",              parse_my_hdr,           0 },
   { "named-mailboxes",     parse_mailboxes,        MUTT_NAMED },
   { "nospam",              parse_spam_list,        MUTT_NOSPAM },
-#ifdef USE_COMP_MBOX
-  { "open-hook",           mutt_parse_hook,        MUTT_OPEN_HOOK },
-#endif
   { "pgp-hook",            mutt_parse_hook,        MUTT_CRYPT_HOOK },
   { "push",                mutt_parse_push,        0 },
   { "reply-hook",          mutt_parse_hook,        MUTT_REPLY_HOOK },
@@ -109,17 +96,11 @@ const struct Command Commands[] = {
   { "set",                 parse_set,              MUTT_SET_SET },
   { "setenv",              parse_setenv,           MUTT_SET_SET },
   { "shutdown-hook",       mutt_parse_hook,        MUTT_SHUTDOWN_HOOK | MUTT_GLOBAL_HOOK },
-#ifdef USE_SIDEBAR
-  { "sidebar_whitelist",   sb_parse_whitelist,     0 },
-#endif
   { "source",              parse_source,           0 },
   { "spam",                parse_spam_list,        MUTT_SPAM },
   { "startup-hook",        mutt_parse_hook,        MUTT_STARTUP_HOOK | MUTT_GLOBAL_HOOK },
   { "subjectrx",           parse_subjectrx_list,   0 },
   { "subscribe",           parse_subscribe,        0 },
-#ifdef USE_IMAP
-  { "subscribe-to",        parse_subscribe_to,     0 },
-#endif
   { "tag-formats",         parse_tag_formats,      0 },
   { "tag-transforms",      parse_tag_transforms,   0 },
   { "timeout-hook",        mutt_parse_hook,        MUTT_TIMEOUT_HOOK | MUTT_GLOBAL_HOOK },
@@ -147,18 +128,97 @@ const struct Command Commands[] = {
   { "unscore",             mutt_parse_unscore,     0 },
   { "unset",               parse_set,              MUTT_SET_UNSET },
   { "unsetenv",            parse_setenv,           MUTT_SET_UNSET },
-#ifdef USE_SIDEBAR
-  { "unsidebar_whitelist", sb_parse_unwhitelist,   0 },
-#endif
   { "unsubjectrx",         parse_unsubjectrx_list, 0 },
   { "unsubscribe",         parse_unsubscribe,      0 },
-#ifdef USE_IMAP
-  { "unsubscribe-from",    parse_unsubscribe_from, 0 },
-#endif
-#ifdef USE_NOTMUCH
-  { "unvirtual-mailboxes", parse_unmailboxes,      0 },
-  { "virtual-mailboxes",   parse_mailboxes,        MUTT_NAMED },
-#endif
-  { NULL,                  NULL,                   0 },
+  // clang-format on
 };
-// clang-format on
+
+ARRAY_HEAD(, struct Command) commands = ARRAY_HEAD_INITIALIZER;
+
+/**
+ * mutt_commands_init - Initialize commands array and register default commands
+ */
+void mutt_commands_init(void)
+{
+  ARRAY_RESERVE(&commands, 100);
+  COMMANDS_REGISTER(mutt_commands);
+}
+
+/**
+ * commands_cmp - Compare two commands by name - Implements ::sort_t
+ */
+int commands_cmp(const void *a, const void *b)
+{
+  struct Command x = *(const struct Command *) a;
+  struct Command y = *(const struct Command *) b;
+
+  return strcmp(x.name, y.name);
+}
+
+/**
+ * commands_register - Add commands to Commands array
+ * @param cmds     Array of Commands
+ * @param num_cmds Number of Commands in the Array
+ */
+void commands_register(const struct Command *cmds, const size_t num_cmds)
+{
+  for (int i = 0; i < num_cmds; i++)
+  {
+    ARRAY_ADD(&commands, cmds[i]);
+  }
+  ARRAY_SORT(&commands, commands_cmp);
+}
+
+/**
+ * mutt_commands_free - Free Commands array
+ */
+void mutt_commands_free(void)
+{
+  ARRAY_FREE(&commands);
+}
+
+/**
+ * mutt_commands_array - Get Commands array
+ * @param first Set to first element of Commands array
+ * @retval size_t Size of Commands array
+ */
+size_t mutt_commands_array(struct Command **first)
+{
+  *first = ARRAY_FIRST(&commands);
+  return ARRAY_SIZE(&commands);
+}
+
+/**
+ * mutt_command_get - Get a Command by its name
+ * @param s Command string to lookup
+ * @retval ptr  Success, Command
+ * @retval NULL Error, no such command
+ */
+struct Command *mutt_command_get(const char *s)
+{
+  struct Command *cmd = NULL;
+  ARRAY_FOREACH(cmd, &commands)
+  {
+    if (mutt_str_equal(s, cmd->name))
+      return cmd;
+  }
+  return NULL;
+}
+
+#ifdef USE_LUA
+/**
+ * mutt_commands_apply - Run a callback function on every Command
+ * @param data        Data to pass to the callback function
+ * @param application Callback function
+ *
+ * This is used by Lua to expose all of NeoMutt's Commands.
+ */
+void mutt_commands_apply(void *data, void (*application)(void *, const struct Command *))
+{
+  struct Command *cmd = NULL;
+  ARRAY_FOREACH(cmd, &commands)
+  {
+    application(data, cmd);
+  }
+}
+#endif

--- a/mutt_commands.h
+++ b/mutt_commands.h
@@ -23,6 +23,7 @@
 #ifndef MUTT_MUTT_COMMANDS_H
 #define MUTT_MUTT_COMMANDS_H
 
+#include <stddef.h>
 #include <stdint.h>
 
 struct Buffer;
@@ -72,6 +73,16 @@ enum MuttSetCommand
 /* parameter to parse_mailboxes */
 #define MUTT_NAMED   (1 << 0)
 
-extern const struct Command Commands[];
+/* command registry functions */
+#define COMMANDS_REGISTER(cmds) commands_register(cmds, mutt_array_size(cmds))
+
+void            mutt_commands_init     (void);
+void            commands_register      (const struct Command *cmdv, const size_t cmds);
+void            mutt_commands_free     (void);
+size_t          mutt_commands_array    (struct Command **first);
+struct Command *mutt_command_get       (const char *s);
+#ifdef USE_LUA
+void            mutt_commands_apply    (void *data, void (*application)(void *, const struct Command *));
+#endif
 
 #endif /* MUTT_MUTT_COMMANDS_H */

--- a/mutt_lua.c
+++ b/mutt_lua.c
@@ -52,6 +52,13 @@
 #include "muttlib.h"
 #include "myvar.h"
 
+const struct Command lua_commands[] = {
+  // clang-format off
+  { "lua",        mutt_lua_parse,       0 },
+  { "lua-source", mutt_lua_source_file, 0 },
+  // clang-format on
+};
+
 /**
  * handle_panic - Handle a panic in the Lua interpreter
  * @param l Lua State
@@ -437,6 +444,14 @@ static bool lua_init(lua_State **l)
   luaopen_mutt(*l);
 
   return true;
+}
+
+/**
+ * mutt_lua_init - Setup feature commands
+ */
+void mutt_lua_init(void)
+{
+  COMMANDS_REGISTER(lua_commands);
 }
 
 /**

--- a/mutt_lua.h
+++ b/mutt_lua.h
@@ -31,4 +31,6 @@ struct Buffer;
 enum CommandResult mutt_lua_parse      (struct Buffer *tmp, struct Buffer *s, intptr_t data, struct Buffer *err);
 enum CommandResult mutt_lua_source_file(struct Buffer *tmp, struct Buffer *s, intptr_t data, struct Buffer *err);
 
+void mutt_lua_init(void);
+
 #endif /* MUTT_MUTT_LUA_H */

--- a/notmuch/lib.h
+++ b/notmuch/lib.h
@@ -53,6 +53,7 @@ extern int   C_NmQueryWindowDuration;
 extern char *C_VfolderFormat;
 extern bool  C_VirtualSpoolfile;
 
+void  nm_init                    (void);
 void  nm_db_debug_check          (struct Mailbox *m);
 void  nm_db_longrun_done         (struct Mailbox *m);
 void  nm_db_longrun_init         (struct Mailbox *m, bool writable);

--- a/notmuch/notmuch.c
+++ b/notmuch/notmuch.c
@@ -61,7 +61,9 @@
 #include "lib.h"
 #include "hcache/lib.h"
 #include "maildir/lib.h"
+#include "command_parse.h"
 #include "index.h"
+#include "mutt_commands.h"
 #include "mutt_globals.h"
 #include "mutt_thread.h"
 #include "mx.h"
@@ -70,8 +72,22 @@
 
 struct stat;
 
+const struct Command nm_commands[] = {
+  // clang-format off
+  { "unvirtual-mailboxes", parse_unmailboxes, 0 },
+  { "virtual-mailboxes",   parse_mailboxes,   MUTT_NAMED },
+  // clang-format on
+};
 const char NmUrlProtocol[] = "notmuch://";
 const int NmUrlProtocolLen = sizeof(NmUrlProtocol) - 1;
+
+/**
+ * nm_init - Setup feature commands
+ */
+void nm_init(void)
+{
+  COMMANDS_REGISTER(nm_commands);
+}
 
 /**
  * nm_hcache_open - Open a header cache

--- a/sidebar/sidebar.c
+++ b/sidebar/sidebar.c
@@ -41,6 +41,13 @@
 
 struct ListHead SidebarWhitelist = STAILQ_HEAD_INITIALIZER(SidebarWhitelist); ///< List of mailboxes to always display in the sidebar
 
+const struct Command sb_commands[] = {
+  // clang-format off
+  { "sidebar_whitelist",   sb_parse_whitelist,     0 },
+  { "unsidebar_whitelist", sb_parse_unwhitelist,   0 },
+  // clang-format on
+};
+
 /**
  * sb_get_highlight - Get the Mailbox that's highlighted in the sidebar
  * @param win Sidebar Window
@@ -181,6 +188,8 @@ void sb_set_current_mailbox(struct SidebarWindowData *wdata, struct Mailbox *m)
  */
 void sb_init(void)
 {
+  COMMANDS_REGISTER(sb_commands);
+
   // Listen for dialog creation events
   notify_observer_add(AllDialogsWindow->notify, NT_WINDOW, sb_insertion_observer, NULL);
 }


### PR DESCRIPTION
* **What does this PR do?**

Refactor the Commands list: feature specific commands are now moved into the feature source. 
Mutt_commands.c/h provides a facility for features to register their commands on init into a new dynamic Commands array. Commands for the following features were moved:

- `USE_COMP_MBOX`
- `USE_IMAP`
- `USE_LUA`
- `USE_NOTMUCH`
- `USE_SIDEBAR`

* **What are the relevant issue numbers?**

#2641 