### PR TITLE
notmuch: Ensure old flags are preserved in the index

### DIFF
--- a/notmuch/notmuch.c
+++ b/notmuch/notmuch.c
@@ -2168,6 +2168,7 @@ static enum MxStatus nm_mbox_check(struct Mailbox *m)
       struct Email e_tmp = { 0 };
       e_tmp.edata = maildir_edata_new();
       maildir_parse_flags(&e_tmp, new_file);
+      e_tmp.old = e->old;
       maildir_update_flags(m, e, &e_tmp);
       maildir_edata_free(&e_tmp.edata);
     }


### PR DESCRIPTION
Using a notmuch virtual mailbox folder can give strange behaviour for the old/new flags.  When the nm_mailbox_check function is called, the maildir flags are parsed from the filename.  However the maildir_parse_flags function does not set "old" in the Email structure.  This change ensures that the previous version of the "old" flag is preserved.

It would seem to me that this might actually be a problem in the maildir_parse_flags function and not due to the notmuch code.  I would expect that when parsing the flags, the 'old' flag is set in accordance to where the message is found in the maildir (i.e. in cur/ or new/).  I'm unsure how doing this would break other code.

