### PR TITLE
Refactor MxOps->msg_open() to eliminate msgno

### DIFF
--- a/compmbox/compress.c
+++ b/compmbox/compress.c
@@ -743,7 +743,7 @@ static enum MxStatus comp_mbox_close(struct Mailbox *m)
 /**
  * comp_msg_open - Open an email message in a Mailbox - Implements MxOps::msg_open() - @ingroup mx_msg_open
  */
-static bool comp_msg_open(struct Mailbox *m, struct Message *msg, int msgno)
+static bool comp_msg_open(struct Mailbox *m, struct Message *msg, struct Email *e)
 {
   if (!m->compress_info)
     return false;
@@ -755,7 +755,7 @@ static bool comp_msg_open(struct Mailbox *m, struct Message *msg, int msgno)
     return false;
 
   /* Delegate */
-  return ops->msg_open(m, msg, msgno);
+  return ops->msg_open(m, msg, e);
 }
 
 /**

--- a/copy.c
+++ b/copy.c
@@ -952,8 +952,11 @@ int mutt_append_message(struct Mailbox *m_dst, struct Mailbox *m_src,
                         struct Email *e, struct Message *msg,
                         CopyMessageFlags cmflags, CopyHeaderFlags chflags)
 {
+  if (!e)
+    return -1;
+
   const bool own_msg = !msg;
-  if (own_msg && !(msg = mx_msg_open(m_src, e->msgno)))
+  if (own_msg && !(msg = mx_msg_open(m_src, e)))
   {
     return -1;
   }

--- a/core/mxapi.h
+++ b/core/mxapi.h
@@ -224,17 +224,17 @@ struct MxOps
    * @ingroup mx_api
    *
    * msg_open - Open an email message in a Mailbox
-   * @param m     Mailbox
-   * @param msg   Message to open
-   * @param msgno Index of message to open
+   * @param m   Mailbox
+   * @param msg Message to open
+   * @param e   Email to open
    * @retval true Success
    * @retval false Error
    *
    * @pre m   is not NULL
    * @pre msg is not NULL
-   * @pre 0 <= msgno < msg->msg_count
+   * @pre e   is not NULL
    */
-  bool (*msg_open)(struct Mailbox *m, struct Message *msg, int msgno);
+  bool (*msg_open)(struct Mailbox *m, struct Message *msg, struct Email *e);
 
   /**
    * @defgroup mx_msg_open_new msg_open_new()

--- a/external.c
+++ b/external.c
@@ -170,7 +170,7 @@ void ci_bounce_message(struct Mailbox *m, struct EmailList *el)
   struct Message *msg = NULL;
   STAILQ_FOREACH(en, el, entries)
   {
-    msg = mx_msg_open(m, en->email->msgno);
+    msg = mx_msg_open(m, en->email);
     if (!msg)
     {
       rc = -1;
@@ -256,7 +256,7 @@ static void pipe_msg(struct Mailbox *m, struct Email *e, struct Message *msg,
   const bool own_msg = !msg;
   if (own_msg)
   {
-    msg = mx_msg_open(m, e->msgno);
+    msg = mx_msg_open(m, e);
     if (!msg)
     {
       return;
@@ -309,7 +309,7 @@ static int pipe_message(struct Mailbox *m, struct EmailList *el, const char *cmd
     /* handle a single message */
     mutt_message_hook(m, en->email, MUTT_MESSAGE_HOOK);
 
-    struct Message *msg = mx_msg_open(m, en->email->msgno);
+    struct Message *msg = mx_msg_open(m, en->email);
     if (msg && (WithCrypto != 0) && decode)
     {
       mutt_parse_mime_message(en->email, msg->fp);
@@ -344,7 +344,7 @@ static int pipe_message(struct Mailbox *m, struct EmailList *el, const char *cmd
     {
       STAILQ_FOREACH(en, el, entries)
       {
-        struct Message *msg = mx_msg_open(m, en->email->msgno);
+        struct Message *msg = mx_msg_open(m, en->email);
         if (msg)
         {
           mutt_parse_mime_message(en->email, msg->fp);
@@ -763,7 +763,7 @@ int mutt_save_message_ctx(struct Mailbox *m_src, struct Email *e, enum MessageSa
 
   set_copy_flags(e, transform_opt, &cmflags, &chflags);
 
-  struct Message *msg = mx_msg_open(m_src, e->msgno);
+  struct Message *msg = mx_msg_open(m_src, e);
   if (msg && transform_opt != TRANSFORM_NONE)
   {
     mutt_parse_mime_message(e, msg->fp);
@@ -1205,7 +1205,7 @@ static bool check_traditional_pgp(struct Mailbox *m, struct Email *e)
 
   e->security |= PGP_TRADITIONAL_CHECKED;
 
-  struct Message *msg = mx_msg_open(m, e->msgno);
+  struct Message *msg = mx_msg_open(m, e);
   if (msg)
   {
     mutt_parse_mime_message(e, msg->fp);

--- a/hdrline.c
+++ b/hdrline.c
@@ -1191,7 +1191,7 @@ static const char *index_format_str(char *buf, size_t buflen, size_t col, int co
 
     case 'X':
     {
-      struct Message *msg = mx_msg_open(m, e->msgno);
+      struct Message *msg = mx_msg_open(m, e);
       if (msg)
       {
         int count = mutt_count_body_parts(m, e, msg->fp);

--- a/imap/message.c
+++ b/imap/message.c
@@ -1938,7 +1938,7 @@ char *imap_set_flags(struct Mailbox *m, struct Email *e, char *s, bool *server_c
 /**
  * imap_msg_open - Open an email message in a Mailbox - Implements MxOps::msg_open() - @ingroup mx_msg_open
  */
-bool imap_msg_open(struct Mailbox *m, struct Message *msg, int msgno)
+bool imap_msg_open(struct Mailbox *m, struct Message *msg, struct Email *e)
 {
   struct Envelope *newenv = NULL;
   char buf[1024] = { 0 };
@@ -1956,10 +1956,6 @@ bool imap_msg_open(struct Mailbox *m, struct Message *msg, int msgno)
   struct ImapAccountData *adata = imap_adata_get(m);
 
   if (!adata || (adata->mailbox != m))
-    return false;
-
-  struct Email *e = m->emails[msgno];
-  if (!e)
     return false;
 
   msg->fp = msg_cache_get(m, e);

--- a/imap/private.h
+++ b/imap/private.h
@@ -213,7 +213,7 @@ int imap_cache_del(struct Mailbox *m, struct Email *e);
 int imap_cache_clean(struct Mailbox *m);
 int imap_append_message(struct Mailbox *m, struct Message *msg);
 
-bool imap_msg_open(struct Mailbox *m, struct Message *msg, int msgno);
+bool imap_msg_open(struct Mailbox *m, struct Message *msg, struct Email *e);
 int imap_msg_close(struct Mailbox *m, struct Message *msg);
 int imap_msg_commit(struct Mailbox *m, struct Message *msg);
 int imap_msg_save_hcache(struct Mailbox *m, struct Email *e);

--- a/index/functions.c
+++ b/index/functions.c
@@ -2216,7 +2216,7 @@ static int op_view_attachments(struct IndexSharedData *shared,
     return FR_NO_ACTION;
 
   enum FunctionRetval rc = FR_ERROR;
-  struct Message *msg = mx_msg_open(shared->mailbox, shared->email->msgno);
+  struct Message *msg = mx_msg_open(shared->mailbox, shared->email);
   if (msg)
   {
     dlg_select_attachment(NeoMutt->sub, shared->mailbox, shared->email, msg->fp);

--- a/maildir/lib.h
+++ b/maildir/lib.h
@@ -57,9 +57,9 @@ FILE *        maildir_open_find_message(const char *folder, const char *msg, cha
 void          maildir_parse_flags      (struct Email *e, const char *path);
 struct Email *maildir_parse_message    (enum MailboxType type, const char *fname, bool is_old, struct Email *e);
 struct Email *maildir_parse_stream     (enum MailboxType type, FILE *fp, const char *fname, bool is_old, struct Email *e);
-bool          maildir_sync_mailbox_message(struct Mailbox *m, int msgno, struct HeaderCache *hc);
+bool          maildir_sync_mailbox_message(struct Mailbox *m, struct Email *e, struct HeaderCache *hc);
 bool          maildir_update_flags     (struct Mailbox *m, struct Email *e_old, struct Email *e_new);
 int           mh_check_empty           (const char *path);
-int           mh_sync_mailbox_message  (struct Mailbox *m, int msgno, struct HeaderCache *hc);
+int           mh_sync_mailbox_message  (struct Mailbox *m, struct Email *e, struct HeaderCache *hc);
 
 #endif /* MUTT_MAILDIR_LIB_H */

--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -1316,7 +1316,7 @@ static enum MxStatus mbox_mbox_sync(struct Mailbox *m)
        * 'offset' in the real mailbox */
       new_offset[i - first].hdr = ftello(fp) + offset;
 
-      struct Message *msg = mx_msg_open(m, m->emails[i]->msgno);
+      struct Message *msg = mx_msg_open(m, m->emails[i]);
       const int rc2 = mutt_copy_message(fp, m->emails[i], msg, MUTT_CM_UPDATE,
                                         CH_FROM | CH_UPDATE | CH_UPDATE_LEN, 0);
       mx_msg_close(m, &msg);
@@ -1583,7 +1583,7 @@ static enum MxStatus mbox_mbox_close(struct Mailbox *m)
 /**
  * mbox_msg_open - Open an email message in a Mailbox - Implements MxOps::msg_open() - @ingroup mx_msg_open
  */
-static bool mbox_msg_open(struct Mailbox *m, struct Message *msg, int msgno)
+static bool mbox_msg_open(struct Mailbox *m, struct Message *msg, struct Email *e)
 {
   struct MboxAccountData *adata = mbox_adata_get(m);
   if (!adata)

--- a/mx.c
+++ b/mx.c
@@ -1144,14 +1144,14 @@ enum MxStatus mx_mbox_check(struct Mailbox *m)
 
 /**
  * mx_msg_open - Return a stream pointer for a message
- * @param m   Mailbox
- * @param msgno Message number
+ * @param m Mailbox
+ * @param e Email
  * @retval ptr  Message
  * @retval NULL Error
  */
-struct Message *mx_msg_open(struct Mailbox *m, int msgno)
+struct Message *mx_msg_open(struct Mailbox *m, struct Email *e)
 {
-  if (!m || !m->emails || (msgno < 0) || (msgno >= m->msg_count))
+  if (!m || !e)
     return NULL;
 
   if (!m->mx_ops || !m->mx_ops->msg_open)
@@ -1161,7 +1161,7 @@ struct Message *mx_msg_open(struct Mailbox *m, int msgno)
   }
 
   struct Message *msg = mutt_mem_calloc(1, sizeof(struct Message));
-  if (!m->mx_ops->msg_open(m, msg, msgno))
+  if (!m->mx_ops->msg_open(m, msg, e))
     FREE(&msg);
 
   return msg;

--- a/mx.h
+++ b/mx.h
@@ -50,7 +50,7 @@ enum MxStatus   mx_mbox_sync       (struct Mailbox *m);
 int             mx_msg_close       (struct Mailbox *m, struct Message **msg);
 int             mx_msg_commit      (struct Mailbox *m, struct Message *msg);
 struct Message *mx_msg_open_new    (struct Mailbox *m, const struct Email *e, MsgOpenFlags flags);
-struct Message *mx_msg_open        (struct Mailbox *m, int msgno);
+struct Message *mx_msg_open        (struct Mailbox *m, struct Email *e);
 int             mx_msg_padding_size(struct Mailbox *m);
 int             mx_save_hcache     (struct Mailbox *m, struct Email *e);
 int             mx_path_canon      (char *buf, size_t buflen, const char *folder, enum MailboxType *type);

--- a/ncrypt/crypt.c
+++ b/ncrypt/crypt.c
@@ -850,7 +850,7 @@ void crypt_extract_keys_from_messages(struct Mailbox *m, struct EmailList *el)
   STAILQ_FOREACH(en, el, entries)
   {
     struct Email *e = en->email;
-    struct Message *msg = mx_msg_open(m, e->msgno);
+    struct Message *msg = mx_msg_open(m, e);
     if (!msg)
     {
       continue;

--- a/nntp/nntp.c
+++ b/nntp/nntp.c
@@ -2589,13 +2589,9 @@ static enum MxStatus nntp_mbox_close(struct Mailbox *m)
 /**
  * nntp_msg_open - Open an email message in a Mailbox - Implements MxOps::msg_open() - @ingroup mx_msg_open
  */
-static bool nntp_msg_open(struct Mailbox *m, struct Message *msg, int msgno)
+static bool nntp_msg_open(struct Mailbox *m, struct Message *msg, struct Email *e)
 {
   struct NntpMboxData *mdata = m->mdata;
-  struct Email *e = m->emails[msgno];
-  if (!e)
-    return false;
-
   char article[16] = { 0 };
 
   /* try to get article from cache */

--- a/notmuch/notmuch.c
+++ b/notmuch/notmuch.c
@@ -2265,7 +2265,7 @@ static enum MxStatus nm_mbox_sync(struct Mailbox *m)
     buf_strcpy(&m->pathbuf, edata->folder);
     m->type = edata->type;
 
-    bool ok = maildir_sync_mailbox_message(m, i, h);
+    bool ok = maildir_sync_mailbox_message(m, e, h);
     if (!ok)
     {
       // Syncing file failed, query notmuch for new filepath.
@@ -2279,7 +2279,7 @@ static enum MxStatus nm_mbox_sync(struct Mailbox *m)
 
         buf_strcpy(&m->pathbuf, edata->folder);
         m->type = edata->type;
-        ok = maildir_sync_mailbox_message(m, i, h);
+        ok = maildir_sync_mailbox_message(m, e, h);
         m->type = MUTT_NOTMUCH;
       }
       nm_db_release(m);
@@ -2349,12 +2349,8 @@ static enum MxStatus nm_mbox_close(struct Mailbox *m)
 /**
  * nm_msg_open - Open an email message in a Mailbox - Implements MxOps::msg_open() - @ingroup mx_msg_open
  */
-static bool nm_msg_open(struct Mailbox *m, struct Message *msg, int msgno)
+static bool nm_msg_open(struct Mailbox *m, struct Message *msg, struct Email *e)
 {
-  struct Email *e = m->emails[msgno];
-  if (!e)
-    return false;
-
   char path[PATH_MAX] = { 0 };
   char *folder = nm_email_get_folder(e);
 

--- a/pager/message.c
+++ b/pager/message.c
@@ -310,7 +310,7 @@ cleanup:
  */
 int external_pager(struct Mailbox *m, struct Email *e, const char *command)
 {
-  struct Message *msg = mx_msg_open(m, e->msgno);
+  struct Message *msg = mx_msg_open(m, e);
   if (!msg)
     return -1;
 
@@ -459,7 +459,7 @@ int mutt_display_message(struct MuttWindow *win_index, struct IndexSharedData *s
   int rc = PAGER_LOOP_QUIT;
   do
   {
-    msg = mx_msg_open(shared->mailbox, shared->email->msgno);
+    msg = mx_msg_open(shared->mailbox, shared->email);
     if (!msg)
       break;
 

--- a/pattern/exec.c
+++ b/pattern/exec.c
@@ -1135,7 +1135,7 @@ bool mutt_pattern_exec(struct Pattern *pat, PatternExecFlags flags,
                        struct Mailbox *m, struct Email *e, struct PatternCache *cache)
 {
   const bool needs_msg = pattern_needs_msg(m, pat);
-  struct Message *msg = needs_msg ? mx_msg_open(m, e->msgno) : NULL;
+  struct Message *msg = needs_msg ? mx_msg_open(m, e) : NULL;
   if (needs_msg && !msg)
   {
     return false;

--- a/pop/pop.c
+++ b/pop/pop.c
@@ -972,11 +972,10 @@ static enum MxStatus pop_mbox_close(struct Mailbox *m)
 /**
  * pop_msg_open - Open an email message in a Mailbox - Implements MxOps::msg_open() - @ingroup mx_msg_open
  */
-static bool pop_msg_open(struct Mailbox *m, struct Message *msg, int msgno)
+static bool pop_msg_open(struct Mailbox *m, struct Message *msg, struct Email *e)
 {
   char buf[1024] = { 0 };
   struct PopAccountData *adata = pop_adata_get(m);
-  struct Email *e = m->emails[msgno];
   struct PopEmailData *edata = pop_edata_get(e);
   bool bcache = true;
   bool success = false;
@@ -1104,7 +1103,7 @@ static bool pop_msg_open(struct Mailbox *m, struct Message *msg, int msgno)
   e->lines = 0;
   while (fgets(buf, sizeof(buf), msg->fp) && !feof(msg->fp))
   {
-    m->emails[msgno]->lines++;
+    e->lines++;
   }
 
   e->body->length = ftello(msg->fp) - e->body->offset;

--- a/postpone/postpone.c
+++ b/postpone/postpone.c
@@ -499,7 +499,7 @@ int mutt_prepare_template(FILE *fp, struct Mailbox *m, struct Email *e_new,
   struct Envelope *protected_headers = NULL;
   struct Buffer *file = NULL;
 
-  if (!fp && !(msg = mx_msg_open(m, e->msgno)))
+  if (!fp && !(msg = mx_msg_open(m, e)))
     return -1;
 
   if (!fp)

--- a/send/send.c
+++ b/send/send.c
@@ -501,7 +501,7 @@ static int include_forward(struct Mailbox *m, struct Email *e, FILE *fp_out,
   CopyHeaderFlags chflags = CH_DECODE;
   CopyMessageFlags cmflags = MUTT_CM_NO_FLAGS;
 
-  struct Message *msg = mx_msg_open(m, e->msgno);
+  struct Message *msg = mx_msg_open(m, e);
   if (!msg)
   {
     return -1;
@@ -563,7 +563,7 @@ static int inline_forward_attachments(struct Mailbox *m, struct Email *e,
   struct AttachCtx *actx = NULL;
   int rc = 0, i;
 
-  struct Message *msg = mx_msg_open(m, e->msgno);
+  struct Message *msg = mx_msg_open(m, e);
   if (!msg)
   {
     return -1;
@@ -778,7 +778,7 @@ static int include_reply(struct Mailbox *m, struct Email *e, FILE *fp_out,
       return -1;
   }
 
-  struct Message *msg = mx_msg_open(m, e->msgno);
+  struct Message *msg = mx_msg_open(m, e);
   if (!msg)
   {
     return -1;

--- a/send/sendlib.c
+++ b/send/sendlib.c
@@ -484,7 +484,7 @@ struct Body *mutt_make_message_attach(struct Mailbox *m, struct Email *e,
 
   buf_pool_release(&buf);
 
-  struct Message *msg = mx_msg_open(m, e->msgno);
+  struct Message *msg = mx_msg_open(m, e);
   if (!msg)
   {
     mutt_body_free(&body);

--- a/test/pattern/dummy.c
+++ b/test/pattern/dummy.c
@@ -174,7 +174,7 @@ int mx_msg_close(struct Mailbox *m, struct Message **msg)
   return 0;
 }
 
-struct Message *mx_msg_open(struct Mailbox *m, int msgno)
+struct Message *mx_msg_open(struct Mailbox *m, struct Email *e)
 {
   return NULL;
 }


### PR DESCRIPTION
This PR refactors numerous functions to replace `int msgno` with `struct Email *e`.
The result is that the backends no longer reference `Email->msgno`.

---

This was a happy discovery...

`Email->msgno` is a sequential number given to Emails as seen in the Index.
(see: [`%C` in `$index_format`](https://neomutt.org/guide/reference#index-format))

It's also used as an index number, into the `Mailbox->emails[]` array, for `MxOps->msg_open()`.

e.g. `pipe_message() -> mx_msg_open() -> maildir_msg_open()`

In every case, the caller passes `Email->msgno` through the MXAPI and the backend, then looks up that number in `Mailbox->emails[]`.

---
Of course, there's a diagram of the changes :-)

- Each left-hand leaf uses `Email->msgno`
- Each right-hand leaf uses `Mailbox->emails[msgno]`

<img src="https://flatcap.org/mutt/index/mx_msg_open.svg">

