### PR TITLE
test: use a real FILE pointer

### DIFF
--- a/test/attach/mutt_actx_add_fp.c
+++ b/test/attach/mutt_actx_add_fp.c
@@ -31,9 +31,10 @@ void test_mutt_actx_add_fp(void)
   // void mutt_actx_add_fp(struct AttachCtx *actx, FILE *fp_new);
 
   {
-    FILE fp = { 0 };
-    mutt_actx_add_fp(NULL, &fp);
-    TEST_CHECK_(1, "mutt_actx_add_fp(NULL, &fp)");
+    FILE *fp = fopen("/dev/null", "r");
+    mutt_actx_add_fp(NULL, fp);
+    TEST_CHECK_(1, "mutt_actx_add_fp(NULL, fp)");
+    fclose(fp);
   }
 
   {

--- a/test/charset/mutt_ch_fgetconv_open.c
+++ b/test/charset/mutt_ch_fgetconv_open.c
@@ -38,16 +38,18 @@ void test_mutt_ch_fgetconv_open(void)
   }
 
   {
-    FILE fp = { 0 };
+    FILE *fp = fopen("/dev/null", "r");
     struct FgetConv *conv = NULL;
-    TEST_CHECK((conv = mutt_ch_fgetconv_open(&fp, NULL, "banana", MUTT_ICONV_NO_FLAGS)) != NULL);
+    TEST_CHECK((conv = mutt_ch_fgetconv_open(fp, NULL, "banana", MUTT_ICONV_NO_FLAGS)) != NULL);
     mutt_ch_fgetconv_close(&conv);
+    fclose(fp);
   }
 
   {
-    FILE fp = { 0 };
+    FILE *fp = fopen("/dev/null", "r");
     struct FgetConv *conv = NULL;
-    TEST_CHECK((conv = mutt_ch_fgetconv_open(&fp, "apple", NULL, MUTT_ICONV_NO_FLAGS)) != NULL);
+    TEST_CHECK((conv = mutt_ch_fgetconv_open(fp, "apple", NULL, MUTT_ICONV_NO_FLAGS)) != NULL);
     mutt_ch_fgetconv_close(&conv);
+    fclose(fp);
   }
 }

--- a/test/file/mutt_file_copy_bytes.c
+++ b/test/file/mutt_file_copy_bytes.c
@@ -31,12 +31,14 @@ void test_mutt_file_copy_bytes(void)
   // int mutt_file_copy_bytes(FILE *fp_in, FILE *fp_out, size_t size);
 
   {
-    FILE fp = { 0 };
-    TEST_CHECK(mutt_file_copy_bytes(NULL, &fp, 10) != 0);
+    FILE *fp = fopen("/dev/null", "r");
+    TEST_CHECK(mutt_file_copy_bytes(NULL, fp, 10) != 0);
+    fclose(fp);
   }
 
   {
-    FILE fp = { 0 };
-    TEST_CHECK(mutt_file_copy_bytes(&fp, NULL, 10) != 0);
+    FILE *fp = fopen("/dev/null", "r");
+    TEST_CHECK(mutt_file_copy_bytes(fp, NULL, 10) != 0);
+    fclose(fp);
   }
 }

--- a/test/file/mutt_file_copy_stream.c
+++ b/test/file/mutt_file_copy_stream.c
@@ -31,12 +31,14 @@ void test_mutt_file_copy_stream(void)
   // int mutt_file_copy_stream(FILE *fp_in, FILE *fp_out);
 
   {
-    FILE fp = { 0 };
-    TEST_CHECK(mutt_file_copy_stream(NULL, &fp) != 0);
+    FILE *fp = fopen("/dev/null", "r");
+    TEST_CHECK(mutt_file_copy_stream(NULL, fp) != 0);
+    fclose(fp);
   }
 
   {
-    FILE fp = { 0 };
-    TEST_CHECK(mutt_file_copy_stream(&fp, NULL) != 0);
+    FILE *fp = fopen("/dev/null", "r");
+    TEST_CHECK(mutt_file_copy_stream(fp, NULL) != 0);
+    fclose(fp);
   }
 }

--- a/test/file/mutt_file_iter_line.c
+++ b/test/file/mutt_file_iter_line.c
@@ -35,8 +35,9 @@ void test_mutt_file_iter_line(void)
   // bool mutt_file_iter_line(struct MuttFileIter *iter, FILE *fp, ReadLineFlags flags);
 
   {
-    FILE fp = { 0 };
-    TEST_CHECK(!mutt_file_iter_line(NULL, &fp, MUTT_RL_NO_FLAGS));
+    FILE *fp = fopen("/dev/null", "r");
+    TEST_CHECK(!mutt_file_iter_line(NULL, fp, MUTT_RL_NO_FLAGS));
+    fclose(fp);
   }
 
   {

--- a/test/file/mutt_file_map_lines.c
+++ b/test/file/mutt_file_map_lines.c
@@ -63,8 +63,9 @@ void test_mutt_file_map_lines(void)
   // bool mutt_file_map_lines(mutt_file_map_t func, void *user_data, FILE *fp, ReadLineFlags flags);
 
   {
-    FILE fp = { 0 };
-    TEST_CHECK(!mutt_file_map_lines(NULL, "apple", &fp, MUTT_RL_NO_FLAGS));
+    FILE *fp = fopen("/dev/null", "r");
+    TEST_CHECK(!mutt_file_map_lines(NULL, "apple", fp, MUTT_RL_NO_FLAGS));
+    fclose(fp);
   }
 
   {

--- a/test/file/mutt_file_read_line.c
+++ b/test/file/mutt_file_read_line.c
@@ -41,11 +41,12 @@ void test_mutt_file_read_line(void)
   }
 
   {
-    FILE fp = { 0 };
+    FILE *fp = fopen("/dev/null", "r");
     char *line = strdup("apple");
     int line_num = 0;
-    TEST_CHECK(!mutt_file_read_line(line, NULL, &fp, &line_num, MUTT_RL_NO_FLAGS));
+    TEST_CHECK(!mutt_file_read_line(line, NULL, fp, &line_num, MUTT_RL_NO_FLAGS));
     free(line);
+    fclose(fp);
   }
 
   {
@@ -59,7 +60,8 @@ void test_mutt_file_read_line(void)
   {
     size_t size = 0;
     char *line = strdup("apple");
-    FILE fp = { 0 };
-    TEST_CHECK(!mutt_file_read_line(line, &size, &fp, NULL, MUTT_RL_NO_FLAGS));
+    FILE *fp = fopen("/dev/null", "r");
+    TEST_CHECK(!mutt_file_read_line(line, &size, fp, NULL, MUTT_RL_NO_FLAGS));
+    fclose(fp);
   }
 }

--- a/test/parse/mutt_parse_multipart.c
+++ b/test/parse/mutt_parse_multipart.c
@@ -39,7 +39,8 @@ void test_mutt_parse_multipart(void)
   }
 
   {
-    FILE fp = { 0 };
-    TEST_CHECK(!mutt_parse_multipart(&fp, NULL, 0, false));
+    FILE *fp = fopen("/dev/null", "r");
+    TEST_CHECK(!mutt_parse_multipart(fp, NULL, 0, false));
+    fclose(fp);
   }
 }

--- a/test/parse/mutt_parse_part.c
+++ b/test/parse/mutt_parse_part.c
@@ -37,8 +37,9 @@ void test_mutt_parse_part(void)
   }
 
   {
-    FILE fp = { 0 };
-    mutt_parse_part(&fp, NULL);
-    TEST_CHECK_(1, "mutt_parse_part(&fp, NULL)");
+    FILE *fp = fopen("/dev/null", "r");
+    mutt_parse_part(fp, NULL);
+    TEST_CHECK_(1, "mutt_parse_part(fp, NULL)");
+    fclose(fp);
   }
 }

--- a/test/parse/mutt_rfc822_parse_message.c
+++ b/test/parse/mutt_rfc822_parse_message.c
@@ -36,7 +36,8 @@ void test_mutt_rfc822_parse_message(void)
   }
 
   {
-    FILE fp = { 0 };
-    TEST_CHECK(!mutt_rfc822_parse_message(&fp, NULL));
+    FILE *fp = fopen("/dev/null", "r");
+    TEST_CHECK(!mutt_rfc822_parse_message(fp, NULL));
+    fclose(fp);
   }
 }

--- a/test/parse/mutt_rfc822_read_line.c
+++ b/test/parse/mutt_rfc822_read_line.c
@@ -109,8 +109,9 @@ void test_mutt_rfc822_read_line(void)
   }
 
   {
-    FILE fp = { 0 };
-    TEST_CHECK(mutt_rfc822_read_line(&fp, NULL) == 0);
+    FILE *fp = fopen("/dev/null", "r");
+    TEST_CHECK(mutt_rfc822_read_line(fp, NULL) == 0);
+    fclose(fp);
   }
 
   {


### PR DESCRIPTION
Some C libraries don't expose the contents of `FILE`.
This means that the shortcut used in some tests doesn't work:
```c
FILE fp = { 0 };
```

Replace them all with real `FILE` pointers:
```c
FILE *fp = fopen("/dev/null", "r");
// ...
fclose(fp);
```