### PR TITLE
Do not return a single "." for a domain name

### DIFF
--- a/conn/getdomain.c
+++ b/conn/getdomain.c
@@ -139,14 +139,14 @@ int getdnsdomainname(struct Buffer *result)
   lookup_result = mutt_getaddrinfo(node, &hints);
 #endif
 
-  char *hostname = NULL;
   if (lookup_result && lookup_result->ai_canonname)
-    hostname = strchr(lookup_result->ai_canonname, '.');
-
-  if (hostname)
   {
-    mutt_buffer_strcpy(result, ++hostname);
-    rc = 0;
+    const char *hostname = strchr(lookup_result->ai_canonname, '.');
+    if (hostname && hostname[1] != '\0')
+    {
+      mutt_buffer_strcpy(result, ++hostname);
+      rc = 0;
+    }
   }
 
   if (lookup_result)


### PR DESCRIPTION
When we compute the hostname, we get the canonical name from addrinfo, take the part after the first ".", and use that as a domain name. It might happen (see #3568) that addrinfo.ai_canonname ends in a ".". In this case, we don't want to end up constructing "<hostname>.", so let's skip an empty domain name altogether.

Fixes #3568
