### PR TITLE
editor: Small Improvements

### DIFF
--- a/enter/functions.c
+++ b/enter/functions.c
@@ -672,6 +672,18 @@ static int op_editor_transpose_chars(struct EnterWindowData *wdata, int op)
   return editor_transpose_chars(wdata->state);
 }
 
+/**
+ * op_redraw - Redraw the screen - Implements ::enter_function_t - @ingroup enter_function_api
+ */
+static int op_redraw(struct EnterWindowData *wdata, int op)
+{
+  clearok(stdscr, true);
+  mutt_resize_screen();
+  window_invalidate_all();
+  window_redraw(NULL);
+  return FR_SUCCESS;
+}
+
 // -----------------------------------------------------------------------------
 
 /**
@@ -703,6 +715,7 @@ static const struct EnterFunction EnterFunctions[] = {
   { OP_EDITOR_QUOTE_CHAR,         op_editor_quote_char },
   { OP_EDITOR_TRANSPOSE_CHARS,    op_editor_transpose_chars },
   { OP_EDITOR_UPCASE_WORD,        op_editor_capitalize_word },
+  { OP_REDRAW,                    op_redraw },
   { 0, NULL },
   // clang-format on
 };

--- a/enter/functions.c
+++ b/enter/functions.c
@@ -46,6 +46,7 @@
 #include "mutt_mailbox.h"
 #include "muttlib.h"
 #include "opcodes.h"
+#include "protos.h"
 #include "state.h" // IWYU pragma: keep
 #include "wdata.h"
 
@@ -673,6 +674,15 @@ static int op_editor_transpose_chars(struct EnterWindowData *wdata, int op)
 }
 
 /**
+ * op_help - Display Help - Implements ::enter_function_t - @ingroup enter_function_api
+ */
+static int op_help(struct EnterWindowData *wdata, int op)
+{
+  mutt_help(MENU_EDITOR);
+  return FR_SUCCESS;
+}
+
+/**
  * op_redraw - Redraw the screen - Implements ::enter_function_t - @ingroup enter_function_api
  */
 static int op_redraw(struct EnterWindowData *wdata, int op)
@@ -715,6 +725,7 @@ static const struct EnterFunction EnterFunctions[] = {
   { OP_EDITOR_QUOTE_CHAR,         op_editor_quote_char },
   { OP_EDITOR_TRANSPOSE_CHARS,    op_editor_transpose_chars },
   { OP_EDITOR_UPCASE_WORD,        op_editor_capitalize_word },
+  { OP_HELP,                      op_help },
   { OP_REDRAW,                    op_redraw },
   { 0, NULL },
   // clang-format on

--- a/functions.c
+++ b/functions.c
@@ -274,6 +274,7 @@ const struct MenuFuncOp OpEditor[] = { /* map: editor */
   { "kill-word",                     OP_EDITOR_KILL_WORD },
   { "mailbox-cycle",                 OP_EDITOR_MAILBOX_CYCLE },
   { "quote-char",                    OP_EDITOR_QUOTE_CHAR },
+  { "redraw-screen",                 OP_REDRAW },
   { "transpose-chars",               OP_EDITOR_TRANSPOSE_CHARS },
   { "upcase-word",                   OP_EDITOR_UPCASE_WORD },
   // Deprecated
@@ -935,6 +936,7 @@ const struct MenuOpSeq EditorDefaultBindings[] = { /* map: editor */
   { OP_EDITOR_MAILBOX_CYCLE,               " " },              // <Space>
   { OP_EDITOR_QUOTE_CHAR,                  "\026" },           // <Ctrl-V>
   { OP_EDITOR_UPCASE_WORD,                 "\033u" },          // <Alt-u>
+  { OP_REDRAW,                             "\014" },           // <Ctrl-L>
   { 0, NULL },
 };
 

--- a/functions.c
+++ b/functions.c
@@ -264,6 +264,7 @@ const struct MenuFuncOp OpEditor[] = { /* map: editor */
   { "eol",                           OP_EDITOR_EOL },
   { "forward-char",                  OP_EDITOR_FORWARD_CHAR },
   { "forward-word",                  OP_EDITOR_FORWARD_WORD },
+  { "help",                          OP_HELP },
   { "history-down",                  OP_EDITOR_HISTORY_DOWN },
   { "history-search",                OP_EDITOR_HISTORY_SEARCH },
   { "history-up",                    OP_EDITOR_HISTORY_UP },
@@ -936,6 +937,7 @@ const struct MenuOpSeq EditorDefaultBindings[] = { /* map: editor */
   { OP_EDITOR_MAILBOX_CYCLE,               " " },              // <Space>
   { OP_EDITOR_QUOTE_CHAR,                  "\026" },           // <Ctrl-V>
   { OP_EDITOR_UPCASE_WORD,                 "\033u" },          // <Alt-u>
+  { OP_HELP,                               "\033?" },          // <Alt-?>
   { OP_REDRAW,                             "\014" },           // <Ctrl-L>
   { 0, NULL },
 };

--- a/functions.c
+++ b/functions.c
@@ -262,7 +262,6 @@ const struct MenuFuncOp OpEditor[] = { /* map: editor */
   { "delete-char",                   OP_EDITOR_DELETE_CHAR },
   { "downcase-word",                 OP_EDITOR_DOWNCASE_WORD },
   { "eol",                           OP_EDITOR_EOL },
-  { "exit",                          OP_EXIT },
   { "forward-char",                  OP_EDITOR_FORWARD_CHAR },
   { "forward-word",                  OP_EDITOR_FORWARD_WORD },
   { "history-down",                  OP_EDITOR_HISTORY_DOWN },


### PR DESCRIPTION
- 8dafdf7a5 editor: drop `<exit>` function
  Added accidentally during a refactoring.

- 2b08fab83 editor: add `<redraw-screen>` function
  Bound to <kbd>\<Ctrl-L\></kbd>

- 04d0ea54d editor: add `<help>` function
  Bound to <kbd>\<Alt-?\></kbd>

To test the help:
- Start NeoMutt
- Type `:echo hello`
- Hit <kbd>\<Alt-?\></kbd>
- <kbd>q</kbd> to quit
