### PR TITLE
Eliminate Menu Stack - Part 1

### DIFF
--- a/compose/compose.c
+++ b/compose/compose.c
@@ -1503,7 +1503,7 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, uint8_t flags,
                       MUTT_WIN_SIZE_UNLIMITED, 1);
 
   struct MuttWindow *win_attach =
-      mutt_window_new(WT_INDEX, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
+      mutt_window_new(WT_MENU, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
   dlg->focus = win_attach;
 

--- a/compose/compose.c
+++ b/compose/compose.c
@@ -1505,6 +1505,7 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, uint8_t flags,
   struct MuttWindow *win_attach =
       mutt_window_new(WT_INDEX, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
+  dlg->focus = win_attach;
 
   struct MuttWindow *win_cbar =
       mutt_window_new(WT_INDEX_BAR, MUTT_WIN_ORIENT_VERTICAL,
@@ -1551,6 +1552,7 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, uint8_t flags,
 
   struct Menu *menu = menu_new(MENU_COMPOSE);
   notify_set_parent(menu->notify, win_attach->notify);
+  win_attach->wdata = menu;
 
   menu->pagelen = win_attach->state.rows;
   menu->win_index = win_attach;

--- a/debug/common.c
+++ b/debug/common.c
@@ -143,6 +143,11 @@ const char *win_name(const struct MuttWindow *win)
         return "WT_INDEX_BAR";
       else
         return "Index Bar";
+    case WT_MENU:
+      if (symbol)
+        return "WT_MENU";
+      else
+        return "Menu";
     case WT_MESSAGE:
       if (symbol)
         return "WT_MESSAGE";

--- a/gui/curs_lib.c
+++ b/gui/curs_lib.c
@@ -699,7 +699,7 @@ int mutt_do_pager(struct PagerView *pview)
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
 
   struct MuttWindow *pager =
-      mutt_window_new(WT_PAGER, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
+      mutt_window_new(WT_MENU, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
   dlg->focus = pager;
 

--- a/gui/mutt_window.h
+++ b/gui/mutt_window.h
@@ -92,10 +92,11 @@ enum WindowType
   // Common Windows
   WT_CUSTOM,          ///< Window with a custom drawing function
   WT_HELP_BAR,        ///< Help Bar containing list of useful key bindings
-  WT_INDEX,           ///< An Index Window containing a selection list
+  WT_INDEX,           ///< A panel containing the Index Window
   WT_INDEX_BAR,       ///< Index Bar containing status info about the Index
+  WT_MENU,            ///< An Window containing a Menu
   WT_MESSAGE,         ///< Window for messages/errors and command entry
-  WT_PAGER,           ///< Window containing paged free-form text
+  WT_PAGER,           ///< A panel containing the Pager Window
   WT_PAGER_BAR,       ///< Pager Bar containing status info about the Pager
   WT_SIDEBAR,         ///< Side panel containing Accounts or groups of data
 };

--- a/gui/simple.c
+++ b/gui/simple.c
@@ -55,8 +55,8 @@ static int dialog_config_observer(struct NotifyCallback *nc)
   struct MuttWindow *win_first = TAILQ_FIRST(&dlg->children);
 
   const bool c_status_on_top = cs_subset_bool(NeoMutt->sub, "status_on_top");
-  if ((c_status_on_top && (win_first->type == WT_INDEX)) ||
-      (!c_status_on_top && (win_first->type != WT_INDEX)))
+  if ((c_status_on_top && (win_first->type == WT_MENU)) ||
+      (!c_status_on_top && (win_first->type != WT_MENU)))
   {
     // Swap the Index and the IndexBar Windows
     TAILQ_REMOVE(&dlg->children, win_first, entries);
@@ -87,7 +87,7 @@ struct MuttWindow *dialog_create_simple_index(enum MenuType mtype, enum WindowTy
   dlg->wdata = menu;
 
   struct MuttWindow *index =
-      mutt_window_new(WT_INDEX, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
+      mutt_window_new(WT_MENU, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
   dlg->focus = index;
   index->wdata = menu;

--- a/index/index.c
+++ b/index/index.c
@@ -1152,7 +1152,7 @@ struct Mailbox *mutt_index_menu(struct MuttWindow *dlg, struct Mailbox *m_init)
   index_shared_data_set_context(shared, ctx_new(m_init));
 
   struct MuttWindow *win_index2 = mutt_window_find(dlg, WT_INDEX);
-  struct IndexPrivateData *priv = win_index2->wdata;
+  struct IndexPrivateData *priv = win_index2->parent->wdata;
   priv->attach_msg = OptAttachMsg;
   priv->win_index = win_index2;
   priv->win_ibar = mutt_window_find(dlg, WT_INDEX_BAR);
@@ -4224,10 +4224,10 @@ static struct MuttWindow *create_panel_index(struct MuttWindow *parent, bool sta
     mutt_window_add_child(panel_index, win_ibar);
   }
 
-  struct IndexPrivateData *private = index_private_data_new();
+  struct IndexPrivateData *priv = index_private_data_new();
 
-  win_index->wdata = private;
-  win_index->wdata_free = index_private_data_free;
+  panel_index->wdata = priv;
+  panel_index->wdata_free = index_private_data_free;
 
   return panel_index;
 }

--- a/index/index.c
+++ b/index/index.c
@@ -1151,13 +1151,15 @@ struct Mailbox *mutt_index_menu(struct MuttWindow *dlg, struct Mailbox *m_init)
   struct IndexSharedData *shared = dlg->wdata;
   index_shared_data_set_context(shared, ctx_new(m_init));
 
-  struct MuttWindow *win_index2 = mutt_window_find(dlg, WT_INDEX);
-  struct IndexPrivateData *priv = win_index2->parent->wdata;
+  struct MuttWindow *panel_index = mutt_window_find(dlg, WT_INDEX);
+  struct MuttWindow *panel_pager = mutt_window_find(dlg, WT_PAGER);
+
+  struct IndexPrivateData *priv = panel_index->wdata;
   priv->attach_msg = OptAttachMsg;
-  priv->win_index = win_index2;
-  priv->win_ibar = mutt_window_find(dlg, WT_INDEX_BAR);
-  priv->win_pager = mutt_window_find(dlg, WT_PAGER);
-  priv->win_pbar = mutt_window_find(dlg, WT_PAGER_BAR);
+  priv->win_index = mutt_window_find(panel_index, WT_MENU);
+  priv->win_ibar = mutt_window_find(panel_index, WT_INDEX_BAR);
+  priv->win_pager = mutt_window_find(panel_pager, WT_MENU);
+  priv->win_pbar = mutt_window_find(panel_pager, WT_PAGER_BAR);
 
   int op = OP_NULL;
 
@@ -1170,6 +1172,7 @@ struct Mailbox *mutt_index_menu(struct MuttWindow *dlg, struct Mailbox *m_init)
   dlg->help_menu = MENU_MAIN;
 
   struct Menu *menu = menu_new(MENU_MAIN);
+  priv->win_index->wdata = menu;
   notify_set_parent(menu->notify, priv->win_index->notify);
 
   priv->menu = menu;
@@ -4200,12 +4203,12 @@ void mutt_set_header_color(struct Mailbox *m, struct Email *e)
 static struct MuttWindow *create_panel_index(struct MuttWindow *parent, bool status_on_top)
 {
   struct MuttWindow *panel_index =
-      mutt_window_new(WT_CONTAINER, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
+      mutt_window_new(WT_INDEX, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
   parent->focus = panel_index;
 
   struct MuttWindow *win_index =
-      mutt_window_new(WT_INDEX, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
+      mutt_window_new(WT_MENU, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
   panel_index->focus = win_index;
 

--- a/pager/pager.c
+++ b/pager/pager.c
@@ -2277,7 +2277,7 @@ static void pager_custom_redraw(struct Menu *pager_menu)
     }
   }
 
-  if ((pager_menu->redraw & REDRAW_INDEX) && rd->menu)
+  if ((pager_menu->redraw & REDRAW_INDEX) && rd->menu && (c_pager_index_lines != 0))
   {
     /* redraw the pager_index indicator, because the
      * flags for this message might have changed. */
@@ -2524,6 +2524,7 @@ int mutt_pager(struct PagerView *pview)
 
   //---------- setup pager menu------------------------------------------------
   struct Menu *menu = menu_new(MENU_PAGER);
+  pview->win_pager->wdata = menu;
   notify_set_parent(menu->notify, pview->win_pager->notify);
 
   pager_menu = menu;
@@ -4194,13 +4195,13 @@ int mutt_pager(struct PagerView *pview)
 struct MuttWindow *add_panel_pager(struct MuttWindow *parent, bool status_on_top)
 {
   struct MuttWindow *panel_pager =
-      mutt_window_new(WT_CONTAINER, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
+      mutt_window_new(WT_PAGER, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
   panel_pager->state.visible = false; // The Pager and Pager Bar are initially hidden
   mutt_window_add_child(parent, panel_pager);
 
   struct MuttWindow *win_pager =
-      mutt_window_new(WT_PAGER, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
+      mutt_window_new(WT_MENU, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
   panel_pager->focus = win_pager;
 

--- a/test/pattern/dummy.c
+++ b/test/pattern/dummy.c
@@ -68,10 +68,10 @@ typedef uint16_t CompletionFlags;
 typedef uint16_t PagerFlags;
 typedef uint8_t SelectFileFlags;
 
-typedef const char *(format_t)(char *buf, size_t buflen, size_t col, int cols,
-                               char op, const char *src, const char *prec,
-                               const char *if_str, const char *else_str,
-                               intptr_t data, MuttFormatFlags flags);
+typedef const char *(format_t) (char *buf, size_t buflen, size_t col, int cols,
+                                char op, const char *src, const char *prec,
+                                const char *if_str, const char *else_str,
+                                intptr_t data, MuttFormatFlags flags);
 
 int crypt_valid_passphrase(int flags)
 {


### PR DESCRIPTION
Preparation for some Menu refactoring.

- efe7372ff8 compose: ensure focus is on Menu
- 93830484be index: move private data to panel
- d1e54c269e window: focussed Window is a Menu

All the Windows whose `wdata` is a `struct Menu`, now have type `WT_MEMU`.
This will allow us to find the 'current' Menu, e.g. for refreshes, without needing a global stack.

With the new naming, the Index/Pager now looks like:

- WT_DLG_INDEX
    - WT_SIDEBAR
    - WT_CONTAINER
        - WT_INDEX
            - WT_MENU
            - WT_STATUS_BAR
        - WT_PAGER
            - WT_MENU
            - WT_STATUS_BAR
