### PR TITLE
Fix off-by-one error in progress during IMAP fetch

### DIFF
--- a/imap/edata.c
+++ b/imap/edata.c
@@ -67,3 +67,17 @@ struct ImapEmailData *imap_edata_get(struct Email *e)
     return NULL;
   return e->edata;
 }
+
+/**
+ * imap_edata_clone - Clone an ImapEmailData
+ * @param src The source ImapEmailData to clone
+ * @retval ptr New ImapEmailData
+ */
+struct ImapEmailData *imap_edata_clone(struct ImapEmailData *src)
+{
+  struct ImapEmailData *dst = imap_edata_new();
+  memcpy(dst, src, sizeof(*src));
+  dst->flags_system = mutt_str_dup(src->flags_system);
+  dst->flags_remote = mutt_str_dup(src->flags_remote);
+  return dst;
+}

--- a/imap/edata.h
+++ b/imap/edata.h
@@ -51,5 +51,6 @@ struct ImapEmailData
 void                  imap_edata_free(void **ptr);
 struct ImapEmailData *imap_edata_get (struct Email *e);
 struct ImapEmailData *imap_edata_new (void);
+struct ImapEmailData *imap_edata_clone(struct ImapEmailData *src);
 
 #endif /* MUTT_IMAP_EDATA_H */


### PR DESCRIPTION
We have three nested loops here:

1. separate chunks (see imap_fetch_chunk_size)
2. messages within one chunk + handle the datastructures for loop 3
3. responses from the server until we get a message

Loop 2 was entered a last time after all messages were fetched. I have
moved the call to progress_update to where we are sure we are handling a
new message, moved the exit condition at the end of loop 3 and turned
loop 2 into a while (true) to make it clear that the exit condition is
elsewhere.

Fixes #3389