### PR TITLE
Make free'ing a mailbox easier for the caller

### DIFF
--- a/browser/browser.c
+++ b/browser/browser.c
@@ -504,7 +504,7 @@ static void add_folder(struct Menu *menu, struct BrowserState *state,
                        const char *name, const char *desc,
                        const struct stat *st, struct Mailbox *m, void *data)
 {
-  if ((!menu || state->is_mailbox_list) && m && (m->flags & MB_HIDDEN))
+  if ((!menu || state->is_mailbox_list) && m && !m->visible)
   {
     return;
   }

--- a/command_parse.c
+++ b/command_parse.c
@@ -601,9 +601,12 @@ enum CommandResult parse_mailboxes(struct Buffer *buf, struct Buffer *s,
       }
     }
 
-    if (!mx_ac_add(a, m))
+    if (mx_ac_add(a, m))
     {
-      //error
+      m->flags = MB_NORMAL; // make it finally visible
+    }
+    else
+    {
       mailbox_free(&m);
       if (new_account)
       {

--- a/commands.c
+++ b/commands.c
@@ -1089,8 +1089,7 @@ errcleanup:
     }
   }
 
-  if (m_save && (m_save->flags == MB_HIDDEN))
-    mailbox_free(&m_save);
+  mailbox_free(&m_save);
 
 cleanup:
   mutt_buffer_pool_release(&buf);

--- a/core/account.c
+++ b/core/account.c
@@ -121,6 +121,8 @@ bool account_mailbox_remove(struct Account *a, struct Mailbox *m)
     }
     else
     {
+      // we set MB_HIDDEN here to force the deletion of the mailbox
+      np->mailbox->flags = MB_HIDDEN;
       mailbox_free(&np->mailbox);
     }
     FREE(&np);

--- a/core/account.c
+++ b/core/account.c
@@ -121,8 +121,8 @@ bool account_mailbox_remove(struct Account *a, struct Mailbox *m)
     }
     else
     {
-      // we set MB_HIDDEN here to force the deletion of the mailbox
-      np->mailbox->flags = MB_HIDDEN;
+      // we make it invisible here to force the deletion of the mailbox
+      np->mailbox->visible = false;
       mailbox_free(&np->mailbox);
     }
     FREE(&np);

--- a/core/mailbox.c
+++ b/core/mailbox.c
@@ -71,7 +71,6 @@ struct Mailbox *mailbox_new(void)
 
   mutt_buffer_init(&m->pathbuf);
   m->notify = notify_new();
-  m->flags = MB_HIDDEN;
 
   m->email_max = 25;
   m->emails = mutt_mem_calloc(m->email_max, sizeof(struct Email *));
@@ -92,10 +91,10 @@ void mailbox_free(struct Mailbox **ptr)
 
   struct Mailbox *m = *ptr;
 
-  const bool do_free = (m->opened == 0) && (m->flags == MB_HIDDEN);
+  const bool do_free = (m->opened == 0) && !m->visible;
 
   mutt_debug(LL_DEBUG3, "%sfreeing %s mailbox %s with refcount %d\n",
-             do_free ? "" : "not ", m->flags == MB_HIDDEN ? "invisible" : "visible",
+             do_free ? "" : "not ", m->visible ? "visible" : "invisible",
              mutt_buffer_string(&m->pathbuf), m->opened);
 
   if (!do_free)

--- a/core/mailbox.c
+++ b/core/mailbox.c
@@ -71,6 +71,7 @@ struct Mailbox *mailbox_new(void)
 
   mutt_buffer_init(&m->pathbuf);
   m->notify = notify_new();
+  m->flags = MB_HIDDEN;
 
   m->email_max = 25;
   m->emails = mutt_mem_calloc(m->email_max, sizeof(struct Email *));
@@ -90,6 +91,17 @@ void mailbox_free(struct Mailbox **ptr)
     return;
 
   struct Mailbox *m = *ptr;
+
+  const bool do_free = (m->opened == 0) && (m->flags == MB_HIDDEN);
+
+  mutt_debug(LL_DEBUG3, "%sfreeing %s mailbox %s with refcount %d\n",
+             do_free ? "" : "not ", m->flags == MB_HIDDEN ? "invisible" : "visible",
+             mutt_buffer_string(&m->pathbuf), m->opened);
+
+  if (!do_free)
+  {
+    return;
+  }
 
   mutt_debug(LL_NOTIFY, "NT_MAILBOX_DELETE: %s %p\n", mailbox_get_type_name(m->type), m);
   struct EventMailbox ev_m = { m };

--- a/core/mailbox.h
+++ b/core/mailbox.h
@@ -34,9 +34,6 @@
 struct ConfigSubset;
 struct Email;
 
-#define MB_NORMAL 0
-#define MB_HIDDEN 1
-
 /**
  * enum MailboxType - Supported mailbox formats
  */
@@ -131,7 +128,7 @@ struct Mailbox
   struct Account *account;            ///< Account that owns this Mailbox
   int opened;                         ///< Number of times mailbox is opened
 
-  uint8_t flags;                      ///< e.g. #MB_NORMAL
+  bool visible;                       ///< True if a result of "mailboxes"
 
   void *mdata;                        ///< Driver specific data
 

--- a/editmsg.c
+++ b/editmsg.c
@@ -86,8 +86,7 @@ static int ev_message(enum EvMessage action, struct Mailbox *m, struct Email *e)
   int oerrno = errno;
 
   mx_mbox_close(m_fname);
-  if (m_fname->flags == MB_HIDDEN)
-    mailbox_free(&m_fname);
+  mailbox_free(&m_fname);
 
   if (rc == -1)
   {

--- a/index/dlg_index.c
+++ b/index/dlg_index.c
@@ -583,8 +583,7 @@ void change_folder_mailbox(struct Menu *menu, struct Mailbox *m, int *oldcount,
   if (shared->mailbox && (mutt_buffer_is_empty(&shared->mailbox->pathbuf)))
   {
     ctx_free(&shared->ctx);
-    if (shared->mailbox->flags == MB_HIDDEN)
-      mailbox_free(&shared->mailbox);
+    mailbox_free(&shared->mailbox);
   }
 
   if (shared->mailbox)
@@ -605,8 +604,10 @@ void change_folder_mailbox(struct Menu *menu, struct Mailbox *m, int *oldcount,
     if (check == MX_STATUS_OK)
     {
       ctx_free(&shared->ctx);
-      if ((shared->mailbox != m) && (shared->mailbox->flags == MB_HIDDEN))
+      if (shared->mailbox != m)
+      {
         mailbox_free(&shared->mailbox);
+      }
     }
     else
     {

--- a/index/functions.c
+++ b/index/functions.c
@@ -2012,8 +2012,7 @@ static int op_quit(struct IndexSharedData *shared, struct IndexPrivateData *priv
     if (!shared->ctx || ((check = mx_mbox_close(shared->mailbox)) == MX_STATUS_OK))
     {
       ctx_free(&shared->ctx);
-      if (shared->mailbox && (shared->mailbox->flags == MB_HIDDEN))
-        mailbox_free(&shared->mailbox);
+      mailbox_free(&shared->mailbox);
       return IR_DONE;
     }
 

--- a/main.c
+++ b/main.c
@@ -1380,8 +1380,7 @@ main
       mutt_curses_set_cursor(MUTT_CURSOR_INVISIBLE);
       m = mutt_index_menu(dlg, m);
       mutt_curses_set_cursor(MUTT_CURSOR_VISIBLE);
-      if (m && (m->flags == MB_HIDDEN))
-        mailbox_free(&m);
+      mailbox_free(&m);
 
       dialog_pop();
       mutt_window_free(&dlg);

--- a/mutt_mailbox.c
+++ b/mutt_mailbox.c
@@ -214,7 +214,7 @@ int mutt_mailbox_check(struct Mailbox *m_cur, int force)
   struct MailboxNode *np = NULL;
   STAILQ_FOREACH(np, &ml, entries)
   {
-    if (np->mailbox->flags & MB_HIDDEN)
+    if (!np->mailbox->visible)
       continue;
 
     mailbox_check(m_cur, np->mailbox, &st_ctx,

--- a/mx.c
+++ b/mx.c
@@ -593,8 +593,7 @@ static int trash_append(struct Mailbox *m)
 
   mx_mbox_close(m_trash);
   m_trash->append = old_append;
-  if (m_trash->flags == MB_HIDDEN)
-    mailbox_free(&m_trash);
+  mailbox_free(&m_trash);
 
   return 0;
 }
@@ -1688,7 +1687,6 @@ struct Mailbox *mx_path_resolve(const char *path)
     return m;
 
   m = mailbox_new();
-  m->flags = MB_HIDDEN;
   mutt_buffer_strcpy(&m->pathbuf, path);
   const char *const c_folder = cs_subset_string(NeoMutt->sub, "folder");
   mx_path_canon2(m, c_folder);

--- a/mx.c
+++ b/mx.c
@@ -458,7 +458,7 @@ void mx_fastclose_mailbox(struct Mailbox *m, bool keep_account)
     }
   }
 
-  if (m->flags & MB_HIDDEN)
+  if (!m->visible)
   {
     mx_ac_remove(m, keep_account);
   }

--- a/postpone.c
+++ b/postpone.c
@@ -160,14 +160,12 @@ int mutt_num_postponed(struct Mailbox *m, bool force)
     {
       PostCount = m_post->msg_count;
       mx_fastclose_mailbox(m_post, false);
-      if (m_post->flags == MB_HIDDEN)
-        mailbox_free(&m_post);
     }
     else
     {
-      mailbox_free(&m_post);
       PostCount = 0;
     }
+    mailbox_free(&m_post);
 
 #ifdef USE_NNTP
     if (optnews)
@@ -687,8 +685,7 @@ int mutt_get_postponed(struct Mailbox *m_cur, struct Email *hdr,
     {
       PostCount = 0;
       mutt_error(_("No postponed messages"));
-      if (m->flags == MB_HIDDEN)
-        mailbox_free(&m);
+      mailbox_free(&m);
       return -1;
     }
   }
@@ -702,8 +699,7 @@ int mutt_get_postponed(struct Mailbox *m_cur, struct Email *hdr,
     if (m_cur != m)
     {
       mx_fastclose_mailbox(m, false);
-      if (m->flags == MB_HIDDEN)
-        mailbox_free(&m);
+      mailbox_free(&m);
     }
     return -1;
   }
@@ -815,8 +811,7 @@ cleanup:
   {
     hardclose(m);
     ctx_free(&ctx);
-    if (m->flags == MB_HIDDEN)
-      mailbox_free(&m);
+    mailbox_free(&m);
   }
 
   cs_subset_str_native_set(NeoMutt->sub, "delete", c_delete, NULL);

--- a/send/send.c
+++ b/send/send.c
@@ -1880,12 +1880,8 @@ full_fcc:
      * the From_ line contains the current time instead of when the
      * message was first postponed.  */
     e->received = mutt_date_epoch();
-    int old_flags = MB_NORMAL;
-    if (m)
-    {
-      old_flags = m->flags;
-      m->flags = MB_NORMAL;
-    }
+    const int old_flags = m->flags;
+    m->flags = MB_NORMAL;
     rc = mutt_write_multiple_fcc(mutt_buffer_string(fcc), e, NULL, false, NULL,
                                  finalpath, sub);
     while (rc && !(flags & SEND_BATCH))
@@ -1926,8 +1922,7 @@ full_fcc:
           break;
       }
     }
-    if (m)
-      m->flags = old_flags;
+    m->flags = old_flags;
   }
 
   if (!c_fcc_before_send)

--- a/send/send.c
+++ b/send/send.c
@@ -1880,8 +1880,6 @@ full_fcc:
      * the From_ line contains the current time instead of when the
      * message was first postponed.  */
     e->received = mutt_date_epoch();
-    const int old_flags = m->flags;
-    m->flags = MB_NORMAL;
     rc = mutt_write_multiple_fcc(mutt_buffer_string(fcc), e, NULL, false, NULL,
                                  finalpath, sub);
     while (rc && !(flags & SEND_BATCH))
@@ -1922,7 +1920,6 @@ full_fcc:
           break;
       }
     }
-    m->flags = old_flags;
   }
 
   if (!c_fcc_before_send)

--- a/send/sendlib.c
+++ b/send/sendlib.c
@@ -1744,8 +1744,7 @@ int mutt_write_fcc(const char *path, struct Email *e, const char *msgid, bool po
 
 done:
   m_fcc->append = old_append;
-  if (m_fcc->flags == MB_HIDDEN)
-    mailbox_free(&m_fcc);
+  mailbox_free(&m_fcc);
 
 #ifdef RECORD_FOLDER_HOOK
   /* We ran a folder hook for the destination mailbox,

--- a/sidebar/observer.c
+++ b/sidebar/observer.c
@@ -171,7 +171,7 @@ static void sb_init_data(struct MuttWindow *win)
   struct MailboxNode *np = NULL;
   STAILQ_FOREACH(np, &ml, entries)
   {
-    if (!(np->mailbox->flags & MB_HIDDEN))
+    if (np->mailbox->visible)
       sb_add_mailbox(wdata, np->mailbox);
   }
   neomutt_mailboxlist_clear(&ml);

--- a/sidebar/sidebar.c
+++ b/sidebar/sidebar.c
@@ -187,7 +187,7 @@ void sb_set_current_mailbox(struct SidebarWindowData *wdata, struct Mailbox *m)
         break;
       }
     }
-    (*sbep)->is_hidden = ((*sbep)->mailbox->flags & MB_HIDDEN);
+    (*sbep)->is_hidden = !(*sbep)->mailbox->visible;
   }
 }
 

--- a/sidebar/window.c
+++ b/sidebar/window.c
@@ -588,7 +588,7 @@ static void update_entries_visibility(struct SidebarWindowData *wdata)
 
     sbe->is_hidden = false;
 
-    if (sbe->mailbox->flags & MB_HIDDEN)
+    if (!sbe->mailbox->visible)
     {
       sbe->is_hidden = true;
       continue;
@@ -661,9 +661,9 @@ static bool prepare_sidebar(struct SidebarWindowData *wdata, int page_size)
   {
     ARRAY_FOREACH(sbep, &wdata->entries)
     {
-      if ((opn_entry == *sbep) && ((*sbep)->mailbox->flags != MB_HIDDEN))
+      if ((opn_entry == *sbep) && (*sbep)->mailbox->visible)
         wdata->opn_index = ARRAY_FOREACH_IDX;
-      if ((hil_entry == *sbep) && ((*sbep)->mailbox->flags != MB_HIDDEN))
+      if ((hil_entry == *sbep) && (*sbep)->mailbox->visible)
         wdata->hil_index = ARRAY_FOREACH_IDX;
     }
   }
@@ -737,7 +737,7 @@ int sb_recalc(struct MuttWindow *win)
     struct MailboxNode *np = NULL;
     STAILQ_FOREACH(np, &ml, entries)
     {
-      if (!(np->mailbox->flags & MB_HIDDEN))
+      if (np->mailbox->visible)
         sb_add_mailbox(wdata, np->mailbox);
     }
     neomutt_mailboxlist_clear(&ml);


### PR DESCRIPTION
Let's just try and free a mailbox whenever we're done with it, and
leave it to mailbox_free to decide when it's actually safe to do.

In this PoC, safe means the mailbox isn't open and isn't visible. This
can probably cause a few leaks, e.g., when quitting NeoMutt.

Fixes #3098