### PR TITLE
Do not remove "active" mailboxes

### DIFF
--- a/command_parse.c
+++ b/command_parse.c
@@ -44,7 +44,6 @@
 #include "mutt.h"
 #include "command_parse.h"
 #include "imap/lib.h"
-#include "context.h"
 #include "init.h"
 #include "keymap.h"
 #include "monitor.h"
@@ -1466,7 +1465,7 @@ static void do_unmailboxes(struct Mailbox *m)
 #endif
   m->flags = MB_HIDDEN;
   m->gen = -1;
-  if (Context && (Context->mailbox == m))
+  if (m->opened)
   {
     struct EventMailbox em = { NULL };
     notify_send(NeoMutt->notify, NT_MAILBOX, NT_MAILBOX_SWITCH, &em);


### PR DESCRIPTION
We we are in attach-message mode, we have a stack of two mutt_index_menu
running, and the global Context refers to the mailbox we're browsing to
select the files to attach. The mailbox in the background, where we were
when we started to compose a new message, must be kept alive even if it
is not currently in the Context.

As a side effect, this decontextualizes command_parse.c.

Fixes this use case:
1. open +Inbox
2. compose
3. attach-message, chose another mailbox, e.g., +Sent
5. unmailboxes *
6. <kbd>q</kbd> to get back to compose
7. crash

Fixed #2874 