### PR TITLE
config: skip line rest of line after a warning

### DIFF
--- a/color/command.c
+++ b/color/command.c
@@ -370,7 +370,7 @@ static enum CommandResult parse_object(struct Buffer *buf, struct Buffer *s,
     {
       if (!mutt_str_atoi_full(buf->data + 6, &val) || (val > COLOR_QUOTES_MAX))
       {
-        mutt_buffer_printf(err, _("%s: no such object"), buf->data);
+        mutt_buffer_printf(err, _("%s: no such color"), buf->data);
         return MUTT_CMD_WARNING;
       }
     }
@@ -393,7 +393,7 @@ static enum CommandResult parse_object(struct Buffer *buf, struct Buffer *s,
     rc = mutt_map_get_value(buf->data, ComposeColorFields);
     if (rc == -1)
     {
-      mutt_buffer_printf(err, _("%s: no such object"), buf->data);
+      mutt_buffer_printf(err, _("%s: no such color"), buf->data);
       return MUTT_CMD_WARNING;
     }
 
@@ -404,7 +404,7 @@ static enum CommandResult parse_object(struct Buffer *buf, struct Buffer *s,
   rc = mutt_map_get_value(buf->data, ColorFields);
   if (rc == -1)
   {
-    mutt_buffer_printf(err, _("%s: no such object"), buf->data);
+    mutt_buffer_printf(err, _("%s: no such color"), buf->data);
     return MUTT_CMD_WARNING;
   }
   else
@@ -448,7 +448,7 @@ static enum CommandResult parse_uncolor(struct Buffer *buf, struct Buffer *s,
 
   if (cid == -1)
   {
-    mutt_buffer_printf(err, _("%s: no such object"), buf->data);
+    mutt_buffer_printf(err, _("%s: no such color"), buf->data);
     return MUTT_CMD_ERROR;
   }
 

--- a/init.c
+++ b/init.c
@@ -866,7 +866,7 @@ enum CommandResult mutt_parse_rc_buffer(struct Buffer *line,
       {
         mutt_debug(LL_DEBUG1, "NT_COMMAND: %s\n", cmd[i].name);
         rc = cmd[i].parse(token, line, cmd[i].data, err);
-        if ((rc == MUTT_CMD_ERROR) || (rc == MUTT_CMD_FINISH))
+        if ((rc == MUTT_CMD_WARNING) || (rc == MUTT_CMD_ERROR) || (rc == MUTT_CMD_FINISH))
           goto finish; /* Propagate return code */
 
         notify_send(NeoMutt->notify, NT_COMMAND, i, (void *) cmd);


### PR DESCRIPTION
- warn about colours not objects
  (we already have a translation)

- config: skip line rest of line after a warning
  Don't try to parse the rest of a line, after a mistake is found

Fixes: #3615 