### PR TITLE
observer: check global_data

### DIFF
--- a/mutt/notify.c
+++ b/mutt/notify.c
@@ -178,7 +178,7 @@ bool notify_observer_add(struct Notify *notify, enum NotifyType type,
     if (!np->observer)
       continue;
 
-    if (np->observer->callback == callback)
+    if ((np->observer->callback == callback) && (np->observer->global_data == global_data))
       return true;
   }
 


### PR DESCRIPTION
When adding observers, check the global_data when looking for duplicates.

Some observers will add the same callback function multiple times, differing only by their associated data.