### PR TITLE
refactor: Don't use the global Context when not necessary

### DIFF
--- a/alias/dlgalias.c
+++ b/alias/dlgalias.c
@@ -42,6 +42,7 @@
 #include "lib.h"
 #include "pattern/lib.h"
 #include "alias.h"
+#include "context.h"
 #include "format_flags.h"
 #include "gui.h"
 #include "keymap.h"
@@ -165,7 +166,10 @@ static int alias_alias_observer(struct NotifyCallback *nc)
     alias_array_alias_add(&mdata->ava, alias);
 
     if (alias_array_count_visible(&mdata->ava) != ARRAY_SIZE(&mdata->ava))
-      mutt_pattern_alias_func(MUTT_LIMIT, NULL, _("Aliases"), mdata, Context, menu);
+    {
+      mutt_pattern_alias_func(MUTT_LIMIT, NULL, _("Aliases"), mdata,
+                              ctx_mailbox(Context), menu);
+    }
   }
   else if (nc->event_subtype == NT_ALIAS_DELETED)
   {
@@ -302,7 +306,8 @@ static void dlg_select_alias(char *buf, size_t buflen, struct AliasMenuData *mda
       case OP_SEARCH_NEXT:
       case OP_SEARCH_OPPOSITE:
       case OP_SEARCH:
-        menu->current = mutt_search_alias_command(Context, menu, menu->current, op);
+        menu->current =
+            mutt_search_alias_command(ctx_mailbox(Context), menu, menu->current, op);
         if (menu->current == -1)
           menu->current = menu->oldcurrent;
         else
@@ -311,8 +316,9 @@ static void dlg_select_alias(char *buf, size_t buflen, struct AliasMenuData *mda
 
       case OP_MAIN_LIMIT:
       {
-        int result = mutt_pattern_alias_func(MUTT_LIMIT, _("Limit to messages matching: "),
-                                             _("Aliases"), mdata, Context, menu);
+        int result =
+            mutt_pattern_alias_func(MUTT_LIMIT, _("Limit to messages matching: "),
+                                    _("Aliases"), mdata, ctx_mailbox(Context), menu);
         if (result == 0)
         {
           alias_array_sort(&mdata->ava, mdata->sub);
@@ -440,7 +446,8 @@ int alias_complete(char *buf, size_t buflen, struct ConfigSubset *sub)
       alias_array_alias_add(&mdata.ava, np);
     }
 
-    mutt_pattern_alias_func(MUTT_LIMIT, NULL, _("Aliases"), &mdata, Context, NULL);
+    mutt_pattern_alias_func(MUTT_LIMIT, NULL, _("Aliases"), &mdata,
+                            ctx_mailbox(Context), NULL);
   }
 
   alias_array_sort(&mdata.ava, mdata.sub);

--- a/alias/dlgalias.c
+++ b/alias/dlgalias.c
@@ -167,8 +167,7 @@ static int alias_alias_observer(struct NotifyCallback *nc)
 
     if (alias_array_count_visible(&mdata->ava) != ARRAY_SIZE(&mdata->ava))
     {
-      mutt_pattern_alias_func(MUTT_LIMIT, NULL, _("Aliases"), mdata,
-                              ctx_mailbox(Context), menu);
+      mutt_pattern_alias_func(MUTT_LIMIT, NULL, _("Aliases"), mdata, menu);
     }
   }
   else if (nc->event_subtype == NT_ALIAS_DELETED)
@@ -306,8 +305,7 @@ static void dlg_select_alias(char *buf, size_t buflen, struct AliasMenuData *mda
       case OP_SEARCH_NEXT:
       case OP_SEARCH_OPPOSITE:
       case OP_SEARCH:
-        menu->current =
-            mutt_search_alias_command(ctx_mailbox(Context), menu, menu->current, op);
+        menu->current = mutt_search_alias_command(menu, menu->current, op);
         if (menu->current == -1)
           menu->current = menu->oldcurrent;
         else
@@ -316,9 +314,8 @@ static void dlg_select_alias(char *buf, size_t buflen, struct AliasMenuData *mda
 
       case OP_MAIN_LIMIT:
       {
-        int result =
-            mutt_pattern_alias_func(MUTT_LIMIT, _("Limit to messages matching: "),
-                                    _("Aliases"), mdata, ctx_mailbox(Context), menu);
+        int result = mutt_pattern_alias_func(MUTT_LIMIT, _("Limit to messages matching: "),
+                                             _("Aliases"), mdata, menu);
         if (result == 0)
         {
           alias_array_sort(&mdata->ava, mdata->sub);
@@ -446,8 +443,7 @@ int alias_complete(char *buf, size_t buflen, struct ConfigSubset *sub)
       alias_array_alias_add(&mdata.ava, np);
     }
 
-    mutt_pattern_alias_func(MUTT_LIMIT, NULL, _("Aliases"), &mdata,
-                            ctx_mailbox(Context), NULL);
+    mutt_pattern_alias_func(MUTT_LIMIT, NULL, _("Aliases"), &mdata, NULL);
   }
 
   alias_array_sort(&mdata.ava, mdata.sub);

--- a/alias/dlgquery.c
+++ b/alias/dlgquery.c
@@ -45,6 +45,7 @@
 #include "pattern/lib.h"
 #include "send/lib.h"
 #include "alias.h"
+#include "context.h"
 #include "format_flags.h"
 #include "gui.h"
 #include "keymap.h"
@@ -515,7 +516,8 @@ static void dlg_select_query(char *buf, size_t buflen, struct AliasList *all,
       case OP_SEARCH_NEXT:
       case OP_SEARCH_OPPOSITE:
       case OP_SEARCH:
-        menu->current = mutt_search_alias_command(Context, menu, menu->current, op);
+        menu->current =
+            mutt_search_alias_command(ctx_mailbox(Context), menu, menu->current, op);
         if (menu->current == -1)
           menu->current = menu->oldcurrent;
         else
@@ -524,8 +526,9 @@ static void dlg_select_query(char *buf, size_t buflen, struct AliasList *all,
 
       case OP_MAIN_LIMIT:
       {
-        int result = mutt_pattern_alias_func(MUTT_LIMIT, _("Limit to messages matching: "),
-                                             _("Query"), &mdata, Context, menu);
+        int result =
+            mutt_pattern_alias_func(MUTT_LIMIT, _("Limit to messages matching: "),
+                                    _("Query"), &mdata, ctx_mailbox(Context), menu);
 
         if (result == 0)
         {

--- a/alias/dlgquery.c
+++ b/alias/dlgquery.c
@@ -516,8 +516,7 @@ static void dlg_select_query(char *buf, size_t buflen, struct AliasList *all,
       case OP_SEARCH_NEXT:
       case OP_SEARCH_OPPOSITE:
       case OP_SEARCH:
-        menu->current =
-            mutt_search_alias_command(ctx_mailbox(Context), menu, menu->current, op);
+        menu->current = mutt_search_alias_command(menu, menu->current, op);
         if (menu->current == -1)
           menu->current = menu->oldcurrent;
         else
@@ -526,9 +525,8 @@ static void dlg_select_query(char *buf, size_t buflen, struct AliasList *all,
 
       case OP_MAIN_LIMIT:
       {
-        int result =
-            mutt_pattern_alias_func(MUTT_LIMIT, _("Limit to messages matching: "),
-                                    _("Query"), &mdata, ctx_mailbox(Context), menu);
+        int result = mutt_pattern_alias_func(
+            MUTT_LIMIT, _("Limit to messages matching: "), _("Query"), &mdata, menu);
 
         if (result == 0)
         {

--- a/commands.c
+++ b/commands.c
@@ -1456,12 +1456,11 @@ bool mutt_edit_content_type(struct Email *e, struct Body *b, FILE *fp)
 
 /**
  * check_traditional_pgp - Check for an inline PGP content
- * @param[in]  m      Mailbox
- * @param[in]  e      Email to check
- * @param[out] redraw Flags if the screen needs redrawing, see #MuttRedrawFlags
+ * @param m Mailbox
+ * @param e Email to check
  * @retval true Message contains inline PGP content
  */
-static bool check_traditional_pgp(struct Mailbox *m, struct Email *e, MuttRedrawFlags *redraw)
+static bool check_traditional_pgp(struct Mailbox *m, struct Email *e)
 {
   bool rc = false;
 
@@ -1474,7 +1473,6 @@ static bool check_traditional_pgp(struct Mailbox *m, struct Email *e, MuttRedraw
   if (crypt_pgp_check_traditional(msg->fp, e->body, false))
   {
     e->security = crypt_query(e->body);
-    *redraw |= REDRAW_FULL;
     rc = true;
   }
 
@@ -1485,19 +1483,18 @@ static bool check_traditional_pgp(struct Mailbox *m, struct Email *e, MuttRedraw
 
 /**
  * mutt_check_traditional_pgp - Check if a message has inline PGP content
- * @param[in]  m      Mailbox
- * @param[in]  el     List of Emails to check
- * @param[out] redraw Flags if the screen needs redrawing, see #MuttRedrawFlags
+ * @param m  Mailbox
+ * @param el List of Emails to check
  * @retval true Message contains inline PGP content
  */
-bool mutt_check_traditional_pgp(struct Mailbox *m, struct EmailList *el, MuttRedrawFlags *redraw)
+bool mutt_check_traditional_pgp(struct Mailbox *m, struct EmailList *el)
 {
   bool rc = false;
   struct EmailNode *en = NULL;
   STAILQ_FOREACH(en, el, entries)
   {
     if (!(en->email->security & PGP_TRADITIONAL_CHECKED))
-      rc = check_traditional_pgp(m, en->email, redraw) || rc;
+      rc = check_traditional_pgp(m, en->email) || rc;
   }
 
   return rc;

--- a/commands.h
+++ b/commands.h
@@ -55,7 +55,7 @@ enum MessageSaveOpt
 
 void ci_bounce_message(struct Mailbox *m, struct EmailList *el);
 void mutt_check_stats(struct Mailbox *m);
-bool mutt_check_traditional_pgp(struct Mailbox *m, struct EmailList *el, MuttRedrawFlags *redraw);
+bool mutt_check_traditional_pgp(struct Mailbox *m, struct EmailList *el);
 void mutt_commands_cleanup(void);
 void mutt_display_address(struct Envelope *env);
 int  mutt_display_message(struct MuttWindow *win_index, struct MuttWindow *win_ibar, struct MuttWindow *win_pager, struct MuttWindow *win_pbar, struct Mailbox *m, struct Email *e);

--- a/commands.h
+++ b/commands.h
@@ -64,7 +64,7 @@ void mutt_enter_command(void);
 void mutt_pipe_message(struct Mailbox *m, struct EmailList *el);
 void mutt_print_message(struct Mailbox *m, struct EmailList *el);
 int  mutt_save_message(struct Mailbox *m, struct EmailList *el, enum MessageSaveOpt, enum MessageTransformOpt transform_opt);
-int  mutt_save_message_ctx(struct Email *e, enum MessageSaveOpt, enum MessageTransformOpt transform_opt, struct Mailbox *m);
+int mutt_save_message_ctx(struct Mailbox *m_src, struct Email *e, enum MessageSaveOpt save_opt, enum MessageTransformOpt transform_opt, struct Mailbox *m_dst);
 bool mutt_select_sort(bool reverse);
 bool mutt_shell_escape(void);
 

--- a/copy.c
+++ b/copy.c
@@ -905,22 +905,22 @@ static int append_message(struct Mailbox *dest, FILE *fp_in, struct Mailbox *src
 
 /**
  * mutt_append_message - Append a message
- * @param dest    Destination Mailbox
- * @param src     Source Mailbox
+ * @param m_dst   Destination Mailbox
+ * @param m_src   Source Mailbox
  * @param e       Email
  * @param cmflags Flags, see #CopyMessageFlags
  * @param chflags Flags, see #CopyHeaderFlags
  * @retval  0 Success
  * @retval -1 Failure
  */
-int mutt_append_message(struct Mailbox *dest, struct Mailbox *src, struct Email *e,
+int mutt_append_message(struct Mailbox *m_dst, struct Mailbox *m_src, struct Email *e,
                         CopyMessageFlags cmflags, CopyHeaderFlags chflags)
 {
-  struct Message *msg = mx_msg_open(src, e->msgno);
+  struct Message *msg = mx_msg_open(m_src, e->msgno);
   if (!msg)
     return -1;
-  int rc = append_message(dest, msg->fp, src, e, cmflags, chflags);
-  mx_msg_close(src, &msg);
+  int rc = append_message(m_dst, msg->fp, m_src, e, cmflags, chflags);
+  mx_msg_close(m_src, &msg);
   return rc;
 }
 

--- a/copy.h
+++ b/copy.h
@@ -78,6 +78,6 @@ int mutt_copy_header(FILE *fp_in, struct Email *e, FILE *fp_out, CopyHeaderFlags
 int mutt_copy_message_fp(FILE *fp_out, FILE *fp_in,       struct Email *e, CopyMessageFlags cmflags, CopyHeaderFlags chflags, int wraplen);
 int mutt_copy_message   (FILE *fp_out, struct Mailbox *m, struct Email *e, CopyMessageFlags cmflags, CopyHeaderFlags chflags, int wraplen);
 
-int mutt_append_message(struct Mailbox *dest, struct Mailbox *src, struct Email *e, CopyMessageFlags cmflags, CopyHeaderFlags chflags);
+int mutt_append_message(struct Mailbox *m_dst, struct Mailbox *m_src, struct Email *e, CopyMessageFlags cmflags, CopyHeaderFlags chflags);
 
 #endif /* MUTT_COPY_H */

--- a/gui/color.c
+++ b/gui/color.c
@@ -995,7 +995,7 @@ static enum CommandResult add_pattern(struct Colors *c, struct ColorLineList *to
       const char *const c_simple_search =
           cs_subset_string(NeoMutt->sub, "simple_search");
       mutt_check_simple(buf, NONULL(c_simple_search));
-      tmp->color_pattern = mutt_pattern_comp(Context, buf->data, MUTT_PC_FULL_MSG, err);
+      tmp->color_pattern = mutt_pattern_comp(ctx_mailbox(Context), Context ? Context->menu : NULL, buf->data, MUTT_PC_FULL_MSG, err);
       mutt_buffer_pool_release(&buf);
       if (!tmp->color_pattern)
       {

--- a/hook.c
+++ b/hook.c
@@ -266,7 +266,8 @@ enum CommandResult mutt_parse_hook(struct Buffer *buf, struct Buffer *s,
     else
       comp_flags = MUTT_PC_FULL_MSG;
 
-    pat = mutt_pattern_comp(Context, mutt_buffer_string(pattern), comp_flags, err);
+    pat = mutt_pattern_comp(ctx_mailbox(Context), Context ? Context->menu : NULL,
+                            mutt_buffer_string(pattern), comp_flags, err);
     if (!pat)
       goto cleanup;
   }
@@ -438,7 +439,8 @@ enum CommandResult mutt_parse_idxfmt_hook(struct Buffer *buf, struct Buffer *s,
    * used for date ranges, and they need to be evaluated relative to "now", not
    * the hook compilation time.  */
   struct PatternList *pat =
-      mutt_pattern_comp(Context, mutt_buffer_string(pattern),
+      mutt_pattern_comp(ctx_mailbox(Context), Context ? Context->menu : NULL,
+                        mutt_buffer_string(pattern),
                         MUTT_PC_FULL_MSG | MUTT_PC_PATTERN_DYNAMIC, err);
   if (!pat)
     goto out;

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -1624,7 +1624,7 @@ enum MxStatus imap_sync_mailbox(struct Mailbox *m, bool expunge, bool close)
         }
         bool save_append = m->append;
         m->append = true;
-        mutt_save_message_ctx(e, SAVE_MOVE, TRANSFORM_NONE, m);
+        mutt_save_message_ctx(m, e, SAVE_MOVE, TRANSFORM_NONE, m);
         m->append = save_append;
         /* TODO: why the check for e->env?  Is this possible? */
         if (e->env)

--- a/index/index.c
+++ b/index/index.c
@@ -2650,7 +2650,8 @@ int mutt_index_menu(struct MuttWindow *dlg)
         {
           struct EmailList el = STAILQ_HEAD_INITIALIZER(el);
           el_add_tagged(&el, Context, cur.e, tag);
-          mutt_check_traditional_pgp(ctx_mailbox(Context), &el, &menu->redraw);
+          if (mutt_check_traditional_pgp(ctx_mailbox(Context), &el))
+            menu->redraw |= REDRAW_FULL;
           emaillist_clear(&el);
         }
         set_current_email(&cur, mutt_get_virt_email(Context->mailbox, menu->current));
@@ -3511,7 +3512,8 @@ int mutt_index_menu(struct MuttWindow *dlg)
         {
           struct EmailList el = STAILQ_HEAD_INITIALIZER(el);
           el_add_tagged(&el, Context, cur.e, tag);
-          mutt_check_traditional_pgp(ctx_mailbox(Context), &el, &menu->redraw);
+          if (mutt_check_traditional_pgp(ctx_mailbox(Context), &el))
+            menu->redraw |= REDRAW_FULL;
           emaillist_clear(&el);
         }
         struct EmailList el = STAILQ_HEAD_INITIALIZER(el);
@@ -3535,7 +3537,8 @@ int mutt_index_menu(struct MuttWindow *dlg)
             cs_subset_bool(NeoMutt->sub, "pgp_auto_decode");
         if (c_pgp_auto_decode && (tag || !(cur.e->security & PGP_TRADITIONAL_CHECKED)))
         {
-          mutt_check_traditional_pgp(ctx_mailbox(Context), &el, &menu->redraw);
+          if (mutt_check_traditional_pgp(ctx_mailbox(Context), &el))
+            menu->redraw |= REDRAW_FULL;
         }
         mutt_send_message(SEND_FORWARD, NULL, NULL, Context, &el, NeoMutt->sub);
         emaillist_clear(&el);
@@ -3565,7 +3568,8 @@ int mutt_index_menu(struct MuttWindow *dlg)
             cs_subset_bool(NeoMutt->sub, "pgp_auto_decode");
         if (c_pgp_auto_decode && (tag || !(cur.e->security & PGP_TRADITIONAL_CHECKED)))
         {
-          mutt_check_traditional_pgp(ctx_mailbox(Context), &el, &menu->redraw);
+          if (mutt_check_traditional_pgp(ctx_mailbox(Context), &el))
+            menu->redraw |= REDRAW_FULL;
         }
         mutt_send_message(replyflags, NULL, NULL, Context, &el, NeoMutt->sub);
         emaillist_clear(&el);
@@ -3614,7 +3618,8 @@ int mutt_index_menu(struct MuttWindow *dlg)
             cs_subset_bool(NeoMutt->sub, "pgp_auto_decode");
         if (c_pgp_auto_decode && (tag || !(cur.e->security & PGP_TRADITIONAL_CHECKED)))
         {
-          mutt_check_traditional_pgp(ctx_mailbox(Context), &el, &menu->redraw);
+          if (mutt_check_traditional_pgp(ctx_mailbox(Context), &el))
+            menu->redraw |= REDRAW_FULL;
         }
         mutt_send_message(SEND_REPLY | SEND_LIST_REPLY, NULL, NULL, Context,
                           &el, NeoMutt->sub);
@@ -3665,7 +3670,8 @@ int mutt_index_menu(struct MuttWindow *dlg)
         {
           struct EmailList el = STAILQ_HEAD_INITIALIZER(el);
           el_add_tagged(&el, Context, cur.e, tag);
-          mutt_check_traditional_pgp(ctx_mailbox(Context), &el, &menu->redraw);
+          if (mutt_check_traditional_pgp(ctx_mailbox(Context), &el))
+            menu->redraw |= REDRAW_FULL;
           emaillist_clear(&el);
         }
 
@@ -3887,7 +3893,8 @@ int mutt_index_menu(struct MuttWindow *dlg)
             cs_subset_bool(NeoMutt->sub, "pgp_auto_decode");
         if (c_pgp_auto_decode && (tag || !(cur.e->security & PGP_TRADITIONAL_CHECKED)))
         {
-          mutt_check_traditional_pgp(ctx_mailbox(Context), &el, &menu->redraw);
+          if (mutt_check_traditional_pgp(ctx_mailbox(Context), &el))
+            menu->redraw |= REDRAW_FULL;
         }
         mutt_send_message(SEND_REPLY, NULL, NULL, Context, &el, NeoMutt->sub);
         emaillist_clear(&el);

--- a/index/index.c
+++ b/index/index.c
@@ -1941,7 +1941,7 @@ int mutt_index_menu(struct MuttWindow *dlg)
       case OP_SEARCH:
         if (!prereq(Context, menu, CHECK_IN_MAILBOX))
           break;
-        menu->current = mutt_search_command(Context, Context->mailbox, menu->current, op);
+        menu->current = mutt_search_command(Context->mailbox, menu, menu->current, op);
         if (menu->current == -1)
           menu->current = menu->oldcurrent;
         else

--- a/init.c
+++ b/init.c
@@ -149,6 +149,7 @@ static void candidate(char *user, const char *src, char *dest, size_t dlen)
  */
 static int complete_all_nm_tags(const char *pt)
 {
+  struct Mailbox *m = ctx_mailbox(Context);
   int tag_count_1 = 0;
   int tag_count_2 = 0;
 
@@ -157,10 +158,10 @@ static int complete_all_nm_tags(const char *pt)
   memset(Matches, 0, MatchesListsize);
   memset(Completed, 0, sizeof(Completed));
 
-  nm_db_longrun_init(Context->mailbox, false);
+  nm_db_longrun_init(m, false);
 
   /* Work out how many tags there are. */
-  if (nm_get_all_tags(Context->mailbox, NULL, &tag_count_1) || (tag_count_1 == 0))
+  if (nm_get_all_tags(m, NULL, &tag_count_1) || (tag_count_1 == 0))
     goto done;
 
   /* Free the old list, if any. */
@@ -175,11 +176,11 @@ static int complete_all_nm_tags(const char *pt)
   nm_tags[tag_count_1] = NULL;
 
   /* Get all the tags. */
-  if (nm_get_all_tags(Context->mailbox, nm_tags, &tag_count_2) || (tag_count_1 != tag_count_2))
+  if (nm_get_all_tags(m, nm_tags, &tag_count_2) || (tag_count_1 != tag_count_2))
   {
     FREE(&nm_tags);
     nm_tags = NULL;
-    nm_db_longrun_done(Context->mailbox);
+    nm_db_longrun_done(m);
     return -1;
   }
 
@@ -193,7 +194,7 @@ static int complete_all_nm_tags(const char *pt)
   Matches[NumMatched++] = UserTyped;
 
 done:
-  nm_db_longrun_done(Context->mailbox);
+  nm_db_longrun_done(m);
   return 0;
 }
 #endif

--- a/pattern/compile.c
+++ b/pattern/compile.c
@@ -897,12 +897,15 @@ static int eat_range_by_regex(struct Pattern *pat, struct Buffer *s, int kind,
   /* Special case for a bare 0. */
   if ((kind == RANGE_K_BARE) && (pat->min == 0) && (pat->max == 0))
   {
-    if (!menu)
+    if (!m || !menu)
     {
       mutt_buffer_strcpy(err, _("No current message"));
       return RANGE_E_CTX;
     }
     struct Email *e = mutt_get_virt_email(m, menu->current);
+    if (!e)
+      return RANGE_E_CTX;
+
     pat->max = EMSG(e);
     pat->min = pat->max;
   }
@@ -929,9 +932,9 @@ static bool eat_message_range(struct Pattern *pat, PatternCompFlags flags,
                               struct Buffer *s, struct Buffer *err,
                               struct Mailbox *m, struct Menu *menu)
 {
-  if (!menu)
+  if (!m || !menu)
   {
-    // We need a Context for pretty much anything
+    // We need these for pretty much anything
     mutt_buffer_strcpy(err, _("No Context"));
     return false;
   }

--- a/pattern/lib.h
+++ b/pattern/lib.h
@@ -56,11 +56,11 @@ struct Menu;
 
 #define MUTT_ALIAS_SIMPLESEARCH "~f %s | ~t %s | ~c %s"
 
-typedef uint8_t PatternCompFlags;       ///< Flags for mutt_pattern_comp(), e.g. #MUTT_PC_FULL_MSG
-#define MUTT_PC_NO_FLAGS            0   ///< No flags are set
-#define MUTT_PC_FULL_MSG        (1<<0)  ///< Enable body and header matching
-#define MUTT_PC_PATTERN_DYNAMIC (1<<1)  ///< Enable runtime date range evaluation
-#define MUTT_PC_SEND_MODE_SEARCH (1<<2) ///< Allow send-mode body searching
+typedef uint8_t PatternCompFlags;           ///< Flags for mutt_pattern_comp(), e.g. #MUTT_PC_FULL_MSG
+#define MUTT_PC_NO_FLAGS                0   ///< No flags are set
+#define MUTT_PC_FULL_MSG          (1 << 0)  ///< Enable body and header matching
+#define MUTT_PC_PATTERN_DYNAMIC   (1 << 1)  ///< Enable runtime date range evaluation
+#define MUTT_PC_SEND_MODE_SEARCH  (1 << 2)  ///< Allow send-mode body searching
 
 /**
  * struct Pattern - A simple (non-regex) pattern
@@ -175,7 +175,7 @@ int mutt_pattern_exec(struct Pattern *pat, PatternExecFlags flags, struct Mailbo
 int mutt_pattern_alias_exec(struct Pattern *pat, PatternExecFlags flags,
                             struct AliasView *av, struct PatternCache *cache);
 
-struct PatternList *mutt_pattern_comp(struct Context *ctx, const char *s, PatternCompFlags flags, struct Buffer *err);
+struct PatternList *mutt_pattern_comp(struct Mailbox *m, struct Menu *menu, const char *s, PatternCompFlags flags, struct Buffer *err);
 void mutt_check_simple(struct Buffer *s, const char *simple);
 void mutt_pattern_free(struct PatternList **pat);
 bool dlg_select_pattern(char *buf, size_t buflen);
@@ -184,9 +184,9 @@ int mutt_which_case(const char *s);
 int mutt_is_list_recipient(bool all_addr, struct Envelope *e);
 int mutt_is_subscribed_list_recipient(bool all_addr, struct Envelope *e);
 int mutt_pattern_func(struct Context *ctx, int op, char *prompt);
-int mutt_pattern_alias_func(int op, char *prompt, char *title, struct AliasMenuData *mdata, struct Context *ctx, struct Menu *menu);
-int mutt_search_command(struct Context *ctx, struct Mailbox *m, int cur, int op);
-int mutt_search_alias_command(struct Context *ctx, struct Menu *menu, int cur, int op);
+int mutt_pattern_alias_func(int op, char *prompt, char *menu_name, struct AliasMenuData *mdata, struct Mailbox *m, struct Menu *menu);
+int mutt_search_command(struct Mailbox *m, struct Menu *menu, int cur, int op);
+int mutt_search_alias_command(struct Mailbox *m, struct Menu *menu, int cur, int op);
 
 bool mutt_limit_current_thread(struct Context *ctx, struct Email *e);
 

--- a/pattern/lib.h
+++ b/pattern/lib.h
@@ -184,9 +184,9 @@ int mutt_which_case(const char *s);
 int mutt_is_list_recipient(bool all_addr, struct Envelope *e);
 int mutt_is_subscribed_list_recipient(bool all_addr, struct Envelope *e);
 int mutt_pattern_func(struct Context *ctx, int op, char *prompt);
-int mutt_pattern_alias_func(int op, char *prompt, char *menu_name, struct AliasMenuData *mdata, struct Mailbox *m, struct Menu *menu);
+int mutt_pattern_alias_func(int op, char *prompt, char *menu_name, struct AliasMenuData *mdata, struct Menu *menu);
 int mutt_search_command(struct Mailbox *m, struct Menu *menu, int cur, int op);
-int mutt_search_alias_command(struct Mailbox *m, struct Menu *menu, int cur, int op);
+int mutt_search_alias_command(struct Menu *menu, int cur, int op);
 
 bool mutt_limit_current_thread(struct Context *ctx, struct Email *e);
 

--- a/pattern/pattern.c
+++ b/pattern/pattern.c
@@ -235,13 +235,13 @@ bool mutt_limit_current_thread(struct Context *ctx, struct Email *e)
  * @param prompt    Prompt to show the user
  * @param menu_name Name of the current menu, e.g. Aliases, Query
  * @param mdata     Menu data holding Aliases
- * @param ctx       Current Mailbox
+ * @param m         Mailbox
  * @param menu      Current menu
  * @retval  0 Success
  * @retval -1 Failure
  */
 int mutt_pattern_alias_func(int op, char *prompt, char *menu_name,
-                            struct AliasMenuData *mdata, struct Context *ctx,
+                            struct AliasMenuData *mdata, struct Mailbox *m,
                             struct Menu *menu)
 {
   int rc = -1;
@@ -274,7 +274,7 @@ int mutt_pattern_alias_func(int op, char *prompt, char *menu_name,
     match_all = mutt_str_equal(pbuf, "~A");
 
     struct Buffer err = mutt_buffer_make(0);
-    pat = mutt_pattern_comp(ctx, buf->data, MUTT_PC_FULL_MSG, &err);
+    pat = mutt_pattern_comp(m, menu, buf->data, MUTT_PC_FULL_MSG, &err);
     if (!pat)
     {
       mutt_error("%s", mutt_buffer_string(&err));
@@ -381,7 +381,8 @@ int mutt_pattern_func(struct Context *ctx, int op, char *prompt)
   mutt_buffer_init(&err);
   err.dsize = 256;
   err.data = mutt_mem_malloc(err.dsize);
-  struct PatternList *pat = mutt_pattern_comp(ctx, buf->data, MUTT_PC_FULL_MSG, &err);
+  struct PatternList *pat =
+      mutt_pattern_comp(m, ctx->menu, buf->data, MUTT_PC_FULL_MSG, &err);
   if (!pat)
   {
     mutt_error("%s", err.data);
@@ -470,7 +471,8 @@ int mutt_pattern_func(struct Context *ctx, int op, char *prompt)
     {
       ctx->pattern = simple;
       simple = NULL; /* don't clobber it */
-      ctx->limit_pattern = mutt_pattern_comp(ctx, buf->data, MUTT_PC_FULL_MSG, &err);
+      ctx->limit_pattern =
+          mutt_pattern_comp(m, ctx->menu, buf->data, MUTT_PC_FULL_MSG, &err);
     }
   }
 
@@ -487,14 +489,14 @@ bail:
 
 /**
  * mutt_search_command - Perform a search
- * @param ctx Current Mailbox
- * @param m   Mailbox to search through
- * @param cur Index number of current email
- * @param op  Operation to perform, e.g. OP_SEARCH_NEXT
- * @retval >= 0 Index of matching email
- * @retval -1 No match, or error
+ * @param m    Mailbox to search through
+ * @param menu Current Menu
+ * @param cur  Index number of current email
+ * @param op   Operation to perform, e.g. OP_SEARCH_NEXT
+ * @retval >=0 Index of matching email
+ * @retval -1  No match, or error
  */
-int mutt_search_command(struct Context *ctx, struct Mailbox *m, int cur, int op)
+int mutt_search_command(struct Mailbox *m, struct Menu *menu, int cur, int op)
 {
   struct Progress progress;
 
@@ -534,7 +536,7 @@ int mutt_search_command(struct Context *ctx, struct Mailbox *m, int cur, int op)
       mutt_pattern_free(&SearchPattern);
       err.dsize = 256;
       err.data = mutt_mem_malloc(err.dsize);
-      SearchPattern = mutt_pattern_comp(ctx, tmp->data, MUTT_PC_FULL_MSG, &err);
+      SearchPattern = mutt_pattern_comp(m, menu, tmp->data, MUTT_PC_FULL_MSG, &err);
       if (!SearchPattern)
       {
         mutt_buffer_pool_release(&tmp);
@@ -639,14 +641,14 @@ int mutt_search_command(struct Context *ctx, struct Mailbox *m, int cur, int op)
 
 /**
  * mutt_search_alias_command - Perform a search
- * @param ctx  Current Mailbox
+ * @param m    Mailbox
  * @param menu Menu to search through
  * @param cur  Index number of current alias
  * @param op   Operation to perform, e.g. OP_SEARCH_NEXT
  * @retval >=0 Index of matching alias
  * @retval -1 No match, or error
  */
-int mutt_search_alias_command(struct Context *ctx, struct Menu *menu, int cur, int op)
+int mutt_search_alias_command(struct Mailbox *m, struct Menu *menu, int cur, int op)
 {
   struct Progress progress;
 
@@ -686,7 +688,7 @@ int mutt_search_alias_command(struct Context *ctx, struct Menu *menu, int cur, i
       mutt_pattern_free(&SearchPattern);
       err.dsize = 256;
       err.data = mutt_mem_malloc(err.dsize);
-      SearchPattern = mutt_pattern_comp(ctx, tmp->data, MUTT_PC_FULL_MSG, &err);
+      SearchPattern = mutt_pattern_comp(m, menu, tmp->data, MUTT_PC_FULL_MSG, &err);
       if (!SearchPattern)
       {
         mutt_buffer_pool_release(&tmp);

--- a/pattern/pattern.c
+++ b/pattern/pattern.c
@@ -235,14 +235,12 @@ bool mutt_limit_current_thread(struct Context *ctx, struct Email *e)
  * @param prompt    Prompt to show the user
  * @param menu_name Name of the current menu, e.g. Aliases, Query
  * @param mdata     Menu data holding Aliases
- * @param m         Mailbox
  * @param menu      Current menu
  * @retval  0 Success
  * @retval -1 Failure
  */
 int mutt_pattern_alias_func(int op, char *prompt, char *menu_name,
-                            struct AliasMenuData *mdata, struct Mailbox *m,
-                            struct Menu *menu)
+                            struct AliasMenuData *mdata, struct Menu *menu)
 {
   int rc = -1;
   struct Progress progress;
@@ -274,7 +272,7 @@ int mutt_pattern_alias_func(int op, char *prompt, char *menu_name,
     match_all = mutt_str_equal(pbuf, "~A");
 
     struct Buffer err = mutt_buffer_make(0);
-    pat = mutt_pattern_comp(m, menu, buf->data, MUTT_PC_FULL_MSG, &err);
+    pat = mutt_pattern_comp(NULL, menu, buf->data, MUTT_PC_FULL_MSG, &err);
     if (!pat)
     {
       mutt_error("%s", mutt_buffer_string(&err));
@@ -641,14 +639,13 @@ int mutt_search_command(struct Mailbox *m, struct Menu *menu, int cur, int op)
 
 /**
  * mutt_search_alias_command - Perform a search
- * @param m    Mailbox
  * @param menu Menu to search through
  * @param cur  Index number of current alias
  * @param op   Operation to perform, e.g. OP_SEARCH_NEXT
  * @retval >=0 Index of matching alias
  * @retval -1 No match, or error
  */
-int mutt_search_alias_command(struct Mailbox *m, struct Menu *menu, int cur, int op)
+int mutt_search_alias_command(struct Menu *menu, int cur, int op)
 {
   struct Progress progress;
 
@@ -688,7 +685,7 @@ int mutt_search_alias_command(struct Mailbox *m, struct Menu *menu, int cur, int
       mutt_pattern_free(&SearchPattern);
       err.dsize = 256;
       err.data = mutt_mem_malloc(err.dsize);
-      SearchPattern = mutt_pattern_comp(m, menu, tmp->data, MUTT_PC_FULL_MSG, &err);
+      SearchPattern = mutt_pattern_comp(NULL, menu, tmp->data, MUTT_PC_FULL_MSG, &err);
       if (!SearchPattern)
       {
         mutt_buffer_pool_release(&tmp);

--- a/postpone.c
+++ b/postpone.c
@@ -279,7 +279,7 @@ static struct Email *dlg_select_postponed_email(struct Context *ctx)
       case OP_SEARCH_NEXT:
       case OP_SEARCH_OPPOSITE:
       case OP_SEARCH:
-        menu->current = mutt_search_command(ctx, ctx->mailbox, menu->current, op);
+        menu->current = mutt_search_command(ctx->mailbox, menu, menu->current, op);
         if (menu->current == -1)
           menu->current = menu->oldcurrent;
         else

--- a/score.c
+++ b/score.c
@@ -36,6 +36,7 @@
 #include "mutt.h"
 #include "score.h"
 #include "pattern/lib.h"
+#include "context.h"
 #include "init.h"
 #include "keymap.h"
 #include "mutt_commands.h"
@@ -124,7 +125,9 @@ enum CommandResult mutt_parse_score(struct Buffer *buf, struct Buffer *s,
       break;
   if (!ptr)
   {
-    struct PatternList *pat = mutt_pattern_comp(Context, pattern, MUTT_PC_NO_FLAGS, err);
+    struct PatternList *pat =
+        mutt_pattern_comp(ctx_mailbox(Context), Context ? Context->menu : NULL,
+                          pattern, MUTT_PC_NO_FLAGS, err);
     if (!pat)
     {
       FREE(&pattern);

--- a/test/pattern/comp.c
+++ b/test/pattern/comp.c
@@ -179,7 +179,7 @@ void test_mutt_pattern_comp(void)
     char *s = "";
 
     mutt_buffer_reset(&err);
-    struct PatternList *pat = mutt_pattern_comp(NULL, s, 0, &err);
+    struct PatternList *pat = mutt_pattern_comp(NULL, NULL, s, 0, &err);
 
     if (!TEST_CHECK(!pat))
     {
@@ -199,7 +199,7 @@ void test_mutt_pattern_comp(void)
     char *s = "x";
 
     mutt_buffer_reset(&err);
-    struct PatternList *pat = mutt_pattern_comp(NULL, s, 0, &err);
+    struct PatternList *pat = mutt_pattern_comp(NULL, NULL, s, 0, &err);
 
     if (!TEST_CHECK(!pat))
     {
@@ -219,7 +219,7 @@ void test_mutt_pattern_comp(void)
     char *s = "=s";
 
     mutt_buffer_reset(&err);
-    struct PatternList *pat = mutt_pattern_comp(NULL, s, 0, &err);
+    struct PatternList *pat = mutt_pattern_comp(NULL, NULL, s, 0, &err);
 
     if (!TEST_CHECK(!pat))
     {
@@ -239,7 +239,7 @@ void test_mutt_pattern_comp(void)
     char *s = "| =s foo";
 
     mutt_buffer_reset(&err);
-    struct PatternList *pat = mutt_pattern_comp(NULL, s, 0, &err);
+    struct PatternList *pat = mutt_pattern_comp(NULL, NULL, s, 0, &err);
 
     if (!TEST_CHECK(!pat))
     {
@@ -259,7 +259,7 @@ void test_mutt_pattern_comp(void)
     char *s = "=s foobar";
 
     mutt_buffer_reset(&err);
-    struct PatternList *pat = mutt_pattern_comp(NULL, s, 0, &err);
+    struct PatternList *pat = mutt_pattern_comp(NULL, NULL, s, 0, &err);
 
     if (!TEST_CHECK(pat != NULL))
     {
@@ -305,7 +305,7 @@ void test_mutt_pattern_comp(void)
     char *s = "! =s foobar";
 
     mutt_buffer_reset(&err);
-    struct PatternList *pat = mutt_pattern_comp(NULL, s, 0, &err);
+    struct PatternList *pat = mutt_pattern_comp(NULL, NULL, s, 0, &err);
 
     if (!TEST_CHECK(pat != NULL))
     {
@@ -352,7 +352,7 @@ void test_mutt_pattern_comp(void)
     char *s = "=s foo =s bar";
 
     mutt_buffer_reset(&err);
-    struct PatternList *pat = mutt_pattern_comp(NULL, s, 0, &err);
+    struct PatternList *pat = mutt_pattern_comp(NULL, NULL, s, 0, &err);
 
     if (!TEST_CHECK(pat != NULL))
     {
@@ -431,7 +431,7 @@ void test_mutt_pattern_comp(void)
     char *s = "(=s foo =s bar)";
 
     mutt_buffer_reset(&err);
-    struct PatternList *pat = mutt_pattern_comp(NULL, s, 0, &err);
+    struct PatternList *pat = mutt_pattern_comp(NULL, NULL, s, 0, &err);
 
     if (!TEST_CHECK(pat != NULL))
     {
@@ -510,7 +510,7 @@ void test_mutt_pattern_comp(void)
     char *s = "! (=s foo =s bar)";
 
     mutt_buffer_reset(&err);
-    struct PatternList *pat = mutt_pattern_comp(NULL, s, 0, &err);
+    struct PatternList *pat = mutt_pattern_comp(NULL, NULL, s, 0, &err);
 
     if (!TEST_CHECK(pat != NULL))
     {
@@ -589,7 +589,7 @@ void test_mutt_pattern_comp(void)
     char *s = "=s foo =s bar =s quux";
 
     mutt_buffer_reset(&err);
-    struct PatternList *pat = mutt_pattern_comp(NULL, s, 0, &err);
+    struct PatternList *pat = mutt_pattern_comp(NULL, NULL, s, 0, &err);
 
     if (!TEST_CHECK(pat != NULL))
     {
@@ -680,7 +680,7 @@ void test_mutt_pattern_comp(void)
     char *s = "!(=s foo|=s bar) =s quux";
 
     mutt_buffer_reset(&err);
-    struct PatternList *pat = mutt_pattern_comp(NULL, s, 0, &err);
+    struct PatternList *pat = mutt_pattern_comp(NULL, NULL, s, 0, &err);
 
     if (!TEST_CHECK(pat != NULL))
     {


### PR DESCRIPTION
These commits reduce function dependencies.
They mostly eliminate the use of the global `Context`.

- 3d3d009b07 strip gui dep from `mutt_check_traditional_pgp()`
  Crypto functions should know about GUI flags

- b86af1a2ae context: eliminate from pattern functions
  Don't pass a Context parameter when only a Mailbox is needed

- 2ac84e2974 context: eliminate from alias/query
  The alias/query patterns don't need a Context/Mailbox

- 0f44eb4d17 context: eliminate from `mutt_save_message_ctx()`
  Pass a Context paramater, rather than using the global

- 237cb9f811 context: reduce complexity of `complete_all_nm_tags()`
  Simple tidying
