### PR TITLE
Implement 'prompt_user' command

### DIFF
--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -10470,6 +10470,31 @@ macro index ,a "&lt;save-message&gt;=archive&lt;enter&gt;&lt;enter-command&gt;ec
 
     </sect1>
 
+    <sect1 id="prompt-user">
+      <title>User-Defined Prompts</title>
+      <para>
+        Usage:
+      </para>
+      <cmdsynopsis>
+        <command>prompt_user</command>
+        <arg choice="opt">
+          <option>-hidden</option>
+        </arg>
+        <arg choice="opt">
+          <option>-file</option>
+        </arg>
+        <arg choice="opt">
+          <option>-anykey</option>
+        </arg>
+        <arg choice="plain">
+          <replaceable class="parameter">&quot;prompt&quot;</replaceable>
+        </arg>
+      </cmdsynopsis>
+      <para>
+        description
+      </para>
+    </sect1>
+
     <sect1 id="compose-flow">
       <title>Message Composition Flow</title>
         <para>


### PR DESCRIPTION
* **What does this PR do?**

`prompt_user` is a new command that takes a variable and, optionally, a message, implemented by `parse_prompt`. It prompts the user if a message was given, and stores their response in the variable. The user can abort giving an input, which leaves the variable unchanged.

This command takes a number of flags:

* `-hidden`: hides the user input whilst it is being typed
* `-file`: enables file/directory name completion on the user input
* `-onechar`: takes user input as normal, but then discards all of it except for the first character
* `-anykey`: stop taking user input after the first keypress

Flags can be anywhere in the command, and the target variable is the the first non-flag token. If a second non-flag token is given, it is used as the user prompt. The flags `-hidden` and `-file` conflict, and the one given last will be used instead of the other.

* **Does this PR meet the acceptance criteria?** (This is just a reminder for you,
  this section can be removed if you fulfill it.)

Not yet - documentation still needs to be written for `prompt_user`. There was also discussion in the issue about adding a menus flag that restricts the response to a set of letters, and abort. I have not written any tests for `parse_prompt` yet (not sure how I would given the command requires user input - any pointers would be great)

* **What are the relevant issue numbers?**

#2659 - Prompt-User command