### PR TITLE
pager: add pager_read_delay

### DIFF
--- a/contrib/samples/sample.neomuttrc
+++ b/contrib/samples/sample.neomuttrc
@@ -60,6 +60,7 @@ set move=yes			# don't ask about moving messages, just do it
 #set pager_context=3		# no. of lines of context to give when scrolling
 #set pager_format="-%S- %-20.20f %s"	# format of the pager status bar
 set pager_index_lines=6		# how many index lines to show in the pager
+#set pager_read_delay=5		# seconds to wait before marking message read
 #set pager_stop			# don't move to the next message on next-page
 #set pgp_strict_enc		# use Q-P encoding when needed for PGP
 set postponed=+postponed	# mailbox to store postponed messages in

--- a/docs/config.c
+++ b/docs/config.c
@@ -2777,6 +2777,18 @@
 ** $$pager_index_lines, then the index will only use as many lines as it needs.
 */
 
+{ "pager_read_delay", DT_NUMBER, 0 },
+/*
+** .pp
+** Determines the number of seconds that must elapse after first
+** opening a new message in the pager before that message will be
+** marked as read.  A value of 0 results in the message being marked
+** read unconditionally; for other values, navigating to another
+** message or exiting the pager before the timeout will leave the
+** message marked unread.  This setting is ignored if $$pager is not
+** \fBbuiltin\fP.
+*/
+
 { "pager_stop", DT_BOOL, false },
 /*
 ** .pp

--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -1929,7 +1929,12 @@ color sidebar_divider   color8  default     <emphasis role="comment"># Dark grey
         </para>
         <para>
           Also, the internal pager supports a couple other advanced features.
-          For one, it will accept and translate the <quote>standard</quote>
+          For one, you can set <link
+          linkend="pager_read_delay">$pager_read_delay</link> to
+          operate in a preview mode, where new messages are not marked
+          read unless you remain on the message for a certain length
+          of time. Additionally,
+          it will accept and translate the <quote>standard</quote>
           nroff sequences for bold and underline. These sequences are a series
           of either the letter, backspace (<quote>^H</quote>), the letter
           again for bold or the letter, backspace, <quote>_</quote> for

--- a/pager/config.c
+++ b/pager/config.c
@@ -45,6 +45,9 @@ static struct ConfigDef PagerVars[] = {
   { "pager_index_lines", DT_NUMBER|DT_NOT_NEGATIVE|R_PAGER, 0, 0, NULL,
     "Number of index lines to display above the pager"
   },
+  { "pager_read_delay", DT_NUMBER|DT_NOT_NEGATIVE, 0, 0, NULL,
+    "Number of seconds to wait before marking a message read"
+  },
   { "pager_stop", DT_BOOL, false, 0, NULL,
     "Don't automatically open the next message when at the end of a message"
   },


### PR DESCRIPTION
implements https://github.com/neomutt/neomutt/issues/2954
- config: add pager_read_delay config var
- docs: document it
- pager: delay marking new message as read

* **What does this PR do?**
* Adds a delay before the pager marks a message as read; if you navigate away prior to that delay, the message remains unread.  This is comparable to a feature present in at least Thunderbird, and allows for easier previewing of messages you want to focus on now vs. later.

* **Screenshots (if relevant)**

* **Does this PR meet the acceptance criteria?** (This is just a reminder for you,
  this section can be removed if you fulfill it.)

   - Documentation created/updated (you have to edit
     [doc/manual.xml.head](https://www.github.com/neomutt/neomutt/blob/master/doc/manual.xml.head)
     for that)

   - All builds and tests are passing

   - Added [doxygen code documentation](https://neomutt.org/dev/doxygen)
     [syntax](http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html)

   - Code follows the [style guide](https://neomutt.org/dev/coding-style)

* **What are the relevant issue numbers?**
2954