### PR TITLE
fix: move 'check_stats' check to MUTT_NOTMUCH case

### DIFF
--- a/mutt_mailbox.c
+++ b/mutt_mailbox.c
@@ -118,16 +118,21 @@ static void mailbox_check(struct Mailbox *m_cur, struct Mailbox *m_check,
       cs_subset_bool(NeoMutt->sub, "check_mbox_size");
 
   /* check to see if the folder is the currently selected folder before polling */
-  if (check_stats && !is_same_mailbox(m_cur, m_check, st_ctx, &st))
+  if (!is_same_mailbox(m_cur, m_check, st_ctx, &st))
   {
     switch (m_check->type)
     {
+      case MUTT_NOTMUCH:
+        // Remove this when non-notmuch backends only check unread, flagged,
+        // and total counts per 'mbox_check_stats' docs.
+        if (!check_stats)
+          break;
+        /* fall through */
       case MUTT_IMAP:
       case MUTT_MBOX:
       case MUTT_MMDF:
       case MUTT_MAILDIR:
       case MUTT_MH:
-      case MUTT_NOTMUCH:
         mx_mbox_check_stats(m_check, check_stats);
         break;
       default:; /* do nothing */


### PR DESCRIPTION
This commits moves the check introduced in commit 0bef239d6 to the
notmuch case. This restores any functionality broken by 0bef239d6 while
keeping the goal of not leaking high-level details into the notmuch
'mbox_check_stats()' implementation.

This commit does not fix the fact that all other 'mbox_check_stats()'
implementations are aware they're called every 'mail_check' and that
they compute additional statistics not listed in the API docs nor
'mail_check_stats' docs. In addition, it does not fix the fact that
'mbox_check_stats()' is called more often than
'mail_check_stats_interval', but all non-notmuch backends handle this
with the 'check_stats' parameter.