### PR TITLE
Fix a double-free crash when using :fetch-mail

### DIFF
--- a/pop/pop.c
+++ b/pop/pop.c
@@ -677,7 +677,6 @@ finish:
   if (pop_query(adata, buf, sizeof(buf)) == -1)
     goto fail;
   mutt_socket_close(conn);
-  FREE(&conn);
   pop_adata_free((void **) &adata);
   return;
 


### PR DESCRIPTION
* **What does this PR do?**

In commit  [c97f9d9d23e90e65e204d2a3b33bb3f7f935a8ff](https://github.com/neomutt/neomutt/commit/c97f9d9d23e90e65e204d2a3b33bb3f7f935a8ff), I fixed a memory leak when closing a POP connection. This turned out to cause a double-free crash when fetching mail. `mutt_mem_free()` setting its passed pointer to `NULL` did not help because the pointer stored in `adata` was a copy.

This commit fixes this. Valgrind does not report the resource to leak when fetching mail.

* **What are the relevant issue numbers?**

None.