### PR TITLE
Fix decryption issue when postponing S/MIME encrypted mails

### DIFF
--- a/postpone/postpone.c
+++ b/postpone/postpone.c
@@ -462,6 +462,12 @@ static int create_tmp_files_for_attachments(FILE *fp_body, struct Buffer *file,
           return -1;
         }
 
+        if ((b == body) && !protected_headers)
+        {
+          protected_headers = b->mime_headers;
+          b->mime_headers = NULL;
+        }
+
         e_new->security |= sec_type;
         b->type = TYPE_TEXT;
         mutt_str_replace(&b->subtype, "plain");

--- a/postpone/postpone.c
+++ b/postpone/postpone.c
@@ -513,7 +513,6 @@ int mutt_prepare_template(FILE *fp, struct Mailbox *m, struct Email *e_new,
   struct Body *b = NULL;
   FILE *fp_body = NULL;
   int rc = -1;
-  SecurityFlags sec_type = SEC_NO_FLAGS;
   struct Envelope *protected_headers = NULL;
   struct Buffer *file = NULL;
 
@@ -546,6 +545,7 @@ int mutt_prepare_template(FILE *fp, struct Mailbox *m, struct Email *e_new,
     mutt_addrlist_clear(&e_new->env->mail_followup_to);
   }
 
+  SecurityFlags sec_type = SEC_NO_FLAGS;
   if (((WithCrypto & APPLICATION_PGP) != 0) && sec_type == SEC_NO_FLAGS)
     sec_type = mutt_is_multipart_encrypted(e_new->body);
   if (((WithCrypto & APPLICATION_SMIME) != 0) && sec_type == SEC_NO_FLAGS)


### PR DESCRIPTION
## What does this PR do?

I don't claim that I fully understand what the code does, but by symmetry between S/MIME end PGP this should be as presented here (and it fixes #3711 too!)

## What I (believe to) have found out:

The issue is that when postponing a Mail marked for S/MIME encryption and then recalling that encrypted message, then the headers seem to get corrupted.  Actually, I believe now that the headers are not corrupted they are the headers belonging to the outer message + some random(?) modification to set the MIME type to text/plain:

https://github.com/neomutt/neomutt/blob/01733225d4eed2a12b8400d37df881b3d94143c5/postpone/postpone.c#L466-L467

(Quest for the ambitious: Figure out why this is there and if it can be removed)

I believe what actually happened was, that the S/MIME message was *not decrypted at all*! A decryption code path existed for PGP but was simply missing for S/MIME.  One of the commits adds the same code path as for PGP but uses S/MIME.
I guess by sheer coincidence a later level decrypted the message (but that level did not care about any headers...)

## What else

The `dump_envelope()` crashed if given a null pointer, now fixed.  Also changed (IMHO enhanced) the debug methods to print if they got a null pointer. Take it or leave it I don't care.

In the code path the protected headers were also treated differently between PGP and S/MIME.  I don't understand what the code does but I'm a firm believer that there should be no difference between PGP and S/MIME.  (Hopefully this does not destroy some hidden invariance somewhere else...)

And a little treat to reduce duplication (and hopefully not forget one of PGP / S/MIME) the next time something gets updated.

## Conclusion

This fixes the postponing issue (at least I can no longer replicate it).

An honourable mention: during the debugging I noticed the following code:

https://github.com/neomutt/neomutt/blob/01733225d4eed2a12b8400d37df881b3d94143c5/ncrypt/crypt_gpgme.c#L2759-L2819

Here `tattach` contains the decrypted part including Content-Type etc headers.  But only some (e.g. `mime_headers`) are actually preserved, the rest is thrown away. (Incidentally, that was the layer which decrypted the postponed message later and one reason for the charset mismatch). Also fascinating(?) `decrypt_part()` passes its return value to its caller via a file descriptor...

And lastly, **kudos to all the maintainers**.

## What are the relevant issue numbers?

#3711