### PR TITLE
Refactor Sidebar Functions

### DIFF
--- a/index/dlg_index.c
+++ b/index/dlg_index.c
@@ -1428,3 +1428,28 @@ struct MuttWindow *index_pager_init(void)
 
   return dlg;
 }
+
+/**
+ * dlg_change_folder - Change the current folder, cautiously
+ * @param dlg Dialog holding the Index
+ * @param m   Mailbox to change to
+ */
+void dlg_change_folder(struct MuttWindow *dlg, struct Mailbox *m)
+{
+  if (!dlg || !m)
+    return;
+
+  struct IndexSharedData *shared = dlg->wdata;
+  if (!shared)
+    return;
+
+  struct MuttWindow *panel_index = window_find_child(dlg, WT_INDEX);
+  if (!panel_index)
+    return;
+
+  struct IndexPrivateData *priv = panel_index->wdata;
+  if (!priv)
+    return;
+
+  change_folder_mailbox(priv->menu, m, &priv->oldcount, shared, false);
+}

--- a/index/dlg_index.c
+++ b/index/dlg_index.c
@@ -97,6 +97,9 @@
 #ifdef USE_INOTIFY
 #include "monitor.h"
 #endif
+#ifdef USE_SIDEBAR
+#include "sidebar/lib.h"
+#endif
 
 /// Help Bar for the Index dialog
 static const struct Mapping IndexHelp[] = {
@@ -1339,6 +1342,14 @@ struct Mailbox *mutt_index_menu(struct MuttWindow *dlg, struct Mailbox *m_init)
 #endif
 
     int rc = index_function_dispatcher(priv->win_index, op);
+
+#ifdef USE_SIDEBAR
+    if (rc == IR_UNKNOWN)
+    {
+      struct MuttWindow *win_sidebar = window_find_child(dlg, WT_SIDEBAR);
+      rc = sb_function_dispatcher(win_sidebar, op);
+    }
+#endif
 
     if (rc == IR_CONTINUE)
     {

--- a/index/functions.h
+++ b/index/functions.h
@@ -32,7 +32,7 @@ struct MuttWindow;
  */
 enum IndexRetval
 {
-  IR_UNKNOWN   = -7, ///< Unknown key
+  IR_UNKNOWN   = -7, ///< Unknown function
   IR_CONTINUE  = -6, ///< Return to the Pager
   IR_DONE      = -5, ///< Exit the Index
   IR_NOT_IMPL  = -4, ///< Invalid function - feature not enabled
@@ -40,6 +40,8 @@ enum IndexRetval
   IR_ERROR     = -2, ///< Valid function - error occurred
   IR_SUCCESS   = -1, ///< Valid function - successfully performed
 };
+
+extern const struct Mapping RetvalNames[];
 
 /**
  * @defgroup index_function_api Index Function API

--- a/index/lib.h
+++ b/index/lib.h
@@ -94,5 +94,6 @@ extern const struct Mapping IndexNewsHelp[];
 struct Mailbox *change_folder_notmuch(struct Menu *menu, char *buf, int buflen, int *oldcount, struct IndexSharedData *shared, bool read_only);
 struct Mailbox *get_current_mailbox(void);
 struct Menu *get_current_menu(void);
+void dlg_change_folder(struct MuttWindow *dlg, struct Mailbox *m);
 
 #endif /* MUTT_INDEX_LIB_H */

--- a/pager/dlg_pager.c
+++ b/pager/dlg_pager.c
@@ -64,6 +64,9 @@
 #include "private_data.h"
 #include "protos.h"
 #include "status.h"
+#ifdef USE_SIDEBAR
+#include "sidebar/lib.h"
+#endif
 
 /**
  * struct Resize - Keep track of screen resizing
@@ -832,6 +835,15 @@ int mutt_pager(struct PagerView *pview)
     }
 
     int rc = pager_function_dispatcher(priv->pview->win_pager, op);
+
+#ifdef USE_SIDEBAR
+    if (rc == IR_UNKNOWN)
+    {
+      struct MuttWindow *win_sidebar = window_find_child(dlg, WT_SIDEBAR);
+      rc = sb_function_dispatcher(win_sidebar, op);
+    }
+#endif
+
     if (rc == IR_DONE)
       break;
     if (rc == IR_UNKNOWN)

--- a/sidebar/functions.c
+++ b/sidebar/functions.c
@@ -385,50 +385,11 @@ int sb_function_dispatcher(struct MuttWindow *win, int op)
     }
   }
 
-  return rc;
-}
+  if (rc == IR_UNKNOWN) // Not our function
+    return rc;
 
-/**
- * sb_change_mailbox - Perform a Sidebar function
- * @param win Sidebar Window
- * @param op  Operation to perform, e.g. OP_SIDEBAR_NEXT_NEW
- */
-void sb_change_mailbox(struct MuttWindow *win, int op)
-{
-  struct SidebarWindowData *wdata = sb_wdata_get(win);
-  if (!wdata)
-    return;
+  const char *result = mutt_map_get_name(rc, RetvalNames);
+  mutt_debug(LL_DEBUG1, "Handled %s (%d) -> %s\n", OpStrings[op][0], op, NONULL(result));
 
-  if (wdata->hil_index < 0) /* It'll get reset on the next draw */
-    return;
-
-  switch (op)
-  {
-    case OP_SIDEBAR_FIRST:
-      op_sidebar_first(wdata, op);
-      break;
-    case OP_SIDEBAR_LAST:
-      op_sidebar_last(wdata, op);
-      break;
-    case OP_SIDEBAR_NEXT:
-      op_sidebar_next(wdata, op);
-      break;
-    case OP_SIDEBAR_NEXT_NEW:
-      op_sidebar_next_new(wdata, op);
-      break;
-    case OP_SIDEBAR_PAGE_DOWN:
-      op_sidebar_page_down(wdata, op);
-      break;
-    case OP_SIDEBAR_PAGE_UP:
-      op_sidebar_page_up(wdata, op);
-      break;
-    case OP_SIDEBAR_PREV:
-      op_sidebar_prev(wdata, op);
-      break;
-    case OP_SIDEBAR_PREV_NEW:
-      op_sidebar_prev_new(wdata, op);
-      break;
-    default:
-      return;
-  }
+  return IR_SUCCESS; // Whatever the outcome, we handled it
 }

--- a/sidebar/functions.c
+++ b/sidebar/functions.c
@@ -219,6 +219,20 @@ static int op_sidebar_next_new(struct SidebarWindowData *wdata, int op)
 }
 
 /**
+ * op_sidebar_open - Open highlighted mailbox - Implements ::sidebar_function_t - @ingroup sidebar_function_api
+ */
+int op_sidebar_open(struct SidebarWindowData *wdata, int op)
+{
+  struct MuttWindow *win_sidebar = wdata->win;
+  if (!mutt_window_is_visible(win_sidebar))
+    return IR_NO_ACTION;
+
+  struct MuttWindow *dlg = dialog_find(win_sidebar);
+  dlg_change_folder(dlg, sb_get_highlight(win_sidebar));
+  return IR_SUCCESS;
+}
+
+/**
  * op_sidebar_page_down - Selects the first entry in the next page of mailboxes - Implements ::sidebar_function_t - @ingroup sidebar_function_api
  */
 static int op_sidebar_page_down(struct SidebarWindowData *wdata, int op)
@@ -315,6 +329,16 @@ static int op_sidebar_prev_new(struct SidebarWindowData *wdata, int op)
   }
 
   return IR_NO_ACTION;
+}
+
+/**
+ * op_sidebar_toggle_visible - Make the sidebar (in)visible - Implements ::sidebar_function_t - @ingroup sidebar_function_api
+ */
+int op_sidebar_toggle_visible(struct SidebarWindowData *wdata, int op)
+{
+  // Config notifications will do the rest
+  bool_str_toggle(NeoMutt->sub, "sidebar_visible", NULL);
+  return IR_SUCCESS;
 }
 
 /**

--- a/sidebar/functions.c
+++ b/sidebar/functions.c
@@ -38,14 +38,14 @@
 #include "opcodes.h"
 
 /**
- * next_new - Return the next mailbox with new messages
+ * sb_next_new - Return the next mailbox with new messages
  * @param wdata Sidebar data
  * @param begin Starting index for searching
  * @param end   Ending index for searching
  * @retval ptr  Pointer to the first entry with new messages
  * @retval NULL None could be found
  */
-static struct SbEntry **next_new(struct SidebarWindowData *wdata, size_t begin, size_t end)
+static struct SbEntry **sb_next_new(struct SidebarWindowData *wdata, size_t begin, size_t end)
 {
   struct SbEntry **sbep = NULL;
   ARRAY_FOREACH_FROM_TO(sbep, &wdata->entries, begin, end)
@@ -57,14 +57,14 @@ static struct SbEntry **next_new(struct SidebarWindowData *wdata, size_t begin, 
 }
 
 /**
- * prev_new - Return the previous mailbox with new messages
+ * sb_prev_new - Return the previous mailbox with new messages
  * @param wdata Sidebar data
  * @param begin Starting index for searching
  * @param end   Ending index for searching
  * @retval ptr  Pointer to the first entry with new messages
  * @retval NULL None could be found
  */
-static struct SbEntry **prev_new(struct SidebarWindowData *wdata, size_t begin, size_t end)
+static struct SbEntry **sb_prev_new(struct SidebarWindowData *wdata, size_t begin, size_t end)
 {
   struct SbEntry **sbep = NULL, **prev = NULL;
   ARRAY_FOREACH_FROM_TO(sbep, &wdata->entries, begin, end)
@@ -79,11 +79,11 @@ static struct SbEntry **prev_new(struct SidebarWindowData *wdata, size_t begin, 
 // -----------------------------------------------------------------------------
 
 /**
- * select_first - Selects the first unhidden mailbox
+ * op_sidebar_first - Selects the first unhidden mailbox
  * @param wdata Sidebar data
  * @retval true The selection changed
  */
-static bool select_first(struct SidebarWindowData *wdata)
+static bool op_sidebar_first(struct SidebarWindowData *wdata)
 {
   if (ARRAY_EMPTY(&wdata->entries) || (wdata->hil_index < 0))
     return false;
@@ -92,18 +92,18 @@ static bool select_first(struct SidebarWindowData *wdata)
 
   wdata->hil_index = 0;
   if ((*ARRAY_GET(&wdata->entries, wdata->hil_index))->is_hidden)
-    if (!select_next(wdata))
+    if (!op_sidebar_next(wdata))
       wdata->hil_index = orig_hil_index;
 
   return (orig_hil_index != wdata->hil_index);
 }
 
 /**
- * select_last - Selects the last unhidden mailbox
+ * op_sidebar_last - Selects the last unhidden mailbox
  * @param wdata Sidebar data
  * @retval true The selection changed
  */
-static bool select_last(struct SidebarWindowData *wdata)
+static bool op_sidebar_last(struct SidebarWindowData *wdata)
 {
   if (ARRAY_EMPTY(&wdata->entries) || (wdata->hil_index < 0))
     return false;
@@ -111,18 +111,18 @@ static bool select_last(struct SidebarWindowData *wdata)
   int orig_hil_index = wdata->hil_index;
 
   wdata->hil_index = ARRAY_SIZE(&wdata->entries);
-  if (!select_prev(wdata))
+  if (!op_sidebar_prev(wdata))
     wdata->hil_index = orig_hil_index;
 
   return (orig_hil_index != wdata->hil_index);
 }
 
 /**
- * select_next - Selects the next unhidden mailbox
+ * op_sidebar_next - Selects the next unhidden mailbox
  * @param wdata Sidebar data
  * @retval true The selection changed
  */
-bool select_next(struct SidebarWindowData *wdata)
+bool op_sidebar_next(struct SidebarWindowData *wdata)
 {
   if (ARRAY_EMPTY(&wdata->entries) || (wdata->hil_index < 0))
     return false;
@@ -141,14 +141,14 @@ bool select_next(struct SidebarWindowData *wdata)
 }
 
 /**
- * select_next_new - Selects the next new mailbox
+ * op_sidebar_next_new - Selects the next new mailbox
  * @param wdata         Sidebar data
  * @param next_new_wrap Wrap around when searching for the next mailbox with new mail
  * @retval true The selection changed
  *
  * Search down the list of mail folders for one containing new mail.
  */
-static bool select_next_new(struct SidebarWindowData *wdata, bool next_new_wrap)
+static bool op_sidebar_next_new(struct SidebarWindowData *wdata, bool next_new_wrap)
 {
   const size_t max_entries = ARRAY_SIZE(&wdata->entries);
 
@@ -156,8 +156,8 @@ static bool select_next_new(struct SidebarWindowData *wdata, bool next_new_wrap)
     return false;
 
   struct SbEntry **sbep = NULL;
-  if ((sbep = next_new(wdata, wdata->hil_index + 1, max_entries)) ||
-      (next_new_wrap && (sbep = next_new(wdata, 0, wdata->hil_index))))
+  if ((sbep = sb_next_new(wdata, wdata->hil_index + 1, max_entries)) ||
+      (next_new_wrap && (sbep = sb_next_new(wdata, 0, wdata->hil_index))))
   {
     wdata->hil_index = ARRAY_IDX(&wdata->entries, sbep);
     return true;
@@ -167,11 +167,11 @@ static bool select_next_new(struct SidebarWindowData *wdata, bool next_new_wrap)
 }
 
 /**
- * select_page_down - Selects the first entry in the next page of mailboxes
+ * op_sidebar_page_down - Selects the first entry in the next page of mailboxes
  * @param wdata Sidebar data
  * @retval true The selection changed
  */
-static bool select_page_down(struct SidebarWindowData *wdata)
+static bool op_sidebar_page_down(struct SidebarWindowData *wdata)
 {
   if (ARRAY_EMPTY(&wdata->entries) || (wdata->bot_index < 0))
     return false;
@@ -179,20 +179,20 @@ static bool select_page_down(struct SidebarWindowData *wdata)
   int orig_hil_index = wdata->hil_index;
 
   wdata->hil_index = wdata->bot_index;
-  select_next(wdata);
+  op_sidebar_next(wdata);
   /* If the rest of the entries are hidden, go up to the last unhidden one */
   if ((*ARRAY_GET(&wdata->entries, wdata->hil_index))->is_hidden)
-    select_prev(wdata);
+    op_sidebar_prev(wdata);
 
   return (orig_hil_index != wdata->hil_index);
 }
 
 /**
- * select_page_up - Selects the last entry in the previous page of mailboxes
+ * op_sidebar_page_up - Selects the last entry in the previous page of mailboxes
  * @param wdata Sidebar data
  * @retval true The selection changed
  */
-static bool select_page_up(struct SidebarWindowData *wdata)
+static bool op_sidebar_page_up(struct SidebarWindowData *wdata)
 {
   if (ARRAY_EMPTY(&wdata->entries) || (wdata->top_index < 0))
     return false;
@@ -200,20 +200,20 @@ static bool select_page_up(struct SidebarWindowData *wdata)
   int orig_hil_index = wdata->hil_index;
 
   wdata->hil_index = wdata->top_index;
-  select_prev(wdata);
+  op_sidebar_prev(wdata);
   /* If the rest of the entries are hidden, go down to the last unhidden one */
   if ((*ARRAY_GET(&wdata->entries, wdata->hil_index))->is_hidden)
-    select_next(wdata);
+    op_sidebar_next(wdata);
 
   return (orig_hil_index != wdata->hil_index);
 }
 
 /**
- * select_prev - Selects the previous unhidden mailbox
+ * op_sidebar_prev - Selects the previous unhidden mailbox
  * @param wdata Sidebar data
  * @retval true The selection changed
  */
-bool select_prev(struct SidebarWindowData *wdata)
+bool op_sidebar_prev(struct SidebarWindowData *wdata)
 {
   if (ARRAY_EMPTY(&wdata->entries) || (wdata->hil_index < 0))
     return false;
@@ -235,14 +235,14 @@ bool select_prev(struct SidebarWindowData *wdata)
 }
 
 /**
- * select_prev_new - Selects the previous new mailbox
+ * op_sidebar_prev_new - Selects the previous new mailbox
  * @param wdata         Sidebar data
  * @param next_new_wrap Wrap around when searching for the next mailbox with new mail
  * @retval true The selection changed
  *
  * Search up the list of mail folders for one containing new mail.
  */
-static bool select_prev_new(struct SidebarWindowData *wdata, bool next_new_wrap)
+static bool op_sidebar_prev_new(struct SidebarWindowData *wdata, bool next_new_wrap)
 {
   const size_t max_entries = ARRAY_SIZE(&wdata->entries);
 
@@ -250,8 +250,8 @@ static bool select_prev_new(struct SidebarWindowData *wdata, bool next_new_wrap)
     return false;
 
   struct SbEntry **sbep = NULL;
-  if ((sbep = prev_new(wdata, 0, wdata->hil_index)) ||
-      (next_new_wrap && (sbep = prev_new(wdata, wdata->hil_index + 1, max_entries))))
+  if ((sbep = sb_prev_new(wdata, 0, wdata->hil_index)) ||
+      (next_new_wrap && (sbep = sb_prev_new(wdata, wdata->hil_index + 1, max_entries))))
   {
     wdata->hil_index = ARRAY_IDX(&wdata->entries, sbep);
     return true;
@@ -283,28 +283,28 @@ void sb_change_mailbox(struct MuttWindow *win, int op)
   switch (op)
   {
     case OP_SIDEBAR_FIRST:
-      changed = select_first(wdata);
+      changed = op_sidebar_first(wdata);
       break;
     case OP_SIDEBAR_LAST:
-      changed = select_last(wdata);
+      changed = op_sidebar_last(wdata);
       break;
     case OP_SIDEBAR_NEXT:
-      changed = select_next(wdata);
+      changed = op_sidebar_next(wdata);
       break;
     case OP_SIDEBAR_NEXT_NEW:
-      changed = select_next_new(wdata, c_sidebar_next_new_wrap);
+      changed = op_sidebar_next_new(wdata, c_sidebar_next_new_wrap);
       break;
     case OP_SIDEBAR_PAGE_DOWN:
-      changed = select_page_down(wdata);
+      changed = op_sidebar_page_down(wdata);
       break;
     case OP_SIDEBAR_PAGE_UP:
-      changed = select_page_up(wdata);
+      changed = op_sidebar_page_up(wdata);
       break;
     case OP_SIDEBAR_PREV:
-      changed = select_prev(wdata);
+      changed = op_sidebar_prev(wdata);
       break;
     case OP_SIDEBAR_PREV_NEW:
-      changed = select_prev_new(wdata, c_sidebar_next_new_wrap);
+      changed = op_sidebar_prev_new(wdata, c_sidebar_next_new_wrap);
       break;
     default:
       return;

--- a/sidebar/functions.h
+++ b/sidebar/functions.h
@@ -1,0 +1,52 @@
+/**
+ * @file
+ * Sidebar functions
+ *
+ * @authors
+ * Copyright (C) 2022 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MUTT_SIDEBAR_FUNCTIONS_H
+#define MUTT_SIDEBAR_FUNCTIONS_H
+
+#include <stdbool.h>
+
+struct SidebarWindowData;
+
+/**
+ * @defgroup sidebar_function_api Sidebar Function API
+ *
+ * Prototype for a Sidebar Function
+ *
+ * @param wdata  Sidebar Window data
+ * @param op     Operation to perform, e.g. OP_SIDEBAR_NEXT
+ * @retval enum #IndexRetval
+ */
+typedef int (*sidebar_function_t)(struct SidebarWindowData *wdata, int op);
+
+/**
+ * struct SidebarFunction - A NeoMutt function
+ */
+struct SidebarFunction
+{
+  int op;                      ///< Op code, e.g. OP_SIDEBAR_NEXT
+  sidebar_function_t function; ///< Function to call
+};
+
+extern struct SidebarFunction SidebarFunctions[];
+
+#endif /* MUTT_SIDEBAR_FUNCTIONS_H */

--- a/sidebar/lib.h
+++ b/sidebar/lib.h
@@ -58,4 +58,6 @@ struct Mailbox *sb_get_highlight (struct MuttWindow *win);
 enum CommandResult sb_parse_unwhitelist(struct Buffer *buf, struct Buffer *s, intptr_t data, struct Buffer *err);
 enum CommandResult sb_parse_whitelist  (struct Buffer *buf, struct Buffer *s, intptr_t data, struct Buffer *err);
 
+int sb_function_dispatcher(struct MuttWindow *win_sidebar, int op);
+
 #endif /* MUTT_SIDEBAR_LIB_H */

--- a/sidebar/lib.h
+++ b/sidebar/lib.h
@@ -42,21 +42,10 @@
 #ifndef MUTT_SIDEBAR_LIB_H
 #define MUTT_SIDEBAR_LIB_H
 
-#include <stdbool.h>
-#include <stdint.h>
-#include "core/lib.h"
-
-struct Buffer;
 struct MuttWindow;
 
 void sb_init    (void);
 void sb_shutdown(void);
-
-void            sb_change_mailbox(struct MuttWindow *win, int op);
-struct Mailbox *sb_get_highlight (struct MuttWindow *win);
-
-enum CommandResult sb_parse_unwhitelist(struct Buffer *buf, struct Buffer *s, intptr_t data, struct Buffer *err);
-enum CommandResult sb_parse_whitelist  (struct Buffer *buf, struct Buffer *s, intptr_t data, struct Buffer *err);
 
 int sb_function_dispatcher(struct MuttWindow *win_sidebar, int op);
 

--- a/sidebar/observer.c
+++ b/sidebar/observer.c
@@ -127,7 +127,7 @@ static struct MuttWindow *sb_win_init(struct MuttWindow *dlg)
   win_sidebar->state.visible = c_sidebar_visible && (c_sidebar_width > 0);
 
   struct IndexSharedData *shared = dlg->wdata;
-  win_sidebar->wdata = sb_wdata_new(shared);
+  win_sidebar->wdata = sb_wdata_new(win_sidebar, shared);
   win_sidebar->wdata_free = sb_wdata_free;
 
   calc_divider(win_sidebar->wdata);

--- a/sidebar/private.h
+++ b/sidebar/private.h
@@ -82,8 +82,8 @@ void sb_remove_mailbox     (struct SidebarWindowData *wdata, struct Mailbox *m);
 void sb_set_current_mailbox(struct SidebarWindowData *wdata, struct Mailbox *m);
 
 // functions.c
-bool op_sidebar_next(struct SidebarWindowData *wdata);
-bool op_sidebar_prev(struct SidebarWindowData *wdata);
+bool sb_next(struct SidebarWindowData *wdata);
+bool sb_prev(struct SidebarWindowData *wdata);
 
 // observer.c
 int sb_insertion_window_observer(struct NotifyCallback *nc);

--- a/sidebar/private.h
+++ b/sidebar/private.h
@@ -82,8 +82,8 @@ void sb_remove_mailbox     (struct SidebarWindowData *wdata, struct Mailbox *m);
 void sb_set_current_mailbox(struct SidebarWindowData *wdata, struct Mailbox *m);
 
 // functions.c
-bool select_next(struct SidebarWindowData *wdata);
-bool select_prev(struct SidebarWindowData *wdata);
+bool op_sidebar_next(struct SidebarWindowData *wdata);
+bool op_sidebar_prev(struct SidebarWindowData *wdata);
 
 // observer.c
 int sb_insertion_window_observer(struct NotifyCallback *nc);

--- a/sidebar/private.h
+++ b/sidebar/private.h
@@ -81,6 +81,11 @@ struct SidebarWindowData
 void sb_add_mailbox        (struct SidebarWindowData *wdata, struct Mailbox *m);
 void sb_remove_mailbox     (struct SidebarWindowData *wdata, struct Mailbox *m);
 void sb_set_current_mailbox(struct SidebarWindowData *wdata, struct Mailbox *m);
+struct Mailbox *sb_get_highlight(struct MuttWindow *win);
+
+// commands.c
+enum CommandResult sb_parse_unwhitelist(struct Buffer *buf, struct Buffer *s, intptr_t data, struct Buffer *err);
+enum CommandResult sb_parse_whitelist  (struct Buffer *buf, struct Buffer *s, intptr_t data, struct Buffer *err);
 
 // functions.c
 bool sb_next(struct SidebarWindowData *wdata);

--- a/sidebar/private.h
+++ b/sidebar/private.h
@@ -63,6 +63,7 @@ enum DivType
  */
 struct SidebarWindowData
 {
+  struct MuttWindow *win;                 ///< Sidebar Window
   struct IndexSharedData *shared;         ///< Shared Index Data
   struct SbEntryArray entries;            ///< Items to display in the sidebar
 
@@ -95,7 +96,7 @@ void sb_sort_entries(struct SidebarWindowData *wdata, enum SortType sort);
 // wdata.c
 void                      sb_wdata_free(struct MuttWindow *win, void **ptr);
 struct SidebarWindowData *sb_wdata_get(struct MuttWindow *win);
-struct SidebarWindowData *sb_wdata_new(struct IndexSharedData *shared);
+struct SidebarWindowData *sb_wdata_new(struct MuttWindow *win, struct IndexSharedData *shared);
 
 // window.c
 int sb_recalc(struct MuttWindow *win);

--- a/sidebar/sidebar.c
+++ b/sidebar/sidebar.c
@@ -148,14 +148,13 @@ void sb_remove_mailbox(struct SidebarWindowData *wdata, struct Mailbox *m)
       if (!sbep_cur)
       {
         // The last entry was deleted, so backtrack
-        op_sidebar_prev(wdata);
+        sb_prev(wdata);
       }
       else if ((*sbep)->is_hidden)
       {
         // Find the next unhidden entry, or the previous
-        if (!op_sidebar_next(wdata))
-          if (!op_sidebar_prev(wdata))
-            wdata->hil_index = -1;
+        if (!sb_next(wdata) && !sb_prev(wdata))
+          wdata->hil_index = -1;
       }
     }
     else if ((wdata->hil_index > 0) && (wdata->hil_index > ARRAY_FOREACH_IDX))

--- a/sidebar/sidebar.c
+++ b/sidebar/sidebar.c
@@ -148,13 +148,13 @@ void sb_remove_mailbox(struct SidebarWindowData *wdata, struct Mailbox *m)
       if (!sbep_cur)
       {
         // The last entry was deleted, so backtrack
-        select_prev(wdata);
+        op_sidebar_prev(wdata);
       }
       else if ((*sbep)->is_hidden)
       {
         // Find the next unhidden entry, or the previous
-        if (!select_next(wdata))
-          if (!select_prev(wdata))
+        if (!op_sidebar_next(wdata))
+          if (!op_sidebar_prev(wdata))
             wdata->hil_index = -1;
       }
     }

--- a/sidebar/wdata.c
+++ b/sidebar/wdata.c
@@ -36,11 +36,14 @@ struct IndexSharedData;
 
 /**
  * sb_wdata_new - Create new Window data for the Sidebar
+ * @param win    Sidebar Window
+ * @param shared Index shared data
  * @retval ptr New Window data
  */
-struct SidebarWindowData *sb_wdata_new(struct IndexSharedData *shared)
+struct SidebarWindowData *sb_wdata_new(struct MuttWindow *win, struct IndexSharedData *shared)
 {
   struct SidebarWindowData *wdata = mutt_mem_calloc(1, sizeof(struct SidebarWindowData));
+  wdata->win = win;
   wdata->shared = shared;
   ARRAY_INIT(&wdata->entries);
   return wdata;

--- a/sidebar/window.c
+++ b/sidebar/window.c
@@ -649,7 +649,7 @@ static bool prepare_sidebar(struct SidebarWindowData *wdata, int page_size)
     {
       wdata->hil_index = 0;
       /* Note is_hidden will only be set when `$sidebar_new_mail_only` */
-      if ((*ARRAY_GET(&wdata->entries, 0))->is_hidden && !op_sidebar_next(wdata))
+      if ((*ARRAY_GET(&wdata->entries, 0))->is_hidden && !sb_next(wdata))
         wdata->hil_index = -1;
     }
   }

--- a/sidebar/window.c
+++ b/sidebar/window.c
@@ -649,7 +649,7 @@ static bool prepare_sidebar(struct SidebarWindowData *wdata, int page_size)
     {
       wdata->hil_index = 0;
       /* Note is_hidden will only be set when `$sidebar_new_mail_only` */
-      if ((*ARRAY_GET(&wdata->entries, 0))->is_hidden && !select_next(wdata))
+      if ((*ARRAY_GET(&wdata->entries, 0))->is_hidden && !op_sidebar_next(wdata))
         wdata->hil_index = -1;
     }
   }


### PR DESCRIPTION
In the beginning, the Index and Pager had to handle all the sidebar function in a big `switch`.
Next came the separate op functions -- better but still lots of duplication.

This PR creates a Sidebar-specific function dispatcher.
Now, the Index and Pager are _almost_ unaware of the Sidebar.

- 694a76159 sidebar: reorder functions
- 669f5a5d4 sidebar: rename functions
- b808899be sidebar: refactor op_sidebar_next/prev()
- 8490dd35f sidebar: add the window to wdata
- 33842b594 sidebar: convert work functions
- 7f3d28177 sidebar: create functions for open and toggle
- beef03872 sidebar: add a function dispatcher
- 1736fbbb0 index/pager: convert to use the sidebar dispatcher

The changes are broken into small pieces.
The first couple don't make any functional changes.
Then refactor the functions to the right format, and create the dispatcher.

---

In the future, I'd like the dispatchers to be connected to the windows.
When an event happened, the event loop would search for a handler starting with the focused window.

