### PR TITLE
mbyte: upgrade `mutt_mb_width()` to use `mbrtowc()`

### DIFF
--- a/mutt/mbyte.h
+++ b/mutt/mbyte.h
@@ -49,7 +49,7 @@ size_t mutt_mb_mbstowcs(wchar_t **pwbuf, size_t *pwbuflen, size_t i, const char 
 void   mutt_mb_wcstombs(char *dest, size_t dlen, const wchar_t *src, size_t slen);
 int    mutt_mb_wcswidth(const wchar_t *s, size_t n);
 int    mutt_mb_wcwidth(wchar_t wc);
-int    mutt_mb_width(const char *str, int col, bool display);
+int    mutt_mb_width(const char *str, int col, bool indent);
 size_t mutt_mb_width_ceiling(const wchar_t *s, size_t n, int w1);
 
 #endif /* MUTT_MUTT_MBYTE_H */


### PR DESCRIPTION
`mutt_mb_width()` calculates the number of screen columns some text will occupy.
e.g. `a` takes up 1 cell, `한` takes 2.

Replace `mbtowc()` with the improved version `mbrtowc()`.
(one multibyte width function with another)
This was the last case in the code.

Add some tests for `mutt_mb_width()`.

---

The change is simpler that it looks.
`mbtowc()` takes a `struct mbstate` param that we reset if we detect an illegal sequence.
Other than that, I've just renamed all the cryptic one-letter variables.