### PR TITLE
Rename $attribution and $post_indent_string

### DIFF
--- a/debug/parse_test.c
+++ b/debug/parse_test.c
@@ -39,19 +39,19 @@
 void test_parse_set(void)
 {
   const char *vars[] = {
-    "from",        // ADDRESS
-    "beep",        // BOOL
-    "ispell",      // COMMAND
-    "mbox_type",   // ENUM
-    "to_chars",    // MBTABLE
-    "net_inc",     // NUMBER
-    "signature",   // PATH
-    "print",       // QUAD
-    "mask",        // REGEX
-    "sort",        // SORT
-    "attribution", // STRING
-    "zzz",         // UNKNOWN
-    "my_var",      // MY_VAR
+    "from",              // ADDRESS
+    "beep",              // BOOL
+    "ispell",            // COMMAND
+    "mbox_type",         // ENUM
+    "to_chars",          // MBTABLE
+    "net_inc",           // NUMBER
+    "signature",         // PATH
+    "print",             // QUAD
+    "mask",              // REGEX
+    "sort",              // SORT
+    "attribution_intro", // STRING
+    "zzz",               // UNKNOWN
+    "my_var",            // MY_VAR
   };
 
   const char *commands[] = {

--- a/docs/config.c
+++ b/docs/config.c
@@ -307,9 +307,12 @@
 { "attribution_intro", DT_STRING, "On %d, %n wrote:" },
 /*
 ** .pp
-** This is the string that will precede a message which has been included
-** in a reply.  For a full listing of defined \fCprintf(3)\fP-like sequences see
-** the section on $$index_format.
+** This is the string that will precede a replied-to message which is
+** quoted in the main body of the reply (this is the case when $$include is
+** set).
+** .pp
+** For a full listing of defined \fCprintf(3)\fP-like sequences see the section
+** on $$index_format.  See also $$attribution_locale.
 */
 
 { "attribution_locale", DT_STRING, 0 },
@@ -331,8 +334,12 @@
 { "attribution_trailer", DT_STRING, 0 },
 /*
 ** .pp
-** Similar to the $$attribution_intro variable, NeoMutt will append this
-** string after the inclusion of a message which is being replied to.
+** Similar to the $$attribution_intro variable, this is the string that will
+** come after a replied-to message which is quoted in the main body of the reply
+** (this is the case when $$include is set).
+** .pp
+** For a full listing of defined \fCprintf(3)\fP-like sequences see the section
+** on $$index_format.  See also $$attribution_locale.
 */
 
 { "auto_edit", DT_BOOL, false },

--- a/docs/config.c
+++ b/docs/config.c
@@ -316,13 +316,16 @@
 /*
 ** .pp
 ** The locale used by \fCstrftime(3)\fP to format dates in the
-** $attribution string.  Legal values are the strings your system
+** attribution strings.  Legal values are the strings your system
 ** accepts for the locale environment variable \fC$$$LC_TIME\fP.
 ** .pp
 ** This variable is to allow the attribution date format to be
 ** customized by recipient or folder using hooks.  By default, NeoMutt
 ** will use your locale environment, so there is no need to set
 ** this except to override that default.
+** .pp
+** Affected variables are: $$attribution_intro, $$attribution_trailer,
+** $$forward_attribution_intro, $$forward_attribution_trailer, $$indent_string.
 */
 
 { "attribution_trailer", DT_STRING, 0 },

--- a/docs/config.c
+++ b/docs/config.c
@@ -325,6 +325,13 @@
 ** this except to override that default.
 */
 
+{ "attribution_trailer", DT_STRING, 0 },
+/*
+** .pp
+** Similar to the $$attribution_intro variable, NeoMutt will append this
+** string after the inclusion of a message which is being replied to.
+*/
+
 { "auto_edit", DT_BOOL, false },
 /*
 ** .pp
@@ -3515,13 +3522,6 @@
 ** This variable defaults to your user name on the local machine.
 */
 #endif
-
-{ "post_indent_string", DT_STRING, 0 },
-/*
-** .pp
-** Similar to the $$attribution_intro variable, NeoMutt will append this
-** string after the inclusion of a message which is being replied to.
-*/
 
 #ifdef USE_NNTP
 { "post_moderated", DT_QUAD, MUTT_ASKYES },

--- a/docs/config.c
+++ b/docs/config.c
@@ -304,7 +304,7 @@
 ** NeoMutt will operate on the attachments one by one.
 */
 
-{ "attribution", DT_STRING, "On %d, %n wrote:" },
+{ "attribution_intro", DT_STRING, "On %d, %n wrote:" },
 /*
 ** .pp
 ** This is the string that will precede a message which has been included
@@ -923,7 +923,7 @@
 ** UI: $$folder_format, $$index_format, $$mailbox_folder_format,
 ** $$message_format
 ** .pp
-** Composing: $$attribution, $$forward_attribution_intro,
+** Composing: $$attribution_intro, $$forward_attribution_intro,
 ** $$forward_attribution_trailer, $$forward_format, $$indent_string.
 ** .pp
 */
@@ -3519,7 +3519,7 @@
 { "post_indent_string", DT_STRING, 0 },
 /*
 ** .pp
-** Similar to the $$attribution variable, NeoMutt will append this
+** Similar to the $$attribution_intro variable, NeoMutt will append this
 ** string after the inclusion of a message which is being replied to.
 */
 

--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -2788,7 +2788,7 @@ color sidebar_divider   color8  default     <emphasis role="comment"># Dark grey
           message body should start on a new line after the existing blank line
           at the end of headers. Any messages you are replying to will be added
           in sort order to the message, with appropriate
-          <link linkend="attribution">$attribution</link>,
+          <link linkend="attribution-intro">$attribution_intro</link>,
           <link linkend="indent-string">$indent_string</link> and
           <link linkend="post-indent-string">$post_indent_string</link>. When
           forwarding a message, if the
@@ -6378,7 +6378,7 @@ save-hook aol\\.com$ +spam
       </para>
       <para>
         Another typical use for this command is to change the values of the
-        <link linkend="attribution">$attribution</link>,
+        <link linkend="attribution-intro">$attribution_intro</link>,
         <link linkend="attribution-locale">$attribution_locale</link>, and
         <link linkend="signature">$signature</link> variables in order to
         change the language of the attributions and signatures based upon the

--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -2790,7 +2790,7 @@ color sidebar_divider   color8  default     <emphasis role="comment"># Dark grey
           in sort order to the message, with appropriate
           <link linkend="attribution-intro">$attribution_intro</link>,
           <link linkend="indent-string">$indent_string</link> and
-          <link linkend="post-indent-string">$post_indent_string</link>. When
+          <link linkend="attribution-trailer">$attribution_trailer</link>. When
           forwarding a message, if the
           <link linkend="mime-forward">$mime_forward</link> variable is unset,
           a copy of the forwarded message will be included. If you have

--- a/recvcmd.c
+++ b/recvcmd.c
@@ -933,7 +933,7 @@ static void attach_include_reply(FILE *fp, FILE *fp_tmp, struct Email *e)
   }
 
   mutt_copy_message_fp(fp_tmp, fp, e, cmflags, chflags, 0);
-  mutt_make_post_indent(e, fp_tmp, NeoMutt->sub);
+  mutt_make_attribution_trailer(e, fp_tmp, NeoMutt->sub);
 }
 
 /**
@@ -1088,7 +1088,7 @@ void mutt_attach_reply(FILE *fp, struct Mailbox *m, struct Email *e,
       }
     }
 
-    mutt_make_post_indent(e_parent, fp_tmp, NeoMutt->sub);
+    mutt_make_attribution_trailer(e_parent, fp_tmp, NeoMutt->sub);
 
     if (mime_reply_any && !e_cur && !copy_problematic_attachments(&e_tmp->body, actx, false))
     {

--- a/recvcmd.c
+++ b/recvcmd.c
@@ -920,7 +920,7 @@ static void attach_include_reply(FILE *fp, FILE *fp_tmp, struct Email *e)
   CopyMessageFlags cmflags = MUTT_CM_PREFIX | MUTT_CM_DECODE | MUTT_CM_CHARCONV;
   CopyHeaderFlags chflags = CH_DECODE;
 
-  mutt_make_attribution(e, fp_tmp, NeoMutt->sub);
+  mutt_make_attribution_intro(e, fp_tmp, NeoMutt->sub);
 
   const bool c_header = cs_subset_bool(NeoMutt->sub, "header");
   if (!c_header)
@@ -1032,7 +1032,7 @@ void mutt_attach_reply(FILE *fp, struct Mailbox *m, struct Email *e,
   }
   else
   {
-    mutt_make_attribution(e_parent, fp_tmp, NeoMutt->sub);
+    mutt_make_attribution_intro(e_parent, fp_tmp, NeoMutt->sub);
 
     struct State st;
     memset(&st, 0, sizeof(struct State));

--- a/send/config.c
+++ b/send/config.c
@@ -130,7 +130,7 @@ static struct ConfigDef SendVars[] = {
   { "attach_charset", DT_SLIST|SLIST_SEP_COLON|SLIST_ALLOW_EMPTY, 0, 0, charset_slist_validator,
     "When attaching files, use one of these character sets"
   },
-  { "attribution", DT_STRING, IP "On %d, %n wrote:", 0, NULL,
+  { "attribution_intro", DT_STRING, IP "On %d, %n wrote:", 0, NULL,
     "Message to start a reply, 'On DATE, PERSON wrote:'"
   },
   { "attribution_locale", DT_STRING, 0, 0, NULL,
@@ -315,6 +315,7 @@ static struct ConfigDef SendVars[] = {
   { "askbcc",                   DT_SYNONYM, IP "ask_bcc",                    IP "2021-03-21" },
   { "askcc",                    DT_SYNONYM, IP "ask_cc",                     IP "2021-03-21" },
   { "attach_keyword",           DT_SYNONYM, IP "abort_noattach_regex",       IP "2021-03-21" },
+  { "attribution",              DT_SYNONYM, IP "attribution_intro",          IP "2023-02-20" },
   { "crypt_autoencrypt",        DT_SYNONYM, IP "crypt_auto_encrypt",         IP "2021-03-21" },
   { "crypt_autopgp",            DT_SYNONYM, IP "crypt_auto_pgp",             IP "2021-03-21" },
   { "crypt_autosign",           DT_SYNONYM, IP "crypt_auto_sign",            IP "2021-03-21" },

--- a/send/config.c
+++ b/send/config.c
@@ -136,6 +136,9 @@ static struct ConfigDef SendVars[] = {
   { "attribution_locale", DT_STRING, 0, 0, NULL,
     "Locale for dates in the attribution message"
   },
+  { "attribution_trailer", DT_STRING, 0, 0, NULL,
+    "Suffix message to add after reply text"
+  },
   { "bounce_delivered", DT_BOOL, true, 0, NULL,
     "Add 'Delivered-To' to bounced messages"
   },
@@ -247,9 +250,6 @@ static struct ConfigDef SendVars[] = {
   { "pgp_reply_inline", DT_BOOL, false, 0, NULL,
     "Reply using old-style inline PGP messages (not recommended)"
   },
-  { "post_indent_string", DT_STRING, 0, 0, NULL,
-    "Suffix message to add after reply text"
-  },
   { "postpone_encrypt", DT_BOOL, false, 0, NULL,
     "Self-encrypt postponed messages"
   },
@@ -335,6 +335,7 @@ static struct ConfigDef SendVars[] = {
   { "pgp_replysign",            DT_SYNONYM, IP "crypt_reply_sign",           IP "2021-03-21" },
   { "pgp_replysignencrypted",   DT_SYNONYM, IP "crypt_reply_sign_encrypted", IP "2021-03-21" },
   { "post_indent_str",          DT_SYNONYM, IP "post_indent_string",         IP "2021-03-21" },
+  { "post_indent_string",       DT_SYNONYM, IP "attribution_trailer",        IP "2023-02-20" },
   { "reverse_realname",         DT_SYNONYM, IP "reverse_real_name",          IP "2021-03-21" },
   { "use_8bitmime",             DT_SYNONYM, IP "use_8bit_mime",              IP "2021-03-21" },
 

--- a/send/send.c
+++ b/send/send.c
@@ -625,6 +625,29 @@ cleanup:
 }
 
 /**
+ * format_attribution - Format an attribution prefix/suffix
+ * @param s      String to format
+ * @param e      Email
+ * @param fp_out File to write to
+ * @param sub    Config Subset
+ */
+static void format_attribution(const char *s, struct Email *e, FILE *fp_out,
+                               struct ConfigSubset *sub)
+{
+  if (!s || !fp_out)
+    return;
+
+  const char *const c_attribution_locale = cs_subset_string(sub, "attribution_locale");
+
+  char buf[1024] = { 0 };
+  setlocale(LC_TIME, NONULL(c_attribution_locale));
+  mutt_make_string(buf, sizeof(buf), 0, s, NULL, -1, e, MUTT_FORMAT_NO_FLAGS, NULL);
+  setlocale(LC_TIME, "");
+  fputs(buf, fp_out);
+  fputc('\n', fp_out);
+}
+
+/**
  * mutt_make_attribution_intro - Add "on DATE, PERSON wrote" header
  * @param e      Email
  * @param fp_out File to write to
@@ -632,19 +655,7 @@ cleanup:
  */
 void mutt_make_attribution_intro(struct Email *e, FILE *fp_out, struct ConfigSubset *sub)
 {
-  const char *const c_attribution_intro = cs_subset_string(sub, "attribution_intro");
-  if (!c_attribution_intro || !fp_out)
-    return;
-
-  const char *const c_attribution_locale = cs_subset_string(sub, "attribution_locale");
-
-  char buf[1024] = { 0 };
-  setlocale(LC_TIME, NONULL(c_attribution_locale));
-  mutt_make_string(buf, sizeof(buf), 0, c_attribution_intro, NULL, -1, e,
-                   MUTT_FORMAT_NO_FLAGS, NULL);
-  setlocale(LC_TIME, "");
-  fputs(buf, fp_out);
-  fputc('\n', fp_out);
+  format_attribution(cs_subset_string(sub, "attribution_intro"), e, fp_out, sub);
 }
 
 /**
@@ -655,19 +666,7 @@ void mutt_make_attribution_intro(struct Email *e, FILE *fp_out, struct ConfigSub
  */
 void mutt_make_attribution_trailer(struct Email *e, FILE *fp_out, struct ConfigSubset *sub)
 {
-  const char *const c_attribution_trailer = cs_subset_string(sub, "attribution_trailer");
-  if (!c_attribution_trailer || !fp_out)
-    return;
-
-  const char *const c_attribution_locale = cs_subset_string(sub, "attribution_locale");
-
-  char buf[256] = { 0 };
-  setlocale(LC_TIME, NONULL(c_attribution_locale));
-  mutt_make_string(buf, sizeof(buf), 0, c_attribution_trailer, NULL, -1, e,
-                   MUTT_FORMAT_NO_FLAGS, NULL);
-  setlocale(LC_TIME, "");
-  fputs(buf, fp_out);
-  fputc('\n', fp_out);
+  format_attribution(cs_subset_string(sub, "attribution_trailer"), e, fp_out, sub);
 }
 
 /**

--- a/send/send.c
+++ b/send/send.c
@@ -632,15 +632,15 @@ cleanup:
  */
 void mutt_make_attribution(struct Email *e, FILE *fp_out, struct ConfigSubset *sub)
 {
-  const char *const c_attribution = cs_subset_string(sub, "attribution");
-  if (!c_attribution || !fp_out)
+  const char *const c_attribution_intro = cs_subset_string(sub, "attribution_intro");
+  if (!c_attribution_intro || !fp_out)
     return;
 
   const char *const c_attribution_locale = cs_subset_string(sub, "attribution_locale");
 
   char buf[1024] = { 0 };
   setlocale(LC_TIME, NONULL(c_attribution_locale));
-  mutt_make_string(buf, sizeof(buf), 0, c_attribution, NULL, -1, e,
+  mutt_make_string(buf, sizeof(buf), 0, c_attribution_intro, NULL, -1, e,
                    MUTT_FORMAT_NO_FLAGS, NULL);
   setlocale(LC_TIME, "");
   fputs(buf, fp_out);

--- a/send/send.c
+++ b/send/send.c
@@ -625,12 +625,12 @@ cleanup:
 }
 
 /**
- * mutt_make_attribution - Add "on DATE, PERSON wrote" header
+ * mutt_make_attribution_intro - Add "on DATE, PERSON wrote" header
  * @param e      Email
  * @param fp_out File to write to
  * @param sub    Config Subset
  */
-void mutt_make_attribution(struct Email *e, FILE *fp_out, struct ConfigSubset *sub)
+void mutt_make_attribution_intro(struct Email *e, FILE *fp_out, struct ConfigSubset *sub)
 {
   const char *const c_attribution_intro = cs_subset_string(sub, "attribution_intro");
   if (!c_attribution_intro || !fp_out)
@@ -786,7 +786,7 @@ static int include_reply(struct Mailbox *m, struct Email *e, FILE *fp_out,
   mutt_parse_mime_message(e, msg->fp);
   mutt_message_hook(m, e, MUTT_MESSAGE_HOOK);
 
-  mutt_make_attribution(e, fp_out, sub);
+  mutt_make_attribution_intro(e, fp_out, sub);
 
   const bool c_header = cs_subset_bool(sub, "header");
   if (!c_header)

--- a/send/send.c
+++ b/send/send.c
@@ -741,15 +741,15 @@ static void mutt_make_greeting(struct Email *e, FILE *fp_out, struct ConfigSubse
  */
 void mutt_make_post_indent(struct Email *e, FILE *fp_out, struct ConfigSubset *sub)
 {
-  const char *const c_post_indent_string = cs_subset_string(sub, "post_indent_string");
-  if (!c_post_indent_string || !fp_out)
+  const char *const c_attribution_trailer = cs_subset_string(sub, "attribution_trailer");
+  if (!c_attribution_trailer || !fp_out)
     return;
 
   const char *const c_attribution_locale = cs_subset_string(sub, "attribution_locale");
 
   char buf[256] = { 0 };
   setlocale(LC_TIME, NONULL(c_attribution_locale));
-  mutt_make_string(buf, sizeof(buf), 0, c_post_indent_string, NULL, -1, e,
+  mutt_make_string(buf, sizeof(buf), 0, c_attribution_trailer, NULL, -1, e,
                    MUTT_FORMAT_NO_FLAGS, NULL);
   setlocale(LC_TIME, "");
   fputs(buf, fp_out);

--- a/send/send.c
+++ b/send/send.c
@@ -648,6 +648,29 @@ void mutt_make_attribution_intro(struct Email *e, FILE *fp_out, struct ConfigSub
 }
 
 /**
+ * mutt_make_attribution_trailer - Add suffix to replied email text
+ * @param e      Email
+ * @param fp_out File to write to
+ * @param sub    Config Subset
+ */
+void mutt_make_attribution_trailer(struct Email *e, FILE *fp_out, struct ConfigSubset *sub)
+{
+  const char *const c_attribution_trailer = cs_subset_string(sub, "attribution_trailer");
+  if (!c_attribution_trailer || !fp_out)
+    return;
+
+  const char *const c_attribution_locale = cs_subset_string(sub, "attribution_locale");
+
+  char buf[256] = { 0 };
+  setlocale(LC_TIME, NONULL(c_attribution_locale));
+  mutt_make_string(buf, sizeof(buf), 0, c_attribution_trailer, NULL, -1, e,
+                   MUTT_FORMAT_NO_FLAGS, NULL);
+  setlocale(LC_TIME, "");
+  fputs(buf, fp_out);
+  fputc('\n', fp_out);
+}
+
+/**
  * greeting_format_str - Format a greetings string - Implements ::format_t - @ingroup expando_api
  *
  * | Expando | Description
@@ -734,29 +757,6 @@ static void mutt_make_greeting(struct Email *e, FILE *fp_out, struct ConfigSubse
 }
 
 /**
- * mutt_make_post_indent - Add suffix to replied email text
- * @param e      Email
- * @param fp_out File to write to
- * @param sub    Config Subset
- */
-void mutt_make_post_indent(struct Email *e, FILE *fp_out, struct ConfigSubset *sub)
-{
-  const char *const c_attribution_trailer = cs_subset_string(sub, "attribution_trailer");
-  if (!c_attribution_trailer || !fp_out)
-    return;
-
-  const char *const c_attribution_locale = cs_subset_string(sub, "attribution_locale");
-
-  char buf[256] = { 0 };
-  setlocale(LC_TIME, NONULL(c_attribution_locale));
-  mutt_make_string(buf, sizeof(buf), 0, c_attribution_trailer, NULL, -1, e,
-                   MUTT_FORMAT_NO_FLAGS, NULL);
-  setlocale(LC_TIME, "");
-  fputs(buf, fp_out);
-  fputc('\n', fp_out);
-}
-
-/**
  * include_reply - Generate the reply text for an email
  * @param m      Mailbox
  * @param e      Email
@@ -802,7 +802,7 @@ static int include_reply(struct Mailbox *m, struct Email *e, FILE *fp_out,
   mutt_copy_message(fp_out, e, msg, cmflags, chflags, 0);
   mx_msg_close(m, &msg);
 
-  mutt_make_post_indent(e, fp_out, sub);
+  mutt_make_attribution_trailer(e, fp_out, sub);
 
   return 0;
 }

--- a/send/send.h
+++ b/send/send.h
@@ -61,7 +61,7 @@ int             mutt_fetch_recips(struct Envelope *out, struct Envelope *in, Sen
 void            mutt_fix_reply_recipients(struct Envelope *env, struct ConfigSubset *sub);
 void            mutt_forward_intro(struct Email *e, FILE *fp, struct ConfigSubset *sub);
 void            mutt_forward_trailer(struct Email *e, FILE *fp, struct ConfigSubset *sub);
-void            mutt_make_attribution(struct Email *e, FILE *fp_out, struct ConfigSubset *sub);
+void            mutt_make_attribution_intro(struct Email *e, FILE *fp_out, struct ConfigSubset *sub);
 void            mutt_make_forward_subject(struct Envelope *env, struct Email *e, struct ConfigSubset *sub);
 void            mutt_make_misc_reply_headers(struct Envelope *env, struct Envelope *curenv, struct ConfigSubset *sub);
 void            mutt_make_post_indent(struct Email *e, FILE *fp_out, struct ConfigSubset *sub);

--- a/send/send.h
+++ b/send/send.h
@@ -62,9 +62,9 @@ void            mutt_fix_reply_recipients(struct Envelope *env, struct ConfigSub
 void            mutt_forward_intro(struct Email *e, FILE *fp, struct ConfigSubset *sub);
 void            mutt_forward_trailer(struct Email *e, FILE *fp, struct ConfigSubset *sub);
 void            mutt_make_attribution_intro(struct Email *e, FILE *fp_out, struct ConfigSubset *sub);
+void            mutt_make_attribution_trailer(struct Email *e, FILE *fp_out, struct ConfigSubset *sub);
 void            mutt_make_forward_subject(struct Envelope *env, struct Email *e, struct ConfigSubset *sub);
 void            mutt_make_misc_reply_headers(struct Envelope *env, struct Envelope *curenv, struct ConfigSubset *sub);
-void            mutt_make_post_indent(struct Email *e, FILE *fp_out, struct ConfigSubset *sub);
 int             mutt_resend_message(FILE *fp, struct Mailbox *m, struct Email *e_cur, struct ConfigSubset *sub);
 int             mutt_send_message(SendFlags flags, struct Email *e_templ, const char *tempfile, struct Mailbox *m, struct EmailList *el, struct ConfigSubset *sub);
 void            mutt_set_followup_to(struct Envelope *env, struct ConfigSubset *sub);


### PR DESCRIPTION
* **What does this PR do?**

Rename $attribution to $attribution_intro and $post_indent_string to $attribution_trailer.
Some minor rewording in the documentation.

* **What are the relevant issue numbers?**

Fixes #3715