### PR TITLE
Improve composition of multipart messages

### DIFF
--- a/attach/recvattach.c
+++ b/attach/recvattach.c
@@ -952,6 +952,16 @@ int mutt_attach_display_loop(struct ConfigSubset *sub, struct Menu *menu, int op
       case OP_VIEW_ATTACH:
       {
         struct AttachPtr *cur_att = current_attachment(actx, menu);
+        if (!cur_att->fp)
+        {
+          if (cur_att->body->type == TYPE_MULTIPART)
+          {
+            struct Body *b = cur_att->body->parts;
+            while (b->parts)
+              b = b->parts;
+            cur_att = b->aptr;
+          }
+        }
         op = mutt_view_attachment(cur_att->fp, cur_att->body, MUTT_VA_REGULAR,
                                   e, actx, menu->win);
         break;

--- a/compose/compose.c
+++ b/compose/compose.c
@@ -285,21 +285,16 @@ static void gen_attach_list(struct AttachCtx *actx, struct Body *m, int parent_t
 {
   for (; m; m = m->next)
   {
+    struct AttachPtr *ap = mutt_mem_calloc(1, sizeof(struct AttachPtr));
+    mutt_actx_add_attach(actx, ap);
+    ap->body = m;
+    m->aptr = ap;
+    ap->parent_type = parent_type;
+    ap->level = level;
     if ((m->type == TYPE_MULTIPART) && m->parts &&
         (!(WithCrypto & APPLICATION_PGP) || !mutt_is_multipart_encrypted(m)))
     {
-      gen_attach_list(actx, m->parts, m->type, level);
-    }
-    else
-    {
-      struct AttachPtr *ap = mutt_mem_calloc(1, sizeof(struct AttachPtr));
-      mutt_actx_add_attach(actx, ap);
-      ap->body = m;
-      m->aptr = ap;
-      ap->parent_type = parent_type;
-      ap->level = level;
-
-      /* We don't support multipart messages in the compose menu yet */
+      gen_attach_list(actx, m->parts, m->type, level + 1);
     }
   }
 }

--- a/compose/functions.c
+++ b/compose/functions.c
@@ -935,8 +935,18 @@ static int op_compose_edit_headers(struct ComposeSharedData *shared, int op)
   char *err = NULL;
   mutt_env_to_local(shared->email->env);
   const char *const c_editor = cs_subset_string(shared->sub, "editor");
-  mutt_edit_headers(NONULL(c_editor), shared->email->body->filename,
-                    shared->email, shared->fcc);
+  if (shared->email->body->type == TYPE_MULTIPART)
+  {
+    struct Body *b = shared->email->body->parts;
+    while (b->parts)
+      b = b->parts;
+    mutt_edit_headers(NONULL(c_editor), b->filename, shared->email, shared->fcc);
+  }
+  else
+  {
+    mutt_edit_headers(NONULL(c_editor), shared->email->body->filename,
+                      shared->email, shared->fcc);
+  }
   if (mutt_env_to_intl(shared->email->env, &tag, &err))
   {
     mutt_error(_("Bad IDN in '%s': '%s'"), tag, err);

--- a/compose/functions.c
+++ b/compose/functions.c
@@ -442,6 +442,9 @@ static int group_attachments(struct ComposeSharedData *shared,
         }
       }
 
+      if (i > 0)
+        shared->adata->actx->idx[i - 1]->body->next = bptr->next;
+
       // append bptr to the alts list, and remove from the shared->email->body list
       if (alts)
       {
@@ -482,6 +485,11 @@ static int group_attachments(struct ComposeSharedData *shared,
   struct AttachPtr *gptr = mutt_mem_calloc(1, sizeof(struct AttachPtr));
   gptr->body = group;
   update_idx(shared->adata->menu, shared->adata->actx, gptr);
+
+  // update email body and last attachment pointers
+  shared->email->body = shared->adata->actx->idx[0]->body;
+  shared->adata->actx->idx[shared->adata->actx->idxlen - 1]->body->next = NULL;
+
   menu_queue_redraw(shared->adata->menu, MENU_REDRAW_INDEX);
   return IR_SUCCESS;
 }

--- a/compose/functions.c
+++ b/compose/functions.c
@@ -1323,11 +1323,6 @@ static int op_compose_move_down(struct ComposeSharedData *shared, int op)
     mutt_error(_("Attachment is already at bottom"));
     return IR_NO_ACTION;
   }
-  if (index == 0)
-  {
-    mutt_error(_("The fundamental part can't be moved"));
-    return IR_ERROR;
-  }
   compose_attach_swap(shared->email, shared->adata->actx, index, index + 1);
   menu_queue_redraw(shared->adata->menu, MENU_REDRAW_INDEX);
   menu_set_index(shared->adata->menu, index + 1);
@@ -1347,11 +1342,6 @@ static int op_compose_move_up(struct ComposeSharedData *shared, int op)
   {
     mutt_error(_("Attachment is already at top"));
     return IR_NO_ACTION;
-  }
-  if (index == 1)
-  {
-    mutt_error(_("The fundamental part can't be moved"));
-    return IR_ERROR;
   }
   compose_attach_swap(shared->email, shared->adata->actx, index - 1, index);
   menu_queue_redraw(shared->adata->menu, MENU_REDRAW_INDEX);

--- a/compose/functions.c
+++ b/compose/functions.c
@@ -504,6 +504,8 @@ static int group_attachments(struct ComposeSharedData *shared,
   shared->adata->actx->idx[shared->adata->actx->idxlen - 1]->body->next = NULL;
 
   menu_queue_redraw(shared->adata->menu, MENU_REDRAW_INDEX);
+
+  mutt_message_hook(NULL, shared->email, MUTT_SEND2_HOOK);
   return IR_SUCCESS;
 }
 

--- a/compose/functions.c
+++ b/compose/functions.c
@@ -106,6 +106,52 @@ static bool check_count(struct AttachCtx *actx)
   return true;
 }
 
+/**
+ * find_body_parent - Find the parent of a body
+ * @param[in]  start        Body to start search from
+ * @param[in]  start_parent Parent of start Body pointer (or NULL if none)
+ * @param[in]  body         Body to find parent of
+ * @param[out] body_parent  Body Parent if found
+ * @retval     true         Parent body found
+ * @retval     false        Parent body not found
+ */
+static bool find_body_parent(struct Body *start, struct Body *start_parent,
+                             struct Body *body, struct Body **body_parent)
+{
+  if (!start || !body)
+    return false;
+
+  struct Body *b = start;
+
+  if (b->parts)
+  {
+    if (b->parts == body)
+    {
+      *body_parent = b;
+      return true;
+    }
+  }
+  while (b)
+  {
+    if (b == body)
+    {
+      *body_parent = start_parent;
+      if (start_parent)
+        return true;
+      else
+        return false;
+    }
+    if (b->parts)
+    {
+      if (find_body_parent(b->parts, b, body, body_parent))
+        return true;
+    }
+    b = b->next;
+  }
+
+  return false;
+}
+
 #ifdef USE_AUTOCRYPT
 /**
  * autocrypt_compose_menu - Autocrypt compose settings

--- a/compose/functions.c
+++ b/compose/functions.c
@@ -152,6 +152,39 @@ static bool find_body_parent(struct Body *start, struct Body *start_parent,
   return false;
 }
 
+/**
+ * find_body_previous - Find the previous body of a body
+ * @param[in]  start        Body to start search from
+ * @param[in]  body         Body to find previous body of
+ * @param[out] previous     Previous Body if found
+ * @retval     true         Previous body found
+ * @retval     false        Previous body not found
+ */
+static bool find_body_previous(struct Body *start, struct Body *body, struct Body **previous)
+{
+  if (!start || !body)
+    return false;
+
+  struct Body *b = start;
+
+  while (b)
+  {
+    if (b->next == body)
+    {
+      *previous = b;
+      return true;
+    }
+    if (b->parts)
+    {
+      if (find_body_previous(b->parts, body, previous))
+        return true;
+    }
+    b = b->next;
+  }
+
+  return false;
+}
+
 #ifdef USE_AUTOCRYPT
 /**
  * autocrypt_compose_menu - Autocrypt compose settings

--- a/compose/functions.c
+++ b/compose/functions.c
@@ -486,9 +486,16 @@ static int delete_attachment(struct AttachCtx *actx, int aidx)
  */
 static void update_idx(struct Menu *menu, struct AttachCtx *actx, struct AttachPtr *ap)
 {
-  ap->level = (actx->idxlen > 0) ? actx->idx[actx->idxlen - 1]->level : 0;
-  if (actx->idxlen)
-    actx->idx[actx->idxlen - 1]->body->next = ap->body;
+  ap->level = 0;
+  for (int i = actx->idxlen; i > 0; i--)
+  {
+    if (ap->level == actx->idx[i - 1]->level)
+    {
+      actx->idx[i - 1]->body->next = ap->body;
+      break;
+    }
+  }
+
   ap->body->aptr = ap;
   mutt_actx_add_attach(actx, ap);
   update_menu(actx, menu, false);

--- a/compose/functions.c
+++ b/compose/functions.c
@@ -901,6 +901,11 @@ static int op_compose_edit_file(struct ComposeSharedData *shared, int op)
     return IR_NO_ACTION;
   struct AttachPtr *cur_att =
       current_attachment(shared->adata->actx, shared->adata->menu);
+  if (cur_att->body->type == TYPE_MULTIPART)
+  {
+    mutt_error(_("Can't edit multipart attachments"));
+    return IR_ERROR;
+  }
   const char *const c_editor = cs_subset_string(shared->sub, "editor");
   mutt_edit_file(NONULL(c_editor), cur_att->body->filename);
   mutt_update_encoding(cur_att->body, shared->sub);
@@ -1114,6 +1119,11 @@ static int op_compose_get_attachment(struct ComposeSharedData *shared, int op)
     return IR_NO_ACTION;
   struct AttachPtr *cur_att =
       current_attachment(shared->adata->actx, shared->adata->menu);
+  if (cur_att->body->type == TYPE_MULTIPART)
+  {
+    mutt_error(_("Can't get multipart attachments"));
+    return IR_ERROR;
+  }
   if (shared->adata->menu->tagprefix)
   {
     for (struct Body *top = shared->email->body; top; top = top->next)
@@ -1421,6 +1431,11 @@ static int op_compose_rename_file(struct ComposeSharedData *shared, int op)
     return IR_NO_ACTION;
   struct AttachPtr *cur_att =
       current_attachment(shared->adata->actx, shared->adata->menu);
+  if (cur_att->body->type == TYPE_MULTIPART)
+  {
+    mutt_error(_("Can't rename multipart attachments"));
+    return IR_ERROR;
+  }
   struct Buffer *fname = mutt_buffer_pool_get();
   mutt_buffer_strcpy(fname, cur_att->body->filename);
   mutt_buffer_pretty_mailbox(fname);
@@ -1761,6 +1776,11 @@ static int op_filter(struct ComposeSharedData *shared, int op)
     return IR_NO_ACTION;
   struct AttachPtr *cur_att =
       current_attachment(shared->adata->actx, shared->adata->menu);
+  if (cur_att->body->type == TYPE_MULTIPART)
+  {
+    mutt_error(_("Can't filter multipart attachments"));
+    return IR_ERROR;
+  }
   mutt_pipe_attachment_list(shared->adata->actx, NULL, shared->adata->menu->tagprefix,
                             cur_att->body, (op == OP_FILTER));
   if (op == OP_FILTER) /* cte might have changed */
@@ -1789,6 +1809,11 @@ static int op_print(struct ComposeSharedData *shared, int op)
     return IR_NO_ACTION;
   struct AttachPtr *cur_att =
       current_attachment(shared->adata->actx, shared->adata->menu);
+  if (cur_att->body->type == TYPE_MULTIPART)
+  {
+    mutt_error(_("Can't print multipart attachments"));
+    return IR_ERROR;
+  }
   mutt_print_attachment_list(shared->adata->actx, NULL,
                              shared->adata->menu->tagprefix, cur_att->body);
   /* no send2hook, since this doesn't modify the message */
@@ -1804,6 +1829,11 @@ static int op_save(struct ComposeSharedData *shared, int op)
     return IR_NO_ACTION;
   struct AttachPtr *cur_att =
       current_attachment(shared->adata->actx, shared->adata->menu);
+  if (cur_att->body->type == TYPE_MULTIPART)
+  {
+    mutt_error(_("Can't save multipart attachments"));
+    return IR_ERROR;
+  }
   mutt_save_attachment_list(shared->adata->actx, NULL, shared->adata->menu->tagprefix,
                             cur_att->body, NULL, shared->adata->menu);
   /* no send2hook, since this doesn't modify the message */

--- a/compose/functions.c
+++ b/compose/functions.c
@@ -431,7 +431,6 @@ static int group_attachments(struct ComposeSharedData *shared,
     {
       shared->adata->menu->tagged--;
       bptr->tagged = false;
-      bptr->disposition = DISP_INLINE;
 
       /* for first match, set group desc according to match */
       if (!group->description)

--- a/compose/functions.c
+++ b/compose/functions.c
@@ -420,6 +420,7 @@ static int group_attachments(struct ComposeSharedData *shared,
   group->type = TYPE_MULTIPART;
   group->subtype = mutt_str_dup(subtype);
   group->disposition = DISP_INLINE;
+  group->encoding = ENC_7BIT;
 
   struct Body *alts = NULL;
   /* group tagged message into a multipart group */

--- a/compose/functions.c
+++ b/compose/functions.c
@@ -428,6 +428,7 @@ static int group_attachments(struct ComposeSharedData *shared,
   {
     if (bptr->tagged)
     {
+      shared->adata->menu->tagged--;
       bptr->tagged = false;
       bptr->disposition = DISP_INLINE;
 

--- a/compose/functions.c
+++ b/compose/functions.c
@@ -107,6 +107,33 @@ static bool check_count(struct AttachCtx *actx)
 }
 
 /**
+ * count_attachments - Count attachments
+ * @param  body    Body to start counting from
+ * @param  recurse Whether to recurse into groups or not
+ * @retval num     Number of attachments
+ * @retval -1      Failure
+ * */
+static int count_attachments(struct Body *body, bool recurse)
+{
+  if (!body)
+    return -1;
+
+  int attachments = 0;
+
+  for (struct Body *b = body; b; b = b->next)
+  {
+    attachments++;
+    if (recurse)
+    {
+      if (b->parts)
+        attachments += count_attachments(b->parts, true);
+    }
+  }
+
+  return attachments;
+}
+
+/**
  * find_body_parent - Find the parent of a body
  * @param[in]  start        Body to start search from
  * @param[in]  start_parent Parent of start Body pointer (or NULL if none)

--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -11376,10 +11376,12 @@ alternative_order text/enriched text/plain text application/postscript image/*
           <listitem>
             <para>
               Tag the attachments that are alternatives, and press the
-              <command>&lt;group-alternatives&gt;</command> (&amp;) binding to group
-              them together. After this, the separate parts will be replaced by a single
-              new part with the <literal>multipart/alternative</literal> type and the
-              alternatives must be manipulated or deleted as a group.
+              <literal>&lt;group-alternatives&gt;</literal> (&amp;) binding to group
+              them together. After this, the separate parts will be displayed in a tree
+              structure. Attachments can still be edited separately and reordered within
+              the group, but must be ungrouped using the <literal>&lt;ungroup-attachment&gt;</literal>
+              (#) binding for more advanced editing before tagging and grouping together again
+              as described above.
             </para>
           </listitem>
           <listitem>
@@ -11394,15 +11396,6 @@ alternative_order text/enriched text/plain text application/postscript image/*
           as a <literal>multipart/alternative</literal> email, otherwise it will be sent
           as a <literal>multipart/mixed</literal> email.
         </para>
-        <para>
-          Note that after grouping, you can't view, edit or break the
-          <literal>multipart/alternative</literal> bundle, because it is in a temporary
-          form. But you can view and edit its primitive part using the
-          <command>&lt;edit&gt;</command> command. When postponing emails or on error
-          (e.g., no recipients address when sending emails) this
-          <literal>multipart/alternative</literal> will be broken apart and need to
-          be tagged and group together again as described above.
-        </para>
 
         <para>
           Be aware that when sending a <literal>multipart/alternative</literal> email,
@@ -11411,12 +11404,17 @@ alternative_order text/enriched text/plain text application/postscript image/*
           you can compose a plain text email as usual and turn that into a
           <literal>multipart/alternative</literal> email in one single command, with
           one part being <literal>text/plain</literal> and the other
-          <literal>text/html</literal>. An example macro will be the following:
+          <literal>text/html</literal>. An example macro which adds an HTML
+          part to the main body of an email and sends it could be the following:
 
 <screen>
-macro compose K "| pandoc -o /tmp/neomutt-alternative.html&lt;enter&gt; \
+  macro compose Y "&lt;first-entry&gt;&lt;enter-command&gt;set wait_key=no&lt;enter&gt; \
+    | pandoc -o /tmp/neomutt-alternative.html&lt;enter&gt; \
     &lt;attach-file&gt;/tmp/neomutt-alternative.html&lt;enter&gt; \
-    &lt;tag-entry&gt;&lt;previous-entry&gt;&lt;tag-entry&gt;&lt;group-alternatives&gt;"
+    &lt;toggle-unlink&gt;&lt;toggle-disposition&gt; \
+    &lt;tag-entry&gt;&lt;first-entry&gt;&lt;tag-entry&gt;&lt;group-alternatives&gt; \
+    &lt;enter-command&gt;set wait_key=yes&lt;enter&gt;&lt;send-message&gt;" \
+    "send the message as 'multipart/alternative'"
 </screen>
         </para>
       </sect2>
@@ -11478,14 +11476,14 @@ set preferred_languages="fr,en,de"
 
           <listitem>
             <para>
-              Tag them with <command>&lt;tag-entry&gt;</command>
+              Tag them with <literal>&lt;tag-entry&gt;</literal>
             </para>
           </listitem>
 
           <listitem>
             <para>
               Edit the <literal>Content-Language</literal> header of every attachment with command
-              <command>&lt;edit-language&gt;</command> (default to <literal>Ctrl-L</literal>). This
+              <literal>&lt;edit-language&gt;</literal> (default to <literal>Ctrl-L</literal>). This
               is important, otherwise the recipient of this email will not know the corresponding
               languages. You can set arbitrary string as <literal>Content-Language</literal>, but it
               is recommended to set it as some common prefixes such as "en", "zh" and "fr".
@@ -11493,7 +11491,7 @@ set preferred_languages="fr,en,de"
           </listitem>
           <listitem>
             <para>
-              Group all the tag messages together by <command>&lt;group-multilingual&gt;</command>
+              Group all the tag messages together by <literal>&lt;group-multilingual&gt;</literal>
               (default to <literal>^</literal>).
             </para>
           </listitem>
@@ -11511,12 +11509,11 @@ set preferred_languages="fr,en,de"
         </para>
 
         <para>
-          Note that after grouping, you can't view, edit or break the
-          <literal>multipart/multilingual</literal> email bundle, because it is in a temporary form.
-          But you can view and edit its primitive part using the <command>&lt;edit&gt;</command>
-          command. When postponing emails or on error (e.g., no recipients address when sending
-          emails) this <literal>multipart/multilingual</literal> will be broken apart and need to
-          be tagged and group together again as described above.
+          After grouping the separate parts will be displayed in a tree
+          structure. Attachments can still be edited separately and reordered within
+          the group, but must be ungrouped using the <literal>&lt;ungroup-attachment&gt;</literal>
+          (#) binding for more advanced editing before tagging and grouping together again
+          as described above.
         </para>
       </sect2>
     </sect1>

--- a/email/attach.c
+++ b/email/attach.c
@@ -58,6 +58,37 @@ void mutt_actx_add_attach(struct AttachCtx *actx, struct AttachPtr *attach)
 }
 
 /**
+ * mutt_actx_ins_attach - Insert an Attachment into an Attachment Context at Specified Index
+ * @param actx   Attachment context
+ * @param attach Attachment to insert
+ * @param aidx   Index to insert attachment at
+ */
+void mutt_actx_ins_attach(struct AttachCtx *actx, struct AttachPtr *attach, int aidx)
+{
+  if (!actx || !attach)
+    return;
+
+  if ((aidx < 0) || (aidx > actx->idxmax))
+    return;
+
+  if (actx->idxlen == actx->idxmax)
+  {
+    actx->idxmax += 5;
+    mutt_mem_realloc(&actx->idx, sizeof(struct AttachPtr *) * actx->idxmax);
+    mutt_mem_realloc(&actx->v2r, sizeof(short) * actx->idxmax);
+    for (int i = actx->idxlen; i < actx->idxmax; i++)
+      actx->idx[i] = NULL;
+  }
+
+  actx->idxlen++;
+
+  for (int i = actx->idxlen - 1; i > aidx; i--)
+    actx->idx[i] = actx->idx[i - 1];
+
+  actx->idx[aidx] = attach;
+}
+
+/**
  * mutt_actx_add_fp - Save a File handle to the Attachment Context
  * @param actx   Attachment context
  * @param fp_new File handle to save

--- a/email/attach.h
+++ b/email/attach.h
@@ -68,6 +68,7 @@ struct AttachCtx
 };
 
 void              mutt_actx_add_attach  (struct AttachCtx *actx, struct AttachPtr *attach);
+void              mutt_actx_ins_attach  (struct AttachCtx *actx, struct AttachPtr *attach, int aidx);
 void              mutt_actx_add_body    (struct AttachCtx *actx, struct Body *new_body);
 void              mutt_actx_add_fp      (struct AttachCtx *actx, FILE *fp_new);
 void              mutt_actx_free        (struct AttachCtx **ptr);

--- a/functions.c
+++ b/functions.c
@@ -502,6 +502,7 @@ const struct Binding OpCompose[] = { /* map: compose */
   { "get-attachment",        OP_COMPOSE_GET_ATTACHMENT,      "G" },
   { "group-alternatives",    OP_COMPOSE_GROUP_ALTS,          "&" },
   { "group-multilingual",    OP_COMPOSE_GROUP_LINGUAL,       "^" },
+  { "ungroup-attachment",    OP_COMPOSE_UNGROUP_ATTACHMENT,  "#" },
   { "ispell",                OP_COMPOSE_ISPELL,              "i" },
 #ifdef MIXMASTER
   { "mix",                   OP_COMPOSE_MIX,                 "M" },

--- a/opcodes.h
+++ b/opcodes.h
@@ -80,6 +80,7 @@
   _fmt(OP_COMPOSE_GET_ATTACHMENT,         N_("get a temporary copy of an attachment")) \
   _fmt(OP_COMPOSE_GROUP_ALTS,             N_("group tagged attachments as 'multipart/alternative'")) \
   _fmt(OP_COMPOSE_GROUP_LINGUAL,          N_("group tagged attachments as 'multipart/multilingual'")) \
+  _fmt(OP_COMPOSE_UNGROUP_ATTACHMENT,     N_("ungroup 'multipart' attachment")) \
   _fmt(OP_COMPOSE_ISPELL,                 N_("run ispell on the message")) \
   _fmt(OP_COMPOSE_MOVE_DOWN,              N_("move an attachment down in the attachment list")) \
   _fmt(OP_COMPOSE_MOVE_UP,                N_("move an attachment up in the attachment list")) \

--- a/postpone.c
+++ b/postpone.c
@@ -353,6 +353,144 @@ SecurityFlags mutt_parse_crypt_hdr(const char *p, bool set_empty_signas, Securit
 }
 
 /**
+ * create_tmp_files_for_attachments - Create temporary files for all attachments
+ * @param fp_body           file containing the template
+ * @param file              Allocated buffer for temporary file name
+ * @param e_new             The new email template header
+ * @param body              First body in email or group
+ * @param protected_headers MIME headers for email template
+ * @retval  0 Success
+ * @retval -1 Error
+ */
+static int create_tmp_files_for_attachments(FILE *fp_body, struct Buffer *file,
+                                            struct Email *e_new, struct Body *body,
+                                            struct Envelope *protected_headers)
+{
+  struct Body *b = NULL;
+  struct State s = { 0 };
+  SecurityFlags sec_type;
+
+  s.fp_in = fp_body;
+
+  for (b = body; b; b = b->next)
+  {
+    if (b->type == TYPE_MULTIPART)
+    {
+      if (create_tmp_files_for_attachments(fp_body, file, e_new, b->parts, protected_headers) < 0)
+      {
+        return -1;
+      }
+    }
+    else
+    {
+      mutt_buffer_reset(file);
+      if (b->filename)
+      {
+        mutt_buffer_strcpy(file, b->filename);
+        b->d_filename = mutt_str_dup(b->filename);
+      }
+      else
+      {
+        /* avoid Content-Disposition: header with temporary filename */
+        b->use_disp = false;
+      }
+
+      /* set up state flags */
+
+      s.flags = 0;
+
+      if (b->type == TYPE_TEXT)
+      {
+        if (mutt_istr_equal("yes",
+                            mutt_param_get(&b->parameter, "x-mutt-noconv")))
+        {
+          b->noconv = true;
+        }
+        else
+        {
+          s.flags |= MUTT_CHARCONV;
+          b->noconv = false;
+        }
+
+        mutt_param_delete(&b->parameter, "x-mutt-noconv");
+      }
+
+      mutt_adv_mktemp(file);
+      s.fp_out = mutt_file_fopen(mutt_buffer_string(file), "w");
+      if (!s.fp_out)
+        return -1;
+
+      if (((WithCrypto & APPLICATION_PGP) != 0) &&
+          ((sec_type = mutt_is_application_pgp(b)) & (SEC_ENCRYPT | SEC_SIGN)))
+      {
+        if (sec_type & SEC_ENCRYPT)
+        {
+          if (!crypt_valid_passphrase(APPLICATION_PGP))
+            return -1;
+          mutt_message(_("Decrypting message..."));
+        }
+
+        if (mutt_body_handler(b, &s) < 0)
+        {
+          mutt_error(_("Decryption failed"));
+          return -1;
+        }
+
+        if ((b == body) && !protected_headers)
+        {
+          protected_headers = b->mime_headers;
+          b->mime_headers = NULL;
+        }
+
+        e_new->security |= sec_type;
+        b->type = TYPE_TEXT;
+        mutt_str_replace(&b->subtype, "plain");
+        mutt_param_delete(&b->parameter, "x-action");
+      }
+      else if (((WithCrypto & APPLICATION_SMIME) != 0) &&
+               ((sec_type = mutt_is_application_smime(b)) & (SEC_ENCRYPT | SEC_SIGN)))
+      {
+        if (sec_type & SEC_ENCRYPT)
+        {
+          if (!crypt_valid_passphrase(APPLICATION_SMIME))
+            return -1;
+          crypt_smime_getkeys(e_new->env);
+          mutt_message(_("Decrypting message..."));
+        }
+
+        if (mutt_body_handler(b, &s) < 0)
+        {
+          mutt_error(_("Decryption failed"));
+          return -1;
+        }
+
+        e_new->security |= sec_type;
+        b->type = TYPE_TEXT;
+        mutt_str_replace(&b->subtype, "plain");
+      }
+      else
+      {
+        mutt_decode_attachment(b, &s);
+      }
+
+      if (mutt_file_fclose(&s.fp_out) != 0)
+        return -1;
+
+      mutt_str_replace(&b->filename, mutt_buffer_string(file));
+      b->unlink = true;
+
+      mutt_stamp_attachment(b);
+
+      mutt_body_free(&b->parts);
+      if (b->email)
+        b->email->body = NULL; /* avoid dangling pointer */
+    }
+  }
+
+  return 0;
+}
+
+/**
  * mutt_prepare_template - Prepare a message template
  * @param fp      If not NULL, file containing the template
  * @param m       If fp is NULL, the Mailbox containing the header with the template
@@ -371,7 +509,6 @@ int mutt_prepare_template(FILE *fp, struct Mailbox *m, struct Email *e_new,
   struct Body *b = NULL;
   FILE *fp_body = NULL;
   int rc = -1;
-  struct State s = { 0 };
   SecurityFlags sec_type;
   struct Envelope *protected_headers = NULL;
   struct Buffer *file = NULL;
@@ -459,143 +596,16 @@ int mutt_prepare_template(FILE *fp, struct Mailbox *m, struct Email *e_new,
     }
   }
 
-  /* We don't need no primary multipart.
-   * Note: We _do_ preserve messages!
-   *
-   * XXX - we don't handle multipart/alternative in any
-   * smart way when sending messages.  However, one may
-   * consider this a feature.  */
-  if (e_new->body->type == TYPE_MULTIPART)
+  /* We don't need no primary multipart/mixed. */
+  if ((e_new->body->type == TYPE_MULTIPART) && mutt_istr_equal(e_new->body->subtype, "mixed"))
     e_new->body = mutt_remove_multipart(e_new->body);
-
-  s.fp_in = fp_body;
 
   file = mutt_buffer_pool_get();
 
-  struct Body *b_previous = NULL;
-
   /* create temporary files for all attachments */
-  for (b = e_new->body; b; b = b->next)
+  if (create_tmp_files_for_attachments(fp_body, file, e_new, e_new->body, protected_headers) < 0)
   {
-    /* what follows is roughly a receive-mode variant of
-     * mutt_get_tmp_attachment () from muttlib.c */
-
-    while (b->type == TYPE_MULTIPART)
-    {
-      struct Body *b_next = b->next;
-      b->next = NULL;
-      b = mutt_remove_multipart(b);
-      if (!b_previous)
-        e_new->body = b;
-      else
-        b_previous->next = b;
-      struct Body *b_part = b;
-      while (b_part->next)
-        b_part = b_part->next;
-      b_part->next = b_next;
-    }
-
-    b_previous = b;
-
-    mutt_buffer_reset(file);
-    if (b->filename)
-    {
-      mutt_buffer_strcpy(file, b->filename);
-      b->d_filename = mutt_str_dup(b->filename);
-    }
-    else
-    {
-      /* avoid Content-Disposition: header with temporary filename */
-      b->use_disp = false;
-    }
-
-    /* set up state flags */
-
-    s.flags = 0;
-
-    if (b->type == TYPE_TEXT)
-    {
-      if (mutt_istr_equal("yes",
-                          mutt_param_get(&b->parameter, "x-mutt-noconv")))
-      {
-        b->noconv = true;
-      }
-      else
-      {
-        s.flags |= MUTT_CHARCONV;
-        b->noconv = false;
-      }
-
-      mutt_param_delete(&b->parameter, "x-mutt-noconv");
-    }
-
-    mutt_adv_mktemp(file);
-    s.fp_out = mutt_file_fopen(mutt_buffer_string(file), "w");
-    if (!s.fp_out)
-      goto bail;
-
-    if (((WithCrypto & APPLICATION_PGP) != 0) &&
-        ((sec_type = mutt_is_application_pgp(b)) & (SEC_ENCRYPT | SEC_SIGN)))
-    {
-      if (sec_type & SEC_ENCRYPT)
-      {
-        if (!crypt_valid_passphrase(APPLICATION_PGP))
-          goto bail;
-        mutt_message(_("Decrypting message..."));
-      }
-
-      if (mutt_body_handler(b, &s) < 0)
-      {
-        mutt_error(_("Decryption failed"));
-        goto bail;
-      }
-
-      if ((b == e_new->body) && !protected_headers)
-      {
-        protected_headers = b->mime_headers;
-        b->mime_headers = NULL;
-      }
-
-      e_new->security |= sec_type;
-      b->type = TYPE_TEXT;
-      mutt_str_replace(&b->subtype, "plain");
-      mutt_param_delete(&b->parameter, "x-action");
-    }
-    else if (((WithCrypto & APPLICATION_SMIME) != 0) &&
-             ((sec_type = mutt_is_application_smime(b)) & (SEC_ENCRYPT | SEC_SIGN)))
-    {
-      if (sec_type & SEC_ENCRYPT)
-      {
-        if (!crypt_valid_passphrase(APPLICATION_SMIME))
-          goto bail;
-        crypt_smime_getkeys(e_new->env);
-        mutt_message(_("Decrypting message..."));
-      }
-
-      if (mutt_body_handler(b, &s) < 0)
-      {
-        mutt_error(_("Decryption failed"));
-        goto bail;
-      }
-
-      e_new->security |= sec_type;
-      b->type = TYPE_TEXT;
-      mutt_str_replace(&b->subtype, "plain");
-    }
-    else
-      mutt_decode_attachment(b, &s);
-
-    if (mutt_file_fclose(&s.fp_out) != 0)
-      goto bail;
-
-    mutt_str_replace(&b->filename, mutt_buffer_string(file));
-    b->unlink = true;
-
-    mutt_stamp_attachment(b);
-
-    mutt_body_free(&b->parts);
-    if (b->email)
-      b->email->body = NULL; /* avoid dangling pointer */
+    goto bail;
   }
 
   const bool c_crypt_protected_headers_read =

--- a/send/send.c
+++ b/send/send.c
@@ -2004,7 +2004,8 @@ static int postpone_message(struct Email *e_post, struct Email *e_cur,
     {
       if (mutt_autocrypt_set_sign_as_default_key(e_post))
       {
-        e_post->body = mutt_remove_multipart(e_post->body);
+        if (mutt_istr_equal(e_post->body->subtype, "mixed"))
+          e_post->body = mutt_remove_multipart(e_post->body);
         decode_descriptions(e_post->body);
         mutt_error(_("Error encrypting message. Check your crypt settings."));
         return -1;
@@ -2020,7 +2021,8 @@ static int postpone_message(struct Email *e_post, struct Email *e_cur,
       if (mutt_protect(e_post, pgpkeylist, true) == -1)
       {
         FREE(&pgpkeylist);
-        e_post->body = mutt_remove_multipart(e_post->body);
+        if (mutt_istr_equal(e_post->body->subtype, "mixed"))
+          e_post->body = mutt_remove_multipart(e_post->body);
         decode_descriptions(e_post->body);
         mutt_error(_("Error encrypting message. Check your crypt settings."));
         return -1;
@@ -2051,7 +2053,8 @@ static int postpone_message(struct Email *e_post, struct Email *e_cur,
     }
     mutt_env_free(&e_post->body->mime_headers); /* protected headers */
     mutt_param_delete(&e_post->body->parameter, "protected-headers");
-    e_post->body = mutt_remove_multipart(e_post->body);
+    if (mutt_istr_equal(e_post->body->subtype, "mixed"))
+      e_post->body = mutt_remove_multipart(e_post->body);
     decode_descriptions(e_post->body);
     mutt_unprepare_envelope(e_post->env);
     return -1;
@@ -2845,7 +2848,8 @@ int mutt_send_message(SendFlags flags, struct Email *e_templ, const char *tempfi
       if ((crypt_get_keys(e_templ, &pgpkeylist, 0) == -1) ||
           (mutt_protect(e_templ, pgpkeylist, false) == -1))
       {
-        e_templ->body = mutt_remove_multipart(e_templ->body);
+        if (mutt_istr_equal(e_templ->body->subtype, "mixed"))
+          e_templ->body = mutt_remove_multipart(e_templ->body);
 
         FREE(&pgpkeylist);
 
@@ -2896,13 +2900,15 @@ int mutt_send_message(SendFlags flags, struct Email *e_templ, const char *tempfi
       else if ((e_templ->security & SEC_SIGN) && (e_templ->body->type == TYPE_MULTIPART))
       {
         mutt_body_free(&e_templ->body->parts->next); /* destroy sig */
-        e_templ->body = mutt_remove_multipart(e_templ->body);
+        if (mutt_istr_equal(e_templ->body->subtype, "mixed"))
+          e_templ->body = mutt_remove_multipart(e_templ->body);
       }
 
       FREE(&pgpkeylist);
       mutt_env_free(&e_templ->body->mime_headers); /* protected headers */
       mutt_param_delete(&e_templ->body->parameter, "protected-headers");
-      e_templ->body = mutt_remove_multipart(e_templ->body);
+      if (mutt_istr_equal(e_templ->body->subtype, "mixed"))
+        e_templ->body = mutt_remove_multipart(e_templ->body);
       decode_descriptions(e_templ->body);
       mutt_unprepare_envelope(e_templ->env);
       FREE(&finalpath);

--- a/send/send.c
+++ b/send/send.c
@@ -2245,11 +2245,26 @@ int mutt_send_message(SendFlags flags, struct Email *e_templ, const char *tempfi
 
     if (flags & (SEND_POSTPONED | SEND_RESEND))
     {
-      fp_tmp = mutt_file_fopen(e_templ->body->filename, "a+");
-      if (!fp_tmp)
+      if (e_templ->body->type == TYPE_MULTIPART)
       {
-        mutt_perror(e_templ->body->filename);
-        goto cleanup;
+        struct Body *b = e_templ->body->parts;
+        while (b->type == TYPE_MULTIPART)
+          b = b->parts;
+        fp_tmp = mutt_file_fopen(b->filename, "a+");
+        if (!fp_tmp)
+        {
+          mutt_perror(b->filename);
+          goto cleanup;
+        }
+      }
+      else
+      {
+        fp_tmp = mutt_file_fopen(e_templ->body->filename, "a+");
+        if (!fp_tmp)
+        {
+          mutt_perror(e_templ->body->filename);
+          goto cleanup;
+        }
       }
     }
 
@@ -2497,14 +2512,32 @@ int mutt_send_message(SendFlags flags, struct Email *e_templ, const char *tempfi
   if (!(flags & SEND_BATCH))
   {
     struct stat st = { 0 };
-    time_t mtime = mutt_file_decrease_mtime(e_templ->body->filename, NULL);
-    if (mtime == (time_t) -1)
+    time_t mtime;
+    if (e_templ->body->type == TYPE_MULTIPART)
     {
-      mutt_perror(e_templ->body->filename);
-      goto cleanup;
-    }
+      struct Body *b = e_templ->body->parts;
+      while (b->type == TYPE_MULTIPART)
+        b = b->parts;
+      mtime = mutt_file_decrease_mtime(b->filename, NULL);
+      if (mtime == (time_t) -1)
+      {
+        mutt_perror(b->filename);
+        goto cleanup;
+      }
 
-    mutt_update_encoding(e_templ->body, sub);
+      mutt_update_encoding(e_templ->body->parts, sub);
+    }
+    else
+    {
+      mtime = mutt_file_decrease_mtime(e_templ->body->filename, NULL);
+      if (mtime == (time_t) -1)
+      {
+        mutt_perror(e_templ->body->filename);
+        goto cleanup;
+      }
+
+      mutt_update_encoding(e_templ->body, sub);
+    }
 
     const bool c_edit_headers = cs_subset_bool(sub, "edit_headers");
     const bool c_auto_edit = cs_subset_bool(sub, "auto_edit");
@@ -2524,27 +2557,62 @@ int mutt_send_message(SendFlags flags, struct Email *e_templ, const char *tempfi
     {
       /* If the this isn't a text message, look for a mailcap edit command */
       const char *const c_editor = cs_subset_string(sub, "editor");
-      if (mutt_needs_mailcap(e_templ->body))
+      if (e_templ->body->type == TYPE_MULTIPART)
       {
-        if (!mutt_edit_attachment(e_templ->body))
-          goto cleanup;
-      }
-      else if (c_edit_headers)
-      {
-        mutt_env_to_local(e_templ->env);
-        mutt_edit_headers(c_editor, e_templ->body->filename, e_templ, &fcc);
-        mutt_env_to_intl(e_templ->env, NULL, NULL);
+        struct Body *b = e_templ->body->parts;
+        while (b->type == TYPE_MULTIPART)
+          b = b->parts;
+        if (mutt_needs_mailcap(b))
+        {
+          if (!mutt_edit_attachment(b))
+            goto cleanup;
+        }
+        else if (c_edit_headers)
+        {
+          mutt_env_to_local(e_templ->env);
+          mutt_edit_headers(c_editor, b->filename, e_templ, &fcc);
+          mutt_env_to_intl(e_templ->env, NULL, NULL);
+        }
+        else
+        {
+          mutt_edit_file(c_editor, b->filename);
+          if (stat(b->filename, &st) == 0)
+          {
+            if (mtime != st.st_mtime)
+              fix_end_of_file(b->filename);
+          }
+          else
+          {
+            mutt_perror(b->filename);
+          }
+        }
       }
       else
       {
-        mutt_edit_file(c_editor, e_templ->body->filename);
-        if (stat(e_templ->body->filename, &st) == 0)
+        if (mutt_needs_mailcap(e_templ->body))
         {
-          if (mtime != st.st_mtime)
-            fix_end_of_file(e_templ->body->filename);
+          if (!mutt_edit_attachment(e_templ->body))
+            goto cleanup;
+        }
+        else if (c_edit_headers)
+        {
+          mutt_env_to_local(e_templ->env);
+          mutt_edit_headers(c_editor, e_templ->body->filename, e_templ, &fcc);
+          mutt_env_to_intl(e_templ->env, NULL, NULL);
         }
         else
-          mutt_perror(e_templ->body->filename);
+        {
+          mutt_edit_file(c_editor, e_templ->body->filename);
+          if (stat(e_templ->body->filename, &st) == 0)
+          {
+            if (mtime != st.st_mtime)
+              fix_end_of_file(e_templ->body->filename);
+          }
+          else
+          {
+            mutt_perror(e_templ->body->filename);
+          }
+        }
       }
 
       mutt_message_hook(NULL, e_templ, MUTT_SEND2_HOOK);


### PR DESCRIPTION
## Background

The present support for creating multipart emails is basic and suffers from functionality and usability problems. For example,

- Grouped attachments display as a single attachment which cannot be modified or ungrouped.
- Grouped attachments are appended to the list of attachments and can not be made the body of the email if other attachments have been added prior to grouping. See issue #2387.
- Grouping is lost if sending is aborted for any reason (e.g., crypt function fails or failed attachment check) or an email is postponed.

## Goals for this branch

The goal for this branch is to provide better support for both composing multipart/alternative and multipart/multilingual emails.

### Tasks:

- [x] `<group-attachment>` should place multipart/alternative group at position of first tagged attachment rather than end of attachment list.
- [x] Multipart/alternative attachments should display with correct tree structure.
- [x] Attachments (grouped and otherwise) should be able to be moved around in a natural way.
- [x] Support `<edit-message>` when the body of the email is a multipart/alternative attachment.
- [x] Support ungrouping of multipart attachments.
- [x] Preserve grouping when postponing a message.
- [x] Provide analogous support for multipart/multilingual attachments.
- [x] Amend documentation.
- [x] Support nested groups.
- [x] Create tests.
