### PR TITLE
formats: drop Mailbox param

### DIFF
--- a/attachments.c
+++ b/attachments.c
@@ -252,6 +252,9 @@ static int count_body_parts(struct Body *body)
  */
 int mutt_count_body_parts(struct Mailbox *m, struct Email *e)
 {
+  if (!m || !e)
+    return 0;
+
   bool keep_parts = false;
 
   if (e->attach_valid)

--- a/hdrline.c
+++ b/hdrline.c
@@ -1355,6 +1355,9 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
 
     case '@':
     {
+      if (!m)
+        break;
+
       const char *end = src;
       static unsigned char recurse = 0;
 

--- a/pager/pager.c
+++ b/pager/pager.c
@@ -3628,7 +3628,7 @@ int mutt_pager(struct PagerView *pview)
         }
         if (pview->mode == PAGER_MODE_ATTACH_E)
         {
-          mutt_attach_forward(pview->pdata->fp, m, pview->pdata->email,
+          mutt_attach_forward(pview->pdata->fp, pview->pdata->email,
                               pview->pdata->actx, pview->pdata->body, SEND_NEWS);
         }
         else
@@ -3762,7 +3762,7 @@ int mutt_pager(struct PagerView *pview)
           break;
         if (pview->mode == PAGER_MODE_ATTACH_E)
         {
-          mutt_attach_forward(pview->pdata->fp, m, pview->pdata->email,
+          mutt_attach_forward(pview->pdata->fp, pview->pdata->email,
                               pview->pdata->actx, pview->pdata->body, SEND_NO_FLAGS);
         }
         else

--- a/recvattach.c
+++ b/recvattach.c
@@ -1798,7 +1798,7 @@ void dlg_select_attachment(struct Mailbox *m, struct Email *e)
 
       case OP_FORWARD_MESSAGE:
         CHECK_ATTACH;
-        mutt_attach_forward(CUR_ATTACH->fp, m, e, actx,
+        mutt_attach_forward(CUR_ATTACH->fp, e, actx,
                             menu->tagprefix ? NULL : CUR_ATTACH->body, SEND_NO_FLAGS);
         menu->redraw = REDRAW_FULL;
         break;
@@ -1806,7 +1806,7 @@ void dlg_select_attachment(struct Mailbox *m, struct Email *e)
 #ifdef USE_NNTP
       case OP_FORWARD_TO_GROUP:
         CHECK_ATTACH;
-        mutt_attach_forward(CUR_ATTACH->fp, m, e, actx,
+        mutt_attach_forward(CUR_ATTACH->fp, e, actx,
                             menu->tagprefix ? NULL : CUR_ATTACH->body, SEND_NEWS);
         menu->redraw = REDRAW_FULL;
         break;

--- a/recvcmd.c
+++ b/recvcmd.c
@@ -398,13 +398,11 @@ static struct AttachPtr *find_parent(struct AttachCtx *actx, struct Body *cur, s
  * include_header - Write an email header to a file, optionally quoting it
  * @param quote  If true, prefix the lines
  * @param fp_in  File to read from
- * @param m      Mailbox
  * @param e      Email
  * @param fp_out File to write to
  * @param prefix Prefix for each line (OPTIONAL)
  */
-static void include_header(bool quote, FILE *fp_in, struct Mailbox *m,
-                           struct Email *e, FILE *fp_out, char *prefix)
+static void include_header(bool quote, FILE *fp_in, struct Email *e, FILE *fp_out, char *prefix)
 {
   CopyHeaderFlags chflags = CH_DECODE;
   char prefix2[128];
@@ -422,8 +420,8 @@ static void include_header(bool quote, FILE *fp_in, struct Mailbox *m,
     {
       const char *const c_indent_string =
           cs_subset_string(NeoMutt->sub, "indent_string");
-      mutt_make_string(prefix2, sizeof(prefix2), 0, NONULL(c_indent_string), m,
-                       -1, e, MUTT_FORMAT_NO_FLAGS, NULL);
+      mutt_make_string(prefix2, sizeof(prefix2), 0, NONULL(c_indent_string),
+                       NULL, -1, e, MUTT_FORMAT_NO_FLAGS, NULL);
     }
     else
       mutt_str_copy(prefix2, ">", sizeof(prefix2));
@@ -461,7 +459,6 @@ static struct Body **copy_problematic_attachments(struct Body **last,
 /**
  * attach_forward_bodies - forward one or several MIME bodies
  * @param fp      File to read from
- * @param m       Mailbox
  * @param e       Email
  * @param actx    Attachment Context
  * @param cur     Body of email
@@ -469,8 +466,8 @@ static struct Body **copy_problematic_attachments(struct Body **last,
  *
  * (non-message types)
  */
-static void attach_forward_bodies(FILE *fp, struct Mailbox *m, struct Email *e,
-                                  struct AttachCtx *actx, struct Body *cur, short nattach)
+static void attach_forward_bodies(FILE *fp, struct Email *e, struct AttachCtx *actx,
+                                  struct Body *cur, short nattach)
 {
   bool mime_fwd_all = false;
   bool mime_fwd_any = true;
@@ -497,7 +494,7 @@ static void attach_forward_bodies(FILE *fp, struct Mailbox *m, struct Email *e,
 
   struct Email *e_tmp = email_new();
   e_tmp->env = mutt_env_new();
-  mutt_make_forward_subject(e_tmp->env, m, e_parent, NeoMutt->sub);
+  mutt_make_forward_subject(e_tmp->env, e_parent, NeoMutt->sub);
 
   tmpbody = mutt_buffer_pool_get();
   mutt_buffer_mktemp(tmpbody);
@@ -509,7 +506,7 @@ static void attach_forward_bodies(FILE *fp, struct Mailbox *m, struct Email *e,
     goto bail;
   }
 
-  mutt_forward_intro(m, e_parent, fp_tmp, NeoMutt->sub);
+  mutt_forward_intro(e_parent, fp_tmp, NeoMutt->sub);
 
   /* prepare the prefix here since we'll need it later. */
 
@@ -523,12 +520,12 @@ static void attach_forward_bodies(FILE *fp, struct Mailbox *m, struct Email *e,
     {
       const char *const c_indent_string =
           cs_subset_string(NeoMutt->sub, "indent_string");
-      mutt_make_string(prefix, sizeof(prefix), 0, NONULL(c_indent_string), m,
+      mutt_make_string(prefix, sizeof(prefix), 0, NONULL(c_indent_string), NULL,
                        -1, e_parent, MUTT_FORMAT_NO_FLAGS, NULL);
     }
   }
 
-  include_header(c_forward_quote, fp_parent, m, e_parent, fp_tmp, prefix);
+  include_header(c_forward_quote, fp_parent, e_parent, fp_tmp, prefix);
 
   /* Now, we have prepared the first part of the message body: The
    * original message's header.
@@ -613,7 +610,7 @@ static void attach_forward_bodies(FILE *fp, struct Mailbox *m, struct Email *e,
       goto bail;
   }
 
-  mutt_forward_trailer(m, e_parent, fp_tmp, NeoMutt->sub);
+  mutt_forward_trailer(e_parent, fp_tmp, NeoMutt->sub);
 
   mutt_file_fclose(&fp_tmp);
   fp_tmp = NULL;
@@ -641,7 +638,6 @@ bail:
 /**
  * attach_forward_msgs - Forward one or several message-type attachments
  * @param fp    File handle to attachment
- * @param m     Mailbox
  * @param actx  Attachment Context
  * @param cur   Attachment to forward (OPTIONAL)
  * @param flags Send mode, see #SendFlags
@@ -653,7 +649,7 @@ bail:
  * context structure to find messages, while, on the attachment menu, messages
  * are referenced through the attachment index.
  */
-static void attach_forward_msgs(FILE *fp, struct Mailbox *m, struct AttachCtx *actx,
+static void attach_forward_msgs(FILE *fp, struct AttachCtx *actx,
                                 struct Body *cur, SendFlags flags)
 {
   struct Email *e_cur = NULL;
@@ -681,7 +677,7 @@ static void attach_forward_msgs(FILE *fp, struct Mailbox *m, struct AttachCtx *a
 
   e_tmp = email_new();
   e_tmp->env = mutt_env_new();
-  mutt_make_forward_subject(e_tmp->env, m, e_cur, NeoMutt->sub);
+  mutt_make_forward_subject(e_tmp->env, e_cur, NeoMutt->sub);
 
   tmpbody = mutt_buffer_pool_get();
 
@@ -723,9 +719,9 @@ static void attach_forward_msgs(FILE *fp, struct Mailbox *m, struct AttachCtx *a
 
     if (cur)
     {
-      mutt_forward_intro(m, cur->email, fp_tmp, NeoMutt->sub);
+      mutt_forward_intro(cur->email, fp_tmp, NeoMutt->sub);
       mutt_copy_message_fp(fp_tmp, fp, cur->email, cmflags, chflags, 0);
-      mutt_forward_trailer(m, cur->email, fp_tmp, NeoMutt->sub);
+      mutt_forward_trailer(cur->email, fp_tmp, NeoMutt->sub);
     }
     else
     {
@@ -733,10 +729,10 @@ static void attach_forward_msgs(FILE *fp, struct Mailbox *m, struct AttachCtx *a
       {
         if (actx->idx[i]->body->tagged)
         {
-          mutt_forward_intro(m, actx->idx[i]->body->email, fp_tmp, NeoMutt->sub);
+          mutt_forward_intro(actx->idx[i]->body->email, fp_tmp, NeoMutt->sub);
           mutt_copy_message_fp(fp_tmp, actx->idx[i]->fp,
                                actx->idx[i]->body->email, cmflags, chflags, 0);
-          mutt_forward_trailer(m, actx->idx[i]->body->email, fp_tmp, NeoMutt->sub);
+          mutt_forward_trailer(actx->idx[i]->body->email, fp_tmp, NeoMutt->sub);
         }
       }
     }
@@ -778,21 +774,20 @@ cleanup:
 /**
  * mutt_attach_forward - Forward an Attachment
  * @param fp    Handle to the attachment
- * @param m     Mailbox
  * @param e     Email
  * @param actx  Attachment Context
  * @param cur   Current message
  * @param flags Send mode, see #SendFlags
  */
-void mutt_attach_forward(FILE *fp, struct Mailbox *m, struct Email *e,
-                         struct AttachCtx *actx, struct Body *cur, SendFlags flags)
+void mutt_attach_forward(FILE *fp, struct Email *e, struct AttachCtx *actx,
+                         struct Body *cur, SendFlags flags)
 {
   if (check_all_msg(actx, cur, false))
-    attach_forward_msgs(fp, m, actx, cur, flags);
+    attach_forward_msgs(fp, actx, cur, flags);
   else
   {
     const short nattach = count_tagged(actx);
-    attach_forward_bodies(fp, m, e, actx, cur, nattach);
+    attach_forward_bodies(fp, e, actx, cur, nattach);
   }
 }
 
@@ -906,15 +901,14 @@ static int attach_reply_envelope_defaults(struct Envelope *env, struct AttachCtx
  * attach_include_reply - This is _very_ similar to send.c's include_reply()
  * @param fp     File handle to attachment
  * @param fp_tmp File handle to temporary file
- * @param m      Mailbox
  * @param e      Email
  */
-static void attach_include_reply(FILE *fp, FILE *fp_tmp, struct Mailbox *m, struct Email *e)
+static void attach_include_reply(FILE *fp, FILE *fp_tmp, struct Email *e)
 {
   CopyMessageFlags cmflags = MUTT_CM_PREFIX | MUTT_CM_DECODE | MUTT_CM_CHARCONV;
   CopyHeaderFlags chflags = CH_DECODE;
 
-  mutt_make_attribution(m, e, fp_tmp, NeoMutt->sub);
+  mutt_make_attribution(e, fp_tmp, NeoMutt->sub);
 
   const bool c_header = cs_subset_bool(NeoMutt->sub, "header");
   if (!c_header)
@@ -927,7 +921,7 @@ static void attach_include_reply(FILE *fp, FILE *fp_tmp, struct Mailbox *m, stru
   }
 
   mutt_copy_message_fp(fp_tmp, fp, e, cmflags, chflags, 0);
-  mutt_make_post_indent(m, e, fp_tmp, NeoMutt->sub);
+  mutt_make_post_indent(e, fp_tmp, NeoMutt->sub);
 }
 
 /**
@@ -1014,19 +1008,19 @@ void mutt_attach_reply(FILE *fp, struct Mailbox *m, struct Email *e,
   if (!e_parent)
   {
     if (e_cur)
-      attach_include_reply(fp, fp_tmp, m, e_cur->email);
+      attach_include_reply(fp, fp_tmp, e_cur->email);
     else
     {
       for (short i = 0; i < actx->idxlen; i++)
       {
         if (actx->idx[i]->body->tagged)
-          attach_include_reply(actx->idx[i]->fp, fp_tmp, m, actx->idx[i]->body->email);
+          attach_include_reply(actx->idx[i]->fp, fp_tmp, actx->idx[i]->body->email);
       }
     }
   }
   else
   {
-    mutt_make_attribution(m, e_parent, fp_tmp, NeoMutt->sub);
+    mutt_make_attribution(e_parent, fp_tmp, NeoMutt->sub);
 
     struct State st;
     memset(&st, 0, sizeof(struct State));
@@ -1054,7 +1048,7 @@ void mutt_attach_reply(FILE *fp, struct Mailbox *m, struct Email *e,
 
     const bool c_header = cs_subset_bool(NeoMutt->sub, "header");
     if (c_header)
-      include_header(true, fp_parent, m, e_parent, fp_tmp, prefix);
+      include_header(true, fp_parent, e_parent, fp_tmp, prefix);
 
     if (e_cur)
     {
@@ -1080,7 +1074,7 @@ void mutt_attach_reply(FILE *fp, struct Mailbox *m, struct Email *e,
       }
     }
 
-    mutt_make_post_indent(m, e_parent, fp_tmp, NeoMutt->sub);
+    mutt_make_post_indent(e_parent, fp_tmp, NeoMutt->sub);
 
     if (mime_reply_any && !e_cur && !copy_problematic_attachments(&e_tmp->body, actx, false))
     {

--- a/recvcmd.h
+++ b/recvcmd.h
@@ -33,7 +33,7 @@ struct Mailbox;
 
 void mutt_attach_bounce(struct Mailbox *m, FILE *fp, struct AttachCtx *actx, struct Body *cur);
 void mutt_attach_resend(FILE *fp, struct Mailbox *m, struct AttachCtx *actx, struct Body *cur);
-void mutt_attach_forward(FILE *fp, struct Mailbox *m, struct Email *e, struct AttachCtx *actx, struct Body *cur, SendFlags flags);
+void mutt_attach_forward(FILE *fp, struct Email *e, struct AttachCtx *actx, struct Body *cur, SendFlags flags);
 void mutt_attach_reply(FILE *fp, struct Mailbox *m, struct Email *e, struct AttachCtx *actx, struct Body *e_cur, SendFlags flags);
 void mutt_attach_mail_sender(FILE *fp, struct Email *e, struct AttachCtx *actx, struct Body *cur);
 

--- a/send/send.c
+++ b/send/send.c
@@ -421,12 +421,11 @@ static void process_user_header(struct Envelope *env)
 
 /**
  * mutt_forward_intro - Add the "start of forwarded message" text
- * @param m   Mailbox
  * @param e   Email
  * @param sub Config Subset
  * @param fp  File to write to
  */
-void mutt_forward_intro(struct Mailbox *m, struct Email *e, FILE *fp, struct ConfigSubset *sub)
+void mutt_forward_intro(struct Email *e, FILE *fp, struct ConfigSubset *sub)
 {
   const char *const c_forward_attribution_intro =
       cs_subset_string(sub, "forward_attribution_intro");
@@ -438,8 +437,8 @@ void mutt_forward_intro(struct Mailbox *m, struct Email *e, FILE *fp, struct Con
 
   char buf[1024];
   setlocale(LC_TIME, NONULL(c_attribution_locale));
-  mutt_make_string(buf, sizeof(buf), 0, c_forward_attribution_intro, m, -1, e,
-                   MUTT_FORMAT_NO_FLAGS, NULL);
+  mutt_make_string(buf, sizeof(buf), 0, c_forward_attribution_intro, NULL, -1,
+                   e, MUTT_FORMAT_NO_FLAGS, NULL);
   setlocale(LC_TIME, "");
   fputs(buf, fp);
   fputs("\n\n", fp);
@@ -447,13 +446,11 @@ void mutt_forward_intro(struct Mailbox *m, struct Email *e, FILE *fp, struct Con
 
 /**
  * mutt_forward_trailer - Add a "end of forwarded message" text
- * @param m   Mailbox
  * @param e   Email
  * @param sub Config Subset
  * @param fp  File to write to
  */
-void mutt_forward_trailer(struct Mailbox *m, struct Email *e, FILE *fp,
-                          struct ConfigSubset *sub)
+void mutt_forward_trailer(struct Email *e, FILE *fp, struct ConfigSubset *sub)
 {
   const char *const c_forward_attribution_trailer =
       cs_subset_string(sub, "forward_attribution_trailer");
@@ -465,8 +462,8 @@ void mutt_forward_trailer(struct Mailbox *m, struct Email *e, FILE *fp,
 
   char buf[1024];
   setlocale(LC_TIME, NONULL(c_attribution_locale));
-  mutt_make_string(buf, sizeof(buf), 0, c_forward_attribution_trailer, m, -1, e,
-                   MUTT_FORMAT_NO_FLAGS, NULL);
+  mutt_make_string(buf, sizeof(buf), 0, c_forward_attribution_trailer, NULL, -1,
+                   e, MUTT_FORMAT_NO_FLAGS, NULL);
   setlocale(LC_TIME, "");
   fputc('\n', fp);
   fputs(buf, fp);
@@ -499,7 +496,7 @@ static int include_forward(struct Mailbox *m, struct Email *e, FILE *fp_out,
       return -1;
   }
 
-  mutt_forward_intro(m, e, fp_out, sub);
+  mutt_forward_intro(e, fp_out, sub);
 
   if (c_forward_decode)
   {
@@ -518,7 +515,7 @@ static int include_forward(struct Mailbox *m, struct Email *e, FILE *fp_out,
     cmflags |= MUTT_CM_PREFIX;
 
   mutt_copy_message(fp_out, m, e, cmflags, chflags, 0);
-  mutt_forward_trailer(m, e, fp_out, sub);
+  mutt_forward_trailer(e, fp_out, sub);
   return 0;
 }
 
@@ -603,13 +600,11 @@ cleanup:
 
 /**
  * mutt_make_attribution - Add "on DATE, PERSON wrote" header
- * @param m      Mailbox
  * @param e      Email
  * @param fp_out File to write to
  * @param sub    Config Subset
  */
-void mutt_make_attribution(struct Mailbox *m, struct Email *e, FILE *fp_out,
-                           struct ConfigSubset *sub)
+void mutt_make_attribution(struct Email *e, FILE *fp_out, struct ConfigSubset *sub)
 {
   const char *const c_attribution = cs_subset_string(sub, "attribution");
   if (!c_attribution || !fp_out)
@@ -620,7 +615,8 @@ void mutt_make_attribution(struct Mailbox *m, struct Email *e, FILE *fp_out,
 
   char buf[1024];
   setlocale(LC_TIME, NONULL(c_attribution_locale));
-  mutt_make_string(buf, sizeof(buf), 0, c_attribution, m, -1, e, MUTT_FORMAT_NO_FLAGS, NULL);
+  mutt_make_string(buf, sizeof(buf), 0, c_attribution, NULL, -1, e,
+                   MUTT_FORMAT_NO_FLAGS, NULL);
   setlocale(LC_TIME, "");
   fputs(buf, fp_out);
   fputc('\n', fp_out);
@@ -715,13 +711,11 @@ static void mutt_make_greeting(struct Mailbox *m, struct Email *e, FILE *fp_out,
 
 /**
  * mutt_make_post_indent - Add suffix to replied email text
- * @param m      Mailbox
  * @param e      Email
  * @param fp_out File to write to
  * @param sub    Config Subset
  */
-void mutt_make_post_indent(struct Mailbox *m, struct Email *e, FILE *fp_out,
-                           struct ConfigSubset *sub)
+void mutt_make_post_indent(struct Email *e, FILE *fp_out, struct ConfigSubset *sub)
 {
   const char *const c_post_indent_string =
       cs_subset_string(sub, "post_indent_string");
@@ -729,7 +723,7 @@ void mutt_make_post_indent(struct Mailbox *m, struct Email *e, FILE *fp_out,
     return;
 
   char buf[256];
-  mutt_make_string(buf, sizeof(buf), 0, c_post_indent_string, m, -1, e,
+  mutt_make_string(buf, sizeof(buf), 0, c_post_indent_string, NULL, -1, e,
                    MUTT_FORMAT_NO_FLAGS, NULL);
   fputs(buf, fp_out);
   fputc('\n', fp_out);
@@ -761,7 +755,7 @@ static int include_reply(struct Mailbox *m, struct Email *e, FILE *fp_out,
   mutt_parse_mime_message(m, e);
   mutt_message_hook(m, e, MUTT_MESSAGE_HOOK);
 
-  mutt_make_attribution(m, e, fp_out, sub);
+  mutt_make_attribution(e, fp_out, sub);
 
   const bool c_header = cs_subset_bool(sub, "header");
   if (!c_header)
@@ -776,7 +770,7 @@ static int include_reply(struct Mailbox *m, struct Email *e, FILE *fp_out,
 
   mutt_copy_message(fp_out, m, e, cmflags, chflags, 0);
 
-  mutt_make_post_indent(m, e, fp_out, sub);
+  mutt_make_post_indent(e, fp_out, sub);
 
   return 0;
 }
@@ -1015,12 +1009,10 @@ void mutt_fix_reply_recipients(struct Envelope *env, struct ConfigSubset *sub)
 /**
  * mutt_make_forward_subject - Create a subject for a forwarded email
  * @param env Envelope for result
- * @param m   Mailbox
  * @param e   Email
  * @param sub Config Subset
  */
-void mutt_make_forward_subject(struct Envelope *env, struct Mailbox *m,
-                               struct Email *e, struct ConfigSubset *sub)
+void mutt_make_forward_subject(struct Envelope *env, struct Email *e, struct ConfigSubset *sub)
 {
   if (!env)
     return;
@@ -1029,7 +1021,7 @@ void mutt_make_forward_subject(struct Envelope *env, struct Mailbox *m,
 
   char buf[256];
   /* set the default subject for the message. */
-  mutt_make_string(buf, sizeof(buf), 0, NONULL(c_forward_format), m, -1, e,
+  mutt_make_string(buf, sizeof(buf), 0, NONULL(c_forward_format), NULL, -1, e,
                    MUTT_FORMAT_NO_FLAGS, NULL);
   mutt_str_replace(&env->subject, buf);
 }
@@ -1177,7 +1169,7 @@ static int envelope_defaults(struct Envelope *env, struct Mailbox *m, struct Ema
   }
   else if (flags & SEND_FORWARD)
   {
-    mutt_make_forward_subject(env, m, en->email, sub);
+    mutt_make_forward_subject(env, en->email, sub);
 
     const bool c_forward_references = cs_subset_bool(sub, "forward_references");
     if (c_forward_references)

--- a/send/send.h
+++ b/send/send.h
@@ -58,12 +58,12 @@ int             mutt_edit_address(struct AddressList *al, const char *field, boo
 void            mutt_encode_descriptions(struct Body *b, bool recurse, struct ConfigSubset *sub);
 int             mutt_fetch_recips(struct Envelope *out, struct Envelope *in, SendFlags flags, struct ConfigSubset *sub);
 void            mutt_fix_reply_recipients(struct Envelope *env, struct ConfigSubset *sub);
-void            mutt_forward_intro(struct Mailbox *m, struct Email *e, FILE *fp, struct ConfigSubset *sub);
-void            mutt_forward_trailer(struct Mailbox *m, struct Email *e, FILE *fp, struct ConfigSubset *sub);
-void            mutt_make_attribution(struct Mailbox *m, struct Email *e, FILE *fp_out, struct ConfigSubset *sub);
-void            mutt_make_forward_subject(struct Envelope *env, struct Mailbox *m, struct Email *e, struct ConfigSubset *sub);
+void            mutt_forward_intro(struct Email *e, FILE *fp, struct ConfigSubset *sub);
+void            mutt_forward_trailer(struct Email *e, FILE *fp, struct ConfigSubset *sub);
+void            mutt_make_attribution(struct Email *e, FILE *fp_out, struct ConfigSubset *sub);
+void            mutt_make_forward_subject(struct Envelope *env, struct Email *e, struct ConfigSubset *sub);
 void            mutt_make_misc_reply_headers(struct Envelope *env, struct Envelope *curenv, struct ConfigSubset *sub);
-void            mutt_make_post_indent(struct Mailbox *m, struct Email *e, FILE *fp_out, struct ConfigSubset *sub);
+void            mutt_make_post_indent(struct Email *e, FILE *fp_out, struct ConfigSubset *sub);
 int             mutt_resend_message(FILE *fp, struct Mailbox *m, struct Email *e_cur, struct ConfigSubset *sub);
 int             mutt_send_message(SendFlags flags, struct Email *e_templ, const char *tempfile, struct Mailbox *m, struct EmailList *el, struct ConfigSubset *sub);
 void            mutt_set_followup_to(struct Envelope *env, struct ConfigSubset *sub);


### PR DESCRIPTION
Some Config items have format strings that allow Mailbox properties:

```sh
# Message to start a reply, 'On DATE, PERSON wrote:'
set attribution = "On %d, %n wrote:"

# Prefix message for forwarded messages
set forward_attribution_intro = "----- Forwarded message from %f -----"

# Suffix message for forwarded messages
set forward_attribution_trailer = "----- End forwarded message -----"

# printf-like format string to control the subject when forwarding a message
set forward_format = "[%a: %s]"

# String used to indent 'reply' text
set indent_string = "> "

# Suffix message to add after reply text
set post_indent_string = ""
```

Ultimately, these end in calls to `index_format_str()`.
By dropping the Mailbox parameter, we remove the possibility of using a few expandos

| Expando | Description                                                        |
| :------ | :----------------------------------------------------------------- |
| `%b`    | Filename of the original message folder (think mailbox)            |
| `%B`    | The list to which the email was sent, or else the folder name (%b) |
| `%m`    | Total number of message in the mailbox                             |

They aren't really meaningful for these Config items.
Only Email-specific attributes are, such as `%a` Author.