### PR TITLE
sort: avoid assertion under <attach-message>

### DIFF
--- a/mutt_thread.c
+++ b/mutt_thread.c
@@ -1096,15 +1096,17 @@ void mutt_sort_threads(struct ThreadsContext *tctx, bool init)
 
   /* if $sort_aux or similar changed after the mailbox is sorted, then
    * all the subthreads need to be resorted */
-  assert(tctx->tree);
-  mutt_sort_subthreads(tctx, init || OptSortSubthreads);
-  OptSortSubthreads = false;
+  if (tctx->tree)
+  {
+    mutt_sort_subthreads(tctx, init || OptSortSubthreads);
+    OptSortSubthreads = false;
 
-  /* Put the list into an array. */
-  linearize_tree(tctx);
+    /* Put the list into an array. */
+    linearize_tree(tctx);
 
-  /* Draw the thread tree. */
-  mutt_draw_tree(tctx);
+    /* Draw the thread tree. */
+    mutt_draw_tree(tctx);
+  }
 }
 
 /**


### PR DESCRIPTION
Partially Fixes: https://github.com/neomutt/neomutt/issues/2996

Commit b698a6ab added an assert that tctx->tree was set and dropped an
'if', because I could not at the time find any scenario where we would
try sorting threads but not find any.  But in the meantime, I found
(at least) one: when using <attach-message> and selecting the same
folder as already being visited, and when no new mail has arrived in
the meantime, then ALL messages already have e->thread set, and there
is no need to sort subthreads.  But the comment behind the assert was
correct: in that code path, we forgot to restore the value of $sort
after temporarily munging it to the value of $sort_aux.

Later, commit aaa2ece04 changed things so that we no longer munge
$sort in the first place.  So now all we need to do is remove the
bogus assertion, while still restoring the 'if' to avoid unnecessary
work if there are no new threads that need subthread sorting.

Note that the issue of potentially leaving $sort munged to $sort_aux
if ctx->tree remains unset after searching for new threads is present
even in upstream mutt.  But upstream never saw the problem with
<attach-message> because it always opened a NEW mailbox context,
passing init=true.  It is only in neomutt (and possibly only with
notmuch folders, since I didn't manage to reproduce with maildir),
where we try harder to reuse an existing mailbox and pass init=false
while tctx->tree is still NULL.

* **What does this PR do?**

* **Screenshots (if relevant)**

* **Does this PR meet the acceptance criteria?** (This is just a reminder for you,
  this section can be removed if you fulfill it.)

   - Documentation created/updated (you have to edit
     [doc/manual.xml.head](https://www.github.com/neomutt/neomutt/blob/master/doc/manual.xml.head)
     for that)

   - All builds and tests are passing

   - Added [doxygen code documentation](https://neomutt.org/dev/doxygen)
     [syntax](http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html)

   - Code follows the [style guide](https://neomutt.org/dev/coding-style)

* **What are the relevant issue numbers?**
