### PR TITLE
color: fix dupe regex crash

### DIFF
--- a/color/regex.c
+++ b/color/regex.c
@@ -412,14 +412,15 @@ bool regex_colors_parse_uncolor(enum ColorId cid, const char *pat, bool uncolor)
 
   if (!pat) // Reset all patterns
   {
-    bool rc = STAILQ_FIRST(cl);
+    if (STAILQ_EMPTY(cl))
+      return true;
 
     mutt_debug(LL_NOTIFY, "NT_COLOR_RESET: [ALL]\n");
     struct EventColor ev_c = { cid, NULL };
     notify_send(ColorsNotify, NT_COLOR, NT_COLOR_RESET, &ev_c);
 
     regex_color_list_clear(cl);
-    return rc;
+    return true;
   }
 
   bool rc = false;

--- a/color/regex.c
+++ b/color/regex.c
@@ -231,11 +231,14 @@ static enum CommandResult add_pattern(struct RegexColorList *rcl, const char *s,
     // different colours
     if (cc && ((cc->fg != fg) || (cc->bg != bg)))
     {
-      attr_color_clear(&rcol->attr_color);
       cc = curses_color_new(fg, bg);
-      cc->fg = fg;
-      cc->bg = bg;
-      ac->curses_color = cc;
+      if (cc)
+      {
+        attr_color_clear(&rcol->attr_color);
+        cc->fg = fg;
+        cc->bg = bg;
+        ac->curses_color = cc;
+      }
     }
     ac->attrs = attrs;
   }


### PR DESCRIPTION
Fix a crash where a `mono` follows a `color` with the same regex, e.g.

```
color body      red green "signature from"
mono  body bold           "signature from"
```

Thanks to:
- Vladimir Zakharov (@z2v)
- Sam Axe (@SamAxe)
- Страхиња Радић (@Strahinja)