### PR TITLE
nntp: change nntp_context type to DT_LONG

### DIFF
--- a/docs/config.c
+++ b/docs/config.c
@@ -2771,7 +2771,7 @@
 ** authentication fails, NeoMutt will not connect to the IMAP server.
 */
 
-{ "nntp_context", DT_NUMBER, 1000 },
+{ "nntp_context", DT_LONG, 1000 },
 /*
 ** .pp
 ** This variable defines number of articles which will be in index when

--- a/nntp/config.c
+++ b/nntp/config.c
@@ -54,7 +54,7 @@ static struct ConfigDef NntpVars[] = {
   { "nntp_authenticators", DT_STRING, 0, 0, NULL,
     "(nntp) Allowed authentication methods"
   },
-  { "nntp_context", DT_NUMBER|DT_NOT_NEGATIVE, 1000, 0, NULL,
+  { "nntp_context", DT_LONG|DT_NOT_NEGATIVE, 1000, 0, NULL,
     "(nntp) Maximum number of articles to list (0 for all articles)"
   },
   { "nntp_listgroup", DT_BOOL, true, 0, NULL,

--- a/nntp/lib.h
+++ b/nntp/lib.h
@@ -57,8 +57,8 @@ extern struct NntpAccountData *CurrentNewsSrv; ///< Current NNTP news server
 extern struct MxOps MxNntpOps;
 
 /* article number type and format */
-#define anum_t uint32_t
-#define ANUM "%u"
+#define anum_t long
+#define ANUM "%ld"
 
 /**
  * struct NntpAcache - NNTP article cache

--- a/nntp/newsrc.c
+++ b/nntp/newsrc.c
@@ -478,10 +478,10 @@ int nntp_newsrc_update(struct NntpAccountData *adata)
       if (j)
         buf[off++] = ',';
       if (mdata->newsrc_ent[j].first == mdata->newsrc_ent[j].last)
-        snprintf(buf + off, buflen - off, "%u", mdata->newsrc_ent[j].first);
+        snprintf(buf + off, buflen - off, ANUM, mdata->newsrc_ent[j].first);
       else if (mdata->newsrc_ent[j].first < mdata->newsrc_ent[j].last)
       {
-        snprintf(buf + off, buflen - off, "%u-%u", mdata->newsrc_ent[j].first,
+        snprintf(buf + off, buflen - off, ANUM "-" ANUM, mdata->newsrc_ent[j].first,
                  mdata->newsrc_ent[j].last);
       }
       off += strlen(buf + off);
@@ -671,7 +671,7 @@ int nntp_active_save_cache(struct NntpAccountData *adata)
       buflen *= 2;
       mutt_mem_realloc(&buf, buflen);
     }
-    snprintf(buf + off, buflen - off, "%s %u %u %c%s%s\n", mdata->group,
+    snprintf(buf + off, buflen - off, "%s " ANUM " " ANUM " %c%s%s\n", mdata->group,
              mdata->last_message, mdata->first_message, mdata->allowed ? 'y' : 'n',
              mdata->desc ? " " : "", mdata->desc ? mdata->desc : "");
     off += strlen(buf + off);
@@ -759,7 +759,7 @@ void nntp_hcache_update(struct NntpMboxData *mdata, struct HeaderCache *hc)
         if ((current >= mdata->first_message) && (current <= mdata->last_message))
           continue;
 
-        snprintf(buf, sizeof(buf), "%u", current);
+        snprintf(buf, sizeof(buf), ANUM, current);
         mutt_debug(LL_DEBUG2, "mutt_hcache_delete_record %s\n", buf);
         mutt_hcache_delete_record(hc, buf, strlen(buf));
       }
@@ -770,7 +770,7 @@ void nntp_hcache_update(struct NntpMboxData *mdata, struct HeaderCache *hc)
   /* store current values of first and last */
   if (!old || (mdata->first_message != first) || (mdata->last_message != last))
   {
-    snprintf(buf, sizeof(buf), "%u %u", mdata->first_message, mdata->last_message);
+    snprintf(buf, sizeof(buf), ANUM " " ANUM, mdata->first_message, mdata->last_message);
     mutt_debug(LL_DEBUG2, "mutt_hcache_store index: %s\n", buf);
     mutt_hcache_store_raw(hc, "index", 5, buf, strlen(buf) + 1);
   }
@@ -1190,7 +1190,7 @@ struct NntpAccountData *nntp_select_server(struct Mailbox *m, const char *server
             if ((last >= mdata->first_message) && (last <= mdata->last_message))
             {
               mdata->last_cached = last;
-              mutt_debug(LL_DEBUG2, "%s last_cached=%u\n", mdata->group, last);
+              mutt_debug(LL_DEBUG2, "%s last_cached=" ANUM "\n", mdata->group, last);
             }
           }
           mutt_hcache_free_raw(hc, (void **) &hdata);

--- a/nntp/nntp.c
+++ b/nntp/nntp.c
@@ -1074,7 +1074,7 @@ static int parse_overview_line(char *line, void *data)
     char buf[16] = { 0 };
 
     /* try to replace with header from cache */
-    snprintf(buf, sizeof(buf), "%u", anum);
+    snprintf(buf, sizeof(buf), ANUM, anum);
     struct HCacheEntry hce = mutt_hcache_fetch(fc->hc, buf, strlen(buf), 0);
     if (hce.email)
     {
@@ -1180,7 +1180,7 @@ static int nntp_fetch_headers(struct Mailbox *m, void *hc, anum_t first, anum_t 
     if (m->verbose)
       mutt_message(_("Fetching list of articles..."));
     if (mdata->adata->hasLISTGROUPrange)
-      snprintf(buf, sizeof(buf), "LISTGROUP %s %u-%u\r\n", mdata->group, first, last);
+      snprintf(buf, sizeof(buf), "LISTGROUP %s " ANUM "-" ANUM "\r\n", mdata->group, first, last);
     else
       snprintf(buf, sizeof(buf), "LISTGROUP %s\r\n", mdata->group);
     rc = nntp_fetch_lines(mdata, buf, sizeof(buf), NULL, fetch_numbers, &fc);
@@ -1195,7 +1195,7 @@ static int nntp_fetch_headers(struct Mailbox *m, void *hc, anum_t first, anum_t 
         if (fc.messages[current - first])
           continue;
 
-        snprintf(buf, sizeof(buf), "%u", current);
+        snprintf(buf, sizeof(buf), ANUM, current);
         if (mdata->bcache)
         {
           mutt_debug(LL_DEBUG2, "#1 mutt_bcache_del %s\n", buf);
@@ -1230,7 +1230,7 @@ static int nntp_fetch_headers(struct Mailbox *m, void *hc, anum_t first, anum_t 
       progress_update(fc.progress, current - first + 1, -1);
 
 #ifdef USE_HCACHE
-    snprintf(buf, sizeof(buf), "%u", current);
+    snprintf(buf, sizeof(buf), ANUM, current);
 #endif
 
     /* delete header from cache that does not exist on server */
@@ -1294,7 +1294,7 @@ static int nntp_fetch_headers(struct Mailbox *m, void *hc, anum_t first, anum_t 
         break;
       }
 
-      snprintf(buf, sizeof(buf), "HEAD %u\r\n", current);
+      snprintf(buf, sizeof(buf), "HEAD " ANUM "\r\n", current);
       rc = nntp_fetch_lines(mdata, buf, sizeof(buf), NULL, fetch_tempfile, fp);
       if (rc)
       {
@@ -1312,7 +1312,7 @@ static int nntp_fetch_headers(struct Mailbox *m, void *hc, anum_t first, anum_t 
         /* no such article */
         if (mdata->bcache)
         {
-          snprintf(buf, sizeof(buf), "%u", current);
+          snprintf(buf, sizeof(buf), ANUM, current);
           mutt_debug(LL_DEBUG2, "#3 mutt_bcache_del %s\n", buf);
           mutt_bcache_del(mdata->bcache, buf);
         }
@@ -1356,7 +1356,7 @@ static int nntp_fetch_headers(struct Mailbox *m, void *hc, anum_t first, anum_t 
   if ((current <= last) && (rc == 0) && !mdata->deleted)
   {
     char *cmd = mdata->adata->hasOVER ? "OVER" : "XOVER";
-    snprintf(buf, sizeof(buf), "%s %u-%u\r\n", cmd, current, last);
+    snprintf(buf, sizeof(buf), "%s " ANUM "-" ANUM "\r\n", cmd, current, last);
     rc = nntp_fetch_lines(mdata, buf, sizeof(buf), NULL, parse_overview_line, &fc);
     if (rc > 0)
     {
@@ -1505,7 +1505,7 @@ static enum MxStatus check_mailbox(struct Mailbox *m)
         if ((anum >= first) && (anum <= mdata->last_loaded))
           messages[anum - first] = 1;
 
-        snprintf(buf, sizeof(buf), "%u", anum);
+        snprintf(buf, sizeof(buf), ANUM, anum);
         struct HCacheEntry hce = mutt_hcache_fetch(hc, buf, strlen(buf), 0);
         if (hce.email)
         {
@@ -1550,7 +1550,7 @@ static enum MxStatus check_mailbox(struct Mailbox *m)
       if (messages[anum - first])
         continue;
 
-      snprintf(buf, sizeof(buf), "%u", anum);
+      snprintf(buf, sizeof(buf), ANUM, anum);
       struct HCacheEntry hce = mutt_hcache_fetch(hc, buf, strlen(buf), 0);
       if (hce.email)
       {
@@ -2220,7 +2220,7 @@ int nntp_check_children(struct Mailbox *m, const char *msgid)
   cc.child = mutt_mem_malloc(sizeof(anum_t) * cc.max);
 
   /* fetch numbers of child messages */
-  snprintf(buf, sizeof(buf), "XPAT References %u-%u *%s*\r\n",
+  snprintf(buf, sizeof(buf), "XPAT References " ANUM "-" ANUM " *%s*\r\n",
            mdata->first_message, mdata->last_loaded, msgid);
   rc = nntp_fetch_lines(mdata, buf, sizeof(buf), NULL, fetch_children, &cc);
   if (rc)

--- a/nntp/nntp.c
+++ b/nntp/nntp.c
@@ -1465,7 +1465,7 @@ static enum MxStatus check_mailbox(struct Mailbox *m)
     if (mdata->last_message < mdata->last_loaded)
     {
       mdata->last_loaded = mdata->first_message - 1;
-      const short c_nntp_context = cs_subset_number(NeoMutt->sub, "nntp_context");
+      const long c_nntp_context = cs_subset_long(NeoMutt->sub, "nntp_context");
       if (c_nntp_context && (mdata->last_message - mdata->last_loaded > c_nntp_context))
         mdata->last_loaded = mdata->last_message - c_nntp_context;
     }
@@ -1481,7 +1481,7 @@ static enum MxStatus check_mailbox(struct Mailbox *m)
     struct Email *e = NULL;
     anum_t first = mdata->first_message;
 
-    const short c_nntp_context = cs_subset_number(NeoMutt->sub, "nntp_context");
+    const long c_nntp_context = cs_subset_long(NeoMutt->sub, "nntp_context");
     if (c_nntp_context && (mdata->last_message - first + 1 > c_nntp_context))
       first = mdata->last_message - c_nntp_context + 1;
     messages = mutt_mem_calloc(mdata->last_loaded - first + 1, sizeof(unsigned char));
@@ -2423,7 +2423,7 @@ static enum MxOpenReturns nntp_mbox_open(struct Mailbox *m)
 
   /* strip off extra articles if adding context is greater than $nntp_context */
   first = mdata->first_message;
-  const short c_nntp_context = cs_subset_number(NeoMutt->sub, "nntp_context");
+  const long c_nntp_context = cs_subset_long(NeoMutt->sub, "nntp_context");
   if (c_nntp_context && (mdata->last_message - first + 1 > c_nntp_context))
     first = mdata->last_message - c_nntp_context + 1;
   mdata->last_loaded = first ? first - 1 : 0;


### PR DESCRIPTION
 Short values for this option are too limiting. And I came across
 servers/implementations where not only article numbers are not
 serial, but long gaps can exist between successive ones, so you
 would have to set nntp_context to a high enough value (> SHRT_MAX)
 to get enough articles back.