### PR TITLE
fixed possible fail in mutt_date_parse_imap

### DIFF
--- a/test/date/mutt_date_parse_imap.c
+++ b/test/date/mutt_date_parse_imap.c
@@ -58,7 +58,7 @@ void test_mutt_date_parse_imap(void)
   {
     for (size_t i = 0; i < mutt_array_size(imap_tests); i++)
     {
-      TEST_CASE(imap_tests[i]);
+      TEST_CASE(imap_tests[i].str);
       time_t result = mutt_date_parse_imap(imap_tests[i].str);
       if (!TEST_CHECK(result == imap_tests[i].expected))
       {


### PR DESCRIPTION
Obvious bug, this is supposed to be a string, but a struct is passed instead, fails on some uncommon calling conventions.