### PR TITLE
Focus the logs pager view to the bottom

### DIFF
--- a/index/index.c
+++ b/index/index.c
@@ -1799,7 +1799,7 @@ struct Mailbox *mutt_index_menu(struct MuttWindow *dlg, struct Mailbox *m_init)
         pdata.fname = tempfile;
 
         pview.banner = "messages";
-        pview.flags = MUTT_PAGER_LOGS;
+        pview.flags = MUTT_PAGER_LOGS | MUTT_PAGER_BOTTOM;
         pview.mode = PAGER_MODE_OTHER;
 
         mutt_do_pager(&pview);

--- a/pager/lib.h
+++ b/pager/lib.h
@@ -56,6 +56,7 @@ typedef uint16_t PagerFlags;              ///< Flags for mutt_pager(), e.g. #MUT
 #define MUTT_PAGER_ATTACHMENT (1 << 8)    ///< Attachments may exist
 #define MUTT_PAGER_NOWRAP     (1 << 9)    ///< Format for term width, ignore $wrap
 #define MUTT_PAGER_LOGS       (1 << 10)   ///< Logview mode
+#define MUTT_PAGER_BOTTOM     (1 << 11)   ///< Start at the bottom
 #define MUTT_PAGER_MESSAGE    (MUTT_SHOWCOLOR | MUTT_PAGER_MARKER)
 
 #define MUTT_DISPLAYFLAGS (MUTT_SHOW | MUTT_PAGER_NSKIP | MUTT_PAGER_MARKER | MUTT_PAGER_LOGS)


### PR DESCRIPTION
This makes the log viewer  of `<show-log-messages>` always scroll to the bottom, so the most rececent log lines are visible.