### PR TITLE
Make $pager_index_lines use a fixed number of rows

### DIFF
--- a/docs/config.c
+++ b/docs/config.c
@@ -2895,8 +2895,7 @@
 ** giving the reader the context of a few messages before and after the
 ** message.  This is useful, for example, to determine how many messages
 ** remain to be read in the current thread.  A value of 0 results in no index
-** being shown.  If the number of messages in the current folder is less than
-** $$pager_index_lines, then the index will only use as many lines as it needs.
+** being shown.
 */
 
 { "pager_read_delay", DT_NUMBER, 0 },

--- a/pager/message.c
+++ b/pager/message.c
@@ -401,15 +401,13 @@ static void squash_index_panel(struct Mailbox *m, struct MuttWindow *win_index,
                                struct MuttWindow *win_pager)
 {
   const short c_pager_index_lines = cs_subset_number(NeoMutt->sub, "pager_index_lines");
-
-  const int index_space = MIN(c_pager_index_lines, m->vcount);
-  if (index_space > 0)
+  if (c_pager_index_lines > 0)
   {
     win_index->size = MUTT_WIN_SIZE_FIXED;
-    win_index->req_rows = index_space;
+    win_index->req_rows = c_pager_index_lines;
     win_index->parent->size = MUTT_WIN_SIZE_MINIMISE;
   }
-  window_set_visible(win_index->parent, (index_space > 0));
+  window_set_visible(win_index->parent, (c_pager_index_lines > 0));
 
   window_set_visible(win_pager->parent, true);
 

--- a/pager/pager.c
+++ b/pager/pager.c
@@ -95,9 +95,7 @@ static int config_pager_index_lines(struct MuttWindow *win)
 
   if (c_pager_index_lines > 0)
   {
-    struct IndexSharedData *shared = dlg->wdata;
-    int vcount = shared->mailbox ? shared->mailbox->vcount : 0;
-    win_index->req_rows = MIN(c_pager_index_lines, vcount);
+    win_index->req_rows = c_pager_index_lines;
     win_index->size = MUTT_WIN_SIZE_FIXED;
 
     panel_index->size = MUTT_WIN_SIZE_MINIMISE;


### PR DESCRIPTION
`set pager_index_lines = 5` will use less than five rows when fewer than five messages. `set pager_index_lines = -5` always uses five rows, even if some are blank.

> &lt;flatcap&gt; start with no config, and we can think a bit longer about if we want to change the default behaviour