### PR TITLE
store: promote modern databases

### DIFF
--- a/hcache/hcachever.sh
+++ b/hcache/hcachever.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-BASEVERSION=7
+BASEVERSION=8
 STRUCTURES="Address Body Buffer Email Envelope ListNode Parameter"
 
 cleanstruct () {

--- a/store/store.c
+++ b/store/store.c
@@ -48,29 +48,29 @@ STORE_BACKEND(tokyocabinet)
  * StoreOps - Backend implementations
  */
 static const struct StoreOps *StoreOps[] = {
+#ifdef HAVE_LMDB
+  &store_lmdb_ops,
+#endif
+#ifdef HAVE_ROCKSDB
+  &store_rocksdb_ops,
+#endif
+#ifdef HAVE_TDB
+  &store_tdb_ops,
+#endif
 #ifdef HAVE_TC
   &store_tokyocabinet_ops,
 #endif
 #ifdef HAVE_KC
   &store_kyotocabinet_ops,
 #endif
-#ifdef HAVE_QDBM
-  &store_qdbm_ops,
-#endif
-#ifdef HAVE_ROCKSDB
-  &store_rocksdb_ops,
+#ifdef HAVE_BDB
+  &store_bdb_ops,
 #endif
 #ifdef HAVE_GDBM
   &store_gdbm_ops,
 #endif
-#ifdef HAVE_BDB
-  &store_bdb_ops,
-#endif
-#ifdef HAVE_TDB
-  &store_tdb_ops,
-#endif
-#ifdef HAVE_LMDB
-  &store_lmdb_ops,
+#ifdef HAVE_QDBM
+  &store_qdbm_ops,
 #endif
   NULL,
 };


### PR DESCRIPTION
Modern databases, like lmdb, rocksdb and tdb outperform the old default of tokyocabinet.

See: #3645 

---

If `$header_cache_backend` isn't set, then the first compiled-in database is used.

The new priority order is:
- lmdb, rocksdb, tdb, tokyocabinet, kyotocabinet, bdb, gdbm, qdbm

This change will naturally invalidate any existing caches,
but due to our frequent refactoring, almost every release does this anyway.

---

If this change is accepted, we should urge the downstream packagers to compile-in at least one of the modern databases.