### PR TITLE
Fix back-reference parsing in mutt_replacelist_add

### DIFF
--- a/test/regex/mutt_replacelist_match.c
+++ b/test/regex/mutt_replacelist_match.c
@@ -23,6 +23,7 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
+#include "test_common.h"
 #include "mutt/lib.h"
 
 void test_mutt_replacelist_match(void)
@@ -43,5 +44,21 @@ void test_mutt_replacelist_match(void)
     struct ReplaceList replacelist = { 0 };
     char buf[32] = { 0 };
     TEST_CHECK(!mutt_replacelist_match(&replacelist, buf, sizeof(buf), NULL));
+  }
+
+  {
+    struct ReplaceList replacelist = STAILQ_HEAD_INITIALIZER(replacelist);
+    mutt_replacelist_add(&replacelist, "foo-([^-]+)-bar", "foo [%0] bar", NULL);
+    char buf[32] = { 0 };
+    TEST_CHECK(mutt_replacelist_match(&replacelist, buf, sizeof(buf), "foo-1234-bar"));
+    TEST_CHECK_STR_EQ("foo [foo-1234-bar] bar", buf);
+  }
+
+  {
+    struct ReplaceList replacelist = STAILQ_HEAD_INITIALIZER(replacelist);
+    mutt_replacelist_add(&replacelist, "foo-([^-]+)-bar", "foo [%1] bar", NULL);
+    char buf[32] = { 0 };
+    TEST_CHECK(mutt_replacelist_match(&replacelist, buf, sizeof(buf), "foo-1234-bar"));
+    TEST_CHECK_STR_EQ("foo [1234] bar", buf);
   }
 }

--- a/test/regex/mutt_replacelist_match.c
+++ b/test/regex/mutt_replacelist_match.c
@@ -61,4 +61,11 @@ void test_mutt_replacelist_match(void)
     TEST_CHECK(mutt_replacelist_match(&replacelist, buf, sizeof(buf), "foo-1234-bar"));
     TEST_CHECK_STR_EQ("foo [1234] bar", buf);
   }
+
+  {
+    struct ReplaceList replacelist = STAILQ_HEAD_INITIALIZER(replacelist);
+    mutt_replacelist_add(&replacelist, "foo-([^-]+)-bar", "foo [%2] bar", NULL);
+    char buf[32] = { 0 };
+    TEST_CHECK(!mutt_replacelist_match(&replacelist, buf, sizeof(buf), "foo-1234-bar"));
+  }
 }


### PR DESCRIPTION
A back-reference not at the end of the string was not properly parsed.
This is because our mutt_str_ato[li] functions explicitely check that
the full string was parsed. Perhaps we should do something about it.

Also, without the fix, the test would crash because `mutt_replacelist_match` keeps some static variables that are not properly reset.