### PR TITLE
Eliminate config usage in libmutt

### DIFF
--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -326,7 +326,7 @@ $(PWD)/convert:
 # libcore
 LIBCORE=	libcore.a
 LIBCOREOBJS=	core/account.o core/command.o core/dispatcher.o core/mailbox.o \
-		core/neomutt.o
+		core/neomutt.o core/tmp.o
 CLEANFILES+=	$(LIBCORE) $(LIBCOREOBJS)
 ALLOBJS+=	$(LIBCOREOBJS)
 

--- a/attach/cid.c
+++ b/attach/cid.c
@@ -32,11 +32,11 @@
 #include <stdio.h>
 #include <string.h>
 #include "email/lib.h"
+#include "core/tmp.h"
 #include "cid.h"
 #include "attach.h"
 #include "mailcap.h"
 #include "mutt_attach.h"
-#include "muttlib.h"
 
 /**
  * cid_map_free - Free a CidMap

--- a/attach/mutt_attach.c
+++ b/attach/mutt_attach.c
@@ -649,9 +649,13 @@ int mutt_view_attachment(FILE *fp, struct Body *a, enum ViewAttachMode mode,
     }
     else
     {
+      StateFlags flags = STATE_DISPLAY | STATE_DISPLAY_ATTACH;
+      const char *const c_pager = cs_subset_string(NeoMutt->sub, "pager");
+      if (!c_pager || mutt_str_equal(c_pager, "builtin"))
+        flags |= STATE_PAGER;
+
       /* Use built-in handler */
-      if (mutt_decode_save_attachment(fp, a, mutt_buffer_string(pagerfile),
-                                      STATE_DISPLAY | STATE_DISPLAY_ATTACH, MUTT_SAVE_NO_FLAGS))
+      if (mutt_decode_save_attachment(fp, a, mutt_buffer_string(pagerfile), flags, MUTT_SAVE_NO_FLAGS))
       {
         goto return_error;
       }

--- a/attach/mutt_attach.h
+++ b/attach/mutt_attach.h
@@ -27,6 +27,7 @@
 
 #include <stdbool.h>
 #include <stdio.h>
+#include "mutt/lib.h"
 
 struct AttachCtx;
 struct Body;

--- a/color/command.c
+++ b/color/command.c
@@ -42,7 +42,6 @@
 #ifdef USE_DEBUG_COLOR
 #include <stdio.h>
 #include "mutt.h"
-#include "muttlib.h"
 #include "pager/private_data.h"
 #endif
 

--- a/copy.c
+++ b/copy.c
@@ -762,6 +762,9 @@ int mutt_copy_message_fp(FILE *fp_out, FILE *fp_in, struct Email *e,
     {
       state.flags |= STATE_DISPLAY;
       state.wraplen = wraplen;
+      const char *const c_pager = cs_subset_string(NeoMutt->sub, "pager");
+      if (!c_pager || mutt_str_equal(c_pager, "builtin"))
+        state.flags |= STATE_PAGER;
     }
     if (cmflags & MUTT_CM_PRINTING)
       state.flags |= STATE_PRINTING;

--- a/core/lib.h
+++ b/core/lib.h
@@ -31,6 +31,7 @@
  * | core/dispatcher.c   | @subpage core_dispatcher   |
  * | core/mailbox.c      | @subpage core_mailbox      |
  * | core/neomutt.c      | @subpage core_neomutt      |
+ * | core/tmp.c          | @subpage core_tmp          |
  */
 
 #ifndef MUTT_CORE_LIB_H
@@ -43,6 +44,7 @@
 #include "mailbox.h"
 #include "mxapi.h"
 #include "neomutt.h"
+#include "tmp.h"
 // IWYU pragma: end_exports
 
 #endif /* MUTT_CORE_LIB_H */

--- a/core/tmp.c
+++ b/core/tmp.c
@@ -1,0 +1,132 @@
+/**
+ * @file
+ * Create Temporary Files
+ *
+ * @authors
+ * Copyright (C) 2023 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @page core_tmp Create Temporary Files
+ *
+ * Create Temporary Files
+ */
+
+#include "config.h"
+#include <errno.h>
+#include <inttypes.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include "mutt/lib.h"
+#include "config/lib.h"
+#include "globals.h"
+#include "neomutt.h"
+
+/**
+ * mutt_buffer_mktemp_full - Create a temporary file
+ * @param buf    Buffer for result
+ * @param prefix Prefix for filename
+ * @param suffix Suffix for filename
+ * @param src    Source file of caller
+ * @param line   Source line number of caller
+ */
+void mutt_buffer_mktemp_full(struct Buffer *buf, const char *prefix,
+                             const char *suffix, const char *src, int line)
+{
+  const char *const c_tmp_dir = cs_subset_path(NeoMutt->sub, "tmp_dir");
+  mutt_buffer_printf(buf, "%s/%s-%s-%d-%d-%" PRIu64 "%s%s", NONULL(c_tmp_dir),
+                     NONULL(prefix), NONULL(ShortHostname), (int) getuid(),
+                     (int) getpid(), mutt_rand64(), suffix ? "." : "", NONULL(suffix));
+
+  mutt_debug(LL_DEBUG3, "%s:%d: mutt_mktemp returns \"%s\"\n", src, line,
+             mutt_buffer_string(buf));
+  if (unlink(mutt_buffer_string(buf)) && (errno != ENOENT))
+  {
+    mutt_debug(LL_DEBUG1, "%s:%d: ERROR: unlink(\"%s\"): %s (errno %d)\n", src,
+               line, mutt_buffer_string(buf), strerror(errno), errno);
+  }
+}
+
+/**
+ * mutt_file_mkstemp_full - Create temporary file safely
+ * @param file Source file of caller
+ * @param line Source line number of caller
+ * @param func Function name of caller
+ * @retval ptr  FILE handle
+ * @retval NULL Error, see errno
+ *
+ * Create and immediately unlink a temp file using mkstemp().
+ */
+FILE *mutt_file_mkstemp_full(const char *file, int line, const char *func)
+{
+  char name[PATH_MAX] = { 0 };
+
+  const char *const c_tmp_dir = cs_subset_path(NeoMutt->sub, "tmp_dir");
+  int n = snprintf(name, sizeof(name), "%s/neomutt-XXXXXX", NONULL(c_tmp_dir));
+  if (n < 0)
+    return NULL;
+
+  int fd = mkstemp(name);
+  if (fd == -1)
+    return NULL;
+
+  FILE *fp = fdopen(fd, "w+");
+
+  if ((unlink(name) != 0) && (errno != ENOENT))
+  {
+    mutt_file_fclose(&fp);
+    return NULL;
+  }
+
+  MuttLogger(0, file, line, func, 1, "created temp file '%s'\n", name);
+  return fp;
+}
+
+/**
+ * mutt_mktemp_full - Create a temporary filename
+ * @param buf    Buffer for result
+ * @param buflen Length of buffer
+ * @param prefix Prefix for filename
+ * @param suffix Suffix for filename
+ * @param src    Source file of caller
+ * @param line   Source line number of caller
+ *
+ * @note This doesn't create the file, only the name
+ */
+void mutt_mktemp_full(char *buf, size_t buflen, const char *prefix,
+                      const char *suffix, const char *src, int line)
+{
+  const char *const c_tmp_dir = cs_subset_path(NeoMutt->sub, "tmp_dir");
+  size_t n = snprintf(buf, buflen, "%s/%s-%s-%d-%d-%" PRIu64 "%s%s",
+                      NONULL(c_tmp_dir), NONULL(prefix), NONULL(ShortHostname),
+                      (int) getuid(), (int) getpid(), mutt_rand64(),
+                      suffix ? "." : "", NONULL(suffix));
+  if (n >= buflen)
+  {
+    mutt_debug(LL_DEBUG1, "%s:%d: ERROR: insufficient buffer space to hold temporary filename! buflen=%zu but need %zu\n",
+               src, line, buflen, n);
+  }
+  mutt_debug(LL_DEBUG3, "%s:%d: mutt_mktemp returns \"%s\"\n", src, line, buf);
+  if ((unlink(buf) != 0) && (errno != ENOENT))
+  {
+    mutt_debug(LL_DEBUG1, "%s:%d: ERROR: unlink(\"%s\"): %s (errno %d)\n", src,
+               line, buf, strerror(errno), errno);
+  }
+}

--- a/core/tmp.h
+++ b/core/tmp.h
@@ -1,0 +1,42 @@
+/**
+ * @file
+ * Create Temporary Files
+ *
+ * @authors
+ * Copyright (C) 2023 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MUTT_CORE_TMP_H
+#define MUTT_CORE_TMP_H
+
+#include <stdio.h>
+
+struct Buffer;
+
+void  mutt_buffer_mktemp_full(struct Buffer *buf, const char *prefix, const char *suffix, const char *src, int line);
+FILE *mutt_file_mkstemp_full (const char *file, int line, const char *func);
+void  mutt_mktemp_full       (char *s, size_t slen, const char *prefix, const char *suffix, const char *src, int line);
+
+#define mutt_mktemp(buf, buflen)                         mutt_mktemp_pfx_sfx(buf, buflen, "neomutt", NULL)
+#define mutt_mktemp_pfx_sfx(buf, buflen, prefix, suffix) mutt_mktemp_full(buf, buflen, prefix, suffix, __FILE__, __LINE__)
+
+#define mutt_buffer_mktemp(buf)                         mutt_buffer_mktemp_pfx_sfx(buf, "neomutt", NULL)
+#define mutt_buffer_mktemp_pfx_sfx(buf, prefix, suffix) mutt_buffer_mktemp_full(buf, prefix, suffix, __FILE__, __LINE__)
+
+#define mutt_file_mkstemp() mutt_file_mkstemp_full(__FILE__, __LINE__, __func__)
+
+#endif /* MUTT_CORE_TMP_H */

--- a/editmsg.c
+++ b/editmsg.c
@@ -40,7 +40,6 @@
 #include "gui/lib.h"
 #include "mutt.h"
 #include "copy.h"
-#include "muttlib.h"
 #include "mx.h"
 #include "protos.h"
 

--- a/email/parse.c
+++ b/email/parse.c
@@ -513,8 +513,9 @@ void mutt_parse_content_type(const char *s, struct Body *ct)
     }
     else
     {
+      const struct Slist *const c_assumed_charset = cs_subset_slist(NeoMutt->sub, "assumed_charset");
       mutt_param_set(&ct->parameter, "charset",
-                     (const char *) mutt_ch_get_default_charset());
+                     mutt_ch_get_default_charset(c_assumed_charset));
     }
   }
 }

--- a/email/rfc2047.c
+++ b/email/rfc2047.c
@@ -694,7 +694,8 @@ void rfc2047_decode(char **pd)
         if (c_assumed_charset)
         {
           char *conv = mutt_strn_dup(s, holelen);
-          mutt_ch_convert_nonmime_string(&conv);
+          const char *const c_charset = cs_subset_string(NeoMutt->sub, "charset");
+          mutt_ch_convert_nonmime_string(c_assumed_charset, c_charset, &conv);
           mutt_buffer_addstr(&buf, conv);
           FREE(&conv);
         }

--- a/email/rfc2231.c
+++ b/email/rfc2231.c
@@ -267,9 +267,14 @@ void rfc2231_decode_parameters(struct ParameterList *pl)
       const bool c_rfc2047_parameters = cs_subset_bool(NeoMutt->sub, "rfc2047_parameters");
       const struct Slist *const c_assumed_charset = cs_subset_slist(NeoMutt->sub, "assumed_charset");
       if (c_rfc2047_parameters && np->value && strstr(np->value, "=?"))
+      {
         rfc2047_decode(&np->value);
+      }
       else if (c_assumed_charset)
-        mutt_ch_convert_nonmime_string(&np->value);
+      {
+        const char *const c_charset = cs_subset_string(NeoMutt->sub, "charset");
+        mutt_ch_convert_nonmime_string(c_assumed_charset, c_charset, &np->value);
+      }
     }
     /* Single value with encoding:
      *   attr*=us-ascii''the%20value

--- a/handler.c
+++ b/handler.c
@@ -1886,7 +1886,7 @@ void mutt_decode_attachment(struct Body *b, struct State *state)
       const struct Slist *const c_assumed_charset = cs_subset_slist(NeoMutt->sub, "assumed_charset");
       charset = mutt_param_get(&b->parameter, "charset");
       if (!charset && c_assumed_charset)
-        charset = mutt_ch_get_default_charset();
+        charset = mutt_ch_get_default_charset(c_assumed_charset);
     }
     const char *const c_charset = cs_subset_string(NeoMutt->sub, "charset");
     if (charset && c_charset)

--- a/help.c
+++ b/help.c
@@ -41,7 +41,6 @@
 #include "pager/lib.h"
 #include "functions.h"
 #include "keymap.h"
-#include "muttlib.h"
 #include "opcodes.h"
 #include "protos.h"
 

--- a/imap/message.c
+++ b/imap/message.c
@@ -57,7 +57,6 @@
 #include "mdata.h"
 #include "msn.h"
 #include "mutt_logging.h"
-#include "muttlib.h"
 #include "mx.h"
 #include "protos.h"
 #ifdef ENABLE_NLS

--- a/keymap.c
+++ b/keymap.c
@@ -48,7 +48,6 @@
 #include "functions.h"
 #include "globals.h"
 #include "mutt_logging.h"
-#include "muttlib.h"
 #include "opcodes.h"
 #ifdef USE_IMAP
 #include "imap/lib.h"

--- a/mutt/charset.h
+++ b/mutt/charset.h
@@ -77,13 +77,13 @@ int              mutt_ch_check(const char *s, size_t slen, const char *from, con
 bool             mutt_ch_check_charset(const char *cs, bool strict);
 char *           mutt_ch_choose(const char *fromcode, const struct Slist *charsets, const char *u, size_t ulen, char **d, size_t *dlen);
 bool             mutt_ch_chscmp(const char *cs1, const char *cs2);
-int              mutt_ch_convert_nonmime_string(char **ps);
+int              mutt_ch_convert_nonmime_string(const struct Slist *const assumed_charset, const char *charset, char **ps);
 int              mutt_ch_convert_string(char **ps, const char *from, const char *to, uint8_t flags);
 int              mutt_ch_fgetconv(struct FgetConv *fc);
 void             mutt_ch_fgetconv_close(struct FgetConv **fc);
 struct FgetConv *mutt_ch_fgetconv_open(FILE *fp, const char *from, const char *to, uint8_t flags);
 char *           mutt_ch_fgetconvs(char *buf, size_t buflen, struct FgetConv *fc);
-char *           mutt_ch_get_default_charset(void);
+const char *     mutt_ch_get_default_charset(const struct Slist *const assumed_charset);
 char *           mutt_ch_get_langinfo_charset(void);
 size_t           mutt_ch_iconv(iconv_t cd, const char **inbuf, size_t *inbytesleft, char **outbuf, size_t *outbytesleft, const char **inrepls, const char *outrepl, int *iconverrno);
 const char *     mutt_ch_iconv_lookup(const char *chs);

--- a/mutt/file.c
+++ b/mutt/file.c
@@ -39,8 +39,6 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #include <utime.h>
-#include "config/lib.h"
-#include "core/lib.h"
 #include "file.h"
 #include "buffer.h"
 #include "date.h"
@@ -986,41 +984,6 @@ int mutt_file_mkdir(const char *path, mode_t mode)
     return -1;
 
   return 0;
-}
-
-/**
- * mutt_file_mkstemp_full - Create temporary file safely
- * @param file Source file of caller
- * @param line Source line number of caller
- * @param func Function name of caller
- * @retval ptr  FILE handle
- * @retval NULL Error, see errno
- *
- * Create and immediately unlink a temp file using mkstemp().
- */
-FILE *mutt_file_mkstemp_full(const char *file, int line, const char *func)
-{
-  char name[PATH_MAX] = { 0 };
-
-  const char *const c_tmp_dir = cs_subset_path(NeoMutt->sub, "tmp_dir");
-  int n = snprintf(name, sizeof(name), "%s/neomutt-XXXXXX", NONULL(c_tmp_dir));
-  if (n < 0)
-    return NULL;
-
-  int fd = mkstemp(name);
-  if (fd == -1)
-    return NULL;
-
-  FILE *fp = fdopen(fd, "w+");
-
-  if ((unlink(name) != 0) && (errno != ENOENT))
-  {
-    mutt_file_fclose(&fp);
-    return NULL;
-  }
-
-  MuttLogger(0, file, line, func, 1, "created temp file '%s'\n", name);
-  return fp;
 }
 
 /**

--- a/mutt/file.h
+++ b/mutt/file.h
@@ -118,8 +118,6 @@ bool        mutt_file_iter_line(struct MuttFileIter *iter, FILE *fp, ReadLineFla
 int         mutt_file_lock(int fd, bool excl, bool timeout);
 bool        mutt_file_map_lines(mutt_file_map_t func, void *user_data, FILE *fp, ReadLineFlags flags);
 int         mutt_file_mkdir(const char *path, mode_t mode);
-FILE *      mutt_file_mkstemp_full(const char *file, int line, const char *func);
-#define     mutt_file_mkstemp() mutt_file_mkstemp_full(__FILE__, __LINE__, __func__)
 int         mutt_file_open(const char *path, uint32_t flags);
 DIR *       mutt_file_opendir(const char *path, enum MuttOpenDirMode mode);
 size_t      mutt_file_quote_filename(const char *filename, char *buf, size_t buflen);

--- a/mutt/state.c
+++ b/mutt/state.c
@@ -32,8 +32,6 @@
 #include <stdarg.h>
 #include <stdio.h>
 #include <wchar.h>
-#include "config/lib.h"
-#include "core/lib.h"
 #include "state.h"
 #include "date.h"
 #include "random.h"
@@ -74,8 +72,8 @@ void state_mark_attach(struct State *state)
 {
   if (!state || !state->fp_out)
     return;
-  const char *const c_pager = cs_subset_string(NeoMutt->sub, "pager");
-  if ((state->flags & STATE_DISPLAY) && (!c_pager || mutt_str_equal(c_pager, "builtin")))
+
+  if ((state->flags & (STATE_DISPLAY | STATE_PAGER)) == (STATE_DISPLAY | STATE_PAGER))
   {
     state_puts(state, state_attachment_marker());
   }
@@ -87,8 +85,10 @@ void state_mark_attach(struct State *state)
  */
 void state_mark_protected_header(struct State *state)
 {
-  const char *const c_pager = cs_subset_string(NeoMutt->sub, "pager");
-  if ((state->flags & STATE_DISPLAY) && (!c_pager || mutt_str_equal(c_pager, "builtin")))
+  if (!state || !state->fp_out)
+    return;
+
+  if ((state->flags & (STATE_DISPLAY | STATE_PAGER)) == (STATE_DISPLAY | STATE_PAGER))
   {
     state_puts(state, state_protected_header_marker());
   }

--- a/mutt/state.h
+++ b/mutt/state.h
@@ -38,6 +38,7 @@ typedef uint16_t StateFlags;          ///< Flags for State->flags, e.g. #STATE_D
 #define STATE_REPLYING       (1 << 6) ///< Are we replying?
 #define STATE_FIRSTDONE      (1 << 7) ///< The first attachment has been done
 #define STATE_DISPLAY_ATTACH (1 << 8) ///< We are displaying an attachment
+#define STATE_PAGER          (1 << 9) ///< Output will be displayed in the Pager
 
 /**
  * struct State - Keep track when processing files

--- a/muttlib.c
+++ b/muttlib.c
@@ -31,7 +31,6 @@
 #include "config.h"
 #include <ctype.h>
 #include <errno.h>
-#include <inttypes.h>
 #include <limits.h>
 #include <pwd.h>
 #include <stdbool.h>
@@ -454,63 +453,6 @@ bool mutt_is_text_part(struct Body *b)
   }
 
   return false;
-}
-
-/**
- * mutt_buffer_mktemp_full - Create a temporary file
- * @param buf    Buffer for result
- * @param prefix Prefix for filename
- * @param suffix Suffix for filename
- * @param src    Source file of caller
- * @param line   Source line number of caller
- */
-void mutt_buffer_mktemp_full(struct Buffer *buf, const char *prefix,
-                             const char *suffix, const char *src, int line)
-{
-  const char *const c_tmp_dir = cs_subset_path(NeoMutt->sub, "tmp_dir");
-  mutt_buffer_printf(buf, "%s/%s-%s-%d-%d-%" PRIu64 "%s%s", NONULL(c_tmp_dir),
-                     NONULL(prefix), NONULL(ShortHostname), (int) getuid(),
-                     (int) getpid(), mutt_rand64(), suffix ? "." : "", NONULL(suffix));
-
-  mutt_debug(LL_DEBUG3, "%s:%d: mutt_mktemp returns \"%s\"\n", src, line,
-             mutt_buffer_string(buf));
-  if (unlink(mutt_buffer_string(buf)) && (errno != ENOENT))
-  {
-    mutt_debug(LL_DEBUG1, "%s:%d: ERROR: unlink(\"%s\"): %s (errno %d)\n", src,
-               line, mutt_buffer_string(buf), strerror(errno), errno);
-  }
-}
-
-/**
- * mutt_mktemp_full - Create a temporary filename
- * @param buf    Buffer for result
- * @param buflen Length of buffer
- * @param prefix Prefix for filename
- * @param suffix Suffix for filename
- * @param src    Source file of caller
- * @param line   Source line number of caller
- *
- * @note This doesn't create the file, only the name
- */
-void mutt_mktemp_full(char *buf, size_t buflen, const char *prefix,
-                      const char *suffix, const char *src, int line)
-{
-  const char *const c_tmp_dir = cs_subset_path(NeoMutt->sub, "tmp_dir");
-  size_t n = snprintf(buf, buflen, "%s/%s-%s-%d-%d-%" PRIu64 "%s%s",
-                      NONULL(c_tmp_dir), NONULL(prefix), NONULL(ShortHostname),
-                      (int) getuid(), (int) getpid(), mutt_rand64(),
-                      suffix ? "." : "", NONULL(suffix));
-  if (n >= buflen)
-  {
-    mutt_debug(LL_DEBUG1, "%s:%d: ERROR: insufficient buffer space to hold temporary filename! buflen=%zu but need %zu\n",
-               src, line, buflen, n);
-  }
-  mutt_debug(LL_DEBUG3, "%s:%d: mutt_mktemp returns \"%s\"\n", src, line, buf);
-  if ((unlink(buf) != 0) && (errno != ENOENT))
-  {
-    mutt_debug(LL_DEBUG1, "%s:%d: ERROR: unlink(\"%s\"): %s (errno %d)\n", src,
-               line, buf, strerror(errno), errno);
-  }
 }
 
 /**

--- a/muttlib.h
+++ b/muttlib.h
@@ -39,7 +39,6 @@ struct passwd;
 struct stat;
 
 void        mutt_adv_mktemp(struct Buffer *buf);
-void        mutt_buffer_mktemp_full(struct Buffer *buf, const char *prefix, const char *suffix, const char *src, int line);
 void        mutt_buffer_expand_path(struct Buffer *buf);
 void        mutt_buffer_expand_path_regex(struct Buffer *buf, bool regex);
 void        mutt_buffer_pretty_mailbox(struct Buffer *s);
@@ -55,7 +54,6 @@ void        mutt_get_parent_path(const char *path, char *buf, size_t buflen);
 int         mutt_inbox_cmp(const char *a, const char *b);
 bool        mutt_is_text_part(struct Body *b);
 const char *mutt_make_version(void);
-void        mutt_mktemp_full(char *s, size_t slen, const char *prefix, const char *suffix, const char *src, int line);
 bool        mutt_needs_mailcap(struct Body *m);
 FILE *      mutt_open_read(const char *path, pid_t *thepid);
 void        mutt_pretty_mailbox(char *buf, size_t buflen);
@@ -67,11 +65,5 @@ void        mutt_str_pretty_size(char *buf, size_t buflen, size_t num);
 
 void add_to_stailq     (struct ListHead *head, const char *str);
 void remove_from_stailq(struct ListHead *head, const char *str);
-
-#define mutt_mktemp(buf, buflen)                         mutt_mktemp_pfx_sfx(buf, buflen, "neomutt", NULL)
-#define mutt_mktemp_pfx_sfx(buf, buflen, prefix, suffix) mutt_mktemp_full(buf, buflen, prefix, suffix, __FILE__, __LINE__)
-
-#define mutt_buffer_mktemp(buf)                         mutt_buffer_mktemp_pfx_sfx(buf, "neomutt", NULL)
-#define mutt_buffer_mktemp_pfx_sfx(buf, prefix, suffix) mutt_buffer_mktemp_full(buf, prefix, suffix, __FILE__, __LINE__)
 
 #endif /* MUTT_MUTTLIB_H */

--- a/ncrypt/crypt.c
+++ b/ncrypt/crypt.c
@@ -54,7 +54,6 @@
 #include "cryptglue.h"
 #include "globals.h" // IWYU pragma: keep
 #include "handler.h"
-#include "muttlib.h"
 #include "mx.h"
 #ifdef USE_AUTOCRYPT
 #include "autocrypt/lib.h"

--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -63,7 +63,6 @@
 #include "handler.h"
 #include "hook.h"
 #include "mutt_logging.h"
-#include "muttlib.h"
 #ifdef USE_AUTOCRYPT
 #include "autocrypt/lib.h"
 #endif

--- a/ncrypt/gpgme_functions.c
+++ b/ncrypt/gpgme_functions.c
@@ -46,7 +46,6 @@
 #include "crypt_gpgme.h"
 #include "globals.h"
 #include "mutt_logging.h"
-#include "muttlib.h"
 #include "opcodes.h"
 #ifdef ENABLE_NLS
 #include <libintl.h>

--- a/ncrypt/pgp.c
+++ b/ncrypt/pgp.c
@@ -57,7 +57,6 @@
 #include "globals.h" // IWYU pragma: keep
 #include "handler.h"
 #include "hook.h"
-#include "muttlib.h"
 #include "pgpinvoke.h"
 #include "pgpkey.h"
 #include "pgpmicalg.h"

--- a/ncrypt/pgp_functions.c
+++ b/ncrypt/pgp_functions.c
@@ -40,7 +40,6 @@
 #include "question/lib.h"
 #include "globals.h"
 #include "mutt_logging.h"
-#include "muttlib.h"
 #include "opcodes.h"
 #include "pgp.h"
 #include "pgpinvoke.h"

--- a/ncrypt/pgpkey.c
+++ b/ncrypt/pgpkey.c
@@ -50,7 +50,6 @@
 #include "globals.h" // IWYU pragma: keep
 #include "gnupgparse.h"
 #include "mutt_logging.h"
-#include "muttlib.h"
 #include "pgpinvoke.h"
 #ifdef CRYPT_BACKEND_CLASSIC_PGP
 #include "pgp.h"

--- a/ncrypt/pgpmicalg.c
+++ b/ncrypt/pgpmicalg.c
@@ -32,6 +32,7 @@
 #include <stdio.h>
 #include <string.h>
 #include "mutt/lib.h"
+#include "core/lib.h"
 #include "pgpmicalg.h"
 #include "handler.h"
 #include "pgppacket.h"

--- a/pager/message.c
+++ b/pager/message.c
@@ -49,7 +49,6 @@
 #include "hdrline.h"
 #include "hook.h"
 #include "keymap.h"
-#include "muttlib.h"
 #include "mx.h"
 #include "protos.h"
 #ifdef USE_AUTOCRYPT

--- a/pattern/exec.c
+++ b/pattern/exec.c
@@ -51,7 +51,6 @@
 #include "copy.h"
 #include "handler.h"
 #include "maillist.h"
-#include "muttlib.h"
 #include "mx.h"
 #ifndef USE_FMEMOPEN
 #include <sys/stat.h>

--- a/pop/pop.c
+++ b/pop/pop.c
@@ -56,7 +56,6 @@
 #include "mutt_header.h"
 #include "mutt_logging.h"
 #include "mutt_socket.h"
-#include "muttlib.h"
 #include "mx.h"
 #ifdef ENABLE_NLS
 #include <libintl.h>

--- a/recvcmd.c
+++ b/recvcmd.c
@@ -52,7 +52,6 @@
 #include "hdrline.h"
 #include "mutt_body.h"
 #include "mutt_logging.h"
-#include "muttlib.h"
 #include "protos.h"
 #ifdef ENABLE_NLS
 #include <libintl.h>

--- a/rfc3676.c
+++ b/rfc3676.c
@@ -39,7 +39,6 @@
 #include "core/lib.h"
 #include "gui/lib.h"
 #include "rfc3676.h"
-#include "muttlib.h"
 
 #define FLOWED_MAX 72
 

--- a/send/sendmail.c
+++ b/send/sendmail.c
@@ -40,6 +40,7 @@
 #include "mutt/lib.h"
 #include "address/lib.h"
 #include "config/lib.h"
+#include "core/tmp.h"
 #include "gui/lib.h"
 #include "lib.h"
 #include "pager/lib.h"

--- a/test/Makefile.autosetup
+++ b/test/Makefile.autosetup
@@ -140,6 +140,10 @@ CONVERT_OBJS	= test/convert/mutt_update_content_info.o \
 		  test/convert/mutt_convert_file_to.o \
 		  test/convert/mutt_convert_file_from_to.o
 
+CORE_OBJS	= test/core/mutt_buffer_mktemp_full.o \
+		  test/core/mutt_file_mkstemp_full.o \
+		  test/core/mutt_mktemp_full.o
+
 DATE_OBJS	= test/date/mutt_date_add_timeout.o \
 		  test/date/mutt_date_check_month.o \
 		  test/date/mutt_date_now.o \
@@ -224,7 +228,6 @@ FILE_OBJS	= test/file/common.o \
 		  test/file/mutt_file_lock.o \
 		  test/file/mutt_file_map_lines.o \
 		  test/file/mutt_file_mkdir.o \
-		  test/file/mutt_file_mkstemp_full.o \
 		  test/file/mutt_file_open.o \
 		  test/file/mutt_file_quote_filename.o \
 		  test/file/mutt_file_read_keyword.o \
@@ -612,6 +615,7 @@ TEST_OBJS	= test/main.o test/common.o \
 		  $(COMPRESS_OBJS) \
 		  $(CONFIG_OBJS) \
 		  $(CONVERT_OBJS) \
+		  $(CORE_OBJS) \
 		  $(DATE_OBJS) \
 		  $(EMAIL_OBJS) \
 		  $(ENTER_OBJS) \

--- a/test/charset/mutt_ch_convert_nonmime_string.c
+++ b/test/charset/mutt_ch_convert_nonmime_string.c
@@ -28,9 +28,9 @@
 
 void test_mutt_ch_convert_nonmime_string(void)
 {
-  // int mutt_ch_convert_nonmime_string(char **ps);
+  // int mutt_ch_convert_nonmime_string(const struct Slist *const assumed_charset, const char *charset, char **ps);
 
   {
-    TEST_CHECK(mutt_ch_convert_nonmime_string(NULL) != 0);
+    TEST_CHECK(mutt_ch_convert_nonmime_string(NULL, NULL, NULL) != 0);
   }
 }

--- a/test/charset/mutt_ch_get_default_charset.c
+++ b/test/charset/mutt_ch_get_default_charset.c
@@ -38,13 +38,13 @@ static struct ConfigDef Vars[] = {
 
 void test_mutt_ch_get_default_charset(void)
 {
-  // char *mutt_ch_get_default_charset(void);
+  // const char *mutt_ch_get_default_charset(const struct Slist *const assumed_charset);
 
   {
     NeoMutt = test_neomutt_create();
     TEST_CHECK(cs_register_variables(NeoMutt->sub->cs, Vars, DT_NO_FLAGS));
 
-    char *cs = mutt_ch_get_default_charset();
+    const char *cs = mutt_ch_get_default_charset(NULL);
     TEST_CHECK(strlen(cs) != 0);
 
     test_neomutt_destroy(&NeoMutt);

--- a/test/common.c
+++ b/test/common.c
@@ -44,6 +44,13 @@ char *ShortHostname = "example";
 
 #define TEST_DIR "NEOMUTT_TEST_DIR"
 
+static struct ConfigDef Vars[] = {
+  // clang-format off
+  { "tmp_dir", DT_PATH|DT_PATH_DIR|DT_NOT_EMPTY, IP TMPDIR, 0, NULL, },
+  { NULL },
+  // clang-format on
+};
+
 #define CONFIG_INIT_TYPE(CS, NAME)                                             \
   extern const struct ConfigSetType Cst##NAME;                                 \
   cs_register_type(CS, &Cst##NAME)
@@ -127,6 +134,7 @@ struct NeoMutt *test_neomutt_create(void)
 
   struct NeoMutt *n = neomutt_new(cs);
 
+  cs_register_variables(cs, Vars, DT_NO_FLAGS);
   return n;
 }
 

--- a/test/common.c
+++ b/test/common.c
@@ -40,6 +40,7 @@ bool StartupComplete = true;
 char *HomeDir = NULL;
 int SigInt = 0;
 int SigWinch = 0;
+char *ShortHostname = "example";
 
 #define TEST_DIR "NEOMUTT_TEST_DIR"
 
@@ -161,11 +162,6 @@ struct Mailbox *get_current_mailbox(void)
 struct Menu *get_current_menu(void)
 {
   return NULL;
-}
-
-void mutt_mktemp_full(char *buf, size_t buflen, const char *prefix,
-                      const char *suffix, const char *src, int line)
-{
 }
 
 int mutt_do_pager(struct PagerView *pview, struct Email *e)

--- a/test/core/mutt_buffer_mktemp_full.c
+++ b/test/core/mutt_buffer_mktemp_full.c
@@ -1,0 +1,53 @@
+/**
+ * @file
+ * Test code for mutt_buffer_mktemp_full()
+ *
+ * @authors
+ * Copyright (C) 2023 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define TEST_NO_MAIN
+#include "config.h"
+#include "acutest.h"
+#include <stdio.h>
+#include "mutt/lib.h"
+#include "config/lib.h"
+#include "core/lib.h"
+#include "test_common.h"
+
+static struct ConfigDef Vars[] = {
+  // clang-format off
+  { "tmp_dir", DT_PATH|DT_PATH_DIR|DT_NOT_EMPTY, IP TMPDIR, 0, NULL, },
+  { NULL },
+  // clang-format on
+};
+
+void test_mutt_buffer_mktemp_full(void)
+{
+  // void mutt_buffer_mktemp_full(struct Buffer *buf, const char *prefix, const char *suffix, const char *src, int line);
+
+  NeoMutt = test_neomutt_create();
+  TEST_CHECK(cs_register_variables(NeoMutt->sub->cs, Vars, 0));
+
+  {
+    struct Buffer buf = mutt_buffer_make(1024);
+    mutt_buffer_mktemp_full(&buf, NULL, NULL, __FILE__, __LINE__);
+    mutt_buffer_dealloc(&buf);
+  }
+
+  test_neomutt_destroy(&NeoMutt);
+}

--- a/test/core/mutt_buffer_mktemp_full.c
+++ b/test/core/mutt_buffer_mktemp_full.c
@@ -29,19 +29,11 @@
 #include "core/lib.h"
 #include "test_common.h"
 
-static struct ConfigDef Vars[] = {
-  // clang-format off
-  { "tmp_dir", DT_PATH|DT_PATH_DIR|DT_NOT_EMPTY, IP TMPDIR, 0, NULL, },
-  { NULL },
-  // clang-format on
-};
-
 void test_mutt_buffer_mktemp_full(void)
 {
   // void mutt_buffer_mktemp_full(struct Buffer *buf, const char *prefix, const char *suffix, const char *src, int line);
 
   NeoMutt = test_neomutt_create();
-  TEST_CHECK(cs_register_variables(NeoMutt->sub->cs, Vars, 0));
 
   {
     struct Buffer buf = mutt_buffer_make(1024);

--- a/test/core/mutt_file_mkstemp_full.c
+++ b/test/core/mutt_file_mkstemp_full.c
@@ -29,19 +29,11 @@
 #include "core/lib.h"
 #include "test_common.h"
 
-static struct ConfigDef Vars[] = {
-  // clang-format off
-  { "tmp_dir", DT_PATH|DT_PATH_DIR|DT_NOT_EMPTY, IP TMPDIR, 0, NULL, },
-  { NULL },
-  // clang-format on
-};
-
 void test_mutt_file_mkstemp_full(void)
 {
   // FILE *mutt_file_mkstemp_full(const char *file, int line, const char *func);
 
   NeoMutt = test_neomutt_create();
-  TEST_CHECK(cs_register_variables(NeoMutt->sub->cs, Vars, 0));
 
   {
     FILE *fp = NULL;

--- a/test/core/mutt_file_mkstemp_full.c
+++ b/test/core/mutt_file_mkstemp_full.c
@@ -1,0 +1,59 @@
+/**
+ * @file
+ * Test code for mutt_file_mkstemp_full()
+ *
+ * @authors
+ * Copyright (C) 2023 Richard Russon <rich@flatcap.org>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define TEST_NO_MAIN
+#include "config.h"
+#include "acutest.h"
+#include <stdio.h>
+#include "mutt/lib.h"
+#include "config/lib.h"
+#include "core/lib.h"
+#include "test_common.h"
+
+static struct ConfigDef Vars[] = {
+  // clang-format off
+  { "tmp_dir", DT_PATH|DT_PATH_DIR|DT_NOT_EMPTY, IP TMPDIR, 0, NULL, },
+  { NULL },
+  // clang-format on
+};
+
+void test_mutt_file_mkstemp_full(void)
+{
+  // FILE *mutt_file_mkstemp_full(const char *file, int line, const char *func);
+
+  NeoMutt = test_neomutt_create();
+  TEST_CHECK(cs_register_variables(NeoMutt->sub->cs, Vars, 0));
+
+  {
+    FILE *fp = NULL;
+    TEST_CHECK((fp = mutt_file_mkstemp_full(NULL, 0, "apple")) != NULL);
+    fclose(fp);
+  }
+
+  {
+    FILE *fp = NULL;
+    TEST_CHECK((fp = mutt_file_mkstemp_full("apple", 0, NULL)) != NULL);
+    fclose(fp);
+  }
+
+  test_neomutt_destroy(&NeoMutt);
+}

--- a/test/core/mutt_mktemp_full.c
+++ b/test/core/mutt_mktemp_full.c
@@ -1,9 +1,9 @@
 /**
  * @file
- * Test code for mutt_file_mkstemp_full()
+ * Test code for mutt_mktemp_full()
  *
  * @authors
- * Copyright (C) 2019 Richard Russon <rich@flatcap.org>
+ * Copyright (C) 2023 Richard Russon <rich@flatcap.org>
  *
  * @copyright
  * This program is free software: you can redistribute it and/or modify it under
@@ -32,28 +32,20 @@
 static struct ConfigDef Vars[] = {
   // clang-format off
   { "tmp_dir", DT_PATH|DT_PATH_DIR|DT_NOT_EMPTY, IP TMPDIR, 0, NULL, },
-  { "tmpdir", DT_SYNONYM, IP "tmp_dir", IP "2023-01-25" },
   { NULL },
   // clang-format on
 };
 
-void test_mutt_file_mkstemp_full(void)
+void test_mutt_mktemp_full(void)
 {
-  // FILE *mutt_file_mkstemp_full(const char *file, int line, const char *func);
+  // void mutt_mktemp_full(char *buf, size_t buflen, const char *prefix, const char *suffix, const char *src, int line);
 
   NeoMutt = test_neomutt_create();
   TEST_CHECK(cs_register_variables(NeoMutt->sub->cs, Vars, 0));
 
   {
-    FILE *fp = NULL;
-    TEST_CHECK((fp = mutt_file_mkstemp_full(NULL, 0, "apple")) != NULL);
-    fclose(fp);
-  }
-
-  {
-    FILE *fp = NULL;
-    TEST_CHECK((fp = mutt_file_mkstemp_full("apple", 0, NULL)) != NULL);
-    fclose(fp);
+    char buf[256] = { 0 };
+    mutt_mktemp_full(buf, sizeof(buf), NULL, NULL, __FILE__, __LINE__);
   }
 
   test_neomutt_destroy(&NeoMutt);

--- a/test/core/mutt_mktemp_full.c
+++ b/test/core/mutt_mktemp_full.c
@@ -29,19 +29,11 @@
 #include "core/lib.h"
 #include "test_common.h"
 
-static struct ConfigDef Vars[] = {
-  // clang-format off
-  { "tmp_dir", DT_PATH|DT_PATH_DIR|DT_NOT_EMPTY, IP TMPDIR, 0, NULL, },
-  { NULL },
-  // clang-format on
-};
-
 void test_mutt_mktemp_full(void)
 {
   // void mutt_mktemp_full(char *buf, size_t buflen, const char *prefix, const char *suffix, const char *src, int line);
 
   NeoMutt = test_neomutt_create();
-  TEST_CHECK(cs_register_variables(NeoMutt->sub->cs, Vars, 0));
 
   {
     char buf[256] = { 0 };

--- a/test/main.c
+++ b/test/main.c
@@ -165,6 +165,11 @@
   NEOMUTT_TEST_ITEM(test_mutt_update_content_info)                             \
   NEOMUTT_TEST_ITEM(test_mutt_get_content_info)                                \
                                                                                \
+  /* core */                                                                   \
+  NEOMUTT_TEST_ITEM(test_mutt_buffer_mktemp_full)                              \
+  NEOMUTT_TEST_ITEM(test_mutt_file_mkstemp_full)                               \
+  NEOMUTT_TEST_ITEM(test_mutt_mktemp_full)                                     \
+                                                                               \
   /* date */                                                                   \
   NEOMUTT_TEST_ITEM(test_mutt_date_add_timeout)                                \
   NEOMUTT_TEST_ITEM(test_mutt_date_check_month)                                \
@@ -253,7 +258,6 @@
   NEOMUTT_TEST_ITEM(test_mutt_file_lock)                                       \
   NEOMUTT_TEST_ITEM(test_mutt_file_map_lines)                                  \
   NEOMUTT_TEST_ITEM(test_mutt_file_mkdir)                                      \
-  NEOMUTT_TEST_ITEM(test_mutt_file_mkstemp_full)                               \
   NEOMUTT_TEST_ITEM(test_mutt_file_open)                                       \
   NEOMUTT_TEST_ITEM(test_mutt_file_quote_filename)                             \
   NEOMUTT_TEST_ITEM(test_mutt_file_read_keyword)                               \

--- a/test/pattern/dummy.c
+++ b/test/pattern/dummy.c
@@ -205,11 +205,6 @@ struct Email *mutt_get_virt_email(struct Mailbox *m, int vnum)
   return m->emails[inum];
 }
 
-void mutt_buffer_mktemp_full(struct Buffer *buf, const char *prefix,
-                             const char *suffix, const char *src, int line)
-{
-}
-
 int mutt_rfc822_write_header(FILE *fp, struct Envelope *env, struct Body *attach,
                              int mode, bool privacy, bool hide_protected_subject)
 {


### PR DESCRIPTION
`libmutt` shouldn't have any dependencies, but unfortunately it contains three sets of functions that rely on config variables.

These commits update the functions to take extra parameters, use flags or simply move the functions elsewhere. 

### 574579eb8 drop config usage from mutt/state.c

Factor out config usage from:

- `state_mark_attach()`
- `state_mark_protected_header()`

Add a new flag, STATE_PAGER, instead.

### 7b40b874e drop config mutt/charset.c

Factor out config usage from:

- `mutt_ch_convert_nonmime_string()`
- `mutt_ch_get_default_charset()`

Pass in the required strings instead.

### c04a4bd63 move tmp functions to libcore

Move the three temporary-file functions to libcore:

- `mutt_buffer_mktemp_full()`
- `mutt_file_mkstemp_full()`
- `mutt_mktemp_full()`

This includes their macro wrappers:

- `mutt_buffer_mktemp()`
- `mutt_buffer_mktemp_pfx_sfx()`
- `mutt_file_mkstemp()`
- `mutt_mktemp()`
- `mutt_mktemp_pfx_sfx()`

This makes them available to the unit tests, without adding dependencies to libmutt.

### 855dc85ce test: add $tmp_dir to common NeoMutt init

Automatically register `$tmp_dir` when creating a NeoMutt for the unit tests.