### PR TITLE
Unify Alias and Query with function dispatcher

### DIFF
--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -110,8 +110,8 @@ $(PWD)/address:
 # libalias
 LIBALIAS=	libalias.a
 LIBALIASOBJS=	alias/alias.o alias/array.o alias/commands.o alias/config.o \
-		alias/dlgalias.o alias/dlgquery.o alias/gui.o alias/reverse.o \
-		alias/sort.o
+		alias/dlgalias.o alias/dlgquery.o alias/functions.o \
+		alias/gui.o alias/reverse.o alias/sort.o
 CLEANFILES+=	$(LIBALIAS) $(LIBALIASOBJS)
 ALLOBJS+=	$(LIBALIASOBJS)
 

--- a/alias/dlgalias.c
+++ b/alias/dlgalias.c
@@ -323,7 +323,6 @@ static void dlg_select_alias(struct Buffer *buf, struct AliasMenuData *mdata)
     avp->num = ARRAY_FOREACH_IDX;
   }
 
-  int t = -1;
   int done = 0;
   while (done == 0)
   {
@@ -424,14 +423,14 @@ static void dlg_select_alias(struct Buffer *buf, struct AliasMenuData *mdata)
       }
 
       case OP_GENERIC_SELECT_ENTRY:
-        t = menu_get_index(menu);
-        if (t >= ARRAY_SIZE(&mdata->ava))
-          t = -1;
-        done = 1;
-        break;
-
       case OP_MAIL:
       {
+        if (buf)
+        {
+          done = 2;
+          break;
+        }
+
         struct Email *e = email_new();
         e->env = mutt_env_new();
         if (menu->tag_prefix)
@@ -474,19 +473,26 @@ static void dlg_select_alias(struct Buffer *buf, struct AliasMenuData *mdata)
   if (buf)
   {
     mutt_buffer_alloc(buf, 8192);
-    ARRAY_FOREACH(avp, &mdata->ava)
+    if (menu->tag_prefix)
     {
-      if (avp->is_tagged)
+      ARRAY_FOREACH(avp, &mdata->ava)
       {
+        if (!avp->is_tagged)
+          continue;
+
         mutt_addrlist_write(&avp->alias->addr, buf->data, buf->dsize, true);
-        t = -1;
       }
     }
-
-    if (t != -1)
+    else
     {
-      mutt_addrlist_write(&ARRAY_GET(&mdata->ava, t)->alias->addr, buf->data,
-                          buf->dsize, true);
+      int idx = menu_get_index(menu);
+      if (idx >= ARRAY_SIZE(&mdata->ava))
+        idx = -1;
+      if (idx != -1)
+      {
+        mutt_addrlist_write(&ARRAY_GET(&mdata->ava, idx)->alias->addr,
+                            buf->data, buf->dsize, true);
+      }
     }
   }
 

--- a/alias/dlgquery.c
+++ b/alias/dlgquery.c
@@ -117,7 +117,7 @@ static const struct Mapping QueryHelp[] = {
  * @param alias Alias to use
  * @retval true Success
  */
-static bool alias_to_addrlist(struct AddressList *al, struct Alias *alias)
+bool alias_to_addrlist(struct AddressList *al, struct Alias *alias)
 {
   if (!al || !TAILQ_EMPTY(al) || !alias)
     return false;

--- a/alias/dlgquery.c
+++ b/alias/dlgquery.c
@@ -137,37 +137,6 @@ static bool alias_to_addrlist(struct AddressList *al, struct Alias *alias)
 }
 
 /**
- * query_search - Search a Address menu item - Implements Menu::search() - @ingroup menu_search
- *
- * Try to match various Address fields.
- */
-static int query_search(struct Menu *menu, regex_t *rx, int line)
-{
-  const struct AliasViewArray *ava = &((struct AliasMenuData *) menu->mdata)->ava;
-  struct AliasView *av = ARRAY_GET(ava, line);
-  struct Alias *alias = av->alias;
-
-  if (alias->name && (regexec(rx, alias->name, 0, NULL, 0) == 0))
-    return 0;
-  if (alias->comment && (regexec(rx, alias->comment, 0, NULL, 0) == 0))
-    return 0;
-  if (!TAILQ_EMPTY(&alias->addr))
-  {
-    struct Address *addr = TAILQ_FIRST(&alias->addr);
-    if (addr->personal && (regexec(rx, addr->personal, 0, NULL, 0) == 0))
-    {
-      return 0;
-    }
-    if (addr->mailbox && (regexec(rx, addr->mailbox, 0, NULL, 0) == 0))
-    {
-      return 0;
-    }
-  }
-
-  return REG_NOMATCH;
-}
-
-/**
  * query_format_str - Format a string for the query menu - Implements ::format_t - @ingroup expando_api
  *
  * | Expando | Description
@@ -385,7 +354,6 @@ static struct MuttWindow *query_dialog_new(struct AliasMenuData *mdata, const ch
   struct Menu *menu = dlg->wdata;
 
   menu->make_entry = query_make_entry;
-  menu->search = query_search;
   menu->custom_search = true;
   menu->tag = query_tag;
   menu->max = ARRAY_SIZE(&mdata->ava);

--- a/alias/functions.c
+++ b/alias/functions.c
@@ -1,0 +1,162 @@
+/**
+ * @file
+ * Alias functions
+ *
+ * @authors
+ * Copyright (C) 2022 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @page alias_functions Alias functions
+ *
+ * Alias functions
+ */
+
+#include "config.h"
+#include <stddef.h>
+#include <stdbool.h>
+#include "mutt/lib.h"
+#include "config/lib.h"
+#include "core/lib.h"
+#include "gui/lib.h"
+#include "functions.h"
+#include "lib.h"
+#include "index/lib.h"
+#include "opcodes.h"
+
+/**
+ * op_create_alias - create an alias from a message sender - Implements ::alias_function_t - @ingroup alias_function_api
+ */
+static int op_create_alias(struct AliasMenuData *mdata, int op)
+{
+  return IR_NOT_IMPL;
+}
+
+/**
+ * op_delete - delete the current entry - Implements ::alias_function_t - @ingroup alias_function_api
+ */
+static int op_delete(struct AliasMenuData *mdata, int op)
+{
+  return IR_NOT_IMPL;
+}
+
+/**
+ * op_exit - exit this menu - Implements ::alias_function_t - @ingroup alias_function_api
+ */
+static int op_exit(struct AliasMenuData *mdata, int op)
+{
+  return IR_NOT_IMPL;
+}
+
+/**
+ * op_generic_select_entry - select the current entry - Implements ::alias_function_t - @ingroup alias_function_api
+ */
+static int op_generic_select_entry(struct AliasMenuData *mdata, int op)
+{
+  return IR_NOT_IMPL;
+}
+
+/**
+ * op_main_limit - show only messages matching a pattern - Implements ::alias_function_t - @ingroup alias_function_api
+ */
+static int op_main_limit(struct AliasMenuData *mdata, int op)
+{
+  return IR_NOT_IMPL;
+}
+
+/**
+ * op_query - query external program for addresses - Implements ::alias_function_t - @ingroup alias_function_api
+ */
+static int op_query(struct AliasMenuData *mdata, int op)
+{
+  return IR_NOT_IMPL;
+}
+
+/**
+ * op_search - search for a regular expression - Implements ::alias_function_t - @ingroup alias_function_api
+ */
+static int op_search(struct AliasMenuData *mdata, int op)
+{
+  return IR_NOT_IMPL;
+}
+
+/**
+ * op_sort - sort aliases - Implements ::alias_function_t - @ingroup alias_function_api
+ */
+static int op_sort(struct AliasMenuData *mdata, int op)
+{
+  return IR_NOT_IMPL;
+}
+
+// -----------------------------------------------------------------------------
+
+/**
+ * AliasFunctions - All the NeoMutt functions that the Alias supports
+ */
+struct AliasFunction AliasFunctions[] = {
+  // clang-format off
+  { OP_CREATE_ALIAS,           op_create_alias },
+  { OP_DELETE,                 op_delete },
+  { OP_EXIT,                   op_exit },
+  { OP_GENERIC_SELECT_ENTRY,   op_generic_select_entry },
+  { OP_MAIL,                   op_generic_select_entry },
+  { OP_MAIN_LIMIT,             op_main_limit },
+  { OP_QUERY,                  op_query },
+  { OP_QUERY_APPEND,           op_query },
+  { OP_SEARCH,                 op_search },
+  { OP_SEARCH_NEXT,            op_search },
+  { OP_SEARCH_OPPOSITE,        op_search },
+  { OP_SEARCH_REVERSE,         op_search },
+  { OP_SORT,                   op_sort },
+  { OP_SORT_REVERSE,           op_sort },
+  { OP_UNDELETE,               op_delete },
+  { 0, NULL },
+  // clang-format on
+};
+
+/**
+ * alias_function_dispatcher - Perform a Alias function
+ * @param win Alias Window
+ * @param op  Operation to perform, e.g. OP_ALIAS_NEXT
+ * @retval num #IndexRetval, e.g. #IR_SUCCESS
+ */
+int alias_function_dispatcher(struct MuttWindow *win, int op)
+{
+  if (!win || !win->wdata)
+    return IR_UNKNOWN;
+
+  struct Menu *menu = win->wdata;
+  struct AliasMenuData *mdata = menu->mdata;
+  int rc = IR_UNKNOWN;
+  for (size_t i = 0; AliasFunctions[i].op != OP_NULL; i++)
+  {
+    const struct AliasFunction *fn = &AliasFunctions[i];
+    if (fn->op == op)
+    {
+      rc = fn->function(mdata, op);
+      break;
+    }
+  }
+
+  if (rc == IR_UNKNOWN) // Not our function
+    return rc;
+
+  const char *result = mutt_map_get_name(rc, RetvalNames);
+  mutt_debug(LL_DEBUG1, "Handled %s (%d) -> %s\n", OpStrings[op][0], op, NONULL(result));
+
+  return rc;
+}

--- a/alias/functions.c
+++ b/alias/functions.c
@@ -30,12 +30,20 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include "mutt/lib.h"
+#include "address/lib.h"
 #include "config/lib.h"
+#include "email/lib.h"
 #include "core/lib.h"
+#include "alias/lib.h"
 #include "gui/lib.h"
 #include "functions.h"
 #include "lib.h"
 #include "index/lib.h"
+#include "pattern/lib.h"
+#include "question/lib.h"
+#include "send/lib.h"
+#include "alias.h"
+#include "gui.h"
 #include "opcodes.h"
 
 /**
@@ -43,7 +51,39 @@
  */
 static int op_create_alias(struct AliasMenuData *mdata, int op)
 {
-  return IR_NOT_IMPL;
+  struct Menu *menu = mdata->menu;
+
+  if (menu->tag_prefix)
+  {
+    struct AddressList naddr = TAILQ_HEAD_INITIALIZER(naddr);
+
+    struct AliasView *avp = NULL;
+    ARRAY_FOREACH(avp, &mdata->ava)
+    {
+      if (!avp->is_tagged)
+        continue;
+
+      struct AddressList al = TAILQ_HEAD_INITIALIZER(al);
+      if (alias_to_addrlist(&al, avp->alias))
+      {
+        mutt_addrlist_copy(&naddr, &al, false);
+        mutt_addrlist_clear(&al);
+      }
+    }
+
+    alias_create(&naddr, mdata->sub);
+    mutt_addrlist_clear(&naddr);
+  }
+  else
+  {
+    struct AddressList al = TAILQ_HEAD_INITIALIZER(al);
+    if (alias_to_addrlist(&al, ARRAY_GET(&mdata->ava, menu_get_index(menu))->alias))
+    {
+      alias_create(&al, mdata->sub);
+      mutt_addrlist_clear(&al);
+    }
+  }
+  return IR_SUCCESS;
 }
 
 /**
@@ -51,7 +91,31 @@ static int op_create_alias(struct AliasMenuData *mdata, int op)
  */
 static int op_delete(struct AliasMenuData *mdata, int op)
 {
-  return IR_NOT_IMPL;
+  struct Menu *menu = mdata->menu;
+
+  if (menu->tag_prefix)
+  {
+    struct AliasView *avp = NULL;
+    ARRAY_FOREACH(avp, &mdata->ava)
+    {
+      if (avp->is_tagged)
+        avp->is_deleted = (op == OP_DELETE);
+    }
+    menu_queue_redraw(menu, MENU_REDRAW_INDEX);
+  }
+  else
+  {
+    int index = menu_get_index(menu);
+    ARRAY_GET(&mdata->ava, index)->is_deleted = (op == OP_DELETE);
+    menu_queue_redraw(menu, MENU_REDRAW_CURRENT);
+    const bool c_resolve = cs_subset_bool(mdata->sub, "resolve");
+    if (c_resolve && (index < (menu->max - 1)))
+    {
+      menu_set_index(menu, index + 1);
+      menu_queue_redraw(menu, MENU_REDRAW_INDEX);
+    }
+  }
+  return IR_SUCCESS;
 }
 
 /**
@@ -59,7 +123,7 @@ static int op_delete(struct AliasMenuData *mdata, int op)
  */
 static int op_exit(struct AliasMenuData *mdata, int op)
 {
-  return IR_NOT_IMPL;
+  return IR_DONE;
 }
 
 /**
@@ -67,7 +131,42 @@ static int op_exit(struct AliasMenuData *mdata, int op)
  */
 static int op_generic_select_entry(struct AliasMenuData *mdata, int op)
 {
-  return IR_NOT_IMPL;
+  if (mdata->query)
+    return IR_CONTINUE;
+
+  struct Menu *menu = mdata->menu;
+  struct Email *e = email_new();
+  e->env = mutt_env_new();
+
+  if (menu->tag_prefix)
+  {
+    struct AliasView *avp = NULL;
+    ARRAY_FOREACH(avp, &mdata->ava)
+    {
+      if (!avp->is_tagged)
+        continue;
+
+      struct AddressList al = TAILQ_HEAD_INITIALIZER(al);
+      if (alias_to_addrlist(&al, avp->alias))
+      {
+        mutt_addrlist_copy(&e->env->to, &al, false);
+        mutt_addrlist_clear(&al);
+      }
+    }
+  }
+  else
+  {
+    struct AddressList al = TAILQ_HEAD_INITIALIZER(al);
+    if (alias_to_addrlist(&al, ARRAY_GET(&mdata->ava, menu_get_index(menu))->alias))
+    {
+      mutt_addrlist_copy(&e->env->to, &al, false);
+      mutt_addrlist_clear(&al);
+    }
+  }
+  struct Mailbox *m_cur = get_current_mailbox();
+  mutt_send_message(SEND_NO_FLAGS, e, NULL, m_cur, NULL, mdata->sub);
+  menu_queue_redraw(menu, MENU_REDRAW_FULL);
+  return IR_SUCCESS;
 }
 
 /**
@@ -75,7 +174,17 @@ static int op_generic_select_entry(struct AliasMenuData *mdata, int op)
  */
 static int op_main_limit(struct AliasMenuData *mdata, int op)
 {
-  return IR_NOT_IMPL;
+  struct Menu *menu = mdata->menu;
+  int rc = mutt_pattern_alias_func(_("Limit to addresses matching: "), mdata, menu);
+  if (rc != 0)
+    return IR_NO_ACTION;
+
+  alias_array_sort(&mdata->ava, mdata->sub);
+  alias_set_title(mdata->sbar, mdata->title, mdata->limit);
+  menu_queue_redraw(menu, MENU_REDRAW_FULL);
+  window_redraw(NULL);
+
+  return IR_SUCCESS;
 }
 
 /**
@@ -83,7 +192,46 @@ static int op_main_limit(struct AliasMenuData *mdata, int op)
  */
 static int op_query(struct AliasMenuData *mdata, int op)
 {
-  return IR_NOT_IMPL;
+  struct Buffer *buf = mdata->query;
+  if ((mutt_buffer_get_field(_("Query: "), buf, MUTT_COMP_NO_FLAGS, false, NULL,
+                             NULL, NULL) != 0) ||
+      mutt_buffer_is_empty(buf))
+  {
+    return IR_NO_ACTION;
+  }
+
+  if (op == OP_QUERY)
+  {
+    ARRAY_FREE(&mdata->ava);
+    aliaslist_free(mdata->al);
+  }
+
+  struct Menu *menu = mdata->menu;
+  struct AliasList al = TAILQ_HEAD_INITIALIZER(al);
+
+  query_run(mutt_buffer_string(buf), true, &al, mdata->sub);
+  menu_queue_redraw(menu, MENU_REDRAW_FULL);
+  char title[256];
+  snprintf(title, sizeof(title), "%s%s", _("Query: "), mutt_buffer_string(buf));
+  sbar_set_title(mdata->sbar, title);
+
+  if (TAILQ_EMPTY(&al))
+  {
+    menu->max = 0;
+    return IR_NO_ACTION;
+  }
+
+  struct Alias *np = NULL;
+  struct Alias *tmp = NULL;
+  TAILQ_FOREACH_SAFE(np, &al, entries, tmp)
+  {
+    alias_array_alias_add(&mdata->ava, np);
+    TAILQ_REMOVE(&al, np, entries);
+    TAILQ_INSERT_TAIL(mdata->al, np, entries); // Transfer
+  }
+  alias_array_sort(&mdata->ava, mdata->sub);
+  menu->max = ARRAY_SIZE(&mdata->ava);
+  return IR_SUCCESS;
 }
 
 /**
@@ -91,7 +239,13 @@ static int op_query(struct AliasMenuData *mdata, int op)
  */
 static int op_search(struct AliasMenuData *mdata, int op)
 {
-  return IR_NOT_IMPL;
+  struct Menu *menu = mdata->menu;
+  int index = mutt_search_alias_command(menu, menu_get_index(menu), op);
+  if (index == -1)
+    return IR_NO_ACTION;
+
+  menu_set_index(menu, index);
+  return IR_SUCCESS;
 }
 
 /**
@@ -99,7 +253,46 @@ static int op_search(struct AliasMenuData *mdata, int op)
  */
 static int op_sort(struct AliasMenuData *mdata, int op)
 {
-  return IR_NOT_IMPL;
+  int sort = cs_subset_sort(mdata->sub, "sort_alias");
+  bool resort = true;
+  bool reverse = (op == OP_SORT_REVERSE);
+
+  switch (mutt_multi_choice(
+      reverse ?
+          /* L10N: The highlighted letters must match the "Sort" options */
+          _("Rev-Sort (a)lias, a(d)dress or (u)nsorted?") :
+          /* L10N: The highlighted letters must match the "Rev-Sort" options */
+          _("Sort (a)lias, a(d)dress or (u)nsorted?"),
+      /* L10N: These must match the highlighted letters from "Sort" and "Rev-Sort" */
+      _("adu")))
+  {
+    case -1: /* abort */
+      resort = false;
+      break;
+
+    case 1: /* (a)lias */
+      sort = SORT_ALIAS;
+      break;
+
+    case 2: /* a(d)dress */
+      sort = SORT_ADDRESS;
+      break;
+
+    case 3: /* (u)nsorted */
+      sort = SORT_ORDER;
+      break;
+  }
+
+  if (resort)
+  {
+    sort |= reverse ? SORT_REVERSE : 0;
+
+    // This will trigger a WA_RECALC
+    cs_subset_str_native_set(mdata->sub, "sort_alias", sort, NULL);
+    //QWQ menu_queue_redraw(menu, MENU_REDRAW_FULL);
+  }
+
+  return IR_SUCCESS;
 }
 
 // -----------------------------------------------------------------------------

--- a/alias/functions.h
+++ b/alias/functions.h
@@ -1,0 +1,52 @@
+/**
+ * @file
+ * Alias functions
+ *
+ * @authors
+ * Copyright (C) 2022 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MUTT_ALIAS_FUNCTIONS_H
+#define MUTT_ALIAS_FUNCTIONS_H
+
+#include <stdbool.h>
+
+struct AliasMenuData;
+
+/**
+ * @defgroup alias_function_api Alias Function API
+ *
+ * Prototype for a Alias Function
+ *
+ * @param wdata  Alias Window data
+ * @param op     Operation to perform, e.g. OP_ALIAS_NEXT
+ * @retval enum #IndexRetval
+ */
+typedef int (*alias_function_t)(struct AliasMenuData *wdata, int op);
+
+/**
+ * struct AliasFunction - A NeoMutt function
+ */
+struct AliasFunction
+{
+  int op;                    ///< Op code, e.g. OP_SEARCH
+  alias_function_t function; ///< Function to call
+};
+
+extern struct AliasFunction AliasFunctions[];
+
+#endif /* MUTT_ALIAS_FUNCTIONS_H */

--- a/alias/functions.h
+++ b/alias/functions.h
@@ -25,7 +25,13 @@
 
 #include <stdbool.h>
 
+struct AddressList;
+struct Alias;
+struct AliasList;
 struct AliasMenuData;
+struct AliasViewArray;
+struct ConfigSubset;
+struct MuttWindow;
 
 /**
  * @defgroup alias_function_api Alias Function API
@@ -48,5 +54,11 @@ struct AliasFunction
 };
 
 extern struct AliasFunction AliasFunctions[];
+
+void alias_array_sort(struct AliasViewArray *ava, const struct ConfigSubset *sub);
+int alias_function_dispatcher(struct MuttWindow *win, int op);
+bool alias_to_addrlist(struct AddressList *al, struct Alias *alias);
+int query_run(const char *s, bool verbose, struct AliasList *al, const struct ConfigSubset *sub);
+
 
 #endif /* MUTT_ALIAS_FUNCTIONS_H */

--- a/alias/gui.c
+++ b/alias/gui.c
@@ -34,6 +34,7 @@
 #include "gui.h"
 #include "lib.h"
 #include "menu/lib.h"
+#include "functions.h"
 
 /**
  * alias_config_observer - Notification that a Config Variable has changed - Implements ::observer_t - @ingroup observer_api

--- a/alias/gui.h
+++ b/alias/gui.h
@@ -50,9 +50,14 @@ ARRAY_HEAD(AliasViewArray, struct AliasView);
  */
 struct AliasMenuData
 {
-  char *str;                 ///< String representing the limit being used
-  struct AliasViewArray ava; ///< Array of AliasView
-  struct ConfigSubset *sub;  ///< Config items
+  struct AliasViewArray ava;    ///< All Aliases/Queries
+  struct AliasList *al;         ///< Alias data
+  struct ConfigSubset *sub;     ///< Config items
+  struct Menu *menu;            ///< Menu
+  struct Buffer *query;         ///< Query string
+  char *limit;                  ///< Limit being used
+  struct MuttWindow *sbar;      ///< Status Bar
+  char *title;                  ///< Title for the status bar
 };
 
 int alias_config_observer(struct NotifyCallback *nc);

--- a/alias/lib.h
+++ b/alias/lib.h
@@ -68,6 +68,7 @@ enum CommandResult parse_alias  (struct Buffer *buf, struct Buffer *s, intptr_t 
 enum CommandResult parse_unalias(struct Buffer *buf, struct Buffer *s, intptr_t data, struct Buffer *err);
 
 int  alias_complete(char *buf, size_t buflen, struct ConfigSubset *sub);
+void alias_dialog  (struct ConfigSubset *sub);
 
 int  query_complete(struct Buffer *buf, struct ConfigSubset *sub);
 void query_index   (struct ConfigSubset *sub);

--- a/alias/lib.h
+++ b/alias/lib.h
@@ -76,8 +76,4 @@ void query_index   (struct ConfigSubset *sub);
 
 struct Address *alias_reverse_lookup(const struct Address *addr);
 
-void alias_array_sort(struct AliasViewArray *ava, const struct ConfigSubset *sub);
-
-int alias_function_dispatcher(struct MuttWindow *win, int op);
-
 #endif /* MUTT_ALIAS_LIB_H */

--- a/alias/lib.h
+++ b/alias/lib.h
@@ -52,6 +52,7 @@ struct AliasViewArray;
 struct Buffer;
 struct ConfigSubset;
 struct Envelope;
+struct MuttWindow;
 
 void alias_init    (void);
 void alias_shutdown(void);
@@ -76,5 +77,7 @@ void query_index   (struct ConfigSubset *sub);
 struct Address *alias_reverse_lookup(const struct Address *addr);
 
 void alias_array_sort(struct AliasViewArray *ava, const struct ConfigSubset *sub);
+
+int alias_function_dispatcher(struct MuttWindow *win, int op);
 
 #endif /* MUTT_ALIAS_LIB_H */

--- a/functions.c
+++ b/functions.c
@@ -55,6 +55,7 @@
 const struct MenuFuncOp OpAlias[] = { /* map: alias */
   { "delete-entry",                  OP_DELETE },
   { "limit",                         OP_MAIN_LIMIT },
+  { "mail",                          OP_MAIL },
   { "sort-alias",                    OP_SORT },
   { "sort-alias-reverse",            OP_SORT_REVERSE },
   { "undelete-entry",                OP_UNDELETE },
@@ -704,6 +705,7 @@ const struct MenuFuncOp OpSmime[] = { /* map: smime */
  */
 const struct MenuOpSeq AliasDefaultBindings[] = { /* map: alias */
   { OP_DELETE,                             "d" },
+  { OP_MAIL,                               "m" },
   { OP_MAIN_LIMIT,                         "l" },
   { OP_SORT,                               "o" },
   { OP_SORT_REVERSE,                       "O" },

--- a/functions.c
+++ b/functions.c
@@ -324,6 +324,7 @@ const struct MenuFuncOp OpGeneric[] = { /* map: generic */
  * OpIndex - Functions for the Index Menu
  */
 const struct MenuFuncOp OpIndex[] = { /* map: index */
+  { "alias-dialog",                  OP_ALIAS_DIALOG },
 #ifdef USE_AUTOCRYPT
   { "autocrypt-acct-menu",           OP_AUTOCRYPT_ACCT_MENU },
 #endif

--- a/index/functions.c
+++ b/index/functions.c
@@ -106,6 +106,16 @@ const struct Mapping RetvalNames[] = {
 // -----------------------------------------------------------------------------
 
 /**
+ * op_alias_dialog - Open the aliases dialog - Implements ::index_function_t - @ingroup index_function_api
+ */
+static int op_alias_dialog(struct IndexSharedData *shared,
+                           struct IndexPrivateData *priv, int op)
+{
+  alias_dialog(shared->sub);
+  return IR_SUCCESS;
+}
+
+/**
  * op_attachment_edit_type - Edit attachment content type - Implements ::index_function_t - @ingroup index_function_api
  */
 static int op_attachment_edit_type(struct IndexSharedData *shared,
@@ -3187,6 +3197,7 @@ int index_function_dispatcher(struct MuttWindow *win_index, int op)
  */
 struct IndexFunction IndexFunctions[] = {
   // clang-format off
+  { OP_ALIAS_DIALOG,                        op_alias_dialog,                      CHECK_NO_FLAGS },
   { OP_ATTACHMENT_EDIT_TYPE,                op_attachment_edit_type,              CHECK_ATTACH | CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE },
   { OP_BOTTOM_PAGE,                         op_menu_move,                         CHECK_NO_FLAGS },
   { OP_BOUNCE_MESSAGE,                      op_bounce_message,                    CHECK_ATTACH | CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE },

--- a/opcodes.h
+++ b/opcodes.h
@@ -76,6 +76,7 @@
 #endif
 
 #define OPS_CORE(_fmt) \
+  _fmt(OP_ALIAS_DIALOG,                       N_("open the aliases dialog")) \
   _fmt(OP_BOTTOM_PAGE,                        N_("move to the bottom of the page")) \
   _fmt(OP_BOUNCE_MESSAGE,                     N_("remail a message to another user")) \
   _fmt(OP_BROWSER_GOTO_FOLDER,                N_("swap the current folder position with $folder if it exists")) \

--- a/pattern/pattern.c
+++ b/pattern/pattern.c
@@ -246,7 +246,7 @@ int mutt_pattern_alias_func(char *prompt, struct AliasMenuData *mdata, struct Me
   struct Progress *progress = NULL;
   struct Buffer *buf = mutt_buffer_pool_get();
 
-  mutt_buffer_strcpy(buf, mdata->str);
+  mutt_buffer_strcpy(buf, mdata->limit);
   if (prompt)
   {
     if ((mutt_buffer_get_field(prompt, buf, MUTT_COMP_PATTERN | MUTT_COMP_CLEAR,
@@ -307,10 +307,10 @@ int mutt_pattern_alias_func(char *prompt, struct AliasMenuData *mdata, struct Me
   }
   progress_free(&progress);
 
-  FREE(&mdata->str);
+  FREE(&mdata->limit);
   if (!match_all)
   {
-    mdata->str = simple;
+    mdata->limit = simple;
     simple = NULL;
   }
 


### PR DESCRIPTION
## Overview

This PR changes the behaviour of the Alias and Query Dialogs.
It brings them in line with NeoMutt and each other.

The workflow is changed so that leaving the Alias/Query Dialog always returns you to where your _were_.
(See the diagrams at the bottom)

## Changes

The diffs are quite large, but most of that bulk is non-functional (moving functions around).

- 876a93d4d drop `query_search()`
  `query_search()` hasn't been needed since `menu->custom_search` was enabled.

- b435f3345 convert `dlg_select_alias()` to use Buffer
  This brings it in line with `dlg_select_query()`.

- 70d7a391c add `<alias-dialog>` function
  Add an `<alias-dialog>` function to mirror the `<query>` function.
  This gives the user direct access to the address book.

- 52cf73fbd enable `<mail>` function
  Enable the `<mail>` function in the Alias Dialog, to match the Query Dialog.

- d8983cd77 unify tagging behaviour
  Change the Alias and Query Dialogs to honour tagged addreses and the `<tag-prefix>` function.

- fad9b1b2e create function dispatcher
  Create a unifed Alias function dispatcher for the Alias and Query Dialogs.

- ecdd54119 move functions to dispatcher
  Move all duplicated code out of the Alias and Query dialogs into the alias function dispatcher.

## Testing

Pre-requisites:

- Config for some aliases
- Config for a query command

See the actor data in the [Sample Data Repo](https://github.com/neomutt/sample-data.git).

```sh
set query_command = "echo '# Header line'; grep -i %s actor-query.txt"
```

### Four Starting Places

There are four starting places for the tests.

- Alias Dialog
  - Directly `<alias-dialog>`
  - Completion, e.g. <kbd>john</kbd> + <kbd>\<tab\></kbd> (`<complete>`)
- Query Dialog
  - Directly `<query>`
  - Completion, e.g. <kbd>john</kbd> + <kbd>\<Ctrl-t\></kbd> (`<complete-query>`)

These macros get you to the four starting places.

```sh
macro index <F5> "<alias-dialog>4<enter><tag-entry><tag-entry><tag-entry><next-entry>"
macro index <F6> "<query>.<enter>4<enter><tag-entry><tag-entry><tag-entry><next-entry>"
macro index <F7> "<mail>rich, <complete>4<enter><tag-entry><tag-entry><tag-entry><next-entry>"
macro index <F8> "<mail>rich, <complete-query>4<enter><tag-entry><tag-entry><tag-entry><next-entry>"
```

### Five Actions

From each of the starting places, there are five actions to test.

- Single selection -- `<select-entry>` (<kbd>\<enter\></kbd>)
  A new mail will be started with **one** address

- Tagged selection -- `<tag-prefix><select-entry>`  (<kbd>;</kbd> <kbd>\<enter\></kbd>)
  A new mail will be started with **three** addresses

- Single mail -- `<mail>` (<kbd>m</kbd>)
  A new mail will be started with **one** address

- Tagged mail -- `<tag-prefix><mail>`  (<kbd>;</kbd> <kbd>m</kbd>)
  A new mail will be started with **three** addresses

- Quit -- `<exit>` (<kbd>q</kbd>)
  NeoMutt will return to the Index Dialog

### Results

The workflow for the four starting places looks like this:

#### Direct Access

<img src="https://raw.githubusercontent.com/neomutt/gfx/main/arch/direct.svg">

#### Auto-Completion

<img src="https://raw.githubusercontent.com/neomutt/gfx/main/arch/complete.svg">