### PR TITLE
build: tidy Makefiles, fix race condition

### DIFF
--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -28,6 +28,7 @@ RANLIB=		@RANLIB@
 SRCDIR=		@srcdir@
 INSTALL=	@INSTALL@ -c
 INSTALL_DATA=	@INSTALL@ -m 644
+INSTALL_DIR=	@INSTALL@ -d -m 755
 MKDIR_P=	mkdir -p
 RM=		rm -fr
 DEPFILES=	$(ALLOBJS:.o=.Po)
@@ -865,11 +866,11 @@ clean: $(CLEAN_TARGETS)
 # install
 install: all $(INSTALL_TARGETS)
 	# Install binaries
-	$(MKDIR_P) $(DESTDIR)$(bindir)
+	$(INSTALL_DIR) $(DESTDIR)$(bindir)
 	for f in $(BINFILES); do \
 		$(INSTALL) $$f $(DESTDIR)$(bindir)/`basename $$f` || exit 1; \
 	done
-	$(MKDIR_P) $(DESTDIR)$(libexecdir)/$(PACKAGE)
+	$(INSTALL_DIR) $(DESTDIR)$(libexecdir)/$(PACKAGE)
 	for f in $(LIBBINFILES); do \
 		$(INSTALL) $$f $(DESTDIR)$(libexecdir)/$(PACKAGE)/`basename $$f` || exit 1; \
 	done

--- a/contrib/Makefile.autosetup
+++ b/contrib/Makefile.autosetup
@@ -3,7 +3,7 @@ CONTRIB_DIRS=	oauth2 vim-keys
 all-contrib:
 clean-contrib:
 
-install-contrib:
+install-contrib: $(DESTDIR)$(datadir)
 	for d in $(CONTRIB_DIRS); do \
 		echo "Creating directory $(DESTDIR)$(datadir)/$$d"; \
 		$(INSTALL_DIR) $(DESTDIR)$(datadir)/$$d || exit 1; \

--- a/contrib/Makefile.autosetup
+++ b/contrib/Makefile.autosetup
@@ -9,7 +9,7 @@ install-contrib:
 		$(INSTALL) -d -m 755 $(DESTDIR)$(datadir)/$$d || exit 1; \
 		for f in $$(find $(SRCDIR)/contrib/$$d -type f); do \
 			echo "Installing $$f"; \
-			$(INSTALL) -m 644 $$f $(DESTDIR)$(datadir)/$$d || exit 1; \
+			$(INSTALL_DATA) $$f $(DESTDIR)$(datadir)/$$d || exit 1; \
 		done \
 	done
 	find $(DESTDIR)$(datadir) \( -name "*.sh" -o -name "*.py" \) -exec chmod a+x {} \;

--- a/contrib/Makefile.autosetup
+++ b/contrib/Makefile.autosetup
@@ -6,7 +6,7 @@ clean-contrib:
 install-contrib:
 	for d in $(CONTRIB_DIRS); do \
 		echo "Creating directory $(DESTDIR)$(datadir)/$$d"; \
-		$(INSTALL) -d -m 755 $(DESTDIR)$(datadir)/$$d || exit 1; \
+		$(INSTALL_DIR) $(DESTDIR)$(datadir)/$$d || exit 1; \
 		for f in $$(find $(SRCDIR)/contrib/$$d -type f); do \
 			echo "Installing $$f"; \
 			$(INSTALL_DATA) $$f $(DESTDIR)$(datadir)/$$d || exit 1; \

--- a/data/Makefile.autosetup
+++ b/data/Makefile.autosetup
@@ -10,7 +10,7 @@ install-data:
 		$(INSTALL) -d -m 755 $(DESTDIR)$(datadir)/$$d || exit 1; \
 		for f in $$(find $(SRCDIR)/data/$$d -maxdepth 1 -type f); do \
 			echo "Installing $$f"; \
-			$(INSTALL) -m 644 $$f $(DESTDIR)$(datadir)/$$d || exit 1; \
+			$(INSTALL_DATA) $$f $(DESTDIR)$(datadir)/$$d || exit 1; \
 		done \
 	done
 	# Install mime.types

--- a/data/Makefile.autosetup
+++ b/data/Makefile.autosetup
@@ -4,7 +4,10 @@ all-data:
 
 clean-data:
 
-install-data:
+$(DESTDIR)$(datadir):
+	$(INSTALL_DIR) $(DESTDIR)$(datadir)
+
+install-data: $(DESTDIR)$(datadir)
 	for d in $(DATA_DIRS); do \
 		echo "Creating directory $(DESTDIR)$(datadir)/$$d"; \
 		$(INSTALL_DIR) $(DESTDIR)$(datadir)/$$d || exit 1; \

--- a/data/Makefile.autosetup
+++ b/data/Makefile.autosetup
@@ -7,7 +7,7 @@ clean-data:
 install-data:
 	for d in $(DATA_DIRS); do \
 		echo "Creating directory $(DESTDIR)$(datadir)/$$d"; \
-		$(INSTALL) -d -m 755 $(DESTDIR)$(datadir)/$$d || exit 1; \
+		$(INSTALL_DIR) $(DESTDIR)$(datadir)/$$d || exit 1; \
 		for f in $$(find $(SRCDIR)/data/$$d -maxdepth 1 -type f); do \
 			echo "Installing $$f"; \
 			$(INSTALL_DATA) $$f $(DESTDIR)$(datadir)/$$d || exit 1; \

--- a/docs/Makefile.autosetup
+++ b/docs/Makefile.autosetup
@@ -79,16 +79,16 @@ docs/manual.xml:	docs/makedoc$(EXEEXT) $(SRCDIR)/docs/gen-map-doc \
 	) > $@
 
 install-docs: all-docs
-	$(MKDIR_P) $(DESTDIR)$(mandir)/man1
-	$(MKDIR_P) $(DESTDIR)$(mandir)/man5
-	$(MKDIR_P) $(DESTDIR)$(sysconfdir)
+	$(INSTALL_DIR) $(DESTDIR)$(mandir)/man1
+	$(INSTALL_DIR) $(DESTDIR)$(mandir)/man5
+	$(INSTALL_DIR) $(DESTDIR)$(sysconfdir)
 	$(INSTALL_DATA) docs/neomutt.1 $(DESTDIR)$(mandir)/man1/neomutt.1
 	$(INSTALL_DATA) docs/neomuttrc.5 $(DESTDIR)$(mandir)/man5/neomuttrc.5
 	$(INSTALL_DATA) $(SRCDIR)/docs/smime_keys.1 $(DESTDIR)$(mandir)/man1/smime_keys_$(PACKAGE).1
 	$(INSTALL_DATA) $(SRCDIR)/docs/pgpewrap.1 $(DESTDIR)$(mandir)/man1/pgpewrap_$(PACKAGE).1
 	$(INSTALL_DATA) $(SRCDIR)/docs/mbox.5 $(DESTDIR)$(mandir)/man5/mbox_$(PACKAGE).5
 	$(INSTALL_DATA) $(SRCDIR)/docs/mmdf.5 $(DESTDIR)$(mandir)/man5/mmdf_$(PACKAGE).5
-	$(MKDIR_P) $(DESTDIR)$(docdir)
+	$(INSTALL_DIR) $(DESTDIR)$(docdir)
 	for f in $(srcdir_DOCFILES); do \
 		$(INSTALL_DATA) $$f $(DESTDIR)$(docdir) || exit 1; \
 	done
@@ -146,7 +146,7 @@ clean-docs:
 	$(RM) docs/neomuttrc docs/makedoc$(EXEEXT)
 
 install-docs: all-docs
-	$(MKDIR_P) $(DESTDIR)$(sysconfdir)
+	$(INSTALL_DIR) $(DESTDIR)$(sysconfdir)
 	$(INSTALL_DATA) docs/neomuttrc $(DESTDIR)$(sysconfdir)/neomuttrc
 
 uninstall-docs:

--- a/docs/Makefile.autosetup
+++ b/docs/Makefile.autosetup
@@ -82,21 +82,21 @@ install-docs: all-docs
 	$(MKDIR_P) $(DESTDIR)$(mandir)/man1
 	$(MKDIR_P) $(DESTDIR)$(mandir)/man5
 	$(MKDIR_P) $(DESTDIR)$(sysconfdir)
-	$(INSTALL) -m 644 docs/neomutt.1 $(DESTDIR)$(mandir)/man1/neomutt.1
-	$(INSTALL) -m 644 docs/neomuttrc.5 $(DESTDIR)$(mandir)/man5/neomuttrc.5
-	$(INSTALL) -m 644 $(SRCDIR)/docs/smime_keys.1 $(DESTDIR)$(mandir)/man1/smime_keys_$(PACKAGE).1
-	$(INSTALL) -m 644 $(SRCDIR)/docs/pgpewrap.1 $(DESTDIR)$(mandir)/man1/pgpewrap_$(PACKAGE).1
-	$(INSTALL) -m 644 $(SRCDIR)/docs/mbox.5 $(DESTDIR)$(mandir)/man5/mbox_$(PACKAGE).5
-	$(INSTALL) -m 644 $(SRCDIR)/docs/mmdf.5 $(DESTDIR)$(mandir)/man5/mmdf_$(PACKAGE).5
+	$(INSTALL_DATA) docs/neomutt.1 $(DESTDIR)$(mandir)/man1/neomutt.1
+	$(INSTALL_DATA) docs/neomuttrc.5 $(DESTDIR)$(mandir)/man5/neomuttrc.5
+	$(INSTALL_DATA) $(SRCDIR)/docs/smime_keys.1 $(DESTDIR)$(mandir)/man1/smime_keys_$(PACKAGE).1
+	$(INSTALL_DATA) $(SRCDIR)/docs/pgpewrap.1 $(DESTDIR)$(mandir)/man1/pgpewrap_$(PACKAGE).1
+	$(INSTALL_DATA) $(SRCDIR)/docs/mbox.5 $(DESTDIR)$(mandir)/man5/mbox_$(PACKAGE).5
+	$(INSTALL_DATA) $(SRCDIR)/docs/mmdf.5 $(DESTDIR)$(mandir)/man5/mmdf_$(PACKAGE).5
 	$(MKDIR_P) $(DESTDIR)$(docdir)
 	for f in $(srcdir_DOCFILES); do \
-		$(INSTALL) -m 644 $$f $(DESTDIR)$(docdir) || exit 1; \
+		$(INSTALL_DATA) $$f $(DESTDIR)$(docdir) || exit 1; \
 	done
-	[ -s docs/manual.txt ] && $(INSTALL) -m 644 docs/manual.txt $(DESTDIR)$(docdir) || true
+	[ -s docs/manual.txt ] && $(INSTALL_DATA) docs/manual.txt $(DESTDIR)$(docdir) || true
 	for f in $(HTML_DOCFILES); do \
-		$(INSTALL) -m 644 $$f $(DESTDIR)$(docdir) || exit 1; \
+		$(INSTALL_DATA) $$f $(DESTDIR)$(docdir) || exit 1; \
 	done
-	$(INSTALL) -m 644 docs/neomuttrc $(DESTDIR)$(sysconfdir)/neomuttrc
+	$(INSTALL_DATA) docs/neomuttrc $(DESTDIR)$(sysconfdir)/neomuttrc
 
 uninstall-docs:
 	for f in neomutt.1 smime_keys_$(PACKAGE).1 pgpewrap_$(PACKAGE).1; do \
@@ -147,7 +147,7 @@ clean-docs:
 
 install-docs: all-docs
 	$(MKDIR_P) $(DESTDIR)$(sysconfdir)
-	$(INSTALL) -m 644 docs/neomuttrc $(DESTDIR)$(sysconfdir)/neomuttrc
+	$(INSTALL_DATA) docs/neomuttrc $(DESTDIR)$(sysconfdir)/neomuttrc
 
 uninstall-docs:
 	$(RM) $(DESTDIR)$(sysconfdir)/neomuttrc

--- a/po/Makefile.autosetup
+++ b/po/Makefile.autosetup
@@ -36,7 +36,7 @@ install-po: all-po
 	for cat in $$catalogs; do \
 	  lang=`echo $$cat | sed -e 's/\.mo$$//' -e 's|^po/||'`; \
 	  dir=$(DESTDIR)$(localedir)/$$lang/LC_MESSAGES; \
-	  $(MKDIR_P) $$dir; \
+	  $(INSTALL_DIR) $$dir; \
 	  $(INSTALL_DATA) $$cat $$dir/$(PACKAGE).mo || exit 1; \
 	  echo "installing $$dir/$(PACKAGE).mo"; \
 	done


### PR DESCRIPTION
- d3403d150 build: use `$(INSTALL_DATA)`
- 04b61e5e2 build: create `$(INSTALL_DIR)`
- 2c67e8161 build: create data dir separately

Tested:
- A wide variety of builds
- Building out-of-tree
- Installing, uninstalling