### PR TITLE
Rename `message_cachedir` to `message_cache_dir`

### DIFF
--- a/bcache/bcache.c
+++ b/bcache/bcache.c
@@ -65,14 +65,14 @@ static int bcache_path(struct ConnAccount *account, const char *mailbox, struct 
   char host[256] = { 0 };
   struct Url url = { 0 };
 
-  const char *const c_message_cachedir = cs_subset_path(NeoMutt->sub, "message_cachedir");
-  if (!account || !c_message_cachedir || !bcache)
+  const char *const c_message_cache_dir = cs_subset_path(NeoMutt->sub, "message_cache_dir");
+  if (!account || !c_message_cache_dir || !bcache)
     return -1;
 
   struct stat st = { 0 };
-  if (!((stat(c_message_cachedir, &st) == 0) && S_ISDIR(st.st_mode)))
+  if (!((stat(c_message_cache_dir, &st) == 0) && S_ISDIR(st.st_mode)))
   {
-    mutt_error(_("Cache disabled, $message_cachedir isn't a directory: %s"), c_message_cachedir);
+    mutt_error(_("Cache disabled, $message_cache_dir isn't a directory: %s"), c_message_cache_dir);
     return -1;
   }
 
@@ -91,7 +91,7 @@ static int bcache_path(struct ConnAccount *account, const char *mailbox, struct 
   struct Buffer *dst = mutt_buffer_pool_get();
   mutt_encode_path(path, NONULL(mailbox));
 
-  mutt_buffer_printf(dst, "%s/%s%s", c_message_cachedir, host, mutt_buffer_string(path));
+  mutt_buffer_printf(dst, "%s/%s%s", c_message_cache_dir, host, mutt_buffer_string(path));
   if (*(dst->dptr - 1) != '/')
     mutt_buffer_addch(dst, '/');
 

--- a/docs/config.c
+++ b/docs/config.c
@@ -2404,7 +2404,7 @@
 ** (especially for large folders).
 */
 
-{ "message_cachedir", DT_PATH, 0 },
+{ "message_cache_dir", DT_PATH, 0 },
 /*
 ** .pp
 ** Set this to a directory and NeoMutt will cache copies of messages from

--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -12457,7 +12457,7 @@ folder-hook imap://user@host2/ 'set folder=imap://host2/ ; set record=+INBOX/Sen
         </para>
         <para>
           For configuration, the variable
-          <link linkend="message-cachedir">$message_cachedir</link> must point
+          <link linkend="message-cache-dir">$message_cache_dir</link> must point
           to a directory. There, NeoMutt will create a hierarchy of
           subdirectories named like the account and mailbox path the cache is
           for.
@@ -12469,7 +12469,7 @@ folder-hook imap://user@host2/ 'set folder=imap://host2/ ; set record=+INBOX/Sen
         <para>
           For using both, header and body caching,
           <link linkend="header-cache">$header_cache</link> and
-          <link linkend="message-cachedir">$message_cachedir</link> can be
+          <link linkend="message-cache-dir">$message_cache_dir</link> can be
           safely set to the same value.
         </para>
         <para>

--- a/mutt_config.c
+++ b/mutt_config.c
@@ -380,7 +380,7 @@ static struct ConfigDef MainVars[] = {
   { "message_cache_clean", DT_BOOL, false, 0, NULL,
     "(imap/pop) Clean out obsolete entries from the message cache"
   },
-  { "message_cachedir", DT_PATH|DT_PATH_DIR, 0, 0, NULL,
+  { "message_cache_dir", DT_PATH|DT_PATH_DIR, 0, 0, NULL,
     "(imap/pop) Directory for the message cache"
   },
   { "message_format", DT_STRING|DT_NOT_EMPTY, IP "%s", 0, NULL,
@@ -645,6 +645,7 @@ static struct ConfigDef MainVars[] = {
   { "hdr_format",                DT_SYNONYM, IP "index_format",               IP "2021-03-21" },
   { "include_onlyfirst",         DT_SYNONYM, IP "include_only_first",         IP "2021-03-21" },
   { "indent_str",                DT_SYNONYM, IP "indent_string",              IP "2021-03-21" },
+  { "message_cachedir",          DT_SYNONYM, IP "message_cache_dir",          IP "2023-01-25" },
   { "mime_fwd",                  DT_SYNONYM, IP "mime_forward",               IP "2021-03-21" },
   { "msg_format",                DT_SYNONYM, IP "message_format",             IP "2021-03-21" },
   { "print_cmd",                 DT_SYNONYM, IP "print_command",              IP "2021-03-21" },

--- a/po/bg.po
+++ b/po/bg.po
@@ -680,7 +680,7 @@ msgstr ""
 
 #: bcache/bcache.c:75
 #, fuzzy, c-format
-msgid "Cache disabled, $message_cachedir isn't a directory: %s"
+msgid "Cache disabled, $message_cache_dir isn't a directory: %s"
 msgstr "%s не е директория"
 
 #: bcache/bcache.c:221

--- a/po/ca.po
+++ b/po/ca.po
@@ -724,7 +724,7 @@ msgstr "La versió de la base de dades d’Autocrypt és massa nova"
 
 #: bcache/bcache.c:75
 #, fuzzy, c-format
-msgid "Cache disabled, $message_cachedir isn't a directory: %s"
+msgid "Cache disabled, $message_cache_dir isn't a directory: %s"
 msgstr "«%s» no és un directori"
 
 #: bcache/bcache.c:221

--- a/po/cs.po
+++ b/po/cs.po
@@ -672,8 +672,8 @@ msgstr "Verze databáze autocrypt je příliš nová"
 
 #: bcache/bcache.c:75
 #, c-format
-msgid "Cache disabled, $message_cachedir isn't a directory: %s"
-msgstr "Cache vypnuta, $message_cachedir není adresářem: %s"
+msgid "Cache disabled, $message_cache_dir isn't a directory: %s"
+msgstr "Cache vypnuta, $message_cache_dir není adresářem: %s"
 
 #: bcache/bcache.c:221
 #, c-format

--- a/po/da.po
+++ b/po/da.po
@@ -667,7 +667,7 @@ msgstr "Version af autocrypt-database er for ny"
 
 #: bcache/bcache.c:75
 #, fuzzy, c-format
-msgid "Cache disabled, $message_cachedir isn't a directory: %s"
+msgid "Cache disabled, $message_cache_dir isn't a directory: %s"
 msgstr "%s er ikke et filkatalog"
 
 #: bcache/bcache.c:221

--- a/po/de.po
+++ b/po/de.po
@@ -664,8 +664,8 @@ msgstr "Die Version der Autocrypt-Datenbank zu hoch"
 
 #: bcache/bcache.c:75
 #, c-format
-msgid "Cache disabled, $message_cachedir isn't a directory: %s"
-msgstr "Cache deaktiviert, $message_cachedir ist kein Verzeichnis: %s"
+msgid "Cache disabled, $message_cache_dir isn't a directory: %s"
+msgstr "Cache deaktiviert, $message_cache_dir ist kein Verzeichnis: %s"
 
 #: bcache/bcache.c:221
 #, c-format

--- a/po/el.po
+++ b/po/el.po
@@ -670,8 +670,8 @@ msgstr "Η βάση δεδομένων autocrypt είναι πολύ νέα"
 
 #: bcache/bcache.c:75
 #, c-format
-msgid "Cache disabled, $message_cachedir isn't a directory: %s"
-msgstr "Η cache είναι απενεργοποιημένη, το $message_cachedir δεν είναι κατάλογος: %s"
+msgid "Cache disabled, $message_cache_dir isn't a directory: %s"
+msgstr "Η cache είναι απενεργοποιημένη, το $message_cache_dir δεν είναι κατάλογος: %s"
 
 #: bcache/bcache.c:221
 #, c-format

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -658,8 +658,8 @@ msgstr "Autocrypt database version is too new"
 
 #: bcache/bcache.c:75
 #, c-format
-msgid "Cache disabled, $message_cachedir isn't a directory: %s"
-msgstr "Cache disabled, $message_cachedir isn't a directory: %s"
+msgid "Cache disabled, $message_cache_dir isn't a directory: %s"
+msgstr "Cache disabled, $message_cache_dir isn't a directory: %s"
 
 #: bcache/bcache.c:221
 #, c-format

--- a/po/eo.po
+++ b/po/eo.po
@@ -658,7 +658,7 @@ msgstr "Versio de autocrypt-datenaro estas tro nova"
 
 #: bcache/bcache.c:75
 #, fuzzy, c-format
-msgid "Cache disabled, $message_cachedir isn't a directory: %s"
+msgid "Cache disabled, $message_cache_dir isn't a directory: %s"
 msgstr "%s ne estas dosierujo"
 
 #: bcache/bcache.c:221

--- a/po/es.po
+++ b/po/es.po
@@ -663,7 +663,7 @@ msgstr "La base de datos de autocrypt es demasiado nueva"
 
 #: bcache/bcache.c:75
 #, fuzzy, c-format
-msgid "Cache disabled, $message_cachedir isn't a directory: %s"
+msgid "Cache disabled, $message_cache_dir isn't a directory: %s"
 msgstr "El caché de mensajes %s no es un directorio"
 
 #: bcache/bcache.c:221

--- a/po/et.po
+++ b/po/et.po
@@ -675,7 +675,7 @@ msgstr ""
 
 #: bcache/bcache.c:75
 #, fuzzy, c-format
-msgid "Cache disabled, $message_cachedir isn't a directory: %s"
+msgid "Cache disabled, $message_cache_dir isn't a directory: %s"
 msgstr "%s ei ole kataloog"
 
 #: bcache/bcache.c:221

--- a/po/eu.po
+++ b/po/eu.po
@@ -671,7 +671,7 @@ msgstr ""
 
 #: bcache/bcache.c:75
 #, fuzzy, c-format
-msgid "Cache disabled, $message_cachedir isn't a directory: %s"
+msgid "Cache disabled, $message_cache_dir isn't a directory: %s"
 msgstr "%s ez da karpeta bat"
 
 #: bcache/bcache.c:221

--- a/po/fi.po
+++ b/po/fi.po
@@ -674,7 +674,7 @@ msgstr ""
 
 #: bcache/bcache.c:75
 #, fuzzy, c-format
-msgid "Cache disabled, $message_cachedir isn't a directory: %s"
+msgid "Cache disabled, $message_cache_dir isn't a directory: %s"
 msgstr "Viestivälimuisti ei ole hakemisto: %s"
 
 #: bcache/bcache.c:221

--- a/po/fr.po
+++ b/po/fr.po
@@ -692,7 +692,7 @@ msgstr "La version de la base de donnée Autocrypt est trop récente"
 # , c-format
 #: bcache/bcache.c:75
 #, fuzzy, c-format
-msgid "Cache disabled, $message_cachedir isn't a directory: %s"
+msgid "Cache disabled, $message_cache_dir isn't a directory: %s"
 msgstr "%s n'est pas un répertoire"
 
 # , c-format

--- a/po/ga.po
+++ b/po/ga.po
@@ -677,7 +677,7 @@ msgstr ""
 
 #: bcache/bcache.c:75
 #, fuzzy, c-format
-msgid "Cache disabled, $message_cachedir isn't a directory: %s"
+msgid "Cache disabled, $message_cache_dir isn't a directory: %s"
 msgstr "Ní comhadlann í %s"
 
 #: bcache/bcache.c:221

--- a/po/gl.po
+++ b/po/gl.po
@@ -682,7 +682,7 @@ msgstr ""
 
 #: bcache/bcache.c:75
 #, fuzzy, c-format
-msgid "Cache disabled, $message_cachedir isn't a directory: %s"
+msgid "Cache disabled, $message_cache_dir isn't a directory: %s"
 msgstr "%s non é un directorio"
 
 #: bcache/bcache.c:221

--- a/po/hu.po
+++ b/po/hu.po
@@ -661,8 +661,8 @@ msgstr "Autocrypt adatbázis verzió túl új"
 
 #: bcache/bcache.c:75
 #, c-format
-msgid "Cache disabled, $message_cachedir isn't a directory: %s"
-msgstr "A gyorsítótár tiltva, $message_cachedir nem könyvtár: %s"
+msgid "Cache disabled, $message_cache_dir isn't a directory: %s"
+msgstr "A gyorsítótár tiltva, $message_cache_dir nem könyvtár: %s"
 
 #: bcache/bcache.c:221
 #, c-format

--- a/po/id.po
+++ b/po/id.po
@@ -671,7 +671,7 @@ msgstr ""
 
 #: bcache/bcache.c:75
 #, fuzzy, c-format
-msgid "Cache disabled, $message_cachedir isn't a directory: %s"
+msgid "Cache disabled, $message_cache_dir isn't a directory: %s"
 msgstr "%s bukan direktori"
 
 #: bcache/bcache.c:221

--- a/po/it.po
+++ b/po/it.po
@@ -673,7 +673,7 @@ msgstr ""
 
 #: bcache/bcache.c:75
 #, fuzzy, c-format
-msgid "Cache disabled, $message_cachedir isn't a directory: %s"
+msgid "Cache disabled, $message_cache_dir isn't a directory: %s"
 msgstr "%s non è una directory"
 
 #: bcache/bcache.c:221

--- a/po/ja.po
+++ b/po/ja.po
@@ -664,7 +664,7 @@ msgstr "autocrypt データベースバージョンが新しすぎる"
 
 #: bcache/bcache.c:75
 #, fuzzy, c-format
-msgid "Cache disabled, $message_cachedir isn't a directory: %s"
+msgid "Cache disabled, $message_cache_dir isn't a directory: %s"
 msgstr "%s はディレクトリではない。"
 
 #: bcache/bcache.c:221

--- a/po/ko.po
+++ b/po/ko.po
@@ -675,7 +675,7 @@ msgstr ""
 
 #: bcache/bcache.c:75
 #, fuzzy, c-format
-msgid "Cache disabled, $message_cachedir isn't a directory: %s"
+msgid "Cache disabled, $message_cache_dir isn't a directory: %s"
 msgstr "%s는 디렉토리가 아닙니다"
 
 #: bcache/bcache.c:221

--- a/po/lt.po
+++ b/po/lt.po
@@ -662,8 +662,8 @@ msgstr "Autocrypt duomenų bazės versija per nauja"
 
 #: bcache/bcache.c:75
 #, c-format
-msgid "Cache disabled, $message_cachedir isn't a directory: %s"
-msgstr "Podėlis išjungtas, $message_cachedir nėra katalogas: %s"
+msgid "Cache disabled, $message_cache_dir isn't a directory: %s"
+msgstr "Podėlis išjungtas, $message_cache_dir nėra katalogas: %s"
 
 #: bcache/bcache.c:221
 #, c-format

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -666,8 +666,8 @@ msgstr "Versjonen av Autocrypt-databasen er for ny"
 
 #: bcache/bcache.c:75
 #, fuzzy, c-format
-msgid "Cache disabled, $message_cachedir isn't a directory: %s"
-msgstr "Hurtiglager avskrudd, $message_cachedir er ikke en mappe, %s"
+msgid "Cache disabled, $message_cache_dir isn't a directory: %s"
+msgstr "Hurtiglager avskrudd, $message_cache_dir er ikke en mappe, %s"
 
 #: bcache/bcache.c:221
 #, fuzzy, c-format

--- a/po/nl.po
+++ b/po/nl.po
@@ -670,7 +670,7 @@ msgstr ""
 
 #: bcache/bcache.c:75
 #, fuzzy, c-format
-msgid "Cache disabled, $message_cachedir isn't a directory: %s"
+msgid "Cache disabled, $message_cache_dir isn't a directory: %s"
 msgstr "%s is geen map"
 
 #: bcache/bcache.c:221

--- a/po/pl.po
+++ b/po/pl.po
@@ -663,8 +663,8 @@ msgstr "Zbyt nowa wersja bazy danych autocrypt"
 
 #: bcache/bcache.c:75
 #, c-format
-msgid "Cache disabled, $message_cachedir isn't a directory: %s"
-msgstr "Pamięć podręczna (cache) wiadomości $message_cachedir nie jest katalogiem: %s"
+msgid "Cache disabled, $message_cache_dir isn't a directory: %s"
+msgstr "Pamięć podręczna (cache) wiadomości $message_cache_dir nie jest katalogiem: %s"
 
 #: bcache/bcache.c:221
 #, c-format

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -663,7 +663,7 @@ msgstr "Versão do banco de dados de auto-criptografia recente demais"
 
 #: bcache/bcache.c:75
 #, fuzzy, c-format
-msgid "Cache disabled, $message_cachedir isn't a directory: %s"
+msgid "Cache disabled, $message_cache_dir isn't a directory: %s"
 msgstr "Cachê de mensagens não é um diretório: %s"
 
 #: bcache/bcache.c:221

--- a/po/ru.po
+++ b/po/ru.po
@@ -668,8 +668,8 @@ msgstr "Версия базы данных autocrypt слишком новая"
 
 #: bcache/bcache.c:75
 #, c-format
-msgid "Cache disabled, $message_cachedir isn't a directory: %s"
-msgstr "Кэш отключен, $message_cachedir не является каталогом: %s"
+msgid "Cache disabled, $message_cache_dir isn't a directory: %s"
+msgstr "Кэш отключен, $message_cache_dir не является каталогом: %s"
 
 #: bcache/bcache.c:221
 #, c-format

--- a/po/sk.po
+++ b/po/sk.po
@@ -672,8 +672,8 @@ msgstr "Verzia databáze autocrypt je príliš nová"
 
 #: bcache/bcache.c:75
 #, c-format
-msgid "Cache disabled, $message_cachedir isn't a directory: %s"
-msgstr "Cache vypnutá, $message_cachedir nie je adresár: %s"
+msgid "Cache disabled, $message_cache_dir isn't a directory: %s"
+msgstr "Cache vypnutá, $message_cache_dir nie je adresár: %s"
 
 #: bcache/bcache.c:221
 #, c-format

--- a/po/sr.po
+++ b/po/sr.po
@@ -661,8 +661,8 @@ msgstr "Верзија базе аутошифровања је превише �
 
 #: bcache/bcache.c:75
 #, c-format
-msgid "Cache disabled, $message_cachedir isn't a directory: %s"
-msgstr "Кеш онемогућен, $message_cachedir није директоријум: %s"
+msgid "Cache disabled, $message_cache_dir isn't a directory: %s"
+msgstr "Кеш онемогућен, $message_cache_dir није директоријум: %s"
 
 #: bcache/bcache.c:221
 #, c-format

--- a/po/sv.po
+++ b/po/sv.po
@@ -671,7 +671,7 @@ msgstr ""
 
 #: bcache/bcache.c:75
 #, fuzzy, c-format
-msgid "Cache disabled, $message_cachedir isn't a directory: %s"
+msgid "Cache disabled, $message_cache_dir isn't a directory: %s"
 msgstr "%s är inte en katalog"
 
 #: bcache/bcache.c:221

--- a/po/tr.po
+++ b/po/tr.po
@@ -661,8 +661,8 @@ msgstr "Autocrypt veritabanı sürümü pek yeni"
 
 #: bcache/bcache.c:75
 #, c-format
-msgid "Cache disabled, $message_cachedir isn't a directory: %s"
-msgstr "Önbellek devre dışı, $message_cachedir bir dizin değil: %s"
+msgid "Cache disabled, $message_cache_dir isn't a directory: %s"
+msgstr "Önbellek devre dışı, $message_cache_dir bir dizin değil: %s"
 
 #: bcache/bcache.c:221
 #, c-format

--- a/po/uk.po
+++ b/po/uk.po
@@ -663,8 +663,8 @@ msgstr "Версія бази даних autocrypt занадто нова"
 
 #: bcache/bcache.c:75
 #, c-format
-msgid "Cache disabled, $message_cachedir isn't a directory: %s"
-msgstr "Кеш вимкнено, $message_cachedir не є каталогом: %s"
+msgid "Cache disabled, $message_cache_dir isn't a directory: %s"
+msgstr "Кеш вимкнено, $message_cache_dir не є каталогом: %s"
 
 #: bcache/bcache.c:221
 #, c-format

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -663,8 +663,8 @@ msgstr "Autocrypt 数据库版本太新"
 
 #: bcache/bcache.c:75
 #, c-format
-msgid "Cache disabled, $message_cachedir isn't a directory: %s"
-msgstr "已禁用缓存，$message_cachedir 不是一个目录：%s"
+msgid "Cache disabled, $message_cache_dir isn't a directory: %s"
+msgstr "已禁用缓存，$message_cache_dir 不是一个目录：%s"
 
 #: bcache/bcache.c:221
 #, c-format

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -677,7 +677,7 @@ msgstr ""
 
 #: bcache/bcache.c:75
 #, fuzzy, c-format
-msgid "Cache disabled, $message_cachedir isn't a directory: %s"
+msgid "Cache disabled, $message_cache_dir isn't a directory: %s"
 msgstr "%s 不是一個目錄"
 
 #: bcache/bcache.c:221

--- a/pop/pop.c
+++ b/pop/pop.c
@@ -991,7 +991,7 @@ static bool pop_msg_open(struct Mailbox *m, struct Message *msg, int msgno)
     return true;
 
   /* see if we already have the message in our cache in
-   * case $message_cachedir is unset */
+   * case $message_cache_dir is unset */
   struct PopCache *cache = &adata->cache[e->index % POP_CACHE_LEN];
 
   if (cache->path)


### PR DESCRIPTION
* **What does this PR do?**

Renames the option `message_cachedir` to `message_cache_dir` to bring it in line with other `*_dir` config variables like `attach_save_dir`, `autocrypt_dir`, `news_cache_dir` (but not `tmpdir`).
