### PR TITLE
gui: refactor resize handling

### DIFF
--- a/core/neomutt.c
+++ b/core/neomutt.c
@@ -54,6 +54,9 @@ struct NeoMutt *neomutt_new(struct ConfigSet *cs)
   n->sub->cs = cs;
   n->sub->scope = SET_SCOPE_NEOMUTT;
 
+  n->notify_resize = notify_new();
+  notify_set_parent(n->notify_resize, n->notify);
+
   return n;
 }
 
@@ -70,6 +73,7 @@ void neomutt_free(struct NeoMutt **ptr)
 
   neomutt_account_remove(n, NULL);
   cs_subset_free(&n->sub);
+  notify_free(&n->notify_resize);
   notify_free(&n->notify);
 
   FREE(ptr);

--- a/core/neomutt.h
+++ b/core/neomutt.h
@@ -35,9 +35,10 @@ struct ConfigSet;
  */
 struct NeoMutt
 {
-  struct Notify *notify;       ///< Notifications handler
-  struct ConfigSubset *sub;    ///< Inherited config items
-  struct AccountList accounts; ///< List of all Accounts
+  struct Notify *notify;         ///< Root notifications handler
+  struct Notify *notify_resize;  ///< Window resize notifications handler
+  struct ConfigSubset *sub;      ///< Inherited config items
+  struct AccountList accounts;   ///< List of all Accounts
 };
 
 extern struct NeoMutt *NeoMutt;

--- a/debug/names.c
+++ b/debug/names.c
@@ -111,6 +111,7 @@ const char *name_notify_type(enum NotifyType type)
     DEBUG_NAME(NT_MENU);
     DEBUG_NAME(NT_MVIEW);
     DEBUG_NAME(NT_PAGER);
+    DEBUG_NAME(NT_RESIZE);
     DEBUG_NAME(NT_SCORE);
     DEBUG_NAME(NT_SUBJRX);
     DEBUG_NAME(NT_WINDOW);

--- a/debug/notify.c
+++ b/debug/notify.c
@@ -233,6 +233,8 @@ int debug_all_observer(struct NotifyCallback *nc)
     case NT_MAILBOX:
       notify_dump_mailbox(nc);
       break;
+    case NT_RESIZE:
+      break; // no other data
     case NT_WINDOW:
       if (nc->event_subtype == NT_WINDOW_STATE)
         notify_dump_window_state(nc);

--- a/gui/rootwin.c
+++ b/gui/rootwin.c
@@ -101,6 +101,8 @@
 #include "msgwin.h"
 #include "mutt_window.h"
 
+void mutt_resize_screen(void);
+
 struct MuttWindow *RootWindow = NULL; ///< Parent of all Windows
 
 /**
@@ -144,6 +146,28 @@ static int rootwin_config_observer(struct NotifyCallback *nc)
 }
 
 /**
+ * rootwin_resize_observer - Notification that the terminal has been resized - Implements ::observer_t - @ingroup observer_api
+ *
+ * This function is triggered by SIGWINCH.
+ */
+static int rootwin_resize_observer(struct NotifyCallback *nc)
+{
+  if (nc->event_type != NT_RESIZE)
+    return 0;
+  if (!nc->global_data)
+    return -1;
+
+  struct MuttWindow *win_root = nc->global_data;
+
+  window_invalidate_all();
+  mutt_resize_screen();
+  window_redraw(win_root);
+
+  mutt_debug(LL_DEBUG5, "window resize done\n");
+  return 0;
+}
+
+/**
  * rootwin_window_observer - Notification that a Window has changed - Implements ::observer_t - @ingroup observer_api
  *
  * This function is triggered by changes to the windows.
@@ -166,7 +190,10 @@ static int rootwin_window_observer(struct NotifyCallback *nc)
 
   notify_observer_remove(win_root->notify, rootwin_window_observer, win_root);
   if (NeoMutt)
+  {
     notify_observer_remove(NeoMutt->sub->notify, rootwin_config_observer, win_root);
+    notify_observer_remove(NeoMutt->notify_resize, rootwin_resize_observer, win_root);
+  }
 
   mutt_debug(LL_DEBUG5, "window delete done\n");
   return 0;
@@ -213,6 +240,7 @@ void rootwin_new(void)
   mutt_window_add_child(win_root, win_cont);
 
   notify_observer_add(NeoMutt->sub->notify, NT_CONFIG, rootwin_config_observer, win_root);
+  notify_observer_add(NeoMutt->notify_resize, NT_RESIZE, rootwin_resize_observer, win_root);
   notify_observer_add(win_root->notify, NT_WINDOW, rootwin_window_observer, win_root);
 }
 

--- a/mutt/notify.c
+++ b/mutt/notify.c
@@ -37,11 +37,11 @@
 /// Lookup table for NotifyType
 /// Must be the same size and order as #NotifyType
 static const char *NotifyTypeNames[] = {
-  "NT_ALL",     "NT_ACCOUNT",  "NT_ALIAS",   "NT_ALTERN", "NT_ATTACH",
-  "NT_BINDING", "NT_COLOR",    "NT_COMMAND", "NT_CONFIG", "NT_CONTEXT",
-  "NT_EMAIL",   "NT_ENVELOPE", "NT_GLOBAL",  "NT_HEADER", "NT_INDEX",
-  "NT_MAILBOX", "NT_MENU",     "NT_PAGER",   "NT_SCORE",  "NT_SUBJRX",
-  "NT_WINDOW",
+  "NT_ALL",      "NT_ACCOUNT", "NT_ALIAS",   "NT_ALTERN", "NT_ATTACH",
+  "NT_BINDING",  "NT_COLOR",   "NT_COMMAND", "NT_CONFIG", "NT_EMAIL",
+  "NT_ENVELOPE", "NT_GLOBAL",  "NT_HEADER",  "NT_INDEX",  "NT_MAILBOX",
+  "NT_MVIEW",    "NT_MENU",    "NT_RESIZE",  "NT_PAGER",  "NT_SCORE",
+  "NT_SUBJRX",   "NT_WINDOW",
 };
 
 /**

--- a/mutt/notify_type.h
+++ b/mutt/notify_type.h
@@ -49,6 +49,7 @@ enum NotifyType
   NT_MAILBOX,   ///< Mailbox has changed,           #NotifyMailbox,   #EventMailbox
   NT_MVIEW,     ///< MailboxView has changed,       #NotifyMview,     #EventMview
   NT_MENU,      ///< Menu has changed,              #MenuRedrawFlags
+  NT_RESIZE,    ///< Window has been resized
   NT_PAGER,     ///< Pager data has changed,        #NotifyPager,     #PagerPrivateData
   NT_SCORE,     ///< Email scoring has changed
   NT_SUBJRX,    ///< Subject Regex has changed,     #NotifySubjRx

--- a/mutt_signal.c
+++ b/mutt_signal.c
@@ -76,10 +76,12 @@ static void curses_signal_handler(int sig)
       /* We don't receive SIGWINCH when suspended; however, no harm is done by
        * just assuming we received one, and triggering the 'resize' anyway. */
       SigWinch = true;
+      notify_send(NeoMutt->notify_resize, NT_RESIZE, 0, NULL);
       break;
 
     case SIGWINCH:
       SigWinch = true;
+      notify_send(NeoMutt->notify_resize, NT_RESIZE, 0, NULL);
       break;
 
     case SIGINT:


### PR DESCRIPTION
When the terminal is resized it sends a `SIGWINCH` signal to NeoMutt.
This is caught in `curses_signal_handler()` which sets a global variable: `SigWinch = true`.
The signal's arrival causes `getch()` to return immediately with a timeout.

What happens next depends on which Window has focus.

In some Dialogs, the event loop clears the variable `SigWinch = false` and manually forces a refresh of the entire screen.
Others don't.
While _they_ are waiting for keystrokes, the resized screen won't get repainted.

The signal handler now sends a notification to a new notifier: `NeoMutt.notify_resize`.
The Root Window has set up an observer of this notification.

The Root Window, now:
- Looks up the new Terminal size
- Reflows all the Windows (redistributing the space)
- Recalculates all the Windows
- Repaints all the Windows