### PR TITLE
Add $use_threads config variable

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -900,9 +900,12 @@ bool mutt_select_sort(bool reverse)
 
   const unsigned char c_use_threads =
       cs_subset_enum(NeoMutt->sub, "use_threads");
+  const short c_sort = cs_subset_sort(NeoMutt->sub, "sort");
   int rc = CSR_ERR_CODE;
   if ((sort != SORT_THREADS) || (c_use_threads == UT_UNSET))
   {
+    if ((sort != SORT_THREADS) && (c_sort & SORT_LAST))
+      sort |= SORT_LAST;
     if (reverse)
       sort |= SORT_REVERSE;
 
@@ -910,7 +913,6 @@ bool mutt_select_sort(bool reverse)
   }
   else
   {
-    const short c_sort = cs_subset_sort(NeoMutt->sub, "sort");
     assert((c_sort & SORT_MASK) != SORT_THREADS); /* See index_config_observer() */
     /* Preserve the value of $sort, and toggle whether we are threaded. */
     switch (c_use_threads)

--- a/compose/compose.c
+++ b/compose/compose.c
@@ -1369,8 +1369,11 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, uint8_t flags,
           break;
         }
 
-        const enum SortType old_sort = cs_subset_sort(sub, "sort"); /* `$sort`, `$sort_aux` could be changed in mutt_index_menu() */
+        /* `$sort`, `$sort_aux`, `$use_threads` could be changed in mutt_index_menu() */
+        const enum SortType old_sort = cs_subset_sort(sub, "sort");
         const enum SortType old_sort_aux = cs_subset_sort(sub, "sort_aux");
+        const unsigned char old_use_threads =
+            cs_subset_enum(sub, "use_threads");
 
         OptAttachMsg = true;
         mutt_message(_("Tag the messages you want to attach"));
@@ -1383,9 +1386,10 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, uint8_t flags,
 
         if (!Context)
         {
-          /* Restore old $sort and $sort_aux */
+          /* Restore old $sort variables */
           cs_subset_str_native_set(sub, "sort", old_sort, NULL);
           cs_subset_str_native_set(sub, "sort_aux", old_sort_aux, NULL);
+          cs_subset_str_native_set(sub, "use_threads", old_use_threads, NULL);
           menu_queue_redraw(menu, MENU_REDRAW_INDEX);
           notify_send(shared->notify, NT_COMPOSE, NT_COMPOSE_ATTACH, NULL);
           break;
@@ -1421,9 +1425,10 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, uint8_t flags,
         }
         mx_fastclose_mailbox(m_attach_new);
 
-        /* Restore old $sort and $sort_aux */
+        /* Restore old $sort variables */
         cs_subset_str_native_set(sub, "sort", old_sort, NULL);
         cs_subset_str_native_set(sub, "sort_aux", old_sort_aux, NULL);
+        cs_subset_str_native_set(sub, "use_threads", old_use_threads, NULL);
         if (added_attachment)
           mutt_message_hook(NULL, e, MUTT_SEND2_HOOK);
         break;

--- a/contrib/samples/sample.neomuttrc
+++ b/contrib/samples/sample.neomuttrc
@@ -87,10 +87,9 @@ set nosave_empty		# remove files when no messages are left
 # I subscribe to a lot of mailing lists, so this is _very_ useful.  This
 # groups messages on the same subject to make it easier to follow a
 # discussion.  NeoMutt will draw a nice tree showing how the discussion flows.
-set sort=threads		# primary sorting method
-
-#set sort_aux=reverse-date-received	# how to sort subthreads
-#set sort_aux=last-date		# date of the last message in thread
+set use_threads=yes           # primary sorting method
+set sort=reverse-last-date    # sort overall thread with latest activity first
+set sort_aux=date             # within thread, sort subthreads by date started
 set sort_browser=reverse-date	# how to sort files in the dir browser
 set spool_file='~/mailbox'	# where my new mail is located
 #set status_format="-%r-NeoMutt: %f [Msgs:%?M?%M/?%m%?n? New:%n?%?d? Del:%d?%?F? Flag:%F?%?t? Tag:%t?%?p? Post:%p?%?b? Inc:%b?  %l]---(%s)-%>-(%P)---"

--- a/contrib/samples/sample.neomuttrc-tlr
+++ b/contrib/samples/sample.neomuttrc-tlr
@@ -248,8 +248,9 @@ set   save_name                         # Save copies by name.  Together with $r
 set   signature=~/.signature            # Silly signature
 set   sig_dashes                        # Add dashes above my signature
 set   smart_wrap                        # Try to be smart when wrapping around lines in the pager
-set   sort=threads                      # sort by threads,
-set   sort_aux=date                     # then by date
+set   use_threads=yes                   # sort by threads,
+set   sort=last-date                    # thread with recent activity to bottom,
+set   sort_aux=date                     # then by date within a thread
 unset strict_threads                    # don't be strict about threads
 # set   suspend=no                      # Don't suspend - I usually run mutt like this: "xterm -e mutt"
 set   tilde                             # Indicate empty lines in the pager.

--- a/docs/config.c
+++ b/docs/config.c
@@ -4968,7 +4968,7 @@
 ** .de
 */
 
-{ "status_format", DT_STRING, "-%r-NeoMutt: %D [Msgs:%?M?%M/?%m%?n? New:%n?%?o? Old:%o?%?d? Del:%d?%?F? Flag:%F?%?t? Tag:%t?%?p? Post:%p?%?b? Inc:%b?%?l? %l?]---(%s/%S)-%>-(%P)---" },
+{ "status_format", DT_STRING, "-%r-NeoMutt: %D [Msgs:%?M?%M/?%m%?n? New:%n?%?o? Old:%o?%?d? Del:%d?%?F? Flag:%F?%?t? Tag:%t?%?p? Post:%p?%?b? Inc:%b?%?l? %l?]---(%?T?%T/?%s/%S)-%>-(%P)---" },
 /*
 ** .pp
 ** Controls the format of the status line displayed in the "index"
@@ -4996,6 +4996,7 @@
 ** .dt %s  .dd   .dd Current sorting mode ($$sort)
 ** .dt %S  .dd   .dd Current aux sorting method ($$sort_aux)
 ** .dt %t  .dd * .dd Number of tagged messages in the mailbox
+** .dt %T  .dd * .dd Current threading mode ($$use_threads)
 ** .dt %u  .dd * .dd Number of unread messages in the mailbox (seen or unseen)
 ** .dt %v  .dd   .dd NeoMutt version string
 ** .dt %V  .dd * .dd Currently active limit pattern, if any
@@ -5033,6 +5034,12 @@
 ** .pp
 ** If the value of \fIsequence_char\fP is non-zero, \fIif_string\fP will
 ** be expanded, otherwise \fIelse_string\fP will be expanded.
+** .pp
+** As another example, here is how to show either $$sort and
+** $$sort_aux or $$use_threads and $$sort, based on whether threads
+** are enabled with $$use_threads:
+** .pp
+** \fC%?T?%s/%S&%T/s?\fP
 ** .pp
 ** You can force the result of any \fCprintf(3)\fP-like sequence to be lowercase
 ** by prefixing the sequence character with an underscore ("_") sign.

--- a/docs/config.c
+++ b/docs/config.c
@@ -4660,18 +4660,31 @@
 ** .dd unsorted
 ** .ie
 ** .pp
-** You may optionally use the "reverse-" prefix to specify reverse sorting
-** order.
+** You may optionally use the "reverse-" prefix to specify reverse
+** sorting order, or the "last-" prefix to sort threads based on the
+** corresponding attribute of the last descendant rather than the
+** thread root.  If both prefixes are in use, "reverse-" must come
+** before "last-".  The "last-" prefix has no effect on a flat view.
 ** .pp
-** Any ties in the primary sort are broken by $$sort_aux.
+** Any ties in the primary sort are broken by $$sort_aux.  When
+** $$use_threads is "threads" or "reverse", $$sort controls the
+** sorting between threads, and $$sort_aux controls the sorting within
+** a thread.
 ** .pp
 ** The "date-sent" value is a synonym for "date". The "mailbox-order" value is
 ** a synonym for "unsorted".
 ** .pp
-** The values of "threads" and "reverse-threads" are legacy options;
-** the preferred way to enable a threaded view is via
+** The values of "threads" and "reverse-threads" are legacy options,
+** which cause the value of \fC$$sort_aux\fP to also contol sorting
+** between threads, and they may not be used with the "last-" prefix.
+** The preferred way to enable a threaded view is via
 ** \fC$$use_threads\fP.  This variable can also be set via the
 ** \fC<sort-mailbox>\fP and \fC<sort-reverse>\fP functions.
+** .pp
+** Note: When $$use_threads is "threads", the last thread sorts to the
+** bottom; when it is "reversed", the last thread sorts to the top.
+** The use of "reverse-" in $$sort swaps which end the last thread
+** will sort to.
 ** .pp
 ** See the "Use Threads Feature" section for further explanation and
 ** examples.
@@ -4698,27 +4711,20 @@
 ** This provides a secondary sort for messages in the "index" menu, used
 ** when the $$sort value is equal for two messages.
 ** .pp
-** When sorting by threads, this variable controls how threads are
-** sorted in relation to other threads, and how the branches of the
-** thread trees are sorted.  This can be set to any value that $$sort
-** can, except "threads" (in that case, NeoMutt will just use "date").
-** You can also specify the "last-" prefix in addition to the
-** "reverse-" prefix, but "last-" must come after "reverse-".  The
-** "last-" prefix causes the overall thread to sort by whichever
-** descendant would sort last in a flat view sorted by the same value
-** of $$sort_aux, rather than the thread root.  For instance,
+** When sorting by threads, this variable controls how subthreads are
+** sorted within a single thread (for the order between threads, see
+** $$sort).  This can be set to any value that $$sort can, including
+** with the use of "reverse-" and "last-" prefixes, except for
+** variations using "threads" (in that case, NeoMutt will just use
+** "date").  For instance,
 ** .ts
 ** set sort_aux=last-date-received
 ** .te
 ** .pp
-** would mean that if a new message is received in a
-** thread, that thread becomes the last one displayed (or the first, if
-** you have "\fCset sort=reverse-threads\fP".)
-** .pp
-** Note: When $$use_threads is "threads", the last thread sorts to the
-** bottom; when it is "reversed", the last thread sorts to the top.
-** The use of "reverse-" in $$sort_aux swaps which end the last thread
-** will sort to.
+** would mean that if a new message is received in a thread, that
+** subthread becomes the last one displayed (or the first, if you have
+** "\fCset use_threads=reverse\fP".)  When using $$use_threads, it is
+** more common to use "last-" with $$sort and not with $$sort_aux.
 ** .pp
 ** See the "Use Threads Feature" section for further explanation and
 ** examples.
@@ -5321,10 +5327,13 @@
 ** "threads", and "no" is a synonym for "flat".
 ** .pp
 ** If this variable is never set, then \fC$$sort\fP controls whether
-** threading is used, and using \fC<sort-mailbox>\fP to select threads
-** affects only \fC$$sort\fP.  Once this variable is set, attempting
-** to set \fC$$sort\fP to a value using "threads" will warn, and
-** \fC<sort-mailbox>\fP toggles \fC$$use_threads\fP.
+** threading is used, \fC$$sort_aux\fP controls both the sorting of
+** threads and subthreads, and using \fC<sort-mailbox>\fP to select
+** threads affects only \fC$$sort\fP.  Once this variable is set,
+** attempting to set \fC$$sort\fP to a value using "threads" will
+** warn, the value of \fC$$sort\fP controls the sorting between
+** threads while \fC$$sort_aux\fP controls sorting within a thread,
+** and \fC<sort-mailbox>\fP toggles \fC$$use_threads\fP.
 ** .pp
 ** Example:
 ** .ts

--- a/docs/config.c
+++ b/docs/config.c
@@ -4663,13 +4663,18 @@
 ** You may optionally use the "reverse-" prefix to specify reverse sorting
 ** order.
 ** .pp
+** Any ties in the primary sort are broken by $$sort_aux.
+** .pp
 ** The "date-sent" value is a synonym for "date". The "mailbox-order" value is
 ** a synonym for "unsorted".
 ** .pp
-** Example:
-** .ts
-** set sort=reverse-date-sent
-** .te
+** The values of "threads" and "reverse-threads" are legacy options;
+** the preferred way to enable a threaded view is via
+** \fC$$use_threads\fP.  This variable can also be set via the
+** \fC<sort-mailbox>\fP and \fC<sort-reverse>\fP functions.
+** .pp
+** See the "Use Threads Feature" section for further explanation and
+** examples.
 */
 
 { "sort_alias", DT_SORT, SORT_ALIAS },
@@ -4693,14 +4698,15 @@
 ** This provides a secondary sort for messages in the "index" menu, used
 ** when the $$sort value is equal for two messages.
 ** .pp
-** When sorting by threads, this variable controls how threads are sorted
-** in relation to other threads, and how the branches of the thread trees
-** are sorted.  This can be set to any value that $$sort can, except
-** "threads" (in that case, NeoMutt will just use "date").  You can also
-** specify the "last-" prefix in addition to the "reverse-" prefix, but "last-"
-** must come after "reverse-".  The "last-" prefix causes messages to be
-** sorted against its siblings by which has the last descendant, using
-** the rest of $$sort_aux as an ordering.  For instance,
+** When sorting by threads, this variable controls how threads are
+** sorted in relation to other threads, and how the branches of the
+** thread trees are sorted.  This can be set to any value that $$sort
+** can, except "threads" (in that case, NeoMutt will just use "date").
+** You can also specify the "last-" prefix in addition to the
+** "reverse-" prefix, but "last-" must come after "reverse-".  The
+** "last-" prefix causes the overall thread to sort by whichever
+** descendant would sort last in a flat view sorted by the same value
+** of $$sort_aux, rather than the thread root.  For instance,
 ** .ts
 ** set sort_aux=last-date-received
 ** .te
@@ -4709,9 +4715,13 @@
 ** thread, that thread becomes the last one displayed (or the first, if
 ** you have "\fCset sort=reverse-threads\fP".)
 ** .pp
-** Note: For reversed-threads $$sort
-** order, $$sort_aux is reversed again (which is not the right thing to do,
-** but kept to not break any existing configuration setting).
+** Note: When $$use_threads is "threads", the last thread sorts to the
+** bottom; when it is "reversed", the last thread sorts to the top.
+** The use of "reverse-" in $$sort_aux swaps which end the last thread
+** will sort to.
+** .pp
+** See the "Use Threads Feature" section for further explanation and
+** examples.
 */
 
 { "sort_browser", DT_SORT, SORT_ALPHA },
@@ -5300,6 +5310,30 @@
 ** Normally, the default should work.
 */
 #endif
+
+{ "use_threads", DT_ENUM, THREADS_UNSET },
+/*
+** .pp
+** The style of threading used in the index. May be one of "flat" (no
+** threading), "threads" (threaded, with subthreads below root
+** message) or "reverse" (threaded, with subthreads above root
+** message). For convenience, the value "yes" is a synonym for
+** "threads", and "no" is a synonym for "flat".
+** .pp
+** If this variable is never set, then \fC$$sort\fP controls whether
+** threading is used, and using \fC<sort-mailbox>\fP to select threads
+** affects only \fC$$sort\fP.  Once this variable is set, attempting
+** to set \fC$$sort\fP to a value using "threads" will warn, and
+** \fC<sort-mailbox>\fP toggles \fC$$use_threads\fP.
+** .pp
+** Example:
+** .ts
+** set use_threads=yes
+** .te
+** .pp
+** See the "Use Threads Feature" section for further explanation and
+** examples.
+*/
 
 { "user_agent", DT_BOOL, false },
 /*

--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -17799,6 +17799,13 @@ bind index D purge-message
           thread root.  The <literal>last-</literal> prefix is ignored
           when <literal>use_threads=flat</literal>.
         </para>
+        <para>
+          The <quote>Use Threads</quote> feature also modifies the
+          existing config variable <link
+          linkend="status-format">$status_format</link>, adding the
+          <literal>%T</literal> expando which shows the current
+          threading method.
+        </para>
       </sect2>
 
       <sect2 id="use-threads-neomuttrc">

--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -17428,8 +17428,9 @@ set toggle_quoted_show_levels = 1
 set status_format='-%r-NeoMutt: %f [Msgs:%?M?%M/?%m%?n? New:%n?%?o? Old:%o?%?d? Del:%d?%?F? \
   Flag:%F?%?t? Tag:%t?%?p? Post:%p?%?b? Inc:%b?%?l? %l?]---(%s/%S)-%&gt;-(%P)---'
 set index_format='%4C %Z %{%b %d} %-15.15L (%?l?%4l&amp;%4c?) %s'
-set sort=threads
-set sort_aux=last-date-received
+set use_threads=yes
+set sort=last-date-received
+set sort_aux=date
 <emphasis role="comment"># 'status color' can take up to 2 extra parameters</emphasis>
 <emphasis role="comment"># color status foreground background [ regex [ num ]]</emphasis>
 <emphasis role="comment"># 0 extra parameters</emphasis>
@@ -17854,7 +17855,7 @@ set use_threads=reverse sort=date sort_aux=date
 <emphasis role="comment">#set sort=threads sort_aux=reverse-last-date</emphasis>
 <emphasis role="comment"># Modern configuration for the same</emphasis>
 <emphasis role="comment"># Note that subthreads are also rearranged</emphasis>
-set use_threads=threads sort=reverse-date sort_aux=reverse-last-date
+set use_threads=threads sort=reverse-last-date sort_aux=reverse-last-date
 <emphasis role="comment">#   Barbara  12:05  thread 2</emphasis>
 <emphasis role="comment">#   Erica    12:08  `-&gt;re: thread 2</emphasis>
 <emphasis role="comment">#   Anne     12:01  cover letter for thread 1</emphasis>
@@ -17863,6 +17864,19 @@ set use_threads=threads sort=reverse-date sort_aux=reverse-last-date
 <emphasis role="comment">#   Anne     12:04  |-&gt;part 3 of thread 1</emphasis>
 <emphasis role="comment">#   Anne     12:02  `-&gt;part 1 of thread 1</emphasis>
 <emphasis role="comment">#   Claire   12:06  thread 3</emphasis>
+
+<emphasis role="comment"># ------------------------------------------------------------</emphasis>
+<emphasis role="comment"># Modern configuration: threads keep date order, recently active thread last</emphasis>
+<emphasis role="comment"># (not possible with legacy configuration)</emphasis>
+set use_threads=threads sort=last-date sort_aux=date
+<emphasis role="comment">#   Claire   12:06  thread 3</emphasis>
+<emphasis role="comment">#   Anne     12:01  cover letter for thread 1</emphasis>
+<emphasis role="comment">#   Anne     12:02  |-&gt;part 1 of thread 1</emphasis>
+<emphasis role="comment">#   Anne     12:03  |-&gt;part 2 of thread 1</emphasis>
+<emphasis role="comment">#   Diane    12:07  | `-&gt;re: part 2 of thread 1</emphasis>
+<emphasis role="comment">#   Anne     12:04  `-&gt;part 3 of thread 1</emphasis>
+<emphasis role="comment">#   Barbara  12:05  thread 2</emphasis>
+<emphasis role="comment">#   Erica    12:08  `-&gt;re: thread 2</emphasis>
 
 <emphasis role="comment"># vim: syntax=neomuttrc</emphasis>
 </screen>
@@ -17878,14 +17892,6 @@ set use_threads=threads sort=reverse-date sort_aux=reverse-last-date
           bare <literal>set use_threads</literal> performs a query
           rather than setting it to <literal>yes</literal>, and the
           variable is not usable with <literal>toggle</literal>.
-        </para>
-        <para>
-          Neither the old nor new style is able to sort top-level
-          threads differently from subthreads within a thread.  If you
-          use <literal>sort_aux=last-date</literal>, not only is the
-          thread with the most recent activity moved to the bottom,
-          but the subthreads within that thread are rearranged in the
-          same manner.  This will be addressed in upcoming patches.
         </para>
       </sect2>
 

--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -17728,6 +17728,175 @@ bind index D purge-message
       </sect2>
     </sect1>
 
+    <sect1 id="use-threads-feature">
+      <title>Use Threads Feature</title>
+      <subtitle>Improve the experience with viewing threads in the
+      index</subtitle>
+
+      <sect2 id="use-threads-support">
+        <title>Support</title>
+        <para>
+          <emphasis role="bold">Since:</emphasis> NeoMutt 2021-08-01
+        </para>
+        <para>
+          <emphasis role="bold">Dependencies:</emphasis> None
+        </para>
+      </sect2>
+
+      <sect2 id="use-threads-intro">
+        <title>Introduction</title>
+        <para>
+          The <quote>Use Threads</quote> feature adds a new config
+          variable to allow more precise control of how threads are
+          displayed in the index.  Whether threads are in use is now
+          orthogonal from how messages are sorted.
+        </para>
+      </sect2>
+
+      <sect2 id="use-thread-functions">
+        <title>Functions</title>
+        <para>
+          The <quote>Use Threads</quote> feature adds no new functions
+          to NeoMutt.  The existing functions
+          <literal>&lt;sort-mailbox&gt;</literal> and
+          <literal>&lt;sort-reverse&gt;</literal> are updated to
+          toggle the state of <literal>$use_threads</literal> once it
+          has been set, while preserving backwards-compatible behavior
+          on <literal>$sort</literal> if this feature is not used.
+        </para>
+      </sect2>
+
+      <sect2 id="use-threads-variables">
+        <title>Variables</title>
+        <para>
+          The <quote>Use Threads</quote> feature adds one new config
+          variable, <link linkend="use-threads">$use_threads</link>,
+          which is an enumeration of possible thread views.  The
+          variable defaults to unset for the original behavior of
+          overloading <link linkend="sort">$sort=threads</link> to
+          enable sorting.  It can be set to <literal>flat</literal>
+          (or <literal>no</literal>) for an unthreaded view based on
+          <literal>$sort</literal>, to <literal>threads</literal> (or
+          <literal>yes</literal> for a threaded view where roots
+          appear above children, or to <literal>reverse</literal> for
+          a threaded view where children appear above roots.
+        </para>
+        <para>
+          When sorting by threads, the value of <link
+          linkend="sort-aux">$sort_aux</link> determines which thread
+          floats to the top.  If <literal>$sort_aux</literal> does not
+          contain <literal>reverse-</literal>, the latest thread goes
+          to the bottom for <literal>use_threads=threads</literal> and
+          to the top for <literal>use_threads=reverse</literal>; the
+          direction of float is swapped if
+          <literal>$sort_aux</literal> also uses
+          <literal>reverse-</literal>.  If
+          <literal>$sort_aux</literal> includes
+          <literal>last-</literal>, the overall thread is sorted by
+          its descendant at any depth which would sort last in a flat
+          view; otherwise, the overall thread is sorted solely by the
+          thread root.  The <literal>last-</literal> prefix is ignored
+          when <literal>use_threads=flat</literal>.
+        </para>
+      </sect2>
+
+      <sect2 id="use-threads-neomuttrc">
+        <title>neomuttrc</title>
+
+<screen>
+<emphasis role="comment"># Example NeoMutt config file for the use-threads feature.</emphasis>
+
+
+<emphasis role="comment"># ------------------------------------------------------------</emphasis>
+<emphasis role="comment"># Default configuration: flat view sorted by date</emphasis>
+<emphasis role="comment">#set use_threads=no sort=date sort_aux=date</emphasis>
+<emphasis role="comment">#   Anne     12:01  cover letter for thread 1</emphasis>
+<emphasis role="comment">#   Anne     12:02  part 1 of thread 1</emphasis>
+<emphasis role="comment">#   Anne     12:03  part 2 of thread 1</emphasis>
+<emphasis role="comment">#   Anne     12:04  part 3 of thread 1</emphasis>
+<emphasis role="comment">#   Barbara  12:05  thread 2</emphasis>
+<emphasis role="comment">#   Claire   12:06  thread 3</emphasis>
+<emphasis role="comment">#   Diane    12:07  re: part 2 of thread 1</emphasis>
+<emphasis role="comment">#   Erica    12:08  re: thread 2</emphasis>
+
+<emphasis role="comment"># ------------------------------------------------------------</emphasis>
+<emphasis role="comment"># Legacy configuration: sorting threads by date started</emphasis>
+<emphasis role="comment">#set sort=threads sort_aux=date</emphasis>
+<emphasis role="comment"># Modern configuration for the same</emphasis>
+<emphasis role="comment"># Latest root message sorts last</emphasis>
+set use_threads=yes sort=date sort_aux=date
+<emphasis role="comment">#   Anne     12:01  cover letter for thread 1</emphasis>
+<emphasis role="comment">#   Anne     12:02  |-&gt;part 1 of thread 1</emphasis>
+<emphasis role="comment">#   Anne     12:03  |-&gt;part 2 of thread 1</emphasis>
+<emphasis role="comment">#   Diane    12:07  | `-&gt;re: part 2 of thread 1</emphasis>
+<emphasis role="comment">#   Anne     12:04  `-&gt;part 3 of thread 1</emphasis>
+<emphasis role="comment">#   Barbara  12:05  thread 2</emphasis>
+<emphasis role="comment">#   Erica    12:08  `-&gt;re: thread 2</emphasis>
+<emphasis role="comment">#   Claire   12:06  thread 3</emphasis>
+
+<emphasis role="comment"># ------------------------------------------------------------</emphasis>
+<emphasis role="comment"># Legacy configuration: display threads upside-down</emphasis>
+<emphasis role="comment">#set sort=reverse-threads sort_aux=date</emphasis>
+<emphasis role="comment"># Modern configuration for the same</emphasis>
+<emphasis role="comment"># Latest root message sorts first</emphasis>
+set use_threads=reverse sort=date sort_aux=date
+<emphasis role="comment">#   Claire   12:06  thread 3</emphasis>
+<emphasis role="comment">#   Erica    12:08  ,-&gt;re: thread 2</emphasis>
+<emphasis role="comment">#   Barbara  12:05  thread 2</emphasis>
+<emphasis role="comment">#   Anne     12:04  ,-&gt;part 3 of thread 1</emphasis>
+<emphasis role="comment">#   Diane    12:07  | ,-&gt;re: part 2 of thread 1</emphasis>
+<emphasis role="comment">#   Anne     12:03  |-&gt;part 2 of thread 1</emphasis>
+<emphasis role="comment">#   Anne     12:02  |-&gt;part 1 of thread 1</emphasis>
+<emphasis role="comment">#   Anne     12:01  cover letter for thread 1</emphasis>
+
+<emphasis role="comment"># ------------------------------------------------------------</emphasis>
+<emphasis role="comment"># Legacy configuration: recently active thread/subthread first</emphasis>
+<emphasis role="comment">#set sort=threads sort_aux=reverse-last-date</emphasis>
+<emphasis role="comment"># Modern configuration for the same</emphasis>
+<emphasis role="comment"># Note that subthreads are also rearranged</emphasis>
+set use_threads=threads sort=reverse-date sort_aux=reverse-last-date
+<emphasis role="comment">#   Barbara  12:05  thread 2</emphasis>
+<emphasis role="comment">#   Erica    12:08  `-&gt;re: thread 2</emphasis>
+<emphasis role="comment">#   Anne     12:01  cover letter for thread 1</emphasis>
+<emphasis role="comment">#   Anne     12:03  |-&gt;part 2 of thread 1</emphasis>
+<emphasis role="comment">#   Diane    12:07  | `-&gt;re: part 2 of thread 1</emphasis>
+<emphasis role="comment">#   Anne     12:04  |-&gt;part 3 of thread 1</emphasis>
+<emphasis role="comment">#   Anne     12:02  `-&gt;part 1 of thread 1</emphasis>
+<emphasis role="comment">#   Claire   12:06  thread 3</emphasis>
+
+<emphasis role="comment"># vim: syntax=neomuttrc</emphasis>
+</screen>
+
+      </sect2>
+
+      <sect2 id="use-threads-known-bugs">
+        <title>Known Bugs</title>
+        <para>
+          Even though <literal>use_threads</literal> accepts the
+          values <literal>yes</literal> and <literal>no</literal>, it
+          does not behave like a boolean or quad-option variable.  A
+          bare <literal>set use_threads</literal> performs a query
+          rather than setting it to <literal>yes</literal>, and the
+          variable is not usable with <literal>toggle</literal>.
+        </para>
+        <para>
+          Neither the old nor new style is able to sort top-level
+          threads differently from subthreads within a thread.  If you
+          use <literal>sort_aux=last-date</literal>, not only is the
+          thread with the most recent activity moved to the bottom,
+          but the subthreads within that thread are rearranged in the
+          same manner.  This will be addressed in upcoming patches.
+        </para>
+      </sect2>
+
+      <sect2 id="use-threads-credits">
+        <title>Credits</title>
+        <para>
+          Eric Blake
+        </para>
+      </sect2>
+    </sect1>
+
     <sect1 id="autocryptdoc">
       <title>Autocrypt</title>
 

--- a/email/thread.c
+++ b/email/thread.c
@@ -76,10 +76,18 @@ void unlink_message(struct MuttThread **old, struct MuttThread *cur)
   if (cur->next)
     cur->next->prev = cur->prev;
 
-  if (cur->sort_key)
+  if (cur->sort_thread_key)
   {
-    for (tmp = cur->parent; tmp && (tmp->sort_key == cur->sort_key); tmp = tmp->parent)
-      tmp->sort_key = NULL;
+    for (tmp = cur->parent;
+         tmp && (tmp->sort_thread_key == cur->sort_thread_key); tmp = tmp->parent)
+    {
+      tmp->sort_thread_key = NULL;
+    }
+  }
+  if (cur->sort_aux_key)
+  {
+    for (tmp = cur->parent; tmp && (tmp->sort_aux_key == cur->sort_aux_key); tmp = tmp->parent)
+      tmp->sort_aux_key = NULL;
   }
 }
 

--- a/email/thread.h
+++ b/email/thread.h
@@ -47,7 +47,8 @@ struct MuttThread
   struct MuttThread *next;          ///< Next sibling Thread
   struct MuttThread *prev;          ///< Previous sibling Thread
   struct Email *message;            ///< Email this Thread refers to
-  struct Email *sort_key;           ///< Email that this Thread is sorted against
+  struct Email *sort_thread_key;    ///< Email that controls how top thread sorts
+  struct Email *sort_aux_key;       ///< Email that controls how subthread siblings sort
 };
 
 void          clean_references      (struct MuttThread *brk, struct MuttThread *cur);

--- a/flags.c
+++ b/flags.c
@@ -37,6 +37,7 @@
 #include "mutt.h"
 #include "index/lib.h"
 #include "keymap.h"
+#include "mutt_thread.h"
 #include "protos.h"
 
 /**
@@ -377,8 +378,7 @@ int mutt_thread_set_flag(struct Mailbox *m, struct Email *e,
   struct MuttThread *start = NULL;
   struct MuttThread *cur = e->thread;
 
-  const short c_sort = cs_subset_sort(NeoMutt->sub, "sort");
-  if ((c_sort & SORT_MASK) != SORT_THREADS)
+  if (!mutt_using_threads())
   {
     mutt_error(_("Threading is not enabled"));
     return -1;

--- a/hdrline.c
+++ b/hdrline.c
@@ -446,8 +446,7 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
   char fmt[128], tmp[1024];
   char *p = NULL, *tags = NULL;
   bool optional = (flags & MUTT_FORMAT_OPTIONAL);
-  const short c_sort = cs_subset_sort(NeoMutt->sub, "sort");
-  int threads = ((c_sort & SORT_MASK) == SORT_THREADS);
+  const bool threads = mutt_using_threads();
   int is_index = (flags & MUTT_FORMAT_INDEX);
   size_t colorlen;
 

--- a/index/dlg_index.c
+++ b/index/dlg_index.c
@@ -387,11 +387,13 @@ static int ci_first_message(struct Mailbox *m)
   if (old != -1)
     return old;
 
-  /* If `$sort` is reverse and not threaded, the latest message is first.
-   * If `$sort` is threaded, the latest message is first if exactly one
-   * of `$sort` and `$sort_aux` are reverse.  */
-  const short c_sort = cs_subset_sort(m->sub, "sort");
-  const short c_sort_aux = cs_subset_sort(m->sub, "sort_aux");
+  /* If `$use_threads` is not threaded and `$sort` is reverse, the latest
+   * message is first.  Otherwise, the latest message is first if exactly
+   * one of `$use_threads` and `$sort` are reverse.
+   */
+  short c_sort = cs_subset_sort(m->sub, "sort");
+  if ((c_sort & SORT_MASK) == SORT_THREADS)
+    c_sort = cs_subset_sort(m->sub, "sort_aux");
   bool reverse = false;
   switch (mutt_thread_style())
   {
@@ -399,10 +401,10 @@ static int ci_first_message(struct Mailbox *m)
       reverse = c_sort & SORT_REVERSE;
       break;
     case UT_THREADS:
-      reverse = c_sort_aux & SORT_REVERSE;
+      reverse = c_sort & SORT_REVERSE;
       break;
     case UT_REVERSE:
-      reverse = !(c_sort_aux & SORT_REVERSE);
+      reverse = !(c_sort & SORT_REVERSE);
       break;
     default:
       assert(false);

--- a/index/dlg_index.c
+++ b/index/dlg_index.c
@@ -392,17 +392,26 @@ static int ci_first_message(struct Mailbox *m)
    * of `$sort` and `$sort_aux` are reverse.  */
   const short c_sort = cs_subset_sort(m->sub, "sort");
   const short c_sort_aux = cs_subset_sort(m->sub, "sort_aux");
-  if (((c_sort & SORT_REVERSE) && ((c_sort & SORT_MASK) != SORT_THREADS)) ||
-      (((c_sort & SORT_MASK) == SORT_THREADS) && ((c_sort ^ c_sort_aux) & SORT_REVERSE)))
+  bool reverse = false;
+  switch (mutt_thread_style())
   {
-    return 0;
-  }
-  else
-  {
-    return m->vcount ? m->vcount - 1 : 0;
+    case UT_FLAT:
+      reverse = c_sort & SORT_REVERSE;
+      break;
+    case UT_THREADS:
+      reverse = c_sort_aux & SORT_REVERSE;
+      break;
+    case UT_REVERSE:
+      reverse = !(c_sort_aux & SORT_REVERSE);
+      break;
+    default:
+      assert(false);
   }
 
-  return 0;
+  if (reverse || (m->vcount == 0))
+    return 0;
+
+  return m->vcount - 1;
 }
 
 /**
@@ -468,8 +477,7 @@ static void resort_index(struct Context *ctx, struct Menu *menu)
     }
   }
 
-  const short c_sort = cs_subset_sort(m->sub, "sort");
-  if (((c_sort & SORT_MASK) == SORT_THREADS) && (old_index < 0))
+  if (mutt_using_threads() && (old_index < 0))
     new_index = mutt_parent_message(e_cur, false);
 
   if (old_index < 0)
@@ -617,8 +625,7 @@ static void update_index(struct Menu *menu, struct Context *ctx, enum MxStatus c
     return;
 
   struct Mailbox *m = ctx->mailbox;
-  const short c_sort = cs_subset_sort(m->sub, "sort");
-  if ((c_sort & SORT_MASK) == SORT_THREADS)
+  if (mutt_using_threads())
     update_index_threaded(ctx, check, oldcount);
   else
     update_index_unthreaded(ctx, check);
@@ -783,9 +790,8 @@ static void change_folder_mailbox(struct Menu *menu, struct Mailbox *m, int *old
     menu_set_index(menu, 0);
   }
 
-  const short c_sort = cs_subset_sort(shared->sub, "sort");
   const bool c_collapse_all = cs_subset_bool(shared->sub, "collapse_all");
-  if (((c_sort & SORT_MASK) == SORT_THREADS) && c_collapse_all)
+  if (mutt_using_threads() && c_collapse_all)
     collapse_all(shared->ctx, menu, 0);
 
   struct MuttWindow *dlg = dialog_find(menu->win_index);
@@ -896,15 +902,15 @@ void index_make_entry(struct Menu *menu, char *buf, size_t buflen, int line)
   MuttFormatFlags flags = MUTT_FORMAT_ARROWCURSOR | MUTT_FORMAT_INDEX;
   struct MuttThread *tmp = NULL;
 
-  const short c_sort = cs_subset_sort(shared->sub, "sort");
-  if (((c_sort & SORT_MASK) == SORT_THREADS) && e->tree)
+  const enum UseThreads c_threads = mutt_thread_style();
+  if ((c_threads > UT_FLAT) && e->tree)
   {
     flags |= MUTT_FORMAT_TREE; /* display the thread tree */
     if (e->display_subject)
       flags |= MUTT_FORMAT_FORCESUBJ;
     else
     {
-      const int reverse = c_sort & SORT_REVERSE;
+      const bool reverse = c_threads == UT_REVERSE;
       int edgemsgno;
       if (reverse)
       {
@@ -1395,9 +1401,8 @@ struct Mailbox *mutt_index_menu(struct MuttWindow *dlg, struct Mailbox *m_init)
 #endif
 
   {
-    const short c_sort = cs_subset_sort(shared->sub, "sort");
     const bool c_collapse_all = cs_subset_bool(shared->sub, "collapse_all");
-    if (((c_sort & SORT_MASK) == SORT_THREADS) && c_collapse_all)
+    if (mutt_using_threads() && c_collapse_all)
     {
       collapse_all(shared->ctx, priv->menu, 0);
       menu_queue_redraw(priv->menu, MENU_REDRAW_FULL);
@@ -1424,9 +1429,8 @@ struct Mailbox *mutt_index_menu(struct MuttWindow *dlg, struct Mailbox *m_init)
     priv->oldcount = shared->mailbox ? shared->mailbox->msg_count : 0;
 
     {
-      const short c_sort = cs_subset_sort(shared->sub, "sort");
-      if (OptRedrawTree && shared->mailbox && (shared->mailbox->msg_count != 0) &&
-          ((c_sort & SORT_MASK) == SORT_THREADS))
+      if (OptRedrawTree && shared->mailbox &&
+          (shared->mailbox->msg_count != 0) && mutt_using_threads())
       {
         mutt_draw_tree(shared->ctx->threads);
         menu_queue_redraw(priv->menu, MENU_REDRAW_STATUS);
@@ -2008,8 +2012,7 @@ struct Mailbox *mutt_index_menu(struct MuttWindow *dlg, struct Mailbox *m_init)
           }
           menu_set_index(priv->menu, index);
 
-          const short c_sort = cs_subset_sort(shared->sub, "sort");
-          if ((shared->mailbox->msg_count != 0) && ((c_sort & SORT_MASK) == SORT_THREADS))
+          if ((shared->mailbox->msg_count != 0) && mutt_using_threads())
           {
             const bool c_collapse_all =
                 cs_subset_bool(shared->sub, "collapse_all");
@@ -2778,8 +2781,7 @@ struct Mailbox *mutt_index_menu(struct MuttWindow *dlg, struct Mailbox *m_init)
 
         OptNeedResort = false;
 
-        const short c_sort = cs_subset_sort(shared->sub, "sort");
-        if (((c_sort & SORT_MASK) == SORT_THREADS) && shared->email->collapsed)
+        if (mutt_using_threads() && shared->email->collapsed)
         {
           mutt_uncollapse_thread(shared->email);
           mutt_set_vnum(shared->mailbox);
@@ -2857,8 +2859,7 @@ struct Mailbox *mutt_index_menu(struct MuttWindow *dlg, struct Mailbox *m_init)
         if (!shared->email)
           break;
 
-        const short c_sort = cs_subset_sort(shared->sub, "sort");
-        if ((c_sort & SORT_MASK) != SORT_THREADS)
+        if (!mutt_using_threads())
           mutt_error(_("Threading is not enabled"));
         else if (!STAILQ_EMPTY(&shared->email->env->in_reply_to) ||
                  !STAILQ_EMPTY(&shared->email->env->references))
@@ -2902,8 +2903,7 @@ struct Mailbox *mutt_index_menu(struct MuttWindow *dlg, struct Mailbox *m_init)
         if (!shared->email)
           break;
 
-        const short c_sort = cs_subset_sort(shared->sub, "sort");
-        if ((c_sort & SORT_MASK) != SORT_THREADS)
+        if (!mutt_using_threads())
           mutt_error(_("Threading is not enabled"));
         else if (!shared->email->env->message_id)
           mutt_error(_("No Message-ID: header available to link thread"));
@@ -3094,8 +3094,7 @@ struct Mailbox *mutt_index_menu(struct MuttWindow *dlg, struct Mailbox *m_init)
         const int saved_current = menu_get_index(priv->menu);
         int mcur = saved_current;
         int index = -1;
-        const short c_sort = cs_subset_sort(shared->sub, "sort");
-        const bool threaded = ((c_sort & SORT_MASK) == SORT_THREADS);
+        const bool threaded = mutt_using_threads();
         for (size_t i = 0; i != shared->mailbox->vcount; i++)
         {
           if ((op == OP_MAIN_NEXT_NEW) || (op == OP_MAIN_NEXT_UNREAD) ||
@@ -3444,8 +3443,7 @@ struct Mailbox *mutt_index_menu(struct MuttWindow *dlg, struct Mailbox *m_init)
         if (!prereq(shared->ctx, priv->menu, CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE))
           break;
 
-        const short c_sort = cs_subset_sort(shared->sub, "sort");
-        if ((c_sort & SORT_MASK) != SORT_THREADS)
+        if (!mutt_using_threads())
         {
           mutt_error(_("Threading is not enabled"));
           break;
@@ -3485,8 +3483,7 @@ struct Mailbox *mutt_index_menu(struct MuttWindow *dlg, struct Mailbox *m_init)
         if (!prereq(shared->ctx, priv->menu, CHECK_IN_MAILBOX))
           break;
 
-        const short c_sort = cs_subset_sort(shared->sub, "sort");
-        if ((c_sort & SORT_MASK) != SORT_THREADS)
+        if (!mutt_using_threads())
         {
           mutt_error(_("Threading is not enabled"));
           break;

--- a/index/index.c
+++ b/index/index.c
@@ -134,7 +134,6 @@ static int config_sort(const struct ConfigSubset *sub)
      * observer for $sort will be a no-op.
      */
     short c_sort_aux = cs_subset_sort(sub, "sort_aux");
-    c_sort_aux &= ~SORT_LAST;
     c_sort_aux ^= (c_sort & SORT_REVERSE);
     rc = cs_subset_str_native_set(sub, "sort", c_sort_aux, NULL);
   }
@@ -168,7 +167,7 @@ static int config_use_threads(const struct ConfigSubset *sub)
    * no-op.
    */
   const short c_sort_aux = cs_subset_sort(sub, "sort_aux");
-  int rc = cs_subset_str_native_set(sub, "sort", c_sort_aux & ~SORT_LAST, NULL);
+  int rc = cs_subset_str_native_set(sub, "sort", c_sort_aux, NULL);
   return (CSR_RESULT(rc) == CSR_SUCCESS) ? 0 : -1;
 }
 

--- a/mutt_config.c
+++ b/mutt_config.c
@@ -568,7 +568,7 @@ static struct ConfigDef MainVars[] = {
   { "sleep_time", DT_NUMBER|DT_NOT_NEGATIVE, 1, 0, NULL,
     "Time to pause after certain info messages"
   },
-  { "sort", DT_SORT|R_INDEX|R_RESORT|DT_SORT_REVERSE, SORT_DATE, IP SortMethods, NULL,
+  { "sort", DT_SORT|DT_SORT_REVERSE|DT_SORT_LAST|R_INDEX|R_RESORT, SORT_DATE, IP SortMethods, sort_validator,
     "Sort method for the index"
   },
   { "sort_aux", DT_SORT|DT_SORT_REVERSE|DT_SORT_LAST|R_INDEX|R_RESORT|R_RESORT_SUB, SORT_DATE, IP SortAuxMethods, NULL,

--- a/mutt_config.c
+++ b/mutt_config.c
@@ -128,31 +128,11 @@ int multipart_validator(const struct ConfigSet *cs, const struct ConfigDef *cdef
 }
 
 /**
- * pager_validator - Check for config variables that can't be set from the pager - Implements ConfigDef::validator()
- */
-int pager_validator(const struct ConfigSet *cs, const struct ConfigDef *cdef,
-                    intptr_t value, struct Buffer *err)
-{
-  const enum MenuType mtype = menu_get_current_type();
-  if (mtype == MENU_PAGER)
-  {
-    mutt_buffer_printf(err, _("Option %s may not be set or reset from the pager"),
-                       cdef->name);
-    return CSR_ERR_INVALID;
-  }
-
-  return CSR_SUCCESS;
-}
-
-/**
  * reply_validator - Validate the "reply_regex" config variable - Implements ConfigDef::validator()
  */
 int reply_validator(const struct ConfigSet *cs, const struct ConfigDef *cdef,
                     intptr_t value, struct Buffer *err)
 {
-  if (pager_validator(cs, cdef, value, err) != CSR_SUCCESS)
-    return CSR_ERR_INVALID;
-
   if (!OptAttachMsg)
     return CSR_SUCCESS;
 
@@ -283,7 +263,7 @@ static struct ConfigDef MainVars[] = {
   { "display_filter", DT_STRING|DT_COMMAND|R_PAGER, 0, 0, NULL,
     "External command to pre-process an email before display"
   },
-  { "duplicate_threads", DT_BOOL|R_RESORT|R_RESORT_INIT|R_INDEX, true, 0, pager_validator,
+  { "duplicate_threads", DT_BOOL|R_RESORT|R_RESORT_INIT|R_INDEX, true, 0, NULL,
     "Highlight messages with duplicated message IDs"
   },
   { "editor", DT_STRING|DT_NOT_EMPTY|DT_COMMAND, 0, 0, NULL,
@@ -587,7 +567,7 @@ static struct ConfigDef MainVars[] = {
   { "sleep_time", DT_NUMBER|DT_NOT_NEGATIVE, 1, 0, NULL,
     "Time to pause after certain info messages"
   },
-  { "sort", DT_SORT|R_INDEX|R_RESORT|DT_SORT_REVERSE, SORT_DATE, IP SortMethods, pager_validator,
+  { "sort", DT_SORT|R_INDEX|R_RESORT|DT_SORT_REVERSE, SORT_DATE, IP SortMethods, NULL,
     "Sort method for the index"
   },
   { "sort_aux", DT_SORT|DT_SORT_REVERSE|DT_SORT_LAST|R_INDEX|R_RESORT|R_RESORT_SUB, SORT_DATE, IP SortAuxMethods, NULL,
@@ -596,7 +576,7 @@ static struct ConfigDef MainVars[] = {
   { "sort_browser", DT_SORT|DT_SORT_REVERSE, SORT_ALPHA, IP SortBrowserMethods, NULL,
     "Sort method for the browser"
   },
-  { "sort_re", DT_BOOL|R_INDEX|R_RESORT|R_RESORT_INIT, true, 0, pager_validator,
+  { "sort_re", DT_BOOL|R_INDEX|R_RESORT|R_RESORT_INIT, true, 0, NULL,
     "Whether $reply_regex must be matched when not $strict_threads"
   },
   { "spam_separator", DT_STRING, IP ",", 0, NULL,
@@ -614,7 +594,7 @@ static struct ConfigDef MainVars[] = {
   { "status_on_top", DT_BOOL, false, 0, NULL,
     "Display the status bar at the top"
   },
-  { "strict_threads", DT_BOOL|R_RESORT|R_RESORT_INIT|R_INDEX, false, 0, pager_validator,
+  { "strict_threads", DT_BOOL|R_RESORT|R_RESORT_INIT|R_INDEX, false, 0, NULL,
     "Thread messages using 'In-Reply-To' and 'References' headers"
   },
   { "suspend", DT_BOOL, true, 0, NULL,
@@ -623,7 +603,7 @@ static struct ConfigDef MainVars[] = {
   { "text_flowed", DT_BOOL, false, 0, NULL,
     "Generate 'format=flowed' messages"
   },
-  { "thread_received", DT_BOOL|R_RESORT|R_RESORT_INIT|R_INDEX, false, 0, pager_validator,
+  { "thread_received", DT_BOOL|R_RESORT|R_RESORT_INIT|R_INDEX, false, 0, NULL,
     "Sort threaded messages by their received date"
   },
   { "time_inc", DT_NUMBER|DT_NOT_NEGATIVE, 0, 0, NULL,

--- a/mutt_config.c
+++ b/mutt_config.c
@@ -589,7 +589,7 @@ static struct ConfigDef MainVars[] = {
   { "status_chars", DT_MBTABLE|R_INDEX|R_PAGER, IP "-*%A", 0, NULL,
     "Indicator characters for the status bar"
   },
-  { "status_format", DT_STRING|R_INDEX|R_PAGER, IP "-%r-NeoMutt: %D [Msgs:%?M?%M/?%m%?n? New:%n?%?o? Old:%o?%?d? Del:%d?%?F? Flag:%F?%?t? Tag:%t?%?p? Post:%p?%?b? Inc:%b?%?l? %l?]---(%s/%S)-%>-(%P)---", 0, NULL,
+  { "status_format", DT_STRING|R_INDEX|R_PAGER, IP "-%r-NeoMutt: %D [Msgs:%?M?%M/?%m%?n? New:%n?%?o? Old:%o?%?d? Del:%d?%?F? Flag:%F?%?t? Tag:%t?%?p? Post:%p?%?b? Inc:%b?%?l? %l?]---(%?T?%T/?%s/%S)-%>-(%P)---", 0, NULL,
     "printf-like format string for the index's status line"
   },
   { "status_on_top", DT_BOOL, false, 0, NULL,

--- a/mutt_config.c
+++ b/mutt_config.c
@@ -37,6 +37,7 @@
 #include "menu/lib.h"
 #include "init.h"
 #include "mutt_logging.h"
+#include "mutt_thread.h"
 #include "mx.h"
 #include "options.h"
 
@@ -635,6 +636,9 @@ static struct ConfigDef MainVars[] = {
   },
   { "use_domain", DT_BOOL, true, 0, NULL,
     "Qualify local addresses using this domain"
+  },
+  { "use_threads", DT_ENUM|R_INDEX|R_RESORT, UT_UNSET, IP &UseThreadsTypeDef, NULL,
+    "Whether to use threads for the index"
   },
   { "wait_key", DT_BOOL, true, 0, NULL,
     "Prompt to press a key after running external commands"

--- a/mutt_thread.c
+++ b/mutt_thread.c
@@ -101,6 +101,16 @@ enum UseThreads mutt_thread_style(void)
 }
 
 /**
+ * get_use_threads_str - Convert UseThreads enum to string
+ * @param value Value to convert
+ * @retval string form of value
+ */
+const char *get_use_threads_str(enum UseThreads value)
+{
+  return mutt_map_get_name(value, UseThreadsMethods);
+}
+
+/**
  * sort_validator - Validate values of "sort" - Implements ConfigDef::validator()
  */
 int sort_validator(const struct ConfigSet *cs, const struct ConfigDef *cdef,

--- a/mutt_thread.c
+++ b/mutt_thread.c
@@ -51,7 +51,8 @@ struct ThreadsContext
   struct Mailbox *mailbox; ///< Current mailbox
   struct MuttThread *tree; ///< Top of thread tree
   struct HashTable *hash;  ///< Hash table for threads
-  short c_sort;            ///< Sort method
+  short c_sort;            ///< Last sort method
+  short c_sort_aux;        ///< Last sort_aux method
 };
 
 /**
@@ -97,6 +98,20 @@ enum UseThreads mutt_thread_style(void)
   if (c_sort & SORT_REVERSE)
     return UT_REVERSE;
   return UT_THREADS;
+}
+
+/**
+ * sort_validator - Validate values of "sort" - Implements ConfigDef::validator()
+ */
+int sort_validator(const struct ConfigSet *cs, const struct ConfigDef *cdef,
+                   intptr_t value, struct Buffer *err)
+{
+  if (((value & SORT_MASK) == SORT_THREADS) && (value & SORT_LAST))
+  {
+    mutt_buffer_printf(err, _("Cannot use 'last-' prefix with 'threads' for %s"), cdef->name);
+    return CSR_ERR_INVALID;
+  }
+  return CSR_SUCCESS;
 }
 
 /**
@@ -722,8 +737,17 @@ static int compare_threads(const void *a, const void *b, void *arg)
   assert(ta->parent == tb->parent);
   /* If c_sort ties, remember we are building the thread array in
    * reverse from the index the mails had in the mailbox.  */
-  return mutt_compare_emails(ta->sort_key, tb->sort_key, mx_type(tctx->mailbox),
-                             tctx->c_sort, SORT_REVERSE | SORT_ORDER);
+  if (ta->parent)
+  {
+    return mutt_compare_emails(ta->sort_aux_key, tb->sort_aux_key, mx_type(tctx->mailbox),
+                               tctx->c_sort_aux, SORT_REVERSE | SORT_ORDER);
+  }
+  else
+  {
+    return mutt_compare_emails(ta->sort_thread_key, tb->sort_thread_key,
+                               mx_type(tctx->mailbox), tctx->c_sort,
+                               SORT_REVERSE | SORT_ORDER);
+  }
 }
 
 /**
@@ -738,7 +762,8 @@ static void mutt_sort_subthreads(struct ThreadsContext *tctx, bool init)
     return;
 
   struct MuttThread **array = NULL, *top = NULL, *tmp = NULL;
-  struct Email *sort_key = NULL, *oldsort_key = NULL;
+  struct Email *sort_aux_key = NULL, *oldsort_aux_key = NULL;
+  struct Email *oldsort_thread_key = NULL;
   int i, array_size;
   bool sort_top = false;
 
@@ -746,9 +771,23 @@ static void mutt_sort_subthreads(struct ThreadsContext *tctx, bool init)
    * but we want to have to move less stuff around if we're
    * resorting, so we sort backwards and then put them back
    * in reverse order so they're forwards */
-  short c_sort = cs_subset_sort(NeoMutt->sub, "sort_aux");
+  const bool reverse = (mutt_thread_style() == UT_REVERSE);
+  short c_sort = cs_subset_sort(NeoMutt->sub, "sort");
+  short c_sort_aux = cs_subset_sort(NeoMutt->sub, "sort_aux");
+  if ((c_sort & SORT_MASK) == SORT_THREADS)
+  {
+    assert(!(c_sort & SORT_REVERSE) != reverse);
+    assert(cs_subset_enum(NeoMutt->sub, "use_threads") == UT_UNSET);
+    c_sort = c_sort_aux;
+  }
   c_sort ^= SORT_REVERSE;
-  tctx->c_sort = c_sort;
+  c_sort_aux ^= SORT_REVERSE;
+  if (init || tctx->c_sort != c_sort || tctx->c_sort_aux != c_sort_aux)
+  {
+    tctx->c_sort = c_sort;
+    tctx->c_sort_aux = c_sort_aux;
+    init = true;
+  }
 
   top = thread;
 
@@ -756,9 +795,10 @@ static void mutt_sort_subthreads(struct ThreadsContext *tctx, bool init)
   array = mutt_mem_calloc(array_size, sizeof(struct MuttThread *));
   while (true)
   {
-    if (init || !thread->sort_key)
+    if (init || !thread->sort_thread_key || !thread->sort_aux_key)
     {
-      thread->sort_key = NULL;
+      thread->sort_thread_key = NULL;
+      thread->sort_aux_key = NULL;
 
       if (thread->parent)
         thread->parent->sort_children = true;
@@ -774,7 +814,8 @@ static void mutt_sort_subthreads(struct ThreadsContext *tctx, bool init)
     else
     {
       /* if it has no children, it must be real. sort it on its own merits */
-      thread->sort_key = thread->message;
+      thread->sort_thread_key = thread->message;
+      thread->sort_aux_key = thread->message;
 
       if (thread->next)
       {
@@ -821,33 +862,72 @@ static void mutt_sort_subthreads(struct ThreadsContext *tctx, bool init)
         tmp = thread;
         thread = thread->parent;
 
-        if (!thread->sort_key || thread->sort_children)
+        if (!thread->sort_thread_key || !thread->sort_aux_key || thread->sort_children)
         {
-          /* make sort_key the first or last sibling, as appropriate */
-          sort_key = ((!(c_sort & SORT_LAST)) ^ (!(c_sort & SORT_REVERSE))) ?
-                         thread->child->sort_key :
-                         tmp->sort_key;
-
           /* we just sorted its children */
           thread->sort_children = false;
 
-          oldsort_key = thread->sort_key;
-          thread->sort_key = thread->message;
+          oldsort_aux_key = thread->sort_aux_key;
+          oldsort_thread_key = thread->sort_thread_key;
 
-          if (c_sort & SORT_LAST)
+          /* update sort keys. sort_aux_key will be the first or last
+           * sibling, as appropriate... */
+          thread->sort_aux_key = thread->message;
+          sort_aux_key = ((!(c_sort_aux & SORT_LAST)) ^ (!(c_sort_aux & SORT_REVERSE))) ?
+                             thread->child->sort_aux_key :
+                             tmp->sort_aux_key;
+
+          if (c_sort_aux & SORT_LAST)
           {
-            if (!thread->sort_key ||
-                (mutt_compare_emails(thread->sort_key, sort_key, mx_type(tctx->mailbox),
-                                     c_sort | SORT_REVERSE, SORT_ORDER) > 0))
+            if (!thread->sort_aux_key ||
+                (mutt_compare_emails(thread->sort_aux_key, sort_aux_key, mx_type(tctx->mailbox),
+                                     c_sort_aux | SORT_REVERSE, SORT_ORDER) > 0))
             {
-              thread->sort_key = sort_key;
+              thread->sort_aux_key = sort_aux_key;
             }
           }
-          else if (!thread->sort_key)
-            thread->sort_key = sort_key;
+          else if (!thread->sort_aux_key)
+            thread->sort_aux_key = sort_aux_key;
 
-          /* if its sort_key has changed, we need to resort it and siblings */
-          if (oldsort_key != thread->sort_key)
+          /* ...but sort_thread_key may require searching the entire
+           * list of siblings */
+          if ((c_sort_aux & ~SORT_REVERSE) == (c_sort & ~SORT_REVERSE))
+          {
+            thread->sort_thread_key = thread->sort_aux_key;
+          }
+          else
+          {
+            if (thread->message)
+            {
+              thread->sort_thread_key = thread->message;
+            }
+            else if (reverse != (!(c_sort_aux & SORT_REVERSE)))
+            {
+              thread->sort_thread_key = tmp->sort_thread_key;
+            }
+            else
+            {
+              thread->sort_thread_key = thread->child->sort_thread_key;
+            }
+            if (c_sort & SORT_LAST)
+            {
+              for (tmp = thread->child; tmp; tmp = tmp->next)
+              {
+                if (tmp->sort_thread_key == thread->sort_thread_key)
+                  continue;
+                if ((mutt_compare_emails(thread->sort_thread_key, tmp->sort_thread_key,
+                                         mx_type(tctx->mailbox),
+                                         c_sort | SORT_REVERSE, SORT_ORDER) > 0))
+                {
+                  thread->sort_thread_key = tmp->sort_thread_key;
+                }
+              }
+            }
+          }
+
+          /* if a sort_key has changed, we need to resort it and siblings */
+          if ((oldsort_aux_key != thread->sort_aux_key) ||
+              (oldsort_thread_key != thread->sort_thread_key))
           {
             if (thread->parent)
               thread->parent->sort_children = true;
@@ -998,7 +1078,8 @@ void mutt_sort_threads(struct ThreadsContext *tctx, bool init)
             tmp = thread->parent;
             unlink_message(&tmp->child, thread);
             thread->parent = NULL;
-            thread->sort_key = NULL;
+            thread->sort_thread_key = NULL;
+            thread->sort_aux_key = NULL;
             thread->fake_thread = false;
             thread = tmp;
           } while (thread != &top && !thread->child && !thread->message);

--- a/mutt_thread.c
+++ b/mutt_thread.c
@@ -55,14 +55,43 @@ struct ThreadsContext
 };
 
 /**
+ * UseThreadsMethods - Choices for '$use_threads' for the index
+ */
+static const struct Mapping UseThreadsMethods[] = {
+  // clang-format off
+  { "unset",         UT_UNSET },
+  { "flat",          UT_FLAT },
+  { "threads",       UT_THREADS },
+  { "reverse",       UT_REVERSE },
+  // aliases
+  { "no",            UT_FLAT },
+  { "yes",           UT_THREADS },
+  { NULL,            0 },
+  // clang-format on
+};
+
+struct EnumDef UseThreadsTypeDef = {
+  "use_threads_type",
+  4,
+  (struct Mapping *) &UseThreadsMethods,
+};
+
+/**
  * mutt_thread_style - Which threading style is active?
  * @retval UT_FLAT    No threading in use
  * @retval UT_THREADS Normal threads (root above subthread)
  * @retval UT_REVERSE Reverse threads (subthread above root)
+ *
+ * @note UT_UNSET is never returned; rather, this function considers the
+ *       interaction between $use_threads and $sort.
  */
 enum UseThreads mutt_thread_style(void)
 {
+  const unsigned char c_use_threads =
+      cs_subset_enum(NeoMutt->sub, "use_threads");
   const short c_sort = cs_subset_sort(NeoMutt->sub, "sort");
+  if (c_use_threads > UT_FLAT)
+    return c_use_threads;
   if ((c_sort & SORT_MASK) != SORT_THREADS)
     return UT_FLAT;
   if (c_sort & SORT_REVERSE)

--- a/mutt_thread.h
+++ b/mutt_thread.h
@@ -72,14 +72,17 @@ enum MessageInThread
 };
 
 /**
- * enum UseThreads - Which threading style is active
+ * enum UseThreads - Which threading style is active, $use_threads
  */
 enum UseThreads
 {
+  UT_UNSET,     ///< Not yet set by user, stick to legacy semantics
   UT_FLAT,      ///< Unthreaded
   UT_THREADS,   ///< Normal threading (root above subthreads)
   UT_REVERSE,   ///< Reverse threading (subthreads above root)
 };
+
+extern struct EnumDef UseThreadsTypeDef;
 
 int mutt_traverse_thread(struct Email *e, MuttThreadFlags flag);
 #define mutt_collapse_thread(e)         mutt_traverse_thread(e, MUTT_THREAD_COLLAPSE)

--- a/mutt_thread.h
+++ b/mutt_thread.h
@@ -93,6 +93,7 @@ int mutt_traverse_thread(struct Email *e, MuttThreadFlags flag);
 
 enum UseThreads mutt_thread_style(void);
 #define mutt_using_threads() (mutt_thread_style() > UT_FLAT)
+const char *get_use_threads_str(enum UseThreads value);
 int sort_validator(const struct ConfigSet *cs, const struct ConfigDef *cdef,
                    intptr_t value, struct Buffer *err);
 

--- a/mutt_thread.h
+++ b/mutt_thread.h
@@ -71,12 +71,25 @@ enum MessageInThread
   MIT_POSITION,     // Our position in the thread
 };
 
+/**
+ * enum UseThreads - Which threading style is active
+ */
+enum UseThreads
+{
+  UT_FLAT,      ///< Unthreaded
+  UT_THREADS,   ///< Normal threading (root above subthreads)
+  UT_REVERSE,   ///< Reverse threading (subthreads above root)
+};
+
 int mutt_traverse_thread(struct Email *e, MuttThreadFlags flag);
 #define mutt_collapse_thread(e)         mutt_traverse_thread(e, MUTT_THREAD_COLLAPSE)
 #define mutt_uncollapse_thread(e)       mutt_traverse_thread(e, MUTT_THREAD_UNCOLLAPSE)
 #define mutt_thread_contains_unread(e)  mutt_traverse_thread(e, MUTT_THREAD_UNREAD)
 #define mutt_thread_contains_flagged(e) mutt_traverse_thread(e, MUTT_THREAD_FLAGGED)
 #define mutt_thread_next_unread(e)      mutt_traverse_thread(e, MUTT_THREAD_NEXT_UNREAD)
+
+enum UseThreads mutt_thread_style(void);
+#define mutt_using_threads() (mutt_thread_style() > UT_FLAT)
 
 int mutt_aside_thread(struct Email *e, bool forwards, bool subthreads);
 #define mutt_next_thread(e)        mutt_aside_thread(e, true,  false)

--- a/mutt_thread.h
+++ b/mutt_thread.h
@@ -93,6 +93,8 @@ int mutt_traverse_thread(struct Email *e, MuttThreadFlags flag);
 
 enum UseThreads mutt_thread_style(void);
 #define mutt_using_threads() (mutt_thread_style() > UT_FLAT)
+int sort_validator(const struct ConfigSet *cs, const struct ConfigDef *cdef,
+                   intptr_t value, struct Buffer *err);
 
 int mutt_aside_thread(struct Email *e, bool forwards, bool subthreads);
 #define mutt_next_thread(e)        mutt_aside_thread(e, true,  false)

--- a/score.c
+++ b/score.c
@@ -40,6 +40,7 @@
 #include "init.h"
 #include "mutt_commands.h"
 #include "mutt_globals.h"
+#include "mutt_thread.h"
 #include "options.h"
 #include "protos.h"
 
@@ -71,7 +72,7 @@ void mutt_check_rescore(struct Mailbox *m)
     if (((c_sort & SORT_MASK) == SORT_SCORE) || ((c_sort_aux & SORT_MASK) == SORT_SCORE))
     {
       OptNeedResort = true;
-      if ((c_sort & SORT_MASK) == SORT_THREADS)
+      if (mutt_using_threads())
         OptSortSubthreads = true;
     }
 

--- a/sort.c
+++ b/sort.c
@@ -397,9 +397,8 @@ void mutt_sort_headers(struct Mailbox *m, struct ThreadsContext *threads,
   if (init)
     mutt_clear_threads(threads);
 
-  const short c_sort = cs_subset_sort(NeoMutt->sub, "sort");
-  const short c_sort_aux = cs_subset_sort(NeoMutt->sub, "sort_aux");
-  if ((c_sort & SORT_MASK) == SORT_THREADS)
+  const bool threaded = mutt_using_threads();
+  if (threaded)
   {
     mutt_sort_threads(threads, init);
   }
@@ -407,8 +406,8 @@ void mutt_sort_headers(struct Mailbox *m, struct ThreadsContext *threads,
   {
     struct EmailCompare cmp;
     cmp.type = mx_type(m);
-    cmp.sort = c_sort;
-    cmp.sort_aux = c_sort_aux;
+    cmp.sort = cs_subset_sort(NeoMutt->sub, "sort");
+    cmp.sort_aux = cs_subset_sort(NeoMutt->sub, "sort_aux");
     mutt_qsort_r((void *) m->emails, m->msg_count, sizeof(struct Email *),
                  compare_email_shim, &cmp);
   }
@@ -431,7 +430,7 @@ void mutt_sort_headers(struct Mailbox *m, struct ThreadsContext *threads,
   }
 
   /* re-collapse threads marked as collapsed */
-  if ((c_sort & SORT_MASK) == SORT_THREADS)
+  if (threaded)
   {
     mutt_thread_collapse_collapsed(threads);
     *vsize = mutt_set_vnum(m);

--- a/status.c
+++ b/status.c
@@ -41,6 +41,7 @@
 #include "format_flags.h"
 #include "mutt_globals.h"
 #include "mutt_mailbox.h"
+#include "mutt_thread.h"
 #include "muttlib.h"
 #include "options.h"
 #include "protos.h"
@@ -92,6 +93,7 @@ struct MenuStatusLineData
  * | \%r     | Readonly/wontwrite/changed flag
  * | \%S     | Current aux sorting method (`$sort_aux`)
  * | \%s     | Current sorting method (`$sort`)
+ * | \%T     | Current threading view (`$use_threads`)
  * | \%t     | Number of tagged messages
  * | \%u     | Number of unread messages
  * | \%V     | Currently active limit pattern
@@ -366,6 +368,19 @@ static const char *status_format_str(char *buf, size_t buflen, size_t col, int c
         snprintf(buf, buflen, fmt, num);
       }
       else if (num == 0)
+        optional = false;
+      break;
+    }
+
+    case 'T':
+    {
+      const enum UseThreads c_use_threads = mutt_thread_style();
+      if (!optional)
+      {
+        snprintf(fmt, sizeof(fmt), "%%%ss", prec);
+        snprintf(buf, buflen, fmt, get_use_threads_str(c_use_threads));
+      }
+      else if (c_use_threads == UT_FLAT)
         optional = false;
       break;
     }


### PR DESCRIPTION
* **What does this PR do?**
Add $sort_thread so that I can finally sort emails in the same manner as Thunderbird.

* **Screenshots (if relevant)**
With the March 2021 neomutt-devel archives mbox, `ot:set sort_thread=last-date` produces the following (no combination of $sort and $sort_aux without this patch is able to achieve the same):
```
q:Quit  d:Del  u:Undel  s:Save  m:Mail  r:Reply  g:Group  ?:Help
   1 O   Mar 02 toogley         (  66) [neomutt-devel] Lua in neomutt | systemat
   2 O   Mar 02 Ihor Antonov    (  70) ├─>
   3 O   Mar 03 Pietro Cerutti  (  35) │ ├─>
   4 O   Mar 03 toogley         (  51) │ └─>
   5 O   Mar 03 Richard Russon  (  88) ├─>
   6 O   Mar 04 toogley         (  39) │ └─>
   7 O   Mar 03 Anton Rieger    (  23) └─>
   8 O   Mar 06 Richard Russon  (  33)   └─>
   9 O   Mar 06 Anton Rieger    (  32)     └─>
  10 O   Mar 06 toogley         (  61) [neomutt-devel] [PATCH] add -Werror and -
  11 O   Mar 06 Richard Russon  (  35) └─>
  12 O   Mar 06 toogley         (  48)   └─>
  13 O   Mar 06 Stuart Henderso (  44)     ├─>
  14 O   Mar 06 Anton Rieger    (  49)     ├─>
  15 O   Mar 06 Richard Russon  (  53)     └─>
  16 O   Mar 06 toogley         (  70)       └─>
  17 O   Mar 06 Richard Russon  (  43)         └─>
  18 O   Mar 06 toogley         (  24) [neomutt-devel] user-questions on github
  19 O   Mar 06 Ihor Antonov    (  35) ├─>
  20 O   Mar 06 Reto            (  18) │ └─>
  21 O   Mar 08 Pietro Cerutti  (  33) ├─>
  22     Mar 08 Richard Russon  (  24) └─>
  23 O   Mar 19 toogley         (  82) [neomutt-devel] using sourcehut as altern
  24 O   Mar 19 Richard Russon  (  37) ├─>[neomutt-devel] using sourcehut as alt
  25 O   Mar 20 Pietro Cerutti  (  40) │ └─>
  26 O   Mar 19 Ihor Antonov    ( 117) └─>[neomutt-devel] using sourcehut as alt
  27 O   Mar 20 Richard Russon  (  14)   └─>
  28 O   Mar 19 toogley         (  47) [neomutt-devel] [PATCH 1/2] remove dead c
  29 O   Mar 19 toogley         (  41) ├─>[neomutt-devel] [PATCH 2/2] remove unu
  30 O   Mar 20 Richard Russon  (  22) │ └─>
  31 O   Mar 20 Richard Russon  (  21) └─>[neomutt-devel] [PATCH 1/2] remove dea

---NeoMutt: ~/neomutt-sample-mail/2021-March.txt [Msgs:31 Old:30 67K]---(last-da


```
Of note: the thread [PATCH 1/2] has the most recent activity so it appears last, but within the thread, [PATCH 1/2] comes before [PATCH 2/2].  (The reply to PATCH 1/2 comes after the subthread for PATCH 2/2, but that's because it IS a sibling thread; on other mailing lists, senders include a 0/2 cover letter so that 1/2 and 2/2 are siblings rather than 1/2 a parent of 2/2).


* **Does this PR meet the acceptance criteria?** (This is just a reminder for you,
  this section can be removed if you fulfill it.)

   - Documentation created/updated (you have to edit
     [doc/manual.xml.head](https://www.github.com/neomutt/neomutt/blob/master/doc/manual.xml.head)
     for that)

   - All builds and tests are passing

   - Added [doxygen code documentation](https://neomutt.org/dev/doxygen)
     [syntax](http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html)

   - Code follows the [style guide](https://neomutt.org/dev/coding-style)

* **What are the relevant issue numbers?**
#2342 