### PR TITLE
buffer: fix runaway memory allocation

### DIFF
--- a/mutt/buffer.c
+++ b/mutt/buffer.c
@@ -103,7 +103,8 @@ size_t mutt_buffer_addstr_n(struct Buffer *buf, const char *s, size_t len)
   if (!buf || !s)
     return 0;
 
-  mutt_buffer_alloc(buf, buf->dsize + len + 1);
+  if (!buf->data || !buf->dptr || ((buf->dptr + len + 1) > (buf->data + buf->dsize)))
+    mutt_buffer_alloc(buf, buf->dsize + MAX(BufferStepSize, len + 1));
 
   memcpy(buf->dptr, s, len);
   buf->dptr += len;


### PR DESCRIPTION
Fix a bug introduced in 34dc388b4 that caused `mutt_buffer_addstr_n()` to get a bit carried away when allocating memory.

As the function is used by the config parsing code, it caused a slowdown on startup and excessive memory usage.

Fixes: #3445