### PR TITLE
Refactor notmuch window queries, improve documentation, and fix #2900

### DIFF
--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -15910,6 +15910,31 @@ virtual-mailboxes "My INBOX" "notmuch://?query=tag:inbox"
                   supports mailbox descriptions.
                 </entry>
               </row>
+              <row>
+                <entry><literal>nm_query_window_duration</literal></entry>
+                <entry>number</entry>
+                <entry><literal>0</literal></entry>
+                <entry>
+                  Duration between start and end dates for windowed notmuch query.
+                  This corresponds to a bounded notmuch <literal>date:</literal> query.
+                  See <literal>notmuch-search-terms</literal> manual page for more info.
+
+                  Value of <literal>0</literal> disables windowed queries unless
+                  <literal>nm_query_window_enable=yes</literal>
+                </entry>
+              </row>
+              <row>
+                <entry><literal>nm_query_window_timebase</literal></entry>
+                <entry>string</entry>
+                <entry><literal>week</literal></entry>
+                <entry>
+                  Time base for windowed notmuch queries.
+
+                  Must be one of: <literal>hour</literal>, <literal>day</literal>,
+                  <literal>week</literal>, <literal>month</literal>, or
+                  <literal>year</literal>
+                </entry>
+              </row>
             </tbody>
           </tgroup>
         </table>

--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -15911,6 +15911,15 @@ virtual-mailboxes "My INBOX" "notmuch://?query=tag:inbox"
                 </entry>
               </row>
               <row>
+                <entry><literal>nm_query_window_enable</literal></entry>
+                <entry>boolean</entry>
+                <entry><literal>no</literal></entry>
+                <entry>
+                  Enables windowed notmuch queries for
+                  <literal>nm_query_window_duration = 0</literal>
+                </entry>
+              </row>
+              <row>
                 <entry><literal>nm_query_window_duration</literal></entry>
                 <entry>number</entry>
                 <entry><literal>0</literal></entry>
@@ -16129,6 +16138,8 @@ set virtual_spool_file = no
 <emphasis role="comment"># setup time window preferences</emphasis>
 <emphasis role="comment"># first setup the duration, and then the time unit of that duration</emphasis>
 <emphasis role="comment"># when set to 0 (the default) the search window feature is disabled</emphasis>
+<emphasis role="comment"># unless explicitly enabled with nm_query_window_enable.</emphasis>
+set nm_query_window_enable=yes
 set nm_query_window_duration=2
 set nm_query_window_timebase="week" # or "hour", "day", "week", "month", "year"
 <emphasis role="comment"># --------------------------------------------------------------------------</emphasis>

--- a/index/index.c
+++ b/index/index.c
@@ -2419,7 +2419,9 @@ struct Mailbox *mutt_index_menu(struct MuttWindow *dlg, struct Mailbox *m_init)
           break;
         const short c_nm_query_window_duration =
             cs_subset_number(shared->sub, "nm_query_window_duration");
-        if (c_nm_query_window_duration <= 0)
+        const bool c_nm_query_window_enable =
+            cs_subset_bool(shared->sub, "nm_query_window_enable");
+        if (!c_nm_query_window_enable && (c_nm_query_window_duration <= 0))
         {
           mutt_message(_("Windowed queries disabled"));
           break;
@@ -2444,7 +2446,9 @@ struct Mailbox *mutt_index_menu(struct MuttWindow *dlg, struct Mailbox *m_init)
           break;
         const short c_nm_query_window_duration =
             cs_subset_number(shared->sub, "nm_query_window_duration");
-        if (c_nm_query_window_duration <= 0)
+        const bool c_nm_query_window_enable =
+            cs_subset_bool(shared->sub, "nm_query_window_enable");
+        if (!c_nm_query_window_enable && (c_nm_query_window_duration <= 0))
         {
           mutt_message(_("Windowed queries disabled"));
           break;

--- a/notmuch/config.c
+++ b/notmuch/config.c
@@ -108,6 +108,10 @@ static struct ConfigDef NotmuchVars[] = {
   { "nm_query_type", DT_STRING, IP "messages", 0, NULL,
     "(notmuch) Default query type: 'threads' or 'messages'"
   },
+  {
+    "nm_query_window_enable", DT_BOOL, false, 0, NULL,
+    "(notmuch) Enable query windows"
+  },
   { "nm_query_window_current_position", DT_NUMBER, 0, 0, NULL,
     "(notmuch) Position of current search window"
   },

--- a/notmuch/config.c
+++ b/notmuch/config.c
@@ -33,6 +33,7 @@
 #include <stdint.h>
 #include "mutt/lib.h"
 #include "notmuch/private.h"
+#include "notmuch/query.h"
 
 /**
  * is_valid_notmuch_url - Checks that a URL is in required form.
@@ -55,6 +56,32 @@ static int nm_default_url_validator(const struct ConfigSet *cs, const struct Con
   {
     mutt_buffer_printf(
         err, _("nm_default_url must be: notmuch://<absolute path> . Current: %s"), url);
+    return CSR_ERR_INVALID;
+  }
+
+  return CSR_SUCCESS;
+}
+
+/**
+ * nm_query_window_timebase_validator - Ensures nm_query_window_timebase matches allowed values - Implements ConfigDef::validator()
+ *
+ * Allowed values:
+ * - hour
+ * - day
+ * - week
+ * - month
+ * - year
+ */
+static int nm_query_window_timebase_validator(const struct ConfigSet *cs,
+                                              const struct ConfigDef *cdef,
+                                              intptr_t value, struct Buffer *err)
+{
+  const char *timebase = (const char *) value;
+  if (!nm_query_window_check_timebase(timebase))
+  {
+    mutt_buffer_printf(
+        err, _("Invalid nm_query_window_timebase value (valid values are: "
+               "hour, day, week, month or year)"));
     return CSR_ERR_INVALID;
   }
 
@@ -90,7 +117,7 @@ static struct ConfigDef NotmuchVars[] = {
   { "nm_query_window_duration", DT_NUMBER|DT_NOT_NEGATIVE, 0, 0, NULL,
     "(notmuch) Time duration of the current search window"
   },
-  { "nm_query_window_timebase", DT_STRING, IP "week", 0, NULL,
+  { "nm_query_window_timebase", DT_STRING, IP "week", 0, nm_query_window_timebase_validator,
     "(notmuch) Units for the time duration"
   },
   { "nm_record_tags", DT_STRING, 0, 0, NULL,

--- a/notmuch/notmuch.c
+++ b/notmuch/notmuch.c
@@ -249,13 +249,15 @@ static void query_window_reset(void)
  *
  * Creates a `date:` search term window from the following user settings:
  *
+ * - `nm_query_window_enable` (only required for `nm_query_window_duration = 0`)
  * - `nm_query_window_duration`
  * - `nm_query_window_timebase`
  * - `nm_query_window_current_position`
  *
  * The window won't be applied:
  *
- * - If the duration of the search query is set to `0` this function will be disabled.
+ * - If the duration of the search query is set to `0` this function will be
+ *   disabled unless a user explictly enables windowed queries.
  * - If the timebase is invalid, it will show an error message and do nothing.
  *
  * If there's no search registered in `nm_query_window_current_search` or this is
@@ -265,6 +267,8 @@ static bool windowed_query_from_query(const char *query, char *buf, size_t bufle
 {
   mutt_debug(LL_DEBUG2, "nm: %s\n", query);
 
+  const bool c_nm_query_window_enable =
+      cs_subset_bool(NeoMutt->sub, "nm_query_window_enable");
   const short c_nm_query_window_duration =
       cs_subset_number(NeoMutt->sub, "nm_query_window_duration");
   const short c_nm_query_window_current_position =
@@ -280,8 +284,9 @@ static bool windowed_query_from_query(const char *query, char *buf, size_t bufle
     query_window_reset();
 
   enum NmWindowQueryRc rc = nm_windowed_query_from_query(
-      buf, buflen, c_nm_query_window_duration, c_nm_query_window_current_position,
-      c_nm_query_window_current_search, c_nm_query_window_timebase);
+      buf, buflen, c_nm_query_window_enable, c_nm_query_window_duration,
+      c_nm_query_window_current_position, c_nm_query_window_current_search,
+      c_nm_query_window_timebase);
 
   switch (rc)
   {

--- a/notmuch/notmuch.c
+++ b/notmuch/notmuch.c
@@ -225,27 +225,6 @@ static char *email_get_fullpath(struct Email *e, char *buf, size_t buflen)
 }
 
 /**
- * query_window_check_timebase - Checks if a given timebase string is valid
- * @param[in] timebase: string containing a time base
- * @retval true The given time base is valid
- *
- * This function returns whether a given timebase string is valid or not,
- * which is used to validate the user settable configuration setting:
- *
- *     nm_query_window_timebase
- */
-static bool query_window_check_timebase(const char *timebase)
-{
-  if ((strcmp(timebase, "hour") == 0) || (strcmp(timebase, "day") == 0) ||
-      (strcmp(timebase, "week") == 0) || (strcmp(timebase, "month") == 0) ||
-      (strcmp(timebase, "year") == 0))
-  {
-    return true;
-  }
-  return false;
-}
-
-/**
  * query_window_reset - Restore vfolder's search window to its original position
  *
  * After moving a vfolder search window backward and forward, calling this function
@@ -268,27 +247,11 @@ static void query_window_reset(void)
  * @retval true  Transformed search query is available as a string in buf
  * @retval false Search query shall not be transformed
  *
- * This is where the magic of windowed queries happens. Taking a vfolder search
- * query string as parameter, it will use the following two user settings:
+ * Creates a `date:` search term window from the following user settings:
  *
- * - `nm_query_window_duration` and
+ * - `nm_query_window_duration`
  * - `nm_query_window_timebase`
- *
- * to amend given vfolder search window. Then using a third parameter:
- *
  * - `nm_query_window_current_position`
- *
- * it will generate a proper notmuch `date:` parameter. For example, given a
- * duration of `2`, a timebase set to `week` and a position defaulting to `0`,
- * it will prepend to the 'tag:inbox' notmuch search query the following string:
- *
- * - `query`: `tag:inbox`
- * - `buf`:   `date:2week..now and tag:inbox`
- *
- * If the position is set to `4`, with `duration=3` and `timebase=month`:
- *
- * - `query`: `tag:archived`
- * - `buf`:   `date:12month..9month and tag:archived`
  *
  * The window won't be applied:
  *
@@ -306,47 +269,41 @@ static bool windowed_query_from_query(const char *query, char *buf, size_t bufle
       cs_subset_number(NeoMutt->sub, "nm_query_window_duration");
   const short c_nm_query_window_current_position =
       cs_subset_number(NeoMutt->sub, "nm_query_window_current_position");
-  int beg = c_nm_query_window_duration * (c_nm_query_window_current_position + 1);
-  int end = c_nm_query_window_duration * c_nm_query_window_current_position;
-
-  /* if the duration is a non positive integer, disable the window */
-  if (c_nm_query_window_duration <= 0)
-  {
-    query_window_reset();
-    return false;
-  }
-
-  /* if the query has changed, reset the window position */
   const char *const c_nm_query_window_current_search =
       cs_subset_string(NeoMutt->sub, "nm_query_window_current_search");
+  const char *const c_nm_query_window_timebase =
+      cs_subset_string(NeoMutt->sub, "nm_query_window_timebase");
+
+  /* if the query has changed, reset the window position */
   if (!c_nm_query_window_current_search ||
       (strcmp(query, c_nm_query_window_current_search) != 0))
     query_window_reset();
 
-  const char *const c_nm_query_window_timebase =
-      cs_subset_string(NeoMutt->sub, "nm_query_window_timebase");
-  if (!query_window_check_timebase(c_nm_query_window_timebase))
-  {
-    mutt_message(_("Invalid nm_query_window_timebase value (valid values are: "
-                   "hour, day, week, month or year)"));
-    mutt_debug(LL_DEBUG2, "Invalid nm_query_window_timebase value\n");
-    return false;
-  }
+  enum NmWindowQueryRc rc = nm_windowed_query_from_query(
+      buf, buflen, c_nm_query_window_duration, c_nm_query_window_current_position,
+      c_nm_query_window_current_search, c_nm_query_window_timebase);
 
-  if (end == 0)
+  switch (rc)
   {
-    // Open-ended date allows mail from the future.
-    // This may occur is the sender's time settings are off.
-    snprintf(buf, buflen, "date:%d%s.. and %s", beg, c_nm_query_window_timebase,
-             c_nm_query_window_current_search);
+    case NM_WINDOW_QUERY_SUCCESS:
+    {
+      mutt_debug(LL_DEBUG2, "nm: %s -> %s\n", query, buf);
+      break;
+    }
+    case NM_WINDOW_QUERY_INVALID_DURATION:
+    {
+      query_window_reset();
+      return false;
+    }
+    case NM_WINDOW_QUERY_INVALID_TIMEBASE:
+    {
+      mutt_message(
+          _("Invalid nm_query_window_timebase value (valid values are: "
+            "hour, day, week, month or year)"));
+      mutt_debug(LL_DEBUG2, "Invalid nm_query_window_timebase value\n");
+      return false;
+    }
   }
-  else
-  {
-    snprintf(buf, buflen, "date:%d%s..%d%s and %s", beg, c_nm_query_window_timebase,
-             end, c_nm_query_window_timebase, c_nm_query_window_current_search);
-  }
-
-  mutt_debug(LL_DEBUG2, "nm: %s -> %s\n", query, buf);
 
   return true;
 }

--- a/notmuch/query.c
+++ b/notmuch/query.c
@@ -121,7 +121,7 @@ enum NmQueryType nm_string_to_query_type_mapper(const char *str)
 }
 
 /**
- * query_window_check_timebase - Checks if a given timebase string is valid
+ * nm_query_window_check_timebase - Checks if a given timebase string is vali_
  * @param[in] timebase: string containing a time base
  * @retval true The given time base is valid
  *
@@ -130,7 +130,7 @@ enum NmQueryType nm_string_to_query_type_mapper(const char *str)
  *
  *     nm_query_window_timebase
  */
-static bool query_window_check_timebase(const char *timebase)
+bool nm_query_window_check_timebase(const char *timebase)
 {
   if ((strcmp(timebase, "hour") == 0) || (strcmp(timebase, "day") == 0) ||
       (strcmp(timebase, "week") == 0) || (strcmp(timebase, "month") == 0) ||
@@ -197,7 +197,7 @@ enum NmWindowQueryRc nm_windowed_query_from_query(char *buf, size_t buflen,
   int beg = duration * (cur_pos + 1);
   int end = duration * cur_pos;
 
-  if (!query_window_check_timebase(timebase))
+  if (!nm_query_window_check_timebase(timebase))
   {
     return NM_WINDOW_QUERY_INVALID_TIMEBASE;
   }

--- a/notmuch/query.c
+++ b/notmuch/query.c
@@ -119,3 +119,99 @@ enum NmQueryType nm_string_to_query_type_mapper(const char *str)
 
   return NM_QUERY_TYPE_UNKNOWN;
 }
+
+/**
+ * query_window_check_timebase - Checks if a given timebase string is valid
+ * @param[in] timebase: string containing a time base
+ * @retval true The given time base is valid
+ *
+ * This function returns whether a given timebase string is valid or not,
+ * which is used to validate the user settable configuration setting:
+ *
+ *     nm_query_window_timebase
+ */
+static bool query_window_check_timebase(const char *timebase)
+{
+  if ((strcmp(timebase, "hour") == 0) || (strcmp(timebase, "day") == 0) ||
+      (strcmp(timebase, "week") == 0) || (strcmp(timebase, "month") == 0) ||
+      (strcmp(timebase, "year") == 0))
+  {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * nm_windowed_query_from_query - Windows `buf` with notmuch `date:` search term
+ * @param[out] buf    allocated string buffer to receive the modified search query
+ * @param[in]  buflen allocated maximum size of the buf string buffer
+ * @param[in]  duration Duration of time between beginning and end for notmuch `date` search term
+ * @param[in]  cur_pos  Current position of vfolder window
+ * @param[in]  cur_search Current notmuch search
+ * @param[in]  timebase Timebase for `date:` search term. Must be: `hour`,
+ *                      `day`, `week`, `month`, or `year`
+ * @retval NM_WINDOW_QUERY_SUCCESS  Prepended `buf` with `date:` search term
+ * @retval NM_WINDOW_QUERY_INVALID_DURATION Duration out-of-range for search term. `buf` *not* prepended with `date:`
+ * @retval NM_WINDOW_QUERY_INVALID_TIMEBASE Timebase isn't one of `hour`, `day`, `week`, `month`, or `year`
+ *
+ * This is where the magic of windowed queries happens. Taking a vfolder search
+ * query string as parameter, it will use the following two user settings:
+ *
+ * - `duration` and
+ * - `timebase`
+ *
+ * to amend given vfolder search window. Then using a third parameter:
+ *
+ * - `cur_pos`
+ *
+ * it will generate a proper notmuch `date:` parameter. For example, given a
+ * duration of `2`, a timebase set to `week` and a position defaulting to `0`,
+ * it will prepend to the 'tag:inbox' notmuch search query the following string:
+ *
+ * - `query`: `tag:inbox`
+ * - `buf`:   `date:2week..now and tag:inbox`
+ *
+ * If the position is set to `4`, with `duration=3` and `timebase=month`:
+ *
+ * - `query`: `tag:archived`
+ * - `buf`:   `date:12month..9month and tag:archived`
+ *
+ * The window won't be applied:
+ *
+ * - If the duration of the search query is set to `0` this function will be disabled
+ *   and return NM_WINDOW_QUERY_INVALID_DURATION
+ *
+ * - If the timebase is invalid, it will return NM_WINDOW_QUERY_INVALID_TIMEBASE
+ */
+enum NmWindowQueryRc nm_windowed_query_from_query(char *buf, size_t buflen,
+                                                  const short duration, const short cur_pos,
+                                                  const char *cur_search, const char *timebase)
+{
+  // if the duration is a non positive integer, disable the window unless the
+  // user explictly enables windowed queries.
+  if (duration <= 0)
+  {
+    return NM_WINDOW_QUERY_INVALID_DURATION;
+  }
+
+  int beg = duration * (cur_pos + 1);
+  int end = duration * cur_pos;
+
+  if (!query_window_check_timebase(timebase))
+  {
+    return NM_WINDOW_QUERY_INVALID_TIMEBASE;
+  }
+
+  if (end == 0)
+  {
+    // Open-ended date allows mail from the future.
+    // This may occur is the sender's time settings are off.
+    snprintf(buf, buflen, "date:%d%s.. and %s", beg, timebase, cur_search);
+  }
+  else
+  {
+    snprintf(buf, buflen, "date:%d%s..%d%s and %s", beg, timebase, end, timebase, cur_search);
+  }
+
+  return NM_WINDOW_QUERY_SUCCESS;
+}

--- a/notmuch/query.c
+++ b/notmuch/query.c
@@ -145,6 +145,7 @@ bool nm_query_window_check_timebase(const char *timebase)
  * nm_windowed_query_from_query - Windows `buf` with notmuch `date:` search term
  * @param[out] buf    allocated string buffer to receive the modified search query
  * @param[in]  buflen allocated maximum size of the buf string buffer
+ * @param[in]  force_enable Enables windowing for duration=0
  * @param[in]  duration Duration of time between beginning and end for notmuch `date` search term
  * @param[in]  cur_pos  Current position of vfolder window
  * @param[in]  cur_search Current notmuch search
@@ -178,24 +179,34 @@ bool nm_query_window_check_timebase(const char *timebase)
  *
  * The window won't be applied:
  *
- * - If the duration of the search query is set to `0` this function will be disabled
- *   and return NM_WINDOW_QUERY_INVALID_DURATION
+ * - If the duration of the search query is set to `0` this function will be
+ *   disabled unless a user explictly enables windowed queries. This returns
+ *   NM_WINDOW_QUERY_INVALID_DURATION
  *
  * - If the timebase is invalid, it will return NM_WINDOW_QUERY_INVALID_TIMEBASE
  */
-enum NmWindowQueryRc nm_windowed_query_from_query(char *buf, size_t buflen,
-                                                  const short duration, const short cur_pos,
-                                                  const char *cur_search, const char *timebase)
+enum NmWindowQueryRc
+nm_windowed_query_from_query(char *buf, size_t buflen, const bool force_enable,
+                             const short duration, const short cur_pos,
+                             const char *cur_search, const char *timebase)
 {
   // if the duration is a non positive integer, disable the window unless the
   // user explictly enables windowed queries.
-  if (duration <= 0)
+  if (!force_enable && (duration <= 0))
   {
     return NM_WINDOW_QUERY_INVALID_DURATION;
   }
 
   int beg = duration * (cur_pos + 1);
   int end = duration * cur_pos;
+
+  // If the duration is 0, we want to generate a query spanning a single timebase.
+  // For example, `date:1month..1month` spans the previous month.
+  if ((duration == 0) && (cur_pos != 0))
+  {
+    end = cur_pos;
+    beg = end;
+  }
 
   if (!nm_query_window_check_timebase(timebase))
   {

--- a/notmuch/query.h
+++ b/notmuch/query.h
@@ -56,5 +56,6 @@ enum NmWindowQueryRc nm_windowed_query_from_query(char *buf, size_t buflen,
                                                   const short duration, const short current_pos,
                                                   const char *current_search,
                                                   const char *timebase);
+bool nm_query_window_check_timebase(const char *timebase);
 
 #endif /* MUTT_NOTMUCH_QUERY_H */

--- a/notmuch/query.h
+++ b/notmuch/query.h
@@ -23,6 +23,9 @@
 #ifndef MUTT_NOTMUCH_QUERY_H
 #define MUTT_NOTMUCH_QUERY_H
 
+#include <stddef.h>
+#include <stdbool.h>
+
 /**
  * enum NmQueryType - Notmuch Query Types
  *
@@ -35,9 +38,23 @@ enum NmQueryType
   NM_QUERY_TYPE_UNKNOWN,   ///< Unknown query type. Error in notmuch query.
 };
 
+/**
+ * enum NmWindowQueryRc - Return codes for nm_windowed_query_from_query()
+ */
+enum NmWindowQueryRc
+{
+  NM_WINDOW_QUERY_SUCCESS = 1,
+  NM_WINDOW_QUERY_INVALID_TIMEBASE,
+  NM_WINDOW_QUERY_INVALID_DURATION
+};
+
 enum NmQueryType nm_parse_type_from_query(char *buf);
 enum NmQueryType nm_string_to_query_type(const char *str);
 enum NmQueryType nm_string_to_query_type_mapper(const char *str);
 const char *nm_query_type_to_string(enum NmQueryType query_type);
+enum NmWindowQueryRc nm_windowed_query_from_query(char *buf, size_t buflen,
+                                                  const short duration, const short current_pos,
+                                                  const char *current_search,
+                                                  const char *timebase);
 
 #endif /* MUTT_NOTMUCH_QUERY_H */

--- a/notmuch/query.h
+++ b/notmuch/query.h
@@ -52,10 +52,10 @@ enum NmQueryType nm_parse_type_from_query(char *buf);
 enum NmQueryType nm_string_to_query_type(const char *str);
 enum NmQueryType nm_string_to_query_type_mapper(const char *str);
 const char *nm_query_type_to_string(enum NmQueryType query_type);
-enum NmWindowQueryRc nm_windowed_query_from_query(char *buf, size_t buflen,
-                                                  const short duration, const short current_pos,
-                                                  const char *current_search,
-                                                  const char *timebase);
+enum NmWindowQueryRc
+nm_windowed_query_from_query(char *buf, size_t buflen, const bool force_enable,
+                             const short duration, const short current_pos,
+                             const char *current_search, const char *timebase);
 bool nm_query_window_check_timebase(const char *timebase);
 
 #endif /* MUTT_NOTMUCH_QUERY_H */

--- a/test/Makefile.autosetup
+++ b/test/Makefile.autosetup
@@ -351,7 +351,8 @@ NOTIFY_OBJS	= test/notify/notify_free.o \
 		  test/notify/notify_set_parent.o
 
 @if USE_NOTMUCH
-NOTMUCH_OBJS	= test/notmuch/query_type.o
+NOTMUCH_OBJS	= test/notmuch/query_type.o \
+		  test/notmuch/window_query.o
 @endif
 
 PARAMETER_OBJS	= test/parameter/mutt_param_cmp_strict.o \

--- a/test/main.c
+++ b/test/main.c
@@ -586,6 +586,7 @@ NEOMUTT_TEST_LIST
   NEOMUTT_TEST_ITEM(test_nm_query_type_to_string)
   NEOMUTT_TEST_ITEM(test_nm_string_to_query_type)
   NEOMUTT_TEST_ITEM(test_nm_string_to_query_type_mapper)
+  NEOMUTT_TEST_ITEM(test_nm_windowed_query_from_query)
 #endif
 #ifdef USE_ZLIB
   NEOMUTT_TEST_ITEM(test_compress_zlib)
@@ -636,6 +637,7 @@ NEOMUTT_TEST_ITEM(test_compress_common)
   NEOMUTT_TEST_ITEM(test_nm_query_type_to_string)
   NEOMUTT_TEST_ITEM(test_nm_string_to_query_type)
   NEOMUTT_TEST_ITEM(test_nm_string_to_query_type_mapper)
+  NEOMUTT_TEST_ITEM(test_nm_windowed_query_from_query)
 #endif
 #ifdef USE_ZLIB
   NEOMUTT_TEST_ITEM(test_compress_zlib)

--- a/test/notmuch/window_query.c
+++ b/test/notmuch/window_query.c
@@ -28,19 +28,19 @@
 
 void test_nm_windowed_query_from_query(void)
 {
-  // Ensure existing behavior functions as expected with duration = 0
+  // Ensure legacy-behavior functions as expected with duration = 0
   {
     char buf[1024] = "\0";
     enum NmWindowQueryRc rc =
-        nm_windowed_query_from_query(buf, 1024, 0, 0, "tag:inbox", "month");
+        nm_windowed_query_from_query(buf, 1024, false, 0, 0, "tag:inbox", "month");
     TEST_CHECK(rc == NM_WINDOW_QUERY_INVALID_DURATION);
   }
 
-  // Check existing behavior with duration > 0
+  // Check legacy behavior with duration > 0
   {
     char buf[1024] = "\0";
     enum NmWindowQueryRc rc =
-        nm_windowed_query_from_query(buf, 1024, 1, 0, "tag:inbox", "month");
+        nm_windowed_query_from_query(buf, 1024, false, 1, 0, "tag:inbox", "month");
     TEST_CHECK(rc == NM_WINDOW_QUERY_SUCCESS);
     TEST_CHECK(mutt_str_equal(buf, "date:1month.. and tag:inbox"));
   }
@@ -49,7 +49,7 @@ void test_nm_windowed_query_from_query(void)
   {
     char buf[1024] = "\0";
     enum NmWindowQueryRc rc =
-        nm_windowed_query_from_query(buf, 1024, 1, 1, "tag:inbox", "month");
+        nm_windowed_query_from_query(buf, 1024, false, 1, 1, "tag:inbox", "month");
     TEST_CHECK(rc == NM_WINDOW_QUERY_SUCCESS);
     TEST_CHECK(mutt_str_equal(buf, "date:2month..1month and tag:inbox"));
   }
@@ -58,7 +58,7 @@ void test_nm_windowed_query_from_query(void)
   {
     char buf[1024] = "\0";
     enum NmWindowQueryRc rc =
-        nm_windowed_query_from_query(buf, 1024, 1, 3, "tag:inbox", "month");
+        nm_windowed_query_from_query(buf, 1024, false, 1, 3, "tag:inbox", "month");
     TEST_CHECK(rc == NM_WINDOW_QUERY_SUCCESS);
     TEST_CHECK(mutt_str_equal(buf, "date:4month..3month and tag:inbox"));
   }
@@ -67,7 +67,7 @@ void test_nm_windowed_query_from_query(void)
   {
     char buf[1024] = "\0";
     enum NmWindowQueryRc rc =
-        nm_windowed_query_from_query(buf, 1024, 3, 3, "tag:inbox", "month");
+        nm_windowed_query_from_query(buf, 1024, false, 3, 3, "tag:inbox", "month");
     TEST_CHECK(rc == NM_WINDOW_QUERY_SUCCESS);
     TEST_CHECK(mutt_str_equal(buf, "date:12month..9month and tag:inbox"));
   }
@@ -76,7 +76,34 @@ void test_nm_windowed_query_from_query(void)
   {
     char buf[1024] = "\0";
     enum NmWindowQueryRc rc =
-        nm_windowed_query_from_query(buf, 1024, 3, 3, "tag:inbox", "months");
+        nm_windowed_query_from_query(buf, 1024, false, 3, 3, "tag:inbox", "months");
     TEST_CHECK(rc == NM_WINDOW_QUERY_INVALID_TIMEBASE);
+  }
+
+  // Check zero-duration support with force_enable
+  {
+    char buf[1024] = "\0";
+    enum NmWindowQueryRc rc =
+        nm_windowed_query_from_query(buf, 1024, true, 0, 0, "tag:inbox", "month");
+    TEST_CHECK(rc == NM_WINDOW_QUERY_SUCCESS);
+    TEST_CHECK(mutt_str_equal(buf, "date:0month.. and tag:inbox"));
+  }
+
+  // Check zero duration span 1 position back
+  {
+    char buf[1024] = "\0";
+    enum NmWindowQueryRc rc =
+        nm_windowed_query_from_query(buf, 1024, true, 0, 1, "tag:inbox", "month");
+    TEST_CHECK(rc == NM_WINDOW_QUERY_SUCCESS);
+    TEST_CHECK(mutt_str_equal(buf, "date:1month..1month and tag:inbox"));
+  }
+
+  // Check zero duration span 3 position backs
+  {
+    char buf[1024] = "\0";
+    enum NmWindowQueryRc rc =
+        nm_windowed_query_from_query(buf, 1024, true, 0, 3, "tag:inbox", "month");
+    TEST_CHECK(rc == NM_WINDOW_QUERY_SUCCESS);
+    TEST_CHECK(mutt_str_equal(buf, "date:3month..3month and tag:inbox"));
   }
 }

--- a/test/notmuch/window_query.c
+++ b/test/notmuch/window_query.c
@@ -1,0 +1,82 @@
+/**
+ * @file
+ * Test code for notmuch windowed queries
+ *
+ * @authors
+ * Copyright (C) 2021 Austin Ray <austin@austinray.io>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define TEST_NO_MAIN
+#include "config.h"
+#include "acutest.h"
+#include "mutt/lib.h"
+#include "notmuch/query.h"
+
+void test_nm_windowed_query_from_query(void)
+{
+  // Ensure existing behavior functions as expected with duration = 0
+  {
+    char buf[1024] = "\0";
+    enum NmWindowQueryRc rc =
+        nm_windowed_query_from_query(buf, 1024, 0, 0, "tag:inbox", "month");
+    TEST_CHECK(rc == NM_WINDOW_QUERY_INVALID_DURATION);
+  }
+
+  // Check existing behavior with duration > 0
+  {
+    char buf[1024] = "\0";
+    enum NmWindowQueryRc rc =
+        nm_windowed_query_from_query(buf, 1024, 1, 0, "tag:inbox", "month");
+    TEST_CHECK(rc == NM_WINDOW_QUERY_SUCCESS);
+    TEST_CHECK(mutt_str_equal(buf, "date:1month.. and tag:inbox"));
+  }
+
+  // Check duration 1 one position back
+  {
+    char buf[1024] = "\0";
+    enum NmWindowQueryRc rc =
+        nm_windowed_query_from_query(buf, 1024, 1, 1, "tag:inbox", "month");
+    TEST_CHECK(rc == NM_WINDOW_QUERY_SUCCESS);
+    TEST_CHECK(mutt_str_equal(buf, "date:2month..1month and tag:inbox"));
+  }
+
+  // Check duration 1 span 3 positions back
+  {
+    char buf[1024] = "\0";
+    enum NmWindowQueryRc rc =
+        nm_windowed_query_from_query(buf, 1024, 1, 3, "tag:inbox", "month");
+    TEST_CHECK(rc == NM_WINDOW_QUERY_SUCCESS);
+    TEST_CHECK(mutt_str_equal(buf, "date:4month..3month and tag:inbox"));
+  }
+
+  // Check 3 duration span 3 position backs
+  {
+    char buf[1024] = "\0";
+    enum NmWindowQueryRc rc =
+        nm_windowed_query_from_query(buf, 1024, 3, 3, "tag:inbox", "month");
+    TEST_CHECK(rc == NM_WINDOW_QUERY_SUCCESS);
+    TEST_CHECK(mutt_str_equal(buf, "date:12month..9month and tag:inbox"));
+  }
+
+  // Check invalid timebase
+  {
+    char buf[1024] = "\0";
+    enum NmWindowQueryRc rc =
+        nm_windowed_query_from_query(buf, 1024, 3, 3, "tag:inbox", "months");
+    TEST_CHECK(rc == NM_WINDOW_QUERY_INVALID_TIMEBASE);
+  }
+}


### PR DESCRIPTION
This PR is a bit larger than I'd like, but I got ahead of myself. It's best understood by reading each commit message. However, there are four goals in this PR:

 - Refactor window query logic into two components, high-level and low-level, then add tests to protect against regressions.
 - Improve documentation of the feature
 - Fix #2900
 - Don't break any existing configurations so we're not burning our users' good will

Please note that commit 5b01866 is shown out of order on GitHub, it is the **last** commit in this series. I reordered the branch so the refactor comes before fixing #2900 for easier reverting if need be.

---

@neomutt/notmuch-users Please test this and let me know if I've broken a use-case, I've tried my best to test manually, but errors are always possible. If you can contribute a unit test for any broken use-case, I'd greatly appreciate it!