### PR TITLE
resize: Include termios.h to get size of struct winsize.

### DIFF
--- a/resize.c
+++ b/resize.c
@@ -43,6 +43,7 @@
 #include <ioctl.h>
 #endif
 #endif
+#include <termios.h>
 
 /**
  * mutt_get_winsize - Use an ioctl to get the window size


### PR DESCRIPTION
Fix the build on Solaris/illumos.

Without this, the build fails with:
```
gcc -I/usr/include/kerberosv5 -I/usr/include/gssapi -I/usr/include -I/opt/pkg/include -I/opt/pkg/include/ncurses -pipe -fno-aggressive-loop-optimizations -pipe -fno-aggressive-loop-optimizations -D_FORTIFY_SOURCE=2 -I/usr/include/kerberosv5 -I/usr/include/gssapi -I/usr/include -I/opt/pkg/include -I/opt/pkg/include/ncurses -std=c99 -fno-delete-null-pointer-checks -D_ALL_SOURCE=1 -D_GNU_SOURCE=1 -D__EXTENSIONS__ -DNCURSES_WIDECHAR -I. -I. -Wall  -I./test -MT resize.o -MD -MP -MF resize.Tpo -c -o resize.o resize.c
resize.c:51:23: error: return type is an incomplete type
  51 | static struct winsize mutt_get_winsize(void)
     |                       ^~~~~~~~~~~~~~~~
resize.c: In function 'mutt_get_winsize':
resize.c:53:10: error: variable 'w' has initializer but incomplete type
  53 |   struct winsize w = { 0 };
     |          ^~~~~~~
resize.c:53:24: warning: excess elements in struct initializer
  53 |   struct winsize w = { 0 };
     |                        ^
resize.c:53:24: note: (near initialization for 'w')
resize.c:53:18: error: storage size of 'w' isn't known
  53 |   struct winsize w = { 0 };
     |                  ^
resize.c:57:15: error: 'TIOCGWINSZ' undeclared (first use in this function)
  57 |     ioctl(fd, TIOCGWINSZ, &w);
     |               ^~~~~~~~~~
resize.c:57:15: note: each undeclared identifier is reported only once for each function it appears in
resize.c:60:10: warning: 'return' with a value, in function returning void [-Wreturn-type]
  60 |   return w;
     |          ^
resize.c:51:23: note: declared here
  51 | static struct winsize mutt_get_winsize(void)
     |                       ^~~~~~~~~~~~~~~~
resize.c:53:18: warning: unused variable 'w' [-Wunused-variable]
  53 |   struct winsize w = { 0 };
     |                  ^
resize.c: In function 'mutt_resize_screen':
resize.c:103:10: error: variable 'w' has initializer but incomplete type
 103 |   struct winsize w = mutt_get_winsize();
     |          ^~~~~~~
resize.c:103:18: error: storage size of 'w' isn't known
 103 |   struct winsize w = mutt_get_winsize();
     |                  ^
resize.c:103:18: warning: unused variable 'w' [-Wunused-variable]
```