### PR TITLE
trivial: replace strcmp() with mutt_str_equal()

### DIFF
--- a/test/base64/mutt_b64_decode.c
+++ b/test/base64/mutt_b64_decode.c
@@ -51,11 +51,7 @@ void test_mutt_b64_decode(void)
       TEST_MSG("Actual  : %zu", len);
     }
     buffer[len] = '\0';
-    if (!TEST_CHECK(mutt_str_equal(buffer, clear)))
-    {
-      TEST_MSG("Expected: %s", clear);
-      TEST_MSG("Actual  : %s", buffer);
-    }
+    TEST_CHECK_STR_EQ(buffer, clear);
   }
 
   {

--- a/test/base64/mutt_b64_encode.c
+++ b/test/base64/mutt_b64_encode.c
@@ -25,6 +25,7 @@
 #include "acutest.h"
 #include <string.h>
 #include "mutt/lib.h"
+#include "test_common.h"
 
 static const char clear[] = "Hello";
 static const char encoded[] = "SGVsbG8=";
@@ -50,11 +51,7 @@ void test_mutt_b64_encode(void)
       TEST_MSG("Expected: %zu", sizeof(encoded) - 1);
       TEST_MSG("Actual  : %zu", len);
     }
-    if (!TEST_CHECK(mutt_str_equal(buffer, encoded)))
-    {
-      TEST_MSG("Expected: %zu", encoded);
-      TEST_MSG("Actual  : %zu", buffer);
-    }
+    TEST_CHECK_STR_EQ(buffer, encoded);
   }
 
   {

--- a/test/buffer/buf_add_printf.c
+++ b/test/buffer/buf_add_printf.c
@@ -25,6 +25,7 @@
 #include "acutest.h"
 #include <string.h>
 #include "mutt/lib.h"
+#include "test_common.h"
 
 void test_buf_add_printf(void)
 {
@@ -54,7 +55,7 @@ void test_buf_add_printf(void)
     const char *str = "apple";
     struct Buffer buf = buf_make(0);
     TEST_CHECK(buf_add_printf(&buf, str) == 5);
-    TEST_CHECK(mutt_str_equal(buf_string(&buf), str));
+    TEST_CHECK_STR_EQ(buf_string(&buf), str);
     buf_dealloc(&buf);
   }
 
@@ -63,7 +64,7 @@ void test_buf_add_printf(void)
     const char *str = "apple banana cherry damson elderberry fig guava hawthorn ilama jackfruit kumquat lemon mango nectarine olive papaya quince raspberry strawberry tangerine ugli vanilla wolfberry xigua yew ziziphus";
     struct Buffer buf = buf_make(0);
     TEST_CHECK(buf_add_printf(&buf, str) == 195);
-    TEST_CHECK(mutt_str_equal(buf_string(&buf), str));
+    TEST_CHECK_STR_EQ(buf_string(&buf), str);
     buf_dealloc(&buf);
   }
 
@@ -73,7 +74,7 @@ void test_buf_add_printf(void)
     const char *result = "app 1234567 3.1416";
     struct Buffer buf = buf_make(0);
     TEST_CHECK(buf_add_printf(&buf, "%.3s %ld %3.4f", str, 1234567, 3.141592654) == 18);
-    TEST_CHECK(mutt_str_equal(buf_string(&buf), result));
+    TEST_CHECK_STR_EQ(buf_string(&buf), result);
     buf_dealloc(&buf);
   }
 
@@ -85,7 +86,7 @@ void test_buf_add_printf(void)
     struct Buffer buf = buf_make(0);
     buf_addstr(&buf, str);
     TEST_CHECK(buf_add_printf(&buf, "") == 0);
-    TEST_CHECK(mutt_str_equal(buf_string(&buf), str));
+    TEST_CHECK_STR_EQ(buf_string(&buf), str);
     buf_dealloc(&buf);
   }
 
@@ -96,7 +97,7 @@ void test_buf_add_printf(void)
     struct Buffer buf = buf_make(0);
     buf_addstr(&buf, "test");
     TEST_CHECK(buf_add_printf(&buf, str) == 5);
-    TEST_CHECK(mutt_str_equal(buf_string(&buf), result));
+    TEST_CHECK_STR_EQ(buf_string(&buf), result);
     buf_dealloc(&buf);
   }
 
@@ -107,7 +108,7 @@ void test_buf_add_printf(void)
     struct Buffer buf = buf_make(0);
     buf_addstr(&buf, "test");
     TEST_CHECK(buf_add_printf(&buf, str) == 195);
-    TEST_CHECK(mutt_str_equal(buf_string(&buf), result));
+    TEST_CHECK_STR_EQ(buf_string(&buf), result);
     buf_dealloc(&buf);
   }
 
@@ -118,7 +119,7 @@ void test_buf_add_printf(void)
     struct Buffer buf = buf_make(0);
     buf_addstr(&buf, "test");
     TEST_CHECK(buf_add_printf(&buf, "%.3s %ld %3.4f", str, 1234567, 3.141592654) == 18);
-    TEST_CHECK(mutt_str_equal(buf_string(&buf), result));
+    TEST_CHECK_STR_EQ(buf_string(&buf), result);
     buf_dealloc(&buf);
   }
 }

--- a/test/buffer/buf_addch.c
+++ b/test/buffer/buf_addch.c
@@ -25,6 +25,7 @@
 #include "acutest.h"
 #include <string.h>
 #include "mutt/lib.h"
+#include "test_common.h"
 
 void test_buf_addch(void)
 {
@@ -37,7 +38,7 @@ void test_buf_addch(void)
   {
     struct Buffer buf = buf_make(0);
     TEST_CHECK(buf_addch(&buf, 'a') == 1);
-    TEST_CHECK(mutt_str_equal(buf_string(&buf), "a"));
+    TEST_CHECK_STR_EQ(buf_string(&buf), "a");
     buf_dealloc(&buf);
   }
 
@@ -45,7 +46,7 @@ void test_buf_addch(void)
     struct Buffer buf = buf_make(0);
     buf_addstr(&buf, "test");
     TEST_CHECK(buf_addch(&buf, 'a') == 1);
-    TEST_CHECK(mutt_str_equal(buf_string(&buf), "testa"));
+    TEST_CHECK_STR_EQ(buf_string(&buf), "testa");
     buf_dealloc(&buf);
   }
 }

--- a/test/buffer/buf_addstr.c
+++ b/test/buffer/buf_addstr.c
@@ -25,6 +25,7 @@
 #include "acutest.h"
 #include <string.h>
 #include "mutt/lib.h"
+#include "test_common.h"
 
 void test_buf_addstr(void)
 {
@@ -42,7 +43,7 @@ void test_buf_addstr(void)
   {
     struct Buffer buf = buf_make(0);
     TEST_CHECK(buf_addstr(&buf, "apple") == 5);
-    TEST_CHECK(mutt_str_equal(buf_string(&buf), "apple"));
+    TEST_CHECK_STR_EQ(buf_string(&buf), "apple");
     buf_dealloc(&buf);
   }
 
@@ -50,7 +51,7 @@ void test_buf_addstr(void)
     struct Buffer buf = buf_make(0);
     buf_addstr(&buf, "test");
     TEST_CHECK(buf_addstr(&buf, "apple") == 5);
-    TEST_CHECK(mutt_str_equal(buf_string(&buf), "testapple"));
+    TEST_CHECK_STR_EQ(buf_string(&buf), "testapple");
     buf_dealloc(&buf);
   }
 }

--- a/test/buffer/buf_concat_path.c
+++ b/test/buffer/buf_concat_path.c
@@ -25,6 +25,7 @@
 #include "acutest.h"
 #include <string.h>
 #include "mutt/lib.h"
+#include "test_common.h"
 
 void test_buf_concat_path(void)
 {
@@ -64,7 +65,7 @@ void test_buf_concat_path(void)
         buf_concat_path(&buf, concat_test[i][0], concat_test[i][1]);
         if (concat_test[i][2])
         {
-          TEST_CHECK(mutt_str_equal(buf_string(&buf), concat_test[i][2]));
+          TEST_CHECK_STR_EQ(buf_string(&buf), concat_test[i][2]);
         }
         else
         {
@@ -83,11 +84,11 @@ void test_buf_concat_path(void)
         buf_concat_path(&buf, concat_test[i][0], concat_test[i][1]);
         if (concat_test[i][2])
         {
-          TEST_CHECK(mutt_str_equal(buf_string(&buf), concat_test[i][2]));
+          TEST_CHECK_STR_EQ(buf_string(&buf), concat_test[i][2]);
         }
         else
         {
-          TEST_CHECK(mutt_str_equal(buf_string(&buf), str));
+          TEST_CHECK_STR_EQ(buf_string(&buf), str);
         }
         buf_dealloc(&buf);
       }

--- a/test/buffer/buf_concatn_path.c
+++ b/test/buffer/buf_concatn_path.c
@@ -25,6 +25,7 @@
 #include "acutest.h"
 #include <stddef.h>
 #include "mutt/lib.h"
+#include "test_common.h"
 
 void test_buf_concatn_path(void)
 {
@@ -44,7 +45,7 @@ void test_buf_concatn_path(void)
     size_t len = buf_concatn_path(&buf, dir, 9, file, 4);
 
     TEST_CHECK(len == 14);
-    TEST_CHECK(mutt_str_equal(buf_string(&buf), result));
+    TEST_CHECK_STR_EQ(buf_string(&buf), result);
 
     buf_dealloc(&buf);
   }

--- a/test/buffer/buf_copy.c
+++ b/test/buffer/buf_copy.c
@@ -26,6 +26,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include "mutt/lib.h"
+#include "test_common.h"
 
 void test_buf_copy(void)
 {
@@ -59,7 +60,7 @@ void test_buf_copy(void)
     size_t len = buf_copy(&buf2, &buf1);
 
     TEST_CHECK(len == 10);
-    TEST_CHECK(mutt_str_equal(buf_string(&buf1), buf_string(&buf2)));
+    TEST_CHECK_STR_EQ(buf_string(&buf1), buf_string(&buf2));
 
     buf_dealloc(&buf1);
     buf_dealloc(&buf2);

--- a/test/buffer/buf_printf.c
+++ b/test/buffer/buf_printf.c
@@ -25,6 +25,7 @@
 #include "acutest.h"
 #include <string.h>
 #include "mutt/lib.h"
+#include "test_common.h"
 
 void test_buf_printf(void)
 {
@@ -54,7 +55,7 @@ void test_buf_printf(void)
     const char *str = "apple";
     struct Buffer buf = buf_make(0);
     TEST_CHECK(buf_printf(&buf, str) == 5);
-    TEST_CHECK(mutt_str_equal(buf_string(&buf), str));
+    TEST_CHECK_STR_EQ(buf_string(&buf), str);
     buf_dealloc(&buf);
   }
 
@@ -64,7 +65,7 @@ void test_buf_printf(void)
     const char *result = "app 1234567 3.1416";
     struct Buffer buf = buf_make(0);
     TEST_CHECK(buf_printf(&buf, "%.3s %ld %3.4f", str, 1234567, 3.141592654) == 18);
-    TEST_CHECK(mutt_str_equal(buf_string(&buf), result));
+    TEST_CHECK_STR_EQ(buf_string(&buf), result);
     buf_dealloc(&buf);
   }
 
@@ -76,7 +77,7 @@ void test_buf_printf(void)
     struct Buffer buf = buf_make(0);
     buf_addstr(&buf, str);
     TEST_CHECK(buf_printf(&buf, "") == 0);
-    TEST_CHECK(mutt_str_equal(buf_string(&buf), ""));
+    TEST_CHECK_STR_EQ(buf_string(&buf), "");
     buf_dealloc(&buf);
   }
 
@@ -86,7 +87,7 @@ void test_buf_printf(void)
     struct Buffer buf = buf_make(0);
     buf_addstr(&buf, "test");
     TEST_CHECK(buf_printf(&buf, str) == 5);
-    TEST_CHECK(mutt_str_equal(buf_string(&buf), str));
+    TEST_CHECK_STR_EQ(buf_string(&buf), str);
     buf_dealloc(&buf);
   }
 
@@ -96,11 +97,7 @@ void test_buf_printf(void)
     struct Buffer buf = buf_make(0);
     buf_addstr(&buf, "test");
     TEST_CHECK(buf_printf(&buf, str) == 195);
-    if (!TEST_CHECK(mutt_str_equal(buf_string(&buf), str)))
-    {
-      TEST_MSG("Expected: %s", str);
-      TEST_MSG("Actual  : %s", buf_string(&buf));
-    }
+    TEST_CHECK_STR_EQ(buf_string(&buf), str);
     buf_dealloc(&buf);
   }
 
@@ -111,7 +108,7 @@ void test_buf_printf(void)
     struct Buffer buf = buf_make(0);
     buf_addstr(&buf, "test");
     TEST_CHECK(buf_printf(&buf, "%.3s %ld %3.4f", str, 1234567, 3.141592654) == 18);
-    TEST_CHECK(mutt_str_equal(buf_string(&buf), result));
+    TEST_CHECK_STR_EQ(buf_string(&buf), result);
     buf_dealloc(&buf);
   }
 }

--- a/test/buffer/buf_strcpy.c
+++ b/test/buffer/buf_strcpy.c
@@ -25,6 +25,7 @@
 #include "acutest.h"
 #include <string.h>
 #include "mutt/lib.h"
+#include "test_common.h"
 
 void test_buf_strcpy(void)
 {
@@ -47,7 +48,7 @@ void test_buf_strcpy(void)
     TEST_CASE("Empty");
     struct Buffer buf = buf_make(0);
     buf_strcpy(&buf, "");
-    TEST_CHECK(mutt_str_equal(buf_string(&buf), ""));
+    TEST_CHECK_STR_EQ(buf_string(&buf), "");
     buf_dealloc(&buf);
   }
 
@@ -56,7 +57,7 @@ void test_buf_strcpy(void)
     const char *str = "test";
     struct Buffer buf = buf_make(0);
     buf_strcpy(&buf, str);
-    TEST_CHECK(mutt_str_equal(buf_string(&buf), str));
+    TEST_CHECK_STR_EQ(buf_string(&buf), str);
     buf_dealloc(&buf);
   }
 
@@ -67,7 +68,7 @@ void test_buf_strcpy(void)
     struct Buffer buf = buf_make(0);
     buf_addstr(&buf, "test");
     buf_strcpy(&buf, "");
-    TEST_CHECK(mutt_str_equal(buf_string(&buf), ""));
+    TEST_CHECK_STR_EQ(buf_string(&buf), "");
     buf_dealloc(&buf);
   }
 
@@ -77,7 +78,7 @@ void test_buf_strcpy(void)
     struct Buffer buf = buf_make(0);
     buf_addstr(&buf, "test");
     buf_strcpy(&buf, str);
-    TEST_CHECK(mutt_str_equal(buf_string(&buf), str));
+    TEST_CHECK_STR_EQ(buf_string(&buf), str);
     buf_dealloc(&buf);
   }
 }

--- a/test/buffer/buf_strdup.c
+++ b/test/buffer/buf_strdup.c
@@ -25,6 +25,7 @@
 #include "acutest.h"
 #include <string.h>
 #include "mutt/lib.h"
+#include "test_common.h"
 
 void test_buf_strdup(void)
 {
@@ -46,7 +47,7 @@ void test_buf_strdup(void)
     result = buf_strdup(&buf);
 
     TEST_CHECK(result != NULL);
-    TEST_CHECK(mutt_str_equal(result, src));
+    TEST_CHECK_STR_EQ(result, src);
 
     FREE(&result);
 

--- a/test/buffer/buf_substrcpy.c
+++ b/test/buffer/buf_substrcpy.c
@@ -25,6 +25,7 @@
 #include "acutest.h"
 #include <stddef.h>
 #include "mutt/lib.h"
+#include "test_common.h"
 
 void test_buf_substrcpy(void)
 {
@@ -43,7 +44,7 @@ void test_buf_substrcpy(void)
     size_t len = buf_substrcpy(&buf, src + 9, src + 18);
 
     TEST_CHECK(len == 9);
-    TEST_CHECK(mutt_str_equal(buf_string(&buf), result));
+    TEST_CHECK_STR_EQ(buf_string(&buf), result);
 
     buf_dealloc(&buf);
   }

--- a/test/config/address.c
+++ b/test/config/address.c
@@ -71,13 +71,13 @@ static bool test_initial_values(struct ConfigSubset *sub, struct Buffer *err)
   const char *apple_orig = "apple@example.com";
   const char *banana_orig = "banana@example.com";
 
-  if (!TEST_CHECK(mutt_str_equal(VarApple->mailbox, apple_orig)))
+  if (!TEST_CHECK_STR_EQ(VarApple->mailbox, apple_orig))
   {
     TEST_MSG("Error: initial values were wrong\n");
     return false;
   }
 
-  if (!TEST_CHECK(mutt_str_equal(VarBanana->mailbox, banana_orig)))
+  if (!TEST_CHECK_STR_EQ(VarBanana->mailbox, banana_orig))
   {
     TEST_MSG("Error: initial values were wrong\n");
     return false;
@@ -101,7 +101,7 @@ static bool test_initial_values(struct ConfigSubset *sub, struct Buffer *err)
     return false;
   }
 
-  if (!TEST_CHECK(mutt_str_equal(buf_string(value), apple_orig)))
+  if (!TEST_CHECK_STR_EQ(buf_string(value), apple_orig))
   {
     TEST_MSG("Apple's initial value is wrong: '%s'\n", buf_string(value));
     return false;
@@ -117,7 +117,7 @@ static bool test_initial_values(struct ConfigSubset *sub, struct Buffer *err)
     return false;
   }
 
-  if (!TEST_CHECK(mutt_str_equal(buf_string(value), banana_orig)))
+  if (!TEST_CHECK_STR_EQ(buf_string(value), banana_orig))
   {
     TEST_MSG("Banana's initial value is wrong: '%s'\n", buf_string(value));
     return false;
@@ -181,7 +181,7 @@ static bool test_string_set(struct ConfigSubset *sub, struct Buffer *err)
 
     VarDamson = cs_subset_address(sub, "Damson");
     addr = VarDamson ? VarDamson->mailbox : NULL;
-    if (!TEST_CHECK(mutt_str_equal(addr, valid[i])))
+    if (!TEST_CHECK_STR_EQ(addr, valid[i]))
     {
       TEST_MSG("Value of %s wasn't changed\n", name);
       return false;
@@ -202,7 +202,7 @@ static bool test_string_set(struct ConfigSubset *sub, struct Buffer *err)
 
     const struct Address *VarElderberry = cs_subset_address(sub, "Elderberry");
     addr = VarElderberry ? VarElderberry->mailbox : NULL;
-    if (!TEST_CHECK(mutt_str_equal(addr, valid[i])))
+    if (!TEST_CHECK_STR_EQ(addr, valid[i]))
     {
       TEST_MSG("Value of %s wasn't changed\n", name);
       return false;
@@ -284,7 +284,7 @@ static bool test_native_set(struct ConfigSubset *sub, struct Buffer *err)
 
   const struct Address *VarIlama = cs_subset_address(sub, "Ilama");
   addr = VarIlama ? VarIlama->mailbox : NULL;
-  if (!TEST_CHECK(mutt_str_equal(addr, a->mailbox)))
+  if (!TEST_CHECK_STR_EQ(addr, a->mailbox))
   {
     TEST_MSG("Value of %s wasn't changed\n", name);
     goto tbns_out;
@@ -371,7 +371,7 @@ static bool test_reset(struct ConfigSubset *sub, struct Buffer *err)
 
   VarLemon = cs_subset_address(sub, "Lemon");
   addr = VarLemon ? VarLemon->mailbox : NULL;
-  if (!TEST_CHECK(mutt_str_equal(addr, "lemon@example.com")))
+  if (!TEST_CHECK_STR_EQ(addr, "lemon@example.com"))
   {
     TEST_MSG("Value of %s wasn't changed\n", name);
     return false;
@@ -404,7 +404,7 @@ static bool test_reset(struct ConfigSubset *sub, struct Buffer *err)
   }
 
   VarMango = cs_subset_address(sub, "Mango");
-  if (!TEST_CHECK(mutt_str_equal(VarMango->mailbox, "john@example.com")))
+  if (!TEST_CHECK_STR_EQ(VarMango->mailbox, "john@example.com"))
   {
     TEST_MSG("Value of %s changed\n", name);
     return false;

--- a/test/config/bool.c
+++ b/test/config/bool.c
@@ -93,7 +93,7 @@ static bool test_initial_values(struct ConfigSubset *sub, struct Buffer *err)
     return false;
   }
 
-  if (!TEST_CHECK(mutt_str_equal(buf_string(value), "no")))
+  if (!TEST_CHECK_STR_EQ(buf_string(value), "no"))
   {
     TEST_MSG("Apple's initial value is wrong: '%s'\n", buf_string(value));
     return false;
@@ -111,7 +111,7 @@ static bool test_initial_values(struct ConfigSubset *sub, struct Buffer *err)
     return false;
   }
 
-  if (!TEST_CHECK(mutt_str_equal(buf_string(value), "yes")))
+  if (!TEST_CHECK_STR_EQ(buf_string(value), "yes"))
   {
     TEST_MSG("Banana's initial value is wrong: '%s'\n", buf_string(value));
     return false;

--- a/test/config/dump.c
+++ b/test/config/dump.c
@@ -29,6 +29,7 @@
 #include "config/lib.h"
 #include "core/lib.h"
 #include "common.h" // IWYU pragma: keep
+#include "test_common.h"
 
 // clang-format off
 static struct Mapping MboxTypeMap[] = {
@@ -114,7 +115,7 @@ bool test_pretty_var(void)
       return false;
     }
 
-    if (!TEST_CHECK(mutt_str_equal("\"apple\"", buf_string(&buf))))
+    if (!TEST_CHECK_STR_EQ("\"apple\"", buf_string(&buf)))
     {
       buf_dealloc(&buf);
       return false;
@@ -151,7 +152,7 @@ bool test_escape_string(void)
       return false;
     }
 
-    if (!TEST_CHECK(mutt_str_equal(buf_string(&buf), after)))
+    if (!TEST_CHECK_STR_EQ(buf_string(&buf), after))
     {
       buf_dealloc(&buf);
       return false;

--- a/test/config/enum.c
+++ b/test/config/enum.c
@@ -126,7 +126,7 @@ static bool test_initial_values(struct ConfigSubset *sub, struct Buffer *err)
     return false;
   }
 
-  if (!TEST_CHECK(mutt_str_equal(buf_string(value), "Dingo")))
+  if (!TEST_CHECK_STR_EQ(buf_string(value), "Dingo"))
   {
     TEST_MSG("Apple's initial value is wrong: '%s'\n", buf_string(value));
     return false;
@@ -143,7 +143,7 @@ static bool test_initial_values(struct ConfigSubset *sub, struct Buffer *err)
     return false;
   }
 
-  if (!TEST_CHECK(mutt_str_equal(buf_string(value), "Badger")))
+  if (!TEST_CHECK_STR_EQ(buf_string(value), "Badger"))
   {
     TEST_MSG("Banana's initial value is wrong: '%s'\n", buf_string(value));
     return false;

--- a/test/config/helpers.c
+++ b/test/config/helpers.c
@@ -99,14 +99,14 @@ void test_config_helpers(void)
   TEST_CHECK(cs_subset_bool(sub, "Apple") == false);
   TEST_CHECK(cs_subset_enum(sub, "Hawthorn") == 2);
   TEST_CHECK(cs_subset_long(sub, "Guava") == 0);
-  TEST_CHECK(mutt_str_equal(cs_subset_mbtable(sub, "Ilama")->orig_str, "abcdef"));
+  TEST_CHECK_STR_EQ(cs_subset_mbtable(sub, "Ilama")->orig_str, "abcdef");
   TEST_CHECK(cs_subset_number(sub, "Cherry") == 0);
-  TEST_CHECK(mutt_str_equal(cs_subset_path(sub, "Jackfruit"), "/etc/passwd"));
+  TEST_CHECK_STR_EQ(cs_subset_path(sub, "Jackfruit"), "/etc/passwd");
   TEST_CHECK(cs_subset_quad(sub, "Kumquat") == 0);
   TEST_CHECK(cs_subset_regex(sub, "Lemon") == 0);
   TEST_CHECK(cs_subset_slist(sub, "Olive") != NULL);
   TEST_CHECK(cs_subset_sort(sub, "Mango") == 1);
-  TEST_CHECK(mutt_str_equal(cs_subset_string(sub, "Nectarine"), "nectarine"));
+  TEST_CHECK_STR_EQ(cs_subset_string(sub, "Nectarine"), "nectarine");
 
   test_neomutt_destroy();
 }

--- a/test/config/long.c
+++ b/test/config/long.c
@@ -95,7 +95,7 @@ static bool test_initial_values(struct ConfigSubset *sub, struct Buffer *err)
     return false;
   }
 
-  if (!TEST_CHECK(mutt_str_equal(buf_string(value), "-42")))
+  if (!TEST_CHECK_STR_EQ(buf_string(value), "-42"))
   {
     TEST_MSG("Apple's initial value is wrong: '%s'\n", buf_string(value));
     return false;
@@ -112,7 +112,7 @@ static bool test_initial_values(struct ConfigSubset *sub, struct Buffer *err)
     return false;
   }
 
-  if (!TEST_CHECK(mutt_str_equal(buf_string(value), "99")))
+  if (!TEST_CHECK_STR_EQ(buf_string(value), "99"))
   {
     TEST_MSG("Banana's initial value is wrong: '%s'\n", buf_string(value));
     return false;

--- a/test/config/mbtable.c
+++ b/test/config/mbtable.c
@@ -66,13 +66,13 @@ static bool test_initial_values(struct ConfigSubset *sub, struct Buffer *err)
   TEST_MSG("Apple = %s\n", VarApple->orig_str);
   TEST_MSG("Banana = %s\n", VarBanana->orig_str);
 
-  if (!TEST_CHECK(mutt_str_equal(VarApple->orig_str, "apple")))
+  if (!TEST_CHECK_STR_EQ(VarApple->orig_str, "apple"))
   {
     TEST_MSG("Error: initial values were wrong\n");
     return false;
   }
 
-  if (!TEST_CHECK(mutt_str_equal(VarBanana->orig_str, "banana")))
+  if (!TEST_CHECK_STR_EQ(VarBanana->orig_str, "banana"))
   {
     TEST_MSG("Error: initial values were wrong\n");
     return false;
@@ -96,7 +96,7 @@ static bool test_initial_values(struct ConfigSubset *sub, struct Buffer *err)
     return false;
   }
 
-  if (!TEST_CHECK(mutt_str_equal(buf_string(value), "apple")))
+  if (!TEST_CHECK_STR_EQ(buf_string(value), "apple"))
   {
     TEST_MSG("Apple's initial value is wrong: '%s'\n", buf_string(value));
     return false;
@@ -113,7 +113,7 @@ static bool test_initial_values(struct ConfigSubset *sub, struct Buffer *err)
     return false;
   }
 
-  if (!TEST_CHECK(mutt_str_equal(buf_string(value), "banana")))
+  if (!TEST_CHECK_STR_EQ(buf_string(value), "banana"))
   {
     TEST_MSG("Banana's initial value is wrong: %s\n", buf_string(value));
     return false;
@@ -183,7 +183,7 @@ static bool test_string_set(struct ConfigSubset *sub, struct Buffer *err)
 
     struct MbTable *VarDamson = cs_subset_mbtable(sub, "Damson");
     mb = VarDamson ? VarDamson->orig_str : NULL;
-    if (!TEST_CHECK(mutt_str_equal(mb, valid[i])))
+    if (!TEST_CHECK_STR_EQ(mb, valid[i]))
     {
       TEST_MSG("Value of %s wasn't changed\n", name);
       return false;
@@ -210,7 +210,7 @@ static bool test_string_set(struct ConfigSubset *sub, struct Buffer *err)
 
     struct MbTable *VarElderberry = cs_subset_mbtable(sub, "Elderberry");
     const char *orig_str = VarElderberry ? VarElderberry->orig_str : NULL;
-    if (!TEST_CHECK(mutt_str_equal(orig_str, valid[i])))
+    if (!TEST_CHECK_STR_EQ(orig_str, valid[i]))
     {
       TEST_MSG("Value of %s wasn't changed\n", name);
       return false;
@@ -300,7 +300,7 @@ static bool test_native_set(struct ConfigSubset *sub, struct Buffer *err)
 
   struct MbTable *VarIlama = cs_subset_mbtable(sub, "Ilama");
   mb = VarIlama ? VarIlama->orig_str : NULL;
-  if (!TEST_CHECK(mutt_str_equal(mb, t->orig_str)))
+  if (!TEST_CHECK_STR_EQ(mb, t->orig_str))
   {
     TEST_MSG("Value of %s wasn't changed\n", name);
     goto tns_out;
@@ -388,7 +388,7 @@ static bool test_reset(struct ConfigSubset *sub, struct Buffer *err)
 
   VarLemon = cs_subset_mbtable(sub, "Lemon");
   mb = VarLemon ? VarLemon->orig_str : NULL;
-  if (!TEST_CHECK(mutt_str_equal(mb, "lemon")))
+  if (!TEST_CHECK_STR_EQ(mb, "lemon"))
   {
     TEST_MSG("Value of %s wasn't changed\n", name);
     return false;
@@ -421,7 +421,7 @@ static bool test_reset(struct ConfigSubset *sub, struct Buffer *err)
   }
 
   VarMango = cs_subset_mbtable(sub, "Mango");
-  if (!TEST_CHECK(mutt_str_equal(VarMango->orig_str, "hello")))
+  if (!TEST_CHECK_STR_EQ(VarMango->orig_str, "hello"))
   {
     TEST_MSG("Value of %s changed\n", name);
     return false;

--- a/test/config/number.c
+++ b/test/config/number.c
@@ -95,7 +95,7 @@ static bool test_initial_values(struct ConfigSubset *sub, struct Buffer *err)
     return false;
   }
 
-  if (!TEST_CHECK(mutt_str_equal(buf_string(value), "-42")))
+  if (!TEST_CHECK_STR_EQ(buf_string(value), "-42"))
   {
     TEST_MSG("Apple's initial value is wrong: '%s'\n", buf_string(value));
     return false;
@@ -112,7 +112,7 @@ static bool test_initial_values(struct ConfigSubset *sub, struct Buffer *err)
     return false;
   }
 
-  if (!TEST_CHECK(mutt_str_equal(buf_string(value), "99")))
+  if (!TEST_CHECK_STR_EQ(buf_string(value), "99"))
   {
     TEST_MSG("Banana's initial value is wrong: '%s'\n", buf_string(value));
     return false;

--- a/test/config/path.c
+++ b/test/config/path.c
@@ -68,13 +68,13 @@ static bool test_initial_values(struct ConfigSubset *sub, struct Buffer *err)
   TEST_MSG("Apple = %s\n", VarApple);
   TEST_MSG("Banana = %s\n", VarBanana);
 
-  if (!TEST_CHECK(mutt_str_equal(VarApple, "apple")))
+  if (!TEST_CHECK_STR_EQ(VarApple, "apple"))
   {
     TEST_MSG("Error: initial values were wrong\n");
     return false;
   }
 
-  if (!TEST_CHECK(mutt_str_equal(VarBanana, "banana")))
+  if (!TEST_CHECK_STR_EQ(VarBanana, "banana"))
   {
     TEST_MSG("Error: initial values were wrong\n");
     return false;
@@ -99,7 +99,7 @@ static bool test_initial_values(struct ConfigSubset *sub, struct Buffer *err)
   }
 
   VarApple = cs_subset_path(sub, "Apple");
-  if (!TEST_CHECK(mutt_str_equal(buf_string(value), "apple")))
+  if (!TEST_CHECK_STR_EQ(buf_string(value), "apple"))
   {
     TEST_MSG("Apple's initial value is wrong: '%s'\n", buf_string(value));
     return false;
@@ -116,7 +116,7 @@ static bool test_initial_values(struct ConfigSubset *sub, struct Buffer *err)
   }
 
   VarBanana = cs_subset_path(sub, "Banana");
-  if (!TEST_CHECK(mutt_str_equal(buf_string(value), "banana")))
+  if (!TEST_CHECK_STR_EQ(buf_string(value), "banana"))
   {
     TEST_MSG("Banana's initial value is wrong: '%s'\n", buf_string(value));
     return false;
@@ -191,7 +191,7 @@ static bool test_string_set(struct ConfigSubset *sub, struct Buffer *err)
     }
 
     const char *VarDamson = cs_subset_path(sub, "Damson");
-    if (!TEST_CHECK(mutt_str_equal(VarDamson, valid[i])))
+    if (!TEST_CHECK_STR_EQ(VarDamson, valid[i]))
     {
       TEST_MSG("Value of %s wasn't changed\n", name);
       return false;
@@ -232,7 +232,7 @@ static bool test_string_set(struct ConfigSubset *sub, struct Buffer *err)
     }
 
     const char *VarElderberry = cs_subset_path(sub, "Elderberry");
-    if (!TEST_CHECK(mutt_str_equal(VarElderberry, valid[i])))
+    if (!TEST_CHECK_STR_EQ(VarElderberry, valid[i]))
     {
       TEST_MSG("Value of %s wasn't changed\n", name);
       return false;
@@ -316,7 +316,7 @@ static bool test_native_set(struct ConfigSubset *sub, struct Buffer *err)
     }
 
     const char *VarJackfruit = cs_subset_path(sub, "Jackfruit");
-    if (!TEST_CHECK(mutt_str_equal(VarJackfruit, valid[i])))
+    if (!TEST_CHECK_STR_EQ(VarJackfruit, valid[i]))
     {
       TEST_MSG("Value of %s wasn't changed\n", name);
       return false;
@@ -357,7 +357,7 @@ static bool test_native_set(struct ConfigSubset *sub, struct Buffer *err)
     }
 
     const char *VarKumquat = cs_subset_path(sub, "Kumquat");
-    if (!TEST_CHECK(mutt_str_equal(VarKumquat, valid[i])))
+    if (!TEST_CHECK_STR_EQ(VarKumquat, valid[i]))
     {
       TEST_MSG("Value of %s wasn't changed\n", name);
       return false;
@@ -382,7 +382,7 @@ static bool test_native_get(struct ConfigSubset *sub, struct Buffer *err)
   const char *VarMango = cs_subset_path(sub, "Mango");
   buf_reset(err);
   intptr_t value = cs_str_native_get(cs, name, err);
-  if (!TEST_CHECK(mutt_str_equal(VarMango, (char *) value)))
+  if (!TEST_CHECK_STR_EQ(VarMango, (char *) value))
   {
     TEST_MSG("Get failed: %s\n", buf_string(err));
     return false;
@@ -417,7 +417,7 @@ static bool test_reset(struct ConfigSubset *sub, struct Buffer *err)
   }
 
   VarNectarine = cs_subset_path(sub, "Nectarine");
-  if (!TEST_CHECK(mutt_str_equal(VarNectarine, "nectarine")))
+  if (!TEST_CHECK_STR_EQ(VarNectarine, "nectarine"))
   {
     TEST_MSG("Value of %s wasn't changed\n", name);
     return false;
@@ -457,7 +457,7 @@ static bool test_reset(struct ConfigSubset *sub, struct Buffer *err)
   }
 
   VarOlive = cs_subset_path(sub, "Olive");
-  if (!TEST_CHECK(mutt_str_equal(VarOlive, "hello")))
+  if (!TEST_CHECK_STR_EQ(VarOlive, "hello"))
   {
     TEST_MSG("Value of %s changed\n", name);
     return false;

--- a/test/config/quad.c
+++ b/test/config/quad.c
@@ -93,7 +93,7 @@ static bool test_initial_values(struct ConfigSubset *sub, struct Buffer *err)
     return false;
   }
 
-  if (!TEST_CHECK(mutt_str_equal(buf_string(value), "no")))
+  if (!TEST_CHECK_STR_EQ(buf_string(value), "no"))
   {
     TEST_MSG("Apple's initial value is wrong: '%s'\n", buf_string(value));
     return false;
@@ -111,7 +111,7 @@ static bool test_initial_values(struct ConfigSubset *sub, struct Buffer *err)
     return false;
   }
 
-  if (!TEST_CHECK(mutt_str_equal(buf_string(value), "ask-yes")))
+  if (!TEST_CHECK_STR_EQ(buf_string(value), "ask-yes"))
   {
     TEST_MSG("Banana's initial value is wrong: '%s'\n", buf_string(value));
     return false;

--- a/test/config/regex.c
+++ b/test/config/regex.c
@@ -68,13 +68,13 @@ static bool test_initial_values(struct ConfigSubset *sub, struct Buffer *err)
   TEST_MSG("Apple = %s\n", VarApple->pattern);
   TEST_MSG("Banana = %s\n", VarBanana->pattern);
 
-  if (!TEST_CHECK(mutt_str_equal(VarApple->pattern, "apple.*")))
+  if (!TEST_CHECK_STR_EQ(VarApple->pattern, "apple.*"))
   {
     TEST_MSG("Error: initial values were wrong\n");
     return false;
   }
 
-  if (!TEST_CHECK(mutt_str_equal(VarBanana->pattern, "banana.*")))
+  if (!TEST_CHECK_STR_EQ(VarBanana->pattern, "banana.*"))
   {
     TEST_MSG("Error: initial values were wrong\n");
     return false;
@@ -98,7 +98,7 @@ static bool test_initial_values(struct ConfigSubset *sub, struct Buffer *err)
     return false;
   }
 
-  if (!TEST_CHECK(mutt_str_equal(buf_string(value), "apple.*")))
+  if (!TEST_CHECK_STR_EQ(buf_string(value), "apple.*"))
   {
     TEST_MSG("Apple's initial value is wrong: '%s'\n", buf_string(value));
     return false;
@@ -115,7 +115,7 @@ static bool test_initial_values(struct ConfigSubset *sub, struct Buffer *err)
     return false;
   }
 
-  if (!TEST_CHECK(mutt_str_equal(buf_string(value), "banana.*")))
+  if (!TEST_CHECK_STR_EQ(buf_string(value), "banana.*"))
   {
     TEST_MSG("Banana's initial value is wrong: %s\n", buf_string(value));
     return false;
@@ -186,7 +186,7 @@ static bool test_string_set(struct ConfigSubset *sub, struct Buffer *err)
 
     const struct Regex *VarDamson = cs_subset_regex(sub, "Damson");
     regex = VarDamson ? VarDamson->pattern : NULL;
-    if (!TEST_CHECK(mutt_str_equal(regex, valid[i])))
+    if (!TEST_CHECK_STR_EQ(regex, valid[i]))
     {
       TEST_MSG("Value of %s wasn't changed\n", name);
       return false;
@@ -213,7 +213,7 @@ static bool test_string_set(struct ConfigSubset *sub, struct Buffer *err)
 
     const struct Regex *VarElderberry = cs_subset_regex(sub, "Elderberry");
     regex = VarElderberry ? VarElderberry->pattern : NULL;
-    if (!TEST_CHECK(mutt_str_equal(regex, valid[i])))
+    if (!TEST_CHECK_STR_EQ(regex, valid[i]))
     {
       TEST_MSG("Value of %s wasn't changed\n", name);
       return false;
@@ -314,7 +314,7 @@ static bool test_native_set(struct ConfigSubset *sub, struct Buffer *err)
 
   const struct Regex *VarIlama = cs_subset_regex(sub, "Ilama");
   regex = VarIlama ? VarIlama->pattern : NULL;
-  if (!TEST_CHECK(mutt_str_equal(regex, r->pattern)))
+  if (!TEST_CHECK_STR_EQ(regex, r->pattern))
   {
     TEST_MSG("Value of %s wasn't changed\n", name);
     goto tns_out;
@@ -436,7 +436,7 @@ static bool test_reset(struct ConfigSubset *sub, struct Buffer *err)
 
   VarMango = cs_subset_regex(sub, "Mango");
   regex = VarMango ? VarMango->pattern : NULL;
-  if (!TEST_CHECK(mutt_str_equal(regex, "mango.*")))
+  if (!TEST_CHECK_STR_EQ(regex, "mango.*"))
   {
     TEST_MSG("Value of %s wasn't changed\n", name);
     return false;
@@ -480,7 +480,7 @@ static bool test_reset(struct ConfigSubset *sub, struct Buffer *err)
   }
 
   VarOlive = cs_subset_regex(sub, "Olive");
-  if (!TEST_CHECK(mutt_str_equal(VarOlive->pattern, "hel*o")))
+  if (!TEST_CHECK_STR_EQ(VarOlive->pattern, "hel*o"))
   {
     TEST_MSG("Value of %s changed\n", name);
     return false;

--- a/test/config/slist.c
+++ b/test/config/slist.c
@@ -596,7 +596,7 @@ static bool test_native_set(struct ConfigSubset *sub, struct Buffer *err)
     return false;
   }
 
-  if (!TEST_CHECK(mutt_str_equal(buf_string(err), init)))
+  if (!TEST_CHECK_STR_EQ(buf_string(err), init))
     return false;
 
   buf_reset(err);
@@ -682,12 +682,8 @@ static bool test_plus_equals(struct ConfigSubset *sub, struct Buffer *err)
       return false;
     }
 
-    if (!TEST_CHECK(mutt_str_equal(PlusTests[i][2], buf_string(err))))
-    {
-      TEST_MSG("Expected: %s\n", PlusTests[i][2]);
-      TEST_MSG("Actual  : %s\n", buf_string(err));
+    if (!TEST_CHECK_STR_EQ(PlusTests[i][2], buf_string(err)))
       return false;
-    }
   }
 
   // Test a failing validator
@@ -761,12 +757,8 @@ static bool test_minus_equals(struct ConfigSubset *sub, struct Buffer *err)
       return false;
     }
 
-    if (!TEST_CHECK(mutt_str_equal(MinusTests[i][2], buf_string(err))))
-    {
-      TEST_MSG("Expected: %s\n", MinusTests[i][2]);
-      TEST_MSG("Actual  : %s\n", buf_string(err));
+    if (!TEST_CHECK_STR_EQ(MinusTests[i][2], buf_string(err)))
       return false;
-    }
   }
 
   // Test a failing validator
@@ -814,7 +806,7 @@ static bool test_reset(struct ConfigSubset *sub, struct Buffer *err)
 
   VarLemon = cs_subset_slist(sub, "Lemon");
   item = STAILQ_FIRST(&VarLemon->head)->data;
-  if (!TEST_CHECK(mutt_str_equal(item, "lemon")))
+  if (!TEST_CHECK_STR_EQ(item, "lemon"))
   {
     TEST_MSG("Value of %s wasn't changed\n", name);
     return false;
@@ -850,7 +842,7 @@ static bool test_reset(struct ConfigSubset *sub, struct Buffer *err)
 
   VarMango = cs_subset_slist(sub, "Mango");
   item = STAILQ_FIRST(&VarMango->head)->data;
-  if (!TEST_CHECK(mutt_str_equal(item, "banana")))
+  if (!TEST_CHECK_STR_EQ(item, "banana"))
   {
     TEST_MSG("Value of %s changed\n", name);
     return false;

--- a/test/config/sort.c
+++ b/test/config/sort.c
@@ -126,7 +126,7 @@ static bool test_initial_values(struct ConfigSubset *sub, struct Buffer *err)
     return false;
   }
 
-  if (!TEST_CHECK(mutt_str_equal(buf_string(value), "date")))
+  if (!TEST_CHECK_STR_EQ(buf_string(value), "date"))
   {
     TEST_MSG("Apple's initial value is wrong: '%s'\n", buf_string(value));
     return false;
@@ -143,7 +143,7 @@ static bool test_initial_values(struct ConfigSubset *sub, struct Buffer *err)
     return false;
   }
 
-  if (!TEST_CHECK(mutt_str_equal(buf_string(value), "size")))
+  if (!TEST_CHECK_STR_EQ(buf_string(value), "size"))
   {
     TEST_MSG("Banana's initial value is wrong: '%s'\n", buf_string(value));
     return false;

--- a/test/config/string.c
+++ b/test/config/string.c
@@ -71,13 +71,13 @@ static bool test_initial_values(struct ConfigSubset *sub, struct Buffer *err)
   TEST_MSG("Apple = %s\n", VarApple);
   TEST_MSG("Banana = %s\n", VarBanana);
 
-  if (!TEST_CHECK(mutt_str_equal(VarApple, "apple")))
+  if (!TEST_CHECK_STR_EQ(VarApple, "apple"))
   {
     TEST_MSG("Error: initial values were wrong\n");
     return false;
   }
 
-  if (!TEST_CHECK(mutt_str_equal(VarBanana, "banana")))
+  if (!TEST_CHECK_STR_EQ(VarBanana, "banana"))
   {
     TEST_MSG("Error: initial values were wrong\n");
     return false;
@@ -102,7 +102,7 @@ static bool test_initial_values(struct ConfigSubset *sub, struct Buffer *err)
   }
 
   VarApple = cs_subset_string(sub, "Apple");
-  if (!TEST_CHECK(mutt_str_equal(buf_string(value), "apple")))
+  if (!TEST_CHECK_STR_EQ(buf_string(value), "apple"))
   {
     TEST_MSG("Apple's initial value is wrong: '%s'\n", buf_string(value));
     return false;
@@ -119,7 +119,7 @@ static bool test_initial_values(struct ConfigSubset *sub, struct Buffer *err)
   }
 
   VarBanana = cs_subset_string(sub, "Banana");
-  if (!TEST_CHECK(mutt_str_equal(buf_string(value), "banana")))
+  if (!TEST_CHECK_STR_EQ(buf_string(value), "banana"))
   {
     TEST_MSG("Banana's initial value is wrong: '%s'\n", buf_string(value));
     return false;
@@ -186,7 +186,7 @@ static bool test_string_set(struct ConfigSubset *sub, struct Buffer *err)
     }
 
     const char *VarDamson = cs_subset_string(sub, "Damson");
-    if (!TEST_CHECK(mutt_str_equal(VarDamson, valid[i])))
+    if (!TEST_CHECK_STR_EQ(VarDamson, valid[i]))
     {
       TEST_MSG("Value of %s wasn't changed\n", name);
       return false;
@@ -227,7 +227,7 @@ static bool test_string_set(struct ConfigSubset *sub, struct Buffer *err)
     }
 
     const char *VarElderberry = cs_subset_string(sub, "Elderberry");
-    if (!TEST_CHECK(mutt_str_equal(VarElderberry, valid[i])))
+    if (!TEST_CHECK_STR_EQ(VarElderberry, valid[i]))
     {
       TEST_MSG("Value of %s wasn't changed\n", name);
       return false;
@@ -311,7 +311,7 @@ static bool test_native_set(struct ConfigSubset *sub, struct Buffer *err)
     }
 
     const char *VarJackfruit = cs_subset_string(sub, "Jackfruit");
-    if (!TEST_CHECK(mutt_str_equal(VarJackfruit, valid[i])))
+    if (!TEST_CHECK_STR_EQ(VarJackfruit, valid[i]))
     {
       TEST_MSG("Value of %s wasn't changed\n", name);
       return false;
@@ -352,7 +352,7 @@ static bool test_native_set(struct ConfigSubset *sub, struct Buffer *err)
     }
 
     const char *VarKumquat = cs_subset_string(sub, "Kumquat");
-    if (!TEST_CHECK(mutt_str_equal(VarKumquat, valid[i])))
+    if (!TEST_CHECK_STR_EQ(VarKumquat, valid[i]))
     {
       TEST_MSG("Value of %s wasn't changed\n", name);
       return false;
@@ -377,7 +377,7 @@ static bool test_native_get(struct ConfigSubset *sub, struct Buffer *err)
   const char *VarMango = cs_subset_string(sub, "Mango");
   buf_reset(err);
   intptr_t value = cs_str_native_get(cs, name, err);
-  if (!TEST_CHECK(mutt_str_equal(VarMango, (char *) value)))
+  if (!TEST_CHECK_STR_EQ(VarMango, (char *) value))
   {
     TEST_MSG("Get failed: %s\n", buf_string(err));
     return false;
@@ -434,12 +434,8 @@ static bool test_string_plus_equals(struct ConfigSubset *sub, struct Buffer *err
       return false;
     }
 
-    if (!TEST_CHECK(mutt_str_equal(PlusTests[i][2], buf_string(err))))
-    {
-      TEST_MSG("Expected: %s\n", PlusTests[i][2]);
-      TEST_MSG("Actual  : %s\n", buf_string(err));
+    if (!TEST_CHECK_STR_EQ(PlusTests[i][2], buf_string(err)))
       return false;
-    }
   }
 
   log_line(__func__);
@@ -470,7 +466,7 @@ static bool test_reset(struct ConfigSubset *sub, struct Buffer *err)
   }
 
   VarNectarine = cs_subset_string(sub, "Nectarine");
-  if (!TEST_CHECK(mutt_str_equal(VarNectarine, "nectarine")))
+  if (!TEST_CHECK_STR_EQ(VarNectarine, "nectarine"))
   {
     TEST_MSG("Value of %s wasn't changed\n", name);
     return false;
@@ -510,7 +506,7 @@ static bool test_reset(struct ConfigSubset *sub, struct Buffer *err)
   }
 
   VarOlive = cs_subset_string(sub, "Olive");
-  if (!TEST_CHECK(mutt_str_equal(VarOlive, "hello")))
+  if (!TEST_CHECK_STR_EQ(VarOlive, "hello"))
   {
     TEST_MSG("Value of %s changed\n", name);
     return false;

--- a/test/config/subset.c
+++ b/test/config/subset.c
@@ -31,6 +31,7 @@
 #include "config/lib.h"
 #include "core/lib.h"
 #include "common.h" // IWYU pragma: keep
+#include "test_common.h"
 
 // clang-format off
 static struct ConfigDef Vars[] = {
@@ -136,11 +137,8 @@ void test_config_subset(void)
   expected = "142";
   rc = cs_subset_he_string_get(NeoMutt->sub, he, err);
   if (!TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS) ||
-      !TEST_CHECK(mutt_str_equal(buf_string(err), expected)))
+      !TEST_CHECK_STR_EQ(buf_string(err), expected))
   {
-    TEST_MSG("cs_subset_he_string_get failed\n");
-    TEST_MSG("Expected: %s", expected);
-    TEST_MSG("Actual  : %s", buf_string(err));
     return;
   }
 
@@ -156,11 +154,8 @@ void test_config_subset(void)
   expected = "142";
   rc = cs_subset_str_string_get(NeoMutt->sub, name, err);
   if (!TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS) ||
-      !TEST_CHECK(mutt_str_equal(buf_string(err), expected)))
+      !TEST_CHECK_STR_EQ(buf_string(err), expected))
   {
-    TEST_MSG("cs_subset_str_string_get failed\n");
-    TEST_MSG("Expected: %s", expected);
-    TEST_MSG("Actual  : %s", buf_string(err));
     return;
   }
 

--- a/test/config/synonym.c
+++ b/test/config/synonym.c
@@ -70,7 +70,7 @@ static bool test_string_set(struct ConfigSubset *sub, struct Buffer *err)
   }
 
   const char *VarApple = cs_subset_string(sub, "Apple");
-  if (!TEST_CHECK(mutt_str_equal(VarApple, value)))
+  if (!TEST_CHECK_STR_EQ(VarApple, value))
   {
     TEST_MSG("Value of %s wasn't changed\n", name);
     return false;
@@ -116,7 +116,7 @@ static bool test_native_set(struct ConfigSubset *sub, struct Buffer *err)
   }
 
   const char *VarElderberry = cs_subset_string(sub, "Elderberry");
-  if (!TEST_CHECK(mutt_str_equal(VarElderberry, value)))
+  if (!TEST_CHECK_STR_EQ(VarElderberry, value))
   {
     TEST_MSG("Value of %s wasn't changed\n", name);
     return false;
@@ -139,7 +139,7 @@ static bool test_native_get(struct ConfigSubset *sub, struct Buffer *err)
   buf_reset(err);
   intptr_t value = cs_str_native_get(cs, name, err);
   const char *VarGuava = cs_subset_string(sub, "Guava");
-  if (!TEST_CHECK(mutt_str_equal(VarGuava, (const char *) value)))
+  if (!TEST_CHECK_STR_EQ(VarGuava, (const char *) value))
   {
     TEST_MSG("Get failed: %s\n", buf_string(err));
     return false;
@@ -173,7 +173,7 @@ static bool test_reset(struct ConfigSubset *sub, struct Buffer *err)
   }
 
   VarIlama = cs_subset_string(sub, "Ilama");
-  if (!TEST_CHECK(mutt_str_equal(VarIlama, "iguana")))
+  if (!TEST_CHECK_STR_EQ(VarIlama, "iguana"))
   {
     TEST_MSG("Value of %s wasn't changed\n", name);
     return false;

--- a/test/config/variable.c
+++ b/test/config/variable.c
@@ -97,7 +97,7 @@ void test_config_variable(void)
 
   buf_reset(err);
   intptr_t value = cs_he_native_get(cs, he, err);
-  if (!TEST_CHECK(mutt_str_equal((const char *) value, "bar")))
+  if (!TEST_CHECK_STR_EQ((const char *) value, "bar"))
   {
     TEST_MSG("Error: %s\n", buf_string(err));
     return;

--- a/test/convert/mutt_convert_file_from_to.c
+++ b/test/convert/mutt_convert_file_from_to.c
@@ -28,6 +28,7 @@
 #include "email/lib.h"
 #include "convert/lib.h"
 #include "convert_common.h"
+#include "test_common.h"
 
 void test_mutt_convert_file_from_to(void)
 {
@@ -46,9 +47,9 @@ void test_mutt_convert_file_from_to(void)
     char *tocode = NULL;
     mutt_convert_file_from_to(fp, fromcodes, tocodes, &fromcode, &tocode, &info);
 
-    TEST_CHECK(mutt_str_equal(fromcode, "us-ascii"));
+    TEST_CHECK_STR_EQ(fromcode, "us-ascii");
     TEST_MSG("Check failed: %s == us-ascii", fromcode);
-    TEST_CHECK(mutt_str_equal(tocode, "utf-8"));
+    TEST_CHECK_STR_EQ(tocode, "utf-8");
     TEST_MSG("Check failed: %s == utf-8", tocode);
 
     slist_free(&fromcodes);
@@ -72,9 +73,9 @@ void test_mutt_convert_file_from_to(void)
 
     mutt_convert_file_from_to(fp, fromcodes, tocodes, &fromcode, &tocode, &info);
 
-    TEST_CHECK(mutt_str_equal(fromcode, "utf-8"));
+    TEST_CHECK_STR_EQ(fromcode, "utf-8");
     TEST_MSG("Check failed: %s == us-ascii", fromcode);
-    TEST_CHECK(mutt_str_equal(tocode, "iso-8859-2"));
+    TEST_CHECK_STR_EQ(tocode, "iso-8859-2");
     TEST_MSG("Check failed: %s == utf-8", tocode);
 
     slist_free(&fromcodes);

--- a/test/date/mutt_date_make_tls.c
+++ b/test/date/mutt_date_make_tls.c
@@ -26,6 +26,7 @@
 #include <string.h>
 #include <time.h>
 #include "mutt/lib.h"
+#include "test_common.h"
 
 void test_mutt_date_make_tls(void)
 {
@@ -39,6 +40,6 @@ void test_mutt_date_make_tls(void)
     char buf[64] = { 0 };
     time_t t = 961930800;
     TEST_CHECK(mutt_date_make_tls(buf, sizeof(buf), t) > 0);
-    TEST_CHECK(mutt_str_equal(buf, "Sun, 25 Jun 2000 11:00:00 UTC"));
+    TEST_CHECK_STR_EQ(buf, "Sun, 25 Jun 2000 11:00:00 UTC");
   }
 }

--- a/test/email/email_header_add.c
+++ b/test/email/email_header_add.c
@@ -26,6 +26,7 @@
 #include <string.h>
 #include "mutt/lib.h"
 #include "email/lib.h"
+#include "test_common.h"
 
 void test_email_header_add(void)
 {
@@ -36,7 +37,7 @@ void test_email_header_add(void)
 
   {
     struct ListNode *n = header_add(&hdrlist, header);
-    TEST_CHECK(mutt_str_equal(n->data, header));    /* header stored in node */
+    TEST_CHECK_STR_EQ(n->data, header);             /* header stored in node */
     TEST_CHECK(n == header_find(&hdrlist, header)); /* node added to list */
   }
   mutt_list_free(&hdrlist);

--- a/test/email/email_header_set.c
+++ b/test/email/email_header_set.c
@@ -26,6 +26,7 @@
 #include <string.h>
 #include "mutt/lib.h"
 #include "email/lib.h"
+#include "test_common.h"
 
 void test_email_header_set(void)
 {
@@ -38,15 +39,15 @@ void test_email_header_set(void)
   {
     /* Set value for first time */
     struct ListNode *got = header_set(&hdrlist, starting_value);
-    TEST_CHECK(mutt_str_equal(got->data, starting_value)); /* value set */
-    TEST_CHECK(got == STAILQ_FIRST(&hdrlist)); /* header was added to list */
+    TEST_CHECK_STR_EQ(got->data, starting_value); /* value set */
+    TEST_CHECK(got == STAILQ_FIRST(&hdrlist));    /* header was added to list */
   }
 
   {
     /* Update value */
     struct ListNode *got = header_set(&hdrlist, updated_value);
-    TEST_CHECK(mutt_str_equal(got->data, updated_value)); /* value set*/
-    TEST_CHECK(got == STAILQ_FIRST(&hdrlist)); /* no new header added*/
+    TEST_CHECK_STR_EQ(got->data, updated_value); /* value set*/
+    TEST_CHECK(got == STAILQ_FIRST(&hdrlist));   /* no new header added*/
   }
   mutt_list_free(&hdrlist);
 }

--- a/test/email/email_header_update.c
+++ b/test/email/email_header_update.c
@@ -26,6 +26,7 @@
 #include <string.h>
 #include "mutt/lib.h"
 #include "email/lib.h"
+#include "test_common.h"
 
 void test_email_header_update(void)
 {
@@ -38,8 +39,8 @@ void test_email_header_update(void)
 
   {
     struct ListNode *got = header_update(n, new_value);
-    TEST_CHECK(got == n);                             /* returns updated node */
-    TEST_CHECK(mutt_str_equal(got->data, new_value)); /* node updated to new value */
+    TEST_CHECK(got == n);                    /* returns updated node */
+    TEST_CHECK_STR_EQ(got->data, new_value); /* node updated to new value */
   }
   FREE(&n->data);
   FREE(&n);

--- a/test/enter/editor_case_word.c
+++ b/test/enter/editor_case_word.c
@@ -28,6 +28,7 @@
 #include "email/lib.h"
 #include "core/lib.h"
 #include "enter/lib.h"
+#include "test_common.h"
 
 void test_editor_case_word(void)
 {
@@ -55,7 +56,7 @@ void test_editor_case_word(void)
 
     char buf[64];
     mutt_mb_wcstombs(buf, sizeof(buf), es->wbuf, es->lastchar);
-    TEST_CHECK(mutt_str_equal(buf, "Test string"));
+    TEST_CHECK_STR_EQ(buf, "Test string");
     enter_state_free(&es);
   }
 
@@ -71,7 +72,7 @@ void test_editor_case_word(void)
 
     char buf[64];
     mutt_mb_wcstombs(buf, sizeof(buf), es->wbuf, es->lastchar);
-    TEST_CHECK(mutt_str_equal(buf, "Test string"));
+    TEST_CHECK_STR_EQ(buf, "Test string");
     enter_state_free(&es);
   }
 
@@ -87,7 +88,7 @@ void test_editor_case_word(void)
 
     char buf[64];
     mutt_mb_wcstombs(buf, sizeof(buf), es->wbuf, es->lastchar);
-    TEST_CHECK(mutt_str_equal(buf, "TEST string"));
+    TEST_CHECK_STR_EQ(buf, "TEST string");
     enter_state_free(&es);
   }
 
@@ -104,7 +105,7 @@ void test_editor_case_word(void)
 
     char buf[64];
     mutt_mb_wcstombs(buf, sizeof(buf), es->wbuf, es->lastchar);
-    TEST_CHECK(mutt_str_equal(buf, "test stRING"));
+    TEST_CHECK_STR_EQ(buf, "test stRING");
     enter_state_free(&es);
   }
 
@@ -121,7 +122,7 @@ void test_editor_case_word(void)
 
     char buf[64];
     mutt_mb_wcstombs(buf, sizeof(buf), es->wbuf, es->lastchar);
-    TEST_CHECK(mutt_str_equal(buf, "test     STRING    "));
+    TEST_CHECK_STR_EQ(buf, "test     STRING    ");
     enter_state_free(&es);
   }
 
@@ -137,7 +138,7 @@ void test_editor_case_word(void)
 
     char buf[64];
     mutt_mb_wcstombs(buf, sizeof(buf), es->wbuf, es->lastchar);
-    TEST_CHECK(mutt_str_equal(buf, "TEST string"));
+    TEST_CHECK_STR_EQ(buf, "TEST string");
     enter_state_free(&es);
   }
 
@@ -153,7 +154,7 @@ void test_editor_case_word(void)
 
     char buf[64];
     mutt_mb_wcstombs(buf, sizeof(buf), es->wbuf, es->lastchar);
-    TEST_CHECK(mutt_str_equal(buf, "test STRING"));
+    TEST_CHECK_STR_EQ(buf, "test STRING");
     enter_state_free(&es);
   }
 }

--- a/test/file/buf_quote_filename.c
+++ b/test/file/buf_quote_filename.c
@@ -27,6 +27,7 @@
 #include <stdbool.h>
 #include "mutt/lib.h"
 #include "common.h"
+#include "test_common.h"
 
 void test_buf_quote_filename(void)
 {
@@ -53,12 +54,7 @@ void test_buf_quote_filename(void)
   {
     TEST_CASE(tests[i].first);
     buf_quote_filename(&result, tests[i].first, (i % 2));
-    if (!TEST_CHECK(mutt_str_equal(buf_string(&result), tests[i].second)))
-    {
-      TEST_MSG("Original: %s", tests[i].first);
-      TEST_MSG("Expected: %s", tests[i].second);
-      TEST_MSG("Actual:   %s", buf_string(&result));
-    }
+    TEST_CHECK_STR_EQ(buf_string(&result), tests[i].second);
   }
 
   buf_dealloc(&result);

--- a/test/file/mutt_file_iter_line.c
+++ b/test/file/mutt_file_iter_line.c
@@ -28,6 +28,7 @@
 #include <string.h>
 #include "mutt/lib.h"
 #include "common.h"
+#include "test_common.h"
 
 void test_mutt_file_iter_line(void)
 {
@@ -57,11 +58,7 @@ void test_mutt_file_iter_line(void)
         TEST_MSG("Expected: true");
         TEST_MSG("Actual: false");
       }
-      if (!TEST_CHECK(mutt_str_equal(iter.line, file_lines[i])))
-      {
-        TEST_MSG("Expected: %s", file_lines[i]);
-        TEST_MSG("Actual: %s", iter.line);
-      }
+      TEST_CHECK_STR_EQ(iter.line, file_lines[i]);
       if (!TEST_CHECK(iter.line_num == (i + 1)))
       {
         TEST_MSG("Expected: %d", i + 1);

--- a/test/file/mutt_file_map_lines.c
+++ b/test/file/mutt_file_map_lines.c
@@ -28,6 +28,7 @@
 #include <string.h>
 #include "mutt/lib.h"
 #include "common.h"
+#include "test_common.h"
 
 #define BOOLIFY(x) ((x) ? "true" : "false")
 
@@ -39,11 +40,7 @@ bool map_dummy(char *line, int line_num, void *user_data)
 static bool mapping_func(char *line, int line_num, void *user_data)
 {
   const int *p_last_line_num = (const int *) (user_data);
-  if (!TEST_CHECK(mutt_str_equal(line, file_lines[line_num - 1])))
-  {
-    TEST_MSG("Expected: %s", file_lines[line_num - 1]);
-    TEST_MSG("Actual: %s", line);
-  }
+  TEST_CHECK_STR_EQ(line, file_lines[line_num - 1]);
   return (line_num < *p_last_line_num);
 }
 

--- a/test/file/mutt_file_quote_filename.c
+++ b/test/file/mutt_file_quote_filename.c
@@ -26,6 +26,7 @@
 #include <string.h>
 #include "mutt/lib.h"
 #include "common.h"
+#include "test_common.h"
 
 void test_mutt_file_quote_filename(void)
 {
@@ -55,14 +56,7 @@ void test_mutt_file_quote_filename(void)
     TEST_CASE(tests[i].first);
     memset(buf, 0, sizeof(buf));
     rc = mutt_file_quote_filename(tests[i].first, buf, sizeof(buf));
-    if (!TEST_CHECK(rc == tests[i].retval) ||
-        !TEST_CHECK(mutt_str_equal(buf, tests[i].second)))
-    {
-      TEST_MSG("Expected: %d", tests[i].retval);
-      TEST_MSG("Actual:   %d", rc);
-      TEST_MSG("Original: %s", tests[i].first);
-      TEST_MSG("Expected: %s", tests[i].second);
-      TEST_MSG("Actual:   %s", buf);
-    }
+    TEST_CHECK(rc == tests[i].retval);
+    TEST_CHECK_STR_EQ(buf, tests[i].second);
   }
 }

--- a/test/file/mutt_file_resolve_symlink.c
+++ b/test/file/mutt_file_resolve_symlink.c
@@ -55,12 +55,7 @@ void test_mutt_file_resolve_symlink(void)
 
     TEST_CASE(first);
     mutt_file_resolve_symlink(&result);
-    if (!TEST_CHECK(mutt_str_equal(buf_string(&result), second)))
-    {
-      TEST_MSG("Original: %s", NONULL(tests[i].first));
-      TEST_MSG("Expected: %s", second);
-      TEST_MSG("Actual:   %s", buf_string(&result));
-    }
+    TEST_CHECK_STR_EQ(buf_string(&result), second);
   }
 
   buf_dealloc(&result);

--- a/test/from/is_from.c
+++ b/test/from/is_from.c
@@ -27,6 +27,7 @@
 #include <time.h>
 #include "mutt/lib.h"
 #include "email/lib.h"
+#include "test_common.h"
 
 struct IsFromTest
 {
@@ -129,11 +130,7 @@ void test_is_from(void)
     if (!valid)
       continue;
 
-    if (!TEST_CHECK(mutt_str_equal(t->path, path)))
-    {
-      TEST_MSG("Expected: %s", t->path);
-      TEST_MSG("Actual  : %s", path);
-    }
+    TEST_CHECK_STR_EQ(t->path, path);
 
     if (!TEST_CHECK(t->epoch == epoch))
     {

--- a/test/gui/reflow.c
+++ b/test/gui/reflow.c
@@ -28,6 +28,7 @@
 #include <string.h>
 #include "mutt/lib.h"
 #include "gui/lib.h"
+#include "test_common.h"
 
 typedef uint16_t MuttRedrawFlags;
 
@@ -111,7 +112,7 @@ void test_window_reflow(void)
 
     struct Buffer buf = buf_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(mutt_str_equal(buf_string(&buf), expected));
+    TEST_CHECK_STR_EQ(buf_string(&buf), expected);
     TEST_MSG("Expected %s\n", expected);
     TEST_MSG("Got      %s\n", buf_string(&buf));
 
@@ -138,7 +139,7 @@ void test_window_reflow(void)
 
     struct Buffer buf = buf_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(mutt_str_equal(buf_string(&buf), expected));
+    TEST_CHECK_STR_EQ(buf_string(&buf), expected);
     TEST_MSG("Expected %s\n", expected);
     TEST_MSG("Got      %s\n", buf_string(&buf));
 
@@ -171,7 +172,7 @@ void test_window_reflow(void)
 
     struct Buffer buf = buf_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(mutt_str_equal(buf_string(&buf), expected));
+    TEST_CHECK_STR_EQ(buf_string(&buf), expected);
     TEST_MSG("Expected %s\n", expected);
     TEST_MSG("Got      %s\n", buf_string(&buf));
 
@@ -210,7 +211,7 @@ void test_window_reflow(void)
 
     struct Buffer buf = buf_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(mutt_str_equal(buf_string(&buf), expected));
+    TEST_CHECK_STR_EQ(buf_string(&buf), expected);
     TEST_MSG("Expected %s\n", expected);
     TEST_MSG("Got      %s\n", buf_string(&buf));
 
@@ -250,7 +251,7 @@ void test_window_reflow(void)
 
     struct Buffer buf = buf_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(mutt_str_equal(buf_string(&buf), expected));
+    TEST_CHECK_STR_EQ(buf_string(&buf), expected);
     TEST_MSG("Expected %s\n", expected);
     TEST_MSG("Got      %s\n", buf_string(&buf));
 
@@ -286,7 +287,7 @@ void test_window_reflow(void)
 
     struct Buffer buf = buf_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(mutt_str_equal(buf_string(&buf), expected));
+    TEST_CHECK_STR_EQ(buf_string(&buf), expected);
     TEST_MSG("Expected %s\n", expected);
     TEST_MSG("Got      %s\n", buf_string(&buf));
 
@@ -320,7 +321,7 @@ void test_window_reflow(void)
 
     struct Buffer buf = buf_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(mutt_str_equal(buf_string(&buf), expected));
+    TEST_CHECK_STR_EQ(buf_string(&buf), expected);
     TEST_MSG("Expected %s\n", expected);
     TEST_MSG("Got      %s\n", buf_string(&buf));
 
@@ -366,7 +367,7 @@ void test_window_reflow(void)
 
     struct Buffer buf = buf_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(mutt_str_equal(buf_string(&buf), expected));
+    TEST_CHECK_STR_EQ(buf_string(&buf), expected);
     TEST_MSG("Expected %s\n", expected);
     TEST_MSG("Got      %s\n", buf_string(&buf));
 
@@ -400,7 +401,7 @@ void test_window_reflow(void)
 
     struct Buffer buf = buf_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(mutt_str_equal(buf_string(&buf), expected));
+    TEST_CHECK_STR_EQ(buf_string(&buf), expected);
     TEST_MSG("Expected %s\n", expected);
     TEST_MSG("Got      %s\n", buf_string(&buf));
 
@@ -431,7 +432,7 @@ void test_window_reflow(void)
 
     struct Buffer buf = buf_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(mutt_str_equal(buf_string(&buf), expected));
+    TEST_CHECK_STR_EQ(buf_string(&buf), expected);
     TEST_MSG("Expected %s\n", expected);
     TEST_MSG("Got      %s\n", buf_string(&buf));
 
@@ -470,7 +471,7 @@ void test_window_reflow(void)
 
     struct Buffer buf = buf_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(mutt_str_equal(buf_string(&buf), expected));
+    TEST_CHECK_STR_EQ(buf_string(&buf), expected);
     TEST_MSG("Expected %s\n", expected);
     TEST_MSG("Got      %s\n", buf_string(&buf));
 
@@ -506,7 +507,7 @@ void test_window_reflow(void)
 
     struct Buffer buf = buf_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(mutt_str_equal(buf_string(&buf), expected));
+    TEST_CHECK_STR_EQ(buf_string(&buf), expected);
     TEST_MSG("Expected %s\n", expected);
     TEST_MSG("Got      %s\n", buf_string(&buf));
 
@@ -542,7 +543,7 @@ void test_window_reflow(void)
 
     struct Buffer buf = buf_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(mutt_str_equal(buf_string(&buf), expected));
+    TEST_CHECK_STR_EQ(buf_string(&buf), expected);
     TEST_MSG("Expected %s\n", expected);
     TEST_MSG("Got      %s\n", buf_string(&buf));
 
@@ -581,7 +582,7 @@ void test_window_reflow(void)
 
     struct Buffer buf = buf_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(mutt_str_equal(buf_string(&buf), expected));
+    TEST_CHECK_STR_EQ(buf_string(&buf), expected);
     TEST_MSG("Expected %s\n", expected);
     TEST_MSG("Got      %s\n", buf_string(&buf));
 
@@ -620,7 +621,7 @@ void test_window_reflow(void)
 
     struct Buffer buf = buf_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(mutt_str_equal(buf_string(&buf), expected));
+    TEST_CHECK_STR_EQ(buf_string(&buf), expected);
     TEST_MSG("Expected %s\n", expected);
     TEST_MSG("Got      %s\n", buf_string(&buf));
 
@@ -659,7 +660,7 @@ void test_window_reflow(void)
 
     struct Buffer buf = buf_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(mutt_str_equal(buf_string(&buf), expected));
+    TEST_CHECK_STR_EQ(buf_string(&buf), expected);
     TEST_MSG("Expected %s\n", expected);
     TEST_MSG("Got      %s\n", buf_string(&buf));
 
@@ -698,7 +699,7 @@ void test_window_reflow(void)
 
     struct Buffer buf = buf_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(mutt_str_equal(buf_string(&buf), expected));
+    TEST_CHECK_STR_EQ(buf_string(&buf), expected);
     TEST_MSG("Expected %s\n", expected);
     TEST_MSG("Got      %s\n", buf_string(&buf));
 
@@ -730,7 +731,7 @@ void test_window_reflow(void)
 
     struct Buffer buf = buf_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(mutt_str_equal(buf_string(&buf), expected));
+    TEST_CHECK_STR_EQ(buf_string(&buf), expected);
     TEST_MSG("Expected %s\n", expected);
     TEST_MSG("Got      %s\n", buf_string(&buf));
 
@@ -757,7 +758,7 @@ void test_window_reflow(void)
 
     struct Buffer buf = buf_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(mutt_str_equal(buf_string(&buf), expected));
+    TEST_CHECK_STR_EQ(buf_string(&buf), expected);
     TEST_MSG("Expected %s\n", expected);
     TEST_MSG("Got      %s\n", buf_string(&buf));
 
@@ -790,7 +791,7 @@ void test_window_reflow(void)
 
     struct Buffer buf = buf_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(mutt_str_equal(buf_string(&buf), expected));
+    TEST_CHECK_STR_EQ(buf_string(&buf), expected);
     TEST_MSG("Expected %s\n", expected);
     TEST_MSG("Got      %s\n", buf_string(&buf));
 
@@ -829,7 +830,7 @@ void test_window_reflow(void)
 
     struct Buffer buf = buf_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(mutt_str_equal(buf_string(&buf), expected));
+    TEST_CHECK_STR_EQ(buf_string(&buf), expected);
     TEST_MSG("Expected %s\n", expected);
     TEST_MSG("Got      %s\n", buf_string(&buf));
 
@@ -869,7 +870,7 @@ void test_window_reflow(void)
 
     struct Buffer buf = buf_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(mutt_str_equal(buf_string(&buf), expected));
+    TEST_CHECK_STR_EQ(buf_string(&buf), expected);
     TEST_MSG("Expected %s\n", expected);
     TEST_MSG("Got      %s\n", buf_string(&buf));
 
@@ -905,7 +906,7 @@ void test_window_reflow(void)
 
     struct Buffer buf = buf_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(mutt_str_equal(buf_string(&buf), expected));
+    TEST_CHECK_STR_EQ(buf_string(&buf), expected);
     TEST_MSG("Expected %s\n", expected);
     TEST_MSG("Got      %s\n", buf_string(&buf));
 
@@ -939,7 +940,7 @@ void test_window_reflow(void)
 
     struct Buffer buf = buf_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(mutt_str_equal(buf_string(&buf), expected));
+    TEST_CHECK_STR_EQ(buf_string(&buf), expected);
     TEST_MSG("Expected %s\n", expected);
     TEST_MSG("Got      %s\n", buf_string(&buf));
 
@@ -985,7 +986,7 @@ void test_window_reflow(void)
 
     struct Buffer buf = buf_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(mutt_str_equal(buf_string(&buf), expected));
+    TEST_CHECK_STR_EQ(buf_string(&buf), expected);
     TEST_MSG("Expected %s\n", expected);
     TEST_MSG("Got      %s\n", buf_string(&buf));
 
@@ -1019,7 +1020,7 @@ void test_window_reflow(void)
 
     struct Buffer buf = buf_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(mutt_str_equal(buf_string(&buf), expected));
+    TEST_CHECK_STR_EQ(buf_string(&buf), expected);
     TEST_MSG("Expected %s\n", expected);
     TEST_MSG("Got      %s\n", buf_string(&buf));
 
@@ -1050,7 +1051,7 @@ void test_window_reflow(void)
 
     struct Buffer buf = buf_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(mutt_str_equal(buf_string(&buf), expected));
+    TEST_CHECK_STR_EQ(buf_string(&buf), expected);
     TEST_MSG("Expected %s\n", expected);
     TEST_MSG("Got      %s\n", buf_string(&buf));
 
@@ -1089,7 +1090,7 @@ void test_window_reflow(void)
 
     struct Buffer buf = buf_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(mutt_str_equal(buf_string(&buf), expected));
+    TEST_CHECK_STR_EQ(buf_string(&buf), expected);
     TEST_MSG("Expected %s\n", expected);
     TEST_MSG("Got      %s\n", buf_string(&buf));
 
@@ -1125,7 +1126,7 @@ void test_window_reflow(void)
 
     struct Buffer buf = buf_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(mutt_str_equal(buf_string(&buf), expected));
+    TEST_CHECK_STR_EQ(buf_string(&buf), expected);
     TEST_MSG("Expected %s\n", expected);
     TEST_MSG("Got      %s\n", buf_string(&buf));
 
@@ -1161,7 +1162,7 @@ void test_window_reflow(void)
 
     struct Buffer buf = buf_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(mutt_str_equal(buf_string(&buf), expected));
+    TEST_CHECK_STR_EQ(buf_string(&buf), expected);
     TEST_MSG("Expected %s\n", expected);
     TEST_MSG("Got      %s\n", buf_string(&buf));
 
@@ -1200,7 +1201,7 @@ void test_window_reflow(void)
 
     struct Buffer buf = buf_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(mutt_str_equal(buf_string(&buf), expected));
+    TEST_CHECK_STR_EQ(buf_string(&buf), expected);
     TEST_MSG("Expected %s\n", expected);
     TEST_MSG("Got      %s\n", buf_string(&buf));
 
@@ -1239,7 +1240,7 @@ void test_window_reflow(void)
 
     struct Buffer buf = buf_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(mutt_str_equal(buf_string(&buf), expected));
+    TEST_CHECK_STR_EQ(buf_string(&buf), expected);
     TEST_MSG("Expected %s\n", expected);
     TEST_MSG("Got      %s\n", buf_string(&buf));
 
@@ -1278,7 +1279,7 @@ void test_window_reflow(void)
 
     struct Buffer buf = buf_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(mutt_str_equal(buf_string(&buf), expected));
+    TEST_CHECK_STR_EQ(buf_string(&buf), expected);
     TEST_MSG("Expected %s\n", expected);
     TEST_MSG("Got      %s\n", buf_string(&buf));
 
@@ -1317,7 +1318,7 @@ void test_window_reflow(void)
 
     struct Buffer buf = buf_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(mutt_str_equal(buf_string(&buf), expected));
+    TEST_CHECK_STR_EQ(buf_string(&buf), expected);
     TEST_MSG("Expected %s\n", expected);
     TEST_MSG("Got      %s\n", buf_string(&buf));
 
@@ -1397,7 +1398,7 @@ void test_window_reflow(void)
 
     struct Buffer buf = buf_make(1024);
     win_serialise(root, &buf);
-    TEST_CHECK(mutt_str_equal(buf_string(&buf), expected));
+    TEST_CHECK_STR_EQ(buf_string(&buf), expected);
     TEST_MSG("Expected %s\n", expected);
     TEST_MSG("Got      %s\n", buf_string(&buf));
 

--- a/test/main.c
+++ b/test/main.c
@@ -21,8 +21,10 @@
  * this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+void test_init(void);
+void test_fini(void);
+
 #include "config.h"
-#include "test_common.h"
 #define TEST_INIT test_init()
 #define TEST_FINI test_fini()
 #include "acutest.h"

--- a/test/mbyte/mutt_mb_wcstombs.c
+++ b/test/mbyte/mutt_mb_wcstombs.c
@@ -26,6 +26,7 @@
 #include <string.h>
 #include <wchar.h>
 #include "mutt/lib.h"
+#include "test_common.h"
 
 void test_mutt_mb_wcstombs(void)
 {
@@ -71,7 +72,7 @@ void test_mutt_mb_wcstombs(void)
       size_t len = wcslen(test[i].src);
       mutt_mb_wcstombs(buf, sizeof(buf), test[i].src, len);
 
-      TEST_CHECK(mutt_str_equal(buf, test[i].expected));
+      TEST_CHECK_STR_EQ(buf, test[i].expected);
     }
   }
 }

--- a/test/md5/mutt_md5.c
+++ b/test/md5/mutt_md5.c
@@ -26,6 +26,7 @@
 #include <string.h>
 #include "mutt/lib.h"
 #include "common.h"
+#include "test_common.h"
 
 void test_mutt_md5(void)
 {
@@ -47,12 +48,7 @@ void test_mutt_md5(void)
       char digest[33];
       mutt_md5(md5_test_data[i].text, buf);
       mutt_md5_toascii(buf, digest);
-      if (!TEST_CHECK(mutt_str_equal(md5_test_data[i].hash, digest)))
-      {
-        TEST_MSG("Iteration: %zu", i);
-        TEST_MSG("Expected : %s", md5_test_data[i].hash);
-        TEST_MSG("Actual   : %s", digest);
-      }
+      TEST_CHECK_STR_EQ(md5_test_data[i].hash, digest);
     }
   }
 }

--- a/test/md5/mutt_md5_bytes.c
+++ b/test/md5/mutt_md5_bytes.c
@@ -26,6 +26,7 @@
 #include <string.h>
 #include "mutt/lib.h"
 #include "common.h"
+#include "test_common.h"
 
 void test_mutt_md5_bytes(void)
 {
@@ -53,12 +54,7 @@ void test_mutt_md5_bytes(void)
       mutt_md5_process_bytes(md5_test_data[i].text, strlen(md5_test_data[i].text), &ctx);
       mutt_md5_finish_ctx(&ctx, buf);
       mutt_md5_toascii(buf, digest);
-      if (!TEST_CHECK(mutt_str_equal(md5_test_data[i].hash, digest)))
-      {
-        TEST_MSG("Iteration: %zu", i);
-        TEST_MSG("Expected : %s", md5_test_data[i].hash);
-        TEST_MSG("Actual   : %s", digest);
-      }
+      TEST_CHECK_STR_EQ(md5_test_data[i].hash, digest);
     }
   }
 }

--- a/test/md5/mutt_md5_init_ctx.c
+++ b/test/md5/mutt_md5_init_ctx.c
@@ -26,6 +26,7 @@
 #include <string.h>
 #include "mutt/lib.h"
 #include "common.h"
+#include "test_common.h"
 
 void test_mutt_md5_init_ctx(void)
 {
@@ -46,12 +47,7 @@ void test_mutt_md5_init_ctx(void)
       mutt_md5_process(md5_test_data[i].text, &ctx);
       mutt_md5_finish_ctx(&ctx, buf);
       mutt_md5_toascii(buf, digest);
-      if (!TEST_CHECK(mutt_str_equal(md5_test_data[i].hash, digest)))
-      {
-        TEST_MSG("Iteration: %zu", i);
-        TEST_MSG("Expected : %s", md5_test_data[i].hash);
-        TEST_MSG("Actual   : %s", digest);
-      }
+      TEST_CHECK_STR_EQ(md5_test_data[i].hash, digest);
     }
   }
 }

--- a/test/notmuch/query_type.c
+++ b/test/notmuch/query_type.c
@@ -27,6 +27,7 @@
 #include "mutt/lib.h"
 #include "notmuch/lib.h"
 #include "notmuch/query.h" // IWYU pragma: keep
+#include "test_common.h"
 
 struct NmParseTypeTest
 {
@@ -106,10 +107,10 @@ void test_nm_string_to_query_type_mapper(void)
 void test_nm_query_type_to_string(void)
 {
   {
-    TEST_CHECK(mutt_str_equal(nm_query_type_to_string(NM_QUERY_TYPE_THREADS), "threads"));
+    TEST_CHECK_STR_EQ(nm_query_type_to_string(NM_QUERY_TYPE_THREADS), "threads");
   }
 
   {
-    TEST_CHECK(mutt_str_equal(nm_query_type_to_string(NM_QUERY_TYPE_MESGS), "messages"));
+    TEST_CHECK_STR_EQ(nm_query_type_to_string(NM_QUERY_TYPE_MESGS), "messages");
   }
 }

--- a/test/notmuch/tag.c
+++ b/test/notmuch/tag.c
@@ -26,6 +26,7 @@
 #include "mutt/lib.h"
 #include "notmuch/tag.h" // IWYU pragma: keep
 #include "notmuch/lib.h"
+#include "test_common.h"
 
 void test_nm_tag_string_to_tags(void)
 {
@@ -35,8 +36,8 @@ void test_nm_tag_string_to_tags(void)
     const char *input = "inbox,archive";
     struct TagArray output = nm_tag_str_to_tags(input);
 
-    TEST_CHECK(mutt_str_equal("inbox", *ARRAY_GET(&output.tags, 0)));
-    TEST_CHECK(mutt_str_equal("archive", *ARRAY_GET(&output.tags, 1)));
+    TEST_CHECK_STR_EQ("inbox", *ARRAY_GET(&output.tags, 0));
+    TEST_CHECK_STR_EQ("archive", *ARRAY_GET(&output.tags, 1));
 
     nm_tag_array_free(&output);
   }
@@ -45,8 +46,8 @@ void test_nm_tag_string_to_tags(void)
     const char *input = "inbox archive";
     struct TagArray output = nm_tag_str_to_tags(input);
 
-    TEST_CHECK(mutt_str_equal("inbox", *ARRAY_GET(&output.tags, 0)));
-    TEST_CHECK(mutt_str_equal("archive", *ARRAY_GET(&output.tags, 1)));
+    TEST_CHECK_STR_EQ("inbox", *ARRAY_GET(&output.tags, 0));
+    TEST_CHECK_STR_EQ("archive", *ARRAY_GET(&output.tags, 1));
 
     nm_tag_array_free(&output);
   }
@@ -55,9 +56,9 @@ void test_nm_tag_string_to_tags(void)
     const char *input = "inbox archive,sent";
     struct TagArray output = nm_tag_str_to_tags(input);
 
-    TEST_CHECK(mutt_str_equal("inbox", *ARRAY_GET(&output.tags, 0)));
-    TEST_CHECK(mutt_str_equal("archive", *ARRAY_GET(&output.tags, 1)));
-    TEST_CHECK(mutt_str_equal("sent", *ARRAY_GET(&output.tags, 2)));
+    TEST_CHECK_STR_EQ("inbox", *ARRAY_GET(&output.tags, 0));
+    TEST_CHECK_STR_EQ("archive", *ARRAY_GET(&output.tags, 1));
+    TEST_CHECK_STR_EQ("sent", *ARRAY_GET(&output.tags, 2));
 
     nm_tag_array_free(&output);
   }

--- a/test/notmuch/window_query.c
+++ b/test/notmuch/window_query.c
@@ -27,6 +27,7 @@
 #include "mutt/lib.h"
 #include "notmuch/lib.h"
 #include "notmuch/query.h" // IWYU pragma: keep
+#include "test_common.h"
 
 struct TestCase
 {
@@ -86,7 +87,6 @@ void test_nm_windowed_query_from_query(void)
                                                            t->timebase, t->or_terms);
 
     TEST_CHECK(rc == NM_WINDOW_QUERY_SUCCESS);
-    TEST_CHECK_(mutt_str_equal(buf, t->expected),
-                "expected \"%s\" got \"%s\" instead.", t->expected, buf);
+    TEST_CHECK_STR_EQ(buf, t->expected);
   }
 }

--- a/test/parse/mutt_parse_mailto.c
+++ b/test/parse/mutt_parse_mailto.c
@@ -49,11 +49,7 @@ static void check_addrlist(struct AddressList *list, const char *const exp[], si
   for (size_t i = 0; i < num; ++i)
   {
     char *tok = mutt_str_skip_whitespace(mutt_str_sep(&pp, ","));
-    if (!TEST_CHECK(mutt_str_equal(tok, exp[i])))
-    {
-      TEST_MSG("Expected: %s", exp[i]);
-      TEST_MSG("Actual  : %s", tok);
-    }
+    TEST_CHECK_STR_EQ(tok, exp[i]);
   }
   FREE(&orig);
 }
@@ -102,11 +98,7 @@ void test_mutt_parse_mailto(void)
     }
     check_addrlist(&env->to, to, mutt_array_size(to));
     check_addrlist(&env->cc, cc, mutt_array_size(cc));
-    if (!TEST_CHECK(mutt_str_equal(body, parsed_body)))
-    {
-      TEST_MSG("Expected: %s", body);
-      TEST_MSG("Actual  : %s", parsed_body);
-    }
+    TEST_CHECK_STR_EQ(body, parsed_body);
     FREE(&parsed_body);
     mutt_env_free(&env);
   }

--- a/test/parse/parse_rc_line.c
+++ b/test/parse/parse_rc_line.c
@@ -169,7 +169,7 @@ static bool test_set(struct Buffer *err)
           TEST_MSG("Failed to get %s: %s\n", boolish[v], buf_string(err));
           return false;
         }
-        if (!TEST_CHECK(mutt_str_equal(err->data, "yes")))
+        if (!TEST_CHECK_STR_EQ(err->data, "yes"))
         {
           TEST_MSG("Variable not set %s: %s\n", boolish[v], buf_string(err));
           return false;
@@ -197,7 +197,7 @@ static bool test_set(struct Buffer *err)
       TEST_MSG("Failed to get %s: %s\n", "Damson", buf_string(err));
       return false;
     }
-    if (!TEST_CHECK(mutt_str_equal(err->data, "newfoo")))
+    if (!TEST_CHECK_STR_EQ(err->data, "newfoo"))
     {
       TEST_MSG("Variable not set %s: %s\n", "Damson", buf_string(err));
       return false;
@@ -296,7 +296,7 @@ static bool test_unset(struct Buffer *err)
           TEST_MSG("Failed to get %s: %s\n", boolish[v], buf_string(err));
           return false;
         }
-        if (!TEST_CHECK(mutt_str_equal(err->data, "no")))
+        if (!TEST_CHECK_STR_EQ(err->data, "no"))
         {
           TEST_MSG("Variable not unset %s: %s\n", boolish[v], buf_string(err));
           return false;
@@ -336,7 +336,7 @@ static bool test_unset(struct Buffer *err)
       TEST_MSG("Failed to get %s: %s\n", "Damson", buf_string(err));
       return false;
     }
-    if (!TEST_CHECK(mutt_str_equal(err->data, "")))
+    if (!TEST_CHECK_STR_EQ(err->data, ""))
     {
       TEST_MSG("Variable not unset %s: %s\n", "Damson", buf_string(err));
       return false;
@@ -445,7 +445,7 @@ static bool test_reset(struct Buffer *err)
           buf_pool_release(&buf);
           return false;
         }
-        if (!TEST_CHECK(mutt_str_equal(err->data, buf->data)))
+        if (!TEST_CHECK_STR_EQ(err->data, buf->data))
         {
           TEST_MSG("Variable not reset %s: %s != %s\n", ConfigVars[v].name,
                    buf_string(err), buf_string(buf));
@@ -624,7 +624,7 @@ static bool test_toggle(struct Buffer *err)
             TEST_MSG("Failed to get %s: %s\n", boolish[v], buf_string(err));
             return false;
           }
-          if (!TEST_CHECK(mutt_str_equal(err->data, expected1[v])))
+          if (!TEST_CHECK_STR_EQ(err->data, expected1[v]))
           {
             TEST_MSG("Variable %s not toggled off: got = %s, expected = %s\n",
                      boolish[v], err->data, expected1[v], buf_string(err));
@@ -653,7 +653,7 @@ static bool test_toggle(struct Buffer *err)
             TEST_MSG("Failed to get %s: %s\n", boolish[v], buf_string(err));
             return false;
           }
-          if (!TEST_CHECK(mutt_str_equal(err->data, expected2[v])))
+          if (!TEST_CHECK_STR_EQ(err->data, expected2[v]))
           {
             TEST_MSG("Variable %s not toggled on: got = %s, expected = %s\n",
                      boolish[v], err->data, expected2[v], buf_string(err));
@@ -725,7 +725,7 @@ static bool test_query(struct Buffer *err)
 
         // Check effect
         snprintf(line, sizeof(line), "%s=\"%s\"", vars[v], expected[v]);
-        if (!TEST_CHECK(mutt_str_equal(err->data, line)))
+        if (!TEST_CHECK_STR_EQ(err->data, line))
         {
           TEST_MSG("Variable query failed for %s: got = %s, expected = %s\n",
                    vars[v], buf_string(err), line);
@@ -774,7 +774,7 @@ static bool test_query(struct Buffer *err)
 
       // Check effect
       snprintf(line, sizeof(line), "%s=\"%s\"", vars[v], expected[v]);
-      if (!TEST_CHECK(mutt_str_equal(err->data, line)))
+      if (!TEST_CHECK_STR_EQ(err->data, line))
       {
         TEST_MSG("Variable query failed for %s: got = %s, expected = %s\n",
                  vars[v], buf_string(err), line);
@@ -844,7 +844,7 @@ static bool test_increment(struct Buffer *err)
         TEST_MSG("Failed to get %s: %s\n", vars[v], buf_string(err));
         return false;
       }
-      if (!TEST_CHECK(mutt_str_equal(err->data, expected[v])))
+      if (!TEST_CHECK_STR_EQ(err->data, expected[v]))
       {
         TEST_MSG("Variable not incremented %s: got = %s, expected = %s\n",
                  vars[v], buf_string(err), expected[v]);
@@ -901,7 +901,7 @@ static bool test_decrement(struct Buffer *err)
         TEST_MSG("Failed to get %s: %s\n", vars[v], buf_string(err));
         return false;
       }
-      if (!TEST_CHECK(mutt_str_equal(err->data, expected[v])))
+      if (!TEST_CHECK_STR_EQ(err->data, expected[v]))
       {
         TEST_MSG("Variable not decremented %s: got = %s, expected = %s\n",
                  vars[v], buf_string(err), expected[v]);
@@ -993,7 +993,7 @@ static bool test_path_expanding(struct Buffer *err)
         TEST_MSG("Failed to get %s: %s\n", pathlike[v], buf_string(err));
         return false;
       }
-      if (!TEST_CHECK(mutt_str_equal(err->data, expected[v])))
+      if (!TEST_CHECK_STR_EQ(err->data, expected[v]))
       {
         TEST_MSG("Variable not incremented %s: got = %s, expected = %s\n",
                  pathlike[v], buf_string(err), expected[v]);

--- a/test/path/mutt_path_tidy.c
+++ b/test/path/mutt_path_tidy.c
@@ -26,6 +26,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include "mutt/lib.h"
+#include "test_common.h"
 
 void test_mutt_path_tidy(void)
 {
@@ -150,12 +151,7 @@ void test_mutt_path_tidy(void)
 
       mutt_str_copy(buf, tests[i][0], sizeof(buf));
       mutt_path_tidy(buf, true);
-      if (!TEST_CHECK(mutt_str_equal(buf, tests[i][1])))
-      {
-        TEST_MSG("Input:    %s", tests[i][0]);
-        TEST_MSG("Expected: %s", tests[i][1]);
-        TEST_MSG("Actual:   %s", buf);
-      }
+      TEST_CHECK_STR_EQ(buf, tests[i][1]);
     }
   }
 }

--- a/test/path/mutt_path_tidy_dotdot.c
+++ b/test/path/mutt_path_tidy_dotdot.c
@@ -25,6 +25,7 @@
 #include "acutest.h"
 #include <stddef.h>
 #include "mutt/lib.h"
+#include "test_common.h"
 
 void test_mutt_path_tidy_dotdot(void)
 {
@@ -85,12 +86,7 @@ void test_mutt_path_tidy_dotdot(void)
 
       mutt_str_copy(buf, tests[i][0], sizeof(buf));
       mutt_path_tidy_dotdot(buf);
-      if (!TEST_CHECK(mutt_str_equal(buf, tests[i][1])))
-      {
-        TEST_MSG("Input:    %s", tests[i][0]);
-        TEST_MSG("Expected: %s", tests[i][1]);
-        TEST_MSG("Actual:   %s", buf);
-      }
+      TEST_CHECK_STR_EQ(buf, tests[i][1]);
     }
   }
 }

--- a/test/path/mutt_path_tidy_slash.c
+++ b/test/path/mutt_path_tidy_slash.c
@@ -26,6 +26,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include "mutt/lib.h"
+#include "test_common.h"
 
 void test_mutt_path_tidy_slash(void)
 {
@@ -73,12 +74,7 @@ void test_mutt_path_tidy_slash(void)
 
       mutt_str_copy(buf, tests[i][0], sizeof(buf));
       mutt_path_tidy_slash(buf, true);
-      if (!TEST_CHECK(mutt_str_equal(buf, tests[i][1])))
-      {
-        TEST_MSG("Input:    %s", tests[i][0]);
-        TEST_MSG("Expected: %s", tests[i][1]);
-        TEST_MSG("Actual:   %s", buf);
-      }
+      TEST_CHECK_STR_EQ(buf, tests[i][1]);
     }
   }
 }

--- a/test/pattern/comp.c
+++ b/test/pattern/comp.c
@@ -29,6 +29,7 @@
 #include "mutt/lib.h"
 #include "pattern/lib.h"
 #include "globals.h"
+#include "test_common.h"
 
 bool ResumeEditedDraftFiles;
 
@@ -186,11 +187,7 @@ void test_mutt_pattern_comp(void)
     }
 
     char *msg = "empty pattern";
-    if (!TEST_CHECK(mutt_str_equal(err.data, msg)))
-    {
-      TEST_MSG("Expected: %s", msg);
-      TEST_MSG("Actual  : %s", err.data);
-    }
+    TEST_CHECK_STR_EQ(err.data, msg);
   }
 
   { /* invalid */
@@ -206,11 +203,7 @@ void test_mutt_pattern_comp(void)
     }
 
     char *msg = "error in pattern at: x";
-    if (!TEST_CHECK(mutt_str_equal(err.data, msg)))
-    {
-      TEST_MSG("Expected: %s", msg);
-      TEST_MSG("Actual  : %s", err.data);
-    }
+    TEST_CHECK_STR_EQ(err.data, msg);
   }
 
   { /* missing parameter */
@@ -226,11 +219,7 @@ void test_mutt_pattern_comp(void)
     }
 
     char *msg = "missing parameter";
-    if (!TEST_CHECK(mutt_str_equal(err.data, msg)))
-    {
-      TEST_MSG("Expected: %s", msg);
-      TEST_MSG("Actual  : %s", err.data);
-    }
+    TEST_CHECK_STR_EQ(err.data, msg);
   }
 
   { /* error in pattern */
@@ -246,11 +235,7 @@ void test_mutt_pattern_comp(void)
     }
 
     char *msg = "error in pattern at: | =s foo";
-    if (!TEST_CHECK(mutt_str_equal(err.data, msg)))
-    {
-      TEST_MSG("Expected: %s", msg);
-      TEST_MSG("Actual  : %s", err.data);
-    }
+    TEST_CHECK_STR_EQ(err.data, msg);
   }
 
   {
@@ -289,11 +274,7 @@ void test_mutt_pattern_comp(void)
     }
 
     char *msg = "";
-    if (!TEST_CHECK(mutt_str_equal(err.data, msg)))
-    {
-      TEST_MSG("Expected: %s", msg);
-      TEST_MSG("Actual  : %s", err.data);
-    }
+    TEST_CHECK_STR_EQ(err.data, msg);
 
     mutt_pattern_free(&pat);
   }
@@ -335,11 +316,7 @@ void test_mutt_pattern_comp(void)
     }
 
     char *msg = "";
-    if (!TEST_CHECK(mutt_str_equal(err.data, msg)))
-    {
-      TEST_MSG("Expected: %s", msg);
-      TEST_MSG("Actual  : %s", err.data);
-    }
+    TEST_CHECK_STR_EQ(err.data, msg);
 
     mutt_pattern_free(&pat);
   }
@@ -412,11 +389,7 @@ void test_mutt_pattern_comp(void)
     }
 
     char *msg = "";
-    if (!TEST_CHECK(mutt_str_equal(err.data, msg)))
-    {
-      TEST_MSG("Expected: %s", msg);
-      TEST_MSG("Actual  : %s", err.data);
-    }
+    TEST_CHECK_STR_EQ(err.data, msg);
 
     mutt_pattern_free(&pat);
   }
@@ -489,11 +462,7 @@ void test_mutt_pattern_comp(void)
     }
 
     char *msg = "";
-    if (!TEST_CHECK(mutt_str_equal(err.data, msg)))
-    {
-      TEST_MSG("Expected: %s", msg);
-      TEST_MSG("Actual  : %s", err.data);
-    }
+    TEST_CHECK_STR_EQ(err.data, msg);
 
     mutt_pattern_free(&pat);
   }
@@ -566,11 +535,7 @@ void test_mutt_pattern_comp(void)
     }
 
     char *msg = "";
-    if (!TEST_CHECK(mutt_str_equal(err.data, msg)))
-    {
-      TEST_MSG("Expected: %s", msg);
-      TEST_MSG("Actual  : %s", err.data);
-    }
+    TEST_CHECK_STR_EQ(err.data, msg);
 
     mutt_pattern_free(&pat);
   }
@@ -656,11 +621,7 @@ void test_mutt_pattern_comp(void)
     }
 
     char *msg = "";
-    if (!TEST_CHECK(mutt_str_equal(err.data, msg)))
-    {
-      TEST_MSG("Expected: %s", msg);
-      TEST_MSG("Actual  : %s", err.data);
-    }
+    TEST_CHECK_STR_EQ(err.data, msg);
 
     mutt_pattern_free(&pat);
   }
@@ -761,11 +722,7 @@ void test_mutt_pattern_comp(void)
     }
 
     char *msg = "";
-    if (!TEST_CHECK(mutt_str_equal(err.data, msg)))
-    {
-      TEST_MSG("Expected: %s", msg);
-      TEST_MSG("Actual  : %s", err.data);
-    }
+    TEST_CHECK_STR_EQ(err.data, msg);
 
     mutt_pattern_free(&pat);
   }

--- a/test/rfc2047/rfc2047_decode.c
+++ b/test/rfc2047/rfc2047_decode.c
@@ -54,23 +54,13 @@ void test_rfc2047_decode(void)
       /* decode the original string */
       char *s = mutt_str_dup(rfc2047_test_data[i].original);
       rfc2047_decode(&s);
-      if (!TEST_CHECK(mutt_str_equal(s, rfc2047_test_data[i].decoded)))
-      {
-        TEST_MSG("Iteration: %zu", i);
-        TEST_MSG("Expected : %s", rfc2047_test_data[i].decoded);
-        TEST_MSG("Actual   : %s", s);
-      }
+      TEST_CHECK_STR_EQ(s, rfc2047_test_data[i].decoded);
       FREE(&s);
 
       /* decode the encoded result */
       s = mutt_str_dup(rfc2047_test_data[i].encoded);
       rfc2047_decode(&s);
-      if (!TEST_CHECK(mutt_str_equal(s, rfc2047_test_data[i].decoded)))
-      {
-        TEST_MSG("Iteration: %zu", i);
-        TEST_MSG("Expected : %s", rfc2047_test_data[i].decoded);
-        TEST_MSG("Actual   : %s", s);
-      }
+      TEST_CHECK_STR_EQ(s, rfc2047_test_data[i].decoded);
       FREE(&s);
     }
   }

--- a/test/rfc2047/rfc2047_encode.c
+++ b/test/rfc2047/rfc2047_encode.c
@@ -66,12 +66,7 @@ void test_rfc2047_encode(void)
       /* encode the expected result */
       char *s = mutt_str_dup(rfc2047_test_data[i].decoded);
       rfc2047_encode(&s, NULL, 0, charsets);
-      if (!TEST_CHECK(mutt_str_equal(s, rfc2047_test_data[i].encoded)))
-      {
-        TEST_MSG("Iteration: %zu", i);
-        TEST_MSG("Expected : %s", rfc2047_test_data[i].encoded);
-        TEST_MSG("Actual   : %s", s);
-      }
+      TEST_CHECK_STR_EQ(s, rfc2047_test_data[i].encoded);
       FREE(&s);
     }
     slist_free(&charsets);

--- a/test/store/common.c
+++ b/test/store/common.c
@@ -48,7 +48,7 @@ bool test_store_degenerate(const struct StoreOps *sops, const char *name)
   if (!sops)
     return false;
 
-  if (!TEST_CHECK(mutt_str_equal(sops->name, name)))
+  if (!TEST_CHECK_STR_EQ(sops->name, name))
     return false;
 
   if (!TEST_CHECK(sops->open(NULL) == NULL))

--- a/test/string/mutt_istr_remall.c
+++ b/test/string/mutt_istr_remall.c
@@ -25,6 +25,7 @@
 #include "acutest.h"
 #include <string.h>
 #include "mutt/lib.h"
+#include "test_common.h"
 
 struct RemallTest
 {
@@ -86,7 +87,7 @@ void test_mutt_istr_remall(void)
       TEST_CASE(buf);
 
       mutt_istr_remall(buf, remove);
-      TEST_CHECK(mutt_str_equal(buf, t->expected));
+      TEST_CHECK_STR_EQ(buf, t->expected);
     }
   }
 }

--- a/test/string/mutt_str_append_item.c
+++ b/test/string/mutt_str_append_item.c
@@ -25,6 +25,7 @@
 #include "acutest.h"
 #include <string.h>
 #include "mutt/lib.h"
+#include "test_common.h"
 
 struct AppendTest
 {
@@ -69,7 +70,7 @@ void test_mutt_str_append_item(void)
       char *str = t->first ? strdup(t->first) : NULL;
       TEST_CASE_("\"%s\", \"%s\", '%c'", NONULL(t->first), t->second, t->sep);
       mutt_str_append_item(&str, t->second, t->sep);
-      TEST_CHECK(mutt_str_equal(str, t->result));
+      TEST_CHECK_STR_EQ(str, t->result);
       FREE(&str);
     }
   }

--- a/test/string/mutt_str_asprintf.c
+++ b/test/string/mutt_str_asprintf.c
@@ -25,6 +25,7 @@
 #include "acutest.h"
 #include <string.h>
 #include "mutt/lib.h"
+#include "test_common.h"
 
 void test_mutt_str_asprintf(void)
 {
@@ -51,7 +52,7 @@ void test_mutt_str_asprintf(void)
     const char *str = "apple";
     char *result = NULL;
     TEST_CHECK(mutt_str_asprintf(&result, str) == 5);
-    TEST_CHECK(mutt_str_equal(result, str));
+    TEST_CHECK_STR_EQ(result, str);
     FREE(&result);
   }
 
@@ -62,7 +63,7 @@ void test_mutt_str_asprintf(void)
                       "strawberry tangerine ugli vanilla wolfberry xigua yew ziziphus";
     char *result = NULL;
     TEST_CHECK(mutt_str_asprintf(&result, str) == 195);
-    TEST_CHECK(mutt_str_equal(result, str));
+    TEST_CHECK_STR_EQ(result, str);
     FREE(&result);
   }
 
@@ -72,7 +73,7 @@ void test_mutt_str_asprintf(void)
     const char *expected = "app 1234567 3.1416";
     char *result = NULL;
     TEST_CHECK(mutt_str_asprintf(&result, "%.3s %ld %3.4f", str, 1234567, 3.141592654) == 18);
-    TEST_CHECK(mutt_str_equal(result, expected));
+    TEST_CHECK_STR_EQ(result, expected);
     FREE(&result);
   }
 }

--- a/test/string/mutt_str_cat.c
+++ b/test/string/mutt_str_cat.c
@@ -25,6 +25,7 @@
 #include "acutest.h"
 #include <string.h>
 #include "mutt/lib.h"
+#include "test_common.h"
 
 void test_mutt_str_cat(void)
 {
@@ -37,7 +38,7 @@ void test_mutt_str_cat(void)
   {
     char buf[64] = { 0 };
     TEST_CHECK(mutt_str_cat(buf, 0, "apple") == buf);
-    TEST_CHECK(mutt_str_equal(buf, ""));
+    TEST_CHECK_STR_EQ(buf, "");
   }
 
   {
@@ -48,24 +49,24 @@ void test_mutt_str_cat(void)
   {
     char buf[32] = { 0 };
     TEST_CHECK(mutt_str_cat(buf, sizeof(buf), "") == buf);
-    TEST_CHECK(mutt_str_equal(buf, ""));
+    TEST_CHECK_STR_EQ(buf, "");
   }
 
   {
     char buf[32] = { 0 };
     TEST_CHECK(mutt_str_cat(buf, sizeof(buf), "banana") == buf);
-    TEST_CHECK(mutt_str_equal(buf, "banana"));
+    TEST_CHECK_STR_EQ(buf, "banana");
   }
 
   {
     char buf[32] = "apple";
     TEST_CHECK(mutt_str_cat(buf, sizeof(buf), "") == buf);
-    TEST_CHECK(mutt_str_equal(buf, "apple"));
+    TEST_CHECK_STR_EQ(buf, "apple");
   }
 
   {
     char buf[32] = "apple";
     TEST_CHECK(mutt_str_cat(buf, sizeof(buf), "banana") == buf);
-    TEST_CHECK(mutt_str_equal(buf, "applebanana"));
+    TEST_CHECK_STR_EQ(buf, "applebanana");
   }
 }

--- a/test/string/mutt_str_copy.c
+++ b/test/string/mutt_str_copy.c
@@ -25,6 +25,7 @@
 #include "acutest.h"
 #include <string.h>
 #include "mutt/lib.h"
+#include "test_common.h"
 
 void test_mutt_str_copy(void)
 {
@@ -60,11 +61,7 @@ void test_mutt_str_copy(void)
       TEST_MSG("Expected: %zu", sizeof(trial) - 1);
       TEST_MSG("Actual  : %zu", len);
     }
-    if (!TEST_CHECK(mutt_str_equal(dst, trial)))
-    {
-      TEST_MSG("Expected: %s", trial);
-      TEST_MSG("Actual  : %s", dst);
-    }
+    TEST_CHECK_STR_EQ(dst, trial);
   }
 
   { /* too long */

--- a/test/string/mutt_str_dequote_comment.c
+++ b/test/string/mutt_str_dequote_comment.c
@@ -25,6 +25,7 @@
 #include "acutest.h"
 #include <string.h>
 #include "mutt/lib.h"
+#include "test_common.h"
 
 void test_mutt_str_dequote_comment(void)
 {
@@ -40,7 +41,7 @@ void test_mutt_str_dequote_comment(void)
     char *dequote = strdup(str);
     mutt_str_dequote_comment(dequote);
     TEST_CHECK_(1, "mutt_str_dequote_comment(dequote)");
-    TEST_CHECK(mutt_str_equal(dequote, str));
+    TEST_CHECK_STR_EQ(dequote, str);
     FREE(&dequote);
   }
 
@@ -50,7 +51,7 @@ void test_mutt_str_dequote_comment(void)
     char *dequote = strdup(str);
     mutt_str_dequote_comment(dequote);
     TEST_CHECK_(1, "mutt_str_dequote_comment(dequote)");
-    TEST_CHECK(mutt_str_equal(dequote, expected));
+    TEST_CHECK_STR_EQ(dequote, expected);
     FREE(&dequote);
   }
 
@@ -60,7 +61,7 @@ void test_mutt_str_dequote_comment(void)
     char *dequote = strdup(str);
     mutt_str_dequote_comment(dequote);
     TEST_CHECK_(1, "mutt_str_dequote_comment(dequote)");
-    TEST_CHECK(mutt_str_equal(dequote, expected));
+    TEST_CHECK_STR_EQ(dequote, expected);
     FREE(&dequote);
   }
 
@@ -70,7 +71,7 @@ void test_mutt_str_dequote_comment(void)
     char *dequote = strdup(str);
     mutt_str_dequote_comment(dequote);
     TEST_CHECK_(1, "mutt_str_dequote_comment(dequote)");
-    TEST_CHECK(mutt_str_equal(dequote, expected));
+    TEST_CHECK_STR_EQ(dequote, expected);
     FREE(&dequote);
   }
 }

--- a/test/string/mutt_str_dup.c
+++ b/test/string/mutt_str_dup.c
@@ -25,6 +25,7 @@
 #include "acutest.h"
 #include <string.h>
 #include "mutt/lib.h"
+#include "test_common.h"
 
 void test_mutt_str_dup(void)
 {
@@ -43,7 +44,7 @@ void test_mutt_str_dup(void)
     char *result = mutt_str_dup(str);
     TEST_CHECK(result != NULL);
     TEST_CHECK(result != str);
-    TEST_CHECK(mutt_str_equal(result, str));
+    TEST_CHECK_STR_EQ(result, str);
     FREE(&result);
   }
 }

--- a/test/string/mutt_str_equal.c
+++ b/test/string/mutt_str_equal.c
@@ -25,6 +25,7 @@
 #include "acutest.h"
 #include <stddef.h>
 #include "mutt/lib.h"
+#include "test_common.h"
 
 void test_mutt_str_equal(void)
 {
@@ -32,10 +33,10 @@ void test_mutt_str_equal(void)
 
   TEST_CHECK(!mutt_str_equal(NULL, "apple"));
   TEST_CHECK(!mutt_str_equal("apple", NULL));
-  TEST_CHECK(mutt_str_equal(NULL, NULL));
+  TEST_CHECK_STR_EQ(NULL, NULL);
 
-  TEST_CHECK(mutt_str_equal("", ""));
-  TEST_CHECK(mutt_str_equal("apple", "apple"));
+  TEST_CHECK_STR_EQ("", "");
+  TEST_CHECK_STR_EQ("apple", "apple");
   TEST_CHECK(!mutt_str_equal("apple", "APPLE"));
   TEST_CHECK(!mutt_str_equal("apple", "apple2"));
   TEST_CHECK(!mutt_str_equal("apple1", "apple"));

--- a/test/string/mutt_str_getenv.c
+++ b/test/string/mutt_str_getenv.c
@@ -26,6 +26,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "mutt/lib.h"
+#include "test_common.h"
 
 void test_mutt_str_getenv(void)
 {
@@ -42,7 +43,7 @@ void test_mutt_str_getenv(void)
     TEST_CASE(name);
 
     const char *result = mutt_str_getenv(name);
-    TEST_CHECK(mutt_str_equal(result, value));
+    TEST_CHECK_STR_EQ(result, value);
     unsetenv(name);
   }
 

--- a/test/string/mutt_str_inline_replace.c
+++ b/test/string/mutt_str_inline_replace.c
@@ -26,6 +26,7 @@
 #include <stdbool.h>
 #include <string.h>
 #include "mutt/lib.h"
+#include "test_common.h"
 
 struct InlineReplaceTest
 {
@@ -75,9 +76,9 @@ void test_mutt_str_inline_replace(void)
       bool result = mutt_str_inline_replace(buf, sizeof(buf), t->replace_len, t->replace);
       TEST_CHECK(result == t->success);
       if (result)
-        TEST_CHECK(mutt_str_equal(buf, t->expected));
+        TEST_CHECK_STR_EQ(buf, t->expected);
       else
-        TEST_CHECK(mutt_str_equal(buf, t->initial));
+        TEST_CHECK_STR_EQ(buf, t->initial);
     }
   }
 }

--- a/test/string/mutt_str_lower.c
+++ b/test/string/mutt_str_lower.c
@@ -25,6 +25,7 @@
 #include "acutest.h"
 #include <string.h>
 #include "mutt/lib.h"
+#include "test_common.h"
 
 void test_mutt_str_lower(void)
 {
@@ -37,18 +38,18 @@ void test_mutt_str_lower(void)
   {
     char buf[64] = "";
     mutt_str_lower(buf);
-    TEST_CHECK(mutt_str_equal(buf, ""));
+    TEST_CHECK_STR_EQ(buf, "");
   }
 
   {
     char buf[64] = "apple";
     mutt_str_lower(buf);
-    TEST_CHECK(mutt_str_equal(buf, "apple"));
+    TEST_CHECK_STR_EQ(buf, "apple");
   }
 
   {
     char buf[64] = "aPPLe";
     mutt_str_lower(buf);
-    TEST_CHECK(mutt_str_equal(buf, "apple"));
+    TEST_CHECK_STR_EQ(buf, "apple");
   }
 }

--- a/test/string/mutt_str_remove_trailing_ws.c
+++ b/test/string/mutt_str_remove_trailing_ws.c
@@ -25,6 +25,7 @@
 #include "acutest.h"
 #include <string.h>
 #include "mutt/lib.h"
+#include "test_common.h"
 
 struct TrailTest
 {
@@ -75,7 +76,7 @@ void test_mutt_str_remove_trailing_ws(void)
       TEST_CASE_("'%s'", buf);
 
       mutt_str_remove_trailing_ws(buf);
-      TEST_CHECK(mutt_str_equal(buf, t->expected));
+      TEST_CHECK_STR_EQ(buf, t->expected);
     }
   }
 }

--- a/test/string/mutt_str_replace.c
+++ b/test/string/mutt_str_replace.c
@@ -25,6 +25,7 @@
 #include "acutest.h"
 #include <string.h>
 #include "mutt/lib.h"
+#include "test_common.h"
 
 void test_mutt_str_replace(void)
 {
@@ -52,7 +53,7 @@ void test_mutt_str_replace(void)
     mutt_str_replace(&ptr, str);
     TEST_CHECK(ptr != NULL);
     TEST_CHECK(ptr != str);
-    TEST_CHECK(mutt_str_equal(ptr, str));
+    TEST_CHECK_STR_EQ(ptr, str);
     FREE(&ptr);
   }
 
@@ -62,7 +63,7 @@ void test_mutt_str_replace(void)
     mutt_str_replace(&ptr, str);
     TEST_CHECK(ptr != NULL);
     TEST_CHECK(ptr != str);
-    TEST_CHECK(mutt_str_equal(ptr, str));
+    TEST_CHECK_STR_EQ(ptr, str);
     FREE(&ptr);
   }
 

--- a/test/string/mutt_str_sysexit.c
+++ b/test/string/mutt_str_sysexit.c
@@ -25,6 +25,7 @@
 #include "acutest.h"
 #include <stddef.h>
 #include "mutt/lib.h"
+#include "test_common.h"
 #ifdef HAVE_SYSEXITS_H
 #include <sysexits.h>
 #endif
@@ -68,10 +69,6 @@ void test_mutt_str_sysexit(void)
     TEST_MSG("Testing %d, expecting '%s'\n", tests[i].err_num, NONULL(tests[i].result));
     result = mutt_str_sysexit(tests[i].err_num);
 
-    if (!TEST_CHECK(mutt_str_equal(result, tests[i].result)))
-    {
-      TEST_MSG("Expected: '%s', Got: '%s'\n", result, NONULL(tests[i].result));
-      return;
-    }
+    TEST_CHECK_STR_EQ(result, tests[i].result);
   }
 }

--- a/test/string/mutt_strn_cat.c
+++ b/test/string/mutt_strn_cat.c
@@ -25,6 +25,7 @@
 #include "acutest.h"
 #include <string.h>
 #include "mutt/lib.h"
+#include "test_common.h"
 
 void test_mutt_strn_cat(void)
 {
@@ -53,37 +54,37 @@ void test_mutt_strn_cat(void)
   {
     char buf[32] = { 0 };
     TEST_CHECK(mutt_strn_cat(buf, sizeof(buf), "", 1) == buf);
-    TEST_CHECK(mutt_str_equal(buf, ""));
+    TEST_CHECK_STR_EQ(buf, "");
   }
 
   {
     char buf[32] = { 0 };
     TEST_CHECK(mutt_strn_cat(buf, sizeof(buf), "banana", 6) == buf);
-    TEST_CHECK(mutt_str_equal(buf, "banana"));
+    TEST_CHECK_STR_EQ(buf, "banana");
   }
 
   {
     char buf[32] = { 0 };
     TEST_CHECK(mutt_strn_cat(buf, sizeof(buf), "banana", 3) == buf);
-    TEST_CHECK(mutt_str_equal(buf, "ban"));
+    TEST_CHECK_STR_EQ(buf, "ban");
   }
 
   {
     char buf[32] = "apple";
     TEST_CHECK(mutt_strn_cat(buf, sizeof(buf), "", 1) == buf);
-    TEST_CHECK(mutt_str_equal(buf, "apple"));
+    TEST_CHECK_STR_EQ(buf, "apple");
   }
 
   {
     char buf[32] = "apple";
     TEST_CHECK(mutt_strn_cat(buf, sizeof(buf), "banana", 6) == buf);
-    TEST_CHECK(mutt_str_equal(buf, "applebanana"));
+    TEST_CHECK_STR_EQ(buf, "applebanana");
   }
 
   {
     char buf[32] = "apple";
     TEST_CHECK(mutt_strn_cat(buf, sizeof(buf), "banana", 3) == buf);
-    TEST_CHECK(mutt_str_equal(buf, "appleban"));
+    TEST_CHECK_STR_EQ(buf, "appleban");
   }
 
   // Buffer too small
@@ -91,12 +92,12 @@ void test_mutt_strn_cat(void)
   {
     char buf[6] = { 0 };
     TEST_CHECK(mutt_strn_cat(buf, sizeof(buf), "banana", 6) == buf);
-    TEST_CHECK(mutt_str_equal(buf, "banan"));
+    TEST_CHECK_STR_EQ(buf, "banan");
   }
 
   {
     char buf[8] = "apple";
     TEST_CHECK(mutt_strn_cat(buf, sizeof(buf), "banana", 6) == buf);
-    TEST_CHECK(mutt_str_equal(buf, "appleba"));
+    TEST_CHECK_STR_EQ(buf, "appleba");
   }
 }

--- a/test/string/mutt_strn_copy.c
+++ b/test/string/mutt_strn_copy.c
@@ -25,6 +25,7 @@
 #include "acutest.h"
 #include <string.h>
 #include "mutt/lib.h"
+#include "test_common.h"
 
 void test_mutt_strn_copy(void)
 {
@@ -56,18 +57,18 @@ void test_mutt_strn_copy(void)
   {
     char buf[32] = { 0 };
     TEST_CHECK(mutt_strn_copy(buf, str + 3, 0, sizeof(buf)) == buf);
-    TEST_CHECK(mutt_str_equal(buf, ""));
+    TEST_CHECK_STR_EQ(buf, "");
   }
 
   {
     char buf[32] = { 0 };
     TEST_CHECK(mutt_strn_copy(buf, str + 3, 4, sizeof(buf)) == buf);
-    TEST_CHECK(mutt_str_equal(buf, "le b"));
+    TEST_CHECK_STR_EQ(buf, "le b");
   }
 
   {
     char buf[32] = { 0 };
     TEST_CHECK(mutt_strn_copy(buf, str + 3, 61, sizeof(buf)) == buf);
-    TEST_CHECK(mutt_str_equal(buf, "le banana"));
+    TEST_CHECK_STR_EQ(buf, "le banana");
   }
 }

--- a/test/string/mutt_strn_dup.c
+++ b/test/string/mutt_strn_dup.c
@@ -25,6 +25,7 @@
 #include "acutest.h"
 #include <string.h>
 #include "mutt/lib.h"
+#include "test_common.h"
 
 void test_mutt_strn_dup(void)
 {
@@ -41,7 +42,7 @@ void test_mutt_strn_dup(void)
   {
     char *ptr = mutt_strn_dup(str, 7);
     TEST_CHECK(ptr != NULL);
-    TEST_CHECK(mutt_str_equal(ptr, "apple b"));
+    TEST_CHECK_STR_EQ(ptr, "apple b");
     TEST_MSG(ptr);
     FREE(&ptr);
   }
@@ -49,7 +50,7 @@ void test_mutt_strn_dup(void)
   {
     char *ptr = mutt_strn_dup(str + 3, 4);
     TEST_CHECK(ptr != NULL);
-    TEST_CHECK(mutt_str_equal(ptr, "le b"));
+    TEST_CHECK_STR_EQ(ptr, "le b");
     TEST_MSG(ptr);
     FREE(&ptr);
   }
@@ -57,7 +58,7 @@ void test_mutt_strn_dup(void)
   {
     char *ptr = mutt_strn_dup(str + 3, 61);
     TEST_CHECK(ptr != NULL);
-    TEST_CHECK(mutt_str_equal(ptr, "le banana"));
+    TEST_CHECK_STR_EQ(ptr, "le banana");
     TEST_MSG(ptr);
     FREE(&ptr);
   }
@@ -65,7 +66,7 @@ void test_mutt_strn_dup(void)
   {
     char *ptr = mutt_strn_dup(str + 3, 0);
     TEST_CHECK(ptr != NULL);
-    TEST_CHECK(mutt_str_equal(ptr, ""));
+    TEST_CHECK_STR_EQ(ptr, "");
     TEST_MSG(ptr);
     FREE(&ptr);
   }

--- a/test/test_common.h
+++ b/test/test_common.h
@@ -26,25 +26,28 @@
 #include <limits.h>
 #include <stdbool.h>
 #include <stdio.h>
+#include "mutt/lib.h"
 
 struct NeoMutt;
 
 void test_gen_path(char *buf, size_t buflen, const char *fmt);
-void test_init(void);
-void test_fini(void);
 
 bool test_neomutt_create (void);
 void test_neomutt_destroy(void);
 
-#define TEST_CHECK_STR_EQ(expected, actual)                                    \
-  do                                                                           \
-  {                                                                            \
-    if (!TEST_CHECK(mutt_str_equal(expected, actual)))                         \
-    {                                                                          \
-      TEST_MSG("Expected: %s", expected);                                      \
-      TEST_MSG("Actual  : %s", actual);                                        \
-    }                                                                          \
-  } while (false)
+static inline bool test_check_str_eq(const char *expected, const char *actual, const char *file, int lnum)
+{
+  const bool rc = mutt_str_equal(expected, actual);
+  if (!acutest_check_(rc, file, lnum, "test_check_str_eq"))
+  {
+    TEST_MSG("Expected: %s", expected);
+    TEST_MSG("Actual  : %s", actual);
+  }
+
+  return rc;
+}
+
+#define TEST_CHECK_STR_EQ(expected, actual) test_check_str_eq(expected, actual, __FILE__, __LINE__)
 
 #define LONG_IS_64 (LONG_MAX == 9223372036854775807)
 

--- a/test/url/url_parse.c
+++ b/test/url/url_parse.c
@@ -28,6 +28,7 @@
 #include <string.h>
 #include "mutt/lib.h"
 #include "email/lib.h"
+#include "test_common.h"
 
 struct UrlTest
 {
@@ -216,20 +217,12 @@ void check_query_string(const char *exp, const struct UrlQueryList *act)
     next = strchr(exp, '|');
     mutt_str_copy(tmp, exp, next - exp + 1);
     exp = next + 1;
-    if (!TEST_CHECK(mutt_str_equal(tmp, np->name)))
-    {
-      TEST_MSG("Expected: <%s>", tmp);
-      TEST_MSG("Actual  : <%s>", np->name);
-    }
+    TEST_CHECK_STR_EQ(tmp, np->name);
 
     next = strchr(exp, '|');
     mutt_str_copy(tmp, exp, next - exp + 1);
     exp = next + 1;
-    if (!TEST_CHECK(mutt_str_equal(tmp, np->value)))
-    {
-      TEST_MSG("Expected: <%s>", tmp);
-      TEST_MSG("Actual  : <%s>", np->value);
-    }
+    TEST_CHECK_STR_EQ(tmp, np->value);
 
     np = STAILQ_NEXT(np, entries);
   }
@@ -268,31 +261,15 @@ void test_url_parse(void)
         TEST_MSG("Expected: %d", test[i].url.scheme);
         TEST_MSG("Actual  : %d", url->scheme);
       }
-      if (!TEST_CHECK(mutt_str_equal(test[i].url.user, url->user)))
-      {
-        TEST_MSG("Expected: %s", test[i].url.user);
-        TEST_MSG("Actual  : %s", url->user);
-      }
-      if (!TEST_CHECK(mutt_str_equal(test[i].url.pass, url->pass)))
-      {
-        TEST_MSG("Expected: %s", test[i].url.pass);
-        TEST_MSG("Actual  : %s", url->pass);
-      }
-      if (!TEST_CHECK(mutt_str_equal(test[i].url.host, url->host)))
-      {
-        TEST_MSG("Expected: %s", test[i].url.host);
-        TEST_MSG("Actual  : %s", url->host);
-      }
+      TEST_CHECK_STR_EQ(test[i].url.user, url->user);
+      TEST_CHECK_STR_EQ(test[i].url.pass, url->pass);
+      TEST_CHECK_STR_EQ(test[i].url.host, url->host);
       if (!TEST_CHECK(test[i].url.port == url->port))
       {
         TEST_MSG("Expected: %hu", test[i].url.port);
         TEST_MSG("Actual  : %hu", url->port);
       }
-      if (!TEST_CHECK(mutt_str_equal(test[i].url.path, url->path)))
-      {
-        TEST_MSG("Expected: %s", test[i].url.path);
-        TEST_MSG("Actual  : %s", url->path);
-      }
+      TEST_CHECK_STR_EQ(test[i].url.path, url->path);
       check_query_string(test[i].qs_elem, &url->query_strings);
 
       url_free(&url);

--- a/test/url/url_pct_decode.c
+++ b/test/url/url_pct_decode.c
@@ -25,6 +25,7 @@
 #include "acutest.h"
 #include <string.h>
 #include "email/lib.h"
+#include "test_common.h"
 
 void test_url_pct_decode(void)
 {
@@ -37,10 +38,6 @@ void test_url_pct_decode(void)
   {
     char s[] = "Hello%20world";
     TEST_CHECK(url_pct_decode(s) == 0);
-    if (!TEST_CHECK(mutt_str_equal(s, "Hello world")))
-    {
-      TEST_MSG("Expected: %s", "Hello world");
-      TEST_MSG("Actual  : %s", s);
-    }
+    TEST_CHECK_STR_EQ(s, "Hello world");
   }
 }

--- a/test/url/url_pct_encode.c
+++ b/test/url/url_pct_encode.c
@@ -25,6 +25,7 @@
 #include "acutest.h"
 #include <string.h>
 #include "email/lib.h"
+#include "test_common.h"
 
 void test_url_pct_encode(void)
 {
@@ -44,10 +45,6 @@ void test_url_pct_encode(void)
   {
     char buf[32] = { 0 };
     url_pct_encode(buf, sizeof(buf), "Hello world");
-    if (!TEST_CHECK(mutt_str_equal(buf, "Hello%20world")))
-    {
-      TEST_MSG("Expected: %s", "Hello%20world");
-      TEST_MSG("Actual  : %s", buf);
-    }
+    TEST_CHECK_STR_EQ(buf, "Hello%20world");
   }
 }


### PR DESCRIPTION
Replace uses of `strcmp()` with the more intuitive `mutt_str_equal()`.

The changes are split into many commits.
Each commit has one type of change, making reviewing simpler.
They can all be squashed before merging.

- 1d2559ade Form: `strcmp(a,b) == 0` -- simple parameters
- 5353764e4 Form: `strcmp(a,b) == 0` -- parameters contain expressions
- fe62d3578 Form: `strcmp(a,b) != 0` -- parameter contain expressions
- f70117476 Form: `strcmp(a,b)` -- Five places where `mutt_str_cmp()` was needed
- 50917d57c test: Form: `strcmp(a,b) == 0` -- simple parameters
- 2e0593fba test: Form: `strcmp(a,b) == 0` -- parameters contain expressions
- c619352ea test: Form: `!strcmp(a,b)` -- parameters contain expressions
- 102bf5c1c test: Form: `strcmp(a,b)` -- parameters contain expressions
- 6d44cc716 test: Form: `strcmp(a,b)` -- Two places where `mutt_str_cmp()` was needed
