### PR TITLE
hcache: preserve Email->notify

### DIFF
--- a/hcache/hcache.c
+++ b/hcache/hcache.c
@@ -115,6 +115,7 @@ static void *dump(struct HeaderCache *hc, const struct Email *e, int *off, uint3
   e_dump.tree = NULL;
   e_dump.thread = NULL;
   e_dump.sequence = 0;
+  e_dump.notify = NULL;
   STAILQ_INIT(&e_dump.tags);
 #ifdef MIXMASTER
   STAILQ_INIT(&e_dump.chain);
@@ -152,9 +153,11 @@ static struct Email *restore(const unsigned char *d)
   off += sizeof(unsigned int);
 
   size_t sequence = e->sequence;
+  struct Notify *notify = e->notify;
   memcpy(e, d + off, sizeof(struct Email));
   off += sizeof(struct Email);
   e->sequence = sequence;
+  e->notify = notify;
 
   STAILQ_INIT(&e->tags);
 #ifdef MIXMASTER


### PR DESCRIPTION
Don't save `Email->notify` to the header cache.
When restoring from the cache, preserve the existing `notify` value.

Fixes: #2919 