### PR TITLE
pager: fix infinite loop

### DIFF
--- a/pager/dlg_pager.c
+++ b/pager/dlg_pager.c
@@ -2505,11 +2505,11 @@ int mutt_pager(struct PagerView *pview)
   priv->menu = pager_menu;
 
   //---------- restore global state if needed ---------------------------------
-  while (pview->mode == PAGER_MODE_EMAIL && (OldEmail == pview->pdata->email) // are we "resuming" to the same Email?
-         && (TopLine != priv->topline) // is saved offset different?
-         && priv->line_info[priv->curline].offset < (priv->sb.st_size - 1))
+  while ((pview->mode == PAGER_MODE_EMAIL) && (OldEmail == pview->pdata->email) && // are we "resuming" to the same Email?
+         (TopLine != priv->topline) && // is saved offset different?
+         (priv->line_info[priv->curline].offset < (priv->sb.st_size - 1)))
   {
-    // needed to avoid SIGSEGV
+    menu_queue_redraw(pager_menu, MENU_REDRAW_FULL);
     pager_custom_redraw(pager_menu);
     // trick user, as if nothing happened
     // scroll down to previosly saved offset


### PR DESCRIPTION
Fixes: #2978

On startup, the Pager does a looped refresh to move the focus to the required place.
Without the MENU_REDRAW_FULL flag the line offsets weren't being updated so it kept looping forever.