### PR TITLE
Let patterns cover Bcc header

### DIFF
--- a/debug/graphviz.c
+++ b/debug/graphviz.c
@@ -1694,6 +1694,7 @@ const char *pattern_type_name(int type)
     // clang-format off
     { "address",         MUTT_PAT_ADDRESS },
     { "AND",             MUTT_PAT_AND },
+    { "bcc",             MUTT_PAT_BCC },
     { "body",            MUTT_PAT_BODY },
     { "broken",          MUTT_PAT_BROKEN },
     { "cc",              MUTT_PAT_CC },

--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -8340,6 +8340,13 @@ set index_format="%4C %Z %{%b %d} %-15.15L (%?l?%4l&amp;%4c?)%*  %s"
                 </entry>
               </row>
               <row>
+                <entry>~K <emphasis>EXPR</emphasis></entry>
+                <entry></entry>
+                <entry>
+                  messages blind carbon-copied to <emphasis>EXPR</emphasis>
+                </entry>
+              </row>
+              <row>
                 <entry>~L <emphasis>EXPR</emphasis></entry>
                 <entry></entry>
                 <entry>

--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -8202,14 +8202,14 @@ set index_format="%4C %Z %{%b %d} %-15.15L (%?l?%4l&amp;%4c?)%*  %s"
                 <entry>~C <emphasis>EXPR</emphasis></entry>
                 <entry></entry>
                 <entry>
-                  messages either to: or cc: <emphasis>EXPR</emphasis>
+                  messages either to:, cc: or bcc: <emphasis>EXPR</emphasis>
                 </entry>
               </row>
               <row>
                 <entry>%C <emphasis>GROUP</emphasis></entry>
                 <entry></entry>
                 <entry>
-                  messages either to: or cc: to any member of
+                  messages either to:, cc: or bcc: to any member of
                   <emphasis>GROUP</emphasis>
                 </entry>
               </row>

--- a/docs/neomuttrc.man.head
+++ b/docs/neomuttrc.man.head
@@ -1049,6 +1049,10 @@ _
 messages containing PGP key material
 T}
 _
+\0~K \fIEXPR\fP|T{
+messages blind carbon-copied to \fIEXPR\fP
+T}
+_
 \0%L \fIGROUP\fP|T{
 messages either originated or received by any member of \fIGROUP\fP
 T}

--- a/docs/neomuttrc.man.head
+++ b/docs/neomuttrc.man.head
@@ -1065,6 +1065,10 @@ _
 messages addressed to a known mailing list
 T}
 _
+\0~M \fIEXPR\fP|T{
+messages which contain a mime Content-Type matching \fIEXPR\fP
+T}
+_
 \0~m <\fIMAX\fP|T{
 messages with numbers less than \fIMAX\fP \fB*\fP)
 T}
@@ -1148,6 +1152,10 @@ T}
 _
 \0~v|T{
 message is part of a collapsed thread.
+T}
+_
+\0~w \fIEXPR\fP|T{
+newsgroups matching \fIEXPR\fP
 T}
 _
 \0~X \fIMIN\fP-\fIMAX\fP|T{

--- a/docs/neomuttrc.man.head
+++ b/docs/neomuttrc.man.head
@@ -965,7 +965,7 @@ messages which contain \fIEXPR\fP in the message body
 T}
 _
 \0%C \fIGROUP\fP|T{
-messages either \(lqTo:\(rq or \(lqCc:\(rq to any member of \fIGROUP\fP
+messages either \(lqTo:\(rq, \(lqCc:\(rq or \(lqBcc:\(rq to any member of \fIGROUP\fP
 T}
 _
 \0%c \fIGROUP\fP|T{
@@ -973,7 +973,7 @@ messages carbon-copied to any member of \fIGROUP\fP
 T}
 _
 \0~C \fIEXPR\fP|T{
-messages either \(lqTo:\(rq or \(lqCc:\(rq \fIEXPR\fP
+messages either \(lqTo:\(rq, \(lqCc:\(rq or \(lqBcc:\(rq \fIEXPR\fP
 T}
 _
 \0~c \fIEXPR\fP|T{

--- a/pattern/exec.c
+++ b/pattern/exec.c
@@ -385,7 +385,7 @@ static int match_addrlist(struct Pattern *pat, bool match_personal, int n, ...)
   va_list ap;
 
   va_start(ap, n);
-  for (; n; n--)
+  while (n-- > 0)
   {
     struct AddressList *al = va_arg(ap, struct AddressList *);
     struct Address *a = NULL;

--- a/pattern/exec.c
+++ b/pattern/exec.c
@@ -477,13 +477,13 @@ bool mutt_is_list_recipient(bool all_addr, struct Envelope *env)
 /**
  * match_user - Matches the user's email Address
  * @param all_addr If true, ALL Addresses must refer to the user
- * @param n       number of AddressesLists supplied
- * @param ...     Variable number of AddressesLists
+ * @param n       number of AddressLists supplied
+ * @param ...     Variable number of AddressLists
  * @retval true
  * - One Address refers to the user (all_addr is false)
  * - All the Addresses refer to the user (all_addr is true)
  */
-static int match_user(int all_addr, int n, ...)
+static int match_user(bool all_addr, int n, ...)
 {
   va_list ap;
 
@@ -998,7 +998,9 @@ static bool pattern_exec(struct Pattern *pat, PatternExecFlags flags,
         result = get_pattern_cache_value(*cache_entry);
       }
       else
+      {
         result = match_user(pat->all_addr, 3, &e->env->to, &e->env->cc, &e->env->bcc);
+      }
       return pat->pat_not ^ result;
     }
     case MUTT_PAT_PERSONAL_FROM:
@@ -1018,7 +1020,9 @@ static bool pattern_exec(struct Pattern *pat, PatternExecFlags flags,
         result = get_pattern_cache_value(*cache_entry);
       }
       else
+      {
         result = match_user(pat->all_addr, 1, &e->env->from);
+      }
       return pat->pat_not ^ result;
     }
     case MUTT_PAT_COLLAPSED:

--- a/pattern/exec.c
+++ b/pattern/exec.c
@@ -986,13 +986,14 @@ static bool pattern_exec(struct Pattern *pat, PatternExecFlags flags,
         int *cache_entry = pat->all_addr ? &cache->pers_recip_all : &cache->pers_recip_one;
         if (!is_pattern_cache_set(*cache_entry))
         {
-          set_pattern_cache_value(cache_entry, match_user(pat->all_addr, 2,
-                                                          &e->env->to, &e->env->cc));
+          set_pattern_cache_value(cache_entry,
+                                  match_user(pat->all_addr, 3, &e->env->to,
+                                             &e->env->cc, &e->env->bcc));
         }
         result = get_pattern_cache_value(*cache_entry);
       }
       else
-        result = match_user(pat->all_addr, 2, &e->env->to, &e->env->cc);
+        result = match_user(pat->all_addr, 3, &e->env->to, &e->env->cc, &e->env->bcc);
       return pat->pat_not ^ result;
     }
     case MUTT_PAT_PERSONAL_FROM:

--- a/pattern/exec.c
+++ b/pattern/exec.c
@@ -929,8 +929,8 @@ static bool pattern_exec(struct Pattern *pat, PatternExecFlags flags,
       if (!e->env)
         return false;
       return pat->pat_not ^ match_addrlist(pat, (flags & MUTT_MATCH_FULL_ADDRESS),
-                                           4, &e->env->from, &e->env->sender,
-                                           &e->env->to, &e->env->cc);
+                                           5, &e->env->from, &e->env->sender,
+                                           &e->env->to, &e->env->cc, &e->env->bcc);
     case MUTT_PAT_RECIPIENT:
       if (!e->env)
         return false;

--- a/pattern/exec.c
+++ b/pattern/exec.c
@@ -904,6 +904,11 @@ static bool pattern_exec(struct Pattern *pat, PatternExecFlags flags,
         return false;
       return pat->pat_not ^
              match_addrlist(pat, (flags & MUTT_MATCH_FULL_ADDRESS), 1, &e->env->cc);
+    case MUTT_PAT_BCC:
+      if (!e->env)
+        return false;
+      return pat->pat_not ^
+             match_addrlist(pat, (flags & MUTT_MATCH_FULL_ADDRESS), 1, &e->env->bcc);
     case MUTT_PAT_SUBJECT:
       if (!e->env)
         return false;

--- a/pattern/exec.c
+++ b/pattern/exec.c
@@ -934,8 +934,8 @@ static bool pattern_exec(struct Pattern *pat, PatternExecFlags flags,
     case MUTT_PAT_RECIPIENT:
       if (!e->env)
         return false;
-      return pat->pat_not ^ match_addrlist(pat, (flags & MUTT_MATCH_FULL_ADDRESS),
-                                           2, &e->env->to, &e->env->cc);
+      return pat->pat_not ^ match_addrlist(pat, (flags & MUTT_MATCH_FULL_ADDRESS), 3,
+                                           &e->env->to, &e->env->cc, &e->env->bcc);
     case MUTT_PAT_LIST: /* known list, subscribed or not */
     {
       if (!e->env)

--- a/pattern/flags.c
+++ b/pattern/flags.c
@@ -93,6 +93,9 @@ const struct PatternFlags Flags[] = {
   { 'k', MUTT_PAT_PGP_KEY, 0, EAT_NONE,
     // L10N: Pattern Completion Menu description for ~k
     N_("messages which contain PGP key") },
+  { 'K', MUTT_PAT_BCC, 0, EAT_REGEX,
+    // L10N: Pattern Completion Menu description for ~K
+    N_("messages whose BCC header matches EXPR") },
   { 'l', MUTT_PAT_LIST, 0, EAT_NONE,
     // L10N: Pattern Completion Menu description for ~l
     N_("messages addressed to known mailing lists") },

--- a/pattern/lib.h
+++ b/pattern/lib.h
@@ -134,6 +134,7 @@ enum PatternType
   MUTT_PAT_CHILDREN,          ///< Pattern matches a child email
   MUTT_PAT_TO,                ///< Pattern matches 'To:' field
   MUTT_PAT_CC,                ///< Pattern matches 'Cc:' field
+  MUTT_PAT_BCC,               ///< Pattern matches 'Bcc:' field
   MUTT_PAT_COLLAPSED,         ///< Thread is collapsed
   MUTT_PAT_SUBJECT,           ///< Pattern matches 'Subject:' field
   MUTT_PAT_FROM,              ///< Pattern matches 'From:' field


### PR DESCRIPTION
* **What does this PR do?**

Maybe answer @flatcap 's question:
> Are you sitting on any other useful patches?

Whether this is useful to you or not depends.  It slightly modifies existing patterns (or phrased pessimistically it breaks them) and steals another character from the alphabet for the Bcc field.  Note that lower k is used to find keys, since I do not expect a ~c <-> ~C duality for Bcc, one letter is all we need.  I believe I chose K because its counterpart was already taken, instead of e.g. j where both j, J are still free.

1) patterns ~C, %C, ~L and ~p now also search Bcc
2) add pattern ~K to search Bcc field
