### PR TITLE
sidebar: add background colour

### DIFF
--- a/color/color.h
+++ b/color/color.h
@@ -61,6 +61,7 @@ enum ColorId
   MT_COLOR_QUOTED,                   ///< Pager: quoted text
   MT_COLOR_SEARCH,                   ///< Pager: search matches
 #ifdef USE_SIDEBAR
+  MT_COLOR_SIDEBAR_BACKGROUND,       ///< Background colour for the Sidebar
   MT_COLOR_SIDEBAR_DIVIDER,          ///< Line dividing sidebar from the index/pager
   MT_COLOR_SIDEBAR_FLAGGED,          ///< Mailbox with flagged messages
   MT_COLOR_SIDEBAR_HIGHLIGHT,        ///< Select cursor

--- a/color/command.c
+++ b/color/command.c
@@ -73,6 +73,7 @@ const struct Mapping ColorFields[] = {
   { "quoted",            MT_COLOR_QUOTED },
   { "search",            MT_COLOR_SEARCH },
 #ifdef USE_SIDEBAR
+  { "sidebar_background", MT_COLOR_SIDEBAR_BACKGROUND },
   { "sidebar_divider",   MT_COLOR_SIDEBAR_DIVIDER },
   { "sidebar_flagged",   MT_COLOR_SIDEBAR_FLAGGED },
   { "sidebar_highlight", MT_COLOR_SIDEBAR_HIGHLIGHT },

--- a/docs/config.c
+++ b/docs/config.c
@@ -4199,6 +4199,9 @@
 ** This specifies the characters to be drawn between the sidebar (when
 ** visible) and the other NeoMutt panels. ASCII and Unicode line-drawing
 ** characters are supported.
+** .pp
+** If the sidebar_background color is set, then the divider char can be set to
+** an empty string for extra space.
 */
 
 { "sidebar_folder_indent", DT_BOOL, false },

--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -887,19 +887,19 @@ set sidebar_divider_char = '│'          <emphasis role="comment"># Pretty line
                 <tbody>
                   <row>
                     <entry><literal>%B%?F? [%F]?%* %?N?%N/?%S</literal></entry>
-                    <entry><screen>mailbox [F]            N/S</screen></entry>
+                    <entry><screen>mailbox [F]            N/S </screen></entry>
                   </row>
                   <row>
                     <entry><literal>%B%* %F:%N:%S</literal></entry>
-                    <entry><screen>mailbox              F:N:S</screen></entry>
+                    <entry><screen>mailbox              F:N:S </screen></entry>
                   </row>
                   <row>
                     <entry><literal>%B %?N?(%N)?%* %S</literal></entry>
-                    <entry><screen>mailbox (N)              S</screen></entry>
+                    <entry><screen>mailbox (N)              S </screen></entry>
                   </row>
                   <row>
                     <entry><literal>%B%* ?F?%F/?%N</literal></entry>
-                    <entry><screen>mailbox                F/S</screen></entry>
+                    <entry><screen>mailbox                F/S </screen></entry>
                   </row>
                 </tbody>
               </tgroup>
@@ -1075,14 +1075,15 @@ sidebar_pin +fruit +fruit/apple   <emphasis role="comment"># Always display thes
           </para>
 
 <screen>
-color sidebar_indicator default color17     <emphasis role="comment"># Dark blue background</emphasis>
-color sidebar_highlight white   color238    <emphasis role="comment"># Grey background</emphasis>
+color sidebar_background default black       <emphasis role="comment"># Black background</emphasis>
+color sidebar_indicator  default color17     <emphasis role="comment"># Dark blue background</emphasis>
+color sidebar_highlight  white   color238    <emphasis role="comment"># Grey background</emphasis>
 color sidebar_spool_file yellow  default     <emphasis role="comment"># Yellow</emphasis>
-color sidebar_unread    cyan    default     <emphasis role="comment"># Light blue</emphasis>
-color sidebar_new       green   default     <emphasis role="comment"># Green</emphasis>
-color sidebar_ordinary  default default     <emphasis role="comment"># Default colors</emphasis>
-color sidebar_flagged   red     default     <emphasis role="comment"># Red</emphasis>
-color sidebar_divider   color8  default     <emphasis role="comment"># Dark grey</emphasis>
+color sidebar_unread     cyan    default     <emphasis role="comment"># Light blue</emphasis>
+color sidebar_new        green   default     <emphasis role="comment"># Green</emphasis>
+color sidebar_ordinary   default default     <emphasis role="comment"># Default colors</emphasis>
+color sidebar_flagged    red     default     <emphasis role="comment"># Red</emphasis>
+color sidebar_divider    color8  default     <emphasis role="comment"># Dark grey</emphasis>
 </screen>
 
           <para>
@@ -1137,64 +1138,6 @@ color sidebar_divider   color8  default     <emphasis role="comment"># Dark grey
                   <entry>Lowest</entry>
                   <entry><literal>sidebar_ordinary</literal></entry>
                   <entry>Mailbox does not match above</entry>
-                </row>
-              </tbody>
-            </tgroup>
-          </table>
-        </sect3>
-
-        <sect3 id="intro-sidebar-config-changes">
-          <title>Config Changes</title>
-          <para>
-            If you haven't used Sidebar before, you can ignore this section.
-          </para>
-          <para>
-            Some of the Sidebar config has been changed to make its meaning
-            clearer. These changes have been made since the previous Sidebar
-            release: 2015-11-11.
-          </para>
-
-          <table id="table-intro-sidebar-config-changes">
-            <title>Config Changes</title>
-            <tgroup cols="2">
-              <thead>
-                <row>
-                  <entry>Old Name</entry>
-                  <entry>New Name</entry>
-                </row>
-              </thead>
-              <tbody>
-                <row>
-                  <entry><literal>$sidebar_delim</literal></entry>
-                  <entry><literal>$sidebar_divider_char</literal></entry>
-                </row>
-                <row>
-                  <entry><literal>$sidebar_folderindent</literal></entry>
-                  <entry><literal>$sidebar_folder_indent</literal></entry>
-                </row>
-                <row>
-                  <entry><literal>$sidebar_indentstr</literal></entry>
-                  <entry><literal>$sidebar_indent_string</literal></entry>
-                </row>
-                <row>
-                  <entry><literal>$sidebar_newmail_only</literal></entry>
-                  <entry><literal>$sidebar_new_mail_only</literal></entry>
-                </row>
-                <row>
-                  <entry><literal>$sidebar_shortpath</literal></entry>
-                  <entry><literal>$sidebar_short_path</literal></entry>
-                </row>
-                <row>
-                  <entry><literal>$sidebar_sort</literal></entry>
-                  <entry><literal>$sidebar_sort_method</literal></entry>
-                </row>
-                <row>
-                  <entry><literal>&lt;sidebar-scroll-down&gt;</literal></entry>
-                  <entry><literal>&lt;sidebar-page-down&gt;</literal></entry>
-                </row>
-                <row>
-                  <entry><literal>&lt;sidebar-scroll-up&gt;</literal></entry>
-                  <entry><literal>&lt;sidebar-page-up&gt;</literal></entry>
                 </row>
               </tbody>
             </tgroup>
@@ -5296,6 +5239,10 @@ uncolor prompt
               </row>
             </thead>
             <tbody>
+              <row>
+                <entry>sidebar_background</entry>
+                <entry>The entire sidebar panel</entry>
+              </row>
               <row>
                 <entry>sidebar_divider</entry>
                 <entry>The dividing line between the Sidebar and the Index/Pager panels</entry>
@@ -17501,6 +17448,13 @@ set sort_browser="reverse-size"
             </thead>
             <tbody>
               <row>
+                <entry><literal>sidebar_background</literal></entry>
+                <entry>default</entry>
+                <entry>
+                  The entire sidebar panel
+                </entry>
+              </row>
+              <row>
                 <entry><literal>sidebar_divider</literal></entry>
                 <entry>default</entry>
                 <entry>
@@ -17711,6 +17665,8 @@ color indicator cyan black
 color sidebar_indicator cyan black
 <emphasis role="comment"># Color of the highlighted, but not open, mailbox.</emphasis>
 color sidebar_highlight black color8
+<emphasis role="comment"># Color of the entire Sidebar panel</emphasis>
+color sidebar_background default black
 <emphasis role="comment"># Color of the divider separating the Sidebar from NeoMutt panels</emphasis>
 color sidebar_divider color8 black
 <emphasis role="comment"># Color to give mailboxes containing flagged mail</emphasis>

--- a/docs/neomuttrc.man.head
+++ b/docs/neomuttrc.man.head
@@ -300,6 +300,7 @@ currently defined \fIobject\fPs are:
 .BR underline "."
 .IP
 If the sidebar is enabled the following \fIobject\fPs are also valid:
+.BR sidebar_\:background ", "
 .BR sidebar_\:divider ", "
 .BR sidebar_\:flagged ", "
 .BR sidebar_\:highlight ", "

--- a/sidebar/window.c
+++ b/sidebar/window.c
@@ -278,6 +278,7 @@ static struct AttrColor *calc_color(const struct Mailbox *m, bool current, bool 
   }
 
   struct AttrColor *ac_bg = simple_color_get(MT_COLOR_NORMAL);
+  ac_bg = merged_color_overlay(ac_bg, simple_color_get(MT_COLOR_SIDEBAR_BACKGROUND));
   ac = merged_color_overlay(ac_bg, ac);
 
   if (current || highlight)
@@ -831,13 +832,17 @@ int sb_recalc(struct MuttWindow *win)
 static int draw_divider(struct SidebarWindowData *wdata, struct MuttWindow *win,
                         int num_rows, int num_cols)
 {
-  if ((num_rows < 1) || (num_cols < 1) || (wdata->divider_width > num_cols))
+  if ((num_rows < 1) || (num_cols < 1) || (wdata->divider_width > num_cols) ||
+      (wdata->divider_width == 0))
+  {
     return 0;
+  }
 
   const int width = wdata->divider_width;
   const char *const c_sidebar_divider_char = cs_subset_string(NeoMutt->sub, "sidebar_divider_char");
 
   struct AttrColor *ac = simple_color_get(MT_COLOR_NORMAL);
+  ac = merged_color_overlay(ac, simple_color_get(MT_COLOR_SIDEBAR_BACKGROUND));
   ac = merged_color_overlay(ac, simple_color_get(MT_COLOR_SIDEBAR_DIVIDER));
   mutt_curses_set_color(ac);
 
@@ -881,6 +886,7 @@ static void fill_empty_space(struct MuttWindow *win, int first_row,
 {
   /* Fill the remaining rows with blank space */
   struct AttrColor *ac = simple_color_get(MT_COLOR_NORMAL);
+  ac = merged_color_overlay(ac, simple_color_get(MT_COLOR_SIDEBAR_BACKGROUND));
   mutt_curses_set_color(ac);
 
   const bool c_sidebar_on_right = cs_subset_bool(NeoMutt->sub, "sidebar_on_right");
@@ -889,6 +895,7 @@ static void fill_empty_space(struct MuttWindow *win, int first_row,
   for (int r = 0; r < num_rows; r++)
   {
     mutt_window_move(win, div_width, first_row + r);
+    mutt_curses_set_color_by_id(MT_COLOR_SIDEBAR_BACKGROUND);
 
     for (int i = 0; i < num_cols; i++)
       mutt_window_addch(win, ' ');


### PR DESCRIPTION
A minor addition to the sidebar:

- Add a `sidebar_background` colour
- Allow the `$sidebar_divider_char` to be empty
- Remove some very old sidebar docs

Give the Sidebar a background colour to allow contrast from the Index.
This now allows the divider character to be turned off (giving the user extra space).