### PR TITLE
Show error if nm_default_uri{,/.notmuch} doesn't point to a valid dir

### DIFF
--- a/notmuch/db.c
+++ b/notmuch/db.c
@@ -27,6 +27,7 @@
  */
 
 #include "config.h"
+#include <errno.h>
 #include <limits.h>
 #include <notmuch.h>
 #include <stdbool.h>
@@ -87,6 +88,19 @@ const char *nm_db_get_filename(struct Mailbox *m)
  */
 notmuch_database_t *nm_db_do_open(const char *filename, bool writable, bool verbose)
 {
+  struct stat st1;
+  char buf[PATH_MAX];
+  if (stat(mutt_path_concat(buf, filename, ".notmuch", sizeof(buf)), &st1) != 0)
+  {
+    mutt_error(_("Can't stat %s: %s"), buf, strerror(errno));
+    return NULL;
+  }
+  else if (!S_ISDIR(st1.st_mode))
+  {
+    mutt_error(_("%s is not a directory"), buf);
+    return NULL;
+  }
+
   notmuch_database_t *db = NULL;
   int ct = 0;
   notmuch_status_t st = NOTMUCH_STATUS_SUCCESS;


### PR DESCRIPTION
* **What does this PR do?**
Show error when directory provided in `nm_default_uri` doesn't exist, or isn't directory. The same applies for subdir `./.notmuch`

* **Screenshots (if relevant)**

* **Does this PR meet the acceptance criteria?** (This is just a reminder for you,
  this section can be removed if you fulfill it.)

   - Documentation created/updated (you have to edit
     [doc/manual.xml.head](https://www.github.com/neomutt/neomutt/blob/master/doc/manual.xml.head)
     for that)

   - All builds and tests are passing

   - Added [doxygen code documentation](https://neomutt.org/dev/doxygen)
     [syntax](http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html)

   - Code follows the [style guide](https://neomutt.org/dev/coding-style)

* **What are the relevant issue numbers?**
#2891