### PR TITLE
fix(notmuch): use 'nm_query_type' as default for vfolder-from-query

### DIFF
--- a/notmuch/notmuch.c
+++ b/notmuch/notmuch.c
@@ -1586,7 +1586,9 @@ char *nm_url_from_query(struct Mailbox *m, char *buf, size_t buflen)
     using_default_data = true;
   }
 
-  mdata->query_type = nm_parse_type_from_query(buf);
+  enum NmQueryType c_nm_query_type =
+      nm_string_to_query_type(cs_subset_string(NeoMutt->sub, "nm_query_type"));
+  mdata->query_type = nm_parse_type_from_query(buf, c_nm_query_type);
 
   const short c_nm_db_limit = cs_subset_number(NeoMutt->sub, "nm_db_limit");
   if (get_limit(mdata) == c_nm_db_limit)

--- a/notmuch/query.c
+++ b/notmuch/query.c
@@ -38,19 +38,20 @@
 /**
  * nm_parse_type_from_query - Parse a query type out of a query
  * @param buf   Buffer for URL
- * @retval Notmuch query type.  Default: #NM_QUERY_TYPE_MESGS
+ * @param fallback Fallback query type if buf doesn't contain a type= statement.
+ * @retval Notmuch query type.
  *
  * If a user writes a query for a vfolder and includes a type= statement, that
  * type= will be encoded, which Notmuch will treat as part of the query=
  * statement. This method will remove the type= and return its corresponding
  * NmQueryType representation.
  */
-enum NmQueryType nm_parse_type_from_query(char *buf)
+enum NmQueryType nm_parse_type_from_query(char *buf, enum NmQueryType fallback)
 {
-  if (!buf)
-    return NM_QUERY_TYPE_MESGS;
+  enum NmQueryType query_type = fallback;
 
-  enum NmQueryType query_type = NM_QUERY_TYPE_MESGS;
+  if (!buf)
+    return query_type;
 
   size_t buf_len = mutt_str_len(buf);
   const char *message_ptr = mutt_istrn_rfind(buf, buf_len, "type=messages");

--- a/notmuch/query.h
+++ b/notmuch/query.h
@@ -48,7 +48,7 @@ enum NmWindowQueryRc
   NM_WINDOW_QUERY_INVALID_DURATION  ///< Invalid duration
 };
 
-enum NmQueryType nm_parse_type_from_query(char *buf);
+enum NmQueryType nm_parse_type_from_query(char *buf, enum NmQueryType fallback);
 enum NmQueryType nm_string_to_query_type(const char *str);
 enum NmQueryType nm_string_to_query_type_mapper(const char *str);
 const char *nm_query_type_to_string(enum NmQueryType query_type);

--- a/test/notmuch/query_type.c
+++ b/test/notmuch/query_type.c
@@ -53,7 +53,8 @@ void test_nm_parse_type_from_query(void)
   };
 
   // Degenerate test
-  TEST_CHECK(nm_parse_type_from_query(NULL) == NM_QUERY_TYPE_MESGS);
+  TEST_CHECK(nm_parse_type_from_query(NULL, NM_QUERY_TYPE_MESGS) == NM_QUERY_TYPE_MESGS);
+  TEST_CHECK(nm_parse_type_from_query(NULL, NM_QUERY_TYPE_THREADS) == NM_QUERY_TYPE_THREADS);
 
   char buf[1024];
   for (int i = 0; i < mutt_array_size(tests); i++)
@@ -62,7 +63,7 @@ void test_nm_parse_type_from_query(void)
     memset(buf, 0, sizeof(buf));
     mutt_str_copy(buf, t->input, sizeof(buf));
     TEST_CASE(buf);
-    TEST_CHECK(nm_parse_type_from_query(buf) == t->expected);
+    TEST_CHECK(nm_parse_type_from_query(buf, NM_QUERY_TYPE_MESGS) == t->expected);
   }
 }
 


### PR DESCRIPTION
The implementation of `nm_parse_type_from_query()` assumes a default
value of `NM_QUERY_TYPE_MESGS` if it's unable to parse a `type=`
statement. However, defaulting to `NM_QUERY_TYPE_MESGS` is not a safe
assumption as `nm_query_type` controls the default query type. This
assumptions results in using query type `messages` for
`vfolder-from-query` with `nm_query_type=threads`. The single caller of
`nm_parse_type_from_query()` overrides `mdata->query_type` with the
returned value, resulting in the assumption replacing the default query
type.

To fix this, this commit modifies `nm_parse_type_from_query()` to take a
fallback parameter for the default value. This avoids introducing state
into `nm_parse_type_from_query()`. Its single caller passes the global
`nm_query_type` value as the fallback.

Fixes #3159

---
Before:
![image](https://user-images.githubusercontent.com/1640737/146436242-6f22cc00-e542-47e1-b63b-3b68ceea4ba7.png)

After:

![image](https://user-images.githubusercontent.com/1640737/146436226-55eebc46-9d01-4265-9205-96c2e3d71686.png)

