### PR TITLE
browser: add mailbox_folder_format config variable

### DIFF
--- a/browser/browser.c
+++ b/browser/browser.c
@@ -805,7 +805,8 @@ static int select_file_search(struct Menu *menu, regex_t *rx, int line)
  */
 static void folder_make_entry(struct Menu *menu, char *buf, size_t buflen, int line)
 {
-  struct BrowserStateEntry *entry = menu->mdata;
+  struct BrowserState *state = menu->mdata;
+  struct BrowserStateEntry *entry = &state->entry;
   struct Folder folder = {
     .ff = ARRAY_GET(entry, line),
     .num = line,
@@ -821,6 +822,14 @@ static void folder_make_entry(struct Menu *menu, char *buf, size_t buflen, int l
   }
   else
 #endif
+      if (state->is_mailbox_list)
+  {
+    const char *const c_mailbox_folder_format = cs_subset_string(NeoMutt->sub, "mailbox_folder_format");
+    mutt_expando_format(buf, buflen, 0, menu->win->state.cols,
+                        NONULL(c_mailbox_folder_format), folder_format_str,
+                        (intptr_t) &folder, MUTT_FORMAT_ARROWCURSOR);
+  }
+  else
   {
     const char *const c_folder_format = cs_subset_string(NeoMutt->sub, "folder_format");
     mutt_expando_format(buf, buflen, 0, menu->win->state.cols, NONULL(c_folder_format),
@@ -1313,7 +1322,7 @@ void mutt_buffer_select_file(struct Buffer *file, SelectFileFlags flags,
 
   init_menu(&priv->state, priv->menu, m, priv->sbar);
   // only now do we have a valid priv->state to attach
-  priv->menu->mdata = &priv->state.entry;
+  priv->menu->mdata = &priv->state;
 
   // ---------------------------------------------------------------------------
   // Event Loop

--- a/browser/config.c
+++ b/browser/config.c
@@ -44,6 +44,9 @@ static struct ConfigDef BrowserVars[] = {
   { "group_index_format", DT_STRING|DT_NOT_EMPTY|R_INDEX|R_PAGER, IP "%4C %M%N %5s  %-45.45f %d", 0, NULL,
     "(nntp) printf-like format string for the browser's display of newsgroups"
   },
+  { "mailbox_folder_format", DT_STRING|DT_NOT_EMPTY|R_MENU, IP "%2C %t %N %6n %6m %i", 0, NULL,
+    "printf-like format string for the browser's display of mailbox folders"
+  },
   { "mask", DT_REGEX|DT_REGEX_MATCH_CASE|DT_REGEX_ALLOW_NOT|DT_REGEX_NOSUB, IP "!^\\.[^.]", 0, NULL,
     "Only display files/dirs matching this regex in the browser"
   },

--- a/docs/config.c
+++ b/docs/config.c
@@ -2210,6 +2210,43 @@
 ** how often (in seconds) NeoMutt will update message counts.
 */
 
+{ "mailbox_folder_format", DT_STRING, "%2C %t %N %n %m %i" },
+/*
+** .pp
+** This variable allows you to customize the file browser display to your
+** personal taste. It's only used to customize network mailboxes (e.g. imap).
+** This string is similar to $$index_format, but has its own set of
+** \fCprintf(3)\fP-like sequences:
+** .dl
+** .dt %C  .dd   .dd Current file number
+** .dt %d  .dd   .dd Date/time folder was last modified
+** .dt %D  .dd   .dd Date/time folder was last modified using $$date_format.
+** .dt %f  .dd   .dd Filename ("/" is appended to directory names,
+**                   "@" to symbolic links and "*" to executable files)
+** .dt %F  .dd   .dd File permissions
+** .dt %g  .dd   .dd Group name (or numeric gid, if missing)
+** .dt %i  .dd   .dd Description of the folder
+** .dt %l  .dd   .dd Number of hard links
+** .dt %m  .dd * .dd Number of messages in the mailbox
+** .dt %n  .dd * .dd Number of unread messages in the mailbox
+** .dt %N  .dd   .dd "N" if mailbox has new mail, blank otherwise
+** .dt %s  .dd   .dd Size in bytes (see $formatstrings-size)
+** .dt %t  .dd   .dd "*" if the file is tagged, blank otherwise
+** .dt %u  .dd   .dd Owner name (or numeric uid, if missing)
+** .dt %>X .dd   .dd Right justify the rest of the string and pad with character "X"
+** .dt %|X .dd   .dd Pad to the end of the line with character "X"
+** .dt %*X .dd   .dd Soft-fill with character "X" as pad
+** .de
+** .pp
+** For an explanation of "soft-fill", see the $$index_format documentation.
+** .pp
+** * = can be optionally printed if nonzero
+** .pp
+** %m, %n, and %N only work for monitored mailboxes.
+** %m requires $$mail_check_stats to be set.
+** %n requires $$mail_check_stats to be set (except for IMAP mailboxes).
+*/
+
 { "mailcap_path", DT_SLIST, "~/.mailcap:" PKGDATADIR "/mailcap:" SYSCONFDIR "/mailcap:/etc/mailcap:/usr/etc/mailcap:/usr/local/etc/mailcap" },
 /*
 ** .pp


### PR DESCRIPTION
Implementation of #181.

Adds a new format string for viewing non-local mailboxes in the browser.

- browser/browser.c: folder_make_entry: receive BrowserState as data
  and check if it's a mailbox to print it accordingly.
- browser/browser.c: mutt_buffer_select_file: pass BrowserState as data.
- browser/config.c: declare mailbox_folder_format.
- docs/config.c: document the new var.

For the default value, mailboxes should look like this:


![Screenshot from 2022-05-24 23-34-34](https://user-images.githubusercontent.com/34252251/170329632-ea3f66c0-9577-4af3-a798-f5f15e0548b2.png)