### PR TITLE
muttlib/mutt_expando_format: allow for longer expansions in e.g. index_format

### DIFF
--- a/muttlib.c
+++ b/muttlib.c
@@ -785,7 +785,7 @@ void mutt_expando_format(char *buf, size_t buflen, size_t col, int cols, const c
   FILE *fp_filter = NULL;
   char *recycler = NULL;
 
-  char src2[256];
+  char src2[1024];
   mutt_str_copy(src2, src, mutt_str_len(src) + 1);
   src = src2;
 


### PR DESCRIPTION
* **What does this PR do?**

It allows expansion strings not to be limited to 256 characters.

In my index, I like to use a lot of icons and colors to categorize my messages based on the notmuch tags they get, this results in a very long `index_format` string because I'm not using `%g`, but am individually enumerating all the tags as `%Gx`.

My currrent index_format:

``
set index_format='%4C %Z %<[y?%<[m?%<[d?%10[     %H:%M  ]&%10[%a %b %d  ]>&%12[%b %d  ]>&%10[%b %d, %Y]> %-20.20L %?E?%2.e/%2.E&     ? %?Gi?%Gi&?%?GS?%GS&?%?Gr?%Gr&?%?Gt?%Gt&?%?GI?%GI&?%?GL?%GL&?%?Gl?%Gl&?%?GW?%GW&?%?GD?%GD&?%?Gc?%Gc&?%?Gs?%Gs&?%?Ge?%Ge&?%?Gp?%Gp&?%?Gw?%Gw&?%?Gf?%Gf&?%?Gn?%Gn&?%?Gu?%Gu&?%?Gg?%Gg&?%?Gy?%Gy&?%?GP?%GP&?%?Gh?%Gh&?%?GF?%GF&?%?G2?%G2&?%?GT?%GT&?%?GM?%GM&? %s'
``

This didn't render correctly as the index_format was clipped off at 256, I now increased this to 1024 (might not be the most sustainable solution but at least gives some more breathing room)

* **Screenshots (if relevant)**

After the fix: 

![image](https://user-images.githubusercontent.com/75427/173229932-e61f65d6-92f7-447d-880d-d326905d61f5.png)

Before the fix only a few icons showed and %s was cut off.

* **What are the relevant issue numbers?**

I haven't seen any issues about this yet