### PR TITLE
Don't assume e->tree != NULL implies e->thread != NULL

### DIFF
--- a/index/dlg_index.c
+++ b/index/dlg_index.c
@@ -818,7 +818,7 @@ void index_make_entry(struct Menu *menu, char *buf, size_t buflen, int line)
   struct MuttThread *tmp = NULL;
 
   const enum UseThreads c_threads = mutt_thread_style();
-  if ((c_threads > UT_FLAT) && e->tree)
+  if ((c_threads > UT_FLAT) && e->tree && e->thread)
   {
     flags |= MUTT_FORMAT_TREE; /* display the thread tree */
     if (e->display_subject)


### PR DESCRIPTION
I don't know whether the assumption should hold, but currently it clearly does not.

Fixes #3498