### PR TITLE
Support viewing text/html attachments with embedded images

### DIFF
--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -121,9 +121,9 @@ $(PWD)/alias:
 ###############################################################################
 # libattach
 LIBATTACH=	libattach.a
-LIBATTACHOBJS=	attach/attach.o attach/attachments.o attach/dlg_attach.o \
-		attach/functions.o attach/lib.o attach/mutt_attach.o \
-		attach/private_data.o attach/recvattach.o
+LIBATTACHOBJS=	attach/attach.o attach/attachments.o attach/cid.o \
+		attach/dlg_attach.o attach/functions.o attach/lib.o \
+		attach/mutt_attach.o attach/private_data.o attach/recvattach.o
 CLEANFILES+=	$(LIBATTACH) $(LIBATTACHOBJS)
 ALLOBJS+=	$(LIBATTACHOBJS)
 

--- a/attach/cid.c
+++ b/attach/cid.c
@@ -1,0 +1,84 @@
+/**
+ * @file
+ * Attachment Content-ID header functions
+ *
+ * @authors
+ * Copyright (C) 2022 David Purton <dcpurton@marshwiggle.net>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @page attach_cid Attachment Content-ID header functions
+ *
+ * Attachment Content-ID header functions
+ */
+
+#include "config.h"
+#include <stddef.h>
+#include "cid.h"
+
+/**
+ * cid_map_free - Free a CidMap
+ * @param[out] ptr CidMap to free
+ */
+void cid_map_free(struct CidMap **ptr)
+{
+  if (!ptr)
+    return;
+
+  struct CidMap *cid_map = *ptr;
+
+  FREE(&cid_map->cid);
+  FREE(&cid_map->fname);
+
+  FREE(ptr);
+}
+
+/**
+ * cid_map_new - Initialise a new CidMap
+ * @param  cid      Content-ID to replace including "cid:" prefix
+ * @param  filename Path to file to replace Content-ID with
+ * @retval ptr      Newly allocated CidMap
+ */
+struct CidMap *cid_map_new(const char *cid, const char *filename)
+{
+  if (!cid || !filename)
+    return NULL;
+
+  struct CidMap *cid_map = mutt_mem_calloc(1, sizeof(struct CidMap));
+
+  cid_map->cid = mutt_str_dup(cid);
+  cid_map->fname = mutt_str_dup(filename);
+
+  return cid_map;
+}
+
+/**
+ * cid_map_list_clear - Empty a CidMapList
+ * @param cid_map_list List of Content-ID to filename mappings
+ */
+void cid_map_list_clear(struct CidMapList *cid_map_list)
+{
+  if (!cid_map_list)
+    return;
+
+  while (!STAILQ_EMPTY(cid_map_list))
+  {
+    struct CidMap *cid_map = STAILQ_FIRST(cid_map_list);
+    STAILQ_REMOVE_HEAD(cid_map_list, entries);
+    cid_map_free(&cid_map);
+  }
+}

--- a/attach/cid.c
+++ b/attach/cid.c
@@ -30,11 +30,13 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <stdio.h>
+#include <string.h>
 #include "email/lib.h"
 #include "cid.h"
 #include "attach.h"
 #include "mailcap.h"
 #include "mutt_attach.h"
+#include "muttlib.h"
 
 /**
  * cid_map_free - Free a CidMap
@@ -157,4 +159,93 @@ void cid_save_attachments(struct Body *body, struct CidMapList *cid_map_list)
     else
       cid_save_attachment(b, cid_map_list);
   }
+}
+
+/**
+ * cid_to_filename - Replace Content-IDs with filenames
+ * @param filename     Path to file to replace Content-IDs with filenames
+ * @param cid_map_list List of Content-ID to filename mappings
+ */
+void cid_to_filename(struct Buffer *filename, const struct CidMapList *cid_map_list)
+{
+  if (!filename || !cid_map_list)
+    return;
+
+  FILE *fp_out = NULL;
+  char *pbuf = NULL;
+  char *searchbuf = NULL;
+  char *buf = NULL;
+  char *cid = NULL;
+  size_t blen = 0;
+  struct CidMap *cid_map = NULL;
+
+  struct Buffer *tmpfile = mutt_buffer_pool_get();
+  struct Buffer *tmpbuf = mutt_buffer_pool_get();
+
+  FILE *fp_in = mutt_file_fopen(mutt_buffer_string(filename), "r");
+  if (!fp_in)
+    goto bail;
+
+  /* ensure tmpfile has the same file extension as filename otherwise an
+   * HTML file may be opened as plain text by the viewer */
+  const char *suffix = mutt_strn_rfind(mutt_buffer_string(filename),
+                                       mutt_buffer_len(filename), ".");
+  if (suffix && *(suffix++))
+    mutt_buffer_mktemp_pfx_sfx(tmpfile, "neomutt", suffix);
+  else
+    mutt_buffer_mktemp(tmpfile);
+  fp_out = mutt_file_fopen(mutt_buffer_string(tmpfile), "w+");
+  if (!fp_out)
+    goto bail;
+
+  /* Read in lines from filename into buf */
+  while ((buf = mutt_file_read_line(buf, &blen, fp_in, NULL, MUTT_RL_NO_FLAGS)) != NULL)
+  {
+    if (mutt_str_len(buf) == 0)
+    {
+      fputs(buf, fp_out);
+      continue;
+    }
+
+    /* copy buf to searchbuf because we need to edit multiple times */
+    searchbuf = mutt_str_dup(buf);
+    mutt_buffer_reset(tmpbuf);
+
+    /* loop through Content-ID to filename mappings and do search and replace */
+    STAILQ_FOREACH(cid_map, cid_map_list, entries)
+    {
+      pbuf = searchbuf;
+      while ((cid = strstr(pbuf, cid_map->cid)) != NULL)
+      {
+        mutt_buffer_addstr_n(tmpbuf, pbuf, cid - pbuf);
+        mutt_buffer_addstr(tmpbuf, cid_map->fname);
+        pbuf = cid + mutt_str_len(cid_map->cid);
+        mutt_debug(LL_DEBUG2, "replaced \"%s\" with \"%s\" in file \"%s\"\n",
+                   cid_map->cid, cid_map->fname, mutt_buffer_string(filename));
+      }
+      mutt_buffer_addstr(tmpbuf, pbuf);
+      FREE(&searchbuf);
+      searchbuf = mutt_buffer_strdup(tmpbuf);
+      mutt_buffer_reset(tmpbuf);
+    }
+
+    /* write edited line to output file */
+    fputs(searchbuf, fp_out);
+    fputs("\n", fp_out);
+    FREE(&searchbuf);
+  }
+
+  mutt_file_set_mtime(mutt_buffer_string(filename), mutt_buffer_string(tmpfile));
+
+  /* add filename to TempAtachmentsList so it doesn't get left lying around */
+  mutt_add_temp_attachment(mutt_buffer_string(filename));
+  /* update filename to point to new file */
+  mutt_buffer_copy(filename, tmpfile);
+
+bail:
+  FREE(&buf);
+  mutt_file_fclose(&fp_in);
+  mutt_file_fclose(&fp_out);
+  mutt_buffer_pool_release(&tmpfile);
+  mutt_buffer_pool_release(&tmpbuf);
 }

--- a/attach/cid.c
+++ b/attach/cid.c
@@ -28,7 +28,13 @@
 
 #include "config.h"
 #include <stddef.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include "email/lib.h"
 #include "cid.h"
+#include "attach.h"
+#include "mailcap.h"
+#include "mutt_attach.h"
 
 /**
  * cid_map_free - Free a CidMap
@@ -80,5 +86,75 @@ void cid_map_list_clear(struct CidMapList *cid_map_list)
     struct CidMap *cid_map = STAILQ_FIRST(cid_map_list);
     STAILQ_REMOVE_HEAD(cid_map_list, entries);
     cid_map_free(&cid_map);
+  }
+}
+
+/**
+ * cid_save_attachment - Save attachment if it has a Content-ID
+ * @param[in]  body         Body to check and save
+ * @param[out] cid_map_list List of Content-ID to filename mappings
+ *
+ * If body has a Content-ID, it is saved to disk and a new Content-ID to filename
+ * mapping is added to cid_map_list.
+ */
+static void cid_save_attachment(struct Body *body, struct CidMapList *cid_map_list)
+{
+  if (!body || !cid_map_list)
+    return;
+
+  char *id = mutt_param_get(&body->parameter, "content-id");
+  if (!id)
+    return;
+
+  struct Buffer *tmpfile = mutt_buffer_pool_get();
+  struct Buffer *cid = mutt_buffer_pool_get();
+  bool has_tempfile = false;
+  FILE *fp = NULL;
+
+  mutt_debug(LL_DEBUG2, "attachment found with \"Content-ID: %s\"\n", id);
+  /* get filename */
+  char *fname = mutt_str_dup(body->filename);
+  if (body->aptr)
+    fp = body->aptr->fp;
+  mutt_file_sanitize_filename(fname, fp ? true : false);
+  mailcap_expand_filename("%s", fname, tmpfile);
+  FREE(&fname);
+
+  /* save attachment */
+  if (mutt_save_attachment(fp, body, mutt_buffer_string(tmpfile), 0, NULL) == -1)
+    goto bail;
+  has_tempfile = true;
+  mutt_debug(LL_DEBUG2, "attachment with \"Content-ID: %s\" saved to file \"%s\"\n",
+             id, mutt_buffer_string(tmpfile));
+
+  /* add Content-ID to filename mapping to list */
+  mutt_buffer_printf(cid, "cid:%s", id);
+  struct CidMap *cid_map = cid_map_new(mutt_buffer_string(cid), mutt_buffer_string(tmpfile));
+  STAILQ_INSERT_TAIL(cid_map_list, cid_map, entries);
+
+bail:
+
+  if ((fp && !mutt_buffer_is_empty(tmpfile)) || has_tempfile)
+    mutt_add_temp_attachment(mutt_buffer_string(tmpfile));
+  mutt_buffer_pool_release(&tmpfile);
+  mutt_buffer_pool_release(&cid);
+}
+
+/**
+ * cid_save_attachments - Save all attachments in a "multipart/related" group with a Content-ID
+ * @param[in]  body         First body in "multipart/related" group
+ * @param[out] cid_map_list List of Content-ID to filename mappings
+ */
+void cid_save_attachments(struct Body *body, struct CidMapList *cid_map_list)
+{
+  if (!body || !cid_map_list)
+    return;
+
+  for (struct Body *b = body; b; b = b->next)
+  {
+    if (b->parts)
+      cid_save_attachments(b->parts, cid_map_list);
+    else
+      cid_save_attachment(b, cid_map_list);
   }
 }

--- a/attach/cid.h
+++ b/attach/cid.h
@@ -1,0 +1,44 @@
+/**
+ * @file
+ * Attachment Content-ID header functions
+ *
+ * @authors
+ * Copyright (C) 2022 David Purton <dcpurton@marshwiggle.net>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MUTT_ATTACH_CID_H
+#define MUTT_ATTACH_CID_H
+
+#include "config.h"
+#include "mutt/lib.h"
+
+/**
+ * struct CidMap - List of Content-ID to filename mappings
+ */
+struct CidMap
+{
+  char *cid;                    ///< Content-ID
+  char *fname;                  ///< Filename
+  STAILQ_ENTRY(CidMap) entries; ///< Linked list
+};
+STAILQ_HEAD(CidMapList, CidMap);
+
+void           cid_map_free        (struct CidMap **ptr);
+struct CidMap *cid_map_new         (const char *cid, const char *filename);
+void           cid_map_list_clear  (struct CidMapList *cid_map_list);
+
+#endif /* MUTT_ATTACH_CID_H */

--- a/attach/cid.h
+++ b/attach/cid.h
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "mutt/lib.h"
 
+struct Body;
+
 /**
  * struct CidMap - List of Content-ID to filename mappings
  */
@@ -40,5 +42,7 @@ STAILQ_HEAD(CidMapList, CidMap);
 void           cid_map_free        (struct CidMap **ptr);
 struct CidMap *cid_map_new         (const char *cid, const char *filename);
 void           cid_map_list_clear  (struct CidMapList *cid_map_list);
+void           cid_save_attachments(struct Body *body,
+                                    struct CidMapList *cid_map_list);
 
 #endif /* MUTT_ATTACH_CID_H */

--- a/attach/cid.h
+++ b/attach/cid.h
@@ -44,5 +44,7 @@ struct CidMap *cid_map_new         (const char *cid, const char *filename);
 void           cid_map_list_clear  (struct CidMapList *cid_map_list);
 void           cid_save_attachments(struct Body *body,
                                     struct CidMapList *cid_map_list);
+void           cid_to_filename     (struct Buffer *filename,
+                                    const struct CidMapList *cid_map_list);
 
 #endif /* MUTT_ATTACH_CID_H */

--- a/attach/lib.c
+++ b/attach/lib.c
@@ -27,7 +27,9 @@
  */
 
 #include "config.h"
+#include <stddef.h>
 #include <stdbool.h>
+#include "mutt/lib.h"
 #include "email/lib.h"
 
 /**
@@ -101,6 +103,32 @@ bool attach_body_parent(struct Body *start, struct Body *start_parent,
   }
 
   return false;
+}
+
+/**
+ * attach_body_ancestor - Find the ancestor of a body with specified subtype
+ * @param[in] start         Body to start search from
+ * @param[in] body          Body to find ancestor of
+ * @param[in] subtype       Mime subtype of ancestor to find
+ * @retval    body_ancestor Body ancestor if found
+ * @retval    NULL          If ancestor body not found
+ */
+struct Body *attach_body_ancestor(struct Body *start, struct Body *body, const char *subtype)
+{
+  if (!start || !body)
+    return false;
+
+  struct Body *b = body;
+  struct Body *b_parent = NULL;
+
+  while (attach_body_parent(start, NULL, b, &b_parent))
+  {
+    if (mutt_str_equal(subtype, b_parent->subtype))
+      return b_parent;
+    b = b_parent;
+  }
+
+  return NULL;
 }
 
 /**

--- a/attach/lib.h
+++ b/attach/lib.h
@@ -29,6 +29,7 @@
  * | :-------------------- | :--------------------------- |
  * | attach/attach.c       | @subpage attach_attach       |
  * | attach/attachments.c  | @subpage attach_attachments  |
+ * | attach/cid.c          | @subpage attach_cid          |
  * | attach/dlg_attach.c   | @subpage attach_dlg_attach   |
  * | attach/functions.c    | @subpage attach_functions    |
  * | attach/lib.c          | @subpage attach_lib          |

--- a/attach/lib.h
+++ b/attach/lib.h
@@ -53,11 +53,13 @@
 struct Body;
 struct Buffer;
 
-int  attach_body_count   (struct Body *body, bool recurse);
-bool attach_body_parent  (struct Body *start, struct Body *start_parent,
-                          struct Body *body, struct Body **body_parent);
-bool attach_body_previous(struct Body *start, struct Body *body,
-                          struct Body **previous);
+int          attach_body_count   (struct Body *body, bool recurse);
+bool         attach_body_parent  (struct Body *start, struct Body *start_parent,
+                                  struct Body *body, struct Body **body_parent);
+struct Body *attach_body_ancestor(struct Body *start, struct Body *body,
+                                  const char *subtype);
+bool         attach_body_previous(struct Body *start, struct Body *body,
+                                  struct Body **previous);
 
 enum CommandResult parse_attachments  (struct Buffer *buf, struct Buffer *s, intptr_t data, struct Buffer *err);
 enum CommandResult parse_unattachments(struct Buffer *buf, struct Buffer *s, intptr_t data, struct Buffer *err);


### PR DESCRIPTION
## What does this PR do?

When viewing a `text/html` part within a `multipart/related` group, this PR adds support for writing out all attachments with a Content-ID header and mapping `cid` references to filenames in the `text/html` part.

### Implementation notes

- The logic of `save_cid_attachment()` is similar to the code that saves the attachment in `mutt_view_attachment()`.
- The logic of `map_cid_to_filename()` is similar to the code that edits an attachment in `mutt_rfc3676_space_unstuff_attachment()`.

### Linked issues and discussions

- #3209
- #3168

## Testing

Call the following `rc` file using `./neomutt -n -F view-related.rc` from within the build directory.

A `multipart/related` email with an embedded image is created, postponed, and then its `text/html` part viewed.

If it worked (and you have an appropriate `mailcap` entry for `text/html`), you should see:

![neomutt-256](https://user-images.githubusercontent.com/6268044/164979489-c9474305-bd12-4908-88da-8990f7550e44.png)

```
# vim: syn=neomuttrc

# filename: view-related.rc

# run from build directory:
#   ./neomutt -n -F view-related.rc

unset record
unset signature

set attach_format = "%u%D%I %t%4n %T%.40d%> [%.15m/%.15M, %.6e%?C?, %C?, %s]"
set folder = "./"
set from = "john.doe@example.com"
set help = no
set postpone = no
set postponed = "postponed.mbox"
set realname = "John Doe"
set recall = no
set spoolfile = "inbox.mbox"
set wait_key = no

set editor = "echo '![](cid:neomutt-256.png)' >> %s"

push "<view-attachments>3<enter><enter>"
push "<postpone-message><change-folder>postponed.mbox<enter>"
push "<group-related>"
push "<tag-entry>4<enter><tag-entry>"
push "<group-alternatives>"
push "1<enter><tag-entry>"
push "<toggle-disposition><toggle-unlink><tag-entry>"
push "<attach-file>/tmp/neomutt-alternative.html<enter>"
push "1<enter><pipe-entry>pandoc -o /tmp/neomutt-alternative.html<enter>"
push "<edit-content-id>\Cuneomutt-256.png<enter>"
push "<rename-attachment><enter>"
push "<toggle-disposition>"
push "<attach-file>contrib/logo/neomutt-256.png<enter>"
push "view multipart/related test<enter>"
push "<mail>John Doe <john.doe@example.com><enter>"
```