### PR TITLE
buffer: tidy printf usage

### DIFF
--- a/keymap.c
+++ b/keymap.c
@@ -405,8 +405,8 @@ static enum CommandResult km_bind_err(const char *s, enum MenuType mtype, int op
         if (err)
         {
           /* err was passed, put the string there */
-          snprintf(err->data, err->dsize, err_msg, old_binding, new_binding,
-                   mutt_map_get_name(mtype, MenuNames), new_binding);
+          mutt_buffer_printf(err, err_msg, old_binding, new_binding,
+                             mutt_map_get_name(mtype, MenuNames), new_binding);
         }
         else
         {

--- a/pattern/compile.c
+++ b/pattern/compile.c
@@ -115,7 +115,7 @@ static bool eat_regex(struct Pattern *pat, PatternCompFlags flags,
     {
       char errmsg[256];
       regerror(rc2, pat->p.regex, errmsg, sizeof(errmsg));
-      mutt_buffer_add_printf(err, "'%s': %s", buf->data, errmsg);
+      mutt_buffer_printf(err, "'%s': %s", buf->data, errmsg);
       FREE(&pat->p.regex);
       goto out;
     }

--- a/pattern/compile.c
+++ b/pattern/compile.c
@@ -317,12 +317,12 @@ static const char *get_date(const char *s, struct tm *t, struct Buffer *err)
 
     if ((t->tm_mday < 1) || (t->tm_mday > 31))
     {
-      snprintf(err->data, err->dsize, _("Invalid day of month: %s"), s);
+      mutt_buffer_printf(err, _("Invalid day of month: %s"), s);
       return NULL;
     }
     if ((t->tm_mon < 0) || (t->tm_mon > 11))
     {
-      snprintf(err->data, err->dsize, _("Invalid month: %s"), s);
+      mutt_buffer_printf(err, _("Invalid month: %s"), s);
       return NULL;
     }
 
@@ -983,13 +983,13 @@ static bool eat_date(struct Pattern *pat, PatternCompFlags flags,
   char *pexpr = s->dptr;
   if (mutt_extract_token(tmp, s, MUTT_TOKEN_COMMENT | MUTT_TOKEN_PATTERN) != 0)
   {
-    snprintf(err->data, err->dsize, _("Error in expression: %s"), pexpr);
+    mutt_buffer_printf(err, _("Error in expression: %s"), pexpr);
     goto out;
   }
 
   if (mutt_buffer_is_empty(tmp))
   {
-    snprintf(err->data, err->dsize, "%s", _("Empty expression"));
+    mutt_buffer_printf(err, "%s", _("Empty expression"));
     goto out;
   }
 


### PR DESCRIPTION
- 58b513cdc buffer: tidy printf usage
- 7afd3a098 pattern: fix buffer crash and leak

The `Buffer` (`err`) for errors in `mutt_pattern_func()` was allocated on the stack and not fully initialised.

If a pattern error occurred, `mutt_buffer_add_printf()` was used which relied on an uninitialised `Buffer->dptr`.

- Replace `mutt_buffer_add_printf()` with `mutt_buffer_printf()`
  (we're not appending to anything)
- Replace the stack `Buffer` with one from the pool
- Fix leak of `buf`

Fixes: #3459 

---

**Steps**:
- In Index search for `\1`

**Results**:
- Error message: `'\1': Invalid back reference`
- No leaks
- No crashes
