### PR TITLE
Fix `$pager_read_delay`

### DIFF
--- a/pager/dlg_pager.c
+++ b/pager/dlg_pager.c
@@ -574,10 +574,6 @@ int mutt_pager(struct PagerView *pview)
   // END OF ACT 3: Read user input loop - while (op != OP_ABORT)
   //-------------------------------------------------------------------------
 
-  if (check_read_delay(&priv->delay_read_timestamp))
-  {
-    mutt_set_flag(shared->mailbox, shared->email, MUTT_READ, true);
-  }
   mutt_file_fclose(&priv->fp);
   if (pview->mode == PAGER_MODE_EMAIL)
   {


### PR DESCRIPTION
* **What does this PR do?**

I don't understand the event loop (nor the "multi"threading) between pager and index fully.  However, the timer check should be done *after* the statement which takes the idle time, here waiting for user input.  They should also done *before* handling the operations as those can alter the internal state (like the current mail) leading to bugs such as #3609.

Alternatively, we can do the timer check at the end of the loop. To this end, we have to introduce two local variables `cur_mail`, `cur_mailbox` set them at the beginning of the loop and use those cached values at the end of the loop in the timer check (the `mutt_set_flag` call).

Please check if this does not break any other invariant other parts of the code relay upon.

Fixes #3609.
