### PR TITLE
Allow percentage i18n

### DIFF
--- a/progress/window.c
+++ b/progress/window.c
@@ -162,19 +162,19 @@ static int progress_window_repaint(struct MuttWindow *win)
 
   if (wdata->size == 0)
   {
-    message_bar(wdata->win, wdata->display_percent, "%s %zu (%d%%)", wdata->msg,
+    message_bar(wdata->win, wdata->display_percent, _("%s %zu (%d%%)"), wdata->msg,
                 wdata->display_pos, wdata->display_percent);
   }
   else
   {
     if (wdata->is_bytes)
     {
-      message_bar(wdata->win, wdata->display_percent, "%s %s/%s (%d%%)", wdata->msg,
+      message_bar(wdata->win, wdata->display_percent, _("%s %s/%s (%d%%)"), wdata->msg,
                   wdata->pretty_pos, wdata->pretty_size, wdata->display_percent);
     }
     else
     {
-      message_bar(wdata->win, wdata->display_percent, "%s %zu/%zu (%d%%)", wdata->msg,
+      message_bar(wdata->win, wdata->display_percent, _("%s %zu/%zu (%d%%)"), wdata->msg,
                   wdata->display_pos, wdata->size, wdata->display_percent);
     }
   }


### PR DESCRIPTION
Some languages, including Turkish, French etc. use a different percentage display format like %100, 100 % respectively. Allowing percentage i18n makes it more coherent with the system locale settings.