### PR TITLE
Fix how group addresses are displayed

### DIFF
--- a/address/address.h
+++ b/address/address.h
@@ -86,7 +86,7 @@ struct Address *mutt_addr_new        (void);
 bool            mutt_addr_to_intl    (struct Address *a);
 bool            mutt_addr_to_local   (struct Address *a);
 bool            mutt_addr_uses_unicode(const char *str);
-size_t          mutt_addr_write      (char *buf, size_t buflen, struct Address *addr, bool display);
+size_t          mutt_addr_write      (struct Buffer *buf, struct Address *addr, bool display);
 
 /* Functions that work on struct AddressList */
 void   mutt_addrlist_append      (struct AddressList *al, struct Address *a);
@@ -105,8 +105,9 @@ bool   mutt_addrlist_search      (const struct AddressList *haystack, const stru
 int    mutt_addrlist_to_intl     (struct AddressList *al, char **err);
 int    mutt_addrlist_to_local    (struct AddressList *al);
 bool   mutt_addrlist_uses_unicode(const struct AddressList *al);
-size_t mutt_addrlist_write       (const struct AddressList *al, char *buf, size_t buflen, bool display);
-void   mutt_addrlist_write_file  (const struct AddressList *addr, FILE *fp, int start_col, bool display);
+size_t mutt_addrlist_write       (const struct AddressList *al, struct Buffer *buf, bool display);
+size_t mutt_addrlist_write_wrap  (const struct AddressList *al, struct Buffer *buf, const char *header);
+void   mutt_addrlist_write_file  (const struct AddressList *al, FILE *fp,           const char *header);
 size_t mutt_addrlist_write_list  (const struct AddressList *al, struct ListHead *list);
 
 #endif /* MUTT_ADDRESS_ADDRESS_H */

--- a/alias/alias.c
+++ b/alias/alias.c
@@ -477,7 +477,7 @@ retry_name:
   }
 
   mutt_buffer_reset(buf);
-  mutt_addrlist_write(&alias->addr, buf->data, buf->dsize, true);
+  mutt_addrlist_write(&alias->addr, buf, true);
   prompt = mutt_buffer_pool_get();
   if (alias->comment)
   {
@@ -547,7 +547,7 @@ retry_name:
   fprintf(fp_alias, "alias %s ", mutt_buffer_string(buf));
   mutt_buffer_reset(buf);
 
-  mutt_addrlist_write(&alias->addr, buf->data, buf->dsize, false);
+  mutt_addrlist_write(&alias->addr, buf, false);
   recode_buf(buf->data, buf->dsize);
   write_safe_address(fp_alias, mutt_buffer_string(buf));
   if (alias->comment)

--- a/commands.c
+++ b/commands.c
@@ -140,7 +140,7 @@ void ci_bounce_message(struct Mailbox *m, struct EmailList *el)
   }
 
   mutt_buffer_reset(buf);
-  mutt_addrlist_write(&al, buf->data, buf->dsize, true);
+  mutt_addrlist_write(&al, buf, true);
 
 #define EXTRA_SPACE (15 + 7 + 2)
   scratch = mutt_buffer_pool_get();
@@ -696,7 +696,6 @@ done:
 void mutt_display_address(struct Envelope *env)
 {
   const char *pfx = NULL;
-  char buf[128] = { 0 };
 
   struct AddressList *al = mutt_get_address(env, &pfx);
   if (!al)
@@ -706,9 +705,10 @@ void mutt_display_address(struct Envelope *env)
    * That is intentional, so the user has an opportunity to copy &
    * paste the on-the-wire form of the address to other, IDN-unable
    * software.  */
-  buf[0] = '\0';
-  mutt_addrlist_write(al, buf, sizeof(buf), false);
-  mutt_message("%s: %s", pfx, buf);
+  struct Buffer *buf = mutt_buffer_pool_get();
+  mutt_addrlist_write(al, buf, false);
+  mutt_message("%s: %s", pfx, mutt_buffer_string(buf));
+  mutt_buffer_pool_release(&buf);
 }
 
 /**

--- a/config/address.c
+++ b/config/address.c
@@ -115,27 +115,22 @@ static int address_string_set(const struct ConfigSet *cs, void *var, struct Conf
 static int address_string_get(const struct ConfigSet *cs, void *var,
                               const struct ConfigDef *cdef, struct Buffer *result)
 {
-  char tmp[8192] = { 0 };
-  const char *str = NULL;
-
   if (var)
   {
     struct Address *a = *(struct Address **) var;
     if (a)
     {
-      mutt_addr_write(tmp, sizeof(tmp), a, false);
-      str = tmp;
+      mutt_addr_write(result, a, false);
     }
   }
   else
   {
-    str = (char *) cdef->initial;
+    mutt_buffer_addstr(result, (char *) cdef->initial);
   }
 
-  if (!str)
+  if (mutt_buffer_is_empty(result))
     return CSR_SUCCESS | CSR_SUC_EMPTY; /* empty string */
 
-  mutt_buffer_addstr(result, str);
   return CSR_SUCCESS;
 }
 

--- a/envelope/functions.c
+++ b/envelope/functions.c
@@ -114,7 +114,7 @@ static bool edit_address_list(enum HeaderField field, struct AddressList *al)
   mutt_buffer_alloc(new_list, 8192);
 
   mutt_addrlist_to_local(al);
-  mutt_addrlist_write(al, new_list->data, new_list->dsize, false);
+  mutt_addrlist_write(al, new_list, false);
   mutt_buffer_fix_dptr(new_list);
   mutt_buffer_copy(old_list, new_list);
   if (mutt_buffer_get_field(_(Prompts[field]), new_list, MUTT_COMP_ALIAS, false,

--- a/envelope/wdata.c
+++ b/envelope/wdata.c
@@ -38,13 +38,6 @@
  */
 void env_wdata_free(struct MuttWindow *win, void **ptr)
 {
-  struct EnvelopeWindowData *wdata = *ptr;
-
-  // Don't free email, env, fcc, sub -- we don't own them
-  mutt_list_free(&wdata->to_list);
-  mutt_list_free(&wdata->cc_list);
-  mutt_list_free(&wdata->bcc_list);
-
   FREE(ptr);
 }
 
@@ -55,10 +48,6 @@ void env_wdata_free(struct MuttWindow *win, void **ptr)
 struct EnvelopeWindowData *env_wdata_new(void)
 {
   struct EnvelopeWindowData *wdata = mutt_mem_calloc(1, sizeof(struct EnvelopeWindowData));
-
-  STAILQ_INIT(&wdata->to_list);
-  STAILQ_INIT(&wdata->cc_list);
-  STAILQ_INIT(&wdata->bcc_list);
 
 #ifdef USE_AUTOCRYPT
   wdata->autocrypt_rec = AUTOCRYPT_REC_OFF;

--- a/envelope/wdata.h
+++ b/envelope/wdata.h
@@ -41,10 +41,6 @@ struct EnvelopeWindowData
   struct Email *email;             ///< Email being composed
   struct Buffer *fcc;              ///< Where the outgoing Email will be saved
 
-  struct ListHead to_list;         ///< 'To:' list of addresses
-  struct ListHead cc_list;         ///< 'Cc:' list of addresses
-  struct ListHead bcc_list;        ///< 'Bcc:' list of addresses
-
   short to_rows;                   ///< Number of rows used by the 'To:' field
   short cc_rows;                   ///< Number of rows used by the 'Cc:' field
   short bcc_rows;                  ///< Number of rows used by the 'Bcc:' field

--- a/hdrline.c
+++ b/hdrline.c
@@ -772,10 +772,14 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
       break;
 
     case 'f':
-      tmp[0] = '\0';
-      mutt_addrlist_write(&e->env->from, tmp, sizeof(tmp), true);
+    {
+      struct Buffer *tmpbuf = mutt_buffer_pool_get();
+      mutt_addrlist_write(&e->env->from, tmpbuf, true);
+      mutt_str_copy(tmp, mutt_buffer_string(tmpbuf), sizeof(tmp));
+      mutt_buffer_pool_release(&tmpbuf);
       mutt_format_s(buf, buflen, prec, tmp);
       break;
+    }
 
     case 'F':
       if (!optional)
@@ -1008,20 +1012,28 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
 #endif
 
     case 'r':
-      tmp[0] = '\0';
-      mutt_addrlist_write(&e->env->to, tmp, sizeof(tmp), true);
+    {
+      struct Buffer *tmpbuf = mutt_buffer_pool_get();
+      mutt_addrlist_write(&e->env->to, tmpbuf, true);
+      mutt_str_copy(tmp, mutt_buffer_string(tmpbuf), sizeof(tmp));
+      mutt_buffer_pool_release(&tmpbuf);
       if (optional && (tmp[0] == '\0'))
         optional = false;
       mutt_format_s(buf, buflen, prec, tmp);
       break;
+    }
 
     case 'R':
-      tmp[0] = '\0';
-      mutt_addrlist_write(&e->env->cc, tmp, sizeof(tmp), true);
+    {
+      struct Buffer *tmpbuf = mutt_buffer_pool_get();
+      mutt_addrlist_write(&e->env->cc, tmpbuf, true);
+      mutt_str_copy(tmp, mutt_buffer_string(tmpbuf), sizeof(tmp));
+      mutt_buffer_pool_release(&tmpbuf);
       if (optional && (tmp[0] == '\0'))
         optional = false;
       mutt_format_s(buf, buflen, prec, tmp);
       break;
+    }
 
     case 's':
     {

--- a/main.c
+++ b/main.c
@@ -871,7 +871,10 @@ main
       {
         /* output in machine-readable form */
         mutt_addrlist_to_intl(al, NULL);
-        mutt_addrlist_write_file(al, stdout, 0, false);
+        struct Buffer *buf = mutt_buffer_pool_get();
+        mutt_addrlist_write(al, buf, false);
+        printf("%s\n", mutt_buffer_string(buf));
+        mutt_buffer_pool_release(&buf);
       }
       else
       {

--- a/mutt/buffer.c
+++ b/mutt/buffer.c
@@ -253,6 +253,44 @@ size_t mutt_buffer_addch(struct Buffer *buf, char c)
 }
 
 /**
+ * mutt_buffer_insert - Add a string in the middle of a buffer
+ * @param buf    Buffer
+ * @param offset Position for the insertion
+ * @param s      String to insert
+ * @retval num Characters written
+ * @retval -1  Error
+ */
+size_t mutt_buffer_insert(struct Buffer *buf, size_t offset, const char *s)
+{
+  if (!buf || !s || (*s == '\0'))
+  {
+    return -1;
+  }
+
+  const size_t slen = mutt_str_len(s);
+  const size_t curlen = mutt_buffer_len(buf);
+  mutt_buffer_alloc(buf, curlen + slen + 1);
+
+  if (offset > curlen)
+  {
+    for (size_t i = curlen; i < offset; ++i)
+    {
+      mutt_buffer_addch(buf, ' ');
+    }
+    mutt_buffer_addstr(buf, s);
+  }
+  else
+  {
+    memmove(buf->data + offset + slen, buf->data + offset, curlen - offset);
+    memcpy(buf->data + offset, s, slen);
+    buf->data[curlen + slen] = '\0';
+    buf->dptr = buf->data + curlen + slen;
+  }
+
+  return mutt_buffer_len(buf) - curlen;
+}
+
+/**
  * mutt_buffer_is_empty - Is the Buffer empty?
  * @param buf Buffer to inspect
  * @retval true Buffer is empty

--- a/mutt/buffer.h
+++ b/mutt/buffer.h
@@ -56,6 +56,9 @@ size_t         mutt_buffer_addstr       (struct Buffer *buf, const char *s);
 size_t         mutt_buffer_addstr_n     (struct Buffer *buf, const char *s, size_t len);
 int            mutt_buffer_add_printf   (struct Buffer *buf, const char *fmt, ...);
 
+// Functions that INSERT into a Buffer
+size_t         mutt_buffer_insert       (struct Buffer *buf, size_t offset, const char *s);
+
 // Functions that OVERWRITE a Buffer
 size_t         mutt_buffer_concat_path  (struct Buffer *buf, const char *dir, const char *fname);
 size_t         mutt_buffer_concatn_path (struct Buffer *dst, const char *dir, size_t dirlen, const char *fname, size_t fnamelen);

--- a/ncrypt/pgpinvoke.c
+++ b/ncrypt/pgpinvoke.c
@@ -434,7 +434,6 @@ void pgp_class_invoke_import(const char *fname)
  */
 void pgp_class_invoke_getkeys(struct Address *addr)
 {
-  char tmp[1024] = { 0 };
   char cmd[STR_COMMAND] = { 0 };
 
   char *personal = NULL;
@@ -449,10 +448,11 @@ void pgp_class_invoke_getkeys(struct Address *addr)
   personal = addr->personal;
   addr->personal = NULL;
 
-  *tmp = '\0';
+  struct Buffer *tmp = mutt_buffer_pool_get();
   mutt_addr_to_local(addr);
-  mutt_addr_write(tmp, sizeof(tmp), addr, false);
-  mutt_buffer_quote_filename(buf, tmp, true);
+  mutt_addr_write(tmp, addr, false);
+  mutt_buffer_quote_filename(buf, mutt_buffer_string(tmp), true);
+  mutt_buffer_pool_release(&tmp);
 
   addr->personal = personal;
 

--- a/recvcmd.c
+++ b/recvcmd.c
@@ -232,7 +232,7 @@ void mutt_attach_bounce(struct Mailbox *m, FILE *fp, struct AttachCtx *actx, str
 
   mutt_buffer_reset(buf);
   mutt_buffer_alloc(buf, 8192);
-  mutt_addrlist_write(&al, buf->data, buf->dsize, true);
+  mutt_addrlist_write(&al, buf, true);
 
 #define EXTRA_SPACE (15 + 7 + 2)
   /* See commands.c.  */

--- a/send/header.c
+++ b/send/header.c
@@ -573,8 +573,6 @@ int mutt_rfc822_write_header(FILE *fp, struct Envelope *env, struct Body *attach
                              enum MuttWriteHeaderMode mode, bool privacy,
                              bool hide_protected_subject, struct ConfigSubset *sub)
 {
-  char buf[1024] = { 0 };
-
   if (((mode == MUTT_WRITE_HEADER_NORMAL) || (mode == MUTT_WRITE_HEADER_FCC) ||
        (mode == MUTT_WRITE_HEADER_POSTPONE)) &&
       !privacy)
@@ -589,22 +587,17 @@ int mutt_rfc822_write_header(FILE *fp, struct Envelope *env, struct Body *attach
    * field if the user sets it with the 'my_hdr' command */
   if (!TAILQ_EMPTY(&env->from) && !privacy)
   {
-    buf[0] = '\0';
-    mutt_addrlist_write(&env->from, buf, sizeof(buf), false);
-    fprintf(fp, "From: %s\n", buf);
+    mutt_addrlist_write_file(&env->from, fp, "From");
   }
 
   if (!TAILQ_EMPTY(&env->sender) && !privacy)
   {
-    buf[0] = '\0';
-    mutt_addrlist_write(&env->sender, buf, sizeof(buf), false);
-    fprintf(fp, "Sender: %s\n", buf);
+    mutt_addrlist_write_file(&env->sender, fp, "Sender");
   }
 
   if (!TAILQ_EMPTY(&env->to))
   {
-    fputs("To: ", fp);
-    mutt_addrlist_write_file(&env->to, fp, 4, false);
+    mutt_addrlist_write_file(&env->to, fp, "To");
   }
   else if (mode == MUTT_WRITE_HEADER_EDITHDRS)
 #ifdef USE_NNTP
@@ -614,8 +607,7 @@ int mutt_rfc822_write_header(FILE *fp, struct Envelope *env, struct Body *attach
 
   if (!TAILQ_EMPTY(&env->cc))
   {
-    fputs("Cc: ", fp);
-    mutt_addrlist_write_file(&env->cc, fp, 4, false);
+    mutt_addrlist_write_file(&env->cc, fp, "Cc");
   }
   else if (mode == MUTT_WRITE_HEADER_EDITHDRS)
 #ifdef USE_NNTP
@@ -631,8 +623,7 @@ int mutt_rfc822_write_header(FILE *fp, struct Envelope *env, struct Body *attach
         (mode == MUTT_WRITE_HEADER_EDITHDRS) || (mode == MUTT_WRITE_HEADER_FCC) ||
         ((mode == MUTT_WRITE_HEADER_NORMAL) && c_write_bcc))
     {
-      fputs("Bcc: ", fp);
-      mutt_addrlist_write_file(&env->bcc, fp, 5, false);
+      mutt_addrlist_write_file(&env->bcc, fp, "Bcc");
     }
   }
   else if (mode == MUTT_WRITE_HEADER_EDITHDRS)
@@ -681,8 +672,7 @@ int mutt_rfc822_write_header(FILE *fp, struct Envelope *env, struct Body *attach
 
   if (!TAILQ_EMPTY(&env->reply_to))
   {
-    fputs("Reply-To: ", fp);
-    mutt_addrlist_write_file(&env->reply_to, fp, 10, false);
+    mutt_addrlist_write_file(&env->reply_to, fp, "Reply-To");
   }
   else if (mode == MUTT_WRITE_HEADER_EDITHDRS)
     fputs("Reply-To:\n", fp);
@@ -693,8 +683,7 @@ int mutt_rfc822_write_header(FILE *fp, struct Envelope *env, struct Body *attach
     if (!OptNewsSend)
 #endif
     {
-      fputs("Mail-Followup-To: ", fp);
-      mutt_addrlist_write_file(&env->mail_followup_to, fp, 18, false);
+      mutt_addrlist_write_file(&env->mail_followup_to, fp, "Mail-Followup-To");
     }
   }
 

--- a/send/send.c
+++ b/send/send.c
@@ -187,7 +187,7 @@ int mutt_edit_address(struct AddressList *al, const char *field, bool expand_ali
   {
     mutt_addrlist_to_local(al);
     mutt_buffer_reset(buf);
-    mutt_addrlist_write(al, buf->data, buf->dsize, false);
+    mutt_addrlist_write(al, buf, false);
     if (mutt_buffer_get_field(field, buf, MUTT_COMP_ALIAS, false, NULL, NULL, NULL) != 0)
     {
       rc = -1;

--- a/test/Makefile.autosetup
+++ b/test/Makefile.autosetup
@@ -68,6 +68,7 @@ BUFFER_OBJS	= test/buffer/mutt_buffer_add_printf.o \
 		  test/buffer/mutt_buffer_dealloc.o \
 		  test/buffer/mutt_buffer_fix_dptr.o \
 		  test/buffer/mutt_buffer_init.o \
+		  test/buffer/mutt_buffer_insert.o \
 		  test/buffer/mutt_buffer_is_empty.o \
 		  test/buffer/mutt_buffer_len.o \
 		  test/buffer/mutt_buffer_make.o \

--- a/test/address/mutt_addr_write.c
+++ b/test/address/mutt_addr_write.c
@@ -35,18 +35,18 @@ void test_mutt_addr_write(void)
 
   {
     struct Address addr = { 0 };
-    mutt_addr_write(NULL, 32, &addr, false);
+    mutt_addr_write(NULL, &addr, false);
     TEST_CHECK_(1, "mutt_addr_write(NULL, 32, &addr, false)");
   }
 
   {
-    char buf[32] = { 0 };
-    mutt_addr_write(buf, sizeof(buf), NULL, false);
+    struct Buffer buf = { 0 };
+    mutt_addr_write(&buf, NULL, false);
     TEST_CHECK_(1, "mutt_addr_write(buf, sizeof(buf), NULL, false)");
   }
 
   { /* integration */
-    char buf[256] = { 0 };
+    struct Buffer *buf = mutt_buffer_pool_get();
     char per[64] = "bobby bob";
     char mbx[64] = "bob@bobsdomain";
 
@@ -58,11 +58,12 @@ void test_mutt_addr_write(void)
       .intl_checked = 0,
     };
 
-    size_t len = mutt_addr_write(buf, sizeof(buf), &addr, false);
+    size_t len = mutt_addr_write(buf, &addr, false);
 
     const char *expected = "bobby bob <bob@bobsdomain>";
 
-    TEST_CHECK_STR_EQ(expected, buf);
+    TEST_CHECK_STR_EQ(expected, mutt_buffer_string(buf));
     TEST_CHECK(len == strlen(expected));
+    mutt_buffer_pool_release(&buf);
   }
 }

--- a/test/address/mutt_addrlist_parse.c
+++ b/test/address/mutt_addrlist_parse.c
@@ -65,7 +65,7 @@ void test_mutt_addrlist_parse(void)
 
   {
     struct AddressList alist = TAILQ_HEAD_INITIALIZER(alist);
-    int parsed = mutt_addrlist_parse(&alist, "Simple Address <test@example.com>, My Group: member1@group.org, member2@group.org, \"John M. Doe\" <john@doe.org>; Another One <foo@bar.baz>, Elvis (The Pelvis) Presley <elvis@king.com>");
+    int parsed = mutt_addrlist_parse(&alist, "Simple Address <test@example.com>, My Group: member1@group.org, member2@group.org, \"John M. Doe\" <john@doe.org>;, Another One <foo@bar.baz>, Elvis (The Pelvis) Presley <elvis@king.com>");
     TEST_CHECK(parsed == 6);
     TEST_CHECK(!TAILQ_EMPTY(&alist));
     struct Address *a = TAILQ_FIRST(&alist);

--- a/test/buffer/mutt_buffer_insert.c
+++ b/test/buffer/mutt_buffer_insert.c
@@ -1,0 +1,119 @@
+/**
+ * @file
+ * Test code for mutt_buffer_insert()
+ *
+ * @authors
+ * Copyright (C) 2023 Pietro Cerutti <gahr@gahr.ch>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define TEST_NO_MAIN
+#include "config.h"
+#include "acutest.h"
+#include <stddef.h>
+#include "mutt/lib.h"
+#include "test_common.h"
+
+struct InsertTest
+{
+  const char *orig;
+  int position;
+  const char *insert;
+  const char *result;
+};
+
+void test_mutt_buffer_insert(void)
+{
+  // Degenerate tests
+  {
+    TEST_CHECK(mutt_buffer_insert(NULL, 0, NULL) == -1);
+  }
+
+  {
+    struct Buffer buf = { 0 };
+    TEST_CHECK(mutt_buffer_insert(&buf, 0, NULL) == -1);
+  }
+
+  {
+    TEST_CHECK(mutt_buffer_insert(NULL, 0, "something") == -1);
+  }
+
+  static const struct InsertTest tests[] = {
+    // clang-format off
+    { NULL,          0,  "I",      "I"       },
+    { NULL,          0,  "INSERT", "INSERT"  },
+    { NULL,          1,  "I",      " I"      },
+    { NULL,          1,  "INSERT", " INSERT" },
+
+    { "a",           0,  "I",      "Ia"       },
+    { "a",           0,  "INSERT", "INSERTa"  },
+    { "a",           1,  "I",      "aI"       },
+    { "a",           1,  "INSERT", "aINSERT"  },
+    { "a",           2,  "I",      "a I"      },
+    { "a",           2,  "INSERT", "a INSERT" },
+
+    { "ab",          0,  "I",      "Iab"       },
+    { "ab",          0,  "INSERT", "INSERTab"  },
+    { "ab",          1,  "I",      "aIb"       },
+    { "ab",          1,  "INSERT", "aINSERTb"  },
+    { "ab",          2,  "I",      "abI"       },
+    { "ab",          2,  "INSERT", "abINSERT"  },
+    { "ab",          3,  "I",      "ab I"      },
+    { "ab",          3,  "INSERT", "ab INSERT" },
+
+    { "applebanana", 0,  "I",      "Iapplebanana"       },
+    { "applebanana", 0,  "INSERT", "INSERTapplebanana"  },
+    { "applebanana", 1,  "I",      "aIpplebanana"       },
+    { "applebanana", 1,  "INSERT", "aINSERTpplebanana"  },
+    { "applebanana", 5,  "I",      "appleIbanana"       },
+    { "applebanana", 5,  "INSERT", "appleINSERTbanana"  },
+    { "applebanana", 10, "I",      "applebananIa"       },
+    { "applebanana", 10, "INSERT", "applebananINSERTa"  },
+    { "applebanana", 11, "I",      "applebananaI"       },
+    { "applebanana", 11, "INSERT", "applebananaINSERT"  },
+    { "applebanana", 12, "I",      "applebanana I"      },
+    { "applebanana", 12, "INSERT", "applebanana INSERT" },
+
+    { NULL, 0, NULL, NULL },
+    // clang-format on
+  };
+
+  {
+    for (size_t i = 0; tests[i].result; i++)
+    {
+      TEST_CASE_("%d", i);
+      struct Buffer *buf = mutt_buffer_pool_get();
+      mutt_buffer_addstr(buf, tests[i].orig);
+      mutt_buffer_insert(buf, tests[i].position, tests[i].insert);
+      TEST_CHECK_STR_EQ(tests[i].result, mutt_buffer_string(buf));
+      mutt_buffer_pool_release(&buf);
+    }
+  }
+
+  {
+    // Insertion that triggers a realloc
+    struct Buffer *buf = mutt_buffer_pool_get();
+    const size_t len = buf->dsize;
+    for (size_t i = 0; i < len - 2; ++i)
+    {
+      mutt_buffer_addch(buf, 'A');
+    }
+    TEST_CHECK(buf->dsize == len);
+    mutt_buffer_insert(buf, len / 2, "CDEFG");
+    TEST_CHECK(buf->dsize != len);
+    mutt_buffer_pool_release(&buf);
+  }
+}

--- a/test/main.c
+++ b/test/main.c
@@ -101,6 +101,7 @@
   NEOMUTT_TEST_ITEM(test_mutt_buffer_dealloc)                                  \
   NEOMUTT_TEST_ITEM(test_mutt_buffer_fix_dptr)                                 \
   NEOMUTT_TEST_ITEM(test_mutt_buffer_init)                                     \
+  NEOMUTT_TEST_ITEM(test_mutt_buffer_insert)                                   \
   NEOMUTT_TEST_ITEM(test_mutt_buffer_is_empty)                                 \
   NEOMUTT_TEST_ITEM(test_mutt_buffer_len)                                      \
   NEOMUTT_TEST_ITEM(test_mutt_buffer_make)                                     \

--- a/test/parse/mutt_parse_mailto.c
+++ b/test/parse/mutt_parse_mailto.c
@@ -43,14 +43,16 @@ static struct ConfigDef Vars[] = {
 
 static void check_addrlist(struct AddressList *list, const char *const exp[], size_t num)
 {
-  char parsed[1024] = { 0 };
-  if (mutt_addrlist_write(list, parsed, sizeof(parsed), false) == 0)
+  struct Buffer *parsed = mutt_buffer_pool_get();
+  if (mutt_addrlist_write(list, parsed, false) == 0)
   {
     TEST_MSG("Expected: parsed %s (...)", exp[0]);
     TEST_MSG("Actual  : not parsed");
   }
 
-  char *pp = parsed;
+  char *pp = mutt_buffer_strdup(parsed);
+  char *orig = pp;
+  mutt_buffer_pool_release(&parsed);
   for (size_t i = 0; i < num; ++i)
   {
     char *tok = mutt_str_skip_whitespace(mutt_str_sep(&pp, ","));
@@ -60,6 +62,7 @@ static void check_addrlist(struct AddressList *list, const char *const exp[], si
       TEST_MSG("Actual  : %s", tok);
     }
   }
+  FREE(&orig);
 }
 
 void test_mutt_parse_mailto(void)


### PR DESCRIPTION
Fixes #3745 

Also, refactor the AddressList writing routines to avoid duplicated logic.
In particular, we don't want multiple places in the code to be aware of how we represent address groups:
it's ugly and I would like to change it, eventually.