### PR TITLE
mutt: cache calls to iconv_open()

### DIFF
--- a/convert/convert.c
+++ b/convert/convert.c
@@ -185,11 +185,6 @@ size_t mutt_convert_file_to(FILE *fp, const char *fromcode, struct Slist const *
     }
   }
 
-  for (int i = 0; i < ncodes; i++)
-    if (cd[i] != (iconv_t) (-1))
-      iconv_close(cd[i]);
-
-  iconv_close(cd1);
   FREE(&cd);
   FREE(&infos);
   FREE(&score);

--- a/convert/convert.c
+++ b/convert/convert.c
@@ -67,7 +67,7 @@ size_t mutt_convert_file_to(FILE *fp, const char *fromcode, struct Slist const *
   size_t rc;
 
   const iconv_t cd1 = mutt_ch_iconv_open("utf-8", fromcode, MUTT_ICONV_NO_FLAGS);
-  if (cd1 == (iconv_t) (-1))
+  if (!iconv_t_valid(cd1))
     return -1;
 
   int ncodes = tocodes->count;
@@ -87,7 +87,7 @@ size_t mutt_convert_file_to(FILE *fp, const char *fromcode, struct Slist const *
     else
     {
       /* Special case for conversion to UTF-8 */
-      cd[ni] = (iconv_t) (-1);
+      cd[ni] = ICONV_T_INVALID;
       score[ni] = (size_t) (-1);
     }
     ni += 1;
@@ -118,7 +118,7 @@ size_t mutt_convert_file_to(FILE *fp, const char *fromcode, struct Slist const *
     /* Convert from UTF-8 */
     for (int i = 0; i < ncodes; i++)
     {
-      if ((cd[i] != (iconv_t) (-1)) && (score[i] != (size_t) (-1)))
+      if (iconv_t_valid(cd[i]) && (score[i] != (size_t) (-1)))
       {
         const char *ub = bufu;
         size_t ubl = ubl1;
@@ -136,7 +136,7 @@ size_t mutt_convert_file_to(FILE *fp, const char *fromcode, struct Slist const *
           mutt_update_content_info(&infos[i], &states[i], bufo, ob - bufo);
         }
       }
-      else if ((cd[i] == (iconv_t) (-1)) && (score[i] == (size_t) (-1)))
+      else if (!iconv_t_valid(cd[i]) && (score[i] == (size_t) (-1)))
       {
         /* Special case for conversion to UTF-8 */
         mutt_update_content_info(&infos[i], &states[i], bufu, ubl1);
@@ -161,14 +161,14 @@ size_t mutt_convert_file_to(FILE *fp, const char *fromcode, struct Slist const *
     rc = (size_t) (-1);
     for (int i = 0; i < ncodes; i++)
     {
-      if ((cd[i] == (iconv_t) (-1)) && (score[i] == (size_t) (-1)))
+      if (!iconv_t_valid(cd[i]) && (score[i] == (size_t) (-1)))
       {
         /* Special case for conversion to UTF-8 */
         *tocode = i;
         rc = 0;
         break;
       }
-      else if ((cd[i] == (iconv_t) (-1)) || (score[i] == (size_t) (-1)))
+      else if (!iconv_t_valid(cd[i]) || (score[i] == (size_t) (-1)))
         continue;
       else if ((rc == (size_t) (-1)) || (score[i] < rc))
       {

--- a/email/rfc2047.c
+++ b/email/rfc2047.c
@@ -206,11 +206,9 @@ static size_t try_block(const char *d, size_t dlen, const char *fromcode,
         (iconv(cd, NULL, NULL, &ob, &obl) == (size_t) (-1)))
     {
       assert(errno == E2BIG);
-      iconv_close(cd);
       assert(ib > d);
       return ((ib - d) == dlen) ? dlen : ib - d + 1;
     }
-    iconv_close(cd);
   }
   else
   {
@@ -288,7 +286,6 @@ static size_t encode_block(char *str, char *buf, size_t buflen, const char *from
   const size_t n1 = iconv(cd, (ICONV_CONST char **) &ib, &ibl, &ob, &obl);
   const size_t n2 = iconv(cd, NULL, NULL, &ob, &obl);
   assert(n1 != (size_t) (-1) && n2 != (size_t) (-1));
-  iconv_close(cd);
   return (*encoder)(str, tmp, ob - tmp, tocode);
 }
 

--- a/email/rfc2047.c
+++ b/email/rfc2047.c
@@ -197,13 +197,13 @@ static size_t try_block(const char *d, size_t dlen, const char *fromcode,
   if (fromcode)
   {
     iconv_t cd = mutt_ch_iconv_open(tocode, fromcode, MUTT_ICONV_NO_FLAGS);
-    assert(cd != (iconv_t) (-1));
+    assert(iconv_t_valid(cd));
     ib = d;
     ibl = dlen;
     ob = buf;
     obl = sizeof(buf) - strlen(tocode);
-    if ((iconv(cd, (ICONV_CONST char **) &ib, &ibl, &ob, &obl) == (size_t) (-1)) ||
-        (iconv(cd, NULL, NULL, &ob, &obl) == (size_t) (-1)))
+    if ((iconv(cd, (ICONV_CONST char **) &ib, &ibl, &ob, &obl) == ICONV_ERROR) ||
+        (iconv(cd, NULL, NULL, &ob, &obl) == ICONV_ERROR))
     {
       assert(errno == E2BIG);
       assert(ib > d);
@@ -277,7 +277,7 @@ static size_t encode_block(char *str, char *buf, size_t buflen, const char *from
   }
 
   const iconv_t cd = mutt_ch_iconv_open(tocode, fromcode, MUTT_ICONV_NO_FLAGS);
-  assert(cd != (iconv_t) (-1));
+  assert(iconv_t_valid(cd));
   const char *ib = buf;
   size_t ibl = buflen;
   char tmp[ENCWORD_LEN_MAX - ENCWORD_LEN_MIN + 1];

--- a/handler.c
+++ b/handler.c
@@ -119,7 +119,7 @@ static void convert_to_state(iconv_t cd, char *bufi, size_t *l, struct State *st
 
   if (!bufi)
   {
-    if (cd != (iconv_t) (-1))
+    if (iconv_t_valid(cd))
     {
       ob = bufo;
       obl = sizeof(bufo);
@@ -130,7 +130,7 @@ static void convert_to_state(iconv_t cd, char *bufi, size_t *l, struct State *st
     return;
   }
 
-  if (cd == (iconv_t) (-1))
+  if (!iconv_t_valid(cd))
   {
     state_prefix_put(state, bufi, *l);
     *l = 0;
@@ -1889,7 +1889,7 @@ bool mutt_can_decode(struct Body *b)
 void mutt_decode_attachment(struct Body *b, struct State *state)
 {
   int istext = mutt_is_text_part(b) && (b->disposition == DISP_INLINE);
-  iconv_t cd = (iconv_t) (-1);
+  iconv_t cd = ICONV_T_INVALID;
 
   if (!mutt_file_seek(state->fp_in, b->offset, SEEK_SET))
   {

--- a/handler.c
+++ b/handler.c
@@ -1938,7 +1938,4 @@ void mutt_decode_attachment(struct Body *b, struct State *state)
                   cd);
       break;
   }
-
-  if (cd != (iconv_t) (-1))
-    iconv_close(cd);
 }

--- a/main.c
+++ b/main.c
@@ -1396,6 +1396,7 @@ main_exit:
   commands_cleanup();
   menu_cleanup();
   crypt_cleanup();
+  mutt_ch_cache_cleanup();
   mutt_opts_free();
   subjrx_free();
   attach_free();

--- a/mutt/charset.c
+++ b/mutt/charset.c
@@ -76,6 +76,23 @@ TAILQ_HEAD(LookupList, Lookup);
 static struct LookupList Lookups = TAILQ_HEAD_INITIALIZER(Lookups);
 
 /**
+ * struct IconvCacheEntry - Cached iconv conversion descriptor
+ */
+struct IconvCacheEntry
+{
+  char *fromcode1; ///< Source character set
+  char *tocode1;   ///< Destination character set
+  iconv_t cd;      ///< iconv conversion descriptor
+};
+
+/// Max size of the iconv cache
+#define ICONV_CACHE_SIZE 16
+/// Cache of iconv conversion descriptors
+static struct IconvCacheEntry IconvCache[ICONV_CACHE_SIZE];
+/// Number of iconv descriptors in the cache
+static int IconvCacheUsed = 0;
+
+/**
  * struct MimeNames - MIME name lookup entry
  */
 struct MimeNames
@@ -554,6 +571,11 @@ const char *mutt_ch_charset_lookup(const char *chs)
  * label, or such. Misusing MUTT_ICONV_HOOK_FROM leads to unwanted interactions
  * in some setups.
  *
+ * Since calling iconv_open() repeatedly can be expensive, we keep a cache of
+ * the most recently used iconv_t objects, kept in LRU order. This means that
+ * you should not call iconv_close() on the object yourself. All remaining
+ * objects in the cache will exit when main() calls mutt_ch_cache_cleanup().
+ *
  * @note By design charset-hooks should never be, and are never, applied
  * to tocode.
  *
@@ -566,8 +588,6 @@ iconv_t mutt_ch_iconv_open(const char *tocode, const char *fromcode, uint8_t fla
   char fromcode1[128];
   const char *tocode2 = NULL, *fromcode2 = NULL;
   const char *tmp = NULL;
-
-  iconv_t cd;
 
   /* transform to MIME preferred charset names */
   mutt_ch_canonical_charset(tocode1, sizeof(tocode1), tocode);
@@ -583,18 +603,67 @@ iconv_t mutt_ch_iconv_open(const char *tocode, const char *fromcode, uint8_t fla
       mutt_ch_canonical_charset(fromcode1, sizeof(fromcode1), tmp);
   }
 
-  /* always apply iconv-hooks to suit system's iconv tastes */
-  tocode2 = mutt_ch_iconv_lookup(tocode1);
-  tocode2 = tocode2 ? tocode2 : tocode1;
-  fromcode2 = mutt_ch_iconv_lookup(fromcode1);
-  fromcode2 = fromcode2 ? fromcode2 : fromcode1;
+  /* check if we have this pair cached already */
+  iconv_t cd = (iconv_t) -1;
+  for (int i = 0; i < IconvCacheUsed; ++i)
+  {
+    if (strcmp(tocode1, IconvCache[i].tocode1) == 0 &&
+        strcmp(fromcode1, IconvCache[i].fromcode1) == 0)
+    {
+      cd = IconvCache[i].cd;
 
-  /* call system iconv with names it appreciates */
-  cd = iconv_open(tocode2, fromcode2);
-  if (cd != (iconv_t) -1)
-    return cd;
+      /* reset state */
+      iconv(cd, NULL, NULL, NULL, NULL);
 
-  return (iconv_t) -1;
+      /* make room for this one at the top */
+      struct IconvCacheEntry top = IconvCache[i];
+      for (int j = i; j-- > 0;)
+      {
+        IconvCache[j + 1] = IconvCache[j];
+      }
+      IconvCache[0] = top;
+      break;
+    }
+  }
+
+  if (cd == (iconv_t) -1) /* not found in cache */
+  {
+    /* always apply iconv-hooks to suit system's iconv tastes */
+    tocode2 = mutt_ch_iconv_lookup(tocode1);
+    tocode2 = tocode2 ? tocode2 : tocode1;
+    fromcode2 = mutt_ch_iconv_lookup(fromcode1);
+    fromcode2 = fromcode2 ? fromcode2 : fromcode1;
+
+    /* call system iconv with names it appreciates */
+    cd = iconv_open(tocode2, fromcode2);
+
+    if (IconvCacheUsed == ICONV_CACHE_SIZE)
+    {
+      mutt_debug(LL_DEBUG2, "iconv: dropping %s -> %s from the cache\n",
+                 IconvCache[IconvCacheUsed - 1].fromcode1,
+                 IconvCache[IconvCacheUsed - 1].tocode1);
+      /* get rid of the oldest entry */
+      FREE(&IconvCache[IconvCacheUsed - 1].fromcode1);
+      FREE(&IconvCache[IconvCacheUsed - 1].tocode1);
+      iconv_close(IconvCache[IconvCacheUsed - 1].cd);
+      --IconvCacheUsed;
+    }
+
+    /* make room for this one at the top */
+    for (int j = IconvCacheUsed; j-- > 0;)
+    {
+      IconvCache[j + 1] = IconvCache[j];
+    }
+
+    ++IconvCacheUsed;
+
+    mutt_debug(LL_DEBUG2, "iconv: adding %s -> %s to the cache\n", fromcode1, tocode1);
+    IconvCache[0].fromcode1 = strdup(fromcode1);
+    IconvCache[0].tocode1 = strdup(tocode1);
+    IconvCache[0].cd = cd;
+  }
+
+  return cd;
 }
 
 /**
@@ -731,7 +800,6 @@ int mutt_ch_check(const char *s, size_t slen, const char *from, const char *to)
     rc = errno;
 
   FREE(&saved_out);
-  iconv_close(cd);
   return rc;
 }
 
@@ -782,7 +850,6 @@ int mutt_ch_convert_string(char **ps, const char *from, const char *to, uint8_t 
   size_t ibl = strlen(s);
   if (ibl >= (SIZE_MAX / MB_LEN_MAX))
   {
-    iconv_close(cd);
     return -1;
   }
   size_t obl = MB_LEN_MAX * ibl;
@@ -791,7 +858,6 @@ int mutt_ch_convert_string(char **ps, const char *from, const char *to, uint8_t 
 
   mutt_ch_iconv(cd, &ib, &ibl, &ob, &obl, inrepls, outrepl, &rc);
   iconv(cd, 0, 0, &ob, &obl);
-  iconv_close(cd);
 
   *ob = '\0';
 
@@ -836,7 +902,6 @@ bool mutt_ch_check_charset(const char *cs, bool strict)
   iconv_t cd = mutt_ch_iconv_open(cs, cs, MUTT_ICONV_NO_FLAGS);
   if (cd != (iconv_t) (-1))
   {
-    iconv_close(cd);
     return true;
   }
 
@@ -890,8 +955,6 @@ void mutt_ch_fgetconv_close(struct FgetConv **fc)
   if (!fc || !*fc)
     return;
 
-  if ((*fc)->cd != (iconv_t) -1)
-    iconv_close((*fc)->cd);
   FREE(fc);
 }
 
@@ -1095,4 +1158,18 @@ char *mutt_ch_choose(const char *fromcode, const struct Slist *charsets,
     mutt_str_replace(&tocode, canonical_buf);
   }
   return tocode;
+}
+
+/**
+ * mutt_ch_cache_cleanup - Clean up the cached iconv handles and charset strings
+ */
+void mutt_ch_cache_cleanup(void)
+{
+  for (int i = 0; i < IconvCacheUsed; ++i)
+  {
+    FREE(&IconvCache[i].fromcode1);
+    FREE(&IconvCache[i].tocode1);
+    iconv_close(IconvCache[i].cd);
+  }
+  IconvCacheUsed = 0;
 }

--- a/mutt/charset.c
+++ b/mutt/charset.c
@@ -604,7 +604,7 @@ iconv_t mutt_ch_iconv_open(const char *tocode, const char *fromcode, uint8_t fla
   }
 
   /* check if we have this pair cached already */
-  iconv_t cd = (iconv_t) -1;
+  iconv_t cd = ICONV_T_INVALID;
   for (int i = 0; i < IconvCacheUsed; ++i)
   {
     if (strcmp(tocode1, IconvCache[i].tocode1) == 0 &&
@@ -626,7 +626,7 @@ iconv_t mutt_ch_iconv_open(const char *tocode, const char *fromcode, uint8_t fla
     }
   }
 
-  if (cd == (iconv_t) -1) /* not found in cache */
+  if (!iconv_t_valid(cd)) /* not found in cache */
   {
     /* always apply iconv-hooks to suit system's iconv tastes */
     tocode2 = mutt_ch_iconv_lookup(tocode1);
@@ -788,7 +788,7 @@ int mutt_ch_check(const char *s, size_t slen, const char *from, const char *to)
 
   int rc = 0;
   iconv_t cd = mutt_ch_iconv_open(to, from, MUTT_ICONV_NO_FLAGS);
-  if (cd == (iconv_t) -1)
+  if (!iconv_t_valid(cd))
     return -1;
 
   size_t outlen = MB_LEN_MAX * slen;
@@ -833,7 +833,7 @@ int mutt_ch_convert_string(char **ps, const char *from, const char *to, uint8_t 
   int rc = 0;
 
   iconv_t cd = mutt_ch_iconv_open(to, from, flags);
-  if (cd == (iconv_t) -1)
+  if (!iconv_t_valid(cd))
     return -1;
 
   const char **inrepls = NULL;
@@ -900,7 +900,7 @@ bool mutt_ch_check_charset(const char *cs, bool strict)
   }
 
   iconv_t cd = mutt_ch_iconv_open(cs, cs, MUTT_ICONV_NO_FLAGS);
-  if (cd != (iconv_t) (-1))
+  if (iconv_t_valid(cd))
   {
     return true;
   }
@@ -921,12 +921,12 @@ bool mutt_ch_check_charset(const char *cs, bool strict)
 struct FgetConv *mutt_ch_fgetconv_open(FILE *fp, const char *from, const char *to, uint8_t flags)
 {
   struct FgetConv *fc = NULL;
-  iconv_t cd = (iconv_t) -1;
+  iconv_t cd = ICONV_T_INVALID;
 
   if (from && to)
     cd = mutt_ch_iconv_open(to, from, flags);
 
-  if (cd != (iconv_t) -1)
+  if (iconv_t_valid(cd))
   {
     static const char *repls[] = { "\357\277\275", "?", 0 };
 
@@ -972,7 +972,7 @@ int mutt_ch_fgetconv(struct FgetConv *fc)
 {
   if (!fc)
     return EOF;
-  if (fc->cd == (iconv_t) -1)
+  if (!iconv_t_valid(fc->cd))
     return fgetc(fc->fp);
   if (!fc->p)
     return EOF;

--- a/mutt/charset.h
+++ b/mutt/charset.h
@@ -40,7 +40,7 @@ extern wchar_t ReplacementChar;
 struct FgetConv
 {
   FILE *fp;
-  iconv_t cd;
+  iconv_t cd; ///< iconv conversion descriptor
   char bufi[512];
   char bufo[512];
   char *p;
@@ -56,7 +56,7 @@ struct FgetConv
 struct FgetConvNot
 {
   FILE *fp;
-  iconv_t cd;
+  iconv_t cd; ///< iconv conversion descriptor
 };
 
 /**
@@ -95,5 +95,21 @@ void             mutt_ch_cache_cleanup(void);
 
 #define mutt_ch_is_utf8(str)     mutt_ch_chscmp(str, "utf-8")
 #define mutt_ch_is_us_ascii(str) mutt_ch_chscmp(str, "us-ascii")
+
+/// Error value for iconv functions
+#define ICONV_T_INVALID ((iconv_t) -1)
+
+/// Error value for iconv()
+#define ICONV_ERROR ((size_t) -1)
+
+/**
+ * iconv_t_valid - Is the conversion descriptor valid?
+ * @param cd Conversion descriptor to test
+ * @retval true It's valid
+ */
+static inline bool iconv_t_valid(const iconv_t cd)
+{
+  return cd != ICONV_T_INVALID;
+}
 
 #endif /* MUTT_LIB_CHARSET_H */

--- a/mutt/charset.h
+++ b/mutt/charset.h
@@ -91,6 +91,7 @@ iconv_t          mutt_ch_iconv_open(const char *tocode, const char *fromcode, ui
 bool             mutt_ch_lookup_add(enum LookupType type, const char *pat, const char *replace, struct Buffer *err);
 void             mutt_ch_lookup_remove(void);
 void             mutt_ch_set_charset(const char *charset);
+void             mutt_ch_cache_cleanup(void);
 
 #define mutt_ch_is_utf8(str)     mutt_ch_chscmp(str, "utf-8")
 #define mutt_ch_is_us_ascii(str) mutt_ch_chscmp(str, "us-ascii")

--- a/ncrypt/gnupgparse.c
+++ b/ncrypt/gnupgparse.c
@@ -115,7 +115,6 @@ static void fix_uid(char *uid)
         memcpy(uid, buf, n);
     }
     FREE(&buf);
-    iconv_close(cd);
   }
 }
 

--- a/ncrypt/gnupgparse.c
+++ b/ncrypt/gnupgparse.c
@@ -79,7 +79,7 @@ static char *chs = NULL;
 static void fix_uid(char *uid)
 {
   char *s = NULL, *d = NULL;
-  iconv_t cd;
+  iconv_t cd = ICONV_T_INVALID;
 
   for (s = uid, d = uid; *s;)
   {
@@ -94,7 +94,7 @@ static void fix_uid(char *uid)
   }
   *d = '\0';
 
-  if (chs && ((cd = mutt_ch_iconv_open(chs, "utf-8", MUTT_ICONV_NO_FLAGS)) != (iconv_t) -1))
+  if (chs && iconv_t_valid(cd = mutt_ch_iconv_open(chs, "utf-8", MUTT_ICONV_NO_FLAGS)))
   {
     int n = s - uid + 1; /* chars available in original buffer */
 

--- a/ncrypt/pgpmicalg.c
+++ b/ncrypt/pgpmicalg.c
@@ -140,7 +140,7 @@ static void pgp_dearmor(FILE *fp_in, FILE *fp_out)
     return;
   }
 
-  mutt_decode_base64(&state, end - start, false, (iconv_t) -1);
+  mutt_decode_base64(&state, end - start, false, ICONV_T_INVALID);
 }
 
 /**


### PR DESCRIPTION
Calling iconv_open() for every message can be expensive (it seems especially with some source charsets, like iso-2022-jp), and libc does not necessarily cache anything itself. Add a small LRU cache around it.

Speeds up opening a large Maildir by about 8%.

* **What does this PR do?**

* **Screenshots (if relevant)**

* **Does this PR meet the acceptance criteria?** (This is just a reminder for you,
  this section can be removed if you fulfill it.)

   - Documentation created/updated (you have to edit
     [docs/manual.xml.head](https://www.github.com/neomutt/neomutt/blob/main/docs/manual.xml.head)
     for that)

   - All builds and tests are passing

   - Added [doxygen code documentation](https://neomutt.org/dev/doxygen)
     [syntax](http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html)

   - Code follows the [style guide](https://neomutt.org/dev/code)

* **What are the relevant issue numbers?**
