### PR TITLE
hcache: remove spurious +1 from Buffer serialization.

### DIFF
--- a/hcache/serialize.c
+++ b/hcache/serialize.c
@@ -330,7 +330,7 @@ unsigned char *serial_dump_buffer(struct Buffer *buf, unsigned char *d, int *off
 
   d = serial_dump_int(1, d, off);
 
-  d = serial_dump_char_size(buf->data, buf->dsize + 1, d, off, convert);
+  d = serial_dump_char_size(buf->data, buf->dsize, d, off, convert);
   d = serial_dump_int(buf->dptr - buf->data, d, off);
   d = serial_dump_int(buf->dsize, d, off);
 


### PR DESCRIPTION
* **What does this PR do?**

Removes spurious +1 added to allocated buffer size in hcache serialization. This causes read overruns, e.g. 257 bytes from a 256 byte buffer which leads to ASan crashes when the stars align right.

* **Screenshots (if relevant)**

None.

* **Does this PR meet the acceptance criteria?** (This is just a reminder for you,
  this section can be removed if you fulfill it.)

No user visible changes, no new test failures.

* **What are the relevant issue numbers?**

#3763 