### PR TITLE
Fix broken $tunnel reconnect with $ssl_force_tls=yes

### DIFF
--- a/conn/tunnel.c
+++ b/conn/tunnel.c
@@ -129,6 +129,12 @@ static int tunnel_socket_open(struct Connection *conn)
 
   conn->fd = 42; /* stupid hack */
 
+  /* Note we are using ssf as a boolean in this case.  See the notes in
+   * conn/connection.h */
+  const bool c_tunnel_is_secure = cs_subset_bool(NeoMutt->sub, "tunnel_is_secure");
+  if (c_tunnel_is_secure)
+    conn->ssf = 1;
+
   return 0;
 }
 
@@ -238,9 +244,4 @@ void mutt_tunnel_socket_setup(struct Connection *conn)
   conn->read = tunnel_socket_read;
   conn->write = tunnel_socket_write;
   conn->poll = tunnel_socket_poll;
-  /* Note we are using ssf as a boolean in this case.  See the notes in
-   * conn/connection.h */
-  const bool c_tunnel_is_secure = cs_subset_bool(NeoMutt->sub, "tunnel_is_secure");
-  if (c_tunnel_is_secure)
-    conn->ssf = 1;
 }


### PR DESCRIPTION
When $ssl_force_tls=yes imap bails out with "Encrypted connection unavailable" on reconnect when the tunnel process exits. We observed `conn->ssf==0` in this case.

This happens because the tunnel backend only sets `conn->ssf=1` once ever in mutt_tunnel_socket_setup, but mutt_socket_close sets `conn->ssf=0` on process exit.

Fix this by refreshing `conn->ssf` in mutt_socket_tunnel_open.

---

Note: as a workaround `$ssl_force_tls` can just be set to false.