### PR TITLE
nm_windowed_query_from_query: better account for buffer length

### DIFF
--- a/notmuch/query.c
+++ b/notmuch/query.c
@@ -250,7 +250,7 @@ nm_windowed_query_from_query(char *buf, size_t buflen, const bool force_enable,
   }
 
   // Add current search to window query.
-  snprintf(buf + length, buflen, " and %s", cur_search);
+  snprintf(buf + length, buflen - length, " and %s", cur_search);
 
   return NM_WINDOW_QUERY_SUCCESS;
 }


### PR DESCRIPTION
With fortified sources, glibc will notice that this call to snprintf could potentially write more bytes to the buffer than what it can hold. That's because it is not accounting for the initial offset in the buffer itself.

* **What does this PR do?**
Fixes a crash when selecting a notmuch folder.
