### PR TITLE
Don't create empty buffers for Address mailbox/personal parts

### DIFF
--- a/address/address.c
+++ b/address/address.c
@@ -412,8 +412,14 @@ struct Address *mutt_addr_new(void)
 struct Address *mutt_addr_create(const char *personal, const char *mailbox)
 {
   struct Address *a = mutt_addr_new();
-  a->personal = buf_new(personal);
-  a->mailbox = buf_new(mailbox);
+  if (personal)
+  {
+    a->personal = buf_new(personal);
+  }
+  if (mailbox)
+  {
+    a->mailbox = buf_new(mailbox);
+  }
   return a;
 }
 
@@ -542,7 +548,10 @@ int mutt_addrlist_parse(struct AddressList *al, const char *s)
       {
         struct Address *a = mutt_addr_new();
         terminate_buffer(phrase, phraselen);
-        a->mailbox = buf_new(phrase);
+        if (phraselen != 0)
+        {
+          a->mailbox = buf_new(phrase);
+        }
         a->group = true;
         mutt_addrlist_append(al, a);
         phraselen = 0;
@@ -555,7 +564,10 @@ int mutt_addrlist_parse(struct AddressList *al, const char *s)
       {
         struct Address *a = mutt_addr_new();
         terminate_buffer(phrase, phraselen);
-        a->personal = buf_new(phrase);
+        if (phraselen != 0)
+        {
+          a->personal = buf_new(phrase);
+        }
         s = parse_route_addr(s + 1, comment, &commentlen, sizeof(comment) - 1, a);
         if (!s)
         {

--- a/hcache/serialize.c
+++ b/hcache/serialize.c
@@ -252,10 +252,20 @@ void serial_restore_address(struct AddressList *al, const unsigned char *d,
   while (counter)
   {
     struct Address *a = mutt_addr_new();
+
     a->personal = buf_new(NULL);
-    a->mailbox = buf_new(NULL);
     serial_restore_buffer(a->personal, d, off, convert);
+    if (buf_is_empty(a->personal))
+    {
+      buf_free(&a->personal);
+    }
+
+    a->mailbox = buf_new(NULL);
     serial_restore_buffer(a->mailbox, d, off, false);
+    if (buf_is_empty(a->mailbox))
+    {
+      buf_free(&a->mailbox);
+    }
 
     serial_restore_int(&g, d, off);
     a->group = !!g;


### PR DESCRIPTION
The code base is still treating `a->personal` and `a->mailbox` as strings, i.e., a non-NULL value means a non-empty string.

Alternatively, we could change the callers to check for `buf_is_empty`, but we would probably still check if the pointers are valid, so at this point I guess I'd go the cheap way and *not* have a `personal` or `mailbox` member if it's empty.