### PR TITLE
Fix pager dropped input on SigWinch flag handling

### DIFF
--- a/pager.c
+++ b/pager.c
@@ -2376,14 +2376,6 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
     else
       OldEmail = NULL;
 
-    ch = km_dokey(MENU_PAGER);
-    if (ch >= 0)
-    {
-      mutt_clear_error();
-      mutt_debug(LL_DEBUG1, "Got op %s (%d)\n", OpStrings[ch][0], ch);
-    }
-    mutt_curses_set_cursor(MUTT_CURSOR_VISIBLE);
-
     bool do_new_mail = false;
 
     if (m && !OptAttachMsg)
@@ -2500,6 +2492,14 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
       }
       continue;
     }
+
+    ch = km_dokey(MENU_PAGER);
+    if (ch >= 0)
+    {
+      mutt_clear_error();
+      mutt_debug(LL_DEBUG1, "Got op %s (%d)\n", OpStrings[ch][0], ch);
+    }
+    mutt_curses_set_cursor(MUTT_CURSOR_VISIBLE);
 
     if (ch < 0)
     {


### PR DESCRIPTION
Upstream patch: https://gist.github.com/flatcap/9d701d2ec21057dd77c6f685c56647c6#file-0007-fix-pager-dropped-input-on-sigwinch-flag-handling-patch

Fix pager dropped input on SigWinch flag handling

The code to process the SigWinch flag ocurred after, and would drop an
input character when the flag was set outside of, km_dokey().  This
could happen, for instance, when a pipe operation was invoked.

Thanks to Vincent Lefèvre for uncovering the problem.
