### PR TITLE
Implement account_command

### DIFF
--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -268,8 +268,9 @@ $(PWD)/config:
 ###############################################################################
 # libconn
 LIBCONN=	libconn.a
-LIBCONNOBJS=	conn/config.o conn/connaccount.o conn/getdomain.o conn/raw.o \
-		conn/sasl_plain.o conn/socket.o conn/tunnel.o
+LIBCONNOBJS=	conn/accountcmd.o conn/config.o conn/connaccount.o \
+		conn/getdomain.o conn/raw.o conn/sasl_plain.o conn/socket.o \
+		conn/tunnel.o 
 @if HAVE_SASL
 LIBCONNOBJS+=	conn/sasl.o
 @endif

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ sorted through them, fixed them up and documented them.
 
 | Name                     | Description
 | ------------------------ | ------------------------------------------------------
+| Account Command          | Populate account credentials via an external command
 | Attach Headers Color     | Color attachment headers using regex, just like mail bodies
 | Compose to Sender        | Send new mail to the sender of the current mail
 | Compressed Folders       | Read from/write to compressed mailboxes

--- a/conn/accountcmd.c
+++ b/conn/accountcmd.c
@@ -1,0 +1,185 @@
+/**
+ * @file
+ * Connection Credentials External Command
+ *
+ * @authors
+ * Copyright (C) 2022 Pietro Cerutti <gahr@gahr.ch>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @page conn_account_ext_cmd Connection Credentials External Command
+ *
+ * Connection Credentials External Command
+ */
+
+#include "config.h"
+#include <assert.h>
+#include <stdio.h>
+#include <sys/types.h>
+#include "mutt/lib.h"
+#include "config/lib.h"
+#include "core/lib.h"
+#include "accountcmd.h"
+#include "mutt_account.h"
+
+/**
+ * make_cmd - Build the command line for the external account command.
+ * @param buf Buffer to fill with a command line
+ * @param cac ConnAccount to read params from
+ * @param cmd Account command from the user config
+ */
+static void make_cmd(struct Buffer *buf, const struct ConnAccount *cac, const char *cmd)
+{
+  assert(buf && cac);
+
+  mutt_buffer_addstr(buf, cmd);
+  mutt_buffer_add_printf(buf, " --hostname %s", cac->host);
+  if (cac->flags & MUTT_ACCT_USER)
+  {
+    mutt_buffer_add_printf(buf, " --username %s", cac->user);
+  }
+
+  static const char *types[] = { "", "imap", "pop", "smtp", "nntp" };
+  assert(sizeof(types) / sizeof(*types) == MUTT_ACCT_TYPE_MAX);
+  if (cac->type != MUTT_ACCT_TYPE_NONE)
+  {
+    mutt_buffer_add_printf(buf, " --type %s%c", types[cac->type],
+                           (cac->flags & MUTT_ACCT_SSL) ? 's' : '\0');
+  }
+}
+
+/**
+ * parse_one - Parse a single line of the response
+ * @param cac ConnAccount to write to
+ * @param line Line from the response
+ * @retval num #MuttAccountFlags that matched
+ * @retval MUTT_ACCT_NO_FLAGS Failure
+ */
+static MuttAccountFlags parse_one(struct ConnAccount *cac, char *line)
+{
+  assert(cac && line);
+
+  const regmatch_t *match = mutt_prex_capture(PREX_ACCOUNT_CMD, line);
+  if (!match)
+  {
+    mutt_perror(_("Line is malformed: expected <key: val>, got <%s>"), line);
+    return MUTT_ACCT_NO_FLAGS;
+  }
+
+  const regmatch_t *keymatch = &match[PREX_ACCOUNT_CMD_MATCH_KEY];
+  const regmatch_t *valmatch = &match[PREX_ACCOUNT_CMD_MATCH_VALUE];
+  line[mutt_regmatch_start(keymatch) + mutt_regmatch_len(keymatch)] = '\0';
+  const char *key = line + mutt_regmatch_start(keymatch);
+  const char *val = line + mutt_regmatch_start(valmatch);
+
+  switch (key[0])
+  {
+    case 'l':
+      if (mutt_str_equal(key + 1, "ogin"))
+      {
+        mutt_str_copy(cac->login, val, sizeof(cac->login));
+        return MUTT_ACCT_LOGIN;
+      }
+      break;
+
+    case 'p':
+      if (mutt_str_equal(key + 1, "assword"))
+      {
+        mutt_str_copy(cac->pass, val, sizeof(cac->pass));
+        return MUTT_ACCT_PASS;
+      }
+      break;
+
+    case 'u':
+      if (mutt_str_equal(key + 1, "sername"))
+      {
+        mutt_str_copy(cac->user, val, sizeof(cac->user));
+        return MUTT_ACCT_USER;
+      }
+      break;
+
+    default:
+      break;
+  }
+
+  mutt_warning(_("Unhandled key in line <%s: %s>"), key, val);
+  return MUTT_ACCT_NO_FLAGS;
+}
+
+/**
+ * call_cmd - Call the account command
+ * @param cac ConnAccount to write to
+ * @param cmd Command line to run
+ * @retval num #MuttAccountFlags that matched
+ * @retval MUTT_ACCT_NO_FLAGS Failure
+ */
+static MuttAccountFlags call_cmd(struct ConnAccount *cac, const struct Buffer *cmd)
+{
+  assert(cac && cmd);
+
+  MuttAccountFlags rc = MUTT_ACCT_NO_FLAGS;
+
+  FILE *fp = NULL;
+  pid_t pid = filter_create(mutt_buffer_string(cmd), NULL, &fp, NULL);
+  if (pid < 0)
+  {
+    mutt_perror(_("Unable to run account command"));
+    return rc;
+  }
+
+  size_t len = 0;
+  char *line = NULL;
+  while ((line = mutt_file_read_line(NULL, &len, fp, NULL, MUTT_RL_NO_FLAGS)))
+  {
+    rc |= parse_one(cac, line);
+    FREE(&line);
+  }
+
+  mutt_file_fclose(&fp);
+  filter_wait(pid);
+  return rc;
+}
+
+/**
+ * mutt_account_call_external_cmd - Retrieve account credentials via an external command
+ * @param cac ConnAccount to fill
+ * @retval num A bitmask of MuttAccountFlags that were retrieved on success
+ * @retval MUTT_ACCT_NO_FLAGS Failure
+ */
+MuttAccountFlags mutt_account_call_external_cmd(struct ConnAccount *cac)
+{
+  if (!cac || (cac->host[0] == '\0') || (cac->type == MUTT_ACCT_TYPE_NONE))
+  {
+    return MUTT_ACCT_NO_FLAGS;
+  }
+
+  const char *c_account_command = cs_subset_string(NeoMutt->sub, "account_command");
+  if (!c_account_command)
+  {
+    return MUTT_ACCT_NO_FLAGS;
+  }
+
+  MuttAccountFlags rc = MUTT_ACCT_NO_FLAGS;
+  struct Buffer *cmd_buf = mutt_buffer_pool_get();
+
+  make_cmd(cmd_buf, cac, c_account_command);
+  rc = call_cmd(cac, cmd_buf);
+  cac->flags |= rc;
+
+  mutt_buffer_pool_release(&cmd_buf);
+  return rc;
+}

--- a/conn/accountcmd.h
+++ b/conn/accountcmd.h
@@ -1,0 +1,30 @@
+/**
+ * @file
+ * Connection Credentials External Command
+ *
+ * @authors
+ * Copyright (C) 2022 Pietro Cerutti <gahr@gahr.ch>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MUTT_CONN_ACCOUNTCMD_H
+#define MUTT_CONN_ACCOUNTCMD_H
+
+#include "connaccount.h"
+
+MuttAccountFlags mutt_account_call_external_cmd(struct ConnAccount *cac);
+
+#endif /* MUTT_CONN_ACCOUNTCMD_H */

--- a/conn/config.c
+++ b/conn/config.c
@@ -33,6 +33,9 @@
 
 static struct ConfigDef ConnVars[] = {
   // clang-format off
+  { "account_command", DT_STRING | DT_COMMAND, 0, 0, NULL,
+    "Shell command to retrieve account credentials"
+  },
   { "connect_timeout", DT_NUMBER, 30, 0, NULL,
     "Timeout for making network connections (-1 to wait indefinitely)"
   },

--- a/conn/connaccount.c
+++ b/conn/connaccount.c
@@ -36,6 +36,7 @@
 #include "gui/lib.h"
 #include "mutt.h"
 #include "connaccount.h"
+#include "accountcmd.h"
 #include "mutt_globals.h"
 #include "options.h"
 
@@ -54,9 +55,20 @@ int mutt_account_getuser(struct ConnAccount *cac)
 
   const char *user = cac->get_field(MUTT_CA_USER, cac->gf_data);
   if (user)
+  {
     mutt_str_copy(cac->user, user, sizeof(cac->user));
+  }
+  else if (mutt_account_call_external_cmd(cac) != MUTT_ACCT_NO_FLAGS)
+  {
+    /* The external command might interact with the screen */
+    if (!OptNoCurses)
+      mutt_need_hard_redraw();
+    return 0;
+  }
   else if (OptNoCurses)
+  {
     return -1;
+  }
   else
   {
     /* prompt (defaults to unix username), copy into cac->user */
@@ -122,9 +134,20 @@ int mutt_account_getpass(struct ConnAccount *cac)
 
   const char *pass = cac->get_field(MUTT_CA_PASS, cac->gf_data);
   if (pass)
+  {
     mutt_str_copy(cac->pass, pass, sizeof(cac->pass));
+  }
+  else if (mutt_account_call_external_cmd(cac) != MUTT_ACCT_NO_FLAGS)
+  {
+    /* The external command might interact with the screen */
+    if (!OptNoCurses)
+      mutt_need_hard_redraw();
+    return 0;
+  }
   else if (OptNoCurses)
+  {
     return -1;
+  }
   else
   {
     char prompt[256];

--- a/conn/lib.h
+++ b/conn/lib.h
@@ -25,20 +25,21 @@
  *
  * Network connections and their encryption
  *
- * | File                  | Description                  |
- * | :-------------------- | :--------------------------- |
- * | conn/config.c         | @subpage conn_config         |
- * | conn/connaccount.c    | @subpage conn_account        |
- * | conn/dlg_verifycert.c | @subpage conn_dlg_verifycert |
- * | conn/getdomain.c      | @subpage conn_getdomain      |
- * | conn/gnutls.c         | @subpage conn_gnutls         |
- * | conn/openssl.c        | @subpage conn_openssl        |
- * | conn/raw.c            | @subpage conn_raw            |
- * | conn/sasl.c           | @subpage conn_sasl           |
- * | conn/sasl_plain.c     | @subpage conn_sasl_plain     |
- * | conn/socket.c         | @subpage conn_socket         |
- * | conn/tunnel.c         | @subpage conn_tunnel         |
- * | conn/zstrm.c          | @subpage conn_zstrm          |
+ * | File                  | Description                   |
+ * | :-------------------- | :---------------------------- |
+ * | conn/accountcmd.c     | @subpage conn_account_ext_cmd |
+ * | conn/config.c         | @subpage conn_config          |
+ * | conn/connaccount.c    | @subpage conn_account         |
+ * | conn/dlg_verifycert.c | @subpage conn_dlg_verifycert  |
+ * | conn/getdomain.c      | @subpage conn_getdomain       |
+ * | conn/gnutls.c         | @subpage conn_gnutls          |
+ * | conn/openssl.c        | @subpage conn_openssl         |
+ * | conn/raw.c            | @subpage conn_raw             |
+ * | conn/sasl.c           | @subpage conn_sasl            |
+ * | conn/sasl_plain.c     | @subpage conn_sasl_plain      |
+ * | conn/socket.c         | @subpage conn_socket          |
+ * | conn/tunnel.c         | @subpage conn_tunnel          |
+ * | conn/zstrm.c          | @subpage conn_zstrm           |
  */
 
 #ifndef MUTT_CONN_LIB_H

--- a/docs/config.c
+++ b/docs/config.c
@@ -80,6 +80,19 @@
 ** to \fIno\fP, composition will never be aborted.
 */
 
+{ "account_command", DT_COMMAND, 0 },
+/*
+** .pp
+** If set, this command is used to retrieve account credentials. The command
+** is invoked passing a number of \fI--key value\fP arguments with the
+** specifics of the account to lookup. The command writes to standard output a
+** number of \fIkey: value\fP lines. Currently supported arguments are
+** \fI--hostname\fP, \fI--username\fP, and \fI--type\fP, where type can be
+** any of \fIimap\fP, \fIimaps\fP, \fIpop\fP, \fIpops\fP, \fIsmtp\fP,
+** \fIsmtps\fP, \fInntp\fP, and \fInntps\fP. Currently supported output lines
+** are \fIlogin\fP, \fIusername\fP, and \fIpassword\fP.
+*/
+
 { "alias_file", DT_PATH, "~/.neomuttrc" },
 /*
 ** .pp

--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -12552,6 +12552,121 @@ folder-hook imap://user@host2/ 'set folder=imap://host2/ ; set record=+INBOX/Sen
       </para>
     </sect1>
 
+    <sect1 id="account-cmd">
+      <title>Account Command Feature</title>
+      <subtitle>Populate account credentials via an external command</subtitle>
+
+      <sect2 id="account-cmd-support">
+        <title>Support</title>
+        <para><emphasis role="bold">Since:</emphasis> NeoMutt 2022-xx-yy</para>
+        <para><emphasis role="bold">Dependencies:</emphasis> None</para>
+      </sect2>
+
+      <sect2 id="account-cmd-intro">
+        <title>Introduction</title>
+        <para>
+          NeoMutt provides dedicated config variables to specify credentials
+          for network servers. These include <literal>imap_user</literal>,
+          <literal>imap_pass</literal>, <literal>smtp_user</literal>,
+          <literal>smtp_pass</literal>, etc.  There are a few downsides to this
+          approach. For one thing, their use encourages storing usernames and
+          passwords in plain text inside a NeoMutt config file. People have
+          come up with solutions to this, including using gpg-encrypted files
+          and populating <literal>my_</literal> variables via external scripts
+          through <literal>source "/path/to/script|"</literal>.
+          However, once the variables are set, the secrets can be inspected
+          with the <literal>set</literal> command.
+          Also, because these config variables are not account-specific, they
+          have been the cause of a proliferation of ways to mimic per-account
+          setups using a combination of convoluted hooks and macros to modify
+          them on on folder change or on a keypress.
+        </para>
+
+        <para>
+          The goal of this feature is to get rid of most <literal>_user</literal>
+          and <literal>_pass</literal> variables. To do so, we provide a way of
+          specifying an external command that NeoMutt will call to populate
+          account credentials for network servers such as IMAP, POP, or SMTP.
+          The external command is called with a number of arguments indicating
+          the known properties of the account such as the account type and
+          hostname; the external command provides NeoMutt with a list of
+          additional properties such as username and password.
+        </para>
+      </sect2>
+
+      <sect2 id="accound-cmd-usage">
+        <title>Usage</title>
+        <para>
+          The variable <literal>account_command</literal> configures an
+          external program to be used to gather account credentials.
+        </para>
+        <screen>set account_command = "/path/to/my/script.sh"</screen>
+        <para>
+          The program specified will be called by NeoMutt with a number of
+          key-value command line arguments.
+        </para>
+
+        <itemizedlist>
+          <listitem>
+            <para>
+              <literal>--hostname val</literal>: the network host name of the
+              service
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              <literal>--username val</literal>: the username for the account.
+              This might be specified in the URL itself, e.g.,
+              <literal>set folder="imaps://me@example.com@example.com"</literal> or
+              with a dedicated existing variable, e.g., 
+              <literal>set imap_user=me@example.com</literal>.
+            </para>
+          </listitem>
+          <listitem>
+            <para>
+              <literal>--type val</literal>: the type of the account, one of
+              <literal>imap</literal>, <literal>pop</literal>,
+              <literal>smtp</literal>, <literal>nntp</literal>, with an optional
+              trailing <literal>s</literal> if SSL/TLS is required.
+            </para>
+          </listitem>
+        </itemizedlist>
+
+        <para>
+          The program specified will have to respond by printing to stdout a
+          number of <literal>key: value</literal> lines. NeoMutt currently
+          recognizes the following keys.
+        </para>
+
+        <itemizedlist>
+          <listitem><para>login</para></listitem>
+          <listitem><para>username</para></listitem>
+          <listitem><para>password</para></listitem>
+        </itemizedlist>
+
+        <para>
+          Because password can contain any characters, including spaces, we
+          expect lines to match the regex <literal>^([[:alpha:]]+): (.*)$</literal>
+          exactly.
+        </para>
+      </sect2>
+
+      <sect2 id="account-cmd-known-bugs">
+        <title>Known Bugs</title>
+        <para>
+          None
+        </para>
+      </sect2>
+
+      <sect2 id="account-cmd-credits">
+        <title>Credits</title>
+        <para>
+          Pietro Cerutti
+        </para>
+      </sect2>
+
+    </sect1>
+
     <sect1 id="attach-headers-color">
       <title>Attach Headers Color Feature</title>
       <subtitle>Color attachment headers using regex, just like mail

--- a/mutt/prex.c
+++ b/mutt/prex.c
@@ -259,7 +259,12 @@ static struct PrexStorage *prex(enum Prex which)
         "|"
         "([[:digit:]]{2})"      // Year (YY)
       ")"
-    }
+    },
+    {
+      PREX_ACCOUNT_CMD,
+      PREX_ACCOUNT_CMD_MATCH_MAX,
+      "^([[:alpha:]]+): (.*)$"
+    },
     // clang-format on
   };
 

--- a/mutt/prex.h
+++ b/mutt/prex.h
@@ -39,6 +39,7 @@ enum Prex
   PREX_IMAP_DATE,             ///< `[16-MAR-2020 15:09:35 -0700]`
   PREX_MBOX_FROM,             ///< `[From god@heaven.af.mil Sat Jan  3 01:05:34 1996]`
   PREX_MBOX_FROM_LAX,         ///< `[From god@heaven.af.mil Sat Jan  3 01:05:34 1996]`
+  PREX_ACCOUNT_CMD,           ///< `key: value`
   PREX_MAX
 };
 
@@ -233,6 +234,17 @@ enum PrexMboxFromLax
   PREX_MBOX_FROM_LAX_MATCH_YEAR_4DIG,       ///< `From god@heaven.af.mil Sat Jan 10 01:05:34 [1996]`
   PREX_MBOX_FROM_LAX_MATCH_YEAR_2DIG,       ///< `From god@heaven.af.mil Sat Jan 10 01:05:34 [96]`
   PREX_MBOX_FROM_LAX_MATCH_MAX
+};
+
+/**
+ * enum PrexAccountCmd - Regex matches for the output lines of account_command
+ */
+enum PrexAccountCmd
+{
+  PREX_ACCOUNT_CMD_MATCH_FULL,  ///< `[key: value]`
+  PREX_ACCOUNT_CMD_MATCH_KEY,   ///< `[key]: value`
+  PREX_ACCOUNT_CMD_MATCH_VALUE, ///< `key: [value]`
+  PREX_ACCOUNT_CMD_MATCH_MAX
 };
 
 regmatch_t *mutt_prex_capture(enum Prex which, const char *str);

--- a/mutt_account.h
+++ b/mutt_account.h
@@ -38,6 +38,7 @@ enum AccountType
   MUTT_ACCT_TYPE_POP,      ///< Pop Account
   MUTT_ACCT_TYPE_SMTP,     ///< Smtp Account
   MUTT_ACCT_TYPE_NNTP,     ///< Nntp (Usenet) Account
+  MUTT_ACCT_TYPE_MAX
 };
 
 int   mutt_account_fromurl(struct ConnAccount *account, const struct Url *url);


### PR DESCRIPTION
This implements the proposal spec'd in #3405: it introduces a new
`account_command` config variable that can be set to the path of an
executable used to retrieve account credentials.

The following arguments to the script are produced:

* `--hostname`
* `--username`
* `--type` (`imap`, `pop`, `smtp`, `nntp`, with an optional trailing `s` for ssl)

The following keys are parsed from the command's output

* `login`
* `username`
* `password`

As an example, here's an account command that wraps [bwget](https://github.com/gahr/bwget):

```tcl

set entries {
    imap.fastmail.com     { me@fastmail.com   "^FastMail-Me$"
                            you@fastmail.com  "^FastMail-You$" }
    smtp.fastmail.com     { me@fastmail.com   "^FastMail-Me$"
                            you@fastmail.com  "^FastMail-You$" }
    outlook.office365.com { me@hotmail.com    "^Hotmail$"      }
    smtp.office365.com    { me@Hotmail.com    "^Hotmail$"      }
    imap.gmail.com        { me@gmail.com      "^Google$"       }
    smtp.gmail.com        { me@gmail.com      "^Google$"       }}

set host {}
set user {}
foreach {key val} $::argv {
    switch -exact -- $key {
        --hostname { set host $val }
        --username { set user $val }
    }
}

proc pass {entry} {
    set pfd [open "| bwget pass $entry"]
    set pass [read $pfd]
    close $pfd
    set pass
}

if {$host ne {} && $user ne {}} {
    set hostidx [lsearch -exact -stride 2 $entries $host]
    if {$hostidx != -1} {
        set sub [lindex $entries $hostidx+1]
        set useridx [lsearch -exact -stride 2 $sub $user]
        if {$useridx != -1} {
            puts "username: $user"
            puts "login: $user"
            puts "password: [pass [lindex $sub $useridx+1]]"
        }
    }
}
```

To use this, just set `imap_url` and `smtp_url` to `user@host`, and don't set
any of `imap_user`, `imap_pass`, `smtp_user`, or `smtp_pass`.