### PR TITLE
Add preserve_new flag

### DIFF
--- a/docs/config.c
+++ b/docs/config.c
@@ -3593,6 +3593,13 @@
 ** .te
 */
 
+{ "preserve_new", DT_BOOL, false },
+/*
+** .pp
+** Controls whether or not NeoMutt marks should distinguish between old and new messages
+** when \fImark_old\fP is unset.
+*/
+
 { "print", DT_QUAD, MUTT_ASKNO },
 /*
 ** .pp

--- a/email/parse.c
+++ b/email/parse.c
@@ -957,7 +957,9 @@ int mutt_rfc822_parse_line(struct Envelope *env, struct Email *e, const char *na
               case 'O':
               {
                 const bool c_mark_old = cs_subset_bool(NeoMutt->sub, "mark_old");
-                e->old = c_mark_old;
+                const bool c_preserve_new =
+                    cs_subset_bool(NeoMutt->sub, "preserve_new");
+                e->old = c_mark_old || c_preserve_new;
                 break;
               }
               case 'R':

--- a/imap/message.c
+++ b/imap/message.c
@@ -246,7 +246,8 @@ static char *msg_parse_flags(struct ImapHeader *h, char *s)
     else if ((plen = mutt_istr_startswith(s, "old")))
     {
       s += plen;
-      edata->old = cs_subset_bool(NeoMutt->sub, "mark_old");
+      edata->old = cs_subset_bool(NeoMutt->sub, "mark_old") ||
+                   cs_subset_bool(NeoMutt->sub, "preserve_new");
     }
     else
     {

--- a/maildir/maildir.c
+++ b/maildir/maildir.c
@@ -523,7 +523,8 @@ int maildir_parse_dir(struct Mailbox *m, struct MdEmailArray *mda,
 
   mutt_buffer_printf(buf, "%s/%s", mailbox_path(m), subdir);
   const bool c_mark_old = cs_subset_bool(NeoMutt->sub, "mark_old");
-  is_old = c_mark_old ? mutt_str_equal("cur", subdir) : false;
+  const bool preserve_new = cs_subset_bool(NeoMutt->sub, "preserve_new");
+  is_old = c_mark_old || preserve_new ? mutt_str_equal("cur", subdir) : false;
 
   DIR *dirp = opendir(mutt_buffer_string(buf));
   if (!dirp)

--- a/mutt_config.c
+++ b/mutt_config.c
@@ -431,6 +431,9 @@ static struct ConfigDef MainVars[] = {
   { "preferred_languages", DT_SLIST|SLIST_SEP_COMMA, 0, 0, NULL,
     "List of Preferred Languages for multilingual MIME (comma-separated)"
   },
+  { "preserve_new", DT_BOOL|R_INDEX|R_PAGER, false, 0, NULL,
+    "Distinguish between new/old messages when mark_old is unset"
+  },
   { "print", DT_QUAD, MUTT_ASKNO, 0, NULL,
     "Confirm before printing a message"
   },

--- a/notmuch/notmuch.c
+++ b/notmuch/notmuch.c
@@ -528,7 +528,8 @@ static int update_message_path(struct Email *e, const char *path)
     FREE(&edata->folder);
 
     p -= 3; /* skip subfolder (e.g. "new") */
-    if (cs_subset_bool(NeoMutt->sub, "mark_old"))
+    if (cs_subset_bool(NeoMutt->sub, "mark_old") ||
+        cs_subset_bool(NeoMutt->sub, "preserve_new"))
     {
       e->old = mutt_str_startswith(p, "cur");
     }


### PR DESCRIPTION
* **What does this PR do?**
Adds a `preserve_new` flag which differentiates between old and new messages when `mark_old` flag is unset

* **What are the relevant issue numbers?**
Fix #1536

* **Other Notes**
I don't really use nntp/pop, so I wasn't sure how to set it for those.