### PR TITLE
notmuch: really tolerate file renames behind neomutt's back

### DIFF
--- a/notmuch/notmuch.c
+++ b/notmuch/notmuch.c
@@ -2250,6 +2250,7 @@ static enum MxStatus nm_mbox_sync(struct Mailbox *m)
     if (!ok)
     {
       // Syncing file failed, query notmuch for new filepath.
+      m->type = MUTT_NOTMUCH;
       notmuch_database_t *db = nm_db_get(m, true);
       if (db)
       {
@@ -2257,9 +2258,13 @@ static enum MxStatus nm_mbox_sync(struct Mailbox *m)
 
         sync_email_path_with_nm(e, msg);
 
+        mutt_buffer_strcpy(&m->pathbuf, edata->folder);
+        m->type = edata->type;
         ok = maildir_sync_mailbox_message(m, i, h);
+        m->type = MUTT_NOTMUCH;
       }
       nm_db_release(m);
+      m->type = edata->type;
     }
 
     mutt_buffer_strcpy(&m->pathbuf, url);
@@ -2268,7 +2273,6 @@ static enum MxStatus nm_mbox_sync(struct Mailbox *m)
     if (!ok)
     {
       mh_sync_errors += 1;
-      rc = MX_STATUS_ERROR;
       continue;
     }
 


### PR DESCRIPTION
Resolves https://github.com/neomutt/neomutt/issues/2973

In commit 731a3d9c, we noted that aborting a mailbox sync on a
notmuch failure is not helpful (the user is now stuck in that mailbox,
and must quit neomutt to recover); it was deemed better to notify the
user of the failure, but to allow sync to claim success after all.
But the logic in that patch was flawed: the final value of rc depends
on the value of rc for the last message visited in the mailbox: if an
earlier message fails and a later one resets rc back to 0, we get the
desired behavior, but if the last message fails, rc is an error.

Later, commit c3afc987 cleaned up the error return code to make rc
sticky: now it gets set to a non-zero value on ANY failed message, not
just the last one in the notmuch mailbox being synced.

In the meantime, commit 84d9944f tried to get smarter about the
situation: just because the filename neomutt knows didn't work doesn't
mean notmuch doesn't know what to do - after all, notmuch's philosophy
is that REALLY deleting emails is an infrequent operation, more
likely, you just move them to a different folder or tag them with
something so they no longer appear in default queries, but the
underlying mail is still known to the database.  However, that code
never worked!  In order for mh_sync_mailbox_message() to succeed, we
first had to munge m->type to MUTT_MAILDIR, but nm_db_get() returns
NULL unless m->type is MUTT_NOTMUCH.  So if we're going to mess with
m->type, we have to mess with it in multiple places.

- nm_mbox_sync: try fallback to notmuch for real
- nm_mbox_sync: ignore sync failures for real

* **What does this PR do?**

* **Screenshots (if relevant)**

* **Does this PR meet the acceptance criteria?** (This is just a reminder for you,
  this section can be removed if you fulfill it.)

   - Documentation created/updated (you have to edit
     [doc/manual.xml.head](https://www.github.com/neomutt/neomutt/blob/master/doc/manual.xml.head)
     for that)

   - All builds and tests are passing

   - Added [doxygen code documentation](https://neomutt.org/dev/doxygen)
     [syntax](http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html)

   - Code follows the [style guide](https://neomutt.org/dev/coding-style)

* **What are the relevant issue numbers?**
