### PR TITLE
Document handling of `source` command inside hooks

### DIFF
--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -7177,19 +7177,12 @@ mailboxes $my_mx +mailbox3
       </para>
       <note>
         <para>
-          Commands of a hook like
-          <link linkend="folder-hook"><command>folder-hook</command></link>
-          are not executed when being read from the configuration file but
-          later at runtime when they are triggered. Thus, relative paths in
-          hooks are interpreted relative to the current working directory and
-          not relative to the configuration file the hook was defined in.
-        </para>
-        <para>
-          For example: the hook defined with
-          <screen>folder-hook foo "source foo.rc"</screen>
-          in the file <literal>~/.config/neomutt/neomuttrc</literal> sources
-          the file <literal>$CWD/foo.rc</literal> and not
-          <literal>~/.config/neomutt/foo.rc</literal>.
+          A hook remembers the configuration file it was defined in and sets the
+          context to that file when executing its commands.  As a result
+          a <command>source</command> command inside a hook is executed in the
+          context of the configuration file the hook was defined in.  Thus
+          relative filenames are interpreted relative to the configuration file
+          the hook is defined in.
         </para>
       </note>
       <para>

--- a/docs/neomuttrc.man.head
+++ b/docs/neomuttrc.man.head
@@ -800,6 +800,19 @@ the path of your home directory.
 If the \fIfilename\fP ends with a vertical bar (\(lq|\(rq), then \fIfilename\fP
 is considered to be an executable program from which to read input, (e.g.
 \(lq\fBsource\fP\~\fI~/\:bin/\:myscript\fP|\(rq).
+.IP
+If the filename is relative and the command \fBsource\fP is executed from the
+context of a configuration file, then the filename is interpreted relative to
+the directory of that configuration file.  If the command is executed outside
+of a configuration file, e.g. from the prompt, then the filename is interpreted
+relative to the current working directory (see \fBcd\fP on how to change the
+current working directory at runtime).
+.IP
+Note: A hook remembers the configuration file it was defined in and sets the
+context to that file when executing its commands.  As a result a \fBsource\fP command
+inside a hook is executed in the context of the configuration file the hook was
+defined in.  Thus relative filenames are interpreted relative to the
+configuration file the hook is defined in.
 .
 .PP
 .nf


### PR DESCRIPTION
Since eb48fd1368b5d821a74708963aff45f61b709a4b hook store the file context they are defined in and restore that context when they execute their commands.  As a result a source command inside a hook is executed with the context of the file the hook was defined in.  Thus, relative filenames are interpreted relative to the source file the hook was defined in.
