### PR TITLE
[Fix] poll to use PollFdsCount and not PollFdsLen

### DIFF
--- a/monitor.c
+++ b/monitor.c
@@ -405,7 +405,7 @@ int mutt_monitor_poll(void)
 
   if (INotifyFd != -1)
   {
-    int fds = poll(PollFds, PollFdsLen, MuttGetchTimeout);
+    int fds = poll(PollFds, PollFdsCount, MuttGetchTimeout);
 
     if (fds == -1)
     {


### PR DESCRIPTION
Commit message
```
PollFdsLen tracks the maximum elements of the pollfd struct before
needing reallocation, whereas PollFdsCount tracks the number of actual
elements in it. Polling has to be done only on the actual number of
elements.
```
The original code in `mutt_monitor_poll` calls `poll(PollFds, PollFdsLen, MuttGetchTimeout)`.

We can see in `mutt_poll_fd_add` that when a new fd is to be added in the `pollfd` struct, if no space is available in the struct, the struct is extended to fit two more elementrs (`PollFdsLen += 2`) and the number of elements gets incremented by 1 (`++PollFdsCount`). The expansion of 2 happens probably in order to reallocate just once for the basic scenario of only polling for `STDIN` and `INotifyFd`. 

If for some reason, a 3rd fd is added, then `PollFdsLen` get to `4`, `PollFdsCount` to `3` and poll is called for `4` elements instead of `3`. 

This can cause the `poll` call to return before the timeout period, even if no data has be written on the file descriptors (in case their flag is `POLLIN` for example). In such a case we could have `poll` called many times per second and driving up the `CPU` usage.
