### PR TITLE
Avoid double mx_msg_open by passing Message into some functions

### DIFF
--- a/attachments.h
+++ b/attachments.h
@@ -40,7 +40,7 @@ void attach_init(void);
 void attach_free(void);
 
 void mutt_attachments_reset (struct Mailbox *m);
-int  mutt_count_body_parts  (struct Mailbox *m, struct Email *e);
-void mutt_parse_mime_message(struct Mailbox *m, struct Email *e);
+int  mutt_count_body_parts  (struct Mailbox *m, struct Email *e, struct Message *msg);
+void mutt_parse_mime_message(struct Mailbox *m, struct Email *e, struct Message *msg);
 
 #endif /* MUTT_ATTACHMENTS_H */

--- a/commands.c
+++ b/commands.c
@@ -212,7 +212,8 @@ int mutt_display_message(struct MuttWindow *win_index, struct MuttWindow *win_ib
   struct Buffer *tempfile = NULL;
   int res;
 
-  mutt_parse_mime_message(m, e);
+  struct Message *msg = mx_msg_open(m, e->msgno);
+  mutt_parse_mime_message(m, e, msg);
   mutt_message_hook(m, e, MUTT_MESSAGE_HOOK);
 
   char columns[16];
@@ -307,7 +308,7 @@ int mutt_display_message(struct MuttWindow *win_index, struct MuttWindow *win_ib
   if (m->type == MUTT_NOTMUCH)
     chflags |= CH_VIRTUAL;
 #endif
-  res = mutt_copy_message(fp_out, m, e, cmflags, chflags, win_index->state.cols);
+  res = mutt_copy_message(fp_out, m, e, msg, cmflags, chflags, win_index->state.cols);
 
   if (((mutt_file_fclose(&fp_out) != 0) && (errno != EPIPE)) || (res < 0))
   {
@@ -411,6 +412,7 @@ int mutt_display_message(struct MuttWindow *win_index, struct MuttWindow *win_ib
   }
 
 cleanup:
+  mx_msg_close(m, &msg);
   mutt_envlist_unset("COLUMNS");
   mutt_buffer_pool_release(&tempfile);
   return rc;
@@ -561,11 +563,13 @@ static void pipe_set_flags(bool decode, bool print, CopyMessageFlags *cmflags,
  * pipe_msg - Pipe a message
  * @param m      Mailbox
  * @param e      Email to pipe
+ * @param msg    Message
  * @param fp     File to write to
  * @param decode If true, decode the message
  * @param print  If true, message is for printing
  */
-static void pipe_msg(struct Mailbox *m, struct Email *e, FILE *fp, bool decode, bool print)
+static void pipe_msg(struct Mailbox *m, struct Email *e, struct Message *msg,
+                     FILE *fp, bool decode, bool print)
 {
   CopyMessageFlags cmflags = MUTT_CM_NO_FLAGS;
   CopyHeaderFlags chflags = CH_FROM;
@@ -579,10 +583,23 @@ static void pipe_msg(struct Mailbox *m, struct Email *e, FILE *fp, bool decode, 
     endwin();
   }
 
-  if (decode)
-    mutt_parse_mime_message(m, e);
+  const bool own_msg = !msg;
+  if (own_msg)
+  {
+    msg = mx_msg_open(m, e->msgno);
+  }
 
-  mutt_copy_message(fp, m, e, cmflags, chflags, 0);
+  if (decode)
+  {
+    mutt_parse_mime_message(m, e, msg);
+  }
+
+  mutt_copy_message(fp, m, e, msg, cmflags, chflags, 0);
+
+  if (own_msg)
+  {
+    mx_msg_close(m, &msg);
+  }
 }
 
 /**
@@ -618,12 +635,14 @@ static int pipe_message(struct Mailbox *m, struct EmailList *el, const char *cmd
     /* handle a single message */
     mutt_message_hook(m, en->email, MUTT_MESSAGE_HOOK);
 
-    if ((WithCrypto != 0) && decode)
+    struct Message *msg = mx_msg_open(m, en->email->msgno);
+    if (WithCrypto && decode)
     {
-      mutt_parse_mime_message(m, en->email);
+      mutt_parse_mime_message(m, en->email, msg);
       if ((en->email->security & SEC_ENCRYPT) &&
           !crypt_valid_passphrase(en->email->security))
       {
+        mx_msg_close(m, &msg);
         return 1;
       }
     }
@@ -633,11 +652,13 @@ static int pipe_message(struct Mailbox *m, struct EmailList *el, const char *cmd
     if (pid < 0)
     {
       mutt_perror(_("Can't create filter process"));
+      mx_msg_close(m, &msg);
       return 1;
     }
 
     OptKeepQuiet = true;
-    pipe_msg(m, en->email, fp_out, decode, print);
+    pipe_msg(m, en->email, msg, fp_out, decode, print);
+    mx_msg_close(m, &msg);
     mutt_file_fclose(&fp_out);
     rc = filter_wait(pid);
     OptKeepQuiet = false;
@@ -649,8 +670,10 @@ static int pipe_message(struct Mailbox *m, struct EmailList *el, const char *cmd
     {
       STAILQ_FOREACH(en, el, entries)
       {
+        struct Message *msg = mx_msg_open(m, en->email->msgno);
+        mutt_parse_mime_message(m, en->email, msg);
         mutt_message_hook(m, en->email, MUTT_MESSAGE_HOOK);
-        mutt_parse_mime_message(m, en->email);
+        mx_msg_close(m, &msg);
         if ((en->email->security & SEC_ENCRYPT) &&
             !crypt_valid_passphrase(en->email->security))
         {
@@ -672,7 +695,7 @@ static int pipe_message(struct Mailbox *m, struct EmailList *el, const char *cmd
           return 1;
         }
         OptKeepQuiet = true;
-        pipe_msg(m, en->email, fp_out, decode, print);
+        pipe_msg(m, en->email, NULL, fp_out, decode, print);
         /* add the message separator */
         if (sep)
           fputs(sep, fp_out);
@@ -695,7 +718,7 @@ static int pipe_message(struct Mailbox *m, struct EmailList *el, const char *cmd
       STAILQ_FOREACH(en, el, entries)
       {
         mutt_message_hook(m, en->email, MUTT_MESSAGE_HOOK);
-        pipe_msg(m, en->email, fp_out, decode, print);
+        pipe_msg(m, en->email, NULL, fp_out, decode, print);
         /* add the message separator */
         if (sep)
           fputs(sep, fp_out);
@@ -1039,10 +1062,14 @@ int mutt_save_message_ctx(struct Mailbox *m_src, struct Email *e, enum MessageSa
 
   set_copy_flags(e, transform_opt, &cmflags, &chflags);
 
+  struct Message *msg = mx_msg_open(m_src, e->msgno);
   if (transform_opt != TRANSFORM_NONE)
-    mutt_parse_mime_message(m_src, e);
+  {
+    mutt_parse_mime_message(m_src, e, msg);
+  }
 
-  rc = mutt_append_message(m_dst, m_src, e, cmflags, chflags);
+  rc = mutt_append_message(m_dst, m_src, e, msg, cmflags, chflags);
+  mx_msg_close(m_src, &msg);
   if (rc != 0)
     return rc;
 
@@ -1472,18 +1499,19 @@ static bool check_traditional_pgp(struct Mailbox *m, struct Email *e)
 
   e->security |= PGP_TRADITIONAL_CHECKED;
 
-  mutt_parse_mime_message(m, e);
   struct Message *msg = mx_msg_open(m, e->msgno);
-  if (!msg)
-    return 0;
-  if (crypt_pgp_check_traditional(msg->fp, e->body, false))
+  if (msg)
   {
-    e->security = crypt_query(e->body);
-    rc = true;
-  }
+    mutt_parse_mime_message(m, e, msg);
+    if (crypt_pgp_check_traditional(msg->fp, e->body, false))
+    {
+      e->security = crypt_query(e->body);
+      rc = true;
+    }
 
-  e->security |= PGP_TRADITIONAL_CHECKED;
-  mx_msg_close(m, &msg);
+    e->security |= PGP_TRADITIONAL_CHECKED;
+    mx_msg_close(m, &msg);
+  }
   return rc;
 }
 

--- a/copy.h
+++ b/copy.h
@@ -29,6 +29,7 @@
 
 struct Email;
 struct Mailbox;
+struct Message;
 
 typedef uint16_t CopyMessageFlags;     ///< Flags for mutt_copy_message(), e.g. #MUTT_CM_NOHEADER
 #define MUTT_CM_NO_FLAGS           0   ///< No flags are set
@@ -76,8 +77,8 @@ int mutt_copy_hdr(FILE *fp_in, FILE *fp_out, LOFF_T off_start, LOFF_T off_end, C
 int mutt_copy_header(FILE *fp_in, struct Email *e, FILE *fp_out, CopyHeaderFlags chflags, const char *prefix, int wraplen);
 
 int mutt_copy_message_fp(FILE *fp_out, FILE *fp_in,       struct Email *e, CopyMessageFlags cmflags, CopyHeaderFlags chflags, int wraplen);
-int mutt_copy_message   (FILE *fp_out, struct Mailbox *m, struct Email *e, CopyMessageFlags cmflags, CopyHeaderFlags chflags, int wraplen);
+int mutt_copy_message   (FILE *fp_out, struct Mailbox *m, struct Email *e, struct Message *msg, CopyMessageFlags cmflags, CopyHeaderFlags chflags, int wraplen);
 
-int mutt_append_message(struct Mailbox *m_dst, struct Mailbox *m_src, struct Email *e, CopyMessageFlags cmflags, CopyHeaderFlags chflags);
+int mutt_append_message(struct Mailbox *m_dst, struct Mailbox *m_src, struct Email *e, struct Message *msg, CopyMessageFlags cmflags, CopyHeaderFlags chflags);
 
 #endif /* MUTT_COPY_H */

--- a/editmsg.c
+++ b/editmsg.c
@@ -82,7 +82,7 @@ static int ev_message(enum EvMessage action, struct Mailbox *m, struct Email *e)
 
   const CopyHeaderFlags chflags =
       CH_NOLEN | (((m->type == MUTT_MBOX) || (m->type == MUTT_MMDF)) ? CH_NO_FLAGS : CH_NOSTATUS);
-  rc = mutt_append_message(m_fname, m, e, MUTT_CM_NO_FLAGS, chflags);
+  rc = mutt_append_message(m_fname, m, e, NULL, MUTT_CM_NO_FLAGS, chflags);
   int oerrno = errno;
 
   mx_mbox_close(m_fname);

--- a/hdrline.c
+++ b/hdrline.c
@@ -53,6 +53,7 @@
 #include "mutt_globals.h"
 #include "mutt_thread.h"
 #include "muttlib.h"
+#include "mx.h"
 #include "sort.h"
 #include "subjectrx.h"
 #ifdef USE_NOTMUCH
@@ -1163,7 +1164,9 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
 
     case 'X':
     {
-      int count = mutt_count_body_parts(m, e);
+      struct Message *msg = mx_msg_open(m, e->msgno);
+      int count = mutt_count_body_parts(m, e, msg);
+      mx_msg_close(m, &msg);
 
       /* The recursion allows messages without depth to return 0. */
       if (optional)

--- a/maildir/maildir.c
+++ b/maildir/maildir.c
@@ -343,7 +343,7 @@ int maildir_rewrite_message(struct Mailbox *m, int msgno)
   if (!dest)
     return -1;
 
-  int rc = mutt_copy_message(dest->fp, m, e, MUTT_CM_UPDATE, CH_UPDATE | CH_UPDATE_LEN, 0);
+  int rc = mutt_copy_message(dest->fp, m, e, dest, MUTT_CM_UPDATE, CH_UPDATE | CH_UPDATE_LEN, 0);
   if (rc == 0)
   {
     char oldpath[PATH_MAX];
@@ -352,7 +352,6 @@ int maildir_rewrite_message(struct Mailbox *m, int msgno)
     mutt_str_copy(partpath, e->path, sizeof(partpath));
 
     rc = maildir_commit_message(m, dest, e);
-    mx_msg_close(m, &dest);
 
     if (rc == 0)
     {
@@ -360,8 +359,7 @@ int maildir_rewrite_message(struct Mailbox *m, int msgno)
       restore = false;
     }
   }
-  else
-    mx_msg_close(m, &dest);
+  mx_msg_close(m, &dest);
 
   if ((rc == -1) && restore)
   {

--- a/maildir/mh.c
+++ b/maildir/mh.c
@@ -385,7 +385,7 @@ int mh_rewrite_message(struct Mailbox *m, int msgno)
   if (!dest)
     return -1;
 
-  int rc = mutt_copy_message(dest->fp, m, e, MUTT_CM_UPDATE, CH_UPDATE | CH_UPDATE_LEN, 0);
+  int rc = mutt_copy_message(dest->fp, m, e, dest, MUTT_CM_UPDATE, CH_UPDATE | CH_UPDATE_LEN, 0);
   if (rc == 0)
   {
     char oldpath[PATH_MAX];
@@ -394,7 +394,6 @@ int mh_rewrite_message(struct Mailbox *m, int msgno)
     mutt_str_copy(partpath, e->path, sizeof(partpath));
 
     rc = mh_commit_msg(m, dest, e, false);
-    mx_msg_close(m, &dest);
 
     if (rc == 0)
     {
@@ -423,8 +422,7 @@ int mh_rewrite_message(struct Mailbox *m, int msgno)
         mutt_str_replace(&e->path, partpath);
     }
   }
-  else
-    mx_msg_close(m, &dest);
+  mx_msg_close(m, &dest);
 
   if ((rc == -1) && restore)
   {

--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -1283,7 +1283,7 @@ static enum MxStatus mbox_mbox_sync(struct Mailbox *m)
        * 'offset' in the real mailbox */
       new_offset[i - first].hdr = ftello(fp) + offset;
 
-      if (mutt_copy_message(fp, m, m->emails[i], MUTT_CM_UPDATE,
+      if (mutt_copy_message(fp, m, m->emails[i], NULL, MUTT_CM_UPDATE,
                             CH_FROM | CH_UPDATE | CH_UPDATE_LEN, 0) != 0)
       {
         mutt_perror(mutt_buffer_string(tempfile));

--- a/mx.c
+++ b/mx.c
@@ -577,7 +577,7 @@ static int trash_append(struct Mailbox *m)
 
     if (e->deleted && !e->purge)
     {
-      if (mutt_append_message(m_trash, m, e, MUTT_CM_NO_FLAGS, CH_NO_FLAGS) == -1)
+      if (mutt_append_message(m_trash, m, e, NULL, MUTT_CM_NO_FLAGS, CH_NO_FLAGS) == -1)
       {
         mx_mbox_close(m_trash);
         m_trash->append = old_append;
@@ -781,7 +781,7 @@ enum MxStatus mx_mbox_close(struct Mailbox *m)
           break;
         if (e->read && !e->deleted && !(e->flagged && c_keep_flagged))
         {
-          if (mutt_append_message(m_read, m, e, MUTT_CM_NO_FLAGS, CH_UPDATE_LEN) == 0)
+          if (mutt_append_message(m_read, m, e, NULL, MUTT_CM_NO_FLAGS, CH_UPDATE_LEN) == 0)
           {
             mutt_set_flag(m, e, MUTT_DELETE, true);
             mutt_set_flag(m, e, MUTT_PURGE, true);

--- a/ncrypt/crypt.c
+++ b/ncrypt/crypt.c
@@ -54,6 +54,7 @@
 #include "handler.h"
 #include "muttlib.h"
 #include "options.h"
+#include "mx.h"
 #ifdef USE_AUTOCRYPT
 #include "autocrypt/lib.h"
 #endif
@@ -874,8 +875,9 @@ void crypt_extract_keys_from_messages(struct Mailbox *m, struct EmailList *el)
   STAILQ_FOREACH(en, el, entries)
   {
     struct Email *e = en->email;
-
-    mutt_parse_mime_message(m, e);
+    struct Message *msg = mx_msg_open(m, e->msgno);
+    mutt_parse_mime_message(m, e, msg);
+    mx_msg_close(m, &msg);
     if (e->security & SEC_ENCRYPT && !crypt_valid_passphrase(e->security))
     {
       mutt_file_fclose(&fp_out);
@@ -884,7 +886,8 @@ void crypt_extract_keys_from_messages(struct Mailbox *m, struct EmailList *el)
 
     if (((WithCrypto & APPLICATION_PGP) != 0) && (e->security & APPLICATION_PGP))
     {
-      mutt_copy_message(fp_out, m, e, MUTT_CM_DECODE | MUTT_CM_CHARCONV, CH_NO_FLAGS, 0);
+      mutt_copy_message(fp_out, m, e, NULL, MUTT_CM_DECODE | MUTT_CM_CHARCONV,
+                        CH_NO_FLAGS, 0);
       fflush(fp_out);
 
       mutt_endwin();
@@ -894,13 +897,11 @@ void crypt_extract_keys_from_messages(struct Mailbox *m, struct EmailList *el)
 
     if (((WithCrypto & APPLICATION_SMIME) != 0) && (e->security & APPLICATION_SMIME))
     {
-      if (e->security & SEC_ENCRYPT)
-      {
-        mutt_copy_message(fp_out, m, e, MUTT_CM_NOHEADER | MUTT_CM_DECODE_CRYPT | MUTT_CM_DECODE_SMIME,
-                          CH_NO_FLAGS, 0);
-      }
-      else
-        mutt_copy_message(fp_out, m, e, MUTT_CM_NO_FLAGS, CH_NO_FLAGS, 0);
+      const bool encrypt = e->security & SEC_ENCRYPT;
+      mutt_copy_message(fp_out, m, e, NULL,
+                        encrypt ? MUTT_CM_NOHEADER | MUTT_CM_DECODE_CRYPT | MUTT_CM_DECODE_SMIME :
+                                  MUTT_CM_NO_FLAGS,
+                        CH_NO_FLAGS, 0);
       fflush(fp_out);
 
       char *mbox = NULL;

--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -1242,13 +1242,10 @@ int smime_class_verify_sender(struct Mailbox *m, struct Email *e)
     goto cleanup;
   }
 
-  if (e->security & SEC_ENCRYPT)
-  {
-    mutt_copy_message(fp_out, m, e, MUTT_CM_DECODE_CRYPT & MUTT_CM_DECODE_SMIME,
-                      CH_MIME | CH_WEED | CH_NONEWLINE, 0);
-  }
-  else
-    mutt_copy_message(fp_out, m, e, MUTT_CM_NO_FLAGS, CH_NO_FLAGS, 0);
+  const double encrypt = e->security & SEC_ENCRYPT;
+  mutt_copy_message(fp_out, m, e, NULL,
+                    encrypt ? (MUTT_CM_DECODE_CRYPT & MUTT_CM_DECODE_SMIME) : MUTT_CM_NO_FLAGS,
+                    encrypt ? (CH_MIME | CH_WEED | CH_NONEWLINE) : CH_NO_FLAGS, 0);
 
   fflush(fp_out);
   mutt_file_fclose(&fp_out);

--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -1242,7 +1242,7 @@ int smime_class_verify_sender(struct Mailbox *m, struct Email *e)
     goto cleanup;
   }
 
-  const double encrypt = e->security & SEC_ENCRYPT;
+  const bool encrypt = e->security & SEC_ENCRYPT;
   mutt_copy_message(fp_out, m, e, NULL,
                     encrypt ? (MUTT_CM_DECODE_CRYPT & MUTT_CM_DECODE_SMIME) : MUTT_CM_NO_FLAGS,
                     encrypt ? (CH_MIME | CH_WEED | CH_NONEWLINE) : CH_NO_FLAGS, 0);

--- a/nntp/nntp.c
+++ b/nntp/nntp.c
@@ -2677,7 +2677,7 @@ static bool nntp_msg_open(struct Mailbox *m, struct Message *msg, int msgno)
    * which is probably wrong, but we just call it again here to handle
    * the problem instead of fixing it */
   nntp_edata_get(e)->parsed = true;
-  mutt_parse_mime_message(m, e);
+  mutt_parse_mime_message(m, e, msg);
 
   /* these would normally be updated in ctx_update(), but the
    * full headers aren't parsed with overview, so the information wasn't

--- a/pattern/exec.c
+++ b/pattern/exec.c
@@ -56,6 +56,10 @@
 #include <sys/stat.h>
 #endif
 
+static int pattern_exec(struct Pattern *pat, PatternExecFlags flags,
+                      struct Mailbox *m, struct Email *e, struct Message *msg,
+                      struct PatternCache *cache);
+
 /**
  * patmatch - Compare a string to a Pattern
  * @param pat Pattern to use
@@ -98,24 +102,20 @@ static void print_crypt_pattern_op_error(int op)
 
 /**
  * msg_search - Search an email
- * @param m   Mailbox
  * @param pat   Pattern to find
- * @param msgno Message to search
+ * @param m   Mailbox
+ * @param e   Email
+ * @param msg Message
  * @retval true Pattern found
  * @retval false Error or pattern not found
  */
-static bool msg_search(struct Mailbox *m, struct Pattern *pat, int msgno)
+static bool msg_search(struct Pattern *pat, struct Mailbox *m, struct Email *e,
+                       struct Message *msg)
 {
   bool match = false;
-  struct Message *msg = mx_msg_open(m, msgno);
-  if (!msg)
-  {
-    return match;
-  }
 
   FILE *fp = NULL;
   long len = 0;
-  struct Email *e = m->emails[msgno];
 #ifdef USE_FMEMOPEN
   char *temp = NULL;
   size_t tempsize = 0;
@@ -152,12 +152,11 @@ static bool msg_search(struct Mailbox *m, struct Pattern *pat, int msgno)
 
     if (pat->op != MUTT_PAT_HEADER)
     {
-      mutt_parse_mime_message(m, e);
+      mutt_parse_mime_message(m, e, msg);
 
       if ((WithCrypto != 0) && (e->security & SEC_ENCRYPT) &&
           !crypt_valid_passphrase(e->security))
       {
-        mx_msg_close(m, &msg);
         if (s.fp_out)
         {
           mutt_file_fclose(&s.fp_out);
@@ -244,14 +243,13 @@ static bool msg_search(struct Mailbox *m, struct Pattern *pat, int msgno)
 
   FREE(&buf);
 
-  mx_msg_close(m, &msg);
-
   if (c_thorough_search)
     mutt_file_fclose(&fp);
 
 #ifdef USE_FMEMOPEN
   FREE(&temp);
 #endif
+
   return match;
 }
 
@@ -261,17 +259,19 @@ static bool msg_search(struct Mailbox *m, struct Pattern *pat, int msgno)
  * @param flags Optional flags, e.g. #MUTT_MATCH_FULL_ADDRESS
  * @param m   Mailbox
  * @param e   Email
+ * @param msg Message
  * @param cache Cached Patterns
  * @retval true ALL of the Patterns evaluates to true
  */
 static bool perform_and(struct PatternList *pat, PatternExecFlags flags,
-                        struct Mailbox *m, struct Email *e, struct PatternCache *cache)
+                        struct Mailbox *m, struct Email *e, struct Message *msg,
+                        struct PatternCache *cache)
 {
   struct Pattern *p = NULL;
 
   SLIST_FOREACH(p, pat, entries)
   {
-    if (mutt_pattern_exec(p, flags, m, e, cache) <= 0)
+    if (pattern_exec(p, flags, m, e, msg, cache) <= 0)
       return false;
   }
   return true;
@@ -304,17 +304,19 @@ static bool perform_alias_and(struct PatternList *pat, PatternExecFlags flags,
  * @param flags Optional flags, e.g. #MUTT_MATCH_FULL_ADDRESS
  * @param m   Mailbox
  * @param e   Email
+ * @param msg Message
  * @param cache Cached Patterns
  * @retval true ONE (or more) of the Patterns evaluates to true
  */
 static int perform_or(struct PatternList *pat, PatternExecFlags flags,
-                      struct Mailbox *m, struct Email *e, struct PatternCache *cache)
+                      struct Mailbox *m, struct Email *e, struct Message *msg,
+                      struct PatternCache *cache)
 {
   struct Pattern *p = NULL;
 
   SLIST_FOREACH(p, pat, entries)
   {
-    if (mutt_pattern_exec(p, flags, m, e, cache) > 0)
+    if (pattern_exec(p, flags, m, e, msg, cache) > 0)
       return true;
   }
   return false;
@@ -589,13 +591,15 @@ static bool match_content_type(const struct Pattern *pat, struct Body *b)
  * @param pat   Pattern to match
  * @param m   Mailbox
  * @param e   Email
+ * @param msg Message
  * @retval true  Success, pattern matched
  * @retval false Pattern did not match
  */
 static bool match_mime_content_type(const struct Pattern *pat,
-                                    struct Mailbox *m, struct Email *e)
+                                    struct Mailbox *m, struct Email *e,
+                                    struct Message *msg)
 {
-  mutt_parse_mime_message(m, e);
+  mutt_parse_mime_message(m, e, msg);
   return match_content_type(pat, e->body);
 }
 
@@ -724,29 +728,45 @@ static int msg_search_sendmode(struct Email *e, struct Pattern *pat)
 }
 
 /**
- * mutt_pattern_exec - Match a pattern against an email header
- * @param pat   Pattern to match
- * @param flags Flags, e.g. #MUTT_MATCH_FULL_ADDRESS
- * @param m   Mailbox
- * @param e     Email
- * @param cache Cache for common Patterns
- * @retval  1 Success, pattern matched
- * @retval  0 Pattern did not match
- * @retval -1 Error
- *
- * flags: MUTT_MATCH_FULL_ADDRESS - match both personal and machine address
- * cache: For repeated matches against the same Header, passing in non-NULL will
- *        store some of the cacheable pattern matches in this structure.
+ * pattern_needs_msg - Check whether a pattern needs a full message
+ * @param pat Pattern
+ * @retval true The pattern needs a full message
+ * @retval false The pattern does not need a full message
  */
-int mutt_pattern_exec(struct Pattern *pat, PatternExecFlags flags,
-                      struct Mailbox *m, struct Email *e, struct PatternCache *cache)
+static bool pattern_needs_msg(const struct Pattern *pat)
+{
+  if ((pat->op == MUTT_PAT_MIMETYPE) ||
+      (pat->op == MUTT_PAT_WHOLE_MSG) ||
+      (pat->op == MUTT_PAT_MIMEATTACH))
+  {
+    return true;
+  }
+
+  if ((pat->op == MUTT_PAT_AND) || (pat->op == MUTT_PAT_OR))
+  {
+    struct Pattern *p = NULL;
+    SLIST_FOREACH(p, pat->child, entries)
+    {
+      if (pattern_needs_msg(p))
+      {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+static int pattern_exec(struct Pattern *pat, PatternExecFlags flags,
+                      struct Mailbox *m, struct Email *e, struct Message *msg,
+                      struct PatternCache *cache)
 {
   switch (pat->op)
   {
     case MUTT_PAT_AND:
-      return pat->pat_not ^ (perform_and(pat->child, flags, m, e, cache) > 0);
+      return pat->pat_not ^ (perform_and(pat->child, flags, m, e, msg, cache) > 0);
     case MUTT_PAT_OR:
-      return pat->pat_not ^ (perform_or(pat->child, flags, m, e, cache) > 0);
+      return pat->pat_not ^ (perform_or(pat->child, flags, m, e, msg, cache) > 0);
     case MUTT_PAT_THREAD:
       return pat->pat_not ^
              match_threadcomplete(pat->child, flags, m, e->thread, 1, 1, 1, 1);
@@ -805,7 +825,7 @@ int mutt_pattern_exec(struct Pattern *pat, PatternExecFlags flags,
       if ((m->type == MUTT_IMAP) && pat->string_match)
         return e->matched;
 #endif
-      return pat->pat_not ^ msg_search(m, pat, e->msgno);
+      return pat->pat_not ^ msg_search(pat, m, e, msg);
     case MUTT_PAT_SERVERSEARCH:
 #ifdef USE_IMAP
       if (!m)
@@ -1004,14 +1024,14 @@ int mutt_pattern_exec(struct Pattern *pat, PatternExecFlags flags,
       if (!m)
         return 0;
       {
-        int count = mutt_count_body_parts(m, e);
+        int count = mutt_count_body_parts(m, e, msg);
         return pat->pat_not ^ (count >= pat->min &&
                                (pat->max == MUTT_MAXRANGE || count <= pat->max));
       }
     case MUTT_PAT_MIMETYPE:
       if (!m)
         return 0;
-      return pat->pat_not ^ match_mime_content_type(pat, m, e);
+      return pat->pat_not ^ match_mime_content_type(pat, m, e, msg);
     case MUTT_PAT_UNREFERENCED:
       return pat->pat_not ^ (e->thread && !e->thread->child);
     case MUTT_PAT_BROKEN:
@@ -1025,6 +1045,31 @@ int mutt_pattern_exec(struct Pattern *pat, PatternExecFlags flags,
   }
   mutt_error(_("error: unknown op %d (report this error)"), pat->op);
   return 0;
+
+}
+
+/**
+ * mutt_pattern_exec - Match a pattern against an email header
+ * @param pat   Pattern to match
+ * @param flags Flags, e.g. #MUTT_MATCH_FULL_ADDRESS
+ * @param m   Mailbox
+ * @param e     Email
+ * @param cache Cache for common Patterns
+ * @retval  1 Success, pattern matched
+ * @retval  0 Pattern did not match
+ * @retval -1 Error
+ *
+ * flags: MUTT_MATCH_FULL_ADDRESS - match both personal and machine address
+ * cache: For repeated matches against the same Header, passing in non-NULL will
+ *        store some of the cacheable pattern matches in this structure.
+ */
+int mutt_pattern_exec(struct Pattern *pat, PatternExecFlags flags,
+                      struct Mailbox *m, struct Email *e, struct PatternCache *cache)
+{
+  struct Message *msg = pattern_needs_msg(pat) ? mx_msg_open(m, e->msgno) : NULL;
+  const int rc = pattern_exec(pat, flags, m, e, msg, cache);
+  mx_msg_close(m, &msg);
+  return rc;
 }
 
 /**

--- a/recvattach.c
+++ b/recvattach.c
@@ -1574,11 +1574,11 @@ void dlg_select_attachment(struct Mailbox *m, struct Email *e)
   int op = OP_NULL;
 
   /* make sure we have parsed this message */
-  mutt_parse_mime_message(m, e);
+  struct Message *msg = mx_msg_open(m, e->msgno);
+  mutt_parse_mime_message(m, e, msg);
 
   mutt_message_hook(m, e, MUTT_MESSAGE_HOOK);
 
-  struct Message *msg = mx_msg_open(m, e->msgno);
   if (!msg)
     return;
 

--- a/send/sendlib.c
+++ b/send/sendlib.c
@@ -972,7 +972,8 @@ struct Body *mutt_make_message_attach(struct Mailbox *m, struct Email *e,
 
   mutt_buffer_pool_release(&buf);
 
-  mutt_parse_mime_message(m, e);
+  struct Message *msg = mx_msg_open(m, e->msgno);
+  mutt_parse_mime_message(m, e, msg);
 
   CopyHeaderFlags chflags = CH_XMIT;
   cmflags = MUTT_CM_NO_FLAGS;
@@ -1011,7 +1012,8 @@ struct Body *mutt_make_message_attach(struct Mailbox *m, struct Email *e,
     }
   }
 
-  mutt_copy_message(fp, m, e, cmflags, chflags, 0);
+  mutt_copy_message(fp, m, e, msg, cmflags, chflags, 0);
+  mx_msg_close(m, &msg);
 
   fflush(fp);
   rewind(fp);

--- a/test/pattern/dummy.c
+++ b/test/pattern/dummy.c
@@ -107,7 +107,7 @@ int mutt_copy_header(FILE *in, struct Email *e, FILE *out, int flags, const char
   return -1;
 }
 
-int mutt_count_body_parts(struct Mailbox *m, struct Email *e)
+int mutt_count_body_parts(struct Mailbox *m, struct Email *e, struct Message *msg)
 {
   return g_body_parts;
 }
@@ -122,13 +122,14 @@ bool mutt_is_subscribed_list(struct Address *addr)
   return g_is_subscribed_list;
 }
 
-void mutt_parse_mime_message(struct Mailbox *m, struct Email *e)
+void mutt_parse_mime_message(struct Mailbox *m, struct Email *e, struct Message *msg)
 {
 }
 
 void mutt_progress_init(struct Progress *progress, const char *msg, int type, size_t size)
 {
 }
+
 void mutt_progress_update(struct Progress *progress, long pos, int percent)
 {
 }


### PR DESCRIPTION
Some functions where doing a sequence of `mx_msg_open` followed by, e.g., `mutt_copy_message`. The latter did a `mx_msg_open`, too, which resulted in fetching the message twice. This sucks especially with large messages over IMAP.