### PR TITLE
Provide expando to show the fingerprint of a key

### DIFF
--- a/docs/config.c
+++ b/docs/config.c
@@ -3113,6 +3113,7 @@
 ** .dt %a     .dd Algorithm
 ** .dt %c     .dd Capabilities
 ** .dt %f     .dd Flags
+** .dt %i     .dd Key fingerprint (or long key id if non-existent)
 ** .dt %k     .dd Key id
 ** .dt %l     .dd Key length
 ** .dt %n     .dd Number

--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -3836,7 +3836,7 @@ static SecurityFlags gpgme_send_menu(struct Email *e, bool is_smime)
           snprintf(input_signas, sizeof(input_signas), "0x%s", crypt_fpr_or_lkeyid(p));
 
           if (is_smime)
-            cs_subset_str_string_set(NeoMutt->sub, "smime_default_key", input_signas, NULL);
+            cs_subset_str_string_set(NeoMutt->sub, "smime_sign_as", input_signas, NULL);
           else
             cs_subset_str_string_set(NeoMutt->sub, "pgp_sign_as", input_signas, NULL);
 

--- a/ncrypt/dlg_gpgme.c
+++ b/ncrypt/dlg_gpgme.c
@@ -349,12 +349,14 @@ static char crypt_flags(KeyFlags flags)
  * | \%a     | Algorithm
  * | \%c     | Capabilities
  * | \%f     | Flags
+ * | \%i     | Key fingerprint (or long key id if non-existent)
  * | \%k     | Key id
  * | \%l     | Length
  * |         |
  * | \%A     | Algorithm of the principal key
  * | \%C     | Capabilities of the principal key
  * | \%F     | Flags of the principal key
+ * | \%I     | Key fingerprint of the principal key (or long key id if non-existent)
  * | \%K     | Key id of the principal key
  * | \%L     | Length of the principal key
  */
@@ -408,6 +410,16 @@ static const char *crypt_format_str(char *buf, size_t buflen, size_t col, int co
       }
       else if (!(kflags & KEYFLAG_RESTRICTIONS))
         optional = false;
+      break;
+
+    case 'i':
+      if (!optional)
+      {
+        /* fixme: we need a way to distinguish between main and subkeys.
+         * Store the idx in entry? */
+        snprintf(fmt, sizeof(fmt), "%%%ss", prec);
+        snprintf(buf, buflen, fmt, crypt_fpr_or_lkeyid(key));
+      }
       break;
 
     case 'k':


### PR DESCRIPTION
* **What does this PR do?**

1) The first commit fixes a legacy/mixup of $smime_default_key, I've stumpled while coding the rest.  Since you flatten your history anyway, I refrained from providing a separate PR.

2) Add a new expando, `%i` to `$pgp_entry_format` which expands to the full fingerprint of a key (or its long id, if there is no fingerprint).

3) Discussion worthy:  change the meaning of `%k` and `%i` expandos.  This naming aligns better with the actual names `i` for id and `k` for `key fingerprint`.  Obviously, this is a user visible change, its strictly providing more information as the keyid is a substring of the fingerprint.  I guess almost nobody will notice.  To mitigate the change even further we could change the default `$pgp_entry_format` to use  `%i` instead of `%k`, so only those who changed pgp_entry_format will notice a difference.

*Why this change*: It is well known that short key ids are broken.  Long key ids (double the digits) are a little better but still do not provide the guarantee of no collision. Therefore, the key fingerprint is the only safe way to guarantee that we are dealing with the key we think we are dealing.