### PR TITLE
Always recreate a mailbox after folder-hook

### DIFF
--- a/index.c
+++ b/index.c
@@ -741,11 +741,10 @@ static void change_folder_mailbox(struct Menu *menu, struct Mailbox *m, int *old
      * of the function. */
     notify_observer_remove(m->notify, mailbox_index_observer, &m);
   }
-  else
-  {
-    // Recreate the Mailbox (probably because a hook has done `unmailboxes *`)
-    m = mx_path_resolve(dup_path);
-  }
+
+  // Recreate the Mailbox as the folder-hook might have invoked `mailboxes`
+  // and/or `unmailboxes`.
+  m = mx_path_resolve(dup_path);
   FREE(&dup_path);
   FREE(&dup_name);
 


### PR DESCRIPTION
A folder-hook might have various effects on the mailboxes.

1. opening of an existing mailbox: `unmailboxes ...` might make it
   invalid (the previous code was guarding against this case)
2. opening of a new mailbox: `mailboxes ...` might create and link to an
   account the same mailbox we're trying to open (the new code guards
   against this case too)
3. both of the above, which resulted in a crash in the sidebar

Fixes #2743
