### PR TITLE
enter: unify behaviour

### DIFF
--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -903,6 +903,7 @@ coverage: all test
 	  --directory config \
 	  --directory core \
 	  --directory email \
+	  --directory enter \
 	  --directory mutt \
 	  --directory notmuch \
 	  --directory pattern \

--- a/enter/enter.c
+++ b/enter/enter.c
@@ -36,7 +36,7 @@
 #include "state.h"
 
 /// combining mark / non-spacing character
-#define COMB_CHAR(wc) (IsWPrint(wc) && !wcwidth(wc))
+#define COMB_CHAR(wc) (IsWPrint(wc) && (wcwidth(wc) == 0))
 
 /**
  * editor_backspace - Delete the char in front of the cursor
@@ -127,10 +127,6 @@ int editor_case_word(struct EnterState *es, enum EnterCase ec)
   if (!es || (es->curpos == es->lastchar))
     return FR_ERROR;
 
-  while (es->curpos && !iswspace(es->wbuf[es->curpos]))
-  {
-    es->curpos--;
-  }
   while ((es->curpos < es->lastchar) && iswspace(es->wbuf[es->curpos]))
   {
     es->curpos++;
@@ -164,8 +160,6 @@ int editor_delete_char(struct EnterState *es)
     return FR_ERROR;
 
   size_t i = es->curpos;
-  while ((i < es->lastchar) && COMB_CHAR(es->wbuf[i]))
-    i++;
   if (i < es->lastchar)
     i++;
   while ((i < es->lastchar) && COMB_CHAR(es->wbuf[i]))
@@ -299,8 +293,13 @@ int editor_kill_line(struct EnterState *es)
   if (!es)
     return FR_ERROR;
 
+  size_t len = es->lastchar - es->curpos;
+
+  memmove(es->wbuf, es->wbuf + es->curpos, len * sizeof(wchar_t));
+
+  es->lastchar = len;
   es->curpos = 0;
-  es->lastchar = 0;
+
   return FR_SUCCESS;
 }
 

--- a/enter/enter.c
+++ b/enter/enter.c
@@ -391,3 +391,60 @@ bool editor_buffer_is_empty(struct EnterState *es)
 
   return (es->lastchar == 0);
 }
+
+/**
+ * editor_buffer_get_lastchar - Get the position of the last character
+ * @param es State of the Enter buffer
+ * @retval num Position of last character
+ */
+size_t editor_buffer_get_lastchar(struct EnterState *es)
+{
+  if (!es)
+    return 0;
+
+  return es->lastchar;
+}
+
+/**
+ * editor_buffer_get_cursor - Get the position of the cursor
+ * @param es State of the Enter buffer
+ * @retval num Position of cursor
+ */
+size_t editor_buffer_get_cursor(struct EnterState *es)
+{
+  if (!es)
+    return 0;
+
+  return es->curpos;
+}
+
+/**
+ * editor_buffer_set_cursor - Set the position of the cursor
+ * @param es  State of the Enter buffer
+ * @param pos New postition for the cursor
+ */
+void editor_buffer_set_cursor(struct EnterState *es, size_t pos)
+{
+  if (!es)
+    return;
+
+  if (pos >= es->lastchar)
+    return;
+
+  es->curpos = pos;
+}
+
+/**
+ * editor_buffer_set - Set the string in the buffer
+ * @param es  State of the Enter buffer
+ * @param str String to set
+ * @retval num Length of string
+ */
+int editor_buffer_set(struct EnterState *es, const char *str)
+
+{
+  es->wbuflen = 0;
+  es->lastchar = mutt_mb_mbstowcs(&es->wbuf, &es->wbuflen, 0, str);
+  es->curpos = es->lastchar;
+  return es->lastchar;
+}

--- a/enter/enter.c
+++ b/enter/enter.c
@@ -305,6 +305,23 @@ int editor_kill_line(struct EnterState *es)
 }
 
 /**
+ * editor_kill_whole_line - Delete all chars on the line
+ * @param es State of the Enter buffer
+ * @retval FR_SUCCESS Characters deleted
+ * @retval FR_ERROR   Error
+ */
+int editor_kill_whole_line(struct EnterState *es)
+{
+  if (!es)
+    return FR_ERROR;
+
+  es->lastchar = 0;
+  es->curpos = 0;
+
+  return FR_SUCCESS;
+}
+
+/**
  * editor_kill_word - Delete the word in front of the cursor
  * @param es State of the Enter buffer
  * @retval FR_SUCCESS Characters deleted

--- a/enter/enter.c
+++ b/enter/enter.c
@@ -289,7 +289,7 @@ int editor_kill_eow(struct EnterState *es)
 }
 
 /**
- * editor_kill_line - Delete all chars on the line
+ * editor_kill_line - Delete chars from cursor to beginning the line
  * @param es State of the Enter buffer
  * @retval FR_SUCCESS Characters deleted
  * @retval FR_ERROR   Error

--- a/enter/enter.h
+++ b/enter/enter.h
@@ -49,6 +49,7 @@ int editor_forward_word   (struct EnterState *es);
 int editor_kill_eol       (struct EnterState *es);
 int editor_kill_eow       (struct EnterState *es);
 int editor_kill_line      (struct EnterState *es);
+int editor_kill_whole_line(struct EnterState *es);
 int editor_kill_word      (struct EnterState *es);
 int editor_transpose_chars(struct EnterState *es);
 

--- a/enter/enter.h
+++ b/enter/enter.h
@@ -53,6 +53,10 @@ int editor_kill_whole_line(struct EnterState *es);
 int editor_kill_word      (struct EnterState *es);
 int editor_transpose_chars(struct EnterState *es);
 
-bool editor_buffer_is_empty(struct EnterState *es);
+size_t editor_buffer_get_cursor  (struct EnterState *es);
+size_t editor_buffer_get_lastchar(struct EnterState *es);
+bool   editor_buffer_is_empty    (struct EnterState *es);
+int    editor_buffer_set         (struct EnterState *es, const char *str);
+void   editor_buffer_set_cursor  (struct EnterState *es, size_t pos);
 
 #endif /* MUTT_ENTER_ENTER_H */

--- a/enter/functions.c
+++ b/enter/functions.c
@@ -609,6 +609,14 @@ static int op_editor_kill_line(struct EnterWindowData *wdata, int op)
 }
 
 /**
+ * op_editor_kill_whole_line - Delete all chars on the line - Implements ::enter_function_t - @ingroup enter_function_api
+ */
+static int op_editor_kill_whole_line(struct EnterWindowData *wdata, int op)
+{
+  return editor_kill_whole_line(wdata->state);
+}
+
+/**
  * op_editor_kill_word - Delete the word in front of the cursor - Implements ::enter_function_t - @ingroup enter_function_api
  */
 static int op_editor_kill_word(struct EnterWindowData *wdata, int op)
@@ -671,6 +679,7 @@ struct EnterFunction EnterFunctions[] = {
   { OP_EDITOR_KILL_EOL,           op_editor_kill_eol },
   { OP_EDITOR_KILL_EOW,           op_editor_kill_eow },
   { OP_EDITOR_KILL_LINE,          op_editor_kill_line },
+  { OP_EDITOR_KILL_WHOLE_LINE,    op_editor_kill_whole_line },
   { OP_EDITOR_KILL_WORD,          op_editor_kill_word },
   { OP_EDITOR_MAILBOX_CYCLE,      op_editor_mailbox_cycle },
   { OP_EDITOR_QUOTE_CHAR,         op_editor_quote_char },

--- a/enter/lib.h
+++ b/enter/lib.h
@@ -40,6 +40,7 @@
 #include <stdbool.h>
 #include "mutt.h"
 // IWYU pragma: begin_exports
+#include "enter.h"
 #include "state.h"
 // IWYU pragma: end_exports
 

--- a/enter/state.c
+++ b/enter/state.c
@@ -30,6 +30,10 @@
 #include "mutt/lib.h"
 #include "state.h"
 
+const int BufferStepSize = 128;
+
+#define ROUND_UP(NUM, STEP) ((((NUM) + (STEP) -1) / (STEP)) * (STEP))
+
 /**
  * mutt_enter_state_free - Free an EnterState
  * @param[out] ptr EnterState to free
@@ -46,10 +50,32 @@ void mutt_enter_state_free(struct EnterState **ptr)
 }
 
 /**
+ * mutt_enter_state_resize - Make the buffer bigger
+ * @param es  State of the Enter buffer
+ * @param num Number of wide characters
+ */
+void mutt_enter_state_resize(struct EnterState *es, size_t num)
+{
+  if (!es)
+    return;
+
+  if (num <= es->wbuflen)
+    return;
+
+  num = ROUND_UP(num, 128);
+  es->wbuflen = num;
+  mutt_mem_realloc(&es->wbuf, num * sizeof(wchar_t));
+}
+
+/**
  * mutt_enter_state_new - Create a new EnterState
  * @retval ptr New EnterState
  */
 struct EnterState *mutt_enter_state_new(void)
 {
-  return mutt_mem_calloc(1, sizeof(struct EnterState));
+  struct EnterState *es = mutt_mem_calloc(1, sizeof(struct EnterState));
+
+  mutt_enter_state_resize(es, 1);
+
+  return es;
 }

--- a/enter/state.h
+++ b/enter/state.h
@@ -40,5 +40,6 @@ struct EnterState
 
 void               mutt_enter_state_free(struct EnterState **ptr);
 struct EnterState *mutt_enter_state_new(void);
+void               mutt_enter_state_resize(struct EnterState *es, size_t num);
 
 #endif /* MUTT_ENTER_STATE_H */

--- a/functions.c
+++ b/functions.c
@@ -271,6 +271,7 @@ const struct MenuFuncOp OpEditor[] = { /* map: editor */
   { "kill-eol",                      OP_EDITOR_KILL_EOL },
   { "kill-eow",                      OP_EDITOR_KILL_EOW },
   { "kill-line",                     OP_EDITOR_KILL_LINE },
+  { "kill-whole-line",               OP_EDITOR_KILL_WHOLE_LINE },
   { "kill-word",                     OP_EDITOR_KILL_WORD },
   { "mailbox-cycle",                 OP_EDITOR_MAILBOX_CYCLE },
   { "quote-char",                    OP_EDITOR_QUOTE_CHAR },

--- a/opcodes.h
+++ b/opcodes.h
@@ -138,6 +138,7 @@ const char *opcodes_get_name       (int op);
   _fmt(OP_EDITOR_KILL_EOL,                    N_("delete chars from cursor to end of line")) \
   _fmt(OP_EDITOR_KILL_EOW,                    N_("delete chars from the cursor to the end of the word")) \
   _fmt(OP_EDITOR_KILL_LINE,                   N_("delete all chars on the line")) \
+  _fmt(OP_EDITOR_KILL_WHOLE_LINE,             N_("delete all chars on the line")) \
   _fmt(OP_EDITOR_KILL_WORD,                   N_("delete the word in front of the cursor")) \
   _fmt(OP_EDITOR_MAILBOX_CYCLE,               N_("cycle among incoming mailboxes")) \
   _fmt(OP_EDITOR_QUOTE_CHAR,                  N_("quote the next typed key")) \

--- a/opcodes.h
+++ b/opcodes.h
@@ -137,7 +137,7 @@ const char *opcodes_get_name       (int op);
   _fmt(OP_EDITOR_HISTORY_UP,                  N_("scroll up through the history list")) \
   _fmt(OP_EDITOR_KILL_EOL,                    N_("delete chars from cursor to end of line")) \
   _fmt(OP_EDITOR_KILL_EOW,                    N_("delete chars from the cursor to the end of the word")) \
-  _fmt(OP_EDITOR_KILL_LINE,                   N_("delete all chars on the line")) \
+  _fmt(OP_EDITOR_KILL_LINE,                   N_("delete chars from cursor to beginning the line")) \
   _fmt(OP_EDITOR_KILL_WHOLE_LINE,             N_("delete all chars on the line")) \
   _fmt(OP_EDITOR_KILL_WORD,                   N_("delete the word in front of the cursor")) \
   _fmt(OP_EDITOR_MAILBOX_CYCLE,               N_("cycle among incoming mailboxes")) \

--- a/test/Makefile.autosetup
+++ b/test/Makefile.autosetup
@@ -171,6 +171,23 @@ EMAIL_OBJS	= test/email/common.o \
 		  test/email/mutt_autocrypthdr_free.o \
 		  test/email/mutt_autocrypthdr_new.o
 
+ENTER_OBJS	= test/enter/editor_backspace.o \
+		  test/enter/editor_backward_char.o \
+		  test/enter/editor_backward_word.o \
+		  test/enter/editor_bol.o \
+		  test/enter/editor_case_word.o \
+		  test/enter/editor_delete_char.o \
+		  test/enter/editor_eol.o \
+		  test/enter/editor_forward_char.o \
+		  test/enter/editor_forward_word.o \
+		  test/enter/editor_kill_eol.o \
+		  test/enter/editor_kill_eow.o \
+		  test/enter/editor_kill_line.o \
+		  test/enter/editor_kill_whole_line.o \
+		  test/enter/editor_kill_word.o \
+		  test/enter/editor_transpose_chars.o \
+		  test/enter/state.o
+
 ENVELOPE_OBJS	= test/envelope/mutt_env_cmp_strict.o \
 		  test/envelope/mutt_env_free.o \
 		  test/envelope/mutt_env_merge.o \
@@ -563,19 +580,20 @@ BUILD_DIRS	= $(PWD)/test/account $(PWD)/test/address $(PWD)/test/array \
 		  $(PWD)/test/atoi $(PWD)/test/attach $(PWD)/test/base64 \
 		  $(PWD)/test/body $(PWD)/test/buffer $(PWD)/test/charset \
 		  $(PWD)/test/compress $(PWD)/test/config $(PWD)/test/convert \
-		  $(PWD)/test/date $(PWD)/test/email $(PWD)/test/envelope \
-		  $(PWD)/test/envlist $(PWD)/test/file $(PWD)/test/filter \
-		  $(PWD)/test/from $(PWD)/test/group $(PWD)/test/gui \
-		  $(PWD)/test/hash $(PWD)/test/history $(PWD)/test/idna \
-		  $(PWD)/test/list $(PWD)/test/logging $(PWD)/test/mailbox \
-		  $(PWD)/test/mapping $(PWD)/test/mbyte $(PWD)/test/md5 \
-		  $(PWD)/test/memory $(PWD)/test/neo $(PWD)/test/notify \
-		  $(PWD)/test/notmuch $(PWD)/test/parameter $(PWD)/test/parse \
-		  $(PWD)/test/path $(PWD)/test/pattern $(PWD)/test/pool \
-		  $(PWD)/test/prex $(PWD)/test/regex $(PWD)/test/rfc2047 \
-		  $(PWD)/test/rfc2231 $(PWD)/test/signal $(PWD)/test/slist \
-		  $(PWD)/test/sort $(PWD)/test/store $(PWD)/test/string \
-		  $(PWD)/test/tags $(PWD)/test/thread $(PWD)/test/url
+		  $(PWD)/test/date $(PWD)/test/email $(PWD)/test/enter \
+		  $(PWD)/test/envelope $(PWD)/test/envlist $(PWD)/test/file \
+		  $(PWD)/test/filter $(PWD)/test/from $(PWD)/test/group \
+		  $(PWD)/test/gui $(PWD)/test/hash $(PWD)/test/history \
+		  $(PWD)/test/idna $(PWD)/test/list $(PWD)/test/logging \
+		  $(PWD)/test/mailbox $(PWD)/test/mapping $(PWD)/test/mbyte \
+		  $(PWD)/test/md5 $(PWD)/test/memory $(PWD)/test/neo \
+		  $(PWD)/test/notify $(PWD)/test/notmuch \
+		  $(PWD)/test/parameter $(PWD)/test/parse $(PWD)/test/path \
+		  $(PWD)/test/pattern $(PWD)/test/pool $(PWD)/test/prex \
+		  $(PWD)/test/regex $(PWD)/test/rfc2047 $(PWD)/test/rfc2231 \
+		  $(PWD)/test/signal $(PWD)/test/slist $(PWD)/test/sort \
+		  $(PWD)/test/store $(PWD)/test/string $(PWD)/test/tags \
+		  $(PWD)/test/thread $(PWD)/test/url
 
 TEST_OBJS	= test/main.o test/common.o \
 		  $(ACCOUNT_OBJS) \
@@ -592,6 +610,7 @@ TEST_OBJS	= test/main.o test/common.o \
 		  $(CONVERT_OBJS) \
 		  $(DATE_OBJS) \
 		  $(EMAIL_OBJS) \
+		  $(ENTER_OBJS) \
 		  $(ENVELOPE_OBJS) \
 		  $(ENVLIST_OBJS) \
 		  $(FILE_OBJS) \

--- a/test/enter/editor_backspace.c
+++ b/test/enter/editor_backspace.c
@@ -1,0 +1,90 @@
+/**
+ * @file
+ * Test code for editor_backspace()
+ *
+ * @authors
+ * Copyright (C) 2022 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define TEST_NO_MAIN
+#include "config.h"
+#include "acutest.h"
+#include <stddef.h>
+#include <stdbool.h>
+#include "email/lib.h"
+#include "core/lib.h"
+#include "enter/lib.h"
+
+void test_editor_backspace(void)
+{
+  // int editor_backspace(struct EnterState *es);
+
+  {
+    TEST_CHECK(editor_backspace(NULL) == FR_ERROR);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    TEST_CHECK(editor_backspace(es) == FR_ERROR);
+    mutt_enter_state_free(&es);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    editor_buffer_set(es, "test string");
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 11);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 11);
+    editor_buffer_set_cursor(es, 0);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 0);
+    TEST_CHECK(editor_backspace(es) == FR_ERROR);
+    mutt_enter_state_free(&es);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    editor_buffer_set(es, "test string");
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 11);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 11);
+    editor_buffer_set_cursor(es, 3);
+    TEST_CHECK(editor_backspace(es) == FR_SUCCESS);
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 10);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 2);
+    mutt_enter_state_free(&es);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    editor_buffer_set(es, "义勇军");
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 3);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 3);
+    TEST_CHECK(editor_backspace(es) == FR_SUCCESS);
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 2);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 2);
+    mutt_enter_state_free(&es);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    editor_buffer_set(es, "I ❤️");
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 4);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 4);
+    TEST_CHECK(editor_backspace(es) == FR_SUCCESS);
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 2);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 2);
+    mutt_enter_state_free(&es);
+  }
+}

--- a/test/enter/editor_backward_char.c
+++ b/test/enter/editor_backward_char.c
@@ -1,0 +1,90 @@
+/**
+ * @file
+ * Test code for editor_backward_char()
+ *
+ * @authors
+ * Copyright (C) 2022 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define TEST_NO_MAIN
+#include "config.h"
+#include "acutest.h"
+#include <stddef.h>
+#include <stdbool.h>
+#include "email/lib.h"
+#include "core/lib.h"
+#include "enter/lib.h"
+
+void test_editor_backward_char(void)
+{
+  // int editor_backward_char(struct EnterState *es);
+
+  {
+    TEST_CHECK(editor_backward_char(NULL) == FR_ERROR);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    TEST_CHECK(editor_backward_char(es) == FR_ERROR);
+    mutt_enter_state_free(&es);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    editor_buffer_set(es, "test string");
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 11);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 11);
+    editor_buffer_set_cursor(es, 0);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 0);
+    TEST_CHECK(editor_backward_char(es) == FR_ERROR);
+    mutt_enter_state_free(&es);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    editor_buffer_set(es, "test string");
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 11);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 11);
+    editor_buffer_set_cursor(es, 3);
+    TEST_CHECK(editor_backward_char(es) == FR_SUCCESS);
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 11);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 2);
+    mutt_enter_state_free(&es);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    editor_buffer_set(es, "义勇军");
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 3);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 3);
+    TEST_CHECK(editor_backward_char(es) == FR_SUCCESS);
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 3);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 2);
+    mutt_enter_state_free(&es);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    editor_buffer_set(es, "I ❤️");
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 4);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 4);
+    TEST_CHECK(editor_backward_char(es) == FR_SUCCESS);
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 4);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 2);
+    mutt_enter_state_free(&es);
+  }
+}

--- a/test/enter/editor_backward_word.c
+++ b/test/enter/editor_backward_word.c
@@ -1,0 +1,100 @@
+/**
+ * @file
+ * Test code for editor_backward_word()
+ *
+ * @authors
+ * Copyright (C) 2022 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define TEST_NO_MAIN
+#include "config.h"
+#include "acutest.h"
+#include <stddef.h>
+#include <stdbool.h>
+#include "email/lib.h"
+#include "core/lib.h"
+#include "enter/lib.h"
+
+void test_editor_backward_word(void)
+{
+  // int editor_backward_word(struct EnterState *es);
+
+  {
+    TEST_CHECK(editor_backward_word(NULL) == FR_ERROR);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    TEST_CHECK(editor_backward_word(es) == FR_ERROR);
+    mutt_enter_state_free(&es);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    editor_buffer_set(es, "test string");
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 11);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 11);
+    editor_buffer_set_cursor(es, 0);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 0);
+    TEST_CHECK(editor_backward_word(es) == FR_ERROR);
+    mutt_enter_state_free(&es);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    editor_buffer_set(es, "test string");
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 11);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 11);
+    TEST_CHECK(editor_backward_word(es) == FR_SUCCESS);
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 11);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 5);
+    mutt_enter_state_free(&es);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    editor_buffer_set(es, "test string  ");
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 13);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 13);
+    TEST_CHECK(editor_backward_word(es) == FR_SUCCESS);
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 13);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 5);
+    mutt_enter_state_free(&es);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    editor_buffer_set(es, "test 义勇军");
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 8);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 8);
+    TEST_CHECK(editor_backward_word(es) == FR_SUCCESS);
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 8);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 5);
+    mutt_enter_state_free(&es);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    editor_buffer_set(es, "I ❤️");
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 4);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 4);
+    TEST_CHECK(editor_backward_word(es) == FR_SUCCESS);
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 4);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 2);
+    mutt_enter_state_free(&es);
+  }
+}

--- a/test/enter/editor_bol.c
+++ b/test/enter/editor_bol.c
@@ -1,0 +1,67 @@
+/**
+ * @file
+ * Test code for editor_bol()
+ *
+ * @authors
+ * Copyright (C) 2022 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define TEST_NO_MAIN
+#include "config.h"
+#include "acutest.h"
+#include <stddef.h>
+#include <stdbool.h>
+#include "email/lib.h"
+#include "core/lib.h"
+#include "enter/lib.h"
+
+void test_editor_bol(void)
+{
+  // int editor_bol(struct EnterState *es);
+
+  {
+    TEST_CHECK(editor_bol(NULL) == FR_ERROR);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    TEST_CHECK(editor_bol(es) == FR_SUCCESS);
+    mutt_enter_state_free(&es);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    editor_buffer_set(es, "test string");
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 11);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 11);
+    TEST_CHECK(editor_bol(es) == FR_SUCCESS);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 0);
+    mutt_enter_state_free(&es);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    editor_buffer_set(es, "test string");
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 11);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 11);
+    editor_buffer_set_cursor(es, 0);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 0);
+    TEST_CHECK(editor_bol(es) == FR_SUCCESS);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 0);
+    mutt_enter_state_free(&es);
+  }
+}

--- a/test/enter/editor_case_word.c
+++ b/test/enter/editor_case_word.c
@@ -1,0 +1,159 @@
+/**
+ * @file
+ * Test code for editor_case_word()
+ *
+ * @authors
+ * Copyright (C) 2022 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define TEST_NO_MAIN
+#include "config.h"
+#include "acutest.h"
+#include <stddef.h>
+#include <stdbool.h>
+#include "email/lib.h"
+#include "core/lib.h"
+#include "enter/lib.h"
+
+void test_editor_case_word(void)
+{
+  // int editor_case_word(struct EnterState *es, enum EnterCase ec);
+
+  {
+    TEST_CHECK(editor_case_word(NULL, EC_CAPITALIZE) == FR_ERROR);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    TEST_CHECK(editor_case_word(es, EC_CAPITALIZE) == FR_ERROR);
+    mutt_enter_state_free(&es);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    editor_buffer_set(es, "test string");
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 11);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 11);
+    editor_bol(es);
+    TEST_CHECK(editor_case_word(es, EC_CAPITALIZE) == FR_SUCCESS);
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 11);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 4);
+
+    char buf[64];
+    mutt_mb_wcstombs(buf, sizeof(buf), es->wbuf, es->lastchar);
+    TEST_CHECK(mutt_str_equal(buf, "Test string"));
+    mutt_enter_state_free(&es);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    editor_buffer_set(es, "TEST string");
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 11);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 11);
+    editor_bol(es);
+    TEST_CHECK(editor_case_word(es, EC_CAPITALIZE) == FR_SUCCESS);
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 11);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 4);
+
+    char buf[64];
+    mutt_mb_wcstombs(buf, sizeof(buf), es->wbuf, es->lastchar);
+    TEST_CHECK(mutt_str_equal(buf, "Test string"));
+    mutt_enter_state_free(&es);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    editor_buffer_set(es, "test string");
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 11);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 11);
+    editor_bol(es);
+    TEST_CHECK(editor_case_word(es, EC_UPCASE) == FR_SUCCESS);
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 11);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 4);
+
+    char buf[64];
+    mutt_mb_wcstombs(buf, sizeof(buf), es->wbuf, es->lastchar);
+    TEST_CHECK(mutt_str_equal(buf, "TEST string"));
+    mutt_enter_state_free(&es);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    editor_buffer_set(es, "test string");
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 11);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 11);
+    editor_buffer_set_cursor(es, 7);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 7);
+    TEST_CHECK(editor_case_word(es, EC_UPCASE) == FR_SUCCESS);
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 11);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 11);
+
+    char buf[64];
+    mutt_mb_wcstombs(buf, sizeof(buf), es->wbuf, es->lastchar);
+    TEST_CHECK(mutt_str_equal(buf, "test stRING"));
+    mutt_enter_state_free(&es);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    editor_buffer_set(es, "test     string    ");
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 19);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 19);
+    editor_buffer_set_cursor(es, 6);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 6);
+    TEST_CHECK(editor_case_word(es, EC_UPCASE) == FR_SUCCESS);
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 19);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 15);
+
+    char buf[64];
+    mutt_mb_wcstombs(buf, sizeof(buf), es->wbuf, es->lastchar);
+    TEST_CHECK(mutt_str_equal(buf, "test     STRING    "));
+    mutt_enter_state_free(&es);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    editor_buffer_set(es, "test string");
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 11);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 11);
+    editor_bol(es);
+    TEST_CHECK(editor_case_word(es, EC_UPCASE) == FR_SUCCESS);
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 11);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 4);
+
+    char buf[64];
+    mutt_mb_wcstombs(buf, sizeof(buf), es->wbuf, es->lastchar);
+    TEST_CHECK(mutt_str_equal(buf, "TEST string"));
+    mutt_enter_state_free(&es);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    editor_buffer_set(es, "TEST STRING");
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 11);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 11);
+    editor_bol(es);
+    TEST_CHECK(editor_case_word(es, EC_DOWNCASE) == FR_SUCCESS);
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 11);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 4);
+
+    char buf[64];
+    mutt_mb_wcstombs(buf, sizeof(buf), es->wbuf, es->lastchar);
+    TEST_CHECK(mutt_str_equal(buf, "test STRING"));
+    mutt_enter_state_free(&es);
+  }
+}

--- a/test/enter/editor_delete_char.c
+++ b/test/enter/editor_delete_char.c
@@ -1,0 +1,92 @@
+/**
+ * @file
+ * Test code for editor_delete_char()
+ *
+ * @authors
+ * Copyright (C) 2022 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define TEST_NO_MAIN
+#include "config.h"
+#include "acutest.h"
+#include <stddef.h>
+#include <stdbool.h>
+#include "email/lib.h"
+#include "core/lib.h"
+#include "enter/lib.h"
+
+void test_editor_delete_char(void)
+{
+  // int editor_delete_char(struct EnterState *es);
+
+  {
+    TEST_CHECK(editor_delete_char(NULL) == FR_ERROR);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    TEST_CHECK(editor_delete_char(es) == FR_ERROR);
+    mutt_enter_state_free(&es);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    editor_buffer_set(es, "test string");
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 11);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 11);
+    TEST_CHECK(editor_delete_char(es) == FR_ERROR);
+    mutt_enter_state_free(&es);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    editor_buffer_set(es, "test string");
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 11);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 11);
+    editor_buffer_set_cursor(es, 3);
+    TEST_CHECK(editor_delete_char(es) == FR_SUCCESS);
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 10);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 3);
+    mutt_enter_state_free(&es);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    editor_buffer_set(es, "义勇军");
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 3);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 3);
+    editor_buffer_set_cursor(es, 1);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 1);
+    TEST_CHECK(editor_delete_char(es) == FR_SUCCESS);
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 2);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 1);
+    mutt_enter_state_free(&es);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    editor_buffer_set(es, "I ❤️");
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 4);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 4);
+    editor_buffer_set_cursor(es, 2);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 2);
+    TEST_CHECK(editor_delete_char(es) == FR_SUCCESS);
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 2);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 2);
+    mutt_enter_state_free(&es);
+  }
+}

--- a/test/enter/editor_eol.c
+++ b/test/enter/editor_eol.c
@@ -1,0 +1,67 @@
+/**
+ * @file
+ * Test code for editor_eol()
+ *
+ * @authors
+ * Copyright (C) 2022 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define TEST_NO_MAIN
+#include "config.h"
+#include "acutest.h"
+#include <stddef.h>
+#include <stdbool.h>
+#include "email/lib.h"
+#include "core/lib.h"
+#include "enter/lib.h"
+
+void test_editor_eol(void)
+{
+  // int editor_eol(struct EnterState *es);
+
+  {
+    TEST_CHECK(editor_eol(NULL) == FR_ERROR);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    TEST_CHECK(editor_eol(es) == FR_SUCCESS);
+    mutt_enter_state_free(&es);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    editor_buffer_set(es, "test string");
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 11);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 11);
+    TEST_CHECK(editor_eol(es) == FR_SUCCESS);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 11);
+    mutt_enter_state_free(&es);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    editor_buffer_set(es, "test string");
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 11);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 11);
+    editor_buffer_set_cursor(es, 0);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 0);
+    TEST_CHECK(editor_eol(es) == FR_SUCCESS);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 11);
+    mutt_enter_state_free(&es);
+  }
+}

--- a/test/enter/editor_forward_char.c
+++ b/test/enter/editor_forward_char.c
@@ -1,0 +1,91 @@
+/**
+ * @file
+ * Test code for editor_forward_char()
+ *
+ * @authors
+ * Copyright (C) 2022 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define TEST_NO_MAIN
+#include "config.h"
+#include "acutest.h"
+#include <stddef.h>
+#include <stdbool.h>
+#include "email/lib.h"
+#include "core/lib.h"
+#include "enter/lib.h"
+
+void test_editor_forward_char(void)
+{
+  // int editor_forward_char(struct EnterState *es);
+
+  {
+    TEST_CHECK(editor_forward_char(NULL) == FR_ERROR);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    TEST_CHECK(editor_forward_char(es) == FR_ERROR);
+    mutt_enter_state_free(&es);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    editor_buffer_set(es, "test string");
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 11);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 11);
+    TEST_CHECK(editor_forward_char(es) == FR_ERROR);
+    mutt_enter_state_free(&es);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    editor_buffer_set(es, "test string");
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 11);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 11);
+    editor_buffer_set_cursor(es, 3);
+    TEST_CHECK(editor_forward_char(es) == FR_SUCCESS);
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 11);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 4);
+    mutt_enter_state_free(&es);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    editor_buffer_set(es, "义勇军");
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 3);
+    editor_buffer_set_cursor(es, 1);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 1);
+    TEST_CHECK(editor_forward_char(es) == FR_SUCCESS);
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 3);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 2);
+    mutt_enter_state_free(&es);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    editor_buffer_set(es, "I ❤️xyz");
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 7);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 7);
+    editor_buffer_set_cursor(es, 2);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 2);
+    TEST_CHECK(editor_forward_char(es) == FR_SUCCESS);
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 7);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 4);
+    mutt_enter_state_free(&es);
+  }
+}

--- a/test/enter/editor_forward_word.c
+++ b/test/enter/editor_forward_word.c
@@ -1,0 +1,106 @@
+/**
+ * @file
+ * Test code for editor_forward_word()
+ *
+ * @authors
+ * Copyright (C) 2022 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define TEST_NO_MAIN
+#include "config.h"
+#include "acutest.h"
+#include <stddef.h>
+#include <stdbool.h>
+#include "email/lib.h"
+#include "core/lib.h"
+#include "enter/lib.h"
+
+void test_editor_forward_word(void)
+{
+  // int editor_forward_word(struct EnterState *es);
+
+  {
+    TEST_CHECK(editor_forward_word(NULL) == FR_ERROR);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    TEST_CHECK(editor_forward_word(es) == FR_ERROR);
+    mutt_enter_state_free(&es);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    editor_buffer_set(es, "test string");
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 11);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 11);
+    TEST_CHECK(editor_forward_word(es) == FR_ERROR);
+    mutt_enter_state_free(&es);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    editor_buffer_set(es, "test string");
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 11);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 11);
+    editor_buffer_set_cursor(es, 0);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 0);
+    TEST_CHECK(editor_forward_word(es) == FR_SUCCESS);
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 11);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 4);
+    mutt_enter_state_free(&es);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    editor_buffer_set(es, "  test string");
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 13);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 13);
+    editor_buffer_set_cursor(es, 0);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 0);
+    TEST_CHECK(editor_forward_word(es) == FR_SUCCESS);
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 13);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 6);
+    mutt_enter_state_free(&es);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    editor_buffer_set(es, "test 义勇军 abc");
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 12);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 12);
+    editor_buffer_set_cursor(es, 4);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 4);
+    TEST_CHECK(editor_forward_word(es) == FR_SUCCESS);
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 12);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 8);
+    mutt_enter_state_free(&es);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    editor_buffer_set(es, "I ❤️  xyz");
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 9);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 9);
+    editor_buffer_set_cursor(es, 2);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 2);
+    TEST_CHECK(editor_forward_word(es) == FR_SUCCESS);
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 9);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 4);
+    mutt_enter_state_free(&es);
+  }
+}

--- a/test/enter/editor_kill_eol.c
+++ b/test/enter/editor_kill_eol.c
@@ -1,0 +1,82 @@
+/**
+ * @file
+ * Test code for editor_kill_eol()
+ *
+ * @authors
+ * Copyright (C) 2022 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define TEST_NO_MAIN
+#include "config.h"
+#include "acutest.h"
+#include <stddef.h>
+#include <stdbool.h>
+#include "email/lib.h"
+#include "core/lib.h"
+#include "enter/lib.h"
+
+void test_editor_kill_eol(void)
+{
+  // int editor_kill_eol(struct EnterState *es);
+
+  {
+    TEST_CHECK(editor_kill_eol(NULL) == FR_ERROR);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    TEST_CHECK(editor_kill_eol(es) == FR_SUCCESS);
+    mutt_enter_state_free(&es);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    editor_buffer_set(es, "test string");
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 11);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 11);
+    editor_buffer_set_cursor(es, 0);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 0);
+    TEST_CHECK(editor_kill_eol(es) == FR_SUCCESS);
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 0);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 0);
+    mutt_enter_state_free(&es);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    editor_buffer_set(es, "test string");
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 11);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 11);
+    editor_buffer_set_cursor(es, 4);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 4);
+    TEST_CHECK(editor_kill_eol(es) == FR_SUCCESS);
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 4);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 4);
+    mutt_enter_state_free(&es);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    editor_buffer_set(es, "test string");
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 11);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 11);
+    TEST_CHECK(editor_kill_eol(es) == FR_SUCCESS);
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 11);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 11);
+    mutt_enter_state_free(&es);
+  }
+}

--- a/test/enter/editor_kill_eow.c
+++ b/test/enter/editor_kill_eow.c
@@ -1,0 +1,93 @@
+/**
+ * @file
+ * Test code for editor_kill_eow()
+ *
+ * @authors
+ * Copyright (C) 2022 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define TEST_NO_MAIN
+#include "config.h"
+#include "acutest.h"
+#include <stddef.h>
+#include <stdbool.h>
+#include "email/lib.h"
+#include "core/lib.h"
+#include "enter/lib.h"
+
+void test_editor_kill_eow(void)
+{
+  // int editor_kill_eow(struct EnterState *es);
+
+  {
+    TEST_CHECK(editor_kill_eow(NULL) == FR_ERROR);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    TEST_CHECK(editor_kill_eow(es) == FR_SUCCESS);
+    mutt_enter_state_free(&es);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    editor_buffer_set(es, "test string");
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 11);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 11);
+    TEST_CHECK(editor_kill_eow(es) == FR_SUCCESS);
+    mutt_enter_state_free(&es);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    editor_buffer_set(es, "test string");
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 11);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 11);
+    editor_buffer_set_cursor(es, 0);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 0);
+    TEST_CHECK(editor_kill_eow(es) == FR_SUCCESS);
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 7);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 0);
+    mutt_enter_state_free(&es);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    editor_buffer_set(es, "apple 义勇军 banana");
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 16);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 16);
+    editor_buffer_set_cursor(es, 6);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 6);
+    TEST_CHECK(editor_kill_eow(es) == FR_SUCCESS);
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 13);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 6);
+    mutt_enter_state_free(&es);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    editor_buffer_set(es, "I ❤️xyz abc");
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 11);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 11);
+    editor_buffer_set_cursor(es, 2);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 2);
+    TEST_CHECK(editor_kill_eow(es) == FR_SUCCESS);
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 10);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 2);
+    mutt_enter_state_free(&es);
+  }
+}

--- a/test/enter/editor_kill_line.c
+++ b/test/enter/editor_kill_line.c
@@ -1,0 +1,82 @@
+/**
+ * @file
+ * Test code for editor_kill_line()
+ *
+ * @authors
+ * Copyright (C) 2022 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define TEST_NO_MAIN
+#include "config.h"
+#include "acutest.h"
+#include <stddef.h>
+#include <stdbool.h>
+#include "email/lib.h"
+#include "core/lib.h"
+#include "enter/lib.h"
+
+void test_editor_kill_line(void)
+{
+  // int editor_kill_line(struct EnterState *es);
+
+  {
+    TEST_CHECK(editor_kill_line(NULL) == FR_ERROR);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    TEST_CHECK(editor_kill_line(es) == FR_SUCCESS);
+    mutt_enter_state_free(&es);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    editor_buffer_set(es, "test string");
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 11);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 11);
+    editor_buffer_set_cursor(es, 0);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 0);
+    TEST_CHECK(editor_kill_line(es) == FR_SUCCESS);
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 11);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 0);
+    mutt_enter_state_free(&es);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    editor_buffer_set(es, "test string");
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 11);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 11);
+    editor_buffer_set_cursor(es, 4);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 4);
+    TEST_CHECK(editor_kill_line(es) == FR_SUCCESS);
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 7);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 0);
+    mutt_enter_state_free(&es);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    editor_buffer_set(es, "test string");
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 11);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 11);
+    TEST_CHECK(editor_kill_line(es) == FR_SUCCESS);
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 0);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 0);
+    mutt_enter_state_free(&es);
+  }
+}

--- a/test/enter/editor_kill_whole_line.c
+++ b/test/enter/editor_kill_whole_line.c
@@ -1,0 +1,82 @@
+/**
+ * @file
+ * Test code for editor_kill_whole_line()
+ *
+ * @authors
+ * Copyright (C) 2022 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define TEST_NO_MAIN
+#include "config.h"
+#include "acutest.h"
+#include <stddef.h>
+#include <stdbool.h>
+#include "email/lib.h"
+#include "core/lib.h"
+#include "enter/lib.h"
+
+void test_editor_kill_whole_line(void)
+{
+  // int editor_kill_whole_line(struct EnterState *es);
+
+  {
+    TEST_CHECK(editor_kill_whole_line(NULL) == FR_ERROR);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    TEST_CHECK(editor_kill_whole_line(es) == FR_SUCCESS);
+    mutt_enter_state_free(&es);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    editor_buffer_set(es, "test string");
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 11);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 11);
+    editor_buffer_set_cursor(es, 0);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 0);
+    TEST_CHECK(editor_kill_whole_line(es) == FR_SUCCESS);
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 0);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 0);
+    mutt_enter_state_free(&es);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    editor_buffer_set(es, "test string");
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 11);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 11);
+    editor_buffer_set_cursor(es, 4);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 4);
+    TEST_CHECK(editor_kill_whole_line(es) == FR_SUCCESS);
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 0);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 0);
+    mutt_enter_state_free(&es);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    editor_buffer_set(es, "test string");
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 11);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 11);
+    TEST_CHECK(editor_kill_whole_line(es) == FR_SUCCESS);
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 0);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 0);
+    mutt_enter_state_free(&es);
+  }
+}

--- a/test/enter/editor_kill_word.c
+++ b/test/enter/editor_kill_word.c
@@ -1,0 +1,104 @@
+/**
+ * @file
+ * Test code for editor_kill_word()
+ *
+ * @authors
+ * Copyright (C) 2022 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define TEST_NO_MAIN
+#include "config.h"
+#include "acutest.h"
+#include <stddef.h>
+#include <stdbool.h>
+#include "email/lib.h"
+#include "core/lib.h"
+#include "enter/lib.h"
+
+void test_editor_kill_word(void)
+{
+  // int editor_kill_word(struct EnterState *es);
+
+  {
+    TEST_CHECK(editor_kill_word(NULL) == FR_ERROR);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    TEST_CHECK(editor_kill_word(es) == FR_ERROR);
+    mutt_enter_state_free(&es);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    editor_buffer_set(es, "test string");
+    editor_buffer_set_cursor(es, 0);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 0);
+    TEST_CHECK(editor_kill_word(es) == FR_ERROR);
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 11);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 0);
+    mutt_enter_state_free(&es);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    editor_buffer_set(es, "test string");
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 11);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 11);
+    TEST_CHECK(editor_kill_word(es) == FR_SUCCESS);
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 5);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 5);
+    mutt_enter_state_free(&es);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    editor_buffer_set(es, "test string--");
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 13);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 13);
+    TEST_CHECK(editor_kill_word(es) == FR_SUCCESS);
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 12);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 12);
+    mutt_enter_state_free(&es);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    editor_buffer_set(es, "apple 义勇军 banana");
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 16);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 16);
+    editor_buffer_set_cursor(es, 10);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 10);
+    TEST_CHECK(editor_kill_word(es) == FR_SUCCESS);
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 12);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 6);
+    mutt_enter_state_free(&es);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    editor_buffer_set(es, "I ❤️xyz abc");
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 11);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 11);
+    editor_buffer_set_cursor(es, 7);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 7);
+    TEST_CHECK(editor_kill_word(es) == FR_SUCCESS);
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 8);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 4);
+    mutt_enter_state_free(&es);
+  }
+}

--- a/test/enter/editor_transpose_chars.c
+++ b/test/enter/editor_transpose_chars.c
@@ -1,0 +1,92 @@
+/**
+ * @file
+ * Test code for editor_transpose_chars()
+ *
+ * @authors
+ * Copyright (C) 2022 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define TEST_NO_MAIN
+#include "config.h"
+#include "acutest.h"
+#include <stddef.h>
+#include <stdbool.h>
+#include "email/lib.h"
+#include "core/lib.h"
+#include "enter/lib.h"
+
+void test_editor_transpose_chars(void)
+{
+  // int editor_transpose_chars(struct EnterState *es);
+
+  {
+    TEST_CHECK(editor_transpose_chars(NULL) == FR_ERROR);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    TEST_CHECK(editor_transpose_chars(es) == FR_ERROR);
+    mutt_enter_state_free(&es);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    editor_buffer_set(es, "t");
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 1);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 1);
+    TEST_CHECK(editor_transpose_chars(es) == FR_ERROR);
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 1);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 1);
+    mutt_enter_state_free(&es);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    editor_buffer_set(es, "test string");
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 11);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 11);
+    TEST_CHECK(editor_transpose_chars(es) == FR_SUCCESS);
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 11);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 11);
+    mutt_enter_state_free(&es);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    editor_buffer_set(es, "test string");
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 11);
+    editor_buffer_set_cursor(es, 0);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 0);
+    TEST_CHECK(editor_transpose_chars(es) == FR_SUCCESS);
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 11);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 2);
+    mutt_enter_state_free(&es);
+  }
+
+  {
+    struct EnterState *es = mutt_enter_state_new();
+    editor_buffer_set(es, "apple 义勇军 banana");
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 16);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 16);
+    editor_buffer_set_cursor(es, 7);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 7);
+    TEST_CHECK(editor_transpose_chars(es) == FR_SUCCESS);
+    TEST_CHECK(editor_buffer_get_lastchar(es) == 16);
+    TEST_CHECK(editor_buffer_get_cursor(es) == 8);
+    mutt_enter_state_free(&es);
+  }
+}

--- a/test/enter/state.c
+++ b/test/enter/state.c
@@ -1,0 +1,43 @@
+/**
+ * @file
+ * Test code for the editor state
+ *
+ * @authors
+ * Copyright (C) 2022 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define TEST_NO_MAIN
+#include "config.h"
+#include "acutest.h"
+#include <stddef.h>
+#include <stdbool.h>
+#include "email/lib.h"
+#include "core/lib.h"
+#include "enter/lib.h"
+
+void test_editor_state(void)
+{
+  struct EnterState *es = mutt_enter_state_new();
+
+  mutt_enter_state_resize(NULL, 16);
+
+  mutt_enter_state_resize(es, 16);
+
+  mutt_enter_state_free(&es);
+
+  mutt_enter_state_free(NULL);
+}

--- a/test/main.c
+++ b/test/main.c
@@ -197,6 +197,24 @@
   NEOMUTT_TEST_ITEM(test_email_header_set)                                     \
   NEOMUTT_TEST_ITEM(test_email_header_free)                                    \
                                                                                \
+  /* enter */                                                                  \
+  NEOMUTT_TEST_ITEM(test_editor_backspace)                                     \
+  NEOMUTT_TEST_ITEM(test_editor_backward_char)                                 \
+  NEOMUTT_TEST_ITEM(test_editor_backward_word)                                 \
+  NEOMUTT_TEST_ITEM(test_editor_bol)                                           \
+  NEOMUTT_TEST_ITEM(test_editor_case_word)                                     \
+  NEOMUTT_TEST_ITEM(test_editor_delete_char)                                   \
+  NEOMUTT_TEST_ITEM(test_editor_eol)                                           \
+  NEOMUTT_TEST_ITEM(test_editor_forward_char)                                  \
+  NEOMUTT_TEST_ITEM(test_editor_forward_word)                                  \
+  NEOMUTT_TEST_ITEM(test_editor_kill_eol)                                      \
+  NEOMUTT_TEST_ITEM(test_editor_kill_eow)                                      \
+  NEOMUTT_TEST_ITEM(test_editor_kill_line)                                     \
+  NEOMUTT_TEST_ITEM(test_editor_kill_whole_line)                               \
+  NEOMUTT_TEST_ITEM(test_editor_kill_word)                                     \
+  NEOMUTT_TEST_ITEM(test_editor_state)                                         \
+  NEOMUTT_TEST_ITEM(test_editor_transpose_chars)                               \
+                                                                               \
   /* envelope */                                                               \
   NEOMUTT_TEST_ITEM(test_mutt_env_cmp_strict)                                  \
   NEOMUTT_TEST_ITEM(test_mutt_env_free)                                        \

--- a/test/pattern/dummy.c
+++ b/test/pattern/dummy.c
@@ -48,9 +48,9 @@ struct KeyEvent
 enum WindowType
 {
   // Structural Windows
-  WT_ROOT,            ///< Parent of All Windows
-  WT_CONTAINER,       ///< Invisible shaping container Window
-  WT_ALL_DIALOGS,     ///< Container for All Dialogs (nested Windows)
+  WT_ROOT,        ///< Parent of All Windows
+  WT_CONTAINER,   ///< Invisible shaping container Window
+  WT_ALL_DIALOGS, ///< Container for All Dialogs (nested Windows)
 
   // Dialogs (nested Windows) displayed to the user
   WT_DLG_ALIAS,       ///< Alias Dialog,       dlg_select_alias()
@@ -71,16 +71,15 @@ enum WindowType
   WT_DLG_SMIME,       ///< Smime Dialog,       dlg_select_smime_key()
 
   // Common Windows
-  WT_CUSTOM,          ///< Window with a custom drawing function
-  WT_HELP_BAR,        ///< Help Bar containing list of useful key bindings
-  WT_INDEX,           ///< A panel containing the Index Window
-  WT_MENU,            ///< An Window containing a Menu
-  WT_MESSAGE,         ///< Window for messages/errors and command entry
-  WT_PAGER,           ///< A panel containing the Pager Window
-  WT_SIDEBAR,         ///< Side panel containing Accounts or groups of data
-  WT_STATUS_BAR,      ///< Status Bar containing extra info about the Index/Pager/etc
+  WT_CUSTOM,     ///< Window with a custom drawing function
+  WT_HELP_BAR,   ///< Help Bar containing list of useful key bindings
+  WT_INDEX,      ///< A panel containing the Index Window
+  WT_MENU,       ///< An Window containing a Menu
+  WT_MESSAGE,    ///< Window for messages/errors and command entry
+  WT_PAGER,      ///< A panel containing the Pager Window
+  WT_SIDEBAR,    ///< Side panel containing Accounts or groups of data
+  WT_STATUS_BAR, ///< Status Bar containing extra info about the Index/Pager/etc
 };
-
 
 bool g_addr_is_user = false;
 int g_body_parts = 1;
@@ -335,7 +334,8 @@ bool mutt_nm_tag_complete(char *buf, size_t buflen, int numtabs)
   return false;
 }
 
-void mutt_select_file(char *file, size_t filelen, SelectFileFlags flags, struct Mailbox *m, char ***files, int *numfiles)
+void mutt_select_file(char *file, size_t filelen, SelectFileFlags flags,
+                      struct Mailbox *m, char ***files, int *numfiles)
 {
 }
 
@@ -362,7 +362,8 @@ void simple_dialog_free(struct MuttWindow **ptr)
 {
 }
 
-struct MuttWindow *simple_dialog_new(enum MenuType mtype, enum WindowType wtype, const struct Mapping *help_data)
+struct MuttWindow *simple_dialog_new(enum MenuType mtype, enum WindowType wtype,
+                                     const struct Mapping *help_data)
 {
   return NULL;
 }


### PR DESCRIPTION
Unify the behaviour of text-entry with that of readline.

- Kill line <kbd>Ctrl-u</kbd>
  **Old**: Kill the entire line
  **New**: Kill from the cursor to the beginning-of-line

- Capitalise <kbd>Alt-c</kbd>, Downcase <kbd>Alt-l</kbd>, Upcase <kbd>Alt-u</kbd>
  **Old**: Fix case of **entire** word
  **New**: Fix case from cursor to end-of-word

---

- 33571c45c add function `kill-whole-line`
  Add a new NeoMutt function that kills the **entire** line

- 0e91123fa add state resize function
  Let the state do its own memory management.
  (this is another step towards making the text-entry buffer opaque)

- 028ccc9d8 match functions to readline behaviour
  Fix behaviour of: `kill-line`, `capitalize-word`, `downcase-word`, `upcase-word`

- a8c405939 add test coverage
  Create units tests for all the editor functions