### PR TITLE
Resolve alternates when subscribing/unsubscribing

### DIFF
--- a/send/send.h
+++ b/send/send.h
@@ -68,7 +68,7 @@ void            mutt_make_post_indent(struct Email *e, FILE *fp_out, struct Conf
 int             mutt_resend_message(FILE *fp, struct Mailbox *m, struct Email *e_cur, struct ConfigSubset *sub);
 int             mutt_send_message(SendFlags flags, struct Email *e_templ, const char *tempfile, struct Mailbox *m, struct EmailList *el, struct ConfigSubset *sub);
 void            mutt_set_followup_to(struct Envelope *env, struct ConfigSubset *sub);
-bool            mutt_send_list_subscribe(struct Mailbox *m, const struct Email *e);
-bool            mutt_send_list_unsubscribe(struct Mailbox *m, const struct Email *e);
+bool            mutt_send_list_subscribe(struct Mailbox *m, struct Email *e);
+bool            mutt_send_list_unsubscribe(struct Mailbox *m, struct Email *e);
 
 #endif /* MUTT_SEND_SEND_H */


### PR DESCRIPTION
Fixes #3461

[`mutt_send_message`](https://github.com/neomutt/neomutt/blob/d8fd4643b1a4221163a96974543fcbd4c4a78892/send/send.c#L2303-L2320) needs the current email (first entry in EmailList) to resolve the reverse name.