### PR TITLE
Replace NULL with "" in call to notmuch 5.4 call to fix segmentation fault

### DIFF
--- a/notmuch/db.c
+++ b/notmuch/db.c
@@ -121,7 +121,7 @@ notmuch_database_t *nm_db_do_open(const char *filename, bool writable, bool verb
   {
 #if LIBNOTMUCH_CHECK_VERSION(5, 4, 0)
     // notmuch 0.32-0.32.2 didn't bump libnotmuch version to 5.4.
-    st = notmuch_database_open_with_config(filename, mode, NULL, NULL, &db, &msg);
+    st = notmuch_database_open_with_config(filename, mode, "", NULL, &db, &msg);
 #elif LIBNOTMUCH_CHECK_VERSION(4, 2, 0)
     st = notmuch_database_open_verbose(filename, mode, &db, &msg);
 #elif defined(NOTMUCH_API_3)


### PR DESCRIPTION
I haven't found a relevant issue, but in the new release 2021-10-15 together with notmuch 0.33.2, neomutt crashes with a segmentation fault in xapian. After debugging the issue, I found that the call to `notmuch_database_open_with_config` returns the status code `NOTMUCH_STATUS_NO_CONFIG` which in turn leads to a segmentation fault later on. It should not be fatal error, but apparently this sets `config_path` in the query struct to the default value `$HOME/.notmuch-config` instead of setting `xapian_path`.

According the notmuch documentation, `notmuch_database_open_verbose` has been replaced with `notmuch_database_open_with_config` and `config_path=''` instead of `NULL`. 

Setting it to an empty string, fixes this issue for me.
