### PR TITLE
color: disable mono command

### DIFF
--- a/color/command.c
+++ b/color/command.c
@@ -678,12 +678,8 @@ enum CommandResult mutt_parse_uncolor(struct Buffer *buf, struct Buffer *s,
 enum CommandResult mutt_parse_unmono(struct Buffer *buf, struct Buffer *s,
                                      intptr_t data, struct Buffer *err)
 {
-  if (OptNoCurses)
-  {
-    *s->dptr = '\0'; /* fake that we're done parsing */
-    return MUTT_CMD_SUCCESS;
-  }
-  return parse_uncolor(buf, s, err, false);
+  *s->dptr = '\0'; /* fake that we're done parsing */
+  return MUTT_CMD_SUCCESS;
 }
 
 /**
@@ -707,7 +703,5 @@ enum CommandResult mutt_parse_color(struct Buffer *buf, struct Buffer *s,
 enum CommandResult mutt_parse_mono(struct Buffer *buf, struct Buffer *s,
                                    intptr_t data, struct Buffer *err)
 {
-  bool dry_run = OptNoCurses;
-
-  return parse_color(buf, s, err, parse_attr_spec, dry_run, false);
+  return parse_color(buf, s, err, parse_attr_spec, true, false);
 }


### PR DESCRIPTION
Historically the `mono` and `unmono` commands were only enabled if:
- Mutt was compiled **without** support for colour,
- Your terminal didn't support colour.

Both these conditions are very unlikely, these days.

The `color` command can take attributes in addition to the colours, e.g.

```
color body bold underline red default "neomutt"
```

During the refactoring, I made the decision to turn `mono` commands into a stripped down `color` command.
This would have allowed the user to tweak the attributes of an object, without having to specify the colour info.

```
# Equivalent
color body bold default default "neomutt"
mono body bold "neomutt"
```

Unfortunately, this means that all those `mono` commands that were laying dormant in users' config files have started interfering with their themes.
(including our own `/etc/neomuttrc`)

Conclusion.  Kill `mono` and encourage users to drop it from their config.