### PR TITLE
Roundup but for warnings

### DIFF
--- a/pop/pop.c
+++ b/pop/pop.c
@@ -1103,11 +1103,9 @@ static bool pop_msg_open(struct Mailbox *m, struct Message *msg, int msgno)
   e->edata_free = pop_edata_free;
 
   e->lines = 0;
-  fgets(buf, sizeof(buf), msg->fp);
-  while (!feof(msg->fp))
+  while (fgets(buf, sizeof(buf), msg->fp) && !feof(msg->fp))
   {
     m->emails[msgno]->lines++;
-    fgets(buf, sizeof(buf), msg->fp);
   }
 
   e->body->length = ftello(msg->fp) - e->body->offset;

--- a/pop/pop.c
+++ b/pop/pop.c
@@ -169,7 +169,8 @@ static int pop_read_header(struct PopAccountData *adata, struct Email *e)
       while (!feof(fp))
       {
         e->body->length--;
-        fgets(buf, sizeof(buf), fp);
+        if(!fgets(buf, sizeof(buf), fp))
+          break;
       }
       break;
     }

--- a/send/send.c
+++ b/send/send.c
@@ -1732,9 +1732,8 @@ static bool search_attach_keyword(char *filename, struct ConfigSubset *sub)
 
   char *inputline = mutt_mem_malloc(1024);
   bool found = false;
-  while (!feof(fp_att))
+  while (!feof(fp_att) && fgets(inputline, 1024, fp_att))
   {
-    fgets(inputline, 1024, fp_att);
     if (!mutt_is_quote_line(inputline, NULL) &&
         mutt_regex_match(c_abort_noattach_regex, inputline))
     {


### PR DESCRIPTION
The first patch is copied from the IMAP one. The rest should be functionally equivalent.

See #3810