### PR TITLE
Rename sidebar_whitelist to sidebar_pin

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -541,7 +541,7 @@
   - fix resize bugs
   - notmuch: fix entire-thread: update current email pointer
   - sidebar: support indenting and shortening of names
-  - Handle variables inside backticks in sidebar_whitelist
+  - Handle variables inside backticks in sidebar_pin
   - browser: fix mask regex error reporting
 * Translations
   - 100.00% Lithuanian
@@ -1635,7 +1635,7 @@
   - Pass envlist to filter children too
   - Fix mutt_envlist_set() for the case that envlist is null
   - Fix setenv overwriting to not truncate the envlist
-  - Fix (un)sidebar_whitelist to expand paths
+  - Fix (un)sidebar_pin to expand paths
   - Fix mutt_refresh() pausing during macro events
   - Add a menu stack to track current and past menus
   - Change CurrentMenu to be controlled by the menu stack
@@ -1678,7 +1678,7 @@
   - Set refresh when popping the menu stack
   - Remove redraw parameter from crypt send_menus
   - Don't full redraw the index when handling a command from the pager
-  - Fix (un)sidebar_whitelist to expand paths
+  - Fix (un)sidebar_pin to expand paths
   - Filter other directional markers that corrupt the screen
   - Remove the OPTFORCEREDRAW options
   - Remove SidebarNeedsRedraw
@@ -2006,7 +2006,7 @@
   - forgotten-attachment: Fix checking logic.
   - forgotten-attachment: Update docs regarding $quote_regex.
   - notmuch: Add a fake "Folder" header to viewed emails
-  - sidebar: consider description when using whitelist
+  - sidebar: consider description when using pinning
   - skip-quoted: skip to body
 * Bug Fixes
   - sensible-browser/notmuch changing mailbox
@@ -2123,7 +2123,7 @@
   - docs: mass tidy up
 * Upstream
   - Fix sidebar documentation a bit
-  - Add unsidebar_whitelist command
+  - Add sidebar_pin command
   - Remove the $locale configuration variable
   - Add $attribution_locale configuration variable
   - Add missing include \<locale.h\> to send.c and edit.c

--- a/alternates.c
+++ b/alternates.c
@@ -40,7 +40,7 @@
 #include "init.h"
 
 struct RegexList Alternates = STAILQ_HEAD_INITIALIZER(Alternates); ///< List of regexes to match the user's alternate email addresses
-struct RegexList UnAlternates = STAILQ_HEAD_INITIALIZER(UnAlternates); ///< List of regexes to blacklist false matches in Alternates
+struct RegexList UnAlternates = STAILQ_HEAD_INITIALIZER(UnAlternates); ///< List of regexes to exclude false matches in Alternates
 static struct Notify *AlternatesNotify = NULL;
 
 /**

--- a/docs/config.c
+++ b/docs/config.c
@@ -4262,7 +4262,7 @@
 ** When set, the sidebar will only display mailboxes containing new, or
 ** flagged, mail.
 ** .pp
-** \fBSee also:\fP $sidebar_whitelist, $$sidebar_non_empty_mailbox_only.
+** \fBSee also:\fP $sidebar_pin, $$sidebar_non_empty_mailbox_only.
 */
 
 { "sidebar_next_new_wrap", DT_BOOL, false },
@@ -4279,7 +4279,7 @@
 ** .pp
 ** When set, the sidebar will only display mailboxes that contain one or more mails.
 ** .pp
-** \fBSee also:\fP $$sidebar_new_mail_only, $sidebar_whitelist.
+** \fBSee also:\fP $$sidebar_new_mail_only, $sidebar_pin.
 */
 
 { "sidebar_on_right", DT_BOOL, false },

--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -532,7 +532,7 @@ Cars            4|  3    + Feb 28  Imogen Baker     (193)  Pechora Sea
             </listitem>
             <listitem>
               <para>
-                Whitelist mailboxes to display always
+                Pin mailboxes to display always
               </para>
             </listitem>
           </itemizedlist>
@@ -1056,13 +1056,13 @@ set sidebar_indent_string="  "          <emphasis role="comment"># Indent with t
             </para>
             <para>
               If you want some mailboxes to be always visible, then use the
-              <literal>sidebar_whitelist</literal> command. It takes a list of
+              <literal>sidebar_pin</literal> command. It takes a list of
               mailboxes as parameters.
             </para>
 
 <screen>
-set sidebar_new_mail_only               <emphasis role="comment"># Only mailboxes with new/flagged email</emphasis>
-sidebar_whitelist +fruit +fruit/apple   <emphasis role="comment"># Always display these two mailboxes</emphasis>
+set sidebar_new_mail_only         <emphasis role="comment"># Only mailboxes with new/flagged email</emphasis>
+sidebar_pin +fruit +fruit/apple   <emphasis role="comment"># Always display these two mailboxes</emphasis>
 </screen>
 
           </sect4>
@@ -17312,17 +17312,17 @@ set sort_browser="reverse-size"
 
       <sect2 id="sidebar-commands">
         <title>Commands</title>
-        <anchor id="sidebar-whitelist" />
-        <anchor id="unsidebar-whitelist" />
+        <anchor id="sidebar-pin" />
+        <anchor id="sidebar-unpin" />
         <cmdsynopsis>
-          <command>sidebar_whitelist</command>
+          <command>sidebar_pin</command>
           <arg choice="plain">
             <replaceable class="parameter">mailbox</replaceable>
           </arg>
           <arg choice="opt" rep="repeat">
             <replaceable class="parameter">mailbox</replaceable>
           </arg>
-          <command>unsidebar_whitelist</command>
+          <command>sidebar_unpin</command>
           <group choice="req">
             <arg choice="plain">
               <replaceable class="parameter">*</replaceable>
@@ -17339,9 +17339,9 @@ set sort_browser="reverse-size"
           is set and the mailbox does not contain new mail.
         </para>
         <para>
-          The <quote>unsidebar_whitelist</quote> command is used to remove
-          a mailbox from the list of whitelisted mailboxes. Use
-          <quote>unsidebar_whitelist&#160;*</quote> to remove all mailboxes.
+          The <quote>sidebar_unpin</quote> command is used to remove
+          a mailbox from the list of always displayed mailboxes. Use
+          <quote>sidebar_unpin&#160;*</quote> to remove all mailboxes.
         </para>
       </sect2>
 
@@ -17510,12 +17510,12 @@ set sidebar_indent_string = '  '
 <emphasis role="comment"># Make the Sidebar only display mailboxes that contain new, or flagged,</emphasis>
 <emphasis role="comment"># mail.</emphasis>
 set sidebar_new_mail_only = no
-<emphasis role="comment"># Any mailboxes that are whitelisted will always be visible, even if the</emphasis>
+<emphasis role="comment"># Any mailboxes that are pinned will always be visible, even if the</emphasis>
 <emphasis role="comment"># sidebar_new_mail_only option is enabled.</emphasis>
 set sidebar_non_empty_mailbox_only = no
 <emphasis role="comment"># Only show mailboxes that contain some mail</emphasis>
-sidebar_whitelist '/home/user/mailbox1'
-sidebar_whitelist '/home/user/mailbox2'
+sidebar_pin '/home/user/mailbox1'
+sidebar_pin '/home/user/mailbox2'
 <emphasis role="comment"># When searching for mailboxes containing new mail, should the search wrap</emphasis>
 <emphasis role="comment"># around when it reaches the end of the list?</emphasis>
 set sidebar_next_new_wrap = no
@@ -20358,7 +20358,7 @@ neomutt mailto:some@one.org?subject=test&amp;cc=other@one.org
         <listitem>
           <cmdsynopsis>
             <command>
-              <link linkend="sidebar-whitelist">sidebar_whitelist</link>
+              <link linkend="sidebar-pin">sidebar_pin</link>
             </command>
             <arg choice="plain">
               <replaceable class="parameter">mailbox</replaceable>
@@ -20367,7 +20367,7 @@ neomutt mailto:some@one.org?subject=test&amp;cc=other@one.org
               <replaceable class="parameter">mailbox</replaceable>
             </arg>
             <command>
-              <link linkend="sidebar-whitelist">unsidebar_whitelist</link>
+              <link linkend="sidebar-pin">sidebar_unpin</link>
             </command>
             <group choice="req">
               <arg choice="plain">

--- a/docs/neomuttrc.man.head
+++ b/docs/neomuttrc.man.head
@@ -784,17 +784,17 @@ You can also query current environment \fIvalue\fPs by prefixing a
 .
 .PP
 .nf
-\fBsidebar_whitelist\fP \fImailbox\fP [ \fImailbox\fP ...]
-\fBunsidebar_whitelist\fP { \fB*\fP | \fImailbox\fP ... }
+\fBsidebar_pin\fP \fImailbox\fP [ \fImailbox\fP ...]
+\fBsidebar_unpin\fP { \fB*\fP | \fImailbox\fP ... }
 .fi
 .IP
-The \fBsidebar_whitelist\fP command specifies \fImailbox\fPes that will always
+The \fBsidebar_pin\fP command specifies \fImailbox\fPes that will always
 be displayed in the sidebar, even if $sidebar_new_mail_only is set and the
 \fImailbox\fP does not contain new mail.
 .IP
-The \fBunsidebar_whitelist\fP command is used to remove a \fImailbox\fP from
-the list of whitelisted \fImailbox\fPes. Use
-\(lq\fBunsidebar_whitelist\~*\fP\(rq to remove all \fImailbox\fPes.
+The \fBsidebar_unpin\fP command is used to remove a \fImailbox\fP from
+the list of always displayed \fImailbox\fPes. Use
+\(lq\fBsidebar_unpin\~*\fP\(rq to remove all \fImailbox\fPes.
 .
 .PP
 .nf

--- a/email/globals.h
+++ b/email/globals.h
@@ -33,9 +33,9 @@ extern struct ReplaceList SpamList;         ///< List of regexes and patterns to
 extern struct ListHead UnIgnore;            ///< List of header patterns to unignore (see)
 extern struct ListHead MailToAllow;         ///< List of permitted fields in a mailto: url
 extern struct HashTable *AutoSubscribeCache;///< Hash Table of auto-subscribed mailing lists
-extern struct RegexList UnSubscribedLists;  ///< List of regexes to blacklist false matches in SubscribedLists
+extern struct RegexList UnSubscribedLists;  ///< List of regexes to exclude false matches in SubscribedLists
 extern struct RegexList MailLists;          ///< List of regexes to match mailing lists
-extern struct RegexList UnMailLists;        ///< List of regexes to blacklist false matches in MailLists
+extern struct RegexList UnMailLists;        ///< List of regexes to exclude false matches in MailLists
 extern struct RegexList SubscribedLists;    ///< List of regexes to match subscribed mailing lists
 
 #endif /* MUTT_EMAIL_GLOBALS_H */

--- a/email/globals.h
+++ b/email/globals.h
@@ -28,7 +28,7 @@
 
 /* Global variables */
 extern struct ListHead Ignore;              ///< List of header patterns to ignore
-extern struct RegexList NoSpamList;         ///< List of regexes to whitelist non-spam emails
+extern struct RegexList NoSpamList;         ///< List of regexes to identify non-spam emails
 extern struct ReplaceList SpamList;         ///< List of regexes and patterns to match spam emails
 extern struct ListHead UnIgnore;            ///< List of header patterns to unignore (see)
 extern struct ListHead MailToAllow;         ///< List of permitted fields in a mailto: url

--- a/sidebar/commands.c
+++ b/sidebar/commands.c
@@ -36,10 +36,10 @@
 #include "muttlib.h"
 
 /**
- * sb_parse_whitelist - Parse the 'sidebar_pin' command - Implements Command::parse() - @ingroup command_parse
+ * sb_parse_sidebar_pin - Parse the 'sidebar_pin' command - Implements Command::parse() - @ingroup command_parse
  */
-enum CommandResult sb_parse_whitelist(struct Buffer *buf, struct Buffer *s,
-                                      intptr_t data, struct Buffer *err)
+enum CommandResult sb_parse_sidebar_pin(struct Buffer *buf, struct Buffer *s,
+                                        intptr_t data, struct Buffer *err)
 {
   struct Buffer *path = mutt_buffer_pool_get();
 
@@ -55,10 +55,10 @@ enum CommandResult sb_parse_whitelist(struct Buffer *buf, struct Buffer *s,
 }
 
 /**
- * sb_parse_unwhitelist - Parse the 'sidebar_unpin' command - Implements Command::parse() - @ingroup command_parse
+ * sb_parse_sidebar_unpin - Parse the 'sidebar_unpin' command - Implements Command::parse() - @ingroup command_parse
  */
-enum CommandResult sb_parse_unwhitelist(struct Buffer *buf, struct Buffer *s,
-                                        intptr_t data, struct Buffer *err)
+enum CommandResult sb_parse_sidebar_unpin(struct Buffer *buf, struct Buffer *s,
+                                          intptr_t data, struct Buffer *err)
 {
   struct Buffer *path = mutt_buffer_pool_get();
 

--- a/sidebar/commands.c
+++ b/sidebar/commands.c
@@ -47,7 +47,7 @@ enum CommandResult sb_parse_sidebar_pin(struct Buffer *buf, struct Buffer *s,
   {
     mutt_extract_token(path, s, MUTT_TOKEN_BACKTICK_VARS);
     mutt_buffer_expand_path(path);
-    add_to_stailq(&SidebarWhitelist, mutt_buffer_string(path));
+    add_to_stailq(&SidebarPinned, mutt_buffer_string(path));
   } while (MoreArgs(s));
   mutt_buffer_pool_release(&path);
 
@@ -68,11 +68,11 @@ enum CommandResult sb_parse_sidebar_unpin(struct Buffer *buf, struct Buffer *s,
     /* Check for deletion of entire list */
     if (mutt_str_equal(mutt_buffer_string(path), "*"))
     {
-      mutt_list_free(&SidebarWhitelist);
+      mutt_list_free(&SidebarPinned);
       break;
     }
     mutt_buffer_expand_path(path);
-    remove_from_stailq(&SidebarWhitelist, mutt_buffer_string(path));
+    remove_from_stailq(&SidebarPinned, mutt_buffer_string(path));
   } while (MoreArgs(s));
   mutt_buffer_pool_release(&path);
 

--- a/sidebar/commands.c
+++ b/sidebar/commands.c
@@ -36,7 +36,7 @@
 #include "muttlib.h"
 
 /**
- * sb_parse_whitelist - Parse the 'sidebar_whitelist' command - Implements Command::parse() - @ingroup command_parse
+ * sb_parse_whitelist - Parse the 'sidebar_pin' command - Implements Command::parse() - @ingroup command_parse
  */
 enum CommandResult sb_parse_whitelist(struct Buffer *buf, struct Buffer *s,
                                       intptr_t data, struct Buffer *err)
@@ -55,7 +55,7 @@ enum CommandResult sb_parse_whitelist(struct Buffer *buf, struct Buffer *s,
 }
 
 /**
- * sb_parse_unwhitelist - Parse the 'unsidebar_whitelist' command - Implements Command::parse() - @ingroup command_parse
+ * sb_parse_unwhitelist - Parse the 'sidebar_unpin' command - Implements Command::parse() - @ingroup command_parse
  */
 enum CommandResult sb_parse_unwhitelist(struct Buffer *buf, struct Buffer *s,
                                         intptr_t data, struct Buffer *err)

--- a/sidebar/observer.c
+++ b/sidebar/observer.c
@@ -250,7 +250,7 @@ static int sb_command_observer(struct NotifyCallback *nc)
 
   struct Command *cmd = nc->event_data;
 
-  if ((cmd->parse != sb_parse_whitelist) && (cmd->parse != sb_parse_unwhitelist))
+  if ((cmd->parse != sb_parse_sidebar_pin) && (cmd->parse != sb_parse_sidebar_unpin))
     return 0;
 
   struct MuttWindow *win = nc->global_data;

--- a/sidebar/private.h
+++ b/sidebar/private.h
@@ -84,8 +84,8 @@ void sb_set_current_mailbox(struct SidebarWindowData *wdata, struct Mailbox *m);
 struct Mailbox *sb_get_highlight(struct MuttWindow *win);
 
 // commands.c
-enum CommandResult sb_parse_unwhitelist(struct Buffer *buf, struct Buffer *s, intptr_t data, struct Buffer *err);
-enum CommandResult sb_parse_whitelist  (struct Buffer *buf, struct Buffer *s, intptr_t data, struct Buffer *err);
+enum CommandResult sb_parse_sidebar_unpin(struct Buffer *buf, struct Buffer *s, intptr_t data, struct Buffer *err);
+enum CommandResult sb_parse_sidebar_pin  (struct Buffer *buf, struct Buffer *s, intptr_t data, struct Buffer *err);
 
 // functions.c
 bool sb_next(struct SidebarWindowData *wdata);

--- a/sidebar/private.h
+++ b/sidebar/private.h
@@ -32,7 +32,7 @@
 struct IndexSharedData;
 struct MuttWindow;
 
-extern struct ListHead SidebarWhitelist;
+extern struct ListHead SidebarPinned;
 
 /**
  * struct SbEntry - Info about folders in the sidebar

--- a/sidebar/sidebar.c
+++ b/sidebar/sidebar.c
@@ -41,7 +41,7 @@
 #include "index/lib.h"
 #include "mutt_commands.h"
 
-struct ListHead SidebarWhitelist = STAILQ_HEAD_INITIALIZER(SidebarWhitelist); ///< List of mailboxes to always display in the sidebar
+struct ListHead SidebarPinned = STAILQ_HEAD_INITIALIZER(SidebarPinned); ///< List of mailboxes to always display in the sidebar
 
 static const struct Command sb_commands[] = {
   // clang-format off
@@ -212,5 +212,5 @@ void sb_shutdown(void)
 {
   if (AllDialogsWindow)
     notify_observer_remove(AllDialogsWindow->notify, sb_insertion_window_observer, NULL);
-  mutt_list_free(&SidebarWhitelist);
+  mutt_list_free(&SidebarPinned);
 }

--- a/sidebar/sidebar.c
+++ b/sidebar/sidebar.c
@@ -45,6 +45,9 @@ struct ListHead SidebarWhitelist = STAILQ_HEAD_INITIALIZER(SidebarWhitelist); //
 
 static const struct Command sb_commands[] = {
   // clang-format off
+  { "sidebar_pin",   sb_parse_whitelist,     0 },
+  { "sidebar_unpin", sb_parse_unwhitelist,   0 },
+
   { "sidebar_whitelist",   sb_parse_whitelist,     0 },
   { "unsidebar_whitelist", sb_parse_unwhitelist,   0 },
   // clang-format on

--- a/sidebar/sidebar.c
+++ b/sidebar/sidebar.c
@@ -45,11 +45,11 @@ struct ListHead SidebarWhitelist = STAILQ_HEAD_INITIALIZER(SidebarWhitelist); //
 
 static const struct Command sb_commands[] = {
   // clang-format off
-  { "sidebar_pin",   sb_parse_whitelist,     0 },
-  { "sidebar_unpin", sb_parse_unwhitelist,   0 },
+  { "sidebar_pin",   sb_parse_sidebar_pin,     0 },
+  { "sidebar_unpin", sb_parse_sidebar_unpin,   0 },
 
-  { "sidebar_whitelist",   sb_parse_whitelist,     0 },
-  { "unsidebar_whitelist", sb_parse_unwhitelist,   0 },
+  { "sidebar_whitelist",   sb_parse_sidebar_pin,     0 },
+  { "unsidebar_whitelist", sb_parse_sidebar_unpin,   0 },
   // clang-format on
 };
 

--- a/sidebar/window.c
+++ b/sidebar/window.c
@@ -559,7 +559,7 @@ static void make_sidebar_entry(char *buf, size_t buflen, int width,
  * * is the currently highlighted mailbox
  * * has unread messages
  * * has flagged messages
- * * is whitelisted
+ * * is pinned
  */
 static void update_entries_visibility(struct SidebarWindowData *wdata)
 {

--- a/sidebar/window.c
+++ b/sidebar/window.c
@@ -590,8 +590,8 @@ static void update_entries_visibility(struct SidebarWindowData *wdata)
       continue;
     }
 
-    if (mutt_list_find(&SidebarWhitelist, mailbox_path(sbe->mailbox)) ||
-        mutt_list_find(&SidebarWhitelist, sbe->mailbox->name))
+    if (mutt_list_find(&SidebarPinned, mailbox_path(sbe->mailbox)) ||
+        mutt_list_find(&SidebarPinned, sbe->mailbox->name))
     {
       /* Explicitly asked to be visible */
       continue;


### PR DESCRIPTION
* **What does this PR do?**

* Rename sidebar_whitelist / sidebar_unwhitelist to sidebar_pin / sidebar_unpin (old commands are still provided for backwards compatibility)
* Rename internal functions to match the above command renaming
* Remove the words "blacklist" and "whitelist" from API comments.

Closes: #3619