### PR TITLE
Keep mailbox in memory

### DIFF
--- a/main.c
+++ b/main.c
@@ -1342,6 +1342,7 @@ main
     repeat_error = true;
     struct Mailbox *m = mx_resolve(buf_string(&folder));
     const bool c_read_only = cs_subset_bool(NeoMutt->sub, "read_only");
+
     if (!mx_mbox_open(m, ((flags & MUTT_CLI_RO) || c_read_only) ? MUTT_READONLY : MUTT_OPEN_NO_FLAGS))
     {
       if (m->account)

--- a/mutt_config.c
+++ b/mutt_config.c
@@ -311,6 +311,9 @@ static struct ConfigDef MainVars[] = {
   { "keep_flagged", DT_BOOL, false, 0, NULL,
     "Don't move flagged messages from `$spool_file` to `$mbox`"
   },
+  { "keep_mailbox", DT_BOOL, false, 0, NULL,
+    "If set, mailbox contents are kept in memory"
+  },
   { "local_date_header", DT_BOOL, true, 0, NULL,
     "Convert the date in the Date header of sent emails into local timezone, UTC otherwise"
   },

--- a/mview.c
+++ b/mview.c
@@ -250,7 +250,7 @@ static void update_tables(struct MailboxView *mv)
   m->msg_flagged = 0;
   padding = mx_msg_padding_size(m);
   const bool c_maildir_trash = cs_subset_bool(NeoMutt->sub, "maildir_trash");
-  for (i = 0, j = 0; i < m->msg_count; i++)
+  for (i = 0, j = 0; i < m->email_max; i++)
   {
     if (!m->emails[i])
       break;

--- a/mview.c
+++ b/mview.c
@@ -54,10 +54,14 @@ void mview_free(struct MailboxView **ptr)
     return;
 
   struct MailboxView *mv = *ptr, *np, *tmp;
+  const bool c_keep_mailbox = cs_subset_bool(NeoMutt->sub, "keep_mailbox");
 
   struct EventMview ev_m = { mv };
   mutt_debug(LL_NOTIFY, "NT_MVIEW_DELETE: %p\n", (void *) mv);
   notify_send(mv->notify, NT_MVIEW, NT_MVIEW_DELETE, &ev_m);
+
+  if (c_keep_mailbox && mv->mailbox->opened)
+    return;
 
   if (mv->mailbox)
     notify_observer_remove(mv->mailbox->notify, mview_mailbox_observer, mv);

--- a/mview.c
+++ b/mview.c
@@ -42,6 +42,8 @@
 #include "score.h"
 #include "sort.h"
 
+struct MailboxViewList mvl = STAILQ_HEAD_INITIALIZER(mvl); ///< List of Contexts
+
 /**
  * mview_free - Free a MailboxView
  * @param[out] ptr MailboxView to free
@@ -51,7 +53,7 @@ void mview_free(struct MailboxView **ptr)
   if (!ptr || !*ptr)
     return;
 
-  struct MailboxView *mv = *ptr;
+  struct MailboxView *mv = *ptr, *np, *tmp;
 
   struct EventMview ev_m = { mv };
   mutt_debug(LL_NOTIFY, "NT_MVIEW_DELETE: %p\n", (void *) mv);
@@ -65,6 +67,11 @@ void mview_free(struct MailboxView **ptr)
   FREE(&mv->pattern);
   mutt_pattern_free(&mv->limit_pattern);
 
+  STAILQ_FOREACH_SAFE(np, &mvl, entries, tmp)
+  {
+    if (np->mailbox == mv->mailbox)
+      STAILQ_REMOVE(&mvl, np, MailboxView, entries);
+  }
   *ptr = NULL;
   FREE(&mv);
 }

--- a/mview.h
+++ b/mview.h
@@ -31,6 +31,7 @@ struct EmailArray;
 struct Mailbox;
 struct Notify;
 struct NotifyCallback;
+extern struct MailboxViewList mvl;
 
 /**
  * struct MailboxView - View of a Mailbox
@@ -49,7 +50,9 @@ struct MailboxView
 
   struct Mailbox *mailbox;           ///< Current Mailbox
   struct Notify *notify;             ///< Notifications: #NotifyMview, #EventMview
+  STAILQ_ENTRY(MailboxView) entries;     ///< Linked list
 };
+STAILQ_HEAD(MailboxViewList, MailboxView);
 
 /**
  * enum NotifyMview - Types of MailboxView Event


### PR DESCRIPTION
* **What does this PR do?**
add keep_mailbox option

keep_mailbox prevents MailboxViews from being free'd when switching mailboxes. Once a mailbox has been opened it's content is kept in memory. This increases memory consumption, but makes switching between mailboxes lightning fast.
 The default is off to conserve memory.

This is a RFC, feedback is welcome. Please give it a try.

To enable add 
set keep_mailbox=yes
to neomuttrc