### PR TITLE
Move mx_check_empty into mx_ops

### DIFF
--- a/compmbox/compress.c
+++ b/compmbox/compress.c
@@ -953,5 +953,6 @@ struct MxOps MxCompOps = {
   .path_canon       = comp_path_canon,
   .path_pretty      = comp_path_pretty,
   .path_parent      = comp_path_parent,
+  .path_is_empty    = NULL,
 };
 // clang-format on

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -2437,6 +2437,19 @@ static int imap_path_parent(char *buf, size_t buflen)
   return 0;
 }
 
+/**
+ * imap_path_is_empty - Is the mailbox empty - Implements MxOps::path_is_empty()
+ */
+static int imap_path_is_empty(const char *path)
+{
+  int rc = imap_path_status(path, false);
+  if (rc < 0)
+    return -1;
+  if (rc == 0)
+    return 1;
+  return 0;
+}
+
 // clang-format off
 /**
  * MxImapOps - IMAP Mailbox - Implements ::MxOps
@@ -2465,5 +2478,6 @@ struct MxOps MxImapOps = {
   .path_canon       = imap_path_canon,
   .path_pretty      = imap_path_pretty,
   .path_parent      = imap_path_parent,
+  .path_is_empty    = imap_path_is_empty,
 };
 // clang-format on

--- a/maildir/maildir.c
+++ b/maildir/maildir.c
@@ -711,5 +711,6 @@ struct MxOps MxMaildirOps = {
   .path_canon       = maildir_path_canon,
   .path_pretty      = maildir_path_pretty,
   .path_parent      = maildir_path_parent,
+  .path_is_empty    = maildir_check_empty,
 };
 // clang-format on

--- a/maildir/mh.c
+++ b/maildir/mh.c
@@ -815,5 +815,6 @@ struct MxOps MxMhOps = {
   .path_canon       = maildir_path_canon,
   .path_pretty      = maildir_path_pretty,
   .path_parent      = maildir_path_parent,
+  .path_is_empty    = mh_check_empty,
 };
 // clang-format on

--- a/main.c
+++ b/main.c
@@ -1198,7 +1198,7 @@ int main(int argc, char *argv[], char *envp[])
     if (flags & MUTT_CLI_IGNORE)
     {
       /* check to see if there are any messages in the folder */
-      switch (mx_check_empty(mutt_b2s(&folder)))
+      switch (mx_path_is_empty(mutt_b2s(&folder)))
       {
         case -1:
           mutt_perror(mutt_b2s(&folder));

--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -1721,6 +1721,14 @@ static int mbox_path_parent(char *buf, size_t buflen)
 }
 
 /**
+ * mbox_path_is_empty - Is the mailbox empty - Implements MxOps::path_is_empty()
+ */
+static int mbox_path_is_empty(const char *path)
+{
+  return mutt_file_check_empty(path);
+}
+
+/**
  * mmdf_msg_commit - Save changes to an email - Implements MxOps::msg_commit()
  */
 static int mmdf_msg_commit(struct Mailbox *m, struct Message *msg)
@@ -1827,6 +1835,7 @@ struct MxOps MxMboxOps = {
   .path_canon       = mbox_path_canon,
   .path_pretty      = mbox_path_pretty,
   .path_parent      = mbox_path_parent,
+  .path_is_empty    = mbox_path_is_empty,
 };
 
 /**
@@ -1856,5 +1865,6 @@ struct MxOps MxMmdfOps = {
   .path_canon       = mbox_path_canon,
   .path_pretty      = mbox_path_pretty,
   .path_parent      = mbox_path_parent,
+  .path_is_empty    = mbox_path_is_empty,
 };
 // clang-format on

--- a/mx.h
+++ b/mx.h
@@ -359,6 +359,18 @@ struct MxOps
    * - @a buf is not NULL
    */
   int (*path_parent)     (char *buf, size_t buflen);
+
+  /**
+   * path_is_empty - Is the Mailbox empty?
+   * @param path Mailbox to check
+   * @retval 1 Mailbox is empty
+   * @retval 0 Mailbox contains mail
+   * @retval -1 Error
+   *
+   * **Contract**
+   * - @a path is not NULL and not empty
+   */
+  int (*path_is_empty)     (const char *path);
 };
 
 /* Wrappers for the Mailbox API, see MxOps */
@@ -392,7 +404,7 @@ int             mx_ac_remove   (struct Mailbox *m);
 
 int                 mx_access           (const char *path, int flags);
 void                mx_alloc_memory     (struct Mailbox *m);
-int                 mx_check_empty      (const char *path);
+int                 mx_path_is_empty    (const char *path);
 void                mx_fastclose_mailbox(struct Mailbox *m);
 const struct MxOps *mx_get_ops          (enum MailboxType type);
 bool                mx_tags_is_supported(struct Mailbox *m);

--- a/notmuch/notmuch.c
+++ b/notmuch/notmuch.c
@@ -2652,5 +2652,6 @@ struct MxOps MxNotmuchOps = {
   .path_canon       = nm_path_canon,
   .path_pretty      = nm_path_pretty,
   .path_parent      = nm_path_parent,
+  .path_is_empty    = NULL,
 };
 // clang-format on

--- a/pop/pop.c
+++ b/pop/pop.c
@@ -1266,5 +1266,6 @@ struct MxOps MxPopOps = {
   .path_canon       = pop_path_canon,
   .path_pretty      = pop_path_pretty,
   .path_parent      = pop_path_parent,
+  .path_is_empty    = NULL,
 };
 // clang-format on


### PR DESCRIPTION
Move `mx_check_empty()` into the mx_ops and rename to `mx_path_is_empty`.
The actual business logic is moved to the backends.
