### PR TITLE
functions: move <show-version> to generic

### DIFF
--- a/functions.c
+++ b/functions.c
@@ -333,6 +333,7 @@ const struct MenuFuncOp OpGeneric[] = { /* map: generic */
   { "select-entry",                  OP_GENERIC_SELECT_ENTRY },
   { "shell-escape",                  OP_SHELL_ESCAPE },
   { "show-log-messages",             OP_SHOW_LOG_MESSAGES },
+  { "show-version",                  OP_VERSION },
   { "tag-entry",                     OP_TAG },
   { "tag-prefix",                    OP_TAG_PREFIX },
   { "tag-prefix-cond",               OP_TAG_PREFIX_COND },
@@ -466,7 +467,6 @@ const struct MenuFuncOp OpIndex[] = { /* map: index */
   { "save-message",                  OP_SAVE },
   { "set-flag",                      OP_MAIN_SET_FLAG },
   { "show-limit",                    OP_MAIN_SHOW_LIMIT },
-  { "show-version",                  OP_VERSION },
 #ifdef USE_SIDEBAR
   { "sidebar-first",                 OP_SIDEBAR_FIRST },
   { "sidebar-last",                  OP_SIDEBAR_LAST },
@@ -988,6 +988,7 @@ const struct MenuOpSeq GenericDefaultBindings[] = { /* map: generic */
   { OP_TAG,                                "t" },
   { OP_TAG_PREFIX,                         ";" },
   { OP_TOP_PAGE,                           "H" },
+  { OP_VERSION,                            "V" },
   { 0, NULL },
 };
 
@@ -1081,7 +1082,6 @@ const struct MenuOpSeq IndexDefaultBindings[] = { /* map: index */
   { OP_UNDELETE,                           "u" },
   { OP_UNDELETE_SUBTHREAD,                 "\033u" },          // <Alt-u>
   { OP_UNDELETE_THREAD,                    "\025" },           // <Ctrl-U>
-  { OP_VERSION,                            "V" },
   { OP_VIEW_ATTACHMENTS,                   "v" },
   { 0, NULL },
 };


### PR DESCRIPTION
All of NeoMutt functions are divided into blocks, e.g. [`OpAlias`](https://github.com/neomutt/neomutt/blob/5bbc865600107986f20066c2e4169ad1866c117d/functions.c#L55-L64).
Each of these blocks is handled by a function dispatcher, e.g. [`alias_function_dispatcher()`](https://github.com/neomutt/neomutt/blob/5bbc865600107986f20066c2e4169ad1866c117d/alias/functions.c#L332-L357).

Function `<show-version>` is implemented by the [`global_function_dispatcher()`](https://github.com/neomutt/neomutt/blob/5bbc865600107986f20066c2e4169ad1866c117d/gui/global.c#L165-L185), so it belongs in [`OpGeneric`](https://github.com/neomutt/neomutt/blob/5bbc865600107986f20066c2e4169ad1866c117d/functions.c#L289-L345).

This PR moves the function out of [`OpIndex`](https://github.com/neomutt/neomutt/blob/5bbc865600107986f20066c2e4169ad1866c117d/functions.c#L350-L509) .

**Update**: Just `OpIndex`;  `<show-version>` needs to stay in OpPager, for now, because the Pager doesn't use `OpGeneric`. 

----

See Also: [NeoMutt Keybindings](https://gist.github.com/flatcap/fc84519ad7361f6e093eadda039aa0eb)