### PR TITLE
Rename ask_follow_up to ask_followup_to

### DIFF
--- a/docs/config.c
+++ b/docs/config.c
@@ -189,7 +189,7 @@
 */
 
 #ifdef USE_NNTP
-{ "ask_follow_up", DT_BOOL, false },
+{ "ask_followup_to", DT_BOOL, false },
 /*
 ** .pp
 ** If set, NeoMutt will prompt you for follow-up groups before editing

--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -15395,7 +15395,7 @@ set new_mail_command = ""
             </thead>
             <tbody>
               <row>
-                <entry><literal>ask_follow_up</literal></entry>
+                <entry><literal>ask_followup_to</literal></entry>
                 <entry>boolean</entry>
                 <entry><literal>no</literal></entry>
               </row>
@@ -15636,7 +15636,7 @@ set new_mail_command = ""
 <emphasis role="comment"># --------------------------------------------------------------------------</emphasis>
 <emphasis role="comment"># VARIABLES – shown with their default values</emphasis>
 <emphasis role="comment"># --------------------------------------------------------------------------</emphasis>
-set ask_follow_up = no
+set ask_followup_to = no
 set ask_x_comment_to = no
 set catchup_newsgroup = ask-yes
 set followup_to_poster = ask-yes

--- a/send/config.c
+++ b/send/config.c
@@ -318,7 +318,7 @@ static struct ConfigDef SendVars[] = {
 #if defined(USE_NNTP)
 static struct ConfigDef SendVarsNntp[] = {
   // clang-format off
-  { "ask_follow_up", DT_BOOL, false, 0, NULL,
+  { "ask_followup_to", DT_BOOL, false, 0, NULL,
     "(nntp) Ask the user for follow-up groups before editing"
   },
   { "ask_x_comment_to", DT_BOOL, false, 0, NULL,
@@ -328,6 +328,8 @@ static struct ConfigDef SendVarsNntp[] = {
     "(nntp) External command to post news articles"
   },
   { "mime_subject", DT_DEPRECATED|DT_BOOL, true, IP "2021-03-24" },
+
+  { "ask_follow_up", DT_SYNONYM, IP "ask_followup_to", IP "2023-01-20" },
   { NULL },
   // clang-format on
 };

--- a/send/send.c
+++ b/send/send.c
@@ -244,9 +244,9 @@ static int edit_envelope(struct Envelope *en, SendFlags flags, struct ConfigSubs
     else
       mutt_buffer_reset(buf);
 
-    const bool c_ask_follow_up = cs_subset_bool(sub, "ask_follow_up");
-    if (c_ask_follow_up && (mutt_buffer_get_field("Followup-To: ", buf, MUTT_COMP_NO_FLAGS,
-                                                  false, NULL, NULL, NULL) != 0))
+    const bool c_ask_followup_to = cs_subset_bool(sub, "ask_followup_to");
+    if (c_ask_followup_to && (mutt_buffer_get_field("Followup-To: ", buf, MUTT_COMP_NO_FLAGS,
+                                                    false, NULL, NULL, NULL) != 0))
     {
       goto done;
     }


### PR DESCRIPTION
Rename the config variable `ask_follow_up` to `ask_followup_to` so that its name matches the header name it is guarding (namely `Followup-To:`) and to be consistent with the config variable `followup_to_poster`.

Create synonym `ask_follow_up` to not break existing configs.

