### PR TITLE
config: fix a couple of small bugs

### DIFF
--- a/docs/config.c
+++ b/docs/config.c
@@ -1066,7 +1066,7 @@
 ** ignored for interoperability reasons.
 */
 
-{ "editor", DT_COMMAND, "vi" },
+{ "editor", DT_COMMAND, 0 },
 /*
 ** .pp
 ** This variable specifies which editor is used by NeoMutt.

--- a/docs/config.c
+++ b/docs/config.c
@@ -5307,15 +5307,6 @@
 */
 #endif
 
-{ "visual", DT_COMMAND, "vi" },
-/*
-** .pp
-** Specifies the visual editor to invoke when the "\fC~v\fP" command is
-** given in the built-in editor.
-** .pp
-** $$visual is overridden by the environment variable \fC$$$VISUAL\fP or \fC$$$EDITOR\fP.
-*/
-
 { "wait_key", DT_BOOL, true },
 /*
 ** .pp

--- a/init.c
+++ b/init.c
@@ -800,11 +800,13 @@ int mutt_init(struct ConfigSet *cs, bool skip_sys_rc, struct ListHead *commands)
   const char *env_ed = mutt_str_getenv("VISUAL");
   if (!env_ed)
     env_ed = mutt_str_getenv("EDITOR");
-  if (env_ed)
-  {
-    cs_str_string_set(cs, "editor", env_ed, NULL);
-    cs_str_string_set(cs, "visual", env_ed, NULL);
-  }
+  if (!env_ed)
+    env_ed = "vi";
+  cs_str_initial_set(cs, "editor", env_ed, NULL);
+
+  const char *c_editor = cs_subset_string(NeoMutt->sub, "editor");
+  if (!c_editor)
+    cs_str_reset(cs, "editor", NULL);
 
   C_Charset = mutt_ch_get_langinfo_charset();
   cs_str_initial_set(cs, "charset", C_Charset, NULL);

--- a/mutt_config.c
+++ b/mutt_config.c
@@ -75,6 +75,7 @@
 /* These options are deprecated */
 char *C_Escape = NULL;
 bool C_IgnoreLinearWhiteSpace = false;
+char *C_Visual;
 
 /**
  * SortAuxMethods - Sort methods for '$sort_aux' for the index
@@ -689,9 +690,6 @@ struct ConfigDef MainVars[] = {
   { "use_domain", DT_BOOL, &C_UseDomain, true, 0, NULL,
     "Qualify local addresses using this domain"
   },
-  { "visual", DT_STRING|DT_COMMAND, &C_Visual, IP "vi", 0, NULL,
-    "Editor to use when '~v' is given in the built-in editor"
-  },
   { "wait_key", DT_BOOL, &C_WaitKey, true, 0, NULL,
     "Prompt to press a key after running external commands"
   },
@@ -711,8 +709,9 @@ struct ConfigDef MainVars[] = {
     "Update the progress bar after this many records written (0 to disable)"
   },
 
-  { "escape", DT_DEPRECATED|DT_STRING, &C_Escape, IP "~" },
-  { "ignore_linear_white_space", DT_DEPRECATED|DT_BOOL, &C_IgnoreLinearWhiteSpace, false },
+  { "escape",                    DT_DEPRECATED|DT_STRING,            &C_Escape,                 IP "~" },
+  { "ignore_linear_white_space", DT_DEPRECATED|DT_BOOL,              &C_IgnoreLinearWhiteSpace, false },
+  { "visual",                    DT_DEPRECATED|DT_STRING|DT_COMMAND, &C_Visual,                 0 },
 
   { "askbcc",                    DT_SYNONYM, NULL, IP "ask_bcc",                    },
   { "askcc",                     DT_SYNONYM, NULL, IP "ask_cc",                     },

--- a/mutt_config.c
+++ b/mutt_config.c
@@ -314,7 +314,7 @@ struct ConfigDef MainVars[] = {
   { "duplicate_threads", DT_BOOL|R_RESORT|R_RESORT_INIT|R_INDEX, &C_DuplicateThreads, true, 0, pager_validator,
     "Highlight messages with duplicated message IDs"
   },
-  { "editor", DT_STRING|DT_NOT_EMPTY|DT_COMMAND, &C_Editor, IP "vi", 0, NULL,
+  { "editor", DT_STRING|DT_NOT_EMPTY|DT_COMMAND, &C_Editor, 0, 0, NULL,
     "External command to use as an email editor"
   },
   { "flag_chars", DT_MBTABLE|R_INDEX|R_PAGER, &C_FlagChars, IP "*!DdrONon- ", 0, NULL,

--- a/mutt_globals.h
+++ b/mutt_globals.h
@@ -110,7 +110,6 @@ WHERE char *C_SpoolFile;                     ///< Config: Inbox
 WHERE char *C_StatusFormat;                  ///< Config: printf-like format string for the index's status line
 WHERE char *C_TsStatusFormat;                ///< Config: printf-like format string for the terminal's status (window title)
 WHERE char *C_TsIconFormat;                  ///< Config: printf-like format string for the terminal's icon title
-WHERE char *C_Visual;                        ///< Config: Editor to use when '~v' is given in the built-in editor
 
 WHERE short C_SleepTime;                     ///< Config: Time to pause after certain info messages
 WHERE short C_Timeout;                       ///< Config: Time to wait for user input in menus

--- a/send/send.c
+++ b/send/send.c
@@ -106,11 +106,19 @@ static void append_signature(FILE *fp, struct ConfigSubset *sub)
   if (!c_signature)
     return;
 
+  // If the user hasn't set $signature, don't warn them if it doesn't exist
+  struct Buffer *def_sig = mutt_buffer_pool_get();
+  cs_str_initial_get(sub->cs, "signature", def_sig);
+  mutt_path_canon(def_sig->data, def_sig->dsize, HomeDir, false);
+  bool notify_missing = !mutt_str_equal(c_signature, mutt_buffer_string(def_sig));
+  mutt_buffer_pool_release(&def_sig);
+
   pid_t pid = 0;
   FILE *fp_tmp = mutt_open_read(c_signature, &pid);
   if (!fp_tmp)
   {
-    mutt_perror(c_signature);
+    if (notify_missing)
+      mutt_perror(c_signature);
     return;
   }
 


### PR DESCRIPTION
- 619f926b18 config: deprecate $visual
  Config variable hasn't been used in a long time

- 16923700c4 config: fix editor defaults
  `$EDITOR` env var wasn't being honoured, when `$editor` neomutt config wasn't set

- 3d42e5706d config: fix signature warning
  Only warn about a missing signature file **IF** the user set the config