### PR TITLE
notmuch: implement query window reset functionality

### DIFF
--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -16040,6 +16040,14 @@ virtual-mailboxes "My INBOX" "notmuch://?query=tag:inbox"
                   backward
                 </entry>
               </row>
+              <row>
+                <entry>index</entry>
+                <entry><literal>&lt;vfolder-window-reset&gt;</literal></entry>
+                <entry>
+                  generate virtual folder by moving the query's time window to
+                  the present
+                </entry>
+              </row>
             </tbody>
           </tgroup>
         </table>

--- a/functions.c
+++ b/functions.c
@@ -248,6 +248,7 @@ const struct Binding OpMain[] = { /* map: index */
   { "vfolder-from-query-readonly", OP_MAIN_VFOLDER_FROM_QUERY_READONLY, NULL },
   { "vfolder-window-backward",   OP_MAIN_WINDOWED_VFOLDER_BACKWARD, NULL },
   { "vfolder-window-forward",    OP_MAIN_WINDOWED_VFOLDER_FORWARD,  NULL },
+  { "vfolder-window-reset",      OP_MAIN_WINDOWED_VFOLDER_RESET,    NULL },
 #endif
   { "view-attachments",          OP_VIEW_ATTACHMENTS,               "v" },
   { "view-raw-message",          OP_VIEW_RAW_MESSAGE,               NULL },

--- a/index/dlg_index.c
+++ b/index/dlg_index.c
@@ -2429,6 +2429,33 @@ struct Mailbox *mutt_index_menu(struct MuttWindow *dlg, struct Mailbox *m_init)
         change_folder_notmuch(priv->menu, buf, sizeof(buf), &priv->oldcount, shared, false);
         break;
       }
+
+      case OP_MAIN_WINDOWED_VFOLDER_RESET:
+      {
+        if (!prereq(shared->ctx, priv->menu, CHECK_IN_MAILBOX))
+          break;
+        const short c_nm_query_window_duration =
+            cs_subset_number(shared->sub, "nm_query_window_duration");
+        const bool c_nm_query_window_enable =
+            cs_subset_bool(shared->sub, "nm_query_window_enable");
+        if (!c_nm_query_window_enable && (c_nm_query_window_duration <= 0))
+        {
+          mutt_message(_("Windowed queries disabled"));
+          break;
+        }
+        const char *const c_nm_query_window_current_search =
+            cs_subset_string(shared->sub, "nm_query_window_current_search");
+        if (!c_nm_query_window_current_search)
+        {
+          mutt_message(_("No notmuch vfolder currently loaded"));
+          break;
+        }
+        nm_query_window_reset();
+        char buf[PATH_MAX] = { 0 };
+        mutt_str_copy(buf, c_nm_query_window_current_search, sizeof(buf));
+        change_folder_notmuch(priv->menu, buf, sizeof(buf), &priv->oldcount, shared, false);
+        break;
+      }
 #endif
 
 #ifdef USE_SIDEBAR

--- a/index/dlg_index.c
+++ b/index/dlg_index.c
@@ -2377,53 +2377,10 @@ struct Mailbox *mutt_index_menu(struct MuttWindow *dlg, struct Mailbox *m_init)
       }
 
       case OP_MAIN_WINDOWED_VFOLDER_BACKWARD:
-      {
-        if (!prereq(shared->ctx, priv->menu, CHECK_IN_MAILBOX))
-          break;
-        if (!nm_query_window_available())
-        {
-          mutt_message(_("Windowed queries disabled"));
-          break;
-        }
-        const char *const c_nm_query_window_current_search =
-            cs_subset_string(shared->sub, "nm_query_window_current_search");
-        if (!c_nm_query_window_current_search)
-        {
-          mutt_message(_("No notmuch vfolder currently loaded"));
-          break;
-        }
-        nm_query_window_backward();
-        char buf[PATH_MAX] = { 0 };
-        mutt_str_copy(buf, c_nm_query_window_current_search, sizeof(buf));
-        change_folder_notmuch(priv->menu, buf, sizeof(buf), &priv->oldcount, shared, false);
-        break;
-      }
-
       case OP_MAIN_WINDOWED_VFOLDER_FORWARD:
-      {
-        if (!prereq(shared->ctx, priv->menu, CHECK_IN_MAILBOX))
-          break;
-        if (!nm_query_window_available())
-        {
-          mutt_message(_("Windowed queries disabled"));
-          break;
-        }
-        const char *const c_nm_query_window_current_search =
-            cs_subset_string(shared->sub, "nm_query_window_current_search");
-        if (!c_nm_query_window_current_search)
-        {
-          mutt_message(_("No notmuch vfolder currently loaded"));
-          break;
-        }
-        nm_query_window_forward();
-        char buf[PATH_MAX] = { 0 };
-        mutt_str_copy(buf, c_nm_query_window_current_search, sizeof(buf));
-        change_folder_notmuch(priv->menu, buf, sizeof(buf), &priv->oldcount, shared, false);
-        break;
-      }
-
       case OP_MAIN_WINDOWED_VFOLDER_RESET:
       {
+        // Common guard clauses.
         if (!prereq(shared->ctx, priv->menu, CHECK_IN_MAILBOX))
           break;
         if (!nm_query_window_available())
@@ -2438,7 +2395,22 @@ struct Mailbox *mutt_index_menu(struct MuttWindow *dlg, struct Mailbox *m_init)
           mutt_message(_("No notmuch vfolder currently loaded"));
           break;
         }
-        nm_query_window_reset();
+
+        // Call the specific operation.
+        switch (op)
+        {
+          case OP_MAIN_WINDOWED_VFOLDER_BACKWARD:
+            nm_query_window_backward();
+            break;
+          case OP_MAIN_WINDOWED_VFOLDER_FORWARD:
+            nm_query_window_forward();
+            break;
+          case OP_MAIN_WINDOWED_VFOLDER_RESET:
+            nm_query_window_reset();
+            break;
+        }
+
+        // Common query window folder change.
         char buf[PATH_MAX] = { 0 };
         mutt_str_copy(buf, c_nm_query_window_current_search, sizeof(buf));
         change_folder_notmuch(priv->menu, buf, sizeof(buf), &priv->oldcount, shared, false);

--- a/index/dlg_index.c
+++ b/index/dlg_index.c
@@ -2380,11 +2380,7 @@ struct Mailbox *mutt_index_menu(struct MuttWindow *dlg, struct Mailbox *m_init)
       {
         if (!prereq(shared->ctx, priv->menu, CHECK_IN_MAILBOX))
           break;
-        const short c_nm_query_window_duration =
-            cs_subset_number(shared->sub, "nm_query_window_duration");
-        const bool c_nm_query_window_enable =
-            cs_subset_bool(shared->sub, "nm_query_window_enable");
-        if (!c_nm_query_window_enable && (c_nm_query_window_duration <= 0))
+        if (!nm_query_window_available())
         {
           mutt_message(_("Windowed queries disabled"));
           break;
@@ -2407,11 +2403,7 @@ struct Mailbox *mutt_index_menu(struct MuttWindow *dlg, struct Mailbox *m_init)
       {
         if (!prereq(shared->ctx, priv->menu, CHECK_IN_MAILBOX))
           break;
-        const short c_nm_query_window_duration =
-            cs_subset_number(shared->sub, "nm_query_window_duration");
-        const bool c_nm_query_window_enable =
-            cs_subset_bool(shared->sub, "nm_query_window_enable");
-        if (!c_nm_query_window_enable && (c_nm_query_window_duration <= 0))
+        if (!nm_query_window_available())
         {
           mutt_message(_("Windowed queries disabled"));
           break;
@@ -2434,11 +2426,7 @@ struct Mailbox *mutt_index_menu(struct MuttWindow *dlg, struct Mailbox *m_init)
       {
         if (!prereq(shared->ctx, priv->menu, CHECK_IN_MAILBOX))
           break;
-        const short c_nm_query_window_duration =
-            cs_subset_number(shared->sub, "nm_query_window_duration");
-        const bool c_nm_query_window_enable =
-            cs_subset_bool(shared->sub, "nm_query_window_enable");
-        if (!c_nm_query_window_enable && (c_nm_query_window_duration <= 0))
+        if (!nm_query_window_available())
         {
           mutt_message(_("Windowed queries disabled"));
           break;

--- a/notmuch/lib.h
+++ b/notmuch/lib.h
@@ -60,6 +60,7 @@ bool  nm_message_is_still_queried(struct Mailbox *m, struct Email *e);
 enum MailboxType nm_path_probe   (const char *path, const struct stat *st);
 void  nm_query_window_backward   (void);
 void  nm_query_window_forward    (void);
+void  nm_query_window_reset      (void);
 int   nm_read_entire_thread      (struct Mailbox *m, struct Email *e);
 int   nm_record_message          (struct Mailbox *m, char *path, struct Email *e);
 int   nm_update_filename         (struct Mailbox *m, const char *old_file, const char *new_file, struct Email *e);

--- a/notmuch/lib.h
+++ b/notmuch/lib.h
@@ -58,6 +58,7 @@ char *nm_email_get_folder_rel_db (struct Mailbox *m, struct Email *e);
 int   nm_get_all_tags            (struct Mailbox *m, char **tag_list, int *tag_count);
 bool  nm_message_is_still_queried(struct Mailbox *m, struct Email *e);
 enum MailboxType nm_path_probe   (const char *path, const struct stat *st);
+bool  nm_query_window_available  (void);
 void  nm_query_window_backward   (void);
 void  nm_query_window_forward    (void);
 void  nm_query_window_reset      (void);

--- a/notmuch/notmuch.c
+++ b/notmuch/notmuch.c
@@ -1608,6 +1608,20 @@ char *nm_url_from_query(struct Mailbox *m, char *buf, size_t buflen)
 }
 
 /**
+ * nm_query_window_available - Are windowed queries enabled for use?
+ * @retval true Windowed queries in use
+ */
+bool nm_query_window_available(void)
+{
+  const short c_nm_query_window_duration =
+      cs_subset_number(NeoMutt->sub, "nm_query_window_duration");
+  const bool c_nm_query_window_enable =
+      cs_subset_bool(NeoMutt->sub, "nm_query_window_enable");
+
+  return c_nm_query_window_enable || (c_nm_query_window_duration > 0);
+}
+
+/**
  * nm_query_window_forward - Function to move the current search window forward in time
  *
  * Updates `nm_query_window_current_position` by decrementing it by 1, or does nothing

--- a/notmuch/notmuch.c
+++ b/notmuch/notmuch.c
@@ -1647,6 +1647,15 @@ void nm_query_window_backward(void)
 }
 
 /**
+ * nm_query_window_reset - Resets the vfolder window position to the present.
+ */
+void nm_query_window_reset(void)
+{
+  cs_subset_str_native_set(NeoMutt->sub, "nm_query_window_current_position", 0, NULL);
+  mutt_debug(LL_DEBUG2, "Reset nm_query_window_current_position to 0\n");
+}
+
+/**
  * nm_message_is_still_queried - Is a message still visible in the query?
  * @param m Mailbox
  * @param e Email

--- a/opcodes.h
+++ b/opcodes.h
@@ -291,7 +291,8 @@
   _fmt(OP_MAIN_VFOLDER_FROM_QUERY,        N_("generate virtual folder from query")) \
   _fmt(OP_MAIN_VFOLDER_FROM_QUERY_READONLY, N_("generate a read-only virtual folder from query")) \
   _fmt(OP_MAIN_WINDOWED_VFOLDER_BACKWARD, N_("shifts virtual folder time window backwards")) \
-  _fmt(OP_MAIN_WINDOWED_VFOLDER_FORWARD,  N_("shifts virtual folder time window forwards"))
+  _fmt(OP_MAIN_WINDOWED_VFOLDER_FORWARD,  N_("shifts virtual folder time window forwards")) \
+  _fmt(OP_MAIN_WINDOWED_VFOLDER_RESET,    N_("resets virtual folder time window to the present"))
 #else
 #define OPS_NOTMUCH(_)
 #endif


### PR DESCRIPTION
This PR adds a user function to reset the current query window position to the present. It's a quality of life improvement for notmuch users as there's no documented way to reset the position. While it's possible to use the undocumented config. variable `nm_query_window_current_position`, it's used for internal state keeping so not something a user should access. It's much better to give the user a function.

In addition to the feature, there's a refactor merging all the query window `index` code into a single code block because the only difference between them is the notmuch backend call. There's no need for duplication at this time.

---

@ebblake can you test this functionality to see if it matches your request in #2972