### PR TITLE
imap: rename config imap_keepalive

### DIFF
--- a/attach/mutt_attach.c
+++ b/attach/mutt_attach.c
@@ -391,7 +391,7 @@ static int wait_interactive_filter(pid_t pid)
   int rc;
 
 #ifdef USE_IMAP
-  rc = imap_wait_keepalive(pid);
+  rc = imap_wait_keep_alive(pid);
 #else
   waitpid(pid, &rc, 0);
 #endif

--- a/docs/config.c
+++ b/docs/config.c
@@ -1883,7 +1883,7 @@
 ** up periodically, try unsetting this.
 */
 
-{ "imap_keepalive", DT_NUMBER, 300 },
+{ "imap_keep_alive", DT_NUMBER, 300 },
 /*
 ** .pp
 ** This variable specifies the maximum amount of time in seconds that NeoMutt

--- a/imap/config.c
+++ b/imap/config.c
@@ -107,7 +107,7 @@ static struct ConfigDef ImapVars[] = {
   { "imap_server_noise", DT_BOOL, true, 0, NULL,
     "(imap) Display server warnings as error messages"
   },
-  { "imap_keepalive", DT_NUMBER|DT_NOT_NEGATIVE, 300, 0, NULL,
+  { "imap_keep_alive", DT_NUMBER|DT_NOT_NEGATIVE, 300, 0, NULL,
     "(imap) Time to wait before polling an open IMAP connection"
   },
   { "imap_list_subscribed", DT_BOOL, false, 0, NULL,
@@ -132,6 +132,7 @@ static struct ConfigDef ImapVars[] = {
     "(imap) Username for the IMAP server"
   },
 
+  { "imap_keepalive",   DT_SYNONYM, IP "imap_keep_alive",   IP "2023-05-31" },
   { "imap_servernoise", DT_SYNONYM, IP "imap_server_noise", IP "2021-02-11" },
   { NULL },
   // clang-format on

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -1029,9 +1029,9 @@ enum MxStatus imap_check_mailbox(struct Mailbox *m, bool force)
 
   /* try IDLE first, unless force is set */
   const bool c_imap_idle = cs_subset_bool(NeoMutt->sub, "imap_idle");
-  const short c_imap_keepalive = cs_subset_number(NeoMutt->sub, "imap_keepalive");
+  const short c_imap_keep_alive = cs_subset_number(NeoMutt->sub, "imap_keep_alive");
   if (!force && c_imap_idle && (adata->capabilities & IMAP_CAP_IDLE) &&
-      ((adata->state != IMAP_IDLE) || (mutt_date_now() >= adata->lastread + c_imap_keepalive)))
+      ((adata->state != IMAP_IDLE) || (mutt_date_now() >= adata->lastread + c_imap_keep_alive)))
   {
     if (imap_cmd_idle(adata) < 0)
       return MX_STATUS_ERROR;

--- a/imap/lib.h
+++ b/imap/lib.h
@@ -105,8 +105,8 @@ int imap_parse_path(const char *path, struct ConnAccount *cac, char *mailbox, si
 void imap_pretty_mailbox(char *path, size_t pathlen, const char *folder);
 int imap_mxcmp(const char *mx1, const char *mx2);
 
-int imap_wait_keepalive(pid_t pid);
-void imap_keepalive(void);
+int imap_wait_keep_alive(pid_t pid);
+void imap_keep_alive(void);
 
 void imap_get_parent_path(const char *path, char *buf, size_t buflen);
 void imap_clean_path(char *path, size_t plen);

--- a/imap/util.c
+++ b/imap/util.c
@@ -935,13 +935,13 @@ void imap_unmunge_mbox_name(bool unicode, char *s)
 }
 
 /**
- * imap_keepalive - Poll the current folder to keep the connection alive
+ * imap_keep_alive - Poll the current folder to keep the connection alive
  */
-void imap_keepalive(void)
+void imap_keep_alive(void)
 {
   time_t now = mutt_date_now();
   struct Account *np = NULL;
-  const short c_imap_keepalive = cs_subset_number(NeoMutt->sub, "imap_keepalive");
+  const short c_imap_keep_alive = cs_subset_number(NeoMutt->sub, "imap_keep_alive");
   TAILQ_FOREACH(np, &NeoMutt->accounts, entries)
   {
     if (np->type != MUTT_IMAP)
@@ -951,17 +951,17 @@ void imap_keepalive(void)
     if (!adata || !adata->mailbox)
       continue;
 
-    if ((adata->state >= IMAP_AUTHENTICATED) && (now >= (adata->lastread + c_imap_keepalive)))
+    if ((adata->state >= IMAP_AUTHENTICATED) && (now >= (adata->lastread + c_imap_keep_alive)))
       imap_check_mailbox(adata->mailbox, true);
   }
 }
 
 /**
- * imap_wait_keepalive - Wait for a process to change state
+ * imap_wait_keep_alive - Wait for a process to change state
  * @param pid Process ID to listen to
  * @retval num 'wstatus' from waitpid()
  */
-int imap_wait_keepalive(pid_t pid)
+int imap_wait_keep_alive(pid_t pid)
 {
   struct sigaction oldalrm;
   struct sigaction act;
@@ -984,13 +984,13 @@ int imap_wait_keepalive(pid_t pid)
 
   sigaction(SIGALRM, &act, &oldalrm);
 
-  const short c_imap_keepalive = cs_subset_number(NeoMutt->sub, "imap_keepalive");
-  alarm(c_imap_keepalive);
+  const short c_imap_keep_alive = cs_subset_number(NeoMutt->sub, "imap_keep_alive");
+  alarm(c_imap_keep_alive);
   while ((waitpid(pid, &rc, 0) < 0) && (errno == EINTR))
   {
     alarm(0); /* cancel a possibly pending alarm */
-    imap_keepalive();
-    alarm(c_imap_keepalive);
+    imap_keep_alive();
+    alarm(c_imap_keep_alive);
   }
 
   alarm(0); /* cancel a possibly pending alarm */

--- a/keymap.c
+++ b/keymap.c
@@ -651,7 +651,7 @@ struct KeyEvent km_dokey_event(enum MenuType mtype)
     return retry_generic(mtype, NULL, 0, 0);
 
 #ifdef USE_IMAP
-  const short c_imap_keepalive = cs_subset_number(NeoMutt->sub, "imap_keepalive");
+  const short c_imap_keep_alive = cs_subset_number(NeoMutt->sub, "imap_keep_alive");
 #endif
 
   const short c_timeout = cs_subset_number(NeoMutt->sub, "timeout");
@@ -659,18 +659,18 @@ struct KeyEvent km_dokey_event(enum MenuType mtype)
   {
     int i = (c_timeout > 0) ? c_timeout : 60;
 #ifdef USE_IMAP
-    /* keepalive may need to run more frequently than `$timeout` allows */
-    if (c_imap_keepalive != 0)
+    /* keep_alive may need to run more frequently than `$timeout` allows */
+    if (c_imap_keep_alive != 0)
     {
-      if (c_imap_keepalive >= i)
+      if (c_imap_keep_alive >= i)
       {
-        imap_keepalive();
+        imap_keep_alive();
       }
       else
       {
-        while (c_imap_keepalive < i)
+        while (c_imap_keep_alive < i)
         {
-          tmp = mutt_getch_timeout(c_imap_keepalive * 1000);
+          tmp = mutt_getch_timeout(c_imap_keep_alive * 1000);
           /* If a timeout was not received, or the window was resized, exit the
            * loop now.  Otherwise, continue to loop until reaching a total of
            * $timeout seconds.  */
@@ -680,8 +680,8 @@ struct KeyEvent km_dokey_event(enum MenuType mtype)
           if (MonitorFilesChanged)
             goto gotkey;
 #endif
-          i -= c_imap_keepalive;
-          imap_keepalive();
+          i -= c_imap_keep_alive;
+          imap_keep_alive();
         }
       }
     }

--- a/system.c
+++ b/system.c
@@ -93,7 +93,7 @@ int mutt_system(const char *cmd)
   else if (pid != -1)
   {
 #ifdef USE_IMAP
-    rc = imap_wait_keepalive(pid);
+    rc = imap_wait_keep_alive(pid);
 #endif
   }
 


### PR DESCRIPTION
Rename `$imap_keepalive` to `$imap_keep_alive` for consistency with the other config.