### PR TITLE
Eliminate `int flag`

### DIFF
--- a/address/address.c
+++ b/address/address.c
@@ -1365,7 +1365,7 @@ bool mutt_addr_to_local(struct Address *a)
     return false;
   }
 
-  char *local_mailbox = mutt_idna_intl_to_local(user, domain, 0);
+  char *local_mailbox = mutt_idna_intl_to_local(user, domain, MI_NO_FLAGS);
   FREE(&user);
   FREE(&domain);
 

--- a/address/group.c
+++ b/address/group.c
@@ -201,7 +201,7 @@ static void group_add_addrlist(struct Group *g, const struct AddressList *al)
  * @retval  0 Success
  * @retval -1 Error
  */
-static int group_add_regex(struct Group *g, const char *s, int flags, struct Buffer *err)
+static int group_add_regex(struct Group *g, const char *s, uint16_t flags, struct Buffer *err)
 {
   return mutt_regexlist_add(&g->rs, s, flags, err);
 }
@@ -273,7 +273,8 @@ int mutt_grouplist_remove_addrlist(struct GroupList *gl, struct AddressList *al)
  * @retval  0 Success
  * @retval -1 Error
  */
-int mutt_grouplist_add_regex(struct GroupList *gl, const char *s, int flags, struct Buffer *err)
+int mutt_grouplist_add_regex(struct GroupList *gl, const char *s,
+                             uint16_t flags, struct Buffer *err)
 {
   if (!gl || !s)
     return -1;

--- a/address/group.h
+++ b/address/group.h
@@ -26,6 +26,7 @@
 #define MUTT_GROUP_H
 
 #include <stdbool.h>
+#include <stdint.h>
 #include "mutt/lib.h"
 #include "address.h"
 
@@ -54,7 +55,7 @@ STAILQ_HEAD(GroupList, GroupNode);
 
 void mutt_grouplist_add            (struct GroupList *gl, struct Group *group);
 void mutt_grouplist_add_addrlist   (struct GroupList *gl, struct AddressList *a);
-int  mutt_grouplist_add_regex      (struct GroupList *gl, const char *s, int flags, struct Buffer *err);
+int  mutt_grouplist_add_regex      (struct GroupList *gl, const char *s, uint16_t flags, struct Buffer *err);
 void mutt_grouplist_clear          (struct GroupList *gl);
 void mutt_grouplist_destroy        (struct GroupList *gl);
 void mutt_grouplist_free           (void);

--- a/address/idna.c
+++ b/address/idna.c
@@ -113,7 +113,7 @@ static bool check_idn(char *domain)
  *
  * @note The caller must free output
  */
-int mutt_idna_to_ascii_lz(const char *input, char **output, int flags)
+int mutt_idna_to_ascii_lz(const char *input, char **output, uint8_t flags)
 {
   if (!input || !output)
     return 1;
@@ -144,7 +144,7 @@ int mutt_idna_to_ascii_lz(const char *input, char **output, int flags)
  *
  * @note The caller must free the returned string.
  */
-char *mutt_idna_intl_to_local(const char *user, const char *domain, int flags)
+char *mutt_idna_intl_to_local(const char *user, const char *domain, uint8_t flags)
 {
   char *mailbox = NULL;
   char *reversed_user = NULL, *reversed_domain = NULL;

--- a/address/idna.c
+++ b/address/idna.c
@@ -171,10 +171,10 @@ char *mutt_idna_intl_to_local(const char *user, const char *domain, int flags)
 #endif /* HAVE_LIBIDN */
 
   /* we don't want charset-hook effects, so we set flags to 0 */
-  if (mutt_ch_convert_string(&local_user, "utf-8", C_Charset, 0) != 0)
+  if (mutt_ch_convert_string(&local_user, "utf-8", C_Charset, MUTT_ICONV_NO_FLAGS) != 0)
     goto cleanup;
 
-  if (mutt_ch_convert_string(&local_domain, "utf-8", C_Charset, 0) != 0)
+  if (mutt_ch_convert_string(&local_domain, "utf-8", C_Charset, MUTT_ICONV_NO_FLAGS) != 0)
     goto cleanup;
 
   /* make sure that we can convert back and come out with the same
@@ -183,7 +183,7 @@ char *mutt_idna_intl_to_local(const char *user, const char *domain, int flags)
   {
     reversed_user = mutt_str_dup(local_user);
 
-    if (mutt_ch_convert_string(&reversed_user, C_Charset, "utf-8", 0) != 0)
+    if (mutt_ch_convert_string(&reversed_user, C_Charset, "utf-8", MUTT_ICONV_NO_FLAGS) != 0)
     {
       mutt_debug(LL_DEBUG1, "Not reversible. Charset conv to utf-8 failed for user = '%s'\n",
                  reversed_user);
@@ -199,7 +199,7 @@ char *mutt_idna_intl_to_local(const char *user, const char *domain, int flags)
 
     reversed_domain = mutt_str_dup(local_domain);
 
-    if (mutt_ch_convert_string(&reversed_domain, C_Charset, "utf-8", 0) != 0)
+    if (mutt_ch_convert_string(&reversed_domain, C_Charset, "utf-8", MUTT_ICONV_NO_FLAGS) != 0)
     {
       mutt_debug(LL_DEBUG1, "Not reversible. Charset conv to utf-8 failed for domain = '%s'\n",
                  reversed_domain);
@@ -271,10 +271,10 @@ char *mutt_idna_local_to_intl(const char *user, const char *domain)
   char *intl_domain = mutt_str_dup(domain);
 
   /* we don't want charset-hook effects, so we set flags to 0 */
-  if (mutt_ch_convert_string(&intl_user, C_Charset, "utf-8", 0) != 0)
+  if (mutt_ch_convert_string(&intl_user, C_Charset, "utf-8", MUTT_ICONV_NO_FLAGS) != 0)
     goto cleanup;
 
-  if (mutt_ch_convert_string(&intl_domain, C_Charset, "utf-8", 0) != 0)
+  if (mutt_ch_convert_string(&intl_domain, C_Charset, "utf-8", MUTT_ICONV_NO_FLAGS) != 0)
     goto cleanup;
 
 #ifdef HAVE_LIBIDN

--- a/address/idna2.h
+++ b/address/idna2.h
@@ -24,16 +24,18 @@
 #define MUTT_EMAIL_IDNA_H
 
 #include <stdbool.h>
+#include <stdint.h>
 
 /* These Config Variables are only used in mutt/idna.c */
 extern bool C_IdnDecode;
 extern bool C_IdnEncode;
 
+#define MI_NO_FLAGS                  0
 #define MI_MAY_BE_IRREVERSIBLE (1 << 0)
 
-char *      mutt_idna_intl_to_local(const char *user, const char *domain, int flags);
+char *      mutt_idna_intl_to_local(const char *user, const char *domain, uint8_t flags);
 char *      mutt_idna_local_to_intl(const char *user, const char *domain);
 const char *mutt_idna_print_version(void);
-int         mutt_idna_to_ascii_lz  (const char *input, char **output, int flags);
+int         mutt_idna_to_ascii_lz  (const char *input, char **output, uint8_t flags);
 
 #endif /* MUTT_EMAIL_IDNA_H */

--- a/alias/alias.c
+++ b/alias/alias.c
@@ -190,7 +190,7 @@ static void recode_buf(char *buf, size_t buflen)
   char *s = mutt_str_dup(buf);
   if (!s)
     return;
-  if (mutt_ch_convert_string(&s, C_Charset, C_ConfigCharset, 0) == 0)
+  if (mutt_ch_convert_string(&s, C_Charset, C_ConfigCharset, MUTT_ICONV_NO_FLAGS) == 0)
     mutt_str_copy(buf, s, buflen);
   FREE(&s);
 }

--- a/alias/dlgquery.c
+++ b/alias/dlgquery.c
@@ -261,8 +261,8 @@ static int query_run(char *s, bool verbose, struct AliasList *al,
 
   /* The query protocol first reads one NL-terminated line. If an error
    * occurs, this is assumed to be an error message. Otherwise it's ignored. */
-  msg = mutt_file_read_line(msg, &msglen, fp, NULL, 0);
-  while ((buf = mutt_file_read_line(buf, &buflen, fp, NULL, 0)))
+  msg = mutt_file_read_line(msg, &msglen, fp, NULL, MUTT_RL_NO_FLAGS);
+  while ((buf = mutt_file_read_line(buf, &buflen, fp, NULL, MUTT_RL_NO_FLAGS)))
   {
     p = strtok(buf, "\t\n");
     if (p)

--- a/command_parse.c
+++ b/command_parse.c
@@ -487,7 +487,7 @@ int source_rc(const char *rcfile_path, struct Buffer *err)
       currentline = mutt_str_dup(line);
       if (!currentline)
         continue;
-      mutt_ch_convert_string(&currentline, C_ConfigCharset, C_Charset, 0);
+      mutt_ch_convert_string(&currentline, C_ConfigCharset, C_Charset, MUTT_ICONV_NO_FLAGS);
     }
     else
       currentline = line;

--- a/command_parse.c
+++ b/command_parse.c
@@ -479,7 +479,7 @@ int source_rc(const char *rcfile_path, struct Buffer *err)
   token = mutt_buffer_pool_get();
   linebuf = mutt_buffer_pool_get();
 
-  while ((line = mutt_file_read_line(line, &linelen, fp, &lineno, MUTT_CONT)) != NULL)
+  while ((line = mutt_file_read_line(line, &linelen, fp, &lineno, MUTT_RL_CONT)) != NULL)
   {
     const bool conv = C_ConfigCharset && C_Charset;
     if (conv)

--- a/compose/compose.c
+++ b/compose/compose.c
@@ -1469,7 +1469,7 @@ static int compose_header_observer(struct NotifyCallback *nc)
  * @retval -1 Abort message
  */
 int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur,
-                      int flags, struct ConfigSubset *sub)
+                      uint8_t flags, struct ConfigSubset *sub)
 {
   char buf[PATH_MAX];
   int rc = -1;

--- a/compose/lib.h
+++ b/compose/lib.h
@@ -34,13 +34,15 @@
 #ifndef MUTT_COMPOSE_LIB_H
 #define MUTT_COMPOSE_LIB_H
 
+#include <stdint.h>
+
 struct Buffer;
 struct Email;
 
 /* flags for mutt_compose_menu() */
 #define MUTT_COMPOSE_NOFREEHEADER (1 << 0)
 
-int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur, int flags, struct ConfigSubset *sub);
+int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur, uint8_t flags, struct ConfigSubset *sub);
 
 bool config_init_compose(struct ConfigSet *);
 

--- a/config/regex.c
+++ b/config/regex.c
@@ -77,7 +77,7 @@ static void regex_destroy(const struct ConfigSet *cs, void *var, const struct Co
  * @retval ptr New Regex object
  * @retval NULL Error
  */
-struct Regex *regex_new(const char *str, int flags, struct Buffer *err)
+struct Regex *regex_new(const char *str, uint32_t flags, struct Buffer *err)
 {
   if (!str)
     return NULL;
@@ -219,7 +219,7 @@ static int regex_native_set(const struct ConfigSet *cs, void *var,
 
   if (orig && orig->pattern)
   {
-    const int flags = orig->pat_not ? DT_REGEX_ALLOW_NOT : 0;
+    const uint32_t flags = orig->pat_not ? DT_REGEX_ALLOW_NOT : 0;
     r = regex_new(orig->pattern, flags, err);
     if (!r)
       rc = CSR_ERR_INVALID;

--- a/config/regex2.h
+++ b/config/regex2.h
@@ -23,6 +23,7 @@
 #ifndef MUTT_CONFIG_REGEX_H
 #define MUTT_CONFIG_REGEX_H
 
+#include <stdint.h>
 #include "mutt/regex3.h"
 
 struct Buffer;
@@ -30,6 +31,6 @@ struct ConfigSet;
 struct Regex;
 
 void          regex_free(struct Regex **regex);
-struct Regex *regex_new (const char *str, int flags, struct Buffer *err);
+struct Regex *regex_new (const char *str, uint32_t flags, struct Buffer *err);
 
 #endif /* MUTT_CONFIG_REGEX_H */

--- a/config/set.c
+++ b/config/set.c
@@ -283,7 +283,7 @@ bool cs_register_type(struct ConfigSet *cs, const struct ConfigSetType *cst)
  * @param flags Flags, e.g. #DT_NO_VARIABLE
  * @retval bool True, if all variables were registered successfully
  */
-bool cs_register_variables(const struct ConfigSet *cs, struct ConfigDef vars[], int flags)
+bool cs_register_variables(const struct ConfigSet *cs, struct ConfigDef vars[], uint32_t flags)
 {
   if (!cs || !vars)
     return false;

--- a/config/set.h
+++ b/config/set.h
@@ -61,7 +61,7 @@ struct HashElem;
 struct ConfigDef
 {
   const char   *name;      ///< User-visible name
-  unsigned int  type;      ///< Variable type, e.g. #DT_STRING
+  uint32_t      type;      ///< Variable type, e.g. #DT_STRING
   void         *var;       ///< Pointer to the global variable
   intptr_t      initial;   ///< Initial value
   intptr_t      data;      ///< Extra variable data
@@ -239,7 +239,7 @@ struct HashElem *           cs_get_elem    (const struct ConfigSet *cs, const ch
 const struct ConfigSetType *cs_get_type_def(const struct ConfigSet *cs, unsigned int type);
 
 bool             cs_register_type     (struct ConfigSet *cs, const struct ConfigSetType *cst);
-bool             cs_register_variables(const struct ConfigSet *cs, struct ConfigDef vars[], int flags);
+bool             cs_register_variables(const struct ConfigSet *cs, struct ConfigDef vars[], uint32_t flags);
 struct HashElem *cs_inherit_variable  (const struct ConfigSet *cs, struct HashElem *parent, const char *name);
 void             cs_uninherit_variable(const struct ConfigSet *cs, const char *name);
 

--- a/config/sort.c
+++ b/config/sort.c
@@ -48,7 +48,7 @@ static int sort_string_set(const struct ConfigSet *cs, void *var, struct ConfigD
                            const char *value, struct Buffer *err)
 {
   intptr_t id = -1;
-  int flags = 0;
+  uint16_t flags = 0;
 
   if (!value || (value[0] == '\0'))
   {

--- a/config/types.h
+++ b/config/types.h
@@ -80,7 +80,7 @@ typedef uint32_t ConfigRedrawFlags; ///< Flags for redraw/resort, e.g. #R_INDEX
 #define DT_INHERITED    (1 << 28)  ///< Config item is inherited
 #define DT_INITIAL_SET  (1 << 29)  ///< Config item must have its initial value freed
 #define DT_DISABLED     (1 << 30)  ///< Config item is disabled
-// #define DT_MY_CONFIG    (1 << 31)  ///< Config item is a "my_" variable
-#define DT_NO_VARIABLE  (1 << 31)  ///< Config item doesn't have a backing global variable
+// #define DT_MY_CONFIG    (1U << 31) ///< Config item is a "my_" variable
+#define DT_NO_VARIABLE  (1U << 31) ///< Config item doesn't have a backing global variable
 
 #endif /* MUTT_CONFIG_TYPES_H */

--- a/conn/connaccount.c
+++ b/conn/connaccount.c
@@ -184,7 +184,7 @@ char *mutt_account_getoauthbearer(struct ConnAccount *cac)
   }
 
   size_t token_size = 0;
-  char *token = mutt_file_read_line(NULL, &token_size, fp, NULL, 0);
+  char *token = mutt_file_read_line(NULL, &token_size, fp, NULL, MUTT_RL_NO_FLAGS);
   mutt_file_fclose(&fp);
   filter_wait(pid);
 

--- a/conn/gnutls.c
+++ b/conn/gnutls.c
@@ -198,7 +198,7 @@ static int tls_check_stored_hostname(const gnutls_datum_t *cert, const char *hos
   char buf[80];
   buf[0] = '\0';
   tls_fingerprint(GNUTLS_DIG_MD5, buf, sizeof(buf), cert);
-  while ((linestr = mutt_file_read_line(linestr, &linestrsize, fp, NULL, 0)))
+  while ((linestr = mutt_file_read_line(linestr, &linestrsize, fp, NULL, MUTT_RL_NO_FLAGS)))
   {
     regmatch_t *match = mutt_prex_capture(PREX_GNUTLS_CERT_HOST_HASH, linestr);
     if (match)

--- a/core/mailbox.h
+++ b/core/mailbox.h
@@ -131,7 +131,7 @@ struct Mailbox
   struct Account *account;            ///< Account that owns this Mailbox
   int opened;                         ///< Number of times mailbox is opened
 
-  int flags;                          ///< e.g. #MB_NORMAL
+  uint8_t flags;                      ///< e.g. #MB_NORMAL
 
   void *mdata;                        ///< Driver specific data
 

--- a/email/rfc2047.c
+++ b/email/rfc2047.c
@@ -191,7 +191,7 @@ static size_t try_block(const char *d, size_t dlen, const char *fromcode,
 
   if (fromcode)
   {
-    iconv_t cd = mutt_ch_iconv_open(tocode, fromcode, 0);
+    iconv_t cd = mutt_ch_iconv_open(tocode, fromcode, MUTT_ICONV_NO_FLAGS);
     assert(cd != (iconv_t)(-1));
     ib = d;
     ibl = dlen;
@@ -271,7 +271,7 @@ static size_t encode_block(char *str, char *buf, size_t buflen, const char *from
     return (*encoder)(str, buf, buflen, tocode);
   }
 
-  const iconv_t cd = mutt_ch_iconv_open(tocode, fromcode, 0);
+  const iconv_t cd = mutt_ch_iconv_open(tocode, fromcode, MUTT_ICONV_NO_FLAGS);
   assert(cd != (iconv_t)(-1));
   const char *ib = buf;
   size_t ibl = buflen;
@@ -428,7 +428,7 @@ static int encode(const char *d, size_t dlen, int col, const char *fromcode,
 
   /* Try to convert to UTF-8. */
   char *u = mutt_strn_dup(d, dlen);
-  if (mutt_ch_convert_string(&u, fromcode, icode, 0) != 0)
+  if (mutt_ch_convert_string(&u, fromcode, icode, MUTT_ICONV_NO_FLAGS) != 0)
   {
     rc = 1;
     icode = 0;

--- a/email/url.c
+++ b/email/url.c
@@ -350,7 +350,7 @@ err:
  * @retval  0 Success
  * @retval -1 Error
  */
-int url_tobuffer(struct Url *url, struct Buffer *buf, int flags)
+int url_tobuffer(struct Url *url, struct Buffer *buf, uint8_t flags)
 {
   if (!url || !buf)
     return -1;
@@ -415,7 +415,7 @@ int url_tobuffer(struct Url *url, struct Buffer *buf, int flags)
  * @retval  0 Success
  * @retval -1 Error
  */
-int url_tostring(struct Url *url, char *dest, size_t len, int flags)
+int url_tostring(struct Url *url, char *dest, size_t len, uint8_t flags)
 {
   if (!url || !dest)
     return -1;

--- a/email/url.h
+++ b/email/url.h
@@ -45,6 +45,7 @@ enum UrlScheme
   U_NOTMUCH, ///< Url is notmuch://
 };
 
+#define U_NO_FLAGS       0
 #define U_PATH          (1 << 1)
 
 /**
@@ -80,7 +81,7 @@ void           url_free        (struct Url **ptr);
 struct Url    *url_parse       (const char *src);
 int            url_pct_decode  (char *s);
 void           url_pct_encode  (char *buf, size_t buflen, const char *src);
-int            url_tobuffer    (struct Url *url, struct Buffer *dest, int flags);
-int            url_tostring    (struct Url *url, char *buf, size_t buflen, int flags);
+int            url_tobuffer    (struct Url *url, struct Buffer *dest, uint8_t flags);
+int            url_tostring    (struct Url *url, char *buf, size_t buflen, uint8_t flags);
 
 #endif /* MUTT_EMAIL_URL_H */

--- a/flags.c
+++ b/flags.c
@@ -51,7 +51,8 @@
  * @param bf       true: set the flag; false: clear the flag
  * @param upd_mbox true: update the Mailbox
  */
-void mutt_set_flag_update(struct Mailbox *m, struct Email *e, int flag, bool bf, bool upd_mbox)
+void mutt_set_flag_update(struct Mailbox *m, struct Email *e,
+                          enum MessageType flag, bool bf, bool upd_mbox)
 {
   if (!m || !e)
     return;
@@ -323,6 +324,9 @@ void mutt_set_flag_update(struct Mailbox *m, struct Email *e, int flag, bool bf,
           m->msg_tagged--;
       }
       break;
+
+    default:
+      break;
   }
 
   if (update)
@@ -347,7 +351,8 @@ void mutt_set_flag_update(struct Mailbox *m, struct Email *e, int flag, bool bf,
  * @param flag Flag to set, e.g. #MUTT_DELETE
  * @param bf   true: set the flag; false: clear the flag
  */
-void mutt_emails_set_flag(struct Mailbox *m, struct EmailList *el, int flag, bool bf)
+void mutt_emails_set_flag(struct Mailbox *m, struct EmailList *el,
+                          enum MessageType flag, bool bf)
 {
   if (!m || !el || STAILQ_EMPTY(el))
     return;
@@ -368,7 +373,7 @@ void mutt_emails_set_flag(struct Mailbox *m, struct EmailList *el, int flag, boo
  * @retval  0 Success
  * @retval -1 Failure
  */
-int mutt_thread_set_flag(struct Email *e, int flag, bool bf, bool subthread)
+int mutt_thread_set_flag(struct Email *e, enum MessageType flag, bool bf, bool subthread)
 {
   struct MuttThread *start = NULL;
   struct MuttThread *cur = e->thread;
@@ -431,7 +436,7 @@ int mutt_change_flag(struct Mailbox *m, struct EmailList *el, bool bf)
   if (!m || !el || STAILQ_EMPTY(el))
     return -1;
 
-  int flag;
+  enum MessageType flag = MUTT_NONE;
   struct KeyEvent event;
 
   mutt_window_mvprintw(MessageWindow, 0, 0,

--- a/gui/color.c
+++ b/gui/color.c
@@ -1002,7 +1002,7 @@ static enum CommandResult add_pattern(struct Colors *c, struct ColorLineList *to
     }
     else
     {
-      int flags = 0;
+      uint16_t flags = 0;
       if (sensitive)
         flags = mutt_mb_is_lower(s) ? REG_ICASE : 0;
       else

--- a/handler.c
+++ b/handler.c
@@ -683,7 +683,7 @@ static int text_plain_handler(struct Body *b, struct State *s)
   char *buf = NULL;
   size_t sz = 0;
 
-  while ((buf = mutt_file_read_line(buf, &sz, s->fp_in, NULL, 0)))
+  while ((buf = mutt_file_read_line(buf, &sz, s->fp_in, NULL, MUTT_RL_NO_FLAGS)))
   {
     if (!mutt_str_equal(buf, "-- ") && C_TextFlowed)
     {

--- a/hcache/serialize.c
+++ b/hcache/serialize.c
@@ -135,7 +135,7 @@ unsigned char *serial_dump_char_size(char *c, ssize_t size, unsigned char *d,
   if (convert && !mutt_str_is_ascii(c, size))
   {
     p = mutt_strn_dup(c, size);
-    if (mutt_ch_convert_string(&p, C_Charset, "utf-8", 0) == 0)
+    if (mutt_ch_convert_string(&p, C_Charset, "utf-8", MUTT_ICONV_NO_FLAGS) == 0)
     {
       size = mutt_str_len(p) + 1;
     }
@@ -188,7 +188,7 @@ void serial_restore_char(char **c, const unsigned char *d, int *off, bool conver
   if (convert && !mutt_str_is_ascii(*c, size))
   {
     char *tmp = mutt_str_dup(*c);
-    if (mutt_ch_convert_string(&tmp, "utf-8", C_Charset, 0) == 0)
+    if (mutt_ch_convert_string(&tmp, "utf-8", C_Charset, MUTT_ICONV_NO_FLAGS) == 0)
     {
       FREE(c);
       *c = tmp;

--- a/hdrline.c
+++ b/hdrline.c
@@ -778,16 +778,16 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
 
     case 'e':
       snprintf(fmt, sizeof(fmt), "%%%sd", prec);
-      snprintf(buf, buflen, fmt, mutt_messages_in_thread(m, e, 1));
+      snprintf(buf, buflen, fmt, mutt_messages_in_thread(m, e, MIT_POSITION));
       break;
 
     case 'E':
       if (!optional)
       {
         snprintf(fmt, sizeof(fmt), "%%%sd", prec);
-        snprintf(buf, buflen, fmt, mutt_messages_in_thread(m, e, 0));
+        snprintf(buf, buflen, fmt, mutt_messages_in_thread(m, e, MIT_NUM_MESSAGES));
       }
-      else if (mutt_messages_in_thread(m, e, 0) <= 1)
+      else if (mutt_messages_in_thread(m, e, MIT_NUM_MESSAGES) <= 1)
         optional = false;
       break;
 

--- a/history/history.c
+++ b/history/history.c
@@ -210,7 +210,7 @@ static void shrink_histfile(void)
       dup_hashes[hclass] = mutt_hash_new(MAX(10, C_SaveHistory * 2), MUTT_HASH_STRDUP_KEYS);
 
   line = 0;
-  while ((linebuf = mutt_file_read_line(linebuf, &buflen, fp, &line, 0)))
+  while ((linebuf = mutt_file_read_line(linebuf, &buflen, fp, &line, MUTT_RL_NO_FLAGS)))
   {
     if ((sscanf(linebuf, "%d:%n", &hclass, &read) < 1) || (read == 0) ||
         (*(p = linebuf + strlen(linebuf) - 1) != '|') || (hclass < 0))
@@ -252,7 +252,7 @@ static void shrink_histfile(void)
     }
     rewind(fp);
     line = 0;
-    while ((linebuf = mutt_file_read_line(linebuf, &buflen, fp, &line, 0)))
+    while ((linebuf = mutt_file_read_line(linebuf, &buflen, fp, &line, MUTT_RL_NO_FLAGS)))
     {
       if ((sscanf(linebuf, "%d:%n", &hclass, &read) < 1) || (read == 0) ||
           (*(p = linebuf + strlen(linebuf) - 1) != '|') || (hclass < 0))
@@ -578,7 +578,7 @@ void mutt_hist_read_file(void)
   if (!fp)
     return;
 
-  while ((linebuf = mutt_file_read_line(linebuf, &buflen, fp, &line, 0)))
+  while ((linebuf = mutt_file_read_line(linebuf, &buflen, fp, &line, MUTT_RL_NO_FLAGS)))
   {
     read = 0;
     if ((sscanf(linebuf, "%d:%n", &hclass, &read) < 1) || (read == 0) ||

--- a/history/history.c
+++ b/history/history.c
@@ -309,7 +309,7 @@ static void save_history(enum HistoryClass hclass, const char *str)
     return;
 
   tmp = mutt_str_dup(str);
-  mutt_ch_convert_string(&tmp, C_Charset, "utf-8", 0);
+  mutt_ch_convert_string(&tmp, C_Charset, "utf-8", MUTT_ICONV_NO_FLAGS);
 
   /* Format of a history item (1 line): "<histclass>:<string>|".
    * We add a '|' in order to avoid lines ending with '\'. */
@@ -594,7 +594,7 @@ void mutt_hist_read_file(void)
     p = mutt_str_dup(linebuf + read);
     if (p)
     {
-      mutt_ch_convert_string(&p, "utf-8", C_Charset, 0);
+      mutt_ch_convert_string(&p, "utf-8", C_Charset, MUTT_ICONV_NO_FLAGS);
       mutt_hist_add(hclass, p, false);
       FREE(&p);
     }

--- a/imap/command.c
+++ b/imap/command.c
@@ -694,7 +694,7 @@ static void cmd_parse_lsub(struct ImapAccountData *adata, char *s)
   url.path[strlen(url.path) - 1] = '\0';
   if (mutt_str_equal(url.user, C_ImapUser))
     url.user = NULL;
-  url_tostring(&url, buf + 11, sizeof(buf) - 11, 0);
+  url_tostring(&url, buf + 11, sizeof(buf) - 11, U_NO_FLAGS);
   mutt_str_cat(buf, sizeof(buf), "\"");
   mutt_buffer_init(&err);
   err.dsize = 256;

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -414,7 +414,7 @@ static int complete_hosts(char *buf, size_t buflen)
     /* FIXME: how to handle multiple users on the same host? */
     url.user = NULL;
     url.path = NULL;
-    url_tostring(&url, urlstr, sizeof(urlstr), 0);
+    url_tostring(&url, urlstr, sizeof(urlstr), U_NO_FLAGS);
     if (mutt_strn_equal(buf, urlstr, matchlen))
     {
       if (rc)
@@ -2386,7 +2386,7 @@ int imap_path_canon(char *buf, size_t buflen)
 
   imap_fix_path('\0', url->path, tmp, sizeof(tmp));
   url->path = tmp;
-  url_tostring(url, tmp2, sizeof(tmp2), 0);
+  url_tostring(url, tmp2, sizeof(tmp2), U_NO_FLAGS);
   mutt_str_copy(buf, tmp2, buflen);
   url_free(&url);
 

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -169,7 +169,7 @@ static char *get_flags(struct ListHead *hflags, char *s)
  * @param[out] flags   Buffer for server command
  * @param[in]  flsize  Length of buffer
  */
-static void set_flag(struct Mailbox *m, AclFlags aclflag, int flag,
+static void set_flag(struct Mailbox *m, AclFlags aclflag, bool flag,
                      const char *str, char *flags, size_t flsize)
 {
   if (m->rights & aclflag)
@@ -190,8 +190,8 @@ static void set_flag(struct Mailbox *m, AclFlags aclflag, int flag,
  * @note Headers must be in #SORT_ORDER. See imap_exec_msgset() for args.
  * Pos is an opaque pointer a la strtok(). It should be 0 at first call.
  */
-static int make_msg_set(struct Mailbox *m, struct Buffer *buf, int flag,
-                        bool changed, bool invert, int *pos)
+static int make_msg_set(struct Mailbox *m, struct Buffer *buf,
+                        enum MessageType flag, bool changed, bool invert, int *pos)
 {
   int count = 0;             /* number of messages in message set */
   unsigned int setstart = 0; /* start of current message range */
@@ -243,6 +243,8 @@ static int make_msg_set(struct Mailbox *m, struct Buffer *buf, int flag,
         case MUTT_TRASH:
           if (e->deleted && !e->purge)
             match = true;
+          break;
+        default:
           break;
       }
     }
@@ -315,7 +317,8 @@ static bool compare_flags_for_copy(struct Email *e)
  * @retval >=0 Success, number of messages
  * @retval  -1 Failure
  */
-static int sync_helper(struct Mailbox *m, AclFlags right, int flag, const char *name)
+static int sync_helper(struct Mailbox *m, AclFlags right, enum MessageType flag,
+                       const char *name)
 {
   int count = 0;
   int rc;
@@ -909,7 +912,7 @@ static int compare_uid(const void *a, const void *b)
  * (must be flushed with imap_exec)
  */
 int imap_exec_msgset(struct Mailbox *m, const char *pre, const char *post,
-                     int flag, bool changed, bool invert)
+                     enum MessageType flag, bool changed, bool invert)
 {
   struct ImapAccountData *adata = imap_adata_get(m);
   if (!adata || (adata->mailbox != m))
@@ -1038,10 +1041,10 @@ int imap_sync_message_for_copy(struct Mailbox *m, struct Email *e,
    * explicitly revoke all system flags (if we have permission) */
   if (*flags == '\0')
   {
-    set_flag(m, MUTT_ACL_SEEN, 1, "\\Seen ", flags, sizeof(flags));
-    set_flag(m, MUTT_ACL_WRITE, 1, "Old ", flags, sizeof(flags));
-    set_flag(m, MUTT_ACL_WRITE, 1, "\\Flagged ", flags, sizeof(flags));
-    set_flag(m, MUTT_ACL_WRITE, 1, "\\Answered ", flags, sizeof(flags));
+    set_flag(m, MUTT_ACL_SEEN, true, "\\Seen ", flags, sizeof(flags));
+    set_flag(m, MUTT_ACL_WRITE, true, "Old ", flags, sizeof(flags));
+    set_flag(m, MUTT_ACL_WRITE, true, "\\Flagged ", flags, sizeof(flags));
+    set_flag(m, MUTT_ACL_WRITE, true, "\\Answered ", flags, sizeof(flags));
     set_flag(m, MUTT_ACL_DELETE, !imap_edata_get(e)->deleted, "\\Deleted ",
              flags, sizeof(flags));
 

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -1197,7 +1197,7 @@ static int imap_status(struct ImapAccountData *adata, struct ImapMboxData *mdata
 /**
  * imap_mbox_check_stats - Check the Mailbox statistics - Implements MxOps::mbox_check_stats()
  */
-static int imap_mbox_check_stats(struct Mailbox *m, int flags)
+static int imap_mbox_check_stats(struct Mailbox *m, uint8_t flags)
 {
   return imap_mailbox_status(m, true);
 }

--- a/imap/message.c
+++ b/imap/message.c
@@ -647,7 +647,7 @@ static unsigned int imap_fetch_msn_seqset(struct Buffer *buf, struct ImapAccount
  * made.
  */
 static void set_changed_flag(struct Mailbox *m, struct Email *e, int local_changes,
-                             bool *server_changes, int flag_name,
+                             bool *server_changes, enum MessageType flag_name,
                              bool old_hd_flag, bool new_hd_flag, bool h_flag)
 {
   /* If there are local_changes, we only want to note if the server

--- a/imap/private.h
+++ b/imap/private.h
@@ -32,6 +32,7 @@
 #include <time.h>
 #include "mutt/lib.h"
 #include "config/lib.h"
+#include "mutt.h"
 #include "hcache/lib.h"
 
 struct Account;
@@ -281,7 +282,7 @@ extern char *        C_ImapUser;
 int imap_create_mailbox(struct ImapAccountData *adata, char *mailbox);
 int imap_rename_mailbox(struct ImapAccountData *adata, char *oldname, const char *newname);
 int imap_exec_msgset(struct Mailbox *m, const char *pre, const char *post,
-                     int flag, bool changed, bool invert);
+                     enum MessageType flag, bool changed, bool invert);
 int imap_open_connection(struct ImapAccountData *adata);
 void imap_close_connection(struct ImapAccountData *adata);
 int imap_read_literal(FILE *fp, struct ImapAccountData *adata, unsigned long bytes, struct Progress *pbar);

--- a/imap/utf7.c
+++ b/imap/utf7.c
@@ -323,7 +323,7 @@ void imap_utf_encode(bool unicode, char **s)
     return;
   }
 
-  if (mutt_ch_convert_string(s, C_Charset, "utf-8", 0) != 0)
+  if (mutt_ch_convert_string(s, C_Charset, "utf-8", MUTT_ICONV_NO_FLAGS) != 0)
   {
     FREE(s);
     return;
@@ -359,7 +359,7 @@ void imap_utf_decode(bool unicode, char **s)
     *s = utf8;
   }
 
-  if (mutt_ch_convert_string(s, "utf-8", C_Charset, 0) != 0)
+  if (mutt_ch_convert_string(s, "utf-8", C_Charset, MUTT_ICONV_NO_FLAGS) != 0)
   {
     FREE(s);
   }

--- a/imap/util.c
+++ b/imap/util.c
@@ -775,7 +775,7 @@ void imap_pretty_mailbox(char *path, size_t pathlen, const char *folder)
 fallback:
   mutt_account_tourl(&cac_target, &url);
   url.path = target_mailbox;
-  url_tostring(&url, path, pathlen, 0);
+  url_tostring(&url, path, pathlen, U_NO_FLAGS);
 }
 
 /**
@@ -956,7 +956,7 @@ void imap_qualify_path(char *buf, size_t buflen, struct ConnAccount *cac, char *
   struct Url url = { 0 };
   mutt_account_tourl(cac, &url);
   url.path = path;
-  url_tostring(&url, buf, buflen, 0);
+  url_tostring(&url, buf, buflen, U_NO_FLAGS);
 }
 
 /**

--- a/index.c
+++ b/index.c
@@ -753,7 +753,7 @@ static void change_folder_mailbox(struct Menu *menu, struct Mailbox *m, int *old
   if (!m)
     return;
 
-  const int flags = read_only ? MUTT_READONLY : MUTT_OPEN_NO_FLAGS;
+  const OpenMailboxFlags flags = read_only ? MUTT_READONLY : MUTT_OPEN_NO_FLAGS;
   Context = mx_mbox_open(m, flags);
   if (Context)
   {
@@ -1694,7 +1694,7 @@ int mutt_index_menu(struct MuttWindow *dlg)
         {
           struct Email *e = Context->mailbox->emails[msg_num - 1];
 
-          if (mutt_messages_in_thread(Context->mailbox, e, 1) > 1)
+          if (mutt_messages_in_thread(Context->mailbox, e, MIT_POSITION) > 1)
           {
             mutt_uncollapse_thread(e);
             mutt_set_vnum(Context->mailbox);

--- a/init.c
+++ b/init.c
@@ -294,7 +294,7 @@ static char *getmailname(void)
       continue;
 
     size_t len = 0;
-    mailname = mutt_file_read_line(NULL, &len, fp, NULL, 0);
+    mailname = mutt_file_read_line(NULL, &len, fp, NULL, MUTT_RL_NO_FLAGS);
     mutt_file_fclose(&fp);
     if (mailname && *mailname)
       break;
@@ -537,7 +537,7 @@ int mutt_extract_token(struct Buffer *dest, struct Buffer *tok, TokenFlags flags
 
       /* read line */
       struct Buffer expn = mutt_buffer_make(0);
-      expn.data = mutt_file_read_line(NULL, &expn.dsize, fp, NULL, 0);
+      expn.data = mutt_file_read_line(NULL, &expn.dsize, fp, NULL, MUTT_RL_NO_FLAGS);
       mutt_file_fclose(&fp);
       filter_wait(pid);
 

--- a/mailcap.c
+++ b/mailcap.c
@@ -255,7 +255,7 @@ static bool rfc1524_mailcap_parse(struct Body *a, const char *filename, const ch
   if (fp)
   {
     size_t buflen;
-    while (!found && (buf = mutt_file_read_line(buf, &buflen, fp, &line, MUTT_CONT)))
+    while (!found && (buf = mutt_file_read_line(buf, &buflen, fp, &line, MUTT_RL_CONT)))
     {
       /* ignore comments */
       if (*buf == '#')

--- a/maildir/maildir.c
+++ b/maildir/maildir.c
@@ -1352,7 +1352,7 @@ int maildir_mbox_check(struct Mailbox *m)
 /**
  * maildir_mbox_check_stats - Check the Mailbox statistics - Implements MxOps::mbox_check_stats()
  */
-static int maildir_mbox_check_stats(struct Mailbox *m, int flags)
+static int maildir_mbox_check_stats(struct Mailbox *m, uint8_t flags)
 {
   bool check_stats = flags;
   bool check_new = true;

--- a/maildir/mh.c
+++ b/maildir/mh.c
@@ -182,7 +182,7 @@ int mh_check_empty(const char *path)
 /**
  * mh_mbox_check_stats - Check the Mailbox statistics - Implements MxOps::mbox_check_stats()
  */
-static int mh_mbox_check_stats(struct Mailbox *m, int flags)
+static int mh_mbox_check_stats(struct Mailbox *m, uint8_t flags)
 {
   struct MhSequences mhs = { 0 };
   bool check_new = true;

--- a/maildir/sequence.c
+++ b/maildir/sequence.c
@@ -138,7 +138,7 @@ void mh_seq_add_one(struct Mailbox *m, int n, bool unseen, bool flagged, bool re
   FILE *fp_old = fopen(sequences, "r");
   if (fp_old)
   {
-    while ((buf = mutt_file_read_line(buf, &sz, fp_old, NULL, 0)))
+    while ((buf = mutt_file_read_line(buf, &sz, fp_old, NULL, MUTT_RL_NO_FLAGS)))
     {
       if (unseen && mutt_strn_equal(buf, seq_unseen, mutt_str_len(seq_unseen)))
       {
@@ -267,7 +267,7 @@ void mh_seq_update(struct Mailbox *m)
   FILE *fp_old = fopen(sequences, "r");
   if (fp_old)
   {
-    while ((buf = mutt_file_read_line(buf, &s, fp_old, NULL, 0)))
+    while ((buf = mutt_file_read_line(buf, &s, fp_old, NULL, MUTT_RL_NO_FLAGS)))
     {
       if (mutt_str_startswith(buf, seq_unseen) || mutt_str_startswith(buf, seq_flagged) ||
           mutt_str_startswith(buf, seq_replied))
@@ -387,7 +387,7 @@ int mh_seq_read(struct MhSequences *mhs, const char *path)
   if (!fp)
     return 0; /* yes, ask callers to silently ignore the error */
 
-  while ((buf = mutt_file_read_line(buf, &sz, fp, NULL, 0)))
+  while ((buf = mutt_file_read_line(buf, &sz, fp, NULL, MUTT_RL_NO_FLAGS)))
   {
     char *t = strtok(buf, " \t:");
     if (!t)

--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -1755,7 +1755,7 @@ static int mmdf_msg_padding_size(struct Mailbox *m)
 /**
  * mbox_mbox_check_stats - Check the Mailbox statistics - Implements MxOps::mbox_check_stats()
  */
-static int mbox_mbox_check_stats(struct Mailbox *m, int flags)
+static int mbox_mbox_check_stats(struct Mailbox *m, uint8_t flags)
 {
   struct stat sb = { 0 };
   if (stat(mailbox_path(m), &sb) != 0)
@@ -1791,7 +1791,8 @@ static int mbox_mbox_check_stats(struct Mailbox *m, int flags)
   if (m->newly_created && ((sb.st_ctime != sb.st_mtime) || (sb.st_ctime != sb.st_atime)))
     m->newly_created = false;
 
-  if (flags && mutt_file_stat_timespec_compare(&sb, MUTT_STAT_MTIME, &m->stats_last_checked) > 0)
+  if ((flags != 0) && mutt_file_stat_timespec_compare(&sb, MUTT_STAT_MTIME,
+                                                      &m->stats_last_checked) > 0)
   {
     bool old_peek = m->peekonly;
     struct Context *ctx = mx_mbox_open(m, MUTT_QUIET | MUTT_NOSORT | MUTT_PEEK);

--- a/menu.c
+++ b/menu.c
@@ -1160,7 +1160,7 @@ static int search(struct Menu *menu, int op)
 
   if (search_buf)
   {
-    int flags = mutt_mb_is_lower(search_buf) ? REG_ICASE : 0;
+    uint16_t flags = mutt_mb_is_lower(search_buf) ? REG_ICASE : 0;
     rc = REG_COMP(&re, search_buf, REG_NOSUB | flags);
   }
 

--- a/mutt/charset.c
+++ b/mutt/charset.c
@@ -327,7 +327,7 @@ int mutt_ch_convert_nonmime_string(char **ps)
     char *fromcode = mutt_mem_malloc(n + 1);
     mutt_str_copy(fromcode, c, n + 1);
     char *s = mutt_strn_dup(u, ulen);
-    int m = mutt_ch_convert_string(&s, fromcode, C_Charset, 0);
+    int m = mutt_ch_convert_string(&s, fromcode, C_Charset, MUTT_ICONV_NO_FLAGS);
     FREE(&fromcode);
     FREE(&s);
     if (m == 0)
@@ -562,7 +562,7 @@ const char *mutt_ch_charset_lookup(const char *chs)
  * @note The top-well-named MUTT_ICONV_HOOK_FROM acts on charset-hooks,
  * not at all on iconv-hooks.
  */
-iconv_t mutt_ch_iconv_open(const char *tocode, const char *fromcode, int flags)
+iconv_t mutt_ch_iconv_open(const char *tocode, const char *fromcode, uint8_t flags)
 {
   char tocode1[128];
   char fromcode1[128];
@@ -720,7 +720,7 @@ int mutt_ch_check(const char *s, size_t slen, const char *from, const char *to)
     return -1;
 
   int rc = 0;
-  iconv_t cd = mutt_ch_iconv_open(to, from, 0);
+  iconv_t cd = mutt_ch_iconv_open(to, from, MUTT_ICONV_NO_FLAGS);
   if (cd == (iconv_t) -1)
     return -1;
 
@@ -751,7 +751,7 @@ int mutt_ch_check(const char *s, size_t slen, const char *from, const char *to)
  * Parameter flags is given as-is to mutt_ch_iconv_open().
  * See there for its meaning and usage policy.
  */
-int mutt_ch_convert_string(char **ps, const char *from, const char *to, int flags)
+int mutt_ch_convert_string(char **ps, const char *from, const char *to, uint8_t flags)
 {
   if (!ps)
     return -1;
@@ -835,7 +835,7 @@ bool mutt_ch_check_charset(const char *cs, bool strict)
     }
   }
 
-  iconv_t cd = mutt_ch_iconv_open(cs, cs, 0);
+  iconv_t cd = mutt_ch_iconv_open(cs, cs, MUTT_ICONV_NO_FLAGS);
   if (cd != (iconv_t)(-1))
   {
     iconv_close(cd);
@@ -855,7 +855,7 @@ bool mutt_ch_check_charset(const char *cs, bool strict)
  *
  * Parameter flags is given as-is to mutt_ch_iconv_open().
  */
-struct FgetConv *mutt_ch_fgetconv_open(FILE *fp, const char *from, const char *to, int flags)
+struct FgetConv *mutt_ch_fgetconv_open(FILE *fp, const char *from, const char *to, uint8_t flags)
 {
   struct FgetConv *fc = NULL;
   iconv_t cd = (iconv_t) -1;
@@ -1056,7 +1056,7 @@ char *mutt_ch_choose(const char *fromcode, const char *charsets, const char *u,
     t[n] = '\0';
 
     char *s = mutt_strn_dup(u, ulen);
-    const int rc = d ? mutt_ch_convert_string(&s, fromcode, t, 0) :
+    const int rc = d ? mutt_ch_convert_string(&s, fromcode, t, MUTT_ICONV_NO_FLAGS) :
                        mutt_ch_check(s, ulen, fromcode, t);
     if (rc)
     {

--- a/mutt/charset.h
+++ b/mutt/charset.h
@@ -25,6 +25,7 @@
 
 #include <iconv.h>
 #include <stdbool.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <wchar.h>
 
@@ -69,6 +70,7 @@ enum LookupType
   MUTT_LOOKUP_ICONV,   ///< Character set conversion
 };
 
+#define MUTT_ICONV_NO_FLAGS  0 ///< No flags are set
 #define MUTT_ICONV_HOOK_FROM 1 ///< apply charset-hooks to fromcode
 
 void             mutt_ch_canonical_charset(char *buf, size_t buflen, const char *name);
@@ -78,16 +80,16 @@ bool             mutt_ch_check_charset(const char *cs, bool strict);
 char *           mutt_ch_choose(const char *fromcode, const char *charsets, const char *u, size_t ulen, char **d, size_t *dlen);
 bool             mutt_ch_chscmp(const char *cs1, const char *cs2);
 int              mutt_ch_convert_nonmime_string(char **ps);
-int              mutt_ch_convert_string(char **ps, const char *from, const char *to, int flags);
+int              mutt_ch_convert_string(char **ps, const char *from, const char *to, uint8_t flags);
 int              mutt_ch_fgetconv(struct FgetConv *fc);
 void             mutt_ch_fgetconv_close(struct FgetConv **fc);
-struct FgetConv *mutt_ch_fgetconv_open(FILE *fp, const char *from, const char *to, int flags);
+struct FgetConv *mutt_ch_fgetconv_open(FILE *fp, const char *from, const char *to, uint8_t flags);
 char *           mutt_ch_fgetconvs(char *buf, size_t buflen, struct FgetConv *fc);
 char *           mutt_ch_get_default_charset(void);
 char *           mutt_ch_get_langinfo_charset(void);
 size_t           mutt_ch_iconv(iconv_t cd, const char **inbuf, size_t *inbytesleft, char **outbuf, size_t *outbytesleft, const char **inrepls, const char *outrepl, int *iconverrno);
 const char *     mutt_ch_iconv_lookup(const char *chs);
-iconv_t          mutt_ch_iconv_open(const char *tocode, const char *fromcode, int flags);
+iconv_t          mutt_ch_iconv_open(const char *tocode, const char *fromcode, uint8_t flags);
 bool             mutt_ch_lookup_add(enum LookupType type, const char *pat, const char *replace, struct Buffer *err);
 void             mutt_ch_lookup_remove(void);
 void             mutt_ch_set_charset(const char *charset);

--- a/mutt/file.c
+++ b/mutt/file.c
@@ -519,7 +519,7 @@ int mutt_file_rmtree(const char *path)
  * @retval >0 Success, file handle
  * @retval -1 Error
  */
-int mutt_file_open(const char *path, int flags)
+int mutt_file_open(const char *path, uint32_t flags)
 {
   if (!path)
     return -1;
@@ -592,15 +592,14 @@ FILE *mutt_file_fopen(const char *path, const char *mode)
 
   if (mode[0] == 'w')
   {
-    int fd;
-    int flags = O_CREAT | O_EXCL | O_NOFOLLOW;
+    uint32_t flags = O_CREAT | O_EXCL | O_NOFOLLOW;
 
     if (mode[1] == '+')
       flags |= O_RDWR;
     else
       flags |= O_WRONLY;
 
-    fd = mutt_file_open(path, flags);
+    int fd = mutt_file_open(path, flags);
     if (fd < 0)
       return NULL;
 
@@ -656,7 +655,7 @@ int mutt_file_sanitize_regex(struct Buffer *dest, const char *src)
  * @param[in]  size     Length of buffer
  * @param[in]  fp       File to read
  * @param[out] line_num Current line number (optional)
- * @param[in]  flags    Flags, e.g. #MUTT_CONT
+ * @param[in]  flags    Flags, e.g. #MUTT_RL_CONT
  * @retval ptr          The allocated string
  *
  * Read a line from "fp" into the dynamically allocated "line", increasing
@@ -664,7 +663,7 @@ int mutt_file_sanitize_regex(struct Buffer *dest, const char *src)
  * with "\", this char and the linefeed is removed, and the next line is read
  * too.
  */
-char *mutt_file_read_line(char *line, size_t *size, FILE *fp, int *line_num, int flags)
+char *mutt_file_read_line(char *line, size_t *size, FILE *fp, int *line_num, ReadLineFlags flags)
 {
   if (!size || !fp)
     return NULL;
@@ -690,12 +689,12 @@ char *mutt_file_read_line(char *line, size_t *size, FILE *fp, int *line_num, int
     {
       if (line_num)
         (*line_num)++;
-      if (flags & MUTT_EOL)
+      if (flags & MUTT_RL_EOL)
         return line;
       *ch = '\0';
       if ((ch > line) && (*(ch - 1) == '\r'))
         *--ch = '\0';
-      if (!(flags & MUTT_CONT) || (ch == line) || (*(ch - 1) != '\\'))
+      if (!(flags & MUTT_RL_CONT) || (ch == line) || (*(ch - 1) != '\\'))
         return line;
       offset = ch - line - 1;
     }
@@ -744,7 +743,7 @@ char *mutt_file_read_line(char *line, size_t *size, FILE *fp, int *line_num, int
  * }
  * ```
  */
-bool mutt_file_iter_line(struct MuttFileIter *iter, FILE *fp, int flags)
+bool mutt_file_iter_line(struct MuttFileIter *iter, FILE *fp, ReadLineFlags flags)
 {
   if (!iter)
     return false;
@@ -764,7 +763,7 @@ bool mutt_file_iter_line(struct MuttFileIter *iter, FILE *fp, int flags)
  * @param flags     Same as mutt_file_read_line()
  * @retval          true if all data mapped, false if "func" returns false
  */
-bool mutt_file_map_lines(mutt_file_map_t func, void *user_data, FILE *fp, int flags)
+bool mutt_file_map_lines(mutt_file_map_t func, void *user_data, FILE *fp, ReadLineFlags flags)
 {
   if (!func || !fp)
     return false;

--- a/mutt/file.h
+++ b/mutt/file.h
@@ -25,6 +25,7 @@
 
 #include "config.h"
 #include <stdbool.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <sys/types.h>
 
@@ -34,8 +35,10 @@ extern char *C_Tmpdir;
 extern const char filename_safe_chars[];
 
 /* Flags for mutt_file_read_line() */
-#define MUTT_CONT (1 << 0) ///< \-continuation
-#define MUTT_EOL  (1 << 1) ///< don't strip `\n` / `\r\n`
+typedef uint8_t ReadLineFlags;             ///< Flags for mutt_file_read_line(), e.g. #MUTT_RL_CONT
+#define MUTT_RL_NO_FLAGS        0  ///< No flags are set
+#define MUTT_RL_CONT      (1 << 0) ///< \-continuation
+#define MUTT_RL_EOL       (1 << 1) ///< don't strip `\n` / `\r\n`
 
 #ifdef HAVE_STRUCT_TIMESPEC
 struct timespec;
@@ -98,16 +101,16 @@ FILE *      mutt_file_fopen(const char *path, const char *mode);
 int         mutt_file_fsync_close(FILE **fp);
 long        mutt_file_get_size(const char *path);
 void        mutt_file_get_stat_timespec(struct timespec *dest, struct stat *sb, enum MuttStatType type);
-bool        mutt_file_iter_line(struct MuttFileIter *iter, FILE *fp, int flags);
+bool        mutt_file_iter_line(struct MuttFileIter *iter, FILE *fp, ReadLineFlags flags);
 int         mutt_file_lock(int fd, bool excl, bool timeout);
-bool        mutt_file_map_lines(mutt_file_map_t func, void *user_data, FILE *fp, int flags);
+bool        mutt_file_map_lines(mutt_file_map_t func, void *user_data, FILE *fp, ReadLineFlags flags);
 int         mutt_file_mkdir(const char *path, mode_t mode);
 FILE *      mutt_file_mkstemp_full(const char *file, int line, const char *func);
 #define     mutt_file_mkstemp() mutt_file_mkstemp_full(__FILE__, __LINE__, __func__)
-int         mutt_file_open(const char *path, int flags);
+int         mutt_file_open(const char *path, uint32_t flags);
 size_t      mutt_file_quote_filename(const char *filename, char *buf, size_t buflen);
 char *      mutt_file_read_keyword(const char *file, char *buf, size_t buflen);
-char *      mutt_file_read_line(char *line, size_t *size, FILE *fp, int *line_num, int flags);
+char *      mutt_file_read_line(char *line, size_t *size, FILE *fp, int *line_num, ReadLineFlags flags);
 int         mutt_file_rename(const char *oldfile, const char *newfile);
 int         mutt_file_rmtree(const char *path);
 int         mutt_file_safe_rename(const char *src, const char *target);

--- a/mutt/regex.c
+++ b/mutt/regex.c
@@ -30,6 +30,7 @@
 #include "config.h"
 #include <ctype.h>
 #include <stdbool.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -49,7 +50,7 @@
  * @retval ptr New Regex object
  * @retval NULL Error
  */
-struct Regex *mutt_regex_compile(const char *str, int flags)
+struct Regex *mutt_regex_compile(const char *str, uint16_t flags)
 {
   if (!str || (*str == '\0'))
     return NULL;
@@ -70,12 +71,12 @@ struct Regex *mutt_regex_compile(const char *str, int flags)
  * @retval ptr New Regex object
  * @retval NULL Error
  */
-struct Regex *mutt_regex_new(const char *str, int flags, struct Buffer *err)
+struct Regex *mutt_regex_new(const char *str, uint32_t flags, struct Buffer *err)
 {
   if (!str || (*str == '\0'))
     return NULL;
 
-  int rflags = 0;
+  uint16_t rflags = 0;
   struct Regex *reg = mutt_mem_calloc(1, sizeof(struct Regex));
 
   reg->regex = mutt_mem_calloc(1, sizeof(regex_t));
@@ -128,7 +129,8 @@ void mutt_regex_free(struct Regex **r)
  * @retval 0  Success, Regex compiled and added to the list
  * @retval -1 Error, see message in 'err'
  */
-int mutt_regexlist_add(struct RegexList *rl, const char *str, int flags, struct Buffer *err)
+int mutt_regexlist_add(struct RegexList *rl, const char *str, uint16_t flags,
+                       struct Buffer *err)
 {
   if (!rl || !str || (*str == '\0'))
     return 0;

--- a/mutt/regex3.h
+++ b/mutt/regex3.h
@@ -27,6 +27,7 @@
 #include <stddef.h>
 #include <regex.h>
 #include <stdbool.h>
+#include <stdint.h>
 #include "queue.h"
 
 struct Buffer;
@@ -114,11 +115,11 @@ struct Replace
 };
 STAILQ_HEAD(ReplaceList, Replace);
 
-struct Regex *mutt_regex_compile(const char *str, int flags);
-struct Regex *mutt_regex_new(const char *str, int flags, struct Buffer *err);
+struct Regex *mutt_regex_compile(const char *str, uint16_t flags);
+struct Regex *mutt_regex_new(const char *str, uint32_t flags, struct Buffer *err);
 void          mutt_regex_free(struct Regex **r);
 
-int               mutt_regexlist_add   (struct RegexList *rl, const char *str, int flags, struct Buffer *err);
+int               mutt_regexlist_add   (struct RegexList *rl, const char *str, uint16_t flags, struct Buffer *err);
 void              mutt_regexlist_free  (struct RegexList *rl);
 bool              mutt_regexlist_match (struct RegexList *rl, const char *str);
 struct RegexNode *mutt_regexlist_new   (void);

--- a/mutt/slist.c
+++ b/mutt/slist.c
@@ -40,7 +40,7 @@
  * @param flags Flag to set, e.g. #SLIST_SEP_COMMA
  * @retval ptr New string list
  */
-struct Slist *slist_new(int flags)
+struct Slist *slist_new(uint32_t flags)
 {
   struct Slist *list = mutt_mem_calloc(1, sizeof(*list));
   list->flags = flags;
@@ -197,7 +197,7 @@ bool slist_is_member(const struct Slist *list, const char *str)
  * @param flags Flags, e.g. #SLIST_ALLOW_EMPTY
  * @retval ptr New Slist object
  */
-struct Slist *slist_parse(const char *str, int flags)
+struct Slist *slist_parse(const char *str, uint32_t flags)
 {
   char *src = mutt_str_dup(str);
   if (!src && !(flags & SLIST_ALLOW_EMPTY))

--- a/mutt/slist.h
+++ b/mutt/slist.h
@@ -25,6 +25,7 @@
 
 #include <stddef.h>
 #include <stdbool.h>
+#include <stdint.h>
 #include "list.h"
 
 struct Buffer;
@@ -46,7 +47,7 @@ struct Slist
 {
   struct ListHead head;
   size_t count;
-  unsigned int flags;
+  uint32_t flags;
 };
 
 struct Slist *slist_add_list(struct Slist *list, const struct Slist *add);
@@ -56,8 +57,8 @@ struct Slist *slist_dup(const struct Slist *list);
 struct Slist *slist_empty(struct Slist **list);
 void          slist_free(struct Slist **list);
 bool          slist_is_member(const struct Slist *list, const char *str);
-struct Slist *slist_new(int flags);
-struct Slist *slist_parse(const char *str, int flags);
+struct Slist *slist_new(uint32_t flags);
+struct Slist *slist_parse(const char *str, uint32_t flags);
 struct Slist *slist_remove_string(struct Slist *list, const char *str);
 int           slist_to_buffer(const struct Slist *list, struct Buffer *buf);
 

--- a/mutt_socket.c
+++ b/mutt_socket.c
@@ -91,7 +91,7 @@ struct Connection *mutt_conn_find(const struct ConnAccount *cac)
   /* cac isn't actually modified, since url isn't either */
   mutt_account_tourl((struct ConnAccount *) cac, &url);
   url.path = NULL;
-  url_tostring(&url, hook, sizeof(hook), 0);
+  url_tostring(&url, hook, sizeof(hook), U_NO_FLAGS);
   mutt_account_hook(hook);
 
   return mutt_conn_new(cac);

--- a/mutt_thread.c
+++ b/mutt_thread.c
@@ -1470,13 +1470,10 @@ int mutt_traverse_thread(struct Email *e_cur, MuttThreadFlags flag)
  * mutt_messages_in_thread - Count the messages in a thread
  * @param m    Mailbox
  * @param e    Email
- * @param flag Flag, see notes below
+ * @param mit  Flag, e.g. #MIT_NUM_MESSAGES
  * @retval num Number of message / Our position
- *
- * If flag is 0, we want to know how many messages are in the thread.
- * If flag is 1, we want to know our position in the thread.
  */
-int mutt_messages_in_thread(struct Mailbox *m, struct Email *e, int flag)
+int mutt_messages_in_thread(struct Mailbox *m, struct Email *e, enum MessageInThread mit)
 {
   if (!m || !e)
     return 1;
@@ -1491,9 +1488,9 @@ int mutt_messages_in_thread(struct Mailbox *m, struct Email *e, int flag)
   while (threads[0]->parent)
     threads[0] = threads[0]->parent;
 
-  threads[1] = flag ? e->thread : threads[0]->next;
+  threads[1] = (mit == MIT_POSITION) ? e->thread : threads[0]->next;
 
-  for (int i = 0; i < ((flag || !threads[1]) ? 1 : 2); i++)
+  for (int i = 0; i < (((mit == MIT_POSITION) || !threads[1]) ? 1 : 2); i++)
   {
     while (!threads[i]->message)
       threads[i] = threads[i]->child;
@@ -1507,7 +1504,7 @@ int mutt_messages_in_thread(struct Mailbox *m, struct Email *e, int flag)
          threads[0]->message->msgno;
   }
 
-  if (flag)
+  if (mit == MIT_POSITION)
     rc += 1;
 
   return rc;

--- a/mutt_thread.h
+++ b/mutt_thread.h
@@ -79,6 +79,12 @@ typedef uint8_t MuttThreadFlags;         ///< Flags, e.g. #MUTT_THREAD_COLLAPSE
 #define MUTT_THREAD_NEXT_UNREAD (1 << 3) ///< Find the next unread email
 #define MUTT_THREAD_FLAGGED     (1 << 4) ///< Count flagged emails in a thread
 
+enum MessageInThread
+{
+  MIT_NUM_MESSAGES, // How many messages are in the thread
+  MIT_POSITION,     // Our position in the thread
+};
+
 int mutt_traverse_thread(struct Email *e, MuttThreadFlags flag);
 #define mutt_collapse_thread(e)         mutt_traverse_thread(e, MUTT_THREAD_COLLAPSE)
 #define mutt_uncollapse_thread(e)       mutt_traverse_thread(e, MUTT_THREAD_UNCOLLAPSE)
@@ -102,7 +108,7 @@ void                   mutt_clear_threads     (struct ThreadsContext *tctx);
 void                   mutt_draw_tree         (struct ThreadsContext *tctx);
 bool                   mutt_link_threads      (struct Email *parent, struct EmailList *children, struct Mailbox *m);
 struct HashTable *     mutt_make_id_hash      (struct Mailbox *m);
-int                    mutt_messages_in_thread(struct Mailbox *m, struct Email *e, int flag);
+int                    mutt_messages_in_thread(struct Mailbox *m, struct Email *e, enum MessageInThread mit);
 int                    mutt_parent_message    (struct Email *e, bool find_root);
 off_t                  mutt_set_vnum          (struct Mailbox *m);
 void                   mutt_sort_subthreads   (struct ThreadsContext *tctx, bool init);

--- a/muttlib.c
+++ b/muttlib.c
@@ -1474,7 +1474,7 @@ const char *mutt_make_version(void)
 void mutt_encode_path(struct Buffer *buf, const char *src)
 {
   char *p = mutt_str_dup(src);
-  int rc = mutt_ch_convert_string(&p, C_Charset, "us-ascii", 0);
+  int rc = mutt_ch_convert_string(&p, C_Charset, "us-ascii", MUTT_ICONV_NO_FLAGS);
   size_t len = mutt_buffer_strcpy(buf, (rc == 0) ? NONULL(p) : NONULL(src));
 
   /* convert the path to POSIX "Portable Filename Character Set" */

--- a/mx.c
+++ b/mx.c
@@ -1799,7 +1799,7 @@ int mx_ac_remove(struct Mailbox *m)
 /**
  * mx_mbox_check_stats - Check the statistics for a mailbox - Wrapper for MxOps::mbox_check_stats()
  */
-int mx_mbox_check_stats(struct Mailbox *m, int flags)
+int mx_mbox_check_stats(struct Mailbox *m, uint8_t flags)
 {
   if (!m)
     return -1;

--- a/mx.h
+++ b/mx.h
@@ -179,7 +179,7 @@ struct MxOps
    * **Contract**
    * - @a m is not NULL
    */
-  int (*mbox_check_stats)(struct Mailbox *m, int flags);
+  int (*mbox_check_stats)(struct Mailbox *m, uint8_t flags);
 
   /**
    * mbox_sync - Save changes to the Mailbox
@@ -375,7 +375,7 @@ struct MxOps
 
 /* Wrappers for the Mailbox API, see MxOps */
 int             mx_mbox_check      (struct Mailbox *m);
-int             mx_mbox_check_stats(struct Mailbox *m, int flags);
+int             mx_mbox_check_stats(struct Mailbox *m, uint8_t flags);
 int             mx_mbox_close      (struct Context **ptr);
 struct Context *mx_mbox_open       (struct Mailbox *m, OpenMailboxFlags flags);
 int             mx_mbox_sync       (struct Mailbox *m);

--- a/ncrypt/crypt.c
+++ b/ncrypt/crypt.c
@@ -166,7 +166,7 @@ int mutt_protect(struct Email *e, char *keylist, bool postpone)
   if (!WithCrypto)
     return -1;
 
-  int security = e->security;
+  SecurityFlags security = e->security;
   int sign = security & (SEC_AUTOCRYPT | SEC_SIGN);
   if (postpone)
   {

--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -4149,7 +4149,7 @@ void smime_gpgme_init(void)
  * @param is_smime True if an SMIME message
  * @retval num Flags, e.g. #APPLICATION_SMIME | #SEC_ENCRYPT
  */
-static int gpgme_send_menu(struct Email *e, bool is_smime)
+static SecurityFlags gpgme_send_menu(struct Email *e, bool is_smime)
 {
   struct CryptKeyInfo *p = NULL;
   const char *prompt = NULL;
@@ -4310,7 +4310,7 @@ static int gpgme_send_menu(struct Email *e, bool is_smime)
 /**
  * pgp_gpgme_send_menu - Implements CryptModuleSpecs::send_menu()
  */
-int pgp_gpgme_send_menu(struct Email *e)
+SecurityFlags pgp_gpgme_send_menu(struct Email *e)
 {
   return gpgme_send_menu(e, false);
 }
@@ -4318,7 +4318,7 @@ int pgp_gpgme_send_menu(struct Email *e)
 /**
  * smime_gpgme_send_menu - Implements CryptModuleSpecs::send_menu()
  */
-int smime_gpgme_send_menu(struct Email *e)
+SecurityFlags smime_gpgme_send_menu(struct Email *e)
 {
   return gpgme_send_menu(e, true);
 }

--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -2986,7 +2986,8 @@ int pgp_gpgme_application_handler(struct Body *m, struct State *s)
       {
         int c;
         rewind(fp_out);
-        struct FgetConv *fc = mutt_ch_fgetconv_open(fp_out, "utf-8", C_Charset, 0);
+        struct FgetConv *fc =
+            mutt_ch_fgetconv_open(fp_out, "utf-8", C_Charset, MUTT_ICONV_NO_FLAGS);
         while ((c = mutt_ch_fgetconv(fc)) != EOF)
         {
           state_putc(s, c);

--- a/ncrypt/crypt_gpgme.h
+++ b/ncrypt/crypt_gpgme.h
@@ -88,7 +88,7 @@ struct Body *pgp_gpgme_encrypt_message(struct Body *a, char *keylist, bool sign,
 char *       pgp_gpgme_find_keys(struct AddressList *addrlist, bool oppenc_mode);
 void         pgp_gpgme_invoke_import(const char *fname);
 struct Body *pgp_gpgme_make_key_attachment(void);
-int          pgp_gpgme_send_menu(struct Email *e);
+SecurityFlags pgp_gpgme_send_menu(struct Email *e);
 struct Body *pgp_gpgme_sign_message(struct Body *a, const struct AddressList *from);
 int          pgp_gpgme_verify_one(struct Body *sigbdy, struct State *s, const char *tempfile);
 
@@ -97,7 +97,7 @@ struct Body *smime_gpgme_build_smime_entity(struct Body *a, char *keylist);
 int          smime_gpgme_decrypt_mime(FILE *fp_in, FILE **fp_out, struct Body *b, struct Body **cur);
 char *       smime_gpgme_find_keys(struct AddressList *addrlist, bool oppenc_mode);
 void         smime_gpgme_init(void);
-int          smime_gpgme_send_menu(struct Email *e);
+SecurityFlags smime_gpgme_send_menu(struct Email *e);
 struct Body *smime_gpgme_sign_message(struct Body *a, const struct AddressList *from);
 int          smime_gpgme_verify_one(struct Body *sigbdy, struct State *s, const char *tempfile);
 int          smime_gpgme_verify_sender(struct Mailbox *m, struct Email *e);

--- a/ncrypt/crypt_mod.h
+++ b/ncrypt/crypt_mod.h
@@ -135,7 +135,7 @@ struct CryptModuleSpecs
    * @param e Email
    * @retval num Flags, e.g. #APPLICATION_PGP | #SEC_ENCRYPT
    */
-  int (*send_menu)(struct Email *e);
+  SecurityFlags (*send_menu)(struct Email *e);
 
   /**
    * set_sender - Set the sender of the email

--- a/ncrypt/cryptglue.c
+++ b/ncrypt/cryptglue.c
@@ -289,7 +289,7 @@ int crypt_pgp_check_traditional(FILE *fp, struct Body *b, bool just_one)
 /**
  * crypt_pgp_traditional_encryptsign - Wrapper for CryptModuleSpecs::pgp_traditional_encryptsign()
  */
-struct Body *crypt_pgp_traditional_encryptsign(struct Body *a, int flags, char *keylist)
+struct Body *crypt_pgp_traditional_encryptsign(struct Body *a, SecurityFlags flags, char *keylist)
 {
   if (CRYPT_MOD_CALL_CHECK(PGP, pgp_traditional_encryptsign))
     return CRYPT_MOD_CALL(PGP, pgp_traditional_encryptsign)(a, flags, keylist);
@@ -379,7 +379,7 @@ int crypt_pgp_verify_one(struct Body *sigbdy, struct State *s, const char *tempf
 /**
  * crypt_pgp_send_menu - Wrapper for CryptModuleSpecs::send_menu()
  */
-int crypt_pgp_send_menu(struct Email *e)
+SecurityFlags crypt_pgp_send_menu(struct Email *e)
 {
   if (CRYPT_MOD_CALL_CHECK(PGP, send_menu))
     return CRYPT_MOD_CALL(PGP, send_menu)(e);
@@ -525,7 +525,7 @@ int crypt_smime_verify_one(struct Body *sigbdy, struct State *s, const char *tem
 /**
  * crypt_smime_send_menu - Wrapper for CryptModuleSpecs::send_menu()
  */
-int crypt_smime_send_menu(struct Email *e)
+SecurityFlags crypt_smime_send_menu(struct Email *e)
 {
   if (CRYPT_MOD_CALL_CHECK(SMIME, send_menu))
     return CRYPT_MOD_CALL(SMIME, send_menu)(e);

--- a/ncrypt/cryptglue.h
+++ b/ncrypt/cryptglue.h
@@ -25,6 +25,7 @@
 #define MUTT_NCRYPT_CRYPTGLUE_H
 
 #include <stdbool.h>
+#include "lib.h"
 
 struct AddressList;
 struct Body;
@@ -36,7 +37,7 @@ char *       crypt_pgp_find_keys(struct AddressList *al, bool oppenc_mode);
 void         crypt_pgp_invoke_import(const char *fname);
 void         crypt_pgp_set_sender(const char *sender);
 struct Body *crypt_pgp_sign_message(struct Body *a, const struct AddressList *from);
-struct Body *crypt_pgp_traditional_encryptsign(struct Body *a, int flags, char *keylist);
+struct Body *crypt_pgp_traditional_encryptsign(struct Body *a, SecurityFlags flags, char *keylist);
 bool         crypt_pgp_valid_passphrase(void);
 int          crypt_pgp_verify_one(struct Body *sigbdy, struct State *s, const char *tempf);
 void         crypt_pgp_void_passphrase(void);

--- a/ncrypt/dlggpgme.c
+++ b/ncrypt/dlggpgme.c
@@ -114,7 +114,7 @@ static void print_utf8(FILE *fp, const char *buf, size_t len)
 
   /* fromcode "utf-8" is sure, so we don't want
    * charset-hook corrections: flags must be 0.  */
-  mutt_ch_convert_string(&tstr, "utf-8", C_Charset, 0);
+  mutt_ch_convert_string(&tstr, "utf-8", C_Charset, MUTT_ICONV_NO_FLAGS);
   fputs(tstr, fp);
   FREE(&tstr);
 }

--- a/ncrypt/gnupgparse.c
+++ b/ncrypt/gnupgparse.c
@@ -94,7 +94,7 @@ static void fix_uid(char *uid)
   }
   *d = '\0';
 
-  if (chs && ((cd = mutt_ch_iconv_open(chs, "utf-8", 0)) != (iconv_t) -1))
+  if (chs && ((cd = mutt_ch_iconv_open(chs, "utf-8", MUTT_ICONV_NO_FLAGS)) != (iconv_t) -1))
   {
     int n = s - uid + 1; /* chars available in original buffer */
 

--- a/ncrypt/lib.h
+++ b/ncrypt/lib.h
@@ -178,11 +178,11 @@ int          crypt_pgp_encrypted_handler(struct Body *a, struct State *s);
 void         crypt_pgp_extract_key_from_attachment(FILE *fp, struct Body *top);
 void         crypt_pgp_invoke_getkeys(struct Address *addr);
 struct Body *crypt_pgp_make_key_attachment(void);
-int          crypt_pgp_send_menu(struct Email *e);
+SecurityFlags crypt_pgp_send_menu(struct Email *e);
 int          crypt_smime_application_handler(struct Body *m, struct State *s);
 int          crypt_smime_decrypt_mime(FILE *fp_in, FILE **fp_out, struct Body *b, struct Body **cur);
 void         crypt_smime_getkeys(struct Envelope *env);
-int          crypt_smime_send_menu(struct Email *e);
+SecurityFlags crypt_smime_send_menu(struct Email *e);
 int          crypt_smime_verify_sender(struct Mailbox *m, struct Email *e);
 
 /* crypt_mod.c */

--- a/ncrypt/pgp.c
+++ b/ncrypt/pgp.c
@@ -247,7 +247,7 @@ static int pgp_copy_checksig(FILE *fp_in, FILE *fp_out)
     char *line = NULL;
     size_t linelen;
 
-    while ((line = mutt_file_read_line(line, &linelen, fp_in, NULL, 0)))
+    while ((line = mutt_file_read_line(line, &linelen, fp_in, NULL, MUTT_RL_NO_FLAGS)))
     {
       if (mutt_regex_match(C_PgpGoodSign, line))
       {
@@ -293,7 +293,7 @@ static int pgp_check_pgp_decryption_okay_regex(FILE *fp_in)
     char *line = NULL;
     size_t linelen;
 
-    while ((line = mutt_file_read_line(line, &linelen, fp_in, NULL, 0)))
+    while ((line = mutt_file_read_line(line, &linelen, fp_in, NULL, MUTT_RL_NO_FLAGS)))
     {
       if (mutt_regex_match(C_PgpDecryptionOkay, line))
       {
@@ -345,7 +345,7 @@ static int pgp_check_decryption_okay(FILE *fp_in)
   if (!C_PgpCheckGpgDecryptStatusFd)
     return pgp_check_pgp_decryption_okay_regex(fp_in);
 
-  while ((line = mutt_file_read_line(line, &linelen, fp_in, NULL, 0)))
+  while ((line = mutt_file_read_line(line, &linelen, fp_in, NULL, MUTT_RL_NO_FLAGS)))
   {
     size_t plen = mutt_str_startswith(line, "[GNUPG:] ");
     if (plen == 0)

--- a/ncrypt/pgp.c
+++ b/ncrypt/pgp.c
@@ -1721,7 +1721,7 @@ struct Body *pgp_class_traditional_encryptsign(struct Body *a, SecurityFlags fla
       send_charset = "utf-8";
 
     /* fromcode is assumed to be correct: we set flags to 0 */
-    fc = mutt_ch_fgetconv_open(fp_body, from_charset, "utf-8", 0);
+    fc = mutt_ch_fgetconv_open(fp_body, from_charset, "utf-8", MUTT_ICONV_NO_FLAGS);
     while ((c = mutt_ch_fgetconv(fc)) != EOF)
       fputc(c, fp_pgp_in);
 

--- a/ncrypt/pgp.c
+++ b/ncrypt/pgp.c
@@ -1836,7 +1836,7 @@ cleanup:
 /**
  * pgp_class_send_menu - Implements CryptModuleSpecs::send_menu()
  */
-int pgp_class_send_menu(struct Email *e)
+SecurityFlags pgp_class_send_menu(struct Email *e)
 {
   struct PgpKeyInfo *p = NULL;
   const char *prompt = NULL;

--- a/ncrypt/pgp.h
+++ b/ncrypt/pgp.h
@@ -27,6 +27,7 @@
 #define MUTT_NCRYPT_PGP_H
 
 #include <stdbool.h>
+#include <stdint.h>
 #include <stdio.h>
 #include "lib.h"
 
@@ -61,6 +62,6 @@ struct Body *pgp_class_traditional_encryptsign(struct Body *a, SecurityFlags fla
 struct Body *pgp_class_encrypt_message(struct Body *a, char *keylist, bool sign, const struct AddressList *from);
 struct Body *pgp_class_sign_message(struct Body *a, const struct AddressList *from);
 
-int pgp_class_send_menu(struct Email *e);
+SecurityFlags pgp_class_send_menu(struct Email *e);
 
 #endif /* MUTT_NCRYPT_PGP_H */

--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -2097,7 +2097,7 @@ int smime_class_application_handler(struct Body *m, struct State *s)
 /**
  * smime_class_send_menu - Implements CryptModuleSpecs::send_menu()
  */
-int smime_class_send_menu(struct Email *e)
+SecurityFlags smime_class_send_menu(struct Email *e)
 {
   struct SmimeKey *key = NULL;
   const char *prompt = NULL;

--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -1747,7 +1747,7 @@ int smime_class_verify_one(struct Body *sigbdy, struct State *s, const char *tem
       fflush(fp_smime_err);
       rewind(fp_smime_err);
 
-      line = mutt_file_read_line(line, &linelen, fp_smime_err, NULL, 0);
+      line = mutt_file_read_line(line, &linelen, fp_smime_err, NULL, MUTT_RL_NO_FLAGS);
       if (linelen && mutt_istr_equal(line, "verification successful"))
         badsig = 0;
 
@@ -1993,7 +1993,7 @@ static struct Body *smime_handle_entity(struct Body *m, struct State *s, FILE *f
 
     rewind(fp_smime_err);
 
-    line = mutt_file_read_line(line, &linelen, fp_smime_err, NULL, 0);
+    line = mutt_file_read_line(line, &linelen, fp_smime_err, NULL, MUTT_RL_NO_FLAGS);
     if (linelen && mutt_istr_equal(line, "verification successful"))
       m->goodsig = true;
     FREE(&line);

--- a/ncrypt/smime.h
+++ b/ncrypt/smime.h
@@ -60,7 +60,7 @@ int          smime_class_decrypt_mime(FILE *fp_in, FILE **fp_out, struct Body *b
 char *       smime_class_find_keys(struct AddressList *addrlist, bool oppenc_mode);
 void         smime_class_getkeys(struct Envelope *env);
 void         smime_class_invoke_import(const char *infile, const char *mailbox);
-int          smime_class_send_menu(struct Email *e);
+SecurityFlags smime_class_send_menu(struct Email *e);
 struct Body *smime_class_sign_message(struct Body *a, const struct AddressList *from);
 bool         smime_class_valid_passphrase(void);
 int          smime_class_verify_one(struct Body *sigbdy, struct State *s, const char *tempfile);

--- a/nntp/newsrc.c
+++ b/nntp/newsrc.c
@@ -560,7 +560,7 @@ void nntp_expand_path(char *buf, size_t buflen, struct ConnAccount *cac)
 
   mutt_account_tourl(cac, &url);
   url.path = mutt_str_dup(buf);
-  url_tostring(&url, buf, buflen, 0);
+  url_tostring(&url, buf, buflen, U_NO_FLAGS);
   FREE(&url.path);
 }
 

--- a/nntp/nntp.c
+++ b/nntp/nntp.c
@@ -2415,7 +2415,7 @@ static int nntp_mbox_open(struct Mailbox *m)
     group++;
 
   url->path = strchr(url->path, '\0');
-  url_tostring(url, server, sizeof(server), 0);
+  url_tostring(url, server, sizeof(server), U_NO_FLAGS);
 
   mutt_account_hook(m->realpath);
   struct NntpAccountData *adata = m->account->adata;

--- a/notmuch/notmuch.c
+++ b/notmuch/notmuch.c
@@ -1979,7 +1979,7 @@ int nm_update_filename(struct Mailbox *m, const char *old_file,
 /**
  * nm_mbox_check_stats - Check the Mailbox statistics - Implements MxOps::mbox_check_stats()
  */
-static int nm_mbox_check_stats(struct Mailbox *m, int flags)
+static int nm_mbox_check_stats(struct Mailbox *m, uint8_t flags)
 {
   struct UrlQuery *item = NULL;
   struct Url *url = NULL;

--- a/pager.c
+++ b/pager.c
@@ -2010,7 +2010,7 @@ static void pager_custom_redraw(struct Menu *pager_menu)
       rd->search_compiled = Resize->search_compiled;
       if (rd->search_compiled)
       {
-        int flags = mutt_mb_is_lower(rd->searchbuf) ? REG_ICASE : 0;
+        uint16_t flags = mutt_mb_is_lower(rd->searchbuf) ? REG_ICASE : 0;
         const int err = REG_COMP(&rd->search_re, rd->searchbuf, REG_NEWLINE | flags);
         if (err == 0)
         {
@@ -2740,7 +2740,7 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
           }
         }
 
-        int rflags = mutt_mb_is_lower(searchbuf) ? REG_ICASE : 0;
+        uint16_t rflags = mutt_mb_is_lower(searchbuf) ? REG_ICASE : 0;
         int err = REG_COMP(&rd.search_re, searchbuf, REG_NEWLINE | rflags);
         if (err != 0)
         {

--- a/pager.c
+++ b/pager.c
@@ -1446,7 +1446,7 @@ static int fill_buffer(FILE *fp, LOFF_T *last_pos, LOFF_T offset, unsigned char 
     if (offset != *last_pos)
       fseeko(fp, offset, SEEK_SET);
 
-    *buf = (unsigned char *) mutt_file_read_line((char *) *buf, blen, fp, NULL, MUTT_EOL);
+    *buf = (unsigned char *) mutt_file_read_line((char *) *buf, blen, fp, NULL, MUTT_RL_EOL);
     if (!*buf)
     {
       fmt[0] = NULL;

--- a/pattern/compile.c
+++ b/pattern/compile.c
@@ -204,7 +204,7 @@ static bool eat_query(struct Pattern *pat, int flags, struct Buffer *s, struct B
     return false;
   }
 
-  mutt_file_map_lines(add_query_msgid, &pat->p.multi_cases, fp, 0);
+  mutt_file_map_lines(add_query_msgid, &pat->p.multi_cases, fp, MUTT_RL_NO_FLAGS);
   mutt_file_fclose(&fp);
   filter_wait(pid);
   FREE(&cmd_buf.data);

--- a/pattern/compile.c
+++ b/pattern/compile.c
@@ -77,7 +77,8 @@ enum EatRangeError
 /**
  * eat_regex - Parse a regex - Implements ::eat_arg_t
  */
-static bool eat_regex(struct Pattern *pat, int flags, struct Buffer *s, struct Buffer *err)
+static bool eat_regex(struct Pattern *pat, PatternCompFlags flags,
+                      struct Buffer *s, struct Buffer *err)
 {
   struct Buffer buf;
 
@@ -145,7 +146,8 @@ static bool add_query_msgid(char *line, int line_num, void *user_data)
 /**
  * eat_query - Parse a query for an external search program - Implements ::eat_arg_t
  */
-static bool eat_query(struct Pattern *pat, int flags, struct Buffer *s, struct Buffer *err)
+static bool eat_query(struct Pattern *pat, PatternCompFlags flags,
+                      struct Buffer *s, struct Buffer *err)
 {
   struct Buffer cmd_buf;
   struct Buffer tok_buf;
@@ -615,7 +617,8 @@ bool eval_date_minmax(struct Pattern *pat, const char *s, struct Buffer *err)
 /**
  * eat_range - Parse a number range - Implements ::eat_arg_t
  */
-static bool eat_range(struct Pattern *pat, int flags, struct Buffer *s, struct Buffer *err)
+static bool eat_range(struct Pattern *pat, PatternCompFlags flags,
+                      struct Buffer *s, struct Buffer *err)
 {
   char *tmp = NULL;
   bool do_exclusive = false;
@@ -899,8 +902,8 @@ static int eat_range_by_regex(struct Pattern *pat, struct Buffer *s, int kind,
 /**
  * eat_message_range - Parse a range of message numbers - Implements ::eat_arg_t
  */
-static bool eat_message_range(struct Pattern *pat, int flags, struct Buffer *s,
-                              struct Buffer *err)
+static bool eat_message_range(struct Pattern *pat, PatternCompFlags flags,
+                              struct Buffer *s, struct Buffer *err)
 {
   bool skip_quote = false;
 
@@ -943,7 +946,8 @@ static bool eat_message_range(struct Pattern *pat, int flags, struct Buffer *s,
 /**
  * eat_date - Parse a date pattern - Implements ::eat_arg_t
  */
-static bool eat_date(struct Pattern *pat, int flags, struct Buffer *s, struct Buffer *err)
+static bool eat_date(struct Pattern *pat, PatternCompFlags flags,
+                     struct Buffer *s, struct Buffer *err)
 {
   struct Buffer *tmp = mutt_buffer_pool_get();
   bool rc = false;

--- a/pattern/compile.c
+++ b/pattern/compile.c
@@ -110,7 +110,7 @@ static bool eat_regex(struct Pattern *pat, int flags, struct Buffer *s, struct B
   else
   {
     pat->p.regex = mutt_mem_malloc(sizeof(regex_t));
-    int case_flags = mutt_mb_is_lower(buf.data) ? REG_ICASE : 0;
+    uint16_t case_flags = mutt_mb_is_lower(buf.data) ? REG_ICASE : 0;
     int rc = REG_COMP(pat->p.regex, buf.data, REG_NEWLINE | REG_NOSUB | case_flags);
     if (rc != 0)
     {

--- a/pattern/exec.c
+++ b/pattern/exec.c
@@ -677,7 +677,7 @@ static int msg_search_sendmode(struct Email *e, struct Pattern *pat)
     fflush(fp);
     fseek(fp, 0, 0);
 
-    while ((buf = mutt_file_read_line(buf, &blen, fp, NULL, 0)) != NULL)
+    while ((buf = mutt_file_read_line(buf, &blen, fp, NULL, MUTT_RL_NO_FLAGS)) != NULL)
     {
       if (patmatch(pat, buf) == 0)
       {
@@ -704,7 +704,7 @@ static int msg_search_sendmode(struct Email *e, struct Pattern *pat)
       return 0;
     }
 
-    while ((buf = mutt_file_read_line(buf, &blen, fp, NULL, 0)) != NULL)
+    while ((buf = mutt_file_read_line(buf, &blen, fp, NULL, MUTT_RL_NO_FLAGS)) != NULL)
     {
       if (patmatch(pat, buf) == 0)
       {

--- a/pattern/pattern.c
+++ b/pattern/pattern.c
@@ -78,7 +78,8 @@ struct RangeRegex range_regexes[] = {
  * @param err   Buffer for error messages
  * @retval true If the pattern was read successfully
  */
-bool (*eat_arg_t)(struct Pattern *pat, int flags, struct Buffer *s, struct Buffer *err);
+bool (*eat_arg_t)(struct Pattern *pat, PatternCompFlags flags, struct Buffer *s,
+                  struct Buffer *err);
 
 static struct PatternList *SearchPattern = NULL; ///< current search pattern
 static char LastSearch[256] = { 0 };             ///< last pattern searched for

--- a/pattern/private.h
+++ b/pattern/private.h
@@ -26,6 +26,7 @@
 #include "config.h"
 #include <stdbool.h>
 #include "mutt/lib.h"
+#include "lib.h"
 
 struct Buffer;
 struct Pattern;
@@ -50,9 +51,9 @@ enum PatternEat
  */
 struct PatternFlags
 {
-  int tag;   ///< Character used to represent this operation, e.g. 'A' for '~A'
-  int op;    ///< Operation to perform, e.g. #MUTT_PAT_SCORE
-  int flags; ///< Pattern flags, e.g. #MUTT_PC_FULL_MSG
+  int tag;                ///< Character used to represent this operation, e.g. 'A' for '~A'
+  int op;                 ///< Operation to perform, e.g. #MUTT_PAT_SCORE
+  PatternCompFlags flags; ///< Pattern flags, e.g. #MUTT_PC_FULL_MSG
 
   enum PatternEat eat_arg;
   char *desc;

--- a/pop/pop.c
+++ b/pop/pop.c
@@ -804,7 +804,7 @@ static int pop_mbox_open(struct Mailbox *m)
 
   mutt_account_tourl(&cac, &url);
   url.path = NULL;
-  url_tostring(&url, buf, sizeof(buf), 0);
+  url_tostring(&url, buf, sizeof(buf), U_NO_FLAGS);
 
   mutt_buffer_strcpy(&m->pathbuf, buf);
   mutt_str_replace(&m->realpath, mailbox_path(m));

--- a/protos.h
+++ b/protos.h
@@ -63,10 +63,10 @@ int mutt_system(const char *cmd);
 
 int mutt_set_xdg_path(enum XdgType type, struct Buffer *buf);
 void mutt_help(enum MenuType menu, int wraplan);
-void mutt_set_flag_update(struct Mailbox *m, struct Email *e, int flag, bool bf, bool upd_mbox);
+void mutt_set_flag_update(struct Mailbox *m, struct Email *e, enum MessageType flag, bool bf, bool upd_mbox);
 #define mutt_set_flag(m, e, flag, bf) mutt_set_flag_update(m, e, flag, bf, true)
 void mutt_signal_init(void);
-void mutt_emails_set_flag(struct Mailbox *m, struct EmailList *el, int flag, bool bf);
+void mutt_emails_set_flag(struct Mailbox *m, struct EmailList *el, enum MessageType flag, bool bf);
 int mutt_change_flag(struct Mailbox *m, struct EmailList *el, bool bf);
 
 int mutt_complete(char *buf, size_t buflen);
@@ -77,7 +77,7 @@ int mutt_enter_string_full(char *buf, size_t buflen, int col, CompletionFlags fl
 int mutt_get_postponed(struct Context *ctx, struct Email *hdr, struct Email **cur, struct Buffer *fcc);
 SecurityFlags mutt_parse_crypt_hdr(const char *p, bool set_empty_signas, SecurityFlags crypt_app);
 int mutt_num_postponed(struct Mailbox *m, bool force);
-int mutt_thread_set_flag(struct Email *e, int flag, bool bf, bool subthread);
+int mutt_thread_set_flag(struct Email *e, enum MessageType flag, bool bf, bool subthread);
 void mutt_update_num_postponed(void);
 int mutt_is_quote_line(char *buf, regmatch_t *pmatch);
 

--- a/rfc3676.c
+++ b/rfc3676.c
@@ -332,7 +332,7 @@ int rfc3676_handler(struct Body *a, struct State *s)
 
   mutt_debug(LL_DEBUG3, "f=f: DelSp: %s\n", delsp ? "yes" : "no");
 
-  while ((buf = mutt_file_read_line(buf, &sz, s->fp_in, NULL, 0)))
+  while ((buf = mutt_file_read_line(buf, &sz, s->fp_in, NULL, MUTT_RL_NO_FLAGS)))
   {
     const size_t buf_len = mutt_str_len(buf);
     const unsigned int newql = get_quote_level(buf);
@@ -426,7 +426,7 @@ static void rfc3676_space_stuff(const char *filename, bool unstuff)
   if (!fp_out)
     goto bail;
 
-  while ((buf = mutt_file_read_line(buf, &blen, fp_in, NULL, 0)) != NULL)
+  while ((buf = mutt_file_read_line(buf, &blen, fp_in, NULL, MUTT_RL_NO_FLAGS)) != NULL)
   {
     if (unstuff)
     {

--- a/send/body.c
+++ b/send/body.c
@@ -361,12 +361,12 @@ int mutt_write_mime_body(struct Body *a, FILE *fp, struct ConfigSubset *sub)
   if ((a->type == TYPE_TEXT) && (!a->noconv))
   {
     char send_charset[128];
-    fc = mutt_ch_fgetconv_open(
-        fp_in, a->charset,
-        mutt_body_get_charset(a, send_charset, sizeof(send_charset)), 0);
+    fc = mutt_ch_fgetconv_open(fp_in, a->charset,
+                               mutt_body_get_charset(a, send_charset, sizeof(send_charset)),
+                               MUTT_ICONV_NO_FLAGS);
   }
   else
-    fc = mutt_ch_fgetconv_open(fp_in, 0, 0, 0);
+    fc = mutt_ch_fgetconv_open(fp_in, 0, 0, MUTT_ICONV_NO_FLAGS);
 
   mutt_sig_allow_interrupt(true);
   if (a->encoding == ENC_QUOTED_PRINTABLE)

--- a/send/sendlib.c
+++ b/send/sendlib.c
@@ -231,7 +231,7 @@ static size_t convert_file_to(FILE *fp, const char *fromcode, int ncodes,
   char bufi[256], bufu[512], bufo[4 * sizeof(bufi)];
   size_t ret;
 
-  const iconv_t cd1 = mutt_ch_iconv_open("utf-8", fromcode, 0);
+  const iconv_t cd1 = mutt_ch_iconv_open("utf-8", fromcode, MUTT_ICONV_NO_FLAGS);
   if (cd1 == (iconv_t)(-1))
     return -1;
 
@@ -243,7 +243,7 @@ static size_t convert_file_to(FILE *fp, const char *fromcode, int ncodes,
   for (int i = 0; i < ncodes; i++)
   {
     if (!mutt_istr_equal(tocodes[i], "utf-8"))
-      cd[i] = mutt_ch_iconv_open(tocodes[i], "utf-8", 0);
+      cd[i] = mutt_ch_iconv_open(tocodes[i], "utf-8", MUTT_ICONV_NO_FLAGS);
     else
     {
       /* Special case for conversion to UTF-8 */

--- a/send/sendlib.c
+++ b/send/sendlib.c
@@ -1061,7 +1061,7 @@ static void run_mime_type_query(struct Body *att, struct ConfigSubset *sub)
   }
   mutt_buffer_pool_release(&cmd);
 
-  buf = mutt_file_read_line(buf, &buflen, fp, NULL, 0);
+  buf = mutt_file_read_line(buf, &buflen, fp, NULL, MUTT_RL_NO_FLAGS);
   if (buf)
   {
     if (strchr(buf, '/'))

--- a/test/charset/mutt_ch_convert_string.c
+++ b/test/charset/mutt_ch_convert_string.c
@@ -27,26 +27,26 @@
 
 void test_mutt_ch_convert_string(void)
 {
-  // int mutt_ch_convert_string(char **ps, const char *from, const char *to, int flags);
+  // int mutt_ch_convert_string(char **ps, const char *from, const char *to, uint8_t flags);
 
   {
-    TEST_CHECK(mutt_ch_convert_string(NULL, "apple", "banana", 0) != 0);
+    TEST_CHECK(mutt_ch_convert_string(NULL, "apple", "banana", MUTT_ICONV_NO_FLAGS) != 0);
   }
 
   {
     char *ps = NULL;
-    TEST_CHECK(mutt_ch_convert_string(&ps, "apple", "banana", 0) == 0);
+    TEST_CHECK(mutt_ch_convert_string(&ps, "apple", "banana", MUTT_ICONV_NO_FLAGS) == 0);
   }
 
   {
     char *ps = strdup("apple");
-    TEST_CHECK(mutt_ch_convert_string(&ps, NULL, "banana", 0) != 0);
+    TEST_CHECK(mutt_ch_convert_string(&ps, NULL, "banana", MUTT_ICONV_NO_FLAGS) != 0);
     free(ps);
   }
 
   {
     char *ps = strdup("apple");
-    TEST_CHECK(mutt_ch_convert_string(&ps, "apple", NULL, 0) != 0);
+    TEST_CHECK(mutt_ch_convert_string(&ps, "apple", NULL, MUTT_ICONV_NO_FLAGS) != 0);
     free(ps);
   }
 }

--- a/test/charset/mutt_ch_fgetconv_open.c
+++ b/test/charset/mutt_ch_fgetconv_open.c
@@ -27,25 +27,26 @@
 
 void test_mutt_ch_fgetconv_open(void)
 {
-  // struct FgetConv *mutt_ch_fgetconv_open(FILE *fp, const char *from, const char *to, int flags);
+  // struct FgetConv *mutt_ch_fgetconv_open(FILE *fp, const char *from, const char *to, uint8_t flags);
 
   {
     struct FgetConv *conv = NULL;
-    TEST_CHECK((conv = mutt_ch_fgetconv_open(NULL, "apple", "banana", 0)) != NULL);
+    TEST_CHECK((conv = mutt_ch_fgetconv_open(NULL, "apple", "banana",
+                                             MUTT_ICONV_NO_FLAGS)) != NULL);
     mutt_ch_fgetconv_close(&conv);
   }
 
   {
     FILE fp = { 0 };
     struct FgetConv *conv = NULL;
-    TEST_CHECK((conv = mutt_ch_fgetconv_open(&fp, NULL, "banana", 0)) != NULL);
+    TEST_CHECK((conv = mutt_ch_fgetconv_open(&fp, NULL, "banana", MUTT_ICONV_NO_FLAGS)) != NULL);
     mutt_ch_fgetconv_close(&conv);
   }
 
   {
     FILE fp = { 0 };
     struct FgetConv *conv = NULL;
-    TEST_CHECK((conv = mutt_ch_fgetconv_open(&fp, "apple", NULL, 0)) != NULL);
+    TEST_CHECK((conv = mutt_ch_fgetconv_open(&fp, "apple", NULL, MUTT_ICONV_NO_FLAGS)) != NULL);
     mutt_ch_fgetconv_close(&conv);
   }
 }

--- a/test/charset/mutt_ch_iconv_open.c
+++ b/test/charset/mutt_ch_iconv_open.c
@@ -27,13 +27,13 @@
 
 void test_mutt_ch_iconv_open(void)
 {
-  // iconv_t mutt_ch_iconv_open(const char *tocode, const char *fromcode, int flags);
+  // iconv_t mutt_ch_iconv_open(const char *tocode, const char *fromcode, uint8_t flags);
 
   {
-    TEST_CHECK(mutt_ch_iconv_open(NULL, "banana", 0) != NULL);
+    TEST_CHECK(mutt_ch_iconv_open(NULL, "banana", MUTT_ICONV_NO_FLAGS) != NULL);
   }
 
   {
-    TEST_CHECK(mutt_ch_iconv_open("apple", NULL, 0) != NULL);
+    TEST_CHECK(mutt_ch_iconv_open("apple", NULL, MUTT_ICONV_NO_FLAGS) != NULL);
   }
 }

--- a/test/config/slist.c
+++ b/test/config/slist.c
@@ -173,7 +173,7 @@ static bool test_slist_parse(struct Buffer *err)
     "apple::banana",
   };
 
-  unsigned int flags = SLIST_SEP_COLON | SLIST_ALLOW_EMPTY;
+  uint32_t flags = SLIST_SEP_COLON | SLIST_ALLOW_EMPTY;
   slist_flags(flags, err);
   TEST_MSG("Flags: %s", mutt_b2s(err));
   TEST_MSG("\n");
@@ -230,7 +230,7 @@ static bool test_slist_remove_string(struct Buffer *err)
   {
     mutt_buffer_reset(err);
 
-    unsigned int flags = SLIST_SEP_COLON | SLIST_ALLOW_EMPTY;
+    uint32_t flags = SLIST_SEP_COLON | SLIST_ALLOW_EMPTY;
     struct Slist *list = slist_parse("apple:banana::cherry", flags);
     slist_dump(list, err);
 
@@ -270,7 +270,7 @@ static bool test_slist_is_member(struct Buffer *err)
 
     TEST_CHECK(slist_is_member(NULL, "apple") == false);
 
-    unsigned int flags = SLIST_SEP_COLON | SLIST_ALLOW_EMPTY;
+    uint32_t flags = SLIST_SEP_COLON | SLIST_ALLOW_EMPTY;
     struct Slist *list = slist_parse("apple:banana::cherry", flags);
     slist_dump(list, err);
 
@@ -297,7 +297,7 @@ static bool test_slist_add_list(struct Buffer *err)
 {
   mutt_buffer_reset(err);
 
-  unsigned int flags = SLIST_SEP_COLON | SLIST_ALLOW_EMPTY;
+  uint32_t flags = SLIST_SEP_COLON | SLIST_ALLOW_EMPTY;
 
   struct Slist *list1 = slist_parse("apple:banana::cherry", flags);
   slist_dump(list1, err);

--- a/test/file/mutt_file_iter_line.c
+++ b/test/file/mutt_file_iter_line.c
@@ -28,16 +28,16 @@
 
 void test_mutt_file_iter_line(void)
 {
-  // bool mutt_file_iter_line(struct MuttFileIter *iter, FILE *fp, int flags);
+  // bool mutt_file_iter_line(struct MuttFileIter *iter, FILE *fp, ReadLineFlags flags);
 
   {
     FILE fp = { 0 };
-    TEST_CHECK(!mutt_file_iter_line(NULL, &fp, 0));
+    TEST_CHECK(!mutt_file_iter_line(NULL, &fp, MUTT_RL_NO_FLAGS));
   }
 
   {
     struct MuttFileIter muttfileiter = { 0 };
-    TEST_CHECK(!mutt_file_iter_line(&muttfileiter, NULL, 0));
+    TEST_CHECK(!mutt_file_iter_line(&muttfileiter, NULL, MUTT_RL_NO_FLAGS));
   }
 
   {
@@ -48,7 +48,7 @@ void test_mutt_file_iter_line(void)
     bool res;
     for (int i = 0; file_lines[i]; i++)
     {
-      res = mutt_file_iter_line(&iter, fp, 0);
+      res = mutt_file_iter_line(&iter, fp, MUTT_RL_NO_FLAGS);
       if (!TEST_CHECK(res))
       {
         TEST_MSG("Expected: true");
@@ -65,7 +65,7 @@ void test_mutt_file_iter_line(void)
         TEST_MSG("Actual: %d", iter.line_num);
       }
     }
-    res = mutt_file_iter_line(&iter, fp, 0);
+    res = mutt_file_iter_line(&iter, fp, MUTT_RL_NO_FLAGS);
     if (!TEST_CHECK(!res))
     {
       TEST_MSG("Expected: false");

--- a/test/file/mutt_file_map_lines.c
+++ b/test/file/mutt_file_map_lines.c
@@ -49,7 +49,7 @@ static void test_file_map_lines_breaking_after(int last_line, bool expected)
   FILE *fp = SET_UP();
   if (!fp)
     return;
-  bool res = mutt_file_map_lines(mapping_func, &last_line, fp, 0);
+  bool res = mutt_file_map_lines(mapping_func, &last_line, fp, MUTT_RL_NO_FLAGS);
   if (!TEST_CHECK(res == expected))
   {
     TEST_MSG("Expected: %s", BOOLIFY(expected));
@@ -60,23 +60,23 @@ static void test_file_map_lines_breaking_after(int last_line, bool expected)
 
 void test_mutt_file_map_lines(void)
 {
-  // bool mutt_file_map_lines(mutt_file_map_t func, void *user_data, FILE *fp, int flags);
+  // bool mutt_file_map_lines(mutt_file_map_t func, void *user_data, FILE *fp, ReadLineFlags flags);
 
   {
     FILE fp = { 0 };
-    TEST_CHECK(!mutt_file_map_lines(NULL, "apple", &fp, 0));
+    TEST_CHECK(!mutt_file_map_lines(NULL, "apple", &fp, MUTT_RL_NO_FLAGS));
   }
 
   {
     mutt_file_map_t map = map_dummy;
     FILE *fp = fopen("/dev/null", "r");
-    TEST_CHECK(mutt_file_map_lines(map, NULL, fp, 0));
+    TEST_CHECK(mutt_file_map_lines(map, NULL, fp, MUTT_RL_NO_FLAGS));
     fclose(fp);
   }
 
   {
     mutt_file_map_t map = map_dummy;
-    TEST_CHECK(!mutt_file_map_lines(map, "apple", NULL, 0));
+    TEST_CHECK(!mutt_file_map_lines(map, "apple", NULL, MUTT_RL_NO_FLAGS));
   }
 
   {

--- a/test/file/mutt_file_open.c
+++ b/test/file/mutt_file_open.c
@@ -27,7 +27,7 @@
 
 void test_mutt_file_open(void)
 {
-  // int mutt_file_open(const char *path, int flags);
+  // int mutt_file_open(const char *path, uint32_t flags);
 
   {
     TEST_CHECK(mutt_file_open(NULL, 0) != 0);

--- a/test/file/mutt_file_read_line.c
+++ b/test/file/mutt_file_read_line.c
@@ -27,13 +27,13 @@
 
 void test_mutt_file_read_line(void)
 {
-  // char *mutt_file_read_line(char *line, size_t *size, FILE *fp, int *line_num, int flags);
+  // char *mutt_file_read_line(char *line, size_t *size, FILE *fp, int *line_num, ReadLineFlags flags);
 
   {
     size_t size = 0;
     FILE *fp = fopen("/dev/null", "r");
     int line_num = 0;
-    TEST_CHECK(!mutt_file_read_line(NULL, &size, fp, &line_num, 0));
+    TEST_CHECK(!mutt_file_read_line(NULL, &size, fp, &line_num, MUTT_RL_NO_FLAGS));
     fclose(fp);
   }
 
@@ -41,7 +41,7 @@ void test_mutt_file_read_line(void)
     FILE fp = { 0 };
     char *line = strdup("apple");
     int line_num = 0;
-    TEST_CHECK(!mutt_file_read_line(line, NULL, &fp, &line_num, 0));
+    TEST_CHECK(!mutt_file_read_line(line, NULL, &fp, &line_num, MUTT_RL_NO_FLAGS));
     free(line);
   }
 
@@ -49,7 +49,7 @@ void test_mutt_file_read_line(void)
     size_t size = 0;
     char *line = strdup("apple");
     int line_num = 0;
-    TEST_CHECK(!mutt_file_read_line(line, &size, NULL, &line_num, 0));
+    TEST_CHECK(!mutt_file_read_line(line, &size, NULL, &line_num, MUTT_RL_NO_FLAGS));
     free(line);
   }
 
@@ -57,6 +57,6 @@ void test_mutt_file_read_line(void)
     size_t size = 0;
     char *line = strdup("apple");
     FILE fp = { 0 };
-    TEST_CHECK(!mutt_file_read_line(line, &size, &fp, NULL, 0));
+    TEST_CHECK(!mutt_file_read_line(line, &size, &fp, NULL, MUTT_RL_NO_FLAGS));
   }
 }

--- a/test/group/mutt_grouplist_add_regex.c
+++ b/test/group/mutt_grouplist_add_regex.c
@@ -28,7 +28,7 @@
 
 void test_mutt_grouplist_add_regex(void)
 {
-  // int mutt_grouplist_add_regex(struct GroupList *head, const char *s, int flags, struct Buffer *err);
+  // int mutt_grouplist_add_regex(struct GroupList *gl, const char *s, uint16_t flags, struct Buffer *err);
 
   {
     struct Buffer err = mutt_buffer_make(0);

--- a/test/idna/mutt_idna_intl_to_local.c
+++ b/test/idna/mutt_idna_intl_to_local.c
@@ -28,15 +28,15 @@
 
 void test_mutt_idna_intl_to_local(void)
 {
-  // char * mutt_idna_intl_to_local(const char *user, const char *domain, int flags);
+  // char *mutt_idna_intl_to_local(const char *user, const char *domain, uint8_t flags);
 
 #ifdef HAVE_LIBIDN
   {
-    TEST_CHECK(!mutt_idna_intl_to_local(NULL, "banana", 0));
+    TEST_CHECK(!mutt_idna_intl_to_local(NULL, "banana", MI_NO_FLAGS));
   }
 
   {
-    TEST_CHECK(!mutt_idna_intl_to_local("apple", NULL, 0));
+    TEST_CHECK(!mutt_idna_intl_to_local("apple", NULL, MI_NO_FLAGS));
   }
 #endif
 }

--- a/test/idna/mutt_idna_to_ascii_lz.c
+++ b/test/idna/mutt_idna_to_ascii_lz.c
@@ -28,7 +28,7 @@
 
 void test_mutt_idna_to_ascii_lz(void)
 {
-  // int mutt_idna_to_ascii_lz(const char *input, char **output, int flags);
+  // int mutt_idna_to_ascii_lz(const char *input, char **output, uint8_t flags);
 
 #ifdef HAVE_LIBIDN
   {

--- a/test/pattern/extract.c
+++ b/test/pattern/extract.c
@@ -169,7 +169,7 @@ int mutt_extract_token(struct Buffer *dest, struct Buffer *tok, TokenFlags flags
 
       /* read line */
       struct Buffer expn = mutt_buffer_make(0);
-      expn.data = mutt_file_read_line(NULL, &expn.dsize, fp, NULL, 0);
+      expn.data = mutt_file_read_line(NULL, &expn.dsize, fp, NULL, MUTT_RL_NO_FLAGS);
       mutt_file_fclose(&fp);
       filter_wait(pid);
 

--- a/test/regex/mutt_regex_compile.c
+++ b/test/regex/mutt_regex_compile.c
@@ -27,7 +27,7 @@
 
 void test_mutt_regex_compile(void)
 {
-  // struct Regex *mutt_regex_compile(const char *str, int flags);
+  // struct Regex *mutt_regex_compile(const char *str, uint16_t flags);
 
   {
     TEST_CHECK(!mutt_regex_compile(NULL, 0));

--- a/test/regex/mutt_regex_new.c
+++ b/test/regex/mutt_regex_new.c
@@ -27,7 +27,7 @@
 
 void test_mutt_regex_new(void)
 {
-  // struct Regex *mutt_regex_new(const char *str, int flags, struct Buffer *err);
+  // struct Regex *mutt_regex_new(const char *str, uint32_t flags, struct Buffer *err);
 
   {
     struct Buffer buf = mutt_buffer_make(0);

--- a/test/regex/mutt_regexlist_add.c
+++ b/test/regex/mutt_regexlist_add.c
@@ -27,7 +27,7 @@
 
 void test_mutt_regexlist_add(void)
 {
-  // int mutt_regexlist_add(struct RegexList *rl, const char *str, int flags, struct Buffer *err);
+  // int mutt_regexlist_add(struct RegexList *rl, const char *str, uint16_t flags, struct Buffer *err);
 
   {
     struct Buffer buf = mutt_buffer_make(0);

--- a/test/slist/slist_parse.c
+++ b/test/slist/slist_parse.c
@@ -27,5 +27,5 @@
 
 void test_slist_parse(void)
 {
-  // struct Slist *slist_parse(const char *str, int flags);
+  // struct Slist *slist_parse(const char *str, uint32_t flags);
 }

--- a/test/url/url_tobuffer.c
+++ b/test/url/url_tobuffer.c
@@ -29,15 +29,15 @@
 
 void test_url_tobuffer(void)
 {
-  // int url_tobuffer(struct Url *u, struct Buffer *buf, int flags);
+  // int url_tobuffer(struct Url *url, struct Buffer *buf, uint8_t flags);
 
   {
     struct Buffer buf = mutt_buffer_make(0);
-    TEST_CHECK(url_tobuffer(NULL, &buf, 0) != 0);
+    TEST_CHECK(url_tobuffer(NULL, &buf, U_NO_FLAGS) != 0);
   }
 
   {
     struct Url url = { 0 };
-    TEST_CHECK(url_tobuffer(&url, NULL, 0) != 0);
+    TEST_CHECK(url_tobuffer(&url, NULL, U_NO_FLAGS) != 0);
   }
 }

--- a/test/url/url_tostring.c
+++ b/test/url/url_tostring.c
@@ -29,15 +29,15 @@
 
 void test_url_tostring(void)
 {
-  // int url_tostring(struct Url *u, char *dest, size_t len, int flags);
+  // int url_tostring(struct Url *url, char *dest, size_t len, uint8_t flags);
 
   {
     char buf[32] = { 0 };
-    TEST_CHECK(url_tostring(NULL, buf, sizeof(buf), 0) != 0);
+    TEST_CHECK(url_tostring(NULL, buf, sizeof(buf), U_NO_FLAGS) != 0);
   }
 
   {
     struct Url url = { 0 };
-    TEST_CHECK(url_tostring(&url, NULL, 10, 0) != 0);
+    TEST_CHECK(url_tostring(&url, NULL, 10, U_NO_FLAGS) != 0);
   }
 }


### PR DESCRIPTION
The [first commit](https://github.com/neomutt/neomutt/commit/777ba18e1904904bbc9b5eb88cd021b7469dbcd4) makes a 1 char change to force a constant to be `unsigned`.
That seems to fix #2785.

The rest make the code more specific when dealing with flags.
- Create more flags constants
- Create types to wrap some `#define`d flags
- Replace `int` with a fixed width unsigned type

The changes are split by area.
(They can be merged later)

- 777ba18e1 unsigned
- 1df80a370 regex
- cb3cdbf25 slist
- e19cff206 config
- 7633cadc9 compose
- fbb79b00e charset
- a5782b362 readline
- 00fa6c50b url
- dd7a21dc4 mbox_check_stats
- 8290cad04 idn
- b24bfa2eb pattern
- 479a080e6 mailbox
- e9faf94e8 email
- 0d4681644 imap
- 37b37245e messages
- 7277c079f crypt
