### PR TITLE
Try to avoid redundant mx_msg_open calls

### DIFF
--- a/attachments.c
+++ b/attachments.c
@@ -248,9 +248,10 @@ static int count_body_parts(struct Body *body)
  * mutt_count_body_parts - Count the MIME Body parts
  * @param m Mailbox
  * @param e Email
+ * @param fp File to parse
  * @retval num Number of MIME Body parts
  */
-int mutt_count_body_parts(struct Mailbox *m, struct Email *e)
+int mutt_count_body_parts(struct Mailbox *m, struct Email *e, FILE *fp)
 {
   if (!m || !e)
     return 0;
@@ -263,7 +264,7 @@ int mutt_count_body_parts(struct Mailbox *m, struct Email *e)
   if (e->body->parts)
     keep_parts = true;
   else
-    mutt_parse_mime_message(m, e);
+    mutt_parse_mime_message(m, e, fp);
 
   if (!STAILQ_EMPTY(&AttachAllow) || !STAILQ_EMPTY(&AttachExclude) ||
       !STAILQ_EMPTY(&InlineAllow) || !STAILQ_EMPTY(&InlineExclude))
@@ -582,28 +583,22 @@ enum CommandResult parse_unattachments(struct Buffer *buf, struct Buffer *s,
  * mutt_parse_mime_message - Parse a MIME email
  * @param m Mailbox
  * @param e Email
+ * @param fp File to parse
  */
-void mutt_parse_mime_message(struct Mailbox *m, struct Email *e)
+void mutt_parse_mime_message(struct Mailbox *m, struct Email *e, FILE *fp)
 {
-  do
+  const bool right_type =
+      (e->body->type == TYPE_MESSAGE) || (e->body->type == TYPE_MULTIPART);
+  const bool not_parsed = (e->body->parts == NULL);
+
+  if (right_type && fp && not_parsed)
   {
-    if ((e->body->type != TYPE_MESSAGE) && (e->body->type != TYPE_MULTIPART))
-      break; /* nothing to do */
-
-    if (e->body->parts)
-      break; /* The message was parsed earlier. */
-
-    struct Message *msg = mx_msg_open(m, e->msgno);
-    if (msg)
+    mutt_parse_part(fp, e->body);
+    if (WithCrypto)
     {
-      mutt_parse_part(msg->fp, e->body);
-
-      if (WithCrypto)
-        e->security = crypt_query(e->body);
-
-      mx_msg_close(m, &msg);
+      e->security = crypt_query(e->body);
     }
-  } while (false);
+  }
 
   e->attach_valid = false;
 }

--- a/attachments.h
+++ b/attachments.h
@@ -40,7 +40,7 @@ void attach_init(void);
 void attach_free(void);
 
 void mutt_attachments_reset (struct Mailbox *m);
-int  mutt_count_body_parts  (struct Mailbox *m, struct Email *e);
-void mutt_parse_mime_message(struct Mailbox *m, struct Email *e);
+int  mutt_count_body_parts  (struct Mailbox *m, struct Email *e, FILE *fp);
+void mutt_parse_mime_message(struct Mailbox *m, struct Email *e, FILE *fp);
 
 #endif /* MUTT_ATTACHMENTS_H */

--- a/commands.c
+++ b/commands.c
@@ -352,7 +352,7 @@ int mutt_display_message(struct MuttWindow *win_index, struct MuttWindow *win_ib
     {
       if (e->security & SEC_GOODSIGN)
       {
-        if (crypt_smime_verify_sender(m, e) == 0)
+        if (crypt_smime_verify_sender(m, e, msg) == 0)
           mutt_message(_("S/MIME signature successfully verified"));
         else
           mutt_error(_("S/MIME certificate owner does not match sender"));

--- a/copy.c
+++ b/copy.c
@@ -847,23 +847,15 @@ int mutt_copy_message(FILE *fp_out, struct Mailbox *m, struct Email *e,
                       struct Message *msg, CopyMessageFlags cmflags,
                       CopyHeaderFlags chflags, int wraplen)
 {
-  const bool own_msg = !msg;
-  if (own_msg && !(msg = mx_msg_open(m, e->msgno)))
+  if (!msg || !e->body)
   {
     return -1;
   }
-
-  if (!e->body)
-    return -1;
   int rc = mutt_copy_message_fp(fp_out, msg->fp, e, cmflags, chflags, wraplen);
   if ((rc == 0) && (ferror(fp_out) || feof(fp_out)))
   {
     mutt_debug(LL_DEBUG1, "failed to detect EOF!\n");
     rc = -1;
-  }
-  if (own_msg)
-  {
-    mx_msg_close(m, &msg);
   }
   return rc;
 }

--- a/copy.c
+++ b/copy.c
@@ -833,6 +833,7 @@ int mutt_copy_message_fp(FILE *fp_out, FILE *fp_in, struct Email *e,
  * @param fp_out  FILE pointer to write to
  * @param m       Source mailbox
  * @param e       Email
+ * @param msg     Message
  * @param cmflags Flags, see #CopyMessageFlags
  * @param chflags Flags, see #CopyHeaderFlags
  * @param wraplen Width to wrap at (when chflags & CH_DISPLAY)
@@ -843,11 +844,15 @@ int mutt_copy_message_fp(FILE *fp_out, FILE *fp_in, struct Email *e,
  * like partial decode, where it is worth displaying as much as possible
  */
 int mutt_copy_message(FILE *fp_out, struct Mailbox *m, struct Email *e,
-                      CopyMessageFlags cmflags, CopyHeaderFlags chflags, int wraplen)
+                      struct Message *msg, CopyMessageFlags cmflags,
+                      CopyHeaderFlags chflags, int wraplen)
 {
-  struct Message *msg = mx_msg_open(m, e->msgno);
-  if (!msg)
+  const bool own_msg = !msg;
+  if (own_msg && !(msg = mx_msg_open(m, e->msgno)))
+  {
     return -1;
+  }
+
   if (!e->body)
     return -1;
   int rc = mutt_copy_message_fp(fp_out, msg->fp, e, cmflags, chflags, wraplen);
@@ -856,7 +861,10 @@ int mutt_copy_message(FILE *fp_out, struct Mailbox *m, struct Email *e,
     mutt_debug(LL_DEBUG1, "failed to detect EOF!\n");
     rc = -1;
   }
-  mx_msg_close(m, &msg);
+  if (own_msg)
+  {
+    mx_msg_close(m, &msg);
+  }
   return rc;
 }
 
@@ -907,19 +915,27 @@ static int append_message(struct Mailbox *dest, FILE *fp_in, struct Mailbox *src
  * @param m_dst   Destination Mailbox
  * @param m_src   Source Mailbox
  * @param e       Email
+ * @param msg     Message
  * @param cmflags Flags, see #CopyMessageFlags
  * @param chflags Flags, see #CopyHeaderFlags
  * @retval  0 Success
  * @retval -1 Failure
  */
-int mutt_append_message(struct Mailbox *m_dst, struct Mailbox *m_src, struct Email *e,
+int mutt_append_message(struct Mailbox *m_dst, struct Mailbox *m_src,
+                        struct Email *e, struct Message *msg,
                         CopyMessageFlags cmflags, CopyHeaderFlags chflags)
 {
-  struct Message *msg = mx_msg_open(m_src, e->msgno);
-  if (!msg)
+  const bool own_msg = !msg;
+  if (own_msg && !(msg = mx_msg_open(m_src, e->msgno)))
+  {
     return -1;
+  }
+
   int rc = append_message(m_dst, msg->fp, m_src, e, cmflags, chflags);
-  mx_msg_close(m_src, &msg);
+  if (own_msg)
+  {
+    mx_msg_close(m_src, &msg);
+  }
   return rc;
 }
 

--- a/copy.h
+++ b/copy.h
@@ -29,6 +29,7 @@
 
 struct Email;
 struct Mailbox;
+struct Message;
 
 typedef uint16_t CopyMessageFlags;     ///< Flags for mutt_copy_message(), e.g. #MUTT_CM_NOHEADER
 #define MUTT_CM_NO_FLAGS           0   ///< No flags are set
@@ -76,8 +77,8 @@ int mutt_copy_hdr(FILE *fp_in, FILE *fp_out, LOFF_T off_start, LOFF_T off_end, C
 int mutt_copy_header(FILE *fp_in, struct Email *e, FILE *fp_out, CopyHeaderFlags chflags, const char *prefix, int wraplen);
 
 int mutt_copy_message_fp(FILE *fp_out, FILE *fp_in,       struct Email *e, CopyMessageFlags cmflags, CopyHeaderFlags chflags, int wraplen);
-int mutt_copy_message   (FILE *fp_out, struct Mailbox *m, struct Email *e, CopyMessageFlags cmflags, CopyHeaderFlags chflags, int wraplen);
+int mutt_copy_message   (FILE *fp_out, struct Mailbox *m, struct Email *e, struct Message *msg, CopyMessageFlags cmflags, CopyHeaderFlags chflags, int wraplen);
 
-int mutt_append_message(struct Mailbox *m_dst, struct Mailbox *m_src, struct Email *e, CopyMessageFlags cmflags, CopyHeaderFlags chflags);
+int mutt_append_message(struct Mailbox *m_dst, struct Mailbox *m_src, struct Email *e, struct Message *msg, CopyMessageFlags cmflags, CopyHeaderFlags chflags);
 
 #endif /* MUTT_COPY_H */

--- a/editmsg.c
+++ b/editmsg.c
@@ -82,7 +82,7 @@ static int ev_message(enum EvMessage action, struct Mailbox *m, struct Email *e)
 
   const CopyHeaderFlags chflags =
       CH_NOLEN | (((m->type == MUTT_MBOX) || (m->type == MUTT_MMDF)) ? CH_NO_FLAGS : CH_NOSTATUS);
-  rc = mutt_append_message(m_fname, m, e, MUTT_CM_NO_FLAGS, chflags);
+  rc = mutt_append_message(m_fname, m, e, NULL, MUTT_CM_NO_FLAGS, chflags);
   int oerrno = errno;
 
   mx_mbox_close(m_fname);

--- a/hdrline.c
+++ b/hdrline.c
@@ -53,6 +53,7 @@
 #include "mutt_globals.h"
 #include "mutt_thread.h"
 #include "muttlib.h"
+#include "mx.h"
 #include "sort.h"
 #include "subjectrx.h"
 #ifdef USE_NOTMUCH
@@ -1163,14 +1164,19 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
 
     case 'X':
     {
-      int count = mutt_count_body_parts(m, e);
+      struct Message *msg = mx_msg_open(m, e->msgno);
+      if (msg)
+      {
+        int count = mutt_count_body_parts(m, e, msg->fp);
+        mx_msg_close(m, &msg);
 
-      /* The recursion allows messages without depth to return 0. */
-      if (optional)
-        optional = (count != 0);
+        /* The recursion allows messages without depth to return 0. */
+        if (optional)
+          optional = (count != 0);
 
-      snprintf(fmt, sizeof(fmt), "%%%sd", prec);
-      snprintf(buf, buflen, fmt, count);
+        snprintf(fmt, sizeof(fmt), "%%%sd", prec);
+        snprintf(buf, buflen, fmt, count);
+      }
       break;
     }
 

--- a/index/index.c
+++ b/index/index.c
@@ -4074,15 +4074,24 @@ struct Mailbox *mutt_index_menu(struct MuttWindow *dlg, struct Mailbox *m_init)
         break;
 
       case OP_VIEW_ATTACHMENTS:
+      {
         if (!prereq(shared->ctx, priv->menu, CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE))
           break;
         if (!shared->email)
           break;
-        dlg_select_attachment(shared->mailbox, shared->email, NULL);
-        if (shared->email->attach_del)
-          shared->mailbox->changed = true;
+        struct Message *msg = mx_msg_open(shared->mailbox, shared->email->msgno);
+        if (msg)
+        {
+          dlg_select_attachment(shared->mailbox, shared->email, msg->fp);
+          if (shared->email->attach_del)
+          {
+            shared->mailbox->changed = true;
+          }
+          mx_msg_close(shared->mailbox, &msg);
+        }
         priv->menu->redraw = REDRAW_FULL;
         break;
+      }
 
       case OP_END_COND:
         break;

--- a/index/index.c
+++ b/index/index.c
@@ -4078,7 +4078,7 @@ struct Mailbox *mutt_index_menu(struct MuttWindow *dlg, struct Mailbox *m_init)
           break;
         if (!shared->email)
           break;
-        dlg_select_attachment(shared->mailbox, shared->email);
+        dlg_select_attachment(shared->mailbox, shared->email, NULL);
         if (shared->email->attach_del)
           shared->mailbox->changed = true;
         priv->menu->redraw = REDRAW_FULL;

--- a/maildir/maildir.c
+++ b/maildir/maildir.c
@@ -343,7 +343,8 @@ int maildir_rewrite_message(struct Mailbox *m, int msgno)
   if (!dest)
     return -1;
 
-  int rc = mutt_copy_message(dest->fp, m, e, MUTT_CM_UPDATE, CH_UPDATE | CH_UPDATE_LEN, 0);
+  int rc = mutt_copy_message(dest->fp, m, e, dest, MUTT_CM_UPDATE,
+                             CH_UPDATE | CH_UPDATE_LEN, 0);
   if (rc == 0)
   {
     char oldpath[PATH_MAX];
@@ -352,7 +353,6 @@ int maildir_rewrite_message(struct Mailbox *m, int msgno)
     mutt_str_copy(partpath, e->path, sizeof(partpath));
 
     rc = maildir_commit_message(m, dest, e);
-    mx_msg_close(m, &dest);
 
     if (rc == 0)
     {
@@ -360,8 +360,7 @@ int maildir_rewrite_message(struct Mailbox *m, int msgno)
       restore = false;
     }
   }
-  else
-    mx_msg_close(m, &dest);
+  mx_msg_close(m, &dest);
 
   if ((rc == -1) && restore)
   {

--- a/maildir/mh.c
+++ b/maildir/mh.c
@@ -385,7 +385,8 @@ int mh_rewrite_message(struct Mailbox *m, int msgno)
   if (!dest)
     return -1;
 
-  int rc = mutt_copy_message(dest->fp, m, e, MUTT_CM_UPDATE, CH_UPDATE | CH_UPDATE_LEN, 0);
+  int rc = mutt_copy_message(dest->fp, m, e, dest, MUTT_CM_UPDATE,
+                             CH_UPDATE | CH_UPDATE_LEN, 0);
   if (rc == 0)
   {
     char oldpath[PATH_MAX];
@@ -394,7 +395,6 @@ int mh_rewrite_message(struct Mailbox *m, int msgno)
     mutt_str_copy(partpath, e->path, sizeof(partpath));
 
     rc = mh_commit_msg(m, dest, e, false);
-    mx_msg_close(m, &dest);
 
     if (rc == 0)
     {
@@ -423,8 +423,7 @@ int mh_rewrite_message(struct Mailbox *m, int msgno)
         mutt_str_replace(&e->path, partpath);
     }
   }
-  else
-    mx_msg_close(m, &dest);
+  mx_msg_close(m, &dest);
 
   if ((rc == -1) && restore)
   {

--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -1283,8 +1283,11 @@ static enum MxStatus mbox_mbox_sync(struct Mailbox *m)
        * 'offset' in the real mailbox */
       new_offset[i - first].hdr = ftello(fp) + offset;
 
-      if (mutt_copy_message(fp, m, m->emails[i], NULL, MUTT_CM_UPDATE,
-                            CH_FROM | CH_UPDATE | CH_UPDATE_LEN, 0) != 0)
+      struct Message *msg = mx_msg_open(m, m->emails[i]->msgno);
+      const int rc2 = mutt_copy_message(fp, m, m->emails[i], msg, MUTT_CM_UPDATE,
+                                        CH_FROM | CH_UPDATE | CH_UPDATE_LEN, 0);
+      mx_msg_close(m, &msg);
+      if (rc2 != 0)
       {
         mutt_perror(mutt_buffer_string(tempfile));
         goto bail;

--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -1283,7 +1283,7 @@ static enum MxStatus mbox_mbox_sync(struct Mailbox *m)
        * 'offset' in the real mailbox */
       new_offset[i - first].hdr = ftello(fp) + offset;
 
-      if (mutt_copy_message(fp, m, m->emails[i], MUTT_CM_UPDATE,
+      if (mutt_copy_message(fp, m, m->emails[i], NULL, MUTT_CM_UPDATE,
                             CH_FROM | CH_UPDATE | CH_UPDATE_LEN, 0) != 0)
       {
         mutt_perror(mutt_buffer_string(tempfile));

--- a/mx.c
+++ b/mx.c
@@ -577,7 +577,7 @@ static int trash_append(struct Mailbox *m)
 
     if (e->deleted && !e->purge)
     {
-      if (mutt_append_message(m_trash, m, e, MUTT_CM_NO_FLAGS, CH_NO_FLAGS) == -1)
+      if (mutt_append_message(m_trash, m, e, NULL, MUTT_CM_NO_FLAGS, CH_NO_FLAGS) == -1)
       {
         mx_mbox_close(m_trash);
         m_trash->append = old_append;
@@ -781,7 +781,7 @@ enum MxStatus mx_mbox_close(struct Mailbox *m)
           break;
         if (e->read && !e->deleted && !(e->flagged && c_keep_flagged))
         {
-          if (mutt_append_message(m_read, m, e, MUTT_CM_NO_FLAGS, CH_UPDATE_LEN) == 0)
+          if (mutt_append_message(m_read, m, e, NULL, MUTT_CM_NO_FLAGS, CH_UPDATE_LEN) == 0)
           {
             mutt_set_flag(m, e, MUTT_DELETE, true);
             mutt_set_flag(m, e, MUTT_PURGE, true);

--- a/ncrypt/crypt.c
+++ b/ncrypt/crypt.c
@@ -876,20 +876,21 @@ void crypt_extract_keys_from_messages(struct Mailbox *m, struct EmailList *el)
   {
     struct Email *e = en->email;
     struct Message *msg = mx_msg_open(m, e->msgno);
-    if (msg)
+    if (!msg)
     {
-      mutt_parse_mime_message(m, e, msg->fp);
-      mx_msg_close(m, &msg);
+      continue;
     }
+    mutt_parse_mime_message(m, e, msg->fp);
     if (e->security & SEC_ENCRYPT && !crypt_valid_passphrase(e->security))
     {
+      mx_msg_close(m, &msg);
       mutt_file_fclose(&fp_out);
       break;
     }
 
     if (((WithCrypto & APPLICATION_PGP) != 0) && (e->security & APPLICATION_PGP))
     {
-      mutt_copy_message(fp_out, m, e, NULL, MUTT_CM_DECODE | MUTT_CM_CHARCONV,
+      mutt_copy_message(fp_out, m, e, msg, MUTT_CM_DECODE | MUTT_CM_CHARCONV,
                         CH_NO_FLAGS, 0);
       fflush(fp_out);
 
@@ -901,7 +902,7 @@ void crypt_extract_keys_from_messages(struct Mailbox *m, struct EmailList *el)
     if (((WithCrypto & APPLICATION_SMIME) != 0) && (e->security & APPLICATION_SMIME))
     {
       const bool encrypt = e->security & SEC_ENCRYPT;
-      mutt_copy_message(fp_out, m, e, NULL,
+      mutt_copy_message(fp_out, m, e, msg,
                         encrypt ? MUTT_CM_NOHEADER | MUTT_CM_DECODE_CRYPT | MUTT_CM_DECODE_SMIME :
                                   MUTT_CM_NO_FLAGS,
                         CH_NO_FLAGS, 0);
@@ -925,6 +926,7 @@ void crypt_extract_keys_from_messages(struct Mailbox *m, struct EmailList *el)
         crypt_smime_invoke_import(mutt_buffer_string(tempfname), mbox);
       }
     }
+    mx_msg_close(m, &msg);
 
     rewind(fp_out);
   }

--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -4444,7 +4444,7 @@ static bool verify_sender(struct Email *e)
 /**
  * smime_gpgme_verify_sender - Implements CryptModuleSpecs::smime_verify_sender()
  */
-int smime_gpgme_verify_sender(struct Mailbox *m, struct Email *e)
+int smime_gpgme_verify_sender(struct Mailbox *m, struct Email *e, struct Message *msg)
 {
   return verify_sender(e);
 }

--- a/ncrypt/crypt_gpgme.h
+++ b/ncrypt/crypt_gpgme.h
@@ -33,6 +33,7 @@ struct AddressList;
 struct Body;
 struct Email;
 struct Mailbox;
+struct Message;
 struct State;
 
 /* We work based on user IDs, getting from a user ID to the key is
@@ -100,7 +101,7 @@ void         smime_gpgme_init(void);
 SecurityFlags smime_gpgme_send_menu(struct Mailbox *m, struct Email *e);
 struct Body *smime_gpgme_sign_message(struct Body *a, const struct AddressList *from);
 int          smime_gpgme_verify_one(struct Body *sigbdy, struct State *s, const char *tempfile);
-int          smime_gpgme_verify_sender(struct Mailbox *m, struct Email *e);
+int          smime_gpgme_verify_sender(struct Mailbox *m, struct Email *e, struct Message *msg);
 
 bool crypt_id_is_strong(struct CryptKeyInfo *key);
 int digit(const char *s);

--- a/ncrypt/crypt_mod.h
+++ b/ncrypt/crypt_mod.h
@@ -34,6 +34,7 @@ struct Body;
 struct Email;
 struct Envelope;
 struct Mailbox;
+struct Message;
 struct State;
 
 /**
@@ -213,10 +214,11 @@ struct CryptModuleSpecs
    * smime_verify_sender - Does the sender match the certificate?
    * @param m Mailbox
    * @param e Email
+   * @param msg Message
    * @retval 0 Success
    * @retval 1 Failure
    */
-  int (*smime_verify_sender)(struct Mailbox *m, struct Email *e);
+  int (*smime_verify_sender)(struct Mailbox *m, struct Email *e, struct Message *msg);
 
   /**
    * smime_build_smime_entity - Encrypt the email body to all recipients

--- a/ncrypt/cryptglue.c
+++ b/ncrypt/cryptglue.c
@@ -471,10 +471,10 @@ void crypt_smime_getkeys(struct Envelope *env)
 /**
  * crypt_smime_verify_sender - Wrapper for CryptModuleSpecs::smime_verify_sender()
  */
-int crypt_smime_verify_sender(struct Mailbox *m, struct Email *e)
+int crypt_smime_verify_sender(struct Mailbox *m, struct Email *e, struct Message *msg)
 {
   if (CRYPT_MOD_CALL_CHECK(SMIME, smime_verify_sender))
-    return CRYPT_MOD_CALL(SMIME, smime_verify_sender)(m, e);
+    return CRYPT_MOD_CALL(SMIME, smime_verify_sender)(m, e, msg);
 
   return 1;
 }

--- a/ncrypt/lib.h
+++ b/ncrypt/lib.h
@@ -67,6 +67,7 @@ struct Email;
 struct EmailList;
 struct Envelope;
 struct Mailbox;
+struct Message;
 struct State;
 
 typedef uint16_t SecurityFlags;           ///< Flags, e.g. #SEC_ENCRYPT
@@ -172,7 +173,7 @@ int          crypt_smime_application_handler(struct Body *m, struct State *s);
 int          crypt_smime_decrypt_mime(FILE *fp_in, FILE **fp_out, struct Body *b, struct Body **cur);
 void         crypt_smime_getkeys(struct Envelope *env);
 SecurityFlags crypt_smime_send_menu(struct Mailbox *m, struct Email *e);
-int          crypt_smime_verify_sender(struct Mailbox *m, struct Email *e);
+int          crypt_smime_verify_sender(struct Mailbox *m, struct Email *e, struct Message *msg);
 
 /* crypt_mod.c */
 void crypto_module_free(void);

--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -1228,7 +1228,7 @@ void smime_class_invoke_import(const char *infile, const char *mailbox)
 /**
  * smime_class_verify_sender - Implements CryptModuleSpecs::smime_verify_sender()
  */
-int smime_class_verify_sender(struct Mailbox *m, struct Email *e)
+int smime_class_verify_sender(struct Mailbox *m, struct Email *e, struct Message *msg)
 {
   char *mbox = NULL, *certfile = NULL;
   int rc = 1;
@@ -1243,7 +1243,7 @@ int smime_class_verify_sender(struct Mailbox *m, struct Email *e)
   }
 
   const bool encrypt = e->security & SEC_ENCRYPT;
-  mutt_copy_message(fp_out, m, e, NULL,
+  mutt_copy_message(fp_out, m, e, msg,
                     encrypt ? (MUTT_CM_DECODE_CRYPT & MUTT_CM_DECODE_SMIME) : MUTT_CM_NO_FLAGS,
                     encrypt ? (CH_MIME | CH_WEED | CH_NONEWLINE) : CH_NO_FLAGS, 0);
 

--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -1242,13 +1242,10 @@ int smime_class_verify_sender(struct Mailbox *m, struct Email *e)
     goto cleanup;
   }
 
-  if (e->security & SEC_ENCRYPT)
-  {
-    mutt_copy_message(fp_out, m, e, MUTT_CM_DECODE_CRYPT & MUTT_CM_DECODE_SMIME,
-                      CH_MIME | CH_WEED | CH_NONEWLINE, 0);
-  }
-  else
-    mutt_copy_message(fp_out, m, e, MUTT_CM_NO_FLAGS, CH_NO_FLAGS, 0);
+  const bool encrypt = e->security & SEC_ENCRYPT;
+  mutt_copy_message(fp_out, m, e, NULL,
+                    encrypt ? (MUTT_CM_DECODE_CRYPT & MUTT_CM_DECODE_SMIME) : MUTT_CM_NO_FLAGS,
+                    encrypt ? (CH_MIME | CH_WEED | CH_NONEWLINE) : CH_NO_FLAGS, 0);
 
   fflush(fp_out);
   mutt_file_fclose(&fp_out);

--- a/ncrypt/smime.h
+++ b/ncrypt/smime.h
@@ -35,6 +35,7 @@ struct Body;
 struct Email;
 struct Envelope;
 struct Mailbox;
+struct Message;
 struct State;
 
 /**
@@ -64,7 +65,7 @@ SecurityFlags smime_class_send_menu(struct Mailbox *m, struct Email *e);
 struct Body *smime_class_sign_message(struct Body *a, const struct AddressList *from);
 bool         smime_class_valid_passphrase(void);
 int          smime_class_verify_one(struct Body *sigbdy, struct State *s, const char *tempfile);
-int          smime_class_verify_sender(struct Mailbox *m, struct Email *e);
+int          smime_class_verify_sender(struct Mailbox *m, struct Email *e, struct Message *msg);
 void         smime_class_void_passphrase(void);
 
 #endif /* MUTT_NCRYPT_SMIME_H */

--- a/nntp/nntp.c
+++ b/nntp/nntp.c
@@ -2677,7 +2677,7 @@ static bool nntp_msg_open(struct Mailbox *m, struct Message *msg, int msgno)
    * which is probably wrong, but we just call it again here to handle
    * the problem instead of fixing it */
   nntp_edata_get(e)->parsed = true;
-  mutt_parse_mime_message(m, e);
+  mutt_parse_mime_message(m, e, msg->fp);
 
   /* these would normally be updated in ctx_update(), but the
    * full headers aren't parsed with overview, so the information wasn't

--- a/pager/pager.c
+++ b/pager/pager.c
@@ -3985,7 +3985,8 @@ int mutt_pager(struct PagerView *pview)
         }
         if (!assert_pager_mode(pview->mode == PAGER_MODE_EMAIL))
           break;
-        dlg_select_attachment(ctx_mailbox(Context), pview->pdata->email);
+        dlg_select_attachment(ctx_mailbox(Context), pview->pdata->email,
+                              pview->pdata->fp);
         if (pview->pdata->email->attach_del)
           m->changed = true;
         pager_menu->redraw = REDRAW_FULL;

--- a/recvattach.c
+++ b/recvattach.c
@@ -1572,14 +1572,9 @@ static void attach_collapse(struct AttachCtx *actx, struct Menu *menu)
  */
 void dlg_select_attachment(struct Mailbox *m, struct Email *e, FILE *fp)
 {
-  struct Message *msg = fp ? NULL : mx_msg_open(m, e->msgno);
-  if (!m || !e || (!fp && !msg))
+  if (!m || !e || !fp)
   {
     return;
-  }
-  if (msg)
-  {
-    fp = msg->fp;
   }
 
   int op = OP_NULL;
@@ -1870,10 +1865,6 @@ void dlg_select_attachment(struct Mailbox *m, struct Email *e, FILE *fp)
         break;
 
       case OP_EXIT:
-        if (msg)
-        {
-          mx_msg_close(m, &msg);
-        }
         e->attach_del = false;
         for (int i = 0; i < actx->idxlen; i++)
         {

--- a/recvattach.h
+++ b/recvattach.h
@@ -39,7 +39,7 @@ void mutt_attach_init(struct AttachCtx *actx);
 void mutt_update_tree(struct AttachCtx *actx);
 
 const char *attach_format_str(char *buf, size_t buflen, size_t col, int cols, char op, const char *src, const char *prec, const char *if_str, const char *else_str, intptr_t data, MuttFormatFlags flags);
-void dlg_select_attachment(struct Mailbox *m, struct Email *e);
+void dlg_select_attachment(struct Mailbox *m, struct Email *e, FILE *fp);
 
 void mutt_generate_recvattach_list(struct AttachCtx *actx, struct Email *e, struct Body *parts, FILE *fp, int parent_type, int level, bool decrypted);
 

--- a/send/send.c
+++ b/send/send.c
@@ -485,7 +485,12 @@ static int include_forward(struct Mailbox *m, struct Email *e, FILE *fp_out,
   CopyHeaderFlags chflags = CH_DECODE;
   CopyMessageFlags cmflags = MUTT_CM_NO_FLAGS;
 
-  mutt_parse_mime_message(m, e);
+  struct Message *msg = mx_msg_open(m, e->msgno);
+  if (!msg)
+  {
+    return -1;
+  }
+  mutt_parse_mime_message(m, e, msg->fp);
   mutt_message_hook(m, e, MUTT_MESSAGE_HOOK);
 
   const bool c_forward_decode = cs_subset_bool(sub, "forward_decode");
@@ -493,7 +498,10 @@ static int include_forward(struct Mailbox *m, struct Email *e, FILE *fp_out,
   {
     /* make sure we have the user's passphrase before proceeding... */
     if (!crypt_valid_passphrase(e->security))
+    {
+      mx_msg_close(m, &msg);
       return -1;
+    }
   }
 
   mutt_forward_intro(e, fp_out, sub);
@@ -514,7 +522,8 @@ static int include_forward(struct Mailbox *m, struct Email *e, FILE *fp_out,
   if (c_forward_quote)
     cmflags |= MUTT_CM_PREFIX;
 
-  mutt_copy_message(fp_out, m, e, cmflags, chflags, 0);
+  mutt_copy_message(fp_out, m, e, msg, cmflags, chflags, 0);
+  mx_msg_close(m, &msg);
   mutt_forward_trailer(e, fp_out, sub);
   return 0;
 }
@@ -535,16 +544,17 @@ static int inline_forward_attachments(struct Mailbox *m, struct Email *e,
 {
   struct Body **last = *plast;
   struct Body *body = NULL;
-  struct Message *msg = NULL;
   struct AttachCtx *actx = NULL;
   int rc = 0, i;
 
-  mutt_parse_mime_message(m, e);
-  mutt_message_hook(m, e, MUTT_MESSAGE_HOOK);
-
-  msg = mx_msg_open(m, e->msgno);
+  struct Message *msg = mx_msg_open(m, e->msgno);
   if (!msg)
+  {
     return -1;
+  }
+
+  mutt_parse_mime_message(m, e, msg->fp);
+  mutt_message_hook(m, e, MUTT_MESSAGE_HOOK);
 
   actx = mutt_mem_calloc(1, sizeof(*actx));
   actx->email = e;
@@ -752,7 +762,12 @@ static int include_reply(struct Mailbox *m, struct Email *e, FILE *fp_out,
       return -1;
   }
 
-  mutt_parse_mime_message(m, e);
+  struct Message *msg = mx_msg_open(m, e->msgno);
+  if (!msg)
+  {
+    return -1;
+  }
+  mutt_parse_mime_message(m, e, msg->fp);
   mutt_message_hook(m, e, MUTT_MESSAGE_HOOK);
 
   mutt_make_attribution(e, fp_out, sub);
@@ -768,7 +783,8 @@ static int include_reply(struct Mailbox *m, struct Email *e, FILE *fp_out,
     cmflags |= MUTT_CM_WEED;
   }
 
-  mutt_copy_message(fp_out, m, e, cmflags, chflags, 0);
+  mutt_copy_message(fp_out, m, e, msg, cmflags, chflags, 0);
+  mx_msg_close(m, &msg);
 
   mutt_make_post_indent(e, fp_out, sub);
 

--- a/send/sendlib.c
+++ b/send/sendlib.c
@@ -972,7 +972,12 @@ struct Body *mutt_make_message_attach(struct Mailbox *m, struct Email *e,
 
   mutt_buffer_pool_release(&buf);
 
-  mutt_parse_mime_message(m, e);
+  struct Message *msg = mx_msg_open(m, e->msgno);
+  if (!msg)
+  {
+    return NULL;
+  }
+  mutt_parse_mime_message(m, e, msg->fp);
 
   CopyHeaderFlags chflags = CH_XMIT;
   cmflags = MUTT_CM_NO_FLAGS;
@@ -1011,7 +1016,8 @@ struct Body *mutt_make_message_attach(struct Mailbox *m, struct Email *e,
     }
   }
 
-  mutt_copy_message(fp, m, e, cmflags, chflags, 0);
+  mutt_copy_message(fp, m, e, msg, cmflags, chflags, 0);
+  mx_msg_close(m, &msg);
 
   fflush(fp);
   rewind(fp);

--- a/test/pattern/dummy.c
+++ b/test/pattern/dummy.c
@@ -107,7 +107,7 @@ int mutt_copy_header(FILE *in, struct Email *e, FILE *out, int flags, const char
   return -1;
 }
 
-int mutt_count_body_parts(struct Mailbox *m, struct Email *e)
+int mutt_count_body_parts(struct Mailbox *m, struct Email *e, struct Message *msg)
 {
   return g_body_parts;
 }
@@ -122,13 +122,14 @@ bool mutt_is_subscribed_list(struct Address *addr)
   return g_is_subscribed_list;
 }
 
-void mutt_parse_mime_message(struct Mailbox *m, struct Email *e)
+void mutt_parse_mime_message(struct Mailbox *m, struct Email *e, FILE *msg)
 {
 }
 
 void mutt_progress_init(struct Progress *progress, const char *msg, int type, size_t size)
 {
 }
+
 void mutt_progress_update(struct Progress *progress, long pos, int percent)
 {
 }


### PR DESCRIPTION
This reduces the number of calls to mx_msg_open when viewing a message,
its attachments, or limiting the index, by trying to call mx_msg_open as
soon as possible and pass the resulting Message or FILE pointer down.
This has impact mostly on IMAP w/o `message_cachedir`.

Some net results:
- `<display-message>` then `<view-attachments>` fetches the message once
  instead of twice
- limiting with `|` or `&` with patterns that require a full message
  (e.g., `~M`) fetches the message once instead of once per branch of
  the conditional

