### PR TITLE
Document that some pattern operations only apply to visible messages

### DIFF
--- a/opcodes.h
+++ b/opcodes.h
@@ -193,7 +193,7 @@ const char *opcodes_get_name       (int op);
   _fmt(OP_MAIN_CLEAR_FLAG,                    N_("clear a status flag from a message")) \
   _fmt(OP_MAIN_COLLAPSE_ALL,                  N_("collapse/uncollapse all threads")) \
   _fmt(OP_MAIN_COLLAPSE_THREAD,               N_("collapse/uncollapse current thread")) \
-  _fmt(OP_MAIN_DELETE_PATTERN,                N_("delete messages matching a pattern")) \
+  _fmt(OP_MAIN_DELETE_PATTERN,                N_("delete non-hidden messages matching a pattern")) \
   _fmt(OP_MAIN_FETCH_MAIL,                    N_("retrieve mail from POP server")) \
   _fmt(OP_MAIN_IMAP_FETCH,                    N_("force retrieval of mail from IMAP server")) \
   _fmt(OP_MAIN_IMAP_LOGOUT_ALL,               N_("logout from all IMAP servers")) \
@@ -222,9 +222,9 @@ const char *opcodes_get_name       (int op);
   _fmt(OP_MAIN_SET_FLAG,                      N_("set a status flag on a message")) \
   _fmt(OP_MAIN_SHOW_LIMIT,                    N_("show currently active limit pattern")) \
   _fmt(OP_MAIN_SYNC_FOLDER,                   N_("save changes to mailbox")) \
-  _fmt(OP_MAIN_TAG_PATTERN,                   N_("tag messages matching a pattern")) \
-  _fmt(OP_MAIN_UNDELETE_PATTERN,              N_("undelete messages matching a pattern")) \
-  _fmt(OP_MAIN_UNTAG_PATTERN,                 N_("untag messages matching a pattern")) \
+  _fmt(OP_MAIN_TAG_PATTERN,                   N_("tag non-hidden messages matching a pattern")) \
+  _fmt(OP_MAIN_UNDELETE_PATTERN,              N_("undelete non-hidden messages matching a pattern")) \
+  _fmt(OP_MAIN_UNTAG_PATTERN,                 N_("untag non-hidden messages matching a pattern")) \
   _fmt(OP_MARK_MSG,                           N_("create a hotkey macro for the current message")) \
   _fmt(OP_MIDDLE_PAGE,                        N_("move to the middle of the page")) \
   _fmt(OP_NEXT_ENTRY,                         N_("move to the next entry")) \


### PR DESCRIPTION
The patterns given to the functions `<delete-pattern>`, `<undelete-pattern>`, `<tag-pattern>`, and `<untag-pattern>` only match messages which are not hidden, i.e. shown by the limit and not collapsed inside a thread.  This is in contrast to the pattern matched by the `<limit>` function which applies to all messages in the mailbox hidden or not.

Note: This might invalidate a couple of translations.

Closes: #3690