### PR TITLE
Avoid infinite loop in OptNoCurses mode

### DIFF
--- a/gui/curs_lib.c
+++ b/gui/curs_lib.c
@@ -225,14 +225,16 @@ struct KeyEvent mutt_getch(void)
     return err;
   }
 
-  /* either timeout, a sigwinch (if timeout is set), or the terminal
-   * has been lost */
+  /* either timeout, a sigwinch (if timeout is set), the terminal
+   * has been lost, or curses was never initialized */
   if (ch == ERR)
   {
     if (!isatty(0))
+    {
       mutt_exit(1);
+    }
 
-    return timeout;
+    return OptNoCurses ? err : timeout;
   }
 
   const bool c_meta_key = cs_subset_bool(NeoMutt->sub, "meta_key");


### PR DESCRIPTION
A call to getch() in OptNoCurses mode will return -1. We need to differentiate it from a regular timeout, or the caller will re-enter infinitely. This prevents NeoMutt from hanging e.g., on a certificate verification dialog when running with -Q varname.