### PR TITLE
Move attachment to top of attachment list in compose window

### DIFF
--- a/compose/compose.c
+++ b/compose/compose.c
@@ -1272,6 +1272,40 @@ static void compose_attach_swap(struct Body *msg, struct AttachPtr **idx, short 
 }
 
 /**
+ * compose_attach_move_top - Move an attachment to the top of the attachment list
+ * @param[in]  e   Email
+ * @param[out] idx Array of Attachments
+ * @param[in]  new Index of attachment to make the body of the email
+ */
+static void compose_attach_move_top(struct Email *e, struct AttachPtr **idx, short new)
+{
+  struct Body *saved_part = e->body;
+
+  /* Reorder Body pointers.
+   * Must traverse msg from top since Body has no previous ptr.  */
+  for (struct Body *part = e->body; part; part = part->next)
+  {
+    if (part->next == idx[new]->body)
+    {
+      part->next = idx[new]->body->next;
+      e->body = idx[new]->body;
+      e->body->next = saved_part;
+      break;
+    }
+  }
+
+  /* Reorder index and ptr->num */
+  struct AttachPtr *saved = idx[new];
+  for (short i = new; i > 0; i--)
+  {
+    idx[i] = idx[i - 1];
+    idx[i]->num += 1;
+  }
+  idx[0] = saved;
+  idx[0]->num = 0;
+}
+
+/**
  * cum_attachs_size - Cumulative Attachments Size
  * @param menu Menu listing attachments
  * @retval num Bytes in attachments

--- a/compose/compose.c
+++ b/compose/compose.c
@@ -1873,6 +1873,10 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur,
               actx->idx[j] = actx->idx[j + 1];
               actx->idx[j + 1] = NULL; /* for debug reason */
             }
+
+            if (i > 0)
+              actx->idx[i - 1]->body->next = actx->idx[i]->body;
+
             actx->idxlen--;
           }
           else
@@ -1892,6 +1896,10 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur,
         struct AttachPtr *gptr = mutt_mem_calloc(1, sizeof(struct AttachPtr));
         gptr->body = group;
         update_idx(menu, actx, gptr);
+
+        /* update e->body pointer */
+        e->body = actx->idx[0]->body;
+
         menu->redraw |= REDRAW_INDEX;
         break;
       }
@@ -1970,6 +1978,10 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur,
               actx->idx[j] = actx->idx[j + 1];
               actx->idx[j + 1] = NULL; /* for debug reason */
             }
+
+            if (i > 0)
+              actx->idx[i - 1]->body->next = actx->idx[i]->body;
+
             actx->idxlen--;
           }
           else
@@ -1989,6 +2001,10 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur,
         struct AttachPtr *gptr = mutt_mem_calloc(1, sizeof(struct AttachPtr));
         gptr->body = group;
         update_idx(menu, actx, gptr);
+
+        /* update e->body pointer */
+        e->body = actx->idx[0]->body;
+
         menu->redraw |= REDRAW_INDEX;
         break;
       }

--- a/compose/compose.c
+++ b/compose/compose.c
@@ -1853,6 +1853,17 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur,
         menu->current++;
         break;
 
+      case OP_COMPOSE_MOVE_TOP:
+        if (menu->current == 0)
+        {
+          mutt_error(_("Attachment is already at top"));
+          break;
+        }
+        compose_attach_move_top(e, actx->idx, menu->current);
+        menu->redraw |= REDRAW_INDEX;
+        menu->current = 0;
+        break;
+
       case OP_COMPOSE_GROUP_ALTS:
       {
         if (menu->tagged < 2)

--- a/compose/compose.c
+++ b/compose/compose.c
@@ -1825,10 +1825,12 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur,
         }
         if (menu->current == 1)
         {
-          mutt_error(_("The fundamental part can't be moved"));
-          break;
+          compose_attach_move_top(e, actx->idx, menu->current);
         }
-        compose_attach_swap(e->body, actx->idx, menu->current - 1);
+        else
+        {
+          compose_attach_swap(e->body, actx->idx, menu->current - 1);
+        }
         menu->redraw |= REDRAW_INDEX;
         menu->current--;
         break;
@@ -1841,10 +1843,12 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur,
         }
         if (menu->current == 0)
         {
-          mutt_error(_("The fundamental part can't be moved"));
-          break;
+          compose_attach_move_top(e, actx->idx, menu->current + 1);
         }
-        compose_attach_swap(e->body, actx->idx, menu->current);
+        else
+        {
+          compose_attach_swap(e->body, actx->idx, menu->current);
+        }
         menu->redraw |= REDRAW_INDEX;
         menu->current++;
         break;

--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -11170,9 +11170,9 @@ alternative_order text/enriched text/plain text application/postscript image/*
             <para>
               In the Compose menu, attach the two (or more) alternatives as
               usual. For example, attach "invitation.html" and then "invitation.txt".
-              (You can reorder them using the <literal>&lt;move-up&gt;</literal> (-)
-              and <literal>&lt;move-down&gt;</literal> (+) bindings, and edit the
-              descriptions).
+              (You can reorder them using the <literal>&lt;move-up&gt;</literal> (-),
+              <literal>&lt;move-down&gt;</literal> (+) and <literal>&lt;move-top&gt;</literal>
+              (_) bindings, and edit the descriptions).
             </para>
           </listitem>
           <listitem>

--- a/functions.c
+++ b/functions.c
@@ -499,6 +499,7 @@ const struct Binding OpCompose[] = { /* map: compose */
 #endif
   { "move-down",             OP_COMPOSE_MOVE_DOWN,           "+" },
   { "move-up",               OP_COMPOSE_MOVE_UP,             "-" },
+  { "move-top",              OP_COMPOSE_MOVE_TOP,            "_" },
   { "new-mime",              OP_COMPOSE_NEW_MIME,            "n" },
   { "pgp-menu",              OP_COMPOSE_PGP_MENU,            "p" },
   { "pipe-entry",            OP_PIPE,                        "|" },

--- a/opcodes.h
+++ b/opcodes.h
@@ -82,6 +82,7 @@
   _fmt(OP_COMPOSE_ISPELL,                 N_("run ispell on the message")) \
   _fmt(OP_COMPOSE_MOVE_DOWN,              N_("move an attachment down in the attachment list")) \
   _fmt(OP_COMPOSE_MOVE_UP,                N_("move an attachment up in the attachment list")) \
+  _fmt(OP_COMPOSE_MOVE_TOP,               N_("move an attachment to the top of the attachment list")) \
   _fmt(OP_COMPOSE_NEW_MIME,               N_("compose new attachment using mailcap entry")) \
   _fmt(OP_COMPOSE_POSTPONE_MESSAGE,       N_("save this message to send later")) \
   _fmt(OP_COMPOSE_RENAME_ATTACHMENT,      N_("send attachment with a different name")) \


### PR DESCRIPTION
* **What does this PR do?**

    This patch creates a new function `<move-top>` which allows any attachment to be moved to the top of the list of attachments in the compose window.

    The first commit is a pre-requisite bug fix which syncs the `e->body` and `actx->idx` attachment lists. These lists seem to get out of sync after grouping attachments (either alternatives or multilingual).

* **Does this PR meet the acceptance criteria?** (This is just a reminder for you,
  this section can be removed if you fulfill it.)

   - Documentation created/updated (you have to edit
     [doc/manual.xml.head](https://www.github.com/neomutt/neomutt/blob/master/doc/manual.xml.head)
     for that)

     Yes.

   - All builds and tests are passing

     I'm not sure how to do this.

   - Added [doxygen code documentation](https://neomutt.org/dev/doxygen)
     [syntax](http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html)

     I think so.

   - Code follows the [style guide](https://neomutt.org/dev/coding-style)

     I think so.

* **What are the relevant issue numbers?**

    This PR implements feature request #2387.