### PR TITLE
fix: leak of notmuch tags

### DIFF
--- a/notmuch/notmuch.c
+++ b/notmuch/notmuch.c
@@ -496,6 +496,7 @@ static int update_email_tags(struct Email *e, notmuch_message_t *msg)
     mutt_debug(LL_DEBUG2, "nm: tags unchanged\n");
     return 1;
   }
+  FREE(&old_tags);
 
   /* new version */
   driver_tags_replace(&e->tags, new_tags);


### PR DESCRIPTION
#3066 reports an unbelievable amount of leaks (454653).
The 8 unique call-stacks in the ASAN report all end:

- **`update_email_tags()`** https://github.com/neomutt/neomutt/blob/613e2c78fe0a077d7cf154053bbe3af06a0f51f9/notmuch/notmuch.c#L490
- **`driver_tags_get()`** https://github.com/neomutt/neomutt/blob/613e2c78fe0a077d7cf154053bbe3af06a0f51f9/email/tags.c#L147
- **`driver_tags_getter()`** https://github.com/neomutt/neomutt/blob/613e2c78fe0a077d7cf154053bbe3af06a0f51f9/email/tags.c#L66
- **`mutt_str_append_item()`** https://github.com/neomutt/neomutt/blob/613e2c78fe0a077d7cf154053bbe3af06a0f51f9/mutt/string.c#L474

The fix seems to simply be to free the `old_tags` in `update_email_tags()`.

Fixes: #3066