### PR TITLE
build: refactor testing

### DIFF
--- a/Makefile.autosetup
+++ b/Makefile.autosetup
@@ -955,9 +955,7 @@ coverage: all test
 @include @srcdir@/contrib/Makefile.autosetup
 @include @srcdir@/data/Makefile.autosetup
 @include @srcdir@/docs/Makefile.autosetup
-@if ENABLE_UNIT_TESTS
 @include @srcdir@/test/Makefile.autosetup
-@endif
 @if ENABLE_FUZZ_TESTS
 @include @srcdir@/fuzz/Makefile.autosetup
 @endif

--- a/auto.def
+++ b/auto.def
@@ -20,7 +20,7 @@ define PACKAGE_VERSION  "20230407"
 define BUGS_ADDRESS     "neomutt-devel@neomutt.org"
 
 # Subdirectories that contain additional Makefile.autosetup files
-set subdirs {po data docs contrib}
+set subdirs {po data docs contrib test}
 ###############################################################################
 
 ###############################################################################
@@ -112,7 +112,6 @@ set valid_options {
   asan=0                    => "Enable the Address Sanitizer"
   ubsan=0                   => "Enable the Undefined Behaviour Sanitizer"
   coverage=0                => "Enable Coverage Testing"
-  testing=0                 => "Enable Unit Testing"
   fuzzing                   => "Enable Fuzz Testing"
   compile-commands          => "Generate compile_commands.json (requires clang)"
 # Enable all options
@@ -132,6 +131,7 @@ set deprecated_options  {
   idn:
   with-idn:=
   pkgconf:=
+  testing:=
   with-slang:
   with-ui:=
   with-gpgme:
@@ -172,7 +172,7 @@ if {1} {
     everything fmemopen full-doc fuzzing gdbm gnutls gpgme gsasl gss homespool
     idn2 include-path-in-cflags inotify kyotocabinet lmdb locales-fix lua lz4
     mixmaster nls notmuch pcre2 pgp qdbm rocksdb sasl smime sqlite ssl
-    testing tdb tokyocabinet ubsan zlib zstd
+    tdb tokyocabinet ubsan zlib zstd
   } {
     define want-$opt [opt-bool $opt]
   }
@@ -561,13 +561,6 @@ if {[get-define want-sasl]} {
     user-error "Unable to find SASL"
   }
   define USE_SASL_CYRUS
-}
-
-###############################################################################
-# Unit Testing
-if {[get-define want-testing]} {
-  define ENABLE_UNIT_TESTS
-  lappend subdirs test
 }
 
 ###############################################################################
@@ -1115,8 +1108,6 @@ if {[get-define want-compile-commands]} {
 ###############################################################################
 # Coverage Testing
 if {[get-define want-coverage]} {
-  define ENABLE_UNIT_TESTS
-  lappend subdirs test
   define ENABLE_COVERAGE
   define-append CFLAGS -fprofile-arcs -ftest-coverage
   define-append LDFLAGS -fprofile-arcs -ftest-coverage

--- a/test/Makefile.autosetup
+++ b/test/Makefile.autosetup
@@ -658,7 +658,6 @@ TEST_OBJS	= test/main.o test/common.o \
 		  $(TAGS_OBJS) \
 		  $(THREAD_OBJS) \
 		  $(URL_OBJS)
-ALLOBJS+=   $(TEST_OBJS)
 
 CFLAGS	+= -I$(SRCDIR)/test
 

--- a/test/Makefile.autosetup
+++ b/test/Makefile.autosetup
@@ -663,22 +663,8 @@ CFLAGS	+= -I$(SRCDIR)/test
 
 TEST_BINARY = test/neomutt-test$(EXEEXT)
 
-pre-req:
-	@if ! test -n "$(NEOMUTT_TEST_DIR)"; then \
-		echo "Environment variable NEOMUTT_TEST_DIR isn't set."; \
-		echo "The test files and instructions can be found here:"; \
-		echo "    https://github.com/neomutt/neomutt-test-files"; \
-		false; \
-	fi
-	@if ! test -f "$(NEOMUTT_TEST_DIR)/setup.sh"; then \
-		echo "The test files don't exist in NEOMUTT_TEST_DIR."; \
-		echo "Instructions can be found here:"; \
-		echo "    https://github.com/neomutt/neomutt-test-files"; \
-		false; \
-	fi
-
 .PHONY: test
-test: $(TEST_BINARY) pre-req
+test: $(TEST_BINARY)
 	$(TEST_BINARY)
 
 $(BUILD_DIRS):

--- a/test/Makefile.autosetup
+++ b/test/Makefile.autosetup
@@ -664,8 +664,22 @@ CFLAGS	+= -I$(SRCDIR)/test
 
 TEST_BINARY = test/neomutt-test$(EXEEXT)
 
+pre-req:
+	@if ! test -n "$(NEOMUTT_TEST_DIR)"; then \
+		echo "Environment variable NEOMUTT_TEST_DIR isn't set."; \
+		echo "The test files and instructions can be found here:"; \
+		echo "    https://github.com/neomutt/neomutt-test-files"; \
+		false; \
+	fi
+	@if ! test -f "$(NEOMUTT_TEST_DIR)/setup.sh"; then \
+		echo "The test files don't exist in NEOMUTT_TEST_DIR."; \
+		echo "Instructions can be found here:"; \
+		echo "    https://github.com/neomutt/neomutt-test-files"; \
+		false; \
+	fi
+
 .PHONY: test
-test: $(TEST_BINARY)
+test: $(TEST_BINARY) pre-req
 	$(TEST_BINARY)
 
 $(BUILD_DIRS):

--- a/test/Makefile.autosetup
+++ b/test/Makefile.autosetup
@@ -674,7 +674,7 @@ $(BUILD_DIRS):
 $(TEST_BINARY): $(BUILD_DIRS) $(MUTTLIBS) $(TEST_OBJS)
 	$(CC) -o $@ $(TEST_OBJS) $(MUTTLIBS) $(LDFLAGS) $(LIBS)
 
-all-test: $(TEST_BINARY)
+all-test:
 
 clean-test:
 	$(RM) $(TEST_BINARY) $(TEST_OBJS) $(TEST_OBJS:.o=.Po)


### PR DESCRIPTION
Make it more obvious how to run the NeoMutt unit tests.

- e40deede4 build: drop configure --testing option
  Always include the test Makefile, just don't build anything by default

- 2f5080c86 build: add instructions for testing
  If `$NEOMUTT_TEST_DIR` isn't set, or the directory doesn't contain `setup.sh`

---

To run the unit tests, test files must be downloaded from:

- https://github.com/neomutt/neomutt-test-files

and an environment variable must be set to point to the test files:

- `export NEOMUTT_TEST_DIR=/path/to/neomutt-test-files`
