### PR TITLE
Use the (new) application/pkcs7-* MIME types

### DIFF
--- a/docs/config.c
+++ b/docs/config.c
@@ -4474,7 +4474,7 @@
 /*
 ** .pp
 ** This format string specifies a command which is used to decrypt
-** \fCapplication/x-pkcs7-mime\fP attachments.
+** \fCapplication/pkcs7-mime\fP attachments.
 ** .pp
 ** The OpenSSL command formats have their own set of \fCprintf(3)\fP-like sequences
 ** similar to PGP's:
@@ -4691,7 +4691,7 @@
 /*
 ** .pp
 ** This command is used to verify S/MIME signatures of type
-** \fCapplication/x-pkcs7-mime\fP.
+** \fCapplication/pkcs7-mime\fP.
 ** .pp
 ** This is a format string, see the $$smime_decrypt_command command for
 ** possible \fCprintf(3)\fP-like sequences.

--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -11780,13 +11780,14 @@ set preferred_languages="fr,en,de"
 <emphasis role="comment"># text/x-vcard and application/pgp parts. (PGP parts are already known</emphasis>
 <emphasis role="comment"># to NeoMutt, and can be searched for with ~g, ~G, and ~k.)</emphasis>
 <emphasis role="comment">#</emphasis>
-<emphasis role="comment"># I've added x-pkcs7 to this, since it functions (for S/MIME)</emphasis>
+<emphasis role="comment"># I've added pkcs7/x-pkcs7 to this, since it functions (for S/MIME)</emphasis>
 <emphasis role="comment"># analogously to PGP signature attachments. S/MIME isn't supported</emphasis>
 <emphasis role="comment"># in a stock NeoMutt build, but we can still treat it specially here.</emphasis>
 <emphasis role="comment">#</emphasis>
 attachments  +A */.*
-attachments  -A text/x-vcard application/pgp.*
-attachments  -A application/x-pkcs7-.*
+attachments  -A text/x-vcard
+attachments  -A application/pgp.*
+attachments  -A application/pkcs7-.* application/x-pkcs7-.*
 <emphasis role="comment"># Discount all MIME parts with an "inline" disposition, unless they're</emphasis>
 <emphasis role="comment"># text/plain. (Why inline a text/plain part unless it's external to the</emphasis>
 <emphasis role="comment"># message flow?)</emphasis>

--- a/docs/neomuttrc.head
+++ b/docs/neomuttrc.head
@@ -78,13 +78,14 @@ mime_lookup application/octet-stream
 ## text/x-vcard and application/pgp parts. (PGP parts are already known
 ## to neomutt, and can be searched for with ~g, ~G, and ~k.)
 ##
-## I've added x-pkcs7 to this, since it functions (for S/MIME)
+## I've added pkcs7/x-pkcs7 to this, since it functions (for S/MIME)
 ## analogously to PGP signature attachments. S/MIME isn't supported
 ## in a stock neomutt build, but we can still treat it specially here.
 ##
 attachments   +A */.*
-attachments   -A text/x-vcard application/pgp.*
-attachments   -A application/x-pkcs7-.*
+attachments   -A text/x-vcard
+attachments   -A application/pgp.*
+attachments   -A application/pkcs7-.* application/x-pkcs7-.*
 
 ## Discount all MIME parts with an "inline" disposition, unless they're
 ## text/plain. (Why inline a text/plain part unless it's external to the

--- a/docs/smime-notes.txt
+++ b/docs/smime-notes.txt
@@ -90,5 +90,7 @@ to get a valid certificate outside of neomutt. (See above)
 
 A certificate can be viewed by adding the following to your ~/.mailcap:
 
+application/pkcs7-signature;openssl pkcs7 -in %s -inform der -noout \
+-print_certs -text | less; needsterminal
 application/x-pkcs7-signature;openssl pkcs7 -in %s -inform der -noout \
 -print_certs -text | less; needsterminal

--- a/ncrypt/crypt.c
+++ b/ncrypt/crypt.c
@@ -418,11 +418,9 @@ SecurityFlags mutt_is_multipart_signed(struct Body *b)
     return PGP_SIGN;
   }
 
-  if (((WithCrypto & APPLICATION_SMIME) != 0) && mutt_istr_equal(p, "application/x-pkcs7-signature"))
-  {
-    return SMIME_SIGN;
-  }
-  if (((WithCrypto & APPLICATION_SMIME) != 0) && mutt_istr_equal(p, "application/pkcs7-signature"))
+  if (((WithCrypto & APPLICATION_SMIME) != 0) &&
+      (mutt_istr_equal(p, "application/x-pkcs7-signature") ||
+       mutt_istr_equal(p, "application/pkcs7-signature")))
   {
     return SMIME_SIGN;
   }

--- a/ncrypt/smime.c
+++ b/ncrypt/smime.c
@@ -1451,7 +1451,7 @@ struct Body *smime_class_build_smime_entity(struct Body *a, char *certlist)
 
   t = mutt_body_new();
   t->type = TYPE_APPLICATION;
-  t->subtype = mutt_str_dup("x-pkcs7-mime");
+  t->subtype = mutt_str_dup("pkcs7-mime");
   mutt_param_set(&t->parameter, "name", "smime.p7m");
   mutt_param_set(&t->parameter, "smime-type", "enveloped-data");
   t->encoding = ENC_BASE64; /* The output of OpenSSL SHOULD be binary */
@@ -1635,7 +1635,7 @@ struct Body *smime_class_sign_message(struct Body *a, const struct AddressList *
   mutt_param_set(&t->parameter, "micalg", micalg);
   FREE(&micalg);
 
-  mutt_param_set(&t->parameter, "protocol", "application/x-pkcs7-signature");
+  mutt_param_set(&t->parameter, "protocol", "application/pkcs7-signature");
 
   t->parts = a;
   retval = t;
@@ -1643,7 +1643,7 @@ struct Body *smime_class_sign_message(struct Body *a, const struct AddressList *
   t->parts->next = mutt_body_new();
   t = t->parts->next;
   t->type = TYPE_APPLICATION;
-  t->subtype = mutt_str_dup("x-pkcs7-signature");
+  t->subtype = mutt_str_dup("pkcs7-signature");
   t->filename = mutt_buffer_strdup(signedfile);
   t->d_filename = mutt_str_dup("smime.p7s");
   t->use_disp = true;


### PR DESCRIPTION
Do not generate the legacy MIME types application/x-pkcs7-* (note the "x-") but the standardised types application/pkcs7-*.

The application/pkcs7-* MIME types are standardised in [RFC8551] section 3.2.  The (historic) [RFC2311] states in section C.1

   Some early implementations of S/MIME agents used the following MIME
   types:

   application/x-pkcs7-mime
   application/x-pkcs7-signature
   application/x-pkcs10

   In each case, the "x-" subtypes correspond to the subtypes described
   in this document without the "x-".

[RFC8551] https://datatracker.ietf.org/doc/rfc8551/
[RFC2311] https://datatracker.ietf.org/doc/rfc2311/
