### PR TITLE
fix coverity defects

### DIFF
--- a/compmbox/compress.c
+++ b/compmbox/compress.c
@@ -35,6 +35,7 @@
  */
 
 #include "config.h"
+#include <errno.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -713,7 +714,11 @@ static enum MxStatus comp_mbox_close(struct Mailbox *m)
     }
     else
     {
-      remove(mailbox_path(m));
+      if (remove(mailbox_path(m)) < 0)
+      {
+        mutt_debug(LL_DEBUG1, "remove failed: %s: %s (errno %d)\n",
+                   mailbox_path(m), strerror(errno), errno);
+      }
     }
 
     unlock_realpath(m);
@@ -726,12 +731,20 @@ static enum MxStatus comp_mbox_close(struct Mailbox *m)
       const bool c_save_empty = cs_subset_bool(NeoMutt->sub, "save_empty");
       if (!c_save_empty)
       {
-        remove(m->realpath);
+        if (remove(m->realpath) < 0)
+        {
+          mutt_debug(LL_DEBUG1, "remove failed: %s: %s (errno %d)\n",
+                     m->realpath, strerror(errno), errno);
+        }
       }
     }
     else
     {
-      remove(mailbox_path(m));
+      if (remove(mailbox_path(m)) < 0)
+      {
+        mutt_debug(LL_DEBUG1, "remove failed: %s: %s (errno %d)\n",
+                   mailbox_path(m), strerror(errno), errno);
+      }
     }
   }
 

--- a/email/parse.c
+++ b/email/parse.c
@@ -29,6 +29,7 @@
 
 #include "config.h"
 #include <ctype.h>
+#include <errno.h>
 #include <string.h>
 #include <time.h>
 #include "mutt/lib.h"
@@ -1174,6 +1175,12 @@ struct Envelope *mutt_rfc822_read_header(FILE *fp, struct Email *e, bool user_hd
   struct Envelope *env = mutt_env_new();
   char *p = NULL;
   LOFF_T loc = e ? e->offset : ftello(fp);
+  if (loc < 0)
+  {
+    mutt_debug(LL_DEBUG1, "ftello: %s (errno %d)\n", strerror(errno), errno);
+    loc = 0;
+  }
+
   struct Buffer *line = buf_pool_get();
 
   if (e)

--- a/email/parse.c
+++ b/email/parse.c
@@ -1127,7 +1127,7 @@ size_t mutt_rfc822_read_line(FILE *fp, struct Buffer *buf)
       } while (off && isspace(line[--off]));
 
       /* check to see if the next line is a continuation line */
-      char ch = fgetc(fp);
+      int ch = fgetc(fp);
       if ((ch != ' ') && (ch != '\t'))
       {
         /* next line is a separate header field or EOH */
@@ -1135,12 +1135,12 @@ size_t mutt_rfc822_read_line(FILE *fp, struct Buffer *buf)
         buf_addstr(buf, line);
         break;
       }
-      ++read;
+      read++;
 
       /* eat tabs and spaces from the beginning of the continuation line */
       while (((ch = fgetc(fp)) == ' ') || (ch == '\t'))
       {
-        ++read;
+        read++;
       }
 
       ungetc(ch, fp);

--- a/imap/message.c
+++ b/imap/message.c
@@ -2094,7 +2094,8 @@ bool imap_msg_open(struct Mailbox *m, struct Message *msg, struct Email *e)
   if (!fetched || !imap_code(adata->buf))
     goto bail;
 
-  msg_cache_commit(m, e);
+  if (msg_cache_commit(m, e) < 0)
+    mutt_debug(LL_DEBUG1, "failed to add message to cache\n");
 
 parsemsg:
   /* Update the header information.  Previously, we only downloaded a

--- a/init.c
+++ b/init.c
@@ -28,6 +28,7 @@
  */
 
 #include "config.h"
+#include <errno.h>
 #include <pwd.h>
 #include <stdbool.h>
 #include <stdio.h>
@@ -575,7 +576,11 @@ int mutt_init(struct ConfigSet *cs, bool skip_sys_rc, struct ListHead *commands)
   }
 
   const char *const c_tmp_dir = cs_subset_path(NeoMutt->sub, "tmp_dir");
-  mutt_file_mkdir(c_tmp_dir, S_IRWXU);
+  if (mutt_file_mkdir(c_tmp_dir, S_IRWXU) < 0)
+  {
+    mutt_error(_("Can't create %s: %s"), c_tmp_dir, strerror(errno));
+    goto done;
+  }
 
   mutt_hist_init();
   mutt_hist_read_file();

--- a/mailcap.c
+++ b/mailcap.c
@@ -361,7 +361,12 @@ static bool rfc1524_mailcap_parse(struct Body *a, const char *filename, const ch
               buf_sanitize_filename(afilename, NONULL(a->filename), true);
             else
               buf_strcpy(afilename, NONULL(a->filename));
-            mailcap_expand_command(a, buf_string(afilename), type, command);
+            if (mailcap_expand_command(a, buf_string(afilename), type, command) == 1)
+            {
+              mutt_debug(LL_DEBUG1, "mailcap command needs a pipe: %s\n",
+                         buf_string(command));
+            }
+
             if (mutt_system(buf_string(command)))
             {
               /* a non-zero exit code means test failed */

--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -34,6 +34,7 @@
  */
 
 #include "config.h"
+#include <errno.h>
 #include <fcntl.h>
 #include <inttypes.h>
 #include <limits.h>
@@ -385,6 +386,12 @@ static enum MxOpenReturns mbox_parse_mailbox(struct Mailbox *m)
   }
 
   loc = ftello(adata->fp);
+  if (loc < 0)
+  {
+    mutt_debug(LL_DEBUG1, "ftello: %s (errno %d)\n", strerror(errno), errno);
+    loc = 0;
+  }
+
   while ((fgets(buf, sizeof(buf), adata->fp)) && !SigInt)
   {
     if (is_from(buf, return_path, sizeof(return_path), &t))
@@ -428,6 +435,11 @@ static enum MxOpenReturns mbox_parse_mailbox(struct Mailbox *m)
         LOFF_T tmploc;
 
         loc = ftello(adata->fp);
+        if (loc < 0)
+        {
+          mutt_debug(LL_DEBUG1, "ftello: %s (errno %d)\n", strerror(errno), errno);
+          loc = 0;
+        }
 
         /* The test below avoids a potential integer overflow if the
          * content-length is huge (thus necessarily invalid).  */

--- a/mutt/buffer.c
+++ b/mutt/buffer.c
@@ -350,7 +350,12 @@ void buf_alloc(struct Buffer *buf, size_t new_size)
     return;
 
   if (buf->data && (new_size <= buf->dsize))
+  {
+    // Extra sanity-checking
+    if (!buf->dptr || (buf->dptr < buf->data) || (buf->dptr > (buf->data + buf->dsize)))
+      buf->dptr = buf->data;
     return;
+  }
 
   if (new_size > (SIZE_MAX - BufferStepSize))
   {
@@ -366,12 +371,11 @@ void buf_alloc(struct Buffer *buf, size_t new_size)
   buf->dsize = ROUND_UP(new_size + 1, BufferStepSize);
 
   mutt_mem_realloc(&buf->data, buf->dsize);
-  buf_seek(buf, offset);
+  buf->dptr = buf->data + offset;
 
   // Ensures that initially NULL buf->data is properly terminated
   if (was_empty)
   {
-    buf->dptr = buf->data;
     *buf->dptr = '\0';
   }
 }

--- a/ncrypt/crypt_gpgme.c
+++ b/ncrypt/crypt_gpgme.c
@@ -1764,7 +1764,6 @@ restart:
         plaintext = NULL;
         /* gpgsm ends the session after an error; restart it */
         gpgme_release(ctx);
-        ctx = NULL;
         goto restart;
       }
     }

--- a/pattern/exec.c
+++ b/pattern/exec.c
@@ -172,6 +172,9 @@ static bool msg_search(struct Pattern *pat, struct Email *e, struct Message *msg
 
       if (!mutt_file_seek(msg->fp, e->offset, SEEK_SET))
       {
+#ifdef USE_FMEMOPEN
+        FREE(&temp);
+#endif
         return false;
       }
       mutt_body_handler(e->body, &state);
@@ -197,6 +200,7 @@ static bool msg_search(struct Pattern *pat, struct Email *e, struct Message *msg
       if (!fp)
       {
         mutt_perror(_("Error opening /dev/null"));
+        FREE(&temp);
         return false;
       }
     }

--- a/pattern/pattern.c
+++ b/pattern/pattern.c
@@ -447,6 +447,8 @@ int mutt_search_command(struct MailboxView *mv, struct Menu *menu, int cur, int 
   struct Buffer *buf = NULL;
   int rc = -1;
   struct Mailbox *m = mv ? mv->mailbox : NULL;
+  if (!m)
+    return -1;
 
   if ((*LastSearch == '\0') || ((op != OP_SEARCH_NEXT) && (op != OP_SEARCH_OPPOSITE)))
   {

--- a/send/smtp.c
+++ b/send/smtp.c
@@ -861,8 +861,8 @@ static int smtp_auth_login(struct SmtpAccountData *adata, const char *method)
   }
 
   /* Read the 334 VXNlcm5hbWU6 challenge ("Username:" base64-encoded) */
-  mutt_socket_readln_d(buf, sizeof(buf), adata->conn, MUTT_SOCK_LOG_FULL);
-  if (!mutt_str_equal(buf, "334 VXNlcm5hbWU6"))
+  int rc = mutt_socket_readln_d(buf, sizeof(buf), adata->conn, MUTT_SOCK_LOG_FULL);
+  if ((rc < 0) || !mutt_str_equal(buf, "334 VXNlcm5hbWU6"))
   {
     goto error;
   }
@@ -877,8 +877,8 @@ static int smtp_auth_login(struct SmtpAccountData *adata, const char *method)
   }
 
   /* Read the 334 UGFzc3dvcmQ6 challenge ("Password:" base64-encoded) */
-  mutt_socket_readln_d(buf, sizeof(buf), adata->conn, MUTT_SOCK_LOG_FULL);
-  if (!mutt_str_equal(buf, "334 UGFzc3dvcmQ6"))
+  rc = mutt_socket_readln_d(buf, sizeof(buf), adata->conn, MUTT_SOCK_LOG_FULL);
+  if ((rc < 0) || !mutt_str_equal(buf, "334 UGFzc3dvcmQ6"))
   {
     goto error;
   }


### PR DESCRIPTION
A bunch of small fixes to check return values, avoid null pointers, etc.

Note: the links won't work if you don't have access to [our Coverity Account](https://scan.coverity.com/projects/neomutt-neomutt).

- f6fe70e52 [coverity 76952](https://scan9.scan.coverity.com/reports.htm#v28870/p12145/fileInstanceId=114668943&defectInstanceId=9078682&mergedDefectId=76952) Improper use of negative value
- a34773fdb [coverity 186475](https://scan9.scan.coverity.com/reports.htm#v28870/p12145/fileInstanceId=114668507&defectInstanceId=9026208&mergedDefectId=186475) Unchecked return value from library
- 869a793fa [coverity 204088](https://scan9.scan.coverity.com/reports.htm#v28870/p12145/fileInstanceId=114668334&defectInstanceId=9063748&mergedDefectId=204088) Unchecked return value
- 1a9bc963d [coverity 208392](https://scan9.scan.coverity.com/reports.htm#v28870/p12145/fileInstanceId=114668322&defectInstanceId=9063750&mergedDefectId=208392) Unchecked return value
- 4e9402abf [coverity 209342](https://scan9.scan.coverity.com/reports.htm#v28870/p12145/fileInstanceId=114668668&defectInstanceId=9026220&mergedDefectId=209342) Resource leak
- 5ac48a145 [coverity 215479](https://scan9.scan.coverity.com/reports.htm#v28870/p12145/fileInstanceId=114668595&defectInstanceId=9063752&mergedDefectId=215479) Unchecked return value
- 128aca8c6 [coverity 300228](https://scan9.scan.coverity.com/reports.htm#v28870/p12145/fileInstanceId=114668802&defectInstanceId=9063754&mergedDefectId=300228) Unchecked return value from library
- 21665c43c [coverity 313624](https://scan9.scan.coverity.com/reports.htm#v28870/p12145/fileInstanceId=114668945&defectInstanceId=9063736&mergedDefectId=313624) Dereference after null check
- ef82ca53b [coverity 313932](https://scan9.scan.coverity.com/reports.htm#v28870/p12145/fileInstanceId=114668944&defectInstanceId=9058597&mergedDefectId=313932) Truncated stdio return value
- c1dd60feb [coverity 315319](https://scan9.scan.coverity.com/reports.htm#v28870/p12145/fileInstanceId=114668756&defectInstanceId=9063741&mergedDefectId=315319) Unused value
- b5949145f [coverity 315730](https://scan9.scan.coverity.com/reports.htm#v28870/p12145/fileInstanceId=114668672&defectInstanceId=9058609&mergedDefectId=315730) Explicit null dereferenced

