### PR TITLE
Change postpone mode to write Date header too

### DIFF
--- a/send/header.c
+++ b/send/header.c
@@ -576,7 +576,8 @@ int mutt_rfc822_write_header(FILE *fp, struct Envelope *env, struct Body *attach
 {
   char buf[1024];
 
-  if (((mode == MUTT_WRITE_HEADER_NORMAL) || (mode == MUTT_WRITE_HEADER_FCC)) && !privacy)
+  if (((mode == MUTT_WRITE_HEADER_NORMAL) || (mode == MUTT_WRITE_HEADER_FCC) ||
+      (mode == MUTT_WRITE_HEADER_POSTPONE)) && !privacy)
   {
     struct Buffer *date = mutt_buffer_pool_get();
     mutt_date_make_date(date);


### PR DESCRIPTION
This will ensure that postponed mails are written with a Date header.
rfc5322 says the Date field must be there for an email to be valid.