### PR TITLE
email: Read assumed_charset outside loops

### DIFF
--- a/email/parse.c
+++ b/email/parse.c
@@ -112,6 +112,8 @@ static void parse_parameters(struct ParameterList *pl, const char *s, bool allow
   struct Parameter *pnew = NULL;
   const char *p = NULL;
   size_t i;
+  const struct Slist *const c_assumed_charset =
+    cs_subset_slist(NeoMutt->sub, "assumed_charset");
 
   struct Buffer *buf = mutt_buffer_pool_get();
   /* allow_value_spaces, especially with autocrypt keydata, can result
@@ -164,8 +166,6 @@ static void parse_parameters(struct ParameterList *pl, const char *s, bool allow
           s++;
           for (; *s; s++)
           {
-            const struct Slist *const c_assumed_charset =
-                cs_subset_slist(NeoMutt->sub, "assumed_charset");
             if (c_assumed_charset)
             {
               // As iso-2022-* has a character of '"' with non-ascii state, ignore it

--- a/email/rfc2047.c
+++ b/email/rfc2047.c
@@ -780,10 +780,11 @@ void rfc2047_decode_addrlist(struct AddressList *al)
   if (!al)
     return;
 
+  const struct Slist *const c_assumed_charset = cs_subset_slist(NeoMutt->sub, "assumed_charset");
+
   struct Address *a = NULL;
   TAILQ_FOREACH(a, al, entries)
   {
-    const struct Slist *const c_assumed_charset = cs_subset_slist(NeoMutt->sub, "assumed_charset");
     if (a->personal && ((strstr(a->personal, "=?")) || c_assumed_charset))
     {
       rfc2047_decode(&a->personal);


### PR DESCRIPTION
Looking up assumed_charset in the configuration hash table is not free, so doing it over and over again is not useful.

Speeds up opening a large Maildir by about 1.5%.

* **What does this PR do?**

* **Screenshots (if relevant)**

* **Does this PR meet the acceptance criteria?** (This is just a reminder for you,
  this section can be removed if you fulfill it.)

   - Documentation created/updated (you have to edit
     [docs/manual.xml.head](https://www.github.com/neomutt/neomutt/blob/main/docs/manual.xml.head)
     for that)

   - All builds and tests are passing

   - Added [doxygen code documentation](https://neomutt.org/dev/doxygen)
     [syntax](http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html)

   - Code follows the [style guide](https://neomutt.org/dev/code)

* **What are the relevant issue numbers?**
