### PR TITLE
Do not crash on an invalid use_threads/sort combination

### DIFF
--- a/index/dlg_index.c
+++ b/index/dlg_index.c
@@ -1015,6 +1015,9 @@ dsl_finish:
  */
 struct Mailbox *mutt_index_menu(struct MuttWindow *dlg, struct Mailbox *m_init)
 {
+  /* Make sure use_threads/sort/sort_aux are coherent */
+  index_adjust_sort_threads(NeoMutt->sub);
+
   struct IndexSharedData *shared = dlg->wdata;
   index_shared_data_set_context(shared, mview_new(m_init));
 
@@ -1058,9 +1061,6 @@ struct Mailbox *mutt_index_menu(struct MuttWindow *dlg, struct Mailbox *m_init)
       menu_queue_redraw(priv->menu, MENU_REDRAW_FULL);
     }
   }
-
-  /* Make sure use_threads/sort/sort_aux are coherent */
-  index_adjust_sort_threads(NeoMutt->sub);
 
   int rc = 0;
   do

--- a/index/dlg_index.c
+++ b/index/dlg_index.c
@@ -1059,6 +1059,9 @@ struct Mailbox *mutt_index_menu(struct MuttWindow *dlg, struct Mailbox *m_init)
     }
   }
 
+  /* Make sure use_threads/sort/sort_aux are coherent */
+  index_adjust_sort_threads(NeoMutt->sub);
+
   int rc = 0;
   do
   {

--- a/index/index.c
+++ b/index/index.c
@@ -175,6 +175,16 @@ static int config_use_threads(const struct ConfigSubset *sub)
 }
 
 /**
+ * index_adjust_sort_threads - Adjust use_threads/sort/sort_aux
+ * @param sub the config subset that was just updated
+ */
+void index_adjust_sort_threads(const struct ConfigSubset *sub)
+{
+  /* For lack of a better way, we fake a "set use_threads" */
+  config_use_threads(sub);
+}
+
+/**
  * config_reply_regex - React to changes to $reply_regex
  * @param m Mailbox
  * @retval  0 Successfully handled

--- a/index/private.h
+++ b/index/private.h
@@ -27,8 +27,10 @@
 
 struct IndexPrivateData;
 struct IndexSharedData;
+struct ConfigSubset;
 
 struct MuttWindow *index_window_new(struct IndexPrivateData *priv);
 struct MuttWindow *ipanel_new(bool status_on_top, struct IndexSharedData *shared);
+int index_adjust_sort_threads(const struct ConfigSubset *sub);
 
 #endif /* MUTT_INDEX_PRIVATE_H */


### PR DESCRIPTION
This is not very elegant. @ebblake I'm open to better approaches to avoid
a crash on startup.

Fixes #3126