### PR TITLE
Do not crash on return from shell-exec if there's no open mailbox

### DIFF
--- a/browser.c
+++ b/browser.c
@@ -839,7 +839,7 @@ static int examine_mailboxes(struct Menu *menu, struct BrowserState *state)
       return -1;
     mailbox = mutt_buffer_pool_get();
     md = mutt_buffer_pool_get();
-    mutt_mailbox_check(Context ? Context->mailbox : NULL, 0);
+    mutt_mailbox_check(ctx_mailbox(Context), 0);
 
     struct MailboxList ml = STAILQ_HEAD_INITIALIZER(ml);
     neomutt_mailboxlist_get_all(&ml, NeoMutt, MUTT_MAILBOX_ANY);
@@ -1017,7 +1017,7 @@ static void init_menu(struct BrowserState *state, struct Menu *menu,
     {
       menu->is_mailbox_list = true;
       snprintf(title, titlelen, _("Mailboxes [%d]"),
-               mutt_mailbox_check(Context ? Context->mailbox : NULL, 0));
+               mutt_mailbox_check(ctx_mailbox(Context), 0));
     }
     else
     {

--- a/commands.c
+++ b/commands.c
@@ -1434,6 +1434,6 @@ bool mutt_check_traditional_pgp(struct EmailList *el, MuttRedrawFlags *redraw)
  */
 void mutt_check_stats(void)
 {
-  if (Context && Context->mailbox)
-    mutt_mailbox_check(Context->mailbox, MUTT_MAILBOX_CHECK_FORCE | MUTT_MAILBOX_CHECK_FORCE_STATS);
+  mutt_mailbox_check(ctx_mailbox(Context),
+                     MUTT_MAILBOX_CHECK_FORCE | MUTT_MAILBOX_CHECK_FORCE_STATS);
 }

--- a/commands.c
+++ b/commands.c
@@ -840,19 +840,25 @@ int mutt_select_sort(bool reverse)
 
 /**
  * mutt_shell_escape - invoke a command in a subshell
+ * @retval true A command was invoked (no matter what its result)
+ * @retval false No command was invoked
  */
-void mutt_shell_escape(void)
+bool mutt_shell_escape(void)
 {
   char buf[1024];
 
   buf[0] = '\0';
   if (mutt_get_field(_("Shell command: "), buf, sizeof(buf), MUTT_CMD) != 0)
-    return;
+  {
+    return false;
+  }
 
   if ((buf[0] == '\0') && C_Shell)
     mutt_str_copy(buf, C_Shell, sizeof(buf));
   if (buf[0] == '\0')
-    return;
+  {
+    return false;
+  }
 
   mutt_window_clearline(MessageWindow, 0);
   mutt_endwin();
@@ -863,7 +869,8 @@ void mutt_shell_escape(void)
 
   if ((rc != 0) || C_WaitKey)
     mutt_any_key_to_continue(NULL);
-  mutt_mailbox_check(Context->mailbox, MUTT_MAILBOX_CHECK_FORCE);
+
+  return true;
 }
 
 /**
@@ -1427,5 +1434,6 @@ bool mutt_check_traditional_pgp(struct EmailList *el, MuttRedrawFlags *redraw)
  */
 void mutt_check_stats(void)
 {
-  mutt_mailbox_check(Context->mailbox, MUTT_MAILBOX_CHECK_FORCE | MUTT_MAILBOX_CHECK_FORCE_STATS);
+  if (Context && Context->mailbox)
+    mutt_mailbox_check(Context->mailbox, MUTT_MAILBOX_CHECK_FORCE | MUTT_MAILBOX_CHECK_FORCE_STATS);
 }

--- a/commands.h
+++ b/commands.h
@@ -56,6 +56,6 @@ void mutt_print_message(struct Mailbox *m, struct EmailList *el);
 int  mutt_save_message_ctx(struct Email *e, bool delete_original, bool decode, bool decrypt, struct Mailbox *m);
 int  mutt_save_message(struct Mailbox *m, struct EmailList *el, bool delete_original, bool decode, bool decrypt);
 int  mutt_select_sort(bool reverse);
-void mutt_shell_escape(void);
+bool mutt_shell_escape(void);
 
 #endif /* MUTT_COMMANDS_H */

--- a/context.c
+++ b/context.c
@@ -418,3 +418,14 @@ bool ctx_has_limit(const struct Context *ctx)
 {
   return ctx && ctx->pattern;
 }
+
+/**
+ * ctx_mailbox - wrapper to get the mailbox in a Context, or NULL
+ * @param ctx Context
+ * @retval ptr The mailbox in the Context
+ * @retval NULL Context is NULL or doesn't have a mailbox
+ */
+struct Mailbox *ctx_mailbox(struct Context *ctx)
+{
+  return Context ? Context->mailbox : NULL;
+}

--- a/context.h
+++ b/context.h
@@ -75,6 +75,7 @@ int             ctx_mailbox_observer(struct NotifyCallback *nc);
 struct Context *ctx_new             (struct Mailbox *m);
 void            ctx_update          (struct Context *ctx);
 bool            ctx_has_limit       (const struct Context *ctx);
+struct Mailbox* ctx_mailbox         (struct Context *ctx);
 
 bool message_is_tagged (struct Context *ctx, struct Email *e);
 struct Email *mutt_get_virt_email(struct Mailbox *m, int vnum);

--- a/index.c
+++ b/index.c
@@ -3770,7 +3770,10 @@ int mutt_index_menu(struct MuttWindow *dlg)
       }
 
       case OP_SHELL_ESCAPE:
-        mutt_shell_escape();
+        if (mutt_shell_escape() && Context && Context->mailbox)
+        {
+          mutt_mailbox_check(Context->mailbox, MUTT_MAILBOX_CHECK_FORCE);
+        }
         break;
 
       case OP_TAG_THREAD:

--- a/index.c
+++ b/index.c
@@ -773,7 +773,8 @@ static void change_folder_mailbox(struct Menu *menu, struct Mailbox *m, int *old
   notify_send(dlg->notify, NT_MAILBOX, NT_MAILBOX_SWITCH, &em);
 
   mutt_clear_error();
-  mutt_mailbox_check(Context ? Context->mailbox : NULL, MUTT_MAILBOX_CHECK_FORCE); /* force the mailbox check after we have changed the folder */
+  /* force the mailbox check after we have changed the folder */
+  mutt_mailbox_check(ctx_mailbox(Context), MUTT_MAILBOX_CHECK_FORCE);
   menu->redraw = REDRAW_FULL;
   OptSearchInvalid = true;
 }
@@ -1180,7 +1181,7 @@ int mutt_index_menu(struct MuttWindow *dlg)
   if (!attach_msg)
   {
     /* force the mailbox check after we enter the folder */
-    mutt_mailbox_check(Context ? Context->mailbox : NULL, MUTT_MAILBOX_CHECK_FORCE);
+    mutt_mailbox_check(ctx_mailbox(Context), MUTT_MAILBOX_CHECK_FORCE);
   }
 #ifdef USE_INOTIFY
   mutt_monitor_add(NULL);
@@ -3770,9 +3771,9 @@ int mutt_index_menu(struct MuttWindow *dlg)
       }
 
       case OP_SHELL_ESCAPE:
-        if (mutt_shell_escape() && Context && Context->mailbox)
+        if (mutt_shell_escape())
         {
-          mutt_mailbox_check(Context->mailbox, MUTT_MAILBOX_CHECK_FORCE);
+          mutt_mailbox_check(ctx_mailbox(Context), MUTT_MAILBOX_CHECK_FORCE);
         }
         break;
 

--- a/main.c
+++ b/main.c
@@ -1128,7 +1128,7 @@ int main(int argc, char *argv[], char *envp[])
       bool passive = C_ImapPassive;
       C_ImapPassive = false;
 #endif
-      if (mutt_mailbox_check(Context ? Context->mailbox : NULL, 0) == 0)
+      if (mutt_mailbox_check(ctx_mailbox(Context), 0) == 0)
       {
         mutt_message(_("No mailbox with new mail"));
         goto main_curses; // TEST37: neomutt -Z (no new mail)

--- a/menu.c
+++ b/menu.c
@@ -1515,9 +1515,9 @@ int mutt_menu_loop(struct Menu *menu)
         break;
 
       case OP_SHELL_ESCAPE:
-        if (mutt_shell_escape() && Context && Context->mailbox)
+        if (mutt_shell_escape())
         {
-          mutt_mailbox_check(Context->mailbox, MUTT_MAILBOX_CHECK_FORCE);
+          mutt_mailbox_check(ctx_mailbox(Context), MUTT_MAILBOX_CHECK_FORCE);
         }
         break;
 

--- a/menu.c
+++ b/menu.c
@@ -43,6 +43,7 @@
 #include "keymap.h"
 #include "mutt_globals.h"
 #include "mutt_logging.h"
+#include "mutt_mailbox.h"
 #include "mutt_menu.h"
 #include "mutt_thread.h"
 #include "muttlib.h"
@@ -1514,7 +1515,10 @@ int mutt_menu_loop(struct Menu *menu)
         break;
 
       case OP_SHELL_ESCAPE:
-        mutt_shell_escape();
+        if (mutt_shell_escape() && Context && Context->mailbox)
+        {
+          mutt_mailbox_check(Context->mailbox, MUTT_MAILBOX_CHECK_FORCE);
+        }
         break;
 
       case OP_WHAT_KEY:

--- a/pager.c
+++ b/pager.c
@@ -3360,9 +3360,9 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
       }
 
       case OP_SHELL_ESCAPE:
-        if (mutt_shell_escape() && Context && Context->mailbox)
+        if (mutt_shell_escape())
         {
-          mutt_mailbox_check(Context->mailbox, MUTT_MAILBOX_CHECK_FORCE);
+          mutt_mailbox_check(ctx_mailbox(Context), MUTT_MAILBOX_CHECK_FORCE);
         }
         break;
 

--- a/pager.c
+++ b/pager.c
@@ -3360,7 +3360,10 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
       }
 
       case OP_SHELL_ESCAPE:
-        mutt_shell_escape();
+        if (mutt_shell_escape() && Context && Context->mailbox)
+        {
+          mutt_mailbox_check(Context->mailbox, MUTT_MAILBOX_CHECK_FORCE);
+        }
         break;
 
       case OP_TAG:


### PR DESCRIPTION
The simple fix would be to check for Context (and Context->mailbox)
inside mutt_shell_escape, but I really think mutt_mailbox_check belongs
at the caller's.

Fixes #2757
