### PR TITLE
Update documentation wrt. need to set $header_cache_backend

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,6 +14,6 @@
    - Added [doxygen code documentation](https://neomutt.org/dev/doxygen)
      [syntax](http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html)
 
-   - Code follows the [style guide](https://neomutt.org/dev/coding-style)
+   - Code follows the [style guide](https://neomutt.org/dev/code)
 
 * **What are the relevant issue numbers?**

--- a/docs/config.c
+++ b/docs/config.c
@@ -1524,8 +1524,9 @@
 { "header_cache_backend", DT_STRING, 0 },
 /*
 ** .pp
-** This variable specifies the header cache backend.  By default it is
-** \fIunset\fP so no header caching will be used.
+** This variable specifies the header cache backend.  If no backend is
+** specified, the first available backend will be used in the following order:
+** tokyocabinet, kyotocabinet, qdbm, rocksdb, gdbm, bdb, tdb, lmdb.
 */
 
 #ifdef USE_HCACHE_COMPRESSION

--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -12422,7 +12422,7 @@ folder-hook imap://user@host2/ 'set folder=imap://host2/ ; set record=+INBOX/Sen
         </para>
         <para>
           Additionally,
-          <link linkend="header-cache-backend">$header_cache_backend</link> must
+          <link linkend="header-cache-backend">$header_cache_backend</link> can
           be set to specify which backend to use. The list of available
           backends can be specified at configure time with a set of
           --with-&lt;backend&gt; options. Currently, the following backends are


### PR DESCRIPTION
* **What does this PR do?**
  This PR updates (corrects) the documentation concerning the need to set `$header_cache_backend` for header caching to work. Reality is that `$header_cache_backend` doesn't need to be set unless the user wants to explicitly specify which backend should be used for header caching.

  Also part of this PR is a small change (26fbd795c0f55782d016507cf33b047afd087b51) to fix a broken link in the GitHub pull request template.

* **What are the relevant issue numbers?**
  #3259