### PR TITLE
fix leak of hidden mailbox

### DIFF
--- a/main.c
+++ b/main.c
@@ -1365,7 +1365,10 @@ int main(int argc, char *argv[], char *envp[])
       mutt_debug(LL_NOTIFY, "NT_MAILBOX_SWITCH: %p\n", m);
       notify_send(dlg->notify, NT_MAILBOX, NT_MAILBOX_SWITCH, &ev_m);
 
-      mutt_index_menu(dlg, m);
+      m = mutt_index_menu(dlg, m);
+      if (m->flags == MB_HIDDEN)
+        mailbox_free(&m);
+
       dialog_pop();
       mutt_window_free(&dlg);
       log_queue_empty();


### PR DESCRIPTION
If the current Mailbox isn't in the sidebar, then it would be leaked when exiting NeoMutt.

**Setup**:
- Using several mailboxes: **apple**, **banana**, **cherry**, **damson**
- Config: `mailboxes apple banana`

**Tests**:

1. `set spoolfile = apple`
   `<quit>`

1. `set spoolfile = apple`
   `<change-folder>banana`
   `<quit>`

1. `set spoolfile = cherry`
   `<quit>`

1. `set spoolfile = cherry`
   `<change-folder>damson`
   `<quit>`

1. `set spoolfile = apple`
   `<change-folder>cherry`
   `<quit>`

1. `set spoolfile = cherry`
   `<change-folder>apple`
   `<quit>`