### PR TITLE
compose: include autocrypt depending on USE_AUTOCRYPT

### DIFF
--- a/compose/functions.c
+++ b/compose/functions.c
@@ -47,7 +47,9 @@
 #include "functions.h"
 #include "lib.h"
 #include "attach/lib.h"
+#ifdef USE_AUTOCRYPT
 #include "autocrypt/lib.h"
+#endif
 #include "index/lib.h"
 #include "menu/lib.h"
 #include "ncrypt/lib.h"


### PR DESCRIPTION
* **What does this PR do?**
It adds an `ifdef USE_AUTOCRYPT` around the inclusion of `autocrypt/lib.h`. This `ifdef` "vanished" during the refactoring at commit c4ff91c0cd55b7995171340d9d7a680a792d1599.

Without this patch I cannot compile neomutt without autocrypt-support.