### PR TITLE
MX API review

### DIFF
--- a/command_parse.c
+++ b/command_parse.c
@@ -974,7 +974,7 @@ enum CommandResult parse_mailboxes(struct Buffer *buf, struct Buffer *s,
       }
     }
 
-    if (mx_ac_add(a, m) < 0)
+    if (!mx_ac_add(a, m))
     {
       //error
       mailbox_free(&m);

--- a/compmbox/compress.c
+++ b/compmbox/compress.c
@@ -492,12 +492,12 @@ cmo_fail:
  * To append to a compressed mailbox we need an append-hook (or both open- and
  * close-hooks).
  */
-static int comp_mbox_open_append(struct Mailbox *m, OpenMailboxFlags flags)
+static bool comp_mbox_open_append(struct Mailbox *m, OpenMailboxFlags flags)
 {
   /* If this succeeds, we know there's an open-hook */
   struct CompressInfo *ci = set_compress_info(m);
   if (!ci)
-    return -1;
+    return false;
 
   /* To append we need an append-hook or a close-hook */
   if (!ci->cmd_append && !ci->cmd_close)
@@ -546,10 +546,10 @@ static int comp_mbox_open_append(struct Mailbox *m, OpenMailboxFlags flags)
     goto cmoa_fail2;
   }
 
-  if (ci->child_ops->mbox_open_append(m, flags) != 0)
+  if (!ci->child_ops->mbox_open_append(m, flags))
     goto cmoa_fail2;
 
-  return 0;
+  return true;
 
 cmoa_fail2:
   /* remove the partial uncompressed file */
@@ -558,7 +558,7 @@ cmoa_fail1:
   /* Free the compress_info to prevent close from trying to recompress */
   compress_info_free(m);
 
-  return -1;
+  return false;
 }
 
 /**

--- a/compmbox/compress.c
+++ b/compmbox/compress.c
@@ -725,16 +725,16 @@ static enum MxStatus comp_mbox_close(struct Mailbox *m)
 /**
  * comp_msg_open - Open an email message in a Mailbox - Implements MxOps::msg_open()
  */
-static int comp_msg_open(struct Mailbox *m, struct Message *msg, int msgno)
+static bool comp_msg_open(struct Mailbox *m, struct Message *msg, int msgno)
 {
   if (!m->compress_info)
-    return -1;
+    return false;
 
   struct CompressInfo *ci = m->compress_info;
 
   const struct MxOps *ops = ci->child_ops;
   if (!ops)
-    return -1;
+    return false;
 
   /* Delegate */
   return ops->msg_open(m, msg, msgno);
@@ -743,16 +743,16 @@ static int comp_msg_open(struct Mailbox *m, struct Message *msg, int msgno)
 /**
  * comp_msg_open_new - Open a new message in a Mailbox - Implements MxOps::msg_open_new()
  */
-static int comp_msg_open_new(struct Mailbox *m, struct Message *msg, const struct Email *e)
+static bool comp_msg_open_new(struct Mailbox *m, struct Message *msg, const struct Email *e)
 {
   if (!m->compress_info)
-    return -1;
+    return false;
 
   struct CompressInfo *ci = m->compress_info;
 
   const struct MxOps *ops = ci->child_ops;
   if (!ops)
-    return -1;
+    return false;
 
   /* Delegate */
   return ops->msg_open_new(m, msg, e);

--- a/compmbox/compress.c
+++ b/compmbox/compress.c
@@ -421,9 +421,9 @@ static bool comp_ac_owns_path(struct Account *a, const char *path)
 /**
  * comp_ac_add - Add a Mailbox to an Account - Implements MxOps::ac_add()
  */
-static int comp_ac_add(struct Account *a, struct Mailbox *m)
+static bool comp_ac_add(struct Account *a, struct Mailbox *m)
 {
-  return 0;
+  return true;
 }
 
 /**

--- a/compmbox/compress.c
+++ b/compmbox/compress.c
@@ -659,10 +659,10 @@ sync_cleanup:
  * If the mailbox has been changed then re-compress the tmp file.
  * Then delete the tmp file.
  */
-static int comp_mbox_close(struct Mailbox *m)
+static enum MxCheckReturns comp_mbox_close(struct Mailbox *m)
 {
   if (!m->compress_info)
-    return -1;
+    return MX_CHECK_ERROR;
 
   struct CompressInfo *ci = m->compress_info;
 
@@ -670,7 +670,7 @@ static int comp_mbox_close(struct Mailbox *m)
   if (!ops)
   {
     compress_info_free(m);
-    return -1;
+    return MX_CHECK_ERROR;
   }
 
   ops->mbox_close(m);
@@ -719,7 +719,7 @@ static int comp_mbox_close(struct Mailbox *m)
 
   compress_info_free(m);
 
-  return 0;
+  return MX_CHECK_NO_CHANGE;
 }
 
 /**

--- a/compmbox/compress.c
+++ b/compmbox/compress.c
@@ -434,13 +434,11 @@ static bool comp_ac_add(struct Account *a, struct Mailbox *m)
  * Then determine the type of the mailbox so we can delegate the handling of
  * messages.
  */
-static int comp_mbox_open(struct Mailbox *m)
+static enum MxOpenReturns comp_mbox_open(struct Mailbox *m)
 {
   struct CompressInfo *ci = set_compress_info(m);
   if (!ci)
-    return -1;
-
-  int rc;
+    return MX_OPEN_ERROR;
 
   /* If there's no close-hook, or the file isn't writable */
   if (!ci->cmd_close || (access(mailbox_path(m), W_OK) != 0))
@@ -456,7 +454,7 @@ static int comp_mbox_open(struct Mailbox *m)
     goto cmo_fail;
   }
 
-  rc = execute_command(m, ci->cmd_open, _("Decompressing %s"));
+  int rc = execute_command(m, ci->cmd_open, _("Decompressing %s"));
   if (rc == 0)
     goto cmo_fail;
 
@@ -483,7 +481,7 @@ cmo_fail:
   /* remove the partial uncompressed file */
   remove(mailbox_path(m));
   compress_info_free(m);
-  return -1;
+  return MX_OPEN_ERROR;
 }
 
 /**

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -1200,9 +1200,14 @@ static int imap_status(struct ImapAccountData *adata, struct ImapMboxData *mdata
 /**
  * imap_mbox_check_stats - Check the Mailbox statistics - Implements MxOps::mbox_check_stats()
  */
-static int imap_mbox_check_stats(struct Mailbox *m, uint8_t flags)
+static enum MxCheckStatsReturns imap_mbox_check_stats(struct Mailbox *m, uint8_t flags)
 {
-  return imap_mailbox_status(m, true);
+  const int new_msgs = imap_mailbox_status(m, true);
+  if (new_msgs == -1)
+    return MX_CHECK_STATS_ERROR;
+  if (new_msgs == 0)
+    return MX_CHECK_STATS_NO_CHANGE;
+  return MX_CHECK_STATS_NEW_MAIL;
 }
 
 /**

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -2189,9 +2189,9 @@ static enum MxStatus imap_mbox_close(struct Mailbox *m)
 /**
  * imap_msg_open_new - Open a new message in a Mailbox - Implements MxOps::msg_open_new()
  */
-static int imap_msg_open_new(struct Mailbox *m, struct Message *msg, const struct Email *e)
+static bool imap_msg_open_new(struct Mailbox *m, struct Message *msg, const struct Email *e)
 {
-  int rc = -1;
+  bool success = false;
 
   struct Buffer *tmp = mutt_buffer_pool_get();
   mutt_buffer_mktemp(tmp);
@@ -2204,11 +2204,11 @@ static int imap_msg_open_new(struct Mailbox *m, struct Message *msg, const struc
   }
 
   msg->path = mutt_buffer_strdup(tmp);
-  rc = 0;
+  success = true;
 
 cleanup:
   mutt_buffer_pool_release(&tmp);
-  return rc;
+  return success;
 }
 
 /**

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -1734,7 +1734,7 @@ static bool imap_ac_owns_path(struct Account *a, const char *path)
 /**
  * imap_ac_add - Add a Mailbox to an Account - Implements MxOps::ac_add()
  */
-static int imap_ac_add(struct Account *a, struct Mailbox *m)
+static bool imap_ac_add(struct Account *a, struct Mailbox *m)
 {
   struct ImapAccountData *adata = a->adata;
 
@@ -1744,14 +1744,14 @@ static int imap_ac_add(struct Account *a, struct Mailbox *m)
     char mailbox[PATH_MAX];
 
     if (imap_parse_path(mailbox_path(m), &cac, mailbox, sizeof(mailbox)) < 0)
-      return -1;
+      return false;
 
     adata = imap_adata_new(a);
     adata->conn = mutt_conn_new(&cac);
     if (!adata->conn)
     {
       imap_adata_free((void **) &adata);
-      return -1;
+      return false;
     }
 
     mutt_account_hook(m->realpath);
@@ -1759,7 +1759,7 @@ static int imap_ac_add(struct Account *a, struct Mailbox *m)
     if (imap_login(adata) < 0)
     {
       imap_adata_free((void **) &adata);
-      return -1;
+      return false;
     }
 
     a->adata = adata;
@@ -1781,7 +1781,7 @@ static int imap_ac_add(struct Account *a, struct Mailbox *m)
     m->mdata_free = imap_mdata_free;
     url_free(&url);
   }
-  return 0;
+  return true;
 }
 
 /**

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -1893,10 +1893,10 @@ int imap_login(struct ImapAccountData *adata)
 /**
  * imap_mbox_open - Open a mailbox - Implements MxOps::mbox_open()
  */
-static int imap_mbox_open(struct Mailbox *m)
+static enum MxOpenReturns imap_mbox_open(struct Mailbox *m)
 {
   if (!m->account || !m->mdata)
-    return -1;
+    return MX_OPEN_ERROR;
 
   char buf[PATH_MAX];
   int count = 0;
@@ -2084,12 +2084,12 @@ static int imap_mbox_open(struct Mailbox *m)
   }
 
   mutt_debug(LL_DEBUG2, "msg_count is %d\n", m->msg_count);
-  return 0;
+  return MX_OPEN_OK;
 
 fail:
   if (adata->state == IMAP_SELECTED)
     adata->state = IMAP_AUTHENTICATED;
-  return -1;
+  return MX_OPEN_ERROR;
 }
 
 /**

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -2147,14 +2147,14 @@ static enum MxCheckReturns imap_mbox_check(struct Mailbox *m)
 /**
  * imap_mbox_close - Close a Mailbox - Implements MxOps::mbox_close()
  */
-static int imap_mbox_close(struct Mailbox *m)
+static enum MxCheckReturns imap_mbox_close(struct Mailbox *m)
 {
   struct ImapAccountData *adata = imap_adata_get(m);
   struct ImapMboxData *mdata = imap_mdata_get(m);
 
   /* Check to see if the mailbox is actually open */
   if (!adata || !mdata)
-    return 0;
+    return MX_CHECK_NO_CHANGE;
 
   /* imap_mbox_open_append() borrows the struct ImapAccountData temporarily,
    * just for the connection.
@@ -2183,7 +2183,7 @@ static int imap_mbox_close(struct Mailbox *m)
     imap_mdata_cache_reset(m->mdata);
   }
 
-  return 0;
+  return MX_CHECK_NO_CHANGE;
 }
 
 /**

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -2095,10 +2095,10 @@ fail:
 /**
  * imap_mbox_open_append - Open a Mailbox for appending - Implements MxOps::mbox_open_append()
  */
-static int imap_mbox_open_append(struct Mailbox *m, OpenMailboxFlags flags)
+static bool imap_mbox_open_append(struct Mailbox *m, OpenMailboxFlags flags)
 {
   if (!m->account)
-    return -1;
+    return false;
 
   /* in APPEND mode, we appear to hijack an existing IMAP connection -
    * ctx is brand new and mostly empty */
@@ -2107,19 +2107,19 @@ static int imap_mbox_open_append(struct Mailbox *m, OpenMailboxFlags flags)
 
   int rc = imap_mailbox_status(m, false);
   if (rc >= 0)
-    return 0;
+    return true;
   if (rc == -1)
-    return -1;
+    return false;
 
   char buf[PATH_MAX + 64];
   snprintf(buf, sizeof(buf), _("Create %s?"), mdata->name);
   if (C_Confirmcreate && (mutt_yesorno(buf, MUTT_YES) != MUTT_YES))
-    return -1;
+    return false;
 
   if (imap_create_mailbox(adata, mdata->name) < 0)
-    return -1;
+    return false;
 
-  return 0;
+  return true;
 }
 
 /**

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -1200,14 +1200,14 @@ static int imap_status(struct ImapAccountData *adata, struct ImapMboxData *mdata
 /**
  * imap_mbox_check_stats - Check the Mailbox statistics - Implements MxOps::mbox_check_stats()
  */
-static enum MxCheckStatsReturns imap_mbox_check_stats(struct Mailbox *m, uint8_t flags)
+static enum MxCheckReturns imap_mbox_check_stats(struct Mailbox *m, uint8_t flags)
 {
   const int new_msgs = imap_mailbox_status(m, true);
   if (new_msgs == -1)
-    return MX_CHECK_STATS_ERROR;
+    return MX_CHECK_ERROR;
   if (new_msgs == 0)
-    return MX_CHECK_STATS_NO_CHANGE;
-  return MX_CHECK_STATS_NEW_MAIL;
+    return MX_CHECK_NO_CHANGE;
+  return MX_CHECK_NEW_MAIL;
 }
 
 /**

--- a/imap/message.c
+++ b/imap/message.c
@@ -1842,7 +1842,7 @@ char *imap_set_flags(struct Mailbox *m, struct Email *e, char *s, bool *server_c
 /**
  * imap_msg_open - Open an email message in a Mailbox - Implements MxOps::msg_open()
  */
-int imap_msg_open(struct Mailbox *m, struct Message *msg, int msgno)
+bool imap_msg_open(struct Mailbox *m, struct Message *msg, int msgno)
 {
   struct Envelope *newenv = NULL;
   char buf[1024];
@@ -1861,17 +1861,17 @@ int imap_msg_open(struct Mailbox *m, struct Message *msg, int msgno)
   struct ImapAccountData *adata = imap_adata_get(m);
 
   if (!adata || (adata->mailbox != m))
-    return -1;
+    return false;
 
   struct Email *e = m->emails[msgno];
   if (!e)
-    return -1;
+    return false;
 
   msg->fp = msg_cache_get(m, e);
   if (msg->fp)
   {
     if (imap_edata_get(e)->parsed)
-      return 0;
+      return true;
     goto parsemsg;
   }
 
@@ -1891,7 +1891,7 @@ int imap_msg_open(struct Mailbox *m, struct Message *msg, int msgno)
     mutt_buffer_pool_release(&path);
 
     if (!msg->fp)
-      return -1;
+      return false;
   }
 
   /* mark this header as currently inactive so the command handler won't
@@ -2029,13 +2029,13 @@ parsemsg:
     goto parsemsg;
   }
 
-  return 0;
+  return true;
 
 bail:
   e->active = true;
   mutt_file_fclose(&msg->fp);
   imap_cache_del(m, e);
-  return -1;
+  return false;
 }
 
 /**

--- a/imap/private.h
+++ b/imap/private.h
@@ -313,7 +313,7 @@ int imap_cache_del(struct Mailbox *m, struct Email *e);
 int imap_cache_clean(struct Mailbox *m);
 int imap_append_message(struct Mailbox *m, struct Message *msg);
 
-int imap_msg_open(struct Mailbox *m, struct Message *msg, int msgno);
+bool imap_msg_open(struct Mailbox *m, struct Message *msg, int msgno);
 int imap_msg_close(struct Mailbox *m, struct Message *msg);
 int imap_msg_commit(struct Mailbox *m, struct Message *msg);
 int imap_msg_save_hcache(struct Mailbox *m, struct Email *e);

--- a/index.c
+++ b/index.c
@@ -710,8 +710,8 @@ static void change_folder_mailbox(struct Menu *menu, struct Mailbox *m, int *old
       new_last_folder = mutt_str_dup(mailbox_path(m_ctx));
     *oldcount = m_ctx->msg_count;
 
-    int check = mx_mbox_close(&Context);
-    if (check != 0)
+    const enum MxCheckReturns check = mx_mbox_close(&Context);
+    if (check != MX_CHECK_NO_CHANGE)
     {
 #ifdef USE_INOTIFY
       if (monitor_remove_rc == 0)
@@ -1860,14 +1860,13 @@ int mutt_index_menu(struct MuttWindow *dlg)
 
         if (query_quadoption(C_Quit, _("Quit NeoMutt?")) == MUTT_YES)
         {
-          int check;
-
-          oldcount = ctx_mailbox(Context) ? Context->mailbox->msg_count : 0;
+          oldcount = (Context && Context->mailbox) ? Context->mailbox->msg_count : 0;
 
           mutt_startup_shutdown_hook(MUTT_SHUTDOWN_HOOK);
           notify_send(NeoMutt->notify, NT_GLOBAL, NT_GLOBAL_SHUTDOWN, NULL);
 
-          if (!Context || ((check = mx_mbox_close(&Context)) == 0))
+          enum MxCheckReturns check = MX_CHECK_NO_CHANGE;
+          if (!Context || ((check = mx_mbox_close(&Context)) == MX_CHECK_NO_CHANGE))
           {
             done = true;
           }
@@ -2018,8 +2017,8 @@ int mutt_index_menu(struct MuttWindow *dlg)
       case OP_MAIN_IMAP_LOGOUT_ALL:
         if (ctx_mailbox(Context) && (Context->mailbox->type == MUTT_IMAP))
         {
-          int check = mx_mbox_close(&Context);
-          if (check != 0)
+          const enum MxCheckReturns check = mx_mbox_close(&Context);
+          if (check != MX_CHECK_NO_CHANGE)
           {
             if ((check == MX_CHECK_NEW_MAIL) || (check == MX_CHECK_REOPENED))
             {

--- a/index.c
+++ b/index.c
@@ -447,10 +447,10 @@ static void resort_index(struct Context *ctx, struct Menu *menu)
 /**
  * update_index_threaded - Update the index (if threaded)
  * @param ctx      Mailbox
- * @param check    Flags, e.g. #MUTT_REOPENED
+ * @param check    Flags, e.g. #MX_CHECK_REOPENED
  * @param oldcount How many items are currently in the index
  */
-static void update_index_threaded(struct Context *ctx, int check, int oldcount)
+static void update_index_threaded(struct Context *ctx, enum MxCheckReturns check, int oldcount)
 {
   struct Email **save_new = NULL;
   const bool lmt = ctx_has_limit(ctx);
@@ -458,7 +458,8 @@ static void update_index_threaded(struct Context *ctx, int check, int oldcount)
   int num_new = MAX(0, ctx->mailbox->msg_count - oldcount);
 
   /* save the list of new messages */
-  if ((check != MUTT_REOPENED) && (oldcount > 0) && (lmt || C_UncollapseNew) && (num_new > 0))
+  if ((check != MX_CHECK_REOPENED) && (oldcount > 0) &&
+      (lmt || C_UncollapseNew) && (num_new > 0))
   {
     save_new = mutt_mem_malloc(num_new * sizeof(struct Email *));
     for (int i = oldcount; i < ctx->mailbox->msg_count; i++)
@@ -469,7 +470,7 @@ static void update_index_threaded(struct Context *ctx, int check, int oldcount)
    * require the threading information.
    *
    * If the mailbox was reopened, need to rethread from scratch. */
-  mutt_sort_headers(ctx->mailbox, ctx->threads, (check == MUTT_REOPENED), &ctx->vsize);
+  mutt_sort_headers(ctx->mailbox, ctx->threads, (check == MX_CHECK_REOPENED), &ctx->vsize);
 
   if (lmt)
   {
@@ -501,7 +502,7 @@ static void update_index_threaded(struct Context *ctx, int check, int oldcount)
   /* uncollapse threads with new mail */
   if (C_UncollapseNew)
   {
-    if (check == MUTT_REOPENED)
+    if (check == MX_CHECK_REOPENED)
     {
       ctx->collapsed = false;
       mutt_thread_collapse(ctx->threads, ctx->collapsed);
@@ -526,9 +527,9 @@ static void update_index_threaded(struct Context *ctx, int check, int oldcount)
 /**
  * update_index_unthreaded - Update the index (if unthreaded)
  * @param ctx      Mailbox
- * @param check    Flags, e.g. #MUTT_REOPENED
+ * @param check    Flags, e.g. #MX_CHECK_REOPENED
  */
-static void update_index_unthreaded(struct Context *ctx, int check)
+static void update_index_unthreaded(struct Context *ctx, enum MxCheckReturns check)
 {
   /* We are in a limited view. Check if the new message(s) satisfy
    * the limit criteria. If they do, set their virtual msgno so that
@@ -561,7 +562,7 @@ static void update_index_unthreaded(struct Context *ctx, int check)
   }
 
   /* if the mailbox was reopened, need to rethread from scratch */
-  mutt_sort_headers(ctx->mailbox, ctx->threads, (check == MUTT_REOPENED), &ctx->vsize);
+  mutt_sort_headers(ctx->mailbox, ctx->threads, (check == MX_CHECK_REOPENED), &ctx->vsize);
 }
 
 /**
@@ -600,11 +601,11 @@ static void set_current_email(struct CurrentEmail *cur, struct Email *e)
  * update_index - Update the index
  * @param menu       Current Menu
  * @param ctx        Mailbox
- * @param check      Flags, e.g. #MUTT_REOPENED
+ * @param check      Flags, e.g. #MX_CHECK_REOPENED
  * @param oldcount   How many items are currently in the index
  * @param cur        Remember our place in the index
  */
-static void update_index(struct Menu *menu, struct Context *ctx, int check,
+static void update_index(struct Menu *menu, struct Context *ctx, enum MxCheckReturns check,
                          int oldcount, const struct CurrentEmail *cur)
 {
   if (!menu || !ctx)
@@ -643,13 +644,13 @@ static void update_index(struct Menu *menu, struct Context *ctx, int check,
  * mutt_update_index - Update the index
  * @param menu      Current Menu
  * @param ctx       Mailbox
- * @param check     Flags, e.g. #MUTT_REOPENED
+ * @param check     Flags, e.g. #MX_CHECK_REOPENED
  * @param oldcount  How many items are currently in the index
  * @param cur_email Currently selected email
  *
  * @note cur_email cannot be NULL
  */
-void mutt_update_index(struct Menu *menu, struct Context *ctx, int check,
+void mutt_update_index(struct Menu *menu, struct Context *ctx, enum MxCheckReturns check,
                        int oldcount, const struct Email *cur_email)
 {
   struct CurrentEmail se = { .e = NULL, .sequence = cur_email->sequence };
@@ -716,7 +717,7 @@ static void change_folder_mailbox(struct Menu *menu, struct Mailbox *m, int *old
       if (monitor_remove_rc == 0)
         mutt_monitor_add(NULL);
 #endif
-      if ((check == MUTT_NEW_MAIL) || (check == MUTT_REOPENED))
+      if ((check == MX_CHECK_NEW_MAIL) || (check == MX_CHECK_REOPENED))
         update_index(menu, Context, check, *oldcount, cur);
 
       FREE(&new_last_folder);
@@ -1230,9 +1231,9 @@ int mutt_index_menu(struct MuttWindow *dlg)
       /* check for new mail in the mailbox.  If nonzero, then something has
        * changed about the file (either we got new mail or the file was
        * modified underneath us.) */
-      int check = mx_mbox_check(Context->mailbox);
+      enum MxCheckReturns check = mx_mbox_check(Context->mailbox);
 
-      if (check < 0)
+      if (check == MX_CHECK_ERROR)
       {
         if (mutt_buffer_is_empty(&Context->mailbox->pathbuf))
         {
@@ -1243,15 +1244,16 @@ int mutt_index_menu(struct MuttWindow *dlg)
 
         OptSearchInvalid = true;
       }
-      else if ((check == MUTT_NEW_MAIL) || (check == MUTT_REOPENED) || (check == MUTT_FLAGS))
+      else if ((check == MX_CHECK_NEW_MAIL) || (check == MX_CHECK_REOPENED) ||
+               (check == MX_CHECK_FLAGS))
       {
         /* notify the user of new mail */
-        if (check == MUTT_REOPENED)
+        if (check == MX_CHECK_REOPENED)
         {
           mutt_error(
               _("Mailbox was externally modified.  Flags may be wrong."));
         }
-        else if (check == MUTT_NEW_MAIL)
+        else if (check == MX_CHECK_NEW_MAIL)
         {
           for (size_t i = 0; i < Context->mailbox->msg_count; i++)
           {
@@ -1273,7 +1275,7 @@ int mutt_index_menu(struct MuttWindow *dlg)
             }
           }
         }
-        else if (check == MUTT_FLAGS)
+        else if (check == MX_CHECK_FLAGS)
         {
           mutt_message(_("Mailbox was externally modified"));
         }
@@ -1871,8 +1873,10 @@ int mutt_index_menu(struct MuttWindow *dlg)
           }
           else
           {
-            if ((check == MUTT_NEW_MAIL) || (check == MUTT_REOPENED))
+            if ((check == MX_CHECK_NEW_MAIL) || (check == MX_CHECK_REOPENED))
+            {
               update_index(menu, Context, check, oldcount, &cur);
+            }
 
             menu->redraw = REDRAW_FULL; /* new mail arrived? */
             OptSearchInvalid = true;
@@ -2017,8 +2021,10 @@ int mutt_index_menu(struct MuttWindow *dlg)
           int check = mx_mbox_close(&Context);
           if (check != 0)
           {
-            if ((check == MUTT_NEW_MAIL) || (check == MUTT_REOPENED))
+            if ((check == MX_CHECK_NEW_MAIL) || (check == MX_CHECK_REOPENED))
+            {
               update_index(menu, Context, check, oldcount, &cur);
+            }
             OptSearchInvalid = true;
             menu->redraw = REDRAW_FULL;
             break;
@@ -2058,8 +2064,8 @@ int mutt_index_menu(struct MuttWindow *dlg)
               e = mutt_get_virt_email(Context->mailbox, newidx);
           }
 
-          int check = mx_mbox_sync(Context->mailbox);
-          if (check == 0)
+          enum MxCheckReturns check = mx_mbox_sync(Context->mailbox);
+          if (check == MX_CHECK_NO_CHANGE)
           {
             if (e && (Context->mailbox->vcount != ovc))
             {
@@ -2075,8 +2081,10 @@ int mutt_index_menu(struct MuttWindow *dlg)
             }
             OptSearchInvalid = true;
           }
-          else if ((check == MUTT_NEW_MAIL) || (check == MUTT_REOPENED))
+          else if ((check == MX_CHECK_NEW_MAIL) || (check == MX_CHECK_REOPENED))
+          {
             update_index(menu, Context, check, oc, &cur);
+          }
 
           /* do a sanity check even if mx_mbox_sync failed.  */
 
@@ -2594,7 +2602,7 @@ int mutt_index_menu(struct MuttWindow *dlg)
         in_pager = true;
         menu->oldcurrent = menu->current;
         if (ctx_mailbox(Context))
-          update_index(menu, Context, MUTT_NEW_MAIL, Context->mailbox->msg_count, &cur);
+          update_index(menu, Context, MX_CHECK_NEW_MAIL, Context->mailbox->msg_count, &cur);
         continue;
       }
 

--- a/maildir/lib.h
+++ b/maildir/lib.h
@@ -61,7 +61,7 @@ FILE *        maildir_open_find_message(const char *folder, const char *msg, cha
 void          maildir_parse_flags      (struct Email *e, const char *path);
 struct Email *maildir_parse_message    (enum MailboxType type, const char *fname, bool is_old, struct Email *e);
 struct Email *maildir_parse_stream     (enum MailboxType type, FILE *fp, const char *fname, bool is_old, struct Email *e);
-int           maildir_sync_mailbox_message(struct Mailbox *m, int msgno, struct HeaderCache *hc);
+bool          maildir_sync_mailbox_message(struct Mailbox *m, int msgno, struct HeaderCache *hc);
 bool          maildir_update_flags     (struct Mailbox *m, struct Email *e_old, struct Email *e_new);
 int           mh_check_empty           (const char *path);
 int           mh_sync_mailbox_message  (struct Mailbox *m, int msgno, struct HeaderCache *hc);

--- a/maildir/lib.h
+++ b/maildir/lib.h
@@ -56,7 +56,7 @@ extern struct MxOps MxMhOps;
 
 int           maildir_check_empty      (const char *path);
 void          maildir_gen_flags        (char *dest, size_t destlen, struct Email *e);
-int           maildir_msg_open_new     (struct Mailbox *m, struct Message *msg, const struct Email *e);
+bool          maildir_msg_open_new     (struct Mailbox *m, struct Message *msg, const struct Email *e);
 FILE *        maildir_open_find_message(const char *folder, const char *msg, char **newname);
 void          maildir_parse_flags      (struct Email *e, const char *path);
 struct Email *maildir_parse_message    (enum MailboxType type, const char *fname, bool is_old, struct Email *e);

--- a/maildir/maildir.c
+++ b/maildir/maildir.c
@@ -1115,18 +1115,18 @@ static enum MxOpenReturns maildir_mbox_open(struct Mailbox *m)
 /**
  * maildir_mbox_open_append - Open a Mailbox for appending - Implements MxOps::mbox_open_append()
  */
-static int maildir_mbox_open_append(struct Mailbox *m, OpenMailboxFlags flags)
+static bool maildir_mbox_open_append(struct Mailbox *m, OpenMailboxFlags flags)
 {
   if (!(flags & (MUTT_APPEND | MUTT_APPENDNEW | MUTT_NEWFOLDER)))
   {
-    return 0;
+    return true;
   }
 
   errno = 0;
   if ((mutt_file_mkdir(mailbox_path(m), S_IRWXU) != 0) && (errno != EEXIST))
   {
     mutt_perror(mailbox_path(m));
-    return -1;
+    return false;
   }
 
   char tmp[PATH_MAX];
@@ -1136,7 +1136,7 @@ static int maildir_mbox_open_append(struct Mailbox *m, OpenMailboxFlags flags)
   {
     mutt_perror(tmp);
     rmdir(mailbox_path(m));
-    return -1;
+    return false;
   }
 
   snprintf(tmp, sizeof(tmp), "%s/new", mailbox_path(m));
@@ -1147,7 +1147,7 @@ static int maildir_mbox_open_append(struct Mailbox *m, OpenMailboxFlags flags)
     snprintf(tmp, sizeof(tmp), "%s/cur", mailbox_path(m));
     rmdir(tmp);
     rmdir(mailbox_path(m));
-    return -1;
+    return false;
   }
 
   snprintf(tmp, sizeof(tmp), "%s/tmp", mailbox_path(m));
@@ -1160,10 +1160,10 @@ static int maildir_mbox_open_append(struct Mailbox *m, OpenMailboxFlags flags)
     snprintf(tmp, sizeof(tmp), "%s/new", mailbox_path(m));
     rmdir(tmp);
     rmdir(mailbox_path(m));
-    return -1;
+    return false;
   }
 
-  return 0;
+  return true;
 }
 
 /**

--- a/maildir/maildir.c
+++ b/maildir/maildir.c
@@ -1445,11 +1445,11 @@ err:
 
 /**
  * maildir_mbox_close - Close a Mailbox - Implements MxOps::mbox_close()
- * @retval 0 Always
+ * @retval MX_CHECK_NO_CHANGE  Always
  */
-int maildir_mbox_close(struct Mailbox *m)
+enum MxCheckReturns maildir_mbox_close(struct Mailbox *m)
 {
-  return 0;
+  return MX_CHECK_NO_CHANGE;
 }
 
 /**

--- a/maildir/maildir.c
+++ b/maildir/maildir.c
@@ -1102,14 +1102,14 @@ bool maildir_ac_add(struct Account *a, struct Mailbox *m)
 /**
  * maildir_mbox_open - Open a Mailbox - Implements MxOps::mbox_open()
  */
-static int maildir_mbox_open(struct Mailbox *m)
+static enum MxOpenReturns maildir_mbox_open(struct Mailbox *m)
 {
   /* maildir looks sort of like MH, except that there are two subdirectories
    * of the main folder path from which to read messages */
   if ((maildir_read_dir(m, "new") == -1) || (maildir_read_dir(m, "cur") == -1))
-    return -1;
+    return MX_OPEN_ERROR;
 
-  return 0;
+  return MX_OPEN_OK;
 }
 
 /**

--- a/maildir/maildir.c
+++ b/maildir/maildir.c
@@ -1094,9 +1094,9 @@ bool maildir_ac_owns_path(struct Account *a, const char *path)
 /**
  * maildir_ac_add - Add a Mailbox to an Account - Implements MxOps::ac_add()
  */
-int maildir_ac_add(struct Account *a, struct Mailbox *m)
+bool maildir_ac_add(struct Account *a, struct Mailbox *m)
 {
-  return 0;
+  return true;
 }
 
 /**

--- a/maildir/maildir.c
+++ b/maildir/maildir.c
@@ -1352,7 +1352,7 @@ enum MxCheckReturns maildir_mbox_check(struct Mailbox *m)
 /**
  * maildir_mbox_check_stats - Check the Mailbox statistics - Implements MxOps::mbox_check_stats()
  */
-static enum MxCheckStatsReturns maildir_mbox_check_stats(struct Mailbox *m, uint8_t flags)
+static enum MxCheckReturns maildir_mbox_check_stats(struct Mailbox *m, uint8_t flags)
 {
   bool check_stats = flags;
   bool check_new = true;
@@ -1371,7 +1371,7 @@ static enum MxCheckStatsReturns maildir_mbox_check_stats(struct Mailbox *m, uint
   if (check_new || check_stats)
     maildir_check_dir(m, "cur", check_new, check_stats);
 
-  return m->msg_new ? MX_CHECK_STATS_NEW_MAIL : MX_CHECK_STATS_NO_CHANGE;
+  return m->msg_new ? MX_CHECK_NEW_MAIL : MX_CHECK_NO_CHANGE;
 }
 
 /**

--- a/maildir/maildir.c
+++ b/maildir/maildir.c
@@ -1352,7 +1352,7 @@ enum MxCheckReturns maildir_mbox_check(struct Mailbox *m)
 /**
  * maildir_mbox_check_stats - Check the Mailbox statistics - Implements MxOps::mbox_check_stats()
  */
-static int maildir_mbox_check_stats(struct Mailbox *m, uint8_t flags)
+static enum MxCheckStatsReturns maildir_mbox_check_stats(struct Mailbox *m, uint8_t flags)
 {
   bool check_stats = flags;
   bool check_new = true;
@@ -1371,7 +1371,7 @@ static int maildir_mbox_check_stats(struct Mailbox *m, uint8_t flags)
   if (check_new || check_stats)
     maildir_check_dir(m, "cur", check_new, check_stats);
 
-  return m->msg_new;
+  return m->msg_new ? MX_CHECK_STATS_NEW_MAIL : MX_CHECK_STATS_NO_CHANGE;
 }
 
 /**

--- a/maildir/mh.c
+++ b/maildir/mh.c
@@ -675,13 +675,13 @@ void mh_delayed_parsing(struct Mailbox *m, struct MdEmailArray *mda, struct Prog
 /**
  * mh_read_dir - Read an MH mailbox
  * @param m Mailbox
- * @retval  0 Success
- * @retval -1 Failure
+ * @retval true Success
+ * @retval false Error
  */
-int mh_read_dir(struct Mailbox *m)
+static bool mh_read_dir(struct Mailbox *m)
 {
   if (!m)
-    return -1;
+    return false;
 
   struct MhSequences mhs = { 0 };
   struct Progress progress;
@@ -705,7 +705,7 @@ int mh_read_dir(struct Mailbox *m)
 
   struct MdEmailArray mda = ARRAY_HEAD_INITIALIZER;
   if (mh_parse_dir(m, &mda, &progress) < 0)
-    return -1;
+    return false;
 
   if (m->verbose)
   {
@@ -718,7 +718,7 @@ int mh_read_dir(struct Mailbox *m)
   if (mh_seq_read(&mhs, mailbox_path(m)) < 0)
   {
     maildirarray_clear(&mda);
-    return -1;
+    return false;
   }
   mh_update_maildir(&mda, &mhs);
   mh_seq_free(&mhs);
@@ -728,7 +728,7 @@ int mh_read_dir(struct Mailbox *m)
   if (!mdata->mh_umask)
     mdata->mh_umask = mh_umask(m);
 
-  return 0;
+  return true;
 }
 
 /**
@@ -859,9 +859,9 @@ bool mh_ac_add(struct Account *a, struct Mailbox *m)
 /**
  * mh_mbox_open - Open a Mailbox - Implements MxOps::mbox_open()
  */
-static int mh_mbox_open(struct Mailbox *m)
+static enum MxOpenReturns mh_mbox_open(struct Mailbox *m)
 {
-  return mh_read_dir(m);
+  return mh_read_dir(m) ? MX_OPEN_OK : MX_OPEN_ERROR;
 }
 
 /**

--- a/maildir/mh.c
+++ b/maildir/mh.c
@@ -867,15 +867,15 @@ static enum MxOpenReturns mh_mbox_open(struct Mailbox *m)
 /**
  * mh_mbox_open_append - Open a Mailbox for appending - Implements MxOps::mbox_open_append()
  */
-static int mh_mbox_open_append(struct Mailbox *m, OpenMailboxFlags flags)
+static bool mh_mbox_open_append(struct Mailbox *m, OpenMailboxFlags flags)
 {
   if (!(flags & (MUTT_APPENDNEW | MUTT_NEWFOLDER)))
-    return 0;
+    return true;
 
   if (mutt_file_mkdir(mailbox_path(m), S_IRWXU))
   {
     mutt_perror(mailbox_path(m));
-    return -1;
+    return false;
   }
 
   char tmp[PATH_MAX];
@@ -885,11 +885,11 @@ static int mh_mbox_open_append(struct Mailbox *m, OpenMailboxFlags flags)
   {
     mutt_perror(tmp);
     rmdir(mailbox_path(m));
-    return -1;
+    return false;
   }
   close(i);
 
-  return 0;
+  return true;
 }
 
 /**

--- a/maildir/mh.c
+++ b/maildir/mh.c
@@ -851,9 +851,9 @@ bool mh_ac_owns_path(struct Account *a, const char *path)
 /**
  * mh_ac_add - Add a Mailbox to an Account - Implements MxOps::ac_add()
  */
-int mh_ac_add(struct Account *a, struct Mailbox *m)
+bool mh_ac_add(struct Account *a, struct Mailbox *m)
 {
-  return 0;
+  return true;
 }
 
 /**

--- a/maildir/mh.c
+++ b/maildir/mh.c
@@ -1108,11 +1108,11 @@ err:
 
 /**
  * mh_mbox_close - Close a Mailbox - Implements MxOps::mbox_close()
- * @retval 0 Always
+ * @retval MX_CHECK_NO_CHANGE Always
  */
-int mh_mbox_close(struct Mailbox *m)
+enum MxCheckReturns mh_mbox_close(struct Mailbox *m)
 {
-  return 0;
+  return MX_CHECK_NO_CHANGE;
 }
 
 /**

--- a/maildir/mh.c
+++ b/maildir/mh.c
@@ -182,7 +182,7 @@ int mh_check_empty(const char *path)
 /**
  * mh_mbox_check_stats - Check the Mailbox statistics - Implements MxOps::mbox_check_stats()
  */
-static enum MxCheckStatsReturns mh_mbox_check_stats(struct Mailbox *m, uint8_t flags)
+static enum MxCheckReturns mh_mbox_check_stats(struct Mailbox *m, uint8_t flags)
 {
   struct MhSequences mhs = { 0 };
   DIR *dirp = NULL;
@@ -192,17 +192,17 @@ static enum MxCheckStatsReturns mh_mbox_check_stats(struct Mailbox *m, uint8_t f
    * since the last m visit, there is no "new mail" */
   if (C_MailCheckRecent && (mh_seq_changed(m) <= 0))
   {
-    return MX_CHECK_STATS_NO_CHANGE;
+    return MX_CHECK_NO_CHANGE;
   }
 
   if (mh_seq_read(&mhs, mailbox_path(m)) < 0)
-    return MX_CHECK_STATS_ERROR;
+    return MX_CHECK_ERROR;
 
   m->msg_count = 0;
   m->msg_unread = 0;
   m->msg_flagged = 0;
 
-  enum MxCheckStatsReturns rc = MX_CHECK_STATS_NO_CHANGE;
+  enum MxCheckReturns rc = MX_CHECK_NO_CHANGE;
   bool check_new = true;
   for (int i = mhs.max; i > 0; i--)
   {
@@ -218,7 +218,7 @@ static enum MxCheckStatsReturns mh_mbox_check_stats(struct Mailbox *m, uint8_t f
         if (!C_MailCheckRecent || (mh_already_notified(m, i) == 0))
         {
           m->has_new = true;
-          rc = MX_CHECK_STATS_NEW_MAIL;
+          rc = MX_CHECK_NEW_MAIL;
         }
         /* Because we are traversing from high to low, we can stop
          * checking for new mail after the first unseen message.

--- a/maildir/private.h
+++ b/maildir/private.h
@@ -46,7 +46,7 @@ extern char *C_MhSeqReplied;
 extern char *C_MhSeqUnseen;
 
 int    maildir_move_to_mailbox(struct Mailbox *m, struct MdEmailArray *mda);
-int    mh_mkstemp             (struct Mailbox *m, FILE **fp, char **tgt);
+bool   mh_mkstemp             (struct Mailbox *m, FILE **fp, char **tgt);
 mode_t mh_umask               (struct Mailbox *m);
 
 #endif /* MUTT_MAILDIR_PRIVATE_H */

--- a/maildir/sequence.c
+++ b/maildir/sequence.c
@@ -127,7 +127,7 @@ void mh_seq_add_one(struct Mailbox *m, int n, bool unseen, bool flagged, bool re
   size_t sz;
 
   FILE *fp_new = NULL;
-  if (mh_mkstemp(m, &fp_new, &tmpfname) == -1)
+  if (!mh_mkstemp(m, &fp_new, &tmpfname))
     return;
 
   snprintf(seq_unseen, sizeof(seq_unseen), "%s:", NONULL(C_MhSeqUnseen));
@@ -255,7 +255,7 @@ void mh_seq_update(struct Mailbox *m)
   snprintf(seq_flagged, sizeof(seq_flagged), "%s:", NONULL(C_MhSeqFlagged));
 
   FILE *fp_new = NULL;
-  if (mh_mkstemp(m, &fp_new, &tmpfname) != 0)
+  if (!mh_mkstemp(m, &fp_new, &tmpfname))
   {
     /* error message? */
     return;

--- a/mbox/lib.h
+++ b/mbox/lib.h
@@ -63,7 +63,7 @@ extern struct MxOps MxMmdfOps;
 
 #define MMDF_SEP "\001\001\001\001\n"
 
-enum MxCheckReturns mbox_check(struct Mailbox *m, struct stat *sb, bool check_stats);
+enum MxStatus    mbox_check(struct Mailbox *m, struct stat *sb, bool check_stats);
 enum MailboxType mbox_path_probe(const char *path, const struct stat *st);
 void             mbox_reset_atime(struct Mailbox *m, struct stat *st);
 bool             mbox_test_new_folder(const char *path);

--- a/mbox/lib.h
+++ b/mbox/lib.h
@@ -63,7 +63,7 @@ extern struct MxOps MxMmdfOps;
 
 #define MMDF_SEP "\001\001\001\001\n"
 
-int              mbox_check(struct Mailbox *m, struct stat *sb, bool check_stats);
+enum MxCheckReturns mbox_check(struct Mailbox *m, struct stat *sb, bool check_stats);
 enum MailboxType mbox_path_probe(const char *path, const struct stat *st);
 void             mbox_reset_atime(struct Mailbox *m, struct stat *st);
 bool             mbox_test_new_folder(const char *path);

--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -960,14 +960,14 @@ static enum MxOpenReturns mbox_mbox_open(struct Mailbox *m)
 /**
  * mbox_mbox_open_append - Open a Mailbox for appending - Implements MxOps::mbox_open_append()
  */
-static int mbox_mbox_open_append(struct Mailbox *m, OpenMailboxFlags flags)
+static bool mbox_mbox_open_append(struct Mailbox *m, OpenMailboxFlags flags)
 {
   if (init_mailbox(m) != 0)
-    return -1;
+    return false;
 
   struct MboxAccountData *adata = mbox_adata_get(m);
   if (!adata)
-    return -1;
+    return false;
 
   if (!adata->fp)
   {
@@ -977,7 +977,7 @@ static int mbox_mbox_open_append(struct Mailbox *m, OpenMailboxFlags flags)
     {
       mutt_perror(mailbox_path(m));
       FREE(&tmp_path);
-      return -1;
+      return false;
     }
     FREE(&tmp_path);
 
@@ -986,20 +986,20 @@ static int mbox_mbox_open_append(struct Mailbox *m, OpenMailboxFlags flags)
     if (!adata->fp)
     {
       mutt_perror(mailbox_path(m));
-      return -1;
+      return false;
     }
 
     if (mbox_lock_mailbox(m, true, true) != false)
     {
       mutt_error(_("Couldn't lock %s"), mailbox_path(m));
       mutt_file_fclose(&adata->fp);
-      return -1;
+      return false;
     }
   }
 
   fseek(adata->fp, 0, SEEK_END);
 
-  return 0;
+  return true;
 }
 
 /**

--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -877,9 +877,9 @@ static bool mbox_ac_owns_path(struct Account *a, const char *path)
 /**
  * mbox_ac_add - Add a Mailbox to an Account - Implements MxOps::ac_add()
  */
-static int mbox_ac_add(struct Account *a, struct Mailbox *m)
+static bool mbox_ac_add(struct Account *a, struct Mailbox *m)
 {
-  return 0;
+  return true;
 }
 
 /**

--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -527,7 +527,7 @@ static enum MxOpenReturns mbox_parse_mailbox(struct Mailbox *m)
 /**
  * reopen_mailbox - Close and reopen a mailbox
  * @param m          Mailbox
- * @retval >0 Success, e.g. #MX_CHECK_REOPENED, #MX_CHECK_NEW_MAIL
+ * @retval >0 Success, e.g. #MX_STATUS_REOPENED, #MX_STATUS_NEW_MAIL
  * @retval -1 Error
  */
 static int reopen_mailbox(struct Mailbox *m)
@@ -699,7 +699,7 @@ static int reopen_mailbox(struct Mailbox *m)
   mailbox_changed(m, NT_MAILBOX_UPDATE);
   m->verbose = true;
 
-  return (m->changed || msg_mod) ? MX_CHECK_REOPENED : MX_CHECK_NEW_MAIL;
+  return (m->changed || msg_mod) ? MX_STATUS_REOPENED : MX_STATUS_NEW_MAIL;
 }
 
 /**
@@ -1005,20 +1005,20 @@ static bool mbox_mbox_open_append(struct Mailbox *m, OpenMailboxFlags flags)
 /**
  * mbox_mbox_check - Check for new mail - Implements MxOps::mbox_check()
  * @param[in]  m Mailbox
- * @retval #MX_CHECK_REOPENED  Mailbox has been reopened
- * @retval #MX_CHECK_NEW_MAIL  New mail has arrived
- * @retval #MX_CHECK_LOCKED    Couldn't lock the file
+ * @retval #MX_STATUS_REOPENED  Mailbox has been reopened
+ * @retval #MX_STATUS_NEW_MAIL  New mail has arrived
+ * @retval #MX_STATUS_LOCKED    Couldn't lock the file
  */
-static enum MxCheckReturns mbox_mbox_check(struct Mailbox *m)
+static enum MxStatus mbox_mbox_check(struct Mailbox *m)
 {
   struct MboxAccountData *adata = mbox_adata_get(m);
   if (!adata)
-    return MX_CHECK_ERROR;
+    return MX_STATUS_ERROR;
 
   if (!adata->fp)
   {
     if (mbox_mbox_open(m) != MX_OPEN_OK)
-      return MX_CHECK_ERROR;
+      return MX_STATUS_ERROR;
     mailbox_changed(m, NT_MAILBOX_INVALID);
   }
 
@@ -1031,14 +1031,14 @@ static enum MxCheckReturns mbox_mbox_check(struct Mailbox *m)
     if ((mutt_file_stat_timespec_compare(&st, MUTT_STAT_MTIME, &m->mtime) == 0) &&
         (st.st_size == m->size))
     {
-      return MX_CHECK_NO_CHANGE;
+      return MX_STATUS_OK;
     }
 
     if (st.st_size == m->size)
     {
       /* the file was touched, but it is still the same length, so just exit */
       mutt_file_get_stat_timespec(&m->mtime, &st, MUTT_STAT_MTIME);
-      return MX_CHECK_NO_CHANGE;
+      return MX_STATUS_OK;
     }
 
     if (st.st_size > m->size)
@@ -1053,7 +1053,7 @@ static enum MxCheckReturns mbox_mbox_check(struct Mailbox *m)
           /* we couldn't lock the mailbox, but nothing serious happened:
            * probably the new mail arrived: no reason to wait till we can
            * parse it: we'll get it on the next pass */
-          return MX_CHECK_LOCKED;
+          return MX_STATUS_LOCKED;
         }
         unlock = 1;
       }
@@ -1091,7 +1091,7 @@ static enum MxCheckReturns mbox_mbox_check(struct Mailbox *m)
             mutt_sig_unblock();
           }
 
-          return MX_CHECK_NEW_MAIL; /* signal that new mail arrived */
+          return MX_STATUS_NEW_MAIL; /* signal that new mail arrived */
         }
         else
           modified = true;
@@ -1116,7 +1116,7 @@ static enum MxCheckReturns mbox_mbox_check(struct Mailbox *m)
         mbox_unlock_mailbox(m);
         mutt_sig_unblock();
       }
-      return MX_CHECK_REOPENED;
+      return MX_STATUS_REOPENED;
     }
   }
 
@@ -1126,17 +1126,17 @@ static enum MxCheckReturns mbox_mbox_check(struct Mailbox *m)
   mx_fastclose_mailbox(m);
   mutt_sig_unblock();
   mutt_error(_("Mailbox was corrupted"));
-  return MX_CHECK_ERROR;
+  return MX_STATUS_ERROR;
 }
 
 /**
  * mbox_mbox_sync - Save changes to the Mailbox - Implements MxOps::mbox_sync()
  */
-static enum MxCheckReturns mbox_mbox_sync(struct Mailbox *m)
+static enum MxStatus mbox_mbox_sync(struct Mailbox *m)
 {
   struct MboxAccountData *adata = mbox_adata_get(m);
   if (!adata)
-    return MX_CHECK_ERROR;
+    return MX_STATUS_ERROR;
 
   struct Buffer *tempfile = NULL;
   char buf[32];
@@ -1151,7 +1151,7 @@ static enum MxCheckReturns mbox_mbox_sync(struct Mailbox *m)
   struct MUpdate *old_offset = NULL;
   FILE *fp = NULL;
   struct Progress progress;
-  enum MxCheckReturns rc = MX_CHECK_ERROR;
+  enum MxStatus rc = MX_STATUS_ERROR;
 
   /* sort message by their position in the mailbox on disk */
   if (C_Sort != SORT_ORDER)
@@ -1183,8 +1183,8 @@ static enum MxCheckReturns mbox_mbox_sync(struct Mailbox *m)
   }
 
   /* Check to make sure that the file hasn't changed on disk */
-  enum MxCheckReturns check = mbox_mbox_check(m);
-  if ((check == MX_CHECK_NEW_MAIL) || (check == MX_CHECK_REOPENED))
+  enum MxStatus check = mbox_mbox_check(m);
+  if ((check == MX_STATUS_NEW_MAIL) || (check == MX_STATUS_REOPENED))
   {
     /* new mail arrived, or mailbox reopened */
     rc = check;
@@ -1503,14 +1503,14 @@ fatal:
 /**
  * mbox_mbox_close - Close a Mailbox - Implements MxOps::mbox_close()
  */
-static enum MxCheckReturns mbox_mbox_close(struct Mailbox *m)
+static enum MxStatus mbox_mbox_close(struct Mailbox *m)
 {
   struct MboxAccountData *adata = mbox_adata_get(m);
   if (!adata)
-    return MX_CHECK_ERROR;
+    return MX_STATUS_ERROR;
 
   if (!adata->fp)
-    return MX_CHECK_NO_CHANGE;
+    return MX_STATUS_OK;
 
   if (adata->append)
   {
@@ -1537,7 +1537,7 @@ static enum MxCheckReturns mbox_mbox_close(struct Mailbox *m)
 #endif
   }
 
-  return MX_CHECK_NO_CHANGE;
+  return MX_STATUS_OK;
 }
 
 /**
@@ -1750,11 +1750,11 @@ static int mmdf_msg_padding_size(struct Mailbox *m)
 /**
  * mbox_mbox_check_stats - Check the Mailbox statistics - Implements MxOps::mbox_check_stats()
  */
-static enum MxCheckReturns mbox_mbox_check_stats(struct Mailbox *m, uint8_t flags)
+static enum MxStatus mbox_mbox_check_stats(struct Mailbox *m, uint8_t flags)
 {
   struct stat sb = { 0 };
   if (stat(mailbox_path(m), &sb) != 0)
-    return MX_CHECK_ERROR;
+    return MX_STATUS_ERROR;
 
   bool new_or_changed;
 
@@ -1795,7 +1795,9 @@ static enum MxCheckReturns mbox_mbox_check_stats(struct Mailbox *m, uint8_t flag
     m->peekonly = old_peek;
   }
 
-  return (m->has_new || m->msg_new) ? MX_CHECK_NEW_MAIL : MX_CHECK_NO_CHANGE;
+  if (m->has_new || m->msg_new)
+    return MX_STATUS_NEW_MAIL;
+  return MX_STATUS_OK;
 }
 
 // clang-format off

--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -1543,30 +1543,30 @@ static enum MxStatus mbox_mbox_close(struct Mailbox *m)
 /**
  * mbox_msg_open - Open an email message in a Mailbox - Implements MxOps::msg_open()
  */
-static int mbox_msg_open(struct Mailbox *m, struct Message *msg, int msgno)
+static bool mbox_msg_open(struct Mailbox *m, struct Message *msg, int msgno)
 {
   struct MboxAccountData *adata = mbox_adata_get(m);
   if (!adata)
-    return -1;
+    return false;
 
   msg->fp = mutt_file_fopen(mailbox_path(m), "r");
   if (!msg->fp)
-    return -1;
+    return false;
 
-  return 0;
+  return true;
 }
 
 /**
  * mbox_msg_open_new - Open a new message in a Mailbox - Implements MxOps::msg_open_new()
  */
-static int mbox_msg_open_new(struct Mailbox *m, struct Message *msg, const struct Email *e)
+static bool mbox_msg_open_new(struct Mailbox *m, struct Message *msg, const struct Email *e)
 {
   struct MboxAccountData *adata = mbox_adata_get(m);
   if (!adata)
-    return -1;
+    return false;
 
   msg->fp = adata->fp;
-  return 0;
+  return true;
 }
 
 /**

--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -1750,11 +1750,11 @@ static int mmdf_msg_padding_size(struct Mailbox *m)
 /**
  * mbox_mbox_check_stats - Check the Mailbox statistics - Implements MxOps::mbox_check_stats()
  */
-static int mbox_mbox_check_stats(struct Mailbox *m, uint8_t flags)
+static enum MxCheckStatsReturns mbox_mbox_check_stats(struct Mailbox *m, uint8_t flags)
 {
   struct stat sb = { 0 };
   if (stat(mailbox_path(m), &sb) != 0)
-    return -1;
+    return MX_CHECK_STATS_ERROR;
 
   bool new_or_changed;
 
@@ -1795,10 +1795,7 @@ static int mbox_mbox_check_stats(struct Mailbox *m, uint8_t flags)
     m->peekonly = old_peek;
   }
 
-  if (m->msg_new == 0 && m->has_new)
-    return 1;
-
-  return m->msg_new;
+  return (m->has_new || m->msg_new) ? MX_CHECK_STATS_NEW_MAIL : MX_CHECK_STATS_NO_CHANGE;
 }
 
 // clang-format off

--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -1503,14 +1503,14 @@ fatal:
 /**
  * mbox_mbox_close - Close a Mailbox - Implements MxOps::mbox_close()
  */
-static int mbox_mbox_close(struct Mailbox *m)
+static enum MxCheckReturns mbox_mbox_close(struct Mailbox *m)
 {
   struct MboxAccountData *adata = mbox_adata_get(m);
   if (!adata)
-    return -1;
+    return MX_CHECK_ERROR;
 
   if (!adata->fp)
-    return 0;
+    return MX_CHECK_NO_CHANGE;
 
   if (adata->append)
   {
@@ -1537,7 +1537,7 @@ static int mbox_mbox_close(struct Mailbox *m)
 #endif
   }
 
-  return 0;
+  return MX_CHECK_NO_CHANGE;
 }
 
 /**

--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -1750,11 +1750,11 @@ static int mmdf_msg_padding_size(struct Mailbox *m)
 /**
  * mbox_mbox_check_stats - Check the Mailbox statistics - Implements MxOps::mbox_check_stats()
  */
-static enum MxCheckStatsReturns mbox_mbox_check_stats(struct Mailbox *m, uint8_t flags)
+static enum MxCheckReturns mbox_mbox_check_stats(struct Mailbox *m, uint8_t flags)
 {
   struct stat sb = { 0 };
   if (stat(mailbox_path(m), &sb) != 0)
-    return MX_CHECK_STATS_ERROR;
+    return MX_CHECK_ERROR;
 
   bool new_or_changed;
 
@@ -1795,7 +1795,7 @@ static enum MxCheckStatsReturns mbox_mbox_check_stats(struct Mailbox *m, uint8_t
     m->peekonly = old_peek;
   }
 
-  return (m->has_new || m->msg_new) ? MX_CHECK_STATS_NEW_MAIL : MX_CHECK_STATS_NO_CHANGE;
+  return (m->has_new || m->msg_new) ? MX_CHECK_NEW_MAIL : MX_CHECK_NO_CHANGE;
 }
 
 // clang-format off

--- a/mutt_mailbox.c
+++ b/mutt_mailbox.c
@@ -108,7 +108,7 @@ static void mailbox_check(struct Mailbox *m_cur, struct Mailbox *m_check,
       case MUTT_MAILDIR:
       case MUTT_MH:
       case MUTT_NOTMUCH:
-        if ((mx_mbox_check_stats(m_check, check_stats) != MX_CHECK_ERROR) &&
+        if ((mx_mbox_check_stats(m_check, check_stats) != MX_CHECK_STATS_ERROR) &&
             m_check->has_new)
         {
           MailboxCount++;

--- a/mutt_mailbox.c
+++ b/mutt_mailbox.c
@@ -108,8 +108,11 @@ static void mailbox_check(struct Mailbox *m_cur, struct Mailbox *m_check,
       case MUTT_MAILDIR:
       case MUTT_MH:
       case MUTT_NOTMUCH:
-        if ((mx_mbox_check_stats(m_check, check_stats) > 0) && m_check->has_new)
+        if ((mx_mbox_check_stats(m_check, check_stats) != MX_CHECK_ERROR) &&
+            m_check->has_new)
+        {
           MailboxCount++;
+        }
         break;
       default:; /* do nothing */
     }

--- a/mutt_mailbox.c
+++ b/mutt_mailbox.c
@@ -108,7 +108,7 @@ static void mailbox_check(struct Mailbox *m_cur, struct Mailbox *m_check,
       case MUTT_MAILDIR:
       case MUTT_MH:
       case MUTT_NOTMUCH:
-        if ((mx_mbox_check_stats(m_check, check_stats) != MX_CHECK_STATS_ERROR) &&
+        if ((mx_mbox_check_stats(m_check, check_stats) != MX_CHECK_ERROR) &&
             m_check->has_new)
         {
           MailboxCount++;

--- a/mutt_mailbox.c
+++ b/mutt_mailbox.c
@@ -108,7 +108,7 @@ static void mailbox_check(struct Mailbox *m_cur, struct Mailbox *m_check,
       case MUTT_MAILDIR:
       case MUTT_MH:
       case MUTT_NOTMUCH:
-        if ((mx_mbox_check_stats(m_check, check_stats) != MX_CHECK_ERROR) &&
+        if ((mx_mbox_check_stats(m_check, check_stats) != MX_STATUS_ERROR) &&
             m_check->has_new)
         {
           MailboxCount++;

--- a/mx.c
+++ b/mx.c
@@ -1793,10 +1793,10 @@ int mx_ac_remove(struct Mailbox *m)
 /**
  * mx_mbox_check_stats - Check the statistics for a mailbox - Wrapper for MxOps::mbox_check_stats()
  */
-int mx_mbox_check_stats(struct Mailbox *m, uint8_t flags)
+enum MxCheckStatsReturns mx_mbox_check_stats(struct Mailbox *m, uint8_t flags)
 {
   if (!m)
-    return -1;
+    return MX_CHECK_ERROR;
 
   return m->mx_ops->mbox_check_stats(m, flags);
 }

--- a/mx.c
+++ b/mx.c
@@ -1791,7 +1791,7 @@ int mx_ac_remove(struct Mailbox *m)
 /**
  * mx_mbox_check_stats - Check the statistics for a mailbox - Wrapper for MxOps::mbox_check_stats()
  */
-enum MxCheckStatsReturns mx_mbox_check_stats(struct Mailbox *m, uint8_t flags)
+enum MxCheckReturns mx_mbox_check_stats(struct Mailbox *m, uint8_t flags)
 {
   if (!m)
     return MX_CHECK_ERROR;

--- a/mx.c
+++ b/mx.c
@@ -1093,7 +1093,7 @@ struct Message *mx_msg_open_new(struct Mailbox *m, const struct Email *e, MsgOpe
   if (msg->received == 0)
     msg->received = mutt_date_epoch();
 
-  if (m->mx_ops->msg_open_new(m, msg, e) == 0)
+  if (m->mx_ops->msg_open_new(m, msg, e))
   {
     if (m->type == MUTT_MMDF)
       fputs(MMDF_SEP, msg->fp);
@@ -1162,7 +1162,7 @@ struct Message *mx_msg_open(struct Mailbox *m, int msgno)
   }
 
   struct Message *msg = mutt_mem_calloc(1, sizeof(struct Message));
-  if (m->mx_ops->msg_open(m, msg, msgno) < 0)
+  if (!m->mx_ops->msg_open(m, msg, msgno))
     FREE(&msg);
 
   return msg;

--- a/mx.c
+++ b/mx.c
@@ -279,7 +279,7 @@ bool mx_mbox_ac_link(struct Mailbox *m)
     a = account_new(NULL, NeoMutt->sub);
     a->type = m->type;
   }
-  if (mx_ac_add(a, m) < 0)
+  if (!mx_ac_add(a, m))
   {
     if (new_account)
     {
@@ -1767,16 +1767,12 @@ struct Mailbox *mx_resolve(const char *path_or_name)
 /**
  * mx_ac_add - Add a Mailbox to an Account - Wrapper for MxOps::ac_add()
  */
-int mx_ac_add(struct Account *a, struct Mailbox *m)
+bool mx_ac_add(struct Account *a, struct Mailbox *m)
 {
   if (!a || !m || !m->mx_ops || !m->mx_ops->ac_add)
-    return -1;
+    return false;
 
-  if (m->mx_ops->ac_add(a, m) < 0)
-    return -1;
-
-  account_mailbox_add(a, m);
-  return 0;
+  return m->mx_ops->ac_add(a, m) && account_mailbox_add(a, m);
 }
 
 /**

--- a/mx.c
+++ b/mx.c
@@ -398,12 +398,12 @@ struct Context *mx_mbox_open(struct Mailbox *m, OpenMailboxFlags flags)
   m->msg_tagged = 0;
   m->vcount = 0;
 
-  int rc = m->mx_ops->mbox_open(ctx->mailbox);
+  enum MxOpenReturns rc = m->mx_ops->mbox_open(ctx->mailbox);
   m->opened++;
-  if (rc == 0)
+  if (rc == MX_OPEN_OK)
     ctx_update(ctx);
 
-  if ((rc == 0) || (rc == -2))
+  if ((rc == MX_OPEN_OK) || (rc == MX_OPEN_ABORT))
   {
     if ((flags & MUTT_NOSORT) == 0)
     {
@@ -414,7 +414,7 @@ struct Context *mx_mbox_open(struct Mailbox *m, OpenMailboxFlags flags)
     }
     if (m->verbose)
       mutt_clear_error();
-    if (rc == -2)
+    if (rc == MX_OPEN_ABORT)
     {
       mutt_error(_("Reading from %s interrupted..."), mailbox_path(m));
       mutt_sort_headers(ctx->mailbox, ctx->threads, true, &ctx->vsize);

--- a/mx.c
+++ b/mx.c
@@ -195,13 +195,13 @@ int mx_access(const char *path, int flags)
  * mx_open_mailbox_append - Open a mailbox for appending
  * @param m     Mailbox
  * @param flags Flags, see #OpenMailboxFlags
- * @retval  0 Success
- * @retval -1 Failure
+ * @retval true Success
+ * @retval false Failure
  */
-static int mx_open_mailbox_append(struct Mailbox *m, OpenMailboxFlags flags)
+static bool mx_open_mailbox_append(struct Mailbox *m, OpenMailboxFlags flags)
 {
   if (!m)
-    return -1;
+    return false;
 
   struct stat sb;
 
@@ -219,7 +219,7 @@ static int mx_open_mailbox_append(struct Mailbox *m, OpenMailboxFlags flags)
       else
       {
         mutt_error(_("%s is not a mailbox"), mailbox_path(m));
-        return -1;
+        return false;
       }
     }
 
@@ -240,20 +240,20 @@ static int mx_open_mailbox_append(struct Mailbox *m, OpenMailboxFlags flags)
         else
         {
           mutt_perror(mailbox_path(m));
-          return -1;
+          return false;
         }
       }
       else
-        return -1;
+        return false;
     }
 
     m->mx_ops = mx_get_ops(m->type);
   }
 
   if (!m->mx_ops || !m->mx_ops->mbox_open_append)
-    return -1;
+    return false;
 
-  int rc = m->mx_ops->mbox_open_append(m, flags);
+  const bool rc = m->mx_ops->mbox_open_append(m, flags);
   m->opened++;
   return rc;
 }
@@ -340,7 +340,7 @@ struct Context *mx_mbox_open(struct Mailbox *m, OpenMailboxFlags flags)
 
   if (flags & (MUTT_APPEND | MUTT_NEWFOLDER))
   {
-    if (mx_open_mailbox_append(ctx->mailbox, flags) != 0)
+    if (!mx_open_mailbox_append(ctx->mailbox, flags))
     {
       goto error;
     }

--- a/mx.h
+++ b/mx.h
@@ -124,14 +124,14 @@ struct MxOps
    * ac_add - Add a Mailbox to an Account
    * @param a Account to add to
    * @param m Mailbox to add
-   * @retval  0 Success
-   * @retval -1 Error
+   * @retval  true  Success
+   * @retval  false Error
    *
    * **Contract**
    * - @a a is not NULL
    * - @a m is not NULL
    */
-  int             (*ac_add)   (struct Account *a, struct Mailbox *m);
+  bool (*ac_add) (struct Account *a, struct Mailbox *m);
 
   /**
    * mbox_open - Open a Mailbox
@@ -399,7 +399,7 @@ struct Account *mx_ac_find     (struct Mailbox *m);
 struct Mailbox *mx_mbox_find   (struct Account *a, const char *path);
 struct Mailbox *mx_mbox_find2  (const char *path);
 bool            mx_mbox_ac_link(struct Mailbox *m);
-int             mx_ac_add      (struct Account *a, struct Mailbox *m);
+bool            mx_ac_add      (struct Account *a, struct Mailbox *m);
 int             mx_ac_remove   (struct Mailbox *m);
 
 int                 mx_access           (const char *path, int flags);

--- a/mx.h
+++ b/mx.h
@@ -159,13 +159,13 @@ struct MxOps
    * mbox_open_append - Open a Mailbox for appending
    * @param m     Mailbox to open
    * @param flags Flags, see #OpenMailboxFlags
-   * @retval  0 Success
-   * @retval -1 Failure
+   * @retval true Success
+   * @retval false Failure
    *
    * **Contract**
    * - @a m is not NULL
    */
-  int (*mbox_open_append)(struct Mailbox *m, OpenMailboxFlags flags);
+  bool (*mbox_open_append)(struct Mailbox *m, OpenMailboxFlags flags);
 
   /**
    * mbox_check - Check for new mail

--- a/mx.h
+++ b/mx.h
@@ -79,6 +79,17 @@ enum MxCheckReturns
 };
 
 /**
+ * enum MxCheckStatsReturns - Return values from mx_mbox_check_stats()
+ * @note This is a subset of MxCheckReturns.
+ */
+enum MxCheckStatsReturns
+{
+  MX_CHECK_STATS_ERROR = -1, ///< An error occurred
+  MX_CHECK_STATS_NO_CHANGE,  ///< No changes
+  MX_CHECK_STATS_NEW_MAIL,   ///< New mail received in Mailbox
+};
+
+/**
  * enum MxOpenReturns - Return values for mbox_open()
  */
 enum MxOpenReturns
@@ -181,14 +192,12 @@ struct MxOps
    * mbox_check_stats - Check the Mailbox statistics
    * @param m     Mailbox to check
    * @param flags Function flags
-   * @retval  0 Success, no new mail
-   * @retval >0 Success, number of new emails
-   * @retval -1 Failure
+   * @retval enum #MxCheckStatsReturns
    *
    * **Contract**
    * - @a m is not NULL
    */
-  int (*mbox_check_stats)(struct Mailbox *m, uint8_t flags);
+  enum MxCheckStatsReturns (*mbox_check_stats)(struct Mailbox *m, uint8_t flags);
 
   /**
    * mbox_sync - Save changes to the Mailbox
@@ -383,7 +392,7 @@ struct MxOps
 
 /* Wrappers for the Mailbox API, see MxOps */
 enum MxCheckReturns mx_mbox_check  (struct Mailbox *m);
-int             mx_mbox_check_stats(struct Mailbox *m, uint8_t flags);
+enum MxCheckStatsReturns mx_mbox_check_stats(struct Mailbox *m, uint8_t flags);
 int             mx_mbox_close      (struct Context **ptr);
 struct Context *mx_mbox_open       (struct Mailbox *m, OpenMailboxFlags flags);
 enum MxCheckReturns mx_mbox_sync       (struct Mailbox *m);

--- a/mx.h
+++ b/mx.h
@@ -66,7 +66,7 @@ typedef uint8_t MsgOpenFlags;      ///< Flags for mx_msg_open_new(), e.g. #MUTT_
 #define MUTT_SET_DRAFT    (1 << 1) ///< set the message draft flag
 
 /**
- * enum MxCheckReturns - Return values from mx_mbox_check() and mx_mbox_sync()
+ * enum MxCheckReturns - Return values from mx_mbox_check(), mx_mbox_sync(), and mx_mbox_close()
  */
 enum MxCheckReturns
 {
@@ -212,13 +212,12 @@ struct MxOps
   /**
    * mbox_close - Close a Mailbox
    * @param m Mailbox to close
-   * @retval  0 Success
-   * @retval -1 Failure
+   * @retval enum #MxCheckReturns
    *
    * **Contract**
    * - @a m is not NULL
    */
-  int (*mbox_close)      (struct Mailbox *m);
+  enum MxCheckReturns (*mbox_close)(struct Mailbox *m);
 
   /**
    * msg_open - Open an email message in a Mailbox
@@ -391,9 +390,9 @@ struct MxOps
 };
 
 /* Wrappers for the Mailbox API, see MxOps */
-enum MxCheckReturns mx_mbox_check  (struct Mailbox *m);
+enum MxCheckReturns      mx_mbox_check      (struct Mailbox *m);
 enum MxCheckStatsReturns mx_mbox_check_stats(struct Mailbox *m, uint8_t flags);
-int             mx_mbox_close      (struct Context **ptr);
+enum MxCheckReturns      mx_mbox_close      (struct Context **ptr);
 struct Context *mx_mbox_open       (struct Mailbox *m, OpenMailboxFlags flags);
 enum MxCheckReturns mx_mbox_sync       (struct Mailbox *m);
 int             mx_msg_close       (struct Mailbox *m, struct Message **msg);

--- a/mx.h
+++ b/mx.h
@@ -68,14 +68,14 @@ typedef uint8_t MsgOpenFlags;      ///< Flags for mx_msg_open_new(), e.g. #MUTT_
 /**
  * enum MxCheckReturns - Return values from mx_mbox_check(), mx_mbox_sync(), and mx_mbox_close()
  */
-enum MxCheckReturns
+enum MxStatus
 {
-  MX_CHECK_ERROR = -1, ///< An error occurred
-  MX_CHECK_NO_CHANGE,  ///< No changes
-  MX_CHECK_NEW_MAIL,   ///< New mail received in Mailbox
-  MX_CHECK_LOCKED,     ///< Couldn't lock the Mailbox
-  MX_CHECK_REOPENED,   ///< Mailbox was reopened
-  MX_CHECK_FLAGS,      ///< Nondestructive flags change (IMAP)
+  MX_STATUS_ERROR = -1, ///< An error occurred
+  MX_STATUS_OK,         ///< No changes
+  MX_STATUS_NEW_MAIL,   ///< New mail received in Mailbox
+  MX_STATUS_LOCKED,     ///< Couldn't lock the Mailbox
+  MX_STATUS_REOPENED,   ///< Mailbox was reopened
+  MX_STATUS_FLAGS,      ///< Nondestructive flags change (IMAP)
 };
 
 /**
@@ -170,43 +170,43 @@ struct MxOps
   /**
    * mbox_check - Check for new mail
    * @param m Mailbox
-   * @retval enum #MxCheckReturns
+   * @retval enum #MxStatus
    *
    * **Contract**
    * - @a m is not NULL
    */
-  enum MxCheckReturns (*mbox_check) (struct Mailbox *m);
+  enum MxStatus (*mbox_check) (struct Mailbox *m);
 
   /**
    * mbox_check_stats - Check the Mailbox statistics
    * @param m     Mailbox to check
    * @param flags Function flags
-   * @retval enum #MxCheckReturns
+   * @retval enum #MxStatus
    *
    * **Contract**
    * - @a m is not NULL
    */
-  enum MxCheckReturns (*mbox_check_stats)(struct Mailbox *m, uint8_t flags);
+  enum MxStatus (*mbox_check_stats)(struct Mailbox *m, uint8_t flags);
 
   /**
    * mbox_sync - Save changes to the Mailbox
    * @param m Mailbox to sync
-   * @retval enum #MxCheckReturns
+   * @retval enum #MxStatus
    *
    * **Contract**
    * - @a m is not NULL
    */
-  enum MxCheckReturns (*mbox_sync)(struct Mailbox *m);
+  enum MxStatus (*mbox_sync)(struct Mailbox *m);
 
   /**
    * mbox_close - Close a Mailbox
    * @param m Mailbox to close
-   * @retval enum #MxCheckReturns
+   * @retval enum #MxStatus
    *
    * **Contract**
    * - @a m is not NULL
    */
-  enum MxCheckReturns (*mbox_close)(struct Mailbox *m);
+  enum MxStatus (*mbox_close)(struct Mailbox *m);
 
   /**
    * msg_open - Open an email message in a Mailbox
@@ -379,11 +379,11 @@ struct MxOps
 };
 
 /* Wrappers for the Mailbox API, see MxOps */
-enum MxCheckReturns mx_mbox_check  (struct Mailbox *m);
-enum MxCheckReturns mx_mbox_check_stats(struct Mailbox *m, uint8_t flags);
-enum MxCheckReturns mx_mbox_close  (struct Context **ptr);
+enum MxStatus   mx_mbox_check      (struct Mailbox *m);
+enum MxStatus   mx_mbox_check_stats(struct Mailbox *m, uint8_t flags);
+enum MxStatus   mx_mbox_close      (struct Context **ptr);
 struct Context *mx_mbox_open       (struct Mailbox *m, OpenMailboxFlags flags);
-enum MxCheckReturns mx_mbox_sync   (struct Mailbox *m);
+enum MxStatus   mx_mbox_sync       (struct Mailbox *m);
 int             mx_msg_close       (struct Mailbox *m, struct Message **msg);
 int             mx_msg_commit      (struct Mailbox *m, struct Message *msg);
 struct Message *mx_msg_open_new    (struct Mailbox *m, const struct Email *e, MsgOpenFlags flags);

--- a/mx.h
+++ b/mx.h
@@ -130,7 +130,7 @@ struct MxOps
    * - @a a    is not NULL
    * - @a path is not NULL
    */
-  bool (*ac_owns_path) (struct Account *a, const char *path);
+  bool (*ac_owns_path)(struct Account *a, const char *path);
 
   /**
    * ac_add - Add a Mailbox to an Account
@@ -143,7 +143,7 @@ struct MxOps
    * - @a a is not NULL
    * - @a m is not NULL
    */
-  bool (*ac_add) (struct Account *a, struct Mailbox *m);
+  bool (*ac_add)(struct Account *a, struct Mailbox *m);
 
   /**
    * mbox_open - Open a Mailbox
@@ -153,7 +153,7 @@ struct MxOps
    * **Contract**
    * - @a m is not NULL
    */
-  enum MxOpenReturns (*mbox_open)       (struct Mailbox *m);
+  enum MxOpenReturns (*mbox_open)(struct Mailbox *m);
 
   /**
    * mbox_open_append - Open a Mailbox for appending
@@ -175,7 +175,7 @@ struct MxOps
    * **Contract**
    * - @a m is not NULL
    */
-  enum MxStatus (*mbox_check) (struct Mailbox *m);
+  enum MxStatus (*mbox_check)(struct Mailbox *m);
 
   /**
    * mbox_check_stats - Check the Mailbox statistics
@@ -213,29 +213,29 @@ struct MxOps
    * @param m     Mailbox
    * @param msg   Message to open
    * @param msgno Index of message to open
-   * @retval  0 Success
-   * @retval -1 Error
+   * @retval true Success
+   * @retval false Error
    *
    * **Contract**
    * - @a m   is not NULL
    * - @a msg is not NULL
    * - 0 <= @a msgno < msg->msg_count
    */
-  int (*msg_open)        (struct Mailbox *m, struct Message *msg, int msgno);
+  bool (*msg_open)(struct Mailbox *m, struct Message *msg, int msgno);
 
   /**
    * msg_open_new - Open a new message in a Mailbox
    * @param m   Mailbox
    * @param msg Message to open
    * @param e   Email
-   * @retval  0 Success
-   * @retval -1 Failure
+   * @retval true Success
+   * @retval false Failure
    *
    * **Contract**
    * - @a m   is not NULL
    * - @a msg is not NULL
    */
-  int (*msg_open_new)    (struct Mailbox *m, struct Message *msg, const struct Email *e);
+  bool (*msg_open_new)(struct Mailbox *m, struct Message *msg, const struct Email *e);
 
   /**
    * msg_commit - Save changes to an email

--- a/mx.h
+++ b/mx.h
@@ -79,17 +79,6 @@ enum MxCheckReturns
 };
 
 /**
- * enum MxCheckStatsReturns - Return values from mx_mbox_check_stats()
- * @note This is a subset of MxCheckReturns.
- */
-enum MxCheckStatsReturns
-{
-  MX_CHECK_STATS_ERROR = -1, ///< An error occurred
-  MX_CHECK_STATS_NO_CHANGE,  ///< No changes
-  MX_CHECK_STATS_NEW_MAIL,   ///< New mail received in Mailbox
-};
-
-/**
  * enum MxOpenReturns - Return values for mbox_open()
  */
 enum MxOpenReturns
@@ -192,12 +181,12 @@ struct MxOps
    * mbox_check_stats - Check the Mailbox statistics
    * @param m     Mailbox to check
    * @param flags Function flags
-   * @retval enum #MxCheckStatsReturns
+   * @retval enum #MxCheckReturns
    *
    * **Contract**
    * - @a m is not NULL
    */
-  enum MxCheckStatsReturns (*mbox_check_stats)(struct Mailbox *m, uint8_t flags);
+  enum MxCheckReturns (*mbox_check_stats)(struct Mailbox *m, uint8_t flags);
 
   /**
    * mbox_sync - Save changes to the Mailbox
@@ -390,11 +379,11 @@ struct MxOps
 };
 
 /* Wrappers for the Mailbox API, see MxOps */
-enum MxCheckReturns      mx_mbox_check      (struct Mailbox *m);
-enum MxCheckStatsReturns mx_mbox_check_stats(struct Mailbox *m, uint8_t flags);
-enum MxCheckReturns      mx_mbox_close      (struct Context **ptr);
+enum MxCheckReturns mx_mbox_check  (struct Mailbox *m);
+enum MxCheckReturns mx_mbox_check_stats(struct Mailbox *m, uint8_t flags);
+enum MxCheckReturns mx_mbox_close  (struct Context **ptr);
 struct Context *mx_mbox_open       (struct Mailbox *m, OpenMailboxFlags flags);
-enum MxCheckReturns mx_mbox_sync       (struct Mailbox *m);
+enum MxCheckReturns mx_mbox_sync   (struct Mailbox *m);
 int             mx_msg_close       (struct Mailbox *m, struct Message **msg);
 int             mx_msg_commit      (struct Mailbox *m, struct Message *msg);
 struct Message *mx_msg_open_new    (struct Mailbox *m, const struct Email *e, MsgOpenFlags flags);

--- a/mx.h
+++ b/mx.h
@@ -66,7 +66,7 @@ typedef uint8_t MsgOpenFlags;      ///< Flags for mx_msg_open_new(), e.g. #MUTT_
 #define MUTT_SET_DRAFT    (1 << 1) ///< set the message draft flag
 
 /**
- * enum MxCheckReturns - Return values from mx_mbox_check()
+ * enum MxCheckReturns - Return values from mx_mbox_check() and mx_mbox_sync()
  */
 enum MxCheckReturns
 {
@@ -76,6 +76,16 @@ enum MxCheckReturns
   MX_CHECK_LOCKED,     ///< Couldn't lock the Mailbox
   MX_CHECK_REOPENED,   ///< Mailbox was reopened
   MX_CHECK_FLAGS,      ///< Nondestructive flags change (IMAP)
+};
+
+/**
+ * enum MxOpenReturns - Return values for mbox_open()
+ */
+enum MxOpenReturns
+{
+  MX_OPEN_OK,           ///< Open succeeded
+  MX_OPEN_ERROR,        ///< Open failed with an error
+  MX_OPEN_ABORT,        ///< Open was aborted
 };
 
 /**
@@ -138,14 +148,12 @@ struct MxOps
   /**
    * mbox_open - Open a Mailbox
    * @param m Mailbox to open
-   * @retval  0 Success
-   * @retval -1 Error
-   * @retval -2 Aborted
+   * @retval enum #MxOpenReturns
    *
    * **Contract**
    * - @a m is not NULL
    */
-  int (*mbox_open)       (struct Mailbox *m);
+  enum MxOpenReturns (*mbox_open)       (struct Mailbox *m);
 
   /**
    * mbox_open_append - Open a Mailbox for appending

--- a/mx.h
+++ b/mx.h
@@ -70,10 +70,12 @@ typedef uint8_t MsgOpenFlags;      ///< Flags for mx_msg_open_new(), e.g. #MUTT_
  */
 enum MxCheckReturns
 {
-  MUTT_NEW_MAIL = 1, ///< New mail received in Mailbox
-  MUTT_LOCKED,       ///< Couldn't lock the Mailbox
-  MUTT_REOPENED,     ///< Mailbox was reopened
-  MUTT_FLAGS,        ///< Nondestructive flags change (IMAP)
+  MX_CHECK_ERROR = -1, ///< An error occurred
+  MX_CHECK_NO_CHANGE,  ///< No changes
+  MX_CHECK_NEW_MAIL,   ///< New mail received in Mailbox
+  MX_CHECK_LOCKED,     ///< Couldn't lock the Mailbox
+  MX_CHECK_REOPENED,   ///< Mailbox was reopened
+  MX_CHECK_FLAGS,      ///< Nondestructive flags change (IMAP)
 };
 
 /**
@@ -159,14 +161,13 @@ struct MxOps
 
   /**
    * mbox_check - Check for new mail
-   * @param m          Mailbox
-   * @retval >0 Success, e.g. #MUTT_REOPENED
-   * @retval -1 Error
+   * @param m Mailbox
+   * @retval enum #MxCheckReturns
    *
    * **Contract**
    * - @a m is not NULL
    */
-  int (*mbox_check)      (struct Mailbox *m);
+  enum MxCheckReturns (*mbox_check) (struct Mailbox *m);
 
   /**
    * mbox_check_stats - Check the Mailbox statistics
@@ -183,14 +184,13 @@ struct MxOps
 
   /**
    * mbox_sync - Save changes to the Mailbox
-   * @param m          Mailbox to sync
-   * @retval  0 Success
-   * @retval -1 Failure
+   * @param m Mailbox to sync
+   * @retval enum #MxCheckReturns
    *
    * **Contract**
    * - @a m is not NULL
    */
-  int (*mbox_sync)       (struct Mailbox *m);
+  enum MxCheckReturns (*mbox_sync)(struct Mailbox *m);
 
   /**
    * mbox_close - Close a Mailbox
@@ -374,11 +374,11 @@ struct MxOps
 };
 
 /* Wrappers for the Mailbox API, see MxOps */
-int             mx_mbox_check      (struct Mailbox *m);
+enum MxCheckReturns mx_mbox_check  (struct Mailbox *m);
 int             mx_mbox_check_stats(struct Mailbox *m, uint8_t flags);
 int             mx_mbox_close      (struct Context **ptr);
 struct Context *mx_mbox_open       (struct Mailbox *m, OpenMailboxFlags flags);
-int             mx_mbox_sync       (struct Mailbox *m);
+enum MxCheckReturns mx_mbox_sync       (struct Mailbox *m);
 int             mx_msg_close       (struct Mailbox *m, struct Message **msg);
 int             mx_msg_commit      (struct Mailbox *m, struct Message *msg);
 struct Message *mx_msg_open_new    (struct Mailbox *m, const struct Email *e, MsgOpenFlags flags);

--- a/nntp/nntp.c
+++ b/nntp/nntp.c
@@ -2645,12 +2645,12 @@ static enum MxStatus nntp_mbox_close(struct Mailbox *m)
 /**
  * nntp_msg_open - Open an email message in a Mailbox - Implements MxOps::msg_open()
  */
-static int nntp_msg_open(struct Mailbox *m, struct Message *msg, int msgno)
+static bool nntp_msg_open(struct Mailbox *m, struct Message *msg, int msgno)
 {
   struct NntpMboxData *mdata = m->mdata;
   struct Email *e = m->emails[msgno];
   if (!e)
-    return -1;
+    return false;
 
   char article[16];
 
@@ -2662,7 +2662,7 @@ static int nntp_msg_open(struct Mailbox *m, struct Message *msg, int msgno)
     {
       msg->fp = mutt_file_fopen(acache->path, "r");
       if (msg->fp)
-        return 0;
+        return true;
     }
     /* clear previous entry */
     else
@@ -2676,14 +2676,14 @@ static int nntp_msg_open(struct Mailbox *m, struct Message *msg, int msgno)
   if (msg->fp)
   {
     if (nntp_edata_get(e)->parsed)
-      return 0;
+      return true;
   }
   else
   {
     char buf[PATH_MAX];
     /* don't try to fetch article from removed newsgroup */
     if (mdata->deleted)
-      return -1;
+      return false;
 
     /* create new cache file */
     const char *fetch_msg = _("Fetching message...");
@@ -2700,7 +2700,7 @@ static int nntp_msg_open(struct Mailbox *m, struct Message *msg, int msgno)
         mutt_perror(acache->path);
         unlink(acache->path);
         FREE(&acache->path);
-        return -1;
+        return false;
       }
     }
 
@@ -2727,7 +2727,7 @@ static int nntp_msg_open(struct Mailbox *m, struct Message *msg, int msgno)
         else
           mutt_error("ARTICLE: %s", buf);
       }
-      return -1;
+      return false;
     }
 
     if (!acache->path)
@@ -2767,7 +2767,7 @@ static int nntp_msg_open(struct Mailbox *m, struct Message *msg, int msgno)
 
   rewind(msg->fp);
   mutt_clear_error();
-  return 0;
+  return true;
 }
 
 /**

--- a/nntp/nntp.c
+++ b/nntp/nntp.c
@@ -2623,23 +2623,23 @@ static enum MxCheckReturns nntp_mbox_sync(struct Mailbox *m)
  * nntp_mbox_close - Close a Mailbox - Implements MxOps::mbox_close()
  * @retval 0 Always
  */
-static int nntp_mbox_close(struct Mailbox *m)
+static enum MxCheckReturns nntp_mbox_close(struct Mailbox *m)
 {
   struct NntpMboxData *mdata = m->mdata;
   struct NntpMboxData *tmp_mdata = NULL;
   if (!mdata)
-    return 0;
+    return MX_CHECK_NO_CHANGE;
 
   mdata->unread = m->msg_unread;
 
   nntp_acache_free(mdata);
   if (!mdata->adata || !mdata->adata->groups_hash || !mdata->group)
-    return 0;
+    return MX_CHECK_NO_CHANGE;
 
   tmp_mdata = mutt_hash_find(mdata->adata->groups_hash, mdata->group);
   if (!tmp_mdata || (tmp_mdata != mdata))
     nntp_mdata_free((void **) &mdata);
-  return 0;
+  return MX_CHECK_NO_CHANGE;
 }
 
 /**

--- a/nntp/nntp.c
+++ b/nntp/nntp.c
@@ -2381,9 +2381,9 @@ static bool nntp_ac_owns_path(struct Account *a, const char *path)
 /**
  * nntp_ac_add - Add a Mailbox to an Account - Implements MxOps::ac_add()
  */
-static int nntp_ac_add(struct Account *a, struct Mailbox *m)
+static bool nntp_ac_add(struct Account *a, struct Mailbox *m)
 {
-  return 0;
+  return true;
 }
 
 /**

--- a/nntp/nntp.c
+++ b/nntp/nntp.c
@@ -2386,10 +2386,10 @@ static bool nntp_ac_add(struct Account *a, struct Mailbox *m)
 /**
  * nntp_mbox_open - Open a Mailbox - Implements MxOps::mbox_open()
  */
-static int nntp_mbox_open(struct Mailbox *m)
+static enum MxOpenReturns nntp_mbox_open(struct Mailbox *m)
 {
   if (!m->account)
-    return -1;
+    return MX_OPEN_ERROR;
 
   char buf[8192];
   char server[1024];
@@ -2404,7 +2404,7 @@ static int nntp_mbox_open(struct Mailbox *m)
   {
     url_free(&url);
     mutt_error(_("%s is an invalid newsgroup specification"), mailbox_path(m));
-    return -1;
+    return MX_OPEN_ERROR;
   }
 
   group = url->path;
@@ -2426,7 +2426,7 @@ static int nntp_mbox_open(struct Mailbox *m)
   if (!adata)
   {
     url_free(&url);
-    return -1;
+    return MX_OPEN_ERROR;
   }
   CurrentNewsSrv = adata;
 
@@ -2444,7 +2444,7 @@ static int nntp_mbox_open(struct Mailbox *m)
     nntp_newsrc_close(adata);
     mutt_error(_("Newsgroup %s not found on the server"), group);
     url_free(&url);
-    return -1;
+    return MX_OPEN_ERROR;
   }
 
   m->rights &= ~MUTT_ACL_INSERT; // Clear the flag
@@ -2458,7 +2458,7 @@ static int nntp_mbox_open(struct Mailbox *m)
   if (nntp_query(mdata, buf, sizeof(buf)) < 0)
   {
     nntp_newsrc_close(adata);
-    return -1;
+    return MX_OPEN_ERROR;
   }
 
   /* newsgroup not found, remove it */
@@ -2486,7 +2486,7 @@ static int nntp_mbox_open(struct Mailbox *m)
     {
       nntp_newsrc_close(adata);
       mutt_error("GROUP: %s", buf);
-      return -1;
+      return MX_OPEN_ERROR;
     }
     mdata->first_message = first;
     mdata->last_message = last;
@@ -2498,7 +2498,7 @@ static int nntp_mbox_open(struct Mailbox *m)
       if (get_description(mdata, NULL, NULL) < 0)
       {
         nntp_newsrc_close(adata);
-        return -1;
+        return MX_OPEN_ERROR;
       }
       if (mdata->desc)
         nntp_active_save_cache(adata);
@@ -2535,10 +2535,10 @@ static int nntp_mbox_open(struct Mailbox *m)
   mutt_hcache_close(hc);
 #endif
   if (rc < 0)
-    return -1;
+    return MX_OPEN_ERROR;
   mdata->last_loaded = mdata->last_message;
   adata->newsrc_modified = false;
-  return 0;
+  return MX_OPEN_OK;
 }
 
 /**

--- a/notmuch/notmuch.c
+++ b/notmuch/notmuch.c
@@ -2205,34 +2205,34 @@ static bool nm_ac_add(struct Account *a, struct Mailbox *m)
 /**
  * nm_mbox_open - Open a Mailbox - Implements MxOps::mbox_open()
  */
-static int nm_mbox_open(struct Mailbox *m)
+static enum MxOpenReturns nm_mbox_open(struct Mailbox *m)
 {
   if (init_mailbox(m) != 0)
-    return -1;
+    return MX_OPEN_ERROR;
 
   struct NmMboxData *mdata = nm_mdata_get(m);
   if (!mdata)
-    return -1;
+    return MX_OPEN_ERROR;
 
   mutt_debug(LL_DEBUG1, "nm: reading messages...[current count=%d]\n", m->msg_count);
 
   progress_reset(m);
 
-  int rc = -1;
+  enum MxOpenReturns rc = MX_OPEN_ERROR;
 
   notmuch_query_t *q = get_query(m, false);
   if (q)
   {
-    rc = 0;
+    rc = MX_OPEN_OK;
     switch (mdata->query_type)
     {
       case NM_QUERY_TYPE_MESGS:
         if (!read_mesgs_query(m, q, false))
-          rc = -2;
+          rc = MX_OPEN_ABORT;
         break;
       case NM_QUERY_TYPE_THREADS:
         if (!read_threads_query(m, q, false, get_limit(mdata)))
-          rc = -2;
+          rc = MX_OPEN_ABORT;
         break;
     }
     notmuch_query_destroy(q);

--- a/notmuch/notmuch.c
+++ b/notmuch/notmuch.c
@@ -2190,16 +2190,16 @@ static bool nm_ac_owns_path(struct Account *a, const char *path)
 /**
  * nm_ac_add - Add a Mailbox to an Account - Implements MxOps::ac_add()
  */
-static int nm_ac_add(struct Account *a, struct Mailbox *m)
+static bool nm_ac_add(struct Account *a, struct Mailbox *m)
 {
   if (a->adata)
-    return 0;
+    return true;
 
   struct NmAccountData *adata = nm_adata_new();
   a->adata = adata;
   a->adata_free = nm_adata_free;
 
-  return 0;
+  return true;
 }
 
 /**

--- a/notmuch/notmuch.c
+++ b/notmuch/notmuch.c
@@ -2520,11 +2520,11 @@ static enum MxStatus nm_mbox_close(struct Mailbox *m)
 /**
  * nm_msg_open - Open an email message in a Mailbox - Implements MxOps::msg_open()
  */
-static int nm_msg_open(struct Mailbox *m, struct Message *msg, int msgno)
+static bool nm_msg_open(struct Mailbox *m, struct Message *msg, int msgno)
 {
   struct Email *e = m->emails[msgno];
   if (!e)
-    return -1;
+    return false;
 
   char path[PATH_MAX];
   char *folder = nm_email_get_folder(e);
@@ -2537,10 +2537,7 @@ static int nm_msg_open(struct Mailbox *m, struct Message *msg, int msgno)
     msg->fp = maildir_open_find_message(folder, e->path, NULL);
   }
 
-  if (!msg->fp)
-    return -1;
-
-  return 0;
+  return msg->fp != NULL;
 }
 
 /**

--- a/notmuch/notmuch.c
+++ b/notmuch/notmuch.c
@@ -2512,9 +2512,9 @@ static enum MxCheckReturns nm_mbox_sync(struct Mailbox *m)
  *
  * Nothing to do.
  */
-static int nm_mbox_close(struct Mailbox *m)
+static enum MxCheckReturns nm_mbox_close(struct Mailbox *m)
 {
-  return 0;
+  return MX_CHECK_NO_CHANGE;
 }
 
 /**

--- a/notmuch/notmuch.c
+++ b/notmuch/notmuch.c
@@ -1979,13 +1979,13 @@ int nm_update_filename(struct Mailbox *m, const char *old_file,
 /**
  * nm_mbox_check_stats - Check the Mailbox statistics - Implements MxOps::mbox_check_stats()
  */
-static enum MxCheckStatsReturns nm_mbox_check_stats(struct Mailbox *m, uint8_t flags)
+static enum MxCheckReturns nm_mbox_check_stats(struct Mailbox *m, uint8_t flags)
 {
   struct UrlQuery *item = NULL;
   struct Url *url = NULL;
   char *db_filename = NULL, *db_query = NULL;
   notmuch_database_t *db = NULL;
-  enum MxCheckStatsReturns rc = MX_CHECK_STATS_ERROR;
+  enum MxCheckReturns rc = MX_CHECK_ERROR;
   int limit = C_NmDbLimit;
   mutt_debug(LL_DEBUG1, "nm: count\n");
 
@@ -2052,7 +2052,7 @@ static enum MxCheckStatsReturns nm_mbox_check_stats(struct Mailbox *m, uint8_t f
   m->msg_flagged = count_query(db, qstr, limit);
   FREE(&qstr);
 
-  rc = (m->msg_new > 0) ? MX_CHECK_STATS_NEW_MAIL : MX_CHECK_STATS_NO_CHANGE;
+  rc = (m->msg_new > 0) ? MX_CHECK_NEW_MAIL : MX_CHECK_NO_CHANGE;
 done:
   if (db)
   {

--- a/notmuch/notmuch.c
+++ b/notmuch/notmuch.c
@@ -2251,19 +2251,15 @@ static int nm_mbox_open(struct Mailbox *m)
 
 /**
  * nm_mbox_check - Check for new mail - Implements MxOps::mbox_check()
- * @param m           Mailbox
- * @retval -1 Error
- * @retval  0 Success
- * @retval #MUTT_NEW_MAIL New mail has arrived
- * @retval #MUTT_REOPENED Mailbox closed and reopened
- * @retval #MUTT_FLAGS    Flags have changed
+ * @param m Mailbox
+ * @retval enum #MxCheckReturns
  */
-static int nm_mbox_check(struct Mailbox *m)
+static enum MxCheckReturns nm_mbox_check(struct Mailbox *m)
 {
   struct NmMboxData *mdata = nm_mdata_get(m);
   time_t mtime = 0;
   if (!mdata || (nm_db_get_mtime(m, &mtime) != 0))
-    return -1;
+    return MX_CHECK_ERROR;
 
   int new_flags = 0;
   bool occult = false;
@@ -2272,7 +2268,7 @@ static int nm_mbox_check(struct Mailbox *m)
   {
     mutt_debug(LL_DEBUG2, "nm: check unnecessary (db=%lu mailbox=%lu)\n", mtime,
                m->mtime.tv_sec);
-    return 0;
+    return MX_CHECK_NO_CHANGE;
   }
 
   mutt_debug(LL_DEBUG1, "nm: checking (db=%lu mailbox=%lu)\n", mtime, m->mtime.tv_sec);
@@ -2301,7 +2297,7 @@ static int nm_mbox_check(struct Mailbox *m)
   // TODO: Analyze impact of removing this version guard.
 #if LIBNOTMUCH_CHECK_VERSION(5, 0, 0)
   if (!msgs)
-    return false;
+    return MX_CHECK_NO_CHANGE;
 #elif LIBNOTMUCH_CHECK_VERSION(4, 3, 0)
   if (!msgs)
     goto done;
@@ -2381,22 +2377,25 @@ done:
   mutt_debug(LL_DEBUG1, "nm: ... check done [count=%d, new_flags=%d, occult=%d]\n",
              m->msg_count, new_flags, occult);
 
-  return occult                              ? MUTT_REOPENED :
-         (m->msg_count > mdata->oldmsgcount) ? MUTT_NEW_MAIL :
-         new_flags                           ? MUTT_FLAGS :
-                                               0;
+  if (occult)
+    return MX_CHECK_REOPENED;
+  if (m->msg_count > mdata->oldmsgcount)
+    return MX_CHECK_NEW_MAIL;
+  if (new_flags)
+    return MX_CHECK_FLAGS;
+  return MX_CHECK_NO_CHANGE;
 }
 
 /**
  * nm_mbox_sync - Save changes to the Mailbox - Implements MxOps::mbox_sync()
  */
-static int nm_mbox_sync(struct Mailbox *m)
+static enum MxCheckReturns nm_mbox_sync(struct Mailbox *m)
 {
   struct NmMboxData *mdata = nm_mdata_get(m);
   if (!mdata)
-    return -1;
+    return MX_CHECK_ERROR;
 
-  int rc = 0;
+  enum MxCheckReturns rc = MX_CHECK_NO_CHANGE;
   struct Progress progress;
   char *url = mutt_str_dup(mailbox_path(m));
   bool changed = false;
@@ -2440,11 +2439,11 @@ static int nm_mbox_sync(struct Mailbox *m)
 
     mutt_buffer_strcpy(&m->pathbuf, edata->folder);
     m->type = edata->type;
-    rc = maildir_sync_mailbox_message(m, i, h);
 
-    // Syncing file failed, query notmuch for new filepath.
-    if (rc)
+    bool ok = maildir_sync_mailbox_message(m, i, h);
+    if (!ok)
     {
+      // Syncing file failed, query notmuch for new filepath.
       notmuch_database_t *db = nm_db_get(m, true);
       if (db)
       {
@@ -2452,7 +2451,7 @@ static int nm_mbox_sync(struct Mailbox *m)
 
         sync_email_path_with_nm(e, msg);
 
-        rc = maildir_sync_mailbox_message(m, i, h);
+        ok = maildir_sync_mailbox_message(m, i, h);
       }
       nm_db_release(m);
     }
@@ -2460,9 +2459,10 @@ static int nm_mbox_sync(struct Mailbox *m)
     mutt_buffer_strcpy(&m->pathbuf, url);
     m->type = MUTT_NOTMUCH;
 
-    if (rc)
+    if (!ok)
     {
       mh_sync_errors += 1;
+      rc = MX_CHECK_ERROR;
       continue;
     }
 

--- a/notmuch/notmuch.c
+++ b/notmuch/notmuch.c
@@ -1979,13 +1979,13 @@ int nm_update_filename(struct Mailbox *m, const char *old_file,
 /**
  * nm_mbox_check_stats - Check the Mailbox statistics - Implements MxOps::mbox_check_stats()
  */
-static int nm_mbox_check_stats(struct Mailbox *m, uint8_t flags)
+static enum MxCheckStatsReturns nm_mbox_check_stats(struct Mailbox *m, uint8_t flags)
 {
   struct UrlQuery *item = NULL;
   struct Url *url = NULL;
   char *db_filename = NULL, *db_query = NULL;
   notmuch_database_t *db = NULL;
-  int rc = -1;
+  enum MxCheckStatsReturns rc = MX_CHECK_STATS_ERROR;
   int limit = C_NmDbLimit;
   mutt_debug(LL_DEBUG1, "nm: count\n");
 
@@ -2052,7 +2052,7 @@ static int nm_mbox_check_stats(struct Mailbox *m, uint8_t flags)
   m->msg_flagged = count_query(db, qstr, limit);
   FREE(&qstr);
 
-  rc = (m->msg_new > 0);
+  rc = (m->msg_new > 0) ? MX_CHECK_STATS_NEW_MAIL : MX_CHECK_STATS_NO_CHANGE;
 done:
   if (db)
   {

--- a/pager.c
+++ b/pager.c
@@ -2382,8 +2382,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
     {
       int oldcount = m->msg_count;
       /* check for new mail */
-      enum MxCheckReturns check = mx_mbox_check(m);
-      if (check == MX_CHECK_ERROR)
+      enum MxStatus check = mx_mbox_check(m);
+      if (check == MX_STATUS_ERROR)
       {
         if (!m || mutt_buffer_is_empty(&m->pathbuf))
         {
@@ -2393,11 +2393,11 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
           break;
         }
       }
-      else if ((check == MX_CHECK_NEW_MAIL) || (check == MX_CHECK_REOPENED) ||
-               (check == MX_CHECK_FLAGS))
+      else if ((check == MX_STATUS_NEW_MAIL) || (check == MX_STATUS_REOPENED) ||
+               (check == MX_STATUS_FLAGS))
       {
         /* notify user of newly arrived mail */
-        if (check == MX_CHECK_NEW_MAIL)
+        if (check == MX_STATUS_NEW_MAIL)
         {
           for (size_t i = oldcount; i < m->msg_count; i++)
           {
@@ -2412,7 +2412,7 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
           }
         }
 
-        if ((check == MX_CHECK_NEW_MAIL) || (check == MX_CHECK_REOPENED))
+        if ((check == MX_STATUS_NEW_MAIL) || (check == MX_STATUS_REOPENED))
         {
           if (rd.menu && m)
           {

--- a/pager.c
+++ b/pager.c
@@ -2382,8 +2382,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
     {
       int oldcount = m->msg_count;
       /* check for new mail */
-      int check = mx_mbox_check(m);
-      if (check < 0)
+      enum MxCheckReturns check = mx_mbox_check(m);
+      if (check == MX_CHECK_ERROR)
       {
         if (!m || mutt_buffer_is_empty(&m->pathbuf))
         {
@@ -2393,10 +2393,11 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
           break;
         }
       }
-      else if ((check == MUTT_NEW_MAIL) || (check == MUTT_REOPENED) || (check == MUTT_FLAGS))
+      else if ((check == MX_CHECK_NEW_MAIL) || (check == MX_CHECK_REOPENED) ||
+               (check == MX_CHECK_FLAGS))
       {
         /* notify user of newly arrived mail */
-        if (check == MUTT_NEW_MAIL)
+        if (check == MX_CHECK_NEW_MAIL)
         {
           for (size_t i = oldcount; i < m->msg_count; i++)
           {
@@ -2411,7 +2412,7 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
           }
         }
 
-        if ((check == MUTT_NEW_MAIL) || (check == MUTT_REOPENED))
+        if ((check == MX_CHECK_NEW_MAIL) || (check == MX_CHECK_REOPENED))
         {
           if (rd.menu && m)
           {

--- a/pop/pop.c
+++ b/pop/pop.c
@@ -756,10 +756,10 @@ static bool pop_ac_owns_path(struct Account *a, const char *path)
 /**
  * pop_ac_add - Add a Mailbox to an Account - Implements MxOps::ac_add()
  */
-static int pop_ac_add(struct Account *a, struct Mailbox *m)
+static bool pop_ac_add(struct Account *a, struct Mailbox *m)
 {
   if (a->adata)
-    return 0;
+    return true;
 
   struct ConnAccount cac = { { 0 } };
   struct PopAccountData *adata = pop_adata_new();
@@ -769,17 +769,17 @@ static int pop_ac_add(struct Account *a, struct Mailbox *m)
   if (pop_parse_path(mailbox_path(m), &cac))
   {
     mutt_error(_("%s is an invalid POP path"), mailbox_path(m));
-    return -1;
+    return false;
   }
 
   adata->conn = mutt_conn_new(&cac);
   if (!adata->conn)
   {
     pop_adata_free((void **) &adata);
-    return -1;
+    return false;
   }
 
-  return 0;
+  return true;
 }
 
 /**

--- a/pop/pop.c
+++ b/pop/pop.c
@@ -989,11 +989,11 @@ static enum MxCheckReturns pop_mbox_sync(struct Mailbox *m)
 /**
  * pop_mbox_close - Close a Mailbox - Implements MxOps::mbox_close()
  */
-static int pop_mbox_close(struct Mailbox *m)
+static enum MxCheckReturns pop_mbox_close(struct Mailbox *m)
 {
   struct PopAccountData *adata = pop_adata_get(m);
   if (!adata)
-    return 0;
+    return MX_CHECK_NO_CHANGE;
 
   pop_logout(m);
 
@@ -1010,7 +1010,7 @@ static int pop_mbox_close(struct Mailbox *m)
 
   mutt_bcache_close(&adata->bcache);
 
-  return 0;
+  return MX_CHECK_NO_CHANGE;
 }
 
 /**

--- a/pop/pop.c
+++ b/pop/pop.c
@@ -1016,7 +1016,7 @@ static enum MxStatus pop_mbox_close(struct Mailbox *m)
 /**
  * pop_msg_open - Open an email message in a Mailbox - Implements MxOps::msg_open()
  */
-static int pop_msg_open(struct Mailbox *m, struct Message *msg, int msgno)
+static bool pop_msg_open(struct Mailbox *m, struct Message *msg, int msgno)
 {
   char buf[1024];
   struct Progress progress;
@@ -1024,13 +1024,13 @@ static int pop_msg_open(struct Mailbox *m, struct Message *msg, int msgno)
   struct Email *e = m->emails[msgno];
   struct PopEmailData *edata = pop_edata_get(e);
   bool bcache = true;
-  int rc = -1;
+  bool success = false;
   struct Buffer *path = NULL;
 
   /* see if we already have the message in body cache */
   msg->fp = mutt_bcache_get(adata->bcache, cache_id(edata->uid));
   if (msg->fp)
-    return 0;
+    return true;
 
   /* see if we already have the message in our cache in
    * case $message_cachedir is unset */
@@ -1043,10 +1043,10 @@ static int pop_msg_open(struct Mailbox *m, struct Message *msg, int msgno)
       /* yes, so just return a pointer to the message */
       msg->fp = fopen(cache->path, "r");
       if (msg->fp)
-        return 0;
+        return true;
 
       mutt_perror(cache->path);
-      return -1;
+      return false;
     }
     else
     {
@@ -1161,11 +1161,11 @@ static int pop_msg_open(struct Mailbox *m, struct Message *msg, int msgno)
   mutt_clear_error();
   rewind(msg->fp);
 
-  rc = 0;
+  success = true;
 
 cleanup:
   mutt_buffer_pool_release(&path);
-  return rc;
+  return success;
 }
 
 /**

--- a/pop/pop.c
+++ b/pop/pop.c
@@ -787,10 +787,10 @@ static bool pop_ac_add(struct Account *a, struct Mailbox *m)
  *
  * Fetch only headers
  */
-static int pop_mbox_open(struct Mailbox *m)
+static enum MxOpenReturns pop_mbox_open(struct Mailbox *m)
 {
   if (!m->account)
-    return -1;
+    return MX_OPEN_ERROR;
 
   char buf[PATH_MAX];
   struct ConnAccount cac = { { 0 } };
@@ -799,7 +799,7 @@ static int pop_mbox_open(struct Mailbox *m)
   if (pop_parse_path(mailbox_path(m), &cac))
   {
     mutt_error(_("%s is an invalid POP path"), mailbox_path(m));
-    return -1;
+    return MX_OPEN_ERROR;
   }
 
   mutt_account_tourl(&cac, &url);
@@ -823,14 +823,14 @@ static int pop_mbox_open(struct Mailbox *m)
     adata->conn = mutt_conn_new(&cac);
     conn = adata->conn;
     if (!conn)
-      return -1;
+      return MX_OPEN_ERROR;
   }
 
   if (conn->fd < 0)
     mutt_account_hook(m->realpath);
 
   if (pop_open_connection(adata) < 0)
-    return -1;
+    return MX_OPEN_ERROR;
 
   adata->bcache = mutt_bcache_open(&cac, NULL);
 
@@ -845,7 +845,7 @@ static int pop_mbox_open(struct Mailbox *m)
   while (true)
   {
     if (pop_reconnect(m) < 0)
-      return -1;
+      return MX_OPEN_ERROR;
 
     m->size = adata->size;
 
@@ -854,10 +854,10 @@ static int pop_mbox_open(struct Mailbox *m)
     const int rc = pop_fetch_headers(m);
 
     if (rc >= 0)
-      return 0;
+      return MX_OPEN_OK;
 
     if (rc < -1)
-      return -1;
+      return MX_OPEN_ERROR;
   }
 }
 

--- a/postpone.c
+++ b/postpone.c
@@ -304,6 +304,21 @@ static struct Email *dlg_select_postponed_email(struct Context *ctx)
 }
 
 /**
+ * hardclose - try hard to close a mailbox
+ * @param pctx Context to close
+ */
+static void hardclose(struct Context **pctx)
+{
+  /* messages might have been marked for deletion.
+   * try once more on reopen before giving up. */
+  enum MxCheckReturns rc = mx_mbox_close(pctx);
+  if (rc != MX_CHECK_ERROR && rc != MX_CHECK_NO_CHANGE)
+    rc = mx_mbox_close(pctx);
+  if (rc != MX_CHECK_NO_CHANGE)
+    mx_fastclose_mailbox((*pctx)->mailbox);
+}
+
+/**
  * mutt_get_postponed - Recall a postponed message
  * @param[in]  ctx     Context info, used when recalling a message to which we reply
  * @param[in]  hdr     envelope/attachment info for recalled message
@@ -321,7 +336,6 @@ int mutt_get_postponed(struct Context *ctx, struct Email *hdr,
 
   struct Email *e = NULL;
   int rc = SEND_POSTPONED;
-  int rc_close;
   const char *p = NULL;
   struct Context *ctx_post = NULL;
 
@@ -370,16 +384,12 @@ int mutt_get_postponed(struct Context *ctx, struct Email *hdr,
   else if (!(e = dlg_select_postponed_email(ctx_post)))
   {
     if (ctx_post == ctx)
+    {
       ctx_post = NULL;
+    }
     else
     {
-      /* messages might have been marked for deletion.
-       * try once more on reopen before giving up. */
-      rc_close = mx_mbox_close(&ctx_post);
-      if (rc_close > 0)
-        rc_close = mx_mbox_close(&ctx_post);
-      if (rc_close != 0)
-        mx_fastclose_mailbox(ctx_post->mailbox);
+      hardclose(&ctx_post);
     }
     return -1;
   }
@@ -405,14 +415,12 @@ int mutt_get_postponed(struct Context *ctx, struct Email *hdr,
   int opt_delete = C_Delete;
   C_Delete = MUTT_YES;
   if (ctx_post == ctx)
+  {
     ctx_post = NULL;
+  }
   else
   {
-    rc_close = mx_mbox_close(&ctx_post);
-    if (rc_close > 0)
-      rc_close = mx_mbox_close(&ctx_post);
-    if (rc_close != 0)
-      mx_fastclose_mailbox(ctx_post->mailbox);
+    hardclose(&ctx_post);
   }
   C_Delete = opt_delete;
 

--- a/postpone.c
+++ b/postpone.c
@@ -311,10 +311,10 @@ static void hardclose(struct Context **pctx)
 {
   /* messages might have been marked for deletion.
    * try once more on reopen before giving up. */
-  enum MxCheckReturns rc = mx_mbox_close(pctx);
-  if (rc != MX_CHECK_ERROR && rc != MX_CHECK_NO_CHANGE)
+  enum MxStatus rc = mx_mbox_close(pctx);
+  if (rc != MX_STATUS_ERROR && rc != MX_STATUS_OK)
     rc = mx_mbox_close(pctx);
-  if (rc != MX_CHECK_NO_CHANGE)
+  if (rc != MX_STATUS_OK)
     mx_fastclose_mailbox((*pctx)->mailbox);
 }
 


### PR DESCRIPTION
Small API tidying.

The structure `MxOps` in mx.h defines the interface that mailbox backends such as mbox, maildir, or IMAP implement. The scope of this PR is to review and clean up this API, e.g.,
* functions returning `int` with values `0` (success) and `-1` (failure) can be changed to return `bool`
* functions returning `int` with values `0` (something), `1` (something else), `2` (something different) can be changed to return an `enum`