### PR TITLE
buffer: replace mutt_b2s macro with mutt_buffer_string function

### DIFF
--- a/alias/dlgquery.c
+++ b/alias/dlgquery.c
@@ -247,10 +247,10 @@ static int query_run(char *s, bool verbose, struct AliasList *al,
   const char *query_command = cs_subset_string(sub, "query_command");
   mutt_buffer_file_expand_fmt_quote(cmd, query_command, s);
 
-  pid_t pid = filter_create(mutt_b2s(cmd), NULL, &fp, NULL);
+  pid_t pid = filter_create(mutt_buffer_string(cmd), NULL, &fp, NULL);
   if (pid < 0)
   {
-    mutt_debug(LL_DEBUG1, "unable to fork command: %s\n", mutt_b2s(cmd));
+    mutt_debug(LL_DEBUG1, "unable to fork command: %s\n", mutt_buffer_string(cmd));
     mutt_buffer_pool_release(&cmd);
     return -1;
   }

--- a/autocrypt/autocrypt.c
+++ b/autocrypt/autocrypt.c
@@ -69,7 +69,7 @@ static int autocrypt_dir_init(bool can_create)
      for some reason (e.g. autocrypt, header cache, bcache), but it
      doesn't exist.  The prompt is asking whether to create the directory */
   mutt_buffer_printf(prompt, _("%s does not exist. Create it?"), C_AutocryptDir);
-  if (mutt_yesorno(mutt_b2s(prompt), MUTT_YES) == MUTT_YES)
+  if (mutt_yesorno(mutt_buffer_string(prompt), MUTT_YES) == MUTT_YES)
   {
     if (mutt_file_mkdir(C_AutocryptDir, S_IRWXU) < 0)
     {
@@ -219,8 +219,11 @@ int mutt_autocrypt_account_init(bool prompt)
   if (mutt_yesorno(_("Prefer encryption?"), MUTT_NO) == MUTT_YES)
     prefer_encrypt = true;
 
-  if (mutt_autocrypt_db_account_insert(addr, mutt_b2s(keyid), mutt_b2s(keydata), prefer_encrypt))
+  if (mutt_autocrypt_db_account_insert(addr, mutt_buffer_string(keyid),
+                                       mutt_buffer_string(keydata), prefer_encrypt))
+  {
     goto cleanup;
+  }
 
   rc = 0;
 
@@ -359,7 +362,7 @@ int mutt_autocrypt_process_autocrypt_header(struct Email *e, struct Envelope *en
     keyid = mutt_buffer_pool_get();
     if (mutt_autocrypt_gpgme_import_key(peer->keydata, keyid))
       goto cleanup;
-    mutt_str_replace(&peer->keyid, mutt_b2s(keyid));
+    mutt_str_replace(&peer->keyid, mutt_buffer_string(keyid));
   }
 
   if (insert_db && mutt_autocrypt_db_peer_insert(from, peer))
@@ -498,7 +501,7 @@ int mutt_autocrypt_process_gossip_header(struct Email *e, struct Envelope *prot_
     {
       if (mutt_autocrypt_gpgme_import_key(peer->gossip_keydata, keyid))
         goto cleanup;
-      mutt_str_replace(&peer->gossip_keyid, mutt_b2s(keyid));
+      mutt_str_replace(&peer->gossip_keyid, mutt_buffer_string(keyid));
     }
 
     if (insert_db && mutt_autocrypt_db_peer_insert(peer_addr, peer))
@@ -666,7 +669,7 @@ enum AutocryptRec mutt_autocrypt_ui_recommendation(struct Email *e, char **keyli
     rc = AUTOCRYPT_REC_AVAILABLE;
 
   if (keylist)
-    mutt_str_replace(keylist, mutt_b2s(keylist_buf));
+    mutt_str_replace(keylist, mutt_buffer_string(keylist_buf));
 
 cleanup:
   mutt_autocrypt_db_account_free(&account);
@@ -917,7 +920,7 @@ void mutt_autocrypt_scan_mailboxes(void)
         (!mutt_buffer_is_empty(folderbuf)))
     {
       mutt_buffer_expand_path_regex(folderbuf, false);
-      struct Mailbox *m = mx_path_resolve(mutt_b2s(folderbuf));
+      struct Mailbox *m = mx_path_resolve(mutt_buffer_string(folderbuf));
       /* NOTE: I am purposely *not* executing folder hooks here,
        * as they can do all sorts of things like push into the getch() buffer.
        * Authentication should be in account-hooks. */

--- a/autocrypt/db.c
+++ b/autocrypt/db.c
@@ -88,13 +88,14 @@ int mutt_autocrypt_db_init(bool can_create)
   mutt_buffer_concat_path(db_path, C_AutocryptDir, "autocrypt.db");
 
   struct stat sb;
-  if (stat(mutt_b2s(db_path), &sb) == 0)
+  if (stat(mutt_buffer_string(db_path), &sb) == 0)
   {
-    if (sqlite3_open_v2(mutt_b2s(db_path), &AutocryptDB, SQLITE_OPEN_READWRITE, NULL) != SQLITE_OK)
+    if (sqlite3_open_v2(mutt_buffer_string(db_path), &AutocryptDB,
+                        SQLITE_OPEN_READWRITE, NULL) != SQLITE_OK)
     {
       /* L10N: Error message if autocrypt couldn't open the SQLite database
          for some reason.  The %s is the full path of the database file.  */
-      mutt_error(_("Unable to open autocrypt database %s"), mutt_b2s(db_path));
+      mutt_error(_("Unable to open autocrypt database %s"), mutt_buffer_string(db_path));
       goto cleanup;
     }
 
@@ -105,7 +106,7 @@ int mutt_autocrypt_db_init(bool can_create)
   {
     if (!can_create)
       goto cleanup;
-    if (autocrypt_db_create(mutt_b2s(db_path)))
+    if (autocrypt_db_create(mutt_buffer_string(db_path)))
       goto cleanup;
     /* Don't abort the whole init process because account creation failed */
     mutt_autocrypt_account_init(true);

--- a/autocrypt/gpgme.c
+++ b/autocrypt/gpgme.c
@@ -187,10 +187,10 @@ int mutt_autocrypt_gpgme_create_key(struct Address *addr, struct Buffer *keyid,
   if (!keyresult->fpr)
     goto cleanup;
   mutt_buffer_strcpy(keyid, keyresult->fpr);
-  mutt_debug(LL_DEBUG1, "Generated key with id %s\n", mutt_b2s(keyid));
+  mutt_debug(LL_DEBUG1, "Generated key with id %s\n", mutt_buffer_string(keyid));
 
   /* Get gpgme_key_t to create the secondary key and export keydata */
-  err = gpgme_get_key(ctx, mutt_b2s(keyid), &primary_key, 0);
+  err = gpgme_get_key(ctx, mutt_buffer_string(keyid), &primary_key, 0);
   if (err)
     goto cleanup;
 
@@ -206,7 +206,7 @@ int mutt_autocrypt_gpgme_create_key(struct Address *addr, struct Buffer *keyid,
   /* get keydata */
   if (export_keydata(ctx, primary_key, keydata))
     goto cleanup;
-  mutt_debug(LL_DEBUG1, "key has keydata *%s*\n", mutt_b2s(keydata));
+  mutt_debug(LL_DEBUG1, "key has keydata *%s*\n", mutt_buffer_string(keydata));
 
   rc = 0;
 
@@ -236,7 +236,7 @@ int mutt_autocrypt_gpgme_select_key(struct Buffer *keyid, struct Buffer *keydata
   if (create_gpgme_context(&ctx))
     goto cleanup;
 
-  if (gpgme_get_key(ctx, mutt_b2s(keyid), &key, 0))
+  if (gpgme_get_key(ctx, mutt_buffer_string(keyid), &key, 0))
     goto cleanup;
 
   if (key->revoked || key->expired || key->disabled || key->invalid ||
@@ -246,7 +246,7 @@ int mutt_autocrypt_gpgme_select_key(struct Buffer *keyid, struct Buffer *keydata
        this is displayed if the key was revoked/expired/disabled/invalid
        or can't be used for both signing and encryption.
        %s is the key fingerprint.  */
-    mutt_error(_("The key %s is not usable for autocrypt"), mutt_b2s(keyid));
+    mutt_error(_("The key %s is not usable for autocrypt"), mutt_buffer_string(keyid));
     goto cleanup;
   }
 
@@ -324,8 +324,11 @@ int mutt_autocrypt_gpgme_import_key(const char *keydata, struct Buffer *keyid)
   if (!mutt_b64_buffer_decode(raw_keydata, keydata))
     goto cleanup;
 
-  if (gpgme_data_new_from_mem(&dh, mutt_b2s(raw_keydata), mutt_buffer_len(raw_keydata), 0))
+  if (gpgme_data_new_from_mem(&dh, mutt_buffer_string(raw_keydata),
+                              mutt_buffer_len(raw_keydata), 0))
+  {
     goto cleanup;
+  }
 
   if (gpgme_op_import(ctx, dh))
     goto cleanup;

--- a/bcache/bcache.c
+++ b/bcache/bcache.c
@@ -93,11 +93,11 @@ static int bcache_path(struct ConnAccount *account, const char *mailbox, struct 
   struct Buffer *dst = mutt_buffer_pool_get();
   mutt_encode_path(path, NONULL(mailbox));
 
-  mutt_buffer_printf(dst, "%s/%s%s", C_MessageCachedir, host, mutt_b2s(path));
+  mutt_buffer_printf(dst, "%s/%s%s", C_MessageCachedir, host, mutt_buffer_string(path));
   if (*(dst->dptr - 1) != '/')
     mutt_buffer_addch(dst, '/');
 
-  mutt_debug(LL_DEBUG3, "path: '%s'\n", mutt_b2s(dst));
+  mutt_debug(LL_DEBUG3, "path: '%s'\n", mutt_buffer_string(dst));
   bcache->path = mutt_buffer_strdup(dst);
 
   mutt_buffer_pool_release(&path);
@@ -122,9 +122,10 @@ static int mutt_bcache_move(struct BodyCache *bcache, const char *id, const char
   mutt_buffer_printf(path, "%s%s", bcache->path, id);
   mutt_buffer_printf(newpath, "%s%s", bcache->path, newid);
 
-  mutt_debug(LL_DEBUG3, "bcache: mv: '%s' '%s'\n", mutt_b2s(path), mutt_b2s(newpath));
+  mutt_debug(LL_DEBUG3, "bcache: mv: '%s' '%s'\n", mutt_buffer_string(path),
+             mutt_buffer_string(newpath));
 
-  int rc = rename(mutt_b2s(path), mutt_b2s(newpath));
+  int rc = rename(mutt_buffer_string(path), mutt_buffer_string(newpath));
   mutt_buffer_pool_release(&path);
   mutt_buffer_pool_release(&newpath);
   return rc;
@@ -185,9 +186,10 @@ FILE *mutt_bcache_get(struct BodyCache *bcache, const char *id)
   mutt_buffer_addstr(path, bcache->path);
   mutt_buffer_addstr(path, id);
 
-  FILE *fp = mutt_file_fopen(mutt_b2s(path), "r");
+  FILE *fp = mutt_file_fopen(mutt_buffer_string(path), "r");
 
-  mutt_debug(LL_DEBUG3, "bcache: get: '%s': %s\n", mutt_b2s(path), fp ? "yes" : "no");
+  mutt_debug(LL_DEBUG3, "bcache: get: '%s': %s\n", mutt_buffer_string(path),
+             fp ? "yes" : "no");
 
   mutt_buffer_pool_release(&path);
   return fp;
@@ -231,7 +233,7 @@ FILE *mutt_bcache_put(struct BodyCache *bcache, const char *id)
 
   mutt_debug(LL_DEBUG3, "bcache: put: '%s'\n", path);
 
-  FILE *fp = mutt_file_fopen(mutt_b2s(path), "w+");
+  FILE *fp = mutt_file_fopen(mutt_buffer_string(path), "w+");
   mutt_buffer_pool_release(&path);
   return fp;
 }
@@ -248,7 +250,7 @@ int mutt_bcache_commit(struct BodyCache *bcache, const char *id)
   struct Buffer *tmpid = mutt_buffer_pool_get();
   mutt_buffer_printf(tmpid, "%s.tmp", id);
 
-  int rc = mutt_bcache_move(bcache, mutt_b2s(tmpid), id);
+  int rc = mutt_bcache_move(bcache, mutt_buffer_string(tmpid), id);
   mutt_buffer_pool_release(&tmpid);
   return rc;
 }
@@ -269,9 +271,9 @@ int mutt_bcache_del(struct BodyCache *bcache, const char *id)
   mutt_buffer_addstr(path, bcache->path);
   mutt_buffer_addstr(path, id);
 
-  mutt_debug(LL_DEBUG3, "bcache: del: '%s'\n", mutt_b2s(path));
+  mutt_debug(LL_DEBUG3, "bcache: del: '%s'\n", mutt_buffer_string(path));
 
-  int rc = unlink(mutt_b2s(path));
+  int rc = unlink(mutt_buffer_string(path));
   mutt_buffer_pool_release(&path);
   return rc;
 }
@@ -294,12 +296,12 @@ int mutt_bcache_exists(struct BodyCache *bcache, const char *id)
 
   int rc = 0;
   struct stat st;
-  if (stat(mutt_b2s(path), &st) < 0)
+  if (stat(mutt_buffer_string(path), &st) < 0)
     rc = -1;
   else
     rc = (S_ISREG(st.st_mode) && (st.st_size != 0)) ? 0 : -1;
 
-  mutt_debug(LL_DEBUG3, "bcache: exists: '%s': %s\n", mutt_b2s(path),
+  mutt_debug(LL_DEBUG3, "bcache: exists: '%s': %s\n", mutt_buffer_string(path),
              (rc == 0) ? "yes" : "no");
 
   mutt_buffer_pool_release(&path);

--- a/command_parse.c
+++ b/command_parse.c
@@ -676,7 +676,7 @@ enum CommandResult parse_cd(struct Buffer *buf, struct Buffer *s, intptr_t data,
     }
   }
 
-  if (chdir(mutt_b2s(buf)) != 0)
+  if (chdir(mutt_buffer_string(buf)) != 0)
   {
     mutt_buffer_printf(err, "cd: %s", strerror(errno));
     return MUTT_CMD_ERROR;
@@ -1291,7 +1291,7 @@ enum CommandResult parse_set(struct Buffer *buf, struct Buffer *s,
               mutt_buffer_expand_path(&scratch);
             }
             mutt_buffer_reset(buf);
-            mutt_buffer_addstr(buf, mutt_b2s(&scratch));
+            mutt_buffer_addstr(buf, mutt_buffer_string(&scratch));
             mutt_buffer_dealloc(&scratch);
           }
           if (increment)
@@ -1985,7 +1985,7 @@ enum CommandResult parse_unmailboxes(struct Buffer *buf, struct Buffer *s,
     struct Account *a = NULL;
     TAILQ_FOREACH(a, &NeoMutt->accounts, entries)
     {
-      struct Mailbox *m = mx_mbox_find(a, mutt_b2s(buf));
+      struct Mailbox *m = mx_mbox_find(a, mutt_buffer_string(buf));
       if (m)
       {
         do_unmailboxes(m);

--- a/complete.c
+++ b/complete.c
@@ -92,9 +92,9 @@ int mutt_complete(char *buf, size_t buflen)
   else
     mutt_buffer_strcpy(imap_path, buf);
 
-  if (imap_path_probe(mutt_b2s(imap_path), NULL) == MUTT_IMAP)
+  if (imap_path_probe(mutt_buffer_string(imap_path), NULL) == MUTT_IMAP)
   {
-    rc = imap_complete(buf, buflen, mutt_b2s(imap_path));
+    rc = imap_complete(buf, buflen, mutt_buffer_string(imap_path));
     mutt_buffer_pool_release(&imap_path);
     return rc;
   }
@@ -117,15 +117,16 @@ int mutt_complete(char *buf, size_t buflen)
     p = strrchr(buf, '/');
     if (p)
     {
-      mutt_buffer_concatn_path(tmp, mutt_b2s(exp_dirpart), mutt_buffer_len(exp_dirpart),
-                               buf + 1, (size_t)(p - buf - 1));
+      mutt_buffer_concatn_path(tmp, mutt_buffer_string(exp_dirpart),
+                               mutt_buffer_len(exp_dirpart), buf + 1,
+                               (size_t)(p - buf - 1));
       mutt_buffer_copy(exp_dirpart, tmp);
       mutt_buffer_substrcpy(dirpart, buf, p + 1);
       mutt_buffer_strcpy(filepart, p + 1);
     }
     else
       mutt_buffer_strcpy(filepart, buf + 1);
-    dirp = opendir(mutt_b2s(exp_dirpart));
+    dirp = opendir(mutt_buffer_string(exp_dirpart));
   }
   else
   {
@@ -137,7 +138,7 @@ int mutt_complete(char *buf, size_t buflen)
         p = buf + 1;
         mutt_buffer_strcpy(dirpart, "/");
         mutt_buffer_strcpy(filepart, p);
-        dirp = opendir(mutt_b2s(dirpart));
+        dirp = opendir(mutt_buffer_string(dirpart));
       }
       else
       {
@@ -145,7 +146,7 @@ int mutt_complete(char *buf, size_t buflen)
         mutt_buffer_strcpy(filepart, p + 1);
         mutt_buffer_copy(exp_dirpart, dirpart);
         mutt_buffer_expand_path(exp_dirpart);
-        dirp = opendir(mutt_b2s(exp_dirpart));
+        dirp = opendir(mutt_buffer_string(exp_dirpart));
       }
     }
     else
@@ -158,8 +159,8 @@ int mutt_complete(char *buf, size_t buflen)
 
   if (!dirp)
   {
-    mutt_debug(LL_DEBUG1, "%s: %s (errno %d)\n", mutt_b2s(exp_dirpart),
-               strerror(errno), errno);
+    mutt_debug(LL_DEBUG1, "%s: %s (errno %d)\n",
+               mutt_buffer_string(exp_dirpart), strerror(errno), errno);
     goto cleanup;
   }
 
@@ -181,7 +182,7 @@ int mutt_complete(char *buf, size_t buflen)
 
   while ((de = readdir(dirp)))
   {
-    if (mutt_strn_equal(de->d_name, mutt_b2s(filepart), len))
+    if (mutt_strn_equal(de->d_name, mutt_buffer_string(filepart), len))
     {
       if (init)
       {
@@ -211,8 +212,8 @@ int mutt_complete(char *buf, size_t buflen)
           mutt_buffer_copy(tmp, exp_dirpart);
           mutt_buffer_addch(tmp, '/');
         }
-        mutt_buffer_addstr(tmp, mutt_b2s(filepart));
-        if ((stat(mutt_b2s(tmp), &st) != -1) && (st.st_mode & S_IFDIR))
+        mutt_buffer_addstr(tmp, mutt_buffer_string(filepart));
+        if ((stat(mutt_buffer_string(tmp), &st) != -1) && (st.st_mode & S_IFDIR))
           mutt_buffer_addch(filepart, '/');
         init = 1;
       }
@@ -222,16 +223,16 @@ int mutt_complete(char *buf, size_t buflen)
 
   if (!mutt_buffer_is_empty(dirpart))
   {
-    mutt_str_copy(buf, mutt_b2s(dirpart), buflen);
-    if (!mutt_str_equal("/", mutt_b2s(dirpart)) &&
-        (mutt_b2s(dirpart)[0] != '=') && (mutt_b2s(dirpart)[0] != '+'))
+    mutt_str_copy(buf, mutt_buffer_string(dirpart), buflen);
+    if (!mutt_str_equal("/", mutt_buffer_string(dirpart)) &&
+        (mutt_buffer_string(dirpart)[0] != '=') && (mutt_buffer_string(dirpart)[0] != '+'))
     {
       mutt_str_copy(buf + strlen(buf), "/", buflen - strlen(buf));
     }
-    mutt_str_copy(buf + strlen(buf), mutt_b2s(filepart), buflen - strlen(buf));
+    mutt_str_copy(buf + strlen(buf), mutt_buffer_string(filepart), buflen - strlen(buf));
   }
   else
-    mutt_str_copy(buf, mutt_b2s(filepart), buflen);
+    mutt_str_copy(buf, mutt_buffer_string(filepart), buflen);
 
 cleanup:
   mutt_buffer_pool_release(&dirpart);

--- a/compmbox/compress.c
+++ b/compmbox/compress.c
@@ -263,12 +263,12 @@ static const char *compress_format_str(char *buf, size_t buflen, size_t col, int
     case 'f':
       /* Compressed file */
       mutt_buffer_quote_filename(quoted, m->realpath, false);
-      snprintf(buf, buflen, "%s", mutt_b2s(quoted));
+      snprintf(buf, buflen, "%s", mutt_buffer_string(quoted));
       break;
     case 't':
       /* Plaintext, temporary file */
       mutt_buffer_quote_filename(quoted, mailbox_path(m), false);
-      snprintf(buf, buflen, "%s", mutt_b2s(quoted));
+      snprintf(buf, buflen, "%s", mutt_buffer_string(quoted));
       break;
   }
 

--- a/config/set.c
+++ b/config/set.c
@@ -297,7 +297,7 @@ bool cs_register_variables(const struct ConfigSet *cs, struct ConfigDef vars[], 
     vars[i].type |= flags;
     if (!reg_one_var(cs, &vars[i], &err))
     {
-      mutt_debug(LL_DEBUG1, "%s\n", mutt_b2s(&err));
+      mutt_debug(LL_DEBUG1, "%s\n", mutt_buffer_string(&err));
       rc = false;
     }
   }

--- a/conn/getdomain.c
+++ b/conn/getdomain.c
@@ -98,7 +98,7 @@ int getdnsdomainname(struct Buffer *domain)
   {
     mutt_buffer_strcpy(domain, ++p);
     rc = 0;
-    mutt_debug(LL_DEBUG1, "Hostname: %s\n", mutt_b2s(domain));
+    mutt_debug(LL_DEBUG1, "Hostname: %s\n", mutt_buffer_string(domain));
     freeaddrinfo(h);
   }
 #endif /* HAVE_GETADDRINFO || defined HAVE_GETADDRINFO_A */

--- a/conn/gnutls.c
+++ b/conn/gnutls.c
@@ -793,11 +793,11 @@ static int tls_set_priority(struct TlsSockData *data)
     goto cleanup;
   }
 
-  int err = gnutls_priority_set_direct(data->state, mutt_b2s(priority), NULL);
+  int err = gnutls_priority_set_direct(data->state, mutt_buffer_string(priority), NULL);
   if (err < 0)
   {
-    mutt_error("gnutls_priority_set_direct(%s): %s", mutt_b2s(priority),
-               gnutls_strerror(err));
+    mutt_error("gnutls_priority_set_direct(%s): %s",
+               mutt_buffer_string(priority), gnutls_strerror(err));
     goto cleanup;
   }
 

--- a/conn/openssl.c
+++ b/conn/openssl.c
@@ -556,7 +556,7 @@ static int ssl_init(void)
 #ifdef HAVE_RAND_EGD
     add_entropy(mutt_str_getenv("EGDSOCKET"));
     mutt_buffer_printf(path, "%s/.entropy", NONULL(HomeDir));
-    add_entropy(mutt_b2s(path));
+    add_entropy(mutt_buffer_string(path));
     add_entropy(TMPDIR "/entropy");
 #endif
 

--- a/copy.c
+++ b/copy.c
@@ -670,7 +670,7 @@ int mutt_copy_message_fp(FILE *fp_out, FILE *fp_in, struct Email *e,
       /* Copy the body */
       if (fseeko(fp_in, body->offset, SEEK_SET) < 0)
         goto attach_del_cleanup;
-      if (copy_delete_attach(body, fp_in, fp_out, mutt_b2s(quoted_date)))
+      if (copy_delete_attach(body, fp_in, fp_out, mutt_buffer_string(quoted_date)))
         goto attach_del_cleanup;
 
       mutt_buffer_pool_release(&quoted_date);

--- a/core/mailbox.h
+++ b/core/mailbox.h
@@ -203,7 +203,7 @@ void            mailbox_update    (struct Mailbox *m);
  */
 static inline const char *mailbox_path(const struct Mailbox *m) // LCOV_EXCL_LINE
 {
-  return mutt_b2s(&m->pathbuf); // LCOV_EXCL_LINE
+  return mutt_buffer_string(&m->pathbuf); // LCOV_EXCL_LINE
 }
 
 #endif /* MUTT_CORE_MAILBOX_H */

--- a/debug/email.c
+++ b/debug/email.c
@@ -60,7 +60,7 @@ void dump_list_head(const struct ListHead *list, const char *name)
     mutt_buffer_addstr(&buf, np->data);
   }
 
-  mutt_debug(LL_DEBUG1, "\t%s: %s\n", name, mutt_b2s(&buf));
+  mutt_debug(LL_DEBUG1, "\t%s: %s\n", name, mutt_buffer_string(&buf));
   mutt_buffer_dealloc(&buf);
 }
 
@@ -78,7 +78,7 @@ void dump_envelope(const struct Envelope *env)
   ADD_FLAG(MUTT_ENV_CHANGED_SUBJECT);
 #undef ADD_FLAG
   mutt_debug(LL_DEBUG1, "\tchanged: %s\n",
-             mutt_buffer_is_empty(&buf) ? "[NONE]" : mutt_b2s(&buf));
+             mutt_buffer_is_empty(&buf) ? "[NONE]" : mutt_buffer_string(&buf));
 
 #define ADDR_LIST(AL) dump_addr_list(arr, sizeof(arr), &env->AL, #AL)
   ADDR_LIST(return_path);
@@ -117,7 +117,7 @@ void dump_envelope(const struct Envelope *env)
   dump_list_head(&env->userhdrs, "userhdrs");
 
   if (!mutt_buffer_is_empty(&env->spam))
-    mutt_debug(LL_DEBUG1, "\tspam: %s\n", mutt_b2s(&env->spam));
+    mutt_debug(LL_DEBUG1, "\tspam: %s\n", mutt_buffer_string(&env->spam));
 
 #ifdef USE_AUTOCRYPT
   if (env->autocrypt)
@@ -167,7 +167,7 @@ void dump_email(const struct Email *e)
   ADD_FLAG(visible);
 #undef ADD_FLAG
   mutt_debug(LL_DEBUG1, "\tFlags: %s\n",
-             mutt_buffer_is_empty(&buf) ? "[NONE]" : mutt_b2s(&buf));
+             mutt_buffer_is_empty(&buf) ? "[NONE]" : mutt_buffer_string(&buf));
 
 #define ADD_FLAG(F) add_flag(&buf, (e->security & F), #F)
   mutt_buffer_reset(&buf);
@@ -187,7 +187,7 @@ void dump_email(const struct Email *e)
   ADD_FLAG(PGP_TRADITIONAL_CHECKED);
 #undef ADD_FLAG
   mutt_debug(LL_DEBUG1, "\tSecurity: %s\n",
-             mutt_buffer_is_empty(&buf) ? "[NONE]" : mutt_b2s(&buf));
+             mutt_buffer_is_empty(&buf) ? "[NONE]" : mutt_buffer_string(&buf));
 
   mutt_date_make_tls(arr, sizeof(arr), e->date_sent);
   mutt_debug(LL_DEBUG1, "\tSent: %s (%c%02u%02u)\n", arr,
@@ -259,7 +259,7 @@ void dump_body(const struct Body *body)
   ADD_FLAG(warnsig);
 #undef ADD_FLAG
   mutt_debug(LL_DEBUG1, "\tFlags: %s\n",
-             mutt_buffer_is_empty(&buf) ? "[NONE]" : mutt_b2s(&buf));
+             mutt_buffer_is_empty(&buf) ? "[NONE]" : mutt_buffer_string(&buf));
 
 #define OPT_STRING(S)                                                          \
   if (body->S)                                                                 \

--- a/debug/graphviz.c
+++ b/debug/graphviz.c
@@ -594,14 +594,14 @@ static void dot_mailbox(FILE *fp, struct Mailbox *m, struct ListHead *links)
 
   if ((m->type == MUTT_IMAP) || (m->type == MUTT_POP))
   {
-    dot_path_imap(buf, sizeof(buf), mutt_b2s(&m->pathbuf));
+    dot_path_imap(buf, sizeof(buf), mutt_buffer_string(&m->pathbuf));
     dot_type_string(fp, "pathbuf", buf, true);
     dot_path_imap(buf, sizeof(buf), m->realpath);
     dot_type_string(fp, "realpath", buf, true);
   }
   else
   {
-    dot_path_fs(buf, sizeof(buf), mutt_b2s(&m->pathbuf));
+    dot_path_fs(buf, sizeof(buf), mutt_buffer_string(&m->pathbuf));
     dot_type_string(fp, "pathbuf", buf, true);
     dot_path_fs(buf, sizeof(buf), m->realpath);
     dot_type_string(fp, "realpath", buf, true);
@@ -966,7 +966,7 @@ void dump_graphviz(const char *title)
   dot_ptr_name(obj1, sizeof(obj1), NeoMutt);
   dot_ptr_name(obj2, sizeof(obj2), NeoMutt->sub);
   mutt_buffer_printf(&buf, "{ rank=same %s %s }", obj1, obj2);
-  mutt_list_insert_tail(&links, mutt_str_dup(mutt_b2s(&buf)));
+  mutt_list_insert_tail(&links, mutt_str_dup(mutt_buffer_string(&buf)));
   mutt_buffer_dealloc(&buf);
 #endif
 #endif
@@ -1124,7 +1124,8 @@ static void dot_body(FILE *fp, struct Body *b, struct ListHead *links, bool link
   ADD_BOOL(use_disp);
   ADD_BOOL(warnsig);
 #undef ADD_BOOL
-  dot_type_string(fp, "bools", mutt_buffer_is_empty(&buf) ? "[NONE]" : mutt_b2s(&buf), true);
+  dot_type_string(fp, "bools",
+                  mutt_buffer_is_empty(&buf) ? "[NONE]" : mutt_buffer_string(&buf), true);
 
   dot_type_number(fp, "attach_count", b->attach_count);
   dot_type_number(fp, "hdr_offset", b->hdr_offset);
@@ -1216,7 +1217,7 @@ static void dot_list_head(FILE *fp, const char *name, const struct ListHead *lis
     mutt_buffer_addstr(&buf, np->data);
   }
 
-  dot_type_string(fp, name, mutt_b2s(&buf), false);
+  dot_type_string(fp, name, mutt_buffer_string(&buf), false);
 }
 
 static void dot_addr_list(FILE *fp, const char *name,
@@ -1246,7 +1247,7 @@ static void dot_envelope(FILE *fp, struct Envelope *env, struct ListHead *links)
   ADD_FLAG(MUTT_ENV_CHANGED_SUBJECT);
 #undef ADD_BOOL
   dot_type_string(fp, "changed",
-                  mutt_buffer_is_empty(&buf) ? "[NONE]" : mutt_b2s(&buf), true);
+                  mutt_buffer_is_empty(&buf) ? "[NONE]" : mutt_buffer_string(&buf), true);
 
 #define ADDR_LIST(AL) dot_addr_list(fp, #AL, &env->AL, links)
   ADDR_LIST(return_path);
@@ -1268,7 +1269,7 @@ static void dot_envelope(FILE *fp, struct Envelope *env, struct ListHead *links)
   dot_type_string(fp, "newsgroups", env->newsgroups, false);
   dot_type_string(fp, "organization", env->organization, false);
   dot_type_string(fp, "real_subj", env->real_subj, false);
-  dot_type_string(fp, "spam", mutt_b2s(&env->spam), false);
+  dot_type_string(fp, "spam", mutt_buffer_string(&env->spam), false);
   dot_type_string(fp, "subject", env->subject, false);
   dot_type_string(fp, "supersedes", env->supersedes, false);
   dot_type_string(fp, "xref", env->xref, false);
@@ -1327,7 +1328,8 @@ static void dot_email(FILE *fp, struct Email *e, struct ListHead *links)
   ADD_BOOL(trash);
   ADD_BOOL(visible);
 #undef ADD_BOOL
-  dot_type_string(fp, "bools", mutt_buffer_is_empty(&buf) ? "[NONE]" : mutt_b2s(&buf), true);
+  dot_type_string(fp, "bools",
+                  mutt_buffer_is_empty(&buf) ? "[NONE]" : mutt_buffer_string(&buf), true);
 
   mutt_buffer_reset(&buf);
 #define ADD_BOOL(F) add_flag(&buf, (e->security & F), #F)
@@ -1347,7 +1349,7 @@ static void dot_email(FILE *fp, struct Email *e, struct ListHead *links)
   ADD_BOOL(PGP_TRADITIONAL_CHECKED);
 #undef ADD_BOOL
   dot_type_string(fp, "security",
-                  mutt_buffer_is_empty(&buf) ? "[NONE]" : mutt_b2s(&buf), true);
+                  mutt_buffer_is_empty(&buf) ? "[NONE]" : mutt_buffer_string(&buf), true);
 
   dot_type_number(fp, "num_hidden", e->num_hidden);
   dot_type_number(fp, "offset", e->offset);

--- a/debug/notify.c
+++ b/debug/notify.c
@@ -211,8 +211,8 @@ static void notify_dump_config(struct NotifyCallback *nc)
 
   struct Buffer value = mutt_buffer_make(128);
   cs_he_string_get(ev_c->sub->cs, ev_c->he, &value);
-  mutt_debug(LL_DEBUG1, "    Config: %s %s = %s\n",
-             get_config_type(nc->event_subtype), ev_c->name, mutt_b2s(&value));
+  mutt_debug(LL_DEBUG1, "    Config: %s %s = %s\n", get_config_type(nc->event_subtype),
+             ev_c->name, mutt_buffer_string(&value));
   mutt_buffer_dealloc(&value);
 }
 
@@ -283,7 +283,7 @@ static void notify_dump_window_state(struct NotifyCallback *nc)
   if (flags & WN_NARROWER)
     mutt_buffer_add_printf(&buf, "narrower [%d->%d] ", win->old.cols, win->state.cols);
 
-  mutt_debug(LL_DEBUG1, "    Window: %s\n", mutt_b2s(&buf));
+  mutt_debug(LL_DEBUG1, "    Window: %s\n", mutt_buffer_string(&buf));
 
   mutt_buffer_dealloc(&buf);
 }
@@ -313,7 +313,7 @@ static void notify_dump_window_focus(struct NotifyCallback *nc)
     mutt_buffer_addstr(&buf, "NONE");
   }
 
-  mutt_debug(LL_DEBUG1, "    Window: %s\n", mutt_b2s(&buf));
+  mutt_debug(LL_DEBUG1, "    Window: %s\n", mutt_buffer_string(&buf));
 
   mutt_buffer_dealloc(&buf);
 }

--- a/debug/window.c
+++ b/debug/window.c
@@ -93,7 +93,7 @@ void debug_win_dump(void)
   mutt_debug(LL_DEBUG1, "\n");
   struct Buffer buf = mutt_buffer_make(1024);
   win_serialise(RootWindow, &buf);
-  mutt_debug(LL_DEBUG1, "%s\n", mutt_b2s(&buf));
+  mutt_debug(LL_DEBUG1, "%s\n", mutt_buffer_string(&buf));
   mutt_buffer_dealloc(&buf);
   win_focus = NULL;
 }

--- a/email/url.c
+++ b/email/url.c
@@ -424,7 +424,7 @@ int url_tostring(struct Url *url, char *dest, size_t len, uint8_t flags)
 
   int retval = url_tobuffer(url, dest_buf, flags);
   if (retval == 0)
-    mutt_str_copy(dest, mutt_b2s(dest_buf), len);
+    mutt_str_copy(dest, mutt_buffer_string(dest_buf), len);
 
   mutt_buffer_pool_release(&dest_buf);
 

--- a/enter.c
+++ b/enter.c
@@ -509,7 +509,7 @@ int mutt_enter_string_full(char *buf, size_t buflen, int col,
             struct Buffer *pool = mutt_buffer_pool_get();
             mutt_buffer_addstr(pool, buf);
             mutt_mailbox_next(Context ? Context->mailbox : NULL, pool);
-            mutt_str_copy(buf, mutt_b2s(pool), buflen);
+            mutt_str_copy(buf, mutt_buffer_string(pool), buflen);
             mutt_buffer_pool_release(&pool);
 
             state->curpos = state->lastchar =

--- a/gui/curs_lib.c
+++ b/gui/curs_lib.c
@@ -358,9 +358,9 @@ void mutt_edit_file(const char *editor, const char *file)
 
   mutt_endwin();
   mutt_buffer_file_expand_fmt_quote(cmd, editor, file);
-  if (mutt_system(mutt_b2s(cmd)) != 0)
+  if (mutt_system(mutt_buffer_string(cmd)) != 0)
   {
-    mutt_error(_("Error running \"%s\""), mutt_b2s(cmd));
+    mutt_error(_("Error running \"%s\""), mutt_buffer_string(cmd));
   }
   /* the terminal may have been resized while the editor owned it */
   mutt_resize_screen();
@@ -736,9 +736,9 @@ int mutt_do_pager(const char *banner, const char *tempfile, PagerFlags do_color,
 
     mutt_endwin();
     mutt_buffer_file_expand_fmt_quote(cmd, C_Pager, tempfile);
-    if (mutt_system(mutt_b2s(cmd)) == -1)
+    if (mutt_system(mutt_buffer_string(cmd)) == -1)
     {
-      mutt_error(_("Error running \"%s\""), mutt_b2s(cmd));
+      mutt_error(_("Error running \"%s\""), mutt_buffer_string(cmd));
       rc = -1;
     }
     else
@@ -776,7 +776,7 @@ int mutt_buffer_enter_fname_full(const char *prompt, struct Buffer *fname,
   mutt_window_addstr(_(" ('?' for list): "));
   mutt_curses_set_color(MT_COLOR_NORMAL);
   if (!mutt_buffer_is_empty(fname))
-    mutt_window_addstr(mutt_b2s(fname));
+    mutt_window_addstr(mutt_buffer_string(fname));
   mutt_window_clrtoeol(MessageWindow);
   mutt_refresh();
 

--- a/hcache/hcache.c
+++ b/hcache/hcache.c
@@ -265,7 +265,7 @@ static void hcache_per_folder(struct Buffer *hcpath, const char *path,
   {
     /* An existing file or a non-existing path not ending with a slash */
     mutt_encode_path(hcpath, path);
-    create_hcache_dir(mutt_b2s(hcpath));
+    create_hcache_dir(mutt_buffer_string(hcpath));
     return;
   }
 
@@ -274,7 +274,7 @@ static void hcache_per_folder(struct Buffer *hcpath, const char *path,
   if (namer)
   {
     namer(folder, hcfile);
-    mutt_buffer_concat_path(hcpath, path, mutt_b2s(hcfile));
+    mutt_buffer_concat_path(hcpath, path, mutt_buffer_string(hcfile));
   }
   else
   {
@@ -286,15 +286,15 @@ static void hcache_per_folder(struct Buffer *hcpath, const char *path,
 #else
     mutt_buffer_printf(name, "%s|%s", hcache_get_ops()->name, folder);
 #endif
-    mutt_md5(mutt_b2s(name), m);
+    mutt_md5(mutt_buffer_string(name), m);
     mutt_buffer_reset(name);
     mutt_md5_toascii(m, name->data);
-    mutt_buffer_printf(hcpath, "%s%s%s", path, slash ? "" : "/", mutt_b2s(name));
+    mutt_buffer_printf(hcpath, "%s%s%s", path, slash ? "" : "/", mutt_buffer_string(name));
     mutt_buffer_pool_release(&name);
   }
 
-  mutt_encode_path(hcpath, mutt_b2s(hcpath));
-  create_hcache_dir(mutt_b2s(hcpath));
+  mutt_encode_path(hcpath, mutt_buffer_string(hcpath));
+  create_hcache_dir(mutt_buffer_string(hcpath));
   mutt_buffer_pool_release(&hcfile);
 }
 
@@ -392,13 +392,13 @@ struct HeaderCache *mutt_hcache_open(const char *path, const char *folder, hcach
   struct Buffer *hcpath = mutt_buffer_pool_get();
   hcache_per_folder(hcpath, path, hc->folder, namer);
 
-  hc->ctx = ops->open(mutt_b2s(hcpath));
+  hc->ctx = ops->open(mutt_buffer_string(hcpath));
   if (!hc->ctx)
   {
     /* remove a possibly incompatible version */
-    if (unlink(mutt_b2s(hcpath)) == 0)
+    if (unlink(mutt_buffer_string(hcpath)) == 0)
     {
-      hc->ctx = ops->open(mutt_b2s(hcpath));
+      hc->ctx = ops->open(mutt_buffer_string(hcpath));
       if (!hc->ctx)
       {
         FREE(&hc->folder);
@@ -501,7 +501,7 @@ void *mutt_hcache_fetch_raw(struct HeaderCache *hc, const char *key,
 
   struct Buffer path = mutt_buffer_make(1024);
   keylen = mutt_buffer_printf(&path, "%s%.*s", hc->folder, (int) keylen, key);
-  void *blob = ops->fetch(hc->ctx, mutt_b2s(&path), keylen, dlen);
+  void *blob = ops->fetch(hc->ctx, mutt_buffer_string(&path), keylen, dlen);
   mutt_buffer_dealloc(&path);
   return blob;
 }
@@ -590,7 +590,7 @@ int mutt_hcache_store_raw(struct HeaderCache *hc, const char *key,
   struct Buffer path = mutt_buffer_make(1024);
 
   keylen = mutt_buffer_printf(&path, "%s%.*s", hc->folder, (int) keylen, key);
-  int rc = ops->store(hc->ctx, mutt_b2s(&path), keylen, data, dlen);
+  int rc = ops->store(hc->ctx, mutt_buffer_string(&path), keylen, data, dlen);
   mutt_buffer_dealloc(&path);
 
   return rc;
@@ -609,7 +609,7 @@ int mutt_hcache_delete_record(struct HeaderCache *hc, const char *key, size_t ke
 
   keylen = mutt_buffer_printf(&path, "%s%s", hc->folder, key);
 
-  int rc = ops->delete_record(hc->ctx, mutt_b2s(&path), keylen);
+  int rc = ops->delete_record(hc->ctx, mutt_buffer_string(&path), keylen);
   mutt_buffer_dealloc(&path);
   return rc;
 }

--- a/hdrline.c
+++ b/hdrline.c
@@ -874,7 +874,7 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
       if (optional)
         optional = !mutt_buffer_is_empty(&e->env->spam);
 
-      mutt_format_s(buf, buflen, prec, mutt_b2s(&e->env->spam));
+      mutt_format_s(buf, buflen, prec, mutt_buffer_string(&e->env->spam));
       break;
 
     case 'i':

--- a/help.c
+++ b/help.c
@@ -399,10 +399,10 @@ void mutt_help(enum MenuType menu, int wraplen)
 
   do
   {
-    fp = mutt_file_fopen(mutt_b2s(&t), "w");
+    fp = mutt_file_fopen(mutt_buffer_string(&t), "w");
     if (!fp)
     {
-      mutt_perror(mutt_b2s(&t));
+      mutt_perror(mutt_buffer_string(&t));
       goto cleanup;
     }
 
@@ -422,7 +422,7 @@ void mutt_help(enum MenuType menu, int wraplen)
     mutt_file_fclose(&fp);
 
     snprintf(buf, sizeof(buf), _("Help for %s"), desc);
-  } while (mutt_do_pager(buf, mutt_b2s(&t),
+  } while (mutt_do_pager(buf, mutt_buffer_string(&t),
                          MUTT_PAGER_RETWINCH | MUTT_PAGER_MARKER | MUTT_PAGER_NSKIP | MUTT_PAGER_NOWRAP,
                          NULL) == OP_REFORMAT_WINCH);
 

--- a/imap/auth_gss.c
+++ b/imap/auth_gss.c
@@ -184,7 +184,7 @@ enum ImapAuthRes imap_auth_gss(struct ImapAccountData *adata, const char *method
   mutt_b64_buffer_encode(buf1, send_token.value, send_token.length);
   gss_release_buffer(&min_stat, &send_token);
   mutt_buffer_addstr(buf1, "\r\n");
-  mutt_socket_send(adata->conn, mutt_b2s(buf1));
+  mutt_socket_send(adata->conn, mutt_buffer_string(buf1));
 
   while (maj_stat == GSS_S_CONTINUE_NEEDED)
   {
@@ -227,7 +227,7 @@ enum ImapAuthRes imap_auth_gss(struct ImapAccountData *adata, const char *method
     mutt_b64_buffer_encode(buf1, send_token.value, send_token.length);
     gss_release_buffer(&min_stat, &send_token);
     mutt_buffer_addstr(buf1, "\r\n");
-    mutt_socket_send(adata->conn, mutt_b2s(buf1));
+    mutt_socket_send(adata->conn, mutt_buffer_string(buf1));
   }
 
   gss_release_name(&min_stat, &target_name);
@@ -300,7 +300,7 @@ enum ImapAuthRes imap_auth_gss(struct ImapAccountData *adata, const char *method
   mutt_b64_buffer_encode(buf1, send_token.value, send_token.length);
   mutt_debug(LL_DEBUG2, "Requesting authorisation as %s\n", adata->conn->account.user);
   mutt_buffer_addstr(buf1, "\r\n");
-  mutt_socket_send(adata->conn, mutt_b2s(buf1));
+  mutt_socket_send(adata->conn, mutt_buffer_string(buf1));
 
   /* Joy of victory or agony of defeat? */
   do

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -494,7 +494,7 @@ int imap_rename_mailbox(struct ImapAccountData *adata, char *oldname, const char
   struct Buffer *buf = mutt_buffer_pool_get();
   mutt_buffer_printf(buf, "RENAME %s %s", oldmbox, newmbox);
 
-  if (imap_exec(adata, mutt_b2s(buf), IMAP_CMD_NO_FLAGS) != IMAP_EXEC_SUCCESS)
+  if (imap_exec(adata, mutt_buffer_string(buf), IMAP_CMD_NO_FLAGS) != IMAP_EXEC_SUCCESS)
     rc = -1;
 
   mutt_buffer_pool_release(&buf);
@@ -2195,10 +2195,10 @@ static int imap_msg_open_new(struct Mailbox *m, struct Message *msg, const struc
   struct Buffer *tmp = mutt_buffer_pool_get();
   mutt_buffer_mktemp(tmp);
 
-  msg->fp = mutt_file_fopen(mutt_b2s(tmp), "w");
+  msg->fp = mutt_file_fopen(mutt_buffer_string(tmp), "w");
   if (!msg->fp)
   {
-    mutt_perror(mutt_b2s(tmp));
+    mutt_perror(mutt_buffer_string(tmp));
     goto cleanup;
   }
 

--- a/imap/message.c
+++ b/imap/message.c
@@ -122,7 +122,8 @@ static struct BodyCache *msg_cache_open(struct Mailbox *m)
   struct Buffer *mailbox = mutt_buffer_pool_get();
   imap_cachepath(adata->delim, mdata->name, mailbox);
 
-  struct BodyCache *bc = mutt_bcache_open(&adata->conn->account, mutt_b2s(mailbox));
+  struct BodyCache *bc =
+      mutt_bcache_open(&adata->conn->account, mutt_buffer_string(mailbox));
   mutt_buffer_pool_release(&mailbox);
 
   return bc;
@@ -1038,11 +1039,11 @@ static int read_headers_fetch_new(struct Mailbox *m, unsigned int msn_begin,
 
   if (adata->capabilities & IMAP_CAP_IMAP4REV1)
   {
-    mutt_str_asprintf(&hdrreq, "BODY.PEEK[HEADER.FIELDS (%s)]", mutt_b2s(hdr_list));
+    mutt_str_asprintf(&hdrreq, "BODY.PEEK[HEADER.FIELDS (%s)]", mutt_buffer_string(hdr_list));
   }
   else if (adata->capabilities & IMAP_CAP_IMAP4)
   {
-    mutt_str_asprintf(&hdrreq, "RFC822.HEADER.LINES (%s)", mutt_b2s(hdr_list));
+    mutt_str_asprintf(&hdrreq, "RFC822.HEADER.LINES (%s)", mutt_buffer_string(hdr_list));
   }
   else
   { /* Unable to fetch headers for lower versions */
@@ -1056,13 +1057,13 @@ static int read_headers_fetch_new(struct Mailbox *m, unsigned int msn_begin,
    * as they come in. */
   tempfile = mutt_buffer_pool_get();
   mutt_buffer_mktemp(tempfile);
-  fp = mutt_file_fopen(mutt_b2s(tempfile), "w+");
+  fp = mutt_file_fopen(mutt_buffer_string(tempfile), "w+");
   if (!fp)
   {
-    mutt_error(_("Could not create temporary file %s"), mutt_b2s(tempfile));
+    mutt_error(_("Could not create temporary file %s"), mutt_buffer_string(tempfile));
     goto bail;
   }
-  unlink(mutt_b2s(tempfile));
+  unlink(mutt_buffer_string(tempfile));
   mutt_buffer_pool_release(&tempfile);
 
   if (m->verbose)
@@ -1088,7 +1089,7 @@ static int read_headers_fetch_new(struct Mailbox *m, unsigned int msn_begin,
   {
     char *cmd = NULL;
     mutt_str_asprintf(&cmd, "FETCH %s (UID FLAGS INTERNALDATE RFC822.SIZE %s)",
-                      mutt_b2s(buf), hdrreq);
+                      mutt_buffer_string(buf), hdrreq);
     imap_cmd_start(adata, cmd);
     FREE(&cmd);
 
@@ -1884,8 +1885,8 @@ int imap_msg_open(struct Mailbox *m, struct Message *msg, int msgno)
   {
     struct Buffer *path = mutt_buffer_pool_get();
     mutt_buffer_mktemp(path);
-    msg->fp = mutt_file_fopen(mutt_b2s(path), "w+");
-    unlink(mutt_b2s(path));
+    msg->fp = mutt_file_fopen(mutt_buffer_string(path), "w+");
+    unlink(mutt_buffer_string(path));
     mutt_buffer_pool_release(&path);
 
     if (!msg->fp)

--- a/imap/util.c
+++ b/imap/util.c
@@ -446,13 +446,14 @@ void imap_hcache_open(struct ImapAccountData *adata, struct ImapMboxData *mdata)
 
   imap_cachepath(adata->delim, mdata->name, mbox);
 
-  if (strstr(mutt_b2s(mbox), "/../") || mutt_str_equal(mutt_b2s(mbox), "..") ||
-      mutt_strn_equal(mutt_b2s(mbox), "../", 3))
+  if (strstr(mutt_buffer_string(mbox), "/../") ||
+      mutt_str_equal(mutt_buffer_string(mbox), "..") ||
+      mutt_strn_equal(mutt_buffer_string(mbox), "../", 3))
   {
     goto cleanup;
   }
   size_t len = mutt_buffer_len(mbox);
-  if ((len > 3) && (strcmp(mutt_b2s(mbox) + len - 3, "/..") == 0))
+  if ((len > 3) && (strcmp(mutt_buffer_string(mbox) + len - 3, "/..") == 0))
     goto cleanup;
 
   struct Url url = { 0 };
@@ -460,7 +461,7 @@ void imap_hcache_open(struct ImapAccountData *adata, struct ImapMboxData *mdata)
   url.path = mbox->data;
   url_tobuffer(&url, cachepath, U_PATH);
 
-  hc = mutt_hcache_open(C_HeaderCache, mutt_b2s(cachepath), imap_hcache_namer);
+  hc = mutt_hcache_open(C_HeaderCache, mutt_buffer_string(cachepath), imap_hcache_namer);
 
 cleanup:
   mutt_buffer_pool_release(&mbox);

--- a/index.c
+++ b/index.c
@@ -2444,7 +2444,7 @@ int mutt_index_menu(struct MuttWindow *dlg)
           goto changefoldercleanup;
 
         /* Selected directory is okay, let's save it. */
-        mutt_browser_select_dir(mutt_b2s(folderbuf));
+        mutt_browser_select_dir(mutt_buffer_string(folderbuf));
 
         if (mutt_buffer_is_empty(folderbuf))
         {
@@ -2452,7 +2452,7 @@ int mutt_index_menu(struct MuttWindow *dlg)
           goto changefoldercleanup;
         }
 
-        struct Mailbox *m = mx_mbox_find2(mutt_b2s(folderbuf));
+        struct Mailbox *m = mx_mbox_find2(mutt_buffer_string(folderbuf));
         if (m)
         {
           change_folder_mailbox(menu, m, &oldcount, &cur, read_only);
@@ -2516,7 +2516,7 @@ int mutt_index_menu(struct MuttWindow *dlg)
           goto changefoldercleanup2;
 
         /* Selected directory is okay, let's save it. */
-        mutt_browser_select_dir(mutt_b2s(folderbuf));
+        mutt_browser_select_dir(mutt_buffer_string(folderbuf));
 
         if (mutt_buffer_is_empty(folderbuf))
         {
@@ -2524,7 +2524,7 @@ int mutt_index_menu(struct MuttWindow *dlg)
           goto changefoldercleanup2;
         }
 
-        struct Mailbox *m = mx_mbox_find2(mutt_b2s(folderbuf));
+        struct Mailbox *m = mx_mbox_find2(mutt_buffer_string(folderbuf));
         if (m)
         {
           change_folder_mailbox(menu, m, &oldcount, &cur, read_only);

--- a/init.c
+++ b/init.c
@@ -219,9 +219,9 @@ static int execute_commands(struct ListHead *p)
   {
     enum CommandResult rc2 = mutt_parse_rc_line(np->data, err);
     if (rc2 == MUTT_CMD_ERROR)
-      mutt_error(_("Error in command line: %s"), mutt_b2s(err));
+      mutt_error(_("Error in command line: %s"), mutt_buffer_string(err));
     else if (rc2 == MUTT_CMD_WARNING)
-      mutt_warning(_("Warning in command line: %s"), mutt_b2s(err));
+      mutt_warning(_("Warning in command line: %s"), mutt_buffer_string(err));
 
     if ((rc2 == MUTT_CMD_ERROR) || (rc2 == MUTT_CMD_WARNING))
     {
@@ -360,7 +360,8 @@ static bool get_hostname(struct ConfigSet *cs)
       {
         C_Hostname =
             mutt_mem_malloc(mutt_buffer_len(domain) + mutt_str_len(ShortHostname) + 2);
-        sprintf((char *) C_Hostname, "%s.%s", NONULL(ShortHostname), mutt_b2s(domain));
+        sprintf((char *) C_Hostname, "%s.%s", NONULL(ShortHostname),
+                mutt_buffer_string(domain));
       }
       else
       {
@@ -767,7 +768,7 @@ int mutt_init(struct ConfigSet *cs, bool skip_sys_rc, struct ListHead *commands)
 #else
     mutt_buffer_concat_path(&buf, MAILPATH, NONULL(Username));
 #endif
-    p = mutt_b2s(&buf);
+    p = mutt_buffer_string(&buf);
   }
   cs_str_initial_set(cs, "spoolfile", p, NULL);
   cs_str_reset(cs, "spoolfile", NULL);
@@ -845,7 +846,7 @@ int mutt_init(struct ConfigSet *cs, bool skip_sys_rc, struct ListHead *commands)
     if (!xdg_cfg_home && HomeDir)
     {
       mutt_buffer_printf(&buf, "%s/.config", HomeDir);
-      xdg_cfg_home = mutt_b2s(&buf);
+      xdg_cfg_home = mutt_buffer_string(&buf);
     }
 
     char *config = find_cfg(HomeDir, xdg_cfg_home);
@@ -886,23 +887,23 @@ int mutt_init(struct ConfigSet *cs, bool skip_sys_rc, struct ListHead *commands)
         break;
 
       mutt_buffer_printf(&buf, "%s/neomuttrc", SYSCONFDIR);
-      if (access(mutt_b2s(&buf), F_OK) == 0)
+      if (access(mutt_buffer_string(&buf), F_OK) == 0)
         break;
 
       mutt_buffer_printf(&buf, "%s/Muttrc", SYSCONFDIR);
-      if (access(mutt_b2s(&buf), F_OK) == 0)
+      if (access(mutt_buffer_string(&buf), F_OK) == 0)
         break;
 
       mutt_buffer_printf(&buf, "%s/neomuttrc", PKGDATADIR);
-      if (access(mutt_b2s(&buf), F_OK) == 0)
+      if (access(mutt_buffer_string(&buf), F_OK) == 0)
         break;
 
       mutt_buffer_printf(&buf, "%s/Muttrc", PKGDATADIR);
     } while (false);
 
-    if (access(mutt_b2s(&buf), F_OK) == 0)
+    if (access(mutt_buffer_string(&buf), F_OK) == 0)
     {
-      if (source_rc(mutt_b2s(&buf), &err) != 0)
+      if (source_rc(mutt_buffer_string(&buf), &err) != 0)
       {
         mutt_error("%s", err.data);
         need_pause = 1; // TEST11: neomutt (error in /etc/neomuttrc)

--- a/mailcap.c
+++ b/mailcap.c
@@ -75,7 +75,7 @@ int mailcap_expand_command(struct Body *a, const char *filename,
   struct Buffer *param = NULL;
   struct Buffer *type2 = NULL;
 
-  const char *cptr = mutt_b2s(command);
+  const char *cptr = mutt_buffer_string(command);
   while (*cptr)
   {
     if (*cptr == '\\')
@@ -104,10 +104,10 @@ int mailcap_expand_command(struct Body *a, const char *filename,
         /* In send mode, use the current charset, since the message hasn't
          * been converted yet.   If noconv is set, then we assume the
          * charset parameter has the correct value instead. */
-        if (mutt_istr_equal(mutt_b2s(param), "charset") && a->charset && !a->noconv)
+        if (mutt_istr_equal(mutt_buffer_string(param), "charset") && a->charset && !a->noconv)
           pvalue2 = a->charset;
         else
-          pvalue2 = mutt_param_get(&a->parameter, mutt_b2s(param));
+          pvalue2 = mutt_param_get(&a->parameter, mutt_buffer_string(param));
 
         /* Now copy the parameter value into param buffer */
         if (C_MailcapSanitize)
@@ -115,13 +115,13 @@ int mailcap_expand_command(struct Body *a, const char *filename,
         else
           mutt_buffer_strcpy(param, NONULL(pvalue2));
 
-        mutt_buffer_quote_filename(quoted, mutt_b2s(param), true);
-        mutt_buffer_addstr(buf, mutt_b2s(quoted));
+        mutt_buffer_quote_filename(quoted, mutt_buffer_string(param), true);
+        mutt_buffer_addstr(buf, mutt_buffer_string(quoted));
       }
       else if ((*cptr == 's') && filename)
       {
         mutt_buffer_quote_filename(quoted, filename, true);
-        mutt_buffer_addstr(buf, mutt_b2s(quoted));
+        mutt_buffer_addstr(buf, mutt_buffer_string(quoted));
         needspipe = false;
       }
       else if (*cptr == 't')
@@ -134,8 +134,8 @@ int mailcap_expand_command(struct Body *a, const char *filename,
           else
             mutt_buffer_strcpy(type2, type);
         }
-        mutt_buffer_quote_filename(quoted, mutt_b2s(type2), true);
-        mutt_buffer_addstr(buf, mutt_b2s(quoted));
+        mutt_buffer_quote_filename(quoted, mutt_buffer_string(type2), true);
+        mutt_buffer_addstr(buf, mutt_buffer_string(quoted));
       }
 
       if (*cptr)
@@ -357,8 +357,8 @@ static bool rfc1524_mailcap_parse(struct Body *a, const char *filename, const ch
               mutt_buffer_sanitize_filename(afilename, NONULL(a->filename), true);
             else
               mutt_buffer_strcpy(afilename, NONULL(a->filename));
-            mailcap_expand_command(a, mutt_b2s(afilename), type, command);
-            if (mutt_system(mutt_b2s(command)))
+            mailcap_expand_command(a, mutt_buffer_string(afilename), type, command);
+            if (mutt_system(mutt_buffer_string(command)))
             {
               /* a non-zero exit code means test failed */
               found = false;
@@ -500,8 +500,8 @@ bool mailcap_lookup(struct Body *a, char *type, size_t typelen,
     mutt_buffer_strcpy(path, np->data);
     mutt_buffer_expand_path(path);
 
-    mutt_debug(LL_DEBUG2, "Checking mailcap file: %s\n", mutt_b2s(path));
-    found = rfc1524_mailcap_parse(a, mutt_b2s(path), type, entry, opt);
+    mutt_debug(LL_DEBUG2, "Checking mailcap file: %s\n", mutt_buffer_string(path));
+    found = rfc1524_mailcap_parse(a, mutt_buffer_string(path), type, entry, opt);
     if (found)
       break;
   }
@@ -617,7 +617,8 @@ void mailcap_expand_filename(const char *nametemplate, const char *oldfile,
         mutt_buffer_strcpy_n(left, nametemplate, i);
       if (!rmatch)
         mutt_buffer_strcpy(right, nametemplate + i + 2);
-      mutt_buffer_printf(newfile, "%s%s%s", mutt_b2s(left), oldfile, mutt_b2s(right));
+      mutt_buffer_printf(newfile, "%s%s%s", mutt_buffer_string(left), oldfile,
+                         mutt_buffer_string(right));
 
       mutt_buffer_pool_release(&left);
       mutt_buffer_pool_release(&right);

--- a/maildir/mh.c
+++ b/maildir/mh.c
@@ -507,7 +507,7 @@ int mh_parse_dir(struct Mailbox *m, struct MdEmailArray *mda, struct Progress *p
   struct Buffer *buf = mutt_buffer_pool_get();
   mutt_buffer_strcpy(buf, mailbox_path(m));
 
-  DIR *dirp = opendir(mutt_b2s(buf));
+  DIR *dirp = opendir(mutt_buffer_string(buf));
   if (!dirp)
   {
     rc = -1;

--- a/main.c
+++ b/main.c
@@ -789,21 +789,21 @@ int main(int argc, char *argv[], char *envp[])
     bool skip = false;
 #ifdef USE_IMAP
     /* we're not connected yet - skip mail folder creation */
-    skip |= (imap_path_probe(mutt_b2s(fpath), NULL) == MUTT_IMAP);
+    skip |= (imap_path_probe(mutt_buffer_string(fpath), NULL) == MUTT_IMAP);
 #endif
 #ifdef USE_POP
-    skip |= (pop_path_probe(mutt_b2s(fpath), NULL) == MUTT_POP);
+    skip |= (pop_path_probe(mutt_buffer_string(fpath), NULL) == MUTT_POP);
 #endif
 #ifdef USE_NNTP
-    skip |= (nntp_path_probe(mutt_b2s(fpath), NULL) == MUTT_NNTP);
+    skip |= (nntp_path_probe(mutt_buffer_string(fpath), NULL) == MUTT_NNTP);
 #endif
-    if (!skip && (stat(mutt_b2s(fpath), &sb) == -1) && (errno == ENOENT))
+    if (!skip && (stat(mutt_buffer_string(fpath), &sb) == -1) && (errno == ENOENT))
     {
       char msg2[256];
       snprintf(msg2, sizeof(msg2), _("%s does not exist. Create it?"), C_Folder);
       if (mutt_yesorno(msg2, MUTT_YES) == MUTT_YES)
       {
-        if ((mkdir(mutt_b2s(fpath), 0700) == -1) && (errno != EEXIST))
+        if ((mkdir(mutt_buffer_string(fpath), 0700) == -1) && (errno != EEXIST))
           mutt_error(_("Can't create %s: %s"), C_Folder, strerror(errno)); // TEST21: neomutt -n -F /dev/null (and ~/Mail doesn't exist)
       }
     }
@@ -908,10 +908,10 @@ int main(int argc, char *argv[], char *envp[])
         {
           mutt_buffer_strcpy(&expanded_infile, infile);
           mutt_buffer_expand_path(&expanded_infile);
-          fp_in = fopen(mutt_b2s(&expanded_infile), "r");
+          fp_in = fopen(mutt_buffer_string(&expanded_infile), "r");
           if (!fp_in)
           {
-            mutt_perror(mutt_b2s(&expanded_infile));
+            mutt_perror(mutt_buffer_string(&expanded_infile));
             email_free(&e);
             goto main_curses; // TEST28: neomutt -E -H missing
           }
@@ -925,11 +925,11 @@ int main(int argc, char *argv[], char *envp[])
       {
         mutt_buffer_mktemp(&tempfile);
 
-        fp_out = mutt_file_fopen(mutt_b2s(&tempfile), "w");
+        fp_out = mutt_file_fopen(mutt_buffer_string(&tempfile), "w");
         if (!fp_out)
         {
           mutt_file_fclose(&fp_in);
-          mutt_perror(mutt_b2s(&tempfile));
+          mutt_perror(mutt_buffer_string(&tempfile));
           email_free(&e);
           goto main_curses; // TEST29: neomutt -H existing-file (where tmpdir=/path/to/FILE blocking tmpdir)
         }
@@ -943,10 +943,10 @@ int main(int argc, char *argv[], char *envp[])
           fputs(bodytext, fp_out);
         mutt_file_fclose(&fp_out);
 
-        fp_in = fopen(mutt_b2s(&tempfile), "r");
+        fp_in = fopen(mutt_buffer_string(&tempfile), "r");
         if (!fp_in)
         {
-          mutt_perror(mutt_b2s(&tempfile));
+          mutt_perror(mutt_buffer_string(&tempfile));
           email_free(&e);
           goto main_curses; // TEST30: can't test
         }
@@ -1015,10 +1015,10 @@ int main(int argc, char *argv[], char *envp[])
       /* Editing the include_file: pass it directly in.
        * Note that SEND_NO_FREE_HEADER is set above so it isn't unlinked.  */
       else if (edit_infile)
-        bodyfile = mutt_b2s(&expanded_infile);
+        bodyfile = mutt_buffer_string(&expanded_infile);
       // For bodytext and unedited include_file: use the tempfile.
       else
-        bodyfile = mutt_b2s(&tempfile);
+        bodyfile = mutt_buffer_string(&tempfile);
 
       mutt_file_fclose(&fp_in);
     }
@@ -1068,16 +1068,16 @@ int main(int argc, char *argv[], char *envp[])
         e->body->unlink = false;
       else if (draft_file)
       {
-        if (truncate(mutt_b2s(&expanded_infile), 0) == -1)
+        if (truncate(mutt_buffer_string(&expanded_infile), 0) == -1)
         {
-          mutt_perror(mutt_b2s(&expanded_infile));
+          mutt_perror(mutt_buffer_string(&expanded_infile));
           email_free(&e);
           goto main_curses; // TEST33: neomutt -H read-only -s test john@example.com -E
         }
-        fp_out = mutt_file_fopen(mutt_b2s(&expanded_infile), "a");
+        fp_out = mutt_file_fopen(mutt_buffer_string(&expanded_infile), "a");
         if (!fp_out)
         {
-          mutt_perror(mutt_b2s(&expanded_infile));
+          mutt_perror(mutt_buffer_string(&expanded_infile));
           email_free(&e);
           goto main_curses; // TEST34: can't test
         }
@@ -1114,7 +1114,7 @@ int main(int argc, char *argv[], char *envp[])
 
     /* !edit_infile && draft_file will leave the tempfile around */
     if (!mutt_buffer_is_empty(&tempfile))
-      unlink(mutt_b2s(&tempfile));
+      unlink(mutt_buffer_string(&tempfile));
 
     mutt_window_free_all();
 
@@ -1194,16 +1194,16 @@ int main(int argc, char *argv[], char *envp[])
 #endif
       mutt_buffer_expand_path(&folder);
 
-    mutt_str_replace(&CurrentFolder, mutt_b2s(&folder));
-    mutt_str_replace(&LastFolder, mutt_b2s(&folder));
+    mutt_str_replace(&CurrentFolder, mutt_buffer_string(&folder));
+    mutt_str_replace(&LastFolder, mutt_buffer_string(&folder));
 
     if (flags & MUTT_CLI_IGNORE)
     {
       /* check to see if there are any messages in the folder */
-      switch (mx_path_is_empty(mutt_b2s(&folder)))
+      switch (mx_path_is_empty(mutt_buffer_string(&folder)))
       {
         case -1:
-          mutt_perror(mutt_b2s(&folder));
+          mutt_perror(mutt_buffer_string(&folder));
           goto main_curses; // TEST41: neomutt -z -f missing
         case 1:
           mutt_error(_("Mailbox is empty"));
@@ -1211,12 +1211,12 @@ int main(int argc, char *argv[], char *envp[])
       }
     }
 
-    mutt_folder_hook(mutt_b2s(&folder), NULL);
+    mutt_folder_hook(mutt_buffer_string(&folder), NULL);
     mutt_startup_shutdown_hook(MUTT_STARTUP_HOOK);
     notify_send(NeoMutt->notify, NT_GLOBAL, NT_GLOBAL_STARTUP, NULL);
 
     repeat_error = true;
-    struct Mailbox *m = mx_resolve(mutt_b2s(&folder));
+    struct Mailbox *m = mx_resolve(mutt_buffer_string(&folder));
     Context = mx_mbox_open(m, ((flags & MUTT_CLI_RO) || C_ReadOnly) ? MUTT_READONLY : MUTT_OPEN_NO_FLAGS);
     if (!Context)
     {
@@ -1224,7 +1224,7 @@ int main(int argc, char *argv[], char *envp[])
         account_mailbox_remove(m->account, m);
 
       mailbox_free(&m);
-      mutt_error(_("Unable to open mailbox %s"), mutt_b2s(&folder));
+      mutt_error(_("Unable to open mailbox %s"), mutt_buffer_string(&folder));
       repeat_error = false;
     }
     if (Context || !explicit_folder)

--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -1204,7 +1204,7 @@ static int mbox_mbox_sync(struct Mailbox *m)
   /* Create a temporary file to write the new version of the mailbox in. */
   tempfile = mutt_buffer_pool_get();
   mutt_buffer_mktemp(tempfile);
-  int fd = open(mutt_b2s(tempfile), O_WRONLY | O_EXCL | O_CREAT, 0600);
+  int fd = open(mutt_buffer_string(tempfile), O_WRONLY | O_EXCL | O_CREAT, 0600);
   if ((fd == -1) || !(fp = fdopen(fd, "w")))
   {
     if (fd != -1)
@@ -1277,7 +1277,7 @@ static int mbox_mbox_sync(struct Mailbox *m)
       {
         if (fputs(MMDF_SEP, fp) == EOF)
         {
-          mutt_perror(mutt_b2s(tempfile));
+          mutt_perror(mutt_buffer_string(tempfile));
           goto bail;
         }
       }
@@ -1290,7 +1290,7 @@ static int mbox_mbox_sync(struct Mailbox *m)
       if (mutt_copy_message(fp, m, m->emails[i], MUTT_CM_UPDATE,
                             CH_FROM | CH_UPDATE | CH_UPDATE_LEN, 0) != 0)
       {
-        mutt_perror(mutt_b2s(tempfile));
+        mutt_perror(mutt_buffer_string(tempfile));
         goto bail;
       }
 
@@ -1307,14 +1307,14 @@ static int mbox_mbox_sync(struct Mailbox *m)
         case MUTT_MMDF:
           if (fputs(MMDF_SEP, fp) == EOF)
           {
-            mutt_perror(mutt_b2s(tempfile));
+            mutt_perror(mutt_buffer_string(tempfile));
             goto bail;
           }
           break;
         default:
           if (fputs("\n", fp) == EOF)
           {
-            mutt_perror(mutt_b2s(tempfile));
+            mutt_perror(mutt_buffer_string(tempfile));
             goto bail;
           }
       }
@@ -1324,7 +1324,7 @@ static int mbox_mbox_sync(struct Mailbox *m)
   if (mutt_file_fclose(&fp) != 0)
   {
     mutt_debug(LL_DEBUG1, "mutt_file_fclose (&) returned non-zero\n");
-    mutt_perror(mutt_b2s(tempfile));
+    mutt_perror(mutt_buffer_string(tempfile));
     goto bail;
   }
 
@@ -1337,13 +1337,13 @@ static int mbox_mbox_sync(struct Mailbox *m)
 
   unlink_tempfile = false;
 
-  fp = fopen(mutt_b2s(tempfile), "r");
+  fp = fopen(mutt_buffer_string(tempfile), "r");
   if (!fp)
   {
     mutt_sig_unblock();
     mx_fastclose_mailbox(m);
     mutt_debug(LL_DEBUG1, "unable to reopen temp copy of mailbox!\n");
-    mutt_perror(mutt_b2s(tempfile));
+    mutt_perror(mutt_buffer_string(tempfile));
     FREE(&new_offset);
     FREE(&old_offset);
     goto fatal;
@@ -1400,11 +1400,11 @@ static int mbox_mbox_sync(struct Mailbox *m)
 
     mutt_buffer_printf(savefile, "%s/neomutt.%s-%s-%u", NONULL(C_Tmpdir), NONULL(Username),
                        NONULL(ShortHostname), (unsigned int) getpid());
-    rename(mutt_b2s(tempfile), mutt_b2s(savefile));
+    rename(mutt_buffer_string(tempfile), mutt_buffer_string(savefile));
     mutt_sig_unblock();
     mx_fastclose_mailbox(m);
     mutt_buffer_pretty_mailbox(savefile);
-    mutt_error(_("Write failed!  Saved partial mailbox to %s"), mutt_b2s(savefile));
+    mutt_error(_("Write failed!  Saved partial mailbox to %s"), mutt_buffer_string(savefile));
     mutt_buffer_pool_release(&savefile);
     FREE(&new_offset);
     FREE(&old_offset);
@@ -1422,7 +1422,7 @@ static int mbox_mbox_sync(struct Mailbox *m)
   }
   if (!adata->fp)
   {
-    unlink(mutt_b2s(tempfile));
+    unlink(mutt_buffer_string(tempfile));
     mutt_sig_unblock();
     mx_fastclose_mailbox(m);
     mutt_error(_("Fatal error!  Could not reopen mailbox!"));
@@ -1444,7 +1444,7 @@ static int mbox_mbox_sync(struct Mailbox *m)
   }
   FREE(&new_offset);
   FREE(&old_offset);
-  unlink(mutt_b2s(tempfile)); /* remove partial copy of the mailbox */
+  unlink(mutt_buffer_string(tempfile)); /* remove partial copy of the mailbox */
   mutt_buffer_pool_release(&tempfile);
   mutt_sig_unblock();
 
@@ -1462,7 +1462,7 @@ bail: /* Come here in case of disaster */
   mutt_file_fclose(&fp);
 
   if (tempfile && unlink_tempfile)
-    unlink(mutt_b2s(tempfile));
+    unlink(mutt_buffer_string(tempfile));
 
   /* restore offsets, as far as they are valid */
   if ((first >= 0) && old_offset)

--- a/monitor.c
+++ b/monitor.c
@@ -366,7 +366,7 @@ static enum ResolveResult monitor_resolve(struct MonitorInfo *info, struct Mailb
   if (fmt)
   {
     mutt_buffer_printf(&info->path_buf, fmt, info->path);
-    info->path = mutt_b2s(&info->path_buf);
+    info->path = mutt_buffer_string(&info->path_buf);
   }
   if (stat(info->path, &sb) != 0)
     return RESOLVE_RES_FAIL_STAT;

--- a/mutt/buffer.c
+++ b/mutt/buffer.c
@@ -454,7 +454,7 @@ size_t mutt_buffer_copy(struct Buffer *dst, const struct Buffer *src)
   return mutt_buffer_addstr_n(dst, src->data, mutt_buffer_len(src));
 }
 
-/** 
+/**
  * mutt_buffer_seek - set current read/write position to offset from beginning
  * @param buf    Buffer to use
  * @param offset Distance from the beginning

--- a/mutt/buffer.h
+++ b/mutt/buffer.h
@@ -37,9 +37,6 @@ struct Buffer
   size_t dsize; ///< Length of data
 };
 
-/* Convert a buffer to a const char * "string" */
-#define mutt_b2s(buf) ((buf)->data ? (const char *) (buf)->data : "")
-
 #define MoreArgs(buf) (*(buf)->dptr && (*(buf)->dptr != ';') && (*(buf)->dptr != '#'))
 
 void           mutt_buffer_alloc        (struct Buffer *buf, size_t size);
@@ -67,5 +64,22 @@ int            mutt_buffer_printf       (struct Buffer *buf, const char *fmt, ..
 size_t         mutt_buffer_strcpy       (struct Buffer *buf, const char *s);
 size_t         mutt_buffer_strcpy_n     (struct Buffer *buf, const char *s, size_t len);
 size_t         mutt_buffer_substrcpy    (struct Buffer *buf, const char *beg, const char *end);
+
+/**
+ * mutt_buffer_string - Convert a buffer to a const char * "string"
+ * @param buf Buffer to that is to be converted
+ * @retval ptr String inside the Buffer
+ *
+ * This method exposes Buffer's underlying data field
+ *
+ * @note Returns an empty string if Buffer isn't initialised
+ */
+static inline const char *mutt_buffer_string(const struct Buffer *buf)
+{
+  if (!buf || !buf->data)
+    return "";
+
+  return buf->data;
+}
 
 #endif /* MUTT_LIB_BUFFER_H */

--- a/mutt_body.c
+++ b/mutt_body.c
@@ -65,7 +65,7 @@ int mutt_body_copy(FILE *fp, struct Body **tgt, struct Body *src)
   }
 
   mutt_adv_mktemp(tmp);
-  if (mutt_save_attachment(fp, src, mutt_b2s(tmp), MUTT_SAVE_NO_FLAGS, NULL) == -1)
+  if (mutt_save_attachment(fp, src, mutt_buffer_string(tmp), MUTT_SAVE_NO_FLAGS, NULL) == -1)
   {
     mutt_buffer_pool_release(&tmp);
     return -1;

--- a/mutt_header.c
+++ b/mutt_header.c
@@ -176,10 +176,10 @@ void mutt_edit_headers(const char *editor, const char *body, struct Email *e,
 
   struct Buffer *path = mutt_buffer_pool_get();
   mutt_buffer_mktemp(path);
-  FILE *fp_out = mutt_file_fopen(mutt_b2s(path), "w");
+  FILE *fp_out = mutt_file_fopen(mutt_buffer_string(path), "w");
   if (!fp_out)
   {
-    mutt_perror(mutt_b2s(path));
+    mutt_perror(mutt_buffer_string(path));
     goto cleanup;
   }
 
@@ -202,26 +202,26 @@ void mutt_edit_headers(const char *editor, const char *body, struct Email *e,
   mutt_file_fclose(&fp_in);
   mutt_file_fclose(&fp_out);
 
-  if (stat(mutt_b2s(path), &st) == -1)
+  if (stat(mutt_buffer_string(path), &st) == -1)
   {
-    mutt_perror(mutt_b2s(path));
+    mutt_perror(mutt_buffer_string(path));
     goto cleanup;
   }
 
-  mtime = mutt_file_decrease_mtime(mutt_b2s(path), &st);
+  mtime = mutt_file_decrease_mtime(mutt_buffer_string(path), &st);
   if (mtime == (time_t) -1)
   {
-    mutt_perror(mutt_b2s(path));
+    mutt_perror(mutt_buffer_string(path));
     goto cleanup;
   }
 
-  mutt_edit_file(editor, mutt_b2s(path));
-  stat(mutt_b2s(path), &st);
+  mutt_edit_file(editor, mutt_buffer_string(path));
+  stat(mutt_buffer_string(path), &st);
   if (mtime == st.st_mtime)
   {
     mutt_debug(LL_DEBUG1, "temp file was not modified\n");
     /* the file has not changed! */
-    mutt_file_unlink(mutt_b2s(path));
+    mutt_file_unlink(mutt_buffer_string(path));
     goto cleanup;
   }
 
@@ -229,10 +229,10 @@ void mutt_edit_headers(const char *editor, const char *body, struct Email *e,
   mutt_list_free(&e->env->userhdrs);
 
   /* Read the temp file back in */
-  fp_in = fopen(mutt_b2s(path), "r");
+  fp_in = fopen(mutt_buffer_string(path), "r");
   if (!fp_in)
   {
-    mutt_perror(mutt_b2s(path));
+    mutt_perror(mutt_buffer_string(path));
     goto cleanup;
   }
 
@@ -250,7 +250,7 @@ void mutt_edit_headers(const char *editor, const char *body, struct Email *e,
     fwrite(buf, 1, i, fp_out);
   mutt_file_fclose(&fp_out);
   mutt_file_fclose(&fp_in);
-  mutt_file_unlink(mutt_b2s(path));
+  mutt_file_unlink(mutt_buffer_string(path));
 
   /* in case the user modifies/removes the In-Reply-To header with
    * $edit_headers set, we remove References: as they're likely invalid;
@@ -320,7 +320,7 @@ void mutt_edit_headers(const char *editor, const char *body, struct Email *e,
         p = mutt_str_skip_email_wsp(p);
 
         mutt_buffer_expand_path(path);
-        body2 = mutt_make_file_attach(mutt_b2s(path), NeoMutt->sub);
+        body2 = mutt_make_file_attach(mutt_buffer_string(path), NeoMutt->sub);
         if (body2)
         {
           body2->description = mutt_str_dup(p);
@@ -332,7 +332,7 @@ void mutt_edit_headers(const char *editor, const char *body, struct Email *e,
         else
         {
           mutt_buffer_pretty_mailbox(path);
-          mutt_error(_("%s: unable to attach file"), mutt_b2s(path));
+          mutt_error(_("%s: unable to attach file"), mutt_buffer_string(path));
         }
       }
       keep = false;

--- a/mutt_logging.c
+++ b/mutt_logging.c
@@ -97,7 +97,7 @@ static const char *rotate_logs(const char *file, int count)
 
     mutt_buffer_expand_path(old_file);
     mutt_buffer_expand_path(new_file);
-    rename(mutt_b2s(old_file), mutt_b2s(new_file));
+    rename(mutt_buffer_string(old_file), mutt_buffer_string(new_file));
   }
 
   file = mutt_buffer_strdup(old_file);

--- a/mutt_lua.c
+++ b/mutt_lua.c
@@ -127,12 +127,12 @@ static int lua_mutt_call(lua_State *l)
 
   if (cmd->parse(token, &expn, cmd->data, err))
   {
-    luaL_error(l, "NeoMutt error: %s", mutt_b2s(err));
+    luaL_error(l, "NeoMutt error: %s", mutt_buffer_string(err));
     rc = -1;
   }
   else
   {
-    if (!lua_pushstring(l, mutt_b2s(err)))
+    if (!lua_pushstring(l, mutt_buffer_string(err)))
       handle_error(l);
     else
       rc++;
@@ -313,12 +313,12 @@ static int lua_mutt_enter(lua_State *l)
 
   if (mutt_parse_rc_line(buf, err))
   {
-    luaL_error(l, "NeoMutt error: %s", mutt_b2s(err));
+    luaL_error(l, "NeoMutt error: %s", mutt_buffer_string(err));
     rc = -1;
   }
   else
   {
-    if (!lua_pushstring(l, mutt_b2s(err)))
+    if (!lua_pushstring(l, mutt_buffer_string(err)))
       handle_error(l);
     else
       rc++;

--- a/mutt_mailbox.c
+++ b/mutt_mailbox.c
@@ -254,7 +254,8 @@ bool mutt_mailbox_list(void)
       np->mailbox->notified = true;
       MailboxNotify--;
     }
-    pos += strlen(strncat(mailboxlist + pos, mutt_b2s(path), sizeof(mailboxlist) - 1 - pos));
+    pos += strlen(strncat(mailboxlist + pos, mutt_buffer_string(path),
+                          sizeof(mailboxlist) - 1 - pos));
     first = 0;
   }
   neomutt_mailboxlist_clear(&ml);
@@ -330,7 +331,7 @@ struct Mailbox *mutt_mailbox_next(struct Mailbox *m_cur, struct Buffer *s)
           neomutt_mailboxlist_clear(&ml);
           return m_result;
         }
-        if (mutt_str_equal(mutt_b2s(s), mailbox_path(np->mailbox)))
+        if (mutt_str_equal(mutt_buffer_string(s), mailbox_path(np->mailbox)))
           found = true;
       }
       neomutt_mailboxlist_clear(&ml);

--- a/mx.c
+++ b/mx.c
@@ -702,7 +702,8 @@ int mx_mbox_close(struct Context **ptr)
     else
     {
       mutt_buffer_strcpy(mbox, C_Mbox);
-      is_spool = mutt_is_spool(mailbox_path(m)) && !mutt_is_spool(mutt_b2s(mbox));
+      is_spool = mutt_is_spool(mailbox_path(m)) &&
+                 !mutt_is_spool(mutt_buffer_string(mbox));
     }
 
     if (is_spool && !mutt_buffer_is_empty(mbox))
@@ -713,8 +714,8 @@ int mx_mbox_close(struct Context **ptr)
                             moved, the second argument is the target mailbox. */
                          ngettext("Move %d read message to %s?",
                                   "Move %d read messages to %s?", read_msgs),
-                         read_msgs, mutt_b2s(mbox));
-      move_messages = query_quadoption(C_Move, mutt_b2s(buf));
+                         read_msgs, mutt_buffer_string(mbox));
+      move_messages = query_quadoption(C_Move, mutt_buffer_string(buf));
       if (move_messages == MUTT_ABORT)
         goto cleanup;
     }
@@ -728,7 +729,7 @@ int mx_mbox_close(struct Context **ptr)
                        ngettext("Purge %d deleted message?",
                                 "Purge %d deleted messages?", m->msg_deleted),
                        m->msg_deleted);
-    purge = query_quadoption(C_Delete, mutt_b2s(buf));
+    purge = query_quadoption(C_Delete, mutt_buffer_string(buf));
     if (purge == MUTT_ABORT)
       goto cleanup;
   }
@@ -748,13 +749,13 @@ int mx_mbox_close(struct Context **ptr)
   if (move_messages)
   {
     if (m->verbose)
-      mutt_message(_("Moving read messages to %s..."), mutt_b2s(mbox));
+      mutt_message(_("Moving read messages to %s..."), mutt_buffer_string(mbox));
 
 #ifdef USE_IMAP
     /* try to use server-side copy first */
     i = 1;
 
-    if ((m->type == MUTT_IMAP) && (imap_path_probe(mutt_b2s(mbox), NULL) == MUTT_IMAP))
+    if ((m->type == MUTT_IMAP) && (imap_path_probe(mutt_buffer_string(mbox), NULL) == MUTT_IMAP))
     {
       /* add messages for moving, and clear old tags, if any */
       struct EmailList el = STAILQ_HEAD_INITIALIZER(el);
@@ -773,7 +774,7 @@ int mx_mbox_close(struct Context **ptr)
           e->tagged = false;
       }
 
-      i = imap_copy_messages(ctx->mailbox, &el, mutt_b2s(mbox), true);
+      i = imap_copy_messages(ctx->mailbox, &el, mutt_buffer_string(mbox), true);
       emaillist_clear(&el);
     }
 
@@ -784,7 +785,7 @@ int mx_mbox_close(struct Context **ptr)
     else /* use regular append-copy mode */
 #endif
     {
-      struct Mailbox *m_read = mx_path_resolve(mutt_b2s(mbox));
+      struct Mailbox *m_read = mx_path_resolve(mutt_buffer_string(mbox));
       struct Context *ctx_read = mx_mbox_open(m_read, MUTT_APPEND);
       if (!ctx_read)
       {

--- a/ncrypt/crypt.c
+++ b/ncrypt/crypt.c
@@ -848,10 +848,10 @@ void crypt_extract_keys_from_messages(struct Mailbox *m, struct EmailList *el)
 
   struct Buffer *tempfname = mutt_buffer_pool_get();
   mutt_buffer_mktemp(tempfname);
-  FILE *fp_out = mutt_file_fopen(mutt_b2s(tempfname), "w");
+  FILE *fp_out = mutt_file_fopen(mutt_buffer_string(tempfname), "w");
   if (!fp_out)
   {
-    mutt_perror(mutt_b2s(tempfname));
+    mutt_perror(mutt_buffer_string(tempfname));
     goto cleanup;
   }
 
@@ -877,7 +877,7 @@ void crypt_extract_keys_from_messages(struct Mailbox *m, struct EmailList *el)
 
       mutt_endwin();
       puts(_("Trying to extract PGP keys...\n"));
-      crypt_pgp_invoke_import(mutt_b2s(tempfname));
+      crypt_pgp_invoke_import(mutt_buffer_string(tempfname));
     }
 
     if (((WithCrypto & APPLICATION_SMIME) != 0) && (e->security & APPLICATION_SMIME))
@@ -906,7 +906,7 @@ void crypt_extract_keys_from_messages(struct Mailbox *m, struct EmailList *el)
       {
         mutt_endwin();
         puts(_("Trying to extract S/MIME certificates..."));
-        crypt_smime_invoke_import(mutt_b2s(tempfname), mbox);
+        crypt_smime_invoke_import(mutt_buffer_string(tempfname), mbox);
       }
     }
 
@@ -917,7 +917,7 @@ void crypt_extract_keys_from_messages(struct Mailbox *m, struct EmailList *el)
   if (isendwin())
     mutt_any_key_to_continue(NULL);
 
-  mutt_file_unlink(mutt_b2s(tempfname));
+  mutt_file_unlink(mutt_buffer_string(tempfname));
 
   if (WithCrypto & APPLICATION_PGP)
     OptDontHandlePgpKeys = false;
@@ -1181,7 +1181,7 @@ int mutt_signed_handler(struct Body *a, struct State *s)
       tempfile = mutt_buffer_pool_get();
       mutt_buffer_mktemp(tempfile);
       bool goodsig = true;
-      if (crypt_write_signed(a, s, mutt_b2s(tempfile)) == 0)
+      if (crypt_write_signed(a, s, mutt_buffer_string(tempfile)) == 0)
       {
         for (int i = 0; i < sigcnt; i++)
         {
@@ -1189,7 +1189,7 @@ int mutt_signed_handler(struct Body *a, struct State *s)
               (signatures[i]->type == TYPE_APPLICATION) &&
               mutt_istr_equal(signatures[i]->subtype, "pgp-signature"))
           {
-            if (crypt_pgp_verify_one(signatures[i], s, mutt_b2s(tempfile)) != 0)
+            if (crypt_pgp_verify_one(signatures[i], s, mutt_buffer_string(tempfile)) != 0)
               goodsig = false;
 
             continue;
@@ -1200,7 +1200,7 @@ int mutt_signed_handler(struct Body *a, struct State *s)
               (mutt_istr_equal(signatures[i]->subtype, "x-pkcs7-signature") ||
                mutt_istr_equal(signatures[i]->subtype, "pkcs7-signature")))
           {
-            if (crypt_smime_verify_one(signatures[i], s, mutt_b2s(tempfile)) != 0)
+            if (crypt_smime_verify_one(signatures[i], s, mutt_buffer_string(tempfile)) != 0)
               goodsig = false;
 
             continue;
@@ -1213,7 +1213,7 @@ int mutt_signed_handler(struct Body *a, struct State *s)
         }
       }
 
-      mutt_file_unlink(mutt_b2s(tempfile));
+      mutt_file_unlink(mutt_buffer_string(tempfile));
       mutt_buffer_pool_release(&tempfile);
 
       b->goodsig = goodsig;

--- a/ncrypt/dlggpgme.c
+++ b/ncrypt/dlggpgme.c
@@ -836,7 +836,7 @@ static void verify_key(struct CryptKeyInfo *key)
 
   struct Buffer tempfile = mutt_buffer_make(PATH_MAX);
   mutt_buffer_mktemp(&tempfile);
-  FILE *fp = mutt_file_fopen(mutt_b2s(&tempfile), "w");
+  FILE *fp = mutt_file_fopen(mutt_buffer_string(&tempfile), "w");
   if (!fp)
   {
     mutt_perror(_("Can't create temporary file"));
@@ -881,7 +881,7 @@ leave:
   mutt_clear_error();
   char title[1024];
   snprintf(title, sizeof(title), _("Key ID: 0x%s"), crypt_keyid(key));
-  mutt_do_pager(title, mutt_b2s(&tempfile), MUTT_PAGER_NO_FLAGS, NULL);
+  mutt_do_pager(title, mutt_buffer_string(&tempfile), MUTT_PAGER_NO_FLAGS, NULL);
 
 cleanup:
   mutt_buffer_dealloc(&tempfile);

--- a/ncrypt/dlgpgp.c
+++ b/ncrypt/dlgpgp.c
@@ -568,7 +568,7 @@ struct PgpKeyInfo *dlg_select_pgp_key(struct PgpKeyInfo *keys,
         }
         tempfile = mutt_buffer_pool_get();
         mutt_buffer_mktemp(tempfile);
-        FILE *fp_tmp = mutt_file_fopen(mutt_b2s(tempfile), "w");
+        FILE *fp_tmp = mutt_file_fopen(mutt_buffer_string(tempfile), "w");
         if (!fp_tmp)
         {
           mutt_perror(_("Can't create temporary file"));
@@ -587,7 +587,7 @@ struct PgpKeyInfo *dlg_select_pgp_key(struct PgpKeyInfo *keys,
         if (pid == -1)
         {
           mutt_perror(_("Can't create filter"));
-          unlink(mutt_b2s(tempfile));
+          unlink(mutt_buffer_string(tempfile));
           mutt_file_fclose(&fp_tmp);
           mutt_file_fclose(&fp_null);
         }
@@ -599,7 +599,7 @@ struct PgpKeyInfo *dlg_select_pgp_key(struct PgpKeyInfo *keys,
         char title[1024];
         snprintf(title, sizeof(title), _("Key ID: 0x%s"),
                  pgp_keyid(pgp_principal_key(key_table[menu->current]->parent)));
-        mutt_do_pager(title, mutt_b2s(tempfile), MUTT_PAGER_NO_FLAGS, NULL);
+        mutt_do_pager(title, mutt_buffer_string(tempfile), MUTT_PAGER_NO_FLAGS, NULL);
         mutt_buffer_pool_release(&tempfile);
         menu->redraw = REDRAW_FULL;
         break;

--- a/ncrypt/pgpinvoke.c
+++ b/ncrypt/pgpinvoke.c
@@ -397,7 +397,7 @@ void pgp_class_invoke_import(const char *fname)
   struct Buffer *buf_fname = mutt_buffer_pool_get();
 
   mutt_buffer_quote_filename(buf_fname, fname, true);
-  cctx.fname = mutt_b2s(buf_fname);
+  cctx.fname = mutt_buffer_string(buf_fname);
   if (C_PgpSignAs)
     cctx.signas = C_PgpSignAs;
   else
@@ -436,7 +436,7 @@ void pgp_class_invoke_getkeys(struct Address *addr)
 
   addr->personal = personal;
 
-  cctx.ids = mutt_b2s(buf);
+  cctx.ids = mutt_buffer_string(buf);
 
   mutt_pgp_command(cmd, sizeof(cmd), &cctx, C_PgpGetkeysCommand);
 
@@ -528,13 +528,13 @@ pid_t pgp_invoke_list_keys(FILE **fp_pgp_in, FILE **fp_pgp_out, FILE **fp_pgp_er
   STAILQ_FOREACH(np, hints, entries)
   {
     mutt_buffer_quote_filename(quoted, (char *) np->data, true);
-    mutt_buffer_addstr(uids, mutt_b2s(quoted));
+    mutt_buffer_addstr(uids, mutt_buffer_string(quoted));
     if (STAILQ_NEXT(np, entries))
       mutt_buffer_addch(uids, ' ');
   }
 
-  pid_t rc = pgp_invoke(fp_pgp_in, fp_pgp_out, fp_pgp_err, fd_pgp_in,
-                        fd_pgp_out, fd_pgp_err, 0, NULL, NULL, mutt_b2s(uids),
+  pid_t rc = pgp_invoke(fp_pgp_in, fp_pgp_out, fp_pgp_err, fd_pgp_in, fd_pgp_out,
+                        fd_pgp_err, 0, NULL, NULL, mutt_buffer_string(uids),
                         (keyring == PGP_SECRING) ? C_PgpListSecringCommand :
                                                    C_PgpListPubringCommand);
 

--- a/ncrypt/pgpkey.c
+++ b/ncrypt/pgpkey.c
@@ -261,7 +261,7 @@ struct Body *pgp_class_make_key_attachment(void)
 
   tempf = mutt_buffer_pool_get();
   mutt_buffer_mktemp(tempf);
-  FILE *fp_tmp = mutt_file_fopen(mutt_b2s(tempf), "w");
+  FILE *fp_tmp = mutt_file_fopen(mutt_buffer_string(tempf), "w");
   if (!fp_tmp)
   {
     mutt_perror(_("Can't create temporary file"));
@@ -273,7 +273,7 @@ struct Body *pgp_class_make_key_attachment(void)
   {
     mutt_perror(_("Can't open /dev/null"));
     mutt_file_fclose(&fp_tmp);
-    unlink(mutt_b2s(tempf));
+    unlink(mutt_buffer_string(tempf));
     goto cleanup;
   }
 
@@ -283,7 +283,7 @@ struct Body *pgp_class_make_key_attachment(void)
   if (pid == -1)
   {
     mutt_perror(_("Can't create filter"));
-    unlink(mutt_b2s(tempf));
+    unlink(mutt_buffer_string(tempf));
     mutt_file_fclose(&fp_tmp);
     mutt_file_fclose(&fp_null);
     goto cleanup;
@@ -304,7 +304,7 @@ struct Body *pgp_class_make_key_attachment(void)
   att->description = mutt_str_dup(buf);
   mutt_update_encoding(att, NeoMutt->sub);
 
-  stat(mutt_b2s(tempf), &sb);
+  stat(mutt_buffer_string(tempf), &sb);
   att->length = sb.st_size;
 
 cleanup:

--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -227,15 +227,15 @@ static const char *smime_command_format_str(char *buf, size_t buflen, size_t col
 
         mutt_buffer_strcpy(path, C_SmimeCaLocation);
         mutt_buffer_expand_path(path);
-        mutt_buffer_quote_filename(buf1, mutt_b2s(path), true);
+        mutt_buffer_quote_filename(buf1, mutt_buffer_string(path), true);
 
-        if ((stat(mutt_b2s(path), &sb) != 0) || !S_ISDIR(sb.st_mode))
-          mutt_buffer_printf(buf2, "-CAfile %s", mutt_b2s(buf1));
+        if ((stat(mutt_buffer_string(path), &sb) != 0) || !S_ISDIR(sb.st_mode))
+          mutt_buffer_printf(buf2, "-CAfile %s", mutt_buffer_string(buf1));
         else
-          mutt_buffer_printf(buf2, "-CApath %s", mutt_b2s(buf1));
+          mutt_buffer_printf(buf2, "-CApath %s", mutt_buffer_string(buf1));
 
         snprintf(fmt, sizeof(fmt), "%%%ss", prec);
-        snprintf(buf, buflen, fmt, mutt_b2s(buf2));
+        snprintf(buf, buflen, fmt, mutt_buffer_string(buf2));
 
         mutt_buffer_pool_release(&path);
         mutt_buffer_pool_release(&buf1);
@@ -511,10 +511,10 @@ static struct SmimeKey *smime_get_candidates(char *search, bool only_public_key)
   mutt_buffer_printf(index_file, "%s/.index",
                      only_public_key ? NONULL(C_SmimeCertificates) : NONULL(C_SmimeKeys));
 
-  FILE *fp = mutt_file_fopen(mutt_b2s(index_file), "r");
+  FILE *fp = mutt_file_fopen(mutt_buffer_string(index_file), "r");
   if (!fp)
   {
-    mutt_perror(mutt_b2s(index_file));
+    mutt_perror(mutt_buffer_string(index_file));
     mutt_buffer_pool_release(&index_file);
     return NULL;
   }
@@ -958,10 +958,10 @@ static char *smime_extract_certificate(const char *infile)
   }
 
   mutt_buffer_mktemp(pk7out);
-  fp_out = mutt_file_fopen(mutt_b2s(pk7out), "w+");
+  fp_out = mutt_file_fopen(mutt_buffer_string(pk7out), "w+");
   if (!fp_out)
   {
-    mutt_perror(mutt_b2s(pk7out));
+    mutt_perror(mutt_buffer_string(pk7out));
     goto cleanup;
   }
 
@@ -984,35 +984,35 @@ static char *smime_extract_certificate(const char *infile)
   empty = (fgetc(fp_out) == EOF);
   if (empty)
   {
-    mutt_perror(mutt_b2s(pk7out));
+    mutt_perror(mutt_buffer_string(pk7out));
     mutt_file_copy_stream(fp_err, stdout);
     goto cleanup;
   }
   mutt_file_fclose(&fp_out);
 
   mutt_buffer_mktemp(certfile);
-  fp_cert = mutt_file_fopen(mutt_b2s(certfile), "w+");
+  fp_cert = mutt_file_fopen(mutt_buffer_string(certfile), "w+");
   if (!fp_cert)
   {
-    mutt_perror(mutt_b2s(certfile));
-    mutt_file_unlink(mutt_b2s(pk7out));
+    mutt_perror(mutt_buffer_string(certfile));
+    mutt_file_unlink(mutt_buffer_string(pk7out));
     goto cleanup;
   }
 
   // Step 2: Extract the certificates from a PKCS#7 structure.
   pid = smime_invoke(NULL, NULL, NULL, -1, fileno(fp_cert), fileno(fp_err),
-                     mutt_b2s(pk7out), NULL, NULL, NULL, NULL, NULL, NULL,
-                     C_SmimeGetCertCommand);
+                     mutt_buffer_string(pk7out), NULL, NULL, NULL, NULL, NULL,
+                     NULL, C_SmimeGetCertCommand);
   if (pid == -1)
   {
     mutt_any_key_to_continue(_("Error: unable to create OpenSSL subprocess"));
-    mutt_file_unlink(mutt_b2s(pk7out));
+    mutt_file_unlink(mutt_buffer_string(pk7out));
     goto cleanup;
   }
 
   filter_wait(pid);
 
-  mutt_file_unlink(mutt_b2s(pk7out));
+  mutt_file_unlink(mutt_buffer_string(pk7out));
 
   fflush(fp_cert);
   rewind(fp_cert);
@@ -1034,12 +1034,12 @@ cleanup:
   if (fp_out)
   {
     mutt_file_fclose(&fp_out);
-    mutt_file_unlink(mutt_b2s(pk7out));
+    mutt_file_unlink(mutt_buffer_string(pk7out));
   }
   if (fp_cert)
   {
     mutt_file_fclose(&fp_cert);
-    mutt_file_unlink(mutt_b2s(certfile));
+    mutt_file_unlink(mutt_buffer_string(certfile));
   }
   mutt_buffer_pool_release(&pk7out);
   mutt_buffer_pool_release(&certfile);
@@ -1067,18 +1067,19 @@ static char *smime_extract_signer_certificate(const char *infile)
 
   certfile = mutt_buffer_pool_get();
   mutt_buffer_mktemp(certfile);
-  FILE *fp_out = mutt_file_fopen(mutt_b2s(certfile), "w+");
+  FILE *fp_out = mutt_file_fopen(mutt_buffer_string(certfile), "w+");
   if (!fp_out)
   {
     mutt_file_fclose(&fp_err);
-    mutt_perror(mutt_b2s(certfile));
+    mutt_perror(mutt_buffer_string(certfile));
     goto cleanup;
   }
 
   /* Extract signer's certificate
    */
-  pid = smime_invoke(NULL, NULL, NULL, -1, -1, fileno(fp_err), infile, NULL, NULL, NULL,
-                     NULL, mutt_b2s(certfile), NULL, C_SmimeGetSignerCertCommand);
+  pid = smime_invoke(NULL, NULL, NULL, -1, -1, fileno(fp_err), infile, NULL,
+                     NULL, NULL, NULL, mutt_buffer_string(certfile), NULL,
+                     C_SmimeGetSignerCertCommand);
   if (pid == -1)
   {
     mutt_any_key_to_continue(_("Error: unable to create OpenSSL subprocess"));
@@ -1108,7 +1109,7 @@ cleanup:
   if (fp_out)
   {
     mutt_file_fclose(&fp_out);
-    mutt_file_unlink(mutt_b2s(certfile));
+    mutt_file_unlink(mutt_buffer_string(certfile));
   }
   mutt_buffer_pool_release(&certfile);
   return cert;
@@ -1196,10 +1197,10 @@ int smime_class_verify_sender(struct Mailbox *m, struct Email *e)
 
   struct Buffer *tempfname = mutt_buffer_pool_get();
   mutt_buffer_mktemp(tempfname);
-  FILE *fp_out = mutt_file_fopen(mutt_b2s(tempfname), "w");
+  FILE *fp_out = mutt_file_fopen(mutt_buffer_string(tempfname), "w");
   if (!fp_out)
   {
-    mutt_perror(mutt_b2s(tempfname));
+    mutt_perror(mutt_buffer_string(tempfname));
     goto cleanup;
   }
 
@@ -1227,10 +1228,10 @@ int smime_class_verify_sender(struct Mailbox *m, struct Email *e)
 
   if (mbox)
   {
-    certfile = smime_extract_signer_certificate(mutt_b2s(tempfname));
+    certfile = smime_extract_signer_certificate(mutt_buffer_string(tempfname));
     if (certfile)
     {
-      mutt_file_unlink(mutt_b2s(tempfname));
+      mutt_file_unlink(mutt_buffer_string(tempfname));
       if (smime_handle_cert_email(certfile, mbox, false, NULL, NULL))
       {
         if (isendwin())
@@ -1247,7 +1248,7 @@ int smime_class_verify_sender(struct Mailbox *m, struct Email *e)
   else
     mutt_any_key_to_continue(_("no mbox"));
 
-  mutt_file_unlink(mutt_b2s(tempfname));
+  mutt_file_unlink(mutt_buffer_string(tempfname));
 
 cleanup:
   mutt_buffer_pool_release(&tempfname);
@@ -1299,10 +1300,11 @@ static pid_t smime_invoke_sign(FILE **fp_smime_in, FILE **fp_smime_out,
                                FILE **fp_smime_err, int fp_smime_infd, int fp_smime_outfd,
                                int fp_smime_errfd, const char *fname)
 {
-  return smime_invoke(fp_smime_in, fp_smime_out, fp_smime_err, fp_smime_infd, fp_smime_outfd,
-                      fp_smime_errfd, fname, NULL, NULL, C_SmimeSignDigestAlg,
-                      mutt_b2s(&SmimeKeyToUse), mutt_b2s(&SmimeCertToUse),
-                      mutt_b2s(&SmimeIntermediateToUse), C_SmimeSignCommand);
+  return smime_invoke(fp_smime_in, fp_smime_out, fp_smime_err, fp_smime_infd,
+                      fp_smime_outfd, fp_smime_errfd, fname, NULL, NULL,
+                      C_SmimeSignDigestAlg, mutt_buffer_string(&SmimeKeyToUse),
+                      mutt_buffer_string(&SmimeCertToUse),
+                      mutt_buffer_string(&SmimeIntermediateToUse), C_SmimeSignCommand);
 }
 
 /**
@@ -1321,10 +1323,10 @@ struct Body *smime_class_build_smime_entity(struct Body *a, char *certlist)
   struct Buffer *smime_infile = mutt_buffer_pool_get();
 
   mutt_buffer_mktemp(tempfile);
-  fp_out = mutt_file_fopen(mutt_b2s(tempfile), "w+");
+  fp_out = mutt_file_fopen(mutt_buffer_string(tempfile), "w+");
   if (!fp_out)
   {
-    mutt_perror(mutt_b2s(tempfile));
+    mutt_perror(mutt_buffer_string(tempfile));
     goto cleanup;
   }
 
@@ -1336,10 +1338,10 @@ struct Body *smime_class_build_smime_entity(struct Body *a, char *certlist)
   }
 
   mutt_buffer_mktemp(smime_infile);
-  fp_tmp = mutt_file_fopen(mutt_b2s(smime_infile), "w+");
+  fp_tmp = mutt_file_fopen(mutt_buffer_string(smime_infile), "w+");
   if (!fp_tmp)
   {
-    mutt_perror(mutt_b2s(smime_infile));
+    mutt_perror(mutt_buffer_string(smime_infile));
     goto cleanup;
   }
 
@@ -1366,17 +1368,18 @@ struct Body *smime_class_build_smime_entity(struct Body *a, char *certlist)
   mutt_file_fclose(&fp_tmp);
 
   pid = smime_invoke_encrypt(&fp_smime_in, NULL, NULL, -1, fileno(fp_out),
-                             fileno(fp_smime_err), mutt_b2s(smime_infile), certfile);
+                             fileno(fp_smime_err),
+                             mutt_buffer_string(smime_infile), certfile);
   if (pid == -1)
   {
-    mutt_file_unlink(mutt_b2s(smime_infile));
+    mutt_file_unlink(mutt_buffer_string(smime_infile));
     goto cleanup;
   }
 
   mutt_file_fclose(&fp_smime_in);
 
   filter_wait(pid);
-  mutt_file_unlink(mutt_b2s(smime_infile));
+  mutt_file_unlink(mutt_buffer_string(smime_infile));
 
   fflush(fp_out);
   rewind(fp_out);
@@ -1401,7 +1404,7 @@ struct Body *smime_class_build_smime_entity(struct Body *a, char *certlist)
     /* fatal error while trying to encrypt message */
     if (err == 0)
       mutt_any_key_to_continue(_("No output from OpenSSL..."));
-    mutt_file_unlink(mutt_b2s(tempfile));
+    mutt_file_unlink(mutt_buffer_string(tempfile));
     goto cleanup;
   }
 
@@ -1423,13 +1426,13 @@ cleanup:
   if (fp_out)
   {
     mutt_file_fclose(&fp_out);
-    mutt_file_unlink(mutt_b2s(tempfile));
+    mutt_file_unlink(mutt_buffer_string(tempfile));
   }
   mutt_file_fclose(&fp_smime_err);
   if (fp_tmp)
   {
     mutt_file_fclose(&fp_tmp);
-    mutt_file_unlink(mutt_b2s(smime_infile));
+    mutt_file_unlink(mutt_buffer_string(smime_infile));
   }
   mutt_buffer_pool_release(&tempfile);
   mutt_buffer_pool_release(&smime_infile);
@@ -1497,18 +1500,18 @@ struct Body *smime_class_sign_message(struct Body *a, const struct AddressList *
   signedfile = mutt_buffer_pool_get();
 
   mutt_buffer_mktemp(filetosign);
-  fp_sign = mutt_file_fopen(mutt_b2s(filetosign), "w+");
+  fp_sign = mutt_file_fopen(mutt_buffer_string(filetosign), "w+");
   if (!fp_sign)
   {
-    mutt_perror(mutt_b2s(filetosign));
+    mutt_perror(mutt_buffer_string(filetosign));
     goto cleanup;
   }
 
   mutt_buffer_mktemp(signedfile);
-  fp_smime_out = mutt_file_fopen(mutt_b2s(signedfile), "w+");
+  fp_smime_out = mutt_file_fopen(mutt_buffer_string(signedfile), "w+");
   if (!fp_smime_out)
   {
-    mutt_perror(mutt_b2s(signedfile));
+    mutt_perror(mutt_buffer_string(signedfile));
     goto cleanup;
   }
 
@@ -1532,11 +1535,11 @@ struct Body *smime_class_sign_message(struct Body *a, const struct AddressList *
   smime_key_free(&signas_key);
 
   pid = smime_invoke_sign(&fp_smime_in, NULL, &fp_smime_err, -1,
-                          fileno(fp_smime_out), -1, mutt_b2s(filetosign));
+                          fileno(fp_smime_out), -1, mutt_buffer_string(filetosign));
   if (pid == -1)
   {
     mutt_perror(_("Can't open OpenSSL subprocess"));
-    mutt_file_unlink(mutt_b2s(filetosign));
+    mutt_file_unlink(mutt_buffer_string(filetosign));
     goto cleanup;
   }
   fputs(SmimePass, fp_smime_in);
@@ -1561,7 +1564,7 @@ struct Body *smime_class_sign_message(struct Body *a, const struct AddressList *
   empty = (fgetc(fp_smime_out) == EOF);
   mutt_file_fclose(&fp_smime_out);
 
-  mutt_file_unlink(mutt_b2s(filetosign));
+  mutt_file_unlink(mutt_buffer_string(filetosign));
 
   if (err)
     mutt_any_key_to_continue(NULL);
@@ -1569,7 +1572,7 @@ struct Body *smime_class_sign_message(struct Body *a, const struct AddressList *
   if (empty)
   {
     mutt_any_key_to_continue(_("No output from OpenSSL..."));
-    mutt_file_unlink(mutt_b2s(signedfile));
+    mutt_file_unlink(mutt_buffer_string(signedfile));
     goto cleanup; /* fatal error while signing */
   }
 
@@ -1606,12 +1609,12 @@ cleanup:
   if (fp_sign)
   {
     mutt_file_fclose(&fp_sign);
-    mutt_file_unlink(mutt_b2s(filetosign));
+    mutt_file_unlink(mutt_buffer_string(filetosign));
   }
   if (fp_smime_out)
   {
     mutt_file_fclose(&fp_smime_out);
-    mutt_file_unlink(mutt_b2s(signedfile));
+    mutt_file_unlink(mutt_buffer_string(signedfile));
   }
   mutt_buffer_pool_release(&filetosign);
   mutt_buffer_pool_release(&signedfile);
@@ -1666,8 +1669,8 @@ static pid_t smime_invoke_decrypt(FILE **fp_smime_in, FILE **fp_smime_out,
 {
   return smime_invoke(fp_smime_in, fp_smime_out, fp_smime_err, fp_smime_infd,
                       fp_smime_outfd, fp_smime_errfd, fname, NULL, NULL, NULL,
-                      mutt_b2s(&SmimeKeyToUse), mutt_b2s(&SmimeCertToUse), NULL,
-                      C_SmimeDecryptCommand);
+                      mutt_buffer_string(&SmimeKeyToUse),
+                      mutt_buffer_string(&SmimeCertToUse), NULL, C_SmimeDecryptCommand);
 }
 
 /**
@@ -1689,10 +1692,10 @@ int smime_class_verify_one(struct Body *sigbdy, struct State *s, const char *tem
 
   /* decode to a tempfile, saving the original destination */
   fp = s->fp_out;
-  s->fp_out = mutt_file_fopen(mutt_b2s(signedfile), "w");
+  s->fp_out = mutt_file_fopen(mutt_buffer_string(signedfile), "w");
   if (!s->fp_out)
   {
-    mutt_perror(mutt_b2s(signedfile));
+    mutt_perror(mutt_buffer_string(signedfile));
     goto cleanup;
   }
   /* decoding the attachment changes the size and offset, so save a copy
@@ -1714,7 +1717,7 @@ int smime_class_verify_one(struct Body *sigbdy, struct State *s, const char *tem
   /* restore final destination and substitute the tempfile for input */
   s->fp_out = fp;
   fp = s->fp_in;
-  s->fp_in = fopen(mutt_b2s(signedfile), "r");
+  s->fp_in = fopen(mutt_buffer_string(signedfile), "r");
 
   /* restore the prefix */
   s->prefix = save_prefix;
@@ -1731,7 +1734,7 @@ int smime_class_verify_one(struct Body *sigbdy, struct State *s, const char *tem
   crypt_current_time(s, "OpenSSL");
 
   pid = smime_invoke_verify(NULL, &fp_smime_out, NULL, -1, -1, fileno(fp_smime_err),
-                            tempfile, mutt_b2s(signedfile), 0);
+                            tempfile, mutt_buffer_string(signedfile), 0);
   if (pid != -1)
   {
     fflush(fp_smime_out);
@@ -1762,7 +1765,7 @@ int smime_class_verify_one(struct Body *sigbdy, struct State *s, const char *tem
 
   state_attach_puts(s, _("[-- End of OpenSSL output --]\n\n"));
 
-  mutt_file_unlink(mutt_b2s(signedfile));
+  mutt_file_unlink(mutt_buffer_string(signedfile));
 
   sigbdy->length = tmplength;
   sigbdy->offset = tmpoffset;
@@ -1814,10 +1817,10 @@ static struct Body *smime_handle_entity(struct Body *m, struct State *s, FILE *f
   }
 
   mutt_buffer_mktemp(&tmpfname);
-  fp_tmp = mutt_file_fopen(mutt_b2s(&tmpfname), "w+");
+  fp_tmp = mutt_file_fopen(mutt_buffer_string(&tmpfname), "w+");
   if (!fp_tmp)
   {
-    mutt_perror(mutt_b2s(&tmpfname));
+    mutt_perror(mutt_buffer_string(&tmpfname));
     goto cleanup;
   }
 
@@ -1829,10 +1832,11 @@ static struct Body *smime_handle_entity(struct Body *m, struct State *s, FILE *f
   mutt_file_fclose(&fp_tmp);
 
   if ((type & SEC_ENCRYPT) &&
-      ((pid = smime_invoke_decrypt(&fp_smime_in, NULL, NULL, -1, fileno(fp_smime_out),
-                                   fileno(fp_smime_err), mutt_b2s(&tmpfname))) == -1))
+      ((pid = smime_invoke_decrypt(&fp_smime_in, NULL, NULL, -1,
+                                   fileno(fp_smime_out), fileno(fp_smime_err),
+                                   mutt_buffer_string(&tmpfname))) == -1))
   {
-    mutt_file_unlink(mutt_b2s(&tmpfname));
+    mutt_file_unlink(mutt_buffer_string(&tmpfname));
     if (s->flags & MUTT_DISPLAY)
     {
       state_attach_puts(
@@ -1841,11 +1845,11 @@ static struct Body *smime_handle_entity(struct Body *m, struct State *s, FILE *f
     goto cleanup;
   }
   else if ((type & SEC_SIGNOPAQUE) &&
-           ((pid = smime_invoke_verify(&fp_smime_in, NULL, NULL, -1,
-                                       fileno(fp_smime_out), fileno(fp_smime_err), NULL,
-                                       mutt_b2s(&tmpfname), SEC_SIGNOPAQUE)) == -1))
+           ((pid = smime_invoke_verify(
+                 &fp_smime_in, NULL, NULL, -1, fileno(fp_smime_out), fileno(fp_smime_err),
+                 NULL, mutt_buffer_string(&tmpfname), SEC_SIGNOPAQUE)) == -1))
   {
-    mutt_file_unlink(mutt_b2s(&tmpfname));
+    mutt_file_unlink(mutt_buffer_string(&tmpfname));
     if (s->flags & MUTT_DISPLAY)
     {
       state_attach_puts(
@@ -1865,7 +1869,7 @@ static struct Body *smime_handle_entity(struct Body *m, struct State *s, FILE *f
   mutt_file_fclose(&fp_smime_in);
 
   filter_wait(pid);
-  mutt_file_unlink(mutt_b2s(&tmpfname));
+  mutt_file_unlink(mutt_buffer_string(&tmpfname));
 
   if (s->flags & MUTT_DISPLAY)
   {
@@ -1974,7 +1978,7 @@ static struct Body *smime_handle_entity(struct Body *m, struct State *s, FILE *f
   if (!fp_out_file)
   {
     mutt_file_fclose(&fp_out);
-    mutt_file_unlink(mutt_b2s(&tmpfname));
+    mutt_file_unlink(mutt_buffer_string(&tmpfname));
   }
   fp_out = NULL;
 
@@ -2280,7 +2284,7 @@ SecurityFlags smime_class_send_menu(struct Email *e)
           }
 
           if ((CSR_RESULT(rc) != CSR_SUCCESS) && !mutt_buffer_is_empty(&errmsg))
-            mutt_error("%s", mutt_b2s(&errmsg));
+            mutt_error("%s", mutt_buffer_string(&errmsg));
 
           mutt_buffer_dealloc(&errmsg);
         } while (choice == -1);

--- a/nntp/newsrc.c
+++ b/nntp/newsrc.c
@@ -544,7 +544,7 @@ static void cache_expand(char *dst, size_t dstlen, struct ConnAccount *cac, cons
   mutt_buffer_addstr(tmp, dst);
   mutt_buffer_expand_path(tmp);
   mutt_encode_path(tmp, dst);
-  mutt_str_copy(dst, mutt_b2s(tmp), dstlen);
+  mutt_str_copy(dst, mutt_buffer_string(tmp), dstlen);
   mutt_buffer_pool_release(&tmp);
 }
 
@@ -690,8 +690,8 @@ static void nntp_hcache_namer(const char *path, struct Buffer *dest)
   mutt_buffer_printf(dest, "%s.hcache", path);
 
   /* Strip out any directories in the path */
-  char *first = strchr(mutt_b2s(dest), '/');
-  char *last = strrchr(mutt_b2s(dest), '/');
+  char *first = strchr(mutt_buffer_string(dest), '/');
+  char *last = strrchr(mutt_buffer_string(dest), '/');
   if (first && last && (last > first))
   {
     memmove(first, last, strlen(last) + 1);
@@ -811,10 +811,11 @@ void nntp_delete_group_cache(struct NntpMboxData *mdata)
 #ifdef USE_HCACHE
   struct Buffer file = mutt_buffer_make(PATH_MAX);
   nntp_hcache_namer(mdata->group, &file);
-  cache_expand(file.data, file.dsize, &mdata->adata->conn->account, mutt_b2s(&file));
-  unlink(mutt_b2s(&file));
+  cache_expand(file.data, file.dsize, &mdata->adata->conn->account,
+               mutt_buffer_string(&file));
+  unlink(mutt_buffer_string(&file));
   mdata->last_cached = 0;
-  mutt_debug(LL_DEBUG2, "%s\n", mutt_b2s(&file));
+  mutt_debug(LL_DEBUG2, "%s\n", mutt_buffer_string(&file));
   mutt_buffer_dealloc(&file);
 #endif
 

--- a/pattern/dlgpattern.c
+++ b/pattern/dlgpattern.c
@@ -145,7 +145,7 @@ static struct Menu *create_pattern_menu(void)
     entries[i].num = i + 1;
 
     mutt_buffer_printf(entrybuf, "~%c", (char) Flags[i].tag);
-    entries[i].tag = mutt_str_dup(mutt_b2s(entrybuf));
+    entries[i].tag = mutt_str_dup(mutt_buffer_string(entrybuf));
 
     switch (Flags[i].eat_arg)
     {
@@ -180,7 +180,7 @@ static struct Menu *create_pattern_menu(void)
       default:
         break;
     }
-    entries[i].expr = mutt_str_dup(mutt_b2s(entrybuf));
+    entries[i].expr = mutt_str_dup(mutt_buffer_string(entrybuf));
     entries[i].descr = mutt_str_dup(_(Flags[i].desc));
 
     i++;
@@ -198,7 +198,7 @@ static struct Menu *create_pattern_menu(void)
   entries[i].num = i + 1;
   entries[i].tag = mutt_str_dup("~()");
   mutt_buffer_printf(entrybuf, "~(%s)", patternstr);
-  entries[i].expr = mutt_str_dup(mutt_b2s(entrybuf));
+  entries[i].expr = mutt_str_dup(mutt_buffer_string(entrybuf));
   // L10N: Pattern Completion Menu description for ~()
   entries[i].descr = mutt_str_dup(
       _("messages in threads containing messages matching PATTERN"));
@@ -207,7 +207,7 @@ static struct Menu *create_pattern_menu(void)
   entries[i].num = i + 1;
   entries[i].tag = mutt_str_dup("~<()");
   mutt_buffer_printf(entrybuf, "~<(%s)", patternstr);
-  entries[i].expr = mutt_str_dup(mutt_b2s(entrybuf));
+  entries[i].expr = mutt_str_dup(mutt_buffer_string(entrybuf));
   // L10N: Pattern Completion Menu description for ~<()
   entries[i].descr =
       mutt_str_dup(_("messages whose immediate parent matches PATTERN"));
@@ -216,7 +216,7 @@ static struct Menu *create_pattern_menu(void)
   entries[i].num = i + 1;
   entries[i].tag = mutt_str_dup("~>()");
   mutt_buffer_printf(entrybuf, "~>(%s)", patternstr);
-  entries[i].expr = mutt_str_dup(mutt_b2s(entrybuf));
+  entries[i].expr = mutt_str_dup(mutt_buffer_string(entrybuf));
   // L10N: Pattern Completion Menu description for ~>()
   entries[i].descr =
       mutt_str_dup(_("messages having an immediate child matching PATTERN"));

--- a/pattern/exec.c
+++ b/pattern/exec.c
@@ -664,10 +664,10 @@ static int msg_search_sendmode(struct Email *e, struct Pattern *pat)
   {
     struct Buffer *tempfile = mutt_buffer_pool_get();
     mutt_buffer_mktemp(tempfile);
-    fp = mutt_file_fopen(mutt_b2s(tempfile), "w+");
+    fp = mutt_file_fopen(mutt_buffer_string(tempfile), "w+");
     if (!fp)
     {
-      mutt_perror(mutt_b2s(tempfile));
+      mutt_perror(mutt_buffer_string(tempfile));
       mutt_buffer_pool_release(&tempfile);
       return 0;
     }
@@ -688,7 +688,7 @@ static int msg_search_sendmode(struct Email *e, struct Pattern *pat)
 
     FREE(&buf);
     mutt_file_fclose(&fp);
-    unlink(mutt_b2s(tempfile));
+    unlink(mutt_buffer_string(tempfile));
     mutt_buffer_pool_release(&tempfile);
 
     if (match)

--- a/pattern/pattern.c
+++ b/pattern/pattern.c
@@ -112,7 +112,7 @@ void mutt_check_simple(struct Buffer *buf, const char *simple)
 {
   bool do_simple = true;
 
-  for (const char *p = mutt_b2s(buf); p && (p[0] != '\0'); p++)
+  for (const char *p = mutt_buffer_string(buf); p && (p[0] != '\0'); p++)
   {
     if ((p[0] == '\\') && (p[1] != '\0'))
       p++;
@@ -129,32 +129,33 @@ void mutt_check_simple(struct Buffer *buf, const char *simple)
   if (do_simple) /* yup, so spoof a real request */
   {
     /* convert old tokens into the new format */
-    if (mutt_istr_equal("all", mutt_b2s(buf)) || mutt_str_equal("^", mutt_b2s(buf)) ||
-        mutt_str_equal(".", mutt_b2s(buf))) /* ~A is more efficient */
+    if (mutt_istr_equal("all", mutt_buffer_string(buf)) ||
+        mutt_str_equal("^", mutt_buffer_string(buf)) ||
+        mutt_str_equal(".", mutt_buffer_string(buf))) /* ~A is more efficient */
     {
       mutt_buffer_strcpy(buf, "~A");
     }
-    else if (mutt_istr_equal("del", mutt_b2s(buf)))
+    else if (mutt_istr_equal("del", mutt_buffer_string(buf)))
       mutt_buffer_strcpy(buf, "~D");
-    else if (mutt_istr_equal("flag", mutt_b2s(buf)))
+    else if (mutt_istr_equal("flag", mutt_buffer_string(buf)))
       mutt_buffer_strcpy(buf, "~F");
-    else if (mutt_istr_equal("new", mutt_b2s(buf)))
+    else if (mutt_istr_equal("new", mutt_buffer_string(buf)))
       mutt_buffer_strcpy(buf, "~N");
-    else if (mutt_istr_equal("old", mutt_b2s(buf)))
+    else if (mutt_istr_equal("old", mutt_buffer_string(buf)))
       mutt_buffer_strcpy(buf, "~O");
-    else if (mutt_istr_equal("repl", mutt_b2s(buf)))
+    else if (mutt_istr_equal("repl", mutt_buffer_string(buf)))
       mutt_buffer_strcpy(buf, "~Q");
-    else if (mutt_istr_equal("read", mutt_b2s(buf)))
+    else if (mutt_istr_equal("read", mutt_buffer_string(buf)))
       mutt_buffer_strcpy(buf, "~R");
-    else if (mutt_istr_equal("tag", mutt_b2s(buf)))
+    else if (mutt_istr_equal("tag", mutt_buffer_string(buf)))
       mutt_buffer_strcpy(buf, "~T");
-    else if (mutt_istr_equal("unread", mutt_b2s(buf)))
+    else if (mutt_istr_equal("unread", mutt_buffer_string(buf)))
       mutt_buffer_strcpy(buf, "~U");
     else
     {
       struct Buffer *tmp = mutt_buffer_pool_get();
-      quote_simple(mutt_b2s(buf), tmp);
-      mutt_file_expand_fmt(buf, simple, mutt_b2s(tmp));
+      quote_simple(mutt_buffer_string(buf), tmp);
+      mutt_file_expand_fmt(buf, simple, mutt_buffer_string(tmp));
       mutt_buffer_pool_release(&tmp);
     }
   }
@@ -269,7 +270,7 @@ int mutt_pattern_alias_func(int op, char *prompt, char *menu_name,
     pat = mutt_pattern_comp(buf->data, MUTT_PC_FULL_MSG, &err);
     if (!pat)
     {
-      mutt_error("%s", mutt_b2s(&err));
+      mutt_error("%s", mutt_buffer_string(&err));
       mutt_buffer_dealloc(&err);
       goto bail;
     }
@@ -508,13 +509,13 @@ int mutt_search_command(struct Mailbox *m, int cur, int op)
     mutt_buffer_strcpy(tmp, buf);
     mutt_check_simple(tmp, NONULL(C_SimpleSearch));
 
-    if (!SearchPattern || !mutt_str_equal(mutt_b2s(tmp), LastSearchExpn))
+    if (!SearchPattern || !mutt_str_equal(mutt_buffer_string(tmp), LastSearchExpn))
     {
       struct Buffer err;
       mutt_buffer_init(&err);
       OptSearchInvalid = true;
       mutt_str_copy(LastSearch, buf, sizeof(LastSearch));
-      mutt_str_copy(LastSearchExpn, mutt_b2s(tmp), sizeof(LastSearchExpn));
+      mutt_str_copy(LastSearchExpn, mutt_buffer_string(tmp), sizeof(LastSearchExpn));
       mutt_message(_("Compiling search pattern..."));
       mutt_pattern_free(&SearchPattern);
       err.dsize = 256;
@@ -659,13 +660,13 @@ int mutt_search_alias_command(struct Menu *menu, int cur, int op)
     mutt_buffer_strcpy(tmp, buf);
     mutt_check_simple(tmp, MUTT_ALIAS_SIMPLESEARCH);
 
-    if (!SearchPattern || !mutt_str_equal(mutt_b2s(tmp), LastSearchExpn))
+    if (!SearchPattern || !mutt_str_equal(mutt_buffer_string(tmp), LastSearchExpn))
     {
       struct Buffer err;
       mutt_buffer_init(&err);
       OptSearchInvalid = true;
       mutt_str_copy(LastSearch, buf, sizeof(LastSearch));
-      mutt_str_copy(LastSearchExpn, mutt_b2s(tmp), sizeof(LastSearchExpn));
+      mutt_str_copy(LastSearchExpn, mutt_buffer_string(tmp), sizeof(LastSearchExpn));
       mutt_message(_("Compiling search pattern..."));
       mutt_pattern_free(&SearchPattern);
       err.dsize = 256;

--- a/pop/pop.c
+++ b/pop/pop.c
@@ -1081,10 +1081,10 @@ static int pop_msg_open(struct Mailbox *m, struct Message *msg, int msgno)
       /* no */
       bcache = false;
       mutt_buffer_mktemp(path);
-      msg->fp = mutt_file_fopen(mutt_b2s(path), "w+");
+      msg->fp = mutt_file_fopen(mutt_buffer_string(path), "w+");
       if (!msg->fp)
       {
-        mutt_perror(mutt_b2s(path));
+        mutt_perror(mutt_buffer_string(path));
         goto cleanup;
       }
     }
@@ -1101,7 +1101,7 @@ static int pop_msg_open(struct Mailbox *m, struct Message *msg, int msgno)
      * the file in bcache or from POP's own cache since the next iteration
      * of the loop will re-attempt to put() the message */
     if (!bcache)
-      unlink(mutt_b2s(path));
+      unlink(mutt_buffer_string(path));
 
     if (ret == -2)
     {

--- a/postpone.c
+++ b/postpone.c
@@ -151,7 +151,8 @@ int mutt_num_postponed(struct Mailbox *m, bool force)
     struct Buffer *buf = mutt_buffer_pool_get();
 
     mutt_buffer_printf(buf, "%s/new", C_Postponed);
-    if ((access(mutt_b2s(buf), F_OK) == 0) && (stat(mutt_b2s(buf), &st) == -1))
+    if ((access(mutt_buffer_string(buf), F_OK) == 0) &&
+        (stat(mutt_buffer_string(buf), &st) == -1))
     {
       PostCount = 0;
       LastModify = 0;
@@ -618,7 +619,7 @@ SecurityFlags mutt_parse_crypt_hdr(const char *p, bool set_empty_signas, Securit
                                       smime_cryptalg, &errmsg);
 
     if ((CSR_RESULT(rc) != CSR_SUCCESS) && !mutt_buffer_is_empty(&errmsg))
-      mutt_error("%s", mutt_b2s(&errmsg));
+      mutt_error("%s", mutt_buffer_string(&errmsg));
 
     mutt_buffer_dealloc(&errmsg);
   }
@@ -794,7 +795,7 @@ int mutt_prepare_template(FILE *fp, struct Mailbox *m, struct Email *e_new,
     }
 
     mutt_adv_mktemp(file);
-    s.fp_out = mutt_file_fopen(mutt_b2s(file), "w");
+    s.fp_out = mutt_file_fopen(mutt_buffer_string(file), "w");
     if (!s.fp_out)
       goto bail;
 
@@ -852,7 +853,7 @@ int mutt_prepare_template(FILE *fp, struct Mailbox *m, struct Email *e_new,
     if (mutt_file_fclose(&s.fp_out) != 0)
       goto bail;
 
-    mutt_str_replace(&b->filename, mutt_b2s(file));
+    mutt_str_replace(&b->filename, mutt_buffer_string(file));
     b->unlink = true;
 
     mutt_stamp_attachment(b);

--- a/recvcmd.c
+++ b/recvcmd.c
@@ -497,10 +497,10 @@ static void attach_forward_bodies(FILE *fp, struct Email *e, struct AttachCtx *a
 
   tmpbody = mutt_buffer_pool_get();
   mutt_buffer_mktemp(tmpbody);
-  FILE *fp_tmp = mutt_file_fopen(mutt_b2s(tmpbody), "w");
+  FILE *fp_tmp = mutt_file_fopen(mutt_buffer_string(tmpbody), "w");
   if (!fp_tmp)
   {
-    mutt_error(_("Can't open temporary file %s"), mutt_b2s(tmpbody));
+    mutt_error(_("Can't open temporary file %s"), mutt_buffer_string(tmpbody));
     email_free(&e_tmp);
     goto bail;
   }
@@ -608,7 +608,8 @@ static void attach_forward_bodies(FILE *fp, struct Email *e, struct AttachCtx *a
   /* now that we have the template, send it. */
   struct EmailList el = STAILQ_HEAD_INITIALIZER(el);
   emaillist_add_email(&el, e_parent);
-  mutt_send_message(SEND_NO_FLAGS, e_tmp, mutt_b2s(tmpbody), NULL, &el, NeoMutt->sub);
+  mutt_send_message(SEND_NO_FLAGS, e_tmp, mutt_buffer_string(tmpbody), NULL,
+                    &el, NeoMutt->sub);
   emaillist_clear(&el);
   mutt_buffer_pool_release(&tmpbody);
   return;
@@ -617,7 +618,7 @@ bail:
   if (fp_tmp)
   {
     mutt_file_fclose(&fp_tmp);
-    mutt_file_unlink(mutt_b2s(tmpbody));
+    mutt_file_unlink(mutt_buffer_string(tmpbody));
   }
   mutt_buffer_pool_release(&tmpbody);
 
@@ -676,10 +677,10 @@ static void attach_forward_msgs(FILE *fp, struct AttachCtx *actx,
     /* no MIME encapsulation */
 
     mutt_buffer_mktemp(tmpbody);
-    fp_tmp = mutt_file_fopen(mutt_b2s(tmpbody), "w");
+    fp_tmp = mutt_file_fopen(mutt_buffer_string(tmpbody), "w");
     if (!fp_tmp)
     {
-      mutt_error(_("Can't create %s"), mutt_b2s(tmpbody));
+      mutt_error(_("Can't create %s"), mutt_buffer_string(tmpbody));
       goto cleanup;
     }
 
@@ -745,7 +746,8 @@ static void attach_forward_msgs(FILE *fp, struct AttachCtx *actx,
 
   struct EmailList el = STAILQ_HEAD_INITIALIZER(el);
   emaillist_add_email(&el, e_cur);
-  mutt_send_message(flags, e_tmp, mutt_buffer_is_empty(tmpbody) ? NULL : mutt_b2s(tmpbody),
+  mutt_send_message(flags, e_tmp,
+                    mutt_buffer_is_empty(tmpbody) ? NULL : mutt_buffer_string(tmpbody),
                     NULL, &el, NeoMutt->sub);
   emaillist_clear(&el);
   e_tmp = NULL; /* mutt_send_message frees this */
@@ -977,10 +979,10 @@ void mutt_attach_reply(FILE *fp, struct Email *e, struct AttachCtx *actx,
 
   tmpbody = mutt_buffer_pool_get();
   mutt_buffer_mktemp(tmpbody);
-  fp_tmp = mutt_file_fopen(mutt_b2s(tmpbody), "w");
+  fp_tmp = mutt_file_fopen(mutt_buffer_string(tmpbody), "w");
   if (!fp_tmp)
   {
-    mutt_error(_("Can't create %s"), mutt_b2s(tmpbody));
+    mutt_error(_("Can't create %s"), mutt_buffer_string(tmpbody));
     goto cleanup;
   }
 
@@ -1059,7 +1061,8 @@ void mutt_attach_reply(FILE *fp, struct Email *e, struct AttachCtx *actx,
   mutt_file_fclose(&fp_tmp);
 
   emaillist_add_email(&el, e_parent ? e_parent : (e_cur ? e_cur->email : NULL));
-  if (mutt_send_message(flags, e_tmp, mutt_b2s(tmpbody), NULL, &el, NeoMutt->sub) == 0)
+  if (mutt_send_message(flags, e_tmp, mutt_buffer_string(tmpbody), NULL, &el,
+                        NeoMutt->sub) == 0)
   {
     mutt_set_flag(Context->mailbox, e, MUTT_REPLIED, true);
   }
@@ -1069,7 +1072,7 @@ cleanup:
   if (fp_tmp)
   {
     mutt_file_fclose(&fp_tmp);
-    mutt_file_unlink(mutt_b2s(tmpbody));
+    mutt_file_unlink(mutt_buffer_string(tmpbody));
   }
   mutt_buffer_pool_release(&tmpbody);
   email_free(&e_tmp);

--- a/remailer.c
+++ b/remailer.c
@@ -198,7 +198,8 @@ static struct Remailer **mix_type2_list(size_t *l)
   struct Buffer *cmd = mutt_buffer_pool_get();
   mutt_buffer_printf(cmd, "%s -T", C_Mixmaster);
 
-  pid_t mm_pid = filter_create_fd(mutt_b2s(cmd), NULL, &fp, NULL, fd_null, -1, fd_null);
+  pid_t mm_pid =
+      filter_create_fd(mutt_buffer_string(cmd), NULL, &fp, NULL, fd_null, -1, fd_null);
   if (mm_pid == -1)
   {
     mutt_buffer_pool_release(&cmd);
@@ -855,7 +856,7 @@ int mix_send_message(struct ListHead *chain, const char *tempfile)
   {
     mutt_buffer_addstr(cmd, (i != 0) ? "," : " -l ");
     mutt_buffer_quote_filename(cd_quoted, (char *) np->data, true);
-    mutt_buffer_addstr(cmd, mutt_b2s(cd_quoted));
+    mutt_buffer_addstr(cmd, mutt_buffer_string(cd_quoted));
     i = 1;
   }
 

--- a/rfc3676.c
+++ b/rfc3676.c
@@ -422,7 +422,7 @@ static void rfc3676_space_stuff(const char *filename, bool unstuff)
     goto bail;
 
   mutt_buffer_mktemp(tmpfile);
-  fp_out = mutt_file_fopen(mutt_b2s(tmpfile), "w+");
+  fp_out = mutt_file_fopen(mutt_buffer_string(tmpfile), "w+");
   if (!fp_out)
     goto bail;
 
@@ -446,9 +446,9 @@ static void rfc3676_space_stuff(const char *filename, bool unstuff)
   FREE(&buf);
   mutt_file_fclose(&fp_in);
   mutt_file_fclose(&fp_out);
-  mutt_file_set_mtime(filename, mutt_b2s(tmpfile));
+  mutt_file_set_mtime(filename, mutt_buffer_string(tmpfile));
 
-  fp_in = mutt_file_fopen(mutt_b2s(tmpfile), "r");
+  fp_in = mutt_file_fopen(mutt_buffer_string(tmpfile), "r");
   if (!fp_in)
     goto bail;
 
@@ -459,8 +459,8 @@ static void rfc3676_space_stuff(const char *filename, bool unstuff)
   }
 
   mutt_file_copy_stream(fp_in, fp_out);
-  mutt_file_set_mtime(mutt_b2s(tmpfile), filename);
-  unlink(mutt_b2s(tmpfile));
+  mutt_file_set_mtime(mutt_buffer_string(tmpfile), filename);
+  unlink(mutt_buffer_string(tmpfile));
 
 bail:
   mutt_file_fclose(&fp_in);

--- a/send/header.c
+++ b/send/header.c
@@ -582,7 +582,7 @@ int mutt_rfc822_write_header(FILE *fp, struct Envelope *env, struct Body *attach
   {
     struct Buffer *date = mutt_buffer_pool_get();
     mutt_date_make_date(date);
-    fprintf(fp, "Date: %s\n", mutt_b2s(date));
+    fprintf(fp, "Date: %s\n", mutt_buffer_string(date));
     mutt_buffer_pool_release(&date);
   }
 

--- a/sidebar/commands.c
+++ b/sidebar/commands.c
@@ -48,7 +48,7 @@ enum CommandResult sb_parse_whitelist(struct Buffer *buf, struct Buffer *s,
   {
     mutt_extract_token(path, s, MUTT_TOKEN_BACKTICK_VARS);
     mutt_buffer_expand_path(path);
-    add_to_stailq(&SidebarWhitelist, mutt_b2s(path));
+    add_to_stailq(&SidebarWhitelist, mutt_buffer_string(path));
   } while (MoreArgs(s));
   mutt_buffer_pool_release(&path);
 
@@ -67,13 +67,13 @@ enum CommandResult sb_parse_unwhitelist(struct Buffer *buf, struct Buffer *s,
   {
     mutt_extract_token(path, s, MUTT_TOKEN_BACKTICK_VARS);
     /* Check for deletion of entire list */
-    if (mutt_str_equal(mutt_b2s(path), "*"))
+    if (mutt_str_equal(mutt_buffer_string(path), "*"))
     {
       mutt_list_free(&SidebarWhitelist);
       break;
     }
     mutt_buffer_expand_path(path);
-    remove_from_stailq(&SidebarWhitelist, mutt_b2s(path));
+    remove_from_stailq(&SidebarWhitelist, mutt_buffer_string(path));
   } while (MoreArgs(s));
   mutt_buffer_pool_release(&path);
 

--- a/store/bdb.c
+++ b/store/bdb.c
@@ -103,7 +103,7 @@ static void *store_bdb_open(const char *path)
   ctx->lockfile = mutt_buffer_make(128);
   mutt_buffer_printf(&ctx->lockfile, "%s-lock-hack", path);
 
-  ctx->fd = open(mutt_b2s(&ctx->lockfile), O_WRONLY | O_CREAT, S_IRUSR | S_IWUSR);
+  ctx->fd = open(mutt_buffer_string(&ctx->lockfile), O_WRONLY | O_CREAT, S_IRUSR | S_IWUSR);
   if (ctx->fd < 0)
   {
     FREE(&ctx);
@@ -146,7 +146,7 @@ fail_unlock:
   mutt_file_unlock(ctx->fd);
 fail_close:
   close(ctx->fd);
-  unlink(mutt_b2s(&ctx->lockfile));
+  unlink(mutt_buffer_string(&ctx->lockfile));
   mutt_buffer_dealloc(&ctx->lockfile);
   FREE(&ctx);
 
@@ -237,7 +237,7 @@ static void store_bdb_close(void **ptr)
   db->env->close(db->env, 0);
   mutt_file_unlock(db->fd);
   close(db->fd);
-  unlink(mutt_b2s(&db->lockfile));
+  unlink(mutt_buffer_string(&db->lockfile));
   mutt_buffer_dealloc(&db->lockfile);
   FREE(ptr);
 }

--- a/store/kc.c
+++ b/store/kc.c
@@ -53,11 +53,11 @@ static void *store_kyotocabinet_open(const char *path)
 
   mutt_buffer_printf(&kcdbpath, "%s#type=kct#opts=l#rcomp=lex", path);
 
-  if (!kcdbopen(db, mutt_b2s(&kcdbpath), KCOWRITER | KCOCREATE))
+  if (!kcdbopen(db, mutt_buffer_string(&kcdbpath), KCOWRITER | KCOCREATE))
   {
     int ecode = kcdbecode(db);
     mutt_debug(LL_DEBUG2, "kcdbopen failed for %s: %s (ecode %d)\n",
-               mutt_b2s(&kcdbpath), kcdbemsg(db), ecode);
+               mutt_buffer_string(&kcdbpath), kcdbemsg(db), ecode);
     kcdbdel(db);
     db = NULL;
   }

--- a/test/buffer/mutt_buffer_add_printf.c
+++ b/test/buffer/mutt_buffer_add_printf.c
@@ -44,7 +44,7 @@ void test_mutt_buffer_add_printf(void)
     TEST_CASE("Empty");
     struct Buffer buf = mutt_buffer_make(0);
     TEST_CHECK(mutt_buffer_add_printf(&buf, "") == 0);
-    TEST_CHECK(strlen(mutt_b2s(&buf)) == 0);
+    TEST_CHECK(strlen(mutt_buffer_string(&buf)) == 0);
     mutt_buffer_dealloc(&buf);
   }
 
@@ -53,7 +53,7 @@ void test_mutt_buffer_add_printf(void)
     const char *str = "apple";
     struct Buffer buf = mutt_buffer_make(0);
     TEST_CHECK(mutt_buffer_add_printf(&buf, str) == 5);
-    TEST_CHECK(strcmp(mutt_b2s(&buf), str) == 0);
+    TEST_CHECK(strcmp(mutt_buffer_string(&buf), str) == 0);
     mutt_buffer_dealloc(&buf);
   }
 
@@ -65,7 +65,7 @@ void test_mutt_buffer_add_printf(void)
         "strawberry tangerine ugli vanilla wolfberry xigua yew ziziphus";
     struct Buffer buf = mutt_buffer_make(0);
     TEST_CHECK(mutt_buffer_add_printf(&buf, str) == 195);
-    TEST_CHECK(strcmp(mutt_b2s(&buf), str) == 0);
+    TEST_CHECK(strcmp(mutt_buffer_string(&buf), str) == 0);
     mutt_buffer_dealloc(&buf);
   }
 
@@ -75,7 +75,7 @@ void test_mutt_buffer_add_printf(void)
     const char *result = "app 1234567 3.1416";
     struct Buffer buf = mutt_buffer_make(0);
     TEST_CHECK(mutt_buffer_add_printf(&buf, "%.3s %ld %3.4f", str, 1234567, 3.141592654) == 18);
-    TEST_CHECK(strcmp(mutt_b2s(&buf), result) == 0);
+    TEST_CHECK(strcmp(mutt_buffer_string(&buf), result) == 0);
     mutt_buffer_dealloc(&buf);
   }
 
@@ -87,7 +87,7 @@ void test_mutt_buffer_add_printf(void)
     struct Buffer buf = mutt_buffer_make(0);
     mutt_buffer_addstr(&buf, str);
     TEST_CHECK(mutt_buffer_add_printf(&buf, "") == 0);
-    TEST_CHECK(strcmp(mutt_b2s(&buf), str) == 0);
+    TEST_CHECK(strcmp(mutt_buffer_string(&buf), str) == 0);
     mutt_buffer_dealloc(&buf);
   }
 
@@ -98,7 +98,7 @@ void test_mutt_buffer_add_printf(void)
     struct Buffer buf = mutt_buffer_make(0);
     mutt_buffer_addstr(&buf, "test");
     TEST_CHECK(mutt_buffer_add_printf(&buf, str) == 5);
-    TEST_CHECK(strcmp(mutt_b2s(&buf), result) == 0);
+    TEST_CHECK(strcmp(mutt_buffer_string(&buf), result) == 0);
     mutt_buffer_dealloc(&buf);
   }
 
@@ -115,7 +115,7 @@ void test_mutt_buffer_add_printf(void)
     struct Buffer buf = mutt_buffer_make(0);
     mutt_buffer_addstr(&buf, "test");
     TEST_CHECK(mutt_buffer_add_printf(&buf, str) == 195);
-    TEST_CHECK(strcmp(mutt_b2s(&buf), result) == 0);
+    TEST_CHECK(strcmp(mutt_buffer_string(&buf), result) == 0);
     mutt_buffer_dealloc(&buf);
   }
 
@@ -126,7 +126,7 @@ void test_mutt_buffer_add_printf(void)
     struct Buffer buf = mutt_buffer_make(0);
     mutt_buffer_addstr(&buf, "test");
     TEST_CHECK(mutt_buffer_add_printf(&buf, "%.3s %ld %3.4f", str, 1234567, 3.141592654) == 18);
-    TEST_CHECK(strcmp(mutt_b2s(&buf), result) == 0);
+    TEST_CHECK(strcmp(mutt_buffer_string(&buf), result) == 0);
     mutt_buffer_dealloc(&buf);
   }
 }

--- a/test/buffer/mutt_buffer_addch.c
+++ b/test/buffer/mutt_buffer_addch.c
@@ -36,7 +36,7 @@ void test_mutt_buffer_addch(void)
   {
     struct Buffer buf = mutt_buffer_make(0);
     TEST_CHECK(mutt_buffer_addch(&buf, 'a') == 1);
-    TEST_CHECK(strcmp(mutt_b2s(&buf), "a") == 0);
+    TEST_CHECK(strcmp(mutt_buffer_string(&buf), "a") == 0);
     mutt_buffer_dealloc(&buf);
   }
 
@@ -44,7 +44,7 @@ void test_mutt_buffer_addch(void)
     struct Buffer buf = mutt_buffer_make(0);
     mutt_buffer_addstr(&buf, "test");
     TEST_CHECK(mutt_buffer_addch(&buf, 'a') == 1);
-    TEST_CHECK(strcmp(mutt_b2s(&buf), "testa") == 0);
+    TEST_CHECK(strcmp(mutt_buffer_string(&buf), "testa") == 0);
     mutt_buffer_dealloc(&buf);
   }
 }

--- a/test/buffer/mutt_buffer_addstr.c
+++ b/test/buffer/mutt_buffer_addstr.c
@@ -41,7 +41,7 @@ void test_mutt_buffer_addstr(void)
   {
     struct Buffer buf = mutt_buffer_make(0);
     TEST_CHECK(mutt_buffer_addstr(&buf, "apple") == 5);
-    TEST_CHECK(strcmp(mutt_b2s(&buf), "apple") == 0);
+    TEST_CHECK(strcmp(mutt_buffer_string(&buf), "apple") == 0);
     mutt_buffer_dealloc(&buf);
   }
 
@@ -49,7 +49,7 @@ void test_mutt_buffer_addstr(void)
     struct Buffer buf = mutt_buffer_make(0);
     mutt_buffer_addstr(&buf, "test");
     TEST_CHECK(mutt_buffer_addstr(&buf, "apple") == 5);
-    TEST_CHECK(strcmp(mutt_b2s(&buf), "testapple") == 0);
+    TEST_CHECK(strcmp(mutt_buffer_string(&buf), "testapple") == 0);
     mutt_buffer_dealloc(&buf);
   }
 }

--- a/test/buffer/mutt_buffer_addstr_n.c
+++ b/test/buffer/mutt_buffer_addstr_n.c
@@ -50,8 +50,8 @@ void test_mutt_buffer_addstr_n(void)
       TEST_CASE_("%ld", sizes[i]);
       struct Buffer buf = mutt_buffer_make(0);
       TEST_CHECK(mutt_buffer_addstr_n(&buf, str, sizes[i]) == sizes[i]);
-      TEST_CHECK(strlen(mutt_b2s(&buf)) == MIN(len, sizes[i]));
-      TEST_CHECK(mutt_strn_equal(mutt_b2s(&buf), str, sizes[i]));
+      TEST_CHECK(strlen(mutt_buffer_string(&buf)) == MIN(len, sizes[i]));
+      TEST_CHECK(mutt_strn_equal(mutt_buffer_string(&buf), str, sizes[i]));
       mutt_buffer_dealloc(&buf);
     }
   }
@@ -72,8 +72,8 @@ void test_mutt_buffer_addstr_n(void)
       struct Buffer buf = mutt_buffer_make(0);
       mutt_buffer_addstr(&buf, base);
       TEST_CHECK(mutt_buffer_addstr_n(&buf, str, sizes[i]) == sizes[i]);
-      TEST_CHECK(strlen(mutt_b2s(&buf)) == (base_len + MIN(len, sizes[i])));
-      TEST_CHECK(mutt_strn_equal(mutt_b2s(&buf), combined, base_len + sizes[i]));
+      TEST_CHECK(strlen(mutt_buffer_string(&buf)) == (base_len + MIN(len, sizes[i])));
+      TEST_CHECK(mutt_strn_equal(mutt_buffer_string(&buf), combined, base_len + sizes[i]));
       mutt_buffer_dealloc(&buf);
     }
   }

--- a/test/buffer/mutt_buffer_concat_path.c
+++ b/test/buffer/mutt_buffer_concat_path.c
@@ -63,13 +63,13 @@ void test_mutt_buffer_concat_path(void)
         mutt_buffer_concat_path(&buf, concat_test[i][0], concat_test[i][1]);
         if (concat_test[i][2])
         {
-          TEST_CHECK(strcmp(mutt_b2s(&buf), concat_test[i][2]) == 0);
+          TEST_CHECK(strcmp(mutt_buffer_string(&buf), concat_test[i][2]) == 0);
         }
         else
         {
-          if (!TEST_CHECK(strlen(mutt_b2s(&buf)) == 0))
+          if (!TEST_CHECK(strlen(mutt_buffer_string(&buf)) == 0))
           {
-            TEST_MSG("len = %ld", strlen(mutt_b2s(&buf)));
+            TEST_MSG("len = %ld", strlen(mutt_buffer_string(&buf)));
           }
         }
         mutt_buffer_dealloc(&buf);
@@ -82,11 +82,11 @@ void test_mutt_buffer_concat_path(void)
         mutt_buffer_concat_path(&buf, concat_test[i][0], concat_test[i][1]);
         if (concat_test[i][2])
         {
-          TEST_CHECK(strcmp(mutt_b2s(&buf), concat_test[i][2]) == 0);
+          TEST_CHECK(strcmp(mutt_buffer_string(&buf), concat_test[i][2]) == 0);
         }
         else
         {
-          TEST_CHECK(strcmp(mutt_b2s(&buf), str) == 0);
+          TEST_CHECK(strcmp(mutt_buffer_string(&buf), str) == 0);
         }
         mutt_buffer_dealloc(&buf);
       }

--- a/test/buffer/mutt_buffer_concatn_path.c
+++ b/test/buffer/mutt_buffer_concatn_path.c
@@ -43,7 +43,7 @@ void test_mutt_buffer_concatn_path(void)
     size_t len = mutt_buffer_concatn_path(&buf, dir, 9, file, 4);
 
     TEST_CHECK(len == 14);
-    TEST_CHECK(mutt_str_equal(mutt_b2s(&buf), result));
+    TEST_CHECK(mutt_str_equal(mutt_buffer_string(&buf), result));
 
     mutt_buffer_dealloc(&buf);
   }

--- a/test/buffer/mutt_buffer_copy.c
+++ b/test/buffer/mutt_buffer_copy.c
@@ -57,7 +57,7 @@ void test_mutt_buffer_copy(void)
     size_t len = mutt_buffer_copy(&buf2, &buf1);
 
     TEST_CHECK(len == 10);
-    TEST_CHECK(mutt_str_equal(mutt_b2s(&buf1), mutt_b2s(&buf2)));
+    TEST_CHECK(mutt_str_equal(mutt_buffer_string(&buf1), mutt_buffer_string(&buf2)));
 
     mutt_buffer_dealloc(&buf1);
     mutt_buffer_dealloc(&buf2);

--- a/test/buffer/mutt_buffer_printf.c
+++ b/test/buffer/mutt_buffer_printf.c
@@ -44,7 +44,7 @@ void test_mutt_buffer_printf(void)
     TEST_CASE("Empty");
     struct Buffer buf = mutt_buffer_make(0);
     TEST_CHECK(mutt_buffer_printf(&buf, "") == 0);
-    TEST_CHECK(strlen(mutt_b2s(&buf)) == 0);
+    TEST_CHECK(strlen(mutt_buffer_string(&buf)) == 0);
     mutt_buffer_dealloc(&buf);
   }
 
@@ -53,7 +53,7 @@ void test_mutt_buffer_printf(void)
     const char *str = "apple";
     struct Buffer buf = mutt_buffer_make(0);
     TEST_CHECK(mutt_buffer_printf(&buf, str) == 5);
-    TEST_CHECK(strcmp(mutt_b2s(&buf), str) == 0);
+    TEST_CHECK(strcmp(mutt_buffer_string(&buf), str) == 0);
     mutt_buffer_dealloc(&buf);
   }
 
@@ -63,7 +63,7 @@ void test_mutt_buffer_printf(void)
     const char *result = "app 1234567 3.1416";
     struct Buffer buf = mutt_buffer_make(0);
     TEST_CHECK(mutt_buffer_printf(&buf, "%.3s %ld %3.4f", str, 1234567, 3.141592654) == 18);
-    TEST_CHECK(strcmp(mutt_b2s(&buf), result) == 0);
+    TEST_CHECK(strcmp(mutt_buffer_string(&buf), result) == 0);
     mutt_buffer_dealloc(&buf);
   }
 
@@ -75,7 +75,7 @@ void test_mutt_buffer_printf(void)
     struct Buffer buf = mutt_buffer_make(0);
     mutt_buffer_addstr(&buf, str);
     TEST_CHECK(mutt_buffer_printf(&buf, "") == 0);
-    TEST_CHECK(strcmp(mutt_b2s(&buf), "") == 0);
+    TEST_CHECK(strcmp(mutt_buffer_string(&buf), "") == 0);
     mutt_buffer_dealloc(&buf);
   }
 
@@ -85,7 +85,7 @@ void test_mutt_buffer_printf(void)
     struct Buffer buf = mutt_buffer_make(0);
     mutt_buffer_addstr(&buf, "test");
     TEST_CHECK(mutt_buffer_printf(&buf, str) == 5);
-    TEST_CHECK(strcmp(mutt_b2s(&buf), str) == 0);
+    TEST_CHECK(strcmp(mutt_buffer_string(&buf), str) == 0);
     mutt_buffer_dealloc(&buf);
   }
 
@@ -98,7 +98,7 @@ void test_mutt_buffer_printf(void)
     struct Buffer buf = mutt_buffer_make(0);
     mutt_buffer_addstr(&buf, "test");
     TEST_CHECK(mutt_buffer_printf(&buf, str) == 195);
-    TEST_CHECK(strcmp(mutt_b2s(&buf), str) == 0);
+    TEST_CHECK(strcmp(mutt_buffer_string(&buf), str) == 0);
     mutt_buffer_dealloc(&buf);
   }
 
@@ -109,7 +109,7 @@ void test_mutt_buffer_printf(void)
     struct Buffer buf = mutt_buffer_make(0);
     mutt_buffer_addstr(&buf, "test");
     TEST_CHECK(mutt_buffer_printf(&buf, "%.3s %ld %3.4f", str, 1234567, 3.141592654) == 18);
-    TEST_CHECK(strcmp(mutt_b2s(&buf), result) == 0);
+    TEST_CHECK(strcmp(mutt_buffer_string(&buf), result) == 0);
     mutt_buffer_dealloc(&buf);
   }
 }

--- a/test/buffer/mutt_buffer_strcpy.c
+++ b/test/buffer/mutt_buffer_strcpy.c
@@ -46,7 +46,7 @@ void test_mutt_buffer_strcpy(void)
     TEST_CASE("Empty");
     struct Buffer buf = mutt_buffer_make(0);
     mutt_buffer_strcpy(&buf, "");
-    TEST_CHECK(strcmp(mutt_b2s(&buf), "") == 0);
+    TEST_CHECK(strcmp(mutt_buffer_string(&buf), "") == 0);
     mutt_buffer_dealloc(&buf);
   }
 
@@ -55,7 +55,7 @@ void test_mutt_buffer_strcpy(void)
     const char *str = "test";
     struct Buffer buf = mutt_buffer_make(0);
     mutt_buffer_strcpy(&buf, str);
-    TEST_CHECK(strcmp(mutt_b2s(&buf), str) == 0);
+    TEST_CHECK(strcmp(mutt_buffer_string(&buf), str) == 0);
     mutt_buffer_dealloc(&buf);
   }
 
@@ -66,7 +66,7 @@ void test_mutt_buffer_strcpy(void)
     struct Buffer buf = mutt_buffer_make(0);
     mutt_buffer_addstr(&buf, "test");
     mutt_buffer_strcpy(&buf, "");
-    TEST_CHECK(strcmp(mutt_b2s(&buf), "") == 0);
+    TEST_CHECK(strcmp(mutt_buffer_string(&buf), "") == 0);
     mutt_buffer_dealloc(&buf);
   }
 
@@ -76,7 +76,7 @@ void test_mutt_buffer_strcpy(void)
     struct Buffer buf = mutt_buffer_make(0);
     mutt_buffer_addstr(&buf, "test");
     mutt_buffer_strcpy(&buf, str);
-    TEST_CHECK(strcmp(mutt_b2s(&buf), str) == 0);
+    TEST_CHECK(strcmp(mutt_buffer_string(&buf), str) == 0);
     mutt_buffer_dealloc(&buf);
   }
 }

--- a/test/buffer/mutt_buffer_strcpy_n.c
+++ b/test/buffer/mutt_buffer_strcpy_n.c
@@ -52,8 +52,8 @@ void test_mutt_buffer_strcpy_n(void)
       TEST_CASE_("%ld", sizes[i]);
       struct Buffer buf = mutt_buffer_make(0);
       mutt_buffer_strcpy_n(&buf, str, sizes[i]);
-      TEST_CHECK(strlen(mutt_b2s(&buf)) == MIN(len, sizes[i]));
-      TEST_CHECK(mutt_strn_equal(mutt_b2s(&buf), str, sizes[i]));
+      TEST_CHECK(strlen(mutt_buffer_string(&buf)) == MIN(len, sizes[i]));
+      TEST_CHECK(mutt_strn_equal(mutt_buffer_string(&buf), str, sizes[i]));
       mutt_buffer_dealloc(&buf);
     }
   }
@@ -72,8 +72,8 @@ void test_mutt_buffer_strcpy_n(void)
       struct Buffer buf = mutt_buffer_make(0);
       mutt_buffer_addstr(&buf, base);
       mutt_buffer_strcpy_n(&buf, str, sizes[i]);
-      TEST_CHECK(strlen(mutt_b2s(&buf)) == MIN(len, sizes[i]));
-      TEST_CHECK(mutt_strn_equal(mutt_b2s(&buf), str, sizes[i]));
+      TEST_CHECK(strlen(mutt_buffer_string(&buf)) == MIN(len, sizes[i]));
+      TEST_CHECK(mutt_strn_equal(mutt_buffer_string(&buf), str, sizes[i]));
       mutt_buffer_dealloc(&buf);
     }
   }

--- a/test/buffer/mutt_buffer_substrcpy.c
+++ b/test/buffer/mutt_buffer_substrcpy.c
@@ -42,7 +42,7 @@ void test_mutt_buffer_substrcpy(void)
     size_t len = mutt_buffer_substrcpy(&buf, src + 9, src + 18);
 
     TEST_CHECK(len == 9);
-    TEST_CHECK(mutt_str_equal(mutt_b2s(&buf), result));
+    TEST_CHECK(mutt_str_equal(mutt_buffer_string(&buf), result));
 
     mutt_buffer_dealloc(&buf);
   }

--- a/test/config/dump.c
+++ b/test/config/dump.c
@@ -127,7 +127,7 @@ bool test_pretty_var(void)
       return false;
     }
 
-    if (!TEST_CHECK(mutt_str_equal("\"apple\"", mutt_b2s(&buf))))
+    if (!TEST_CHECK(mutt_str_equal("\"apple\"", mutt_buffer_string(&buf))))
     {
       mutt_buffer_dealloc(&buf);
       return false;
@@ -165,7 +165,7 @@ bool test_escape_string(void)
       return false;
     }
 
-    if (!TEST_CHECK(mutt_str_equal(mutt_b2s(&buf), after)))
+    if (!TEST_CHECK(mutt_str_equal(mutt_buffer_string(&buf), after)))
     {
       mutt_buffer_dealloc(&buf);
       return false;

--- a/test/config/slist.c
+++ b/test/config/slist.c
@@ -151,7 +151,7 @@ static void slist_dump(const struct Slist *list, struct Buffer *buf)
     if (STAILQ_NEXT(np, entries))
       mutt_buffer_addstr(buf, ",");
   }
-  TEST_MSG("%s\n", mutt_b2s(buf));
+  TEST_MSG("%s\n", mutt_buffer_string(buf));
   mutt_buffer_reset(buf);
 }
 
@@ -175,7 +175,7 @@ static bool test_slist_parse(struct Buffer *err)
 
   uint32_t flags = SLIST_SEP_COLON | SLIST_ALLOW_EMPTY;
   slist_flags(flags, err);
-  TEST_MSG("Flags: %s", mutt_b2s(err));
+  TEST_MSG("Flags: %s", mutt_buffer_string(err));
   TEST_MSG("\n");
   mutt_buffer_reset(err);
 
@@ -374,7 +374,7 @@ static bool test_initial_values(struct ConfigSet *cs, struct Buffer *err)
   static const char *values[] = { "apple", "banana", "cherry", NULL };
 
   slist_flags(VarApple->flags, err);
-  TEST_MSG("Apple, %ld items, %s flags\n", VarApple->count, mutt_b2s(err));
+  TEST_MSG("Apple, %ld items, %s flags\n", VarApple->count, mutt_buffer_string(err));
   mutt_buffer_reset(err);
   if (VarApple->count != 1)
   {
@@ -392,7 +392,7 @@ static bool test_initial_values(struct ConfigSet *cs, struct Buffer *err)
   }
 
   slist_flags(VarBanana->flags, err);
-  TEST_MSG("Banana, %ld items, %s flags\n", VarBanana->count, mutt_b2s(err));
+  TEST_MSG("Banana, %ld items, %s flags\n", VarBanana->count, mutt_buffer_string(err));
   mutt_buffer_reset(err);
   if (VarBanana->count != 2)
   {
@@ -410,7 +410,7 @@ static bool test_initial_values(struct ConfigSet *cs, struct Buffer *err)
   }
 
   slist_flags(VarCherry->flags, err);
-  TEST_MSG("Cherry, %ld items, %s flags\n", VarCherry->count, mutt_b2s(err));
+  TEST_MSG("Cherry, %ld items, %s flags\n", VarCherry->count, mutt_buffer_string(err));
   mutt_buffer_reset(err);
   if (VarCherry->count != 3)
   {
@@ -612,7 +612,7 @@ static bool test_native_set(struct ConfigSet *cs, struct Buffer *err)
     return false;
   }
 
-  if (!TEST_CHECK(strcmp(mutt_b2s(err), init) == 0))
+  if (!TEST_CHECK(strcmp(mutt_buffer_string(err), init) == 0))
     return false;
 
   mutt_buffer_reset(err);
@@ -695,10 +695,10 @@ static bool test_plus_equals(struct ConfigSet *cs, struct Buffer *err)
       return false;
     }
 
-    if (!TEST_CHECK(mutt_str_equal(PlusTests[i][2], mutt_b2s(err))))
+    if (!TEST_CHECK(mutt_str_equal(PlusTests[i][2], mutt_buffer_string(err))))
     {
       TEST_MSG("Expected: %s\n", PlusTests[i][2]);
-      TEST_MSG("Actual  : %s\n", mutt_b2s(err));
+      TEST_MSG("Actual  : %s\n", mutt_buffer_string(err));
       return false;
     }
   }
@@ -773,10 +773,10 @@ static bool test_minus_equals(struct ConfigSet *cs, struct Buffer *err)
       return false;
     }
 
-    if (!TEST_CHECK(mutt_str_equal(MinusTests[i][2], mutt_b2s(err))))
+    if (!TEST_CHECK(mutt_str_equal(MinusTests[i][2], mutt_buffer_string(err))))
     {
       TEST_MSG("Expected: %s\n", MinusTests[i][2]);
-      TEST_MSG("Actual  : %s\n", mutt_b2s(err));
+      TEST_MSG("Actual  : %s\n", mutt_buffer_string(err));
       return false;
     }
   }

--- a/test/config/string.c
+++ b/test/config/string.c
@@ -439,10 +439,10 @@ static bool test_string_plus_equals(struct ConfigSet *cs, struct Buffer *err)
       return false;
     }
 
-    if (!TEST_CHECK(mutt_str_equal(PlusTests[i][2], mutt_b2s(err))))
+    if (!TEST_CHECK(mutt_str_equal(PlusTests[i][2], mutt_buffer_string(err))))
     {
       TEST_MSG("Expected: %s\n", PlusTests[i][2]);
-      TEST_MSG("Actual  : %s\n", mutt_b2s(err));
+      TEST_MSG("Actual  : %s\n", mutt_buffer_string(err));
       return false;
     }
   }

--- a/test/config/subset.c
+++ b/test/config/subset.c
@@ -139,11 +139,11 @@ void test_config_subset(void)
   expected = "142";
   rc = cs_subset_he_string_get(NeoMutt->sub, he, &err);
   if (!TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS) ||
-      !TEST_CHECK(strcmp(mutt_b2s(&err), expected) == 0))
+      !TEST_CHECK(strcmp(mutt_buffer_string(&err), expected) == 0))
   {
     TEST_MSG("cs_subset_he_string_get failed\n");
     TEST_MSG("Expected: %s", expected);
-    TEST_MSG("Actual  : %s", mutt_b2s(&err));
+    TEST_MSG("Actual  : %s", mutt_buffer_string(&err));
     return;
   }
 
@@ -159,11 +159,11 @@ void test_config_subset(void)
   expected = "142";
   rc = cs_subset_str_string_get(NeoMutt->sub, name, &err);
   if (!TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS) ||
-      !TEST_CHECK(strcmp(mutt_b2s(&err), expected) == 0))
+      !TEST_CHECK(strcmp(mutt_buffer_string(&err), expected) == 0))
   {
     TEST_MSG("cs_subset_str_string_get failed\n");
     TEST_MSG("Expected: %s", expected);
-    TEST_MSG("Actual  : %s", mutt_b2s(&err));
+    TEST_MSG("Actual  : %s", mutt_buffer_string(&err));
     return;
   }
 

--- a/test/file/mutt_buffer_quote_filename.c
+++ b/test/file/mutt_buffer_quote_filename.c
@@ -51,11 +51,11 @@ void test_mutt_buffer_quote_filename(void)
   {
     TEST_CASE(tests[i].first);
     mutt_buffer_quote_filename(&result, tests[i].first, (i % 2));
-    if (!TEST_CHECK(mutt_str_equal(mutt_b2s(&result), tests[i].second)))
+    if (!TEST_CHECK(mutt_str_equal(mutt_buffer_string(&result), tests[i].second)))
     {
       TEST_MSG("Original: %s", tests[i].first);
       TEST_MSG("Expected: %s", tests[i].second);
-      TEST_MSG("Actual:   %s", mutt_b2s(&result));
+      TEST_MSG("Actual:   %s", mutt_buffer_string(&result));
     }
   }
 

--- a/test/file/mutt_file_resolve_symlink.c
+++ b/test/file/mutt_file_resolve_symlink.c
@@ -55,11 +55,11 @@ void test_mutt_file_resolve_symlink(void)
 
     TEST_CASE(first);
     mutt_file_resolve_symlink(&result);
-    if (!TEST_CHECK(mutt_str_equal(mutt_b2s(&result), second)))
+    if (!TEST_CHECK(mutt_str_equal(mutt_buffer_string(&result), second)))
     {
       TEST_MSG("Original: %s", NONULL(tests[i].first));
       TEST_MSG("Expected: %s", second);
-      TEST_MSG("Actual:   %s", mutt_b2s(&result));
+      TEST_MSG("Actual:   %s", mutt_buffer_string(&result));
     }
   }
 

--- a/test/gui/reflow.c
+++ b/test/gui/reflow.c
@@ -112,9 +112,9 @@ void test_window_reflow(void)
 
     struct Buffer buf = mutt_buffer_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(strcmp(mutt_b2s(&buf), expected) == 0);
+    TEST_CHECK(strcmp(mutt_buffer_string(&buf), expected) == 0);
     TEST_MSG("Expected %s\n", expected);
-    TEST_MSG("Got      %s\n", mutt_b2s(&buf));
+    TEST_MSG("Got      %s\n", mutt_buffer_string(&buf));
 
     mutt_buffer_dealloc(&buf);
     mutt_window_free(&root);
@@ -140,9 +140,9 @@ void test_window_reflow(void)
 
     struct Buffer buf = mutt_buffer_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(strcmp(mutt_b2s(&buf), expected) == 0);
+    TEST_CHECK(strcmp(mutt_buffer_string(&buf), expected) == 0);
     TEST_MSG("Expected %s\n", expected);
-    TEST_MSG("Got      %s\n", mutt_b2s(&buf));
+    TEST_MSG("Got      %s\n", mutt_buffer_string(&buf));
 
     mutt_buffer_dealloc(&buf);
     mutt_window_free(&root);
@@ -174,9 +174,9 @@ void test_window_reflow(void)
 
     struct Buffer buf = mutt_buffer_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(strcmp(mutt_b2s(&buf), expected) == 0);
+    TEST_CHECK(strcmp(mutt_buffer_string(&buf), expected) == 0);
     TEST_MSG("Expected %s\n", expected);
-    TEST_MSG("Got      %s\n", mutt_b2s(&buf));
+    TEST_MSG("Got      %s\n", mutt_buffer_string(&buf));
 
     mutt_buffer_dealloc(&buf);
     mutt_window_free(&root);
@@ -214,9 +214,9 @@ void test_window_reflow(void)
 
     struct Buffer buf = mutt_buffer_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(strcmp(mutt_b2s(&buf), expected) == 0);
+    TEST_CHECK(strcmp(mutt_buffer_string(&buf), expected) == 0);
     TEST_MSG("Expected %s\n", expected);
-    TEST_MSG("Got      %s\n", mutt_b2s(&buf));
+    TEST_MSG("Got      %s\n", mutt_buffer_string(&buf));
 
     mutt_buffer_dealloc(&buf);
     mutt_window_free(&root);
@@ -256,9 +256,9 @@ void test_window_reflow(void)
 
     struct Buffer buf = mutt_buffer_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(strcmp(mutt_b2s(&buf), expected) == 0);
+    TEST_CHECK(strcmp(mutt_buffer_string(&buf), expected) == 0);
     TEST_MSG("Expected %s\n", expected);
-    TEST_MSG("Got      %s\n", mutt_b2s(&buf));
+    TEST_MSG("Got      %s\n", mutt_buffer_string(&buf));
 
     mutt_buffer_dealloc(&buf);
     mutt_window_free(&root);
@@ -293,9 +293,9 @@ void test_window_reflow(void)
 
     struct Buffer buf = mutt_buffer_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(strcmp(mutt_b2s(&buf), expected) == 0);
+    TEST_CHECK(strcmp(mutt_buffer_string(&buf), expected) == 0);
     TEST_MSG("Expected %s\n", expected);
-    TEST_MSG("Got      %s\n", mutt_b2s(&buf));
+    TEST_MSG("Got      %s\n", mutt_buffer_string(&buf));
 
     mutt_buffer_dealloc(&buf);
     mutt_window_free(&root);
@@ -328,9 +328,9 @@ void test_window_reflow(void)
 
     struct Buffer buf = mutt_buffer_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(strcmp(mutt_b2s(&buf), expected) == 0);
+    TEST_CHECK(strcmp(mutt_buffer_string(&buf), expected) == 0);
     TEST_MSG("Expected %s\n", expected);
-    TEST_MSG("Got      %s\n", mutt_b2s(&buf));
+    TEST_MSG("Got      %s\n", mutt_buffer_string(&buf));
 
     mutt_buffer_dealloc(&buf);
     mutt_window_free(&root);
@@ -375,9 +375,9 @@ void test_window_reflow(void)
 
     struct Buffer buf = mutt_buffer_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(strcmp(mutt_b2s(&buf), expected) == 0);
+    TEST_CHECK(strcmp(mutt_buffer_string(&buf), expected) == 0);
     TEST_MSG("Expected %s\n", expected);
-    TEST_MSG("Got      %s\n", mutt_b2s(&buf));
+    TEST_MSG("Got      %s\n", mutt_buffer_string(&buf));
 
     mutt_buffer_dealloc(&buf);
     mutt_window_free(&root);
@@ -410,9 +410,9 @@ void test_window_reflow(void)
 
     struct Buffer buf = mutt_buffer_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(strcmp(mutt_b2s(&buf), expected) == 0);
+    TEST_CHECK(strcmp(mutt_buffer_string(&buf), expected) == 0);
     TEST_MSG("Expected %s\n", expected);
-    TEST_MSG("Got      %s\n", mutt_b2s(&buf));
+    TEST_MSG("Got      %s\n", mutt_buffer_string(&buf));
 
     mutt_buffer_dealloc(&buf);
     mutt_window_free(&root);
@@ -442,9 +442,9 @@ void test_window_reflow(void)
 
     struct Buffer buf = mutt_buffer_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(strcmp(mutt_b2s(&buf), expected) == 0);
+    TEST_CHECK(strcmp(mutt_buffer_string(&buf), expected) == 0);
     TEST_MSG("Expected %s\n", expected);
-    TEST_MSG("Got      %s\n", mutt_b2s(&buf));
+    TEST_MSG("Got      %s\n", mutt_buffer_string(&buf));
 
     mutt_buffer_dealloc(&buf);
     mutt_window_free(&root);
@@ -483,9 +483,9 @@ void test_window_reflow(void)
 
     struct Buffer buf = mutt_buffer_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(strcmp(mutt_b2s(&buf), expected) == 0);
+    TEST_CHECK(strcmp(mutt_buffer_string(&buf), expected) == 0);
     TEST_MSG("Expected %s\n", expected);
-    TEST_MSG("Got      %s\n", mutt_b2s(&buf));
+    TEST_MSG("Got      %s\n", mutt_buffer_string(&buf));
 
     mutt_buffer_dealloc(&buf);
     mutt_window_free(&root);
@@ -521,9 +521,9 @@ void test_window_reflow(void)
 
     struct Buffer buf = mutt_buffer_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(strcmp(mutt_b2s(&buf), expected) == 0);
+    TEST_CHECK(strcmp(mutt_buffer_string(&buf), expected) == 0);
     TEST_MSG("Expected %s\n", expected);
-    TEST_MSG("Got      %s\n", mutt_b2s(&buf));
+    TEST_MSG("Got      %s\n", mutt_buffer_string(&buf));
 
     mutt_buffer_dealloc(&buf);
     mutt_window_free(&root);
@@ -559,9 +559,9 @@ void test_window_reflow(void)
 
     struct Buffer buf = mutt_buffer_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(strcmp(mutt_b2s(&buf), expected) == 0);
+    TEST_CHECK(strcmp(mutt_buffer_string(&buf), expected) == 0);
     TEST_MSG("Expected %s\n", expected);
-    TEST_MSG("Got      %s\n", mutt_b2s(&buf));
+    TEST_MSG("Got      %s\n", mutt_buffer_string(&buf));
 
     mutt_buffer_dealloc(&buf);
     mutt_window_free(&root);
@@ -600,9 +600,9 @@ void test_window_reflow(void)
 
     struct Buffer buf = mutt_buffer_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(strcmp(mutt_b2s(&buf), expected) == 0);
+    TEST_CHECK(strcmp(mutt_buffer_string(&buf), expected) == 0);
     TEST_MSG("Expected %s\n", expected);
-    TEST_MSG("Got      %s\n", mutt_b2s(&buf));
+    TEST_MSG("Got      %s\n", mutt_buffer_string(&buf));
 
     mutt_buffer_dealloc(&buf);
     mutt_window_free(&root);
@@ -641,9 +641,9 @@ void test_window_reflow(void)
 
     struct Buffer buf = mutt_buffer_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(strcmp(mutt_b2s(&buf), expected) == 0);
+    TEST_CHECK(strcmp(mutt_buffer_string(&buf), expected) == 0);
     TEST_MSG("Expected %s\n", expected);
-    TEST_MSG("Got      %s\n", mutt_b2s(&buf));
+    TEST_MSG("Got      %s\n", mutt_buffer_string(&buf));
 
     mutt_buffer_dealloc(&buf);
     mutt_window_free(&root);
@@ -682,9 +682,9 @@ void test_window_reflow(void)
 
     struct Buffer buf = mutt_buffer_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(strcmp(mutt_b2s(&buf), expected) == 0);
+    TEST_CHECK(strcmp(mutt_buffer_string(&buf), expected) == 0);
     TEST_MSG("Expected %s\n", expected);
-    TEST_MSG("Got      %s\n", mutt_b2s(&buf));
+    TEST_MSG("Got      %s\n", mutt_buffer_string(&buf));
 
     mutt_buffer_dealloc(&buf);
     mutt_window_free(&root);
@@ -723,9 +723,9 @@ void test_window_reflow(void)
 
     struct Buffer buf = mutt_buffer_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(strcmp(mutt_b2s(&buf), expected) == 0);
+    TEST_CHECK(strcmp(mutt_buffer_string(&buf), expected) == 0);
     TEST_MSG("Expected %s\n", expected);
-    TEST_MSG("Got      %s\n", mutt_b2s(&buf));
+    TEST_MSG("Got      %s\n", mutt_buffer_string(&buf));
 
     mutt_buffer_dealloc(&buf);
     mutt_window_free(&root);
@@ -756,9 +756,9 @@ void test_window_reflow(void)
 
     struct Buffer buf = mutt_buffer_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(strcmp(mutt_b2s(&buf), expected) == 0);
+    TEST_CHECK(strcmp(mutt_buffer_string(&buf), expected) == 0);
     TEST_MSG("Expected %s\n", expected);
-    TEST_MSG("Got      %s\n", mutt_b2s(&buf));
+    TEST_MSG("Got      %s\n", mutt_buffer_string(&buf));
 
     mutt_buffer_dealloc(&buf);
     mutt_window_free(&root);
@@ -784,9 +784,9 @@ void test_window_reflow(void)
 
     struct Buffer buf = mutt_buffer_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(strcmp(mutt_b2s(&buf), expected) == 0);
+    TEST_CHECK(strcmp(mutt_buffer_string(&buf), expected) == 0);
     TEST_MSG("Expected %s\n", expected);
-    TEST_MSG("Got      %s\n", mutt_b2s(&buf));
+    TEST_MSG("Got      %s\n", mutt_buffer_string(&buf));
 
     mutt_buffer_dealloc(&buf);
     mutt_window_free(&root);
@@ -818,9 +818,9 @@ void test_window_reflow(void)
 
     struct Buffer buf = mutt_buffer_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(strcmp(mutt_b2s(&buf), expected) == 0);
+    TEST_CHECK(strcmp(mutt_buffer_string(&buf), expected) == 0);
     TEST_MSG("Expected %s\n", expected);
-    TEST_MSG("Got      %s\n", mutt_b2s(&buf));
+    TEST_MSG("Got      %s\n", mutt_buffer_string(&buf));
 
     mutt_buffer_dealloc(&buf);
     mutt_window_free(&root);
@@ -858,9 +858,9 @@ void test_window_reflow(void)
 
     struct Buffer buf = mutt_buffer_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(strcmp(mutt_b2s(&buf), expected) == 0);
+    TEST_CHECK(strcmp(mutt_buffer_string(&buf), expected) == 0);
     TEST_MSG("Expected %s\n", expected);
-    TEST_MSG("Got      %s\n", mutt_b2s(&buf));
+    TEST_MSG("Got      %s\n", mutt_buffer_string(&buf));
 
     mutt_buffer_dealloc(&buf);
     mutt_window_free(&root);
@@ -900,9 +900,9 @@ void test_window_reflow(void)
 
     struct Buffer buf = mutt_buffer_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(strcmp(mutt_b2s(&buf), expected) == 0);
+    TEST_CHECK(strcmp(mutt_buffer_string(&buf), expected) == 0);
     TEST_MSG("Expected %s\n", expected);
-    TEST_MSG("Got      %s\n", mutt_b2s(&buf));
+    TEST_MSG("Got      %s\n", mutt_buffer_string(&buf));
 
     mutt_buffer_dealloc(&buf);
     mutt_window_free(&root);
@@ -937,9 +937,9 @@ void test_window_reflow(void)
 
     struct Buffer buf = mutt_buffer_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(strcmp(mutt_b2s(&buf), expected) == 0);
+    TEST_CHECK(strcmp(mutt_buffer_string(&buf), expected) == 0);
     TEST_MSG("Expected %s\n", expected);
-    TEST_MSG("Got      %s\n", mutt_b2s(&buf));
+    TEST_MSG("Got      %s\n", mutt_buffer_string(&buf));
 
     mutt_buffer_dealloc(&buf);
     mutt_window_free(&root);
@@ -972,9 +972,9 @@ void test_window_reflow(void)
 
     struct Buffer buf = mutt_buffer_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(strcmp(mutt_b2s(&buf), expected) == 0);
+    TEST_CHECK(strcmp(mutt_buffer_string(&buf), expected) == 0);
     TEST_MSG("Expected %s\n", expected);
-    TEST_MSG("Got      %s\n", mutt_b2s(&buf));
+    TEST_MSG("Got      %s\n", mutt_buffer_string(&buf));
 
     mutt_buffer_dealloc(&buf);
     mutt_window_free(&root);
@@ -1019,9 +1019,9 @@ void test_window_reflow(void)
 
     struct Buffer buf = mutt_buffer_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(strcmp(mutt_b2s(&buf), expected) == 0);
+    TEST_CHECK(strcmp(mutt_buffer_string(&buf), expected) == 0);
     TEST_MSG("Expected %s\n", expected);
-    TEST_MSG("Got      %s\n", mutt_b2s(&buf));
+    TEST_MSG("Got      %s\n", mutt_buffer_string(&buf));
 
     mutt_buffer_dealloc(&buf);
     mutt_window_free(&root);
@@ -1054,9 +1054,9 @@ void test_window_reflow(void)
 
     struct Buffer buf = mutt_buffer_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(strcmp(mutt_b2s(&buf), expected) == 0);
+    TEST_CHECK(strcmp(mutt_buffer_string(&buf), expected) == 0);
     TEST_MSG("Expected %s\n", expected);
-    TEST_MSG("Got      %s\n", mutt_b2s(&buf));
+    TEST_MSG("Got      %s\n", mutt_buffer_string(&buf));
 
     mutt_buffer_dealloc(&buf);
     mutt_window_free(&root);
@@ -1086,9 +1086,9 @@ void test_window_reflow(void)
 
     struct Buffer buf = mutt_buffer_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(strcmp(mutt_b2s(&buf), expected) == 0);
+    TEST_CHECK(strcmp(mutt_buffer_string(&buf), expected) == 0);
     TEST_MSG("Expected %s\n", expected);
-    TEST_MSG("Got      %s\n", mutt_b2s(&buf));
+    TEST_MSG("Got      %s\n", mutt_buffer_string(&buf));
 
     mutt_buffer_dealloc(&buf);
     mutt_window_free(&root);
@@ -1127,9 +1127,9 @@ void test_window_reflow(void)
 
     struct Buffer buf = mutt_buffer_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(strcmp(mutt_b2s(&buf), expected) == 0);
+    TEST_CHECK(strcmp(mutt_buffer_string(&buf), expected) == 0);
     TEST_MSG("Expected %s\n", expected);
-    TEST_MSG("Got      %s\n", mutt_b2s(&buf));
+    TEST_MSG("Got      %s\n", mutt_buffer_string(&buf));
 
     mutt_buffer_dealloc(&buf);
     mutt_window_free(&root);
@@ -1165,9 +1165,9 @@ void test_window_reflow(void)
 
     struct Buffer buf = mutt_buffer_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(strcmp(mutt_b2s(&buf), expected) == 0);
+    TEST_CHECK(strcmp(mutt_buffer_string(&buf), expected) == 0);
     TEST_MSG("Expected %s\n", expected);
-    TEST_MSG("Got      %s\n", mutt_b2s(&buf));
+    TEST_MSG("Got      %s\n", mutt_buffer_string(&buf));
 
     mutt_buffer_dealloc(&buf);
     mutt_window_free(&root);
@@ -1203,9 +1203,9 @@ void test_window_reflow(void)
 
     struct Buffer buf = mutt_buffer_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(strcmp(mutt_b2s(&buf), expected) == 0);
+    TEST_CHECK(strcmp(mutt_buffer_string(&buf), expected) == 0);
     TEST_MSG("Expected %s\n", expected);
-    TEST_MSG("Got      %s\n", mutt_b2s(&buf));
+    TEST_MSG("Got      %s\n", mutt_buffer_string(&buf));
 
     mutt_buffer_dealloc(&buf);
     mutt_window_free(&root);
@@ -1244,9 +1244,9 @@ void test_window_reflow(void)
 
     struct Buffer buf = mutt_buffer_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(strcmp(mutt_b2s(&buf), expected) == 0);
+    TEST_CHECK(strcmp(mutt_buffer_string(&buf), expected) == 0);
     TEST_MSG("Expected %s\n", expected);
-    TEST_MSG("Got      %s\n", mutt_b2s(&buf));
+    TEST_MSG("Got      %s\n", mutt_buffer_string(&buf));
 
     mutt_buffer_dealloc(&buf);
     mutt_window_free(&root);
@@ -1285,9 +1285,9 @@ void test_window_reflow(void)
 
     struct Buffer buf = mutt_buffer_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(strcmp(mutt_b2s(&buf), expected) == 0);
+    TEST_CHECK(strcmp(mutt_buffer_string(&buf), expected) == 0);
     TEST_MSG("Expected %s\n", expected);
-    TEST_MSG("Got      %s\n", mutt_b2s(&buf));
+    TEST_MSG("Got      %s\n", mutt_buffer_string(&buf));
 
     mutt_buffer_dealloc(&buf);
     mutt_window_free(&root);
@@ -1326,9 +1326,9 @@ void test_window_reflow(void)
 
     struct Buffer buf = mutt_buffer_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(strcmp(mutt_b2s(&buf), expected) == 0);
+    TEST_CHECK(strcmp(mutt_buffer_string(&buf), expected) == 0);
     TEST_MSG("Expected %s\n", expected);
-    TEST_MSG("Got      %s\n", mutt_b2s(&buf));
+    TEST_MSG("Got      %s\n", mutt_buffer_string(&buf));
 
     mutt_buffer_dealloc(&buf);
     mutt_window_free(&root);
@@ -1367,9 +1367,9 @@ void test_window_reflow(void)
 
     struct Buffer buf = mutt_buffer_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(strcmp(mutt_b2s(&buf), expected) == 0);
+    TEST_CHECK(strcmp(mutt_buffer_string(&buf), expected) == 0);
     TEST_MSG("Expected %s\n", expected);
-    TEST_MSG("Got      %s\n", mutt_b2s(&buf));
+    TEST_MSG("Got      %s\n", mutt_buffer_string(&buf));
 
     mutt_buffer_dealloc(&buf);
     mutt_window_free(&root);
@@ -1452,9 +1452,9 @@ void test_window_reflow(void)
 
     struct Buffer buf = mutt_buffer_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(strcmp(mutt_b2s(&buf), expected) == 0);
+    TEST_CHECK(strcmp(mutt_buffer_string(&buf), expected) == 0);
     TEST_MSG("Expected %s\n", expected);
-    TEST_MSG("Got      %s\n", mutt_b2s(&buf));
+    TEST_MSG("Got      %s\n", mutt_buffer_string(&buf));
 
     mutt_buffer_dealloc(&buf);
     mutt_window_free(&root);


### PR DESCRIPTION
Macro

```c
#define mutt_b2s(buf) ((buf)->data ? (const char *) (buf)->data : "")
```

- poorly named, does not follow mutt_buffer_action naming pattern
- can be confused with a function call [1]
- is not type-safe
- allows mutating underlying buffers data

A new function is introduced instead - `mutt_buffer_string()`
- follows naming pattern
- function name clearly communicates the contract
- can still be inlined by the compiler
- does not allow mutating the data

And macroses are evil in general. So get rid of them.

[1] https://drewdevault.com/2021/01/19/Spooky-code-at-a-distance.html

