### PR TITLE
Add GNU SASL support for authentication

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,7 +22,7 @@ jobs:
           - name: default
             options:
           - name: disabled
-            options: --disable-idn --disable-nls --disable-pgp --disable-smime --ssl
+            options: --disable-idn --disable-nls --disable-pgp --disable-smime --ssl --gsasl
           - name: everything
             options: --autocrypt --bdb --disable-idn --fmemopen --gdbm --gnutls --gpgme --gss --idn2 --kyotocabinet --lmdb --lua --lz4 --mixmaster --notmuch --pcre2 --qdbm --rocksdb --sasl --tdb --tokyocabinet --with-lock=fcntl --zlib --zstd
 

--- a/.github/workflows/centos.yml
+++ b/.github/workflows/centos.yml
@@ -19,7 +19,7 @@ jobs:
           - name: Default
             options:
           - name: Minimal
-            options: --disable-idn --disable-nls --disable-pgp --disable-smime --ssl --with-lock=flock
+            options: --disable-idn --disable-nls --disable-pgp --disable-smime --ssl --gsasl --with-lock=flock
           - name: Everything
             options: --bdb --full-doc --gnutls --gpgme --gss --lz4 --pcre2 --sasl --tdb --tokyocabinet --with-lock=fcntl --zlib
             options8: --autocrypt --disable-idn --gdbm --idn2 --lua --notmuch --zstd

--- a/.github/workflows/fedora.yml
+++ b/.github/workflows/fedora.yml
@@ -20,7 +20,7 @@ jobs:
           - name: Default
             options:
           - name: Minimal
-            options: --disable-idn --disable-nls --disable-pgp --disable-smime --ssl --with-lock=flock
+            options: --disable-idn --disable-nls --disable-pgp --disable-smime --ssl --gsasl --with-lock=flock
           - name: Everything
             options: --autocrypt --bdb --disable-idn --full-doc --gdbm --gnutls --gpgme --gss --idn2 --lmdb --lua --lz4 --notmuch --pcre2 --qdbm --sasl --tdb --tokyocabinet --with-lock=fcntl --zlib --zstd
 

--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -284,7 +284,10 @@ LIBCONN=	libconn.a
 LIBCONNOBJS=	conn/accountcmd.o conn/config.o conn/connaccount.o \
 		conn/getdomain.o conn/raw.o conn/sasl_plain.o conn/socket.o \
 		conn/tunnel.o 
-@if HAVE_SASL
+@if USE_SASL_GNU
+LIBCONNOBJS+=	conn/gsasl.o
+@endif
+@if USE_SASL_CYRUS
 LIBCONNOBJS+=	conn/sasl.o
 @endif
 @if USE_SSL
@@ -479,9 +482,13 @@ LIBIMAPOBJS=	imap/auth.o imap/auth_login.o imap/auth_oauth.o \
 @if USE_GSS
 LIBIMAPOBJS+=	imap/auth_gss.o
 @endif
-@if HAVE_SASL
+@if USE_SASL_CYRUS
 LIBIMAPOBJS+=	imap/auth_sasl.o
-@else
+@endif
+@if USE_SASL_GNU
+LIBIMAPOBJS+=	imap/auth_gsasl.o
+@endif
+@if !HAVE_SASL
 LIBIMAPOBJS+=	imap/auth_anon.o imap/auth_cram.o
 @endif
 CLEANFILES+=	$(LIBIMAP) $(LIBIMAPOBJS)

--- a/auto.def
+++ b/auto.def
@@ -57,6 +57,8 @@ options {
   gss=0                     => "Use GSSAPI authentication for IMAP"
   with-gss:path             => "Location of GSSAPI library"
   # SASL (IMAP and POP auth)
+  gsasl=0                   => "Use the GNU SASL network security library"
+  with-gsasl:path           => "Location of the GNU SASL network security library"
   sasl=0                    => "Use the SASL network security library"
   with-sasl:path            => "Location of the SASL network security library"
   # AutoCrypt
@@ -154,7 +156,7 @@ if {1} {
   foreach opt {
     asan autocrypt bdb coverage debug-backtrace debug-color debug-email
     debug-graphviz debug-notify debug-parse-test debug-queue debug-window doc
-    everything fmemopen full-doc fuzzing gdbm gnutls gpgme gss homespool idn
+    everything fmemopen full-doc fuzzing gdbm gnutls gpgme gsasl gss homespool idn
     idn2 include-path-in-cflags inotify kyotocabinet lmdb locales-fix lua lz4
     mixmaster nls notmuch pcre2 pgp pkgconf qdbm rocksdb sasl smime sqlite ssl
     testing tdb tokyocabinet zlib zstd
@@ -166,7 +168,7 @@ if {1} {
   # relative --enable-opt to true. This allows "--with-opt=/usr" to be used as
   # a shortcut for "--opt --with-opt=/usr".
   foreach opt {
-    bdb gdbm gnutls gpgme gss homespool idn idn2 kyotocabinet lmdb lua lz4
+    bdb gdbm gnutls gpgme gsasl gss homespool idn idn2 kyotocabinet lmdb lua lz4
     mixmaster nls notmuch pcre2 qdbm rocksdb sasl sqlite ssl tdb tokyocabinet
     zlib zstd
   } {
@@ -585,6 +587,26 @@ if {[get-define want-pgp]} {
 if {[get-define want-smime]} {
   define-feature SMIME
   define CRYPT_BACKEND_CLASSIC_SMIME
+}
+
+###############################################################################
+# GNU SASL
+if {[get-define want-gsasl] && [get-define want-sasl]} {
+  user-error "Cannot specify both --gsasl and --sasl"
+}
+if {[get-define want-gsasl]} {
+  if {[get-define want-pkgconf]} {
+    pkgconf true libgsasl
+    define USE_SASL_GNU
+    define-feature SASL
+  } else {
+    if {[check-inc-and-lib gsasl [opt-val with-gsasl $prefix] \
+                           gsasl.h gsasl_init gsasl]} {
+      define USE_SASL_GNU
+    } else {
+      user-error "Unable to find GNU SASL"
+    }
+  }
 }
 
 ###############################################################################

--- a/conn/gsasl.c
+++ b/conn/gsasl.c
@@ -1,0 +1,223 @@
+/**
+ * @file
+ * GNU SASL authentication support
+ *
+ * @authors
+ * Copyright (C) 2022 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @page conn_gsasl GNU SASL authentication support
+ *
+ * GNU SASL authentication support
+ */
+
+#include "config.h"
+#include <gsasl.h>
+#include <stdbool.h>
+#include <string.h>
+#include "mutt/lib.h"
+#include "connaccount.h"
+#include "connection.h"
+#include "gsasl2.h"
+#include "mutt_account.h"
+
+static Gsasl *mutt_gsasl_ctx = NULL;
+
+/**
+ * mutt_gsasl_callback - Callback to retrieve authname or user from ConnAccount
+ * @param ctx  GNU SASL context
+ * @param sctx GNU SASL session
+ * @param prop Property to get, e.g. GSASL_PASSWORD
+ * @retval num GNU SASL error code, e.g. GSASL_OK
+ */
+static int mutt_gsasl_callback(Gsasl *ctx, Gsasl_session *sctx, Gsasl_property prop)
+{
+  int rc = GSASL_NO_CALLBACK;
+
+  struct Connection *conn = gsasl_session_hook_get(sctx);
+  if (!conn)
+  {
+    mutt_debug(LL_DEBUG1, "missing session hook data!\n");
+    return rc;
+  }
+
+  switch (prop)
+  {
+    case GSASL_PASSWORD:
+      if (mutt_account_getpass(&conn->account))
+        return rc;
+      gsasl_property_set(sctx, GSASL_PASSWORD, conn->account.pass);
+      rc = GSASL_OK;
+      break;
+
+    case GSASL_AUTHID:
+      /* whom the provided password belongs to: login */
+      if (mutt_account_getlogin(&conn->account))
+        return rc;
+      gsasl_property_set(sctx, GSASL_AUTHID, conn->account.login);
+      rc = GSASL_OK;
+      break;
+
+    case GSASL_AUTHZID:
+      /* name of the user whose mail/resources you intend to access: user */
+      if (mutt_account_getuser(&conn->account))
+        return rc;
+      gsasl_property_set(sctx, GSASL_AUTHZID, conn->account.user);
+      rc = GSASL_OK;
+      break;
+
+    case GSASL_ANONYMOUS_TOKEN:
+      gsasl_property_set(sctx, GSASL_ANONYMOUS_TOKEN, "dummy");
+      rc = GSASL_OK;
+      break;
+
+    case GSASL_SERVICE:
+    {
+      const char *service = NULL;
+      switch (conn->account.type)
+      {
+        case MUTT_ACCT_TYPE_IMAP:
+          service = "imap";
+          break;
+        case MUTT_ACCT_TYPE_POP:
+          service = "pop";
+          break;
+        case MUTT_ACCT_TYPE_SMTP:
+          service = "smtp";
+          break;
+        default:
+          return rc;
+      }
+      gsasl_property_set(sctx, GSASL_SERVICE, service);
+      rc = GSASL_OK;
+      break;
+    }
+
+    case GSASL_HOSTNAME:
+      gsasl_property_set(sctx, GSASL_HOSTNAME, conn->account.host);
+      rc = GSASL_OK;
+      break;
+
+    default:
+      break;
+  }
+
+  return rc;
+}
+
+/**
+ * mutt_gsasl_init - Initialise GNU SASL library
+ * @retval true Success
+ */
+static bool mutt_gsasl_init(void)
+{
+  if (mutt_gsasl_ctx)
+    return true;
+
+  int rc = gsasl_init(&mutt_gsasl_ctx);
+  if (rc != GSASL_OK)
+  {
+    mutt_gsasl_ctx = NULL;
+    mutt_debug(LL_DEBUG1, "libgsasl initialisation failed (%d): %s.\n", rc,
+               gsasl_strerror(rc));
+    return false;
+  }
+
+  gsasl_callback_set(mutt_gsasl_ctx, mutt_gsasl_callback);
+  return true;
+}
+
+/**
+ * mutt_gsasl_done - Shutdown GNU SASL library
+ */
+void mutt_gsasl_done(void)
+{
+  if (!mutt_gsasl_ctx)
+    return;
+
+  gsasl_done(mutt_gsasl_ctx);
+  mutt_gsasl_ctx = NULL;
+}
+
+/**
+ * mutt_gsasl_get_mech - Pick a connection mechanism
+ * @param requested_mech  Requested mechanism
+ * @param server_mechlist Server's list of mechanisms
+ * @retval ptr Selected mechanism string
+ */
+const char *mutt_gsasl_get_mech(const char *requested_mech, const char *server_mechlist)
+{
+  if (!mutt_gsasl_init())
+    return NULL;
+
+  /* libgsasl does not do case-independent string comparisons,
+   * and stores its methods internally in uppercase. */
+  char *uc_server_mechlist = mutt_str_dup(server_mechlist);
+  if (uc_server_mechlist)
+    mutt_str_upper(uc_server_mechlist);
+
+  char *uc_requested_mech = mutt_str_dup(requested_mech);
+  if (uc_requested_mech)
+    mutt_str_upper(uc_requested_mech);
+
+  const char *sel_mech = NULL;
+  if (uc_requested_mech)
+    sel_mech = gsasl_client_suggest_mechanism(mutt_gsasl_ctx, uc_requested_mech);
+  else
+    sel_mech = gsasl_client_suggest_mechanism(mutt_gsasl_ctx, uc_server_mechlist);
+
+  FREE(&uc_requested_mech);
+  FREE(&uc_server_mechlist);
+
+  return sel_mech;
+}
+
+/**
+ * mutt_gsasl_client_new - Create a new GNU SASL client
+ * @param conn Connection to a server
+ * @param mech Mechanisms to use
+ * @param sctx GNU SASL Session
+ * @retval  0 Success
+ * @retval -1 Error
+ */
+int mutt_gsasl_client_new(struct Connection *conn, const char *mech, Gsasl_session **sctx)
+{
+  if (!mutt_gsasl_init())
+    return -1;
+
+  int rc = gsasl_client_start(mutt_gsasl_ctx, mech, sctx);
+  if (rc != GSASL_OK)
+  {
+    *sctx = NULL;
+    mutt_debug(LL_DEBUG1, "gsasl_client_start failed (%d): %s.\n", rc, gsasl_strerror(rc));
+    return -1;
+  }
+
+  gsasl_session_hook_set(*sctx, conn);
+  return 0;
+}
+
+/**
+ * mutt_gsasl_client_finish - Free a GNU SASL client
+ * @param sctx GNU SASL Session
+ */
+void mutt_gsasl_client_finish(Gsasl_session **sctx)
+{
+  gsasl_finish(*sctx);
+  *sctx = NULL;
+}

--- a/conn/gsasl2.h
+++ b/conn/gsasl2.h
@@ -1,9 +1,9 @@
 /**
  * @file
- * SASL authentication support
+ * GNU SASL authentication support
  *
  * @authors
- * Copyright (C) 2000-2005,2008 Brendan Cully <brendan@kublai.com>
+ * Copyright (C) 2022 Richard Russon <rich@flatcap.org>
  *
  * @copyright
  * This program is free software: you can redistribute it and/or modify it under
@@ -20,19 +20,16 @@
  * this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef MUTT_CONN_SASL_H
-#define MUTT_CONN_SASL_H
+#ifndef MUTT_CONN_GSASL_H
+#define MUTT_CONN_GSASL_H
 
-#include <sasl/sasl.h>
-#include <stdbool.h>
+#include <gsasl.h>
 
 struct Connection;
 
-bool sasl_auth_validator(const char *authenticator);
+void        mutt_gsasl_client_finish(Gsasl_session **sctx);
+int         mutt_gsasl_client_new   (struct Connection *conn, const char *mech, Gsasl_session **sctx);
+void        mutt_gsasl_done         (void);
+const char *mutt_gsasl_get_mech     (const char *requested_mech, const char *server_mechlist);
 
-int  mutt_sasl_client_new(struct Connection *conn, sasl_conn_t **saslconn);
-void mutt_sasl_done      (void);
-int  mutt_sasl_interact  (sasl_interact_t *interaction);
-void mutt_sasl_setup_conn(struct Connection *conn, sasl_conn_t *saslconn);
-
-#endif /* MUTT_CONN_SASL_H */
+#endif /* MUTT_CONN_GSASL_H */

--- a/conn/lib.h
+++ b/conn/lib.h
@@ -33,6 +33,7 @@
  * | conn/dlg_verifycert.c | @subpage conn_dlg_verifycert  |
  * | conn/getdomain.c      | @subpage conn_getdomain       |
  * | conn/gnutls.c         | @subpage conn_gnutls          |
+ * | conn/gsasl.c          | @subpage conn_gsasl           |
  * | conn/openssl.c        | @subpage conn_openssl         |
  * | conn/raw.c            | @subpage conn_raw             |
  * | conn/sasl.c           | @subpage conn_sasl            |
@@ -51,6 +52,9 @@
 #include "connection.h"
 #include "sasl_plain.h"
 #include "socket.h"
+#ifdef USE_SASL_GNU
+#include "gsasl2.h"
+#endif
 #ifdef USE_SASL_CYRUS
 #include "sasl.h"
 #endif

--- a/imap/auth.c
+++ b/imap/auth.c
@@ -61,8 +61,10 @@ static const struct ImapAuth ImapAuthenticators[] = {
   { imap_auth_oauth, "oauthbearer" },
   { imap_auth_xoauth2, "xoauth2" },
   { imap_auth_plain, "plain" },
-#ifdef USE_SASL_CYRUS
+#if defined(USE_SASL_CYRUS)
   { imap_auth_sasl, NULL },
+#elif defined(USE_SASL_GNU)
+  { imap_auth_gsasl, NULL },
 #else
   { imap_auth_anon, "anonymous" },
 #endif

--- a/imap/auth.h
+++ b/imap/auth.h
@@ -56,6 +56,9 @@ enum ImapAuthRes imap_auth_gss(struct ImapAccountData *adata, const char *method
 #ifdef USE_SASL_CYRUS
 enum ImapAuthRes imap_auth_sasl(struct ImapAccountData *adata, const char *method);
 #endif
+#ifdef USE_SASL_GNU
+enum ImapAuthRes imap_auth_gsasl(struct ImapAccountData *adata, const char *method);
+#endif
 enum ImapAuthRes imap_auth_oauth(struct ImapAccountData *adata, const char *method);
 enum ImapAuthRes imap_auth_xoauth2(struct ImapAccountData *adata, const char *method);
 

--- a/imap/auth_gsasl.c
+++ b/imap/auth_gsasl.c
@@ -1,0 +1,151 @@
+/**
+ * @file
+ * IMAP GNU SASL authentication method
+ *
+ * @authors
+ * Copyright (C) 2022 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @page imap_auth_gsasl GNU SASL authentication
+ *
+ * IMAP GNU SASL authentication method
+ */
+
+#include "config.h"
+#include <stddef.h>
+#include <gsasl.h>
+#include "private.h"
+#include "mutt/lib.h"
+#include "conn/lib.h"
+#include "adata.h"
+#include "auth.h"
+
+/**
+ * imap_auth_gsasl - GNU SASL authenticator - Implements ImapAuth::authenticate()
+ */
+enum ImapAuthRes imap_auth_gsasl(struct ImapAccountData *adata, const char *method)
+{
+  Gsasl_session *gsasl_session = NULL;
+  struct Buffer *output_buf = NULL;
+  char *imap_step_output = NULL;
+  int rc = IMAP_AUTH_FAILURE;
+  int gsasl_rc = GSASL_OK;
+  int imap_step_rc = IMAP_RES_CONTINUE;
+
+  const char *chosen_mech = mutt_gsasl_get_mech(method, adata->capstr);
+  if (!chosen_mech)
+  {
+    mutt_debug(LL_DEBUG2, "mutt_gsasl_get_mech() returned no usable mech\n");
+    return IMAP_AUTH_UNAVAIL;
+  }
+
+  mutt_debug(LL_DEBUG2, "using mech %s\n", chosen_mech);
+
+  if (mutt_gsasl_client_new(adata->conn, chosen_mech, &gsasl_session) < 0)
+  {
+    mutt_debug(LL_DEBUG1, "Error allocating GSASL connection.\n");
+    return IMAP_AUTH_UNAVAIL;
+  }
+
+  mutt_message(_("Authenticating (%s)..."), chosen_mech);
+
+  output_buf = mutt_buffer_pool_get();
+  mutt_buffer_printf(output_buf, "AUTHENTICATE %s", chosen_mech);
+  if (adata->capabilities & IMAP_CAP_SASL_IR)
+  {
+    char *gsasl_step_output = NULL;
+    gsasl_rc = gsasl_step64(gsasl_session, "", &gsasl_step_output);
+    if ((gsasl_rc != GSASL_NEEDS_MORE) && (gsasl_rc != GSASL_OK))
+    {
+      mutt_debug(LL_DEBUG1, "gsasl_step64() failed (%d): %s\n", gsasl_rc,
+                 gsasl_strerror(gsasl_rc));
+      rc = IMAP_AUTH_UNAVAIL;
+      goto bail;
+    }
+
+    mutt_buffer_addch(output_buf, ' ');
+    mutt_buffer_addstr(output_buf, gsasl_step_output);
+    gsasl_free(gsasl_step_output);
+  }
+  imap_cmd_start(adata, mutt_buffer_string(output_buf));
+
+  do
+  {
+    do
+    {
+      imap_step_rc = imap_cmd_step(adata);
+    } while (imap_step_rc == IMAP_RES_CONTINUE);
+
+    if ((imap_step_rc == IMAP_RES_BAD) || (imap_step_rc == IMAP_RES_NO))
+      goto bail;
+
+    if (imap_step_rc != IMAP_RES_RESPOND)
+      break;
+
+    imap_step_output = imap_next_word(adata->buf);
+
+    char *gsasl_step_output = NULL;
+    gsasl_rc = gsasl_step64(gsasl_session, imap_step_output, &gsasl_step_output);
+    if ((gsasl_rc == GSASL_NEEDS_MORE) || (gsasl_rc == GSASL_OK))
+    {
+      mutt_buffer_strcpy(output_buf, gsasl_step_output);
+      gsasl_free(gsasl_step_output);
+    }
+    else
+    {
+      // sasl error occured, send an abort string
+      mutt_debug(LL_DEBUG1, "gsasl_step64() failed (%d): %s\n", gsasl_rc,
+                 gsasl_strerror(gsasl_rc));
+      mutt_buffer_strcpy(output_buf, "*");
+    }
+
+    mutt_buffer_addstr(output_buf, "\r\n");
+    mutt_socket_send(adata->conn, mutt_buffer_string(output_buf));
+  } while ((gsasl_rc == GSASL_NEEDS_MORE) || (gsasl_rc == GSASL_OK));
+
+  if (imap_step_rc != IMAP_RES_OK)
+  {
+    do
+      imap_step_rc = imap_cmd_step(adata);
+    while (imap_step_rc == IMAP_RES_CONTINUE);
+  }
+
+  if (imap_step_rc == IMAP_RES_RESPOND)
+  {
+    mutt_socket_send(adata->conn, "*\r\n");
+    goto bail;
+  }
+
+  if ((gsasl_rc != GSASL_OK) || (imap_step_rc != IMAP_RES_OK))
+    goto bail;
+
+  if (imap_code(adata->buf))
+    rc = IMAP_AUTH_SUCCESS;
+
+bail:
+  mutt_buffer_pool_release(&output_buf);
+  mutt_gsasl_client_finish(&gsasl_session);
+
+  if (rc == IMAP_AUTH_FAILURE)
+  {
+    mutt_debug(LL_DEBUG2, "%s failed\n", chosen_mech);
+    mutt_error(_("SASL authentication failed"));
+  }
+
+  return rc;
+}

--- a/imap/auth_sasl.c
+++ b/imap/auth_sasl.c
@@ -40,7 +40,7 @@
 #include "auth.h"
 
 /**
- * imap_auth_sasl - Default authenticator if available - Implements ImapAuth::authenticate()
+ * imap_auth_sasl - SASL authenticator - Implements ImapAuth::authenticate()
  */
 enum ImapAuthRes imap_auth_sasl(struct ImapAccountData *adata, const char *method)
 {

--- a/imap/config.c
+++ b/imap/config.c
@@ -32,8 +32,10 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include "mutt/lib.h"
-#include "conn/lib.h"
 #include "auth.h"
+#ifdef USE_SASL_CYRUS
+#include "conn/lib.h"
+#endif
 
 /**
  * imap_auth_validator - Validate the "imap_authenticators" config variable - Implements ConfigDef::validator() - @ingroup cfg_def_validator

--- a/main.c
+++ b/main.c
@@ -1383,6 +1383,9 @@ main
 #ifdef USE_SASL_CYRUS
     mutt_sasl_done();
 #endif
+#ifdef USE_SASL_GNU
+    mutt_gsasl_done();
+#endif
 #ifdef USE_AUTOCRYPT
     mutt_autocrypt_cleanup();
 #endif

--- a/pop/config.c
+++ b/pop/config.c
@@ -33,7 +33,6 @@
 #include <stdint.h>
 #include "private.h"
 #include "mutt/lib.h"
-#include "conn/lib.h"
 
 /**
  * pop_auth_validator - Validate the "pop_authenticators" config variable - Implements ConfigDef::validator() - @ingroup cfg_def_validator

--- a/send/config.c
+++ b/send/config.c
@@ -33,8 +33,10 @@
 #include <stdint.h>
 #include <string.h>
 #include "mutt/lib.h"
-#include "conn/lib.h"
 #include "lib.h"
+#ifdef USE_SASL_CYRUS
+#include "conn/lib.h"
+#endif
 
 /**
  * wrapheaders_validator - Validate the "wrap_headers" config variable - Implements ConfigDef::validator() - @ingroup cfg_def_validator

--- a/version.c
+++ b/version.c
@@ -198,6 +198,11 @@ static struct CompileOptions comp_opts[] = {
 #else
   { "gpgme", 0 },
 #endif
+#ifdef USE_SASL_GNU
+  { "gsasl", 1 },
+#else
+  { "gsasl", 0 },
+#endif
 #ifdef USE_GSS
   { "gss", 1 },
 #else


### PR DESCRIPTION
Add support for the GNU SASL library, using **configure** option **`--gsasl`**

Add multiline response support for SMTP authentication (which is probably not actually needed).  Also add arbitrary line length for the SASL server responses (the RFCs note that for SASL, the protocol line lengths don't apply).

Upstream-commit: https://gitlab.com/muttmua/mutt/commit/68caf9140c8217ecf6c848460c4b4d27996b2922
