### PR TITLE
myvar: Allow += modification of my_ variables.

### DIFF
--- a/command_parse.c
+++ b/command_parse.c
@@ -29,6 +29,7 @@
  */
 
 #include "config.h"
+#include <assert.h>
 #include <errno.h>
 #include <limits.h>
 #include <stdbool.h>
@@ -789,6 +790,11 @@ enum CommandResult parse_set(struct Buffer *buf, struct Buffer *s,
       else
         decrement = true;
 
+      if (my && decrement)
+      {
+        mutt_buffer_printf(err, _("Can't decrement a my_ variable"), set_commands[data]);
+        return MUTT_CMD_WARNING;
+      }
       s->dptr++;
       if (*s->dptr == '=')
       {
@@ -894,7 +900,15 @@ enum CommandResult parse_set(struct Buffer *buf, struct Buffer *s,
         mutt_extract_token(buf, s, MUTT_TOKEN_BACKTICK_VARS);
         if (my)
         {
-          myvar_set(name, buf->data);
+          assert(!decrement);
+          if (increment)
+          {
+            myvar_append(name, buf->data);
+          }
+          else
+          {
+            myvar_set(name, buf->data);
+          }
           FREE(&name);
         }
         else

--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -6829,15 +6829,15 @@ set spam_separator=", "
         <para>
           This command is used to set (and unset)
           <link linkend="variables">configuration variables</link>. There are
-          four basic types of variables: boolean, number, string, string list
+          several basic types of variables: boolean, number, string, string list
           and quadoption. <emphasis>boolean</emphasis> variables can be
           <emphasis>set</emphasis> (true) or <emphasis>unset</emphasis>
           (false). <emphasis>number</emphasis> variables can be assigned
-          a positive integer value. Value of number variables can be
+          a positive integer value. The value of numeric variables can be
           incremented <emphasis>+=</emphasis> and decremented
           <emphasis>-=</emphasis>. <emphasis>String list</emphasis> variables
-          use <emphasis>+=</emphasis> for appending increment to the string list
-          and <emphasis>-=</emphasis> for removal decrement from the string list.
+          use <emphasis>+=</emphasis> for appending to the string list
+          and <emphasis>-=</emphasis> for removal from the string list.
           <emphasis>string</emphasis> variables
           consist of any number of printable characters and must be enclosed in
           quotes if they contain spaces or tabs. You may also use the escape
@@ -6911,9 +6911,16 @@ set spam_separator=", "
           </para>
           <para>
             The <command>set</command> command either creates a custom
-            <literal>my_</literal> variable or changes its value if it does
-            exist already. The <command>unset</command> and
-            <command>reset</command> commands remove the variable entirely.
+            <literal>my_</literal> variable or changes its value if it
+            exists already. Use of <emphasis>+=</emphasis> will adjust
+            a custom variable using the same behavior as a string
+            variable, by appending additional characters (this is true
+            even if the current contents of the variable resemble an
+            integer, which is different than the behavior of
+            <emphasis>+=</emphasis> on built-in numeric
+            variables). The <command>unset</command> and
+            <command>reset</command> commands remove the variable
+            entirely.
           </para>
           <para>
             Since user-defined variables are expanded in the same way that

--- a/myvar.c
+++ b/myvar.c
@@ -121,6 +121,25 @@ void myvar_set(const char *var, const char *val)
 }
 
 /**
+ * myvar_append - Append to the value of a "my_" variable
+ * @param var Variable name
+ * @param val Value to append
+ */
+void myvar_append(const char *var, const char *val)
+{
+  struct MyVar *myv = myvar_find(var);
+
+  if (myv)
+  {
+    mutt_str_append_item(&myv->value, val, '\0');
+    return;
+  }
+
+  myv = myvar_new(var, val);
+  TAILQ_INSERT_TAIL(&MyVars, myv, entries);
+}
+
+/**
  * myvar_del - Unset the value of a "my_" variable
  * @param var Variable name
  */

--- a/myvar.c
+++ b/myvar.c
@@ -65,6 +65,25 @@ static void myvar_free(struct MyVar **ptr)
 }
 
 /**
+ * myvar_find - Locate a "my_" variable
+ * @param var Variable name
+ * @retval ptr  Success, variable exists
+ * @retval NULL Error, variable doesn't exist
+ */
+static struct MyVar *myvar_find(const char *var)
+{
+  struct MyVar *myv = NULL;
+
+  TAILQ_FOREACH(myv, &MyVars, entries)
+  {
+    if (mutt_str_equal(myv->name, var))
+      return myv;
+  }
+
+  return NULL;
+}
+
+/**
  * myvar_get - Get the value of a "my_" variable
  * @param var Variable name
  * @retval ptr  Success, value of variable
@@ -72,12 +91,11 @@ static void myvar_free(struct MyVar **ptr)
  */
 const char *myvar_get(const char *var)
 {
-  struct MyVar *myv = NULL;
+  struct MyVar *myv = myvar_find(var);
 
-  TAILQ_FOREACH(myv, &MyVars, entries)
+  if (myv)
   {
-    if (mutt_str_equal(myv->name, var))
-      return NONULL(myv->value);
+    return NONULL(myv->value);
   }
 
   return NULL;
@@ -90,15 +108,12 @@ const char *myvar_get(const char *var)
  */
 void myvar_set(const char *var, const char *val)
 {
-  struct MyVar *myv = NULL;
+  struct MyVar *myv = myvar_find(var);
 
-  TAILQ_FOREACH(myv, &MyVars, entries)
+  if (myv)
   {
-    if (mutt_str_equal(myv->name, var))
-    {
-      mutt_str_replace(&myv->value, val);
-      return;
-    }
+    mutt_str_replace(&myv->value, val);
+    return;
   }
 
   myv = myvar_new(var, val);
@@ -111,16 +126,12 @@ void myvar_set(const char *var, const char *val)
  */
 void myvar_del(const char *var)
 {
-  struct MyVar *myv = NULL;
+  struct MyVar *myv = myvar_find(var);
 
-  TAILQ_FOREACH(myv, &MyVars, entries)
+  if (myv)
   {
-    if (mutt_str_equal(myv->name, var))
-    {
-      TAILQ_REMOVE(&MyVars, myv, entries);
-      myvar_free(&myv);
-      return;
-    }
+    TAILQ_REMOVE(&MyVars, myv, entries);
+    myvar_free(&myv);
   }
 }
 

--- a/myvar.h
+++ b/myvar.h
@@ -41,6 +41,7 @@ extern struct MyVarList MyVars; ///< List of all the user's custom config variab
 void        myvar_del(const char *var);
 const char *myvar_get(const char *var);
 void        myvar_set(const char *var, const char *val);
+void        myvar_append(const char *var, const char *val);
 
 void myvarlist_free(struct MyVarList *list);
 


### PR DESCRIPTION
Fixes: https://github.com/neomutt/neomutt/issues/2937

- myvar: add append parameter to myvar_set
- command_parse: use it in parse_set
- docs: tweak docs to match

* **What does this PR do?**
* Make it possible to use 'set my_var += "string value"'
* Error out on 'set my_var -= anything' instead of silently treating it like '='

* **What are the relevant issue numbers?**
2937