### PR TITLE
fix selecton after <limit>

### DIFF
--- a/index/functions.c
+++ b/index/functions.c
@@ -1016,17 +1016,18 @@ static int op_main_limit(struct IndexSharedData *shared, struct IndexPrivateData
     {
       priv->menu->max = shared->mailbox->vcount;
       /* try to find what used to be the current message */
-      for (size_t i = 0; i < shared->mailbox->vcount; i++)
+      int i;
+      for (i = 0; i < shared->mailbox->vcount; i++)
       {
         struct Email *e = mutt_get_virt_email(shared->mailbox, i);
         if (!e)
           continue;
         if (e->index == old_index)
         {
-          menu_set_index(priv->menu, i);
           break;
         }
       }
+      menu_set_index(priv->menu, i);
     }
 
     if ((shared->mailbox->msg_count != 0) && mutt_using_threads())

--- a/index/functions.c
+++ b/index/functions.c
@@ -1016,18 +1016,18 @@ static int op_main_limit(struct IndexSharedData *shared, struct IndexPrivateData
     {
       priv->menu->max = shared->mailbox->vcount;
       /* try to find what used to be the current message */
-      int i;
-      for (i = 0; i < shared->mailbox->vcount; i++)
+      menu_set_index(priv->menu, 0);
+      for (size_t i = 0; i < shared->mailbox->vcount; i++)
       {
         struct Email *e = mutt_get_virt_email(shared->mailbox, i);
         if (!e)
           continue;
         if (e->index == old_index)
         {
+          menu_set_index(priv->menu, i);
           break;
         }
       }
-      menu_set_index(priv->menu, i);
     }
 
     if ((shared->mailbox->msg_count != 0) && mutt_using_threads())


### PR DESCRIPTION
If the selection was on a non-matching line
and that line's number is beyond the number of limited entries,
then selection would end up off-screen and the screen would be blank.

**Test case**:

- Mailbox with 3 entries
- Flag the second entry
- Put the cursor on the third entry
- Command: `<limit>~F`

A recent fix moved the `menu_set_index()` into the `for` loop.
Unfortunately, if the selection ended up off-screen, it wouldn't get corrected.

`menu_set_index()` clamps its inputs to valid values,
so if the match isn't found the selection will be set to a safe value.