### PR TITLE
Allow a -noregex param to folder and mbox hooks

### DIFF
--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -4559,8 +4559,11 @@ bind index gg first-entry
       </para>
       <cmdsynopsis>
         <command>folder-hook</command>
+        <arg choice="opt">
+          <replaceable class="parameter">-noregex</replaceable>
+        </arg>
         <arg choice="plain">
-          <replaceable class="parameter">regex</replaceable>
+          <replaceable class="parameter">pattern</replaceable>
         </arg>
         <arg choice="plain">
           <replaceable class="parameter">command</replaceable>
@@ -4570,9 +4573,11 @@ bind index gg first-entry
         It is often desirable to change settings based on which mailbox you are
         reading. The <command>folder-hook</command> command provides a method
         by which you can execute any configuration command.
-        <emphasis>regex</emphasis> is a regular expression specifying in which
-        mailboxes to execute <emphasis>command</emphasis> before loading. If
-        a mailbox matches multiple <command>folder-hook</command>s, they are
+        The <emphasis>command</emphasis> is executed before loading any mailboxes
+        matching <emphasis>pattern</emphasis>. The <emphasis>-noregex</emphasis>
+        switch controls whether <emphasis>pattern</emphasis> is matched using
+        a simple string comparison or a full regex match.
+        If a mailbox matches multiple <command>folder-hook</command>s, they are
         executed in the order given in the <literal>.neomuttrc</literal>.
       </para>
       <para>
@@ -5848,8 +5853,11 @@ unignore posted-to:
       </para>
       <cmdsynopsis>
         <command>mbox-hook</command>
+        <arg choice="opt">
+          <replaceable class="parameter">-noregex</replaceable>
+        </arg>
         <arg choice="plain">
-          <replaceable class="parameter">regex</replaceable>
+          <replaceable class="parameter">pattern</replaceable>
         </arg>
         <arg choice="plain">
           <replaceable class="parameter">mailbox</replaceable>
@@ -5858,10 +5866,12 @@ unignore posted-to:
       <para>
         This command is used to move read messages from a specified mailbox to
         a different mailbox automatically when you quit or change folders.
-        <emphasis>regex</emphasis> is a regular expression specifying the
-        mailbox to treat as a <quote>spool</quote> mailbox and
-        <emphasis>mailbox</emphasis> specifies where mail should be saved when
-        read.
+        <emphasis>pattern</emphasis> is used to specifying the mailbox to
+        treat as a <quote>spool</quote> mailbox and <emphasis>mailbox</emphasis>
+        specifies where mail should be saved when read.
+        The <emphasis>-noregex</emphasis> switch controls whether
+        <emphasis>pattern</emphasis> is matched using a simple string
+        comparison or a full regex match.
       </para>
       <para>
         The regex parameter has

--- a/docs/neomuttrc.man.head
+++ b/docs/neomuttrc.man.head
@@ -383,12 +383,13 @@ NeoMutt manual for information on the exact format of \fIpattern\fP.
 .
 .PP
 .nf
-\fBfolder-hook\fP \fIregex\fP \fIcommand\fP
+\fBfolder-hook\fP [\fI-noregex\fP] \fIpattern\fP \fIcommand\fP
 .fi
 .IP
-When NeoMutt enters a folder which matches \fIregex\fP (or, when \fIregex\fP is
-preceded by an exclamation mark, does not match \fIregex\fP), the given
-\fIcommand\fP is executed.
+When NeoMutt enters a folder which matches \fIpattern\fP (or, when \fIpattern\fP is
+preceded by an exclamation mark, does not match \fIpattern\fP), the given
+\fIcommand\fP is executed. The \fI-noregex\fP switch controls whether \fIpattern\fP
+is matches as simple string equality or full regex match.
 .IP
 When several \fBfolder-hook\fPs match a given mail folder, they are executed in
 the order given in the configuration file.
@@ -549,12 +550,14 @@ Changes the current working directory.
 .
 .PP
 .nf
-\fBmbox-hook\fP \fIregex\fP \fImailbox\fP
+\fBmbox-hook\fP [\fI-noregex\fP] \fIpattern\fP \fImailbox\fP
 .fi
 .IP
-When NeoMutt changes to a mail folder which matches \fIregex\fP, \fImailbox\fP
+When NeoMutt changes to a mail folder which matches \fIpattern\fP, \fImailbox\fP
 will be used as the \(lqmbox\(rq folder, i.e. read messages will be moved to
-that folder when the mail folder is left.
+that folder when the mail folder is left. The \fI-noregex\fP switch controls
+whether \fIpattern\fP is matches as simple string equality or full regex match.
+
 .IP
 Note that execution of \fBmbox-hook\fPs is dependent on the $move configuration
 variable. If set to \(lqno\(rq (the default), \fBmbox-hook\fPs will not be

--- a/hook.c
+++ b/hook.c
@@ -85,8 +85,10 @@ enum CommandResult mutt_parse_hook(struct Buffer *buf, struct Buffer *s,
   struct Hook *hook = NULL;
   int rc = MUTT_CMD_ERROR;
   bool pat_not = false;
+  bool use_regex = true;
   regex_t *rx = NULL;
   struct PatternList *pat = NULL;
+  const bool folder_or_mbox = (data & (MUTT_FOLDER_HOOK | MUTT_MBOX_HOOK));
 
   struct Buffer *cmd = mutt_buffer_pool_get();
   struct Buffer *pattern = mutt_buffer_pool_get();
@@ -101,6 +103,17 @@ enum CommandResult mutt_parse_hook(struct Buffer *buf, struct Buffer *s,
     }
 
     mutt_extract_token(pattern, s, MUTT_TOKEN_NO_FLAGS);
+    if (folder_or_mbox && mutt_str_equal(mutt_buffer_string(pattern), "-noregex"))
+    {
+      use_regex = false;
+      if (!MoreArgs(s))
+      {
+        mutt_buffer_printf(err, _("%s: too few arguments"), buf->data);
+        rc = MUTT_CMD_WARNING;
+        goto cleanup;
+      }
+      mutt_extract_token(pattern, s, MUTT_TOKEN_NO_FLAGS);
+    }
 
     if (!MoreArgs(s))
     {
@@ -132,7 +145,7 @@ enum CommandResult mutt_parse_hook(struct Buffer *buf, struct Buffer *s,
 
   const char *const c_default_hook =
       cs_subset_string(NeoMutt->sub, "default_hook");
-  if (data & (MUTT_FOLDER_HOOK | MUTT_MBOX_HOOK))
+  if (folder_or_mbox)
   {
     /* Accidentally using the ^ mailbox shortcut in the .neomuttrc is a
      * common mistake */
@@ -144,7 +157,7 @@ enum CommandResult mutt_parse_hook(struct Buffer *buf, struct Buffer *s,
 
     struct Buffer *tmp = mutt_buffer_pool_get();
     mutt_buffer_copy(tmp, pattern);
-    mutt_buffer_expand_path_regex(tmp, true);
+    mutt_buffer_expand_path_regex(tmp, use_regex);
 
     /* Check for other mailbox shortcuts that expand to the empty string.
      * This is likely a mistake too */
@@ -155,7 +168,14 @@ enum CommandResult mutt_parse_hook(struct Buffer *buf, struct Buffer *s,
       goto cleanup;
     }
 
-    mutt_buffer_copy(pattern, tmp);
+    if (use_regex)
+    {
+      mutt_buffer_copy(pattern, tmp);
+    }
+    else
+    {
+      mutt_file_sanitize_regex(pattern, mutt_buffer_string(tmp));
+    }
     mutt_buffer_pool_release(&tmp);
   }
 #ifdef USE_COMP_MBOX


### PR DESCRIPTION
This is helpful if we want to match mailbox that comes from a variable exactly (or we simply can't be bothered to escape the whole thingie).
As an example, in `folder-hook -noregex $trash set my_foo=bar` we don't want an expansion of `$trash` such as `imaps://user@gmail.com/[Gmail]/Trash` to be treated as a regex containing a character class `[Gmail]`.

An alternative approach would be to create different commands with an additional flag
```
{ "folder-hook-noregex",  mutt_parse_hook,  MUTT_FOLDER_HOOK | MUTT_HOOK_NOREGEX}`
```
and handle the flag in `mutt_parse_hook`. I'm fine with implementing either approach. 