### PR TITLE
Devel/pager break 2

### DIFF
--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -509,7 +509,8 @@ $(PWD)/notmuch:
 ###############################################################################
 # libpager
 LIBPAGER=	libpager.a
-LIBPAGEROBJS=	pager/config.o pager/pager.o pager/pbar.o pager/private_data.o
+LIBPAGEROBJS=	pager/config.o pager/functions.o pager/pager.o pager/pbar.o \
+		pager/private_data.o
 CLEANFILES+=	$(LIBPAGER) $(LIBPAGEROBJS)
 ALLOBJS+=	$(LIBPAGEROBJS)
 

--- a/commands.c
+++ b/commands.c
@@ -371,8 +371,6 @@ int mutt_display_message(struct MuttWindow *win_index, struct MuttWindow *win_ib
     struct PagerData pdata = { 0 };
     struct PagerView pview = { &pdata };
 
-    pdata.email = e;
-    pdata.ctx = Context;
     pdata.fname = mutt_buffer_string(tempfile);
 
     pview.mode = PAGER_MODE_EMAIL;

--- a/index/functions.c
+++ b/index/functions.c
@@ -130,9 +130,6 @@ static enum IndexRetval op_check_traditional(struct IndexSharedData *shared,
     emaillist_clear(&el);
   }
 
-  if (priv->in_pager)
-    return IR_CONTINUE;
-
   return IR_VOID;
 }
 
@@ -200,10 +197,6 @@ static enum IndexRetval op_delete(struct IndexSharedData *shared,
       {
         priv->menu->current = priv->menu->oldcurrent;
         priv->menu->redraw |= REDRAW_CURRENT;
-      }
-      else if (priv->in_pager)
-      {
-        return IR_CONTINUE;
       }
       else
         priv->menu->redraw |= REDRAW_MOTION_RESYNC;
@@ -315,10 +308,6 @@ static enum IndexRetval op_display_message(struct IndexSharedData *shared,
     return IR_ERROR;
   }
 
-  /* This is used to redirect a single operation back here afterwards.  If
-   * mutt_display_message() returns 0, then this flag and pager state will
-   * be cleaned up after this switch statement. */
-  priv->in_pager = true;
   priv->menu->oldcurrent = priv->menu->current;
   if (shared->mailbox)
   {
@@ -407,9 +396,6 @@ static enum IndexRetval op_edit_type(struct IndexSharedData *shared,
   if (!shared->email)
     return IR_NO_ACTION;
   mutt_edit_content_type(shared->email, shared->email->body, NULL);
-  /* if we were in the pager, redisplay the message */
-  if (priv->in_pager)
-    return IR_CONTINUE;
 
   priv->menu->redraw = REDRAW_CURRENT;
   return IR_VOID;
@@ -444,12 +430,11 @@ static enum IndexRetval op_enter_command(struct IndexSharedData *shared,
 static enum IndexRetval op_exit(struct IndexSharedData *shared,
                                 struct IndexPrivateData *priv, int op)
 {
-  if ((!priv->in_pager) && priv->attach_msg)
+  if (priv->attach_msg)
     return IR_CONTINUE;
 
   const enum QuadOption c_quit = cs_subset_quad(shared->sub, "quit");
-  if ((!priv->in_pager) &&
-      (query_quadoption(c_quit, _("Exit NeoMutt without saving?")) == MUTT_YES))
+  if ((query_quadoption(c_quit, _("Exit NeoMutt without saving?")) == MUTT_YES))
   {
     if (shared->ctx)
     {
@@ -636,9 +621,6 @@ static enum IndexRetval op_jump(struct IndexSharedData *shared,
     priv->menu->current = e->vnum;
   }
 
-  if (priv->in_pager)
-    return IR_CONTINUE;
-
   priv->menu->redraw = REDRAW_FULL;
   //QWQ
   return 0;
@@ -731,9 +713,6 @@ static enum IndexRetval op_main_break_thread(struct IndexSharedData *shared,
     shared->mailbox->changed = true;
     mutt_message(_("Thread broken"));
 
-    if (priv->in_pager)
-      return IR_CONTINUE;
-
     priv->menu->redraw |= REDRAW_INDEX;
   }
   else
@@ -808,8 +787,6 @@ static enum IndexRetval op_main_change_folder(struct IndexSharedData *shared,
 
 changefoldercleanup:
   mutt_buffer_pool_release(&folderbuf);
-  if (priv->in_pager && pager_return)
-    return IR_CONTINUE;
 
   //QWQ
   return 0;
@@ -997,9 +974,6 @@ static enum IndexRetval op_main_link_threads(struct IndexSharedData *shared,
     emaillist_clear(&el);
   }
 
-  if (priv->in_pager)
-    return IR_CONTINUE;
-
   priv->menu->redraw |= REDRAW_INDEX;
   return IR_VOID;
 }
@@ -1092,8 +1066,6 @@ static enum IndexRetval op_main_modify_tags(struct IndexSharedData *shared,
       shared->email->quasi_deleted = !still_queried;
       m->changed = true;
     }
-    if (priv->in_pager)
-      return IR_CONTINUE;
 
     const bool c_resolve = cs_subset_bool(shared->sub, "resolve");
     if (c_resolve)
@@ -1221,9 +1193,6 @@ static enum IndexRetval op_main_next_new(struct IndexSharedData *shared,
     mutt_message(_("Search wrapped to bottom"));
   }
 
-  if (priv->in_pager)
-    return IR_CONTINUE;
-
   priv->menu->redraw = REDRAW_MOTION;
   return IR_VOID;
 }
@@ -1261,10 +1230,6 @@ static enum IndexRetval op_main_next_thread(struct IndexSharedData *shared,
     else
       mutt_error(_("You are on the first thread"));
   }
-  else if (priv->in_pager)
-  {
-    return IR_CONTINUE;
-  }
   else
     priv->menu->redraw = REDRAW_MOTION;
 
@@ -1279,20 +1244,14 @@ static enum IndexRetval op_main_next_undeleted(struct IndexSharedData *shared,
 {
   if (priv->menu->current >= (shared->mailbox->vcount - 1))
   {
-    if (!priv->in_pager)
-      mutt_message(_("You are on the last message"));
+    mutt_message(_("You are on the last message"));
     return IR_ERROR;
   }
   priv->menu->current = ci_next_undeleted(shared->mailbox, priv->menu->current);
   if (priv->menu->current == -1)
   {
     priv->menu->current = priv->menu->oldcurrent;
-    if (!priv->in_pager)
-      mutt_error(_("No undeleted messages"));
-  }
-  else if (priv->in_pager)
-  {
-    return IR_CONTINUE;
+    mutt_error(_("No undeleted messages"));
   }
   else
     priv->menu->redraw = REDRAW_MOTION;
@@ -1338,12 +1297,7 @@ static enum IndexRetval op_main_prev_undeleted(struct IndexSharedData *shared,
   if (priv->menu->current == -1)
   {
     priv->menu->current = priv->menu->oldcurrent;
-    if (!priv->in_pager)
-      mutt_error(_("No undeleted messages"));
-  }
-  else if (priv->in_pager)
-  {
-    return IR_CONTINUE;
+    mutt_error(_("No undeleted messages"));
   }
   else
     priv->menu->redraw = REDRAW_MOTION;
@@ -1410,10 +1364,6 @@ static enum IndexRetval op_main_read_thread(struct IndexSharedData *shared,
       {
         priv->menu->current = priv->menu->oldcurrent;
       }
-      else if (priv->in_pager)
-      {
-        return IR_CONTINUE;
-      }
     }
     priv->menu->redraw |= REDRAW_INDEX;
   }
@@ -1431,10 +1381,6 @@ static enum IndexRetval op_main_root_message(struct IndexSharedData *shared,
   if (priv->menu->current < 0)
   {
     priv->menu->current = priv->menu->oldcurrent;
-  }
-  else if (priv->in_pager)
-  {
-    return IR_CONTINUE;
   }
   else
     priv->menu->redraw = REDRAW_MOTION;
@@ -1562,13 +1508,7 @@ static enum IndexRetval op_main_sync_folder(struct IndexSharedData *shared,
     ctx_free(&ctx);
   }
 
-  /* if we were in the pager, redisplay the message */
-  if (priv->in_pager)
-  {
-    return IR_CONTINUE;
-  }
-  else
-    priv->menu->redraw = REDRAW_FULL;
+  priv->menu->redraw = REDRAW_FULL;
 
   return IR_VOID;
 }
@@ -1728,13 +1668,10 @@ static enum IndexRetval op_next_entry(struct IndexSharedData *shared,
 {
   if (priv->menu->current >= (shared->mailbox->vcount - 1))
   {
-    if (!priv->in_pager)
-      mutt_message(_("You are on the last message"));
+    mutt_message(_("You are on the last message"));
     return IR_ERROR;
   }
   priv->menu->current++;
-  if (priv->in_pager)
-    return IR_CONTINUE;
 
   priv->menu->redraw = REDRAW_MOTION;
   return IR_VOID;
@@ -1772,13 +1709,10 @@ static enum IndexRetval op_prev_entry(struct IndexSharedData *shared,
 {
   if (priv->menu->current < 1)
   {
-    if (!priv->in_pager)
-      mutt_message(_("You are on the first message"));
+    mutt_message(_("You are on the first message"));
     return IR_ERROR;
   }
   priv->menu->current--;
-  if (priv->in_pager)
-    return IR_CONTINUE;
 
   priv->menu->redraw = REDRAW_MOTION;
   return IR_VOID;
@@ -2036,8 +1970,6 @@ static enum IndexRetval op_sort(struct IndexSharedData *shared,
     resort_index(shared->ctx, priv->menu);
     OptSearchInvalid = true;
   }
-  if (priv->in_pager)
-    return IR_CONTINUE;
 
   return IR_VOID;
 }
@@ -2175,8 +2107,6 @@ static enum IndexRetval op_toggle_write(struct IndexSharedData *shared,
 {
   if (mx_toggle_write(shared->mailbox) == 0)
   {
-    if (priv->in_pager)
-      return IR_CONTINUE;
   }
 
   return IR_VOID;
@@ -2423,7 +2353,6 @@ static enum IndexRetval op_get_children(struct IndexSharedData *shared,
   /* at least one message has been loaded */
   if (shared->mailbox->msg_count > oldmsgcount)
   {
-    struct Email *e_oldcur = mutt_get_virt_email(shared->mailbox, priv->menu->current);
     bool verbose = shared->mailbox->verbose;
 
     if (rc < 0)
@@ -2431,15 +2360,6 @@ static enum IndexRetval op_get_children(struct IndexSharedData *shared,
     mutt_sort_headers(shared->mailbox, shared->ctx->threads,
                       (op == OP_RECONSTRUCT_THREAD), &shared->ctx->vsize);
     shared->mailbox->verbose = verbose;
-
-    /* Similar to OP_MAIN_ENTIRE_THREAD, keep displaying the old message, but
-     * update the index */
-    if (priv->in_pager)
-    {
-      priv->menu->current = e_oldcur->vnum;
-      priv->menu->redraw = REDRAW_INDEX;
-      return IR_CONTINUE;
-    }
 
     /* if the root message was retrieved, move to it */
     struct Email *e = mutt_hash_find(shared->mailbox->id_hash, buf);
@@ -2468,12 +2388,6 @@ static enum IndexRetval op_get_children(struct IndexSharedData *shared,
   else if (rc >= 0)
   {
     mutt_error(_("No deleted messages found in the thread"));
-    /* Similar to OP_MAIN_ENTIRE_THREAD, keep displaying the old message, but
-     * update the index */
-    if (priv->in_pager)
-    {
-      return IR_CONTINUE;
-    }
   }
 
   return IR_VOID;
@@ -2620,8 +2534,6 @@ static enum IndexRetval op_main_change_group(struct IndexSharedData *shared,
 
 changefoldercleanup2:
   mutt_buffer_pool_release(&folderbuf);
-  if (priv->in_pager && pager_return)
-    return IR_CONTINUE;
 
   return IR_VOID;
 }
@@ -2746,8 +2658,6 @@ static enum IndexRetval op_main_entire_thread(struct IndexSharedData *shared,
       mutt_set_vnum(shared->mailbox);
     }
   }
-  if (priv->in_pager)
-    return IR_CONTINUE;
 
   return IR_VOID;
 }

--- a/index/index.c
+++ b/index/index.c
@@ -1368,7 +1368,6 @@ struct Mailbox *mutt_index_menu(struct MuttWindow *dlg, struct Mailbox *m_init)
 
     if (priv->in_pager)
     {
-      mutt_clear_pager_position();
       priv->in_pager = false;
       priv->menu->redraw = REDRAW_FULL;
     }

--- a/index/index.c
+++ b/index/index.c
@@ -1225,116 +1225,108 @@ struct Mailbox *mutt_index_menu(struct MuttWindow *dlg, struct Mailbox *m_init)
     if (op >= 0)
       mutt_curses_set_cursor(MUTT_CURSOR_INVISIBLE);
 
-    if (priv->in_pager)
-    {
-      if (priv->menu->current < priv->menu->max)
-        priv->menu->oldcurrent = priv->menu->current;
-      else
-        priv->menu->oldcurrent = -1;
+    index_custom_redraw(priv->menu);
+    window_redraw(RootWindow, false);
 
-      mutt_curses_set_cursor(MUTT_CURSOR_VISIBLE); /* fallback from the pager */
+    /* give visual indication that the next command is a tag- command */
+    if (priv->tag)
+    {
+      mutt_window_mvaddstr(MessageWindow, 0, 0, "tag-");
+      mutt_window_clrtoeol(MessageWindow);
+    }
+
+    if (priv->menu->current < priv->menu->max)
+      priv->menu->oldcurrent = priv->menu->current;
+    else
+      priv->menu->oldcurrent = -1;
+
+    const bool c_arrow_cursor = cs_subset_bool(shared->sub, "arrow_cursor");
+    const bool c_braille_friendly =
+        cs_subset_bool(shared->sub, "braille_friendly");
+    if (c_arrow_cursor)
+    {
+      mutt_window_move(priv->menu->win_index, 2,
+                       priv->menu->current - priv->menu->top);
+    }
+    else if (c_braille_friendly)
+    {
+      mutt_window_move(priv->menu->win_index, 0,
+                       priv->menu->current - priv->menu->top);
     }
     else
     {
-      index_custom_redraw(priv->menu);
-      window_redraw(RootWindow, false);
+      mutt_window_move(priv->menu->win_index, priv->menu->win_index->state.cols - 1,
+                       priv->menu->current - priv->menu->top);
+    }
+    mutt_refresh();
 
-      /* give visual indication that the next command is a tag- command */
+    if (SigWinch)
+    {
+      SigWinch = 0;
+      mutt_resize_screen();
+      priv->menu->top = 0; /* so we scroll the right amount */
+      /* force a real complete redraw.  clrtobot() doesn't seem to be able
+       * to handle every case without this.  */
+      clearok(stdscr, true);
+      mutt_window_clearline(MessageWindow, 0);
+      continue;
+    }
+
+    op = km_dokey(MENU_MAIN);
+
+    /* either user abort or timeout */
+    if (op < 0)
+    {
+      mutt_timeout_hook();
+      if (priv->tag)
+        mutt_window_clearline(MessageWindow, 0);
+      continue;
+    }
+
+    mutt_debug(LL_DEBUG1, "Got op %s (%d)\n", OpStrings[op][0], op);
+
+    mutt_curses_set_cursor(MUTT_CURSOR_VISIBLE);
+
+    /* special handling for the priv->tag-prefix function */
+    const bool c_auto_tag = cs_subset_bool(shared->sub, "auto_tag");
+    if ((op == OP_TAG_PREFIX) || (op == OP_TAG_PREFIX_COND))
+    {
+      /* A second priv->tag-prefix command aborts */
       if (priv->tag)
       {
-        mutt_window_mvaddstr(MessageWindow, 0, 0, "tag-");
-        mutt_window_clrtoeol(MessageWindow);
-      }
-
-      if (priv->menu->current < priv->menu->max)
-        priv->menu->oldcurrent = priv->menu->current;
-      else
-        priv->menu->oldcurrent = -1;
-
-      const bool c_arrow_cursor = cs_subset_bool(shared->sub, "arrow_cursor");
-      const bool c_braille_friendly =
-          cs_subset_bool(shared->sub, "braille_friendly");
-      if (c_arrow_cursor)
-        mutt_window_move(priv->menu->win_index, 2,
-                         priv->menu->current - priv->menu->top);
-      else if (c_braille_friendly)
-        mutt_window_move(priv->menu->win_index, 0,
-                         priv->menu->current - priv->menu->top);
-      else
-      {
-        mutt_window_move(priv->menu->win_index, priv->menu->win_index->state.cols - 1,
-                         priv->menu->current - priv->menu->top);
-      }
-      mutt_refresh();
-
-      if (SigWinch)
-      {
-        SigWinch = 0;
-        mutt_resize_screen();
-        priv->menu->top = 0; /* so we scroll the right amount */
-        /* force a real complete redraw.  clrtobot() doesn't seem to be able
-         * to handle every case without this.  */
-        clearok(stdscr, true);
+        priv->tag = false;
         mutt_window_clearline(MessageWindow, 0);
         continue;
       }
 
-      op = km_dokey(MENU_MAIN);
-
-      /* either user abort or timeout */
-      if (op < 0)
+      if (!shared->mailbox)
       {
-        mutt_timeout_hook();
-        if (priv->tag)
-          mutt_window_clearline(MessageWindow, 0);
+        mutt_error(_("No mailbox is open"));
         continue;
       }
 
-      mutt_debug(LL_DEBUG1, "Got op %s (%d)\n", OpStrings[op][0], op);
-
-      mutt_curses_set_cursor(MUTT_CURSOR_VISIBLE);
-
-      /* special handling for the priv->tag-prefix function */
-      const bool c_auto_tag = cs_subset_bool(shared->sub, "auto_tag");
-      if ((op == OP_TAG_PREFIX) || (op == OP_TAG_PREFIX_COND))
+      if (shared->mailbox->msg_tagged == 0)
       {
-        /* A second priv->tag-prefix command aborts */
-        if (priv->tag)
+        if (op == OP_TAG_PREFIX)
+          mutt_error(_("No tagged messages"));
+        else if (op == OP_TAG_PREFIX_COND)
         {
-          priv->tag = false;
-          mutt_window_clearline(MessageWindow, 0);
-          continue;
+          mutt_flush_macro_to_endcond();
+          mutt_message(_("Nothing to do"));
         }
-
-        if (!shared->mailbox)
-        {
-          mutt_error(_("No mailbox is open"));
-          continue;
-        }
-
-        if (shared->mailbox->msg_tagged == 0)
-        {
-          if (op == OP_TAG_PREFIX)
-            mutt_error(_("No tagged messages"));
-          else if (op == OP_TAG_PREFIX_COND)
-          {
-            mutt_flush_macro_to_endcond();
-            mutt_message(_("Nothing to do"));
-          }
-          continue;
-        }
-
-        /* get the real command */
-        priv->tag = true;
         continue;
       }
-      else if (c_auto_tag && shared->mailbox && (shared->mailbox->msg_tagged != 0))
-      {
-        priv->tag = true;
-      }
 
-      mutt_clear_error();
+      /* get the real command */
+      priv->tag = true;
+      continue;
     }
+    else if (c_auto_tag && shared->mailbox && (shared->mailbox->msg_tagged != 0))
+    {
+      priv->tag = true;
+    }
+
+    mutt_clear_error();
 
 #ifdef USE_NNTP
     OptNews = false; /* for any case */
@@ -1358,19 +1350,12 @@ struct Mailbox *mutt_index_menu(struct MuttWindow *dlg, struct Mailbox *m_init)
     // switch (op)
     // {
     //   default:
-    //     if (!idata->in_pager)
-    //       km_error_key(MENU_MAIN);
+    //     km_error_key(MENU_MAIN);
     // }
 
 #ifdef USE_NOTMUCH
     nm_db_debug_check(shared->mailbox);
 #endif
-
-    if (priv->in_pager)
-    {
-      priv->in_pager = false;
-      priv->menu->redraw = REDRAW_FULL;
-    }
 
     if (priv->done)
       break;

--- a/index/lib.h
+++ b/index/lib.h
@@ -90,5 +90,6 @@ void resort_index(struct Context *ctx, struct Menu *menu);
 int mx_toggle_write(struct Mailbox *m);
 extern const struct Mapping IndexNewsHelp[];
 struct Mailbox *change_folder_notmuch(struct Menu *menu, char *buf, int buflen, int *oldcount, struct IndexSharedData *shared, bool read_only);
+bool index_function_dispatcher(struct MuttWindow *win_index, int op);
 
 #endif /* MUTT_INDEX_LIB_H */

--- a/index/private_data.h
+++ b/index/private_data.h
@@ -38,7 +38,6 @@ struct IndexPrivateData
   int  newcount;                 ///< New count of Emails in the Mailbox
   bool do_mailbox_notify;        ///< Do we need to notify the user of new mail?
   int  attach_msg;               ///< Are we in "attach message" mode?
-  bool in_pager;                 ///< Is the Pager active?
   struct Menu *menu;             ///< Menu controlling the index
   struct MuttWindow *win_index;  ///< Window for the Index
   struct MuttWindow *win_ibar;   ///< Window for the Index Bar (status)

--- a/mutt_attach.c
+++ b/mutt_attach.c
@@ -657,10 +657,8 @@ int mutt_view_attachment(FILE *fp, struct Body *a, enum ViewAttachMode mode,
 
     pdata.actx = actx;
     pdata.body = a;
-    pdata.email = e;
     pdata.fname = mutt_buffer_string(pagerfile);
     pdata.fp = fp;
-    pdata.ctx = Context;
 
     pview.banner = desc;
     pview.flags = MUTT_PAGER_ATTACHMENT |

--- a/pager/functions.c
+++ b/pager/functions.c
@@ -1,6 +1,6 @@
 /**
  * @file
- * Private state data for the Pager
+ * Pager functions
  *
  * @authors
  * Copyright (C) 2021 Richard Russon <rich@flatcap.org>
@@ -21,39 +21,35 @@
  */
 
 /**
- * @page pager_private_data Private state data for the Pager
+ * @page pager_functions Pager functions
  *
- * Private state data for the Pager
+ * Pager functions
  */
 
-#include "config.h"
-#include "mutt/lib.h"
-#include "private_data.h"
+#include <stddef.h>
+#include <assert.h>
+#include <stdbool.h>
+#include "functions.h"
 
 /**
- * pager_private_data_free - Free Pager Data
- * @param win Window
- * @param ptr Pager Data to free
+ * pager_function_dispatcher - Perform a Pager function
+ * @param win_pager Window for the Index
+ * @param op        Operation to perform, e.g. OP_MAIN_LIMIT
+ * @retval true Value function
  */
-void pager_private_data_free(struct MuttWindow *win, void **ptr)
+bool pager_function_dispatcher(struct MuttWindow *win_pager, int op)
 {
-  if (!ptr || !*ptr)
-    return;
-
-  // struct PagerPrivateData *priv = *ptr;
-
-  FREE(ptr);
+  // TODO: write pager_function_dispatcher
+  assert(false);
+  return true;
 }
 
 /**
- * pager_private_data_new - Create new Pager Data
- * @retval ptr New PagerPrivateData
+ * PagerFunctions - All the NeoMutt functions that the Pager supports
  */
-struct PagerPrivateData *pager_private_data_new(void)
-{
-  struct PagerPrivateData *priv = mutt_mem_calloc(1, sizeof(struct PagerPrivateData));
+struct PagerFunction PagerFunctions[] = {
+  // clang-format off
 
-  // TODO initialize fields
-
-  return priv;
-}
+  // clang-format on
+  { 0, NULL },
+};

--- a/pager/functions.h
+++ b/pager/functions.h
@@ -1,0 +1,66 @@
+/**
+ * @file
+ * Pager functions
+ *
+ * @authors
+ * Copyright (C) 2021 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MUTT_PAGER_FUNCTIONS_H
+#define MUTT_PAGER_FUNCTIONS_H
+
+#include <stdbool.h>
+
+struct PagerPrivateData;
+struct MuttWindow;
+
+/**
+ * enum PagerRetval - Possible return values for Pager functions
+ */
+enum PagerRetval
+{
+  IR_ERROR   = -2,
+  IR_WARNING = -1,
+  IR_SUCCESS =  0,
+  IR_NOT_IMPL,
+  IR_NO_ACTION,
+  IR_VOID,
+  IR_CONTINUE,
+  IR_BREAK,
+};
+
+/**
+ * typedef pager_function_t - Perform an Index Function
+ * @param priv   Private Index data
+ * @param op     Operation to perform, e.g. OP_MAIN_LIMIT
+ * @retval enum #IndexRetval
+ */
+typedef enum PagerRetval (*pager_function_t)(struct PagerPrivateData *priv, int op);
+
+struct PagerFunction
+{
+  int op;                    ///< Op code, e.g. OP_MAIN_LIMIT
+  pager_function_t function; ///< Function to call
+  // TODO not sure yet if pager needs this
+  //int flags;               ///< Prerequisites for the function, e.g. #CHECK_IN_MAILBOX
+};
+
+bool pager_function_dispatcher(struct MuttWindow *win_index, int op);
+
+extern struct PagerFunction PagerFunctions[];
+
+#endif //MUTT_PAGER_FUNCTIONS_H

--- a/pager/lib.h
+++ b/pager/lib.h
@@ -133,8 +133,6 @@ enum PagerMode
  */
 struct PagerData
 {
-  struct Context   *ctx;    ///< Current Mailbox context
-  struct Email     *email;  ///< Current message
   struct Body      *body;   ///< Current attachment
   FILE             *fp;     ///< Source stream
   struct AttachCtx *actx;   ///< Attachment information

--- a/pager/lib.h
+++ b/pager/lib.h
@@ -203,6 +203,4 @@ int mutt_pager(struct PagerView *pview);
 void mutt_buffer_strip_formatting(struct Buffer *dest, const char *src, bool strip_markers);
 struct MuttWindow *add_panel_pager(struct MuttWindow *parent, bool status_on_top);
 
-void mutt_clear_pager_position(void);
-
 #endif /* MUTT_PAGER_LIB_H */

--- a/pager/pager.c
+++ b/pager/pager.c
@@ -156,10 +156,6 @@ struct Resize
   bool search_back;
 };
 
-/* hack to return to position when returning from index to same message */
-static int TopLine = 0;
-static struct Email *OldEmail = NULL;
-
 static int braille_line = -1;
 static int braille_col = -1;
 
@@ -1981,15 +1977,6 @@ static int up_n_lines(int nlines, struct Line *info, int cur, bool hiding)
 }
 
 /**
- * mutt_clear_pager_position - Reset the pager's viewing position
- */
-void mutt_clear_pager_position(void)
-{
-  TopLine = 0;
-  OldEmail = NULL;
-}
-
-/**
  * pager_custom_redraw - Redraw the pager window - Implements Menu::custom_redraw()
  */
 static void pager_custom_redraw(struct Menu *pager_menu)
@@ -2413,21 +2400,6 @@ int mutt_pager(struct PagerView *pview)
   pager_menu->mdata = &rd;
   mutt_menu_push_current(pager_menu);
   priv->menu = menu;
-
-  //---------- restore global state if needed ---------------------------------
-  while (pview->mode == PAGER_MODE_EMAIL && (OldEmail == pview->pdata->email) // are we "resuming" to the same Email?
-         && (TopLine != rd.topline) // is saved offset different?
-         && rd.line_info[rd.curline].offset < (rd.sb.st_size - 1))
-  {
-    // needed to avoid SIGSEGV
-    pager_custom_redraw(pager_menu);
-    // trick user, as if nothing happened
-    // scroll down to previosly saved offset
-    rd.topline = ((TopLine - rd.topline) > rd.lines) ? rd.topline + rd.lines : TopLine;
-  }
-
-  TopLine = 0;
-  OldEmail = NULL;
 
   //---------- show windows, set focus and visibility --------------------------
   if (rd.pview->win_index)
@@ -3986,7 +3958,66 @@ int mutt_pager(struct PagerView *pview)
 
         //=======================================================================
 
+      // Missing generic functions. Not sure if they should be be here.
+      // Maybe it should be covered by default case.
+      case OP_JUMP:
+      case OP_NEXT_ENTRY:
+      case OP_PREV_ENTRY:
+        mutt_message(_("Operation is not available in pager"));
+        break;
+
+      // Operations that pager delegates to index
+      case OP_DISPLAY_HEADERS:
+      case OP_EDIT_OR_VIEW_RAW_MESSAGE:
+      case OP_EDIT_RAW_MESSAGE:
+      case OP_EDIT_TYPE:
+      case OP_MAIN_BREAK_THREAD:
+      case OP_MAIN_CHANGE_FOLDER:
+      case OP_MAIN_CHANGE_FOLDER_READONLY:
+      case OP_MAIN_CHANGE_GROUP:
+      case OP_MAIN_CHANGE_GROUP_READONLY:
+#ifdef USE_NOTMUCH
+      case OP_MAIN_CHANGE_VFOLDER:
+      case OP_MAIN_ENTIRE_THREAD:
+      case OP_MAIN_VFOLDER_FROM_QUERY:
+      case OP_MAIN_VFOLDER_FROM_QUERY_READONLY:
+#endif
+      case OP_MAIN_IMAP_FETCH:
+      case OP_MAIN_IMAP_LOGOUT_ALL:
+      case OP_MAIN_LINK_THREADS:
+      case OP_MAIN_MODIFY_TAGS:
+      case OP_MAIN_MODIFY_TAGS_THEN_HIDE:
+      case OP_MAIN_NEXT_NEW:
+      case OP_MAIN_NEXT_NEW_THEN_UNREAD:
+      case OP_MAIN_NEXT_SUBTHREAD:
+      case OP_MAIN_NEXT_THREAD:
+      case OP_MAIN_NEXT_UNDELETED:
+      case OP_MAIN_NEXT_UNREAD:
+      case OP_MAIN_NEXT_UNREAD_MAILBOX:
+      case OP_MAIN_PARENT_MESSAGE:
+      case OP_MAIN_PREV_NEW:
+      case OP_MAIN_PREV_NEW_THEN_UNREAD:
+      case OP_MAIN_PREV_SUBTHREAD:
+      case OP_MAIN_PREV_THREAD:
+      case OP_MAIN_PREV_UNDELETED:
+      case OP_MAIN_PREV_UNREAD:
+      case OP_MAIN_QUASI_DELETE:
+      case OP_MAIN_READ_SUBTHREAD:
+      case OP_MAIN_READ_THREAD:
+      case OP_MAIN_ROOT_MESSAGE:
+      case OP_MAIN_SYNC_FOLDER:
+      case OP_RECONSTRUCT_THREAD:
+      case OP_TOGGLE_WRITE:
+      case OP_VIEW_RAW_MESSAGE:
+        mutt_message(_("Operation is not available in pager"));
+        break;
+
 #ifdef USE_SIDEBAR
+
+      case OP_SIDEBAR_OPEN:
+        mutt_message(_("Operation is not available in pager"));
+        break;
+
       case OP_SIDEBAR_FIRST:
       case OP_SIDEBAR_LAST:
       case OP_SIDEBAR_NEXT:
@@ -4015,7 +4046,7 @@ int mutt_pager(struct PagerView *pview)
 #endif
 
       default:
-        ch = -1;
+        mutt_message(_("Unknown operation"));
         break;
     }
   }
@@ -4028,17 +4059,6 @@ int mutt_pager(struct PagerView *pview)
   {
     pview->pdata->ctx->msg_in_pager = -1;
     priv->win_pbar->actions |= WA_RECALC;
-    switch (rc)
-    {
-      case -1:
-      case OP_DISPLAY_HEADERS:
-        mutt_clear_pager_position();
-        break;
-      default:
-        TopLine = rd.topline;
-        OldEmail = pview->pdata->email;
-        break;
-    }
   }
 
   cleanup_quote(&rd.quote_list);

--- a/pager/pager.c
+++ b/pager/pager.c
@@ -2449,7 +2449,7 @@ int mutt_pager(struct PagerView *pview)
     //-------------------------------------------------------------------------
     // Check if information in the status bar needs an update
     // This is done because pager is a single-threaded application, which
-    // tries to emulate cuncurency.
+    // tries to emulate concurrency.
     //-------------------------------------------------------------------------
     bool do_new_mail = false;
     if (shared->mailbox && !OptAttachMsg)
@@ -3986,49 +3986,165 @@ int mutt_pager(struct PagerView *pview)
 
       // Index-specific operations that pager used to delegate to index
       case OP_DISPLAY_HEADERS:
+        index_function_dispatcher(pview->win_index, OP_DISPLAY_HEADERS);
+        break;
+
       case OP_EDIT_OR_VIEW_RAW_MESSAGE:
+        index_function_dispatcher(pview->win_index, OP_EDIT_OR_VIEW_RAW_MESSAGE);
+        break;
+
       case OP_EDIT_RAW_MESSAGE:
+        index_function_dispatcher(pview->win_index, OP_EDIT_RAW_MESSAGE);
+        break;
+
       case OP_EDIT_TYPE:
+        index_function_dispatcher(pview->win_index, OP_EDIT_TYPE);
+        break;
+
       case OP_MAIN_BREAK_THREAD:
+        index_function_dispatcher(pview->win_index, OP_MAIN_BREAK_THREAD);
+        break;
+
       case OP_MAIN_CHANGE_FOLDER:
+        index_function_dispatcher(pview->win_index, OP_MAIN_CHANGE_FOLDER);
+        break;
+
       case OP_MAIN_CHANGE_FOLDER_READONLY:
+        index_function_dispatcher(pview->win_index, OP_MAIN_CHANGE_FOLDER_READONLY);
+        break;
+
       case OP_MAIN_CHANGE_GROUP:
+        index_function_dispatcher(pview->win_index, OP_MAIN_CHANGE_GROUP);
+        break;
+
       case OP_MAIN_CHANGE_GROUP_READONLY:
+        index_function_dispatcher(pview->win_index, OP_MAIN_CHANGE_GROUP_READONLY);
+        break;
+
 #ifdef USE_NOTMUCH
       case OP_MAIN_CHANGE_VFOLDER:
+        index_function_dispatcher(pview->win_index, OP_MAIN_CHANGE_VFOLDER);
+        break;
+
       case OP_MAIN_ENTIRE_THREAD:
+        index_function_dispatcher(pview->win_index, OP_MAIN_ENTIRE_THREAD);
+        break;
+
       case OP_MAIN_VFOLDER_FROM_QUERY:
+        index_function_dispatcher(pview->win_index, OP_MAIN_VFOLDER_FROM_QUERY);
+        break;
+
       case OP_MAIN_VFOLDER_FROM_QUERY_READONLY:
+        index_function_dispatcher(pview->win_index, OP_MAIN_VFOLDER_FROM_QUERY_READONLY);
+        break;
+
 #endif
       case OP_MAIN_IMAP_FETCH:
+        index_function_dispatcher(pview->win_index, OP_MAIN_IMAP_FETCH);
+        break;
+
       case OP_MAIN_IMAP_LOGOUT_ALL:
+        index_function_dispatcher(pview->win_index, OP_MAIN_IMAP_LOGOUT_ALL);
+        break;
+
       case OP_MAIN_LINK_THREADS:
+        index_function_dispatcher(pview->win_index, OP_MAIN_LINK_THREADS);
+        break;
+
       case OP_MAIN_MODIFY_TAGS:
+        index_function_dispatcher(pview->win_index, OP_MAIN_MODIFY_TAGS);
+        break;
+
       case OP_MAIN_MODIFY_TAGS_THEN_HIDE:
+        index_function_dispatcher(pview->win_index, OP_MAIN_MODIFY_TAGS_THEN_HIDE);
+        break;
+
       case OP_MAIN_NEXT_NEW:
+        index_function_dispatcher(pview->win_index, OP_MAIN_NEXT_NEW);
+        break;
+
       case OP_MAIN_NEXT_NEW_THEN_UNREAD:
+        index_function_dispatcher(pview->win_index, OP_MAIN_NEXT_NEW_THEN_UNREAD);
+        break;
+
       case OP_MAIN_NEXT_SUBTHREAD:
+        index_function_dispatcher(pview->win_index, OP_MAIN_NEXT_SUBTHREAD);
+        break;
+
       case OP_MAIN_NEXT_THREAD:
+        index_function_dispatcher(pview->win_index, OP_MAIN_NEXT_THREAD);
+        break;
+
       case OP_MAIN_NEXT_UNDELETED:
+        index_function_dispatcher(pview->win_index, OP_MAIN_NEXT_UNDELETED);
+        break;
+
       case OP_MAIN_NEXT_UNREAD:
+        index_function_dispatcher(pview->win_index, OP_MAIN_NEXT_UNREAD);
+        break;
+
       case OP_MAIN_NEXT_UNREAD_MAILBOX:
+        index_function_dispatcher(pview->win_index, OP_MAIN_NEXT_UNREAD_MAILBOX);
+        break;
+
       case OP_MAIN_PARENT_MESSAGE:
+        index_function_dispatcher(pview->win_index, OP_MAIN_PARENT_MESSAGE);
+        break;
+
       case OP_MAIN_PREV_NEW:
+        index_function_dispatcher(pview->win_index, OP_MAIN_PREV_NEW);
+        break;
+
       case OP_MAIN_PREV_NEW_THEN_UNREAD:
+        index_function_dispatcher(pview->win_index, OP_MAIN_PREV_NEW_THEN_UNREAD);
+        break;
+
       case OP_MAIN_PREV_SUBTHREAD:
+        index_function_dispatcher(pview->win_index, OP_MAIN_PREV_SUBTHREAD);
+        break;
+
       case OP_MAIN_PREV_THREAD:
+        index_function_dispatcher(pview->win_index, OP_MAIN_PREV_THREAD);
+        break;
+
       case OP_MAIN_PREV_UNDELETED:
+        index_function_dispatcher(pview->win_index, OP_MAIN_PREV_UNDELETED);
+        break;
+
       case OP_MAIN_PREV_UNREAD:
+        index_function_dispatcher(pview->win_index, OP_MAIN_PREV_UNREAD);
+        break;
+
       case OP_MAIN_QUASI_DELETE:
+        index_function_dispatcher(pview->win_index, OP_MAIN_QUASI_DELETE);
+        break;
+
       case OP_MAIN_READ_SUBTHREAD:
+        index_function_dispatcher(pview->win_index, OP_MAIN_READ_SUBTHREAD);
+        break;
+
       case OP_MAIN_READ_THREAD:
+        index_function_dispatcher(pview->win_index, OP_MAIN_READ_THREAD);
+        break;
+
       case OP_MAIN_ROOT_MESSAGE:
+        index_function_dispatcher(pview->win_index, OP_MAIN_ROOT_MESSAGE);
+        break;
+
       case OP_MAIN_SYNC_FOLDER:
+        index_function_dispatcher(pview->win_index, OP_MAIN_SYNC_FOLDER);
+        break;
+
       case OP_RECONSTRUCT_THREAD:
+        index_function_dispatcher(pview->win_index, OP_RECONSTRUCT_THREAD);
+        break;
+
       case OP_TOGGLE_WRITE:
+        index_function_dispatcher(pview->win_index, OP_TOGGLE_WRITE);
+        break;
+
       case OP_VIEW_RAW_MESSAGE:
-        mutt_message(_("Index operations are not currently available in pager. "
-                       "Please continue refactoring to re-enable it"));
+        index_function_dispatcher(pview->win_index, OP_VIEW_RAW_MESSAGE);
         break;
 
 #ifdef USE_SIDEBAR

--- a/pager/pager.c
+++ b/pager/pager.c
@@ -55,6 +55,7 @@
 #include "commands.h"
 #include "context.h"
 #include "format_flags.h"
+#include "functions.h"
 #include "hdrline.h"
 #include "hook.h"
 #include "keymap.h"

--- a/pager/pager.c
+++ b/pager/pager.c
@@ -3958,15 +3958,21 @@ int mutt_pager(struct PagerView *pview)
 
         //=======================================================================
 
-      // Missing generic functions. Not sure if they should be be here.
-      // Maybe it should be covered by default case.
+      // Generic functions that were delegated to index
       case OP_JUMP:
+        mutt_message(_("OP_JUMP is not currently available in pager. "
+                       "Please continue refactoring to re-enable it"));
+        break;
       case OP_NEXT_ENTRY:
+        mutt_message(_("OP_NEXT_ENTRY is not currently available in pager. "
+                       "Please continue refactoring to re-enable it"));
+        break;
       case OP_PREV_ENTRY:
-        mutt_message(_("Operation is not available in pager"));
+        mutt_message(_("OP_PREV_ENTRY is not currently available in pager. "
+                       "Please continue refactoring to re-enable it"));
         break;
 
-      // Operations that pager delegates to index
+      // Index-specific operations that pager used to delegate to index
       case OP_DISPLAY_HEADERS:
       case OP_EDIT_OR_VIEW_RAW_MESSAGE:
       case OP_EDIT_RAW_MESSAGE:
@@ -4009,13 +4015,15 @@ int mutt_pager(struct PagerView *pview)
       case OP_RECONSTRUCT_THREAD:
       case OP_TOGGLE_WRITE:
       case OP_VIEW_RAW_MESSAGE:
-        mutt_message(_("Operation is not available in pager"));
+        mutt_message(_("Index operations are not currently available in pager. "
+                       "Please continue refactoring to re-enable it"));
         break;
 
 #ifdef USE_SIDEBAR
 
       case OP_SIDEBAR_OPEN:
-        mutt_message(_("Operation is not available in pager"));
+        mutt_message(_("OP_SIDEBAR_OPEN not currently available in pager. "
+                       "Please continue refactoring to re-enable it"));
         break;
 
       case OP_SIDEBAR_FIRST:

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -237,6 +237,7 @@ notmuch/query.c
 opcodes.c
 opcodes.h
 pager/config.c
+pager/functions.c
 pager/pager.c
 pager/pbar.c
 pager/private_data.c


### PR DESCRIPTION
* **What does this PR do?**

- removes TopLine and OldEmail global variables
- renders operations that pager used to delegate to index temporarily unavailable
- removes IS_HEADER macro
- adds `functions.{c,h}`, `private_data.{c,h}` files to `pager/`
- rewires `mutt_pager` and `pager_cutom_redraw` to use `IndexSharedData`
- wires in `index_function_dispatcher` into `mutt_pager` to properly call index functions from pager