### PR TITLE
Mention S/MIME key/certificate management with GPGME

### DIFF
--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -3479,6 +3479,18 @@ set crypt_use_gpgme
         </para>
 
         <para>
+          When using GPGME as S/MIME backend, keys and certificates are
+          managed by GnuPG.  You can add your key (or certificates) to
+          GnuPG with the command
+          <quote><literal>gpgsm --import mykey.p12</literal></quote>.
+          Note that in order to use the key for signing or encrypting, the root
+          certificate of that key must be trusted, which might involve editing
+          <literal>~/.gnupg/trustlist.txt</literal>.
+          Consult your documentation of GnuPG for details, in particular
+          <literal>gpgsm</literal>.
+        </para>
+
+        <para>
           In <quote>classic mode</quote>, keys and certificates are managed by
           the <literal>smime_keys</literal> program that comes with NeoMutt.  By
           default they are stored under <literal>~/.smime/</literal>. (This is


### PR DESCRIPTION
* **What does this PR do?**

Currently, there is no mentioning in the manual on how keys and certificates are handled with the GPGME backend for S/MIME.
Add a paragraph which gives some basics, so users are on the right track to get a simple S/MIME setup working.