### PR TITLE
Ensure mutt_extract_token() never returns a NULL dest->data

### DIFF
--- a/init.c
+++ b/init.c
@@ -400,6 +400,12 @@ int mutt_extract_token(struct Buffer *dest, struct Buffer *tok, TokenFlags flags
   char qc = '\0'; /* quote char */
   char *pc = NULL;
 
+  /* Some callers used to rely on the (bad) assumption that dest->data would be
+   * non-NULL after calling this function.  Perhaps I've missed a few cases, or
+   * a future caller might make the same mistake.  */
+  if (!dest->data)
+    mutt_buffer_alloc(dest, 256);
+
   mutt_buffer_reset(dest);
 
   SKIPWS(tok->dptr);


### PR DESCRIPTION
**Upstream patch**
https://gist.github.com/flatcap/9d701d2ec21057dd77c6f685c56647c6#file-0005-ensure-mutt_extract_token-never-returns-a-null-dest-patch

**Upstream commit message**:
Commit e5a32a61 removed a 'mutt_buffer_addch (dest, 0)' at the end of
the function.  Most callers had been converted to use the buffer pool,
and the call was strange since buffers self-terminate.

However, this line covered up logic errors in some of the callers,
which assumed the buffer->data could not be NULL afterwards.

I will try to fix up callers with the logic errors in master.  This is
to fix the problem in stable, and also ensure future callers don't
make the same mistake.

