### PR TITLE
hcache-bench: adjust README.md linebreaks

### DIFF
--- a/contrib/hcache-bench/README.md
+++ b/contrib/hcache-bench/README.md
@@ -9,8 +9,8 @@ benchmark the NeoMutt hcache backends.
 
 In order to run the benchmark, you must have a directory in maildir format at
 hand. NeoMutt will load messages from there and populate the header cache with
-them. Please note that you'll need a reasonable large number of messages - >50k
-- to see anything interesting.
+them. Please note that you'll need a reasonable large number of messages -
+over 50,000 - to see anything interesting.
 
 ## Running the benchmark
 


### PR DESCRIPTION
Some Markdown implementations (e.g. the GitHub one, as can be seen at [0]) can treat a line starting with `-` as a list item.  Move a line break to avoid that happening unnecessarily.

[0]: https://github.com/neomutt/neomutt/blob/1ce876f0c2935832ed6a2c11ff85dd5708f11daa/contrib/hcache-bench/README.md