### PR TITLE
test: fix path_tilde(root)

### DIFF
--- a/test/path/mutt_path_tilde.c
+++ b/test/path/mutt_path_tilde.c
@@ -23,6 +23,8 @@
 #define TEST_NO_MAIN
 #include "config.h"
 #include "acutest.h"
+#include <pwd.h>
+#include <sys/types.h>
 #include "mutt/lib.h"
 #include "test_common.h"
 
@@ -72,9 +74,18 @@ void test_mutt_path_tilde(void)
   // test user expansion
 
   {
+    struct passwd *pw = getpwnam("root");
+    TEST_CHECK(pw != NULL);
+    TEST_CHECK(pw->pw_dir != NULL);
+
+    struct Buffer *expected = buf_new(NULL);
+    buf_printf(expected, "%s/orange", pw->pw_dir);
+
     struct Buffer *path = buf_new("~root/orange");
     TEST_CHECK(mutt_path_tilde(path, NULL));
-    TEST_CHECK_STR_EQ(buf_string(path), "/root/orange");
+    TEST_CHECK_STR_EQ(buf_string(path), buf_string(expected));
+
+    buf_free(&expected);
     buf_free(&path);
   }
 


### PR DESCRIPTION
Fix the test for `mutt_path_tilde()` where I assumed `root`s home would be in `/root`