### PR TITLE
coverity scan

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,0 +1,56 @@
+name: Coverity
+on:
+  push:
+    schedule:
+      - cron: '0 3 * * 1'
+        # Mondays at 3am
+
+jobs:
+  build:
+    name: Coverity
+    runs-on: ubuntu-latest
+    container: ghcr.io/neomutt/neomutt-docker-build
+
+    env:
+      TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}
+      OPTIONS: --autocrypt --bdb --disable-idn --full-doc --gdbm --gnutls --gpgme --gss --idn2 --kyotocabinet --lmdb --lua --lz4 --notmuch --qdbm --sasl --tdb --tokyocabinet --with-lock=fcntl --with-ui=ncurses --zlib --zstd
+      COV_TOOLS: cov-tools
+      COV_RESULTS: cov-int
+
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v2
+      with:
+        ref: master
+
+    - name: Configure Neomutt
+      run: ./configure $OPTIONS
+
+    - name: Download Coverity
+      run: |
+        wget --quiet https://scan.coverity.com/download/linux64 --post-data "token=$TOKEN&project=neomutt%2Fneomutt" -O "$COV_TOOLS.tar.gz"
+        mkdir "$COV_TOOLS"
+        tar xzf "$COV_TOOLS.tar.gz" --strip 1 -C "$COV_TOOLS"
+        ls -l "$COV_TOOLS"
+
+    - name: Build with Coverity
+      run: |
+        export PATH="$(pwd)/$COV_TOOLS/bin:$PATH"
+        cov-build --dir $COV_RESULTS make -j 2
+
+    - name: Submit Results
+      run: |
+        tar -czf neomutt.tgz $COV_RESULTS
+        ls -lh neomutt.tgz
+        GIT_HASH="$(git rev-parse --short master)"
+        echo "HASH: $GIT_HASH"
+        GIT_DESC="$(git log -n1 --format="%s" $GIT_HASH)"
+        echo "DESC: $GIT_DESC"
+        curl \
+          --form token=$TOKEN \
+          --form email=richard.russon@gmail.com \
+          --form file=@neomutt.tgz \
+          --form version="$GIT_HASH" \
+          --form description="$GIT_DESC" \
+          https://scan.coverity.com/builds?project=neomutt%2Fneomutt
+


### PR DESCRIPTION
Use a GitHub Action to perform automatic Coverity Scans.

The action is triggered by a [cron job](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#onschedule).
The job is scheduled for: Mondays at 3am.

This PR removes another dependency on TravisCI.