### PR TITLE
Fallback to manual detection of LMDB

### DIFF
--- a/auto.def
+++ b/auto.def
@@ -88,6 +88,7 @@ set valid_options {
   kyotocabinet=0            => "Use KyotoCabinet for the header cache"
   with-kyotocabinet:path    => "Location of KyotoCabinet"
   lmdb=0                    => "Use LMDB for the header cache"
+  with-lmdb:path            => "Location of LMDB"
   qdbm=0                    => "Use QDBM for the header cache"
   with-qdbm:path            => "Location of QDBM"
   rocksdb=0                 => "Use RocksDB for the header cache"
@@ -134,7 +135,6 @@ set deprecated_options  {
   with-slang:
   with-ui:=
   with-gpgme:
-  with-lmdb:
   with-lz4:
   with-zstd:
 }
@@ -888,8 +888,12 @@ if {[get-define want-gdbm]} {
 ###############################################################################
 # Header cache - LMDB
 if {[get-define want-lmdb]} {
-  pkgconf true lmdb
-  define-feature lmdb
+  if {[pkgconf false lmdb]} {
+    define-feature lmdb
+  } elseif {![check-inc-and-lib lmdb [opt-val with-lmdb $prefix] \
+                                lmdb.h mdb_env_create lmdb]} {
+    user-error "Unable to find LMDB"
+  }
   define-append HCACHE_BACKENDS "lmdb"
   define USE_HCACHE
 }


### PR DESCRIPTION
Debian [1], FreeBSD [2], and probably other OSs provide pkg-config files for lmdb. However, brew [3] and upstream [4] don't and don't want to.

Let's fallback to manual detection of LMDB, in case the pkg-config file is not there.

[1] https://salsa.debian.org/debian/lmdb/-/blob/master/debian/rules#L27-36
[2] https://cgit.freebsd.org/ports/plain/databases/lmdb/files/lmdb.pc.in
[3] https://github.com/Homebrew/homebrew-core/pull/115376#issuecomment-1310483540
[4] https://github.com/Homebrew/homebrew-core/pull/115376#issuecomment-1310462073
