### PR TITLE
docs(notmuch): specify `nm_default_url` format

### DIFF
--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -15855,7 +15855,9 @@ virtual-mailboxes "My INBOX" "notmuch://?query=tag:inbox"
                 <entry><literal>nm_default_url</literal></entry>
                 <entry>string</entry>
                 <entry>(empty)</entry>
-                <entry></entry>
+                <entry>
+                  Must use format: <literal>notmuch://&lt;absolute path&gt;</literal>
+                </entry>
               </row>
               <row>
                 <entry><literal>nm_exclude_tags</literal></entry>


### PR DESCRIPTION
The required format for `nm_default_url` exists in section 8 of the
notmuch feature page[0] and the neomuttrc manual. However, users using
section 4[1] to discover configuration options may miss the required
format and receive a config. error. While the error message contains the
correct format, it's sub-optimal user exprience. A better user
experience is noting the required format in section 4 so a user never
receives an error.

[0] https://neomutt.org/feature/notmuch#8-%C2%A0neomuttrc
[1] https://neomutt.org/feature/notmuch#4-%C2%A0variables