### PR TITLE
Set invalidity flags for gpgme/smime keys

### DIFF
--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -3484,6 +3484,13 @@ static struct CryptKeyInfo *get_candidates(struct ListHead *hints, SecurityFlags
       if (key_check_cap(key, KEY_CAP_CAN_SIGN))
         flags |= KEYFLAG_CANSIGN;
 
+      if (key->revoked)
+        flags |= KEYFLAG_REVOKED;
+      if (key->expired)
+        flags |= KEYFLAG_EXPIRED;
+      if (key->disabled)
+        flags |= KEYFLAG_DISABLED;
+
       for (idx = 0, uid = key->uids; uid; idx++, uid = uid->next)
       {
         k = mutt_mem_calloc(1, sizeof(*k));
@@ -3492,6 +3499,8 @@ static struct CryptKeyInfo *get_candidates(struct ListHead *hints, SecurityFlags
         k->idx = idx;
         k->uid = uid->uid;
         k->flags = flags;
+        if (uid->revoked)
+          k->flags |= KEYFLAG_REVOKED;
         k->validity = uid->validity;
         *kend = k;
         kend = &k->next;


### PR DESCRIPTION
* **What does this PR do?**

Previously, flags that show keys to be revoked/expired/disabled were
not transfered from the gpgme_key_t to KeyFlags for smime, even though
they were for pgp keys.

* **What are the relevant issue numbers?**

Not sure if there are any. I've just noticed that neomutt kept showing me a list of smime keys for contacts where all but one of them were expired and I went to see why. Turns out that there is code that checks for/filters valid keys (in particular paths that use `pgp_show_unusable`), but the flags that indicate invalidity were never set.