### PR TITLE
fix(index): find next mailbox with unread mail

### DIFF
--- a/index/functions.c
+++ b/index/functions.c
@@ -1342,7 +1342,7 @@ static int op_main_next_undeleted(struct IndexSharedData *shared,
 }
 
 /**
- * op_main_next_unread_mailbox - open next mailbox with new mail - Implements ::index_function_t - @ingroup index_function_api
+ * op_main_next_unread_mailbox - open next mailbox with unread mail - Implements ::index_function_t - @ingroup index_function_api
  */
 static int op_main_next_unread_mailbox(struct IndexSharedData *shared,
                                        struct IndexPrivateData *priv, int op)
@@ -1351,7 +1351,7 @@ static int op_main_next_unread_mailbox(struct IndexSharedData *shared,
 
   struct Buffer *folderbuf = mutt_buffer_pool_get();
   mutt_buffer_strcpy(folderbuf, mailbox_path(m));
-  m = mutt_mailbox_next(m, folderbuf);
+  m = mutt_mailbox_next_unread(m, folderbuf);
   mutt_buffer_pool_release(&folderbuf);
 
   if (!m)

--- a/mutt_mailbox.h
+++ b/mutt_mailbox.h
@@ -36,6 +36,7 @@ int  mutt_mailbox_check       (struct Mailbox *m_cur, int force);
 void mutt_mailbox_cleanup     (const char *path, struct stat *st);
 bool mutt_mailbox_list        (void);
 struct Mailbox *mutt_mailbox_next(struct Mailbox *m_cur, struct Buffer *s);
+struct Mailbox *mutt_mailbox_next_unread(struct Mailbox *m_cur, struct Buffer *s);
 bool mutt_mailbox_notify      (struct Mailbox *m_cur);
 void mutt_mailbox_set_notified(struct Mailbox *m);
 


### PR DESCRIPTION
Existing implementation of `next-unread-mailbox` finds the next mailbox
with new mail. This contradicts the function's name and
documentation[0], which states:

   The (by default unbound) function `<next-unread-mailbox>` in the
   index can be used to immediately open the next folder with unread
   mail (if any).

To bring implementation in line with the name and documentation,
introduce 'mutt_mailbox_next_unread()', which mirrors
'mutt_mailbox_next()' except it for unread check mail and omission of
stat checking, and call it.

[0] https://neomutt.org/guide/advancedusage#13-2-%C2%A0polling-for-new-mail

-- 

* **What are the relevant issue numbers?**

Partial fix for #3053 

Per discussion on IRC, this PR is meant to ensure `next-unread-mailbox` works for the next release. Future PRs will introduce `next-new-mailbox` (more design consideration needed), fix `sidebar-next/prev-new` naming, and update the error message (omitted from this commit so translate work isn't need for PR.)