### PR TITLE
pager: add helper for getting $pager

### DIFF
--- a/attach/mutt_attach.c
+++ b/attach/mutt_attach.c
@@ -660,8 +660,8 @@ int mutt_view_attachment(FILE *fp, struct Body *a, enum ViewAttachMode mode,
     else
     {
       StateFlags flags = STATE_DISPLAY | STATE_DISPLAY_ATTACH;
-      const char *const c_pager = cs_subset_string(NeoMutt->sub, "pager");
-      if (!c_pager || mutt_str_equal(c_pager, "builtin"))
+      const char *const c_pager = pager_get_pager(NeoMutt->sub);
+      if (!c_pager)
         flags |= STATE_PAGER;
 
       /* Use built-in handler */

--- a/copy.c
+++ b/copy.c
@@ -43,6 +43,7 @@
 #include "copy.h"
 #include "index/lib.h"
 #include "ncrypt/lib.h"
+#include "pager/lib.h"
 #include "send/lib.h"
 #include "format_flags.h"
 #include "globals.h" // IWYU pragma: keep
@@ -766,8 +767,8 @@ int mutt_copy_message_fp(FILE *fp_out, FILE *fp_in, struct Email *e,
     {
       state.flags |= STATE_DISPLAY;
       state.wraplen = wraplen;
-      const char *const c_pager = cs_subset_string(NeoMutt->sub, "pager");
-      if (!c_pager || mutt_str_equal(c_pager, "builtin"))
+      const char *const c_pager = pager_get_pager(NeoMutt->sub);
+      if (!c_pager)
         state.flags |= STATE_PAGER;
     }
     if (cmflags & MUTT_CM_PRINTING)

--- a/help.c
+++ b/help.c
@@ -244,10 +244,10 @@ static void format_line(FILE *fp, int ismacro, const char *t1, const char *t2,
     col = pad(fp, mutt_strwidth(t1), col_a);
   }
 
-  const char *const c_pager = cs_subset_string(NeoMutt->sub, "pager");
+  const char *const c_pager = pager_get_pager(NeoMutt->sub);
   if (ismacro > 0)
   {
-    if (!c_pager || mutt_str_equal(c_pager, "builtin"))
+    if (!c_pager)
       fputs("_\010", fp); // Ctrl-H (backspace)
     fputs("M ", fp);
     col += 2;
@@ -287,17 +287,17 @@ static void format_line(FILE *fp, int ismacro, const char *t1, const char *t2,
 
       if (*t3)
       {
-        if (mutt_str_equal(c_pager, "builtin"))
+        if (c_pager)
+        {
+          fputc('\n', fp);
+          n = 0;
+        }
+        else
         {
           n += col - wraplen;
           const bool c_markers = cs_subset_bool(NeoMutt->sub, "markers");
           if (c_markers)
             n++;
-        }
-        else
-        {
-          fputc('\n', fp);
-          n = 0;
         }
         col = pad(fp, n, col_b);
       }

--- a/index/functions.c
+++ b/index/functions.c
@@ -407,8 +407,8 @@ static int op_display_message(struct IndexSharedData *shared,
   const int index = menu_get_index(priv->menu);
   index_shared_data_set_email(shared, mutt_get_virt_email(shared->mailbox, index));
 
-  const char *const c_pager = cs_subset_string(NeoMutt->sub, "pager");
-  if (c_pager && !mutt_str_equal(c_pager, "builtin"))
+  const char *const c_pager = pager_get_pager(NeoMutt->sub);
+  if (c_pager)
   {
     op = external_pager(shared->mailbox, shared->email, c_pager);
   }

--- a/mutt_config.c
+++ b/mutt_config.c
@@ -372,9 +372,6 @@ static struct ConfigDef MainVars[] = {
   { "new_mail_command", DT_STRING|DT_COMMAND, 0, 0, NULL,
     "External command to run when new mail arrives"
   },
-  { "pager", DT_STRING|DT_COMMAND, IP "builtin", 0, NULL,
-    "External command for viewing messages, or 'builtin' to use NeoMutt's"
-  },
   { "pipe_decode", DT_BOOL, false, 0, NULL,
     "Decode the message when piping it"
   },

--- a/pager/config.c
+++ b/pager/config.c
@@ -30,6 +30,7 @@
 #include <stddef.h>
 #include <config/lib.h>
 #include <stdbool.h>
+#include "mutt/lib.h"
 
 /**
  * PagerVars - Config definitions for the Pager
@@ -44,6 +45,9 @@ static struct ConfigDef PagerVars[] = {
   },
   { "header_color_partial", DT_BOOL, false, 0, NULL,
     "Only colour the part of the header matching the regex"
+  },
+  { "pager", DT_STRING|DT_COMMAND, IP "builtin", 0, NULL,
+    "External command for viewing messages, or 'builtin' to use NeoMutt's"
   },
   { "pager_context", DT_NUMBER|DT_NOT_NEGATIVE, 0, 0, NULL,
     "Number of lines of overlap when changing pages in the pager"
@@ -87,6 +91,23 @@ static struct ConfigDef PagerVars[] = {
   { NULL },
   // clang-format on
 };
+
+/**
+ * pager_get_pager - Get the value of $pager
+ * @param sub Config Subset
+ * @retval str  External command to use
+ * @retval NULL The internal pager will be used
+ *
+ * @note If $pager has the magic value of "builtin", NULL will be returned
+ */
+const char *pager_get_pager(struct ConfigSubset *sub)
+{
+  const char *c_pager = cs_subset_string(sub, "pager");
+  if (!c_pager || mutt_str_equal(c_pager, "builtin"))
+    return NULL;
+
+  return c_pager;
+}
 
 /**
  * config_init_pager - Register pager config variables - Implements ::module_init_config_t - @ingroup cfg_module_api

--- a/pager/do_pager.c
+++ b/pager/do_pager.c
@@ -155,12 +155,8 @@ int mutt_do_pager(struct PagerView *pview, struct Email *e)
 
   int rc;
 
-  const char *const c_pager = cs_subset_string(NeoMutt->sub, "pager");
-  if (!c_pager || mutt_str_equal(c_pager, "builtin"))
-  {
-    rc = mutt_pager(pview);
-  }
-  else
+  const char *const c_pager = pager_get_pager(NeoMutt->sub);
+  if (c_pager)
   {
     struct Buffer *cmd = mutt_buffer_pool_get();
 
@@ -177,6 +173,10 @@ int mutt_do_pager(struct PagerView *pview, struct Email *e)
     }
     mutt_file_unlink(pview->pdata->fname);
     mutt_buffer_pool_release(&cmd);
+  }
+  else
+  {
+    rc = mutt_pager(pview);
   }
 
   dialog_pop();

--- a/pager/lib.h
+++ b/pager/lib.h
@@ -50,6 +50,7 @@
 
 struct Email;
 struct IndexSharedData;
+struct ConfigSubset;
 struct Mailbox;
 struct MuttWindow;
 struct PagerPrivateData;
@@ -200,6 +201,7 @@ int mutt_display_message(struct MuttWindow *win_index, struct IndexSharedData *s
 int external_pager(struct Mailbox *m, struct Email *e, const char *command);
 void pager_queue_redraw(struct PagerPrivateData *priv, PagerRedrawFlags redraw);
 bool mutt_is_quote_line(char *buf, regmatch_t *pmatch);
+const char *pager_get_pager(struct ConfigSubset *sub);
 
 void mutt_clear_pager_position(void);
 


### PR DESCRIPTION
The setting `$pager` has three possible values.
If it's empty, or contains the magic string `builtin`, then the internal pager will be used.
Otherwise it's the name of an external command.

Create a helper to hide the `builtin` magic. 

---

- Move the $pager config item to libpager
- Create a wrapper for $pager to hide the magic value: "builtin"