### PR TITLE
Added Locale headers for OSX platforms

### DIFF
--- a/mx.c
+++ b/mx.c
@@ -80,8 +80,7 @@
 #include <libintl.h>
 #endif
 #ifdef __APPLE__
-# include <string.h>
-# include <xlocale.h>
+#include <xlocale.h>
 #endif
 
 /* These Config Variables are only used in mx.c */

--- a/mx.c
+++ b/mx.c
@@ -79,6 +79,10 @@
 #ifdef ENABLE_NLS
 #include <libintl.h>
 #endif
+#ifdef __APPLE__
+# include <string.h>
+# include <xlocale.h>
+#endif
 
 /* These Config Variables are only used in mx.c */
 bool C_KeepFlagged; ///< Config: Don't move flagged messages from `$spoolfile` to `$mbox`


### PR DESCRIPTION
Compiling on macos will give
```mx.c:1113:7: error: use of undeclared identifier 'locale_t'```
Error
To counteract that Added header for OSX.

* **What does this PR do?**

Added OSX Platform-specific headers


