### PR TITLE
Make the location of /tmp configurable

### DIFF
--- a/auto.def
+++ b/auto.def
@@ -110,6 +110,7 @@ options {
   with-zstd:path            => "Location of Zstandard"
 # System
   with-sysroot:path         => "Target system root"
+  with-tmpdir:=/tmp         => "location of the tmp directory"
 # Misc
   include-path-in-cflags=1  => "Remove include paths from CFLAGS in the output of neomutt -v"
 # Testing
@@ -173,6 +174,7 @@ define MUTTLOCALEDIR    [get-define datadir]/locale
 define PKGDATADIR       [get-define datadir]/neomutt
 define PKGDOCDIR        [opt-val docdir [get-define datadir]/doc/neomutt]
 define SYSCONFDIR       [get-define sysconfdir]
+define TMPDIR           [opt-val with-tmpdir /tmp]
 ###############################################################################
 
 ###############################################################################
@@ -1268,6 +1270,7 @@ set auto_rep {
   SUN_ATTACHMENT
   SYSCONFDIR
   TEST_CASE_MAXSIZE
+  TMPDIR
   USE_*
   VPATH
   WORDS_BIGENDIAN

--- a/compmbox/compress.c
+++ b/compmbox/compress.c
@@ -152,7 +152,7 @@ static int setup_paths(struct Mailbox *m)
   /* Setup the right paths */
   mutt_str_replace(&m->realpath, mailbox_path(m));
 
-  /* We will uncompress to /tmp */
+  /* We will uncompress to TMPDIR */
   struct Buffer *buf = mutt_buffer_pool_get();
   mutt_buffer_mktemp(buf);
   mutt_buffer_copy(&m->pathbuf, buf);

--- a/conn/openssl.c
+++ b/conn/openssl.c
@@ -557,7 +557,7 @@ static int ssl_init(void)
     add_entropy(mutt_str_getenv("EGDSOCKET"));
     mutt_buffer_printf(path, "%s/.entropy", NONULL(HomeDir));
     add_entropy(mutt_b2s(path));
-    add_entropy("/tmp/entropy");
+    add_entropy(TMPDIR "/entropy");
 #endif
 
     /* shuffle $RANDFILE (or ~/.rnd if unset) */

--- a/docs/config.c
+++ b/docs/config.c
@@ -5091,7 +5091,7 @@
 ** A value of zero or less will cause NeoMutt to never time out.
 */
 
-{ "tmpdir", DT_PATH, "/tmp" },
+{ "tmpdir", DT_PATH, TMPDIR },
 /*
 ** .pp
 ** This variable allows you to specify where NeoMutt will place its

--- a/mutt_config.c
+++ b/mutt_config.c
@@ -702,7 +702,7 @@ struct ConfigDef MainVars[] = {
   { "timeout", DT_NUMBER|DT_NOT_NEGATIVE, &C_Timeout, 600, 0, NULL,
     "Time to wait for user input in menus"
   },
-  { "tmpdir", DT_PATH|DT_PATH_DIR|DT_NOT_EMPTY, &C_Tmpdir, IP "/tmp", 0, NULL,
+  { "tmpdir", DT_PATH|DT_PATH_DIR|DT_NOT_EMPTY, &C_Tmpdir, IP TMPDIR, 0, NULL,
     "Directory for temporary files"
   },
   { "toggle_quoted_show_levels", DT_NUMBER|DT_NOT_NEGATIVE, &C_ToggleQuotedShowLevels, 0, 0, NULL,

--- a/test/file/mutt_file_mkstemp_full.c
+++ b/test/file/mutt_file_mkstemp_full.c
@@ -29,7 +29,7 @@ void test_mutt_file_mkstemp_full(void)
 {
   // FILE *mutt_file_mkstemp_full(const char *file, int line, const char *func);
 
-  C_Tmpdir = "/tmp";
+  C_Tmpdir = TMPDIR;
 
   {
     FILE *fp = NULL;


### PR DESCRIPTION
Termux (Android) and Debian packagers would like to be able to configure the
/tmp location to somewhere else. Add a corresponding --with-tmpdir option.

The docs of neomutt (https://neomutt.org/dev/build/autosetup) say that if you set a default option eg `with-mailpath:=/var/mail   => "Location of the spool mailboxes"` you should be able to get the default by using `[opt-val with-mailpath]`. However at least on my machine that isn't actually working and I need to repeat the default argument there.