### PR TITLE
Provide a mean to turn off wrapping output of mailcap commands

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -378,7 +378,7 @@ int mutt_display_message(struct MuttWindow *win_index, struct MuttWindow *win_ib
 
     pview.mode = PAGER_MODE_EMAIL;
     pview.banner = NULL;
-    pview.flags = MUTT_PAGER_MESSAGE;
+    pview.flags = MUTT_PAGER_MESSAGE | (e->body->nowrap ? MUTT_PAGER_NOWRAP : 0);
     pview.win_ibar = win_ibar;
     pview.win_index = win_index;
     pview.win_pbar = win_pbar;

--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -10895,6 +10895,18 @@ text/html; lynx %s
                 <screen>text/html; firefox %s &amp; x-neomutt-keep</screen>
               </listitem>
             </varlistentry>
+            <varlistentry>
+              <term>x-neomutt-nowrap</term>
+              <listitem>
+                <para>
+                  <literal>x-neomutt-nowrap</literal> tells the NeoMutt pager
+                  to ignore the <link linked="wrap">$wrap</link> parameter and
+                  to assume the output from the mailcap command to already be
+                  correctly wrapped.
+                </para>
+                <screen>text/html; /usr/local/bin/w3m -s -T text/html -o display_link_number=1 %s; nametemplate=%s.html; copiousoutput; x-neomutt-nowrap;</screen>
+              </listitem>
+            </varlistentry>
           </variablelist>
         </sect3>
 

--- a/email/body.h
+++ b/email/body.h
@@ -71,6 +71,7 @@ struct Body
   bool deleted : 1;               ///< Attachment marked for deletion
 
   bool noconv : 1;                ///< Don't do character set conversion
+  bool nowrap : 1;                ///< Do not wrap the output in the pager
   bool force_charset : 1;         ///< Send mode: don't adjust the character set when in send-mode.
   bool goodsig : 1;               ///< Good cryptographic signature
   bool warnsig : 1;               ///< Maybe good signature

--- a/handler.c
+++ b/handler.c
@@ -927,6 +927,7 @@ static int external_body_handler(struct Body *b, struct State *s)
  */
 static int alternative_handler(struct Body *a, struct State *s)
 {
+  struct Body *const head = a;
   struct Body *choice = NULL;
   struct Body *b = NULL;
   bool mustfree = false;
@@ -1068,6 +1069,10 @@ static int alternative_handler(struct Body *a, struct State *s)
       print_part_line(s, choice, 0);
     }
     mutt_body_handler(choice, s);
+
+    /* Let it flow back to the main part */
+    head->nowrap = choice->nowrap;
+    choice->nowrap = false;
 
     if (mutt_str_equal("info", c_show_multipart_alternative))
     {

--- a/mailcap.c
+++ b/mailcap.c
@@ -375,6 +375,11 @@ static bool rfc1524_mailcap_parse(struct Body *a, const char *filename, const ch
           if (entry)
             entry->xneomuttkeep = true;
         }
+        else if (mutt_istr_startswith(field, "x-neomutt-nowrap"))
+        {
+          if (entry)
+            entry->xneomuttnowrap = true;
+        }
       } /* while (ch) */
 
       if (opt == MUTT_MC_AUTOVIEW)

--- a/mailcap.c
+++ b/mailcap.c
@@ -379,6 +379,7 @@ static bool rfc1524_mailcap_parse(struct Body *a, const char *filename, const ch
         {
           if (entry)
             entry->xneomuttnowrap = true;
+          a->nowrap = true;
         }
       } /* while (ch) */
 

--- a/mailcap.h
+++ b/mailcap.h
@@ -45,6 +45,7 @@ struct MailcapEntry
   bool needsterminal : 1; ///< endwin() and system
   bool copiousoutput : 1; ///< needs pager, basically
   bool xneomuttkeep  : 1; ///< do not remove the file on command exit
+  bool xneomuttnowrap: 1; ///< do not wrap the output in the pager
 };
 
 /**

--- a/mutt_attach.c
+++ b/mutt_attach.c
@@ -666,7 +666,7 @@ int mutt_view_attachment(FILE *fp, struct Body *a, enum ViewAttachMode mode,
     pview.banner = desc;
     pview.flags = MUTT_PAGER_ATTACHMENT |
                   (is_message ? MUTT_PAGER_MESSAGE : MUTT_PAGER_NO_FLAGS) |
-                  (use_mailcap ? MUTT_PAGER_NOWRAP : MUTT_PAGER_NO_FLAGS);
+                  (use_mailcap && entry->xneomuttnowrap ? MUTT_PAGER_NOWRAP : MUTT_PAGER_NO_FLAGS);
     pview.mode = PAGER_MODE_ATTACH;
 
     rc = mutt_do_pager(&pview);

--- a/mutt_attach.c
+++ b/mutt_attach.c
@@ -665,7 +665,8 @@ int mutt_view_attachment(FILE *fp, struct Body *a, enum ViewAttachMode mode,
 
     pview.banner = desc;
     pview.flags = MUTT_PAGER_ATTACHMENT |
-                  (is_message ? MUTT_PAGER_MESSAGE : MUTT_PAGER_NO_FLAGS);
+                  (is_message ? MUTT_PAGER_MESSAGE : MUTT_PAGER_NO_FLAGS) |
+                  (use_mailcap ? MUTT_PAGER_NOWRAP : MUTT_PAGER_NO_FLAGS);
     pview.mode = PAGER_MODE_ATTACH;
 
     rc = mutt_do_pager(&pview);

--- a/mutt_attach.c
+++ b/mutt_attach.c
@@ -666,7 +666,8 @@ int mutt_view_attachment(FILE *fp, struct Body *a, enum ViewAttachMode mode,
     pview.banner = desc;
     pview.flags = MUTT_PAGER_ATTACHMENT |
                   (is_message ? MUTT_PAGER_MESSAGE : MUTT_PAGER_NO_FLAGS) |
-                  (use_mailcap && entry->xneomuttnowrap ? MUTT_PAGER_NOWRAP : MUTT_PAGER_NO_FLAGS);
+                  ((use_mailcap && entry->xneomuttnowrap) ? MUTT_PAGER_NOWRAP :
+                                                            MUTT_PAGER_NO_FLAGS);
     pview.mode = PAGER_MODE_ATTACH;
 
     rc = mutt_do_pager(&pview);


### PR DESCRIPTION
* **What does this PR do?**

~Disable wrapping in the pager if the data is being generated by a mailcap command.~

This implements a new mailcap extension flag, `x-neomutt-nowrap`, to disable wrapping in the pager for particular mailcap entries.