### PR TITLE
Optionally keep an account alive on removal of its last mailbox

### DIFF
--- a/compose/functions.c
+++ b/compose/functions.c
@@ -573,7 +573,7 @@ static int op_compose_attach_message(struct ComposeSharedData *shared, int op)
   if (!mx_mbox_open(m_attach, MUTT_READONLY))
   {
     mutt_error(_("Unable to open mailbox %s"), mutt_buffer_string(fname));
-    mx_fastclose_mailbox(m_attach);
+    mx_fastclose_mailbox(m_attach, false);
     m_attach = NULL;
     mutt_buffer_pool_release(&fname);
     return IR_ERROR;
@@ -641,7 +641,7 @@ static int op_compose_attach_message(struct ComposeSharedData *shared, int op)
   {
     m_attach->readonly = old_readonly;
   }
-  mx_fastclose_mailbox(m_attach_new);
+  mx_fastclose_mailbox(m_attach_new, false);
 
   /* Restore old $sort variables */
   cs_subset_str_native_set(shared->sub, "sort", old_sort, NULL);

--- a/imap/command.c
+++ b/imap/command.c
@@ -173,11 +173,9 @@ static void cmd_handle_fatal(struct ImapAccountData *adata)
 
   if ((adata->state >= IMAP_SELECTED) && (mdata->reopen & IMAP_REOPEN_ALLOW))
   {
-    mx_fastclose_mailbox(adata->mailbox);
-    mutt_socket_close(adata->conn);
+    mx_fastclose_mailbox(adata->mailbox, true);
     mutt_error(_("Mailbox %s@%s closed"), adata->conn->account.user,
                adata->conn->account.host);
-    adata->state = IMAP_DISCONNECTED;
   }
 
   imap_close_connection(adata);

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -1251,7 +1251,7 @@ int imap_path_status(const char *path, bool queue)
 
   if (is_temp)
   {
-    mx_ac_remove(m);
+    mx_ac_remove(m, false);
     mailbox_free(&m);
   }
 

--- a/index/functions.c
+++ b/index/functions.c
@@ -482,7 +482,7 @@ static int op_exit(struct IndexSharedData *shared, struct IndexPrivateData *priv
   {
     if (shared->ctx)
     {
-      mx_fastclose_mailbox(shared->mailbox);
+      mx_fastclose_mailbox(shared->mailbox, false);
       ctx_free(&shared->ctx);
     }
     return IR_DONE;

--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -1150,7 +1150,7 @@ static enum MxStatus mbox_mbox_check(struct Mailbox *m)
 
 error:
   mbox_unlock_mailbox(m);
-  mx_fastclose_mailbox(m);
+  mx_fastclose_mailbox(m, false);
   mutt_sig_unblock();
   mutt_error(_("Mailbox was corrupted"));
   return MX_STATUS_ERROR;
@@ -1194,7 +1194,7 @@ static enum MxStatus mbox_mbox_sync(struct Mailbox *m)
   adata->fp = freopen(mailbox_path(m), "r+", adata->fp);
   if (!adata->fp)
   {
-    mx_fastclose_mailbox(m);
+    mx_fastclose_mailbox(m, false);
     mutt_error(_("Fatal error!  Could not reopen mailbox!"));
     goto fatal;
   }
@@ -1365,7 +1365,7 @@ static enum MxStatus mbox_mbox_sync(struct Mailbox *m)
   if (!fp)
   {
     mutt_sig_unblock();
-    mx_fastclose_mailbox(m);
+    mx_fastclose_mailbox(m, false);
     mutt_debug(LL_DEBUG1, "unable to reopen temp copy of mailbox!\n");
     mutt_perror(mutt_buffer_string(tempfile));
     FREE(&new_offset);
@@ -1426,7 +1426,7 @@ static enum MxStatus mbox_mbox_sync(struct Mailbox *m)
                        NONULL(ShortHostname), (unsigned int) getpid());
     rename(mutt_buffer_string(tempfile), mutt_buffer_string(savefile));
     mutt_sig_unblock();
-    mx_fastclose_mailbox(m);
+    mx_fastclose_mailbox(m, false);
     mutt_buffer_pretty_mailbox(savefile);
     mutt_error(_("Write failed!  Saved partial mailbox to %s"), mutt_buffer_string(savefile));
     mutt_buffer_pool_release(&savefile);
@@ -1448,7 +1448,7 @@ static enum MxStatus mbox_mbox_sync(struct Mailbox *m)
   {
     unlink(mutt_buffer_string(tempfile));
     mutt_sig_unblock();
-    mx_fastclose_mailbox(m);
+    mx_fastclose_mailbox(m, false);
     mutt_error(_("Fatal error!  Could not reopen mailbox!"));
     FREE(&new_offset);
     FREE(&old_offset);
@@ -1515,7 +1515,7 @@ bail: /* Come here in case of disaster */
   if (!adata->fp)
   {
     mutt_error(_("Could not reopen mailbox"));
-    mx_fastclose_mailbox(m);
+    mx_fastclose_mailbox(m, false);
     goto fatal;
   }
 

--- a/mx.h
+++ b/mx.h
@@ -70,12 +70,12 @@ struct Mailbox *mx_mbox_find   (struct Account *a, const char *path);
 struct Mailbox *mx_mbox_find2  (const char *path);
 bool            mx_mbox_ac_link(struct Mailbox *m);
 bool            mx_ac_add      (struct Account *a, struct Mailbox *m);
-int             mx_ac_remove   (struct Mailbox *m);
+int             mx_ac_remove   (struct Mailbox *m, bool keep_account);
 
 int                 mx_access           (const char *path, int flags);
 void                mx_alloc_memory     (struct Mailbox *m);
 int                 mx_path_is_empty    (const char *path);
-void                mx_fastclose_mailbox(struct Mailbox *m);
+void                mx_fastclose_mailbox(struct Mailbox *m, bool keep_account);
 const struct MxOps *mx_get_ops          (enum MailboxType type);
 bool                mx_tags_is_supported(struct Mailbox *m);
 int                 mx_toggle_write     (struct Mailbox *m);

--- a/postpone.c
+++ b/postpone.c
@@ -159,7 +159,7 @@ int mutt_num_postponed(struct Mailbox *m, bool force)
     if (mx_mbox_open(m_post, MUTT_NOSORT | MUTT_QUIET))
     {
       PostCount = m_post->msg_count;
-      mx_fastclose_mailbox(m_post);
+      mx_fastclose_mailbox(m_post, false);
       if (m_post->flags == MB_HIDDEN)
         mailbox_free(&m_post);
     }
@@ -198,7 +198,7 @@ static void hardclose(struct Mailbox *m)
   if (rc != MX_STATUS_ERROR && rc != MX_STATUS_OK)
     rc = mx_mbox_close(m);
   if (rc != MX_STATUS_OK)
-    mx_fastclose_mailbox(m);
+    mx_fastclose_mailbox(m, false);
 }
 
 /**
@@ -672,7 +672,7 @@ int mutt_get_postponed(struct Mailbox *m_cur, struct Email *hdr,
     mutt_error(_("No postponed messages"));
     if (m_cur != m)
     {
-      mx_fastclose_mailbox(m);
+      mx_fastclose_mailbox(m, false);
       if (m->flags == MB_HIDDEN)
         mailbox_free(&m);
     }


### PR DESCRIPTION
Fixes #3152

We still won't be able to reopen the mailbox, since the mailbox is gone after `mx_fastclose_mailbox`. We'll need to look more into that part.