### PR TITLE
Update style and comments in the default neomuttrc

### DIFF
--- a/docs/neomuttrc.head
+++ b/docs/neomuttrc.head
@@ -52,56 +52,49 @@ bind editor <delete> delete-char
 # be undone with unmime_lookup.
 mime_lookup application/octet-stream
 
-##
-## *** DEFAULT SETTINGS FOR THE ATTACHMENTS PATCH ***
-##
+# Please see the manual (section "attachments")  for detailed
+# documentation of the "attachments" command.
+#
+# Removing a pattern from a list removes that pattern literally. It
+# does not remove any type matching the pattern.
+#
+#  attachments   +A */.*
+#  attachments   +A image/jpeg
+#  unattachments +A */.*
+#
+# This leaves "attached" image/jpeg files on the allowed attachments
+# list. It does not remove all items, as you might expect, because the
+# second */.* is not a matching expression at this time.
+#
+# Remember: "unattachments" only undoes what "attachments" has done!
+# It does not trigger any matching on actual messages.
 
-##
-## Please see the manual (section "attachments")  for detailed
-## documentation of the "attachments" command.
-##
-## Removing a pattern from a list removes that pattern literally. It
-## does not remove any type matching the pattern.
-##
-##  attachments   +A */.*
-##  attachments   +A image/jpeg
-##  unattachments +A */.*
-##
-## This leaves "attached" image/jpeg files on the allowed attachments
-## list. It does not remove all items, as you might expect, because the
-## second */.* is not a matching expression at this time.
-##
-## Remember: "unattachments" only undoes what "attachments" has done!
-## It does not trigger any matching on actual messages.
-
-## Qualify any MIME part with an "attachment" disposition, EXCEPT for
-## text/x-vcard, application/pgp.*, application/pkcs7-.* and
-## application/x-pkcs7-.* parts. (PGP and S/MIME parts are already known
-## to NeoMutt, and can be searched for with ~g, ~G, and ~k.)
+# Qualify any MIME part with an "attachment" disposition, EXCEPT for
+# text/x-vcard, application/pgp.*, application/pkcs7-.* and
+# application/x-pkcs7-.* parts. (PGP and S/MIME parts are already known
+# to NeoMutt, and can be searched for with ~g, ~G, and ~k.)
 attachments   +A */.*
 attachments   -A text/x-vcard
 attachments   -A application/pgp.*
 attachments   -A application/pkcs7-.* application/x-pkcs7-.*
 
-## Discount all MIME parts with an "inline" disposition, unless they're
-## text/plain. (Why inline a text/plain part unless it's external to the
-## message flow?)
-##
+# Discount all MIME parts with an "inline" disposition, unless they're
+# text/plain. (Why inline a text/plain part unless it's external to the
+# message flow?)
 attachments   +I text/plain
 
-## These two lines make NeoMutt qualify MIME containers.  (So, for example,
-## a message/rfc822 forward will count as an attachment.)  The first
-## line is unnecessary if you already have "attach-allow */.*", of
-## course.  These are off by default!  The MIME elements contained
-## within a message/* or multipart/* are still examined, even if the
-## containers themselves don't qualify.
-## Recursion into multipart/alternatives containers is controlled by the
-## $count_alternatives setting.
-##
+# These two lines make NeoMutt qualify MIME containers.  (So, for example,
+# a message/rfc822 forward will count as an attachment.)  The first
+# line is unnecessary if you already have "attach-allow */.*", of
+# course.  These are off by default!  The MIME elements contained
+# within a message/* or multipart/* are still examined, even if the
+# containers themselves don't qualify.
+# Recursion into multipart/alternatives containers is controlled by the
+# $count_alternatives setting.
 #attachments  +A message/.* multipart/.*
 #attachments  +I message/.* multipart/.*
 
-## You probably don't really care to know about deleted attachments.
+# You probably don't really care to know about deleted attachments.
 attachments   -A message/external-body
 attachments   -I message/external-body
 

--- a/docs/neomuttrc.head
+++ b/docs/neomuttrc.head
@@ -75,13 +75,9 @@ mime_lookup application/octet-stream
 ## It does not trigger any matching on actual messages.
 
 ## Qualify any MIME part with an "attachment" disposition, EXCEPT for
-## text/x-vcard and application/pgp parts. (PGP parts are already known
-## to neomutt, and can be searched for with ~g, ~G, and ~k.)
-##
-## I've added pkcs7/x-pkcs7 to this, since it functions (for S/MIME)
-## analogously to PGP signature attachments. S/MIME isn't supported
-## in a stock neomutt build, but we can still treat it specially here.
-##
+## text/x-vcard, application/pgp.*, application/pkcs7-.* and
+## application/x-pkcs7-.* parts. (PGP and S/MIME parts are already known
+## to NeoMutt, and can be searched for with ~g, ~G, and ~k.)
 attachments   +A */.*
 attachments   -A text/x-vcard
 attachments   -A application/pgp.*


### PR DESCRIPTION
**WARNING This patch is intended to be on top of PR #3634**

To save me and you from some merge conflicts I made this adjustments after the correction to the MIME type application/pkcs7-*.  However, I was not able to figure out how to tell GitHub that this comes after that PR. So this also includes the commit of PR #3634.

---

* **What does this PR do?**

Reword the comments around the handling of attachments with respect to application/pkcs7-

Also update the style to reflect the other comments and get rid of artefacts from a time long gone, where attachment handling was a separate patch to Mutt. 