### PR TITLE
Fix use after free of a->mailbox due to missing strdup

### DIFF
--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -3581,7 +3581,7 @@ static struct CryptKeyInfo *crypt_getkeybyaddr(struct Address *a,
   *forced_valid = 0;
 
   if (a && a->mailbox)
-    mutt_list_insert_tail(&hints, a->mailbox);
+    mutt_list_insert_tail(&hints, mutt_str_dup(a->mailbox));
   if (a && a->personal)
     crypt_add_string_to_hints(a->personal, &hints);
 

--- a/ncrypt/pgpkey.c
+++ b/ncrypt/pgpkey.c
@@ -369,7 +369,7 @@ struct PgpKeyInfo *pgp_getkeybyaddr(struct Address *a, KeyFlags abilities,
   struct PgpUid *q = NULL;
 
   if (a->mailbox)
-    mutt_list_insert_tail(&hints, a->mailbox);
+    mutt_list_insert_tail(&hints, mutt_str_dup(a->mailbox));
   if (a->personal)
     pgp_add_string_to_hints(a->personal, &hints);
 


### PR DESCRIPTION
Commit 87ae932bcae3f229d681af9848015ba49049a581 changed `crypt_add_string_to_hints(a->mailbox, &hints)` to `mutt_list_insert_tail(&hints, a->mailbox)`. However, there is a behavioural difference between the two functions: [`crypt_add_string_to_hints()` adds a copy of the string to the list](https://github.com/neomutt/neomutt/blob/7a41cd9370b0afd9653934a4c73d4da3fd85332d/ncrypt/crypt_gpgme.c#L3549), while [`mutt_list_insert_tail()` does not](https://github.com/neomutt/neomutt/blob/fdf8eae4f74bcbca76f1c26eb7e12f1cdf12ec20/mutt/list.c#L62). This leads to a crash because the original `a->mailbox` is freed prematurely [as part of the `hints` list](https://github.com/neomutt/neomutt/blob/e9f3170930764eca9626bc6e51df53e62cbafd7b/ncrypt/crypt_gpgme.c#L3592). Fix this by adding a copy of the original to the list instead.

Note that commit 87ae932bcae3f229d681af9848015ba49049a581 originally [came from Mutt](https://gitlab.com/muttmua/mutt/-/commit/3cf7a1492e8a709adee0e003594d2b58b2953403). Upstream is not affected by this however because their `mutt_add_list()` functions [always copies the data](https://gitlab.com/muttmua/mutt/-/blob/75be20d605a976750a5c1a3bab9b56e87eabbd78/muttlib.c#L258).

Downstream tracking issue in Arch Linux: [FS#72525](https://bugs.archlinux.org/task/72525)