### PR TITLE
keymap.c: Remove superfluous code

### DIFF
--- a/keymap.c
+++ b/keymap.c
@@ -703,9 +703,6 @@ struct KeyEvent km_dokey_event(enum MenuType mtype)
       if ((funcs = km_get_table(mtype)) && (func = mutt_get_func(funcs, tmp.op)))
         return tmp;
 
-      if ((mtype == MENU_EDITOR) && mutt_get_func(OpEditor, tmp.op))
-        return tmp;
-
       if ((mtype != MENU_EDITOR) && (mtype != MENU_PAGER) && (mtype != MENU_GENERIC))
       {
         /* check generic menu type */


### PR DESCRIPTION
Probably shouldn't have done it but I was curious why pager did not use the generic menu.
On the way I found this superfluous piece of code.

It's superfluous because in the previous if we already checked the op for mtype, no need to do it again for editor if mtype == MENU_EDITOR.