### PR TITLE
fix unhook index-format-hook

### DIFF
--- a/mutt_commands.c
+++ b/mutt_commands.c
@@ -70,7 +70,7 @@ static const struct Command mutt_commands[] = {
   { "ifdef",               parse_ifdef,            0 },
   { "ifndef",              parse_ifdef,            1 },
   { "ignore",              parse_ignore,           0 },
-  { "index-format-hook",   mutt_parse_idxfmt_hook, 0 },
+  { "index-format-hook",   mutt_parse_idxfmt_hook, MUTT_IDXFMTHOOK },
   { "lists",               parse_lists,            0 },
   { "macro",               mutt_parse_macro,       0 },
   { "mailboxes",           parse_mailboxes,        0 },


### PR DESCRIPTION
The `index-format-hook` command was missing its data field which should contain MUTT_IDXFMTHOOK.
This data is needed for `unhook` to work correctly.

Fixes: #3688 