### PR TITLE
Fix attaching multiple files by tagging

### DIFF
--- a/compose/compose.c
+++ b/compose/compose.c
@@ -2002,12 +2002,8 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur,
         mutt_buffer_reset(&fname);
         if ((mutt_buffer_enter_fname_full(prompt, &fname, false, true, &files,
                                           &numfiles, MUTT_SEL_MULTI) == -1) ||
-            mutt_buffer_is_empty(&fname))
+            (mutt_buffer_is_empty(&fname) && numfiles == 0))
         {
-          for (int i = 0; i < numfiles; i++)
-            FREE(&files[i]);
-
-          FREE(&files);
           break;
         }
 
@@ -2037,8 +2033,8 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur,
           }
           FREE(&files[i]);
         }
-
         FREE(&files);
+
         if (!error)
           mutt_clear_error();
 


### PR DESCRIPTION
* **What does this PR do?**

This fixes the functionality to attach multiple files by tagging. I can't figure when this was broken.

The `mutt_buffer_enter_fname_full` API can be used in single- or multi-file mode, controlled by the `MUTT_SEL_MULTI` flag. If a single file is selected (either because the API is called in single-file mode or because tagging wasn't used), the API returns the selected file in the `fname` parameter. If multiple files are selected (multi-file mode and tagged files), the API returns the list of files and its length in the `files` and `numfiles` parameters.

Here, we were just checking for `fname`, thus disregarding the possibility that the user had selected multiple files by tagging.