### PR TITLE
test for, and fix, logging problems

### DIFF
--- a/mutt/logging.c
+++ b/mutt/logging.c
@@ -242,8 +242,8 @@ bool log_file_running(void)
  *
  * If stamp is 0, then the current time will be used.
  */
-int log_disp_file(time_t stamp, const char *file, int line,
-                  const char *function, enum LogLevel level, ...)
+int log_disp_file(time_t stamp, const char *file, int line, const char *function,
+                  enum LogLevel level, const char *format, ...)
 {
   if (!LogFileFP || (level < LL_PERROR) || (level > LogFileLevel))
     return 0;
@@ -257,9 +257,8 @@ int log_disp_file(time_t stamp, const char *file, int line,
   rc += fprintf(LogFileFP, "[%s]<%c> %s() ", timestamp(stamp), LevelAbbr[level + 3], function);
 
   va_list ap;
-  va_start(ap, level);
-  const char *fmt = va_arg(ap, const char *);
-  rc += vfprintf(LogFileFP, fmt, ap);
+  va_start(ap, format);
+  rc += vfprintf(LogFileFP, format, ap);
   va_end(ap);
 
   if (level == LL_PERROR)
@@ -395,16 +394,15 @@ int log_queue_save(FILE *fp)
  *
  * @warning Log lines are limited to LOG_LINE_MAX_LEN bytes
  */
-int log_disp_queue(time_t stamp, const char *file, int line,
-                   const char *function, enum LogLevel level, ...)
+int log_disp_queue(time_t stamp, const char *file, int line, const char *function,
+                   enum LogLevel level, const char *format, ...)
 {
   char buf[LOG_LINE_MAX_LEN] = { 0 };
   int err = errno;
 
   va_list ap;
-  va_start(ap, level);
-  const char *fmt = va_arg(ap, const char *);
-  int rc = vsnprintf(buf, sizeof(buf), fmt, ap);
+  va_start(ap, format);
+  int rc = vsnprintf(buf, sizeof(buf), format, ap);
   va_end(ap);
 
   if (level == LL_PERROR)
@@ -439,15 +437,14 @@ int log_disp_queue(time_t stamp, const char *file, int line,
  * @note The output will be coloured using ANSI escape sequences,
  *       unless the output is redirected.
  */
-int log_disp_terminal(time_t stamp, const char *file, int line,
-                      const char *function, enum LogLevel level, ...)
+int log_disp_terminal(time_t stamp, const char *file, int line, const char *function,
+                      enum LogLevel level, const char *format, ...)
 {
   char buf[LOG_LINE_MAX_LEN] = { 0 };
 
   va_list ap;
-  va_start(ap, level);
-  const char *fmt = va_arg(ap, const char *);
-  int rc = vsnprintf(buf, sizeof(buf), fmt, ap);
+  va_start(ap, format);
+  int rc = vsnprintf(buf, sizeof(buf), format, ap);
   va_end(ap);
 
   log_disp_file(stamp, file, line, function, level, "%s", buf);
@@ -496,8 +493,8 @@ int log_disp_terminal(time_t stamp, const char *file, int line,
 /**
  * log_disp_null - Discard log lines - Implements ::log_dispatcher_t - @ingroup logging_api
  */
-int log_disp_null(time_t stamp, const char *file, int line,
-                  const char *function, enum LogLevel level, ...)
+int log_disp_null(time_t stamp, const char *file, int line, const char *function,
+                  enum LogLevel level, const char *format, ...)
 {
   return 0;
 }

--- a/mutt/logging2.h
+++ b/mutt/logging2.h
@@ -60,12 +60,14 @@ enum LogLevel
  * @param line     Source line
  * @param function Source function
  * @param level    Logging level, e.g. #LL_WARNING
+ * @param format   printf()-style formatting string
  * @param ...      Format string and parameters, like printf()
  * @retval -1 Error
  * @retval  0 Success, filtered
  * @retval >0 Success, number of characters written
  */
-typedef int (*log_dispatcher_t)(time_t stamp, const char *file, int line, const char *function, enum LogLevel level, ...);
+typedef int (*log_dispatcher_t)(time_t stamp, const char *file, int line, const char *function, enum LogLevel level, const char *format, ...)
+__attribute__((__format__(__printf__, 6, 7)));
 
 extern log_dispatcher_t MuttLogger;
 
@@ -90,10 +92,10 @@ STAILQ_HEAD(LogLineList, LogLine);
 #define mutt_error(...)        MuttLogger(0, __FILE__, __LINE__, __func__, LL_ERROR,   __VA_ARGS__) ///< @ingroup logging_api
 #define mutt_perror(...)       MuttLogger(0, __FILE__, __LINE__, __func__, LL_PERROR,  __VA_ARGS__) ///< @ingroup logging_api
 
-int  log_disp_file    (time_t stamp, const char *file, int line, const char *function, enum LogLevel level, ...);
-int  log_disp_null    (time_t stamp, const char *file, int line, const char *function, enum LogLevel level, ...);
-int  log_disp_queue   (time_t stamp, const char *file, int line, const char *function, enum LogLevel level, ...);
-int  log_disp_terminal(time_t stamp, const char *file, int line, const char *function, enum LogLevel level, ...);
+int  log_disp_file    (time_t stamp, const char *file, int line, const char *function, enum LogLevel level, const char *format, ...);
+int  log_disp_null    (time_t stamp, const char *file, int line, const char *function, enum LogLevel level, const char *format, ...);
+int  log_disp_queue   (time_t stamp, const char *file, int line, const char *function, enum LogLevel level, const char *format, ...);
+int  log_disp_terminal(time_t stamp, const char *file, int line, const char *function, enum LogLevel level, const char *format, ...);
 
 int  log_queue_add(struct LogLine *ll);
 void log_queue_empty(void);

--- a/mutt_logging.c
+++ b/mutt_logging.c
@@ -84,8 +84,8 @@ void mutt_clear_error(void)
 /**
  * log_disp_curses - Display a log line in the message line - Implements ::log_dispatcher_t - @ingroup logging_api
  */
-int log_disp_curses(time_t stamp, const char *file, int line,
-                    const char *function, enum LogLevel level, ...)
+int log_disp_curses(time_t stamp, const char *file, int line, const char *function,
+                    enum LogLevel level, const char *format, ...)
 {
   const short c_debug_level = cs_subset_number(NeoMutt->sub, "debug_level");
   if (level > c_debug_level)
@@ -94,9 +94,8 @@ int log_disp_curses(time_t stamp, const char *file, int line,
   char buf[LOG_LINE_MAX_LEN] = { 0 };
 
   va_list ap;
-  va_start(ap, level);
-  const char *fmt = va_arg(ap, const char *);
-  int rc = vsnprintf(buf, sizeof(buf), fmt, ap);
+  va_start(ap, format);
+  int rc = vsnprintf(buf, sizeof(buf), format, ap);
   va_end(ap);
 
   if ((level == LL_PERROR) && (rc >= 0) && (rc < sizeof(buf)))

--- a/mutt_logging.h
+++ b/mutt_logging.h
@@ -31,7 +31,7 @@
 struct ConfigDef;
 struct ConfigSet;
 
-int log_disp_curses(time_t stamp, const char *file, int line, const char *function, enum LogLevel level, ...);
+int log_disp_curses(time_t stamp, const char *file, int line, const char *function, enum LogLevel level, const char *format, ...);
 
 void mutt_log_prep(void);
 int  mutt_log_start(void);


### PR DESCRIPTION
**Updated**:

- Refactor the log dispatcher to explicitly name the printf format parameter
- Add the _printf_ attribute to the log dispatcher

These functions can now be checked for mismatched parameters:

- `mutt_debug()`
- `mutt_error()`
- `mutt_message()`
- `mutt_perror()`
- `mutt_warning()`

e.g.

`error: format specifies type 'char *' but the argument has type 'struct Buffer *'`