### PR TITLE
fix memory leaks

### DIFF
--- a/autocrypt/autocrypt.c
+++ b/autocrypt/autocrypt.c
@@ -959,7 +959,7 @@ void mutt_autocrypt_scan_mailboxes(struct Mailbox *m)
        * as they can do all sorts of things like push into the getch() buffer.
        * Authentication should be in account-hooks. */
       mx_mbox_open(m_ac, MUTT_READONLY);
-      mx_mbox_close(m_ac);
+      mx_mbox_close(&m_ac);
       mutt_buffer_reset(folderbuf);
     }
 

--- a/commands.c
+++ b/commands.c
@@ -1275,8 +1275,9 @@ int mutt_save_message(struct Mailbox *m, struct EmailList *el,
     rc = mutt_save_message_ctx(m, en->email, save_opt, transform_opt, m_save);
     if (rc != 0)
     {
-      mx_mbox_close(m_save);
-      m_save->append = old_append;
+      mx_mbox_close(&m_save);
+      if (m_save)
+        m_save->append = old_append;
       goto errcleanup;
     }
 #ifdef USE_COMP_MBOX
@@ -1334,8 +1335,9 @@ int mutt_save_message(struct Mailbox *m, struct EmailList *el,
 #endif
     if (rc != 0)
     {
-      mx_mbox_close(m_save);
-      m_save->append = old_append;
+      mx_mbox_close(&m_save);
+      if (m_save)
+        m_save->append = old_append;
       goto errcleanup;
     }
   }
@@ -1343,8 +1345,9 @@ int mutt_save_message(struct Mailbox *m, struct EmailList *el,
   const bool need_mailbox_cleanup =
       ((m_save->type == MUTT_MBOX) || (m_save->type == MUTT_MMDF));
 
-  mx_mbox_close(m_save);
-  m_save->append = old_append;
+  mx_mbox_close(&m_save);
+  if (m_save)
+    m_save->append = old_append;
 
   if (need_mailbox_cleanup)
     mutt_mailbox_cleanup(mutt_buffer_string(buf), &st);

--- a/compose/compose.c
+++ b/compose/compose.c
@@ -1325,13 +1325,12 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, uint8_t flags,
         if (!mx_mbox_open(m_attach, MUTT_READONLY))
         {
           mutt_error(_("Unable to open mailbox %s"), mutt_buffer_string(&fname));
-          mx_fastclose_mailbox(m_attach);
-          m_attach = NULL;
+          mx_fastclose_mailbox(&m_attach);
           break;
         }
         if (m_attach->msg_count == 0)
         {
-          mx_mbox_close(m_attach);
+          mx_mbox_close(&m_attach);
           mutt_error(_("No messages in that folder"));
           break;
         }
@@ -1386,7 +1385,7 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, uint8_t flags,
         {
           m_attach->readonly = old_readonly;
         }
-        mx_fastclose_mailbox(m_attach_new);
+        mx_fastclose_mailbox(&m_attach_new);
 
         /* Restore old $sort and $sort_aux */
         cs_subset_str_native_set(sub, "sort", old_sort, NULL);

--- a/context.c
+++ b/context.c
@@ -60,6 +60,7 @@ void ctx_free(struct Context **ptr)
   if (ctx->mailbox)
     notify_observer_remove(ctx->mailbox->notify, ctx_mailbox_observer, ctx);
 
+  mutt_clear_threads(ctx->mailbox, ctx->threads);
   mutt_thread_ctx_free(&ctx->threads);
   notify_free(&ctx->notify);
   FREE(&ctx->pattern);

--- a/context.c
+++ b/context.c
@@ -105,14 +105,14 @@ static void ctx_cleanup(struct Context *ctx)
 {
   FREE(&ctx->pattern);
   mutt_pattern_free(&ctx->limit_pattern);
+  mutt_clear_threads(ctx->mailbox, ctx->threads);
+  mutt_thread_ctx_free(&ctx->threads);
   if (ctx->mailbox)
     notify_observer_remove(ctx->mailbox->notify, ctx_mailbox_observer, ctx);
 
   struct Notify *notify = ctx->notify;
-  struct Mailbox *m = ctx->mailbox;
   memset(ctx, 0, sizeof(struct Context));
   ctx->notify = notify;
-  ctx->mailbox = m;
 }
 
 /**
@@ -319,7 +319,6 @@ int ctx_mailbox_observer(struct NotifyCallback *nc)
   switch (nc->event_subtype)
   {
     case NT_MAILBOX_CLOSED:
-      mutt_clear_threads(ctx->mailbox, ctx->threads);
       ctx_cleanup(ctx);
       break;
     case NT_MAILBOX_INVALID:

--- a/context.c
+++ b/context.c
@@ -89,7 +89,7 @@ struct Context *ctx_new(struct Mailbox *m)
   notify_observer_add(m->notify, NT_MAILBOX, ctx_mailbox_observer, ctx);
 
   ctx->mailbox = m;
-  ctx->threads = mutt_thread_ctx_init(m);
+  ctx->threads = mutt_thread_ctx_init();
   ctx->msg_in_pager = -1;
   ctx->collapsed = false;
   ctx_update(ctx);
@@ -140,7 +140,7 @@ void ctx_update(struct Context *ctx)
   m->vcount = 0;
   m->changed = false;
 
-  mutt_clear_threads(ctx->threads);
+  mutt_clear_threads(ctx->mailbox, ctx->threads);
 
   const bool c_score = cs_subset_bool(NeoMutt->sub, "score");
   struct Email *e = NULL;
@@ -319,7 +319,7 @@ int ctx_mailbox_observer(struct NotifyCallback *nc)
   switch (nc->event_subtype)
   {
     case NT_MAILBOX_CLOSED:
-      mutt_clear_threads(ctx->threads);
+      mutt_clear_threads(ctx->mailbox, ctx->threads);
       ctx_cleanup(ctx);
       break;
     case NT_MAILBOX_INVALID:

--- a/editmsg.c
+++ b/editmsg.c
@@ -85,7 +85,7 @@ static int ev_message(enum EvMessage action, struct Mailbox *m, struct Email *e)
   rc = mutt_append_message(m_fname, m, e, NULL, MUTT_CM_NO_FLAGS, chflags);
   int oerrno = errno;
 
-  mx_mbox_close(m_fname);
+  mx_mbox_close(&m_fname);
 
   if (rc == -1)
   {
@@ -223,7 +223,7 @@ static int ev_message(enum EvMessage action, struct Mailbox *m, struct Email *e)
   {
     rc = -1;
     mutt_error(_("Can't append to folder: %s"), strerror(errno));
-    mx_mbox_close(m);
+    mx_mbox_close(&m);
     goto bail;
   }
 
@@ -237,7 +237,7 @@ static int ev_message(enum EvMessage action, struct Mailbox *m, struct Email *e)
   rc = mx_msg_commit(m, msg);
   mx_msg_close(m, &msg);
 
-  mx_mbox_close(m);
+  mx_mbox_close(&m);
 
 bail:
   mutt_file_fclose(&fp);
@@ -258,7 +258,8 @@ bail:
   else if (rc == -1)
     mutt_message(_("Error. Preserving temporary file: %s"), mutt_buffer_string(fname));
 
-  m->append = old_append;
+  if (m)
+    m->append = old_append;
 
   mutt_buffer_pool_release(&fname);
   return rc;

--- a/imap/command.c
+++ b/imap/command.c
@@ -172,7 +172,7 @@ static void cmd_handle_fatal(struct ImapAccountData *adata)
 
   if ((adata->state >= IMAP_SELECTED) && (mdata->reopen & IMAP_REOPEN_ALLOW))
   {
-    mx_fastclose_mailbox(adata->mailbox);
+    mx_fastclose_mailbox(&adata->mailbox);
     mutt_socket_close(adata->conn);
     mutt_error(_("Mailbox %s@%s closed"), adata->conn->account.user,
                adata->conn->account.host);

--- a/index/dlg_index.c
+++ b/index/dlg_index.c
@@ -692,7 +692,7 @@ static void change_folder_mailbox(struct Menu *menu, struct Mailbox *m, int *old
       new_last_folder = mutt_str_dup(mailbox_path(shared->mailbox));
     *oldcount = shared->mailbox->msg_count;
 
-    const enum MxStatus check = mx_mbox_close(shared->mailbox);
+    const enum MxStatus check = mx_mbox_close(&shared->mailbox);
     if (check == MX_STATUS_OK)
     {
       struct Context *ctx = shared->ctx;
@@ -1876,7 +1876,7 @@ struct Mailbox *mutt_index_menu(struct MuttWindow *dlg, struct Mailbox *m_init)
           notify_send(NeoMutt->notify, NT_GLOBAL, NT_GLOBAL_SHUTDOWN, NULL);
 
           enum MxStatus check = MX_STATUS_OK;
-          if (!shared->ctx || ((check = mx_mbox_close(shared->mailbox)) == MX_STATUS_OK))
+          if (!shared->ctx || ((check = mx_mbox_close(&shared->mailbox)) == MX_STATUS_OK))
           {
             struct Context *ctx = shared->ctx;
             index_shared_data_set_context(shared, NULL);
@@ -2040,7 +2040,7 @@ struct Mailbox *mutt_index_menu(struct MuttWindow *dlg, struct Mailbox *m_init)
       case OP_MAIN_IMAP_LOGOUT_ALL:
         if (shared->mailbox && (shared->mailbox->type == MUTT_IMAP))
         {
-          const enum MxStatus check = mx_mbox_close(shared->mailbox);
+          const enum MxStatus check = mx_mbox_close(&shared->mailbox);
           if (check == MX_STATUS_OK)
           {
             struct Context *ctx = shared->ctx;
@@ -2697,7 +2697,7 @@ struct Mailbox *mutt_index_menu(struct MuttWindow *dlg, struct Mailbox *m_init)
           {
             struct Context *ctx = shared->ctx;
             index_shared_data_set_context(shared, NULL);
-            mx_fastclose_mailbox(shared->mailbox);
+            mx_fastclose_mailbox(&shared->mailbox);
             ctx_free(&ctx);
           }
           priv->done = true;

--- a/index/dlg_index.c
+++ b/index/dlg_index.c
@@ -848,7 +848,9 @@ static void change_folder_string(struct Menu *menu, char *buf, size_t buflen,
   *pager_return = false;
 
   struct Mailbox *m = mx_path_resolve(buf);
+  m->opened++;
   change_folder_mailbox(menu, m, oldcount, shared, read_only);
+  mx_fastclose_mailbox(&m);
 }
 
 /**

--- a/main.c
+++ b/main.c
@@ -1258,9 +1258,10 @@ int main(int argc, char *argv[], char *envp[])
       mutt_debug(LL_NOTIFY, "NT_MAILBOX_SWITCH: %p\n", m);
       notify_send(dlg->notify, NT_MAILBOX, NT_MAILBOX_SWITCH, &ev_m);
 
-      mutt_index_menu(dlg, m);
+      m = mutt_index_menu(dlg, m);
       dialog_pop();
       mutt_window_free(&dlg);
+      mailbox_free(&m);
       log_queue_empty();
       repeat_error = false;
     }

--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -1131,7 +1131,7 @@ static enum MxStatus mbox_mbox_check(struct Mailbox *m)
   /* fatal error */
 
   mbox_unlock_mailbox(m);
-  mx_fastclose_mailbox(m);
+  mx_fastclose_mailbox(&m);
   mutt_sig_unblock();
   mutt_error(_("Mailbox was corrupted"));
   return MX_STATUS_ERROR;
@@ -1175,7 +1175,7 @@ static enum MxStatus mbox_mbox_sync(struct Mailbox *m)
   adata->fp = freopen(mailbox_path(m), "r+", adata->fp);
   if (!adata->fp)
   {
-    mx_fastclose_mailbox(m);
+    mx_fastclose_mailbox(&m);
     mutt_error(_("Fatal error!  Could not reopen mailbox!"));
     goto fatal;
   }
@@ -1346,7 +1346,7 @@ static enum MxStatus mbox_mbox_sync(struct Mailbox *m)
   if (!fp)
   {
     mutt_sig_unblock();
-    mx_fastclose_mailbox(m);
+    mx_fastclose_mailbox(&m);
     mutt_debug(LL_DEBUG1, "unable to reopen temp copy of mailbox!\n");
     mutt_perror(mutt_buffer_string(tempfile));
     FREE(&new_offset);
@@ -1408,7 +1408,7 @@ static enum MxStatus mbox_mbox_sync(struct Mailbox *m)
                        NONULL(ShortHostname), (unsigned int) getpid());
     rename(mutt_buffer_string(tempfile), mutt_buffer_string(savefile));
     mutt_sig_unblock();
-    mx_fastclose_mailbox(m);
+    mx_fastclose_mailbox(&m);
     mutt_buffer_pretty_mailbox(savefile);
     mutt_error(_("Write failed!  Saved partial mailbox to %s"), mutt_buffer_string(savefile));
     mutt_buffer_pool_release(&savefile);
@@ -1430,7 +1430,7 @@ static enum MxStatus mbox_mbox_sync(struct Mailbox *m)
   {
     unlink(mutt_buffer_string(tempfile));
     mutt_sig_unblock();
-    mx_fastclose_mailbox(m);
+    mx_fastclose_mailbox(&m);
     mutt_error(_("Fatal error!  Could not reopen mailbox!"));
     FREE(&new_offset);
     FREE(&old_offset);
@@ -1497,7 +1497,7 @@ bail: /* Come here in case of disaster */
   if (!adata->fp)
   {
     mutt_error(_("Could not reopen mailbox"));
-    mx_fastclose_mailbox(m);
+    mx_fastclose_mailbox(&m);
     goto fatal;
   }
 
@@ -1812,11 +1812,12 @@ static enum MxStatus mbox_mbox_check_stats(struct Mailbox *m, uint8_t flags)
   {
     bool old_peek = m->peekonly;
     mx_mbox_open(m, MUTT_QUIET | MUTT_NOSORT | MUTT_PEEK);
-    mx_mbox_close(m);
-    m->peekonly = old_peek;
+    mx_mbox_close(&m);
+    if (m)
+      m->peekonly = old_peek;
   }
 
-  if (m->has_new || m->msg_new)
+  if (m && (m->has_new || m->msg_new))
     return MX_STATUS_NEW_MAIL;
   return MX_STATUS_OK;
 }

--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -1807,19 +1807,19 @@ static enum MxStatus mbox_mbox_check_stats(struct Mailbox *m, uint8_t flags)
   if (m->newly_created && ((sb.st_ctime != sb.st_mtime) || (sb.st_ctime != sb.st_atime)))
     m->newly_created = false;
 
+  int rc = (m->has_new || m->msg_new) ? MX_STATUS_NEW_MAIL : MX_STATUS_OK;
   if ((flags != 0) && mutt_file_stat_timespec_compare(&sb, MUTT_STAT_MTIME,
                                                       &m->stats_last_checked) > 0)
   {
     bool old_peek = m->peekonly;
     mx_mbox_open(m, MUTT_QUIET | MUTT_NOSORT | MUTT_PEEK);
+    rc = (m->has_new || m->msg_new) ? MX_STATUS_NEW_MAIL : MX_STATUS_OK;
     mx_mbox_close(&m);
     if (m)
       m->peekonly = old_peek;
   }
 
-  if (m && (m->has_new || m->msg_new))
-    return MX_STATUS_NEW_MAIL;
-  return MX_STATUS_OK;
+  return rc;
 }
 
 // clang-format off

--- a/mutt/hash.c
+++ b/mutt/hash.c
@@ -231,14 +231,11 @@ static void union_hash_delete(struct HashTable *table, union HashKey key, const 
       if (table->strdup_keys)
         FREE(&he->key.strkey);
       FREE(&he);
+      return;
+    }
 
-      he = *last;
-    }
-    else
-    {
-      last = &he->next;
-      he = he->next;
-    }
+    last = &he->next;
+    he = he->next;
   }
 }
 

--- a/mutt_attach.c
+++ b/mutt_attach.c
@@ -916,7 +916,7 @@ int mutt_save_attachment(FILE *fp, struct Body *m, const char *path,
                             is_from(buf, NULL, 0, NULL) ? MUTT_MSG_NO_FLAGS : MUTT_ADD_FROM);
       if (!msg)
       {
-        mx_mbox_close(m_att);
+        mx_mbox_close(&m_att);
         return -1;
       }
       if ((m_att->type == MUTT_MBOX) || (m_att->type == MUTT_MMDF))
@@ -933,7 +933,7 @@ int mutt_save_attachment(FILE *fp, struct Body *m, const char *path,
       }
 
       mx_msg_close(m_att, &msg);
-      mx_mbox_close(m_att);
+      mx_mbox_close(&m_att);
       return rc;
     }
     else

--- a/mutt_thread.h
+++ b/mutt_thread.h
@@ -84,20 +84,20 @@ int mutt_aside_thread(struct Email *e, bool forwards, bool subthreads);
 #define mutt_next_subthread(e)     mutt_aside_thread(e, true,  true)
 #define mutt_previous_subthread(e) mutt_aside_thread(e, false, true)
 
-struct ThreadsContext *mutt_thread_ctx_init          (struct Mailbox *m);
+struct ThreadsContext *mutt_thread_ctx_init          (void);
 void                   mutt_thread_ctx_free          (struct ThreadsContext **tctx);
 void                   mutt_thread_collapse_collapsed(struct ThreadsContext *tctx);
 void                   mutt_thread_collapse          (struct ThreadsContext *tctx, bool collapse);
 bool                   mutt_thread_can_collapse      (struct Email *e);
 
-void                   mutt_clear_threads     (struct ThreadsContext *tctx);
+void                   mutt_clear_threads     (struct Mailbox *m, struct ThreadsContext *tctx);
 void                   mutt_draw_tree         (struct ThreadsContext *tctx);
 bool                   mutt_link_threads      (struct Email *parent, struct EmailList *children, struct Mailbox *m);
 struct HashTable *     mutt_make_id_hash      (struct Mailbox *m);
 int                    mutt_messages_in_thread(struct Mailbox *m, struct Email *e, enum MessageInThread mit);
 int                    mutt_parent_message    (struct Email *e, bool find_root);
 off_t                  mutt_set_vnum          (struct Mailbox *m);
-void                   mutt_sort_subthreads   (struct ThreadsContext *tctx, bool init);
-void                   mutt_sort_threads      (struct ThreadsContext *tctx, bool init);
+void                   mutt_sort_subthreads   (struct Mailbox *m, struct ThreadsContext *tctx, bool init);
+void                   mutt_sort_threads      (struct Mailbox *m, struct ThreadsContext *tctx, bool init);
 
 #endif /* MUTT_MUTT_THREAD_H */

--- a/mx.c
+++ b/mx.c
@@ -461,6 +461,7 @@ void mx_fastclose_mailbox(struct Mailbox **ptr)
   if (m->flags & MB_HIDDEN)
   {
     mx_ac_remove(m);
+    mailbox_free(ptr);
   }
 }
 

--- a/mx.h
+++ b/mx.h
@@ -45,7 +45,7 @@ typedef uint8_t MsgOpenFlags;      ///< Flags for mx_msg_open_new(), e.g. #MUTT_
 /* Wrappers for the Mailbox API, see MxOps */
 enum MxStatus   mx_mbox_check      (struct Mailbox *m);
 enum MxStatus   mx_mbox_check_stats(struct Mailbox *m, uint8_t flags);
-enum MxStatus   mx_mbox_close      (struct Mailbox *m);
+enum MxStatus   mx_mbox_close      (struct Mailbox **ptr);
 bool            mx_mbox_open       (struct Mailbox *m, OpenMailboxFlags flags);
 enum MxStatus   mx_mbox_sync       (struct Mailbox *m);
 int             mx_msg_close       (struct Mailbox *m, struct Message **msg);
@@ -75,7 +75,7 @@ int             mx_ac_remove   (struct Mailbox *m);
 int                 mx_access           (const char *path, int flags);
 void                mx_alloc_memory     (struct Mailbox *m);
 int                 mx_path_is_empty    (const char *path);
-void                mx_fastclose_mailbox(struct Mailbox *m);
+void                mx_fastclose_mailbox(struct Mailbox **ptr);
 const struct MxOps *mx_get_ops          (enum MailboxType type);
 bool                mx_tags_is_supported(struct Mailbox *m);
 

--- a/pop/pop.c
+++ b/pop/pop.c
@@ -642,8 +642,9 @@ void pop_fetch_mail(void)
 
     if (ret == -1)
     {
-      m_spool->append = old_append;
-      mx_mbox_close(m_spool);
+      mx_mbox_close(&m_spool);
+      if (m_spool)
+        m_spool->append = old_append;
       goto fail;
     }
     if (ret == -2)
@@ -664,8 +665,9 @@ void pop_fetch_mail(void)
                  msgbuf, i - last, msgs - last);
   }
 
-  m_spool->append = old_append;
-  mx_mbox_close(m_spool);
+  mx_mbox_close(&m_spool);
+  if (m_spool)
+    m_spool->append = old_append;
 
   if (rset)
   {

--- a/postpone.c
+++ b/postpone.c
@@ -182,7 +182,7 @@ int mutt_num_postponed(struct Mailbox *m, bool force)
       mailbox_free(&m_post);
       PostCount = 0;
     }
-    mx_fastclose_mailbox(m_post);
+    mx_fastclose_mailbox(&m_post);
 #ifdef USE_NNTP
     if (optnews)
       OptNews = true;
@@ -305,11 +305,11 @@ static void hardclose(struct Mailbox *m)
 {
   /* messages might have been marked for deletion.
    * try once more on reopen before giving up. */
-  enum MxStatus rc = mx_mbox_close(m);
+  enum MxStatus rc = mx_mbox_close(&m);
   if (rc != MX_STATUS_ERROR && rc != MX_STATUS_OK)
-    rc = mx_mbox_close(m);
+    rc = mx_mbox_close(&m);
   if (rc != MX_STATUS_OK)
-    mx_fastclose_mailbox(m);
+    mx_fastclose_mailbox(&m);
 }
 
 /**
@@ -353,7 +353,7 @@ int mutt_get_postponed(struct Mailbox *m_cur, struct Email *hdr,
     mutt_error(_("No postponed messages"));
     if (m_cur != m)
     {
-      mx_fastclose_mailbox(m);
+      mx_fastclose_mailbox(&m);
     }
     return -1;
   }

--- a/send/sendlib.c
+++ b/send/sendlib.c
@@ -1548,7 +1548,7 @@ int mutt_write_fcc(const char *path, struct Email *e, const char *msgid, bool po
     if (!fp_tmp)
     {
       mutt_perror(mutt_buffer_string(tempfile));
-      mx_mbox_close(m_fcc);
+      mx_mbox_close(&m_fcc);
       goto done;
     }
     /* remember new mail status before appending message */
@@ -1564,7 +1564,7 @@ int mutt_write_fcc(const char *path, struct Email *e, const char *msgid, bool po
   if (!msg)
   {
     mutt_file_fclose(&fp_tmp);
-    mx_mbox_close(m_fcc);
+    mx_mbox_close(&m_fcc);
     goto done;
   }
 
@@ -1688,7 +1688,7 @@ int mutt_write_fcc(const char *path, struct Email *e, const char *msgid, bool po
       unlink(mutt_buffer_string(tempfile));
       mx_msg_commit(m_fcc, msg); /* XXX really? */
       mx_msg_close(m_fcc, &msg);
-      mx_mbox_close(m_fcc);
+      mx_mbox_close(&m_fcc);
       goto done;
     }
 
@@ -1724,7 +1724,7 @@ int mutt_write_fcc(const char *path, struct Email *e, const char *msgid, bool po
   else if (finalpath)
     *finalpath = mutt_str_dup(msg->committed_path);
   mx_msg_close(m_fcc, &msg);
-  mx_mbox_close(m_fcc);
+  mx_mbox_close(&m_fcc);
 
   if (!post && need_mailbox_cleanup)
     mutt_mailbox_cleanup(path, &st);

--- a/sort.c
+++ b/sort.c
@@ -391,7 +391,7 @@ void mutt_sort_headers(struct Mailbox *m, struct ThreadsContext *threads,
      * deleted all the messages.  the virtual message numbers are not updated
      * in that routine, so we must make sure to zero the vcount member.  */
     m->vcount = 0;
-    mutt_clear_threads(threads);
+    mutt_clear_threads(m, threads);
     *vsize = 0;
     return; /* nothing to do! */
   }
@@ -419,7 +419,7 @@ void mutt_sort_headers(struct Mailbox *m, struct ThreadsContext *threads,
   }
 
   if (init)
-    mutt_clear_threads(threads);
+    mutt_clear_threads(m, threads);
 
   const short c_sort = cs_subset_sort(NeoMutt->sub, "sort");
   const short c_sort_aux = cs_subset_sort(NeoMutt->sub, "sort_aux");
@@ -431,11 +431,11 @@ void mutt_sort_headers(struct Mailbox *m, struct ThreadsContext *threads,
     if (OptSortSubthreads)
     {
       cs_subset_str_native_set(NeoMutt->sub, "sort", c_sort_aux, NULL);
-      mutt_sort_subthreads(threads, true);
+      mutt_sort_subthreads(m, threads, true);
       cs_subset_str_native_set(NeoMutt->sub, "sort", c_sort, NULL);
       OptSortSubthreads = false;
     }
-    mutt_sort_threads(threads, init);
+    mutt_sort_threads(m, threads, init);
   }
   else if (!(sortfunc = mutt_get_sort_func(c_sort & SORT_MASK, mx_type(m))) ||
            !(AuxSort = mutt_get_sort_func(c_sort_aux & SORT_MASK, mx_type(m))))


### PR DESCRIPTION
Fix a few memory leaks.

1. In `main()` use the Mailbox returned from `mutt_index_menu()` and free it
2. Free a couple of strings in `mutt_send_message()`
3. Free the Mailbox in `mx_fastclose_mailbox()`
   This function calls `mx_ac_remove()`, but that doesn't free the Mailbox any more

Change `mx_mbox_close()` and `mx_fastclose_mailbox()` to take `Mailbox**`,
so that if they close a Mailbox, they also `NULL` the pointer.

Fixes: #2884 