### PR TITLE
Add support for IMAP ID extension

### DIFF
--- a/docs/config.c
+++ b/docs/config.c
@@ -1990,6 +1990,14 @@
 ** .pp
 ** This variable defaults to your user name on the local machine.
 */
+
+{ "imap_send_id", DT_BOOL, false },
+/*
+** .pp
+** When \fIset\fP, NeoMutt will send an IMAP ID command (RFC2971) to the
+** server when logging in if advertised by the server. This command provides
+** information about the IMAP client, such as "NeoMutt" and the current version.
+*/
 #endif
 
 { "implicit_auto_view", DT_BOOL, false },

--- a/imap/command.c
+++ b/imap/command.c
@@ -81,6 +81,7 @@ static const char *const Capabilities[] = {
   "LIST-EXTENDED",
   "COMPRESS=DEFLATE",
   "X-GM-EXT-1",
+  "ID",
   NULL,
 };
 

--- a/imap/config.c
+++ b/imap/config.c
@@ -126,6 +126,9 @@ static struct ConfigDef ImapVars[] = {
   { "imap_qresync", DT_BOOL, false, 0, NULL,
     "(imap) Enable the QRESYNC extension"
   },
+  { "imap_send_id", DT_BOOL, false, 0, NULL,
+    "(imap) Send ID command when logging in"
+  },
   { "imap_user", DT_STRING|DT_SENSITIVE, 0, 0, NULL,
     "(imap) Username for the IMAP server"
   },

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -1902,6 +1902,14 @@ int imap_login(struct ImapAccountData *adata)
     }
 #endif
 
+    /* enable RFC2971, if the server supports that */
+    const bool c_imap_send_id = cs_subset_bool(NeoMutt->sub, "imap_send_id");
+    if (c_imap_send_id && (adata->capabilities & IMAP_CAP_ID))
+    {
+      imap_exec(adata, "ID (\"name\" \"NeoMutt\" \"version\" \"" PACKAGE_VERSION "\")",
+                IMAP_CMD_QUEUE);
+    }
+
     /* enable RFC6855, if the server supports that */
     const bool c_imap_rfc5161 = cs_subset_bool(NeoMutt->sub, "imap_rfc5161");
     if (c_imap_rfc5161 && (adata->capabilities & IMAP_CAP_ENABLE))

--- a/imap/private.h
+++ b/imap/private.h
@@ -140,8 +140,9 @@ typedef uint32_t ImapCapFlags;              ///< Flags, e.g. #IMAP_CAP_IMAP4
 #define IMAP_CAP_LIST_EXTENDED    (1 << 17) ///< RFC5258: IMAP4 LIST Command Extensions
 #define IMAP_CAP_COMPRESS         (1 << 18) ///< RFC4978: COMPRESS=DEFLATE
 #define IMAP_CAP_X_GM_EXT_1       (1 << 19) ///< https://developers.google.com/gmail/imap/imap-extensions
+#define IMAP_CAP_ID               (1 << 20) ///< RFC2971: IMAP4 ID extension
 
-#define IMAP_CAP_ALL             ((1 << 20) - 1)
+#define IMAP_CAP_ALL             ((1 << 21) - 1)
 
 /**
  * struct ImapList - Items in an IMAP browser


### PR DESCRIPTION
* **What does this PR do?**
Adds a `imap_send_id` boolean config, defaults to false. When set, an `ID` command will be sent to the server when logging in. This provides the IMAP client name and version to the server.

    Example log output:

    > [2023-03-25 10:49:45]<2> mutt_socket_write_d() 4> a0004 ID ("name" "NeoMutt" "version" "20230322-18-a8bdba-dirty")

* **What are the relevant issue numbers?**
#3769