### PR TITLE
Document additional quirks of the `attachments` command

### DIFF
--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -11762,6 +11762,13 @@ set preferred_languages="fr,en,de"
         actually evaluating a message.
       </para>
       <para>
+        Note that the first MIME part is treated slightly differently: It is
+        almost always the message text.  Thus, it is not counted as an
+        attachment if its disposition is <literal>inline</literal> and it is
+        not a <literal>multipart/*</literal> or <literal>message/*</literal>
+        MIME-type.
+      </para>
+      <para>
         Some examples might help to illustrate. The examples that are not
         commented out define the default configuration of the lists.
       </para>

--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -11701,6 +11701,9 @@ set preferred_languages="fr,en,de"
         <arg choice="plain">
           <replaceable>mime-type</replaceable>
         </arg>
+        <arg choice="opt" rep="repeat">
+          <replaceable>mime-type</replaceable>
+        </arg>
         <command>unattachments</command>
         <group choice="req">
           <arg choice="plain">+</arg>
@@ -11710,6 +11713,9 @@ set preferred_languages="fr,en,de"
           <replaceable>disposition</replaceable>
         </arg>
         <arg choice="plain">
+          <replaceable>mime-type</replaceable>
+        </arg>
+        <arg choice="opt" rep="repeat">
           <replaceable>mime-type</replaceable>
         </arg>
         <command>attachments</command>
@@ -19411,6 +19417,9 @@ neomutt mailto:some@one.org?subject=test&amp;cc=other@one.org
             <arg choice="plain">
               <replaceable>mime-type</replaceable>
             </arg>
+            <arg choice="opt" rep="repeat">
+              <replaceable>mime-type</replaceable>
+            </arg>
             <command>
               <link linkend="attachments">unattachments</link>
             </command>
@@ -19422,6 +19431,9 @@ neomutt mailto:some@one.org?subject=test&amp;cc=other@one.org
               <replaceable>disposition</replaceable>
             </arg>
             <arg choice="plain">
+              <replaceable>mime-type</replaceable>
+            </arg>
+            <arg choice="opt" rep="repeat">
               <replaceable>mime-type</replaceable>
             </arg>
             <command>

--- a/docs/neomuttrc.man.head
+++ b/docs/neomuttrc.man.head
@@ -180,6 +180,11 @@ of \fImime-type\fP must be literal text (or the special token \(lq\fB*\fP\(rq,
 but the minor part may be a regular expression. Therefore, \(lq\fB*/.*\fP\(rq
 matches any MIME type.
 .IP
+Note that the first MIME part is treated slightly differently: It is almost
+always the message text.  Thus, it is not counted as an attachment if its
+disposition is \fBinline\fP and it is not a \fBmultipart/*\fP or
+\fBmessage/*\fP MIME-type.
+.IP
 Entering the command \(lq\fBattachments ?\fP\(rq as a command will list your
 current settings in neomuttrc format, so that it can be pasted elsewhere.
 .IP

--- a/docs/neomuttrc.man.head
+++ b/docs/neomuttrc.man.head
@@ -154,8 +154,8 @@ entire list when \(lq\fB*\fP\(rq is used as an argument.
 .
 .PP
 .nf
-\fBattachments\fP { \fB+\fP | \fB\-\fP }\fIdisposition\fP \fImime-type\fP
-\fBunattachments\fP { \fB+\fP | \fB\-\fP }\fIdisposition\fP \fImime-type\fP
+\fBattachments\fP { \fB+\fP | \fB\-\fP }\fIdisposition\fP \fImime-type\fP [ \fImime-type\fP ... ]
+\fBunattachments\fP { \fB+\fP | \fB\-\fP }\fIdisposition\fP \fImime-type\fP [ \fImime-type\fP ... ]
 \fBattachments\fP \fB?\fP
 \fBunattachments\fP \fB*\fP
 .fi


### PR DESCRIPTION
1) `attachments` and `unattachments` can take more than one MIME type
2) When counting attachments the first MIME part is treated slightly differently, we document this.

**Note** maybe the algorithm for the exceptions of the first MIME part is documented to precisely.  Maybe it suffices to just say:

> "The first MIME part is treated slightly differently because it is almost always the message text."
