### PR TITLE
fast_reply applied when to, cc, or bcc predefined

### DIFF
--- a/docs/config.c
+++ b/docs/config.c
@@ -1155,12 +1155,17 @@
 { "fast_reply", DT_BOOL, false },
 /*
 ** .pp
-** When \fIset\fP, the initial prompt for recipients and subject are skipped
-** when replying to messages, and the initial prompt for subject is
-** skipped when forwarding messages.
+** When \fIset\fP, the initial prompt for recipients (to, cc, bcc) and
+** subject are skipped when the relevant information is already provided.
+** These cases include replying to messages and passing the relevant
+** command line arguments. The initial prompt for recipients
+** is also skipped when composing a new message to the current message sender,
+** while the initial prompt for subject is also skipped when forwarding messages.
 ** .pp
 ** \fBNote:\fP this variable has no effect when the $$auto_edit
 ** variable is \fIset\fP.
+** .pp
+** See also: $$auto_edit, $$edit_headers, $$ask_cc, $$ask_bcc
 */
 
 { "fcc_attach", DT_QUAD, MUTT_YES },

--- a/send/send.c
+++ b/send/send.c
@@ -259,16 +259,27 @@ static int edit_envelope(struct Envelope *en, SendFlags flags, struct ConfigSubs
   else
 #endif
   {
-    if ((mutt_edit_address(&en->to, _("To: "), true) == -1) || TAILQ_EMPTY(&en->to))
-      return -1;
+    const bool c_fast_reply = cs_subset_bool(sub, "fast_reply");
+    if (TAILQ_EMPTY(&en->to) || !c_fast_reply)
+    {
+      if ((mutt_edit_address(&en->to, _("To: "), true) == -1) || TAILQ_EMPTY(&en->to))
+        return -1;
+    }
 
     const bool c_ask_cc = cs_subset_bool(sub, "ask_cc");
-    if (c_ask_cc && (mutt_edit_address(&en->cc, _("Cc: "), true) == -1))
-      return -1;
+    if (TAILQ_EMPTY(&en->cc) || !c_fast_reply)
+    {
+      if (c_ask_cc && (mutt_edit_address(&en->cc, _("Cc: "), true) == -1))
+        return -1;
+    }
+
 
     const bool c_ask_bcc = cs_subset_bool(sub, "ask_bcc");
-    if (c_ask_bcc && (mutt_edit_address(&en->bcc, _("Bcc: "), true) == -1))
-      return -1;
+    if (TAILQ_EMPTY(&en->bcc) || !c_fast_reply)
+    {
+      if (c_ask_bcc && (mutt_edit_address(&en->bcc, _("Bcc: "), true) == -1))
+        return -1;
+    }
 
     const bool c_reply_with_xorig = cs_subset_bool(sub, "reply_with_xorig");
     if (c_reply_with_xorig && (flags & (SEND_REPLY | SEND_LIST_REPLY | SEND_GROUP_REPLY)) &&


### PR DESCRIPTION
```
The recipients of a message are not confirmed/edited if the program flow
has defined them in any kind of way. This extends the fast_reply
functionality for the compose_to_sender function and the case of command
line defined arguments related to the above parameters.
```
Docs will be updated in a future commit, if the patch is accepted provisionally.

Let's discuss all the relevant parts in this merge request.