### PR TITLE
notmuch: Update Email.old when a maildir file path is detected

### DIFF
--- a/notmuch/notmuch.c
+++ b/notmuch/notmuch.c
@@ -579,6 +579,7 @@ static int update_message_path(struct Email *e, const char *path)
     FREE(&edata->folder);
 
     p -= 3; /* skip subfolder (e.g. "new") */
+    e->old = mutt_str_startswith(p, "cur");
     e->path = mutt_str_dup(p);
 
     for (; (p > path) && (*(p - 1) == '/'); p--)
@@ -830,7 +831,11 @@ static void append_message(struct HeaderCache *h, struct Mailbox *m,
 #endif
   {
     if (access(path, F_OK) == 0)
+    {
+      /* We pass is_old=false as argument here, but e->old will be updated later
+       * by update_message_path() (called by init_email() below).  */
       e = maildir_parse_message(MUTT_MAILDIR, path, false, NULL);
+    }
     else
     {
       /* maybe moved try find it... */


### PR DESCRIPTION
* **What does this PR do?**

Fix for #1818.

append_message() has is_old hardcoded to false, which might make
messages that are old be moved back to the `new` subdirectory in
a maildir when calling maildir_sync_mailbox_message() later.

Update `Email.old` in update_message_path() so it matches
the detected maildir subdirectory.  As update_message_path() is
always called by init_email(), `Email.old` will always be
consistent with maildir message paths.

* **Does this PR meet the acceptance criteria?** (This is just a reminder for you,
  this section can be removed if you fulfill it.)

   - Documentation created/updated (you have to edit
     [doc/manual.xml.head](https://www.github.com/neomutt/neomutt/blob/master/doc/manual.xml.head)
     for that)
     - not applicable

   - All builds and tests are passing
     - build successful
     - all unit tests (`make test`) passing

   - Added [doxygen code documentation](https://neomutt.org/dev/doxygen)
     [syntax](http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html)
     - not applicable

   - Code follows the [style guide](https://neomutt.org/dev/coding-style)
      - yes (braces added to match coding style)

* **What are the relevant issue numbers?**

#1818.