### PR TITLE
Add encryption and decryption pipes to arg parser

### DIFF
--- a/contrib/oauth2/mutt_oauth2.py.README
+++ b/contrib/oauth2/mutt_oauth2.py.README
@@ -117,19 +117,18 @@ Configure script's token file encryption
 ----------------------------------------
 
 The script remembers tokens between invocations by keeping them in a
-token file. This file is encrypted. Inside the script are two lines
-  ENCRYPTION_PIPE
-  DECRYPTION_PIPE
-that must be edited to specify your choice of encryption system. A
-popular choice is gpg. To use this:
+token file. This file is encrypted.
+
+A popular choice is gpg. To use this:
 
  - Install gpg. For example, "sudo apt install gpg".
  - "gpg --gen-key". Answer the questions. Instead of your email
    address you could choose say "My mutt_oauth2 token store", then
    choose a passphrase. You will need to produce that same passphrase
    whenever mutt_oauth2 needs to unlock the token store.
- - Edit mutt_oauth2.py and put your GPG identity (your email address or
-   whatever you picked above) in the ENCRYPTION_PIPE line.
+ - Pass your GPG identity (your email address or whatever you picked above)
+   to mutt_oauth2.py via --encryption-pipe
+   example: --encryption-pipe "gpg --encrypt --recipient YOUR_GPG_IDENTITY"
  - For the gpg-agent to be able to ask you the unlock passphrase,
    the environment variable GPG_TTY must be set to the current tty.
    Typically you would put the following inside your .profile or equivalent:
@@ -153,8 +152,9 @@ which and blessing by the cloud provider might require payment and/or arduous
 review), or might perhaps be willing to roll their own "in-house" registration.
 
 What you ultimately need is the "client_id" (and "client_secret" if
-one was set) for this registration. Those values must be edited into
-the mutt_oauth2.py script.  If your work or school environment has a
+one was set) for this registration. Those values must be passed to
+the mutt_oauth2.py script (using the --provider, --client-id, and
+--client-secret arguments).  If your work or school environment has a
 knowledge base that provides the client_id, then someone already took
 care of the app registration, and you can skip the step of creating
 your own registration.


### PR DESCRIPTION
* **What does this PR do?**
allow use of oauth2 script without manual modification, set executable bit on script

* **Validation**
I didn't see any existing tests (please correct me if I'm wrong). To minimally validate the behavior works as expected, I applied the following patch and tested some inputs:
```diff
diff --git a/contrib/oauth2/mutt_oauth2.py b/contrib/oauth2/mutt_oauth2.py
index 66b741ae3..1bc9f6687 100755
--- a/contrib/oauth2/mutt_oauth2.py
+++ b/contrib/oauth2/mutt_oauth2.py
@@ -103,6 +103,9 @@ args = ap.parse_args()
 
 ENCRYPTION_PIPE = args.encryption_pipe
 DECRYPTION_PIPE = args.decryption_pipe
+print(ENCRYPTION_PIPE)
+print(DECRYPTION_PIPE)
+import os; os._exit(0)
 
 token = {}
 path = Path(args.tokenfile)
```
note that `shlex` handles spaces in quoted arguments as one would expect:
```
> ./mutt_oauth2.py userid@myschool.edu.tokens --verbose --test --encryption-pipe 'gpg --encrypt --recipient "me plus you"' --decrypt 'gpg --decrypt "another arg"'
['gpg', '--encrypt', '--recipient', 'me plus you']
['gpg', '--decrypt', 'another arg']
```
an email won't have spaces, but since this may be an arbitrary command, shlex is good hygiene

default values:
```
> ./mutt_oauth2.py userid@myschool.edu.tokens --verbose --test
['gpg', '--encrypt', '--recipient', 'YOUR_GPG_IDENTITY']
['gpg', '--decrypt']
```
and updated help:
```
options:
  -h, --help            show this help message and exit
  -v, --verbose         increase verbosity
  -d, --debug           enable debug output
  -a, --authorize       manually authorize new tokens
  --authflow AUTHFLOW   authcode | localhostauthcode | devicecode
  -t, --test            test IMAP/POP/SMTP endpoints
  --decryption-pipe DECRYPTION_PIPE
                        decryption command (string) default: "gpg --decrypt"
  --encryption-pipe ENCRYPTION_PIPE
                        encryption command (string) default: "gpg --encrypt --recipient YOUR_GPG_IDENTITY"
```

* **Does this PR meet the acceptance criteria?** (This is just a reminder for you,
  this section can be removed if you fulfill it.)

   - Code follows the [style guide](https://neomutt.org/dev/code)
   
No mention of python that I see on this page, so I used best judgement, avoided additional dependencies, avoided new python3 features for broad compatibility, etc.

* **What are the relevant issue numbers?**

https://github.com/neomutt/neomutt/issues/3441