### PR TITLE
Generate compile_commands.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ fuzz/address-fuzz
 
 # Build products
 *.o
+*.o.json
 *.gc??
 *.Po
 *.Tpo

--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -850,7 +850,7 @@ $(NEOMUTT): $(GENERATED) $(NEOMUTTOBJS) $(MUTTLIBS)
 
 # clean
 clean: $(CLEAN_TARGETS)
-	rm -f $(CLEANFILES)
+	$(RM) $(CLEANFILES)
 
 # install
 install: all $(INSTALL_TARGETS)
@@ -881,7 +881,6 @@ distclean: clean
 		test/Makefile .clang_complete
 	$(RM) *.gc?? */*.gc?? test/*/*.gc??
 	$(RM) *.expand */*.expand test/*/*.expand
-	$(RM) compile_commands.*
 	$(RM) coverage.info coverage
 
 ###############################################################################
@@ -894,7 +893,7 @@ git_ver.c: $(ALL_FILES)
 		sed -e 's/^[0-9]\{8\}//; s/-g\([a-z0-9]\{6\}\)/-\1/'`; \
 	echo 'const char *GitVer = "'$$version'";' > $@.tmp; \
 	cmp -s $@.tmp $@ || mv $@.tmp $@; \
-	rm -f $@.tmp
+	$(RM) $@.tmp
 
 hcache/hcversion.h:	$(SRCDIR)/address/address.h $(SRCDIR)/email/body.h \
 			$(SRCDIR)/email/email.h $(SRCDIR)/email/envelope.h \
@@ -949,6 +948,17 @@ coverage: all test
 @endif
 @if ENABLE_FUZZ_TESTS
 @include @srcdir@/fuzz/Makefile.autosetup
+@endif
+
+@if COMPILE_COMMANDS
+compile_commands.json: $(ALLOBJS)
+	echo '[' > compile_commands.json
+	cat $(ALLOBJS:.o=.o.json) >> compile_commands.json
+	echo ']' >> compile_commands.json
+
+clean-compile_commands.json:
+	$(RM) $(ALLOBJS:.o=.o.json)
+	$(RM) compile_commands.json
 @endif
 
 # vim: set ts=8 noexpandtab:

--- a/auto.def
+++ b/auto.def
@@ -1114,7 +1114,7 @@ if {[get-define want-compile-commands]} {
   define COMPILE_COMMANDS
   define-append ALL_TARGETS compile_commands.json
   define-append CLEAN_TARGETS clean-compile_commands.json
-  define-append CFLAGS {-MJ $(@:.o=.o.json)}
+  define-append CFLAGS {-MJ$(@:.o=.o.json)}
 }
 
 ###############################################################################
@@ -1218,7 +1218,16 @@ make-config-header config.h -auto $auto_rep -bare $bare_rep -str $str_rep
 
 ###############################################################################
 # Generate .clang_complete
-define cflags-one-per-line [string map {" " "\n"} [get-define CFLAGS]]
+proc cflags-for-clang-complete {} {
+  lmap x [get-define CFLAGS] {
+    if {[string match "-MJ*" $x]} {
+      continue
+    } else {
+      set x
+    }
+  }
+}
+define cflags-one-per-line [string map {" " "\n"} [cflags-for-clang-complete]]
 make-template .clang_complete.in
 
 ###############################################################################

--- a/auto.def
+++ b/auto.def
@@ -116,6 +116,7 @@ set valid_options {
   coverage=0                => "Enable Coverage Testing"
   testing=0                 => "Enable Unit Testing"
   fuzzing                   => "Enable Fuzz Testing"
+  compile-commands          => "Generate compile_commands.json (requires clang)"
 # Enable all options
   everything=0              => "Enable all options"
 # Debug options
@@ -167,7 +168,7 @@ if {[llength $notices]} {
 if {1} {
   # Keep sorted, please.
   foreach opt {
-    asan autocrypt bdb coverage debug-backtrace debug-color debug-email
+    asan autocrypt bdb compile-commands coverage debug-backtrace debug-color debug-email
     debug-graphviz debug-notify debug-parse-test debug-queue debug-window doc
     everything fmemopen full-doc fuzzing gdbm gnutls gpgme gsasl gss homespool idn
     idn2 include-path-in-cflags inotify kyotocabinet lmdb locales-fix lua lz4
@@ -1105,6 +1106,18 @@ if {[get-define want-fuzzing]} {
 }
 
 ###############################################################################
+# Generate compile_commands.json
+if {[get-define want-compile-commands]} {
+  if {![has-define {} __clang__]} {
+    user-error "The clang compiler is required to generate compile_commands.json"
+  }
+  define COMPILE_COMMANDS
+  define-append ALL_TARGETS compile_commands.json
+  define-append CLEAN_TARGETS clean-compile_commands.json
+  define-append CFLAGS {-MJ $(@:.o=.o.json)}
+}
+
+###############################################################################
 # Coverage Testing
 if {[get-define want-coverage]} {
   define ENABLE_COVERAGE
@@ -1136,6 +1149,7 @@ set auto_rep {
   *_TARGETS
   BINDIR
   BUILD_DOC
+  COMPILE_COMMANDS
   CRYPT_*
   DOMAIN
   ENABLE_*

--- a/test/Makefile.autosetup
+++ b/test/Makefile.autosetup
@@ -648,6 +648,7 @@ TEST_OBJS	= test/main.o test/common.o \
 		  $(TAGS_OBJS) \
 		  $(THREAD_OBJS) \
 		  $(URL_OBJS)
+ALLOBJS+=   $(TEST_OBJS)
 
 CFLAGS	+= -I$(SRCDIR)/test
 


### PR DESCRIPTION
This adds a `--compile-commands` configure option to generated a clang
compilation database. This only works if the compiler is clang.