### PR TITLE
window refactoring

### DIFF
--- a/alias/dlgalias.c
+++ b/alias/dlgalias.c
@@ -213,7 +213,7 @@ static void dlg_select_alias(char *buf, size_t buflen, struct AliasMenuData *mda
   menu->max = alias_array_count_visible(&mdata->ava);
   menu->mdata = mdata;
 
-  struct MuttWindow *sbar = mutt_window_find(dlg, WT_INDEX_BAR);
+  struct MuttWindow *sbar = mutt_window_find(dlg, WT_STATUS_BAR);
 
   char *title = menu_create_alias_title(_("Aliases"), mdata->str);
   sbar_set_title(sbar, title);

--- a/alias/dlgquery.c
+++ b/alias/dlgquery.c
@@ -327,7 +327,7 @@ static void dlg_select_query(char *buf, size_t buflen, struct AliasList *all,
   snprintf(title, sizeof(title), "%s%s", _("Query: "), buf);
 
   struct MuttWindow *dlg = dialog_create_simple_index(MENU_QUERY, WT_DLG_QUERY, QueryHelp);
-  struct MuttWindow *sbar = mutt_window_find(dlg, WT_INDEX_BAR);
+  struct MuttWindow *sbar = mutt_window_find(dlg, WT_STATUS_BAR);
 
   struct Menu *menu = dlg->wdata;
   menu->make_entry = query_make_entry;

--- a/autocrypt/dlgautocrypt.c
+++ b/autocrypt/dlgautocrypt.c
@@ -176,7 +176,7 @@ static struct Menu *create_menu(struct MuttWindow *dlg)
   menu->make_entry = account_make_entry;
   /* menu->tag = account_tag; */
 
-  struct MuttWindow *sbar = mutt_window_find(dlg, WT_INDEX_BAR);
+  struct MuttWindow *sbar = mutt_window_find(dlg, WT_STATUS_BAR);
   // L10N: Autocrypt Account Management Menu title
   sbar_set_title(sbar, _("Autocrypt Accounts"));
 

--- a/browser.c
+++ b/browser.c
@@ -1368,7 +1368,7 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
   if (multiple)
     menu->tag = file_tag;
 
-  struct MuttWindow *sbar = mutt_window_find(dlg, WT_INDEX_BAR);
+  struct MuttWindow *sbar = mutt_window_find(dlg, WT_STATUS_BAR);
 
   if (state.is_mailbox_list)
   {

--- a/commands.c
+++ b/commands.c
@@ -945,7 +945,6 @@ void mutt_enter_command(void)
 {
   char buf[1024] = { 0 };
 
-  window_set_focus(MessageWindow);
   window_redraw(RootWindow);
   /* if enter is pressed after : with no command, just return */
   if ((mutt_get_field(":", buf, sizeof(buf), MUTT_COMMAND, false, NULL, NULL) != 0) ||

--- a/compose/cbar.c
+++ b/compose/cbar.c
@@ -286,7 +286,7 @@ static struct CBarPrivateData *cbar_data_new(struct ComposeRedrawData *rd)
 struct MuttWindow *cbar_create(struct MuttWindow *parent, struct ComposeRedrawData *rd)
 {
   struct MuttWindow *win_cbar =
-      mutt_window_new(WT_INDEX_BAR, MUTT_WIN_ORIENT_VERTICAL,
+      mutt_window_new(WT_STATUS_BAR, MUTT_WIN_ORIENT_VERTICAL,
                       MUTT_WIN_SIZE_FIXED, MUTT_WIN_SIZE_UNLIMITED, 1);
 
   win_cbar->wdata = cbar_data_new(rd);

--- a/compose/compose.c
+++ b/compose/compose.c
@@ -1263,7 +1263,7 @@ static int compose_config_observer(struct NotifyCallback *nc)
   if (!mutt_str_equal(ev_c->name, "status_on_top"))
     return 0;
 
-  struct MuttWindow *win_cbar = mutt_window_find(dlg, WT_INDEX_BAR);
+  struct MuttWindow *win_cbar = mutt_window_find(dlg, WT_STATUS_BAR);
   if (!win_cbar)
     return 0;
 

--- a/conn/dlgverifycert.c
+++ b/conn/dlgverifycert.c
@@ -71,7 +71,7 @@ int dlg_verify_certificate(const char *title, struct ListHead *list,
 
   struct Menu *menu = dlg->wdata;
 
-  struct MuttWindow *sbar = mutt_window_find(dlg, WT_INDEX_BAR);
+  struct MuttWindow *sbar = mutt_window_find(dlg, WT_STATUS_BAR);
   sbar_set_title(sbar, title);
 
   struct ListNode *np = NULL;

--- a/flags.c
+++ b/flags.c
@@ -439,10 +439,12 @@ int mutt_change_flag(struct Mailbox *m, struct EmailList *el, bool bf)
   enum MessageType flag = MUTT_NONE;
   struct KeyEvent event;
 
+  struct MuttWindow *old_focus = window_set_focus(MessageWindow);
+
   mutt_window_mvprintw(MessageWindow, 0, 0,
                        "%s? (D/N/O/r/*/!): ", bf ? _("Set flag") : _("Clear flag"));
   mutt_window_clrtoeol(MessageWindow);
-  mutt_refresh();
+  window_redraw(RootWindow);
 
   do
   {
@@ -450,6 +452,7 @@ int mutt_change_flag(struct Mailbox *m, struct EmailList *el, bool bf)
   } while (event.ch == -2); // Timeout
 
   mutt_window_clearline(MessageWindow, 0);
+  window_set_focus(old_focus);
 
   if (event.ch < 0) // SIGINT, Abort key (Ctrl-G)
     return -1;

--- a/gui/curs_lib.c
+++ b/gui/curs_lib.c
@@ -66,19 +66,16 @@
 
 /* not possible to unget more than one char under some curses libs, and it
  * is impossible to unget function keys in SLang, so roll our own input
- * buffering routines.
- */
+ * buffering routines.  */
 
 /* These are used for macros and exec/push commands.
- * They can be temporarily ignored by setting OptIgnoreMacroEvents
- */
+ * They can be temporarily ignored by setting OptIgnoreMacroEvents */
 static size_t MacroBufferCount = 0;
 static size_t MacroBufferLen = 0;
 static struct KeyEvent *MacroEvents;
 
 /* These are used in all other "normal" situations, and are not
- * ignored when setting OptIgnoreMacroEvents
- */
+ * ignored when setting OptIgnoreMacroEvents */
 static size_t UngetCount = 0;
 static size_t UngetLen = 0;
 static struct KeyEvent *UngetKeyEvents;
@@ -260,6 +257,8 @@ int mutt_buffer_get_field(const char *field, struct Buffer *buf, CompletionFlags
 
   struct EnterState *es = mutt_enter_state_new();
 
+  struct MuttWindow *old_focus = window_set_focus(MessageWindow);
+  window_redraw(RootWindow);
   do
   {
     if (SigWinch)
@@ -278,6 +277,7 @@ int mutt_buffer_get_field(const char *field, struct Buffer *buf, CompletionFlags
     ret = mutt_enter_string_full(buf->data, buf->dsize, col, complete, multiple,
                                  m, files, numfiles, es);
   } while (ret == 1);
+  window_set_focus(old_focus);
 
   if (ret == 0)
     mutt_buffer_fix_dptr(buf);
@@ -404,6 +404,8 @@ enum QuadOption mutt_yesorno(const char *msg, enum QuadOption def)
   answer_string_wid = mutt_strwidth(answer_string);
   msg_wid = mutt_strwidth(msg);
 
+  struct MuttWindow *old_focus = window_set_focus(MessageWindow);
+  window_redraw(RootWindow);
   while (true)
   {
     if (redraw || SigWinch)
@@ -472,6 +474,7 @@ enum QuadOption mutt_yesorno(const char *msg, enum QuadOption def)
       mutt_beep(false);
     }
   }
+  window_set_focus(old_focus);
 
   FREE(&answer_string);
 
@@ -831,6 +834,8 @@ int mutt_multi_choice(const char *prompt, const char *letters)
   const bool opt_cols = ((mutt_color(MT_COLOR_OPTIONS) != 0) &&
                          (mutt_color(MT_COLOR_OPTIONS) != mutt_color(MT_COLOR_PROMPT)));
 
+  struct MuttWindow *old_focus = window_set_focus(MessageWindow);
+  window_redraw(RootWindow);
   while (true)
   {
     if (redraw || SigWinch)
@@ -936,6 +941,7 @@ int mutt_multi_choice(const char *prompt, const char *letters)
     mutt_window_reflow_message_rows(1);
     window_redraw(RootWindow);
   }
+  window_set_focus(old_focus);
   mutt_refresh();
   return choice;
 }

--- a/gui/curs_lib.c
+++ b/gui/curs_lib.c
@@ -82,6 +82,21 @@ static struct KeyEvent *UngetKeyEvents;
 
 int MuttGetchTimeout = -1;
 
+/// Help Bar for the Command Line Editor
+static const struct Mapping EditorHelp[] = {
+  // clang-format off
+  { N_("Complete"),    OP_EDITOR_COMPLETE },
+  { N_("Hist Up"),     OP_EDITOR_HISTORY_UP },
+  { N_("Hist Down"),   OP_EDITOR_HISTORY_DOWN },
+  { N_("Hist Search"), OP_EDITOR_HISTORY_SEARCH },
+  { N_("Begin Line"),  OP_EDITOR_BOL },
+  { N_("End Line"),    OP_EDITOR_EOL },
+  { N_("Kill Line"),   OP_EDITOR_KILL_LINE },
+  { N_("Kill Word"),   OP_EDITOR_KILL_WORD },
+  { NULL, 0 },
+  // clang-format off
+};
+
 /**
  * mutt_beep - Irritate the user
  * @param force If true, ignore the "$beep" config variable
@@ -257,7 +272,13 @@ int mutt_buffer_get_field(const char *field, struct Buffer *buf, CompletionFlags
 
   struct EnterState *es = mutt_enter_state_new();
 
+  const struct Mapping *old_help = MessageWindow->help_data;
+  int old_menu = MessageWindow->help_menu;
+
+  MessageWindow->help_data = EditorHelp;
+  MessageWindow->help_menu = MENU_EDITOR;
   struct MuttWindow *old_focus = window_set_focus(MessageWindow);
+
   window_redraw(RootWindow);
   do
   {
@@ -277,6 +298,9 @@ int mutt_buffer_get_field(const char *field, struct Buffer *buf, CompletionFlags
     ret = mutt_enter_string_full(buf->data, buf->dsize, col, complete, multiple,
                                  m, files, numfiles, es);
   } while (ret == 1);
+
+  MessageWindow->help_data = old_help;
+  MessageWindow->help_menu = old_menu;
   window_set_focus(old_focus);
 
   if (ret == 0)

--- a/gui/mutt_window.c
+++ b/gui/mutt_window.c
@@ -941,5 +941,6 @@ bool window_status_on_top(struct MuttWindow *panel, struct ConfigSubset *sub)
   TAILQ_INSERT_TAIL(&panel->children, win_first, entries);
 
   mutt_window_reflow(panel);
+  mutt_debug(LL_DEBUG5, "config done, request WA_REFLOW\n");
   return true;
 }

--- a/gui/mutt_window.c
+++ b/gui/mutt_window.c
@@ -87,13 +87,12 @@ static const struct Mapping WindowNames[] = {
   { "WT_DLG_SMIME",       WT_DLG_SMIME },
   { "WT_HELP_BAR",        WT_HELP_BAR },
   { "WT_INDEX",           WT_INDEX },
-  { "WT_INDEX_BAR",       WT_INDEX_BAR },
   { "WT_MENU",            WT_MENU },
   { "WT_MESSAGE",         WT_MESSAGE },
   { "WT_PAGER",           WT_PAGER },
-  { "WT_PAGER_BAR",       WT_PAGER_BAR },
   { "WT_ROOT",            WT_ROOT },
   { "WT_SIDEBAR",         WT_SIDEBAR },
+  { "WT_STATUS_BAR",      WT_STATUS_BAR },
   // clang-format off
   { NULL, 0 },
 };
@@ -708,7 +707,7 @@ bool mutt_window_is_visible(struct MuttWindow *win)
 /**
  * mutt_window_find - Find a Window of a given type
  * @param root Window to start searching
- * @param type Window type to find, e.g. #WT_INDEX_BAR
+ * @param type Window type to find, e.g. #WT_STATUS_BAR
  * @retval ptr  Matching Window
  * @retval NULL No match
  */

--- a/gui/mutt_window.c
+++ b/gui/mutt_window.c
@@ -48,21 +48,6 @@ struct MuttWindow *RootWindow = NULL;       ///< Parent of all Windows
 struct MuttWindow *AllDialogsWindow = NULL; ///< Parent of all Dialogs
 struct MuttWindow *MessageWindow = NULL;    ///< Message Window, ":set", etc
 
-/// Help Bar for the Command Line Editor
-static const struct Mapping EditorHelp[] = {
-  // clang-format off
-  { N_("Complete"),    OP_EDITOR_COMPLETE },
-  { N_("Hist Up"),     OP_EDITOR_HISTORY_UP },
-  { N_("Hist Down"),   OP_EDITOR_HISTORY_DOWN },
-  { N_("Hist Search"), OP_EDITOR_HISTORY_SEARCH },
-  { N_("Begin Line"),  OP_EDITOR_BOL },
-  { N_("End Line"),    OP_EDITOR_EOL },
-  { N_("Kill Line"),   OP_EDITOR_KILL_LINE },
-  { N_("Kill Word"),   OP_EDITOR_KILL_WORD },
-  { NULL, 0 },
-  // clang-format off
-};
-
 /// Lookups for Window Names
 static const struct Mapping WindowNames[] = {
   // clang-format off
@@ -394,8 +379,6 @@ void mutt_window_init(void)
 
   MessageWindow = mutt_window_new(WT_MESSAGE, MUTT_WIN_ORIENT_VERTICAL,
                                   MUTT_WIN_SIZE_FIXED, MUTT_WIN_SIZE_UNLIMITED, 1);
-  MessageWindow->help_data = EditorHelp;
-  MessageWindow->help_menu = MENU_EDITOR;
 
   const bool c_status_on_top = cs_subset_bool(NeoMutt->sub, "status_on_top");
   if (c_status_on_top)

--- a/gui/mutt_window.h
+++ b/gui/mutt_window.h
@@ -93,12 +93,11 @@ enum WindowType
   WT_CUSTOM,          ///< Window with a custom drawing function
   WT_HELP_BAR,        ///< Help Bar containing list of useful key bindings
   WT_INDEX,           ///< A panel containing the Index Window
-  WT_INDEX_BAR,       ///< Index Bar containing status info about the Index
   WT_MENU,            ///< An Window containing a Menu
   WT_MESSAGE,         ///< Window for messages/errors and command entry
   WT_PAGER,           ///< A panel containing the Pager Window
-  WT_PAGER_BAR,       ///< Pager Bar containing status info about the Pager
   WT_SIDEBAR,         ///< Side panel containing Accounts or groups of data
+  WT_STATUS_BAR,      ///< Status Bar containing extra info about the Index/Pager/etc
 };
 
 TAILQ_HEAD(MuttWindowList, MuttWindow);

--- a/gui/mutt_window.h
+++ b/gui/mutt_window.h
@@ -28,6 +28,8 @@
 #include <stdint.h>
 #include "mutt/lib.h"
 
+struct ConfigSubset;
+
 /**
  * enum MuttWindowOrientation - Which way does the Window expand?
  */
@@ -239,5 +241,6 @@ struct MuttWindow *window_get_dialog (void);
 void window_redraw(struct MuttWindow *win);
 void window_invalidate_all(void);
 const char *mutt_window_win_name(const struct MuttWindow *win);
+bool window_status_on_top(struct MuttWindow *panel, struct ConfigSubset *sub);
 
 #endif /* MUTT_MUTT_WINDOW_H */

--- a/gui/sbar.c
+++ b/gui/sbar.c
@@ -137,7 +137,7 @@ static struct SBarPrivateData *sbar_data_new(void)
 struct MuttWindow *sbar_create(struct MuttWindow *parent)
 {
   struct MuttWindow *win_sbar =
-      mutt_window_new(WT_INDEX_BAR, MUTT_WIN_ORIENT_VERTICAL,
+      mutt_window_new(WT_STATUS_BAR, MUTT_WIN_ORIENT_VERTICAL,
                       MUTT_WIN_SIZE_FIXED, MUTT_WIN_SIZE_UNLIMITED, 1);
 
   win_sbar->wdata = sbar_data_new();
@@ -159,7 +159,7 @@ struct MuttWindow *sbar_create(struct MuttWindow *parent)
  */
 void sbar_set_title(struct MuttWindow *win, const char *title)
 {
-  if (!win || !win->wdata || (win->type != WT_INDEX_BAR))
+  if (!win || !win->wdata || (win->type != WT_STATUS_BAR))
     return;
 
   struct SBarPrivateData *priv = win->wdata;

--- a/gui/simple.c
+++ b/gui/simple.c
@@ -45,24 +45,11 @@ static int simple_config_observer(struct NotifyCallback *nc)
     return 0;
 
   struct EventConfig *ev_c = nc->event_data;
-  struct MuttWindow *dlg = nc->global_data;
-
   if (!mutt_str_equal(ev_c->name, "status_on_top"))
     return 0;
 
-  struct MuttWindow *win_first = TAILQ_FIRST(&dlg->children);
-
-  const bool c_status_on_top = cs_subset_bool(NeoMutt->sub, "status_on_top");
-  if ((c_status_on_top && (win_first->type == WT_MENU)) ||
-      (!c_status_on_top && (win_first->type != WT_MENU)))
-  {
-    // Swap the Index and the IndexBar Windows
-    TAILQ_REMOVE(&dlg->children, win_first, entries);
-    TAILQ_INSERT_TAIL(&dlg->children, win_first, entries);
-  }
-
-  mutt_window_reflow(dlg);
-  mutt_debug(LL_DEBUG5, "config done, request WA_REFLOW\n");
+  struct MuttWindow *dlg = nc->global_data;
+  window_status_on_top(dlg, NeoMutt->sub);
   return 0;
 }
 

--- a/history/dlghistory.c
+++ b/history/dlghistory.c
@@ -101,7 +101,7 @@ void dlg_select_history(char *buf, size_t buflen, char **matches, int match_coun
   struct MuttWindow *dlg =
       dialog_create_simple_index(MENU_GENERIC, WT_DLG_HISTORY, HistoryHelp);
 
-  struct MuttWindow *sbar = mutt_window_find(dlg, WT_INDEX_BAR);
+  struct MuttWindow *sbar = mutt_window_find(dlg, WT_STATUS_BAR);
   sbar_set_title(sbar, title);
 
   struct Menu *menu = dlg->wdata;

--- a/index/ibar.c
+++ b/index/ibar.c
@@ -319,7 +319,7 @@ struct MuttWindow *ibar_create(struct MuttWindow *parent, struct IndexSharedData
                                struct IndexPrivateData *priv)
 {
   struct MuttWindow *win_ibar =
-      mutt_window_new(WT_INDEX_BAR, MUTT_WIN_ORIENT_VERTICAL,
+      mutt_window_new(WT_STATUS_BAR, MUTT_WIN_ORIENT_VERTICAL,
                       MUTT_WIN_SIZE_FIXED, MUTT_WIN_SIZE_UNLIMITED, 1);
 
   win_ibar->wdata = ibar_data_new(shared, priv);

--- a/index/index.c
+++ b/index/index.c
@@ -3549,7 +3549,6 @@ struct Mailbox *mutt_index_menu(struct MuttWindow *dlg, struct Mailbox *m_init)
 
       case OP_ENTER_COMMAND:
         mutt_enter_command();
-        window_set_focus(priv->win_index);
         mutt_check_rescore(shared->mailbox);
         menu_queue_redraw(priv->menu, MENU_REDRAW_FULL);
         break;

--- a/index/index.c
+++ b/index/index.c
@@ -1140,9 +1140,9 @@ struct Mailbox *mutt_index_menu(struct MuttWindow *dlg, struct Mailbox *m_init)
   struct IndexPrivateData *priv = panel_index->wdata;
   priv->attach_msg = OptAttachMsg;
   priv->win_index = mutt_window_find(panel_index, WT_MENU);
-  priv->win_ibar = mutt_window_find(panel_index, WT_INDEX_BAR);
+  priv->win_ibar = mutt_window_find(panel_index, WT_STATUS_BAR);
   priv->win_pager = mutt_window_find(panel_pager, WT_MENU);
-  priv->win_pbar = mutt_window_find(panel_pager, WT_PAGER_BAR);
+  priv->win_pbar = mutt_window_find(panel_pager, WT_STATUS_BAR);
 
   int op = OP_NULL;
 

--- a/index/observer.c
+++ b/index/observer.c
@@ -136,28 +136,8 @@ static int config_status_on_top(struct MuttWindow *dlg)
   if (!win_index || !win_pager)
     return -1;
 
-  const bool c_status_on_top = cs_subset_bool(NeoMutt->sub, "status_on_top");
-
-  struct MuttWindow *first = TAILQ_FIRST(&win_index->children);
-  if ((c_status_on_top && (first->type == WT_MENU)) ||
-      (!c_status_on_top && (first->type != WT_MENU)))
-  {
-    // Swap the Index and the Index Bar Windows
-    TAILQ_REMOVE(&win_index->children, first, entries);
-    TAILQ_INSERT_TAIL(&win_index->children, first, entries);
-  }
-
-  first = TAILQ_FIRST(&win_pager->children);
-  if ((c_status_on_top && (first->type == WT_MENU)) ||
-      (!c_status_on_top && (first->type != WT_MENU)))
-  {
-    // Swap the Pager and Pager Bar Windows
-    TAILQ_REMOVE(&win_pager->children, first, entries);
-    TAILQ_INSERT_TAIL(&win_pager->children, first, entries);
-  }
-
-  mutt_window_reflow(dlg);
-  mutt_debug(LL_DEBUG5, "config, request WA_REFLOW\n");
+  window_status_on_top(win_index, NeoMutt->sub);
+  window_status_on_top(win_pager, NeoMutt->sub);
   return 0;
 }
 

--- a/menu/menu.c
+++ b/menu/menu.c
@@ -455,7 +455,6 @@ int menu_loop(struct Menu *menu)
 
       case OP_ENTER_COMMAND:
         mutt_enter_command();
-        window_set_focus(menu->win_index);
         window_redraw(RootWindow);
         break;
 

--- a/ncrypt/dlggpgme.c
+++ b/ncrypt/dlggpgme.c
@@ -1312,7 +1312,7 @@ struct CryptKeyInfo *dlg_select_gpgme_key(struct CryptKeyInfo *keys,
       snprintf(buf, sizeof(buf), _("%s \"%s\""), ts, s);
     }
 
-    struct MuttWindow *sbar = mutt_window_find(dlg, WT_INDEX_BAR);
+    struct MuttWindow *sbar = mutt_window_find(dlg, WT_STATUS_BAR);
     sbar_set_title(sbar, buf);
   }
 

--- a/ncrypt/dlgpgp.c
+++ b/ncrypt/dlgpgp.c
@@ -561,7 +561,7 @@ struct PgpKeyInfo *dlg_select_pgp_key(struct PgpKeyInfo *keys,
   else
     snprintf(buf, sizeof(buf), _("PGP keys matching \"%s\""), s);
 
-  struct MuttWindow *sbar = mutt_window_find(dlg, WT_INDEX_BAR);
+  struct MuttWindow *sbar = mutt_window_find(dlg, WT_STATUS_BAR);
   sbar_set_title(sbar, buf);
 
   kp = NULL;

--- a/ncrypt/dlgsmime.c
+++ b/ncrypt/dlgsmime.c
@@ -182,7 +182,7 @@ struct SmimeKey *dlg_select_smime_key(struct SmimeKey *keys, char *query)
   /* sorting keys might be done later - TODO */
 
   char title[256];
-  struct MuttWindow *sbar = mutt_window_find(dlg, WT_INDEX_BAR);
+  struct MuttWindow *sbar = mutt_window_find(dlg, WT_STATUS_BAR);
   snprintf(title, sizeof(title), _("S/MIME certificates matching \"%s\""), query);
   sbar_set_title(sbar, title);
 

--- a/pager/do_pager.c
+++ b/pager/do_pager.c
@@ -107,7 +107,7 @@ int mutt_do_pager(struct PagerView *pview)
 
   pview->win_ibar = NULL;
   pview->win_index = NULL;
-  pview->win_pbar = mutt_window_find(panel_pager, WT_PAGER_BAR);
+  pview->win_pbar = mutt_window_find(panel_pager, WT_STATUS_BAR);
   pview->win_pager = mutt_window_find(panel_pager, WT_MENU);
 
   int rc;

--- a/pager/do_pager.c
+++ b/pager/do_pager.c
@@ -50,26 +50,11 @@ static int dopager_config_observer(struct NotifyCallback *nc)
     return 0;
 
   struct EventConfig *ev_c = nc->event_data;
-  struct MuttWindow *dlg = nc->global_data;
-
   if (!mutt_str_equal(ev_c->name, "status_on_top"))
     return 0;
 
-  struct MuttWindow *win_first = TAILQ_FIRST(&dlg->children);
-  if (!win_first)
-    return -1;
-
-  const bool c_status_on_top = cs_subset_bool(NeoMutt->sub, "status_on_top");
-  if ((c_status_on_top && (win_first->type == WT_PAGER)) ||
-      (!c_status_on_top && (win_first->type != WT_PAGER)))
-  {
-    // Swap the Index and the IndexBar Windows
-    TAILQ_REMOVE(&dlg->children, win_first, entries);
-    TAILQ_INSERT_TAIL(&dlg->children, win_first, entries);
-    mutt_window_reflow(dlg);
-    mutt_debug(LL_DEBUG5, "config done, request WA_REFLOW\n");
-  }
-
+  struct MuttWindow *dlg = nc->global_data;
+  window_status_on_top(dlg, NeoMutt->sub);
   return 0;
 }
 

--- a/pager/pager.c
+++ b/pager/pager.c
@@ -3440,7 +3440,6 @@ int mutt_pager(struct PagerView *pview)
 
       case OP_ENTER_COMMAND:
         mutt_enter_command();
-        window_set_focus(rd.pview->win_pager);
         menu_queue_redraw(pager_menu, MENU_REDRAW_FULL);
 
         if (OptNeedResort)

--- a/pager/pbar.c
+++ b/pager/pbar.c
@@ -318,7 +318,7 @@ struct MuttWindow *pbar_create(struct MuttWindow *parent, struct IndexSharedData
                                struct PagerPrivateData *priv)
 {
   struct MuttWindow *win_pbar =
-      mutt_window_new(WT_PAGER_BAR, MUTT_WIN_ORIENT_VERTICAL,
+      mutt_window_new(WT_STATUS_BAR, MUTT_WIN_ORIENT_VERTICAL,
                       MUTT_WIN_SIZE_FIXED, MUTT_WIN_SIZE_UNLIMITED, 1);
 
   win_pbar->wdata = pbar_data_new(shared, priv);

--- a/pattern/dlgpattern.c
+++ b/pattern/dlgpattern.c
@@ -135,7 +135,7 @@ static struct Menu *create_pattern_menu(struct MuttWindow *dlg)
   menu->mdata = entries = mutt_mem_calloc(num_entries, sizeof(struct PatternEntry));
   menu->max = num_entries;
 
-  struct MuttWindow *sbar = mutt_window_find(dlg, WT_INDEX_BAR);
+  struct MuttWindow *sbar = mutt_window_find(dlg, WT_STATUS_BAR);
   // L10N: Pattern completion menu title
   sbar_set_title(sbar, _("Patterns"));
 

--- a/postpone.c
+++ b/postpone.c
@@ -231,7 +231,7 @@ static struct Email *dlg_select_postponed_email(struct Mailbox *m)
   menu->mdata = m;
   menu->custom_search = true;
 
-  struct MuttWindow *sbar = mutt_window_find(dlg, WT_INDEX_BAR);
+  struct MuttWindow *sbar = mutt_window_find(dlg, WT_STATUS_BAR);
   sbar_set_title(sbar, _("Postponed Messages"));
 
   /* The postponed mailbox is setup to have sorting disabled, but the global

--- a/recvattach.c
+++ b/recvattach.c
@@ -1641,7 +1641,7 @@ void dlg_select_attachment(struct ConfigSubset *sub, struct Mailbox *m,
   menu->make_entry = attach_make_entry;
   menu->tag = attach_tag;
 
-  struct MuttWindow *sbar = mutt_window_find(dlg, WT_INDEX_BAR);
+  struct MuttWindow *sbar = mutt_window_find(dlg, WT_STATUS_BAR);
   sbar_set_title(sbar, _("Attachments"));
 
   struct AttachCtx *actx = mutt_actx_new();

--- a/remailer.c
+++ b/remailer.c
@@ -567,28 +567,11 @@ static int remailer_config_observer(struct NotifyCallback *nc)
     return 0;
 
   struct EventConfig *ev_c = nc->event_data;
-  struct MuttWindow *dlg = nc->global_data;
-
   if (!mutt_str_equal(ev_c->name, "status_on_top"))
     return 0;
 
-  const bool c_status_on_top = cs_subset_bool(ev_c->sub, "status_on_top");
-  struct MuttWindow *win_move = NULL;
-  if (c_status_on_top)
-  {
-    win_move = TAILQ_LAST(&dlg->children, MuttWindowList);
-    TAILQ_REMOVE(&dlg->children, win_move, entries);
-    TAILQ_INSERT_HEAD(&dlg->children, win_move, entries);
-  }
-  else
-  {
-    win_move = TAILQ_FIRST(&dlg->children);
-    TAILQ_REMOVE(&dlg->children, win_move, entries);
-    TAILQ_INSERT_TAIL(&dlg->children, win_move, entries);
-  }
-
-  mutt_window_reflow(dlg);
-  mutt_debug(LL_DEBUG5, "config done, request WA_REFLOW\n");
+  struct MuttWindow *dlg = nc->global_data;
+  window_status_on_top(dlg, NeoMutt->sub);
   return 0;
 }
 


### PR DESCRIPTION
Some more preparation for the Window event/focus changes that are coming soon.

- 6b12157c4 **use one status bar type**
  Each Window used to have a unique type.
  Now it seems simpler to have some generic types like, `WT_MENU` or `WT_STATUS_BAR`

- 211c44275 **add `window_status_on_top()`**
  Given a Window containing children `WT_MENU` and `WT_STATUS_BAR`, swap them around.

- 3ae97b5d4 **unify handling of `$status_on_top`**
  Use the new helper function.

- 9313f9401 **set focus explicitly**
  When focus is needed, take it.  When done put it back where it was.

- c16c79068 **move EditorHelp**
  This data belongs in the Editor code, not the MessageWindow code.
  (currently `curs_lib.c` rather than `mutt_window.c`)