### PR TITLE
feat(notmuch): show originating folder in index

### DIFF
--- a/hdrline.c
+++ b/hdrline.c
@@ -56,6 +56,9 @@
 #include "mutt_thread.h"
 #include "muttlib.h"
 #include "sort.h"
+#ifdef USE_NOTMUCH
+#include "notmuch/lib.h"
+#endif
 
 /* These Config Variables are only used in hdrline.c */
 struct MbTable *C_CryptChars; ///< Config: User-configurable crypto flags: signed, encrypted etc.
@@ -540,6 +543,15 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
       if (m)
       {
         p = strrchr(mailbox_path(m), '/');
+#ifdef USE_NOTMUCH
+        if (m->type == MUTT_NOTMUCH)
+        {
+          char *rel_path = nm_email_get_folder_rel_db(m, e);
+          if (rel_path)
+            p = rel_path;
+        }
+#endif
+
         if (p)
           mutt_str_copy(buf, p + 1, buflen);
         else

--- a/notmuch/lib.h
+++ b/notmuch/lib.h
@@ -58,6 +58,7 @@ void  nm_db_debug_check          (struct Mailbox *m);
 void  nm_db_longrun_done         (struct Mailbox *m);
 void  nm_db_longrun_init         (struct Mailbox *m, bool writable);
 char *nm_email_get_folder        (struct Email *e);
+char *nm_email_get_folder_rel_db (struct Mailbox *m, struct Email *e);
 int   nm_get_all_tags            (struct Mailbox *m, char **tag_list, int *tag_count);
 bool  nm_message_is_still_queried(struct Mailbox *m, struct Email *e);
 void  nm_parse_type_from_query   (struct NmMboxData *mdata, char *buf);

--- a/notmuch/notmuch.c
+++ b/notmuch/notmuch.c
@@ -1676,6 +1676,29 @@ char *nm_email_get_folder(struct Email *e)
 }
 
 /**
+ * nm_email_get_folder_rel_db - Get the folder for a Email from the same level as the notmuch database
+ * @param m Mailbox containing Email
+ * @param e Email
+ * @retval ptr  Folder containing email from the same level as the notmuch db
+ * @retval NULL Error
+ *
+ * Instead of returning a path like /var/mail/account/Inbox, this returns
+ * account/Inbox. If wanting the full path, use nm_email_get_folder().
+ */
+char *nm_email_get_folder_rel_db(struct Mailbox *m, struct Email *e)
+{
+  char *full_folder = nm_email_get_folder(e);
+  if (!full_folder)
+    return NULL;
+
+  const char *db_path = nm_db_get_filename(m);
+  if (!db_path)
+    return NULL;
+
+  return full_folder + strlen(db_path);
+}
+
+/**
  * nm_read_entire_thread - Get the entire thread of an email
  * @param m Mailbox
  * @param e   Email


### PR DESCRIPTION
Changes the behavior of '%b' in 'index_format' to display the email's
folder instead of the notmuch query if it exists. In a notmuch mailbox,
the current behavior of index_format's %b' expando displays the query
portion of a notmuch mailbox declaration.

The reference documentation for 'index_format' says '%b' shows "Filename
of the original message folder (think mailbox)". By my interpretation,
displaying the notmuch query is incorrect as it _is not_ the original
message folder. The underlying maildir folder _is_ the original message
folder. Therefore it should be shown instead.

[0] https://neomutt.org/guide/reference.html#3-169-%C2%A0index_format

* **Some decision considerations**

1. This brings the `%b` behavior in line with other local mailboxes; however, it only displays the last part of the folder. So if there's emails from `email1@email.com/INBOX` and `email2@email.com/INBOX` then it will only display `INBOX`. Is this something we want to changes? How far back do we go?


* **What are the relevant issue numbers?**

Closes #1849 
