### PR TITLE
build: reinstate -O2 and -O0

### DIFF
--- a/auto.def
+++ b/auto.def
@@ -1023,26 +1023,31 @@ if {[get-define want-debug-backtrace]} {
     user-error "Unable to find libunwind"
   }
   define LIBS "-lunwind-generic [get-define LIBS]"
+  define debug_build 1
 }
 
 # Color dump
 if {[get-define want-debug-color]} {
   define USE_DEBUG_COLOR 1
+  define debug_build 1
 }
 
 # Email dump
 if {[get-define want-debug-email]} {
   define USE_DEBUG_EMAIL 1
+  define debug_build 1
 }
 
 # Graphviz dump
 if {[get-define want-debug-graphviz]} {
   define USE_DEBUG_GRAPHVIZ 1
+  define debug_build 1
 }
 
 # Notifications dump
 if {[get-define want-debug-notify]} {
   define USE_DEBUG_NOTIFY 1
+  define debug_build 1
 }
 
 # TAILQ debugging
@@ -1051,11 +1056,13 @@ if {[get-define want-debug-queue]} {
   define QUEUE_MACRO_DEBUG_TRACE
   # Invalidated pointers will be set to 0xffffffffffffffff
   define QUEUE_MACRO_DEBUG_TRASH
+  define debug_build 1
 }
 
 # Windows dump
 if {[get-define want-debug-window]} {
   define USE_DEBUG_WINDOW 1
+  define debug_build 1
 }
 
 ###############################################################################
@@ -1066,9 +1073,10 @@ if {[get-define want-asan]} {
     user-error "Unable to compile with -fsanitize=address"
   }
   msg-result "yes"
-  define-append CFLAGS -fsanitize=address -O0 -fno-omit-frame-pointer -fno-common
+  define-append CFLAGS -fsanitize=address -fno-omit-frame-pointer -fno-common
   define-append LDFLAGS -fsanitize=address
   define USE_ASAN
+  define debug_build 1
 }
 
 ###############################################################################
@@ -1079,9 +1087,10 @@ if {[get-define want-ubsan]} {
     user-error "Unable to compile with -fsanitize=undefined"
   }
   msg-result "yes"
-  define-append CFLAGS -fsanitize=undefined -O0 -fno-omit-frame-pointer -fno-common
+  define-append CFLAGS -fsanitize=undefined -fno-omit-frame-pointer -fno-common
   define-append LDFLAGS -fsanitize=undefined
   define USE_UBSAN
+  define debug_build 1
 }
 
 ###############################################################################
@@ -1111,6 +1120,14 @@ if {[get-define want-coverage]} {
   define ENABLE_COVERAGE
   define-append CFLAGS -fprofile-arcs -ftest-coverage
   define-append LDFLAGS -fprofile-arcs -ftest-coverage
+}
+
+###############################################################################
+# Debug or Release build?
+if {[get-define debug_build]} {
+  define-append CFLAGS -g -O0
+} else {
+  define-append CFLAGS -O2
 }
 
 ###############################################################################


### PR DESCRIPTION
Build with **`-g -O0`** if debug options are enabled, **`-O2`** otherwise.

Nearly a year ago, upstream Autosetup made [this change](https://github.com/msteveb/autosetup/commit/ef0915f8a56cc7bf0789abb2acf2a004c593e428), arguing that it wasn't their place to be setting `CFLAGS`.

```diff
-foreach i {LDFLAGS LIBS CPPFLAGS LINKFLAGS {CFLAGS "-g -O2"}} {
+foreach i {LDFLAGS LIBS CPPFLAGS LINKFLAGS CFLAGS} {
```

A few months later we adopted the change, 8b31f42532027d435cfcaf308046eabaecdfe7c0.
Since then, builds haven't included **`-O2`** by default.

This PR adds a local variable (`debug_build`) to `auto.def`.

If any of the debug configure options are given, then build with **`-g -O0`**, otherwise build with **`-O2`**
(`--debug-{backtrace,color,email,graphviz,notify,queue,window}`)