### PR TITLE
Refactor auto-completion code

### DIFF
--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -198,7 +198,7 @@ $(PWD)/color:
 ###############################################################################
 # libcomplete
 LIBCOMPLETE=	libcomplete.a
-LIBCOMPLETEOBJS=complete/complete.o complete/helpers.o
+LIBCOMPLETEOBJS=complete/complete.o complete/data.o complete/helpers.o
 CLEANFILES+=	$(LIBCOMPLETE) $(LIBCOMPLETEOBJS)
 ALLOBJS+=	$(LIBCOMPLETEOBJS)
 

--- a/complete/complete.c
+++ b/complete/complete.c
@@ -34,6 +34,7 @@
 #include "mutt/lib.h"
 #include "config/lib.h"
 #include "core/lib.h"
+#include "data.h"
 #include "muttlib.h"
 #include "options.h"
 #include "protos.h" // IWYU pragma: keep
@@ -46,6 +47,7 @@
 
 /**
  * mutt_complete - Attempt to complete a partial pathname
+ * @param cd     Completion Data
  * @param buf    Buffer containing pathname
  * @param buflen Length of buffer
  * @retval  0 Ok
@@ -54,7 +56,7 @@
  * Given a partial pathname, fill in as much of the rest of the path as is
  * unique.
  */
-int mutt_complete(char *buf, size_t buflen)
+int mutt_complete(struct CompletionData *cd, char *buf, size_t buflen)
 {
   const char *p = NULL;
   DIR *dirp = NULL;

--- a/complete/data.c
+++ b/complete/data.c
@@ -57,7 +57,7 @@ void completion_data_free(struct CompletionData **ptr)
 
   struct CompletionData *cd = *ptr;
 
-  FREE(&cd->Matches);
+  FREE(&cd->match_list);
 #ifdef USE_NOTMUCH
   completion_data_free_nm_list(cd);
 #endif
@@ -73,8 +73,8 @@ struct CompletionData *completion_data_new(void)
 {
   struct CompletionData *cd = mutt_mem_calloc(1, sizeof(struct CompletionData));
 
-  cd->MatchesListsize = 512;
-  cd->Matches = mutt_mem_calloc(cd->MatchesListsize, sizeof(char *));
+  cd->match_list_len = 512;
+  cd->match_list = mutt_mem_calloc(cd->match_list_len, sizeof(char *));
 
   return cd;
 }
@@ -88,10 +88,10 @@ void completion_data_reset(struct CompletionData *cd)
   if (!cd)
     return;
 
-  memset(cd->UserTyped, 0, sizeof(cd->UserTyped));
-  memset(cd->Completed, 0, sizeof(cd->Completed));
-  memset(cd->Matches, 0, cd->MatchesListsize * sizeof(char *));
-  cd->NumMatched = 0;
+  memset(cd->user_typed, 0, sizeof(cd->user_typed));
+  memset(cd->completed, 0, sizeof(cd->completed));
+  memset(cd->match_list, 0, cd->match_list_len * sizeof(char *));
+  cd->num_matched = 0;
 #ifdef USE_NOTMUCH
   completion_data_free_nm_list(cd);
 #endif

--- a/complete/data.c
+++ b/complete/data.c
@@ -1,0 +1,98 @@
+/**
+ * @file
+ * String auto-completion data
+ *
+ * @authors
+ * Copyright (C) 2022 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @page complete_data String auto-completion data
+ *
+ * String auto-completion data
+ */
+
+#include "config.h"
+#include "mutt/lib.h"
+#include "data.h"
+
+#ifdef USE_NOTMUCH
+/**
+ * completion_data_free_nm_list - Free the Notmuch Completion strings
+ * @param cd Completion Data
+ */
+void completion_data_free_nm_list(struct CompletionData *cd)
+{
+  if (!cd || !cd->nm_tags)
+    return;
+
+  for (int i = 0; cd->nm_tags[i]; i++)
+    FREE(&cd->nm_tags[i]);
+  FREE(&cd->nm_tags);
+}
+#endif
+
+/**
+ * completion_data_free - Free the Completion Data
+ * @param ptr CompletionData to free
+ */
+void completion_data_free(struct CompletionData **ptr)
+{
+  if (!ptr || !*ptr)
+    return;
+
+  struct CompletionData *cd = *ptr;
+
+  FREE(&cd->Matches);
+#ifdef USE_NOTMUCH
+  completion_data_free_nm_list(cd);
+#endif
+
+  FREE(ptr);
+}
+
+/**
+ * completion_data_new - Create new Completion Data
+ * @retval ptr New Completion Data
+ */
+struct CompletionData *completion_data_new(void)
+{
+  struct CompletionData *cd = mutt_mem_calloc(1, sizeof(struct CompletionData));
+
+  cd->MatchesListsize = 512;
+  cd->Matches = mutt_mem_calloc(cd->MatchesListsize, sizeof(char *));
+
+  return cd;
+}
+
+/**
+ * completion_data_reset - Wipe the stored Comletion Data
+ * @param cd Completion Data
+ */
+void completion_data_reset(struct CompletionData *cd)
+{
+  if (!cd)
+    return;
+
+  memset(cd->UserTyped, 0, sizeof(cd->UserTyped));
+  memset(cd->Completed, 0, sizeof(cd->Completed));
+  memset(cd->Matches, 0, cd->MatchesListsize * sizeof(char *));
+  cd->NumMatched = 0;
+#ifdef USE_NOTMUCH
+  completion_data_free_nm_list(cd);
+#endif
+}

--- a/complete/data.c
+++ b/complete/data.c
@@ -30,21 +30,20 @@
 #include "mutt/lib.h"
 #include "data.h"
 
-#ifdef USE_NOTMUCH
 /**
- * completion_data_free_nm_list - Free the Notmuch Completion strings
+ * completion_data_free_match_strings - Free the Completion strings
  * @param cd Completion Data
  */
-void completion_data_free_nm_list(struct CompletionData *cd)
+void completion_data_free_match_strings(struct CompletionData *cd)
 {
-  if (!cd || !cd->nm_tags)
+  if (!cd || !cd->free_match_strings)
     return;
 
-  for (int i = 0; cd->nm_tags[i]; i++)
-    FREE(&cd->nm_tags[i]);
-  FREE(&cd->nm_tags);
+  for (int i = 0; i < cd->num_matched; i++)
+    FREE(&cd->match_list[i]);
+
+  cd->free_match_strings = false;
 }
-#endif
 
 /**
  * completion_data_free - Free the Completion Data
@@ -57,10 +56,9 @@ void completion_data_free(struct CompletionData **ptr)
 
   struct CompletionData *cd = *ptr;
 
+  completion_data_free_match_strings(cd);
+
   FREE(&cd->match_list);
-#ifdef USE_NOTMUCH
-  completion_data_free_nm_list(cd);
-#endif
 
   FREE(ptr);
 }
@@ -88,11 +86,11 @@ void completion_data_reset(struct CompletionData *cd)
   if (!cd)
     return;
 
+  completion_data_free_match_strings(cd);
+
   memset(cd->user_typed, 0, sizeof(cd->user_typed));
   memset(cd->completed, 0, sizeof(cd->completed));
   memset(cd->match_list, 0, cd->match_list_len * sizeof(char *));
   cd->num_matched = 0;
-#ifdef USE_NOTMUCH
-  completion_data_free_nm_list(cd);
-#endif
+  cd->free_match_strings = false;
 }

--- a/complete/data.h
+++ b/complete/data.h
@@ -30,13 +30,13 @@
  */
 struct CompletionData
 {
-  char UserTyped[1024];     ///< Initial string that starts completion
-  int NumMatched;           ///< Number of matches for completion
-  char Completed[256];      ///< Completed string (command or variable)
-  const char **Matches;     ///< Matching strings
-  int MatchesListsize;      ///< Enough space for all of the config items
+  char user_typed[1024];       ///< Initial string that starts completion
+  int num_matched;             ///< Number of matches for completion
+  char completed[256];         ///< Completed string (command or variable)
+  const char **match_list;     ///< Matching strings
+  int match_list_len;          ///< Enough space for all of the config items
 #ifdef USE_NOTMUCH
-  char **nm_tags;           ///< List of tags found by mutt_nm_query_complete()
+  char **nm_tags;              ///< List of tags found by mutt_nm_query_complete()
 #endif
 };
 

--- a/complete/data.h
+++ b/complete/data.h
@@ -35,13 +35,11 @@ struct CompletionData
   char completed[256];         ///< Completed string (command or variable)
   const char **match_list;     ///< Matching strings
   int match_list_len;          ///< Enough space for all of the config items
-#ifdef USE_NOTMUCH
-  char **nm_tags;              ///< List of tags found by mutt_nm_query_complete()
-#endif
+  bool free_match_strings;     ///< Should the strings in match_list be freed?
 };
 
 void                   completion_data_free(struct CompletionData **ptr);
-void                   completion_data_free_nm_list(struct CompletionData *cd);
+void                   completion_data_free_match_strings(struct CompletionData *cd);
 struct CompletionData *completion_data_new(void);
 void                   completion_data_reset(struct CompletionData *cd);
 

--- a/complete/data.h
+++ b/complete/data.h
@@ -1,0 +1,48 @@
+/**
+ * @file
+ * String auto-completion data
+ *
+ * @authors
+ * Copyright (C) 2022 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MUTT_COMPLETE_DATA_H
+#define MUTT_COMPLETE_DATA_H
+
+#include "config.h"
+
+/**
+ * struct CompletionData - State data for auto-completion
+ */
+struct CompletionData
+{
+  char UserTyped[1024];     ///< Initial string that starts completion
+  int NumMatched;           ///< Number of matches for completion
+  char Completed[256];      ///< Completed string (command or variable)
+  const char **Matches;     ///< Matching strings
+  int MatchesListsize;      ///< Enough space for all of the config items
+#ifdef USE_NOTMUCH
+  char **nm_tags;           ///< List of tags found by mutt_nm_query_complete()
+#endif
+};
+
+void                   completion_data_free(struct CompletionData **ptr);
+void                   completion_data_free_nm_list(struct CompletionData *cd);
+struct CompletionData *completion_data_new(void);
+void                   completion_data_reset(struct CompletionData *cd);
+
+#endif /* MUTT_COMPLETE_DATA_H */

--- a/complete/lib.h
+++ b/complete/lib.h
@@ -28,6 +28,7 @@
  * | File                   | Description                  |
  * | :--------------------- | :--------------------------- |
  * | complete/complete.c    | @subpage complete_complete   |
+ * | complete/data.c        | @subpage complete_data       |
  * | complete/helpers.c     | @subpage complete_helpers    |
  */
 
@@ -36,14 +37,15 @@
 
 #include <stdbool.h>
 #include <stdio.h>
+// IWYU pragma: begin_exports
+#include "data.h"
+// IWYU pragma: end_exports
 
-void complete_init(void);
-
-int  mutt_command_complete  (char *buf, size_t buflen, int pos, int numtabs);
-int  mutt_complete          (char *buf, size_t buflen);
-int  mutt_label_complete    (char *buf, size_t buflen, int numtabs);
-bool mutt_nm_query_complete (char *buf, size_t buflen, int pos, int numtabs);
-bool mutt_nm_tag_complete   (char *buf, size_t buflen, int numtabs);
-int  mutt_var_value_complete(char *buf, size_t buflen, int pos);
+int  mutt_command_complete  (struct CompletionData *cd, char *buf, size_t buflen, int pos, int numtabs);
+int  mutt_complete          (struct CompletionData *cd, char *buf, size_t buflen);
+int  mutt_label_complete    (struct CompletionData *cd, char *buf, size_t buflen, int numtabs);
+bool mutt_nm_query_complete (struct CompletionData *cd, char *buf, size_t buflen, int pos, int numtabs);
+bool mutt_nm_tag_complete   (struct CompletionData *cd, char *buf, size_t buflen, int numtabs);
+int  mutt_var_value_complete(struct CompletionData *cd, char *buf, size_t buflen, int pos);
 
 #endif /* MUTT_COMPLETE_LIB_H */

--- a/enter/wdata.h
+++ b/enter/wdata.h
@@ -30,6 +30,7 @@
 #include "mutt.h"
 #include "history/lib.h"
 
+struct CompletionData;
 struct MuttWindow;
 
 /**
@@ -69,6 +70,8 @@ struct EnterWindowData
   int tabs;                       ///< Number of times the user has hit tab
 
   bool done;                      ///< Is text-entry done?
+
+  struct CompletionData *cd;      ///< Auto-completion state data
 };
 
 #endif /* MUTT_ENTER_WDATA_H */

--- a/enter/window.c
+++ b/enter/window.c
@@ -36,6 +36,7 @@
 #include "core/lib.h"
 #include "gui/lib.h"
 #include "mutt.h"
+#include "complete/lib.h"
 #include "enter/lib.h"
 #include "history/lib.h"
 #include "menu/lib.h"
@@ -227,7 +228,7 @@ int mutt_buffer_get_field(const char *field, struct Buffer *buf, CompletionFlags
     // clang-format off
     struct EnterWindowData wdata = { buf->data, buf->dsize, col, complete,
       multiple, m, files, numfiles, state, ENTER_REDRAW_NONE,
-      (complete & MUTT_COMP_PASS), true, 0, NULL, 0, &mbstate, 0, false };
+      (complete & MUTT_COMP_PASS), true, 0, NULL, 0, &mbstate, 0, false, NULL };
     // clang-format on
     win->wdata = &wdata;
 
@@ -352,6 +353,7 @@ int mutt_buffer_get_field(const char *field, struct Buffer *buf, CompletionFlags
   bye:
     mutt_hist_reset_state(wdata.hclass);
     FREE(&wdata.tempbuf);
+    completion_data_free(&wdata.cd);
   } while (rc == 1);
   mutt_curses_set_cursor(cursor);
 

--- a/init.c
+++ b/init.c
@@ -48,7 +48,6 @@
 #include "mutt.h"
 #include "init.h"
 #include "color/lib.h"
-#include "complete/lib.h"
 #include "history/lib.h"
 #include "notmuch/lib.h"
 #include "command_parse.h"
@@ -664,8 +663,6 @@ int mutt_init(struct ConfigSet *cs, bool skip_sys_rc, struct ListHead *commands)
   mutt_ch_set_charset(charset);
   FREE(&charset);
 
-  complete_init();
-
 #ifdef HAVE_GETSID
   /* Unset suspend by default if we're the session leader */
   if (getsid(0) == getpid())
@@ -971,4 +968,3 @@ int mutt_query_variables(struct ListHead *queries, bool show_docs)
 
   return rc; // TEST16: neomutt -Q charset
 }
-

--- a/main.c
+++ b/main.c
@@ -49,15 +49,16 @@
  *
  * Libraries:
  * @ref lib_address, @ref lib_alias, @ref lib_attach, @ref lib_autocrypt,
- * @ref lib_bcache, @ref lib_browser, @ref lib_color, @ref lib_compmbox,
- * @ref lib_compose, @ref lib_compress, @ref lib_config, @ref lib_conn,
- * @ref lib_convert, @ref lib_core, @ref lib_email, @ref lib_enter,
- * @ref lib_envelope, @ref lib_gui, @ref lib_hcache, @ref lib_helpbar,
- * @ref lib_history, @ref lib_imap, @ref lib_index, @ref lib_maildir,
- * @ref lib_mbox, @ref lib_menu, @ref lib_mixmaster, @ref lib_mutt,
- * @ref lib_ncrypt, @ref lib_nntp, @ref lib_notmuch, @ref lib_pager,
- * @ref lib_pattern, @ref lib_pop, @ref lib_postpone, @ref lib_progress,
- * @ref lib_question, @ref lib_send, @ref lib_sidebar, @ref lib_store.
+ * @ref lib_bcache, @ref lib_browser, @ref lib_color, @ref lib_complete,
+ * @ref lib_compmbox, @ref lib_compose, @ref lib_compress, @ref lib_config,
+ * @ref lib_conn, @ref lib_convert, @ref lib_core, @ref lib_email,
+ * @ref lib_enter, @ref lib_envelope, @ref lib_gui, @ref lib_hcache,
+ * @ref lib_helpbar, @ref lib_history, @ref lib_imap, @ref lib_index,
+ * @ref lib_maildir, @ref lib_mbox, @ref lib_menu, @ref lib_mixmaster,
+ * @ref lib_mutt, @ref lib_ncrypt, @ref lib_nntp, @ref lib_notmuch,
+ * @ref lib_pager, @ref lib_pattern, @ref lib_pop, @ref lib_postpone,
+ * @ref lib_progress, @ref lib_question, @ref lib_send, @ref lib_sidebar,
+ * @ref lib_store.
  *
  * ## Miscellaneous files
  *
@@ -68,7 +69,6 @@
  * | alternates.c    | @subpage neo_alternates    |
  * | commands.c      | @subpage neo_commands      |
  * | command_parse.c | @subpage neo_command_parse |
- * | complete.c      | @subpage neo_complete      |
  * | copy.c          | @subpage neo_copy          |
  * | editmsg.c       | @subpage neo_editmsg       |
  * | enriched.c      | @subpage neo_enriched      |

--- a/notmuch/lib.h
+++ b/notmuch/lib.h
@@ -55,7 +55,7 @@ void  nm_db_longrun_done         (struct Mailbox *m);
 void  nm_db_longrun_init         (struct Mailbox *m, bool writable);
 char *nm_email_get_folder        (struct Email *e);
 char *nm_email_get_folder_rel_db (struct Mailbox *m, struct Email *e);
-int   nm_get_all_tags            (struct Mailbox *m, char **tag_list, int *tag_count);
+int   nm_get_all_tags            (struct Mailbox *m, const char **tag_list, int *tag_count);
 bool  nm_message_is_still_queried(struct Mailbox *m, struct Email *e);
 enum MailboxType nm_path_probe   (const char *path, const struct stat *st);
 bool  nm_query_window_available  (void);

--- a/notmuch/notmuch.c
+++ b/notmuch/notmuch.c
@@ -1947,7 +1947,7 @@ done:
  *
  * If tag_list is NULL, just count the tags.
  */
-int nm_get_all_tags(struct Mailbox *m, char **tag_list, int *tag_count)
+int nm_get_all_tags(struct Mailbox *m, const char **tag_list, int *tag_count)
 {
   struct NmMboxData *mdata = nm_mdata_get(m);
   if (!mdata)


### PR DESCRIPTION
This is a small step forward towards an auto-completion API.

- 0ccb31556 complete: kill global data
  Rather than using six global variables, create `struct CompletionData` and pass it to the functions

- 7d023452a complete: unify naming
  Clean up the member naming

- 6d49fd2d9 complete: strip notmuch
  Refactor the Notmuch completion to use the same array as other completions.
  The other completion code fills the array with strings that are owned by other structs.
  In the Notmuch case, we need to free them after use.