### PR TITLE
imap: move $delete_untag out

### DIFF
--- a/external.c
+++ b/external.c
@@ -917,6 +917,17 @@ int mutt_save_message(struct Mailbox *m, struct EmailList *el,
       case 0:
         mutt_clear_error();
         rc = 0;
+        if (save_opt == SAVE_MOVE)
+        {
+          const bool c_delete_untag = cs_subset_bool(NeoMutt->sub, "delete_untag");
+          if (c_delete_untag)
+          {
+            STAILQ_FOREACH(en, el, entries)
+            {
+              mutt_set_flag(m, en->email, MUTT_TAG, false, true);
+            }
+          }
+        }
         goto cleanup;
       /* non-fatal error: continue to fetch/append */
       case 1:

--- a/imap/message.c
+++ b/imap/message.c
@@ -1810,13 +1810,10 @@ int imap_copy_messages(struct Mailbox *m, struct EmailList *el,
   /* cleanup */
   if (save_opt == SAVE_MOVE)
   {
-    const bool c_delete_untag = cs_subset_bool(NeoMutt->sub, "delete_untag");
     STAILQ_FOREACH(en, el, entries)
     {
       mutt_set_flag(m, en->email, MUTT_DELETE, true, true);
       mutt_set_flag(m, en->email, MUTT_PURGE, true, true);
-      if (c_delete_untag)
-        mutt_set_flag(m, en->email, MUTT_TAG, false, true);
     }
   }
 

--- a/mx.c
+++ b/mx.c
@@ -762,6 +762,18 @@ enum MxStatus mx_mbox_close(struct Mailbox *m)
       }
 
       i = imap_copy_messages(m, &el, buf_string(mbox), SAVE_MOVE);
+      if (i == 0)
+      {
+        const bool c_delete_untag = cs_subset_bool(NeoMutt->sub, "delete_untag");
+        if (c_delete_untag)
+        {
+          struct EmailNode *en = NULL;
+          STAILQ_FOREACH(en, &el, entries)
+          {
+            mutt_set_flag(m, en->email, MUTT_TAG, false, true);
+          }
+        }
+      }
       emaillist_clear(&el);
     }
 


### PR DESCRIPTION
The "(un-)tagging" of Emails is a GUI thing; it doesn't belong in the backends.

When `imap_copy_messages()` succeeds, it checks config `$delete_untag` and untags the Emails that it worked on.
This is called from `mutt_save_message()` and `mx_mbox_close()`.

Move this code out of Imap into the two callers.