### PR TITLE
Fix sidebar indentation issue for multiple accounts configuration

### DIFF
--- a/sidebar/window.c
+++ b/sidebar/window.c
@@ -693,7 +693,7 @@ int sb_recalc(struct MuttWindow *win)
     const char *last_part = abbr;
     entry->depth = calc_path_depth(abbr, C_SidebarDelimChars, &last_part);
 
-    const bool short_path_is_abbr = (short_path == abbr);
+    const bool short_path_is_abbr = (short_path != path);
     if (C_SidebarShortPath)
     {
       short_path = last_part;
@@ -701,7 +701,7 @@ int sb_recalc(struct MuttWindow *win)
 
     // Don't indent if we were unable to create an abbreviation.
     // Otherwise, the full path will be indent, and it looks unusual.
-    if (C_SidebarFolderIndent && short_path_is_abbr)
+    if (C_SidebarFolderIndent && !short_path_is_abbr)
     {
       if (C_SidebarComponentDepth > 0)
         entry->depth -= C_SidebarComponentDepth;


### PR DESCRIPTION
After v.20200806 sidebar indentation was broken for all mailboxes names
which are not relative to the path set by the `folder` parameter.

Only successfully abbreviated mailboxes names were indented correctly.
Here is how the sidebar was displayed in the configuration with multiple
accounts:

```
[=-account1-=]     <<------ `folder` parameter is pointing to this account
INBOX
  Newsletters
Sent
Drafts
          [=-account2-=]    <<----- other mailboxes are all extra indented
          INBOX                     to the depth value being calculated
            Newsletters             from the absolute path of the
          Sent                      mailbox, but not in relation to the
          Drafts                    base path of the account
          [=-account3-=]
          INBOX
            Newsletters
            ...
```

There is `sidebar_component_depth` parameter which decreases the depth
of the actual path of all mailboxes, so that all those common path parts
'/home/Mail/xxxxxxxxx/' could be omitted when calculating the
indentation needed, this worked like so:

```
  if (C_SidebarComponentDepth > 0)
    entry->depth -= C_SidebarComponentDepth;
```

But the problem was that, this depth correction was excessively applied
to the abbreviated mailboxes to which the `folder` parameter was
pointing, which is not needed, because all the depth had been removed by
`abbrev_folder` already.

```
[=-account1-=]     <<------ `folder` parameter is pointing to this account
INBOX                       { This line should be indented, but because
Newsletters    <<---------- { of decrease of depth set by
Sent                        { `sidebar_component_depth` all mailboxes
Drafts                      { are de-indented
[=-account2-=]
INBOX
  Newsletters      <<----- other mailboxes are indented correctly
Sent
Drafts
[=-account3-=]
INBOX
  Newsletters
...
```

So, it looks like, instead of
    ```
    if (C_SidebarFolderIndent && short_path_is_abbr)
      if (C_SidebarComponentDepth > 0)
        entry->depth -= C_SidebarComponentDepth;
    ```
it should do
    ```
    if (C_SidebarFolderIndent && !short_path_is_abbr)
      ...
    ```

Also, in this block:
```
    const char *abbr = abbrev_folder(path, C_Folder, m->type);
    ...
    const char *short_path = abbr ? abbr : path;
    ...
    const bool short_path_is_abbr = (short_path != path);
```
it looks like `abbr` is never `false`, because `abbrev_folder` always returns a string, either abbreviation or full path, so this ternary ? operator always returns `abbr` value. This needs a modification.

So, after those corrections, with `sidebar_component_depth` applied accordingly to the mailboxes
common path depth, the result looks like this:

```
[=-account1-=]     <<------ `folder` parameter is pointing to this account
INBOX
  Newsletters
Sent
Drafts
[=-account2-=]     <<----- other mailboxes are all extra indented
INBOX
  Newsletters
Sent
Drafts
[=-account3-=]
INBOX
  Newsletters
...
```
