### PR TITLE
email: call ftello() less

### DIFF
--- a/email/parse.c
+++ b/email/parse.c
@@ -1166,7 +1166,7 @@ struct Envelope *mutt_rfc822_read_header(FILE *fp, struct Email *e, bool user_hd
 
   struct Envelope *env = mutt_env_new();
   char *p = NULL;
-  LOFF_T loc;
+  LOFF_T loc = e ? e->offset : ftello(fp);
   struct Buffer *line = buf_pool_get();
 
   if (e)
@@ -1186,12 +1186,15 @@ struct Envelope *mutt_rfc822_read_header(FILE *fp, struct Email *e, bool user_hd
     }
   }
 
-  while ((loc = ftello(fp)) != -1)
+  while (true)
   {
-    if (mutt_rfc822_read_line(fp, line) == 0)
+    LOFF_T line_start_loc = loc;
+    size_t len = mutt_rfc822_read_line(fp, line);
+    if (len == 0)
     {
       break;
     }
+    loc += len;
     const char *lines = buf_string(line);
     p = strpbrk(lines, ": \t");
     if (!p || (*p != ':'))
@@ -1212,7 +1215,10 @@ struct Envelope *mutt_rfc822_read_header(FILE *fp, struct Email *e, bool user_hd
         continue;
       }
 
-      (void) mutt_file_seek(fp, loc, SEEK_SET);
+      /* We need to seek back to the start of the body. Note that we
+       * keep track of loc ourselves, since calling ftello() incurs
+       * a syscall, which can be expensive to do for every single line */
+      (void) mutt_file_seek(fp, line_start_loc, SEEK_SET);
       break; /* end of header */
     }
 


### PR DESCRIPTION
Every call to ftello() translates into an lseek() system call, because glibc cannot know whether someone moved the underlying file descriptor or not. Keep track of the position ourselves instead of checking anew for every header line that we read.

Speeds up opening a large Maildir by about 19% (!).

* **What does this PR do?**

* **Screenshots (if relevant)**

* **Does this PR meet the acceptance criteria?** (This is just a reminder for you,
  this section can be removed if you fulfill it.)

   - Documentation created/updated (you have to edit
     [docs/manual.xml.head](https://www.github.com/neomutt/neomutt/blob/main/docs/manual.xml.head)
     for that)

   - All builds and tests are passing

   - Added [doxygen code documentation](https://neomutt.org/dev/doxygen)
     [syntax](http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html)

   - Code follows the [style guide](https://neomutt.org/dev/code)

* **What are the relevant issue numbers?**
