### PR TITLE
Fix crash with the iconv cache

### DIFF
--- a/mutt/charset.c
+++ b/mutt/charset.c
@@ -1172,7 +1172,10 @@ void mutt_ch_cache_cleanup(void)
   {
     FREE(&IconvCache[i].fromcode1);
     FREE(&IconvCache[i].tocode1);
-    iconv_close(IconvCache[i].cd);
+    if (iconv_t_valid(IconvCache[i].cd))
+    {
+      iconv_close(IconvCache[i].cd);
+    }
   }
   IconvCacheUsed = 0;
 }


### PR DESCRIPTION
The iconv cache might contain invalid descriptors: let's not try to close them when making room for a new one.

This fixes a crash running `neomutt-test -E`, but a failure remains:

```
Test test_rfc2047_encode...                     [ FAILED ]
  Case Common setup:
    rfc2047_encode.c:69: Check test_check_str_eq... failed
      Expected : =?utf-8?Q?Kvie=C4=8Diame_drauge_pildyti_ESO_pasi=C5=BEad=C4=97jim=C5=B3_g?=
        =?utf-8?Q?irliand=C4=85!?=
      Actual   : =?apple?Q?Kvie=C4=8Diame_drauge_pildyti_ESO_pasi=C5=BEad=C4=97jim=C5=B3_g?=
        =?apple?Q?irliand=C4=85!?=
    rfc2047_encode.c:69: Check test_check_str_eq... failed
      Expected : =?utf-8?B?xJc=?=
      Actual   : =?apple?B?xJc=?=
    rfc2047_encode.c:69: Check test_check_str_eq... failed
      Expected : =?utf-8?B?6IGq5piO55qE?=    Hello
      Actual   : =?apple?B?6IGq5piO55qE?=    Hello
    rfc2047_encode.c:69: Check test_check_str_eq... failed
      Expected : Hello    =?utf-8?B?6IGq5piO55qE?=
      Actual   : Hello    =?apple?B?6IGq5piO55qE?=
    rfc2047_encode.c:69: Check test_check_str_eq... failed
      Expected : =?utf-8?B?6IGq5piO55qEICAgIOiBquaYjueahA==?=
      Actual   : =?apple?B?6IGq5piO55qEICAgIOiBquaYjueahA==?=
    rfc2047_encode.c:69: Check test_check_str_eq... failed
      Expected : =?utf-8?Q?Sicherheitsl=C3=BCcke?= in praktisch allen IT-Systemen
      Actual   : =?apple?Q?Sicherheitsl=C3=BCcke?= in praktisch allen IT-Systemen
```