### PR TITLE
index: fix cursor after new mail

### DIFF
--- a/email/email.c
+++ b/email/email.c
@@ -77,7 +77,7 @@ void email_free(struct Email **ptr)
  */
 struct Email *email_new(void)
 {
-  static size_t sequence = 0;
+  static size_t sequence = 1;
 
   struct Email *e = mutt_mem_calloc(1, sizeof(struct Email));
 #ifdef MIXMASTER


### PR DESCRIPTION
When new mail arrives, the backends (maildir/imap) update the Mailbox and send notifications.
In the frontend, the Mailbox view (`MView`) observes these changes (`mview_mailbox_observer()`).
(`MView` was previously known as the `Context`)

Before we do anything that might affect the ordering of the `Email`s, remember the sequence number of the current `Email`.
Afterwards, search for the `Email` by the sequence number.

Fixes: #3544