### PR TITLE
fix parsing of user headers

### DIFF
--- a/email/parse.c
+++ b/email/parse.c
@@ -1059,22 +1059,20 @@ int mutt_rfc822_parse_line(struct Envelope *env, struct Email *e, const char *na
   if (!matched && user_hdrs)
   {
     const bool c_weed = cs_subset_bool(NeoMutt->sub, "weed");
-    if (!weed && !c_weed)
+    char *dup = NULL;
+    mutt_str_asprintf(&dup, "%s: %s", name, body);
+
+    if (!weed || !c_weed || !mutt_matches_ignore(dup))
     {
-      char *dup = NULL;
-      mutt_str_asprintf(&dup, "%s:%s", name, body);
-      if (!mutt_matches_ignore(dup))
+      struct ListNode *np = mutt_list_insert_tail(&env->userhdrs, dup);
+      if (do_2047)
       {
-        struct ListNode *np = mutt_list_insert_tail(&env->userhdrs, dup);
-        if (do_2047)
-        {
-          rfc2047_decode(&np->data);
-        }
+        rfc2047_decode(&np->data);
       }
-      else
-      {
-        FREE(&dup);
-      }
+    }
+    else
+    {
+      FREE(&dup);
     }
   }
 


### PR DESCRIPTION
Fix logical test in `mutt_rfc822_parse_line` from commit d2bd01662a9

* **What does this PR do?**

In the commit d2bd01662a9 the parsing of the user headers changed.

Before: https://github.com/neomutt/neomutt/blob/a86eda64bfdd4477bbbd6c60081ffd98218039a8/email/parse.c#L1025-L1030
With this commit: https://github.com/neomutt/neomutt/blob/d2bd01662a94de29ca052de395f168ee8192b4f9/email/parse.c#L1022-L1038

Before: The header line was added iff `weed` and/or `c_weed` and/or `mutt_matches_ignore` was `false`. To put it in other words: It was enough that one of the three was `false`.

In my case I had the (pseudo-)header line (added in the editor, and obviously `user_hdrs` is `true`):

```
Pgp: ES
```
and the command `ignore *` and `Pgp` is/was *not* mentioned in the `unignore` command. Then reaching the location at the source code the variables are:
`c_weed = true`, `weed = false` and `mutt_matches_ignore` is true.

Before the change in the commit d2bd01662a9 this was enough to trigger the `if` and the header-line was appended to the user headers, which what I want and which, I think, is according to the documentation. (It states that the `ignore` and `unignore` commands are for the lines *visible* in the pager.)

After the change in the commit d2bd01662a9 all of the three tests have to be false in order for this line to be added. [Remember `!(A && B)`  is equivalent to `!A || !B`]

With the PR I try to bring back the old test (which I believe does the thing like documented). More than one line was changed because this commit introduced `name` and `body` instead of the old all-in-one `line`. And for the `mutt_matches_ignore`-test a `line` is needed. So I always generate the `dup` in order to make this test possible.

Caution: 
I also added a space in the `asprintf` format string, to have a space after the colon. This mimics the old "format" where there (typically) was a space there. I don't know if this space was removed on purpose.Then this PR has to be changed.
