### PR TITLE
sidebar: allow an empty divider

### DIFF
--- a/docs/config.c
+++ b/docs/config.c
@@ -4193,15 +4193,18 @@
 ** \fBSee also:\fP $$sidebar_short_path, $$sidebar_folder_indent, $$sidebar_indent_string.
 */
 
-{ "sidebar_divider_char", DT_STRING, 0 },
+{ "sidebar_divider_char", DT_STRING, "|" },
 /*
+** .pp
+** The default is a Unicode vertical line.
 ** .pp
 ** This specifies the characters to be drawn between the sidebar (when
 ** visible) and the other NeoMutt panels. ASCII and Unicode line-drawing
 ** characters are supported.
 ** .pp
-** If the sidebar_background color is set, then the divider char can be set to
-** an empty string for extra space.
+** The divider char can be set to an empty string for some extra space.
+** If empty, setting the sidebar_background color may help distinguish the
+** sidebar from other panels.
 */
 
 { "sidebar_folder_indent", DT_BOOL, false },

--- a/sidebar/config.c
+++ b/sidebar/config.c
@@ -62,7 +62,7 @@ static struct ConfigDef SidebarVars[] = {
   { "sidebar_delim_chars", DT_STRING, IP "/.", 0, NULL,
     "(sidebar) Characters that separate nested folders"
   },
-  { "sidebar_divider_char", DT_STRING, 0, 0, NULL,
+  { "sidebar_divider_char", DT_STRING, IP "\342\224\202", 0, NULL, // Box Drawings Light Vertical, U+2502
     "(sidebar) Character to draw between the sidebar and index"
   },
   { "sidebar_folder_indent", DT_BOOL, false, 0, NULL,

--- a/sidebar/private.h
+++ b/sidebar/private.h
@@ -55,7 +55,6 @@ enum DivType
 {
   SB_DIV_USER,  ///< User configured using $sidebar_divider_char
   SB_DIV_ASCII, ///< An ASCII vertical bar (pipe)
-  SB_DIV_UTF8,  ///< A unicode line-drawing character
 };
 
 /**

--- a/sidebar/window.c
+++ b/sidebar/window.c
@@ -853,18 +853,10 @@ static int draw_divider(struct SidebarWindowData *wdata, struct MuttWindow *win,
   {
     mutt_window_move(win, col, i);
 
-    switch (wdata->divider_type)
-    {
-      case SB_DIV_USER:
-        mutt_window_addstr(win, NONULL(c_sidebar_divider_char));
-        break;
-      case SB_DIV_ASCII:
-        mutt_window_addch(win, '|');
-        break;
-      case SB_DIV_UTF8:
-        mutt_window_addch(win, ACS_VLINE);
-        break;
-    }
+    if (wdata->divider_type == SB_DIV_USER)
+      mutt_window_addstr(win, NONULL(c_sidebar_divider_char));
+    else
+      mutt_window_addch(win, '|');
   }
 
   mutt_curses_set_color_by_id(MT_COLOR_NORMAL);


### PR DESCRIPTION
- Allow an empty value for the divider
- Set the divider's default value to a Unicode vertical line
- Simplify the logic for `$ascii_chars`

If the user sets `$ascii_chars` or the charset isn't utf-8, then the divider character will fallback to an ASCII pipe character `|`.

Fixes: #3750 
