### PR TITLE
hcache: do less work when not in use

### DIFF
--- a/hcache/hcache.c
+++ b/hcache/hcache.c
@@ -340,10 +340,13 @@ static char *get_foldername(const char *folder)
  */
 static void *fetch_raw(struct HeaderCache *hc, const char *key, size_t keylen, size_t *dlen)
 {
+  if (!hc)
+    return NULL;
+
   const char *const c_header_cache_backend = cs_subset_string(NeoMutt->sub, "header_cache_backend");
   const struct StoreOps *ops = store_get_backend_ops(c_header_cache_backend);
 
-  if (!hc || !ops)
+  if (!ops)
     return NULL;
 
   struct Buffer path = mutt_buffer_make(1024);


### PR DESCRIPTION
If hcache is compiled in, but it's not actually in use, we would still go through a lot of the motions; check for flags, stat() files (if maildir_header_cache_verify is not explicitly turned off), and so on. We can short-circuit a lot of these operations by simply checking early on whether the hcache is NULL or not.

Speeds up opening a large Maildir by about 2.5% (in the specific situation where hcache is compiled in but not enabled).

* **What does this PR do?**

* **Screenshots (if relevant)**

* **Does this PR meet the acceptance criteria?** (This is just a reminder for you,
  this section can be removed if you fulfill it.)

   - Documentation created/updated (you have to edit
     [docs/manual.xml.head](https://www.github.com/neomutt/neomutt/blob/main/docs/manual.xml.head)
     for that)

   - All builds and tests are passing

   - Added [doxygen code documentation](https://neomutt.org/dev/doxygen)
     [syntax](http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html)

   - Code follows the [style guide](https://neomutt.org/dev/code)

* **What are the relevant issue numbers?**
