### PR TITLE
Skip zero width non-joiner in the pager

### DIFF
--- a/pager/display.c
+++ b/pager/display.c
@@ -840,8 +840,8 @@ static int format_line(struct MuttWindow *win, struct Line **lines, int line_num
 
     if (CharsetIsUtf8)
     {
-      /* zero width space, zero width no-break space */
-      if ((wc == 0x200B) || (wc == 0xFEFF))
+      /* zero width space, zero with non-joiner, zero width no-break space */
+      if ((wc == 0x200B) || (wc == 0x200C) || (wc == 0xFEFF))
       {
         mutt_debug(LL_DEBUG3, "skip zero-width character U+%04X\n", (unsigned short) wc);
         continue;


### PR DESCRIPTION
Fixes #3580

Upstream-commit: https://gitlab.com/muttmua/mutt/-/commit/a60b22fe2a250f87769239b6120c2ff5de751b28