### PR TITLE
Recognise text/vcard as not an attachment

### DIFF
--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -11854,8 +11854,10 @@ set preferred_languages="fr,en,de"
 <emphasis role="comment">#</emphasis>
 <emphasis role="comment"># Remember: "unattachments" only undoes what "attachments" has done!</emphasis>
 <emphasis role="comment"># It does not trigger any matching on actual messages.</emphasis>
+<emphasis role="comment">#</emphasis>
 <emphasis role="comment"># Qualify any MIME part with an "attachment" disposition, EXCEPT for</emphasis>
-<emphasis role="comment"># text/x-vcard and application/pgp parts. (PGP parts are already known</emphasis>
+<emphasis role="comment"># text/vcard, text/x-vcard, application/pgp.*, application/pkcs7-.* and</emphasis>
+<emphasis role="comment"># application/x-pkcs7-.* parts. (PGP and S/MIME parts are already known</emphasis>
 <emphasis role="comment"># to NeoMutt, and can be searched for with ~g, ~G, and ~k.)</emphasis>
 <emphasis role="comment">#</emphasis>
 <emphasis role="comment"># I've added pkcs7/x-pkcs7 to this, since it functions (for S/MIME)</emphasis>
@@ -11863,7 +11865,7 @@ set preferred_languages="fr,en,de"
 <emphasis role="comment"># in a stock NeoMutt build, but we can still treat it specially here.</emphasis>
 <emphasis role="comment">#</emphasis>
 attachments  +A */.*
-attachments  -A text/x-vcard
+attachments  -A text/vcard text/x-vcard
 attachments  -A application/pgp.*
 attachments  -A application/pkcs7-.* application/x-pkcs7-.*
 <emphasis role="comment"># Discount all MIME parts with an "inline" disposition, unless they're</emphasis>

--- a/docs/neomuttrc.head
+++ b/docs/neomuttrc.head
@@ -70,11 +70,11 @@ mime_lookup application/octet-stream
 # It does not trigger any matching on actual messages.
 
 # Qualify any MIME part with an "attachment" disposition, EXCEPT for
-# text/x-vcard, application/pgp.*, application/pkcs7-.* and
+# text/vcard, text/x-vcard, application/pgp.*, application/pkcs7-.* and
 # application/x-pkcs7-.* parts. (PGP and S/MIME parts are already known
 # to NeoMutt, and can be searched for with ~g, ~G, and ~k.)
 attachments   +A */.*
-attachments   -A text/x-vcard
+attachments   -A text/vcard text/x-vcard
 attachments   -A application/pgp.*
 attachments   -A application/pkcs7-.* application/x-pkcs7-.*
 


### PR DESCRIPTION
Similar to https://github.com/neomutt/neomutt/pull/3634

---

We already exclude text/x-vcard from being an attachment, also do that for its successor text/vcard.

[RFC 6350] states in section 10.1 that text/x-vcard is a deprecated/legacy MIME-type and that text/vcard should be used.

[RFC 6350] https://datatracker.ietf.org/doc/rfc6350/
