### PR TITLE
Improve API of strto* wrappers

### DIFF
--- a/color/command.c
+++ b/color/command.c
@@ -325,8 +325,7 @@ static enum CommandResult parse_object(struct Buffer *buf, struct Buffer *s,
     int val = 0;
     if (buf->data[6] != '\0')
     {
-      rc = mutt_str_atoi(buf->data + 6, &val);
-      if ((rc != 0) || (val > COLOR_QUOTES_MAX))
+      if (!mutt_str_atoi_full(buf->data + 6, &val) || (val > COLOR_QUOTES_MAX))
       {
         mutt_buffer_printf(err, _("%s: no such object"), buf->data);
         return MUTT_CMD_WARNING;
@@ -639,7 +638,7 @@ static enum CommandResult parse_color(struct Buffer *buf, struct Buffer *s,
     {
       struct Buffer tmp = mutt_buffer_make(0);
       mutt_extract_token(&tmp, s, MUTT_TOKEN_NO_FLAGS);
-      if (mutt_str_atoui(tmp.data, &match) < 0)
+      if (!mutt_str_atoui_full(tmp.data, &match))
       {
         mutt_buffer_printf(err, _("%s: invalid number: %s"),
                            color ? "color" : "mono", tmp.data);

--- a/config/long.c
+++ b/config/long.c
@@ -50,7 +50,7 @@ static int long_string_set(const struct ConfigSet *cs, void *var, struct ConfigD
   }
 
   long num = 0;
-  if (mutt_str_atol(value, &num) < 0)
+  if (!mutt_str_atol_full(value, &num))
   {
     mutt_buffer_printf(err, _("Invalid long: %s"), value);
     return CSR_ERR_INVALID | CSR_INV_TYPE;
@@ -146,7 +146,7 @@ static int long_string_plus_equals(const struct ConfigSet *cs, void *var,
                                    const char *value, struct Buffer *err)
 {
   long num = 0;
-  if (!value || (value[0] == '\0') || (mutt_str_atol(value, &num) < 0))
+  if (!mutt_str_atol_full(value, &num))
   {
     mutt_buffer_printf(err, _("Invalid long: %s"), NONULL(value));
     return CSR_ERR_INVALID | CSR_INV_TYPE;
@@ -182,9 +182,9 @@ static int long_string_minus_equals(const struct ConfigSet *cs, void *var,
                                     const char *value, struct Buffer *err)
 {
   long num = 0;
-  if (!value || (value[0] == '\0') || (mutt_str_atol(value, &num) < 0))
+  if (!mutt_str_atol_full(value, &num))
   {
-    mutt_buffer_printf(err, _("Invalid long: %s"), value);
+    mutt_buffer_printf(err, _("Invalid long: %s"), NONULL(value));
     return CSR_ERR_INVALID | CSR_INV_TYPE;
   }
 

--- a/config/number.c
+++ b/config/number.c
@@ -51,7 +51,7 @@ static int number_string_set(const struct ConfigSet *cs, void *var, struct Confi
   }
 
   int num = 0;
-  if (mutt_str_atoi(value, &num) < 0)
+  if (!mutt_str_atoi_full(value, &num))
   {
     mutt_buffer_printf(err, _("Invalid number: %s"), value);
     return CSR_ERR_INVALID | CSR_INV_TYPE;
@@ -160,7 +160,7 @@ static int number_string_plus_equals(const struct ConfigSet *cs, void *var,
                                      const char *value, struct Buffer *err)
 {
   int num = 0;
-  if (!value || (value[0] == '\0') || (mutt_str_atoi(value, &num) < 0))
+  if (!mutt_str_atoi_full(value, &num))
   {
     mutt_buffer_printf(err, _("Invalid number: %s"), NONULL(value));
     return CSR_ERR_INVALID | CSR_INV_TYPE;
@@ -199,9 +199,9 @@ static int number_string_minus_equals(const struct ConfigSet *cs, void *var,
                                       const char *value, struct Buffer *err)
 {
   int num = 0;
-  if (!value || (value[0] == '\0') || (mutt_str_atoi(value, &num) < 0))
+  if (!mutt_str_atoi(value, &num))
   {
-    mutt_buffer_printf(err, _("Invalid number: %s"), value);
+    mutt_buffer_printf(err, _("Invalid number: %s"), NONULL(value));
     return CSR_ERR_INVALID | CSR_INV_TYPE;
   }
 

--- a/email/rfc2231.c
+++ b/email/rfc2231.c
@@ -306,7 +306,7 @@ void rfc2231_decode_parameters(struct ParameterList *pl)
        * thus an overflow should never occur in a valid message, thus
        * the value INT_MAX in case of overflow does not really matter
        * (the goal is just to avoid undefined behaviour). */
-      if (mutt_str_atoi(s, &index) != 0)
+      if (!mutt_str_atoi_full(s, &index))
         index = INT_MAX;
 
       conttmp = parameter_new();

--- a/email/url.c
+++ b/email/url.c
@@ -305,12 +305,12 @@ struct Url *url_parse(const char *src)
   {
     url->src[mutt_regmatch_end(port)] = '\0';
     const char *ports = url->src + mutt_regmatch_start(port);
-    int num;
-    if ((mutt_str_atoi(ports, &num) < 0) || (num < 0) || (num > 0xffff))
+    unsigned short num;
+    if (!mutt_str_atous_full(ports, &num))
     {
       goto err;
     }
-    url->port = (unsigned short) num;
+    url->port = num;
   }
 
   /* path */

--- a/imap/command.c
+++ b/imap/command.c
@@ -263,7 +263,7 @@ static void cmd_parse_expunge(struct ImapAccountData *adata, const char *s)
 
   struct ImapMboxData *mdata = adata->mailbox->mdata;
 
-  if ((mutt_str_atoui(s, &exp_msn) < 0) || (exp_msn < 1) ||
+  if (!mutt_str_atoui(s, &exp_msn) || (exp_msn < 1) ||
       (exp_msn > imap_msn_highest(&mdata->msn)))
   {
     return;
@@ -407,7 +407,7 @@ static void cmd_parse_fetch(struct ImapAccountData *adata, char *s)
 
   mutt_debug(LL_DEBUG3, "Handling FETCH\n");
 
-  if (mutt_str_atoui(s, &msn) < 0)
+  if (!mutt_str_atoui(s, &msn))
   {
     mutt_debug(LL_DEBUG3, "Skipping FETCH response - illegal MSN\n");
     return;
@@ -470,7 +470,7 @@ static void cmd_parse_fetch(struct ImapAccountData *adata, char *s)
     {
       s += plen;
       SKIPWS(s);
-      if (mutt_str_atoui(s, &uid) < 0)
+      if (!mutt_str_atoui(s, &uid))
       {
         mutt_debug(LL_DEBUG1, "Illegal UID.  Skipping update\n");
         return;
@@ -945,6 +945,7 @@ static void cmd_parse_enabled(struct ImapAccountData *adata, const char *s)
       adata->qresync = true;
   }
 }
+
 /**
  * cmd_parse_exists - Parse EXISTS message from serer
  * @param adata  Imap Account data
@@ -955,7 +956,7 @@ static void cmd_parse_exists(struct ImapAccountData *adata, const char *pn)
   unsigned int count = 0;
   mutt_debug(LL_DEBUG2, "Handling EXISTS\n");
 
-  if (mutt_str_atoui(pn, &count) < 0)
+  if (!mutt_str_atoui(pn, &count))
   {
     mutt_debug(LL_DEBUG1, "Malformed EXISTS: '%s'\n", pn);
     return;

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -2022,7 +2022,7 @@ static enum MxOpenReturns imap_mbox_open(struct Mailbox *m)
       mutt_debug(LL_DEBUG3, "Getting mailbox UIDVALIDITY\n");
       pc += 3;
       pc = imap_next_word(pc);
-      if (mutt_str_atoui(pc, &mdata->uidvalidity) < 0)
+      if (!mutt_str_atoui(pc, &mdata->uidvalidity))
         goto fail;
     }
     else if (mutt_istr_startswith(pc, "OK [UIDNEXT"))
@@ -2030,7 +2030,7 @@ static enum MxOpenReturns imap_mbox_open(struct Mailbox *m)
       mutt_debug(LL_DEBUG3, "Getting mailbox UIDNEXT\n");
       pc += 3;
       pc = imap_next_word(pc);
-      if (mutt_str_atoui(pc, &mdata->uid_next) < 0)
+      if (!mutt_str_atoui(pc, &mdata->uid_next))
         goto fail;
     }
     else if (mutt_istr_startswith(pc, "OK [HIGHESTMODSEQ"))
@@ -2038,7 +2038,7 @@ static enum MxOpenReturns imap_mbox_open(struct Mailbox *m)
       mutt_debug(LL_DEBUG3, "Getting mailbox HIGHESTMODSEQ\n");
       pc += 3;
       pc = imap_next_word(pc);
-      if (mutt_str_atoull(pc, &mdata->modseq) < 0)
+      if (!mutt_str_atoull(pc, &mdata->modseq))
         goto fail;
     }
     else if (mutt_istr_startswith(pc, "OK [NOMODSEQ"))

--- a/imap/message.c
+++ b/imap/message.c
@@ -316,7 +316,7 @@ static int msg_parse_fetch(struct ImapHeader *h, char *s)
     {
       s += plen;
       SKIPWS(s);
-      if (mutt_str_atoui(s, &h->edata->uid) < 0)
+      if (!mutt_str_atoui(s, &h->edata->uid))
         return -1;
 
       s = imap_next_word(s);
@@ -348,7 +348,7 @@ static int msg_parse_fetch(struct ImapHeader *h, char *s)
       while (isdigit((unsigned char) *s) && (ptmp != (tmp + sizeof(tmp) - 1)))
         *ptmp++ = *s++;
       *ptmp = '\0';
-      if (mutt_str_atol(tmp, &h->content_length) < 0)
+      if (!mutt_str_atol(tmp, &h->content_length))
         return -1;
     }
     else if (mutt_istr_startswith(s, "BODY") ||
@@ -413,7 +413,7 @@ static int msg_fetch_header(struct Mailbox *m, struct ImapHeader *ih, char *buf,
 
   /* skip to message number */
   buf = imap_next_word(buf);
-  if (mutt_str_atoui(buf, &ih->edata->msn) < 0)
+  if (!mutt_str_atoui(buf, &ih->edata->msn))
     return rc;
 
   /* find FETCH tag */
@@ -917,7 +917,7 @@ static int read_headers_condstore_qresync_updates(struct ImapAccountData *adata,
       continue;
 
     fetch_buf = imap_next_word(fetch_buf);
-    if (!isdigit((unsigned char) *fetch_buf) || (mutt_str_atoui(fetch_buf, &header_msn) < 0))
+    if (!isdigit((unsigned char) *fetch_buf) || !mutt_str_atoui(fetch_buf, &header_msn))
       continue;
 
     if ((header_msn < 1) || (header_msn > msn_end) ||
@@ -2007,7 +2007,7 @@ bool imap_msg_open(struct Mailbox *m, struct Message *msg, int msgno)
         if (mutt_istr_startswith(pc, "UID"))
         {
           pc = imap_next_word(pc);
-          if (mutt_str_atoui(pc, &uid) < 0)
+          if (!mutt_str_atoui(pc, &uid))
             goto bail;
           if (uid != imap_edata_get(e)->uid)
           {

--- a/imap/search.c
+++ b/imap/search.c
@@ -266,7 +266,7 @@ void cmd_parse_search(struct ImapAccountData *adata, const char *s)
 
   while ((s = imap_next_word((char *) s)) && (*s != '\0'))
   {
-    if (mutt_str_atoui(s, &uid) < 0)
+    if (!mutt_str_atoui(s, &uid))
       continue;
     e = mutt_hash_int_find(mdata->uid_hash, uid);
     if (e)

--- a/imap/util.c
+++ b/imap/util.c
@@ -758,7 +758,7 @@ int imap_get_literal_count(const char *buf, unsigned int *bytes)
   while (isdigit((unsigned char) *pc))
     pc++;
   *pc = '\0';
-  if (mutt_str_atoui(pn, bytes) < 0)
+  if (!mutt_str_atoui(pn, bytes))
     return -1;
 
   return 0;
@@ -1129,11 +1129,11 @@ int mutt_seqset_iterator_next(struct SeqsetIterator *iter, unsigned int *next)
     if (range_sep)
       *range_sep++ = '\0';
 
-    if (mutt_str_atoui(iter->substr_cur, &iter->range_cur) != 0)
+    if (!mutt_str_atoui_full(iter->substr_cur, &iter->range_cur))
       return -1;
     if (range_sep)
     {
-      if (mutt_str_atoui(range_sep, &iter->range_end) != 0)
+      if (!mutt_str_atoui_full(range_sep, &iter->range_end))
         return -1;
     }
     else

--- a/index/functions.c
+++ b/index/functions.c
@@ -628,7 +628,7 @@ static int op_jump(struct IndexSharedData *shared, struct IndexPrivateData *priv
   {
     mutt_error(_("Nothing to do"));
   }
-  else if (mutt_str_atoi(buf, &msg_num) < 0)
+  else if (!mutt_str_atoi_full(buf, &msg_num))
     mutt_error(_("Argument must be a message number"));
   else if ((msg_num < 1) || (msg_num > shared->mailbox->msg_count))
     mutt_error(_("Invalid message number"));

--- a/maildir/mh.c
+++ b/maildir/mh.c
@@ -271,7 +271,7 @@ void mh_update_maildir(struct MdEmailArray *mda, struct MhSequences *mhs)
       p = md->email->path;
 
     int i = 0;
-    if (mutt_str_atoi(p, &i) < 0)
+    if (!mutt_str_atoi_full(p, &i))
       continue;
     MhSeqFlags flags = mh_seq_check(mhs, i);
 
@@ -326,7 +326,7 @@ int mh_commit_msg(struct Mailbox *m, struct Message *msg, struct Email *e, bool 
     }
     if (*cp == '\0')
     {
-      if (mutt_str_atoui(dep, &n) < 0)
+      if (!mutt_str_atoui(dep, &n))
         mutt_debug(LL_DEBUG2, "Invalid MH message number '%s'\n", dep);
       if (n > hi)
         hi = n;

--- a/maildir/sequence.c
+++ b/maildir/sequence.c
@@ -302,7 +302,7 @@ void mh_seq_update(struct Mailbox *m)
     else
       p = e->path;
 
-    if (mutt_str_atoi(p, &seq_num) < 0)
+    if (!mutt_str_atoi_full(p, &seq_num))
       continue;
 
     if (!e->read)
@@ -359,12 +359,12 @@ static int mh_seq_read_token(char *t, int *first, int *last)
   if (p)
   {
     *p++ = '\0';
-    if ((mutt_str_atoi(t, first) < 0) || (mutt_str_atoi(p, last) < 0))
+    if (!mutt_str_atoi_full(t, first) || !mutt_str_atoi_full(p, last))
       return -1;
   }
   else
   {
-    if (mutt_str_atoi(t, first) < 0)
+    if (!mutt_str_atoi_full(t, first))
       return -1;
     *last = *first;
   }

--- a/main.c
+++ b/main.c
@@ -716,7 +716,7 @@ int main(int argc, char *argv[], char *envp[])
   if (dlevel)
   {
     short num = 0;
-    if ((mutt_str_atos(dlevel, &num) < 0) || (num < LL_MESSAGE) || (num >= LL_MAX))
+    if (!mutt_str_atos_full(dlevel, &num) || (num < LL_MESSAGE) || (num >= LL_MAX))
     {
       mutt_error(_("Error: value '%s' is invalid for -d"), dlevel);
       goto main_exit; // TEST07: neomutt -d xyz

--- a/menu/menu.c
+++ b/menu/menu.c
@@ -75,7 +75,7 @@ static void menu_jump(struct Menu *menu)
       (buf[0] != '\0'))
   {
     int n = 0;
-    if ((mutt_str_atoi(buf, &n) == 0) && (n > 0) && (n < (menu->max + 1)))
+    if (mutt_str_atoi_full(buf, &n) && (n > 0) && (n < (menu->max + 1)))
     {
       menu_set_index(menu, n - 1); // msg numbers are 0-based
     }

--- a/mutt/regex.c
+++ b/mutt/regex.c
@@ -314,18 +314,25 @@ int mutt_replacelist_add(struct ReplaceList *rl, const char *pat,
   {
     if (*p == '%')
     {
-      char *end = NULL;
-      errno = 0;
-      int n = strtol(++p, &end, 10);
-      if (errno != 0)
+      int n = 0;
+      const char *end = mutt_str_atoi(++p, &n);
+      if (!end)
       {
+        // this is not an error, we might have matched %R or %L in subjectrx
         mutt_debug(LL_DEBUG2, "Invalid match number in replacelist: '%s'\n", p);
       }
-      else if (n > np->nmatch)
+      if (n > np->nmatch)
       {
         np->nmatch = n;
       }
-      p = end;
+      if (end)
+      {
+        p = end;
+      }
+      else
+      {
+        p++;
+      }
     }
     else
       p++;

--- a/mutt/string.c
+++ b/mutt/string.c
@@ -175,35 +175,108 @@ size_t mutt_istr_startswith(const char *str, const char *prefix)
 }
 
 /**
- * mutt_str_atol - Convert ASCII string to a long
+ * str_atol_clamp - Convert ASCII string to a long and clamp
  * @param[in]  str String to read
+ * @param[in]  lmin Lower bound
+ * @param[in]  lmax Upper bound
  * @param[out] dst Store the result
- * @retval  0 Success
- * @retval -1 Error
- * @retval -2 Overflow
+ * @retval endptr
+ *
+ * endptr    == NULL -> no conversion happened, or overflow
+ * endptr[0] == '\0' -> str was fully converted
+ * endptr[0] != '\0' -> endptr points to first non converted char in str
  *
  * This is a strtol() wrapper with range checking.
  * errno may be set on error, e.g. ERANGE
  */
-int mutt_str_atol(const char *str, long *dst)
+static const char *str_atol_clamp(const char *str, long *dst, long lmin, long lmax)
 {
   if (dst)
+  {
     *dst = 0;
+  }
 
-  if (!str || (*str == '\0')) /* no input: 0 */
-    return 0;
+  if (!str || (*str == '\0'))
+  {
+    return NULL;
+  }
 
   char *e = NULL;
   errno = 0;
-
   long res = strtol(str, &e, 10);
+  if ((e == str) || (((res == LONG_MIN) || (res == LONG_MAX)) && (errno == ERANGE)) ||
+      (res < lmin) || (res > lmax))
+  {
+    return NULL;
+  }
+
   if (dst)
+  {
     *dst = res;
-  if (((res == LONG_MIN) || (res == LONG_MAX)) && (errno == ERANGE))
-    return -2;
-  if (e && (*e != '\0'))
-    return -1;
-  return 0;
+  }
+
+  return e;
+}
+
+/**
+ * str_atoull_clamp - Convert ASCII string to an unsigned long long and clamp
+ * @param[in]  str String to read
+ * @param[in]  ullmax Upper bound
+ * @param[out] dst Store the result
+ * @retval endptr
+ *
+ * endptr    == NULL -> no conversion happened, or overflow
+ * endptr[0] == '\0' -> str was fully converted
+ * endptr[0] != '\0' -> endptr points to first non converted char in str
+ *
+ * This is a strtoull() wrapper with range checking.
+ * errno may be set on error, e.g. ERANGE
+ */
+static const char *str_atoull_clamp(const char *str, unsigned long long *dst,
+                                    unsigned long long ullmax)
+{
+  if (dst)
+  {
+    *dst = 0;
+  }
+
+  if (!str || (*str == '\0'))
+  {
+    return str;
+  }
+
+  char *e = NULL;
+  errno = 0;
+  unsigned long long res = strtoull(str, &e, 10);
+  if ((e == str) || ((res == ULLONG_MAX) && (errno == ERANGE)) || (res > ullmax))
+  {
+    return NULL;
+  }
+
+  if (dst)
+  {
+    *dst = res;
+  }
+
+  return e;
+}
+
+/**
+ * mutt_str_atol - Convert ASCII string to a long
+ * @param[in]  str String to read
+ * @param[out] dst Store the result
+ * @retval endptr
+ *
+ * endptr    == NULL -> no conversion happened, or overflow
+ * endptr[0] == '\0' -> str was fully converted
+ * endptr[0] != '\0' -> endptr points to first non converted char in str
+ *
+ * This is a strtol() wrapper with range checking.
+ * errno may be set on error, e.g. ERANGE
+ */
+const char *mutt_str_atol(const char *str, long *dst)
+{
+  return str_atol_clamp(str, dst, LONG_MIN, LONG_MAX);
 }
 
 /**
@@ -219,146 +292,130 @@ int mutt_str_atol(const char *str, long *dst)
  *
  * errno may be set on error, e.g. ERANGE
  */
-int mutt_str_atos(const char *str, short *dst)
+const char *mutt_str_atos(const char *str, short *dst)
 {
+  long l;
+  const char *res = str_atol_clamp(str, &l, SHRT_MIN, SHRT_MAX);
   if (dst)
-    *dst = 0;
-
-  long res = 0;
-  int rc = mutt_str_atol(str, &res);
-  if (rc < 0)
-    return rc;
-  if ((res < SHRT_MIN) || (res > SHRT_MAX))
-    return -2;
-
-  if (dst)
-    *dst = (short) res;
-
-  return 0;
+  {
+    *dst = res ? l : 0;
+  }
+  return res;
 }
 
 /**
  * mutt_str_atoi - Convert ASCII string to an integer
  * @param[in]  str String to read
  * @param[out] dst Store the result
- * @retval  0 Success
- * @retval -1 Error
- * @retval -2 Error, overflow
+ * @retval endptr
+ *
+ * endptr    == NULL -> no conversion happened, or overflow
+ * endptr[0] == '\0' -> str was fully converted
+ * endptr[0] != '\0' -> endptr points to first non converted char in str
  *
  * This is a strtol() wrapper with range checking.
  * If @a dst is NULL, the string will be tested only (without conversion).
  * errno may be set on error, e.g. ERANGE
  */
-int mutt_str_atoi(const char *str, int *dst)
+const char *mutt_str_atoi(const char *str, int *dst)
 {
+  long l;
+  const char *res = str_atol_clamp(str, &l, INT_MIN, INT_MAX);
   if (dst)
-    *dst = 0;
-
-  long res = 0;
-  int rc = mutt_str_atol(str, &res);
-  if (rc < 0)
-    return rc;
-  if ((res < INT_MIN) || (res > INT_MAX))
-    return -2;
-
-  if (dst)
-    *dst = (int) res;
-
-  return 0;
+  {
+    *dst = res ? l : 0;
+  }
+  return res;
 }
 
 /**
  * mutt_str_atoui - Convert ASCII string to an unsigned integer
  * @param[in]  str String to read
  * @param[out] dst Store the result
- * @retval  1 Successful conversion, with trailing characters
- * @retval  0 Successful conversion
- * @retval -1 Invalid input
- * @retval -2 Input out of range
+ * @retval endptr
+ *
+ * endptr    == NULL -> no conversion happened, or overflow
+ * endptr[0] == '\0' -> str was fully converted
+ * endptr[0] != '\0' -> endptr points to first non converted char in str
  *
  * @note This function's return value differs from the other functions.
  *       They return -1 if there is input beyond the number.
  */
-int mutt_str_atoui(const char *str, unsigned int *dst)
+const char *mutt_str_atoui(const char *str, unsigned int *dst)
 {
+  unsigned long long l;
+  const char *res = str_atoull_clamp(str, &l, UINT_MAX);
   if (dst)
-    *dst = 0;
-
-  unsigned long res = 0;
-  int rc = mutt_str_atoul(str, &res);
-  if (rc < 0)
-    return rc;
-  if (res > UINT_MAX)
-    return -2;
-
-  if (dst)
-    *dst = (unsigned int) res;
-
-  return rc;
+  {
+    *dst = res ? l : 0;
+  }
+  return res;
 }
 
 /**
  * mutt_str_atoul - Convert ASCII string to an unsigned long
  * @param[in]  str String to read
  * @param[out] dst Store the result
- * @retval  1 Successful conversion, with trailing characters
- * @retval  0 Successful conversion
- * @retval -1 Invalid input
+ * @retval endptr
+ *
+ * endptr    == NULL -> no conversion happened, or overflow
+ * endptr[0] == '\0' -> str was fully converted
+ * endptr[0] != '\0' -> endptr points to first non converted char in str
  *
  * @note This function's return value differs from the other functions.
  *       They return -1 if there is input beyond the number.
  */
-int mutt_str_atoul(const char *str, unsigned long *dst)
+const char *mutt_str_atoul(const char *str, unsigned long *dst)
 {
+  unsigned long long l;
+  const char *res = str_atoull_clamp(str, &l, ULONG_MAX);
   if (dst)
-    *dst = 0;
+  {
+    *dst = res ? l : 0;
+  }
+  return res;
+}
 
-  if (!str || (*str == '\0')) /* no input: 0 */
-    return 0;
-
-  char *e = NULL;
-  errno = 0;
-
-  unsigned long res = strtoul(str, &e, 10);
+/**
+ * mutt_str_atous - Convert ASCII string to an unsigned short
+ * @param[in]  str String to read
+ * @param[out] dst Store the result
+ * @retval endptr
+ *
+ * endptr    == NULL -> no conversion happened, or overflow
+ * endptr[0] == '\0' -> str was fully converted
+ * endptr[0] != '\0' -> endptr points to first non converted char in str
+ *
+ * @note This function's return value differs from the other functions.
+ *       They return -1 if there is input beyond the number.
+ */
+const char *mutt_str_atous(const char *str, unsigned short *dst)
+{
+  unsigned long long l;
+  const char *res = str_atoull_clamp(str, &l, USHRT_MAX);
   if (dst)
-    *dst = res;
-  if ((res == ULONG_MAX) && (errno == ERANGE))
-    return -1;
-  if (e && (*e != '\0'))
-    return 1;
-  return 0;
+  {
+    *dst = res ? l : 0;
+  }
+  return res;
 }
 
 /**
  * mutt_str_atoull - Convert ASCII string to an unsigned long long
  * @param[in]  str String to read
  * @param[out] dst Store the result
- * @retval  1 Successful conversion, with trailing characters
- * @retval  0 Successful conversion
- * @retval -1 Invalid input
+ * @retval endptr
+ *
+ * endptr    == NULL -> no conversion happened, or overflow
+ * endptr[0] == '\0' -> str was fully converted
+ * endptr[0] != '\0' -> endptr points to first non converted char in str
  *
  * @note This function's return value differs from the other functions.
  *       They return -1 if there is input beyond the number.
  */
-int mutt_str_atoull(const char *str, unsigned long long *dst)
+const char *mutt_str_atoull(const char *str, unsigned long long *dst)
 {
-  if (dst)
-    *dst = 0;
-
-  if (!str || (*str == '\0')) /* no input: 0 */
-    return 0;
-
-  char *e = NULL;
-  errno = 0;
-
-  unsigned long long res = strtoull(str, &e, 10);
-  if (dst)
-    *dst = res;
-  if ((res == ULLONG_MAX) && (errno == ERANGE))
-    return -1;
-  if (e && (*e != '\0'))
-    return 1;
-  return 0;
+  return str_atoull_clamp(str, dst, ULLONG_MAX);
 }
 
 /**

--- a/mutt/string2.h
+++ b/mutt/string2.h
@@ -56,12 +56,13 @@
 void        mutt_str_adjust(char **ptr);
 void        mutt_str_append_item(char **str, const char *item, char sep);
 int         mutt_str_asprintf(char **strp, const char *fmt, ...);
-int         mutt_str_atoi(const char *str, int *dst);
-int         mutt_str_atol(const char *str, long *dst);
-int         mutt_str_atos(const char *str, short *dst);
-int         mutt_str_atoui(const char *str, unsigned int *dst);
-int         mutt_str_atoul(const char *str, unsigned long *dst);
-int         mutt_str_atoull(const char *str, unsigned long long *dst);
+const char *mutt_str_atoi(const char *str, int *dst);
+const char *mutt_str_atol(const char *str, long *dst);
+const char *mutt_str_atos(const char *str, short *dst);
+const char *mutt_str_atoui(const char *str, unsigned int *dst);
+const char *mutt_str_atoul(const char *str, unsigned long *dst);
+const char *mutt_str_atous(const char *str, unsigned short *dst);
+const char *mutt_str_atoull(const char *str, unsigned long long *dst);
 int         mutt_str_coll(const char *a, const char *b);
 void        mutt_str_dequote_comment(char *str);
 const char *mutt_str_find_word(const char *src);
@@ -106,5 +107,20 @@ size_t      mutt_istr_startswith(const char *str, const char *prefix);
 int         mutt_istrn_cmp(const char *a, const char *b, size_t num);
 bool        mutt_istrn_equal(const char *a, const char *b, size_t num);
 const char *mutt_istrn_rfind(const char *haystack, size_t haystack_length, const char *needle);
+
+#define make_str_ato_wrappers(flavour, type) \
+  static inline bool mutt_str_ato ## flavour ## _full(const char *src, type *dst) \
+  { \
+    const char * end = mutt_str_ato ## flavour(src, dst); \
+    return end && !*end; \
+  } \
+
+make_str_ato_wrappers(i,   int)
+make_str_ato_wrappers(l,   long)
+make_str_ato_wrappers(s,   short)
+make_str_ato_wrappers(ui,  unsigned int)
+make_str_ato_wrappers(ul,  unsigned long)
+make_str_ato_wrappers(ull, unsigned long long)
+make_str_ato_wrappers(us,  unsigned short)
 
 #endif /* MUTT_LIB_STRING_H */

--- a/ncrypt/gnupgparse.c
+++ b/ncrypt/gnupgparse.c
@@ -232,7 +232,7 @@ static struct PgpKeyInfo *parse_pub_line(char *buf, bool *is_subkey, struct PgpK
       {
         mutt_debug(LL_DEBUG2, "key len: %s\n", p);
 
-        if (!(*is_subkey && c_pgp_ignore_subkeys) && (mutt_str_atos(p, &tmp.keylen) < 0))
+        if (!(*is_subkey && c_pgp_ignore_subkeys) && !mutt_str_atos_full(p, &tmp.keylen))
         {
           goto bail;
         }
@@ -245,7 +245,7 @@ static struct PgpKeyInfo *parse_pub_line(char *buf, bool *is_subkey, struct PgpK
         if (!(*is_subkey && c_pgp_ignore_subkeys))
         {
           int x = 0;
-          if (mutt_str_atoi(p, &x) < 0)
+          if (!mutt_str_atoi_full(p, &x))
             goto bail;
           tmp.numalg = x;
           tmp.algorithm = pgp_pkalgbytype(x);
@@ -274,19 +274,19 @@ static struct PgpKeyInfo *parse_pub_line(char *buf, bool *is_subkey, struct PgpK
           strncpy(tstr, p, 11);
           tstr[4] = '\0';
           tstr[7] = '\0';
-          if (mutt_str_atoi(tstr, &time.tm_year) < 0)
+          if (!mutt_str_atoi_full(tstr, &time.tm_year))
           {
             p = tstr;
             goto bail;
           }
           time.tm_year -= 1900;
-          if (mutt_str_atoi(tstr + 5, &time.tm_mon) < 0)
+          if (!mutt_str_atoi_full(tstr + 5, &time.tm_mon))
           {
             p = tstr + 5;
             goto bail;
           }
           time.tm_mon -= 1;
-          if (mutt_str_atoi(tstr + 8, &time.tm_mday) < 0)
+          if (!mutt_str_atoi_full(tstr + 8, &time.tm_mday))
           {
             p = tstr + 8;
             goto bail;
@@ -297,7 +297,7 @@ static struct PgpKeyInfo *parse_pub_line(char *buf, bool *is_subkey, struct PgpK
         {
           unsigned long long secs;
 
-          if (mutt_str_atoull(p, &secs) < 0)
+          if (!mutt_str_atoull(p, &secs))
             goto bail;
           tmp.gen_time = (time_t) secs;
         }

--- a/notmuch/notmuch.c
+++ b/notmuch/notmuch.c
@@ -361,8 +361,10 @@ static char *get_query_string(struct NmMboxData *mdata, bool window)
 
     if (strcmp(item->name, "limit") == 0)
     {
-      if (mutt_str_atoi(item->value, &mdata->db_limit))
+      if (!mutt_str_atoi_full(item->value, &mdata->db_limit))
+      {
         mutt_error(_("failed to parse notmuch limit: %s"), item->value);
+      }
     }
     else if (strcmp(item->name, "type") == 0)
       mdata->query_type = nm_string_to_query_type(item->value);
@@ -1798,7 +1800,7 @@ static enum MxStatus nm_mbox_check_stats(struct Mailbox *m, uint8_t flags)
     else if (item->value && (strcmp(item->name, "limit") == 0))
     {
       // Try to parse the limit
-      if (mutt_str_atoi(item->value, &limit) != 0)
+      if (!mutt_str_atoi_full(item->value, &limit))
       {
         mutt_error(_("failed to parse limit: %s"), item->value);
         goto done;

--- a/resize.c
+++ b/resize.c
@@ -80,14 +80,14 @@ void mutt_resize_screen(void)
   if (screenrows <= 0)
   {
     const char *cp = mutt_str_getenv("LINES");
-    if (cp && (mutt_str_atoi(cp, &screenrows) < 0))
+    if (cp && !mutt_str_atoi_full(cp, &screenrows))
       screenrows = 24;
   }
 
   if (screencols <= 0)
   {
     const char *cp = mutt_str_getenv("COLUMNS");
-    if (cp && (mutt_str_atoi(cp, &screencols) < 0))
+    if (cp && !mutt_str_atoi_full(cp, &screencols))
       screencols = 80;
   }
 

--- a/score.c
+++ b/score.c
@@ -141,7 +141,7 @@ enum CommandResult mutt_parse_score(struct Buffer *buf, struct Buffer *s,
     ptr->exact = true;
     pc++;
   }
-  if (mutt_str_atoi(pc, &ptr->val) < 0)
+  if (!mutt_str_atoi_full(pc, &ptr->val))
   {
     FREE(&pattern);
     mutt_buffer_strcpy(err, _("Error: score: invalid number"));

--- a/send/smtp.c
+++ b/send/smtp.c
@@ -125,17 +125,7 @@ struct SmtpAuth
  */
 static bool valid_smtp_code(char *buf, size_t buflen, int *n)
 {
-  char code[4];
-
-  if (buflen < 4)
-    return false;
-  code[0] = buf[0];
-  code[1] = buf[1];
-  code[2] = buf[2];
-  code[3] = '\0';
-  if (mutt_str_atoi(code, n) < 0)
-    return false;
-  return true;
+  return (mutt_str_atoi(buf, n) - buf) <= 3;
 }
 
 /**

--- a/test/string/mutt_str_atoi.c
+++ b/test/string/mutt_str_atoi.c
@@ -90,11 +90,11 @@ void test_mutt_str_atoi(void)
   // int mutt_str_atoi(const char *str, int *dst);
 
   int result = UNEXPECTED;
-  int retval = 0;
 
   // Degenerate tests
-  TEST_CHECK(mutt_str_atoi(NULL, &result) == 0);
-  TEST_CHECK(mutt_str_atoi("42", NULL) == 0);
+  TEST_CHECK(mutt_str_atoi(NULL, &result) == NULL);
+  TEST_CHECK(result == 0);
+  TEST_CHECK(mutt_str_atoi("42", NULL) != NULL);
 
   // Normal tests
   for (size_t i = 0; i < mutt_array_size(tests); i++)
@@ -102,12 +102,19 @@ void test_mutt_str_atoi(void)
     TEST_CASE(tests[i].str);
 
     result = UNEXPECTED;
-    retval = mutt_str_atoi(tests[i].str, &result);
+    const char *end = mutt_str_atoi(tests[i].str, &result);
 
-    if (!TEST_CHECK((retval == tests[i].retval) && (result == tests[i].result)))
+    if (tests[i].retval == 0 && (end == NULL || *end))
     {
-      TEST_MSG("retval: Expected: %d, Got: %d\n", tests[i].retval, retval);
-      TEST_MSG("result: Expected: %ld, Got: %ld\n", tests[i].result, result);
+      TEST_MSG("retval: Expected: \\0, Got: %s\n", end);
+    }
+    else if (tests[i].retval == -1 && end)
+    {
+      TEST_MSG("retval: Expected: NULL, Got: %s\n", end);
+    }
+    else if (tests[i].retval == -2 && end)
+    {
+      TEST_MSG("retval: Expected: NULL, Got: %s\n", end);
     }
   }
 }

--- a/test/string/mutt_str_atol.c
+++ b/test/string/mutt_str_atol.c
@@ -118,11 +118,11 @@ void test_mutt_str_atol(void)
   // int mutt_str_atol(const char *str, long *dst);
 
   long result = UNEXPECTED;
-  int retval = 0;
 
   // Degenerate tests
-  TEST_CHECK(mutt_str_atol(NULL, &result) == 0);
-  TEST_CHECK(mutt_str_atol("42", NULL) == 0);
+  TEST_CHECK(mutt_str_atol(NULL, &result) == NULL);
+  TEST_CHECK(result == 0);
+  TEST_CHECK(mutt_str_atol("42", NULL) != NULL);
 
   // Normal tests
   for (size_t i = 0; i < mutt_array_size(tests); i++)
@@ -130,12 +130,19 @@ void test_mutt_str_atol(void)
     TEST_CASE(tests[i].str);
 
     result = UNEXPECTED;
-    retval = mutt_str_atol(tests[i].str, &result);
+    const char *end = mutt_str_atol(tests[i].str, &result);
 
-    if (!TEST_CHECK((retval == tests[i].retval) && (result == tests[i].result)))
+    if (tests[i].retval == 0 && (end == NULL || *end))
     {
-      TEST_MSG("retval: Expected: %d, Got: %d\n", tests[i].retval, retval);
-      TEST_MSG("result: Expected: %ld, Got: %ld\n", tests[i].result, result);
+      TEST_MSG("retval: Expected: \\0, Got: %s\n", end);
+    }
+    else if (tests[i].retval == -1 && end)
+    {
+      TEST_MSG("retval: Expected: NULL, Got: %s\n", end);
+    }
+    else if (tests[i].retval == -2 && end)
+    {
+      TEST_MSG("retval: Expected: NULL, Got: %s\n", end);
     }
   }
 }

--- a/test/string/mutt_str_atos.c
+++ b/test/string/mutt_str_atos.c
@@ -90,11 +90,11 @@ void test_mutt_str_atos(void)
   // int mutt_str_atos(const char *str, short *dst);
 
   short result = UNEXPECTED;
-  int retval = 0;
 
   // Degenerate tests
-  TEST_CHECK(mutt_str_atos(NULL, &result) == 0);
-  TEST_CHECK(mutt_str_atos("42", NULL) == 0);
+  TEST_CHECK(mutt_str_atos(NULL, &result) == NULL);
+  TEST_CHECK(result == 0);
+  TEST_CHECK(mutt_str_atos("42", NULL) != 0);
 
   // Normal tests
   for (size_t i = 0; i < mutt_array_size(tests); i++)
@@ -102,12 +102,19 @@ void test_mutt_str_atos(void)
     TEST_CASE(tests[i].str);
 
     result = UNEXPECTED;
-    retval = mutt_str_atos(tests[i].str, &result);
+    const char *end = mutt_str_atos(tests[i].str, &result);
 
-    if (!TEST_CHECK((retval == tests[i].retval) && (result == tests[i].result)))
+    if (tests[i].retval == 0 && (end == NULL || *end))
     {
-      TEST_MSG("retval: Expected: %d, Got: %d\n", tests[i].retval, retval);
-      TEST_MSG("result: Expected: %d, Got: %d\n", tests[i].result, result);
+      TEST_MSG("retval: Expected: \\0, Got: %s\n", end);
+    }
+    else if (tests[i].retval == -1 && end)
+    {
+      TEST_MSG("retval: Expected: NULL, Got: %s\n", end);
+    }
+    else if (tests[i].retval == -2 && end)
+    {
+      TEST_MSG("retval: Expected: NULL, Got: %s\n", end);
     }
   }
 }

--- a/test/string/mutt_str_atoui.c
+++ b/test/string/mutt_str_atoui.c
@@ -89,11 +89,11 @@ void test_mutt_str_atoui(void)
   // int mutt_str_atoui(const char *str, unsigned int *dst);
 
   unsigned int result = UNEXPECTED;
-  int retval = 0;
 
   // Degenerate tests
-  TEST_CHECK(mutt_str_atoui(NULL, &result) == 0);
-  TEST_CHECK(mutt_str_atoui("42", NULL) == 0);
+  TEST_CHECK(mutt_str_atoui(NULL, &result) == NULL);
+  TEST_CHECK(result == 0);
+  TEST_CHECK(mutt_str_atoui("42", NULL) != NULL);
 
   // Normal tests
   for (size_t i = 0; i < mutt_array_size(tests); i++)
@@ -101,12 +101,19 @@ void test_mutt_str_atoui(void)
     TEST_CASE(tests[i].str);
 
     result = UNEXPECTED;
-    retval = mutt_str_atoui(tests[i].str, &result);
+    const char *end = mutt_str_atoui(tests[i].str, &result);
 
-    if (!TEST_CHECK((retval == tests[i].retval) && (result == tests[i].result)))
+    if (tests[i].retval == 0 && (end == NULL || *end))
     {
-      TEST_MSG("retval: Expected: %d, Got: %d\n", tests[i].retval, retval);
-      TEST_MSG("result: Expected: %lu, Got: %lu\n", tests[i].result, result);
+      TEST_MSG("retval: Expected: \\0, Got: %s\n", end);
+    }
+    else if (tests[i].retval == -1 && end)
+    {
+      TEST_MSG("retval: Expected: NULL, Got: %s\n", end);
+    }
+    else if (tests[i].retval == -2 && end)
+    {
+      TEST_MSG("retval: Expected: NULL, Got: %s\n", end);
     }
   }
 }

--- a/test/string/mutt_str_atoul.c
+++ b/test/string/mutt_str_atoul.c
@@ -95,11 +95,11 @@ void test_mutt_str_atoul(void)
   // int mutt_str_atoul(const char *str, unsigned long *dst);
 
   unsigned long result = UNEXPECTED;
-  int retval = 0;
 
   // Degenerate tests
-  TEST_CHECK(mutt_str_atoul(NULL, &result) == 0);
-  TEST_CHECK(mutt_str_atoul("42", NULL) == 0);
+  TEST_CHECK(mutt_str_atoul(NULL, &result) == NULL);
+  TEST_CHECK(result == 0);
+  TEST_CHECK(mutt_str_atoul("42", NULL) != NULL);
 
   // Normal tests
   for (size_t i = 0; i < mutt_array_size(tests); i++)
@@ -107,12 +107,19 @@ void test_mutt_str_atoul(void)
     TEST_CASE(tests[i].str);
 
     result = UNEXPECTED;
-    retval = mutt_str_atoul(tests[i].str, &result);
+    const char *end = mutt_str_atoul(tests[i].str, &result);
 
-    if (!TEST_CHECK((retval == tests[i].retval) && (result == tests[i].result)))
+    if (tests[i].retval == 0 && (end == NULL || *end))
     {
-      TEST_MSG("retval: Expected: %d, Got: %d\n", tests[i].retval, retval);
-      TEST_MSG("result: Expected: %lu, Got: %lu\n", tests[i].result, result);
+      TEST_MSG("retval: Expected: \\0, Got: %s\n", end);
+    }
+    else if (tests[i].retval == -1 && end)
+    {
+      TEST_MSG("retval: Expected: NULL, Got: %s\n", end);
+    }
+    else if (tests[i].retval == -2 && end)
+    {
+      TEST_MSG("retval: Expected: NULL, Got: %s\n", end);
     }
   }
 }

--- a/test/string/mutt_str_atoull.c
+++ b/test/string/mutt_str_atoull.c
@@ -75,11 +75,11 @@ void test_mutt_str_atoull(void)
   // int mutt_str_atoull(const char *str, unsigned long long *dst);
 
   unsigned long long result = UNEXPECTED;
-  int retval = 0;
 
   // Degenerate tests
-  TEST_CHECK(mutt_str_atoull(NULL, &result) == 0);
-  TEST_CHECK(mutt_str_atoull("42", NULL) == 0);
+  TEST_CHECK(mutt_str_atoull(NULL, &result) == NULL);
+  TEST_CHECK(result == 0);
+  TEST_CHECK(mutt_str_atoull("42", NULL) != NULL);
 
   // Normal tests
   for (size_t i = 0; i < mutt_array_size(tests); i++)
@@ -87,12 +87,19 @@ void test_mutt_str_atoull(void)
     TEST_CASE(tests[i].str);
 
     result = UNEXPECTED;
-    retval = mutt_str_atoull(tests[i].str, &result);
+    const char *end = mutt_str_atoull(tests[i].str, &result);
 
-    if (!TEST_CHECK((retval == tests[i].retval) && (result == tests[i].result)))
+    if (tests[i].retval == 0 && (end == NULL || *end))
     {
-      TEST_MSG("retval: Expected: %d, Got: %d\n", tests[i].retval, retval);
-      TEST_MSG("result: Expected: %lu, Got: %lu\n", tests[i].result, result);
+      TEST_MSG("retval: Expected: \\0, Got: %s\n", end);
+    }
+    else if (tests[i].retval == -1 && end)
+    {
+      TEST_MSG("retval: Expected: NULL, Got: %s\n", end);
+    }
+    else if (tests[i].retval == -2 && end)
+    {
+      TEST_MSG("retval: Expected: NULL, Got: %s\n", end);
     }
   }
 }


### PR DESCRIPTION
The signature of the `mutt_str_ato*` functions have been changed to return the endptr argument to the relative libc functions. In addition, I have added wrappers named `mutt_str_ato*_full` that return a bool indicating whether a successful conversion consumed the whole string. So, the changes at API level are

```diff
- if (mutt_str_ato*(...) < 0)
+ if (!mutt_str_ato*(...))
```

and

```diff
- if (mutt_str_ato*(...) != 0)
+ if (!mutt_str_ato*_full(...))
```

Additionally, whoever needs more control can use the returned endptr, see e.g., the changes in mutt/regex.c .