### PR TITLE
refactor mx_alloc_memory()

### DIFF
--- a/core/mailbox.h
+++ b/core/mailbox.h
@@ -94,7 +94,7 @@ struct Mailbox
   int msg_tagged;                     ///< How many messages are tagged?
 
   struct Email **emails;              ///< Array of Emails
-  int email_max;                      ///< Number of pointers in emails
+  int email_max;                      ///< Size of `emails` array
   int *v2r;                           ///< Mapping from virtual to real msgno
   int vcount;                         ///< The number of virtual messages
 

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -2027,8 +2027,7 @@ static enum MxOpenReturns imap_mbox_open(struct Mailbox *m)
     m->readonly = true;
   }
 
-  while (m->email_max < count)
-    mx_alloc_memory(m);
+  mx_alloc_memory(m, count);
 
   m->msg_count = 0;
   m->msg_unread = 0;

--- a/maildir/shared.c
+++ b/maildir/shared.c
@@ -92,8 +92,7 @@ int maildir_move_to_mailbox(struct Mailbox *m, struct MdEmailArray *mda)
                md->email->flagged ? "f" : "", md->email->deleted ? "D" : "",
                md->email->replied ? "r" : "", md->email->old ? "O" : "",
                md->email->read ? "R" : "");
-    if (m->msg_count == m->email_max)
-      mx_alloc_memory(m);
+    mx_alloc_memory(m, m->msg_count);
 
     m->emails[m->msg_count] = md->email;
     m->emails[m->msg_count]->index = m->msg_count;

--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -231,8 +231,7 @@ static enum MxOpenReturns mmdf_parse_mailbox(struct Mailbox *m)
       if (m->verbose)
         progress_update(progress, count, (int) (loc / (m->size / 100 + 1)));
 
-      if (m->msg_count == m->email_max)
-        mx_alloc_memory(m);
+      mx_alloc_memory(m, m->msg_count);
       e = email_new();
       m->emails[m->msg_count] = e;
       e->offset = loc;
@@ -411,8 +410,7 @@ static enum MxOpenReturns mbox_parse_mailbox(struct Mailbox *m)
         progress_update(progress, count, (int) (ftello(adata->fp) / (m->size / 100 + 1)));
       }
 
-      if (m->msg_count == m->email_max)
-        mx_alloc_memory(m);
+      mx_alloc_memory(m, m->msg_count);
 
       m->emails[m->msg_count] = email_new();
       e_cur = m->emails[m->msg_count];

--- a/mx.h
+++ b/mx.h
@@ -72,7 +72,7 @@ bool            mx_ac_add      (struct Account *a, struct Mailbox *m);
 int             mx_ac_remove   (struct Mailbox *m, bool keep_account);
 
 int                 mx_access           (const char *path, int flags);
-void                mx_alloc_memory     (struct Mailbox *m);
+void                mx_alloc_memory     (struct Mailbox *m, int req_size);
 int                 mx_path_is_empty    (const char *path);
 void                mx_fastclose_mailbox(struct Mailbox *m, bool keep_account);
 const struct MxOps *mx_get_ops          (enum MailboxType type);

--- a/nntp/nntp.c
+++ b/nntp/nntp.c
@@ -1081,8 +1081,7 @@ static int parse_overview_line(char *line, void *data)
   rewind(fp);
 
   /* allocate memory for headers */
-  if (m->msg_count >= m->email_max)
-    mx_alloc_memory(m);
+  mx_alloc_memory(m, m->msg_count);
 
   /* parse header */
   m->emails[m->msg_count] = email_new();
@@ -1270,8 +1269,7 @@ static int nntp_fetch_headers(struct Mailbox *m, void *hc, anum_t first, anum_t 
       continue;
 
     /* allocate memory for headers */
-    if (m->msg_count >= m->email_max)
-      mx_alloc_memory(m);
+    mx_alloc_memory(m, m->msg_count);
 
 #ifdef USE_HCACHE
     /* try to fetch header from cache */
@@ -1590,8 +1588,7 @@ static enum MxStatus check_mailbox(struct Mailbox *m)
       if (hce.email)
       {
         mutt_debug(LL_DEBUG2, "#2 mutt_hcache_fetch %s\n", buf);
-        if (m->msg_count >= m->email_max)
-          mx_alloc_memory(m);
+        mx_alloc_memory(m, m->msg_count);
 
         e = hce.email;
         m->emails[m->msg_count] = e;
@@ -2201,8 +2198,7 @@ int nntp_check_msgid(struct Mailbox *m, const char *msgid)
   }
 
   /* parse header */
-  if (m->msg_count == m->email_max)
-    mx_alloc_memory(m);
+  mx_alloc_memory(m, m->msg_count);
   m->emails[m->msg_count] = email_new();
   struct Email *e = m->emails[m->msg_count];
   e->edata = nntp_edata_new();

--- a/notmuch/notmuch.c
+++ b/notmuch/notmuch.c
@@ -770,11 +770,7 @@ static void append_message(struct HeaderCache *h, struct Mailbox *m,
   mutt_debug(LL_DEBUG2, "nm: appending message, i=%d, id=%s, path=%s\n",
              m->msg_count, notmuch_message_get_message_id(msg), path);
 
-  if (m->msg_count >= m->email_max)
-  {
-    mutt_debug(LL_DEBUG2, "nm: allocate mx memory\n");
-    mx_alloc_memory(m);
-  }
+  mx_alloc_memory(m, m->msg_count);
 
 #ifdef USE_HCACHE
   e = mutt_hcache_fetch(h, path, mutt_str_len(path), 0).email;
@@ -1828,8 +1824,7 @@ static enum MxStatus nm_mbox_check_stats(struct Mailbox *m, uint8_t flags)
 
   /* all emails */
   m->msg_count = count_query(db, db_query, limit);
-  while (m->email_max < m->msg_count)
-    mx_alloc_memory(m);
+  mx_alloc_memory(m, m->msg_count);
 
   // holder variable for extending query to unread/flagged
   char *qstr = NULL;

--- a/pop/pop.c
+++ b/pop/pop.c
@@ -227,8 +227,7 @@ static int fetch_uidl(const char *line, void *data)
   {
     mutt_debug(LL_DEBUG1, "new header %d %s\n", index, line);
 
-    if (i >= m->email_max)
-      mx_alloc_memory(m);
+    mx_alloc_memory(m, i);
 
     m->msg_count++;
     m->emails[i] = email_new();


### PR DESCRIPTION
- Add a parameter for a required size
- Simplify all the callers

Tell the function how much space we need and avoid any looping.

**Note**: I haven't used `m->msg_count` in the function to allow the callers to increase the size of `m->emails[]` **before** they start populating it.

---

There are three types of caller for `mx_alloc_memory()`
```c
// Safe
while (m->msg_count > m->email_max)
  mx_alloc_memory(m);
```
```c
// Risky if msg_count is bigger than the alloc step size
if (m->msg_count >= m->email_max)
  mx_alloc_memory(m);
```
```c
// Very risky if the counting is off
if (m->msg_count == m->email_max)
  mx_alloc_memory(m);
```

Replaced by:

```c
mx_alloc_memory(m, m->msg_count);
```