### PR TITLE
test: fix `neomutt-test -E` wrt the config cache

### DIFF
--- a/config/cache.h
+++ b/config/cache.h
@@ -26,4 +26,6 @@
 const struct Slist *cc_assumed_charset(void);
 const char *        cc_charset        (void);
 
+void config_cache_free(void);
+
 #endif /* MUTT_CONFIG_CACHE_H */

--- a/main.c
+++ b/main.c
@@ -1403,6 +1403,7 @@ main_exit:
   alternates_free();
   mutt_keys_free();
   mutt_prex_free();
+  config_cache_free();
   neomutt_free(&NeoMutt);
   cs_free(&cs);
   log_queue_flush(log_disp_terminal);

--- a/test/account/account_mailbox_add.c
+++ b/test/account/account_mailbox_add.c
@@ -44,28 +44,22 @@ void test_account_mailbox_add(void)
     TEST_CHECK(account_mailbox_add(NULL, NULL) == false);
   }
 
-  {
-    test_neomutt_create();
-    TEST_CHECK(cs_register_variables(NeoMutt->sub->cs, Vars, DT_NO_FLAGS));
+  TEST_CHECK(cs_register_variables(NeoMutt->sub->cs, Vars, DT_NO_FLAGS));
 
+  {
     struct ConfigSubset *sub = cs_subset_new("account", NULL, NULL);
-    struct Account *a = account_new("dummy", sub);
+    struct Account *a = account_new("apple", sub);
     TEST_CHECK(a != NULL);
 
     TEST_CHECK(account_mailbox_add(a, NULL) == false);
 
     account_free(&a);
     cs_subset_free(&sub);
-
-    test_neomutt_destroy();
   }
 
   {
-    test_neomutt_create();
-    TEST_CHECK(cs_register_variables(NeoMutt->sub->cs, Vars, DT_NO_FLAGS));
-
     struct ConfigSubset *sub = cs_subset_new("account", NULL, NULL);
-    struct Account *a = account_new("dummy", sub);
+    struct Account *a = account_new("banana", sub);
     TEST_CHECK(a != NULL);
 
     struct Mailbox *m = mailbox_new();
@@ -74,6 +68,5 @@ void test_account_mailbox_add(void)
 
     account_free(&a);
     cs_subset_free(&sub);
-    test_neomutt_destroy();
   }
 }

--- a/test/account/account_mailbox_remove.c
+++ b/test/account/account_mailbox_remove.c
@@ -45,7 +45,6 @@ void test_account_mailbox_remove(void)
   }
 
   {
-    test_neomutt_create();
     TEST_CHECK(cs_register_variables(NeoMutt->sub->cs, Vars, DT_NO_FLAGS));
 
     struct ConfigSubset *sub = cs_subset_new("account", NULL, NULL);
@@ -61,6 +60,5 @@ void test_account_mailbox_remove(void)
     mailbox_free(&m);
     account_free(&a);
     cs_subset_free(&sub);
-    test_neomutt_destroy();
   }
 }

--- a/test/account/account_new.c
+++ b/test/account/account_new.c
@@ -45,7 +45,6 @@ void test_account_new(void)
   }
 
   {
-    test_neomutt_create();
     TEST_CHECK(cs_register_variables(NeoMutt->sub->cs, Vars, DT_NO_FLAGS));
 
     struct ConfigSubset *sub = cs_subset_new("account", NULL, NULL);
@@ -54,6 +53,5 @@ void test_account_new(void)
 
     account_free(&a);
     cs_subset_free(&sub);
-    test_neomutt_destroy();
   }
 }

--- a/test/address/mutt_addr_for_display.c
+++ b/test/address/mutt_addr_for_display.c
@@ -58,14 +58,11 @@ void test_mutt_addr_for_display(void)
       .intl_checked = 0,
     };
 
-    test_neomutt_create();
     TEST_CHECK(cs_register_variables(NeoMutt->sub->cs, Vars, DT_NO_FLAGS));
 
     const char *expected = "bob@bobsdomain";
     const char *actual = mutt_addr_for_display(&addr);
 
     TEST_CHECK_STR_EQ(expected, actual);
-
-    test_neomutt_destroy();
   }
 }

--- a/test/address/mutt_addrlist_to_intl.c
+++ b/test/address/mutt_addrlist_to_intl.c
@@ -64,7 +64,6 @@ void test_mutt_addrlist_to_intl(void)
                          .intl = "test@xn--nixierhre-57a.nixieclock-tube.com" },
                        { .local = "test@வலைப்பூ.com", .intl = "test@xn--xlcawl2e7azb.com" } };
 
-    test_neomutt_create();
     TEST_CHECK(cs_register_variables(NeoMutt->sub->cs, Vars, DT_NO_FLAGS));
 
     cs_subset_str_string_set(NeoMutt->sub, "charset", "utf-8", NULL);
@@ -88,7 +87,5 @@ void test_mutt_addrlist_to_intl(void)
       TEST_CHECK_STR_EQ(local2intl[i].local, a->mailbox);
       mutt_addrlist_clear(&al);
     }
-
-    test_neomutt_destroy();
   }
 }

--- a/test/address/mutt_addrlist_write_list.c
+++ b/test/address/mutt_addrlist_write_list.c
@@ -38,7 +38,6 @@ static struct ConfigDef Vars[] = {
 void test_mutt_addrlist_write_list(void)
 {
   {
-    test_neomutt_create();
     TEST_CHECK(cs_register_variables(NeoMutt->sub->cs, Vars, DT_NO_FLAGS));
     struct AddressList al = TAILQ_HEAD_INITIALIZER(al);
     const char in[] = "some-group: first@example.com,second@example.com; John Doe <john@doe.org>, \"Foo J. Bar\" <foo-j-bar@baz.com>";
@@ -58,6 +57,5 @@ void test_mutt_addrlist_write_list(void)
                       out);
     mutt_addrlist_clear(&al);
     mutt_list_free(&l);
-    test_neomutt_destroy();
   }
 }

--- a/test/charset/mutt_ch_get_default_charset.c
+++ b/test/charset/mutt_ch_get_default_charset.c
@@ -34,11 +34,7 @@ void test_mutt_ch_get_default_charset(void)
   // const char *mutt_ch_get_default_charset(const struct Slist *const assumed_charset);
 
   {
-    test_neomutt_create();
-
     const char *cs = mutt_ch_get_default_charset(NULL);
     TEST_CHECK(strlen(cs) != 0);
-
-    test_neomutt_destroy();
   }
 }

--- a/test/common.c
+++ b/test/common.c
@@ -161,6 +161,7 @@ done:
 
 void test_fini(void)
 {
+  config_cache_free();
   test_neomutt_destroy();
   buf_pool_free();
 }

--- a/test/common.c
+++ b/test/common.c
@@ -78,6 +78,40 @@ void test_gen_path(char *buf, size_t buflen, const char *fmt)
   snprintf(buf, buflen, NONULL(fmt), NONULL(get_test_dir()));
 }
 
+bool test_neomutt_create(void)
+{
+  struct ConfigSet *cs = cs_new(50);
+  CONFIG_INIT_TYPE(cs, Address);
+  CONFIG_INIT_TYPE(cs, Bool);
+  CONFIG_INIT_TYPE(cs, Enum);
+  CONFIG_INIT_TYPE(cs, Long);
+  CONFIG_INIT_TYPE(cs, Mbtable);
+  CONFIG_INIT_TYPE(cs, MyVar);
+  CONFIG_INIT_TYPE(cs, Number);
+  CONFIG_INIT_TYPE(cs, Path);
+  CONFIG_INIT_TYPE(cs, Quad);
+  CONFIG_INIT_TYPE(cs, Regex);
+  CONFIG_INIT_TYPE(cs, Slist);
+  CONFIG_INIT_TYPE(cs, Sort);
+  CONFIG_INIT_TYPE(cs, String);
+
+  NeoMutt = neomutt_new(cs);
+  TEST_CHECK(NeoMutt != NULL);
+
+  TEST_CHECK(cs_register_variables(cs, Vars, DT_NO_FLAGS));
+
+  init_tmp_dir(NeoMutt);
+
+  return NeoMutt;
+}
+
+void test_neomutt_destroy(void)
+{
+  struct ConfigSet *cs = NeoMutt->sub->cs;
+  neomutt_free(&NeoMutt);
+  cs_free(&cs);
+}
+
 void test_init(void)
 {
   const char *path = get_test_dir();
@@ -118,6 +152,7 @@ void test_init(void)
     goto done;
   }
 
+  test_neomutt_create();
   success = true;
 done:
   if (!success)
@@ -126,41 +161,8 @@ done:
 
 void test_fini(void)
 {
+  test_neomutt_destroy();
   buf_pool_free();
-}
-
-bool test_neomutt_create(void)
-{
-  struct ConfigSet *cs = cs_new(50);
-  CONFIG_INIT_TYPE(cs, Address);
-  CONFIG_INIT_TYPE(cs, Bool);
-  CONFIG_INIT_TYPE(cs, Enum);
-  CONFIG_INIT_TYPE(cs, Long);
-  CONFIG_INIT_TYPE(cs, Mbtable);
-  CONFIG_INIT_TYPE(cs, MyVar);
-  CONFIG_INIT_TYPE(cs, Number);
-  CONFIG_INIT_TYPE(cs, Path);
-  CONFIG_INIT_TYPE(cs, Quad);
-  CONFIG_INIT_TYPE(cs, Regex);
-  CONFIG_INIT_TYPE(cs, Slist);
-  CONFIG_INIT_TYPE(cs, Sort);
-  CONFIG_INIT_TYPE(cs, String);
-
-  NeoMutt = neomutt_new(cs);
-  TEST_CHECK(NeoMutt != NULL);
-
-  TEST_CHECK(cs_register_variables(cs, Vars, DT_NO_FLAGS));
-
-  init_tmp_dir(NeoMutt);
-
-  return NeoMutt;
-}
-
-void test_neomutt_destroy(void)
-{
-  struct ConfigSet *cs = NeoMutt->sub->cs;
-  neomutt_free(&NeoMutt);
-  cs_free(&cs);
 }
 
 struct IndexSharedData *index_shared_data_new(void)

--- a/test/config/account.c
+++ b/test/config/account.c
@@ -46,7 +46,6 @@ void test_config_account(void)
   struct Buffer *err = buf_pool_get();
 
   int rc = 0;
-  test_neomutt_create();
   struct ConfigSet *cs = NeoMutt->sub->cs;
 
   if (!TEST_CHECK(cs_register_variables(cs, Vars, DT_NO_FLAGS)))
@@ -237,6 +236,5 @@ void test_config_account(void)
   account_free(&a);
   cs_subset_free(&sub);
   buf_pool_release(&err);
-  test_neomutt_destroy();
   log_line(__func__);
 }

--- a/test/config/address.c
+++ b/test/config/address.c
@@ -611,7 +611,6 @@ ti_out:
 
 void test_config_address(void)
 {
-  test_neomutt_create();
   struct ConfigSubset *sub = NeoMutt->sub;
   struct ConfigSet *cs = sub->cs;
 
@@ -634,6 +633,4 @@ void test_config_address(void)
   TEST_CHECK(test_validator(sub, err));
   TEST_CHECK(test_inherit(cs, err));
   buf_pool_release(&err);
-
-  test_neomutt_destroy();
 }

--- a/test/config/bool.c
+++ b/test/config/bool.c
@@ -788,7 +788,6 @@ static bool test_toggle(struct ConfigSubset *sub, struct Buffer *err)
 
 void test_config_bool(void)
 {
-  test_neomutt_create();
   struct ConfigSubset *sub = NeoMutt->sub;
   struct ConfigSet *cs = sub->cs;
 
@@ -812,6 +811,4 @@ void test_config_bool(void)
   TEST_CHECK(test_inherit(cs, err));
   TEST_CHECK(test_toggle(sub, err));
   buf_pool_release(&err);
-
-  test_neomutt_destroy();
 }

--- a/test/config/cache.c
+++ b/test/config/cache.c
@@ -37,7 +37,6 @@ void test_config_cache(void)
 {
   log_line(__func__);
 
-  test_neomutt_create();
   struct ConfigSubset *sub = NeoMutt->sub;
 
   {
@@ -50,6 +49,5 @@ void test_config_cache(void)
     TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS);
   }
 
-  test_neomutt_destroy();
   log_line(__func__);
 }

--- a/test/config/enum.c
+++ b/test/config/enum.c
@@ -668,7 +668,6 @@ ti_out:
 
 void test_config_enum(void)
 {
-  test_neomutt_create();
   struct ConfigSubset *sub = NeoMutt->sub;
   struct ConfigSet *cs = sub->cs;
 
@@ -690,6 +689,5 @@ void test_config_enum(void)
   TEST_CHECK(test_inherit(cs, err));
   buf_pool_release(&err);
 
-  test_neomutt_destroy();
   log_line(__func__);
 }

--- a/test/config/helpers.c
+++ b/test/config/helpers.c
@@ -90,7 +90,6 @@ static struct ConfigDef Vars[] = {
 
 void test_config_helpers(void)
 {
-  test_neomutt_create();
   TEST_CHECK(cs_register_variables(NeoMutt->sub->cs, Vars, DT_NO_FLAGS));
 
   struct ConfigSubset *sub = NeoMutt->sub;
@@ -107,6 +106,4 @@ void test_config_helpers(void)
   TEST_CHECK(cs_subset_slist(sub, "Olive") != NULL);
   TEST_CHECK(cs_subset_sort(sub, "Mango") == 1);
   TEST_CHECK_STR_EQ(cs_subset_string(sub, "Nectarine"), "nectarine");
-
-  test_neomutt_destroy();
 }

--- a/test/config/initial.c
+++ b/test/config/initial.c
@@ -93,7 +93,6 @@ void test_config_initial(void)
 {
   log_line(__func__);
 
-  test_neomutt_create();
   struct ConfigSubset *sub = NeoMutt->sub;
   struct ConfigSet *cs = sub->cs;
 
@@ -107,11 +106,9 @@ void test_config_initial(void)
   struct Buffer *err = buf_pool_get();
   if (!TEST_CHECK(test_set_initial(sub, err)))
   {
-    test_neomutt_destroy();
     buf_pool_release(&err);
     return;
   }
 
-  test_neomutt_destroy();
   buf_pool_release(&err);
 }

--- a/test/config/long.c
+++ b/test/config/long.c
@@ -828,7 +828,6 @@ ti_out:
 
 void test_config_long(void)
 {
-  test_neomutt_create();
   struct ConfigSubset *sub = NeoMutt->sub;
   struct ConfigSet *cs = sub->cs;
 
@@ -853,6 +852,4 @@ void test_config_long(void)
   TEST_CHECK(test_validator(sub, err));
   TEST_CHECK(test_inherit(cs, err));
   buf_pool_release(&err);
-
-  test_neomutt_destroy();
 }

--- a/test/config/mbtable.c
+++ b/test/config/mbtable.c
@@ -628,7 +628,6 @@ ti_out:
 
 void test_config_mbtable(void)
 {
-  test_neomutt_create();
   struct ConfigSubset *sub = NeoMutt->sub;
   struct ConfigSet *cs = sub->cs;
 
@@ -651,6 +650,4 @@ void test_config_mbtable(void)
   TEST_CHECK(test_validator(sub, err));
   TEST_CHECK(test_inherit(cs, err));
   buf_pool_release(&err);
-
-  test_neomutt_destroy();
 }

--- a/test/config/myvar.c
+++ b/test/config/myvar.c
@@ -597,7 +597,6 @@ ti_out:
 
 void test_config_myvar(void)
 {
-  test_neomutt_create();
   struct ConfigSubset *sub = NeoMutt->sub;
   struct ConfigSet *cs = sub->cs;
 
@@ -621,6 +620,4 @@ void test_config_myvar(void)
   TEST_CHECK(test_reset(sub, err));
   TEST_CHECK(test_inherit(cs, err));
   buf_pool_release(&err);
-
-  test_neomutt_destroy();
 }

--- a/test/config/number.c
+++ b/test/config/number.c
@@ -913,7 +913,6 @@ ti_out:
 
 void test_config_number(void)
 {
-  test_neomutt_create();
   struct ConfigSubset *sub = NeoMutt->sub;
   struct ConfigSet *cs = sub->cs;
 
@@ -938,6 +937,4 @@ void test_config_number(void)
   TEST_CHECK(test_validator(sub, err));
   TEST_CHECK(test_inherit(cs, err));
   buf_pool_release(&err);
-
-  test_neomutt_destroy();
 }

--- a/test/config/path.c
+++ b/test/config/path.c
@@ -645,7 +645,6 @@ ti_out:
 
 void test_config_path(void)
 {
-  test_neomutt_create();
   struct ConfigSubset *sub = NeoMutt->sub;
   struct ConfigSet *cs = sub->cs;
 
@@ -668,6 +667,4 @@ void test_config_path(void)
   TEST_CHECK(test_validator(sub, err));
   TEST_CHECK(test_inherit(cs, err));
   buf_pool_release(&err);
-
-  test_neomutt_destroy();
 }

--- a/test/config/quad.c
+++ b/test/config/quad.c
@@ -724,7 +724,6 @@ static bool test_toggle(struct ConfigSubset *sub, struct Buffer *err)
 
 void test_config_quad(void)
 {
-  test_neomutt_create();
   struct ConfigSubset *sub = NeoMutt->sub;
   struct ConfigSet *cs = sub->cs;
 
@@ -748,6 +747,4 @@ void test_config_quad(void)
   TEST_CHECK(test_inherit(cs, err));
   TEST_CHECK(test_toggle(sub, err));
   buf_pool_release(&err);
-
-  test_neomutt_destroy();
 }

--- a/test/config/regex.c
+++ b/test/config/regex.c
@@ -687,7 +687,6 @@ ti_out:
 
 void test_config_regex(void)
 {
-  test_neomutt_create();
   struct ConfigSubset *sub = NeoMutt->sub;
   struct ConfigSet *cs = sub->cs;
 
@@ -710,6 +709,4 @@ void test_config_regex(void)
   TEST_CHECK(test_validator(sub, err));
   TEST_CHECK(test_inherit(cs, err));
   buf_pool_release(&err);
-
-  test_neomutt_destroy();
 }

--- a/test/config/set.c
+++ b/test/config/set.c
@@ -351,8 +351,6 @@ void test_config_set(void)
   if (!TEST_CHECK(cs != NULL))
     return;
 
-  test_neomutt_create();
-
   const struct ConfigSetType CstDummy = {
     DT_STRING, "dummy", NULL, NULL, NULL, NULL, NULL, NULL,
   };
@@ -490,7 +488,6 @@ void test_config_set(void)
   if (!creation_and_deletion_tests(cs, err))
     return;
 
-  test_neomutt_destroy();
   cs_free(&cs);
   buf_pool_release(&err);
   log_line(__func__);

--- a/test/config/slist.c
+++ b/test/config/slist.c
@@ -1124,7 +1124,6 @@ bool slist_test_separator(struct ConfigDef vars[], struct Buffer *err)
 {
   log_line(__func__);
 
-  test_neomutt_create();
   struct ConfigSubset *sub = NeoMutt->sub;
   struct ConfigSet *cs = sub->cs;
 
@@ -1145,7 +1144,14 @@ bool slist_test_separator(struct ConfigDef vars[], struct Buffer *err)
   if (!test_string_get(sub, err))
     return false;
 
-  test_neomutt_destroy();
+  cs_str_delete(cs, "Apple", NULL);
+  cs_str_delete(cs, "Banana", NULL);
+  cs_str_delete(cs, "Cherry", NULL);
+  cs_str_delete(cs, "Damson", NULL);
+  cs_str_delete(cs, "Elderberry", NULL);
+  cs_str_delete(cs, "Fig", NULL);
+  cs_str_delete(cs, "Guava", NULL);
+  cs_str_delete(cs, "Hawthorn", NULL);
   return true;
 }
 
@@ -1165,7 +1171,6 @@ void test_config_slist(void)
   TEST_CHECK(slist_test_separator(VarsComma, err));
   TEST_CHECK(slist_test_separator(VarsSpace, err));
 
-  test_neomutt_create();
   struct ConfigSubset *sub = NeoMutt->sub;
   struct ConfigSet *cs = sub->cs;
 
@@ -1186,6 +1191,5 @@ void test_config_slist(void)
   TEST_CHECK(test_inherit(cs, err));
   buf_pool_release(&err);
 
-  test_neomutt_destroy();
   log_line(__func__);
 }

--- a/test/config/sort.c
+++ b/test/config/sort.c
@@ -755,7 +755,6 @@ static bool test_sort_type(struct ConfigSubset *sub, struct Buffer *err)
 
 void test_config_sort(void)
 {
-  test_neomutt_create();
   struct ConfigSubset *sub = NeoMutt->sub;
   struct ConfigSet *cs = sub->cs;
 
@@ -783,6 +782,4 @@ void test_config_sort(void)
   TEST_CHECK(test_inherit(cs, err));
   TEST_CHECK(test_sort_type(sub, err));
   buf_pool_release(&err);
-
-  test_neomutt_destroy();
 }

--- a/test/config/string.c
+++ b/test/config/string.c
@@ -759,7 +759,6 @@ ti_out:
 
 void test_config_string(void)
 {
-  test_neomutt_create();
   struct ConfigSubset *sub = NeoMutt->sub;
   struct ConfigSet *cs = sub->cs;
 
@@ -783,6 +782,4 @@ void test_config_string(void)
   TEST_CHECK(test_validator(sub, err));
   TEST_CHECK(test_inherit(cs, err));
   buf_pool_release(&err);
-
-  test_neomutt_destroy();
 }

--- a/test/config/subset.c
+++ b/test/config/subset.c
@@ -54,11 +54,11 @@ void test_config_subset(void)
   if (!TEST_CHECK(cs_register_variables(cs, Vars, DT_NO_FLAGS)))
     return;
 
-  NeoMutt = neomutt_new(cs);
+  struct NeoMutt *n = neomutt_new(cs);
 
   cs_subset_free(NULL);
 
-  struct ConfigSubset *sub_a = cs_subset_new("account", NeoMutt->sub, NeoMutt->notify);
+  struct ConfigSubset *sub_a = cs_subset_new("account", n->sub, n->notify);
   sub_a->cs = cs;
   struct ConfigSubset *sub_m = cs_subset_new("mailbox", sub_a, sub_a->notify);
   sub_m->cs = cs;
@@ -77,7 +77,7 @@ void test_config_subset(void)
     return;
   }
 
-  he = cs_subset_lookup(NeoMutt->sub, name);
+  he = cs_subset_lookup(n->sub, name);
   if (!TEST_CHECK(he != NULL))
   {
     TEST_MSG("cs_subset_lookup failed\n");
@@ -94,7 +94,7 @@ void test_config_subset(void)
   }
 
   buf_reset(err);
-  value = cs_subset_he_native_get(NeoMutt->sub, he, err);
+  value = cs_subset_he_native_get(n->sub, he, err);
   if (!TEST_CHECK(value != INT_MIN))
   {
     TEST_MSG("cs_subset_he_native_get failed\n");
@@ -102,7 +102,7 @@ void test_config_subset(void)
   }
 
   buf_reset(err);
-  value = cs_subset_str_native_get(NeoMutt->sub, name, err);
+  value = cs_subset_str_native_get(n->sub, name, err);
   if (!TEST_CHECK(value != INT_MIN))
   {
     TEST_MSG("cs_subset_str_native_get failed\n");
@@ -118,7 +118,7 @@ void test_config_subset(void)
   }
 
   buf_reset(err);
-  rc = cs_subset_he_native_set(NeoMutt->sub, he, value + 100, err);
+  rc = cs_subset_he_native_set(n->sub, he, value + 100, err);
   if (!TEST_CHECK(value != INT_MIN))
   {
     TEST_MSG("cs_subset_he_native_set failed\n");
@@ -126,7 +126,7 @@ void test_config_subset(void)
   }
 
   buf_reset(err);
-  rc = cs_subset_str_native_set(NeoMutt->sub, name, value + 100, err);
+  rc = cs_subset_str_native_set(n->sub, name, value + 100, err);
   if (!TEST_CHECK(value != INT_MIN))
   {
     TEST_MSG("cs_subset_str_native_set failed\n");
@@ -135,7 +135,7 @@ void test_config_subset(void)
 
   buf_reset(err);
   expected = "142";
-  rc = cs_subset_he_string_get(NeoMutt->sub, he, err);
+  rc = cs_subset_he_string_get(n->sub, he, err);
   if (!TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS) ||
       !TEST_CHECK_STR_EQ(buf_string(err), expected))
   {
@@ -152,7 +152,7 @@ void test_config_subset(void)
 
   buf_reset(err);
   expected = "142";
-  rc = cs_subset_str_string_get(NeoMutt->sub, name, err);
+  rc = cs_subset_str_string_get(n->sub, name, err);
   if (!TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS) ||
       !TEST_CHECK_STR_EQ(buf_string(err), expected))
   {
@@ -170,7 +170,7 @@ void test_config_subset(void)
 
   buf_reset(err);
   expected = "678";
-  rc = cs_subset_he_string_set(NeoMutt->sub, he, expected, err);
+  rc = cs_subset_he_string_set(n->sub, he, expected, err);
   if (!TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS))
   {
     TEST_MSG("cs_subset_he_string_set failed\n");
@@ -179,7 +179,7 @@ void test_config_subset(void)
 
   buf_reset(err);
   expected = "678";
-  rc = cs_subset_str_string_set(NeoMutt->sub, name, expected, err);
+  rc = cs_subset_str_string_set(n->sub, name, expected, err);
   if (!TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS))
   {
     TEST_MSG("cs_subset_str_string_set failed\n");
@@ -197,7 +197,7 @@ void test_config_subset(void)
 
   buf_reset(err);
   expected = "678";
-  rc = cs_subset_he_string_plus_equals(NeoMutt->sub, he, expected, err);
+  rc = cs_subset_he_string_plus_equals(n->sub, he, expected, err);
   if (!TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS))
   {
     TEST_MSG("cs_subset_he_string_plus_equals failed\n");
@@ -206,7 +206,7 @@ void test_config_subset(void)
 
   buf_reset(err);
   expected = "678";
-  rc = cs_subset_str_string_plus_equals(NeoMutt->sub, name, expected, err);
+  rc = cs_subset_str_string_plus_equals(n->sub, name, expected, err);
   if (!TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS))
   {
     TEST_MSG("cs_subset_str_string_plus_equals failed\n");
@@ -224,7 +224,7 @@ void test_config_subset(void)
 
   buf_reset(err);
   expected = "678";
-  rc = cs_subset_he_string_minus_equals(NeoMutt->sub, he, expected, err);
+  rc = cs_subset_he_string_minus_equals(n->sub, he, expected, err);
   if (!TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS))
   {
     TEST_MSG("cs_subset_he_string_minus_equals failed\n");
@@ -233,7 +233,7 @@ void test_config_subset(void)
 
   buf_reset(err);
   expected = "678";
-  rc = cs_subset_str_string_minus_equals(NeoMutt->sub, name, expected, err);
+  rc = cs_subset_str_string_minus_equals(n->sub, name, expected, err);
   if (!TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS))
   {
     TEST_MSG("cs_subset_str_string_minus_equals failed\n");
@@ -249,7 +249,7 @@ void test_config_subset(void)
   }
 
   buf_reset(err);
-  rc = cs_subset_he_reset(NeoMutt->sub, he, err);
+  rc = cs_subset_he_reset(n->sub, he, err);
   if (!TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS))
   {
     TEST_MSG("cs_subset_he_reset failed\n");
@@ -257,7 +257,7 @@ void test_config_subset(void)
   }
 
   buf_reset(err);
-  rc = cs_subset_str_reset(NeoMutt->sub, name, err);
+  rc = cs_subset_str_reset(n->sub, name, err);
   if (!TEST_CHECK(CSR_RESULT(rc) == CSR_SUCCESS))
   {
     TEST_MSG("cs_subset_str_reset failed\n");
@@ -304,7 +304,7 @@ void test_config_subset(void)
     return;
   }
 
-  he = cs_subset_lookup(NeoMutt->sub, name);
+  he = cs_subset_lookup(n->sub, name);
   if (!TEST_CHECK(he != NULL))
   {
     TEST_MSG("cs_subset_lookup failed\n");
@@ -314,7 +314,7 @@ void test_config_subset(void)
   cs_subset_free(&sub_m);
   cs_subset_free(&sub_a);
 
-  neomutt_free(&NeoMutt);
+  neomutt_free(&n);
   cs_free(&cs);
   buf_pool_release(&err);
   log_line(__func__);

--- a/test/config/synonym.c
+++ b/test/config/synonym.c
@@ -188,7 +188,6 @@ void test_config_synonym(void)
 {
   log_line(__func__);
 
-  test_neomutt_create();
   struct ConfigSubset *sub = NeoMutt->sub;
   struct ConfigSet *cs = sub->cs;
 
@@ -214,6 +213,4 @@ void test_config_synonym(void)
   TEST_CHECK(test_native_get(sub, err));
   TEST_CHECK(test_reset(sub, err));
   buf_pool_release(&err);
-
-  test_neomutt_destroy();
 }

--- a/test/config/variable.c
+++ b/test/config/variable.c
@@ -43,7 +43,6 @@ void test_config_variable(void)
 {
   log_line(__func__);
 
-  test_neomutt_create();
   struct ConfigSubset *sub = NeoMutt->sub;
   struct ConfigSet *cs = sub->cs;
 
@@ -123,6 +122,5 @@ void test_config_variable(void)
   }
 
   buf_pool_release(&err);
-  test_neomutt_destroy();
   log_line(__func__);
 }

--- a/test/convert/mutt_get_content_info.c
+++ b/test/convert/mutt_get_content_info.c
@@ -48,8 +48,6 @@ void test_mutt_get_content_info(void)
 
   static const char *text = "file\ncontent";
 
-  test_neomutt_create();
-
   char fname[PATH_MAX] = { 0 };
   mutt_mktemp(fname, sizeof(fname));
 
@@ -94,5 +92,4 @@ void test_mutt_get_content_info(void)
 
   mutt_body_free(&body);
   FREE(&content);
-  test_neomutt_destroy();
 }

--- a/test/core/buf_mktemp_full.c
+++ b/test/core/buf_mktemp_full.c
@@ -33,13 +33,9 @@ void test_buf_mktemp_full(void)
 {
   // void buf_mktemp_full(struct Buffer *buf, const char *prefix, const char *suffix, const char *src, int line);
 
-  test_neomutt_create();
-
   {
     struct Buffer buf = buf_make(1024);
     buf_mktemp_full(&buf, NULL, NULL, __FILE__, __LINE__);
     buf_dealloc(&buf);
   }
-
-  test_neomutt_destroy();
 }

--- a/test/core/mutt_file_mkstemp_full.c
+++ b/test/core/mutt_file_mkstemp_full.c
@@ -33,8 +33,6 @@ void test_mutt_file_mkstemp_full(void)
 {
   // FILE *mutt_file_mkstemp_full(const char *file, int line, const char *func);
 
-  test_neomutt_create();
-
   {
     FILE *fp = NULL;
     TEST_CHECK((fp = mutt_file_mkstemp_full(NULL, 0, "apple")) != NULL);
@@ -46,6 +44,4 @@ void test_mutt_file_mkstemp_full(void)
     TEST_CHECK((fp = mutt_file_mkstemp_full("apple", 0, NULL)) != NULL);
     fclose(fp);
   }
-
-  test_neomutt_destroy();
 }

--- a/test/core/mutt_mktemp_full.c
+++ b/test/core/mutt_mktemp_full.c
@@ -33,12 +33,8 @@ void test_mutt_mktemp_full(void)
 {
   // void mutt_mktemp_full(char *buf, size_t buflen, const char *prefix, const char *suffix, const char *src, int line);
 
-  test_neomutt_create();
-
   {
     char buf[256] = { 0 };
     mutt_mktemp_full(buf, sizeof(buf), NULL, NULL, __FILE__, __LINE__);
   }
-
-  test_neomutt_destroy();
 }

--- a/test/eqi/eqi.c
+++ b/test/eqi/eqi.c
@@ -92,5 +92,4 @@ void test_eqi(void)
   TEST_CHECK(eqi17("abcdefghijklmnopq", "abcdefghijklmnopq"));
   TEST_CHECK(eqi17("AbCdeFGHijKLmNoPq", "abcdefghijklmnopq"));
   TEST_CHECK(!eqi17("djeigwdjsdjfsdfjj", "abcdefghijklmnopq"));
-
 }

--- a/test/history/mutt_hist_add.c
+++ b/test/history/mutt_hist_add.c
@@ -36,13 +36,10 @@ void test_mutt_hist_add(void)
 {
   // void mutt_hist_add(enum HistoryClass hclass, const char *str, bool save);
 
-  test_neomutt_create();
   config_init_history(NeoMutt->sub->cs);
 
   {
     mutt_hist_add(0, NULL, false);
     TEST_CHECK_(1, "mutt_hist_add(0, NULL, false)");
   }
-
-  test_neomutt_destroy();
 }

--- a/test/history/mutt_hist_at_scratch.c
+++ b/test/history/mutt_hist_at_scratch.c
@@ -33,8 +33,5 @@ void test_mutt_hist_at_scratch(void)
 {
   // bool mutt_hist_at_scratch(enum HistoryClass hclass);
 
-  // test_neomutt_create();
   // config_init_history(NeoMutt->sub->cs);
-
-  // test_neomutt_destroy();
 }

--- a/test/history/mutt_hist_free.c
+++ b/test/history/mutt_hist_free.c
@@ -33,8 +33,5 @@ void test_mutt_hist_free(void)
 {
   // void mutt_hist_free(void);
 
-  // test_neomutt_create();
   // config_init_history(NeoMutt->sub->cs);
-
-  // test_neomutt_destroy();
 }

--- a/test/history/mutt_hist_init.c
+++ b/test/history/mutt_hist_init.c
@@ -33,8 +33,5 @@ void test_mutt_hist_init(void)
 {
   // void mutt_hist_init(void);
 
-  // test_neomutt_create();
   // config_init_history(NeoMutt->sub->cs);
-
-  // test_neomutt_destroy();
 }

--- a/test/history/mutt_hist_next.c
+++ b/test/history/mutt_hist_next.c
@@ -33,8 +33,5 @@ void test_mutt_hist_next(void)
 {
   // char *mutt_hist_next(enum HistoryClass hclass);
 
-  // test_neomutt_create();
   // config_init_history(NeoMutt->sub->cs);
-
-  // test_neomutt_destroy();
 }

--- a/test/history/mutt_hist_prev.c
+++ b/test/history/mutt_hist_prev.c
@@ -33,8 +33,5 @@ void test_mutt_hist_prev(void)
 {
   // char *mutt_hist_prev(enum HistoryClass hclass);
 
-  // test_neomutt_create();
   // config_init_history(NeoMutt->sub->cs);
-
-  // test_neomutt_destroy();
 }

--- a/test/history/mutt_hist_read_file.c
+++ b/test/history/mutt_hist_read_file.c
@@ -33,8 +33,5 @@ void test_mutt_hist_read_file(void)
 {
   // void mutt_hist_read_file(void);
 
-  // test_neomutt_create();
   // config_init_history(NeoMutt->sub->cs);
-
-  // test_neomutt_destroy();
 }

--- a/test/history/mutt_hist_reset_state.c
+++ b/test/history/mutt_hist_reset_state.c
@@ -33,8 +33,5 @@ void test_mutt_hist_reset_state(void)
 {
   // void mutt_hist_reset_state(enum HistoryClass hclass);
 
-  // test_neomutt_create();
   // config_init_history(NeoMutt->sub->cs);
-
-  // test_neomutt_destroy();
 }

--- a/test/history/mutt_hist_save_scratch.c
+++ b/test/history/mutt_hist_save_scratch.c
@@ -36,13 +36,10 @@ void test_mutt_hist_save_scratch(void)
 {
   // void mutt_hist_save_scratch(enum HistoryClass hclass, const char *str);
 
-  test_neomutt_create();
   config_init_history(NeoMutt->sub->cs);
 
   {
     mutt_hist_save_scratch(0, NULL);
     TEST_CHECK_(1, "mutt_hist_save_scratch(0, NULL)");
   }
-
-  test_neomutt_destroy();
 }

--- a/test/history/mutt_hist_search.c
+++ b/test/history/mutt_hist_search.c
@@ -36,7 +36,6 @@ void test_mutt_hist_search(void)
 {
   // int mutt_hist_search(const char *search_buf, enum HistoryClass hclass, char **matches);
 
-  test_neomutt_create();
   config_init_history(NeoMutt->sub->cs);
 
   {
@@ -48,6 +47,4 @@ void test_mutt_hist_search(void)
     char buf[32] = { 0 };
     TEST_CHECK(mutt_hist_search(buf, 0, NULL) == 0);
   }
-
-  test_neomutt_destroy();
 }

--- a/test/idna/mutt_idna_intl_to_local.c
+++ b/test/idna/mutt_idna_intl_to_local.c
@@ -45,7 +45,6 @@ void test_mutt_idna_intl_to_local(void)
   // char *mutt_idna_intl_to_local(const char *user, const char *domain, uint8_t flags);
 
 #ifdef HAVE_LIBIDN
-  test_neomutt_create();
   TEST_CHECK(cs_register_variables(NeoMutt->sub->cs, Vars, DT_NO_FLAGS));
 
   {
@@ -59,7 +58,5 @@ void test_mutt_idna_intl_to_local(void)
     TEST_CHECK(addr != NULL);
     FREE(&addr);
   }
-
-  test_neomutt_destroy();
 #endif
 }

--- a/test/idna/mutt_idna_local_to_intl.c
+++ b/test/idna/mutt_idna_local_to_intl.c
@@ -45,7 +45,6 @@ void test_mutt_idna_local_to_intl(void)
   // char * mutt_idna_local_to_intl(const char *user, const char *domain);
 
 #ifdef HAVE_LIBIDN
-  test_neomutt_create();
   TEST_CHECK(cs_register_variables(NeoMutt->sub->cs, Vars, DT_NO_FLAGS));
 
   {
@@ -59,7 +58,5 @@ void test_mutt_idna_local_to_intl(void)
     TEST_CHECK(addr != NULL);
     FREE(&addr);
   }
-
-  test_neomutt_destroy();
 #endif
 }

--- a/test/neo/neomutt_new.c
+++ b/test/neo/neomutt_new.c
@@ -40,8 +40,8 @@ void test_neomutt_new(void)
   // struct NeoMutt *neomutt_new(struct ConfigSet *cs);
 
   {
-    NeoMutt = neomutt_new(NULL);
-    TEST_CHECK(NeoMutt == NULL);
+    struct NeoMutt *n = neomutt_new(NULL);
+    TEST_CHECK(n == NULL);
   }
 
   {
@@ -49,10 +49,10 @@ void test_neomutt_new(void)
     cs_register_type(cs, &CstNumber);
     TEST_CHECK(cs_register_variables(cs, Vars, DT_NO_FLAGS));
 
-    NeoMutt = neomutt_new(cs);
-    TEST_CHECK(NeoMutt != NULL);
+    struct NeoMutt *n = neomutt_new(cs);
+    TEST_CHECK(n != NULL);
 
-    neomutt_free(&NeoMutt);
+    neomutt_free(&n);
     cs_free(&cs);
   }
 }

--- a/test/parse/mutt_extract_message_id.c
+++ b/test/parse/mutt_extract_message_id.c
@@ -51,8 +51,6 @@ struct TestData
 
 void test_mutt_extract_message_id(void)
 {
-  test_neomutt_create();
-
   for (size_t i = 0; i < mutt_array_size(test); i++)
   {
     size_t len = 0;
@@ -86,5 +84,4 @@ void test_mutt_extract_message_id(void)
       FREE(&tmp);
     }
   }
-  test_neomutt_destroy();
 }

--- a/test/parse/mutt_parse_mailto.c
+++ b/test/parse/mutt_parse_mailto.c
@@ -58,8 +58,6 @@ void test_mutt_parse_mailto(void)
 {
   // int mutt_parse_mailto(struct Envelope *e, char **body, const char *src);
 
-  test_neomutt_create();
-
   mutt_list_insert_head(&MailToAllow, "cc");
   mutt_list_insert_head(&MailToAllow, "body");
 
@@ -102,6 +100,4 @@ void test_mutt_parse_mailto(void)
     FREE(&parsed_body);
     mutt_env_free(&env);
   }
-
-  test_neomutt_destroy();
 }

--- a/test/parse/parse_rc.c
+++ b/test/parse/parse_rc.c
@@ -131,10 +131,8 @@ void test_parse_rc(void)
   rc = parse_rc_buffer(NULL, NULL, NULL);
   TEST_CHECK(rc == MUTT_CMD_SUCCESS);
 
-  test_neomutt_create();
   TEST_CHECK(cs_register_variables(NeoMutt->sub->cs, Vars, DT_NO_FLAGS));
   cs_str_initial_set(NeoMutt->sub->cs, "from", "rich@flatcap.org", NULL);
   cs_str_reset(NeoMutt->sub->cs, "from", NULL);
   test_parse_set();
-  test_neomutt_destroy();
 }

--- a/test/parse/parse_rc_line.c
+++ b/test/parse/parse_rc_line.c
@@ -1007,8 +1007,6 @@ static bool test_path_expanding(struct Buffer *err)
 
 void test_command_set(void)
 {
-  test_neomutt_create();
-
   if (!TEST_CHECK(cs_register_variables(NeoMutt->sub->cs, ConfigVars, DT_NO_FLAGS)))
   {
     TEST_MSG("Failed to register config variables\n");
@@ -1026,6 +1024,4 @@ void test_command_set(void)
   TEST_CHECK(test_invalid_syntax(err));
   TEST_CHECK(test_path_expanding(err));
   buf_pool_release(&err);
-
-  test_neomutt_destroy();
 }

--- a/test/pattern/leak.c
+++ b/test/pattern/leak.c
@@ -48,7 +48,6 @@ static void test_one_leak(const char *pattern)
 void test_mutt_pattern_leak(void)
 {
   MuttLogger = log_disp_null;
-  test_neomutt_create();
   TEST_CHECK(cs_register_variables(NeoMutt->sub->cs, Vars, DT_NO_FLAGS));
 
   test_one_leak("~E ~F | ~D");
@@ -122,6 +121,4 @@ void test_mutt_pattern_leak(void)
   test_one_leak("~d 01/00/2020");
   test_one_leak("~d 20210009");
   test_one_leak("~d 20210300");
-
-  test_neomutt_destroy();
 }

--- a/test/rfc2047/rfc2047_decode.c
+++ b/test/rfc2047/rfc2047_decode.c
@@ -35,8 +35,6 @@ void test_rfc2047_decode(void)
 {
   // void rfc2047_decode(char **pd);
 
-  test_neomutt_create();
-
   {
     rfc2047_decode(NULL);
     TEST_CHECK_(1, "rfc2047_decode(NULL)");
@@ -64,6 +62,4 @@ void test_rfc2047_decode(void)
       FREE(&s);
     }
   }
-
-  test_neomutt_destroy();
 }

--- a/test/rfc2047/rfc2047_encode.c
+++ b/test/rfc2047/rfc2047_encode.c
@@ -36,8 +36,6 @@ void test_rfc2047_encode(void)
 {
   // void rfc2047_encode(char **pd, const char *specials, int col, const struct Slist *charsets);
 
-  test_neomutt_create();
-
   {
     struct Slist *charsets = slist_parse("apple", SLIST_SEP_COLON);
     rfc2047_encode(NULL, AddressSpecials, 0, charsets);
@@ -71,6 +69,4 @@ void test_rfc2047_encode(void)
     }
     slist_free(&charsets);
   }
-
-  test_neomutt_destroy();
 }

--- a/test/rfc2047/rfc2047_encode_addrlist.c
+++ b/test/rfc2047/rfc2047_encode_addrlist.c
@@ -43,7 +43,6 @@ void test_rfc2047_encode_addrlist(void)
 {
   // void rfc2047_encode_addrlist(struct Address *addr, const char *tag);
 
-  test_neomutt_create();
   TEST_CHECK(cs_register_variables(NeoMutt->sub->cs, Vars, DT_NO_FLAGS));
 
   {
@@ -56,6 +55,4 @@ void test_rfc2047_encode_addrlist(void)
     rfc2047_encode_addrlist(&address, NULL);
     TEST_CHECK_(1, "rfc2047_encode_addrlist(&address, NULL)");
   }
-
-  test_neomutt_destroy();
 }


### PR DESCRIPTION
- 306bfa7ad test: create a NeoMutt for every test
  Rather than lots of tests creating / destroying their own NeoMutts,
  the shared code now does this for every test.
  (something I was already considering)

- 3d28070ce config cache: restore manual cleanup
  Manually call `config_cache_free()`.
  Many of the tests needed NeoMutt to be set up so they could use config.
  This meant hundreds of NeoMutts being created and destroyed,
  which in turn made the config cache hard to maintain.

Tests:
- Plain `test/neomutt-test` runs correctly
- ASAN `test/neomutt-test` runs correctly
- Plain `test/neomutt-test -E` runs correctly<sup>†</sup>
- ASAN `test/neomutt-test -E` runs correctly<sup>†</sup>

† When tests **test_filter_wait** and **test_mutt_sig_exit_handler** are excluded.