### PR TITLE
Omit `$` as `sidebar_whitelist` is a command not a variable

### DIFF
--- a/docs/config.c
+++ b/docs/config.c
@@ -4236,7 +4236,7 @@
 ** When set, the sidebar will only display mailboxes containing new, or
 ** flagged, mail.
 ** .pp
-** \fBSee also:\fP $$sidebar_whitelist, $$sidebar_non_empty_mailbox_only.
+** \fBSee also:\fP $sidebar_whitelist, $$sidebar_non_empty_mailbox_only.
 */
 
 { "sidebar_next_new_wrap", DT_BOOL, false },
@@ -4253,7 +4253,7 @@
 ** .pp
 ** When set, the sidebar will only display mailboxes that contain one or more mails.
 ** .pp
-** \fBSee also:\fP $$sidebar_new_mail_only, $$sidebar_whitelist.
+** \fBSee also:\fP $$sidebar_new_mail_only, $sidebar_whitelist.
 */
 
 { "sidebar_on_right", DT_BOOL, false },


### PR DESCRIPTION
Change references of `$sidebar_whitelist` to `sidebar_whitelist`. Since `sidebar_whitelist` is a command it should not be prefixed by a dollar `$`.
