### PR TITLE
notmuch: handle missing libnotmuch version bumps

### DIFF
--- a/notmuch/db.c
+++ b/notmuch/db.c
@@ -119,7 +119,7 @@ notmuch_database_t *nm_db_do_open(const char *filename, bool writable, bool verb
 
   do
   {
-#if LIBNOTMUCH_CHECK_VERSION(5, 4, 0) || defined(HAVE_NOTMUCH_DATABASE_OPEN_WITH_CONFIG)
+#if LIBNOTMUCH_CHECK_VERSION(5, 4, 0)
     // notmuch 0.32-0.32.2 didn't bump libnotmuch version to 5.4.
     st = notmuch_database_open_with_config(filename, mode, NULL, NULL, &db, &msg);
 #elif LIBNOTMUCH_CHECK_VERSION(4, 2, 0)

--- a/notmuch/notmuch.c
+++ b/notmuch/notmuch.c
@@ -1340,7 +1340,7 @@ static int rename_filename(struct Mailbox *m, const char *old_file,
     return -1;
 
   mutt_debug(LL_DEBUG2, "nm: rename: add '%s'\n", new_file);
-#ifdef HAVE_NOTMUCH_DATABASE_INDEX_FILE
+#if LIBNOTMUCH_CHECK_VERSION(5, 1, 0)
   st = notmuch_database_index_file(db, new_file, NULL, &msg);
 #else
   st = notmuch_database_add_message(db, new_file, &msg);
@@ -1379,7 +1379,7 @@ static int rename_filename(struct Mailbox *m, const char *old_file,
         {
           mutt_debug(LL_DEBUG2, "nm: rename dup %s -> %s\n", path, newpath);
           notmuch_database_remove_message(db, path);
-#ifdef HAVE_NOTMUCH_DATABASE_INDEX_FILE
+#if LIBNOTMUCH_CHECK_VERSION(5, 1, 0)
           notmuch_database_index_file(db, newpath, NULL, NULL);
 #else
           notmuch_database_add_message(db, newpath, NULL);
@@ -1925,7 +1925,7 @@ int nm_record_message(struct Mailbox *m, char *path, struct Email *e)
   if (trans < 0)
     goto done;
 
-#ifdef HAVE_NOTMUCH_DATABASE_INDEX_FILE
+#if LIBNOTMUCH_CHECK_VERSION(5, 1, 0)
   st = notmuch_database_index_file(db, path, NULL, &msg);
 #else
   st = notmuch_database_add_message(db, path, &msg);

--- a/notmuch/private.h
+++ b/notmuch/private.h
@@ -33,12 +33,28 @@ struct Mailbox;
 #undef LIBNOTMUCH_CHECK_VERSION
 #endif
 
-/* The definition in <notmuch.h> is broken */
-#define LIBNOTMUCH_CHECK_VERSION(major, minor, micro)                             \
-  (LIBNOTMUCH_MAJOR_VERSION > (major) ||                                          \
-   (LIBNOTMUCH_MAJOR_VERSION == (major) && LIBNOTMUCH_MINOR_VERSION > (minor)) || \
-   (LIBNOTMUCH_MAJOR_VERSION == (major) &&                                        \
-    LIBNOTMUCH_MINOR_VERSION == (minor) && LIBNOTMUCH_MICRO_VERSION >= (micro)))
+#ifndef HAVE_NOTMUCH_DATABASE_INDEX_FILE
+#define HAVE_NOTMUCH_DATABASE_INDEX_FILE 0
+#endif
+
+#ifndef HAVE_NOTMUCH_DATABASE_OPEN_WITH_CONFIG
+#define HAVE_NOTMUCH_DATABASE_OPEN_WITH_CONFIG 0
+#endif
+
+/*
+ * The definition in <notmuch.h> is broken.
+ *
+ * Corrects for libnotmuch releases with missing version bumps:
+ * - libnotmuch 5.4 released with notmuch 0.32. notmuch 0.32.3 fixed version.
+ * - libnotmuch 5.1 released with notmuch 0.26. notmuch 0.26.1 fixed version.
+ */
+#define LIBNOTMUCH_CHECK_VERSION(major, minor, micro)                              \
+  (major == 5 && minor == 4 && HAVE_NOTMUCH_DATABASE_OPEN_WITH_CONFIG)          || \
+  (major == 5 && minor == 1 && HAVE_NOTMUCH_DATABASE_INDEX_FILE)                || \
+  ((LIBNOTMUCH_MAJOR_VERSION > (major) ||                                          \
+   (LIBNOTMUCH_MAJOR_VERSION == (major) && LIBNOTMUCH_MINOR_VERSION > (minor))  || \
+   (LIBNOTMUCH_MAJOR_VERSION == (major) &&                                         \
+    LIBNOTMUCH_MINOR_VERSION == (minor) && LIBNOTMUCH_MICRO_VERSION >= (micro))))
 
 extern const char NmUrlProtocol[];
 extern const int NmUrlProtocolLen;


### PR DESCRIPTION
Sometimes libnotmuch's version isn't bumped when new APIs are available.
Some new features require updating our integration to support users
using them, such as separate database and email directories, but we're
unable to use the standard `LIBNOTMUCH_CHECK_VERSION` macro. The current
approach is #ifdef on a function's existence; however, this is
inconsistent with our usage of the version check macro.

Instead, move the function existence checks into
`LIBNOTMUCH_CHECK_VERSION`. Since we know which libnotmuch version
introduced a function, we're able to check the major and minor version
against the function's existence.

There are two libnotmuch version bumps NeoMutt corrects for:
 - libnotmuch 5.1 released in notmuch 0.26 but not bumped until 0.26.1
 - libnotmuch 5.4 released in notmuch 0.32 but not bumped until 0.32.3

---

Note to reviewer: as I'm not super familiar with macros, please take extra care reviewing the change.