### PR TITLE
stats: don't check mailbox stats unless told

### DIFF
--- a/mutt_mailbox.c
+++ b/mutt_mailbox.c
@@ -118,7 +118,7 @@ static void mailbox_check(struct Mailbox *m_cur, struct Mailbox *m_check,
       cs_subset_bool(NeoMutt->sub, "check_mbox_size");
 
   /* check to see if the folder is the currently selected folder before polling */
-  if (!is_same_mailbox(m_cur, m_check, st_ctx, &st))
+  if (check_stats && !is_same_mailbox(m_cur, m_check, st_ctx, &st))
   {
     switch (m_check->type)
     {


### PR DESCRIPTION
`mailbox_check()` has a single caller `mutt_mailbox_check()`, which
passes `check_stats=true` when there's a forced update or the mail check
stats interval passes (assuming user enable those settings.) However,
`mail_check()` doesn't use `check_stats` and passes it to
`mx_mbox_check_stats()` which doesn't use it either and passes it onto
the backends. Some backends, like notmuch, do not check this value
before calculating stats.

As a result, for some backends, every call to `mailbox_check()` checks
stats even when it shouldn't. Since checking stats can be expensive,
performance will degrade with a low `mail_check` value, and scale with
the number of mailboxes. If a user sets `mail_check=0`, NeoMutt will
check stats as fast as possible and the UI lags. Having `mail_check=0`
isn't unusual as the guide[0] recommended to me for initial
configuration contains it.

To fix this, ensure `check_stats=true` before calling
`mx_mbox_check_stats()`.

Fixes #1728
Fixes #1827

[0] https://stevelosh.com/blog/2012/10/the-homely-mutt/#s13-configuring