### PR TITLE
Fix smtp debug segfault on invalid C_SmtpAuthenticators list

### DIFF
--- a/send/smtp.c
+++ b/send/smtp.c
@@ -457,7 +457,7 @@ static int smtp_auth_sasl(struct SmtpAccountData *adata, const char *mechlist)
 
   if ((rc != SASL_OK) && (rc != SASL_CONTINUE))
   {
-    mutt_debug(LL_DEBUG2, "%s unavailable\n", mech);
+    mutt_debug(LL_DEBUG2, "%s unavailable\n", NONULL(mech));
     sasl_dispose(&saslconn);
     return SMTP_AUTH_UNAVAIL;
   }


### PR DESCRIPTION
Upstream patch: https://gist.github.com/flatcap/9d701d2ec21057dd77c6f685c56647c6#file-0013-fix-smtp-debug-segfault-on-invalid-smtpauthenticator-patch

sasl_client_start() sets the mech parameter only on success.
mutt_debug(LL_DEBUG) the whole mechlist on failure.

