### PR TITLE
Fix negative new count on maildir

### DIFF
--- a/maildir/maildir.c
+++ b/maildir/maildir.c
@@ -1345,13 +1345,13 @@ static enum MxStatus maildir_mbox_check_stats(struct Mailbox *m, uint8_t flags)
 {
   bool check_stats = flags & MUTT_MAILBOX_CHECK_FORCE_STATS;
   bool check_new = true;
+  m->msg_new = 0;
 
   if (check_stats)
   {
     m->msg_count = 0;
     m->msg_unread = 0;
     m->msg_flagged = 0;
-    m->msg_new = 0;
   }
 
   maildir_check_dir(m, "new", check_new, check_stats);


### PR DESCRIPTION
Reset `m->msg_new` to zero unconditionally, because `check_new` triggers a recomputation of it.

Fixes #3649