### PR TITLE
Allow %[fmt] in $folder_format

### DIFF
--- a/browser/browser.c
+++ b/browser/browser.c
@@ -209,7 +209,8 @@ static const char *folder_format_str(char *buf, size_t buflen, size_t col, int c
                                      const char *if_str, const char *else_str,
                                      intptr_t data, MuttFormatFlags flags)
 {
-  char fn[128], fmt[128];
+  char fn[128] = { 0 };
+  char fmt[128] = { 0 };
   struct Folder *folder = (struct Folder *) data;
   bool optional = (flags & MUTT_FORMAT_OPTIONAL);
 

--- a/browser/browser.c
+++ b/browser/browser.c
@@ -203,6 +203,7 @@ bool link_is_dir(const char *folder, const char *path)
  * | \%s     | Size in bytes
  * | \%t     | `*` if the file is tagged, blank otherwise
  * | \%u     | Owner name (or numeric uid, if missing)
+ * | \%[fmt] | Date folder was last modified using strftime(3)
  */
 static const char *folder_format_str(char *buf, size_t buflen, size_t col, int cols,
                                      char op, const char *src, const char *prec,
@@ -252,6 +253,67 @@ static const char *folder_format_str(char *buf, size_t buflen, size_t col, int c
           setlocale(LC_TIME, "");
 
         mutt_format_s(buf, buflen, prec, date);
+      }
+      else
+      {
+        mutt_format_s(buf, buflen, prec, "");
+      }
+      break;
+
+    case '[':
+      if (folder->ff->local)
+      {
+        char buf2[128] = { 0 };
+        bool do_locales = true;
+        struct tm tm = { 0 };
+
+        char *p = buf;
+
+        const char *cp = src;
+        if (*cp == '!')
+        {
+          do_locales = false;
+          cp++;
+        }
+
+        size_t len = buflen - 1;
+        while ((len > 0) && (*cp != ']'))
+        {
+          if (*cp == '%')
+          {
+            cp++;
+            if (len >= 2)
+            {
+              *p++ = '%';
+              *p++ = *cp;
+              len -= 2;
+            }
+            else
+            {
+              break; /* not enough space */
+            }
+            cp++;
+          }
+          else
+          {
+            *p++ = *cp++;
+            len--;
+          }
+        }
+        *p = '\0';
+
+        tm = mutt_date_localtime(folder->ff->mtime);
+
+        if (!do_locales)
+          setlocale(LC_TIME, "C");
+        strftime(buf2, sizeof(buf2), buf, &tm);
+        if (!do_locales)
+          setlocale(LC_TIME, "");
+
+        snprintf(fmt, sizeof(fmt), "%%%ss", prec);
+        snprintf(buf, buflen, fmt, buf2);
+        if (len > 0)
+          src = cp + 1;
       }
       else
       {

--- a/browser/browser.c
+++ b/browser/browser.c
@@ -1076,6 +1076,7 @@ static int browser_config_observer(struct NotifyCallback *nc)
       !mutt_str_equal(ev_c->name, "date_format") && !mutt_str_equal(ev_c->name, "folder") &&
       !mutt_str_equal(ev_c->name, "folder_format") &&
       !mutt_str_equal(ev_c->name, "group_index_format") &&
+      !mutt_str_equal(ev_c->name, "mailbox_folder_format") &&
       !mutt_str_equal(ev_c->name, "sort_browser"))
   {
     return 0;

--- a/docs/config.c
+++ b/docs/config.c
@@ -1269,6 +1269,7 @@
 ** .dt %s  .dd   .dd Size in bytes (see $formatstrings-size)
 ** .dt %t  .dd   .dd "*" if the file is tagged, blank otherwise
 ** .dt %u  .dd   .dd Owner name (or numeric uid, if missing)
+** .dt %[fmt] .dd   .dd Date/time folder was last modified using an \fCstrftime(3)\fP expression
 ** .dt %>X .dd   .dd Right justify the rest of the string and pad with character "X"
 ** .dt %|X .dd   .dd Pad to the end of the line with character "X"
 ** .dt %*X .dd   .dd Soft-fill with character "X" as pad
@@ -2234,6 +2235,7 @@
 ** .dt %N  .dd   .dd "N" if mailbox has new mail, " " (space) otherwise
 ** .dt %s  .dd   .dd Size in bytes (see $formatstrings-size)
 ** .dt %u  .dd   .dd Owner name (or numeric uid, if missing)
+** .dt %[fmt] .dd   .dd Date/time folder was last modified using an \fCstrftime(3)\fP expression
 ** .dt %>X .dd   .dd Right justify the rest of the string and pad with character "X"
 ** .dt %|X .dd   .dd Pad to the end of the line with character "X"
 ** .dt %*X .dd   .dd Soft-fill with character "X" as pad

--- a/docs/config.c
+++ b/docs/config.c
@@ -2218,36 +2218,8 @@
 ** .pp
 ** This variable allows you to customize the file browser display to your
 ** personal taste. It's only used to customize network mailboxes (e.g. imap).
-** This string is similar to $$index_format, but has its own set of
-** \fCprintf(3)\fP-like sequences:
-** .dl
-** .dt %C  .dd   .dd Current file number
-** .dt %d  .dd   .dd Date/time folder was last modified
-** .dt %D  .dd   .dd Date/time folder was last modified using $$date_format.
-** .dt %f  .dd   .dd Filename ("/" is appended to directory names,
-**                   "@" to symbolic links and "*" to executable files)
-** .dt %F  .dd   .dd File permissions
-** .dt %g  .dd   .dd Group name (or numeric gid, if missing)
-** .dt %i  .dd   .dd Description of the folder
-** .dt %l  .dd   .dd Number of hard links
-** .dt %m  .dd * .dd Number of messages in the mailbox
-** .dt %n  .dd * .dd Number of unread messages in the mailbox
-** .dt %N  .dd   .dd "N" if mailbox has new mail, " " (space) otherwise
-** .dt %s  .dd   .dd Size in bytes (see $formatstrings-size)
-** .dt %u  .dd   .dd Owner name (or numeric uid, if missing)
-** .dt %[fmt] .dd   .dd Date/time folder was last modified using an \fCstrftime(3)\fP expression
-** .dt %>X .dd   .dd Right justify the rest of the string and pad with character "X"
-** .dt %|X .dd   .dd Pad to the end of the line with character "X"
-** .dt %*X .dd   .dd Soft-fill with character "X" as pad
-** .de
-** .pp
-** For an explanation of "soft-fill", see the $$index_format documentation.
-** .pp
-** * = can be optionally printed if nonzero
-** .pp
-** %m, %n, and %N only work for monitored mailboxes.
-** %m requires $$mail_check_stats to be set.
-** %n requires $$mail_check_stats to be set (except for IMAP mailboxes).
+** This string is identical in formatting to the one used by
+** "$$folder_format".
 */
 
 { "mailcap_path", DT_SLIST, "~/.mailcap:" PKGDATADIR "/mailcap:" SYSCONFDIR "/mailcap:/etc/mailcap:/usr/etc/mailcap:/usr/local/etc/mailcap" },


### PR DESCRIPTION
* **What does this PR do?**

This is a patch I've bin sitting on for a while, I've polished it a little, so maybe it might be useful to others.
The patch adds the `%[fmt]` expand to browser format to allow formatting the date with an `strftime(3)` sequence similar to what `$pgp_entry_format` has.

To my knowledge this is the last format which relies on `$date_format` but had no other way of formatting dates, so maybe you guys can think about deprecating `$date_format`.