### PR TITLE
Allow mutt to handle mails dating Wed 31 Dec 22:13:21 1969

### DIFF
--- a/autocrypt/autocrypt.c
+++ b/autocrypt/autocrypt.c
@@ -294,7 +294,7 @@ int mutt_autocrypt_process_autocrypt_header(struct Email *e, struct Envelope *en
 
   /* Ignore emails that appear to be more than a week in the future,
    * since they can block all future updates during that time. */
-  if (e->date_sent > (mutt_date_epoch() + (7 * 24 * 60 * 60)))
+  if (e->date_sent > (mutt_date_now() + (7 * 24 * 60 * 60)))
     return 0;
 
   for (struct AutocryptHeader *ac_hdr = env->autocrypt; ac_hdr; ac_hdr = ac_hdr->next)
@@ -437,7 +437,7 @@ int mutt_autocrypt_process_gossip_header(struct Email *e, struct Envelope *prot_
 
   /* Ignore emails that appear to be more than a week in the future,
    * since they can block all future updates during that time. */
-  if (e->date_sent > (mutt_date_epoch() + (7 * 24 * 60 * 60)))
+  if (e->date_sent > (mutt_date_now() + (7 * 24 * 60 * 60)))
     return 0;
 
   struct Buffer *keyid = mutt_buffer_pool_get();

--- a/browser/browser.c
+++ b/browser/browser.c
@@ -240,7 +240,7 @@ static const char *folder_format_str(char *buf, size_t buflen, size_t col, int c
         else
         {
           static const time_t one_year = 31536000;
-          t_fmt = ((mutt_date_epoch() - folder->ff->mtime) < one_year) ? "%b %d %H:%M" : "%b %d  %Y";
+          t_fmt = ((mutt_date_now() - folder->ff->mtime) < one_year) ? "%b %d %H:%M" : "%b %d  %Y";
         }
 
         if (!do_locales)

--- a/conn/gnutls.c
+++ b/conn/gnutls.c
@@ -338,9 +338,9 @@ static int tls_check_preauth(const gnutls_datum_t *certdata,
   const bool c_ssl_verify_dates = cs_subset_bool(NeoMutt->sub, "ssl_verify_dates");
   if (c_ssl_verify_dates != MUTT_NO)
   {
-    if (gnutls_x509_crt_get_expiration_time(cert) < mutt_date_epoch())
+    if (gnutls_x509_crt_get_expiration_time(cert) < mutt_date_now())
       *certerr |= CERTERR_EXPIRED;
-    if (gnutls_x509_crt_get_activation_time(cert) > mutt_date_epoch())
+    if (gnutls_x509_crt_get_activation_time(cert) > mutt_date_now())
       *certerr |= CERTERR_NOTYETVALID;
   }
 

--- a/conn/raw.c
+++ b/conn/raw.c
@@ -339,9 +339,9 @@ int raw_socket_poll(struct Connection *conn, time_t wait_secs)
     FD_ZERO(&rfds);
     FD_SET(conn->fd, &rfds);
 
-    uint64_t pre_t = mutt_date_epoch_ms();
+    uint64_t pre_t = mutt_date_now_ms();
     const int rc = select(conn->fd + 1, &rfds, NULL, NULL, &tv);
-    uint64_t post_t = mutt_date_epoch_ms();
+    uint64_t post_t = mutt_date_now_ms();
 
     if ((rc > 0) || ((rc < 0) && (errno != EINTR)))
       return rc;

--- a/email/parse.c
+++ b/email/parse.c
@@ -760,7 +760,7 @@ int mutt_rfc822_parse_line(struct Envelope *env, struct Email *e, const char *na
 
     case 'e':
       if (mutt_istr_equal("xpires", name + 1) && e &&
-          (mutt_date_parse_date(body, NULL) < mutt_date_epoch()))
+          (mutt_date_parse_date(body, NULL) < mutt_date_now()))
       {
         e->expired = true;
       }

--- a/handler.c
+++ b/handler.c
@@ -873,7 +873,7 @@ static int external_body_handler(struct Body *b, struct State *s)
                     chflags, NULL, 0);
     }
   }
-  else if (expiration && (expire < mutt_date_epoch()))
+  else if (expiration && (expire < mutt_date_now()))
   {
     if (s->flags & MUTT_DISPLAY)
     {

--- a/hcache/hcache.c
+++ b/hcache/hcache.c
@@ -90,7 +90,7 @@ static void *dump(struct HeaderCache *hc, const struct Email *e, int *off, uint3
   *off = 0;
   unsigned char *d = mutt_mem_malloc(4096);
 
-  d = serial_dump_uint32_t((uidvalidity != 0) ? uidvalidity : mutt_date_epoch(), d, off);
+  d = serial_dump_uint32_t((uidvalidity != 0) ? uidvalidity : mutt_date_now(), d, off);
   d = serial_dump_int(hc->crc, d, off);
 
   assert((size_t) *off == header_size());

--- a/hdrline.c
+++ b/hdrline.c
@@ -728,7 +728,7 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
           tm = mutt_date_localtime(e->received);
         else if (op == '<')
         {
-          tm = mutt_date_localtime(MUTT_DATE_NOW);
+          tm = mutt_date_localtime(mutt_date_now());
         }
         else
         {

--- a/hdrline.c
+++ b/hdrline.c
@@ -579,7 +579,7 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
 
         if (optional && ((op == '[') || (op == '(')))
         {
-          now = mutt_date_epoch();
+          now = mutt_date_now();
           struct tm tm = mutt_date_localtime(now);
           now -= (op == '(') ? e->received : e->date_sent;
 

--- a/imap/command.c
+++ b/imap/command.c
@@ -1127,7 +1127,7 @@ int imap_cmd_step(struct ImapAccountData *adata)
     mutt_debug(LL_DEBUG3, "shrank buffer to %lu bytes\n", adata->blen);
   }
 
-  adata->lastread = mutt_date_epoch();
+  adata->lastread = mutt_date_now();
 
   /* handle untagged messages. The caller still gets its shot afterwards. */
   if ((mutt_str_startswith(adata->buf, "* ") ||

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -1119,7 +1119,7 @@ enum MxStatus imap_check_mailbox(struct Mailbox *m, bool force)
   const bool c_imap_idle = cs_subset_bool(NeoMutt->sub, "imap_idle");
   const short c_imap_keepalive = cs_subset_number(NeoMutt->sub, "imap_keepalive");
   if (!force && c_imap_idle && (adata->capabilities & IMAP_CAP_IDLE) &&
-      ((adata->state != IMAP_IDLE) || (mutt_date_epoch() >= adata->lastread + c_imap_keepalive)))
+      ((adata->state != IMAP_IDLE) || (mutt_date_now() >= adata->lastread + c_imap_keepalive)))
   {
     if (imap_cmd_idle(adata) < 0)
       return MX_STATUS_ERROR;
@@ -1142,8 +1142,7 @@ enum MxStatus imap_check_mailbox(struct Mailbox *m, bool force)
   }
 
   const short c_timeout = cs_subset_number(NeoMutt->sub, "timeout");
-  if ((force || ((adata->state != IMAP_IDLE) &&
-                 (mutt_date_epoch() >= adata->lastread + c_timeout))) &&
+  if ((force || ((adata->state != IMAP_IDLE) && (mutt_date_now() >= adata->lastread + c_timeout))) &&
       (imap_exec(adata, "NOOP", IMAP_CMD_POLL) != IMAP_EXEC_SUCCESS))
   {
     return MX_STATUS_ERROR;

--- a/imap/util.c
+++ b/imap/util.c
@@ -944,7 +944,7 @@ void imap_unmunge_mbox_name(bool unicode, char *s)
  */
 void imap_keepalive(void)
 {
-  time_t now = mutt_date_epoch();
+  time_t now = mutt_date_now();
   struct Account *np = NULL;
   TAILQ_FOREACH(np, &NeoMutt->accounts, entries)
   {

--- a/maildir/maildir.c
+++ b/maildir/maildir.c
@@ -263,7 +263,7 @@ int maildir_commit_message(struct Mailbox *m, struct Message *msg, struct Email 
   while (true)
   {
     mutt_buffer_printf(path, "%s/%lld.R%" PRIu64 ".%s%s", subdir,
-                       (long long) mutt_date_epoch(), mutt_rand64(),
+                       (long long) mutt_date_now(), mutt_rand64(),
                        NONULL(ShortHostname), suffix);
     mutt_buffer_printf(full, "%s/%s", mailbox_path(m), mutt_buffer_string(path));
 
@@ -1509,7 +1509,7 @@ bool maildir_msg_open_new(struct Mailbox *m, struct Message *msg, const struct E
   while (true)
   {
     snprintf(path, sizeof(path), "%s/tmp/%s.%lld.R%" PRIu64 ".%s%s",
-             mailbox_path(m), subdir, (long long) mutt_date_epoch(),
+             mailbox_path(m), subdir, (long long) mutt_date_now(),
              mutt_rand64(), NONULL(ShortHostname), suffix);
 
     mutt_debug(LL_DEBUG2, "Trying %s\n", path);

--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -1418,8 +1418,8 @@ static enum MxStatus mbox_mbox_sync(struct Mailbox *m)
     struct Buffer *savefile = mutt_buffer_pool_get();
 
     const char *const c_tmp_dir = cs_subset_path(NeoMutt->sub, "tmp_dir");
-    mutt_buffer_printf(savefile, "%s/neomutt.%s-%s-%u", NONULL(c_tmp_dir), NONULL(Username),
-                       NONULL(ShortHostname), (unsigned int) getpid());
+    mutt_buffer_printf(savefile, "%s/neomutt.%s-%s-%u", NONULL(c_tmp_dir),
+                       NONULL(Username), NONULL(ShortHostname), (unsigned int) getpid());
     rename(mutt_buffer_string(tempfile), mutt_buffer_string(savefile));
     mutt_sig_unblock();
     mx_fastclose_mailbox(m, false);

--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -1827,7 +1827,7 @@ static enum MxStatus mbox_mbox_check_stats(struct Mailbox *m, uint8_t flags)
       mx_mbox_open(m, MUTT_QUIET | MUTT_NOSORT | MUTT_PEEK);
       mx_mbox_close(m);
       m->peekonly = old_peek;
-      adata->stats_last_checked.tv_sec = mutt_date_epoch();
+      adata->stats_last_checked.tv_sec = mutt_date_now();
     }
   }
 

--- a/mutt/date.c
+++ b/mutt/date.c
@@ -659,7 +659,15 @@ struct tm mutt_date_localtime(time_t t)
   if (t == MUTT_DATE_NOW)
     t = mutt_date_epoch();
 
-  localtime_r(&t, &tm);
+  struct tm *ret = localtime_r(&t, &tm);
+  if (!ret)
+  {
+    mutt_debug(LL_DEBUG1, "Could not convert time_t via localtime_r() to struct tm: time_t = %jd\n",
+               (intmax_t) t);
+    struct tm default_tm = { 0 }; // 1970-01-01 00:00:00
+    mktime(&default_tm); // update derived fields making tm into a valid tm.
+    tm = default_tm;
+  }
   return tm;
 }
 
@@ -677,7 +685,15 @@ struct tm mutt_date_gmtime(time_t t)
   if (t == MUTT_DATE_NOW)
     t = mutt_date_epoch();
 
-  gmtime_r(&t, &tm);
+  struct tm *ret = gmtime_r(&t, &tm);
+  if (!ret)
+  {
+    mutt_debug(LL_DEBUG1, "Could not convert time_t via gmtime_r() to struct tm: time_t = %jd\n",
+               (intmax_t) t);
+    struct tm default_tm = { 0 }; // 1970-01-01 00:00:00
+    mktime(&default_tm); // update derived fields making tm into a valid tm.
+    tm = default_tm;
+  }
   return tm;
 }
 

--- a/mutt/date.c
+++ b/mutt/date.c
@@ -649,15 +649,10 @@ time_t mutt_date_add_timeout(time_t now, time_t timeout)
  * mutt_date_localtime - Converts calendar time to a broken-down time structure expressed in user timezone
  * @param  t  Time
  * @retval obj Broken-down time representation
- *
- * Uses current time if t is #MUTT_DATE_NOW
  */
 struct tm mutt_date_localtime(time_t t)
 {
   struct tm tm = { 0 };
-
-  if (t == MUTT_DATE_NOW)
-    t = mutt_date_now();
 
   struct tm *ret = localtime_r(&t, &tm);
   if (!ret)
@@ -675,15 +670,10 @@ struct tm mutt_date_localtime(time_t t)
  * mutt_date_gmtime - Converts calendar time to a broken-down time structure expressed in UTC timezone
  * @param  t  Time
  * @retval obj Broken-down time representation
- *
- * Uses current time if t is #MUTT_DATE_NOW
  */
 struct tm mutt_date_gmtime(time_t t)
 {
   struct tm tm = { 0 };
-
-  if (t == MUTT_DATE_NOW)
-    t = mutt_date_now();
 
   struct tm *ret = gmtime_r(&t, &tm);
   if (!ret)

--- a/mutt/date.c
+++ b/mutt/date.c
@@ -210,7 +210,7 @@ int mutt_date_local_tz(time_t t)
     return 0;
 
   if (t == 0)
-    t = mutt_date_epoch();
+    t = mutt_date_now();
 
   struct tm tm = mutt_date_gmtime(t);
   return compute_tz(t, &tm);
@@ -385,7 +385,7 @@ void mutt_date_make_date(struct Buffer *buf, bool local)
   struct tm tm;
   int tz = 0;
 
-  time_t t = mutt_date_epoch();
+  time_t t = mutt_date_now();
   if (local)
   {
     tm = mutt_date_localtime(t);
@@ -422,19 +422,19 @@ int mutt_date_check_month(const char *s)
 }
 
 /**
- * mutt_date_epoch - Return the number of seconds since the Unix epoch
+ * mutt_date_now - Return the number of seconds since the Unix epoch
  * @retval num Number of seconds since the Unix epoch, or 0 on failure
  */
-time_t mutt_date_epoch(void)
+time_t mutt_date_now(void)
 {
-  return mutt_date_epoch_ms() / 1000;
+  return mutt_date_now_ms() / 1000;
 }
 
 /**
- * mutt_date_epoch_ms - Return the number of milliseconds since the Unix epoch
+ * mutt_date_now_ms - Return the number of milliseconds since the Unix epoch
  * @retval ms The number of ms since the Unix epoch, or 0 on failure
  */
-uint64_t mutt_date_epoch_ms(void)
+uint64_t mutt_date_now_ms(void)
 {
   struct timeval tv = { 0, 0 };
   gettimeofday(&tv, NULL);
@@ -657,7 +657,7 @@ struct tm mutt_date_localtime(time_t t)
   struct tm tm = { 0 };
 
   if (t == MUTT_DATE_NOW)
-    t = mutt_date_epoch();
+    t = mutt_date_now();
 
   struct tm *ret = localtime_r(&t, &tm);
   if (!ret)
@@ -683,7 +683,7 @@ struct tm mutt_date_gmtime(time_t t)
   struct tm tm = { 0 };
 
   if (t == MUTT_DATE_NOW)
-    t = mutt_date_epoch();
+    t = mutt_date_now();
 
   struct tm *ret = gmtime_r(&t, &tm);
   if (!ret)

--- a/mutt/date.h
+++ b/mutt/date.h
@@ -51,8 +51,8 @@ struct Tz
 
 time_t    mutt_date_add_timeout(time_t now, time_t timeout);
 int       mutt_date_check_month(const char *s);
-time_t    mutt_date_epoch(void);
-uint64_t  mutt_date_epoch_ms(void);
+time_t    mutt_date_now(void);
+uint64_t  mutt_date_now_ms(void);
 struct tm mutt_date_gmtime(time_t t);
 size_t    mutt_date_localtime_format(char *buf, size_t buflen, const char *format, time_t t);
 struct tm mutt_date_localtime(time_t t);

--- a/mutt/date.h
+++ b/mutt/date.h
@@ -36,8 +36,6 @@ struct Buffer;
   (1970 + (((((TIME_T_MAX - 59) / 60) - 59) / 60) - 23) / 24 / 366)
 #define TM_YEAR_MIN (1970 - (TM_YEAR_MAX - 1970) - 1)
 
-#define MUTT_DATE_NOW -9999 ///< Constant representing the 'current time', see: mutt_date_gmtime(), mutt_date_localtime()
-
 /**
  * struct Tz - List of recognised Timezones
  */

--- a/mutt/file.c
+++ b/mutt/file.c
@@ -1049,7 +1049,7 @@ time_t mutt_file_decrease_mtime(const char *fp, struct stat *st)
   }
 
   mtime = st->st_mtime;
-  if (mtime == mutt_date_epoch())
+  if (mtime == mutt_date_now())
   {
     mtime -= 1;
     utim.actime = mtime;

--- a/mutt/logging.c
+++ b/mutt/logging.c
@@ -80,7 +80,7 @@ static const char *timestamp(time_t stamp)
   static time_t last = 0;
 
   if (stamp == 0)
-    stamp = mutt_date_epoch();
+    stamp = mutt_date_now();
 
   if (stamp != last)
   {
@@ -415,7 +415,7 @@ int log_disp_queue(time_t stamp, const char *file, int line,
   }
 
   struct LogLine *ll = mutt_mem_calloc(1, sizeof(*ll));
-  ll->time = (stamp != 0) ? stamp : mutt_date_epoch();
+  ll->time = (stamp != 0) ? stamp : mutt_date_now();
   ll->file = file;
   ll->line = line;
   ll->function = function;

--- a/mutt/state.c
+++ b/mutt/state.c
@@ -59,7 +59,7 @@ const char *state_protected_header_marker(void)
   static char marker[256] = { 0 };
   if (!marker[0])
   {
-    snprintf(marker, sizeof(marker), "\033]8;%lld\a", (long long) mutt_date_epoch());
+    snprintf(marker, sizeof(marker), "\033]8;%lld\a", (long long) mutt_date_now());
   }
   return marker;
 }

--- a/mutt_logging.c
+++ b/mutt_logging.c
@@ -59,7 +59,7 @@ const int NumOfLogs = 5;  ///< How many log files to rotate
 static void error_pause(void)
 {
   const short c_sleep_time = cs_subset_number(NeoMutt->sub, "sleep_time");
-  const uint64_t elapsed = mutt_date_epoch_ms() - LastError;
+  const uint64_t elapsed = mutt_date_now_ms() - LastError;
   const uint64_t sleep = c_sleep_time * S_TO_MS;
   if ((LastError == 0) || (elapsed >= sleep))
     return;
@@ -156,7 +156,7 @@ int log_disp_curses(time_t stamp, const char *file, int line,
   if ((level <= LL_ERROR) && !dupe)
   {
     OptMsgErr = true;
-    LastError = mutt_date_epoch_ms();
+    LastError = mutt_date_now_ms();
   }
   else
   {

--- a/mutt_mailbox.c
+++ b/mutt_mailbox.c
@@ -173,7 +173,7 @@ int mutt_mailbox_check(struct Mailbox *m_cur, CheckStatsFlags flags)
   const bool c_mail_check_stats = cs_subset_bool(NeoMutt->sub, "mail_check_stats");
   const short c_mail_check_stats_interval = cs_subset_number(NeoMutt->sub, "mail_check_stats_interval");
 
-  t = mutt_date_epoch();
+  t = mutt_date_now();
   if ((flags == MUTT_MAILBOX_CHECK_NO_FLAGS) && (t - MailboxTime < c_mail_check))
     return MailboxCount;
 
@@ -318,7 +318,7 @@ void mutt_mailbox_set_notified(struct Mailbox *m)
 #ifdef HAVE_CLOCK_GETTIME
   clock_gettime(CLOCK_REALTIME, &m->last_visited);
 #else
-  m->last_visited.tv_sec = mutt_date_epoch();
+  m->last_visited.tv_sec = mutt_date_now();
   m->last_visited.tv_nsec = 0;
 #endif
 }
@@ -449,7 +449,7 @@ void mutt_mailbox_cleanup(const char *path, struct stat *st)
       utimensat(AT_FDCWD, buf, ts, 0);
 #else
       ut.actime = st->st_atime;
-      ut.modtime = mutt_date_epoch();
+      ut.modtime = mutt_date_now();
       utime(path, &ut);
 #endif
     }

--- a/muttlib.c
+++ b/muttlib.c
@@ -496,9 +496,10 @@ void mutt_mktemp_full(char *buf, size_t buflen, const char *prefix,
                       const char *suffix, const char *src, int line)
 {
   const char *const c_tmp_dir = cs_subset_path(NeoMutt->sub, "tmp_dir");
-  size_t n = snprintf(buf, buflen, "%s/%s-%s-%d-%d-%" PRIu64 "%s%s", NONULL(c_tmp_dir),
-                      NONULL(prefix), NONULL(ShortHostname), (int) getuid(),
-                      (int) getpid(), mutt_rand64(), suffix ? "." : "", NONULL(suffix));
+  size_t n = snprintf(buf, buflen, "%s/%s-%s-%d-%d-%" PRIu64 "%s%s",
+                      NONULL(c_tmp_dir), NONULL(prefix), NONULL(ShortHostname),
+                      (int) getuid(), (int) getpid(), mutt_rand64(),
+                      suffix ? "." : "", NONULL(suffix));
   if (n >= buflen)
   {
     mutt_debug(LL_DEBUG1, "%s:%d: ERROR: insufficient buffer space to hold temporary filename! buflen=%zu but need %zu\n",

--- a/mx.c
+++ b/mx.c
@@ -1081,7 +1081,7 @@ struct Message *mx_msg_open_new(struct Mailbox *m, const struct Email *e, MsgOpe
   }
 
   if (msg->received == 0)
-    msg->received = mutt_date_epoch();
+    msg->received = mutt_date_now();
 
   if (m->mx_ops->msg_open_new(m, msg, e))
   {

--- a/ncrypt/crypt.c
+++ b/ncrypt/crypt.c
@@ -77,7 +77,7 @@ void crypt_current_time(struct State *s, const char *app_name)
   const bool c_crypt_timestamp = cs_subset_bool(NeoMutt->sub, "crypt_timestamp");
   if (c_crypt_timestamp)
   {
-    mutt_date_localtime_format(p, sizeof(p), _(" (current time: %c)"), MUTT_DATE_NOW);
+    mutt_date_localtime_format(p, sizeof(p), _(" (current time: %c)"), mutt_date_now());
   }
   else
     *p = '\0';

--- a/ncrypt/pgp.c
+++ b/ncrypt/pgp.c
@@ -89,7 +89,7 @@ bool pgp_class_valid_passphrase(void)
     return true; /* handled by gpg-agent */
   }
 
-  if (mutt_date_epoch() < PgpExptime)
+  if (mutt_date_now() < PgpExptime)
   {
     /* Use cached copy.  */
     return true;
@@ -107,7 +107,7 @@ bool pgp_class_valid_passphrase(void)
   if (rc == 0)
   {
     const long c_pgp_timeout = cs_subset_long(NeoMutt->sub, "pgp_timeout");
-    PgpExptime = mutt_date_add_timeout(mutt_date_epoch(), c_pgp_timeout);
+    PgpExptime = mutt_date_add_timeout(mutt_date_now(), c_pgp_timeout);
     return true;
   }
   else

--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -167,7 +167,7 @@ void smime_class_void_passphrase(void)
  */
 bool smime_class_valid_passphrase(void)
 {
-  const time_t now = mutt_date_epoch();
+  const time_t now = mutt_date_now();
   if (now < SmimeExpTime)
   {
     /* Use cached copy.  */

--- a/nntp/nntp.c
+++ b/nntp/nntp.c
@@ -1437,7 +1437,7 @@ static enum MxStatus check_mailbox(struct Mailbox *m)
 
   struct NntpMboxData *mdata = m->mdata;
   struct NntpAccountData *adata = mdata->adata;
-  time_t now = mutt_date_epoch();
+  time_t now = mutt_date_now();
   enum MxStatus rc = MX_STATUS_OK;
   void *hc = NULL;
 
@@ -1666,7 +1666,7 @@ static int nntp_date(struct NntpAccountData *adata, time_t *now)
       }
     }
   }
-  *now = mutt_date_epoch();
+  *now = mutt_date_now();
   return 0;
 }
 
@@ -2416,7 +2416,7 @@ static enum MxOpenReturns nntp_mbox_open(struct Mailbox *m)
     }
   }
 
-  adata->check_time = mutt_date_epoch();
+  adata->check_time = mutt_date_now();
   m->mdata = mdata;
   // Every known newsgroup has an mdata which is stored in adata->groups_list.
   // Currently we don't let the Mailbox free the mdata.

--- a/notmuch/notmuch.c
+++ b/notmuch/notmuch.c
@@ -1523,7 +1523,7 @@ int nm_read_entire_thread(struct Mailbox *m, struct Email *e)
   notmuch_query_set_sort(q, NOTMUCH_SORT_NEWEST_FIRST);
 
   read_threads_query(m, q, true, 0);
-  m->mtime.tv_sec = mutt_date_epoch();
+  m->mtime.tv_sec = mutt_date_now();
   m->mtime.tv_nsec = 0;
   rc = 0;
 
@@ -1751,7 +1751,7 @@ int nm_update_filename(struct Mailbox *m, const char *old_file,
   int rc = rename_filename(m, old_file, new_file, e);
 
   nm_db_release(m);
-  m->mtime.tv_sec = mutt_date_epoch();
+  m->mtime.tv_sec = mutt_date_now();
   m->mtime.tv_nsec = 0;
   return rc;
 }
@@ -2050,7 +2050,7 @@ static enum MxOpenReturns nm_mbox_open(struct Mailbox *m)
 
   nm_db_release(m);
 
-  m->mtime.tv_sec = mutt_date_epoch();
+  m->mtime.tv_sec = mutt_date_now();
   m->mtime.tv_nsec = 0;
 
   mdata->oldmsgcount = 0;
@@ -2182,7 +2182,7 @@ done:
 
   nm_db_release(m);
 
-  m->mtime.tv_sec = mutt_date_epoch();
+  m->mtime.tv_sec = mutt_date_now();
   m->mtime.tv_nsec = 0;
 
   mutt_debug(LL_DEBUG1, "nm: ... check done [count=%d, new_flags=%d, occult=%d]\n",
@@ -2310,7 +2310,7 @@ static enum MxStatus nm_mbox_sync(struct Mailbox *m)
 
   if (changed)
   {
-    m->mtime.tv_sec = mutt_date_epoch();
+    m->mtime.tv_sec = mutt_date_now();
     m->mtime.tv_nsec = 0;
   }
 
@@ -2420,7 +2420,7 @@ done:
   nm_db_release(m);
   if (e->changed)
   {
-    m->mtime.tv_sec = mutt_date_epoch();
+    m->mtime.tv_sec = mutt_date_now();
     m->mtime.tv_nsec = 0;
   }
   mutt_debug(LL_DEBUG1, "nm: tags modify done [rc=%d]\n", rc);

--- a/pager/dlg_pager.c
+++ b/pager/dlg_pager.c
@@ -191,7 +191,7 @@ static const struct Mapping *pager_resolve_help_mapping(enum PagerMode mode, enu
  */
 static bool check_read_delay(uint64_t *timestamp)
 {
-  if ((*timestamp != 0) && (mutt_date_epoch_ms() > *timestamp))
+  if ((*timestamp != 0) && (mutt_date_now_ms() > *timestamp))
   {
     *timestamp = 0;
     return true;
@@ -318,7 +318,7 @@ int mutt_pager(struct PagerView *pview)
     }
     else
     {
-      priv->delay_read_timestamp = mutt_date_epoch_ms() + (1000 * c_pager_read_delay);
+      priv->delay_read_timestamp = mutt_date_now_ms() + (1000 * c_pager_read_delay);
     }
   }
   //---------- setup help menu ------------------------------------------------

--- a/pattern/compile.c
+++ b/pattern/compile.c
@@ -290,7 +290,7 @@ static const char *get_offset(struct tm *tm, const char *s, int sign)
 static const char *get_date(const char *s, struct tm *t, struct Buffer *err)
 {
   char *p = NULL;
-  struct tm tm = mutt_date_localtime(MUTT_DATE_NOW);
+  struct tm tm = mutt_date_localtime(mutt_date_now());
   bool iso8601 = true;
 
   for (int v = 0; v < 8; v++)
@@ -527,12 +527,12 @@ bool eval_date_minmax(struct Pattern *pat, const char *s, struct Buffer *err)
 
     if (s[0] == '<')
     {
-      min = mutt_date_localtime(MUTT_DATE_NOW);
+      min = mutt_date_localtime(mutt_date_now());
       tm = &min;
     }
     else
     {
-      max = mutt_date_localtime(MUTT_DATE_NOW);
+      max = mutt_date_localtime(mutt_date_now());
       tm = &max;
 
       if (s[0] == '=')
@@ -594,7 +594,7 @@ bool eval_date_minmax(struct Pattern *pat, const char *s, struct Buffer *err)
       if (!have_min)
       { /* save base minimum and set current date, e.g. for "-3d+1d" */
         memcpy(&base_min, &min, sizeof(base_min));
-        min = mutt_date_localtime(MUTT_DATE_NOW);
+        min = mutt_date_localtime(mutt_date_now());
         min.tm_hour = 0;
         min.tm_sec = 0;
         min.tm_min = 0;

--- a/pop/pop.c
+++ b/pop/pop.c
@@ -330,7 +330,7 @@ static int pop_fetch_headers(struct Mailbox *m)
   struct HeaderCache *hc = pop_hcache_open(adata, mailbox_path(m));
 #endif
 
-  adata->check_time = mutt_date_epoch();
+  adata->check_time = mutt_date_now();
   adata->clear_cache = false;
 
   for (int i = 0; i < m->msg_count; i++)
@@ -823,7 +823,7 @@ static enum MxStatus pop_mbox_check(struct Mailbox *m)
   struct PopAccountData *adata = pop_adata_get(m);
 
   const short c_pop_check_interval = cs_subset_number(NeoMutt->sub, "pop_check_interval");
-  if ((adata->check_time + c_pop_check_interval) > mutt_date_epoch())
+  if ((adata->check_time + c_pop_check_interval) > mutt_date_now())
     return MX_STATUS_OK;
 
   pop_logout(m);

--- a/progress/window.c
+++ b/progress/window.c
@@ -248,7 +248,7 @@ bool progress_window_update(struct MuttWindow *win, size_t pos, int percent)
       return false;
   }
 
-  const uint64_t now = mutt_date_epoch_ms();
+  const uint64_t now = mutt_date_now_ms();
   if (!time_needs_update(wdata, now))
     return false;
 

--- a/send/send.c
+++ b/send/send.c
@@ -1865,7 +1865,7 @@ full_fcc:
     /* update received time so that when storing to a mbox-style folder
      * the From_ line contains the current time instead of when the
      * message was first postponed.  */
-    e->received = mutt_date_epoch();
+    e->received = mutt_date_now();
     rc = mutt_write_multiple_fcc(mutt_buffer_string(fcc), e, NULL, false, NULL,
                                  finalpath, sub);
     while (rc && !(flags & SEND_BATCH))

--- a/send/sendlib.c
+++ b/send/sendlib.c
@@ -735,7 +735,7 @@ static char *gen_msgid(struct ConfigSubset *sub)
   if (!fqdn)
     fqdn = NONULL(ShortHostname);
 
-  struct tm tm = mutt_date_gmtime(MUTT_DATE_NOW);
+  struct tm tm = mutt_date_gmtime(mutt_date_now());
   snprintf(buf, sizeof(buf), "<%d%02d%02d%02d%02d%02d.%s@%s>", tm.tm_year + 1900,
            tm.tm_mon + 1, tm.tm_mday, tm.tm_hour, tm.tm_min, tm.tm_sec, rndid, fqdn);
   return mutt_str_dup(buf);

--- a/send/sendlib.c
+++ b/send/sendlib.c
@@ -400,7 +400,7 @@ static void set_encoding(struct Body *b, struct Content *info, struct ConfigSubs
  */
 void mutt_stamp_attachment(struct Body *a)
 {
-  a->stamp = mutt_date_epoch();
+  a->stamp = mutt_date_now();
 }
 
 /**

--- a/test/Makefile.autosetup
+++ b/test/Makefile.autosetup
@@ -141,8 +141,8 @@ CONVERT_OBJS	= test/convert/mutt_update_content_info.o \
 
 DATE_OBJS	= test/date/mutt_date_add_timeout.o \
 		  test/date/mutt_date_check_month.o \
-		  test/date/mutt_date_epoch.o \
-		  test/date/mutt_date_epoch_ms.o \
+		  test/date/mutt_date_now.o \
+		  test/date/mutt_date_now_ms.o \
 		  test/date/mutt_date_gmtime.o \
 		  test/date/mutt_date_local_tz.o \
 		  test/date/mutt_date_localtime.o \

--- a/test/date/mutt_date_add_timeout.c
+++ b/test/date/mutt_date_add_timeout.c
@@ -30,7 +30,7 @@ void test_mutt_date_add_timeout(void)
 {
   // time_t mutt_date_add_timeout(time_t now, long timeout);
 
-  time_t now = mutt_date_epoch();
+  time_t now = mutt_date_now();
 
   TEST_CHECK(mutt_date_add_timeout(now, -1000) == now);
   TEST_CHECK(mutt_date_add_timeout(now, -1) == now);

--- a/test/date/mutt_date_gmtime.c
+++ b/test/date/mutt_date_gmtime.c
@@ -56,7 +56,7 @@ void test_mutt_date_gmtime(void)
 
   {
     TEST_CASE("Today");
-    struct tm tm = mutt_date_gmtime(MUTT_DATE_NOW);
+    struct tm tm = mutt_date_gmtime(mutt_date_now());
     TEST_CHECK(tm.tm_year >= 119);
   }
 }

--- a/test/date/mutt_date_localtime.c
+++ b/test/date/mutt_date_localtime.c
@@ -61,7 +61,7 @@ void test_mutt_date_localtime(void)
 
   {
     TEST_CASE("Today");
-    struct tm tm = mutt_date_localtime(MUTT_DATE_NOW);
+    struct tm tm = mutt_date_localtime(mutt_date_now());
     TEST_CHECK(tm.tm_year >= 119);
   }
 }

--- a/test/date/mutt_date_now.c
+++ b/test/date/mutt_date_now.c
@@ -1,6 +1,6 @@
 /**
  * @file
- * Test code for mutt_date_epoch()
+ * Test code for mutt_date_now()
  *
  * @authors
  * Copyright (C) 2020 Richard Russon <rich@flatcap.org>
@@ -24,7 +24,7 @@
 #include "config.h"
 #include "acutest.h"
 
-void test_mutt_date_epoch(void)
+void test_mutt_date_now(void)
 {
-  // time_t mutt_date_epoch(void);
+  // time_t mutt_date_now(void);
 }

--- a/test/date/mutt_date_now_ms.c
+++ b/test/date/mutt_date_now_ms.c
@@ -1,6 +1,6 @@
 /**
  * @file
- * Test code for mutt_date_epoch_ms()
+ * Test code for mutt_date_now_ms()
  *
  * @authors
  * Copyright (C) 2020 Richard Russon <rich@flatcap.org>
@@ -24,7 +24,7 @@
 #include "config.h"
 #include "acutest.h"
 
-void test_mutt_date_epoch_ms(void)
+void test_mutt_date_now_ms(void)
 {
-  // uint64_t mutt_date_epoch_ms(void);
+  // uint64_t mutt_date_now_ms(void);
 }

--- a/test/main.c
+++ b/test/main.c
@@ -167,8 +167,8 @@
   /* date */                                                                   \
   NEOMUTT_TEST_ITEM(test_mutt_date_add_timeout)                                \
   NEOMUTT_TEST_ITEM(test_mutt_date_check_month)                                \
-  NEOMUTT_TEST_ITEM(test_mutt_date_epoch)                                      \
-  NEOMUTT_TEST_ITEM(test_mutt_date_epoch_ms)                                   \
+  NEOMUTT_TEST_ITEM(test_mutt_date_now)                                        \
+  NEOMUTT_TEST_ITEM(test_mutt_date_now_ms)                                     \
   NEOMUTT_TEST_ITEM(test_mutt_date_gmtime)                                     \
   NEOMUTT_TEST_ITEM(test_mutt_date_local_tz)                                   \
   NEOMUTT_TEST_ITEM(test_mutt_date_localtime)                                  \


### PR DESCRIPTION
* **What does this PR do?**

Two things:

1) Make the `mutt_date_gmtime()` and `mutt_date_localtime()` more robust by checking the return value of `gmtime()` and `localtime()` for a failure condition.  Since these function do get passed user supplied data, it is possible that these fail.
In the case of a failure return a default date. I opted for the common 1970-01-01 00:00:00.
Note: There seems to be no *guaranteed* way to produce a valid `tm` structure, all function producing one could fail. However, passing the above mentioned date seems pretty safe so I do not check the return value of `mktime()`.

2) Get rid of `MUTT_DATE_NOW`

`MUTT_DATE_NOW` is the date *Wed 31 Dec 22:13:21 1969* which is used to indicate not some cold day somewhere in the past but "now".  Remove the handling of this magic date and use dedicated functions (`mutt_date_gmtime_now()` and `mutt_date_localtime_now()`) to produce the current date.

The replacement on the caller side was pretty simple:
`mutt_date_gmtime(MUTT_DATE_NOW)` ==> `mutt_date_gmtime_now()`
`mutt_date_localtime(MUTT_DATE_NOW)` ==> `mutt_date_localtime_now()`

The only place which became slightly harder to read was a single call to `mutt_date_localtime_format(..., MUTT_DATE_NOW)` which had to be replaced with `mutt_date_localtime_format(..., mutt_date_epoch())`.

---

If you don't like the second change, I'd at least advise to incorporate the first one.

Have fun
Ray