### PR TITLE
Implement `Smime:` pseudo header for composing

### DIFF
--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -3012,6 +3012,27 @@ color sidebar_divider   color8  default     <emphasis role="comment"># Dark grey
           </para>
         </sect3>
 
+        <sect3 id="smime-header">
+          <title>Smime: Pseudo Header</title>
+          <para>
+            If you want to use S/MIME, you can specify
+          </para>
+          <para>
+            <literal>Smime:</literal> [
+            <literal>E</literal> |
+            <literal>S</literal> |
+            <literal>S</literal>
+            <emphasis>&lt;id&gt;</emphasis> ]
+          </para>
+          <para>
+            <quote>E</quote> selects encryption, <quote>S</quote> selects signing
+            and <quote>S&lt;id&gt;</quote> selects signing with the given key,
+            setting <link linkend="smime-sign-as">$smime_sign_as</link> for the
+            duration of the message composition session. The selection can later
+            be changed in the compose menu.
+          </para>
+        </sect3>
+
         <sect3 id="in-reply-to-header">
           <title>In-Reply-To: Header</title>
           <para>

--- a/mutt_header.c
+++ b/mutt_header.c
@@ -281,7 +281,7 @@ void mutt_edit_headers(const char *editor, const char *body, struct Email *e,
   mutt_expand_aliases_env(e->env);
 
   /* search through the user defined headers added to see if
-   * fcc: or attach: or pgp: was specified */
+   * fcc: or attach: or pgp: or smime: was specified */
 
   struct ListNode *np = NULL, *tmp = NULL;
   STAILQ_FOREACH_SAFE(np, &e->env->userhdrs, entries, tmp)
@@ -344,6 +344,19 @@ void mutt_edit_headers(const char *editor, const char *body, struct Email *e,
       SecurityFlags sec = mutt_parse_crypt_hdr(np->data + plen, false, APPLICATION_PGP);
       if (sec != SEC_NO_FLAGS)
         sec |= APPLICATION_PGP;
+      if (sec != e->security)
+      {
+        e->security = sec;
+        notify_send(e->notify, NT_EMAIL, NT_EMAIL_CHANGE, NULL);
+      }
+      keep = false;
+    }
+    else if (((WithCrypto & APPLICATION_SMIME) != 0) &&
+             (plen = mutt_istr_startswith(np->data, "smime:")))
+    {
+      SecurityFlags sec = mutt_parse_crypt_hdr(np->data + plen, false, APPLICATION_SMIME);
+      if (sec != SEC_NO_FLAGS)
+        sec |= APPLICATION_SMIME;
       if (sec != e->security)
       {
         e->security = sec;


### PR DESCRIPTION
When composing messages NeoMutt supports some pseudo headers like "Attach:" or "Pgp:".

Implement the "Smime:" header which allows to select S/MIME encryption/signing just like the "Pgp:" header. The valid values for the header are the same as for "Pgp:", namely "E" (encrypt), "S" (sign), and "S <id>" (sign as).

* **What does this PR do?**

Brings support of S/MIME closer on par with PGP.

* **Rambling Notes**

I noticed that postponed mails have an "X-Mutt-PGP:", "X-Mutt-SMIME:" header.  Maybe it might be worth supporting those too when composing a message? (maybe even saying that those should be used as they avoid ambiguity??)