### PR TITLE
fix(notmuch): null DB pointer on open failure

### DIFF
--- a/notmuch/db.c
+++ b/notmuch/db.c
@@ -149,6 +149,11 @@ notmuch_database_t *nm_db_do_open(const char *filename, bool writable, bool verb
     ct++;
   } while (true);
 
+  if (st != NOTMUCH_STATUS_SUCCESS)
+  {
+    db = NULL;
+  }
+
   if (verbose)
   {
     if (!db)


### PR DESCRIPTION
This commit nulls 'db' if there's an error in opening the database. The
discussion on #3082 revealed that a failure to open the database is not
guaranteed to NULL the database pointer. So our existing NULL checks in
'nm_db_do_open()' won't function and we may return an invalid non-NULL
database pointer.
