### PR TITLE
The CLOSE command is the last thing we send, so don't queue it

### DIFF
--- a/imap/imap.c
+++ b/imap/imap.c
@@ -1726,7 +1726,7 @@ enum MxStatus imap_sync_mailbox(struct Mailbox *m, bool expunge, bool close)
   if (expunge && close)
   {
     adata->closing = true;
-    imap_exec(adata, "CLOSE", IMAP_CMD_QUEUE);
+    imap_exec(adata, "CLOSE", IMAP_CMD_NO_FLAGS);
     adata->state = IMAP_AUTHENTICATED;
   }
 


### PR DESCRIPTION
We were putting a `CLOSE` in the imap queue, but we were never going to flush it.