### PR TITLE
notmuch: respect mark_old

### DIFF
--- a/notmuch/notmuch.c
+++ b/notmuch/notmuch.c
@@ -536,7 +536,10 @@ static int update_message_path(struct Email *e, const char *path)
     FREE(&edata->folder);
 
     p -= 3; /* skip subfolder (e.g. "new") */
-    e->old = mutt_str_startswith(p, "cur");
+    if (cs_subset_bool(NeoMutt->sub, "mark_old"))
+    {
+      e->old = mutt_str_startswith(p, "cur");
+    }
     e->path = mutt_str_dup(p);
 
     for (; (p > path) && (*(p - 1) == '/'); p--)


### PR DESCRIPTION
Only mark messages as old when the user has set mark_old.

Fixes https://github.com/neomutt/neomutt/issues/3047


Note, that introduces a new user of the global config object, that's what maildir does.
Would you rather have the function accept the config as a parameter?