### PR TITLE
help: disable index functions

### DIFF
--- a/pager/dlg_pager.c
+++ b/pager/dlg_pager.c
@@ -564,6 +564,10 @@ int mutt_pager(struct PagerView *pview)
       priv->rc = op;
       break;
     }
+
+    if ((pview->mode != PAGER_MODE_EMAIL) && (rc == FR_UNKNOWN))
+      mutt_flushinp();
+
   } while (priv->loop == PAGER_LOOP_CONTINUE);
 
   //-------------------------------------------------------------------------

--- a/pager/dlg_pager.c
+++ b/pager/dlg_pager.c
@@ -545,12 +545,15 @@ int mutt_pager(struct PagerView *pview)
 
     int rc = pager_function_dispatcher(priv->pview->win_pager, op);
 
-    if ((rc == FR_UNKNOWN) && priv->pview->win_index)
-      rc = index_function_dispatcher(priv->pview->win_index, op);
+    if (pview->mode == PAGER_MODE_EMAIL)
+    {
+      if ((rc == FR_UNKNOWN) && priv->pview->win_index)
+        rc = index_function_dispatcher(priv->pview->win_index, op);
 #ifdef USE_SIDEBAR
-    if (rc == FR_UNKNOWN)
-      rc = sb_function_dispatcher(win_sidebar, op);
+      if (rc == FR_UNKNOWN)
+        rc = sb_function_dispatcher(win_sidebar, op);
 #endif
+    }
     if (rc == FR_UNKNOWN)
       rc = global_function_dispatcher(NULL, op);
 


### PR DESCRIPTION
WIP: This solves the problem, but it may need work...

- 700b91d9f help: disable index functions
  When in the Help Screen (pager) disable the Index and Sidebar functions.

- cb68f49de pager: clear input buffer on error
  If the function isn't recognised, this could be a broken macro.
  Clear the input buffer to prevent accidents.

- c6aafb201 pager: only clear input buffer for help
  Tighten up the check.
  The macro behaviour when viewing emails is unchanged.

Fixes: #3464 