### PR TITLE
Handle corrupted header caches

### DIFF
--- a/compress/lz4.c
+++ b/compress/lz4.c
@@ -29,6 +29,7 @@
 
 #include "config.h"
 #include <stddef.h>
+#include <limits.h>
 #include <lz4.h>
 #include "private.h"
 #include "mutt/lib.h"
@@ -72,13 +73,15 @@ static void *compr_lz4_open(short level)
  */
 static void *compr_lz4_compress(void *cctx, const char *data, size_t dlen, size_t *clen)
 {
-  if (!cctx)
+  if (!cctx || (dlen > INT_MAX))
     return NULL;
 
   struct ComprLz4Ctx *ctx = cctx;
 
   int datalen = dlen;
   int len = LZ4_compressBound(dlen);
+  if (len > (INT_MAX - 4))
+    return NULL;
   mutt_mem_realloc(&ctx->buf, len + 4);
   char *cbuf = ctx->buf;
 
@@ -115,6 +118,8 @@ static void *compr_lz4_decompress(void *cctx, const char *cbuf, size_t clen)
   if (clen < 4)
     return NULL;
   size_t ulen = cs[0] + (cs[1] << 8) + (cs[2] << 16) + ((size_t) cs[3] << 24);
+  if (ulen > INT_MAX)
+    return NULL;
   if (ulen == 0)
     return (void *) cbuf;
 

--- a/compress/lz4.c
+++ b/compress/lz4.c
@@ -112,6 +112,8 @@ static void *compr_lz4_decompress(void *cctx, const char *cbuf, size_t clen)
 
   /* first 4 bytes store the size */
   const unsigned char *cs = (const unsigned char *) cbuf;
+  if (clen < 4)
+    return NULL;
   size_t ulen = cs[0] + (cs[1] << 8) + (cs[2] << 16) + ((size_t) cs[3] << 24);
   if (ulen == 0)
     return (void *) cbuf;

--- a/compress/zlib.c
+++ b/compress/zlib.c
@@ -112,6 +112,8 @@ static void *compr_zlib_decompress(void *cctx, const char *cbuf, size_t clen)
 
   /* first 4 bytes store the size */
   const unsigned char *cs = (const unsigned char *) cbuf;
+  if (clen < 4)
+    return NULL;
   uLong ulen = cs[0] + (cs[1] << 8) + (cs[2] << 16) + ((uLong) cs[3] << 24);
   if (ulen == 0)
     return NULL;

--- a/hcache/hcache.c
+++ b/hcache/hcache.c
@@ -469,6 +469,10 @@ struct HCacheEntry mutt_hcache_fetch(struct HeaderCache *hc, const char *key,
 
   /* restore uidvalidity and crc */
   size_t hlen = header_size();
+  if (hlen > dlen)
+  {
+    goto end;
+  }
   int off = 0;
   serial_restore_uint32_t(&entry.uidvalidity, data, &off);
   serial_restore_int(&entry.crc, data, &off);

--- a/imap/mdata.c
+++ b/imap/mdata.c
@@ -95,8 +95,23 @@ struct ImapMboxData *imap_mdata_new(struct ImapAccountData *adata, const char *n
   {
     size_t dlen = 0;
     void *uidvalidity = mutt_hcache_fetch_raw(mdata->hcache, "/UIDVALIDITY", 12, &dlen);
+    if (uidvalidity && (dlen < sizeof(uint32_t)))
+    {
+      mutt_hcache_free_raw(mdata->hcache, &uidvalidity);
+      uidvalidity = NULL;
+    }
     void *uidnext = mutt_hcache_fetch_raw(mdata->hcache, "/UIDNEXT", 8, &dlen);
+    if (uidnext && (dlen < sizeof(unsigned int)))
+    {
+      mutt_hcache_free_raw(mdata->hcache, &uidnext);
+      uidnext = NULL;
+    }
     unsigned long long *modseq = mutt_hcache_fetch_raw(mdata->hcache, "/MODSEQ", 7, &dlen);
+    if (modseq && (dlen < sizeof(unsigned long long)))
+    {
+      mutt_hcache_free_raw(mdata->hcache, (void **) &modseq);
+      modseq = NULL;
+    }
     if (uidvalidity)
     {
       mdata->uidvalidity = *(uint32_t *) uidvalidity;

--- a/imap/message.c
+++ b/imap/message.c
@@ -1371,10 +1371,18 @@ retry:
   {
     size_t dlen = 0;
     uidvalidity = mutt_hcache_fetch_raw(mdata->hcache, "/UIDVALIDITY", 12, &dlen);
+    if (uidvalidity && (dlen < sizeof(uint32_t)))
+    {
+      mutt_hcache_free_raw(mdata->hcache, &uidvalidity);
+      uidvalidity = NULL;
+    }
     puid_next = mutt_hcache_fetch_raw(mdata->hcache, "/UIDNEXT", 8, &dlen);
     if (puid_next)
     {
-      uid_next = *(unsigned int *) puid_next;
+      if (dlen >= sizeof(unsigned int))
+      {
+        uid_next = *(unsigned int *) puid_next;
+      }
       mutt_hcache_free_raw(mdata->hcache, &puid_next);
     }
 
@@ -1398,7 +1406,10 @@ retry:
                                                                 "/MODSEQ", 7, &dlen2);
       if (pmodseq)
       {
-        hc_modseq = *pmodseq;
+        if (dlen2 >= sizeof(unsigned long long))
+        {
+          hc_modseq = *pmodseq;
+        }
         mutt_hcache_free_raw(mdata->hcache, (void **) &pmodseq);
       }
       if (hc_modseq)

--- a/store/gdbm.c
+++ b/store/gdbm.c
@@ -33,6 +33,7 @@
 #include "config.h"
 #include <stddef.h>
 #include <gdbm.h>
+#include <limits.h>
 #include "mutt/lib.h"
 #include "lib.h"
 
@@ -59,7 +60,7 @@ static void *store_gdbm_open(const char *path)
  */
 static void *store_gdbm_fetch(void *store, const char *key, size_t klen, size_t *vlen)
 {
-  if (!store)
+  if (!store || (klen > INT_MAX))
     return NULL;
 
   datum dkey;
@@ -88,7 +89,7 @@ static void store_gdbm_free(void *store, void **ptr)
  */
 static int store_gdbm_store(void *store, const char *key, size_t klen, void *value, size_t vlen)
 {
-  if (!store)
+  if (!store || (klen > INT_MAX) || (vlen > INT_MAX))
     return -1;
 
   datum dkey;
@@ -110,7 +111,7 @@ static int store_gdbm_store(void *store, const char *key, size_t klen, void *val
  */
 static int store_gdbm_delete_record(void *store, const char *key, size_t klen)
 {
-  if (!store)
+  if (!store || (klen > INT_MAX))
     return -1;
 
   datum dkey;


### PR DESCRIPTION
* **What does this PR do?**

Check local cache files while parsing them to prevent undefined behavior
like out of boundary reads.

* **What are the relevant issue numbers?**

No issue created. It can be tested by compiling with asan, gdbm, and zlib
(or lz4) and modifying the relevant store functions to write only 1 byte.

Required configuration: `set header_cache = "~/.mutt/cache"`