### PR TITLE
conn: do not prompt for username with client certificate

### DIFF
--- a/conn/gnutls.c
+++ b/conn/gnutls.c
@@ -697,7 +697,7 @@ static int tls_check_certificate(struct Connection *conn)
  * @param conn Connection to a server
  *
  * @note This function grabs the CN out of the client cert but appears to do
- *       nothing with it.  It does contain a call to mutt_account_getuser().
+ *       nothing with it.
  */
 static void tls_get_client_cert(struct Connection *conn)
 {
@@ -736,10 +736,6 @@ static void tls_get_client_cert(struct Connection *conn)
       goto err;
     }
     mutt_debug(LL_DEBUG2, "client certificate CN: %s\n", cn);
-
-    /* if we are using a client cert, SASL may expect an external auth name */
-    if (mutt_account_getuser(&conn->account) < 0)
-      mutt_debug(LL_DEBUG1, "Couldn't get user info\n");
   }
 
 err:

--- a/conn/openssl.c
+++ b/conn/openssl.c
@@ -613,10 +613,6 @@ static void ssl_get_client_cert(struct SslSockData *ssldata, struct Connection *
   SSL_CTX_set_default_passwd_cb(ssldata->sctx, ssl_passwd_cb);
   SSL_CTX_use_certificate_file(ssldata->sctx, c_ssl_client_cert, SSL_FILETYPE_PEM);
   SSL_CTX_use_PrivateKey_file(ssldata->sctx, c_ssl_client_cert, SSL_FILETYPE_PEM);
-
-  /* if we are using a client cert, SASL may expect an external auth name */
-  if (mutt_account_getuser(&conn->account) < 0)
-    mutt_debug(LL_DEBUG1, "Couldn't get user info\n");
 }
 
 /**


### PR DESCRIPTION
* **What does this PR do?**

Currently it is not possible to authenticate to a SMTP server using a
client certificate only as neomutt prompts for an username if one is not
provided in the configuration file. This will fail if the server doesn't
support username authentication as seems to be common with servers
expecting a client certificate.

This patch changes the behaviour so that username is only used if it's
explicitly set before the operation is started (e. g. via the
configuration file).

I haven't been able to verify whether it is possible for a server to require
both an username and a client certificate - please let me know if you are - but
this (i. e. not being prompted for the username and having to set it
beforehand) seems to be at least better than not being able to use the client
certificate functionality at all.

Possibly a better solution would be to make cancelling the prompt an option
without interrupting the sending of the message.

* **Does this PR meet the acceptance criteria?** (This is just a reminder for you,
  this section can be removed if you fulfill it.)

   - Documentation created/updated (you have to edit
     [docs/manual.xml.head](https://www.github.com/neomutt/neomutt/blob/main/docs/manual.xml.head)
     for that)

No.

   - All builds and tests are passing

`mutt_path_to_absolute` is failing but that doesn't seem to be related.

   - Added [doxygen code documentation](https://neomutt.org/dev/doxygen)
     [syntax](http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html)

Updated.

   - Code follows the [style guide](https://neomutt.org/dev/code)

I believe I have not introduced any violation.

* **What are the relevant issue numbers?**

Should close #3681.

Cc: @luchr
