### PR TITLE
notmuch: document `get_nm_message()` error value

### DIFF
--- a/notmuch/notmuch.c
+++ b/notmuch/notmuch.c
@@ -1027,6 +1027,7 @@ static bool read_threads_query(struct Mailbox *m, notmuch_query_t *q, bool dedup
  * @param db  Notmuch database
  * @param e Email
  * @retval ptr Handle to the Notmuch message
+ * @retval NULL Error occurred
  */
 static notmuch_message_t *get_nm_message(notmuch_database_t *db, struct Email *e)
 {


### PR DESCRIPTION
Document that `get_nm_message()` returns `NULL` if an errors occurs, which sets `id` or `db` to `NULL`.

---

I was pretty confused why I was getting `NULL` during debugging when the function didn't mention that as a valid return value.