### PR TITLE
Use pkgconf to find GPGMe

### DIFF
--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -601,7 +601,7 @@ $(PWD)/mutt:
 LIBNCRYPT=	libncrypt.a
 LIBNCRYPTOBJS=	ncrypt/config.o ncrypt/crypt.o ncrypt/cryptglue.o \
 		ncrypt/crypt_mod.o
-@if HAVE_GPGME
+@if HAVE_PKG_GPGME
 LIBNCRYPTOBJS+=	ncrypt/crypt_gpgme.o ncrypt/dlg_gpgme.o \
 		ncrypt/gpgme_functions.o ncrypt/crypt_mod_pgp_gpgme.o \
 		ncrypt/crypt_mod_smime_gpgme.o

--- a/auto.def
+++ b/auto.def
@@ -25,7 +25,7 @@ set subdirs {po data docs contrib}
 
 ###############################################################################
 # Add any user options here
-options {
+set valid_options {
 # Curses
   with-ncurses:path         => "Location of ncurses"
 # Features w/o 3rd party dependencies
@@ -130,20 +130,33 @@ options {
   debug-parse-test=0        => "DEBUG: Enable 'neomutt -T' for config testing"
   debug-queue=0             => "DEBUG: Enable TAILQ debugging"
   debug-window=0            => "DEBUG: Enable windows dump"
-# Deprecated stuff
-  pkgconf:=deprecated       => "Deprecated"
-  with-slang:deprecated     => "Deprecated"
-  with-ui:=deprecated       => "Deprecated"
-  with-gpgme:deprecated     => "Deprecated"
 }
+
+set deprecated_options  {
+  pkgconf:=
+  with-slang:
+  with-ui:=
+  with-gpgme:
+}
+
+foreach dep $deprecated_options {
+  append valid_options "${dep}deprecated => Deprecated\n"
+}
+
+options $valid_options
 ###############################################################################
 
 ###############################################################################
-# Deprecated config options
-foreach dep {with-ui with-slang pkgconf with-gpgme} {
-  if {[opt-bool -nodefault $dep] != -1} {
-    user-notice "\nThe configure option \"--$dep\" is not used anymore\n"
+# Issue a warning for deprecated options on the command line
+set notices {}
+foreach dep $deprecated_options {
+  lassign [split $dep :] name
+  if {[opt-bool -nodefault $name] != -1} {
+    lappend notices --$name
   }
+}
+if {[llength $notices]} {
+  user-notice "\nThe following options are deprecated: [join $notices {, }]\n"
 }
 ###############################################################################
 

--- a/auto.def
+++ b/auto.def
@@ -480,14 +480,8 @@ if {[get-define want-gpgme]} {
   if {[is-defined _FILE_OFFSET_BITS]} {
     define-append CFLAGS -D_FILE_OFFSET_BITS=[get-define _FILE_OFFSET_BITS]
   }
-
   pkgconf true gpgme
   pkgconf true gpg-error
-
-  # Version might look like this: 1.13.1-unknown, so split on both '.' and '-'
-  lassign [split [get-define PKG_GPGME_VERSION] .-] gpgme_maj gpgme_min gpgme_patch
-
-  define GPGME_VERSION_NUMBER [format "0x%02x%02x%02x" $gpgme_maj $gpgme_min $gpgme_patch]
   define CRYPT_BACKEND_GPGME
 }
 

--- a/auto.def
+++ b/auto.def
@@ -52,7 +52,6 @@ options {
   with-gnutls:path          => "Location of GnuTLS"
   # GPGME
   gpgme=0                   => "Enable GPGME support"
-  with-gpgme:path           => "Location of GPGME"
   # GSS (IMAP auth)
   gss=0                     => "Use GSSAPI authentication for IMAP"
   with-gss:path             => "Location of GSSAPI library"
@@ -135,12 +134,13 @@ options {
   pkgconf:=deprecated       => "Deprecated"
   with-slang:deprecated     => "Deprecated"
   with-ui:=deprecated       => "Deprecated"
+  with-gpgme:deprecated     => "Deprecated"
 }
 ###############################################################################
 
 ###############################################################################
 # Deprecated config options
-foreach dep {with-ui with-slang pkgconf} {
+foreach dep {with-ui with-slang pkgconf with-gpgme} {
   if {[opt-bool -nodefault $dep] != -1} {
     user-notice "\nThe configure option \"--$dep\" is not used anymore\n"
   }

--- a/auto.def
+++ b/auto.def
@@ -481,56 +481,13 @@ if {[get-define want-gpgme]} {
     define-append CFLAGS -D_FILE_OFFSET_BITS=[get-define _FILE_OFFSET_BITS]
   }
 
-  msg-checking "Checking for GPGME..."
-  if {1} {
-    # Locate gpgme-config
-    set gpgme_prefix [opt-val with-gpgme $prefix]
-    set gpgme_config_guess [file join $gpgme_prefix bin gpgme-config]
-    if {[file-isexec $gpgme_config_guess]} {
-      define GPGME-CONFIG $gpgme_config_guess
-    } else {
-      if {![cc-check-progs gpgme-config]} {
-        user-error "Unable to find gpgme-config"
-      }
-    }
-    set gpgme_config [get-define GPGME-CONFIG]
-
-    # Version
-    if {[catch {exec-with-stderr $gpgme_config --version} gpgme_version err]} {
-      user-error "Could not derive --version from $gpgme_config"
-    }
-    if {[scan $gpgme_version "%d.%d.%d" gpgme_maj gpgme_min gpgme_patch] != 3} {
-      user-error "Could not parse GPGME version $gpgme_version"
-    }
-    msg-result $gpgme_version
-    if {[get-define want-autocrypt]} {
-      if {$gpgme_maj < 1 || $gpgme_min < 8} {
-        # GPGME v1.8.0 was released on 2016-11-16
-        user-error "Found GPGME version $gpgme_version, need 1.8.0 for AutoCrypt"
-      }
-    } else {
-      if {$gpgme_maj < 1 || $gpgme_min < 4} {
-        # GPGME v1.4.0 was released on 2013-02-26
-        user-error "Found GPGME version $gpgme_version, need 1.4.0"
-      }
-    }
-    define GPGME_VERSION_NUMBER [format "0x%02x%02x%02x" $gpgme_maj $gpgme_min $gpgme_patch]
-
-    # CFLAGS
-    if {[catch {exec-with-stderr $gpgme_config --cflags} res err]} {
-      user-error "Could not derive --cflags from $gpgme_config"
-    }
-    define-append CFLAGS $res
-
-    # LIBS
-    if {[catch {exec-with-stderr $gpgme_config --libs} res err]} {
-      user-error "Could not derive --libs from $gpgme_config"
-    }
-    define-append LIBS $res
-  }
-  define-feature gpgme
-
+  pkgconf true gpgme
   pkgconf true gpg-error
+
+  # Version might look like this: 1.13.1-unknown, so split on both '.' and '-'
+  lassign [split [get-define PKG_GPGME_VERSION] .-] gpgme_maj gpgme_min gpgme_patch
+
+  define GPGME_VERSION_NUMBER [format "0x%02x%02x%02x" $gpgme_maj $gpgme_min $gpgme_patch]
   define CRYPT_BACKEND_GPGME
 }
 

--- a/ncrypt/gpgme_functions.c
+++ b/ncrypt/gpgme_functions.c
@@ -762,20 +762,6 @@ static int op_generic_select_entry(struct GpgmeData *gd, int op)
       mutt_clear_error();
       return FR_NO_ACTION;
     }
-
-    /* A '!' is appended to a key in find_keys() when forced_valid is
-     * set.  Prior to GPGME 1.11.0, encrypt_gpgme_object() called
-     * create_recipient_set() which interpreted the '!' to mean set
-     * GPGME_VALIDITY_FULL for the key.
-     *
-     * Starting in GPGME 1.11.0, we now use a '\n' delimited recipient
-     * string, which is passed directly to the gpgme_op_encrypt_ext()
-     * function.  This allows to use the original meaning of '!' to
-     * force a subkey use. */
-#if (GPGME_VERSION_NUMBER < 0x010b00) // GPGME < 1.11.0
-    if (gd->forced_valid)
-      *gd->forced_valid = true;
-#endif
   }
 
   gd->key = crypt_copy_key(cur_key);


### PR DESCRIPTION
The first GPGMe version to ship a pkg-config file is 1.13.0, released in March 2019. See this [upstream commit](https://dev.gnupg.org/rMf3e60521899e6126229b6efedc9f011b84122e11). I think it's ok to assume at least 1.13.0 is present, given that we already use pkg-config for gpg-error.

Fixes #3553