### PR TITLE
msgwin: factor out MessageWindow

### DIFF
--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -308,9 +308,9 @@ $(PWD)/email:
 ###############################################################################
 # libgui
 LIBGUI=		libgui.a
-LIBGUIOBJS=	gui/color.o gui/curs_lib.o gui/dialog.o gui/mutt_curses.o \
-		gui/mutt_window.o gui/reflow.o gui/sbar.o gui/simple.o \
-		gui/terminal.o
+LIBGUIOBJS=	gui/color.o gui/curs_lib.o gui/dialog.o gui/msgwin.o \
+		gui/mutt_curses.o gui/mutt_window.o gui/reflow.o gui/sbar.o \
+		gui/simple.o gui/terminal.o
 CLEANFILES+=	$(LIBGUI) $(LIBGUIOBJS)
 ALLOBJS+=	$(LIBGUIOBJS)
 

--- a/commands.c
+++ b/commands.c
@@ -501,12 +501,12 @@ void ci_bounce_message(struct Mailbox *m, struct EmailList *el)
   if (query_quadoption(c_bounce, prompt) != MUTT_YES)
   {
     mutt_addrlist_clear(&al);
-    mutt_window_clearline(MessageWindow, 0);
+    msgwin_clear_text();
     mutt_message(ngettext("Message not bounced", "Messages not bounced", msg_count));
     return;
   }
 
-  mutt_window_clearline(MessageWindow, 0);
+  msgwin_clear_text();
 
   struct Message *msg = NULL;
   STAILQ_FOREACH(en, el, entries)
@@ -925,7 +925,7 @@ bool mutt_shell_escape(void)
     return false;
   }
 
-  mutt_window_clearline(MessageWindow, 0);
+  msgwin_clear_text();
   mutt_endwin();
   fflush(stdout);
   int rc = mutt_system(buf);

--- a/commands.c
+++ b/commands.c
@@ -487,9 +487,10 @@ void ci_bounce_message(struct Mailbox *m, struct EmailList *el)
   snprintf(scratch, sizeof(scratch),
            ngettext("Bounce message to %s?", "Bounce messages to %s?", msg_count), buf);
 
-  if (mutt_strwidth(scratch) > (MessageWindow->state.cols - EXTRA_SPACE))
+  const size_t width = msgwin_get_width();
+  if (mutt_strwidth(scratch) > (width - EXTRA_SPACE))
   {
-    mutt_simple_format(prompt, sizeof(prompt), 0, MessageWindow->state.cols - EXTRA_SPACE,
+    mutt_simple_format(prompt, sizeof(prompt), 0, width - EXTRA_SPACE,
                        JUSTIFY_LEFT, 0, scratch, sizeof(scratch), false);
     mutt_str_cat(prompt, sizeof(prompt), "...?");
   }

--- a/enter.c
+++ b/enter.c
@@ -151,7 +151,11 @@ int mutt_enter_string_full(char *buf, size_t buflen, int col, CompletionFlags fl
                            bool multiple, struct Mailbox *m, char ***files,
                            int *numfiles, struct EnterState *state)
 {
-  int width = MessageWindow->state.cols - col - 1;
+  struct MuttWindow *win = msgwin_get_window();
+  if (!win)
+    return -1;
+
+  int width = win->state.cols - col - 1;
   enum EnterRedrawFlags redraw = ENTER_REDRAW_NONE;
   bool pass = (flags & MUTT_PASS);
   bool first = true;
@@ -211,17 +215,17 @@ int mutt_enter_string_full(char *buf, size_t buflen, int col, CompletionFlags fl
             state->wbuf, state->lastchar,
             mutt_mb_wcswidth(state->wbuf, state->curpos) - (width / 2));
       }
-      mutt_window_move(MessageWindow, col, 0);
+      mutt_window_move(win, col, 0);
       int w = 0;
       for (size_t i = state->begin; i < state->lastchar; i++)
       {
         w += mutt_mb_wcwidth(state->wbuf[i]);
         if (w > width)
           break;
-        my_addwch(MessageWindow, state->wbuf[i]);
+        my_addwch(win, state->wbuf[i]);
       }
-      mutt_window_clrtoeol(MessageWindow);
-      mutt_window_move(MessageWindow,
+      mutt_window_clrtoeol(win);
+      mutt_window_move(win,
                        col + mutt_mb_wcswidth(state->wbuf + state->begin,
                                               state->curpos - state->begin),
                        0);

--- a/flags.c
+++ b/flags.c
@@ -451,7 +451,7 @@ int mutt_change_flag(struct Mailbox *m, struct EmailList *el, bool bf)
     event = mutt_getch();
   } while (event.ch == -2); // Timeout
 
-  mutt_window_clearline(MessageWindow, 0);
+  msgwin_clear_text();
   window_set_focus(old_focus);
 
   if (event.ch < 0) // SIGINT, Abort key (Ctrl-G)

--- a/flags.c
+++ b/flags.c
@@ -433,17 +433,20 @@ done:
  */
 int mutt_change_flag(struct Mailbox *m, struct EmailList *el, bool bf)
 {
+  struct MuttWindow *win = msgwin_get_window();
+  if (!win)
+    return -1;
+
   if (!m || !el || STAILQ_EMPTY(el))
     return -1;
 
   enum MessageType flag = MUTT_NONE;
   struct KeyEvent event;
 
-  struct MuttWindow *old_focus = window_set_focus(MessageWindow);
+  struct MuttWindow *old_focus = window_set_focus(win);
 
-  mutt_window_mvprintw(MessageWindow, 0, 0,
-                       "%s? (D/N/O/r/*/!): ", bf ? _("Set flag") : _("Clear flag"));
-  mutt_window_clrtoeol(MessageWindow);
+  mutt_window_mvprintw(win, 0, 0, "%s? (D/N/O/r/*/!): ", bf ? _("Set flag") : _("Clear flag"));
+  mutt_window_clrtoeol(win);
   window_redraw(RootWindow);
 
   do

--- a/gui/curs_lib.c
+++ b/gui/curs_lib.c
@@ -49,6 +49,7 @@
 #include "color.h"
 #include "enter_state.h"
 #include "keymap.h"
+#include "msgwin.h"
 #include "mutt_curses.h"
 #include "mutt_globals.h"
 #include "mutt_logging.h"
@@ -450,7 +451,7 @@ enum QuadOption mutt_yesorno(const char *msg, enum QuadOption def)
       }
       if (prompt_lines != MessageWindow->state.rows)
       {
-        mutt_window_reflow_message_rows(prompt_lines);
+        msgwin_set_height(prompt_lines);
         window_redraw(RootWindow);
       }
 
@@ -513,7 +514,7 @@ enum QuadOption mutt_yesorno(const char *msg, enum QuadOption def)
   }
   else
   {
-    mutt_window_reflow_message_rows(1);
+    msgwin_set_height(1);
     window_redraw(RootWindow);
   }
 
@@ -886,7 +887,7 @@ int mutt_multi_choice(const char *prompt, const char *letters)
       }
       if (prompt_lines != MessageWindow->state.rows)
       {
-        mutt_window_reflow_message_rows(prompt_lines);
+        msgwin_set_height(prompt_lines);
         window_redraw(RootWindow);
       }
 
@@ -962,7 +963,7 @@ int mutt_multi_choice(const char *prompt, const char *letters)
   }
   else
   {
-    mutt_window_reflow_message_rows(1);
+    msgwin_set_height(1);
     window_redraw(RootWindow);
   }
   window_set_focus(old_focus);

--- a/gui/curs_lib.c
+++ b/gui/curs_lib.c
@@ -577,20 +577,6 @@ void mutt_query_exit(void)
 }
 
 /**
- * mutt_show_error - Show the user an error message
- */
-void mutt_show_error(void)
-{
-  if (OptKeepQuiet || !ErrorBufMessage)
-    return;
-
-  mutt_curses_set_color(OptMsgErr ? MT_COLOR_ERROR : MT_COLOR_MESSAGE);
-  mutt_window_mvaddstr(MessageWindow, 0, 0, ErrorBuf);
-  mutt_curses_set_color(MT_COLOR_NORMAL);
-  mutt_window_clrtoeol(MessageWindow);
-}
-
-/**
  * mutt_endwin - Shutdown curses/slang
  */
 void mutt_endwin(void)

--- a/gui/curs_lib.c
+++ b/gui/curs_lib.c
@@ -548,7 +548,7 @@ enum QuadOption query_quadoption(enum QuadOption opt, const char *prompt)
 
     default:
       opt = mutt_yesorno(prompt, (opt == MUTT_ASKYES) ? MUTT_YES : MUTT_NO);
-      mutt_window_clearline(MessageWindow, 0);
+      msgwin_clear_text();
       return opt;
   }
 

--- a/gui/curs_lib.c
+++ b/gui/curs_lib.c
@@ -268,17 +268,21 @@ struct KeyEvent mutt_getch(void)
 int mutt_buffer_get_field(const char *field, struct Buffer *buf, CompletionFlags complete,
                           bool multiple, struct Mailbox *m, char ***files, int *numfiles)
 {
+  struct MuttWindow *win = msgwin_get_window();
+  if (!win)
+    return -1;
+
   int ret;
   int col;
 
   struct EnterState *es = mutt_enter_state_new();
 
-  const struct Mapping *old_help = MessageWindow->help_data;
-  int old_menu = MessageWindow->help_menu;
+  const struct Mapping *old_help = win->help_data;
+  int old_menu = win->help_menu;
 
-  MessageWindow->help_data = EditorHelp;
-  MessageWindow->help_menu = MENU_EDITOR;
-  struct MuttWindow *old_focus = window_set_focus(MessageWindow);
+  win->help_data = EditorHelp;
+  win->help_menu = MENU_EDITOR;
+  struct MuttWindow *old_focus = window_set_focus(win);
 
   window_redraw(RootWindow);
   do
@@ -290,18 +294,18 @@ int mutt_buffer_get_field(const char *field, struct Buffer *buf, CompletionFlags
       clearok(stdscr, true);
       window_redraw(RootWindow);
     }
-    mutt_window_clearline(MessageWindow, 0);
+    mutt_window_clearline(win, 0);
     mutt_curses_set_color(MT_COLOR_PROMPT);
-    mutt_window_addstr(MessageWindow, field);
+    mutt_window_addstr(win, field);
     mutt_curses_set_color(MT_COLOR_NORMAL);
     mutt_refresh();
-    mutt_window_get_coords(MessageWindow, &col, NULL);
+    mutt_window_get_coords(win, &col, NULL);
     ret = mutt_enter_string_full(buf->data, buf->dsize, col, complete, multiple,
                                  m, files, numfiles, es);
   } while (ret == 1);
 
-  MessageWindow->help_data = old_help;
-  MessageWindow->help_menu = old_menu;
+  win->help_data = old_help;
+  win->help_menu = old_menu;
   window_set_focus(old_focus);
 
   if (ret == 0)
@@ -309,7 +313,7 @@ int mutt_buffer_get_field(const char *field, struct Buffer *buf, CompletionFlags
   else
     mutt_buffer_reset(buf);
 
-  mutt_window_clearline(MessageWindow, 0);
+  mutt_window_clearline(win, 0);
   mutt_enter_state_free(&es);
 
   return ret;
@@ -399,6 +403,10 @@ void mutt_edit_file(const char *editor, const char *file)
  */
 enum QuadOption mutt_yesorno(const char *msg, enum QuadOption def)
 {
+  struct MuttWindow *win = msgwin_get_window();
+  if (!win)
+    return MUTT_ABORT;
+
   struct KeyEvent ch;
   char *yes = _("yes");
   char *no = _("no");
@@ -429,7 +437,7 @@ enum QuadOption mutt_yesorno(const char *msg, enum QuadOption def)
   answer_string_wid = mutt_strwidth(answer_string);
   msg_wid = mutt_strwidth(msg);
 
-  struct MuttWindow *old_focus = window_set_focus(MessageWindow);
+  struct MuttWindow *old_focus = window_set_focus(win);
   window_redraw(RootWindow);
   while (true)
   {
@@ -443,13 +451,13 @@ enum QuadOption mutt_yesorno(const char *msg, enum QuadOption def)
         clearok(stdscr, true);
         window_redraw(RootWindow);
       }
-      if (MessageWindow->state.cols)
+      if (win->state.cols)
       {
-        prompt_lines = (msg_wid + answer_string_wid + MessageWindow->state.cols - 1) /
-                       MessageWindow->state.cols;
+        prompt_lines = (msg_wid + answer_string_wid + win->state.cols - 1) /
+                       win->state.cols;
         prompt_lines = MAX(1, MIN(3, prompt_lines));
       }
-      if (prompt_lines != MessageWindow->state.rows)
+      if (prompt_lines != win->state.rows)
       {
         msgwin_set_height(prompt_lines);
         window_redraw(RootWindow);
@@ -457,15 +465,15 @@ enum QuadOption mutt_yesorno(const char *msg, enum QuadOption def)
 
       /* maxlen here is sort of arbitrary, so pick a reasonable upper bound */
       trunc_msg_len = mutt_wstr_trunc(
-          msg, (size_t) 4 * prompt_lines * MessageWindow->state.cols,
-          ((size_t) prompt_lines * MessageWindow->state.cols) - answer_string_wid, NULL);
+          msg, (size_t) 4 * prompt_lines * win->state.cols,
+          ((size_t) prompt_lines * win->state.cols) - answer_string_wid, NULL);
 
-      mutt_window_move(MessageWindow, 0, 0);
+      mutt_window_move(win, 0, 0);
       mutt_curses_set_color(MT_COLOR_PROMPT);
-      mutt_window_addnstr(MessageWindow, msg, trunc_msg_len);
-      mutt_window_addstr(MessageWindow, answer_string);
+      mutt_window_addnstr(win, msg, trunc_msg_len);
+      mutt_window_addstr(win, answer_string);
       mutt_curses_set_color(MT_COLOR_NORMAL);
-      mutt_window_clrtoeol(MessageWindow);
+      mutt_window_clrtoeol(win);
     }
 
     mutt_refresh();
@@ -508,9 +516,9 @@ enum QuadOption mutt_yesorno(const char *msg, enum QuadOption def)
   if (reno_ok)
     regfree(&reno);
 
-  if (MessageWindow->state.rows == 1)
+  if (win->state.rows == 1)
   {
-    mutt_window_clearline(MessageWindow, 0);
+    mutt_window_clearline(win, 0);
   }
   else
   {
@@ -526,7 +534,7 @@ enum QuadOption mutt_yesorno(const char *msg, enum QuadOption def)
   }
   else
   {
-    mutt_window_addstr(MessageWindow, (char *) ((def == MUTT_YES) ? yes : no));
+    mutt_window_addstr(win, (char *) ((def == MUTT_YES) ? yes : no));
     mutt_refresh();
   }
   return def;
@@ -674,15 +682,19 @@ int mutt_buffer_enter_fname(const char *prompt, struct Buffer *fname,
                             bool mailbox, struct Mailbox *m, bool multiple,
                             char ***files, int *numfiles, SelectFileFlags flags)
 {
+  struct MuttWindow *win = msgwin_get_window();
+  if (!win)
+    return -1;
+
   struct KeyEvent ch;
 
   mutt_curses_set_color(MT_COLOR_PROMPT);
-  mutt_window_mvaddstr(MessageWindow, 0, 0, prompt);
-  mutt_window_addstr(MessageWindow, _(" ('?' for list): "));
+  mutt_window_mvaddstr(win, 0, 0, prompt);
+  mutt_window_addstr(win, _(" ('?' for list): "));
   mutt_curses_set_color(MT_COLOR_NORMAL);
   if (!mutt_buffer_is_empty(fname))
-    mutt_window_addstr(MessageWindow, mutt_buffer_string(fname));
-  mutt_window_clrtoeol(MessageWindow);
+    mutt_window_addstr(win, mutt_buffer_string(fname));
+  mutt_window_clrtoeol(win);
   mutt_refresh();
 
   do
@@ -691,7 +703,7 @@ int mutt_buffer_enter_fname(const char *prompt, struct Buffer *fname,
   } while (ch.ch == -2); // Timeout
   if (ch.ch < 0)
   {
-    mutt_window_clearline(MessageWindow, 0);
+    mutt_window_clearline(win, 0);
     return -1;
   }
   else if (ch.ch == '?')
@@ -837,6 +849,10 @@ void mutt_flushinp(void)
  */
 int mutt_multi_choice(const char *prompt, const char *letters)
 {
+  struct MuttWindow *win = msgwin_get_window();
+  if (!win)
+    return -1;
+
   struct KeyEvent ch;
   int choice;
   bool redraw = true;
@@ -845,7 +861,7 @@ int mutt_multi_choice(const char *prompt, const char *letters)
   const bool opt_cols = ((mutt_color(MT_COLOR_OPTIONS) != 0) &&
                          (mutt_color(MT_COLOR_OPTIONS) != mutt_color(MT_COLOR_PROMPT)));
 
-  struct MuttWindow *old_focus = window_set_focus(MessageWindow);
+  struct MuttWindow *old_focus = window_set_focus(win);
   window_redraw(RootWindow);
   while (true)
   {
@@ -859,7 +875,7 @@ int mutt_multi_choice(const char *prompt, const char *letters)
         clearok(stdscr, true);
         window_redraw(RootWindow);
       }
-      if (MessageWindow->state.cols)
+      if (win->state.cols)
       {
         int width = mutt_strwidth(prompt) + 2; // + '?' + space
         /* If we're going to colour the options,
@@ -868,16 +884,16 @@ int mutt_multi_choice(const char *prompt, const char *letters)
           width -= 2 * mutt_str_len(letters);
 
         prompt_lines =
-            (width + MessageWindow->state.cols - 1) / MessageWindow->state.cols;
+            (width + win->state.cols - 1) / win->state.cols;
         prompt_lines = MAX(1, MIN(3, prompt_lines));
       }
-      if (prompt_lines != MessageWindow->state.rows)
+      if (prompt_lines != win->state.rows)
       {
         msgwin_set_height(prompt_lines);
         window_redraw(RootWindow);
       }
 
-      mutt_window_move(MessageWindow, 0, 0);
+      mutt_window_move(win, 0, 0);
 
       if (opt_cols)
       {
@@ -887,30 +903,30 @@ int mutt_multi_choice(const char *prompt, const char *letters)
         {
           // write the part between prompt and cur using MT_COLOR_PROMPT
           mutt_curses_set_color(MT_COLOR_PROMPT);
-          mutt_window_addnstr(MessageWindow, prompt, cur - prompt);
+          mutt_window_addnstr(win, prompt, cur - prompt);
 
           if (isalnum(cur[1]) && (cur[2] == ')'))
           {
             // we have a single letter within parentheses
             mutt_curses_set_color(MT_COLOR_OPTIONS);
-            mutt_window_addch(MessageWindow, cur[1]);
+            mutt_window_addch(win, cur[1]);
             prompt = cur + 3;
           }
           else
           {
             // we have a parenthesis followed by something else
-            mutt_window_addch(MessageWindow, cur[0]);
+            mutt_window_addch(win, cur[0]);
             prompt = cur + 1;
           }
         }
       }
 
       mutt_curses_set_color(MT_COLOR_PROMPT);
-      mutt_window_addstr(MessageWindow, prompt);
+      mutt_window_addstr(win, prompt);
       mutt_curses_set_color(MT_COLOR_NORMAL);
 
-      mutt_window_addch(MessageWindow, ' ');
-      mutt_window_clrtoeol(MessageWindow);
+      mutt_window_addch(win, ' ');
+      mutt_window_clrtoeol(win);
     }
 
     mutt_refresh();
@@ -943,9 +959,9 @@ int mutt_multi_choice(const char *prompt, const char *letters)
     }
     mutt_beep(false);
   }
-  if (MessageWindow->state.rows == 1)
+  if (win->state.rows == 1)
   {
-    mutt_window_clearline(MessageWindow, 0);
+    mutt_window_clearline(win, 0);
   }
   else
   {

--- a/gui/curs_lib.h
+++ b/gui/curs_lib.h
@@ -70,7 +70,6 @@ void         mutt_perror_debug(const char *s);
 void         mutt_push_macro_event(int ch, int op);
 void         mutt_query_exit(void);
 void         mutt_refresh(void);
-void         mutt_show_error(void);
 void         mutt_simple_format(char *buf, size_t buflen, int min_width, int max_width, enum FormatJustify justify, char pad_char, const char *s, size_t n, bool arboreal);
 int          mutt_strwidth(const char *s);
 int          mutt_strnwidth(const char *s, size_t len);

--- a/gui/lib.h
+++ b/gui/lib.h
@@ -30,6 +30,7 @@
  * | gui/color.c         | @subpage gui_color         |
  * | gui/curs_lib.c      | @subpage gui_curs_lib      |
  * | gui/dialog.c        | @subpage gui_dialog        |
+ * | gui/msgwin.c        | @subpage gui_msgwin        |
  * | gui/mutt_curses.c   | @subpage gui_curses        |
  * | gui/mutt_window.c   | @subpage gui_window        |
  * | gui/reflow.c        | @subpage gui_reflow        |
@@ -45,6 +46,7 @@
 #include "color.h"
 #include "curs_lib.h"
 #include "dialog.h"
+#include "msgwin.h"
 #include "mutt_curses.h"
 #include "mutt_window.h"
 #include "reflow.h"

--- a/gui/msgwin.c
+++ b/gui/msgwin.c
@@ -35,6 +35,8 @@
 #include "mutt_curses.h"
 #include "mutt_window.h"
 
+struct MuttWindow *MessageWindow = NULL; ///< Message Window, ":set", etc
+
 /**
  * struct MsgWinPrivateData - Private data for the Message Window
  */
@@ -119,6 +121,7 @@ static int msgwin_window_observer(struct NotifyCallback *nc)
       return 0;
 
     notify_observer_remove(NeoMutt->notify, msgwin_window_observer, win_msg);
+    MessageWindow = NULL;
     mutt_debug(LL_DEBUG5, "window delete done\n");
   }
   return 0;
@@ -169,6 +172,8 @@ struct MuttWindow *msgwin_create(void)
   win->repaint = msgwin_repaint;
 
   notify_observer_add(win->notify, NT_WINDOW, msgwin_window_observer, win);
+
+  MessageWindow = win;
   return win;
 }
 

--- a/gui/msgwin.c
+++ b/gui/msgwin.c
@@ -1,0 +1,43 @@
+/**
+ * @file
+ * Message Window
+ *
+ * @authors
+ * Copyright (C) 2021 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @page gui_msgwin Message Window
+ *
+ * Message Window for displaying messages and text entry.
+ */
+
+#include "config.h"
+#include "mutt_window.h"
+
+/**
+ * msgwin_create - Create the Message Window
+ * @retval ptr New Window
+ */
+struct MuttWindow *msgwin_create(void)
+{
+  struct MuttWindow *win =
+      mutt_window_new(WT_MESSAGE, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_FIXED,
+                      MUTT_WIN_SIZE_UNLIMITED, 1);
+
+  return win;
+}

--- a/gui/msgwin.c
+++ b/gui/msgwin.c
@@ -27,7 +27,130 @@
  */
 
 #include "config.h"
+#include "mutt/lib.h"
+#include "core/lib.h"
+#include "color.h"
+#include "curs_lib.h"
+#include "mutt_curses.h"
 #include "mutt_window.h"
+
+/**
+ * struct MsgWinPrivateData - Private data for the Message Window
+ */
+struct MsgWinPrivateData
+{
+  enum ColorId color; ///< Colour for the text, e.g. #MT_COLOR_MESSAGE
+  char *text;         ///< Cached display string
+};
+
+/**
+ * msgwin_recalc - Recalculate the display of the Message Window
+ * @param win Message Window
+ */
+static int msgwin_recalc(struct MuttWindow *win)
+{
+  if (!win)
+    return -1;
+
+  struct MuttWindow *win_focus = window_get_focus();
+  if (!win_focus)
+    return 0;
+
+  // If the MessageWindow is focussed, then someone else is actively using it.
+  if (win_focus == win)
+    return 0;
+
+  // If nobody is using it, we'll take charge
+  win->actions |= WA_REPAINT;
+  mutt_debug(LL_DEBUG5, "recalc done, request WA_REPAINT\n");
+  return 0;
+}
+
+/**
+ * msgwin_repaint - Redraw the Message Window
+ * @param win Message Window
+ */
+static int msgwin_repaint(struct MuttWindow *win)
+{
+  if (!mutt_window_is_visible(win))
+    return 0;
+
+  struct MuttWindow *win_focus = window_get_focus();
+  if (!win_focus)
+    return 0;
+
+  // If the MessageWindow is focussed, then someone else is actively using it.
+  if (win_focus == win)
+    return 0;
+
+  struct MsgWinPrivateData *priv = win->wdata;
+
+  mutt_window_move(win, 0, 0);
+
+  mutt_curses_set_color(priv->color);
+  mutt_window_move(win, 0, 0);
+  mutt_paddstr(win, win->state.cols, priv->text);
+  mutt_curses_set_color(MT_COLOR_NORMAL);
+
+  mutt_debug(LL_DEBUG5, "repaint done\n");
+  return 0;
+}
+
+/**
+ * msgwin_window_observer - Window has changed - Implements ::observer_t
+ */
+static int msgwin_window_observer(struct NotifyCallback *nc)
+{
+  if ((nc->event_type != NT_WINDOW) || !nc->event_data || !nc->global_data)
+    return -1;
+
+  struct MuttWindow *win_msg = nc->global_data;
+
+  if (nc->event_subtype == NT_WINDOW_STATE)
+  {
+    win_msg->actions |= WA_RECALC;
+    mutt_debug(LL_NOTIFY, "state change, request WA_RECALC\n");
+  }
+  else if (nc->event_subtype == NT_WINDOW_DELETE)
+  {
+    struct EventWindow *ev_w = nc->event_data;
+    if (ev_w->win != win_msg)
+      return 0;
+
+    notify_observer_remove(NeoMutt->notify, msgwin_window_observer, win_msg);
+    mutt_debug(LL_DEBUG5, "window delete done\n");
+  }
+  return 0;
+}
+
+/**
+ * msgwin_wdata_free - Free the private data attached to the Message Window - Implements MuttWindow::wdata_free()
+ */
+static void msgwin_wdata_free(struct MuttWindow *win, void **ptr)
+{
+  if (!ptr || !*ptr)
+    return;
+
+  struct MsgWinPrivateData *priv = *ptr;
+
+  FREE(&priv->text);
+
+  FREE(ptr);
+}
+
+/**
+ * msgwin_wdata_new - Create new private data for the Message Window
+ * @retval ptr New private data
+ */
+static struct MsgWinPrivateData *msgwin_wdata_new(void)
+{
+  struct MsgWinPrivateData *msgwin_data =
+      mutt_mem_calloc(1, sizeof(struct MsgWinPrivateData));
+
+  msgwin_data->color = MT_COLOR_NORMAL;
+
+  return msgwin_data;
+}
 
 /**
  * msgwin_create - Create the Message Window
@@ -39,5 +162,11 @@ struct MuttWindow *msgwin_create(void)
       mutt_window_new(WT_MESSAGE, MUTT_WIN_ORIENT_VERTICAL, MUTT_WIN_SIZE_FIXED,
                       MUTT_WIN_SIZE_UNLIMITED, 1);
 
+  win->wdata = msgwin_wdata_new();
+  win->wdata_free = msgwin_wdata_free;
+  win->recalc = msgwin_recalc;
+  win->repaint = msgwin_repaint;
+
+  notify_observer_add(win->notify, NT_WINDOW, msgwin_window_observer, win);
   return win;
 }

--- a/gui/msgwin.c
+++ b/gui/msgwin.c
@@ -52,18 +52,9 @@ struct MsgWinPrivateData
  */
 static int msgwin_recalc(struct MuttWindow *win)
 {
-  if (!win)
-    return -1;
-
-  struct MuttWindow *win_focus = window_get_focus();
-  if (!win_focus)
+  if (window_is_focused(win)) // Someone else is using it
     return 0;
 
-  // If the MessageWindow is focussed, then someone else is actively using it.
-  if (win_focus == win)
-    return 0;
-
-  // If nobody is using it, we'll take charge
   win->actions |= WA_REPAINT;
   mutt_debug(LL_DEBUG5, "recalc done, request WA_REPAINT\n");
   return 0;
@@ -75,15 +66,7 @@ static int msgwin_recalc(struct MuttWindow *win)
  */
 static int msgwin_repaint(struct MuttWindow *win)
 {
-  if (!mutt_window_is_visible(win))
-    return 0;
-
-  struct MuttWindow *win_focus = window_get_focus();
-  if (!win_focus)
-    return 0;
-
-  // If the MessageWindow is focussed, then someone else is actively using it.
-  if (win_focus == win)
+  if (!mutt_window_is_visible(win) || window_is_focused(win)) // or someone else is using it
     return 0;
 
   struct MsgWinPrivateData *priv = win->wdata;

--- a/gui/msgwin.c
+++ b/gui/msgwin.c
@@ -27,6 +27,7 @@
  */
 
 #include "config.h"
+#include <stddef.h>
 #include "mutt/lib.h"
 #include "core/lib.h"
 #include "color.h"
@@ -169,4 +170,75 @@ struct MuttWindow *msgwin_create(void)
 
   notify_observer_add(win->notify, NT_WINDOW, msgwin_window_observer, win);
   return win;
+}
+
+/**
+ * msgwin_set_text - Set the text for the Message Window
+ * @param color Colour, e.g. #MT_COLOR_MESSAGE
+ * @param text  Text to set
+ *
+ * @note The text string will be copied
+ */
+void msgwin_set_text(enum ColorId color, const char *text)
+{
+  if (!MessageWindow)
+    return;
+
+  struct MsgWinPrivateData *priv = MessageWindow->wdata;
+
+  priv->color = color;
+  mutt_str_replace(&priv->text, text);
+
+  MessageWindow->actions |= WA_RECALC;
+}
+
+/**
+ * msgwin_clear_text - Clear the text in the Message Window
+ */
+void msgwin_clear_text(void)
+{
+  msgwin_set_text(MT_COLOR_NORMAL, NULL);
+}
+
+/**
+ * msgwin_get_window - Get the Message Window pointer
+ * @retval ptr Message Window
+ *
+ * Allow some users direct access to the Message Window.
+ */
+struct MuttWindow *msgwin_get_window(void)
+{
+  return MessageWindow;
+}
+
+/**
+ * msgwin_get_width - Get the width of the Message Window
+ * @retval num Width of Message Window
+ */
+size_t msgwin_get_width(void)
+{
+  if (!MessageWindow)
+    return 0;
+
+  return MessageWindow->state.cols;
+}
+
+/**
+ * msgwin_set_height - Resize the Message Window
+ * @param height Number of rows required
+ *
+ * Resize the other Windows to allow a multi-line message to be displayed.
+ */
+void msgwin_set_height(short height)
+{
+  if (!MessageWindow)
+    return;
+
+  if (height < 1)
+    height = 1;
+  else if (height > 3)
+    height = 3;
+
+  MessageWindow->req_rows = height;
+  mutt_window_reflow(MessageWindow->parent);
 }

--- a/gui/msgwin.h
+++ b/gui/msgwin.h
@@ -1,0 +1,28 @@
+/**
+ * @file
+ * Message Window
+ *
+ * @authors
+ * Copyright (C) 2021 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MUTT_MSGWIN_H
+#define MUTT_MSGWIN_H
+
+struct MuttWindow *msgwin_create    (void);
+
+#endif /* MUTT_MSGWIN_H */

--- a/gui/msgwin.h
+++ b/gui/msgwin.h
@@ -23,6 +23,14 @@
 #ifndef MUTT_MSGWIN_H
 #define MUTT_MSGWIN_H
 
+#include <stdio.h>
+#include "color.h"
+
+void               msgwin_clear_text(void);
 struct MuttWindow *msgwin_create    (void);
+size_t             msgwin_get_width (void);
+struct MuttWindow *msgwin_get_window(void);
+void               msgwin_set_height(short height);
+void               msgwin_set_text  (enum ColorId color, const char *text);
 
 #endif /* MUTT_MSGWIN_H */

--- a/gui/mutt_window.c
+++ b/gui/mutt_window.c
@@ -750,6 +750,21 @@ void window_redraw(struct MuttWindow *win)
 }
 
 /**
+ * window_is_focused - Does the given Window have the focus?
+ * @param win Window to check
+ * @retval true Window has focus
+ */
+bool window_is_focused(struct MuttWindow *win)
+{
+  if (!win)
+    return false;
+
+  struct MuttWindow *win_focus = window_get_focus();
+
+  return (win_focus == win);
+}
+
+/**
  * window_get_focus - Get the currently focussed Window
  * @retval ptr Window with focus
  */

--- a/gui/mutt_window.c
+++ b/gui/mutt_window.c
@@ -45,7 +45,6 @@
 
 struct MuttWindow *RootWindow = NULL;       ///< Parent of all Windows
 struct MuttWindow *AllDialogsWindow = NULL; ///< Parent of all Dialogs
-struct MuttWindow *MessageWindow = NULL;    ///< Message Window, ":set", etc
 
 /// Lookups for Window Names
 static const struct Mapping WindowNames[] = {
@@ -331,7 +330,6 @@ void mutt_window_free_all(void)
   if (NeoMutt)
     notify_observer_remove(NeoMutt->notify, rootwin_config_observer, RootWindow);
   AllDialogsWindow = NULL;
-  MessageWindow = NULL;
   mutt_window_free(&RootWindow);
 }
 
@@ -376,7 +374,7 @@ void mutt_window_init(void)
                                      MUTT_WIN_SIZE_MAXIMISE, MUTT_WIN_SIZE_UNLIMITED,
                                      MUTT_WIN_SIZE_UNLIMITED);
 
-  MessageWindow = msgwin_create();
+  struct MuttWindow *win_msg = msgwin_create();
 
   const bool c_status_on_top = cs_subset_bool(NeoMutt->sub, "status_on_top");
   if (c_status_on_top)
@@ -390,7 +388,7 @@ void mutt_window_init(void)
     mutt_window_add_child(RootWindow, AllDialogsWindow);
   }
 
-  mutt_window_add_child(RootWindow, MessageWindow);
+  mutt_window_add_child(RootWindow, win_msg);
   notify_observer_add(NeoMutt->notify, NT_CONFIG, rootwin_config_observer, RootWindow);
 }
 

--- a/gui/mutt_window.c
+++ b/gui/mutt_window.c
@@ -471,22 +471,6 @@ void mutt_window_reflow(struct MuttWindow *win)
 }
 
 /**
- * mutt_window_reflow_message_rows - Resize the Message Window
- * @param mw_rows Number of rows required
- *
- * Resize the other Windows to allow a multi-line message to be displayed.
- */
-void mutt_window_reflow_message_rows(int mw_rows)
-{
-  MessageWindow->req_rows = mw_rows;
-  mutt_window_reflow(MessageWindow->parent);
-
-  /* We don't also set MENU_REDRAW_FLOW because this function only
-   * changes rows and is a temporary adjustment. */
-  window_redraw(RootWindow);
-}
-
-/**
  * mutt_window_wrap_cols - Calculate the wrap column for a given screen width
  * @param width Screen width
  * @param wrap  Wrap config

--- a/gui/mutt_window.c
+++ b/gui/mutt_window.c
@@ -34,10 +34,9 @@
 #include "core/lib.h"
 #include "mutt_window.h"
 #include "helpbar/lib.h"
-#include "menu/lib.h"
 #include "curs_lib.h"
+#include "msgwin.h"
 #include "mutt_curses.h"
-#include "opcodes.h"
 #include "options.h"
 #include "reflow.h"
 #ifdef USE_DEBUG_WINDOW
@@ -377,8 +376,7 @@ void mutt_window_init(void)
                                      MUTT_WIN_SIZE_MAXIMISE, MUTT_WIN_SIZE_UNLIMITED,
                                      MUTT_WIN_SIZE_UNLIMITED);
 
-  MessageWindow = mutt_window_new(WT_MESSAGE, MUTT_WIN_ORIENT_VERTICAL,
-                                  MUTT_WIN_SIZE_FIXED, MUTT_WIN_SIZE_UNLIMITED, 1);
+  MessageWindow = msgwin_create();
 
   const bool c_status_on_top = cs_subset_bool(NeoMutt->sub, "status_on_top");
   if (c_status_on_top)

--- a/gui/mutt_window.h
+++ b/gui/mutt_window.h
@@ -202,7 +202,6 @@ struct EventWindow
 
 extern struct MuttWindow *RootWindow;
 extern struct MuttWindow *AllDialogsWindow;
-extern struct MuttWindow *MessageWindow;
 
 // Functions that deal with the Window
 void               mutt_window_add_child          (struct MuttWindow *parent, struct MuttWindow *child);

--- a/gui/mutt_window.h
+++ b/gui/mutt_window.h
@@ -234,6 +234,7 @@ void               window_notify_all (struct MuttWindow *win);
 void               window_set_visible(struct MuttWindow *win, bool visible);
 struct MuttWindow *window_set_focus  (struct MuttWindow *win);
 struct MuttWindow *window_get_focus  (void);
+bool               window_is_focused (struct MuttWindow *win);
 struct MuttWindow *window_get_dialog (void);
 
 void window_redraw(struct MuttWindow *win);

--- a/gui/mutt_window.h
+++ b/gui/mutt_window.h
@@ -212,7 +212,6 @@ void               mutt_window_get_coords         (struct MuttWindow *win, int *
 void               mutt_window_init               (void);
 struct MuttWindow *mutt_window_new                (enum WindowType type, enum MuttWindowOrientation orient, enum MuttWindowSize size, int cols, int rows);
 void               mutt_window_reflow             (struct MuttWindow *win);
-void               mutt_window_reflow_message_rows(int mw_rows);
 struct MuttWindow *mutt_window_remove_child       (struct MuttWindow *parent, struct MuttWindow *child);
 void               mutt_window_set_root           (int cols, int rows);
 int                mutt_window_wrap_cols          (int width, short wrap);

--- a/index/index.c
+++ b/index/index.c
@@ -1094,10 +1094,7 @@ dsl_finish:
 static void index_custom_redraw(struct Menu *menu)
 {
   if (menu->redraw & MENU_REDRAW_FULL)
-  {
     menu_redraw_full(menu);
-    mutt_show_error();
-  }
 
   struct IndexSharedData *shared = menu->mdata;
   struct Mailbox *m = shared->mailbox;
@@ -1337,10 +1334,7 @@ struct Mailbox *mutt_index_menu(struct MuttWindow *dlg, struct Mailbox *m_init)
 
       /* give visual indication that the next command is a tag- command */
       if (priv->tag)
-      {
-        mutt_window_mvaddstr(MessageWindow, 0, 0, "tag-");
-        mutt_window_clrtoeol(MessageWindow);
-      }
+        msgwin_set_text(MT_COLOR_NORMAL, "tag-");
 
       const bool c_arrow_cursor = cs_subset_bool(shared->sub, "arrow_cursor");
       const bool c_braille_friendly =
@@ -1373,6 +1367,7 @@ struct Mailbox *mutt_index_menu(struct MuttWindow *dlg, struct Mailbox *m_init)
         continue;
       }
 
+      window_redraw(RootWindow);
       op = km_dokey(MENU_MAIN);
 
       /* either user abort or timeout */

--- a/index/index.c
+++ b/index/index.c
@@ -1369,7 +1369,7 @@ struct Mailbox *mutt_index_menu(struct MuttWindow *dlg, struct Mailbox *m_init)
         /* force a real complete redraw.  clrtobot() doesn't seem to be able
          * to handle every case without this.  */
         clearok(stdscr, true);
-        mutt_window_clearline(MessageWindow, 0);
+        msgwin_clear_text();
         continue;
       }
 
@@ -1380,7 +1380,7 @@ struct Mailbox *mutt_index_menu(struct MuttWindow *dlg, struct Mailbox *m_init)
       {
         mutt_timeout_hook();
         if (priv->tag)
-          mutt_window_clearline(MessageWindow, 0);
+          msgwin_clear_text();
         continue;
       }
 
@@ -1396,7 +1396,7 @@ struct Mailbox *mutt_index_menu(struct MuttWindow *dlg, struct Mailbox *m_init)
         if (priv->tag)
         {
           priv->tag = false;
-          mutt_window_clearline(MessageWindow, 0);
+          msgwin_clear_text();
           continue;
         }
 
@@ -2518,7 +2518,7 @@ struct Mailbox *mutt_index_menu(struct MuttWindow *dlg, struct Mailbox *m_init)
 
         if (mutt_buffer_is_empty(folderbuf))
         {
-          mutt_window_clearline(MessageWindow, 0);
+          msgwin_clear_text();
           goto changefoldercleanup;
         }
 
@@ -2594,7 +2594,7 @@ struct Mailbox *mutt_index_menu(struct MuttWindow *dlg, struct Mailbox *m_init)
 
         if (mutt_buffer_is_empty(folderbuf))
         {
-          mutt_window_clearline(MessageWindow, 0);
+          msgwin_clear_text();
           goto changefoldercleanup2;
         }
 

--- a/keymap.c
+++ b/keymap.c
@@ -1721,8 +1721,11 @@ void mutt_what_key(void)
 {
   int ch;
 
-  mutt_window_mvprintw(MessageWindow, 0, 0, _("Enter keys (%s to abort): "),
-                       km_keyname(AbortKey));
+  struct MuttWindow *win = msgwin_get_window();
+  if (!win)
+    return;
+
+  mutt_window_mvprintw(win, 0, 0, _("Enter keys (%s to abort): "), km_keyname(AbortKey));
   do
   {
     ch = getch();

--- a/menu/draw.c
+++ b/menu/draw.c
@@ -342,8 +342,6 @@ void menu_redraw_full(struct Menu *menu)
   window_redraw(RootWindow);
   menu->pagelen = menu->win_index->state.rows;
 
-  mutt_show_error();
-
   menu->redraw = MENU_REDRAW_INDEX | MENU_REDRAW_STATUS;
 }
 
@@ -546,8 +544,7 @@ static void menu_redraw_prompt(struct Menu *menu)
   if (ErrorBufMessage)
     mutt_clear_error();
 
-  mutt_window_mvaddstr(MessageWindow, 0, 0, menu->prompt);
-  mutt_window_clrtoeol(MessageWindow);
+  msgwin_set_text(MT_COLOR_NORMAL, menu->prompt);
 
   mutt_debug(LL_NOTIFY, "NT_MENU\n");
   notify_send(menu->notify, NT_MENU, 0, NULL);

--- a/menu/menu.c
+++ b/menu/menu.c
@@ -333,7 +333,7 @@ int menu_loop(struct Menu *menu)
       if (menu->tagprefix)
       {
         menu->tagprefix = false;
-        mutt_window_clearline(MessageWindow, 0);
+        msgwin_clear_text();
         continue;
       }
 
@@ -369,7 +369,7 @@ int menu_loop(struct Menu *menu)
     if (op < 0)
     {
       if (menu->tagprefix)
-        mutt_window_clearline(MessageWindow, 0);
+        msgwin_clear_text();
       continue;
     }
 

--- a/menu/menu.c
+++ b/menu/menu.c
@@ -300,10 +300,7 @@ int menu_loop(struct Menu *menu)
 
     /* give visual indication that the next command is a tag- command */
     if (menu->tagprefix)
-    {
-      mutt_window_mvaddstr(MessageWindow, 0, 0, "tag-");
-      mutt_window_clrtoeol(MessageWindow);
-    }
+      msgwin_set_text(MT_COLOR_NORMAL, "tag-");
 
     const bool c_arrow_cursor = cs_subset_bool(menu->sub, "arrow_cursor");
     const bool c_braille_friendly =

--- a/mutt_logging.c
+++ b/mutt_logging.c
@@ -117,7 +117,7 @@ void mutt_clear_error(void)
 
   ErrorBufMessage = false;
   if (!OptNoCurses)
-    mutt_window_clearline(MessageWindow, 0);
+    msgwin_clear_text();
 }
 
 /**

--- a/mutt_logging.c
+++ b/mutt_logging.c
@@ -166,30 +166,29 @@ int log_disp_curses(time_t stamp, const char *file, int line,
   if ((level > LL_ERROR) && OptMsgErr && !dupe)
     error_pause();
 
-  mutt_simple_format(ErrorBuf, sizeof(ErrorBuf), 0,
-                     MessageWindow ? MessageWindow->state.cols : sizeof(ErrorBuf),
+  size_t width = msgwin_get_width();
+  mutt_simple_format(ErrorBuf, sizeof(ErrorBuf), 0, width ? width : sizeof(ErrorBuf),
                      JUSTIFY_LEFT, 0, buf, sizeof(buf), false);
   ErrorBufMessage = true;
 
   if (!OptKeepQuiet)
   {
+    enum ColorId color = MT_COLOR_NORMAL;
     switch (level)
     {
       case LL_ERROR:
         mutt_beep(false);
-        mutt_curses_set_color(MT_COLOR_ERROR);
+        color = MT_COLOR_ERROR;
         break;
       case LL_WARNING:
-        mutt_curses_set_color(MT_COLOR_WARNING);
+        color = MT_COLOR_WARNING;
         break;
       default:
-        mutt_curses_set_color(MT_COLOR_MESSAGE);
+        color = MT_COLOR_MESSAGE;
         break;
     }
 
-    mutt_window_mvaddstr(MessageWindow, 0, 0, ErrorBuf);
-    mutt_curses_set_color(MT_COLOR_NORMAL);
-    mutt_window_clrtoeol(MessageWindow);
+    msgwin_set_text(color, ErrorBuf);
     mutt_refresh();
   }
 

--- a/mutt_mailbox.c
+++ b/mutt_mailbox.c
@@ -243,8 +243,8 @@ bool mutt_mailbox_list(void)
     mutt_buffer_strcpy(path, mailbox_path(np->mailbox));
     mutt_buffer_pretty_mailbox(path);
 
-    if (!first && (MessageWindow->state.cols >= 7) &&
-        ((pos + mutt_buffer_len(path)) >= ((size_t) MessageWindow->state.cols - 7)))
+    const size_t width = msgwin_get_width();
+    if (!first && (width >= 7) && ((pos + mutt_buffer_len(path)) >= (width - 7)))
     {
       break;
     }

--- a/muttlib.c
+++ b/muttlib.c
@@ -1448,7 +1448,7 @@ int mutt_save_confirm(const char *s, struct stat *st)
     }
   }
 
-  mutt_window_clearline(MessageWindow, 0);
+  msgwin_clear_text();
   return ret;
 }
 

--- a/pager/pager.c
+++ b/pager/pager.c
@@ -2082,7 +2082,6 @@ static void pager_custom_redraw(struct Menu *pager_menu)
     }
 
     menu_queue_redraw(pager_menu, MENU_REDRAW_BODY | MENU_REDRAW_INDEX | MENU_REDRAW_STATUS);
-    mutt_show_error();
   }
 
   if (pager_menu->redraw & MENU_REDRAW_FLOW)

--- a/pager/pager.c
+++ b/pager/pager.c
@@ -2633,7 +2633,7 @@ int mutt_pager(struct PagerView *pview)
       SigWinch = false;
       mutt_resize_screen();
       clearok(stdscr, true); /* force complete redraw */
-      mutt_window_clearline(MessageWindow, 0);
+      msgwin_clear_text();
 
       if (pview->flags & MUTT_PAGER_RETWINCH)
       {

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -93,6 +93,7 @@ functions.c
 gui/color.c
 gui/curs_lib.c
 gui/dialog.c
+gui/msgwin.c
 gui/mutt_curses.c
 gui/mutt_window.c
 gui/reflow.c

--- a/recvattach.c
+++ b/recvattach.c
@@ -878,7 +878,7 @@ static void query_pipe_attachment(const char *command, FILE *fp, struct Body *bo
              _("WARNING!  You are about to overwrite %s, continue?"), body->filename);
     if (mutt_yesorno(warning, MUTT_NO) != MUTT_YES)
     {
-      mutt_window_clearline(MessageWindow, 0);
+      msgwin_clear_text();
       return;
     }
     mutt_mktemp(tfile, sizeof(tfile));

--- a/recvcmd.c
+++ b/recvcmd.c
@@ -250,12 +250,12 @@ void mutt_attach_bounce(struct Mailbox *m, FILE *fp, struct AttachCtx *actx, str
   const enum QuadOption c_bounce = cs_subset_quad(NeoMutt->sub, "bounce");
   if (query_quadoption(c_bounce, prompt) != MUTT_YES)
   {
-    mutt_window_clearline(MessageWindow, 0);
+    msgwin_clear_text();
     mutt_message(ngettext("Message not bounced", "Messages not bounced", p));
     goto end;
   }
 
-  mutt_window_clearline(MessageWindow, 0);
+  msgwin_clear_text();
 
   if (cur)
     ret = mutt_bounce_message(fp, m, cur->email, &al, NeoMutt->sub);

--- a/recvcmd.c
+++ b/recvcmd.c
@@ -237,9 +237,10 @@ void mutt_attach_bounce(struct Mailbox *m, FILE *fp, struct AttachCtx *actx, str
   snprintf(prompt, sizeof(prompt) - 4,
            ngettext("Bounce message to %s?", "Bounce messages to %s?", p), buf);
 
-  if (mutt_strwidth(prompt) > MessageWindow->state.cols - EXTRA_SPACE)
+  const size_t width = msgwin_get_width();
+  if (mutt_strwidth(prompt) > (width - EXTRA_SPACE))
   {
-    mutt_simple_format(prompt, sizeof(prompt) - 4, 0, MessageWindow->state.cols - EXTRA_SPACE,
+    mutt_simple_format(prompt, sizeof(prompt) - 4, 0, width - EXTRA_SPACE,
                        JUSTIFY_LEFT, 0, prompt, sizeof(prompt), false);
     mutt_str_cat(prompt, sizeof(prompt), "...?");
   }


### PR DESCRIPTION
### Overview

Make the MessageWindow self-contained.
**This PR** is quite simple, but it explains the changes coming in the next PR.

- 6ea96d9ca factor out MessageWindow
  Move the Message Window into separate source file.

- 4cba5ca3b let the MessageWindow paint itself
  Give the MessageWindow `recalc()` and `repaint()` functions.

- 17dac7ca2 add helper functions
  Future changes to the MessageWindow will be done using these functions.

- 03119e38b Convert the code to use `msgwin_set_height()`

- 7c61d8c01 Convert the code to use `msgwin_get_width()`

- 4a488b733 Convert the code to use `msgwin_clear_text()`

- 65965f8f5 Convert the code to use `msgwin_set_text()`

- 17bbd4e5f ask for a MessageWindow pointer
  The active users must ask for a pointer to the MessageWindow.

- 4161a1377 convert the Progress Bar to use `msgwin_get_window()`

- fb682b86a hide the details of the MessageWindow
  Nobody needs the MessageWindow pointer any more.

---

The MessageWindow is used by a lot of different parts of the code.
However, the users fall into two types: Active, Passive.

### Passive Users

Passive users don't care about the details of the MessageWindow.
They just want to display some text (and clear it up later).

Examples:
- Logging system (`mutt_message()`, etc)
- Index printing 'tag-' on `<tag-prefix>`

Passive users expect that if the screen is resized or needs repainting, that it will "just happen".

### Active Users

Active users are characterised by an event loop.
They take the focus and wait for user input.

Examples:
- `mutt_yesorno()` - "Are you sure [Y/n]?"
- `mutt_buffer_get_field()` - "To: "

Active users are expected to handle:
- user input
- `SIGWINCH` (window resizing)
- Re-flowing, calculating, painting of all the windows

### Progress Bar

Technically, the progress bar is passive -- it just displays some text.
However, calling `progress_update()` forces a screen update, so it's behaving like an event loop.

As an example, imagine the IMAP code reading all the headers.
Here's how I expect it to work:

- Code calls `progress_new()`
  Progress Bar does `set_focus(MessageWindow)`

- Code loops
  - Code does some work
  - Code calls `progress_update()`
    Progress Bar updates itself and calls `window_redraw()`

  - Code does some work
  - Code calls `progress_update()`
    Progress Bar updates itself and calls `window_redraw()`

  - ....

  - User unexpectedly resizes the window

  - Code does some work
  - Code calls `progress_update()`
    Progress Bar detects `SIGWINCH` and calls:
    - `mutt_resize_screen()`
    - `mutt_window_set_root()`
    - `mutt_window_reflow()`
    - `window_notify_all()`
    Progress Bar updates itself and calls `window_redraw()`
      - Relevant windows get `recalc()` called
      - Relevant windows get `repaint()` called

  - ...

- Code calls `progress_free()`
  Progress Bar is destroyed, focus is returned to the previous state

