### PR TITLE
Fall back to manual detection of SASL

### DIFF
--- a/auto.def
+++ b/auto.def
@@ -547,12 +547,9 @@ if {[get-define want-sasl]} {
     define USE_SASL_CYRUS
     define-feature SASL
   } else {
-    foreach sasl_lib {sasl2 sasl} {
-      if {[check-inc-and-lib sasl [opt-val with-sasl $prefix] \
-                             sasl/sasl.h sasl_encode64 $sasl_lib]} {
-        define USE_SASL_CYRUS
-        break
-      }
+    if {[check-inc-and-lib sasl [opt-val with-sasl $prefix] \
+                           sasl/sasl.h sasl_encode64 sasl2]} {
+      define USE_SASL_CYRUS
     }
     if {![get-define USE_SASL_CYRUS]} {
       user-error "Unable to find SASL"

--- a/auto.def
+++ b/auto.def
@@ -544,17 +544,12 @@ if {[get-define want-gsasl]} {
 # SASL
 if {[get-define want-sasl]} {
   if {[pkgconf false libsasl2]} {
-    define USE_SASL_CYRUS
     define-feature SASL
-  } else {
-    if {[check-inc-and-lib sasl [opt-val with-sasl $prefix] \
-                           sasl/sasl.h sasl_encode64 sasl2]} {
-      define USE_SASL_CYRUS
-    }
-    if {![get-define USE_SASL_CYRUS]} {
-      user-error "Unable to find SASL"
-    }
+  } elseif {![check-inc-and-lib sasl [opt-val with-sasl $prefix] \
+                                sasl/sasl.h sasl_encode64 sasl2]} {
+    user-error "Unable to find SASL"
   }
+  define USE_SASL_CYRUS
 }
 
 ###############################################################################

--- a/auto.def
+++ b/auto.def
@@ -543,9 +543,21 @@ if {[get-define want-gsasl]} {
 ###############################################################################
 # SASL
 if {[get-define want-sasl]} {
-  pkgconf true libsasl2
-  define USE_SASL_CYRUS
-  define-feature SASL
+  if {[pkgconf false libsasl2]} {
+    define USE_SASL_CYRUS
+    define-feature SASL
+  } else {
+    foreach sasl_lib {sasl2 sasl} {
+      if {[check-inc-and-lib sasl [opt-val with-sasl $prefix] \
+                             sasl/sasl.h sasl_encode64 $sasl_lib]} {
+        define USE_SASL_CYRUS
+        break
+      }
+    }
+    if {![get-define USE_SASL_CYRUS]} {
+      user-error "Unable to find SASL"
+    }
+  }
 }
 
 ###############################################################################


### PR DESCRIPTION
On macOS, neomutt can be built against the system-provided `libsasl2`.
However, since d52a637, detection of the system `libsasl2` broke since
there is no pkg-config file provided.

We can fix that by falling back to the old detection scheme for SASL,
which allowed use of system `libsasl2`. This allows users on macOS to
enable the feature without having to provide additional dependencies
themselves.

I patterened this change after the similar fallback for LMDB in 4974ff3.
