### PR TITLE
gui: add global timeout notification

### DIFF
--- a/core/neomutt.c
+++ b/core/neomutt.c
@@ -73,6 +73,7 @@ void neomutt_free(struct NeoMutt **ptr)
 
   neomutt_account_remove(n, NULL);
   cs_subset_free(&n->sub);
+  notify_free(&n->notify_timeout);
   notify_free(&n->notify);
 
   FREE(ptr);

--- a/core/neomutt.c
+++ b/core/neomutt.c
@@ -54,6 +54,9 @@ struct NeoMutt *neomutt_new(struct ConfigSet *cs)
   n->sub->cs = cs;
   n->sub->scope = SET_SCOPE_NEOMUTT;
 
+  n->notify_timeout = notify_new();
+  notify_set_parent(n->notify_timeout, n->notify);
+
   return n;
 }
 

--- a/core/neomutt.h
+++ b/core/neomutt.h
@@ -35,9 +35,10 @@ struct ConfigSet;
  */
 struct NeoMutt
 {
-  struct Notify *notify;       ///< Notifications handler
-  struct ConfigSubset *sub;    ///< Inherited config items
-  struct AccountList accounts; ///< List of all Accounts
+  struct Notify *notify;         ///< Notifications handler
+  struct Notify *notify_timeout; ///< Timeout notifications handler
+  struct ConfigSubset *sub;      ///< Inherited config items
+  struct AccountList accounts;   ///< List of all Accounts
 };
 
 extern struct NeoMutt *NeoMutt;

--- a/debug/names.c
+++ b/debug/names.c
@@ -113,6 +113,7 @@ const char *name_notify_type(enum NotifyType type)
     DEBUG_NAME(NT_PAGER);
     DEBUG_NAME(NT_SCORE);
     DEBUG_NAME(NT_SUBJRX);
+    DEBUG_NAME(NT_TIMEOUT);
     DEBUG_NAME(NT_WINDOW);
     DEBUG_DEFAULT;
   }

--- a/debug/notify.c
+++ b/debug/notify.c
@@ -233,6 +233,8 @@ int debug_all_observer(struct NotifyCallback *nc)
     case NT_MAILBOX:
       notify_dump_mailbox(nc);
       break;
+    case NT_TIMEOUT:
+      break; // no other data
     case NT_WINDOW:
       if (nc->event_subtype == NT_WINDOW_STATE)
         notify_dump_window_state(nc);

--- a/keymap.c
+++ b/keymap.c
@@ -1904,7 +1904,10 @@ void mw_what_key(void)
       break;
 
     if (ch == ERR) // Timeout
+    {
+      notify_send(NeoMutt->notify_timeout, NT_TIMEOUT, 0, NULL);
       continue;
+    }
 
     mutt_message(_("Char = %s, Octal = %o, Decimal = %d"), km_keyname(ch), ch, ch);
     mutt_window_move(win, 0, 0);

--- a/mutt/notify.c
+++ b/mutt/notify.c
@@ -41,7 +41,7 @@ static const char *NotifyTypeNames[] = {
   "NT_BINDING", "NT_COLOR",    "NT_COMMAND", "NT_CONFIG", "NT_CONTEXT",
   "NT_EMAIL",   "NT_ENVELOPE", "NT_GLOBAL",  "NT_HEADER", "NT_INDEX",
   "NT_MAILBOX", "NT_MENU",     "NT_PAGER",   "NT_SCORE",  "NT_SUBJRX",
-  "NT_WINDOW",
+  "NT_TIMEOUT", "NT_WINDOW",
 };
 
 /**

--- a/mutt/notify_type.h
+++ b/mutt/notify_type.h
@@ -52,6 +52,7 @@ enum NotifyType
   NT_PAGER,     ///< Pager data has changed,        #NotifyPager,     #PagerPrivateData
   NT_SCORE,     ///< Email scoring has changed
   NT_SUBJRX,    ///< Subject Regex has changed,     #NotifySubjRx
+  NT_TIMEOUT,   ///< Timeout has occurred
   NT_WINDOW,    ///< MuttWindow has changed,        #NotifyWindow,    #EventWindow
 };
 


### PR DESCRIPTION
WIP

- Add a new notification type, `NT_TIMEOUT`
- Add notifier to `NeoMutt.notify_timeout`
- Add a timeout observer to the IMAP Account Data
- Strip the IMAP code from `km_dokey_event()`
- Send a timeout notification every second
- Convert `my_what_key()` to send timeouts