### PR TITLE
Document alternatives to $date_format

### DIFF
--- a/docs/config.c
+++ b/docs/config.c
@@ -1271,6 +1271,8 @@
 ** .dt %C  .dd   .dd Current file number
 ** .dt %d  .dd   .dd Date/time folder was last modified
 ** .dt %D  .dd   .dd Date/time folder was last modified using $$date_format.
+**                   It is encouraged to use "%[fmt]" instead, where "fmt" is
+**                   the value of $$date_format.
 ** .dt %f  .dd   .dd Filename ("/" is appended to directory names,
 **                   "@" to symbolic links and "*" to executable files)
 ** .dt %F  .dd   .dd File permissions
@@ -2044,7 +2046,9 @@
 ** .dt %c .dd Number of characters (bytes) in the body of the message (see $formatstrings-size)
 ** .dt %cr .dd Number of characters (bytes) in the raw message, including the header (see $formatstrings-size)
 ** .dt %D .dd Date and time of message using $date_format and local timezone
+**            It is encouraged to use "%[fmt]" instead, where "fmt" is the value of $$date_format.
 ** .dt %d .dd Date and time of message using $date_format and sender's timezone
+**            It is encouraged to use "%{fmt}" instead, where "fmt" is the value of $$date_format.
 ** .dt %e .dd Current message number in thread
 ** .dt %E .dd Number of messages in current thread
 ** .dt %F .dd Author name, or recipient name if the message is from you

--- a/docs/config.c
+++ b/docs/config.c
@@ -902,6 +902,11 @@
 { "date_format", DT_STRING, "!%a, %b %d, %Y at %I:%M:%S%p %Z" },
 /*
 ** .pp
+** Instead of using $$date_format it is encouraged to use "%[fmt]"
+** directly in the corresponding format strings, where "fmt" is the
+** value of $$date_format.  This allows for a more fine grained control
+** of the different menu needs.
+** .pp
 ** This variable controls the format of the date printed by the "%d"
 ** sequence in $$index_format.  This is passed to the \fCstrftime(3)\fP
 ** function to process the date, see the man page for the proper syntax.
@@ -912,6 +917,15 @@
 ** bang, the bang is discarded, and the month and week day names in the
 ** rest of the string are expanded in the \fIC\fP locale (that is in US
 ** English).
+** .pp
+** Format strings using this variable are:
+** .pp
+** UI: $$folder_format, $$index_format, $$mailbox_folder_format,
+** $$message_format
+** .pp
+** Composing: $$attribution, $$forward_attribution_intro,
+** $$forward_attribution_trailer, $$forward_format, $$indent_string.
+** .pp
 */
 
 { "debug_file", DT_PATH, "~/.neomuttdebug" },


### PR DESCRIPTION
* **What does this PR do?**

This is a followup to #3717 following a suggestion of @flatcap.
Describe alternatives to using $date_format, namely `%[fmt]` (or in the case of the index also `%{fmt}`)