### PR TITLE
feat(notmuch): allow specifying notmuch configuration file

### DIFF
--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -16209,6 +16209,17 @@ virtual-mailboxes "My INBOX" "notmuch://?query=tag:inbox"
             </thead>
             <tbody>
               <row>
+                <entry><literal>nm_config_file</literal></entry>
+                <entry>path</entry>
+                <entry><literal>auto</literal></entry>
+                <entry>
+                  Configuration file for the notmuch database. Either a path,
+                  <literal>auto</literal> for detecting a config. file, or
+                  empty for no configuration file. Only useful for notmuch
+                  0.32+.
+                </entry>
+              </row>
+              <row>
                 <entry><literal>nm_db_limit</literal></entry>
                 <entry>number</entry>
                 <entry><literal>0</literal></entry>

--- a/notmuch/config.c
+++ b/notmuch/config.c
@@ -96,6 +96,9 @@ static int nm_query_window_timebase_validator(const struct ConfigSet *cs,
 
 static struct ConfigDef NotmuchVars[] = {
   // clang-format off
+  { "nm_config_file", DT_PATH, IP "auto", 0, NULL,
+    "(notmuch) Configuration file for notmuch. Use 'auto' to detect configuration."
+  },
   { "nm_db_limit", DT_NUMBER|DT_NOT_NEGATIVE, 0, 0, NULL,
     "(notmuch) Default limit for Notmuch queries"
   },


### PR DESCRIPTION
Since `notmuch` 0.32, `libnotmuch` has an API to open the database with
a configuration file. The options are a fully qualified path, empty
string for no configuration file, and NULL for auto-detection of notmuch
configuration. The `notmuch` backend relies on the auto-detection for
opening the database with a fallback to no configuration. We have no
mechanism for user-specified configurations.

To allow user specification, this commit introduces a new configuration
variable, `nm_config_file`. Users have the option of three values:

 1. A path
 2. An empty string for no configuration file
 3. `auto` for auto-detecting a config. file

Allowing users to express the three possible options we can pass to
`libnotmuch`. The `auto` keyword allows us to workaround the constraints
of the configuration system without relying on validator and internal
variable hacks.

However, this change requires working around NeoMutt's configuration
system as path variables map empty strings to `NULL`. While not ideal,
it's a single conditional.