### PR TITLE
separate dialogs from km_dokey_event()

### DIFF
--- a/conn/dlg_verifycert.c
+++ b/conn/dlg_verifycert.c
@@ -251,11 +251,7 @@ int dlg_verify_certificate(const char *title, struct CertArray *carr,
     // Try to catch dialog keys before ops
     if (menu_dialog_dokey(menu, &op) != 0)
     {
-      struct KeyEvent event = km_dokey_event(MENU_GENERIC);
-      if (event.ch == 'q')
-        op = OP_EXIT;
-      else
-        op = event.op;
+      op = km_dokey(MENU_DIALOG);
     }
 
     if (op == OP_TIMEOUT)
@@ -272,7 +268,7 @@ int dlg_verify_certificate(const char *title, struct CertArray *carr,
     switch (op)
     {
       case -1:         // Abort: Ctrl-G
-      case OP_EXIT:    // Q)uit
+      case OP_QUIT:    // Q)uit
       case OP_MAX + 1: // R)eject
         choice = 1;
         break;

--- a/functions.c
+++ b/functions.c
@@ -249,6 +249,14 @@ const struct MenuFuncOp OpCompose[] = { /* map: compose */
 };
 
 /**
+ * OpDialog - Functions for Simple Dialogs
+ */
+const struct MenuFuncOp OpDialog[] = {
+  { "exit",                          OP_EXIT },
+  { NULL, 0 },
+};
+
+/**
  * OpEditor - Functions for the Editor Menu
  */
 const struct MenuFuncOp OpEditor[] = { /* map: editor */
@@ -899,6 +907,14 @@ const struct MenuOpSeq ComposeDefaultBindings[] = { /* map: compose */
   { OP_ENVELOPE_EDIT_TO,                   "t" },
   { OP_FORGET_PASSPHRASE,                  "\006" },           // <Ctrl-F>
   { OP_TAG,                                "T" },
+  { 0, NULL },
+};
+
+/**
+ * DialogDefaultBindings - Key bindings for Simple Dialogs
+ */
+const struct MenuOpSeq DialogDefaultBindings[] = {
+  { OP_QUIT,                               "q" },
   { 0, NULL },
 };
 

--- a/functions.h
+++ b/functions.h
@@ -33,6 +33,7 @@ extern struct MenuFuncOp OpAutocrypt[];
 #endif
 extern struct MenuFuncOp OpBrowser[];
 extern struct MenuFuncOp OpCompose[];
+extern struct MenuFuncOp OpDialog[];
 extern struct MenuFuncOp OpEditor[];
 extern struct MenuFuncOp OpGeneric[];
 extern struct MenuFuncOp OpIndex[];
@@ -52,6 +53,7 @@ extern const struct MenuOpSeq AutocryptAcctDefaultBindings[];
 #endif
 extern const struct MenuOpSeq BrowserDefaultBindings[];
 extern const struct MenuOpSeq ComposeDefaultBindings[];
+extern const struct MenuOpSeq DialogDefaultBindings[];
 extern const struct MenuOpSeq EditorDefaultBindings[];
 extern const struct MenuOpSeq GenericDefaultBindings[];
 extern const struct MenuOpSeq IndexDefaultBindings[];

--- a/history/dlg_history.c
+++ b/history/dlg_history.c
@@ -154,12 +154,7 @@ void dlg_select_history(char *buf, size_t buflen, char **matches, int match_coun
     menu_tagging_dispatcher(menu->win, op);
     window_redraw(NULL);
 
-    struct KeyEvent event = km_dokey_event(MENU_GENERIC);
-    if (event.ch == 'q')
-      op = OP_EXIT;
-    else
-      op = event.op;
-
+    op = km_dokey(MENU_DIALOG);
     mutt_debug(LL_DEBUG1, "Got op %s (%d)\n", opcodes_get_name(op), op);
     if (op < 0)
       continue;
@@ -171,7 +166,6 @@ void dlg_select_history(char *buf, size_t buflen, char **matches, int match_coun
     mutt_clear_error();
 
     int rc = history_function_dispatcher(dlg, op);
-
     if (rc == FR_UNKNOWN)
       rc = menu_function_dispatcher(menu->win, op);
     if (rc == FR_UNKNOWN)

--- a/history/functions.c
+++ b/history/functions.c
@@ -35,16 +35,6 @@
 #include "opcodes.h"
 
 /**
- * op_exit - Exit this menu - Implements ::history_function_t - @ingroup history_function_api
- */
-static int op_exit(struct HistoryData *hd, int op)
-{
-  hd->done = true;
-  hd->selection = false;
-  return FR_SUCCESS;
-}
-
-/**
  * op_generic_select_entry - Select the current entry - Implements ::history_function_t - @ingroup history_function_api
  */
 static int op_generic_select_entry(struct HistoryData *hd, int op)
@@ -57,6 +47,16 @@ static int op_generic_select_entry(struct HistoryData *hd, int op)
   return FR_SUCCESS;
 }
 
+/**
+ * op_quit - Quit this menu - Implements ::history_function_t - @ingroup history_function_api
+ */
+static int op_quit(struct HistoryData *hd, int op)
+{
+  hd->done = true;
+  hd->selection = false;
+  return FR_SUCCESS;
+}
+
 // -----------------------------------------------------------------------------
 
 /**
@@ -64,8 +64,8 @@ static int op_generic_select_entry(struct HistoryData *hd, int op)
  */
 static const struct HistoryFunction HistoryFunctions[] = {
   // clang-format off
-  { OP_EXIT,                   op_exit },
   { OP_GENERIC_SELECT_ENTRY,   op_generic_select_entry },
+  { OP_QUIT,                   op_quit },
   { 0, NULL },
   // clang-format on
 };

--- a/keymap.c
+++ b/keymap.c
@@ -1055,6 +1055,7 @@ void km_init(void)
   create_bindings(AutocryptAcctDefaultBindings, MENU_AUTOCRYPT_ACCT);
 #endif
   create_bindings(BrowserDefaultBindings, MENU_FOLDER);
+  create_bindings(DialogDefaultBindings, MENU_DIALOG);
   create_bindings(ComposeDefaultBindings, MENU_COMPOSE);
   create_bindings(EditorDefaultBindings, MENU_EDITOR);
   create_bindings(GenericDefaultBindings, MENU_GENERIC);
@@ -1266,6 +1267,8 @@ const struct MenuFuncOp *km_get_table(enum MenuType mtype)
 #endif
     case MENU_COMPOSE:
       return OpCompose;
+    case MENU_DIALOG:
+      return OpDialog;
     case MENU_EDITOR:
       return OpEditor;
     case MENU_FOLDER:

--- a/menu/type.c
+++ b/menu/type.c
@@ -43,6 +43,7 @@ const struct Mapping MenuNames[] = {
 #endif
   { "browser",          MENU_FOLDER },
   { "compose",          MENU_COMPOSE },
+  { "dialog",           MENU_DIALOG },
   { "editor",           MENU_EDITOR },
   { "index",            MENU_INDEX },
   { "pager",            MENU_PAGER },

--- a/menu/type.h
+++ b/menu/type.h
@@ -40,6 +40,7 @@ enum MenuType
   MENU_AUTOCRYPT_ACCT,   ///< Autocrypt Account menu
 #endif
   MENU_COMPOSE,          ///< Compose an email
+  MENU_DIALOG,           ///< Simple Dialog
   MENU_EDITOR,           ///< Text entry area
   MENU_FOLDER,           ///< General file/mailbox browser
   MENU_GENERIC,          ///< Generic selection list

--- a/pattern/dlg_pattern.c
+++ b/pattern/dlg_pattern.c
@@ -355,12 +355,7 @@ bool dlg_select_pattern(char *buf, size_t buflen)
     menu_tagging_dispatcher(menu->win, op);
     window_redraw(NULL);
 
-    struct KeyEvent event = km_dokey_event(MENU_GENERIC);
-    if (event.ch == 'q')
-      op = OP_EXIT;
-    else
-      op = event.op;
-
+    op = km_dokey(MENU_DIALOG);
     mutt_debug(LL_DEBUG1, "Got op %s (%d)\n", opcodes_get_name(op), op);
     if (op < 0)
       continue;
@@ -372,7 +367,6 @@ bool dlg_select_pattern(char *buf, size_t buflen)
     mutt_clear_error();
 
     int rc = pattern_function_dispatcher(dlg, op);
-
     if (rc == FR_UNKNOWN)
       rc = menu_function_dispatcher(menu->win, op);
     if (rc == FR_UNKNOWN)

--- a/pattern/functions.c
+++ b/pattern/functions.c
@@ -36,16 +36,6 @@
 #include "opcodes.h"
 
 /**
- * op_exit - Exit this menu - Implements ::pattern_function_t - @ingroup pattern_function_api
- */
-static int op_exit(struct PatternData *pd, int op)
-{
-  pd->done = true;
-  pd->selection = false;
-  return FR_SUCCESS;
-}
-
-/**
  * op_generic_select_entry - Select the current entry - Implements ::pattern_function_t - @ingroup pattern_function_api
  */
 static int op_generic_select_entry(struct PatternData *pd, int op)
@@ -59,6 +49,16 @@ static int op_generic_select_entry(struct PatternData *pd, int op)
   return FR_SUCCESS;
 }
 
+/**
+ * op_quit - Quit this menu - Implements ::pattern_function_t - @ingroup pattern_function_api
+ */
+static int op_quit(struct PatternData *pd, int op)
+{
+  pd->done = true;
+  pd->selection = false;
+  return FR_SUCCESS;
+}
+
 // -----------------------------------------------------------------------------
 
 /**
@@ -66,8 +66,8 @@ static int op_generic_select_entry(struct PatternData *pd, int op)
  */
 static const struct PatternFunction PatternFunctions[] = {
   // clang-format off
-  { OP_EXIT,                   op_exit },
   { OP_GENERIC_SELECT_ENTRY,   op_generic_select_entry },
+  { OP_QUIT,                   op_quit },
   { 0, NULL },
   // clang-format on
 };

--- a/test/pattern/dummy.c
+++ b/test/pattern/dummy.c
@@ -281,6 +281,11 @@ int global_function_dispatcher(struct MuttWindow *win, int op)
   return 0;
 }
 
+int km_dokey(enum MenuType mtype)
+{
+  return 0;
+}
+
 struct KeyEvent km_dokey_event(enum MenuType mtype)
 {
   struct KeyEvent ke = { 0 };


### PR DESCRIPTION
Define OpDialog so that these dialogs can use km_dokey() rather than km_dokey_event().

- dlg_history()
- dlg_pattern()
- dlg_verifycert()

--- 

@lucilanga No action required on either PR; just thought you might like to read them.