### PR TITLE
fix: stuck browser cursor

### DIFF
--- a/browser/browser.c
+++ b/browser/browser.c
@@ -1349,12 +1349,6 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
   int rc;
   do
   {
-    if (state.is_mailbox_list && (last_selected_mailbox >= 0) &&
-        (last_selected_mailbox < menu->max))
-    {
-      menu_set_index(menu, last_selected_mailbox);
-    }
-
     rc = FR_UNKNOWN;
     menu_tagging_dispatcher(menu->win, op);
     window_redraw(NULL);
@@ -1942,9 +1936,7 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
       case OP_CHECK_NEW:
       {
         if (state.is_mailbox_list)
-        {
-          last_selected_mailbox = menu->current;
-        }
+          last_selected_mailbox = menu_get_index(menu);
 
         if (op == OP_TOGGLE_MAILBOXES)
         {
@@ -2003,6 +1995,9 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
           goto bail;
         }
         init_menu(&state, menu, m, sbar);
+        if (state.is_mailbox_list)
+          menu_set_index(menu, last_selected_mailbox);
+
         continue;
       }
 


### PR DESCRIPTION
Restore the mailbox selection when toggling from the Directory to the Mailbox view.
Do this in `OP_TOGGLE_MAILBOXES` rather than every loop.

Fixes: #3376 

Some recent refactoring meant that `last_selected_mailbox` wasn't being updated,
so the main loop kept setting the cursor position to the same place.

---

**Steps**:
- Open mailbox
- Open browser `c?`
- Repeat:
  - Move cursor
  - `<tab>` to switch views

**Results**:
- The cursor position for the Mailboxes view is remembered
- The cursor can be moved after switching back-and-forth several times