### PR TITLE
Do not insert an actual key mapping for noop

### DIFF
--- a/keymap.c
+++ b/keymap.c
@@ -613,12 +613,13 @@ static void generic_tokenize_push_string(char *s, void (*generic_push)(int, int)
  */
 static int retry_generic(enum MenuType mtype, keycode_t *keys, int keyslen, int lastkey)
 {
+  if (lastkey)
+    mutt_unget_event(lastkey, 0);
+  for (; keyslen; keyslen--)
+    mutt_unget_event(keys[keyslen - 1], 0);
+
   if ((mtype != MENU_EDITOR) && (mtype != MENU_GENERIC) && (mtype != MENU_PAGER))
   {
-    if (lastkey)
-      mutt_unget_event(lastkey, 0);
-    for (; keyslen; keyslen--)
-      mutt_unget_event(keys[keyslen - 1], 0);
     return km_dokey(MENU_GENERIC);
   }
   if (mtype != MENU_EDITOR)
@@ -626,6 +627,8 @@ static int retry_generic(enum MenuType mtype, keycode_t *keys, int keyslen, int 
     /* probably a good idea to flush input here so we can abort macros */
     mutt_flushinp();
   }
+
+  LastKey = mutt_getch().ch;
   return OP_NULL;
 }
 

--- a/keymap.c
+++ b/keymap.c
@@ -426,17 +426,24 @@ static enum CommandResult km_bind_err(const char *s, enum MenuType mtype, int op
     }
   }
 
-  if (last) /* if queue has at least one entry */
+  if (map->op == OP_NULL)
   {
-    if (STAILQ_NEXT(last, entries))
-      STAILQ_INSERT_AFTER(&Keymaps[mtype], last, map, entries);
-    else /* last entry in the queue */
-      STAILQ_INSERT_TAIL(&Keymaps[mtype], map, entries);
-    last->eq = lastpos;
+    mutt_keymap_free(&map);
   }
-  else /* queue is empty, so insert from head */
+  else
   {
-    STAILQ_INSERT_HEAD(&Keymaps[mtype], map, entries);
+    if (last) /* if queue has at least one entry */
+    {
+      if (STAILQ_NEXT(last, entries))
+        STAILQ_INSERT_AFTER(&Keymaps[mtype], last, map, entries);
+      else /* last entry in the queue */
+        STAILQ_INSERT_TAIL(&Keymaps[mtype], map, entries);
+      last->eq = lastpos;
+    }
+    else /* queue is empty, so insert from head */
+    {
+      STAILQ_INSERT_HEAD(&Keymaps[mtype], map, entries);
+    }
   }
 
   return rc;


### PR DESCRIPTION
`unmacro * dd` adds a binding from `dd` to `OP_NULL` (i.e., `noop`) to
all menus, including the editor. This `dd` mapping will keep matching
text typed into the editor, so if we type `abcde` the `d` will be
matched and eaten, resulting in `abce`.

This is a quick fix that solves the `unmacro *` case of #3288, but the
problem is more profound. If we want the editor to jump to the
begin-of-line on `bl`, we might try to `macro editor bl <bol>`. This
works, but this also eats any `b` we type in the editor. The editor is
special in this regard, because unlike other dialogs we want typed keys
to actually appear. ~I don't have a solution for this yet.~ 
Edit: I think [26d8c59](https://github.com/neomutt/neomutt/pull/3316/commits/26d8c5901b0241c979633ab66bc7ae85f8aa7dcb) might be a reasonable fix for this.
Edit2: this bug (eating all but the last char of a non-matching sequence) exists upstream too.  

Fixes #3288