### PR TITLE
Fallback: Open Notmuch database without config

### DIFF
--- a/notmuch/db.c
+++ b/notmuch/db.c
@@ -122,6 +122,14 @@ notmuch_database_t *nm_db_do_open(const char *filename, bool writable, bool verb
 #if LIBNOTMUCH_CHECK_VERSION(5, 4, 0)
     // notmuch 0.32-0.32.2 didn't bump libnotmuch version to 5.4.
     st = notmuch_database_open_with_config(filename, mode, NULL, NULL, &db, &msg);
+    if (st == NOTMUCH_STATUS_NO_CONFIG)
+    {
+      mutt_debug(LL_DEBUG1,
+                 "nm: Could not find a Notmuch configuration file\n");
+      FREE(&msg);
+
+      st = notmuch_database_open_with_config(filename, mode, "", NULL, &db, &msg);
+    }
 #elif LIBNOTMUCH_CHECK_VERSION(4, 2, 0)
     st = notmuch_database_open_verbose(filename, mode, &db, &msg);
 #elif defined(NOTMUCH_API_3)


### PR DESCRIPTION
After a failed attempt opening notmuch database with default config, fall back to using notmuch without a configuration file.

See #3082 for discussion.