### PR TITLE
notmuch: open database with user's configuration

### DIFF
--- a/auto.def
+++ b/auto.def
@@ -655,6 +655,7 @@ if {[get-define want-notmuch]} {
     msg-result "no"
   }
   cc-check-function-in-lib notmuch_database_index_file notmuch
+  cc-check-function-in-lib notmuch_database_open_with_config notmuch
 }
 
 ###############################################################################

--- a/notmuch/db.c
+++ b/notmuch/db.c
@@ -119,7 +119,10 @@ notmuch_database_t *nm_db_do_open(const char *filename, bool writable, bool verb
 
   do
   {
-#if LIBNOTMUCH_CHECK_VERSION(4, 2, 0)
+#if LIBNOTMUCH_CHECK_VERSION(5, 4, 0) || defined(HAVE_NOTMUCH_DATABASE_OPEN_WITH_CONFIG)
+    // notmuch 0.32-0.32.2 didn't bump libnotmuch version to 5.4.
+    st = notmuch_database_open_with_config(filename, mode, NULL, NULL, &db, &msg);
+#elif LIBNOTMUCH_CHECK_VERSION(4, 2, 0)
     st = notmuch_database_open_verbose(filename, mode, &db, &msg);
 #elif defined(NOTMUCH_API_3)
     st = notmuch_database_open(filename, mode, &db);


### PR DESCRIPTION
Notmuch 0.32 introduced a new database open function that allows using
the user's configuration. With libnotmuch using the user's
configuration, the notmuch backend behaves more like the notmuch CLI. It
will exclude tags defined in `.notmuch-config`, correct file paths for
split database and email directory setups, and allow notmuch saved
queries.

The new function call is wrapped behind a libnotmuch version check or if
libnotmuch provides the new method. Notmuch 0.32-0.32.2 didn't bump the
version number so it incorrectly reports 5.3. The version number will be
fixed in notmuch 0.32.3.

* **What are the relevant issue numbers?**

Fixes #3017