### PR TITLE
config: get values after hooks

### DIFF
--- a/send/send.c
+++ b/send/send.c
@@ -2205,7 +2205,6 @@ int mutt_send_message(SendFlags flags, struct Email *e_templ, const char *tempfi
   }
 
   const bool c_resume_draft_files = cs_subset_bool(sub, "resume_draft_files");
-  const char *c_editor = cs_subset_string(sub, "editor");
   if (!(flags & (SEND_POSTPONED | SEND_RESEND)) &&
       !((flags & SEND_DRAFT_FILE) && c_resume_draft_files))
   {
@@ -2300,6 +2299,7 @@ int mutt_send_message(SendFlags flags, struct Email *e_templ, const char *tempfi
     }
 
     const bool c_sig_on_top = cs_subset_bool(sub, "sig_on_top");
+    const char *c_editor = cs_subset_string(sub, "editor");
     if (c_sig_on_top && !(flags & (SEND_KEY | SEND_BATCH)) && c_editor)
     {
       append_signature(fp_tmp, sub);
@@ -2378,6 +2378,7 @@ int mutt_send_message(SendFlags flags, struct Email *e_templ, const char *tempfi
          (query_quadoption(c_forward_edit, _("Edit forwarded message?")) == MUTT_YES)))
     {
       /* If the this isn't a text message, look for a mailcap edit command */
+      const char *c_editor = cs_subset_string(sub, "editor");
       if (mutt_needs_mailcap(e_templ->body))
       {
         if (!mutt_edit_attachment(e_templ->body))


### PR DESCRIPTION
Recently, I converted `libsend` to use the config system, rather than the `C_*` global varaibles.
Unfortunately, calling hook functions can invalidate config variables that we've already fetched.

I've traced all the callers of `mutt_parse_rc_line()` and `*_hook()` and found that there's only a bug in one place.

1. `mutt_send_message()` stored the value for '$editor'
2. A hook fired which set the value for '$editor'
3. The config system freed the original string, leaving a dangling pointer