### PR TITLE
fix status_on_top for complex windows

### DIFF
--- a/compose/compose.c
+++ b/compose/compose.c
@@ -138,19 +138,7 @@ static int compose_config_observer(struct NotifyCallback *nc)
   if (!mutt_str_equal(ev_c->name, "status_on_top"))
     return 0;
 
-  struct MuttWindow *win_cbar = window_find_child(dlg, WT_STATUS_BAR);
-  if (!win_cbar)
-    return 0;
-
-  TAILQ_REMOVE(&dlg->children, win_cbar, entries);
-
-  const bool c_status_on_top = cs_subset_bool(ev_c->sub, "status_on_top");
-  if (c_status_on_top)
-    TAILQ_INSERT_HEAD(&dlg->children, win_cbar, entries);
-  else
-    TAILQ_INSERT_TAIL(&dlg->children, win_cbar, entries);
-
-  mutt_window_reflow(dlg);
+  window_status_on_top(dlg, NeoMutt->sub);
   mutt_debug(LL_DEBUG5, "config done, request WA_REFLOW\n");
   return 0;
 }

--- a/gui/mutt_window.c
+++ b/gui/mutt_window.c
@@ -760,18 +760,27 @@ bool window_status_on_top(struct MuttWindow *panel, struct ConfigSubset *sub)
 {
   const bool c_status_on_top = cs_subset_bool(sub, "status_on_top");
 
-  struct MuttWindow *win_first = TAILQ_FIRST(&panel->children);
+  struct MuttWindow *win = TAILQ_FIRST(&panel->children);
 
-  if ((c_status_on_top && (win_first->type == WT_STATUS_BAR)) ||
-      (!c_status_on_top && (win_first->type != WT_STATUS_BAR)))
+  if ((c_status_on_top && (win->type == WT_STATUS_BAR)) ||
+      (!c_status_on_top && (win->type != WT_STATUS_BAR)))
   {
     return false;
   }
 
-  TAILQ_REMOVE(&panel->children, win_first, entries);
-  TAILQ_INSERT_TAIL(&panel->children, win_first, entries);
+  if (c_status_on_top)
+  {
+    win = TAILQ_LAST(&panel->children, MuttWindowList);
+    TAILQ_REMOVE(&panel->children, win, entries);
+    TAILQ_INSERT_HEAD(&panel->children, win, entries);
+  }
+  else
+  {
+    TAILQ_REMOVE(&panel->children, win, entries);
+    TAILQ_INSERT_TAIL(&panel->children, win, entries);
+  }
 
   mutt_window_reflow(panel);
-  mutt_debug(LL_DEBUG5, "config done, request WA_REFLOW\n");
+  window_invalidate_all();
   return true;
 }


### PR DESCRIPTION
Improve the status_on_top logic for non-trivial window, e.g. compose.

**Config**:
- Bind <kbd>\<F5\></kbd> to `toggle status_on_top`
- Bind <kbd>\<F6\></kbd> to `toggle help`
```
macro alias,attach,autocrypt,browser,compose,editor,generic,index,key_select_pgp,key_select_smime,mix,pager,pgp,postpone,query,smime <F5> "<enter-command>toggle status_on_top<enter>"
macro alias,attach,autocrypt,browser,compose,editor,generic,index,key_select_pgp,key_select_smime,mix,pager,pgp,postpone,query,smime <F6> "<enter-command>toggle help<enter>"
```

**Steps**:
- Open a dialog, e.g. compose
- Hit <kbd>\<F5\></kbd> and <kbd>\<F6\></kbd> a lot

**Results**:
- Screen looks correct (no duplicate status bars, etc)
- Pressing <kbd>Ctrl-L</kbd> doesn't show any changes