### PR TITLE
mutt: do strict date parsing without regex

### DIFF
--- a/mutt/eqi.h
+++ b/mutt/eqi.h
@@ -1,0 +1,210 @@
+/**
+ * @file
+ * Case-insensitive fixed-chunk comparisons
+ *
+ * @authors
+ * Copyright (C) 2023 Steinar H. Gunderson <steinar+neomutt@gunderson.no>
+ *
+ * @copyright
+ * This program is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 2 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @page mutt_eqi Case-insensitive fixed-chunk comparisons
+ *
+ * These functions are much faster for short strings than calling
+ * mutt_istr_equal(), and are not affected by locale in any way. But you will
+ * need to do length checking yourself, and the right-hand side (b) is assumed
+ * to already be lowercased. It also is assumed to be constant, so that the
+ * generated 0x20 mask (for lowercasing) will be generated compile-time.
+ *
+ * In general, you want the fewest possible comparison calls; on most
+ * platforms, these will all generally be the same speed. So if you e.g. have
+ * an 11-byte value, it's cheaper to call eqi8() and eqi4() with a one-byte
+ * overlap than calling eqi8(), eqi2() and eqi1(). Similarly, if your value is
+ * 8 bytes, you can ignore the fact that you know what the first byte is, and
+ * do a full eqi8() compare to save time. There are helpers (e.g. eqi11()) that
+ * can help with the former.
+ */
+
+#ifndef MUTT_MUTT_EQI_H
+#define MUTT_MUTT_EQI_H
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+/**
+ * make_lowercase_mask - Create a mask to lowercase alphabetic characters
+ * @param x       Character to test
+ * @param bytenum Which byte position to set
+ * @retval num Bitmask
+ *
+ * Utility for the functions below
+ *
+ * If the character is alphabetic, then the position determines where to shift
+ * the 0x20 mask.
+ * - Position 0: 0x00000020
+ * - Position 1: 0x00002000
+ * - Position 2: 0x00200000
+ * - Position 3: 0x20000000
+ */
+static inline uint64_t make_lowercase_mask(uint64_t x, int bytenum)
+{
+  const char ch = x >> (bytenum * 8);
+  const uint64_t mask = ((ch >= 'a') && (ch <= 'z')) ? 0x20 : 0;
+  return mask << (bytenum * 8);
+}
+
+/**
+ * eqi1 - Compare two 1-byte strings, ignoring case - See: @subpage mutt_eqi
+ * @param a First string
+ * @param b Second string, must be lower case
+ * @retval true Strings match
+ */
+static inline bool eqi1(const char *a, const char b[1])
+{
+  uint8_t b8 = b[0];
+  return (*a | make_lowercase_mask(b8, 0)) == b[0];
+}
+
+/**
+ * eqi2 - Compare two 2-byte strings, ignoring case - See: @subpage mutt_eqi
+ * @param a First string
+ * @param b Second string, must be lower case
+ * @retval true Strings match
+ */
+static inline bool eqi2(const char *a, const char b[2])
+{
+  uint16_t a16, b16;
+  memcpy(&a16, a, sizeof(a16));
+  memcpy(&b16, b, sizeof(b16));
+  const uint16_t lowercase_mask = make_lowercase_mask(b16, 0) |
+                                  make_lowercase_mask(b16, 1);
+  return (a16 | lowercase_mask) == b16;
+}
+
+/**
+ * eqi4 - Compare two 4-byte strings, ignoring case - See: @subpage mutt_eqi
+ * @param a First string
+ * @param b Second string, must be lower case
+ * @retval true Strings match
+ */
+static inline bool eqi4(const char *a, const char b[4])
+{
+  uint32_t a32, b32;
+  memcpy(&a32, a, sizeof(a32));
+  memcpy(&b32, b, sizeof(b32));
+  const uint32_t lowercase_mask = make_lowercase_mask(b32, 0) |
+                                  make_lowercase_mask(b32, 1) |
+                                  make_lowercase_mask(b32, 2) |
+                                  make_lowercase_mask(b32, 3);
+  return (a32 | lowercase_mask) == b32;
+}
+
+/**
+ * eqi8 - Compare two 8-byte strings, ignoring case - See: @subpage mutt_eqi
+ * @param a First string
+ * @param b Second string, must be lower case
+ * @retval true Strings match
+ */
+static inline bool eqi8(const char *a, const char b[8])
+{
+  uint64_t a64, b64;
+  memcpy(&a64, a, sizeof(a64));
+  memcpy(&b64, b, sizeof(b64));
+  const uint64_t lowercase_mask = make_lowercase_mask(b64, 0) |
+                                  make_lowercase_mask(b64, 1) |
+                                  make_lowercase_mask(b64, 2) |
+                                  make_lowercase_mask(b64, 3) |
+                                  make_lowercase_mask(b64, 4) |
+                                  make_lowercase_mask(b64, 5) |
+                                  make_lowercase_mask(b64, 6) |
+                                  make_lowercase_mask(b64, 7);
+  return (a64 | lowercase_mask) == b64;
+}
+
+/* various helpers for increased readability */
+
+/* there's no eqi3(); consider using eqi4() instead if you can */
+
+/// eqi5 - Compare two 5-byte strings, ignoring case - See: @subpage mutt_eqi
+static inline bool eqi5(const char *a, const char b[5])
+{
+  return eqi4(a, b) && eqi1(a + 1, b + 1);
+}
+
+/// eqi6 - Compare two 6-byte strings, ignoring case - See: @subpage mutt_eqi
+static inline bool eqi6(const char *a, const char b[6])
+{
+  return eqi4(a, b) && eqi2(a + 4, b + 4);
+}
+
+/* there's no eqi7(); consider using eqi8() instead if you can */
+
+/// eqi9 - Compare two 9-byte strings, ignoring case - See: @subpage mutt_eqi
+static inline bool eqi9(const char *a, const char b[9])
+{
+  return eqi8(a, b) && eqi1(a + 8, b + 8);
+}
+
+/// eqi10 - Compare two 10-byte strings, ignoring case - See: @subpage mutt_eqi
+static inline bool eqi10(const char *a, const char b[10])
+{
+  return eqi8(a, b) && eqi2(a + 8, b + 8);
+}
+
+/// eqi11 - Compare two 11-byte strings, ignoring case - See: @subpage mutt_eqi
+static inline bool eqi11(const char *a, const char b[11])
+{
+  return eqi8(a, b) && eqi4(a + 7, b + 7);
+}
+
+/// eqi12 - Compare two 12-byte strings, ignoring case - See: @subpage mutt_eqi
+static inline bool eqi12(const char *a, const char b[12])
+{
+  return eqi8(a, b) && eqi4(a + 8, b + 8);
+}
+
+/// eqi13 - Compare two 13-byte strings, ignoring case - See: @subpage mutt_eqi
+static inline bool eqi13(const char *a, const char b[13])
+{
+  return eqi8(a, b) && eqi8(a + 5, b + 5);
+}
+
+/// eqi14 - Compare two 14-byte strings, ignoring case - See: @subpage mutt_eqi
+static inline bool eqi14(const char *a, const char b[14])
+{
+  return eqi8(a, b) && eqi8(a + 6, b + 6);
+}
+
+/// eqi15 - Compare two 15-byte strings, ignoring case - See: @subpage mutt_eqi
+static inline bool eqi15(const char *a, const char b[15])
+{
+  return eqi8(a, b) && eqi8(a + 7, b + 7);
+}
+
+/// eqi16 - Compare two 16-byte strings, ignoring case - See: @subpage mutt_eqi
+static inline bool eqi16(const char *a, const char b[16])
+{
+  return eqi8(a, b) && eqi8(a + 8, b + 8);
+}
+
+/// eqi17 - Compare two 17-byte strings, ignoring case - See: @subpage mutt_eqi
+static inline bool eqi17(const char *a, const char b[17])
+{
+  return eqi16(a, b) && eqi1(a + 16, b + 16);
+}
+
+#endif /* MUTT_MUTT_EQI_H */

--- a/mutt/lib.h
+++ b/mutt/lib.h
@@ -36,6 +36,7 @@
  * | mutt/charset.c   | @subpage mutt_charset   |
  * | mutt/date.c      | @subpage mutt_date      |
  * | mutt/envlist.c   | @subpage mutt_envlist   |
+ * | mutt/eqi.h       | @subpage mutt_eqi       |
  * | mutt/exit.c      | @subpage mutt_exit      |
  * | mutt/file.c      | @subpage mutt_file      |
  * | mutt/filter.c    | @subpage mutt_filter    |
@@ -75,6 +76,7 @@
 #include "charset.h"
 #include "date.h"
 #include "envlist.h"
+#include "eqi.h"
 #include "exit.h"
 #include "file.h"
 #include "filter.h"

--- a/mutt/prex.c
+++ b/mutt/prex.c
@@ -159,25 +159,6 @@ static struct PrexStorage *prex(enum Prex which)
       "^\\#H ([[:alnum:]_\\.-]+) ([[:alnum:]]{4}( [[:alnum:]]{4}){7})[ \t]*$"
     },
     {
-      PREX_RFC5322_DATE,
-      PREX_RFC5322_DATE_MATCH_MAX,
-      /* Spec: https://tools.ietf.org/html/rfc5322#section-3.3 */
-      "^"
-        "(" PREX_DOW ", )?"       // Day of week
-        " *"
-        "([[:digit:]]{1,2}) "     // Day
-        PREX_MONTH                // Month
-        " ([[:digit:]]{2,4}) "    // Year
-        "([[:digit:]]{2})"        // Hour
-        ":([[:digit:]]{2})"       // Minute
-        "(:([[:digit:]]{2}))?"    // Second
-        " *"
-        "("
-        "([+-][[:digit:]]{4})|"   // TZ
-        "([[:alpha:]]+)"          // Obsolete TZ
-        ")"
-    },
-    {
       PREX_RFC5322_DATE_LAX,
       PREX_RFC5322_DATE_LAX_MATCH_MAX,
       /* Spec: https://tools.ietf.org/html/rfc5322#section-3.3 */

--- a/mutt/prex.h
+++ b/mutt/prex.h
@@ -34,7 +34,6 @@ enum Prex
   PREX_URL_QUERY_KEY_VAL,     ///< `https://example.com/?[q=foo]`
   PREX_RFC2047_ENCODED_WORD,  ///< `[=?utf-8?Q?=E8=81=AA=E6=98=8E=E7=9A=84?=]`
   PREX_GNUTLS_CERT_HOST_HASH, ///<\c [\#H foo.com A76D 954B EB79 1F49 5B3A 0A0E 0681 65B1]
-  PREX_RFC5322_DATE,          ///< `[Mon, 16 Mar 2020 15:09:35 -0700]`
   PREX_RFC5322_DATE_LAX,      ///< `[Mon, (Comment) 16 Mar 2020 15:09:35 -0700]`
   PREX_IMAP_DATE,             ///< `[16-MAR-2020 15:09:35 -0700]`
   PREX_MBOX_FROM,             ///< `[From god@heaven.af.mil Sat Jan  3 01:05:34 1996]`
@@ -114,34 +113,11 @@ enum PrexGnuTlsCertHostnameMatch
 };
 
 /**
- * enum PrexRfc5322Date - Regex Matches for a RFC5322 date
- *
- * @note The []s show the matching path of the RFC5322 date
- */
-enum PrexRfc5322Date
-{
-  PREX_RFC5322_DATE_MATCH_FULL,        ///< `[Mon, 2 Mar 2020 14:32:55 +0200]`
-  PREX_RFC5322_DATE_MATCH_MAYBE_DOW,   ///< `[Mon, ]2 Mar 2020 14:32:55 +0200`
-  PREX_RFC5322_DATE_MATCH_DOW,         ///< `[Mon], 2 Mar 2020 14:32:55 +0200`
-  PREX_RFC5322_DATE_MATCH_DAY,         ///< `Tue, [3] Mar 2020 14:32:55 +0200`
-  PREX_RFC5322_DATE_MATCH_MONTH,       ///< `Tue, 3 [Jan] 2020 14:32:55 +0200`
-  PREX_RFC5322_DATE_MATCH_YEAR,        ///< `Tue, 3 Mar [2020] 14:32:55 +0200`
-  PREX_RFC5322_DATE_MATCH_HOUR,        ///< `Tue, 3 Mar 2020 [14]:32:55 +0200`
-  PREX_RFC5322_DATE_MATCH_MINUTE,      ///< `Tue, 3 Mar 2020 14:[32]:55 +0200`
-  PREX_RFC5322_DATE_MATCH_COLONSECOND, ///< `Tue, 3 Mar 2020 14:32[:55] +0200`
-  PREX_RFC5322_DATE_MATCH_SECOND,      ///< `Tue, 3 Mar 2020 14:32:[55] +0200`
-  PREX_RFC5322_DATE_MATCH_TZFULL,      ///< `Tue, 3 Mar 2020 14:32:55[CET]`
-  PREX_RFC5322_DATE_MATCH_TZ,          ///< `Tue, 3 Mar 2020 14:32:55 [+0200]`
-  PREX_RFC5322_DATE_MATCH_TZ_OBS,      ///< `Tue, 3 Mar 2020 14:32:55[UT]`
-  PREX_RFC5322_DATE_MATCH_MAX
-};
-
-/**
  * enum PrexRfc5322DateLax - Regex Matches for a RFC5322 date, including
  * obsolete comments in parentheses
  *
- * The reason we provide an alternate regex for RFC5322 dates is that the
- * non-obsolete one is faster, while this one is more complete.
+ * The reason we provide a regex for RFC5322 dates is that the regular parser
+ * is faster, while this one is more complete.
  *
  * @note The []s show the matching path of the RFC5322 date
  * @note The `*_CFWS*` constants match `()`d comments with whitespace

--- a/test/date/mutt_date_check_month.c
+++ b/test/date/mutt_date_check_month.c
@@ -34,8 +34,8 @@ void test_mutt_date_check_month(void)
   TEST_CHECK(mutt_date_check_month("ja") == -1);
   TEST_CHECK(mutt_date_check_month("Monday") == -1);
 
-  TEST_CHECK(mutt_date_check_month("jan") == 0);
-  TEST_CHECK(mutt_date_check_month("FEB") == 1);
+  TEST_CHECK(mutt_date_check_month("jan") == -1);
+  TEST_CHECK(mutt_date_check_month("FEB") == -1);
   TEST_CHECK(mutt_date_check_month("September") == 8);
   TEST_CHECK(mutt_date_check_month("SepXXXX") == 8);
 }


### PR DESCRIPTION
sscanf() is a generic and large function, which is overkill for parsing our simple 2- and 4-byte dates and years. Replace it with a trivial integer parsing routine.

Speeds up opening a large Maildir by about 3%.

* **What does this PR do?**

* **Screenshots (if relevant)**

* **Does this PR meet the acceptance criteria?** (This is just a reminder for you,
  this section can be removed if you fulfill it.)

   - Documentation created/updated (you have to edit
     [docs/manual.xml.head](https://www.github.com/neomutt/neomutt/blob/main/docs/manual.xml.head)
     for that)

   - All builds and tests are passing

   - Added [doxygen code documentation](https://neomutt.org/dev/doxygen)
     [syntax](http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html)

   - Code follows the [style guide](https://neomutt.org/dev/code)

* **What are the relevant issue numbers?**
