### PR TITLE
Implement 24bit colors aka truecolor

### DIFF
--- a/auto.def
+++ b/auto.def
@@ -672,6 +672,12 @@ cc-with [list -libs -L$ncurses_prefix/$::libdir_tail] {
   foreach f {bkgrndset setcchar use_extended_names} {
     cc-check-function-in-lib $f $ncurses_lib
   }
+
+  set nc_maj [get-define-value $ncurses_prefix/include/ncurses.h NCURSES_VERSION_MAJOR]
+  set nc_min [get-define-value $ncurses_prefix/include/ncurses.h NCURSES_VERSION_MINOR]
+  if {$nc_maj ne {} && $nc_min ne {} && ($nc_maj > 6 || ($nc_maj == 6 && $nc_min >= 1))} {
+    define-append CFLAGS -DNEOMUTT_DIRECT_COLORS
+  }
 }
 
 # Locate the directory containing ncurses.h

--- a/color/command.c
+++ b/color/command.c
@@ -28,6 +28,7 @@
 
 #include "config.h"
 #include <stddef.h>
+#include <assert.h>
 #include <limits.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -115,6 +116,138 @@ const struct Mapping ComposeColorFields[] = {
   // clang-format on
 };
 
+#ifdef NEOMUTT_DIRECT_COLORS
+/**
+ * color_xterm256_to_24bit - Convert a xterm color to its RGB value
+ * @param[in] color xterm color number to be converted
+ * @retval num The color's RGB value as number with value 0xRRGGBB
+ *
+ * There are 256 xterm colors numbered 0 to 255.
+ *
+ * Caller contract: color must be between 0 and 255.
+ *
+ * ## Xterm Color Codes
+ * 
+ * ### Basic and Bright Colors
+ * 
+ * - 0-7 correspond to the 8 terminal colours
+ * - 8-15 are the bright variants of 0-7
+ * 
+ * |     |           |     |           |     |           |     |           |     |           |     |           |    |           |    |           |
+ * | :-- | :-------- | :-- | :-------  | :-- | :-------  | :-- | :-------  | :-- | :-------  | :-- | :-------  | :- | :-------  | :- | :-------- |
+ * |  0  | `#000000` |  1  | `#800000` |  2  | `#008000` |  3  | `#808000` |  4  | `#000080` |  5  | `#800080` |  6 | `#008080` |  7 | `#c0c0c0` |
+ * |  8  | `#808080` |  9  | `#ff0000` | 10  | `#00ff00` | 11  | `#ffff00` | 12  | `#0000ff` | 13  | `#ff00ff` | 14 | `#00ffff` | 15 | `#ffffff` |
+ * 
+ * ### Color palette
+ * 
+ * |     |           |     |           |     |           |     |           |     |           |     |           |
+ * | :-- | :-------  | :-- | :-------  | :-- | :-------  | :-- | :-------  | :-- | :-------  | :-- | :-------  |
+ * |  16 | `#000000` |  17 | `#00005f` |  18 | `#000087` |  19 | `#0000af` |  20 | `#0000d7` |  21 | `#0000ff` |
+ * |  22 | `#005f00` |  23 | `#005f5f` |  24 | `#005f87` |  25 | `#005faf` |  26 | `#005fd7` |  27 | `#005fff` |
+ * |  28 | `#008700` |  29 | `#00875f` |  30 | `#008787` |  31 | `#0087af` |  32 | `#0087d7` |  33 | `#0087ff` |
+ * |  34 | `#00af00` |  35 | `#00af5f` |  36 | `#00af87` |  37 | `#00afaf` |  38 | `#00afd7` |  39 | `#00afff` |
+ * |  40 | `#00d700` |  41 | `#00d75f` |  42 | `#00d787` |  43 | `#00d7af` |  44 | `#00d7d7` |  45 | `#00d7ff` |
+ * |  46 | `#00ff00` |  47 | `#00ff5f` |  48 | `#00ff87` |  49 | `#00ffaf` |  50 | `#00ffd7` |  51 | `#00ffff` |
+ * |  52 | `#5f0000` |  53 | `#5f005f` |  54 | `#5f0087` |  55 | `#5f00af` |  56 | `#5f00d7` |  57 | `#5f00ff` |
+ * |  58 | `#5f5f00` |  59 | `#5f5f5f` |  60 | `#5f5f87` |  61 | `#5f5faf` |  62 | `#5f5fd7` |  63 | `#5f5fff` |
+ * |  64 | `#5f8700` |  65 | `#5f875f` |  66 | `#5f8787` |  67 | `#5f87af` |  68 | `#5f87d7` |  69 | `#5f87ff` |
+ * |  70 | `#5faf00` |  71 | `#5faf5f` |  72 | `#5faf87` |  73 | `#5fafaf` |  74 | `#5fafd7` |  75 | `#5fafff` |
+ * |  76 | `#5fd700` |  77 | `#5fd75f` |  78 | `#5fd787` |  79 | `#5fd7af` |  80 | `#5fd7d7` |  81 | `#5fd7ff` |
+ * |  82 | `#5fff00` |  83 | `#5fff5f` |  84 | `#5fff87` |  85 | `#5fffaf` |  86 | `#5fffd7` |  87 | `#5fffff` |
+ * |  88 | `#870000` |  89 | `#87005f` |  90 | `#870087` |  91 | `#8700af` |  92 | `#8700d7` |  93 | `#8700ff` |
+ * |  94 | `#875f00` |  95 | `#875f5f` |  96 | `#875f87` |  97 | `#875faf` |  98 | `#875fd7` |  99 | `#875fff` |
+ * | 100 | `#878700` | 101 | `#87875f` | 102 | `#878787` | 103 | `#8787af` | 104 | `#8787d7` | 105 | `#8787ff` |
+ * | 106 | `#87af00` | 107 | `#87af5f` | 108 | `#87af87` | 109 | `#87afaf` | 110 | `#87afd7` | 111 | `#87afff` |
+ * | 112 | `#87d700` | 113 | `#87d75f` | 114 | `#87d787` | 115 | `#87d7af` | 116 | `#87d7d7` | 117 | `#87d7ff` |
+ * | 118 | `#87ff00` | 119 | `#87ff5f` | 120 | `#87ff87` | 121 | `#87ffaf` | 122 | `#87ffd7` | 123 | `#87ffff` |
+ * | 124 | `#af0000` | 125 | `#af005f` | 126 | `#af0087` | 127 | `#af00af` | 128 | `#af00d7` | 129 | `#af00ff` |
+ * | 130 | `#af5f00` | 131 | `#af5f5f` | 132 | `#af5f87` | 133 | `#af5faf` | 134 | `#af5fd7` | 135 | `#af5fff` |
+ * | 136 | `#af8700` | 137 | `#af875f` | 138 | `#af8787` | 139 | `#af87af` | 140 | `#af87d7` | 141 | `#af87ff` |
+ * | 142 | `#afaf00` | 143 | `#afaf5f` | 144 | `#afaf87` | 145 | `#afafaf` | 146 | `#afafd7` | 147 | `#afafff` |
+ * | 148 | `#afd700` | 149 | `#afd75f` | 150 | `#afd787` | 151 | `#afd7af` | 152 | `#afd7d7` | 153 | `#afd7ff` |
+ * | 154 | `#afff00` | 155 | `#afff5f` | 156 | `#afff87` | 157 | `#afffaf` | 158 | `#afffd7` | 159 | `#afffff` |
+ * | 160 | `#d70000` | 161 | `#d7005f` | 162 | `#d70087` | 163 | `#d700af` | 164 | `#d700d7` | 165 | `#d700ff` |
+ * | 166 | `#d75f00` | 167 | `#d75f5f` | 168 | `#d75f87` | 169 | `#d75faf` | 170 | `#d75fd7` | 171 | `#d75fff` |
+ * | 172 | `#d78700` | 173 | `#d7875f` | 174 | `#d78787` | 175 | `#d787af` | 176 | `#d787d7` | 177 | `#d787ff` |
+ * | 178 | `#d7af00` | 179 | `#d7af5f` | 180 | `#d7af87` | 181 | `#d7afaf` | 182 | `#d7afd7` | 183 | `#d7afff` |
+ * | 184 | `#d7d700` | 185 | `#d7d75f` | 186 | `#d7d787` | 187 | `#d7d7af` | 188 | `#d7d7d7` | 189 | `#d7d7ff` |
+ * | 190 | `#d7ff00` | 191 | `#d7ff5f` | 192 | `#d7ff87` | 193 | `#d7ffaf` | 194 | `#d7ffd7` | 195 | `#d7ffff` |
+ * | 196 | `#ff0000` | 197 | `#ff005f` | 198 | `#ff0087` | 199 | `#ff00af` | 200 | `#ff00d7` | 201 | `#ff00ff` |
+ * | 202 | `#ff5f00` | 203 | `#ff5f5f` | 204 | `#ff5f87` | 205 | `#ff5faf` | 206 | `#ff5fd7` | 207 | `#ff5fff` |
+ * | 208 | `#ff8700` | 209 | `#ff875f` | 210 | `#ff8787` | 211 | `#ff87af` | 212 | `#ff87d7` | 213 | `#ff87ff` |
+ * | 214 | `#ffaf00` | 215 | `#ffaf5f` | 216 | `#ffaf87` | 217 | `#ffafaf` | 218 | `#ffafd7` | 219 | `#ffafff` |
+ * | 220 | `#ffd700` | 221 | `#ffd75f` | 222 | `#ffd787` | 223 | `#ffd7af` | 224 | `#ffd7d7` | 225 | `#ffd7ff` |
+ * | 226 | `#ffff00` | 227 | `#ffff5f` | 228 | `#ffff87` | 229 | `#ffffaf` | 230 | `#ffffd7` | 231 | `#ffffff` |
+ * 
+ * ### Grey Scale Ramp
+ * 
+ * |     |           |     |           |     |           |     |           |     |           |     |           |     |           |     |           |
+ * | :-- | :-------- | :-- | :-------  | :-- | :-------  | :-- | :-------  | :-- | :-------  | :-- | :-------  | :-- | :-------  | :-- | :-------- |
+ * | 232 | `#080808` | 233 | `#121212` | 234 | `#1c1c1c` | 235 | `#262626` | 236 | `#303030` | 237 | `#3a3a3a` | 238 | `#444444` | 239 | `#4e4e4e` |
+ * | 240 | `#585858` | 241 | `#606060` | 242 | `#666666` | 243 | `#767676` | 244 | `#808080` | 245 | `#8a8a8a` | 246 | `#949494` | 247 | `#9e9e9e` |
+ * | 248 | `#a8a8a8` | 249 | `#b2b2b2` | 250 | `#bcbcbc` | 251 | `#c6c6c6` | 252 | `#d0d0d0` | 253 | `#dadada` | 254 | `#e4e4e4` | 255 | `#eeeeee` |
+ */
+static uint32_t color_xterm256_to_24bit(const uint32_t color)
+{
+  static const uint32_t basic[] = {
+    0x000000, 0x800000, 0x008000, 0x808000, 0x000080, 0x800080,
+    0x008080, 0xc0c0c0, 0x808080, 0xff0000, 0x00ff00, 0xffff00,
+    0x0000ff, 0xff00ff, 0x00ffff, 0xffffff,
+  };
+
+  assert(color < 256);
+
+  if (color < 16)
+  {
+    color_debug(LL_DEBUG5, "Converted color 0-15: %d\n", color);
+    /* The first 16 colours are the "usual" terminal colours */
+    return basic[color];
+  }
+
+  if (color < 232)
+  {
+    /* The Color palette is divided in 6x6x6 colours, i.e. each R, G, B channel
+     * has six values:
+     *
+     *  value: 1     2     3     4     5     6
+     *  color: 0x00  0x5f  0x87  0xaf  0xd7  0xff
+     *
+     * The steps between the values is 0x28 = 40, the EXCEPT for the first one
+     * where it is 0x5f = 95.
+     *
+     * If we express the xterm color number minus 16 to base 6, i.e.
+     *
+     *    color - 16 = vr * 36 + vg * 6 + vb * 1
+     *
+     * with vr, vg, vb integers between 0 and 5, then vr, vg, vb is the channel
+     * value for red, green, and blue, respectively.
+     */
+
+    uint32_t normalised_color = color - 16;
+    uint32_t vr = (normalised_color % 216) / 36; /* 216 = 6*6*6 */
+    uint32_t vg = (normalised_color % 36) / 6;
+    uint32_t vb = (normalised_color % 6) / 1;
+
+    /* First step is wider than the other ones, so add the difference if needed */
+    uint32_t r = vr * 0x28 + ((vr > 0) ? (0x5f - 0x40) : 0);
+    uint32_t g = vg * 0x28 + ((vg > 0) ? (0x5f - 0x40) : 0);
+    uint32_t b = vb * 0x28 + ((vb > 0) ? (0x5f - 0x40) : 0);
+
+    uint32_t rgb = (r << 16) + (g << 8) + (b << 0);
+    color_debug(LL_DEBUG5, "Converted xterm color %d to RGB #%x:\n", color, rgb);
+    return rgb;
+  }
+
+  /* Grey scale starts at 0x08 and adds 0xa = 10 in very step ending in 0xee.
+   * There are a total of 6*4 = 24 grey colors in total. */
+  uint32_t steps = color - 232;
+  uint32_t grey = (steps * 0x0a) + 0x08;
+  uint32_t rgb = (grey << 16) + (grey << 8) + (grey << 0);
+  color_debug(LL_DEBUG5, "Converted xterm color %d to RGB #%x:\n", color, rgb);
+  return rgb;
+}
+#endif
+
 /**
  * parse_color_name - Parse a colour name
  * @param[in]  s     String to parse
@@ -139,11 +272,23 @@ static enum CommandResult parse_color_name(const char *s, uint32_t *col, int *at
     s += clen;
     char *eptr = NULL;
     *col = strtoul(s, &eptr, 10);
-    if ((*s == '\0') || (*eptr != '\0') || ((*col >= COLORS) && !OptNoCurses))
+    /* There are only 256 xterm colors.  Do not confuse with COLORS which is
+     * the number of colours the terminal supports (usually one of 16, 256,
+     * 16777216 (=24bit)). */
+    if ((*s == '\0') || (*eptr != '\0') || (*col >= 256) || ((*col >= COLORS) && !OptNoCurses))
     {
       buf_printf(err, _("%s: color not supported by term"), s);
       return MUTT_CMD_ERROR;
     }
+#ifdef NEOMUTT_DIRECT_COLORS
+    const bool c_color_directcolor = cs_subset_bool(NeoMutt->sub, "color_directcolor");
+    if (c_color_directcolor)
+    {
+      /* If we are running in direct color mode, we must convert the xterm
+       * color numbers 0-255 to an RGB value. */
+      *col = color_xterm256_to_24bit(*col);
+    }
+#endif
     color_debug(LL_DEBUG5, "colorNNN %d\n", *col);
     return MUTT_CMD_SUCCESS;
   }
@@ -237,6 +382,22 @@ static enum CommandResult parse_color_name(const char *s, uint32_t *col, int *at
         }
       }
     }
+#ifdef NEOMUTT_DIRECT_COLORS
+    /* If we are running in direct color mode, we must convert the color
+     * number 0-15 to an RGB value.
+     * The first 16 colours of the xterm palette correspond to the terminal
+     * colours. Note that this replace the colour with a predefined RGB value
+     * and not the RGB value the terminal configured to use.
+     *
+     * Note that some colors are "special" e.g. "default" and do not fall in
+     * the range from 0 to 15.  These must not be converted.
+     */
+    const bool c_color_directcolor = cs_subset_bool(NeoMutt->sub, "color_directcolor");
+    if (c_color_directcolor && (0 <= *col) && (*col < 16))
+    {
+      *col = color_xterm256_to_24bit(*col);
+    }
+#endif
     return MUTT_CMD_SUCCESS;
   }
 

--- a/color/command.c
+++ b/color/command.c
@@ -477,13 +477,13 @@ static enum CommandResult parse_color_pair(struct Buffer *buf, struct Buffer *s,
 {
   while (true)
   {
-    if (!MoreArgs(s))
+    if (!MoreArgsF(s, TOKEN_COMMENT))
     {
       buf_printf(err, _("%s: too few arguments"), "color");
       return MUTT_CMD_WARNING;
     }
 
-    parse_extract_token(buf, s, TOKEN_NO_FLAGS);
+    parse_extract_token(buf, s, TOKEN_COMMENT);
 
     if (mutt_istr_equal("bold", buf->data))
     {
@@ -529,13 +529,13 @@ static enum CommandResult parse_color_pair(struct Buffer *buf, struct Buffer *s,
     }
   }
 
-  if (!MoreArgs(s))
+  if (!MoreArgsF(s, TOKEN_COMMENT))
   {
     buf_printf(err, _("%s: too few arguments"), "color");
     return MUTT_CMD_WARNING;
   }
 
-  parse_extract_token(buf, s, TOKEN_NO_FLAGS);
+  parse_extract_token(buf, s, TOKEN_COMMENT);
 
   return parse_color_name(buf->data, bg, attrs, false, err);
 }

--- a/color/command.c
+++ b/color/command.c
@@ -287,6 +287,11 @@ static enum CommandResult parse_color_name(const char *s, uint32_t *col, int *at
       /* If we are running in direct color mode, we must convert the xterm
        * color numbers 0-255 to an RGB value. */
       *col = color_xterm256_to_24bit(*col);
+      /* FIXME: The color values 0 to 7 (both inclusive) are still occupied by
+       * the default terminal colours.  As a workaround we round them up to
+       * #000008 which is the blackest black we can produce. */
+      if (*col < 8)
+        *col = 8;
     }
 #endif
     color_debug(LL_DEBUG5, "colorNNN %d\n", *col);
@@ -314,6 +319,12 @@ static enum CommandResult parse_color_name(const char *s, uint32_t *col, int *at
       buf_printf(err, _("%s: color not supported by term"), s);
       return MUTT_CMD_ERROR;
     }
+    /* FIXME: The color values 0 to 7 (both inclusive) are still occupied by
+     * the default terminal colours.  As a workaround we round them up to
+     * #000008 which is the blackest black we can produce. */
+    if (*col < 8)
+      *col = 8;
+
     color_debug(LL_DEBUG5, "#RRGGBB: %d\n", *col);
     return MUTT_CMD_SUCCESS;
   }

--- a/color/curses.c
+++ b/color/curses.c
@@ -103,8 +103,13 @@ static int curses_color_init(int fg, int bg)
   if (bg == COLOR_DEFAULT)
     bg = COLOR_UNSET;
 
+#ifdef NEOMUTT_DIRECT_COLORS
+  int rc = init_extended_pair(index, fg, bg);
+  color_debug(LL_DEBUG5, "init_extended_pair(%d,%d,%d) -> %d\n", index, fg, bg, rc);
+#else
   int rc = init_pair(index, fg, bg);
   color_debug(LL_DEBUG5, "init_pair(%d,%d,%d) -> %d\n", index, fg, bg, rc);
+#endif
 
   return index;
 }

--- a/docs/config.c
+++ b/docs/config.c
@@ -577,6 +577,28 @@
 ** unread messages.
 */
 
+{ "color_directcolor", DT_BOOL, false },
+/*
+** .pp
+** When \fIset\fP, NeoMutt will use and allow 24bit colours (aka truecolor aka
+** directcolor).  For colours to work properly support from the terminal is
+** required as well as a properly set TERM environment variable advertising the
+** terminals directcolor capability, e.g. "TERM=xterm-direct".
+** .pp
+** NeoMutt tries to detect whether the terminal supports 24bit colours and
+** enables this variable if it does.  If this fails for some reason, you can
+** force 24bit colours by setting this variable manually.  You may also try to
+** force a certain TERM environment variable by starting NeoMutt from
+** a terminal as follows (this results in wrong colours if the terminal does
+** not implement directcolors):
+** .ts
+** TERM=xterm-direct neomutt
+** .te
+** .pp
+** Note: This variable must be set before using any `color` commands.
+** .pp
+*/
+
 { "compose_format", DT_STRING, "-- NeoMutt: Compose  [Approx. msg size: %l   Atts: %a]%>-" },
 /*
 ** .pp

--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -5248,6 +5248,14 @@ folder-hook work "set sort=threads"
         If your terminal supports color, you can spice up NeoMutt by creating
         your own <link linkend="color-style">color scheme</link>.
       </para>
+      <note>
+        <para>
+          The config variable
+          <link linkend="color-directcolor">$color_directcolor</link> must be
+          set to its final value <emphasis>before</emphasis> using any
+          <literal>color</literal> command.
+        </para>
+      </note>
       <para>
         The types of objects that can be colored fall into two categories:
         <link linkend="color-simple">Simple Colors</link> such as the
@@ -5271,12 +5279,19 @@ folder-hook work "set sort=threads"
           </para>
         </note>
         <para>
-          Colors can be specified in two ways, using their name
-          such as <literal>green</literal>, <literal>blue</literal>,
-          or by their number in the palette,
+          Colors can be specified in up to three ways, using their name
+          such as <literal>green</literal>, <literal>blue</literal>;
+          by their number in the palette,
           such as <literal>color12</literal>, <literal>color207</literal>
           (the palette consists of the
-          <ulink url="https://web.archive.org/web/20190712111427/https://jonasjacek.github.io/colors/">256 Xterm colors</ulink>).
+          <ulink url="https://web.archive.org/web/20190712111427/https://jonasjacek.github.io/colors/">256 Xterm colors</ulink>);
+          or by using hexadecimal RGB codes <literal>#RRGGBB</literal>, where
+          <literal>RR</literal>, <literal>GG</literal>, <literal>BB</literal>
+          are the red, green, and blue components given as a hexadecimal number
+          between 00 and FF (=255), e.g. <literal>#00FFFF</literal> (bright
+          cyan) or <literal>#12af84</literal> (greenish).  The last syntax is
+          only accepted if <link linkend="color-directcolor">$color_directcolor</link>
+          is set.
         </para>
         <para>
           Named colours may also be prefixed by a <emphasis>modifier</emphasis>.
@@ -5381,6 +5396,38 @@ folder-hook work "set sort=threads"
 color error default red
 color error white   default
 </screen>
+        <para>
+          On startup NeoMutt tries to detect whether the terminal it is running
+          in supports directcolor (aka TrueColor aka 24-bit color).  If the
+          terminal does, NeoMutt enables the config variable
+          <link linkend="color-directcolor">$color_directcolor</link> otherwise
+          it disables it.  Furthermore, NeoMutt allows to use the RGB colors
+          syntax with the <literal>color</literal> command to colour elements
+          with 24-bit colors.
+        </para>
+        <para>
+          For the detection to work the
+          <emphasis>TERM</emphasis> environment variable must be set up
+          properly to advertise the terminals directcolor capability.
+          <emphasis>TERM</emphasis>-values which do that usually end in
+          <literal>-direct</literal>, e.g. <literal>xterm-direct</literal>.
+        </para>
+        <para>
+          If NeoMutt does not detect directcolor color support, but you are
+          sure your terminal supports it, you may try to explicitly set the
+          <emphasis>TERM</emphasis> environment variable by starting NeoMutt
+          from the terminal as follows:
+        </para>
+<screen>
+TERM=xterm-direct neomutt
+</screen>
+        <para>
+          If that still does not help, you can additionally force NeoMutt to
+          use directcolors by setting
+          <link linkend="color-directcolor">$color_directcolor</link>.
+          Setting this variable manually is strongly discouraged since it
+          usually leads to wrong colors.
+        </para>
       </sect2>
 
       <sect2 id="color-simple">

--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -5266,6 +5266,8 @@ folder-hook work "set sort=threads"
           <para>
             Objects must be given <emphasis>both</emphasis> a foreground and
             background color (it is not possible to specify one or the other).
+            Note that <literal>default</literal> can be used as transparent
+            color (see below).
           </para>
         </note>
         <para>
@@ -5368,7 +5370,17 @@ folder-hook work "set sort=threads"
           If your terminal supports it, the special keyword
           <emphasis>default</emphasis> can be used as a transparent color. The
           value <emphasis>brightdefault</emphasis> is also valid.
+          In this case <emphasis>default</emphasis> can be used to only set the
+          foreground or background color.  The following sets the foreground
+          and background color individually: the first command leaves the
+          foreground untouched while the second one leaves the background
+          untouched:
         </para>
+<screen>
+<emphasis role="comment"># Make error messages white text on a red background</emphasis>
+color error default red
+color error white   default
+</screen>
       </sect2>
 
       <sect2 id="color-simple">

--- a/docs/neomuttrc.man.head
+++ b/docs/neomuttrc.man.head
@@ -336,6 +336,7 @@ Valid colors include:
 .BR magenta ", "
 .BR cyan ", "
 .BR white ", "
+.BR #\fIRRGGBB\fP ", "
 .BR color\fIN\fP "."
 .IP
 Valid attributes include:

--- a/init.c
+++ b/init.c
@@ -346,6 +346,30 @@ int mutt_init(struct ConfigSet *cs, bool skip_sys_rc, struct ListHead *commands)
   nm_init();
 #endif
 
+#ifdef NEOMUTT_DIRECT_COLORS
+  /* Test if we run in a terminal which supports direct colours.
+   *
+   * The user/terminal can indicate their capability independent of the
+   * terminfo file by setting the COLORTERM environment variable to "truecolor"
+   * or "24bit" (case sensitive).
+   *
+   * Note: This is to test is less about whether the terminal understands
+   * direct color commands but more about whether ncurses believes it can send
+   * them to the terminal, e.g. ncurses ignores COLORTERM.
+   */
+  if (COLORS == 16777216) // 2^24
+  {
+    /* Ncurses believes the Terminal supports it check the environment variable
+     * to respect the user's choice */
+    const char *env_colorterm = mutt_str_getenv("COLORTERM");
+    if (env_colorterm && (mutt_str_equal(env_colorterm, "truecolor") ||
+                          mutt_str_equal(env_colorterm, "24bit")))
+    {
+      cs_subset_str_native_set(NeoMutt->sub, "color_directcolor", true, NULL);
+    }
+  }
+#endif
+
   /* "$spool_file" precedence: config file, environment */
   const char *p = mutt_str_getenv("MAIL");
   if (!p)

--- a/mutt_config.c
+++ b/mutt_config.c
@@ -191,6 +191,9 @@ static struct ConfigDef MainVars[] = {
   { "collapse_unread", DT_BOOL, true, 0, NULL,
     "Prevent the collapse of threads with unread emails"
   },
+  { "color_directcolor", DT_BOOL, false, 0, NULL,
+    "Use 24bit colors (aka truecolor aka directcolor)"
+  },
   { "config_charset", DT_STRING, 0, 0, charset_validator,
     "Character set that the config files are in"
   },

--- a/parse/extract.h
+++ b/parse/extract.h
@@ -29,6 +29,17 @@ struct Buffer;
 
 #define MoreArgs(buf) (*(buf)->dptr && (*(buf)->dptr != ';') && (*(buf)->dptr != '#'))
 
+/* The same conditions as in mutt_extract_token() */
+#define MoreArgsF(buf, flags) (*(buf)->dptr && \
+    (!IS_SPACE(*(buf)->dptr) || ((flags) & TOKEN_SPACE)) && \
+    ((*(buf)->dptr != '#') ||  ((flags) & TOKEN_COMMENT)) && \
+    ((*(buf)->dptr != '+') || !((flags) & TOKEN_PLUS)) && \
+    ((*(buf)->dptr != '-') || !((flags) & TOKEN_MINUS)) && \
+    ((*(buf)->dptr != '=') || !((flags) & TOKEN_EQUAL)) && \
+    ((*(buf)->dptr != '?') || !((flags) & TOKEN_QUESTION)) && \
+    ((*(buf)->dptr != ';') || ((flags) & TOKEN_SEMICOLON)) && \
+    (!((flags) & TOKEN_PATTERN) || strchr("~%=!|", *(buf)->dptr)))
+
 typedef uint16_t TokenFlags;          ///< Flags for parse_extract_token(), e.g. #TOKEN_EQUAL
 #define TOKEN_NO_FLAGS            0   ///< No flags are set
 #define TOKEN_EQUAL         (1 << 0)  ///< Treat '=' as a special


### PR DESCRIPTION
## Implement 24 bit colours aka "truecolor"

and, yes, this is a one line change.

Obviously, this is the bare heart of the machine without any chassis, safeguards, etc.
It's a proof of concept whether this would be acceptable to NeoMutt and maybe we can built on it.

## How to use 24bit colours?

Try this:
```
TERM=xterm-direct neomutt  -F /dev/null -e 'color status color65535 color16711935'
```

This should display a cyan on magenta status line.  The numbers are the RGB color `#00FFFF` and `#FF00FF` expressed in base 10.  Another example: If you want to, say, use the color `#12af84`, you would use the number 1224580.

## What are the caveats?

*  Needs a new enough ncurses and terminal as well as properly setup terminfo.

*  For some reason on my system the colours `#000000` to `#000007` are not black but the standard 8 terminal colours (red, green, ...).  I assume ncurses dose some trickery behind the scene and I couldn't figure out how to tell ncurses to not do that.  Any hints are welcome.

Note: colour 255 = `#0000FF` is blue and 256 = `#000100` is black again, so the colour numbers are not shifted by 8.

*  For this to work the terminal must be a `*-direct` terminal, e.g. `xterm-direct` or any other terminal advertising its 24bit colour capability *in a way ncurses understands*.  Luckily, the `TERM` variable can be used to do this (see above).

   It might be worth pointing out that many terminals support setting 24bit but do not advertise it in their `colors` capability but only by having a `setaf`, `setbf` capability.  This seems not to be enough for ncurses to accept 24bit colours.

## Where to go from here?

To mitigate the first caveat we can map the first 8 colours to `#000008` and hope nobody notices.  Honestly, that's ugly... unless we figure out how to persuate ncurses to use the 24bit colours.

The TERM requirement is more delicate.  I assume most users do run a DirectColor capable terminal emulator (most of these are nowadays) but only a minority uses the `*-direct` flavour of their terminal.  Most TUI programs can distinguish that and adjust, e.g. my Vim runs fine using direct colours without a `*-direct` term (but Vim does not use ncurses).

We could set our own TERM variable before initialising ncurses if we detect that the terminal is suitable for 24bit colours (this brings lots of term detection with it, which is ugly, compex and, honestly, shouldn't be done).  Or we could introduce a config variable `$term` which allows the user to set the terminal for the NeoMutt instance (probably a callback command, so the user can provide a dynamic answer when running the same config in different terminal emulators).  (Disclaimer: I have not tested whether ncurses can be tricked that way.)


If that approach above is acceptable I would start building a chassis around this commit:

*  Check for new enough ncurses
*  Implement the TERM hack above
*  New syntax to specify 24bit colors
*  Convert old `color123` constants to an 24bit-color using these values:

```
 0 #000000  1 #800000  2 #008000  3 #808000  4 #000080  5 #800080  6 #008080  7 #c0c0c0
 8 #808080  9 #ff0000 10 #00ff00 11 #ffff00 12 #0000ff 13 #ff00ff 14 #00ffff 15 #ffffff

 16 #000000  17 #00005f  18 #000087  19 #0000af  20 #0000d7  21 #0000ff
 22 #005f00  23 #005f5f  24 #005f87  25 #005faf  26 #005fd7  27 #005fff
 28 #008700  29 #00875f  30 #008787  31 #0087af  32 #0087d7  33 #0087ff
 34 #00af00  35 #00af5f  36 #00af87  37 #00afaf  38 #00afd7  39 #00afff
 40 #00d700  41 #00d75f  42 #00d787  43 #00d7af  44 #00d7d7  45 #00d7ff
 46 #00ff00  47 #00ff5f  48 #00ff87  49 #00ffaf  50 #00ffd7  51 #00ffff
 52 #5f0000  53 #5f005f  54 #5f0087  55 #5f00af  56 #5f00d7  57 #5f00ff
 58 #5f5f00  59 #5f5f5f  60 #5f5f87  61 #5f5faf  62 #5f5fd7  63 #5f5fff
 64 #5f8700  65 #5f875f  66 #5f8787  67 #5f87af  68 #5f87d7  69 #5f87ff
 70 #5faf00  71 #5faf5f  72 #5faf87  73 #5fafaf  74 #5fafd7  75 #5fafff
 76 #5fd700  77 #5fd75f  78 #5fd787  79 #5fd7af  80 #5fd7d7  81 #5fd7ff
 82 #5fff00  83 #5fff5f  84 #5fff87  85 #5fffaf  86 #5fffd7  87 #5fffff
 88 #870000  89 #87005f  90 #870087  91 #8700af  92 #8700d7  93 #8700ff
 94 #875f00  95 #875f5f  96 #875f87  97 #875faf  98 #875fd7  99 #875fff
100 #878700 101 #87875f 102 #878787 103 #8787af 104 #8787d7 105 #8787ff
106 #87af00 107 #87af5f 108 #87af87 109 #87afaf 110 #87afd7 111 #87afff
112 #87d700 113 #87d75f 114 #87d787 115 #87d7af 116 #87d7d7 117 #87d7ff
118 #87ff00 119 #87ff5f 120 #87ff87 121 #87ffaf 122 #87ffd7 123 #87ffff
124 #af0000 125 #af005f 126 #af0087 127 #af00af 128 #af00d7 129 #af00ff
130 #af5f00 131 #af5f5f 132 #af5f87 133 #af5faf 134 #af5fd7 135 #af5fff
136 #af8700 137 #af875f 138 #af8787 139 #af87af 140 #af87d7 141 #af87ff
142 #afaf00 143 #afaf5f 144 #afaf87 145 #afafaf 146 #afafd7 147 #afafff
148 #afd700 149 #afd75f 150 #afd787 151 #afd7af 152 #afd7d7 153 #afd7ff
154 #afff00 155 #afff5f 156 #afff87 157 #afffaf 158 #afffd7 159 #afffff
160 #d70000 161 #d7005f 162 #d70087 163 #d700af 164 #d700d7 165 #d700ff
166 #d75f00 167 #d75f5f 168 #d75f87 169 #d75faf 170 #d75fd7 171 #d75fff
172 #d78700 173 #d7875f 174 #d78787 175 #d787af 176 #d787d7 177 #d787ff
178 #d7af00 179 #d7af5f 180 #d7af87 181 #d7afaf 182 #d7afd7 183 #d7afff
184 #d7d700 185 #d7d75f 186 #d7d787 187 #d7d7af 188 #d7d7d7 189 #d7d7ff
190 #d7ff00 191 #d7ff5f 192 #d7ff87 193 #d7ffaf 194 #d7ffd7 195 #d7ffff
196 #ff0000 197 #ff005f 198 #ff0087 199 #ff00af 200 #ff00d7 201 #ff00ff
202 #ff5f00 203 #ff5f5f 204 #ff5f87 205 #ff5faf 206 #ff5fd7 207 #ff5fff
208 #ff8700 209 #ff875f 210 #ff8787 211 #ff87af 212 #ff87d7 213 #ff87ff
214 #ffaf00 215 #ffaf5f 216 #ffaf87 217 #ffafaf 218 #ffafd7 219 #ffafff
220 #ffd700 221 #ffd75f 222 #ffd787 223 #ffd7af 224 #ffd7d7 225 #ffd7ff
226 #ffff00 227 #ffff5f 228 #ffff87 229 #ffffaf 230 #ffffd7 231 #ffffff

232 #080808 233 #121212 234 #1c1c1c 235 #262626 236 #303030 237 #3a3a3a
238 #444444 239 #4e4e4e 240 #585858 241 #606060 242 #666666 243 #767676
244 #808080 245 #8a8a8a 246 #949494 247 #9e9e9e 248 #a8a8a8 249 #b2b2b2
250 #bcbcbc 251 #c6c6c6 252 #d0d0d0 253 #dadada 254 #e4e4e4 255 #eeeeee
```

Disclaimer:  I've never used ncurses, so feed back is welcome.
Maybe there is a better way to convince ncurses to use 24bit colours?


## Relevant issue number

https://github.com/neomutt/neomutt/issues/85