### PR TITLE
Issue warnings on duplicate keys

### DIFF
--- a/command_parse.c
+++ b/command_parse.c
@@ -1389,7 +1389,7 @@ enum CommandResult parse_tag_formats(struct Buffer *buf, struct Buffer *s,
     const char *tmp = mutt_hash_find(TagFormats, fmt);
     if (tmp)
     {
-      mutt_debug(LL_DEBUG3, "tag format '%s' already registered as '%s'\n", fmt, tmp);
+      mutt_warning(_("tag format '%s' already registered as '%s'"), fmt, tmp);
       continue;
     }
 
@@ -1432,7 +1432,7 @@ enum CommandResult parse_tag_transforms(struct Buffer *buf, struct Buffer *s,
     const char *tmp = mutt_hash_find(TagTransforms, tag);
     if (tmp)
     {
-      mutt_debug(LL_DEBUG3, "tag tranform '%s' already registered as '%s'\n", tag, tmp);
+      mutt_warning(_("tag transform '%s' already registered as '%s'"), tag, tmp);
       continue;
     }
 


### PR DESCRIPTION
Turn logs into warnings so the user sees that a command wasn't successful.