### PR TITLE
Allow NeoMutt to show complete MIME structure

### DIFF
--- a/compose/dlg_compose.c
+++ b/compose/dlg_compose.c
@@ -205,11 +205,10 @@ static void gen_attach_list(struct AttachCtx *actx, struct Body *m, int parent_t
     m->aptr = ap;
     ap->parent_type = parent_type;
     ap->level = level;
-    if ((m->type == TYPE_MULTIPART) && m->parts &&
-        (!(WithCrypto & APPLICATION_PGP) || !mutt_is_multipart_encrypted(m)))
-    {
-      gen_attach_list(actx, m->parts, m->type, level + 1);
-    }
+    //if ((m->type == TYPE_MULTIPART) || mutt_is_message_type(m->type, m->subtype))
+    //{
+    gen_attach_list(actx, m->parts, m->type, level + 1);
+    //}
   }
 }
 

--- a/compose/functions.c
+++ b/compose/functions.c
@@ -363,7 +363,8 @@ static void compose_attach_swap(struct Email *e, struct AttachCtx *actx, int fir
   idx[first] = saved;
 
   // if moved attachment is a group then move subparts too
-  if ((idx[first]->body->type == TYPE_MULTIPART) && (second < actx->idxlen - 1))
+  //if ((idx[first]->body->type == TYPE_MULTIPART) && (second < actx->idxlen - 1))
+  if (idx[first]->body->parts && (second < actx->idxlen - 1))
   {
     int i = second + 1;
     while (idx[i]->level > idx[first]->level)
@@ -1268,7 +1269,7 @@ static int op_attachment_move_down(struct ComposeSharedData *shared, int op)
   int finalidx = index + 1;
   if (nextidx < actx->idxlen - 1)
   {
-    if ((actx->idx[nextidx]->body->type == TYPE_MULTIPART) &&
+    if (actx->idx[nextidx]->body->parts &&
         (actx->idx[nextidx + 1]->level > actx->idx[nextidx]->level))
     {
       finalidx += attach_body_count(actx->idx[nextidx]->body->parts, true);

--- a/compose/functions.c
+++ b/compose/functions.c
@@ -226,9 +226,16 @@ static int delete_attachment(struct AttachCtx *actx, int aidx)
   {
     if (attach_body_parent(idx[0]->body, NULL, idx[aidx]->body, &bptr_parent))
     {
-      if (attach_body_count(bptr_parent->parts, false) < 3)
+      if ((bptr_parent->type == TYPE_MULTIPART) &&
+          attach_body_count(bptr_parent->parts, false) < 3)
       {
         mutt_error(_("Can't leave group with only one attachment"));
+        return -1;
+      }
+      if ((bptr_parent->type == TYPE_MESSAGE) &&
+          attach_body_count(bptr_parent->parts, false) < 2)
+      {
+        mutt_error(_("Can't leave message with no body attachment"));
         return -1;
       }
     }
@@ -247,8 +254,7 @@ static int delete_attachment(struct AttachCtx *actx, int aidx)
   int part_count = 1;
   if (aidx < (actx->idxlen - 1))
   {
-    if ((idx[aidx]->body->type == TYPE_MULTIPART) &&
-        (idx[aidx + 1]->level > idx[aidx]->level))
+    if (idx[aidx]->body->parts && (idx[aidx + 1]->level > idx[aidx]->level))
     {
       part_count += attach_body_count(idx[aidx]->body->parts, true);
     }

--- a/send/sendlib.c
+++ b/send/sendlib.c
@@ -536,14 +536,11 @@ struct Body *mutt_make_message_attach(struct Mailbox *m, struct Email *e,
   fflush(fp);
   rewind(fp);
 
-  body->email = email_new();
-  body->email->offset = 0;
-  /* we don't need the user headers here */
-  body->email->env = mutt_rfc822_read_header(fp, body->email, false, false);
+  body->length = e->body->length;
+  body->parts = mutt_rfc822_parse_message(fp, body);
   if (WithCrypto)
     body->email->security = pgp;
   mutt_update_encoding(body, sub);
-  body->parts = body->email->body;
 
   mutt_file_fclose(&fp);
 

--- a/send/sendlib.c
+++ b/send/sendlib.c
@@ -436,6 +436,16 @@ void mutt_update_encoding(struct Body *a, struct ConfigSubset *sub)
   a->content = info;
 }
 
+static void set_filename_recursive(struct Body *b, const char *const filename)
+{
+  for (; b; b = b->next)
+  {
+    b->filename = mutt_str_dup(filename);
+    b->unlink = false;
+    set_filename_recursive(b->parts, filename);
+  }
+}
+
 /**
  * mutt_make_message_attach - Create a message attachment
  * @param m          Mailbox
@@ -538,6 +548,7 @@ struct Body *mutt_make_message_attach(struct Mailbox *m, struct Email *e,
 
   body->length = e->body->length;
   body->parts = mutt_rfc822_parse_message(fp, body);
+  set_filename_recursive(body->parts, body->filename);
   if (WithCrypto)
     body->email->security = pgp;
   mutt_update_encoding(body, sub);


### PR DESCRIPTION
The attachment menu hides some MIME parts from the user which are usually uninteresting, e.g. a multipart/mixed MIME part at the top level as it is only the container for the attachments.

However, when debugging email problems, especially when encryption is involved, it is useful to see the complete MIME structure. Example where this would have been useful is https://github.com/neomutt/neomutt/issues/3711 I also had a couple of incidents in the past, where I would have liked to have this feature instead of resorting back to an editor and openssl.

Introduce a new config variable $attach_complete_mime_structure, which defaults to false.  If this variable is set, then NeoMutt does not hide any MIME parts from the user.  If unset, it does what it currently does and hides some MIME parts from the user.

---

@gahr I'm sorry, but yes this is a new config variable.  But I don't see another way if the default should be "hide uninteresting stuff from people".

---

* **What are the relevant issue numbers?**

Related: https://github.com/neomutt/neomutt/issues/3711
Fixes: https://github.com/neomutt/neomutt/issues/3706