### PR TITLE
Fix markup typo in description of uncolor in neomuttrc(1)

### DIFF
--- a/docs/neomuttrc.man.head
+++ b/docs/neomuttrc.man.head
@@ -316,7 +316,7 @@ Valid colors include:
 Valid attributes include:
 .BR none ", " bold ", " underline ", "
 .BR reverse ", and " standout .
-IP
+.IP
 The \fBuncolor\fP command can be applied to the index, header and body objects
 only. It removes entries from the list. You must specify the same \fIpattern\fP
 specified in the \fBcolor\fP command for it to be removed. The pattern


### PR DESCRIPTION
* **What does this PR do?**

Fix markup typo in description of `uncolor` in neomuttrc(1)
