### PR TITLE
Add missing stdbool.h to timegm fallback

### DIFF
--- a/timegm.c
+++ b/timegm.c
@@ -28,6 +28,7 @@
 
 #include "config.h"
 #include <time.h>
+#include <stdbool.h>
 
 /**
  * is_leap_year - Is this a Leap Year?


### PR DESCRIPTION
* **What does this PR do?**

Fix a small compilation issue on systems not having timegm.
