### PR TITLE
query: fix crashes

### DIFF
--- a/alias/dlg_alias.c
+++ b/alias/dlg_alias.c
@@ -498,9 +498,10 @@ int alias_complete(char *buf, size_t buflen, struct ConfigSubset *sub)
 
 /**
  * alias_dialog - Open the aliases dialog
- * @param sub Config items
+ * @param m   Mailbox
+ * @param sub Config item
  */
-void alias_dialog(struct ConfigSubset *sub)
+void alias_dialog(struct Mailbox *m, struct ConfigSubset *sub)
 {
   struct Alias *np = NULL;
 

--- a/alias/dlg_query.c
+++ b/alias/dlg_query.c
@@ -540,9 +540,10 @@ done:
 
 /**
  * query_index - Perform an Alias Query and display the results
- * @param sub    Config item
+ * @param m   Mailbox
+ * @param sub Config item
  */
-void query_index(struct ConfigSubset *sub)
+void query_index(struct Mailbox *m, struct ConfigSubset *sub)
 {
   const char *const query_command = cs_subset_string(sub, "query_command");
   if (!query_command)

--- a/alias/functions.c
+++ b/alias/functions.c
@@ -214,7 +214,8 @@ static int op_query(struct AliasMenuData *mdata, int op)
 
   if (TAILQ_EMPTY(&al))
   {
-    menu->max = 0;
+    if (op == OP_QUERY)
+      menu->max = 0;
     return IR_NO_ACTION;
   }
 

--- a/alias/lib.h
+++ b/alias/lib.h
@@ -52,6 +52,7 @@ struct AliasViewArray;
 struct Buffer;
 struct ConfigSubset;
 struct Envelope;
+struct Mailbox;
 struct MuttWindow;
 
 void alias_init    (void);
@@ -69,10 +70,10 @@ enum CommandResult parse_alias  (struct Buffer *buf, struct Buffer *s, intptr_t 
 enum CommandResult parse_unalias(struct Buffer *buf, struct Buffer *s, intptr_t data, struct Buffer *err);
 
 int  alias_complete(char *buf, size_t buflen, struct ConfigSubset *sub);
-void alias_dialog  (struct ConfigSubset *sub);
+void alias_dialog  (struct Mailbox *m, struct ConfigSubset *sub);
 
 int  query_complete(struct Buffer *buf, struct ConfigSubset *sub);
-void query_index   (struct ConfigSubset *sub);
+void query_index   (struct Mailbox *m, struct ConfigSubset *sub);
 
 struct Address *alias_reverse_lookup(const struct Address *addr);
 

--- a/index/functions.c
+++ b/index/functions.c
@@ -111,7 +111,7 @@ const struct Mapping RetvalNames[] = {
 static int op_alias_dialog(struct IndexSharedData *shared,
                            struct IndexPrivateData *priv, int op)
 {
-  alias_dialog(shared->sub);
+  alias_dialog(shared->mailbox, shared->sub);
   return IR_SUCCESS;
 }
 
@@ -1988,7 +1988,7 @@ static int op_print(struct IndexSharedData *shared, struct IndexPrivateData *pri
  */
 static int op_query(struct IndexSharedData *shared, struct IndexPrivateData *priv, int op)
 {
-  query_index(shared->sub);
+  query_index(shared->mailbox, shared->sub);
   return IR_SUCCESS;
 }
 


### PR DESCRIPTION
Fix crashes introduced by recent refactoring.

Tests:

- `<query>`, no matches
- `<query>`, matches
- `<mail>` `<complete>`, no matches
- `<mail>` `<complete>`, matches
- `<query>`, matches, `<query>`, no matches
- `<query>`, matches, `<query>`, matches
- `<mail>` `<complete>`, matches, `<query>`, no matches
- `<mail>` `<complete>`, matches, `<query>`, matches
- `<query>`, matches, `<query-append>`, no matches
- `<query>`, matches, `<query-append>`, matches
- `<mail>` `<complete>`, matches, `<query-append>`, no matches
- `<mail>` `<complete>`, matches, `<query-append>`, matches



Fixes: #3300