### PR TITLE
Fix deletion of address group

### DIFF
--- a/address/group.c
+++ b/address/group.c
@@ -134,10 +134,6 @@ static void group_remove(struct Group *g)
   if (!g)
     return;
   mutt_hash_delete(Groups, g->name, g);
-  mutt_addrlist_clear(&g->al);
-  mutt_regexlist_free(&g->rs);
-  FREE(&g->name);
-  FREE(&g);
 }
 
 /**


### PR DESCRIPTION
The cleanup is already taken place by the group_hash_free destructor.

Fixes #3588