### PR TITLE
feat(notmuch): allow usage of notmuch profiles

### DIFF
--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -16249,6 +16249,15 @@ virtual-mailboxes "My INBOX" "notmuch://?query=tag:inbox"
                 </entry>
               </row>
               <row>
+                <entry><literal>nm_config_profile</literal></entry>
+                <entry>string</entry>
+                <entry>(empty)</entry>
+                <entry>
+                  Configuration profile for the notmuch database. Only useful
+                  for notmuch 0.32+.
+                </entry>
+              </row>
+              <row>
                 <entry><literal>nm_db_limit</literal></entry>
                 <entry>number</entry>
                 <entry><literal>0</literal></entry>

--- a/notmuch/config.c
+++ b/notmuch/config.c
@@ -99,6 +99,9 @@ static struct ConfigDef NotmuchVars[] = {
   { "nm_config_file", DT_PATH, IP "auto", 0, NULL,
     "(notmuch) Configuration file for notmuch. Use 'auto' to detect configuration."
   },
+  { "nm_config_profile", DT_STRING, 0, 0, NULL,
+    "(notmuch) Configuration profile for notmuch."
+  },
   { "nm_db_limit", DT_NUMBER|DT_NOT_NEGATIVE, 0, 0, NULL,
     "(notmuch) Default limit for Notmuch queries"
   },

--- a/notmuch/db.c
+++ b/notmuch/db.c
@@ -127,8 +127,10 @@ notmuch_database_t *nm_db_do_open(const char *filename, bool writable, bool verb
 #if LIBNOTMUCH_CHECK_VERSION(5, 4, 0)
     // notmuch 0.32-0.32.2 didn't bump libnotmuch version to 5.4.
     const char *config_file = get_nm_config_file();
+    const char *const config_profile = cs_subset_string(NeoMutt->sub, "nm_config_profile");
 
-    st = notmuch_database_open_with_config(filename, mode, config_file, NULL, &db, &msg);
+    st = notmuch_database_open_with_config(filename, mode, config_file,
+                                           config_profile, &db, &msg);
 
     // Attempt opening database without configuration file. Don't if the user specified no config.
     if (st == NOTMUCH_STATUS_NO_CONFIG && !mutt_str_equal(config_file, ""))
@@ -186,6 +188,7 @@ notmuch_database_t *nm_db_do_open(const char *filename, bool writable, bool verb
       mutt_clear_error();
     }
   }
+
   return db;
 }
 


### PR DESCRIPTION
Introduce the `nm_config_profile` option for users to use notmuch profiles. It has a default of an empty string so notmuch will try `NOTMUCH_PROFILE` or the default value (`default` for directories, empty string for config files.)