### PR TITLE
hcache: cache store/comp ops

### DIFF
--- a/compress/compress.c
+++ b/compress/compress.c
@@ -56,16 +56,16 @@ static const struct ComprOps *CompressOps[] = {
 const char *compress_list(void)
 {
   char tmp[256] = { 0 };
-  const struct ComprOps **ops = CompressOps;
+  const struct ComprOps **compr_ops = CompressOps;
   size_t len = 0;
 
-  for (; *ops; ops++)
+  for (; *compr_ops; compr_ops++)
   {
     if (len != 0)
     {
       len += snprintf(tmp + len, sizeof(tmp) - len, ", ");
     }
-    len += snprintf(tmp + len, sizeof(tmp) - len, "%s", (*ops)->name);
+    len += snprintf(tmp + len, sizeof(tmp) - len, "%s", (*compr_ops)->name);
   }
 
   return mutt_str_dup(tmp);
@@ -78,16 +78,16 @@ const char *compress_list(void)
  */
 const struct ComprOps *compress_get_ops(const char *compr)
 {
-  const struct ComprOps **ops = CompressOps;
+  const struct ComprOps **compr_ops = CompressOps;
 
   if (!compr || !*compr)
-    return *ops;
+    return *compr_ops;
 
-  for (; *ops; ops++)
+  for (; *compr_ops; compr_ops++)
   {
-    if (mutt_str_equal(compr, (*ops)->name))
+    if (mutt_str_equal(compr, (*compr_ops)->name))
       break;
   }
 
-  return *ops;
+  return *compr_ops;
 }

--- a/compress/lib.h
+++ b/compress/lib.h
@@ -51,6 +51,9 @@
 
 #include <stdlib.h>
 
+/// Opaque type for compression data
+typedef void ComprHandle;
+
 /**
  * @defgroup compress_api Compression API
  *
@@ -68,55 +71,55 @@ struct ComprOps
    *
    * open - Open a compression context
    * @param[in]  level The compression level
-   * @retval ptr  Success, backend-specific context
+   * @retval ptr  Success, Compression private data
    * @retval NULL Otherwise
    */
-  void *(*open)(short level);
+  ComprHandle *(*open)(short level);
 
   /**
    * @defgroup compress_compress compress()
    * @ingroup compress_api
    *
    * compress - Compress header cache data
-   * @param[in]  cctx Compression context
-   * @param[in]  data Data to be compressed
-   * @param[in]  dlen Length of the uncompressed data
-   * @param[out] clen Length of returned compressed data
+   * @param[in]  handle Compression handle
+   * @param[in]  data   Data to be compressed
+   * @param[in]  dlen   Length of the uncompressed data
+   * @param[out] clen   Length of returned compressed data
    * @retval ptr  Success, pointer to compressed data
    * @retval NULL Otherwise
    *
    * @note This function returns a pointer to data, which will be freed by the
    *       close() function.
    */
-  void *(*compress)(void *cctx, const char *data, size_t dlen, size_t *clen);
+  void *(*compress)(ComprHandle *handle, const char *data, size_t dlen, size_t *clen);
 
   /**
    * @defgroup compress_decompress decompress()
    * @ingroup compress_api
    *
    * decompress - Decompress header cache data
-   * @param[in] cctx Compression context
-   * @param[in] cbuf Data to be decompressed
-   * @param[in] clen Length of the compressed input data
+   * @param[in] handle Compression handle
+   * @param[in] cbuf   Data to be decompressed
+   * @param[in] clen   Length of the compressed input data
    * @retval ptr  Success, pointer to decompressed data
    * @retval NULL Otherwise
    *
    * @note This function returns a pointer to data, which will be freed by the
    *       close() function.
    */
-  void *(*decompress)(void *cctx, const char *cbuf, size_t clen);
+  void *(*decompress)(ComprHandle *handle, const char *cbuf, size_t clen);
 
   /**
    * @defgroup compress_close close()
    * @ingroup compress_api
    *
    * close - Close a compression context
-   * @param[out] cctx Backend-specific context retrieved via open()
+   * @param[out] ptr Pointer to Compression handle
    *
    * @note This function will free all allocated resources, which were
    *       allocated by open(), compress() or decompress()
    */
-  void (*close)(void **cctx);
+  void (*close)(ComprHandle **ptr);
 };
 
 extern const struct ComprOps compr_lz4_ops;

--- a/compress/lz4.c
+++ b/compress/lz4.c
@@ -48,11 +48,35 @@ struct ComprLz4Ctx
 };
 
 /**
+ * lz4_cdata_free - Free Lz4 Compression Data
+ * @param ptr Lz4 Compression Data to free
+ */
+static void lz4_cdata_free(struct ComprLz4Ctx **ptr)
+{
+  if (!ptr || !*ptr)
+    return;
+
+  struct ComprLz4Ctx *cdata = *ptr;
+  FREE(&cdata->buf);
+
+  FREE(ptr);
+}
+
+/**
+ * lz4_cdata_new - Create new Lz4 Compression Data
+ * @retval ptr New Lz4 Compression Data
+ */
+static struct ComprLz4Ctx *lz4_cdata_new(void)
+{
+  return mutt_mem_calloc(1, sizeof(struct ComprLz4Ctx));
+}
+
+/**
  * compr_lz4_open - Implements ComprOps::open() - @ingroup compress_open
  */
 static void *compr_lz4_open(short level)
 {
-  struct ComprLz4Ctx *ctx = mutt_mem_malloc(sizeof(struct ComprLz4Ctx));
+  struct ComprLz4Ctx *ctx = lz4_cdata_new();
 
   ctx->buf = mutt_mem_malloc(LZ4_compressBound(1024 * 32));
 
@@ -141,10 +165,7 @@ static void compr_lz4_close(void **cctx)
   if (!cctx || !*cctx)
     return;
 
-  struct ComprLz4Ctx *ctx = *cctx;
-
-  FREE(&ctx->buf);
-  FREE(cctx);
+  lz4_cdata_free((struct ComprLz4Ctx **) cctx);
 }
 
 COMPRESS_OPS(lz4, MIN_COMP_LEVEL, MAX_COMP_LEVEL)

--- a/compress/zlib.c
+++ b/compress/zlib.c
@@ -48,13 +48,37 @@ struct ComprZlibCtx
 };
 
 /**
+ * zlib_cdata_free - Free Zlib Compression Data
+ * @param ptr Zlib Compression Data to free
+ */
+static void zlib_cdata_free(struct ComprZlibCtx **ptr)
+{
+  if (!ptr || !*ptr)
+    return;
+
+  struct ComprZlibCtx *cdata = *ptr;
+  FREE(&cdata->buf);
+
+  FREE(ptr);
+}
+
+/**
+ * zlib_cdata_new - Create new Zlib Compression Data
+ * @retval ptr New Zlib Compression Data
+ */
+static struct ComprZlibCtx *zlib_cdata_new(void)
+{
+  return mutt_mem_calloc(1, sizeof(struct ComprZlibCtx));
+}
+
+/**
  * compr_zlib_open - Implements ComprOps::open() - @ingroup compress_open
  */
 static void *compr_zlib_open(short level)
 {
-  struct ComprZlibCtx *ctx = mutt_mem_malloc(sizeof(struct ComprZlibCtx));
+  struct ComprZlibCtx *ctx = zlib_cdata_new();
 
-  ctx->buf = mutt_mem_malloc(compressBound(1024 * 32));
+  ctx->buf = mutt_mem_calloc(1, compressBound(1024 * 32));
 
   if ((level < MIN_COMP_LEVEL) || (level > MAX_COMP_LEVEL))
   {
@@ -136,10 +160,7 @@ static void compr_zlib_close(void **cctx)
   if (!cctx || !*cctx)
     return;
 
-  struct ComprZlibCtx *ctx = *cctx;
-
-  FREE(&ctx->buf);
-  FREE(cctx);
+  zlib_cdata_free((struct ComprZlibCtx **) cctx);
 }
 
 COMPRESS_OPS(zlib, MIN_COMP_LEVEL, MAX_COMP_LEVEL)

--- a/compress/zstd.c
+++ b/compress/zstd.c
@@ -38,9 +38,9 @@
 #define MAX_COMP_LEVEL 22 ///< Maximum compression level for zstd
 
 /**
- * struct ComprZstdCtx - Private Zstandard Compression Context
+ * struct ZstdComprData - Private Zstandard Compression Data
  */
-struct ComprZstdCtx
+struct ZstdComprData
 {
   void *buf;   ///< Temporary buffer
   short level; ///< Compression Level to be used
@@ -53,12 +53,12 @@ struct ComprZstdCtx
  * zstd_cdata_free - Free Zstandard Compression Data
  * @param ptr Zstandard Compression Data to free
  */
-static void zstd_cdata_free(struct ComprZstdCtx **ptr)
+static void zstd_cdata_free(struct ZstdComprData **ptr)
 {
   if (!ptr || !*ptr)
     return;
 
-  struct ComprZstdCtx *cdata = *ptr;
+  struct ZstdComprData *cdata = *ptr;
   FREE(&cdata->buf);
 
   FREE(ptr);
@@ -68,9 +68,9 @@ static void zstd_cdata_free(struct ComprZstdCtx **ptr)
  * zstd_cdata_new - Create new Zstandard Compression Data
  * @retval ptr New Zstandard Compression Data
  */
-static struct ComprZstdCtx *zstd_cdata_new(void)
+static struct ZstdComprData *zstd_cdata_new(void)
 {
-  return mutt_mem_calloc(1, sizeof(struct ComprZstdCtx));
+  return mutt_mem_calloc(1, sizeof(struct ZstdComprData));
 }
 
 /**
@@ -78,18 +78,18 @@ static struct ComprZstdCtx *zstd_cdata_new(void)
  */
 static ComprHandle *compr_zstd_open(short level)
 {
-  struct ComprZstdCtx *ctx = zstd_cdata_new();
+  struct ZstdComprData *cdata = zstd_cdata_new();
 
-  ctx->buf = mutt_mem_calloc(1, ZSTD_compressBound(1024 * 128));
-  ctx->cctx = ZSTD_createCCtx();
-  ctx->dctx = ZSTD_createDCtx();
+  cdata->buf = mutt_mem_calloc(1, ZSTD_compressBound(1024 * 128));
+  cdata->cctx = ZSTD_createCCtx();
+  cdata->dctx = ZSTD_createDCtx();
 
-  if (!ctx->cctx || !ctx->dctx)
+  if (!cdata->cctx || !cdata->dctx)
   {
     // LCOV_EXCL_START
-    ZSTD_freeCCtx(ctx->cctx);
-    ZSTD_freeDCtx(ctx->dctx);
-    zstd_cdata_free(&ctx);
+    ZSTD_freeCCtx(cdata->cctx);
+    ZSTD_freeDCtx(cdata->dctx);
+    zstd_cdata_free(&cdata);
     return NULL;
     // LCOV_EXCL_STOP
   }
@@ -101,10 +101,10 @@ static ComprHandle *compr_zstd_open(short level)
     level = MIN_COMP_LEVEL;
   }
 
-  ctx->level = level;
+  cdata->level = level;
 
   // Return an opaque pointer
-  return (ComprHandle *) ctx;
+  return (ComprHandle *) cdata;
 }
 
 /**
@@ -117,18 +117,18 @@ static void *compr_zstd_compress(ComprHandle *handle, const char *data,
     return NULL;
 
   // Decloak an opaque pointer
-  struct ComprZstdCtx *ctx = handle;
+  struct ZstdComprData *cdata = handle;
 
   size_t len = ZSTD_compressBound(dlen);
-  mutt_mem_realloc(&ctx->buf, len);
+  mutt_mem_realloc(&cdata->buf, len);
 
-  size_t rc = ZSTD_compressCCtx(ctx->cctx, ctx->buf, len, data, dlen, ctx->level);
+  size_t rc = ZSTD_compressCCtx(cdata->cctx, cdata->buf, len, data, dlen, cdata->level);
   if (ZSTD_isError(rc))
     return NULL; // LCOV_EXCL_LINE
 
   *clen = rc;
 
-  return ctx->buf;
+  return cdata->buf;
 }
 
 /**
@@ -140,7 +140,7 @@ static void *compr_zstd_decompress(ComprHandle *handle, const char *cbuf, size_t
     return NULL;
 
   // Decloak an opaque pointer
-  struct ComprZstdCtx *ctx = handle;
+  struct ZstdComprData *cdata = handle;
 
   unsigned long long len = ZSTD_getFrameContentSize(cbuf, clen);
   if (len == ZSTD_CONTENTSIZE_UNKNOWN)
@@ -149,13 +149,13 @@ static void *compr_zstd_decompress(ComprHandle *handle, const char *cbuf, size_t
     return NULL;
   else if (len == 0)
     return NULL; // LCOV_EXCL_LINE
-  mutt_mem_realloc(&ctx->buf, len);
+  mutt_mem_realloc(&cdata->buf, len);
 
-  size_t rc = ZSTD_decompressDCtx(ctx->dctx, ctx->buf, len, cbuf, clen);
+  size_t rc = ZSTD_decompressDCtx(cdata->dctx, cdata->buf, len, cbuf, clen);
   if (ZSTD_isError(rc))
     return NULL; // LCOV_EXCL_LINE
 
-  return ctx->buf;
+  return cdata->buf;
 }
 
 /**
@@ -167,15 +167,15 @@ static void compr_zstd_close(ComprHandle **ptr)
     return;
 
   // Decloak an opaque pointer
-  struct ComprZstdCtx *ctx = *ptr;
+  struct ZstdComprData *cdata = *ptr;
 
-  if (ctx->cctx)
-    ZSTD_freeCCtx(ctx->cctx);
+  if (cdata->cctx)
+    ZSTD_freeCCtx(cdata->cctx);
 
-  if (ctx->dctx)
-    ZSTD_freeDCtx(ctx->dctx);
+  if (cdata->dctx)
+    ZSTD_freeDCtx(cdata->dctx);
 
-  zstd_cdata_free((struct ComprZstdCtx **) ptr);
+  zstd_cdata_free((struct ZstdComprData **) ptr);
 }
 
 COMPRESS_OPS(zstd, MIN_COMP_LEVEL, MAX_COMP_LEVEL)

--- a/compress/zstd.c
+++ b/compress/zstd.c
@@ -133,10 +133,10 @@ static void *compr_zstd_compress(void *cctx, const char *data, size_t dlen, size
  */
 static void *compr_zstd_decompress(void *cctx, const char *cbuf, size_t clen)
 {
-  struct ComprZstdCtx *ctx = cctx;
-
   if (!cctx)
     return NULL;
+
+  struct ComprZstdCtx *ctx = cctx;
 
   unsigned long long len = ZSTD_getFrameContentSize(cbuf, clen);
   if (len == ZSTD_CONTENTSIZE_UNKNOWN)

--- a/hcache/hcache.c
+++ b/hcache/hcache.c
@@ -355,7 +355,7 @@ static char *get_foldername(const char *folder)
 
 /**
  * fetch_raw - Fetch a message's header from the cache
- * @param[in]  hc     Pointer to the struct HeaderCache structure got by mutt_hcache_open()
+ * @param[in]  hc     Pointer to the struct HeaderCache structure got by hcache_open()
  * @param[in]  key    Message identification string
  * @param[in]  keylen Length of the string pointed to by key
  * @param[out] dlen   Length of the fetched data
@@ -438,9 +438,9 @@ static unsigned int generate_hcachever(void)
 }
 
 /**
- * mutt_hcache_open - Multiplexor for StoreOps::open
+ * hcache_open - Multiplexor for StoreOps::open
  */
-struct HeaderCache *mutt_hcache_open(const char *path, const char *folder, hcache_namer_t namer)
+struct HeaderCache *hcache_open(const char *path, const char *folder, hcache_namer_t namer)
 {
   if (!path || (path[0] == '\0'))
     return NULL;
@@ -504,9 +504,9 @@ struct HeaderCache *mutt_hcache_open(const char *path, const char *folder, hcach
 }
 
 /**
- * mutt_hcache_close - Multiplexor for StoreOps::close
+ * hcache_close - Multiplexor for StoreOps::close
  */
-void mutt_hcache_close(struct HeaderCache **ptr)
+void hcache_close(struct HeaderCache **ptr)
 {
   if (!ptr || !*ptr)
     return;
@@ -533,10 +533,10 @@ void mutt_hcache_close(struct HeaderCache **ptr)
 }
 
 /**
- * mutt_hcache_fetch - Multiplexor for StoreOps::fetch
+ * hcache_fetch - Multiplexor for StoreOps::fetch
  */
-struct HCacheEntry mutt_hcache_fetch(struct HeaderCache *hc, const char *key,
-                                     size_t keylen, uint32_t uidvalidity)
+struct HCacheEntry hcache_fetch(struct HeaderCache *hc, const char *key,
+                                size_t keylen, uint32_t uidvalidity)
 {
   struct RealKey *rk = realkey(key, keylen);
   struct HCacheEntry hce = { 0 };
@@ -587,8 +587,8 @@ end:
 }
 
 /**
- * mutt_hcache_fetch_obj_ - Fetch a message's header from the cache into a destination object
- * @param[in]  hc     Pointer to the struct HeaderCache structure got by mutt_hcache_open()
+ * hcache_fetch_obj_ - Fetch a message's header from the cache into a destination object
+ * @param[in]  hc     Pointer to the struct HeaderCache structure got by hcache_open()
  * @param[in]  key    Message identification string
  * @param[in]  keylen Length of the string pointed to by key
  * @param[out] dst    Pointer to the destination object
@@ -596,8 +596,8 @@ end:
  * @retval true Success, the data was found and the length matches
  * @retval false Otherwise
  */
-bool mutt_hcache_fetch_obj_(struct HeaderCache *hc, const char *key,
-                            size_t keylen, void *dst, size_t dstlen)
+bool hcache_fetch_obj_(struct HeaderCache *hc, const char *key, size_t keylen,
+                       void *dst, size_t dstlen)
 {
   bool rc = true;
   size_t srclen = 0;
@@ -615,14 +615,14 @@ bool mutt_hcache_fetch_obj_(struct HeaderCache *hc, const char *key,
 }
 
 /**
- * mutt_hcache_fetch_str - Fetch a string from the cache
- * @param[in]  hc     Pointer to the struct HeaderCache structure got by mutt_hcache_open()
+ * hcache_fetch_str - Fetch a string from the cache
+ * @param[in]  hc     Pointer to the struct HeaderCache structure got by hcache_open()
  * @param[in]  key    Message identification string
  * @param[in]  keylen Length of the string pointed to by key
  * @retval ptr  Success, the data if found
  * @retval NULL Otherwise
  */
-char *mutt_hcache_fetch_str(struct HeaderCache *hc, const char *key, size_t keylen)
+char *hcache_fetch_str(struct HeaderCache *hc, const char *key, size_t keylen)
 {
   char *res = NULL;
   size_t dlen = 0;
@@ -636,10 +636,10 @@ char *mutt_hcache_fetch_str(struct HeaderCache *hc, const char *key, size_t keyl
 }
 
 /**
- * mutt_hcache_store - Multiplexor for StoreOps::store
+ * hcache_store - Multiplexor for StoreOps::store
  */
-int mutt_hcache_store(struct HeaderCache *hc, const char *key, size_t keylen,
-                      struct Email *e, uint32_t uidvalidity)
+int hcache_store(struct HeaderCache *hc, const char *key, size_t keylen,
+                 struct Email *e, uint32_t uidvalidity)
 {
   if (!hc)
     return -1;
@@ -679,7 +679,7 @@ int mutt_hcache_store(struct HeaderCache *hc, const char *key, size_t keylen,
 
   /* store uncompressed data */
   struct RealKey *rk = realkey(key, keylen);
-  int rc = mutt_hcache_store_raw(hc, rk->key, rk->len, data, dlen);
+  int rc = hcache_store_raw(hc, rk->key, rk->len, data, dlen);
 
   FREE(&data);
 
@@ -687,8 +687,8 @@ int mutt_hcache_store(struct HeaderCache *hc, const char *key, size_t keylen,
 }
 
 /**
- * mutt_hcache_store_raw - Store a key / data pair
- * @param hc     Pointer to the struct HeaderCache structure got by mutt_hcache_open()
+ * hcache_store_raw - Store a key / data pair
+ * @param hc     Pointer to the struct HeaderCache structure got by hcache_open()
  * @param key    Message identification string
  * @param keylen Length of the string pointed to by key
  * @param data   Payload to associate with key
@@ -696,8 +696,8 @@ int mutt_hcache_store(struct HeaderCache *hc, const char *key, size_t keylen,
  * @retval 0   Success
  * @retval num Generic or backend-specific error code otherwise
  */
-int mutt_hcache_store_raw(struct HeaderCache *hc, const char *key,
-                          size_t keylen, void *data, size_t dlen)
+int hcache_store_raw(struct HeaderCache *hc, const char *key, size_t keylen,
+                     void *data, size_t dlen)
 {
   const char *const c_header_cache_backend = cs_subset_string(NeoMutt->sub, "header_cache_backend");
   const struct StoreOps *ops = store_get_backend_ops(c_header_cache_backend);
@@ -715,9 +715,9 @@ int mutt_hcache_store_raw(struct HeaderCache *hc, const char *key,
 }
 
 /**
- * mutt_hcache_delete_record - Multiplexor for StoreOps::delete_record
+ * hcache_delete_record - Multiplexor for StoreOps::delete_record
  */
-int mutt_hcache_delete_record(struct HeaderCache *hc, const char *key, size_t keylen)
+int hcache_delete_record(struct HeaderCache *hc, const char *key, size_t keylen)
 {
   if (!hc)
     return -1;

--- a/hcache/lib.h
+++ b/hcache/lib.h
@@ -72,6 +72,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include "store/lib.h"
 
 struct Buffer;
 struct Email;
@@ -86,7 +87,7 @@ struct HeaderCache
 {
   char *folder;                       ///< Folder name
   unsigned int crc;                   ///< CRC of the cache entry
-  void *ctx;                          ///< Store context (handle)
+  StoreHandle *store_handle;          ///< Store handle
   void *cctx;                         ///< Compression context (handle)
 };
 

--- a/hcache/lib.h
+++ b/hcache/lib.h
@@ -77,19 +77,17 @@ struct Buffer;
 struct Email;
 
 /**
- * struct HeaderCache - Header cache structure
+ * struct HeaderCache - Header Cache
  *
- * This struct holds both the backend-agnostic and the backend-specific parts
- * of the header cache. Backend code MUST initialize the fetch, store,
- * delete and close function pointers in hcache_open, and MAY store
- * backend-specific context in the ctx pointer.
+ * This is the interface to the local cache of Email headers.
+ * The data is kept in a Store (database) which can be optionally Compressed.
  */
 struct HeaderCache
 {
-  char *folder;     ///< Folder name
-  unsigned int crc; ///< CRC of the cache entry
-  void *ctx;        ///< Store context (handle)
-  void *cctx;       ///< Compression context (handle)
+  char *folder;                       ///< Folder name
+  unsigned int crc;                   ///< CRC of the cache entry
+  void *ctx;                          ///< Store context (handle)
+  void *cctx;                         ///< Compression context (handle)
 };
 
 /**

--- a/hcache/lib.h
+++ b/hcache/lib.h
@@ -88,7 +88,9 @@ struct HeaderCache
 {
   char *folder;                       ///< Folder name
   unsigned int crc;                   ///< CRC of the cache entry
+  const struct StoreOps *store_ops;   ///< Store backend
   StoreHandle *store_handle;          ///< Store handle
+  const struct ComprOps *compr_ops;   ///< Compression backend
   ComprHandle *compr_handle;          ///< Compression handle
 };
 

--- a/hcache/lib.h
+++ b/hcache/lib.h
@@ -72,6 +72,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include "compress/lib.h"
 #include "store/lib.h"
 
 struct Buffer;
@@ -88,7 +89,7 @@ struct HeaderCache
   char *folder;                       ///< Folder name
   unsigned int crc;                   ///< CRC of the cache entry
   StoreHandle *store_handle;          ///< Store handle
-  void *cctx;                         ///< Compression context (handle)
+  ComprHandle *compr_handle;          ///< Compression handle
 };
 
 /**

--- a/hcache/lib.h
+++ b/hcache/lib.h
@@ -113,7 +113,7 @@ struct HCacheEntry
 typedef void (*hcache_namer_t)(const char *path, struct Buffer *dest);
 
 /**
- * mutt_hcache_open - Open the connection to the header cache
+ * hcache_open - Open the connection to the header cache
  * @param path   Location of the header cache (often as specified by the user)
  * @param folder Name of the folder containing the messages
  * @param namer  Optional (might be NULL) client-specific function to form the
@@ -121,19 +121,19 @@ typedef void (*hcache_namer_t)(const char *path, struct Buffer *dest);
  * @retval ptr  Success, struct HeaderCache struct
  * @retval NULL Otherwise
  */
-struct HeaderCache *mutt_hcache_open(const char *path, const char *folder, hcache_namer_t namer);
+struct HeaderCache *hcache_open(const char *path, const char *folder, hcache_namer_t namer);
 
 /**
- * mutt_hcache_close - Close the connection to the header cache
- * @param ptr Pointer to the struct HeaderCache structure got by mutt_hcache_open()
+ * hcache_close - Close the connection to the header cache
+ * @param ptr Pointer to the struct HeaderCache structure got by hcache_open()
  *
  * @note The pointer will be set to NULL
  */
-void mutt_hcache_close(struct HeaderCache **ptr);
+void hcache_close(struct HeaderCache **ptr);
 
 /**
- * mutt_hcache_store - Store a Header along with a validity datum
- * @param hc          Pointer to the struct HeaderCache structure got by mutt_hcache_open()
+ * hcache_store - Store a Header along with a validity datum
+ * @param hc          Pointer to the struct HeaderCache structure got by hcache_open()
  * @param key         Message identification string
  * @param keylen      Length of the key string
  * @param e           Email to store
@@ -141,12 +141,12 @@ void mutt_hcache_close(struct HeaderCache **ptr);
  * @retval 0   Success
  * @retval num Generic or backend-specific error code otherwise
  */
-int mutt_hcache_store(struct HeaderCache *hc, const char *key, size_t keylen,
+int hcache_store(struct HeaderCache *hc, const char *key, size_t keylen,
                       struct Email *e, uint32_t uidvalidity);
 
 /**
- * mutt_hcache_fetch - Fetch and validate a  message's header from the cache
- * @param hc     Pointer to the struct HeaderCache structure got by mutt_hcache_open()
+ * hcache_fetch - Fetch and validate a  message's header from the cache
+ * @param hc     Pointer to the struct HeaderCache structure got by hcache_open()
  * @param key    Message identification string
  * @param keylen Length of the string pointed to by key
  * @param uidvalidity Only restore if it matches the stored uidvalidity
@@ -155,23 +155,23 @@ int mutt_hcache_store(struct HeaderCache *hc, const char *key, size_t keylen,
  * @note This function performs a check on the validity of the data found by
  *       comparing it with the crc value of the struct HeaderCache structure.
  */
-struct HCacheEntry mutt_hcache_fetch(struct HeaderCache *hc, const char *key, size_t keylen, uint32_t uidvalidity);
+struct HCacheEntry hcache_fetch(struct HeaderCache *hc, const char *key, size_t keylen, uint32_t uidvalidity);
 
-char *mutt_hcache_fetch_str(struct HeaderCache *hc, const char *key, size_t keylen);
-bool  mutt_hcache_fetch_obj_(struct HeaderCache *hc, const char *key, size_t keylen, void *dst, size_t dstlen);
-#define mutt_hcache_fetch_obj(hc, key, keylen, dst) mutt_hcache_fetch_obj_(hc, key, keylen, dst, sizeof(*dst))
+char *hcache_fetch_str(struct HeaderCache *hc, const char *key, size_t keylen);
+bool  hcache_fetch_obj_(struct HeaderCache *hc, const char *key, size_t keylen, void *dst, size_t dstlen);
+#define hcache_fetch_obj(hc, key, keylen, dst) hcache_fetch_obj_(hc, key, keylen, dst, sizeof(*dst))
 
-int mutt_hcache_store_raw(struct HeaderCache *hc, const char *key, size_t keylen,
+int hcache_store_raw(struct HeaderCache *hc, const char *key, size_t keylen,
                           void *data, size_t dlen);
 
 /**
- * mutt_hcache_delete_record - Delete a key / data pair
- * @param hc     Pointer to the struct HeaderCache structure got by mutt_hcache_open()
+ * hcache_delete_record - Delete a key / data pair
+ * @param hc     Pointer to the struct HeaderCache structure got by hcache_open()
  * @param key    Message identification string
  * @param keylen Length of the string pointed to by key
  * @retval 0   Success
  * @retval num Generic or backend-specific error code otherwise
  */
-int mutt_hcache_delete_record(struct HeaderCache *hc, const char *key, size_t keylen);
+int hcache_delete_record(struct HeaderCache *hc, const char *key, size_t keylen);
 
 #endif /* MUTT_HCACHE_LIB_H */

--- a/imap/mdata.c
+++ b/imap/mdata.c
@@ -94,10 +94,10 @@ struct ImapMboxData *imap_mdata_new(struct ImapAccountData *adata, const char *n
   imap_hcache_open(adata, mdata);
   if (mdata->hcache)
   {
-    if (mutt_hcache_fetch_obj(mdata->hcache, "/UIDVALIDITY", 12, &mdata->uidvalidity))
+    if (hcache_fetch_obj(mdata->hcache, "/UIDVALIDITY", 12, &mdata->uidvalidity))
     {
-      mutt_hcache_fetch_obj(mdata->hcache, "/UIDNEXT", 8, &mdata->uid_next);
-      mutt_hcache_fetch_obj(mdata->hcache, "/MODSEQ", 7, &mdata->modseq);
+      hcache_fetch_obj(mdata->hcache, "/UIDNEXT", 8, &mdata->uid_next);
+      hcache_fetch_obj(mdata->hcache, "/MODSEQ", 7, &mdata->modseq);
       mutt_debug(LL_DEBUG3, "hcache uidvalidity %u, uidnext %u, modseq %llu\n",
                  mdata->uidvalidity, mdata->uid_next, mdata->modseq);
     }

--- a/imap/message.c
+++ b/imap/message.c
@@ -769,7 +769,7 @@ static int read_headers_normal_eval_cache(struct ImapAccountData *adata,
           e->replied = h.edata->replied;
         }
 
-        /*  mailbox->emails[msgno]->received is restored from mutt_hcache_restore */
+        /*  mailbox->emails[msgno]->received is restored from hcache_fetch() */
         e->edata = h.edata;
         e->edata_free = imap_edata_free;
 

--- a/imap/message.c
+++ b/imap/message.c
@@ -1050,7 +1050,7 @@ fail:
   }
   m->msg_count = 0;
   m->size = 0;
-  mutt_hcache_delete_record(mdata->hcache, "/MODSEQ", 7);
+  hcache_delete_record(mdata->hcache, "/MODSEQ", 7);
   imap_hcache_clear_uid_seqset(mdata);
   imap_hcache_close(mdata);
 
@@ -1369,8 +1369,8 @@ retry:
 
   if (mdata->hcache && initial_download)
   {
-    mutt_hcache_fetch_obj(mdata->hcache, "/UIDVALIDITY", 12, &uidvalidity);
-    mutt_hcache_fetch_obj(mdata->hcache, "/UIDNEXT", 8, &uid_next);
+    hcache_fetch_obj(mdata->hcache, "/UIDVALIDITY", 12, &uidvalidity);
+    hcache_fetch_obj(mdata->hcache, "/UIDNEXT", 8, &uid_next);
     if (mdata->modseq)
     {
       const bool c_imap_condstore = cs_subset_bool(NeoMutt->sub, "imap_condstore");
@@ -1386,7 +1386,7 @@ retry:
     if (uidvalidity && uid_next && uidvalidity == mdata->uidvalidity)
     {
       evalhc = true;
-      if (mutt_hcache_fetch_obj(mdata->hcache, "/MODSEQ", 7, &modseq))
+      if (hcache_fetch_obj(mdata->hcache, "/MODSEQ", 7, &modseq))
       {
         if (has_qresync)
         {
@@ -1460,8 +1460,8 @@ retry:
     mdata->uid_next = maxuid + 1;
 
 #ifdef USE_HCACHE
-  mutt_hcache_store_raw(mdata->hcache, "/UIDVALIDITY", 12, &mdata->uidvalidity,
-                        sizeof(mdata->uidvalidity));
+  hcache_store_raw(mdata->hcache, "/UIDVALIDITY", 12, &mdata->uidvalidity,
+                   sizeof(mdata->uidvalidity));
   if (maxuid && (mdata->uid_next < maxuid + 1))
   {
     mutt_debug(LL_DEBUG2, "Overriding UIDNEXT: %u -> %u\n", mdata->uid_next, maxuid + 1);
@@ -1469,8 +1469,8 @@ retry:
   }
   if (mdata->uid_next > 1)
   {
-    mutt_hcache_store_raw(mdata->hcache, "/UIDNEXT", 8, &mdata->uid_next,
-                          sizeof(mdata->uid_next));
+    hcache_store_raw(mdata->hcache, "/UIDNEXT", 8, &mdata->uid_next,
+                     sizeof(mdata->uid_next));
   }
 
   /* We currently only sync CONDSTORE and QRESYNC on the initial download.
@@ -1481,12 +1481,11 @@ retry:
   {
     if (has_condstore || has_qresync)
     {
-      mutt_hcache_store_raw(mdata->hcache, "/MODSEQ", 7, &mdata->modseq,
-                            sizeof(mdata->modseq));
+      hcache_store_raw(mdata->hcache, "/MODSEQ", 7, &mdata->modseq, sizeof(mdata->modseq));
     }
     else
     {
-      mutt_hcache_delete_record(mdata->hcache, "/MODSEQ", 7);
+      hcache_delete_record(mdata->hcache, "/MODSEQ", 7);
     }
 
     if (has_qresync)

--- a/imap/util.c
+++ b/imap/util.c
@@ -322,7 +322,7 @@ void imap_hcache_open(struct ImapAccountData *adata, struct ImapMboxData *mdata)
   url_tobuffer(&url, cachepath, U_PATH);
 
   const char *const c_header_cache = cs_subset_path(NeoMutt->sub, "header_cache");
-  hc = mutt_hcache_open(c_header_cache, buf_string(cachepath), imap_hcache_namer);
+  hc = hcache_open(c_header_cache, buf_string(cachepath), imap_hcache_namer);
 
 cleanup:
   buf_pool_release(&mbox);
@@ -339,7 +339,7 @@ void imap_hcache_close(struct ImapMboxData *mdata)
   if (!mdata->hcache)
     return;
 
-  mutt_hcache_close(&mdata->hcache);
+  hcache_close(&mdata->hcache);
 }
 
 /**
@@ -357,8 +357,8 @@ struct Email *imap_hcache_get(struct ImapMboxData *mdata, unsigned int uid)
   char key[16] = { 0 };
 
   sprintf(key, "/%u", uid);
-  struct HCacheEntry hce = mutt_hcache_fetch(mdata->hcache, key, mutt_str_len(key),
-                                             mdata->uidvalidity);
+  struct HCacheEntry hce = hcache_fetch(mdata->hcache, key, mutt_str_len(key),
+                                        mdata->uidvalidity);
   if (!hce.email && hce.uidvalidity)
   {
     mutt_debug(LL_DEBUG3, "hcache uidvalidity mismatch: %u\n", hce.uidvalidity);
@@ -382,7 +382,7 @@ int imap_hcache_put(struct ImapMboxData *mdata, struct Email *e)
   char key[16] = { 0 };
 
   sprintf(key, "/%u", imap_edata_get(e)->uid);
-  return mutt_hcache_store(mdata->hcache, key, mutt_str_len(key), e, mdata->uidvalidity);
+  return hcache_store(mdata->hcache, key, mutt_str_len(key), e, mdata->uidvalidity);
 }
 
 /**
@@ -400,7 +400,7 @@ int imap_hcache_del(struct ImapMboxData *mdata, unsigned int uid)
   char key[16] = { 0 };
 
   sprintf(key, "/%u", uid);
-  return mutt_hcache_delete_record(mdata->hcache, key, mutt_str_len(key));
+  return hcache_delete_record(mdata->hcache, key, mutt_str_len(key));
 }
 
 /**
@@ -418,8 +418,7 @@ int imap_hcache_store_uid_seqset(struct ImapMboxData *mdata)
   struct Buffer buf = buf_make(8192);
   imap_msn_index_to_uid_seqset(&buf, mdata);
 
-  int rc = mutt_hcache_store_raw(mdata->hcache, "/UIDSEQSET", 10, buf.data,
-                                 buf_len(&buf) + 1);
+  int rc = hcache_store_raw(mdata->hcache, "/UIDSEQSET", 10, buf.data, buf_len(&buf) + 1);
   mutt_debug(LL_DEBUG3, "Stored /UIDSEQSET %s\n", buf.data);
   buf_dealloc(&buf);
   return rc;
@@ -436,7 +435,7 @@ int imap_hcache_clear_uid_seqset(struct ImapMboxData *mdata)
   if (!mdata->hcache)
     return -1;
 
-  return mutt_hcache_delete_record(mdata->hcache, "/UIDSEQSET", 10);
+  return hcache_delete_record(mdata->hcache, "/UIDSEQSET", 10);
 }
 
 /**
@@ -450,7 +449,7 @@ char *imap_hcache_get_uid_seqset(struct ImapMboxData *mdata)
   if (!mdata->hcache)
     return NULL;
 
-  char *seqset = mutt_hcache_fetch_str(mdata->hcache, "/UIDSEQSET", 10);
+  char *seqset = hcache_fetch_str(mdata->hcache, "/UIDSEQSET", 10);
   mutt_debug(LL_DEBUG3, "Retrieved /UIDSEQSET %s\n", NONULL(seqset));
 
   return seqset;

--- a/maildir/maildir.c
+++ b/maildir/maildir.c
@@ -597,7 +597,7 @@ static void maildir_delayed_parsing(struct Mailbox *m, struct MdEmailArray *mda,
 
 #ifdef USE_HCACHE
   const char *const c_header_cache = cs_subset_path(NeoMutt->sub, "header_cache");
-  struct HeaderCache *hc = mutt_hcache_open(c_header_cache, mailbox_path(m), NULL);
+  struct HeaderCache *hc = hcache_open(c_header_cache, mailbox_path(m), NULL);
   const bool c_maildir_header_cache_verify = cs_subset_bool(NeoMutt->sub, "maildir_header_cache_verify");
 #endif
 
@@ -624,7 +624,7 @@ static void maildir_delayed_parsing(struct Mailbox *m, struct MdEmailArray *mda,
 
     if (hc)
     {
-      hce = mutt_hcache_fetch(hc, key, keylen, 0);
+      hce = hcache_fetch(hc, key, keylen, 0);
     }
 
     if (hce.email && c_maildir_header_cache_verify)
@@ -651,7 +651,7 @@ static void maildir_delayed_parsing(struct Mailbox *m, struct MdEmailArray *mda,
 #ifdef USE_HCACHE
         key = md->email->path + 3;
         keylen = maildir_hcache_keylen(key);
-        mutt_hcache_store(hc, key, keylen, md->email, 0);
+        hcache_store(hc, key, keylen, md->email, 0);
 #endif
       }
       else
@@ -661,7 +661,7 @@ static void maildir_delayed_parsing(struct Mailbox *m, struct MdEmailArray *mda,
     }
   }
 #ifdef USE_HCACHE
-  mutt_hcache_close(&hc);
+  hcache_close(&hc);
 #endif
 }
 
@@ -965,7 +965,7 @@ bool maildir_sync_mailbox_message(struct Mailbox *m, struct Email *e, struct Hea
     {
       const char *key = e->path + 3;
       size_t keylen = maildir_hcache_keylen(key);
-      mutt_hcache_delete_record(hc, key, keylen);
+      hcache_delete_record(hc, key, keylen);
     }
 #endif
     unlink(path);
@@ -982,7 +982,7 @@ bool maildir_sync_mailbox_message(struct Mailbox *m, struct Email *e, struct Hea
   {
     const char *key = e->path + 3;
     size_t keylen = maildir_hcache_keylen(key);
-    mutt_hcache_store(hc, key, keylen, e, 0);
+    hcache_store(hc, key, keylen, e, 0);
   }
 #endif
 
@@ -1395,7 +1395,7 @@ static enum MxStatus maildir_mbox_sync(struct Mailbox *m)
 #ifdef USE_HCACHE
   const char *const c_header_cache = cs_subset_path(NeoMutt->sub, "header_cache");
   if (m->type == MUTT_MAILDIR)
-    hc = mutt_hcache_open(c_header_cache, mailbox_path(m), NULL);
+    hc = hcache_open(c_header_cache, mailbox_path(m), NULL);
 #endif
 
   struct Progress *progress = NULL;
@@ -1422,7 +1422,7 @@ static enum MxStatus maildir_mbox_sync(struct Mailbox *m)
 
 #ifdef USE_HCACHE
   if (m->type == MUTT_MAILDIR)
-    mutt_hcache_close(&hc);
+    hcache_close(&hc);
 #endif
 
   /* XXX race condition? */
@@ -1450,7 +1450,7 @@ static enum MxStatus maildir_mbox_sync(struct Mailbox *m)
 err:
 #ifdef USE_HCACHE
   if (m->type == MUTT_MAILDIR)
-    mutt_hcache_close(&hc);
+    hcache_close(&hc);
 #endif
   return MX_STATUS_ERROR;
 }
@@ -1585,11 +1585,11 @@ static int maildir_msg_save_hcache(struct Mailbox *m, struct Email *e)
   int rc = 0;
 #ifdef USE_HCACHE
   const char *const c_header_cache = cs_subset_path(NeoMutt->sub, "header_cache");
-  struct HeaderCache *hc = mutt_hcache_open(c_header_cache, mailbox_path(m), NULL);
+  struct HeaderCache *hc = hcache_open(c_header_cache, mailbox_path(m), NULL);
   char *key = e->path + 3;
   int keylen = maildir_hcache_keylen(key);
-  rc = mutt_hcache_store(hc, key, keylen, e, 0);
-  mutt_hcache_close(&hc);
+  rc = hcache_store(hc, key, keylen, e, 0);
+  hcache_close(&hc);
 #endif
   return rc;
 }

--- a/maildir/mh.c
+++ b/maildir/mh.c
@@ -609,7 +609,7 @@ static void mh_delayed_parsing(struct Mailbox *m, struct MdEmailArray *mda,
 
 #ifdef USE_HCACHE
   const char *const c_header_cache = cs_subset_path(NeoMutt->sub, "header_cache");
-  struct HeaderCache *hc = mutt_hcache_open(c_header_cache, mailbox_path(m), NULL);
+  struct HeaderCache *hc = hcache_open(c_header_cache, mailbox_path(m), NULL);
 #endif
 
   struct MdEmail *md = NULL;
@@ -636,7 +636,7 @@ static void mh_delayed_parsing(struct Mailbox *m, struct MdEmailArray *mda,
 
     const char *key = md->email->path;
     size_t keylen = strlen(key);
-    struct HCacheEntry hce = mutt_hcache_fetch(hc, key, keylen, 0);
+    struct HCacheEntry hce = hcache_fetch(hc, key, keylen, 0);
 
     if (hce.email && (rc == 0) && (st_lastchanged.st_mtime <= hce.uidvalidity))
     {
@@ -656,7 +656,7 @@ static void mh_delayed_parsing(struct Mailbox *m, struct MdEmailArray *mda,
 #ifdef USE_HCACHE
         key = md->email->path;
         keylen = strlen(key);
-        mutt_hcache_store(hc, key, keylen, md->email, 0);
+        hcache_store(hc, key, keylen, md->email, 0);
 #endif
       }
       else
@@ -666,7 +666,7 @@ static void mh_delayed_parsing(struct Mailbox *m, struct MdEmailArray *mda,
     }
   }
 #ifdef USE_HCACHE
-  mutt_hcache_close(&hc);
+  hcache_close(&hc);
 #endif
 
   const enum SortType c_sort = cs_subset_sort(NeoMutt->sub, "sort");
@@ -765,7 +765,7 @@ int mh_sync_mailbox_message(struct Mailbox *m, struct Email *e, struct HeaderCac
       {
         const char *key = e->path;
         size_t keylen = strlen(key);
-        mutt_hcache_delete_record(hc, key, keylen);
+        hcache_delete_record(hc, key, keylen);
       }
 #endif
       unlink(path);
@@ -796,7 +796,7 @@ int mh_sync_mailbox_message(struct Mailbox *m, struct Email *e, struct HeaderCac
   {
     const char *key = e->path;
     size_t keylen = strlen(key);
-    mutt_hcache_store(hc, key, keylen, e, 0);
+    hcache_store(hc, key, keylen, e, 0);
   }
 #endif
 
@@ -811,9 +811,9 @@ static int mh_msg_save_hcache(struct Mailbox *m, struct Email *e)
   int rc = 0;
 #ifdef USE_HCACHE
   const char *const c_header_cache = cs_subset_path(NeoMutt->sub, "header_cache");
-  struct HeaderCache *hc = mutt_hcache_open(c_header_cache, mailbox_path(m), NULL);
-  rc = mutt_hcache_store(hc, e->path, strlen(e->path), e, 0);
-  mutt_hcache_close(&hc);
+  struct HeaderCache *hc = hcache_open(c_header_cache, mailbox_path(m), NULL);
+  rc = hcache_store(hc, e->path, strlen(e->path), e, 0);
+  hcache_close(&hc);
 #endif
   return rc;
 }
@@ -1046,7 +1046,7 @@ static enum MxStatus mh_mbox_sync(struct Mailbox *m)
 #ifdef USE_HCACHE
   const char *const c_header_cache = cs_subset_path(NeoMutt->sub, "header_cache");
   if (m->type == MUTT_MH)
-    hc = mutt_hcache_open(c_header_cache, mailbox_path(m), NULL);
+    hc = hcache_open(c_header_cache, mailbox_path(m), NULL);
 #endif
 
   struct Progress *progress = NULL;
@@ -1073,7 +1073,7 @@ static enum MxStatus mh_mbox_sync(struct Mailbox *m)
 
 #ifdef USE_HCACHE
   if (m->type == MUTT_MH)
-    mutt_hcache_close(&hc);
+    hcache_close(&hc);
 #endif
 
   mh_seq_update(m);
@@ -1102,7 +1102,7 @@ static enum MxStatus mh_mbox_sync(struct Mailbox *m)
 err:
 #ifdef USE_HCACHE
   if (m->type == MUTT_MH)
-    mutt_hcache_close(&hc);
+    hcache_close(&hc);
 #endif
   return MX_STATUS_ERROR;
 }

--- a/nntp/newsrc.c
+++ b/nntp/newsrc.c
@@ -727,7 +727,7 @@ struct HeaderCache *nntp_hcache_open(struct NntpMboxData *mdata)
   url.path = mdata->group;
   url_tostring(&url, file, sizeof(file), U_PATH);
   const char *const c_news_cache_dir = cs_subset_path(NeoMutt->sub, "news_cache_dir");
-  return mutt_hcache_open(c_news_cache_dir, file, nntp_hcache_namer);
+  return hcache_open(c_news_cache_dir, file, nntp_hcache_namer);
 }
 
 /**
@@ -745,10 +745,10 @@ void nntp_hcache_update(struct NntpMboxData *mdata, struct HeaderCache *hc)
   anum_t first = 0, last = 0;
 
   /* fetch previous values of first and last */
-  char *hdata = mutt_hcache_fetch_str(hc, "index", 5);
+  char *hdata = hcache_fetch_str(hc, "index", 5);
   if (hdata)
   {
-    mutt_debug(LL_DEBUG2, "mutt_hcache_fetch index: %s\n", hdata);
+    mutt_debug(LL_DEBUG2, "hcache_fetch index: %s\n", hdata);
     if (sscanf(hdata, ANUM " " ANUM, &first, &last) == 2)
     {
       old = true;
@@ -761,8 +761,8 @@ void nntp_hcache_update(struct NntpMboxData *mdata, struct HeaderCache *hc)
           continue;
 
         snprintf(buf, sizeof(buf), ANUM, current);
-        mutt_debug(LL_DEBUG2, "mutt_hcache_delete_record %s\n", buf);
-        mutt_hcache_delete_record(hc, buf, strlen(buf));
+        mutt_debug(LL_DEBUG2, "hcache_delete_record %s\n", buf);
+        hcache_delete_record(hc, buf, strlen(buf));
       }
     }
     FREE(&hdata);
@@ -772,8 +772,8 @@ void nntp_hcache_update(struct NntpMboxData *mdata, struct HeaderCache *hc)
   if (!old || (mdata->first_message != first) || (mdata->last_message != last))
   {
     snprintf(buf, sizeof(buf), ANUM " " ANUM, mdata->first_message, mdata->last_message);
-    mutt_debug(LL_DEBUG2, "mutt_hcache_store index: %s\n", buf);
-    mutt_hcache_store_raw(hc, "index", 5, buf, strlen(buf) + 1);
+    mutt_debug(LL_DEBUG2, "hcache_store index: %s\n", buf);
+    hcache_store_raw(hc, "index", 5, buf, strlen(buf) + 1);
   }
 }
 #endif
@@ -1176,7 +1176,7 @@ struct NntpAccountData *nntp_select_server(struct Mailbox *m, const char *server
           continue;
 
         /* fetch previous values of first and last */
-        char *hdata = mutt_hcache_fetch_str(hc, "index", 5);
+        char *hdata = hcache_fetch_str(hc, "index", 5);
         if (hdata)
         {
           anum_t first, last;
@@ -1196,7 +1196,7 @@ struct NntpAccountData *nntp_select_server(struct Mailbox *m, const char *server
           }
           FREE(&hdata);
         }
-        mutt_hcache_close(&hc);
+        hcache_close(&hc);
       }
       closedir(dir);
     }

--- a/nntp/nntp.c
+++ b/nntp/nntp.c
@@ -1098,10 +1098,10 @@ static int parse_overview_line(char *line, void *data)
 
     /* try to replace with header from cache */
     snprintf(buf, sizeof(buf), ANUM, anum);
-    struct HCacheEntry hce = mutt_hcache_fetch(fc->hc, buf, strlen(buf), 0);
+    struct HCacheEntry hce = hcache_fetch(fc->hc, buf, strlen(buf), 0);
     if (hce.email)
     {
-      mutt_debug(LL_DEBUG2, "mutt_hcache_fetch %s\n", buf);
+      mutt_debug(LL_DEBUG2, "hcache_fetch %s\n", buf);
       email_free(&e);
       e = hce.email;
       m->emails[m->msg_count] = e;
@@ -1123,8 +1123,8 @@ static int parse_overview_line(char *line, void *data)
     else
     {
       /* not cached yet, store header */
-      mutt_debug(LL_DEBUG2, "mutt_hcache_store %s\n", buf);
-      mutt_hcache_store(fc->hc, buf, strlen(buf), e, 0);
+      mutt_debug(LL_DEBUG2, "hcache_store %s\n", buf);
+      hcache_store(fc->hc, buf, strlen(buf), e, 0);
     }
   }
 #endif
@@ -1236,8 +1236,8 @@ static int nntp_fetch_headers(struct Mailbox *m, void *hc, anum_t first, anum_t 
 #ifdef USE_HCACHE
         if (fc.hc)
         {
-          mutt_debug(LL_DEBUG2, "mutt_hcache_delete_record %s\n", buf);
-          mutt_hcache_delete_record(fc.hc, buf, strlen(buf));
+          mutt_debug(LL_DEBUG2, "hcache_delete_record %s\n", buf);
+          hcache_delete_record(fc.hc, buf, strlen(buf));
         }
 #endif
       }
@@ -1273,10 +1273,10 @@ static int nntp_fetch_headers(struct Mailbox *m, void *hc, anum_t first, anum_t 
 
 #ifdef USE_HCACHE
     /* try to fetch header from cache */
-    struct HCacheEntry hce = mutt_hcache_fetch(fc.hc, buf, strlen(buf), 0);
+    struct HCacheEntry hce = hcache_fetch(fc.hc, buf, strlen(buf), 0);
     if (hce.email)
     {
-      mutt_debug(LL_DEBUG2, "mutt_hcache_fetch %s\n", buf);
+      mutt_debug(LL_DEBUG2, "hcache_fetch %s\n", buf);
       e = hce.email;
       m->emails[m->msg_count] = e;
       e->edata = NULL;
@@ -1539,12 +1539,12 @@ static enum MxStatus check_mailbox(struct Mailbox *m)
           messages[anum - first] = 1;
 
         snprintf(buf, sizeof(buf), ANUM, anum);
-        struct HCacheEntry hce = mutt_hcache_fetch(hc, buf, strlen(buf), 0);
+        struct HCacheEntry hce = hcache_fetch(hc, buf, strlen(buf), 0);
         if (hce.email)
         {
           bool deleted;
 
-          mutt_debug(LL_DEBUG2, "#1 mutt_hcache_fetch %s\n", buf);
+          mutt_debug(LL_DEBUG2, "#1 hcache_fetch %s\n", buf);
           e = hce.email;
           e->edata = NULL;
           deleted = e->deleted;
@@ -1584,10 +1584,10 @@ static enum MxStatus check_mailbox(struct Mailbox *m)
         continue;
 
       snprintf(buf, sizeof(buf), ANUM, anum);
-      struct HCacheEntry hce = mutt_hcache_fetch(hc, buf, strlen(buf), 0);
+      struct HCacheEntry hce = hcache_fetch(hc, buf, strlen(buf), 0);
       if (hce.email)
       {
-        mutt_debug(LL_DEBUG2, "#2 mutt_hcache_fetch %s\n", buf);
+        mutt_debug(LL_DEBUG2, "#2 hcache_fetch %s\n", buf);
         mx_alloc_memory(m, m->msg_count);
 
         e = hce.email;
@@ -1653,7 +1653,7 @@ static enum MxStatus check_mailbox(struct Mailbox *m)
   }
 
 #ifdef USE_HCACHE
-  mutt_hcache_close(&hc);
+  hcache_close(&hc);
 #endif
   if (rc != MX_STATUS_OK)
     nntp_newsrc_close(adata);
@@ -2300,7 +2300,7 @@ int nntp_check_children(struct Mailbox *m, const char *msgid)
     mailbox_changed(m, NT_MAILBOX_INVALID);
 
 #ifdef USE_HCACHE
-  mutt_hcache_close(&hc);
+  hcache_close(&hc);
 #endif
   m->verbose = verbose;
   FREE(&cc.child);
@@ -2485,7 +2485,7 @@ static enum MxOpenReturns nntp_mbox_open(struct Mailbox *m)
   nntp_newsrc_close(adata);
   rc = nntp_fetch_headers(m, hc, first, mdata->last_message, false);
 #ifdef USE_HCACHE
-  mutt_hcache_close(&hc);
+  hcache_close(&hc);
 #endif
   if (rc < 0)
     return MX_OPEN_ERROR;
@@ -2551,8 +2551,8 @@ static enum MxStatus nntp_mbox_sync(struct Mailbox *m)
     {
       if (e->deleted && !e->read)
         mdata->unread--;
-      mutt_debug(LL_DEBUG2, "mutt_hcache_store %s\n", buf);
-      mutt_hcache_store(hc, buf, strlen(buf), e, 0);
+      mutt_debug(LL_DEBUG2, "hcache_store %s\n", buf);
+      hcache_store(hc, buf, strlen(buf), e, 0);
     }
 #endif
   }
@@ -2560,7 +2560,7 @@ static enum MxStatus nntp_mbox_sync(struct Mailbox *m)
 #ifdef USE_HCACHE
   if (hc)
   {
-    mutt_hcache_close(&hc);
+    hcache_close(&hc);
     mdata->last_cached = mdata->last_loaded;
   }
 #endif

--- a/notmuch/notmuch.c
+++ b/notmuch/notmuch.c
@@ -111,7 +111,7 @@ static struct HeaderCache *nm_hcache_open(struct Mailbox *m)
 {
 #ifdef USE_HCACHE
   const char *const c_header_cache = cs_subset_path(NeoMutt->sub, "header_cache");
-  return mutt_hcache_open(c_header_cache, mailbox_path(m), NULL);
+  return hcache_open(c_header_cache, mailbox_path(m), NULL);
 #else
   return NULL;
 #endif
@@ -124,7 +124,7 @@ static struct HeaderCache *nm_hcache_open(struct Mailbox *m)
 static void nm_hcache_close(struct HeaderCache **ptr)
 {
 #ifdef USE_HCACHE
-  mutt_hcache_close(ptr);
+  hcache_close(ptr);
 #endif
 }
 
@@ -770,7 +770,7 @@ static void append_message(struct HeaderCache *hc, struct Mailbox *m,
   mx_alloc_memory(m, m->msg_count);
 
 #ifdef USE_HCACHE
-  e = mutt_hcache_fetch(hc, path, mutt_str_len(path), 0).email;
+  e = hcache_fetch(hc, path, mutt_str_len(path), 0).email;
   if (!e)
 #endif
   {
@@ -806,8 +806,8 @@ static void append_message(struct HeaderCache *hc, struct Mailbox *m,
     }
 
 #ifdef USE_HCACHE
-    mutt_hcache_store(hc, newpath ? newpath : path,
-                      mutt_str_len(newpath ? newpath : path), e, 0);
+    hcache_store(hc, newpath ? newpath : path,
+                 mutt_str_len(newpath ? newpath : path), e, 0);
 #endif
   }
 
@@ -2094,7 +2094,8 @@ static enum MxStatus nm_mbox_check(struct Mailbox *m)
     return MX_STATUS_OK;
   }
 
-  mutt_debug(LL_DEBUG1, "nm: checking (db=%lu mailbox=%lu)\n", mtime, mdata->mtime.tv_sec);
+  mutt_debug(LL_DEBUG1, "nm: checking (db=%lu mailbox=%lu)\n", mtime,
+             mdata->mtime.tv_sec);
 
   notmuch_query_t *q = get_query(m, false);
   if (!q)

--- a/pop/pop.c
+++ b/pop/pop.c
@@ -299,7 +299,7 @@ static struct HeaderCache *pop_hcache_open(struct PopAccountData *adata, const c
 {
   const char *const c_header_cache = cs_subset_path(NeoMutt->sub, "header_cache");
   if (!adata || !adata->conn)
-    return mutt_hcache_open(c_header_cache, path, NULL);
+    return hcache_open(c_header_cache, path, NULL);
 
   struct Url url = { 0 };
   char p[1024] = { 0 };
@@ -307,7 +307,7 @@ static struct HeaderCache *pop_hcache_open(struct PopAccountData *adata, const c
   mutt_account_tourl(&adata->conn->account, &url);
   url.path = HC_FNAME;
   url_tostring(&url, p, sizeof(p), U_PATH);
-  return mutt_hcache_open(c_header_cache, p, pop_hcache_namer);
+  return hcache_open(c_header_cache, p, pop_hcache_namer);
 }
 #endif
 
@@ -396,7 +396,7 @@ static int pop_fetch_headers(struct Mailbox *m)
         progress_update(progress, i + 1 - old_count, -1);
       struct PopEmailData *edata = pop_edata_get(m->emails[i]);
 #ifdef USE_HCACHE
-      struct HCacheEntry hce = mutt_hcache_fetch(hc, edata->uid, strlen(edata->uid), 0);
+      struct HCacheEntry hce = hcache_fetch(hc, edata->uid, strlen(edata->uid), 0);
       if (hce.email)
       {
         /* Detach the private data */
@@ -427,7 +427,7 @@ static int pop_fetch_headers(struct Mailbox *m)
 #ifdef USE_HCACHE
       else
       {
-        mutt_hcache_store(hc, edata->uid, strlen(edata->uid), m->emails[i], 0);
+        hcache_store(hc, edata->uid, strlen(edata->uid), m->emails[i], 0);
       }
 #endif
 
@@ -464,7 +464,7 @@ static int pop_fetch_headers(struct Mailbox *m)
   progress_free(&progress);
 
 #ifdef USE_HCACHE
-  mutt_hcache_close(&hc);
+  hcache_close(&hc);
 #endif
 
   if (rc < 0)
@@ -904,7 +904,7 @@ static enum MxStatus pop_mbox_sync(struct Mailbox *m)
         {
           mutt_bcache_del(adata->bcache, cache_id(edata->uid));
 #ifdef USE_HCACHE
-          mutt_hcache_delete_record(hc, edata->uid, strlen(edata->uid));
+          hcache_delete_record(hc, edata->uid, strlen(edata->uid));
 #endif
         }
       }
@@ -912,14 +912,14 @@ static enum MxStatus pop_mbox_sync(struct Mailbox *m)
 #ifdef USE_HCACHE
       if (m->emails[i]->changed)
       {
-        mutt_hcache_store(hc, edata->uid, strlen(edata->uid), m->emails[i], 0);
+        hcache_store(hc, edata->uid, strlen(edata->uid), m->emails[i], 0);
       }
 #endif
     }
     progress_free(&progress);
 
 #ifdef USE_HCACHE
-    mutt_hcache_close(&hc);
+    hcache_close(&hc);
 #endif
 
     if (rc == 0)
@@ -1143,8 +1143,8 @@ static int pop_msg_save_hcache(struct Mailbox *m, struct Email *e)
   struct PopAccountData *adata = pop_adata_get(m);
   struct PopEmailData *edata = e->edata;
   struct HeaderCache *hc = pop_hcache_open(adata, mailbox_path(m));
-  rc = mutt_hcache_store(hc, edata->uid, strlen(edata->uid), e, 0);
-  mutt_hcache_close(&hc);
+  rc = hcache_store(hc, edata->uid, strlen(edata->uid), e, 0);
+  hcache_close(&hc);
 #endif
 
   return rc;

--- a/store/bdb.c
+++ b/store/bdb.c
@@ -81,8 +81,8 @@ static struct StoreDbCtx *bdb_sdata_new(void)
 }
 
 /**
- * dbt_init - Initialise a BDB context
- * @param dbt  Context to initialise
+ * dbt_init - Initialise a BDB thing
+ * @param dbt  Thing to initialise
  * @param data ID string to associate
  * @param len  Length of ID string
  */
@@ -97,8 +97,8 @@ static void dbt_init(DBT *dbt, void *data, size_t len)
 }
 
 /**
- * dbt_empty_init - Initialise an empty BDB context
- * @param dbt  Context to initialise
+ * dbt_empty_init - Initialise an empty BDB thing
+ * @param dbt  Thing to initialise
  */
 static void dbt_empty_init(DBT *dbt)
 {
@@ -118,10 +118,6 @@ static void *store_bdb_open(const char *path)
   if (!path)
     return NULL;
 
-  struct stat st = { 0 };
-  int rc;
-  uint32_t createflags = DB_CREATE;
-
   struct StoreDbCtx *ctx = bdb_sdata_new();
 
   const int pagesize = 512;
@@ -138,7 +134,7 @@ static void *store_bdb_open(const char *path)
   if (mutt_file_lock(ctx->fd, true, true))
     goto fail_close;
 
-  rc = db_env_create(&ctx->env, 0);
+  int rc = db_env_create(&ctx->env, 0);
   if (rc)
     goto fail_unlock;
 
@@ -150,6 +146,9 @@ static void *store_bdb_open(const char *path)
   rc = db_create(&ctx->db, ctx->env, 0);
   if (rc)
     goto fail_env;
+
+  uint32_t createflags = DB_CREATE;
+  struct stat st = { 0 };
 
   if ((stat(path, &st) != 0) && (errno == ENOENT))
   {
@@ -185,10 +184,10 @@ static void *store_bdb_fetch(void *store, const char *key, size_t klen, size_t *
   if (!store)
     return NULL;
 
-  DBT dkey;
-  DBT data;
-
   struct StoreDbCtx *ctx = store;
+
+  DBT dkey = { 0 };
+  DBT data = { 0 };
 
   dbt_init(&dkey, (void *) key, klen);
   dbt_empty_init(&data);
@@ -216,10 +215,10 @@ static int store_bdb_store(void *store, const char *key, size_t klen, void *valu
   if (!store)
     return -1;
 
-  DBT dkey;
-  DBT databuf;
-
   struct StoreDbCtx *ctx = store;
+
+  DBT dkey = { 0 };
+  DBT databuf = { 0 };
 
   dbt_init(&dkey, (void *) key, klen);
   dbt_empty_init(&databuf);
@@ -239,10 +238,9 @@ static int store_bdb_delete_record(void *store, const char *key, size_t klen)
   if (!store)
     return -1;
 
-  DBT dkey;
-
   struct StoreDbCtx *ctx = store;
 
+  DBT dkey = { 0 };
   dbt_init(&dkey, (void *) key, klen);
   return ctx->db->del(ctx->db, NULL, &dkey, 0);
 }

--- a/store/bdb.c
+++ b/store/bdb.c
@@ -113,7 +113,7 @@ static void dbt_empty_init(DBT *dbt)
 /**
  * store_bdb_open - Implements StoreOps::open() - @ingroup store_open
  */
-static void *store_bdb_open(const char *path)
+static StoreHandle *store_bdb_open(const char *path)
 {
   if (!path)
     return NULL;
@@ -160,7 +160,8 @@ static void *store_bdb_open(const char *path)
   if (rc)
     goto fail_db;
 
-  return ctx;
+  // Return an opaque pointer
+  return (StoreHandle *) ctx;
 
 fail_db:
   ctx->db->close(ctx->db, 0);
@@ -179,11 +180,13 @@ fail_close:
 /**
  * store_bdb_fetch - Implements StoreOps::fetch() - @ingroup store_fetch
  */
-static void *store_bdb_fetch(void *store, const char *key, size_t klen, size_t *vlen)
+static StoreHandle *store_bdb_fetch(StoreHandle *store, const char *key,
+                                    size_t klen, size_t *vlen)
 {
   if (!store)
     return NULL;
 
+  // Decloak an opaque pointer
   struct StoreDbCtx *ctx = store;
 
   DBT dkey = { 0 };
@@ -202,7 +205,7 @@ static void *store_bdb_fetch(void *store, const char *key, size_t klen, size_t *
 /**
  * store_bdb_free - Implements StoreOps::free() - @ingroup store_free
  */
-static void store_bdb_free(void *store, void **ptr)
+static void store_bdb_free(StoreHandle *store, void **ptr)
 {
   FREE(ptr);
 }
@@ -210,11 +213,13 @@ static void store_bdb_free(void *store, void **ptr)
 /**
  * store_bdb_store - Implements StoreOps::store() - @ingroup store_store
  */
-static int store_bdb_store(void *store, const char *key, size_t klen, void *value, size_t vlen)
+static int store_bdb_store(StoreHandle *store, const char *key, size_t klen,
+                           void *value, size_t vlen)
 {
   if (!store)
     return -1;
 
+  // Decloak an opaque pointer
   struct StoreDbCtx *ctx = store;
 
   DBT dkey = { 0 };
@@ -233,11 +238,12 @@ static int store_bdb_store(void *store, const char *key, size_t klen, void *valu
 /**
  * store_bdb_delete_record - Implements StoreOps::delete_record() - @ingroup store_delete_record
  */
-static int store_bdb_delete_record(void *store, const char *key, size_t klen)
+static int store_bdb_delete_record(StoreHandle *store, const char *key, size_t klen)
 {
   if (!store)
     return -1;
 
+  // Decloak an opaque pointer
   struct StoreDbCtx *ctx = store;
 
   DBT dkey = { 0 };
@@ -248,11 +254,12 @@ static int store_bdb_delete_record(void *store, const char *key, size_t klen)
 /**
  * store_bdb_close - Implements StoreOps::close() - @ingroup store_close
  */
-static void store_bdb_close(void **ptr)
+static void store_bdb_close(StoreHandle **ptr)
 {
   if (!ptr || !*ptr)
     return;
 
+  // Decloak an opaque pointer
   struct StoreDbCtx *db = *ptr;
 
   db->db->close(db->db, 0);

--- a/store/gdbm.c
+++ b/store/gdbm.c
@@ -48,11 +48,13 @@ static void *store_gdbm_open(const char *path)
   const int pagesize = 4096;
 
   GDBM_FILE db = gdbm_open((char *) path, pagesize, GDBM_WRCREAT, 00600, NULL);
-  if (db)
-    return db;
+  if (!db)
+  {
+    /* if rw failed try ro */
+    db = gdbm_open((char *) path, pagesize, GDBM_READER, 00600, NULL);
+  }
 
-  /* if rw failed try ro */
-  return gdbm_open((char *) path, pagesize, GDBM_READER, 00600, NULL);
+  return db;
 }
 
 /**
@@ -63,8 +65,8 @@ static void *store_gdbm_fetch(void *store, const char *key, size_t klen, size_t 
   if (!store || (klen > INT_MAX))
     return NULL;
 
-  datum dkey;
-  datum data;
+  datum dkey = { 0 };
+  datum data = { 0 };
 
   GDBM_FILE db = store;
 
@@ -92,8 +94,8 @@ static int store_gdbm_store(void *store, const char *key, size_t klen, void *val
   if (!store || (klen > INT_MAX) || (vlen > INT_MAX))
     return -1;
 
-  datum dkey;
-  datum databuf;
+  datum dkey = { 0 };
+  datum databuf = { 0 };
 
   GDBM_FILE db = store;
 
@@ -114,7 +116,7 @@ static int store_gdbm_delete_record(void *store, const char *key, size_t klen)
   if (!store || (klen > INT_MAX))
     return -1;
 
-  datum dkey;
+  datum dkey = { 0 };
 
   GDBM_FILE db = store;
 

--- a/store/gdbm.c
+++ b/store/gdbm.c
@@ -40,7 +40,7 @@
 /**
  * store_gdbm_open - Implements StoreOps::open() - @ingroup store_open
  */
-static void *store_gdbm_open(const char *path)
+static StoreHandle *store_gdbm_open(const char *path)
 {
   if (!path)
     return NULL;
@@ -54,13 +54,15 @@ static void *store_gdbm_open(const char *path)
     db = gdbm_open((char *) path, pagesize, GDBM_READER, 00600, NULL);
   }
 
-  return db;
+  // Return an opaque pointer
+  return (StoreHandle *) db;
 }
 
 /**
  * store_gdbm_fetch - Implements StoreOps::fetch() - @ingroup store_fetch
  */
-static void *store_gdbm_fetch(void *store, const char *key, size_t klen, size_t *vlen)
+static StoreHandle *store_gdbm_fetch(StoreHandle *store, const char *key,
+                                     size_t klen, size_t *vlen)
 {
   if (!store || (klen > INT_MAX))
     return NULL;
@@ -68,6 +70,7 @@ static void *store_gdbm_fetch(void *store, const char *key, size_t klen, size_t 
   datum dkey = { 0 };
   datum data = { 0 };
 
+  // Decloak an opaque pointer
   GDBM_FILE db = store;
 
   dkey.dptr = (char *) key;
@@ -81,7 +84,7 @@ static void *store_gdbm_fetch(void *store, const char *key, size_t klen, size_t 
 /**
  * store_gdbm_free - Implements StoreOps::free() - @ingroup store_free
  */
-static void store_gdbm_free(void *store, void **ptr)
+static void store_gdbm_free(StoreHandle *store, void **ptr)
 {
   FREE(ptr);
 }
@@ -89,7 +92,8 @@ static void store_gdbm_free(void *store, void **ptr)
 /**
  * store_gdbm_store - Implements StoreOps::store() - @ingroup store_store
  */
-static int store_gdbm_store(void *store, const char *key, size_t klen, void *value, size_t vlen)
+static int store_gdbm_store(StoreHandle *store, const char *key, size_t klen,
+                            void *value, size_t vlen)
 {
   if (!store || (klen > INT_MAX) || (vlen > INT_MAX))
     return -1;
@@ -97,6 +101,7 @@ static int store_gdbm_store(void *store, const char *key, size_t klen, void *val
   datum dkey = { 0 };
   datum databuf = { 0 };
 
+  // Decloak an opaque pointer
   GDBM_FILE db = store;
 
   dkey.dptr = (char *) key;
@@ -111,13 +116,14 @@ static int store_gdbm_store(void *store, const char *key, size_t klen, void *val
 /**
  * store_gdbm_delete_record - Implements StoreOps::delete_record() - @ingroup store_delete_record
  */
-static int store_gdbm_delete_record(void *store, const char *key, size_t klen)
+static int store_gdbm_delete_record(StoreHandle *store, const char *key, size_t klen)
 {
   if (!store || (klen > INT_MAX))
     return -1;
 
   datum dkey = { 0 };
 
+  // Decloak an opaque pointer
   GDBM_FILE db = store;
 
   dkey.dptr = (char *) key;
@@ -129,11 +135,12 @@ static int store_gdbm_delete_record(void *store, const char *key, size_t klen)
 /**
  * store_gdbm_close - Implements StoreOps::close() - @ingroup store_close
  */
-static void store_gdbm_close(void **ptr)
+static void store_gdbm_close(StoreHandle **ptr)
 {
   if (!ptr || !*ptr)
     return;
 
+  // Decloak an opaque pointer
   GDBM_FILE db = *ptr;
   gdbm_close(db);
   *ptr = NULL;

--- a/store/kc.c
+++ b/store/kc.c
@@ -39,7 +39,7 @@
 /**
  * store_kyotocabinet_open - Implements StoreOps::open() - @ingroup store_open
  */
-static void *store_kyotocabinet_open(const char *path)
+static StoreHandle *store_kyotocabinet_open(const char *path)
 {
   if (!path)
     return NULL;
@@ -62,17 +62,20 @@ static void *store_kyotocabinet_open(const char *path)
   }
 
   buf_dealloc(&kcdbpath);
-  return db;
+  // Return an opaque pointer
+  return (StoreHandle *) db;
 }
 
 /**
  * store_kyotocabinet_fetch - Implements StoreOps::fetch() - @ingroup store_fetch
  */
-static void *store_kyotocabinet_fetch(void *store, const char *key, size_t klen, size_t *vlen)
+static StoreHandle *store_kyotocabinet_fetch(StoreHandle *store, const char *key,
+                                             size_t klen, size_t *vlen)
 {
   if (!store)
     return NULL;
 
+  // Decloak an opaque pointer
   KCDB *db = store;
   return kcdbget(db, key, klen, vlen);
 }
@@ -80,7 +83,7 @@ static void *store_kyotocabinet_fetch(void *store, const char *key, size_t klen,
 /**
  * store_kyotocabinet_free - Implements StoreOps::free() - @ingroup store_free
  */
-static void store_kyotocabinet_free(void *store, void **ptr)
+static void store_kyotocabinet_free(StoreHandle *store, void **ptr)
 {
   if (!ptr || !*ptr)
     return;
@@ -92,12 +95,13 @@ static void store_kyotocabinet_free(void *store, void **ptr)
 /**
  * store_kyotocabinet_store - Implements StoreOps::store() - @ingroup store_store
  */
-static int store_kyotocabinet_store(void *store, const char *key, size_t klen,
-                                    void *value, size_t vlen)
+static int store_kyotocabinet_store(StoreHandle *store, const char *key,
+                                    size_t klen, void *value, size_t vlen)
 {
   if (!store)
     return -1;
 
+  // Decloak an opaque pointer
   KCDB *db = store;
   if (!kcdbset(db, key, klen, value, vlen))
   {
@@ -110,11 +114,12 @@ static int store_kyotocabinet_store(void *store, const char *key, size_t klen,
 /**
  * store_kyotocabinet_delete_record - Implements StoreOps::delete_record() - @ingroup store_delete_record
  */
-static int store_kyotocabinet_delete_record(void *store, const char *key, size_t klen)
+static int store_kyotocabinet_delete_record(StoreHandle *store, const char *key, size_t klen)
 {
   if (!store)
     return -1;
 
+  // Decloak an opaque pointer
   KCDB *db = store;
   if (!kcdbremove(db, key, klen))
   {
@@ -127,11 +132,12 @@ static int store_kyotocabinet_delete_record(void *store, const char *key, size_t
 /**
  * store_kyotocabinet_close - Implements StoreOps::close() - @ingroup store_close
  */
-static void store_kyotocabinet_close(void **ptr)
+static void store_kyotocabinet_close(StoreHandle **ptr)
 {
   if (!ptr || !*ptr)
     return;
 
+  // Decloak an opaque pointer
   KCDB *db = *ptr;
   if (!kcdbclose(db))
   {

--- a/store/lib.h
+++ b/store/lib.h
@@ -77,7 +77,7 @@ struct StoreOps
    *
    * The open function has the purpose of opening a backend-specific
    * connection to the database file specified by the path parameter. Backends
-   * MUST return non-NULL specific context information on success.
+   * MUST return non-NULL specific handle information on success.
    */
   void *(*open)(const char *path);
 

--- a/store/lib.h
+++ b/store/lib.h
@@ -57,6 +57,9 @@
 #include <stdbool.h>
 #include <stdlib.h>
 
+/// Opaque type for store backend
+typedef void StoreHandle;
+
 /**
  * @defgroup store_api Key Value Store API
  *
@@ -79,7 +82,7 @@ struct StoreOps
    * connection to the database file specified by the path parameter. Backends
    * MUST return non-NULL specific handle information on success.
    */
-  void *(*open)(const char *path);
+  StoreHandle *(*open)(const char *path);
 
   /**
    * @defgroup store_fetch fetch()
@@ -93,7 +96,7 @@ struct StoreOps
    * @retval ptr  Success, Value associated with the Key
    * @retval NULL Error, or Key not found
    */
-  void *(*fetch)(void *store, const char *key, size_t klen, size_t *vlen);
+  void *(*fetch)(StoreHandle *store, const char *key, size_t klen, size_t *vlen);
 
   /**
    * @defgroup store_free free()
@@ -103,7 +106,7 @@ struct StoreOps
    * @param[in]  store Store retrieved via open()
    * @param[out] ptr   Value to be freed
    */
-  void (*free)(void *store, void **ptr);
+  void (*free)(StoreHandle *store, void **ptr);
 
   /**
    * @defgroup store_store store()
@@ -118,7 +121,7 @@ struct StoreOps
    * @retval 0   Success
    * @retval num Error, a backend-specific error code
    */
-  int (*store)(void *store, const char *key, size_t klen, void *value, size_t vlen);
+  int (*store)(StoreHandle *store, const char *key, size_t klen, void *value, size_t vlen);
 
   /**
    * @defgroup store_delete_record delete_record()
@@ -131,7 +134,7 @@ struct StoreOps
    * @retval 0   Success
    * @retval num Error, a backend-specific error code
    */
-  int (*delete_record)(void *store, const char *key, size_t klen);
+  int (*delete_record)(StoreHandle *store, const char *key, size_t klen);
 
   /**
    * @defgroup store_close close()
@@ -140,7 +143,7 @@ struct StoreOps
    * close - Close a Store connection
    * @param[in,out] ptr Store retrieved via open()
    */
-  void (*close)(void **ptr);
+  void (*close)(StoreHandle **ptr);
 
   /**
    * @defgroup store_version version()

--- a/store/lmdb.c
+++ b/store/lmdb.c
@@ -125,8 +125,6 @@ static int lmdb_get_read_txn(struct StoreLmdbCtx *ctx)
  */
 static int lmdb_get_write_txn(struct StoreLmdbCtx *ctx)
 {
-  int rc;
-
   if (ctx->txn)
   {
     if (ctx->txn_mode == TXN_WRITE)
@@ -136,7 +134,7 @@ static int lmdb_get_write_txn(struct StoreLmdbCtx *ctx)
     mdb_txn_abort(ctx->txn);
   }
 
-  rc = mdb_txn_begin(ctx->env, NULL, 0, &ctx->txn);
+  int rc = mdb_txn_begin(ctx->env, NULL, 0, &ctx->txn);
   if (rc == MDB_SUCCESS)
     ctx->txn_mode = TXN_WRITE;
   else
@@ -153,11 +151,9 @@ static void *store_lmdb_open(const char *path)
   if (!path)
     return NULL;
 
-  int rc;
-
   struct StoreLmdbCtx *ctx = lmdb_sdata_new();
 
-  rc = mdb_env_create(&ctx->env);
+  int rc = mdb_env_create(&ctx->env);
   if (rc != MDB_SUCCESS)
   {
     mutt_debug(LL_DEBUG2, "mdb_env_create: %s\n", mdb_strerror(rc));
@@ -211,8 +207,8 @@ static void *store_lmdb_fetch(void *store, const char *key, size_t klen, size_t 
   if (!store)
     return NULL;
 
-  MDB_val dkey;
-  MDB_val data;
+  MDB_val dkey = { 0 };
+  MDB_val data = { 0 };
 
   struct StoreLmdbCtx *ctx = store;
 
@@ -258,8 +254,8 @@ static int store_lmdb_store(void *store, const char *key, size_t klen, void *val
   if (!store)
     return -1;
 
-  MDB_val dkey;
-  MDB_val databuf;
+  MDB_val dkey = { 0 };
+  MDB_val databuf = { 0 };
 
   struct StoreLmdbCtx *ctx = store;
 
@@ -292,7 +288,7 @@ static int store_lmdb_delete_record(void *store, const char *key, size_t klen)
   if (!store)
     return -1;
 
-  MDB_val dkey;
+  MDB_val dkey = { 0 };
 
   struct StoreLmdbCtx *ctx = store;
 

--- a/store/lmdb.c
+++ b/store/lmdb.c
@@ -71,6 +71,24 @@ struct StoreLmdbCtx
 };
 
 /**
+ * lmdb_sdata_free - Free Lmdb Store Data
+ * @param ptr Lmdb Store Data to free
+ */
+static void lmdb_sdata_free(struct StoreLmdbCtx **ptr)
+{
+  FREE(ptr);
+}
+
+/**
+ * lmdb_sdata_new - Create new Lmdb Store Data
+ * @retval ptr New Lmdb Store Data
+ */
+static struct StoreLmdbCtx *lmdb_sdata_new(void)
+{
+  return mutt_mem_calloc(1, sizeof(struct StoreLmdbCtx));
+}
+
+/**
  * lmdb_get_read_txn - Get an LMDB read transaction
  * @param ctx LMDB context
  * @retval num LMDB return code, e.g. MDB_SUCCESS
@@ -137,13 +155,13 @@ static void *store_lmdb_open(const char *path)
 
   int rc;
 
-  struct StoreLmdbCtx *ctx = mutt_mem_calloc(1, sizeof(struct StoreLmdbCtx));
+  struct StoreLmdbCtx *ctx = lmdb_sdata_new();
 
   rc = mdb_env_create(&ctx->env);
   if (rc != MDB_SUCCESS)
   {
     mutt_debug(LL_DEBUG2, "mdb_env_create: %s\n", mdb_strerror(rc));
-    FREE(&ctx);
+    lmdb_sdata_free(&ctx);
     return NULL;
   }
 
@@ -181,7 +199,7 @@ fail_dbi:
 
 fail_env:
   mdb_env_close(ctx->env);
-  FREE(&ctx);
+  lmdb_sdata_free(&ctx);
   return NULL;
 }
 
@@ -320,7 +338,7 @@ static void store_lmdb_close(void **ptr)
   }
 
   mdb_env_close(db->env);
-  FREE(ptr);
+  lmdb_sdata_free((struct StoreLmdbCtx **) ptr);
 }
 
 /**

--- a/store/qdbm.c
+++ b/store/qdbm.c
@@ -41,24 +41,27 @@
 /**
  * store_qdbm_open - Implements StoreOps::open() - @ingroup store_open
  */
-static void *store_qdbm_open(const char *path)
+static StoreHandle *store_qdbm_open(const char *path)
 {
   if (!path)
     return NULL;
 
   VILLA *db = vlopen(path, VL_OWRITER | VL_OCREAT, VL_CMPLEX);
 
-  return db;
+  // Return an opaque pointer
+  return (StoreHandle *) db;
 }
 
 /**
  * store_qdbm_fetch - Implements StoreOps::fetch() - @ingroup store_fetch
  */
-static void *store_qdbm_fetch(void *store, const char *key, size_t klen, size_t *vlen)
+static StoreHandle *store_qdbm_fetch(StoreHandle *store, const char *key,
+                                     size_t klen, size_t *vlen)
 {
   if (!store)
     return NULL;
 
+  // Decloak an opaque pointer
   VILLA *db = store;
   int sp = 0;
   void *rv = vlget(db, key, klen, &sp);
@@ -69,7 +72,7 @@ static void *store_qdbm_fetch(void *store, const char *key, size_t klen, size_t 
 /**
  * store_qdbm_free - Implements StoreOps::free() - @ingroup store_free
  */
-static void store_qdbm_free(void *store, void **ptr)
+static void store_qdbm_free(StoreHandle *store, void **ptr)
 {
   FREE(ptr);
 }
@@ -77,11 +80,13 @@ static void store_qdbm_free(void *store, void **ptr)
 /**
  * store_qdbm_store - Implements StoreOps::store() - @ingroup store_store
  */
-static int store_qdbm_store(void *store, const char *key, size_t klen, void *value, size_t vlen)
+static int store_qdbm_store(StoreHandle *store, const char *key, size_t klen,
+                            void *value, size_t vlen)
 {
   if (!store)
     return -1;
 
+  // Decloak an opaque pointer
   VILLA *db = store;
   /* Not sure if dpecode is reset on success, so better to explicitly return 0
    * on success */
@@ -92,11 +97,12 @@ static int store_qdbm_store(void *store, const char *key, size_t klen, void *val
 /**
  * store_qdbm_delete_record - Implements StoreOps::delete_record() - @ingroup store_delete_record
  */
-static int store_qdbm_delete_record(void *store, const char *key, size_t klen)
+static int store_qdbm_delete_record(StoreHandle *store, const char *key, size_t klen)
 {
   if (!store)
     return -1;
 
+  // Decloak an opaque pointer
   VILLA *db = store;
   /* Not sure if dpecode is reset on success, so better to explicitly return 0
    * on success */
@@ -107,11 +113,12 @@ static int store_qdbm_delete_record(void *store, const char *key, size_t klen)
 /**
  * store_qdbm_close - Implements StoreOps::close() - @ingroup store_close
  */
-static void store_qdbm_close(void **ptr)
+static void store_qdbm_close(StoreHandle **ptr)
 {
   if (!ptr || !*ptr)
     return;
 
+  // Decloak an opaque pointer
   VILLA *db = *ptr;
   vlclose(db);
   *ptr = NULL;

--- a/store/qdbm.c
+++ b/store/qdbm.c
@@ -46,7 +46,9 @@ static void *store_qdbm_open(const char *path)
   if (!path)
     return NULL;
 
-  return vlopen(path, VL_OWRITER | VL_OCREAT, VL_CMPLEX);
+  VILLA *db = vlopen(path, VL_OWRITER | VL_OCREAT, VL_CMPLEX);
+
+  return db;
 }
 
 /**
@@ -81,7 +83,7 @@ static int store_qdbm_store(void *store, const char *key, size_t klen, void *val
     return -1;
 
   VILLA *db = store;
-  /* Not sure if dbecode is reset on success, so better to explicitly return 0
+  /* Not sure if dpecode is reset on success, so better to explicitly return 0
    * on success */
   bool success = vlput(db, key, klen, value, vlen, VL_DOVER);
   return success ? 0 : dpecode ? dpecode : -1;
@@ -96,7 +98,7 @@ static int store_qdbm_delete_record(void *store, const char *key, size_t klen)
     return -1;
 
   VILLA *db = store;
-  /* Not sure if dbecode is reset on success, so better to explicitly return 0
+  /* Not sure if dpecode is reset on success, so better to explicitly return 0
    * on success */
   bool success = vlout(db, key, klen);
   return success ? 0 : dpecode ? dpecode : -1;

--- a/store/rocksdb.c
+++ b/store/rocksdb.c
@@ -72,7 +72,7 @@ static struct RocksDbCtx *rocksdb_sdata_new(void)
 /**
  * store_rocksdb_open - Implements StoreOps::open() - @ingroup store_open
  */
-static void *store_rocksdb_open(const char *path)
+static StoreHandle *store_rocksdb_open(const char *path)
 {
   if (!path)
     return NULL;
@@ -107,17 +107,20 @@ static void *store_rocksdb_open(const char *path)
     return NULL;
   }
 
-  return ctx;
+  // Return an opaque pointer
+  return (StoreHandle *) ctx;
 }
 
 /**
  * store_rocksdb_fetch - Implements StoreOps::fetch() - @ingroup store_fetch
  */
-static void *store_rocksdb_fetch(void *store, const char *key, size_t klen, size_t *vlen)
+static StoreHandle *store_rocksdb_fetch(StoreHandle *store, const char *key,
+                                        size_t klen, size_t *vlen)
 {
   if (!store)
     return NULL;
 
+  // Decloak an opaque pointer
   struct RocksDbCtx *ctx = store;
 
   void *rv = rocksdb_get(ctx->db, ctx->read_options, key, klen, vlen, &ctx->err);
@@ -134,7 +137,7 @@ static void *store_rocksdb_fetch(void *store, const char *key, size_t klen, size
 /**
  * store_rocksdb_free - Implements StoreOps::free() - @ingroup store_free
  */
-static void store_rocksdb_free(void *store, void **ptr)
+static void store_rocksdb_free(StoreHandle *store, void **ptr)
 {
   FREE(ptr);
 }
@@ -142,12 +145,13 @@ static void store_rocksdb_free(void *store, void **ptr)
 /**
  * store_rocksdb_store - Implements StoreOps::store() - @ingroup store_store
  */
-static int store_rocksdb_store(void *store, const char *key, size_t klen,
+static int store_rocksdb_store(StoreHandle *store, const char *key, size_t klen,
                                void *value, size_t vlen)
 {
   if (!store)
     return -1;
 
+  // Decloak an opaque pointer
   struct RocksDbCtx *ctx = store;
 
   rocksdb_put(ctx->db, ctx->write_options, key, klen, value, vlen, &ctx->err);
@@ -164,11 +168,12 @@ static int store_rocksdb_store(void *store, const char *key, size_t klen,
 /**
  * store_rocksdb_delete_record - Implements StoreOps::delete_record() - @ingroup store_delete_record
  */
-static int store_rocksdb_delete_record(void *store, const char *key, size_t klen)
+static int store_rocksdb_delete_record(StoreHandle *store, const char *key, size_t klen)
 {
   if (!store)
     return -1;
 
+  // Decloak an opaque pointer
   struct RocksDbCtx *ctx = store;
 
   rocksdb_delete(ctx->db, ctx->write_options, key, klen, &ctx->err);
@@ -185,11 +190,12 @@ static int store_rocksdb_delete_record(void *store, const char *key, size_t klen
 /**
  * store_rocksdb_close - Implements StoreOps::close() - @ingroup store_close
  */
-static void store_rocksdb_close(void **ptr)
+static void store_rocksdb_close(StoreHandle **ptr)
 {
   if (!ptr || !*ptr)
     return;
 
+  // Decloak an opaque pointer
   struct RocksDbCtx *ctx = *ptr;
 
   /* close database and free resources */

--- a/store/rocksdb.c
+++ b/store/rocksdb.c
@@ -79,7 +79,7 @@ static void *store_rocksdb_open(const char *path)
 
   struct RocksDbCtx *ctx = rocksdb_sdata_new();
 
-  /* RocksDB store errors in form of strings */
+  /* RocksDB stores errors in form of strings */
   ctx->err = NULL;
 
   /* setup generic options, create new db and limit log to one file */

--- a/store/rocksdb.c
+++ b/store/rocksdb.c
@@ -46,6 +46,30 @@ struct RocksDbCtx
 };
 
 /**
+ * rocksdb_sdata_free - Free RocksDb Store Data
+ * @param ptr RocksDb Store Data to free
+ */
+static void rocksdb_sdata_free(struct RocksDbCtx **ptr)
+{
+  if (!ptr || !*ptr)
+    return;
+
+  struct RocksDbCtx *sdata = *ptr;
+  FREE(&sdata->err);
+
+  FREE(ptr);
+}
+
+/**
+ * rocksdb_sdata_new - Create new RocksDb Store Data
+ * @retval ptr New RocksDb Store Data
+ */
+static struct RocksDbCtx *rocksdb_sdata_new(void)
+{
+  return mutt_mem_calloc(1, sizeof(struct RocksDbCtx));
+}
+
+/**
  * store_rocksdb_open - Implements StoreOps::open() - @ingroup store_open
  */
 static void *store_rocksdb_open(const char *path)
@@ -53,7 +77,7 @@ static void *store_rocksdb_open(const char *path)
   if (!path)
     return NULL;
 
-  struct RocksDbCtx *ctx = mutt_mem_malloc(sizeof(struct RocksDbCtx));
+  struct RocksDbCtx *ctx = rocksdb_sdata_new();
 
   /* RocksDB store errors in form of strings */
   ctx->err = NULL;
@@ -174,8 +198,7 @@ static void store_rocksdb_close(void **ptr)
   rocksdb_readoptions_destroy(ctx->read_options);
   rocksdb_writeoptions_destroy(ctx->write_options);
 
-  FREE(ptr);
-  *ptr = NULL;
+  rocksdb_sdata_free((struct RocksDbCtx **) ptr);
 }
 
 /**

--- a/store/store.c
+++ b/store/store.c
@@ -83,16 +83,16 @@ static const struct StoreOps *StoreOps[] = {
 const char *store_backend_list(void)
 {
   char tmp[256] = { 0 };
-  const struct StoreOps **ops = StoreOps;
+  const struct StoreOps **store_ops = StoreOps;
   size_t len = 0;
 
-  for (; *ops; ops++)
+  for (; *store_ops; store_ops++)
   {
     if (len != 0)
     {
       len += snprintf(tmp + len, sizeof(tmp) - len, ", ");
     }
-    len += snprintf(tmp + len, sizeof(tmp) - len, "%s", (*ops)->name);
+    len += snprintf(tmp + len, sizeof(tmp) - len, "%s", (*store_ops)->name);
   }
 
   return mutt_str_dup(tmp);
@@ -105,18 +105,18 @@ const char *store_backend_list(void)
  */
 const struct StoreOps *store_get_backend_ops(const char *str)
 {
-  const struct StoreOps **ops = StoreOps;
+  const struct StoreOps **store_ops = StoreOps;
 
   if (!str || (*str == '\0'))
   {
-    return *ops;
+    return *store_ops;
   }
 
-  for (; *ops; ops++)
-    if (mutt_str_equal(str, (*ops)->name))
+  for (; *store_ops; store_ops++)
+    if (mutt_str_equal(str, (*store_ops)->name))
       break;
 
-  return *ops;
+  return *store_ops;
 }
 
 /**

--- a/store/tc.c
+++ b/store/tc.c
@@ -40,7 +40,7 @@
 /**
  * store_tokyocabinet_open - Implements StoreOps::open() - @ingroup store_open
  */
-static void *store_tokyocabinet_open(const char *path)
+static StoreHandle *store_tokyocabinet_open(const char *path)
 {
   if (!path)
     return NULL;
@@ -57,17 +57,20 @@ static void *store_tokyocabinet_open(const char *path)
     return NULL;
   }
 
-  return db;
+  // Return an opaque pointer
+  return (StoreHandle *) db;
 }
 
 /**
  * store_tokyocabinet_fetch - Implements StoreOps::fetch() - @ingroup store_fetch
  */
-static void *store_tokyocabinet_fetch(void *store, const char *key, size_t klen, size_t *vlen)
+static StoreHandle *store_tokyocabinet_fetch(StoreHandle *store, const char *key,
+                                             size_t klen, size_t *vlen)
 {
   if (!store)
     return NULL;
 
+  // Decloak an opaque pointer
   TCBDB *db = store;
   int sp = 0;
   void *rv = tcbdbget(db, key, klen, &sp);
@@ -78,7 +81,7 @@ static void *store_tokyocabinet_fetch(void *store, const char *key, size_t klen,
 /**
  * store_tokyocabinet_free - Implements StoreOps::free() - @ingroup store_free
  */
-static void store_tokyocabinet_free(void *store, void **ptr)
+static void store_tokyocabinet_free(StoreHandle *store, void **ptr)
 {
   FREE(ptr);
 }
@@ -86,12 +89,13 @@ static void store_tokyocabinet_free(void *store, void **ptr)
 /**
  * store_tokyocabinet_store - Implements StoreOps::store() - @ingroup store_store
  */
-static int store_tokyocabinet_store(void *store, const char *key, size_t klen,
-                                    void *value, size_t vlen)
+static int store_tokyocabinet_store(StoreHandle *store, const char *key,
+                                    size_t klen, void *value, size_t vlen)
 {
   if (!store)
     return -1;
 
+  // Decloak an opaque pointer
   TCBDB *db = store;
   if (!tcbdbput(db, key, klen, value, vlen))
   {
@@ -104,11 +108,12 @@ static int store_tokyocabinet_store(void *store, const char *key, size_t klen,
 /**
  * store_tokyocabinet_delete_record - Implements StoreOps::delete_record() - @ingroup store_delete_record
  */
-static int store_tokyocabinet_delete_record(void *store, const char *key, size_t klen)
+static int store_tokyocabinet_delete_record(StoreHandle *store, const char *key, size_t klen)
 {
   if (!store)
     return -1;
 
+  // Decloak an opaque pointer
   TCBDB *db = store;
   if (!tcbdbout(db, key, klen))
   {
@@ -121,11 +126,12 @@ static int store_tokyocabinet_delete_record(void *store, const char *key, size_t
 /**
  * store_tokyocabinet_close - Implements StoreOps::close() - @ingroup store_close
  */
-static void store_tokyocabinet_close(void **ptr)
+static void store_tokyocabinet_close(StoreHandle **ptr)
 {
   if (!ptr || !*ptr)
     return;
 
+  // Decloak an opaque pointer
   TCBDB *db = *ptr;
   if (!tcbdbclose(db))
   {

--- a/store/tdb.c
+++ b/store/tdb.c
@@ -37,7 +37,7 @@
 /**
  * store_tdb_open - Implements StoreOps::open() - @ingroup store_open
  */
-static void *store_tdb_open(const char *path)
+static StoreHandle *store_tdb_open(const char *path)
 {
   if (!path)
     return NULL;
@@ -51,17 +51,20 @@ static void *store_tdb_open(const char *path)
 
   struct tdb_context *db = tdb_open(path, hash_size, flags, O_CREAT | O_RDWR, 00600);
 
-  return db;
+  // Return an opaque pointer
+  return (StoreHandle *) db;
 }
 
 /**
  * store_tdb_fetch - Implements StoreOps::fetch() - @ingroup store_fetch
  */
-static void *store_tdb_fetch(void *store, const char *key, size_t klen, size_t *vlen)
+static StoreHandle *store_tdb_fetch(StoreHandle *store, const char *key,
+                                    size_t klen, size_t *vlen)
 {
   if (!store)
     return NULL;
 
+  // Decloak an opaque pointer
   TDB_CONTEXT *db = store;
   TDB_DATA dkey;
   TDB_DATA data;
@@ -77,7 +80,7 @@ static void *store_tdb_fetch(void *store, const char *key, size_t klen, size_t *
 /**
  * store_tdb_free - Implements StoreOps::free() - @ingroup store_free
  */
-static void store_tdb_free(void *store, void **ptr)
+static void store_tdb_free(StoreHandle *store, void **ptr)
 {
   FREE(ptr);
 }
@@ -85,11 +88,13 @@ static void store_tdb_free(void *store, void **ptr)
 /**
  * store_tdb_store - Implements StoreOps::store() - @ingroup store_store
  */
-static int store_tdb_store(void *store, const char *key, size_t klen, void *value, size_t vlen)
+static int store_tdb_store(StoreHandle *store, const char *key, size_t klen,
+                           void *value, size_t vlen)
 {
   if (!store)
     return -1;
 
+  // Decloak an opaque pointer
   TDB_CONTEXT *db = store;
   TDB_DATA dkey;
   TDB_DATA databuf;
@@ -106,11 +111,12 @@ static int store_tdb_store(void *store, const char *key, size_t klen, void *valu
 /**
  * store_tdb_delete_record - Implements StoreOps::delete_record() - @ingroup store_delete_record
  */
-static int store_tdb_delete_record(void *store, const char *key, size_t klen)
+static int store_tdb_delete_record(StoreHandle *store, const char *key, size_t klen)
 {
   if (!store)
     return -1;
 
+  // Decloak an opaque pointer
   TDB_CONTEXT *db = store;
   TDB_DATA dkey;
 
@@ -123,11 +129,12 @@ static int store_tdb_delete_record(void *store, const char *key, size_t klen)
 /**
  * store_tdb_close - Implements StoreOps::close() - @ingroup store_close
  */
-static void store_tdb_close(void **ptr)
+static void store_tdb_close(StoreHandle **ptr)
 {
   if (!ptr || !*ptr)
     return;
 
+  // Decloak an opaque pointer
   TDB_CONTEXT *db = *ptr;
   tdb_close(db);
   *ptr = NULL;

--- a/store/tdb.c
+++ b/store/tdb.c
@@ -48,7 +48,10 @@ static void *store_tdb_open(const char *path)
    */
   const int flags = TDB_NOLOCK | TDB_INCOMPATIBLE_HASH | TDB_NOSYNC;
   const int hash_size = 33533; // Based on test timings for 100K emails
-  return tdb_open(path, hash_size, flags, O_CREAT | O_RDWR, 00600);
+
+  struct tdb_context *db = tdb_open(path, hash_size, flags, O_CREAT | O_RDWR, 00600);
+
+  return db;
 }
 
 /**

--- a/test/compress/common.c
+++ b/test/compress/common.c
@@ -138,7 +138,7 @@ void compress_data_tests(const struct ComprOps *cops, short min_level, short max
   static const size_t sizes[] = { 63,   64,   65,   127,  128,  129,
                                   255,  256,  257,  511,  512,  513,
                                   1023, 1024, 1024, 2047, 2048, 2049 };
-  char case_name[64];
+  char case_name[64] = { 0 };
   for (short level = min_level; level <= max_level; level++)
   {
     snprintf(case_name, sizeof(case_name), "level %d", level);

--- a/test/compress/common.c
+++ b/test/compress/common.c
@@ -109,10 +109,10 @@ static void one_test(const struct ComprOps *compr_ops, short level, size_t size)
   if (!TEST_CHECK(size < strlen(compress_test_data)))
     return;
 
-  void *cctx = compr_ops->open(level);
+  ComprHandle *compr_handle = compr_ops->open(level);
 
   size_t clen = 0;
-  void *cdata = compr_ops->compress(cctx, compress_test_data, size, &clen);
+  void *cdata = compr_ops->compress(compr_handle, compress_test_data, size, &clen);
   if (!TEST_CHECK(cdata != NULL))
     return;
   if (!TEST_CHECK(clen != 0))
@@ -121,7 +121,7 @@ static void one_test(const struct ComprOps *compr_ops, short level, size_t size)
   void *copy = mutt_mem_malloc(clen);
   memcpy(copy, cdata, clen);
 
-  void *ddata = compr_ops->decompress(cctx, copy, clen);
+  void *ddata = compr_ops->decompress(compr_handle, copy, clen);
   FREE(&copy);
 
   if (!TEST_CHECK(ddata != NULL))
@@ -130,7 +130,7 @@ static void one_test(const struct ComprOps *compr_ops, short level, size_t size)
   if (!TEST_CHECK(memcmp(compress_test_data, ddata, size) == 0))
     return;
 
-  compr_ops->close(&cctx);
+  compr_ops->close(&compr_handle);
 }
 
 void compress_data_tests(const struct ComprOps *compr_ops, short min_level, short max_level)

--- a/test/compress/common.c
+++ b/test/compress/common.c
@@ -94,25 +94,25 @@ void test_compress_common(void)
   TEST_CHECK(list != NULL);
   FREE(&list);
 
-  const struct ComprOps *ops = compress_get_ops(NULL);
-  TEST_CHECK(ops != NULL);
+  const struct ComprOps *compr_ops = compress_get_ops(NULL);
+  TEST_CHECK(compr_ops != NULL);
 
-  ops = compress_get_ops("");
-  TEST_CHECK(ops != NULL);
+  compr_ops = compress_get_ops("");
+  TEST_CHECK(compr_ops != NULL);
 
-  ops = compress_get_ops("foobar");
-  TEST_CHECK(ops == NULL);
+  compr_ops = compress_get_ops("foobar");
+  TEST_CHECK(compr_ops == NULL);
 }
 
-static void one_test(const struct ComprOps *cops, short level, size_t size)
+static void one_test(const struct ComprOps *compr_ops, short level, size_t size)
 {
   if (!TEST_CHECK(size < strlen(compress_test_data)))
     return;
 
-  void *cctx = cops->open(level);
+  void *cctx = compr_ops->open(level);
 
   size_t clen = 0;
-  void *cdata = cops->compress(cctx, compress_test_data, size, &clen);
+  void *cdata = compr_ops->compress(cctx, compress_test_data, size, &clen);
   if (!TEST_CHECK(cdata != NULL))
     return;
   if (!TEST_CHECK(clen != 0))
@@ -121,7 +121,7 @@ static void one_test(const struct ComprOps *cops, short level, size_t size)
   void *copy = mutt_mem_malloc(clen);
   memcpy(copy, cdata, clen);
 
-  void *ddata = cops->decompress(cctx, copy, clen);
+  void *ddata = compr_ops->decompress(cctx, copy, clen);
   FREE(&copy);
 
   if (!TEST_CHECK(ddata != NULL))
@@ -130,10 +130,10 @@ static void one_test(const struct ComprOps *cops, short level, size_t size)
   if (!TEST_CHECK(memcmp(compress_test_data, ddata, size) == 0))
     return;
 
-  cops->close(&cctx);
+  compr_ops->close(&cctx);
 }
 
-void compress_data_tests(const struct ComprOps *cops, short min_level, short max_level)
+void compress_data_tests(const struct ComprOps *compr_ops, short min_level, short max_level)
 {
   static const size_t sizes[] = { 63,   64,   65,   127,  128,  129,
                                   255,  256,  257,  511,  512,  513,
@@ -147,14 +147,14 @@ void compress_data_tests(const struct ComprOps *cops, short min_level, short max
     {
       snprintf(case_name, sizeof(case_name), "    size %zu", size);
       TEST_CASE(case_name);
-      one_test(cops, level, size);
+      one_test(compr_ops, level, size);
     }
 
     for (size_t i = 0; i < mutt_array_size(sizes); i++)
     {
       snprintf(case_name, sizeof(case_name), "    size %zu", sizes[i]);
       TEST_CASE(case_name);
-      one_test(cops, level, sizes[i]);
+      one_test(compr_ops, level, sizes[i]);
     }
   }
 }

--- a/test/compress/lz4.c
+++ b/test/compress/lz4.c
@@ -33,10 +33,10 @@
 
 void test_compress_lz4(void)
 {
-  // void *open(short level);
-  // void *compress(void *cctx, const char *data, size_t dlen, size_t *clen);
-  // void *decompress(void *cctx, const char *cbuf, size_t clen);
-  // void  close(void **cctx);
+  // ComprHandle *open(short level);
+  // void *compress(ComprHandle *handle, const char *data, size_t dlen, size_t *clen);
+  // void *decompress(ComprHandle *handle, const char *cbuf, size_t clen);
+  // void close(ComprHandle **ptr);
 
   const struct ComprOps *compr_ops = compress_get_ops("lz4");
   if (!TEST_CHECK(compr_ops != NULL))
@@ -46,24 +46,24 @@ void test_compress_lz4(void)
     // Degenerate tests
     TEST_CHECK(compr_ops->compress(NULL, NULL, 0, NULL) == NULL);
     TEST_CHECK(compr_ops->decompress(NULL, NULL, 0) == NULL);
-    void *cctx = NULL;
+    ComprHandle *compr_handle = NULL;
     compr_ops->close(NULL);
     TEST_CHECK_(1, "compr_ops->close(NULL)");
-    compr_ops->close(&cctx);
-    TEST_CHECK_(1, "compr_ops->close(&cctx)");
+    compr_ops->close(&compr_handle);
+    TEST_CHECK_(1, "compr_ops->close(&compr_handle)");
   }
 
   {
     // Temporarily disable logging
     MuttLogger = log_disp_null;
 
-    void *cctx = compr_ops->open(MIN_COMP_LEVEL - 1);
-    TEST_CHECK(cctx != NULL);
-    compr_ops->close(&cctx);
+    ComprHandle *compr_handle = compr_ops->open(MIN_COMP_LEVEL - 1);
+    TEST_CHECK(compr_handle != NULL);
+    compr_ops->close(&compr_handle);
 
-    cctx = compr_ops->open(MAX_COMP_LEVEL + 1);
-    TEST_CHECK(cctx != NULL);
-    compr_ops->close(&cctx);
+    compr_handle = compr_ops->open(MAX_COMP_LEVEL + 1);
+    TEST_CHECK(compr_handle != NULL);
+    compr_ops->close(&compr_handle);
 
     // Restore logging
     MuttLogger = log_disp_terminal;
@@ -71,24 +71,24 @@ void test_compress_lz4(void)
 
   {
     // Garbage data
-    void *cctx = compr_ops->open(MIN_COMP_LEVEL);
-    TEST_CHECK(cctx != NULL);
+    ComprHandle *compr_handle = compr_ops->open(MIN_COMP_LEVEL);
+    TEST_CHECK(compr_handle != NULL);
 
     const char zeroes[] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
 
-    void *result = compr_ops->decompress(cctx, zeroes, 0);
+    void *result = compr_ops->decompress(compr_handle, zeroes, 0);
     TEST_CHECK(result == NULL);
 
-    result = compr_ops->decompress(cctx, zeroes, sizeof(zeroes));
+    result = compr_ops->decompress(compr_handle, zeroes, sizeof(zeroes));
     TEST_CHECK(result == zeroes);
 
     const char ones[] = { 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
                           0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01 };
-    result = compr_ops->decompress(cctx, ones, sizeof(ones));
+    result = compr_ops->decompress(compr_handle, ones, sizeof(ones));
     TEST_CHECK(result == NULL);
 
-    compr_ops->close(&cctx);
+    compr_ops->close(&compr_handle);
   }
 
   compress_data_tests(compr_ops, MIN_COMP_LEVEL, MAX_COMP_LEVEL);

--- a/test/compress/lz4.c
+++ b/test/compress/lz4.c
@@ -38,32 +38,32 @@ void test_compress_lz4(void)
   // void *decompress(void *cctx, const char *cbuf, size_t clen);
   // void  close(void **cctx);
 
-  const struct ComprOps *cops = compress_get_ops("lz4");
-  if (!TEST_CHECK(cops != NULL))
+  const struct ComprOps *compr_ops = compress_get_ops("lz4");
+  if (!TEST_CHECK(compr_ops != NULL))
     return;
 
   {
     // Degenerate tests
-    TEST_CHECK(cops->compress(NULL, NULL, 0, NULL) == NULL);
-    TEST_CHECK(cops->decompress(NULL, NULL, 0) == NULL);
+    TEST_CHECK(compr_ops->compress(NULL, NULL, 0, NULL) == NULL);
+    TEST_CHECK(compr_ops->decompress(NULL, NULL, 0) == NULL);
     void *cctx = NULL;
-    cops->close(NULL);
-    TEST_CHECK_(1, "cops->close(NULL)");
-    cops->close(&cctx);
-    TEST_CHECK_(1, "cops->close(&cctx)");
+    compr_ops->close(NULL);
+    TEST_CHECK_(1, "compr_ops->close(NULL)");
+    compr_ops->close(&cctx);
+    TEST_CHECK_(1, "compr_ops->close(&cctx)");
   }
 
   {
     // Temporarily disable logging
     MuttLogger = log_disp_null;
 
-    void *cctx = cops->open(MIN_COMP_LEVEL - 1);
+    void *cctx = compr_ops->open(MIN_COMP_LEVEL - 1);
     TEST_CHECK(cctx != NULL);
-    cops->close(&cctx);
+    compr_ops->close(&cctx);
 
-    cctx = cops->open(MAX_COMP_LEVEL + 1);
+    cctx = compr_ops->open(MAX_COMP_LEVEL + 1);
     TEST_CHECK(cctx != NULL);
-    cops->close(&cctx);
+    compr_ops->close(&cctx);
 
     // Restore logging
     MuttLogger = log_disp_terminal;
@@ -71,25 +71,25 @@ void test_compress_lz4(void)
 
   {
     // Garbage data
-    void *cctx = cops->open(MIN_COMP_LEVEL);
+    void *cctx = compr_ops->open(MIN_COMP_LEVEL);
     TEST_CHECK(cctx != NULL);
 
     const char zeroes[] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
 
-    void *result = cops->decompress(cctx, zeroes, 0);
+    void *result = compr_ops->decompress(cctx, zeroes, 0);
     TEST_CHECK(result == NULL);
 
-    result = cops->decompress(cctx, zeroes, sizeof(zeroes));
+    result = compr_ops->decompress(cctx, zeroes, sizeof(zeroes));
     TEST_CHECK(result == zeroes);
 
     const char ones[] = { 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
                           0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01 };
-    result = cops->decompress(cctx, ones, sizeof(ones));
+    result = compr_ops->decompress(cctx, ones, sizeof(ones));
     TEST_CHECK(result == NULL);
 
-    cops->close(&cctx);
+    compr_ops->close(&cctx);
   }
 
-  compress_data_tests(cops, MIN_COMP_LEVEL, MAX_COMP_LEVEL);
+  compress_data_tests(compr_ops, MIN_COMP_LEVEL, MAX_COMP_LEVEL);
 }

--- a/test/compress/zlib.c
+++ b/test/compress/zlib.c
@@ -33,10 +33,10 @@
 
 void test_compress_zlib(void)
 {
-  // void *open(short level);
-  // void *compress(void *cctx, const char *data, size_t dlen, size_t *clen);
-  // void *decompress(void *cctx, const char *cbuf, size_t clen);
-  // void  close(void **cctx);
+  // ComprHandle *open(short level);
+  // void *compress(ComprHandle *handle, const char *data, size_t dlen, size_t *clen);
+  // void *decompress(ComprHandle *handle, const char *cbuf, size_t clen);
+  // void close(ComprHandle **ptr);
 
   const struct ComprOps *compr_ops = compress_get_ops("zlib");
   if (!TEST_CHECK(compr_ops != NULL))
@@ -46,24 +46,24 @@ void test_compress_zlib(void)
     // Degenerate tests
     TEST_CHECK(compr_ops->compress(NULL, NULL, 0, NULL) == NULL);
     TEST_CHECK(compr_ops->decompress(NULL, NULL, 0) == NULL);
-    void *cctx = NULL;
+    ComprHandle *compr_handle = NULL;
     compr_ops->close(NULL);
     TEST_CHECK_(1, "compr_ops->close(NULL)");
-    compr_ops->close(&cctx);
-    TEST_CHECK_(1, "compr_ops->close(&cctx)");
+    compr_ops->close(&compr_handle);
+    TEST_CHECK_(1, "compr_ops->close(&compr_handle)");
   }
 
   {
     // Temporarily disable logging
     MuttLogger = log_disp_null;
 
-    void *cctx = compr_ops->open(MIN_COMP_LEVEL - 1);
-    TEST_CHECK(cctx != NULL);
-    compr_ops->close(&cctx);
+    ComprHandle *compr_handle = compr_ops->open(MIN_COMP_LEVEL - 1);
+    TEST_CHECK(compr_handle != NULL);
+    compr_ops->close(&compr_handle);
 
-    cctx = compr_ops->open(MAX_COMP_LEVEL + 1);
-    TEST_CHECK(cctx != NULL);
-    compr_ops->close(&cctx);
+    compr_handle = compr_ops->open(MAX_COMP_LEVEL + 1);
+    TEST_CHECK(compr_handle != NULL);
+    compr_ops->close(&compr_handle);
 
     // Restore logging
     MuttLogger = log_disp_terminal;
@@ -71,24 +71,24 @@ void test_compress_zlib(void)
 
   {
     // Garbage data
-    void *cctx = compr_ops->open(MIN_COMP_LEVEL);
-    TEST_CHECK(cctx != NULL);
+    ComprHandle *compr_handle = compr_ops->open(MIN_COMP_LEVEL);
+    TEST_CHECK(compr_handle != NULL);
 
     const char zeroes[] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
 
-    void *result = compr_ops->decompress(cctx, zeroes, 0);
+    void *result = compr_ops->decompress(compr_handle, zeroes, 0);
     TEST_CHECK(result == NULL);
 
-    result = compr_ops->decompress(cctx, zeroes, sizeof(zeroes));
+    result = compr_ops->decompress(compr_handle, zeroes, sizeof(zeroes));
     TEST_CHECK(result == NULL);
 
     const char ones[] = { 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
                           0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01 };
-    result = compr_ops->decompress(cctx, ones, sizeof(ones));
+    result = compr_ops->decompress(compr_handle, ones, sizeof(ones));
     TEST_CHECK(result == NULL);
 
-    compr_ops->close(&cctx);
+    compr_ops->close(&compr_handle);
   }
 
   compress_data_tests(compr_ops, MIN_COMP_LEVEL, MAX_COMP_LEVEL);

--- a/test/compress/zlib.c
+++ b/test/compress/zlib.c
@@ -38,32 +38,32 @@ void test_compress_zlib(void)
   // void *decompress(void *cctx, const char *cbuf, size_t clen);
   // void  close(void **cctx);
 
-  const struct ComprOps *cops = compress_get_ops("zlib");
-  if (!TEST_CHECK(cops != NULL))
+  const struct ComprOps *compr_ops = compress_get_ops("zlib");
+  if (!TEST_CHECK(compr_ops != NULL))
     return;
 
   {
     // Degenerate tests
-    TEST_CHECK(cops->compress(NULL, NULL, 0, NULL) == NULL);
-    TEST_CHECK(cops->decompress(NULL, NULL, 0) == NULL);
+    TEST_CHECK(compr_ops->compress(NULL, NULL, 0, NULL) == NULL);
+    TEST_CHECK(compr_ops->decompress(NULL, NULL, 0) == NULL);
     void *cctx = NULL;
-    cops->close(NULL);
-    TEST_CHECK_(1, "cops->close(NULL)");
-    cops->close(&cctx);
-    TEST_CHECK_(1, "cops->close(&cctx)");
+    compr_ops->close(NULL);
+    TEST_CHECK_(1, "compr_ops->close(NULL)");
+    compr_ops->close(&cctx);
+    TEST_CHECK_(1, "compr_ops->close(&cctx)");
   }
 
   {
     // Temporarily disable logging
     MuttLogger = log_disp_null;
 
-    void *cctx = cops->open(MIN_COMP_LEVEL - 1);
+    void *cctx = compr_ops->open(MIN_COMP_LEVEL - 1);
     TEST_CHECK(cctx != NULL);
-    cops->close(&cctx);
+    compr_ops->close(&cctx);
 
-    cctx = cops->open(MAX_COMP_LEVEL + 1);
+    cctx = compr_ops->open(MAX_COMP_LEVEL + 1);
     TEST_CHECK(cctx != NULL);
-    cops->close(&cctx);
+    compr_ops->close(&cctx);
 
     // Restore logging
     MuttLogger = log_disp_terminal;
@@ -71,25 +71,25 @@ void test_compress_zlib(void)
 
   {
     // Garbage data
-    void *cctx = cops->open(MIN_COMP_LEVEL);
+    void *cctx = compr_ops->open(MIN_COMP_LEVEL);
     TEST_CHECK(cctx != NULL);
 
     const char zeroes[] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
 
-    void *result = cops->decompress(cctx, zeroes, 0);
+    void *result = compr_ops->decompress(cctx, zeroes, 0);
     TEST_CHECK(result == NULL);
 
-    result = cops->decompress(cctx, zeroes, sizeof(zeroes));
+    result = compr_ops->decompress(cctx, zeroes, sizeof(zeroes));
     TEST_CHECK(result == NULL);
 
     const char ones[] = { 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
                           0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01 };
-    result = cops->decompress(cctx, ones, sizeof(ones));
+    result = compr_ops->decompress(cctx, ones, sizeof(ones));
     TEST_CHECK(result == NULL);
 
-    cops->close(&cctx);
+    compr_ops->close(&cctx);
   }
 
-  compress_data_tests(cops, MIN_COMP_LEVEL, MAX_COMP_LEVEL);
+  compress_data_tests(compr_ops, MIN_COMP_LEVEL, MAX_COMP_LEVEL);
 }

--- a/test/compress/zstd.c
+++ b/test/compress/zstd.c
@@ -33,10 +33,10 @@
 
 void test_compress_zstd(void)
 {
-  // void *open(short level);
-  // void *compress(void *cctx, const char *data, size_t dlen, size_t *clen);
-  // void *decompress(void *cctx, const char *cbuf, size_t clen);
-  // void  close(void **cctx);
+  // ComprHandle *open(short level);
+  // void *compress(ComprHandle *handle, const char *data, size_t dlen, size_t *clen);
+  // void *decompress(ComprHandle *handle, const char *cbuf, size_t clen);
+  // void close(ComprHandle **ptr);
 
   const struct ComprOps *compr_ops = compress_get_ops("zstd");
   if (!TEST_CHECK(compr_ops != NULL))
@@ -46,24 +46,24 @@ void test_compress_zstd(void)
     // Degenerate tests
     TEST_CHECK(compr_ops->compress(NULL, NULL, 0, NULL) == NULL);
     TEST_CHECK(compr_ops->decompress(NULL, NULL, 0) == NULL);
-    void *cctx = NULL;
+    ComprHandle *compr_handle = NULL;
     compr_ops->close(NULL);
     TEST_CHECK_(1, "compr_ops->close(NULL)");
-    compr_ops->close(&cctx);
-    TEST_CHECK_(1, "compr_ops->close(&cctx)");
+    compr_ops->close(&compr_handle);
+    TEST_CHECK_(1, "compr_ops->close(&compr_handle)");
   }
 
   {
     // Temporarily disable logging
     MuttLogger = log_disp_null;
 
-    void *cctx = compr_ops->open(MIN_COMP_LEVEL - 1);
-    TEST_CHECK(cctx != NULL);
-    compr_ops->close(&cctx);
+    ComprHandle *compr_handle = compr_ops->open(MIN_COMP_LEVEL - 1);
+    TEST_CHECK(compr_handle != NULL);
+    compr_ops->close(&compr_handle);
 
-    cctx = compr_ops->open(MAX_COMP_LEVEL + 1);
-    TEST_CHECK(cctx != NULL);
-    compr_ops->close(&cctx);
+    compr_handle = compr_ops->open(MAX_COMP_LEVEL + 1);
+    TEST_CHECK(compr_handle != NULL);
+    compr_ops->close(&compr_handle);
 
     // Restore logging
     MuttLogger = log_disp_terminal;
@@ -71,15 +71,15 @@ void test_compress_zstd(void)
 
   {
     // Garbage data
-    void *cctx = compr_ops->open(MIN_COMP_LEVEL);
-    TEST_CHECK(cctx != NULL);
+    ComprHandle *compr_handle = compr_ops->open(MIN_COMP_LEVEL);
+    TEST_CHECK(compr_handle != NULL);
 
     const char zeroes[] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
-    void *result = compr_ops->decompress(cctx, zeroes, sizeof(zeroes));
+    void *result = compr_ops->decompress(compr_handle, zeroes, sizeof(zeroes));
     TEST_CHECK(result == NULL);
 
-    compr_ops->close(&cctx);
+    compr_ops->close(&compr_handle);
   }
 
   compress_data_tests(compr_ops, MIN_COMP_LEVEL, MAX_COMP_LEVEL);

--- a/test/compress/zstd.c
+++ b/test/compress/zstd.c
@@ -38,32 +38,32 @@ void test_compress_zstd(void)
   // void *decompress(void *cctx, const char *cbuf, size_t clen);
   // void  close(void **cctx);
 
-  const struct ComprOps *cops = compress_get_ops("zstd");
-  if (!TEST_CHECK(cops != NULL))
+  const struct ComprOps *compr_ops = compress_get_ops("zstd");
+  if (!TEST_CHECK(compr_ops != NULL))
     return;
 
   {
     // Degenerate tests
-    TEST_CHECK(cops->compress(NULL, NULL, 0, NULL) == NULL);
-    TEST_CHECK(cops->decompress(NULL, NULL, 0) == NULL);
+    TEST_CHECK(compr_ops->compress(NULL, NULL, 0, NULL) == NULL);
+    TEST_CHECK(compr_ops->decompress(NULL, NULL, 0) == NULL);
     void *cctx = NULL;
-    cops->close(NULL);
-    TEST_CHECK_(1, "cops->close(NULL)");
-    cops->close(&cctx);
-    TEST_CHECK_(1, "cops->close(&cctx)");
+    compr_ops->close(NULL);
+    TEST_CHECK_(1, "compr_ops->close(NULL)");
+    compr_ops->close(&cctx);
+    TEST_CHECK_(1, "compr_ops->close(&cctx)");
   }
 
   {
     // Temporarily disable logging
     MuttLogger = log_disp_null;
 
-    void *cctx = cops->open(MIN_COMP_LEVEL - 1);
+    void *cctx = compr_ops->open(MIN_COMP_LEVEL - 1);
     TEST_CHECK(cctx != NULL);
-    cops->close(&cctx);
+    compr_ops->close(&cctx);
 
-    cctx = cops->open(MAX_COMP_LEVEL + 1);
+    cctx = compr_ops->open(MAX_COMP_LEVEL + 1);
     TEST_CHECK(cctx != NULL);
-    cops->close(&cctx);
+    compr_ops->close(&cctx);
 
     // Restore logging
     MuttLogger = log_disp_terminal;
@@ -71,16 +71,16 @@ void test_compress_zstd(void)
 
   {
     // Garbage data
-    void *cctx = cops->open(MIN_COMP_LEVEL);
+    void *cctx = compr_ops->open(MIN_COMP_LEVEL);
     TEST_CHECK(cctx != NULL);
 
     const char zeroes[] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
-    void *result = cops->decompress(cctx, zeroes, sizeof(zeroes));
+    void *result = compr_ops->decompress(cctx, zeroes, sizeof(zeroes));
     TEST_CHECK(result == NULL);
 
-    cops->close(&cctx);
+    compr_ops->close(&cctx);
   }
 
-  compress_data_tests(cops, MIN_COMP_LEVEL, MAX_COMP_LEVEL);
+  compress_data_tests(compr_ops, MIN_COMP_LEVEL, MAX_COMP_LEVEL);
 }

--- a/test/store/bdb.c
+++ b/test/store/bdb.c
@@ -38,20 +38,20 @@ void test_store_bdb(void)
 
   TEST_CASE(DB_NAME);
 
-  const struct StoreOps *sops = store_get_backend_ops(DB_NAME);
-  TEST_CHECK(sops != NULL);
+  const struct StoreOps *store_ops = store_get_backend_ops(DB_NAME);
+  TEST_CHECK(store_ops != NULL);
 
-  TEST_CHECK(test_store_degenerate(sops, DB_NAME) == true);
+  TEST_CHECK(test_store_degenerate(store_ops, DB_NAME) == true);
 
   TEST_CHECK(test_store_setup(path, sizeof(path)) == true);
 
   mutt_str_cat(path, sizeof(path), "/");
   mutt_str_cat(path, sizeof(path), DB_NAME);
 
-  void *db = sops->open(path);
+  void *db = store_ops->open(path);
   TEST_CHECK(db != NULL);
 
-  TEST_CHECK(test_store_db(sops, db) == true);
+  TEST_CHECK(test_store_db(store_ops, db) == true);
 
-  sops->close(&db);
+  store_ops->close(&db);
 }

--- a/test/store/bdb.c
+++ b/test/store/bdb.c
@@ -48,10 +48,10 @@ void test_store_bdb(void)
   mutt_str_cat(path, sizeof(path), "/");
   mutt_str_cat(path, sizeof(path), DB_NAME);
 
-  void *db = store_ops->open(path);
-  TEST_CHECK(db != NULL);
+  StoreHandle *store_handle = store_ops->open(path);
+  TEST_CHECK(store_handle != NULL);
 
-  TEST_CHECK(test_store_db(store_ops, db) == true);
+  TEST_CHECK(test_store_db(store_ops, store_handle) == true);
 
-  store_ops->close(&db);
+  store_ops->close(&store_handle);
 }

--- a/test/store/bdb.c
+++ b/test/store/bdb.c
@@ -34,7 +34,7 @@
 
 void test_store_bdb(void)
 {
-  char path[PATH_MAX];
+  char path[PATH_MAX] = { 0 };
 
   TEST_CASE(DB_NAME);
 

--- a/test/store/common.c
+++ b/test/store/common.c
@@ -43,47 +43,47 @@ bool test_store_setup(char *buf, size_t buflen)
   return true;
 }
 
-bool test_store_degenerate(const struct StoreOps *sops, const char *name)
+bool test_store_degenerate(const struct StoreOps *store_ops, const char *name)
 {
-  if (!sops)
+  if (!store_ops)
     return false;
 
-  if (!TEST_CHECK_STR_EQ(sops->name, name))
+  if (!TEST_CHECK_STR_EQ(store_ops->name, name))
     return false;
 
-  if (!TEST_CHECK(sops->open(NULL) == NULL))
+  if (!TEST_CHECK(store_ops->open(NULL) == NULL))
     return false;
 
-  if (!TEST_CHECK(sops->fetch(NULL, NULL, 0, NULL) == NULL))
+  if (!TEST_CHECK(store_ops->fetch(NULL, NULL, 0, NULL) == NULL))
     return false;
 
   void *ptr = NULL;
-  sops->free(NULL, NULL);
-  TEST_CHECK_(1, "sops->free(NULL, NULL)");
-  sops->free(NULL, &ptr);
-  TEST_CHECK_(1, "sops->free(NULL, ptr)");
+  store_ops->free(NULL, NULL);
+  TEST_CHECK_(1, "store_ops->free(NULL, NULL)");
+  store_ops->free(NULL, &ptr);
+  TEST_CHECK_(1, "store_ops->free(NULL, ptr)");
 
-  if (!TEST_CHECK(sops->store(NULL, NULL, 0, NULL, 0) != 0))
+  if (!TEST_CHECK(store_ops->store(NULL, NULL, 0, NULL, 0) != 0))
     return false;
 
-  if (!TEST_CHECK(sops->delete_record(NULL, NULL, 0) != 0))
+  if (!TEST_CHECK(store_ops->delete_record(NULL, NULL, 0) != 0))
     return false;
 
-  sops->close(NULL);
-  TEST_CHECK_(1, "sops->close(NULL)");
+  store_ops->close(NULL);
+  TEST_CHECK_(1, "store_ops->close(NULL)");
 
-  sops->close(&ptr);
-  TEST_CHECK_(1, "sops->close(&ptr)");
+  store_ops->close(&ptr);
+  TEST_CHECK_(1, "store_ops->close(&ptr)");
 
-  if (!TEST_CHECK(sops->version() != NULL))
+  if (!TEST_CHECK(store_ops->version() != NULL))
     return false;
 
   return true;
 }
 
-bool test_store_db(const struct StoreOps *sops, void *db)
+bool test_store_db(const struct StoreOps *store_ops, void *db)
 {
-  if (!sops || !db)
+  if (!store_ops || !db)
     return false;
 
   const char *key = "one";
@@ -92,20 +92,20 @@ bool test_store_db(const struct StoreOps *sops, void *db)
   size_t vlen = strlen(value);
   int rc;
 
-  rc = sops->store(db, key, klen, value, vlen);
+  rc = store_ops->store(db, key, klen, value, vlen);
   if (!TEST_CHECK(rc == 0))
     return false;
 
   void *data = NULL;
   vlen = 0;
-  data = sops->fetch(db, key, klen, &vlen);
+  data = store_ops->fetch(db, key, klen, &vlen);
   if (!TEST_CHECK(data != NULL))
     return false;
 
-  sops->free(db, &data);
-  TEST_CHECK_(1, "sops->free(db, &data)");
+  store_ops->free(db, &data);
+  TEST_CHECK_(1, "store_ops->free(db, &data)");
 
-  rc = sops->delete_record(db, key, klen);
+  rc = store_ops->delete_record(db, key, klen);
   if (!TEST_CHECK(rc == 0))
     return false;
 

--- a/test/store/common.c
+++ b/test/store/common.c
@@ -81,9 +81,9 @@ bool test_store_degenerate(const struct StoreOps *store_ops, const char *name)
   return true;
 }
 
-bool test_store_db(const struct StoreOps *store_ops, void *db)
+bool test_store_db(const struct StoreOps *store_ops, StoreHandle *store_handle)
 {
-  if (!store_ops || !db)
+  if (!store_ops || !store_handle)
     return false;
 
   const char *key = "one";
@@ -92,20 +92,20 @@ bool test_store_db(const struct StoreOps *store_ops, void *db)
   size_t vlen = strlen(value);
   int rc;
 
-  rc = store_ops->store(db, key, klen, value, vlen);
+  rc = store_ops->store(store_handle, key, klen, value, vlen);
   if (!TEST_CHECK(rc == 0))
     return false;
 
   void *data = NULL;
   vlen = 0;
-  data = store_ops->fetch(db, key, klen, &vlen);
+  data = store_ops->fetch(store_handle, key, klen, &vlen);
   if (!TEST_CHECK(data != NULL))
     return false;
 
-  store_ops->free(db, &data);
-  TEST_CHECK_(1, "store_ops->free(db, &data)");
+  store_ops->free(store_handle, &data);
+  TEST_CHECK_(1, "store_ops->free(store_handle, &data)");
 
-  rc = store_ops->delete_record(db, key, klen);
+  rc = store_ops->delete_record(store_handle, key, klen);
   if (!TEST_CHECK(rc == 0))
     return false;
 

--- a/test/store/gdbm.c
+++ b/test/store/gdbm.c
@@ -46,10 +46,10 @@ void test_store_gdbm(void)
   mutt_str_cat(path, sizeof(path), "/");
   mutt_str_cat(path, sizeof(path), DB_NAME);
 
-  void *db = store_ops->open(path);
-  TEST_CHECK(db != NULL);
+  StoreHandle *store_handle = store_ops->open(path);
+  TEST_CHECK(store_handle != NULL);
 
-  TEST_CHECK(test_store_db(store_ops, db) == true);
+  TEST_CHECK(test_store_db(store_ops, store_handle) == true);
 
-  store_ops->close(&db);
+  store_ops->close(&store_handle);
 }

--- a/test/store/gdbm.c
+++ b/test/store/gdbm.c
@@ -36,20 +36,20 @@ void test_store_gdbm(void)
 {
   char path[PATH_MAX] = { 0 };
 
-  const struct StoreOps *sops = store_get_backend_ops(DB_NAME);
-  TEST_CHECK(sops != NULL);
+  const struct StoreOps *store_ops = store_get_backend_ops(DB_NAME);
+  TEST_CHECK(store_ops != NULL);
 
-  TEST_CHECK(test_store_degenerate(sops, DB_NAME) == true);
+  TEST_CHECK(test_store_degenerate(store_ops, DB_NAME) == true);
 
   TEST_CHECK(test_store_setup(path, sizeof(path)) == true);
 
   mutt_str_cat(path, sizeof(path), "/");
   mutt_str_cat(path, sizeof(path), DB_NAME);
 
-  void *db = sops->open(path);
+  void *db = store_ops->open(path);
   TEST_CHECK(db != NULL);
 
-  TEST_CHECK(test_store_db(sops, db) == true);
+  TEST_CHECK(test_store_db(store_ops, db) == true);
 
-  sops->close(&db);
+  store_ops->close(&db);
 }

--- a/test/store/gdbm.c
+++ b/test/store/gdbm.c
@@ -34,7 +34,7 @@
 
 void test_store_gdbm(void)
 {
-  char path[PATH_MAX];
+  char path[PATH_MAX] = { 0 };
 
   const struct StoreOps *sops = store_get_backend_ops(DB_NAME);
   TEST_CHECK(sops != NULL);

--- a/test/store/kc.c
+++ b/test/store/kc.c
@@ -34,7 +34,7 @@
 
 void test_store_kc(void)
 {
-  char path[PATH_MAX];
+  char path[PATH_MAX] = { 0 };
 
   const struct StoreOps *sops = store_get_backend_ops(DB_NAME);
   TEST_CHECK(sops != NULL);

--- a/test/store/kc.c
+++ b/test/store/kc.c
@@ -36,20 +36,20 @@ void test_store_kc(void)
 {
   char path[PATH_MAX] = { 0 };
 
-  const struct StoreOps *sops = store_get_backend_ops(DB_NAME);
-  TEST_CHECK(sops != NULL);
+  const struct StoreOps *store_ops = store_get_backend_ops(DB_NAME);
+  TEST_CHECK(store_ops != NULL);
 
-  TEST_CHECK(test_store_degenerate(sops, DB_NAME) == true);
+  TEST_CHECK(test_store_degenerate(store_ops, DB_NAME) == true);
 
   TEST_CHECK(test_store_setup(path, sizeof(path)) == true);
 
   mutt_str_cat(path, sizeof(path), "/");
   mutt_str_cat(path, sizeof(path), DB_NAME);
 
-  void *db = sops->open(path);
+  void *db = store_ops->open(path);
   TEST_CHECK(db != NULL);
 
-  TEST_CHECK(test_store_db(sops, db) == true);
+  TEST_CHECK(test_store_db(store_ops, db) == true);
 
-  sops->close(&db);
+  store_ops->close(&db);
 }

--- a/test/store/kc.c
+++ b/test/store/kc.c
@@ -46,10 +46,10 @@ void test_store_kc(void)
   mutt_str_cat(path, sizeof(path), "/");
   mutt_str_cat(path, sizeof(path), DB_NAME);
 
-  void *db = store_ops->open(path);
-  TEST_CHECK(db != NULL);
+  StoreHandle *store_handle = store_ops->open(path);
+  TEST_CHECK(store_handle != NULL);
 
-  TEST_CHECK(test_store_db(store_ops, db) == true);
+  TEST_CHECK(test_store_db(store_ops, store_handle) == true);
 
-  store_ops->close(&db);
+  store_ops->close(&store_handle);
 }

--- a/test/store/lmdb.c
+++ b/test/store/lmdb.c
@@ -46,10 +46,10 @@ void test_store_lmdb(void)
   mutt_str_cat(path, sizeof(path), "/");
   mutt_str_cat(path, sizeof(path), DB_NAME);
 
-  void *db = store_ops->open(path);
-  TEST_CHECK(db != NULL);
+  StoreHandle *store_handle = store_ops->open(path);
+  TEST_CHECK(store_handle != NULL);
 
-  TEST_CHECK(test_store_db(store_ops, db) == true);
+  TEST_CHECK(test_store_db(store_ops, store_handle) == true);
 
-  store_ops->close(&db);
+  store_ops->close(&store_handle);
 }

--- a/test/store/lmdb.c
+++ b/test/store/lmdb.c
@@ -36,20 +36,20 @@ void test_store_lmdb(void)
 {
   char path[PATH_MAX] = { 0 };
 
-  const struct StoreOps *sops = store_get_backend_ops(DB_NAME);
-  TEST_CHECK(sops != NULL);
+  const struct StoreOps *store_ops = store_get_backend_ops(DB_NAME);
+  TEST_CHECK(store_ops != NULL);
 
-  TEST_CHECK(test_store_degenerate(sops, DB_NAME) == true);
+  TEST_CHECK(test_store_degenerate(store_ops, DB_NAME) == true);
 
   TEST_CHECK(test_store_setup(path, sizeof(path)) == true);
 
   mutt_str_cat(path, sizeof(path), "/");
   mutt_str_cat(path, sizeof(path), DB_NAME);
 
-  void *db = sops->open(path);
+  void *db = store_ops->open(path);
   TEST_CHECK(db != NULL);
 
-  TEST_CHECK(test_store_db(sops, db) == true);
+  TEST_CHECK(test_store_db(store_ops, db) == true);
 
-  sops->close(&db);
+  store_ops->close(&db);
 }

--- a/test/store/lmdb.c
+++ b/test/store/lmdb.c
@@ -34,7 +34,7 @@
 
 void test_store_lmdb(void)
 {
-  char path[PATH_MAX];
+  char path[PATH_MAX] = { 0 };
 
   const struct StoreOps *sops = store_get_backend_ops(DB_NAME);
   TEST_CHECK(sops != NULL);

--- a/test/store/qdbm.c
+++ b/test/store/qdbm.c
@@ -36,20 +36,20 @@ void test_store_qdbm(void)
 {
   char path[PATH_MAX] = { 0 };
 
-  const struct StoreOps *sops = store_get_backend_ops(DB_NAME);
-  TEST_CHECK(sops != NULL);
+  const struct StoreOps *store_ops = store_get_backend_ops(DB_NAME);
+  TEST_CHECK(store_ops != NULL);
 
-  TEST_CHECK(test_store_degenerate(sops, DB_NAME) == true);
+  TEST_CHECK(test_store_degenerate(store_ops, DB_NAME) == true);
 
   TEST_CHECK(test_store_setup(path, sizeof(path)) == true);
 
   mutt_str_cat(path, sizeof(path), "/");
   mutt_str_cat(path, sizeof(path), DB_NAME);
 
-  void *db = sops->open(path);
+  void *db = store_ops->open(path);
   TEST_CHECK(db != NULL);
 
-  TEST_CHECK(test_store_db(sops, db) == true);
+  TEST_CHECK(test_store_db(store_ops, db) == true);
 
-  sops->close(&db);
+  store_ops->close(&db);
 }

--- a/test/store/qdbm.c
+++ b/test/store/qdbm.c
@@ -34,7 +34,7 @@
 
 void test_store_qdbm(void)
 {
-  char path[PATH_MAX];
+  char path[PATH_MAX] = { 0 };
 
   const struct StoreOps *sops = store_get_backend_ops(DB_NAME);
   TEST_CHECK(sops != NULL);

--- a/test/store/qdbm.c
+++ b/test/store/qdbm.c
@@ -46,10 +46,10 @@ void test_store_qdbm(void)
   mutt_str_cat(path, sizeof(path), "/");
   mutt_str_cat(path, sizeof(path), DB_NAME);
 
-  void *db = store_ops->open(path);
-  TEST_CHECK(db != NULL);
+  StoreHandle *store_handle = store_ops->open(path);
+  TEST_CHECK(store_handle != NULL);
 
-  TEST_CHECK(test_store_db(store_ops, db) == true);
+  TEST_CHECK(test_store_db(store_ops, store_handle) == true);
 
-  store_ops->close(&db);
+  store_ops->close(&store_handle);
 }

--- a/test/store/rocksdb.c
+++ b/test/store/rocksdb.c
@@ -46,10 +46,10 @@ void test_store_rocksdb(void)
   mutt_str_cat(path, sizeof(path), "/");
   mutt_str_cat(path, sizeof(path), DB_NAME);
 
-  void *db = store_ops->open(path);
-  TEST_CHECK(db != NULL);
+  StoreHandle *store_handle = store_ops->open(path);
+  TEST_CHECK(store_handle != NULL);
 
-  TEST_CHECK(test_store_db(store_ops, db) == true);
+  TEST_CHECK(test_store_db(store_ops, store_handle) == true);
 
-  store_ops->close(&db);
+  store_ops->close(&store_handle);
 }

--- a/test/store/rocksdb.c
+++ b/test/store/rocksdb.c
@@ -34,7 +34,7 @@
 
 void test_store_rocksdb(void)
 {
-  char path[PATH_MAX];
+  char path[PATH_MAX] = { 0 };
 
   const struct StoreOps *sops = store_get_backend_ops(DB_NAME);
   TEST_CHECK(sops != NULL);

--- a/test/store/rocksdb.c
+++ b/test/store/rocksdb.c
@@ -36,20 +36,20 @@ void test_store_rocksdb(void)
 {
   char path[PATH_MAX] = { 0 };
 
-  const struct StoreOps *sops = store_get_backend_ops(DB_NAME);
-  TEST_CHECK(sops != NULL);
+  const struct StoreOps *store_ops = store_get_backend_ops(DB_NAME);
+  TEST_CHECK(store_ops != NULL);
 
-  TEST_CHECK(test_store_degenerate(sops, DB_NAME) == true);
+  TEST_CHECK(test_store_degenerate(store_ops, DB_NAME) == true);
 
   TEST_CHECK(test_store_setup(path, sizeof(path)) == true);
 
   mutt_str_cat(path, sizeof(path), "/");
   mutt_str_cat(path, sizeof(path), DB_NAME);
 
-  void *db = sops->open(path);
+  void *db = store_ops->open(path);
   TEST_CHECK(db != NULL);
 
-  TEST_CHECK(test_store_db(sops, db) == true);
+  TEST_CHECK(test_store_db(store_ops, db) == true);
 
-  sops->close(&db);
+  store_ops->close(&db);
 }

--- a/test/store/store.c
+++ b/test/store/store.c
@@ -36,14 +36,14 @@ void test_store_store(void)
   TEST_CHECK(list != NULL);
   FREE(&list);
 
-  const struct StoreOps *sops = NULL;
+  const struct StoreOps *store_ops = NULL;
 
-  sops = store_get_backend_ops(NULL);
-  TEST_CHECK(sops != NULL);
+  store_ops = store_get_backend_ops(NULL);
+  TEST_CHECK(store_ops != NULL);
 
 #ifdef HAVE_TC
-  sops = store_get_backend_ops("tokyocabinet");
-  TEST_CHECK(sops != NULL);
+  store_ops = store_get_backend_ops("tokyocabinet");
+  TEST_CHECK(store_ops != NULL);
 #endif
 
   TEST_CHECK(store_is_valid_backend(NULL) == true);

--- a/test/store/tc.c
+++ b/test/store/tc.c
@@ -46,10 +46,10 @@ void test_store_tc(void)
   mutt_str_cat(path, sizeof(path), "/");
   mutt_str_cat(path, sizeof(path), DB_NAME);
 
-  void *db = store_ops->open(path);
-  TEST_CHECK(db != NULL);
+  StoreHandle *store_handle = store_ops->open(path);
+  TEST_CHECK(store_handle != NULL);
 
-  TEST_CHECK(test_store_db(store_ops, db) == true);
+  TEST_CHECK(test_store_db(store_ops, store_handle) == true);
 
-  store_ops->close(&db);
+  store_ops->close(&store_handle);
 }

--- a/test/store/tc.c
+++ b/test/store/tc.c
@@ -34,7 +34,7 @@
 
 void test_store_tc(void)
 {
-  char path[PATH_MAX];
+  char path[PATH_MAX] = { 0 };
 
   const struct StoreOps *sops = store_get_backend_ops(DB_NAME);
   TEST_CHECK(sops != NULL);

--- a/test/store/tc.c
+++ b/test/store/tc.c
@@ -36,20 +36,20 @@ void test_store_tc(void)
 {
   char path[PATH_MAX] = { 0 };
 
-  const struct StoreOps *sops = store_get_backend_ops(DB_NAME);
-  TEST_CHECK(sops != NULL);
+  const struct StoreOps *store_ops = store_get_backend_ops(DB_NAME);
+  TEST_CHECK(store_ops != NULL);
 
-  TEST_CHECK(test_store_degenerate(sops, DB_NAME) == true);
+  TEST_CHECK(test_store_degenerate(store_ops, DB_NAME) == true);
 
   TEST_CHECK(test_store_setup(path, sizeof(path)) == true);
 
   mutt_str_cat(path, sizeof(path), "/");
   mutt_str_cat(path, sizeof(path), DB_NAME);
 
-  void *db = sops->open(path);
+  void *db = store_ops->open(path);
   TEST_CHECK(db != NULL);
 
-  TEST_CHECK(test_store_db(sops, db) == true);
+  TEST_CHECK(test_store_db(store_ops, db) == true);
 
-  sops->close(&db);
+  store_ops->close(&db);
 }

--- a/test/store/tdb.c
+++ b/test/store/tdb.c
@@ -46,10 +46,10 @@ void test_store_tdb(void)
   mutt_str_cat(path, sizeof(path), "/");
   mutt_str_cat(path, sizeof(path), DB_NAME);
 
-  void *db = store_ops->open(path);
-  TEST_CHECK(db != NULL);
+  StoreHandle *store_handle = store_ops->open(path);
+  TEST_CHECK(store_handle != NULL);
 
-  TEST_CHECK(test_store_db(store_ops, db) == true);
+  TEST_CHECK(test_store_db(store_ops, store_handle) == true);
 
-  store_ops->close(&db);
+  store_ops->close(&store_handle);
 }

--- a/test/store/tdb.c
+++ b/test/store/tdb.c
@@ -34,7 +34,7 @@
 
 void test_store_tdb(void)
 {
-  char path[PATH_MAX];
+  char path[PATH_MAX] = { 0 };
 
   const struct StoreOps *sops = store_get_backend_ops(DB_NAME);
   TEST_CHECK(sops != NULL);

--- a/test/store/tdb.c
+++ b/test/store/tdb.c
@@ -36,20 +36,20 @@ void test_store_tdb(void)
 {
   char path[PATH_MAX] = { 0 };
 
-  const struct StoreOps *sops = store_get_backend_ops(DB_NAME);
-  TEST_CHECK(sops != NULL);
+  const struct StoreOps *store_ops = store_get_backend_ops(DB_NAME);
+  TEST_CHECK(store_ops != NULL);
 
-  TEST_CHECK(test_store_degenerate(sops, DB_NAME) == true);
+  TEST_CHECK(test_store_degenerate(store_ops, DB_NAME) == true);
 
   TEST_CHECK(test_store_setup(path, sizeof(path)) == true);
 
   mutt_str_cat(path, sizeof(path), "/");
   mutt_str_cat(path, sizeof(path), DB_NAME);
 
-  void *db = sops->open(path);
+  void *db = store_ops->open(path);
   TEST_CHECK(db != NULL);
 
-  TEST_CHECK(test_store_db(sops, db) == true);
+  TEST_CHECK(test_store_db(store_ops, db) == true);
 
-  sops->close(&db);
+  store_ops->close(&db);
 }


### PR DESCRIPTION
The header cache uses three config variables:

- `$header_cache_backend`
- `$header_cache_compress_method`
- `$header_cache_compress_level`

Refactor the code to query them once in `mutt_hcache_open()` and cache the matching Store/Compress ops in `struct HeaderCache`.

---

Changing these variables when using IMAP could crash NeoMutt.
Changing `$header_cache_backend` would cause **store A**'s data to be given to **store B**.

IMAP is the only backend that caches the Header Cache pointer whilst the Mailbox is open.
Maildir, by contrast, opens and closes the Header Cache on each call through the MXAPI.
(there's no opportunity for the config variables to change)