### PR TITLE
Alternating colors in help

### DIFF
--- a/color/color.h
+++ b/color/color.h
@@ -73,6 +73,8 @@ enum ColorId
 #endif
   MT_COLOR_SIGNATURE,                ///< Pager: signature lines
   MT_COLOR_STATUS,                   ///< Status bar (takes a pattern)
+  MT_COLOR_STRIPE_EVEN,              ///< Stripes: even lines of the Help Page
+  MT_COLOR_STRIPE_ODD,               ///< Stripes: odd lines of the Help Page
   MT_COLOR_TILDE,                    ///< Pager: empty lines after message
   MT_COLOR_TREE,                     ///< Index: tree-drawing characters
   MT_COLOR_UNDERLINE,                ///< Underlined text

--- a/color/command.c
+++ b/color/command.c
@@ -93,6 +93,8 @@ const struct Mapping ColorFields[] = {
 #endif
   { "signature",         MT_COLOR_SIGNATURE },
   { "status",            MT_COLOR_STATUS },
+  { "stripe_even",       MT_COLOR_STRIPE_EVEN},
+  { "stripe_odd",        MT_COLOR_STRIPE_ODD},
   { "tilde",             MT_COLOR_TILDE },
   { "tree",              MT_COLOR_TREE },
   { "underline",         MT_COLOR_UNDERLINE },

--- a/color/simple.c
+++ b/color/simple.c
@@ -50,6 +50,7 @@ void simple_colors_init(void)
   SimpleColors[MT_COLOR_SIDEBAR_HIGHLIGHT].attrs = A_UNDERLINE;
 #endif
   SimpleColors[MT_COLOR_STATUS].attrs = A_REVERSE;
+  SimpleColors[MT_COLOR_STRIPE_EVEN].attrs = A_BOLD;
 }
 
 /**

--- a/docs/neomuttrc.man.head
+++ b/docs/neomuttrc.man.head
@@ -295,6 +295,8 @@ currently defined \fIobject\fPs are:
 .BR search ", "
 .BR signature ", "
 .BR status ", "
+.BR stripe_even ", "
+.BR stripe_odd ","
 .BR tilde ", "
 .BR tree ", "
 .BR underline "."

--- a/help.c
+++ b/help.c
@@ -479,7 +479,8 @@ void mutt_help(enum MenuType menu)
   struct PagerView pview = { &pdata };
 
   pview.mode = PAGER_MODE_HELP;
-  pview.flags = MUTT_PAGER_RETWINCH | MUTT_PAGER_MARKER | MUTT_PAGER_NSKIP | MUTT_PAGER_NOWRAP;
+  pview.flags = MUTT_PAGER_RETWINCH | MUTT_PAGER_MARKER | MUTT_PAGER_NSKIP |
+                MUTT_PAGER_NOWRAP | MUTT_PAGER_STRIPES;
 
   do
   {

--- a/pager/display.c
+++ b/pager/display.c
@@ -1238,6 +1238,22 @@ int display_line(FILE *fp, LOFF_T *bytes_read, struct Line **lines,
     goto out;
   }
 
+  if (flags & MUTT_PAGER_STRIPES)
+  {
+    const enum ColorId cid = ((line_num % 2) == 0) ? MT_COLOR_STRIPE_ODD : MT_COLOR_STRIPE_EVEN;
+    struct AttrColor *attr_color = mutt_curses_set_color_by_id(cid);
+
+    memset(&ansi, 0, sizeof(struct AnsiColor));
+    ansi.attr_color = attr_color;
+    ansi.attrs = attr_color->attrs;
+
+    if (attr_color->curses_color)
+    {
+      ansi.fg = attr_color->curses_color->fg;
+      ansi.bg = attr_color->curses_color->bg;
+    }
+  }
+
   /* display the line */
   format_line(win_pager, lines, line_num, buf, flags, &ansi, cnt, &ch, &vch,
               &col, &special, win_pager->state.cols, ansi_list);
@@ -1245,7 +1261,16 @@ int display_line(FILE *fp, LOFF_T *bytes_read, struct Line **lines,
   /* avoid a bug in ncurses... */
   if (col == 0)
   {
-    mutt_curses_set_color_by_id(MT_COLOR_NORMAL);
+    if (flags & MUTT_PAGER_STRIPES)
+    {
+      const enum ColorId cid = ((line_num % 2) == 0) ? MT_COLOR_STRIPE_ODD : MT_COLOR_STRIPE_EVEN;
+      mutt_curses_set_color_by_id(cid);
+    }
+    else
+    {
+      mutt_curses_set_color_by_id(MT_COLOR_NORMAL);
+    }
+
     mutt_window_addch(win_pager, ' ');
   }
 

--- a/pager/lib.h
+++ b/pager/lib.h
@@ -72,6 +72,7 @@ typedef uint16_t PagerFlags;              ///< Flags for dlg_pager(), e.g. #MUTT
 #define MUTT_PAGER_NOWRAP     (1 << 9)    ///< Format for term width, ignore $wrap
 #define MUTT_PAGER_LOGS       (1 << 10)   ///< Logview mode
 #define MUTT_PAGER_BOTTOM     (1 << 11)   ///< Start at the bottom
+#define MUTT_PAGER_STRIPES    (1 << 12)   ///< Striped highlighting
 #define MUTT_PAGER_MESSAGE    (MUTT_SHOWCOLOR | MUTT_PAGER_MARKER)
 
 #define MUTT_DISPLAYFLAGS (MUTT_SHOW | MUTT_PAGER_NSKIP | MUTT_PAGER_MARKER | MUTT_PAGER_LOGS)

--- a/pager/pager.c
+++ b/pager/pager.c
@@ -170,11 +170,14 @@ static int pager_repaint(struct MuttWindow *win)
     }
     int i = -1;
     int j = -1;
+    const PagerFlags flags = priv->has_types | priv->search_flag |
+                             (priv->pview->flags & MUTT_PAGER_NOWRAP) |
+                             (priv->pview->flags & MUTT_PAGER_STRIPES);
+
     while (display_line(priv->fp, &priv->bytes_read, &priv->lines, ++i,
-                        &priv->lines_used, &priv->lines_max,
-                        priv->has_types | priv->search_flag | (priv->pview->flags & MUTT_PAGER_NOWRAP),
-                        &priv->quote_list, &priv->q_level, &priv->force_redraw,
-                        &priv->search_re, priv->pview->win_pager, &priv->ansi_list) == 0)
+                        &priv->lines_used, &priv->lines_max, flags, &priv->quote_list,
+                        &priv->q_level, &priv->force_redraw, &priv->search_re,
+                        priv->pview->win_pager, &priv->ansi_list) == 0)
     {
       if (!priv->lines[i].cont_line && (++j == priv->win_height))
       {
@@ -199,12 +202,15 @@ static int pager_repaint(struct MuttWindow *win)
       while ((priv->win_height < priv->pview->win_pager->state.rows) &&
              (priv->lines[priv->cur_line].offset <= priv->st.st_size - 1))
       {
-        if (display_line(priv->fp, &priv->bytes_read, &priv->lines,
-                         priv->cur_line, &priv->lines_used, &priv->lines_max,
-                         (priv->pview->flags & MUTT_DISPLAYFLAGS) | priv->hide_quoted |
-                             priv->search_flag | (priv->pview->flags & MUTT_PAGER_NOWRAP),
-                         &priv->quote_list, &priv->q_level, &priv->force_redraw,
-                         &priv->search_re, priv->pview->win_pager, &priv->ansi_list) > 0)
+        const PagerFlags flags = (priv->pview->flags & MUTT_DISPLAYFLAGS) |
+                                 priv->hide_quoted | priv->search_flag |
+                                 (priv->pview->flags & MUTT_PAGER_NOWRAP) |
+                                 (priv->pview->flags & MUTT_PAGER_STRIPES);
+
+        if (display_line(priv->fp, &priv->bytes_read, &priv->lines, priv->cur_line,
+                         &priv->lines_used, &priv->lines_max, flags, &priv->quote_list,
+                         &priv->q_level, &priv->force_redraw, &priv->search_re,
+                         priv->pview->win_pager, &priv->ansi_list) > 0)
         {
           priv->win_height++;
         }


### PR DESCRIPTION
This PR add alternating colors for the help menu.

![image](https://github.com/neomutt/neomutt/assets/2278303/0be4b866-d2c8-4d54-b286-1c75ca360231)

New config variables: `$help_alternate`
New colors: `pager_even`, `pager_odd`.

To enable this feature add this to `.muttrc`:
```bash
set help_alternate = yes
color pager_odd  blue cyan
color pager_even black white
```
