### PR TITLE
Add <view-pager> function to attachment menu

### DIFF
--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -10251,6 +10251,87 @@ macro index ,a "&lt;save-message&gt;=archive&lt;enter&gt;&lt;enter-command&gt;ec
           See table <xref linkend="tab-attachment-bindings" /> for all
           available functions.
         </para>
+
+        <sect3 id="attach-viewers">
+          <title>Viewing Attachments</title>
+          
+          <para>
+          There are four(!) ways of viewing attachments, so the functions
+          deserve some extra explanation.
+          </para>
+          
+          <variablelist>
+            <varlistentry>
+              <term>
+                <literal>&lt;view-mailcap&gt;</literal>
+                (default keybinding: m)
+              </term>
+              <listitem>
+                <para>
+                  This will use the first matching mailcap entry.
+                </para>
+                <para>
+                  If no matching mailcap entries are found, it will abort with an
+                  error message.
+                </para>
+              </listitem>
+            </varlistentry>
+          
+            <varlistentry>
+              <term>
+                <literal>&lt;view-attach&gt;</literal>
+                (default keybinding: &lt;Enter&gt;)
+              </term>
+              <listitem>
+                <para>
+                  Mutt will display internally supported MIME types (see <xref
+                  linkend="mime-pager"/>) in the pager.  This will respect
+                  <link linkend="auto-view">auto_view</link> settings, to determine
+                  whether to use a <literal>copiousoutput</literal> mailcap entry or
+                  just directly display the attachment.
+                </para>
+                <para>
+                  Other MIME types will use the first matching mailcap entry.
+                </para>
+                <para>
+                  If no matching mailcap entries are found, the attachment will
+                  be displayed in the pager as raw text.
+                </para>
+              </listitem>
+            </varlistentry>
+          
+            <varlistentry>
+              <term>
+                <literal>&lt;view-pager&gt;</literal>
+              </term>
+              <listitem>
+                <para>
+                  Mutt will use the first matching
+                  <literal>copiousoutput</literal> mailcap entry to display the
+                  attachment in the pager (regardless of <link
+                  linkend="auto-view">auto_view</link> settings).
+                </para>
+                <para>
+                  If no matching mailcap entries are found, the attachment will
+                  be displayed in the pager as raw text.
+                </para>
+              </listitem>
+            </varlistentry>
+          
+            <varlistentry>
+              <term>
+                <literal>&lt;view-text&gt;</literal>
+                (default keybinding: T)
+              </term>
+              <listitem>
+                <para>
+                  The attachment will always be displayed in the pager as raw
+                  text.
+                </para>
+              </listitem>
+            </varlistentry>
+          </variablelist>
+        </sect3>
       </sect2>
 
       <sect2 id="compose-menu">

--- a/functions.c
+++ b/functions.c
@@ -444,6 +444,7 @@ const struct Binding OpAttach[] = { /* map: attachment */
   { "view-attach",           OP_VIEW_ATTACH,                 "\n" },            // <Enter>
   { "view-attach",           OP_VIEW_ATTACH,                 "\r" },            // <Return>
   { "view-mailcap",          OP_ATTACH_VIEW_MAILCAP,         "m" },
+  { "view-pager",            OP_ATTACH_VIEW_PAGER,           NULL },
   { "view-text",             OP_ATTACH_VIEW_TEXT,            "T" },
   { NULL,                    0,                              NULL },
 };

--- a/mutt_attach.c
+++ b/mutt_attach.c
@@ -434,8 +434,9 @@ int mutt_view_attachment(FILE *fp, struct Body *a, enum ViewAttachMode mode,
   struct Buffer *pagerfile = mutt_buffer_pool_get();
   struct Buffer *cmd = mutt_buffer_pool_get();
 
-  use_mailcap =
-      (mode == MUTT_VA_MAILCAP || (mode == MUTT_VA_REGULAR && mutt_needs_mailcap(a)));
+  use_mailcap = ((mode == MUTT_VA_MAILCAP) ||
+                 ((mode == MUTT_VA_REGULAR) && mutt_needs_mailcap(a)) ||
+                 (mode == MUTT_VA_PAGER));
   snprintf(type, sizeof(type), "%s/%s", TYPE(a), a->subtype);
 
   char columns[16];
@@ -445,9 +446,10 @@ int mutt_view_attachment(FILE *fp, struct Body *a, enum ViewAttachMode mode,
   if (use_mailcap)
   {
     entry = mailcap_entry_new();
-    if (!mailcap_lookup(a, type, sizeof(type), entry, MUTT_MC_NO_FLAGS))
+    enum MailcapLookup mailcap_opt = (mode == MUTT_VA_PAGER) ? MUTT_MC_AUTOVIEW : MUTT_MC_NO_FLAGS;
+    if (!mailcap_lookup(a, type, sizeof(type), entry, mailcap_opt))
     {
-      if (mode == MUTT_VA_REGULAR)
+      if ((mode == MUTT_VA_REGULAR) || (mode == MUTT_VA_PAGER))
       {
         /* fallback to view as text */
         mailcap_entry_free(&entry);

--- a/mutt_attach.h
+++ b/mutt_attach.h
@@ -42,6 +42,7 @@ enum ViewAttachMode
   MUTT_VA_REGULAR = 1, ///< View using default method
   MUTT_VA_MAILCAP,     ///< Force viewing using mailcap entry
   MUTT_VA_AS_TEXT,     ///< Force viewing as text
+  MUTT_VA_PAGER,       ///< View attachment in pager using copiousoutput mailcap
 };
 
 /**

--- a/opcodes.h
+++ b/opcodes.h
@@ -42,6 +42,7 @@
 #define OPS_CORE(_fmt) \
   _fmt(OP_ATTACH_COLLAPSE,                N_("toggle display of subparts")) \
   _fmt(OP_ATTACH_VIEW_MAILCAP,            N_("force viewing of attachment using mailcap")) \
+  _fmt(OP_ATTACH_VIEW_PAGER,              N_("view attachment in pager using copiousoutput mailcap")) \
   _fmt(OP_ATTACH_VIEW_TEXT,               N_("view attachment as text")) \
   _fmt(OP_BOTTOM_PAGE,                    N_("move to the bottom of the page")) \
   _fmt(OP_BOUNCE_MESSAGE,                 N_("remail a message to another user")) \

--- a/recvattach.c
+++ b/recvattach.c
@@ -1593,6 +1593,12 @@ void dlg_select_attachment(struct Email *e)
         menu->redraw = REDRAW_FULL;
         break;
 
+      case OP_ATTACH_VIEW_PAGER:
+        mutt_view_attachment(CUR_ATTACH->fp, CUR_ATTACH->body, MUTT_VA_PAGER, e,
+                             actx, menu->win_index);
+        menu->redraw = REDRAW_FULL;
+        break;
+
       case OP_DISPLAY_HEADERS:
       case OP_VIEW_ATTACH:
         op = mutt_attach_display_loop(menu, op, e, actx, true);


### PR DESCRIPTION
This uses a copiousoutput mailcap entry, or falls back to raw text.

The existing functions do not provide a way to use copiousoutput
mailcap entries exclusively.  The default <view-attach> will use one
for internally supported types if auto_view is configured, but there
is no way to do so for other mime types (such as application/pdf).


Upstream-commit: https://gitlab.com/muttmua/mutt/commit/474d368e859aa86b4adf9e41f1048488ece99c42
https://gist.github.com/flatcap/9d701d2ec21057dd77c6f685c56647c6#file-0004-add-view-pager-function-to-attachment-menu-patch
