### PR TITLE
Use Buffer in mutt_rfc822_read_line

### DIFF
--- a/email/parse.c
+++ b/email/parse.c
@@ -1095,13 +1095,17 @@ size_t mutt_rfc822_read_line(FILE *fp, struct Buffer *out)
 
   while (true)
   {
-    if (!fgets(buf, linelen - offset, fp) || /* end of file or */
-        (IS_SPACE(*line) && !offset))        /* end of headers */
+    if (!fgets(buf, linelen - offset, fp))
     {
       return 0;
     }
 
     const size_t len = mutt_str_len(buf);
+    if ((IS_SPACE(*line) && !offset))
+    {
+      return len;
+    }
+
     if (len == 0)
     {
       return read;
@@ -1196,7 +1200,7 @@ struct Envelope *mutt_rfc822_read_header(FILE *fp, struct Email *e, bool user_hd
 
   while ((loc = ftello(fp)) != -1)
   {
-    if ((mutt_rfc822_read_line(fp, line) == 0) || (buf_len(line) == 0))
+    if (mutt_rfc822_read_line(fp, line) == 0)
     {
       break;
     }

--- a/email/parse.c
+++ b/email/parse.c
@@ -1097,18 +1097,20 @@ size_t mutt_rfc822_read_line(FILE *fp, struct Buffer *out)
   {
     if (!fgets(buf, linelen - offset, fp))
     {
-      return 0;
+      read = 0;
+      goto done;
     }
 
     const size_t len = mutt_str_len(buf);
     if ((IS_SPACE(*line) && !offset))
     {
-      return len;
+      read = len;
+      goto done;
     }
 
     if (len == 0)
     {
-      return read;
+      goto done;
     }
     read += len;
 
@@ -1128,8 +1130,7 @@ size_t mutt_rfc822_read_line(FILE *fp, struct Buffer *out)
       {
         ungetc(ch, fp);
         buf_addstr(out, line);
-        FREE(&line);
-        return read; /* next line is a separate header field or EOH */
+        goto done; /* next line is a separate header field or EOH */
       }
       ++read;
 
@@ -1155,7 +1156,10 @@ size_t mutt_rfc822_read_line(FILE *fp, struct Buffer *out)
       buf = line + offset;
     }
   }
-  /* not reached */
+
+done:
+  FREE(&line);
+  return read;
 }
 
 /**

--- a/email/parse.c
+++ b/email/parse.c
@@ -1141,7 +1141,6 @@ size_t mutt_rfc822_read_line(FILE *fp, struct Buffer *out)
       }
 
       ungetc(ch, fp);
-      --read;
       *++buf = ' '; /* string is still terminated because we removed
                        at least one whitespace char above */
     }

--- a/email/parse.h
+++ b/email/parse.h
@@ -46,6 +46,6 @@ struct Body *    mutt_read_mime_header    (FILE *fp, bool digest);
 int              mutt_rfc822_parse_line   (struct Envelope *env, struct Email *e, const char *name, const char *body, bool user_hdrs, bool weed, bool do_2047);
 struct Body *    mutt_rfc822_parse_message(FILE *fp, struct Body *parent);
 struct Envelope *mutt_rfc822_read_header  (FILE *fp, struct Email *e, bool user_hdrs, bool weed);
-char *           mutt_rfc822_read_line    (FILE *fp, char *line, size_t *linelen);
+size_t           mutt_rfc822_read_line    (FILE *fp, struct Buffer *out);
 
 #endif /* MUTT_EMAIL_PARSE_H */

--- a/test/parse/mutt_rfc822_read_line.c
+++ b/test/parse/mutt_rfc822_read_line.c
@@ -31,18 +31,12 @@ void test_mutt_rfc822_read_line(void)
   // char *mutt_rfc822_read_line(FILE *fp, char *line, size_t *linelen);
 
   {
-    size_t linelen = 0;
-    TEST_CHECK(!mutt_rfc822_read_line(NULL, "apple", &linelen));
+    struct Buffer buf = { 0 };
+    TEST_CHECK(mutt_rfc822_read_line(NULL, &buf) == 0);
   }
 
   {
     FILE fp = { 0 };
-    size_t linelen = 0;
-    TEST_CHECK(!mutt_rfc822_read_line(&fp, NULL, &linelen));
-  }
-
-  {
-    FILE fp = { 0 };
-    TEST_CHECK(!mutt_rfc822_read_line(&fp, "apple", NULL));
+    TEST_CHECK(mutt_rfc822_read_line(&fp, NULL) == 0);
   }
 }

--- a/test/parse/mutt_rfc822_read_line.c
+++ b/test/parse/mutt_rfc822_read_line.c
@@ -23,41 +23,80 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
-#include "test_common.h"
 #include <stdio.h>
 #include "email/lib.h"
+#include "test_common.h"
 
 static struct Rfc822ReadLineTestData
 {
   char *input;
   const char *output;
-  size_t      read;
+  size_t read;
 } test_data[] = {
+  /* clang-format off */
   {
+    /*
+     12345678901234567890\1
+     */
     "Subject: basic stuff\n",
     "Subject: basic stuff",
     21
   },
   {
+    /*
+     12345678901234567890\1
+     */
     "Subject: basic stuff\n\n  ",
     "Subject: basic stuff",
     21
   },
   {
+    /*
+     1234567890123\456789012\3
+     */
     "Subject: long\n subject\n", 
     "Subject: long subject",
     23
   },
   {
+    /*
+     1234567890123 45678901234567\8
+     */
     "Subject: long\n      subject\n", 
     "Subject: long subject",
     28
   },
   {
+    /*
+     123456789012\3
+     */
     "Subject: one\nAnother: two\n", 
     "Subject: one",
     13
+  },
+  {
+    /*
+     1234567890123456\7
+     */
+    "Subject: one    \n", 
+    "Subject: one",
+    17
+  },
+  {
+    /* After we read the first chunk ("A:b{2021}" == 1023 bytes), the next read
+     * starts with spaces and continues the header. */
+    "A:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb    c\n",
+    "A:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb    c",
+    1029
+  },
+  {
+    /* After we read the first chunk ("A:b{2021}" == 1023 bytes), the next read
+     * starts with spaces and ends the header. */
+    "A:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb     \n",
+    "A:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    1029
   }
+  /* clang-format on */
 };
 
 void test_mutt_rfc822_read_line(void)
@@ -102,13 +141,13 @@ void test_mutt_rfc822_read_line(void)
     long off = ftell(fp);
     if (!TEST_CHECK(read == test_data[i].read))
     {
-      TEST_MSG("Input   : %s" , test_data[i].input);
+      TEST_MSG("Input   : %s", test_data[i].input);
       TEST_MSG("Expected: %zu", test_data[i].read);
       TEST_MSG("Actual  : %zu", read);
     }
     if (!TEST_CHECK(read == off))
     {
-      TEST_MSG("Input   : %s" , test_data[i].input);
+      TEST_MSG("Input   : %s", test_data[i].input);
       TEST_MSG("Expected: %ld", off);
       TEST_MSG("Actual  : %zu", read);
     }

--- a/test/parse/mutt_rfc822_read_line.c
+++ b/test/parse/mutt_rfc822_read_line.c
@@ -54,7 +54,7 @@ static struct Rfc822ReadLineTestData
     /*
      1234567890123\456789012\3
      */
-    "Subject: long\n subject\n", 
+    "Subject: long\n subject\n",
     "Subject: long subject",
     23
   },
@@ -62,7 +62,7 @@ static struct Rfc822ReadLineTestData
     /*
      1234567890123 45678901234567\8
      */
-    "Subject: long\n      subject\n", 
+    "Subject: long\n      subject\n",
     "Subject: long subject",
     28
   },
@@ -70,7 +70,7 @@ static struct Rfc822ReadLineTestData
     /*
      123456789012\3
      */
-    "Subject: one\nAnother: two\n", 
+    "Subject: one\nAnother: two\n",
     "Subject: one",
     13
   },
@@ -78,7 +78,7 @@ static struct Rfc822ReadLineTestData
     /*
      1234567890123456\7
      */
-    "Subject: one    \n", 
+    "Subject: one    \n",
     "Subject: one",
     17
   },

--- a/test/parse/mutt_rfc822_read_line.c
+++ b/test/parse/mutt_rfc822_read_line.c
@@ -78,10 +78,18 @@ void test_mutt_rfc822_read_line(void)
     char input[] = "Head1: val1.1\n  val1.2\nHead2: val2.1\n val2.2\n";
     FILE *fp = fmemopen(input, sizeof(input), "r");
     struct Buffer *buf = buf_pool_get();
-    mutt_rfc822_read_line(fp, buf);
+
+    const size_t after1 = mutt_rfc822_read_line(fp, buf);
     TEST_CHECK_STR_EQ("Head1: val1.1 val1.2", buf_string(buf));
+
     mutt_rfc822_read_line(fp, buf);
     TEST_CHECK_STR_EQ("Head2: val2.1 val2.2", buf_string(buf));
+
+    fseek(fp, after1, SEEK_SET);
+    buf_reset(buf);
+    mutt_rfc822_read_line(fp, buf);
+    TEST_CHECK_STR_EQ("Head2: val2.1 val2.2", buf_string(buf));
+
     buf_pool_release(&buf);
     fclose(fp);
   }

--- a/test/parse/mutt_rfc822_read_line.c
+++ b/test/parse/mutt_rfc822_read_line.c
@@ -28,7 +28,7 @@
 
 void test_mutt_rfc822_read_line(void)
 {
-  // char *mutt_rfc822_read_line(FILE *fp, char *line, size_t *linelen);
+  // size_t mutt_rfc822_read_line(FILE *fp, struct Buffer *buf);
 
   {
     struct Buffer buf = { 0 };

--- a/test/parse/mutt_rfc822_read_line.c
+++ b/test/parse/mutt_rfc822_read_line.c
@@ -23,8 +23,22 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
+#include "test_common.h"
 #include <stdio.h>
 #include "email/lib.h"
+
+static struct Rfc822ReadLineTestData
+{
+  char *input;
+  const char *output;
+  size_t      read;
+} test_data[] = {
+  {
+    "Subject: long\r\n  subject\r\n\r\n", 
+    "Subject: long subject",
+    26
+  }
+};
 
 void test_mutt_rfc822_read_line(void)
 {
@@ -38,5 +52,26 @@ void test_mutt_rfc822_read_line(void)
   {
     FILE fp = { 0 };
     TEST_CHECK(mutt_rfc822_read_line(&fp, NULL) == 0);
+  }
+
+  for (size_t i = 0; i < mutt_array_size(test_data); ++i)
+  {
+    FILE *fp = fmemopen(test_data[i].input, strlen(test_data[i].input), "r");
+    struct Buffer *buf = buf_pool_get();
+    const size_t read = mutt_rfc822_read_line(fp, buf);
+    long off = ftell(fp);
+    if (!TEST_CHECK(read == test_data[i].read))
+    {
+      TEST_MSG("Expected: %zu", test_data[i].read);
+      TEST_MSG("Actual  : %zu", read);
+    }
+    if (!TEST_CHECK(read == off))
+    {
+      TEST_MSG("Expected: %ld", off);
+      TEST_MSG("Actual  : %zu", read);
+    }
+    TEST_CHECK_STR_EQ(test_data[i].output, buf_string(buf));
+    buf_pool_release(&buf);
+    fclose(fp);
   }
 }


### PR DESCRIPTION
This cleans up the mutt_rfc822_read_line API and implementation, and it makes it return the number of chars read from the file.