### PR TITLE
Fix scanf/printf bugs (one critical, three less so) and constant string warning

### DIFF
--- a/browser.c
+++ b/browser.c
@@ -1563,7 +1563,7 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
               {
                 char *p = NULL;
                 if (lastdirlen > 1)
-                  p = strrchr(mutt_buffer_string(&LastDir) + 1, '/');
+                  p = strrchr(LastDir.data + 1, '/');
 
                 if (p)
                 {

--- a/nntp/newsrc.c
+++ b/nntp/newsrc.c
@@ -38,6 +38,7 @@
 #include <sys/stat.h>
 #include <time.h>
 #include <unistd.h>
+#include <inttypes.h>
 #include "private.h"
 #include "mutt/lib.h"
 #include "config/lib.h"
@@ -625,7 +626,7 @@ static int active_get_cache(struct NntpAccountData *adata)
   if (!fp)
     return -1;
 
-  if (!fgets(buf, sizeof(buf), fp) || (sscanf(buf, "%ld%4095s", &t, file) != 1) || (t == 0))
+  if (!fgets(buf, sizeof(buf), fp) || (sscanf(buf, "%" SCNd64 "%4095s", &t, file) != 1) || (t == 0))
   {
     mutt_file_fclose(&fp);
     return -1;

--- a/remailer.c
+++ b/remailer.c
@@ -410,7 +410,7 @@ static void mix_redraw_chain(struct MuttWindow *win, struct Remailer **type2_lis
 static void mix_redraw_head(struct MuttWindow *win, struct MixChain *chain)
 {
   char buf[1024];
-  snprintf(buf, sizeof(buf), "-- Remailer chain [Length: %ld]", chain ? chain->cl : 0);
+  snprintf(buf, sizeof(buf), "-- Remailer chain [Length: %zu]", chain ? chain->cl : 0);
   sbar_set_title(win, buf);
 }
 

--- a/test/compress/common.c
+++ b/test/compress/common.c
@@ -145,14 +145,14 @@ void compress_data_tests(const struct ComprOps *cops, short min_level, short max
     TEST_CASE(case_name);
     for (size_t size = 1; size < 33; size++)
     {
-      snprintf(case_name, sizeof(case_name), "    size %ld", size);
+      snprintf(case_name, sizeof(case_name), "    size %zu", size);
       TEST_CASE(case_name);
       one_test(cops, level, size);
     }
 
     for (size_t i = 0; i < mutt_array_size(sizes); i++)
     {
-      snprintf(case_name, sizeof(case_name), "    size %ld", sizes[i]);
+      snprintf(case_name, sizeof(case_name), "    size %zu", sizes[i]);
       TEST_CASE(case_name);
       one_test(cops, level, sizes[i]);
     }

--- a/test/hash/mutt_hash_new.c
+++ b/test/hash/mutt_hash_new.c
@@ -43,7 +43,7 @@ void test_mutt_hash_new(void)
     char buf[32];
     for (size_t i = 0; i < 50; i++)
     {
-      snprintf(buf, sizeof(buf), "apple%ld", i);
+      snprintf(buf, sizeof(buf), "apple%zu", i);
       mutt_hash_insert(table, buf, &dummy1);
     }
     mutt_hash_free(&table);


### PR DESCRIPTION
See each commit for warnings from GCC 11.2.0-10.

Found these when building for x32, remaining warnings for a `--mandir=/usr/share/man --libexecdir=/usr/libexec --with-mailpath=/var/mail --gpgme --lua --notmuch --with-ui --gnutls --gss --idn --mixmaster --sasl --tokyocabinet --zlib --zstd --testing` build:
```
notmuch/notmuch.c: In function ‘rename_filename’:
notmuch/notmuch.c:1238:29: warning: ‘%s’ directive output may be truncated writing 3 bytes into a region of size between 0 and 4095 [-Wformat-truncation=]
 1238 |   snprintf(buf, buflen, "%s/%s/%s%s", folder,
      |                             ^~
notmuch/notmuch.c:1238:3: note: ‘snprintf’ output between 6 and 12291 bytes into a destination of size 4096
 1238 |   snprintf(buf, buflen, "%s/%s/%s%s", folder,
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 1239 |            (e->read || e->old) ? "cur" : "new", filename, suffix);
      |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
mutt/regex.c: In function ‘mutt_replacelist_apply’:
mutt/regex.c:406:15: warning: ‘strncpy’ output may be truncated copying between 0 and 1023 bytes from a string of length 2047 [-Wstringop-truncation]
  406 |               strncpy(&dst[tlen], src, cpysize);
      |               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
map autocrypt account undefined at ./docs/gen-map-doc line 64, <XML> line 26.
Error: no ID for constraint linkend: "tunnel".
Error: no ID for constraint linkend: "tunnel-is-secure".
Error: no ID for constraint linkend: "tunnel-is-secure".
Error: no ID for constraint linkend: "autocrypt".
Error: no ID for constraint linkend: "autocrypt-dir".
Error: no ID for constraint linkend: "autocrypt-dir".
Error: no ID for constraint linkend: "autocrypt-dir".
Error: no ID for constraint linkend: "autocrypt-dir".
Error: no ID for constraint linkend: "autocrypt-dir".
Error: no ID for constraint linkend: "autocrypt-dir".
Error: no ID for constraint linkend: "autocrypt-reply".
Error: no ID for constraint linkend: "autocrypt-account-map".
Error: no ID for constraint linkend: "autocrypt-dir".
Error: no ID for constraint linkend: "autocrypt-dir".
Error: no ID for constraint linkend: "autocrypt-dir".
Error: no ID for constraint linkend: "autocrypt-reply".
Error: no ID for constraint linkend: "net-inc".
Error: no ID for constraint linkend: "net-inc".
Error: no ID for constraint linkend: "net-inc".
```

The second one is verified above, but the first one is valid. I'm not sure why a path is hard-`PATH_MAX`-sized, but y'know. It should probably at least get overflow-checked and return -1 if it's passed verbatim to a syscall, or dynamically allocated if it isn't, but I don't use notmuch, so.