### PR TITLE
browser: fix crash in op_browser_subscribe()

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -208,6 +208,7 @@ Rubén Llorente,
 [Ryan Kavanagh](https://github.com/ryanakca "ryanakca"),
 [ryt](https://github.com/0x747972 "0x747972"),
 [Santiago Torres](https://github.com/santiagotorres "santiagotorres"),
+[Sebastian Crane](https://github.com/seabass-labrax "seabass-labrax")
 [Scott Kostyshak](https://github.com/scottkosty "scottkosty"),
 [Sebastian Stark](https://github.com/sstark "sstark"),
 [Serge Gebhardt](https://github.com/sgeb "sgeb"),

--- a/browser/functions.c
+++ b/browser/functions.c
@@ -151,6 +151,12 @@ static int op_browser_subscribe(struct BrowserPrivateData *priv, int op)
 #ifdef USE_IMAP
   else
   {
+    if (ARRAY_EMPTY(&priv->state.entry))
+    {
+      mutt_error(_("There are no mailboxes"));
+      return FR_ERROR;
+    }
+
     char tmp2[256];
     int index = menu_get_index(priv->menu);
     struct FolderFile *ff = ARRAY_GET(&priv->state.entry, index);


### PR DESCRIPTION
* **What does this PR do?**

Fix a segmentation fault that occurs in `op_browser_subscribe()` when the list of mailboxes is empty. The macro `ARRAY_GET` intentionally returns NULL when an out-of-bounds index is accessed; this value is assigned to `*ff`, causing a null pointer access in `mutt_str_copy()`.

Return `FR_ERROR` from `op_browser_subscribe()` if there are no mailboxes in the browser.