### PR TITLE
Fix caching new labels in the header cache

### DIFF
--- a/imap/imap.c
+++ b/imap/imap.c
@@ -2362,6 +2362,7 @@ static int imap_tags_commit(struct Mailbox *m, struct Email *e, char *buf)
   driver_tags_replace(&e->tags, buf);
   FREE(&imap_edata_get(e)->flags_remote);
   imap_edata_get(e)->flags_remote = driver_tags_get_with_hidden(&e->tags);
+  imap_msg_save_hcache(m, e);
   return 0;
 }
 


### PR DESCRIPTION
(Re)fixes #2823

I think I previously misunderstood the reason why I wasn't able to push
labels to GMail. Now everything seems to work fine.