### PR TITLE
index: only refresh the menu on non-focus window changes

### DIFF
--- a/index/index.c
+++ b/index/index.c
@@ -500,7 +500,8 @@ static int index_window_observer(struct NotifyCallback *nc)
   struct Menu *menu = win->wdata;
   if (nc->event_subtype != NT_WINDOW_DELETE)
   {
-    menu_queue_redraw(menu, MENU_REDRAW_FULL | MENU_REDRAW_INDEX);
+    if (nc->event_subtype != NT_WINDOW_FOCUS)
+      menu_queue_redraw(menu, MENU_REDRAW_FULL | MENU_REDRAW_INDEX);
     return 0;
   }
 


### PR DESCRIPTION
* **What does this PR do?**

Fixes: commit 968e302be1d2ac8d952b25bf4fced0d568e81e8e ("index: refresh the menu on window changes")

It appeared (though dprintf()ing the subtype) like `C+Trash<Enter>` yielded event 5 (focus), so just don't redraw for that one

* **What are the relevant issue numbers?**

Closes: #3781, see that one for bisexion