### PR TITLE
Clarify reference to NeoMutt guide in $header_cache

### DIFF
--- a/docs/config.c
+++ b/docs/config.c
@@ -1531,7 +1531,7 @@
 ** By default it is \fIunset\fP so no header caching will be used.
 ** .pp
 ** Header caching can greatly improve speed when opening POP, IMAP
-** MH or Maildir folders, see "$caching" for details.
+** MH or Maildir folders, see "$caching" in the NeoMutt Guide for details.
 */
 
 { "header_cache_backend", DT_STRING, 0 },


### PR DESCRIPTION
The documentation of $header_cache reference a section "caching" which only exist in the NeoMutt Guide but not in the man page.  Clarify that this is reference to the guide.

Note: We did not change the name ("caching") of the reference, even if the referenced section is called "Local Caching" in the chapter "Optional Features".  The reason to keep this wrong name is to get a proper linking as "caching" is the HTML anchor name of the target section.
