### PR TITLE
Fix too strict assertion when viewing an attachment

### DIFF
--- a/pager/dlg_pager.c
+++ b/pager/dlg_pager.c
@@ -2359,8 +2359,6 @@ int mutt_pager(struct PagerView *pview)
       //  - fp and body->email in special case of viewing an attached email.
       assert(pview->pdata->email); // This should point to the top level email
       assert(pview->pdata->body);
-      assert(pview->pdata->ctx);
-      assert(pview->pdata->ctx->mailbox);
       if (pview->pdata->fp && pview->pdata->body->email)
       {
         // Special case: attachment is a full-blown email message.


### PR DESCRIPTION
We don't necessarily need to be sitting on an open mailbox (hence, have
a Context) when composing and email and viewing attachments: we might be
sending from the command line.

Reported by @guckes 