### PR TITLE
Only add the root SRCDIR to VPATH

### DIFF
--- a/auto.def
+++ b/auto.def
@@ -1179,16 +1179,13 @@ if {[get-define CCACHE] ne {none}} {
 
 ###############################################################################
 # Generate targets and Makefile variables for subdirectories
-set vpath "\$(SRCDIR)"
+define VPATH "\$(SRCDIR)"
 foreach dir $subdirs {
-  append vpath ":\$(SRCDIR)/$dir"
   define-append ALL_TARGETS all-$dir
   define-append CLEAN_TARGETS clean-$dir
   define-append INSTALL_TARGETS install-$dir
   define-append UNINSTALL_TARGETS uninstall-$dir
-  define-append VPATH
 }
-define VPATH $vpath
 
 ###############################################################################
 # Define package timestamp (UTC) based on PACKAGE_VERSION for:


### PR DESCRIPTION
We don't need to add all the subdirs because their .o files are listed including the subdir path.

This unbreaks `make clean; make test/neomutt-test; make neomutt`, which previously failed in the last command because the `main.o` target required by `neomutt` was resolved by `test/main.o`, for the utmost sorrow of the linker.
