### PR TITLE
notmuch: refactor tag parsing

### DIFF
--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -504,7 +504,7 @@ $(PWD)/nntp:
 LIBNOTMUCH=	libnotmuch.a
 LIBNOTMUCHOBJS=	notmuch/config.o notmuch/db.o notmuch/notmuch.o \
 		notmuch/adata.o notmuch/edata.o notmuch/mdata.o \
-		notmuch/query.o
+		notmuch/query.o notmuch/tag.o
 CLEANFILES+=	$(LIBNOTMUCH) $(LIBNOTMUCHOBJS)
 ALLOBJS+=	$(LIBNOTMUCHOBJS)
 

--- a/notmuch/lib.h
+++ b/notmuch/lib.h
@@ -34,6 +34,7 @@
  * | notmuch/mdata.c    | @subpage nm_mdata   |
  * | notmuch/notmuch.c  | @subpage nm_notmuch |
  * | notmuch/query.c    | @subpage nm_query   |
+ * | notmuch/tag.c      | @subpage nm_tag     |
  */
 
 #ifndef MUTT_NOTMUCH_LIB_H

--- a/notmuch/tag.c
+++ b/notmuch/tag.c
@@ -1,0 +1,82 @@
+/**
+ * @file
+ * Notmuch tag functions
+ *
+ * @authors
+ * Copyright (C) 2021 Austin Ray <austin@austinray.io>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @page nm_tag Notmuch tag functions
+ *
+ * Notmuch tag functions
+ */
+
+#include "config.h"
+#include <stddef.h>
+#include <ctype.h>
+#include "mutt/lib.h"
+#include "notmuch/tag.h"
+
+/**
+ * nm_tag_array_free - Free all memory of a TagArray
+ * @param tags  TagArray being cleaned up
+ */
+void nm_tag_array_free(struct TagArray *tags)
+{
+  ARRAY_FREE(&tags->tags);
+  FREE(&tags->tag_str);
+}
+
+/**
+ * nm_tag_string_to_tags - Converts a comma and/or space-delimited string of tags into an array
+ * @param tag_str String containing a list of tags, comma- and/or space-delimited
+ * @retval obj Array containing tags represented as strings
+ */
+struct TagArray nm_tag_str_to_tags(const char *tag_str)
+{
+  char *buf = mutt_str_dup(tag_str);
+
+  struct TagArray tags = { ARRAY_HEAD_INITIALIZER, buf };
+
+  char *end = NULL;
+  char *tag = NULL;
+
+  for (char *p = buf; p && (p[0] != '\0'); p++)
+  {
+    if (!tag && isspace(*p))
+      continue;
+    if (!tag)
+      tag = p; /* begin of the tag */
+    if ((p[0] == ',') || (p[0] == ' '))
+      end = p; /* terminate the tag */
+    else if (p[1] == '\0')
+      end = p + 1; /* end of optstr */
+    if (!tag || !end)
+      continue;
+    if (tag >= end)
+      break;
+    *end = '\0';
+
+    ARRAY_ADD(&tags.tags, tag);
+
+    end = NULL;
+    tag = NULL;
+  }
+
+  return tags;
+}

--- a/notmuch/tag.c
+++ b/notmuch/tag.c
@@ -43,7 +43,7 @@ void nm_tag_array_free(struct TagArray *tags)
 }
 
 /**
- * nm_tag_string_to_tags - Converts a comma and/or space-delimited string of tags into an array
+ * nm_tag_str_to_tags - Converts a comma and/or space-delimited string of tags into an array
  * @param tag_str String containing a list of tags, comma- and/or space-delimited
  * @retval obj Array containing tags represented as strings
  */

--- a/notmuch/tag.h
+++ b/notmuch/tag.h
@@ -1,0 +1,43 @@
+/**
+ * @file
+ * Notmuch tag functions
+ *
+ * @authors
+ * Copyright (C) 2021 Austin Ray <austin@austinray.io>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MUTT_NOTMUCH_TAG_H
+#define MUTT_NOTMUCH_TAG_H
+
+#include "mutt/lib.h"
+
+/**
+ * struct TagArray - Array of Notmuch tags
+ *
+ * The tag pointers, in the array, point into the source string.
+ * They must not be freed.
+ */
+struct TagArray
+{
+  ARRAY_HEAD(, char *) tags; ///< Tags
+  char *tag_str;             ///< Source string
+};
+
+void nm_tag_array_free(struct TagArray *tags);
+struct TagArray nm_tag_str_to_tags(const char *tag_string);
+
+#endif /* MUTT_NOTMUCH_TAG_H */

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -237,6 +237,7 @@ notmuch/edata.c
 notmuch/mdata.c
 notmuch/notmuch.c
 notmuch/query.c
+notmuch/tag.c
 opcodes.c
 opcodes.h
 pager/config.c

--- a/test/Makefile.autosetup
+++ b/test/Makefile.autosetup
@@ -352,6 +352,7 @@ NOTIFY_OBJS	= test/notify/notify_free.o \
 
 @if USE_NOTMUCH
 NOTMUCH_OBJS	= test/notmuch/query_type.o \
+		  test/notmuch/tag.o \
 		  test/notmuch/window_query.o
 @endif
 

--- a/test/main.c
+++ b/test/main.c
@@ -588,6 +588,7 @@ NEOMUTT_TEST_LIST
   NEOMUTT_TEST_ITEM(test_nm_string_to_query_type)
   NEOMUTT_TEST_ITEM(test_nm_string_to_query_type_mapper)
   NEOMUTT_TEST_ITEM(test_nm_windowed_query_from_query)
+  NEOMUTT_TEST_ITEM(test_nm_tag_string_to_tags)
 #endif
 #ifdef USE_ZLIB
   NEOMUTT_TEST_ITEM(test_compress_zlib)
@@ -639,6 +640,7 @@ NEOMUTT_TEST_ITEM(test_compress_common)
   NEOMUTT_TEST_ITEM(test_nm_string_to_query_type)
   NEOMUTT_TEST_ITEM(test_nm_string_to_query_type_mapper)
   NEOMUTT_TEST_ITEM(test_nm_windowed_query_from_query)
+  NEOMUTT_TEST_ITEM(test_nm_tag_string_to_tags)
 #endif
 #ifdef USE_ZLIB
   NEOMUTT_TEST_ITEM(test_compress_zlib)

--- a/test/notmuch/tag.c
+++ b/test/notmuch/tag.c
@@ -1,0 +1,63 @@
+/**
+ * @file
+ * Test code for notmuch tag functions
+ *
+ * @authors
+ * Copyright (C) 2021 Austin Ray <austin@austinray.io>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define TEST_NO_MAIN
+#include "config.h"
+#include "acutest.h"
+#include "mutt/lib.h"
+#include "notmuch/tag.h"
+
+void test_nm_tag_string_to_tags(void)
+{
+  // struct TagArray nm_tag_str_to_tags(const char *tag_str);
+
+  {
+    const char *input = "inbox,archive";
+    struct TagArray output = nm_tag_str_to_tags(input);
+
+    TEST_CHECK(mutt_str_equal("inbox", *ARRAY_GET(&output.tags, 0)));
+    TEST_CHECK(mutt_str_equal("archive", *ARRAY_GET(&output.tags, 1)));
+
+    nm_tag_array_free(&output);
+  }
+
+  {
+    const char *input = "inbox archive";
+    struct TagArray output = nm_tag_str_to_tags(input);
+
+    TEST_CHECK(mutt_str_equal("inbox", *ARRAY_GET(&output.tags, 0)));
+    TEST_CHECK(mutt_str_equal("archive", *ARRAY_GET(&output.tags, 1)));
+
+    nm_tag_array_free(&output);
+  }
+
+  {
+    const char *input = "inbox archive,sent";
+    struct TagArray output = nm_tag_str_to_tags(input);
+
+    TEST_CHECK(mutt_str_equal("inbox", *ARRAY_GET(&output.tags, 0)));
+    TEST_CHECK(mutt_str_equal("archive", *ARRAY_GET(&output.tags, 1)));
+    TEST_CHECK(mutt_str_equal("sent", *ARRAY_GET(&output.tags, 2)));
+
+    nm_tag_array_free(&output);
+  }
+}


### PR DESCRIPTION
Refactors the three spots of tag parsing into a single low-level, unit tested function. This removes redundancy and makes the higher-level functions easier to understand.

This is the first time I've used the array API so hopefully it's correct.