### PR TITLE
Add <skip-headers> to skip past message headers in pager

### DIFF
--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -2525,18 +2525,12 @@ color sidebar_divider   color8  default     <emphasis role="comment"># Dark grey
           </varlistentry>
           <varlistentry>
             <term>
-              <literal>&lt;toggle-quoted&gt;</literal> (default: T)
-              <anchor id="toggle-quoted" />
+              <literal>&lt;skip-headers&gt;</literal> (default: H) 
+              <anchor id="skip-headers"/>
             </term>
             <listitem>
               <para>
-                The pager uses the
-                <link linkend="quote-regex">$quote_regex</link> variable to
-                detect quoted text when displaying the body of the message.
-                This function toggles the display of the quoted material in the
-                message. It is particularly useful when being interested in
-                just the response and there is a large amount of quoted text in
-                the way.
+                This function will skip past the headers of the current message.
               </para>
               <para>
                 The variable
@@ -2575,6 +2569,21 @@ color sidebar_divider   color8  default     <emphasis role="comment"># Dark grey
               <para>
                 This function will go to the next line of non-quoted text which
                 comes after a line of quoted text in the internal pager.
+              </para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>
+              <literal>&lt;toggle-quoted&gt;</literal><anchor id="toggle-quoted"/>
+              (default: T)
+            </term>
+            <listitem>
+              <para>
+                The pager uses the <link linkend="quote-regex">$quote_regex</link>
+                variable to detect quoted text when displaying the body of the message.
+                This function toggles the display of the quoted material in the message.
+                It is particularly useful when being interested in just the response and
+                there is a large amount of quoted text in the way.
               </para>
             </listitem>
           </varlistentry>

--- a/functions.c
+++ b/functions.c
@@ -389,6 +389,7 @@ const struct Binding OpPager[] = { /* map: pager */
   { "sidebar-toggle-virtual",    OP_SIDEBAR_TOGGLE_VIRTUAL,       NULL },
   { "sidebar-toggle-visible",    OP_SIDEBAR_TOGGLE_VISIBLE,       NULL },
 #endif
+  { "skip-headers",              OP_PAGER_SKIP_HEADERS,           "H" },
   { "skip-quoted",               OP_PAGER_SKIP_QUOTED,            "S" },
   { "sort-mailbox",              OP_SORT,                         "o" },
   { "sort-reverse",              OP_SORT_REVERSE,                 "O" },

--- a/opcodes.h
+++ b/opcodes.h
@@ -213,6 +213,7 @@
   _fmt(OP_PAGER_BOTTOM,                   N_("jump to the bottom of the message")) \
   _fmt(OP_PAGER_HIDE_QUOTED,              N_("toggle display of quoted text")) \
   _fmt(OP_PAGER_SKIP_QUOTED,              N_("skip beyond quoted text")) \
+  _fmt(OP_PAGER_SKIP_HEADERS,             N_("skip beyond headers")) \
   _fmt(OP_PAGER_TOP,                      N_("jump to the top of the message")) \
   _fmt(OP_PIPE,                           N_("pipe message/attachment to a shell command")) \
   _fmt(OP_POST,                           N_("post message to newsgroup")) \


### PR DESCRIPTION
This is based on `<skip-quoted>`, and is bound to 'H' by default.

I've added an error message in case there is no text past the headers,
just to cover the logical case.  I don't think Mutt allows that to
happen for text passed to the pager, but just in case.

Upstream-commit: https://gitlab.com/muttmua/mutt/commit/42331065e432c03903eac2fc8cc2aa94f7da501e