### PR TITLE
fix leak of threads

### DIFF
--- a/mutt/hash.c
+++ b/mutt/hash.c
@@ -317,7 +317,7 @@ void mutt_hash_set_destructor(struct HashTable *table, hash_hdata_free_t fn, int
 struct HashElem *mutt_hash_typed_insert(struct HashTable *table,
                                         const char *strkey, int type, void *data)
 {
-  if (!table || !strkey || (strkey[0] == '\0'))
+  if (!table || !strkey)
     return NULL;
 
   union HashKey key;


### PR DESCRIPTION
Fixes: #3180

When Emails don't have a Message-ID, we store them in the HashTable with a key of "".
Remove the check that prevented this.
