### PR TITLE
fix: exec command in compose

### DIFF
--- a/compose/compose.c
+++ b/compose/compose.c
@@ -382,6 +382,7 @@ static struct MuttWindow *compose_dlg_init(struct ConfigSubset *sub,
 
   dlg->help_data = ComposeHelp;
   dlg->help_menu = MENU_COMPOSE;
+  dlg->focus = win_attach;
 
   return dlg;
 }


### PR DESCRIPTION
Running `:exec attach-file` in the Compose Dialog failed with "attach-file: no such function"

---

The Compose Dialog must set the focus to the Attachments Menu.

When `mutt_enter_command()` is called, it gets the uses the focused Window to determine which commands are available.

Thanks to David K. Trudgett (@eclecticSoftwareEngineer) for the bug report.