### PR TITLE
Deprecate <refresh> function in favour of <redraw-screen>

### DIFF
--- a/functions.c
+++ b/functions.c
@@ -323,7 +323,8 @@ const struct MenuFuncOp OpGeneric[] = { /* map: generic */
   { "previous-entry",                OP_PREV_ENTRY },
   { "previous-line",                 OP_PREV_LINE },
   { "previous-page",                 OP_PREV_PAGE },
-  { "refresh",                       OP_REDRAW },
+  { "redraw-screen",                 OP_REDRAW },
+  { "refresh",                       OP_REFRESH_DEPRECATED },
   { "search",                        OP_SEARCH },
   { "search-next",                   OP_SEARCH_NEXT },
   { "search-opposite",               OP_SEARCH_OPPOSITE },
@@ -640,7 +641,6 @@ const struct MenuFuncOp OpPager[] = { /* map: pager */
 #ifdef USE_NNTP
   { "reconstruct-thread",            OP_RECONSTRUCT_THREAD },
 #endif
-  { "redraw-screen",                 OP_REDRAW },
   { "reply",                         OP_REPLY },
   { "resend-message",                OP_RESEND },
   { "root-message",                  OP_MAIN_ROOT_MESSAGE },
@@ -1184,7 +1184,6 @@ const struct MenuOpSeq PagerDefaultBindings[] = { /* map: pager */
   { OP_PRINT,                              "p" },
   { OP_QUIT,                               "Q" },
   { OP_RECALL_MESSAGE,                     "R" },
-  { OP_REDRAW,                             "\014" },           // <Ctrl-L>
   { OP_REPLY,                              "r" },
   { OP_RESEND,                             "\033e" },          // <Alt-e>
   { OP_SAVE,                               "s" },

--- a/gui/global.c
+++ b/gui/global.c
@@ -76,6 +76,18 @@ static int op_redraw(int op)
 }
 
 /**
+ * op_refresh_deprecated - Deprecated <refresh> function  - Implements ::global_function_t - @ingroup global_function_api
+ *
+ * This is a wrapper for the deperecated <refresh> function which issues
+ * a warning and then calls <redraw>.
+ */
+static int op_refresh_deprecated(int op)
+{
+  mutt_warning("Use of deprecated <refresh> detected, use <redraw-screen> instead.");
+  return op_redraw(op);
+}
+
+/**
  * op_shell_escape - Invoke a command in a subshell - Implements ::global_function_t - @ingroup global_function_api
  */
 static int op_shell_escape(int op)
@@ -148,6 +160,7 @@ struct GlobalFunction GlobalFunctions[] = {
   { OP_CHECK_STATS,           op_check_stats },
   { OP_ENTER_COMMAND,         op_enter_command },
   { OP_REDRAW,                op_redraw },
+  { OP_REFRESH_DEPRECATED,    op_refresh_deprecated },
   { OP_SHELL_ESCAPE,          op_shell_escape },
   { OP_SHOW_LOG_MESSAGES,     op_show_log_messages },
   { OP_VERSION,               op_version },

--- a/opcodes.h
+++ b/opcodes.h
@@ -248,6 +248,7 @@ const char *opcodes_get_name       (int op);
   _fmt(OP_RECALL_MESSAGE,                     N_("recall a postponed message")) \
   _fmt(OP_RECONSTRUCT_THREAD,                 N_("reconstruct thread containing current message")) \
   _fmt(OP_REDRAW,                             N_("clear and redraw the screen")) \
+  _fmt(OP_REFRESH_DEPRECATED,                 N_("clear and redraw the screen.  This function is deprecated, use <refresh-screen> instead.")) \
   _fmt(OP_REFORMAT_WINCH,                     N_("{internal}")) \
   _fmt(OP_RENAME_MAILBOX,                     N_("rename the current mailbox (IMAP only)")) \
   _fmt(OP_REPLY,                              N_("reply to a message")) \


### PR DESCRIPTION
* **What does this PR do?**

Promote <redraw-screen> into the generic menu and make <refresh> an
alias for it.

Disclaimer: This is mostly untested and I have also no clue how all that function-stuff works but it seems reasonable.

* **Does this PR meet the acceptance criteria?**

   - Manual build fails because I used `<redraw-screen>` in the function description which is interpreted as a tag.  Solutions welcome. (I believe using `&lt` would produce a correct manual but a literal `&lt` at the online help of neomutt.)

* **What are the relevant issue numbers?**

#3415