### PR TITLE
Do not try to sort an empty array

### DIFF
--- a/mutt/array.h
+++ b/mutt/array.h
@@ -275,7 +275,7 @@
  * @param fn   Sort function, see ::sort_t
  */
 #define ARRAY_SORT(head, fn)                                                   \
-  qsort((head)->entries, ARRAY_SIZE(head), ARRAY_ELEM_SIZE(head), (fn))
+  ((head)->entries && (qsort((head)->entries, ARRAY_SIZE(head), ARRAY_ELEM_SIZE(head), (fn)), true))
 
 /******************************************************************************
  * Internal APIs

--- a/test/array/mutt_array_api.c
+++ b/test/array/mutt_array_api.c
@@ -336,7 +336,18 @@ void test_mutt_array_api(void)
 
   /* Sorting */
   {
-    ARRAY_SORT(&d, gt);
+    struct Dummies empty = ARRAY_HEAD_INITIALIZER;
+    if (!TEST_CHECK(!ARRAY_SORT(&empty, gt)))
+    {
+      TEST_MSG("Expected: false");
+      TEST_MSG("Actual  : true");
+    }
+
+    if (!TEST_CHECK(ARRAY_SORT(&d, gt)))
+    {
+      TEST_MSG("Expected: true");
+      TEST_MSG("Actual  : false");
+    }
     struct Dummy *elem = NULL;
     ARRAY_FOREACH_FROM(elem, &d, 1)
     {


### PR DESCRIPTION
While at it, turn ARRAY_SORT into an expression that return whether the array was non-empty.

Apparently, glibc's qsort has a __nonnull attribute on qsort's first argument, which makes `qsort(NULL, 0, ...)` invalid. This is in my opinion a false positive.

Fixes #3774