### PR TITLE
build: configure --debug-queue

### DIFF
--- a/auto.def
+++ b/auto.def
@@ -127,6 +127,7 @@ options {
   debug-graphviz=0          => "DEBUG: Enable Graphviz dump"
   debug-notify=0            => "DEBUG: Enable Notifications dump"
   debug-parse-test=0        => "DEBUG: Enable 'neomutt -T' for config testing"
+  debug-queue=0             => "DEBUG: Enable TAILQ debugging"
   debug-window=0            => "DEBUG: Enable windows dump"
 # Deprecated stuff
   with-ui:=deprecated       => "Deprecated"
@@ -150,11 +151,12 @@ foreach dep {with-ui with-slang} {
 if {1} {
   # Keep sorted, please.
   foreach opt {
-    asan autocrypt bdb coverage debug-backtrace debug-email debug-graphviz debug-notify
-    debug-parse-test debug-window doc everything fmemopen full-doc fuzzing gdbm gnutls
-    gpgme gss homespool idn idn2 include-path-in-cflags inotify kyotocabinet
-    lmdb locales-fix lua lz4 mixmaster nls notmuch pcre2 pgp pkgconf qdbm
-    rocksdb sasl smime sqlite ssl testing tdb tokyocabinet zlib zstd
+    asan autocrypt bdb coverage debug-backtrace debug-email debug-graphviz
+    debug-notify debug-parse-test debug-queue debug-window doc everything
+    fmemopen full-doc fuzzing gdbm gnutls gpgme gss homespool idn idn2
+    include-path-in-cflags inotify kyotocabinet lmdb locales-fix lua lz4
+    mixmaster nls notmuch pcre2 pgp pkgconf qdbm rocksdb sasl smime sqlite ssl
+    testing tdb tokyocabinet zlib zstd
   } {
     define want-$opt [opt-bool $opt]
   }
@@ -1226,6 +1228,14 @@ if {[get-define want-debug-parse-test]} {
   define USE_DEBUG_PARSE_TEST 1
 }
 
+# TAILQ debugging
+if {[get-define want-debug-queue]} {
+  # Store the last 2 places the queue element or head was altered
+  define QUEUE_MACRO_DEBUG_TRACE
+  # Invalidated pointers will be set to 0xffffffffffffffff
+  define QUEUE_MACRO_DEBUG_TRASH
+}
+
 # Windows dump
 if {[get-define want-debug-window]} {
   define USE_DEBUG_WINDOW 1
@@ -1290,6 +1300,7 @@ set auto_rep {
   PACKAGE
   PKGDATADIR
   PKGDOCDIR
+  QUEUE_*
   SENDMAIL
   SUN_ATTACHMENT
   SYSCONFDIR


### PR DESCRIPTION
Enable debugging on mutt/queue.h macros:

- `LIST`, `SLIST`, `TAILQ`, `STAILQ`

This enables two symbols:

- `QUEUE_MACRO_DEBUG_TRACE`
  Store the last 2 places the queue element or head was altered

- `QUEUE_MACRO_DEBUG_TRASH`
  Invalidated pointers will be set to `0xffffffffffffffff`

---

These macros are reliable and very well tested, but they can be hard to use.
Defining these symbols will make it easier to spot mistakes in our code.

### Example of TRACE

In `gdb` examine the contents of a `TAILQ_HEAD`:

```
p *head
1: *head = {tqh_first = 0x850480, tqh_last = 0x850490,
    trace = {lastline = 215, prevline = 74, lastfile = 0x58a3d6 "email/parse.c", prevfile = 0x58a3b3 "email/parameter.c"}}
```
Here we can see the contents of the `TAILQ` **plus** the exact locations of the previous two changes to it.

### Example of TRASH

In `gdb` see the effect of a call to `TAILQ_REMOVE()`:

```
1: *np = {attribute = 0x6ad000 "charset", value = 0x84c640 "iso-8859-1",
    entries = {tqe_next = 0x0, tqe_prev = 0x81ba08,
    trace = {lastline = 215, prevline = 0, lastfile = 0x58a3d6 "email/parse.c", prevfile = 0x0}}}
```

```c
  TAILQ_REMOVE(head, np, entries);
```

`np`s prev/next pointers have become invalidated

```
1: *np = {attribute = 0x6ad000 "charset", value = 0x84c640 "iso-8859-1",
    entries = {tqe_next = 0xffffffffffffffff, tqe_prev = 0xffffffffffffffff,
    trace = {lastline = 71, prevline = 215, lastfile = 0x58ac2b "email/rfc2231.c", prevfile = 0x58a3d6 "email/parse.c"}}}
```