### PR TITLE
misc: ignore clangd lsp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@ hcache/hcversion.h
 *.tmp
 *~
 tags
+
+# Clangd
+.cache/clangd
+compile_commands.json


### PR DESCRIPTION
* **What does this PR do?**

This is a small quality of life improvement for those wanting to use the clangd[0] language server protocol (LSP) implementation. It obviates the need to exclude clangd's configuration and cache when making a commit. I've found clangd to be a productivity multiplier when working with C.

[0] https://clangd.llvm.org/