### PR TITLE
Fix notmuch query type parsing

### DIFF
--- a/mutt/string.c
+++ b/mutt/string.c
@@ -624,6 +624,39 @@ bool mutt_istrn_equal(const char *a, const char *b, size_t num)
 }
 
 /**
+ * mutt_istrn_rfind - Find last instance of a substring, ignoring case
+ * @param haystack        String to search through
+ * @param haystack_length Length of the string
+ * @param needle          String to find
+ * @retval NULL String not found
+ * @retval ptr  Location of string
+ *
+ * Return the last instance of needle in the haystack, or NULL.
+ * Like strcasestr(), only backwards, and for a limited haystack length.
+ */
+const char *mutt_istrn_rfind(const char *haystack, size_t haystack_length, const char *needle)
+{
+  if (!haystack || (haystack_length == 0) || !needle)
+    return NULL;
+
+  int needle_length = strlen(needle);
+  const char *haystack_end = haystack + haystack_length - needle_length;
+
+  for (const char *p = haystack_end; p >= haystack; --p)
+  {
+    for (size_t i = 0; i < needle_length; i++)
+    {
+      if ((tolower((unsigned char) p[i]) != tolower((unsigned char) needle[i])))
+        goto next;
+    }
+    return p;
+
+  next:;
+  }
+  return NULL;
+}
+
+/**
  * mutt_str_len - Calculate the length of a string, safely
  * @param a String to measure
  * @retval num Length in bytes

--- a/mutt/string2.h
+++ b/mutt/string2.h
@@ -105,5 +105,6 @@ size_t      mutt_istr_startswith(const char *str, const char *prefix);
 /* case-insensitive, length-bound flavours */
 int         mutt_istrn_cmp(const char *a, const char *b, size_t num);
 bool        mutt_istrn_equal(const char *a, const char *b, size_t num);
+const char *mutt_istrn_rfind(const char *haystack, size_t haystack_length, const char *needle);
 
 #endif /* MUTT_LIB_STRING_H */

--- a/test/Makefile.autosetup
+++ b/test/Makefile.autosetup
@@ -488,6 +488,7 @@ STRING_OBJS	= test/string/mutt_istr_equal.o \
 		  test/string/mutt_istr_remall.o \
 		  test/string/mutt_istrn_cmp.o \
 		  test/string/mutt_istrn_equal.o \
+		  test/string/mutt_istrn_rfind.o \
 		  test/string/mutt_str_adjust.o \
 		  test/string/mutt_str_append_item.o \
 		  test/string/mutt_str_asprintf.o \

--- a/test/main.c
+++ b/test/main.c
@@ -506,6 +506,7 @@
   NEOMUTT_TEST_ITEM(test_mutt_istr_remall)                                     \
   NEOMUTT_TEST_ITEM(test_mutt_istrn_cmp)                                       \
   NEOMUTT_TEST_ITEM(test_mutt_istrn_equal)                                     \
+  NEOMUTT_TEST_ITEM(test_mutt_istrn_rfind)                                     \
   NEOMUTT_TEST_ITEM(test_mutt_str_adjust)                                      \
   NEOMUTT_TEST_ITEM(test_mutt_str_append_item)                                 \
   NEOMUTT_TEST_ITEM(test_mutt_str_asprintf)                                    \

--- a/test/notmuch/query_type.c
+++ b/test/notmuch/query_type.c
@@ -46,6 +46,10 @@ void test_nm_parse_type_from_query(void)
     { "type=non-existent", NM_QUERY_TYPE_MESGS },
     { "type=threads&type=non-existent", NM_QUERY_TYPE_THREADS },
     { "type=messages&type=non-existent", NM_QUERY_TYPE_MESGS },
+    { "type=messages&type=threads", NM_QUERY_TYPE_THREADS },
+    { "type=messages&type=threads&type=messages", NM_QUERY_TYPE_MESGS },
+    { "type=messages&type=threads&type=messages&type=threads", NM_QUERY_TYPE_THREADS },
+    { "type=messages&type=threads&type=messages&type=threads&type=non-existent", NM_QUERY_TYPE_THREADS },
   };
 
   // Degenerate test

--- a/test/string/mutt_istrn_rfind.c
+++ b/test/string/mutt_istrn_rfind.c
@@ -1,0 +1,73 @@
+/**
+ * @file
+ * Test code for mutt_istrn_rfind()
+ *
+ * @authors
+ * Copyright (C) 2021 Austin Ray <austin@austinray.io>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define TEST_NO_MAIN
+#include "config.h"
+#include "acutest.h"
+#include "mutt/lib.h"
+
+struct RistrnTest
+{
+  const char *str;
+  size_t len;
+  size_t offset;
+};
+
+void test_mutt_istrn_rfind(void)
+{
+  // const char *mutt_istrn_rfind(const char *haystack, size_t haystack_length, const char *needle);
+
+  {
+    TEST_CHECK(mutt_istrn_rfind(NULL, 10, "apple") == NULL);
+    TEST_CHECK(mutt_istrn_rfind("apple", 0, "apple") == NULL);
+    TEST_CHECK(mutt_istrn_rfind("apple", 10, NULL) == NULL);
+    TEST_CHECK(mutt_istrn_rfind("", 1, "apple") == NULL);
+    TEST_CHECK(mutt_istrn_rfind("text", 1, "apple") == NULL);
+    TEST_CHECK(mutt_istrn_rfind("textapple", 8, "apple") == NULL);
+  }
+
+  // clang-format off
+  struct RistrnTest ristrn_tests[] =
+  {
+    { "AppleTEXT",      9,  0 },
+    { "TEXTaPpleTEXT",  13, 4 },
+    { "TEXTapPle",      9,  4 },
+
+    { "TEXTapPleappLe", 14, 9 },
+    { "appLeTEXTapplE", 14, 9 },
+    { "appleAPPLETEXT", 14, 5 },
+  };
+  // clang-format on
+
+  {
+    const char *find = "apple";
+
+    for (size_t i = 0; i < mutt_array_size(ristrn_tests); i++)
+    {
+      struct RistrnTest *t = &ristrn_tests[i];
+      TEST_CASE_("'%s'", t->str);
+
+      const char *result = mutt_istrn_rfind(t->str, t->len, find);
+      TEST_CHECK(result == (t->str + t->offset));
+    }
+  }
+}


### PR DESCRIPTION
Fixes an implementation error in query type parsing where having a `type=messages` parameter before a `type=threads` parameter can override the a correct threads query type.