### PR TITLE
Fix building of neomutt if HAVE_RAND_EGD is enabled

### DIFF
--- a/conn/openssl.c
+++ b/conn/openssl.c
@@ -56,6 +56,7 @@
 #include "lib.h"
 #include "mutt_logging.h"
 #include "ssl.h"
+#include "mutt_globals.h"
 
 /* LibreSSL defines OPENSSL_VERSION_NUMBER but sets it to 0x20000000L.
  * So technically we don't need the defined(OPENSSL_VERSION_NUMBER) check.  */


### PR DESCRIPTION
This commit adds missed mutt_globals.h header to openssl.c as
without it the build is broken with:

```
In file included from ./mutt/lib.h:97,
                 from conn/openssl.c:52:
conn/openssl.c: In function ‘ssl_init’:
conn/openssl.c:568:52: error: ‘HomeDir’ undeclared (first use in this function)
  568 |     mutt_buffer_printf(path, "%s/.entropy", NONULL(HomeDir));

error.
```

-------
The error was caught on Fedora 34 with gcc version 11.1.1 20210531 (Red Hat 11.1.1-3) (GCC). neomutt was configured with `./configure --notmuch --lua --gdbm --gpgme --ssl` command