### PR TITLE
Fix Bug "Could not decrypt PGP message" from commit 673c499

### DIFF
--- a/ncrypt/pgp.c
+++ b/ncrypt/pgp.c
@@ -1123,7 +1123,7 @@ static struct Body *pgp_decrypt_part(struct Body *a, struct State *s,
 
   rewind(fp_out);
   const long size = mutt_file_get_size_fp(fp_out);
-  if (size != 0)
+  if (size == 0)
   {
     goto cleanup;
   }


### PR DESCRIPTION
In Commit 673c4993aca23c06af0a7c6d7b97b2455c470ca3 in the file `ncrypt/pgp.c` the following modification was made (all the shown lines after `rewind`):

https://github.com/neomutt/neomutt/blob/673c4993aca23c06af0a7c6d7b97b2455c470ca3/ncrypt/pgp.c#L1123-L1128

This has for me the consequence that now I'm unable to open/view pgp-encrypted emails. I don't use gpgme, but neomutt has to parse the outputs of the pgp.commands.

The above modification results in the following behaviour ("good" = before; and "bad" = with this 5 additional lines):
```
good                                                   | bad
                                                       |
pgp_class_encrypted_handler                            | pgp_class_encrypted_handler
  ...                                                  |   ...
  pgp_decrypt_part                                     |   pgp_decrypt_part
    ...                                                |     ...
    pgp_invoke_decrypt                                 |     pgp_invoke_decrypt
    ...                                                |     ...
    [decryption successfull, with goodsig=false]       |     [decryption successfull, with goodsig=false]
    ...                                                |     ...
    rewind(fp_out);   /* here tattach == NULL */       |     rewind(fp_out);   /* here tattach == NULL */
    tattach = mutt_read_mime_header(fp_out, 0);        |     const long size = mutt_file_get_size_fp(fp_out); /* is != 0 */
    /* here tattach != NULL */                         |     -> cleanup, and return NULL
  ...                                                  |   gets NULL and says "Could not decrypt PGP message"
  signature is checked with explicit gpg --verify call |
[and sig is OK, and email is shown ...]                |
```

I think the intended test was `size == 0` because that is the signal of the (newly used) `mutt_file_get_size_fp` for an error. Before this commit the size was determined with the direct use of `fstat` (a few lines later for the computation of the new body (rest-)size).
