### PR TITLE
fix crash when forwarding attachments

### DIFF
--- a/mutt_body.c
+++ b/mutt_body.c
@@ -96,11 +96,16 @@ int mutt_body_copy(FILE *fp, struct Body **tgt, struct Body *src)
     b->d_filename = mutt_str_dup(src->filename);
   b->description = mutt_str_dup(b->description);
 
+  b->language = mutt_str_dup(b->language);
+  b->charset = mutt_str_dup(b->charset);
+
+  b->content = NULL;
+  b->aptr = NULL;
+  b->mime_headers = NULL;
+
   /* we don't seem to need the Email structure currently.
    * XXX this may change in the future */
-
-  if (b->email)
-    b->email = NULL;
+  b->email = NULL;
 
   /* copy parameters */
   struct Parameter *np = NULL, *new_param = NULL;


### PR DESCRIPTION
To forward an attachment, NeoMutt makes a copy of the `Body`.
Unfortunately, `mutt_body_copy()` uses `memcpy()` which duplicates pointers too.
When the email is sent, the `Body` is freed, leaving dangling pointers in the original `Body`.

Ensure that all heap-allocated objects are duplicated, or their pointers are set to `NULL`.

Fixes: #3215

---

**Steps to reproduce**:
- Index: select an email with attachments
- <kbd>v</kbd> (`<view-attachments>`)
- Select an attachment
- <kbd>f</kbd> (`<forward-message>`)
- Hit <kbd>\<Enter\></kbd> at the prompt (cancel the sending)
- <kbd>q</kbd> (`<exit>`) quit the attachment view
- <kbd>q</kbd> (`<exit>`) quit NeoMutt
- Crash - heap-use-after-free