### PR TITLE
Make NeoMutt Colourful again

### DIFF
--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -185,6 +185,9 @@ LIBCOLOR=	libcolor.a
 LIBCOLOROBJS=	color/ansi.o color/attr.o color/color.o color/command.o \
 		color/curses.o color/merged.o color/notify.o color/quoted.o \
 		color/regex.o color/simple.o
+@if USE_DEBUG_COLOR
+LIBCOLOROBJS+=	color/debug.o
+@endif
 CLEANFILES+=	$(LIBCOLOR) $(LIBCOLOROBJS)
 ALLOBJS+=	$(LIBCOLOROBJS)
 

--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -182,7 +182,8 @@ $(PWD)/browser:
 ###############################################################################
 # libcolor
 LIBCOLOR=	libcolor.a
-LIBCOLOROBJS=	color/color.o color/command.o color/notify.o color/quoted.o \
+LIBCOLOROBJS=	color/ansi.o color/attr.o color/color.o color/command.o \
+		color/curses.o color/merged.o color/notify.o color/quoted.o \
 		color/regex.o color/simple.o
 CLEANFILES+=	$(LIBCOLOR) $(LIBCOLOROBJS)
 ALLOBJS+=	$(LIBCOLOROBJS)

--- a/auto.def
+++ b/auto.def
@@ -758,6 +758,10 @@ cc-with [list -libs -L$ncurses_prefix/$::libdir_tail] {
   if {![have-feature waddnwstr] || ![have-feature tgetent]} {
     user-error "Unable to find ncursesw library"
   }
+
+  foreach f {bkgrndset setcchar} {
+    cc-check-function-in-lib $f $ncurses_lib
+  }
 }
 
 # Locate the directory containing ncurses.h

--- a/auto.def
+++ b/auto.def
@@ -123,6 +123,7 @@ options {
 # Debug options
   debug-backtrace=0         => "DEBUG: Enable backtrace support with libunwind"
   with-backtrace:path       => "Location of libunwind"
+  debug-color=0             => "DEBUG: Enable Color dump"
   debug-email=0             => "DEBUG: Enable Email dump"
   debug-graphviz=0          => "DEBUG: Enable Graphviz dump"
   debug-notify=0            => "DEBUG: Enable Notifications dump"
@@ -151,10 +152,10 @@ foreach dep {with-ui with-slang} {
 if {1} {
   # Keep sorted, please.
   foreach opt {
-    asan autocrypt bdb coverage debug-backtrace debug-email debug-graphviz
-    debug-notify debug-parse-test debug-queue debug-window doc everything
-    fmemopen full-doc fuzzing gdbm gnutls gpgme gss homespool idn idn2
-    include-path-in-cflags inotify kyotocabinet lmdb locales-fix lua lz4
+    asan autocrypt bdb coverage debug-backtrace debug-color debug-email
+    debug-graphviz debug-notify debug-parse-test debug-queue debug-window doc
+    everything fmemopen full-doc fuzzing gdbm gnutls gpgme gss homespool idn
+    idn2 include-path-in-cflags inotify kyotocabinet lmdb locales-fix lua lz4
     mixmaster nls notmuch pcre2 pgp pkgconf qdbm rocksdb sasl smime sqlite ssl
     testing tdb tokyocabinet zlib zstd
   } {
@@ -1213,6 +1214,11 @@ if {[get-define want-debug-backtrace]} {
     user-error "Unable to find libunwind"
   }
   define LIBS "-lunwind-generic [get-define LIBS]"
+}
+
+# Color dump
+if {[get-define want-debug-color]} {
+  define USE_DEBUG_COLOR 1
 }
 
 # Email dump

--- a/color/ansi.c
+++ b/color/ansi.c
@@ -264,10 +264,10 @@ static void ansi_color_list_add(struct AttrColorList *acl, struct AnsiColor *ans
       case 0:
         return;
       case A_UNDERLINE:
-        // ansi->attr_color = simple_color_get(MT_COLOR_UNDERLINE);
+        ansi->attr_color = simple_color_get(MT_COLOR_UNDERLINE);
         return;
       case A_BOLD:
-        // ansi->attr_color = simple_color_get(MT_COLOR_BOLD);
+        ansi->attr_color = simple_color_get(MT_COLOR_BOLD);
         return;
     }
   }

--- a/color/ansi.c
+++ b/color/ansi.c
@@ -1,0 +1,317 @@
+/**
+ * @file
+ * ANSI Colours
+ *
+ * @authors
+ * Copyright (C) 2021 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @page color_ansi ANSI Colours
+ *
+ * Handle ANSI Colours used in the Pager
+ */
+
+#include "config.h"
+#include <stddef.h>
+#include <ctype.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include "mutt/lib.h"
+#include "config/lib.h"
+#include "core/lib.h"
+#include "gui/lib.h" // IWYU pragma: keep
+#include "ansi.h"
+
+/**
+ * ansi_is_end_char - Is this the end of a sequence?
+ * @param c Character to test
+ * @retval true Is it a valid end char
+ */
+static inline bool ansi_is_end_char(char c)
+{
+  return ((c == 'm') || (c == ';'));
+}
+
+/**
+ * ansi_skip_sequence - Skip an unrecognised sequence
+ * @param str String to examine
+ * @retval num Number of characters to skip over
+ */
+int ansi_skip_sequence(const char *str)
+{
+  if (!str || (str[0] == '\0'))
+    return 0;
+
+  int count = 1;
+  while ((str[0] != '\0') && !ansi_is_end_char(str[0]))
+  {
+    str++;
+    count++;
+  }
+
+  return count;
+}
+
+/**
+ * ansi_color_seq_length - Is this an ANSI escape sequence?
+ * @param str String to test
+ * @retval  0 No, not an ANSI sequence
+ * @retval >0 Length of the ANSI sequence
+ *
+ * Match ANSI escape sequences of type 'm', e.g.
+ * - `<esc>[1;32m`
+ */
+int ansi_color_seq_length(const char *str)
+{
+  if (!str || !*str)
+    return 0;
+
+  if ((str[0] != '\033') || (str[1] != '[')) // Escape
+    return 0;
+
+  int i = 2;
+  while ((str[i] != '\0') && (isdigit(str[i]) || (str[i] == ';')))
+  {
+    i++;
+  }
+
+  if (str[i] == 'm')
+    return i + 1;
+
+  return 0;
+}
+
+/**
+ * ansi_color_parse_single - Parse a single ANSI escape sequence
+ * @param buf     String to parse
+ * @param ansi    AnsiColor for the result
+ * @param dry_run Don't parse anything, just skip over
+ * @retval num Length of the escape sequence
+ *
+ * Parse an ANSI escape sequence into @a ansi.
+ * Calling this function repeatedly, will accumulate sequences in @a ansi.
+ */
+static int ansi_color_parse_single(const char *buf, struct AnsiColor *ansi, bool dry_run)
+{
+  int seq_len = ansi_color_seq_length(buf);
+  if (seq_len == 0)
+    return 0;
+
+  if (dry_run || !ansi)
+    return seq_len;
+
+  int pos = 2; // Skip '<esc>['
+
+  while (pos < seq_len)
+  {
+    if ((buf[pos] == '1') && ansi_is_end_char(buf[pos + 1]))
+    {
+      ansi->attrs |= A_BOLD;
+      pos += 2;
+    }
+    else if ((buf[pos] == '4') && ansi_is_end_char(buf[pos + 1]))
+    {
+      ansi->attrs |= A_UNDERLINE;
+      pos += 2;
+    }
+    else if ((buf[pos] == '5') && ansi_is_end_char(buf[pos + 1]))
+    {
+      ansi->attrs |= A_BLINK;
+      pos += 2;
+    }
+    else if ((buf[pos] == '7') && ansi_is_end_char(buf[pos + 1]))
+    {
+      ansi->attrs |= A_REVERSE;
+      pos += 2;
+    }
+    else if ((buf[pos] == '0') && ansi_is_end_char(buf[pos + 1]))
+    {
+      ansi->fg = COLOR_DEFAULT;
+      ansi->bg = COLOR_DEFAULT;
+      ansi->attrs = 0;
+      ansi->attr_color = NULL;
+      pos += 2;
+    }
+    else if (buf[pos] == '3')
+    {
+      // 30-37 basic fg
+      if ((buf[pos + 1] >= '0') && (buf[pos + 1] < '8') && ansi_is_end_char(buf[pos + 2]))
+      {
+        ansi->fg = buf[pos + 1] - '0';
+        pos += 3;
+      }
+      else if (buf[pos + 1] == '8')
+      {
+        if (mutt_str_startswith(buf + pos, "38;5;") && isdigit(buf[pos + 5]))
+        {
+          // 38;5;n palette fg
+          char *end = NULL;
+          int value = strtoul(buf + pos + 5, &end, 10);
+          if ((value >= 0) && (value < 256) && end && ansi_is_end_char(end[0]))
+          {
+            ansi->fg = value;
+            pos += end - &buf[pos];
+          }
+          else
+          {
+            pos += ansi_skip_sequence(buf + pos);
+          }
+        }
+        else if (mutt_str_startswith(buf + pos, "38;2;") && isdigit(buf[pos + 5]))
+        {
+          // 38;2;R;G;B true colour fg
+          pos += ansi_skip_sequence(buf + pos + 5);
+          pos += ansi_skip_sequence(buf + pos);
+          pos += ansi_skip_sequence(buf + pos);
+        }
+      }
+      else if ((buf[pos + 1] == '9') && ansi_is_end_char(buf[pos + 2]))
+      {
+        // default fg
+        ansi->fg = COLOR_DEFAULT;
+        pos += 2;
+      }
+      else
+      {
+        pos += ansi_skip_sequence(buf + pos);
+      }
+    }
+    else if (buf[pos] == '4')
+    {
+      // 40-47 basic bg
+      if ((buf[pos + 1] >= '0') && (buf[pos + 1] < '8'))
+      {
+        ansi->bg = buf[pos + 1] - '0';
+        pos += 3;
+      }
+      else if (buf[pos + 1] == '8')
+      {
+        if (mutt_str_startswith(buf + pos, "48;5;") && isdigit(buf[pos + 5]))
+        {
+          // 48;5;n palette bg
+          char *end = NULL;
+          int value = strtoul(buf + pos + 5, &end, 10);
+          if ((value >= 0) && (value < 256) && end && ansi_is_end_char(end[0]))
+          {
+            ansi->bg = value;
+            pos += end - &buf[pos];
+          }
+          else
+          {
+            pos += ansi_skip_sequence(buf + pos);
+          }
+        }
+        else if (mutt_str_startswith(buf + pos, "48;2;") && isdigit(buf[pos + 5]))
+        {
+          // 48;2;R;G;B true colour bg
+          pos += ansi_skip_sequence(buf + pos + 5);
+          pos += ansi_skip_sequence(buf + pos);
+          pos += ansi_skip_sequence(buf + pos);
+        }
+        else
+        {
+          pos += ansi_skip_sequence(buf + pos);
+        }
+      }
+      else if ((buf[pos + 1] == '9') && ansi_is_end_char(buf[pos + 2]))
+      {
+        // default bg
+        ansi->bg = COLOR_DEFAULT;
+        pos += 2;
+      }
+    }
+    else
+    {
+      while ((pos < seq_len) && (buf[pos] != ';'))
+        pos++;
+    }
+  }
+
+  return pos;
+}
+
+/**
+ * ansi_color_list_add - Add an Ansi colour to the list
+ * @param acl  List of unique colours
+ * @param ansi Colour to add
+ *
+ * Keep track of all the unique ANSI colours in a list.
+ */
+static void ansi_color_list_add(struct AttrColorList *acl, struct AnsiColor *ansi)
+{
+  if (!acl || !ansi)
+    return;
+
+  if ((ansi->fg == COLOR_DEFAULT) && (ansi->bg == COLOR_DEFAULT))
+  {
+    switch (ansi->attrs)
+    {
+      case 0:
+        return;
+      case A_UNDERLINE:
+        // ansi->attr_color = simple_color_get(MT_COLOR_UNDERLINE);
+        return;
+      case A_BOLD:
+        // ansi->attr_color = simple_color_get(MT_COLOR_BOLD);
+        return;
+    }
+  }
+
+  struct AttrColor *ac = attr_color_list_find(acl, ansi->fg, ansi->bg, ansi->attrs);
+  if (ac)
+  {
+    ansi->attr_color = ac;
+    return;
+  }
+
+  ac = attr_color_new();
+  ac->attrs = ansi->attrs;
+
+  struct CursesColor *cc = curses_color_new(ansi->fg, ansi->bg);
+  ac->curses_color = cc;
+  ansi->attr_color = ac;
+
+  TAILQ_INSERT_TAIL(acl, ac, entries);
+}
+
+/**
+ * ansi_color_parse - Parse a string of ANSI escape sequence
+ * @param str     String to parse
+ * @param ansi    AnsiColor for the result
+ * @param acl     List to store the unique colours
+ * @param dry_run If true, parse but don't save the sequence
+ * @retval num Total length of the escape sequences
+ *
+ * Parse (multiple) ANSI sequence(s) into @a ansi.
+ * If the colour hasn't been seen before, store the it in @a acl.
+ */
+int ansi_color_parse(const char *str, struct AnsiColor *ansi,
+                     struct AttrColorList *acl, bool dry_run)
+{
+  int seq_len = 0;
+  int total_len = 0;
+
+  while ((seq_len = ansi_color_parse_single(str + total_len, ansi, dry_run)) != 0)
+  {
+    total_len += seq_len;
+  }
+
+  ansi_color_list_add(acl, ansi);
+
+  return total_len;
+}

--- a/color/ansi.c
+++ b/color/ansi.c
@@ -36,6 +36,7 @@
 #include "core/lib.h"
 #include "gui/lib.h" // IWYU pragma: keep
 #include "ansi.h"
+#include "debug.h"
 
 /**
  * ansi_is_end_char - Is this the end of a sequence?
@@ -287,6 +288,7 @@ static void ansi_color_list_add(struct AttrColorList *acl, struct AnsiColor *ans
   ansi->attr_color = ac;
 
   TAILQ_INSERT_TAIL(acl, ac, entries);
+  attr_color_list_dump(acl, "AnsiColors");
 }
 
 /**
@@ -308,6 +310,7 @@ int ansi_color_parse(const char *str, struct AnsiColor *ansi,
 
   while ((seq_len = ansi_color_parse_single(str + total_len, ansi, dry_run)) != 0)
   {
+    // color_debug(LL_DEBUG5, "seq_len = %d\n", seq_len);
     total_len += seq_len;
   }
 

--- a/color/ansi.h
+++ b/color/ansi.h
@@ -1,0 +1,44 @@
+/**
+ * @file
+ * ANSI Colours
+ *
+ * @authors
+ * Copyright (C) 2021 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MUTT_COLOR_ANSI_H
+#define MUTT_COLOR_ANSI_H
+
+#include <stdbool.h>
+
+struct AttrColorList;
+
+/**
+ * struct AnsiColor - An ANSI escape sequence
+ */
+struct AnsiColor
+{
+  struct AttrColor *attr_color;    ///< Curses colour of text
+  int attrs;                       ///< Attributes, e.g. A_BOLD
+  int fg;                          ///< Foreground colour
+  int bg;                          ///< Background colour
+};
+
+int ansi_color_parse     (const char *str, struct AnsiColor *ansi, struct AttrColorList *acl, bool dry_run);
+int ansi_color_seq_length(const char *str);
+
+#endif /* MUTT_COLOR_ANSI_H */

--- a/color/attr.c
+++ b/color/attr.c
@@ -1,0 +1,180 @@
+/**
+ * @file
+ * Colour and attributes
+ *
+ * @authors
+ * Copyright (C) 2021 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @page color_attr Colour and attributes
+ *
+ * The colour and attributes of a graphical object are represented by an
+ * AttrColor.
+ */
+
+#include "config.h"
+#include <stddef.h>
+#include <stdint.h>
+#include "mutt/lib.h"
+#include "attr.h"
+#include "curses2.h"
+
+/**
+ * attr_color_clear - Free the contents of an AttrColor
+ * @param ac AttrColor to empty
+ *
+ * @note The AttrColor object isn't freed
+ */
+void attr_color_clear(struct AttrColor *ac)
+{
+  if (!ac)
+    return;
+
+  curses_color_free(&ac->curses_color);
+  ac->attrs = 0;
+}
+
+/**
+ * attr_color_free - Free an AttrColor
+ * @param ptr AttrColor to free
+ */
+void attr_color_free(struct AttrColor **ptr)
+{
+  if (!ptr || !*ptr)
+    return;
+
+  struct AttrColor *ac = *ptr;
+  if (ac->ref_count > 1)
+  {
+    ac->ref_count--;
+    *ptr = NULL;
+    return;
+  }
+
+  attr_color_clear(ac);
+  FREE(ptr);
+}
+
+/**
+ * attr_color_new - Create a new AttrColor
+ * @retval ptr New AttrColor
+ */
+struct AttrColor *attr_color_new(void)
+{
+  struct AttrColor *ac = mutt_mem_calloc(1, sizeof(*ac));
+
+  ac->ref_count = 1;
+
+  return ac;
+}
+
+/**
+ * attr_color_list_clear - Free the contents of an AttrColorList
+ * @param acl List to clear
+ *
+ * Free each of the AttrColors in a list.
+ *
+ * @note The list object isn't freed, only emptied
+ */
+void attr_color_list_clear(struct AttrColorList *acl)
+{
+  if (!acl)
+    return;
+
+  struct AttrColor *ac = NULL;
+  struct AttrColor *tmp = NULL;
+  TAILQ_FOREACH_SAFE(ac, acl, entries, tmp)
+  {
+    TAILQ_REMOVE(acl, ac, entries);
+    attr_color_free(&ac);
+  }
+}
+
+/**
+ * attr_color_list_find - Find an AttrColor in a list
+ * @param acl   List to search
+ * @param fg    Foreground colour
+ * @param bg    Background colour
+ * @param attrs Attributes, e.g. A_UNDERLINE
+ * @retval ptr Matching AttrColor
+ */
+struct AttrColor *attr_color_list_find(struct AttrColorList *acl, uint32_t fg,
+                                       uint32_t bg, int attrs)
+{
+  if (!acl)
+    return NULL;
+
+  struct AttrColor *ac = NULL;
+  TAILQ_FOREACH(ac, acl, entries)
+  {
+    if (ac->attrs != attrs)
+      continue;
+
+    struct CursesColor *cc = ac->curses_color;
+    if (!cc)
+      continue;
+
+    if ((cc->fg == fg) && (cc->bg == bg))
+      return ac;
+  }
+  return NULL;
+}
+
+/**
+ * attr_color_copy - Copy a colour
+ * @param ac Colour to copy
+ * @retval obj Copy of the colour
+ */
+struct AttrColor attr_color_copy(struct AttrColor *ac)
+{
+  struct AttrColor copy = { 0 };
+  if (ac)
+    copy = *ac;
+
+  return copy;
+}
+
+/**
+ * attr_color_is_set - Is the object coloured?
+ * @param ac Colour to check
+ * @retval true Yes, a 'color' command has been used on this object
+ */
+bool attr_color_is_set(struct AttrColor *ac)
+{
+  if (!ac)
+    return false;
+
+  return ((ac->attrs != 0) || ac->curses_color);
+}
+
+/**
+ * attr_color_match - Do the colours match?
+ * @param ac1 First colour
+ * @param ac2 Second colour
+ * @retval true The colours and attributes match
+ */
+bool attr_color_match(struct AttrColor *ac1, struct AttrColor *ac2)
+{
+  if (!ac1 ^ !ac2) // One is set, but not the other
+    return false;
+
+  if (!ac1) // Two empty colours match
+    return true;
+
+  return ((ac1->curses_color == ac2->curses_color) && (ac1->attrs == ac2->attrs));
+}

--- a/color/attr.c
+++ b/color/attr.c
@@ -33,6 +33,7 @@
 #include "mutt/lib.h"
 #include "attr.h"
 #include "curses2.h"
+#include "debug.h"
 
 /**
  * attr_color_clear - Free the contents of an AttrColor
@@ -45,6 +46,8 @@ void attr_color_clear(struct AttrColor *ac)
   if (!ac)
     return;
 
+  if (ac->curses_color)
+    color_debug(LL_DEBUG5, "clear %p\n", ac);
   curses_color_free(&ac->curses_color);
   ac->attrs = 0;
 }

--- a/color/attr.h
+++ b/color/attr.h
@@ -1,0 +1,52 @@
+/**
+ * @file
+ * Colour and attributes
+ *
+ * @authors
+ * Copyright (C) 2021 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MUTT_COLOR_ATTR_H
+#define MUTT_COLOR_ATTR_H
+
+#include "config.h"
+#include <stdint.h>
+#include "mutt/lib.h"
+
+/**
+ * struct AttrColor - A curses colour and its attributes
+ */
+struct AttrColor
+{
+  struct CursesColor *curses_color; ///< Underlying Curses colour
+  int attrs;                        ///< Text attributes, e.g. A_BOLD
+  short ref_count;                  ///< Number of users
+  TAILQ_ENTRY(AttrColor) entries;   ///< Linked list
+};
+TAILQ_HEAD(AttrColorList, AttrColor);
+
+void              attr_color_clear (struct AttrColor *ac);
+struct AttrColor  attr_color_copy  (struct AttrColor *ac);
+void              attr_color_free  (struct AttrColor **ptr);
+bool              attr_color_is_set(struct AttrColor *ac);
+bool              attr_color_match (struct AttrColor *ac1, struct AttrColor *ac2);
+struct AttrColor *attr_color_new   (void);
+
+void              attr_color_list_clear(struct AttrColorList *acl);
+struct AttrColor *attr_color_list_find (struct AttrColorList *acl, uint32_t fg, uint32_t bg, int attrs);
+
+#endif /* MUTT_COLOR_ATTR_H */

--- a/color/color.c
+++ b/color/color.c
@@ -28,40 +28,18 @@
  */
 
 #include "config.h"
+#include <assert.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include "mutt/lib.h"
 #include "config/lib.h"
-#include "email/lib.h"
 #include "core/lib.h"
 #include "gui/lib.h"
-#include "mutt.h"
 #include "lib.h"
 #include "pattern/lib.h"
 #include "context.h"
-#include "init.h"
 #include "mutt_globals.h"
-#include "options.h"
-
-struct ColorList *UserColors; ///< Array of user colours
-int NumUserColors;            ///< Number of user colours
-
-/**
- * struct ColorList - A set of colors
- */
-struct ColorList
-{
-  /* TrueColor uses 24bit. Use fixed-width integer type to make sure it fits.
-   * Use the upper 8 bits to store flags.  */
-  uint32_t fg;            ///< Foreground colour
-  uint32_t bg;            ///< Background colour
-  short index;            ///< Index number
-  short ref_count;        ///< Number of users
-  struct ColorList *next; ///< Linked list
-};
 
 const struct Mapping ColorNames[] = {
   // clang-format off
@@ -79,82 +57,17 @@ const struct Mapping ColorNames[] = {
 };
 
 /**
- * color_list_free - Free the list of curses colours
- * @param ptr Colours
- */
-static void color_list_free(struct ColorList **ptr)
-{
-  if (!ptr || !*ptr)
-    return;
-
-  struct ColorList *cl = *ptr;
-  struct ColorList *next = NULL;
-
-  while (cl)
-  {
-    next = cl->next;
-    FREE(&cl);
-    cl = next;
-  }
-  *ptr = NULL;
-}
-
-/**
- * mutt_color_free - Free a colour
- * @param fg Foreground colour ID
- * @param bg Background colour ID
- *
- * If there are no more users, the resource will be freed.
- */
-void mutt_color_free(uint32_t fg, uint32_t bg)
-{
-  struct ColorList *q = NULL;
-
-  struct ColorList *p = UserColors;
-  while (p)
-  {
-    if ((p->fg == fg) && (p->bg == bg))
-    {
-      (p->ref_count)--;
-      if (p->ref_count > 0)
-        return;
-
-      NumUserColors--;
-      mutt_debug(LL_DEBUG1, "Color pairs used so far: %d\n", NumUserColors);
-
-      if (p == UserColors)
-      {
-        UserColors = UserColors->next;
-        FREE(&p);
-        return;
-      }
-      q = UserColors;
-      while (q)
-      {
-        if (q->next == p)
-        {
-          q->next = p->next;
-          FREE(&p);
-          return;
-        }
-        q = q->next;
-      }
-      /* can't get here */
-    }
-    p = p->next;
-  }
-}
-
-/**
- * colors_clear - Reset all the colours
+ * colors_clear - Reset all the simple, quoted and regex colours
  */
 void colors_clear(void)
 {
+  mutt_debug(LL_NOTIFY, "NT_COLOR_RESET: [ALL]\n");
+  struct EventColor ev_c = { MT_COLOR_MAX, NULL };
+  notify_send(ColorsNotify, NT_COLOR, NT_COLOR_RESET, &ev_c);
+
   simple_colors_clear();
   quoted_colors_clear();
   regex_colors_clear();
-
-  color_list_free(&UserColors);
 }
 
 /**
@@ -163,6 +76,7 @@ void colors_clear(void)
 void mutt_colors_cleanup(void)
 {
   colors_clear();
+  merged_colors_clear();
   color_notify_free();
 }
 
@@ -173,120 +87,12 @@ void mutt_colors_init(void)
 {
   color_notify_init();
   simple_colors_init();
-  quoted_colors_init();
   regex_colors_init();
+  curses_colors_init();
+  merged_colors_init();
 
   start_color();
-}
+  use_default_colors();
 
-/**
- * mutt_color_alloc - Allocate a colour pair
- * @param fg Foreground colour ID
- * @param bg Background colour ID
- * @retval num Combined colour pair
- */
-int mutt_color_alloc(uint32_t fg, uint32_t bg)
-{
-  struct ColorList *p = UserColors;
-
-  /* check to see if this color is already allocated to save space */
-  while (p)
-  {
-    if ((p->fg == fg) && (p->bg == bg))
-    {
-      (p->ref_count)++;
-      return COLOR_PAIR(p->index);
-    }
-    p = p->next;
-  }
-
-  /* check to see if there are colors left */
-  if (++NumUserColors > COLOR_PAIRS)
-    return A_NORMAL;
-
-  /* find the smallest available index (object) */
-  int i = 1;
-  while (true)
-  {
-    p = UserColors;
-    while (p)
-    {
-      if (p->index == i)
-        break;
-      p = p->next;
-    }
-    if (!p)
-      break;
-    i++;
-  }
-
-  /* Check for pair overflow too.
-   * We are currently using init_pair(), which only accepts size short. */
-  if (i > SHRT_MAX)
-    return (0);
-
-  p = mutt_mem_malloc(sizeof(struct ColorList));
-  p->next = UserColors;
-  UserColors = p;
-
-  p->index = i;
-  p->ref_count = 1;
-  p->bg = bg;
-  p->fg = fg;
-
-  if (fg == COLOR_DEFAULT)
-    fg = COLOR_UNSET;
-  if (bg == COLOR_DEFAULT)
-    bg = COLOR_UNSET;
-  init_pair(i, fg, bg);
-
-  mutt_debug(LL_DEBUG3, "Color pairs used so far: %d\n", NumUserColors);
-
-  return COLOR_PAIR(p->index);
-}
-
-/**
- * mutt_lookup_color - Get the colours from a colour pair
- * @param[in]  pair Colour pair
- * @param[out] fg   Foreground colour (OPTIONAL)
- * @param[out] bg   Background colour (OPTIONAL)
- * @retval  0 Success
- * @retval -1 Error
- */
-static int mutt_lookup_color(short pair, uint32_t *fg, uint32_t *bg)
-{
-  struct ColorList *p = UserColors;
-
-  while (p)
-  {
-    if (COLOR_PAIR(p->index) == pair)
-    {
-      if (fg)
-        *fg = p->fg;
-      if (bg)
-        *bg = p->bg;
-      return 0;
-    }
-    p = p->next;
-  }
-  return -1;
-}
-
-/**
- * mutt_color_combine - Combine two colours
- * @param fg_attr Colour pair of foreground to use
- * @param bg_attr Colour pair of background to use
- * @retval num Colour pair of combined colour
- */
-int mutt_color_combine(uint32_t fg_attr, uint32_t bg_attr)
-{
-  uint32_t fg = COLOR_DEFAULT;
-  uint32_t bg = COLOR_DEFAULT;
-
-  mutt_lookup_color(fg_attr, &fg, NULL);
-  mutt_lookup_color(bg_attr, NULL, &bg);
-
-  if ((fg == COLOR_DEFAULT) && (bg == COLOR_DEFAULT))
-    return A_NORMAL;
-  return mutt_color_alloc(fg, bg);
+  notify_set_parent(ColorsNotify, NeoMutt->notify);
 }

--- a/color/color.c
+++ b/color/color.c
@@ -39,6 +39,7 @@
 #include "lib.h"
 #include "pattern/lib.h"
 #include "context.h"
+#include "debug.h"
 #include "mutt_globals.h"
 
 const struct Mapping ColorNames[] = {
@@ -61,6 +62,7 @@ const struct Mapping ColorNames[] = {
  */
 void colors_clear(void)
 {
+  color_debug(LL_DEBUG5, "clean up\n");
   mutt_debug(LL_NOTIFY, "NT_COLOR_RESET: [ALL]\n");
   struct EventColor ev_c = { MT_COLOR_MAX, NULL };
   notify_send(ColorsNotify, NT_COLOR, NT_COLOR_RESET, &ev_c);
@@ -85,6 +87,7 @@ void mutt_colors_cleanup(void)
  */
 void mutt_colors_init(void)
 {
+  color_debug(LL_DEBUG5, "init\n");
   color_notify_init();
   simple_colors_init();
   regex_colors_init();
@@ -93,6 +96,7 @@ void mutt_colors_init(void)
 
   start_color();
   use_default_colors();
+  color_debug(LL_DEBUG5, "COLORS = %d, COLOR_PAIRS = %d\n", COLORS, COLOR_PAIRS);
 
   notify_set_parent(ColorsNotify, NeoMutt->notify);
 }

--- a/color/color.h
+++ b/color/color.h
@@ -96,12 +96,12 @@ extern const struct Mapping ColorNames[];
 extern const struct Mapping ColorFields[];
 extern const struct Mapping ComposeColorFields[];
 
-/* Flags for the high 8bits of the color value.
- * Note that no flag means it's a palette color.  */
-#define RGB24 (1U << 24)
-
 #define COLOR_DEFAULT (-2)
 #define COLOR_UNSET   UINT32_MAX
 
+void mutt_colors_init(void);
+void mutt_colors_cleanup(void);
+
+void colors_clear(void);
 
 #endif /* MUTT_COLOR_COLOR_H */

--- a/color/command.c
+++ b/color/command.c
@@ -145,8 +145,7 @@ static enum CommandResult parse_color_name(const char *s, uint32_t *col, int *at
   {
     s += clen;
     *col = strtoul(s, &eptr, 10);
-    if ((*s == '\0') || (*eptr != '\0') ||
-        ((*col >= COLORS) && !OptNoCurses && has_colors()))
+    if ((*s == '\0') || (*eptr != '\0') || ((*col >= COLORS) && !OptNoCurses))
     {
       mutt_buffer_printf(err, _("%s: color not supported by term"), s);
       return MUTT_CMD_ERROR;
@@ -180,7 +179,7 @@ static enum CommandResult parse_color_name(const char *s, uint32_t *col, int *at
         *attrs |= A_BOLD;
       }
     }
-    else if (!(*col & RGB24))
+    else
     {
       if (COLORS >= 16)
       {
@@ -392,52 +391,6 @@ static enum CommandResult parse_object(struct Buffer *buf, struct Buffer *s,
 }
 
 /**
- * do_uncolor - Parse the 'uncolor' or 'unmono' command
- * @param buf     Buffer for temporary storage
- * @param s       Buffer containing the uncolor command
- * @param cl      List of existing colours
- * @param uncolor If true, 'uncolor', else 'unmono'
- * @retval true A colour was freed
- */
-static bool do_uncolor(struct Buffer *buf, struct Buffer *s,
-                       struct RegexColorList *cl, bool uncolor)
-{
-  struct RegexColor *np = NULL, *prev = NULL;
-  bool rc = false;
-
-  do
-  {
-    mutt_extract_token(buf, s, MUTT_TOKEN_NO_FLAGS);
-    if (mutt_str_equal("*", buf->data))
-    {
-      rc = STAILQ_FIRST(cl);
-      regex_color_list_clear(cl);
-      return rc;
-    }
-
-    prev = NULL;
-    STAILQ_FOREACH(np, cl, entries)
-    {
-      if (mutt_str_equal(buf->data, np->pattern))
-      {
-        rc = true;
-
-        mutt_debug(LL_DEBUG1, "Freeing pattern \"%s\" from user_colors\n", buf->data);
-        if (prev)
-          STAILQ_REMOVE_AFTER(cl, prev, entries);
-        else
-          STAILQ_REMOVE_HEAD(cl, entries);
-        regex_color_free(&np, uncolor);
-        break;
-      }
-      prev = np;
-    }
-  } while (MoreArgs(s));
-
-  return rc;
-}
-
-/**
  * parse_uncolor - Parse an 'uncolor' command
  * @param buf     Temporary Buffer space
  * @param s       Buffer containing string to be parsed
@@ -456,10 +409,7 @@ static enum CommandResult parse_uncolor(struct Buffer *buf, struct Buffer *s,
 
   if (mutt_str_equal(buf->data, "*"))
   {
-    mutt_debug(LL_NOTIFY, "NT_COLOR_RESET: [ALL]\n");
     colors_clear();
-    struct EventColor ev_c = { MT_COLOR_MAX };
-    notify_send(ColorsNotify, NT_COLOR, NT_COLOR_RESET, &ev_c);
     return MUTT_CMD_SUCCESS;
   }
 
@@ -477,8 +427,13 @@ static enum CommandResult parse_uncolor(struct Buffer *buf, struct Buffer *s,
 
   if (cid == MT_COLOR_QUOTED)
   {
-    QuotedColors[ql] = A_NORMAL;
-    /* fallthrough to simple case */
+    return quoted_colors_parse_uncolor(cid, ql, err);
+  }
+
+  if ((cid == MT_COLOR_STATUS) && !MoreArgs(s))
+  {
+    simple_color_reset(cid); // default colour for the status bar
+    return MUTT_CMD_SUCCESS;
   }
 
   if ((cid != MT_COLOR_ATTACH_HEADERS) && (cid != MT_COLOR_BODY) &&
@@ -486,13 +441,7 @@ static enum CommandResult parse_uncolor(struct Buffer *buf, struct Buffer *s,
       (cid != MT_COLOR_INDEX_FLAGS) && (cid != MT_COLOR_INDEX_SUBJECT) &&
       (cid != MT_COLOR_INDEX_TAG) && (cid != MT_COLOR_STATUS))
   {
-    // Simple colours
-    SimpleColors[cid] = A_NORMAL;
-
-    get_colorid_name(cid, buf);
-    mutt_debug(LL_NOTIFY, "NT_COLOR_RESET: %s\n", buf->data);
-    struct EventColor ev_c = { cid };
-    notify_send(ColorsNotify, NT_COLOR, NT_COLOR_RESET, &ev_c);
+    simple_color_reset(cid);
     return MUTT_CMD_SUCCESS;
   }
 
@@ -502,9 +451,7 @@ static enum CommandResult parse_uncolor(struct Buffer *buf, struct Buffer *s,
     return MUTT_CMD_WARNING;
   }
 
-  if (OptNoCurses ||                // running without curses
-      (uncolor && !has_colors()) || // parsing an uncolor command, and have no colors
-      (!uncolor && has_colors())) // parsing an unmono command, and have colors
+  if (OptNoCurses)
   {
     do
     {
@@ -515,49 +462,18 @@ static enum CommandResult parse_uncolor(struct Buffer *buf, struct Buffer *s,
     return MUTT_CMD_SUCCESS;
   }
 
-  bool changed = false;
-  if (cid == MT_COLOR_ATTACH_HEADERS)
-    changed |= do_uncolor(buf, s, regex_colors_get_list(MT_COLOR_ATTACH_HEADERS), uncolor);
-  else if (cid == MT_COLOR_BODY)
-    changed |= do_uncolor(buf, s, regex_colors_get_list(MT_COLOR_BODY), uncolor);
-  else if (cid == MT_COLOR_HEADER)
-    changed |= do_uncolor(buf, s, regex_colors_get_list(MT_COLOR_HEADER), uncolor);
-  else if (cid == MT_COLOR_INDEX)
-    changed |= do_uncolor(buf, s, regex_colors_get_list(MT_COLOR_INDEX), uncolor);
-  else if (cid == MT_COLOR_INDEX_AUTHOR)
-    changed |= do_uncolor(buf, s, regex_colors_get_list(MT_COLOR_INDEX_AUTHOR), uncolor);
-  else if (cid == MT_COLOR_INDEX_FLAGS)
-    changed |= do_uncolor(buf, s, regex_colors_get_list(MT_COLOR_INDEX_FLAGS), uncolor);
-  else if (cid == MT_COLOR_INDEX_SUBJECT)
-    changed |= do_uncolor(buf, s, regex_colors_get_list(MT_COLOR_INDEX_SUBJECT), uncolor);
-  else if (cid == MT_COLOR_INDEX_TAG)
-    changed |= do_uncolor(buf, s, regex_colors_get_list(MT_COLOR_INDEX_TAG), uncolor);
-  else if (cid == MT_COLOR_STATUS)
-    changed |= do_uncolor(buf, s, regex_colors_get_list(MT_COLOR_STATUS), uncolor);
-
-  if (changed)
+  bool changes = false;
+  do
   {
-    get_colorid_name(cid, buf);
-    mutt_debug(LL_NOTIFY, "NT_COLOR_RESET: %s\n", buf->data);
-    struct EventColor ev_c = { cid };
-    notify_send(ColorsNotify, NT_COLOR, NT_COLOR_RESET, &ev_c);
-  }
+    mutt_extract_token(buf, s, MUTT_TOKEN_NO_FLAGS);
+    if (mutt_str_equal("*", buf->data))
+      return regex_colors_parse_uncolor(cid, NULL, uncolor);
+
+    changes |= regex_colors_parse_uncolor(cid, buf->data, uncolor);
+
+  } while (MoreArgs(s));
 
   return MUTT_CMD_SUCCESS;
-}
-
-/**
- * fgbgattr_to_color - Convert a foreground, background, attribute triplet into a colour
- * @param fg    Foreground colour ID
- * @param bg    Background colour ID
- * @param attrs Attribute flags, e.g. A_BOLD
- * @retval num Combined colour pair
- */
-int fgbgattr_to_color(int fg, int bg, int attrs)
-{
-  if ((fg != COLOR_UNSET) && (bg != COLOR_UNSET))
-    return attrs | mutt_color_alloc(fg, bg);
-  return attrs;
 }
 
 /**
@@ -627,25 +543,27 @@ static enum CommandResult parse_color(struct Buffer *buf, struct Buffer *s,
     return MUTT_CMD_SUCCESS;
   }
 
-  if (!OptNoCurses &&
-      has_colors()
-      /* delay use_default_colors() until needed, since it initializes things */
-      && ((fg == COLOR_DEFAULT) || (bg == COLOR_DEFAULT) || (cid == MT_COLOR_TREE)) &&
-      (use_default_colors() != OK))
-  /* the case of the tree cid is special, because a non-default fg color of
+#ifdef NCURSES_VERSION
+  /* The case of the tree object is special, because a non-default fg color of
    * the tree element may be combined dynamically with the default bg color of
    * an index line, not necessarily defined in a rc file.  */
+  if (!OptNoCurses &&
+      ((fg == COLOR_DEFAULT) || (bg == COLOR_DEFAULT) || (cid == MT_COLOR_TREE)) &&
+      (use_default_colors() != OK))
   {
     mutt_buffer_strcpy(err, _("default colors not supported"));
     return MUTT_CMD_ERROR;
   }
+#endif
 
   if (regex_colors_parse_color_list(cid, buf->data, fg, bg, attrs, &rc, err))
   {
+    return MUTT_CMD_SUCCESS;
     // do nothing
   }
   else if (quoted_colors_parse_color(cid, fg, bg, attrs, q_level, &rc, err))
   {
+    return MUTT_CMD_SUCCESS;
     // do nothing
   }
   else if ((cid == MT_COLOR_STATUS) && MoreArgs(s))
@@ -677,17 +595,18 @@ static enum CommandResult parse_color(struct Buffer *buf, struct Buffer *s,
     }
 
     rc = regex_colors_parse_status_list(cid, buf->data, fg, bg, attrs, match, err);
+    return rc;
   }
   else // Remaining simple colours
   {
-    SimpleColors[cid] = fgbgattr_to_color(fg, bg, attrs);
-    rc = MUTT_CMD_SUCCESS;
+    if (simple_color_set(cid, fg, bg, attrs))
+      return MUTT_CMD_SUCCESS;
+    return MUTT_CMD_ERROR;
   }
 
   if (rc == MUTT_CMD_SUCCESS)
   {
     get_colorid_name(cid, buf);
-    mutt_debug(LL_NOTIFY, "NT_COLOR_SET: %s\n", buf->data);
     struct EventColor ev_c = { cid };
     notify_send(ColorsNotify, NT_COLOR, NT_COLOR_SET, &ev_c);
   }
@@ -701,12 +620,13 @@ static enum CommandResult parse_color(struct Buffer *buf, struct Buffer *s,
 enum CommandResult mutt_parse_uncolor(struct Buffer *buf, struct Buffer *s,
                                       intptr_t data, struct Buffer *err)
 {
-  if (OptNoCurses || !has_colors())
+  if (OptNoCurses)
   {
     *s->dptr = '\0'; /* fake that we're done parsing */
     return MUTT_CMD_SUCCESS;
   }
-  return parse_uncolor(buf, s, err, true);
+  enum CommandResult rc = parse_uncolor(buf, s, err, true);
+  return rc;
 }
 
 /**
@@ -715,7 +635,7 @@ enum CommandResult mutt_parse_uncolor(struct Buffer *buf, struct Buffer *s,
 enum CommandResult mutt_parse_unmono(struct Buffer *buf, struct Buffer *s,
                                      intptr_t data, struct Buffer *err)
 {
-  if (OptNoCurses || !has_colors())
+  if (OptNoCurses)
   {
     *s->dptr = '\0'; /* fake that we're done parsing */
     return MUTT_CMD_SUCCESS;
@@ -729,12 +649,10 @@ enum CommandResult mutt_parse_unmono(struct Buffer *buf, struct Buffer *s,
 enum CommandResult mutt_parse_color(struct Buffer *buf, struct Buffer *s,
                                     intptr_t data, struct Buffer *err)
 {
-  bool dry_run = false;
+  bool dry_run = OptNoCurses;
 
-  if (OptNoCurses || !has_colors())
-    dry_run = true;
-
-  return parse_color(buf, s, err, parse_color_pair, dry_run, true);
+  enum CommandResult rc = parse_color(buf, s, err, parse_color_pair, dry_run, true);
+  return rc;
 }
 
 /**
@@ -743,10 +661,7 @@ enum CommandResult mutt_parse_color(struct Buffer *buf, struct Buffer *s,
 enum CommandResult mutt_parse_mono(struct Buffer *buf, struct Buffer *s,
                                    intptr_t data, struct Buffer *err)
 {
-  bool dry_run = false;
-
-  if (OptNoCurses || has_colors())
-    dry_run = true;
+  bool dry_run = OptNoCurses;
 
   return parse_color(buf, s, err, parse_attr_spec, dry_run, false);
 }

--- a/color/command2.h
+++ b/color/command2.h
@@ -51,6 +51,6 @@ enum CommandResult mutt_parse_mono   (struct Buffer *buf, struct Buffer *s, intp
 enum CommandResult mutt_parse_uncolor(struct Buffer *buf, struct Buffer *s, intptr_t data, struct Buffer *err);
 enum CommandResult mutt_parse_unmono (struct Buffer *buf, struct Buffer *s, intptr_t data, struct Buffer *err);
 
-int fgbgattr_to_color(int fg, int bg, int attrs);
+void get_colorid_name(unsigned int color_id, struct Buffer *buf);
 
 #endif /* MUTT_COLOR_COMMAND2_H */

--- a/color/curses.c
+++ b/color/curses.c
@@ -1,0 +1,175 @@
+/**
+ * @file
+ * Curses Colour
+ *
+ * @authors
+ * Copyright (C) 2021 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @page color_curses Curses Colour
+ *
+ * A wrapper that represents a colour in Curses.
+ */
+
+#include "config.h"
+#include <stddef.h>
+#include "mutt/lib.h"
+#include "gui/lib.h"
+
+struct CursesColorList CursesColors; ///< List of all Curses colours
+int NumCursesColors;
+
+/**
+ * curses_colors_init - Initialise the Curses colours
+ */
+void curses_colors_init(void)
+{
+  TAILQ_INIT(&CursesColors);
+  NumCursesColors = 0;
+}
+
+/**
+ * curses_colors_find - Find a Curses colour by foreground/background
+ * @param fg Foreground colour
+ * @param bg Background colour
+ * @retval ptr Curses colour
+ */
+struct CursesColor *curses_colors_find(int fg, int bg)
+{
+  struct CursesColor *cc = NULL;
+  TAILQ_FOREACH(cc, &CursesColors, entries)
+  {
+    if ((cc->fg == fg) && (cc->bg == bg))
+    {
+      return cc;
+    }
+  }
+
+  return NULL;
+}
+
+/**
+ * curses_color_init - Initialise a new Curses colour
+ * @param fg Foreground colour
+ * @param bg Background colour
+ * @retval num Index of Curses colour
+ */
+static int curses_color_init(int fg, int bg)
+{
+  int index = 16;
+  struct CursesColor *cc = NULL;
+  TAILQ_FOREACH(cc, &CursesColors, entries)
+  {
+    if (cc->index == index)
+      index++;
+    else
+      break;
+  }
+  if (index >= COLOR_PAIRS)
+  {
+    static bool warned = false;
+    if (!warned)
+    {
+      mutt_error(_("Too many colors: %d / %d"), index, COLOR_PAIRS);
+      warned = true;
+    }
+    return 0;
+  }
+
+  if (fg == COLOR_DEFAULT)
+    fg = COLOR_UNSET;
+  if (bg == COLOR_DEFAULT)
+    bg = COLOR_UNSET;
+
+  init_pair(index, fg, bg);
+
+  return index;
+}
+
+/**
+ * curses_color_free - Free a CursesColor
+ * @param ptr CursesColor to be freed
+ */
+void curses_color_free(struct CursesColor **ptr)
+{
+  if (!ptr || !*ptr)
+    return;
+
+  struct CursesColor *cc = *ptr;
+  if (cc->ref_count > 1)
+  {
+    cc->ref_count--;
+    *ptr = NULL;
+    return;
+  }
+
+  TAILQ_REMOVE(&CursesColors, cc, entries);
+  NumCursesColors--;
+  FREE(ptr);
+}
+
+/**
+ * curses_color_new - Create a new CursesColor
+ * @param fg Foreground colour
+ * @param bg Background colour
+ * @retval ptr New CursesColor
+ *
+ * If the colour already exists, this function will return a pointer to the
+ * object (and increase its ref-count).
+ */
+struct CursesColor *curses_color_new(int fg, int bg)
+{
+  if (((fg == COLOR_UNSET) && (bg == COLOR_UNSET)) ||
+      ((fg == COLOR_DEFAULT) && (bg == COLOR_DEFAULT)))
+  {
+    return NULL;
+  }
+
+  struct CursesColor *cc = curses_colors_find(fg, bg);
+  if (cc)
+  {
+    cc->ref_count++;
+    return cc;
+  }
+
+  int index = curses_color_init(fg, bg);
+  if (index < 0)
+    return NULL;
+
+  struct CursesColor *cc_new = mutt_mem_calloc(1, sizeof(*cc_new));
+  NumCursesColors++;
+  cc_new->fg = fg;
+  cc_new->bg = bg;
+  cc_new->ref_count = 1;
+  cc_new->index = index;
+
+  // insert curses colour
+  TAILQ_FOREACH(cc, &CursesColors, entries)
+  {
+    if (cc->index > index)
+    {
+      TAILQ_INSERT_BEFORE(cc, cc_new, entries);
+      goto done;
+    }
+  }
+
+  TAILQ_INSERT_TAIL(&CursesColors, cc_new, entries);
+
+done:
+  return cc_new;
+}

--- a/color/curses.c
+++ b/color/curses.c
@@ -30,6 +30,7 @@
 #include <stddef.h>
 #include "mutt/lib.h"
 #include "gui/lib.h"
+#include "debug.h"
 
 struct CursesColorList CursesColors; ///< List of all Curses colours
 int NumCursesColors;
@@ -39,6 +40,7 @@ int NumCursesColors;
  */
 void curses_colors_init(void)
 {
+  color_debug(LL_DEBUG5, "init CursesColors\n");
   TAILQ_INIT(&CursesColors);
   NumCursesColors = 0;
 }
@@ -71,6 +73,7 @@ struct CursesColor *curses_colors_find(int fg, int bg)
  */
 static int curses_color_init(int fg, int bg)
 {
+  color_debug(LL_DEBUG5, "find lowest index\n");
   int index = 16;
   struct CursesColor *cc = NULL;
   TAILQ_FOREACH(cc, &CursesColors, entries)
@@ -80,6 +83,7 @@ static int curses_color_init(int fg, int bg)
     else
       break;
   }
+  color_debug(LL_DEBUG5, "lowest index = %d\n", index);
   if (index >= COLOR_PAIRS)
   {
     static bool warned = false;
@@ -91,11 +95,14 @@ static int curses_color_init(int fg, int bg)
     return 0;
   }
 
+  // const char *color = color_debug_log_color(fg, bg);
+  // printf("%s\n", color);
   if (fg == COLOR_DEFAULT)
     fg = COLOR_UNSET;
   if (bg == COLOR_DEFAULT)
     bg = COLOR_UNSET;
 
+  color_debug(LL_DEBUG5, "init_pair(%d,%d,%d) -> %d\n", index, fg, bg);
   init_pair(index, fg, bg);
 
   return index;
@@ -114,12 +121,17 @@ void curses_color_free(struct CursesColor **ptr)
   if (cc->ref_count > 1)
   {
     cc->ref_count--;
+    curses_color_dump(cc, "CursesColor rc--: ");
     *ptr = NULL;
+    // curses_colors_dump();
     return;
   }
 
+  curses_color_dump(cc, "free: ");
   TAILQ_REMOVE(&CursesColors, cc, entries);
   NumCursesColors--;
+  color_debug(LL_DEBUG5, "CursesColors: %d\n", NumCursesColors);
+  // curses_colors_dump();
   FREE(ptr);
 }
 
@@ -134,9 +146,11 @@ void curses_color_free(struct CursesColor **ptr)
  */
 struct CursesColor *curses_color_new(int fg, int bg)
 {
+  color_debug(LL_DEBUG5, "fg %d, bg %d\n", fg, bg);
   if (((fg == COLOR_UNSET) && (bg == COLOR_UNSET)) ||
       ((fg == COLOR_DEFAULT) && (bg == COLOR_DEFAULT)))
   {
+    color_debug(LL_DEBUG5, "both unset\n");
     return NULL;
   }
 
@@ -144,15 +158,18 @@ struct CursesColor *curses_color_new(int fg, int bg)
   if (cc)
   {
     cc->ref_count++;
+    curses_color_dump(cc, "rc++: ");
     return cc;
   }
 
+  color_debug(LL_DEBUG5, "new curses\n");
   int index = curses_color_init(fg, bg);
   if (index < 0)
     return NULL;
 
   struct CursesColor *cc_new = mutt_mem_calloc(1, sizeof(*cc_new));
   NumCursesColors++;
+  color_debug(LL_DEBUG5, "CursesColor %p\n", cc_new);
   cc_new->fg = fg;
   cc_new->bg = bg;
   cc_new->ref_count = 1;
@@ -163,13 +180,17 @@ struct CursesColor *curses_color_new(int fg, int bg)
   {
     if (cc->index > index)
     {
+      color_debug(LL_DEBUG5, "insert\n");
       TAILQ_INSERT_BEFORE(cc, cc_new, entries);
       goto done;
     }
   }
 
   TAILQ_INSERT_TAIL(&CursesColors, cc_new, entries);
+  color_debug(LL_DEBUG5, "tail\n");
 
 done:
+  curses_color_dump(cc_new, "CursesColor new: ");
+  color_debug(LL_DEBUG5, "CursesColors: %d\n", NumCursesColors);
   return cc_new;
 }

--- a/color/curses2.h
+++ b/color/curses2.h
@@ -46,6 +46,11 @@ struct CursesColor
 };
 TAILQ_HEAD(CursesColorList, CursesColor);
 
+#ifdef USE_DEBUG_COLOR
+extern struct CursesColorList CursesColors;
+extern int NumCursesColors;
+#endif
+
 void                curses_color_free(struct CursesColor **ptr);
 struct CursesColor *curses_color_new (int fg, int bg);
 

--- a/color/curses2.h
+++ b/color/curses2.h
@@ -1,0 +1,55 @@
+/**
+ * @file
+ * Curses Colour
+ *
+ * @authors
+ * Copyright (C) 2021 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MUTT_COLOR_CURSES_H
+#define MUTT_COLOR_CURSES_H
+
+#include "config.h"
+#include <stdint.h>
+#include "mutt/lib.h"
+
+/**
+ * struct CursesColor - Colour in the ncurses palette
+ *
+ * Curses stores colours as a foreground/background pair.
+ * There can be up to COLOR_PAIRS (65535) of these pairs.
+ * To use a colour, it must be initialised using init_pair().
+ */
+struct CursesColor
+{
+  /* TrueColor uses 24bit. Use fixed-width integer type to make sure it fits.
+   * Use the upper 8 bits to store flags.  */
+  uint32_t fg;                      ///< Foreground colour
+  uint32_t bg;                      ///< Background colour
+  short index;                      ///< Index number
+  short ref_count;                  ///< Number of users
+  TAILQ_ENTRY(CursesColor) entries; ///< Linked list
+};
+TAILQ_HEAD(CursesColorList, CursesColor);
+
+void                curses_color_free(struct CursesColor **ptr);
+struct CursesColor *curses_color_new (int fg, int bg);
+
+void                curses_colors_init(void);
+struct CursesColor *curses_colors_find (int fg, int bg);
+
+#endif /* MUTT_COLOR_CURSES_H */

--- a/color/debug.c
+++ b/color/debug.c
@@ -1,0 +1,454 @@
+/**
+ * @file
+ * Colour Debugging
+ *
+ * @authors
+ * Copyright (C) 2021 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @page color_debug Colour Debugging
+ *
+ * Lots of debugging of the colour code, conditional on './configure --debug-color'
+ */
+
+#include "config.h"
+#include <assert.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include "mutt/lib.h"
+#include "gui/lib.h"
+
+/**
+ * color_debug - Write to the log file
+ * @param level  Logging level, e.g. #LL_DEBUG1
+ * @param format Printf format string
+ * @param ...    Args for printf
+ * @retval num Number of characters printed
+ */
+int color_debug(enum LogLevel level, const char *format, ...)
+{
+  char buf[1024];
+
+  va_list ap;
+  va_start(ap, format);
+  int len = vsnprintf(buf, sizeof(buf), format, ap);
+  va_end(ap);
+
+  mutt_debug(level, buf);
+
+  return len;
+}
+
+/**
+ * color_debug_log_color_attrs - Get a colourful string to represent a colour in the log
+ * @param fg    Foreground colour
+ * @param bg    Background colour
+ * @param attrs Attributes, e.g. A_UNDERLINE
+ * @retval ptr Generated string
+ *
+ * @note Do not free the returned string
+ */
+const char *color_debug_log_color_attrs(int fg, int bg, int attrs)
+{
+  static char text[64];
+  int pos = 0;
+
+  if (attrs & A_BLINK)
+    pos += snprintf(text + pos, sizeof(text) - pos, "\033[5m");
+  if (attrs & A_BOLD)
+    pos += snprintf(text + pos, sizeof(text) - pos, "\033[1m");
+  if (attrs & A_NORMAL)
+    pos += snprintf(text + pos, sizeof(text) - pos, "\033[0m");
+  if (attrs & A_REVERSE)
+    pos += snprintf(text + pos, sizeof(text) - pos, "\033[7m");
+  if (attrs & A_STANDOUT)
+    pos += snprintf(text + pos, sizeof(text) - pos, "\033[1m");
+  if (attrs & A_UNDERLINE)
+    pos += snprintf(text + pos, sizeof(text) - pos, "\033[4m");
+
+  if (fg >= 0)
+    pos += snprintf(text + pos, sizeof(text) - pos, "\033[38;5;%dm", fg);
+  if (bg >= 0)
+    pos += snprintf(text + pos, sizeof(text) - pos, "\033[48;5;%dm", bg);
+
+  snprintf(text + pos, sizeof(text) - pos, "XXXXXX\033[0m");
+
+  return text;
+}
+
+/**
+ * color_debug_log_color - Get a colourful string to represent a colour in the log
+ * @param fg Foreground colour
+ * @param bg Background colour
+ * @retval ptr Generated string
+ *
+ * @note Do not free the returned string
+ */
+const char *color_debug_log_color(int fg, int bg)
+{
+  static char text[64];
+  snprintf(text, sizeof(text), "\033[38;5;%dm\033[48;5;%dmXXXXXX\033[0m", fg, bg);
+  return text;
+}
+
+/**
+ * color_debug_log_attrs - Get a string to represent some attributes in the log
+ * @param attrs Attributes, e.g. A_UNDERLINE
+ * @retval ptr Generated string
+ *
+ * @note Do not free the returned string
+ */
+const char *color_debug_log_attrs(int attrs)
+{
+  static char text[64];
+  struct Mapping attr_names[] = {
+    { "\033[5mBLI\033[0m", A_BLINK },
+    { "\033[1mBLD\033[0m", A_BOLD },
+    { "\033[0mNOR\033[0m", A_NORMAL },
+    { "\033[7mREV\033[0m", A_REVERSE },
+    { "\033[1mSTD\033[0m", A_STANDOUT },
+    { "\033[4mUND\033[0m", A_UNDERLINE },
+    { NULL, 0 },
+  };
+
+  int offset = 0;
+  text[0] = '\0';
+  for (int i = 0; attr_names[i].name; i++)
+  {
+    if (attrs & attr_names[i].value)
+    {
+      offset +=
+          snprintf(text + offset, sizeof(text) - offset, "%s ", attr_names[i].name);
+    }
+  }
+  return text;
+}
+
+/**
+ * color_debug_log_attrs_list - Get a string to represent some attributes in the log
+ * @param attrs Attributes, e.g. A_UNDERLINE
+ * @retval ptr Generated string
+ *
+ * @note Do not free the returned string
+ */
+const char *color_debug_log_attrs_list(int attrs)
+{
+  static char text[64];
+
+  text[0] = '\0';
+  int pos = 0;
+  if (attrs & A_BLINK)
+    pos += snprintf(text + pos, sizeof(text) - pos, "blink ");
+  if (attrs & A_BOLD)
+    pos += snprintf(text + pos, sizeof(text) - pos, "bold ");
+  if (attrs & A_NORMAL)
+    pos += snprintf(text + pos, sizeof(text) - pos, "normal ");
+  if (attrs & A_REVERSE)
+    pos += snprintf(text + pos, sizeof(text) - pos, "reverse ");
+  if (attrs & A_STANDOUT)
+    pos += snprintf(text + pos, sizeof(text) - pos, "standout ");
+  if (attrs & A_UNDERLINE)
+    pos += snprintf(text + pos, sizeof(text) - pos, "underline ");
+
+  return text;
+}
+
+/**
+ * color_debug_log_name - Get a string to represent a colour name
+ * @param buf    Buffer for the result
+ * @param buflen Length of the Buffer
+ * @param color  Palette colour number
+ * @retval ptr Generated string
+ */
+const char *color_debug_log_name(char *buf, int buflen, int color)
+{
+  if (color < 0)
+    return "default";
+
+  if (color < 256)
+    snprintf(buf, buflen, "color%d", color);
+  else
+    snprintf(buf, buflen, "BAD:%d", color);
+
+  return buf;
+}
+
+/**
+ * attr_color_dump - Dump an Attr Colour to the log
+ * @param ac     AttrColor to dump
+ * @param prefix prefix for the log block
+ */
+void attr_color_dump(struct AttrColor *ac, const char *prefix)
+{
+  if (!ac)
+    return;
+
+  int index = ac->curses_color ? ac->curses_color->index : -1;
+
+  int fg = COLOR_DEFAULT;
+  int bg = COLOR_DEFAULT;
+  struct CursesColor *cc = ac->curses_color;
+  if (cc)
+  {
+    fg = cc->fg;
+    bg = cc->bg;
+  }
+  const char *color = color_debug_log_color(fg, bg);
+  const char *attrs = color_debug_log_attrs(ac->attrs);
+  color_debug(LL_DEBUG5, "%s| %5d | %s | 0x%08x | %s\n", NONULL(prefix), index,
+              color, ac->attrs, attrs);
+}
+
+/**
+ * attr_color_list_dump - Dump all the Attr Colours to the log
+ * @param acl   List of Attr colours
+ * @param title Title for the log block
+ */
+void attr_color_list_dump(struct AttrColorList *acl, const char *title)
+{
+  if (!acl)
+    return;
+
+  int count = 0;
+  struct AttrColor *ac = NULL;
+  TAILQ_FOREACH(ac, acl, entries)
+  {
+    count++;
+  }
+
+  color_debug(LL_DEBUG5, "\033[1;32m%s:\033[0m (%d)\n", title, count);
+  if (count == 0)
+    return;
+
+  color_debug(LL_DEBUG5, "    | Index | Colour | Attrs      | Attrs\n");
+
+  TAILQ_FOREACH(ac, acl, entries)
+  {
+    attr_color_dump(ac, "    ");
+  }
+}
+
+/**
+ * curses_color_dump - Log one Curses colour
+ * @param cc     CursesColor to log
+ * @param prefix Prefix for the log line
+ */
+void curses_color_dump(struct CursesColor *cc, const char *prefix)
+{
+  if (!cc)
+    return;
+
+  const char *color = color_debug_log_color(cc->fg, cc->bg);
+  color_debug(LL_DEBUG5, "%s| %5d | %3d %3d | %s | %2d |\n", NONULL(prefix),
+              cc->index, cc->fg, cc->bg, color, cc->ref_count);
+}
+
+/**
+ * curses_colors_dump - Log all the Curses colours
+ */
+void curses_colors_dump(void)
+{
+  color_debug(LL_DEBUG5, "\033[1;32mCursesColors:\033[0m (%d)\n", NumCursesColors);
+  if (TAILQ_EMPTY(&CursesColors))
+    return;
+
+  color_debug(LL_DEBUG5, "    | index |  fg  bg | colour | rc |\n");
+
+  struct CursesColor *cc = NULL;
+  TAILQ_FOREACH(cc, &CursesColors, entries)
+  {
+    curses_color_dump(cc, "    ");
+  }
+}
+
+/**
+ * quoted_color_dump - Log a Quoted colour
+ * @param ac      Quoted colour
+ * @param q_level Quote level
+ * @param prefix  Prefix for the log line
+ */
+void quoted_color_dump(struct AttrColor *ac, int q_level, const char *prefix)
+{
+  if (!ac)
+    return;
+
+  int index = ac->curses_color ? ac->curses_color->index : -1;
+
+  int fg = COLOR_DEFAULT;
+  int bg = COLOR_DEFAULT;
+  struct CursesColor *cc = ac->curses_color;
+  if (cc)
+  {
+    fg = cc->fg;
+    bg = cc->bg;
+  }
+  const char *color = color_debug_log_color(fg, bg);
+  const char *attrs = color_debug_log_attrs(ac->attrs);
+  color_debug(LL_DEBUG5, "%s| quoted%d | %5d | %s | 0x%08x | %s\n", prefix,
+              q_level, index, color, ac->attrs, attrs);
+}
+
+/**
+ * quoted_color_list_dump - Log all the Quoted colours
+ */
+void quoted_color_list_dump(void)
+{
+  color_debug(LL_DEBUG5, "\033[1;32mQuotedColors:\033[0m (%d)\n", NumQuotedColors);
+  color_debug(LL_DEBUG5,
+              "    | Name    | Index | Colour | Attrs      | Attrs\n");
+  for (size_t i = 0; i < COLOR_QUOTES_MAX; i++)
+  {
+    quoted_color_dump(&QuotedColors[i], i, "    ");
+  }
+}
+
+/**
+ * regex_color_dump - Dump a Regex colour to the log
+ * @param rcol   Regex to dump
+ * @param prefix Prefix for the log line
+ */
+void regex_color_dump(struct RegexColor *rcol, const char *prefix)
+{
+  if (!rcol)
+    return;
+
+  struct AttrColor *ac = &rcol->attr_color;
+  int index = ac->curses_color ? ac->curses_color->index : -1;
+
+  int fg = COLOR_DEFAULT;
+  int bg = COLOR_DEFAULT;
+  struct CursesColor *cc = ac->curses_color;
+  if (cc)
+  {
+    fg = cc->fg;
+    bg = cc->bg;
+  }
+  const char *color = color_debug_log_color(fg, bg);
+  const char *attrs = color_debug_log_attrs(ac->attrs);
+  color_debug(LL_DEBUG5, "%s| %5d | %s | 0x%08x | %-8s | %s\n", NONULL(prefix),
+              index, color, ac->attrs, attrs, rcol->pattern);
+}
+
+/**
+ * regex_color_list_dump - Dump one Regex's colours to the log
+ * @param name Name of the Regex
+ * @param rcl  RegexColorList to dump
+ */
+void regex_color_list_dump(const char *name, struct RegexColorList *rcl)
+{
+  if (!name || !rcl)
+    return;
+
+  int count = 0;
+  struct RegexColor *rcol = NULL;
+  STAILQ_FOREACH(rcol, rcl, entries)
+  {
+    count++;
+  }
+
+  color_debug(LL_DEBUG5, "\033[1;32mRegexColorList %s\033[0m (%d)\n", name, count);
+  if (count == 0)
+    return;
+
+  color_debug(LL_DEBUG5,
+              "    | Index | Colour | Attrs      | Attrs    | Pattern\n");
+  STAILQ_FOREACH(rcol, rcl, entries)
+  {
+    regex_color_dump(rcol, "    ");
+  }
+}
+
+/**
+ * regex_colors_dump_all - Dump all the Regex colours to the log
+ */
+void regex_colors_dump_all(void)
+{
+  regex_color_list_dump("AttachList", &AttachList);
+  regex_color_list_dump("BodyList", &BodyList);
+  regex_color_list_dump("HeaderList", &HeaderList);
+  regex_color_list_dump("IndexAuthorList", &IndexAuthorList);
+  regex_color_list_dump("IndexFlagsList", &IndexFlagsList);
+  regex_color_list_dump("IndexList", &IndexList);
+  regex_color_list_dump("IndexSubjectList", &IndexSubjectList);
+  regex_color_list_dump("IndexTagList", &IndexTagList);
+  regex_color_list_dump("StatusList", &StatusList);
+}
+
+/**
+ * simple_color_dump - Dump a Simple colour to the log
+ * @param cid    Colour Id, e.g. #MT_COLOR_UNDERLINE
+ * @param prefix Prefix for the log line
+ */
+void simple_color_dump(enum ColorId cid, const char *prefix)
+{
+  struct AttrColor *ac = &SimpleColors[cid];
+  int index = ac->curses_color ? ac->curses_color->index : -1;
+  const char *name = NULL;
+  const char *compose = "";
+
+  name = mutt_map_get_name(cid, ColorFields);
+  if (!name)
+  {
+    name = mutt_map_get_name(cid, ComposeColorFields);
+    if (name)
+    {
+      compose = "compose ";
+    }
+  }
+
+  int fg = COLOR_DEFAULT;
+  int bg = COLOR_DEFAULT;
+  struct CursesColor *cc = ac->curses_color;
+  if (cc)
+  {
+    fg = cc->fg;
+    bg = cc->bg;
+  }
+  const char *color_str = color_debug_log_color(fg, bg);
+  const char *attrs_str = color_debug_log_attrs(ac->attrs);
+  color_debug(LL_DEBUG5, "%s| %s%-17s | %5d | %s | 0x%08x | %s\n", prefix,
+              compose, name, index, color_str, ac->attrs, attrs_str);
+}
+
+/**
+ * simple_colors_dump - Dump all the Simple colours to the log
+ */
+void simple_colors_dump(bool force)
+{
+  color_debug(LL_DEBUG5, "\033[1;32mSimpleColors:\033[0m\n");
+  color_debug(
+      LL_DEBUG5,
+      "    | Name              | Index | Colour | Attrs      | Attrs\n");
+  for (enum ColorId cid = MT_COLOR_NONE; cid < MT_COLOR_MAX; cid++)
+  {
+    struct AttrColor *ac = &SimpleColors[cid];
+    if (!force && !attr_color_is_set(ac))
+      continue;
+
+    simple_color_dump(cid, "    ");
+  }
+}
+
+/**
+ * merged_colors_dump - Dump all the Merged colours to the log
+ */
+void merged_colors_dump(void)
+{
+  attr_color_list_dump(&MergedColors, "MergedColors");
+}

--- a/color/debug.h
+++ b/color/debug.h
@@ -32,14 +32,14 @@ struct AttrColorList;
 struct RegexColor;
 struct RegexColorList;
 
-#ifdef USE_DEBUG_COLOR
-
-const char *color_debug_log_attrs(int attrs);
-const char *color_debug_log_color(int fg, int bg);
 const char *color_debug_log_color_attrs(int fg, int bg, int attrs);
 const char *color_debug_log_name(char *buf, int buflen, int color);
 const char *color_debug_log_attrs_list(int attrs);
 
+#ifdef USE_DEBUG_COLOR
+
+const char *color_debug_log_attrs(int attrs);
+const char *color_debug_log_color(int fg, int bg);
 void attr_color_dump       (struct AttrColor *ac, const char *prefix);
 void attr_color_list_dump  (struct AttrColorList *acl, const char *title);
 

--- a/color/debug.h
+++ b/color/debug.h
@@ -1,0 +1,90 @@
+/**
+ * @file
+ * Colour Debugging
+ *
+ * @authors
+ * Copyright (C) 2021 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MUTT_COLOR_DEBUG_H
+#define MUTT_COLOR_DEBUG_H
+
+#include "config.h"
+#include <stdbool.h>
+#include "mutt/lib.h"
+#include "color.h"
+
+struct AttrColorList;
+struct RegexColor;
+struct RegexColorList;
+
+#ifdef USE_DEBUG_COLOR
+
+const char *color_debug_log_attrs(int attrs);
+const char *color_debug_log_color(int fg, int bg);
+const char *color_debug_log_color_attrs(int fg, int bg, int attrs);
+const char *color_debug_log_name(char *buf, int buflen, int color);
+const char *color_debug_log_attrs_list(int attrs);
+
+void attr_color_dump       (struct AttrColor *ac, const char *prefix);
+void attr_color_list_dump  (struct AttrColorList *acl, const char *title);
+
+void curses_color_dump     (struct CursesColor *cc, const char *prefix);
+void curses_colors_dump    (void);
+
+void merged_colors_dump    (void);
+
+void quoted_color_dump     (struct AttrColor *ac, int q_level, const char *prefix);
+void quoted_color_list_dump(void);
+
+void regex_color_dump      (struct RegexColor *rcol, const char *prefix);
+void regex_color_list_dump (const char *name, struct RegexColorList *rcl);
+void regex_colors_dump_all (void);
+
+void simple_color_dump     (enum ColorId cid, const char *prefix);
+void simple_colors_dump    (bool force);
+
+int color_debug(enum LogLevel level, const char *format, ...);
+
+#else
+
+static inline const char *color_debug_log_attrs(int attrs) { return ""; }
+static inline const char *color_debug_log_color(int fg, int bg) { return ""; }
+
+static inline void attr_color_dump       (struct AttrColor *ac, const char *prefix) {}
+static inline void attr_color_list_dump  (struct AttrColorList *acl, const char *title) {}
+
+static inline void curses_color_dump     (struct CursesColor *cc, const char *prefix) {}
+static inline void curses_colors_dump    (void) {}
+
+static inline void merged_colors_dump    (void) {}
+
+static inline void quoted_color_dump     (struct AttrColor *ac, int q_level, const char *prefix) {}
+static inline void quoted_color_list_dump(void) {}
+
+static inline void regex_color_dump      (struct RegexColor *rcol, const char *prefix) {}
+static inline void regex_color_list_dump (const char *name, struct RegexColorList *rcl) {}
+static inline void regex_colors_dump_all (void) {}
+
+static inline void simple_color_dump     (enum ColorId cid, const char *prefix) {}
+static inline void simple_colors_dump    (bool force) {}
+
+static inline int color_debug(enum LogLevel level, const char *format, ...) { return 0; }
+
+#endif
+
+#endif /* MUTT_COLOR_DEBUG_H */

--- a/color/lib.h
+++ b/color/lib.h
@@ -32,6 +32,7 @@
  * | color/color.c       | @subpage color_color       |
  * | color/command.c     | @subpage color_command     |
  * | color/curses.c      | @subpage color_curses      |
+ * | color/debug.c       | @subpage color_debug       |
  * | color/merged.c      | @subpage color_merge       |
  * | color/notify.c      | @subpage color_notify      |
  * | color/quoted.c      | @subpage color_quote       |
@@ -48,6 +49,7 @@
 #include "color.h"
 #include "command2.h"
 #include "curses2.h"
+#include "debug.h"
 #include "merged.h"
 #include "notify2.h"
 #include "quoted.h"

--- a/color/lib.h
+++ b/color/lib.h
@@ -27,8 +27,12 @@
  *
  * | File                | Description                |
  * | :------------------ | :------------------------- |
+ * | color/ansi.c        | @subpage color_ansi        |
+ * | color/attr.c        | @subpage color_attr        |
  * | color/color.c       | @subpage color_color       |
  * | color/command.c     | @subpage color_command     |
+ * | color/curses.c      | @subpage color_curses      |
+ * | color/merged.c      | @subpage color_merge       |
  * | color/notify.c      | @subpage color_notify      |
  * | color/quoted.c      | @subpage color_quote       |
  * | color/regex.c       | @subpage color_regex       |
@@ -45,8 +49,12 @@
 #include "core/lib.h"
 
 // IWYU pragma: begin_exports
+#include "ansi.h"
+#include "attr.h"
 #include "color.h"
 #include "command2.h"
+#include "curses2.h"
+#include "merged.h"
 #include "notify2.h"
 #include "quoted.h"
 #include "regex4.h"

--- a/color/lib.h
+++ b/color/lib.h
@@ -42,12 +42,6 @@
 #ifndef MUTT_COLOR_LIB_H
 #define MUTT_COLOR_LIB_H
 
-#include "config.h"
-#include <stdbool.h>
-#include <stdint.h>
-#include "mutt/lib.h"
-#include "core/lib.h"
-
 // IWYU pragma: begin_exports
 #include "ansi.h"
 #include "attr.h"
@@ -60,15 +54,5 @@
 #include "regex4.h"
 #include "simple2.h"
 // IWYU pragma: end_exports
-
-bool mutt_color_is_header(enum ColorId color_id);
-int mutt_color_alloc  (uint32_t fg, uint32_t bg);
-int mutt_color_combine(uint32_t fg_attr, uint32_t bg_attr);
-void mutt_color_free  (uint32_t fg, uint32_t bg);
-
-void mutt_colors_init(void);
-void mutt_colors_cleanup(void);
-
-void colors_clear(void);
 
 #endif /* MUTT_COLOR_LIB_H */

--- a/color/merged.c
+++ b/color/merged.c
@@ -1,0 +1,146 @@
+/**
+ * @file
+ * Merged colours
+ *
+ * @authors
+ * Copyright (C) 2021 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @page color_merge Merged colours
+ *
+ * When multiple graphical objects meet, it's often necessary to merge their
+ * colours.  e.g. In the Index where the colour of the Email tree is overlaid
+ * by the Indicator colour.
+ */
+
+#include "config.h"
+#include <stddef.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include "mutt/lib.h"
+#include "gui/lib.h"
+#include "attr.h"
+
+struct AttrColorList MergedColors; ///< Array of user colours
+
+/**
+ * merged_colors_init - Initialise the Merged colours
+ */
+void merged_colors_init(void)
+{
+  TAILQ_INIT(&MergedColors);
+}
+
+/**
+ * merged_colors_clear - Free the list of Merged colours
+ */
+void merged_colors_clear(void)
+{
+  struct AttrColor *ac = NULL;
+  struct AttrColor *tmp = NULL;
+
+  TAILQ_FOREACH_SAFE(ac, &MergedColors, entries, tmp)
+  {
+    TAILQ_REMOVE(&MergedColors, ac, entries);
+    curses_color_free(&ac->curses_color);
+    FREE(&ac);
+  }
+}
+
+/**
+ * merged_colors_find - Find a Merged colour
+ * @param fg    Foreground colour
+ * @param bg    Background colour
+ * @param attrs Attributes, e.g. A_UNDERLINE
+ * @retval ptr Matching Merged colour
+ */
+struct AttrColor *merged_colors_find(int fg, int bg, int attrs)
+{
+  struct AttrColor *ac = NULL;
+  TAILQ_FOREACH(ac, &MergedColors, entries)
+  {
+    if (ac->attrs != attrs)
+      continue;
+
+    bool has_color = (fg != COLOR_DEFAULT) || (bg != COLOR_DEFAULT);
+    struct CursesColor *cc = ac->curses_color;
+
+    // Both have only attributes
+    if (!has_color && !cc)
+      return ac;
+
+    // One has colour, but not the other
+    if ((has_color && !cc) || (!has_color && cc))
+      continue;
+
+    if ((cc->fg == fg) && (cc->bg == bg))
+      return ac;
+  }
+  return NULL;
+}
+
+/**
+ * merged_color_overlay - Combine two colours
+ * @param base Base colour
+ * @param over Overlay colour
+ * @retval ptr Merged colour
+ *
+ * If either the foreground or background of the overlay is 'default', then the
+ * base colour will show through.  The attributes of both base and overlay will
+ * be OR'd together.
+ */
+struct AttrColor *merged_color_overlay(struct AttrColor *base, struct AttrColor *over)
+{
+  if (!over || (!over->curses_color && (over->attrs == 0)))
+    return base;
+  if (!base || (!base->curses_color && (base->attrs == 0)))
+    return over;
+
+  struct CursesColor *cc_base = base->curses_color;
+  struct CursesColor *cc_over = over->curses_color;
+
+  uint32_t fg = COLOR_DEFAULT;
+  uint32_t bg = COLOR_DEFAULT;
+
+  if (cc_over)
+  {
+    fg = cc_over->fg;
+    bg = cc_over->bg;
+  }
+
+  if (cc_base)
+  {
+    if (fg == COLOR_DEFAULT)
+      fg = cc_base->fg;
+    if (bg == COLOR_DEFAULT)
+      bg = cc_base->bg;
+  }
+
+  int attrs = base->attrs | over->attrs;
+
+  struct AttrColor *ac = merged_colors_find(fg, bg, attrs);
+  if (ac)
+    return ac;
+
+  ac = attr_color_new();
+  ac->curses_color = curses_color_new(fg, bg);
+  ac->attrs = attrs;
+  TAILQ_INSERT_TAIL(&MergedColors, ac, entries);
+
+  return ac;
+}

--- a/color/merged.c
+++ b/color/merged.c
@@ -35,6 +35,7 @@
 #include "mutt/lib.h"
 #include "gui/lib.h"
 #include "attr.h"
+#include "debug.h"
 
 struct AttrColorList MergedColors; ///< Array of user colours
 
@@ -141,6 +142,7 @@ struct AttrColor *merged_color_overlay(struct AttrColor *base, struct AttrColor 
   ac->curses_color = curses_color_new(fg, bg);
   ac->attrs = attrs;
   TAILQ_INSERT_TAIL(&MergedColors, ac, entries);
+  merged_colors_dump();
 
   return ac;
 }

--- a/color/merged.h
+++ b/color/merged.h
@@ -26,6 +26,10 @@
 #include "config.h"
 #include "attr.h"
 
+#ifdef USE_DEBUG_COLOR
+extern struct AttrColorList MergedColors;
+#endif
+
 struct AttrColor * merged_color_overlay(struct AttrColor *base, struct AttrColor *over);
 
 void               merged_colors_clear(void);

--- a/color/merged.h
+++ b/color/merged.h
@@ -1,0 +1,35 @@
+/**
+ * @file
+ * Merged colours
+ *
+ * @authors
+ * Copyright (C) 2021 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MUTT_COLOR_MERGED_H
+#define MUTT_COLOR_MERGED_H
+
+#include "config.h"
+#include "attr.h"
+
+struct AttrColor * merged_color_overlay(struct AttrColor *base, struct AttrColor *over);
+
+void               merged_colors_clear(void);
+struct AttrColor * merged_colors_find(int fg, int bg, int attrs);
+void               merged_colors_init(void);
+
+#endif /* MUTT_COLOR_MERGED_H */

--- a/color/notify2.h
+++ b/color/notify2.h
@@ -52,6 +52,7 @@ enum NotifyColor
 struct EventColor
 {
   enum ColorId cid;             ///< Colour ID that has changed
+  struct AttrColor *attr_color; ///< Colour object that has changed
 };
 
 void color_notify_init(void);

--- a/color/quoted.c
+++ b/color/quoted.c
@@ -35,24 +35,32 @@
 #include "gui/lib.h"
 #include "options.h"
 
-int QuotedColors[COLOR_QUOTES_MAX]; ///< Array of colours for quoted email text
-int NumQuotedColors;                ///< Number of colours for quoted email text
+struct AttrColor QuotedColors[COLOR_QUOTES_MAX]; ///< Array of colours for quoted email text
+int NumQuotedColors; ///< Number of colours for quoted email text
+
+/**
+ * find_highest_used - Find the highest-numbered quotedN in use
+ * @retval num Highest number
+ */
+int find_highest_used(void)
+{
+  for (int i = COLOR_QUOTES_MAX - 1; i >= 0; i--)
+  {
+    if (attr_color_is_set(&QuotedColors[i]))
+      return i + 1;
+  }
+  return 0;
+}
 
 /**
  * quoted_colors_clear - Reset the quoted-email colours
  */
 void quoted_colors_clear(void)
 {
-  memset(QuotedColors, A_NORMAL, COLOR_QUOTES_MAX * sizeof(int));
-  NumQuotedColors = 0;
-}
-
-/**
- * quoted_colors_init - Initialise the quoted-email colours
- */
-void quoted_colors_init(void)
-{
-  memset(QuotedColors, A_NORMAL, COLOR_QUOTES_MAX * sizeof(int));
+  for (size_t i = 0; i < COLOR_QUOTES_MAX; i++)
+  {
+    attr_color_clear(&QuotedColors[i]);
+  }
   NumQuotedColors = 0;
 }
 
@@ -61,12 +69,11 @@ void quoted_colors_init(void)
  * @param q Quote level
  * @retval num Color ID, e.g. #MT_COLOR_QUOTED
  */
-int quoted_colors_get(int q)
+struct AttrColor *quoted_colors_get(int q)
 {
-  const int used = NumQuotedColors;
-  if (used == 0)
-    return 0;
-  return QuotedColors[q % used];
+  if (NumQuotedColors == 0)
+    return NULL;
+  return &QuotedColors[q % NumQuotedColors];
 }
 
 /**
@@ -104,23 +111,46 @@ bool quoted_colors_parse_color(enum ColorId cid, uint32_t fg, uint32_t bg,
   if (q_level >= NumQuotedColors)
     NumQuotedColors = q_level + 1;
 
-  if (q_level == 0)
-  {
-    SimpleColors[MT_COLOR_QUOTED] = fgbgattr_to_color(fg, bg, attrs);
+  struct AttrColor *ac = &QuotedColors[q_level];
+  ac->attrs = attrs;
 
-    QuotedColors[0] = SimpleColors[MT_COLOR_QUOTED];
-    for (q_level = 1; q_level < NumQuotedColors; q_level++)
-    {
-      if (QuotedColors[q_level] == A_NORMAL)
-        QuotedColors[q_level] = SimpleColors[MT_COLOR_QUOTED];
-    }
-  }
-  else
-  {
-    QuotedColors[q_level] = fgbgattr_to_color(fg, bg, attrs);
-  }
+  struct CursesColor *cc = curses_color_new(fg, bg);
+  curses_color_free(&ac->curses_color);
+  ac->curses_color = cc;
+
+  if (!cc)
+    NumQuotedColors = find_highest_used();
+
+  struct Buffer *buf = mutt_buffer_pool_get();
+  get_colorid_name(cid, buf);
+  mutt_buffer_pool_release(&buf);
+
+  struct EventColor ev_c = { cid, ac };
+  notify_send(ColorsNotify, NT_COLOR, NT_COLOR_SET, &ev_c);
+
   *rc = MUTT_CMD_SUCCESS;
   return true;
+}
+
+/**
+ * quoted_colors_parse_uncolor - Parse the 'uncolor quoted' command
+ * @param cid     Colour Id, should be #MT_COLOR_QUOTED
+ * @param q_level Quoting depth level
+ * @param err     Buffer for error messages
+ * @retval num Result, e.g. #MUTT_CMD_SUCCESS
+ */
+enum CommandResult quoted_colors_parse_uncolor(enum ColorId cid, int q_level,
+                                               struct Buffer *err)
+{
+  struct AttrColor *ac = &QuotedColors[q_level];
+  attr_color_clear(ac);
+
+  NumQuotedColors = find_highest_used();
+
+  struct EventColor ev_c = { cid, ac };
+  notify_send(ColorsNotify, NT_COLOR, NT_COLOR_RESET, &ev_c);
+
+  return MUTT_CMD_SUCCESS;
 }
 
 /**
@@ -187,7 +217,7 @@ static void qstyle_insert(struct QuoteStyle *quote_list,
     if (q_list->quote_n >= index)
     {
       q_list->quote_n++;
-      q_list->color = quoted_colors_get(q_list->quote_n);
+      q_list->attr_color = quoted_colors_get(q_list->quote_n);
     }
     if (q_list->down)
       q_list = q_list->down;
@@ -207,7 +237,7 @@ static void qstyle_insert(struct QuoteStyle *quote_list,
   }
 
   new_class->quote_n = index;
-  new_class->color = quoted_colors_get(index);
+  new_class->attr_color = quoted_colors_get(index);
   (*q_level)++;
 }
 
@@ -228,19 +258,6 @@ struct QuoteStyle *qstyle_classify(struct QuoteStyle **quote_list, const char *q
   const char *tail_qptr = NULL;
   size_t offset, tail_lng;
   int index = -1;
-
-  if (quoted_colors_num_used() <= 1)
-  {
-    /* not much point in classifying quotes... */
-
-    if (!*quote_list)
-    {
-      qc = qstyle_new();
-      qc->color = quoted_colors_get(0);
-      *quote_list = qc;
-    }
-    return *quote_list;
-  }
 
   /* classify quoting prefix */
   while (q_list)
@@ -480,7 +497,7 @@ struct QuoteStyle *qstyle_classify(struct QuoteStyle **quote_list, const char *q
           tmp->up = ptr;
 
           tmp->quote_n = (*q_level)++;
-          tmp->color = quoted_colors_get(tmp->quote_n);
+          tmp->attr_color = quoted_colors_get(tmp->quote_n);
 
           return tmp;
         }
@@ -508,18 +525,61 @@ struct QuoteStyle *qstyle_classify(struct QuoteStyle **quote_list, const char *q
     qc->prefix = mutt_strn_dup(qptr, length);
     qc->prefix_len = length;
     qc->quote_n = (*q_level)++;
-    qc->color = quoted_colors_get(qc->quote_n);
+    qc->attr_color = quoted_colors_get(qc->quote_n);
 
     if (*quote_list)
     {
-      qc->next = *quote_list;
-      (*quote_list)->prev = qc;
+      (*quote_list)->next = qc;
+      qc->prev = *quote_list;
     }
-    *quote_list = qc;
+    else
+    {
+      *quote_list = qc;
+    }
   }
 
   if (index != -1)
     qstyle_insert(*quote_list, tmp, index, q_level);
 
   return qc;
+}
+
+/**
+ * qstyle_recurse - Update the quoting styles after colour changes
+ * @param quote_list Styles to update
+ * @param num_qlevel Number of quote levels
+ * @param cur_qlevel Current quote level
+ */
+static void qstyle_recurse(struct QuoteStyle *quote_list, int num_qlevel, int *cur_qlevel)
+{
+  if (!quote_list)
+    return;
+
+  if (num_qlevel > 0)
+  {
+    quote_list->attr_color = quoted_colors_get(*cur_qlevel);
+    *cur_qlevel = (*cur_qlevel + 1) % num_qlevel;
+  }
+  else
+  {
+    quote_list->attr_color = NULL;
+  }
+
+  qstyle_recurse(quote_list->down, num_qlevel, cur_qlevel);
+  qstyle_recurse(quote_list->next, num_qlevel, cur_qlevel);
+}
+
+/**
+ * qstyle_recolour - Recolour quotes after colour changes
+ * @param quote_list List of quote colours
+ */
+void qstyle_recolour(struct QuoteStyle *quote_list)
+{
+  if (!quote_list)
+    return;
+
+  int num = quoted_colors_num_used();
+  int cur = 0;
+
+  qstyle_recurse(quote_list, num, &cur);
 }

--- a/color/quoted.c
+++ b/color/quoted.c
@@ -33,6 +33,7 @@
 #include "mutt/lib.h"
 #include "core/lib.h"
 #include "gui/lib.h"
+#include "debug.h"
 #include "options.h"
 
 struct AttrColor QuotedColors[COLOR_QUOTES_MAX]; ///< Array of colours for quoted email text
@@ -57,6 +58,7 @@ int find_highest_used(void)
  */
 void quoted_colors_clear(void)
 {
+  color_debug(LL_DEBUG5, "QuotedColors: clean up\n");
   for (size_t i = 0; i < COLOR_QUOTES_MAX; i++)
   {
     attr_color_clear(&QuotedColors[i]);
@@ -102,6 +104,7 @@ bool quoted_colors_parse_color(enum ColorId cid, uint32_t fg, uint32_t bg,
   if (cid != MT_COLOR_QUOTED)
     return false;
 
+  color_debug(LL_DEBUG5, "quoted %d\n", q_level);
   if (q_level >= COLOR_QUOTES_MAX)
   {
     mutt_buffer_printf(err, _("Maximum quoting level is %d"), COLOR_QUOTES_MAX - 1);
@@ -112,6 +115,7 @@ bool quoted_colors_parse_color(enum ColorId cid, uint32_t fg, uint32_t bg,
     NumQuotedColors = q_level + 1;
 
   struct AttrColor *ac = &QuotedColors[q_level];
+  const bool was_set = ((ac->attrs != 0) || ac->curses_color);
   ac->attrs = attrs;
 
   struct CursesColor *cc = curses_color_new(fg, bg);
@@ -121,12 +125,21 @@ bool quoted_colors_parse_color(enum ColorId cid, uint32_t fg, uint32_t bg,
   if (!cc)
     NumQuotedColors = find_highest_used();
 
+  if (was_set)
+    quoted_color_dump(ac, q_level, "QuotedColors changed: ");
+  else
+    quoted_color_dump(ac, q_level, "QuotedColors new: ");
+
   struct Buffer *buf = mutt_buffer_pool_get();
   get_colorid_name(cid, buf);
+  color_debug(LL_DEBUG5, "NT_COLOR_SET: %s\n", buf->data);
   mutt_buffer_pool_release(&buf);
 
   struct EventColor ev_c = { cid, ac };
   notify_send(ColorsNotify, NT_COLOR, NT_COLOR_SET, &ev_c);
+
+  curses_colors_dump();
+  quoted_color_list_dump();
 
   *rc = MUTT_CMD_SUCCESS;
   return true;
@@ -142,8 +155,14 @@ bool quoted_colors_parse_color(enum ColorId cid, uint32_t fg, uint32_t bg,
 enum CommandResult quoted_colors_parse_uncolor(enum ColorId cid, int q_level,
                                                struct Buffer *err)
 {
+  color_debug(LL_DEBUG5, "unquoted %d\n", q_level);
+
   struct AttrColor *ac = &QuotedColors[q_level];
   attr_color_clear(ac);
+  quoted_color_dump(ac, q_level, "QuotedColors clear: ");
+
+  curses_colors_dump();
+  quoted_color_list_dump();
 
   NumQuotedColors = find_highest_used();
 
@@ -581,5 +600,7 @@ void qstyle_recolour(struct QuoteStyle *quote_list)
   int num = quoted_colors_num_used();
   int cur = 0;
 
+  quoted_color_list_dump();
   qstyle_recurse(quote_list, num, &cur);
+  quoted_color_list_dump();
 }

--- a/color/quoted.h
+++ b/color/quoted.h
@@ -34,10 +34,8 @@ struct Buffer;
 /// Ten colours, quoted0..quoted9 (quoted and quoted0 are equivalent)
 #define COLOR_QUOTES_MAX 10
 
-#ifdef USE_DEBUG_COLOR
 extern struct AttrColor QuotedColors[];
 extern int NumQuotedColors;
-#endif
 
 /**
  * struct QuoteStyle - Style of quoted text

--- a/color/quoted.h
+++ b/color/quoted.h
@@ -34,9 +34,6 @@ struct Buffer;
 /// Ten colours, quoted0..quoted9 (quoted and quoted0 are equivalent)
 #define COLOR_QUOTES_MAX 10
 
-extern int QuotedColors[];
-extern int NumQuotedColors;
-
 /**
  * struct QuoteStyle - Style of quoted text
  *
@@ -65,7 +62,7 @@ extern int NumQuotedColors;
 struct QuoteStyle
 {
   int quote_n;                      ///< The quoteN colour index for this level
-  int color;                        ///< Curses colour pair
+  struct AttrColor *attr_color;     ///< Colour and attribute of the text
   char *prefix;                     ///< Prefix string, e.g. "> "
   size_t prefix_len;                ///< Length of the prefix string
   struct QuoteStyle *prev, *next;   ///< Different quoting styles at the same level
@@ -73,13 +70,14 @@ struct QuoteStyle
 };
 
 void               quoted_colors_clear(void);
-int                quoted_colors_get(int q);
-void               quoted_colors_init(void);
+struct AttrColor * quoted_colors_get(int q);
 int                quoted_colors_num_used(void);
 
 bool               quoted_colors_parse_color  (enum ColorId cid, uint32_t fg, uint32_t bg, int attrs, int q_level, int *rc, struct Buffer *err);
+enum CommandResult quoted_colors_parse_uncolor(enum ColorId cid, int q_level, struct Buffer *err);
 
 struct QuoteStyle *qstyle_classify (struct QuoteStyle **quote_list, const char *qptr, size_t length, bool *force_redraw, int *q_level);
 void               qstyle_free_tree(struct QuoteStyle **quote_list);
+void               qstyle_recolour (struct QuoteStyle *quote_list);
 
 #endif /* MUTT_COLOR_QUOTED_H */

--- a/color/quoted.h
+++ b/color/quoted.h
@@ -34,6 +34,11 @@ struct Buffer;
 /// Ten colours, quoted0..quoted9 (quoted and quoted0 are equivalent)
 #define COLOR_QUOTES_MAX 10
 
+#ifdef USE_DEBUG_COLOR
+extern struct AttrColor QuotedColors[];
+extern int NumQuotedColors;
+#endif
+
 /**
  * struct QuoteStyle - Style of quoted text
  *

--- a/color/regex.c
+++ b/color/regex.c
@@ -33,14 +33,16 @@
 #include <stdint.h>
 #include "mutt/lib.h"
 #include "config/lib.h"
-#include "email/lib.h"
 #include "core/lib.h"
-#include "gui/lib.h"
 #include "index/lib.h"
 #include "pattern/lib.h"
+#include "attr.h"
 #include "color.h"
+#include "command2.h"
 #include "context.h"
+#include "curses2.h"
 #include "mutt_globals.h"
+#include "notify2.h"
 #include "regex4.h"
 
 // clang-format off
@@ -54,41 +56,6 @@ struct RegexColorList IndexSubjectList; ///< List of colours applied to the subj
 struct RegexColorList IndexTagList;     ///< List of colours applied to tags in the index
 struct RegexColorList StatusList;       ///< List of colours applied to the status bar
 // clang-format on
-
-/**
- * regex_color_free - Free a RegexColor
- * @param ptr         RegexColor to free
- * @param free_colors If true, free its colours too
- */
-void regex_color_free(struct RegexColor **ptr, bool free_colors)
-{
-  if (!ptr || !*ptr)
-    return;
-
-  struct RegexColor *cl = *ptr;
-
-  if (free_colors && (cl->fg != COLOR_UNSET) && (cl->bg != COLOR_UNSET))
-    mutt_color_free(cl->fg, cl->bg);
-
-  regfree(&cl->regex);
-  mutt_pattern_free(&cl->color_pattern);
-  FREE(&cl->pattern);
-  FREE(ptr);
-}
-
-/**
- * regex_color_list_clear - Clear a list of colours
- * @param rcl RegexColor List
- */
-void regex_color_list_clear(struct RegexColorList *rcl)
-{
-  struct RegexColor *np = NULL, *tmp = NULL;
-  STAILQ_FOREACH_SAFE(np, rcl, entries, tmp)
-  {
-    STAILQ_REMOVE(rcl, np, RegexColor, entries);
-    regex_color_free(&np, true);
-  }
-}
 
 /**
  * regex_colors_init - Initialise the Regex colours
@@ -120,6 +87,74 @@ void regex_colors_clear(void)
   regex_color_list_clear(&IndexSubjectList);
   regex_color_list_clear(&IndexTagList);
   regex_color_list_clear(&StatusList);
+}
+
+/**
+ * regex_color_clear - Free the contents of a Regex colour
+ * @param rcol RegexColor to empty
+ *
+ * @note The RegexColor object isn't freed
+ */
+void regex_color_clear(struct RegexColor *rcol)
+{
+  if (!rcol)
+    return;
+
+  rcol->match = 0;
+  rcol->stop_matching = false;
+
+  attr_color_clear(&rcol->attr_color);
+  FREE(&rcol->pattern);
+  regfree(&rcol->regex);
+  mutt_pattern_free(&rcol->color_pattern);
+}
+
+/**
+ * regex_color_free - Free a Regex colour
+ * @param list RegexColorList holding the colour
+ * @param ptr  RegexColor to free
+ */
+void regex_color_free(struct RegexColorList *list, struct RegexColor **ptr)
+{
+  if (!ptr || !*ptr)
+    return;
+
+  struct RegexColor *rcol = *ptr;
+  regex_color_clear(rcol);
+
+  FREE(ptr);
+}
+
+/**
+ * regex_color_new - Create a new RegexColor
+ * @retval ptr New RegexColor
+ */
+struct RegexColor *regex_color_new(void)
+{
+  struct RegexColor *rcol = mutt_mem_calloc(1, sizeof(*rcol));
+
+  return rcol;
+}
+
+/**
+ * regex_color_list_clear - Free the contents of a RegexColorList
+ * @param rcl List to clear
+ *
+ * Free each of the RegexColorList in a list.
+ *
+ * @note The list object isn't freed, only emptied
+ */
+void regex_color_list_clear(struct RegexColorList *rcl)
+{
+  if (!rcl)
+    return;
+
+  struct RegexColor *np = NULL, *tmp = NULL;
+  STAILQ_FOREACH_SAFE(np, rcl, entries, tmp)
+  {
+    STAILQ_REMOVE(rcl, np, RegexColor, entries);
+    regex_color_free(rcl, &np);
+  }
 }
 
 /**
@@ -155,27 +190,13 @@ struct RegexColorList *regex_colors_get_list(enum ColorId cid)
 }
 
 /**
- * regex_color_new - Create a new RegexColor
- * @retval ptr Newly allocated RegexColor
- */
-struct RegexColor *regex_color_new(void)
-{
-  struct RegexColor *cl = mutt_mem_calloc(1, sizeof(struct RegexColor));
-
-  cl->fg = COLOR_UNSET;
-  cl->bg = COLOR_UNSET;
-
-  return cl;
-}
-
-/**
  * add_pattern - Associate a colour to a pattern
  * @param rcl       List of existing colours
  * @param s         String to match
  * @param sensitive true if the pattern case-sensitive
  * @param fg        Foreground colour
  * @param bg        Background colour
- * @param attr      Attributes, e.g. A_UNDERLINE
+ * @param attrs     Attributes, e.g. A_UNDERLINE
  * @param err       Buffer for error messages
  * @param is_index  true of this is for the index
  * @param match     Number of regex subexpression to match (0 for entire pattern)
@@ -184,9 +205,9 @@ struct RegexColor *regex_color_new(void)
  * is_index used to store compiled pattern only for 'index' color object when
  * called from mutt_parse_color()
  */
-enum CommandResult add_pattern(struct RegexColorList *rcl, const char *s,
-                               bool sensitive, uint32_t fg, uint32_t bg, int attr,
-                               struct Buffer *err, bool is_index, int match)
+static enum CommandResult add_pattern(struct RegexColorList *rcl, const char *s,
+                                      bool sensitive, uint32_t fg, uint32_t bg, int attrs,
+                                      struct Buffer *err, bool is_index, int match)
 {
   struct RegexColor *rcol = NULL;
 
@@ -199,21 +220,21 @@ enum CommandResult add_pattern(struct RegexColorList *rcl, const char *s,
     }
   }
 
-  if (rcol)
+  if (rcol) // found a matching regex
   {
-    if ((fg != COLOR_UNSET) && (bg != COLOR_UNSET))
+    struct AttrColor *ac = &rcol->attr_color;
+    struct CursesColor *cc = ac->curses_color;
+
+    // different colours
+    if (cc && ((cc->fg != fg) || (cc->bg != bg)))
     {
-      if ((rcol->fg != fg) || (rcol->bg != bg))
-      {
-        mutt_color_free(rcol->fg, rcol->bg);
-        rcol->fg = fg;
-        rcol->bg = bg;
-        attr |= mutt_color_alloc(fg, bg);
-      }
-      else
-        attr |= (rcol->pair & ~A_BOLD);
+      attr_color_clear(&rcol->attr_color);
+      cc = curses_color_new(fg, bg);
+      cc->fg = fg;
+      cc->bg = bg;
+      ac->curses_color = cc;
     }
-    rcol->pair = attr;
+    ac->attrs = attrs;
   }
   else
   {
@@ -232,7 +253,7 @@ enum CommandResult add_pattern(struct RegexColorList *rcl, const char *s,
       mutt_buffer_pool_release(&buf);
       if (!rcol->color_pattern)
       {
-        regex_color_free(&rcol, true);
+        regex_color_free(rcl, &rcol);
         return MUTT_CMD_ERROR;
       }
     }
@@ -248,20 +269,17 @@ enum CommandResult add_pattern(struct RegexColorList *rcl, const char *s,
       if (r != 0)
       {
         regerror(r, &rcol->regex, err->data, err->dsize);
-        regex_color_free(&rcol, true);
+        regex_color_free(rcl, &rcol);
         return MUTT_CMD_ERROR;
       }
     }
     rcol->pattern = mutt_str_dup(s);
     rcol->match = match;
-    if ((fg != COLOR_UNSET) && (bg != COLOR_UNSET))
-    {
-      rcol->fg = fg;
-      rcol->bg = bg;
-      attr |= mutt_color_alloc(fg, bg);
-    }
-    rcol->pair = attr;
-    STAILQ_INSERT_HEAD(rcl, rcol, entries);
+    struct CursesColor *cc = curses_color_new(fg, bg);
+    struct AttrColor *ac = &rcol->attr_color;
+    ac->curses_color = cc;
+    ac->attrs = attrs;
+    STAILQ_INSERT_TAIL(rcl, rcol, entries);
   }
 
   if (is_index)
@@ -291,35 +309,46 @@ bool regex_colors_parse_color_list(enum ColorId cid, const char *pat, uint32_t f
                                    uint32_t bg, int attrs, int *rc, struct Buffer *err)
 
 {
+  if (cid == MT_COLOR_STATUS)
+    return false;
+
+  struct RegexColorList *rcl = regex_colors_get_list(cid);
+  if (!rcl)
+    return false;
+
+  bool sensitive = false;
+  bool is_index = false;
   switch (cid)
   {
     case MT_COLOR_ATTACH_HEADERS:
-      *rc = add_pattern(&AttachList, pat, true, fg, bg, attrs, err, false, 0);
-      break;
     case MT_COLOR_BODY:
-      *rc = add_pattern(&BodyList, pat, true, fg, bg, attrs, err, false, 0);
+      sensitive = true;
+      is_index = false;
       break;
     case MT_COLOR_HEADER:
-      *rc = add_pattern(&HeaderList, pat, false, fg, bg, attrs, err, false, 0);
+      sensitive = false;
+      is_index = false;
       break;
     case MT_COLOR_INDEX:
-      *rc = add_pattern(&IndexList, pat, true, fg, bg, attrs, err, true, 0);
-      break;
     case MT_COLOR_INDEX_AUTHOR:
-      *rc = add_pattern(&IndexAuthorList, pat, true, fg, bg, attrs, err, true, 0);
-      break;
     case MT_COLOR_INDEX_FLAGS:
-      *rc = add_pattern(&IndexFlagsList, pat, true, fg, bg, attrs, err, true, 0);
-      break;
     case MT_COLOR_INDEX_SUBJECT:
-      *rc = add_pattern(&IndexSubjectList, pat, true, fg, bg, attrs, err, true, 0);
-      break;
     case MT_COLOR_INDEX_TAG:
-      *rc = add_pattern(&IndexTagList, pat, true, fg, bg, attrs, err, true, 0);
+      sensitive = true;
+      is_index = true;
       break;
     default:
       return false;
   }
+
+  *rc = add_pattern(rcl, pat, sensitive, fg, bg, attrs, err, is_index, 0);
+
+  struct Buffer *buf = mutt_buffer_pool_get();
+  get_colorid_name(cid, buf);
+  mutt_buffer_pool_release(&buf);
+
+  struct EventColor ev_c = { cid, NULL };
+  notify_send(ColorsNotify, NT_COLOR, NT_COLOR_SET, &ev_c);
 
   return true;
 }
@@ -342,5 +371,68 @@ int regex_colors_parse_status_list(enum ColorId cid, const char *pat, uint32_t f
     return -1;
 
   int rc = add_pattern(&StatusList, pat, true, fg, bg, attrs, err, false, match);
+  if (rc != MUTT_CMD_SUCCESS)
+    return rc;
+
+  struct Buffer *buf = mutt_buffer_pool_get();
+  get_colorid_name(cid, buf);
+  mutt_buffer_pool_release(&buf);
+
+  struct EventColor ev_c = { cid, NULL };
+  notify_send(ColorsNotify, NT_COLOR, NT_COLOR_SET, &ev_c);
+
+  return rc;
+}
+
+/**
+ * regex_colors_parse_uncolor - Parse a Regex 'uncolor' command
+ * @param cid     Colour Id, e.g. #MT_COLOR_STATUS
+ * @param pat     Pattern to remove (NULL to remove all)
+ * @param uncolor true if 'uncolor', false if 'unmono'
+ * @retval true If colours were unset
+ */
+bool regex_colors_parse_uncolor(enum ColorId cid, const char *pat, bool uncolor)
+{
+  struct RegexColorList *cl = regex_colors_get_list(cid);
+  if (!cl)
+    return false;
+
+  if (!pat) // Reset all patterns
+  {
+    bool rc = STAILQ_FIRST(cl);
+
+    mutt_debug(LL_NOTIFY, "NT_COLOR_RESET: [ALL]\n");
+    struct EventColor ev_c = { cid, NULL };
+    notify_send(ColorsNotify, NT_COLOR, NT_COLOR_RESET, &ev_c);
+
+    regex_color_list_clear(cl);
+    return rc;
+  }
+
+  bool rc = false;
+  struct RegexColor *np = NULL, *prev = NULL;
+  prev = NULL;
+  STAILQ_FOREACH(np, cl, entries)
+  {
+    if (mutt_str_equal(pat, np->pattern))
+    {
+      rc = true;
+
+      mutt_debug(LL_DEBUG1, "Freeing pattern \"%s\" from XXX\n", pat);
+      if (prev)
+        STAILQ_REMOVE_AFTER(cl, prev, entries);
+      else
+        STAILQ_REMOVE_HEAD(cl, entries);
+
+      mutt_debug(LL_NOTIFY, "NT_COLOR_RESET: XXX\n");
+      struct EventColor ev_c = { cid, &np->attr_color };
+      notify_send(ColorsNotify, NT_COLOR, NT_COLOR_RESET, &ev_c);
+
+      regex_color_free(cl, &np);
+      break;
+    }
+    prev = np;
+  }
+
   return rc;
 }

--- a/color/regex.c
+++ b/color/regex.c
@@ -41,6 +41,7 @@
 #include "command2.h"
 #include "context.h"
 #include "curses2.h"
+#include "debug.h"
 #include "mutt_globals.h"
 #include "notify2.h"
 #include "regex4.h"
@@ -62,6 +63,7 @@ struct RegexColorList StatusList;       ///< List of colours applied to the stat
  */
 void regex_colors_init(void)
 {
+  color_debug(LL_DEBUG5, "init AttachList, BodyList, etc\n");
   STAILQ_INIT(&AttachList);
   STAILQ_INIT(&BodyList);
   STAILQ_INIT(&HeaderList);
@@ -78,6 +80,7 @@ void regex_colors_init(void)
  */
 void regex_colors_clear(void)
 {
+  color_debug(LL_DEBUG5, "clean up regex\n");
   regex_color_list_clear(&AttachList);
   regex_color_list_clear(&BodyList);
   regex_color_list_clear(&HeaderList);
@@ -345,11 +348,13 @@ bool regex_colors_parse_color_list(enum ColorId cid, const char *pat, uint32_t f
 
   struct Buffer *buf = mutt_buffer_pool_get();
   get_colorid_name(cid, buf);
+  color_debug(LL_DEBUG5, "NT_COLOR_SET: %s\n", buf->data);
   mutt_buffer_pool_release(&buf);
 
   struct EventColor ev_c = { cid, NULL };
   notify_send(ColorsNotify, NT_COLOR, NT_COLOR_SET, &ev_c);
 
+  regex_colors_dump_all();
   return true;
 }
 
@@ -376,11 +381,13 @@ int regex_colors_parse_status_list(enum ColorId cid, const char *pat, uint32_t f
 
   struct Buffer *buf = mutt_buffer_pool_get();
   get_colorid_name(cid, buf);
+  color_debug(LL_DEBUG5, "NT_COLOR_SET: %s\n", buf->data);
   mutt_buffer_pool_release(&buf);
 
   struct EventColor ev_c = { cid, NULL };
   notify_send(ColorsNotify, NT_COLOR, NT_COLOR_SET, &ev_c);
 
+  regex_colors_dump_all();
   return rc;
 }
 

--- a/color/regex4.h
+++ b/color/regex4.h
@@ -47,6 +47,18 @@ struct RegexColor
 };
 STAILQ_HEAD(RegexColorList, RegexColor);
 
+#ifdef USE_DEBUG_COLOR
+extern struct RegexColorList AttachList;
+extern struct RegexColorList BodyList;
+extern struct RegexColorList HeaderList;
+extern struct RegexColorList IndexAuthorList;
+extern struct RegexColorList IndexFlagsList;
+extern struct RegexColorList IndexList;
+extern struct RegexColorList IndexSubjectList;
+extern struct RegexColorList IndexTagList;
+extern struct RegexColorList StatusList;
+#endif
+
 void                   regex_color_clear(struct RegexColor *rcol);
 void                   regex_color_free(struct RegexColorList *list, struct RegexColor **ptr);
 struct RegexColor *    regex_color_new (void);

--- a/color/regex4.h
+++ b/color/regex4.h
@@ -27,20 +27,19 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include "mutt/lib.h"
-#include "lib.h"
+#include "attr.h"
+#include "color.h"
 
 /**
  * struct RegexColor - A regular expression and a color to highlight a line
  */
 struct RegexColor
 {
+  struct AttrColor attr_color;       ///< Colour and attributes to apply
   char *pattern;                     ///< Pattern to match
   regex_t regex;                     ///< Compiled regex
   int match;                         ///< Substring to match, 0 for old behaviour
   struct PatternList *color_pattern; ///< Compiled pattern to speed up index color calculation
-  uint32_t fg;                       ///< Foreground colour
-  uint32_t bg;                       ///< Background colour
-  int pair;                          ///< Colour pair index
 
   bool stop_matching : 1;            ///< Used by the pager for body patterns, to prevent the color from being retried once it fails
 
@@ -48,16 +47,18 @@ struct RegexColor
 };
 STAILQ_HEAD(RegexColorList, RegexColor);
 
-void                   regex_color_free(struct RegexColor **ptr, bool free_colors);
-void                   regex_color_list_clear(struct RegexColorList *rcl);
+void                   regex_color_clear(struct RegexColor *rcol);
+void                   regex_color_free(struct RegexColorList *list, struct RegexColor **ptr);
 struct RegexColor *    regex_color_new (void);
+
 void                   regex_colors_clear(void);
 struct RegexColorList *regex_colors_get_list(enum ColorId cid);
 void                   regex_colors_init(void);
 
+void                   regex_color_list_clear(struct RegexColorList *rcl);
+
 bool regex_colors_parse_color_list (enum ColorId cid, const char *pat, uint32_t fg, uint32_t bg, int attrs, int *rc,   struct Buffer *err);
 int  regex_colors_parse_status_list(enum ColorId cid, const char *pat, uint32_t fg, uint32_t bg, int attrs, int match, struct Buffer *err);
-
-enum CommandResult add_pattern(struct RegexColorList *top, const char *s, bool sensitive, uint32_t fg, uint32_t bg, int attr, struct Buffer *err, bool is_index, int match);
+bool regex_colors_parse_uncolor    (enum ColorId cid, const char *pat, bool uncolor);
 
 #endif /* MUTT_COLOR_REGEX4_H */

--- a/color/simple.c
+++ b/color/simple.c
@@ -33,23 +33,21 @@
 #include "mutt/lib.h"
 #include "gui/lib.h"
 
-int SimpleColors[MT_COLOR_MAX]; ///< Array of all fixed colours, see enum ColorId
+struct AttrColor SimpleColors[MT_COLOR_MAX]; ///< Array of Simple colours
 
 /**
  * simple_colors_init - Initialise the simple colour definitions
  */
 void simple_colors_init(void)
 {
-  memset(SimpleColors, A_NORMAL, MT_COLOR_MAX * sizeof(int));
-
   // Set some defaults
-  SimpleColors[MT_COLOR_INDICATOR] = A_REVERSE;
-  SimpleColors[MT_COLOR_MARKERS] = A_REVERSE;
-  SimpleColors[MT_COLOR_SEARCH] = A_REVERSE;
+  SimpleColors[MT_COLOR_INDICATOR].attrs = A_REVERSE;
+  SimpleColors[MT_COLOR_MARKERS].attrs = A_REVERSE;
+  SimpleColors[MT_COLOR_SEARCH].attrs = A_REVERSE;
 #ifdef USE_SIDEBAR
-  SimpleColors[MT_COLOR_SIDEBAR_HIGHLIGHT] = A_UNDERLINE;
+  SimpleColors[MT_COLOR_SIDEBAR_HIGHLIGHT].attrs = A_UNDERLINE;
 #endif
-  SimpleColors[MT_COLOR_STATUS] = A_REVERSE;
+  SimpleColors[MT_COLOR_STATUS].attrs = A_REVERSE;
 }
 
 /**
@@ -57,28 +55,33 @@ void simple_colors_init(void)
  */
 void simple_colors_clear(void)
 {
-  memset(SimpleColors, A_NORMAL, MT_COLOR_MAX * sizeof(int));
+  for (size_t i = 0; i < MT_COLOR_MAX; i++)
+  {
+    attr_color_clear(&SimpleColors[i]);
+  }
 }
 
 /**
  * simple_color_get - Get the colour of an object by its ID
  * @param cid Colour Id, e.g. #MT_COLOR_SEARCH
- * @retval num Color of the object
+ * @retval ptr AttrColor of the object
+ *
+ * @note Do not free the returned object
  */
-int simple_color_get(enum ColorId cid)
+struct AttrColor *simple_color_get(enum ColorId cid)
 {
   if (cid >= MT_COLOR_MAX)
   {
     mutt_error("colour overflow %d", cid);
-    return 0;
+    return NULL;
   }
   if (cid <= MT_COLOR_NONE)
   {
     mutt_error("colour underflow %d", cid);
-    return 0;
+    return NULL;
   }
 
-  return SimpleColors[cid];
+  return &SimpleColors[cid];
 }
 
 /**
@@ -88,9 +91,7 @@ int simple_color_get(enum ColorId cid)
  */
 bool simple_color_is_set(enum ColorId cid)
 {
-  int color = simple_color_get(cid);
-
-  return (color > 0);
+  return attr_color_is_set(simple_color_get(cid));
 }
 
 /**
@@ -101,4 +102,53 @@ bool simple_color_is_set(enum ColorId cid)
 bool simple_color_is_header(enum ColorId cid)
 {
   return (cid == MT_COLOR_HEADER) || (cid == MT_COLOR_HDRDEFAULT);
+}
+
+/**
+ * simple_color_set - Set the colour of a simple object
+ * @param cid   Colour Id, e.g. #MT_COLOR_SEARCH
+ * @param fg    Foreground colour
+ * @param bg    Background colour
+ * @param attrs Attributes, e.g. A_UNDERLINE
+ * @retval ptr Colour
+ */
+struct AttrColor *simple_color_set(enum ColorId cid, int fg, int bg, int attrs)
+{
+  struct AttrColor *ac = simple_color_get(cid);
+  if (!ac)
+    return NULL;
+
+  struct CursesColor *cc = curses_color_new(fg, bg);
+  curses_color_free(&ac->curses_color);
+  ac->curses_color = cc;
+  ac->attrs = attrs;
+
+  struct Buffer *buf = mutt_buffer_pool_get();
+  get_colorid_name(cid, buf);
+  mutt_buffer_pool_release(&buf);
+
+  struct EventColor ev_c = { cid };
+  notify_send(ColorsNotify, NT_COLOR, NT_COLOR_SET, &ev_c);
+
+  return ac;
+}
+
+/**
+ * simple_color_reset - Clear the colour of a simple object
+ * @param cid Colour Id, e.g. #MT_COLOR_SEARCH
+ */
+void simple_color_reset(enum ColorId cid)
+{
+  struct AttrColor *ac = simple_color_get(cid);
+  if (!ac)
+    return;
+
+  struct Buffer *buf = mutt_buffer_pool_get();
+  get_colorid_name(cid, buf);
+  mutt_buffer_pool_release(&buf);
+
+  struct EventColor ev_c = { cid, ac };
+  notify_send(ColorsNotify, NT_COLOR, NT_COLOR_RESET, &ev_c);
+
+  attr_color_clear(ac);
 }

--- a/color/simple.c
+++ b/color/simple.c
@@ -32,6 +32,7 @@
 #include <stdbool.h>
 #include "mutt/lib.h"
 #include "gui/lib.h"
+#include "debug.h"
 
 struct AttrColor SimpleColors[MT_COLOR_MAX]; ///< Array of Simple colours
 
@@ -41,6 +42,7 @@ struct AttrColor SimpleColors[MT_COLOR_MAX]; ///< Array of Simple colours
 void simple_colors_init(void)
 {
   // Set some defaults
+  color_debug(LL_DEBUG5, "init indicator, markers, etc\n");
   SimpleColors[MT_COLOR_INDICATOR].attrs = A_REVERSE;
   SimpleColors[MT_COLOR_MARKERS].attrs = A_REVERSE;
   SimpleColors[MT_COLOR_SEARCH].attrs = A_REVERSE;
@@ -55,6 +57,7 @@ void simple_colors_init(void)
  */
 void simple_colors_clear(void)
 {
+  color_debug(LL_DEBUG5, "clean up defs\n");
   for (size_t i = 0; i < MT_COLOR_MAX; i++)
   {
     attr_color_clear(&SimpleColors[i]);
@@ -125,6 +128,7 @@ struct AttrColor *simple_color_set(enum ColorId cid, int fg, int bg, int attrs)
 
   struct Buffer *buf = mutt_buffer_pool_get();
   get_colorid_name(cid, buf);
+  color_debug(LL_DEBUG5, "NT_COLOR_SET: %s\n", buf->data);
   mutt_buffer_pool_release(&buf);
 
   struct EventColor ev_c = { cid };
@@ -145,6 +149,7 @@ void simple_color_reset(enum ColorId cid)
 
   struct Buffer *buf = mutt_buffer_pool_get();
   get_colorid_name(cid, buf);
+  color_debug(LL_DEBUG5, "NT_COLOR_RESET: %s\n", buf->data);
   mutt_buffer_pool_release(&buf);
 
   struct EventColor ev_c = { cid, ac };

--- a/color/simple2.h
+++ b/color/simple2.h
@@ -25,13 +25,16 @@
 
 #include "config.h"
 #include <stdbool.h>
+#include "attr.h"
 #include "color.h"
 
-extern int SimpleColors[];
+extern struct AttrColor SimpleColors[];
 
-int               simple_color_get      (enum ColorId cid);
+struct AttrColor *simple_color_get      (enum ColorId cid);
 bool              simple_color_is_header(enum ColorId cid);
 bool              simple_color_is_set   (enum ColorId cid);
+void              simple_color_reset    (enum ColorId cid);
+struct AttrColor *simple_color_set      (enum ColorId cid, int fg, int bg, int attrs);
 
 void              simple_colors_clear(void);
 void              simple_colors_init(void);

--- a/email/email.h
+++ b/email/email.h
@@ -109,7 +109,7 @@ struct Email
 
   int index;                   ///< The absolute (unsorted) message number
   int msgno;                   ///< Number displayed to the user
-  int pair;                    ///< Color-pair to use when displaying in the index
+  struct AttrColor *attr_color; ///< Color-pair to use when displaying in the index
   int score;                   ///< Message score
   int vnum;                    ///< Virtual message number
   short attach_total;          ///< Number of qualifying attachments in message, if attach_valid

--- a/gui/mutt_curses.c
+++ b/gui/mutt_curses.c
@@ -33,27 +33,40 @@
 #include "color/lib.h"
 
 /**
- * mutt_curses_set_attr - Set the attributes for text
- * @param attr Attributes to set, e.g. A_UNDERLINE
+ * mutt_curses_set_color - Set the colour and attributes for text
+ * @param ac Colour and Attributes to set
  */
-void mutt_curses_set_attr(int attr)
+void mutt_curses_set_color(struct AttrColor *ac)
 {
-  bkgdset(attr | ' ');
+  if (!ac)
+    return;
+
+  int index = ac->curses_color ? ac->curses_color->index : 0;
+
+#if defined(HAVE_SETCCHAR) && defined(HAVE_BKGRNDSET)
+  cchar_t cch = { 0 };
+  setcchar(&cch, L" ", ac->attrs, index, NULL);
+  bkgrndset(&cch);
+#elif defined(HAVE_BKGDSET)
+  bkgdset(COLOR_PAIR(index) | ac->attrs | ' ');
+#else
+  attrset(COLOR_PAIR(index) | ac->attrs);
+#endif
 }
 
 /**
- * mutt_curses_set_color_by_id - Set the current colour for text
- * @param cid Colour to set, e.g. #MT_COLOR_HEADER
- *
- * If the system has bkgdset() use it rather than attrset() so that the clr*()
- * functions will properly set the background attributes all the way to the
- * right column.
+ * mutt_curses_set_color_by_id - Set the colour and attributes by the colour id
+ * @param cid Colour Id, e.g. #MT_COLOR_TREE
+ * @retval ptr Colour set
  */
-void mutt_curses_set_color_by_id(enum ColorId cid)
+struct AttrColor *mutt_curses_set_color_by_id(enum ColorId cid)
 {
-  const int chosen = simple_color_get(cid);
-  const int normal = simple_color_get(MT_COLOR_NORMAL);
-  bkgdset((chosen ? chosen : normal) | ' ');
+  struct AttrColor *ac = simple_color_get(cid);
+  if (!ac)
+    ac = simple_color_get(MT_COLOR_NORMAL);
+
+  mutt_curses_set_color(ac);
+  return ac;
 }
 
 /**

--- a/gui/mutt_curses.h
+++ b/gui/mutt_curses.h
@@ -56,8 +56,8 @@ enum MuttCursorState
   MUTT_CURSOR_VERY_VISIBLE =  2, ///< Display a very visible cursor
 };
 
-void              mutt_curses_set_attr(int attr);
-void              mutt_curses_set_color_by_id(enum ColorId cid);
+void              mutt_curses_set_color(struct AttrColor *ac);
+struct AttrColor *mutt_curses_set_color_by_id(enum ColorId cid);
 void              mutt_curses_set_cursor(enum MuttCursorState state);
 void              mutt_resize_screen(void);
 

--- a/hcache/hcache.c
+++ b/hcache/hcache.c
@@ -109,7 +109,7 @@ static void *dump(struct HeaderCache *hc, const struct Email *e, int *off, uint3
   e_dump.visible = true;
   e_dump.num_hidden = 0;
   e_dump.recipient = 0;
-  e_dump.pair = 0;
+  e_dump.attr_color = NULL;
   e_dump.attach_valid = false;
   e_dump.path = NULL;
   e_dump.tree = NULL;

--- a/index/index.c
+++ b/index/index.c
@@ -258,13 +258,15 @@ static int index_color_observer(struct NotifyCallback *nc)
 
   const int cid = ev_c->cid;
 
-  bool simple = (cid == MT_COLOR_INDEX_COLLAPSED) || (cid == MT_COLOR_INDEX_DATE) ||
-                (cid == MT_COLOR_INDEX_LABEL) || (cid == MT_COLOR_INDEX_NUMBER) ||
-                (cid == MT_COLOR_INDEX_SIZE) || (cid == MT_COLOR_INDEX_TAGS);
+  // MT_COLOR_MAX is sent on `uncolor *`
+  bool simple = (cid == MT_COLOR_INDEX_COLLAPSED) ||
+                (cid == MT_COLOR_INDEX_DATE) || (cid == MT_COLOR_INDEX_LABEL) ||
+                (cid == MT_COLOR_INDEX_NUMBER) || (cid == MT_COLOR_INDEX_SIZE) ||
+                (cid == MT_COLOR_INDEX_TAGS) || (cid == MT_COLOR_MAX);
 
   bool lists = (cid == MT_COLOR_INDEX) || (cid == MT_COLOR_INDEX_AUTHOR) ||
-               (cid == MT_COLOR_INDEX_FLAGS) ||
-               (cid == MT_COLOR_INDEX_SUBJECT) || (cid == MT_COLOR_INDEX_TAG);
+               (cid == MT_COLOR_INDEX_FLAGS) || (cid == MT_COLOR_INDEX_SUBJECT) ||
+               (cid == MT_COLOR_INDEX_TAG) || (cid == MT_COLOR_MAX);
 
   // The changes aren't relevant to the index menu
   if (!simple && !lists)
@@ -287,7 +289,7 @@ static int index_color_observer(struct NotifyCallback *nc)
       struct Email *e = m->emails[i];
       if (!e)
         break;
-      e->pair = 0;
+      e->attr_color = NULL;
     }
   }
 
@@ -385,7 +387,7 @@ static int index_score_observer(struct NotifyCallback *nc)
       break;
 
     mutt_score_message(m, e, true);
-    e->pair = 0; // Force recalc of colour
+    e->attr_color = NULL; // Force recalc of colour
   }
 
   mutt_debug(LL_DEBUG5, "score done\n");

--- a/index/lib.h
+++ b/index/lib.h
@@ -73,7 +73,7 @@ typedef uint8_t CheckFlags;       ///< Flags, e.g. #CHECK_IN_MAILBOX
 #define CHECK_READONLY   (1 << 3) ///< Is the mailbox readonly?
 #define CHECK_ATTACH     (1 << 4) ///< Is the user in message-attach mode?
 
-int  index_color(struct Menu *menu, int line);
+struct AttrColor *index_color(struct Menu *menu, int line);
 void index_make_entry(struct Menu *menu, char *buf, size_t buflen, int line);
 void mutt_draw_statusline(struct MuttWindow *win, int cols, const char *buf, size_t buflen);
 struct Mailbox *mutt_index_menu(struct MuttWindow *dlg, struct Mailbox *m);

--- a/init.c
+++ b/init.c
@@ -1015,7 +1015,7 @@ enum CommandResult mutt_parse_rc_buffer(struct Buffer *line,
     {
       if (mutt_str_equal(token->data, cmd[i].name))
       {
-        mutt_debug(LL_NOTIFY, "NT_COMMAND: %s\n", cmd[i].name);
+        mutt_debug(LL_DEBUG1, "NT_COMMAND: %s\n", cmd[i].name);
         rc = cmd[i].parse(token, line, cmd[i].data, err);
         if ((rc == MUTT_CMD_ERROR) || (rc == MUTT_CMD_FINISH))
           goto finish; /* Propagate return code */

--- a/main.c
+++ b/main.c
@@ -477,6 +477,18 @@ main
 #endif
 (int argc, char *argv[], char *envp[])
 {
+#if 0
+  if (argc != 2)
+    return 1;
+  struct AnsiColor ansi = { 0 };
+  int len = ansi_color_parse(argv[1], &ansi, NULL);
+  printf("len = %d\n", len);
+  printf("0x%06x  %4d %4d\n", ansi.attrs, ansi.fg, ansi.bg);
+  printf("%s\n", argv[1] + len);
+  const char *color = color_debug_log_color(ansi.fg, ansi.bg);
+  printf("%s\n", color);
+  return 0;
+#endif
   char *subject = NULL;
   char *include_file = NULL;
   char *draft_file = NULL;

--- a/menu/lib.h
+++ b/menu/lib.h
@@ -139,7 +139,7 @@ struct Menu
    * @retval >0 Colour pair in an integer
    * @retval  0 No colour
    */
-  int (*color)(struct Menu *menu, int line);
+  struct AttrColor *(*color)(struct Menu *menu, int line);
 
   /**
    * @defgroup menu_custom_redraw custom_redraw()

--- a/menu/menu.c
+++ b/menu/menu.c
@@ -93,7 +93,7 @@ static void menu_jump(struct Menu *menu)
 /**
  * default_color - Get the default colour for a line of the menu - Implements Menu::color() - @ingroup menu_color
  */
-static int default_color(struct Menu *menu, int line)
+static struct AttrColor *default_color(struct Menu *menu, int line)
 {
   return simple_color_get(MT_COLOR_NORMAL);
 }

--- a/mutt_thread.c
+++ b/mutt_thread.c
@@ -1453,7 +1453,7 @@ int mutt_traverse_thread(struct Email *e_cur, MuttThreadFlags flag)
 
   if (flag & (MUTT_THREAD_COLLAPSE | MUTT_THREAD_UNCOLLAPSE))
   {
-    e_cur->pair = 0; /* force index entry's color to be re-evaluated */
+    e_cur->attr_color = NULL; /* force index entry's color to be re-evaluated */
     e_cur->collapsed = flag & MUTT_THREAD_COLLAPSE;
     if (e_cur->vnum != -1)
     {
@@ -1487,7 +1487,7 @@ int mutt_traverse_thread(struct Email *e_cur, MuttThreadFlags flag)
     {
       if (flag & (MUTT_THREAD_COLLAPSE | MUTT_THREAD_UNCOLLAPSE))
       {
-        e_cur->pair = 0; /* force index entry's color to be re-evaluated */
+        e_cur->attr_color = NULL; /* force index entry's color to be re-evaluated */
         e_cur->collapsed = flag & MUTT_THREAD_COLLAPSE;
         if (!e_root && e_cur->visible)
         {

--- a/pager/display.h
+++ b/pager/display.h
@@ -25,44 +25,23 @@
 
 #include "config.h"
 #include <stdbool.h>
-#include <stdint.h>
 #include <stdio.h>
 #include "mutt/lib.h"
 #include "lib.h"
 
+struct AttrColorList;
 struct MuttWindow;
-
-// clang-format off
-typedef uint8_t AnsiFlags;      ///< Flags, e.g. #ANSI_OFF
-#define ANSI_NO_FLAGS        0  ///< No flags are set
-#define ANSI_OFF       (1 << 0) ///< Turn off colours and attributes
-#define ANSI_BLINK     (1 << 1) ///< Blinking text
-#define ANSI_BOLD      (1 << 2) ///< Bold text
-#define ANSI_UNDERLINE (1 << 3) ///< Underlined text
-#define ANSI_REVERSE   (1 << 4) ///< Reverse video
-#define ANSI_COLOR     (1 << 5) ///< Use colours
-// clang-format on
 
 /**
  * struct TextSyntax - Highlighting for a piece of text
  */
 struct TextSyntax
 {
-  int color; ///< Curses colour of text
+  struct AttrColor *attr_color; ///< Curses colour of text
   int first; ///< First character in line to be coloured
-  int last;  ///< Last character in line to be coloured
+  int last;  ///< Last character in line to be coloured (not included)
 };
-
-/**
- * struct AnsiAttr - An ANSI escape sequence
- */
-struct AnsiAttr
-{
-  AnsiFlags attr; ///< Attributes, e.g. #ANSI_BOLD
-  int fg;         ///< ANSI Foreground colour, e.g. 1 red, 2 green, etc
-  int bg;         ///< ANSI Background colour, e.g. 1 red, 2 green, etc
-  int pair;       ///< Curses colour pair
-};
+ARRAY_HEAD(TextSyntaxArray, struct TextSyntax);
 
 /**
  * struct Line - A line of text in the pager
@@ -83,8 +62,9 @@ struct Line
   struct QuoteStyle *quote;  ///< Quoting style for this line (pointer into PagerPrivateData->quote_list)
 };
 
-int display_line(FILE *fp, LOFF_T *last_pos, struct Line **lines, int n, int *last,
-                 int *max, PagerFlags flags, struct QuoteStyle **quote_list, int *q_level,
-                 bool *force_redraw, regex_t *search_re, struct MuttWindow *win_pager);
+int display_line(FILE *fp, LOFF_T *bytes_read, struct Line **lines,
+                 int line_num, int *lines_used, int *lines_max, PagerFlags flags,
+                 struct QuoteStyle **quote_list, int *q_level, bool *force_redraw,
+                 regex_t *search_re, struct MuttWindow *win_pager, struct AttrColorList *ansi_list);
 
 #endif /* MUTT_PAGER_DISPLAY_H */

--- a/pager/dlg_pager.c
+++ b/pager/dlg_pager.c
@@ -287,7 +287,7 @@ static void pager_custom_redraw(struct PagerPrivateData *priv)
                         &priv->lines_used, &priv->lines_max,
                         priv->has_types | priv->search_flag | (priv->pview->flags & MUTT_PAGER_NOWRAP),
                         &priv->quote_list, &priv->q_level, &priv->force_redraw,
-                        &priv->search_re, priv->pview->win_pager) == 0)
+                        &priv->search_re, priv->pview->win_pager, &priv->ansi_list) == 0)
     {
       if (!priv->lines[i].cont_line && (++j == priv->win_height))
       {
@@ -317,7 +317,7 @@ static void pager_custom_redraw(struct PagerPrivateData *priv)
                          (priv->pview->flags & MUTT_DISPLAYFLAGS) | priv->hide_quoted |
                              priv->search_flag | (priv->pview->flags & MUTT_PAGER_NOWRAP),
                          &priv->quote_list, &priv->q_level, &priv->force_redraw,
-                         &priv->search_re, priv->pview->win_pager) > 0)
+                         &priv->search_re, priv->pview->win_pager, &priv->ansi_list) > 0)
         {
           priv->win_height++;
         }
@@ -551,6 +551,7 @@ int mutt_pager(struct PagerView *pview)
     priv->menu = menu;
     priv->notify = notify;
     priv->win_pbar = pview->win_pbar;
+    TAILQ_INIT(&priv->ansi_list);
   }
 
   //---------- setup flags ----------------------------------------------------
@@ -800,6 +801,7 @@ int mutt_pager(struct PagerView *pview)
       }
       continue;
     }
+
     //-------------------------------------------------------------------------
     // Finally, read user's key press
     //-------------------------------------------------------------------------
@@ -889,6 +891,15 @@ int mutt_pager(struct PagerView *pview)
     priv->search_compiled = false;
   }
   FREE(&priv->lines);
+  attr_color_list_clear(&priv->ansi_list);
+  {
+    struct AttrColor *ac = NULL;
+    int count = 0;
+    TAILQ_FOREACH(ac, &priv->ansi_list, entries)
+    {
+      count++;
+    }
+  }
 
   expand_index_panel(dlg, priv);
 

--- a/pager/functions.c
+++ b/pager/functions.c
@@ -54,7 +54,6 @@
 #include "context.h"
 #include "display.h"
 #include "keymap.h"
-#include "mutt_globals.h"
 #include "mutt_header.h"
 #include "mutt_mailbox.h"
 #include "muttlib.h"
@@ -201,7 +200,7 @@ bool jump_to_bottom(struct PagerPrivateData *priv, struct PagerView *pview)
                       &priv->lines_used, &priv->lines_max,
                       priv->has_types | (pview->flags & MUTT_PAGER_NOWRAP),
                       &priv->quote_list, &priv->q_level, &priv->force_redraw,
-                      &priv->search_re, priv->pview->win_pager) == 0)
+                      &priv->search_re, priv->pview->win_pager, &priv->ansi_list) == 0)
   {
     line_num++;
   }
@@ -470,7 +469,7 @@ static int op_pager_search(struct IndexSharedData *shared,
                         MUTT_SEARCH | (pview->flags & MUTT_PAGER_NSKIP) |
                             (pview->flags & MUTT_PAGER_NOWRAP) | priv->has_types,
                         &priv->quote_list, &priv->q_level, &priv->force_redraw,
-                        &priv->search_re, priv->pview->win_pager) == 0)
+                        &priv->search_re, priv->pview->win_pager, &priv->ansi_list) == 0)
     {
       line_num++;
     }
@@ -647,7 +646,7 @@ static int op_pager_skip_headers(struct IndexSharedData *shared,
                      priv->fp, &priv->bytes_read, &priv->lines, new_topline, &priv->lines_used,
                      &priv->lines_max, MUTT_TYPES | (pview->flags & MUTT_PAGER_NOWRAP),
                      &priv->quote_list, &priv->q_level, &priv->force_redraw,
-                     &priv->search_re, priv->pview->win_pager)))) &&
+                     &priv->search_re, priv->pview->win_pager, &priv->ansi_list)))) &&
          simple_color_is_header(priv->lines[new_topline].cid))
   {
     new_topline++;
@@ -692,7 +691,7 @@ static int op_pager_skip_quoted(struct IndexSharedData *shared,
                        priv->fp, &priv->bytes_read, &priv->lines, new_topline, &priv->lines_used,
                        &priv->lines_max, MUTT_TYPES | (pview->flags & MUTT_PAGER_NOWRAP),
                        &priv->quote_list, &priv->q_level, &priv->force_redraw,
-                       &priv->search_re, priv->pview->win_pager)))) &&
+                       &priv->search_re, priv->pview->win_pager, &priv->ansi_list)))) &&
            simple_color_is_header(priv->lines[new_topline].cid))
     {
       new_topline++;
@@ -710,7 +709,7 @@ static int op_pager_skip_quoted(struct IndexSharedData *shared,
                        priv->fp, &priv->bytes_read, &priv->lines, new_topline, &priv->lines_used,
                        &priv->lines_max, MUTT_TYPES | (pview->flags & MUTT_PAGER_NOWRAP),
                        &priv->quote_list, &priv->q_level, &priv->force_redraw,
-                       &priv->search_re, priv->pview->win_pager)))) &&
+                       &priv->search_re, priv->pview->win_pager, &priv->ansi_list)))) &&
            (priv->lines[new_topline].cid == MT_COLOR_QUOTED))
     {
       new_topline++;
@@ -733,7 +732,7 @@ static int op_pager_skip_quoted(struct IndexSharedData *shared,
                        priv->fp, &priv->bytes_read, &priv->lines, new_topline, &priv->lines_used,
                        &priv->lines_max, MUTT_TYPES | (pview->flags & MUTT_PAGER_NOWRAP),
                        &priv->quote_list, &priv->q_level, &priv->force_redraw,
-                       &priv->search_re, priv->pview->win_pager)))) &&
+                       &priv->search_re, priv->pview->win_pager, &priv->ansi_list)))) &&
            (priv->lines[new_topline].cid != MT_COLOR_QUOTED))
     {
       new_topline++;
@@ -750,7 +749,7 @@ static int op_pager_skip_quoted(struct IndexSharedData *shared,
                        priv->fp, &priv->bytes_read, &priv->lines, new_topline, &priv->lines_used,
                        &priv->lines_max, MUTT_TYPES | (pview->flags & MUTT_PAGER_NOWRAP),
                        &priv->quote_list, &priv->q_level, &priv->force_redraw,
-                       &priv->search_re, priv->pview->win_pager)))) &&
+                       &priv->search_re, priv->pview->win_pager, &priv->ansi_list)))) &&
            (priv->lines[new_topline].cid == MT_COLOR_QUOTED))
     {
       new_topline++;

--- a/pager/lib.h
+++ b/pager/lib.h
@@ -188,4 +188,10 @@ void pager_queue_redraw(struct PagerPrivateData *priv, MenuRedrawFlags redraw);
 
 void mutt_clear_pager_position(void);
 
+struct TextSyntax;
+struct Line;
+void dump_text_syntax(struct TextSyntax *ts, int num);
+void dump_line(int i, struct Line *line);
+void dump_pager(struct PagerPrivateData *priv);
+
 #endif /* MUTT_PAGER_LIB_H */

--- a/pager/message.c
+++ b/pager/message.c
@@ -295,7 +295,7 @@ static int email_to_file(struct Message *msg, struct Buffer *tempfile,
 
     /* Remove color cache for this message, in case there
      * are color patterns for both ~g and ~V */
-    e->pair = 0;
+    e->attr_color = NULL;
 
     /* Process protected headers and autocrypt gossip headers */
     process_protected_headers(m, e);

--- a/pager/pager.c
+++ b/pager/pager.c
@@ -68,6 +68,7 @@
 #include "lib.h"
 #include "index/lib.h"
 #include "menu/lib.h"
+#include "display.h"
 #include "private_data.h"
 
 /**
@@ -158,6 +159,24 @@ static int pager_color_observer(struct NotifyCallback *nc)
   {
     // rework quoted colours
     qstyle_recolour(priv->quote_list);
+  }
+
+  if (ev_c->cid == MT_COLOR_MAX)
+  {
+    for (size_t i = 0; i < priv->lines_max; i++)
+    {
+      FREE(&(priv->lines[i].syntax));
+      // if (priv->search_compiled && priv->lines[i].search)
+      //   FREE(&(priv->lines[i].search));
+      // priv->lines[i].syntax_arr_size = 0;
+    }
+    priv->lines_used = 0;
+
+    // if (priv->search_compiled)
+    // {
+    //   regfree(&priv->search_re);
+    //   priv->search_compiled = false;
+    // }
   }
 
   mutt_debug(LL_DEBUG5, "color done\n");

--- a/pager/private_data.c
+++ b/pager/private_data.c
@@ -47,6 +47,8 @@ void pager_private_data_free(struct MuttWindow *win, void **ptr)
   notify_send(priv->notify, NT_PAGER, NT_PAGER_DELETE, priv);
   notify_free(&priv->notify);
 
+  attr_color_list_clear(&priv->ansi_list);
+
   FREE(ptr);
 }
 
@@ -61,6 +63,8 @@ struct PagerPrivateData *pager_private_data_new(void)
   priv->notify = notify_new();
 
   // TODO initialize fields
+
+  TAILQ_INIT(&priv->ansi_list);
 
   return priv;
 }

--- a/pager/private_data.h
+++ b/pager/private_data.h
@@ -30,6 +30,7 @@
 #include <sys/stat.h>
 #include "mutt/lib.h"
 #include "lib.h"
+#include "color/lib.h"
 #include "menu/lib.h"
 
 struct MuttWindow;
@@ -70,9 +71,10 @@ struct PagerPrivateData
   int index_size;              ///< Size of the mini-index Window `$pager_index_lines`
   int indicator;               ///< Preferred position of the indicator line in the mini-index Window
 
-  bool force_redraw;           ///< Repaint is needed
-  MenuRedrawFlags redraw;      ///< When to redraw the screen
-  struct Notify *notify;       ///< Notifications: #NotifyPager, #PagerPrivateData
+  bool force_redraw;              ///< Repaint is needed
+  MenuRedrawFlags redraw;         ///< When to redraw the screen
+  struct AttrColorList ansi_list; ///< List of ANSI colours used in the Pager
+  struct Notify *notify;          ///< Notifications: #NotifyPager, #PagerPrivateData
 
   int rc;                        ///< Return code from functions
   int searchctx;                 ///< Space to show around search matches

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -28,8 +28,12 @@ autocrypt/schema.c
 bcache/bcache.c
 browser/browser.c
 browser/sort.c
+color/ansi.c
+color/attr.c
 color/color.c
 color/command.c
+color/curses.c
+color/merged.c
 color/notify.c
 color/quoted.c
 color/regex.c

--- a/question/question.c
+++ b/question/question.c
@@ -58,9 +58,7 @@ int mutt_multi_choice(const char *prompt, const char *letters)
   bool redraw = true;
   int prompt_lines = 1;
 
-  const bool opt_cols =
-      (simple_color_is_set(MT_COLOR_OPTIONS) &&
-       (simple_color_get(MT_COLOR_OPTIONS) != simple_color_get(MT_COLOR_PROMPT)));
+  const bool opt_cols = simple_color_is_set(MT_COLOR_OPTIONS);
 
   struct MuttWindow *old_focus = window_set_focus(win);
   window_redraw(NULL);
@@ -168,6 +166,7 @@ int mutt_multi_choice(const char *prompt, const char *letters)
     msgwin_set_height(1);
     window_redraw(NULL);
   }
+  mutt_curses_set_color_by_id(MT_COLOR_NORMAL);
   window_set_focus(old_focus);
   mutt_refresh();
   return choice;

--- a/sidebar/private.h
+++ b/sidebar/private.h
@@ -44,7 +44,7 @@ struct SbEntry
   int depth;               ///< Indentation depth
   struct Mailbox *mailbox; ///< Mailbox this represents
   bool is_hidden;          ///< Don't show, e.g. $sidebar_new_mail_only
-  enum ColorId cid;        ///< Colour to use
+  struct AttrColor *color; ///< Colour to use
 };
 ARRAY_HEAD(SbEntryArray, struct SbEntry *);
 

--- a/test/common.c
+++ b/test/common.c
@@ -142,3 +142,13 @@ enum QuadOption mutt_yesorno(const char *msg, enum QuadOption def)
 {
   return MUTT_YES;
 }
+
+struct Mailbox *get_current_mailbox(void)
+{
+  return NULL;
+}
+
+struct Menu *get_current_menu(void)
+{
+  return NULL;
+}

--- a/version.c
+++ b/version.c
@@ -295,6 +295,9 @@ static struct CompileOptions debug_opts[] = {
 #ifdef USE_ASAN
   { "asan", 2 },
 #endif
+#ifdef USE_DEBUG_COLOR
+  { "color", 2 },
+#endif
 #ifdef HAVE_LIBUNWIND
   { "backtrace", 2 },
 #endif


### PR DESCRIPTION
NeoMutt's colour handling has been a bit broken for a while.
This brings us back level with Mutt.

- c91005ead add new structs
  - `CursesColor` - Colour in the ncurses palette
  - `AttrColor` - A curses colour and its attributes
  - `AnsiColor` - An ANSI escape sequence

- e42ba8288 start using new objects
  This is huge and ugly as it has to convert a LOT of code

- e1a1881e1 add a lot of debug logging
  Introduce `color_debug()` like `mutt_debug()`, but dependent on `--debug-color`

- 47cc10909 add `:color` command
  Display a list of the current colours (in colour)
  This is also dependent on `--debug-color` (as it's a WIP)