### PR TITLE
source: fix variable interpretation

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -1089,7 +1089,7 @@ static enum CommandResult parse_source(struct Buffer *buf, struct Buffer *s,
 
   do
   {
-    if (parse_extract_token(buf, s, TOKEN_NO_FLAGS) != 0)
+    if (parse_extract_token(buf, s, TOKEN_BACKTICK_VARS) != 0)
     {
       buf_printf(err, _("source: error at %s"), s->dptr);
       buf_pool_release(&path);


### PR DESCRIPTION
Change `source` to look for NeoMutt variables first.

---

The `source` and `set` commands differed in how they interpreted a
$variable name.

    set my_c = `echo $my_dir/test.rc`

`set` would look for a NeoMutt variable called `my_dir` and failing that
look for an extern environment variable with that name.

    source `echo $my_dir/test.rc`

`source` only looked for an extern environment variable.