### PR TITLE
pager refactoring

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -368,15 +368,22 @@ int mutt_display_message(struct MuttWindow *win_index, struct MuttWindow *win_ib
         mutt_message(_("PGP signature could NOT be verified"));
     }
 
-    struct Pager info = { 0 };
     /* Invoke the builtin pager */
-    info.email = e;
-    info.ctx = Context;
-    info.win_ibar = win_ibar;
-    info.win_index = win_index;
-    info.win_pbar = win_pbar;
-    info.win_pager = win_pager;
-    rc = mutt_pager(NULL, mutt_buffer_string(tempfile), MUTT_PAGER_MESSAGE, &info);
+    struct PagerData pdata = { 0 };
+    struct PagerView pview = { &pdata };
+
+    pdata.email = e;
+    pdata.ctx = Context;
+    pdata.fname = mutt_buffer_string(tempfile);
+
+    pview.mode = PAGER_MODE_EMAIL;
+    pview.banner = NULL;
+    pview.flags = MUTT_PAGER_MESSAGE;
+    pview.win_ibar = win_ibar;
+    pview.win_index = win_index;
+    pview.win_pbar = win_pbar;
+    pview.win_pager = win_pager;
+    rc = mutt_pager(&pview);
   }
   else
   {

--- a/gui/curs_lib.c
+++ b/gui/curs_lib.c
@@ -691,7 +691,8 @@ int mutt_do_pager(struct PagerView *pview)
   assert(pview);
   assert(pview->pdata);
   assert(pview->pdata->fname);
-  assert((pview->mode == PAGER_MODE_ATTACH) || (pview->mode == PAGER_MODE_OTHER));
+  assert((pview->mode == PAGER_MODE_ATTACH) ||
+         (pview->mode == PAGER_MODE_HELP) || (pview->mode == PAGER_MODE_OTHER));
 
   struct MuttWindow *dlg =
       mutt_window_new(WT_DLG_DO_PAGER, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,

--- a/gui/curs_lib.c
+++ b/gui/curs_lib.c
@@ -28,6 +28,7 @@
  */
 
 #include "config.h"
+#include <assert.h>
 #include <ctype.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -680,20 +681,17 @@ static int mutt_dlg_dopager_observer(struct NotifyCallback *nc)
 }
 
 /**
- * mutt_do_pager - Display some page-able text to the user
- * @param banner   Message for status bar
- * @param tempfile File to display
- * @param do_color Flags, see #PagerFlags
- * @param info     Info about current mailbox (OPTIONAL)
+ * mutt_do_pager - Display some page-able text to the user (help or attachment)
+ * @param pview PagerView to construct Pager object
  * @retval  0 Success
  * @retval -1 Error
  */
-int mutt_do_pager(const char *banner, const char *tempfile, PagerFlags do_color,
-                  struct Pager *info)
+int mutt_do_pager(struct PagerView *pview)
 {
-  struct Pager info2 = { 0 };
-  if (!info)
-    info = &info2;
+  assert(pview);
+  assert(pview->pdata);
+  assert(pview->pdata->fname);
+  assert((pview->mode == PAGER_MODE_ATTACH) || (pview->mode == PAGER_MODE_OTHER));
 
   struct MuttWindow *dlg =
       mutt_window_new(WT_DLG_DO_PAGER, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
@@ -723,24 +721,24 @@ int mutt_do_pager(const char *banner, const char *tempfile, PagerFlags do_color,
   notify_observer_add(NeoMutt->notify, NT_CONFIG, mutt_dlg_dopager_observer, dlg);
   dialog_push(dlg);
 
-  info->win_ibar = NULL;
-  info->win_index = NULL;
-  info->win_pbar = pbar;
-  info->win_pager = pager;
+  pview->win_ibar = NULL;
+  pview->win_index = NULL;
+  pview->win_pbar = pbar;
+  pview->win_pager = pager;
 
   int rc;
 
   const char *const c_pager = cs_subset_string(NeoMutt->sub, "pager");
   if (!c_pager || mutt_str_equal(c_pager, "builtin"))
   {
-    rc = mutt_pager(banner, tempfile, do_color, info);
+    rc = mutt_pager(pview);
   }
   else
   {
     struct Buffer *cmd = mutt_buffer_pool_get();
 
     mutt_endwin();
-    mutt_buffer_file_expand_fmt_quote(cmd, c_pager, tempfile);
+    mutt_buffer_file_expand_fmt_quote(cmd, c_pager, pview->pdata->fname);
     if (mutt_system(mutt_buffer_string(cmd)) == -1)
     {
       mutt_error(_("Error running \"%s\""), mutt_buffer_string(cmd));
@@ -748,7 +746,7 @@ int mutt_do_pager(const char *banner, const char *tempfile, PagerFlags do_color,
     }
     else
       rc = 0;
-    mutt_file_unlink(tempfile);
+    mutt_file_unlink(pview->pdata->fname);
     mutt_buffer_pool_release(&cmd);
   }
 

--- a/gui/curs_lib.h
+++ b/gui/curs_lib.h
@@ -51,7 +51,7 @@ int          mutt_any_key_to_continue(const char *s);
 void         mutt_beep(bool force);
 int          mutt_buffer_enter_fname(const char *prompt, struct Buffer *fname, bool mailbox, struct Mailbox *m, bool multiple, char ***files, int *numfiles, SelectFileFlags flags);
 int          mutt_buffer_get_field(const char *field, struct Buffer *buf, CompletionFlags complete, bool multiple, struct Mailbox *m, char ***files, int *numfiles);
-int          mutt_do_pager(const char *banner, const char *tempfile, PagerFlags do_color, struct Pager *info);
+int          mutt_do_pager(struct PagerView *pview);
 void         mutt_edit_file(const char *editor, const char *file);
 void         mutt_endwin(void);
 void         mutt_flushinp(void);

--- a/help.c
+++ b/help.c
@@ -388,7 +388,7 @@ static void dump_unbound(FILE *fp, const struct Binding *funcs,
 void mutt_help(enum MenuType menu)
 {
   const int wraplen = AllDialogsWindow->state.cols;
-  char buf[128];
+  char banner[128];
   FILE *fp = NULL;
 
   /* We don't use the buffer pool because of the extended lifetime of t */
@@ -399,6 +399,12 @@ void mutt_help(enum MenuType menu)
   const char *desc = mutt_map_get_name(menu, Menus);
   if (!desc)
     desc = _("<UNKNOWN>");
+
+  struct PagerData pdata = { 0 };
+  struct PagerView pview = { &pdata };
+
+  pview.mode = PAGER_MODE_OTHER;
+  pview.flags = MUTT_PAGER_RETWINCH | MUTT_PAGER_MARKER | MUTT_PAGER_NSKIP | MUTT_PAGER_NOWRAP;
 
   do
   {
@@ -424,10 +430,10 @@ void mutt_help(enum MenuType menu)
 
     mutt_file_fclose(&fp);
 
-    snprintf(buf, sizeof(buf), _("Help for %s"), desc);
-  } while (mutt_do_pager(buf, mutt_buffer_string(&t),
-                         MUTT_PAGER_RETWINCH | MUTT_PAGER_MARKER | MUTT_PAGER_NSKIP | MUTT_PAGER_NOWRAP,
-                         NULL) == OP_REFORMAT_WINCH);
+    snprintf(banner, sizeof(banner), _("Help for %s"), desc);
+    pdata.fname = mutt_buffer_string(&t);
+    pview.banner = banner;
+  } while (mutt_do_pager(&pview) == OP_REFORMAT_WINCH);
 
 cleanup:
   mutt_buffer_dealloc(&t);

--- a/help.c
+++ b/help.c
@@ -403,7 +403,7 @@ void mutt_help(enum MenuType menu)
   struct PagerData pdata = { 0 };
   struct PagerView pview = { &pdata };
 
-  pview.mode = PAGER_MODE_OTHER;
+  pview.mode = PAGER_MODE_HELP;
   pview.flags = MUTT_PAGER_RETWINCH | MUTT_PAGER_MARKER | MUTT_PAGER_NSKIP | MUTT_PAGER_NOWRAP;
 
   do

--- a/icommands.c
+++ b/icommands.c
@@ -291,7 +291,16 @@ static enum CommandResult icmd_bind(struct Buffer *buf, struct Buffer *s,
   mutt_file_fclose(&fp_out);
   mutt_buffer_dealloc(&filebuf);
 
-  if (mutt_do_pager((bind) ? "bind" : "macro", tempfile, MUTT_PAGER_NO_FLAGS, NULL) == -1)
+  struct PagerData pdata = { 0 };
+  struct PagerView pview = { &pdata };
+
+  pdata.fname = tempfile;
+
+  pview.banner = (bind) ? "bind" : "macro";
+  pview.flags = MUTT_PAGER_NO_FLAGS;
+  pview.mode = PAGER_MODE_OTHER;
+
+  if (mutt_do_pager(&pview) == -1)
   {
     // L10N: '%s' is the file name of the temporary file
     mutt_buffer_printf(err, _("Could not create temporary file %s"), tempfile);
@@ -330,7 +339,17 @@ static enum CommandResult icmd_set(struct Buffer *buf, struct Buffer *s,
     dump_config(NeoMutt->sub->cs, CS_DUMP_ONLY_CHANGED, fp_out);
 
   mutt_file_fclose(&fp_out);
-  mutt_do_pager("set", tempfile, MUTT_PAGER_NO_FLAGS, NULL);
+
+  struct PagerData pdata = { 0 };
+  struct PagerView pview = { &pdata };
+
+  pdata.fname = tempfile;
+
+  pview.banner = "set";
+  pview.flags = MUTT_PAGER_NO_FLAGS;
+  pview.mode = PAGER_MODE_OTHER;
+
+  mutt_do_pager(&pview);
 
   return MUTT_CMD_SUCCESS;
 }
@@ -355,7 +374,16 @@ static enum CommandResult icmd_version(struct Buffer *buf, struct Buffer *s,
   print_version(fp_out);
   mutt_file_fclose(&fp_out);
 
-  if (mutt_do_pager("version", tempfile, MUTT_PAGER_NO_FLAGS, NULL) == -1)
+  struct PagerData pdata = { 0 };
+  struct PagerView pview = { &pdata };
+
+  pdata.fname = tempfile;
+
+  pview.banner = "version";
+  pview.flags = MUTT_PAGER_NO_FLAGS;
+  pview.mode = PAGER_MODE_OTHER;
+
+  if (mutt_do_pager(&pview) == -1)
   {
     // L10N: '%s' is the file name of the temporary file
     mutt_buffer_printf(err, _("Could not create temporary file %s"), tempfile);

--- a/index/index.c
+++ b/index/index.c
@@ -1805,7 +1805,16 @@ struct Mailbox *mutt_index_menu(struct MuttWindow *dlg, struct Mailbox *m_init)
         log_queue_save(fp);
         mutt_file_fclose(&fp);
 
-        mutt_do_pager("messages", tempfile, MUTT_PAGER_LOGS, NULL);
+        struct PagerData pdata = { 0 };
+        struct PagerView pview = { &pdata };
+
+        pdata.fname = tempfile;
+
+        pview.banner = "messages";
+        pview.flags = MUTT_PAGER_LOGS;
+        pview.mode = PAGER_MODE_OTHER;
+
+        mutt_do_pager(&pview);
         break;
       }
 

--- a/mutt_attach.c
+++ b/mutt_attach.c
@@ -653,16 +653,23 @@ int mutt_view_attachment(FILE *fp, struct Body *a, enum ViewAttachMode mode,
 
   if (use_pager)
   {
-    struct Pager info = { 0 };
-    info.fp = fp;
-    info.body = a;
-    info.ctx = Context;
-    info.actx = actx;
-    info.email = e;
+    struct PagerData pdata = { 0 };
+    struct PagerView pview = { &pdata };
 
-    rc = mutt_do_pager(desc, mutt_buffer_string(pagerfile),
-                       MUTT_PAGER_ATTACHMENT | (is_message ? MUTT_PAGER_MESSAGE : MUTT_PAGER_NO_FLAGS),
-                       &info);
+    pdata.actx = actx;
+    pdata.body = a;
+    pdata.email = e;
+    pdata.fname = mutt_buffer_string(pagerfile);
+    pdata.fp = fp;
+    pdata.ctx = Context;
+
+    pview.banner = desc;
+    pview.flags = MUTT_PAGER_ATTACHMENT |
+                  (is_message ? MUTT_PAGER_MESSAGE : MUTT_PAGER_NO_FLAGS);
+    pview.mode = PAGER_MODE_ATTACH;
+
+    rc = mutt_do_pager(&pview);
+
     mutt_buffer_reset(pagerfile);
     unlink_pagerfile = false;
   }

--- a/ncrypt/dlggpgme.c
+++ b/ncrypt/dlggpgme.c
@@ -886,7 +886,17 @@ leave:
   mutt_clear_error();
   char title[1024];
   snprintf(title, sizeof(title), _("Key ID: 0x%s"), crypt_keyid(key));
-  mutt_do_pager(title, mutt_buffer_string(&tempfile), MUTT_PAGER_NO_FLAGS, NULL);
+
+  struct PagerData pdata = { 0 };
+  struct PagerView pview = { &pdata };
+
+  pdata.fname = mutt_buffer_string(&tempfile);
+
+  pview.banner = title;
+  pview.flags = MUTT_PAGER_NO_FLAGS;
+  pview.mode = PAGER_MODE_OTHER;
+
+  mutt_do_pager(&pview);
 
 cleanup:
   mutt_buffer_dealloc(&tempfile);

--- a/ncrypt/dlgpgp.c
+++ b/ncrypt/dlgpgp.c
@@ -616,7 +616,17 @@ struct PgpKeyInfo *dlg_select_pgp_key(struct PgpKeyInfo *keys,
         char title[1024];
         snprintf(title, sizeof(title), _("Key ID: 0x%s"),
                  pgp_keyid(pgp_principal_key(key_table[menu->current]->parent)));
-        mutt_do_pager(title, mutt_buffer_string(tempfile), MUTT_PAGER_NO_FLAGS, NULL);
+
+        struct PagerData pdata = { 0 };
+        struct PagerView pview = { &pdata };
+
+        pdata.fname = mutt_buffer_string(tempfile);
+
+        pview.banner = title;
+        pview.flags = MUTT_PAGER_NO_FLAGS;
+        pview.mode = PAGER_MODE_OTHER;
+
+        mutt_do_pager(&pview);
         mutt_buffer_pool_release(&tempfile);
         menu->redraw = REDRAW_FULL;
         break;

--- a/pager/lib.h
+++ b/pager/lib.h
@@ -60,6 +60,56 @@ typedef uint16_t PagerFlags;              ///< Flags for mutt_pager(), e.g. #MUT
 
 #define MUTT_DISPLAYFLAGS (MUTT_SHOW | MUTT_PAGER_NSKIP | MUTT_PAGER_MARKER | MUTT_PAGER_LOGS)
 
+// Pager mode.
+// There are 10 code paths that lead to mutt_pager() invocation:
+//
+// 1. mutt_index_menu -> mutt_display_message -> mutt_pager
+//
+//    This path always results in mailbox and email set,
+//    the rest is unset - Body, fp.
+//    This invocation can be identified by IsEmail macro.
+//    The intent is to display an email message
+//
+// 2. mutt_view_attachment -> mutt_do_pager -> mutt_pager
+//
+//    this path always results in email, body, ctx set
+//    this invocation can be identified by one of the two macros
+//    - IsAttach (viewing a regular attachment)
+//    - IsMsgAttach (viewing nested email)
+//
+//    IsMsgAttach has extra->body->email set
+//    extra->email != extra->body->email
+//    the former is the message that contains the latter message as attachment
+//
+//    NB. extra->email->body->email seems to be always NULL
+//
+// 3. The following 8 invocations are similar, because they all call
+//    mutt_do_page with info = NULL
+//
+//    And so it results in mailbox, body, fp set to NULL.
+//    The intent is to show user some text that is not
+//    directly related to viewing emails,
+//    e.g. help, log messages,gpg key selection etc.
+//
+//    No macro identifies these invocations
+//
+//    mutt_index_menu       -> mutt_do_pager -> mutt_pager
+//    mutt_help             -> mutt_do_pager -> mutt_pager
+//    icmd_bind             -> mutt_do_pager -> mutt_pager
+//    icmd_set              -> mutt_do_pager -> mutt_pager
+//    icmd_version          -> mutt_do_pager -> mutt_pager
+//    dlg_select_pgp_key    -> mutt_do_pager -> mutt_pager
+//    verify_key            -> mutt_do_pager -> mutt_pager
+//    mutt_invoke_sendmail  -> mutt_do_pager -> mutt_pager
+//
+//
+// - IsAttach(pager) (pager && (pager)->body)
+// - IsMsgAttach(pager)
+//   (pager && (pager)->fp && (pager)->body && (pager)->body->email)
+// - IsEmail(pager) (pager && (pager)->email && !(pager)->body)
+// See nice infographic here:
+// https://gist.github.com/flatcap/044ecbd2498c65ea9a85099ef317509a
+
 /**
  * struct Pager - An email being displayed
  */

--- a/pager/lib.h
+++ b/pager/lib.h
@@ -120,6 +120,7 @@ enum PagerMode
   PAGER_MODE_EMAIL,       ///< Pager is invoked via 1st path. The mime part is selected automatically
   PAGER_MODE_ATTACH,      ///< Pager is invoked via 2nd path. A user-selected attachment (mime part or a nested email) will be shown
   PAGER_MODE_ATTACH_E,    ///< A special case of PAGER_MODE_ATTACH - attachment is a full-blown email message
+  PAGER_MODE_HELP,        ///< Pager is invoked via 3rd path to show help.
   PAGER_MODE_OTHER,       ///< Pager is invoked via 3rd path. Non-email content is likely to be shown
 
   PAGER_MODE_MAX,         ///< Another invalid mode, should never be used

--- a/pager/lib.h
+++ b/pager/lib.h
@@ -111,15 +111,42 @@ typedef uint16_t PagerFlags;              ///< Flags for mutt_pager(), e.g. #MUT
 // https://gist.github.com/flatcap/044ecbd2498c65ea9a85099ef317509a
 
 /**
- * struct Pager - An email being displayed
+ * enum PagerMode - Determine the behaviour of the Pager
  */
-struct Pager
+enum PagerMode
 {
-  struct Context *ctx;    ///< Current mailbox
-  struct Email *email;    ///< Current message
-  struct Body *body;      ///< Current attachment
-  FILE *fp;               ///< Source stream
-  struct AttachCtx *actx; ///< Attachment information
+  PAGER_MODE_UNKNOWN = 0, ///< A default and invalid mode, should never be used
+
+  PAGER_MODE_EMAIL,       ///< Pager is invoked via 1st path. The mime part is selected automatically
+  PAGER_MODE_ATTACH,      ///< Pager is invoked via 2nd path. A user-selected attachment (mime part or a nested email) will be shown
+  PAGER_MODE_ATTACH_E,    ///< A special case of PAGER_MODE_ATTACH - attachment is a full-blown email message
+  PAGER_MODE_OTHER,       ///< Pager is invoked via 3rd path. Non-email content is likely to be shown
+
+  PAGER_MODE_MAX,         ///< Another invalid mode, should never be used
+};
+
+/**
+ * struct PagerData - Data to be displayed by PagerView
+ */
+struct PagerData
+{
+  struct Context   *ctx;    ///< Current Mailbox context
+  struct Email     *email;  ///< Current message
+  struct Body      *body;   ///< Current attachment
+  FILE             *fp;     ///< Source stream
+  struct AttachCtx *actx;   ///< Attachment information
+  const char       *fname;  ///< Name of the file to read
+};
+
+/**
+ * struct PagerView - paged view into some data
+ */
+struct PagerView
+{
+  struct PagerData *pdata;   ///< Data that pager displays. NOTNULL
+  enum PagerMode    mode;    ///< Pager mode
+  PagerFlags        flags;   ///< Additional settings to tweak pager's function
+  const char       *banner;  ///< Title to display in status bar
 
   struct MuttWindow *win_ibar;
   struct MuttWindow *win_index;
@@ -127,7 +154,7 @@ struct Pager
   struct MuttWindow *win_pager;
 };
 
-int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct Pager *extra);
+int mutt_pager(struct PagerView *pview);
 void mutt_buffer_strip_formatting(struct Buffer *dest, const char *src, bool strip_markers);
 
 void mutt_clear_pager_position(void);

--- a/pager/pager.c
+++ b/pager/pager.c
@@ -190,8 +190,6 @@ struct PagerRedrawData
 static int TopLine = 0;
 static struct Email *OldEmail = NULL;
 
-static bool InHelp = false;
-
 static int braille_line = -1;
 static int braille_col = -1;
 
@@ -2314,11 +2312,12 @@ static const struct Mapping *pager_resolve_help_mapping(enum PagerMode mode, enu
         result = PagerNormalHelp;
       break;
 
+    case PAGER_MODE_HELP:
+      result = PagerHelpHelp;
+      break;
+
     case PAGER_MODE_OTHER:
-      if (InHelp)
-        result = PagerHelpHelp;
-      else
-        result = PagerHelp;
+      result = PagerHelp;
       break;
 
     case PAGER_MODE_UNKNOWN:
@@ -2393,6 +2392,7 @@ int mutt_pager(struct PagerView *pview)
       }
       break;
 
+    case PAGER_MODE_HELP:
     case PAGER_MODE_OTHER:
       assert(!pview->pdata->email);
       assert(!pview->pdata->body);
@@ -3074,17 +3074,14 @@ int mutt_pager(struct PagerView *pview)
         //=======================================================================
 
       case OP_HELP:
-        if (InHelp)
+        if (pview->mode == PAGER_MODE_HELP)
         {
           /* don't let the user enter the help-menu from the help screen! */
           mutt_error(_("Help is currently being shown"));
           break;
         }
-
-        InHelp = true;
         mutt_help(MENU_PAGER);
         pager_menu->redraw = REDRAW_FULL;
-        InHelp = false;
         break;
 
         //=======================================================================

--- a/pager/pager.c
+++ b/pager/pager.c
@@ -260,53 +260,6 @@ static const struct Mapping PagerNewsHelp[] = {
 
 #define IS_HEADER(x) ((x) == MT_COLOR_HEADER || (x) == MT_COLOR_HDRDEFAULT)
 
-// The macros below appear to be used to determine what mode pagers is
-// operating in. In order to
-// - bring some clarity
-// - prepare for further refactoring
-// I decided to write this comment.
-//
-// There are 10 code paths that lead to mutt_pager() invocation:
-//
-// 1. mutt_index_menu -> mutt_display_message -> mutt_pager
-//
-//    This path always results in mailbox and email set,
-//    the rest is unset - Body, fp.
-//    This invocation can be identified by IsEmail macro.
-//    The intent is to display an email message
-//
-// 2. mutt_view_attachment -> mutt_do_pager -> mutt_pager
-//
-//    this path always results in email, body, ctx set
-//    this invocation can be identified by one of the two macros
-//    - IsAttach (the Body could be any old attachment)
-//    - IsMsgAttach (or a full Email message)
-//    The distinction between the two is set/unset fp and the following:
-//
-//    The intent is to display an attachment of the email message
-//
-// 3. The following 8 invocations are similar, because they all call
-//    mutt_do_page with info = NULL
-//
-//    And so it results in mailbox, body, fp set to NULL.
-//    The intent is to show user some text that is not
-//    directly related to viewing emails,
-//    e.g. help, log messages,gpg key selection etc.
-//
-//    No macro identifies these invocations
-//
-//    mutt_index_menu       -> mutt_do_pager -> mutt_pager
-//    mutt_help             -> mutt_do_pager -> mutt_pager
-//    icmd_bind             -> mutt_do_pager -> mutt_pager
-//    icmd_set              -> mutt_do_pager -> mutt_pager
-//    icmd_version          -> mutt_do_pager -> mutt_pager
-//    dlg_select_pgp_key    -> mutt_do_pager -> mutt_pager
-//    verify_key            -> mutt_do_pager -> mutt_pager
-//    mutt_invoke_sendmail  -> mutt_do_pager -> mutt_pager
-//
-// See nice infographic here:
-// https://gist.github.com/flatcap/044ecbd2498c65ea9a85099ef317509a
-
 #define IsAttach(pager) (pager && (pager)->body)
 #define IsMsgAttach(pager)                                                     \
   (pager && (pager)->fp && (pager)->body && (pager)->body->email)
@@ -2590,6 +2543,7 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         }
       }
     }
+    //-------------------------------------------------------------------------
 
     if (SigWinch)
     {
@@ -2643,10 +2597,14 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
 
     switch (ch)
     {
+        //=======================================================================
+
       case OP_EXIT:
         rc = -1;
         ch = -1;
         break;
+
+        //=======================================================================
 
       case OP_QUIT:
       {
@@ -2659,6 +2617,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         }
         break;
       }
+
+        //=======================================================================
 
       case OP_NEXT_PAGE:
         if (rd.line_info[rd.curline].offset < (rd.sb.st_size - 1))
@@ -2678,6 +2638,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         }
         break;
 
+        //=======================================================================
+
       case OP_PREV_PAGE:
         if (rd.topline == 0)
         {
@@ -2689,6 +2651,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
                                   rd.line_info, rd.topline, rd.hide_quoted);
         }
         break;
+
+        //=======================================================================
 
       case OP_NEXT_LINE:
         if (rd.line_info[rd.curline].offset < (rd.sb.st_size - 1))
@@ -2707,6 +2671,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
           mutt_message(_("Bottom of message is shown"));
         break;
 
+        //=======================================================================
+
       case OP_PREV_LINE:
         if (rd.topline)
           rd.topline = up_n_lines(1, rd.line_info, rd.topline, rd.hide_quoted);
@@ -2714,12 +2680,16 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
           mutt_error(_("Top of message is shown"));
         break;
 
+        //=======================================================================
+
       case OP_PAGER_TOP:
         if (rd.topline)
           rd.topline = 0;
         else
           mutt_error(_("Top of message is shown"));
         break;
+
+        //=======================================================================
 
       case OP_HALF_UP:
         if (rd.topline)
@@ -2731,6 +2701,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         else
           mutt_error(_("Top of message is shown"));
         break;
+
+        //=======================================================================
 
       case OP_HALF_DOWN:
         if (rd.line_info[rd.curline].offset < (rd.sb.st_size - 1))
@@ -2750,6 +2722,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
           ch = -1;
         }
         break;
+
+        //=======================================================================
 
       case OP_SEARCH_NEXT:
       case OP_SEARCH_OPPOSITE:
@@ -2830,6 +2804,7 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         }
         /* no previous search pattern */
         /* fallthrough */
+        //=======================================================================
 
       case OP_SEARCH:
       case OP_SEARCH_REVERSE:
@@ -2961,6 +2936,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         pager_menu->redraw = REDRAW_BODY;
         break;
 
+        //=======================================================================
+
       case OP_SEARCH_TOGGLE:
         if (rd.search_compiled)
         {
@@ -2968,6 +2945,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
           pager_menu->redraw = REDRAW_BODY;
         }
         break;
+
+        //=======================================================================
 
       case OP_SORT:
       case OP_SORT_REVERSE:
@@ -2980,6 +2959,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
           rc = OP_DISPLAY_MESSAGE;
         }
         break;
+
+        //=======================================================================
 
       case OP_HELP:
         if (InHelp)
@@ -2995,6 +2976,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         InHelp = false;
         break;
 
+        //=======================================================================
+
       case OP_PAGER_HIDE_QUOTED:
         if (!rd.has_types)
           break;
@@ -3005,6 +2988,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         else
           pager_menu->redraw = REDRAW_BODY;
         break;
+
+        //=======================================================================
 
       case OP_PAGER_SKIP_QUOTED:
       {
@@ -3068,6 +3053,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         break;
       }
 
+        //=======================================================================
+
       case OP_PAGER_SKIP_HEADERS:
       {
         if (!rd.has_types)
@@ -3108,6 +3095,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         break;
       }
 
+        //=======================================================================
+
       case OP_PAGER_BOTTOM: /* move to the end of the file */
         if (rd.line_info[rd.curline].offset < (rd.sb.st_size - 1))
         {
@@ -3127,20 +3116,24 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
           mutt_error(_("Bottom of message is shown"));
         break;
 
+        //=======================================================================
+
       case OP_REDRAW:
         mutt_window_reflow(NULL);
         clearok(stdscr, true);
         pager_menu->redraw = REDRAW_FULL;
         break;
 
+        //=======================================================================
+
       case OP_NULL:
         km_error_key(MENU_PAGER);
         break;
 
-        /* --------------------------------------------------------------------
-         * The following are operations on the current message rather than
-         * adjusting the view of the message.  */
-
+      //=======================================================================
+      // The following are operations on the current message rather than
+      // adjusting the view of the message.
+      //=======================================================================
       case OP_BOUNCE_MESSAGE:
       {
         if (!assert_pager_mode(IsEmail(extra) || IsMsgAttach(extra)))
@@ -3159,6 +3152,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         break;
       }
 
+        //=======================================================================
+
       case OP_RESEND:
         if (!assert_pager_mode(IsEmail(extra) || IsMsgAttach(extra)))
           break;
@@ -3172,6 +3167,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
                               NeoMutt->sub);
         pager_menu->redraw = REDRAW_FULL;
         break;
+
+        //=======================================================================
 
       case OP_COMPOSE_TO_SENDER:
         if (!assert_pager_mode(IsEmail(extra) || IsMsgAttach(extra)))
@@ -3191,6 +3188,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         pager_menu->redraw = REDRAW_FULL;
         break;
 
+        //=======================================================================
+
       case OP_CHECK_TRADITIONAL:
         if (!assert_pager_mode(IsEmail(extra)))
           break;
@@ -3203,6 +3202,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         }
         break;
 
+        //=======================================================================
+
       case OP_CREATE_ALIAS:
         if (!assert_pager_mode(IsEmail(extra) || IsMsgAttach(extra)))
           break;
@@ -3213,6 +3214,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
           al = mutt_get_address(extra->email->env, NULL);
         alias_create(al, NeoMutt->sub);
         break;
+
+        //=======================================================================
 
       case OP_PURGE_MESSAGE:
       case OP_DELETE:
@@ -3243,6 +3246,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         break;
       }
 
+        //=======================================================================
+
       case OP_MAIN_SET_FLAG:
       case OP_MAIN_CLEAR_FLAG:
       {
@@ -3265,6 +3270,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         emaillist_clear(&el);
         break;
       }
+
+        //=======================================================================
 
       case OP_DELETE_THREAD:
       case OP_DELETE_SUBTHREAD:
@@ -3313,6 +3320,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         break;
       }
 
+        //=======================================================================
+
       case OP_DISPLAY_ADDRESS:
         if (!assert_pager_mode(IsEmail(extra) || IsMsgAttach(extra)))
           break;
@@ -3321,6 +3330,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         else
           mutt_display_address(extra->email->env);
         break;
+
+        //=======================================================================
 
       case OP_ENTER_COMMAND:
         old_PagerIndexLines = c_pager_index_lines;
@@ -3352,6 +3363,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         ch = 0;
         break;
 
+        //=======================================================================
+
       case OP_FLAG_MESSAGE:
       {
         if (!assert_pager_mode(IsEmail(extra)))
@@ -3373,6 +3386,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         break;
       }
 
+        //=======================================================================
+
       case OP_PIPE:
         if (!assert_pager_mode(IsEmail(extra) || IsAttach(extra)))
           break;
@@ -3386,6 +3401,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
           emaillist_clear(&el);
         }
         break;
+
+        //=======================================================================
 
       case OP_PRINT:
         if (!assert_pager_mode(IsEmail(extra) || IsAttach(extra)))
@@ -3401,6 +3418,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         }
         break;
 
+        //=======================================================================
+
       case OP_MAIL:
         if (!assert_pager_mode(IsEmail(extra)))
           break;
@@ -3410,6 +3429,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
                           NULL, NeoMutt->sub);
         pager_menu->redraw = REDRAW_FULL;
         break;
+
+        //=======================================================================
 
 #ifdef USE_NNTP
       case OP_POST:
@@ -3430,6 +3451,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         pager_menu->redraw = REDRAW_FULL;
         break;
       }
+
+        //=======================================================================
 
       case OP_FORWARD_TO_GROUP:
       {
@@ -3457,6 +3480,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         pager_menu->redraw = REDRAW_FULL;
         break;
       }
+
+        //=======================================================================
 
       case OP_FOLLOWUP:
         if (!assert_pager_mode(IsEmail(extra) || IsMsgAttach(extra)))
@@ -3498,6 +3523,9 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
           pager_menu->redraw = REDRAW_FULL;
           break;
         }
+
+        //=======================================================================
+
 #endif
       /* fallthrough */
       case OP_REPLY:
@@ -3532,6 +3560,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         break;
       }
 
+        //=======================================================================
+
       case OP_RECALL_MESSAGE:
       {
         if (!assert_pager_mode(IsEmail(extra)))
@@ -3546,6 +3576,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         pager_menu->redraw = REDRAW_FULL;
         break;
       }
+
+        //=======================================================================
 
       case OP_FORWARD_MESSAGE:
         if (!assert_pager_mode(IsEmail(extra) || IsMsgAttach(extra)))
@@ -3566,13 +3598,17 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         pager_menu->redraw = REDRAW_FULL;
         break;
 
+        //=======================================================================
+
       case OP_DECRYPT_SAVE:
         if (!WithCrypto)
         {
           ch = -1;
           break;
         }
-      /* fallthrough */
+        /* fallthrough */
+        //=======================================================================
+
       case OP_SAVE:
         if (IsAttach(extra))
         {
@@ -3580,7 +3616,9 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
                                     extra->email, NULL);
           break;
         }
-      /* fallthrough */
+        /* fallthrough */
+        //=======================================================================
+
       case OP_COPY_MESSAGE:
       case OP_DECODE_SAVE:
       case OP_DECODE_COPY:
@@ -3622,12 +3660,16 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         break;
       }
 
+        //=======================================================================
+
       case OP_SHELL_ESCAPE:
         if (mutt_shell_escape())
         {
           mutt_mailbox_check(m, MUTT_MAILBOX_CHECK_FORCE);
         }
         break;
+
+        //=======================================================================
 
       case OP_TAG:
       {
@@ -3644,6 +3686,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         }
         break;
       }
+
+        //=======================================================================
 
       case OP_TOGGLE_NEW:
       {
@@ -3672,6 +3716,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         break;
       }
 
+        //=======================================================================
+
       case OP_UNDELETE:
       {
         if (!assert_pager_mode(IsEmail(extra)))
@@ -3695,6 +3741,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         }
         break;
       }
+
+        //=======================================================================
 
       case OP_UNDELETE_THREAD:
       case OP_UNDELETE_SUBTHREAD:
@@ -3736,13 +3784,19 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         break;
       }
 
+        //=======================================================================
+
       case OP_VERSION:
         mutt_message(mutt_make_version());
         break;
 
+        //=======================================================================
+
       case OP_MAILBOX_LIST:
         mutt_mailbox_list();
         break;
+
+        //=======================================================================
 
       case OP_VIEW_ATTACHMENTS:
         if (flags & MUTT_PAGER_ATTACHMENT)
@@ -3758,6 +3812,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
           m->changed = true;
         pager_menu->redraw = REDRAW_FULL;
         break;
+
+        //=======================================================================
 
       case OP_MAIL_KEY:
       {
@@ -3778,6 +3834,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         pager_menu->redraw = REDRAW_FULL;
         break;
       }
+
+        //=======================================================================
 
       case OP_EDIT_LABEL:
       {
@@ -3802,9 +3860,13 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         break;
       }
 
+        //=======================================================================
+
       case OP_FORGET_PASSPHRASE:
         crypt_forget_passphrase();
         break;
+
+        //=======================================================================
 
       case OP_EXTRACT_KEYS:
       {
@@ -3823,13 +3885,19 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         break;
       }
 
+        //=======================================================================
+
       case OP_WHAT_KEY:
         mutt_what_key();
         break;
 
+        //=======================================================================
+
       case OP_CHECK_STATS:
         mutt_check_stats(m);
         break;
+
+        //=======================================================================
 
 #ifdef USE_SIDEBAR
       case OP_SIDEBAR_FIRST:
@@ -3849,10 +3917,14 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         break;
       }
 
+        //=======================================================================
+
       case OP_SIDEBAR_TOGGLE_VISIBLE:
         bool_str_toggle(NeoMutt->sub, "sidebar_visible", NULL);
         mutt_window_reflow(dialog_find(rd.extra->win_pager));
         break;
+
+        //=======================================================================
 #endif
 
       default:

--- a/pager/pager.c
+++ b/pager/pager.c
@@ -2295,6 +2295,42 @@ static void pager_custom_redraw(struct Menu *pager_menu)
 }
 
 /**
+ * pager_resolve_help_mapping - determine help mapping based on pager mode and
+ * mailbox type
+ * @param mode pager mode
+ * @param type mailbox type
+ */
+static const struct Mapping *pager_resolve_help_mapping(enum PagerMode mode, enum MailboxType type)
+{
+  const struct Mapping *result;
+  switch (mode)
+  {
+    case PAGER_MODE_EMAIL:
+    case PAGER_MODE_ATTACH:
+    case PAGER_MODE_ATTACH_E:
+      if (type == MUTT_NNTP)
+        result = PagerNewsHelp;
+      else
+        result = PagerNormalHelp;
+      break;
+
+    case PAGER_MODE_OTHER:
+      if (InHelp)
+        result = PagerHelpHelp;
+      else
+        result = PagerHelp;
+      break;
+
+    case PAGER_MODE_UNKNOWN:
+    case PAGER_MODE_MAX:
+    default:
+      assert(false); // something went really wrong
+  }
+  assert(result);
+  return result;
+}
+
+/**
  * mutt_pager - Display a an email, attachment, or help, in a window
  * @param pview Pager view settings
  * @retval  0 Success
@@ -2400,7 +2436,7 @@ int mutt_pager(struct PagerView *pview)
   int old_PagerIndexLines = index_space; // some people want to resize it while inside the pager
   bool first = true;
   bool wrapped = false;
-
+  enum MailboxType mailbox_type = m ? m->type : MUTT_UNKNOWN;
 #ifdef USE_NNTP
   char *followup_to = NULL;
 #endif
@@ -2415,38 +2451,7 @@ int mutt_pager(struct PagerView *pview)
     mutt_set_flag(m, pview->pdata->email, MUTT_READ, true);
   }
   //---------- setup help menu ------------------------------------------------
-
-  switch (pview->mode)
-  {
-    case PAGER_MODE_EMAIL:
-    case PAGER_MODE_ATTACH:
-    case PAGER_MODE_ATTACH_E:
-#ifdef USE_NNTP
-      if (m && (m->type == MUTT_NNTP))
-      {
-        pview->win_pager->help_data = PagerNewsHelp;
-      }
-      else
-#endif
-      {
-        pview->win_pager->help_data = PagerNormalHelp;
-      }
-      break;
-
-    case PAGER_MODE_OTHER:
-      if (InHelp)
-        pview->win_pager->help_data = PagerHelpHelp;
-      else
-        pview->win_pager->help_data = PagerHelp;
-      break;
-
-    case PAGER_MODE_UNKNOWN:
-    case PAGER_MODE_MAX:
-    default:
-      // should be impossible
-      assert(false);
-  }
-
+  pview->win_pager->help_data = pager_resolve_help_mapping(pview->mode, mailbox_type);
   pview->win_pager->help_menu = MENU_PAGER;
 
   //---------- initialize redraw pdata  -----------------------------------------

--- a/pager/pager.c
+++ b/pager/pager.c
@@ -2081,15 +2081,23 @@ void mutt_clear_pager_position(void)
  */
 static void pager_custom_redraw(struct Menu *pager_menu)
 {
+  assert(pager_menu);
   struct PagerRedrawData *rd = pager_menu->mdata;
-  struct Mailbox *m = ctx_mailbox(Context);
+  struct Mailbox *m = NULL;
   char buf[1024];
+  int msg_in_pager = -1;
   const bool c_tilde = cs_subset_bool(NeoMutt->sub, "tilde");
   const short c_pager_index_lines =
       cs_subset_number(NeoMutt->sub, "pager_index_lines");
 
   if (!rd)
     return;
+
+  if (rd->extra && rd->extra->ctx)
+  {
+    m = rd->extra->ctx->mailbox;
+    msg_in_pager = rd->extra->ctx->msg_in_pager;
+  }
 
   if (pager_menu->redraw & REDRAW_FULL)
   {
@@ -2139,7 +2147,7 @@ static void pager_custom_redraw(struct Menu *pager_menu)
         rd->menu = mutt_menu_new(MENU_MAIN);
         rd->menu->make_entry = index_make_entry;
         rd->menu->color = index_color;
-        rd->menu->max = Context ? m->vcount : 0;
+        rd->menu->max = m ? m->vcount : 0;
         rd->menu->current = rd->extra->email->vnum;
         rd->menu->win_index = rd->extra->win_index;
         rd->menu->win_ibar = rd->extra->win_ibar;
@@ -2282,8 +2290,8 @@ static void pager_custom_redraw(struct Menu *pager_menu)
       const char *const c_pager_format =
           cs_subset_string(NeoMutt->sub, "pager_format");
       mutt_make_string(buf, buflen, rd->extra->win_pbar->state.cols,
-                       NONULL(c_pager_format), m, Context ? Context->msg_in_pager : -1,
-                       e, MUTT_FORMAT_NO_FLAGS, pager_progress_str);
+                       NONULL(c_pager_format), m, msg_in_pager, e,
+                       MUTT_FORMAT_NO_FLAGS, pager_progress_str);
       mutt_draw_statusline(rd->extra->win_pbar->state.cols, buf, l2);
     }
     else
@@ -2345,6 +2353,8 @@ static void pager_custom_redraw(struct Menu *pager_menu)
  */
 int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct Pager *extra)
 {
+  assert(extra);
+  struct Mailbox *m = NULL;
   static char searchbuf[256] = { 0 };
   char buf[1024];
   int ch = 0, rc = -1;
@@ -2366,14 +2376,15 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
   char *followup_to = NULL;
 #endif
 
-  struct Mailbox *m = ctx_mailbox(Context);
-
   if (!(flags & MUTT_SHOWCOLOR))
     flags |= MUTT_SHOWFLAT;
 
   int index_space = c_pager_index_lines;
   if (extra->ctx && extra->ctx->mailbox)
+  {
     index_space = MIN(index_space, extra->ctx->mailbox->vcount);
+    m = extra->ctx->mailbox;
+  }
 
   struct PagerRedrawData rd = { 0 };
   rd.banner = banner;
@@ -2412,9 +2423,9 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
 
   /* Initialize variables */
 
-  if (Context && IsEmail(extra) && !extra->email->read)
+  if (IsEmail(extra) && !extra->email->read && extra->ctx)
   {
-    Context->msg_in_pager = extra->email->msgno;
+    extra->ctx->msg_in_pager = extra->email->msgno;
     mutt_set_flag(m, extra->email, MUTT_READ, true);
   }
 
@@ -2505,7 +2516,6 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         if (!m || mutt_buffer_is_empty(&m->pathbuf))
         {
           /* fatal error occurred */
-          ctx_free(&Context);
           pager_menu->redraw = REDRAW_FULL;
           break;
         }
@@ -2542,7 +2552,7 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
 
             bool verbose = m->verbose;
             m->verbose = false;
-            mutt_update_index(rd.menu, Context, check, oldcount, e);
+            mutt_update_index(rd.menu, extra->ctx, check, oldcount, e);
             m->verbose = verbose;
 
             rd.menu->max = m->vcount;
@@ -3209,21 +3219,20 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
       {
         if (!assert_pager_mode(IsEmail(extra)))
           break;
-        if (!assert_mailbox_writable(Context->mailbox))
+        if (!assert_mailbox_writable(m))
           break;
         /* L10N: CHECK_ACL */
-        if (!assert_mailbox_permissions(Context->mailbox, MUTT_ACL_DELETE,
-                                        _("Can't delete message")))
+        if (!assert_mailbox_permissions(m, MUTT_ACL_DELETE, _("Can't delete message")))
         {
           break;
         }
 
-        mutt_set_flag(Context->mailbox, extra->email, MUTT_DELETE, true);
-        mutt_set_flag(Context->mailbox, extra->email, MUTT_PURGE, (ch == OP_PURGE_MESSAGE));
+        mutt_set_flag(m, extra->email, MUTT_DELETE, true);
+        mutt_set_flag(m, extra->email, MUTT_PURGE, (ch == OP_PURGE_MESSAGE));
         const bool c_delete_untag =
             cs_subset_bool(NeoMutt->sub, "delete_untag");
         if (c_delete_untag)
-          mutt_set_flag(Context->mailbox, extra->email, MUTT_TAG, false);
+          mutt_set_flag(m, extra->email, MUTT_TAG, false);
         pager_menu->redraw |= REDRAW_STATUS | REDRAW_INDEX;
         const bool c_resolve = cs_subset_bool(NeoMutt->sub, "resolve");
         if (c_resolve)
@@ -3239,13 +3248,13 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
       {
         if (!assert_pager_mode(IsEmail(extra)))
           break;
-        if (!assert_mailbox_writable(Context->mailbox))
+        if (!assert_mailbox_writable(m))
           break;
 
         struct EmailList el = STAILQ_HEAD_INITIALIZER(el);
         emaillist_add_email(&el, extra->email);
 
-        if (mutt_change_flag(Context->mailbox, &el, (ch == OP_MAIN_SET_FLAG)) == 0)
+        if (mutt_change_flag(m, &el, (ch == OP_MAIN_SET_FLAG)) == 0)
           pager_menu->redraw |= REDRAW_STATUS | REDRAW_INDEX;
         const bool c_resolve = cs_subset_bool(NeoMutt->sub, "resolve");
         if (extra->email->deleted && c_resolve)
@@ -3263,14 +3272,13 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
       {
         if (!assert_pager_mode(IsEmail(extra)))
           break;
-        if (!assert_mailbox_writable(Context->mailbox))
+        if (!assert_mailbox_writable(m))
           break;
         /* L10N: CHECK_ACL */
         /* L10N: Due to the implementation details we do not know whether we
            delete zero, 1, 12, ... messages. So in English we use
            "messages". Your language might have other means to express this.  */
-        if (!assert_mailbox_permissions(Context->mailbox, MUTT_ACL_DELETE,
-                                        _("Can't delete messages")))
+        if (!assert_mailbox_permissions(m, MUTT_ACL_DELETE, _("Can't delete messages")))
         {
           break;
         }
@@ -3348,13 +3356,13 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
       {
         if (!assert_pager_mode(IsEmail(extra)))
           break;
-        if (!assert_mailbox_writable(Context->mailbox))
+        if (!assert_mailbox_writable(m))
           break;
         /* L10N: CHECK_ACL */
-        if (!assert_mailbox_permissions(Context->mailbox, MUTT_ACL_WRITE, "Can't flag message"))
+        if (!assert_mailbox_permissions(m, MUTT_ACL_WRITE, "Can't flag message"))
           break;
 
-        mutt_set_flag(Context->mailbox, extra->email, MUTT_FLAG, !extra->email->flagged);
+        mutt_set_flag(m, extra->email, MUTT_FLAG, !extra->email->flagged);
         pager_menu->redraw |= REDRAW_STATUS | REDRAW_INDEX;
         const bool c_resolve = cs_subset_bool(NeoMutt->sub, "resolve");
         if (c_resolve)
@@ -3598,7 +3606,7 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
             ((ch == OP_DECRYPT_SAVE) || (ch == OP_DECRYPT_COPY)) ? TRANSFORM_DECRYPT :
                                                                    TRANSFORM_NONE;
 
-        const int rc2 = mutt_save_message(Context->mailbox, &el, save_opt, transform_opt);
+        const int rc2 = mutt_save_message(m, &el, save_opt, transform_opt);
         if ((rc2 == 0) && (save_opt == SAVE_MOVE))
         {
           const bool c_resolve = cs_subset_bool(NeoMutt->sub, "resolve");
@@ -3617,7 +3625,7 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
       case OP_SHELL_ESCAPE:
         if (mutt_shell_escape())
         {
-          mutt_mailbox_check(ctx_mailbox(Context), MUTT_MAILBOX_CHECK_FORCE);
+          mutt_mailbox_check(m, MUTT_MAILBOX_CHECK_FORCE);
         }
         break;
 
@@ -3625,10 +3633,7 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
       {
         if (!assert_pager_mode(IsEmail(extra)))
           break;
-        if (Context)
-        {
-          mutt_set_flag(Context->mailbox, extra->email, MUTT_TAG, !extra->email->tagged);
-        }
+        mutt_set_flag(m, extra->email, MUTT_TAG, !extra->email->tagged);
 
         pager_menu->redraw |= REDRAW_STATUS | REDRAW_INDEX;
         const bool c_resolve = cs_subset_bool(NeoMutt->sub, "resolve");
@@ -3644,18 +3649,19 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
       {
         if (!assert_pager_mode(IsEmail(extra)))
           break;
-        if (!assert_mailbox_writable(Context->mailbox))
+        if (!assert_mailbox_writable(m))
           break;
         /* L10N: CHECK_ACL */
-        if (!assert_mailbox_permissions(Context->mailbox, MUTT_ACL_SEEN, _("Can't toggle new")))
+        if (!assert_mailbox_permissions(m, MUTT_ACL_SEEN, _("Can't toggle new")))
           break;
 
         if (extra->email->read || extra->email->old)
-          mutt_set_flag(Context->mailbox, extra->email, MUTT_NEW, true);
+          mutt_set_flag(m, extra->email, MUTT_NEW, true);
         else if (!first)
-          mutt_set_flag(Context->mailbox, extra->email, MUTT_READ, true);
+          mutt_set_flag(m, extra->email, MUTT_READ, true);
         first = false;
-        Context->msg_in_pager = -1;
+        if (extra->ctx)
+          extra->ctx->msg_in_pager = -1;
         pager_menu->redraw |= REDRAW_STATUS | REDRAW_INDEX;
         const bool c_resolve = cs_subset_bool(NeoMutt->sub, "resolve");
         if (c_resolve)
@@ -3670,17 +3676,16 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
       {
         if (!assert_pager_mode(IsEmail(extra)))
           break;
-        if (!assert_mailbox_writable(Context->mailbox))
+        if (!assert_mailbox_writable(m))
           break;
         /* L10N: CHECK_ACL */
-        if (!assert_mailbox_permissions(Context->mailbox, MUTT_ACL_DELETE,
-                                        _("Can't undelete message")))
+        if (!assert_mailbox_permissions(m, MUTT_ACL_DELETE, _("Can't undelete message")))
         {
           break;
         }
 
-        mutt_set_flag(Context->mailbox, extra->email, MUTT_DELETE, false);
-        mutt_set_flag(Context->mailbox, extra->email, MUTT_PURGE, false);
+        mutt_set_flag(m, extra->email, MUTT_DELETE, false);
+        mutt_set_flag(m, extra->email, MUTT_PURGE, false);
         pager_menu->redraw |= REDRAW_STATUS | REDRAW_INDEX;
         const bool c_resolve = cs_subset_bool(NeoMutt->sub, "resolve");
         if (c_resolve)
@@ -3696,14 +3701,13 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
       {
         if (!assert_pager_mode(IsEmail(extra)))
           break;
-        if (!assert_mailbox_writable(Context->mailbox))
+        if (!assert_mailbox_writable(m))
           break;
         /* L10N: CHECK_ACL */
         /* L10N: Due to the implementation details we do not know whether we
            undelete zero, 1, 12, ... messages. So in English we use
            "messages". Your language might have other means to express this. */
-        if (!assert_mailbox_permissions(Context->mailbox, MUTT_ACL_DELETE,
-                                        _("Can't undelete messages")))
+        if (!assert_mailbox_permissions(m, MUTT_ACL_DELETE, _("Can't undelete messages")))
         {
           break;
         }
@@ -3750,8 +3754,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         if (!assert_pager_mode(IsEmail(extra)))
           break;
         dlg_select_attachment(ctx_mailbox(Context), extra->email);
-        if (Context && extra->email->attach_del)
-          Context->mailbox->changed = true;
+        if (extra->email->attach_del)
+          m->changed = true;
         pager_menu->redraw = REDRAW_FULL;
         break;
 
@@ -3782,12 +3786,12 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
 
         struct EmailList el = STAILQ_HEAD_INITIALIZER(el);
         emaillist_add_email(&el, extra->email);
-        rc = mutt_label_message(Context->mailbox, &el);
+        rc = mutt_label_message(m, &el);
         emaillist_clear(&el);
 
         if (rc > 0)
         {
-          Context->mailbox->changed = true;
+          m->changed = true;
           pager_menu->redraw = REDRAW_FULL;
           mutt_message(ngettext("%d label changed", "%d labels changed", rc), rc);
         }
@@ -3813,7 +3817,7 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
           break;
         struct EmailList el = STAILQ_HEAD_INITIALIZER(el);
         emaillist_add_email(&el, extra->email);
-        crypt_extract_keys_from_messages(Context->mailbox, &el);
+        crypt_extract_keys_from_messages(m, &el);
         emaillist_clear(&el);
         pager_menu->redraw = REDRAW_FULL;
         break;
@@ -3824,7 +3828,7 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         break;
 
       case OP_CHECK_STATS:
-        mutt_check_stats(ctx_mailbox(Context));
+        mutt_check_stats(m);
         break;
 
 #ifdef USE_SIDEBAR
@@ -3860,8 +3864,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
   mutt_file_fclose(&rd.fp);
   if (IsEmail(extra))
   {
-    if (Context)
-      Context->msg_in_pager = -1;
+    if (extra->ctx)
+      extra->ctx->msg_in_pager = -1;
     switch (rc)
     {
       case -1:

--- a/pager/pager.c
+++ b/pager/pager.c
@@ -159,8 +159,7 @@ struct Resize
  */
 struct PagerRedrawData
 {
-  PagerFlags flags;
-  struct Pager *extra;
+  struct PagerView *pview;
   int indexlen;
   int indicator; ///< the indicator line of the PI
   int oldtopline;
@@ -181,7 +180,6 @@ struct PagerRedrawData
   bool search_compiled;
   PagerFlags search_flag;
   bool search_back;
-  const char *banner;
   char *searchbuf;
   struct Line *line_info;
   FILE *fp;
@@ -258,12 +256,7 @@ static const struct Mapping PagerNewsHelp[] = {
 };
 #endif
 
-#define IS_HEADER(x) ((x) == MT_COLOR_HEADER || (x) == MT_COLOR_HDRDEFAULT)
-
-#define IsAttach(pager) (pager && (pager)->body)
-#define IsMsgAttach(pager)                                                     \
-  (pager && (pager)->fp && (pager)->body && (pager)->body->email)
-#define IsEmail(pager) (pager && (pager)->email && !(pager)->body)
+#define IS_HEADER(x) (((x) == MT_COLOR_HEADER) || ((x) == MT_COLOR_HDRDEFAULT))
 
 /**
  * assert_pager_mode - Check that pager is in correct mode
@@ -2034,35 +2027,45 @@ void mutt_clear_pager_position(void)
  */
 static void pager_custom_redraw(struct Menu *pager_menu)
 {
+  //---------------------------------------------------------------------------
+  // ASSUMPTIONS & SANITY CHECKS
+  //---------------------------------------------------------------------------
+  // Since pager_custom_redraw() is a static function and it is always called
+  // after mutt_pager() we can rely on a series of sanity checks in
+  // mutt_pager(), namely:
+  // - PAGER_MODE_EMAIL  guarantees ( data->email) and (!data->body)
+  // - PAGER_MODE_ATTACH guarantees ( data->email) and ( data->body)
+  // - PAGER_MODE_OTHER  guarantees (!data->email) and (!data->body)
+  //
+  // Additionally, while refactoring is still in progress the following checks
+  // are still here to ensure data model consistency.
   assert(pager_menu);
   struct PagerRedrawData *rd = pager_menu->mdata;
-  struct Mailbox *m = NULL;
-  char buf[1024];
-  int msg_in_pager = -1;
+  assert(rd);        // Redraw function can't be called without it's data.
+  assert(rd->pview); // Redraw data can't exist separately without the view.
+  assert(rd->pview->pdata); // View can't exist without it's data
+  //---------------------------------------------------------------------------
+
+  char buf[1024] = { 0 };
+  struct Mailbox *m = rd->pview->pdata->ctx ? rd->pview->pdata->ctx->mailbox : NULL;
+
   const bool c_tilde = cs_subset_bool(NeoMutt->sub, "tilde");
   const short c_pager_index_lines =
       cs_subset_number(NeoMutt->sub, "pager_index_lines");
 
-  if (!rd)
-    return;
-
-  if (rd->extra && rd->extra->ctx)
-  {
-    m = rd->extra->ctx->mailbox;
-    msg_in_pager = rd->extra->ctx->msg_in_pager;
-  }
-
   if (pager_menu->redraw & REDRAW_FULL)
   {
     mutt_curses_set_color(MT_COLOR_NORMAL);
-    mutt_window_clear(rd->extra->win_pager);
+    mutt_window_clear(rd->pview->win_pager);
 
-    if (IsEmail(rd->extra) && m && ((m->vcount + 1) < c_pager_index_lines))
+    if ((rd->pview->mode == PAGER_MODE_EMAIL) && ((m->vcount + 1) < c_pager_index_lines))
     {
       rd->indexlen = m->vcount + 1;
     }
     else
+    {
       rd->indexlen = c_pager_index_lines;
+    }
 
     rd->indicator = rd->indexlen / 3;
 
@@ -2091,7 +2094,7 @@ static void pager_custom_redraw(struct Menu *pager_menu)
       FREE(&Resize);
     }
 
-    if (IsEmail(rd->extra) && (c_pager_index_lines != 0))
+    if ((rd->pview->mode == PAGER_MODE_EMAIL) && (c_pager_index_lines != 0))
     {
       if (!rd->menu)
       {
@@ -2101,13 +2104,13 @@ static void pager_custom_redraw(struct Menu *pager_menu)
         rd->menu->make_entry = index_make_entry;
         rd->menu->color = index_color;
         rd->menu->max = m ? m->vcount : 0;
-        rd->menu->current = rd->extra->email->vnum;
-        rd->menu->win_index = rd->extra->win_index;
-        rd->menu->win_ibar = rd->extra->win_ibar;
+        rd->menu->current = rd->pview->pdata->email->vnum;
+        rd->menu->win_index = rd->pview->win_index;
+        rd->menu->win_ibar = rd->pview->win_ibar;
       }
 
       mutt_curses_set_color(MT_COLOR_NORMAL);
-      rd->menu->pagelen = rd->extra->win_index->state.rows;
+      rd->menu->pagelen = rd->pview->win_index->state.rows;
 
       /* some fudge to work out whereabouts the indicator should go */
       if (rd->menu->current - rd->indicator < 0)
@@ -2126,7 +2129,7 @@ static void pager_custom_redraw(struct Menu *pager_menu)
 
   if (pager_menu->redraw & REDRAW_FLOW)
   {
-    if (!(rd->flags & MUTT_PAGER_RETWINCH))
+    if (!(rd->pview->flags & MUTT_PAGER_RETWINCH))
     {
       rd->lines = -1;
       for (int i = 0; i <= rd->topline; i++)
@@ -2151,10 +2154,10 @@ static void pager_custom_redraw(struct Menu *pager_menu)
     }
     int i = -1;
     int j = -1;
-    while (display_line(rd->fp, &rd->last_pos, &rd->line_info, ++i, &rd->last_line,
-                        &rd->max_line, rd->has_types | rd->search_flag | (rd->flags & MUTT_PAGER_NOWRAP),
+    while (display_line(rd->fp, &rd->last_pos, &rd->line_info, ++i, &rd->last_line, &rd->max_line,
+                        rd->has_types | rd->search_flag | (rd->pview->flags & MUTT_PAGER_NOWRAP),
                         &rd->quote_list, &rd->q_level, &rd->force_redraw,
-                        &rd->search_re, rd->extra->win_pager) == 0)
+                        &rd->search_re, rd->pview->win_pager) == 0)
     {
       if (!rd->line_info[i].continuation && (++j == rd->lines))
       {
@@ -2169,38 +2172,38 @@ static void pager_custom_redraw(struct Menu *pager_menu)
   {
     do
     {
-      mutt_window_move(rd->extra->win_pager, 0, 0);
+      mutt_window_move(rd->pview->win_pager, 0, 0);
       rd->curline = rd->topline;
       rd->oldtopline = rd->topline;
       rd->lines = 0;
       rd->force_redraw = false;
 
-      while ((rd->lines < rd->extra->win_pager->state.rows) &&
+      while ((rd->lines < rd->pview->win_pager->state.rows) &&
              (rd->line_info[rd->curline].offset <= rd->sb.st_size - 1))
       {
         if (display_line(rd->fp, &rd->last_pos, &rd->line_info, rd->curline,
                          &rd->last_line, &rd->max_line,
-                         (rd->flags & MUTT_DISPLAYFLAGS) | rd->hide_quoted |
-                             rd->search_flag | (rd->flags & MUTT_PAGER_NOWRAP),
+                         (rd->pview->flags & MUTT_DISPLAYFLAGS) | rd->hide_quoted |
+                             rd->search_flag | (rd->pview->flags & MUTT_PAGER_NOWRAP),
                          &rd->quote_list, &rd->q_level, &rd->force_redraw,
-                         &rd->search_re, rd->extra->win_pager) > 0)
+                         &rd->search_re, rd->pview->win_pager) > 0)
         {
           rd->lines++;
         }
         rd->curline++;
-        mutt_window_move(rd->extra->win_pager, 0, rd->lines);
+        mutt_window_move(rd->pview->win_pager, 0, rd->lines);
       }
       rd->last_offset = rd->line_info[rd->curline].offset;
     } while (rd->force_redraw);
 
     mutt_curses_set_color(MT_COLOR_TILDE);
-    while (rd->lines < rd->extra->win_pager->state.rows)
+    while (rd->lines < rd->pview->win_pager->state.rows)
     {
-      mutt_window_clrtoeol(rd->extra->win_pager);
+      mutt_window_clrtoeol(rd->pview->win_pager);
       if (c_tilde)
         mutt_window_addch('~');
       rd->lines++;
-      mutt_window_move(rd->extra->win_pager, 0, rd->lines);
+      mutt_window_move(rd->pview->win_pager, 0, rd->lines);
     }
     mutt_curses_set_color(MT_COLOR_NORMAL);
 
@@ -2230,28 +2233,30 @@ static void pager_custom_redraw(struct Menu *pager_menu)
     }
 
     /* print out the pager status bar */
-    mutt_window_move(rd->extra->win_pbar, 0, 0);
+    mutt_window_move(rd->pview->win_pbar, 0, 0);
     mutt_curses_set_color(MT_COLOR_STATUS);
 
-    if (IsEmail(rd->extra) || IsMsgAttach(rd->extra))
+    if (rd->pview->mode == PAGER_MODE_EMAIL || rd->pview->mode == PAGER_MODE_ATTACH_E)
     {
-      const size_t l1 = rd->extra->win_pbar->state.cols * MB_LEN_MAX;
+      const size_t l1 = rd->pview->win_pbar->state.cols * MB_LEN_MAX;
       const size_t l2 = sizeof(buf);
       const int buflen = (l1 < l2) ? l1 : l2;
-      struct Email *e =
-          (IsEmail(rd->extra)) ? rd->extra->email : rd->extra->body->email;
+      struct Email *e = (rd->pview->mode == PAGER_MODE_EMAIL) ?
+                            rd->pview->pdata->email :      // PAGER_MODE_EMAIL
+                            rd->pview->pdata->body->email; // PAGER_MODE_ATTACH_E
+
       const char *const c_pager_format =
           cs_subset_string(NeoMutt->sub, "pager_format");
-      mutt_make_string(buf, buflen, rd->extra->win_pbar->state.cols,
-                       NONULL(c_pager_format), m, msg_in_pager, e,
-                       MUTT_FORMAT_NO_FLAGS, pager_progress_str);
-      mutt_draw_statusline(rd->extra->win_pbar->state.cols, buf, l2);
+      mutt_make_string(buf, buflen, rd->pview->win_pbar->state.cols,
+                       NONULL(c_pager_format), m, rd->pview->pdata->ctx->msg_in_pager,
+                       e, MUTT_FORMAT_NO_FLAGS, pager_progress_str);
+      mutt_draw_statusline(rd->pview->win_pbar->state.cols, buf, l2);
     }
     else
     {
       char bn[256];
-      snprintf(bn, sizeof(bn), "%s (%s)", rd->banner, pager_progress_str);
-      mutt_draw_statusline(rd->extra->win_pbar->state.cols, bn, sizeof(bn));
+      snprintf(bn, sizeof(bn), "%s (%s)", rd->pview->banner, pager_progress_str);
+      mutt_draw_statusline(rd->pview->win_pbar->state.cols, bn, sizeof(bn));
     }
     mutt_curses_set_color(MT_COLOR_NORMAL);
     const bool c_ts_enabled = cs_subset_bool(NeoMutt->sub, "ts_enabled");
@@ -2272,7 +2277,7 @@ static void pager_custom_redraw(struct Menu *pager_menu)
   {
     /* redraw the pager_index indicator, because the
      * flags for this message might have changed. */
-    if (rd->extra->win_index->state.rows > 0)
+    if (rd->pview->win_index->state.rows > 0)
       menu_redraw_current(rd->menu);
 
     /* print out the index status bar */
@@ -2280,9 +2285,9 @@ static void pager_custom_redraw(struct Menu *pager_menu)
         cs_subset_string(NeoMutt->sub, "status_format");
     menu_status_line(buf, sizeof(buf), rd->menu, m, NONULL(c_status_format));
 
-    mutt_window_move(rd->extra->win_ibar, 0, 0);
+    mutt_window_move(rd->pview->win_ibar, 0, 0);
     mutt_curses_set_color(MT_COLOR_STATUS);
-    mutt_draw_statusline(rd->extra->win_ibar->state.cols, buf, sizeof(buf));
+    mutt_draw_statusline(rd->pview->win_ibar->state.cols, buf, sizeof(buf));
     mutt_curses_set_color(MT_COLOR_NORMAL);
   }
 
@@ -2290,30 +2295,87 @@ static void pager_custom_redraw(struct Menu *pager_menu)
 }
 
 /**
- * mutt_pager - Display a file, or help, in a window
- * @param banner Title to display in status bar
- * @param fname  Name of file to read
- * @param flags  Flags, e.g. #MUTT_SHOWCOLOR
- * @param extra  Info about email to display
+ * mutt_pager - Display a an email, attachment, or help, in a window
+ * @param pview Pager view settings
  * @retval  0 Success
  * @retval -1 Error
  *
- * This pager is actually not so simple as it once was.  It now operates in two
- * modes: one for viewing messages and the other for viewing help.  These can
- * be distinguished by whether or not "email" is NULL.  The "email" arg is
- * there so that we can do operations on the current message without the need
- * to pop back out to the main-menu.
+ * This pager is actually not so simple as it once was. But it will be again.
+ * Currently it operates in 3 modes:
+ * - viewing messages.                (PAGER_MODE_EMAIL)
+ * - viewing attachments.             (PAGER_MODE_ATTACH)
+ * - viewing other stuff (e.g. help). (PAGER_MODE_OTHER)
+ * These can be distinguished by PagerMode in PagerView.
+ * Data is not yet polymorphic and is fused into a single struct (PagerData).
+ * Different elements of PagerData are expected to be present depending on the
+ * mode:
+ * - PAGER_MODE_EMAIL expects data->email and not expects data->body
+ * - PAGER_MODE_ATTACH expects data->email and data->body
+ *   special sub-case of this mode is viewing attached email message
+ *   it is recognized by presence of data->fp and data->body->email
+ * - PAGER_MODE_OTHER does not expect data->email or data->body
  */
-int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct Pager *extra)
+int mutt_pager(struct PagerView *pview)
 {
-  assert(extra);
-  struct Mailbox *m = NULL;
-  static char searchbuf[256] = { 0 };
-  char buf[1024];
-  int ch = 0, rc = -1;
-  bool first = true;
-  int searchctx = 0;
-  bool wrapped = false;
+  //===========================================================================
+  // ACT 1 - Ensure sanity of the caller and determine the mode
+  //===========================================================================
+  assert(pview);
+  assert((pview->mode > PAGER_MODE_UNKNOWN) && (pview->mode < PAGER_MODE_MAX));
+  assert(pview->pdata); // view can't exist in a vacuum
+
+  switch (pview->mode)
+  {
+    case PAGER_MODE_EMAIL:
+      // This case was previously identified by IsEmail macro
+      // we expect data to contain email and not contain body
+      // We also expect email to always belong to some mailbox
+      assert(pview->pdata->email);
+      assert(pview->pdata->ctx);
+      assert(pview->pdata->ctx->mailbox);
+      assert(!pview->pdata->body);
+
+      break;
+
+    case PAGER_MODE_ATTACH:
+      // this case was previously identified by IsAttach and IsMsgAttach
+      // macros, we expect data to contain:
+      //  - body (viewing regular attachment)
+      //  - email
+      //  - fp and body->email in special case of viewing an attached email.
+      assert(pview->pdata->email); // This should point to the top level email
+      assert(pview->pdata->body);
+      assert(pview->pdata->ctx);
+      assert(pview->pdata->ctx->mailbox);
+      if (pview->pdata->fp && pview->pdata->body->email)
+      {
+        // Special case: attachment is a full-blown email message.
+        // Yes, emails can contain other emails.
+        pview->mode = PAGER_MODE_ATTACH_E;
+      }
+      break;
+
+    case PAGER_MODE_OTHER:
+      assert(!pview->pdata->email);
+      assert(!pview->pdata->body);
+      assert(!pview->pdata->ctx);
+      break;
+
+    case PAGER_MODE_UNKNOWN:
+    case PAGER_MODE_MAX:
+    default:
+      // Unexpected mode. Catch fire and explode.
+      // This *should* happen if mode is PAGER_MODE_ATTACH_E, since
+      // we do not expect any caller to pass it to us.
+      assert(false);
+      break;
+  }
+
+  //===========================================================================
+  // ACT 2 - Declare, initialize local variables, read config, etc.
+  //===========================================================================
+
+  //---------- reading config values ------------------------------------------
   const bool c_pager_stop = cs_subset_bool(NeoMutt->sub, "pager_stop");
   const short c_pager_context = cs_subset_number(NeoMutt->sub, "pager_context");
   const short c_pager_index_lines =
@@ -2323,67 +2385,73 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
   const short c_skip_quoted_offset =
       cs_subset_number(NeoMutt->sub, "skip_quoted_offset");
 
+  //---------- local variables ------------------------------------------------
+  struct PagerRedrawData rd = { 0 };
   struct Menu *pager_menu = NULL;
-  int old_PagerIndexLines; /* some people want to resize it while inside the pager */
+  struct Mailbox *m = pview->pdata->ctx ? pview->pdata->ctx->mailbox : NULL;
+
+  static char searchbuf[256] = { 0 };
 #ifdef USE_NNTP
   char *followup_to = NULL;
 #endif
+  char buf[1024];
 
-  if (!(flags & MUTT_SHOWCOLOR))
-    flags |= MUTT_SHOWFLAT;
+  int ch = 0;
+  int rc = -1;
+  int searchctx = 0;
+  int index_space = m ? MIN(c_pager_index_lines, m->vcount) : c_pager_index_lines;
+  int old_PagerIndexLines = index_space; // some people want to resize it while inside the pager
 
-  int index_space = c_pager_index_lines;
-  if (extra->ctx && extra->ctx->mailbox)
-  {
-    index_space = MIN(index_space, extra->ctx->mailbox->vcount);
-    m = extra->ctx->mailbox;
-  }
+  bool first = true;
+  bool wrapped = false;
 
-  struct PagerRedrawData rd = { 0 };
-  rd.banner = banner;
-  rd.flags = flags;
-  rd.extra = extra;
-  rd.indexlen = index_space;
+  //---------- initialize pager view  -----------------------------------------
+
+  rd.pview = pview;
+  rd.indexlen = c_pager_index_lines;
   rd.indicator = rd.indexlen / 3;
   rd.searchbuf = searchbuf;
-  rd.has_types = (IsEmail(extra) || (flags & MUTT_SHOWCOLOR)) ? MUTT_TYPES : 0; /* main message or rfc822 attachment */
+  rd.fp = fopen(pview->pdata->fname, "r");
+  rd.has_types = ((pview->mode == PAGER_MODE_EMAIL) || (pview->flags & MUTT_SHOWCOLOR)) ?
+                     MUTT_TYPES :
+                     0; // main message or rfc822 attachment
 
-  rd.fp = fopen(fname, "r");
   if (!rd.fp)
   {
-    mutt_perror(fname);
+    mutt_perror(pview->pdata->fname);
     return -1;
   }
 
-  if (stat(fname, &rd.sb) != 0)
+  if (stat(pview->pdata->fname, &rd.sb) != 0)
   {
-    mutt_perror(fname);
+    mutt_perror(pview->pdata->fname);
     mutt_file_fclose(&rd.fp);
     return -1;
   }
-  unlink(fname);
+  unlink(pview->pdata->fname);
 
-  if (rd.extra->win_index)
+  if (!(pview->flags & MUTT_SHOWCOLOR))
+    pview->flags |= MUTT_SHOWFLAT;
+
+  if (rd.pview->win_index)
   {
-    rd.extra->win_index->size = MUTT_WIN_SIZE_FIXED;
-    rd.extra->win_index->req_rows = index_space;
-    rd.extra->win_index->parent->size = MUTT_WIN_SIZE_MINIMISE;
-    window_set_visible(rd.extra->win_index->parent, (index_space > 0));
+    rd.pview->win_index->size = MUTT_WIN_SIZE_FIXED;
+    rd.pview->win_index->req_rows = index_space;
+    rd.pview->win_index->parent->size = MUTT_WIN_SIZE_MINIMISE;
+    window_set_visible(rd.pview->win_index->parent, (index_space > 0));
   }
-  window_set_visible(rd.extra->win_pager->parent, true);
-  rd.extra->win_pager->size = MUTT_WIN_SIZE_MAXIMISE;
-  mutt_window_reflow(dialog_find(rd.extra->win_pager));
+  window_set_visible(rd.pview->win_pager->parent, true);
+  rd.pview->win_pager->size = MUTT_WIN_SIZE_MAXIMISE;
+  mutt_window_reflow(dialog_find(rd.pview->win_pager));
 
-  /* Initialize variables */
-
-  if (IsEmail(extra) && !extra->email->read && extra->ctx)
+  if (pview->mode == PAGER_MODE_EMAIL && !pview->pdata->email->read)
   {
-    extra->ctx->msg_in_pager = extra->email->msgno;
-    mutt_set_flag(m, extra->email, MUTT_READ, true);
+    pview->pdata->ctx->msg_in_pager = pview->pdata->email->msgno;
+    mutt_set_flag(m, pview->pdata->email, MUTT_READ, true);
   }
-
-  rd.max_line = LINES; /* number of lines on screen, from curses */
+  rd.max_line = LINES; // number of lines on screen, from curses
   rd.line_info = mutt_mem_calloc(rd.max_line, sizeof(struct Line));
+
   for (size_t i = 0; i < rd.max_line; i++)
   {
     rd.line_info[i].type = -1;
@@ -2393,36 +2461,69 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
     (rd.line_info[i].syntax)[0].last = -1;
   }
 
+  //---------- setup pager menu------------------------------------------------
   pager_menu = mutt_menu_new(MENU_PAGER);
-  pager_menu->pagelen = extra->win_pager->state.rows;
-  pager_menu->win_index = extra->win_pager;
-  pager_menu->win_ibar = extra->win_pbar;
-
+  pager_menu->pagelen = pview->win_pager->state.rows;
+  pager_menu->win_index = pview->win_pager;
+  pager_menu->win_ibar = pview->win_pbar;
   pager_menu->custom_redraw = pager_custom_redraw;
   pager_menu->mdata = &rd;
   mutt_menu_push_current(pager_menu);
 
-  if (IsEmail(extra))
+  //---------- restore global state if needed ---------------------------------
+  while (pview->mode == PAGER_MODE_EMAIL && (OldEmail == pview->pdata->email) // are we "resuming" to the same Email?
+         && (TopLine != rd.topline) // is saved offset different?
+         && rd.line_info[rd.curline].offset < (rd.sb.st_size - 1))
   {
-    // Viewing a Mailbox
-#ifdef USE_NNTP
-    if (m && (m->type == MUTT_NNTP))
-      extra->win_pager->help_data = PagerNewsHelp;
-    else
-#endif
-      extra->win_pager->help_data = PagerNormalHelp;
+    // needed to avoid SIGSEGV
+    pager_custom_redraw(pager_menu);
+    // trick user, as if nothing happened
+    // scroll down to previosly saved offset
+    rd.topline = ((TopLine - rd.topline) > rd.lines) ? rd.topline + rd.lines : TopLine;
   }
-  else
-  {
-    // Viewing Help
-    if (InHelp)
-      extra->win_pager->help_data = PagerHelpHelp;
-    else
-      extra->win_pager->help_data = PagerHelp;
-  }
-  extra->win_pager->help_menu = MENU_PAGER;
-  window_set_focus(extra->win_pager);
 
+  TopLine = 0;
+  OldEmail = NULL;
+
+  //---------- setup help menu ------------------------------------------------
+
+  switch (pview->mode)
+  {
+    case PAGER_MODE_EMAIL:
+    case PAGER_MODE_ATTACH:
+    case PAGER_MODE_ATTACH_E:
+#ifdef USE_NNTP
+      if (m && (m->type == MUTT_NNTP))
+      {
+        pview->win_pager->help_data = PagerNewsHelp;
+      }
+      else
+#endif
+      {
+        pview->win_pager->help_data = PagerNormalHelp;
+      }
+      break;
+
+    case PAGER_MODE_OTHER:
+      if (InHelp)
+        pview->win_pager->help_data = PagerHelpHelp;
+      else
+        pview->win_pager->help_data = PagerHelp;
+      break;
+
+    case PAGER_MODE_UNKNOWN:
+    case PAGER_MODE_MAX:
+    default:
+      // should be impossible
+      assert(false);
+  }
+  pview->win_pager->help_menu = MENU_PAGER;
+  window_set_focus(pview->win_pager);
+
+  //-------------------------------------------------------------------------
+  // ACT 3: Read user input and decide what to do with it
+  //        ...but also do a whole lot of other things.
+  //-------------------------------------------------------------------------
   while (ch != -1)
   {
     mutt_curses_set_cursor(MUTT_CURSOR_INVISIBLE);
@@ -2441,24 +2542,17 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
       }
     }
     else
-      mutt_window_move(rd.extra->win_pbar, rd.extra->win_pager->state.cols - 1, 0);
+      mutt_window_move(rd.pview->win_pbar, rd.pview->win_pager->state.cols - 1, 0);
 
+    // force redraw of the screen at every iteration of the event loop
     mutt_refresh();
 
-    if (IsEmail(extra) && (OldEmail == extra->email) && (TopLine != rd.topline) &&
-        (rd.line_info[rd.curline].offset < (rd.sb.st_size - 1)))
-    {
-      if ((TopLine - rd.topline) > rd.lines)
-        rd.topline += rd.lines;
-      else
-        rd.topline = TopLine;
-      continue;
-    }
-    else
-      OldEmail = NULL;
-
+    //-------------------------------------------------------------------------
+    // Check if information in the status bar needs an update
+    // This is done because pager is a single-threaded application, which
+    // tries to emulate cuncurency.
+    //-------------------------------------------------------------------------
     bool do_new_mail = false;
-
     if (m && !OptAttachMsg)
     {
       int oldcount = m->msg_count;
@@ -2505,7 +2599,7 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
 
             bool verbose = m->verbose;
             m->verbose = false;
-            mutt_update_index(rd.menu, extra->ctx, check, oldcount, e);
+            mutt_update_index(rd.menu, pview->pdata->ctx, check, oldcount, e);
             m->verbose = verbose;
 
             rd.menu->max = m->vcount;
@@ -2515,9 +2609,9 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
              * This have a unpleasant behaviour to close the pager even the
              * deleted message is not the opened one, but at least it's safe. */
             e = mutt_get_virt_email(m, rd.menu->current);
-            if (extra->email != e)
+            if (pview->pdata->email != e)
             {
-              extra->email = e;
+              pview->pdata->email = e;
               break;
             }
           }
@@ -2552,7 +2646,7 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
       clearok(stdscr, true); /* force complete redraw */
       mutt_window_clearline(MessageWindow, 0);
 
-      if (flags & MUTT_PAGER_RETWINCH)
+      if (pview->flags & MUTT_PAGER_RETWINCH)
       {
         /* Store current position. */
         rd.lines = -1;
@@ -2577,8 +2671,18 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
       }
       continue;
     }
-
+    //-------------------------------------------------------------------------
+    // Finally, read user's key press
+    //-------------------------------------------------------------------------
+    // km_dokey() reads not only user's key strokes, but also a MacroBuffer
+    // MacroBuffer may contain OP codes of the operations.
+    // MacroBuffer is global
+    // OP codes inserted into the MacroBuffer by various functions.
+    // One of such functions is `mutt_enter_command()`
+    // Some OP codes are not handled by pager, they cause pager to quit returning
+    // OP code to index. Index hadles the operation and then restarts pager
     ch = km_dokey(MENU_PAGER);
+
     if (ch >= 0)
     {
       mutt_clear_error();
@@ -2647,7 +2751,7 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         }
         else
         {
-          rd.topline = up_n_lines(rd.extra->win_pager->state.rows - c_pager_context,
+          rd.topline = up_n_lines(rd.pview->win_pager->state.rows - c_pager_context,
                                   rd.line_info, rd.topline, rd.hide_quoted);
         }
         break;
@@ -2694,8 +2798,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
       case OP_HALF_UP:
         if (rd.topline)
         {
-          rd.topline = up_n_lines(rd.extra->win_pager->state.rows / 2 +
-                                      (rd.extra->win_pager->state.rows % 2),
+          rd.topline = up_n_lines(rd.pview->win_pager->state.rows / 2 +
+                                      (rd.pview->win_pager->state.rows % 2),
                                   rd.line_info, rd.topline, rd.hide_quoted);
         }
         else
@@ -2707,7 +2811,7 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
       case OP_HALF_DOWN:
         if (rd.line_info[rd.curline].offset < (rd.sb.st_size - 1))
         {
-          rd.topline = up_n_lines(rd.extra->win_pager->state.rows / 2,
+          rd.topline = up_n_lines(rd.pview->win_pager->state.rows / 2,
                                   rd.line_info, rd.curline, rd.hide_quoted);
         }
         else if (c_pager_stop)
@@ -2731,7 +2835,7 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         {
           wrapped = false;
 
-          if (c_search_context < rd.extra->win_pager->state.rows)
+          if (c_search_context < rd.pview->win_pager->state.rows)
             searchctx = c_search_context;
           else
             searchctx = 0;
@@ -2876,9 +2980,10 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
           int line_num = 0;
           while (display_line(rd.fp, &rd.last_pos, &rd.line_info, line_num,
                               &rd.last_line, &rd.max_line,
-                              MUTT_SEARCH | (flags & MUTT_PAGER_NSKIP) | (flags & MUTT_PAGER_NOWRAP),
+                              MUTT_SEARCH | (pview->flags & MUTT_PAGER_NSKIP) |
+                                  (pview->flags & MUTT_PAGER_NOWRAP),
                               &rd.quote_list, &rd.q_level, &rd.force_redraw,
-                              &rd.search_re, rd.extra->win_pager) == 0)
+                              &rd.search_re, rd.pview->win_pager) == 0)
           {
             line_num++;
           }
@@ -2925,7 +3030,7 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
           {
             rd.search_flag = MUTT_SEARCH;
             /* give some context for search results */
-            if (c_search_context < rd.extra->win_pager->state.rows)
+            if (c_search_context < rd.pview->win_pager->state.rows)
               searchctx = c_search_context;
             else
               searchctx = 0;
@@ -2950,7 +3055,7 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
 
       case OP_SORT:
       case OP_SORT_REVERSE:
-        if (!assert_pager_mode(IsEmail(extra)))
+        if (!assert_pager_mode(pview->mode == PAGER_MODE_EMAIL))
           break;
         if (mutt_select_sort(ch == OP_SORT_REVERSE))
         {
@@ -3005,9 +3110,9 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
           while (((new_topline < rd.last_line) ||
                   (0 == (dretval = display_line(
                              rd.fp, &rd.last_pos, &rd.line_info, new_topline, &rd.last_line,
-                             &rd.max_line, MUTT_TYPES | (flags & MUTT_PAGER_NOWRAP),
+                             &rd.max_line, MUTT_TYPES | (pview->flags & MUTT_PAGER_NOWRAP),
                              &rd.quote_list, &rd.q_level, &rd.force_redraw,
-                             &rd.search_re, rd.extra->win_pager)))) &&
+                             &rd.search_re, rd.pview->win_pager)))) &&
                  IS_HEADER(rd.line_info[new_topline].type))
           {
             new_topline++;
@@ -3019,9 +3124,9 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         while ((((new_topline + c_skip_quoted_offset) < rd.last_line) ||
                 (0 == (dretval = display_line(
                            rd.fp, &rd.last_pos, &rd.line_info, new_topline, &rd.last_line,
-                           &rd.max_line, MUTT_TYPES | (flags & MUTT_PAGER_NOWRAP),
+                           &rd.max_line, MUTT_TYPES | (pview->flags & MUTT_PAGER_NOWRAP),
                            &rd.quote_list, &rd.q_level, &rd.force_redraw,
-                           &rd.search_re, rd.extra->win_pager)))) &&
+                           &rd.search_re, rd.pview->win_pager)))) &&
                (rd.line_info[new_topline + c_skip_quoted_offset].type != MT_COLOR_QUOTED))
         {
           new_topline++;
@@ -3036,9 +3141,9 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         while ((((new_topline + c_skip_quoted_offset) < rd.last_line) ||
                 (0 == (dretval = display_line(
                            rd.fp, &rd.last_pos, &rd.line_info, new_topline, &rd.last_line,
-                           &rd.max_line, MUTT_TYPES | (flags & MUTT_PAGER_NOWRAP),
+                           &rd.max_line, MUTT_TYPES | (pview->flags & MUTT_PAGER_NOWRAP),
                            &rd.quote_list, &rd.q_level, &rd.force_redraw,
-                           &rd.search_re, rd.extra->win_pager)))) &&
+                           &rd.search_re, rd.pview->win_pager)))) &&
                (rd.line_info[new_topline + c_skip_quoted_offset].type == MT_COLOR_QUOTED))
         {
           new_topline++;
@@ -3074,9 +3179,9 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         while (((new_topline < rd.last_line) ||
                 (0 == (dretval = display_line(
                            rd.fp, &rd.last_pos, &rd.line_info, new_topline, &rd.last_line,
-                           &rd.max_line, MUTT_TYPES | (flags & MUTT_PAGER_NOWRAP),
+                           &rd.max_line, MUTT_TYPES | (pview->flags & MUTT_PAGER_NOWRAP),
                            &rd.quote_list, &rd.q_level, &rd.force_redraw,
-                           &rd.search_re, rd.extra->win_pager)))) &&
+                           &rd.search_re, rd.pview->win_pager)))) &&
                IS_HEADER(rd.line_info[new_topline].type))
         {
           new_topline++;
@@ -3103,13 +3208,13 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
           int line_num = rd.curline;
           /* make sure the types are defined to the end of file */
           while (display_line(rd.fp, &rd.last_pos, &rd.line_info, line_num, &rd.last_line,
-                              &rd.max_line, rd.has_types | (flags & MUTT_PAGER_NOWRAP),
+                              &rd.max_line, rd.has_types | (pview->flags & MUTT_PAGER_NOWRAP),
                               &rd.quote_list, &rd.q_level, &rd.force_redraw,
-                              &rd.search_re, rd.extra->win_pager) == 0)
+                              &rd.search_re, rd.pview->win_pager) == 0)
           {
             line_num++;
           }
-          rd.topline = up_n_lines(rd.extra->win_pager->state.rows, rd.line_info,
+          rd.topline = up_n_lines(rd.pview->win_pager->state.rows, rd.line_info,
                                   rd.last_line, rd.hide_quoted);
         }
         else
@@ -3136,16 +3241,20 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
       //=======================================================================
       case OP_BOUNCE_MESSAGE:
       {
-        if (!assert_pager_mode(IsEmail(extra) || IsMsgAttach(extra)))
+        if (!assert_pager_mode((pview->mode == PAGER_MODE_EMAIL) ||
+                               (pview->mode == PAGER_MODE_ATTACH_E)))
+        {
           break;
+        }
         if (assert_attach_msg_mode(OptAttachMsg))
           break;
-        if (IsMsgAttach(extra))
-          mutt_attach_bounce(m, extra->fp, extra->actx, extra->body);
+        if (pview->mode == PAGER_MODE_ATTACH_E)
+          mutt_attach_bounce(m, pview->pdata->fp, pview->pdata->actx,
+                             pview->pdata->body);
         else
         {
           struct EmailList el = STAILQ_HEAD_INITIALIZER(el);
-          emaillist_add_email(&el, extra->email);
+          emaillist_add_email(&el, pview->pdata->email);
           ci_bounce_message(m, &el);
           emaillist_clear(&el);
         }
@@ -3155,34 +3264,48 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         //=======================================================================
 
       case OP_RESEND:
-        if (!assert_pager_mode(IsEmail(extra) || IsMsgAttach(extra)))
+        if (!assert_pager_mode((pview->mode == PAGER_MODE_EMAIL) ||
+                               (pview->mode == PAGER_MODE_ATTACH_E)))
+        {
           break;
+        }
         if (assert_attach_msg_mode(OptAttachMsg))
           break;
-        if (IsMsgAttach(extra))
-          mutt_attach_resend(extra->fp, ctx_mailbox(extra->ctx), extra->actx,
-                             extra->body);
+        if (pview->mode == PAGER_MODE_ATTACH_E)
+        {
+          mutt_attach_resend(pview->pdata->fp, ctx_mailbox(pview->pdata->ctx),
+                             pview->pdata->actx, pview->pdata->body);
+        }
         else
-          mutt_resend_message(NULL, ctx_mailbox(extra->ctx), extra->email,
-                              NeoMutt->sub);
+        {
+          mutt_resend_message(NULL, ctx_mailbox(pview->pdata->ctx),
+                              pview->pdata->email, NeoMutt->sub);
+        }
         pager_menu->redraw = REDRAW_FULL;
         break;
 
         //=======================================================================
 
       case OP_COMPOSE_TO_SENDER:
-        if (!assert_pager_mode(IsEmail(extra) || IsMsgAttach(extra)))
+        if (!assert_pager_mode((pview->mode == PAGER_MODE_EMAIL) ||
+                               (pview->mode == PAGER_MODE_ATTACH_E)))
+        {
           break;
+        }
         if (assert_attach_msg_mode(OptAttachMsg))
           break;
-        if (IsMsgAttach(extra))
-          mutt_attach_mail_sender(extra->fp, extra->email, extra->actx, extra->body);
+        if (pview->mode == PAGER_MODE_ATTACH_E)
+        {
+          mutt_attach_mail_sender(pview->pdata->fp, pview->pdata->email,
+                                  pview->pdata->actx, pview->pdata->body);
+        }
         else
         {
           struct EmailList el = STAILQ_HEAD_INITIALIZER(el);
-          emaillist_add_email(&el, extra->email);
-          mutt_send_message(SEND_TO_SENDER, NULL, NULL, ctx_mailbox(extra->ctx),
-                            &el, NeoMutt->sub);
+          emaillist_add_email(&el, pview->pdata->email);
+
+          mutt_send_message(SEND_TO_SENDER, NULL, NULL,
+                            ctx_mailbox(pview->pdata->ctx), &el, NeoMutt->sub);
           emaillist_clear(&el);
         }
         pager_menu->redraw = REDRAW_FULL;
@@ -3191,11 +3314,11 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         //=======================================================================
 
       case OP_CHECK_TRADITIONAL:
-        if (!assert_pager_mode(IsEmail(extra)))
+        if (!assert_pager_mode(pview->mode == PAGER_MODE_EMAIL))
           break;
         if (!(WithCrypto & APPLICATION_PGP))
           break;
-        if (!(extra->email->security & PGP_TRADITIONAL_CHECKED))
+        if (!(pview->pdata->email->security & PGP_TRADITIONAL_CHECKED))
         {
           ch = -1;
           rc = OP_CHECK_TRADITIONAL;
@@ -3205,13 +3328,16 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         //=======================================================================
 
       case OP_CREATE_ALIAS:
-        if (!assert_pager_mode(IsEmail(extra) || IsMsgAttach(extra)))
+        if (!assert_pager_mode((pview->mode == PAGER_MODE_EMAIL) ||
+                               (pview->mode == PAGER_MODE_ATTACH_E)))
+        {
           break;
+        }
         struct AddressList *al = NULL;
-        if (IsMsgAttach(extra))
-          al = mutt_get_address(extra->body->email->env, NULL);
+        if (pview->mode == PAGER_MODE_ATTACH_E)
+          al = mutt_get_address(pview->pdata->body->email->env, NULL);
         else
-          al = mutt_get_address(extra->email->env, NULL);
+          al = mutt_get_address(pview->pdata->email->env, NULL);
         alias_create(al, NeoMutt->sub);
         break;
 
@@ -3220,7 +3346,7 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
       case OP_PURGE_MESSAGE:
       case OP_DELETE:
       {
-        if (!assert_pager_mode(IsEmail(extra)))
+        if (!assert_pager_mode(pview->mode == PAGER_MODE_EMAIL))
           break;
         if (!assert_mailbox_writable(m))
           break;
@@ -3230,12 +3356,12 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
           break;
         }
 
-        mutt_set_flag(m, extra->email, MUTT_DELETE, true);
-        mutt_set_flag(m, extra->email, MUTT_PURGE, (ch == OP_PURGE_MESSAGE));
+        mutt_set_flag(m, pview->pdata->email, MUTT_DELETE, true);
+        mutt_set_flag(m, pview->pdata->email, MUTT_PURGE, (ch == OP_PURGE_MESSAGE));
         const bool c_delete_untag =
             cs_subset_bool(NeoMutt->sub, "delete_untag");
         if (c_delete_untag)
-          mutt_set_flag(m, extra->email, MUTT_TAG, false);
+          mutt_set_flag(m, pview->pdata->email, MUTT_TAG, false);
         pager_menu->redraw |= REDRAW_STATUS | REDRAW_INDEX;
         const bool c_resolve = cs_subset_bool(NeoMutt->sub, "resolve");
         if (c_resolve)
@@ -3251,18 +3377,18 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
       case OP_MAIN_SET_FLAG:
       case OP_MAIN_CLEAR_FLAG:
       {
-        if (!assert_pager_mode(IsEmail(extra)))
+        if (!assert_pager_mode(pview->mode == PAGER_MODE_EMAIL))
           break;
         if (!assert_mailbox_writable(m))
           break;
 
         struct EmailList el = STAILQ_HEAD_INITIALIZER(el);
-        emaillist_add_email(&el, extra->email);
+        emaillist_add_email(&el, pview->pdata->email);
 
         if (mutt_change_flag(m, &el, (ch == OP_MAIN_SET_FLAG)) == 0)
           pager_menu->redraw |= REDRAW_STATUS | REDRAW_INDEX;
         const bool c_resolve = cs_subset_bool(NeoMutt->sub, "resolve");
-        if (extra->email->deleted && c_resolve)
+        if (pview->pdata->email->deleted && c_resolve)
         {
           ch = -1;
           rc = OP_MAIN_NEXT_UNDELETED;
@@ -3277,7 +3403,7 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
       case OP_DELETE_SUBTHREAD:
       case OP_PURGE_THREAD:
       {
-        if (!assert_pager_mode(IsEmail(extra)))
+        if (!assert_pager_mode(pview->mode == PAGER_MODE_EMAIL))
           break;
         if (!assert_mailbox_writable(m))
           break;
@@ -3291,12 +3417,12 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         }
 
         int subthread = (ch == OP_DELETE_SUBTHREAD);
-        int r = mutt_thread_set_flag(m, extra->email, MUTT_DELETE, 1, subthread);
+        int r = mutt_thread_set_flag(m, pview->pdata->email, MUTT_DELETE, 1, subthread);
         if (r == -1)
           break;
         if (ch == OP_PURGE_THREAD)
         {
-          r = mutt_thread_set_flag(m, extra->email, MUTT_PURGE, true, subthread);
+          r = mutt_thread_set_flag(m, pview->pdata->email, MUTT_PURGE, true, subthread);
           if (r == -1)
             break;
         }
@@ -3304,7 +3430,7 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         const bool c_delete_untag =
             cs_subset_bool(NeoMutt->sub, "delete_untag");
         if (c_delete_untag)
-          mutt_thread_set_flag(m, extra->email, MUTT_TAG, 0, subthread);
+          mutt_thread_set_flag(m, pview->pdata->email, MUTT_TAG, 0, subthread);
         const bool c_resolve = cs_subset_bool(NeoMutt->sub, "resolve");
         if (c_resolve)
         {
@@ -3323,12 +3449,15 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         //=======================================================================
 
       case OP_DISPLAY_ADDRESS:
-        if (!assert_pager_mode(IsEmail(extra) || IsMsgAttach(extra)))
+        if (!assert_pager_mode((pview->mode == PAGER_MODE_EMAIL) ||
+                               (pview->mode == PAGER_MODE_ATTACH_E)))
+        {
           break;
-        if (IsMsgAttach(extra))
-          mutt_display_address(extra->body->email->env);
+        }
+        if (pview->mode == PAGER_MODE_ATTACH_E)
+          mutt_display_address(pview->pdata->body->email->env);
         else
-          mutt_display_address(extra->email->env);
+          mutt_display_address(pview->pdata->email->env);
         break;
 
         //=======================================================================
@@ -3337,13 +3466,13 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         old_PagerIndexLines = c_pager_index_lines;
 
         mutt_enter_command();
-        window_set_focus(rd.extra->win_pager);
+        window_set_focus(rd.pview->win_pager);
         pager_menu->redraw = REDRAW_FULL;
 
         if (OptNeedResort)
         {
           OptNeedResort = false;
-          if (!assert_pager_mode(IsEmail(extra)))
+          if (!assert_pager_mode(pview->mode == PAGER_MODE_EMAIL))
             break;
           OptNeedResort = true;
         }
@@ -3353,7 +3482,7 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
           mutt_menu_free(&rd.menu);
         }
 
-        if ((pager_menu->redraw & REDRAW_FLOW) && (flags & MUTT_PAGER_RETWINCH))
+        if ((pager_menu->redraw & REDRAW_FLOW) && (pview->flags & MUTT_PAGER_RETWINCH))
         {
           ch = -1;
           rc = OP_REFORMAT_WINCH;
@@ -3367,7 +3496,7 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
 
       case OP_FLAG_MESSAGE:
       {
-        if (!assert_pager_mode(IsEmail(extra)))
+        if (!assert_pager_mode(pview->mode == PAGER_MODE_EMAIL))
           break;
         if (!assert_mailbox_writable(m))
           break;
@@ -3375,7 +3504,7 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         if (!assert_mailbox_permissions(m, MUTT_ACL_WRITE, "Can't flag message"))
           break;
 
-        mutt_set_flag(m, extra->email, MUTT_FLAG, !extra->email->flagged);
+        mutt_set_flag(m, pview->pdata->email, MUTT_FLAG, !pview->pdata->email->flagged);
         pager_menu->redraw |= REDRAW_STATUS | REDRAW_INDEX;
         const bool c_resolve = cs_subset_bool(NeoMutt->sub, "resolve");
         if (c_resolve)
@@ -3389,15 +3518,21 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         //=======================================================================
 
       case OP_PIPE:
-        if (!assert_pager_mode(IsEmail(extra) || IsAttach(extra)))
+        if (!assert_pager_mode((pview->mode == PAGER_MODE_EMAIL) ||
+                               (pview->mode == PAGER_MODE_ATTACH)))
+        {
           break;
-        if (IsAttach(extra))
-          mutt_pipe_attachment_list(extra->actx, extra->fp, false, extra->body, false);
+        }
+        if (pview->mode == PAGER_MODE_ATTACH)
+        {
+          mutt_pipe_attachment_list(pview->pdata->actx, pview->pdata->fp, false,
+                                    pview->pdata->body, false);
+        }
         else
         {
           struct EmailList el = STAILQ_HEAD_INITIALIZER(el);
-          el_add_tagged(&el, extra->ctx, extra->email, false);
-          mutt_pipe_message(extra->ctx->mailbox, &el);
+          el_add_tagged(&el, pview->pdata->ctx, pview->pdata->email, false);
+          mutt_pipe_message(m, &el);
           emaillist_clear(&el);
         }
         break;
@@ -3405,15 +3540,21 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         //=======================================================================
 
       case OP_PRINT:
-        if (!assert_pager_mode(IsEmail(extra) || IsAttach(extra)))
+        if (!assert_pager_mode((pview->mode == PAGER_MODE_EMAIL) ||
+                               (pview->mode == PAGER_MODE_ATTACH)))
+        {
           break;
-        if (IsAttach(extra))
-          mutt_print_attachment_list(extra->actx, extra->fp, false, extra->body);
+        }
+        if (pview->mode == PAGER_MODE_ATTACH)
+        {
+          mutt_print_attachment_list(pview->pdata->actx, pview->pdata->fp,
+                                     false, pview->pdata->body);
+        }
         else
         {
           struct EmailList el = STAILQ_HEAD_INITIALIZER(el);
-          el_add_tagged(&el, extra->ctx, extra->email, false);
-          mutt_print_message(extra->ctx->mailbox, &el);
+          el_add_tagged(&el, pview->pdata->ctx, pview->pdata->email, false);
+          mutt_print_message(m, &el);
           emaillist_clear(&el);
         }
         break;
@@ -3421,12 +3562,13 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         //=======================================================================
 
       case OP_MAIL:
-        if (!assert_pager_mode(IsEmail(extra)))
+        if (!assert_pager_mode(pview->mode == PAGER_MODE_EMAIL))
           break;
         if (assert_attach_msg_mode(OptAttachMsg))
           break;
-        mutt_send_message(SEND_NO_FLAGS, NULL, NULL, ctx_mailbox(extra->ctx),
-                          NULL, NeoMutt->sub);
+
+        mutt_send_message(SEND_NO_FLAGS, NULL, NULL,
+                          ctx_mailbox(pview->pdata->ctx), NULL, NeoMutt->sub);
         pager_menu->redraw = REDRAW_FULL;
         break;
 
@@ -3435,19 +3577,20 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
 #ifdef USE_NNTP
       case OP_POST:
       {
-        if (!assert_pager_mode(IsEmail(extra)))
+        if (!assert_pager_mode(pview->mode == PAGER_MODE_EMAIL))
           break;
         if (assert_attach_msg_mode(OptAttachMsg))
           break;
         const enum QuadOption c_post_moderated =
             cs_subset_quad(NeoMutt->sub, "post_moderated");
-        if (extra->ctx && (extra->ctx->mailbox->type == MUTT_NNTP) &&
-            !((struct NntpMboxData *) extra->ctx->mailbox->mdata)->allowed && (query_quadoption(c_post_moderated, _("Posting to this group not allowed, may be moderated. Continue?")) != MUTT_YES))
+        if ((m->type == MUTT_NNTP) &&
+            !((struct NntpMboxData *) m->mdata)->allowed && (query_quadoption(c_post_moderated, _("Posting to this group not allowed, may be moderated. Continue?")) != MUTT_YES))
         {
           break;
         }
-        mutt_send_message(SEND_NEWS, NULL, NULL, ctx_mailbox(extra->ctx), NULL,
-                          NeoMutt->sub);
+
+        mutt_send_message(SEND_NEWS, NULL, NULL, ctx_mailbox(pview->pdata->ctx),
+                          NULL, NeoMutt->sub);
         pager_menu->redraw = REDRAW_FULL;
         break;
       }
@@ -3456,25 +3599,32 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
 
       case OP_FORWARD_TO_GROUP:
       {
-        if (!assert_pager_mode(IsEmail(extra) || IsMsgAttach(extra)))
+        if (!assert_pager_mode((pview->mode == PAGER_MODE_EMAIL) ||
+                               (pview->mode == PAGER_MODE_ATTACH_E)))
+        {
           break;
+        }
         if (assert_attach_msg_mode(OptAttachMsg))
           break;
         const enum QuadOption c_post_moderated =
             cs_subset_quad(NeoMutt->sub, "post_moderated");
-        if (extra->ctx && (extra->ctx->mailbox->type == MUTT_NNTP) &&
-            !((struct NntpMboxData *) extra->ctx->mailbox->mdata)->allowed && (query_quadoption(c_post_moderated, _("Posting to this group not allowed, may be moderated. Continue?")) != MUTT_YES))
+        if ((m->type == MUTT_NNTP) &&
+            !((struct NntpMboxData *) m->mdata)->allowed && (query_quadoption(c_post_moderated, _("Posting to this group not allowed, may be moderated. Continue?")) != MUTT_YES))
         {
           break;
         }
-        if (IsMsgAttach(extra))
-          mutt_attach_forward(extra->fp, m, extra->email, extra->actx, extra->body, SEND_NEWS);
+        if (pview->mode == PAGER_MODE_ATTACH_E)
+        {
+          mutt_attach_forward(pview->pdata->fp, m, pview->pdata->email,
+                              pview->pdata->actx, pview->pdata->body, SEND_NEWS);
+        }
         else
         {
           struct EmailList el = STAILQ_HEAD_INITIALIZER(el);
-          emaillist_add_email(&el, extra->email);
+          emaillist_add_email(&el, pview->pdata->email);
+
           mutt_send_message(SEND_NEWS | SEND_FORWARD, NULL, NULL,
-                            ctx_mailbox(extra->ctx), &el, NeoMutt->sub);
+                            ctx_mailbox(pview->pdata->ctx), &el, NeoMutt->sub);
           emaillist_clear(&el);
         }
         pager_menu->redraw = REDRAW_FULL;
@@ -3484,15 +3634,18 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         //=======================================================================
 
       case OP_FOLLOWUP:
-        if (!assert_pager_mode(IsEmail(extra) || IsMsgAttach(extra)))
+        if (!assert_pager_mode((pview->mode == PAGER_MODE_EMAIL) ||
+                               (pview->mode == PAGER_MODE_ATTACH_E)))
+        {
           break;
+        }
         if (assert_attach_msg_mode(OptAttachMsg))
           break;
 
-        if (IsMsgAttach(extra))
-          followup_to = extra->body->email->env->followup_to;
+        if (pview->mode == PAGER_MODE_ATTACH_E)
+          followup_to = pview->pdata->body->email->env->followup_to;
         else
-          followup_to = extra->email->env->followup_to;
+          followup_to = pview->pdata->email->env->followup_to;
 
         const enum QuadOption c_followup_to_poster =
             cs_subset_quad(NeoMutt->sub, "followup_to_poster");
@@ -3502,22 +3655,22 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         {
           const enum QuadOption c_post_moderated =
               cs_subset_quad(NeoMutt->sub, "post_moderated");
-          if (extra->ctx && (extra->ctx->mailbox->type == MUTT_NNTP) &&
-              !((struct NntpMboxData *) extra->ctx->mailbox->mdata)->allowed && (query_quadoption(c_post_moderated, _("Posting to this group not allowed, may be moderated. Continue?")) != MUTT_YES))
+          if ((m->type == MUTT_NNTP) &&
+              !((struct NntpMboxData *) m->mdata)->allowed && (query_quadoption(c_post_moderated, _("Posting to this group not allowed, may be moderated. Continue?")) != MUTT_YES))
           {
             break;
           }
-          if (IsMsgAttach(extra))
+          if (pview->mode == PAGER_MODE_ATTACH_E)
           {
-            mutt_attach_reply(extra->fp, m, extra->email, extra->actx,
-                              extra->body, SEND_NEWS | SEND_REPLY);
+            mutt_attach_reply(pview->pdata->fp, m, pview->pdata->email,
+                              pview->pdata->actx, pview->pdata->body, SEND_NEWS | SEND_REPLY);
           }
           else
           {
             struct EmailList el = STAILQ_HEAD_INITIALIZER(el);
-            emaillist_add_email(&el, extra->email);
+            emaillist_add_email(&el, pview->pdata->email);
             mutt_send_message(SEND_NEWS | SEND_REPLY, NULL, NULL,
-                              ctx_mailbox(extra->ctx), &el, NeoMutt->sub);
+                              ctx_mailbox(pview->pdata->ctx), &el, NeoMutt->sub);
             emaillist_clear(&el);
           }
           pager_menu->redraw = REDRAW_FULL;
@@ -3533,8 +3686,11 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
       case OP_GROUP_CHAT_REPLY:
       case OP_LIST_REPLY:
       {
-        if (!assert_pager_mode(IsEmail(extra) || IsMsgAttach(extra)))
+        if (!assert_pager_mode((pview->mode == PAGER_MODE_EMAIL) ||
+                               (pview->mode == PAGER_MODE_ATTACH_E)))
+        {
           break;
+        }
         if (assert_attach_msg_mode(OptAttachMsg))
           break;
 
@@ -3546,14 +3702,17 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         else if (ch == OP_LIST_REPLY)
           replyflags |= SEND_LIST_REPLY;
 
-        if (IsMsgAttach(extra))
-          mutt_attach_reply(extra->fp, m, extra->email, extra->actx, extra->body, replyflags);
+        if (pview->mode == PAGER_MODE_ATTACH_E)
+        {
+          mutt_attach_reply(pview->pdata->fp, m, pview->pdata->email,
+                            pview->pdata->actx, pview->pdata->body, replyflags);
+        }
         else
         {
           struct EmailList el = STAILQ_HEAD_INITIALIZER(el);
-          emaillist_add_email(&el, extra->email);
-          mutt_send_message(replyflags, NULL, NULL, ctx_mailbox(extra->ctx),
-                            &el, NeoMutt->sub);
+          emaillist_add_email(&el, pview->pdata->email);
+          mutt_send_message(replyflags, NULL, NULL,
+                            ctx_mailbox(pview->pdata->ctx), &el, NeoMutt->sub);
           emaillist_clear(&el);
         }
         pager_menu->redraw = REDRAW_FULL;
@@ -3564,14 +3723,15 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
 
       case OP_RECALL_MESSAGE:
       {
-        if (!assert_pager_mode(IsEmail(extra)))
+        if (!assert_pager_mode(pview->mode == PAGER_MODE_EMAIL))
           break;
         if (assert_attach_msg_mode(OptAttachMsg))
           break;
         struct EmailList el = STAILQ_HEAD_INITIALIZER(el);
-        emaillist_add_email(&el, extra->email);
-        mutt_send_message(SEND_POSTPONED, NULL, NULL, ctx_mailbox(extra->ctx),
-                          &el, NeoMutt->sub);
+        emaillist_add_email(&el, pview->pdata->email);
+
+        mutt_send_message(SEND_POSTPONED, NULL, NULL,
+                          ctx_mailbox(pview->pdata->ctx), &el, NeoMutt->sub);
         emaillist_clear(&el);
         pager_menu->redraw = REDRAW_FULL;
         break;
@@ -3580,19 +3740,25 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         //=======================================================================
 
       case OP_FORWARD_MESSAGE:
-        if (!assert_pager_mode(IsEmail(extra) || IsMsgAttach(extra)))
+        if (!assert_pager_mode((pview->mode == PAGER_MODE_EMAIL) ||
+                               (pview->mode == PAGER_MODE_ATTACH_E)))
+        {
           break;
+        }
         if (assert_attach_msg_mode(OptAttachMsg))
           break;
-        if (IsMsgAttach(extra))
-          mutt_attach_forward(extra->fp, m, extra->email, extra->actx,
-                              extra->body, SEND_NO_FLAGS);
+        if (pview->mode == PAGER_MODE_ATTACH_E)
+        {
+          mutt_attach_forward(pview->pdata->fp, m, pview->pdata->email,
+                              pview->pdata->actx, pview->pdata->body, SEND_NO_FLAGS);
+        }
         else
         {
           struct EmailList el = STAILQ_HEAD_INITIALIZER(el);
-          emaillist_add_email(&el, extra->email);
-          mutt_send_message(SEND_FORWARD, NULL, NULL, ctx_mailbox(extra->ctx),
-                            &el, NeoMutt->sub);
+          emaillist_add_email(&el, pview->pdata->email);
+
+          mutt_send_message(SEND_FORWARD, NULL, NULL,
+                            ctx_mailbox(pview->pdata->ctx), &el, NeoMutt->sub);
           emaillist_clear(&el);
         }
         pager_menu->redraw = REDRAW_FULL;
@@ -3610,10 +3776,10 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         //=======================================================================
 
       case OP_SAVE:
-        if (IsAttach(extra))
+        if (pview->mode == PAGER_MODE_ATTACH)
         {
-          mutt_save_attachment_list(extra->actx, extra->fp, false, extra->body,
-                                    extra->email, NULL);
+          mutt_save_attachment_list(pview->pdata->actx, pview->pdata->fp, false,
+                                    pview->pdata->body, pview->pdata->email, NULL);
           break;
         }
         /* fallthrough */
@@ -3629,10 +3795,10 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
           ch = -1;
           break;
         }
-        if (!assert_pager_mode(IsEmail(extra)))
+        if (!assert_pager_mode(pview->mode == PAGER_MODE_EMAIL))
           break;
         struct EmailList el = STAILQ_HEAD_INITIALIZER(el);
-        emaillist_add_email(&el, extra->email);
+        emaillist_add_email(&el, pview->pdata->email);
 
         const enum MessageSaveOpt save_opt =
             ((ch == OP_SAVE) || (ch == OP_DECODE_SAVE) || (ch == OP_DECRYPT_SAVE)) ?
@@ -3673,9 +3839,9 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
 
       case OP_TAG:
       {
-        if (!assert_pager_mode(IsEmail(extra)))
+        if (!assert_pager_mode(pview->mode == PAGER_MODE_EMAIL))
           break;
-        mutt_set_flag(m, extra->email, MUTT_TAG, !extra->email->tagged);
+        mutt_set_flag(m, pview->pdata->email, MUTT_TAG, !pview->pdata->email->tagged);
 
         pager_menu->redraw |= REDRAW_STATUS | REDRAW_INDEX;
         const bool c_resolve = cs_subset_bool(NeoMutt->sub, "resolve");
@@ -3691,7 +3857,7 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
 
       case OP_TOGGLE_NEW:
       {
-        if (!assert_pager_mode(IsEmail(extra)))
+        if (!assert_pager_mode(pview->mode == PAGER_MODE_EMAIL))
           break;
         if (!assert_mailbox_writable(m))
           break;
@@ -3699,13 +3865,12 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         if (!assert_mailbox_permissions(m, MUTT_ACL_SEEN, _("Can't toggle new")))
           break;
 
-        if (extra->email->read || extra->email->old)
-          mutt_set_flag(m, extra->email, MUTT_NEW, true);
+        if (pview->pdata->email->read || pview->pdata->email->old)
+          mutt_set_flag(m, pview->pdata->email, MUTT_NEW, true);
         else if (!first)
-          mutt_set_flag(m, extra->email, MUTT_READ, true);
+          mutt_set_flag(m, pview->pdata->email, MUTT_READ, true);
         first = false;
-        if (extra->ctx)
-          extra->ctx->msg_in_pager = -1;
+        pview->pdata->ctx->msg_in_pager = -1;
         pager_menu->redraw |= REDRAW_STATUS | REDRAW_INDEX;
         const bool c_resolve = cs_subset_bool(NeoMutt->sub, "resolve");
         if (c_resolve)
@@ -3720,7 +3885,7 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
 
       case OP_UNDELETE:
       {
-        if (!assert_pager_mode(IsEmail(extra)))
+        if (!assert_pager_mode(pview->mode == PAGER_MODE_EMAIL))
           break;
         if (!assert_mailbox_writable(m))
           break;
@@ -3730,8 +3895,8 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
           break;
         }
 
-        mutt_set_flag(m, extra->email, MUTT_DELETE, false);
-        mutt_set_flag(m, extra->email, MUTT_PURGE, false);
+        mutt_set_flag(m, pview->pdata->email, MUTT_DELETE, false);
+        mutt_set_flag(m, pview->pdata->email, MUTT_PURGE, false);
         pager_menu->redraw |= REDRAW_STATUS | REDRAW_INDEX;
         const bool c_resolve = cs_subset_bool(NeoMutt->sub, "resolve");
         if (c_resolve)
@@ -3747,7 +3912,7 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
       case OP_UNDELETE_THREAD:
       case OP_UNDELETE_SUBTHREAD:
       {
-        if (!assert_pager_mode(IsEmail(extra)))
+        if (!assert_pager_mode(pview->mode == PAGER_MODE_EMAIL))
           break;
         if (!assert_mailbox_writable(m))
           break;
@@ -3760,11 +3925,11 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
           break;
         }
 
-        int r = mutt_thread_set_flag(m, extra->email, MUTT_DELETE, false,
+        int r = mutt_thread_set_flag(m, pview->pdata->email, MUTT_DELETE, false,
                                      (ch != OP_UNDELETE_THREAD));
         if (r != -1)
         {
-          r = mutt_thread_set_flag(m, extra->email, MUTT_PURGE, false,
+          r = mutt_thread_set_flag(m, pview->pdata->email, MUTT_PURGE, false,
                                    (ch != OP_UNDELETE_THREAD));
         }
         if (r != -1)
@@ -3799,16 +3964,16 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         //=======================================================================
 
       case OP_VIEW_ATTACHMENTS:
-        if (flags & MUTT_PAGER_ATTACHMENT)
+        if (pview->flags & MUTT_PAGER_ATTACHMENT)
         {
           ch = -1;
           rc = OP_ATTACH_COLLAPSE;
           break;
         }
-        if (!assert_pager_mode(IsEmail(extra)))
+        if (!assert_pager_mode(pview->mode == PAGER_MODE_EMAIL))
           break;
-        dlg_select_attachment(ctx_mailbox(Context), extra->email);
-        if (extra->email->attach_del)
+        dlg_select_attachment(ctx_mailbox(Context), pview->pdata->email);
+        if (pview->pdata->email->attach_del)
           m->changed = true;
         pager_menu->redraw = REDRAW_FULL;
         break;
@@ -3822,14 +3987,15 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
           ch = -1;
           break;
         }
-        if (!assert_pager_mode(IsEmail(extra)))
+        if (!assert_pager_mode(pview->mode == PAGER_MODE_EMAIL))
           break;
         if (assert_attach_msg_mode(OptAttachMsg))
           break;
         struct EmailList el = STAILQ_HEAD_INITIALIZER(el);
-        emaillist_add_email(&el, extra->email);
-        mutt_send_message(SEND_KEY, NULL, NULL, ctx_mailbox(extra->ctx), &el,
-                          NeoMutt->sub);
+        emaillist_add_email(&el, pview->pdata->email);
+
+        mutt_send_message(SEND_KEY, NULL, NULL, ctx_mailbox(pview->pdata->ctx),
+                          &el, NeoMutt->sub);
         emaillist_clear(&el);
         pager_menu->redraw = REDRAW_FULL;
         break;
@@ -3839,11 +4005,11 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
 
       case OP_EDIT_LABEL:
       {
-        if (!assert_pager_mode(IsEmail(extra)))
+        if (!assert_pager_mode(pview->mode == PAGER_MODE_EMAIL))
           break;
 
         struct EmailList el = STAILQ_HEAD_INITIALIZER(el);
-        emaillist_add_email(&el, extra->email);
+        emaillist_add_email(&el, pview->pdata->email);
         rc = mutt_label_message(m, &el);
         emaillist_clear(&el);
 
@@ -3875,10 +4041,10 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
           ch = -1;
           break;
         }
-        if (!assert_pager_mode(IsEmail(extra)))
+        if (!assert_pager_mode(pview->mode == PAGER_MODE_EMAIL))
           break;
         struct EmailList el = STAILQ_HEAD_INITIALIZER(el);
-        emaillist_add_email(&el, extra->email);
+        emaillist_add_email(&el, pview->pdata->email);
         crypt_extract_keys_from_messages(m, &el);
         emaillist_clear(&el);
         pager_menu->redraw = REDRAW_FULL;
@@ -3910,7 +4076,7 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
       case OP_SIDEBAR_PREV_NEW:
       {
         struct MuttWindow *win_sidebar =
-            mutt_window_find(dialog_find(rd.extra->win_pager), WT_SIDEBAR);
+            mutt_window_find(dialog_find(rd.pview->win_pager), WT_SIDEBAR);
         if (!win_sidebar)
           break;
         sb_change_mailbox(win_sidebar, ch);
@@ -3921,7 +4087,7 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
 
       case OP_SIDEBAR_TOGGLE_VISIBLE:
         bool_str_toggle(NeoMutt->sub, "sidebar_visible", NULL);
-        mutt_window_reflow(dialog_find(rd.extra->win_pager));
+        mutt_window_reflow(dialog_find(rd.pview->win_pager));
         break;
 
         //=======================================================================
@@ -3932,12 +4098,14 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         break;
     }
   }
+  //-------------------------------------------------------------------------
+  // END OF ACT 3: Read user input loop - while (ch != -1)
+  //-------------------------------------------------------------------------
 
   mutt_file_fclose(&rd.fp);
-  if (IsEmail(extra))
+  if (pview->mode == PAGER_MODE_EMAIL)
   {
-    if (extra->ctx)
-      extra->ctx->msg_in_pager = -1;
+    pview->pdata->ctx->msg_in_pager = -1;
     switch (rc)
     {
       case -1:
@@ -3946,7 +4114,7 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
         break;
       default:
         TopLine = rd.topline;
-        OldEmail = extra->email;
+        OldEmail = pview->pdata->email;
         break;
     }
   }
@@ -3969,16 +4137,16 @@ int mutt_pager(const char *banner, const char *fname, PagerFlags flags, struct P
   mutt_menu_free(&pager_menu);
   mutt_menu_free(&rd.menu);
 
-  if (rd.extra->win_index)
+  if (rd.pview->win_index)
   {
-    rd.extra->win_index->size = MUTT_WIN_SIZE_MAXIMISE;
-    rd.extra->win_index->req_rows = MUTT_WIN_SIZE_UNLIMITED;
-    rd.extra->win_index->parent->size = MUTT_WIN_SIZE_MAXIMISE;
-    rd.extra->win_index->parent->req_rows = MUTT_WIN_SIZE_UNLIMITED;
-    window_set_visible(rd.extra->win_index->parent, true);
+    rd.pview->win_index->size = MUTT_WIN_SIZE_MAXIMISE;
+    rd.pview->win_index->req_rows = MUTT_WIN_SIZE_UNLIMITED;
+    rd.pview->win_index->parent->size = MUTT_WIN_SIZE_MAXIMISE;
+    rd.pview->win_index->parent->req_rows = MUTT_WIN_SIZE_UNLIMITED;
+    window_set_visible(rd.pview->win_index->parent, true);
   }
-  window_set_visible(rd.extra->win_pager->parent, false);
-  mutt_window_reflow(dialog_find(rd.extra->win_pager));
+  window_set_visible(rd.pview->win_pager->parent, false);
+  mutt_window_reflow(dialog_find(rd.pview->win_pager));
 
   return (rc != -1) ? rc : 0;
 }

--- a/send/sendmail.c
+++ b/send/sendmail.c
@@ -434,8 +434,16 @@ int mutt_invoke_sendmail(struct Mailbox *m, struct AddressList *from,
 
         if ((stat(childout, &st) == 0) && (st.st_size > 0))
         {
-          mutt_do_pager(_("Output of the delivery process"), childout,
-                        MUTT_PAGER_NO_FLAGS, NULL);
+          struct PagerData pdata = { 0 };
+          struct PagerView pview = { &pdata };
+
+          pdata.fname = childout;
+
+          pview.banner = _("Output of the delivery process");
+          pview.flags = MUTT_PAGER_NO_FLAGS;
+          pview.mode = PAGER_MODE_OTHER;
+
+          mutt_do_pager(&pview);
         }
       }
     }


### PR DESCRIPTION
Here is @ngortheone's Pager refactoring.

There's quite a lot of churn, because the Pager code is a extremely complicated,
but the main changes are fairly straightforward.

- **Remove references to the global variable `Context`**
  The Index should pass in a parameter `struct Context *ctx` instead.

- **Move local variables into `struct PagerData` and `struct PagerView`**
  The goal is to turn the Index/Pager into sets of functions that work upon some shared data.

- **Define specific modes of display: Viewing: email, plain text, help, etc**
  Eliminate the cryptic macros which used to determine behaviour.
  This may lead to separate top-level functions for displaying: emails, plain text, help, etc

- **Eliminate some static variables which controlled behaviour**
  Like the mode macros, these variables complicate the code making refactoring difficult.

---

- 40672ad5dd Context removal
- 7117632dc8 comments, whitespace
- 8292b85486 refactoring part 1
- 8ae00f5450 group and reorganize init code
- 09f60e2477 remove ugly static variable
- 1a889ddb7c extract help menu mapping resolution out of mutt_pager
- 8efeba1a5b get rid of InHelp global var
