### PR TITLE
menu: allow the user to quit generic menus

### DIFF
--- a/conn/dlg_verifycert.c
+++ b/conn/dlg_verifycert.c
@@ -252,7 +252,11 @@ int dlg_verify_certificate(const char *title, struct CertArray *carr,
     // Try to catch dialog keys before ops
     if (menu_dialog_dokey(menu, &op) != 0)
     {
-      op = km_dokey(MENU_GENERIC);
+      struct KeyEvent event = km_dokey_event(MENU_GENERIC);
+      if (event.ch == 'q')
+        op = OP_EXIT;
+      else
+        op = event.op;
     }
 
     if (op == OP_TIMEOUT)

--- a/history/dlg_history.c
+++ b/history/dlg_history.c
@@ -153,7 +153,12 @@ void dlg_select_history(char *buf, size_t buflen, char **matches, int match_coun
     menu_tagging_dispatcher(menu->win, op);
     window_redraw(NULL);
 
-    op = km_dokey(MENU_GENERIC);
+    struct KeyEvent event = km_dokey_event(MENU_GENERIC);
+    if (event.ch == 'q')
+      op = OP_EXIT;
+    else
+      op = event.op;
+
     mutt_debug(LL_DEBUG1, "Got op %s (%d)\n", opcodes_get_name(op), op);
     if (op < 0)
       continue;

--- a/keymap.c
+++ b/keymap.c
@@ -620,7 +620,7 @@ static struct KeyEvent retry_generic(enum MenuType mtype, keycode_t *keys,
   {
     return km_dokey_event(MENU_GENERIC);
   }
-  if (mtype != MENU_EDITOR)
+  if ((mtype != MENU_EDITOR) && (mtype != MENU_GENERIC))
   {
     /* probably a good idea to flush input here so we can abort macros */
     mutt_flushinp();

--- a/pattern/dlg_pattern.c
+++ b/pattern/dlg_pattern.c
@@ -349,7 +349,12 @@ bool dlg_select_pattern(char *buf, size_t buflen)
     menu_tagging_dispatcher(menu->win, op);
     window_redraw(NULL);
 
-    op = km_dokey(MENU_GENERIC);
+    struct KeyEvent event = km_dokey_event(MENU_GENERIC);
+    if (event.ch == 'q')
+      op = OP_EXIT;
+    else
+      op = event.op;
+
     mutt_debug(LL_DEBUG1, "Got op %s (%d)\n", opcodes_get_name(op), op);
     if (op < 0)
       continue;


### PR DESCRIPTION
Recent key-handling changes have left the user unable to quit from the three generic dialogs:
- Verify Certificate Dialog
- History Dialog
- Pattern Dialog

This PR changes those dialogs to accept <kbd>q</kbd> as `<exit>`

The bit I'm not certain about is the change to `retry_generic()`.

Before the change, the `q` keypress is pushed into the queue:
```c
  if (lastkey)
    mutt_unget_ch(lastkey);
```
but then dumped:
```c
  if (mtype != MENU_EDITOR)
  {
    /* probably a good idea to flush input here so we can abort macros */
    mutt_flushinp();
  }
```
meaning that:
```c
  return (struct KeyEvent){ .ch = mutt_getch().ch, .op = OP_NULL };
```
hangs, waiting for the user to hit <kbd>q</kbd> a second time.