### PR TITLE
Fix 2891

### DIFF
--- a/notmuch/db.c
+++ b/notmuch/db.c
@@ -119,7 +119,7 @@ notmuch_database_t *nm_db_do_open(const char *filename, bool writable, bool verb
 
     if (verbose && ct && ((ct % 2) == 0))
       mutt_error(_("Waiting for notmuch DB... (%d sec)"), ct / 2);
-    mutt_date_sleep_ms(500000); /* Half a second */
+    mutt_date_sleep_ms(500); /* Half a second */
     ct++;
   } while (true);
 

--- a/notmuch/private.h
+++ b/notmuch/private.h
@@ -40,6 +40,7 @@ struct Mailbox;
    (LIBNOTMUCH_MAJOR_VERSION == (major) &&                                        \
     LIBNOTMUCH_MINOR_VERSION == (minor) && LIBNOTMUCH_MICRO_VERSION >= (micro)))
 
+extern const char NmUrlProtocol[];
 extern const int NmUrlProtocolLen;
 
 notmuch_database_t *nm_db_do_open     (const char *filename, bool writable, bool verbose);


### PR DESCRIPTION
Validates `nm_default_url` to ensure its in the correct form, and changes sleep time from 8.33 minutes to the correct 1/2 second.

~~Commit 22c5f2297 changed `nanosleep()` to `mutt_date_sleep_ms()`, but
didn't alter the valaue so a half second sleep became 8 minutes and 20
seconds.~~

* **What are the relevant issue numbers?**

Fixes #2891 

~~Partial fix for #2891~~

~~This fixes the long  timeout since instead of 5 second timeout, we get an 83 minute and 20 second timeout. However, it won't correct the invalid `notmuch` URI issue.~~
