### PR TITLE
fix(entire-thread): stop crash on collapsed thread

### DIFF
--- a/index.c
+++ b/index.c
@@ -2175,7 +2175,7 @@ int mutt_index_menu(struct MuttWindow *dlg)
 
           if (e_oldcur->collapsed || Context->collapsed)
           {
-            menu->current = mutt_uncollapse_thread(cur.e);
+            menu->current = mutt_uncollapse_thread(e_oldcur);
             mutt_set_vnum(Context->mailbox);
           }
         }


### PR DESCRIPTION
Replace 'e.cur' with 'e_oldcur' similar to commit 19eb4cbd6. Since
19eb4cbd6 established 'e.cur' as "stale" in the second mailbox, it's
probable that it'll cause an issue when calling
'mutt_uncollapse_thread()'.

Fixes #2736