### PR TITLE
Fix memory leak on composing from a mailto: argument

### DIFF
--- a/main.c
+++ b/main.c
@@ -1001,7 +1001,10 @@ main
       goto main_curses; // TEST26: neomutt -s test (with auto_edit=yes)
     }
 
-    e->env->subject = mutt_str_dup(subject);
+    if (subject)
+    {
+      mutt_str_replace(&e->env->subject, subject);
+    }
 
     if (draft_file)
     {


### PR DESCRIPTION
Also, only reset a subject given as part of a "mailto:...?subject=foo"
if another subject is specified via -s.

Fixes #3335