### PR TITLE
fix mime forwarding

### DIFF
--- a/send/sendlib.c
+++ b/send/sendlib.c
@@ -978,9 +978,8 @@ struct Body *mutt_make_message_attach(struct Mailbox *m, struct Email *e,
   CopyHeaderFlags chflags = CH_XMIT;
   cmflags = MUTT_CM_NO_FLAGS;
 
-  const bool c_forward_decode = cs_subset_bool(sub, "forward_decode");
   /* If we are attaching a message, ignore `$mime_forward_decode` */
-  if (!attach_msg && c_forward_decode)
+  if (!attach_msg && c_mime_forward_decode)
   {
     chflags |= CH_MIME | CH_TXTPLAIN;
     cmflags = MUTT_CM_DECODE | MUTT_CM_CHARCONV;


### PR DESCRIPTION
When libsend's was converted to use the config system, rather than global variables, a typo was introduced.

Fixes: #2788

---

History:

.   8e3bda144 merge: Convert libsend to use Config functions
|\  
| . 4e434fe55 send: get Config from a ConfigSubset -- **BAD COMMIT**
| . 8732a7280 config: add Config helpers
| . 3e0667e93 send: add ConfigSubset param to functions
| . d8a6a6c19 smtp: move mutt_fqdn() to mutt_smtp_send()
| . 6e686c31c smtp: pass SmtpAccountData
|/  
. 9d6fb50e5 refactor icmd_set

---

Code before conversion (using `C_MimeForwardDecode`):

https://github.com/neomutt/neomutt/blob/9d6fb50e5dafc614bfddde55e0c00c83dd9247f6/send/sendlib.c#L958-L959

Code after conversion (uses `$forward_decode`, `c_forward_decode`):

https://github.com/neomutt/neomutt/blob/4e434fe5564430ad23d00eb7886f8b5283eefd4c/send/sendlib.c#L977-L979

Fixed code (uses `c_mime_forward_decode`):

https://github.com/neomutt/neomutt/blob/ba5119eefb802d1d0ed33829bff3eadfae7c5e61/send/sendlib.c#L981-L982