### PR TITLE
coverage: force testing

### DIFF
--- a/auto.def
+++ b/auto.def
@@ -1127,6 +1127,7 @@ if {[get-define want-compile-commands]} {
 ###############################################################################
 # Coverage Testing
 if {[get-define want-coverage]} {
+  define ENABLE_UNIT_TESTS
   define ENABLE_COVERAGE
   define-append CFLAGS -fprofile-arcs -ftest-coverage
   define-append LDFLAGS -fprofile-arcs -ftest-coverage


### PR DESCRIPTION
If `./configure --coverage` is used, force the building of the test code.

Before, coverage relied on an Autosetup bug, fixed in 219985dfe

---

Is this fix OK?
None of the other tests seem to be relying on `want-testing` or `ENABLE_UNIT_TESTS`