### PR TITLE
docs: update irc address in github issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: true
 contact_links:
-  - name: "🗪  IRC #neomutt on irc.freenode.net"
-    url: https://webchat.freenode.net/#neomutt
+  - name: "🗪  IRC #neomutt on irc.libera.chat"
+    url: https://kiwiirc.com/nextclient/irc.libera.chat/#neomutt
     about: Chat with NeoMutt users
   - name: "🖂  Mailing Lists"
     url: https://neomutt.org/#mailing-lists


### PR DESCRIPTION
Change the IRC address in the GitHub issue template from FreeNode to
Libera. Commit 069cd6a01 updated the IRC information elsewhere.