### PR TITLE
Fix issue 1590

### DIFF
--- a/main.c
+++ b/main.c
@@ -1188,9 +1188,7 @@ main
 
     if (edit_infile)
     {
-      if (include_file)
-        e->body->unlink = false;
-      else if (draft_file)
+      if (draft_file)
       {
         if (truncate(mutt_buffer_string(&expanded_infile), 0) == -1)
         {

--- a/send/send.c
+++ b/send/send.c
@@ -2305,6 +2305,8 @@ int mutt_send_message(SendFlags flags, struct Email *e_templ, const char *tempfi
       {
         fp_tmp = mutt_file_fopen(tempfile, "a+");
         e_templ->body->filename = mutt_str_dup(tempfile);
+        if (flags & SEND_NO_FREE_HEADER)
+          e_templ->body->unlink = false;
       }
       else
       {


### PR DESCRIPTION
## What does this PR do?

When the `-E` flag is passed along with `-i filename` to Neomutt, `filename` should not be deleted.

Neomutt does this by setting `email->body->unlink = false` just before it frees `email`. However this is too late as by that time, the body may have moved from the fundamental part (either by grouping it or explicitly moving it). If this happens `filename` will be deleted and the new `email->body` will remain on disk.

This PR sets `body->unlink = false` for `filename` as soon as it's created and does not change `email->body->unlink` just before freeing the `email`.

## Relevant issue numbers

This fixes issue #1590.