### PR TITLE
convert MxOps path_is_empty() to take a Buffer

### DIFF
--- a/core/mxapi.h
+++ b/core/mxapi.h
@@ -389,7 +389,7 @@ struct MxOps
    *
    * @pre path is not NULL and not empty
    */
-  int (*path_is_empty)     (const char *path);
+  int (*path_is_empty)     (struct Buffer *path);
 };
 
 #endif /* MUTT_CORE_MXAPI_H */

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -2395,9 +2395,9 @@ static int imap_path_parent(char *buf, size_t buflen)
 /**
  * imap_path_is_empty - Is the mailbox empty - Implements MxOps::path_is_empty() - @ingroup mx_path_is_empty
  */
-static int imap_path_is_empty(const char *path)
+static int imap_path_is_empty(struct Buffer *path)
 {
-  int rc = imap_path_status(path, false);
+  int rc = imap_path_status(buf_string(path), false);
   if (rc < 0)
     return -1;
   if (rc == 0)

--- a/maildir/lib.h
+++ b/maildir/lib.h
@@ -44,13 +44,14 @@
 #include <stdio.h>
 #include "core/lib.h"
 
+struct Buffer;
 struct Email;
 struct HeaderCache;
 
 extern const struct MxOps MxMaildirOps;
 extern const struct MxOps MxMhOps;
 
-int           maildir_check_empty      (const char *path);
+int           maildir_check_empty      (struct Buffer *path);
 struct Email *maildir_email_new        (void);
 void          maildir_gen_flags        (char *dest, size_t destlen, struct Email *e);
 bool          maildir_msg_open_new     (struct Mailbox *m, struct Message *msg, const struct Email *e);
@@ -60,7 +61,7 @@ bool          maildir_parse_message    (enum MailboxType type, const char *fname
 bool          maildir_parse_stream     (enum MailboxType type, FILE *fp, const char *fname, bool is_old, struct Email *e);
 bool          maildir_sync_mailbox_message(struct Mailbox *m, struct Email *e, struct HeaderCache *hc);
 bool          maildir_update_flags     (struct Mailbox *m, struct Email *e_old, struct Email *e_new);
-int           mh_check_empty           (const char *path);
+int           mh_check_empty           (struct Buffer *path);
 int           mh_sync_mailbox_message  (struct Mailbox *m, struct Email *e, struct HeaderCache *hc);
 
 #endif /* MUTT_MAILDIR_LIB_H */

--- a/maildir/maildir.c
+++ b/maildir/maildir.c
@@ -1059,7 +1059,7 @@ cleanup:
  * @retval 0 Mailbox contains mail
  * @retval -1 Error
  */
-int maildir_check_empty(const char *path)
+int maildir_check_empty(struct Buffer *path)
 {
   DIR *dir = NULL;
   struct dirent *de = NULL;
@@ -1073,7 +1073,8 @@ int maildir_check_empty(const char *path)
   {
     /* we do "cur" on the first iteration since it's more likely that we'll
      * find old messages without having to scan both subdirs */
-    snprintf(realpath, sizeof(realpath), "%s/%s", path, (iter == 0) ? "cur" : "new");
+    snprintf(realpath, sizeof(realpath), "%s/%s", buf_string(path),
+             (iter == 0) ? "cur" : "new");
     dir = mutt_file_opendir(realpath, MUTT_OPENDIR_CREATE);
     if (!dir)
       return -1;

--- a/maildir/mh.c
+++ b/maildir/mh.c
@@ -163,12 +163,12 @@ static bool mh_valid_message(const char *s)
  * @retval 0 Mailbox contains mail
  * @retval -1 Error
  */
-int mh_check_empty(const char *path)
+int mh_check_empty(struct Buffer *path)
 {
   struct dirent *de = NULL;
   int rc = 1; /* assume empty until we find a message */
 
-  DIR *dir = mutt_file_opendir(path, MUTT_OPENDIR_NONE);
+  DIR *dir = mutt_file_opendir(buf_string(path), MUTT_OPENDIR_NONE);
   if (!dir)
     return -1;
   while ((de = readdir(dir)))

--- a/main.c
+++ b/main.c
@@ -1324,7 +1324,7 @@ main
     if (flags & MUTT_CLI_IGNORE)
     {
       /* check to see if there are any messages in the folder */
-      switch (mx_path_is_empty(buf_string(&folder)))
+      switch (mx_path_is_empty(&folder))
       {
         case -1:
           mutt_perror("%s", buf_string(&folder));

--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -1651,9 +1651,9 @@ static int mbox_path_parent(char *buf, size_t buflen)
 /**
  * mbox_path_is_empty - Is the mailbox empty - Implements MxOps::path_is_empty() - @ingroup mx_path_is_empty
  */
-static int mbox_path_is_empty(const char *path)
+static int mbox_path_is_empty(struct Buffer *path)
 {
-  return mutt_file_check_empty(path);
+  return mutt_file_check_empty(buf_string(path));
 }
 
 /**

--- a/mx.c
+++ b/mx.c
@@ -1275,12 +1275,12 @@ void mx_alloc_memory(struct Mailbox *m, int req_size)
  * @retval 0 Mailbox contains mail
  * @retval -1 Error
  */
-int mx_path_is_empty(const char *path)
+int mx_path_is_empty(struct Buffer *path)
 {
-  if (!path || (*path == '\0'))
+  if (buf_is_empty(path))
     return -1;
 
-  enum MailboxType type = mx_path_probe(path);
+  enum MailboxType type = mx_path_probe(buf_string(path));
   const struct MxOps *ops = mx_get_ops(type);
   if (!ops || !ops->path_is_empty)
     return -1;

--- a/mx.h
+++ b/mx.h
@@ -73,7 +73,7 @@ int             mx_ac_remove   (struct Mailbox *m, bool keep_account);
 
 int                 mx_access           (const char *path, int flags);
 void                mx_alloc_memory     (struct Mailbox *m, int req_size);
-int                 mx_path_is_empty    (const char *path);
+int                 mx_path_is_empty    (struct Buffer *path);
 void                mx_fastclose_mailbox(struct Mailbox *m, bool keep_account);
 const struct MxOps *mx_get_ops          (enum MailboxType type);
 bool                mx_tags_is_supported(struct Mailbox *m);


### PR DESCRIPTION
Convert MxOps path_is_empty() to take a Buffer. Based on the discussion here: https://github.com/neomutt/neomutt/discussions/3902.