### PR TITLE
 Abort IMAP open if condstore/qresync updates fetch fails

### DIFF
--- a/imap/message.c
+++ b/imap/message.c
@@ -954,6 +954,9 @@ static int read_headers_condstore_qresync_updates(struct ImapAccountData *adata,
     imap_hcache_put(mdata, imap_msn_get(&mdata->msn, header_msn - 1));
   }
 
+  if (rc != IMAP_RES_OK)
+    return -1;
+
   /* The IMAP flag setting as part of cmd_parse_fetch() ends up
    * flipping these on. */
   mdata->check_status &= ~IMAP_FLAGS_PENDING;


### PR DESCRIPTION
Upstream patch https://gist.github.com/flatcap/9d701d2ec21057dd77c6f685c56647c6#file-0010-abort-imap-open-if-condstore-qresync-updates-fetch-f-patch

Abort IMAP open if condstore/qresync updates fetch fails

An error in imap_cmd_step() was not being properly returned to the
caller.