### PR TITLE
Add mutt_buffer_seek() function

### DIFF
--- a/hcache/serialize.c
+++ b/hcache/serialize.c
@@ -351,7 +351,7 @@ void serial_restore_buffer(struct Buffer *buf, const unsigned char *d, int *off,
 
   serial_restore_char(&buf->data, d, off, convert);
   serial_restore_int(&offset, d, off);
-  buf->dptr = buf->data + offset;
+  mutt_buffer_seek(buf, offset);
   serial_restore_int(&used, d, off);
   buf->dsize = used;
 }

--- a/icommands.c
+++ b/icommands.c
@@ -85,7 +85,7 @@ enum CommandResult mutt_parse_icommand(/* const */ char *line, struct Buffer *er
   struct Buffer *token = mutt_buffer_pool_get();
   struct Buffer expn = mutt_buffer_make(0);
   mutt_buffer_addstr(&expn, line);
-  expn.dptr = expn.data;
+  mutt_buffer_seek(&expn, 0);
 
   mutt_buffer_reset(err);
 

--- a/init.c
+++ b/init.c
@@ -558,7 +558,7 @@ int mutt_extract_token(struct Buffer *dest, struct Buffer *tok, TokenFlags flags
           mutt_buffer_copy(copy, &expn);
           mutt_buffer_addstr(copy, tok->dptr);
           mutt_buffer_copy(tok, copy);
-          tok->dptr = tok->data;
+          mutt_buffer_seek(tok, 0);
           mutt_buffer_pool_release(&copy);
         }
         FREE(&expn.data);
@@ -995,7 +995,7 @@ enum CommandResult mutt_parse_rc_buffer(struct Buffer *line,
   mutt_buffer_reset(err);
 
   /* Read from the beginning of line->data */
-  line->dptr = line->data;
+  mutt_buffer_seek(line, 0);
 
   SKIPWS(line->dptr);
   while (*line->dptr)

--- a/mutt/base64.c
+++ b/mutt/base64.c
@@ -215,9 +215,9 @@ int mutt_b64_buffer_decode(struct Buffer *buf, const char *in)
   int olen = mutt_b64_decode(in, buf->data, buf->dsize);
   /* mutt_from_base64 returns raw bytes, so don't terminate the buffer either */
   if (olen > 0)
-    buf->dptr = buf->data + olen;
+    mutt_buffer_seek(buf, olen);
   else
-    buf->dptr = buf->data;
+    mutt_buffer_seek(buf, 0);
 
   return olen;
 }

--- a/mutt/buffer.c
+++ b/mutt/buffer.c
@@ -81,7 +81,7 @@ void mutt_buffer_reset(struct Buffer *buf)
   if (!buf || !buf->data || (buf->dsize == 0))
     return;
   memset(buf->data, 0, buf->dsize);
-  buf->dptr = buf->data;
+  mutt_buffer_seek(buf, 0);
 }
 
 /**
@@ -183,7 +183,7 @@ void mutt_buffer_fix_dptr(struct Buffer *buf)
   if (!buf)
     return;
 
-  buf->dptr = buf->data;
+  mutt_buffer_seek(buf, 0);
 
   if (buf->data && (buf->dsize > 0))
   {
@@ -271,7 +271,7 @@ void mutt_buffer_alloc(struct Buffer *buf, size_t new_size)
 
   if (!buf->dptr)
   {
-    buf->dptr = buf->data;
+    mutt_buffer_seek(buf, 0);
   }
 
   if ((new_size > buf->dsize) || !buf->data)
@@ -280,7 +280,7 @@ void mutt_buffer_alloc(struct Buffer *buf, size_t new_size)
 
     buf->dsize = new_size;
     mutt_mem_realloc(&buf->data, buf->dsize);
-    buf->dptr = buf->data + offset;
+    mutt_buffer_seek(buf, offset);
     /* This ensures an initially NULL buf->data is now properly terminated. */
     if (buf->dptr)
       *buf->dptr = '\0';
@@ -453,3 +453,20 @@ size_t mutt_buffer_copy(struct Buffer *dst, const struct Buffer *src)
 
   return mutt_buffer_addstr_n(dst, src->data, mutt_buffer_len(src));
 }
+
+
+/** 
+ * mutt_buffer_seek - set current read/write position to offset from beginning
+ * @param buf    Buffer to use
+ * @param offset Distance from the beginning
+ *
+ * This is used for cases where the buffer is read from
+ * A value is placed in the buffer, and then b->dptr is set back to the
+ * beginning as a read marker instead of write marker.
+ */
+void mutt_buffer_seek (struct Buffer *buf, size_t offset)
+{
+  if (buf)
+    buf->dptr = buf->data + offset;
+}
+

--- a/mutt/buffer.h
+++ b/mutt/buffer.h
@@ -51,6 +51,7 @@ size_t         mutt_buffer_len          (const struct Buffer *buf);
 struct Buffer  mutt_buffer_make         (size_t size);
 void           mutt_buffer_reset        (struct Buffer *buf);
 char *         mutt_buffer_strdup       (const struct Buffer *buf);
+void           mutt_buffer_seek         (struct Buffer *buf, size_t offset);
 
 // Functions that APPEND to a Buffer
 size_t         mutt_buffer_addch        (struct Buffer *buf, char c);

--- a/muttlib.c
+++ b/muttlib.c
@@ -822,7 +822,7 @@ void mutt_expando_format(char *buf, size_t buflen, size_t col, int cols, const c
       mutt_buffer_addstr(&srcbuf, srccopy);
       /* note: we are resetting dptr and *reading* from the buffer, so we don't
        * want to use mutt_buffer_reset(). */
-      srcbuf.dptr = srcbuf.data;
+      mutt_buffer_seek(&srcbuf, 0);
       struct Buffer word = mutt_buffer_make(0);
       struct Buffer cmd = mutt_buffer_make(0);
 

--- a/test/pattern/extract.c
+++ b/test/pattern/extract.c
@@ -190,7 +190,7 @@ int mutt_extract_token(struct Buffer *dest, struct Buffer *tok, TokenFlags flags
           mutt_buffer_copy(copy, &expn);
           mutt_buffer_addstr(copy, tok->dptr);
           mutt_buffer_copy(tok, copy);
-          tok->dptr = tok->data;
+          mutt_buffer_seek(tok, 0);
           mutt_buffer_pool_release(&copy);
         }
         FREE(&expn.data);


### PR DESCRIPTION
upstream patch: https://gist.github.com/flatcap/9d701d2ec21057dd77c6f685c56647c6#file-0006-add-mutt_buffer_rewind-function-patch

This makes it a bit clearer what the assignment is doing, and reduces
direct dptr manipulation a bit.

