### PR TITLE
Put the MessageWindow users in Containers

### DIFF
--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -697,7 +697,7 @@ $(PWD)/postpone:
 ###############################################################################
 # libprogress
 LIBPROGRESS=	libprogress.a
-LIBPROGRESSOBJS=progress/progress.o
+LIBPROGRESSOBJS=	progress/progress.o progress/wdata.o progress/window.o
 CLEANFILES+=	$(LIBPROGRESS) $(LIBPROGRESSOBJS)
 ALLOBJS+=	$(LIBPROGRESSOBJS)
 

--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -401,7 +401,7 @@ $(PWD)/envelope:
 ###############################################################################
 # libgui
 LIBGUI=		libgui.a
-LIBGUIOBJS=	gui/curs_lib.o gui/dialog.o gui/global.o gui/msgwin.o \
+LIBGUIOBJS=	gui/curs_lib.o gui/dialog.o gui/global.o gui/msgcont.o gui/msgwin.o \
 		gui/mutt_curses.o gui/mutt_window.o gui/reflow.o gui/rootwin.o \
 		gui/sbar.o gui/simple.o gui/terminal.o
 CLEANFILES+=	$(LIBGUI) $(LIBGUIOBJS)

--- a/enter/functions.c
+++ b/enter/functions.c
@@ -690,13 +690,14 @@ struct EnterFunction EnterFunctions[] = {
 };
 
 /**
- * enter_function_dispatcher - Perform an Enter function
- * @param wdata Enter window data
- * @param op  Operation to perform, e.g. OP_ENTER_NEXT
- * @retval num #FunctionRetval, e.g. #FR_SUCCESS
+ * enter_function_dispatcher - Perform an Enter function - Implements ::function_dispatcher_t - @ingroup dispatcher_api
  */
-int enter_function_dispatcher(struct EnterWindowData *wdata, int op)
+int enter_function_dispatcher(struct MuttWindow *win, int op)
 {
+  if (!win || !win->wdata)
+    return FR_UNKNOWN;
+
+  struct EnterWindowData *wdata = win->wdata;
   if (!wdata)
     return FR_UNKNOWN;
 

--- a/enter/functions.h
+++ b/enter/functions.h
@@ -26,6 +26,7 @@
 #include <stdbool.h>
 
 struct EnterWindowData;
+struct MuttWindow;
 
 /**
  * @defgroup enter_function_api Enter Function API
@@ -49,7 +50,7 @@ struct EnterFunction
 
 extern struct EnterFunction EnterFunctions[];
 
-int enter_function_dispatcher(struct EnterWindowData *wdata, int op);
+int enter_function_dispatcher(struct MuttWindow *win, int op);
 bool self_insert(struct EnterWindowData *wdata, int ch);
 
 #endif /* MUTT_ENTER_FUNCTIONS_H */

--- a/gui/lib.h
+++ b/gui/lib.h
@@ -30,6 +30,7 @@
  * | gui/curs_lib.c      | @subpage gui_curs_lib      |
  * | gui/dialog.c        | @subpage gui_dialog        |
  * | gui/global.c        | @subpage gui_global        |
+ * | gui/msgcont.c       | @subpage gui_msgcont       |
  * | gui/msgwin.c        | @subpage gui_msgwin        |
  * | gui/mutt_curses.c   | @subpage gui_curses        |
  * | gui/mutt_window.c   | @subpage gui_window        |
@@ -47,6 +48,7 @@
 #include "curs_lib.h"
 #include "dialog.h"
 #include "global.h"
+#include "msgcont.h"
 #include "msgwin.h"
 #include "mutt_curses.h"
 #include "mutt_window.h"

--- a/gui/msgcont.c
+++ b/gui/msgcont.c
@@ -1,0 +1,102 @@
+/**
+ * @file
+ * Message Container
+ *
+ * @authors
+ * Copyright (C) 2022 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @page gui_msgcont Message Container
+ *
+ * Message Container
+ */
+
+#include "config.h"
+#include <stddef.h>
+#include <stdbool.h>
+#include "mutt/lib.h"
+#include "lib.h"
+#ifdef USE_DEBUG_WINDOW
+#include "debug/lib.h"
+#endif
+
+/// Window acting as a stack for the message windows
+static struct MuttWindow *MessageContainer = NULL;
+
+/**
+ * msgcont_new - Create a new Message Container
+ * @retval ptr New Container Window
+ */
+struct MuttWindow *msgcont_new(void)
+{
+  MessageContainer = mutt_window_new(WT_CONTAINER, MUTT_WIN_ORIENT_VERTICAL,
+                                     MUTT_WIN_SIZE_MINIMISE, MUTT_WIN_SIZE_UNLIMITED, 1);
+  return MessageContainer;
+}
+
+/**
+ * msgcont_pop_window - Remove the last Window from the Container Stack
+ * @retval ptr Window removed from the stack
+ */
+struct MuttWindow *msgcont_pop_window(void)
+{
+  if (!MessageContainer)
+    return NULL;
+
+  struct MuttWindow *win_pop = TAILQ_LAST(&MessageContainer->children, MuttWindowList);
+  // Don't pop the last entry
+  if (!TAILQ_PREV(win_pop, MuttWindowList, entries))
+    return NULL;
+
+  TAILQ_REMOVE(&MessageContainer->children, win_pop, entries);
+
+  // Make the top of the stack visible
+  struct MuttWindow *win_top = TAILQ_PREV(win_pop, MuttWindowList, entries);
+  if (win_top)
+  {
+    window_set_visible(win_top, true);
+    win_top->actions |= WA_RECALC;
+  }
+
+  window_redraw(NULL);
+#ifdef USE_DEBUG_WINDOW
+  debug_win_dump();
+#endif
+  return win_pop;
+}
+
+/**
+ * msgcont_push_window - Add a window to the Container Stack
+ * @param win Window to add
+ */
+void msgcont_push_window(struct MuttWindow *win)
+{
+  if (!MessageContainer || !win)
+    return;
+
+  // Hide the current top window
+  struct MuttWindow *win_top = TAILQ_LAST(&MessageContainer->children, MuttWindowList);
+  window_set_visible(win_top, false);
+
+  mutt_window_add_child(MessageContainer, win);
+  win->actions |= WA_RECALC;
+  window_redraw(NULL);
+#ifdef USE_DEBUG_WINDOW
+  debug_win_dump();
+#endif
+}

--- a/gui/msgcont.h
+++ b/gui/msgcont.h
@@ -1,0 +1,32 @@
+/**
+ * @file
+ * Message Window
+ *
+ * @authors
+ * Copyright (C) 2022 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MUTT_GUI_MSGCONT_H
+#define MUTT_GUI_MSGCONT_H
+
+struct MuttWindow;
+
+struct MuttWindow *msgcont_new(void);
+struct MuttWindow *msgcont_pop_window(void);
+void               msgcont_push_window(struct MuttWindow *win);
+
+#endif /* MUTT_GUI_MSGCONT_H */

--- a/gui/rootwin.c
+++ b/gui/rootwin.c
@@ -97,6 +97,7 @@
 #include "core/lib.h"
 #include "helpbar/lib.h"
 #include "dialog.h"
+#include "msgcont.h"
 #include "msgwin.h"
 #include "mutt_window.h"
 
@@ -190,7 +191,6 @@ void rootwin_new(void)
 
   struct MuttWindow *win_helpbar = helpbar_new();
   struct MuttWindow *win_alldlgs = alldialogs_new();
-  struct MuttWindow *win_msg = msgwin_new();
 
   const bool c_status_on_top = cs_subset_bool(NeoMutt->sub, "status_on_top");
   if (c_status_on_top)
@@ -204,7 +204,10 @@ void rootwin_new(void)
     mutt_window_add_child(win_root, win_alldlgs);
   }
 
-  mutt_window_add_child(win_root, win_msg);
+  struct MuttWindow *win_cont = msgcont_new();
+  struct MuttWindow *win_msg = msgwin_new();
+  mutt_window_add_child(win_cont, win_msg);
+  mutt_window_add_child(win_root, win_cont);
 
   notify_observer_add(NeoMutt->notify, NT_CONFIG, rootwin_config_observer, win_root);
   notify_observer_add(win_root->notify, NT_WINDOW, rootwin_window_observer, win_root);

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -583,10 +583,10 @@ void imap_logout_all(void)
 
 /**
  * imap_read_literal - Read bytes bytes from server into file
- * @param fp    File handle for email file
- * @param adata Imap Account data
- * @param bytes Number of bytes to read
- * @param pbar  Progress bar
+ * @param fp       File handle for email file
+ * @param adata    Imap Account data
+ * @param bytes    Number of bytes to read
+ * @param progress Progress bar
  * @retval  0 Success
  * @retval -1 Failure
  *
@@ -596,7 +596,7 @@ void imap_logout_all(void)
  *       Apparently even literals use `\r\n`-terminated strings ?!
  */
 int imap_read_literal(FILE *fp, struct ImapAccountData *adata,
-                      unsigned long bytes, struct Progress *pbar)
+                      unsigned long bytes, struct Progress *progress)
 {
   char c;
   bool r = false;
@@ -632,8 +632,8 @@ int imap_read_literal(FILE *fp, struct ImapAccountData *adata,
 
     fputc(c, fp);
 
-    if (pbar && !(pos % 1024))
-      progress_update(pbar, pos, -1);
+    if (progress && !(pos % 1024))
+      progress_update(progress, pos, -1);
     if (c_debug_level >= IMAP_LOG_LTRL)
       mutt_buffer_addch(&buf, c);
   }

--- a/imap/private.h
+++ b/imap/private.h
@@ -186,7 +186,7 @@ int imap_exec_msgset(struct Mailbox *m, const char *pre, const char *post,
                      enum MessageType flag, bool changed, bool invert);
 int imap_open_connection(struct ImapAccountData *adata);
 void imap_close_connection(struct ImapAccountData *adata);
-int imap_read_literal(FILE *fp, struct ImapAccountData *adata, unsigned long bytes, struct Progress *pbar);
+int imap_read_literal(FILE *fp, struct ImapAccountData *adata, unsigned long bytes, struct Progress *progress);
 void imap_expunge_mailbox(struct Mailbox *m, bool resort);
 int imap_login(struct ImapAccountData *adata);
 int imap_sync_message_for_copy(struct Mailbox *m, struct Email *e, struct Buffer *cmd, enum QuadOption *err_continue);

--- a/progress/lib.h
+++ b/progress/lib.h
@@ -29,11 +29,14 @@
  * | File                | Description                |
  * | :------------------ | :------------------------- |
  * | progress/progress.c | @subpage progress_progress |
+ * | progress/wdata.c    | @subpage progress_wdata    |
+ * | progress/window.c   | @subpage progress_window   |
  */
 
 #ifndef MUTT_PROGRESS_LIB_H
 #define MUTT_PROGRESS_LIB_H
 
+#include <stdbool.h>
 #include <stdio.h>
 
 struct Progress;
@@ -50,6 +53,6 @@ enum ProgressType
 
 void             progress_free  (struct Progress **ptr);
 struct Progress *progress_new   (const char *msg, enum ProgressType type, size_t size);
-void             progress_update(struct Progress *progress, size_t pos, int percent);
+bool             progress_update(struct Progress *progress, size_t pos, int percent);
 
 #endif /* MUTT_PROGRESS_LIB_H */

--- a/progress/progress.c
+++ b/progress/progress.c
@@ -3,7 +3,7 @@
  * Progress bar
  *
  * @authors
- * Copyright (C) 2018-2021 Richard Russon <rich@flatcap.org>
+ * Copyright (C) 2018-2022 Richard Russon <rich@flatcap.org>
  * Copyright (C) 2019 Pietro Cerutti <gahr@gahr.ch>
  *
  * @copyright
@@ -24,102 +24,23 @@
 /**
  * @page progress_progress Progress Bar
  *
- * Progress bar
+ * This is a wrapper around the Progress Bar Window.
+ * After creating the window, it pushes it into the Message Window Container.
  */
 
 #include "config.h"
-#include <stdarg.h>
 #include <stdbool.h>
-#include <stdint.h>
 #include <stdio.h>
 #include "mutt/lib.h"
 #include "config/lib.h"
 #include "core/lib.h"
 #include "gui/lib.h"
 #include "lib.h"
-#include "color/lib.h"
-#include "muttlib.h"
+#include "mutt_logging.h"
 #include "options.h"
+#include "window.h"
 
-/**
- * struct Progress - A Progress Bar
- */
-struct Progress
-{
-  struct MuttWindow *win;       ///< Window to draw on
-  struct MuttWindow *old_focus; ///< Previous focused Window
-  char msg[1024];               ///< Message to display
-  char sizestr[24];             ///< String for percentage/size
-  size_t pos;                   ///< Current position
-  size_t size;                  ///< Total expected size
-  size_t inc;                   ///< Increment size
-  uint64_t timestamp;           ///< Time of last update
-  bool is_bytes;                ///< true if measuring bytes
-};
-
-/**
- * message_bar - Draw a colourful progress bar
- * @param win     Window to draw on
- * @param percent %age complete
- * @param fmt     printf(1)-like formatting string
- * @param ...     Arguments to formatting string
- */
-static void message_bar(struct MuttWindow *win, int percent, const char *fmt, ...)
-{
-  if (!fmt || !win)
-    return;
-
-  va_list ap;
-  char buf[256], buf2[256];
-  int w = (percent * win->state.cols) / 100;
-  size_t l;
-
-  va_start(ap, fmt);
-  vsnprintf(buf, sizeof(buf), fmt, ap);
-  l = mutt_strwidth(buf);
-  va_end(ap);
-
-  mutt_simple_format(buf2, sizeof(buf2), 0, win->state.cols - 2, JUSTIFY_LEFT,
-                     0, buf, sizeof(buf), false);
-
-  mutt_window_move(win, 0, 0);
-
-  if (simple_color_is_set(MT_COLOR_PROGRESS))
-  {
-    if (l < w)
-    {
-      /* The string fits within the colour bar */
-      mutt_curses_set_normal_backed_color_by_id(MT_COLOR_PROGRESS);
-      mutt_window_addstr(win, buf2);
-      w -= l;
-      while (w-- > 0)
-      {
-        mutt_window_addch(win, ' ');
-      }
-      mutt_curses_set_color_by_id(MT_COLOR_NORMAL);
-    }
-    else
-    {
-      /* The string is too long for the colour bar */
-      int off = mutt_wstr_trunc(buf2, sizeof(buf2), w, NULL);
-
-      char ch = buf2[off];
-      buf2[off] = '\0';
-      mutt_curses_set_normal_backed_color_by_id(MT_COLOR_PROGRESS);
-      mutt_window_addstr(win, buf2);
-      buf2[off] = ch;
-      mutt_curses_set_color_by_id(MT_COLOR_NORMAL);
-      mutt_window_addstr(win, &buf2[off]);
-    }
-  }
-  else
-  {
-    mutt_window_addstr(win, buf2);
-  }
-
-  mutt_window_clrtoeol(win);
-  mutt_refresh();
-}
+struct Progress;
 
 /**
  * choose_increment - Choose the right increment given a ProgressType
@@ -136,92 +57,26 @@ static size_t choose_increment(enum ProgressType type)
 }
 
 /**
- * pos_needs_update - Do we need to update, given the current pos?
- * @param progress Progress
- * @param pos      Current pos
- * @retval true Progress needs an update
- */
-static bool pos_needs_update(const struct Progress *progress, long pos)
-{
-  const unsigned shift = progress->is_bytes ? 10 : 0;
-  return pos >= (progress->pos + (progress->inc << shift));
-}
-
-/**
- * time_needs_update - Do we need to update, given the current time?
- * @param progress Progress
- * @param now      Current time
- * @retval true Progress needs an update
- */
-static bool time_needs_update(const struct Progress *progress, size_t now)
-{
-  const size_t elapsed = (now - progress->timestamp);
-  const short c_time_inc = cs_subset_number(NeoMutt->sub, "time_inc");
-  return (c_time_inc == 0) || (now < progress->timestamp) || (c_time_inc < elapsed);
-}
-
-/**
  * progress_update - Update the state of the progress bar
  * @param progress Progress bar
  * @param pos      Position, or count
  * @param percent  Percentage complete
+ * @retval true Screen update is needed
  *
  * If percent is -1, then the percentage will be calculated using pos and the
  * size in progress.
  *
  * If percent is positive, it is displayed as percentage, otherwise
- * percentage is calculated from progress->size and pos if progress
+ * percentage is calculated from size and pos if progress
  * was initialized with positive size, otherwise no percentage is shown
  */
-void progress_update(struct Progress *progress, size_t pos, int percent)
+bool progress_update(struct Progress *progress, size_t pos, int percent)
 {
-  if (OptNoCurses || !progress || (progress->inc == 0))
-    return;
-
-  const bool first = (pos == 0); /* always show the first update */
-
-  if (!first && !pos_needs_update(progress, pos))
-  {
-    return;
-  }
-
-  const uint64_t now = mutt_date_epoch_ms();
-  if (first || time_needs_update(progress, now))
-  {
-    progress->pos = pos;
-    progress->timestamp = now;
-
-    char posstr[128];
-    if (progress->is_bytes)
-    {
-      const size_t round_pos = (progress->pos / (progress->inc << 10)) *
-                               (progress->inc << 10);
-      mutt_str_pretty_size(posstr, sizeof(posstr), round_pos);
-    }
-    else
-    {
-      snprintf(posstr, sizeof(posstr), "%zu", progress->pos);
-    }
-
-    mutt_debug(LL_DEBUG4, "updating progress: %s\n", posstr);
-
-    if (progress->size != 0)
-    {
-      if (percent < 0)
-      {
-        percent = 100.0 * progress->pos / progress->size;
-      }
-      message_bar(progress->win, percent, "%s %s/%s (%d%%)", progress->msg,
-                  posstr, progress->sizestr, percent);
-    }
-    else
-    {
-      if (percent > 0)
-        message_bar(progress->win, percent, "%s %s (%d%%)", progress->msg, posstr, percent);
-      else
-        mutt_message("%s %s", progress->msg, posstr);
-    }
-  }
+  // Decloak an opaque pointer
+  struct MuttWindow *win = (struct MuttWindow *) progress;
+  const bool updated = progress_window_update(win, pos, percent);
+  window_redraw(win);
+  return updated;
 }
 
 /**
@@ -230,69 +85,55 @@ void progress_update(struct Progress *progress, size_t pos, int percent)
  */
 void progress_free(struct Progress **ptr)
 {
-  if (!ptr || !*ptr)
+  if (!ptr)
     return;
 
-  struct Progress *progress = *ptr;
+  if (!*ptr)
+  {
+    mutt_clear_error();
+    return;
+  }
 
-  mutt_window_clearline(progress->win, 0);
-  window_set_focus(progress->old_focus);
+  // Decloak an opaque pointer
+  struct MuttWindow **wptr = (struct MuttWindow **) ptr;
+  struct MuttWindow *win_pop = msgcont_pop_window();
+  if (win_pop != *wptr)
+    return;
 
-  FREE(ptr);
+  mutt_window_free(wptr);
 }
 
 /**
  * progress_new - Create a new Progress Bar
- * @param msg  Message to display; this is copied into the Progress object
+ * @param msg  Message to display
  * @param type Type, e.g. #MUTT_PROGRESS_READ
  * @param size Total size of expected file / traffic
  * @retval ptr New Progress Bar
+ *
+ * If the user has disabled the progress bar, e.g. `set read_inc = 0` then a
+ * simple message will be displayed instead.
+ *
+ * @note msg will be copied
  */
 struct Progress *progress_new(const char *msg, enum ProgressType type, size_t size)
 {
   if (OptNoCurses)
     return NULL;
 
-  struct Progress *progress = mutt_mem_calloc(1, sizeof(struct Progress));
-
-  /* Initialize Progress structure */
-  progress->win = msgwin_get_window();
-  mutt_str_copy(progress->msg, msg, sizeof(progress->msg));
-  progress->size = size;
-  progress->inc = choose_increment(type);
-  progress->is_bytes = (type == MUTT_PROGRESS_NET);
-  progress->old_focus = window_set_focus(progress->win);
-
-  /* Generate the size string, if a total size was specified */
-  if (progress->size != 0)
+  const size_t size_inc = choose_increment(type);
+  if (size_inc == 0) // The user has disabled the progress bar
   {
-    if (progress->is_bytes)
-    {
-      mutt_str_pretty_size(progress->sizestr, sizeof(progress->sizestr),
-                           progress->size);
-    }
-    else
-    {
-      snprintf(progress->sizestr, sizeof(progress->sizestr), "%zu", progress->size);
-    }
+    mutt_message(msg);
+    return NULL;
   }
 
-  if (progress->inc == 0)
-  {
-    /* This progress bar does not increment - write the initial message */
-    if (progress->size == 0)
-    {
-      mutt_message(progress->msg);
-    }
-    else
-    {
-      mutt_message("%s (%s)", progress->msg, progress->sizestr);
-    }
-  }
-  else
-  {
-    /* This progress bar does increment - perform the initial update */
-    progress_update(progress, 0, 0);
-  }
-  return progress;
+  const short c_time_inc = cs_subset_number(NeoMutt->sub, "time_inc");
+  const bool is_bytes = (type == MUTT_PROGRESS_NET);
+
+  struct MuttWindow *win = progress_window_new(msg, size, size_inc, c_time_inc, is_bytes);
+
+  msgcont_push_window(win);
+
+  // Return an opaque pointer
+  return (struct Progress *) win;
 }

--- a/progress/wdata.c
+++ b/progress/wdata.c
@@ -1,0 +1,51 @@
+/**
+ * @file
+ * Progress Bar Window Data
+ *
+ * @authors
+ * Copyright (C) 2022 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @page progress_wdata Progress Bar Window Data
+ *
+ * Progress Bar Window Data
+ */
+
+#include "config.h"
+#include "mutt/lib.h"
+#include "wdata.h"
+
+/**
+ * progress_wdata_new - Create new Progress Bar Window Data
+ * @retval ptr New Progress Bar Window Data
+ */
+struct ProgressWindowData *progress_wdata_new(void)
+{
+  return mutt_mem_calloc(1, sizeof(struct ProgressWindowData));
+}
+
+/**
+ * progress_wdata_free - Free Progress Bar Window data - Implements MuttWindow::wdata_free() - @ingroup window_wdata_free
+ */
+void progress_wdata_free(struct MuttWindow *win, void **ptr)
+{
+  if (!win || !ptr || !*ptr)
+    return;
+
+  FREE(ptr);
+}

--- a/progress/wdata.h
+++ b/progress/wdata.h
@@ -1,0 +1,62 @@
+/**
+ * @file
+ * Progress Bar Window Data
+ *
+ * @authors
+ * Copyright (C) 2022 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MUTT_PROGRESS_WDATA_H
+#define MUTT_PROGRESS_WDATA_H
+
+#include <stdio.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+struct MuttWindow;
+
+/**
+ * struct ProgressWindowData - Progress Bar Window Data
+ */
+struct ProgressWindowData
+{
+  struct MuttWindow *win;       ///< Window to draw on
+
+  // Settings for the Progress Bar
+  char   msg[1024];             ///< Message to display
+  char   pretty_size[24];       ///< Pretty string for size
+  size_t size;                  ///< Total expected size
+  size_t size_inc;              ///< Size increment
+  size_t time_inc;              ///< Time increment
+  bool   is_bytes;              ///< true if measuring bytes
+
+  // Current display
+  size_t   display_pos;         ///< Displayed position
+  int      display_percent;     ///< Displayed percentage complete
+  uint64_t display_time;        ///< Time of last display
+  char     pretty_pos[24];      ///< Pretty string for the position
+
+  // Updates waiting for display
+  size_t   update_pos;          ///< Updated position
+  int      update_percent;      ///< Updated percentage complete
+  uint64_t update_time;         ///< Time of last update
+};
+
+void                       progress_wdata_free(struct MuttWindow *win, void **ptr);
+struct ProgressWindowData *progress_wdata_new (void);
+
+#endif /* MUTT_PROGRESS_WDATA_H */

--- a/progress/window.c
+++ b/progress/window.c
@@ -1,0 +1,298 @@
+/**
+ * @file
+ * Progress Bar Window
+ *
+ * @authors
+ * Copyright (C) 2022 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @page progress_window Progress Bar Window
+ *
+ * Progress Bar Window
+ *
+ * ## Windows
+ *
+ * | Name            | Type          | See Also              |
+ * | :-------------- | :------------ | :-------------------- |
+ * | Progress Window | WT_STATUS_BAR | progress_window_new() |
+ *
+ * **Parent**
+ * - @ref gui_msgcont
+ *
+ * **Children**
+ *
+ * None.
+ *
+ * ## Data
+ * - #ProgressWindowData
+ *
+ * The Progress Bar Window stores its data (#ProgressWindowData) in MuttWindow::wdata.
+ *
+ * ## Events
+ *
+ * Once constructed, it is controlled by the following events:
+ *
+ * | Event Type            | Handler               |
+ * | :-------------------- | :-------------------- |
+ * | MuttWindow::recalc()  | sb_recalc()           |
+ * | MuttWindow::repaint() | sb_repaint()          |
+ */
+
+#include "config.h"
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include "mutt/lib.h"
+#include "gui/lib.h"
+#include "color/lib.h"
+#include "muttlib.h"
+#include "wdata.h"
+
+/**
+ * message_bar - Draw a colourful progress bar
+ * @param win     Window to draw on
+ * @param percent %age complete
+ * @param fmt     printf(1)-like formatting string
+ * @param ...     Arguments to formatting string
+ */
+static void message_bar(struct MuttWindow *win, int percent, const char *fmt, ...)
+{
+  if (!fmt || !win)
+    return;
+
+  va_list ap;
+  char buf[256], buf2[256];
+  int w = (percent * win->state.cols) / 100;
+  size_t l;
+
+  va_start(ap, fmt);
+  vsnprintf(buf, sizeof(buf), fmt, ap);
+  l = mutt_strwidth(buf);
+  va_end(ap);
+
+  mutt_simple_format(buf2, sizeof(buf2), 0, win->state.cols - 2, JUSTIFY_LEFT,
+                     0, buf, sizeof(buf), false);
+
+  mutt_window_move(win, 0, 0);
+
+  if (simple_color_is_set(MT_COLOR_PROGRESS))
+  {
+    if (l < w)
+    {
+      /* The string fits within the colour bar */
+      mutt_curses_set_normal_backed_color_by_id(MT_COLOR_PROGRESS);
+      mutt_window_addstr(win, buf2);
+      w -= l;
+      while (w-- > 0)
+      {
+        mutt_window_addch(win, ' ');
+      }
+      mutt_curses_set_color_by_id(MT_COLOR_NORMAL);
+    }
+    else
+    {
+      /* The string is too long for the colour bar */
+      int off = mutt_wstr_trunc(buf2, sizeof(buf2), w, NULL);
+
+      char ch = buf2[off];
+      buf2[off] = '\0';
+      mutt_curses_set_normal_backed_color_by_id(MT_COLOR_PROGRESS);
+      mutt_window_addstr(win, buf2);
+      buf2[off] = ch;
+      mutt_curses_set_color_by_id(MT_COLOR_NORMAL);
+      mutt_window_addstr(win, &buf2[off]);
+    }
+  }
+  else
+  {
+    mutt_window_addstr(win, buf2);
+  }
+
+  mutt_window_clrtoeol(win);
+}
+
+/**
+ * progress_window_recalc - Recalculate the Progress Bar - Implements MuttWindow::recalc() - @ingroup window_recalc
+ */
+static int progress_window_recalc(struct MuttWindow *win)
+{
+  if (!win || !win->wdata)
+    return -1;
+
+  struct ProgressWindowData *wdata = win->wdata;
+  wdata->display_pos = wdata->update_pos;
+  wdata->display_time = wdata->update_time;
+
+  if (wdata->is_bytes)
+    mutt_str_pretty_size(wdata->pretty_pos, sizeof(wdata->pretty_pos), wdata->display_pos);
+
+  if (wdata->update_percent < 0)
+    wdata->display_percent = 100.0 * wdata->display_pos / wdata->size;
+  else
+    wdata->display_percent = wdata->update_percent;
+
+  win->actions |= WA_REPAINT;
+  return 0;
+}
+
+/**
+ * progress_window_repaint - Repaint the Progress Bar - Implements MuttWindow::repaint() - @ingroup window_repaint
+ */
+static int progress_window_repaint(struct MuttWindow *win)
+{
+  if (!win || !win->wdata)
+    return -1;
+
+  struct ProgressWindowData *wdata = win->wdata;
+
+  if (wdata->size == 0)
+  {
+    message_bar(wdata->win, wdata->display_percent, "%s %zu (%d%%)", wdata->msg,
+                wdata->display_pos, wdata->display_percent);
+  }
+  else
+  {
+    if (wdata->is_bytes)
+    {
+      message_bar(wdata->win, wdata->display_percent, "%s %s/%s (%d%%)", wdata->msg,
+                  wdata->pretty_pos, wdata->pretty_size, wdata->display_percent);
+    }
+    else
+    {
+      message_bar(wdata->win, wdata->display_percent, "%s %zu/%zu (%d%%)", wdata->msg,
+                  wdata->display_pos, wdata->size, wdata->display_percent);
+    }
+  }
+
+  return 0;
+}
+
+/**
+ * percent_needs_update - Do we need to update, given the current percentage?
+ * @param wdata   Private data
+ * @param percent Updated percentage
+ * @retval true Progress needs an update
+ */
+static bool percent_needs_update(const struct ProgressWindowData *wdata, int percent)
+{
+  return (percent > wdata->display_percent);
+}
+
+/**
+ * pos_needs_update - Do we need to update, given the current pos?
+ * @param wdata Private data
+ * @param pos   Current pos
+ * @retval true Progress needs an update
+ */
+static bool pos_needs_update(const struct ProgressWindowData *wdata, long pos)
+{
+  const unsigned shift = wdata->is_bytes ? 10 : 0;
+  return pos >= (wdata->display_pos + (wdata->size_inc << shift));
+}
+
+/**
+ * time_needs_update - Do we need to update, given the current time?
+ * @param wdata Private data
+ * @param now   Time
+ * @retval true Progress needs an update
+ */
+static bool time_needs_update(const struct ProgressWindowData *wdata, size_t now)
+{
+  if (wdata->time_inc == 0)
+    return true;
+
+  if (now < wdata->display_time)
+    return true;
+
+  const size_t elapsed = (now - wdata->display_time);
+  return (wdata->time_inc < elapsed);
+}
+
+/**
+ * progress_window_update - Update the Progress Bar Window
+ * @param win      Window to draw on
+ * @param pos      Position, or count
+ * @param percent  Percentage complete
+ * @retval true Screen update is needed
+ */
+bool progress_window_update(struct MuttWindow *win, size_t pos, int percent)
+{
+  if (!win || !win->wdata)
+    return false;
+
+  struct ProgressWindowData *wdata = win->wdata;
+
+  if (wdata->size == 0)
+  {
+    if (!percent_needs_update(wdata, percent))
+      return false;
+  }
+  else
+  {
+    if (!pos_needs_update(wdata, pos))
+      return false;
+  }
+
+  const uint64_t now = mutt_date_epoch_ms();
+  if (!time_needs_update(wdata, now))
+    return false;
+
+  wdata->update_pos = pos;
+  wdata->update_percent = percent;
+  wdata->update_time = now;
+  win->actions |= WA_RECALC;
+  return true;
+}
+
+/**
+ * progress_window_new - Create a new Progress Bar Window
+ * @param msg      Progress message to display
+ * @param size     Expected number of records or size of traffic
+ * @param size_inc Size increment (step size)
+ * @param time_inc Time increment
+ * @param is_bytes true if measuing bytes
+ * @retval ptr New Progress Window
+ */
+struct MuttWindow *progress_window_new(const char *msg, size_t size, size_t size_inc,
+                                       size_t time_inc, bool is_bytes)
+{
+  if (size_inc == 0) // The user has disabled the progress bar
+    return NULL;
+
+  struct MuttWindow *win = mutt_window_new(WT_STATUS_BAR, MUTT_WIN_ORIENT_VERTICAL,
+                                           MUTT_WIN_SIZE_FIXED,
+                                           MUTT_WIN_SIZE_UNLIMITED, 1);
+  win->recalc = progress_window_recalc;
+  win->repaint = progress_window_repaint;
+  win->actions |= WA_RECALC;
+
+  struct ProgressWindowData *wdata = progress_wdata_new();
+  wdata->win = win;
+  wdata->size = size;
+  wdata->size_inc = size_inc;
+  wdata->time_inc = time_inc;
+  wdata->is_bytes = is_bytes;
+  mutt_str_copy(wdata->msg, msg, sizeof(wdata->msg));
+
+  if (is_bytes)
+    mutt_str_pretty_size(wdata->pretty_size, sizeof(wdata->pretty_size), size);
+
+  win->wdata = wdata;
+
+  return win;
+}

--- a/progress/window.h
+++ b/progress/window.h
@@ -1,0 +1,34 @@
+/**
+ * @file
+ * Progress Bar Window
+ *
+ * @authors
+ * Copyright (C) 2022 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MUTT_PROGRESS_WINDOW
+#define MUTT_PROGRESS_WINDOW
+
+#include <stddef.h>
+#include <stdbool.h>
+
+struct MuttWindow;
+
+struct MuttWindow *progress_window_new(const char *msg, size_t size, size_t size_inc, size_t time_inc, bool is_bytes);
+bool               progress_window_update(struct MuttWindow *win, size_t pos, int percent);
+
+#endif /* MUTT_PROGRESS_WINDOW */


### PR DESCRIPTION
The MessageWindow is used to display messages but also hijacked for user input and the progress bar.
As each user may want to store their own data, while active, this presents a problem.

The solution is to make each separate user have their own window.
A Message Container Window will be LIFO stack of windows, with only the top-most being visible.

The Message Window would always be present and accept `mutt_message()`, `_warning()`, etc.
When other users need to use the space, they will create a new window that has its own private data.

To check the window layout, compile with `--debug-window` and follow the logs, e.g.
```sh
tail -F ~/.neomuttdebug0 | sed 's/.*\]<.> [a-z0-9_]\+() //'
```