### PR TITLE
Fix misaligned fetches, provide a more convenient hcache API

### DIFF
--- a/hcache/lib.h
+++ b/hcache/lib.h
@@ -154,17 +154,12 @@ int mutt_hcache_store(struct HeaderCache *hc, const char *key, size_t keylen,
  */
 struct HCacheEntry mutt_hcache_fetch(struct HeaderCache *hc, const char *key, size_t keylen, uint32_t uidvalidity);
 
+char *mutt_hcache_fetch_str(struct HeaderCache *hc, const char *key, size_t keylen);
+bool  mutt_hcache_fetch_obj_(struct HeaderCache *hc, const char *key, size_t keylen, void *dst, size_t dstlen);
+#define mutt_hcache_fetch_obj(hc, key, keylen, dst) mutt_hcache_fetch_obj_(hc, key, keylen, &dst, sizeof(dst))
+
 int mutt_hcache_store_raw(struct HeaderCache *hc, const char *key, size_t keylen,
                           void *data, size_t dlen);
-
-void *mutt_hcache_fetch_raw(struct HeaderCache *hc, const char *key, size_t keylen, size_t *dlen);
-
-/**
- * mutt_hcache_free_raw - Free data fetched with mutt_hcache_fetch_raw()
- * @param hc   Pointer to the struct HeaderCache structure got by mutt_hcache_open()
- * @param data Pointer to the data got using mutt_hcache_fetch_raw
- */
-void mutt_hcache_free_raw(struct HeaderCache *hc, void **data);
 
 /**
  * mutt_hcache_delete_record - Delete a key / data pair

--- a/imap/mdata.c
+++ b/imap/mdata.c
@@ -28,6 +28,7 @@
 
 #include "config.h"
 #include <stddef.h>
+#include <assert.h>
 #include "private.h"
 #include "core/lib.h"
 #include "mdata.h"
@@ -93,36 +94,13 @@ struct ImapMboxData *imap_mdata_new(struct ImapAccountData *adata, const char *n
   imap_hcache_open(adata, mdata);
   if (mdata->hcache)
   {
-    size_t dlen = 0;
-    void *uidvalidity = mutt_hcache_fetch_raw(mdata->hcache, "/UIDVALIDITY", 12, &dlen);
-    if (uidvalidity && (dlen < sizeof(uint32_t)))
+    if (mutt_hcache_fetch_obj(mdata->hcache, "/UIDVALIDITY", 12, mdata->uidvalidity))
     {
-      mutt_hcache_free_raw(mdata->hcache, &uidvalidity);
-      uidvalidity = NULL;
-    }
-    void *uidnext = mutt_hcache_fetch_raw(mdata->hcache, "/UIDNEXT", 8, &dlen);
-    if (uidnext && (dlen < sizeof(unsigned int)))
-    {
-      mutt_hcache_free_raw(mdata->hcache, &uidnext);
-      uidnext = NULL;
-    }
-    unsigned long long *modseq = mutt_hcache_fetch_raw(mdata->hcache, "/MODSEQ", 7, &dlen);
-    if (modseq && (dlen < sizeof(unsigned long long)))
-    {
-      mutt_hcache_free_raw(mdata->hcache, (void **) &modseq);
-      modseq = NULL;
-    }
-    if (uidvalidity)
-    {
-      mdata->uidvalidity = *(uint32_t *) uidvalidity;
-      mdata->uid_next = uidnext ? *(unsigned int *) uidnext : 0;
-      mdata->modseq = modseq ? *modseq : 0;
+      mutt_hcache_fetch_obj(mdata->hcache, "/UIDNEXT", 8, mdata->uid_next);
+      mutt_hcache_fetch_obj(mdata->hcache, "/MODSEQ", 7, mdata->modseq);
       mutt_debug(LL_DEBUG3, "hcache uidvalidity %u, uidnext %u, modseq %llu\n",
                  mdata->uidvalidity, mdata->uid_next, mdata->modseq);
     }
-    mutt_hcache_free_raw(mdata->hcache, &uidvalidity);
-    mutt_hcache_free_raw(mdata->hcache, &uidnext);
-    mutt_hcache_free_raw(mdata->hcache, (void **) &modseq);
     imap_hcache_close(mdata);
   }
 #endif

--- a/imap/message.c
+++ b/imap/message.c
@@ -1333,14 +1333,13 @@ int imap_read_headers(struct Mailbox *m, unsigned int msn_begin,
   bool evalhc = false;
 
 #ifdef USE_HCACHE
-  void *uidvalidity = NULL;
-  void *puid_next = NULL;
+  uint32_t uidvalidity = 0;
   unsigned int uid_next = 0;
+  unsigned long long modseq = 0;
   bool has_condstore = false;
   bool has_qresync = false;
   bool eval_condstore = false;
   bool eval_qresync = false;
-  unsigned long long hc_modseq = 0;
   char *uid_seqset = NULL;
   const unsigned int msn_begin_save = msn_begin;
 #endif /* USE_HCACHE */
@@ -1369,23 +1368,8 @@ retry:
 
   if (mdata->hcache && initial_download)
   {
-    size_t dlen = 0;
-    uidvalidity = mutt_hcache_fetch_raw(mdata->hcache, "/UIDVALIDITY", 12, &dlen);
-    if (uidvalidity && (dlen < sizeof(uint32_t)))
-    {
-      mutt_hcache_free_raw(mdata->hcache, &uidvalidity);
-      uidvalidity = NULL;
-    }
-    puid_next = mutt_hcache_fetch_raw(mdata->hcache, "/UIDNEXT", 8, &dlen);
-    if (puid_next)
-    {
-      if (dlen >= sizeof(unsigned int))
-      {
-        uid_next = *(unsigned int *) puid_next;
-      }
-      mutt_hcache_free_raw(mdata->hcache, &puid_next);
-    }
-
+    mutt_hcache_fetch_obj(mdata->hcache, "/UIDVALIDITY", 12, uidvalidity);
+    mutt_hcache_fetch_obj(mdata->hcache, "/UIDNEXT",      8, uid_next);
     if (mdata->modseq)
     {
       const bool c_imap_condstore = cs_subset_bool(NeoMutt->sub, "imap_condstore");
@@ -1398,21 +1382,10 @@ retry:
         has_qresync = true;
     }
 
-    if (uidvalidity && uid_next && (*(uint32_t *) uidvalidity == mdata->uidvalidity))
+    if (uidvalidity && uid_next && uidvalidity == mdata->uidvalidity)
     {
-      size_t dlen2 = 0;
       evalhc = true;
-      const unsigned long long *pmodseq = mutt_hcache_fetch_raw(mdata->hcache,
-                                                                "/MODSEQ", 7, &dlen2);
-      if (pmodseq)
-      {
-        if (dlen2 >= sizeof(unsigned long long))
-        {
-          hc_modseq = *pmodseq;
-        }
-        mutt_hcache_free_raw(mdata->hcache, (void **) &pmodseq);
-      }
-      if (hc_modseq)
+      if (mutt_hcache_fetch_obj(mdata->hcache, "/MODSEQ", 7, modseq))
       {
         if (has_qresync)
         {
@@ -1425,7 +1398,6 @@ retry:
           eval_condstore = true;
       }
     }
-    mutt_hcache_free_raw(mdata->hcache, &uidvalidity);
   }
   if (evalhc)
   {
@@ -1441,10 +1413,10 @@ retry:
         goto bail;
     }
 
-    if ((eval_condstore || eval_qresync) && (hc_modseq != mdata->modseq))
+    if ((eval_condstore || eval_qresync) && (modseq != mdata->modseq))
     {
       if (read_headers_condstore_qresync_updates(adata, msn_end, uid_next,
-                                                 hc_modseq, eval_qresync) < 0)
+                                                 modseq, eval_qresync) < 0)
       {
         goto bail;
       }
@@ -1471,10 +1443,10 @@ retry:
       eval_qresync = false;
       eval_condstore = false;
       evalhc = false;
-      hc_modseq = 0;
+      modseq = 0;
       maxuid = 0;
       FREE(&uid_seqset);
-      uidvalidity = NULL;
+      uidvalidity = 0;
       uid_next = 0;
       msn_begin = msn_begin_save;
 

--- a/imap/util.c
+++ b/imap/util.c
@@ -453,14 +453,7 @@ char *imap_hcache_get_uid_seqset(struct ImapMboxData *mdata)
   if (!mdata->hcache)
     return NULL;
 
-  char *seqset = NULL;
-  size_t dlen = 0;
-  char *hc_seqset = mutt_hcache_fetch_raw(mdata->hcache, "/UIDSEQSET", 10, &dlen);
-  if (hc_seqset)
-  {
-    seqset = mutt_strn_dup(hc_seqset, dlen);
-    mutt_hcache_free_raw(mdata->hcache, (void **) &hc_seqset);
-  }
+  char *seqset = mutt_hcache_fetch_str(mdata->hcache, "/UIDSEQSET", 10);
   mutt_debug(LL_DEBUG3, "Retrieved /UIDSEQSET %s\n", NONULL(seqset));
 
   return seqset;

--- a/nntp/newsrc.c
+++ b/nntp/newsrc.c
@@ -742,13 +742,11 @@ void nntp_hcache_update(struct NntpMboxData *mdata, struct HeaderCache *hc)
   anum_t first = 0, last = 0;
 
   /* fetch previous values of first and last */
-  size_t dlen = 0;
-  char *hdata = mutt_hcache_fetch_raw(hc, "index", 5, &dlen);
+  char *hdata = mutt_hcache_fetch_str(hc, "index", 5);
   if (hdata)
   {
-    mutt_debug(LL_DEBUG2, "mutt_hcache_fetch index: %s\n", (char *) hdata);
-    if ((dlen > 0) && (hdata[dlen - 1] == '\0') &&
-        sscanf(hdata, ANUM " " ANUM, &first, &last) == 2)
+    mutt_debug(LL_DEBUG2, "mutt_hcache_fetch index: %s\n", hdata);
+    if (sscanf(hdata, ANUM " " ANUM, &first, &last) == 2)
     {
       old = true;
       mdata->last_cached = last;
@@ -764,7 +762,7 @@ void nntp_hcache_update(struct NntpMboxData *mdata, struct HeaderCache *hc)
         mutt_hcache_delete_record(hc, buf, strlen(buf));
       }
     }
-    mutt_hcache_free_raw(hc, (void **) &hdata);
+    FREE(&hdata);
   }
 
   /* store current values of first and last */
@@ -1157,7 +1155,6 @@ struct NntpAccountData *nntp_select_server(struct Mailbox *m, const char *server
       while ((de = readdir(dir)))
       {
         struct HeaderCache *hc = NULL;
-        char *hdata = NULL;
         char *group = de->d_name;
 
         char *p = group + strlen(group) - 7;
@@ -1173,14 +1170,12 @@ struct NntpAccountData *nntp_select_server(struct Mailbox *m, const char *server
           continue;
 
         /* fetch previous values of first and last */
-        size_t dlen = 0;
-        hdata = mutt_hcache_fetch_raw(hc, "index", 5, &dlen);
+        char *hdata = mutt_hcache_fetch_str(hc, "index", 5);
         if (hdata)
         {
           anum_t first, last;
 
-          if ((dlen > 0) && (hdata[dlen - 1] == '\0') &&
-              sscanf(hdata, ANUM " " ANUM, &first, &last) == 2)
+          if (sscanf(hdata, ANUM " " ANUM, &first, &last) == 2)
           {
             if (mdata->deleted)
             {
@@ -1193,7 +1188,7 @@ struct NntpAccountData *nntp_select_server(struct Mailbox *m, const char *server
               mutt_debug(LL_DEBUG2, "%s last_cached=" ANUM "\n", mdata->group, last);
             }
           }
-          mutt_hcache_free_raw(hc, (void **) &hdata);
+          FREE(&hdata);
         }
         mutt_hcache_close(hc);
       }


### PR DESCRIPTION
This started off as an attempt to get rid of misaligned reads:

```c
uint32_t foo = 0;
void *foo_ptr = mutt_hcache_fetch_raw(mdata->hcache, "/FOO", 4, &dlen);
if (foo_ptr)
{
	foo = *(uint32_t *)foo_ptr;
}
```

It turns out, client code doesn't actually need access to such as low-level API.
So I exposed two wrappers to fetch objects (various sized integers) and strings.