### PR TITLE
Use the email's IMAP UID instead of an increasing number as index

### DIFF
--- a/imap/imap.c
+++ b/imap/imap.c
@@ -682,7 +682,6 @@ void imap_expunge_mailbox(struct Mailbox *m)
     }
     else
     {
-      e->index = i;
       /* NeoMutt has several places where it turns off e->active as a
        * hack.  For example to avoid FLAG updates, or to exclude from
        * imap_exec_msgset.

--- a/imap/message.c
+++ b/imap/message.c
@@ -762,7 +762,7 @@ static int read_headers_normal_eval_cache(struct ImapAccountData *adata,
         imap_msn_set(&mdata->msn, h.edata->msn - 1, e);
         mutt_hash_int_insert(mdata->uid_hash, h.edata->uid, e);
 
-        e->index = idx;
+        e->index = h.edata->uid;
         /* messages which have not been expunged are ACTIVE (borrowed from mh
          * folders) */
         e->active = true;
@@ -860,7 +860,7 @@ static int read_headers_qresync_eval_cache(struct ImapAccountData *adata, char *
       e->edata = edata;
       e->edata_free = imap_edata_free;
 
-      e->index = m->msg_count;
+      e->index = uid;
       e->active = true;
       e->changed = false;
       edata->read = e->read;
@@ -1145,7 +1145,7 @@ static int read_headers_fetch_new(struct Mailbox *m, unsigned int msn_begin,
         imap_msn_set(&mdata->msn, h.edata->msn - 1, e);
         mutt_hash_int_insert(mdata->uid_hash, h.edata->uid, e);
 
-        e->index = idx;
+        e->index = h.edata->uid;
         /* messages which have not been expunged are ACTIVE (borrowed from mh
          * folders) */
         e->active = true;


### PR DESCRIPTION
Index is used for [reverse-|last-]mailbox-order. Most backends assign an
increasing number to each Email as it's created parsing the mailbox. For
IMAP, we have the luxury of UIDs assigned for us by the server, see
https://tools.ietf.org/html/rfc3501#section-2.3.1.1

This saves us from reassigning ascending numbers on expunge, which was
the cause for the bug.

Fixes #2651