### PR TITLE
man: -H: clarification

### DIFF
--- a/docs/neomutt.man
+++ b/docs/neomutt.man
@@ -83,7 +83,7 @@ neomutt \- The NeoMutt Mail User Agent (MUA)
 .OP \-n
 .OP \-e command
 .OP \-F config
-.BR \-D " [" \-S ]
+.BR \-D " [" \-S ] " [" \-O ]
 .YS
 .
 .SY neomutt
@@ -119,7 +119,7 @@ neomutt \- The NeoMutt Mail User Agent (MUA)
 .OP \-n
 .OP \-e command
 .OP \-F config
-.BI \-Q " variable"
+.BI \-Q " variable [" \-O ]
 .YS
 .
 .SY neomutt
@@ -197,6 +197,10 @@ Specify a carbon copy (Cc) recipient
 Dump all configuration variables as
 .RB \(aq name = value \(aq
 pairs to stdout
+.
+.TP
+.BI \-D\ \-O
+Like \fB\-D\fP, but show one-liner documentation
 .
 .TP
 .BI \-D\ \-S
@@ -280,7 +284,8 @@ Resume a prior postponed message, if any
 .TP
 .BI \-Q " variable"
 Query a configuration \fIvariable\fP and print its value to stdout (after the
-config has been read and any commands executed)
+config has been read and any commands executed).
+Add -O for one-liner documentation.
 .
 .TP
 .BI \-R

--- a/docs/neomutt.man
+++ b/docs/neomutt.man
@@ -238,9 +238,13 @@ Start NeoMutt with a listing of subscribed newsgroups
 .BI \-g " server"
 Like \fB\-G\fP, but start at specified news \fIserver\fP
 .
-.TP
 .BI \-H " draft"
-Specify a \fIdraft\fP file with header and body for message composing
+Specify a \fIdraft\fP file which contains header and body to use to send a
+message.
+If \fIdraft\fP is \*(lq\fB\-\fP\*(rq, then data is read from stdin.
+The draft file is expected to contain just an RFC822 email \(em headers and a body.
+Although it is not an mbox file, if an mbox "\fBFrom\~\fP" line is present,
+it will be silently discarded.
 .
 .TP
 .BI \-h


### PR DESCRIPTION
upstream patch: https://gist.github.com/flatcap/9d701d2ec21057dd77c6f685c56647c6#file-0003-mutt-man-h-clarify-that-a-from_-line-in-the-draft-fi-patch

man: -H: clarification
    
`From` line in the draft file is silently discarded because this is likely an mbox file