### PR TITLE
shrink the header cache

### DIFF
--- a/hcache/hcachever.sh
+++ b/hcache/hcachever.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-BASEVERSION=7
+BASEVERSION=8
 STRUCTURES="Address Body Buffer Email Envelope ListNode Parameter"
 
 cleanstruct () {

--- a/hcache/serialize.c
+++ b/hcache/serialize.c
@@ -91,6 +91,22 @@ unsigned char *serial_dump_uint32_t(const uint32_t s, unsigned char *d, int *off
 }
 
 /**
+ * serial_dump_uint64_t - Pack a uint64_t into a binary blob
+ * @param[in]     s   uint64_t to save
+ * @param[in]     d   Binary blob to add to
+ * @param[in,out] off Offset into the blob
+ * @retval ptr End of the newly packed binary
+ */
+unsigned char *serial_dump_uint64_t(const uint64_t s, unsigned char *d, int *off)
+{
+  lazy_realloc(&d, *off + sizeof(uint64_t));
+  memcpy(d + *off, &s, sizeof(uint64_t));
+  (*off) += sizeof(uint64_t);
+
+  return d;
+}
+
+/**
  * serial_restore_int - Unpack an integer from a binary blob
  * @param[in]     i   Integer to write to
  * @param[in]     d   Binary blob to read from
@@ -112,6 +128,18 @@ void serial_restore_uint32_t(uint32_t *s, const unsigned char *d, int *off)
 {
   memcpy(s, d + *off, sizeof(uint32_t));
   (*off) += sizeof(uint32_t);
+}
+
+/**
+ * serial_restore_uint64_t - Unpack an uint64_t from a binary blob
+ * @param[in]     s   uint64_t to write to
+ * @param[in]     d   Binary blob to read from
+ * @param[in,out] off Offset into the blob
+ */
+void serial_restore_uint64_t(uint64_t *s, const unsigned char *d, int *off)
+{
+  memcpy(s, d + *off, sizeof(uint64_t));
+  (*off) += sizeof(uint64_t);
 }
 
 /**

--- a/hcache/serialize.h
+++ b/hcache/serialize.h
@@ -47,6 +47,7 @@ unsigned char *serial_dump_char_size(const char *c, ssize_t size,    unsigned ch
 unsigned char *serial_dump_envelope (const struct Envelope *env,     unsigned char *d, int *off, bool convert);
 unsigned char *serial_dump_int      (const unsigned int i,           unsigned char *d, int *off);
 unsigned char *serial_dump_uint32_t (const uint32_t s,               unsigned char *d, int *off);
+unsigned char *serial_dump_uint64_t (const uint64_t s,               unsigned char *d, int *off);
 unsigned char *serial_dump_parameter(const struct ParameterList *pl, unsigned char *d, int *off, bool convert);
 unsigned char *serial_dump_stailq   (const struct ListHead *l,       unsigned char *d, int *off, bool convert);
 
@@ -58,6 +59,7 @@ void serial_restore_char     (char **c,                 const unsigned char *d, 
 void serial_restore_envelope (struct Envelope *env,     const unsigned char *d, int *off, bool convert);
 void serial_restore_int      (unsigned int *i,          const unsigned char *d, int *off);
 void serial_restore_uint32_t (uint32_t *s,              const unsigned char *d, int *off);
+void serial_restore_uint64_t (uint64_t *s,              const unsigned char *d, int *off);
 void serial_restore_parameter(struct ParameterList *pl, const unsigned char *d, int *off, bool convert);
 void serial_restore_stailq   (struct ListHead *l,       const unsigned char *d, int *off, bool convert);
 


### PR DESCRIPTION
**tl;dr** -- Save **352 bytes** per record in the header cache.

Mutt's header cache stores an entire `struct Email` and `struct Body` into the backend Store for every Email.
While this is efficient, it wastes a lot of space.

Back in #1870 (the PR, not the year :-) I worked out how little we actually needed to save.
This PR implements the idea.

**Note**: `hcache/hcachever.sh` has been updated because I've changed the on-disk format of the cache, but the structs haven't changed.

---

Here are the `struct Email` members that we want to save:
https://github.com/neomutt/neomutt/blob/14d6d0607e4b9c6c901eeac9425bde872e7c4e37/email/email.h#L38-L60

To save space, I've packed the `security` and other flags into one `uint32_t` and the timezone info into another.
There are some helper functions to do the (un)packing.

**Saving**: 188 bytes per record

---

Here are the `struct Body` members that we want to save:
https://github.com/neomutt/neomutt/blob/14d6d0607e4b9c6c901eeac9425bde872e7c4e37/email/body.h#L37-L62

To save space, I've packed the content type and flags into a `uint32_t`.
There are some helper functions to do the (un)packing.

**Saving**: 164 bytes per record

---

To store the `time_t` and `LOFF_T`, I created:

- `serial_dump_uint64_t()`
- `serial_restore_uint64_t()`

The (un)packing functions:

- `email_pack_flags()`
- `email_unpack_flags()`
- `email_pack_timezone()`
- `email_unpack_timezone()`
- `body_pack_flags()`
- `body_unpack_flags()`

Though not integrated, I have a test rig that exhaustively tested packing and unpacking **every possible combination of flags**.
- https://github.com/neomutt/test-rigs#header-cache-packing