### PR TITLE
Fix <sidebar-{next,prev}-new>

### DIFF
--- a/sidebar/functions.c
+++ b/sidebar/functions.c
@@ -72,7 +72,7 @@ static struct SbEntry **next_new(struct SidebarWindowData *wdata, size_t begin, 
   struct SbEntry **sbep = NULL;
   ARRAY_FOREACH_FROM_TO(sbep, &wdata->entries, begin, end)
   {
-    if ((*sbep)->mailbox->has_new && (*sbep)->mailbox->msg_unread != 0)
+    if ((*sbep)->mailbox->has_new || (*sbep)->mailbox->msg_unread != 0)
       return sbep;
   }
   return NULL;
@@ -143,7 +143,7 @@ static struct SbEntry **prev_new(struct SidebarWindowData *wdata, size_t begin, 
   struct SbEntry **sbep = NULL, **prev = NULL;
   ARRAY_FOREACH_FROM_TO(sbep, &wdata->entries, begin, end)
   {
-    if ((*sbep)->mailbox->has_new && (*sbep)->mailbox->msg_unread != 0)
+    if ((*sbep)->mailbox->has_new || (*sbep)->mailbox->msg_unread != 0)
       prev = sbep;
   }
 


### PR DESCRIPTION
Commit 7e743a9fe63bea20d20070e34c86837083790005 "Convert Sidebar entries to ARRAY" incorrectly inverted a `do {} while(!has_new && msg_unread == 0)` into `if(has_new && msg_unread != 0)`, whereas the correct De Morgan is `if(has_new || msg_unread != 0)`

* **What does this PR do?**

Fix a regression against 20200821

* **What are the relevant issue numbers?**

Closes #2670 