### PR TITLE
Rename `implicit_autoview` to `implicit_auto_view`

### DIFF
--- a/docs/config.c
+++ b/docs/config.c
@@ -1969,7 +1969,7 @@
 */
 #endif
 
-{ "implicit_autoview", DT_BOOL, false },
+{ "implicit_auto_view", DT_BOOL, false },
 /*
 ** .pp
 ** If set to "yes", NeoMutt will look for a mailcap entry with the

--- a/handler.c
+++ b/handler.c
@@ -481,10 +481,10 @@ static bool is_autoview(struct Body *b)
 
   snprintf(type, sizeof(type), "%s/%s", TYPE(b), b->subtype);
 
-  const bool c_implicit_autoview = cs_subset_bool(NeoMutt->sub, "implicit_autoview");
-  if (c_implicit_autoview)
+  const bool c_implicit_auto_view = cs_subset_bool(NeoMutt->sub, "implicit_auto_view");
+  if (c_implicit_auto_view)
   {
-    /* $implicit_autoview is essentially the same as "auto_view *" */
+    /* $implicit_auto_view is essentially the same as "auto_view *" */
     is_av = true;
   }
   else

--- a/mutt_config.c
+++ b/mutt_config.c
@@ -326,7 +326,7 @@ static struct ConfigDef MainVars[] = {
   { "hostname", DT_STRING, 0, 0, NULL,
     "Fully-qualified domain name of this machine"
   },
-  { "implicit_autoview", DT_BOOL, false, 0, NULL,
+  { "implicit_auto_view", DT_BOOL, false, 0, NULL,
     "Display MIME attachments inline if a 'copiousoutput' mailcap entry exists"
   },
   { "include_encrypted", DT_BOOL, false, 0, NULL,
@@ -643,6 +643,7 @@ static struct ConfigDef MainVars[] = {
   { "forw_decode",               DT_SYNONYM, IP "forward_decode",             IP "2021-03-21" },
   { "forw_quote",                DT_SYNONYM, IP "forward_quote",              IP "2021-03-21" },
   { "hdr_format",                DT_SYNONYM, IP "index_format",               IP "2021-03-21" },
+  { "implicit_autoview",         DT_SYNONYM, IP "implicit_auto_view",         IP "2023-01-25" },
   { "include_onlyfirst",         DT_SYNONYM, IP "include_only_first",         IP "2021-03-21" },
   { "indent_str",                DT_SYNONYM, IP "indent_string",              IP "2021-03-21" },
   { "mime_fwd",                  DT_SYNONYM, IP "mime_forward",               IP "2021-03-21" },


### PR DESCRIPTION
Rename `implicit_autoview` to `implicit_auto_view` to bring its name in line with the command `auto_view`.

A synonym `implicit_autoview` is provided for backwards compatibility.

Fixes #3626