### PR TITLE
Support for inserting attachments

### DIFF
--- a/compose/functions.c
+++ b/compose/functions.c
@@ -732,6 +732,15 @@ static int op_attachment_attach_file_after(struct ComposeSharedData *shared, int
                               menu_get_index(shared->adata->menu), true);
 }
 
+/*
+ * op_attachment_attach_file_before - Attach files before current entry to this message - Implements ::compose_function_t - @ingroup compose_function_api
+ */
+static int op_attachment_attach_file_before(struct ComposeSharedData *shared, int op)
+{
+  return compose_attach_files(shared, _("Attach file before current entry"),
+                              menu_get_index(shared->adata->menu), false);
+}
+
 /**
  * op_attachment_attach_key - Attach a PGP public key - Implements ::compose_function_t - @ingroup compose_function_api
  */
@@ -2000,6 +2009,7 @@ struct ComposeFunction ComposeFunctions[] = {
   // clang-format off
   { OP_ATTACHMENT_ATTACH_FILE,            op_attachment_attach_file },
   { OP_ATTACHMENT_ATTACH_FILE_AFTER,      op_attachment_attach_file_after },
+  { OP_ATTACHMENT_ATTACH_FILE_BEFORE,     op_attachment_attach_file_before },
   { OP_ATTACHMENT_ATTACH_KEY,             op_attachment_attach_key },
   { OP_ATTACHMENT_ATTACH_MESSAGE,         op_attachment_attach_message },
   { OP_ATTACHMENT_ATTACH_NEWS_MESSAGE,    op_attachment_attach_message },

--- a/compose/functions.c
+++ b/compose/functions.c
@@ -1554,6 +1554,15 @@ static int op_attachment_new_mime_after(struct ComposeSharedData *shared, int op
                           menu_get_index(shared->adata->menu), true);
 }
 
+/*
+ * op_attachment_new_mime_before - Compose new attachment using mailcap entry - Implements ::compose_function_t - @ingroup compose_function_api
+ */
+static int op_attachment_new_mime_before(struct ComposeSharedData *shared, int op)
+{
+  return compose_new_mime(shared, _("New file to insert before: "),
+                          menu_get_index(shared->adata->menu), false);
+}
+
 /**
  * op_attachment_print - Print the current entry - Implements ::compose_function_t - @ingroup compose_function_api
  */
@@ -2110,6 +2119,7 @@ struct ComposeFunction ComposeFunctions[] = {
   { OP_ATTACHMENT_MOVE_UP,                op_attachment_move_up },
   { OP_ATTACHMENT_NEW_MIME,               op_attachment_new_mime },
   { OP_ATTACHMENT_NEW_MIME_AFTER,         op_attachment_new_mime_after },
+  { OP_ATTACHMENT_NEW_MIME_BEFORE,        op_attachment_new_mime_before },
   { OP_PIPE,                              op_attachment_filter },
   { OP_ATTACHMENT_PRINT,                  op_attachment_print },
   { OP_ATTACHMENT_RENAME_ATTACHMENT,      op_attachment_rename_attachment },

--- a/compose/functions.c
+++ b/compose/functions.c
@@ -724,6 +724,15 @@ static int op_attachment_attach_file(struct ComposeSharedData *shared, int op)
 }
 
 /**
+ * op_attachment_attach_file_after - Attach files after current entry to this message - Implements ::compose_function_t - @ingroup compose_function_api
+ */
+static int op_attachment_attach_file_after(struct ComposeSharedData *shared, int op)
+{
+  return compose_attach_files(shared, _("Attach file after current entry"),
+                              menu_get_index(shared->adata->menu), true);
+}
+
+/**
  * op_attachment_attach_key - Attach a PGP public key - Implements ::compose_function_t - @ingroup compose_function_api
  */
 static int op_attachment_attach_key(struct ComposeSharedData *shared, int op)
@@ -1990,6 +1999,7 @@ static int op_forget_passphrase(struct ComposeSharedData *shared, int op)
 struct ComposeFunction ComposeFunctions[] = {
   // clang-format off
   { OP_ATTACHMENT_ATTACH_FILE,            op_attachment_attach_file },
+  { OP_ATTACHMENT_ATTACH_FILE_AFTER,      op_attachment_attach_file_after },
   { OP_ATTACHMENT_ATTACH_KEY,             op_attachment_attach_key },
   { OP_ATTACHMENT_ATTACH_MESSAGE,         op_attachment_attach_message },
   { OP_ATTACHMENT_ATTACH_NEWS_MESSAGE,    op_attachment_attach_message },

--- a/compose/functions.c
+++ b/compose/functions.c
@@ -1546,6 +1546,15 @@ static int op_attachment_new_mime(struct ComposeSharedData *shared, int op)
 }
 
 /**
+ * op_attachment_new_mime_after - Insert new attachment using mailcap entry after current entry - Implements ::compose_function_t - @ingroup compose_function_api
+ */
+static int op_attachment_new_mime_after(struct ComposeSharedData *shared, int op)
+{
+  return compose_new_mime(shared, _("New file to insert after: "),
+                          menu_get_index(shared->adata->menu), true);
+}
+
+/**
  * op_attachment_print - Print the current entry - Implements ::compose_function_t - @ingroup compose_function_api
  */
 static int op_attachment_print(struct ComposeSharedData *shared, int op)
@@ -2100,6 +2109,7 @@ struct ComposeFunction ComposeFunctions[] = {
   { OP_ATTACHMENT_MOVE_DOWN,              op_attachment_move_down },
   { OP_ATTACHMENT_MOVE_UP,                op_attachment_move_up },
   { OP_ATTACHMENT_NEW_MIME,               op_attachment_new_mime },
+  { OP_ATTACHMENT_NEW_MIME_AFTER,         op_attachment_new_mime_after },
   { OP_PIPE,                              op_attachment_filter },
   { OP_ATTACHMENT_PRINT,                  op_attachment_print },
   { OP_ATTACHMENT_RENAME_ATTACHMENT,      op_attachment_rename_attachment },

--- a/functions.c
+++ b/functions.c
@@ -177,6 +177,7 @@ const struct MenuFuncOp OpBrowser[] = { /* map: browser */
 const struct MenuFuncOp OpCompose[] = { /* map: compose */
   { "attach-file",                   OP_ATTACHMENT_ATTACH_FILE },
   { "attach-file-after",             OP_ATTACHMENT_ATTACH_FILE_AFTER },
+  { "attach-file-before",            OP_ATTACHMENT_ATTACH_FILE_BEFORE },
   { "attach-key",                    OP_ATTACHMENT_ATTACH_KEY },
   { "attach-message",                OP_ATTACHMENT_ATTACH_MESSAGE },
 #ifdef USE_NNTP
@@ -845,6 +846,7 @@ const struct MenuOpSeq BrowserDefaultBindings[] = { /* map: browser */
 const struct MenuOpSeq ComposeDefaultBindings[] = { /* map: compose */
   { OP_ATTACHMENT_ATTACH_FILE,             "a" },
   { OP_ATTACHMENT_ATTACH_FILE_AFTER,       "\033a" },          // <Alt-a>
+  { OP_ATTACHMENT_ATTACH_FILE_BEFORE,      "\033b" },          // <Alt-b>
   { OP_ATTACHMENT_ATTACH_KEY,              "\033k" },          // <Alt-k>
   { OP_ATTACHMENT_ATTACH_MESSAGE,          "A" },
   { OP_ATTACHMENT_DETACH,                  "D" },

--- a/functions.c
+++ b/functions.c
@@ -176,6 +176,7 @@ const struct MenuFuncOp OpBrowser[] = { /* map: browser */
  */
 const struct MenuFuncOp OpCompose[] = { /* map: compose */
   { "attach-file",                   OP_ATTACHMENT_ATTACH_FILE },
+  { "attach-file-after",             OP_ATTACHMENT_ATTACH_FILE_AFTER },
   { "attach-key",                    OP_ATTACHMENT_ATTACH_KEY },
   { "attach-message",                OP_ATTACHMENT_ATTACH_MESSAGE },
 #ifdef USE_NNTP
@@ -843,6 +844,7 @@ const struct MenuOpSeq BrowserDefaultBindings[] = { /* map: browser */
  */
 const struct MenuOpSeq ComposeDefaultBindings[] = { /* map: compose */
   { OP_ATTACHMENT_ATTACH_FILE,             "a" },
+  { OP_ATTACHMENT_ATTACH_FILE_AFTER,       "\033a" },          // <Alt-a>
   { OP_ATTACHMENT_ATTACH_KEY,              "\033k" },          // <Alt-k>
   { OP_ATTACHMENT_ATTACH_MESSAGE,          "A" },
   { OP_ATTACHMENT_DETACH,                  "D" },

--- a/functions.c
+++ b/functions.c
@@ -229,6 +229,7 @@ const struct MenuFuncOp OpCompose[] = { /* map: compose */
   { "move-up",                       OP_ATTACHMENT_MOVE_UP },
   { "new-mime",                      OP_ATTACHMENT_NEW_MIME },
   { "new-mime-after",                OP_ATTACHMENT_NEW_MIME_AFTER },
+  { "new-mime-before",               OP_ATTACHMENT_NEW_MIME_BEFORE },
   { "pgp-menu",                      OP_COMPOSE_PGP_MENU },
   { "pipe-entry",                    OP_PIPE },
   { "pipe-message",                  OP_PIPE },
@@ -866,6 +867,7 @@ const struct MenuOpSeq ComposeDefaultBindings[] = { /* map: compose */
   { OP_ATTACHMENT_MOVE_UP,                 "-" },
   { OP_ATTACHMENT_NEW_MIME,                "n" },
   { OP_ATTACHMENT_NEW_MIME_AFTER,          "\033A" },          // <Alt-A>
+  { OP_ATTACHMENT_NEW_MIME_BEFORE,         "\033B" },          // <Alt-B>
   { OP_EXIT,                               "q" },
   { OP_PIPE,                               "|" },
   { OP_ATTACHMENT_PRINT,                   "l" },

--- a/functions.c
+++ b/functions.c
@@ -228,6 +228,7 @@ const struct MenuFuncOp OpCompose[] = { /* map: compose */
   { "move-down",                     OP_ATTACHMENT_MOVE_DOWN },
   { "move-up",                       OP_ATTACHMENT_MOVE_UP },
   { "new-mime",                      OP_ATTACHMENT_NEW_MIME },
+  { "new-mime-after",                OP_ATTACHMENT_NEW_MIME_AFTER },
   { "pgp-menu",                      OP_COMPOSE_PGP_MENU },
   { "pipe-entry",                    OP_PIPE },
   { "pipe-message",                  OP_PIPE },
@@ -864,6 +865,7 @@ const struct MenuOpSeq ComposeDefaultBindings[] = { /* map: compose */
   { OP_ATTACHMENT_MOVE_DOWN,               "+" },
   { OP_ATTACHMENT_MOVE_UP,                 "-" },
   { OP_ATTACHMENT_NEW_MIME,                "n" },
+  { OP_ATTACHMENT_NEW_MIME_AFTER,          "\033A" },          // <Alt-A>
   { OP_EXIT,                               "q" },
   { OP_PIPE,                               "|" },
   { OP_ATTACHMENT_PRINT,                   "l" },

--- a/opcodes.h
+++ b/opcodes.h
@@ -57,6 +57,7 @@ const char *opcodes_get_name       (int op);
   _fmt(OP_ATTACHMENT_MOVE_UP,                 N_("move an attachment up in the attachment list")) \
   _fmt(OP_ATTACHMENT_NEW_MIME,                N_("compose new attachment using mailcap entry")) \
   _fmt(OP_ATTACHMENT_NEW_MIME_AFTER,          N_("insert new attachment using mailcap entry after current entry")) \
+  _fmt(OP_ATTACHMENT_NEW_MIME_BEFORE,         N_("insert new attachment using mailcap entry before current entry")) \
   _fmt(OP_ATTACHMENT_PIPE,                    N_("pipe message/attachment to a shell command")) \
   _fmt(OP_ATTACHMENT_PRINT,                   N_("print the current entry")) \
   _fmt(OP_ATTACHMENT_RENAME_ATTACHMENT,       N_("send attachment with a different name")) \

--- a/opcodes.h
+++ b/opcodes.h
@@ -35,6 +35,7 @@ const char *opcodes_get_name       (int op);
 // clang-format off
 #define OPS_ATTACHMENT(_fmt) \
   _fmt(OP_ATTACHMENT_ATTACH_FILE,             N_("attach files to this message")) \
+  _fmt(OP_ATTACHMENT_ATTACH_FILE_AFTER,       N_("attach files after current entry")) \
   _fmt(OP_ATTACHMENT_ATTACH_MESSAGE,          N_("attach messages to this message")) \
   _fmt(OP_ATTACHMENT_ATTACH_NEWS_MESSAGE,     N_("attach news articles to this message")) \
   _fmt(OP_ATTACHMENT_COLLAPSE,                N_("toggle display of subparts")) \

--- a/opcodes.h
+++ b/opcodes.h
@@ -36,6 +36,7 @@ const char *opcodes_get_name       (int op);
 #define OPS_ATTACHMENT(_fmt) \
   _fmt(OP_ATTACHMENT_ATTACH_FILE,             N_("attach files to this message")) \
   _fmt(OP_ATTACHMENT_ATTACH_FILE_AFTER,       N_("attach files after current entry")) \
+  _fmt(OP_ATTACHMENT_ATTACH_FILE_BEFORE,      N_("attach files before current entry")) \
   _fmt(OP_ATTACHMENT_ATTACH_MESSAGE,          N_("attach messages to this message")) \
   _fmt(OP_ATTACHMENT_ATTACH_NEWS_MESSAGE,     N_("attach news articles to this message")) \
   _fmt(OP_ATTACHMENT_COLLAPSE,                N_("toggle display of subparts")) \

--- a/opcodes.h
+++ b/opcodes.h
@@ -56,6 +56,7 @@ const char *opcodes_get_name       (int op);
   _fmt(OP_ATTACHMENT_MOVE_DOWN,               N_("move an attachment down in the attachment list")) \
   _fmt(OP_ATTACHMENT_MOVE_UP,                 N_("move an attachment up in the attachment list")) \
   _fmt(OP_ATTACHMENT_NEW_MIME,                N_("compose new attachment using mailcap entry")) \
+  _fmt(OP_ATTACHMENT_NEW_MIME_AFTER,          N_("insert new attachment using mailcap entry after current entry")) \
   _fmt(OP_ATTACHMENT_PIPE,                    N_("pipe message/attachment to a shell command")) \
   _fmt(OP_ATTACHMENT_PRINT,                   N_("print the current entry")) \
   _fmt(OP_ATTACHMENT_RENAME_ATTACHMENT,       N_("send attachment with a different name")) \


### PR DESCRIPTION
## What does this PR do?

Add support for inserting attachments before and after the currently selected one.

- [x] attaching existing files before and after the current entry.

  - `<attach-file-after>` (Alt+a) command
  - `<attach-file-before>` (Alt+b) command

- [x] creating new files positioned before and after the current entry.

  - `<mime-new-after>` (Alt+A) command
  - `<mime-new-before>` (Alt+B) command

## Discussion

When attaching multiple files, order is reversed to match with `<attach-file>`.