### PR TITLE
Improve log_file_running reliability

### DIFF
--- a/mutt/logging.c
+++ b/mutt/logging.c
@@ -229,7 +229,7 @@ void log_file_set_version(const char *version)
  */
 bool log_file_running(void)
 {
-  return LogFileFP;
+  return LogFileFP != NULL;
 }
 
 /**


### PR DESCRIPTION
* **What does this PR do?**

Casting LogFileFP (FILE *) to bool truncates the pointer to one byte.
If LogFileFP is aligned properly, then log_file_running returns false
even though LogFileFP itself is not NULL.

Explicitly check for NULL to make log_file_running more reliable.

* **What are the relevant issue numbers?**

No issue created.