### PR TITLE
Split the Index/Pager (Part 2)

### DIFF
--- a/gui/curs_lib.c
+++ b/gui/curs_lib.c
@@ -291,7 +291,7 @@ int mutt_buffer_get_field(const char *field, struct Buffer *buf, CompletionFlags
   struct MuttWindow *old_focus = window_set_focus(win);
 
   enum MuttCursorState cursor = mutt_curses_set_cursor(MUTT_CURSOR_VISIBLE);
-  window_redraw(NULL);
+  window_redraw(win);
   do
   {
     if (SigWinch)

--- a/index/dlg_index.c
+++ b/index/dlg_index.c
@@ -750,8 +750,6 @@ void change_folder_string(struct Menu *menu, char *buf, size_t buflen, int *oldc
     return;
   }
 
-  /* past this point, we don't return to the pager on error */
-
   struct Mailbox *m = mx_path_resolve(buf);
   change_folder_mailbox(menu, m, oldcount, shared, read_only);
 }
@@ -1038,9 +1036,6 @@ static void index_custom_redraw(struct Menu *menu)
  * @param dlg Dialog containing Windows to draw on
  * @param m_init Initial mailbox
  * @retval Mailbox open in the index
- *
- * This function handles the message index window as well as commands returned
- * from the pager (MENU_PAGER).
  */
 struct Mailbox *mutt_index_menu(struct MuttWindow *dlg, struct Mailbox *m_init)
 {
@@ -1120,7 +1115,7 @@ struct Mailbox *mutt_index_menu(struct MuttWindow *dlg, struct Mailbox *m_init)
       }
     }
 
-    if (shared->mailbox)
+    if (shared->mailbox && shared->ctx)
     {
       mailbox_gc_run();
 
@@ -1347,7 +1342,7 @@ struct Mailbox *mutt_index_menu(struct MuttWindow *dlg, struct Mailbox *m_init)
 #ifdef USE_NOTMUCH
     nm_db_debug_check(shared->mailbox);
 #endif
-  } while (rc != FR_DONE);
+  } while ((rc != FR_DONE) && shared->ctx);
 
   ctx_free(&shared->ctx);
 

--- a/index/functions.c
+++ b/index/functions.c
@@ -344,7 +344,12 @@ static int op_display_message(struct IndexSharedData *shared,
   /* toggle the weeding of headers so that a user can press the key
    * again while reading the message.  */
   if (op == OP_DISPLAY_HEADERS)
+  {
     bool_str_toggle(shared->sub, "weed", NULL);
+    notify_send(shared->notify, NT_INDEX, NT_INDEX_EMAIL, shared);
+    if (!window_is_focused(priv->win_index))
+      return FR_SUCCESS;
+  }
 
   OptNeedResort = false;
 
@@ -1718,6 +1723,7 @@ static int op_next_entry(struct IndexSharedData *shared, struct IndexPrivateData
   if (index >= shared->mailbox->vcount)
   {
     mutt_message(_("You are on the last message"));
+    notify_send(shared->notify, NT_INDEX, NT_INDEX_EMAIL, NULL);
     return FR_ERROR;
   }
   menu_set_index(priv->menu, index);

--- a/index/shared_data.c
+++ b/index/shared_data.c
@@ -134,7 +134,11 @@ static int index_shared_email_observer(struct NotifyCallback *nc)
     return 0;
 
   if (nc->event_subtype == NT_EMAIL_DELETE)
+  {
     shared->email = NULL;
+    mutt_debug(LL_NOTIFY, "NT_INDEX_EMAIL: %p\n", shared->email);
+    notify_send(shared->notify, NT_INDEX, NT_INDEX_EMAIL, shared);
+  }
 
   mutt_debug(LL_NOTIFY, "relay NT_EMAIL %p to shared data observers\n", shared->email);
   notify_send(shared->notify, nc->event_type, nc->event_subtype, shared);

--- a/pager/dlg_pager.c
+++ b/pager/dlg_pager.c
@@ -292,7 +292,7 @@ int mutt_pager(struct PagerView *pview)
   priv->first = true;
   priv->wrapped = false;
   priv->delay_read_timestamp = 0;
-  bool pager_redraw = false;
+  priv->pager_redraw = false;
 
   {
     // Wipe any previous state info
@@ -377,7 +377,8 @@ int mutt_pager(struct PagerView *pview)
   // ACT 3: Read user input and decide what to do with it
   //        ...but also do a whole lot of other things.
   //-------------------------------------------------------------------------
-  while (op != OP_ABORT)
+  priv->loop = PAGER_LOOP_CONTINUE;
+  do
   {
     if (check_read_delay(&priv->delay_read_timestamp))
     {
@@ -469,9 +470,9 @@ int mutt_pager(struct PagerView *pview)
     }
     //-------------------------------------------------------------------------
 
-    if (pager_redraw)
+    if (priv->pager_redraw)
     {
-      pager_redraw = false;
+      priv->pager_redraw = false;
       mutt_resize_screen();
       clearok(stdscr, true); /* force complete redraw */
       msgwin_clear_text();
@@ -493,6 +494,7 @@ int mutt_pager(struct PagerView *pview)
 
         op = OP_ABORT;
         priv->rc = OP_REFORMAT_WINCH;
+        break;
       }
       else
       {
@@ -519,7 +521,7 @@ int mutt_pager(struct PagerView *pview)
     // OP code to index. Index handles the operation and then restarts pager
     op = km_dokey(MENU_PAGER);
     if (SigWinch)
-      pager_redraw = true;
+      priv->pager_redraw = true;
 
     if (op >= OP_NULL)
       mutt_clear_error();
@@ -533,8 +535,6 @@ int mutt_pager(struct PagerView *pview)
       continue;
     }
 
-    priv->rc = op;
-
     if (op == OP_NULL)
     {
       km_error_key(MENU_PAGER);
@@ -543,6 +543,8 @@ int mutt_pager(struct PagerView *pview)
 
     int rc = pager_function_dispatcher(priv->pview->win_pager, op);
 
+    if ((rc == FR_UNKNOWN) && priv->pview->win_index)
+      rc = index_function_dispatcher(priv->pview->win_index, op);
 #ifdef USE_SIDEBAR
     if (rc == FR_UNKNOWN)
       rc = sb_function_dispatcher(win_sidebar, op);
@@ -550,11 +552,14 @@ int mutt_pager(struct PagerView *pview)
     if (rc == FR_UNKNOWN)
       rc = global_function_dispatcher(dlg, op);
 
-    if (rc == FR_DONE)
+    if (rc == FR_UNKNOWN && ((pview->mode == PAGER_MODE_ATTACH) || (pview->mode == PAGER_MODE_ATTACH_E)))
+    {
+      // Some attachment functions still need to be delegated
+      priv->rc = op;
       break;
-    if (rc == FR_UNKNOWN)
-      break;
-  }
+    }
+  } while (priv->loop == PAGER_LOOP_CONTINUE);
+
   //-------------------------------------------------------------------------
   // END OF ACT 3: Read user input loop - while (op != OP_ABORT)
   //-------------------------------------------------------------------------
@@ -566,7 +571,8 @@ int mutt_pager(struct PagerView *pview)
   mutt_file_fclose(&priv->fp);
   if (pview->mode == PAGER_MODE_EMAIL)
   {
-    shared->ctx->msg_in_pager = -1;
+    if (shared->ctx)
+      shared->ctx->msg_in_pager = -1;
   }
 
   qstyle_free_tree(&priv->quote_list);
@@ -593,6 +599,9 @@ int mutt_pager(struct PagerView *pview)
     }
     color_debug(LL_DEBUG5, "AnsiColors %d\n", count);
   }
+
+  if (priv->loop == PAGER_LOOP_RELOAD)
+    return PAGER_LOOP_RELOAD;
 
   return (priv->rc != -1) ? priv->rc : 0;
 }

--- a/pager/functions.c
+++ b/pager/functions.c
@@ -719,6 +719,7 @@ static int op_pager_top(struct IndexSharedData *shared, struct PagerPrivateData 
 static int op_exit(struct IndexSharedData *shared, struct PagerPrivateData *priv, int op)
 {
   priv->rc = -1;
+  priv->loop = PAGER_LOOP_QUIT;
   return FR_DONE;
 }
 
@@ -760,11 +761,9 @@ static int op_view_attachments(struct IndexSharedData *shared,
 {
   struct PagerView *pview = priv->pview;
 
+  // This needs to be delegated
   if (pview->flags & MUTT_PAGER_ATTACHMENT)
-  {
-    priv->rc = OP_ATTACHMENT_COLLAPSE;
-    return FR_DONE;
-  }
+    return FR_UNKNOWN;
 
   if (!assert_pager_mode(pview->mode == PAGER_MODE_EMAIL))
     return FR_NOT_IMPL;

--- a/pager/lib.h
+++ b/pager/lib.h
@@ -143,6 +143,16 @@ enum PagerMode
 };
 
 /**
+ * enum PagerLoopMode - What the Pager Event Loop should do next
+ */
+enum PagerLoopMode
+{
+  PAGER_LOOP_CONTINUE = -7,  ///< Stay in the Pager Event Loop
+  PAGER_LOOP_QUIT     = -6,  ///< Quit the Pager
+  PAGER_LOOP_RELOAD   = -5,  ///< Reload the Pager from scratch
+};
+
+/**
  * struct PagerData - Data to be displayed by PagerView
  */
 struct PagerData

--- a/pager/message.c
+++ b/pager/message.c
@@ -455,46 +455,52 @@ static void expand_index_panel(struct MuttWindow *win_index, struct MuttWindow *
  */
 int mutt_display_message(struct MuttWindow *win_index, struct IndexSharedData *shared)
 {
-  struct Message *msg = mx_msg_open(shared->mailbox, shared->email->msgno);
-  if (!msg)
-    return -1;
-
-  struct Buffer *tempfile = mutt_buffer_pool_get();
-
-  CopyMessageFlags cmflags = MUTT_CM_DECODE | MUTT_CM_DISPLAY | MUTT_CM_CHARCONV;
-
   struct MuttWindow *dlg = dialog_find(win_index);
   struct MuttWindow *win_pager = window_find_child(dlg, WT_CUSTOM);
   struct MuttWindow *win_pbar = window_find_child(dlg, WT_STATUS_BAR);
-
-  // win_pager might not be visible and have a size yet, so use win_index
-  int rc = email_to_file(msg, tempfile, shared->mailbox, shared->email, NULL,
-                         win_index->state.cols, &cmflags);
-  if (rc < 0)
-    goto cleanup;
-
-  notify_crypto(shared->email, msg, cmflags);
-
-  /* Invoke the builtin pager */
-  struct PagerData pdata = { 0 };
-  struct PagerView pview = { &pdata };
-
-  pdata.fp = msg->fp;
-  pdata.fname = mutt_buffer_string(tempfile);
-
-  pview.mode = PAGER_MODE_EMAIL;
-  pview.banner = NULL;
-  pview.flags =
-      MUTT_PAGER_MESSAGE | (shared->email->body->nowrap ? MUTT_PAGER_NOWRAP : 0);
-  pview.win_index = win_index;
-  pview.win_pbar = win_pbar;
-  pview.win_pager = win_pager;
+  struct Buffer *tempfile = mutt_buffer_pool_get();
+  struct Message *msg = NULL;
 
   squash_index_panel(shared->mailbox, win_index, win_pager);
-  rc = mutt_pager(&pview);
+
+  int rc = PAGER_LOOP_QUIT;
+  do
+  {
+    msg = mx_msg_open(shared->mailbox, shared->email->msgno);
+    if (!msg)
+      break;
+
+    CopyMessageFlags cmflags = MUTT_CM_DECODE | MUTT_CM_DISPLAY | MUTT_CM_CHARCONV;
+
+    mutt_buffer_reset(tempfile);
+    // win_pager might not be visible and have a size yet, so use win_index
+    rc = email_to_file(msg, tempfile, shared->mailbox, shared->email, NULL, win_index->state.cols, &cmflags);
+    if (rc < 0)
+      break;
+
+    notify_crypto(shared->email, msg, cmflags);
+
+    /* Invoke the builtin pager */
+    struct PagerData pdata = { 0 };
+    struct PagerView pview = { &pdata };
+
+    pdata.fp = msg->fp;
+    pdata.fname = mutt_buffer_string(tempfile);
+
+    pview.mode = PAGER_MODE_EMAIL;
+    pview.banner = NULL;
+    pview.flags = MUTT_PAGER_MESSAGE | (shared->email->body->nowrap ? MUTT_PAGER_NOWRAP : 0);
+    pview.win_index = win_index;
+    pview.win_pbar = win_pbar;
+    pview.win_pager = win_pager;
+
+    rc = mutt_pager(&pview);
+    mx_msg_close(shared->mailbox, &msg);
+  }
+  while (rc == PAGER_LOOP_RELOAD);
+
   expand_index_panel(win_index, win_pager);
 
-cleanup:
   mx_msg_close(shared->mailbox, &msg);
   mutt_buffer_pool_release(&tempfile);
   return rc;

--- a/pager/pager.c
+++ b/pager/pager.c
@@ -353,8 +353,33 @@ static int pager_index_observer(struct NotifyCallback *nc)
 
   struct MuttWindow *win_pager = nc->global_data;
 
-  win_pager->actions |= WA_RECALC;
-  mutt_debug(LL_DEBUG5, "index done, request WA_RECALC\n");
+  struct PagerPrivateData *priv = win_pager->wdata;
+  if (!priv)
+    return 0;
+
+  struct IndexSharedData *shared = nc->event_data;
+
+  if (nc->event_subtype & NT_INDEX_MAILBOX)
+  {
+    win_pager->actions |= WA_RECALC;
+    mutt_debug(LL_DEBUG5, "index done, request WA_RECALC\n");
+    priv->loop = PAGER_LOOP_QUIT;
+  }
+  else if (nc->event_subtype & NT_INDEX_EMAIL)
+  {
+    win_pager->actions |= WA_RECALC;
+    mutt_debug(LL_DEBUG5, "index done, request WA_RECALC\n");
+    priv->pager_redraw = true;
+    if (shared && shared->email && (priv->loop != PAGER_LOOP_QUIT))
+    {
+      priv->loop = PAGER_LOOP_RELOAD;
+    }
+    else
+    {
+      priv->loop = PAGER_LOOP_QUIT;
+      priv->rc = 0;
+    }
+  }
 
   return 0;
 }

--- a/pager/private_data.h
+++ b/pager/private_data.h
@@ -76,6 +76,8 @@ struct PagerPrivateData
   bool first;                    ///< First time flag for toggle-new
   bool wrapped;                  ///< Has the search/next wrapped around?
   uint64_t delay_read_timestamp; ///< Time that email was first shown
+  bool pager_redraw;             ///< Force a complete redraw
+  enum PagerLoopMode loop;       ///< What the Event Loop should do next, e.g. #PAGER_LOOP_CONTINUE
 };
 
 void                     pager_private_data_free(struct MuttWindow *win, void **ptr);


### PR DESCRIPTION
Refactor the Pager to use `index_function_dispatcher()` rather than its own copy of functions.

Add `PagerLoopMode` to control when the Pager should close or reload.

To reload an email, `mutt_pager()` returns to `mutt_display_message()`, which regenerates the file.

I have tested all 130 functions, accessible from the Pager, to make sure they work correctly.

<details>
<summary> ☑️ Handled by Pager (19)</summary>

- `OP_EXIT`
- `OP_HALF_DOWN`
- `OP_HALF_UP`
- `OP_HELP`
- `OP_NEXT_LINE`
- `OP_NEXT_PAGE`
- `OP_PAGER_BOTTOM`
- `OP_PAGER_HIDE_QUOTED`
- `OP_PAGER_SKIP_HEADERS`
- `OP_PAGER_SKIP_QUOTED`
- `OP_PAGER_TOP`
- `OP_PREV_LINE`
- `OP_PREV_PAGE`
- `OP_SEARCH`
- `OP_SEARCH_NEXT`
- `OP_SEARCH_OPPOSITE`
- `OP_SEARCH_REVERSE`
- `OP_SEARCH_TOGGLE`
- `OP_VIEW_ATTACHMENTS`
</details>

<details>
<summary> ☑️ Handled by Sidebar (11)</summary>

- `OP_SIDEBAR_FIRST`
- `OP_SIDEBAR_LAST`
- `OP_SIDEBAR_NEXT`
- `OP_SIDEBAR_NEXT_NEW`
- `OP_SIDEBAR_OPEN`
- `OP_SIDEBAR_PAGE_DOWN`
- `OP_SIDEBAR_PAGE_UP`
- `OP_SIDEBAR_PREV`
- `OP_SIDEBAR_PREV_NEW`
- `OP_SIDEBAR_TOGGLE_VIRTUAL`
- `OP_SIDEBAR_TOGGLE_VISIBLE`
</details>

<details>
<summary> ☑️ Handled by Global (7)</summary>

- `OP_CHECK_STATS`
- `OP_ENTER_COMMAND`
- `OP_REDRAW`
- `OP_SHELL_ESCAPE`
- `OP_SHOW_LOG_MESSAGES`
- `OP_VERSION`
- `OP_WHAT_KEY`
</details>

<details>
<summary> ☑️ Handled by Index (90)</summary>

- `OP_ATTACHMENT_EDIT_TYPE`
- `OP_BOUNCE_MESSAGE`
- `OP_CHECK_TRADITIONAL`
- `OP_COMPOSE_TO_SENDER`
- `OP_COPY_MESSAGE`
- `OP_CREATE_ALIAS`
- `OP_DECODE_COPY`
- `OP_DECODE_SAVE`
- `OP_DECRYPT_COPY`
- `OP_DECRYPT_SAVE`
- `OP_DELETE_SUBTHREAD`
- `OP_DELETE_THREAD`
- `OP_DELETE`
- `OP_DISPLAY_ADDRESS`
- `OP_DISPLAY_HEADERS`
- `OP_EDIT_LABEL`
- `OP_EDIT_OR_VIEW_RAW_MESSAGE`
- `OP_EDIT_RAW_MESSAGE`
- `OP_EXTRACT_KEYS`
- `OP_FLAG_MESSAGE`
- `OP_FOLLOWUP`
- `OP_FORGET_PASSPHRASE`
- `OP_FORWARD_MESSAGE`
- `OP_FORWARD_TO_GROUP`
- `OP_GROUP_CHAT_REPLY`
- `OP_GROUP_REPLY`
- `OP_JUMP`
- `OP_LIST_REPLY`
- `OP_LIST_SUBSCRIBE`
- `OP_LIST_UNSUBSCRIBE`
- `OP_MAILBOX_LIST`
- `OP_MAIL_KEY`
- `OP_MAIL`
- `OP_MAIN_BREAK_THREAD`
- `OP_MAIN_CHANGE_FOLDER_READONLY`
- `OP_MAIN_CHANGE_FOLDER`
- `OP_MAIN_CHANGE_GROUP_READONLY`
- `OP_MAIN_CHANGE_GROUP`
- `OP_MAIN_CHANGE_VFOLDER`
- `OP_MAIN_CLEAR_FLAG`
- `OP_MAIN_ENTIRE_THREAD`
- `OP_MAIN_IMAP_FETCH`
- `OP_MAIN_IMAP_LOGOUT_ALL`
- `OP_MAIN_LINK_THREADS`
- `OP_MAIN_MODIFY_TAGS_THEN_HIDE`
- `OP_MAIN_MODIFY_TAGS`
- `OP_MAIN_NEXT_NEW_THEN_UNREAD`
- `OP_MAIN_NEXT_NEW`
- `OP_MAIN_NEXT_SUBTHREAD`
- `OP_MAIN_NEXT_THREAD`
- `OP_MAIN_NEXT_UNDELETED`
- `OP_MAIN_NEXT_UNREAD_MAILBOX`
- `OP_MAIN_NEXT_UNREAD`
- `OP_MAIN_PARENT_MESSAGE`
- `OP_MAIN_PREV_NEW_THEN_UNREAD`
- `OP_MAIN_PREV_NEW`
- `OP_MAIN_PREV_SUBTHREAD`
- `OP_MAIN_PREV_THREAD`
- `OP_MAIN_PREV_UNDELETED`
- `OP_MAIN_PREV_UNREAD`
- `OP_MAIN_QUASI_DELETE`
- `OP_MAIN_READ_SUBTHREAD`
- `OP_MAIN_READ_THREAD`
- `OP_MAIN_ROOT_MESSAGE`
- `OP_MAIN_SET_FLAG`
- `OP_MAIN_SYNC_FOLDER`
- `OP_MAIN_VFOLDER_FROM_QUERY_READONLY`
- `OP_MAIN_VFOLDER_FROM_QUERY`
- `OP_NEXT_ENTRY`
- `OP_PIPE`
- `OP_POST`
- `OP_PREV_ENTRY`
- `OP_PRINT`
- `OP_PURGE_MESSAGE`
- `OP_PURGE_THREAD`
- `OP_QUIT`
- `OP_RECALL_MESSAGE`
- `OP_RECONSTRUCT_THREAD`
- `OP_REPLY`
- `OP_RESEND`
- `OP_SAVE`
- `OP_SORT_REVERSE`
- `OP_SORT`
- `OP_TAG`
- `OP_TOGGLE_NEW`
- `OP_TOGGLE_WRITE`
- `OP_UNDELETE_SUBTHREAD`
- `OP_UNDELETE_THREAD`
- `OP_UNDELETE`
- `OP_VIEW_RAW_MESSAGE`
</details>
