### PR TITLE
Check arguments in mutt_thread_ctx_free

### DIFF
--- a/mutt_thread.c
+++ b/mutt_thread.c
@@ -364,6 +364,11 @@ struct ThreadsContext *mutt_thread_ctx_init(struct MailboxView *mv)
  */
 void mutt_thread_ctx_free(struct ThreadsContext **ptr)
 {
+  if (!ptr || !*ptr)
+  {
+    return;
+  }
+
   struct ThreadsContext *tctx = *ptr;
 
   mutt_hash_free(&tctx->hash);


### PR DESCRIPTION
I just got a crash after hotmail closed the IMAP connection and I was left with an empty mailbox:

```
(gdb) bt
 #0  0x00000000003b4d9b in mutt_hash_free (ptr=0x10) at mutt/hash.c:459
 #1  0x000000000028dd34 in mutt_thread_ctx_free (ptr=0x801461b08) at mutt_thread.c:369
 #2  0x00000000002922f8 in mview_free (ptr=0x801a00950) at mview.c:63
 #3  0x00000000002a2edc in mutt_index_menu (dlg=0x80145d9a0, m_init=0x801483100) at index/dlg_index.c:1154
 #4  0x00000000002847ae in main (argc=1, argv=0x7fffffffe848, envp=0x7fffffffe858) at main.c:1361
```

This PR mitigates it by checking a pointer before free'ing it.