### PR TITLE
Rename `tmpdir` to `tmp_dir`

### DIFF
--- a/docs/config.c
+++ b/docs/config.c
@@ -5290,7 +5290,7 @@
 ** A value of zero or less will cause NeoMutt to never time out.
 */
 
-{ "tmpdir", DT_PATH, TMPDIR },
+{ "tmp_dir", DT_PATH, TMPDIR },
 /*
 ** .pp
 ** This variable allows you to specify where NeoMutt will place its

--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -3700,7 +3700,7 @@ set crypt_use_gpgme
           <link linkend="news-server">$news_server</link>,
           <link linkend="shell">shell</link>,
           <link linkend="spool-file">$spool_file</link>,
-          <link linkend="tmpdir">$tmpdir</link>,
+          <link linkend="tmp-dir">$tmp_dir</link>,
         </para>
         <para>
           Finally, it's possible to
@@ -13191,7 +13191,7 @@ append-hook '\.gz$' "gzip --stdout '%t' &gt;&gt; '%f'"
           <title>Security</title>
           <para>
             Encrypted files are decrypted into temporary files which are stored
-            in the <link linkend="tmpdir">$tmpdir</link> directory. This could
+            in the <link linkend="tmp-dir">$tmp_dir</link> directory. This could
             be a security risk.
           </para>
         </sect3>
@@ -13248,7 +13248,7 @@ close-hook  '\.gpg$' "gpg --encrypt --recipient YourGpgUserIdOrKeyId &lt; '%t' &
           </listitem>
           <listitem>
             <para>
-              <link linkend="tmpdir">$tmpdir</link>
+              <link linkend="tmp-dir">$tmp_dir</link>
             </para>
           </listitem>
           <listitem>
@@ -18695,7 +18695,7 @@ set use_threads=threads sort=last-date sort_aux=date
         digital signatures, etc. As long as being used, these files are visible
         by other users and maybe even readable in case of misconfiguration.
         Also, a different location for these files may be desired which can be
-        changed via the <link linkend="tmpdir">$tmpdir</link> variable.
+        changed via the <link linkend="tmp-dir">$tmp_dir</link> variable.
       </para>
     </sect1>
 

--- a/docs/neomutt.man
+++ b/docs/neomutt.man
@@ -414,7 +414,7 @@ and used for Native Language Support (NLS) if enabled.
 .SM
 .B TMPDIR
 Directory in which temporary files are created. Defaults to \fI/tmp\fP if
-unset. Configuration variable $tmpdir takes precedence over this one.
+unset. Configuration variable $tmp_dir takes precedence over this one.
 .
 .TP
 .SM

--- a/init.c
+++ b/init.c
@@ -639,10 +639,10 @@ int mutt_init(struct ConfigSet *cs, bool skip_sys_rc, struct ListHead *commands)
   if (env_mc)
     cs_str_string_set(cs, "mailcap_path", env_mc, NULL);
 
-  /* "$tmpdir" precedence: config file, environment, code */
+  /* "$tmp_dir" precedence: config file, environment, code */
   const char *env_tmp = mutt_str_getenv("TMPDIR");
   if (env_tmp)
-    cs_str_string_set(cs, "tmpdir", env_tmp, NULL);
+    cs_str_string_set(cs, "tmp_dir", env_tmp, NULL);
 
   /* "$visual", "$editor" precedence: config file, environment, code */
   const char *env_ed = mutt_str_getenv("VISUAL");
@@ -794,8 +794,8 @@ int mutt_init(struct ConfigSet *cs, bool skip_sys_rc, struct ListHead *commands)
       goto done; // TEST14: neomutt -e broken (press 'q')
   }
 
-  const char *const c_tmpdir = cs_subset_path(NeoMutt->sub, "tmpdir");
-  mutt_file_mkdir(c_tmpdir, S_IRWXU);
+  const char *const c_tmp_dir = cs_subset_path(NeoMutt->sub, "tmp_dir");
+  mutt_file_mkdir(c_tmp_dir, S_IRWXU);
 
   mutt_hist_init();
   mutt_hist_read_file();

--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -1417,8 +1417,8 @@ static enum MxStatus mbox_mbox_sync(struct Mailbox *m)
 
     struct Buffer *savefile = mutt_buffer_pool_get();
 
-    const char *const c_tmpdir = cs_subset_path(NeoMutt->sub, "tmpdir");
-    mutt_buffer_printf(savefile, "%s/neomutt.%s-%s-%u", NONULL(c_tmpdir), NONULL(Username),
+    const char *const c_tmp_dir = cs_subset_path(NeoMutt->sub, "tmp_dir");
+    mutt_buffer_printf(savefile, "%s/neomutt.%s-%s-%u", NONULL(c_tmp_dir), NONULL(Username),
                        NONULL(ShortHostname), (unsigned int) getpid());
     rename(mutt_buffer_string(tempfile), mutt_buffer_string(savefile));
     mutt_sig_unblock();

--- a/mutt/file.c
+++ b/mutt/file.c
@@ -1002,8 +1002,8 @@ FILE *mutt_file_mkstemp_full(const char *file, int line, const char *func)
 {
   char name[PATH_MAX] = { 0 };
 
-  const char *const c_tmpdir = cs_subset_path(NeoMutt->sub, "tmpdir");
-  int n = snprintf(name, sizeof(name), "%s/neomutt-XXXXXX", NONULL(c_tmpdir));
+  const char *const c_tmp_dir = cs_subset_path(NeoMutt->sub, "tmp_dir");
+  int n = snprintf(name, sizeof(name), "%s/neomutt-XXXXXX", NONULL(c_tmp_dir));
   if (n < 0)
     return NULL;
 

--- a/mutt_config.c
+++ b/mutt_config.c
@@ -584,7 +584,7 @@ static struct ConfigDef MainVars[] = {
   { "timeout", DT_NUMBER|DT_NOT_NEGATIVE, 600, 0, NULL,
     "Time to wait for user input in menus"
   },
-  { "tmpdir", DT_PATH|DT_PATH_DIR|DT_NOT_EMPTY, IP TMPDIR, 0, NULL,
+  { "tmp_dir", DT_PATH|DT_PATH_DIR|DT_NOT_EMPTY, IP TMPDIR, 0, NULL,
     "Directory for temporary files"
   },
   { "to_chars", DT_MBTABLE|R_INDEX|R_PAGER, IP " +TCFLR", 0, NULL,
@@ -652,6 +652,7 @@ static struct ConfigDef MainVars[] = {
   { "realname",                  DT_SYNONYM, IP "real_name",                  IP "2021-03-21" },
   { "reply_regexp",              DT_SYNONYM, IP "reply_regex",                IP "2021-03-21" },
   { "spoolfile",                 DT_SYNONYM, IP "spool_file",                 IP "2021-03-21" },
+  { "tmpdir",                    DT_SYNONYM, IP "tmp_dir",                    IP "2023-01-25" },
   { "xterm_icon",                DT_SYNONYM, IP "ts_icon_format",             IP "2021-03-21" },
   { "xterm_set_titles",          DT_SYNONYM, IP "ts_enabled",                 IP "2021-03-21" },
   { "xterm_title",               DT_SYNONYM, IP "ts_status_format",           IP "2021-03-21" },

--- a/muttlib.c
+++ b/muttlib.c
@@ -92,8 +92,8 @@ void mutt_adv_mktemp(struct Buffer *buf)
     struct Buffer *prefix = mutt_buffer_pool_get();
     mutt_buffer_strcpy(prefix, buf->data);
     mutt_file_sanitize_filename(prefix->data, true);
-    const char *const c_tmpdir = cs_subset_path(NeoMutt->sub, "tmpdir");
-    mutt_buffer_printf(buf, "%s/%s", NONULL(c_tmpdir), mutt_buffer_string(prefix));
+    const char *const c_tmp_dir = cs_subset_path(NeoMutt->sub, "tmp_dir");
+    mutt_buffer_printf(buf, "%s/%s", NONULL(c_tmp_dir), mutt_buffer_string(prefix));
 
     struct stat st = { 0 };
     if ((lstat(mutt_buffer_string(buf), &st) == -1) && (errno == ENOENT))
@@ -467,8 +467,8 @@ bool mutt_is_text_part(struct Body *b)
 void mutt_buffer_mktemp_full(struct Buffer *buf, const char *prefix,
                              const char *suffix, const char *src, int line)
 {
-  const char *const c_tmpdir = cs_subset_path(NeoMutt->sub, "tmpdir");
-  mutt_buffer_printf(buf, "%s/%s-%s-%d-%d-%" PRIu64 "%s%s", NONULL(c_tmpdir),
+  const char *const c_tmp_dir = cs_subset_path(NeoMutt->sub, "tmp_dir");
+  mutt_buffer_printf(buf, "%s/%s-%s-%d-%d-%" PRIu64 "%s%s", NONULL(c_tmp_dir),
                      NONULL(prefix), NONULL(ShortHostname), (int) getuid(),
                      (int) getpid(), mutt_rand64(), suffix ? "." : "", NONULL(suffix));
 
@@ -495,8 +495,8 @@ void mutt_buffer_mktemp_full(struct Buffer *buf, const char *prefix,
 void mutt_mktemp_full(char *buf, size_t buflen, const char *prefix,
                       const char *suffix, const char *src, int line)
 {
-  const char *const c_tmpdir = cs_subset_path(NeoMutt->sub, "tmpdir");
-  size_t n = snprintf(buf, buflen, "%s/%s-%s-%d-%d-%" PRIu64 "%s%s", NONULL(c_tmpdir),
+  const char *const c_tmp_dir = cs_subset_path(NeoMutt->sub, "tmp_dir");
+  size_t n = snprintf(buf, buflen, "%s/%s-%s-%d-%d-%" PRIu64 "%s%s", NONULL(c_tmp_dir),
                       NONULL(prefix), NONULL(ShortHostname), (int) getuid(),
                       (int) getpid(), mutt_rand64(), suffix ? "." : "", NONULL(suffix));
   if (n >= buflen)

--- a/test/file/mutt_file_mkstemp_full.c
+++ b/test/file/mutt_file_mkstemp_full.c
@@ -31,7 +31,8 @@
 
 static struct ConfigDef Vars[] = {
   // clang-format off
-  { "tmpdir", DT_PATH|DT_PATH_DIR|DT_NOT_EMPTY, IP TMPDIR, 0, NULL, },
+  { "tmp_dir", DT_PATH|DT_PATH_DIR|DT_NOT_EMPTY, IP TMPDIR, 0, NULL, },
+  { "tmpdir", DT_SYNONYM, IP "tmp_dir", IP "2023-01-25" },
   { NULL },
   // clang-format on
 };


### PR DESCRIPTION
Rename `tmpdir` to `tmp_dir` to bring it in line with other `*_dir` config variables like `attach_save_dir`, `autocrypt_dir`, `news_cache_dir`.

A synonym `tmpdir` is provided for backwards compatibility.

This rename can be seen as controversal:

Pro: uniform naming scheme
Con: $TMPDIR (the environment variable) is a well known, well, environment variable and `tmpdir`/`tmp_dir` is closely related.

If you don't like it, then close it.