### PR TITLE
Force checking stats when launching with -Z

### DIFF
--- a/browser/browser.c
+++ b/browser/browser.c
@@ -638,7 +638,7 @@ static int examine_directory(struct Mailbox *m, struct Menu *menu,
     }
 
     if (m)
-      mutt_mailbox_check(m, 0);
+      mutt_mailbox_check(m, MUTT_MAILBOX_CHECK_NO_FLAGS);
 
     dp = opendir(d);
     if (!dp)
@@ -743,7 +743,7 @@ static int examine_mailboxes(struct Mailbox *m, struct Menu *menu, struct Browse
     mailbox = mutt_buffer_pool_get();
     md = mutt_buffer_pool_get();
 
-    mutt_mailbox_check(m, 0);
+    mutt_mailbox_check(m, MUTT_MAILBOX_CHECK_NO_FLAGS);
 
     struct MailboxList ml = STAILQ_HEAD_INITIALIZER(ml);
     neomutt_mailboxlist_get_all(&ml, NeoMutt, MUTT_MAILBOX_ANY);
@@ -927,7 +927,8 @@ static void init_menu(struct BrowserState *state, struct Menu *menu,
   {
     if (state->is_mailbox_list)
     {
-      snprintf(title, sizeof(title), _("Mailboxes [%d]"), mutt_mailbox_check(m, 0));
+      snprintf(title, sizeof(title), _("Mailboxes [%d]"),
+               mutt_mailbox_check(m, MUTT_MAILBOX_CHECK_NO_FLAGS));
     }
     else
     {

--- a/commands.c
+++ b/commands.c
@@ -1265,11 +1265,3 @@ bool mutt_check_traditional_pgp(struct Mailbox *m, struct EmailList *el)
 
   return rc;
 }
-
-/**
- * mutt_check_stats - Forcibly update mailbox stats
- */
-void mutt_check_stats(struct Mailbox *m)
-{
-  mutt_mailbox_check(m, MUTT_MAILBOX_CHECK_FORCE | MUTT_MAILBOX_CHECK_FORCE_STATS);
-}

--- a/commands.h
+++ b/commands.h
@@ -52,7 +52,6 @@ enum MessageSaveOpt
 };
 
 void ci_bounce_message(struct Mailbox *m, struct EmailList *el);
-void mutt_check_stats(struct Mailbox *m);
 bool mutt_check_traditional_pgp(struct Mailbox *m, struct EmailList *el);
 void mutt_commands_cleanup(void);
 void mutt_display_address(struct Envelope *env);

--- a/core/mxapi.h
+++ b/core/mxapi.h
@@ -69,6 +69,13 @@ typedef uint8_t OpenMailboxFlags;   ///< Flags for mutt_open_mailbox(), e.g. #MU
 #define MUTT_PEEK          (1 << 5) ///< Revert atime back after taking a look (if applicable)
 #define MUTT_APPENDNEW     (1 << 6) ///< Set in mx_open_mailbox_append if the mailbox doesn't exist.
                                     ///< Used by maildir/mh to create the mailbox.
+
+typedef uint8_t CheckStatsFlags;                ///< Flags for mutt_mailbox_check
+#define MUTT_MAILBOX_CHECK_NO_FLAGS          0  ///< No flags are set
+#define MUTT_MAILBOX_CHECK_FORCE       (1 << 0) ///< Ignore MailboxTime and check for new mail
+#define MUTT_MAILBOX_CHECK_FORCE_STATS (1 << 1) ///< Ignore MailboxType and calculate statistics
+#define MUTT_MAILBOX_CHECK_IMMEDIATE   (1 << 2) ///< Don't postpone the actual checking
+
 /**
  * enum MxStatus - Return values from mbox_check(), mbox_check_stats(),
  * mbox_snc(), and mbox_close()
@@ -192,7 +199,7 @@ struct MxOps
    * **Contract**
    * - @a m is not NULL
    */
-  enum MxStatus (*mbox_check_stats)(struct Mailbox *m, uint8_t flags);
+  enum MxStatus (*mbox_check_stats)(struct Mailbox *m, CheckStatsFlags flags);
 
   /**
    * @defgroup mx_mbox_sync mbox_sync()

--- a/gui/global.c
+++ b/gui/global.c
@@ -46,8 +46,8 @@
  */
 static int op_check_stats(int op)
 {
-  struct Mailbox *m_cur = get_current_mailbox();
-  mutt_check_stats(m_cur);
+  mutt_mailbox_check(get_current_mailbox(),
+                     MUTT_MAILBOX_CHECK_FORCE | MUTT_MAILBOX_CHECK_FORCE_STATS);
   return FR_SUCCESS;
 }
 

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -1225,7 +1225,8 @@ static int imap_status(struct ImapAccountData *adata, struct ImapMboxData *mdata
  */
 static enum MxStatus imap_mbox_check_stats(struct Mailbox *m, uint8_t flags)
 {
-  const int new_msgs = imap_mailbox_status(m, true);
+  const bool queue = (flags & MUTT_MAILBOX_CHECK_IMMEDIATE) == 0;
+  const int new_msgs = imap_mailbox_status(m, queue);
   if (new_msgs == -1)
     return MX_STATUS_ERROR;
   if (new_msgs == 0)

--- a/index/dlg_index.c
+++ b/index/dlg_index.c
@@ -1214,7 +1214,7 @@ struct Mailbox *mutt_index_menu(struct MuttWindow *dlg, struct Mailbox *m_init)
     {
       /* check for new mail in the incoming folders */
       priv->oldcount = priv->newcount;
-      priv->newcount = mutt_mailbox_check(shared->mailbox, 0);
+      priv->newcount = mutt_mailbox_check(shared->mailbox, MUTT_MAILBOX_CHECK_NO_FLAGS);
       if (priv->do_mailbox_notify)
       {
         if (mutt_mailbox_notify(shared->mailbox))

--- a/maildir/maildir.c
+++ b/maildir/maildir.c
@@ -1348,7 +1348,7 @@ enum MxStatus maildir_mbox_check(struct Mailbox *m)
  */
 static enum MxStatus maildir_mbox_check_stats(struct Mailbox *m, uint8_t flags)
 {
-  bool check_stats = flags;
+  bool check_stats = flags & MUTT_MAILBOX_CHECK_FORCE_STATS;
   bool check_new = true;
 
   if (check_stats)

--- a/main.c
+++ b/main.c
@@ -1267,7 +1267,8 @@ main
       const bool c_imap_passive = cs_subset_bool(NeoMutt->sub, "imap_passive");
       cs_subset_str_native_set(NeoMutt->sub, "imap_passive", false, NULL);
 #endif
-      if (mutt_mailbox_check(NULL, 0) == 0)
+      const CheckStatsFlags flags = MUTT_MAILBOX_CHECK_FORCE | MUTT_MAILBOX_CHECK_IMMEDIATE;
+      if (mutt_mailbox_check(NULL, flags) == 0)
       {
         mutt_message(_("No mailbox with new mail"));
         goto main_curses; // TEST37: neomutt -Z (no new mail)

--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -1823,8 +1823,8 @@ static enum MxStatus mbox_mbox_check_stats(struct Mailbox *m, uint8_t flags)
   if (m->newly_created && ((st.st_ctime != st.st_mtime) || (st.st_ctime != st.st_atime)))
     m->newly_created = false;
 
-  if ((flags != 0) && mutt_file_stat_timespec_compare(&st, MUTT_STAT_MTIME,
-                                                      &m->stats_last_checked) > 0)
+  const bool force = flags & (MUTT_MAILBOX_CHECK_FORCE | MUTT_MAILBOX_CHECK_FORCE_STATS);
+  if (force && mutt_file_stat_timespec_compare(&st, MUTT_STAT_MTIME, &m->stats_last_checked) > 0)
   {
     bool old_peek = m->peekonly;
     mx_mbox_open(m, MUTT_QUIET | MUTT_NOSORT | MUTT_PEEK);

--- a/mutt_mailbox.h
+++ b/mutt_mailbox.h
@@ -23,16 +23,13 @@
 #define MUTT_MUTT_MAILBOX_H
 
 #include <stdbool.h>
+#include "core/lib.h"
 
 struct Buffer;
 struct Mailbox;
 struct stat;
 
-/* force flags passed to mutt_mailbox_check() */
-#define MUTT_MAILBOX_CHECK_FORCE       (1 << 0)
-#define MUTT_MAILBOX_CHECK_FORCE_STATS (1 << 1)
-
-int  mutt_mailbox_check       (struct Mailbox *m_cur, int force);
+int  mutt_mailbox_check       (struct Mailbox *m_cur, CheckStatsFlags flags);
 void mutt_mailbox_cleanup     (const char *path, struct stat *st);
 bool mutt_mailbox_list        (void);
 struct Mailbox *mutt_mailbox_next(struct Mailbox *m_cur, struct Buffer *s);

--- a/status.c
+++ b/status.c
@@ -116,7 +116,7 @@ static const char *status_format_str(char *buf, size_t buflen, size_t col, int c
   {
     case 'b':
     {
-      const int num = mutt_mailbox_check(m, 0);
+      const int num = mutt_mailbox_check(m, MUTT_MAILBOX_CHECK_NO_FLAGS);
       if (!optional)
       {
         snprintf(fmt, sizeof(fmt), "%%%sd", prec);


### PR DESCRIPTION
When handling the -Z command line option, we want to force checking stats. Also, when we do that, we want to turn off queuing IMAP commands since the caller wants the answer immediately.