### PR TITLE
lens: introduce a new Mailbox type

### DIFF
--- a/lens/lens.c
+++ b/lens/lens.c
@@ -1,0 +1,79 @@
+#include <stddef.h>
+#include <string.h>
+#include "mutt/hash.h"
+#include "email/envelope.h"
+#include "core/neomutt.h"
+#include "lib.h"
+#include "queue.h"
+
+static int mailbox_to_lens(struct Mailbox *mailbox, struct MailboxLens *lens)
+{
+  // TODO: Dumb shallow-ref
+}
+
+static int lens_add_email(struct LensEmailList el, struct Email *e)
+{
+  if (!e)
+    return -1;
+
+  struct LensEmail *en = mutt_mem_calloc(1, sizeof(*en));
+  en->email = e;
+  // TODO: en->mailbox
+  STAILQ_INSERT_TAIL(&el, en, entries);
+
+  return 0;
+}
+
+static int merge_mailboxes(struct Mailbox *primary, struct MailboxList ml,
+                           struct LensMailbox *merged)
+{
+  struct MailboxNode *np = NULL;
+  int alloc = 0;
+  if (!primary)
+    return -1;
+  mailbox_to_lens(primary, merged);
+
+  // Prep: Find the number of elements in all our hash tables
+  STAILQ_FOREACH(np, &ml, entries)
+  {
+    if (!np->mailbox)
+      continue;
+
+    alloc += np->mailbox->id_hash->num_elems;
+  }
+
+  // Step 1: Copy out id_hash into id_hash_aux, converting every key into a LensEmail
+  // TODO
+
+  // Step 2: Merge all the hash tables
+  struct HashTable *table = mutt_hash_new(alloc, MUTT_HASH_NO_FLAGS);
+  STAILQ_FOREACH(np, &ml, entries)
+  {
+    mutt_hash_merge(table, np->mailbox->id_hash);
+  }
+
+  // Now the real work: match in-reply-to against the msg-ids in table
+  struct LensEmail *le = NULL;
+  char *ref = NULL;
+  struct Email *match = NULL;
+  STAILQ_FOREACH(le, &merged->emails, entries)
+  {
+    STAILQ_FOREACH(ref, &le->email->env->in_reply_to, entries)
+    {
+      // TODO: This step should directly return a LensEmail
+      if ((match = mutt_hash_find(table, ref)))
+        lens_add_email(merged->emails, match);
+    }
+  }
+
+  mutt_hash_free(&table);
+  return 0;
+}
+
+struct LensMailbox *mutt_lens_mailbox(struct Mailbox *primary, struct MailboxList ml)
+{
+  struct LensMailbox *lens = NULL;
+  mutt_buffer_allocate(lens);
+  merge_mailboxes(primary, ml, lens);
+  return lens;
+}

--- a/lens/lib.h
+++ b/lens/lib.h
@@ -1,0 +1,75 @@
+#pragma once
+
+#include "mutt/lib.h"
+#include "email/email.h"
+#include "email/thread.h"
+#include "core/account.h"
+#include "core/mailbox.h"
+
+enum LensMailboxType
+{
+  LENS_TYPE_MAILDIR,
+  LENS_TYPE_MBOX,
+  LENS_TYPE_IMAP,
+  LENS_TYPE_POP
+};
+
+struct LensEmail
+{
+  const struct Email *email;
+  const struct Mailbox *mailbox;
+  STAILQ_ENTRY(LensEmail) entries; ///< Linked list
+};
+STAILQ_HEAD(LensEmailList, LensEmail);
+
+struct LensMailbox
+{
+  struct Buffer pathbuf; ///< Path of the Mailbox
+  char *realpath; ///< Used for duplicate detection, context comparison, and the sidebar
+  char *name;               ///< A short name for the Mailbox
+  struct ConfigSubset *sub; ///< Inherited config items
+  off_t size;               ///< Size of the Mailbox
+  bool has_new;             ///< Mailbox has new mail
+
+  // These next three are only set when MailCheckStats is set
+  int msg_count;   ///< Total number of messages
+  int msg_unread;  ///< Number of unread messages
+  int msg_flagged; ///< Number of flagged messages
+
+  int msg_new;     ///< Number of new messages
+  int msg_deleted; ///< Number of deleted messages
+  int msg_tagged;  ///< How many messages are tagged?
+
+  struct LensEmailList emails; ///< Linked list of emails
+  int *v2r;                    ///< Mapping from virtual to real msgno
+  int vcount;                  ///< The number of virtual messages
+
+  bool notified;                ///< User has been notified
+  enum LensMailboxType type;    ///< Mailbox type
+  bool newly_created;           ///< Mbox or mmdf just popped into existence
+  struct timespec mtime;        ///< Time Mailbox was last changed
+  struct timespec last_visited; ///< Time of last exit from this mailbox
+  struct timespec stats_last_checked; ///< Mtime of mailbox the last time stats where checked.
+
+  bool append : 1;                 ///< Mailbox is opened in append mode
+  bool changed : 1;                ///< Mailbox has been modified
+  bool dontwrite : 1;              ///< Don't write the mailbox on close
+  bool first_check_stats_done : 1; ///< True when the check have been done at least on time
+  bool peekonly : 1;               ///< Just taking a glance, revert atime
+  bool verbose : 1;                ///< Display status messages?
+  bool readonly : 1;               ///< Don't allow changes to the mailbox
+
+  struct HashTable *id_hash;    ///< Hash Table by msg id
+  struct HashTable *subj_hash;  ///< Hash Table by subject
+  struct HashTable *label_hash; ///< Hash Table for x-labels
+
+  struct AccountList accounts; ///< The accounts this LensMailbox is associated with
+
+  int opened; ///< Number of times mailbox is opened
+
+  uint8_t flags; ///< e.g. #MB_NORMAL
+
+  struct Notify *notify; ///< Notifications: #NotifyMailbox, #EventMailbox
+
+  int gen; ///< Generation number, for sorting
+};

--- a/mutt/hash.c
+++ b/mutt/hash.c
@@ -337,6 +337,16 @@ struct HashElem *mutt_hash_insert(struct HashTable *table, const char *strkey, v
   return mutt_hash_typed_insert(table, strkey, -1, data);
 }
 
+struct HashTable *mutt_hash_merge(struct HashTable *table, struct HashTable *aux)
+{
+  if (!table || !aux)
+    return NULL;
+  for (struct HashElem *el = mutt_hash_walk(aux, aux->table); !el;
+       el = mutt_hash_walk(aux, el))
+    mutt_hash_insert(table, el->key.strkey, el->data);
+  return table;
+}
+
 /**
  * mutt_hash_int_insert - Add a new element to the Hash Table (with integer keys)
  * @param table  Hash Table (with integer keys)

--- a/mutt/hash.h
+++ b/mutt/hash.h
@@ -97,14 +97,14 @@ struct HashTable
 {
   size_t num_elems;             ///< Number of elements in the Hash Table
   bool strdup_keys : 1;         ///< if set, the key->strkey is strdup()'d
-  bool allow_dups  : 1;         ///< if set, duplicate keys are allowed
+  bool allow_dups : 1;          ///< if set, duplicate keys are allowed
   struct HashElem **table;      ///< Array of Hash keys
   hash_gen_hash_t gen_hash;     ///< Function to generate hash id from the key
   hash_cmp_key_t cmp_key;       ///< Function to compare two Hash keys
   intptr_t hdata;               ///< Data to pass to the hdata_free() function
   hash_hdata_free_t hdata_free; ///< Function to free a Hash element
 };
-
+// clang-format off
 typedef uint8_t HashFlags;             ///< Flags for mutt_hash_new(), e.g. #MUTT_HASH_STRCASECMP
 #define MUTT_HASH_NO_FLAGS          0  ///< No flags are set
 #define MUTT_HASH_STRCASECMP  (1 << 0) ///< use strcasecmp() to compare keys
@@ -117,6 +117,7 @@ void *            mutt_hash_find          (const struct HashTable *table, const 
 struct HashElem * mutt_hash_find_elem     (const struct HashTable *table, const char *strkey);
 void              mutt_hash_free          (struct HashTable **ptr);
 struct HashElem * mutt_hash_insert        (struct HashTable *table, const char *strkey, void *data);
+struct HashTable* mutt_hash_merge         (struct HashTable *table, struct HashTable *aux);
 void              mutt_hash_int_delete    (struct HashTable *table, unsigned int intkey, const void *data);
 void *            mutt_hash_int_find      (const struct HashTable *table, unsigned int intkey);
 struct HashElem * mutt_hash_int_insert    (struct HashTable *table, unsigned int intkey, void *data);
@@ -124,7 +125,7 @@ struct HashTable *mutt_hash_int_new       (size_t num_elems, HashFlags flags);
 struct HashTable *mutt_hash_new           (size_t num_elems, HashFlags flags);
 void              mutt_hash_set_destructor(struct HashTable *table, hash_hdata_free_t fn, intptr_t fn_data);
 struct HashElem * mutt_hash_typed_insert  (struct HashTable *table, const char *strkey, int type, void *data);
-
+// clang-format on
 /**
  * struct HashWalkState - Cursor to iterate through a Hash Table
  */


### PR DESCRIPTION
neomutt faces one stark defeciency compared to modern web-based email:
in an email thread for a received email, the emails that are sent by the
user are missing. In order to fix this, we propose a new Mailbox type
dubbed "lens", that merely acts as a lens into multiple existing
Mailboxes.

This patch is in its very early stages, and is more of a mockup than any
functioning code.