### PR TITLE
Don't propagate read-only state across reopens

### DIFF
--- a/mx.c
+++ b/mx.c
@@ -335,8 +335,7 @@ struct Context *mx_mbox_open(struct Mailbox *m, OpenMailboxFlags flags)
   ctx->collapsed = false;
 
   m->verbose = !(flags & MUTT_QUIET);
-  if (flags & MUTT_READONLY)
-    m->readonly = true;
+  m->readonly = (flags & MUTT_READONLY);
   m->peekonly = (flags & MUTT_PEEK);
 
   if (flags & (MUTT_APPEND | MUTT_NEWFOLDER))


### PR DESCRIPTION
Fixes a change-folder-readonly +Foo, followed by change-folder +Foo,
which was keeping the folder read-only with no way to get back to a
read-write state.
