### PR TITLE
expandos: use `%<...>` conditionals

### DIFF
--- a/browser/config.c
+++ b/browser/config.c
@@ -64,7 +64,7 @@ static struct ConfigDef BrowserVars[] = {
   { "group_index_format", DT_STRING|DT_NOT_EMPTY|R_INDEX, IP "%4C %M%N %5s  %-45.45f %d", 0, NULL,
     "(nntp) printf-like format string for the browser's display of newsgroups"
   },
-  { "mailbox_folder_format", DT_STRING|DT_NOT_EMPTY, IP "%2C %?n?%6n&%6 ? %6m %i", 0, NULL,
+  { "mailbox_folder_format", DT_STRING|DT_NOT_EMPTY, IP "%2C %<n?%6n&      > %6m %i", 0, NULL,
     "printf-like format string for the browser's display of mailbox folders"
   },
   { "mask", DT_REGEX|DT_REGEX_MATCH_CASE|DT_REGEX_ALLOW_NOT|DT_REGEX_NOSUB, IP "!^\\.[^.]", 0, NULL,

--- a/docs/config.c
+++ b/docs/config.c
@@ -241,7 +241,7 @@
 ** of the value as shown above if included.
 */
 
-{ "attach_format", DT_STRING, "%u%D%I %t%4n %T%.40d%> [%.7m/%.10M, %.6e%?C?, %C?, %s] " },
+{ "attach_format", DT_STRING, "%u%D%I %t%4n %T%d %> [%.7m/%.10M, %.6e%<C?, %C>, %s] " },
 /*
 ** .pp
 ** This variable describes the format of the "attachment" menu.  The
@@ -2072,7 +2072,7 @@
 ** $$index_format for supported \fCprintf(3)\fP-style sequences.
 */
 
-{ "index_format", DT_STRING, "%4C %Z %{%b %d} %-15.15L (%?l?%4l&%4c?) %s" },
+{ "index_format", DT_STRING, "%4C %Z %{%b %d} %-15.15L (%<l?%4l&%4c>) %s" },
 /*
 ** .pp
 ** This variable allows you to customize the message index display to
@@ -2080,7 +2080,7 @@
 ** .pp
 ** "Format strings" are similar to the strings used in the C
 ** function \fCprintf(3)\fP to format output (see the man page for more details).
-** For an explanation of the %? construct, see the $status_format description.
+** For an explanation of the %<...> construct, see the $status_format description.
 ** The following sequences are defined in NeoMutt:
 ** .dl
 ** .dt %a .dd Address of the author
@@ -2276,7 +2276,7 @@
 ** how often (in seconds) NeoMutt will update message counts.
 */
 
-{ "mailbox_folder_format", DT_STRING, "%2C %?n?%6n&%6 ? %6m %i" },
+{ "mailbox_folder_format", DT_STRING, "%2C %<n?%6n&      > %6m %i" },
 /*
 ** .pp
 ** This variable allows you to customize the file browser display to your
@@ -3049,7 +3049,7 @@
 **            of $$pgp_default_key.
 ** .dt %f .dd Expands to the name of a file containing a message.
 ** .dt %p .dd Expands to PGPPASSFD=0 when a pass phrase is needed, to an empty
-**            string otherwise. Note: This may be used with a %? construct.
+**            string otherwise. Note: This may be used with a %<...> construct.
 ** .dt %r .dd One or more key IDs (or fingerprints if available).
 ** .dt %s .dd Expands to the name of a file containing the signature part
 **            of a \fCmultipart/signed\fP attachment when verifying it.
@@ -4279,7 +4279,7 @@
 ** .pp
 ** In order to use %S, %N, %F, and %!, $$mail_check_stats must
 ** be \fIset\fP.  When thus set, a suggested value for this option is
-** "%B%?F? [%F]?%* %?N?%N/?%S".
+** "%B%<F? [%F]>%* %<N?%N/>%S".
 */
 
 { "sidebar_indent_string", DT_STRING, "  " },
@@ -5144,7 +5144,7 @@
 ** .de
 */
 
-{ "status_format", DT_STRING, "-%r-NeoMutt: %D [Msgs:%?M?%M/?%m%?n? New:%n?%?o? Old:%o?%?d? Del:%d?%?F? Flag:%F?%?t? Tag:%t?%?p? Post:%p?%?b? Inc:%b?%?l? %l?]---(%?T?%T/?%s/%S)-%>-(%P)---" },
+{ "status_format", DT_STRING, "-%r-NeoMutt: %D [Msgs:%<M?%M/>%m%<n? New:%n>%<o? Old:%o>%<d? Del:%d>%<F? Flag:%F>%<t? Tag:%t>%<p? Post:%p>%<b? Inc:%b>%<l? %l>]---(%<T?%T/>%s/%S)-%>-(%P)---" },
 /*
 ** .pp
 ** Controls the format of the status line displayed in the "index"
@@ -5191,22 +5191,21 @@
 ** particularly meaningful.  To optionally print a string based upon one
 ** of the above sequences, the following construct is used:
 ** .pp
-**  \fC%?<sequence_char>?<optional_string>?\fP
+**  \fC%<sequence_char?optional_string>\fP
 ** .pp
 ** where \fIsequence_char\fP is a character from the table above, and
 ** \fIoptional_string\fP is the string you would like printed if
 ** \fIsequence_char\fP is nonzero.  \fIoptional_string\fP \fBmay\fP contain
-** other sequences as well as normal text, but you may \fBnot\fP nest
-** optional strings.
+** other sequences as well as normal text.
 ** .pp
 ** Here is an example illustrating how to optionally print the number of
 ** new messages in a mailbox:
 ** .pp
-** \fC%?n?%n new messages.?\fP
+** \fC%<n?%n new messages>\fP
 ** .pp
 ** You can also switch between two strings using the following construct:
 ** .pp
-** \fC%?<sequence_char>?<if_string>&<else_string>?\fP
+** \fC%<sequence_char?if_string&else_string>\fP
 ** .pp
 ** If the value of \fIsequence_char\fP is non-zero, \fIif_string\fP will
 ** be expanded, otherwise \fIelse_string\fP will be expanded.
@@ -5215,7 +5214,7 @@
 ** $$sort_aux or $$use_threads and $$sort, based on whether threads
 ** are enabled with $$use_threads:
 ** .pp
-** \fC%?T?%s/%S&%T/%s?\fP
+** \fC%<T?%s/%S&%T/%s>\fP
 ** .pp
 ** You can force the result of any \fCprintf(3)\fP-like sequence to be lowercase
 ** by prefixing the sequence character with an underscore ("_") sign.
@@ -5395,7 +5394,7 @@
 ** Most terminal emulators emulate the status line in the window title.
 */
 
-{ "ts_icon_format", DT_STRING, "M%?n?AIL&ail?" },
+{ "ts_icon_format", DT_STRING, "M%<n?AIL&ail>" },
 /*
 ** .pp
 ** Controls the format of the icon title, as long as "$$ts_enabled" is set.
@@ -5403,7 +5402,7 @@
 ** "$$status_format".
 */
 
-{ "ts_status_format", DT_STRING, "NeoMutt with %?m?%m messages&no messages?%?n? [%n NEW]?" },
+{ "ts_status_format", DT_STRING, "NeoMutt with %<m?%m messages&no messages>%<n? [%n NEW]>" },
 /*
 ** .pp
 ** Controls the format of the terminal status line (or window title),

--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -376,7 +376,7 @@ vim: ts=2 sw=2 sts=2 expandtab:
 
 <screen>
 set sidebar_visible
-set sidebar_format = "%B%?F? [%F]?%* %?N?%N/?%S"
+set sidebar_format = "%B%&lt;F? [%F]&gt;%* %&lt;N?%N/&gt;%S"
 set mail_check_stats
 </screen>
 
@@ -697,7 +697,7 @@ set sidebar_divider_char = '│'          <emphasis role="comment"># Pretty line
             </para>
             <para>
               A more detailed value is:
-              <literal>%B%?F? [%F]?%* %?N?%N/?%S</literal>
+              <literal>%B%&lt;F? [%F]&gt;%* %&lt;N?%N/&gt;%S</literal>
             </para>
             <itemizedlist>
               <title>Which breaks down as:</title>
@@ -708,7 +708,7 @@ set sidebar_divider_char = '│'          <emphasis role="comment"># Pretty line
               </listitem>
               <listitem>
                 <para>
-                  <literal>%?F? [%F]?</literal> – If flagged emails
+                  <literal>%&lt;F? [%F]&gt;</literal> – If flagged emails
                   <literal>[%F]</literal>, otherwise nothing
                 </para>
               </listitem>
@@ -719,7 +719,7 @@ set sidebar_divider_char = '│'          <emphasis role="comment"># Pretty line
               </listitem>
               <listitem>
                 <para>
-                  <literal>%?N?%N/?</literal> – If new emails
+                  <literal>%&lt;N?%N/&gt;</literal> – If new emails
                   <literal>%N/</literal>, otherwise nothing
                 </para>
               </listitem>
@@ -886,7 +886,7 @@ set sidebar_divider_char = '│'          <emphasis role="comment"># Pretty line
                 </thead>
                 <tbody>
                   <row>
-                    <entry><literal>%B%?F? [%F]?%* %?N?%N/?%S</literal></entry>
+                    <entry><literal>%B%&lt;F? [%F]&gt;%* %&lt;N?%N/&gt;%S</literal></entry>
                     <entry><screen>mailbox [F]            N/S </screen></entry>
                   </row>
                   <row>
@@ -894,11 +894,11 @@ set sidebar_divider_char = '│'          <emphasis role="comment"># Pretty line
                     <entry><screen>mailbox              F:N:S </screen></entry>
                   </row>
                   <row>
-                    <entry><literal>%B %?N?(%N)?%* %S</literal></entry>
+                    <entry><literal>%B %&lt;N?(%N)&gt;%* %S</literal></entry>
                     <entry><screen>mailbox (N)              S </screen></entry>
                   </row>
                   <row>
-                    <entry><literal>%B%* ?F?%F/?%N</literal></entry>
+                    <entry><literal>%B%* %&lt;F?%F/&gt;%N</literal></entry>
                     <entry><screen>mailbox                F/S </screen></entry>
                   </row>
                 </tbody>
@@ -2198,10 +2198,10 @@ color sidebar_divider    color8  default     <emphasis role="comment"># Dark gre
           hides the others. This is useful when threads contain so many
           messages that you can only see a handful of threads on the screen.
           See %M in <link linkend="index-format">$index_format</link>. For
-          example, you could use <quote>%?M?(#%03M)&amp;(%4l)?</quote> in
+          example, you could use <literal>%&lt;M?(#%03M)&amp;(%4l)&gt;</literal> in
           <link linkend="index-format">$index_format</link> to optionally display
           the number of hidden messages if the thread is collapsed. The
-          <literal>%?&lt;char&gt;?&lt;if-part&gt;&amp;&lt;else-part&gt;?</literal>
+          <literal>%&lt;char?if-part&amp;else-part&gt;</literal>
           syntax is explained in detail in
           <link linkend="formatstrings-conditionals">format string conditionals</link>.
         </para>
@@ -6968,7 +6968,7 @@ folder-hook . 'push "&lt;enter-command&gt;score ~= 10&lt;enter&gt;"'
         also can display the spam attributes in your index display using the
         <literal>%H</literal> selector in the
         <link linkend="index-format">$index_format</link> variable. (Tip: try
-        <literal>%?H?[%H] ?</literal> to display spam tags only when they are
+        <literal>%&lt;H?[%H] &gt;</literal> to display spam tags only when they are
         defined for a given message.)
       </para>
       <para>
@@ -7685,7 +7685,7 @@ mailboxes $my_mx +mailbox3
           optionally print a string based upon one of the above sequences, the
           following construct is used:
         </para>
-        <screen>%?&lt;sequence_char&gt;?&lt;optional_string&gt;?</screen>
+        <screen>%&lt;sequence_char?optional_string&gt;</screen>
         <para>
           where <emphasis>sequence_char</emphasis> is an expando, and
           <emphasis>optional_string</emphasis> is the string you would like
@@ -7695,17 +7695,17 @@ mailboxes $my_mx +mailbox3
         </para>
         <para>
           Here is an example illustrating how to optionally print the number of
-          new messages in a mailbox in
+          new messages (<literal>%n</literal>) in a mailbox in
           <link linkend="status-format">$status_format</link>:
         </para>
-        <screen>%?n?%n new messages.?</screen>
+        <screen>%&lt;n?%n new messages&gt;</screen>
         <para>
           You can also switch between two strings using the following
           construct:
         </para>
 
 <screen>
-%?&lt;sequence_char&gt;?&lt;if_string&gt;&amp;&lt;else_string&gt;?
+%&lt;sequence_char?if_string&amp;else_string&gt;
 </screen>
 
         <para>
@@ -7781,7 +7781,7 @@ mailboxes $my_mx +mailbox3
               </para>
 
 <screen>
-set status_format = "%v on %h: %B: %?n?%n&amp;no? new messages %|-"
+set status_format = "%v on %h: %B: %&lt;n?%n&amp;no&gt; new messages %|-"
 </screen>
 
             </listitem>
@@ -7803,7 +7803,7 @@ set status_format = "%v on %h: %B: %?n?%n&amp;no? new messages %|-"
               </para>
 
 <screen>
-set status_format = "%B: %?n?%n&amp;no? new messages %&gt; (%v on %h)"
+set status_format = "%B: %&lt;n?%n&amp;no&gt; new messages %&gt; (%v on %h)"
 </screen>
 
             </listitem>
@@ -7828,7 +7828,7 @@ set status_format = "%B: %?n?%n&amp;no? new messages %&gt; (%v on %h)"
               </para>
 
 <screen>
-set index_format="%4C %Z %{%b %d} %-15.15L (%?l?%4l&amp;%4c?)%*  %s"
+set index_format="%4C %Z %{%b %d} %-15.15L (%&lt;l?%4l&amp;%4c&gt;)%*  %s"
 </screen>
 
             </listitem>
@@ -13853,7 +13853,7 @@ close-hook  '\.gpg$' "gpg --encrypt --recipient YourGpgUserIdOrKeyId &lt; '%t' &
           NeoMutt's conditional format strings have the form: (whitespace
           introduced for clarity)
         </para>
-        <screen>%? TEST ? TRUE &amp; FALSE ?</screen>
+        <screen>%&lt; TEST ? TRUE &amp; FALSE &gt;</screen>
         <para>
           The examples below use the test <quote>%[</quote> – the date of the
           message in the local timezone. They will also work with
@@ -13862,7 +13862,7 @@ close-hook  '\.gpg$' "gpg --encrypt --recipient YourGpgUserIdOrKeyId &lt; '%t' &
         <para>
           The date tests are of the form:
         </para>
-        <screen>%[nX? TRUE &amp; FALSE ?</screen>
+        <screen>%&lt;[nX? TRUE &amp; FALSE &gt;</screen>
         <itemizedlist>
           <listitem>
             <para>
@@ -13988,14 +13988,14 @@ close-hook  '\.gpg$' "gpg --encrypt --recipient YourGpgUserIdOrKeyId &lt; '%t' &
           <para>
             The $index_format string would contain:
           </para>
-          <screen>%?[1m?%[%b %d]&amp;%[%Y-%m-%d]?</screen>
+          <screen>%&lt;[1m?%[%b %d]&amp;%[%Y-%m-%d]&gt;</screen>
           <para>
             Reparsed a little, for clarity, you can see the test condition and
             the two format strings.
           </para>
 
 <screen>
-%?[1m?        &amp;           ?
+%&lt;[1m?        &amp;           &gt;
 
       %[%b %d] %[%Y-%m-%d]
 </screen>
@@ -14076,8 +14076,7 @@ close-hook  '\.gpg$' "gpg --encrypt --recipient YourGpgUserIdOrKeyId &lt; '%t' &
 %&lt;[y? %&lt;[m? %&lt;[d? AAA &amp; BBB &gt; &amp; CCC &gt; &amp; DDD &gt;
 </screen>
 
-          <literallayout>AAA = %[%H:%M ] BBB = %[%a %d] CCC = %[%b %d] DDD =
-          %[%m/%y ]</literallayout>
+          <literallayout>AAA = %[%H:%M ] BBB = %[%a %d] CCC = %[%b %d] DDD = %[%m/%y ]</literallayout>
         </sect3>
       </sect2>
 
@@ -14097,10 +14096,10 @@ close-hook  '\.gpg$' "gpg --encrypt --recipient YourGpgUserIdOrKeyId &lt; '%t' &
 
 <emphasis role="comment">#</emphasis>
 <emphasis role="comment"># The default index_format is:</emphasis>
-<emphasis role="comment">#       '%4C %Z %{%b %d} %-15.15L (%?l?%4l&amp;%4c?) %s'</emphasis>
+<emphasis role="comment">#       '%4C %Z %{%b %d} %-15.15L (%&lt;l?%4l&amp;%4c&gt;) %s'</emphasis>
 <emphasis role="comment">#</emphasis>
 <emphasis role="comment"># We replace the date field '%{%b %d}', giving:</emphasis>
-set index_format='%4C %Z %&lt;[y?%&lt;[m?%&lt;[d?%[%H:%M ]&amp;%[%a %d]&gt;&amp;%[%b %d]&gt;&amp;%[%m/%y ]&gt; %-15.15L (%?l?%4l&amp;%4c?) %s'
+set index_format='%4C %Z %&lt;[y?%&lt;[m?%&lt;[d?%[%H:%M ]&amp;%[%a %d]&gt;&amp;%[%b %d]&gt;&amp;%[%m/%y ]&gt; %-15.15L (%&lt;l?%4l&amp;%4c&gt;) %s'
 <emphasis role="comment"># Test  Date Range  Format String  Example</emphasis>
 <emphasis role="comment"># --------------------------------------------</emphasis>
 <emphasis role="comment"># %[d   Today       %[%H:%M ]      12:34</emphasis>
@@ -15207,7 +15206,7 @@ color index_size cyan default
 <emphasis role="comment"># which can be used in the 'index_format' variable.</emphasis>
 
 <emphasis role="comment"># The default 'index_format' is:</emphasis>
-set index_format='%4C %Z %{%b %d} %-15.15L (%?l?%4l&amp;%4c?) %s'
+set index_format='%4C %Z %{%b %d} %-15.15L (%&lt;l?%4l&amp;%4c&gt;) %s'
 <emphasis role="comment"># Where %L represents the author/recipient</emphasis>
 <emphasis role="comment"># This might look like:</emphasis>
 <emphasis role="comment">#       1   + Nov 17 David Bowie   Changesbowie    ( 689)</emphasis>
@@ -15215,7 +15214,7 @@ set index_format='%4C %Z %{%b %d} %-15.15L (%?l?%4l&amp;%4c?) %s'
 <emphasis role="comment">#       3   + Nov 16 Jimi Hendrix  Voodoo Child    ( 263)</emphasis>
 <emphasis role="comment">#       4   + Nov 16 Debbie Harry  Parallel Lines  ( 540)</emphasis>
 <emphasis role="comment"># Using the %I expando:</emphasis>
-set index_format='%4C %Z %{%b %d} %I (%?l?%4l&amp;%4c?) %s'
+set index_format='%4C %Z %{%b %d} %I (%&lt;l?%4l&amp;%4c&gt;) %s'
 <emphasis role="comment"># This might look like:</emphasis>
 <emphasis role="comment">#       1   + Nov 17 DB Changesbowie    ( 689)</emphasis>
 <emphasis role="comment">#       2   ! Nov 17 SN Rumours         ( 555)</emphasis>
@@ -16496,7 +16495,7 @@ macro index,pager tt "&lt;modify-labels&gt;!todo\n" "Toggle the 'todo' tag"
 <emphasis role="comment"># Now instead of using '%g' or '%J' in your $index_format, which lists all tags</emphasis>
 <emphasis role="comment"># in a non-deterministic order, you can something like the following which puts</emphasis>
 <emphasis role="comment"># a transformed tag name in a specific spot on the index line:</emphasis>
-<emphasis role="comment"># set index_format='%4C %S %[%y.%m.%d] %-18.18n %?GU?%GU&amp; ? %?GR?%GR&amp; ? %?GI?%GI&amp; ? %s'</emphasis>
+<emphasis role="comment"># set index_format='%4C %S %[%y.%m.%d] %-18.18n %&lt;GU?%GU&amp; &gt; %&lt;GR?%GR&amp; &gt; %&lt;GI?%GI&amp; &gt; %s'</emphasis>
 
 <emphasis role="comment"># The %G formatting sequence may display all tags including tags hidden by</emphasis>
 <emphasis role="comment"># hidden_tags.</emphasis>
@@ -17994,7 +17993,7 @@ set sidebar_divider_char = '|'
 <emphasis role="comment"># message counts for each mailbox.</emphasis>
 set mail_check_stats
 <emphasis role="comment"># Display the Sidebar mailboxes using this format string.</emphasis>
-set sidebar_format = '%B%?F? [%F]?%* %?N?%N/?%S'
+set sidebar_format = '%B%&lt;F? [%F]&gt;%* %&lt;N?%N/&gt;%S'
 <emphasis role="comment"># Sort the mailboxes in the Sidebar using this method:</emphasis>
 <emphasis role="comment">#       count    – total number of messages</emphasis>
 <emphasis role="comment">#       flagged  – number of flagged messages</emphasis>
@@ -18343,9 +18342,9 @@ set toggle_quoted_show_levels = 1
 <emphasis role="comment"># the status bar (also when it's used by the index).</emphasis>
 
 <emphasis role="comment"># For the examples below, set some defaults</emphasis>
-set status_format='-%r-NeoMutt: %f [Msgs:%?M?%M/?%m%?n? New:%n?%?o? Old:%o?%?d? Del:%d?%?F? \
-  Flag:%F?%?t? Tag:%t?%?p? Post:%p?%?b? Inc:%b?%?l? %l?]---(%s/%S)-%&gt;-(%P)---'
-set index_format='%4C %Z %{%b %d} %-15.15L (%?l?%4l&amp;%4c?) %s'
+set status_format='-%r-NeoMutt: %f [Msgs:%&lt;M?%M/&gt;%m%&lt;n? New:%n&gt;%&lt;o? Old:%o&gt;%&lt;d? Del:%d&gt;\
+%&lt;F? Flag:%F&gt;%&lt;t? Tag:%t&gt;%&lt;p? Post:%p&gt;%&lt;b? Inc:%b&gt;%&lt;l? %l&gt;]---(%s/%S)-%&gt;-(%P)---'
+set index_format='%4C %Z %{%b %d} %-15.15L (%&lt;l?%4l&amp;%4c&gt;) %s'
 set use_threads=yes
 set sort=last-date-received
 set sort_aux=date

--- a/docs/neomuttrc.man.head
+++ b/docs/neomuttrc.man.head
@@ -850,7 +850,7 @@ your spam \fIregex\fPs with the \fBspam\fP and \fBnospam\fP commands, you can
 limit, search, and sort your mail based on its spam attributes, as determined
 by the external filter. You also can display the spam attributes in your index
 display using the %H selector in the $index_format variable. (Tip: try
-\(dq%?H?[%H]\~?\(dq to display spam tags only when they are defined for a given
+\(dq%<H?[%H]\~>\(dq to display spam tags only when they are defined for a given
 message).
 .IP
 For further information on spam-scoring filters, please consult the

--- a/mutt_config.c
+++ b/mutt_config.c
@@ -146,7 +146,7 @@ static struct ConfigDef MainVars[] = {
   { "assumed_charset", DT_SLIST|SLIST_SEP_COLON|SLIST_ALLOW_EMPTY, 0, 0, charset_slist_validator,
     "If a message is missing a character set, assume this character set"
   },
-  { "attach_format", DT_STRING|DT_NOT_EMPTY, IP "%u%D%I %t%4n %T%d %> [%.7m/%.10M, %.6e%?C?, %C?, %s] ", 0, NULL,
+  { "attach_format", DT_STRING|DT_NOT_EMPTY, IP "%u%D%I %t%4n %T%d %> [%.7m/%.10M, %.6e%<C?, %C>, %s] ", 0, NULL,
     "printf-like format string for the attachment menu"
   },
   { "attach_save_dir", DT_PATH|DT_PATH_DIR, IP "./", 0, NULL,
@@ -305,7 +305,7 @@ static struct ConfigDef MainVars[] = {
   { "indent_string", DT_STRING, IP "> ", 0, NULL,
     "String used to indent 'reply' text"
   },
-  { "index_format", DT_STRING|DT_NOT_EMPTY|R_INDEX, IP "%4C %Z %{%b %d} %-15.15L (%?l?%4l&%4c?) %s", 0, NULL,
+  { "index_format", DT_STRING|DT_NOT_EMPTY|R_INDEX, IP "%4C %Z %{%b %d} %-15.15L (%<l?%4l&%4c>) %s", 0, NULL,
     "printf-like format string for the index menu (emails)"
   },
   { "keep_flagged", DT_BOOL, false, 0, NULL,
@@ -515,7 +515,7 @@ static struct ConfigDef MainVars[] = {
   { "status_chars", DT_MBTABLE|R_INDEX, IP "-*%A", 0, NULL,
     "Indicator characters for the status bar"
   },
-  { "status_format", DT_STRING|R_INDEX, IP "-%r-NeoMutt: %D [Msgs:%?M?%M/?%m%?n? New:%n?%?o? Old:%o?%?d? Del:%d?%?F? Flag:%F?%?t? Tag:%t?%?p? Post:%p?%?b? Inc:%b?%?l? %l?]---(%?T?%T/?%s/%S)-%>-(%P)---", 0, NULL,
+  { "status_format", DT_STRING|R_INDEX, IP "-%r-NeoMutt: %D [Msgs:%<M?%M/>%m%<n? New:%n>%<o? Old:%o>%<d? Del:%d>%<F? Flag:%F>%<t? Tag:%t>%<p? Post:%p>%<b? Inc:%b>%<l? %l>]---(%<T?%T/>%s/%S)-%>-(%P)---", 0, NULL,
     "printf-like format string for the index's status line"
   },
   { "status_on_top", DT_BOOL, false, 0, NULL,
@@ -551,10 +551,10 @@ static struct ConfigDef MainVars[] = {
   { "ts_enabled", DT_BOOL|R_INDEX, false, 0, NULL,
     "Allow NeoMutt to set the terminal status line and icon"
   },
-  { "ts_icon_format", DT_STRING|R_INDEX, IP "M%?n?AIL&ail?", 0, NULL,
+  { "ts_icon_format", DT_STRING|R_INDEX, IP "M%<n?AIL&ail>", 0, NULL,
     "printf-like format string for the terminal's icon title"
   },
-  { "ts_status_format", DT_STRING|R_INDEX, IP "NeoMutt with %?m?%m messages&no messages?%?n? [%n NEW]?", 0, NULL,
+  { "ts_status_format", DT_STRING|R_INDEX, IP "NeoMutt with %<m?%m messages&no messages>%<n? [%n NEW]>", 0, NULL,
     "printf-like format string for the terminal's status (window title)"
   },
   { "use_domain", DT_BOOL, true, 0, NULL,


### PR DESCRIPTION
Upgrade `%?...?` conditional expandos to `%<...>`
They are easier to parse visually and can be nested.

(no code changes)

**default config changes**
```diff
-attach_format = "%u%D%I %t%4n %T%d %> [%.7m/%.10M, %.6e%?C?, %C?, %s] "
+attach_format = "%u%D%I %t%4n %T%d %> [%.7m/%.10M, %.6e%<C?, %C>, %s] "

-index_format = "%4C %Z %{%b %d} %-15.15L (%?l?%4l&%4c?) %s"
+index_format = "%4C %Z %{%b %d} %-15.15L (%<l?%4l&%4c>) %s"

-mailbox_folder_format = "%2C %?n?%6n&%6 ? %6m %i"
+mailbox_folder_format = "%2C %<n?%6n&      > %6m %i"

-status_format = "-%r-NeoMutt: %D [Msgs:%?M?%M/?%m%?n? New:%n?%?o? Old:%o?%?d? Del:%d?%?F? Flag:%F?%?t? Tag:%t?%?p? Post:%p?%?b? Inc:%b?%?l? %l?]---(%?T?%T/?%s/%S)-%>-(%P)---"
+status_format = "-%r-NeoMutt: %D [Msgs:%<M?%M/>%m%<n? New:%n>%<o? Old:%o>%<d? Del:%d>%<F? Flag:%F>%<t? Tag:%t>%<p? Post:%p>%<b? Inc:%b>%<l? %l>]---(%<T?%T/>%s/%S)-%>-(%P)---"

-ts_icon_format = "M%?n?AIL&ail?"
+ts_icon_format = "M%<n?AIL&ail>"

-ts_status_format = "NeoMutt with %<m?%m messages&no messages>%<n? [%n NEW]>"
+ts_status_format = "NeoMutt with %?m?%m messages&no messages?%?n? [%n NEW]?"
```

The slight oddity in `$mailbox_folder_format` is where I've changed `%6 ` to `      ` (six spaces).
`%6 ` is an undocumented feature that only works in the browser.