### PR TITLE
 convert MxOps path_parent() to take a Buffer

### DIFF
--- a/compmbox/compress.c
+++ b/compmbox/compress.c
@@ -931,20 +931,14 @@ static int comp_path_pretty(struct Buffer *buf, const char *folder)
  */
 static int comp_path_parent(struct Buffer *path)
 {
-  if (mutt_path_parent(path->data))
-  {
-    buf_fix_dptr(path);
+  if (mutt_path_parent(path))
     return 0;
-  }
 
   if (buf_at(path, 0) == '~')
     mutt_path_canon(path->data, path->dsize, HomeDir, false);
 
-  if (mutt_path_parent(path->data))
-  {
-    buf_fix_dptr(path);
+  if (mutt_path_parent(path))
     return 0;
-  }
 
   return -1;
 }

--- a/compmbox/compress.c
+++ b/compmbox/compress.c
@@ -929,16 +929,22 @@ static int comp_path_pretty(struct Buffer *buf, const char *folder)
 /**
  * comp_path_parent - Find the parent of a Mailbox path - Implements MxOps::path_parent() - @ingroup mx_path_parent
  */
-static int comp_path_parent(char *buf, size_t buflen)
+static int comp_path_parent(struct Buffer *path)
 {
-  if (mutt_path_parent(buf))
+  if (mutt_path_parent(path->data))
+  {
+    buf_fix_dptr(path);
     return 0;
+  }
 
-  if (buf[0] == '~')
-    mutt_path_canon(buf, buflen, HomeDir, false);
+  if (buf_at(path, 0) == '~')
+    mutt_path_canon(path->data, path->dsize, HomeDir, false);
 
-  if (mutt_path_parent(buf))
+  if (mutt_path_parent(path->data))
+  {
+    buf_fix_dptr(path);
     return 0;
+  }
 
   return -1;
 }

--- a/core/mxapi.h
+++ b/core/mxapi.h
@@ -27,7 +27,6 @@
 #include "config.h"
 #include <stdbool.h>
 #include <stdint.h>
-#include <stdio.h>
 #include "mailbox.h"
 
 struct Account;
@@ -368,14 +367,13 @@ struct MxOps
    * @ingroup mx_api
    *
    * path_parent - Find the parent of a Mailbox path
-   * @param buf    Path to modify
-   * @param buflen Length of buffer
+   * @param path   Path to modify
    * @retval  0 Success
    * @retval -1 Failure
    *
    * @pre buf is not NULL
    */
-  int (*path_parent)     (char *buf, size_t buflen);
+  int (*path_parent)     (struct Buffer *path);
 
   /**
    * @defgroup mx_path_is_empty path_is_empty()

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -2383,12 +2383,12 @@ static int imap_path_pretty(struct Buffer *buf, const char *folder)
 /**
  * imap_path_parent - Find the parent of a Mailbox path - Implements MxOps::path_parent() - @ingroup mx_path_parent
  */
-static int imap_path_parent(char *buf, size_t buflen)
+static int imap_path_parent(struct Buffer *path)
 {
   char tmp[PATH_MAX] = { 0 };
 
-  imap_get_parent_path(buf, tmp, sizeof(tmp));
-  mutt_str_copy(buf, tmp, buflen);
+  imap_get_parent_path(buf_string(path), tmp, sizeof(tmp));
+  buf_strcpy(path, tmp);
   return 0;
 }
 

--- a/maildir/maildir.c
+++ b/maildir/maildir.c
@@ -1624,20 +1624,14 @@ static int maildir_path_canon(struct Buffer *buf)
  */
 static int maildir_path_parent(struct Buffer *path)
 {
-  if (mutt_path_parent(path->data))
-  {
-    buf_fix_dptr(path);
+  if (mutt_path_parent(path))
     return 0;
-  }
 
   if (buf_at(path, 0) == '~')
     mutt_path_canon(path->data, path->dsize, HomeDir, true);
 
-  if (mutt_path_parent(path->data))
-  {
-    buf_fix_dptr(path);
+  if (mutt_path_parent(path))
     return 0;
-  }
 
   return -1;
 }

--- a/maildir/maildir.c
+++ b/maildir/maildir.c
@@ -1622,16 +1622,22 @@ static int maildir_path_canon(struct Buffer *buf)
 /**
  * maildir_path_parent - Find the parent of a Mailbox path - Implements MxOps::path_parent() - @ingroup mx_path_parent
  */
-static int maildir_path_parent(char *buf, size_t buflen)
+static int maildir_path_parent(struct Buffer *path)
 {
-  if (mutt_path_parent(buf))
+  if (mutt_path_parent(path->data))
+  {
+    buf_fix_dptr(path);
     return 0;
+  }
 
-  if (buf[0] == '~')
-    mutt_path_canon(buf, buflen, HomeDir, true);
+  if (buf_at(path, 0) == '~')
+    mutt_path_canon(path->data, path->dsize, HomeDir, true);
 
-  if (mutt_path_parent(buf))
+  if (mutt_path_parent(path->data))
+  {
+    buf_fix_dptr(path);
     return 0;
+  }
 
   return -1;
 }

--- a/maildir/mh.c
+++ b/maildir/mh.c
@@ -1175,20 +1175,14 @@ static int mh_path_canon(struct Buffer *buf)
  */
 static int mh_path_parent(struct Buffer *path)
 {
-  if (mutt_path_parent(path->data))
-  {
-    buf_fix_dptr(path);
+  if (mutt_path_parent(path))
     return 0;
-  }
 
   if (buf_at(path, 0) == '~')
     mutt_path_canon(path->data, path->dsize, HomeDir, true);
 
-  if (mutt_path_parent(path->data))
-  {
-    buf_fix_dptr(path);
+  if (mutt_path_parent(path))
     return 0;
-  }
 
   return -1;
 }

--- a/maildir/mh.c
+++ b/maildir/mh.c
@@ -1173,16 +1173,22 @@ static int mh_path_canon(struct Buffer *buf)
 /**
  * mh_path_parent - Find the parent of a Mailbox path - Implements MxOps::path_parent() - @ingroup mx_path_parent
  */
-static int mh_path_parent(char *buf, size_t buflen)
+static int mh_path_parent(struct Buffer *path)
 {
-  if (mutt_path_parent(buf))
+  if (mutt_path_parent(path->data))
+  {
+    buf_fix_dptr(path);
     return 0;
+  }
 
-  if (buf[0] == '~')
-    mutt_path_canon(buf, buflen, HomeDir, true);
+  if (buf_at(path, 0) == '~')
+    mutt_path_canon(path->data, path->dsize, HomeDir, true);
 
-  if (mutt_path_parent(buf))
+  if (mutt_path_parent(path->data))
+  {
+    buf_fix_dptr(path);
     return 0;
+  }
 
   return -1;
 }

--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -1636,20 +1636,14 @@ static int mbox_path_pretty(struct Buffer *buf, const char *folder)
  */
 static int mbox_path_parent(struct Buffer *path)
 {
-  if (mutt_path_parent(path->data))
-  {
-    buf_fix_dptr(path);
+  if (mutt_path_parent(path))
     return 0;
-  }
 
   if (buf_at(path, 0) == '~')
     mutt_path_canon(path->data, path->dsize, HomeDir, false);
 
-  if (mutt_path_parent(path->data))
-  {
-    buf_fix_dptr(path);
+  if (mutt_path_parent(path))
     return 0;
-  }
 
   return -1;
 }

--- a/mbox/mbox.c
+++ b/mbox/mbox.c
@@ -1634,16 +1634,22 @@ static int mbox_path_pretty(struct Buffer *buf, const char *folder)
 /**
  * mbox_path_parent - Find the parent of a Mailbox path - Implements MxOps::path_parent() - @ingroup mx_path_parent
  */
-static int mbox_path_parent(char *buf, size_t buflen)
+static int mbox_path_parent(struct Buffer *path)
 {
-  if (mutt_path_parent(buf))
+  if (mutt_path_parent(path->data))
+  {
+    buf_fix_dptr(path);
     return 0;
+  }
 
-  if (buf[0] == '~')
-    mutt_path_canon(buf, buflen, HomeDir, false);
+  if (buf_at(path, 0) == '~')
+    mutt_path_canon(path->data, path->dsize, HomeDir, false);
 
-  if (mutt_path_parent(buf))
+  if (mutt_path_parent(path->data))
+  {
+    buf_fix_dptr(path);
     return 0;
+  }
 
   return -1;
 }

--- a/mutt/path.c
+++ b/mutt/path.c
@@ -452,29 +452,30 @@ size_t mutt_path_realpath(char *buf)
 
 /**
  * mutt_path_parent - Find the parent of a path
- * @param buf    Buffer for the result
+ * @param  path  Buffer for the result
  * @retval true  Success
  */
-bool mutt_path_parent(char *buf)
+bool mutt_path_parent(struct Buffer *path)
 {
-  if (!buf)
+  if (buf_is_empty(path))
     return false;
 
-  int n = mutt_str_len(buf);
+  int n = buf_len(path);
   if (n < 2)
     return false;
 
-  if (buf[n - 1] == '/')
+  if (buf_at(path, n - 1) == '/')
     n--;
 
   // Find the previous '/'
-  for (n--; ((n >= 0) && (buf[n] != '/')); n--)
+  for (n--; ((n >= 0) && (buf_at(path, n) != '/')); n--)
     ; // do nothing
 
   if (n == 0) // Always keep at least one '/'
     n++;
 
-  buf[n] = '\0';
+  path->data[n] = '\0';
+  buf_fix_dptr(path);
   return true;
 }
 

--- a/mutt/path.h
+++ b/mutt/path.h
@@ -35,7 +35,7 @@ char *      mutt_path_concat(char *d, const char *dir, const char *fname, size_t
 char *      mutt_path_dirname(const char *path);
 char *      mutt_path_escape(const char *src);
 const char *mutt_path_getcwd(struct Buffer *cwd);
-bool        mutt_path_parent(char *buf);
+bool        mutt_path_parent(struct Buffer *path);
 bool        mutt_path_pretty(char *buf, size_t buflen, const char *homedir, bool is_dir);
 size_t      mutt_path_realpath(char *buf);
 bool        mutt_path_tidy(char *buf, bool is_dir);

--- a/mx.c
+++ b/mx.c
@@ -33,6 +33,7 @@
 #include <errno.h>
 #include <locale.h>
 #include <stdbool.h>
+#include <stdio.h>
 #include <string.h>
 #include <sys/stat.h>
 #include <time.h>
@@ -1550,9 +1551,9 @@ int mx_path_pretty(struct Buffer *buf, const char *folder)
 /**
  * mx_path_parent - Find the parent of a mailbox path - Wrapper for MxOps::path_parent()
  */
-int mx_path_parent(const char *buf, size_t buflen)
+int mx_path_parent(struct Buffer *buf)
 {
-  if (!buf)
+  if (buf_is_empty(buf))
     return -1;
 
   return 0;

--- a/mx.h
+++ b/mx.h
@@ -27,7 +27,6 @@
 
 #include <stdbool.h>
 #include <stdint.h>
-#include <stdio.h>
 #include "config/lib.h"
 #include "core/lib.h"
 
@@ -55,7 +54,7 @@ int             mx_msg_padding_size(struct Mailbox *m);
 int             mx_save_hcache     (struct Mailbox *m, struct Email *e);
 int             mx_path_canon      (struct Buffer *buf, const char *folder, enum MailboxType *type);
 int             mx_path_canon2     (struct Mailbox *m, const char *folder);
-int             mx_path_parent     (const char *buf, size_t buflen);
+int             mx_path_parent     (struct Buffer *buf);
 int             mx_path_pretty     (struct Buffer *buf, const char *folder);
 enum MailboxType mx_path_probe     (const char *path);
 struct Mailbox *mx_path_resolve    (const char *path);

--- a/nntp/nntp.c
+++ b/nntp/nntp.c
@@ -2763,7 +2763,7 @@ static int nntp_path_pretty(struct Buffer *buf, const char *folder)
 /**
  * nntp_path_parent - Find the parent of a Mailbox path - Implements MxOps::path_parent() - @ingroup mx_path_parent
  */
-static int nntp_path_parent(char *buf, size_t buflen)
+static int nntp_path_parent(struct Buffer *path)
 {
   /* Succeed, but don't do anything, for now */
   return 0;

--- a/notmuch/notmuch.c
+++ b/notmuch/notmuch.c
@@ -2469,7 +2469,7 @@ static int nm_path_pretty(struct Buffer *buf, const char *folder)
 /**
  * nm_path_parent - Find the parent of a Mailbox path - Implements MxOps::path_parent() - @ingroup mx_path_parent
  */
-static int nm_path_parent(char *buf, size_t buflen)
+static int nm_path_parent(struct Buffer *path)
 {
   /* Succeed, but don't do anything, for now */
   return 0;

--- a/pop/pop.c
+++ b/pop/pop.c
@@ -1182,7 +1182,7 @@ static int pop_path_pretty(struct Buffer *buf, const char *folder)
 /**
  * pop_path_parent - Find the parent of a Mailbox path - Implements MxOps::path_parent() - @ingroup mx_path_parent
  */
-static int pop_path_parent(char *buf, size_t buflen)
+static int pop_path_parent(struct Buffer *path)
 {
   /* Succeed, but don't do anything, for now */
   return 0;


### PR DESCRIPTION
Convert MxOps path_parent() to take a Buffer. Based on the discussion here: #3902.