### PR TITLE
Fix keymap comparison

### DIFF
--- a/keymap.c
+++ b/keymap.c
@@ -336,6 +336,8 @@ static size_t parsekeys(const char *str, keycode_t *d, size_t max)
  */
 static struct Keymap *km_compare_keys(struct Keymap *k1, struct Keymap *k2, size_t *pos)
 {
+  *pos = 0;
+
   while (*pos < k1->len && *pos < k2->len)
   {
     if (k1->keys[*pos] < k2->keys[*pos])


### PR DESCRIPTION
When we compare an incoming new binding against the existing ones, we do need to return to the caller how many characters mached, but we don't have to retain the count found during the previous comparison. Morally, we should just return two values here: the keymap, and the number of chars matched.

This code is scary - I might break stuff...

Fixes #3759