### PR TITLE
Create Widescreen View - Index | Pager

### DIFF
--- a/docs/config.c
+++ b/docs/config.c
@@ -2767,6 +2767,13 @@
 ** $$pager_index_lines, then the index will only use as many lines as it needs.
 */
 
+{ "pager_columns", DT_NUMBER, 0 },
+/*
+** .pp
+** Determines the number of columns used by the the pager. This turns on
+** widescreen mode.
+*/
+
 { "pager_stop", DT_BOOL, false },
 /*
 ** .pp

--- a/index/index.c
+++ b/index/index.c
@@ -4189,10 +4189,16 @@ struct MuttWindow *index_pager_init(void)
   struct MuttWindow *dlg =
       mutt_window_new(WT_DLG_INDEX, MUTT_WIN_ORIENT_HORIZONTAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
+  struct MuttWindow *container =
+      mutt_window_new(WT_CONTAINER, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
+                      MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
 
   const bool c_status_on_top = cs_subset_bool(NeoMutt->sub, "status_on_top");
-  mutt_window_add_child(dlg, create_panel_index(dlg, c_status_on_top));
-  mutt_window_add_child(dlg, create_panel_pager(dlg, c_status_on_top));
+  mutt_window_add_child(container, create_panel_index(container, c_status_on_top));
+  mutt_window_add_child(container, create_panel_pager(container, c_status_on_top));
+
+  mutt_window_add_child(dlg, container);
+  dlg->focus = container;
 
   index_add_observers(dlg);
   return dlg;

--- a/pager/config.c
+++ b/pager/config.c
@@ -45,6 +45,9 @@ struct ConfigDef PagerVars[] = {
   { "pager_index_lines", DT_NUMBER|DT_NOT_NEGATIVE|R_PAGER|R_REFLOW, 0, 0, NULL,
     "Number of index lines to display above the pager"
   },
+  { "pager_columns", DT_NUMBER|DT_NOT_NEGATIVE|R_PAGER|R_REFLOW, NULL, 0, 0, NULL,
+    "Number of pager columns to display on the right side of the index"
+  },
   { "pager_stop", DT_BOOL, false, 0, NULL,
     "Don't automatically open the next message when at the end of a message"
   },

--- a/pager/pager.c
+++ b/pager/pager.c
@@ -2087,6 +2087,7 @@ static void pager_custom_redraw(struct Menu *pager_menu)
   const bool c_tilde = cs_subset_bool(NeoMutt->sub, "tilde");
   const short c_pager_index_lines =
       cs_subset_number(NeoMutt->sub, "pager_index_lines");
+  const short c_pager_columns = cs_subset_number(NeoMutt->sub, "pager_columns");
 
   if (!rd)
     return;
@@ -2102,6 +2103,9 @@ static void pager_custom_redraw(struct Menu *pager_menu)
     }
     else
       rd->indexlen = c_pager_index_lines;
+
+    if (c_pager_columns)
+      rd->indexlen = LINES; /* number of lines on screen, from curses */
 
     rd->indicator = rd->indexlen / 3;
 
@@ -2359,6 +2363,7 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
       cs_subset_number(NeoMutt->sub, "search_context");
   const short c_skip_quoted_offset =
       cs_subset_number(NeoMutt->sub, "skip_quoted_offset");
+  const short c_pager_columns = cs_subset_number(NeoMutt->sub, "pager_columns");
 
   struct Menu *pager_menu = NULL;
   int old_PagerIndexLines; /* some people want to resize it while inside the pager */
@@ -2374,6 +2379,9 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
   int index_space = c_pager_index_lines;
   if (extra->ctx && extra->ctx->mailbox)
     index_space = MIN(index_space, extra->ctx->mailbox->vcount);
+
+  if (c_pager_columns)
+    index_space = LINES; /* number of lines on screen, from curses */
 
   struct PagerRedrawData rd = { 0 };
   rd.banner = banner;

--- a/sidebar/observer.c
+++ b/sidebar/observer.c
@@ -102,20 +102,10 @@ static struct MuttWindow *sb_win_init(struct MuttWindow *dlg)
 {
   dlg->orient = MUTT_WIN_ORIENT_HORIZONTAL;
 
-  struct MuttWindow *index_panel = TAILQ_FIRST(&dlg->children);
-  mutt_window_remove_child(dlg, index_panel);
+  struct MuttWindow *cont_right = TAILQ_FIRST(&dlg->children);
+  mutt_window_remove_child(dlg, cont_right);
 
-  struct MuttWindow *pager_panel = TAILQ_FIRST(&dlg->children);
-  mutt_window_remove_child(dlg, pager_panel);
-
-  struct MuttWindow *cont_right =
-      mutt_window_new(WT_CONTAINER, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
-                      MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
   dlg->focus = cont_right;
-
-  mutt_window_add_child(cont_right, index_panel);
-  mutt_window_add_child(cont_right, pager_panel);
-  cont_right->focus = index_panel;
 
   const short c_sidebar_width = cs_subset_number(NeoMutt->sub, "sidebar_width");
   struct MuttWindow *win_sidebar =


### PR DESCRIPTION
* **What does this PR do?**

This example is a proof of concept for "Show index and body of emails in a horizontal split (side-by-side) #1250"

This is not really intended for merge, but could be used as a base for someone which will like to complete this, I think.
I think that I managed windows layout correctly,  but they are few places in the index window management where probably better fixes are needed. These are places where index in minimised when pager have to be shown. Also space allocated for the pager is permanently visible. Side-by-side layout is controlled by option 'pager_columns', which more or less overwrite 'pager_index_lines'. 

* **Screenshots (if relevant)**

<img width="1501" alt="Screenshot" src="https://user-images.githubusercontent.com/79313907/112619121-9d623c00-8e2f-11eb-83c2-12188a566c08.png">

* **What are the relevant issue numbers?**

Fixes #1250
