### PR TITLE
gpgme: fix crash with partially defined keys

### DIFF
--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -2518,15 +2518,10 @@ static int pgp_gpgme_extract_keys(gpgme_data_t keydata, FILE **fp)
         fprintf(*fp, "sub %5.5s %u/%8s %s\n", gpgme_pubkey_algo_name(subkey->pubkey_algo),
                 subkey->length, shortid, date);
       }
-      else if (uid)
-      {
-        fprintf(*fp, "pub %5.5s %u/%8s %s %s\n", gpgme_pubkey_algo_name(subkey->pubkey_algo),
-                subkey->length, shortid, date, uid->uid);
-      }
       else
       {
-        fprintf(*fp, "pub %5.5s %u/%8s %s\n", gpgme_pubkey_algo_name(subkey->pubkey_algo),
-                subkey->length, shortid, date);
+        fprintf(*fp, "pub %5.5s %u/%8s %s %s\n", gpgme_pubkey_algo_name(subkey->pubkey_algo),
+                subkey->length, shortid, date, (uid ? uid->uid : ""));
       }
       subkey = subkey->next;
       more = true;

--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -2518,10 +2518,15 @@ static int pgp_gpgme_extract_keys(gpgme_data_t keydata, FILE **fp)
         fprintf(*fp, "sub %5.5s %u/%8s %s\n", gpgme_pubkey_algo_name(subkey->pubkey_algo),
                 subkey->length, shortid, date);
       }
-      else
+      else if (uid)
       {
         fprintf(*fp, "pub %5.5s %u/%8s %s %s\n", gpgme_pubkey_algo_name(subkey->pubkey_algo),
                 subkey->length, shortid, date, uid->uid);
+      }
+      else
+      {
+        fprintf(*fp, "pub %5.5s %u/%8s %s\n", gpgme_pubkey_algo_name(subkey->pubkey_algo),
+                subkey->length, shortid, date);
       }
       subkey = subkey->next;
       more = true;


### PR DESCRIPTION
If the key isn't held locally, `uid` may be `NULL`.

Situation:
- Using GPGME
- Decrypting an email
- Decryption key doesn't have a UID

If the encrypted email contains a PGP key, then NeoMutt will display a block, like this:
```
[-- BEGIN PGP PUBLIC KEY BLOCK --]  
pub EdDSA 255/ABC123DE 2020-11-29 John Doe <jd@example.com>
sub  ECDH 255/456DEF78 2020-11-29
sub EdDSA 255/12345678 2020-11-29
[-- END PGP PUBLIC KEY BLOCK --]
```

If the UID ("John Doe...") isn't defined, then `uid` in `pgp_gpgme_extract_keys()` will be `NULL` leading to a crash.

---

Thanks :heart: to Nick Johnson for his help debugging.