### PR TITLE
Document $thread_received more detailed

### DIFF
--- a/docs/config.c
+++ b/docs/config.c
@@ -5218,8 +5218,18 @@
 { "thread_received", DT_BOOL, false },
 /*
 ** .pp
-** When \fIset\fP, NeoMutt uses the date received rather than the date sent
-** to thread messages by subject.
+** If $$strict_threads is \fIunset\fP, then messages may also be grouped by
+** subject.  Unlike threading by "In-Reply-To:" and "References:" header,
+** grouping by subject does not imply a parent-child relation between two
+** messages.
+** .pp
+** To determine the ancestry between messages grouped by subject, Neomutt uses
+** their date: only newer messages can be descendants of older ones.
+** .pp
+** When $$thread_received is \fIset\fP, NeoMutt uses the date received rather
+** than the date sent when comparing messages for the date.
+** .pp
+** See also $$strict_threads, and $$sort_re.
 */
 
 { "tilde", DT_BOOL, false },


### PR DESCRIPTION
* **What does this PR do?**

Enhance the documentation of `$thread_received`.

From the old explanation I didn't understand what `$thread_received` does.
Digging into the code I *believe* it does what the doc in this PR describes.

The relevant lines of code (and only usage side of `$thread_received`) are in `mutt_thread.c` lines 502-605:
`https://github.com/neomutt/neomutt/blob/7ddad5ee30830496d336cd9c2cb756cfd547bc8b/mutt_thread.c#L502-L605`

P.S.: Again don't forget to run your strange, secret, rituals to update the manpage and homepage ;-)

https://github.com/neomutt/neomutt/blob/7ddad5ee30830496d336cd9c2cb756cfd547bc8b/mutt_thread.c#L502-L605