### PR TITLE
Fix bug: hdr_order did not sort last header correctly

### DIFF
--- a/copy.c
+++ b/copy.c
@@ -310,7 +310,6 @@ int mutt_copy_hdr(FILE *fp_in, FILE *fp_out, LOFF_T off_start, LOFF_T off_end,
 
         STAILQ_FOREACH(np, &HeaderOrderList, entries)
         {
-          x++;
           size_t hdr_order_len = mutt_str_len(np->data);
           if (mutt_istrn_equal(buf, np->data, hdr_order_len))
           {
@@ -321,6 +320,7 @@ int mutt_copy_hdr(FILE *fp_in, FILE *fp_out, LOFF_T off_start, LOFF_T off_end,
             }
             mutt_debug(LL_DEBUG2, "Reorder: %s matches %s", np->data, buf);
           }
+          x++;
         }
         if (match != -1)
           x = match;


### PR DESCRIPTION
The algorithm to sort headers by the order given in hdr_order sorted the last mentioned header in hdr_order at the same level as unmentioned headers, i.e. not at all.

The bug was introduced in d9ff90dced82e7328dff4abc0918ee0020af8d0a.

The algorithm puts headers in buckets labeled by their priority (0 = highest, n = lowest).

The problem is that the "priority counter" (which starts at 0) `x` is first incremented and then the header is assigned to priority `x`. Thus, the buckets 0 to n become 1 to n+1 and the header mentioned last in hdr_order (number n) was sorted in the bucket n+1 together with all other headers.

The fix is simple: First sort the header in the bucket, then increase the priority counter.

