### PR TITLE
fix crash in msg_search()

### DIFF
--- a/pattern/exec.c
+++ b/pattern/exec.c
@@ -735,7 +735,8 @@ static int msg_search_sendmode(struct Email *e, struct Pattern *pat)
 static bool pattern_needs_msg(const struct Pattern *pat)
 {
   if ((pat->op == MUTT_PAT_MIMETYPE) || (pat->op == MUTT_PAT_WHOLE_MSG) ||
-      (pat->op == MUTT_PAT_MIMEATTACH))
+      (pat->op == MUTT_PAT_MIMEATTACH) || (pat->op == MUTT_PAT_BODY) ||
+      (pat->op == MUTT_PAT_HEADER))
   {
     return true;
   }


### PR DESCRIPTION
This _may_ fix #2915

`pattern_needs_msg()` checks for `MUTT_PAT_MIMETYPE`, `MUTT_PAT_WHOLE_MSG` and `MUTT_PAT_MIMEATTACH`

but `pattern_exec()` has three cases: `MUTT_PAT_BODY`, `MUTT_PAT_HEADER` and `MUTT_PAT_WHOLE_MSG`
