### PR TITLE
fix: clearing color with default

### DIFF
--- a/color/regex.c
+++ b/color/regex.c
@@ -227,7 +227,7 @@ static enum CommandResult add_pattern(struct RegexColorList *rcl, const char *s,
     struct CursesColor *cc = ac->curses_color;
 
     // different colours
-    if (cc && ((cc->fg != fg) || (cc->bg != bg)))
+    if (!cc || (cc && ((cc->fg != fg) || (cc->bg != bg))))
     {
       cc = curses_color_new(fg, bg);
       if (cc)
@@ -235,8 +235,8 @@ static enum CommandResult add_pattern(struct RegexColorList *rcl, const char *s,
         attr_color_clear(&rcol->attr_color);
         cc->fg = fg;
         cc->bg = bg;
-        ac->curses_color = cc;
       }
+      ac->curses_color = cc;
     }
     ac->attrs = attrs;
   }

--- a/pager/display.c
+++ b/pager/display.c
@@ -148,11 +148,17 @@ static void resolve_color(struct MuttWindow *win, struct Line *lines, int line_n
     def_color = *(lines[line_num].syntax[0].attr_color);
   }
   else if (!(flags & MUTT_SHOWCOLOR))
+  {
     def_color = *simple_color_get(MT_COLOR_NORMAL);
-  else if (lines[m].cid == MT_COLOR_HEADER)
+  }
+  else if ((lines[m].cid == MT_COLOR_HEADER) && lines[m].syntax[0].attr_color)
+  {
     def_color = *lines[m].syntax[0].attr_color;
+  }
   else
+  {
     def_color = *simple_color_get(lines[m].cid);
+  }
 
   if ((flags & MUTT_SHOWCOLOR) && (lines[m].cid == MT_COLOR_QUOTED))
   {


### PR DESCRIPTION
Fix a crash caused by an unset colour.
Make sure that setting a colour to "default default" actually clears the colour.

Fixes: #3364 