### PR TITLE
editorconfig: fix charset entry

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,7 +3,7 @@ root = true
 [*]
 end_of_line = lf
 insert_final_newline = true
-charset = utf8
+charset = utf-8
 trim_trailing_whitespace = false
 
 # those two settings may be overwritten below.


### PR DESCRIPTION
According to the spec, utf-8 must be spelled "utf-8" https://spec.editorconfig.org/#supported-pairs

https://spec.editorconfig.org/#supported-pairs