### PR TITLE
fix: assert in pager

### DIFF
--- a/pager/dlg_pager.c
+++ b/pager/dlg_pager.c
@@ -513,9 +513,7 @@ int mutt_pager(struct PagerView *pview)
       // this case was previously identified by IsAttach and IsMsgAttach
       // macros, we expect data to contain:
       //  - body (viewing regular attachment)
-      //  - email
       //  - fp and body->email in special case of viewing an attached email.
-      assert(shared->email); // This should point to the top level email
       assert(pview->pdata->body);
       if (pview->pdata->fp && pview->pdata->body->email)
       {


### PR DESCRIPTION
When viewing a file from the Browser, there won't be a current Email.

The `assert()` isn't needed.
All the functions that use `shared->email` are behind checks for `PAGER_MODE_EMAIL`.

**To Test**:
- Open browser `<change-folder>`
- Change folder to a local dir
- Select a file
- View the file <kbd>\<Space></kbd> (`<view-file>`)
