### PR TITLE
Localtime

### DIFF
--- a/copy.c
+++ b/copy.c
@@ -661,7 +661,8 @@ int mutt_copy_message_fp(FILE *fp_out, FILE *fp_in, struct Email *e,
 
       quoted_date = mutt_buffer_pool_get();
       mutt_buffer_addch(quoted_date, '"');
-      mutt_date_make_date(quoted_date);
+      mutt_date_make_date(quoted_date,
+                          cs_subset_bool(NeoMutt->sub, "local_date_header"));
       mutt_buffer_addch(quoted_date, '"');
 
       /* Count the number of lines and bytes to be deleted */

--- a/docs/config.c
+++ b/docs/config.c
@@ -2132,6 +2132,15 @@
 ** a "$mbox-hook" command.
 */
 
+{ "local_date_header", DT_BOOL, true },
+/*
+** .pp
+** If \fIset\fP, convert the date in the Date header of sent emails into the
+** local timezone of the sender. When \fIunset\fP, use UTC instead.
+** This is meant for privacy-conscious users that do not want to disclose their
+** time zone when they send mail.
+*/
+
 { "mail_check", DT_NUMBER, 5 },
 /*
 ** .pp

--- a/mutt/date.c
+++ b/mutt/date.c
@@ -369,19 +369,30 @@ void mutt_date_normalize_time(struct tm *tm)
 
 /**
  * mutt_date_make_date - Write a date in RFC822 format to a buffer
- * @param buf Buffer for result
+ * @param buf   Buffer for result
+ * @param local If true, use the local timezone.  Otherwise use UTC.
  *
  * Appends the date to the passed in buffer.
  * The buffer is not cleared because some callers prepend quotes.
  */
-void mutt_date_make_date(struct Buffer *buf)
+void mutt_date_make_date(struct Buffer *buf, bool local)
 {
   if (!buf)
     return;
 
+  struct tm tm;
+  time_t tz = 0;
+
   time_t t = mutt_date_epoch();
-  struct tm tm = mutt_date_localtime(t);
-  time_t tz = mutt_date_local_tz(t);
+  if (local)
+  {
+    tm = mutt_date_localtime(t);
+    tz = mutt_date_local_tz(t);
+  }
+  else
+  {
+    tm = mutt_date_gmtime(t);
+  }
 
   tz /= 60;
 

--- a/mutt/date.h
+++ b/mutt/date.h
@@ -57,7 +57,7 @@ struct tm mutt_date_gmtime(time_t t);
 size_t    mutt_date_localtime_format(char *buf, size_t buflen, const char *format, time_t t);
 struct tm mutt_date_localtime(time_t t);
 time_t    mutt_date_local_tz(time_t t);
-void      mutt_date_make_date(struct Buffer *buf);
+void      mutt_date_make_date(struct Buffer *buf, bool local);
 int       mutt_date_make_imap(char *buf, size_t buflen, time_t timestamp);
 time_t    mutt_date_make_time(struct tm *t, bool local);
 int       mutt_date_make_tls(char *buf, size_t buflen, time_t timestamp);

--- a/mutt_config.c
+++ b/mutt_config.c
@@ -378,6 +378,9 @@ static struct ConfigDef MainVars[] = {
   { "keep_flagged", DT_BOOL, false, 0, NULL,
     "Don't move flagged messages from `$spool_file` to `$mbox`"
   },
+  { "local_date_header", DT_BOOL, true, 0, NULL,
+    "Convert the date in the Date header of sent emails into local timezone, UTC otherwise"
+  },
   { "mail_check", DT_NUMBER|DT_NOT_NEGATIVE, 5, 0, NULL,
     "Number of seconds before NeoMutt checks for new mail"
   },

--- a/send/header.c
+++ b/send/header.c
@@ -582,7 +582,7 @@ int mutt_rfc822_write_header(FILE *fp, struct Envelope *env, struct Body *attach
       !privacy)
   {
     struct Buffer *date = mutt_buffer_pool_get();
-    mutt_date_make_date(date);
+    mutt_date_make_date(date, cs_subset_bool(sub, "local_date_header"));
     fprintf(fp, "Date: %s\n", mutt_buffer_string(date));
     mutt_buffer_pool_release(&date);
   }

--- a/send/sendlib.c
+++ b/send/sendlib.c
@@ -1329,7 +1329,7 @@ static int bounce_message(FILE *fp, struct Mailbox *m, struct Email *e,
     fprintf(fp_tmp, "Resent-From: %s\n", resent_from);
 
     struct Buffer *date = mutt_buffer_pool_get();
-    mutt_date_make_date(date);
+    mutt_date_make_date(date, cs_subset_bool(sub, "local_date_header"));
     fprintf(fp_tmp, "Resent-Date: %s\n", mutt_buffer_string(date));
     mutt_buffer_pool_release(&date);
 

--- a/test/date/mutt_date_make_date.c
+++ b/test/date/mutt_date_make_date.c
@@ -29,16 +29,21 @@ void test_mutt_date_make_date(void)
 {
   // void mutt_date_make_date(struct Buffer *buf);
 
+  bool local = true;
+  do
   {
-    mutt_date_make_date(NULL);
-    TEST_CHECK_(1, "mutt_date_make_date(NULL)");
-  }
+    {
+      mutt_date_make_date(NULL, local);
+      TEST_CHECK_(1, "mutt_date_make_date(NULL, %s)", local ? "true" : "false");
+    }
 
-  {
-    struct Buffer buf = mutt_buffer_make(32);
-    mutt_date_make_date(&buf);
-    TEST_CHECK(mutt_buffer_len(&buf) != 0);
-    TEST_MSG("%s", buf);
-    mutt_buffer_dealloc(&buf);
-  }
+    {
+      struct Buffer buf = mutt_buffer_make(32);
+      mutt_date_make_date(&buf, local);
+      TEST_CHECK(mutt_buffer_len(&buf) != 0);
+      TEST_MSG("%s", buf);
+      mutt_buffer_dealloc(&buf);
+    }
+    local = !local;
+  } while (!local); // test the same with local == false
 }


### PR DESCRIPTION
Add an option to convert the date used in the Date header into the local
timezone of the sender. This is the current behavior and the option
defaults to true. Unsetting this option causes the date in the Date
header to be formatted using the UTC timezone (aka GMT).

This option is useful for privacy-sensitive users who may not wish to
divulge their sending timezone.

This ports mutt's commit from Gregory Anders
https://gitlab.com/muttmua/mutt/-/commit/4c786d8795fa55eca3685d58edc60361ddf4de37

Note: sendlib.c didn't seem to be properly formated with clang... my editor insisted.  
It's on its own commit though if you'd rather have it the old way, feel free to drop it.