### PR TITLE
enter: fix default text

### DIFF
--- a/enter/window.c
+++ b/enter/window.c
@@ -232,19 +232,11 @@ int mutt_buffer_get_field(const char *field, struct Buffer *buf, CompletionFlags
     // clang-format on
     win->wdata = &wdata;
 
-    if (wdata.state->wbuf)
-    {
-      wdata.redraw = ENTER_REDRAW_LINE;
-      wdata.first = false;
-    }
-    else
-    {
-      /* Initialise wbuf from buf */
-      wdata.state->wbuflen = 0;
-      wdata.state->lastchar = mutt_mb_mbstowcs(&wdata.state->wbuf,
-                                               &wdata.state->wbuflen, 0, wdata.buf);
-      wdata.redraw = ENTER_REDRAW_INIT;
-    }
+    /* Initialise wbuf from buf */
+    wdata.state->wbuflen = 0;
+    wdata.state->lastchar = mutt_mb_mbstowcs(&wdata.state->wbuf,
+                                              &wdata.state->wbuflen, 0, wdata.buf);
+    wdata.redraw = ENTER_REDRAW_INIT;
 
     if (wdata.flags & MUTT_COMP_FILE)
       wdata.hclass = HC_FILE;


### PR DESCRIPTION
If the entry field has some default text, e.g. when changing folder, fix `<enter>` to select that text.

This was broken by some recent refactoring of the enter code.