### PR TITLE
crash: alias_file is a path, not a string

### DIFF
--- a/alias/alias.c
+++ b/alias/alias.c
@@ -482,7 +482,7 @@ retry_name:
   alias_reverse_add(alias);
   TAILQ_INSERT_TAIL(&Aliases, alias, entries);
 
-  const char *alias_file = cs_subset_string(sub, "alias_file");
+  const char *alias_file = cs_subset_path(sub, "alias_file");
   mutt_str_copy(buf, NONULL(alias_file), sizeof(buf));
 
   if (mutt_get_field(_("Save to file: "), buf, sizeof(buf), MUTT_FILE | MUTT_CLEAR) != 0)


### PR DESCRIPTION
* **What does this PR do?**
Fix a crash when trying to access the config variable `alias_file` as a string instead of as a path.

This was introduced in 6f79d959b2d2ca88898ab0c24e4caa70af56967c.