### PR TITLE
feat(notmuch): support separate database and mail roots without `.notmuch`

### DIFF
--- a/notmuch/db.c
+++ b/notmuch/db.c
@@ -282,11 +282,24 @@ int nm_db_get_mtime(struct Mailbox *m, time_t *mtime)
   if (!m || !mtime)
     return -1;
 
-  char path[PATH_MAX];
-  snprintf(path, sizeof(path), "%s/.notmuch/xapian", nm_db_get_filename(m));
-  mutt_debug(LL_DEBUG2, "nm: checking '%s' mtime\n", path);
-
   struct stat st = { 0 };
+  char path[PATH_MAX];
+  const char *db_filename = nm_db_get_filename(m);
+
+  mutt_debug(LL_DEBUG2, "nm: checking database mtime '%s'\n", db_filename);
+
+  // See if the path we were given has a Xapian directory.
+  // After notmuch 0.32, a .notmuch folder isn't guaranteed.
+  snprintf(path, sizeof(path), "%s/xapian", db_filename);
+  if (stat(path, &st) == 0)
+  {
+    *mtime = st.st_mtime;
+    return 0;
+  }
+
+  // Otherwise, check for a .notmuch directory.
+  snprintf(path, sizeof(path), "%s/.notmuch/xapian", db_filename);
+
   if (stat(path, &st) != 0)
     return -1;
 


### PR DESCRIPTION
This PR allows notmuch users to use setups, with separate database and mail roots, that do not have a `.notmuch` directory under the database root. As of notmuch 0.32, a `.notmuch` folder isn't guaranteed to exist for split database and mail root configurations.

To facilitate this:
 1. Remove checks for a `.notmuch` sub-directory in `nm_db_do_open()`. These were introduced in e2a6cfc to prevent a SEGFAULT caused by opening a directory without a database. As #3082 revealed, the `db` pointer isn't `NULL`'d on failure so it bypassed our error handling and returning a SEGFAULT-causing pointer. Commit e9f3170 `NULL`s the pointer so our error handling works again and we won't return a bad pointer.
2. Modify `nm_db_get_mtime()` to also check for a `xapian` sub-directory under `db_filename` instead of just expecting a `.notmuch/xapian` sub-directory.


Notes:
 - Using separate database and mail root setups **with** a `.notmuch` sub-dir have been possible since #3018.
 - Users now may fully-qualify the database path. Before users had to omit the `.notmuch` in `nm_default_url`. For example, `notmuch:///home/aray/mail/.notmuch` would fail as NeoMutt checked  for a `.notmuch` sub-dir under the provided path.
 
* **What are the relevant issue numbers?**

Closes #3020

---

@jindraj: Since this removes your checks, I want to get your thoughts. Is there any context, that I might be missing, which would necessitate keeping them?