### PR TITLE
Stop parsing headers at the end of the headers section

### DIFF
--- a/email/parse.c
+++ b/email/parse.c
@@ -1088,7 +1088,7 @@ size_t mutt_rfc822_read_line(FILE *fp, struct Buffer *buf)
   size_t read = 0;
   char line[1024] = { 0 }; /* RFC2822 specifies a maximum line length of 998 */
 
-  buf_seek(buf, 0);
+  buf_reset(buf);
   while (true)
   {
     if (!fgets(line, sizeof(line), fp))
@@ -1191,7 +1191,7 @@ struct Envelope *mutt_rfc822_read_header(FILE *fp, struct Email *e, bool user_hd
   {
     LOFF_T line_start_loc = loc;
     size_t len = mutt_rfc822_read_line(fp, line);
-    if (len == 0)
+    if (buf_len(line) == 0)
     {
       break;
     }


### PR DESCRIPTION
The code to parse an RFC2822 header wasn't properly emptying its buffer on enter, but it was merely resetting the write pointer: https://github.com/neomutt/neomutt/blob/dde403334f7a5c0f2a746735076cddbccdbd605d/email/parse.c#L1091

For this reason, the code that was in place to detect and return in case of an empty line at the start of a header (i.e., the empty line dividing the headers from the body) wasn't triggered:
https://github.com/neomutt/neomutt/blob/dde403334f7a5c0f2a746735076cddbccdbd605d/email/parse.c#L1105-L1109

This was causing the code used to parse the headers to keep trying to parse the whole body:
https://github.com/neomutt/neomutt/blob/dde403334f7a5c0f2a746735076cddbccdbd605d/email/parse.c#L1193-L1197

Fixes #3860