### PR TITLE
Fix memory leak in tag-transforms and tag-formats

### DIFF
--- a/email/tags.c
+++ b/email/tags.c
@@ -35,6 +35,7 @@
 #include "tags.h"
 
 struct HashTable *TagTransforms; ///< Lookup table of alternative tag names
+struct HashTable *TagFormats;    ///< Hash Table of tag-formats (tag -> format string)
 
 /**
  * driver_tags_getter - Get transformed tags
@@ -201,4 +202,33 @@ bool driver_tags_replace(struct TagList *head, const char *tags)
     mutt_list_clear(&hsplit);
   }
   return true;
+}
+
+/**
+ * tags_deleter - Delete a tag - Implements ::hash_hdata_free_t - @ingroup hash_hdata_free_api
+ */
+static void tags_deleter(int type, void *obj, intptr_t data)
+{
+  FREE(&obj);
+}
+
+/**
+ * driver_tags_init - Initialize structures used for tags
+ */
+void driver_tags_init(void)
+{
+  TagTransforms = mutt_hash_new(64, MUTT_HASH_STRCASECMP | MUTT_HASH_STRDUP_KEYS);
+  mutt_hash_set_destructor(TagTransforms, tags_deleter, 0);
+
+  TagFormats = mutt_hash_new(64, MUTT_HASH_STRDUP_KEYS);
+  mutt_hash_set_destructor(TagFormats, tags_deleter, 0);
+}
+
+/**
+ * driver_tags_init - Deinitialize structures used for tags
+ */
+void driver_tags_cleanup(void)
+{
+  mutt_hash_free(&TagFormats);
+  mutt_hash_free(&TagTransforms);
 }

--- a/email/tags.h
+++ b/email/tags.h
@@ -27,6 +27,7 @@
 #include "mutt/lib.h"
 
 extern struct HashTable *TagTransforms;
+extern struct HashTable *TagFormats;
 
 /**
  * struct Tag - LinkedList Tag Element
@@ -50,5 +51,8 @@ char *driver_tags_get_transformed_for(struct TagList *list, const char *name);
 char *driver_tags_get_with_hidden    (struct TagList *list);
 bool  driver_tags_replace            (struct TagList *list, const char *tags);
 void  driver_tags_add                (struct TagList *list, char *tag);
+
+void driver_tags_init(void);
+void driver_tags_cleanup(void);
 
 #endif /* MUTT_EMAIL_TAGS_H */

--- a/init.c
+++ b/init.c
@@ -657,8 +657,7 @@ void mutt_opts_free(void)
   mutt_regexlist_free(&UnSubscribedLists);
 
   mutt_grouplist_free();
-  mutt_hash_free(&TagFormats);
-  mutt_hash_free(&TagTransforms);
+  driver_tags_cleanup();
 
   /* Lists of strings */
   mutt_list_free(&AlternativeOrderList);
@@ -737,8 +736,7 @@ int mutt_init(struct ConfigSet *cs, bool skip_sys_rc, struct ListHead *commands)
 #ifdef USE_LUA
   mutt_lua_init();
 #endif
-  TagTransforms = mutt_hash_new(64, MUTT_HASH_STRCASECMP);
-  TagFormats = mutt_hash_new(64, MUTT_HASH_NO_FLAGS);
+  driver_tags_init();
 
   menu_init();
 #ifdef USE_SIDEBAR

--- a/mutt_globals.h
+++ b/mutt_globals.h
@@ -56,8 +56,6 @@ WHERE char *LastFolder;    ///< Previously selected mailbox
 
 extern const char *GitVer;
 
-WHERE struct HashTable *TagFormats; ///< Hash Table of tag-formats (tag -> format string)
-
 /* Lists of strings */
 WHERE struct ListHead AlternativeOrderList INITVAL(STAILQ_HEAD_INITIALIZER(AlternativeOrderList)); ///< List of preferred mime types to display
 WHERE struct ListHead AutoViewList INITVAL(STAILQ_HEAD_INITIALIZER(AutoViewList));                 ///< List of mime types to auto view


### PR DESCRIPTION
Also, I refactored the code to parse tag-transforms and tag-formats,
which was basically identical except for the hash table used, and I
moved TagFormats from globals into email/tags.h

**TODO**
- [x] figure why we [can't](https://github.com/neomutt/neomutt/blob/bbb669e4a89767746119706281dece19ee301d07/command_parse.c#L1382-L1388) register the same transform / format for two different tags, e.g. `tag-transform important STAR starred STAR`

Fixes #3324