### PR TITLE
notmuch: #if out get_nm_config_file() where unused

### DIFF
--- a/notmuch/db.c
+++ b/notmuch/db.c
@@ -76,6 +76,7 @@ const char *nm_db_get_filename(struct Mailbox *m)
   return db_filename;
 }
 
+#if LIBNOTMUCH_CHECK_VERSION(5, 4, 0)
 /**
  * get_nm_config_file - Gets the configuration file
  * @retval ptr Config file path. Empty string if no config.
@@ -98,6 +99,7 @@ static const char *get_nm_config_file(void)
 
   return config_to_use;
 }
+#endif
 
 /**
  * nm_db_do_open - Open a Notmuch database


### PR DESCRIPTION
According to Debian clang version 17.0.0 (++20230318071855+864a2b25beac-1\~exp1~20230318072020.597):
```
notmuch/db.c:84:20: warning: unused function 'get_nm_config_file' [-Wunused-function]
static const char *get_nm_config_file(void)
                   ^
```

There's one user, just below, guarded by the same `#if`