### PR TITLE
Fix forwarding text attachments when honor_disposition is set

### DIFF
--- a/handler.h
+++ b/handler.h
@@ -30,7 +30,8 @@ struct Body;
 struct State;
 
 int  mutt_body_handler(struct Body *b, struct State *s);
-bool mutt_can_decode(struct Body *a);
+bool mutt_can_decode(struct Body *b);
+bool mutt_prefer_as_attachment(struct Body *b);
 void mutt_decode_attachment(struct Body *b, struct State *s);
 void mutt_decode_base64(struct State *s, size_t len, bool istext, iconv_t cd);
 

--- a/send/send.c
+++ b/send/send.c
@@ -585,7 +585,7 @@ static int inline_forward_attachments(struct Mailbox *m, struct Email *e,
   for (i = 0; i < actx->idxlen; i++)
   {
     body = actx->idx[i]->body;
-    if ((body->type != TYPE_MULTIPART) && !mutt_can_decode(body) &&
+    if ((body->type != TYPE_MULTIPART) && mutt_prefer_as_attachment(body) &&
         !((body->type == TYPE_APPLICATION) &&
           (mutt_istr_equal(body->subtype, "pgp-signature") ||
            mutt_istr_equal(body->subtype, "x-pkcs7-signature") ||


### PR DESCRIPTION
`mutt_can_decode` is used in `inline_forward_attachments` to decide
which parts of a message need to be attached when forwarding an email.
If we don't consider skipped types such as signatures, this set must be
equal to the set of parts that wasn't included in the email text.
However, using `mutt_can_decode` is not enough, because parts with
disposition = attachments that could be decoded might have been skipped
during the formation of the email text because of `honor_disposition`.
Hence, we need a common piece of code to decide if a part is handled
inline or in an attachment.

An alternative to this would be to mark the parts that were handled in
the main body and include all others. I am not sure what is the best
approach.

While at it, use `b` for bodies.

Also, please double check my logic here.

Fixes #3346