### PR TITLE
prex: fix bug in regex; pass wasn't captured in url

### DIFF
--- a/mutt/prex.c
+++ b/mutt/prex.c
@@ -114,8 +114,8 @@ static struct PrexStorage *prex(enum Prex which)
                                                    // . . or path only
           "(//"                                    // . . . authority + path
             "("                                    // . . . . user info
-              "([" UNR_PCTENC_SUBDEL "@-]*)"       // . . . . . user name + '@'
-              "(:([" UNR_PCTENC_SUBDEL "-]*))?"    // . . . . . password
+              "([" UNR_PCTENC_SUBDEL "-]*)"        // . . . . . user name
+              "(:([" UNR_PCTENC_SUBDEL "-]*))?"    // . . . . . + ':' + password
             "@)?"
             "("                                    // . . . . host
               "([" UNR_PCTENC_SUBDEL "-]*)"        // . . . . . host name


### PR DESCRIPTION
Hi,

This is a bug I spotted while investigating the way authentication is done in neomutt for my osxkeychain branch.

Thanks.