### PR TITLE
unlink mailbox when freeing account

### DIFF
--- a/core/account.c
+++ b/core/account.c
@@ -30,6 +30,7 @@
 #include <stddef.h>
 #include "mutt/lib.h"
 #include "config/lib.h"
+#include "core/lib.h"
 #include "account.h"
 #include "mailbox.h"
 
@@ -116,7 +117,7 @@ bool account_mailbox_remove(struct Account *a, struct Mailbox *m)
     if (m)
     {
       m->account = NULL;
-      notify_set_parent(m->notify, NULL);
+      notify_set_parent(m->notify, NeoMutt->notify);
     }
     else
     {

--- a/core/account.c
+++ b/core/account.c
@@ -113,8 +113,15 @@ bool account_mailbox_remove(struct Account *a, struct Mailbox *m)
       continue;
 
     STAILQ_REMOVE(&a->mailboxes, np, MailboxNode, entries);
-    if (!m)
+    if (m)
+    {
+      m->account = NULL;
+      notify_set_parent(m->notify, NULL);
+    }
+    else
+    {
       mailbox_free(&np->mailbox);
+    }
     FREE(&np);
     result = true;
     if (m)

--- a/sidebar/sidebar.c
+++ b/sidebar/sidebar.c
@@ -116,47 +116,47 @@ void sb_remove_mailbox(struct SidebarWindowData *wdata, struct Mailbox *m)
   struct SbEntry **sbep = NULL;
   ARRAY_FOREACH(sbep, &wdata->entries)
   {
-    if (mutt_str_equal((*sbep)->mailbox->realpath, m->realpath))
+    if ((*sbep)->mailbox != m)
+      continue;
+
+    struct SbEntry *sbe_remove = *sbep;
+    ARRAY_REMOVE(&wdata->entries, sbep);
+    FREE(&sbe_remove);
+
+    if (wdata->opn_index == ARRAY_FOREACH_IDX)
     {
-      struct SbEntry *sbe_remove = *sbep;
-      ARRAY_REMOVE(&wdata->entries, sbep);
-      FREE(&sbe_remove);
-
-      if (wdata->opn_index == ARRAY_FOREACH_IDX)
-      {
-        // Open item was deleted
-        wdata->opn_index = -1;
-      }
-      else if ((wdata->opn_index > 0) && (wdata->opn_index > ARRAY_FOREACH_IDX))
-      {
-        // Open item is still visible, so adjust the index
-        wdata->opn_index--;
-      }
-
-      if (wdata->hil_index == ARRAY_FOREACH_IDX)
-      {
-        // If possible, keep the highlight where it is
-        struct SbEntry **sbep_cur = ARRAY_GET(&wdata->entries, ARRAY_FOREACH_IDX);
-        if (!sbep_cur)
-        {
-          // The last entry was deleted, so backtrack
-          select_prev(wdata);
-        }
-        else if ((*sbep)->is_hidden)
-        {
-          // Find the next unhidden entry, or the previous
-          if (!select_next(wdata))
-            if (!select_prev(wdata))
-              wdata->hil_index = -1;
-        }
-      }
-      else if ((wdata->hil_index > 0) && (wdata->hil_index > ARRAY_FOREACH_IDX))
-      {
-        // Highlighted item is still visible, so adjust the index
-        wdata->hil_index--;
-      }
-      break;
+      // Open item was deleted
+      wdata->opn_index = -1;
     }
+    else if ((wdata->opn_index > 0) && (wdata->opn_index > ARRAY_FOREACH_IDX))
+    {
+      // Open item is still visible, so adjust the index
+      wdata->opn_index--;
+    }
+
+    if (wdata->hil_index == ARRAY_FOREACH_IDX)
+    {
+      // If possible, keep the highlight where it is
+      struct SbEntry **sbep_cur = ARRAY_GET(&wdata->entries, ARRAY_FOREACH_IDX);
+      if (!sbep_cur)
+      {
+        // The last entry was deleted, so backtrack
+        select_prev(wdata);
+      }
+      else if ((*sbep)->is_hidden)
+      {
+        // Find the next unhidden entry, or the previous
+        if (!select_next(wdata))
+          if (!select_prev(wdata))
+            wdata->hil_index = -1;
+      }
+    }
+    else if ((wdata->hil_index > 0) && (wdata->hil_index > ARRAY_FOREACH_IDX))
+    {
+      // Highlighted item is still visible, so adjust the index
+      wdata->hil_index--;
+    }
+    break;
   }
 }
 


### PR DESCRIPTION
This fixes a couple of closely-related bugs.

The problem comes where we free the Account before the Mailbox.
The Mailbox still had references to the Account: `Mailbox->account` and `Mailbox->notify`.

@ebblake's test case triggered one problem and a missing mailbox triggered the other.

---

**Update**

This fixes three problems:

### 93ba69a78 unlink mailbox when freeing account

A dangling `Mailbox->account` pointer was causing crashes

### 4bc2090a5 mailbox: keep chain of notifications

When a Mailbox is deleted it sends a notification: `NT_MAILBOX_DELETE`.
That's forwarded to the Account, then to NeoMutt.
The Sidebar is observing NeoMutt to see all Mailbox changes.
If the Mailbox has been separated from the Account, then that notification would never reach NeoMutt,
so the Sidebar would end up with dangling pointers.

### cae0f047d sidebar: be specific when removing mailboxes

Some temporary Mailboxes might have paths matching existing Mailboxes.
When these temporaries are freed, we mustn't accidentally remove the wrong match in the Sidebar.