### PR TITLE
logging: increase max length of lines

### DIFF
--- a/mutt/logging.c
+++ b/mutt/logging.c
@@ -393,12 +393,12 @@ int log_queue_save(FILE *fp)
  *
  * @sa log_queue_set_max_size(), log_queue_flush(), log_queue_empty()
  *
- * @warning Log lines are limited to 1024 bytes.
+ * @warning Log lines are limited to LOG_LINE_MAX_LEN bytes
  */
 int log_disp_queue(time_t stamp, const char *file, int line,
                    const char *function, enum LogLevel level, ...)
 {
-  char buf[1024] = { 0 };
+  char buf[LOG_LINE_MAX_LEN] = { 0 };
   int err = errno;
 
   va_list ap;
@@ -434,13 +434,15 @@ int log_disp_queue(time_t stamp, const char *file, int line,
  * The format is:
  * * `[TIMESTAMP]<LEVEL> FUNCTION() FORMATTED-MESSAGE`
  *
+ * @warning Log lines are limited to LOG_LINE_MAX_LEN bytes
+ *
  * @note The output will be coloured using ANSI escape sequences,
  *       unless the output is redirected.
  */
 int log_disp_terminal(time_t stamp, const char *file, int line,
                       const char *function, enum LogLevel level, ...)
 {
-  char buf[1024] = { 0 };
+  char buf[LOG_LINE_MAX_LEN] = { 0 };
 
   va_list ap;
   va_start(ap, level);

--- a/mutt/logging2.h
+++ b/mutt/logging2.h
@@ -28,6 +28,9 @@
 #include <time.h>
 #include "queue.h"
 
+/// Log lines longer than this will be truncated
+#define LOG_LINE_MAX_LEN 10240
+
 /**
  * enum LogLevel - Names for the Logging Levels
  */

--- a/mutt_logging.c
+++ b/mutt_logging.c
@@ -91,7 +91,7 @@ int log_disp_curses(time_t stamp, const char *file, int line,
   if (level > c_debug_level)
     return 0;
 
-  char buf[1024] = { 0 };
+  char buf[LOG_LINE_MAX_LEN] = { 0 };
 
   va_list ap;
   va_start(ap, level);


### PR DESCRIPTION
This means that NeoMutt can fully log the recently enlarged IMAP commands.
(see d35fc6a30 imap: increase max command length)