### PR TITLE
Fix segfault on OpenBSD current

### DIFF
--- a/conn/getdomain.c
+++ b/conn/getdomain.c
@@ -148,7 +148,9 @@ int getdnsdomainname(struct Buffer *result)
     mutt_buffer_strcpy(result, ++hostname);
     rc = 0;
   }
-  freeaddrinfo(lookup_result);
+
+  if (lookup_result)
+    freeaddrinfo(lookup_result);
 #endif
 
   return rc;


### PR DESCRIPTION
NeoMutt segfaults on OpenBSD current.

```
(gdb) bt
#0  _libc_freeaddrinfo (ai=0x0) at /usr/src/lib/libc/net/freeaddrinfo.c:46
#1  0x0000075218dbab26 in getdnsdomainname (result=0x754f5ca5a80) at ../neomutt-20211015/conn/getdomain.c:152
#2  0x0000075218d13f6f in get_hostname (cs=0x754f5cac000) at ../neomutt-20211015/init.c:357
#3  mutt_init (cs=<optimized out>, skip_sys_rc=<optimized out>, commands=0x7f7ffffed558) at ../neomutt-20211015/init.c:919
#4  0x0000075218d1cc64 in main (argc=1, argv=0x7f7ffffed748, envp=<optimized out>) at ../neomutt-20211015/main.c:786
```

It seems that `freeaddrinfo()` tries to release a structure, which has
not been allocated. Proposed fix is to check before releasing.