### PR TITLE
date: humanize timestamps in index

### DIFF
--- a/hdrline.c
+++ b/hdrline.c
@@ -855,6 +855,13 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
       break;
     }
 
+    case 'h':
+      mutt_date_humanize(tmp, sizeof(tmp), e->received);
+      colorlen = add_index_color(buf, buflen, flags, MT_COLOR_INDEX_DATE);
+      mutt_format_s(buf + colorlen, buflen - colorlen, prec, tmp);
+      add_index_color(buf + colorlen, buflen - colorlen, flags, MT_COLOR_INDEX);
+      break;
+
     case 'H':
       /* (Hormel) spam score */
       if (optional)

--- a/mutt/date.h
+++ b/mutt/date.h
@@ -55,6 +55,7 @@ time_t    mutt_date_epoch(void);
 uint64_t  mutt_date_epoch_ms(void);
 struct tm mutt_date_gmtime(time_t t);
 size_t    mutt_date_localtime_format(char *buf, size_t buflen, const char *format, time_t t);
+size_t    mutt_date_humanize(char *buf, size_t buflen, time_t t);
 struct tm mutt_date_localtime(time_t t);
 time_t    mutt_date_local_tz(time_t t);
 void      mutt_date_make_date(struct Buffer *buf, bool local);

--- a/po/fr.po
+++ b/po/fr.po
@@ -3978,6 +3978,30 @@ msgstr "Défilement vers le haut impossible"
 msgid "You can't scroll down farther"
 msgstr "Défilement vers le bas impossible"
 
+#: mutt/date.c:728
+msgid "just now"
+msgstr "maintenant"
+
+#: mutt/date.c:730
+msgid "an hour ago"
+msgstr "une heure"
+
+#: mutt/date.c:732
+msgid "few hours ago"
+msgstr "quelques heures"
+
+#: mutt/date.c:734
+msgid "earlier today"
+msgstr "aujourd'hui"
+
+#: mutt/date.c:736
+msgid "yesterday"
+msgstr "hier"
+
+#: mutt/date.c:738
+msgid "days ago"
+msgstr "jours"
+
 #: mutt/file.c:674
 #, fuzzy, c-format
 msgid "Failed to seek file: %s"


### PR DESCRIPTION
We introduce a new configuration option `humanize_time`, a boolean that
is set to false by default. When set to true, the index will display
timestamps like "Just now", "A few hours ago", and "Earlier today".

Signed-off-by: Ramkumar Ramachandra <r@artagnon.com>

<img width="1088" alt="Capture d’écran 2022-01-11 à 08 01 44" src="https://user-images.githubusercontent.com/37226/148896400-e3305cb7-e827-48d9-a522-19d294d0b0e8.png">


