### PR TITLE
Rename connect_timeout to socket_timeout, use it for read/write ops too

### DIFF
--- a/conn/config.c
+++ b/conn/config.c
@@ -36,9 +36,10 @@ static struct ConfigDef ConnVars[] = {
   { "account_command", DT_STRING|DT_COMMAND, 0, 0, NULL,
     "Shell command to retrieve account credentials"
   },
-  { "connect_timeout", DT_NUMBER, 30, 0, NULL,
-    "Timeout for making network connections (-1 to wait indefinitely)"
+  { "socket_timeout", DT_NUMBER, 30, 0, NULL,
+    "Timeout for socket connect/read/write operations (-1 to wait indefinitely)"
   },
+  { "connect_timeout", DT_SYNONYM, IP "socket_timeout", IP "2023-02-15" },
   { "preconnect", DT_STRING, 0, 0, NULL,
     "(socket) External command to run prior to opening a socket"
   },

--- a/conn/config.c
+++ b/conn/config.c
@@ -36,12 +36,11 @@ static struct ConfigDef ConnVars[] = {
   { "account_command", DT_STRING|DT_COMMAND, 0, 0, NULL,
     "Shell command to retrieve account credentials"
   },
-  { "socket_timeout", DT_NUMBER, 30, 0, NULL,
-    "Timeout for socket connect/read/write operations (-1 to wait indefinitely)"
-  },
-  { "connect_timeout", DT_SYNONYM, IP "socket_timeout", IP "2023-02-15" },
   { "preconnect", DT_STRING, 0, 0, NULL,
     "(socket) External command to run prior to opening a socket"
+  },
+  { "socket_timeout", DT_NUMBER, 30, 0, NULL,
+    "Timeout for socket connect/read/write operations (-1 to wait indefinitely)"
   },
   { "tunnel", DT_STRING|DT_COMMAND, 0, 0, NULL,
     "Shell command to establish a tunnel"
@@ -49,6 +48,8 @@ static struct ConfigDef ConnVars[] = {
   { "tunnel_is_secure", DT_BOOL, true, 0, NULL,
     "Assume a tunneled connection is secure"
   },
+
+  { "connect_timeout", DT_SYNONYM, IP "socket_timeout", IP "2023-02-15" },
   { NULL },
   // clang-format on
 };

--- a/conn/raw.c
+++ b/conn/raw.c
@@ -99,7 +99,7 @@ static int socket_connect(int fd, struct sockaddr *sa)
   if (c_socket_timeout > 0)
   {
     const struct timeval tv = { c_socket_timeout, 0 };
-    if (setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv)) < -1)
+    if (setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv)) < 0)
     {
       mutt_debug(LL_DEBUG2, "Cannot set socket receive timeout. errno: %d\n", errno);
     }

--- a/docs/config.c
+++ b/docs/config.c
@@ -616,14 +616,6 @@
 ** mailbox which does not yet exist before creating it.
 */
 
-{ "socket_timeout", DT_NUMBER, 30 },
-/*
-** .pp
-** Causes NeoMutt to timeout any socket connect/read/write operation (for IMAP,
-** POP or SMTP) after this many seconds.  A negative value causes NeoMutt to
-** wait indefinitely.
-*/
-
 { "content_type", DT_STRING, "text/plain" },
 /*
 ** .pp
@@ -4771,6 +4763,14 @@
 ** This variable defaults to your user name on the local machine.
 */
 #endif
+
+{ "socket_timeout", DT_NUMBER, 30 },
+/*
+** .pp
+** Causes NeoMutt to timeout any socket connect/read/write operation (for IMAP,
+** POP or SMTP) after this many seconds.  A negative value causes NeoMutt to
+** wait indefinitely.
+*/
 
 { "sort", DT_SORT, SORT_DATE },
 /*

--- a/docs/config.c
+++ b/docs/config.c
@@ -616,12 +616,12 @@
 ** mailbox which does not yet exist before creating it.
 */
 
-{ "connect_timeout", DT_NUMBER, 30 },
+{ "socket_timeout", DT_NUMBER, 30 },
 /*
 ** .pp
-** Causes NeoMutt to timeout a network connection (for IMAP, POP or SMTP) after this
-** many seconds if the connection is not able to be established.  A negative
-** value causes NeoMutt to wait indefinitely for the connection attempt to succeed.
+** Causes NeoMutt to timeout any socket connect/read/write operation (for IMAP,
+** POP or SMTP) after this many seconds.  A negative value causes NeoMutt to
+** wait indefinitely.
 */
 
 { "content_type", DT_STRING, "text/plain" },


### PR DESCRIPTION
Instead of adding dedicated timeout options for read/write, like upstream did, we're reusing the connect_timeout and renaming it to socket_timeout. At this point, we don't see a reason for wanting to specify different values for the connect/read/write operations.

Upstream-commit: https://gitlab.com/muttmua/mutt/-/commit/185346ad778f85f7889cff662516e2121bb1edbb
