### PR TITLE
Check before dereference

### DIFF
--- a/pager/pager.c
+++ b/pager/pager.c
@@ -317,10 +317,8 @@ static int pager_global_observer(struct NotifyCallback *nc)
   struct MuttWindow *win_pager = nc->global_data;
 
   struct PagerPrivateData *priv = win_pager->wdata;
-  if (!priv)
-    return 0;
-
-  if ((priv->redraw & PAGER_REDRAW_FLOW) && (priv->pview->flags & MUTT_PAGER_RETWINCH))
+  const struct PagerView *pview = priv ? priv->pview : NULL;
+  if (priv && pview && (priv->redraw & PAGER_REDRAW_FLOW) && (pview->flags & MUTT_PAGER_RETWINCH))
   {
     priv->rc = OP_REFORMAT_WINCH;
   }


### PR DESCRIPTION
I got a crash here after a restart of dovecot left me without a mailbox:

```
pager/pager.c:323:59: runtime error: member access within null pointer of type 'struct PagerView'
```

Not sure how we came here, but I figure it's worth checking before dereferencing anyway :)
