### PR TITLE
pager: fix next/prev behaviour wrt collapsed threads

### DIFF
--- a/index/dlg_index.c
+++ b/index/dlg_index.c
@@ -217,16 +217,34 @@ void collapse_all(struct MailboxView *mv, struct Menu *menu, int toggle)
 }
 
 /**
- * ci_next_undeleted - Find the next undeleted email
+ * uncollapse_thread - Open a collapsed thread
  * @param m     Mailbox
- * @param msgno Message number to start at
+ * @param index Message number
+ */
+static void uncollapse_thread(struct Mailbox *m, int index)
+{
+  struct Email *e = mutt_get_virt_email(m, index);
+  if (e && e->collapsed)
+  {
+    index = mutt_uncollapse_thread(e);
+    mutt_set_vnum(m);
+  }
+}
+
+/**
+ * ci_next_undeleted - Find the next undeleted email
+ * @param m          Mailbox
+ * @param msgno      Message number to start at
+ * @param uncollapse Open collapsed threads
  * @retval >=0 Message number of next undeleted email
  * @retval  -1 No more undeleted messages
  */
-int ci_next_undeleted(struct Mailbox *m, int msgno)
+int ci_next_undeleted(struct Mailbox *m, int msgno, bool uncollapse)
 {
   if (!m)
     return -1;
+
+  int index = -1;
 
   for (int i = msgno + 1; i < m->vcount; i++)
   {
@@ -234,22 +252,32 @@ int ci_next_undeleted(struct Mailbox *m, int msgno)
     if (!e)
       continue;
     if (!e->deleted)
-      return i;
+    {
+      index = i;
+      break;
+    }
   }
-  return -1;
+
+  if (uncollapse)
+    uncollapse_thread(m, index);
+
+  return index;
 }
 
 /**
  * ci_previous_undeleted - Find the previous undeleted email
- * @param m     Mailbox
- * @param msgno Message number to start at
+ * @param m          Mailbox
+ * @param msgno      Message number to start at
+ * @param uncollapse Open collapsed threads
  * @retval >=0 Message number of next undeleted email
  * @retval  -1 No more undeleted messages
  */
-int ci_previous_undeleted(struct Mailbox *m, int msgno)
+int ci_previous_undeleted(struct Mailbox *m, int msgno, bool uncollapse)
 {
   if (!m)
     return -1;
+
+  int index = -1;
 
   for (int i = msgno - 1; i >= 0; i--)
   {
@@ -257,9 +285,16 @@ int ci_previous_undeleted(struct Mailbox *m, int msgno)
     if (!e)
       continue;
     if (!e->deleted)
-      return i;
+    {
+      index = i;
+      break;
+    }
   }
-  return -1;
+
+  if (uncollapse)
+    uncollapse_thread(m, index);
+
+  return index;
 }
 
 /**

--- a/index/functions.c
+++ b/index/functions.c
@@ -100,14 +100,15 @@ enum ResolveMethod
 
 /**
  * resolve_email - Pick the next Email to advance the cursor to
- * @param menu   Menu
+ * @param priv   Private Index data
  * @param shared Shared Index data
  * @param rm     How to advance the cursor, e.g. #RESOLVE_NEXT_EMAIL
  * @retval true Resolve succeeded
  */
-static bool resolve_email(struct Menu *menu, struct IndexSharedData *shared, enum ResolveMethod rm)
+static bool resolve_email(struct IndexPrivateData *priv,
+                          struct IndexSharedData *shared, enum ResolveMethod rm)
 {
-  if (!menu || !shared || !shared->mailbox || !shared->email)
+  if (!priv || !priv->menu || !shared || !shared->mailbox || !shared->email)
     return false;
 
   const bool c_resolve = cs_subset_bool(shared->sub, "resolve");
@@ -118,12 +119,15 @@ static bool resolve_email(struct Menu *menu, struct IndexSharedData *shared, enu
   switch (rm)
   {
     case RESOLVE_NEXT_EMAIL:
-      index = menu_get_index(menu) + 1;
+      index = menu_get_index(priv->menu) + 1;
       break;
 
     case RESOLVE_NEXT_UNDELETED:
-      index = ci_next_undeleted(shared->mailbox, menu_get_index(menu));
+    {
+      const bool uncollapse = mutt_using_threads() && !window_is_focused(priv->win_index);
+      index = ci_next_undeleted(shared->mailbox, menu_get_index(priv->menu), uncollapse);
       break;
+    }
 
     case RESOLVE_NEXT_THREAD:
       index = mutt_next_thread(shared->email);
@@ -141,7 +145,7 @@ static bool resolve_email(struct Menu *menu, struct IndexSharedData *shared, enu
     return false;
   }
 
-  menu_set_index(menu, index);
+  menu_set_index(priv->menu, index);
   return true;
 }
 
@@ -161,7 +165,10 @@ bool index_next_undeleted(struct MuttWindow *win_index)
   if (!shared)
     return false;
 
-  int index = ci_next_undeleted(shared->mailbox, menu_get_index(menu));
+  struct IndexPrivateData *priv = win_index->parent->wdata;
+  const bool uncollapse = mutt_using_threads() && !window_is_focused(priv->win_index);
+
+  int index = ci_next_undeleted(shared->mailbox, menu_get_index(menu), uncollapse);
   if ((index < 0) || (index >= shared->mailbox->vcount))
   {
     // Selection failed
@@ -296,7 +303,7 @@ static int op_delete(struct IndexSharedData *shared, struct IndexPrivateData *pr
   }
   else
   {
-    resolve_email(priv->menu, shared, RESOLVE_NEXT_UNDELETED);
+    resolve_email(priv, shared, RESOLVE_NEXT_UNDELETED);
   }
 
   return FR_SUCCESS;
@@ -337,7 +344,7 @@ static int op_delete_thread(struct IndexSharedData *shared,
   if (c_delete_untag)
     mutt_thread_set_flag(shared->mailbox, shared->email, MUTT_TAG, false, subthread);
 
-  resolve_email(priv->menu, shared, RESOLVE_NEXT_UNDELETED);
+  resolve_email(priv, shared, RESOLVE_NEXT_UNDELETED);
   menu_queue_redraw(priv->menu, MENU_REDRAW_INDEX);
   return FR_SUCCESS;
 }
@@ -445,7 +452,7 @@ static int op_edit_label(struct IndexSharedData *shared, struct IndexPrivateData
     mutt_message(ngettext("%d label changed", "%d labels changed", num_changed), num_changed);
 
     if (!priv->tag)
-      resolve_email(priv->menu, shared, RESOLVE_NEXT_UNDELETED);
+      resolve_email(priv, shared, RESOLVE_NEXT_UNDELETED);
     return FR_SUCCESS;
   }
 
@@ -578,7 +585,7 @@ static int op_flag_message(struct IndexSharedData *shared,
       return FR_NO_ACTION;
     mutt_set_flag(m, shared->email, MUTT_FLAG, !shared->email->flagged);
 
-    resolve_email(priv->menu, shared, RESOLVE_NEXT_UNDELETED);
+    resolve_email(priv, shared, RESOLVE_NEXT_UNDELETED);
   }
 
   return FR_SUCCESS;
@@ -1180,7 +1187,7 @@ static int op_main_modify_tags(struct IndexSharedData *shared,
       m->changed = true;
     }
 
-    resolve_email(priv->menu, shared, RESOLVE_NEXT_UNDELETED);
+    resolve_email(priv, shared, RESOLVE_NEXT_UNDELETED);
   }
   rc = FR_SUCCESS;
 
@@ -1376,9 +1383,16 @@ static int op_main_next_undeleted(struct IndexSharedData *shared,
     mutt_message(_("You are on the last message"));
     return FR_ERROR;
   }
-  index = ci_next_undeleted(shared->mailbox, index);
+
+  const bool uncollapse = mutt_using_threads() && !window_is_focused(priv->win_index);
+
+  index = ci_next_undeleted(shared->mailbox, index, uncollapse);
   if (index != -1)
+  {
     menu_set_index(priv->menu, index);
+    if (uncollapse)
+      menu_queue_redraw(priv->menu, MENU_REDRAW_INDEX);
+  }
 
   if (index == -1)
   {
@@ -1425,9 +1439,16 @@ static int op_main_prev_undeleted(struct IndexSharedData *shared,
     mutt_message(_("You are on the first message"));
     return FR_ERROR;
   }
-  index = ci_previous_undeleted(shared->mailbox, index);
+
+  const bool uncollapse = mutt_using_threads() && !window_is_focused(priv->win_index);
+
+  index = ci_previous_undeleted(shared->mailbox, index, uncollapse);
   if (index != -1)
+  {
     menu_set_index(priv->menu, index);
+    if (uncollapse)
+      menu_queue_redraw(priv->menu, MENU_REDRAW_INDEX);
+  }
 
   if (index == -1)
   {
@@ -1493,7 +1514,7 @@ static int op_main_read_thread(struct IndexSharedData *shared,
   {
     const enum ResolveMethod rm = (op == OP_MAIN_READ_THREAD) ? RESOLVE_NEXT_THREAD :
                                                                 RESOLVE_NEXT_SUBTHREAD;
-    resolve_email(priv->menu, shared, rm);
+    resolve_email(priv, shared, rm);
     menu_queue_redraw(priv->menu, MENU_REDRAW_INDEX);
   }
 
@@ -1539,7 +1560,7 @@ static int op_main_set_flag(struct IndexSharedData *shared,
     }
     else
     {
-      resolve_email(priv->menu, shared, RESOLVE_NEXT_UNDELETED);
+      resolve_email(priv, shared, RESOLVE_NEXT_UNDELETED);
     }
   }
   emaillist_clear(&el);
@@ -1589,9 +1610,9 @@ static int op_main_sync_folder(struct IndexSharedData *shared,
     if (!shared->email)
       return FR_NO_ACTION;
     if (shared->email->deleted)
-      newidx = ci_next_undeleted(shared->mailbox, index);
+      newidx = ci_next_undeleted(shared->mailbox, index, false);
     if (newidx < 0)
-      newidx = ci_previous_undeleted(shared->mailbox, index);
+      newidx = ci_previous_undeleted(shared->mailbox, index, false);
     if (newidx >= 0)
       e = mutt_get_virt_email(shared->mailbox, newidx);
   }
@@ -1963,7 +1984,7 @@ static int op_save(struct IndexSharedData *shared, struct IndexPrivateData *priv
     }
     else
     {
-      resolve_email(priv->menu, shared, RESOLVE_NEXT_UNDELETED);
+      resolve_email(priv, shared, RESOLVE_NEXT_UNDELETED);
     }
   }
   emaillist_clear(&el);
@@ -2040,7 +2061,7 @@ static int op_tag(struct IndexSharedData *shared, struct IndexPrivateData *priv,
 
   mutt_set_flag(shared->mailbox, shared->email, MUTT_TAG, !shared->email->tagged);
 
-  resolve_email(priv->menu, shared, RESOLVE_NEXT_EMAIL);
+  resolve_email(priv, shared, RESOLVE_NEXT_EMAIL);
   return FR_SUCCESS;
 }
 
@@ -2062,7 +2083,7 @@ static int op_tag_thread(struct IndexSharedData *shared, struct IndexPrivateData
   {
     const enum ResolveMethod rm = (op == OP_TAG_THREAD) ? RESOLVE_NEXT_THREAD :
                                                           RESOLVE_NEXT_SUBTHREAD;
-    resolve_email(priv->menu, shared, rm);
+    resolve_email(priv, shared, rm);
     menu_queue_redraw(priv->menu, MENU_REDRAW_INDEX);
   }
 
@@ -2105,7 +2126,7 @@ static int op_toggle_new(struct IndexSharedData *shared, struct IndexPrivateData
     else
       mutt_set_flag(m, shared->email, MUTT_READ, true);
 
-    resolve_email(priv->menu, shared, RESOLVE_NEXT_UNDELETED);
+    resolve_email(priv, shared, RESOLVE_NEXT_UNDELETED);
   }
 
   return FR_SUCCESS;
@@ -2143,7 +2164,7 @@ static int op_undelete(struct IndexSharedData *shared, struct IndexPrivateData *
   }
   else
   {
-    resolve_email(priv->menu, shared, RESOLVE_NEXT_EMAIL);
+    resolve_email(priv, shared, RESOLVE_NEXT_EMAIL);
   }
 
   return FR_SUCCESS;
@@ -2177,7 +2198,7 @@ static int op_undelete_thread(struct IndexSharedData *shared,
   {
     const enum ResolveMethod rm = (op == OP_UNDELETE_THREAD) ? RESOLVE_NEXT_THREAD :
                                                                RESOLVE_NEXT_SUBTHREAD;
-    resolve_email(priv->menu, shared, rm);
+    resolve_email(priv, shared, rm);
     menu_queue_redraw(priv->menu, MENU_REDRAW_INDEX);
   }
 

--- a/index/lib.h
+++ b/index/lib.h
@@ -82,12 +82,12 @@ void mutt_update_index(struct Menu *menu, struct MailboxView *mv, enum MxStatus 
 struct MuttWindow *index_pager_init(void);
 int mutt_dlgindex_observer(struct NotifyCallback *nc);
 bool check_acl(struct Mailbox *m, AclFlags acl, const char *msg);
-int ci_next_undeleted(struct Mailbox *m, int msgno);
+int ci_next_undeleted(struct Mailbox *m, int msgno, bool uncollapse);
 void update_index(struct Menu *menu, struct MailboxView *mv, enum MxStatus check, int oldcount, const struct IndexSharedData *shared);
 void change_folder_mailbox(struct Menu *menu, struct Mailbox *m, int *oldcount, struct IndexSharedData *shared, bool read_only);
 void collapse_all(struct MailboxView *mv, struct Menu *menu, int toggle);
 void change_folder_string(struct Menu *menu, char *buf, size_t buflen, int *oldcount, struct IndexSharedData *shared, bool read_only);
-int ci_previous_undeleted(struct Mailbox *m, int msgno);
+int ci_previous_undeleted(struct Mailbox *m, int msgno, bool uncollapse);
 int ci_first_message(struct Mailbox *m);
 void resort_index(struct MailboxView *mv, struct Menu *menu);
 int mx_toggle_write(struct Mailbox *m);


### PR DESCRIPTION
Some functions when used from the Pager, cause threads to be uncollapsed:

- `<delete-message>`
- `<delete-thread>`
- `<edit-label>`
- `<flag-message>`
- `<modify-labels>`
- `<next-undeleted>`
- `<previous-undeleted>`
- `<save-message>`
- `<set-flag>`
- `<toggle-new>`

This behaviour was broken by the Index/Pager refactoring.

Fixes: #3460 

---

Change functions to optionally uncollapse a thread:

- `ci_next_undeleted()`
- `ci_previous_undeleted()`
- `resolve_email()`

Whether or not to uncollapse is determined by whether the Index is focussed, or not.