### PR TITLE
Simpify the code for the 'Simple' Dialogs

### DIFF
--- a/alias/dlgalias.c
+++ b/alias/dlgalias.c
@@ -203,11 +203,9 @@ static void dlg_select_alias(char *buf, size_t buflen, struct AliasMenuData *mda
   int t = -1;
   bool done = false;
 
-  struct Menu *menu = mutt_menu_new(MENU_ALIAS);
-  struct MuttWindow *dlg = dialog_create_simple_index(menu, WT_DLG_ALIAS);
-  dlg->help_data = AliasHelp;
-  dlg->help_menu = MENU_ALIAS;
+  struct MuttWindow *dlg = dialog_create_simple_index(MENU_ALIAS, WT_DLG_ALIAS, AliasHelp);
 
+  struct Menu *menu = dlg->wdata;
   menu->make_entry = alias_make_entry;
   menu->custom_search = true;
   menu->tag = alias_tag;
@@ -218,8 +216,6 @@ static void dlg_select_alias(char *buf, size_t buflen, struct AliasMenuData *mda
   notify_observer_add(NeoMutt->notify, NT_ALIAS, alias_alias_observer, menu);
   notify_observer_add(NeoMutt->notify, NT_CONFIG, alias_config_observer, mdata);
   notify_observer_add(NeoMutt->notify, NT_COLOR, alias_color_observer, menu);
-
-  mutt_menu_push_current(menu);
 
   alias_array_sort(&mdata->ava, mdata->sub);
 
@@ -354,10 +350,7 @@ static void dlg_select_alias(char *buf, size_t buflen, struct AliasMenuData *mda
   notify_observer_remove(NeoMutt->notify, alias_config_observer, mdata);
   notify_observer_remove(NeoMutt->notify, alias_color_observer, menu);
 
-  mutt_menu_pop_current(menu);
-
   FREE(&menu->title);
-  mutt_menu_free(&menu);
 
   dialog_destroy_simple_index(&dlg);
 }

--- a/alias/dlgquery.c
+++ b/alias/dlgquery.c
@@ -323,16 +323,12 @@ static void dlg_select_query(char *buf, size_t buflen, struct AliasList *all,
   }
   alias_array_sort(&mdata.ava, mdata.sub);
 
-  struct Menu *menu = NULL;
   char title[256];
-
   snprintf(title, sizeof(title), "%s%s", _("Query: "), buf);
 
-  menu = mutt_menu_new(MENU_QUERY);
-  struct MuttWindow *dlg = dialog_create_simple_index(menu, WT_DLG_QUERY);
-  dlg->help_data = QueryHelp;
-  dlg->help_menu = MENU_QUERY;
+  struct MuttWindow *dlg = dialog_create_simple_index(MENU_QUERY, WT_DLG_QUERY, QueryHelp);
 
+  struct Menu *menu = dlg->wdata;
   menu->make_entry = query_make_entry;
   menu->search = query_search;
   menu->custom_search = true;
@@ -340,7 +336,6 @@ static void dlg_select_query(char *buf, size_t buflen, struct AliasList *all,
   menu->title = strdup(title);
   menu->max = ARRAY_SIZE(&mdata.ava);
   menu->mdata = &mdata;
-  mutt_menu_push_current(menu);
 
   notify_observer_add(NeoMutt->notify, NT_CONFIG, alias_config_observer, &mdata);
   notify_observer_add(NeoMutt->notify, NT_COLOR, alias_color_observer, menu);
@@ -600,8 +595,6 @@ static void dlg_select_query(char *buf, size_t buflen, struct AliasList *all,
   notify_observer_remove(NeoMutt->notify, alias_config_observer, &mdata);
   notify_observer_remove(NeoMutt->notify, alias_color_observer, menu);
 
-  mutt_menu_pop_current(menu);
-  mutt_menu_free(&menu);
   dialog_destroy_simple_index(&dlg);
   ARRAY_FREE(&mdata.ava);
 }

--- a/autocrypt/dlgautocrypt.c
+++ b/autocrypt/dlgautocrypt.c
@@ -162,9 +162,10 @@ static void account_make_entry(struct Menu *menu, char *buf, size_t buflen, int 
 
 /**
  * create_menu - Create the Autocrypt account Menu
+ * @param dlg Dialog holding the Menu
  * @retval ptr New Menu
  */
-static struct Menu *create_menu(void)
+static struct Menu *create_menu(struct MuttWindow *dlg)
 {
   struct AutocryptAccount **accounts = NULL;
   int num_accounts = 0;
@@ -172,7 +173,7 @@ static struct Menu *create_menu(void)
   if (mutt_autocrypt_db_account_get_all(&accounts, &num_accounts) < 0)
     return NULL;
 
-  struct Menu *menu = mutt_menu_new(MENU_AUTOCRYPT_ACCT);
+  struct Menu *menu = dlg->wdata;
   menu->make_entry = account_make_entry;
   /* menu->tag = account_tag; */
   // L10N: Autocrypt Account Management Menu title
@@ -197,8 +198,6 @@ static struct Menu *create_menu(void)
   }
   FREE(&accounts);
 
-  mutt_menu_push_current(menu);
-
   return menu;
 }
 
@@ -216,9 +215,6 @@ static void menu_free(struct Menu **menu)
     mutt_addr_free(&entries[i].addr);
   }
   FREE(&(*menu)->mdata);
-
-  mutt_menu_pop_current(*menu);
-  mutt_menu_free(menu);
 }
 
 /**
@@ -264,13 +260,9 @@ void dlg_select_autocrypt_account(struct Mailbox *m)
   if (mutt_autocrypt_init(m, false))
     return;
 
-  struct Menu *menu = create_menu();
-  if (!menu)
-    return;
-
-  struct MuttWindow *dlg = dialog_create_simple_index(menu, WT_DLG_AUTOCRYPT);
-  dlg->help_data = AutocryptAcctHelp;
-  dlg->help_menu = MENU_AUTOCRYPT_ACCT;
+  struct MuttWindow *dlg =
+      dialog_create_simple_index(MENU_AUTOCRYPT_ACCT, WT_DLG_AUTOCRYPT, AutocryptAcctHelp);
+  struct Menu *menu = create_menu(dlg);
 
   bool done = false;
   while (!done)
@@ -287,10 +279,8 @@ void dlg_select_autocrypt_account(struct Mailbox *m)
 
         menu_free(&menu);
         dialog_destroy_simple_index(&dlg);
-        menu = create_menu();
-        dlg = dialog_create_simple_index(menu, WT_DLG_AUTOCRYPT);
-        dlg->help_data = AutocryptAcctHelp;
-        dlg->help_menu = MENU_AUTOCRYPT_ACCT;
+        dlg = dialog_create_simple_index(MENU_AUTOCRYPT_ACCT, WT_DLG_AUTOCRYPT, AutocryptAcctHelp);
+        menu = create_menu(dlg);
         break;
 
       case OP_AUTOCRYPT_DELETE_ACCT:
@@ -310,10 +300,9 @@ void dlg_select_autocrypt_account(struct Mailbox *m)
         {
           menu_free(&menu);
           dialog_destroy_simple_index(&dlg);
-          menu = create_menu();
-          dlg = dialog_create_simple_index(menu, WT_DLG_AUTOCRYPT);
-          dlg->help_data = AutocryptAcctHelp;
-          dlg->help_menu = MENU_AUTOCRYPT_ACCT;
+          dlg = dialog_create_simple_index(MENU_AUTOCRYPT_ACCT,
+                                           WT_DLG_AUTOCRYPT, AutocryptAcctHelp);
+          menu = create_menu(dlg);
         }
         break;
       }

--- a/browser.c
+++ b/browser.c
@@ -1355,24 +1355,23 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
 
   mutt_buffer_reset(file);
 
-  menu = mutt_menu_new(MENU_FOLDER);
-  struct MuttWindow *dlg = dialog_create_simple_index(menu, WT_DLG_BROWSER);
-
+  const struct Mapping *help_data = NULL;
 #ifdef USE_NNTP
   if (OptNews)
-    dlg->help_data = FolderNewsHelp;
+    help_data = FolderNewsHelp;
   else
 #endif
-    dlg->help_data = FolderHelp;
-  dlg->help_menu = MENU_FOLDER;
+    help_data = FolderHelp;
 
+  struct MuttWindow *dlg =
+      dialog_create_simple_index(MENU_FOLDER, WT_DLG_BROWSER, help_data);
+
+  menu = dlg->wdata;
   menu->make_entry = folder_make_entry;
   menu->search = select_file_search;
   menu->title = title;
   if (multiple)
     menu->tag = file_tag;
-
-  mutt_menu_push_current(menu);
 
   if (mailbox)
   {
@@ -2213,11 +2212,7 @@ bail:
   mutt_buffer_pool_release(&prefix);
 
   if (menu)
-  {
-    mutt_menu_pop_current(menu);
-    mutt_menu_free(&menu);
     dialog_destroy_simple_index(&dlg);
-  }
 
   goto_swapper[0] = '\0';
 }

--- a/conn/dlgverifycert.c
+++ b/conn/dlgverifycert.c
@@ -67,20 +67,17 @@ static const struct Mapping VerifyHelp[] = {
 int dlg_verify_certificate(const char *title, struct ListHead *list,
                            bool allow_always, bool allow_skip)
 {
-  struct Menu *menu = mutt_menu_new(MENU_GENERIC);
-  struct MuttWindow *dlg = dialog_create_simple_index(menu, WT_DLG_CERTIFICATE);
-  dlg->help_data = VerifyHelp;
-  dlg->help_menu = MENU_GENERIC;
+  struct MuttWindow *dlg =
+      dialog_create_simple_index(MENU_GENERIC, WT_DLG_CERTIFICATE, VerifyHelp);
 
-  mutt_menu_push_current(menu);
+  struct Menu *menu = dlg->wdata;
+  menu->title = title;
 
   struct ListNode *np = NULL;
   STAILQ_FOREACH(np, list, entries)
   {
     mutt_menu_add_dialog_row(menu, NONULL(np->data));
   }
-
-  menu->title = title;
 
   if (allow_always)
   {
@@ -147,8 +144,6 @@ int dlg_verify_certificate(const char *title, struct ListHead *list,
   }
   OptIgnoreMacroEvents = old_ime;
 
-  mutt_menu_pop_current(menu);
-  mutt_menu_free(&menu);
   dialog_destroy_simple_index(&dlg);
 
   return rc;

--- a/gui/dialog.h
+++ b/gui/dialog.h
@@ -24,10 +24,11 @@
 #define MUTT_GUI_DIALOG_H
 
 #include "mutt_window.h"
+#include "keymap.h"
 
-struct Menu;
+struct Mapping;
 
-struct MuttWindow *dialog_create_simple_index(struct Menu *menu, enum WindowType type);
+struct MuttWindow *dialog_create_simple_index(enum MenuType mtype, enum WindowType wtype, const struct Mapping *help_data);
 void               dialog_destroy_simple_index(struct MuttWindow **ptr);
 struct MuttWindow *dialog_find(struct MuttWindow *win);
 void               dialog_pop(void);

--- a/history/dlghistory.c
+++ b/history/dlghistory.c
@@ -99,15 +99,12 @@ void dlg_select_history(char *buf, size_t buflen, char **matches, int match_coun
 
   snprintf(title, sizeof(title), _("History '%s'"), buf);
 
-  struct Menu *menu = mutt_menu_new(MENU_GENERIC);
-  struct MuttWindow *dlg = dialog_create_simple_index(menu, WT_DLG_HISTORY);
-  dlg->help_data = HistoryHelp;
-  dlg->help_menu = MENU_GENERIC;
+  struct MuttWindow *dlg =
+      dialog_create_simple_index(MENU_GENERIC, WT_DLG_HISTORY, HistoryHelp);
 
+  struct Menu *menu = dlg->wdata;
   menu->make_entry = history_make_entry;
   menu->title = title;
-  mutt_menu_push_current(menu);
-
   menu->max = match_count;
   menu->mdata = matches;
 
@@ -125,7 +122,5 @@ void dlg_select_history(char *buf, size_t buflen, char **matches, int match_coun
     }
   }
 
-  mutt_menu_pop_current(menu);
-  mutt_menu_free(&menu);
   dialog_destroy_simple_index(&dlg);
 }

--- a/main.c
+++ b/main.c
@@ -828,10 +828,7 @@ int main(int argc, char *argv[], char *envp[])
 
   notify_observer_add(NeoMutt->notify, NT_CONFIG, mutt_hist_observer, NULL);
   notify_observer_add(NeoMutt->notify, NT_CONFIG, mutt_log_observer, NULL);
-  notify_observer_add(NeoMutt->notify, NT_CONFIG, mutt_menu_config_observer, NULL);
   notify_observer_add(NeoMutt->notify, NT_CONFIG, mutt_abort_key_config_observer, NULL);
-  if (Colors)
-    notify_observer_add(Colors->notify, NT_CONFIG, mutt_menu_color_observer, NULL);
 
   if (sendflags & SEND_POSTPONED)
   {

--- a/ncrypt/dlggpgme.c
+++ b/ncrypt/dlggpgme.c
@@ -1280,15 +1280,13 @@ struct CryptKeyInfo *dlg_select_gpgme_key(struct CryptKeyInfo *keys,
   else if (app & APPLICATION_SMIME)
     menu_to_use = MENU_KEY_SELECT_SMIME;
 
-  struct Menu *menu = mutt_menu_new(menu_to_use);
-  struct MuttWindow *dlg = dialog_create_simple_index(menu, WT_DLG_CRYPT_GPGME);
-  dlg->help_data = GpgmeHelp;
-  dlg->help_menu = menu_to_use;
+  struct MuttWindow *dlg =
+      dialog_create_simple_index(menu_to_use, WT_DLG_CRYPT_GPGME, GpgmeHelp);
 
+  struct Menu *menu = dlg->wdata;
   menu->max = i;
   menu->make_entry = crypt_make_entry;
   menu->mdata = key_table;
-  mutt_menu_push_current(menu);
 
   {
     const char *ts = NULL;
@@ -1414,8 +1412,6 @@ struct CryptKeyInfo *dlg_select_gpgme_key(struct CryptKeyInfo *keys,
     }
   }
 
-  mutt_menu_pop_current(menu);
-  mutt_menu_free(&menu);
   dialog_destroy_simple_index(&dlg);
   FREE(&key_table);
 

--- a/ncrypt/dlgpgp.c
+++ b/ncrypt/dlgpgp.c
@@ -550,15 +550,12 @@ struct PgpKeyInfo *dlg_select_pgp_key(struct PgpKeyInfo *keys,
   }
   qsort(key_table, i, sizeof(struct PgpUid *), f);
 
-  menu = mutt_menu_new(MENU_PGP);
-  struct MuttWindow *dlg = dialog_create_simple_index(menu, WT_DLG_PGP);
-  dlg->help_data = PgpHelp;
-  dlg->help_menu = MENU_PGP;
+  struct MuttWindow *dlg = dialog_create_simple_index(MENU_PGP, WT_DLG_PGP, PgpHelp);
 
+  menu = dlg->wdata;
   menu->max = i;
   menu->make_entry = pgp_make_entry;
   menu->mdata = key_table;
-  mutt_menu_push_current(menu);
 
   if (p)
     snprintf(buf, sizeof(buf), _("PGP keys matching <%s>"), p->mailbox);
@@ -700,8 +697,6 @@ struct PgpKeyInfo *dlg_select_pgp_key(struct PgpKeyInfo *keys,
     }
   }
 
-  mutt_menu_pop_current(menu);
-  mutt_menu_free(&menu);
   dialog_destroy_simple_index(&dlg);
   FREE(&key_table);
 

--- a/ncrypt/dlgsmime.c
+++ b/ncrypt/dlgsmime.c
@@ -161,7 +161,6 @@ struct SmimeKey *dlg_select_smime_key(struct SmimeKey *keys, char *query)
   struct SmimeKey *selected_key = NULL;
   char buf[1024];
   char title[256];
-  struct Menu *menu = NULL;
   const char *s = "";
   bool done = false;
 
@@ -178,16 +177,13 @@ struct SmimeKey *dlg_select_smime_key(struct SmimeKey *keys, char *query)
 
   snprintf(title, sizeof(title), _("S/MIME certificates matching \"%s\""), query);
 
-  menu = mutt_menu_new(MENU_SMIME);
-  struct MuttWindow *dlg = dialog_create_simple_index(menu, WT_DLG_SMIME);
-  dlg->help_data = SmimeHelp;
-  dlg->help_menu = MENU_SMIME;
+  struct MuttWindow *dlg = dialog_create_simple_index(MENU_SMIME, WT_DLG_SMIME, SmimeHelp);
 
+  struct Menu *menu = dlg->wdata;
   menu->max = table_index;
   menu->make_entry = smime_make_entry;
   menu->mdata = table;
   menu->title = title;
-  mutt_menu_push_current(menu);
   /* sorting keys might be done later - TODO */
 
   mutt_clear_error();
@@ -235,8 +231,6 @@ struct SmimeKey *dlg_select_smime_key(struct SmimeKey *keys, char *query)
     }
   }
 
-  mutt_menu_pop_current(menu);
-  mutt_menu_free(&menu);
   dialog_destroy_simple_index(&dlg);
   FREE(&table);
 

--- a/postpone.c
+++ b/postpone.c
@@ -223,17 +223,15 @@ static struct Email *dlg_select_postponed_email(struct Mailbox *m)
   int r = -1;
   bool done = false;
 
-  struct Menu *menu = mutt_menu_new(MENU_POSTPONE);
-  struct MuttWindow *dlg = dialog_create_simple_index(menu, WT_DLG_POSTPONE);
-  dlg->help_data = PostponeHelp;
-  dlg->help_menu = MENU_POSTPONE;
+  struct MuttWindow *dlg =
+      dialog_create_simple_index(MENU_POSTPONE, WT_DLG_POSTPONE, PostponeHelp);
 
+  struct Menu *menu = dlg->wdata;
   menu->make_entry = post_make_entry;
   menu->max = m->msg_count;
   menu->title = _("Postponed Messages");
   menu->mdata = m;
   menu->custom_search = true;
-  mutt_menu_push_current(menu);
 
   /* The postponed mailbox is setup to have sorting disabled, but the global
    * `$sort` variable may indicate something different.   Sorting has to be
@@ -292,8 +290,6 @@ static struct Email *dlg_select_postponed_email(struct Mailbox *m)
   }
 
   cs_subset_str_native_set(NeoMutt->sub, "sort", c_sort, NULL);
-  mutt_menu_pop_current(menu);
-  mutt_menu_free(&menu);
   dialog_destroy_simple_index(&dlg);
 
   return (r > -1) ? m->emails[r] : NULL;

--- a/recvattach.c
+++ b/recvattach.c
@@ -1579,15 +1579,13 @@ void dlg_select_attachment(struct Mailbox *m, struct Email *e)
   if (!msg)
     return;
 
-  struct Menu *menu = mutt_menu_new(MENU_ATTACH);
-  struct MuttWindow *dlg = dialog_create_simple_index(menu, WT_DLG_ATTACH);
-  dlg->help_data = AttachHelp;
-  dlg->help_menu = MENU_ATTACH;
+  struct MuttWindow *dlg =
+      dialog_create_simple_index(MENU_ATTACH, WT_DLG_ATTACH, AttachHelp);
 
+  struct Menu *menu = dlg->wdata;
   menu->title = _("Attachments");
   menu->make_entry = attach_make_entry;
   menu->tag = attach_tag;
-  mutt_menu_push_current(menu);
 
   struct AttachCtx *actx = mutt_actx_new();
   actx->email = e;
@@ -1879,8 +1877,6 @@ void dlg_select_attachment(struct Mailbox *m, struct Email *e)
 
         mutt_actx_free(&actx);
 
-        mutt_menu_pop_current(menu);
-        mutt_menu_free(&menu);
         dialog_destroy_simple_index(&dlg);
         return;
     }

--- a/remailer.c
+++ b/remailer.c
@@ -607,18 +607,16 @@ void dlg_select_mixmaster_chain(struct MuttWindow *win, struct ListHead *chainhe
 
   mix_screen_coordinates(win, type2_list, &coords, chain, 0);
 
-  menu = mutt_menu_new(MENU_MIX);
-  struct MuttWindow *dlg = dialog_create_simple_index(menu, WT_DLG_REMAILER);
-  dlg->help_data = RemailerHelp;
-  dlg->help_menu = MENU_MIX;
+  struct MuttWindow *dlg =
+      dialog_create_simple_index(MENU_MIX, WT_DLG_REMAILER, RemailerHelp);
 
+  menu = dlg->wdata;
   menu->max = ttll;
   menu->make_entry = mix_make_entry;
   menu->tag = NULL;
   menu->title = _("Select a remailer chain");
   menu->mdata = type2_list;
   menu->pagelen = MIX_VOFFSET - 1;
-  mutt_menu_push_current(menu);
 
   while (loop)
   {
@@ -758,8 +756,6 @@ void dlg_select_mixmaster_chain(struct MuttWindow *win, struct ListHead *chainhe
     }
   }
 
-  mutt_menu_pop_current(menu);
-  mutt_menu_free(&menu);
   dialog_destroy_simple_index(&dlg);
 
   /* construct the remailer list */


### PR DESCRIPTION
There are 13 'Simple' Dialogs - those screens that have a single window and limited interaction with the user.

- 357b78addd menu: make observers menu-specific
  Eliminate some global dependencies
  (Most of the diff is moving two functions, without change)

- 7d856b03e4 window: refactor simple dialogs
  Move a couple of pairs of functions into the shared code:
  - `mutt_menu_new()` / `mutt_menu_free()`
  - `mutt_menu_push_current()` / `mutt_menu_pop_current()`

<details>
<summary>Simple Dialogs</summary>

| Function                         | Description                                 |
| :------------------------------- | :------------------------------------------ |
| `dlg_select_alias()`             | Display a menu of Aliases                   |
| `dlg_select_attachment()`        | Show the attachments in a Menu              |
| `dlg_select_autocrypt_account()` | Display the Autocrypt account Menu          |
| `dlg_select_gpgme_key()`         | Get the user to select a key                |
| `dlg_select_history()`           | Select an item from a history list          |
| `dlg_select_mixmaster_chain()`   | Create a Mixmaster chain                    |
| `dlg_select_pattern()`           | Show menu to select a Pattern               |
| `dlg_select_pgp_key()`           | Let the user select a key to use            |
| `dlg_select_postponed_email()`   | Create a Menu to select a postponed message |
| `dlg_select_query()`             | Get the user to enter an Address Query      |
| `dlg_select_smime_key()`         | Get the user to select a key                |
| `dlg_verify_certificate()`       | Ask the user to validate the certificate    |
| `mutt_buffer_select_file()`      | Let the user select a file                  |

</details>
