### PR TITLE
Remove use of lmap in auto.def, provide lkill alternative

### DIFF
--- a/auto.def
+++ b/auto.def
@@ -288,6 +288,17 @@ if {1} {
       return 0
     }
   }
+
+  # lkill l p is the list of the elements in l that don't match p
+  proc lkill {l p} {
+    set res [list]
+    foreach elem $l {
+      if {![apply $p $elem]} {
+        lappend res $elem
+      }
+    }
+    set res
+  }
 }
 ###############################################################################
 
@@ -1138,9 +1149,7 @@ set conststrings "\
   unsigned char cc_cflags\[\] = {[text2c [expr {
     [get-define want-include-path-in-cflags]
     ? [get-define CFLAGS]
-    : [lmap x [get-define CFLAGS] {
-        expr {[string equal -length 2 $x {-I}] ? [continue] : $x}
-      }]
+    : [lkill [get-define CFLAGS] {{x} {string equal -length 2 $x {-I}}}]
   }]]};\n\
   unsigned char configure_options\[\] = {[text2c $conf_options]};\n"
 if {[catch {set fd [open conststrings.c w]
@@ -1225,16 +1234,8 @@ make-config-header config.h -auto $auto_rep -bare $bare_rep -str $str_rep
 
 ###############################################################################
 # Generate .clang_complete
-proc cflags-for-clang-complete {} {
-  lmap x [get-define CFLAGS] {
-    if {[string match "-MJ*" $x]} {
-      continue
-    } else {
-      set x
-    }
-  }
-}
-define cflags-one-per-line [string map {" " "\n"} [cflags-for-clang-complete]]
+define cflags-one-per-line [string map {" " "\n"} \
+  [lkill [get-define CFLAGS] {{x} {string equal -length 3 $x "-MJ"}}]]
 make-template .clang_complete.in
 
 ###############################################################################


### PR DESCRIPTION
Our two uses of lmap were limited to a simple filter on a list given a predicate. I've provided a helper function for that.
I've opted not to remove support fro Tcl8.5 not to diverge from upstream autosetup.