### PR TITLE
fix screen mode after attempting decryption

### DIFF
--- a/gui/curs_lib.c
+++ b/gui/curs_lib.c
@@ -135,6 +135,10 @@ void mutt_refresh(void)
  */
 void mutt_need_hard_redraw(void)
 {
+  // Forcibly switch to the alternate screen.
+  // Using encryption can leave ncurses confused about which mode it's in.
+  fputs("\033[?1049h", stdout);
+  fflush(stdout);
   keypad(stdscr, true);
   clearok(stdscr, true);
   window_redraw(NULL);


### PR DESCRIPTION
When decrypting an email, gpg can change the screen mode.
This can confuse ncurses, causing it to write to the "normal", rather than the "alternate" screen.

Forcibly switch to the alternate screen after gpg operations.

Fixes: #3217