### PR TITLE
Fix markup-typo in neomutt(1) man page

### DIFF
--- a/docs/neomutt.man
+++ b/docs/neomutt.man
@@ -242,6 +242,7 @@ Start NeoMutt with a listing of subscribed newsgroups
 .BI \-g " server"
 Like \fB\-G\fP, but start at specified news \fIserver\fP
 .
+.TP
 .BI \-H " draft"
 Specify a \fIdraft\fP file which contains header and body to use to send a
 message.


### PR DESCRIPTION
* **What does this PR do?**

Adds missing markup in docs/neomutt.man to separate `-H` from other command line options.

**Important**: Do not forget to run your strange, *secret*, rituals to update the documentation. ;-)

* **What are the relevant issue numbers?**

Solves #3598.