### PR TITLE
newsrc: squelch warning; format string corresponding to time_t

### DIFF
--- a/nntp/newsrc.c
+++ b/nntp/newsrc.c
@@ -626,8 +626,7 @@ static int active_get_cache(struct NntpAccountData *adata)
   if (!fp)
     return -1;
 
-  if (!fgets(buf, sizeof(buf), fp) ||
-      (sscanf(buf, "%" SCNd64 "%4095s", &t, file) != 1) || (t == 0))
+  if (!fgets(buf, sizeof(buf), fp) || (sscanf(buf, "%jd%4095s", &t, file) != 1) || (t == 0))
   {
     mutt_file_fclose(&fp);
     return -1;


### PR DESCRIPTION
time_t is an undefined type, according to the spec, and %jd is the right
format string to use, according to the docs. Squelch a compiler warning
related to this is newsrc.c.

Signed-off-by: Ramkumar Ramachandra <r@artagnon.com>