### PR TITLE
Don't wait after timeout from getaddrinfo_a

### DIFF
--- a/conn/getdomain.c
+++ b/conn/getdomain.c
@@ -56,16 +56,18 @@ static struct addrinfo *mutt_getaddrinfo_a(const char *node, const struct addrin
    * If it takes longer, the system is mis-configured and the network is not
    * working properly, so...  */
   struct timespec timeout = { 0, 100000000 };
-  struct gaicb *reqs[1];
-  reqs[0] = mutt_mem_calloc(1, sizeof(*reqs[0]));
-  reqs[0]->ar_name = node;
-  reqs[0]->ar_request = hints;
+  struct gaicb req = { 0 };
+  req.ar_name = node;
+  req.ar_request = hints;
+  struct gaicb *reqs[1] = { &req };
   if (getaddrinfo_a(GAI_NOWAIT, reqs, 1, NULL) == 0)
   {
     gai_suspend((const struct gaicb *const *) reqs, 1, &timeout);
     const int status = gai_error(reqs[0]);
     if (status == 0)
+    {
       result = reqs[0]->ar_result;
+    }
     else if (status == EAI_INPROGRESS)
     {
       mutt_debug(LL_DEBUG1, "timeout\n");
@@ -77,9 +79,10 @@ static struct addrinfo *mutt_getaddrinfo_a(const char *node, const struct addrin
       }
     }
     else
+    {
       mutt_debug(LL_DEBUG1, "fail: (%d) %s\n", status, gai_strerror(status));
+    }
   }
-  FREE(&reqs[0]);
   return result;
 }
 

--- a/conn/getdomain.c
+++ b/conn/getdomain.c
@@ -74,8 +74,9 @@ static struct addrinfo *mutt_getaddrinfo_a(const char *node, const struct addrin
       /* request is not finished, cancel it to free it safely */
       if (gai_cancel(reqs[0]) == EAI_NOTCANCELED)
       {
-        while (gai_suspend((const struct gaicb *const *) reqs, 1, NULL) != 0)
-          continue;
+        // try once more for half-a-second, then bail out
+        timeout.tv_nsec = 50000000;
+        gai_suspend((const struct gaicb *const *) reqs, 1, &timeout);
       }
     }
     else


### PR DESCRIPTION
This is an attempt to speedup recovery from getaddrinfo_a timeouts. I am not familiar with this family of APIs and I don't have a linux box to test this on, so I have no idea if this is correct.