### PR TITLE
Implement list-(un)subscribe

### DIFF
--- a/attach/dlg_attach.c
+++ b/attach/dlg_attach.c
@@ -895,6 +895,16 @@ void dlg_select_attachment(struct ConfigSubset *sub, struct Mailbox *m,
         break;
       }
 
+      case OP_LIST_SUBSCRIBE:
+        if (!check_attach())
+          mutt_send_list_subscribe(m, e);
+        break;
+
+      case OP_LIST_UNSUBSCRIBE:
+        if (!check_attach())
+          mutt_send_list_unsubscribe(m, e);
+        break;
+
       case OP_COMPOSE_TO_SENDER:
       {
         if (check_attach())

--- a/debug/email.c
+++ b/debug/email.c
@@ -100,6 +100,7 @@ void dump_envelope(const struct Envelope *env)
   if (env->S)                                                                  \
   mutt_debug(LL_DEBUG1, "\t%s: %s\n", #S, env->S)
   OPT_STRING(list_post);
+  OPT_STRING(list_subscribe);
   OPT_STRING(list_unsubscribe);
   OPT_STRING(subject);
   OPT_STRING(real_subj);

--- a/debug/email.c
+++ b/debug/email.c
@@ -100,6 +100,7 @@ void dump_envelope(const struct Envelope *env)
   if (env->S)                                                                  \
   mutt_debug(LL_DEBUG1, "\t%s: %s\n", #S, env->S)
   OPT_STRING(list_post);
+  OPT_STRING(list_unsubscribe);
   OPT_STRING(subject);
   OPT_STRING(real_subj);
   OPT_STRING(disp_subj);

--- a/debug/graphviz.c
+++ b/debug/graphviz.c
@@ -1279,6 +1279,7 @@ static void dot_envelope(FILE *fp, struct Envelope *env, struct ListHead *links)
   dot_type_string(fp, "disp_subj", env->disp_subj, false);
   dot_type_string(fp, "followup_to", env->followup_to, false);
   dot_type_string(fp, "list_post", env->list_post, false);
+  dot_type_string(fp, "list_subscribe", env->list_subscribe, false);
   dot_type_string(fp, "list_unsubscribe", env->list_unsubscribe, false);
   dot_type_string(fp, "message_id", env->message_id, false);
   dot_type_string(fp, "newsgroups", env->newsgroups, false);

--- a/debug/graphviz.c
+++ b/debug/graphviz.c
@@ -1279,6 +1279,7 @@ static void dot_envelope(FILE *fp, struct Envelope *env, struct ListHead *links)
   dot_type_string(fp, "disp_subj", env->disp_subj, false);
   dot_type_string(fp, "followup_to", env->followup_to, false);
   dot_type_string(fp, "list_post", env->list_post, false);
+  dot_type_string(fp, "list_unsubscribe", env->list_unsubscribe, false);
   dot_type_string(fp, "message_id", env->message_id, false);
   dot_type_string(fp, "newsgroups", env->newsgroups, false);
   dot_type_string(fp, "organization", env->organization, false);

--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -2464,6 +2464,30 @@ color sidebar_divider   color8  default     <emphasis role="comment"># Dark grey
           </varlistentry>
           <varlistentry>
             <term>
+              <literal>&lt;list-subscribe&gt;</literal>
+              <anchor id="list-subscribe" />
+            </term>
+            <listitem>
+              <para>
+                Send an email to the address specified in the List-Subscribe
+                header as specified in RFC2369.
+              </para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>
+              <literal>&lt;list-unsubscribe&gt;</literal>
+              <anchor id="list-unsubscribe" />
+            </term>
+            <listitem>
+              <para>
+                Send an email to the address specified in the List-Unsubscribe
+                header as specified in RFC2369.
+              </para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>
               <literal>&lt;pipe-message&gt;</literal> (default: |)
               <anchor id="pipe-message" />
             </term>
@@ -2644,7 +2668,17 @@ color sidebar_divider   color8  default     <emphasis role="comment"># Dark grey
               <row>
                 <entry>L</entry>
                 <entry><literal>&lt;list-reply&gt;</literal></entry>
-                <entry>reply to mailing list address</entry>
+                <entry>reply to a mailing list</entry>
+              </row>
+              <row>
+                <entry>L</entry>
+                <entry><literal>&lt;list-subscribe&gt;</literal></entry>
+                <entry>send a subscription email to a mailing list</entry>
+              </row>
+              <row>
+                <entry>L</entry>
+                <entry><literal>&lt;list-unsubscribe&gt;</literal></entry>
+                <entry>send an unsubscription email to a mailing list</entry>
               </row>
               <row>
                 <entry>f</entry>

--- a/email/envelope.c
+++ b/email/envelope.c
@@ -111,6 +111,7 @@ void mutt_env_free(struct Envelope **ptr)
   mutt_addrlist_clear(&env->x_original_to);
 
   FREE(&env->list_post);
+  FREE(&env->list_unsubscribe);
   FREE(&env->subject);
   /* real_subj is just an offset to subject and shouldn't be freed */
   FREE(&env->disp_subj);
@@ -191,6 +192,7 @@ void mutt_env_merge(struct Envelope *base, struct Envelope **extra)
   MOVE_ADDRESSLIST(reply_to);
   MOVE_ADDRESSLIST(mail_followup_to);
   MOVE_ELEM(list_post);
+  MOVE_ELEM(list_unsubscribe);
   MOVE_ELEM(message_id);
   MOVE_ELEM(supersedes);
   MOVE_ELEM(date);

--- a/email/envelope.c
+++ b/email/envelope.c
@@ -111,6 +111,7 @@ void mutt_env_free(struct Envelope **ptr)
   mutt_addrlist_clear(&env->x_original_to);
 
   FREE(&env->list_post);
+  FREE(&env->list_subscribe);
   FREE(&env->list_unsubscribe);
   FREE(&env->subject);
   /* real_subj is just an offset to subject and shouldn't be freed */
@@ -192,6 +193,7 @@ void mutt_env_merge(struct Envelope *base, struct Envelope **extra)
   MOVE_ADDRESSLIST(reply_to);
   MOVE_ADDRESSLIST(mail_followup_to);
   MOVE_ELEM(list_post);
+  MOVE_ELEM(list_subscribe);
   MOVE_ELEM(list_unsubscribe);
   MOVE_ELEM(message_id);
   MOVE_ELEM(supersedes);

--- a/email/envelope.h
+++ b/email/envelope.h
@@ -63,6 +63,7 @@ struct Envelope
   struct AddressList mail_followup_to; ///< Email's 'mail-followup-to'
   struct AddressList x_original_to;    ///< Email's 'X-Orig-to'
   char *list_post;                     ///< This stores a mailto URL, or nothing
+  char *list_unsubscribe;              ///< This stores a mailto URL, or nothing
   char *subject;                       ///< Email's subject
   char *real_subj;                     ///< Offset of the real subject
   char *disp_subj;                     ///< Display subject (modified copy of subject)

--- a/email/envelope.h
+++ b/email/envelope.h
@@ -63,6 +63,7 @@ struct Envelope
   struct AddressList mail_followup_to; ///< Email's 'mail-followup-to'
   struct AddressList x_original_to;    ///< Email's 'X-Orig-to'
   char *list_post;                     ///< This stores a mailto URL, or nothing
+  char *list_subscribe;                ///< This stores a mailto URL, or nothing
   char *list_unsubscribe;              ///< This stores a mailto URL, or nothing
   char *subject;                       ///< Email's subject
   char *real_subj;                     ///< Offset of the real subject

--- a/email/parse.c
+++ b/email/parse.c
@@ -812,6 +812,17 @@ int mutt_rfc822_parse_line(struct Envelope *env, struct Email *e, const char *na
         }
         matched = true;
       }
+      else if (mutt_istr_equal(name + 1, "ist-Subscribe"))
+      {
+        /* RFC2369 */
+        char *mailto = rfc2369_first_mailto(body);
+        if (mailto)
+        {
+          FREE(&env->list_subscribe);
+          env->list_subscribe = mailto;
+        }
+        matched = true;
+      }
       else if (mutt_istr_equal(name + 1, "ist-Unsubscribe"))
       {
         /* RFC2369 */

--- a/email/parse.h
+++ b/email/parse.h
@@ -43,7 +43,7 @@ bool             mutt_parse_mailto        (struct Envelope *e, char **body, cons
 struct Body *    mutt_parse_multipart     (FILE *fp, const char *boundary, LOFF_T end_off, bool digest);
 void             mutt_parse_part          (FILE *fp, struct Body *b);
 struct Body *    mutt_read_mime_header    (FILE *fp, bool digest);
-int              mutt_rfc822_parse_line   (struct Envelope *env, struct Email *e, char *line, char *p, bool user_hdrs, bool weed, bool do_2047);
+int              mutt_rfc822_parse_line   (struct Envelope *env, struct Email *e, const char *name, const char *body, bool user_hdrs, bool weed, bool do_2047);
 struct Body *    mutt_rfc822_parse_message(FILE *fp, struct Body *parent);
 struct Envelope *mutt_rfc822_read_header  (FILE *fp, struct Email *e, bool user_hdrs, bool weed);
 char *           mutt_rfc822_read_line    (FILE *fp, char *line, size_t *linelen);

--- a/functions.c
+++ b/functions.c
@@ -390,6 +390,7 @@ const struct Binding OpPager[] = { /* map: pager */
   { "sidebar-toggle-virtual",    OP_SIDEBAR_TOGGLE_VIRTUAL,       NULL },
   { "sidebar-toggle-visible",    OP_SIDEBAR_TOGGLE_VISIBLE,       NULL },
 #endif
+  { "list-unsubscribe",          OP_PAGER_LIST_UNSUBSCRIBE,       "U" },
   { "skip-headers",              OP_PAGER_SKIP_HEADERS,           "H" },
   { "skip-quoted",               OP_PAGER_SKIP_QUOTED,            "S" },
   { "sort-mailbox",              OP_SORT,                         "o" },

--- a/functions.c
+++ b/functions.c
@@ -170,6 +170,8 @@ const struct Binding OpMain[] = { /* map: index */
   { "limit-current-thread",      OP_LIMIT_CURRENT_THREAD,           NULL },
   { "link-threads",              OP_MAIN_LINK_THREADS,              "&" },
   { "list-reply",                OP_LIST_REPLY,                     "L" },
+  { "list-subscribe",            OP_LIST_SUBSCRIBE,                 NULL },
+  { "list-unsubscribe",          OP_LIST_UNSUBSCRIBE,               NULL },
   { "mail",                      OP_MAIL,                           "m" },
   { "mail-key",                  OP_MAIL_KEY,                       "\033k" },  // <Alt-k>
   { "mailbox-list",              OP_MAILBOX_LIST,                   "." },
@@ -320,6 +322,8 @@ const struct Binding OpPager[] = { /* map: pager */
   { "jump",                      OP_JUMP,                         NULL },
   { "link-threads",              OP_MAIN_LINK_THREADS,            "&" },
   { "list-reply",                OP_LIST_REPLY,                   "L" },
+  { "list-subscribe",            OP_LIST_SUBSCRIBE,               NULL },
+  { "list-unsubscribe",          OP_LIST_UNSUBSCRIBE,             NULL },
   { "mail",                      OP_MAIL,                         "m" },
   { "mail-key",                  OP_MAIL_KEY,                     "\033k" },    // <Alt-k>
   { "mailbox-list",              OP_MAILBOX_LIST,                 "." },
@@ -390,8 +394,6 @@ const struct Binding OpPager[] = { /* map: pager */
   { "sidebar-toggle-virtual",    OP_SIDEBAR_TOGGLE_VIRTUAL,       NULL },
   { "sidebar-toggle-visible",    OP_SIDEBAR_TOGGLE_VISIBLE,       NULL },
 #endif
-  { "list-subscribe",            OP_PAGER_LIST_SUBSCRIBE,         NULL},
-  { "list-unsubscribe",          OP_PAGER_LIST_UNSUBSCRIBE,       "U" },
   { "skip-headers",              OP_PAGER_SKIP_HEADERS,           "H" },
   { "skip-quoted",               OP_PAGER_SKIP_QUOTED,            "S" },
   { "sort-mailbox",              OP_SORT,                         "o" },
@@ -439,6 +441,8 @@ const struct Binding OpAttach[] = { /* map: attachment */
   { "group-chat-reply",      OP_GROUP_CHAT_REPLY,            NULL },
   { "group-reply",           OP_GROUP_REPLY,                 "g" },
   { "list-reply",            OP_LIST_REPLY,                  "L" },
+  { "list-subscribe",        OP_LIST_SUBSCRIBE,              NULL },
+  { "list-unsubscribe",      OP_LIST_UNSUBSCRIBE,            NULL },
   { "pipe-entry",            OP_PIPE,                        "|" },
   { "print-entry",           OP_PRINT,                       "p" },
   { "reply",                 OP_REPLY,                       "r" },

--- a/functions.c
+++ b/functions.c
@@ -390,6 +390,7 @@ const struct Binding OpPager[] = { /* map: pager */
   { "sidebar-toggle-virtual",    OP_SIDEBAR_TOGGLE_VIRTUAL,       NULL },
   { "sidebar-toggle-visible",    OP_SIDEBAR_TOGGLE_VISIBLE,       NULL },
 #endif
+  { "list-subscribe",            OP_PAGER_LIST_SUBSCRIBE,         NULL},
   { "list-unsubscribe",          OP_PAGER_LIST_UNSUBSCRIBE,       "U" },
   { "skip-headers",              OP_PAGER_SKIP_HEADERS,           "H" },
   { "skip-quoted",               OP_PAGER_SKIP_QUOTED,            "S" },

--- a/hcache/serialize.c
+++ b/hcache/serialize.c
@@ -501,6 +501,7 @@ unsigned char *serial_dump_envelope(struct Envelope *env, unsigned char *d,
   d = serial_dump_address(&env->mail_followup_to, d, off, convert);
 
   d = serial_dump_char(env->list_post, d, off, convert);
+  d = serial_dump_char(env->list_unsubscribe, d, off, convert);
   d = serial_dump_char(env->subject, d, off, convert);
 
   if (env->real_subj)
@@ -550,6 +551,7 @@ void serial_restore_envelope(struct Envelope *env, const unsigned char *d, int *
   serial_restore_address(&env->mail_followup_to, d, off, convert);
 
   serial_restore_char(&env->list_post, d, off, convert);
+  serial_restore_char(&env->list_unsubscribe, d, off, convert);
 
   const bool c_auto_subscribe = cs_subset_bool(NeoMutt->sub, "auto_subscribe");
   if (c_auto_subscribe)

--- a/hcache/serialize.c
+++ b/hcache/serialize.c
@@ -501,6 +501,7 @@ unsigned char *serial_dump_envelope(struct Envelope *env, unsigned char *d,
   d = serial_dump_address(&env->mail_followup_to, d, off, convert);
 
   d = serial_dump_char(env->list_post, d, off, convert);
+  d = serial_dump_char(env->list_subscribe, d, off, convert);
   d = serial_dump_char(env->list_unsubscribe, d, off, convert);
   d = serial_dump_char(env->subject, d, off, convert);
 
@@ -551,6 +552,7 @@ void serial_restore_envelope(struct Envelope *env, const unsigned char *d, int *
   serial_restore_address(&env->mail_followup_to, d, off, convert);
 
   serial_restore_char(&env->list_post, d, off, convert);
+  serial_restore_char(&env->list_subscribe, d, off, convert);
   serial_restore_char(&env->list_unsubscribe, d, off, convert);
 
   const bool c_auto_subscribe = cs_subset_bool(NeoMutt->sub, "auto_subscribe");

--- a/imap/message.c
+++ b/imap/message.c
@@ -1060,8 +1060,8 @@ static int read_headers_fetch_new(struct Mailbox *m, unsigned int msn_begin,
   struct Buffer *buf = NULL;
   static const char *const want_headers =
       "DATE FROM SENDER SUBJECT TO CC MESSAGE-ID REFERENCES CONTENT-TYPE "
-      "CONTENT-DESCRIPTION IN-REPLY-TO REPLY-TO LINES LIST-POST X-LABEL "
-      "X-ORIGINAL-TO";
+      "CONTENT-DESCRIPTION IN-REPLY-TO REPLY-TO LINES LIST-POST "
+      "LIST-SUBSCRIBE LIST-UNSUBSCRIBE X-LABEL X-ORIGINAL-TO";
 
   struct ImapAccountData *adata = imap_adata_get(m);
   struct ImapMboxData *mdata = imap_mdata_get(m);

--- a/index/functions.c
+++ b/index/functions.c
@@ -677,6 +677,24 @@ static int op_list_reply(struct IndexSharedData *shared, struct IndexPrivateData
 }
 
 /**
+ * op_list_subscribe - subscribe to a mailing list - Implements ::index_function_t - @ingroup index_function_api
+ */
+static int op_list_subscribe(struct IndexSharedData *shared,
+                             struct IndexPrivateData *priv, int op)
+{
+  return mutt_send_list_subscribe(shared->mailbox, shared->email) ? IR_SUCCESS : IR_NO_ACTION;
+}
+
+/**
+ * op_list_unsubscribe - unsubscribe from mailing list - Implements ::index_function_t - @ingroup index_function_api
+ */
+static int op_list_unsubscribe(struct IndexSharedData *shared,
+                               struct IndexPrivateData *priv, int op)
+{
+  return mutt_send_list_unsubscribe(shared->mailbox, shared->email) ? IR_SUCCESS : IR_NO_ACTION;
+}
+
+/**
  * op_mail - compose a new mail message - Implements ::index_function_t - @ingroup index_function_api
  */
 static int op_mail(struct IndexSharedData *shared, struct IndexPrivateData *priv, int op)
@@ -3046,6 +3064,8 @@ struct IndexFunction IndexFunctions[] = {
   { OP_LAST_ENTRY,                       op_menu_move,                      CHECK_NO_FLAGS },
   { OP_LIMIT_CURRENT_THREAD,             op_main_limit,                     CHECK_IN_MAILBOX },
   { OP_LIST_REPLY,                       op_list_reply,                     CHECK_ATTACH | CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE },
+  { OP_LIST_SUBSCRIBE,                   op_list_subscribe,                 CHECK_ATTACH | CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE },
+  { OP_LIST_UNSUBSCRIBE,                 op_list_unsubscribe,               CHECK_ATTACH | CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE },
   { OP_MAIL,                             op_mail,                           CHECK_ATTACH },
   { OP_MAILBOX_LIST,                     op_mailbox_list,                   CHECK_NO_FLAGS },
   { OP_MAIL_KEY,                         op_mail_key,                       CHECK_ATTACH },

--- a/opcodes.h
+++ b/opcodes.h
@@ -212,6 +212,7 @@
   _fmt(OP_NEXT_PAGE,                      N_("move to the next page")) \
   _fmt(OP_PAGER_BOTTOM,                   N_("jump to the bottom of the message")) \
   _fmt(OP_PAGER_HIDE_QUOTED,              N_("toggle display of quoted text")) \
+  _fmt(OP_PAGER_LIST_UNSUBSCRIBE,         N_("unsubscribe from mailing list")) \
   _fmt(OP_PAGER_SKIP_QUOTED,              N_("skip beyond quoted text")) \
   _fmt(OP_PAGER_SKIP_HEADERS,             N_("jump to first line after headers")) \
   _fmt(OP_PAGER_TOP,                      N_("jump to the top of the message")) \

--- a/opcodes.h
+++ b/opcodes.h
@@ -161,6 +161,8 @@
   _fmt(OP_LAST_ENTRY,                     N_("move to the last entry")) \
   _fmt(OP_LIMIT_CURRENT_THREAD,           N_("limit view to current thread")) \
   _fmt(OP_LIST_REPLY,                     N_("reply to specified mailing list")) \
+  _fmt(OP_LIST_SUBSCRIBE,                 N_("subscribe to a mailing list")) \
+  _fmt(OP_LIST_UNSUBSCRIBE,               N_("unsubscribe from a mailing list")) \
   _fmt(OP_LOAD_ACTIVE,                    N_("load list of all newsgroups from NNTP server")) \
   _fmt(OP_MACRO,                          N_("execute a macro")) \
   _fmt(OP_MAIL,                           N_("compose a new mail message")) \
@@ -212,8 +214,6 @@
   _fmt(OP_NEXT_PAGE,                      N_("move to the next page")) \
   _fmt(OP_PAGER_BOTTOM,                   N_("jump to the bottom of the message")) \
   _fmt(OP_PAGER_HIDE_QUOTED,              N_("toggle display of quoted text")) \
-  _fmt(OP_PAGER_LIST_SUBSCRIBE,           N_("subscribe to a mailing list")) \
-  _fmt(OP_PAGER_LIST_UNSUBSCRIBE,         N_("unsubscribe from a mailing list")) \
   _fmt(OP_PAGER_SKIP_QUOTED,              N_("skip beyond quoted text")) \
   _fmt(OP_PAGER_SKIP_HEADERS,             N_("jump to first line after headers")) \
   _fmt(OP_PAGER_TOP,                      N_("jump to the top of the message")) \

--- a/opcodes.h
+++ b/opcodes.h
@@ -212,7 +212,8 @@
   _fmt(OP_NEXT_PAGE,                      N_("move to the next page")) \
   _fmt(OP_PAGER_BOTTOM,                   N_("jump to the bottom of the message")) \
   _fmt(OP_PAGER_HIDE_QUOTED,              N_("toggle display of quoted text")) \
-  _fmt(OP_PAGER_LIST_UNSUBSCRIBE,         N_("unsubscribe from mailing list")) \
+  _fmt(OP_PAGER_LIST_SUBSCRIBE,           N_("subscribe to a mailing list")) \
+  _fmt(OP_PAGER_LIST_UNSUBSCRIBE,         N_("unsubscribe from a mailing list")) \
   _fmt(OP_PAGER_SKIP_QUOTED,              N_("skip beyond quoted text")) \
   _fmt(OP_PAGER_SKIP_HEADERS,             N_("jump to first line after headers")) \
   _fmt(OP_PAGER_TOP,                      N_("jump to the top of the message")) \

--- a/pager/functions.c
+++ b/pager/functions.c
@@ -823,71 +823,6 @@ static int op_pager_hide_quoted(struct IndexSharedData *shared,
   return IR_SUCCESS;
 }
 
-/*
- * TODO - how about a simple API to send an email given from/to/subject/body?
- */
-static void send_simple_email(struct Mailbox *m, const char *mailto, const char *body)
-{
-  struct Email *e = email_new();
-  e->env = mutt_env_new();
-  mutt_parse_mailto(e->env, NULL, mailto);
-  e->body = mutt_body_new();
-  char ctype[] = "text/plain";
-  mutt_parse_content_type(ctype, e->body);
-  char tempfile[PATH_MAX];
-  mutt_mktemp(tempfile, sizeof(tempfile));
-  FILE *fp = mutt_file_fopen(tempfile, "w+");
-  fprintf(fp, "%s\n", body);
-  mutt_file_fclose(&fp);
-  e->body->unlink = true;
-  e->body->filename = mutt_str_dup(tempfile);
-  mutt_send_message(SEND_DRAFT_FILE, e, NULL, m, NULL, NeoMutt->sub);
-}
-
-/**
- * op_pager_list_subscribe - subscribe to a mailing list - Implements ::pager_function_t - @ingroup pager_function_api
- */
-static int op_pager_list_subscribe(struct IndexSharedData *shared,
-                                   struct PagerPrivateData *priv, int op)
-{
-  if (!(shared->email && shared->email->env))
-  {
-    return IR_NO_ACTION;
-  }
-
-  const char *mailto = shared->email->env->list_subscribe;
-  if (!mailto)
-  {
-    mutt_warning(_("No List-Subscribe header found"));
-    return IR_NO_ACTION;
-  }
-
-  send_simple_email(shared->mailbox, mailto, "subscribe");
-  return IR_SUCCESS;
-}
-
-/**
- * op_pager_list_unsubscribe - unsubscribe from mailing list - Implements ::pager_function_t - @ingroup pager_function_api
- */
-static int op_pager_list_unsubscribe(struct IndexSharedData *shared,
-                                     struct PagerPrivateData *priv, int op)
-{
-  if (!(shared->email && shared->email->env))
-  {
-    return IR_NO_ACTION;
-  }
-
-  const char *mailto = shared->email->env->list_unsubscribe;
-  if (!mailto)
-  {
-    mutt_warning(_("No List-Subscribe header found"));
-    return IR_NO_ACTION;
-  }
-
-  send_simple_email(shared->mailbox, mailto, "unsubscribe");
-  return IR_SUCCESS;
-}
-
 /**
  * op_pager_skip_headers - jump to first line after headers - Implements ::pager_function_t - @ingroup pager_function_api
  */
@@ -1210,6 +1145,30 @@ static int op_reply(struct IndexSharedData *shared, struct PagerPrivateData *pri
   }
   pager_queue_redraw(priv, MENU_REDRAW_FULL);
   return IR_SUCCESS;
+}
+
+/**
+ * op_list_subscribe - subscribe to a mailing list - Implements ::pager_function_t - @ingroup pager_function_api
+ */
+static int op_list_subscribe(struct IndexSharedData *shared,
+                             struct PagerPrivateData *priv, int op)
+{
+  const int rc = mutt_send_list_subscribe(shared->mailbox, shared->email) ? IR_SUCCESS : IR_NO_ACTION;
+  pager_queue_redraw(priv, MENU_REDRAW_FULL);
+  return rc;
+}
+
+/**
+ * op_list_unsubscribe - unsubscribe from mailing list - Implements ::pager_function_t - @ingroup pager_function_api
+ */
+static int op_list_unsubscribe(struct IndexSharedData *shared,
+                               struct PagerPrivateData *priv, int op)
+{
+  const int rc = mutt_send_list_unsubscribe(shared->mailbox, shared->email) ?
+                     IR_SUCCESS :
+                     IR_NO_ACTION;
+  pager_queue_redraw(priv, MENU_REDRAW_FULL);
+  return rc;
 }
 
 /**
@@ -1887,8 +1846,6 @@ struct PagerFunction PagerFunctions[] = {
   { OP_NEXT_PAGE,              op_next_page },
   { OP_PAGER_BOTTOM,           op_pager_bottom },
   { OP_PAGER_HIDE_QUOTED,      op_pager_hide_quoted },
-  { OP_PAGER_LIST_SUBSCRIBE,   op_pager_list_subscribe },
-  { OP_PAGER_LIST_UNSUBSCRIBE, op_pager_list_unsubscribe },
   { OP_PAGER_SKIP_HEADERS,     op_pager_skip_headers },
   { OP_PAGER_SKIP_QUOTED,      op_pager_skip_quoted },
   { OP_PAGER_TOP,              op_pager_top },
@@ -1905,6 +1862,8 @@ struct PagerFunction PagerFunctions[] = {
   { OP_GROUP_CHAT_REPLY,       op_reply },
   { OP_GROUP_REPLY,            op_reply },
   { OP_LIST_REPLY,             op_reply },
+  { OP_LIST_SUBSCRIBE,         op_list_subscribe },
+  { OP_LIST_UNSUBSCRIBE,       op_list_unsubscribe },
   { OP_REPLY,                  op_reply },
   { OP_RESEND,                 op_resend },
   { OP_SAVE,                   op_save },

--- a/pager/functions.c
+++ b/pager/functions.c
@@ -824,6 +824,42 @@ static int op_pager_hide_quoted(struct IndexSharedData *shared,
 }
 
 /**
+ * op_pager_list_unsubscribe - unsubscribe from mailing list - Implements ::pager_function_t - @ingroup pager_function_api
+ */
+static int op_pager_list_unsubscribe(struct IndexSharedData *shared,
+                                     struct PagerPrivateData *priv, int op)
+{
+  if (!(shared->email && shared->email->env && shared->email->env->list_unsubscribe))
+  {
+    return IR_NO_ACTION;
+  }
+
+  const char *mailto = shared->email->env->list_unsubscribe;
+
+  /*
+   * TODO - how about a simple API to send an email given from/to/subject/body?
+   */
+  {
+    struct Email *e = email_new();
+    e->env = mutt_env_new();
+    mutt_parse_mailto(e->env, NULL, mailto);
+    e->body = mutt_body_new();
+    char ctype[] = "text/plain";
+    mutt_parse_content_type(ctype, e->body);
+    char tempfile[PATH_MAX];
+    mutt_mktemp(tempfile, sizeof(tempfile));
+    FILE *fp = mutt_file_fopen(tempfile, "w+");
+    fprintf(fp, "Unsubscribe\n");
+    mutt_file_fclose(&fp);
+    e->body->unlink = true;
+    e->body->filename = mutt_str_dup(tempfile);
+    mutt_send_message(SEND_DRAFT_FILE, e, NULL, shared->mailbox, NULL, NeoMutt->sub);
+  }
+
+  return IR_SUCCESS;
+}
+
+/**
  * op_pager_skip_headers - jump to first line after headers - Implements ::pager_function_t - @ingroup pager_function_api
  */
 static int op_pager_skip_headers(struct IndexSharedData *shared,
@@ -1822,6 +1858,7 @@ struct PagerFunction PagerFunctions[] = {
   { OP_NEXT_PAGE,              op_next_page },
   { OP_PAGER_BOTTOM,           op_pager_bottom },
   { OP_PAGER_HIDE_QUOTED,      op_pager_hide_quoted },
+  { OP_PAGER_LIST_UNSUBSCRIBE, op_pager_list_unsubscribe },
   { OP_PAGER_SKIP_HEADERS,     op_pager_skip_headers },
   { OP_PAGER_SKIP_QUOTED,      op_pager_skip_quoted },
   { OP_PAGER_TOP,              op_pager_top },

--- a/send/send.h
+++ b/send/send.h
@@ -67,5 +67,7 @@ void            mutt_make_post_indent(struct Email *e, FILE *fp_out, struct Conf
 int             mutt_resend_message(FILE *fp, struct Mailbox *m, struct Email *e_cur, struct ConfigSubset *sub);
 int             mutt_send_message(SendFlags flags, struct Email *e_templ, const char *tempfile, struct Mailbox *m, struct EmailList *el, struct ConfigSubset *sub);
 void            mutt_set_followup_to(struct Envelope *env, struct ConfigSubset *sub);
+bool            mutt_send_list_subscribe(struct Mailbox *m, const struct Email *e);
+bool            mutt_send_list_unsubscribe(struct Mailbox *m, const struct Email *e);
 
 #endif /* MUTT_SEND_H */


### PR DESCRIPTION
This function uses the List-Subscribe and List-Unsubscribe headers from [RFC2369](https://datatracker.ietf.org/doc/html/rfc2369) to send a subscribe/unsubscribe email request. Works best with `unignore list-subscribe list-unsubscribe`.

**TODO**

- [x] documentation
- [x] implement simple API to send an email - I'll keep this internal for now.