### PR TITLE
Document regex and sub-match argument to `color status`

### DIFF
--- a/docs/neomuttrc.man.head
+++ b/docs/neomuttrc.man.head
@@ -316,7 +316,7 @@ Valid colors include:
 Valid attributes include:
 .BR none ", " bold ", " underline ", "
 .BR reverse ", and " standout .
-IP
+.IP
 The \fBuncolor\fP command can be applied to the index, header and body objects
 only. It removes entries from the list. You must specify the same \fIpattern\fP
 specified in the \fBcolor\fP command for it to be removed. The pattern

--- a/docs/neomuttrc.man.head
+++ b/docs/neomuttrc.man.head
@@ -237,6 +237,7 @@ configuration file.
 .nf
 \fBcolor\fP \fIobject\fP [ \fIattribute\fP ... ] \fIforeground\fP \fIbackground\fP
 \fBcolor\fP { header | body } [ \fIattribute\fP ... ] \fIforeground\fP \fIbackground\fP \fIregex\fP
+\fBcolor\fP status \fIforeground\fP \fIbackground\fP [\fIregex\fP [ \fInum\fP ]]
 \fBcolor\fP index-object [ \fIattribute\fP ... ] \fIforeground\fP \fIbackground\fP \fIpattern\fP
 \fBcolor\fP compose \fIcomposeobject\fP \fIforeground\fP \fIbackground\fP
 \fBcolor\fP compose \fIcomposeobject\fP [ \fIattribute\fP ... ] \fIforeground\fP \fIbackground\fP
@@ -296,6 +297,10 @@ The \fBheader\fP and \fBbody\fP match \fIregex\fP in the header/body of
 a message, \fBindex-object\fP can match \fIpattern\fP in the message index.
 Note that IMAP server-side searches (=b, =B, =h) are not supported for color
 index patterns.
+.IP
+The \fBstatus\fP object optionally takes an regex and a match number.  If the
+regex is given, only the matching parts are colored.  If additionally the match
+number is given, only that sub-match of the regex is colored.
 .IP
 Valid composeobjects include
 .BR header ", " security_encrypt ", " security_sign ", "


### PR DESCRIPTION
1) Fixes a markup typo
2) Documents the syntax `color status foreground background [ regex [ num ]]` in neomuttrc