### PR TITLE
pager: monumental refactoring part 1.

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -368,15 +368,22 @@ int mutt_display_message(struct MuttWindow *win_index, struct MuttWindow *win_ib
         mutt_message(_("PGP signature could NOT be verified"));
     }
 
-    struct Pager info = { 0 };
     /* Invoke the builtin pager */
-    info.email = e;
-    info.ctx = Context;
-    info.win_ibar = win_ibar;
-    info.win_index = win_index;
-    info.win_pbar = win_pbar;
-    info.win_pager = win_pager;
-    rc = mutt_pager(NULL, mutt_buffer_string(tempfile), MUTT_PAGER_MESSAGE, &info);
+    struct PagerData pdata = { 0 };
+    struct PagerView pview = { &pdata };
+
+    pdata.email = e;
+    pdata.ctx = Context;
+    pdata.fname = mutt_buffer_string(tempfile);
+
+    pview.mode = PAGER_MODE_EMAIL;
+    pview.banner = NULL;
+    pview.flags = MUTT_PAGER_MESSAGE;
+    pview.win_ibar = win_ibar;
+    pview.win_index = win_index;
+    pview.win_pbar = win_pbar;
+    pview.win_pager = win_pager;
+    rc = mutt_pager(&pview);
   }
   else
   {

--- a/gui/curs_lib.c
+++ b/gui/curs_lib.c
@@ -691,7 +691,8 @@ int mutt_do_pager(struct PagerView *pview)
   assert(pview);
   assert(pview->pdata);
   assert(pview->pdata->fname);
-  assert((pview->mode == PAGER_MODE_ATTACH) || (pview->mode == PAGER_MODE_OTHER));
+  assert((pview->mode == PAGER_MODE_ATTACH) ||
+         (pview->mode == PAGER_MODE_HELP) || (pview->mode == PAGER_MODE_OTHER));
 
   struct MuttWindow *dlg =
       mutt_window_new(WT_DLG_DO_PAGER, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,

--- a/gui/curs_lib.c
+++ b/gui/curs_lib.c
@@ -28,6 +28,7 @@
  */
 
 #include "config.h"
+#include <assert.h>
 #include <ctype.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -680,20 +681,17 @@ static int mutt_dlg_dopager_observer(struct NotifyCallback *nc)
 }
 
 /**
- * mutt_do_pager - Display some page-able text to the user
- * @param banner   Message for status bar
- * @param tempfile File to display
- * @param do_color Flags, see #PagerFlags
- * @param info     Info about current mailbox (OPTIONAL)
+ * mutt_do_pager - Display some page-able text to the user (help or attachment)
+ * @param view     PagerView to construct Pager object
  * @retval  0 Success
  * @retval -1 Error
  */
-int mutt_do_pager(const char *banner, const char *tempfile, PagerFlags do_color,
-                  struct Pager *info)
+int mutt_do_pager(struct PagerView *pview)
 {
-  struct Pager info2 = { 0 };
-  if (!info)
-    info = &info2;
+  assert(pview);
+  assert(pview->pdata);
+  assert(pview->pdata->fname);
+  assert((pview->mode == PAGER_MODE_ATTACH) || (pview->mode == PAGER_MODE_OTHER));
 
   struct MuttWindow *dlg =
       mutt_window_new(WT_DLG_DO_PAGER, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
@@ -723,24 +721,24 @@ int mutt_do_pager(const char *banner, const char *tempfile, PagerFlags do_color,
   notify_observer_add(NeoMutt->notify, NT_CONFIG, mutt_dlg_dopager_observer, dlg);
   dialog_push(dlg);
 
-  info->win_ibar = NULL;
-  info->win_index = NULL;
-  info->win_pbar = pbar;
-  info->win_pager = pager;
+  pview->win_ibar = NULL;
+  pview->win_index = NULL;
+  pview->win_pbar = pbar;
+  pview->win_pager = pager;
 
   int rc;
 
   const char *const c_pager = cs_subset_string(NeoMutt->sub, "pager");
   if (!c_pager || mutt_str_equal(c_pager, "builtin"))
   {
-    rc = mutt_pager(banner, tempfile, do_color, info);
+    rc = mutt_pager(pview);
   }
   else
   {
     struct Buffer *cmd = mutt_buffer_pool_get();
 
     mutt_endwin();
-    mutt_buffer_file_expand_fmt_quote(cmd, c_pager, tempfile);
+    mutt_buffer_file_expand_fmt_quote(cmd, c_pager, pview->pdata->fname);
     if (mutt_system(mutt_buffer_string(cmd)) == -1)
     {
       mutt_error(_("Error running \"%s\""), mutt_buffer_string(cmd));
@@ -748,7 +746,7 @@ int mutt_do_pager(const char *banner, const char *tempfile, PagerFlags do_color,
     }
     else
       rc = 0;
-    mutt_file_unlink(tempfile);
+    mutt_file_unlink(pview->pdata->fname);
     mutt_buffer_pool_release(&cmd);
   }
 

--- a/gui/curs_lib.h
+++ b/gui/curs_lib.h
@@ -51,7 +51,7 @@ int          mutt_any_key_to_continue(const char *s);
 void         mutt_beep(bool force);
 int          mutt_buffer_enter_fname(const char *prompt, struct Buffer *fname, bool mailbox, struct Mailbox *m, bool multiple, char ***files, int *numfiles, SelectFileFlags flags);
 int          mutt_buffer_get_field(const char *field, struct Buffer *buf, CompletionFlags complete, bool multiple, struct Mailbox *m, char ***files, int *numfiles);
-int          mutt_do_pager(const char *banner, const char *tempfile, PagerFlags do_color, struct Pager *info);
+int          mutt_do_pager(struct PagerView *pview);
 void         mutt_edit_file(const char *editor, const char *file);
 void         mutt_endwin(void);
 void         mutt_flushinp(void);

--- a/help.c
+++ b/help.c
@@ -388,7 +388,7 @@ static void dump_unbound(FILE *fp, const struct Binding *funcs,
 void mutt_help(enum MenuType menu)
 {
   const int wraplen = AllDialogsWindow->state.cols;
-  char buf[128];
+  char banner[128];
   FILE *fp = NULL;
 
   /* We don't use the buffer pool because of the extended lifetime of t */
@@ -399,6 +399,12 @@ void mutt_help(enum MenuType menu)
   const char *desc = mutt_map_get_name(menu, Menus);
   if (!desc)
     desc = _("<UNKNOWN>");
+
+  struct PagerData pdata = { 0 };
+  struct PagerView pview = { &pdata };
+
+  pview.mode = PAGER_MODE_OTHER;
+  pview.flags = MUTT_PAGER_RETWINCH | MUTT_PAGER_MARKER | MUTT_PAGER_NSKIP | MUTT_PAGER_NOWRAP;
 
   do
   {
@@ -424,10 +430,10 @@ void mutt_help(enum MenuType menu)
 
     mutt_file_fclose(&fp);
 
-    snprintf(buf, sizeof(buf), _("Help for %s"), desc);
-  } while (mutt_do_pager(buf, mutt_buffer_string(&t),
-                         MUTT_PAGER_RETWINCH | MUTT_PAGER_MARKER | MUTT_PAGER_NSKIP | MUTT_PAGER_NOWRAP,
-                         NULL) == OP_REFORMAT_WINCH);
+    snprintf(banner, sizeof(banner), _("Help for %s"), desc);
+    pdata.fname = mutt_buffer_string(&t);
+    pview.banner = banner;
+  } while (mutt_do_pager(&pview) == OP_REFORMAT_WINCH);
 
 cleanup:
   mutt_buffer_dealloc(&t);

--- a/help.c
+++ b/help.c
@@ -403,7 +403,7 @@ void mutt_help(enum MenuType menu)
   struct PagerData pdata = { 0 };
   struct PagerView pview = { &pdata };
 
-  pview.mode = PAGER_MODE_OTHER;
+  pview.mode = PAGER_MODE_HELP;
   pview.flags = MUTT_PAGER_RETWINCH | MUTT_PAGER_MARKER | MUTT_PAGER_NSKIP | MUTT_PAGER_NOWRAP;
 
   do

--- a/icommands.c
+++ b/icommands.c
@@ -291,7 +291,16 @@ static enum CommandResult icmd_bind(struct Buffer *buf, struct Buffer *s,
   mutt_file_fclose(&fp_out);
   mutt_buffer_dealloc(&filebuf);
 
-  if (mutt_do_pager((bind) ? "bind" : "macro", tempfile, MUTT_PAGER_NO_FLAGS, NULL) == -1)
+  struct PagerData pdata = { 0 };
+  struct PagerView pview = { &pdata };
+
+  pdata.fname = tempfile;
+
+  pview.banner = (bind) ? "bind" : "macro";
+  pview.flags = MUTT_PAGER_NO_FLAGS;
+  pview.mode = PAGER_MODE_OTHER;
+
+  if (mutt_do_pager(&pview) == -1)
   {
     // L10N: '%s' is the file name of the temporary file
     mutt_buffer_printf(err, _("Could not create temporary file %s"), tempfile);
@@ -330,7 +339,17 @@ static enum CommandResult icmd_set(struct Buffer *buf, struct Buffer *s,
     dump_config(NeoMutt->sub->cs, CS_DUMP_ONLY_CHANGED, fp_out);
 
   mutt_file_fclose(&fp_out);
-  mutt_do_pager("set", tempfile, MUTT_PAGER_NO_FLAGS, NULL);
+
+  struct PagerData pdata = { 0 };
+  struct PagerView pview = { &pdata };
+
+  pdata.fname = tempfile;
+
+  pview.banner = "set";
+  pview.flags = MUTT_PAGER_NO_FLAGS;
+  pview.mode = PAGER_MODE_OTHER;
+
+  mutt_do_pager(&pview);
 
   return MUTT_CMD_SUCCESS;
 }
@@ -355,7 +374,16 @@ static enum CommandResult icmd_version(struct Buffer *buf, struct Buffer *s,
   print_version(fp_out);
   mutt_file_fclose(&fp_out);
 
-  if (mutt_do_pager("version", tempfile, MUTT_PAGER_NO_FLAGS, NULL) == -1)
+  struct PagerData pdata = { 0 };
+  struct PagerView pview = { &pdata };
+
+  pdata.fname = tempfile;
+
+  pview.banner = "version";
+  pview.flags = MUTT_PAGER_NO_FLAGS;
+  pview.mode = PAGER_MODE_OTHER;
+
+  if (mutt_do_pager(&pview) == -1)
   {
     // L10N: '%s' is the file name of the temporary file
     mutt_buffer_printf(err, _("Could not create temporary file %s"), tempfile);

--- a/index/index.c
+++ b/index/index.c
@@ -1797,7 +1797,16 @@ int mutt_index_menu(struct MuttWindow *dlg)
         log_queue_save(fp);
         mutt_file_fclose(&fp);
 
-        mutt_do_pager("messages", tempfile, MUTT_PAGER_LOGS, NULL);
+        struct PagerData pdata = { 0 };
+        struct PagerView pview = { &pdata };
+
+        pdata.fname = tempfile;
+
+        pview.banner = "messages";
+        pview.flags = MUTT_PAGER_LOGS;
+        pview.mode = PAGER_MODE_OTHER;
+
+        mutt_do_pager(&pview);
         break;
       }
 

--- a/mutt_attach.c
+++ b/mutt_attach.c
@@ -653,16 +653,23 @@ int mutt_view_attachment(FILE *fp, struct Body *a, enum ViewAttachMode mode,
 
   if (use_pager)
   {
-    struct Pager info = { 0 };
-    info.fp = fp;
-    info.body = a;
-    info.ctx = Context;
-    info.actx = actx;
-    info.email = e;
+    struct PagerData pdata = { 0 };
+    struct PagerView pview = { &pdata };
 
-    rc = mutt_do_pager(desc, mutt_buffer_string(pagerfile),
-                       MUTT_PAGER_ATTACHMENT | (is_message ? MUTT_PAGER_MESSAGE : MUTT_PAGER_NO_FLAGS),
-                       &info);
+    pdata.actx = actx;
+    pdata.body = a;
+    pdata.email = e;
+    pdata.fname = mutt_buffer_string(pagerfile);
+    pdata.fp = fp;
+    pdata.ctx = Context;
+
+    pview.banner = desc;
+    pview.flags = MUTT_PAGER_ATTACHMENT |
+                  (is_message ? MUTT_PAGER_MESSAGE : MUTT_PAGER_NO_FLAGS);
+    pview.mode = PAGER_MODE_ATTACH;
+
+    rc = mutt_do_pager(&pview);
+
     mutt_buffer_reset(pagerfile);
     unlink_pagerfile = false;
   }

--- a/ncrypt/dlggpgme.c
+++ b/ncrypt/dlggpgme.c
@@ -886,7 +886,17 @@ leave:
   mutt_clear_error();
   char title[1024];
   snprintf(title, sizeof(title), _("Key ID: 0x%s"), crypt_keyid(key));
-  mutt_do_pager(title, mutt_buffer_string(&tempfile), MUTT_PAGER_NO_FLAGS, NULL);
+
+  struct PagerData pdata = { 0 };
+  struct PagerView pview = { &pdata };
+
+  pdata.fname = mutt_buffer_string(&tempfile);
+
+  pview.banner = title;
+  pview.flags = MUTT_PAGER_NO_FLAGS;
+  pview.mode = PAGER_MODE_OTHER;
+
+  mutt_do_pager(&pview);
 
 cleanup:
   mutt_buffer_dealloc(&tempfile);

--- a/ncrypt/dlgpgp.c
+++ b/ncrypt/dlgpgp.c
@@ -616,7 +616,17 @@ struct PgpKeyInfo *dlg_select_pgp_key(struct PgpKeyInfo *keys,
         char title[1024];
         snprintf(title, sizeof(title), _("Key ID: 0x%s"),
                  pgp_keyid(pgp_principal_key(key_table[menu->current]->parent)));
-        mutt_do_pager(title, mutt_buffer_string(tempfile), MUTT_PAGER_NO_FLAGS, NULL);
+
+        struct PagerData pdata = { 0 };
+        struct PagerView pview = { &pdata };
+
+        pdata.fname = mutt_buffer_string(tempfile);
+
+        pview.banner = title;
+        pview.flags = MUTT_PAGER_NO_FLAGS;
+        pview.mode = PAGER_MODE_OTHER;
+
+        mutt_do_pager(&pview);
         mutt_buffer_pool_release(&tempfile);
         menu->redraw = REDRAW_FULL;
         break;

--- a/pager/lib.h
+++ b/pager/lib.h
@@ -60,6 +60,56 @@ typedef uint16_t PagerFlags;              ///< Flags for mutt_pager(), e.g. #MUT
 
 #define MUTT_DISPLAYFLAGS (MUTT_SHOW | MUTT_PAGER_NSKIP | MUTT_PAGER_MARKER | MUTT_PAGER_LOGS)
 
+// Pager mode.
+// There are 10 code paths that lead to mutt_pager() invocation:
+//
+// 1. mutt_index_menu -> mutt_display_message -> mutt_pager
+//
+//    This path always results in mailbox and email set,
+//    the rest is unset - Body, fp.
+//    This invocation can be identified by IsEmail macro.
+//    The intent is to display an email message
+//
+// 2. mutt_view_attachment -> mutt_do_pager -> mutt_pager
+//
+//    this path always results in email, body, ctx set
+//    this invocation can be identified by one of the two macros
+//    - IsAttach (viewing a regular attachment)
+//    - IsMsgAttach (viewing nested email)
+//
+//    IsMsgAttach has extra->body->email set
+//    extra->email != extra->body->email
+//    the former is the message that contains the latter message as attachment
+//
+//    NB. extra->email->body->email seems to be always NULL
+//
+// 3. The following 8 invocations are similar, because they all call
+//    mutt_do_page with info = NULL
+//
+//    And so it results in mailbox, body, fp set to NULL.
+//    The intent is to show user some text that is not
+//    directly related to viewing emails,
+//    e.g. help, log messages,gpg key selection etc.
+//
+//    No macro identifies these invocations
+//
+//    mutt_index_menu       -> mutt_do_pager -> mutt_pager
+//    mutt_help             -> mutt_do_pager -> mutt_pager
+//    icmd_bind             -> mutt_do_pager -> mutt_pager
+//    icmd_set              -> mutt_do_pager -> mutt_pager
+//    icmd_version          -> mutt_do_pager -> mutt_pager
+//    dlg_select_pgp_key    -> mutt_do_pager -> mutt_pager
+//    verify_key            -> mutt_do_pager -> mutt_pager
+//    mutt_invoke_sendmail  -> mutt_do_pager -> mutt_pager
+//
+//
+// - IsAttach(pager) (pager && (pager)->body)
+// - IsMsgAttach(pager)
+//   (pager && (pager)->fp && (pager)->body && (pager)->body->email)
+// - IsEmail(pager) (pager && (pager)->email && !(pager)->body)
+// See nice infographic here:
+// https://gist.github.com/flatcap/044ecbd2498c65ea9a85099ef317509a
+
 /**
  * struct Pager - An email being displayed
  */

--- a/pager/lib.h
+++ b/pager/lib.h
@@ -120,6 +120,7 @@ enum PagerMode
   PAGER_MODE_EMAIL,       ///< Pager is invoked via 1st path. The mime part is selected automatically
   PAGER_MODE_ATTACH,      ///< Pager is invoked via 2nd path. A user-selected attachment (mime part or a nested email) will be shown
   PAGER_MODE_ATTACH_E,    ///< A special case of PAGER_MODE_ATTACH - attachment is a full-blown email message
+  PAGER_MODE_HELP,        ///< Pager is invoked via 3rd path to show help.
   PAGER_MODE_OTHER,       ///< Pager is invoked via 3rd path. Non-email content is likely to be shown
 
   PAGER_MODE_MAX,         ///< Another invalid mode, should never be used

--- a/pager/lib.h
+++ b/pager/lib.h
@@ -111,15 +111,42 @@ typedef uint16_t PagerFlags;              ///< Flags for mutt_pager(), e.g. #MUT
 // https://gist.github.com/flatcap/044ecbd2498c65ea9a85099ef317509a
 
 /**
- * struct Pager - An email being displayed
+ * enum PagerMode - Determine the behaviour of the Pager
  */
-struct Pager
+enum PagerMode
 {
-  struct Context *ctx;    ///< Current mailbox
-  struct Email *email;    ///< Current message
-  struct Body *body;      ///< Current attachment
-  FILE *fp;               ///< Source stream
-  struct AttachCtx *actx; ///< Attachment information
+  PAGER_MODE_UNKNOWN = 0, ///< A default and invalid mode, should never be used
+
+  PAGER_MODE_EMAIL,       ///< Pager is invoked via 1st path. The mime part is selected automatically
+  PAGER_MODE_ATTACH,      ///< Pager is invoked via 2nd path. A user-selected attachment (mime part or a nested email) will be shown
+  PAGER_MODE_ATTACH_E,    ///< A special case of PAGER_MODE_ATTACH - attachment is a full-blown email message
+  PAGER_MODE_OTHER,       ///< Pager is invoked via 3rd path. Non-email content is likely to be shown
+
+  PAGER_MODE_MAX,         ///< Another invalid mode, should never be used
+};
+
+/**
+ * struct PagerData - Data to be displayed by PagerView
+ */
+struct PagerData
+{
+  struct Context   *ctx;    ///< Current Mailbox context
+  struct Email     *email;  ///< Current message
+  struct Body      *body;   ///< Current attachment
+  FILE             *fp;     ///< Source stream
+  struct AttachCtx *actx;   ///< Attachment information
+  const char       *fname;  ///< Name of the file to read
+};
+
+/**
+ * struct PagerView - paged view into some data
+ */
+struct PagerView
+{
+  struct PagerData *pdata;   ///< Data that pager displays. NOTNULL
+  enum PagerMode    mode;    ///< Pager mode
+  PagerFlags        flags;   ///< Additional settings to tweak pager's function
+  const char       *banner;  ///< Title to display in status bar
 
   struct MuttWindow *win_ibar;
   struct MuttWindow *win_index;
@@ -127,7 +154,7 @@ struct Pager
   struct MuttWindow *win_pager;
 };
 
-int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct Pager *extra);
+int mutt_pager(struct PagerView *pview);
 void mutt_buffer_strip_formatting(struct Buffer *dest, const char *src, bool strip_markers);
 
 void mutt_clear_pager_position(void);

--- a/pager/pager.c
+++ b/pager/pager.c
@@ -260,53 +260,6 @@ static const struct Mapping PagerNewsHelp[] = {
 
 #define IS_HEADER(x) ((x) == MT_COLOR_HEADER || (x) == MT_COLOR_HDRDEFAULT)
 
-// The macros below appear to be used to determine what mode pagers is
-// operating in. In order to
-// - bring some clarity
-// - prepare for further refactoring
-// I decided to write this comment.
-//
-// There are 10 code paths that lead to mutt_pager() invocation:
-//
-// 1. mutt_index_menu -> mutt_display_message -> mutt_pager
-//
-//    This path always results in mailbox and email set,
-//    the rest is unset - Body, fp.
-//    This invocation can be identified by IsEmail macro.
-//    The intent is to display an email message
-//
-// 2. mutt_view_attachment -> mutt_do_pager -> mutt_pager
-//
-//    this path always results in email, body, ctx set
-//    this invocation can be identified by one of the two macros
-//    - IsAttach (the Body could be any old attachment)
-//    - IsMsgAttach (or a full Email message)
-//    The distinction between the two is set/unset fp and the following:
-//
-//    The intent is to display an attachment of the email message
-//
-// 3. The following 8 invocations are similar, because they all call
-//    mutt_do_page with info = NULL
-//
-//    And so it results in mailbox, body, fp set to NULL.
-//    The intent is to show user some text that is not
-//    directly related to viewing emails,
-//    e.g. help, log messages,gpg key selection etc.
-//
-//    No macro identifies these invocations
-//
-//    mutt_index_menu       -> mutt_do_pager -> mutt_pager
-//    mutt_help             -> mutt_do_pager -> mutt_pager
-//    icmd_bind             -> mutt_do_pager -> mutt_pager
-//    icmd_set              -> mutt_do_pager -> mutt_pager
-//    icmd_version          -> mutt_do_pager -> mutt_pager
-//    dlg_select_pgp_key    -> mutt_do_pager -> mutt_pager
-//    verify_key            -> mutt_do_pager -> mutt_pager
-//    mutt_invoke_sendmail  -> mutt_do_pager -> mutt_pager
-//
-// See nice infographic here:
-// https://gist.github.com/flatcap/044ecbd2498c65ea9a85099ef317509a
-
 #define IsAttach(pager) (pager && (pager)->body)
 #define IsMsgAttach(pager)                                                     \
   (pager && (pager)->fp && (pager)->body && (pager)->body->email)
@@ -2590,6 +2543,7 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         }
       }
     }
+    //-------------------------------------------------------------------------
 
     if (SigWinch)
     {
@@ -2643,10 +2597,14 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
 
     switch (ch)
     {
+        //=======================================================================
+
       case OP_EXIT:
         rc = -1;
         ch = -1;
         break;
+
+        //=======================================================================
 
       case OP_QUIT:
       {
@@ -2659,6 +2617,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         }
         break;
       }
+
+        //=======================================================================
 
       case OP_NEXT_PAGE:
         if (rd.line_info[rd.curline].offset < (rd.sb.st_size - 1))
@@ -2678,6 +2638,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         }
         break;
 
+        //=======================================================================
+
       case OP_PREV_PAGE:
         if (rd.topline == 0)
         {
@@ -2689,6 +2651,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
                                   rd.line_info, rd.topline, rd.hide_quoted);
         }
         break;
+
+        //=======================================================================
 
       case OP_NEXT_LINE:
         if (rd.line_info[rd.curline].offset < (rd.sb.st_size - 1))
@@ -2707,6 +2671,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
           mutt_message(_("Bottom of message is shown"));
         break;
 
+        //=======================================================================
+
       case OP_PREV_LINE:
         if (rd.topline)
           rd.topline = up_n_lines(1, rd.line_info, rd.topline, rd.hide_quoted);
@@ -2714,12 +2680,16 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
           mutt_error(_("Top of message is shown"));
         break;
 
+        //=======================================================================
+
       case OP_PAGER_TOP:
         if (rd.topline)
           rd.topline = 0;
         else
           mutt_error(_("Top of message is shown"));
         break;
+
+        //=======================================================================
 
       case OP_HALF_UP:
         if (rd.topline)
@@ -2731,6 +2701,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         else
           mutt_error(_("Top of message is shown"));
         break;
+
+        //=======================================================================
 
       case OP_HALF_DOWN:
         if (rd.line_info[rd.curline].offset < (rd.sb.st_size - 1))
@@ -2750,6 +2722,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
           ch = -1;
         }
         break;
+
+        //=======================================================================
 
       case OP_SEARCH_NEXT:
       case OP_SEARCH_OPPOSITE:
@@ -2830,6 +2804,7 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         }
         /* no previous search pattern */
         /* fallthrough */
+        //=======================================================================
 
       case OP_SEARCH:
       case OP_SEARCH_REVERSE:
@@ -2961,6 +2936,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         pager_menu->redraw = REDRAW_BODY;
         break;
 
+        //=======================================================================
+
       case OP_SEARCH_TOGGLE:
         if (rd.search_compiled)
         {
@@ -2968,6 +2945,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
           pager_menu->redraw = REDRAW_BODY;
         }
         break;
+
+        //=======================================================================
 
       case OP_SORT:
       case OP_SORT_REVERSE:
@@ -2980,6 +2959,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
           rc = OP_DISPLAY_MESSAGE;
         }
         break;
+
+        //=======================================================================
 
       case OP_HELP:
         if (InHelp)
@@ -2995,6 +2976,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         InHelp = false;
         break;
 
+        //=======================================================================
+
       case OP_PAGER_HIDE_QUOTED:
         if (!rd.has_types)
           break;
@@ -3005,6 +2988,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         else
           pager_menu->redraw = REDRAW_BODY;
         break;
+
+        //=======================================================================
 
       case OP_PAGER_SKIP_QUOTED:
       {
@@ -3068,6 +3053,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         break;
       }
 
+        //=======================================================================
+
       case OP_PAGER_SKIP_HEADERS:
       {
         if (!rd.has_types)
@@ -3108,6 +3095,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         break;
       }
 
+        //=======================================================================
+
       case OP_PAGER_BOTTOM: /* move to the end of the file */
         if (rd.line_info[rd.curline].offset < (rd.sb.st_size - 1))
         {
@@ -3127,20 +3116,24 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
           mutt_error(_("Bottom of message is shown"));
         break;
 
+        //=======================================================================
+
       case OP_REDRAW:
         mutt_window_reflow(NULL);
         clearok(stdscr, true);
         pager_menu->redraw = REDRAW_FULL;
         break;
 
+        //=======================================================================
+
       case OP_NULL:
         km_error_key(MENU_PAGER);
         break;
 
-        /* --------------------------------------------------------------------
-         * The following are operations on the current message rather than
-         * adjusting the view of the message.  */
-
+      //=======================================================================
+      // The following are operations on the current message rather than
+      // adjusting the view of the message.
+      //=======================================================================
       case OP_BOUNCE_MESSAGE:
       {
         if (!assert_pager_mode(IsEmail(extra) || IsMsgAttach(extra)))
@@ -3159,6 +3152,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         break;
       }
 
+        //=======================================================================
+
       case OP_RESEND:
         if (!assert_pager_mode(IsEmail(extra) || IsMsgAttach(extra)))
           break;
@@ -3170,6 +3165,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
           mutt_resend_message(NULL, extra->ctx, extra->email, NeoMutt->sub);
         pager_menu->redraw = REDRAW_FULL;
         break;
+
+        //=======================================================================
 
       case OP_COMPOSE_TO_SENDER:
         if (!assert_pager_mode(IsEmail(extra) || IsMsgAttach(extra)))
@@ -3188,6 +3185,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         pager_menu->redraw = REDRAW_FULL;
         break;
 
+        //=======================================================================
+
       case OP_CHECK_TRADITIONAL:
         if (!assert_pager_mode(IsEmail(extra)))
           break;
@@ -3200,6 +3199,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         }
         break;
 
+        //=======================================================================
+
       case OP_CREATE_ALIAS:
         if (!assert_pager_mode(IsEmail(extra) || IsMsgAttach(extra)))
           break;
@@ -3210,6 +3211,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
           al = mutt_get_address(extra->email->env, NULL);
         alias_create(al, NeoMutt->sub);
         break;
+
+        //=======================================================================
 
       case OP_PURGE_MESSAGE:
       case OP_DELETE:
@@ -3240,6 +3243,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         break;
       }
 
+        //=======================================================================
+
       case OP_MAIN_SET_FLAG:
       case OP_MAIN_CLEAR_FLAG:
       {
@@ -3262,6 +3267,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         emaillist_clear(&el);
         break;
       }
+
+        //=======================================================================
 
       case OP_DELETE_THREAD:
       case OP_DELETE_SUBTHREAD:
@@ -3310,6 +3317,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         break;
       }
 
+        //=======================================================================
+
       case OP_DISPLAY_ADDRESS:
         if (!assert_pager_mode(IsEmail(extra) || IsMsgAttach(extra)))
           break;
@@ -3318,6 +3327,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         else
           mutt_display_address(extra->email->env);
         break;
+
+        //=======================================================================
 
       case OP_ENTER_COMMAND:
         old_PagerIndexLines = c_pager_index_lines;
@@ -3349,6 +3360,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         ch = 0;
         break;
 
+        //=======================================================================
+
       case OP_FLAG_MESSAGE:
       {
         if (!assert_pager_mode(IsEmail(extra)))
@@ -3370,6 +3383,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         break;
       }
 
+        //=======================================================================
+
       case OP_PIPE:
         if (!assert_pager_mode(IsEmail(extra) || IsAttach(extra)))
           break;
@@ -3383,6 +3398,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
           emaillist_clear(&el);
         }
         break;
+
+        //=======================================================================
 
       case OP_PRINT:
         if (!assert_pager_mode(IsEmail(extra) || IsAttach(extra)))
@@ -3398,6 +3415,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         }
         break;
 
+        //=======================================================================
+
       case OP_MAIL:
         if (!assert_pager_mode(IsEmail(extra)))
           break;
@@ -3406,6 +3425,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         mutt_send_message(SEND_NO_FLAGS, NULL, NULL, extra->ctx, NULL, NeoMutt->sub);
         pager_menu->redraw = REDRAW_FULL;
         break;
+
+        //=======================================================================
 
 #ifdef USE_NNTP
       case OP_POST:
@@ -3425,6 +3446,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         pager_menu->redraw = REDRAW_FULL;
         break;
       }
+
+        //=======================================================================
 
       case OP_FORWARD_TO_GROUP:
       {
@@ -3452,6 +3475,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         pager_menu->redraw = REDRAW_FULL;
         break;
       }
+
+        //=======================================================================
 
       case OP_FOLLOWUP:
         if (!assert_pager_mode(IsEmail(extra) || IsMsgAttach(extra)))
@@ -3493,6 +3518,9 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
           pager_menu->redraw = REDRAW_FULL;
           break;
         }
+
+        //=======================================================================
+
 #endif
       /* fallthrough */
       case OP_REPLY:
@@ -3526,6 +3554,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         break;
       }
 
+        //=======================================================================
+
       case OP_RECALL_MESSAGE:
       {
         if (!assert_pager_mode(IsEmail(extra)))
@@ -3539,6 +3569,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         pager_menu->redraw = REDRAW_FULL;
         break;
       }
+
+        //=======================================================================
 
       case OP_FORWARD_MESSAGE:
         if (!assert_pager_mode(IsEmail(extra) || IsMsgAttach(extra)))
@@ -3558,13 +3590,17 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         pager_menu->redraw = REDRAW_FULL;
         break;
 
+        //=======================================================================
+
       case OP_DECRYPT_SAVE:
         if (!WithCrypto)
         {
           ch = -1;
           break;
         }
-      /* fallthrough */
+        /* fallthrough */
+        //=======================================================================
+
       case OP_SAVE:
         if (IsAttach(extra))
         {
@@ -3572,7 +3608,9 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
                                     extra->email, NULL);
           break;
         }
-      /* fallthrough */
+        /* fallthrough */
+        //=======================================================================
+
       case OP_COPY_MESSAGE:
       case OP_DECODE_SAVE:
       case OP_DECODE_COPY:
@@ -3614,12 +3652,16 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         break;
       }
 
+        //=======================================================================
+
       case OP_SHELL_ESCAPE:
         if (mutt_shell_escape())
         {
           mutt_mailbox_check(m, MUTT_MAILBOX_CHECK_FORCE);
         }
         break;
+
+        //=======================================================================
 
       case OP_TAG:
       {
@@ -3636,6 +3678,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         }
         break;
       }
+
+        //=======================================================================
 
       case OP_TOGGLE_NEW:
       {
@@ -3664,6 +3708,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         break;
       }
 
+        //=======================================================================
+
       case OP_UNDELETE:
       {
         if (!assert_pager_mode(IsEmail(extra)))
@@ -3687,6 +3733,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         }
         break;
       }
+
+        //=======================================================================
 
       case OP_UNDELETE_THREAD:
       case OP_UNDELETE_SUBTHREAD:
@@ -3728,13 +3776,19 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         break;
       }
 
+        //=======================================================================
+
       case OP_VERSION:
         mutt_message(mutt_make_version());
         break;
 
+        //=======================================================================
+
       case OP_MAILBOX_LIST:
         mutt_mailbox_list();
         break;
+
+        //=======================================================================
 
       case OP_VIEW_ATTACHMENTS:
         if (flags & MUTT_PAGER_ATTACHMENT)
@@ -3750,6 +3804,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
           m->changed = true;
         pager_menu->redraw = REDRAW_FULL;
         break;
+
+        //=======================================================================
 
       case OP_MAIL_KEY:
       {
@@ -3769,6 +3825,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         pager_menu->redraw = REDRAW_FULL;
         break;
       }
+
+        //=======================================================================
 
       case OP_EDIT_LABEL:
       {
@@ -3793,9 +3851,13 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         break;
       }
 
+        //=======================================================================
+
       case OP_FORGET_PASSPHRASE:
         crypt_forget_passphrase();
         break;
+
+        //=======================================================================
 
       case OP_EXTRACT_KEYS:
       {
@@ -3814,13 +3876,19 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         break;
       }
 
+        //=======================================================================
+
       case OP_WHAT_KEY:
         mutt_what_key();
         break;
 
+        //=======================================================================
+
       case OP_CHECK_STATS:
         mutt_check_stats(m);
         break;
+
+        //=======================================================================
 
 #ifdef USE_SIDEBAR
       case OP_SIDEBAR_FIRST:
@@ -3840,10 +3908,14 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         break;
       }
 
+        //=======================================================================
+
       case OP_SIDEBAR_TOGGLE_VISIBLE:
         bool_str_toggle(NeoMutt->sub, "sidebar_visible", NULL);
         mutt_window_reflow(dialog_find(rd.extra->win_pager));
         break;
+
+        //=======================================================================
 #endif
 
       default:

--- a/pager/pager.c
+++ b/pager/pager.c
@@ -190,8 +190,6 @@ struct PagerRedrawData
 static int TopLine = 0;
 static struct Email *OldEmail = NULL;
 
-static bool InHelp = false;
-
 static int braille_line = -1;
 static int braille_col = -1;
 
@@ -2314,11 +2312,12 @@ static const struct Mapping *pager_resolve_help_mapping(enum PagerMode mode, enu
         result = PagerNormalHelp;
       break;
 
+    case PAGER_MODE_HELP:
+      result = PagerHelpHelp;
+      break;
+
     case PAGER_MODE_OTHER:
-      if (InHelp)
-        result = PagerHelpHelp;
-      else
-        result = PagerHelp;
+      result = PagerHelp;
       break;
 
     case PAGER_MODE_UNKNOWN:
@@ -2394,6 +2393,7 @@ int mutt_pager(struct PagerView *pview)
       }
       break;
 
+    case PAGER_MODE_HELP:
     case PAGER_MODE_OTHER:
       assert(!pview->pdata->email);
       assert(!pview->pdata->body);
@@ -3075,17 +3075,14 @@ int mutt_pager(struct PagerView *pview)
         //=======================================================================
 
       case OP_HELP:
-        if (InHelp)
+        if (pview->mode == PAGER_MODE_HELP)
         {
           /* don't let the user enter the help-menu from the help screen! */
           mutt_error(_("Help is currently being shown"));
           break;
         }
-
-        InHelp = true;
         mutt_help(MENU_PAGER);
         pager_menu->redraw = REDRAW_FULL;
-        InHelp = false;
         break;
 
         //=======================================================================

--- a/pager/pager.c
+++ b/pager/pager.c
@@ -180,7 +180,7 @@ struct PagerRedrawData
   bool search_compiled;
   PagerFlags search_flag;
   bool search_back;
-  char *searchbuf;
+  char searchbuf[256];
   struct Line *line_info;
   FILE *fp;
   struct stat sb;
@@ -2393,8 +2393,6 @@ int mutt_pager(struct PagerView *pview)
 
   struct Menu *pager_menu = NULL;
   struct PagerRedrawData rd = { 0 };
-  static char searchbuf[256] = { 0 };
-
   char buf[1024] = { 0 };
   int ch = 0;
   int rc = -1;
@@ -2457,7 +2455,6 @@ int mutt_pager(struct PagerView *pview)
   rd.pview = pview;
   rd.indexlen = c_pager_index_lines;
   rd.indicator = rd.indexlen / 3;
-  rd.searchbuf = searchbuf;
   rd.max_line = LINES; // number of lines on screen, from curses
   rd.line_info = mutt_mem_calloc(rd.max_line, sizeof(struct Line));
   rd.fp = fopen(pview->pdata->fname, "r");
@@ -2917,7 +2914,7 @@ int mutt_pager(struct PagerView *pview)
 
       case OP_SEARCH:
       case OP_SEARCH_REVERSE:
-        mutt_str_copy(buf, searchbuf, sizeof(buf));
+        mutt_str_copy(buf, rd.searchbuf, sizeof(buf));
         if (mutt_get_field(((ch == OP_SEARCH) || (ch == OP_SEARCH_NEXT)) ?
                                _("Search for: ") :
                                _("Reverse search for: "),
@@ -2927,7 +2924,7 @@ int mutt_pager(struct PagerView *pview)
           break;
         }
 
-        if (strcmp(buf, searchbuf) == 0)
+        if (strcmp(buf, rd.searchbuf) == 0)
         {
           if (rd.search_compiled)
           {
@@ -2945,7 +2942,7 @@ int mutt_pager(struct PagerView *pview)
         if (buf[0] == '\0')
           break;
 
-        mutt_str_copy(searchbuf, buf, sizeof(searchbuf));
+        mutt_str_copy(rd.searchbuf, buf, sizeof(rd.searchbuf));
 
         /* leave search_back alone if ch == OP_SEARCH_NEXT */
         if (ch == OP_SEARCH)
@@ -2963,8 +2960,8 @@ int mutt_pager(struct PagerView *pview)
           }
         }
 
-        uint16_t rflags = mutt_mb_is_lower(searchbuf) ? REG_ICASE : 0;
-        int err = REG_COMP(&rd.search_re, searchbuf, REG_NEWLINE | rflags);
+        uint16_t rflags = mutt_mb_is_lower(rd.searchbuf) ? REG_ICASE : 0;
+        int err = REG_COMP(&rd.search_re, rd.searchbuf, REG_NEWLINE | rflags);
         if (err != 0)
         {
           regerror(err, &rd.search_re, buf, sizeof(buf));

--- a/pager/pager.c
+++ b/pager/pager.c
@@ -2324,6 +2324,8 @@ int mutt_pager(struct PagerView *pview)
   assert(pview);
   assert((pview->mode > PAGER_MODE_UNKNOWN) && (pview->mode < PAGER_MODE_MAX));
   assert(pview->pdata); // view can't exist in a vacuum
+  assert(pview->win_pager);
+  assert(pview->win_pbar);
 
   switch (pview->mode)
   {
@@ -2387,105 +2389,34 @@ int mutt_pager(struct PagerView *pview)
       cs_subset_number(NeoMutt->sub, "skip_quoted_offset");
 
   //---------- local variables ------------------------------------------------
-  struct PagerRedrawData rd = { 0 };
-  struct Menu *pager_menu = NULL;
   struct Mailbox *m = pview->pdata->ctx ? pview->pdata->ctx->mailbox : NULL;
 
+  struct Menu *pager_menu = NULL;
+  struct PagerRedrawData rd = { 0 };
   static char searchbuf[256] = { 0 };
-#ifdef USE_NNTP
-  char *followup_to = NULL;
-#endif
-  char buf[1024];
 
+  char buf[1024] = { 0 };
   int ch = 0;
   int rc = -1;
   int searchctx = 0;
   int index_space = m ? MIN(c_pager_index_lines, m->vcount) : c_pager_index_lines;
   int old_PagerIndexLines = index_space; // some people want to resize it while inside the pager
-
   bool first = true;
   bool wrapped = false;
 
-  //---------- initialize pager view  -----------------------------------------
+#ifdef USE_NNTP
+  char *followup_to = NULL;
+#endif
 
-  rd.pview = pview;
-  rd.indexlen = c_pager_index_lines;
-  rd.indicator = rd.indexlen / 3;
-  rd.searchbuf = searchbuf;
-  rd.fp = fopen(pview->pdata->fname, "r");
-  rd.has_types = ((pview->mode == PAGER_MODE_EMAIL) || (pview->flags & MUTT_SHOWCOLOR)) ?
-                     MUTT_TYPES :
-                     0; // main message or rfc822 attachment
-
-  if (!rd.fp)
-  {
-    mutt_perror(pview->pdata->fname);
-    return -1;
-  }
-
-  if (stat(pview->pdata->fname, &rd.sb) != 0)
-  {
-    mutt_perror(pview->pdata->fname);
-    mutt_file_fclose(&rd.fp);
-    return -1;
-  }
-  unlink(pview->pdata->fname);
-
+  //---------- setup flags ----------------------------------------------------
   if (!(pview->flags & MUTT_SHOWCOLOR))
     pview->flags |= MUTT_SHOWFLAT;
-
-  if (rd.pview->win_index)
-  {
-    rd.pview->win_index->size = MUTT_WIN_SIZE_FIXED;
-    rd.pview->win_index->req_rows = index_space;
-    rd.pview->win_index->parent->size = MUTT_WIN_SIZE_MINIMISE;
-    window_set_visible(rd.pview->win_index->parent, (index_space > 0));
-  }
-  window_set_visible(rd.pview->win_pager->parent, true);
-  rd.pview->win_pager->size = MUTT_WIN_SIZE_MAXIMISE;
-  mutt_window_reflow(dialog_find(rd.pview->win_pager));
 
   if (pview->mode == PAGER_MODE_EMAIL && !pview->pdata->email->read)
   {
     pview->pdata->ctx->msg_in_pager = pview->pdata->email->msgno;
     mutt_set_flag(m, pview->pdata->email, MUTT_READ, true);
   }
-  rd.max_line = LINES; // number of lines on screen, from curses
-  rd.line_info = mutt_mem_calloc(rd.max_line, sizeof(struct Line));
-
-  for (size_t i = 0; i < rd.max_line; i++)
-  {
-    rd.line_info[i].type = -1;
-    rd.line_info[i].search_cnt = -1;
-    rd.line_info[i].syntax = mutt_mem_malloc(sizeof(struct TextSyntax));
-    (rd.line_info[i].syntax)[0].first = -1;
-    (rd.line_info[i].syntax)[0].last = -1;
-  }
-
-  //---------- setup pager menu------------------------------------------------
-  pager_menu = mutt_menu_new(MENU_PAGER);
-  pager_menu->pagelen = pview->win_pager->state.rows;
-  pager_menu->win_index = pview->win_pager;
-  pager_menu->win_ibar = pview->win_pbar;
-  pager_menu->custom_redraw = pager_custom_redraw;
-  pager_menu->redraw_data = &rd;
-  mutt_menu_push_current(pager_menu);
-
-  //---------- restore global state if needed ---------------------------------
-  while (pview->mode == PAGER_MODE_EMAIL && (OldEmail == pview->pdata->email) // are we "resuming" to the same Email?
-         && (TopLine != rd.topline) // is saved offset different?
-         && rd.line_info[rd.curline].offset < (rd.sb.st_size - 1))
-  {
-    // needed to avoid SIGSEGV
-    pager_custom_redraw(pager_menu);
-    // trick user, as if nothing happened
-    // scroll down to previosly saved offset
-    rd.topline = ((TopLine - rd.topline) > rd.lines) ? rd.topline + rd.lines : TopLine;
-  }
-
-  TopLine = 0;
-  OldEmail = NULL;
-
   //---------- setup help menu ------------------------------------------------
 
   switch (pview->mode)
@@ -2520,6 +2451,78 @@ int mutt_pager(struct PagerView *pview)
   }
 
   pview->win_pager->help_menu = MENU_PAGER;
+
+  //---------- initialize redraw pdata  -----------------------------------------
+  pview->win_pager->size = MUTT_WIN_SIZE_MAXIMISE;
+  rd.pview = pview;
+  rd.indexlen = c_pager_index_lines;
+  rd.indicator = rd.indexlen / 3;
+  rd.searchbuf = searchbuf;
+  rd.max_line = LINES; // number of lines on screen, from curses
+  rd.line_info = mutt_mem_calloc(rd.max_line, sizeof(struct Line));
+  rd.fp = fopen(pview->pdata->fname, "r");
+  rd.has_types = ((pview->mode == PAGER_MODE_EMAIL) || (pview->flags & MUTT_SHOWCOLOR)) ?
+                     MUTT_TYPES :
+                     0; // main message or rfc822 attachment
+
+  for (size_t i = 0; i < rd.max_line; i++)
+  {
+    rd.line_info[i].type = -1;
+    rd.line_info[i].search_cnt = -1;
+    rd.line_info[i].syntax = mutt_mem_malloc(sizeof(struct TextSyntax));
+    (rd.line_info[i].syntax)[0].first = -1;
+    (rd.line_info[i].syntax)[0].last = -1;
+  }
+
+  // ---------- try to open the pdata file -------------------------------------
+  if (!rd.fp)
+  {
+    mutt_perror(pview->pdata->fname);
+    return -1;
+  }
+
+  if (stat(pview->pdata->fname, &rd.sb) != 0)
+  {
+    mutt_perror(pview->pdata->fname);
+    mutt_file_fclose(&rd.fp);
+    return -1;
+  }
+  unlink(pview->pdata->fname);
+
+  //---------- setup pager menu------------------------------------------------
+  pager_menu = mutt_menu_new(MENU_PAGER);
+  pager_menu->pagelen = pview->win_pager->state.rows;
+  pager_menu->win_index = pview->win_pager;
+  pager_menu->win_ibar = pview->win_pbar;
+  pager_menu->custom_redraw = pager_custom_redraw;
+  pager_menu->redraw_data = &rd;
+  mutt_menu_push_current(pager_menu);
+
+  //---------- restore global state if needed ---------------------------------
+  while (pview->mode == PAGER_MODE_EMAIL && (OldEmail == pview->pdata->email) // are we "resuming" to the same Email?
+         && (TopLine != rd.topline) // is saved offset different?
+         && rd.line_info[rd.curline].offset < (rd.sb.st_size - 1))
+  {
+    // needed to avoid SIGSEGV
+    pager_custom_redraw(pager_menu);
+    // trick user, as if nothing happened
+    // scroll down to previosly saved offset
+    rd.topline = ((TopLine - rd.topline) > rd.lines) ? rd.topline + rd.lines : TopLine;
+  }
+
+  TopLine = 0;
+  OldEmail = NULL;
+
+  //---------- show windows, set focus and visibility --------------------------
+  if (rd.pview->win_index)
+  {
+    rd.pview->win_index->size = MUTT_WIN_SIZE_FIXED;
+    rd.pview->win_index->req_rows = index_space;
+    rd.pview->win_index->parent->size = MUTT_WIN_SIZE_MINIMISE;
+    window_set_visible(rd.pview->win_index->parent, (index_space > 0));
+  }
+  window_set_visible(rd.pview->win_pager->parent, true);
+  mutt_window_reflow(dialog_find(rd.pview->win_pager));
   window_set_focus(pview->win_pager);
 
   //-------------------------------------------------------------------------

--- a/send/sendmail.c
+++ b/send/sendmail.c
@@ -434,8 +434,16 @@ int mutt_invoke_sendmail(struct Mailbox *m, struct AddressList *from,
 
         if ((stat(childout, &st) == 0) && (st.st_size > 0))
         {
-          mutt_do_pager(_("Output of the delivery process"), childout,
-                        MUTT_PAGER_NO_FLAGS, NULL);
+          struct PagerData pdata = { 0 };
+          struct PagerView pview = { &pdata };
+
+          pdata.fname = childout;
+
+          pview.banner = _("Output of the delivery process");
+          pview.flags = MUTT_PAGER_NO_FLAGS;
+          pview.mode = PAGER_MODE_OTHER;
+
+          mutt_do_pager(&pview);
         }
       }
     }


### PR DESCRIPTION
* **What does this PR do?**

Begins monumental pager refactoring:
- introduces `PagerMode` enum
- removes `IsEmail`, `IsAttach` and `IsMsgAttach` macros
- splits `struct Pager` into `struct PagerData` and `struct PagerView`
- does some code readability improvements that help @ngortheone to stay a bit more sane
- adds tons of comments


