### PR TITLE
mutt_save_message refactoring

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -1047,11 +1047,11 @@ int mutt_save_message(struct Mailbox *m, struct EmailList *el,
     return -1;
 
   int rc = -1;
-  int app = 0;
   int tagged_progress_count = 0;
   unsigned int msg_count = 0;
 
   struct Buffer *buf = mutt_buffer_pool_get();
+  SecurityFlags security_flags = SEC_NO_FLAGS;
   struct Progress progress;
   struct stat st;
   struct EmailNode *en = NULL;
@@ -1096,8 +1096,8 @@ int mutt_save_message(struct Mailbox *m, struct EmailList *el,
 
   if (WithCrypto)
   {
-    is_passphrase_needed = (en->email->security & SEC_ENCRYPT);
-    app = en->email->security;
+    security_flags = en->email->security;
+    is_passphrase_needed = security_flags & SEC_ENCRYPT;
   }
 
   mutt_message_hook(m, en->email, MUTT_MESSAGE_HOOK);
@@ -1131,7 +1131,7 @@ int mutt_save_message(struct Mailbox *m, struct EmailList *el,
   if (mutt_save_confirm(mutt_buffer_string(buf), &st) != 0)
     goto cleanup;
 
-  if (is_passphrase_needed && transform_opt && !crypt_valid_passphrase(app))
+  if (is_passphrase_needed && transform_opt && !crypt_valid_passphrase(security_flags))
   {
     goto cleanup;
   }

--- a/commands.h
+++ b/commands.h
@@ -53,6 +53,15 @@ enum MessageTransformOpt
   TRANSFORM_DECODE,     ///< Decode message
 };
 
+/**
+ * enum MessageSaveOpt - Message save option
+ */
+enum MessageSaveOpt
+{
+  SAVE_COPY = 0,   ///< Copy message, making a duplicate in another mailbox
+  SAVE_MOVE,       ///< Move message to another mailbox, removing the original
+};
+
 void ci_bounce_message(struct Mailbox *m, struct EmailList *el);
 void mutt_check_stats(void);
 bool mutt_check_traditional_pgp(struct EmailList *el, MuttRedrawFlags *redraw);
@@ -63,8 +72,8 @@ bool mutt_edit_content_type(struct Email *e, struct Body *b, FILE *fp);
 void mutt_enter_command(void);
 void mutt_pipe_message(struct Mailbox *m, struct EmailList *el);
 void mutt_print_message(struct Mailbox *m, struct EmailList *el);
-int  mutt_save_message(struct Mailbox *m, struct EmailList *el, bool delete_original, enum MessageTransformOpt transform_opt);
-int  mutt_save_message_ctx(struct Email *e, bool delete_original, enum MessageTransformOpt transform_opt, struct Mailbox *m);
+int  mutt_save_message(struct Mailbox *m, struct EmailList *el, enum MessageSaveOpt, enum MessageTransformOpt transform_opt);
+int  mutt_save_message_ctx(struct Email *e, enum MessageSaveOpt, enum MessageTransformOpt transform_opt, struct Mailbox *m);
 int  mutt_select_sort(bool reverse);
 bool mutt_shell_escape(void);
 

--- a/commands.h
+++ b/commands.h
@@ -43,6 +43,16 @@ extern bool          C_PrintDecode;
 extern bool          C_PrintSplit;
 extern bool          C_PromptAfter;
 
+/**
+ * enum MessageTransformOpt - Message transformation option
+ */
+enum MessageTransformOpt
+{
+  TRANSFORM_NONE = 0,   ///< No transformation
+  TRANSFORM_DECRYPT,    ///< Decrypt message
+  TRANSFORM_DECODE,     ///< Decode message
+};
+
 void ci_bounce_message(struct Mailbox *m, struct EmailList *el);
 void mutt_check_stats(void);
 bool mutt_check_traditional_pgp(struct EmailList *el, MuttRedrawFlags *redraw);
@@ -53,8 +63,8 @@ bool mutt_edit_content_type(struct Email *e, struct Body *b, FILE *fp);
 void mutt_enter_command(void);
 void mutt_pipe_message(struct Mailbox *m, struct EmailList *el);
 void mutt_print_message(struct Mailbox *m, struct EmailList *el);
-int  mutt_save_message_ctx(struct Email *e, bool delete_original, bool decode, bool decrypt, struct Mailbox *m);
-int  mutt_save_message(struct Mailbox *m, struct EmailList *el, bool delete_original, bool decode, bool decrypt);
+int  mutt_save_message(struct Mailbox *m, struct EmailList *el, bool delete_original, enum MessageTransformOpt transform_opt);
+int  mutt_save_message_ctx(struct Email *e, bool delete_original, enum MessageTransformOpt transform_opt, struct Mailbox *m);
 int  mutt_select_sort(bool reverse);
 bool mutt_shell_escape(void);
 

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -1604,7 +1604,7 @@ int imap_sync_mailbox(struct Mailbox *m, bool expunge, bool close)
         }
         bool save_append = m->append;
         m->append = true;
-        mutt_save_message_ctx(e, true, false, false, m);
+        mutt_save_message_ctx(e, true, TRANSFORM_NONE, m);
         m->append = save_append;
         /* TODO: why the check for e->env?  Is this possible? */
         if (e->env)

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -1604,7 +1604,7 @@ int imap_sync_mailbox(struct Mailbox *m, bool expunge, bool close)
         }
         bool save_append = m->append;
         m->append = true;
-        mutt_save_message_ctx(e, true, TRANSFORM_NONE, m);
+        mutt_save_message_ctx(e, SAVE_MOVE, TRANSFORM_NONE, m);
         m->append = save_append;
         /* TODO: why the check for e->env?  Is this possible? */
         if (e->env)

--- a/imap/lib.h
+++ b/imap/lib.h
@@ -57,6 +57,7 @@
 #include <sys/types.h>
 #include "core/lib.h"
 #include "mx.h"
+#include "commands.h"
 
 struct BrowserState;
 struct Buffer;
@@ -98,7 +99,7 @@ int imap_mailbox_rename(const char *path);
 bool config_init_imap(struct ConfigSet *cs);
 
 /* message.c */
-int imap_copy_messages(struct Mailbox *m, struct EmailList *el, const char *dest, bool delete_original);
+int imap_copy_messages(struct Mailbox *m, struct EmailList *el, const char *dest, enum MessageSaveOpt save_opt);
 
 /* socket.c */
 void imap_logout_all(void);

--- a/imap/message.c
+++ b/imap/message.c
@@ -1553,15 +1553,16 @@ fail:
 
 /**
  * imap_copy_messages - Server COPY messages to another folder
- * @param m      Mailbox
- * @param el     List of Emails to copy
- * @param dest   Destination folder
- * @param delete_original Delete the original?
+ * @param m        Mailbox
+ * @param el       List of Emails to copy
+ * @param dest     Destination folder
+ * @param save_opt Copy or move, e.g. #SAVE_MOVE
  * @retval -1 Error
  * @retval  0 Success
  * @retval  1 Non-fatal error - try fetch/append
  */
-int imap_copy_messages(struct Mailbox *m, struct EmailList *el, const char *dest, bool delete_original)
+int imap_copy_messages(struct Mailbox *m, struct EmailList *el,
+                       const char *dest, enum MessageSaveOpt save_opt)
 {
   if (!m || !el || !dest)
     return -1;
@@ -1706,7 +1707,7 @@ int imap_copy_messages(struct Mailbox *m, struct EmailList *el, const char *dest
   }
 
   /* cleanup */
-  if (delete_original)
+  if (save_opt == SAVE_MOVE)
   {
     STAILQ_FOREACH(en, el, entries)
     {

--- a/index.c
+++ b/index.c
@@ -2824,10 +2824,13 @@ int mutt_index_menu(struct MuttWindow *dlg)
 
         const bool delete_original =
             (op == OP_SAVE) || (op == OP_DECODE_SAVE) || (op == OP_DECRYPT_SAVE);
-        const bool decode = (op == OP_DECODE_SAVE) || (op == OP_DECODE_COPY);
-        const bool decrypt = (op == OP_DECRYPT_SAVE) || (op == OP_DECRYPT_COPY);
 
-        if ((mutt_save_message(Context->mailbox, &el, delete_original, decode, decrypt) == 0) &&
+        enum MessageTransformOpt transform_opt =
+            ((op == OP_DECODE_SAVE) || (op == OP_DECODE_COPY)) ? TRANSFORM_DECODE :
+            ((op == OP_DECRYPT_SAVE) || (op == OP_DECRYPT_COPY)) ? TRANSFORM_DECRYPT :
+                                                                   TRANSFORM_NONE;
+
+        if ((mutt_save_message(Context->mailbox, &el, delete_original, transform_opt) == 0) &&
             delete_original)
         {
           menu->redraw |= REDRAW_STATUS;

--- a/index.c
+++ b/index.c
@@ -2822,16 +2822,18 @@ int mutt_index_menu(struct MuttWindow *dlg)
         struct EmailList el = STAILQ_HEAD_INITIALIZER(el);
         el_add_tagged(&el, Context, cur.e, tag);
 
-        const bool delete_original =
-            (op == OP_SAVE) || (op == OP_DECODE_SAVE) || (op == OP_DECRYPT_SAVE);
+        const enum MessageSaveOpt save_opt =
+            ((op == OP_SAVE) || (op == OP_DECODE_SAVE) || (op == OP_DECRYPT_SAVE)) ?
+                SAVE_MOVE :
+                SAVE_COPY;
 
         enum MessageTransformOpt transform_opt =
             ((op == OP_DECODE_SAVE) || (op == OP_DECODE_COPY)) ? TRANSFORM_DECODE :
             ((op == OP_DECRYPT_SAVE) || (op == OP_DECRYPT_COPY)) ? TRANSFORM_DECRYPT :
                                                                    TRANSFORM_NONE;
 
-        if ((mutt_save_message(Context->mailbox, &el, delete_original, transform_opt) == 0) &&
-            delete_original)
+        const int rc = mutt_save_message(Context->mailbox, &el, save_opt, transform_opt);
+        if ((rc == 0) && (save_opt == SAVE_MOVE))
         {
           menu->redraw |= REDRAW_STATUS;
           if (tag)

--- a/mx.c
+++ b/mx.c
@@ -47,6 +47,7 @@
 #include "mx.h"
 #include "maildir/lib.h"
 #include "mbox/lib.h"
+#include "commands.h"
 #include "context.h"
 #include "copy.h"
 #include "hook.h"
@@ -774,7 +775,7 @@ int mx_mbox_close(struct Context **ptr)
           e->tagged = false;
       }
 
-      i = imap_copy_messages(ctx->mailbox, &el, mutt_buffer_string(mbox), true);
+      i = imap_copy_messages(ctx->mailbox, &el, mutt_buffer_string(mbox), SAVE_MOVE);
       emaillist_clear(&el);
     }
 

--- a/pager.c
+++ b/pager.c
@@ -3381,16 +3381,18 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         struct EmailList el = STAILQ_HEAD_INITIALIZER(el);
         emaillist_add_email(&el, extra->email);
 
-        const bool delete_original =
-            (ch == OP_SAVE) || (ch == OP_DECODE_SAVE) || (ch == OP_DECRYPT_SAVE);
+        const enum MessageSaveOpt save_opt =
+            ((ch == OP_SAVE) || (ch == OP_DECODE_SAVE) || (ch == OP_DECRYPT_SAVE)) ?
+                SAVE_MOVE :
+                SAVE_COPY;
 
         enum MessageTransformOpt transform_opt =
             ((ch == OP_DECODE_SAVE) || (ch == OP_DECODE_COPY)) ? TRANSFORM_DECODE :
             ((ch == OP_DECRYPT_SAVE) || (ch == OP_DECRYPT_COPY)) ? TRANSFORM_DECRYPT :
                                                                    TRANSFORM_NONE;
 
-        if ((mutt_save_message(Context->mailbox, &el, delete_original, transform_opt) == 0) &&
-            delete_original)
+        const int rc2 = mutt_save_message(Context->mailbox, &el, save_opt, transform_opt);
+        if ((rc2 == 0) && (save_opt == SAVE_MOVE))
         {
           if (C_Resolve)
           {

--- a/pager.c
+++ b/pager.c
@@ -3383,10 +3383,13 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
 
         const bool delete_original =
             (ch == OP_SAVE) || (ch == OP_DECODE_SAVE) || (ch == OP_DECRYPT_SAVE);
-        const bool decode = (ch == OP_DECODE_SAVE) || (ch == OP_DECODE_COPY);
-        const bool decrypt = (ch == OP_DECRYPT_SAVE) || (ch == OP_DECRYPT_COPY);
 
-        if ((mutt_save_message(Context->mailbox, &el, delete_original, decode, decrypt) == 0) &&
+        enum MessageTransformOpt transform_opt =
+            ((ch == OP_DECODE_SAVE) || (ch == OP_DECODE_COPY)) ? TRANSFORM_DECODE :
+            ((ch == OP_DECRYPT_SAVE) || (ch == OP_DECRYPT_COPY)) ? TRANSFORM_DECRYPT :
+                                                                   TRANSFORM_NONE;
+
+        if ((mutt_save_message(Context->mailbox, &el, delete_original, transform_opt) == 0) &&
             delete_original)
         {
           if (C_Resolve)


### PR DESCRIPTION
This PR has many refactorings of `mutt_save_message()` function.
Each commit is atomic and results in a green build.

Brief overview of changes:

- `decrypt` and `decode`  boolean flags are merged into `enum MessageTransformOpt` 
- `delete_original` boolean flag is changed into `enum MessageSaveOpt`
- upstream patch https://gist.github.com/flatcap/9d701d2ec21057dd77c6f685c56647c6#file-0008-add-a-mutt_error-when-copy-save-messages-fails-patch
- `single` local variable is removed as unneded in favor of `msg_count` that was already present
- various whitespace, formatting, naming changes,  minor code restructuring to improve readability

Please see individual commit messages for details and explanations.
