### PR TITLE
Use $openssl in hcachever.sh for consistency

### DIFF
--- a/hcache/hcachever.sh
+++ b/hcache/hcachever.sh
@@ -56,7 +56,7 @@ md5prog () {
   # Use OpenSSL if it's installed
   if openssl=$(command -v openssl); then
     # Check that openssl supports the -r option (requires version 1.1.0)
-    if echo test | openssl md5 -r > /dev/null 2>&1; then
+    if echo test | $openssl md5 -r > /dev/null 2>&1; then
       echo "$openssl md5 -r"
       return
     fi


### PR DESCRIPTION
* **What does this PR do?**

Small online fix for consistency, actually use the openssl looked up on the line before and that will be returned.