### PR TITLE
my_hdr compose screen notifications

### DIFF
--- a/command_parse.c
+++ b/command_parse.c
@@ -2019,9 +2019,7 @@ enum CommandResult parse_unmy_hdr(struct Buffer *buf, struct Buffer *s,
     {
       if (mutt_istrn_equal(buf->data, np->data, l) && (np->data[l] == ':'))
       {
-        STAILQ_REMOVE(&UserHeader, np, ListNode, entries);
-        FREE(&np->data);
-        FREE(&np);
+        header_free(&UserHeader, np);
       }
     }
   } while (MoreArgs(s));

--- a/command_parse.c
+++ b/command_parse.c
@@ -1003,9 +1003,6 @@ enum CommandResult parse_mailboxes(struct Buffer *buf, struct Buffer *s,
 enum CommandResult parse_my_hdr(struct Buffer *buf, struct Buffer *s,
                                 intptr_t data, struct Buffer *err)
 {
-  struct ListNode *n = NULL;
-  size_t keylen;
-
   mutt_extract_token(buf, s, MUTT_TOKEN_SPACE | MUTT_TOKEN_QUOTE);
   char *p = strpbrk(buf->data, ": \t");
   if (!p || (*p != ':'))
@@ -1013,29 +1010,17 @@ enum CommandResult parse_my_hdr(struct Buffer *buf, struct Buffer *s,
     mutt_buffer_strcpy(err, _("invalid header field"));
     return MUTT_CMD_WARNING;
   }
-  keylen = p - buf->data + 1;
 
-  STAILQ_FOREACH(n, &UserHeader, entries)
-  {
-    /* see if there is already a field by this name */
-    if (mutt_istrn_equal(buf->data, n->data, keylen))
-    {
-      break;
-    }
-  }
+  struct ListNode *n = header_find(&UserHeader, buf->data);
 
-  if (!n)
+  if (n)
   {
-    /* not found, allocate memory for a new node and add it to the list */
-    n = mutt_list_insert_tail(&UserHeader, NULL);
+    header_update(n, buf->data);
   }
   else
   {
-    /* found, free the existing data */
-    FREE(&n->data);
+    header_add(&UserHeader, buf->data);
   }
-
-  n->data = mutt_buffer_strdup(buf);
 
   return MUTT_CMD_SUCCESS;
 }

--- a/command_parse.c
+++ b/command_parse.c
@@ -1011,15 +1011,18 @@ enum CommandResult parse_my_hdr(struct Buffer *buf, struct Buffer *s,
     return MUTT_CMD_WARNING;
   }
 
+  struct EventHeader event = { buf->data };
   struct ListNode *n = header_find(&UserHeader, buf->data);
 
   if (n)
   {
     header_update(n, buf->data);
+    notify_send(NeoMutt->notify, NT_HEADER, NT_HEADER_CHANGE, &event);
   }
   else
   {
     header_add(&UserHeader, buf->data);
+    notify_send(NeoMutt->notify, NT_HEADER, NT_HEADER_ADD, &event);
   }
 
   return MUTT_CMD_SUCCESS;

--- a/command_parse.c
+++ b/command_parse.c
@@ -2007,6 +2007,12 @@ enum CommandResult parse_unmy_hdr(struct Buffer *buf, struct Buffer *s,
     mutt_extract_token(buf, s, MUTT_TOKEN_NO_FLAGS);
     if (mutt_str_equal("*", buf->data))
     {
+      /* Clear all headers, send a notification for each header */
+      STAILQ_FOREACH(np, &UserHeader, entries)
+      {
+        struct EventHeader event = { np->data };
+        notify_send(NeoMutt->notify, NT_HEADER, NT_HEADER_REMOVE, &event);
+      }
       mutt_list_free(&UserHeader);
       continue;
     }
@@ -2019,6 +2025,9 @@ enum CommandResult parse_unmy_hdr(struct Buffer *buf, struct Buffer *s,
     {
       if (mutt_istrn_equal(buf->data, np->data, l) && (np->data[l] == ':'))
       {
+        struct EventHeader event = { np->data };
+        notify_send(NeoMutt->notify, NT_HEADER, NT_HEADER_REMOVE, &event);
+
         header_free(&UserHeader, np);
       }
     }

--- a/compose/compose.c
+++ b/compose/compose.c
@@ -1360,9 +1360,9 @@ static void compose_status_line(char *buf, size_t buflen, size_t col, int cols,
 }
 
 /**
- * mutt_dlg_compose_observer - Listen for config changes affecting the Compose menu - Implements ::observer_t
+ * compose_config_observer - Listen for config changes affecting the Compose menu - Implements ::observer_t
  */
-static int mutt_dlg_compose_observer(struct NotifyCallback *nc)
+static int compose_config_observer(struct NotifyCallback *nc)
 {
   if (!nc->event_data || !nc->global_data)
     return -1;
@@ -1461,7 +1461,7 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur, 
     mutt_window_add_child(dlg, ebar);
   }
 
-  notify_observer_add(NeoMutt->notify, NT_CONFIG, mutt_dlg_compose_observer, dlg);
+  notify_observer_add(NeoMutt->notify, NT_CONFIG, compose_config_observer, dlg);
   dialog_push(dlg);
 
 #ifdef USE_NNTP
@@ -2675,7 +2675,7 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur, 
   mutt_menu_pop_current(menu);
   mutt_menu_free(&menu);
   dialog_pop();
-  notify_observer_remove(NeoMutt->notify, mutt_dlg_compose_observer, dlg);
+  notify_observer_remove(NeoMutt->notify, compose_config_observer, dlg);
   mutt_window_free(&dlg);
 
   if (actx->idxlen)

--- a/compose/compose.c
+++ b/compose/compose.c
@@ -1411,7 +1411,12 @@ static int compose_header_observer(struct NotifyCallback *nc)
   }
   if (nc->event_subtype == NT_HEADER_REMOVE)
   {
-    /* TODO */
+    struct ListNode *removed = header_find(&env->userhdrs, event->header);
+    if (removed)
+    {
+      header_free(&env->userhdrs, removed);
+      mutt_window_reflow(dlg);
+    }
     return 0;
   }
 

--- a/email/email.c
+++ b/email/email.c
@@ -228,3 +228,15 @@ struct ListNode *header_set(struct ListHead *hdrlist, const char *header)
 
   return n ? header_update(n, header) : header_add(hdrlist, header);
 }
+
+/**
+ * header_free - Free and remove a header from a header list
+ * @param hdrlist List to free the header from
+ * @param target  The header to free
+ */
+void header_free(struct ListHead *hdrlist, struct ListNode *target)
+{
+  STAILQ_REMOVE(hdrlist, target, ListNode, entries);
+  FREE(&target->data);
+  FREE(&target);
+}

--- a/email/email.c
+++ b/email/email.c
@@ -159,3 +159,72 @@ int emaillist_add_email(struct EmailList *el, struct Email *e)
 
   return 0;
 }
+
+/**
+ * header_find - Find a header, matching on its field, in a list of headers
+ * @param hdrlist List of headers to search
+ * @param header  The header to search for
+ * @retval node   The node in the list matching the header
+ * @retval NULL   If no matching header is found
+ *
+ * The header should either of the form "X-Header:" or "X-Header: value"
+ */
+struct ListNode *header_find(const struct ListHead *hdrlist, const char *header)
+{
+  const char *key_end = strchr(header, ':');
+  if (!key_end)
+    return NULL;
+
+  const int keylen = key_end - header + 1;
+
+  struct ListNode *n = NULL;
+  STAILQ_FOREACH(n, hdrlist, entries)
+  {
+    if (mutt_istrn_equal(n->data, header, keylen))
+      return n;
+  }
+  return n;
+}
+
+/**
+ * header_add - Add a header to a list
+ * @param hdrlist List of headers to search
+ * @param header  String to set as the header
+ * @retval node   The created header
+ */
+struct ListNode *header_add(struct ListHead *hdrlist, const char *header)
+{
+  struct ListNode *n = mutt_list_insert_tail(hdrlist, NULL);
+  n->data = mutt_str_dup(header);
+
+  return n;
+}
+
+/**
+ * header_update - Update an existing header
+ * @param hdr     The header to update
+ * @param header  String to update the header with
+ * @retval node   The updated header
+ */
+struct ListNode *header_update(struct ListNode *hdr, const char *header)
+{
+  FREE(&hdr->data);
+  hdr->data = mutt_str_dup(header);
+
+  return hdr;
+}
+
+/**
+ * header_set - Set a header value in a list
+ * @param hdrlist List of headers to search
+ * @param header  String to set the value of the header to
+ * @retval node   The updated or created header
+ *
+ * If a header exists with the same field, update it, otherwise add a new header.
+ */
+struct ListNode *header_set(struct ListHead *hdrlist, const char *header)
+{
+  struct ListNode *n = header_find(hdrlist, header);
+
+  return n ? header_update(n, header) : header_add(hdrlist, header);
+}

--- a/email/email.h
+++ b/email/email.h
@@ -149,6 +149,26 @@ struct EventEmail
   struct Email **emails;
 };
 
+/**
+ * enum NotifyHeader - Types of Header Event
+ *
+ * Observers on #NT_HEADER will be passed an #EventHeader
+ */
+enum NotifyHeader
+{
+  NT_HEADER_ADD = 1, ///< A new header has been added
+  NT_HEADER_CHANGE,  ///< An existing header has been changed
+  NT_HEADER_REMOVE,  ///< A header is about to be removed
+};
+
+/**
+ * struct EventHeader - An event that happened to a header
+ */
+struct EventHeader
+{
+  char *header; ///< The contents of the header
+};
+
 bool          email_cmp_strict(const struct Email *e1, const struct Email *e2);
 void          email_free      (struct Email **ptr);
 struct Email *email_new       (void);

--- a/email/email.h
+++ b/email/email.h
@@ -179,6 +179,7 @@ void emaillist_clear    (struct EmailList *el);
 
 struct ListNode *header_add   (struct ListHead *hdrlist, const char *header);
 struct ListNode *header_find  (const struct ListHead *hdrlist, const char *header);
+void             header_free  (struct ListHead *hdrlist, struct ListNode *target);
 struct ListNode *header_set   (struct ListHead *hdrlist, const char *header);
 struct ListNode *header_update(struct ListNode *hdrnode, const char *header);
 

--- a/email/email.h
+++ b/email/email.h
@@ -157,4 +157,9 @@ size_t        email_size      (const struct Email *e);
 int  emaillist_add_email(struct EmailList *el, struct Email *e);
 void emaillist_clear    (struct EmailList *el);
 
+struct ListNode *header_add   (struct ListHead *hdrlist, const char *header);
+struct ListNode *header_find  (const struct ListHead *hdrlist, const char *header);
+struct ListNode *header_set   (struct ListHead *hdrlist, const char *header);
+struct ListNode *header_update(struct ListNode *hdrnode, const char *header);
+
 #endif /* MUTT_EMAIL_EMAIL_H */

--- a/mutt/notify_type.h
+++ b/mutt/notify_type.h
@@ -38,6 +38,7 @@ enum NotifyType
   NT_CONTEXT, ///< Context has changed,         #NotifyContext, #EventContext
   NT_EMAIL,   ///< Email has changed,           #NotifyEmail,   #EventEmail
   NT_GLOBAL,  ///< Not object-related,          #NotifyGlobal
+  NT_HEADER,  ///< A header has changed,        #NotifyHeader   #EventHeader
   NT_MAILBOX, ///< Mailbox has changed,         #NotifyMailbox, #EventMailbox
   NT_WINDOW,  ///< MuttWindow has changed,      #NotifyWindow,  #EventWindow
   NT_ALIAS,   ///< Alias has changed,           #NotifyAlias,   #EventAlias

--- a/test/Makefile.autosetup
+++ b/test/Makefile.autosetup
@@ -149,6 +149,7 @@ EMAIL_OBJS	= test/email/common.o \
 		  test/email/email_free.o \
 		  test/email/email_header_add.o \
 		  test/email/email_header_find.o \
+		  test/email/email_header_free.o \
 		  test/email/email_header_set.o \
 		  test/email/email_header_update.o \
 		  test/email/email_new.o \

--- a/test/Makefile.autosetup
+++ b/test/Makefile.autosetup
@@ -147,6 +147,10 @@ DATE_OBJS	= test/date/mutt_date_add_timeout.o \
 EMAIL_OBJS	= test/email/common.o \
 		  test/email/email_cmp_strict.o \
 		  test/email/email_free.o \
+		  test/email/email_header_add.o \
+		  test/email/email_header_find.o \
+		  test/email/email_header_set.o \
+		  test/email/email_header_update.o \
 		  test/email/email_new.o \
 		  test/email/email_size.o \
 		  test/email/emaillist_add_email.o \

--- a/test/email/email_header_add.c
+++ b/test/email/email_header_add.c
@@ -1,0 +1,21 @@
+#define TEST_NO_MAIN
+#include "config.h"
+#include "acutest.h"
+#include <string.h>
+#include "mutt/lib.h"
+#include "email/lib.h"
+
+void test_email_header_add(void)
+{
+  // struct ListNode *header_add(struct ListHead *hdrlist, const struct Buffer *buf)
+  const char *header = "X-TestHeader: 123";
+
+  struct ListHead hdrlist = STAILQ_HEAD_INITIALIZER(hdrlist);
+
+  {
+    struct ListNode *n = header_add(&hdrlist, header);
+    TEST_CHECK(strcmp(n->data, header) == 0);       /* header stored in node */
+    TEST_CHECK(n == header_find(&hdrlist, header)); /* node added to list */
+  }
+  mutt_list_free(&hdrlist);
+}

--- a/test/email/email_header_find.c
+++ b/test/email/email_header_find.c
@@ -1,0 +1,38 @@
+#define TEST_NO_MAIN
+#include "config.h"
+#include "acutest.h"
+#include "mutt/lib.h"
+#include "email/lib.h"
+
+void test_email_header_find(void)
+{
+  // struct ListNode *header_find(struct ListHead *hdrlist, const char *header)
+  char *header = "X-TestHeader: 123";
+
+  struct ListHead hdrlist = STAILQ_HEAD_INITIALIZER(hdrlist);
+  struct ListNode *n = mutt_mem_calloc(1, sizeof(struct ListNode));
+  n->data = mutt_str_dup(header);
+  STAILQ_INSERT_TAIL(&hdrlist, n, entries);
+
+  {
+    struct ListNode *found = header_find(&hdrlist, header);
+    TEST_CHECK(found == n);
+  }
+
+  {
+    const char *not_found = "X-NotIncluded: foo";
+    struct ListNode *found = header_find(&hdrlist, not_found);
+    TEST_CHECK(found == NULL);
+  }
+
+  {
+    const char *field_only = "X-TestHeader:";
+    TEST_CHECK(header_find(&hdrlist, field_only) == n);
+  }
+
+  {
+    const char *invalid_header = "Not a header";
+    TEST_CHECK(header_find(&hdrlist, invalid_header) == NULL);
+  }
+  mutt_list_free(&hdrlist);
+}

--- a/test/email/email_header_free.c
+++ b/test/email/email_header_free.c
@@ -1,0 +1,27 @@
+#define TEST_NO_MAIN
+#include "config.h"
+#include "acutest.h"
+#include "mutt/lib.h"
+#include "email/lib.h"
+
+void test_email_header_free(void)
+{
+  char *first_header = "X-First: 0";
+  char *second_header = "X-Second: 1";
+
+  struct ListHead hdrlist = STAILQ_HEAD_INITIALIZER(hdrlist);
+  struct ListNode *first = header_add(&hdrlist, first_header);
+  struct ListNode *second = header_add(&hdrlist, second_header);
+
+  {
+    header_free(&hdrlist, first);
+    TEST_CHECK(header_find(&hdrlist, first_header) == NULL); /* Removed expected header */
+    TEST_CHECK(header_find(&hdrlist, second_header) != NULL); /* Other headers untouched */
+  }
+
+  {
+    header_free(&hdrlist, second);
+    TEST_CHECK(header_find(&hdrlist, second_header) == NULL);
+    TEST_CHECK(STAILQ_FIRST(&hdrlist) == NULL); /* List now empty */
+  }
+}

--- a/test/email/email_header_set.c
+++ b/test/email/email_header_set.c
@@ -1,0 +1,30 @@
+#define TEST_NO_MAIN
+#include "config.h"
+#include "acutest.h"
+#include <string.h>
+#include "mutt/lib.h"
+#include "email/lib.h"
+
+void test_email_header_set(void)
+{
+  // struct ListNode *header_set(struct ListHead *hdrlist, const struct Buffer *buf)
+  const char *starting_value = "X-TestHeader: 0.57";
+  const char *updated_value = "X-TestHeader: 6.28";
+
+  struct ListHead hdrlist = STAILQ_HEAD_INITIALIZER(hdrlist);
+
+  {
+    /* Set value for first time */
+    struct ListNode *got = header_set(&hdrlist, starting_value);
+    TEST_CHECK(strcmp(got->data, starting_value) == 0); /* value set */
+    TEST_CHECK(got == STAILQ_FIRST(&hdrlist)); /* header was added to list */
+  }
+
+  {
+    /* Update value */
+    struct ListNode *got = header_set(&hdrlist, updated_value);
+    TEST_CHECK(strcmp(got->data, updated_value) == 0); /* value set*/
+    TEST_CHECK(got == STAILQ_FIRST(&hdrlist));         /* no new header added*/
+  }
+  mutt_list_free(&hdrlist);
+}

--- a/test/email/email_header_update.c
+++ b/test/email/email_header_update.c
@@ -1,0 +1,23 @@
+#define TEST_NO_MAIN
+#include "config.h"
+#include "acutest.h"
+#include "mutt/lib.h"
+#include "email/lib.h"
+
+void test_email_header_update(void)
+{
+  // struct ListNode *header_update(sturct ListNode *hdr, const struct Buffer *buf)
+  const char *existing_header = "X-Found: foo";
+  const char *new_value = "X-Found: 3.14";
+
+  struct ListNode *n = mutt_mem_calloc(1, sizeof(struct ListNode));
+  n->data = mutt_str_dup(existing_header);
+
+  {
+    struct ListNode *got = header_update(n, new_value);
+    TEST_CHECK(got == n);                          /* returns updated node */
+    TEST_CHECK(strcmp(got->data, new_value) == 0); /* node updated to new value */
+  }
+  FREE(&n->data);
+  FREE(&n);
+}

--- a/test/main.c
+++ b/test/main.c
@@ -188,6 +188,7 @@
   NEOMUTT_TEST_ITEM(test_email_header_add)                                     \
   NEOMUTT_TEST_ITEM(test_email_header_update)                                  \
   NEOMUTT_TEST_ITEM(test_email_header_set)                                     \
+  NEOMUTT_TEST_ITEM(test_email_header_free)                                    \
                                                                                \
   /* envelope */                                                               \
   NEOMUTT_TEST_ITEM(test_mutt_env_cmp_strict)                                  \

--- a/test/main.c
+++ b/test/main.c
@@ -184,6 +184,10 @@
   NEOMUTT_TEST_ITEM(test_emaillist_clear)                                      \
   NEOMUTT_TEST_ITEM(test_mutt_autocrypthdr_free)                               \
   NEOMUTT_TEST_ITEM(test_mutt_autocrypthdr_new)                                \
+  NEOMUTT_TEST_ITEM(test_email_header_find)                                    \
+  NEOMUTT_TEST_ITEM(test_email_header_add)                                     \
+  NEOMUTT_TEST_ITEM(test_email_header_update)                                  \
+  NEOMUTT_TEST_ITEM(test_email_header_set)                                     \
                                                                                \
   /* envelope */                                                               \
   NEOMUTT_TEST_ITEM(test_mutt_env_cmp_strict)                                  \


### PR DESCRIPTION
* **What does this PR do?**

Adds notifications for `my_hdr` changes (note, nothing added for `unmy_hdr`):

* Add utilities for navigating and updating headers to share logic with `my_hdr` parsing
* Refactor parse_my_hdr using new header utils
* Add notification type for headers
* Add header notifications for `parse_my_hdr`
*  Add header observer in compose screen
    Add an observer for NT_HEADER events that updates the current email's
    header and redraw the screen if my_hdr adds or updates a header.

* **What are the relevant issue numbers?**

#2622