### PR TITLE
Fix dangling pointer in `pop_ac_add()`

### DIFF
--- a/pop/pop.c
+++ b/pop/pop.c
@@ -715,9 +715,6 @@ static bool pop_ac_add(struct Account *a, struct Mailbox *m)
 
   struct ConnAccount cac = { { 0 } };
   struct PopAccountData *adata = pop_adata_new();
-  a->adata = adata;
-  a->adata_free = pop_adata_free;
-
   if (pop_parse_path(mailbox_path(m), &cac))
   {
     mutt_error(_("%s is an invalid POP path"), mailbox_path(m));
@@ -730,6 +727,8 @@ static bool pop_ac_add(struct Account *a, struct Mailbox *m)
     pop_adata_free((void **) &adata);
     return false;
   }
+  a->adata = adata;
+  a->adata_free = pop_adata_free;
 
   return true;
 }

--- a/pop/pop.c
+++ b/pop/pop.c
@@ -714,13 +714,13 @@ static bool pop_ac_add(struct Account *a, struct Mailbox *m)
     return true;
 
   struct ConnAccount cac = { { 0 } };
-  struct PopAccountData *adata = pop_adata_new();
   if (pop_parse_path(mailbox_path(m), &cac))
   {
     mutt_error(_("%s is an invalid POP path"), mailbox_path(m));
     return false;
   }
 
+  struct PopAccountData *adata = pop_adata_new();
   adata->conn = mutt_conn_new(&cac);
   if (!adata->conn)
   {


### PR DESCRIPTION
	The member `a->adata` used to be a dangling pointer when
	`mutt_conn_new()` returned a null pointer. This would cause either a
	double free or a segmentation violation further in the execution.

* **What does this PR do?**

It prevents `pop_ac_add()` from leaving a dangling pointer in `a->data`.

This dangling pointer causes at least two crashes:

* A double free at this stacktrace (truncated at `free()`):

```
#8  0x000055555565a4ec in mutt_mem_free (ptr=ptr@entry=0x5555558bb1f0) at mutt/memory.c:75
#9  0x00005555555b8928 in pop_adata_free (ptr=0x5555558bb1f0) at pop/adata.c:47
#10 0x000055555563f2ad in account_free (ptr=ptr@entry=0x7fffffffe060) at core/account.c:155
#11 0x000055555559bd43 in mx_mbox_ac_link (m=m@entry=0x5555558a8e10) at mx.c:286
#12 0x000055555559c03f in mx_mbox_open (m=0x5555558a8e10, flags=<optimized out>) at mx.c:318
#13 0x000055555559192a in main (argc=<optimized out>, argv=<optimized out>, envp=<optimized out>) at main.c:1356
```

* A segmentation violation at this stacktrace (here GDB was run on my system version hence the different source paths):

```
#0  0x00005555555d0a26 in pop_mbox_check (m=0x555555843290) at pop/pop.c:824
#1  0x00005555555a6511 in mx_mbox_check (m=0x555555843290) at /usr/src/debug/neomutt/neomutt-20220429/mx.c:1131
#2  0x00005555555b6281 in mutt_index_menu (dlg=0x55555583b170, m_init=<optimized out>) at index/dlg_index.c:1104
#3  0x000055555557c147 in main (argc=<optimized out>, argv=<optimized out>, envp=<optimized out>) at /usr/src/debug/neomutt/neomutt-20220429/main.c:1374
```

Moving the side effects that `pop_ac_add()` has on `*a` down fixes these issues.

* **What are the relevant issue numbers?**

None. I noticed and addressed the issue myself.