### PR TITLE
optimise config observers

### DIFF
--- a/alias/dlg_alias.c
+++ b/alias/dlg_alias.c
@@ -264,7 +264,7 @@ static int alias_window_observer(struct NotifyCallback *nc)
   struct Menu *menu = win_menu->wdata;
 
   notify_observer_remove(NeoMutt->notify, alias_alias_observer, menu);
-  notify_observer_remove(NeoMutt->notify, alias_config_observer, menu);
+  notify_observer_remove(NeoMutt->sub->notify, alias_config_observer, menu);
   notify_observer_remove(win_menu->notify, alias_window_observer, win_menu);
 
   mutt_debug(LL_DEBUG5, "window delete done\n");
@@ -299,7 +299,7 @@ static struct MuttWindow *alias_dialog_new(struct AliasMenuData *mdata)
 
   // NT_COLOR is handled by the SimpleDialog
   notify_observer_add(NeoMutt->notify, NT_ALIAS, alias_alias_observer, menu);
-  notify_observer_add(NeoMutt->notify, NT_CONFIG, alias_config_observer, menu);
+  notify_observer_add(NeoMutt->sub->notify, NT_CONFIG, alias_config_observer, menu);
   notify_observer_add(win_menu->notify, NT_WINDOW, alias_window_observer, win_menu);
 
   return dlg;

--- a/alias/dlg_query.c
+++ b/alias/dlg_query.c
@@ -338,7 +338,7 @@ static int query_window_observer(struct NotifyCallback *nc)
 
   struct Menu *menu = win_menu->wdata;
 
-  notify_observer_remove(NeoMutt->notify, alias_config_observer, menu);
+  notify_observer_remove(NeoMutt->sub->notify, alias_config_observer, menu);
   notify_observer_remove(win_menu->notify, query_window_observer, win_menu);
 
   mutt_debug(LL_DEBUG5, "window delete done\n");
@@ -376,7 +376,7 @@ static struct MuttWindow *query_dialog_new(struct AliasMenuData *mdata, const ch
   sbar_set_title(sbar, title);
 
   // NT_COLOR is handled by the SimpleDialog
-  notify_observer_add(NeoMutt->notify, NT_CONFIG, alias_config_observer, menu);
+  notify_observer_add(NeoMutt->sub->notify, NT_CONFIG, alias_config_observer, menu);
   notify_observer_add(win_menu->notify, NT_WINDOW, query_window_observer, win_menu);
 
   return dlg;

--- a/attach/dlg_attach.c
+++ b/attach/dlg_attach.c
@@ -451,7 +451,7 @@ static int attach_window_observer(struct NotifyCallback *nc)
 
   struct Menu *menu = win_menu->wdata;
 
-  notify_observer_remove(NeoMutt->notify, attach_config_observer, menu);
+  notify_observer_remove(NeoMutt->sub->notify, attach_config_observer, menu);
   notify_observer_remove(win_menu->notify, attach_window_observer, win_menu);
 
   mutt_debug(LL_DEBUG5, "window delete done\n");
@@ -500,7 +500,7 @@ void dlg_select_attachment(struct ConfigSubset *sub, struct MailboxView *mv,
   menu->mdata_free = attach_private_data_free;
 
   // NT_COLOR is handled by the SimpleDialog
-  notify_observer_add(NeoMutt->notify, NT_CONFIG, attach_config_observer, menu);
+  notify_observer_add(NeoMutt->sub->notify, NT_CONFIG, attach_config_observer, menu);
   notify_observer_add(menu->win->notify, NT_WINDOW, attach_window_observer, menu->win);
 
   struct MuttWindow *sbar = window_find_child(dlg, WT_STATUS_BAR);

--- a/autocrypt/dlg_autocrypt.c
+++ b/autocrypt/dlg_autocrypt.c
@@ -293,7 +293,7 @@ static int autocrypt_window_observer(struct NotifyCallback *nc)
 
   struct Menu *menu = win_menu->wdata;
 
-  notify_observer_remove(NeoMutt->notify, autocrypt_config_observer, menu);
+  notify_observer_remove(NeoMutt->sub->notify, autocrypt_config_observer, menu);
   notify_observer_remove(win_menu->notify, autocrypt_window_observer, win_menu);
 
   mutt_debug(LL_DEBUG5, "window delete done\n");
@@ -330,7 +330,7 @@ void dlg_select_autocrypt(void)
   sbar_set_title(sbar, _("Autocrypt Accounts"));
 
   // NT_COLOR is handled by the SimpleDialog
-  notify_observer_add(NeoMutt->notify, NT_CONFIG, autocrypt_config_observer, menu);
+  notify_observer_add(NeoMutt->sub->notify, NT_CONFIG, autocrypt_config_observer, menu);
   notify_observer_add(menu->win->notify, NT_WINDOW, autocrypt_window_observer, menu->win);
 
   // ---------------------------------------------------------------------------

--- a/browser/dlg_browser.c
+++ b/browser/dlg_browser.c
@@ -1120,7 +1120,7 @@ static int browser_window_observer(struct NotifyCallback *nc)
 
   struct Menu *menu = win_menu->wdata;
 
-  notify_observer_remove(NeoMutt->notify, browser_config_observer, menu);
+  notify_observer_remove(NeoMutt->sub->notify, browser_config_observer, menu);
   notify_observer_remove(win_menu->notify, browser_window_observer, win_menu);
 
   mutt_debug(LL_DEBUG5, "window delete done\n");
@@ -1377,7 +1377,7 @@ void dlg_select_file(struct Buffer *file, SelectFileFlags flags,
   struct MuttWindow *win_menu = priv->menu->win;
 
   // NT_COLOR is handled by the SimpleDialog
-  notify_observer_add(NeoMutt->notify, NT_CONFIG, browser_config_observer, priv->menu);
+  notify_observer_add(NeoMutt->sub->notify, NT_CONFIG, browser_config_observer, priv->menu);
   notify_observer_add(win_menu->notify, NT_WINDOW, browser_window_observer, win_menu);
 
   if (priv->state.is_mailbox_list)

--- a/compose/attach.c
+++ b/compose/attach.c
@@ -188,7 +188,7 @@ static int attach_window_observer(struct NotifyCallback *nc)
     struct ComposeAttachData *adata = menu->mdata;
     struct AttachCtx *actx = adata->actx;
     notify_observer_remove(actx->email->notify, attach_email_observer, win_attach);
-    notify_observer_remove(NeoMutt->notify, attach_config_observer, win_attach);
+    notify_observer_remove(NeoMutt->sub->notify, attach_config_observer, win_attach);
     notify_observer_remove(win_attach->notify, attach_window_observer, win_attach);
     mutt_debug(LL_DEBUG5, "window delete done\n");
   }
@@ -242,7 +242,7 @@ struct MuttWindow *attach_new(struct MuttWindow *parent, struct ComposeSharedDat
   shared->adata = adata;
 
   // NT_COLOR is handled by the Menu Window
-  notify_observer_add(NeoMutt->notify, NT_CONFIG, attach_config_observer, win_attach);
+  notify_observer_add(NeoMutt->sub->notify, NT_CONFIG, attach_config_observer, win_attach);
   notify_observer_add(shared->email->notify, NT_EMAIL, attach_email_observer, win_attach);
   notify_observer_add(win_attach->notify, NT_WINDOW, attach_window_observer, win_attach);
 

--- a/compose/cbar.c
+++ b/compose/cbar.c
@@ -288,7 +288,7 @@ static int cbar_window_observer(struct NotifyCallback *nc)
     struct ComposeSharedData *shared = dlg->wdata;
 
     notify_observer_remove(NeoMutt->notify, cbar_color_observer, win_cbar);
-    notify_observer_remove(NeoMutt->notify, cbar_config_observer, win_cbar);
+    notify_observer_remove(NeoMutt->sub->notify, cbar_config_observer, win_cbar);
     notify_observer_remove(shared->email->notify, cbar_email_observer, win_cbar);
     notify_observer_remove(win_cbar->notify, cbar_window_observer, win_cbar);
 
@@ -314,7 +314,7 @@ struct MuttWindow *cbar_new(struct ComposeSharedData *shared)
   win_cbar->repaint = cbar_repaint;
 
   notify_observer_add(NeoMutt->notify, NT_COLOR, cbar_color_observer, win_cbar);
-  notify_observer_add(NeoMutt->notify, NT_CONFIG, cbar_config_observer, win_cbar);
+  notify_observer_add(NeoMutt->sub->notify, NT_CONFIG, cbar_config_observer, win_cbar);
   notify_observer_add(shared->email->notify, NT_EMAIL, cbar_email_observer, win_cbar);
   notify_observer_add(win_cbar->notify, NT_WINDOW, cbar_window_observer, win_cbar);
 

--- a/compose/cbar.c
+++ b/compose/cbar.c
@@ -287,7 +287,7 @@ static int cbar_window_observer(struct NotifyCallback *nc)
     struct MuttWindow *dlg = win_cbar->parent;
     struct ComposeSharedData *shared = dlg->wdata;
 
-    notify_observer_remove(NeoMutt->notify, cbar_color_observer, win_cbar);
+    mutt_color_observer_remove(cbar_color_observer, win_cbar);
     notify_observer_remove(NeoMutt->sub->notify, cbar_config_observer, win_cbar);
     notify_observer_remove(shared->email->notify, cbar_email_observer, win_cbar);
     notify_observer_remove(win_cbar->notify, cbar_window_observer, win_cbar);
@@ -313,7 +313,7 @@ struct MuttWindow *cbar_new(struct ComposeSharedData *shared)
   win_cbar->recalc = cbar_recalc;
   win_cbar->repaint = cbar_repaint;
 
-  notify_observer_add(NeoMutt->notify, NT_COLOR, cbar_color_observer, win_cbar);
+  mutt_color_observer_add(cbar_color_observer, win_cbar);
   notify_observer_add(NeoMutt->sub->notify, NT_CONFIG, cbar_config_observer, win_cbar);
   notify_observer_add(shared->email->notify, NT_EMAIL, cbar_email_observer, win_cbar);
   notify_observer_add(win_cbar->notify, NT_WINDOW, cbar_window_observer, win_cbar);

--- a/compose/cbar_data.c
+++ b/compose/cbar_data.c
@@ -28,9 +28,7 @@
 
 #include "config.h"
 #include "mutt/lib.h"
-#include "core/lib.h"
 #include "cbar_data.h"
-#include "cbar.h"
 
 /**
  * cbar_data_free - Free the private data attached to the MuttWindow - Implements MuttWindow::wdata_free() - @ingroup window_wdata_free
@@ -41,9 +39,6 @@ void cbar_data_free(struct MuttWindow *win, void **ptr)
     return;
 
   struct ComposeBarData *cbar_data = *ptr;
-
-  notify_observer_remove(NeoMutt->notify, cbar_color_observer, win);
-  notify_observer_remove(NeoMutt->notify, cbar_config_observer, win);
 
   FREE(&cbar_data->compose_format);
 

--- a/compose/dlg_compose.c
+++ b/compose/dlg_compose.c
@@ -181,7 +181,7 @@ static int compose_window_observer(struct NotifyCallback *nc)
   if (ev_w->win != dlg)
     return 0;
 
-  notify_observer_remove(NeoMutt->notify, compose_config_observer, dlg);
+  notify_observer_remove(NeoMutt->sub->notify, compose_config_observer, dlg);
   notify_observer_remove(dlg->notify, compose_window_observer, dlg);
   mutt_debug(LL_DEBUG5, "window delete done\n");
 
@@ -320,7 +320,7 @@ int dlg_compose(struct Email *e, struct Buffer *fcc, uint8_t flags, struct Confi
   shared->flags = flags;
   shared->rc = -1;
 
-  notify_observer_add(NeoMutt->notify, NT_CONFIG, compose_config_observer, dlg);
+  notify_observer_add(NeoMutt->sub->notify, NT_CONFIG, compose_config_observer, dlg);
   notify_observer_add(e->notify, NT_ALL, compose_email_observer, shared);
   notify_observer_add(dlg->notify, NT_WINDOW, compose_window_observer, dlg);
   dialog_push(dlg);

--- a/config/cache.c
+++ b/config/cache.c
@@ -83,7 +83,7 @@ static void cache_setup(void)
   if (CacheActive)
     return; // LCOV_EXCL_LINE
 
-  notify_observer_add(NeoMutt->notify, NT_CONFIG, cc_config_observer, NULL);
+  notify_observer_add(NeoMutt->sub->notify, NT_CONFIG, cc_config_observer, NULL);
 
   CachedAssumedCharset = cs_subset_slist(NeoMutt->sub, "assumed_charset");
   CachedCharset = cs_subset_string(NeoMutt->sub, "charset");
@@ -143,7 +143,7 @@ const char *cc_maildir_field_delimiter(void)
 void config_cache_cleanup(void)
 {
   if (NeoMutt)
-    notify_observer_remove(NeoMutt->notify, cc_config_observer, NULL);
+    notify_observer_remove(NeoMutt->sub->notify, cc_config_observer, NULL);
 
   // Don't free them, the config system owns the data
   CachedAssumedCharset = NULL;

--- a/envelope/window.c
+++ b/envelope/window.c
@@ -980,7 +980,7 @@ static int env_window_observer(struct NotifyCallback *nc)
 
     notify_observer_remove(NeoMutt->notify, env_color_observer, win_env);
     notify_observer_remove(wdata->email->notify, env_email_observer, win_env);
-    notify_observer_remove(NeoMutt->notify, env_config_observer, win_env);
+    notify_observer_remove(NeoMutt->sub->notify, env_config_observer, win_env);
     notify_observer_remove(NeoMutt->notify, env_header_observer, win_env);
     notify_observer_remove(win_env->notify, env_window_observer, win_env);
     mutt_debug(LL_DEBUG5, "window delete done\n");
@@ -1006,7 +1006,7 @@ struct MuttWindow *env_window_new(struct Email *e, struct Buffer *fcc, struct Co
 
   notify_observer_add(NeoMutt->notify, NT_COLOR, env_color_observer, win_env);
   notify_observer_add(e->notify, NT_ALL, env_email_observer, win_env);
-  notify_observer_add(NeoMutt->notify, NT_CONFIG, env_config_observer, win_env);
+  notify_observer_add(NeoMutt->sub->notify, NT_CONFIG, env_config_observer, win_env);
   notify_observer_add(NeoMutt->notify, NT_HEADER, env_header_observer, win_env);
   notify_observer_add(win_env->notify, NT_WINDOW, env_window_observer, win_env);
 

--- a/envelope/window.c
+++ b/envelope/window.c
@@ -978,7 +978,7 @@ static int env_window_observer(struct NotifyCallback *nc)
   {
     struct EnvelopeWindowData *wdata = win_env->wdata;
 
-    notify_observer_remove(NeoMutt->notify, env_color_observer, win_env);
+    mutt_color_observer_remove(env_color_observer, win_env);
     notify_observer_remove(wdata->email->notify, env_email_observer, win_env);
     notify_observer_remove(NeoMutt->sub->notify, env_config_observer, win_env);
     notify_observer_remove(NeoMutt->notify, env_header_observer, win_env);
@@ -1004,7 +1004,7 @@ struct MuttWindow *env_window_new(struct Email *e, struct Buffer *fcc, struct Co
                                                MUTT_WIN_SIZE_FIXED, MUTT_WIN_SIZE_UNLIMITED,
                                                HDR_ATTACH_TITLE - 1);
 
-  notify_observer_add(NeoMutt->notify, NT_COLOR, env_color_observer, win_env);
+  mutt_color_observer_add(env_color_observer, win_env);
   notify_observer_add(e->notify, NT_ALL, env_email_observer, win_env);
   notify_observer_add(NeoMutt->sub->notify, NT_CONFIG, env_config_observer, win_env);
   notify_observer_add(NeoMutt->notify, NT_HEADER, env_header_observer, win_env);

--- a/gui/rootwin.c
+++ b/gui/rootwin.c
@@ -166,7 +166,7 @@ static int rootwin_window_observer(struct NotifyCallback *nc)
 
   notify_observer_remove(win_root->notify, rootwin_window_observer, win_root);
   if (NeoMutt)
-    notify_observer_remove(NeoMutt->notify, rootwin_config_observer, win_root);
+    notify_observer_remove(NeoMutt->sub->notify, rootwin_config_observer, win_root);
 
   mutt_debug(LL_DEBUG5, "window delete done\n");
   return 0;
@@ -212,7 +212,7 @@ void rootwin_new(void)
   mutt_window_add_child(win_cont, win_msg);
   mutt_window_add_child(win_root, win_cont);
 
-  notify_observer_add(NeoMutt->notify, NT_CONFIG, rootwin_config_observer, win_root);
+  notify_observer_add(NeoMutt->sub->notify, NT_CONFIG, rootwin_config_observer, win_root);
   notify_observer_add(win_root->notify, NT_WINDOW, rootwin_window_observer, win_root);
 }
 

--- a/gui/sbar.c
+++ b/gui/sbar.c
@@ -62,7 +62,6 @@
 
 #include "config.h"
 #include "mutt/lib.h"
-#include "core/lib.h"
 #include "lib.h"
 #include "color/lib.h"
 
@@ -162,7 +161,7 @@ static int sbar_window_observer(struct NotifyCallback *nc)
   }
   else if (nc->event_subtype == NT_WINDOW_DELETE)
   {
-    notify_observer_remove(NeoMutt->notify, sbar_color_observer, win_sbar);
+    mutt_color_observer_remove(sbar_color_observer, win_sbar);
     notify_observer_remove(win_sbar->notify, sbar_window_observer, win_sbar);
     mutt_debug(LL_DEBUG5, "window delete done\n");
   }
@@ -211,7 +210,7 @@ struct MuttWindow *sbar_new(void)
   win_sbar->recalc = sbar_recalc;
   win_sbar->repaint = sbar_repaint;
 
-  notify_observer_add(NeoMutt->notify, NT_COLOR, sbar_color_observer, win_sbar);
+  mutt_color_observer_add(sbar_color_observer, win_sbar);
   notify_observer_add(win_sbar->notify, NT_WINDOW, sbar_window_observer, win_sbar);
 
   return win_sbar;

--- a/gui/simple.c
+++ b/gui/simple.c
@@ -112,7 +112,7 @@ static int simple_window_observer(struct NotifyCallback *nc)
   if (ev_w->win != dlg)
     return 0;
 
-  notify_observer_remove(NeoMutt->notify, simple_config_observer, dlg);
+  notify_observer_remove(NeoMutt->sub->notify, simple_config_observer, dlg);
   notify_observer_remove(dlg->notify, simple_window_observer, dlg);
 
   mutt_debug(LL_DEBUG5, "window delete done\n");
@@ -152,7 +152,7 @@ struct MuttWindow *simple_dialog_new(enum MenuType mtype, enum WindowType wtype,
     mutt_window_add_child(dlg, win_sbar);
   }
 
-  notify_observer_add(NeoMutt->notify, NT_CONFIG, simple_config_observer, dlg);
+  notify_observer_add(NeoMutt->sub->notify, NT_CONFIG, simple_config_observer, dlg);
   notify_observer_add(dlg->notify, NT_WINDOW, simple_window_observer, dlg);
   dialog_push(dlg);
 

--- a/helpbar/helpbar.c
+++ b/helpbar/helpbar.c
@@ -314,8 +314,8 @@ static int helpbar_window_observer(struct NotifyCallback *nc)
   }
   else if (nc->event_subtype == NT_WINDOW_DELETE)
   {
+    mutt_color_observer_remove(helpbar_color_observer, win_helpbar);
     notify_observer_remove(NeoMutt->notify, helpbar_binding_observer, win_helpbar);
-    notify_observer_remove(NeoMutt->notify, helpbar_color_observer, win_helpbar);
     notify_observer_remove(NeoMutt->sub->notify, helpbar_config_observer, win_helpbar);
     notify_observer_remove(RootWindow->notify, helpbar_window_observer, win_helpbar);
     mutt_debug(LL_DEBUG5, "window delete done\n");
@@ -343,8 +343,8 @@ struct MuttWindow *helpbar_new(void)
   win->wdata = helpbar_wdata_new();
   win->wdata_free = helpbar_wdata_free;
 
+  mutt_color_observer_add(helpbar_color_observer, win);
   notify_observer_add(NeoMutt->notify, NT_BINDING, helpbar_binding_observer, win);
-  notify_observer_add(NeoMutt->notify, NT_COLOR, helpbar_color_observer, win);
   notify_observer_add(NeoMutt->sub->notify, NT_CONFIG, helpbar_config_observer, win);
   notify_observer_add(RootWindow->notify, NT_WINDOW, helpbar_window_observer, win);
   return win;

--- a/helpbar/helpbar.c
+++ b/helpbar/helpbar.c
@@ -316,7 +316,7 @@ static int helpbar_window_observer(struct NotifyCallback *nc)
   {
     notify_observer_remove(NeoMutt->notify, helpbar_binding_observer, win_helpbar);
     notify_observer_remove(NeoMutt->notify, helpbar_color_observer, win_helpbar);
-    notify_observer_remove(NeoMutt->notify, helpbar_config_observer, win_helpbar);
+    notify_observer_remove(NeoMutt->sub->notify, helpbar_config_observer, win_helpbar);
     notify_observer_remove(RootWindow->notify, helpbar_window_observer, win_helpbar);
     mutt_debug(LL_DEBUG5, "window delete done\n");
   }
@@ -345,7 +345,7 @@ struct MuttWindow *helpbar_new(void)
 
   notify_observer_add(NeoMutt->notify, NT_BINDING, helpbar_binding_observer, win);
   notify_observer_add(NeoMutt->notify, NT_COLOR, helpbar_color_observer, win);
-  notify_observer_add(NeoMutt->notify, NT_CONFIG, helpbar_config_observer, win);
+  notify_observer_add(NeoMutt->sub->notify, NT_CONFIG, helpbar_config_observer, win);
   notify_observer_add(RootWindow->notify, NT_WINDOW, helpbar_window_observer, win);
   return win;
 }

--- a/index/ibar.c
+++ b/index/ibar.c
@@ -281,7 +281,7 @@ static int ibar_window_observer(struct NotifyCallback *nc)
     struct IndexSharedData *shared = dlg->wdata;
 
     notify_observer_remove(NeoMutt->notify, ibar_color_observer, win_ibar);
-    notify_observer_remove(NeoMutt->notify, ibar_config_observer, win_ibar);
+    notify_observer_remove(NeoMutt->sub->notify, ibar_config_observer, win_ibar);
     notify_observer_remove(shared->notify, ibar_index_observer, win_ibar);
     notify_observer_remove(win_ibar->parent->notify, ibar_menu_observer, win_ibar);
     notify_observer_remove(win_ibar->notify, ibar_window_observer, win_ibar);
@@ -346,7 +346,7 @@ struct MuttWindow *ibar_new(struct MuttWindow *parent, struct IndexSharedData *s
   win_ibar->repaint = ibar_repaint;
 
   notify_observer_add(NeoMutt->notify, NT_COLOR, ibar_color_observer, win_ibar);
-  notify_observer_add(NeoMutt->notify, NT_CONFIG, ibar_config_observer, win_ibar);
+  notify_observer_add(NeoMutt->sub->notify, NT_CONFIG, ibar_config_observer, win_ibar);
   notify_observer_add(shared->notify, NT_ALL, ibar_index_observer, win_ibar);
   notify_observer_add(parent->notify, NT_MENU, ibar_menu_observer, win_ibar);
   notify_observer_add(win_ibar->notify, NT_WINDOW, ibar_window_observer, win_ibar);

--- a/index/ibar.c
+++ b/index/ibar.c
@@ -280,7 +280,7 @@ static int ibar_window_observer(struct NotifyCallback *nc)
     struct MuttWindow *dlg = window_find_parent(win_ibar, WT_DLG_INDEX);
     struct IndexSharedData *shared = dlg->wdata;
 
-    notify_observer_remove(NeoMutt->notify, ibar_color_observer, win_ibar);
+    mutt_color_observer_remove(ibar_color_observer, win_ibar);
     notify_observer_remove(NeoMutt->sub->notify, ibar_config_observer, win_ibar);
     notify_observer_remove(shared->notify, ibar_index_observer, win_ibar);
     notify_observer_remove(win_ibar->parent->notify, ibar_menu_observer, win_ibar);
@@ -345,7 +345,7 @@ struct MuttWindow *ibar_new(struct MuttWindow *parent, struct IndexSharedData *s
   win_ibar->recalc = ibar_recalc;
   win_ibar->repaint = ibar_repaint;
 
-  notify_observer_add(NeoMutt->notify, NT_COLOR, ibar_color_observer, win_ibar);
+  mutt_color_observer_add(ibar_color_observer, win_ibar);
   notify_observer_add(NeoMutt->sub->notify, NT_CONFIG, ibar_config_observer, win_ibar);
   notify_observer_add(shared->notify, NT_ALL, ibar_index_observer, win_ibar);
   notify_observer_add(parent->notify, NT_MENU, ibar_menu_observer, win_ibar);

--- a/index/index.c
+++ b/index/index.c
@@ -516,7 +516,7 @@ static int index_window_observer(struct NotifyCallback *nc)
   notify_observer_remove(NeoMutt->notify, index_altern_observer, win);
   notify_observer_remove(NeoMutt->notify, index_attach_observer, win);
   notify_observer_remove(NeoMutt->notify, index_color_observer, win);
-  notify_observer_remove(NeoMutt->notify, index_config_observer, win);
+  notify_observer_remove(NeoMutt->sub->notify, index_config_observer, win);
   notify_observer_remove(NeoMutt->notify, index_global_observer, win);
   notify_observer_remove(priv->shared->notify, index_index_observer, win);
   notify_observer_remove(menu->notify, index_menu_observer, win);
@@ -609,7 +609,7 @@ struct MuttWindow *index_window_new(struct IndexPrivateData *priv)
   notify_observer_add(NeoMutt->notify, NT_ALTERN, index_altern_observer, win);
   notify_observer_add(NeoMutt->notify, NT_ATTACH, index_attach_observer, win);
   notify_observer_add(NeoMutt->notify, NT_COLOR, index_color_observer, win);
-  notify_observer_add(NeoMutt->notify, NT_CONFIG, index_config_observer, win);
+  notify_observer_add(NeoMutt->sub->notify, NT_CONFIG, index_config_observer, win);
   notify_observer_add(NeoMutt->notify, NT_GLOBAL, index_global_observer, win);
   notify_observer_add(priv->shared->notify, NT_ALL, index_index_observer, win);
   notify_observer_add(menu->notify, NT_MENU, index_menu_observer, win);

--- a/index/index.c
+++ b/index/index.c
@@ -513,9 +513,9 @@ static int index_window_observer(struct NotifyCallback *nc)
 
   struct IndexPrivateData *priv = menu->mdata;
 
+  mutt_color_observer_remove(index_color_observer, win);
   notify_observer_remove(NeoMutt->notify, index_altern_observer, win);
   notify_observer_remove(NeoMutt->notify, index_attach_observer, win);
-  notify_observer_remove(NeoMutt->notify, index_color_observer, win);
   notify_observer_remove(NeoMutt->sub->notify, index_config_observer, win);
   notify_observer_remove(NeoMutt->notify, index_global_observer, win);
   notify_observer_remove(priv->shared->notify, index_index_observer, win);
@@ -606,9 +606,9 @@ struct MuttWindow *index_window_new(struct IndexPrivateData *priv)
   menu->mdata_free = NULL; // Menu doesn't own the data
   priv->menu = menu;
 
+  mutt_color_observer_add(index_color_observer, win);
   notify_observer_add(NeoMutt->notify, NT_ALTERN, index_altern_observer, win);
   notify_observer_add(NeoMutt->notify, NT_ATTACH, index_attach_observer, win);
-  notify_observer_add(NeoMutt->notify, NT_COLOR, index_color_observer, win);
   notify_observer_add(NeoMutt->sub->notify, NT_CONFIG, index_config_observer, win);
   notify_observer_add(NeoMutt->notify, NT_GLOBAL, index_global_observer, win);
   notify_observer_add(priv->shared->notify, NT_ALL, index_index_observer, win);

--- a/index/ipanel.c
+++ b/index/ipanel.c
@@ -105,7 +105,7 @@ static int ipanel_window_observer(struct NotifyCallback *nc)
   if (ev_w->win != panel_index)
     return 0;
 
-  notify_observer_remove(NeoMutt->notify, ipanel_config_observer, panel_index);
+  notify_observer_remove(NeoMutt->sub->notify, ipanel_config_observer, panel_index);
   notify_observer_remove(panel_index->notify, ipanel_window_observer, panel_index);
   mutt_debug(LL_DEBUG5, "window delete done\n");
 
@@ -143,7 +143,7 @@ struct MuttWindow *ipanel_new(bool status_on_top, struct IndexSharedData *shared
     mutt_window_add_child(panel_index, win_ibar);
   }
 
-  notify_observer_add(NeoMutt->notify, NT_CONFIG, ipanel_config_observer, panel_index);
+  notify_observer_add(NeoMutt->sub->notify, NT_CONFIG, ipanel_config_observer, panel_index);
   notify_observer_add(panel_index->notify, NT_WINDOW, ipanel_window_observer, panel_index);
 
   return panel_index;

--- a/main.c
+++ b/main.c
@@ -916,9 +916,9 @@ main
   }
   StartupComplete = true;
 
-  notify_observer_add(NeoMutt->notify, NT_CONFIG, main_hist_observer, NULL);
-  notify_observer_add(NeoMutt->notify, NT_CONFIG, main_log_observer, NULL);
-  notify_observer_add(NeoMutt->notify, NT_CONFIG, main_config_observer, NULL);
+  notify_observer_add(NeoMutt->sub->notify, NT_CONFIG, main_hist_observer, NULL);
+  notify_observer_add(NeoMutt->sub->notify, NT_CONFIG, main_log_observer, NULL);
+  notify_observer_add(NeoMutt->sub->notify, NT_CONFIG, main_config_observer, NULL);
 
   if (sendflags & SEND_POSTPONED)
   {
@@ -1391,6 +1391,12 @@ main_curses:
   if (repeat_error && ErrorBufMessage)
     puts(ErrorBuf);
 main_exit:
+  if (NeoMutt && NeoMutt->sub)
+  {
+    notify_observer_remove(NeoMutt->sub->notify, main_hist_observer, NULL);
+    notify_observer_remove(NeoMutt->sub->notify, main_log_observer, NULL);
+    notify_observer_remove(NeoMutt->sub->notify, main_config_observer, NULL);
+  }
   mutt_list_free(&commands);
   MuttLogger = log_disp_queue;
   buf_dealloc(&folder);

--- a/menu/observer.c
+++ b/menu/observer.c
@@ -116,7 +116,7 @@ static int menu_window_observer(struct NotifyCallback *nc)
   }
   else if (nc->event_subtype == NT_WINDOW_DELETE)
   {
-    notify_observer_remove(NeoMutt->notify, menu_config_observer, menu);
+    notify_observer_remove(NeoMutt->sub->notify, menu_config_observer, menu);
     notify_observer_remove(win->notify, menu_window_observer, menu);
     mutt_color_observer_remove(menu_color_observer, menu);
     msgwin_clear_text();
@@ -134,7 +134,7 @@ void menu_add_observers(struct Menu *menu)
 {
   struct MuttWindow *win = menu->win;
 
-  notify_observer_add(NeoMutt->notify, NT_CONFIG, menu_config_observer, menu);
+  notify_observer_add(NeoMutt->sub->notify, NT_CONFIG, menu_config_observer, menu);
   notify_observer_add(win->notify, NT_WINDOW, menu_window_observer, menu);
   mutt_color_observer_add(menu_color_observer, menu);
 }

--- a/mixmaster/dlg_mixmaster.c
+++ b/mixmaster/dlg_mixmaster.c
@@ -125,7 +125,7 @@ static int remailer_window_observer(struct NotifyCallback *nc)
   if (ev_w->win != dlg)
     return 0;
 
-  notify_observer_remove(NeoMutt->notify, remailer_config_observer, dlg);
+  notify_observer_remove(NeoMutt->sub->notify, remailer_config_observer, dlg);
   notify_observer_remove(dlg->notify, remailer_window_observer, dlg);
   mutt_debug(LL_DEBUG5, "window delete done\n");
 
@@ -171,7 +171,7 @@ static struct MuttWindow *mix_dlg_new(struct MixmasterPrivateData *priv,
     mutt_window_add_child(dlg, win_rbar);
   }
 
-  notify_observer_add(NeoMutt->notify, NT_CONFIG, remailer_config_observer, dlg);
+  notify_observer_add(NeoMutt->sub->notify, NT_CONFIG, remailer_config_observer, dlg);
   notify_observer_add(dlg->notify, NT_WINDOW, remailer_window_observer, dlg);
 
   return dlg;

--- a/ncrypt/dlg_gpgme.c
+++ b/ncrypt/dlg_gpgme.c
@@ -657,7 +657,7 @@ static int gpgme_key_window_observer(struct NotifyCallback *nc)
 
   struct Menu *menu = win_menu->wdata;
 
-  notify_observer_remove(NeoMutt->notify, gpgme_key_config_observer, menu);
+  notify_observer_remove(NeoMutt->sub->notify, gpgme_key_config_observer, menu);
   notify_observer_remove(win_menu->notify, gpgme_key_window_observer, win_menu);
 
   mutt_debug(LL_DEBUG5, "window delete done\n");
@@ -751,7 +751,7 @@ struct CryptKeyInfo *dlg_select_gpgme_key(struct CryptKeyInfo *keys,
   dlg->wdata = &gd;
 
   // NT_COLOR is handled by the SimpleDialog
-  notify_observer_add(NeoMutt->notify, NT_CONFIG, gpgme_key_config_observer, menu);
+  notify_observer_add(NeoMutt->sub->notify, NT_CONFIG, gpgme_key_config_observer, menu);
   notify_observer_add(menu->win->notify, NT_WINDOW, gpgme_key_window_observer, menu->win);
 
   const char *ts = NULL;

--- a/ncrypt/dlg_pgp.c
+++ b/ncrypt/dlg_pgp.c
@@ -575,7 +575,7 @@ static int pgp_key_window_observer(struct NotifyCallback *nc)
 
   struct Menu *menu = win_menu->wdata;
 
-  notify_observer_remove(NeoMutt->notify, pgp_key_config_observer, menu);
+  notify_observer_remove(NeoMutt->sub->notify, pgp_key_config_observer, menu);
   notify_observer_remove(win_menu->notify, pgp_key_window_observer, win_menu);
 
   mutt_debug(LL_DEBUG5, "window delete done\n");
@@ -669,7 +669,7 @@ struct PgpKeyInfo *dlg_select_pgp_key(struct PgpKeyInfo *keys,
   dlg->wdata = &pd;
 
   // NT_COLOR is handled by the SimpleDialog
-  notify_observer_add(NeoMutt->notify, NT_CONFIG, pgp_key_config_observer, menu);
+  notify_observer_add(NeoMutt->sub->notify, NT_CONFIG, pgp_key_config_observer, menu);
   notify_observer_add(menu->win->notify, NT_WINDOW, pgp_key_window_observer, menu->win);
 
   if (p)

--- a/pager/do_pager.c
+++ b/pager/do_pager.c
@@ -106,7 +106,7 @@ static int dopager_window_observer(struct NotifyCallback *nc)
   if (ev_w->win != dlg)
     return 0;
 
-  notify_observer_remove(NeoMutt->notify, dopager_config_observer, dlg);
+  notify_observer_remove(NeoMutt->sub->notify, dopager_config_observer, dlg);
   notify_observer_remove(dlg->notify, dopager_window_observer, dlg);
   mutt_debug(LL_DEBUG5, "window delete done\n");
 
@@ -145,7 +145,7 @@ int mutt_do_pager(struct PagerView *pview, struct Email *e)
   dlg->focus = panel_pager;
   mutt_window_add_child(dlg, panel_pager);
 
-  notify_observer_add(NeoMutt->notify, NT_CONFIG, dopager_config_observer, dlg);
+  notify_observer_add(NeoMutt->sub->notify, NT_CONFIG, dopager_config_observer, dlg);
   notify_observer_add(dlg->notify, NT_WINDOW, dopager_window_observer, dlg);
   dialog_push(dlg);
 

--- a/pager/pager.c
+++ b/pager/pager.c
@@ -399,7 +399,7 @@ static int pager_window_observer(struct NotifyCallback *nc)
 
   struct IndexSharedData *shared = dlg->wdata;
 
-  notify_observer_remove(NeoMutt->notify, pager_color_observer, win_pager);
+  mutt_color_observer_remove(pager_color_observer, win_pager);
   notify_observer_remove(NeoMutt->sub->notify, pager_config_observer, win_pager);
   notify_observer_remove(NeoMutt->notify, pager_global_observer, win_pager);
   notify_observer_remove(shared->notify, pager_index_observer, win_pager);
@@ -427,7 +427,7 @@ struct MuttWindow *pager_window_new(struct IndexSharedData *shared,
   win->recalc = pager_recalc;
   win->repaint = pager_repaint;
 
-  notify_observer_add(NeoMutt->notify, NT_COLOR, pager_color_observer, win);
+  mutt_color_observer_add(pager_color_observer, win);
   notify_observer_add(NeoMutt->sub->notify, NT_CONFIG, pager_config_observer, win);
   notify_observer_add(NeoMutt->notify, NT_GLOBAL, pager_global_observer, win);
   notify_observer_add(shared->notify, NT_ALL, pager_index_observer, win);

--- a/pager/pager.c
+++ b/pager/pager.c
@@ -400,7 +400,7 @@ static int pager_window_observer(struct NotifyCallback *nc)
   struct IndexSharedData *shared = dlg->wdata;
 
   notify_observer_remove(NeoMutt->notify, pager_color_observer, win_pager);
-  notify_observer_remove(NeoMutt->notify, pager_config_observer, win_pager);
+  notify_observer_remove(NeoMutt->sub->notify, pager_config_observer, win_pager);
   notify_observer_remove(NeoMutt->notify, pager_global_observer, win_pager);
   notify_observer_remove(shared->notify, pager_index_observer, win_pager);
   notify_observer_remove(shared->notify, pager_pager_observer, win_pager);
@@ -428,7 +428,7 @@ struct MuttWindow *pager_window_new(struct IndexSharedData *shared,
   win->repaint = pager_repaint;
 
   notify_observer_add(NeoMutt->notify, NT_COLOR, pager_color_observer, win);
-  notify_observer_add(NeoMutt->notify, NT_CONFIG, pager_config_observer, win);
+  notify_observer_add(NeoMutt->sub->notify, NT_CONFIG, pager_config_observer, win);
   notify_observer_add(NeoMutt->notify, NT_GLOBAL, pager_global_observer, win);
   notify_observer_add(shared->notify, NT_ALL, pager_index_observer, win);
   notify_observer_add(shared->notify, NT_PAGER, pager_pager_observer, win);

--- a/pager/pbar.c
+++ b/pager/pbar.c
@@ -280,7 +280,7 @@ static int pbar_window_observer(struct NotifyCallback *nc)
     struct PBarPrivateData *pbar_data = win_pbar->wdata;
     struct IndexSharedData *shared = pbar_data->shared;
 
-    notify_observer_remove(NeoMutt->notify, pbar_color_observer, win_pbar);
+    mutt_color_observer_remove(pbar_color_observer, win_pbar);
     notify_observer_remove(NeoMutt->sub->notify, pbar_config_observer, win_pbar);
     notify_observer_remove(shared->notify, pbar_index_observer, win_pbar);
     notify_observer_remove(pbar_data->priv->notify, pbar_pager_observer, win_pbar);
@@ -341,7 +341,7 @@ struct MuttWindow *pbar_new(struct IndexSharedData *shared, struct PagerPrivateD
   win_pbar->recalc = pbar_recalc;
   win_pbar->repaint = pbar_repaint;
 
-  notify_observer_add(NeoMutt->notify, NT_COLOR, pbar_color_observer, win_pbar);
+  mutt_color_observer_add(pbar_color_observer, win_pbar);
   notify_observer_add(NeoMutt->sub->notify, NT_CONFIG, pbar_config_observer, win_pbar);
   notify_observer_add(shared->notify, NT_ALL, pbar_index_observer, win_pbar);
   notify_observer_add(priv->notify, NT_PAGER, pbar_pager_observer, win_pbar);

--- a/pager/pbar.c
+++ b/pager/pbar.c
@@ -281,7 +281,7 @@ static int pbar_window_observer(struct NotifyCallback *nc)
     struct IndexSharedData *shared = pbar_data->shared;
 
     notify_observer_remove(NeoMutt->notify, pbar_color_observer, win_pbar);
-    notify_observer_remove(NeoMutt->notify, pbar_config_observer, win_pbar);
+    notify_observer_remove(NeoMutt->sub->notify, pbar_config_observer, win_pbar);
     notify_observer_remove(shared->notify, pbar_index_observer, win_pbar);
     notify_observer_remove(pbar_data->priv->notify, pbar_pager_observer, win_pbar);
     notify_observer_remove(win_pbar->notify, pbar_window_observer, win_pbar);
@@ -342,7 +342,7 @@ struct MuttWindow *pbar_new(struct IndexSharedData *shared, struct PagerPrivateD
   win_pbar->repaint = pbar_repaint;
 
   notify_observer_add(NeoMutt->notify, NT_COLOR, pbar_color_observer, win_pbar);
-  notify_observer_add(NeoMutt->notify, NT_CONFIG, pbar_config_observer, win_pbar);
+  notify_observer_add(NeoMutt->sub->notify, NT_CONFIG, pbar_config_observer, win_pbar);
   notify_observer_add(shared->notify, NT_ALL, pbar_index_observer, win_pbar);
   notify_observer_add(priv->notify, NT_PAGER, pbar_pager_observer, win_pbar);
   notify_observer_add(win_pbar->notify, NT_WINDOW, pbar_window_observer, win_pbar);

--- a/pager/ppanel.c
+++ b/pager/ppanel.c
@@ -106,7 +106,7 @@ static int ppanel_window_observer(struct NotifyCallback *nc)
   if (ev_w->win != panel_pager)
     return 0;
 
-  notify_observer_remove(NeoMutt->notify, ppanel_config_observer, panel_pager);
+  notify_observer_remove(NeoMutt->sub->notify, ppanel_config_observer, panel_pager);
   notify_observer_remove(panel_pager->notify, ppanel_window_observer, panel_pager);
   mutt_debug(LL_DEBUG5, "window delete done\n");
 
@@ -145,7 +145,7 @@ struct MuttWindow *ppanel_new(bool status_on_top, struct IndexSharedData *shared
     mutt_window_add_child(panel_pager, win_pbar);
   }
 
-  notify_observer_add(NeoMutt->notify, NT_CONFIG, ppanel_config_observer, panel_pager);
+  notify_observer_add(NeoMutt->sub->notify, NT_CONFIG, ppanel_config_observer, panel_pager);
   notify_observer_add(panel_pager->notify, NT_WINDOW, ppanel_window_observer, panel_pager);
 
   return panel_pager;

--- a/pattern/dlg_pattern.c
+++ b/pattern/dlg_pattern.c
@@ -319,7 +319,7 @@ static int pattern_window_observer(struct NotifyCallback *nc)
 
   struct Menu *menu = win_menu->wdata;
 
-  notify_observer_remove(NeoMutt->notify, pattern_config_observer, menu);
+  notify_observer_remove(NeoMutt->sub->notify, pattern_config_observer, menu);
   notify_observer_remove(win_menu->notify, pattern_window_observer, win_menu);
 
   mutt_debug(LL_DEBUG5, "window delete done\n");
@@ -344,7 +344,7 @@ bool dlg_select_pattern(char *buf, size_t buflen)
   dlg->wdata = &pd;
 
   // NT_COLOR is handled by the SimpleDialog
-  notify_observer_add(NeoMutt->notify, NT_CONFIG, pattern_config_observer, menu);
+  notify_observer_add(NeoMutt->sub->notify, NT_CONFIG, pattern_config_observer, menu);
   notify_observer_add(menu->win->notify, NT_WINDOW, pattern_window_observer, menu->win);
 
   // ---------------------------------------------------------------------------

--- a/postpone/dlg_postpone.c
+++ b/postpone/dlg_postpone.c
@@ -156,7 +156,7 @@ static int postponed_window_observer(struct NotifyCallback *nc)
 
   struct Menu *menu = win_menu->wdata;
 
-  notify_observer_remove(NeoMutt->notify, postponed_config_observer, menu);
+  notify_observer_remove(NeoMutt->sub->notify, postponed_config_observer, menu);
   notify_observer_remove(win_menu->notify, postponed_window_observer, win_menu);
 
   mutt_debug(LL_DEBUG5, "window delete done\n");
@@ -215,7 +215,7 @@ struct Email *dlg_select_postponed(struct Mailbox *m)
   dlg->wdata = &pd;
 
   // NT_COLOR is handled by the SimpleDialog
-  notify_observer_add(NeoMutt->notify, NT_CONFIG, postponed_config_observer, menu);
+  notify_observer_add(NeoMutt->sub->notify, NT_CONFIG, postponed_config_observer, menu);
   notify_observer_add(menu->win->notify, NT_WINDOW, postponed_window_observer, menu->win);
 
   struct MuttWindow *sbar = window_find_child(dlg, WT_STATUS_BAR);

--- a/sidebar/observer.c
+++ b/sidebar/observer.c
@@ -432,7 +432,7 @@ void sb_win_add_observers(struct MuttWindow *win)
   notify_observer_add(NeoMutt->notify, NT_ACCOUNT, sb_account_observer, win);
   notify_observer_add(NeoMutt->notify, NT_COLOR, sb_color_observer, win);
   notify_observer_add(NeoMutt->notify, NT_COMMAND, sb_command_observer, win);
-  notify_observer_add(NeoMutt->notify, NT_CONFIG, sb_config_observer, win);
+  notify_observer_add(NeoMutt->sub->notify, NT_CONFIG, sb_config_observer, win);
   notify_observer_add(dlg->notify, NT_ALL, sb_index_observer, win);
   notify_observer_add(NeoMutt->notify, NT_MAILBOX, sb_mailbox_observer, win);
   notify_observer_add(win->notify, NT_WINDOW, sb_window_observer, win);
@@ -452,7 +452,7 @@ void sb_win_remove_observers(struct MuttWindow *win)
   notify_observer_remove(NeoMutt->notify, sb_account_observer, win);
   notify_observer_remove(NeoMutt->notify, sb_color_observer, win);
   notify_observer_remove(NeoMutt->notify, sb_command_observer, win);
-  notify_observer_remove(NeoMutt->notify, sb_config_observer, win);
+  notify_observer_remove(NeoMutt->sub->notify, sb_config_observer, win);
   notify_observer_remove(dlg->notify, sb_index_observer, win);
   notify_observer_remove(NeoMutt->notify, sb_mailbox_observer, win);
   notify_observer_remove(win->notify, sb_window_observer, win);

--- a/sidebar/observer.c
+++ b/sidebar/observer.c
@@ -429,8 +429,8 @@ void sb_win_add_observers(struct MuttWindow *win)
 
   struct MuttWindow *dlg = window_find_parent(win, WT_DLG_INDEX);
 
+  mutt_color_observer_add(sb_color_observer, win);
   notify_observer_add(NeoMutt->notify, NT_ACCOUNT, sb_account_observer, win);
-  notify_observer_add(NeoMutt->notify, NT_COLOR, sb_color_observer, win);
   notify_observer_add(NeoMutt->notify, NT_COMMAND, sb_command_observer, win);
   notify_observer_add(NeoMutt->sub->notify, NT_CONFIG, sb_config_observer, win);
   notify_observer_add(dlg->notify, NT_ALL, sb_index_observer, win);
@@ -449,8 +449,8 @@ void sb_win_remove_observers(struct MuttWindow *win)
 
   struct MuttWindow *dlg = window_find_parent(win, WT_DLG_INDEX);
 
+  mutt_color_observer_remove(sb_color_observer, win);
   notify_observer_remove(NeoMutt->notify, sb_account_observer, win);
-  notify_observer_remove(NeoMutt->notify, sb_color_observer, win);
   notify_observer_remove(NeoMutt->notify, sb_command_observer, win);
   notify_observer_remove(NeoMutt->sub->notify, sb_config_observer, win);
   notify_observer_remove(dlg->notify, sb_index_observer, win);


### PR DESCRIPTION
Move the config and colour observers to reduce the load.

- Config: move observers from `NeoMutt` to `NeoMutt->sub` (`ConfigSubset`)
- Colour: move observers from `NeoMutt` to `ColorsNotify`
  (wrapped by `mutt_color_observer_add()`, `_remove()`)
- Remove a couple of redundant observers from `cbar_data_free()`

---

Notifications are hierarchical and pass upwards to NeoMutt.
Observers attach themselves to `Notify` objects and observe, say `NT_CONFIG`.

All notifications pass through `NeoMutt`.
The notifications _are_ filtered, but any observers on `NeoMutt` will mean more filtering.

<img width="800" src="https://raw.githubusercontent.com/neomutt/gfx/main/arch/notify.svg">
