### PR TITLE
enter: fix auto-complete loss of text

### DIFF
--- a/enter/window.c
+++ b/enter/window.c
@@ -232,11 +232,19 @@ int mutt_buffer_get_field(const char *field, struct Buffer *buf, CompletionFlags
     // clang-format on
     win->wdata = &wdata;
 
-    /* Initialise wbuf from buf */
-    wdata.state->wbuflen = 0;
-    wdata.state->lastchar = mutt_mb_mbstowcs(&wdata.state->wbuf,
-                                             &wdata.state->wbuflen, 0, wdata.buf);
-    wdata.redraw = ENTER_REDRAW_INIT;
+    if (wdata.state->wbuf)
+    {
+      wdata.redraw = ENTER_REDRAW_LINE;
+      wdata.first = false;
+    }
+    else
+    {
+      /* Initialise wbuf from buf */
+      wdata.state->wbuflen = 0;
+      wdata.state->lastchar = mutt_mb_mbstowcs(&wdata.state->wbuf,
+                                               &wdata.state->wbuflen, 0, wdata.buf);
+      wdata.redraw = ENTER_REDRAW_INIT;
+    }
 
     if (wdata.flags & MUTT_COMP_FILE)
       wdata.hclass = HC_FILE;


### PR DESCRIPTION
When using auto-completion on addresses, completing a second address would overwrite the first.

Partially reverts commit d5b865cbcd83e9499ad8f2b1f7006dce1a466419.

The commit keeps the memory-leak fixes, but restores the buffer check that was causing multiple addresses to be lost.

Fixes: #3473 