### PR TITLE
Cleanup account data when closing the last mailbox

### DIFF
--- a/core/account.c
+++ b/core/account.c
@@ -105,6 +105,7 @@ bool account_mailbox_remove(struct Account *a, struct Mailbox *m)
       struct EventMailbox ev_m = { m };
       notify_send(a->notify, NT_MAILBOX, NT_MAILBOX_REMOVE, &ev_m);
       STAILQ_REMOVE(&a->mailboxes, np, MailboxNode, entries);
+      notify_set_parent(np->mailbox->notify, NULL);
       if (!m)
         mailbox_free(&np->mailbox);
       FREE(&np);

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -1249,6 +1249,7 @@ int imap_path_status(const char *path, bool queue)
   if (is_temp)
   {
     mx_ac_remove(m);
+    mailbox_free(&m);
   }
 
   return rc;

--- a/mx.c
+++ b/mx.c
@@ -474,6 +474,11 @@ void mx_fastclose_mailbox(struct Mailbox *m)
       email_free(&m->emails[i]);
     }
   }
+
+  if (m->flags & MB_HIDDEN)
+  {
+    mx_ac_remove(m);
+  }
 }
 
 /**
@@ -1793,6 +1798,7 @@ bool mx_ac_add(struct Account *a, struct Mailbox *m)
 /**
  * mx_ac_remove - Remove a Mailbox from an Account and delete Account if empty
  * @param m Mailbox to remove
+ * @note The mailbox is NOT free'd
  */
 int mx_ac_remove(struct Mailbox *m)
 {
@@ -1801,7 +1807,6 @@ int mx_ac_remove(struct Mailbox *m)
 
   struct Account *a = m->account;
   account_mailbox_remove(m->account, m);
-  mailbox_free(&m);
   if (STAILQ_EMPTY(&a->mailboxes))
   {
     neomutt_account_remove(NeoMutt, a);


### PR DESCRIPTION
Imagine the sequence `unmailboxes *`; `change-folder`. The currently open
mailbox cannot be removed by `unmailboxes *`, which only marks it as
hidden. Then, on `change-folder`, the current mailbox is closed, but
nobody notifies the Account that the mailbox is gone, so in case of IMAP
the connection to the old server stays around.