### PR TITLE
send: delete signature when sending fails

### DIFF
--- a/send/send.c
+++ b/send/send.c
@@ -2892,7 +2892,9 @@ int mutt_send_message(SendFlags flags, struct Email *e_templ, const char *tempfi
         mutt_body_free(&e_templ->body->parts->next); /* destroy sig */
         if (mutt_istr_equal(e_templ->body->subtype, "mixed") ||
             mutt_istr_equal(e_templ->body->subtype, "signed"))
+        {
           e_templ->body = mutt_remove_multipart(e_templ->body);
+        }
       }
 
       FREE(&pgpkeylist);

--- a/send/send.c
+++ b/send/send.c
@@ -2890,7 +2890,8 @@ int mutt_send_message(SendFlags flags, struct Email *e_templ, const char *tempfi
       else if ((e_templ->security & SEC_SIGN) && (e_templ->body->type == TYPE_MULTIPART))
       {
         mutt_body_free(&e_templ->body->parts->next); /* destroy sig */
-        if (mutt_istr_equal(e_templ->body->subtype, "mixed"))
+        if (mutt_istr_equal(e_templ->body->subtype, "mixed") ||
+            mutt_istr_equal(e_templ->body->subtype, "signed"))
           e_templ->body = mutt_remove_multipart(e_templ->body);
       }
 


### PR DESCRIPTION
When sending fails after a message has been signed (but not encrypted), then the `multipart/signed` container is not removed, leaving a corrupt `multipart/signed` message without the actual signature. Subsequent attempts to send the message add additional corrupt `multipart/signed` containers.

This PR removes the `multipart/signed` container in this case.

Fixes #3705 