### PR TITLE
Use smime_sign_as when signing S/MIME messages

### DIFF
--- a/envelope/window.c
+++ b/envelope/window.c
@@ -452,7 +452,7 @@ static int draw_crypt_lines(struct MuttWindow *win, struct EnvelopeWindowData *w
       (e->security & APPLICATION_SMIME) && (e->security & SEC_SIGN))
   {
     draw_header(win, row++, HDR_CRYPTINFO);
-    const char *const c_smime_sign_as = cs_subset_string(wdata->sub, "pgp_sign_as");
+    const char *const c_smime_sign_as = cs_subset_string(wdata->sub, "smime_sign_as");
     mutt_window_printf(win, "%s", c_smime_sign_as ? c_smime_sign_as : _("<default>"));
   }
 


### PR DESCRIPTION
Do not use pgp_sign_as but smime_sign_as when signing messages.

* **What does this PR do?**

I believe there is a copy and past error as the signing for S/MIME queries the **pgp**_sign_as instead of the **smime**_sign_as config varialble.