### PR TITLE
fix(entire-thread): query for current email

### DIFF
--- a/index.c
+++ b/index.c
@@ -2156,7 +2156,7 @@ int mutt_index_menu(struct MuttWindow *dlg)
         }
         oldcount = Context->mailbox->msg_count;
         struct Email *e_oldcur = mutt_get_virt_email(Context->mailbox, menu->current);
-        if (nm_read_entire_thread(Context->mailbox, cur.e) < 0)
+        if (nm_read_entire_thread(Context->mailbox, e_oldcur) < 0)
         {
           mutt_message(_("Failed to read thread, aborting"));
           break;


### PR DESCRIPTION
Please see commit e15cbe5 for context on how 'entire-thread' functions
internally for non-notmuch mailboxes.

This commit fixes a regression in 467c06c where the current email in
the second mailbox isn't passed to 'nm_read_entire_thread()'. We have to
use the 'mutt_get_virt_email()' call to get the current email.

Without this patch, users have to execute 'entire-thread' twice. Once to
get into a notmuch mailbox with a single email then again for the entire
thread.

* **What are the relevant issue numbers?**

Partially addresses #2597