### PR TITLE
Eliminate Menu Stack - Part 2

### DIFF
--- a/compose/compose.c
+++ b/compose/compose.c
@@ -1559,7 +1559,6 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, uint8_t flags,
   menu->tag = compose_attach_tag;
   menu->custom_redraw = compose_custom_redraw;
   menu->mdata = rd;
-  menu_push_current(menu);
 
   struct AttachCtx *actx = mutt_actx_new();
   actx->email = e;
@@ -2773,7 +2772,6 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, uint8_t flags,
     e->security &= ~SEC_AUTOCRYPT;
 #endif
 
-  menu_pop_current(menu);
   menu_free(&menu);
   dialog_pop();
   notify_observer_remove(NeoMutt->notify, compose_config_observer, dlg);

--- a/compose/compose.c
+++ b/compose/compose.c
@@ -1550,10 +1550,7 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, uint8_t flags,
   win_env->req_rows = calc_envelope(rd);
   mutt_window_reflow(dlg);
 
-  struct Menu *menu = menu_new(MENU_COMPOSE);
-  notify_set_parent(menu->notify, win_attach->notify);
-  win_attach->wdata = menu;
-
+  struct Menu *menu = menu_new(win_attach,MENU_COMPOSE);
   menu->pagelen = win_attach->state.rows;
   menu->win_index = win_attach;
   menu->win_ibar = win_cbar;

--- a/gui/curs_lib.c
+++ b/gui/curs_lib.c
@@ -129,7 +129,7 @@ void mutt_need_hard_redraw(void)
 {
   keypad(stdscr, true);
   clearok(stdscr, true);
-  menu_set_current_redraw_full();
+  window_redraw(RootWindow, true);
 }
 
 /**
@@ -271,7 +271,7 @@ int mutt_buffer_get_field(const char *field, struct Buffer *buf, CompletionFlags
       SigWinch = 0;
       mutt_resize_screen();
       clearok(stdscr, true);
-      menu_current_redraw();
+      window_redraw(RootWindow, true);
     }
     mutt_window_clearline(MessageWindow, 0);
     mutt_curses_set_color(MT_COLOR_PROMPT);
@@ -418,7 +418,7 @@ enum QuadOption mutt_yesorno(const char *msg, enum QuadOption def)
         SigWinch = 0;
         mutt_resize_screen();
         clearok(stdscr, true);
-        menu_current_redraw();
+        window_redraw(RootWindow, true);
       }
       if (MessageWindow->state.cols)
       {
@@ -429,7 +429,7 @@ enum QuadOption mutt_yesorno(const char *msg, enum QuadOption def)
       if (prompt_lines != MessageWindow->state.rows)
       {
         mutt_window_reflow_message_rows(prompt_lines);
-        menu_current_redraw();
+        window_redraw(RootWindow, true);
       }
 
       /* maxlen here is sort of arbitrary, so pick a reasonable upper bound */
@@ -491,7 +491,7 @@ enum QuadOption mutt_yesorno(const char *msg, enum QuadOption def)
   else
   {
     mutt_window_reflow_message_rows(1);
-    menu_current_redraw();
+    window_redraw(RootWindow, true);
   }
 
   if (def == MUTT_ABORT)
@@ -955,7 +955,7 @@ int mutt_multi_choice(const char *prompt, const char *letters)
         SigWinch = 0;
         mutt_resize_screen();
         clearok(stdscr, true);
-        menu_current_redraw();
+        window_redraw(RootWindow, true);
       }
       if (MessageWindow->state.cols)
       {
@@ -972,7 +972,7 @@ int mutt_multi_choice(const char *prompt, const char *letters)
       if (prompt_lines != MessageWindow->state.rows)
       {
         mutt_window_reflow_message_rows(prompt_lines);
-        menu_current_redraw();
+        window_redraw(RootWindow, true);
       }
 
       mutt_window_move(MessageWindow, 0, 0);
@@ -1048,7 +1048,7 @@ int mutt_multi_choice(const char *prompt, const char *letters)
   else
   {
     mutt_window_reflow_message_rows(1);
-    menu_current_redraw();
+    window_redraw(RootWindow, true);
   }
   mutt_refresh();
   return choice;

--- a/gui/dialog.c
+++ b/gui/dialog.c
@@ -119,7 +119,6 @@ void dialog_pop(void)
     mutt_window_reflow(AllDialogsWindow);
   }
   window_set_focus(last);
-  menu_set_current_redraw(REDRAW_FULL);
 #ifdef USE_DEBUG_WINDOW
   debug_win_dump();
 #endif

--- a/gui/mutt_window.c
+++ b/gui/mutt_window.c
@@ -444,9 +444,6 @@ void mutt_window_reflow(struct MuttWindow *win)
   window_reflow(win);
   window_notify_all(win);
 
-  menu_set_current_redraw_full();
-  /* the pager menu needs this flag set to recalc line_info */
-  menu_set_current_redraw(REDRAW_FLOW);
 #ifdef USE_DEBUG_WINDOW
   debug_win_dump();
 #endif
@@ -465,7 +462,7 @@ void mutt_window_reflow_message_rows(int mw_rows)
 
   /* We don't also set REDRAW_FLOW because this function only
    * changes rows and is a temporary adjustment. */
-  menu_set_current_redraw_full();
+  window_redraw(RootWindow, true);
 }
 
 /**

--- a/gui/simple.c
+++ b/gui/simple.c
@@ -77,22 +77,19 @@ static int dialog_config_observer(struct NotifyCallback *nc)
 struct MuttWindow *dialog_create_simple_index(enum MenuType mtype, enum WindowType wtype,
                                               const struct Mapping *help_data)
 {
-  struct Menu *menu = menu_new(mtype);
-
   struct MuttWindow *dlg =
       mutt_window_new(wtype, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
   dlg->help_menu = mtype;
   dlg->help_data = help_data;
-  dlg->wdata = menu;
 
   struct MuttWindow *index =
       mutt_window_new(WT_MENU, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_MAXIMISE,
                       MUTT_WIN_SIZE_UNLIMITED, MUTT_WIN_SIZE_UNLIMITED);
   dlg->focus = index;
-  index->wdata = menu;
 
-  notify_set_parent(menu->notify, index->notify);
+  struct Menu *menu = menu_new(index, mtype);
+  dlg->wdata = menu;
 
   const bool c_status_on_top = cs_subset_bool(NeoMutt->sub, "status_on_top");
   if (c_status_on_top)

--- a/gui/simple.c
+++ b/gui/simple.c
@@ -106,8 +106,6 @@ struct MuttWindow *dialog_create_simple_index(enum MenuType mtype, enum WindowTy
   menu->pagelen = index->state.rows;
   menu->win_index = index;
 
-  menu_push_current(menu);
-
   notify_observer_add(NeoMutt->notify, NT_CONFIG, dialog_config_observer, dlg);
   dialog_push(dlg);
 
@@ -126,7 +124,6 @@ void dialog_destroy_simple_index(struct MuttWindow **ptr)
   struct MuttWindow *dlg = *ptr;
 
   struct Menu *menu = dlg->wdata;
-  menu_pop_current(menu);
   menu_free(&menu);
 
   dialog_pop();

--- a/index/index.c
+++ b/index/index.c
@@ -1183,7 +1183,6 @@ struct Mailbox *mutt_index_menu(struct MuttWindow *dlg, struct Mailbox *m_init)
   priv->menu->color = index_color;
   priv->menu->current = ci_first_message(shared->mailbox);
   priv->menu->custom_redraw = index_custom_redraw;
-  menu_push_current(priv->menu);
   mutt_window_reflow(NULL);
 
   if (!priv->attach_msg)
@@ -4156,7 +4155,6 @@ struct Mailbox *mutt_index_menu(struct MuttWindow *dlg, struct Mailbox *m_init)
       break;
   }
 
-  menu_pop_current(priv->menu);
   menu_free(&priv->menu);
 
   struct Context *ctx = shared->ctx;

--- a/index/index.c
+++ b/index/index.c
@@ -1171,9 +1171,7 @@ struct Mailbox *mutt_index_menu(struct MuttWindow *dlg, struct Mailbox *m_init)
     dlg->help_data = IndexHelp;
   dlg->help_menu = MENU_MAIN;
 
-  struct Menu *menu = menu_new(MENU_MAIN);
-  priv->win_index->wdata = menu;
-  notify_set_parent(menu->notify, priv->win_index->notify);
+  struct Menu *menu = menu_new(priv->win_index, MENU_MAIN);
 
   priv->menu = menu;
   priv->menu->pagelen = priv->win_index->state.rows;

--- a/init.c
+++ b/init.c
@@ -806,8 +806,6 @@ int mutt_init(struct ConfigSet *cs, bool skip_sys_rc, struct ListHead *commands)
 
   Matches = mutt_mem_calloc(MatchesListsize, sizeof(char *));
 
-  CurrentMenu = MENU_MAIN;
-
 #ifdef HAVE_GETSID
   /* Unset suspend by default if we're the session leader */
   if (getsid(0) == getpid())
@@ -1246,9 +1244,9 @@ int mutt_command_complete(char *buf, size_t buflen, int pos, int numtabs)
   }
   else if (mutt_str_startswith(buf, "exec"))
   {
-    const struct Binding *menu = km_get_table(CurrentMenu);
-
-    if (!menu && (CurrentMenu != MENU_PAGER))
+    const enum MenuType mtype = menu_get_current_type();
+    const struct Binding *menu = km_get_table(mtype);
+    if (!menu && (mtype != MENU_PAGER))
       menu = OpGeneric;
 
     pt++;
@@ -1262,7 +1260,7 @@ int mutt_command_complete(char *buf, size_t buflen, int pos, int numtabs)
       for (int num = 0; menu[num].name; num++)
         candidate(UserTyped, menu[num].name, Completed, sizeof(Completed));
       /* try the generic menu */
-      if ((Completed[0] == '\0') && (CurrentMenu != MENU_PAGER))
+      if ((Completed[0] == '\0') && (mtype != MENU_PAGER))
       {
         menu = OpGeneric;
         for (int num = 0; menu[num].name; num++)

--- a/keymap.c
+++ b/keymap.c
@@ -45,6 +45,7 @@
 #include "mutt_commands.h"
 #include "mutt_globals.h"
 #include "mutt_logging.h"
+#include "mutt_menu.h"
 #include "opcodes.h"
 #include "options.h"
 #ifndef USE_SLANG_CURSES
@@ -1654,12 +1655,13 @@ enum CommandResult mutt_parse_exec(struct Buffer *buf, struct Buffer *s,
     mutt_extract_token(buf, s, MUTT_TOKEN_NO_FLAGS);
     function = buf->data;
 
-    bindings = km_get_table(CurrentMenu);
-    if (!bindings && (CurrentMenu != MENU_PAGER))
+    const enum MenuType mtype = menu_get_current_type();
+    bindings = km_get_table(mtype);
+    if (!bindings && (mtype != MENU_PAGER))
       bindings = OpGeneric;
 
     ops[nops] = get_op(bindings, function, mutt_str_len(function));
-    if ((ops[nops] == OP_NULL) && (CurrentMenu != MENU_PAGER))
+    if ((ops[nops] == OP_NULL) && (mtype != MENU_PAGER))
       ops[nops] = get_op(OpGeneric, function, mutt_str_len(function));
 
     if (ops[nops] == OP_NULL)

--- a/menu.c
+++ b/menu.c
@@ -1075,7 +1075,7 @@ int menu_config_observer(struct NotifyCallback *nc)
  * @param type Menu type, e.g. #MENU_PAGER
  * @retval ptr New Menu
  */
-struct Menu *menu_new(enum MenuType type)
+struct Menu *menu_new(struct MuttWindow *win, enum MenuType type)
 {
   struct Menu *menu = mutt_mem_calloc(1, sizeof(struct Menu));
 
@@ -1084,6 +1084,9 @@ struct Menu *menu_new(enum MenuType type)
   menu->color = default_color;
   menu->search = generic_search;
   menu->notify = notify_new();
+
+  win->wdata = menu;
+  notify_set_parent(menu->notify, win->notify);
 
   notify_observer_add(NeoMutt->notify, NT_CONFIG, menu_config_observer, menu);
   mutt_color_observer_add(menu_color_observer, menu);

--- a/menu.c
+++ b/menu.c
@@ -983,7 +983,7 @@ void menu_init(void)
  */
 int menu_color_observer(struct NotifyCallback *nc)
 {
-  if (!nc->event_data)
+  if (!nc->event_data || !nc->global_data)
     return -1;
   if (nc->event_type != NT_COLOR)
     return 0;
@@ -1021,7 +1021,9 @@ int menu_color_observer(struct NotifyCallback *nc)
     }
   }
 
-  menu_set_redraw_full(MENU_MAIN);
+  struct Menu *menu = nc->global_data;
+  menu->redraw = REDRAW_FULL;
+
   return 0;
 }
 
@@ -1030,7 +1032,7 @@ int menu_color_observer(struct NotifyCallback *nc)
  */
 int menu_config_observer(struct NotifyCallback *nc)
 {
-  if (!nc->event_data)
+  if (!nc->event_data || !nc->global_data)
     return -1;
   if (nc->event_type != NT_CONFIG)
     return 0;
@@ -1043,14 +1045,14 @@ int menu_config_observer(struct NotifyCallback *nc)
   if (flags == R_REDRAW_NO_FLAGS)
     return 0;
 
-  if (flags & R_INDEX)
-    menu_set_redraw_full(MENU_MAIN);
-  if (flags & R_PAGER)
-    menu_set_redraw_full(MENU_PAGER);
+  struct Menu *menu = nc->global_data;
+  if ((menu->type == MENU_MAIN) && (flags & R_INDEX))
+    menu->redraw |= REDRAW_FULL;
+  if ((menu->type == MENU_PAGER) && (flags & R_PAGER))
+    menu->redraw |= REDRAW_FULL;
   if (flags & R_PAGER_FLOW)
   {
-    menu_set_redraw_full(MENU_PAGER);
-    menu_set_redraw(MENU_PAGER, REDRAW_FLOW);
+    menu->redraw |= REDRAW_FULL | REDRAW_FLOW;
   }
 
   if (flags & R_RESORT_SUB)
@@ -1065,7 +1067,7 @@ int menu_config_observer(struct NotifyCallback *nc)
   if (flags & R_REFLOW)
     mutt_window_reflow(NULL);
   if (flags & R_MENU)
-    menu_set_current_redraw_full();
+    menu->redraw |= REDRAW_FULL;
 
   return 0;
 }

--- a/menu.c
+++ b/menu.c
@@ -1070,6 +1070,35 @@ int menu_config_observer(struct NotifyCallback *nc)
 }
 
 /**
+ * menu_recalc - Recalculate the Window data - Implements MuttWindow::recalc()
+ */
+static int menu_recalc(struct MuttWindow *win)
+{
+  if (win->type != WT_MENU)
+    return 0;
+
+  // struct Menu *menu = win->wdata;
+
+  win->actions |= WA_REPAINT;
+  return 0;
+}
+
+/**
+ * menu_repaint - Repaint the Window - Implements MuttWindow::repaint()
+ */
+static int menu_repaint(struct MuttWindow *win)
+{
+  if (win->type != WT_MENU)
+    return 0;
+
+  // struct Menu *menu = win->wdata;
+  // menu_redraw(menu);
+  // menu->redraw = REDRAW_NO_FLAGS;
+
+  return 0;
+}
+
+/**
  * menu_new - Create a new Menu
  * @param type Menu type, e.g. #MENU_PAGER
  * @retval ptr New Menu
@@ -1084,6 +1113,8 @@ struct Menu *menu_new(struct MuttWindow *win, enum MenuType type)
   menu->search = generic_search;
   menu->notify = notify_new();
 
+  win->recalc = menu_recalc;
+  win->repaint = menu_repaint;
   win->wdata = menu;
   notify_set_parent(menu->notify, win->notify);
 

--- a/mutt_config.c
+++ b/mutt_config.c
@@ -38,6 +38,7 @@
 #include "keymap.h"
 #include "mutt_globals.h"
 #include "mutt_logging.h"
+#include "mutt_menu.h"
 #include "mx.h"
 #include "options.h"
 
@@ -134,7 +135,8 @@ int multipart_validator(const struct ConfigSet *cs, const struct ConfigDef *cdef
 int pager_validator(const struct ConfigSet *cs, const struct ConfigDef *cdef,
                     intptr_t value, struct Buffer *err)
 {
-  if (CurrentMenu == MENU_PAGER)
+  const enum MenuType mtype = menu_get_current_type();
+  if (mtype == MENU_PAGER)
   {
     mutt_buffer_printf(err, _("Option %s may not be set or reset from the pager"),
                        cdef->name);

--- a/mutt_menu.h
+++ b/mutt_menu.h
@@ -155,7 +155,7 @@ void         menu_free(struct Menu **ptr);
 enum MenuType menu_get_current_type(void);
 void         menu_init(void);
 int          menu_loop(struct Menu *menu);
-struct Menu *menu_new(enum MenuType type);
+struct Menu *menu_new(struct MuttWindow *win, enum MenuType type);
 void         menu_pop_current(struct Menu *menu);
 void         menu_push_current(struct Menu *menu);
 void         menu_set_current_redraw_full(void);

--- a/mutt_menu.h
+++ b/mutt_menu.h
@@ -150,17 +150,10 @@ int          menu_redraw(struct Menu *menu);
 void         menu_top_page(struct Menu *menu);
 
 void         menu_add_dialog_row(struct Menu *menu, const char *row);
-void         menu_current_redraw(void);
 void         menu_free(struct Menu **ptr);
 enum MenuType menu_get_current_type(void);
 void         menu_init(void);
 int          menu_loop(struct Menu *menu);
 struct Menu *menu_new(struct MuttWindow *win, enum MenuType type);
-void         menu_pop_current(struct Menu *menu);
-void         menu_push_current(struct Menu *menu);
-void         menu_set_current_redraw_full(void);
-void         menu_set_current_redraw(MuttRedrawFlags redraw);
-void         menu_set_redraw_full(enum MenuType menu);
-void         menu_set_redraw(enum MenuType menu, MuttRedrawFlags redraw);
 
 #endif /* MUTT_MENU_H */

--- a/pager/pager.c
+++ b/pager/pager.c
@@ -2098,9 +2098,7 @@ static void pager_custom_redraw(struct Menu *pager_menu)
       {
         /* only allocate the space if/when we need the index.
          * Initialise the menu as per the main index */
-        struct Menu *menu = menu_new(MENU_MAIN);
-        notify_set_parent(menu->notify, rd->pview->win_index->notify);
-
+        struct Menu *menu = menu_new(rd->pview->win_index, MENU_MAIN);
         rd->menu = menu;
         rd->menu->make_entry = index_make_entry;
         rd->menu->color = index_color;
@@ -2523,10 +2521,7 @@ int mutt_pager(struct PagerView *pview)
   unlink(pview->pdata->fname);
 
   //---------- setup pager menu------------------------------------------------
-  struct Menu *menu = menu_new(MENU_PAGER);
-  pview->win_pager->wdata = menu;
-  notify_set_parent(menu->notify, pview->win_pager->notify);
-
+  struct Menu *menu = menu_new(pview->win_pager, MENU_PAGER);
   pager_menu = menu;
   pager_menu->pagelen = pview->win_pager->state.rows;
   pager_menu->win_index = pview->win_pager;

--- a/pager/pager.c
+++ b/pager/pager.c
@@ -2528,7 +2528,6 @@ int mutt_pager(struct PagerView *pview)
   pager_menu->win_ibar = pview->win_pbar;
   pager_menu->custom_redraw = pager_custom_redraw;
   pager_menu->mdata = &rd;
-  menu_push_current(pager_menu);
 
   //---------- restore global state if needed ---------------------------------
   while (pview->mode == PAGER_MODE_EMAIL && (OldEmail == pview->pdata->email) // are we "resuming" to the same Email?
@@ -4164,7 +4163,6 @@ int mutt_pager(struct PagerView *pview)
     rd.search_compiled = false;
   }
   FREE(&rd.line_info);
-  menu_pop_current(pager_menu);
   menu_free(&pager_menu);
   menu_free(&rd.menu);
 


### PR DESCRIPTION
**Work in progress**

This PR replaces lots of calls to functions that work at a global level.

### Currently

Most screens are powered by a Menu - a list of items + an event loop
As the user navigates, these Menus can get stacked up, (`MenuStack`)
e.g. Index -> Pager -> List attachments -> View an attachment

When an event happens, e.g. user sets a config variable,
NeoMutt looks up which Menu is 'active' and tries to decide if it should be updated.

### Refactor

Now, each Menu sets up observers for any event that it's interested in, e.g. config, colour.
On receiving the event, each Menu decides whether it should update itself, or not.

The stack of Menus isn't needed any more.
These Menu functions aren't needed either:

- `get_current_menu()`
- `menu_current_redraw()`
- `menu_pop_current()`
- `menu_push_current()`
- `menu_set_current_redraw()`
- `menu_set_current_redraw_full()`
- `menu_set_redraw()`
- `menu_set_redraw_full()`

### Changes

- 400a35ec55 score: use notification to update Mailbox
- a99fcba301 window: add helper to get active dialog
- a0da681f50 menu: add helper to get active menu
- 2ece61d505 menu: redraw all windows
- bdaae67266 refactor the pager_validator()
- cdaa0af4c2 menu: refactor event handling
- d7349330ce menu: drop all global functions