### PR TITLE
Don't free and forget queued macro/key events in mutt_endwin

### DIFF
--- a/gui/curs_lib.c
+++ b/gui/curs_lib.c
@@ -475,9 +475,6 @@ void mutt_endwin(void)
   mutt_refresh();
   endwin();
 
-  ARRAY_FREE(&MacroEvents);
-  ARRAY_FREE(&UngetKeyEvents);
-
   errno = e;
 }
 


### PR DESCRIPTION
We use mutt_endwin whenever we need to switch to another program, e.g.,
set pager=vim, pinentry, etc... In #3318 I wrongly assumed that the
function would only be called on exit, so I hooked the cleanup and
freeing of queued macro and key events in it.
This caused the issue in #3398, where part of a macro was forgotten upon
calling an external program.

In this PR, I'm only removing the wrong cleanup. I'll keep the task of
moving the cleanup to a better spot for next time.

Fixes #3398
