### PR TITLE
Remove config_init_autocrypt dummy definition

### DIFF
--- a/init.c
+++ b/init.c
@@ -74,14 +74,6 @@
 #ifdef USE_IMAP
 #include "imap/lib.h"
 #endif
-#ifdef USE_AUTOCRYPT
-#include "autocrypt/lib.h"
-#else
-static inline bool config_init_autocrypt(struct ConfigSet *cs)
-{
-  return true;
-}
-#endif
 
 /* Initial string that starts completion. No telling how much the user has
  * typed so far. Allocate 1024 just to be sure! */


### PR DESCRIPTION
This was introduced in 6b893166b9d724e22db0b45803fc4a45ccb2fb17, I can't see why :/