### PR TITLE
Deprecated `$vfolder_format`

### DIFF
--- a/docs/config.c
+++ b/docs/config.c
@@ -5503,11 +5503,11 @@
 { "virtual_spool_file", DT_BOOL, false },
 /*
 ** .pp
-** When \fIset\fP, NeoMutt will use the first defined virtual mailbox (see
-** virtual-mailboxes) as a spool file.
-** .pp
 ** This command is now unnecessary. $$spool_file has been extended to support
 ** mailbox descriptions as a value.
+** .pp
+** When \fIset\fP, NeoMutt will use the first defined virtual mailbox (see
+** virtual-mailboxes) as a spool file.
 */
 #endif
 

--- a/docs/config.c
+++ b/docs/config.c
@@ -5500,14 +5500,6 @@
 */
 
 #ifdef USE_NOTMUCH
-{ "vfolder_format", DT_STRING, "%2C %?n?%4n/&     ?%4m %f" },
-/*
-** .pp
-** This variable allows you to customize the file browser display for virtual
-** folders to your personal taste.  This string uses many of the same
-** expandos as $$folder_format.
-*/
-
 { "virtual_spool_file", DT_BOOL, false },
 /*
 ** .pp

--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -16405,12 +16405,6 @@ virtual-mailboxes "My INBOX" "notmuch://?query=tag:inbox"
                 <entry></entry>
               </row>
               <row>
-                <entry><literal>vfolder_format</literal></entry>
-                <entry>string</entry>
-                <entry><literal>%6n(%6N) %f</literal></entry>
-                <entry></entry>
-              </row>
-              <row>
                 <entry><literal>virtual_spool_file</literal></entry>
                 <entry>boolean</entry>
                 <entry><literal>no</literal></entry>
@@ -16651,17 +16645,6 @@ set nm_record = no
 set nm_record_tags = ""
 <emphasis role="comment"># This variable specifies the notmuch tag used for unread messages.</emphasis>
 set nm_unread_tag = unread
-<emphasis role="comment"># This variable allows you to customize the file browser display for virtual</emphasis>
-<emphasis role="comment"># folders to your personal taste.</emphasis>
-<emphasis role="comment"># %C   current folder number</emphasis>
-<emphasis role="comment"># %f   folder name (description)</emphasis>
-<emphasis role="comment"># %m   number of messages in the mailbox *</emphasis>
-<emphasis role="comment"># %n   number of unread messages in the mailbox *</emphasis>
-<emphasis role="comment"># %N   "N" if mailbox has new mail, " " (space) otherwise</emphasis>
-<emphasis role="comment"># %>X  right justify the rest of the string and pad with character ``X''</emphasis>
-<emphasis role="comment"># %|X  pad to the end of the line with character ``X''</emphasis>
-<emphasis role="comment"># %*X  soft-fill with character ``X'' as pad</emphasis>
-set vfolder_format = "%6n(%6N) %f"
 <emphasis role="comment"># When set, NeoMutt will use the first virtual mailbox (see virtual-mailboxes)</emphasis>
 <emphasis role="comment"># as a spool_file.</emphasis>
 set virtual_spool_file = no

--- a/notmuch/config.c
+++ b/notmuch/config.c
@@ -147,12 +147,11 @@ static struct ConfigDef NotmuchVars[] = {
   { "nm_unread_tag", DT_STRING, IP "unread", 0, NULL,
     "(notmuch) Tag to use for unread messages"
   },
-  { "vfolder_format", DT_STRING|DT_NOT_EMPTY|R_INDEX, IP "%2C %?n?%4n/&     ?%4m %f", 0, NULL,
-    "(notmuch) printf-like format string for the browser's display of virtual folders"
-  },
   { "virtual_spool_file", DT_BOOL, false, 0, NULL,
     "(notmuch) Use the first virtual mailbox as a spool file"
   },
+
+  { "vfolder_format",    DT_DEPRECATED|DT_STRING|DT_NOT_EMPTY|R_INDEX, IP "%2C %?n?%4n/&     ?%4m %f", IP "2018-11-01" },
 
   { "nm_default_uri",    DT_SYNONYM, IP "nm_default_url",     IP "2021-02-11" },
   { "virtual_spoolfile", DT_SYNONYM, IP "virtual_spool_file", IP "2021-02-11" },


### PR DESCRIPTION
* **What does this PR do?**

1. Deprecated `$vfolder_format`.
2. Swap paragraphs in `$virtual_spool_file` to make clear that this variable is also considered deprecated.

* **What are the relevant issue numbers?**

Closes: #3667 