### PR TITLE
Improve composition of multipart messages

### DIFF
--- a/compose/compose.c
+++ b/compose/compose.c
@@ -515,6 +515,20 @@ static int delete_attachment(struct AttachCtx *actx, int x)
     return -1;
   }
 
+  if (idx[rindex]->parent_type == TYPE_MULTIPART)
+  {
+    mutt_error(_("You may not delete children of a multipart attachment"));
+    idx[rindex]->body->tagged = false;
+    return -1;
+  }
+
+  if (idx[rindex]->body->type == TYPE_MULTIPART)
+  {
+    mutt_error(_("You may not delete a multipart attachment"));
+    idx[rindex]->body->tagged = false;
+    return -1;
+  }
+
   for (int y = 0; y < actx->idxlen; y++)
   {
     if (idx[y]->body->next == idx[rindex]->body)
@@ -1262,6 +1276,7 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, uint8_t flags,
             }
 
             actx->idx[glastidx]->level = glevel + 1;
+            actx->idx[glastidx]->parent_type = TYPE_MULTIPART;
           }
         }
 

--- a/compose/compose.c
+++ b/compose/compose.c
@@ -577,21 +577,16 @@ static void gen_attach_list(struct AttachCtx *actx, struct Body *m, int parent_t
 {
   for (; m; m = m->next)
   {
+    struct AttachPtr *ap = mutt_mem_calloc(1, sizeof(struct AttachPtr));
+    mutt_actx_add_attach(actx, ap);
+    ap->body = m;
+    m->aptr = ap;
+    ap->parent_type = parent_type;
+    ap->level = level;
     if ((m->type == TYPE_MULTIPART) && m->parts &&
         (!(WithCrypto & APPLICATION_PGP) || !mutt_is_multipart_encrypted(m)))
     {
-      gen_attach_list(actx, m->parts, m->type, level);
-    }
-    else
-    {
-      struct AttachPtr *ap = mutt_mem_calloc(1, sizeof(struct AttachPtr));
-      mutt_actx_add_attach(actx, ap);
-      ap->body = m;
-      m->aptr = ap;
-      ap->parent_type = parent_type;
-      ap->level = level;
-
-      /* We don't support multipart messages in the compose menu yet */
+      gen_attach_list(actx, m->parts, m->type, level + 1);
     }
   }
 }

--- a/compose/compose.c
+++ b/compose/compose.c
@@ -692,10 +692,14 @@ static void compose_attach_swap(struct Body *msg, struct AttachCtx *actx,
     while (idx[i]->level > idx[first]->level)
     {
       savedptr = idx[i];
-      idx[i] = idx[i - 1];
-      idx[i]->num = i;
-      idx[i - 1] = savedptr;
-      idx[i - 1]->num = i - 1;
+      int destidx = i - second + first;
+      for (int j = i; j > destidx; j--)
+      {
+        idx[j] = idx[j - 1];
+        idx[j]->num = j;
+      }
+      idx[destidx] = savedptr;
+      idx[destidx]->num = destidx;
       i++;
       if (i >= actx->idxlen)
         break;
@@ -1128,7 +1132,7 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, uint8_t flags,
           break;
         }
         /* If next attachment is multipart find final position */
-        short finalidx = index + 1;
+        short finalidx = nextidx;
         if (actx->idx[finalidx]->body->type == TYPE_MULTIPART)
         {
           finalidx++;
@@ -1139,6 +1143,10 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, uint8_t flags,
               break;
           }
           finalidx--;
+        }
+        else
+        {
+          finalidx = menu->current + 1;
         }
         compose_attach_swap(e->body, actx, index, nextidx);
         mutt_update_tree(actx);

--- a/compose/compose.c
+++ b/compose/compose.c
@@ -989,7 +989,10 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, uint8_t flags,
         char *err = NULL;
         mutt_env_to_local(e->env);
         const char *const c_editor = cs_subset_string(sub, "editor");
-        mutt_edit_headers(NONULL(c_editor), e->body->filename, e, fcc);
+        if (e->body->type == TYPE_MULTIPART)
+          mutt_edit_headers(NONULL(c_editor), e->body->parts->filename, e, fcc);
+        else
+          mutt_edit_headers(NONULL(c_editor), e->body->filename, e, fcc);
         if (mutt_env_to_intl(e->env, &tag, &err))
         {
           mutt_error(_("Bad IDN in '%s': '%s'"), tag, err);

--- a/compose/compose.c
+++ b/compose/compose.c
@@ -1128,6 +1128,36 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, uint8_t flags,
           break;
         }
 
+        /* All tagged attachments must be at top level and can't have children */
+        bool taggedtoplevel = true;
+        bool taggednochildren = true;
+        for (int i = 0; i < actx->idxlen; i++)
+        {
+          if (actx->idx[i]->body->tagged)
+          {
+            if (actx->idx[i]->level > 0)
+            {
+              taggedtoplevel = false;
+              break;
+            }
+            if (actx->idx[i]->body->type == TYPE_MULTIPART)
+            {
+              taggednochildren = false;
+              break;
+            }
+          }
+        }
+        if (!taggedtoplevel)
+        {
+          mutt_error(_("Attachments to be grouped must be at top level"));
+          break;
+        }
+        if (!taggednochildren)
+        {
+          mutt_error(_("Attachments to be grouped can not be multipart"));
+          break;
+        }
+
         struct Body *group = mutt_body_new();
         group->type = TYPE_MULTIPART;
         group->subtype = mutt_str_dup("alternative");

--- a/email/attach.c
+++ b/email/attach.c
@@ -42,6 +42,23 @@ void mutt_actx_add_attach(struct AttachCtx *actx, struct AttachPtr *attach)
   if (!actx || !attach)
     return;
 
+  mutt_actx_ins_attach(actx, attach, actx->idxlen);
+}
+
+/**
+ * mutt_actx_ins_attach - Insert an Attachment into an Attachment Context at Specified Index
+ * @param actx   Attachment context
+ * @param attach Attachment to insert
+ * @param aidx   Index to insert attachment at
+ */
+void mutt_actx_ins_attach(struct AttachCtx *actx, struct AttachPtr *attach, short aidx)
+{
+  if (!actx || !attach)
+    return;
+
+  if (aidx < 0 || aidx > actx->idxmax)
+    return;
+
   if (actx->idxlen == actx->idxmax)
   {
     actx->idxmax += 5;
@@ -51,7 +68,12 @@ void mutt_actx_add_attach(struct AttachCtx *actx, struct AttachPtr *attach)
       actx->idx[i] = NULL;
   }
 
-  actx->idx[actx->idxlen++] = attach;
+  actx->idxlen++;
+
+  for (short i = actx->idxlen - 1; i > aidx; i--)
+    actx->idx[i] = actx->idx[i - 1];
+
+  actx->idx[aidx] = attach;
 }
 
 /**

--- a/email/attach.h
+++ b/email/attach.h
@@ -68,6 +68,7 @@ struct AttachCtx
 };
 
 void              mutt_actx_add_attach  (struct AttachCtx *actx, struct AttachPtr *attach);
+void              mutt_actx_ins_attach  (struct AttachCtx *actx, struct AttachPtr *attach, short aidx);
 void              mutt_actx_add_body    (struct AttachCtx *actx, struct Body *new_body);
 void              mutt_actx_add_fp      (struct AttachCtx *actx, FILE *fp_new);
 void              mutt_actx_free        (struct AttachCtx **ptr);

--- a/functions.c
+++ b/functions.c
@@ -495,6 +495,7 @@ const struct Binding OpCompose[] = { /* map: compose */
   { "get-attachment",        OP_COMPOSE_GET_ATTACHMENT,      "G" },
   { "group-alternatives",    OP_COMPOSE_GROUP_ALTS,          "&" },
   { "group-multilingual",    OP_COMPOSE_GROUP_LINGUAL,       "^" },
+  { "ungroup-attachment",    OP_COMPOSE_UNGROUP_ATTACHMENT,  "#" },
   { "ispell",                OP_COMPOSE_ISPELL,              "i" },
 #ifdef MIXMASTER
   { "mix",                   OP_COMPOSE_MIX,                 "M" },

--- a/opcodes.h
+++ b/opcodes.h
@@ -80,6 +80,7 @@
   _fmt(OP_COMPOSE_GET_ATTACHMENT,         N_("get a temporary copy of an attachment")) \
   _fmt(OP_COMPOSE_GROUP_ALTS,             N_("group tagged attachments as 'multipart/alternative'")) \
   _fmt(OP_COMPOSE_GROUP_LINGUAL,          N_("group tagged attachments as 'multipart/multilingual'")) \
+  _fmt(OP_COMPOSE_UNGROUP_ATTACHMENT,     N_("ungroup 'multipart' attachment")) \
   _fmt(OP_COMPOSE_ISPELL,                 N_("run ispell on the message")) \
   _fmt(OP_COMPOSE_MOVE_DOWN,              N_("move an attachment down in the attachment list")) \
   _fmt(OP_COMPOSE_MOVE_UP,                N_("move an attachment up in the attachment list")) \

--- a/send/send.c
+++ b/send/send.c
@@ -1990,7 +1990,8 @@ static int postpone_message(struct Email *e_post, struct Email *e_cur,
     {
       if (mutt_autocrypt_set_sign_as_default_key(m, e_post))
       {
-        e_post->body = mutt_remove_multipart(e_post->body);
+        if (mutt_istr_equal(e_post->body->subtype, "mixed"))
+          e_post->body = mutt_remove_multipart(e_post->body);
         decode_descriptions(e_post->body);
         mutt_error(_("Error encrypting message. Check your crypt settings."));
         return -1;
@@ -2006,7 +2007,8 @@ static int postpone_message(struct Email *e_post, struct Email *e_cur,
       if (mutt_protect(m, e_post, pgpkeylist, true) == -1)
       {
         FREE(&pgpkeylist);
-        e_post->body = mutt_remove_multipart(e_post->body);
+        if (mutt_istr_equal(e_post->body->subtype, "mixed"))
+          e_post->body = mutt_remove_multipart(e_post->body);
         decode_descriptions(e_post->body);
         mutt_error(_("Error encrypting message. Check your crypt settings."));
         return -1;
@@ -2036,7 +2038,8 @@ static int postpone_message(struct Email *e_post, struct Email *e_cur,
       e_post->body = clear_content;
     }
     mutt_env_free(&e_post->body->mime_headers); /* protected headers */
-    e_post->body = mutt_remove_multipart(e_post->body);
+    if (mutt_istr_equal(e_post->body->subtype, "mixed"))
+      e_post->body = mutt_remove_multipart(e_post->body);
     decode_descriptions(e_post->body);
     mutt_unprepare_envelope(e_post->env);
     return -1;
@@ -2830,7 +2833,8 @@ int mutt_send_message(SendFlags flags, struct Email *e_templ, const char *tempfi
       if ((crypt_get_keys(m, e_templ, &pgpkeylist, 0) == -1) ||
           (mutt_protect(m, e_templ, pgpkeylist, false) == -1))
       {
-        e_templ->body = mutt_remove_multipart(e_templ->body);
+        if (mutt_istr_equal(e_templ->body->subtype, "mixed"))
+          e_templ->body = mutt_remove_multipart(e_templ->body);
 
         FREE(&pgpkeylist);
 
@@ -2881,12 +2885,14 @@ int mutt_send_message(SendFlags flags, struct Email *e_templ, const char *tempfi
       else if ((e_templ->security & SEC_SIGN) && (e_templ->body->type == TYPE_MULTIPART))
       {
         mutt_body_free(&e_templ->body->parts->next); /* destroy sig */
-        e_templ->body = mutt_remove_multipart(e_templ->body);
+        if (mutt_istr_equal(e_templ->body->subtype, "mixed"))
+          e_templ->body = mutt_remove_multipart(e_templ->body);
       }
 
       FREE(&pgpkeylist);
       mutt_env_free(&e_templ->body->mime_headers); /* protected headers */
-      e_templ->body = mutt_remove_multipart(e_templ->body);
+      if (mutt_istr_equal(e_templ->body->subtype, "mixed"))
+        e_templ->body = mutt_remove_multipart(e_templ->body);
       decode_descriptions(e_templ->body);
       mutt_unprepare_envelope(e_templ->env);
       FREE(&finalpath);


### PR DESCRIPTION
## Background

The present support for creating multipart emails is basic and suffers from functionality and usability problems. For example,

- Grouped attachments display as a single attachment which cannot be modified or ungrouped.
- Grouped attachments are appended to the list of attachments and can not be made the body of the email if other attachments have been added prior to grouping. See issue #2387.
- Grouping is lost if sending is aborted for any reason (e.g., crypt function fails or failed attachment check) or an email is postponed.

## Goals for this branch

The goal for this branch is to provide better support for both composing multipart/alternative and multipart/multilingual emails.

### Tasks:

- [x] `<group-attachment>` should place multipart/alternative group at position of first tagged attachment rather than end of attachment list.
- [x] Multipart/alternative attachments should display with correct tree structure.
- [x] Attachments (grouped and otherwise) should be able to be moved around in a natural way.
- [x] Support `<edit-message>` when the body of the email is a multipart/alternative attachment.
- [x] Support ungrouping of multipart attachments.
- [ ] Preserve grouping when postponing a message.
- [ ] Provide analogous support for multipart/multilingual attachments.
- [ ] Create tests.
- [ ] Amend documentation.

### Bugs and issues:

- [x] Trying to create a a nested group breaks the email.
- [x] New attachments to an email with a group at the end of the attachment list append to the group, not the top level.
- [x] Detaching parts of a group breaks the email.
- [x] Attachments are being dropped when postponing messages (regression in current code).
- [ ] Segfault when attempting to edit a grouped main body after postponing (regression in current code).

### Future plans:

- Allow attachments to be added to and removed from a group.
- Allow nested groups.
- Provide support for forwarding an email as message/rfc822.

## Questions for discussion

1. Should there be (or is there) a hook to update alternative parts when the first part of a group is edited with `<edit-message>`?
2. When/should a newly added attachment be added to an existing group?

    Current code always adds new attachments at the top level at the bottom of the list of attachments.

3. Should demoting an attachment from a group be allowed if this would result in a group with less than two parts?
4. Although not directly related, should moving the fundamental part be supported? This is somewhat analogous to moving the first part of a grouped attachment.
5. What should happen if you try and delete a multipart/alternative group?
    1. Require ungrouping first? ← Current behaviour of code
    2. Delete group and sub parts?
    3. Delete group and sub parts after asking for confirmation?