### PR TITLE
progress: update ncurses only when there is actual progress

### DIFF
--- a/progress/progress.c
+++ b/progress/progress.c
@@ -75,7 +75,10 @@ bool progress_update(struct Progress *progress, size_t pos, int percent)
   // Decloak an opaque pointer
   struct MuttWindow *win = (struct MuttWindow *) progress;
   const bool updated = progress_window_update(win, pos, percent);
-  window_redraw(win);
+  if (updated)
+  {
+    window_redraw(win);
+  }
   return updated;
 }
 


### PR DESCRIPTION
If we're not changing the progress bar, there's no need to ask ncurses for an update.

This means that we won't immediately resize on SIGWINCH, but wait until the next time the progress bar updates. That should be fine, though.

Speeds up opening a large Maildir by about 3.5%.

* **What does this PR do?**

* **Screenshots (if relevant)**

* **Does this PR meet the acceptance criteria?** (This is just a reminder for you,
  this section can be removed if you fulfill it.)

   - Documentation created/updated (you have to edit
     [docs/manual.xml.head](https://www.github.com/neomutt/neomutt/blob/main/docs/manual.xml.head)
     for that)

   - All builds and tests are passing

   - Added [doxygen code documentation](https://neomutt.org/dev/doxygen)
     [syntax](http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html)

   - Code follows the [style guide](https://neomutt.org/dev/code)

* **What are the relevant issue numbers?**
