### PR TITLE
enter: re-fix lost data

### DIFF
--- a/enter/state.c
+++ b/enter/state.c
@@ -59,8 +59,11 @@ void enter_state_resize(struct EnterState *es, size_t num)
     return;
 
   num = ROUND_UP(num + 4, 128);
-  es->wbuflen = num;
   mutt_mem_realloc(&es->wbuf, num * sizeof(wchar_t));
+
+  memset(es->wbuf + es->wbuflen, 0, (num - es->wbuflen) * sizeof(wchar_t));
+
+  es->wbuflen = num;
 }
 
 /**

--- a/enter/window.c
+++ b/enter/window.c
@@ -232,11 +232,19 @@ int mutt_buffer_get_field(const char *field, struct Buffer *buf, CompletionFlags
     // clang-format on
     win->wdata = &wdata;
 
-    /* Initialise wbuf from buf */
-    wdata.state->wbuflen = 0;
-    wdata.state->lastchar = mutt_mb_mbstowcs(&wdata.state->wbuf,
-                                             &wdata.state->wbuflen, 0, wdata.buf);
-    wdata.redraw = ENTER_REDRAW_INIT;
+    if (state->wbuf[0] == L'\0')
+    {
+      /* Initialise wbuf from buf */
+      wdata.state->wbuflen = 0;
+      wdata.state->lastchar = mutt_mb_mbstowcs(&wdata.state->wbuf,
+                                               &wdata.state->wbuflen, 0, wdata.buf);
+      wdata.redraw = ENTER_REDRAW_INIT;
+    }
+    else
+    {
+      wdata.redraw = ENTER_REDRAW_LINE;
+      wdata.first = false;
+    }
 
     if (wdata.flags & MUTT_COMP_FILE)
       wdata.hclass = HC_FILE;

--- a/test/enter/state.c
+++ b/test/enter/state.c
@@ -31,11 +31,14 @@
 
 void test_editor_state(void)
 {
-  struct EnterState *es = enter_state_new();
-
   enter_state_resize(NULL, 16);
 
-  enter_state_resize(es, 16);
+  struct EnterState *es = enter_state_new();
+
+  for (size_t i = 0; i < 1000; i++)
+  {
+    enter_state_resize(es, i);
+  }
 
   enter_state_free(&es);
 


### PR DESCRIPTION
Fix a regression that lost data, e.g. when entering "To:", after using auto-completion on a second address.

---

Working:
- Selecting a default, e.g. a mailbox with new mail
- Adding to existing text, e.g. "To:" prompt + address auto-completion