### PR TITLE
complete: fix resizing of matches

### DIFF
--- a/complete/helpers.c
+++ b/complete/helpers.c
@@ -48,21 +48,20 @@
 
 /**
  * matches_ensure_morespace - Allocate more space for auto-completion
- * @param cd      Completion Data
- * @param current Current allocation
+ * @param cd       Completion Data
+ * @param new_size Space required
  */
-static void matches_ensure_morespace(struct CompletionData *cd, int current)
+static void matches_ensure_morespace(struct CompletionData *cd, int new_size)
 {
-  if (current <= (cd->match_list_len - 2))
+  if (new_size <= (cd->match_list_len - 2))
     return;
 
-  int base_space = 512; // Enough space for all of the config items
-  int extra_space = cd->match_list_len - base_space;
-  extra_space *= 2;
-  const int space = base_space + extra_space;
-  mutt_mem_realloc(&cd->match_list, space * sizeof(char *));
-  memset(&cd->match_list[current + 1], 0, space - current);
-  cd->match_list_len = space;
+  new_size = ROUND_UP(new_size + 2, 512);
+
+  mutt_mem_realloc(&cd->match_list, new_size * sizeof(char *));
+  memset(&cd->match_list[cd->match_list_len], 0, new_size - cd->match_list_len);
+
+  cd->match_list_len = new_size;
 }
 
 /**


### PR DESCRIPTION
Fix a crash during auto-completion.
When resizing a block of memory there was an off-by-one when zeroing the new bit.

Thanks to @RaitoBezarius for the ASAN report (IRC)

```
=================================================================
==3638517==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x6210000a4d00 at pc 0x7fbfa076528e bp 0x7fffbf64fca0 sp 0x7fffbf64f450
WRITE of size 1 at 0x6210000a4d00 thread T0
    #0 0x7fbfa076528d in __interceptor_memset (/nix/store/k2a429wpxgfwp4jaacl9iaqw4kxqjaxa-gcc-11.3.0-lib/lib/libasan.so.6+0x3c28d)
    #1 0x443e27 in memset /nix/store/ck17nf5q2m51d9jpkpsirx91s64vh202-glibc-2.35-163-dev/include/bits/string_fortified.h:59
    #2 0x443e27 in matches_ensure_morespace /build/source/init.c:107
    #3 0x443e84 in candidate /build/source/init.c:128
    #4 0x4442d7 in complete_all_nm_tags /build/source/init.c:189
    #5 0x4497d5 in mutt_nm_query_complete /build/source/init.c:1390
    #6 0x56dbf0 in mutt_enter_string_full enter/enter.c:671
    #7 0x5609bb in mutt_buffer_get_field gui/curs_lib.c:310
    #8 0x496d43 in op_main_vfolder_from_query index/functions.c:2681
    #9 0x4a53ec in index_function_dispatcher index/functions.c:2858
    #10 0x495946 in mutt_index_menu index/dlg_index.c:1297
    #11 0x45a17c in main /build/source/main.c:1374
    #12 0x7fbf9fb6424d in __libc_start_call_main (/nix/store/7fz6dhhriwv6n4kdg05qi8cwf7mfqza9-glibc-2.35-163/lib/libc.so.6+0x2924d)
    #13 0x7fbf9fb64308 in __libc_start_main_impl (/nix/store/7fz6dhhriwv6n4kdg05qi8cwf7mfqza9-glibc-2.35-163/lib/libc.so.6+0x29308)
    #14 0x40d2b4 in _start (/nix/store/vwv9d7cdjiy3cxn49gklnx2pii7hwxzy-neomutt-20220429/bin/.neomutt-wrapped+0x40d2b4)

0x6210000a4d00 is located 0 bytes to the right of 4096-byte region [0x6210000a3d00,0x6210000a4d00)
allocated by thread T0 here:
    #0 0x7fbfa07dab48 in realloc (/nix/store/k2a429wpxgfwp4jaacl9iaqw4kxqjaxa-gcc-11.3.0-lib/lib/libasan.so.6+0xb1b48)
    #1 0x6a4d79 in mutt_mem_realloc mutt/memory.c:131
    #2 0x443e04 in matches_ensure_morespace /build/source/init.c:106
    #3 0x443e84 in candidate /build/source/init.c:128
    #4 0x4442d7 in complete_all_nm_tags /build/source/init.c:189
    #5 0x4497d5 in mutt_nm_query_complete /build/source/init.c:1390
    #6 0x56dbf0 in mutt_enter_string_full enter/enter.c:671
    #7 0x5609bb in mutt_buffer_get_field gui/curs_lib.c:310
    #8 0x496d43 in op_main_vfolder_from_query index/functions.c:2681
    #9 0x4a53ec in index_function_dispatcher index/functions.c:2858
    #10 0x495946 in mutt_index_menu index/dlg_index.c:1297
    #11 0x45a17c in main /build/source/main.c:1374
    #12 0x7fbf9fb6424d in __libc_start_call_main (/nix/store/7fz6dhhriwv6n4kdg05qi8cwf7mfqza9-glibc-2.35-163/lib/libc.so.6+0x2924d)

Shadow bytes around the buggy address:
  0x0c428000c950: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c428000c960: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c428000c970: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c428000c980: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c428000c990: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x0c428000c9a0:[fa]fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c428000c9b0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c428000c9c0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c428000c9d0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c428000c9e0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c428000c9f0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
==3638517==ABORTING
```