### PR TITLE
Use mutt_buffer_strcpy instead of mutt_str_copy

### DIFF
--- a/pattern/compile.c
+++ b/pattern/compile.c
@@ -1073,7 +1073,7 @@ struct PatternList *mutt_pattern_comp(const char *s, PatternCompFlags flags, str
 
   if (!s || !*s)
   {
-    mutt_str_copy(err->data, _("empty pattern"), err->dsize);
+    mutt_buffer_strcpy(err, _("empty pattern"));
     return NULL;
   }
 


### PR DESCRIPTION
I was instructed to change appearances of `mutt_str_copy()` which write into a buffer to `mutt_buffer_addstr` or `mutt_buffer_copy`.
Now, the only occurrence I could still find that wasn't writing into a char[] was the one here.  
Considering that addstr doesn't make too much sense and copy isn't applicable, I've used the strcpy variant, which seems to do what we want?
