### PR TITLE
Eliminate the macros from all the enter_field() functions

### DIFF
--- a/alias/alias.c
+++ b/alias/alias.c
@@ -388,7 +388,8 @@ void alias_create(struct AddressList *al, const struct ConfigSubset *sub)
 
 retry_name:
   /* L10N: prompt to add a new alias */
-  if ((mutt_get_field(_("Alias as: "), buf, sizeof(buf), MUTT_COMP_NO_FLAGS) != 0) ||
+  if ((mutt_get_field(_("Alias as: "), buf, sizeof(buf), MUTT_COMP_NO_FLAGS,
+                      false, NULL, NULL) != 0) ||
       (buf[0] == '\0'))
   {
     return;
@@ -428,7 +429,8 @@ retry_name:
 
   do
   {
-    if ((mutt_get_field(_("Address: "), buf, sizeof(buf), MUTT_COMP_NO_FLAGS) != 0) ||
+    if ((mutt_get_field(_("Address: "), buf, sizeof(buf), MUTT_COMP_NO_FLAGS,
+                        false, NULL, NULL) != 0) ||
         (buf[0] == '\0'))
     {
       alias_free(&alias);
@@ -451,7 +453,8 @@ retry_name:
   else
     buf[0] = '\0';
 
-  if (mutt_get_field(_("Personal name: "), buf, sizeof(buf), MUTT_COMP_NO_FLAGS) != 0)
+  if (mutt_get_field(_("Personal name: "), buf, sizeof(buf), MUTT_COMP_NO_FLAGS,
+                     false, NULL, NULL) != 0)
   {
     alias_free(&alias);
     return;
@@ -459,8 +462,11 @@ retry_name:
   mutt_str_replace(&TAILQ_FIRST(&alias->addr)->personal, buf);
 
   buf[0] = '\0';
-  if (mutt_get_field(_("Comment: "), buf, sizeof(buf), MUTT_COMP_NO_FLAGS) == 0)
+  if (mutt_get_field(_("Comment: "), buf, sizeof(buf), MUTT_COMP_NO_FLAGS,
+                     false, NULL, NULL) == 0)
+  {
     mutt_str_replace(&alias->comment, buf);
+  }
 
   buf[0] = '\0';
   mutt_addrlist_write(&alias->addr, buf, sizeof(buf), true);
@@ -485,8 +491,11 @@ retry_name:
   const char *alias_file = cs_subset_path(sub, "alias_file");
   mutt_str_copy(buf, NONULL(alias_file), sizeof(buf));
 
-  if (mutt_get_field(_("Save to file: "), buf, sizeof(buf), MUTT_FILE | MUTT_CLEAR) != 0)
+  if (mutt_get_field(_("Save to file: "), buf, sizeof(buf),
+                     MUTT_FILE | MUTT_CLEAR, false, NULL, NULL) != 0)
+  {
     return;
+  }
   mutt_expand_path(buf, sizeof(buf));
   FILE *fp_alias = fopen(buf, "a+");
   if (!fp_alias)

--- a/alias/dlgquery.c
+++ b/alias/dlgquery.c
@@ -352,7 +352,8 @@ static void dlg_select_query(char *buf, size_t buflen, struct AliasList *all,
       case OP_QUERY_APPEND:
       case OP_QUERY:
       {
-        if ((mutt_get_field(_("Query: "), buf, buflen, MUTT_COMP_NO_FLAGS) != 0) ||
+        if ((mutt_get_field(_("Query: "), buf, buflen, MUTT_COMP_NO_FLAGS,
+                            false, NULL, NULL) != 0) ||
             (buf[0] == '\0'))
         {
           break;
@@ -652,7 +653,8 @@ void query_index(struct ConfigSubset *sub)
   }
 
   char buf[256] = { 0 };
-  if ((mutt_get_field(_("Query: "), buf, sizeof(buf), MUTT_COMP_NO_FLAGS) != 0) ||
+  if ((mutt_get_field(_("Query: "), buf, sizeof(buf), MUTT_COMP_NO_FLAGS, false,
+                      NULL, NULL) != 0) ||
       (buf[0] == '\0'))
   {
     return;

--- a/autocrypt/autocrypt.c
+++ b/autocrypt/autocrypt.c
@@ -916,7 +916,8 @@ void mutt_autocrypt_scan_mailboxes(void)
   while (scan == MUTT_YES)
   {
     // L10N: The prompt for a mailbox to scan for Autocrypt: headers
-    if ((!mutt_buffer_enter_fname(_("Scan mailbox"), folderbuf, true)) &&
+    if ((!mutt_buffer_enter_fname(_("Scan mailbox"), folderbuf, true, false,
+                                  NULL, NULL, MUTT_SEL_NO_FLAGS)) &&
         (!mutt_buffer_is_empty(folderbuf)))
     {
       mutt_buffer_expand_path_regex(folderbuf, false);

--- a/browser.c
+++ b/browser.c
@@ -1765,8 +1765,11 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
       case OP_ENTER_MASK:
       {
         mutt_buffer_strcpy(buf, C_Mask ? C_Mask->pattern : NULL);
-        if (mutt_get_field(_("File Mask: "), buf->data, buf->dsize, MUTT_COMP_NO_FLAGS) != 0)
+        if (mutt_get_field(_("File Mask: "), buf->data, buf->dsize,
+                           MUTT_COMP_NO_FLAGS, false, NULL, NULL) != 0)
+        {
           break;
+        }
 
         mutt_buffer_fix_dptr(buf);
 

--- a/browser.c
+++ b/browser.c
@@ -1689,7 +1689,7 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
         if (op == OP_CHANGE_DIRECTORY)
         {
           /* buf comes from the buffer pool, so defaults to size 1024 */
-          int ret = mutt_buffer_get_field(_("Chdir to: "), buf, MUTT_FILE);
+          int ret = mutt_buffer_get_field(_("Chdir to: "), buf, MUTT_FILE, false, NULL, NULL);
           if ((ret != 0) && mutt_buffer_is_empty(buf))
             break;
         }
@@ -1955,7 +1955,7 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
       case OP_BROWSER_NEW_FILE:
         mutt_buffer_printf(buf, "%s/", mutt_buffer_string(&LastDir));
         /* buf comes from the buffer pool, so defaults to size 1024 */
-        if (mutt_buffer_get_field(_("New file name: "), buf, MUTT_FILE) == 0)
+        if (mutt_buffer_get_field(_("New file name: "), buf, MUTT_FILE, false, NULL, NULL) == 0)
         {
           mutt_buffer_copy(file, buf);
           destroy_state(&state);
@@ -2091,7 +2091,7 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
             else
               snprintf(tmp2, sizeof(tmp2), _("Unsubscribe pattern: "));
             /* buf comes from the buffer pool, so defaults to size 1024 */
-            if ((mutt_buffer_get_field(tmp2, buf, MUTT_PATTERN) != 0) ||
+            if ((mutt_buffer_get_field(tmp2, buf, MUTT_PATTERN, false, NULL, NULL) != 0) ||
                 mutt_buffer_is_empty(buf))
             {
               break;

--- a/commands.c
+++ b/commands.c
@@ -1109,7 +1109,7 @@ int mutt_save_message(struct Mailbox *m, struct EmailList *el,
   mutt_buffer_fix_dptr(buf);
   mutt_buffer_pretty_mailbox(buf);
 
-  if (mutt_buffer_enter_fname(prompt, buf, false) == -1)
+  if (mutt_buffer_enter_fname(prompt, buf, false, false, NULL, NULL, MUTT_SEL_NO_FLAGS) == -1)
     goto cleanup;
 
   size_t pathlen = mutt_buffer_len(buf);

--- a/commands.c
+++ b/commands.c
@@ -710,7 +710,7 @@ void mutt_pipe_message(struct Mailbox *m, struct EmailList *el)
 
   struct Buffer *buf = mutt_buffer_pool_get();
 
-  if (mutt_buffer_get_field(_("Pipe to command: "), buf, MUTT_CMD) != 0)
+  if (mutt_buffer_get_field(_("Pipe to command: "), buf, MUTT_CMD, false, NULL, NULL) != 0)
     goto cleanup;
 
   if (mutt_buffer_len(buf) == 0)

--- a/commands.c
+++ b/commands.c
@@ -441,7 +441,7 @@ void ci_bounce_message(struct Mailbox *m, struct EmailList *el)
   else
     mutt_str_copy(prompt, _("Bounce tagged messages to: "), sizeof(prompt));
 
-  rc = mutt_get_field(prompt, buf, sizeof(buf), MUTT_ALIAS);
+  rc = mutt_get_field(prompt, buf, sizeof(buf), MUTT_ALIAS, false, NULL, NULL);
   if (rc || (buf[0] == '\0'))
     return;
 
@@ -848,7 +848,7 @@ bool mutt_shell_escape(void)
   char buf[1024];
 
   buf[0] = '\0';
-  if (mutt_get_field(_("Shell command: "), buf, sizeof(buf), MUTT_CMD) != 0)
+  if (mutt_get_field(_("Shell command: "), buf, sizeof(buf), MUTT_CMD, false, NULL, NULL) != 0)
   {
     return false;
   }
@@ -883,8 +883,11 @@ void mutt_enter_command(void)
   window_set_focus(MessageWindow);
   window_redraw(RootWindow, true);
   /* if enter is pressed after : with no command, just return */
-  if ((mutt_get_field(":", buf, sizeof(buf), MUTT_COMMAND) != 0) || (buf[0] == '\0'))
+  if ((mutt_get_field(":", buf, sizeof(buf), MUTT_COMMAND, false, NULL, NULL) != 0) ||
+      (buf[0] == '\0'))
+  {
     return;
+  }
 
   struct Buffer err = mutt_buffer_make(256);
 
@@ -1351,7 +1354,8 @@ bool mutt_edit_content_type(struct Email *e, struct Body *b, FILE *fp)
     }
   }
 
-  if ((mutt_get_field("Content-Type: ", buf, sizeof(buf), MUTT_COMP_NO_FLAGS) != 0) ||
+  if ((mutt_get_field("Content-Type: ", buf, sizeof(buf), MUTT_COMP_NO_FLAGS,
+                      false, NULL, NULL) != 0) ||
       (buf[0] == '\0'))
   {
     return false;

--- a/compose/compose.c
+++ b/compose/compose.c
@@ -1706,7 +1706,8 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur,
 
       case OP_COMPOSE_EDIT_FCC:
         mutt_buffer_copy(&fname, fcc);
-        if (mutt_buffer_get_field(Prompts[HDR_FCC], &fname, MUTT_FILE | MUTT_CLEAR) == 0)
+        if (mutt_buffer_get_field(Prompts[HDR_FCC], &fname,
+                                  MUTT_FILE | MUTT_CLEAR, false, NULL, NULL) == 0)
         {
           if (!mutt_str_equal(fcc->data, fname.data))
           {
@@ -2416,7 +2417,8 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur,
         else
           src = CUR_ATTACH->body->filename;
         mutt_buffer_strcpy(&fname, mutt_path_basename(NONULL(src)));
-        int ret = mutt_buffer_get_field(_("Send attachment with name: "), &fname, MUTT_FILE);
+        int ret = mutt_buffer_get_field(_("Send attachment with name: "),
+                                        &fname, MUTT_FILE, false, NULL, NULL);
         if (ret == 0)
         {
           /* As opposed to RENAME_FILE, we don't check buf[0] because it's
@@ -2431,7 +2433,7 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur,
         CHECK_COUNT;
         mutt_buffer_strcpy(&fname, CUR_ATTACH->body->filename);
         mutt_buffer_pretty_mailbox(&fname);
-        if ((mutt_buffer_get_field(_("Rename to: "), &fname, MUTT_FILE) == 0) &&
+        if ((mutt_buffer_get_field(_("Rename to: "), &fname, MUTT_FILE, false, NULL, NULL) == 0) &&
             !mutt_buffer_is_empty(&fname))
         {
           struct stat st;
@@ -2458,7 +2460,7 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur,
       case OP_COMPOSE_NEW_MIME:
       {
         mutt_buffer_reset(&fname);
-        if ((mutt_buffer_get_field(_("New file: "), &fname, MUTT_FILE) != 0) ||
+        if ((mutt_buffer_get_field(_("New file: "), &fname, MUTT_FILE, false, NULL, NULL) != 0) ||
             mutt_buffer_is_empty(&fname))
         {
           continue;

--- a/compose/compose.c
+++ b/compose/compose.c
@@ -1043,7 +1043,7 @@ static bool edit_address_list(int field, struct AddressList *al)
   mutt_addrlist_to_local(al);
   mutt_addrlist_write(al, buf, sizeof(buf), false);
   mutt_str_copy(old_list, buf, sizeof(buf));
-  if (mutt_get_field(_(Prompts[field]), buf, sizeof(buf), MUTT_ALIAS) == 0)
+  if (mutt_get_field(_(Prompts[field]), buf, sizeof(buf), MUTT_ALIAS, false, NULL, NULL) == 0)
   {
     mutt_addrlist_clear(al);
     mutt_addrlist_parse2(al, buf);
@@ -1646,7 +1646,8 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur,
         if (!news)
           break;
         mutt_str_copy(buf, e->env->newsgroups, sizeof(buf));
-        if (mutt_get_field(Prompts[HDR_NEWSGROUPS], buf, sizeof(buf), MUTT_COMP_NO_FLAGS) == 0)
+        if (mutt_get_field(Prompts[HDR_NEWSGROUPS], buf, sizeof(buf),
+                           MUTT_COMP_NO_FLAGS, false, NULL, NULL) == 0)
         {
           mutt_str_replace(&e->env->newsgroups, buf);
           redraw_env = true;
@@ -1657,7 +1658,8 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur,
         if (!news)
           break;
         mutt_str_copy(buf, e->env->followup_to, sizeof(buf));
-        if (mutt_get_field(Prompts[HDR_FOLLOWUPTO], buf, sizeof(buf), MUTT_COMP_NO_FLAGS) == 0)
+        if (mutt_get_field(Prompts[HDR_FOLLOWUPTO], buf, sizeof(buf),
+                           MUTT_COMP_NO_FLAGS, false, NULL, NULL) == 0)
         {
           mutt_str_replace(&e->env->followup_to, buf);
           redraw_env = true;
@@ -1670,7 +1672,8 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur,
         if (!(news && c_x_comment_to))
           break;
         mutt_str_copy(buf, e->env->x_comment_to, sizeof(buf));
-        if (mutt_get_field(Prompts[HDR_XCOMMENTTO], buf, sizeof(buf), MUTT_COMP_NO_FLAGS) == 0)
+        if (mutt_get_field(Prompts[HDR_XCOMMENTTO], buf, sizeof(buf),
+                           MUTT_COMP_NO_FLAGS, false, NULL, NULL) == 0)
         {
           mutt_str_replace(&e->env->x_comment_to, buf);
           redraw_env = true;
@@ -1681,7 +1684,8 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur,
 
       case OP_COMPOSE_EDIT_SUBJECT:
         mutt_str_copy(buf, e->env->subject, sizeof(buf));
-        if (mutt_get_field(Prompts[HDR_SUBJECT], buf, sizeof(buf), MUTT_COMP_NO_FLAGS) == 0)
+        if (mutt_get_field(Prompts[HDR_SUBJECT], buf, sizeof(buf),
+                           MUTT_COMP_NO_FLAGS, false, NULL, NULL) == 0)
         {
           if (!mutt_str_equal(e->env->subject, buf))
           {
@@ -2236,7 +2240,8 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur,
         CHECK_COUNT;
         mutt_str_copy(buf, CUR_ATTACH->body->description, sizeof(buf));
         /* header names should not be translated */
-        if (mutt_get_field("Description: ", buf, sizeof(buf), MUTT_COMP_NO_FLAGS) == 0)
+        if (mutt_get_field("Description: ", buf, sizeof(buf),
+                           MUTT_COMP_NO_FLAGS, false, NULL, NULL) == 0)
         {
           if (!mutt_str_equal(CUR_ATTACH->body->description, buf))
           {
@@ -2298,7 +2303,8 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur,
       case OP_COMPOSE_EDIT_LANGUAGE:
         CHECK_COUNT;
         mutt_str_copy(buf, CUR_ATTACH->body->language, sizeof(buf));
-        if (mutt_get_field("Content-Language: ", buf, sizeof(buf), MUTT_COMP_NO_FLAGS) == 0)
+        if (mutt_get_field("Content-Language: ", buf, sizeof(buf),
+                           MUTT_COMP_NO_FLAGS, false, NULL, NULL) == 0)
         {
           if (!mutt_str_equal(CUR_ATTACH->body->language, buf))
           {
@@ -2316,7 +2322,7 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur,
         CHECK_COUNT;
         mutt_str_copy(buf, ENCODING(CUR_ATTACH->body->encoding), sizeof(buf));
         if ((mutt_get_field("Content-Transfer-Encoding: ", buf, sizeof(buf),
-                            MUTT_COMP_NO_FLAGS) == 0) &&
+                            MUTT_COMP_NO_FLAGS, false, NULL, NULL) == 0) &&
             (buf[0] != '\0'))
         {
           int enc = mutt_check_encoding(buf);
@@ -2461,7 +2467,8 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur,
 
         /* Call to lookup_mime_type () ?  maybe later */
         char type[256] = { 0 };
-        if ((mutt_get_field("Content-Type: ", type, sizeof(type), MUTT_COMP_NO_FLAGS) != 0) ||
+        if ((mutt_get_field("Content-Type: ", type, sizeof(type),
+                            MUTT_COMP_NO_FLAGS, false, NULL, NULL) != 0) ||
             (type[0] == '\0'))
         {
           continue;

--- a/compose/compose.c
+++ b/compose/compose.c
@@ -2006,8 +2006,8 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur,
         char **files = NULL;
 
         mutt_buffer_reset(&fname);
-        if ((mutt_buffer_enter_fname_full(prompt, &fname, false, true, &files,
-                                          &numfiles, MUTT_SEL_MULTI) == -1) ||
+        if ((mutt_buffer_enter_fname(prompt, &fname, false, true, &files,
+                                     &numfiles, MUTT_SEL_MULTI) == -1) ||
             mutt_buffer_is_empty(&fname))
         {
           for (int i = 0; i < numfiles; i++)
@@ -2087,7 +2087,8 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur,
           }
         }
 
-        if ((mutt_buffer_enter_fname(prompt, &fname, true) == -1) ||
+        if ((mutt_buffer_enter_fname(prompt, &fname, true, false, NULL, NULL,
+                                     MUTT_SEL_NO_FLAGS) == -1) ||
             mutt_buffer_is_empty(&fname))
         {
           break;
@@ -2631,7 +2632,8 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, struct Email *e_cur,
         }
         if (actx->idxlen)
           e->body = actx->idx[0]->body;
-        if ((mutt_buffer_enter_fname(_("Write message to mailbox"), &fname, true) != -1) &&
+        if ((mutt_buffer_enter_fname(_("Write message to mailbox"), &fname, true,
+                                     false, NULL, NULL, MUTT_SEL_NO_FLAGS) != -1) &&
             !mutt_buffer_is_empty(&fname))
         {
           mutt_message(_("Writing message to %s ..."), mutt_buffer_string(&fname));

--- a/conn/connaccount.c
+++ b/conn/connaccount.c
@@ -126,7 +126,7 @@ int mutt_account_getpass(struct ConnAccount *cac)
     snprintf(prompt, sizeof(prompt), _("Password for %s@%s: "),
              (cac->flags & MUTT_ACCT_LOGIN) ? cac->login : cac->user, cac->host);
     cac->pass[0] = '\0';
-    if (mutt_get_password(prompt, cac->pass, sizeof(cac->pass)))
+    if (mutt_get_field_unbuffered(prompt, cac->pass, sizeof(cac->pass), MUTT_PASS))
       return -1;
   }
 

--- a/conn/sasl.c
+++ b/conn/sasl.c
@@ -706,8 +706,11 @@ int mutt_sasl_interact(sasl_interact_t *interaction)
 
     snprintf(prompt, sizeof(prompt), "%s: ", interaction->prompt);
     resp[0] = '\0';
-    if (OptNoCurses || mutt_get_field(prompt, resp, sizeof(resp), MUTT_COMP_NO_FLAGS))
+    if (OptNoCurses || mutt_get_field(prompt, resp, sizeof(resp),
+                                      MUTT_COMP_NO_FLAGS, false, NULL, NULL))
+    {
       return SASL_FAIL;
+    }
 
     interaction->len = mutt_str_len(resp) + 1;
     char *result = mutt_mem_malloc(interaction->len);

--- a/gui/curs_lib.c
+++ b/gui/curs_lib.c
@@ -295,7 +295,7 @@ int mutt_buffer_get_field_full(const char *field, struct Buffer *buf, Completion
 }
 
 /**
- * mutt_get_field_full - Ask the user for a string
+ * mutt_get_field - Ask the user for a string
  * @param[in]  field    Prompt
  * @param[in]  buf      Buffer for the result
  * @param[in]  buflen   Length of buffer
@@ -307,8 +307,8 @@ int mutt_buffer_get_field_full(const char *field, struct Buffer *buf, Completion
  * @retval 0  Selection made
  * @retval -1 Aborted
  */
-int mutt_get_field_full(const char *field, char *buf, size_t buflen, CompletionFlags complete,
-                        bool multiple, char ***files, int *numfiles)
+int mutt_get_field(const char *field, char *buf, size_t buflen,
+                   CompletionFlags complete, bool multiple, char ***files, int *numfiles)
 {
   if (!buf)
     return -1;
@@ -340,7 +340,7 @@ int mutt_get_field_unbuffered(const char *msg, char *buf, size_t buflen, Complet
     OptIgnoreMacroEvents = true;
     reset_ignoremacro = true;
   }
-  int rc = mutt_get_field(msg, buf, buflen, flags);
+  int rc = mutt_get_field(msg, buf, buflen, flags, false, NULL, NULL);
   if (reset_ignoremacro)
     OptIgnoreMacroEvents = false;
 

--- a/gui/curs_lib.c
+++ b/gui/curs_lib.c
@@ -754,7 +754,7 @@ int mutt_do_pager(const char *banner, const char *tempfile, PagerFlags do_color,
 }
 
 /**
- * mutt_buffer_enter_fname_full - Ask the user to select a file
+ * mutt_buffer_enter_fname - Ask the user to select a file
  * @param[in]  prompt   Prompt
  * @param[in]  fname    Buffer for the result
  * @param[in]  mailbox  If true, select mailboxes
@@ -765,9 +765,9 @@ int mutt_do_pager(const char *banner, const char *tempfile, PagerFlags do_color,
  * @retval  0 Success
  * @retval -1 Error
  */
-int mutt_buffer_enter_fname_full(const char *prompt, struct Buffer *fname,
-                                 bool mailbox, bool multiple, char ***files,
-                                 int *numfiles, SelectFileFlags flags)
+int mutt_buffer_enter_fname(const char *prompt, struct Buffer *fname,
+                            bool mailbox, bool multiple, char ***files,
+                            int *numfiles, SelectFileFlags flags)
 {
   struct KeyEvent ch;
 

--- a/gui/curs_lib.c
+++ b/gui/curs_lib.c
@@ -245,7 +245,7 @@ struct KeyEvent mutt_getch(void)
 }
 
 /**
- * mutt_buffer_get_field_full - Ask the user for a string
+ * mutt_buffer_get_field - Ask the user for a string
  * @param[in]  field    Prompt
  * @param[in]  buf      Buffer for the result
  * @param[in]  complete Flags, see #CompletionFlags
@@ -256,8 +256,8 @@ struct KeyEvent mutt_getch(void)
  * @retval 0  Selection made
  * @retval -1 Aborted
  */
-int mutt_buffer_get_field_full(const char *field, struct Buffer *buf, CompletionFlags complete,
-                               bool multiple, char ***files, int *numfiles)
+int mutt_buffer_get_field(const char *field, struct Buffer *buf, CompletionFlags complete,
+                          bool multiple, char ***files, int *numfiles)
 {
   int ret;
   int col;
@@ -318,7 +318,7 @@ int mutt_get_field(const char *field, char *buf, size_t buflen,
     .dptr = buf + mutt_str_len(buf),
     .dsize = buflen,
   };
-  return mutt_buffer_get_field_full(field, &tmp, complete, multiple, files, numfiles);
+  return mutt_buffer_get_field(field, &tmp, complete, multiple, files, numfiles);
 }
 
 /**
@@ -813,8 +813,8 @@ int mutt_buffer_enter_fname_full(const char *prompt, struct Buffer *fname,
       mutt_unget_event(0, ch.op);
 
     mutt_buffer_alloc(fname, 1024);
-    if (mutt_buffer_get_field_full(pc, fname, (mailbox ? MUTT_EFILE : MUTT_FILE) | MUTT_CLEAR,
-                                   multiple, files, numfiles) != 0)
+    if (mutt_buffer_get_field(pc, fname, (mailbox ? MUTT_EFILE : MUTT_FILE) | MUTT_CLEAR,
+                              multiple, files, numfiles) != 0)
     {
       mutt_buffer_reset(fname);
     }

--- a/gui/curs_lib.h
+++ b/gui/curs_lib.h
@@ -63,7 +63,7 @@ void         mutt_format_s_tree(char *buf, size_t buflen, const char *prec, cons
 void         mutt_format_s_x(char *buf, size_t buflen, const char *prec, const char *s, bool arboreal);
 void         mutt_getch_timeout(int delay);
 struct KeyEvent mutt_getch(void);
-int          mutt_get_field_full(const char *field, char *buf, size_t buflen, CompletionFlags complete, bool multiple, char ***files, int *numfiles);
+int          mutt_get_field(const char *field, char *buf, size_t buflen, CompletionFlags complete, bool multiple, char ***files, int *numfiles);
 int          mutt_get_field_unbuffered(const char *msg, char *buf, size_t buflen, CompletionFlags flags);
 int          mutt_multi_choice(const char *prompt, const char *letters);
 void         mutt_need_hard_redraw(void);
@@ -88,7 +88,6 @@ int mutt_buffer_get_field_full(const char *field, struct Buffer *buf, Completion
 #define mutt_buffer_enter_fname(prompt, fname, mailbox) mutt_buffer_enter_fname_full(prompt, fname, mailbox, false, NULL, NULL, MUTT_SEL_NO_FLAGS)
 int mutt_buffer_enter_fname_full(const char *prompt, struct Buffer *fname, bool mailbox, bool multiple, char ***files, int *numfiles, SelectFileFlags flags);
 
-#define mutt_get_field(field, buf, buflen, complete)   mutt_get_field_full(field, buf, buflen, complete, false, NULL, NULL)
 #define mutt_get_password(msg, buf, buflen)            mutt_get_field_unbuffered(msg, buf, buflen, MUTT_PASS)
 
 #endif /* MUTT_CURS_LIB_H */

--- a/gui/curs_lib.h
+++ b/gui/curs_lib.h
@@ -52,6 +52,7 @@ enum FormatJustify
 int          mutt_addwch(wchar_t wc);
 int          mutt_any_key_to_continue(const char *s);
 void         mutt_beep(bool force);
+int          mutt_buffer_enter_fname(const char *prompt, struct Buffer *fname, bool mailbox, bool multiple, char ***files, int *numfiles, SelectFileFlags flags);
 int          mutt_buffer_get_field(const char *field, struct Buffer *buf, CompletionFlags complete, bool multiple, char ***files, int *numfiles);
 int          mutt_do_pager(const char *banner, const char *tempfile, PagerFlags do_color, struct Pager *info);
 void         mutt_edit_file(const char *editor, const char *file);
@@ -82,10 +83,6 @@ void         mutt_unget_string(const char *s);
 size_t       mutt_wstr_trunc(const char *src, size_t maxlen, size_t maxwid, size_t *width);
 enum QuadOption mutt_yesorno(const char *msg, enum QuadOption def);
 enum QuadOption query_quadoption(enum QuadOption opt, const char *prompt);
-
-
-#define mutt_buffer_enter_fname(prompt, fname, mailbox) mutt_buffer_enter_fname_full(prompt, fname, mailbox, false, NULL, NULL, MUTT_SEL_NO_FLAGS)
-int mutt_buffer_enter_fname_full(const char *prompt, struct Buffer *fname, bool mailbox, bool multiple, char ***files, int *numfiles, SelectFileFlags flags);
 
 #define mutt_get_password(msg, buf, buflen)            mutt_get_field_unbuffered(msg, buf, buflen, MUTT_PASS)
 

--- a/gui/curs_lib.h
+++ b/gui/curs_lib.h
@@ -84,6 +84,4 @@ size_t       mutt_wstr_trunc(const char *src, size_t maxlen, size_t maxwid, size
 enum QuadOption mutt_yesorno(const char *msg, enum QuadOption def);
 enum QuadOption query_quadoption(enum QuadOption opt, const char *prompt);
 
-#define mutt_get_password(msg, buf, buflen)            mutt_get_field_unbuffered(msg, buf, buflen, MUTT_PASS)
-
 #endif /* MUTT_CURS_LIB_H */

--- a/gui/curs_lib.h
+++ b/gui/curs_lib.h
@@ -52,6 +52,7 @@ enum FormatJustify
 int          mutt_addwch(wchar_t wc);
 int          mutt_any_key_to_continue(const char *s);
 void         mutt_beep(bool force);
+int          mutt_buffer_get_field(const char *field, struct Buffer *buf, CompletionFlags complete, bool multiple, char ***files, int *numfiles);
 int          mutt_do_pager(const char *banner, const char *tempfile, PagerFlags do_color, struct Pager *info);
 void         mutt_edit_file(const char *editor, const char *file);
 void         mutt_endwin(void);
@@ -82,8 +83,6 @@ size_t       mutt_wstr_trunc(const char *src, size_t maxlen, size_t maxwid, size
 enum QuadOption mutt_yesorno(const char *msg, enum QuadOption def);
 enum QuadOption query_quadoption(enum QuadOption opt, const char *prompt);
 
-#define mutt_buffer_get_field(field, buf, complete) mutt_buffer_get_field_full(field, buf, complete, false, NULL, NULL)
-int mutt_buffer_get_field_full(const char *field, struct Buffer *buf, CompletionFlags complete, bool multiple, char ***files, int *numfiles);
 
 #define mutt_buffer_enter_fname(prompt, fname, mailbox) mutt_buffer_enter_fname_full(prompt, fname, mailbox, false, NULL, NULL, MUTT_SEL_NO_FLAGS)
 int mutt_buffer_enter_fname_full(const char *prompt, struct Buffer *fname, bool mailbox, bool multiple, char ***files, int *numfiles, SelectFileFlags flags);

--- a/imap/browse.c
+++ b/imap/browse.c
@@ -397,8 +397,11 @@ int imap_mailbox_create(const char *path)
     name[n + 1] = '\0';
   }
 
-  if (mutt_get_field(_("Create mailbox: "), name, sizeof(name), MUTT_FILE) < 0)
+  if (mutt_get_field(_("Create mailbox: "), name, sizeof(name), MUTT_FILE,
+                     false, NULL, NULL) < 0)
+  {
     goto err;
+  }
 
   if (mutt_str_len(name) == 0)
   {
@@ -449,7 +452,7 @@ int imap_mailbox_rename(const char *path)
   snprintf(buf, sizeof(buf), _("Rename mailbox %s to: "), mdata->name);
   mutt_str_copy(newname, mdata->name, sizeof(newname));
 
-  if (mutt_get_field(buf, newname, sizeof(newname), MUTT_FILE) < 0)
+  if (mutt_get_field(buf, newname, sizeof(newname), MUTT_FILE, false, NULL, NULL) < 0)
     goto err;
 
   if (mutt_str_len(newname) == 0)

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -2234,7 +2234,7 @@ static int imap_tags_edit(struct Mailbox *m, const char *tags, char *buf, size_t
   if (tags)
     mutt_str_copy(buf, tags, buflen);
 
-  if (mutt_get_field("Tags: ", buf, buflen, MUTT_COMP_NO_FLAGS) != 0)
+  if (mutt_get_field("Tags: ", buf, buflen, MUTT_COMP_NO_FLAGS, false, NULL, NULL) != 0)
     return -1;
 
   /* each keyword must be atom defined by rfc822 as:

--- a/index.c
+++ b/index.c
@@ -2448,7 +2448,8 @@ int mutt_index_menu(struct MuttWindow *dlg)
         /* By default, fill buf with the next mailbox that contains unread mail */
         mutt_mailbox_next(Context ? Context->mailbox : NULL, folderbuf);
 
-        if (mutt_buffer_enter_fname(cp, folderbuf, true) == -1)
+        if (mutt_buffer_enter_fname(cp, folderbuf, true, false, NULL, NULL,
+                                    MUTT_SEL_NO_FLAGS) == -1)
           goto changefoldercleanup;
 
         /* Selected directory is okay, let's save it. */
@@ -2520,7 +2521,8 @@ int mutt_index_menu(struct MuttWindow *dlg)
         nntp_mailbox(Context ? Context->mailbox : NULL, folderbuf->data,
                      folderbuf->dsize);
 
-        if (mutt_buffer_enter_fname(cp, folderbuf, true) == -1)
+        if (mutt_buffer_enter_fname(cp, folderbuf, true, false, NULL, NULL,
+                                    MUTT_SEL_NO_FLAGS) == -1)
           goto changefoldercleanup2;
 
         /* Selected directory is okay, let's save it. */

--- a/index.c
+++ b/index.c
@@ -1507,7 +1507,7 @@ int mutt_index_menu(struct MuttWindow *dlg)
           {
             buf[0] = '\0';
             if ((mutt_get_field(_("Enter Message-Id: "), buf, sizeof(buf),
-                                MUTT_COMP_NO_FLAGS) != 0) ||
+                                MUTT_COMP_NO_FLAGS, false, NULL, NULL) != 0) ||
                 (buf[0] == '\0'))
             {
               break;
@@ -1681,7 +1681,8 @@ int mutt_index_menu(struct MuttWindow *dlg)
         if (isdigit(LastKey))
           mutt_unget_event(LastKey, 0);
         buf[0] = '\0';
-        if ((mutt_get_field(_("Jump to message: "), buf, sizeof(buf), MUTT_COMP_NO_FLAGS) != 0) ||
+        if ((mutt_get_field(_("Jump to message: "), buf, sizeof(buf),
+                            MUTT_COMP_NO_FLAGS, false, NULL, NULL) != 0) ||
             (buf[0] == '\0'))
         {
           mutt_error(_("Nothing to do"));
@@ -2317,7 +2318,7 @@ int mutt_index_menu(struct MuttWindow *dlg)
       case OP_MAIN_VFOLDER_FROM_QUERY_READONLY:
       {
         buf[0] = '\0';
-        if ((mutt_get_field("Query: ", buf, sizeof(buf), MUTT_NM_QUERY) != 0) ||
+        if ((mutt_get_field("Query: ", buf, sizeof(buf), MUTT_NM_QUERY, false, NULL, NULL) != 0) ||
             (buf[0] == '\0'))
         {
           mutt_message(_("No query, aborting"));
@@ -3667,7 +3668,8 @@ int mutt_index_menu(struct MuttWindow *dlg)
           /* L10N: This is the prompt for <mark-message>.  Whatever they
              enter will be prefixed by $mark_macro_prefix and will become
              a macro hotkey to jump to the currently selected message. */
-          if (!mutt_get_field(_("Enter macro stroke: "), buf2, sizeof(buf2), MUTT_COMP_NO_FLAGS) &&
+          if (!mutt_get_field(_("Enter macro stroke: "), buf2, sizeof(buf2),
+                              MUTT_COMP_NO_FLAGS, false, NULL, NULL) &&
               buf2[0])
           {
             char str[256], macro[256];

--- a/menu.c
+++ b/menu.c
@@ -603,7 +603,8 @@ static void menu_jump(struct Menu *menu)
 
   mutt_unget_event(LastKey, 0);
   char buf[128] = { 0 };
-  if ((mutt_get_field(_("Jump to: "), buf, sizeof(buf), MUTT_COMP_NO_FLAGS) == 0) &&
+  if ((mutt_get_field(_("Jump to: "), buf, sizeof(buf), MUTT_COMP_NO_FLAGS,
+                      false, NULL, NULL) == 0) &&
       (buf[0] != '\0'))
   {
     int n = 0;
@@ -1140,7 +1141,7 @@ static int search(struct Menu *menu, int op)
     if ((mutt_get_field(((op == OP_SEARCH) || (op == OP_SEARCH_NEXT)) ?
                             _("Search for: ") :
                             _("Reverse search for: "),
-                        buf, sizeof(buf), MUTT_CLEAR) != 0) ||
+                        buf, sizeof(buf), MUTT_CLEAR, false, NULL, NULL) != 0) ||
         (buf[0] == '\0'))
     {
       return -1;

--- a/mutt_header.c
+++ b/mutt_header.c
@@ -136,8 +136,11 @@ int mutt_label_message(struct Mailbox *m, struct EmailList *el)
       mutt_str_copy(buf, en->email->env->x_label, sizeof(buf));
   }
 
-  if (mutt_get_field("Label: ", buf, sizeof(buf), MUTT_LABEL /* | MUTT_CLEAR */) != 0)
+  if (mutt_get_field("Label: ", buf, sizeof(buf), MUTT_LABEL /* | MUTT_CLEAR */,
+                     false, NULL, NULL) != 0)
+  {
     return 0;
+  }
 
   char *new_label = buf;
   SKIPWS(new_label);

--- a/muttlib.c
+++ b/muttlib.c
@@ -660,7 +660,8 @@ int mutt_check_overwrite(const char *attname, const char *path, struct Buffer *f
 
     struct Buffer *tmp = mutt_buffer_pool_get();
     mutt_buffer_strcpy(tmp, mutt_path_basename(NONULL(attname)));
-    if ((mutt_buffer_get_field(_("File under directory: "), tmp, MUTT_FILE | MUTT_CLEAR) != 0) ||
+    if ((mutt_buffer_get_field(_("File under directory: "), tmp,
+                               MUTT_FILE | MUTT_CLEAR, false, NULL, NULL) != 0) ||
         mutt_buffer_is_empty(tmp))
     {
       mutt_buffer_pool_release(&tmp);

--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -3756,8 +3756,10 @@ static struct CryptKeyInfo *crypt_ask_for_key(char *tag, char *whatfor, KeyFlags
   while (true)
   {
     resp[0] = '\0';
-    if (mutt_get_field(tag, resp, sizeof(resp), MUTT_COMP_NO_FLAGS) != 0)
+    if (mutt_get_field(tag, resp, sizeof(resp), MUTT_COMP_NO_FLAGS, false, NULL, NULL) != 0)
+    {
       return NULL;
+    }
 
     if (whatfor)
     {

--- a/ncrypt/pgp.c
+++ b/ncrypt/pgp.c
@@ -97,7 +97,8 @@ bool pgp_class_valid_passphrase(void)
 
   pgp_class_void_passphrase();
 
-  if (mutt_get_password(_("Enter PGP passphrase:"), PgpPass, sizeof(PgpPass)) == 0)
+  if (mutt_get_field_unbuffered(_("Enter PGP passphrase:"), PgpPass,
+                                sizeof(PgpPass), MUTT_PASS) == 0)
   {
     PgpExptime = mutt_date_add_timeout(mutt_date_epoch(), C_PgpTimeout);
     return true;

--- a/ncrypt/pgpkey.c
+++ b/ncrypt/pgpkey.c
@@ -211,8 +211,10 @@ struct PgpKeyInfo *pgp_ask_for_key(char *tag, char *whatfor, KeyFlags abilities,
   while (true)
   {
     resp[0] = '\0';
-    if (mutt_get_field(tag, resp, sizeof(resp), MUTT_COMP_NO_FLAGS) != 0)
+    if (mutt_get_field(tag, resp, sizeof(resp), MUTT_COMP_NO_FLAGS, false, NULL, NULL) != 0)
+    {
       return NULL;
+    }
 
     if (whatfor)
     {

--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -711,8 +711,10 @@ static struct SmimeKey *smime_ask_for_key(char *prompt, KeyFlags abilities, bool
   while (true)
   {
     resp[0] = '\0';
-    if (mutt_get_field(prompt, resp, sizeof(resp), MUTT_COMP_NO_FLAGS) != 0)
+    if (mutt_get_field(prompt, resp, sizeof(resp), MUTT_COMP_NO_FLAGS, false, NULL, NULL) != 0)
+    {
       return NULL;
+    }
 
     key = smime_get_key_by_str(resp, abilities, only_public_key);
     if (key)
@@ -1142,7 +1144,8 @@ void smime_class_invoke_import(const char *infile, const char *mailbox)
   buf[0] = '\0';
   if (C_SmimeAskCertLabel)
   {
-    if ((mutt_get_field(_("Label for certificate: "), buf, sizeof(buf), MUTT_COMP_NO_FLAGS) != 0) ||
+    if ((mutt_get_field(_("Label for certificate: "), buf, sizeof(buf),
+                        MUTT_COMP_NO_FLAGS, false, NULL, NULL) != 0) ||
         (buf[0] == '\0'))
     {
       mutt_file_fclose(&fp_out);

--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -175,7 +175,8 @@ bool smime_class_valid_passphrase(void)
 
   smime_class_void_passphrase();
 
-  if (mutt_get_password(_("Enter S/MIME passphrase:"), SmimePass, sizeof(SmimePass)) == 0)
+  if (mutt_get_field_unbuffered(_("Enter S/MIME passphrase:"), SmimePass,
+                                sizeof(SmimePass), MUTT_PASS) == 0)
   {
     SmimeExpTime = mutt_date_add_timeout(now, C_SmimeTimeout);
     return true;

--- a/notmuch/notmuch.c
+++ b/notmuch/notmuch.c
@@ -2624,8 +2624,10 @@ static int nm_msg_close(struct Mailbox *m, struct Message *msg)
 static int nm_tags_edit(struct Mailbox *m, const char *tags, char *buf, size_t buflen)
 {
   *buf = '\0';
-  if (mutt_get_field("Add/remove labels: ", buf, buflen, MUTT_NM_TAG) != 0)
+  if (mutt_get_field("Add/remove labels: ", buf, buflen, MUTT_NM_TAG, false, NULL, NULL) != 0)
+  {
     return -1;
+  }
   return 1;
 }
 

--- a/pager.c
+++ b/pager.c
@@ -2700,7 +2700,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         if (mutt_get_field(((ch == OP_SEARCH) || (ch == OP_SEARCH_NEXT)) ?
                                _("Search for: ") :
                                _("Reverse search for: "),
-                           buf, sizeof(buf), MUTT_CLEAR | MUTT_PATTERN) != 0)
+                           buf, sizeof(buf), MUTT_CLEAR | MUTT_PATTERN, false,
+                           NULL, NULL) != 0)
         {
           break;
         }

--- a/pattern/pattern.c
+++ b/pattern/pattern.c
@@ -245,7 +245,7 @@ int mutt_pattern_alias_func(int op, char *prompt, char *menu_name,
   mutt_buffer_strcpy(buf, mdata->str);
   if (prompt)
   {
-    if ((mutt_buffer_get_field(prompt, buf, MUTT_PATTERN | MUTT_CLEAR) != 0) ||
+    if ((mutt_buffer_get_field(prompt, buf, MUTT_PATTERN | MUTT_CLEAR, false, NULL, NULL) != 0) ||
         mutt_buffer_is_empty(buf))
     {
       mutt_buffer_pool_release(&buf);
@@ -349,7 +349,7 @@ int mutt_pattern_func(int op, char *prompt)
   mutt_buffer_strcpy(buf, NONULL(Context->pattern));
   if (prompt || (op != MUTT_LIMIT))
   {
-    if ((mutt_buffer_get_field(prompt, buf, MUTT_PATTERN | MUTT_CLEAR) != 0) ||
+    if ((mutt_buffer_get_field(prompt, buf, MUTT_PATTERN | MUTT_CLEAR, false, NULL, NULL) != 0) ||
         mutt_buffer_is_empty(buf))
     {
       mutt_buffer_pool_release(&buf);

--- a/pattern/pattern.c
+++ b/pattern/pattern.c
@@ -489,10 +489,9 @@ int mutt_search_command(struct Mailbox *m, int cur, int op)
   {
     char buf[256];
     mutt_str_copy(buf, (LastSearch[0] != '\0') ? LastSearch : "", sizeof(buf));
-    if ((mutt_get_field(((op == OP_SEARCH) || (op == OP_SEARCH_NEXT)) ?
-                            _("Search for: ") :
-                            _("Reverse search for: "),
-                        buf, sizeof(buf), MUTT_CLEAR | MUTT_PATTERN) != 0) ||
+    if ((mutt_get_field(
+             ((op == OP_SEARCH) || (op == OP_SEARCH_NEXT)) ? _("Search for: ") : _("Reverse search for: "),
+             buf, sizeof(buf), MUTT_CLEAR | MUTT_PATTERN, false, NULL, NULL) != 0) ||
         (buf[0] == '\0'))
     {
       return -1;
@@ -640,10 +639,9 @@ int mutt_search_alias_command(struct Menu *menu, int cur, int op)
   {
     char buf[256];
     mutt_str_copy(buf, (LastSearch[0] != '\0') ? LastSearch : "", sizeof(buf));
-    if ((mutt_get_field(((op == OP_SEARCH) || (op == OP_SEARCH_NEXT)) ?
-                            _("Search for: ") :
-                            _("Reverse search for: "),
-                        buf, sizeof(buf), MUTT_CLEAR | MUTT_PATTERN) != 0) ||
+    if ((mutt_get_field(
+             ((op == OP_SEARCH) || (op == OP_SEARCH_NEXT)) ? _("Search for: ") : _("Reverse search for: "),
+             buf, sizeof(buf), MUTT_CLEAR | MUTT_PATTERN, false, NULL, NULL) != 0) ||
         (buf[0] == '\0'))
     {
       return -1;

--- a/recvattach.c
+++ b/recvattach.c
@@ -602,7 +602,7 @@ static int query_save_attachment(FILE *fp, struct Body *body, struct Email *e, c
   prompt = _("Save to file: ");
   while (prompt)
   {
-    if ((mutt_buffer_get_field(prompt, buf, MUTT_FILE | MUTT_CLEAR) != 0) ||
+    if ((mutt_buffer_get_field(prompt, buf, MUTT_FILE | MUTT_CLEAR, false, NULL, NULL) != 0) ||
         mutt_buffer_is_empty(buf))
     {
       goto cleanup;
@@ -750,7 +750,8 @@ void mutt_save_attachment_list(struct AttachCtx *actx, FILE *fp, bool tag,
           mutt_buffer_strcpy(buf, mutt_path_basename(NONULL(top->filename)));
           prepend_savedir(buf);
 
-          if ((mutt_buffer_get_field(_("Save to file: "), buf, MUTT_FILE | MUTT_CLEAR) != 0) ||
+          if ((mutt_buffer_get_field(_("Save to file: "), buf, MUTT_FILE | MUTT_CLEAR,
+                                     false, NULL, NULL) != 0) ||
               mutt_buffer_is_empty(buf))
           {
             goto cleanup;
@@ -1020,7 +1021,7 @@ void mutt_pipe_attachment_list(struct AttachCtx *actx, FILE *fp, bool tag,
   state.flags = MUTT_CHARCONV;
 
   if (mutt_buffer_get_field((filter ? _("Filter through: ") : _("Pipe to: ")),
-                            buf, MUTT_CMD) != 0)
+                            buf, MUTT_CMD, false, NULL, NULL) != 0)
   {
     goto cleanup;
   }

--- a/recvcmd.c
+++ b/recvcmd.c
@@ -214,8 +214,11 @@ void mutt_attach_bounce(struct Mailbox *m, FILE *fp, struct AttachCtx *actx, str
     mutt_str_copy(prompt, _("Bounce tagged messages to: "), sizeof(prompt));
 
   buf[0] = '\0';
-  if (mutt_get_field(prompt, buf, sizeof(buf), MUTT_ALIAS) || (buf[0] == '\0'))
+  if (mutt_get_field(prompt, buf, sizeof(buf), MUTT_ALIAS, false, NULL, NULL) ||
+      (buf[0] == '\0'))
+  {
     return;
+  }
 
   struct AddressList al = TAILQ_HEAD_INITIALIZER(al);
   mutt_addrlist_parse(&al, buf);

--- a/send/send.c
+++ b/send/send.c
@@ -1764,7 +1764,8 @@ full_fcc:
         case 2: /* alternate (m)ailbox */
           /* L10N: This is the prompt to enter an "alternate (m)ailbox" when the
              initial Fcc fails.  */
-          rc = mutt_buffer_enter_fname(_("Fcc mailbox"), fcc, true);
+          rc = mutt_buffer_enter_fname(_("Fcc mailbox"), fcc, true, false, NULL,
+                                       NULL, MUTT_SEL_NO_FLAGS);
           if ((rc == -1) || mutt_buffer_is_empty(fcc))
           {
             rc = 0;

--- a/send/send.c
+++ b/send/send.c
@@ -175,7 +175,7 @@ int mutt_edit_address(struct AddressList *al, const char *field, bool expand_ali
     buf[0] = '\0';
     mutt_addrlist_to_local(al);
     mutt_addrlist_write(al, buf, sizeof(buf), false);
-    if (mutt_get_field(field, buf, sizeof(buf), MUTT_ALIAS) != 0)
+    if (mutt_get_field(field, buf, sizeof(buf), MUTT_ALIAS, false, NULL, NULL) != 0)
       return -1;
     mutt_addrlist_clear(al);
     mutt_addrlist_parse2(al, buf);
@@ -210,8 +210,11 @@ static int edit_envelope(struct Envelope *en, SendFlags flags, struct ConfigSubs
       mutt_str_copy(buf, en->newsgroups, sizeof(buf));
     else
       buf[0] = '\0';
-    if (mutt_get_field("Newsgroups: ", buf, sizeof(buf), MUTT_COMP_NO_FLAGS) != 0)
+    if (mutt_get_field("Newsgroups: ", buf, sizeof(buf), MUTT_COMP_NO_FLAGS,
+                       false, NULL, NULL) != 0)
+    {
       return -1;
+    }
     FREE(&en->newsgroups);
     en->newsgroups = mutt_str_dup(buf);
 
@@ -221,8 +224,8 @@ static int edit_envelope(struct Envelope *en, SendFlags flags, struct ConfigSubs
       buf[0] = '\0';
 
     const bool c_ask_follow_up = cs_subset_bool(sub, "ask_follow_up");
-    if (c_ask_follow_up &&
-        (mutt_get_field("Followup-To: ", buf, sizeof(buf), MUTT_COMP_NO_FLAGS) != 0))
+    if (c_ask_follow_up && (mutt_get_field("Followup-To: ", buf, sizeof(buf),
+                                           MUTT_COMP_NO_FLAGS, false, NULL, NULL) != 0))
     {
       return -1;
     }
@@ -237,7 +240,8 @@ static int edit_envelope(struct Envelope *en, SendFlags flags, struct ConfigSubs
     const bool c_x_comment_to = cs_subset_bool(sub, "x_comment_to");
     const bool c_ask_x_comment_to = cs_subset_bool(sub, "ask_x_comment_to");
     if (c_x_comment_to && c_ask_x_comment_to &&
-        (mutt_get_field("X-Comment-To: ", buf, sizeof(buf), MUTT_COMP_NO_FLAGS) != 0))
+        (mutt_get_field("X-Comment-To: ", buf, sizeof(buf), MUTT_COMP_NO_FLAGS,
+                        false, NULL, NULL) != 0))
     {
       return -1;
     }
@@ -292,7 +296,8 @@ static int edit_envelope(struct Envelope *en, SendFlags flags, struct ConfigSubs
 
   const enum QuadOption c_abort_nosubject =
       cs_subset_quad(sub, "abort_nosubject");
-  if ((mutt_get_field(_("Subject: "), buf, sizeof(buf), MUTT_COMP_NO_FLAGS) != 0) ||
+  if ((mutt_get_field(_("Subject: "), buf, sizeof(buf), MUTT_COMP_NO_FLAGS,
+                      false, NULL, NULL) != 0) ||
       ((buf[0] == '\0') &&
        (query_quadoption(c_abort_nosubject, _("No subject, abort?")) != MUTT_NO)))
   {


### PR DESCRIPTION
Simplify the callers for all the `enter_field()` functions.

Expand:
- `mutt_get_field()` to `mutt_get_field_full()`
- `mutt_buffer_get_field()` to `mutt_buffer_get_field_full()`
- `mutt_buffer_enter_fname()` to `mutt_buffer_enter_fname_full()`
- `mutt_get_password()` to `mutt_get_field_unbuffered(MUTT_PASS)`

Then rename:
- `mutt_get_field_full()` to `mutt_get_field()`
- `mutt_buffer_get_field_full()` to `mutt_buffer_get_field()`
- `mutt_buffer_enter_fname_full()` to `mutt_buffer_enter_fname()`

Call Tree before and after:
| |
| --: |
| <img width='800' src='https://gist.github.com/flatcap/d120ee4a39aad9365a94f4a5d23b8f51/raw/b836b41e3d327fc46b9a37e043a06556637641e4/enter_before.svg'> |
| <img width='500' src='https://gist.github.com/flatcap/d120ee4a39aad9365a94f4a5d23b8f51/raw/b836b41e3d327fc46b9a37e043a06556637641e4/enter_after.svg'> |

([images source](https://gist.github.com/flatcap/d120ee4a39aad9365a94f4a5d23b8f51))