### PR TITLE
Reset a Mailbox's gen value when it becomes visible

### DIFF
--- a/command_parse.c
+++ b/command_parse.c
@@ -959,6 +959,7 @@ enum CommandResult parse_mailboxes(struct Buffer *buf, struct Buffer *s,
         if (show)
         {
           m_old->flags = MB_NORMAL;
+          m_old->gen = mailbox_gen();
         }
 
         const bool rename = (data & MUTT_NAMED) && !mutt_str_equal(m_old->name, m->name);
@@ -1931,6 +1932,7 @@ static void do_unmailboxes(struct Mailbox *m)
   mutt_monitor_remove(m);
 #endif
   m->flags = MB_HIDDEN;
+  m->gen = -1;
   if (Context && (Context->mailbox == m))
   {
     struct EventMailbox em = { NULL };

--- a/core/mailbox.c
+++ b/core/mailbox.c
@@ -36,13 +36,20 @@
 #include "neomutt.h"
 
 /**
+ * mailbox_gen - Get the next generation number
+ */
+int mailbox_gen(void)
+{
+  static int gen = 0;
+  return gen++;
+}
+
+/**
  * mailbox_new - Create a new Mailbox
  * @retval ptr New Mailbox
  */
 struct Mailbox *mailbox_new(void)
 {
-  static int gen = 0;
-
   struct Mailbox *m = mutt_mem_calloc(1, sizeof(struct Mailbox));
 
   mutt_buffer_init(&m->pathbuf);
@@ -51,7 +58,7 @@ struct Mailbox *mailbox_new(void)
   m->email_max = 25;
   m->emails = mutt_mem_calloc(m->email_max, sizeof(struct Email *));
   m->v2r = mutt_mem_calloc(m->email_max, sizeof(int));
-  m->gen = gen++;
+  m->gen = mailbox_gen();
 
   return m;
 }

--- a/core/mailbox.h
+++ b/core/mailbox.h
@@ -189,6 +189,7 @@ void            mailbox_changed   (struct Mailbox *m, enum NotifyMailbox action)
 struct Mailbox *mailbox_find      (const char *path);
 struct Mailbox *mailbox_find_name (const char *name);
 void            mailbox_free      (struct Mailbox **ptr);
+int             mailbox_gen       (void);
 struct Mailbox *mailbox_new       (void);
 bool            mailbox_set_subset(struct Mailbox *m, struct ConfigSubset *sub);
 void            mailbox_size_add  (struct Mailbox *m, const struct Email *e);

--- a/sidebar/private.h
+++ b/sidebar/private.h
@@ -43,7 +43,6 @@ struct SbEntry
   struct Mailbox *mailbox; ///< Mailbox this represents
   bool is_hidden;          ///< Don't show, e.g. $sidebar_new_mail_only
   enum ColorId color;      ///< Colour to use
-  int seq_unsorted;        ///< Sequence number of unsorted Mailbox list
 };
 
 /**

--- a/sidebar/sidebar.c
+++ b/sidebar/sidebar.c
@@ -79,8 +79,6 @@ struct Mailbox *sb_get_highlight(struct MuttWindow *win)
  */
 void sb_add_mailbox(struct SidebarWindowData *wdata, struct Mailbox *m)
 {
-  static int seq_unsorted = 1;
-
   if (!m)
     return;
 
@@ -89,7 +87,6 @@ void sb_add_mailbox(struct SidebarWindowData *wdata, struct Mailbox *m)
 
   struct SbEntry *entry = mutt_mem_calloc(1, sizeof(struct SbEntry));
   entry->mailbox = m;
-  entry->seq_unsorted = seq_unsorted++;
 
   if (wdata->top_index < 0)
     wdata->top_index = ARRAY_SIZE(&wdata->entries);

--- a/sidebar/sort.c
+++ b/sidebar/sort.c
@@ -160,7 +160,7 @@ static int sb_sort_unsorted(const void *a, const void *b)
   const struct SbEntry *sbe2 = *(struct SbEntry const *const *) b;
 
   // This sort method isn't affected by the reverse flag
-  return (sbe1->seq_unsorted - sbe2->seq_unsorted);
+  return (sbe1->mailbox->gen - sbe2->mailbox->gen);
 }
 
 /**


### PR DESCRIPTION
This fixes the generation order of mailboxes by regenerating the value when a hidden mailbox becomes visible again. This happens when the currently open mailbox is `unmailboxes...`'d and `mailboxes...`'d again.

Fixes #2750

