### PR TITLE
Fix counting new mails in maildir

### DIFF
--- a/maildir/maildir.c
+++ b/maildir/maildir.c
@@ -149,10 +149,14 @@ static void maildir_check_dir(struct Mailbox *m, const char *dir_name,
           }
         }
         m->has_new = true;
-        check_new = false;
-        m->msg_new++;
-        if (!check_stats)
+        if (check_stats)
+        {
+          m->msg_new++;
+        }
+        else
+        {
           break;
+        }
       }
     }
   }
@@ -1354,10 +1358,10 @@ static enum MxStatus maildir_mbox_check_stats(struct Mailbox *m, uint8_t flags)
 {
   bool check_stats = flags & MUTT_MAILBOX_CHECK_FORCE_STATS;
   bool check_new = true;
-  m->msg_new = 0;
 
   if (check_stats)
   {
+    m->msg_new = 0;
     m->msg_count = 0;
     m->msg_unread = 0;
     m->msg_flagged = 0;


### PR DESCRIPTION
We only want to change msg_new if we're gathering stats. If we are only checking whether the mailbox has any new messages, we'll stop at the first new message we encounter, so msg_new would always be 1.

We've been touching this code lately, so I'm unsure if I'm breaking something else..

Fixes #3843