### PR TITLE
clear the message window on SIGWINCH

### DIFF
--- a/index.c
+++ b/index.c
@@ -1367,6 +1367,7 @@ int mutt_index_menu(struct MuttWindow *dlg)
         /* force a real complete redraw.  clrtobot() doesn't seem to be able
          * to handle every case without this.  */
         clearok(stdscr, true);
+        mutt_window_clearline(MessageWindow, 0);
         continue;
       }
 

--- a/pager.c
+++ b/pager.c
@@ -2473,6 +2473,7 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
       SigWinch = 0;
       mutt_resize_screen();
       clearok(stdscr, true); /* force complete redraw */
+      mutt_window_clearline(MessageWindow, 0);
 
       if (flags & MUTT_PAGER_RETWINCH)
       {


### PR DESCRIPTION
When the terminal is resized (or the font-size is changed),
the screen must be redrawn.  This *used* to involve clearing the entire
screen.  Soon, it will be delegated to individual windows to refresh
themselves.

In the mean time, forcibly clear the MessageWindow.

Fixes: #2749

---

To repeat the bug:
In the Index, or Pager: reduce the height of the window by a line or two.
This will cause the Status Bar to be duplicated in the Message Window.

Rapidly reducing the height could sometimes cause the Index lines (or Pager contents) to be left in the Message Window.