### PR TITLE
Fix parsing of sendmail cmd

### DIFF
--- a/send/sendmail.c
+++ b/send/sendmail.c
@@ -366,6 +366,7 @@ int mutt_invoke_sendmail(struct Mailbox *m, struct AddressList *from,
       while ((ps = strtok(ps, " ")))
       {
         ARRAY_ADD(&extra_args, ps);
+        ps = NULL;
       }
     }
 


### PR DESCRIPTION
Steps to reproduce:
- set sendmail to "x -- a"
- try to send a mail
- NeoMutt hangs

