### PR TITLE
Support XDG Base Directory Specification ... a little more

### DIFF
--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -72,7 +72,7 @@ NEOMUTTOBJS=	alternates.o commands.o command_parse.o \
 		mutt_logging.o mutt_mailbox.o mutt_signal.o mutt_socket.o \
 		mutt_thread.o mx.o mview.o myvar.o opcodes.o recvcmd.o \
 		resize.o rfc3676.o score.o sort.o status.o subjectrx.o \
-		system.o version.o
+		system.o version.o xdg.o
 
 @if !HAVE_TIMEGM
 NEOMUTTOBJS+=	timegm.o

--- a/docs/config.c
+++ b/docs/config.c
@@ -5619,5 +5619,82 @@
 ** name of original article author) to article that followuped to newsgroup.
 */
 #endif
+
+{ "xdg_app_data_home", DT_PATH, "$XDG_DATA_HOME/neomutt" },
+/*
+** .pp
+** The family of $$xdg_FOO config variables is a group of convenience variables
+** to get access to value of XDG_FOO environment variable.  The covered XDG
+** variables are:
+** .dl
+** .dt \fBName\fP      .dd \fBDefault value\fP
+** .dt XDG_DATA_HOME   .dd ~/.local/share
+** .dt XDG_CONFIG_HOME .dd ~/.config
+** .dt XDG_STATE_HOME  .dd ~/.local/state
+** .dt XDG_CACHE_HOME  .dd ~/.cache
+** .de
+** They all work the same, in the following we use $$xdg_app_cache_home as
+** example.
+** .pp
+** $$xdg_app_cache_home (note the "app" in the name) expands to
+** "XDG_CACHE_HOME/neomutt" if the environment variable XDG_CACHE_HOME is set,
+** otherwise is expands to the default as defined in the XDG Base Directory
+** Specification (see list above), in the case of XDG_CACHE_HOME it expands to
+** "~/.cache/neomutt".
+** .pp
+** The purpose of this can best be seen on an example:
+** .ts
+** set header_cache = "$$XDG_CACHE_HOME/neomutt/headers"
+** .te
+** The above works as intended if the environment variable XDG_CACHE_HOME is
+** set.  However, if it is not then the header cache would be
+** "/neomutt/headercache" which was not intended.  Using the
+** $$xdg_app_cache_home variable like so
+** .ts
+** set header_cache = "$$xdg_app_cache_home/headers"
+** .te
+** avoids this problem and correctly assigns "~/.cache/neomutt/headers" in the
+** case that XDG_CACHE_HOME is not set.
+** .pp
+** Note: NeoMutt does not use these variables internally, they are solely to
+** help writing your config file and should be considered read-only.  Setting
+** them will have no effect on NeoMutt or the XDG environment variables.  If
+** you want to change the XDG environment variables you have to do that outside
+** of NeoMutt before you launch NeoMutt.
+*/
+
+{ "xdg_app_config_home", DT_PATH, "$XDG_CONFIG_HOME/neomutt" },
+/*
+** .pp
+** See $$xdg_app_data_home for the documentation.
+*/
+
+{ "xdg_app_state_home", DT_PATH, "$XDG_STATE_HOME/neomutt"},
+/*
+** .pp
+** See $$xdg_app_data_home for the documentation.
+*/
+
+// This has no official XDG name yet (as the spec of version 0.8 dated 8th May 2021)
+// TODO: When enabling, list it in the documentation of $xdg_app_data_home
+// { "xdg_app_bin_home", DT_PATH, "$XDG_BIN_HOME/neomutt" },
+// /*
+// ** .pp
+// ** See $$xdg_app_data_home for the documentation.
+// */
+
+{ "xdg_app_cache_home", DT_PATH, "$XDG_CACHE_HOME/neomutt"},
+/*
+** .pp
+** See $$xdg_app_data_home for the documentation.
+*/
+
+// No named default directory
+// TODO: When enabling, list it in the documentation of $xdg_app_data_home
+// { "xdg_app_runtime_dir", DT_PATH, "$XDG_RUNTIME_HOME/neomutt" },
+// /*
+// ** .pp
+// ** See $$xdg_app_data_home for the documentation.
+// */
 // clang-format on
 /*--*/

--- a/init.c
+++ b/init.c
@@ -62,6 +62,7 @@
 #include "myvar.h"
 #include "options.h"
 #include "protos.h"
+#include "xdg.h"
 #ifdef USE_SIDEBAR
 #include "sidebar/lib.h"
 #endif
@@ -684,18 +685,13 @@ int mutt_init(struct ConfigSet *cs, bool skip_sys_rc, struct ListHead *commands)
 
   if (STAILQ_EMPTY(&Muttrc))
   {
-    const char *xdg_cfg_home = mutt_str_getenv("XDG_CONFIG_HOME");
-
-    if (!xdg_cfg_home && HomeDir)
+    if (mutt_xdg_get_path(XDG_CONFIG_HOME, &buf) >= 0)
     {
-      mutt_buffer_printf(&buf, "%s/.config", HomeDir);
-      xdg_cfg_home = mutt_buffer_string(&buf);
-    }
-
-    char *config = find_cfg(HomeDir, xdg_cfg_home);
-    if (config)
-    {
-      mutt_list_insert_tail(&Muttrc, config);
+      char *config = find_cfg(HomeDir, mutt_buffer_string(&buf));
+      if (config)
+      {
+        mutt_list_insert_tail(&Muttrc, config);
+      }
     }
   }
   else

--- a/protos.h
+++ b/protos.h
@@ -28,21 +28,13 @@
 #include <stdbool.h>
 #include "mutt.h"
 #include "menu/lib.h"
+#include "xdg.h"
 
 struct Buffer;
 struct Email;
 struct EmailList;
 struct Mailbox;
 struct NotifyCallback;
-
-/**
- * enum XdgType - XDG variable types
- */
-enum XdgType
-{
-  XDG_CONFIG_HOME, ///< XDG home dir: ~/.config
-  XDG_CONFIG_DIRS, ///< XDG system dir: /etc/xdg
-};
 
 /**
  * enum EvMessage - Edit or View a message
@@ -57,7 +49,7 @@ int mutt_ev_message(struct Mailbox *m, struct EmailList *el, enum EvMessage acti
 
 int mutt_system(const char *cmd);
 
-int mutt_set_xdg_path(enum XdgType type, struct Buffer *buf);
+int mutt_set_xdg_path(enum XdgEnvVar type, struct Buffer *buf);
 void mutt_help(enum MenuType menu);
 void mutt_set_flag_update(struct Mailbox *m, struct Email *e, enum MessageType flag, bool bf, bool upd_mbox);
 #define mutt_set_flag(m, e, flag, bf) mutt_set_flag_update(m, e, flag, bf, true)

--- a/xdg.c
+++ b/xdg.c
@@ -1,0 +1,218 @@
+/**
+ * @file
+ * XDG Base Directory Specification handling
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "xdg.h"
+
+#include "config.h"
+#include <string.h>
+#include <unistd.h>
+#include "mutt/buffer.h"
+#include "mutt/memory.h"
+#include "mutt/string2.h"
+#include "muttlib.h"
+
+/**
+ * The XDG Base Directory Specification environment variable names as strings.
+ * Use this to convert the symbolic constant to a string.
+ */
+const char *const XdgEnvVarNames[] = {
+  [XDG_DATA_HOME] = "XDG_DATA_HOME",
+  [XDG_CONFIG_HOME] = "XDG_CONFIG_HOME",
+  [XDG_STATE_HOME] = "XDG_STATE_HOME",
+  /* Not officially named yet
+  [XDG_BIN_HOME] = "XDG_BIN_HOME",
+*/
+  [XDG_DATA_DIRS] = "XDG_DATA_DIRS",
+  [XDG_CONFIG_DIRS] = "XDG_CONFIG_DIRS",
+  [XDG_CACHE_HOME] = "XDG_CACHE_HOME",
+  /* Has no default value
+  [XDG_RUNTIME_DIR] = "XDG_RUNTIME_DIR",
+*/
+};
+
+/**
+ * The default values for the XDG environment variables according to the XDG
+ * Base Directory Specification [0].
+ *
+ * [0] https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
+ */
+static const char *const XdgDefaults[] = {
+  [XDG_DATA_HOME] = "~/.local/share",
+  [XDG_CONFIG_HOME] = "~/.config",
+  [XDG_STATE_HOME] = "~/.local/state",
+  /* Not officially named yet
+  [XDG_BIN_HOME] = "~/.local/bin",
+*/
+  [XDG_DATA_DIRS] = "/usr/local/share/:/usr/share/",
+  [XDG_CONFIG_DIRS] = "/etc/xdg",
+  [XDG_CACHE_HOME] = "~/.cache",
+  // [XDG_RUNTIME_DIR] = "", // No named default path in the spec
+};
+
+/**
+ * mutt_xdg_get_path - Return the XDG path
+ * @param type Type of XDG variable, e.g. #XDG_CONFIG_HOME
+ * @param buf  the buffer to save the path to
+ * @retval <0  on error
+ * @retval  1  otherwise
+ * @sa mutt_xdg_get_app_path()
+ *
+ * Respects the environment variable and falls back to the specification
+ * default if not set. The path returned is essentially the value of the
+ * environment variable plus fall back handling.
+ *
+ * Some XDG environment variables are allowed to contain colon separated lists
+ * of directories. In this case the buffer contains such a colon separated list
+ * and not a single directory.
+ *
+ * Note: This function does not test whether the path(s) exist.
+ */
+int mutt_xdg_get_path(enum XdgEnvVar type, struct Buffer *buf)
+{
+  int ret = 0;
+  mutt_buffer_reset(buf);
+  const char *xdg_env = mutt_str_getenv(XdgEnvVarNames[type]);
+  if (xdg_env)
+  {
+    // Sanity check: paths given must be absolute, otherwise they should be
+    // ignored (see XDG Spec).
+    char *tmp_xdg_env = mutt_str_dup(xdg_env);
+    char *x = tmp_xdg_env; /* strsep() changes tmp_xdg_env, so free x instead later */
+    bool first_path = true;
+    char *dir = NULL;
+    while ((dir = strsep(&tmp_xdg_env, ":")))
+    {
+      if (dir[0] == '/')
+      {
+        if (!first_path)
+          if ((ret = mutt_buffer_addch(buf, ':')) < 0)
+            break;
+        if ((ret = mutt_buffer_addstr(buf, dir)) < 0)
+          break;
+        first_path = false;
+      }
+    }
+    FREE(&x);
+  }
+  if (ret < 0)
+    return ret; // some error occurred
+
+  if (mutt_buffer_is_empty(buf))
+  {
+    if ((ret = mutt_buffer_strcpy(buf, XdgDefaults[type])) < 0)
+      return ret;
+    // Note that only our defaults have a '~' to expand and that the defaults
+    // are never lists of directories. Thus, this call really expands all paths
+    // (i.e. that one path).
+    mutt_buffer_expand_path(buf);
+  }
+  return 1;
+}
+
+/**
+ * mutt_xdg_get_app_path - Return the XDG path for this application.
+ * @param type Type of XDG variable, e.g. #XDG_CONFIG_HOME
+ * @param buf  the buffer to save the path to
+ * @retval <0  on error
+ * @retval  1  otherwise
+ * @sa mutt_xdg_get_path()
+ *
+ * Respects the environment variable and falls back to the specification
+ * default if not set. The path returned is the path for this application not
+ * the value of $XDG_CONFIG_HOME, i.e. mutt_xdg_get_path(XDG_CONFIG_HOME, buf)
+ * returns something like "/home/foo/.config/neomutt".
+ *
+ * Some XDG environment variables are allowed to contain colon separated lists
+ * of directories. In this case the buffer contains such a colon separated list
+ * and not a single directory.
+ *
+ * Note: This function does not test whether the path(s) exist.
+ */
+int mutt_xdg_get_app_path(enum XdgEnvVar type, struct Buffer *buf)
+{
+  int ret = mutt_xdg_get_path(type, buf);
+  if (ret < 0)
+    return ret;
+
+  char *tmp_dirs = mutt_str_dup(mutt_buffer_string(buf));
+  char *x = tmp_dirs; /* strsep() changes tmp_dirs, so free x instead later */
+  mutt_buffer_reset(buf);
+  bool first_path = true;
+  char *dir = NULL;
+  while ((dir = strsep(&tmp_dirs, ":")))
+  {
+    if (!first_path)
+      if ((ret = mutt_buffer_addch(buf, ':')) < 0)
+        break;
+
+    const int dir_len = strlen(dir);
+    const bool slash = dir[dir_len - 1] == '/';
+    if ((ret = mutt_buffer_add_printf(buf, slash ? "%s%s" : "%s/%s", dir, PACKAGE)) < 0)
+      break;
+    first_path = false;
+  }
+  FREE(&x);
+
+  return ret < 0 ? ret : 1;
+}
+
+/**
+ * mutt_xdg_get_first_existing_path - Return file in an XDG lookup
+ * @param type Type of XDG variable, e.g. #XDG_CONFIG_HOME
+ * @param path path relative to the applications XDG directory
+ * @param buf  the buffer to save the path to
+ * @retval <0  on error
+ * @retval 1   if a file was found in the file system
+ * @retval 0   if no existing file was found
+ *
+ * Lookup file fpath relative to the appications XDG directory, e.g.
+ *
+ *    mutt_xdg_get_first_existing_path(XDG_CONFIG_HOME, "neomuttrc", buf)
+ *
+ * Some XDG variables are a colon separated list of directories. In this case
+ * each directory is tried in order until the first time the file was
+ * found. That occurrence is then returned.
+ *
+ * path is not allowed to be NULL.
+ */
+int mutt_xdg_get_first_existing_path(enum XdgEnvVar type,
+                                     const char *const path, struct Buffer *buf)
+{
+  int ret = mutt_xdg_get_app_path(type, buf);
+  if (ret < 0)
+    return ret;
+  char *tmp_dirs = mutt_str_dup(mutt_buffer_string(buf));
+  char *x = tmp_dirs; /* strsep() changes tmp_dirs, so free x instead later */
+  mutt_buffer_reset(buf);
+  char *dir = NULL;
+  ret = 0;
+  while ((dir = strsep(&tmp_dirs, ":")))
+  {
+    if ((ret = mutt_buffer_printf(buf, "%s/%s", dir, path)) < 0)
+      break;
+
+    if (access(mutt_buffer_string(buf), F_OK) == 0)
+    {
+      ret = 1;
+      break;
+    }
+  }
+  FREE(&x);
+  return ret;
+}

--- a/xdg.h
+++ b/xdg.h
@@ -1,0 +1,54 @@
+/**
+ * @file
+ * XDG Base Directory Specification handling
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MUTT_XDG_H
+#define MUTT_XDG_H
+
+struct Buffer;
+
+/**
+ * enum XdgType - XDG variables
+ *
+ * Constants for the environment variables defined by the XDG Base Directory
+ * Specification.
+ */
+enum XdgEnvVar
+{
+  XDG_DATA_HOME, ///< XDG data dir; usually ~/.local/share
+  XDG_CONFIG_HOME, ///< XDG config dir; usually ~/.config
+  XDG_STATE_HOME, ///< XDG state dir; usually ~/.local/state
+/* Not officially named yet
+  XDG_BIN_HOME, ///< XDG dir for executables; usually ~/.local/bin
+*/
+  XDG_DATA_DIRS, ///< additional XDG data dirs; usually /usr/local/share/:/usr/share/
+  XDG_CONFIG_DIRS, ///< additional XDG config dirs; usually /etc/xdg
+  XDG_CACHE_HOME, ///< XDG cache dir; usually ~/.cache
+/* Has no default value
+  XDG_RUNTIME_DIR, ///< XDG runtime dir
+*/
+};
+
+extern const char *const XdgEnvVarNames[];
+
+int mutt_xdg_get_path(enum XdgEnvVar type, struct Buffer *buf);
+int mutt_xdg_get_app_path(enum XdgEnvVar type, struct Buffer *buf);
+int mutt_xdg_get_first_existing_path(enum XdgEnvVar type, const char *const path, struct Buffer *buf);
+
+
+#endif /* MUTT_XDG_H */


### PR DESCRIPTION
Dear Neomutt developers

* **What does this PR do?**

Better start with the problem this PR tries to solve:
To follow the XDG Directory Specification [0] it is not simply reading its config from `~/.config/neomutt` but also to place associated files in the corresponding directory, e.g. cache files in $XDG_CACHE_HOME.
While I don't expect neomutt to support XDG out of the box, it would be nice if the user can at least configure it to behave that way. Let's take `header_cache` as an example. It should go into `$XDG_CACHE_HOME`

```
set header_cache = "~/.cache/neomutt/headercache"
```
but that doesn't do the job if `$XDG_CACHE_HOME` is something other than `~/.cache`. Likewise,
```
set header_cache = "$XDG_CACHE_HOME/neomutt/headercache"
```
fails if XDG_CACHE_HOME is not set (in which case `~/.cache/` should be used).
I'm sure you can do something with ifdef, shell, sourcing a script, ... but I figured it might be easier to provide the user with the XDG environment variables, so a simple $xdg_dir_you_want will do.

To this end this PR introduce config variables
* `$xdg_app_data_home`
* `$xdg_app_config_home`
* `$xdg_app_state_home`
* `$xdg_app_cache_home`

Which are their corresponding XDG environment variables substituted with defaults and "/neomutt/" appended, e.g. `$xdg_app_config_home` is `~/.config/neomutt`. The above task is now easily solved with
```
set header_cache = "$xdg_app_cache_home/headercache"
```

[0] https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html

Additional notes:

1. `mutt_set_xdg_path()` could be simplified to a two-liner if the order of the config would be
```
confdir1/neomuttrc
confdir2/neomuttrc
...
confdir3/neomuttrc
confdir1/muttrc
confdir2/muttrc
...
confdir3/muttrc
```
currently it is alternating `neomuttrc` and `muttrc`. I don't expect to change that, just wanted to point out why I couldn't simplify that function further.

2. I considered moving `mutt_set_xdg_path()` into `xdg.c` but did not for two reasons.
  a) that function is not for general XDG dir handling but ensuring a particular order of config files
  b) wanted to keep the diff small.
 
3. I didn't know where to place the `xdg.c` / `xdg.h`. Maybe mutt/ would be a good place but then again I have no idea what the guidelines are for inclusion. So I placed it just "somewhere". Feel free to move that.

4. There is not documentation for the config variables yet, as they seem to be not documented in manual.xml.head. Hints on where to put them are welcome.

5. I named the config variables `xdg_app_data_dir` instead of `xdg_data_dir` (note the `APP`) because I added `neomutt` to the end and so this cannot be confused with a potential `$xdg_data_dir` which does not end in `neomutt/`.

6. The backend works for all environment variables defined by the XDG Base Directory Specification but only those containing a single directory are exported as config variables. I see little use in exporting the XDG environment variables which are a colon separated list of directories.

7. I don't usually program C so there might be some more efficient ways of achieving this. Nicely documented code base BTW.

8. In `config_init_main()` in mutt_config.c the call to `cs_register_variables()` returns `false`. This has nothing to do with this PR since it did it already before I started working. According to the doc this means that some variables could not be registered. This might or might not indicate a bug.

9. If you feel this is not the right way to expose XDG directories to the users config, please say so and close this PR.

10. How to set the default value for these new variables? Currently a `reset xdg_app_data_home` resets it to `./`.
      (This in particular applies to a potential `reset all` call).

Darrel