### PR TITLE
Fix crash on failure to parse a URL

### DIFF
--- a/browser.c
+++ b/browser.c
@@ -1473,7 +1473,7 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
 
               /* special case "" needs no delimiter */
               struct Url *url = url_parse(ff->name);
-              if (url->path && (ff->delim != '\0'))
+              if (url && url->path && (ff->delim != '\0'))
               {
                 mutt_buffer_addch(&LastDir, ff->delim);
               }


### PR DESCRIPTION
~Do not try to parse the IMAP path as an URL, which it is not, as the
regex engine might or might not eat Unicode characets.  Instead, use a
simple string-based algorithm to decide whether we need to add a
separator to LastDir.~

The path will eventually be `url_parse`'d anyway, so just check for a failure and avoid crashing.

Fixes #2666

P.S. this is not the highest level of confidency I've ever had, i.e., things I am not foreseeing might break.