### PR TITLE
Rewording around Regex and Pattern

### DIFF
--- a/docs/config.c
+++ b/docs/config.c
@@ -978,18 +978,19 @@
 { "default_hook", DT_STRING, "~f %s !~P | (~P ~C %s)" },
 /*
 ** .pp
-** This variable controls how "$message-hook", "$reply-hook", "$send-hook",
-** "$send2-hook", "$save-hook", and "$fcc-hook" will
-** be interpreted if they are specified with only a simple regex,
-** instead of a matching pattern.  The hooks are expanded when they are
-** declared, so a hook will be interpreted according to the value of this
-** variable at the time the hook is declared.
+** This variable controls how some hooks are interpreted if their pattern is a
+** plain string or a regex. i.e.  They don't contain a pattern, like \fC~f\fP
 ** .pp
-** The default value matches
-** if the message is either from a user matching the regular expression
-** given, or if it is from you (if the from address matches
-** "$alternates") and is to or cc'ed to a user matching the given
-** regular expression.
+** The hooks are: $fcc-hook, $fcc-save-hook, $index-format-hook, $message-hook,
+** $reply-hook, $save-hook, $send-hook and $send2-hook.
+** .pp
+** The hooks are expanded when they are declared, so a hook will be interpreted
+** according to the value of this variable at the time the hook is declared.
+** .pp
+** The default value matches if the message is either from a user matching the
+** regular expression given, or if it is from you (if the from address matches
+** "$alternates") and is to or cc'ed to a user matching the given regular
+** expression.
 */
 
 { "delete", DT_QUAD, MUTT_ASKYES },
@@ -4384,6 +4385,9 @@
 ** Specifies how NeoMutt should expand a simple search into a real search
 ** pattern.  A simple search is one that does not contain any of the "~" pattern
 ** operators.  See "$patterns" for more information on search patterns.
+** .pp
+** simple_search applies to several functions, e.g. \fC<delete-pattern>\fP,
+** \fC<limit>\fP, searching in the index, and all of the index colors.
 ** .pp
 ** For example, if you simply type "joe" at a search or limit prompt, NeoMutt
 ** will automatically expand it to the value specified by this variable by

--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -3997,11 +3997,11 @@ set imap_pass="`gpg --batch -q --decrypt ~/.neomutt/account.gpg`"
         <group choice="req">
           <arg choice="plain" rep="repeat">
             <option>-rx</option>
-            <replaceable class="parameter">expr</replaceable>
+            <replaceable class="parameter">regex</replaceable>
           </arg>
           <arg choice="plain" rep="repeat">
             <option>-addr</option>
-            <replaceable class="parameter">expr</replaceable>
+            <replaceable class="parameter">address</replaceable>
           </arg>
         </group>
         <command>ungroup</command>
@@ -4015,17 +4015,17 @@ set imap_pass="`gpg --batch -q --decrypt ~/.neomutt/account.gpg`"
           </arg>
           <arg choice="plain" rep="repeat">
             <option>-rx</option>
-            <replaceable class="parameter">expr</replaceable>
+            <replaceable class="parameter">regex</replaceable>
           </arg>
           <arg choice="plain" rep="repeat">
             <option>-addr</option>
-            <replaceable class="parameter">expr</replaceable>
+            <replaceable class="parameter">address</replaceable>
           </arg>
         </group>
       </cmdsynopsis>
       <para>
         NeoMutt supports grouping addresses logically into named groups. An
-        address or address pattern can appear in several groups at the same
+        address or regular expression can appear in several groups at the same
         time. These groups can be used in
         <link linkend="patterns">patterns</link> (for searching, limiting and
         tagging) and in hooks by using group patterns. This can be useful to
@@ -4081,8 +4081,8 @@ alternates -group me -group work address3
         its contents. As soon as a group gets empty because all addresses and
         regular expressions have been removed, it'll internally be removed, too
         (i.e. there cannot be an empty group). When removing regular
-        expressions from a group, the pattern must be specified exactly as
-        given to the <command>group</command> command or
+        expressions from a group, the <emphasis>regex</emphasis> must be
+        specified exactly as given to the <command>group</command> command or
         <literal>-group</literal> argument.
       </para>
     </sect1>
@@ -19858,11 +19858,11 @@ neomutt mailto:some@one.org?subject=test&amp;cc=other@one.org
             <group choice="req">
               <arg choice="plain" rep="repeat">
                 <option>-rx</option>
-                <replaceable class="parameter">expr</replaceable>
+                <replaceable class="parameter">regex</replaceable>
               </arg>
               <arg choice="plain" rep="repeat">
                 <option>-addr</option>
-                <replaceable class="parameter">expr</replaceable>
+                <replaceable class="parameter">address</replaceable>
               </arg>
             </group>
             <command>
@@ -19878,11 +19878,11 @@ neomutt mailto:some@one.org?subject=test&amp;cc=other@one.org
               </arg>
               <arg choice="plain" rep="repeat">
                 <option>-rx</option>
-                <replaceable class="parameter">expr</replaceable>
+                <replaceable class="parameter">regex</replaceable>
               </arg>
               <arg choice="plain" rep="repeat">
                 <option>-addr</option>
-                <replaceable class="parameter">expr</replaceable>
+                <replaceable class="parameter">address</replaceable>
               </arg>
             </group>
           </cmdsynopsis>

--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -5827,10 +5827,10 @@ unignore posted-to:
       </para>
       <para>
         The <command>unalternates</command> command can be used to write
-        exceptions to <command>alternates</command> patterns. If an address
+        exceptions to <command>alternates</command> regex. If an address
         matches something in an <command>alternates</command> command, but you
         nonetheless do not think it is from you, you can list a more precise
-        pattern under an <command>unalternates</command> command.
+        regex under an <command>unalternates</command> command.
       </para>
       <para>
         To remove a regular expression from the <command>alternates</command>

--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -5662,10 +5662,10 @@ uncolor status *
         <cmdsynopsis>
           <command>ignore</command>
           <arg choice="plain">
-            <replaceable class="parameter">pattern</replaceable>
+            <replaceable class="parameter">string</replaceable>
           </arg>
           <arg choice="opt" rep="repeat">
-            <replaceable class="parameter">pattern</replaceable>
+            <replaceable class="parameter">string</replaceable>
           </arg>
           <command>unignore</command>
           <group choice="req">
@@ -5673,7 +5673,7 @@ uncolor status *
               <replaceable>*</replaceable>
             </arg>
             <arg choice="plain" rep="repeat">
-              <replaceable>pattern</replaceable>
+              <replaceable>string</replaceable>
             </arg>
           </group>
         </cmdsynopsis>
@@ -5686,13 +5686,13 @@ uncolor status *
         <para>
           You do not need to specify the full header field name. For example,
           <quote>ignore content-</quote> will ignore all header fields that
-          begin with the pattern <quote>content-</quote>.
+          begin with the string <quote>content-</quote>.
           <quote>ignore&#160;*</quote> will ignore all headers.
         </para>
         <para>
           To remove a previously added token from the list, use the
           <quote>unignore</quote> command. The <quote>unignore</quote> command
-          will make NeoMutt display headers with the given pattern. For
+          will make NeoMutt display headers matching the given string. For
           example, if you do <quote>ignore x-</quote> it is possible to
           <quote>unignore x-mailer</quote>.
         </para>
@@ -19942,10 +19942,10 @@ neomutt mailto:some@one.org?subject=test&amp;cc=other@one.org
               <link linkend="ignore">ignore</link>
             </command>
             <arg choice="plain">
-              <replaceable class="parameter">pattern</replaceable>
+              <replaceable class="parameter">string</replaceable>
             </arg>
             <arg choice="opt" rep="repeat">
-              <replaceable class="parameter">pattern</replaceable>
+              <replaceable class="parameter">string</replaceable>
             </arg>
             <command>
               <link linkend="ignore">unignore</link>
@@ -19955,7 +19955,7 @@ neomutt mailto:some@one.org?subject=test&amp;cc=other@one.org
                 <replaceable>*</replaceable>
               </arg>
               <arg choice="plain" rep="repeat">
-                <replaceable>pattern</replaceable>
+                <replaceable>string</replaceable>
               </arg>
             </group>
           </cmdsynopsis>

--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -4703,7 +4703,7 @@ bind index gg first-entry
           <replaceable class="parameter">-noregex</replaceable>
         </arg>
         <arg choice="plain">
-          <replaceable class="parameter">pattern</replaceable>
+          <replaceable class="parameter">regex</replaceable>
         </arg>
         <arg choice="plain">
           <replaceable class="parameter">command</replaceable>
@@ -4714,8 +4714,8 @@ bind index gg first-entry
         reading. The <command>folder-hook</command> command provides a method
         by which you can execute any configuration command.
         The <emphasis>command</emphasis> is executed before loading any mailboxes
-        matching <emphasis>pattern</emphasis>. The <emphasis>-noregex</emphasis>
-        switch controls whether <emphasis>pattern</emphasis> is matched using
+        matching <emphasis>regex</emphasis>. The <emphasis>-noregex</emphasis>
+        switch controls whether <emphasis>regex</emphasis> is matched using
         a simple string comparison or a full regex match.
         If a mailbox matches multiple <command>folder-hook</command>s, they are
         executed in the order given in the <literal>.neomuttrc</literal>.
@@ -4729,10 +4729,10 @@ bind index gg first-entry
       <note>
         <para>
           If you use the <quote>!</quote> shortcut for
-          <link linkend="spool-file">$spool_file</link> at the beginning of the
-          pattern, you must place it inside of double or single quotes in order
-          to distinguish it from the logical <emphasis>not</emphasis> operator
-          for the expression.
+          <link linkend="spool-file">$spool_file</link> at the beginning of
+          <emphasis>regex</emphasis>, you must place it inside of double or
+          single quotes in order to distinguish it from the logical
+          <emphasis>not</emphasis> operator for the expression.
         </para>
       </note>
       <note>
@@ -4745,7 +4745,7 @@ bind index gg first-entry
         <para>
           However, the sorting method is not restored to its previous value
           when reading a different mailbox. To specify
-          a <emphasis>default</emphasis> command, use the pattern
+          a <emphasis>default</emphasis> command, use the regex
           <quote>.</quote> before other <command>folder-hook</command>s
           adjusting a value on a per-folder basis because
           <command>folder-hook</command>s are evaluated in the order given in

--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -6617,7 +6617,7 @@ folder-hook . 'push "&lt;enter-command&gt;score ~= 10&lt;enter&gt;"'
       <cmdsynopsis>
         <command>spam</command>
         <arg choice="plain">
-          <replaceable class="parameter">pattern</replaceable>
+          <replaceable class="parameter">regex</replaceable>
         </arg>
         <arg choice="plain">
           <replaceable class="parameter">format</replaceable>
@@ -6628,13 +6628,13 @@ folder-hook . 'push "&lt;enter-command&gt;score ~= 10&lt;enter&gt;"'
             <replaceable class="parameter">*</replaceable>
           </arg>
           <arg choice="plain">
-            <replaceable class="parameter">pattern</replaceable>
+            <replaceable class="parameter">regex</replaceable>
           </arg>
         </group>
       </cmdsynopsis>
       <para>
         NeoMutt has generalized support for external spam-scoring filters. By
-        defining your spam patterns with the <command>spam</command> and
+        defining your spam regular expressions with the <command>spam</command> and
         <literal>nospam</literal> commands, you can <emphasis>limit</emphasis>,
         <emphasis>search</emphasis>, and <emphasis>sort</emphasis> your mail
         based on its spam attributes, as determined by the external filter. You
@@ -6655,16 +6655,16 @@ folder-hook . 'push "&lt;enter-command&gt;score ~= 10&lt;enter&gt;"'
         header cache files and turn the header cache back on.
       </para>
       <para>
-        Your first step is to define your external filter's spam patterns using
-        the <command>spam</command> command. <emphasis>pattern</emphasis>
+        Your first step is to define your external filter's spam headers using
+        the <command>spam</command> command. <emphasis>regex</emphasis>
         should be a regular expression that matches a header in a mail message.
         If any message in the mailbox matches this regular expression, it will
         receive a <quote>spam tag</quote> or <quote>spam attribute</quote>
-        (unless it also matches a <command>nospam</command> pattern – see
-        below.) The appearance of this attribute is entirely up to you, and is
-        governed by the <emphasis>format</emphasis> parameter.
+        (unless it also matches a <command>nospam</command> regular expression
+        – see below.) The appearance of this attribute is entirely up to you,
+        and is governed by the <emphasis>format</emphasis> parameter.
         <emphasis>format</emphasis> can be any static text, but it also can
-        include back-references from the <emphasis>pattern</emphasis>
+        include back-references from the <emphasis>regex</emphasis>
         expression. (A regular expression <quote>back-reference</quote> refers
         to a sub-expression contained within parentheses.)
         <literal>%1</literal> is replaced with the first back-reference in the
@@ -6679,9 +6679,9 @@ folder-hook . 'push "&lt;enter-command&gt;score ~= 10&lt;enter&gt;"'
       </para>
       <para>
         If you're using multiple spam filters, a message can have more than one
-        spam-related header. You can define <command>spam</command> patterns
+        spam-related header. You can define <command>spam</command> rules
         for each filter you use. If a message matches two or more of these
-        patterns, and the <link linkend="spam-separator">$spam_separator</link>
+        regular expressions, and the <link linkend="spam-separator">$spam_separator</link>
         variable is set to a string, then the message's spam tag will consist
         of all the <emphasis>format</emphasis> strings joined together, with
         the value of <link linkend="spam-separator">$spam_separator</link>
@@ -6712,7 +6712,7 @@ set spam_separator=", "
       </para>
       <para>
         If the <link linkend="spam-separator">$spam_separator</link> variable
-        is unset, then each spam pattern match supersedes the previous one.
+        is unset, then each spam rule match supersedes the previous one.
         Instead of getting joined <emphasis>format</emphasis> strings, you'll
         get only the last one to match.
       </para>
@@ -6738,7 +6738,7 @@ set spam_separator=", "
         will sort numerically first, and lexically only when two numbers are
         equal in value. (This is like UNIX's <literal>sort -n</literal>.)
         A message with no spam attributes at all – that is, one that didn't
-        match <emphasis>any</emphasis> of your <command>spam</command> patterns
+        match <emphasis>any</emphasis> of your <command>spam</command> rules
         – is sorted at lowest priority. Numbers are sorted next, beginning with
         0 and ranging upward. Finally, non-numeric strings are sorted, with
         <quote>a</quote> taking lower priority than <quote>z</quote>. Clearly,
@@ -6748,19 +6748,19 @@ set spam_separator=", "
       </para>
       <para>
         The <command>nospam</command> command can be used to write exceptions
-        to <command>spam</command> patterns. If a header pattern matches
+        to <command>spam</command> rules. If a header field matches
         something in a <command>spam</command> command, but you nonetheless do
-        not want it to receive a spam tag, you can list a more precise pattern
-        under a <command>nospam</command> command.
+        not want it to receive a spam tag, you can list a more precise regular
+        expression under a <command>nospam</command> command.
       </para>
       <para>
-        If the <emphasis>pattern</emphasis> given to <command>nospam</command>
-        is exactly the same as the <emphasis>pattern</emphasis> on an existing
-        <command>spam</command> list entry, the effect will be to remove the
-        entry from the spam list, instead of adding an exception. Likewise, if
-        the <emphasis>pattern</emphasis> for a <command>spam</command> command
-        matches an entry on the <command>nospam</command> list, that nospam
-        entry will be removed. If the <emphasis>pattern</emphasis> for
+        If the <emphasis>regex</emphasis> given to <command>nospam</command>
+        is exactly the same as the <emphasis>regex</emphasis> on an existing
+        <command>spam</command> rule entry, the effect will be to remove the
+        entry from the spam rules list, instead of adding an exception. Likewise, if
+        the <emphasis>regex</emphasis> for a <command>spam</command> command
+        matches an entry on the <command>nospam</command> rule list, that
+        nospam entry will be removed. If the <emphasis>regex</emphasis> for
         <command>nospam</command> is <quote>*</quote>,
         <emphasis>all entries on both lists</emphasis> will be removed. This
         might be the default action if you use <command>spam</command> and
@@ -20486,7 +20486,7 @@ neomutt mailto:some@one.org?subject=test&amp;cc=other@one.org
               <link linkend="spam">spam</link>
             </command>
             <arg choice="plain">
-              <replaceable class="parameter">pattern</replaceable>
+              <replaceable class="parameter">regex</replaceable>
             </arg>
             <arg choice="plain">
               <replaceable class="parameter">format</replaceable>
@@ -20499,7 +20499,7 @@ neomutt mailto:some@one.org?subject=test&amp;cc=other@one.org
                 <replaceable class="parameter">*</replaceable>
               </arg>
               <arg choice="plain">
-                <replaceable class="parameter">pattern</replaceable>
+                <replaceable class="parameter">regex</replaceable>
               </arg>
             </group>
           </cmdsynopsis>

--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -5984,7 +5984,7 @@ unignore posted-to:
           <replaceable class="parameter">-noregex</replaceable>
         </arg>
         <arg choice="plain">
-          <replaceable class="parameter">pattern</replaceable>
+          <replaceable class="parameter">regex</replaceable>
         </arg>
         <arg choice="plain">
           <replaceable class="parameter">mailbox</replaceable>
@@ -5993,11 +5993,11 @@ unignore posted-to:
       <para>
         This command is used to move read messages from a specified mailbox to
         a different mailbox automatically when you quit or change folders.
-        <emphasis>pattern</emphasis> is used to specifying the mailbox to
+        <emphasis>regex</emphasis> is used to specifying the mailbox to
         treat as a <quote>spool</quote> mailbox and <emphasis>mailbox</emphasis>
         specifies where mail should be saved when read.
         The <emphasis>-noregex</emphasis> switch controls whether
-        <emphasis>pattern</emphasis> is matched using a simple string
+        <emphasis>regex</emphasis> is matched using a simple string
         comparison or a full regex match.
       </para>
       <para>
@@ -20128,6 +20128,9 @@ neomutt mailto:some@one.org?subject=test&amp;cc=other@one.org
             <command>
               <link linkend="mbox-hook">mbox-hook</link>
             </command>
+            <arg choice="opt">
+              <replaceable class="parameter">-noregex</replaceable>
+            </arg>
             <arg choice="plain">
               <replaceable class="parameter">regex</replaceable>
             </arg>

--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -4066,7 +4066,7 @@ alternates -group me -group work address3
 </screen>
 
       <para>
-        would create a group named <quote>me</quote> which contains all your
+        would create a group named <quote>me</quote> which contains all three
         addresses and a group named <quote>work</quote> which contains only
         your work address <emphasis>address3</emphasis>. Besides many other
         possibilities, this could be used to automatically mark your own
@@ -6203,6 +6203,10 @@ my_hdr Organization: A Really Big Company, Anytown, USA
         according to <link linkend="index-format">$index_format</link>.
       </para>
       <para>
+        If the pattern is a plain string, or a regex, it will be expanded to a
+        pattern using <link linkend="default-hook">$default_hook</link>.
+      </para>
+      <para>
         <command>fcc-hook</command> is used to save outgoing mail in a mailbox
         other than <link linkend="record">$record</link>. NeoMutt searches the
         initial list of message recipients for the first matching
@@ -6283,6 +6287,10 @@ save-hook aol\\.com$ +spam
         used to match the message, see <xref linkend="pattern-hook" /> for
         details. <emphasis>command</emphasis> is executed when
         <emphasis>pattern</emphasis> matches.
+      </para>
+      <para>
+        If the pattern is a plain string, or a regex, it will be expanded to a
+        pattern using <link linkend="default-hook">$default_hook</link>.
       </para>
       <para>
         <command>reply-hook</command> is matched against the message you are
@@ -6372,6 +6380,10 @@ save-hook aol\\.com$ +spam
         specified in the <literal>.neomuttrc</literal>.
       </para>
       <para>
+        If the pattern is a plain string, or a regex, it will be expanded to a
+        pattern using <link linkend="default-hook">$default_hook</link>.
+      </para>
+      <para>
         See <xref linkend="pattern-hook" /> for information on the exact format
         of <emphasis>pattern</emphasis>.
       </para>
@@ -6442,6 +6454,10 @@ message-hook '~f freshmeat-news' 'set pager="less \"+/^  subject: .*\""'
         This command is used to inject format strings dynamically into <link
         linkend="index-format">$index_format</link> based on pattern matching
         against the current message.
+      </para>
+      <para>
+        If the pattern is a plain string, or a regex, it will be expanded to a
+        pattern using <link linkend="default-hook">$default_hook</link>.
       </para>
       <para>
         The <link linkend="index-format">$index_format</link> expando
@@ -7714,8 +7730,8 @@ set index_format="%4C %Z %{%b %d} %-15.15L (%?l?%4l&amp;%4c?)%*  %s"
         convenience, we have included below a brief description of this syntax.
       </para>
       <para>
-        The search is case sensitive if the pattern contains at least one upper
-        case letter, and case insensitive otherwise.
+        The search is case sensitive if the regular expression contains at
+        least one upper case letter, and case insensitive otherwise.
       </para>
       <note>
         <para>

--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -5924,10 +5924,11 @@ unignore posted-to:
         </para>
       </note>
       <para>
-        More precisely, NeoMutt maintains lists of patterns for the addresses
-        of known and subscribed mailing lists. Every subscribed mailing list is
-        known. To mark a mailing list as known, use the <command>list</command>
-        command. To mark it as subscribed, use <command>subscribe</command>.
+        More precisely, NeoMutt maintains lists of regular expressions for the
+        addresses of known and subscribed mailing lists. Every subscribed
+        mailing list is known. To mark a mailing list as known, use the
+        <command>list</command> command. To mark it as subscribed, use
+        <command>subscribe</command>.
       </para>
       <para>
         You can use regular expressions with both commands. To mark all

--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -7744,6 +7744,22 @@ set index_format="%4C %Z %{%b %d} %-15.15L (%?l?%4l&amp;%4c?)%*  %s"
         special meaning may be quoted by preceding it with a backslash.
       </para>
       <para>
+        The following matches a literal dot <quote>.</quote> in an address:
+      </para>
+      <example id="ex-literal-dot-in-regex">
+        <title>Matching a literal dot</title>
+<screen>
+<emphasis role="comment"># no quotes</emphasis>
+alternates only\\.dot@example\\.org
+
+<emphasis role="comment"># single quotes</emphasis>
+lists 'only\.dot@example\.org'
+
+<emphasis role="comment"># Double quotes</emphasis>
+subscribe "only\\.dot@example\\.org"
+</screen>
+      </example>
+      <para>
         The period <quote>.</quote> matches any single character. The caret
         <quote>^</quote> and the dollar sign <quote>$</quote> are
         metacharacters that respectively match the empty string at the
@@ -8661,6 +8677,22 @@ set index_format="%4C %Z %{%b %d} %-15.15L (%?l?%4l&amp;%4c?)%*  %s"
           in the regular expression, you will need to use two backslashes
           instead (<quote>\\</quote>).
         </para>
+      <example id="ex-literal-dot-in-pattern">
+        <title>Using <literal>\s</literal> and matching a literal dot in patterns</title>
+<screen>
+<emphasis role="comment"># no quotes</emphasis>
+save-hook ~h\ list-id:\\\\s*&lt;only\\\\.dot&gt;    '=archive'
+save-hook ~hlist-id:\\\\s*&lt;only\\\\.dot-here&gt; '=archive'
+
+<emphasis role="comment"># single quotes</emphasis>
+save-hook '~h list-id:\\s&lt;only\\.dot&gt;'        '=archive'
+save-hook ~h'list-id:\\s*&lt;only\\.dot-here&gt;'   '=archive'
+
+<emphasis role="comment"># Double quotes</emphasis>
+save-hook "~h list-id:\\\\s&lt;only\\\\.dot&gt;"    '=archive'
+save-hook ~h"list-id:\\\\s*&lt;only\\\\.dot&gt;"    '=archive'
+</screen>
+      </example>
         <para>
           You can force NeoMutt to treat
           <emphasis>EXPR</emphasis> as a simple substring instead of a regular
@@ -9390,7 +9422,7 @@ Limit to messages matching: ~d 19950120-19951031
 
 <screen>
 send-hook . 'unmy_hdr From:'
-send-hook ~C'^b@b\.b$' my_hdr from: c@c.c
+send-hook ~C'^b@b\\.b$' my_hdr from: c@c.c
 </screen>
 
       </example>
@@ -9431,7 +9463,7 @@ send-hook ~C'^b@b\.b$' my_hdr from: c@c.c
         </para>
 
 <screen>
-send-hook '~t ^user@work\.com$' 'my_hdr From: John Smith &lt;user@host&gt;'
+send-hook '~t ^user@work\\.com$' 'my_hdr From: John Smith &lt;user@host&gt;'
 </screen>
 
         <para>
@@ -9470,10 +9502,10 @@ folder-hook ^/home/user/Mail/bar "set sort=threads"
 folder-hook (^/home/user/Mail/bar) "set sort=threads"
 <emphasis role="comment"># This will expand to the default save folder for the alias "imap.example.com", which</emphasis>
 <emphasis role="comment"># is probably not what you want:</emphasis>
-folder-hook @imap.example.com "set sort=threads"
+folder-hook @imap\\.example\\.com "set sort=threads"
 <emphasis role="comment"># A workaround is to use parenthesis or a backslash:</emphasis>
-folder-hook (@imap.example.com) "set sort=threads"
-folder-hook '\@imap.example.com' "set sort=threads"
+folder-hook (@imap\\.example\\.com) "set sort=threads"
+folder-hook '\@imap\.example\.com' "set sort=threads"
 </screen>
 
         <para>

--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -9845,7 +9845,7 @@ roessler@does-not-exist.org        Thomas Roessler mutt pgp
       <cmdsynopsis>
         <command>subjectrx</command>
         <arg choice="plain">
-          <replaceable class="parameter">pattern</replaceable>
+          <replaceable class="parameter">regex</replaceable>
         </arg>
         <arg choice="plain">
           <replaceable class="parameter">replacement</replaceable>
@@ -9856,13 +9856,13 @@ roessler@does-not-exist.org        Thomas Roessler mutt pgp
             <replaceable class="parameter">*</replaceable>
           </arg>
           <arg choice="plain">
-            <replaceable class="parameter">pattern</replaceable>
+            <replaceable class="parameter">regex</replaceable>
           </arg>
         </group>
       </cmdsynopsis>
       <para>
         <literal>subjectrx</literal> specifies a regular expression
-        <quote>pattern</quote> which, if detected in a message subject, causes
+        which, if detected in a message subject, causes
         the subject to be replaced with the <quote>replacement</quote> value.
         The replacement is subject to substitutions in the same way as for the
         <link linkend="spam">spam</link> command: <literal>%L</literal> for the
@@ -9878,7 +9878,7 @@ roessler@does-not-exist.org        Thomas Roessler mutt pgp
       </para>
       <para>
         <literal>unsubjectrx</literal> removes a given subjectrx from the
-        substitution list. If <literal>*</literal> is used as the pattern, all
+        substitution list. If <literal>*</literal> is used as the argument, all
         substitutions will be removed.
       </para>
       <example id="ex-subjectrx">
@@ -20510,7 +20510,7 @@ neomutt mailto:some@one.org?subject=test&amp;cc=other@one.org
               <link linkend="display-munging">subjectrx</link>
             </command>
             <arg choice="plain">
-              <replaceable class="parameter">pattern</replaceable>
+              <replaceable class="parameter">regex</replaceable>
             </arg>
             <arg choice="plain">
               <replaceable class="parameter">replacement</replaceable>
@@ -20523,7 +20523,7 @@ neomutt mailto:some@one.org?subject=test&amp;cc=other@one.org
                 <replaceable class="parameter">*</replaceable>
               </arg>
               <arg choice="plain">
-                <replaceable class="parameter">pattern</replaceable>
+                <replaceable class="parameter">regex</replaceable>
               </arg>
             </group>
           </cmdsynopsis>

--- a/docs/neomuttrc.man.head
+++ b/docs/neomuttrc.man.head
@@ -129,10 +129,10 @@ receive mail; you can use regular expressions (\fIregex\fP) to specify
 alternate addresses. This affects NeoMutt's idea about messages from you, and
 messages addressed to you.
 .IP
-\fBunalternates\fP can be used to write exceptions to alternates patterns. To
-remove a regular expression from the alternates list, use the unalternates
-command with exactly the same \fIregex\fP or use \(lq\fB*\fP\(rq to remove all
-entries.
+\fBunalternates\fP can be used to write exceptions to alternates regular
+expression. To remove a regular expression from the alternates list, use the
+unalternates command with exactly the same \fIregex\fP or use \(lq\fB*\fP\(rq
+to remove all entries.
 .IP
 The optional \fB\-group\fP flag causes all of the subsequent regular expressions
 to be added to or removed from the \fIname\fPd group.

--- a/docs/neomuttrc.man.head
+++ b/docs/neomuttrc.man.head
@@ -840,12 +840,12 @@ configuration file the hook is defined in.
 .
 .PP
 .nf
-\fBspam\fP \fIpattern\fP \fIformat\fP
-\fBnospam\fP { \fB*\fP | \fIpattern\fP }
+\fBspam\fP \fIregex\fP \fIformat\fP
+\fBnospam\fP { \fB*\fP | \fIregex\fP }
 .fi
 .IP
 NeoMutt has generalized support for external spam-scoring filters. By defining
-your spam \fIpattern\fPs with the \fBspam\fP and \fBnospam\fP commands, you can
+your spam \fIregex\fPs with the \fBspam\fP and \fBnospam\fP commands, you can
 limit, search, and sort your mail based on its spam attributes, as determined
 by the external filter. You also can display the spam attributes in your index
 display using the %H selector in the $index_format variable. (Tip: try

--- a/docs/neomuttrc.man.head
+++ b/docs/neomuttrc.man.head
@@ -514,9 +514,9 @@ ignore list.
 \fBunsubscribe\fP [ \fB\-group\fP \fIname\fP ... ] { \fB*\fP | \fIregex\fP ... }
 .fi
 .IP
-NeoMutt maintains two lists of mailing list address patterns, a list of
-subscribed mailing lists, and a list of known mailing lists. All subscribed
-mailing lists are known. Patterns use regular expressions.
+NeoMutt maintains two lists of mailing list address regular expressions, a list
+of subscribed mailing lists, and a list of known mailing lists. All subscribed
+mailing lists are known.
 .IP
 The \fBlists\fP command adds a mailing list address to the list of known
 mailing lists. The \fBunlists\fP command removes a mailing list from the lists

--- a/docs/neomuttrc.man.head
+++ b/docs/neomuttrc.man.head
@@ -857,11 +857,11 @@ section \(lq\fBSpam Detection\fP\(rq in the NeoMutt manual.
 .
 .PP
 .nf
-\fBsubjectrx\fP \fIpattern\fP \fIreplacement\fP
-\fBunsubjectrx\fP { \fB*\fP | \fIpattern\fP }
+\fBsubjectrx\fP \fIregex\fP \fIreplacement\fP
+\fBunsubjectrx\fP { \fB*\fP | \fIregex\fP }
 .fi
 .IP
-The \fBsubjectrx\fP command specifies a regular expression \fIpattern\fP which,
+The \fBsubjectrx\fP command specifies a regular expression which,
 if detected in a message subject, causes the subject to be replaced with the
 \fIreplacement\fP value. The \fIreplacement\fP is subject to substitutions in
 the same way as for the \fBspam\fP command: %L for the text to the left of the
@@ -873,7 +873,7 @@ Note this well: the \fIreplacement\fP value replaces the entire subject, not
 just the match!
 .IP
 \fBunsubjectrx\fP removes a given \fBsubjectrx\fP from the substitution list.
-If \(lq\fB*\fP\(rq is used as the pattern, all substitutions will be removed.
+If \(lq\fB*\fP\(rq is used as the argument, all substitutions will be removed.
 .
 .PP
 .nf

--- a/docs/neomuttrc.man.head
+++ b/docs/neomuttrc.man.head
@@ -492,14 +492,14 @@ the output of the command \(lq\fBneomutt\~\-v\fP\(rq (in the
 .
 .PP
 .nf
-\fBignore\fP \fIpattern\fP [ \fIpattern\fP ... ]
-\fBunignore\fP { \fB*\fP | \fIpattern\fP ... }
+\fBignore\fP \fIstring\fP [ \fIstring\fP ... ]
+\fBunignore\fP { \fB*\fP | \fIstring\fP ... }
 .fi
 .IP
 The \fBignore\fP command allows you to specify header fields which you don't
 normally want to see in the pager. You do not need to specify the full header
 field name. For example, \(lq\fBignore\fP content-\(rq will ignore all header
-fields that begin with the pattern \(lqcontent-\(rq, \(lq\fBignore\fP\~*\(rq
+fields that begin with the string \(lqcontent-\(rq, \(lq\fBignore\fP\~*\(rq
 will ignore all headers.
 .IP
 To remove a previously added token from the list, use the \fBunignore\fP

--- a/docs/neomuttrc.man.head
+++ b/docs/neomuttrc.man.head
@@ -421,8 +421,8 @@ the order given in the configuration file.
 .
 .PP
 .nf
-\fBgroup\fP [ \fB\-group\fP \fIname\fP ... ] { \fB\-rx\fP \fIexpr\fP ... | \fB\-addr\fP \fIaddress\fP ... }
-\fBungroup\fP [ \fB\-group\fP \fIname\fP ... ] { \fB*\fP | \fB\-rx\fP \fIexpr\fP ... | \fB\-addr\fP \fIaddress\fP ... }
+\fBgroup\fP [ \fB\-group\fP \fIname\fP ... ] { \fB\-rx\fP \fIregex\fP ... | \fB\-addr\fP \fIaddress\fP ... }
+\fBungroup\fP [ \fB\-group\fP \fIname\fP ... ] { \fB*\fP | \fB\-rx\fP \fIregex\fP ... | \fB\-addr\fP \fIaddress\fP ... }
 .fi
 .IP
 \fBgroup\fP is used to directly add either addresses or regular expressions to

--- a/docs/neomuttrc.man.head
+++ b/docs/neomuttrc.man.head
@@ -408,12 +408,12 @@ NeoMutt manual for information on the exact format of \fIpattern\fP.
 .
 .PP
 .nf
-\fBfolder-hook\fP [\fI-noregex\fP] \fIpattern\fP \fIcommand\fP
+\fBfolder-hook\fP [\fI-noregex\fP] \fIregex\fP \fIcommand\fP
 .fi
 .IP
-When NeoMutt enters a folder which matches \fIpattern\fP (or, when \fIpattern\fP is
-preceded by an exclamation mark, does not match \fIpattern\fP), the given
-\fIcommand\fP is executed. The \fI-noregex\fP switch controls whether \fIpattern\fP
+When NeoMutt enters a folder which matches \fIregex\fP (or, when \fIregex\fP is
+preceded by an exclamation mark, does not match \fIregex\fP), the given
+\fIcommand\fP is executed. The \fI-noregex\fP switch controls whether \fIregex\fP
 is matches as simple string equality or full regex match.
 .IP
 When several \fBfolder-hook\fPs match a given mail folder, they are executed in

--- a/docs/neomuttrc.man.head
+++ b/docs/neomuttrc.man.head
@@ -590,13 +590,13 @@ Changes the current working directory.
 .
 .PP
 .nf
-\fBmbox-hook\fP [\fI-noregex\fP] \fIpattern\fP \fImailbox\fP
+\fBmbox-hook\fP [\fI-noregex\fP] \fIregex\fP \fImailbox\fP
 .fi
 .IP
-When NeoMutt changes to a mail folder which matches \fIpattern\fP, \fImailbox\fP
+When NeoMutt changes to a mail folder which matches \fIregex\fP, \fImailbox\fP
 will be used as the \(lqmbox\(rq folder, i.e. read messages will be moved to
 that folder when the mail folder is left. The \fI-noregex\fP switch controls
-whether \fIpattern\fP is matches as simple string equality or full regex match.
+whether \fIregex\fP is matches as simple string equality or full regex match.
 
 .IP
 Note that execution of \fBmbox-hook\fPs is dependent on the $move configuration

--- a/hook.c
+++ b/hook.c
@@ -236,9 +236,9 @@ enum CommandResult mutt_parse_hook(struct Buffer *buf, struct Buffer *s,
   else if (c_default_hook && (~data & MUTT_GLOBAL_HOOK) &&
            !(data & (MUTT_ACCOUNT_HOOK)) && (!WithCrypto || !(data & MUTT_CRYPT_HOOK)))
   {
-    /* At this stage remain only message-hooks, reply-hooks, send-hooks,
-     * send2-hooks, save-hooks, and fcc-hooks: All those allowing full
-     * patterns. If given a simple regex, we expand $default_hook.  */
+    /* At this stage only these hooks remain:
+     * fcc-, fcc-save-, index-format-, message-, reply-, save-, send- and send2-hook
+     * If given a plain string, or regex, we expand it using $default_hook. */
     mutt_check_simple(pattern, c_default_hook);
   }
 


### PR DESCRIPTION
* **What does this PR do?**

1) Try to use the word "pattern" only for NeoMutt patterns like `~f Alice` otherwise use regex or string.  This applies to the synopsis of commands as well as their description

2) Add examples how to quote inside patterns and inside regexs

3) Fix some quoting mistakes in examples (last commit, please verify)