### PR TITLE
Fix selecting the right email after limiting

### DIFF
--- a/index/functions.c
+++ b/index/functions.c
@@ -1005,8 +1005,8 @@ static int op_main_limit(struct IndexSharedData *shared, struct IndexPrivateData
           break;
         }
       }
+      menu_set_index(priv->menu, index);
     }
-    menu_set_index(priv->menu, index);
 
     if ((shared->mailbox->msg_count != 0) && mutt_using_threads())
     {


### PR DESCRIPTION
This was producing an index with no email selected when unapplying a
limit that produced an empty email set.