### PR TITLE
Maildir: Configurable field delimiter

### DIFF
--- a/config/cache.h
+++ b/config/cache.h
@@ -23,8 +23,9 @@
 #ifndef MUTT_CONFIG_CACHE_H
 #define MUTT_CONFIG_CACHE_H
 
-const struct Slist *cc_assumed_charset(void);
-const char *        cc_charset        (void);
+const struct Slist *cc_assumed_charset        (void);
+const char *        cc_charset                (void);
+const char *        cc_maildir_field_delimiter(void);
 
 void config_cache_cleanup(void);
 

--- a/docs/config.c
+++ b/docs/config.c
@@ -2320,6 +2320,17 @@
 ** to scan all cur messages.
 */
 
+{ "maildir_field_delimiter", DT_STRING, ":" },
+/*
+** .pp
+** Use the value as maildir field delimiter. This is a single-character used to
+** accommodate maildir mailboxes on platforms where `:` is not allowed
+** in a filename. The recommended alternative on such platforms is `;`.
+** Neomutt supports all non-alphanumeric values except for `-`, `.`, `\`, `/`.
+** \fBNote:\fP this only applies to maildir-style mailboxes. Setting
+** it will have no effect on other mailbox types.
+*/
+
 #ifdef USE_HCACHE
 { "maildir_header_cache_verify", DT_BOOL, true },
 /*

--- a/maildir/config.c
+++ b/maildir/config.c
@@ -29,7 +29,39 @@
 #include "config.h"
 #include <stddef.h>
 #include <config/lib.h>
+#include <ctype.h>
 #include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+#include "mutt/lib.h"
+
+/**
+ * maildir_field_delimiter_validator - Validate the "maildir_field_delimiter" config variable - Implements ConfigDef::validator() - @ingroup cfg_def_validator
+ *
+ * Ensure maildir_field_delimiter is a single non-alphanumeric non-(-.\/) character.
+ */
+static int maildir_field_delimiter_validator(const struct ConfigSet *cs,
+                                             const struct ConfigDef *cdef,
+                                             intptr_t value, struct Buffer *err)
+{
+  const char *delim = (const char *) value;
+
+  if (strlen(delim) != 1)
+  {
+    // L10N: maildir_field_delimiter is a config variable and shouldn't be translated
+    buf_printf(err, _("maildir_field_delimiter must be exactly one character long"));
+    return CSR_ERR_INVALID;
+  }
+
+  if (isalnum(*delim) || strchr("-.\\/", *delim))
+  {
+    // L10N: maildir_field_delimiter is a config variable and shouldn't be translated
+    buf_printf(err, _("maildir_field_delimiter cannot be alphanumeric or '-.\\/'"));
+    return CSR_ERR_INVALID;
+  }
+
+  return CSR_SUCCESS;
+}
 
 /**
  * MaildirVars - Config definitions for the Maildir library
@@ -41,6 +73,9 @@ static struct ConfigDef MaildirVars[] = {
   },
   { "maildir_check_cur", DT_BOOL, false, 0, NULL,
     "Check both 'new' and 'cur' directories for new mail"
+  },
+  { "maildir_field_delimiter", DT_STRING, IP ":", 0, maildir_field_delimiter_validator,
+    "Field delimiter to be used for maildir email files (default is colon, recommended alternative is semi-colon)"
   },
   { "maildir_trash", DT_BOOL, false, 0, NULL,
     "Use the maildir 'trashed' flag, rather than deleting"

--- a/maildir/config.c
+++ b/maildir/config.c
@@ -60,6 +60,19 @@ static int maildir_field_delimiter_validator(const struct ConfigSet *cs,
     return CSR_ERR_INVALID;
   }
 
+  static bool maildir_field_delimiter_changed = false;
+  if (maildir_field_delimiter_changed)
+  {
+    // L10N: maildir_field_delimiter is a config variable and shouldn't be translated
+    buf_printf(err, _("maildir_field_delimiter can only be set once"));
+    return CSR_ERR_INVALID;
+  }
+
+  if (*delim != *(const char *) cdef->initial)
+  {
+    maildir_field_delimiter_changed = true;
+  }
+
   return CSR_SUCCESS;
 }
 
@@ -74,7 +87,7 @@ static struct ConfigDef MaildirVars[] = {
   { "maildir_check_cur", DT_BOOL, false, 0, NULL,
     "Check both 'new' and 'cur' directories for new mail"
   },
-  { "maildir_field_delimiter", DT_STRING, IP ":", 0, maildir_field_delimiter_validator,
+  { "maildir_field_delimiter", DT_STRING|DT_NOT_EMPTY, IP ":", 0, maildir_field_delimiter_validator,
     "Field delimiter to be used for maildir email files (default is colon, recommended alternative is semi-colon)"
   },
   { "maildir_trash", DT_BOOL, false, 0, NULL,

--- a/maildir/maildir.c
+++ b/maildir/maildir.c
@@ -135,7 +135,7 @@ static void maildir_check_dir(struct Mailbox *m, const char *dir_name,
     goto cleanup;
   }
 
-  const char c_maildir_field_delimiter = *cs_subset_string(NeoMutt->sub, "maildir_field_delimiter");
+  const char c_maildir_field_delimiter = *cc_maildir_field_delimiter();
 
   char delimiter_version[8] = { 0 };
   snprintf(delimiter_version, sizeof(delimiter_version), "%c2,", c_maildir_field_delimiter);
@@ -233,7 +233,7 @@ void maildir_gen_flags(char *dest, size_t destlen, struct Email *e)
     if (flags)
       qsort(tmp, strlen(tmp), 1, maildir_sort_flags);
 
-    const char c_maildir_field_delimiter = *cs_subset_string(NeoMutt->sub, "maildir_field_delimiter");
+    const char c_maildir_field_delimiter = *cc_maildir_field_delimiter();
     snprintf(dest, destlen, "%c2,%s", c_maildir_field_delimiter, tmp);
   }
 }
@@ -279,7 +279,7 @@ static int maildir_commit_message(struct Mailbox *m, struct Message *msg, struct
   mutt_str_copy(subdir, s, 4);
 
   /* extract the flags */
-  const char c_maildir_field_delimiter = *cs_subset_string(NeoMutt->sub, "maildir_field_delimiter");
+  const char c_maildir_field_delimiter = *cc_maildir_field_delimiter();
   s = strchr(s, c_maildir_field_delimiter);
   if (s)
     mutt_str_copy(suffix, s, sizeof(suffix));
@@ -449,7 +449,7 @@ static int maildir_sync_message(struct Mailbox *m, struct Email *e)
     buf_strcpy(newpath, p);
 
     /* kill the previous flags */
-    const char c_maildir_field_delimiter = *cs_subset_string(NeoMutt->sub, "maildir_field_delimiter");
+    const char c_maildir_field_delimiter = *cc_maildir_field_delimiter();
     p = strchr(newpath->data, c_maildir_field_delimiter);
     if (p)
     {
@@ -607,7 +607,7 @@ cleanup:
  */
 static size_t maildir_hcache_keylen(const char *fn)
 {
-  const char c_maildir_field_delimiter = *cs_subset_string(NeoMutt->sub, "maildir_field_delimiter");
+  const char c_maildir_field_delimiter = *cc_maildir_field_delimiter();
   const char *p = strrchr(fn, c_maildir_field_delimiter);
   return p ? (size_t) (p - fn) : mutt_str_len(fn);
 }
@@ -767,7 +767,7 @@ static void maildir_canon_filename(struct Buffer *dest, const char *src)
 
   buf_strcpy(dest, src);
 
-  const char c_maildir_field_delimiter = *cs_subset_string(NeoMutt->sub, "maildir_field_delimiter");
+  const char c_maildir_field_delimiter = *cc_maildir_field_delimiter();
 
   char searchable_bytes[8] = { 0 };
   snprintf(searchable_bytes, sizeof(searchable_bytes), ",%c", c_maildir_field_delimiter);
@@ -856,7 +856,7 @@ void maildir_parse_flags(struct Email *e, const char *path)
 
   struct MaildirEmailData *edata = maildir_edata_get(e);
 
-  const char c_maildir_field_delimiter = *cs_subset_string(NeoMutt->sub, "maildir_field_delimiter");
+  const char c_maildir_field_delimiter = *cc_maildir_field_delimiter();
   char *p = strrchr(path, c_maildir_field_delimiter);
   if (p && mutt_str_startswith(p + 1, "2,"))
   {

--- a/notmuch/notmuch.c
+++ b/notmuch/notmuch.c
@@ -1228,7 +1228,8 @@ static int rename_maildir_filename(const char *old, char *buf, size_t buflen, st
     *p = '\0';
 
   /* remove old flags from filename */
-  p = strchr(filename, ':');
+  const char c_maildir_field_delimiter = *cc_maildir_field_delimiter();
+  p = strchr(filename, c_maildir_field_delimiter);
   if (p)
     *p = '\0';
 

--- a/test/common.c
+++ b/test/common.c
@@ -49,6 +49,7 @@ static struct ConfigDef Vars[] = {
   // clang-format off
   { "assumed_charset", DT_SLIST|SLIST_SEP_COLON|SLIST_ALLOW_EMPTY, 0, 0, NULL, },
   { "charset", DT_STRING|DT_NOT_EMPTY|DT_CHARSET_SINGLE, IP "utf-8", 0, NULL, },
+  { "maildir_field_delimiter", DT_STRING, IP ":", 0, NULL, },
   { "tmp_dir", DT_PATH|DT_PATH_DIR|DT_NOT_EMPTY, IP TMPDIR, 0, NULL, },
   { NULL },
   // clang-format on

--- a/test/config/common.c
+++ b/test/config/common.c
@@ -128,7 +128,7 @@ void cs_dump_set(const struct ConfigSet *cs)
   struct Buffer *result = buf_pool_get();
 
   char tmp[128];
-  char *list[26] = { 0 };
+  char *list[64] = { 0 };
   size_t index = 0;
   size_t i = 0;
 


### PR DESCRIPTION
We allow overriding `:` as field delimiter for maildir using the option maildir_field_delimiter. This option should be changed only in tandem with changing existing maildir files to have that field delimiter.