### PR TITLE
Rename API ac_find into ac_owns_path

### DIFF
--- a/compmbox/compress.c
+++ b/compmbox/compress.c
@@ -411,11 +411,11 @@ int mutt_comp_valid_command(const char *cmd)
 }
 
 /**
- * comp_ac_find - Find an Account that matches a Mailbox path - Implements MxOps::ac_find()
+ * comp_ac_owns_path - Check whether an Account owns a Mailbox path - Implements MxOps::ac_owns_path()
  */
-static struct Account *comp_ac_find(struct Account *a, const char *path)
+static bool comp_ac_owns_path(struct Account *a, const char *path)
 {
-  return NULL;
+  return false;
 }
 
 /**
@@ -933,7 +933,7 @@ struct MxOps MxCompOps = {
   .type            = MUTT_COMPRESSED,
   .name             = "compressed",
   .is_local         = true,
-  .ac_find          = comp_ac_find,
+  .ac_owns_path     = comp_ac_owns_path,
   .ac_add           = comp_ac_add,
   .mbox_open        = comp_mbox_open,
   .mbox_open_append = comp_mbox_open_append,

--- a/maildir/maildir.c
+++ b/maildir/maildir.c
@@ -1084,11 +1084,11 @@ int maildir_check_empty(const char *path)
 }
 
 /**
- * maildir_ac_find - Find an Account that matches a Mailbox path - Implements MxOps::ac_find()
+ * maildir_ac_owns_path - Check whether an Account own a Mailbox path - Implements MxOps::ac_owns_path()
  */
-struct Account *maildir_ac_find(struct Account *a, const char *path)
+bool maildir_ac_owns_path(struct Account *a, const char *path)
 {
-  return a;
+  return true;
 }
 
 /**
@@ -1633,7 +1633,7 @@ struct MxOps MxMaildirOps = {
   .type            = MUTT_MAILDIR,
   .name             = "maildir",
   .is_local         = true,
-  .ac_find          = maildir_ac_find,
+  .ac_owns_path     = maildir_ac_owns_path,
   .ac_add           = maildir_ac_add,
   .mbox_open        = maildir_mbox_open,
   .mbox_open_append = maildir_mbox_open_append,

--- a/maildir/mh.c
+++ b/maildir/mh.c
@@ -844,11 +844,11 @@ int mh_msg_save_hcache(struct Mailbox *m, struct Email *e)
 }
 
 /**
- * mh_ac_find - Find an Account that matches a Mailbox path - Implements MxOps::ac_find()
+ * mh_ac_owns_path - Check whether an Account own a Mailbox path - Implements MxOps::ac_owns_path()
  */
-struct Account *mh_ac_find(struct Account *a, const char *path)
+bool mh_ac_owns_path(struct Account *a, const char *path)
 {
-  return a;
+  return true;
 }
 
 /**
@@ -1246,7 +1246,7 @@ struct MxOps MxMhOps = {
   .type            = MUTT_MH,
   .name             = "mh",
   .is_local         = true,
-  .ac_find          = mh_ac_find,
+  .ac_owns_path     = mh_ac_owns_path,
   .ac_add           = mh_ac_add,
   .mbox_open        = mh_mbox_open,
   .mbox_open_append = mh_mbox_open_append,

--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -860,21 +860,18 @@ void mbox_reset_atime(struct Mailbox *m, struct stat *st)
 }
 
 /**
- * mbox_ac_find - Find an Account that matches a Mailbox path - Implements MxOps::ac_find()
+ * mbox_ac_owns_path - Check whether an Account owns a Mailbox path - Implements MxOps::ac_owns_path()
  */
-static struct Account *mbox_ac_find(struct Account *a, const char *path)
+static bool mbox_ac_owns_path(struct Account *a, const char *path)
 {
   if ((a->type != MUTT_MBOX) && (a->type != MUTT_MMDF))
-    return NULL;
+    return false;
 
   struct MailboxNode *np = STAILQ_FIRST(&a->mailboxes);
   if (!np)
-    return NULL;
+    return false;
 
-  if (!mutt_str_equal(mailbox_path(np->mailbox), path))
-    return NULL;
-
-  return a;
+  return mutt_str_equal(mailbox_path(np->mailbox), path);
 }
 
 /**
@@ -1816,7 +1813,7 @@ struct MxOps MxMboxOps = {
   .type            = MUTT_MBOX,
   .name             = "mbox",
   .is_local         = true,
-  .ac_find          = mbox_ac_find,
+  .ac_owns_path     = mbox_ac_owns_path,
   .ac_add           = mbox_ac_add,
   .mbox_open        = mbox_mbox_open,
   .mbox_open_append = mbox_mbox_open_append,
@@ -1846,7 +1843,7 @@ struct MxOps MxMmdfOps = {
   .type            = MUTT_MMDF,
   .name             = "mmdf",
   .is_local         = true,
-  .ac_find          = mbox_ac_find,
+  .ac_owns_path     = mbox_ac_owns_path,
   .ac_add           = mbox_ac_add,
   .mbox_open        = mbox_mbox_open,
   .mbox_open_append = mbox_mbox_open_append,

--- a/mx.c
+++ b/mx.c
@@ -1576,7 +1576,7 @@ struct Account *mx_ac_find(struct Mailbox *m)
     if (np->type != m->type)
       continue;
 
-    if (m->mx_ops->ac_find(np, m->realpath))
+    if (m->mx_ops->ac_owns_path(np, m->realpath))
       return np;
   }
 

--- a/mx.h
+++ b/mx.h
@@ -108,17 +108,17 @@ struct MxOps
   bool is_local;          ///< True, if Mailbox type has local files/dirs
 
   /**
-   * ac_find - Find an Account that matches a Mailbox path
-   * @param a    Account to search
-   * @param path Path to search for
-   * @retval  0 Success
-   * @retval -1 Error
+   * ac_owns_path - Check whether an Account owns a Mailbox path
+   * @param a    Account
+   * @param path Mailbox Path
+   * @retval true  Account handles path
+   * @retval false Account does not handle path
    *
    * **Contract**
    * - @a a    is not NULL
    * - @a path is not NULL
    */
-  struct Account *(*ac_find)  (struct Account *a, const char *path);
+  bool (*ac_owns_path) (struct Account *a, const char *path);
 
   /**
    * ac_add - Add a Mailbox to an Account

--- a/nntp/nntp.c
+++ b/nntp/nntp.c
@@ -2371,11 +2371,11 @@ int nntp_compare_order(const void *a, const void *b)
 }
 
 /**
- * nntp_ac_find - Find an Account that matches a Mailbox path - Implements MxOps::ac_find()
+ * nntp_ac_owns_path - Check whether an Account owns a Mailbox path - Implements MxOps::ac_owns_path()
  */
-static struct Account *nntp_ac_find(struct Account *a, const char *path)
+static bool nntp_ac_owns_path(struct Account *a, const char *path)
 {
-  return a;
+  return true;
 }
 
 /**
@@ -2835,7 +2835,7 @@ struct MxOps MxNntpOps = {
   .type            = MUTT_NNTP,
   .name             = "nntp",
   .is_local         = false,
-  .ac_find          = nntp_ac_find,
+  .ac_owns_path     = nntp_ac_owns_path,
   .ac_add           = nntp_ac_add,
   .mbox_open        = nntp_mbox_open,
   .mbox_open_append = NULL,

--- a/notmuch/notmuch.c
+++ b/notmuch/notmuch.c
@@ -2180,11 +2180,11 @@ done:
 }
 
 /**
- * nm_ac_find - Find an Account that matches a Mailbox path - Implements MxOps::ac_find()
+ * nm_ac_owns_path - Check whether an Account owns a Mailbox path - Implements MxOps::ac_owns_path()
  */
-static struct Account *nm_ac_find(struct Account *a, const char *path)
+static bool nm_ac_owns_path(struct Account *a, const char *path)
 {
-  return a;
+  return true;
 }
 
 /**
@@ -2656,7 +2656,7 @@ struct MxOps MxNotmuchOps = {
   .type            = MUTT_NOTMUCH,
   .name             = "notmuch",
   .is_local         = false,
-  .ac_find          = nm_ac_find,
+  .ac_owns_path     = nm_ac_owns_path,
   .ac_add           = nm_ac_add,
   .mbox_open        = nm_mbox_open,
   .mbox_open_append = NULL,

--- a/pop/pop.c
+++ b/pop/pop.c
@@ -736,24 +736,21 @@ fail:
 }
 
 /**
- * pop_ac_find - Find an Account that matches a Mailbox path - Implements MxOps::ac_find()
+ * pop_ac_owns_path - Check whether an Account owns a Mailbox path - Implements MxOps::ac_owns_path()
  */
-static struct Account *pop_ac_find(struct Account *a, const char *path)
+static bool pop_ac_owns_path(struct Account *a, const char *path)
 {
   struct Url *url = url_parse(path);
   if (!url)
-    return NULL;
+    return false;
 
   struct PopAccountData *adata = a->adata;
   struct ConnAccount *cac = &adata->conn->account;
 
-  if (!mutt_istr_equal(url->host, cac->host) || !mutt_istr_equal(url->user, cac->user))
-  {
-    a = NULL;
-  }
-
+  const bool ret = mutt_istr_equal(url->host, cac->host) &&
+                   mutt_istr_equal(url->user, cac->user);
   url_free(&url);
-  return a;
+  return ret;
 }
 
 /**
@@ -1246,7 +1243,7 @@ struct MxOps MxPopOps = {
   .type            = MUTT_POP,
   .name             = "pop",
   .is_local         = false,
-  .ac_find          = pop_ac_find,
+  .ac_owns_path     = pop_ac_owns_path,
   .ac_add           = pop_ac_add,
   .mbox_open        = pop_mbox_open,
   .mbox_open_append = NULL,


### PR DESCRIPTION
The `ac_find` API does not find anything, it either returns NULL on
failure or the first argument on success. It's actually a boolean
function, so let's name it accordingly.