### PR TITLE
pager: fix $pager_stop

### DIFF
--- a/index/functions.c
+++ b/index/functions.c
@@ -105,6 +105,7 @@ enum ResolveMethod
  * @param menu   Menu
  * @param shared Shared Index data
  * @param rm     How to advance the cursor, e.g. #RESOLVE_NEXT_EMAIL
+ * @retval true Resolve succeeded
  */
 static bool resolve_email(struct Menu *menu, struct IndexSharedData *shared, enum ResolveMethod rm)
 {
@@ -138,6 +139,34 @@ static bool resolve_email(struct Menu *menu, struct IndexSharedData *shared, enu
   if ((index < 0) || (index >= shared->mailbox->vcount))
   {
     // Resolve failed
+    notify_send(shared->notify, NT_INDEX, NT_INDEX_EMAIL, NULL);
+    return false;
+  }
+
+  menu_set_index(menu, index);
+  return true;
+}
+
+/**
+ * index_next_undeleted - Select the next undeleted Email (if possible)
+ * @param win_index Index Window
+ * @retval true Selection succeeded
+ */
+bool index_next_undeleted(struct MuttWindow *win_index)
+{
+  struct MuttWindow *dlg = dialog_find(win_index);
+  if (!dlg)
+    return false;
+
+  struct Menu *menu = win_index->wdata;
+  struct IndexSharedData *shared = dlg->wdata;
+  if (!shared)
+    return false;
+
+  int index = ci_next_undeleted(shared->mailbox, menu_get_index(menu));
+  if ((index < 0) || (index >= shared->mailbox->vcount))
+  {
+    // Selection failed
     notify_send(shared->notify, NT_INDEX, NT_INDEX_EMAIL, NULL);
     return false;
   }

--- a/index/functions.h
+++ b/index/functions.h
@@ -51,6 +51,7 @@ struct IndexFunction
 };
 
 int index_function_dispatcher(struct MuttWindow *win, int op);
+bool index_next_undeleted(struct MuttWindow *win_index);
 
 extern struct IndexFunction IndexFunctions[];
 

--- a/pager/functions.c
+++ b/pager/functions.c
@@ -177,8 +177,7 @@ static int op_pager_half_down(struct IndexSharedData *shared,
   else
   {
     /* end of the current message, so display the next message. */
-    priv->rc = OP_MAIN_NEXT_UNDELETED;
-    return FR_DONE;
+    index_next_undeleted(priv->pview->win_index);
   }
   return FR_SUCCESS;
 }
@@ -272,8 +271,7 @@ static int op_pager_next_page(struct IndexSharedData *shared,
   else
   {
     /* end of the current message, so display the next message. */
-    priv->rc = OP_MAIN_NEXT_UNDELETED;
-    return FR_DONE;
+    index_next_undeleted(priv->pview->win_index);
   }
   return FR_SUCCESS;
 }


### PR DESCRIPTION
Fix the `$pager_stop` behaviour.

If `pager_stop=no`, then using `<next-page>` or `<half-down>` at the end of an email will jump to the next undeleted email.

This was broken by the Index/Pager refactoring.