### PR TITLE
build: improve ASAN flags

### DIFF
--- a/auto.def
+++ b/auto.def
@@ -1214,7 +1214,7 @@ if {[get-define want-asan]} {
     user-error "Unable to compile with -fsanitize=address"
   }
   msg-result "yes"
-  define-append CFLAGS -fsanitize=address
+  define-append CFLAGS -fsanitize=address -O0 -fno-omit-frame-pointer -fno-common
   define-append LDFLAGS -fsanitize=address
 }
 


### PR DESCRIPTION
Change the build flags:

- Replace `-O2` with `-O0` (turn off optimisations)
- Add `-fno-omit-frame-pointer -fno-common`
  as suggested here, https://github.com/google/sanitizers/wiki/AddressSanitizerFlags