### PR TITLE
Return type_changes too for mutt_edit_content_type

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -1344,7 +1344,7 @@ cleanup:
  * @param e  Email
  * @param b  Attachment
  * @param fp File handle to the attachment
- * @retval true A structural change is made
+ * @retval true A Any change is made
  *
  * recvattach requires the return code to know when to regenerate the actx.
  */
@@ -1452,7 +1452,7 @@ bool mutt_edit_content_type(struct Email *e, struct Body *b, FILE *fp)
     e->security |= crypt_query(b);
   }
 
-  return structure_changed;
+  return structure_changed | type_changed;
 }
 
 /**


### PR DESCRIPTION
This fixes #2875

The only other place this function is used other than to calculate when
to redraw changes in compose is in `recvattach_edit_content_type`, but I
think this change improves that.

Not exactly sure of the context around why a user would want to change
the content type of a recieved email, but I can't trigger the longer
path in that function without the changes in this commit

It's either this or undoing the redraw check made in 49e4decd88