### PR TITLE
notmuch: show additional mail in query windows

### DIFF
--- a/docs/config.c
+++ b/docs/config.c
@@ -2621,6 +2621,12 @@
 ** Accepted values all non negative integers. A value of 0 disables the feature.
 */
 
+{ "nm_query_window_enable", DT_BOOL, false },
+/*
+** .pp
+** This variable enables windowed notmuch queries even if window duration is 0.
+*/
+
 { "nm_query_window_or_terms", DT_STRING, 0 },
 /*
 ** .pp

--- a/docs/config.c
+++ b/docs/config.c
@@ -2621,6 +2621,20 @@
 ** Accepted values all non negative integers. A value of 0 disables the feature.
 */
 
+{ "nm_query_window_or_terms", DT_STRING, 0 },
+/*
+** .pp
+** This variable contains additional notmuch search terms for messages to be
+** shown regardless of date.
+** .pp
+** Example:
+** .pp
+** Using "notmuch://?query=tag:inbox" as the mailbox and "tag:flagged and
+** tag:unread" as the or terms, NeoMutt will produce a query window such as:
+** .pp
+** notmuch://?query=tag:inbox and (date:... or (tag:flagged and tag:unread))
+*/
+
 { "nm_query_window_timebase", DT_STRING, "week" },
 /*
 ** .pp

--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -15947,6 +15947,20 @@ virtual-mailboxes "My INBOX" "notmuch://?query=tag:inbox"
                 </entry>
               </row>
               <row>
+                <entry><literal>nm_query_window_or_terms</literal></entry>
+                <entry>string</entry>
+                <entry><literal>(empty)</literal></entry>
+                <entry>
+                  Additional notmuch search terms to always include in the
+                  window even if they're outside the date range. This turns the
+                  window from <literal>date:...</literal> to 
+                  <literal>date:... or (additional search terms.)</literal>
+
+                  For example, to always include flagged, unread emails, set to
+                  <literal>tag:flagged and tag:unread</literal>
+                </entry>
+              </row>
+              <row>
                 <entry><literal>nm_query_window_timebase</literal></entry>
                 <entry>string</entry>
                 <entry><literal>week</literal></entry>
@@ -16164,6 +16178,8 @@ set virtual_spool_file = no
 set nm_query_window_enable=yes
 set nm_query_window_duration=2
 set nm_query_window_timebase="week" # or "hour", "day", "week", "month", "year"
+<emphasis role="comment"># Extend query window to always show mail matching these terms.</emphasis>
+set nm_query_window_or_terms="tag:unread and tag:flagged"
 <emphasis role="comment"># --------------------------------------------------------------------------</emphasis>
 <emphasis role="comment"># FUNCTIONS – shown with an example mapping</emphasis>
 <emphasis role="comment"># --------------------------------------------------------------------------</emphasis>

--- a/notmuch/config.c
+++ b/notmuch/config.c
@@ -122,6 +122,9 @@ static struct ConfigDef NotmuchVars[] = {
   { "nm_query_window_enable", DT_BOOL, false, 0, NULL,
     "(notmuch) Enable query windows"
   },
+  { "nm_query_window_or_terms", DT_STRING, 0, 0, NULL,
+    "(notmuch) Additional notmuch search terms for messages to be shown regardless of date"
+  },
   { "nm_query_window_timebase", DT_STRING, IP "week", 0, nm_query_window_timebase_validator,
     "(notmuch) Units for the time duration"
   },

--- a/notmuch/notmuch.c
+++ b/notmuch/notmuch.c
@@ -282,6 +282,8 @@ static bool windowed_query_from_query(const char *query, char *buf, size_t bufle
       cs_subset_string(NeoMutt->sub, "nm_query_window_current_search");
   const char *const c_nm_query_window_timebase =
       cs_subset_string(NeoMutt->sub, "nm_query_window_timebase");
+  const char *const c_nm_query_window_or_terms =
+      cs_subset_string(NeoMutt->sub, "nm_query_window_or_terms");
 
   /* if the query has changed, reset the window position */
   if (!c_nm_query_window_current_search ||
@@ -293,7 +295,7 @@ static bool windowed_query_from_query(const char *query, char *buf, size_t bufle
   enum NmWindowQueryRc rc = nm_windowed_query_from_query(
       buf, buflen, c_nm_query_window_enable, c_nm_query_window_duration,
       c_nm_query_window_current_position, c_nm_query_window_current_search,
-      c_nm_query_window_timebase);
+      c_nm_query_window_timebase, c_nm_query_window_or_terms);
 
   switch (rc)
   {

--- a/notmuch/query.c
+++ b/notmuch/query.c
@@ -167,6 +167,7 @@ bool nm_query_window_check_timebase(const char *timebase)
  * @param[in]  cur_search Current notmuch search
  * @param[in]  timebase Timebase for `date:` search term. Must be: `hour`,
  *                      `day`, `week`, `month`, or `year`
+ * @param[in]  or_terms Additional notmuch search terms
  * @retval NM_WINDOW_QUERY_SUCCESS  Prepended `buf` with `date:` search term
  * @retval NM_WINDOW_QUERY_INVALID_DURATION Duration out-of-range for search term. `buf` *not* prepended with `date:`
  * @retval NM_WINDOW_QUERY_INVALID_TIMEBASE Timebase isn't one of `hour`, `day`, `week`, `month`, or `year`
@@ -203,8 +204,8 @@ bool nm_query_window_check_timebase(const char *timebase)
  */
 enum NmWindowQueryRc
 nm_windowed_query_from_query(char *buf, size_t buflen, const bool force_enable,
-                             const short duration, const short cur_pos,
-                             const char *cur_search, const char *timebase)
+                             const short duration, const short cur_pos, const char *cur_search,
+                             const char *timebase, const char *or_terms)
 {
   // if the duration is a non positive integer, disable the window unless the
   // user explicitly enables windowed queries.
@@ -229,16 +230,27 @@ nm_windowed_query_from_query(char *buf, size_t buflen, const bool force_enable,
     return NM_WINDOW_QUERY_INVALID_TIMEBASE;
   }
 
+  size_t length = 0;
   if (end == 0)
   {
     // Open-ended date allows mail from the future.
     // This may occur is the sender's time settings are off.
-    snprintf(buf, buflen, "date:%d%s.. and %s", beg, timebase, cur_search);
+    length = snprintf(buf, buflen, "date:%d%s..", beg, timebase);
   }
   else
   {
-    snprintf(buf, buflen, "date:%d%s..%d%s and %s", beg, timebase, end, timebase, cur_search);
+    length = snprintf(buf, buflen, "date:%d%s..%d%s", beg, timebase, end, timebase);
   }
+
+  if (!mutt_str_equal(or_terms, ""))
+  {
+    char *date_part = mutt_str_dup(buf);
+    length = snprintf(buf, buflen, "(%s or (%s))", date_part, or_terms);
+    FREE(&date_part);
+  }
+
+  // Add current search to window query.
+  snprintf(buf + length, buflen, " and %s", cur_search);
 
   return NM_WINDOW_QUERY_SUCCESS;
 }

--- a/notmuch/query.h
+++ b/notmuch/query.h
@@ -55,7 +55,8 @@ const char *nm_query_type_to_string(enum NmQueryType query_type);
 enum NmWindowQueryRc
 nm_windowed_query_from_query(char *buf, size_t buflen, const bool force_enable,
                              const short duration, const short current_pos,
-                             const char *current_search, const char *timebase);
+                             const char *current_search, const char *timebase,
+                             const char *or_terms);
 bool nm_query_window_check_timebase(const char *timebase);
 
 #endif /* MUTT_NOTMUCH_QUERY_H */

--- a/test/notmuch/window_query.c
+++ b/test/notmuch/window_query.c
@@ -33,6 +33,7 @@ struct TestCase
   int cur_pos;
   char *curr_search;
   char *timebase;
+  char *or_terms;
   char *expected;
 };
 
@@ -42,7 +43,7 @@ void test_nm_windowed_query_from_query(void)
   {
     char buf[1024] = "\0";
     enum NmWindowQueryRc rc =
-        nm_windowed_query_from_query(buf, 1024, false, 0, 0, "tag:inbox", "month");
+        nm_windowed_query_from_query(buf, 1024, false, 0, 0, "tag:inbox", "month", "");
     TEST_CHECK(rc == NM_WINDOW_QUERY_INVALID_DURATION);
   }
 
@@ -50,18 +51,26 @@ void test_nm_windowed_query_from_query(void)
   {
     char buf[1024] = "\0";
     enum NmWindowQueryRc rc =
-        nm_windowed_query_from_query(buf, 1024, false, 3, 3, "tag:inbox", "months");
+        nm_windowed_query_from_query(buf, 1024, false, 3, 3, "tag:inbox", "months", "");
     TEST_CHECK(rc == NM_WINDOW_QUERY_INVALID_TIMEBASE);
   }
 
   static const struct TestCase tests[] = {
-    { false, 1, 0, "tag:inbox", "month", "date:1month.. and tag:inbox" },
-    { false, 1, 1, "tag:inbox", "month", "date:2month..1month and tag:inbox" },
-    { false, 1, 3, "tag:inbox", "month", "date:4month..3month and tag:inbox" },
-    { false, 3, 3, "tag:inbox", "month", "date:12month..9month and tag:inbox" },
-    { true, 0, 0, "tag:inbox", "month", "date:0month.. and tag:inbox" },
-    { true, 0, 1, "tag:inbox", "month", "date:1month..1month and tag:inbox" },
-    { true, 0, 3, "tag:inbox", "month", "date:3month..3month and tag:inbox" },
+    { false, 1, 0, "tag:inbox", "month", "", "date:1month.. and tag:inbox" },
+    { false, 1, 1, "tag:inbox", "month", "", "date:2month..1month and tag:inbox" },
+    { false, 1, 3, "tag:inbox", "month", "", "date:4month..3month and tag:inbox" },
+    { false, 3, 3, "tag:inbox", "month", "", "date:12month..9month and tag:inbox" },
+    { true, 0, 0, "tag:inbox", "month", "", "date:0month.. and tag:inbox" },
+    { true, 0, 1, "tag:inbox", "month", "", "date:1month..1month and tag:inbox" },
+    { true, 0, 3, "tag:inbox", "month", "", "date:3month..3month and tag:inbox" },
+    { false, 3, 3, "tag:inbox", "month", "tag:unread",
+      "(date:12month..9month or (tag:unread)) and tag:inbox" },
+    { true, 0, 3, "tag:inbox", "month", "tag:unread",
+      "(date:3month..3month or (tag:unread)) and tag:inbox" },
+    { false, 3, 3, "tag:inbox", "month", "tag:unread and tag:flagged",
+      "(date:12month..9month or (tag:unread and tag:flagged)) and tag:inbox" },
+    { true, 0, 3, "tag:inbox", "month", "tag:unread and tag:flagged",
+      "(date:3month..3month or (tag:unread and tag:flagged)) and tag:inbox" },
   };
 
   for (int i = 0; i < mutt_array_size(tests); i++)
@@ -70,8 +79,8 @@ void test_nm_windowed_query_from_query(void)
     char buf[1024] = "\0";
 
     enum NmWindowQueryRc rc =
-        nm_windowed_query_from_query(buf, 1024, t->force_enable, t->duration,
-                                     t->cur_pos, t->curr_search, t->timebase);
+        nm_windowed_query_from_query(buf, 1024, t->force_enable, t->duration, t->cur_pos,
+                                     t->curr_search, t->timebase, t->or_terms);
 
     TEST_CHECK(rc == NM_WINDOW_QUERY_SUCCESS);
     TEST_CHECK_(mutt_str_equal(buf, t->expected),


### PR DESCRIPTION
Sometimes a user may wish to include certain messages in a query window
even if it exists outside the date range. For example, always showing
flagged messages.

To support this, extend the query window code to emit a window
containing an `OR` statement with additional search terms if a user
configures the `nm_query_window_additional_terms` variable.

For example, using the mailbox `notmuch://?query=tag:inbox` as the
mailbox and `tag:flagged and tag:unread` as the additional search terms
will produce a query window such as:

`notmuch://?query=tag:inbox and (date:... or (tag:flagged and tag:unread))`

The `date` value was omitted for brevity. The resulting mailbox contains
mail with tag inbox within the date range and mail with tags inbox,
flagged, and unread.

Closes #2972

---

Some notes to focus on in the review:

 1. How do you feel about the new variable name? I had trouble coming up with an adequately descriptive name
 2. Is the documentation descriptive enough for this feature?

