### PR TITLE
Make exiting via SIGINT more graceful

### DIFF
--- a/gui/curs_lib.c
+++ b/gui/curs_lib.c
@@ -339,7 +339,7 @@ void mutt_query_exit(void)
   const short c_timeout = cs_subset_number(NeoMutt->sub, "timeout");
   if (c_timeout)
     set_timeout(-1); /* restore blocking operation */
-  if (mutt_yesorno(_("Exit NeoMutt?"), MUTT_YES) == MUTT_YES)
+  if (mutt_yesorno(_("Exit NeoMutt without saving?"), MUTT_YES) == MUTT_YES)
   {
     mutt_exit(1);
   }

--- a/gui/curs_lib.c
+++ b/gui/curs_lib.c
@@ -341,7 +341,7 @@ void mutt_query_exit(void)
     set_timeout(-1); /* restore blocking operation */
   if (mutt_yesorno(_("Exit NeoMutt without saving?"), MUTT_YES) == MUTT_YES)
   {
-    mutt_exit(1);
+    mutt_exit(0); /* This call never returns */
   }
   mutt_clear_error();
   mutt_curses_set_cursor(cursor);


### PR DESCRIPTION
* **What does this PR do?**

1) Clarify to the user that exiting via SIGINT does *not* save. Previously, the question was phrased the same as the for the `quit` function (which dose save the mailbox), now it is the one from the `exit` function (which does not save).
(No new translation entry is needed)

2) Exit with exit code 0.  The user was asked, they replied, we acted, so this should be considered a normal run, not one with a special exit condition (i.e. != 0)

---

When comparing the SIGINT exit routine with the `exit` function one, we see differences (see below).
This leads to the question, whether the SIGINT code path should do a little more than calling `exit(0)` directly (maybe closing the mailbox)?

https://github.com/neomutt/neomutt/blob/ff76d02c585b81daae56d03e86222621dbd86abc/gui/curs_lib.c#L330-L349

https://github.com/neomutt/neomutt/blob/ff76d02c585b81daae56d03e86222621dbd86abc/index/functions.c#L519-L539