### PR TITLE
Index/Pager: use the global function dispatcher

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -685,6 +685,12 @@ void mutt_enter_command(void)
   }
   /* else successful command */
 
+  if (NeoMutt)
+  {
+    // Running commands could cause anything to change, so let others know
+    notify_send(NeoMutt->notify, NT_GLOBAL, NT_GLOBAL_COMMAND, NULL);
+  }
+
 done:
   mutt_buffer_pool_release(&buf);
   mutt_buffer_pool_release(&err);

--- a/core/neomutt.h
+++ b/core/neomutt.h
@@ -52,6 +52,7 @@ enum NotifyGlobal
   NT_GLOBAL_STARTUP = 1, ///< NeoMutt is initialised
   NT_GLOBAL_SHUTDOWN,    ///< NeoMutt is about to close
   NT_GLOBAL_TIMEOUT,     ///< A timer has elapsed
+  NT_GLOBAL_COMMAND,     ///< A NeoMutt command
 };
 
 bool            neomutt_account_add   (struct NeoMutt *n, struct Account *a);

--- a/index/dlg_index.c
+++ b/index/dlg_index.c
@@ -1348,6 +1348,8 @@ struct Mailbox *mutt_index_menu(struct MuttWindow *dlg, struct Mailbox *m_init)
       rc = sb_function_dispatcher(win_sidebar, op);
     }
 #endif
+    if (rc == FR_UNKNOWN)
+      rc = global_function_dispatcher(dlg, op);
 
     if (rc == FR_CONTINUE)
     {

--- a/index/functions.c
+++ b/index/functions.c
@@ -131,16 +131,6 @@ static int op_bounce_message(struct IndexSharedData *shared,
 }
 
 /**
- * op_check_stats - Calculate message statistics for all mailboxes - Implements ::index_function_t - @ingroup index_function_api
- */
-static int op_check_stats(struct IndexSharedData *shared,
-                          struct IndexPrivateData *priv, int op)
-{
-  mutt_check_stats(shared->mailbox);
-  return FR_SUCCESS;
-}
-
-/**
  * op_check_traditional - Check for classic PGP - Implements ::index_function_t - @ingroup index_function_api
  */
 static int op_check_traditional(struct IndexSharedData *shared,
@@ -458,19 +448,6 @@ static int op_edit_raw_message(struct IndexSharedData *shared,
  */
 static int op_end_cond(struct IndexSharedData *shared, struct IndexPrivateData *priv, int op)
 {
-  return FR_SUCCESS;
-}
-
-/**
- * op_enter_command - Enter a neomuttrc command - Implements ::index_function_t - @ingroup index_function_api
- */
-static int op_enter_command(struct IndexSharedData *shared,
-                            struct IndexPrivateData *priv, int op)
-{
-  mutt_enter_command();
-  mutt_check_rescore(shared->mailbox);
-  menu_queue_redraw(priv->menu, MENU_REDRAW_FULL);
-
   return FR_SUCCESS;
 }
 
@@ -2026,18 +2003,6 @@ static int op_recall_message(struct IndexSharedData *shared,
 }
 
 /**
- * op_redraw - Clear and redraw the screen - Implements ::index_function_t - @ingroup index_function_api
- */
-static int op_redraw(struct IndexSharedData *shared, struct IndexPrivateData *priv, int op)
-{
-  window_invalidate_all();
-  mutt_window_reflow(NULL);
-  clearok(stdscr, true);
-  menu_queue_redraw(priv->menu, MENU_REDRAW_FULL);
-  return FR_SUCCESS;
-}
-
-/**
  * op_reply - Reply to a message - Implements ::index_function_t - @ingroup index_function_api
  */
 static int op_reply(struct IndexSharedData *shared, struct IndexPrivateData *priv, int op)
@@ -2159,20 +2124,6 @@ static int op_search(struct IndexSharedData *shared, struct IndexPrivateData *pr
   index = mutt_search_command(shared->mailbox, priv->menu, index, op);
   if (index != -1)
     menu_set_index(priv->menu, index);
-
-  return FR_SUCCESS;
-}
-
-/**
- * op_shell_escape - Invoke a command in a subshell - Implements ::index_function_t - @ingroup index_function_api
- */
-static int op_shell_escape(struct IndexSharedData *shared,
-                           struct IndexPrivateData *priv, int op)
-{
-  if (mutt_shell_escape())
-  {
-    mutt_mailbox_check(shared->mailbox, MUTT_MAILBOX_CHECK_FORCE);
-  }
 
   return FR_SUCCESS;
 }
@@ -2459,15 +2410,6 @@ static int op_undelete_thread(struct IndexSharedData *shared,
 }
 
 /**
- * op_version - Show the NeoMutt version number and date - Implements ::index_function_t - @ingroup index_function_api
- */
-static int op_version(struct IndexSharedData *shared, struct IndexPrivateData *priv, int op)
-{
-  mutt_message(mutt_make_version());
-  return FR_SUCCESS;
-}
-
-/**
  * op_view_attachments - Show MIME attachments - Implements ::index_function_t - @ingroup index_function_api
  */
 static int op_view_attachments(struct IndexSharedData *shared,
@@ -2490,15 +2432,6 @@ static int op_view_attachments(struct IndexSharedData *shared,
   }
   menu_queue_redraw(priv->menu, MENU_REDRAW_FULL);
   return rc;
-}
-
-/**
- * op_what_key - Display the keycode for a key press - Implements ::index_function_t - @ingroup index_function_api
- */
-static int op_what_key(struct IndexSharedData *shared, struct IndexPrivateData *priv, int op)
-{
-  mutt_what_key();
-  return FR_SUCCESS;
 }
 
 // -----------------------------------------------------------------------------
@@ -3180,7 +3113,6 @@ struct IndexFunction IndexFunctions[] = {
   { OP_ATTACHMENT_EDIT_TYPE,                op_attachment_edit_type,              CHECK_ATTACH | CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE },
   { OP_BOTTOM_PAGE,                         op_menu_move,                         CHECK_NO_FLAGS },
   { OP_BOUNCE_MESSAGE,                      op_bounce_message,                    CHECK_ATTACH | CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE },
-  { OP_CHECK_STATS,                         op_check_stats,                       CHECK_NO_FLAGS },
   { OP_CHECK_TRADITIONAL,                   op_check_traditional,                 CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE },
   { OP_COMPOSE_TO_SENDER,                   op_compose_to_sender,                 CHECK_ATTACH | CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE },
   { OP_COPY_MESSAGE,                        op_save,                              CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE },
@@ -3202,7 +3134,6 @@ struct IndexFunction IndexFunctions[] = {
   { OP_EDIT_OR_VIEW_RAW_MESSAGE,            op_edit_raw_message,                  CHECK_ATTACH | CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE },
   { OP_EDIT_RAW_MESSAGE,                    op_edit_raw_message,                  CHECK_ATTACH | CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_READONLY | CHECK_VISIBLE },
   { OP_END_COND,                            op_end_cond,                          CHECK_NO_FLAGS },
-  { OP_ENTER_COMMAND,                       op_enter_command,                     CHECK_NO_FLAGS },
   { OP_EXIT,                                op_exit,                              CHECK_NO_FLAGS },
   { OP_EXTRACT_KEYS,                        op_extract_keys,                      CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE },
   { OP_FIRST_ENTRY,                         op_menu_move,                         CHECK_NO_FLAGS },
@@ -3273,7 +3204,6 @@ struct IndexFunction IndexFunctions[] = {
   { OP_QUERY,                               op_query,                             CHECK_ATTACH },
   { OP_QUIT,                                op_quit,                              CHECK_NO_FLAGS },
   { OP_RECALL_MESSAGE,                      op_recall_message,                    CHECK_ATTACH },
-  { OP_REDRAW,                              op_redraw,                            CHECK_NO_FLAGS },
   { OP_REPLY,                               op_reply,                             CHECK_ATTACH | CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE },
   { OP_RESEND,                              op_resend,                            CHECK_ATTACH | CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE },
   { OP_SAVE,                                op_save,                              CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE },
@@ -3281,7 +3211,6 @@ struct IndexFunction IndexFunctions[] = {
   { OP_SEARCH_NEXT,                         op_search,                            CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE },
   { OP_SEARCH_OPPOSITE,                     op_search,                            CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE },
   { OP_SEARCH_REVERSE,                      op_search,                            CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE },
-  { OP_SHELL_ESCAPE,                        op_shell_escape,                      CHECK_NO_FLAGS },
   { OP_SHOW_LOG_MESSAGES,                   op_show_log_messages,                 CHECK_NO_FLAGS },
   { OP_SORT,                                op_sort,                              CHECK_NO_FLAGS },
   { OP_SORT_REVERSE,                        op_sort,                              CHECK_NO_FLAGS },
@@ -3295,10 +3224,8 @@ struct IndexFunction IndexFunctions[] = {
   { OP_UNDELETE,                            op_undelete,                          CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_READONLY | CHECK_VISIBLE },
   { OP_UNDELETE_SUBTHREAD,                  op_undelete_thread,                   CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_READONLY | CHECK_VISIBLE },
   { OP_UNDELETE_THREAD,                     op_undelete_thread,                   CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_READONLY | CHECK_VISIBLE },
-  { OP_VERSION,                             op_version,                           CHECK_NO_FLAGS },
   { OP_VIEW_ATTACHMENTS,                    op_view_attachments,                  CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE },
   { OP_VIEW_RAW_MESSAGE,                    op_edit_raw_message,                  CHECK_ATTACH | CHECK_IN_MAILBOX | CHECK_MSGCOUNT | CHECK_VISIBLE },
-  { OP_WHAT_KEY,                            op_what_key,                          CHECK_NO_FLAGS },
 #ifdef USE_AUTOCRYPT
   { OP_AUTOCRYPT_ACCT_MENU,                 op_autocrypt_acct_menu,               CHECK_NO_FLAGS },
 #endif

--- a/index/index.c
+++ b/index/index.c
@@ -345,6 +345,27 @@ static int index_config_observer(struct NotifyCallback *nc)
 }
 
 /**
+ * index_global_observer - Notification that a Global event occurred - Implements ::observer_t - @ingroup observer_api
+ */
+static int index_global_observer(struct NotifyCallback *nc)
+{
+  if ((nc->event_type != NT_GLOBAL) || !nc->global_data)
+    return -1;
+  if (nc->event_subtype != NT_GLOBAL_COMMAND)
+    return 0;
+
+  struct MuttWindow *win = nc->global_data;
+  struct MuttWindow *dlg = dialog_find(win);
+  if (!dlg)
+    return 0;
+
+  struct IndexSharedData *shared = dlg->wdata;
+  mutt_check_rescore(shared->mailbox);
+
+  return 0;
+}
+
+/**
  * index_menu_observer - Notification that the Menu has changed - Implements ::observer_t - @ingroup observer_api
  */
 static int index_menu_observer(struct NotifyCallback *nc)
@@ -433,6 +454,7 @@ static int index_window_observer(struct NotifyCallback *nc)
   notify_observer_remove(NeoMutt->notify, index_attach_observer, win);
   notify_observer_remove(NeoMutt->notify, index_color_observer, win);
   notify_observer_remove(NeoMutt->notify, index_config_observer, win);
+  notify_observer_remove(NeoMutt->notify, index_global_observer, win);
   notify_observer_remove(menu->notify, index_menu_observer, win);
   notify_observer_remove(NeoMutt->notify, index_score_observer, win);
   notify_observer_remove(NeoMutt->notify, index_subjrx_observer, win);
@@ -459,6 +481,7 @@ struct MuttWindow *index_window_new(struct IndexPrivateData *priv)
   notify_observer_add(NeoMutt->notify, NT_ATTACH, index_attach_observer, win);
   notify_observer_add(NeoMutt->notify, NT_COLOR, index_color_observer, win);
   notify_observer_add(NeoMutt->notify, NT_CONFIG, index_config_observer, win);
+  notify_observer_add(NeoMutt->notify, NT_GLOBAL, index_global_observer, win);
   notify_observer_add(menu->notify, NT_MENU, index_menu_observer, win);
   notify_observer_add(NeoMutt->notify, NT_SCORE, index_score_observer, win);
   notify_observer_add(NeoMutt->notify, NT_SUBJRX, index_subjrx_observer, win);

--- a/pager/dlg_pager.c
+++ b/pager/dlg_pager.c
@@ -853,6 +853,8 @@ int mutt_pager(struct PagerView *pview)
       rc = sb_function_dispatcher(win_sidebar, op);
     }
 #endif
+    if (rc == FR_UNKNOWN)
+      rc = global_function_dispatcher(dlg, op);
 
     if (rc == FR_DONE)
       break;

--- a/pager/functions.c
+++ b/pager/functions.c
@@ -809,16 +809,6 @@ static int op_bounce_message(struct IndexSharedData *shared,
 }
 
 /**
- * op_check_stats - Calculate message statistics for all mailboxes - Implements ::pager_function_t - @ingroup pager_function_api
- */
-static int op_check_stats(struct IndexSharedData *shared,
-                          struct PagerPrivateData *priv, int op)
-{
-  mutt_check_stats(shared->mailbox);
-  return FR_SUCCESS;
-}
-
-/**
  * op_check_traditional - Check for classic PGP - Implements ::pager_function_t - @ingroup pager_function_api
  */
 static int op_check_traditional(struct IndexSharedData *shared,
@@ -1066,32 +1056,6 @@ static int op_edit_label(struct IndexSharedData *shared, struct PagerPrivateData
   {
     mutt_message(_("No labels changed"));
   }
-  return FR_SUCCESS;
-}
-
-/**
- * op_enter_command - Enter a neomuttrc command - Implements ::pager_function_t - @ingroup pager_function_api
- */
-static int op_enter_command(struct IndexSharedData *shared,
-                            struct PagerPrivateData *priv, int op)
-{
-  mutt_enter_command();
-  pager_queue_redraw(priv, MENU_REDRAW_FULL);
-
-  if (OptNeedResort)
-  {
-    OptNeedResort = false;
-    if (!assert_pager_mode(priv->pview->mode == PAGER_MODE_EMAIL))
-      return FR_NOT_IMPL;
-    OptNeedResort = true;
-  }
-
-  if ((priv->redraw & MENU_REDRAW_FLOW) && (priv->pview->flags & MUTT_PAGER_RETWINCH))
-  {
-    priv->rc = OP_REFORMAT_WINCH;
-    return FR_DONE;
-  }
-
   return FR_SUCCESS;
 }
 
@@ -1393,18 +1357,6 @@ static int op_recall_message(struct IndexSharedData *shared,
 }
 
 /**
- * op_redraw - Clear and redraw the screen - Implements ::pager_function_t - @ingroup pager_function_api
- */
-static int op_redraw(struct IndexSharedData *shared, struct PagerPrivateData *priv, int op)
-{
-  window_invalidate_all();
-  mutt_window_reflow(NULL);
-  clearok(stdscr, true);
-  pager_queue_redraw(priv, MENU_REDRAW_FULL);
-  return FR_SUCCESS;
-}
-
-/**
  * op_reply - Reply to a message - Implements ::pager_function_t - @ingroup pager_function_api
  *
  * This function handles:
@@ -1508,19 +1460,6 @@ static int op_search_toggle(struct IndexSharedData *shared,
   {
     priv->search_flag ^= MUTT_SEARCH;
     pager_queue_redraw(priv, MENU_REDRAW_BODY);
-  }
-  return FR_SUCCESS;
-}
-
-/**
- * op_shell_escape - Invoke a command in a subshell - Implements ::pager_function_t - @ingroup pager_function_api
- */
-static int op_shell_escape(struct IndexSharedData *shared,
-                           struct PagerPrivateData *priv, int op)
-{
-  if (mutt_shell_escape())
-  {
-    mutt_mailbox_check(shared->mailbox, MUTT_MAILBOX_CHECK_FORCE);
   }
   return FR_SUCCESS;
 }
@@ -1668,15 +1607,6 @@ static int op_undelete_thread(struct IndexSharedData *shared,
 }
 
 /**
- * op_version - Show the NeoMutt version number and date - Implements ::pager_function_t - @ingroup pager_function_api
- */
-static int op_version(struct IndexSharedData *shared, struct PagerPrivateData *priv, int op)
-{
-  mutt_message(mutt_make_version());
-  return FR_SUCCESS;
-}
-
-/**
  * op_view_attachments - Show MIME attachments - Implements ::pager_function_t - @ingroup pager_function_api
  */
 static int op_view_attachments(struct IndexSharedData *shared,
@@ -1697,15 +1627,6 @@ static int op_view_attachments(struct IndexSharedData *shared,
   if (shared->email->attach_del)
     shared->mailbox->changed = true;
   pager_queue_redraw(priv, MENU_REDRAW_FULL);
-  return FR_SUCCESS;
-}
-
-/**
- * op_what_key - Display the keycode for a key press - Implements ::pager_function_t - @ingroup pager_function_api
- */
-static int op_what_key(struct IndexSharedData *shared, struct PagerPrivateData *priv, int op)
-{
-  mutt_what_key();
   return FR_SUCCESS;
 }
 
@@ -1835,7 +1756,6 @@ static int op_post(struct IndexSharedData *shared, struct PagerPrivateData *priv
 struct PagerFunction PagerFunctions[] = {
   // clang-format off
   { OP_BOUNCE_MESSAGE,         op_bounce_message },
-  { OP_CHECK_STATS,            op_check_stats },
   { OP_CHECK_TRADITIONAL,      op_check_traditional },
   { OP_COMPOSE_TO_SENDER,      op_compose_to_sender },
   { OP_COPY_MESSAGE,           op_copy_message },
@@ -1851,7 +1771,6 @@ struct PagerFunction PagerFunctions[] = {
   { OP_PURGE_THREAD,           op_delete_thread },
   { OP_DISPLAY_ADDRESS,        op_display_address },
   { OP_EDIT_LABEL,             op_edit_label },
-  { OP_ENTER_COMMAND,          op_enter_command },
   { OP_EXIT,                   op_exit },
   { OP_EXTRACT_KEYS,           op_extract_keys },
   { OP_FLAG_MESSAGE,           op_flag_message },
@@ -1887,7 +1806,6 @@ struct PagerFunction PagerFunctions[] = {
   { OP_PRINT,                  op_print },
   { OP_QUIT,                   op_quit },
   { OP_RECALL_MESSAGE,         op_recall_message },
-  { OP_REDRAW,                 op_redraw },
   { OP_GROUP_CHAT_REPLY,       op_reply },
   { OP_GROUP_REPLY,            op_reply },
   { OP_LIST_REPLY,             op_reply },
@@ -1901,7 +1819,6 @@ struct PagerFunction PagerFunctions[] = {
   { OP_SEARCH_NEXT,            op_pager_search_next },
   { OP_SEARCH_OPPOSITE,        op_pager_search_next },
   { OP_SEARCH_TOGGLE,          op_search_toggle },
-  { OP_SHELL_ESCAPE,           op_shell_escape },
   { OP_SORT,                   op_sort },
   { OP_SORT_REVERSE,           op_sort },
   { OP_TAG,                    op_tag },
@@ -1909,9 +1826,7 @@ struct PagerFunction PagerFunctions[] = {
   { OP_UNDELETE,               op_undelete },
   { OP_UNDELETE_SUBTHREAD,     op_undelete_thread },
   { OP_UNDELETE_THREAD,        op_undelete_thread },
-  { OP_VERSION,                op_version },
   { OP_VIEW_ATTACHMENTS,       op_view_attachments },
-  { OP_WHAT_KEY,               op_what_key },
   { 0, NULL },
   // clang-format on
 };


### PR DESCRIPTION
- notify on neomutt commands
  Index/Pager perform some updates after every NeoMutt command

- index: use the global function dispatcher
  Call the global dispatcher, strip out our own functions

- pager: use the global function dispatcher
  Call the global dispatcher, strip out our own functions
