### PR TITLE
fix: misalignment of mini-index

### DIFF
--- a/index/functions.c
+++ b/index/functions.c
@@ -1646,6 +1646,7 @@ static int op_main_sync_folder(struct IndexSharedData *shared,
     ctx_free(&shared->ctx);
   }
 
+  priv->menu->max = shared->mailbox->vcount;
   menu_queue_redraw(priv->menu, MENU_REDRAW_FULL);
 
   return FR_SUCCESS;


### PR DESCRIPTION
Steps:
- Enable mini-index (pager_index_lines=10)
- Disable resolve (resolve=no)
- Select last email
- Delete email
- Sync mailbox

This would cause the mini-index to not fill the space and display duplicate copies of emails.

---

Fixes: #3363 
There are bound to be other quirks, but this fixes the immediate problem