### PR TITLE
Fix group-chat-reply

### DIFF
--- a/send/send.c
+++ b/send/send.c
@@ -833,7 +833,7 @@ int mutt_fetch_recips(struct Envelope *out, struct Envelope *in,
       if (flags & SEND_GROUP_REPLY)
         mutt_addrlist_copy(&out->cc, &in->to, true);
       else
-        mutt_addrlist_copy(&out->to, &in->cc, true);
+        mutt_addrlist_copy(&out->to, &in->to, true);
       mutt_addrlist_copy(&out->cc, &in->cc, true);
     }
   }


### PR DESCRIPTION
The bug was introduced in this chunk of 999e51eb43ec028fcd31a3fe8b3f9587037c898d

```diff
-      mutt_addr_append(&out->to, in->to, true);
-      mutt_addr_append(&out->cc, in->cc, true);
+      mutt_addresslist_copy(&out->to, &in->cc, true);
+      mutt_addresslist_copy(&out->cc, &in->cc, true);
```

Fixes #2745

