### PR TITLE
Keep the Message alive in the Pager

### DIFF
--- a/attachments.c
+++ b/attachments.c
@@ -248,10 +248,10 @@ static int count_body_parts(struct Body *body)
  * mutt_count_body_parts - Count the MIME Body parts
  * @param m Mailbox
  * @param e Email
- * @param msg Message
+ * @param fp File to parse
  * @retval num Number of MIME Body parts
  */
-int mutt_count_body_parts(struct Mailbox *m, struct Email *e, struct Message *msg)
+int mutt_count_body_parts(struct Mailbox *m, struct Email *e, FILE *fp)
 {
   if (!m || !e)
     return 0;
@@ -264,7 +264,7 @@ int mutt_count_body_parts(struct Mailbox *m, struct Email *e, struct Message *ms
   if (e->body->parts)
     keep_parts = true;
   else
-    mutt_parse_mime_message(m, e, msg);
+    mutt_parse_mime_message(m, e, fp);
 
   if (!STAILQ_EMPTY(&AttachAllow) || !STAILQ_EMPTY(&AttachExclude) ||
       !STAILQ_EMPTY(&InlineAllow) || !STAILQ_EMPTY(&InlineExclude))
@@ -583,17 +583,16 @@ enum CommandResult parse_unattachments(struct Buffer *buf, struct Buffer *s,
  * mutt_parse_mime_message - Parse a MIME email
  * @param m Mailbox
  * @param e Email
- * @param msg Message
+ * @param fp File to parse
  */
-void mutt_parse_mime_message(struct Mailbox *m, struct Email *e, struct Message *msg)
+void mutt_parse_mime_message(struct Mailbox *m, struct Email *e, FILE *fp)
 {
   const bool right_type = (e->body->type == TYPE_MESSAGE) || (e->body->type == TYPE_MULTIPART);
   const bool not_parsed = (e->body->parts == NULL);
-  const bool could_open = (msg != NULL);
 
-  if (right_type && could_open && not_parsed)
+  if (right_type && fp && not_parsed)
   {
-      mutt_parse_part(msg->fp, e->body);
+      mutt_parse_part(fp, e->body);
       if (WithCrypto)
       {
         e->security = crypt_query(e->body);

--- a/attachments.h
+++ b/attachments.h
@@ -40,7 +40,7 @@ void attach_init(void);
 void attach_free(void);
 
 void mutt_attachments_reset (struct Mailbox *m);
-int  mutt_count_body_parts  (struct Mailbox *m, struct Email *e, struct Message *msg);
-void mutt_parse_mime_message(struct Mailbox *m, struct Email *e, struct Message *msg);
+int  mutt_count_body_parts  (struct Mailbox *m, struct Email *e, FILE *fp);
+void mutt_parse_mime_message(struct Mailbox *m, struct Email *e, FILE *fp);
 
 #endif /* MUTT_ATTACHMENTS_H */

--- a/commands.c
+++ b/commands.c
@@ -373,6 +373,7 @@ int mutt_display_message(struct MuttWindow *win_index, struct MuttWindow *win_ib
     struct PagerView pview = { &pdata };
 
     pdata.email = e;
+    pdata.msg = msg;
     pdata.ctx = Context;
     pdata.fname = mutt_buffer_string(tempfile);
 

--- a/hdrline.c
+++ b/hdrline.c
@@ -1165,15 +1165,18 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
     case 'X':
     {
       struct Message *msg = mx_msg_open(m, e->msgno);
-      int count = mutt_count_body_parts(m, e, msg);
-      mx_msg_close(m, &msg);
+      if (msg)
+      {
+        int count = mutt_count_body_parts(m, e, msg->fp);
+        mx_msg_close(m, &msg);
 
-      /* The recursion allows messages without depth to return 0. */
-      if (optional)
-        optional = (count != 0);
+        /* The recursion allows messages without depth to return 0. */
+        if (optional)
+          optional = (count != 0);
 
-      snprintf(fmt, sizeof(fmt), "%%%sd", prec);
-      snprintf(buf, buflen, fmt, count);
+        snprintf(fmt, sizeof(fmt), "%%%sd", prec);
+        snprintf(buf, buflen, fmt, count);
+      }
       break;
     }
 

--- a/index/index.c
+++ b/index/index.c
@@ -4078,7 +4078,7 @@ struct Mailbox *mutt_index_menu(struct MuttWindow *dlg, struct Mailbox *m_init)
           break;
         if (!shared->email)
           break;
-        dlg_select_attachment(shared->mailbox, shared->email);
+        dlg_select_attachment(shared->mailbox, shared->email, NULL);
         if (shared->email->attach_del)
           shared->mailbox->changed = true;
         priv->menu->redraw = REDRAW_FULL;

--- a/ncrypt/crypt.c
+++ b/ncrypt/crypt.c
@@ -876,8 +876,11 @@ void crypt_extract_keys_from_messages(struct Mailbox *m, struct EmailList *el)
   {
     struct Email *e = en->email;
     struct Message *msg = mx_msg_open(m, e->msgno);
-    mutt_parse_mime_message(m, e, msg);
-    mx_msg_close(m, &msg);
+    if (msg)
+    {
+      mutt_parse_mime_message(m, e, msg->fp);
+      mx_msg_close(m, &msg);
+    }
     if (e->security & SEC_ENCRYPT && !crypt_valid_passphrase(e->security))
     {
       mutt_file_fclose(&fp_out);

--- a/nntp/nntp.c
+++ b/nntp/nntp.c
@@ -2677,7 +2677,7 @@ static bool nntp_msg_open(struct Mailbox *m, struct Message *msg, int msgno)
    * which is probably wrong, but we just call it again here to handle
    * the problem instead of fixing it */
   nntp_edata_get(e)->parsed = true;
-  mutt_parse_mime_message(m, e, msg);
+  mutt_parse_mime_message(m, e, msg->fp);
 
   /* these would normally be updated in ctx_update(), but the
    * full headers aren't parsed with overview, so the information wasn't

--- a/pager/lib.h
+++ b/pager/lib.h
@@ -132,8 +132,7 @@ enum PagerMode
 struct PagerData
 {
   struct Context   *ctx;    ///< Current Mailbox context
-  struct Email     *email;  ///< Current email
-  struct Message   *msg;    ///< Current message
+  struct Email     *email;  ///< Current message
   struct Body      *body;   ///< Current attachment
   FILE             *fp;     ///< Source stream
   struct AttachCtx *actx;   ///< Attachment information

--- a/pager/lib.h
+++ b/pager/lib.h
@@ -132,7 +132,8 @@ enum PagerMode
 struct PagerData
 {
   struct Context   *ctx;    ///< Current Mailbox context
-  struct Email     *email;  ///< Current message
+  struct Email     *email;  ///< Current email
+  struct Message   *msg;    ///< Current message
   struct Body      *body;   ///< Current attachment
   FILE             *fp;     ///< Source stream
   struct AttachCtx *actx;   ///< Attachment information

--- a/pager/pager.c
+++ b/pager/pager.c
@@ -3985,7 +3985,7 @@ int mutt_pager(struct PagerView *pview)
         }
         if (!assert_pager_mode(pview->mode == PAGER_MODE_EMAIL))
           break;
-        dlg_select_attachment(ctx_mailbox(Context), pview->pdata->email);
+        dlg_select_attachment(ctx_mailbox(Context), pview->pdata->email, pview->pdata->msg);
         if (pview->pdata->email->attach_del)
           m->changed = true;
         pager_menu->redraw = REDRAW_FULL;

--- a/pager/pager.c
+++ b/pager/pager.c
@@ -3985,7 +3985,7 @@ int mutt_pager(struct PagerView *pview)
         }
         if (!assert_pager_mode(pview->mode == PAGER_MODE_EMAIL))
           break;
-        dlg_select_attachment(ctx_mailbox(Context), pview->pdata->email, pview->pdata->msg);
+        dlg_select_attachment(ctx_mailbox(Context), pview->pdata->email, pview->pdata->fp);
         if (pview->pdata->email->attach_del)
           m->changed = true;
         pager_menu->redraw = REDRAW_FULL;

--- a/pattern/exec.c
+++ b/pattern/exec.c
@@ -152,7 +152,7 @@ static bool msg_search(struct Pattern *pat, struct Mailbox *m, struct Email *e,
 
     if (pat->op != MUTT_PAT_HEADER)
     {
-      mutt_parse_mime_message(m, e, msg);
+      mutt_parse_mime_message(m, e, msg->fp);
 
       if ((WithCrypto != 0) && (e->security & SEC_ENCRYPT) &&
           !crypt_valid_passphrase(e->security))
@@ -597,9 +597,9 @@ static bool match_content_type(const struct Pattern *pat, struct Body *b)
  */
 static bool match_mime_content_type(const struct Pattern *pat,
                                     struct Mailbox *m, struct Email *e,
-                                    struct Message *msg)
+                                    FILE *fp)
 {
-  mutt_parse_mime_message(m, e, msg);
+  mutt_parse_mime_message(m, e, fp);
   return match_content_type(pat, e->body);
 }
 
@@ -1024,14 +1024,14 @@ static int pattern_exec(struct Pattern *pat, PatternExecFlags flags,
       if (!m)
         return 0;
       {
-        int count = mutt_count_body_parts(m, e, msg);
+        int count = mutt_count_body_parts(m, e, msg->fp);
         return pat->pat_not ^ (count >= pat->min &&
                                (pat->max == MUTT_MAXRANGE || count <= pat->max));
       }
     case MUTT_PAT_MIMETYPE:
       if (!m)
         return 0;
-      return pat->pat_not ^ match_mime_content_type(pat, m, e, msg);
+      return pat->pat_not ^ match_mime_content_type(pat, m, e, msg->fp);
     case MUTT_PAT_UNREFERENCED:
       return pat->pat_not ^ (e->thread && !e->thread->child);
     case MUTT_PAT_BROKEN:

--- a/recvattach.c
+++ b/recvattach.c
@@ -1575,7 +1575,6 @@ void dlg_select_attachment(struct Mailbox *m, struct Email *e, struct Message *m
   int op = OP_NULL;
   const bool own_msg = !msg;
 
-  /* make sure we have parsed this message */
   if (own_msg)
   {
     msg = mx_msg_open(m, e->msgno);
@@ -1583,6 +1582,7 @@ void dlg_select_attachment(struct Mailbox *m, struct Email *e, struct Message *m
   if (!msg)
     return;
 
+  /* make sure we have parsed this message */
   mutt_parse_mime_message(m, e, msg);
   mutt_message_hook(m, e, MUTT_MESSAGE_HOOK);
 

--- a/recvattach.h
+++ b/recvattach.h
@@ -39,7 +39,7 @@ void mutt_attach_init(struct AttachCtx *actx);
 void mutt_update_tree(struct AttachCtx *actx);
 
 const char *attach_format_str(char *buf, size_t buflen, size_t col, int cols, char op, const char *src, const char *prec, const char *if_str, const char *else_str, intptr_t data, MuttFormatFlags flags);
-void dlg_select_attachment(struct Mailbox *m, struct Email *e, struct Message *msg);
+void dlg_select_attachment(struct Mailbox *m, struct Email *e, FILE *fp);
 
 void mutt_generate_recvattach_list(struct AttachCtx *actx, struct Email *e, struct Body *parts, FILE *fp, int parent_type, int level, bool decrypted);
 

--- a/recvattach.h
+++ b/recvattach.h
@@ -39,7 +39,7 @@ void mutt_attach_init(struct AttachCtx *actx);
 void mutt_update_tree(struct AttachCtx *actx);
 
 const char *attach_format_str(char *buf, size_t buflen, size_t col, int cols, char op, const char *src, const char *prec, const char *if_str, const char *else_str, intptr_t data, MuttFormatFlags flags);
-void dlg_select_attachment(struct Mailbox *m, struct Email *e);
+void dlg_select_attachment(struct Mailbox *m, struct Email *e, struct Message *msg);
 
 void mutt_generate_recvattach_list(struct AttachCtx *actx, struct Email *e, struct Body *parts, FILE *fp, int parent_type, int level, bool decrypted);
 

--- a/send/send.c
+++ b/send/send.c
@@ -486,7 +486,11 @@ static int include_forward(struct Mailbox *m, struct Email *e, FILE *fp_out,
   CopyMessageFlags cmflags = MUTT_CM_NO_FLAGS;
 
   struct Message *msg = mx_msg_open(m, e->msgno);
-  mutt_parse_mime_message(m, e, msg);
+  if (!msg)
+  {
+    return -1;
+  }
+  mutt_parse_mime_message(m, e, msg->fp);
   mutt_message_hook(m, e, MUTT_MESSAGE_HOOK);
 
   const bool c_forward_decode = cs_subset_bool(sub, "forward_decode");
@@ -549,7 +553,7 @@ static int inline_forward_attachments(struct Mailbox *m, struct Email *e,
     return -1;
   }
 
-  mutt_parse_mime_message(m, e, msg);
+  mutt_parse_mime_message(m, e, msg->fp);
   mutt_message_hook(m, e, MUTT_MESSAGE_HOOK);
 
   actx = mutt_mem_calloc(1, sizeof(*actx));
@@ -759,7 +763,11 @@ static int include_reply(struct Mailbox *m, struct Email *e, FILE *fp_out,
   }
 
   struct Message *msg = mx_msg_open(m, e->msgno);
-  mutt_parse_mime_message(m, e, msg);
+  if (!msg)
+  {
+    return -1;
+  }
+  mutt_parse_mime_message(m, e, msg->fp);
   mutt_message_hook(m, e, MUTT_MESSAGE_HOOK);
 
   mutt_make_attribution(e, fp_out, sub);

--- a/send/sendlib.c
+++ b/send/sendlib.c
@@ -973,7 +973,11 @@ struct Body *mutt_make_message_attach(struct Mailbox *m, struct Email *e,
   mutt_buffer_pool_release(&buf);
 
   struct Message *msg = mx_msg_open(m, e->msgno);
-  mutt_parse_mime_message(m, e, msg);
+  if (!msg)
+  {
+    return NULL;
+  }
+  mutt_parse_mime_message(m, e, msg->fp);
 
   CopyHeaderFlags chflags = CH_XMIT;
   cmflags = MUTT_CM_NO_FLAGS;

--- a/test/pattern/dummy.c
+++ b/test/pattern/dummy.c
@@ -122,7 +122,7 @@ bool mutt_is_subscribed_list(struct Address *addr)
   return g_is_subscribed_list;
 }
 
-void mutt_parse_mime_message(struct Mailbox *m, struct Email *e, struct Message *msg)
+void mutt_parse_mime_message(struct Mailbox *m, struct Email *e, FILE *msg)
 {
 }
 


### PR DESCRIPTION
So we can avoid re-fetching the message to view the attachments

This finally fixes #2751.