### PR TITLE
Fix out of boundary write with long log lines

### DIFF
--- a/mutt/logging.c
+++ b/mutt/logging.c
@@ -411,7 +411,8 @@ int log_disp_queue(time_t stamp, const char *file, int line,
 
   if (level == LL_PERROR)
   {
-    ret += snprintf(buf + ret, sizeof(buf) - ret, ": %s", strerror(err));
+    if ((ret >= 0) && (ret < sizeof(buf)))
+      ret += snprintf(buf + ret, sizeof(buf) - ret, ": %s", strerror(err));
     level = LL_ERROR;
   }
 

--- a/mutt_logging.c
+++ b/mutt_logging.c
@@ -139,7 +139,7 @@ int log_disp_curses(time_t stamp, const char *file, int line,
   int ret = vsnprintf(buf, sizeof(buf), fmt, ap);
   va_end(ap);
 
-  if (level == LL_PERROR)
+  if ((level == LL_PERROR) && (ret >= 0) && (ret < sizeof(buf)))
   {
     char *buf2 = buf + ret;
     int len = sizeof(buf) - ret;


### PR DESCRIPTION
* **What does this PR do?**

mutt_perror calls can overflow the internal 1024 byte buffer when
errno string representation is added.

Since snprintf returns the amount of bytes it would write regardless
of the limitation of the second argument, the return value has to be
checked for such a truncation before incrementing the start position.

* **Screenshots (if relevant)**

Proof of Concept (compile with -fsanitize=address):
```
echo "set mbox_type=MH" > muttrc
python -c 'print("set postponed=\"/tmp/"+1024*"a"+"\"")' >> muttrc
neomutt -F muttrc -d 1
```
Postpone a newly created mail to see the OOB write.

* **What are the relevant issue numbers?**

No issue created.