### PR TITLE
Refactor uses of global Context

### DIFF
--- a/alias/dlgquery.c
+++ b/alias/dlgquery.c
@@ -82,6 +82,7 @@
 #include "gui/lib.h"
 #include "mutt.h"
 #include "lib.h"
+#include "index/lib.h"
 #include "menu/lib.h"
 #include "pattern/lib.h"
 #include "question/lib.h"
@@ -542,8 +543,8 @@ static void dlg_select_query(struct Buffer *buf, struct AliasList *all,
             mutt_addrlist_clear(&al);
           }
         }
-        mutt_send_message(SEND_NO_FLAGS, e, NULL, ctx_mailbox(Context), NULL,
-                          NeoMutt->sub);
+        struct Mailbox *m_cur = get_current_mailbox();
+        mutt_send_message(SEND_NO_FLAGS, e, NULL, m_cur, NULL, NeoMutt->sub);
         menu_queue_redraw(menu, MENU_REDRAW_FULL);
         break;
       }

--- a/autocrypt/autocrypt.c
+++ b/autocrypt/autocrypt.c
@@ -937,10 +937,10 @@ void mutt_autocrypt_scan_mailboxes(void)
       mutt_yesorno(_("Scan a mailbox for autocrypt headers?"), MUTT_YES);
   while (scan == MUTT_YES)
   {
-    struct Mailbox *m = get_current_mailbox();
+    struct Mailbox *m_cur = get_current_mailbox();
     // L10N: The prompt for a mailbox to scan for Autocrypt: headers
-    if ((!mutt_buffer_enter_fname(_("Scan mailbox"), folderbuf, true, m, false,
-                                  NULL, NULL, MUTT_SEL_NO_FLAGS)) &&
+    if ((!mutt_buffer_enter_fname(_("Scan mailbox"), folderbuf, true, m_cur,
+                                  false, NULL, NULL, MUTT_SEL_NO_FLAGS)) &&
         (!mutt_buffer_is_empty(folderbuf)))
     {
       mutt_buffer_expand_path_regex(folderbuf, false);

--- a/autocrypt/autocrypt.c
+++ b/autocrypt/autocrypt.c
@@ -910,32 +910,6 @@ int mutt_autocrypt_generate_gossip_list(struct Email *e)
 }
 
 /**
- * get_current_mailbox - Get the current Mailbox
- * @retval ptr Current Mailbox
- *
- * Search for the last (most recent) dialog that has an Index.
- * Then return the Mailbox from its shared data.
- */
-static struct Mailbox *get_current_mailbox(void)
-{
-  if (!AllDialogsWindow)
-    return NULL;
-
-  struct MuttWindow *np = NULL;
-  TAILQ_FOREACH_REVERSE(np, &AllDialogsWindow->children, MuttWindowList, entries)
-  {
-    struct MuttWindow *win = window_find_child(np, WT_DLG_INDEX);
-    if (win)
-    {
-      struct IndexSharedData *shared = win->wdata;
-      return shared->mailbox;
-    }
-  }
-
-  return NULL;
-}
-
-/**
  * mutt_autocrypt_scan_mailboxes - Scan mailboxes for Autocrypt headers
  *
  * This is invoked during the first autocrypt initialization,

--- a/color/regex.c
+++ b/color/regex.c
@@ -36,6 +36,7 @@
 #include "email/lib.h"
 #include "core/lib.h"
 #include "gui/lib.h"
+#include "index/lib.h"
 #include "pattern/lib.h"
 #include "color.h"
 #include "context.h"
@@ -224,9 +225,9 @@ enum CommandResult add_pattern(struct RegexColorList *rcl, const char *s,
       const char *const c_simple_search =
           cs_subset_string(NeoMutt->sub, "simple_search");
       mutt_check_simple(buf, NONULL(c_simple_search));
-      rcol->color_pattern =
-          mutt_pattern_comp(ctx_mailbox(Context), Context ? Context->menu : NULL,
-                            buf->data, MUTT_PC_FULL_MSG, err);
+      struct Mailbox *m_cur = get_current_mailbox();
+      rcol->color_pattern = mutt_pattern_comp(m_cur, Context ? Context->menu : NULL,
+                                              buf->data, MUTT_PC_FULL_MSG, err);
       mutt_buffer_pool_release(&buf);
       if (!rcol->color_pattern)
       {

--- a/color/regex.c
+++ b/color/regex.c
@@ -226,8 +226,9 @@ enum CommandResult add_pattern(struct RegexColorList *rcl, const char *s,
           cs_subset_string(NeoMutt->sub, "simple_search");
       mutt_check_simple(buf, NONULL(c_simple_search));
       struct Mailbox *m_cur = get_current_mailbox();
-      rcol->color_pattern = mutt_pattern_comp(m_cur, Context ? Context->menu : NULL,
-                                              buf->data, MUTT_PC_FULL_MSG, err);
+      struct Menu *menu = get_current_menu();
+      rcol->color_pattern =
+          mutt_pattern_comp(m_cur, menu, buf->data, MUTT_PC_FULL_MSG, err);
       mutt_buffer_pool_release(&buf);
       if (!rcol->color_pattern)
       {

--- a/compose/compose.c
+++ b/compose/compose.c
@@ -404,7 +404,7 @@ int mutt_compose_menu(struct Email *e, struct Buffer *fcc, uint8_t flags,
 
   struct MuttWindow *dlg = compose_dlg_init(sub, e, fcc);
   struct ComposeSharedData *shared = dlg->wdata;
-  shared->mailbox = ctx_mailbox(Context);
+  shared->mailbox = get_current_mailbox();
   shared->email = e;
   shared->sub = sub;
   shared->fcc = fcc;

--- a/hook.c
+++ b/hook.c
@@ -268,8 +268,8 @@ enum CommandResult mutt_parse_hook(struct Buffer *buf, struct Buffer *s,
       comp_flags = MUTT_PC_FULL_MSG;
 
     struct Mailbox *m_cur = get_current_mailbox();
-    pat = mutt_pattern_comp(m_cur, Context ? Context->menu : NULL,
-                            mutt_buffer_string(pattern), comp_flags, err);
+    struct Menu *menu = get_current_menu();
+    pat = mutt_pattern_comp(m_cur, menu, mutt_buffer_string(pattern), comp_flags, err);
     if (!pat)
       goto cleanup;
   }
@@ -441,8 +441,9 @@ enum CommandResult mutt_parse_idxfmt_hook(struct Buffer *buf, struct Buffer *s,
    * used for date ranges, and they need to be evaluated relative to "now", not
    * the hook compilation time.  */
   struct Mailbox *m_cur = get_current_mailbox();
+  struct Menu *menu = get_current_menu();
   struct PatternList *pat =
-      mutt_pattern_comp(m_cur, Context ? Context->menu : NULL, mutt_buffer_string(pattern),
+      mutt_pattern_comp(m_cur, menu, mutt_buffer_string(pattern),
                         MUTT_PC_FULL_MSG | MUTT_PC_PATTERN_DYNAMIC, err);
   if (!pat)
     goto out;

--- a/hook.c
+++ b/hook.c
@@ -42,6 +42,7 @@
 #include "mutt.h"
 #include "hook.h"
 #include "attach/lib.h"
+#include "index/lib.h"
 #include "ncrypt/lib.h"
 #include "pattern/lib.h"
 #include "context.h"
@@ -266,7 +267,8 @@ enum CommandResult mutt_parse_hook(struct Buffer *buf, struct Buffer *s,
     else
       comp_flags = MUTT_PC_FULL_MSG;
 
-    pat = mutt_pattern_comp(ctx_mailbox(Context), Context ? Context->menu : NULL,
+    struct Mailbox *m_cur = get_current_mailbox();
+    pat = mutt_pattern_comp(m_cur, Context ? Context->menu : NULL,
                             mutt_buffer_string(pattern), comp_flags, err);
     if (!pat)
       goto cleanup;
@@ -438,9 +440,9 @@ enum CommandResult mutt_parse_idxfmt_hook(struct Buffer *buf, struct Buffer *s,
    * matching.  This of course is slower, but index-format-hook is commonly
    * used for date ranges, and they need to be evaluated relative to "now", not
    * the hook compilation time.  */
+  struct Mailbox *m_cur = get_current_mailbox();
   struct PatternList *pat =
-      mutt_pattern_comp(ctx_mailbox(Context), Context ? Context->menu : NULL,
-                        mutt_buffer_string(pattern),
+      mutt_pattern_comp(m_cur, Context ? Context->menu : NULL, mutt_buffer_string(pattern),
                         MUTT_PC_FULL_MSG | MUTT_PC_PATTERN_DYNAMIC, err);
   if (!pat)
     goto out;
@@ -676,7 +678,8 @@ static int addr_hook(char *path, size_t pathlen, HookFlags type,
 void mutt_default_save(char *path, size_t pathlen, struct Email *e)
 {
   *path = '\0';
-  if (addr_hook(path, pathlen, MUTT_SAVE_HOOK, ctx_mailbox(Context), e) == 0)
+  struct Mailbox *m_cur = get_current_mailbox();
+  if (addr_hook(path, pathlen, MUTT_SAVE_HOOK, m_cur, e) == 0)
     return;
 
   struct Envelope *env = e->env;

--- a/index/index.c
+++ b/index/index.c
@@ -463,3 +463,29 @@ struct MuttWindow *index_window_new(struct IndexPrivateData *priv)
 
   return win;
 }
+
+/**
+ * get_current_mailbox - Get the current Mailbox
+ * @retval ptr Current Mailbox
+ *
+ * Search for the last (most recent) dialog that has an Index.
+ * Then return the Mailbox from its shared data.
+ */
+struct Mailbox *get_current_mailbox(void)
+{
+  if (!AllDialogsWindow)
+    return NULL;
+
+  struct MuttWindow *np = NULL;
+  TAILQ_FOREACH_REVERSE(np, &AllDialogsWindow->children, MuttWindowList, entries)
+  {
+    struct MuttWindow *win = window_find_child(np, WT_DLG_INDEX);
+    if (win)
+    {
+      struct IndexSharedData *shared = win->wdata;
+      return shared->mailbox;
+    }
+  }
+
+  return NULL;
+}

--- a/index/index.c
+++ b/index/index.c
@@ -489,3 +489,30 @@ struct Mailbox *get_current_mailbox(void)
 
   return NULL;
 }
+
+/**
+ * get_current_menu - Get the current Menu
+ * @retval ptr Current Menu
+ *
+ * Search for the last (most recent) dialog that has an Index.
+ * Then return the Menu from its private data.
+ */
+struct Menu *get_current_menu(void)
+{
+  if (!AllDialogsWindow)
+    return NULL;
+
+  struct MuttWindow *np = NULL;
+  TAILQ_FOREACH_REVERSE(np, &AllDialogsWindow->children, MuttWindowList, entries)
+  {
+    struct MuttWindow *dlg = window_find_child(np, WT_DLG_INDEX);
+    if (dlg)
+    {
+      struct MuttWindow *panel_index = window_find_child(dlg, WT_INDEX);
+      struct IndexPrivateData *priv = panel_index->wdata;
+      return priv->menu;
+    }
+  }
+
+  return NULL;
+}

--- a/index/lib.h
+++ b/index/lib.h
@@ -92,5 +92,6 @@ void resort_index(struct Context *ctx, struct Menu *menu);
 int mx_toggle_write(struct Mailbox *m);
 extern const struct Mapping IndexNewsHelp[];
 struct Mailbox *change_folder_notmuch(struct Menu *menu, char *buf, int buflen, int *oldcount, struct IndexSharedData *shared, bool read_only);
+struct Mailbox *get_current_mailbox(void);
 
 #endif /* MUTT_INDEX_LIB_H */

--- a/index/lib.h
+++ b/index/lib.h
@@ -93,5 +93,6 @@ int mx_toggle_write(struct Mailbox *m);
 extern const struct Mapping IndexNewsHelp[];
 struct Mailbox *change_folder_notmuch(struct Menu *menu, char *buf, int buflen, int *oldcount, struct IndexSharedData *shared, bool read_only);
 struct Mailbox *get_current_mailbox(void);
+struct Menu *get_current_menu(void);
 
 #endif /* MUTT_INDEX_LIB_H */

--- a/main.c
+++ b/main.c
@@ -1283,8 +1283,8 @@ main
         const char *const c_news_server =
             cs_subset_string(NeoMutt->sub, "news_server");
         OptNews = true;
-        CurrentNewsSrv = nntp_select_server(Context ? Context->mailbox : NULL,
-                                            c_news_server, false);
+        struct Mailbox *m_cur = get_current_mailbox();
+        CurrentNewsSrv = nntp_select_server(m_cur, c_news_server, false);
         if (!CurrentNewsSrv)
           goto main_curses; // TEST38: neomutt -G (unset news_server)
       }
@@ -1296,8 +1296,8 @@ main
         goto main_curses; // TEST39: neomutt -n -F /dev/null -y
       }
       mutt_buffer_reset(&folder);
-      mutt_buffer_select_file(&folder, MUTT_SEL_FOLDER | MUTT_SEL_MAILBOX,
-                              ctx_mailbox(Context), NULL, NULL);
+      struct Mailbox *m_cur = get_current_mailbox();
+      mutt_buffer_select_file(&folder, MUTT_SEL_FOLDER | MUTT_SEL_MAILBOX, m_cur, NULL, NULL);
       if (mutt_buffer_is_empty(&folder))
       {
         goto main_ok; // TEST40: neomutt -y (quit selection)

--- a/menu/draw.c
+++ b/menu/draw.c
@@ -36,6 +36,7 @@
 #include "email/lib.h"
 #include "gui/lib.h"
 #include "color/lib.h"
+#include "index/lib.h"
 #include "menu/lib.h"
 #include "pattern/lib.h"
 #include "context.h"
@@ -59,7 +60,8 @@ static int get_color(int index, unsigned char *s)
 {
   struct RegexColorList *rcl = NULL;
   struct RegexColor *np = NULL;
-  struct Email *e = mutt_get_virt_email(Context->mailbox, index);
+  struct Mailbox *m_cur = get_current_mailbox();
+  struct Email *e = mutt_get_virt_email(m_cur, index);
   int type = *s;
 
   switch (type)
@@ -92,7 +94,7 @@ static int get_color(int index, unsigned char *s)
   STAILQ_FOREACH(np, rcl, entries)
   {
     if (mutt_pattern_exec(SLIST_FIRST(np->color_pattern),
-                          MUTT_MATCH_FULL_ADDRESS, Context->mailbox, e, NULL))
+                          MUTT_MATCH_FULL_ADDRESS, m_cur, e, NULL))
     {
       return np->pair;
     }

--- a/menu/menu.c
+++ b/menu/menu.c
@@ -38,6 +38,7 @@
 #include "gui/lib.h"
 #include "mutt.h"
 #include "color/lib.h"
+#include "index/lib.h"
 #include "menu/lib.h"
 #include "commands.h"
 #include "context.h"
@@ -499,7 +500,8 @@ int menu_loop(struct Menu *menu)
       case OP_SHELL_ESCAPE:
         if (mutt_shell_escape())
         {
-          mutt_mailbox_check(ctx_mailbox(Context), MUTT_MAILBOX_CHECK_FORCE);
+          struct Mailbox *m_cur = get_current_mailbox();
+          mutt_mailbox_check(m_cur, MUTT_MAILBOX_CHECK_FORCE);
         }
         break;
 
@@ -508,8 +510,11 @@ int menu_loop(struct Menu *menu)
         break;
 
       case OP_CHECK_STATS:
-        mutt_check_stats(ctx_mailbox(Context));
+      {
+        struct Mailbox *m_cur = get_current_mailbox();
+        mutt_check_stats(m_cur);
         break;
+      }
 
       case OP_REDRAW:
         clearok(stdscr, true);

--- a/score.c
+++ b/score.c
@@ -35,6 +35,7 @@
 #include "core/lib.h"
 #include "mutt.h"
 #include "score.h"
+#include "index/lib.h"
 #include "pattern/lib.h"
 #include "context.h"
 #include "init.h"
@@ -112,9 +113,9 @@ enum CommandResult mutt_parse_score(struct Buffer *buf, struct Buffer *s,
       break;
   if (!ptr)
   {
-    struct PatternList *pat =
-        mutt_pattern_comp(ctx_mailbox(Context), Context ? Context->menu : NULL,
-                          pattern, MUTT_PC_NO_FLAGS, err);
+    struct Mailbox *m_cur = get_current_mailbox();
+    struct PatternList *pat = mutt_pattern_comp(m_cur, Context ? Context->menu : NULL,
+                                                pattern, MUTT_PC_NO_FLAGS, err);
     if (!pat)
     {
       FREE(&pattern);

--- a/score.c
+++ b/score.c
@@ -114,8 +114,9 @@ enum CommandResult mutt_parse_score(struct Buffer *buf, struct Buffer *s,
   if (!ptr)
   {
     struct Mailbox *m_cur = get_current_mailbox();
-    struct PatternList *pat = mutt_pattern_comp(m_cur, Context ? Context->menu : NULL,
-                                                pattern, MUTT_PC_NO_FLAGS, err);
+    struct Menu *menu = get_current_menu();
+    struct PatternList *pat =
+        mutt_pattern_comp(m_cur, menu, pattern, MUTT_PC_NO_FLAGS, err);
     if (!pat)
     {
       FREE(&pattern);

--- a/send/sendlib.c
+++ b/send/sendlib.c
@@ -1750,9 +1750,9 @@ done:
 #ifdef RECORD_FOLDER_HOOK
   /* We ran a folder hook for the destination mailbox,
    * now we run it for the user's current mailbox */
-  const struct Mailbox *m = ctx_mailbox(Context);
-  if (m)
-    mutt_folder_hook(m->path, m->desc);
+  const struct Mailbox *m_cur = get_current_mailbox();
+  if (m_cur)
+    mutt_folder_hook(m_cur->path, m_cur->desc);
 #endif
 
   if (fp_tmp)


### PR DESCRIPTION
Fixes: #3176 

Historically, (Neo)Mutt maintained a global `Context` representing the "current" `Mailbox`.
Most code doesn't actually need a `Context`, it just needs the current `Mailbox` or `Menu`,
and most of these needs have been met by passing parameters to functions.

A few poorly written bits of code still use the `Context`.
Instead, use a couple of helper functions: `get_current_mailbox()`, `get_current_menu()`.

The helper functions work out-of-band -- they look up the most recent Index Window and get the `Mailbox` or `Menu` from its private data.
This isn't ideal, but it avoids dangling pointers when the `Context` changes,

- 1f3ca6844 index: move mailbox helper
  Move the helper into the Index library

- a3d0d4652 index: use mailbox helper
  Replace lots of `Context->mailbox` or `ctx_mailbox(Context)` with `get_current_mailbox()`

- 2caf47754 index: create menu helper
  Add `get_current_menu()`

- 3801c2f0e index: use menu helper
  Replace `Context->menu` with `get_current_menu()`