### PR TITLE
Fix detection of mbox files with new mail

### DIFF
--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -1801,8 +1801,9 @@ static int mbox_mbox_check_stats(struct Mailbox *m, int flags)
     mx_mbox_close(&ctx);
     m->peekonly = old_peek;
   }
-  if (m->msg_new == 0)
-    m->has_new = false;
+
+  if (m->msg_new == 0 && m->has_new)
+    return 1;
 
   return m->msg_new;
 }


### PR DESCRIPTION
**What does this PR do?**

Fixes the detection of mbox files with new mail.

mbox_mbox_check_stats() is supposed to return the number of new messages, but if flags = 0 we only look at mtime and atime values without actually parsing the mbox file, so we don't know how many new messages there are.  We just know there are _some_, so let's return 1 and hope for the best.

**Screenshots (if relevant)**

![Ekrano nuotrauka iš 2020-12-01 16-25-47](https://user-images.githubusercontent.com/159967/100752974-e2caab80-33f1-11eb-80cd-ac92f40fa0e6.png)

* **Does this PR meet the acceptance criteria?** (This is just a reminder for you,
  this section can be removed if you fulfill it.)

   - Documentation created/updated (you have to edit
     [doc/manual.xml.head](https://www.github.com/neomutt/neomutt/blob/master/doc/manual.xml.head)
     for that): pretty sure bugfixes are not mentioned in the manual

   - All builds and tests are passing: hopefully?  I ran `make test` and it was happy

   - Added [doxygen code documentation](https://neomutt.org/dev/doxygen)
     [syntax](http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html): no new functions or signature changes here

   - Code follows the [style guide](https://neomutt.org/dev/coding-style): I hope so!  I counted the number of spaces in the indentation very carefully.

* **What are the relevant issue numbers?**

Closes #2740.
