### PR TITLE
Allow percentage i18n

### DIFF
--- a/pager/pbar.c
+++ b/pager/pbar.c
@@ -110,8 +110,11 @@ static int pbar_recalc(struct MuttWindow *win)
 
   if (offset < (priv->st.st_size - 1))
   {
-    snprintf(pager_progress_str, sizeof(pager_progress_str), OFF_T_FMT "%%",
-             (100 * offset / priv->st.st_size));
+    const long percent = (100 * offset) / priv->st.st_size;
+    /* L10N: Pager position percentage.
+       `%ld` is the number, `%%` is the percent symbol.
+       They may be reordered, or space inserted, if you wish. */
+    snprintf(pager_progress_str, sizeof(pager_progress_str), _("%ld%%"), percent);
   }
   else
   {

--- a/progress/window.c
+++ b/progress/window.c
@@ -162,19 +162,28 @@ static int progress_window_repaint(struct MuttWindow *win)
 
   if (wdata->size == 0)
   {
-    message_bar(wdata->win, wdata->display_percent, "%s %zu (%d%%)", wdata->msg,
+    /* L10N: Progress bar: `%s` loading text, `%zu` item count,
+       `%d` percentage, `%%` is the percent symbol.
+       `%d` and `%%` may be reordered, or space inserted, if you wish. */
+    message_bar(wdata->win, wdata->display_percent, _("%s %zu (%d%%)"), wdata->msg,
                 wdata->display_pos, wdata->display_percent);
   }
   else
   {
     if (wdata->is_bytes)
     {
-      message_bar(wdata->win, wdata->display_percent, "%s %s/%s (%d%%)", wdata->msg,
+      /* L10N: Progress bar: `%s` loading text, `%s/%s` position/size,
+         `%d` is the number, `%%` is the percent symbol.
+         `%d` and `%%` may be reordered, or space inserted, if you wish. */
+      message_bar(wdata->win, wdata->display_percent, _("%s %s/%s (%d%%)"), wdata->msg,
                   wdata->pretty_pos, wdata->pretty_size, wdata->display_percent);
     }
     else
     {
-      message_bar(wdata->win, wdata->display_percent, "%s %zu/%zu (%d%%)", wdata->msg,
+      /* L10N: Progress bar: `%s` loading text, `%zu/%zu` position/size,
+         `%d` is the number, `%%` is the percent symbol.
+         `%d` and `%%` may be reordered, or space inserted, if you wish. */
+      message_bar(wdata->win, wdata->display_percent, _("%s %zu/%zu (%d%%)"), wdata->msg,
                   wdata->display_pos, wdata->size, wdata->display_percent);
     }
   }

--- a/status.c
+++ b/status.c
@@ -296,7 +296,10 @@ static const char *status_format_str(char *buf, size_t buflen, size_t col, int c
       else
       {
         int count = (100 * (menu->top + menu->page_len)) / menu->max;
-        snprintf(tmp, sizeof(tmp), "%d%%", count);
+        /* L10N: Status bar, percentage of way through index.
+           `%d` is the number, `%%` is the percent symbol.
+           They may be reordered, or space inserted, if you wish. */
+        snprintf(tmp, sizeof(tmp), _("%d%%"), count);
         cp = tmp;
       }
       snprintf(fmt, sizeof(fmt), "%%%ss", prec);


### PR DESCRIPTION
Some languages, including Turkish, French etc. use a different percentage display format like %100, 100 % respectively. Allowing percentage i18n makes it more coherent with the system locale settings.