### PR TITLE
hash: fix crash on element deletion

### DIFF
--- a/mutt/hash.c
+++ b/mutt/hash.c
@@ -421,8 +421,10 @@ void mutt_hash_delete(struct HashTable *table, const char *strkey, const void *d
   if (!table || !strkey)
     return;
   union HashKey key;
-  key.strkey = strkey;
+  // Copy the key because union_hash_delete() may use it after the HashElem is freed.
+  key.strkey = mutt_str_dup(strkey);
   union_hash_delete(table, key, data);
+  FREE(&key.strkey);
 }
 
 /**


### PR DESCRIPTION
Fixes: #2969

When NeoMutt frees a ConfigSubset, it iterates through the set passing the name (key) of each item to mutt_hash_delete().

Unfortunately, passing the key name from `struct Inheritance` doesn't work.
The HashTable uses the name after deleting the item to check for duplicate items.