### PR TITLE
Dump user-defined variables in `neomutt -D`

### DIFF
--- a/init.c
+++ b/init.c
@@ -961,13 +961,8 @@ int mutt_query_variables(struct ListHead *queries, bool show_docs)
     const char *myvar_value = myvar_get(np->data);
     if (myvar_value)
     {
-      pretty_var(myvar_value, &value);
-      /* style should match style of dump_config_neo() */
-      if (show_docs)
-        printf("# user-defined variable\n");
-      printf("set %s = %s\n", np->data, value.data);
-      if (show_docs)
-        printf("\n");
+      dump_myvar_neo(np->data, myvar_value,
+                     show_docs ? CS_DUMP_SHOW_DOCS : CS_DUMP_NO_FLAGS, stdout);
       continue;
     }
 

--- a/main.c
+++ b/main.c
@@ -854,6 +854,7 @@ main
     if (one_liner)
       cdflags |= CS_DUMP_SHOW_DOCS;
     dump_config(cs, cdflags, stdout);
+    dump_myvar(cdflags, stdout);
     goto main_ok; // TEST18: neomutt -D
   }
 

--- a/myvar.c
+++ b/myvar.c
@@ -171,3 +171,55 @@ void myvarlist_free(struct MyVarList *list)
     myvar_free(&myv);
   }
 }
+
+/**
+ * dump_myvar_neo - Dump a user defined variable "my_var" in style of NeoMutt
+ * @param name    name of the user-defined variable
+ * @param value   Current value of the variable
+ * @param flags   Flags, see #ConfigDumpFlags
+ * @param fp      File pointer to write to
+ */
+void dump_myvar_neo(const char *const name, const char *const value,
+                    ConfigDumpFlags flags, FILE *fp)
+{
+  struct Buffer pretty = mutt_buffer_make(256);
+  pretty_var(value, &pretty);
+  /* style should match style of dump_config_neo() */
+  if (flags & CS_DUMP_SHOW_DOCS)
+    printf("# user-defined variable\n");
+
+  bool show_name = !(flags & CS_DUMP_HIDE_NAME);
+  bool show_value = !(flags & CS_DUMP_HIDE_VALUE);
+
+  if (show_name && show_value)
+    fprintf(fp, "set ");
+  if (show_name)
+    fprintf(fp, "%s", name);
+  if (show_name && show_value)
+    fprintf(fp, " = ");
+  if (show_value)
+    fprintf(fp, "%s", pretty.data);
+  if (show_name || show_value)
+    fprintf(fp, "\n");
+
+  if (flags & CS_DUMP_SHOW_DEFAULTS)
+    fprintf(fp, "# string %s unset\n", name);
+
+  if (flags & CS_DUMP_SHOW_DOCS)
+    printf("\n");
+  mutt_buffer_dealloc(&pretty);
+}
+
+/**
+ * dump_myvar - Write all the user defined variables "my_var" to a file
+ * @param flags Flags, see #ConfigDumpFlags
+ * @param fp    File to write config to
+ */
+void dump_myvar(ConfigDumpFlags flags, FILE *fp)
+{
+  struct MyVar *myvar = NULL;
+  TAILQ_FOREACH(myvar, &MyVars, entries)
+  {
+    dump_myvar_neo(myvar->name, myvar->value, flags, fp);
+  }
+}

--- a/myvar.h
+++ b/myvar.h
@@ -24,6 +24,7 @@
 #define MUTT_MYVAR_H
 
 #include "mutt/lib.h"
+#include "config/dump.h"
 
 /**
  * struct MyVar - A user-set variable
@@ -44,5 +45,8 @@ void        myvar_set(const char *var, const char *val);
 void        myvar_append(const char *var, const char *val);
 
 void myvarlist_free(struct MyVarList *list);
+
+void dump_myvar_neo(const char *const name, const char *const value, ConfigDumpFlags flags, FILE *fp);
+void dump_myvar(ConfigDumpFlags flags, FILE *fp);
 
 #endif /* MUTT_MYVAR_H */


### PR DESCRIPTION
* **What does this PR do?**

`neomutt -D` now also lists user-defined variables.