### PR TITLE
move Mailbox.mtime into private MboxData

### DIFF
--- a/core/mailbox.h
+++ b/core/mailbox.h
@@ -101,7 +101,6 @@ struct Mailbox
   bool notified;                      ///< User has been notified
   enum MailboxType type;              ///< Mailbox type
   bool newly_created;                 ///< Mbox or mmdf just popped into existence
-  struct timespec mtime;              ///< Time Mailbox was last changed
   struct timespec last_visited;       ///< Time of last exit from this mailbox
 
   const struct MxOps *mx_ops;         ///< MXAPI callback functions

--- a/imap/mdata.h
+++ b/imap/mdata.h
@@ -60,6 +60,7 @@ struct ImapMboxData
   struct BodyCache *bcache;            ///< Email body cache
 
   struct HeaderCache *hcache; ///< Email header cache
+  struct timespec mtime;      ///< Time Mailbox was last changed
 };
 
 void                 imap_mdata_free(void **ptr);

--- a/maildir/maildir.c
+++ b/maildir/maildir.c
@@ -482,7 +482,7 @@ static void maildir_update_mtime(struct Mailbox *m)
 
   snprintf(buf, sizeof(buf), "%s/%s", mailbox_path(m), "new");
   if (stat(buf, &st) == 0)
-    mutt_file_get_stat_timespec(&m->mtime, &st, MUTT_STAT_MTIME);
+    mutt_file_get_stat_timespec(&mdata->mtime, &st, MUTT_STAT_MTIME);
 }
 
 /**
@@ -1203,7 +1203,7 @@ static enum MxStatus maildir_check(struct Mailbox *m)
   }
 
   /* determine which subdirectories need to be scanned */
-  if (mutt_file_stat_timespec_compare(&st_new, MUTT_STAT_MTIME, &m->mtime) > 0)
+  if (mutt_file_stat_timespec_compare(&st_new, MUTT_STAT_MTIME, &mdata->mtime) > 0)
     changed = MMC_NEW_DIR;
   if (mutt_file_stat_timespec_compare(&st_cur, MUTT_STAT_MTIME, &mdata->mtime_cur) > 0)
     changed |= MMC_CUR_DIR;
@@ -1229,7 +1229,7 @@ static enum MxStatus maildir_check(struct Mailbox *m)
 #endif
   {
     mutt_file_get_stat_timespec(&mdata->mtime_cur, &st_cur, MUTT_STAT_MTIME);
-    mutt_file_get_stat_timespec(&m->mtime, &st_new, MUTT_STAT_MTIME);
+    mutt_file_get_stat_timespec(&mdata->mtime, &st_new, MUTT_STAT_MTIME);
   }
 
   /* do a fast scan of just the filenames in

--- a/maildir/mdata.h
+++ b/maildir/mdata.h
@@ -33,6 +33,7 @@ struct Mailbox;
  */
 struct MaildirMboxData
 {
+  struct timespec mtime;     ///< Time Mailbox was last changed
   struct timespec mtime_cur; ///< Timestamp of the 'cur' dir
   mode_t mh_umask;           ///< umask to use when creating files
 };

--- a/maildir/mh.c
+++ b/maildir/mh.c
@@ -479,7 +479,7 @@ static void mh_update_mtime(struct Mailbox *m)
   mutt_str_copy(buf, mailbox_path(m), sizeof(buf));
 
   if (stat(buf, &st) == 0)
-    mutt_file_get_stat_timespec(&m->mtime, &st, MUTT_STAT_MTIME);
+    mutt_file_get_stat_timespec(&mdata->mtime, &st, MUTT_STAT_MTIME);
 }
 
 /**
@@ -921,7 +921,7 @@ static enum MxStatus mh_check(struct Mailbox *m)
   if ((rc == -1) && (stat(buf, &st_cur) == -1))
     modified = true;
 
-  if ((mutt_file_stat_timespec_compare(&st, MUTT_STAT_MTIME, &m->mtime) > 0) ||
+  if ((mutt_file_stat_timespec_compare(&st, MUTT_STAT_MTIME, &mdata->mtime) > 0) ||
       (mutt_file_stat_timespec_compare(&st_cur, MUTT_STAT_MTIME, &mdata->mtime_cur) > 0))
   {
     modified = true;
@@ -943,7 +943,7 @@ static enum MxStatus mh_check(struct Mailbox *m)
 #endif
   {
     mutt_file_get_stat_timespec(&mdata->mtime_cur, &st_cur, MUTT_STAT_MTIME);
-    mutt_file_get_stat_timespec(&m->mtime, &st, MUTT_STAT_MTIME);
+    mutt_file_get_stat_timespec(&mdata->mtime, &st, MUTT_STAT_MTIME);
   }
 
   struct MdEmailArray mda = ARRAY_HEAD_INITIALIZER;

--- a/mbox/lib.h
+++ b/mbox/lib.h
@@ -48,6 +48,7 @@ struct stat;
 struct MboxAccountData
 {
   FILE *fp;                           ///< Mailbox file
+  struct timespec mtime;              ///< Time Mailbox was last changed
   struct timespec atime;              ///< File's last-access time
   struct timespec stats_last_checked; ///< Mtime of mailbox the last time stats where checked
 

--- a/nntp/mdata.h
+++ b/nntp/mdata.h
@@ -47,6 +47,7 @@ struct NntpMboxData
   struct NntpAccountData *adata;
   struct NntpAcache acache[NNTP_ACACHE_LEN];
   struct BodyCache *bcache;
+  struct timespec mtime; ///< Time Mailbox was last changed
 };
 
 void nntp_mdata_free(void **ptr);

--- a/notmuch/mdata.h
+++ b/notmuch/mdata.h
@@ -40,6 +40,7 @@ struct NmMboxData
   struct Progress *progress;   ///< A progress bar
   int oldmsgcount;
   int ignmsgcount;             ///< Ignored messages
+  struct timespec mtime;       ///< Time Mailbox was last changed
 };
 
 void                  nm_mdata_free(void **ptr);

--- a/notmuch/notmuch.c
+++ b/notmuch/notmuch.c
@@ -1531,8 +1531,8 @@ int nm_read_entire_thread(struct Mailbox *m, struct Email *e)
   notmuch_query_set_sort(q, NOTMUCH_SORT_NEWEST_FIRST);
 
   read_threads_query(m, q, true, 0);
-  m->mtime.tv_sec = mutt_date_now();
-  m->mtime.tv_nsec = 0;
+  mdata->mtime.tv_sec = mutt_date_now();
+  mdata->mtime.tv_nsec = 0;
   rc = 0;
 
   if (m->msg_count > mdata->oldmsgcount)
@@ -1762,8 +1762,8 @@ int nm_update_filename(struct Mailbox *m, const char *old_file,
   int rc = rename_filename(m, old_file, new_file, e);
 
   nm_db_release(m);
-  m->mtime.tv_sec = mutt_date_now();
-  m->mtime.tv_nsec = 0;
+  mdata->mtime.tv_sec = mutt_date_now();
+  mdata->mtime.tv_nsec = 0;
   return rc;
 }
 
@@ -2062,8 +2062,8 @@ static enum MxOpenReturns nm_mbox_open(struct Mailbox *m)
 
   nm_db_release(m);
 
-  m->mtime.tv_sec = mutt_date_now();
-  m->mtime.tv_nsec = 0;
+  mdata->mtime.tv_sec = mutt_date_now();
+  mdata->mtime.tv_nsec = 0;
 
   mdata->oldmsgcount = 0;
 
@@ -2087,14 +2087,14 @@ static enum MxStatus nm_mbox_check(struct Mailbox *m)
   int new_flags = 0;
   bool occult = false;
 
-  if (m->mtime.tv_sec >= mtime)
+  if (mdata->mtime.tv_sec >= mtime)
   {
     mutt_debug(LL_DEBUG2, "nm: check unnecessary (db=%lu mailbox=%lu)\n", mtime,
-               m->mtime.tv_sec);
+               mdata->mtime.tv_sec);
     return MX_STATUS_OK;
   }
 
-  mutt_debug(LL_DEBUG1, "nm: checking (db=%lu mailbox=%lu)\n", mtime, m->mtime.tv_sec);
+  mutt_debug(LL_DEBUG1, "nm: checking (db=%lu mailbox=%lu)\n", mtime, mdata->mtime.tv_sec);
 
   notmuch_query_t *q = get_query(m, false);
   if (!q)
@@ -2194,8 +2194,8 @@ done:
 
   nm_db_release(m);
 
-  m->mtime.tv_sec = mutt_date_now();
-  m->mtime.tv_nsec = 0;
+  mdata->mtime.tv_sec = mutt_date_now();
+  mdata->mtime.tv_nsec = 0;
 
   mutt_debug(LL_DEBUG1, "nm: ... check done [count=%d, new_flags=%d, occult=%d]\n",
              m->msg_count, new_flags, occult);
@@ -2324,8 +2324,8 @@ static enum MxStatus nm_mbox_sync(struct Mailbox *m)
 
   if (changed)
   {
-    m->mtime.tv_sec = mutt_date_now();
-    m->mtime.tv_nsec = 0;
+    mdata->mtime.tv_sec = mutt_date_now();
+    mdata->mtime.tv_nsec = 0;
   }
 
   nm_hcache_close(h);
@@ -2429,8 +2429,8 @@ done:
   nm_db_release(m);
   if (e->changed)
   {
-    m->mtime.tv_sec = mutt_date_now();
-    m->mtime.tv_nsec = 0;
+    mdata->mtime.tv_sec = mutt_date_now();
+    mdata->mtime.tv_nsec = 0;
   }
   mutt_debug(LL_DEBUG1, "nm: tags modify done [rc=%d]\n", rc);
   return rc;


### PR DESCRIPTION
Mailbox.mtime is used internally by several backends, but it's not used outside of them.

Move mtime into the private MboxData (or AccountData for the mbox backend)

---

Not all mailbox types use `mtime`, but those that do use it in the same way.

https://github.com/neomutt/neomutt/blob/d0fdd26246988a0efe98b6158461c60c59de35fd/core/mailbox.h#L104

Should it live, conveniently, in `Mailbox`, or probably more correctly in `MboxData`?