### PR TITLE
Document the suffix querying syntax for config variables

### DIFF
--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -6921,6 +6921,13 @@ set spam_separator=", "
           <arg choice="opt" rep="repeat">
             <replaceable class="parameter">variable</replaceable>
           </arg>
+          <command>set</command>
+          <arg choice="plain">
+            <replaceable class="parameter">variable</replaceable>
+          </arg>
+          <arg choice="plain">
+            <option>?</option>
+          </arg>
         </cmdsynopsis>
         <para>
           This command is used to set (and unset)
@@ -6975,6 +6982,10 @@ set spam_separator=", "
           mark:
         </para>
         <screen>set allow_8bit?</screen>
+        <para>
+          The old prefix query syntax (<literal><command>set</command>
+          ?allow_8bit</literal>) is also still supported.
+        </para>
         <para>
           The question mark is actually only required for boolean and
           quadoption variables.

--- a/docs/neomuttrc.man.head
+++ b/docs/neomuttrc.man.head
@@ -726,6 +726,7 @@ the list of all score entries.
 \fBunset\fP \fIvariable\fP  [ \fIvariable\fP ... ]
 \fBreset\fP \fIvariable\fP  [ \fIvariable\fP ... ]
 \fBtoggle\fP \fIvariable\fP [ \fIvariable\fP ... ]
+\fBset\fP \fIvariable\fP \fB?\fP
 .fi
 .IP
 These commands are used to set and manipulate configuration \fIvariable\fPs.
@@ -764,8 +765,10 @@ defaults. With the \fBreset\fP command there exists the special \fIvariable\fP
 defaults.
 .IP
 Using the <\fBenter-command\fP> function, you can query the \fIvalue\fP of
-a \fIvariable\fP by prefixing the name of the \fIvariable\fP with a question
-mark: \(dq:\fBset\~?\fPallow_8bit\(dq.
+a \fIvariable\fP by suffixing the name of the \fIvariable\fP with a question
+mark: \(dq:\fBset\fP\~allow_8bit\fB?\fP\(dq.
+The old prefix query syntax (\(dq:\fBset\fP\~\fB?\fPallow_8bit\(dq) is also
+still supported.
 .
 .PP
 .nf


### PR DESCRIPTION
As of 7d01b8c2dac8f3497e714b95625010fcafae5296 the suffix version (`set allow_8bit?`) is preferred over the prefix version (`set ?allow_8bit`).

Document the querying syntax with a suffix ``?``, e.g.

   :set allow_8bit?

prominently and note that the old prefix syntax is still supported.
