### PR TITLE
Add support for composing 'multipart/related' emails

### DIFF
--- a/compose/functions.c
+++ b/compose/functions.c
@@ -123,6 +123,27 @@ static char *gen_cid(void)
 }
 
 /**
+ * check_cid - Check if a Content-ID is valid
+ * @param  cid   Content-ID to check
+ * @retval true  Content-ID is valid
+ * @retval false Content-ID is not valid
+ */
+static bool check_cid(const char *cid)
+{
+  static const char *check = "^[-\\.0-9@A-Z_a-z]+$";
+  struct Buffer buf = mutt_buffer_make(0);
+
+  struct Regex *check_cid_regex = mutt_regex_new(check, 0, &buf);
+  mutt_buffer_dealloc(&buf);
+
+  const bool valid = mutt_regex_match(check_cid_regex, cid);
+
+  mutt_regex_free(&check_cid_regex);
+
+  return valid;
+}
+
+/**
  * count_attachments - Count attachments
  * @param  body    Body to start counting from
  * @param  recurse Whether to recurse into groups or not

--- a/compose/functions.c
+++ b/compose/functions.c
@@ -107,6 +107,22 @@ static bool check_count(struct AttachCtx *actx)
 }
 
 /**
+ * gen_cid - Generate a random Content ID
+ * @retval ptr Content ID
+ *
+ * @note The caller should free the string
+ */
+static char *gen_cid(void)
+{
+  char rndid[MUTT_RANDTAG_LEN + 1];
+
+  mutt_rand_base32(rndid, sizeof(rndid) - 1);
+  rndid[MUTT_RANDTAG_LEN] = 0;
+
+  return mutt_str_dup(rndid);
+}
+
+/**
  * count_attachments - Count attachments
  * @param  body    Body to start counting from
  * @param  recurse Whether to recurse into groups or not

--- a/compose/functions.c
+++ b/compose/functions.c
@@ -1747,6 +1747,39 @@ static int op_attachment_toggle_unlink(struct ComposeSharedData *shared, int op)
 }
 
 /**
+ * op_attachment_group_related - Group tagged attachments as 'multipart/related' - Implements ::compose_function_t - @ingroup compose_function_api
+ */
+static int op_attachment_group_related(struct ComposeSharedData *shared, int op)
+{
+  static const char *RELATED_TAG = "Related parts for \"%s\"";
+  if (shared->adata->menu->tagged < 2)
+  {
+    mutt_error(_("Grouping 'related' requires at least 2 tagged messages"));
+    return IR_ERROR;
+  }
+
+  // ensure Content-ID is set for tagged attachments
+  for (struct Body *b = shared->email->body; b; b = b->next)
+  {
+    if (!b->tagged || (b->type == TYPE_MULTIPART))
+      continue;
+
+    char *id = mutt_param_get(&b->parameter, "content-id");
+    if (id)
+      continue;
+
+    id = gen_cid();
+    if (id)
+    {
+      mutt_param_set(&b->parameter, "content-id", id);
+      FREE(&id);
+    }
+  }
+
+  return group_attachments(shared, RELATED_TAG, "related");
+}
+
+/**
  * op_attachment_ungroup - Ungroup a 'multipart' attachment - Implements ::compose_function_t - @ingroup compose_function_api
  */
 static int op_attachment_ungroup(struct ComposeSharedData *shared, int op)
@@ -2515,6 +2548,7 @@ struct ComposeFunction ComposeFunctions[] = {
   { OP_ATTACHMENT_GET_ATTACHMENT,         op_attachment_get_attachment },
   { OP_ATTACHMENT_GROUP_ALTS,             op_attachment_group_alts },
   { OP_ATTACHMENT_GROUP_LINGUAL,          op_attachment_group_lingual },
+  { OP_ATTACHMENT_GROUP_RELATED,          op_attachment_group_related },
   { OP_ATTACHMENT_MOVE_DOWN,              op_attachment_move_down },
   { OP_ATTACHMENT_MOVE_UP,                op_attachment_move_up },
   { OP_ATTACHMENT_NEW_MIME,               op_attachment_new_mime },

--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -11518,6 +11518,114 @@ set preferred_languages="fr,en,de"
       </sect2>
     </sect1>
 
+    <sect1 id="related">
+      <title>MIME Multipart/Related</title>
+
+      <para>
+        Neomutt doesn't include any special support for reading <literal>multipart/related</literal>
+        emails, but it is possible to write a <literal>multipart/related</literal> email.
+        A <literal>multipart/related</literal> attachment is intended for compound objects
+        consisting of several inter-related body parts which are linked together using the
+        <literal>Content-ID</literal> header. Its format is described by
+        <ulink url="https://tools.ietf.org/html/rfc2387">RFC2387</ulink>.
+      </para>
+
+      <sect2 id="compose-multipart-related">
+        <title>Composing Multipart/Related Emails</title>
+        <para>
+          The procedure for composing a <literal>multipart/related</literal> email is similar
+          to that in <link linkend="compose-alternative-order">Composing Multipart/Alternative</link>.
+          You have to prepare every part manually or using some scripts, and then tag and group them
+          together into a <literal>multipart/related</literal> bundle before sending it:
+        </para>
+
+        <orderedlist>
+          <listitem>
+            <para>
+              Prepare parts of the related email.
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              Attach them as attachments.
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              Tag them with <literal>&lt;tag-entry&gt;</literal>
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              One part can reference another using its <literal>Content-ID</literal> header.
+              For example, an HTML part that includes an embedded image needs to contain:
+              <literal>&lt;img src="cid:content-id"&gt;</literal> where an
+              attached image has a <literal>Content-ID</literal> header of <literal>content-id</literal>.
+              The <literal>Content-ID</literal> of an attachment can be set using
+              <literal>&lt;edit-content-id&gt;</literal> (default key <literal>Alt-i</literal>).
+              <literal>&lt;edit-content-id&gt;</literal> sets a random ID which can then be
+              changed if desired. Permitted characters for <literal>Content-ID</literal> are:
+              <literal>-.0-9@A-Z_a-z</literal>.
+            </para>
+            <para>
+              If the <literal>multipart/related</literal> group is intended to be inline,
+              members of the group should also have their <literal>Content-Disposition</literal>
+              header set to <literal>inline</literal> which can be toggled using
+              <literal>&lt;toggle-disposition&gt;</literal> (default key <literal>Ctrl-D</literal>).
+            </para>
+            <para>
+              It can also be desirable to give referenced files in the group a
+              <literal>filename</literal> even when the <literal>Content-Disposition</literal> is
+              set to be <literal>inline</literal>. To do this use <literal>&lt;rename-attachment&gt;</literal>
+              (default key <literal>Ctrl-O</literal>).
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              Group all the tagged messages together with <literal>&lt;group-related&gt;</literal>
+              (default key <literal>%</literal>).
+            </para>
+            <para>
+              Top level attachments (excluding <literal>multipart</literal> ones) in the group
+              are automatically given a random <literal>Content-ID</literal> if they do not
+              already have one.
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              Send the email as usual.
+            </para>
+          </listitem>
+        </orderedlist>
+
+        <para>
+          Some care needs to be taken with the construction of a <literal>multipart/related</literal>
+          email to ensure it is correctly displayed by the receiving mail client.
+          A typical email with a <literal>multipart/alternative</literal> part
+          containing a <literal>text/plain</literal> part and a <literal>text/html</literal>
+          part with an embedded image, along with a separate attachment might end up like this:
+        </para>
+
+<screen>
+  I     1 &lt;no description&gt;                                         [multipart/related, 7bit, 0K]
+  I     2 ├─>&lt;no description&gt;                                  [multipart/alternative, 7bit, 0K]
+- I     3 │ ├─>/tmp/neomutt-hostname-XXXX-XXXXXX-XXXXXXXXXX   [text/plain, 7bit, us-ascii, 0.1K]
+- I     4 │ └─>/tmp/neomutt-alternative.html                      [text/html, 8bit, utf-8, 0.6K]
+  I     5 └─>image.png                                                  [image/png, base64, 19K]
+  A     6 attachment.pdf                                         [application/pdf, quoted, 7.1K]
+</screen>
+
+        <para>
+          In the above email <literal>/tmp/neomutt-alternative.html</literal> would reference
+          <literal>image.png</literal> using <literal>&lt;img src="cid:content-id"&gt;</literal>
+          and <literal>image.png</literal> has been given an explicit name of
+          <literal>image.png</literal> using <literal>&lt;rename-attachment&gt;</literal>
+          (regardless of its initial filename). <literal>&lt;group-related&gt;</literal>
+          has set its <literal>Content-ID</literal> header to a random value.
+        </para>
+      </sect2>
+    </sect1>
+
     <sect1 id="attachments">
       <title>Attachment Searching and Counting</title>
       <para>

--- a/email/parse.c
+++ b/email/parse.c
@@ -1379,6 +1379,23 @@ struct Body *mutt_read_mime_header(FILE *fp, bool digest)
         mutt_str_replace(&p->description, c);
         rfc2047_decode(&p->description);
       }
+      else if (mutt_istr_equal("id", line + plen))
+      {
+        // strip <angle braces> from Content-ID: header
+        char *id = c;
+        int cid_len = mutt_str_len(c);
+        if (cid_len > 2)
+        {
+          if (id[0] == '<')
+          {
+            id++;
+            cid_len--;
+          }
+          if (id[cid_len - 1] == '>')
+            id[cid_len - 1] = '\0';
+        }
+        mutt_param_set(&p->parameter, "content-id", id);
+      }
     }
 #ifdef SUN_ATTACHMENT
     else if ((plen = mutt_istr_startswith(line, "x-sun-")))

--- a/functions.c
+++ b/functions.c
@@ -503,6 +503,7 @@ const struct Binding OpCompose[] = { /* map: compose */
   { "get-attachment",                OP_ATTACHMENT_GET_ATTACHMENT,          "G" },
   { "group-alternatives",            OP_ATTACHMENT_GROUP_ALTS,              "&" },
   { "group-multilingual",            OP_ATTACHMENT_GROUP_LINGUAL,           "^" },
+  { "group-related",                 OP_ATTACHMENT_GROUP_RELATED,           "%" },
   { "ungroup-attachment",            OP_ATTACHMENT_UNGROUP,                 "#" },
   { "ispell",                        OP_COMPOSE_ISPELL,                     "i" },
 #ifdef MIXMASTER

--- a/functions.c
+++ b/functions.c
@@ -475,6 +475,7 @@ const struct Binding OpCompose[] = { /* map: compose */
   { "display-toggle-weed",           OP_DISPLAY_HEADERS,                    "h" },
   { "edit-bcc",                      OP_ENVELOPE_EDIT_BCC,                  "b" },
   { "edit-cc",                       OP_ENVELOPE_EDIT_CC,                   "c" },
+  { "edit-content-id",               OP_ATTACHMENT_EDIT_CONTENT_ID,         "\033i" },  // <Alt-i>
   { "edit-description",              OP_ATTACHMENT_EDIT_DESCRIPTION,        "d" },
   { "edit-encoding",                 OP_ATTACHMENT_EDIT_ENCODING,           "\005" },   // <Ctrl-E>
   { "edit-fcc",                      OP_ENVELOPE_EDIT_FCC,                  "f" },

--- a/opcodes.h
+++ b/opcodes.h
@@ -34,6 +34,7 @@
   _fmt(OP_ATTACHMENT_COLLAPSE,                N_("toggle display of subparts")) \
   _fmt(OP_ATTACHMENT_DELETE,                  N_("delete the current entry")) \
   _fmt(OP_ATTACHMENT_DETACH,                  N_("delete the current entry")) \
+  _fmt(OP_ATTACHMENT_EDIT_CONTENT_ID,         N_("edit the 'Content-ID' of the attachment")) \
   _fmt(OP_ATTACHMENT_EDIT_DESCRIPTION,        N_("edit attachment description")) \
   _fmt(OP_ATTACHMENT_EDIT_ENCODING,           N_("edit attachment transfer-encoding")) \
   _fmt(OP_ATTACHMENT_EDIT_LANGUAGE,           N_("edit the 'Content-Language' of the attachment")) \

--- a/opcodes.h
+++ b/opcodes.h
@@ -44,6 +44,7 @@
   _fmt(OP_ATTACHMENT_GET_ATTACHMENT,          N_("get a temporary copy of an attachment")) \
   _fmt(OP_ATTACHMENT_GROUP_ALTS,              N_("group tagged attachments as 'multipart/alternative'")) \
   _fmt(OP_ATTACHMENT_GROUP_LINGUAL,           N_("group tagged attachments as 'multipart/multilingual'")) \
+  _fmt(OP_ATTACHMENT_GROUP_RELATED,           N_("group tagged attachments as 'multipart/related'")) \
   _fmt(OP_ATTACHMENT_MOVE_DOWN,               N_("move an attachment down in the attachment list")) \
   _fmt(OP_ATTACHMENT_MOVE_UP,                 N_("move an attachment up in the attachment list")) \
   _fmt(OP_ATTACHMENT_NEW_MIME,                N_("compose new attachment using mailcap entry")) \

--- a/send/header.c
+++ b/send/header.c
@@ -846,7 +846,7 @@ int mutt_write_mime_header(struct Body *a, FILE *fp, struct ConfigSubset *sub)
       fprintf(fp, "Content-Disposition: %s", dispstr[a->disposition]);
       len = 21 + mutt_str_len(dispstr[a->disposition]);
 
-      if (a->use_disp && (a->disposition != DISP_INLINE))
+      if (a->use_disp && ((a->disposition != DISP_INLINE) || a->d_filename))
       {
         char *fn = a->d_filename;
         if (!fn)


### PR DESCRIPTION
## What does this PR do?

Adds support for composing `multipart/related` emails.

## Example

run `./neomutt -n -F multipart-related.rc`

### Needs:

#### `multipart-related.rc`

```
# vim: syn=neomuttrc

# filename: multipart-related.rc

# run from build directory:
#   ./neomutt -n -F multipart-related.rc

# key in <F1> through <F6> to construct the email

unset record
unset signature

set attach_format = "%u%D%I %t%4n %T%.40d%> [%.15m/%.15M, %.6e%?C?, %C?, %s]"
set editor = "echo '![Neomutt Logo](cid:neomutt-256.png)' >> %s"
set from = "john.doe@example.com"
set help = no
set postpone = no
set postponed = "postponed.mbox"
set realname = "John Doe"
set recall=no
set spoolfile = "inbox.mbox"

macro index   <F1> "<mail>John Doe <john.doe@example.com><enter>test<enter>"
macro compose <F2> "<attach-file>contrib/logo/neomutt-256.png<enter>"
macro compose <F3> "<rename-attachment><enter><toggle-disposition>"
macro compose <F4> "<attach-file>html-part.html<enter>"
macro compose <F5> "<toggle-disposition><tag-entry>1<enter><tag-entry><group-alternatives>"
macro compose <F6> "<tag-entry>4<enter><tag-entry><group-related>"
```

#### `html-part.html`

```HTML
<!DOCTYPE html>
<html lang="en">
<head>
  <meta charset="utf-8">
  <meta name="generator" content="pandoc">
  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
  <title> </title>
</head>
<body>
<div style="max-width: 15cm;">
<p style="margin: 1ex 0; padding: 0;"><img src="cid:neomutt-256.png" alt="Neomutt Logo"></p>
</div>
</body>
</html>
```

### Final email structure

```
  I     1 <no description>                                                   [multipart/related, 7bit, 0K]
  I     2 ├─><no description>                                            [multipart/alternative, 7bit, 0K]
- I     3 │ ├─>/tmp/neomutt-hostname-XXXX-XXXXXX-XXXXXXXXX              [text/plain, 7bit, us-ascii, 0.1K] 
  I     4 │ └─>html-part.html                                          [text/html, 8bit, iso-8859-1, 0.4K] 
  I     5 └─>neomutt-256.png                                                      [image/png, base64, 19K] 
```

## Behaviour at receiving end

| MUA | PGP: Clear | PGP: Signed | PGP: Signed and Encrypted |
|---|:---:|:---:|:---:|
| Gmail (Android) | ✔️ | ✔️ | n/a |
| Gmail (Android, Exchange) | ✔️¹ | ❌² | n/a |
| Gmail (iOS) | ✔️ | ✔️ | n/a |
| Gmail (Web) | ✔️ | ✔️ | n/a |
| Mail App (Windows) | ✔️ | ✔️ | n/a |
| Outlook (Android) | ✔️ | ✔️ | n/a |
| Outlook (Web) | ✔️ | ✔️ | n/a |
| Outlook (iOS) | ✔️ | ✔️ | n/a |
| Outlook (Web) | ✔️ | ✔️ | n/a |
| Outlook (Windows) | ✔️ | ✔️ | n/a |
| Proton (Android) | ✔️ | ❌³ | ❌³ |
| Proton (iOS) | ✔️ | ✔️⁴ | ✔️⁴ |
| Proton (Web) | ✔️ | ✔️ | ✔️ |
| Thunderbird (Linux) | ✔️ | ✔️ | ✔️ |

¹ Also displays embedded image as attachment (but emails from other clients display like this too).
² Embedded image is not displayed and isn't available in attachment list. (Also fails on messages from Thunderbird.)
³ Embedded image is not displayed, but is available in attachment list. (Also fails on messages from Thunderbird.)
⁴ Thinks there is remote content for some reason.

## Notes on constructing emails

- Attachments in the `multipart/related` group should probably have inline disposition. (Microsoft Outlook shows also shows them as a separate attachment if they have disposition attachment, but Gmail doesn't.) So ensure embedded images have the header `Content-Disposition: inline; filename="image.png"`. The attachment needs to be given a `d_filename` (with `<rename-attachment>`) for the `filename` field to be included.
- Actual attachments should be placed outside of the `multipart/related` group.