### PR TITLE
Store credentials in the MacOS Keychain

### DIFF
--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -273,6 +273,9 @@ LIBCONNOBJS=	conn/config.o conn/connaccount.o conn/getdomain.o conn/raw.o \
 @if HAVE_SASL
 LIBCONNOBJS+=	conn/sasl.o
 @endif
+@if USE_MACOS_KEYCHAIN
+LIBCONNOBJS+=	conn/macos_keychain.o
+@endif
 @if USE_SSL
 LIBCONNOBJS+=	conn/dlg_verifycert.o
 @endif

--- a/auto.def
+++ b/auto.def
@@ -106,6 +106,8 @@ options {
   with-zlib:path            => "Location of zlib"
   zstd=0                    => "Enable Zstandard header cache compression support"
   with-zstd:path            => "Location of Zstandard"
+# MacOS
+  macoskeychain=0           => "Use MacOS's Keychain for authentication"
 # System
   with-sysroot:path         => "Target system root"
   with-tmpdir:=/tmp         => "location of the tmp directory"
@@ -156,7 +158,7 @@ if {1} {
     debug-graphviz debug-notify debug-parse-test debug-queue debug-window doc
     everything fmemopen full-doc fuzzing gdbm gnutls gpgme gss homespool idn
     idn2 include-path-in-cflags inotify kyotocabinet lmdb locales-fix lua lz4
-    mixmaster nls notmuch pcre2 pgp pkgconf qdbm rocksdb sasl smime sqlite ssl
+    mixmaster nls notmuch macoskeychain pcre2 pgp pkgconf qdbm rocksdb sasl smime sqlite ssl
     testing tdb tokyocabinet zlib zstd
   } {
     define want-$opt [opt-bool $opt]
@@ -1199,6 +1201,16 @@ if {[get-define want-gss]} {
     define HAVE_HEIMDAL
   }
   define USE_GSS
+}
+
+###############################################################################
+# Use MacOS's Keychain for authentication
+if {[get-define want-macoskeychain]} {
+  if {![has-define {} __APPLE__]} {
+    user-error "This isn't a Mac"
+  }
+  define USE_MACOS_KEYCHAIN
+  define-append LDFLAGS -Wl,-framework -Wl,Security
 }
 
 ###############################################################################

--- a/conn/connaccount.c
+++ b/conn/connaccount.c
@@ -38,6 +38,9 @@
 #include "connaccount.h"
 #include "mutt_globals.h"
 #include "options.h"
+#ifdef USE_MACOS_KEYCHAIN
+#include "macos_keychain.h"
+#endif
 
 /**
  * mutt_account_getuser - Retrieve username into ConnAccount, if necessary
@@ -91,6 +94,10 @@ int mutt_account_getlogin(struct ConnAccount *cac)
     return -1;
 
   const char *login = cac->get_field(MUTT_CA_LOGIN, cac->gf_data);
+#ifdef USE_MACOS_KEYCHAIN
+  if (!login && (mutt_account_read_keychain(cac) == 0))
+    login = cac->user;
+#endif
   if (!login && (mutt_account_getuser(cac) == 0))
   {
     login = cac->user;
@@ -125,6 +132,10 @@ int mutt_account_getpass(struct ConnAccount *cac)
     mutt_str_copy(cac->pass, pass, sizeof(cac->pass));
   else if (OptNoCurses)
     return -1;
+#ifdef USE_MACOS_KEYCHAIN
+  else if (mutt_account_read_keychain(cac) == 0)
+    return 0;
+#endif
   else
   {
     char prompt[256];
@@ -135,6 +146,9 @@ int mutt_account_getpass(struct ConnAccount *cac)
     struct Buffer *buf = mutt_buffer_pool_get();
     const int rc = mutt_get_field_unbuffered(prompt, buf, MUTT_COMP_PASS);
     mutt_str_copy(cac->pass, mutt_buffer_string(buf), sizeof(cac->pass));
+#ifdef USE_MACOS_KEYCHAIN
+    mutt_account_write_keychain(cac);
+#endif
     mutt_buffer_pool_release(&buf);
     if (rc != 0)
       return -1;

--- a/conn/lib.h
+++ b/conn/lib.h
@@ -25,20 +25,21 @@
  *
  * Network connections and their encryption
  *
- * | File                | Description                  |
- * | :------------------ | :--------------------------- |
- * | conn/config.c       | @subpage conn_config         |
- * | conn/connaccount.c  | @subpage conn_account        |
- * | conn/getdomain.c    | @subpage conn_getdomain      |
- * | conn/gnutls.c       | @subpage conn_gnutls         |
- * | conn/gui.c          | @subpage conn_dlg_verifycert |
- * | conn/openssl.c      | @subpage conn_openssl        |
- * | conn/raw.c          | @subpage conn_raw            |
- * | conn/sasl.c         | @subpage conn_sasl           |
- * | conn/sasl_plain.c   | @subpage conn_sasl_plain     |
- * | conn/socket.c       | @subpage conn_socket         |
- * | conn/tunnel.c       | @subpage conn_tunnel         |
- * | conn/zstrm.c        | @subpage conn_zstrm          |
+ * | File                  | Description                  |
+ * | :-------------------- | :--------------------------- |
+ * | conn/config.c         | @subpage conn_config         |
+ * | conn/connaccount.c    | @subpage conn_account        |
+ * | conn/getdomain.c      | @subpage conn_getdomain      |
+ * | conn/gnutls.c         | @subpage conn_gnutls         |
+ * | conn/gui.c            | @subpage conn_dlg_verifycert |
+ * | conn/macos_keychain.c | @subpage conn_macos_keychain |
+ * | conn/openssl.c        | @subpage conn_openssl        |
+ * | conn/raw.c            | @subpage conn_raw            |
+ * | conn/sasl.c           | @subpage conn_sasl           |
+ * | conn/sasl_plain.c     | @subpage conn_sasl_plain     |
+ * | conn/socket.c         | @subpage conn_socket         |
+ * | conn/tunnel.c         | @subpage conn_tunnel         |
+ * | conn/zstrm.c          | @subpage conn_zstrm          |
  */
 
 #ifndef MUTT_CONN_LIB_H

--- a/conn/macos_keychain.c
+++ b/conn/macos_keychain.c
@@ -1,0 +1,222 @@
+/**
+ * @file
+ * Credential management via macOS Keychain
+ *
+ * @authors
+ * Copyright (C) 2022 Ramkumar Ramachandra <r@artagnon.com>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @page conn_macos_keychain Read/write macOS Keychain credentials
+ *
+ * Called by mutt_account_getuser() and mutt_user_getpass() as an alternative to
+ * storing/retrieving credentials in the configutation file, or entering them in
+ * the prompt repeatedly. A dialog will automatically pop up requesting permissions
+ * on macOS the very first time.
+ *
+ * Enabled using the configure option '--macoskeychain'.
+ */
+
+#include <Security/Security.h>
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "mutt/lib.h"
+#include "connaccount.h"
+#include "mutt_account.h"
+
+/**
+ * struct Credential - A bunch of pointers that act as a lens into ConnAccount,
+ *                     filtering out only the information relevant to keychain.
+ */
+struct Credential
+{
+  SecProtocolType protocol; ///< Connection type, e.g. HTTP
+  UInt16 port;              ///< Port to connect to
+  const char *host;         ///< Server to login to
+  const char *user;         ///< Username
+  const char *pass;         ///< Password
+};
+
+#define KEYCHAIN_ITEM(x) mutt_str_len(x), x
+
+/**
+ * find_username_in_item - Find the username in a given SecKeychainItem
+ * @param item   A reference to the security keychain item
+ * @param user   A pre-allocated buffer into which to write the username
+ * @param buflen The length of the pre-allocated user buffer
+ * @retval 0 on success, a specialized error-code on failure
+ */
+static int find_username_in_item(SecKeychainItemRef item, char *user, unsigned buflen)
+{
+  SecKeychainAttributeList list = { 0 };
+  SecKeychainAttribute attr = { 0 };
+
+  list.count = 1;
+  list.attr = &attr;
+  attr.tag = kSecAccountItemAttr;
+
+  int rc = SecKeychainItemCopyContent(item, NULL, &list, NULL, NULL);
+  if (rc != 0)
+    return rc;
+
+  assert(attr.length + 1 <= buflen && "Did you modify the keychain item by hand?");
+  mutt_str_copy(user, attr.data, attr.length + 1);
+
+  SecKeychainItemFreeContent(&list, NULL);
+  return rc;
+}
+
+/**
+ * find_internet_password - Find a username/password pair in keychain
+ * @param user     A pre-allocated buffer into which to write the username
+ * @param user_len The length of the pre-allocated user buffer
+ * @param pass     A pre-allocated buffer into which to write the password
+ * @param pass_len The length of the pre-allocated pass buffer
+ * @param cred     A Credential object with partial data to look up in keychain
+ * @retval 0 on success, a specialized error-code on failure
+ */
+static int find_internet_password(char *user, unsigned user_len, char *pass,
+                                  unsigned pass_len, struct Credential cred)
+{
+  void *buf = NULL;
+  UInt32 len = 0;
+  SecKeychainItemRef item = NULL;
+  int rc = 0;
+
+  rc = SecKeychainFindInternetPassword(NULL, /* default keychain */
+                                       KEYCHAIN_ITEM(cred.host), 0, NULL, /* account domain */
+                                       KEYCHAIN_ITEM(cred.user), 0, NULL, cred.port,
+                                       cred.protocol, kSecAuthenticationTypeDefault,
+                                       &len, &buf, &item);
+  if (rc != 0)
+    return rc;
+
+  // guard against buffer overflow
+  assert(len + 1 <= pass_len && "Did you modify the keychain item by hand?");
+
+  // Keychain does not send the password with null-terminator
+  mutt_str_copy(pass, buf, len + 1);
+  if (!cred.user)
+    rc = find_username_in_item(item, user, user_len);
+
+  SecKeychainItemFreeContent(NULL, buf);
+  return rc;
+}
+
+/**
+ * add_internet_password - Add a credential to the keychain
+ * @param cred A credential object to insert
+ * @retval 0 on success, a specialized error-code on failure
+ */
+static int add_internet_password(struct Credential cred)
+{
+  /* Only store complete credentials */
+  if (!cred.protocol || !cred.host || !cred.user || !cred.pass)
+    return -1;
+  return SecKeychainAddInternetPassword(NULL, /* default keychain */
+                                        KEYCHAIN_ITEM(cred.host), 0, NULL, /* account domain */
+                                        KEYCHAIN_ITEM(cred.user), 0, NULL, cred.port,
+                                        cred.protocol, kSecAuthenticationTypeDefault,
+                                        KEYCHAIN_ITEM(cred.pass), NULL);
+}
+
+/**
+ * conn_account_to_cred - Copy relevant fields from a ConnAccount struct to a Credential struct
+ * @param account A connection account, as defined in connaccount.h
+ * @retval ptr Credential
+ */
+static struct Credential conn_account_to_cred(struct ConnAccount *account)
+{
+  struct Credential cred = { 0 };
+  switch (account->type)
+  {
+    case MUTT_ACCT_TYPE_NONE:
+      assert(false && "Unreachable");
+    case MUTT_ACCT_TYPE_IMAP:
+      cred.protocol = account->flags & MUTT_ACCT_SSL ? kSecProtocolTypeIMAPS :
+                                                       kSecProtocolTypeIMAP;
+      break;
+    case MUTT_ACCT_TYPE_POP:
+      cred.protocol = account->flags & MUTT_ACCT_SSL ? kSecProtocolTypePOP3S :
+                                                       kSecProtocolTypePOP3;
+      break;
+    case MUTT_ACCT_TYPE_SMTP:
+      cred.protocol = kSecProtocolTypeSMTP;
+      break;
+    case MUTT_ACCT_TYPE_NNTP:
+      cred.protocol = account->flags & MUTT_ACCT_SSL ? kSecProtocolTypeNNTPS :
+                                                       kSecProtocolTypeNNTP;
+      break;
+  }
+  cred.user = account->user;
+  cred.pass = account->pass;
+  cred.port = account->port;
+  cred.host = account->host;
+  return cred;
+}
+
+/**
+ * mutt_account_write_keychain - Write the relevant data from a pre-filled connection account to keychain
+ * @param account A connection account, as defined in connaccount.h
+ * @retval  0 Success
+ * @retval -1 Failure
+ */
+int mutt_account_write_keychain(struct ConnAccount *account)
+{
+  if (!account || (account->type == MUTT_ACCT_TYPE_NONE))
+    return -1;
+  struct Credential cred = conn_account_to_cred(account);
+
+  // Find more error codes in SecBase.h, and write appropriate errors
+  int rc = add_internet_password(cred);
+  switch (rc)
+  {
+    case errSecSuccess:
+      return 0;
+    case errSecDuplicateItem:
+      mutt_error(_("Duplicate item in keychain"));
+    default:
+      mutt_error(_("Error code from keychain add: %d"), rc);
+  }
+  return -1;
+}
+
+/**
+ * mutt_account_read_keychain - Read user/pass into a paritially-filled connection account from keychain
+ * @param account A connection account, as defined in connaccount.h
+ * @retval  0 Success
+ * @retval -1 Failure
+ */
+int mutt_account_read_keychain(struct ConnAccount *account)
+{
+  if (!account || (account->type == MUTT_ACCT_TYPE_NONE))
+    return -1;
+  struct Credential cred = conn_account_to_cred(account);
+
+  int rc = find_internet_password(account->user, sizeof(account->user),
+                                  account->pass, sizeof(account->pass), cred);
+  switch (rc)
+  {
+    case errSecSuccess:
+      return 0;
+    default:
+      mutt_message(_("Missing credentials for %s in keychain"), account->host);
+  }
+  return -1;
+}

--- a/conn/macos_keychain.h
+++ b/conn/macos_keychain.h
@@ -1,0 +1,31 @@
+/**
+ * @file
+ * Credential management via macOS Keychain
+ *
+ * @authors
+ * Copyright (C) 2022 Ramkumar Ramachandra <r@artagnon.com>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MUTT_CONN_MACOS_KEYCHAIN_H
+#define MUTT_CONN_MACOS_KEYCHAIN_H
+
+struct ConnAccount;
+
+int mutt_account_read_keychain (struct ConnAccount *account);
+int mutt_account_write_keychain(struct ConnAccount *account);
+
+#endif /* MUTT_CONN_MACOS_KEYCHAIN_H */


### PR DESCRIPTION
This is PR #3189, reopened.

On macOS, all passwords are managed centrally in a program known as Keychain.
This patch proposes to integrate neomutt with Keychain, to avoid storing even encrypted passwords in plain text files.
The code has been adapted from a similar (successful) effort in git.git, originally authored by Jeff King.