### PR TITLE
Add url corresponding to $query.

### DIFF
--- a/docs/config.c
+++ b/docs/config.c
@@ -3600,7 +3600,8 @@
 ** string substituted for "%s" automatically according to shell quoting
 ** rules, so you should avoid adding your own.  If no "%s" is found in
 ** the string, NeoMutt will append the user's query to the end of the string.
-** See "$query" for more information.
+** See "$query" (https://neomutt.org/guide/advancedusage.html#query) for more
+** information.
 */
 
 { "query_format", DT_STRING, "%3c %t %-25.25n %-25.25a | %e" },


### PR DESCRIPTION
The "query" section doesn't appear in the neomuttrc man page, so the text 'See
"query" for more information wasn't useful there.

NB: I haven't tried re-building the docs with this change (man page or website). Also, it presumably makes the web version of the docs a bit worse since the URL is redundant there, so not sure if it should be merged.

* **What does this PR do?**

Makes the `neomuttrc`  man page more useful.
