### PR TITLE
refactor mutt_get_field()

### DIFF
--- a/alias/alias.c
+++ b/alias/alias.c
@@ -371,10 +371,11 @@ struct AddressList *mutt_get_address(struct Envelope *env, const char **prefix)
  */
 void alias_create(struct AddressList *al, const struct ConfigSubset *sub)
 {
-  char buf[1024];
-  char fixed[1024];
-  char prompt[2048];
-  char tmp[1024] = { 0 };
+  struct Buffer *buf = mutt_buffer_pool_get();
+  struct Buffer *fixed = mutt_buffer_pool_get();
+  struct Buffer *prompt = NULL;
+  struct Buffer *tmp = mutt_buffer_pool_get();
+
   struct Address *addr = NULL;
   char *pc = NULL;
   char *err = NULL;
@@ -385,38 +386,38 @@ void alias_create(struct AddressList *al, const struct ConfigSubset *sub)
     addr = TAILQ_FIRST(al);
     if (addr && addr->mailbox)
     {
-      mutt_str_copy(tmp, addr->mailbox, sizeof(tmp));
-      pc = strchr(tmp, '@');
+      mutt_buffer_strcpy(tmp, addr->mailbox);
+      pc = strchr(mutt_buffer_string(tmp), '@');
       if (pc)
         *pc = '\0';
     }
   }
 
   /* Don't suggest a bad alias name in the event of a strange local part. */
-  check_alias_name(tmp, buf, sizeof(buf));
+  check_alias_name(mutt_buffer_string(tmp), buf->data, buf->dsize);
 
 retry_name:
   /* L10N: prompt to add a new alias */
-  if ((mutt_get_field(_("Alias as: "), buf, sizeof(buf), MUTT_COMP_NO_FLAGS,
-                      false, NULL, NULL) != 0) ||
-      (buf[0] == '\0'))
+  if ((mutt_buffer_get_field(_("Alias as: "), buf, MUTT_COMP_NO_FLAGS, false,
+                             NULL, NULL, NULL) != 0) ||
+      mutt_buffer_is_empty(buf))
   {
     goto done;
   }
 
   /* check to see if the user already has an alias defined */
-  if (alias_lookup(buf))
+  if (alias_lookup(mutt_buffer_string(buf)))
   {
     mutt_error(_("You already have an alias defined with that name"));
     goto done;
   }
 
-  if (check_alias_name(buf, fixed, sizeof(fixed)))
+  if (check_alias_name(mutt_buffer_string(buf), fixed->data, fixed->dsize))
   {
     switch (mutt_yesorno(_("Warning: This alias name may not work.  Fix it?"), MUTT_YES))
     {
       case MUTT_YES:
-        mutt_str_copy(buf, fixed, sizeof(buf));
+        mutt_buffer_copy(buf, fixed);
         goto retry_name;
       case MUTT_ABORT:
         goto done;
@@ -425,28 +426,28 @@ retry_name:
   }
 
   struct Alias *alias = alias_new();
-  alias->name = mutt_str_dup(buf);
+  alias->name = mutt_buffer_strdup(buf);
 
   mutt_addrlist_to_local(al);
 
   if (addr && addr->mailbox)
-    mutt_str_copy(buf, addr->mailbox, sizeof(buf));
+    mutt_buffer_strcpy(buf, addr->mailbox);
   else
-    buf[0] = '\0';
+    mutt_buffer_reset(buf);
 
   mutt_addrlist_to_intl(al, NULL);
 
   do
   {
-    if ((mutt_get_field(_("Address: "), buf, sizeof(buf), MUTT_COMP_NO_FLAGS,
-                        false, NULL, NULL) != 0) ||
-        (buf[0] == '\0'))
+    if ((mutt_buffer_get_field(_("Address: "), buf, MUTT_COMP_NO_FLAGS, false,
+                               NULL, NULL, NULL) != 0) ||
+        mutt_buffer_is_empty(buf))
     {
       alias_free(&alias);
       goto done;
     }
 
-    mutt_addrlist_parse(&alias->addr, buf);
+    mutt_addrlist_parse(&alias->addr, mutt_buffer_string(buf));
     if (TAILQ_EMPTY(&alias->addr))
       mutt_beep(false);
     if (mutt_addrlist_to_intl(&alias->addr, &err))
@@ -458,37 +459,39 @@ retry_name:
   } while (TAILQ_EMPTY(&alias->addr));
 
   if (addr && addr->personal && !mutt_is_mail_list(addr))
-    mutt_str_copy(buf, addr->personal, sizeof(buf));
+    mutt_buffer_strcpy(buf, addr->personal);
   else
-    buf[0] = '\0';
+    mutt_buffer_reset(buf);
 
-  if (mutt_get_field(_("Personal name: "), buf, sizeof(buf), MUTT_COMP_NO_FLAGS,
-                     false, NULL, NULL) != 0)
+  if (mutt_buffer_get_field(_("Personal name: "), buf, MUTT_COMP_NO_FLAGS,
+                            false, NULL, NULL, NULL) != 0)
   {
     alias_free(&alias);
     goto done;
   }
-  mutt_str_replace(&TAILQ_FIRST(&alias->addr)->personal, buf);
+  mutt_str_replace(&TAILQ_FIRST(&alias->addr)->personal, mutt_buffer_string(buf));
 
-  buf[0] = '\0';
-  if (mutt_get_field(_("Comment: "), buf, sizeof(buf), MUTT_COMP_NO_FLAGS,
-                     false, NULL, NULL) == 0)
+  mutt_buffer_reset(buf);
+  if (mutt_buffer_get_field(_("Comment: "), buf, MUTT_COMP_NO_FLAGS, false,
+                            NULL, NULL, NULL) == 0)
   {
-    mutt_str_replace(&alias->comment, buf);
+    mutt_str_replace(&alias->comment, mutt_buffer_string(buf));
   }
 
-  buf[0] = '\0';
-  mutt_addrlist_write(&alias->addr, buf, sizeof(buf), true);
+  mutt_buffer_reset(buf);
+  mutt_addrlist_write(&alias->addr, buf->data, buf->dsize, true);
+  prompt = mutt_buffer_pool_get();
   if (alias->comment)
   {
-    snprintf(prompt, sizeof(prompt), "[%s = %s # %s] %s", alias->name, buf,
-             alias->comment, _("Accept?"));
+    mutt_buffer_printf(prompt, "[%s = %s # %s] %s", alias->name,
+                       mutt_buffer_string(buf), alias->comment, _("Accept?"));
   }
   else
   {
-    snprintf(prompt, sizeof(prompt), "[%s = %s] %s", alias->name, buf, _("Accept?"));
+    mutt_buffer_printf(prompt, "[%s = %s] %s", alias->name,
+                       mutt_buffer_string(buf), _("Accept?"));
   }
-  if (mutt_yesorno(prompt, MUTT_YES) != MUTT_YES)
+  if (mutt_yesorno(mutt_buffer_string(prompt), MUTT_YES) != MUTT_YES)
   {
     alias_free(&alias);
     goto done;
@@ -498,18 +501,18 @@ retry_name:
   TAILQ_INSERT_TAIL(&Aliases, alias, entries);
 
   const char *const alias_file = cs_subset_path(sub, "alias_file");
-  mutt_str_copy(buf, NONULL(alias_file), sizeof(buf));
+  mutt_buffer_strcpy(buf, alias_file);
 
-  if (mutt_get_field(_("Save to file: "), buf, sizeof(buf),
-                     MUTT_COMP_FILE | MUTT_COMP_CLEAR, false, NULL, NULL) != 0)
+  if (mutt_buffer_get_field(_("Save to file: "), buf, MUTT_COMP_FILE | MUTT_COMP_CLEAR,
+                            false, NULL, NULL, NULL) != 0)
   {
     goto done;
   }
-  mutt_expand_path(buf, sizeof(buf));
-  fp_alias = fopen(buf, "a+");
+  mutt_expand_path(buf->data, buf->dsize);
+  fp_alias = fopen(mutt_buffer_string(buf), "a+");
   if (!fp_alias)
   {
-    mutt_perror(buf);
+    mutt_perror(mutt_buffer_string(buf));
     goto done;
   }
 
@@ -524,7 +527,7 @@ retry_name:
     {
       goto done;
     }
-    if (fread(buf, 1, 1, fp_alias) != 1)
+    if (fread(buf->data, 1, 1, fp_alias) != 1)
     {
       mutt_perror(_("Error reading alias file"));
       goto done;
@@ -533,20 +536,22 @@ retry_name:
     {
       goto done;
     }
-    if (buf[0] != '\n')
+    if (buf->data[0] != '\n')
       fputc('\n', fp_alias);
   }
 
   if (check_alias_name(alias->name, NULL, 0))
-    mutt_file_quote_filename(alias->name, buf, sizeof(buf));
+    mutt_file_quote_filename(alias->name, buf->data, buf->dsize);
   else
-    mutt_str_copy(buf, alias->name, sizeof(buf));
-  recode_buf(buf, sizeof(buf));
-  fprintf(fp_alias, "alias %s ", buf);
-  buf[0] = '\0';
-  mutt_addrlist_write(&alias->addr, buf, sizeof(buf), false);
-  recode_buf(buf, sizeof(buf));
-  write_safe_address(fp_alias, buf);
+    mutt_buffer_strcpy(buf, alias->name);
+
+  recode_buf(buf->data, buf->dsize);
+  fprintf(fp_alias, "alias %s ", mutt_buffer_string(buf));
+  mutt_buffer_reset(buf);
+
+  mutt_addrlist_write(&alias->addr, buf->data, buf->dsize, false);
+  recode_buf(buf->data, buf->dsize);
+  write_safe_address(fp_alias, mutt_buffer_string(buf));
   if (alias->comment)
     fprintf(fp_alias, " # %s", alias->comment);
   fputc('\n', fp_alias);
@@ -557,6 +562,10 @@ retry_name:
 
 done:
   mutt_file_fclose(&fp_alias);
+  mutt_buffer_pool_release(&buf);
+  mutt_buffer_pool_release(&fixed);
+  mutt_buffer_pool_release(&prompt);
+  mutt_buffer_pool_release(&tmp);
 }
 
 /**

--- a/alias/dlgquery.c
+++ b/alias/dlgquery.c
@@ -740,19 +740,22 @@ void query_index(struct ConfigSubset *sub)
     return;
   }
 
-  char buf[256] = { 0 };
-  if ((mutt_get_field(_("Query: "), buf, sizeof(buf), MUTT_COMP_NO_FLAGS, false,
-                      NULL, NULL) != 0) ||
-      (buf[0] == '\0'))
+  struct Buffer *buf = mutt_buffer_pool_get();
+  if ((mutt_buffer_get_field(_("Query: "), buf, MUTT_COMP_NO_FLAGS, false, NULL,
+                             NULL, NULL) != 0) ||
+      mutt_buffer_is_empty(buf))
   {
-    return;
+    goto done;
   }
 
   struct AliasList al = TAILQ_HEAD_INITIALIZER(al);
-  query_run(buf, false, &al, sub);
+  query_run(mutt_buffer_string(buf), false, &al, sub);
   if (TAILQ_EMPTY(&al))
-    return;
+    goto done;
 
-  dlg_select_query(buf, sizeof(buf), &al, false, sub);
+  dlg_select_query(buf->data, buf->dsize, &al, false, sub);
   aliaslist_free(&al);
+
+done:
+  mutt_buffer_pool_release(&buf);
 }

--- a/browser/browser.c
+++ b/browser/browser.c
@@ -1793,8 +1793,8 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
         const struct Regex *c_mask = cs_subset_regex(NeoMutt->sub, "mask");
         struct Buffer *buf = mutt_buffer_pool_get();
         mutt_buffer_strcpy(buf, c_mask ? c_mask->pattern : NULL);
-        if (mutt_get_field(_("File Mask: "), buf->data, buf->dsize,
-                           MUTT_COMP_NO_FLAGS, false, NULL, NULL) != 0)
+        if (mutt_buffer_get_field(_("File Mask: "), buf, MUTT_COMP_NO_FLAGS,
+                                  false, NULL, NULL, NULL) != 0)
         {
           mutt_buffer_pool_release(&buf);
           break;

--- a/commands.c
+++ b/commands.c
@@ -641,19 +641,19 @@ done:
  */
 void mutt_enter_command(void)
 {
-  char buf[1024] = { 0 };
+  struct Buffer *buf = mutt_buffer_pool_get();
   struct Buffer *err = mutt_buffer_pool_get();
 
   window_redraw(NULL);
   /* if enter is pressed after : with no command, just return */
-  if ((mutt_get_field(":", buf, sizeof(buf), MUTT_COMP_COMMAND, false, NULL, NULL) != 0) ||
-      (buf[0] == '\0'))
+  if ((mutt_buffer_get_field(":", buf, MUTT_COMP_COMMAND, false, NULL, NULL, NULL) != 0) ||
+      mutt_buffer_is_empty(buf))
   {
     goto done;
   }
 
   /* check if buf is a valid icommand, else fall back quietly to parse_rc_lines */
-  enum CommandResult rc = mutt_parse_icommand(buf, err);
+  enum CommandResult rc = mutt_parse_icommand(mutt_buffer_string(buf), err);
   if (!mutt_buffer_is_empty(err))
   {
     /* since errbuf could potentially contain printf() sequences in it,
@@ -666,7 +666,7 @@ void mutt_enter_command(void)
   }
   else if (rc != MUTT_CMD_SUCCESS)
   {
-    rc = mutt_parse_rc_line(buf, err);
+    rc = mutt_parse_rc_line(mutt_buffer_string(buf), err);
     if (!mutt_buffer_is_empty(err))
     {
       if (rc == MUTT_CMD_SUCCESS) /* command succeeded with message */
@@ -680,6 +680,7 @@ void mutt_enter_command(void)
   /* else successful command */
 
 done:
+  mutt_buffer_pool_release(&buf);
   mutt_buffer_pool_release(&err);
 }
 

--- a/compose/functions.c
+++ b/compose/functions.c
@@ -946,20 +946,22 @@ static int op_compose_edit_reply_to(struct ComposeSharedData *shared, int op)
 static int op_compose_edit_subject(struct ComposeSharedData *shared, int op)
 {
   int rc = IR_NO_ACTION;
-  char buf[PATH_MAX];
-  mutt_str_copy(buf, shared->email->env->subject, sizeof(buf));
-  if (mutt_get_field(Prompts[HDR_SUBJECT], buf, sizeof(buf), MUTT_COMP_NO_FLAGS,
-                     false, NULL, NULL) == 0)
+  struct Buffer *buf = mutt_buffer_pool_get();
+
+  mutt_buffer_strcpy(buf, shared->email->env->subject);
+  if (mutt_buffer_get_field(Prompts[HDR_SUBJECT], buf, MUTT_COMP_NO_FLAGS,
+                            false, NULL, NULL, NULL) == 0)
   {
-    if (!mutt_str_equal(shared->email->env->subject, buf))
+    if (!mutt_str_equal(shared->email->env->subject, mutt_buffer_string(buf)))
     {
-      mutt_str_replace(&shared->email->env->subject, buf);
+      mutt_str_replace(&shared->email->env->subject, mutt_buffer_string(buf));
       notify_send(shared->notify, NT_COMPOSE, NT_COMPOSE_ENVELOPE, NULL);
       mutt_message_hook(NULL, shared->email, MUTT_SEND2_HOOK);
       rc = IR_SUCCESS;
     }
   }
 
+  mutt_buffer_pool_release(&buf);
   return rc;
 }
 

--- a/compose/functions.c
+++ b/compose/functions.c
@@ -1920,16 +1920,18 @@ static int op_compose_edit_x_comment_to(struct ComposeSharedData *shared, int op
     return IR_NO_ACTION;
 
   int rc = IR_NO_ACTION;
-  char buf[PATH_MAX];
-  mutt_str_copy(buf, shared->email->env->x_comment_to, sizeof(buf));
-  if (mutt_get_field(Prompts[HDR_XCOMMENTTO], buf, sizeof(buf),
-                     MUTT_COMP_NO_FLAGS, false, NULL, NULL) == 0)
+  struct Buffer *buf = mutt_buffer_pool_get();
+
+  mutt_buffer_strcpy(buf, shared->email->env->x_comment_to);
+  if (mutt_buffer_get_field(Prompts[HDR_XCOMMENTTO], buf, MUTT_COMP_NO_FLAGS,
+                            false, NULL, NULL, NULL) == 0)
   {
-    mutt_str_replace(&shared->email->env->x_comment_to, buf);
+    mutt_str_replace(&shared->email->env->x_comment_to, mutt_buffer_string(buf));
     notify_send(shared->notify, NT_COMPOSE, NT_COMPOSE_ENVELOPE, NULL);
     rc = IR_SUCCESS;
   }
 
+  mutt_buffer_pool_release(&buf);
   return rc;
 }
 #endif

--- a/compose/functions.c
+++ b/compose/functions.c
@@ -1871,16 +1871,18 @@ static int op_compose_edit_followup_to(struct ComposeSharedData *shared, int op)
     return IR_NO_ACTION;
 
   int rc = IR_NO_ACTION;
-  char buf[PATH_MAX];
-  mutt_str_copy(buf, shared->email->env->followup_to, sizeof(buf));
-  if (mutt_get_field(Prompts[HDR_FOLLOWUPTO], buf, sizeof(buf),
-                     MUTT_COMP_NO_FLAGS, false, NULL, NULL) == 0)
+  struct Buffer *buf = mutt_buffer_pool_get();
+
+  mutt_buffer_strcpy(buf, shared->email->env->followup_to);
+  if (mutt_buffer_get_field(Prompts[HDR_FOLLOWUPTO], buf, MUTT_COMP_NO_FLAGS,
+                            false, NULL, NULL, NULL) == 0)
   {
-    mutt_str_replace(&shared->email->env->followup_to, buf);
+    mutt_str_replace(&shared->email->env->followup_to, mutt_buffer_string(buf));
     notify_send(shared->notify, NT_COMPOSE, NT_COMPOSE_ENVELOPE, NULL);
     rc = IR_SUCCESS;
   }
 
+  mutt_buffer_pool_release(&buf);
   return rc;
 }
 

--- a/compose/functions.c
+++ b/compose/functions.c
@@ -1895,16 +1895,18 @@ static int op_compose_edit_newsgroups(struct ComposeSharedData *shared, int op)
     return IR_NO_ACTION;
 
   int rc = IR_NO_ACTION;
-  char buf[PATH_MAX];
-  mutt_str_copy(buf, shared->email->env->newsgroups, sizeof(buf));
-  if (mutt_get_field(Prompts[HDR_NEWSGROUPS], buf, sizeof(buf),
-                     MUTT_COMP_NO_FLAGS, false, NULL, NULL) == 0)
+  struct Buffer *buf = mutt_buffer_pool_get();
+
+  mutt_buffer_strcpy(buf, shared->email->env->newsgroups);
+  if (mutt_buffer_get_field(Prompts[HDR_NEWSGROUPS], buf, MUTT_COMP_NO_FLAGS,
+                            false, NULL, NULL, NULL) == 0)
   {
-    mutt_str_replace(&shared->email->env->newsgroups, buf);
+    mutt_str_replace(&shared->email->env->newsgroups, mutt_buffer_string(buf));
     notify_send(shared->notify, NT_COMPOSE, NT_COMPOSE_ENVELOPE, NULL);
     rc = IR_SUCCESS;
   }
 
+  mutt_buffer_pool_release(&buf);
   return rc;
 }
 

--- a/compose/functions.c
+++ b/compose/functions.c
@@ -689,24 +689,26 @@ static int op_compose_edit_description(struct ComposeSharedData *shared, int op)
     return IR_NO_ACTION;
 
   int rc = IR_NO_ACTION;
-  char buf[PATH_MAX];
+  struct Buffer *buf = mutt_buffer_pool_get();
+
   struct AttachPtr *cur_att =
       current_attachment(shared->adata->actx, shared->adata->menu);
-  mutt_str_copy(buf, cur_att->body->description, sizeof(buf));
+  mutt_buffer_strcpy(buf, cur_att->body->description);
 
   /* header names should not be translated */
-  if (mutt_get_field("Description: ", buf, sizeof(buf), MUTT_COMP_NO_FLAGS,
-                     false, NULL, NULL) == 0)
+  if (mutt_buffer_get_field("Description: ", buf, MUTT_COMP_NO_FLAGS, false,
+                            NULL, NULL, NULL) == 0)
   {
-    if (!mutt_str_equal(cur_att->body->description, buf))
+    if (!mutt_str_equal(cur_att->body->description, mutt_buffer_string(buf)))
     {
-      mutt_str_replace(&cur_att->body->description, buf);
+      mutt_str_replace(&cur_att->body->description, mutt_buffer_string(buf));
       menu_queue_redraw(shared->adata->menu, MENU_REDRAW_CURRENT);
       mutt_message_hook(NULL, shared->email, MUTT_SEND2_HOOK);
       rc = IR_SUCCESS;
     }
   }
 
+  mutt_buffer_pool_release(&buf);
   return rc;
 }
 

--- a/compose/functions.c
+++ b/compose/functions.c
@@ -721,15 +721,17 @@ static int op_compose_edit_encoding(struct ComposeSharedData *shared, int op)
     return IR_NO_ACTION;
 
   int rc = IR_NO_ACTION;
+  struct Buffer *buf = mutt_buffer_pool_get();
+
   struct AttachPtr *cur_att =
       current_attachment(shared->adata->actx, shared->adata->menu);
-  char buf[PATH_MAX];
-  mutt_str_copy(buf, ENCODING(cur_att->body->encoding), sizeof(buf));
-  if ((mutt_get_field("Content-Transfer-Encoding: ", buf, sizeof(buf),
-                      MUTT_COMP_NO_FLAGS, false, NULL, NULL) == 0) &&
-      (buf[0] != '\0'))
+  mutt_buffer_strcpy(buf, ENCODING(cur_att->body->encoding));
+
+  if ((mutt_buffer_get_field("Content-Transfer-Encoding: ", buf,
+                             MUTT_COMP_NO_FLAGS, false, NULL, NULL, NULL) == 0) &&
+      !mutt_buffer_is_empty(buf))
   {
-    int enc = mutt_check_encoding(buf);
+    int enc = mutt_check_encoding(mutt_buffer_string(buf));
     if ((enc != ENC_OTHER) && (enc != ENC_UUENCODED))
     {
       if (enc != cur_att->body->encoding)
@@ -749,6 +751,7 @@ static int op_compose_edit_encoding(struct ComposeSharedData *shared, int op)
     }
   }
 
+  mutt_buffer_pool_release(&buf);
   return rc;
 }
 

--- a/index/functions.c
+++ b/index/functions.c
@@ -641,18 +641,19 @@ static int op_help(struct IndexSharedData *shared, struct IndexPrivateData *priv
 static int op_jump(struct IndexSharedData *shared, struct IndexPrivateData *priv, int op)
 {
   int rc = IR_ERROR;
-  char buf[PATH_MAX] = { 0 };
+  struct Buffer *buf = mutt_buffer_pool_get();
+
   int msg_num = 0;
   if (isdigit(LastKey))
     mutt_unget_event(LastKey, 0);
-  if ((mutt_get_field(_("Jump to message: "), buf, sizeof(buf),
-                      MUTT_COMP_NO_FLAGS, false, NULL, NULL) != 0) ||
-      (buf[0] == '\0'))
+  if ((mutt_buffer_get_field(_("Jump to message: "), buf, MUTT_COMP_NO_FLAGS,
+                             false, NULL, NULL, NULL) != 0) ||
+      mutt_buffer_is_empty(buf))
   {
     mutt_message(_("Nothing to do"));
     rc = IR_NO_ACTION;
   }
-  else if (!mutt_str_atoi_full(buf, &msg_num))
+  else if (!mutt_str_atoi_full(mutt_buffer_string(buf), &msg_num))
   {
     mutt_warning(_("Argument must be a message number"));
   }
@@ -680,6 +681,7 @@ static int op_jump(struct IndexSharedData *shared, struct IndexPrivateData *priv
   if (priv->in_pager)
     rc = IR_CONTINUE;
 
+  mutt_buffer_pool_release(&buf);
   menu_queue_redraw(priv->menu, MENU_REDRAW_FULL);
   return rc;
 }

--- a/menu/menu.c
+++ b/menu/menu.c
@@ -69,13 +69,14 @@ static void menu_jump(struct Menu *menu)
   }
 
   mutt_unget_event(LastKey, 0);
-  char buf[128] = { 0 };
-  if ((mutt_get_field(_("Jump to: "), buf, sizeof(buf), MUTT_COMP_NO_FLAGS,
-                      false, NULL, NULL) == 0) &&
-      (buf[0] != '\0'))
+
+  struct Buffer *buf = mutt_buffer_pool_get();
+  if ((mutt_buffer_get_field(_("Jump to: "), buf, MUTT_COMP_NO_FLAGS, false,
+                             NULL, NULL, NULL) == 0) &&
+      !mutt_buffer_is_empty(buf))
   {
     int n = 0;
-    if (mutt_str_atoi_full(buf, &n) && (n > 0) && (n < (menu->max + 1)))
+    if (mutt_str_atoi_full(mutt_buffer_string(buf), &n) && (n > 0) && (n < (menu->max + 1)))
     {
       menu_set_index(menu, n - 1); // msg numbers are 0-based
     }
@@ -84,6 +85,8 @@ static void menu_jump(struct Menu *menu)
       mutt_error(_("Invalid index number"));
     }
   }
+
+  mutt_buffer_pool_release(&buf);
 }
 
 /**

--- a/menu/menu.c
+++ b/menu/menu.c
@@ -150,24 +150,24 @@ static int search(struct Menu *menu, int op)
   int wrap = 0;
   int search_dir;
   regex_t re = { 0 };
-  char buf[128];
+  struct Buffer *buf = mutt_buffer_pool_get();
+
   char *search_buf = ((menu->type < MENU_MAX)) ? SearchBuffers[menu->type] : NULL;
 
   if (!(search_buf && *search_buf) || ((op != OP_SEARCH_NEXT) && (op != OP_SEARCH_OPPOSITE)))
   {
-    mutt_str_copy(buf, search_buf && (search_buf[0] != '\0') ? search_buf : "",
-                  sizeof(buf));
-    if ((mutt_get_field(((op == OP_SEARCH) || (op == OP_SEARCH_NEXT)) ?
-                            _("Search for: ") :
-                            _("Reverse search for: "),
-                        buf, sizeof(buf), MUTT_COMP_CLEAR, false, NULL, NULL) != 0) ||
-        (buf[0] == '\0'))
+    mutt_buffer_strcpy(buf, search_buf && (search_buf[0] != '\0') ? search_buf : "");
+    if ((mutt_buffer_get_field(((op == OP_SEARCH) || (op == OP_SEARCH_NEXT)) ?
+                                   _("Search for: ") :
+                                   _("Reverse search for: "),
+                               buf, MUTT_COMP_CLEAR, false, NULL, NULL, NULL) != 0) ||
+        mutt_buffer_is_empty(buf))
     {
       goto done;
     }
     if (menu->type < MENU_MAX)
     {
-      mutt_str_replace(&SearchBuffers[menu->type], buf);
+      mutt_str_replace(&SearchBuffers[menu->type], mutt_buffer_string(buf));
       search_buf = SearchBuffers[menu->type];
     }
     menu->search_dir =
@@ -186,8 +186,8 @@ static int search(struct Menu *menu, int op)
 
   if (rc != 0)
   {
-    regerror(rc, &re, buf, sizeof(buf));
-    mutt_error("%s", buf);
+    regerror(rc, &re, buf->data, buf->dsize);
+    mutt_error("%s", mutt_buffer_string(buf));
     rc = -1;
     goto done;
   }
@@ -218,6 +218,7 @@ search_next:
   rc = -1;
 
 done:
+  mutt_buffer_pool_release(&buf);
   return rc;
 }
 

--- a/mutt_header.c
+++ b/mutt_header.c
@@ -127,23 +127,23 @@ int mutt_label_message(struct Mailbox *m, struct EmailList *el)
     return 0;
 
   int changed = 0;
-  char buf[1024] = { 0 };
+  struct Buffer *buf = mutt_buffer_pool_get();
 
   struct EmailNode *en = STAILQ_FIRST(el);
   if (!STAILQ_NEXT(en, entries))
   {
     // If there's only one email, use its label as a template
     if (en->email->env->x_label)
-      mutt_str_copy(buf, en->email->env->x_label, sizeof(buf));
+      mutt_buffer_strcpy(buf, en->email->env->x_label);
   }
 
-  if (mutt_get_field("Label: ", buf, sizeof(buf),
-                     MUTT_COMP_LABEL /* | MUTT_COMP_CLEAR */, false, NULL, NULL) != 0)
+  if (mutt_buffer_get_field("Label: ", buf, MUTT_COMP_LABEL /* | MUTT_COMP_CLEAR */,
+                            false, NULL, NULL, NULL) != 0)
   {
     goto done;
   }
 
-  char *new_label = buf;
+  char *new_label = buf->data;
   SKIPWS(new_label);
   if (*new_label == '\0')
     new_label = NULL;
@@ -158,6 +158,7 @@ int mutt_label_message(struct Mailbox *m, struct EmailList *el)
   }
 
 done:
+  mutt_buffer_pool_release(&buf);
   return changed;
 }
 

--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -715,7 +715,7 @@ static struct SmimeKey *smime_get_key_by_str(const char *str, KeyFlags abilities
 static struct SmimeKey *smime_ask_for_key(char *prompt, KeyFlags abilities, bool only_public_key)
 {
   struct SmimeKey *key = NULL;
-  char resp[128];
+  struct Buffer *resp = mutt_buffer_pool_get();
 
   if (!prompt)
     prompt = _("Enter keyID: ");
@@ -724,20 +724,21 @@ static struct SmimeKey *smime_ask_for_key(char *prompt, KeyFlags abilities, bool
 
   while (true)
   {
-    resp[0] = '\0';
-    if (mutt_get_field(prompt, resp, sizeof(resp), MUTT_COMP_NO_FLAGS, false, NULL, NULL) != 0)
+    mutt_buffer_reset(resp);
+    if (mutt_buffer_get_field(prompt, resp, MUTT_COMP_NO_FLAGS, false, NULL, NULL, NULL) != 0)
     {
       goto done;
     }
 
-    key = smime_get_key_by_str(resp, abilities, only_public_key);
+    key = smime_get_key_by_str(mutt_buffer_string(resp), abilities, only_public_key);
     if (key)
       goto done;
 
-    mutt_error(_("No matching keys found for \"%s\""), resp);
+    mutt_error(_("No matching keys found for \"%s\""), mutt_buffer_string(resp));
   }
 
 done:
+  mutt_buffer_pool_release(&resp);
   return key;
 }
 

--- a/pattern/pattern.c
+++ b/pattern/pattern.c
@@ -497,16 +497,17 @@ bail:
 int mutt_search_command(struct Mailbox *m, struct Menu *menu, int cur, int op)
 {
   struct Progress *progress = NULL;
+  struct Buffer *buf = NULL;
   int rc = -1;
 
   if ((*LastSearch == '\0') || ((op != OP_SEARCH_NEXT) && (op != OP_SEARCH_OPPOSITE)))
   {
-    char buf[256];
-    mutt_str_copy(buf, (LastSearch[0] != '\0') ? LastSearch : "", sizeof(buf));
-    if ((mutt_get_field(
+    buf = mutt_buffer_pool_get();
+    mutt_buffer_strcpy(buf, (LastSearch[0] != '\0') ? LastSearch : "");
+    if ((mutt_buffer_get_field(
              ((op == OP_SEARCH) || (op == OP_SEARCH_NEXT)) ? _("Search for: ") : _("Reverse search for: "),
-             buf, sizeof(buf), MUTT_COMP_CLEAR | MUTT_COMP_PATTERN, false, NULL, NULL) != 0) ||
-        (buf[0] == '\0'))
+             buf, MUTT_COMP_CLEAR | MUTT_COMP_PATTERN, false, NULL, NULL, NULL) != 0) ||
+        mutt_buffer_is_empty(buf))
     {
       goto done;
     }
@@ -519,7 +520,7 @@ int mutt_search_command(struct Mailbox *m, struct Menu *menu, int cur, int op)
     /* compare the *expanded* version of the search pattern in case
      * $simple_search has changed while we were searching */
     struct Buffer *tmp = mutt_buffer_pool_get();
-    mutt_buffer_strcpy(tmp, buf);
+    mutt_buffer_copy(tmp, buf);
     const char *const c_simple_search =
         cs_subset_string(NeoMutt->sub, "simple_search");
     mutt_check_simple(tmp, NONULL(c_simple_search));
@@ -529,7 +530,7 @@ int mutt_search_command(struct Mailbox *m, struct Menu *menu, int cur, int op)
       struct Buffer err;
       mutt_buffer_init(&err);
       OptSearchInvalid = true;
-      mutt_str_copy(LastSearch, buf, sizeof(LastSearch));
+      mutt_str_copy(LastSearch, mutt_buffer_string(buf), sizeof(LastSearch));
       mutt_str_copy(LastSearchExpn, mutt_buffer_string(tmp), sizeof(LastSearchExpn));
       mutt_message(_("Compiling search pattern..."));
       mutt_pattern_free(&SearchPattern);
@@ -639,6 +640,7 @@ int mutt_search_command(struct Mailbox *m, struct Menu *menu, int cur, int op)
   mutt_error(_("Not found"));
 done:
   progress_free(&progress);
+  mutt_buffer_pool_release(&buf);
   return rc;
 }
 

--- a/recvcmd.c
+++ b/recvcmd.c
@@ -167,8 +167,8 @@ void mutt_attach_bounce(struct Mailbox *m, FILE *fp, struct AttachCtx *actx, str
     return;
 
   struct AddressList al = TAILQ_HEAD_INITIALIZER(al);
-  char prompt[256];
-  char buf[8192];
+  struct Buffer *prompt = mutt_buffer_pool_get();
+  struct Buffer *buf = mutt_buffer_pool_get();
 
   /* RFC5322 mandates a From: header, so warn before bouncing
    * messages without one */
@@ -199,18 +199,18 @@ void mutt_attach_bounce(struct Mailbox *m, FILE *fp, struct AttachCtx *actx, str
   /* one or more messages? */
   int num_msg = cur ? 1 : count_tagged(actx);
   if (num_msg == 1)
-    mutt_str_copy(prompt, _("Bounce message to: "), sizeof(prompt));
+    mutt_buffer_strcpy(prompt, _("Bounce message to: "));
   else
-    mutt_str_copy(prompt, _("Bounce tagged messages to: "), sizeof(prompt));
+    mutt_buffer_strcpy(prompt, _("Bounce tagged messages to: "));
 
-  buf[0] = '\0';
-  if (mutt_get_field(prompt, buf, sizeof(buf), MUTT_COMP_ALIAS, false, NULL, NULL) ||
-      (buf[0] == '\0'))
+  if (mutt_buffer_get_field(mutt_buffer_string(prompt), buf, MUTT_COMP_ALIAS,
+                            false, NULL, NULL, NULL) ||
+      mutt_buffer_is_empty(buf))
   {
     goto done;
   }
 
-  mutt_addrlist_parse(&al, buf);
+  mutt_addrlist_parse(&al, mutt_buffer_string(buf));
   if (TAILQ_EMPTY(&al))
   {
     mutt_error(_("Error parsing address"));
@@ -227,26 +227,32 @@ void mutt_attach_bounce(struct Mailbox *m, FILE *fp, struct AttachCtx *actx, str
     goto done;
   }
 
-  buf[0] = '\0';
-  mutt_addrlist_write(&al, buf, sizeof(buf), true);
+  mutt_buffer_reset(buf);
+  mutt_buffer_alloc(buf, 8192);
+  mutt_addrlist_write(&al, buf->data, buf->dsize, true);
 
 #define EXTRA_SPACE (15 + 7 + 2)
   /* See commands.c.  */
-  snprintf(prompt, sizeof(prompt) - 4,
-           ngettext("Bounce message to %s?", "Bounce messages to %s?", num_msg), buf);
+  mutt_buffer_printf(prompt, ngettext("Bounce message to %s?", "Bounce messages to %s?", num_msg),
+                     mutt_buffer_string(buf));
 
   const size_t width = msgwin_get_width();
-  if (mutt_strwidth(prompt) > (width - EXTRA_SPACE))
+  if (mutt_strwidth(mutt_buffer_string(prompt)) > (width - EXTRA_SPACE))
   {
-    mutt_simple_format(prompt, sizeof(prompt) - 4, 0, width - EXTRA_SPACE,
-                       JUSTIFY_LEFT, 0, prompt, sizeof(prompt), false);
-    mutt_str_cat(prompt, sizeof(prompt), "...?");
+    struct Buffer *scratch = mutt_buffer_pool_get();
+    mutt_simple_format(scratch->data, scratch->dsize - 4, 0, width - EXTRA_SPACE,
+                       JUSTIFY_LEFT, 0, prompt->data, prompt->dsize, false);
+    mutt_buffer_addstr(scratch, "...?");
+    mutt_buffer_copy(prompt, scratch);
+    mutt_buffer_pool_release(&scratch);
   }
   else
-    mutt_str_cat(prompt, sizeof(prompt), "?");
+  {
+    mutt_buffer_addstr(prompt, "?");
+  }
 
   const enum QuadOption c_bounce = cs_subset_quad(NeoMutt->sub, "bounce");
-  if (query_quadoption(c_bounce, prompt) != MUTT_YES)
+  if (query_quadoption(c_bounce, mutt_buffer_string(prompt)) != MUTT_YES)
   {
     msgwin_clear_text();
     mutt_message(ngettext("Message not bounced", "Messages not bounced", num_msg));
@@ -282,6 +288,8 @@ void mutt_attach_bounce(struct Mailbox *m, FILE *fp, struct AttachCtx *actx, str
 
 done:
   mutt_addrlist_clear(&al);
+  mutt_buffer_pool_release(&buf);
+  mutt_buffer_pool_release(&prompt);
 }
 
 /**


### PR DESCRIPTION
This very repetitive PR refactors 36 functions to use `mutt_buffer_get_field()` rather than `mutt_get_field()`.
See "The Near Future", below.

The code to read some text from the user is too complicated.
It's a mix of functions that take `char []` or `struct Buffer`,
flags that are relevant to some functions but not others,
parameters (arrays of files) that _might_ be needed,
and originally a bunch of macro wrappers.

## The Past

The names have been abbreviated by `mutt_` for clarity.
The blue nodes are macros.

<img src="https://flatcap.org/mutt/enter/g1.svg" />

We eliminated the macros a while back, leading to:

## The Present

**Key**:
<img width="300" src="https://flatcap.org/mutt/enter/key.svg" />
The numbers in `()`s show the number of callers of each function.

<img src="https://flatcap.org/mutt/enter/g2.svg" />

Worryingly, many of the functions pass `CompletionFlags` and an Array for the results of completion.
This means that `mutt_enter_string_full()` has to know a lot about completion methods.

## The Near Future?

The first step is to standardise the string passing, in favour of `struct Buffer`.
This PR is a step to unite `mutt_get_field()` and `mutt_buffer_get_field()`.
When `struct Buffer` is used throughout, the function names can be stripped of `buffer_`.

<img width="600" src="https://flatcap.org/mutt/enter/g3.svg" />

## The Far Future?

With a bit more refactoring, it may be possible to get to this state:

<img width="400" src="https://flatcap.org/mutt/enter/g4.svg" />
