### PR TITLE
Fix printf-format string in debug output

### DIFF
--- a/color/curses.c
+++ b/color/curses.c
@@ -103,8 +103,8 @@ static int curses_color_init(int fg, int bg)
   if (bg == COLOR_DEFAULT)
     bg = COLOR_UNSET;
 
-  color_debug(LL_DEBUG5, "init_pair(%d,%d,%d) -> %d\n", index, fg, bg);
-  init_pair(index, fg, bg);
+  int rc = init_pair(index, fg, bg);
+  color_debug(LL_DEBUG5, "init_pair(%d,%d,%d) -> %d\n", index, fg, bg, rc);
 
   return index;
 }


### PR DESCRIPTION
The format string used 4 arguments, but only 3 were given.

I made a blind guess what could have been meant.  If that's not it, then please help yourself.