### PR TITLE
Restore correct `sort_re` documentation

### DIFF
--- a/docs/config.c
+++ b/docs/config.c
@@ -4699,15 +4699,14 @@
 { "sort_re", DT_BOOL, true },
 /*
 ** .pp
-** This variable is only useful when sorting by mailboxes in sidebar. By default,
-** entries are unsorted.  Valid values:
-** .il
-** .dd count (all message count)
-** .dd desc  (virtual mailbox description)
-** .dd new (new message count)
-** .dd path
-** .dd unsorted
-** .ie
+** This variable is only useful when sorting by threads with
+** $$strict_threads \fIunset\fP.  In that case, it changes the heuristic
+** mutt uses to thread messages by subject.  With $$sort_re \fIset\fP, mutt will
+** only attach a message as the child of another message by subject if
+** the subject of the child message starts with a substring matching the
+** setting of $$reply_regexp.  With $$sort_re \fIunset\fP, mutt will attach
+** the message whether or not this is the case, as long as the
+** non-$$reply_regexp parts of both messages are identical.
 */
 
 { "spam_separator", DT_STRING, "," },


### PR DESCRIPTION
The documentation was bogus'd in 8ffa473227cd121a88aeb7512569dc651a361992.

Fixes #2721
