### PR TITLE
build: strip back curses checks

### DIFF
--- a/auto.def
+++ b/auto.def
@@ -735,11 +735,6 @@ switch [opt-val with-ui ncurses] {
       if {![have-feature waddnwstr] || ![have-feature tgetent]} {
         user-error "Unable to find ncursesw library"
       }
-
-      foreach f {bkgdset curs_set meta start_color typeahead use_default_colors} {
-        cc-check-function-in-lib $f $ncurses_lib
-      }
-      cc-check-functions use_extended_names
     }
 
     # Locate the directory containing ncurses.h
@@ -755,10 +750,6 @@ switch [opt-val with-ui ncurses] {
         user-error "Unable to find ncurses headers"
       }
     }} $ncurses_prefix
-
-    if {[have-feature start_color]} {
-      define-feature COLOR
-    }
   }
 
   slang {
@@ -772,8 +763,6 @@ switch [opt-val with-ui ncurses] {
       user-error "Unable to find S-Lang"
     }
     define USE_SLANG_CURSES
-    define-feature COLOR
-    define-feature DIRECTCOLOR
   }
 
   default {

--- a/gui/mutt_curses.c
+++ b/gui/mutt_curses.c
@@ -38,7 +38,7 @@
  */
 void mutt_curses_set_attr(int attr)
 {
-#ifdef HAVE_BKGDSET
+#ifdef NCURSES_VERSION
   bkgdset(attr | ' ');
 #else
   attrset(attr);
@@ -57,7 +57,7 @@ void mutt_curses_set_color(enum ColorId color)
 {
   const int chosen = mutt_color(color);
   const int normal = mutt_color(MT_COLOR_NORMAL);
-#ifdef HAVE_BKGDSET
+#ifdef NCURSES_VERSION
   bkgdset((chosen ? chosen : normal) | ' ');
 #else
   attrset(chosen ? chosen : normal);
@@ -70,7 +70,6 @@ void mutt_curses_set_color(enum ColorId color)
  */
 void mutt_curses_set_cursor(enum MuttCursorState state)
 {
-#if (defined(USE_SLANG_CURSES) || defined(HAVE_CURS_SET))
   static int SavedCursor = MUTT_CURSOR_VISIBLE;
 
   if (state == MUTT_CURSOR_RESTORE_LAST)
@@ -83,5 +82,4 @@ void mutt_curses_set_cursor(enum MuttCursorState state)
     if (state == MUTT_CURSOR_VISIBLE)
       curs_set(MUTT_CURSOR_VERY_VISIBLE);
   }
-#endif
 }

--- a/gui/terminal.c
+++ b/gui/terminal.c
@@ -73,7 +73,7 @@ bool mutt_ts_capability(void)
     return true;
   }
 
-#ifdef HAVE_USE_EXTENDED_NAMES
+#ifdef NCURSES_VERSION
   /* If XT (boolean) is set, then this terminal supports the standard escape. */
   /* Beware: tigetflag returns -1 if XT is invalid or not a boolean. */
   use_extended_names(true);

--- a/main.c
+++ b/main.c
@@ -364,10 +364,8 @@ static int start_curses(void)
   cbreak();
   noecho();
   nonl();
-#ifdef HAVE_TYPEAHEAD
+#ifdef NCURSES_VERSION
   typeahead(-1); /* simulate smooth scrolling */
-#endif
-#ifdef HAVE_META
   meta(stdscr, true);
 #endif
   init_extended_keys();

--- a/menu/draw.c
+++ b/menu/draw.c
@@ -126,13 +126,9 @@ static void print_enriched_string(struct MuttWindow *win, int index, int attr,
     {
       if (do_color)
       {
-#if defined(HAVE_COLOR) && defined(HAVE_USE_DEFAULT_COLORS)
         /* Combining tree fg color and another bg color requires having
          * use_default_colors, because the other bg color may be undefined. */
         mutt_curses_set_attr(mutt_color_combine(mutt_color(MT_COLOR_TREE), attr));
-#else
-        mutt_curses_set_color(MT_COLOR_TREE);
-#endif
       }
 
       while (*s && (*s < MUTT_TREE_MAX))

--- a/mutt_commands.c
+++ b/mutt_commands.c
@@ -55,9 +55,7 @@ static const struct Command mutt_commands[] = {
   { "bind",                mutt_parse_bind,        0 },
   { "cd",                  parse_cd,               0 },
   { "charset-hook",        mutt_parse_hook,        MUTT_CHARSET_HOOK },
-#ifdef HAVE_COLOR
   { "color",               mutt_parse_color,       0 },
-#endif
   { "crypt-hook",          mutt_parse_hook,        MUTT_CRYPT_HOOK },
   { "echo",                parse_echo,             0 },
   { "exec",                mutt_parse_exec,        0 },
@@ -109,9 +107,7 @@ static const struct Command mutt_commands[] = {
   { "unattachments",       parse_unattachments,    0 },
   { "unauto_view",         parse_unstailq,         IP &AutoViewList },
   { "unbind",              mutt_parse_unbind,      MUTT_UNBIND },
-#ifdef HAVE_COLOR
   { "uncolor",             mutt_parse_uncolor,     0 },
-#endif
   { "ungroup",             parse_group,            MUTT_UNGROUP },
   { "unhdr_order",         parse_unstailq,         IP &HeaderOrderList },
   { "unhook",              mutt_parse_unhook,      0 },

--- a/pager/display.c
+++ b/pager/display.c
@@ -194,7 +194,6 @@ static void resolve_color(struct MuttWindow *win, struct Line *lines, int line_n
   /* handle "special" bold & underlined characters */
   if (special || aa->attr)
   {
-#ifdef HAVE_COLOR
     if ((aa->attr & ANSI_COLOR))
     {
       if (aa->pair == -1)
@@ -203,9 +202,7 @@ static void resolve_color(struct MuttWindow *win, struct Line *lines, int line_n
       if (aa->attr & ANSI_BOLD)
         color |= A_BOLD;
     }
-    else
-#endif
-        if ((special & A_BOLD) || (aa->attr & ANSI_BOLD))
+    else if ((special & A_BOLD) || (aa->attr & ANSI_BOLD))
     {
       if (mutt_color(MT_COLOR_BOLD) && !search)
         color = mutt_color(MT_COLOR_BOLD);
@@ -1023,10 +1020,8 @@ static int grok_ansi(const unsigned char *buf, int pos, struct AnsiAttr *aa)
   {
     if (pos == x)
     {
-#ifdef HAVE_COLOR
       if (aa->pair != -1)
         mutt_color_free(aa->fg, aa->bg);
-#endif
       aa->attr = ANSI_OFF;
       aa->pair = -1;
     }
@@ -1054,20 +1049,16 @@ static int grok_ansi(const unsigned char *buf, int pos, struct AnsiAttr *aa)
       }
       else if ((buf[pos] == '0') && (((pos + 1) == x) || (buf[pos + 1] == ';')))
       {
-#ifdef HAVE_COLOR
         if (aa->pair != -1)
           mutt_color_free(aa->fg, aa->bg);
-#endif
         aa->attr = ANSI_OFF;
         aa->pair = -1;
         pos += 2;
       }
       else if ((buf[pos] == '3') && isdigit(buf[pos + 1]))
       {
-#ifdef HAVE_COLOR
         if (aa->pair != -1)
           mutt_color_free(aa->fg, aa->bg);
-#endif
         aa->pair = -1;
         aa->attr |= ANSI_COLOR;
         aa->fg = buf[pos + 1] - '0';
@@ -1075,10 +1066,8 @@ static int grok_ansi(const unsigned char *buf, int pos, struct AnsiAttr *aa)
       }
       else if ((buf[pos] == '4') && isdigit(buf[pos + 1]))
       {
-#ifdef HAVE_COLOR
         if (aa->pair != -1)
           mutt_color_free(aa->fg, aa->bg);
-#endif
         aa->pair = -1;
         aa->attr |= ANSI_COLOR;
         aa->bg = buf[pos + 1] - '0';

--- a/version.c
+++ b/version.c
@@ -166,21 +166,6 @@ static struct CompileOptions comp_opts[] = {
 #else
   { "autocrypt", 0 },
 #endif
-#ifdef HAVE_BKGDSET
-  { "bkgdset", 1 },
-#else
-  { "bkgdset", 0 },
-#endif
-#ifdef HAVE_COLOR
-  { "color", 1 },
-#else
-  { "color", 0 },
-#endif
-#ifdef HAVE_CURS_SET
-  { "curs_set", 1 },
-#else
-  { "curs_set", 0 },
-#endif
 #ifdef USE_FCNTL
   { "fcntl", 1 },
 #else
@@ -251,11 +236,6 @@ static struct CompileOptions comp_opts[] = {
 #else
   { "lua", 0 },
 #endif
-#ifdef HAVE_META
-  { "meta", 1 },
-#else
-  { "meta", 0 },
-#endif
 #ifdef MIXMASTER
   { "mixmaster", 1 },
 #else
@@ -302,20 +282,10 @@ static struct CompileOptions comp_opts[] = {
 #else
   { "sqlite", 0 },
 #endif
-#ifdef HAVE_START_COLOR
-  { "start_color", 1 },
-#else
-  { "start_color", 0 },
-#endif
 #ifdef SUN_ATTACHMENT
   { "sun_attachment", 1 },
 #else
   { "sun_attachment", 0 },
-#endif
-#ifdef HAVE_TYPEAHEAD
-  { "typeahead", 1 },
-#else
-  { "typeahead", 0 },
 #endif
   { NULL, 0 },
 };


### PR DESCRIPTION
All the curses functions that we check for have been in ncurses for over a decade.

Remove the individual checks for the functions:
- `bkgdset()`                                                                       
- `curs_set()`
- `meta()`
- `start_color()`
- `typeahead()`
- `use_default_colors()`
- `use_extended_names()`

This change shaves nearly **0.4s** off the `./configure` time, which over my lifetime may save me several minutes :-)