### PR TITLE
index: merge more colours

### DIFF
--- a/color/quoted.c
+++ b/color/quoted.c
@@ -133,6 +133,16 @@ bool quoted_colors_parse_color(enum ColorId cid, uint32_t fg, uint32_t bg,
   color_debug(LL_DEBUG5, "NT_COLOR_SET: %s\n", buf->data);
   mutt_buffer_pool_release(&buf);
 
+  if (q_level == 0)
+  {
+    // Copy the colour into the SimpleColors
+    struct AttrColor *ac_quoted = simple_color_get(MT_COLOR_QUOTED);
+    *ac_quoted = *ac;
+    ac_quoted->ref_count = 1;
+    if (ac_quoted->curses_color)
+      ac_quoted->curses_color->ref_count++;
+  }
+
   struct EventColor ev_c = { cid, ac };
   notify_send(ColorsNotify, NT_COLOR, NT_COLOR_SET, &ev_c);
 

--- a/compose/cbar.c
+++ b/compose/cbar.c
@@ -189,7 +189,7 @@ static int cbar_repaint(struct MuttWindow *win)
   struct ComposeBarData *cbar_data = win->wdata;
 
   mutt_window_move(win, 0, 0);
-  mutt_curses_set_color_by_id(MT_COLOR_STATUS);
+  mutt_curses_set_normal_backed_color_by_id(MT_COLOR_STATUS);
   mutt_window_clrtoeol(win);
 
   mutt_window_move(win, 0, 0);

--- a/envelope/window.c
+++ b/envelope/window.c
@@ -346,7 +346,7 @@ static int calc_envelope(struct MuttWindow *win, struct EnvelopeWindowData *wdat
  */
 static void draw_floating(struct MuttWindow *win, int col, int row, const char *text)
 {
-  mutt_curses_set_color_by_id(MT_COLOR_COMPOSE_HEADER);
+  mutt_curses_set_normal_backed_color_by_id(MT_COLOR_COMPOSE_HEADER);
   mutt_window_mvprintw(win, col, row, "%s", text);
   mutt_curses_set_color_by_id(MT_COLOR_NORMAL);
 }
@@ -359,7 +359,7 @@ static void draw_floating(struct MuttWindow *win, int col, int row, const char *
  */
 static void draw_header(struct MuttWindow *win, int row, enum HeaderField field)
 {
-  mutt_curses_set_color_by_id(MT_COLOR_COMPOSE_HEADER);
+  mutt_curses_set_normal_backed_color_by_id(MT_COLOR_COMPOSE_HEADER);
   mutt_window_mvprintw(win, 0, row, "%*s", HeaderPadding[field], _(Prompts[field]));
   mutt_curses_set_color_by_id(MT_COLOR_NORMAL);
 }
@@ -400,23 +400,23 @@ static int draw_crypt_lines(struct MuttWindow *win, struct EnvelopeWindowData *w
   int used = 2;
   if ((e->security & (SEC_ENCRYPT | SEC_SIGN)) == (SEC_ENCRYPT | SEC_SIGN))
   {
-    mutt_curses_set_color_by_id(MT_COLOR_COMPOSE_SECURITY_BOTH);
+    mutt_curses_set_normal_backed_color_by_id(MT_COLOR_COMPOSE_SECURITY_BOTH);
     mutt_window_addstr(win, _("Sign, Encrypt"));
   }
   else if (e->security & SEC_ENCRYPT)
   {
-    mutt_curses_set_color_by_id(MT_COLOR_COMPOSE_SECURITY_ENCRYPT);
+    mutt_curses_set_normal_backed_color_by_id(MT_COLOR_COMPOSE_SECURITY_ENCRYPT);
     mutt_window_addstr(win, _("Encrypt"));
   }
   else if (e->security & SEC_SIGN)
   {
-    mutt_curses_set_color_by_id(MT_COLOR_COMPOSE_SECURITY_SIGN);
+    mutt_curses_set_normal_backed_color_by_id(MT_COLOR_COMPOSE_SECURITY_SIGN);
     mutt_window_addstr(win, _("Sign"));
   }
   else
   {
     /* L10N: This refers to the encryption of the email, e.g. "Security: None" */
-    mutt_curses_set_color_by_id(MT_COLOR_COMPOSE_SECURITY_NONE);
+    mutt_curses_set_normal_backed_color_by_id(MT_COLOR_COMPOSE_SECURITY_NONE);
     mutt_window_addstr(win, _("None"));
     used = 1; // 'Sign as:' won't be needed
   }
@@ -476,12 +476,12 @@ static int draw_crypt_lines(struct MuttWindow *win, struct EnvelopeWindowData *w
     draw_header(win, row, HDR_AUTOCRYPT);
     if (e->security & SEC_AUTOCRYPT)
     {
-      mutt_curses_set_color_by_id(MT_COLOR_COMPOSE_SECURITY_ENCRYPT);
+      mutt_curses_set_normal_backed_color_by_id(MT_COLOR_COMPOSE_SECURITY_ENCRYPT);
       mutt_window_addstr(win, _("Encrypt"));
     }
     else
     {
-      mutt_curses_set_color_by_id(MT_COLOR_COMPOSE_SECURITY_NONE);
+      mutt_curses_set_normal_backed_color_by_id(MT_COLOR_COMPOSE_SECURITY_NONE);
       mutt_window_addstr(win, _("Off"));
     }
 
@@ -627,7 +627,7 @@ static int draw_envelope_addr(int field, struct AddressList *al,
   if (count > 0)
   {
     mutt_window_move(win, win->state.cols - more_len, row);
-    mutt_curses_set_color_by_id(MT_COLOR_BOLD);
+    mutt_curses_set_normal_backed_color_by_id(MT_COLOR_BOLD);
     mutt_window_addstr(win, more);
     mutt_curses_set_color_by_id(MT_COLOR_NORMAL);
     mutt_debug(LL_DEBUG3, "%d more (len %d)\n", count, more_len);
@@ -748,7 +748,6 @@ static void draw_envelope(struct MuttWindow *win, struct EnvelopeWindowData *wda
   if (c_compose_show_user_headers)
     row += draw_envelope_user_hdrs(win, wdata, row);
 
-  mutt_curses_set_color_by_id(MT_COLOR_STATUS);
   mutt_curses_set_color_by_id(MT_COLOR_NORMAL);
 }
 

--- a/gui/curs_lib.c
+++ b/gui/curs_lib.c
@@ -302,7 +302,7 @@ int mutt_buffer_get_field(const char *field, struct Buffer *buf, CompletionFlags
       window_redraw(NULL);
     }
     mutt_window_clearline(win, 0);
-    mutt_curses_set_color_by_id(MT_COLOR_PROMPT);
+    mutt_curses_set_normal_backed_color_by_id(MT_COLOR_PROMPT);
     mutt_window_addstr(win, field);
     mutt_curses_set_color_by_id(MT_COLOR_NORMAL);
     mutt_refresh();
@@ -502,7 +502,7 @@ int mutt_buffer_enter_fname(const char *prompt, struct Buffer *fname,
   struct KeyEvent ch = { OP_NULL, OP_NULL };
   struct MuttWindow *old_focus = window_set_focus(win);
 
-  mutt_curses_set_color_by_id(MT_COLOR_PROMPT);
+  mutt_curses_set_normal_backed_color_by_id(MT_COLOR_PROMPT);
   mutt_window_mvaddstr(win, 0, 0, prompt);
   mutt_window_addstr(win, _(" ('?' for list): "));
   mutt_curses_set_color_by_id(MT_COLOR_NORMAL);

--- a/gui/msgwin.c
+++ b/gui/msgwin.c
@@ -120,7 +120,7 @@ static int msgwin_repaint(struct MuttWindow *win)
 
   mutt_window_move(win, 0, 0);
 
-  mutt_curses_set_color_by_id(priv->cid);
+  mutt_curses_set_normal_backed_color_by_id(priv->cid);
   mutt_window_move(win, 0, 0);
   mutt_window_addstr(win, priv->text);
   mutt_curses_set_color_by_id(MT_COLOR_NORMAL);

--- a/gui/sbar.c
+++ b/gui/sbar.c
@@ -99,7 +99,7 @@ static int sbar_repaint(struct MuttWindow *win)
 
   mutt_window_move(win, 0, 0);
 
-  mutt_curses_set_color_by_id(MT_COLOR_STATUS);
+  mutt_curses_set_normal_backed_color_by_id(MT_COLOR_STATUS);
   mutt_window_move(win, 0, 0);
   mutt_paddstr(win, win->state.cols, priv->display);
   mutt_curses_set_color_by_id(MT_COLOR_NORMAL);

--- a/helpbar/helpbar.c
+++ b/helpbar/helpbar.c
@@ -185,7 +185,7 @@ static int helpbar_repaint(struct MuttWindow *win)
   if (!wdata)
     return 0;
 
-  mutt_curses_set_color_by_id(MT_COLOR_STATUS);
+  mutt_curses_set_normal_backed_color_by_id(MT_COLOR_STATUS);
   mutt_window_move(win, 0, 0);
   mutt_paddstr(win, win->state.cols, wdata->help_str);
   mutt_curses_set_color_by_id(MT_COLOR_NORMAL);

--- a/index/ibar.c
+++ b/index/ibar.c
@@ -146,7 +146,7 @@ static int ibar_repaint(struct MuttWindow *win)
   struct IndexSharedData *shared = ibar_data->shared;
 
   mutt_window_move(win, 0, 0);
-  mutt_curses_set_color_by_id(MT_COLOR_STATUS);
+  mutt_curses_set_normal_backed_color_by_id(MT_COLOR_STATUS);
   mutt_window_clrtoeol(win);
 
   mutt_window_move(win, 0, 0);

--- a/keymap.c
+++ b/keymap.c
@@ -1639,7 +1639,7 @@ void mutt_what_key(void)
   if (!win)
     return;
 
-  mutt_curses_set_color_by_id(MT_COLOR_PROMPT);
+  mutt_curses_set_normal_backed_color_by_id(MT_COLOR_PROMPT);
   mutt_window_mvprintw(win, 0, 0, _("Enter keys (%s to abort): "), km_keyname(AbortKey));
   mutt_curses_set_color_by_id(MT_COLOR_NORMAL);
   enum MuttCursorState cursor = mutt_curses_set_cursor(MUTT_CURSOR_VISIBLE);

--- a/pager/pager.c
+++ b/pager/pager.c
@@ -223,7 +223,7 @@ static int pager_repaint(struct MuttWindow *win)
     // attr_color_list_dump(&priv->ansi_list, "All AnsiColors");
 
     const bool c_tilde = cs_subset_bool(NeoMutt->sub, "tilde");
-    mutt_curses_set_color_by_id(MT_COLOR_TILDE);
+    mutt_curses_set_normal_backed_color_by_id(MT_COLOR_TILDE);
     while (priv->win_height < priv->pview->win_pager->state.rows)
     {
       mutt_window_clrtoeol(priv->pview->win_pager);

--- a/pager/pbar.c
+++ b/pager/pbar.c
@@ -161,7 +161,7 @@ static int pbar_repaint(struct MuttWindow *win)
   // struct IndexSharedData *shared = pbar_data->shared;
 
   mutt_window_move(win, 0, 0);
-  mutt_curses_set_color_by_id(MT_COLOR_STATUS);
+  mutt_curses_set_normal_backed_color_by_id(MT_COLOR_STATUS);
   mutt_window_clrtoeol(win);
 
   mutt_window_move(win, 0, 0);

--- a/progress/progress.c
+++ b/progress/progress.c
@@ -89,7 +89,7 @@ static void message_bar(struct MuttWindow *win, int percent, const char *fmt, ..
     if (l < w)
     {
       /* The string fits within the colour bar */
-      mutt_curses_set_color_by_id(MT_COLOR_PROGRESS);
+      mutt_curses_set_normal_backed_color_by_id(MT_COLOR_PROGRESS);
       mutt_window_addstr(win, buf2);
       w -= l;
       while (w-- > 0)
@@ -105,7 +105,7 @@ static void message_bar(struct MuttWindow *win, int percent, const char *fmt, ..
 
       char ch = buf2[off];
       buf2[off] = '\0';
-      mutt_curses_set_color_by_id(MT_COLOR_PROGRESS);
+      mutt_curses_set_normal_backed_color_by_id(MT_COLOR_PROGRESS);
       mutt_window_addstr(win, buf2);
       buf2[off] = ch;
       mutt_curses_set_color_by_id(MT_COLOR_NORMAL);

--- a/question/question.c
+++ b/question/question.c
@@ -102,7 +102,7 @@ int mutt_multi_choice(const char *prompt, const char *letters)
         while ((cur = strchr(prompt, '(')))
         {
           // write the part between prompt and cur using MT_COLOR_PROMPT
-          mutt_curses_set_color_by_id(MT_COLOR_PROMPT);
+          mutt_curses_set_normal_backed_color_by_id(MT_COLOR_PROMPT);
           mutt_window_addnstr(win, prompt, cur - prompt);
 
           if (isalnum(cur[1]) && (cur[2] == ')'))
@@ -121,7 +121,7 @@ int mutt_multi_choice(const char *prompt, const char *letters)
         }
       }
 
-      mutt_curses_set_color_by_id(MT_COLOR_PROMPT);
+      mutt_curses_set_normal_backed_color_by_id(MT_COLOR_PROMPT);
       mutt_window_addstr(win, prompt);
       mutt_curses_set_color_by_id(MT_COLOR_NORMAL);
 
@@ -275,7 +275,7 @@ enum QuadOption mutt_yesorno(const char *msg, enum QuadOption def)
           ((size_t) prompt_lines * win->state.cols) - answer_string_wid, NULL);
 
       mutt_window_move(win, 0, 0);
-      mutt_curses_set_color_by_id(MT_COLOR_PROMPT);
+      mutt_curses_set_normal_backed_color_by_id(MT_COLOR_PROMPT);
       mutt_window_addnstr(win, msg, trunc_msg_len);
       mutt_window_addstr(win, answer_string);
       mutt_curses_set_color_by_id(MT_COLOR_NORMAL);

--- a/question/question.c
+++ b/question/question.c
@@ -59,7 +59,15 @@ int mutt_multi_choice(const char *prompt, const char *letters)
   bool redraw = true;
   int prompt_lines = 1;
 
-  const bool opt_cols = simple_color_is_set(MT_COLOR_OPTIONS);
+  struct AttrColor *ac_opts = NULL;
+  if (simple_color_is_set(MT_COLOR_OPTIONS))
+  {
+    struct AttrColor *ac_base = simple_color_get(MT_COLOR_NORMAL);
+    ac_base = merged_color_overlay(ac_base, simple_color_get(MT_COLOR_PROMPT));
+
+    ac_opts = simple_color_get(MT_COLOR_OPTIONS);
+    ac_opts = merged_color_overlay(ac_base, ac_opts);
+  }
 
   struct MuttWindow *old_focus = window_set_focus(win);
   enum MuttCursorState cursor = mutt_curses_set_cursor(MUTT_CURSOR_VISIBLE);
@@ -81,7 +89,7 @@ int mutt_multi_choice(const char *prompt, const char *letters)
         int width = mutt_strwidth(prompt) + 2; // + '?' + space
         /* If we're going to colour the options,
          * make an assumption about the modified prompt size. */
-        if (opt_cols)
+        if (ac_opts)
           width -= 2 * mutt_str_len(letters);
 
         prompt_lines = (width + win->state.cols - 1) / win->state.cols;
@@ -95,7 +103,7 @@ int mutt_multi_choice(const char *prompt, const char *letters)
 
       mutt_window_move(win, 0, 0);
 
-      if (opt_cols)
+      if (ac_opts)
       {
         char *cur = NULL;
 
@@ -108,7 +116,7 @@ int mutt_multi_choice(const char *prompt, const char *letters)
           if (isalnum(cur[1]) && (cur[2] == ')'))
           {
             // we have a single letter within parentheses
-            mutt_curses_set_color_by_id(MT_COLOR_OPTIONS);
+            mutt_curses_set_color(ac_opts);
             mutt_window_addch(win, cur[1]);
             prompt = cur + 3;
           }

--- a/sidebar/window.c
+++ b/sidebar/window.c
@@ -858,7 +858,7 @@ static int draw_divider(struct SidebarWindowData *wdata, struct MuttWindow *win,
   const char *const c_sidebar_divider_char =
       cs_subset_string(NeoMutt->sub, "sidebar_divider_char");
 
-  mutt_curses_set_color_by_id(MT_COLOR_SIDEBAR_DIVIDER);
+  mutt_curses_set_normal_backed_color_by_id(MT_COLOR_SIDEBAR_DIVIDER);
 
   const bool c_sidebar_on_right =
       cs_subset_bool(NeoMutt->sub, "sidebar_on_right");

--- a/sidebar/window.c
+++ b/sidebar/window.c
@@ -250,44 +250,40 @@ static size_t add_indent(char *buf, size_t buflen, const struct SbEntry *sbe)
  */
 static struct AttrColor *calc_color(const struct Mailbox *m, bool current, bool highlight)
 {
-  enum ColorId color = MT_COLOR_NORMAL;
   struct AttrColor *ac = NULL;
-
-  if (m->has_new)
-  {
-    color = MT_COLOR_SIDEBAR_NEW;
-    goto done;
-  }
-  if (m->msg_unread > 0)
-  {
-    color = MT_COLOR_SIDEBAR_UNREAD;
-    goto done;
-  }
-  if (m->msg_flagged > 0)
-  {
-    color = MT_COLOR_SIDEBAR_FLAGGED;
-    goto done;
-  }
 
   const char *const c_spool_file = cs_subset_string(NeoMutt->sub, "spool_file");
   if (simple_color_is_set(MT_COLOR_SIDEBAR_SPOOLFILE) &&
       mutt_str_equal(mailbox_path(m), c_spool_file))
   {
-    color = MT_COLOR_SIDEBAR_SPOOLFILE;
-    goto done;
+    ac = merged_color_overlay(ac, simple_color_get(MT_COLOR_SIDEBAR_SPOOLFILE));
   }
 
-  if (simple_color_is_set(MT_COLOR_SIDEBAR_ORDINARY))
+  if (simple_color_is_set(MT_COLOR_SIDEBAR_FLAGGED) && (m->msg_flagged > 0))
   {
-    color = MT_COLOR_SIDEBAR_ORDINARY;
-    goto done;
+    ac = merged_color_overlay(ac, simple_color_get(MT_COLOR_SIDEBAR_FLAGGED));
   }
 
-done:
-  ac = simple_color_get(color);
+  if (simple_color_is_set(MT_COLOR_SIDEBAR_UNREAD) && (m->msg_unread > 0))
+  {
+    ac = merged_color_overlay(ac, simple_color_get(MT_COLOR_SIDEBAR_UNREAD));
+  }
+
+  if (simple_color_is_set(MT_COLOR_SIDEBAR_NEW) && m->has_new)
+  {
+    ac = merged_color_overlay(ac, simple_color_get(MT_COLOR_SIDEBAR_NEW));
+  }
+
+  if (!ac && simple_color_is_set(MT_COLOR_SIDEBAR_ORDINARY))
+  {
+    ac = simple_color_get(MT_COLOR_SIDEBAR_ORDINARY);
+  }
+
+  ac = merged_color_overlay(simple_color_get(MT_COLOR_NORMAL), ac);
 
   if (current || highlight)
   {
+    int color;
     if (current)
     {
       if (simple_color_is_set(MT_COLOR_SIDEBAR_INDICATOR))
@@ -300,9 +296,7 @@ done:
       color = MT_COLOR_SIDEBAR_HIGHLIGHT;
     }
 
-    struct AttrColor *ac_overlay = simple_color_get(color);
-
-    ac = merged_color_overlay(ac, ac_overlay);
+    ac = merged_color_overlay(ac, simple_color_get(color));
   }
 
   return ac;


### PR DESCRIPTION
Some index colours can be configured multiple times with different patterns.
`index_author`, `index_flags`, `index_subject`

If multiple patterns match an entry, their colours will be merged in config order.

@riesebie Please can you give this a try.