### PR TITLE
fix crash with uncoloured quotes

### DIFF
--- a/gui/color.c
+++ b/gui/color.c
@@ -1483,7 +1483,10 @@ struct ColorLineList *mutt_color_index_tags(void)
  */
 int mutt_color_quote(int q)
 {
-  return Colors.quotes[q % Colors.quotes_used];
+  const int used = Colors.quotes_used;
+  if (used == 0)
+    return 0;
+  return Colors.quotes[q % used];
 }
 
 /**


### PR DESCRIPTION
Fixes: #2928

If the user hasn't configured any quoted-email colours, then NeoMutt tries to calculate a value modulo zero!