### PR TITLE
replace qsort() with mutt_qsort_r()

### DIFF
--- a/alias/sort.c
+++ b/alias/sort.c
@@ -52,8 +52,8 @@ static int alias_sort_name(const void *a, const void *b, void *arg)
   if (!av_a->is_visible)
     return 0;
 
-  int r = mutt_str_coll(av_a->alias->name, av_b->alias->name);
-  return sort_reverse ? -r : r;
+  int rc = mutt_str_coll(av_a->alias->name, av_b->alias->name);
+  return sort_reverse ? -rc : rc;
 }
 
 /**
@@ -76,18 +76,18 @@ static int alias_sort_address(const void *a, const void *b, void *arg)
   if (!av_a->is_visible)
     return 0;
 
-  int r;
+  int rc;
   if (al_a == al_b)
   {
-    r = 0;
+    rc = 0;
   }
   else if (!al_a)
   {
-    r = -1;
+    rc = -1;
   }
   else if (!al_b)
   {
-    r = 1;
+    rc = 1;
   }
   else
   {
@@ -96,25 +96,25 @@ static int alias_sort_address(const void *a, const void *b, void *arg)
     if (addr_a && addr_a->personal)
     {
       if (addr_b && addr_b->personal)
-        r = buf_coll(addr_a->personal, addr_b->personal);
+        rc = buf_coll(addr_a->personal, addr_b->personal);
       else
-        r = 1;
+        rc = 1;
     }
     else if (addr_b && addr_b->personal)
     {
-      r = -1;
+      rc = -1;
     }
     else if (addr_a && addr_b)
     {
-      r = buf_coll(addr_a->mailbox, addr_b->mailbox);
+      rc = buf_coll(addr_a->mailbox, addr_b->mailbox);
     }
     else
     {
-      r = 0;
+      rc = 0;
     }
   }
 
-  return sort_reverse ? -r : r;
+  return sort_reverse ? -rc : rc;
 }
 
 /**
@@ -134,8 +134,8 @@ static int alias_sort_unsort(const void *a, const void *b, void *arg)
   if (!av_a->is_visible)
     return 0;
 
-  int r = (av_a->orig_seq - av_b->orig_seq);
-  return sort_reverse ? -r : r;
+  int rc = mutt_numeric_cmp(av_a->orig_seq, av_b->orig_seq);
+  return sort_reverse ? -rc : rc;
 }
 
 /**

--- a/alias/sort.c
+++ b/alias/sort.c
@@ -45,7 +45,7 @@ static short SortAlias = 0;
  *
  * @note Non-visible Aliases are sorted to the end
  */
-static int alias_sort_name(const void *a, const void *b)
+static int alias_sort_name(const void *a, const void *b, void *arg)
 {
   const struct AliasView *av_a = a;
   const struct AliasView *av_b = b;
@@ -66,7 +66,7 @@ static int alias_sort_name(const void *a, const void *b)
  *
  * @note Non-visible Aliases are sorted to the end
  */
-static int alias_sort_address(const void *a, const void *b)
+static int alias_sort_address(const void *a, const void *b, void *arg)
 {
   const struct AliasView *av_a = a;
   const struct AliasView *av_b = b;
@@ -126,7 +126,7 @@ static int alias_sort_address(const void *a, const void *b)
  *
  * @note Non-visible Aliases are sorted to the end
  */
-static int alias_sort_unsort(const void *a, const void *b)
+static int alias_sort_unsort(const void *a, const void *b, void *arg)
 {
   const struct AliasView *av_a = a;
   const struct AliasView *av_b = b;
@@ -172,7 +172,7 @@ void alias_array_sort(struct AliasViewArray *ava, const struct ConfigSubset *sub
     return;
 
   SortAlias = cs_subset_sort(sub, "sort_alias");
-  ARRAY_SORT(ava, alias_get_sort_function(SortAlias));
+  ARRAY_SORT(ava, alias_get_sort_function(SortAlias), NULL);
 
   struct AliasView *avp = NULL;
   ARRAY_FOREACH(avp, ava)

--- a/browser/sort.c
+++ b/browser/sort.c
@@ -43,14 +43,13 @@ static int browser_sort_subject(const void *a, const void *b, void *arg)
 {
   const struct FolderFile *pa = (const struct FolderFile *) a;
   const struct FolderFile *pb = (const struct FolderFile *) b;
-  const bool sort_reverse = *(bool *) arg;
 
   /* inbox should be sorted ahead of its siblings */
   int rc = mutt_inbox_cmp(pa->name, pb->name);
   if (rc == 0)
     rc = mutt_str_coll(pa->name, pb->name);
 
-  return sort_reverse ? -rc : rc;
+  return rc;
 }
 
 /**
@@ -62,11 +61,8 @@ static int browser_sort_order(const void *a, const void *b, void *arg)
 {
   const struct FolderFile *pa = (const struct FolderFile *) a;
   const struct FolderFile *pb = (const struct FolderFile *) b;
-  const bool sort_reverse = *(bool *) arg;
 
-  int rc = mutt_numeric_cmp(pa->gen, pb->gen);
-
-  return sort_reverse ? -rc : rc;
+  return mutt_numeric_cmp(pa->gen, pb->gen);
 }
 
 /**
@@ -76,11 +72,8 @@ static int browser_sort_desc(const void *a, const void *b, void *arg)
 {
   const struct FolderFile *pa = (const struct FolderFile *) a;
   const struct FolderFile *pb = (const struct FolderFile *) b;
-  const bool sort_reverse = *(bool *) arg;
 
-  int rc = mutt_str_coll(pa->desc, pb->desc);
-
-  return sort_reverse ? -rc : rc;
+  return mutt_str_coll(pa->desc, pb->desc);
 }
 
 /**
@@ -90,11 +83,8 @@ static int browser_sort_date(const void *a, const void *b, void *arg)
 {
   const struct FolderFile *pa = (const struct FolderFile *) a;
   const struct FolderFile *pb = (const struct FolderFile *) b;
-  const bool sort_reverse = *(bool *) arg;
 
-  int rc = mutt_numeric_cmp(pa->mtime, pb->mtime);
-
-  return sort_reverse ? -rc : rc;
+  return mutt_numeric_cmp(pa->mtime, pb->mtime);
 }
 
 /**
@@ -104,11 +94,8 @@ static int browser_sort_size(const void *a, const void *b, void *arg)
 {
   const struct FolderFile *pa = (const struct FolderFile *) a;
   const struct FolderFile *pb = (const struct FolderFile *) b;
-  const bool sort_reverse = *(bool *) arg;
 
-  int rc = mutt_numeric_cmp(pa->size, pb->size);
-
-  return sort_reverse ? -rc : rc;
+  return mutt_numeric_cmp(pa->size, pb->size);
 }
 
 /**
@@ -118,7 +105,6 @@ static int browser_sort_count(const void *a, const void *b, void *arg)
 {
   const struct FolderFile *pa = (const struct FolderFile *) a;
   const struct FolderFile *pb = (const struct FolderFile *) b;
-  const bool sort_reverse = *(bool *) arg;
 
   int rc = 0;
   if (pa->has_mailbox && pb->has_mailbox)
@@ -128,7 +114,7 @@ static int browser_sort_count(const void *a, const void *b, void *arg)
   else
     rc = 1;
 
-  return sort_reverse ? -rc : rc;
+  return rc;
 }
 
 /**
@@ -138,7 +124,6 @@ static int browser_sort_count_new(const void *a, const void *b, void *arg)
 {
   const struct FolderFile *pa = (const struct FolderFile *) a;
   const struct FolderFile *pb = (const struct FolderFile *) b;
-  const bool sort_reverse = *(bool *) arg;
 
   int rc = 0;
   if (pa->has_mailbox && pb->has_mailbox)
@@ -148,7 +133,7 @@ static int browser_sort_count_new(const void *a, const void *b, void *arg)
   else
     rc = 1;
 
-  return sort_reverse ? -rc : rc;
+  return rc;
 }
 
 /**
@@ -173,25 +158,34 @@ static int browser_compare(const void *a, const void *b, void *arg)
     if (S_ISDIR(pa->mode) != S_ISDIR(pb->mode))
       return S_ISDIR(pa->mode) ? -1 : 1;
 
-  bool sort_reverse = c_sort_browser & SORT_REVERSE;
+  int rc;
   switch (c_sort_browser & SORT_MASK)
   {
     case SORT_COUNT:
-      return browser_sort_count(a, b, &sort_reverse);
+      rc = browser_sort_count(a, b, NULL);
+      break;
     case SORT_DATE:
-      return browser_sort_date(a, b, &sort_reverse);
+      rc = browser_sort_date(a, b, NULL);
+      break;
     case SORT_DESC:
-      return browser_sort_desc(a, b, &sort_reverse);
+      rc = browser_sort_desc(a, b, NULL);
+      break;
     case SORT_SIZE:
-      return browser_sort_size(a, b, &sort_reverse);
+      rc = browser_sort_size(a, b, NULL);
+      break;
     case SORT_UNREAD:
-      return browser_sort_count_new(a, b, &sort_reverse);
+      rc = browser_sort_count_new(a, b, NULL);
+      break;
     case SORT_SUBJECT:
-      return browser_sort_subject(a, b, &sort_reverse);
+      rc = browser_sort_subject(a, b, NULL);
+      break;
     default:
     case SORT_ORDER:
-      return browser_sort_order(a, b, &sort_reverse);
+      rc = browser_sort_order(a, b, NULL);
+      break;
   }
+
+  return c_sort_browser & SORT_REVERSE ? -rc : rc;
 }
 
 /**

--- a/browser/sort.c
+++ b/browser/sort.c
@@ -154,7 +154,7 @@ static int browser_sort_count_new(const void *a, const void *b)
  * a way to tell "../" is always on the top of the list, independently of the
  * sort method.  $browser_sort_dirs_first is also handled here.
  */
-static int browser_compare(const void *a, const void *b)
+static int browser_compare(const void *a, const void *b, void *arg)
 {
   const struct FolderFile *pa = (const struct FolderFile *) a;
   const struct FolderFile *pb = (const struct FolderFile *) b;
@@ -168,7 +168,7 @@ static int browser_compare(const void *a, const void *b)
     if (S_ISDIR(pa->mode) != S_ISDIR(pb->mode))
       return S_ISDIR(pa->mode) ? -1 : 1;
 
-  const enum SortType c_sort_browser = cs_subset_sort(NeoMutt->sub, "sort_browser");
+  const enum SortType c_sort_browser = *(enum SortType *) arg;
   switch (c_sort_browser & SORT_MASK)
   {
     case SORT_COUNT:
@@ -198,7 +198,7 @@ static int browser_compare(const void *a, const void *b)
  */
 void browser_sort(struct BrowserState *state)
 {
-  const enum SortType c_sort_browser = cs_subset_sort(NeoMutt->sub, "sort_browser");
+  enum SortType c_sort_browser = cs_subset_sort(NeoMutt->sub, "sort_browser");
   switch (c_sort_browser & SORT_MASK)
   {
 #ifdef USE_NNTP
@@ -211,5 +211,5 @@ void browser_sort(struct BrowserState *state)
       break;
   }
 
-  ARRAY_SORT(&state->entry, browser_compare);
+  ARRAY_SORT(&state->entry, browser_compare, &c_sort_browser);
 }

--- a/browser/sort.c
+++ b/browser/sort.c
@@ -38,17 +38,18 @@
 /**
  * browser_sort_subject - Compare the subject of two browser entries - Implements ::sort_t - @ingroup sort_api
  */
-static int browser_sort_subject(const void *a, const void *b)
+static int browser_sort_subject(const void *a, const void *b, void *arg)
 {
   const struct FolderFile *pa = (const struct FolderFile *) a;
   const struct FolderFile *pb = (const struct FolderFile *) b;
+  const bool sort_reverse = *(bool *) arg;
 
   /* inbox should be sorted ahead of its siblings */
   int r = mutt_inbox_cmp(pa->name, pb->name);
   if (r == 0)
     r = mutt_str_coll(pa->name, pb->name);
-  const enum SortType c_sort_browser = cs_subset_sort(NeoMutt->sub, "sort_browser");
-  return (c_sort_browser & SORT_REVERSE) ? -r : r;
+
+  return sort_reverse ? -r : r;
 }
 
 /**
@@ -56,64 +57,65 @@ static int browser_sort_subject(const void *a, const void *b)
  *
  * @note This only affects browsing mailboxes and is a no-op for folders.
  */
-static int browser_sort_order(const void *a, const void *b)
+static int browser_sort_order(const void *a, const void *b, void *arg)
 {
   const struct FolderFile *pa = (const struct FolderFile *) a;
   const struct FolderFile *pb = (const struct FolderFile *) b;
+  const bool sort_reverse = *(bool *) arg;
 
-  const enum SortType c_sort_browser = cs_subset_sort(NeoMutt->sub, "sort_browser");
-  return ((c_sort_browser & SORT_REVERSE) ? -1 : 1) * (pa->gen - pb->gen);
+  return (sort_reverse ? -1 : 1) * (pa->gen - pb->gen);
 }
 
 /**
  * browser_sort_desc - Compare the descriptions of two browser entries - Implements ::sort_t - @ingroup sort_api
  */
-static int browser_sort_desc(const void *a, const void *b)
+static int browser_sort_desc(const void *a, const void *b, void *arg)
 {
   const struct FolderFile *pa = (const struct FolderFile *) a;
   const struct FolderFile *pb = (const struct FolderFile *) b;
+  const bool sort_reverse = *(bool *) arg;
 
   int r = mutt_str_coll(pa->desc, pb->desc);
 
-  const enum SortType c_sort_browser = cs_subset_sort(NeoMutt->sub, "sort_browser");
-  return (c_sort_browser & SORT_REVERSE) ? -r : r;
+  return sort_reverse ? -r : r;
 }
 
 /**
  * browser_sort_date - Compare the date of two browser entries - Implements ::sort_t - @ingroup sort_api
  */
-static int browser_sort_date(const void *a, const void *b)
+static int browser_sort_date(const void *a, const void *b, void *arg)
 {
   const struct FolderFile *pa = (const struct FolderFile *) a;
   const struct FolderFile *pb = (const struct FolderFile *) b;
+  const bool sort_reverse = *(bool *) arg;
 
   int r = pa->mtime - pb->mtime;
 
-  const enum SortType c_sort_browser = cs_subset_sort(NeoMutt->sub, "sort_browser");
-  return (c_sort_browser & SORT_REVERSE) ? -r : r;
+  return sort_reverse ? -r : r;
 }
 
 /**
  * browser_sort_size - Compare the size of two browser entries - Implements ::sort_t - @ingroup sort_api
  */
-static int browser_sort_size(const void *a, const void *b)
+static int browser_sort_size(const void *a, const void *b, void *arg)
 {
   const struct FolderFile *pa = (const struct FolderFile *) a;
   const struct FolderFile *pb = (const struct FolderFile *) b;
+  const bool sort_reverse = *(bool *) arg;
 
   int r = pa->size - pb->size;
 
-  const enum SortType c_sort_browser = cs_subset_sort(NeoMutt->sub, "sort_browser");
-  return (c_sort_browser & SORT_REVERSE) ? -r : r;
+  return sort_reverse ? -r : r;
 }
 
 /**
  * browser_sort_count - Compare the message count of two browser entries - Implements ::sort_t - @ingroup sort_api
  */
-static int browser_sort_count(const void *a, const void *b)
+static int browser_sort_count(const void *a, const void *b, void *arg)
 {
   const struct FolderFile *pa = (const struct FolderFile *) a;
   const struct FolderFile *pb = (const struct FolderFile *) b;
+  const bool sort_reverse = *(bool *) arg;
 
   int r = 0;
   if (pa->has_mailbox && pb->has_mailbox)
@@ -123,17 +125,17 @@ static int browser_sort_count(const void *a, const void *b)
   else
     r = 1;
 
-  const enum SortType c_sort_browser = cs_subset_sort(NeoMutt->sub, "sort_browser");
-  return (c_sort_browser & SORT_REVERSE) ? -r : r;
+  return sort_reverse ? -r : r;
 }
 
 /**
  * browser_sort_count_new - Compare the new count of two browser entries - Implements ::sort_t - @ingroup sort_api
  */
-static int browser_sort_count_new(const void *a, const void *b)
+static int browser_sort_count_new(const void *a, const void *b, void *arg)
 {
   const struct FolderFile *pa = (const struct FolderFile *) a;
   const struct FolderFile *pb = (const struct FolderFile *) b;
+  const bool sort_reverse = *(bool *) arg;
 
   int r = 0;
   if (pa->has_mailbox && pb->has_mailbox)
@@ -143,8 +145,7 @@ static int browser_sort_count_new(const void *a, const void *b)
   else
     r = 1;
 
-  const enum SortType c_sort_browser = cs_subset_sort(NeoMutt->sub, "sort_browser");
-  return (c_sort_browser & SORT_REVERSE) ? -r : r;
+  return sort_reverse ? -r : r;
 }
 
 /**
@@ -158,6 +159,7 @@ static int browser_compare(const void *a, const void *b, void *arg)
 {
   const struct FolderFile *pa = (const struct FolderFile *) a;
   const struct FolderFile *pb = (const struct FolderFile *) b;
+  const enum SortType c_sort_browser = *(enum SortType *) arg;
 
   if ((mutt_str_coll(pa->desc, "../") == 0) || (mutt_str_coll(pa->desc, "..") == 0))
     return -1;
@@ -168,24 +170,24 @@ static int browser_compare(const void *a, const void *b, void *arg)
     if (S_ISDIR(pa->mode) != S_ISDIR(pb->mode))
       return S_ISDIR(pa->mode) ? -1 : 1;
 
-  const enum SortType c_sort_browser = *(enum SortType *) arg;
+  bool sort_reverse = c_sort_browser & SORT_REVERSE;
   switch (c_sort_browser & SORT_MASK)
   {
     case SORT_COUNT:
-      return browser_sort_count(a, b);
+      return browser_sort_count(a, b, &sort_reverse);
     case SORT_DATE:
-      return browser_sort_date(a, b);
+      return browser_sort_date(a, b, &sort_reverse);
     case SORT_DESC:
-      return browser_sort_desc(a, b);
+      return browser_sort_desc(a, b, &sort_reverse);
     case SORT_SIZE:
-      return browser_sort_size(a, b);
+      return browser_sort_size(a, b, &sort_reverse);
     case SORT_UNREAD:
-      return browser_sort_count_new(a, b);
+      return browser_sort_count_new(a, b, &sort_reverse);
     case SORT_SUBJECT:
-      return browser_sort_subject(a, b);
+      return browser_sort_subject(a, b, &sort_reverse);
     default:
     case SORT_ORDER:
-      return browser_sort_order(a, b);
+      return browser_sort_order(a, b, &sort_reverse);
   }
 }
 

--- a/browser/sort.c
+++ b/browser/sort.c
@@ -31,6 +31,7 @@
 #include "mutt/lib.h"
 #include "config/lib.h"
 #include "core/lib.h"
+#include "sort.h"
 #include "lib.h"
 #include "globals.h"
 #include "muttlib.h"
@@ -45,11 +46,11 @@ static int browser_sort_subject(const void *a, const void *b, void *arg)
   const bool sort_reverse = *(bool *) arg;
 
   /* inbox should be sorted ahead of its siblings */
-  int r = mutt_inbox_cmp(pa->name, pb->name);
-  if (r == 0)
-    r = mutt_str_coll(pa->name, pb->name);
+  int rc = mutt_inbox_cmp(pa->name, pb->name);
+  if (rc == 0)
+    rc = mutt_str_coll(pa->name, pb->name);
 
-  return sort_reverse ? -r : r;
+  return sort_reverse ? -rc : rc;
 }
 
 /**
@@ -63,7 +64,9 @@ static int browser_sort_order(const void *a, const void *b, void *arg)
   const struct FolderFile *pb = (const struct FolderFile *) b;
   const bool sort_reverse = *(bool *) arg;
 
-  return (sort_reverse ? -1 : 1) * (pa->gen - pb->gen);
+  int rc = mutt_numeric_cmp(pa->gen, pb->gen);
+
+  return sort_reverse ? -rc : rc;
 }
 
 /**
@@ -75,9 +78,9 @@ static int browser_sort_desc(const void *a, const void *b, void *arg)
   const struct FolderFile *pb = (const struct FolderFile *) b;
   const bool sort_reverse = *(bool *) arg;
 
-  int r = mutt_str_coll(pa->desc, pb->desc);
+  int rc = mutt_str_coll(pa->desc, pb->desc);
 
-  return sort_reverse ? -r : r;
+  return sort_reverse ? -rc : rc;
 }
 
 /**
@@ -89,9 +92,9 @@ static int browser_sort_date(const void *a, const void *b, void *arg)
   const struct FolderFile *pb = (const struct FolderFile *) b;
   const bool sort_reverse = *(bool *) arg;
 
-  int r = pa->mtime - pb->mtime;
+  int rc = mutt_numeric_cmp(pa->mtime, pb->mtime);
 
-  return sort_reverse ? -r : r;
+  return sort_reverse ? -rc : rc;
 }
 
 /**
@@ -103,9 +106,9 @@ static int browser_sort_size(const void *a, const void *b, void *arg)
   const struct FolderFile *pb = (const struct FolderFile *) b;
   const bool sort_reverse = *(bool *) arg;
 
-  int r = pa->size - pb->size;
+  int rc = mutt_numeric_cmp(pa->size, pb->size);
 
-  return sort_reverse ? -r : r;
+  return sort_reverse ? -rc : rc;
 }
 
 /**
@@ -117,15 +120,15 @@ static int browser_sort_count(const void *a, const void *b, void *arg)
   const struct FolderFile *pb = (const struct FolderFile *) b;
   const bool sort_reverse = *(bool *) arg;
 
-  int r = 0;
+  int rc = 0;
   if (pa->has_mailbox && pb->has_mailbox)
-    r = pa->msg_count - pb->msg_count;
+    rc = mutt_numeric_cmp(pa->msg_count, pb->msg_count);
   else if (pa->has_mailbox)
-    r = -1;
+    rc = -1;
   else
-    r = 1;
+    rc = 1;
 
-  return sort_reverse ? -r : r;
+  return sort_reverse ? -rc : rc;
 }
 
 /**
@@ -137,15 +140,15 @@ static int browser_sort_count_new(const void *a, const void *b, void *arg)
   const struct FolderFile *pb = (const struct FolderFile *) b;
   const bool sort_reverse = *(bool *) arg;
 
-  int r = 0;
+  int rc = 0;
   if (pa->has_mailbox && pb->has_mailbox)
-    r = pa->msg_unread - pb->msg_unread;
+    rc = mutt_numeric_cmp(pa->msg_unread, pb->msg_unread);
   else if (pa->has_mailbox)
-    r = -1;
+    rc = -1;
   else
-    r = 1;
+    rc = 1;
 
-  return sort_reverse ? -r : r;
+  return sort_reverse ? -rc : rc;
 }
 
 /**

--- a/commands.c
+++ b/commands.c
@@ -767,7 +767,7 @@ enum CommandResult set_dump(ConfigDumpFlags flags, struct Buffer *err)
 }
 
 /**
- * envlist_sort - Sort two environment strings
+ * envlist_sort - Sort two environment strings - Implements ::sort_t - @ingroup sort_api
  * @param a   First string
  * @param b   Second string
  * @param arg (not used)

--- a/commands.c
+++ b/commands.c
@@ -768,13 +768,14 @@ enum CommandResult set_dump(ConfigDumpFlags flags, struct Buffer *err)
 
 /**
  * envlist_sort - Sort two environment strings
- * @param a First string
- * @param b Second string
+ * @param a   First string
+ * @param b   Second string
+ * @param arg (not used)
  * @retval -1 a precedes b
  * @retval  0 a and b are identical
  * @retval  1 b precedes a
  */
-static int envlist_sort(const void *a, const void *b)
+static int envlist_sort(const void *a, const void *b, void *arg)
 {
   return strcmp(*(const char **) a, *(const char **) b);
 }
@@ -815,7 +816,7 @@ static enum CommandResult parse_setenv(struct Buffer *buf, struct Buffer *s,
     for (char **env = EnvList; *env; env++)
       count++;
 
-    qsort(EnvList, count, sizeof(char *), envlist_sort);
+    mutt_qsort_r(EnvList, count, sizeof(char *), envlist_sort, NULL);
 
     for (char **env = EnvList; *env; env++)
       fprintf(fp_out, "%s\n", *env);

--- a/complete/helpers.c
+++ b/complete/helpers.c
@@ -344,7 +344,7 @@ int mutt_command_complete(struct CompletionData *cd, struct Buffer *buf, int pos
 }
 
 /**
- * label_sort - Sort two label strings
+ * label_sort - Sort two label strings - Implements ::sort_t - @ingroup sort_api
  * @param a   First string
  * @param b   Second string
  * @param arg (not used)

--- a/complete/helpers.c
+++ b/complete/helpers.c
@@ -345,13 +345,14 @@ int mutt_command_complete(struct CompletionData *cd, struct Buffer *buf, int pos
 
 /**
  * label_sort - Sort two label strings
- * @param a First string
- * @param b Second string
+ * @param a   First string
+ * @param b   Second string
+ * @param arg (not used)
  * @retval -1 a precedes b
  * @retval  0 a and b are identical
  * @retval  1 b precedes a
  */
-static int label_sort(const void *a, const void *b)
+static int label_sort(const void *a, const void *b, void *arg)
 {
   return strcasecmp(*(const char **) a, *(const char **) b);
 }
@@ -387,7 +388,7 @@ int mutt_label_complete(struct CompletionData *cd, struct Buffer *buf, int numta
     while ((he = mutt_hash_walk(m_cur->label_hash, &hws)))
       candidate(cd, cd->user_typed, he->key.strkey, cd->completed, sizeof(cd->completed));
     matches_ensure_morespace(cd, cd->num_matched);
-    qsort(cd->match_list, cd->num_matched, sizeof(char *), label_sort);
+    mutt_qsort_r(cd->match_list, cd->num_matched, sizeof(char *), label_sort, NULL);
     cd->match_list[cd->num_matched++] = cd->user_typed;
 
     /* All matches are stored. Longest non-ambiguous string is ""

--- a/config/subset.c
+++ b/config/subset.c
@@ -53,11 +53,12 @@ static const struct Mapping ConfigEventNames[] = {
  * elem_list_sort - Sort two HashElem pointers to config
  * @param a First HashElem
  * @param b Second HashElem
+ * @param arg (not used)
  * @retval -1 a precedes b
  * @retval  0 a and b are identical
  * @retval  1 b precedes a
  */
-int elem_list_sort(const void *a, const void *b)
+int elem_list_sort(const void *a, const void *b, void *arg)
 {
   if (!a || !b)
     return 0;
@@ -91,7 +92,7 @@ struct HashElem **get_elem_list(struct ConfigSet *cs)
       break; /* LCOV_EXCL_LINE */
   }
 
-  qsort(he_list, index, sizeof(struct HashElem *), elem_list_sort);
+  mutt_qsort_r(he_list, index, sizeof(struct HashElem *), elem_list_sort, NULL);
 
   return he_list;
 }

--- a/config/subset.c
+++ b/config/subset.c
@@ -50,7 +50,7 @@ static const struct Mapping ConfigEventNames[] = {
 };
 
 /**
- * elem_list_sort - Sort two HashElem pointers to config
+ * elem_list_sort - Sort two HashElem pointers to config - Implements ::sort_t - @ingroup sort_api
  * @param a First HashElem
  * @param b Second HashElem
  * @param arg (not used)

--- a/config/subset.h
+++ b/config/subset.h
@@ -99,7 +99,7 @@ int      cs_subset_str_string_plus_equals (const struct ConfigSubset *sub, const
 int      cs_subset_str_string_set         (const struct ConfigSubset *sub, const char *name,    const char *value, struct Buffer *err);
 int      cs_subset_str_delete             (const struct ConfigSubset *sub, const char *name,                       struct Buffer *err);
 
-int               elem_list_sort(const void *a, const void *b);
+int               elem_list_sort(const void *a, const void *b, void *arg);
 struct HashElem **get_elem_list(struct ConfigSet *cs);
 
 #endif /* MUTT_CONFIG_SUBSET_H */

--- a/core/command.c
+++ b/core/command.c
@@ -37,7 +37,7 @@ static struct CommandArray Commands = ARRAY_HEAD_INITIALIZER;
 /**
  * commands_sort - Compare two commands by name - Implements ::sort_t - @ingroup sort_api
  */
-static int commands_sort(const void *a, const void *b)
+static int commands_sort(const void *a, const void *b, void *arg)
 {
   struct Command x = *(const struct Command *) a;
   struct Command y = *(const struct Command *) b;
@@ -56,7 +56,7 @@ void commands_register(const struct Command *cmds, const size_t num_cmds)
   {
     ARRAY_ADD(&Commands, cmds[i]);
   }
-  ARRAY_SORT(&Commands, commands_sort);
+  ARRAY_SORT(&Commands, commands_sort, NULL);
 }
 
 /**

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -887,7 +887,7 @@ bool imap_has_flag(struct ListHead *flag_list, const char *flag)
 }
 
 /**
- * imap_sort_email_uid - Compare two Emails by UID
+ * imap_sort_email_uid - Compare two Emails by UID - Implements ::sort_t - @ingroup sort_api
  * @param a First  email to compare
  * @param b Second email to compare
  * @param arg (not used)
@@ -1388,7 +1388,7 @@ int imap_fast_trash(struct Mailbox *m, const char *dest)
   {
     struct UidArray uida = ARRAY_HEAD_INITIALIZER;
     select_email_uids(m->emails, m->msg_count, MUTT_TRASH, false, false, &uida);
-    ARRAY_SORT(&uida, imap_sort_uid);
+    ARRAY_SORT(&uida, imap_sort_uid, NULL);
     rc = imap_exec_msg_set(adata, "UID COPY", dest_mdata->munge_name, &uida);
     if (rc == 0)
     {
@@ -1488,7 +1488,7 @@ enum MxStatus imap_sync_mailbox(struct Mailbox *m, bool expunge, bool close)
   {
     struct UidArray uida = ARRAY_HEAD_INITIALIZER;
     select_email_uids(m->emails, m->msg_count, MUTT_DELETED, true, false, &uida);
-    ARRAY_SORT(&uida, imap_sort_uid);
+    ARRAY_SORT(&uida, imap_sort_uid, NULL);
     rc = imap_exec_msg_set(adata, "UID STORE", "+FLAGS.SILENT (\\Deleted)", &uida);
     ARRAY_FREE(&uida);
     if (rc < 0)

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -887,9 +887,15 @@ bool imap_has_flag(struct ListHead *flag_list, const char *flag)
 }
 
 /**
- * imap_sort_email_uid - Compare two Emails by UID - Implements ::sort_t - @ingroup sort_api
+ * imap_sort_email_uid - Compare two Emails by UID
+ * @param a First  email to compare
+ * @param b Second email to compare
+ * @param arg (not used)
+ * @retval -1 a precedes b
+ * @retval  0 a and b are identical
+ * @retval  1 b precedes a
  */
-static int imap_sort_email_uid(const void *a, const void *b)
+static int imap_sort_email_uid(const void *a, const void *b, void *arg)
 {
   const struct Email *ea = *(struct Email const *const *) a;
   const struct Email *eb = *(struct Email const *const *) b;
@@ -1567,7 +1573,7 @@ enum MxStatus imap_sync_mailbox(struct Mailbox *m, bool expunge, bool close)
   /* presort here to avoid doing 10 resorts in imap_exec_msg_set */
   emails = mutt_mem_malloc(m->msg_count * sizeof(struct Email *));
   memcpy(emails, m->emails, m->msg_count * sizeof(struct Email *));
-  qsort(emails, m->msg_count, sizeof(struct Email *), imap_sort_email_uid);
+  mutt_qsort_r(emails, m->msg_count, sizeof(struct Email *), imap_sort_email_uid, NULL);
 
   rc = sync_helper(m, emails, m->msg_count, MUTT_ACL_DELETE, MUTT_DELETED, "\\Deleted");
   if (rc >= 0)

--- a/imap/message.c
+++ b/imap/message.c
@@ -1650,7 +1650,7 @@ static int emails_to_uid_array(struct EmailArray *ea, struct UidArray *uida)
 
     ARRAY_ADD(uida, edata->uid);
   }
-  ARRAY_SORT(uida, imap_sort_uid);
+  ARRAY_SORT(uida, imap_sort_uid, NULL);
 
   return ARRAY_SIZE(uida);
 }

--- a/imap/msg_set.c
+++ b/imap/msg_set.c
@@ -51,7 +51,7 @@ int ImapMaxCmdlen = 8192;
 /**
  * imap_sort_uid - Compare two UIDs - Implements ::sort_t - @ingroup sort_api
  */
-int imap_sort_uid(const void *a, const void *b)
+int imap_sort_uid(const void *a, const void *b, void *arg)
 {
   unsigned int ua = *(unsigned int *) a;
   unsigned int ub = *(unsigned int *) b;

--- a/imap/msg_set.h
+++ b/imap/msg_set.h
@@ -29,7 +29,7 @@ struct ImapAccountData;
 /// Set of Email UIDs to work on
 ARRAY_HEAD(UidArray, unsigned int);
 
-int imap_sort_uid(const void *a, const void *b);
+int imap_sort_uid(const void *a, const void *b, void *arg);
 int imap_make_msg_set(struct UidArray *uida, struct Buffer *buf, int *pos);
 int imap_exec_msg_set(struct ImapAccountData *adata, const char *pre, const char *post, struct UidArray *uida);
 

--- a/maildir/maildir.c
+++ b/maildir/maildir.c
@@ -191,7 +191,7 @@ cleanup:
 }
 
 /**
- * maildir_sort_flags - Compare two flag characters
+ * maildir_sort_flags - Compare two flag characters - Implements ::sort_t - @ingroup sort_api
  * @param a First  character to compare
  * @param b Second character to compare
  * @param arg (not used)
@@ -521,7 +521,7 @@ static void maildir_update_mtime(struct Mailbox *m)
 /**
  * maildir_sort_inode - Compare two Maildirs by inode number - Implements ::sort_t - @ingroup sort_api
  */
-static int maildir_sort_inode(const void *a, const void *b)
+static int maildir_sort_inode(const void *a, const void *b, void *arg)
 {
   const struct MdEmail *ma = *(struct MdEmail **) a;
   const struct MdEmail *mb = *(struct MdEmail **) b;
@@ -590,7 +590,7 @@ static int maildir_parse_dir(struct Mailbox *m, struct MdEmailArray *mda,
     return -2; /* action aborted */
   }
 
-  ARRAY_SORT(mda, maildir_sort_inode);
+  ARRAY_SORT(mda, maildir_sort_inode, NULL);
 
 cleanup:
   buf_pool_release(&buf);

--- a/maildir/maildir.c
+++ b/maildir/maildir.c
@@ -191,14 +191,15 @@ cleanup:
 }
 
 /**
- * maildir_sort_flags - Compare two flag characters - Implements ::sort_t - @ingroup sort_api
+ * maildir_sort_flags - Compare two flag characters
  * @param a First  character to compare
  * @param b Second character to compare
+ * @param arg (not used)
  * @retval -1 a precedes b
  * @retval  0 a and b are identical
  * @retval  1 b precedes a
  */
-static int maildir_sort_flags(const void *a, const void *b)
+static int maildir_sort_flags(const void *a, const void *b, void *arg)
 {
   return mutt_numeric_cmp(*((const char *) a), *((const char *) b));
 }
@@ -231,7 +232,7 @@ void maildir_gen_flags(char *dest, size_t destlen, struct Email *e)
     snprintf(tmp, sizeof(tmp), "%s%s%s%s%s", e->flagged ? "F" : "", e->replied ? "R" : "",
              e->read ? "S" : "", e->deleted ? "T" : "", NONULL(flags));
     if (flags)
-      qsort(tmp, strlen(tmp), 1, maildir_sort_flags);
+      mutt_qsort_r(tmp, strlen(tmp), 1, maildir_sort_flags, NULL);
 
     const char c_maildir_field_delimiter = *cc_maildir_field_delimiter();
     snprintf(dest, destlen, "%c2,%s", c_maildir_field_delimiter, tmp);

--- a/maildir/mh.c
+++ b/maildir/mh.c
@@ -545,11 +545,11 @@ cleanup:
 /**
  * mh_sort_path - Compare two Maildirs by path - Implements ::sort_t - @ingroup sort_api
  */
-static int mh_sort_path(const void *a, const void *b)
+static int mh_sort_path(const void *a, const void *b, void *arg)
 {
-  struct MdEmail const *const *pa = (struct MdEmail const *const *) a;
-  struct MdEmail const *const *pb = (struct MdEmail const *const *) b;
-  return mutt_str_cmp((*pa)->email->path, (*pb)->email->path);
+  struct MdEmail const *pa = *(struct MdEmail const *const *) a;
+  struct MdEmail const *pb = *(struct MdEmail const *const *) b;
+  return mutt_str_cmp(pa->email->path, pb->email->path);
 }
 
 /**
@@ -671,7 +671,7 @@ static void mh_delayed_parsing(struct Mailbox *m, struct MdEmailArray *mda,
   if (m && mda && (ARRAY_SIZE(mda) > 0) && (c_sort == SORT_ORDER))
   {
     mutt_debug(LL_DEBUG3, "maildir: sorting %s into natural order\n", mailbox_path(m));
-    ARRAY_SORT(mda, mh_sort_path);
+    ARRAY_SORT(mda, mh_sort_path, NULL);
   }
 }
 

--- a/mutt/array.h
+++ b/mutt/array.h
@@ -273,9 +273,11 @@
  * ARRAY_SORT - Sort an array
  * @param head Pointer to a struct defined using ARRAY_HEAD()
  * @param fn   Sort function, see ::sort_t
+ * @param arg  Opaque argument to pass to sort function
  */
-#define ARRAY_SORT(head, fn)                                                   \
-  ((head)->entries && (qsort((head)->entries, ARRAY_SIZE(head), ARRAY_ELEM_SIZE(head), (fn)), true))
+#define ARRAY_SORT(head, fn, arg)                                              \
+  ((head)->entries &&                                                          \
+   (mutt_qsort_r((head)->entries, ARRAY_SIZE(head), ARRAY_ELEM_SIZE(head), (fn), (arg)), true))
 
 /******************************************************************************
  * Internal APIs

--- a/mutt_thread.c
+++ b/mutt_thread.c
@@ -742,7 +742,7 @@ void mutt_clear_threads(struct ThreadsContext *tctx)
 }
 
 /**
- * compare_threads - qsort_r() function for comparing email threads
+ * compare_threads - qsort_r() function for comparing email threads - Implements ::sort_t - @ingroup sort_api
  * @param a   First thread to compare
  * @param b   Second thread to compare
  * @param arg ThreadsContext for how to compare

--- a/muttlib.c
+++ b/muttlib.c
@@ -1554,7 +1554,7 @@ void mutt_get_parent_path(const char *path, char *buf, size_t buflen)
 }
 
 /**
- * mutt_inbox_cmp - Do two folders share the same path and one is an inbox
+ * mutt_inbox_cmp - Do two folders share the same path and one is an inbox - @ingroup sort_api
  * @param a First path
  * @param b Second path
  * @retval -1 a is INBOX of b

--- a/ncrypt/dlg_gpgme.c
+++ b/ncrypt/dlg_gpgme.c
@@ -89,6 +89,7 @@
 #include "mutt_logging.h"
 #include "muttlib.h"
 #include "opcodes.h"
+#include "sort.h"
 
 /// Help Bar for the GPGME key selection dialog
 static const struct Mapping GpgmeHelp[] = {
@@ -130,7 +131,7 @@ static int crypt_compare_key_address(const void *a, const void *b)
 }
 
 /**
- * crypt_compare_address_qsort - Compare the addresses of two keys
+ * crypt_compare_address_qsort - Compare the addresses of two keys - Implements ::sort_t - @ingroup sort_api
  * @param a   First key
  * @param b   Second key
  * @param arg Boolean indicating reverse sort order
@@ -165,7 +166,7 @@ static int crypt_compare_keyid(const void *a, const void *b)
 }
 
 /**
- * crypt_compare_keyid_qsort - Compare the IDs of two keys
+ * crypt_compare_keyid_qsort - Compare the IDs of two keys - Implements ::sort_t - @ingroup sort_api
  * @param a   First key ID
  * @param b   Second key ID
  * @param arg Boolean indicating reverse sort order
@@ -207,7 +208,7 @@ static int crypt_compare_key_date(const void *a, const void *b)
 }
 
 /**
- * crypt_compare_date_qsort - Compare the dates of two keys
+ * crypt_compare_date_qsort - Compare the dates of two keys - Implements ::sort_t - @ingroup sort_api
  * @param a   First key
  * @param b   Second key
  * @param arg Boolean indicating reverse sort order
@@ -271,7 +272,7 @@ static int crypt_compare_key_trust(const void *a, const void *b)
 }
 
 /**
- * crypt_compare_trust_qsort - Compare the trust levels of two keys
+ * crypt_compare_trust_qsort - Compare the trust levels of two keys - Implements ::sort_t - @ingroup sort_api
  * @param a   First key
  * @param b   Second key
  * @param arg Boolean indicating reverse sort order
@@ -682,7 +683,7 @@ struct CryptKeyInfo *dlg_select_gpgme_key(struct CryptKeyInfo *keys,
 {
   int keymax;
   int i;
-  int (*f)(const void *, const void *, void *); // TODO: use sort_t
+  sort_t f = NULL;
   enum MenuType menu_to_use = MENU_GENERIC;
   bool unusable = false;
 

--- a/ncrypt/dlg_pgp.c
+++ b/ncrypt/dlg_pgp.c
@@ -89,6 +89,7 @@
 #include "pgp_functions.h"
 #include "pgpkey.h"
 #include "pgplib.h"
+#include "sort.h"
 
 /// Help Bar for the PGP key selection dialog
 static const struct Mapping PgpHelp[] = {
@@ -134,7 +135,7 @@ static int pgp_compare_key_address(const void *a, const void *b)
 }
 
 /**
- * pgp_compare_address_qsort - Compare the addresses of two PGP keys
+ * pgp_compare_address_qsort - Compare the addresses of two PGP keys - Implements ::sort_t - @ingroup sort_api
  * @param a   First address
  * @param b   Second address
  * @param arg Boolean indicating reverse sort order
@@ -168,7 +169,7 @@ static int pgp_compare_key_date(const void *a, const void *b)
 }
 
 /**
- * pgp_compare_date_qsort - Compare the dates of two PGP keys
+ * pgp_compare_date_qsort - Compare the dates of two PGP keys - Implements ::sort_t - @ingroup sort_api
  * @param a   First key
  * @param b   Second key
  * @param arg Boolean indicating reverse sort order
@@ -202,7 +203,7 @@ static int pgp_compare_keyid(const void *a, const void *b)
 }
 
 /**
- * pgp_compare_keyid_qsort - Compare key IDs
+ * pgp_compare_keyid_qsort - Compare key IDs - Implements ::sort_t - @ingroup sort_api
  * @param a   First key ID
  * @param b   Second key ID
  * @param arg Boolean indicating reverse sort order
@@ -252,7 +253,7 @@ static int pgp_compare_key_trust(const void *a, const void *b)
 }
 
 /**
- * pgp_compare_trust_qsort - Compare the trust levels of two PGP keys
+ * pgp_compare_trust_qsort - Compare the trust levels of two PGP keys - Implements ::sort_t - @ingroup sort_api
  * @param a   First key
  * @param b   Second key
  * @param arg Boolean indicating reverse sort order
@@ -635,7 +636,7 @@ struct PgpKeyInfo *dlg_select_pgp_key(struct PgpKeyInfo *keys,
     return NULL;
   }
 
-  int (*f)(const void *, const void *, void *); // TODO: use sort_t
+  sort_t f = NULL;
   short c_pgp_sort_keys = cs_subset_sort(NeoMutt->sub, "pgp_sort_keys");
   switch (c_pgp_sort_keys & SORT_MASK)
   {

--- a/sidebar/sort.c
+++ b/sidebar/sort.c
@@ -41,7 +41,7 @@ static bool SbSortReverse = false;
 /**
  * sb_sort_count - Sort Sidebar entries by count - Implements ::sort_t - @ingroup sort_api
  */
-static int sb_sort_count(const void *a, const void *b)
+static int sb_sort_count(const void *a, const void *b, void *arg)
 {
   const struct SbEntry *sbe1 = *(struct SbEntry const *const *) a;
   const struct SbEntry *sbe2 = *(struct SbEntry const *const *) b;
@@ -62,7 +62,7 @@ static int sb_sort_count(const void *a, const void *b)
 /**
  * sb_sort_desc - Sort Sidebar entries by description - Implements ::sort_t - @ingroup sort_api
  */
-static int sb_sort_desc(const void *a, const void *b)
+static int sb_sort_desc(const void *a, const void *b, void *arg)
 {
   const struct SbEntry *sbe1 = *(struct SbEntry const *const *) a;
   const struct SbEntry *sbe2 = *(struct SbEntry const *const *) b;
@@ -79,7 +79,7 @@ static int sb_sort_desc(const void *a, const void *b)
 /**
  * sb_sort_flagged - Sort Sidebar entries by flagged - Implements ::sort_t - @ingroup sort_api
  */
-static int sb_sort_flagged(const void *a, const void *b)
+static int sb_sort_flagged(const void *a, const void *b, void *arg)
 {
   const struct SbEntry *sbe1 = *(struct SbEntry const *const *) a;
   const struct SbEntry *sbe2 = *(struct SbEntry const *const *) b;
@@ -100,7 +100,7 @@ static int sb_sort_flagged(const void *a, const void *b)
 /**
  * sb_sort_path - Sort Sidebar entries by path - Implements ::sort_t - @ingroup sort_api
  */
-static int sb_sort_path(const void *a, const void *b)
+static int sb_sort_path(const void *a, const void *b, void *arg)
 {
   const struct SbEntry *sbe1 = *(struct SbEntry const *const *) a;
   const struct SbEntry *sbe2 = *(struct SbEntry const *const *) b;
@@ -120,7 +120,7 @@ static int sb_sort_path(const void *a, const void *b)
 /**
  * sb_sort_unread - Sort Sidebar entries by unread - Implements ::sort_t - @ingroup sort_api
  */
-static int sb_sort_unread(const void *a, const void *b)
+static int sb_sort_unread(const void *a, const void *b, void *arg)
 {
   const struct SbEntry *sbe1 = *(struct SbEntry const *const *) a;
   const struct SbEntry *sbe2 = *(struct SbEntry const *const *) b;
@@ -141,7 +141,7 @@ static int sb_sort_unread(const void *a, const void *b)
 /**
  * sb_sort_order - Sort Sidebar entries by order of creation - Implements ::sort_t - @ingroup sort_api
  */
-static int sb_sort_order(const void *a, const void *b)
+static int sb_sort_order(const void *a, const void *b, void *arg)
 {
   const struct SbEntry *sbe1 = *(struct SbEntry const *const *) a;
   const struct SbEntry *sbe2 = *(struct SbEntry const *const *) b;
@@ -154,7 +154,7 @@ static int sb_sort_order(const void *a, const void *b)
 /**
  * sb_sort_unsorted - Sort Sidebar entries into their original order - Implements ::sort_t - @ingroup sort_api
  */
-static int sb_sort_unsorted(const void *a, const void *b)
+static int sb_sort_unsorted(const void *a, const void *b, void *arg)
 {
   const struct SbEntry *sbe1 = *(struct SbEntry const *const *) a;
   const struct SbEntry *sbe2 = *(struct SbEntry const *const *) b;
@@ -202,5 +202,5 @@ void sb_sort_entries(struct SidebarWindowData *wdata, enum SortType sort)
   }
 
   SbSortReverse = (sort & SORT_REVERSE);
-  ARRAY_SORT(&wdata->entries, fn);
+  ARRAY_SORT(&wdata->entries, fn, NULL);
 }

--- a/sidebar/sort.c
+++ b/sidebar/sort.c
@@ -35,9 +35,6 @@
 #include "sort.h"
 #include "muttlib.h"
 
-/// An extra parameter to control sort order
-static bool SbSortReverse = false;
-
 /**
  * sb_sort_count - Sort Sidebar entries by count - Implements ::sort_t - @ingroup sort_api
  */
@@ -47,6 +44,7 @@ static int sb_sort_count(const void *a, const void *b, void *arg)
   const struct SbEntry *sbe2 = *(struct SbEntry const *const *) b;
   const struct Mailbox *m1 = sbe1->mailbox;
   const struct Mailbox *m2 = sbe2->mailbox;
+  const bool sort_reverse = *(bool *) arg;
 
   int rc = 0;
   if (m1->msg_count == m2->msg_count)
@@ -54,9 +52,7 @@ static int sb_sort_count(const void *a, const void *b, void *arg)
   else
     rc = (m2->msg_count - m1->msg_count);
 
-  if (SbSortReverse)
-    rc = -rc;
-  return rc;
+  return sort_reverse ? -rc : rc;
 }
 
 /**
@@ -68,12 +64,10 @@ static int sb_sort_desc(const void *a, const void *b, void *arg)
   const struct SbEntry *sbe2 = *(struct SbEntry const *const *) b;
   const struct Mailbox *m1 = sbe1->mailbox;
   const struct Mailbox *m2 = sbe2->mailbox;
+  const bool sort_reverse = *(bool *) arg;
 
   int rc = mutt_str_cmp(m1->name, m2->name);
-
-  if (SbSortReverse)
-    rc = -rc;
-  return rc;
+  return sort_reverse ? -rc : rc;
 }
 
 /**
@@ -85,6 +79,7 @@ static int sb_sort_flagged(const void *a, const void *b, void *arg)
   const struct SbEntry *sbe2 = *(struct SbEntry const *const *) b;
   const struct Mailbox *m1 = sbe1->mailbox;
   const struct Mailbox *m2 = sbe2->mailbox;
+  const bool sort_reverse = *(bool *) arg;
 
   int rc = 0;
   if (m1->msg_flagged == m2->msg_flagged)
@@ -92,9 +87,7 @@ static int sb_sort_flagged(const void *a, const void *b, void *arg)
   else
     rc = (m2->msg_flagged - m1->msg_flagged);
 
-  if (SbSortReverse)
-    rc = -rc;
-  return rc;
+  return sort_reverse ? -rc : rc;
 }
 
 /**
@@ -106,15 +99,14 @@ static int sb_sort_path(const void *a, const void *b, void *arg)
   const struct SbEntry *sbe2 = *(struct SbEntry const *const *) b;
   const struct Mailbox *m1 = sbe1->mailbox;
   const struct Mailbox *m2 = sbe2->mailbox;
+  const bool sort_reverse = *(bool *) arg;
 
   int rc = 0;
   rc = mutt_inbox_cmp(mailbox_path(m1), mailbox_path(m2));
   if (rc == 0)
     rc = mutt_str_coll(mailbox_path(m1), mailbox_path(m2));
 
-  if (SbSortReverse)
-    rc = -rc;
-  return rc;
+  return sort_reverse ? -rc : rc;
 }
 
 /**
@@ -126,6 +118,7 @@ static int sb_sort_unread(const void *a, const void *b, void *arg)
   const struct SbEntry *sbe2 = *(struct SbEntry const *const *) b;
   const struct Mailbox *m1 = sbe1->mailbox;
   const struct Mailbox *m2 = sbe2->mailbox;
+  const bool sort_reverse = *(bool *) arg;
 
   int rc = 0;
   if (m1->msg_unread == m2->msg_unread)
@@ -133,9 +126,7 @@ static int sb_sort_unread(const void *a, const void *b, void *arg)
   else
     rc = (m2->msg_unread - m1->msg_unread);
 
-  if (SbSortReverse)
-    rc = -rc;
-  return rc;
+  return sort_reverse ? -rc : rc;
 }
 
 /**
@@ -147,8 +138,9 @@ static int sb_sort_order(const void *a, const void *b, void *arg)
   const struct SbEntry *sbe2 = *(struct SbEntry const *const *) b;
   const struct Mailbox *m1 = sbe1->mailbox;
   const struct Mailbox *m2 = sbe2->mailbox;
+  const bool sort_reverse = *(bool *) arg;
 
-  return (SbSortReverse ? -1 : 1) * (m1->gen - m2->gen);
+  return (sort_reverse ? -1 : 1) * (m1->gen - m2->gen);
 }
 
 /**
@@ -201,6 +193,6 @@ void sb_sort_entries(struct SidebarWindowData *wdata, enum SortType sort)
       break;
   }
 
-  SbSortReverse = (sort & SORT_REVERSE);
-  ARRAY_SORT(&wdata->entries, fn, NULL);
+  bool sort_reverse = (sort & SORT_REVERSE);
+  ARRAY_SORT(&wdata->entries, fn, &sort_reverse);
 }

--- a/sidebar/sort.c
+++ b/sidebar/sort.c
@@ -50,7 +50,7 @@ static int sb_sort_count(const void *a, const void *b, void *arg)
   if (m1->msg_count == m2->msg_count)
     rc = mutt_str_coll(mailbox_path(m1), mailbox_path(m2));
   else
-    rc = (m2->msg_count - m1->msg_count);
+    rc = mutt_numeric_cmp(m2->msg_count, m1->msg_count);
 
   return sort_reverse ? -rc : rc;
 }
@@ -85,7 +85,7 @@ static int sb_sort_flagged(const void *a, const void *b, void *arg)
   if (m1->msg_flagged == m2->msg_flagged)
     rc = mutt_str_coll(mailbox_path(m1), mailbox_path(m2));
   else
-    rc = (m2->msg_flagged - m1->msg_flagged);
+    rc = mutt_numeric_cmp(m2->msg_flagged, m1->msg_flagged);
 
   return sort_reverse ? -rc : rc;
 }
@@ -124,7 +124,7 @@ static int sb_sort_unread(const void *a, const void *b, void *arg)
   if (m1->msg_unread == m2->msg_unread)
     rc = mutt_str_coll(mailbox_path(m1), mailbox_path(m2));
   else
-    rc = (m2->msg_unread - m1->msg_unread);
+    rc = mutt_numeric_cmp(m2->msg_unread, m1->msg_unread);
 
   return sort_reverse ? -rc : rc;
 }
@@ -140,7 +140,8 @@ static int sb_sort_order(const void *a, const void *b, void *arg)
   const struct Mailbox *m2 = sbe2->mailbox;
   const bool sort_reverse = *(bool *) arg;
 
-  return (sort_reverse ? -1 : 1) * (m1->gen - m2->gen);
+  int rc = mutt_numeric_cmp(m1->gen, m2->gen);
+  return sort_reverse ? -rc : rc;
 }
 
 /**

--- a/sort.c
+++ b/sort.c
@@ -59,7 +59,7 @@ struct EmailCompare
 };
 
 /**
- * compare_email_shim - qsort_r() comparator to drive mutt_compare_emails
+ * compare_email_shim - qsort_r() comparator to drive mutt_compare_emails - Implements ::sort_t - @ingroup sort_api
  * @param a   Pointer to first email
  * @param b   Pointer to second email
  * @param arg EmailCompare with needed context

--- a/sort.c
+++ b/sort.c
@@ -319,7 +319,7 @@ static sort_mail_t get_sort_func(enum SortType method, enum MailboxType type)
 }
 
 /**
- * mutt_compare_emails - Compare two emails using up to two sort methods
+ * mutt_compare_emails - Compare two emails using up to two sort methods - @ingroup sort_api
  * @param a        First email
  * @param b        Second email
  * @param type     Mailbox type

--- a/sort.h
+++ b/sort.h
@@ -36,15 +36,16 @@ struct MailboxView;
 /**
  * @defgroup sort_api Sorting API
  *
- * Prototype for generic comparison function, compatible with qsort()
+ * Prototype for generic comparison function, compatible with qsort_r()
  *
- * @param a First item
- * @param b Second item
+ * @param a   First item
+ * @param b   Second item
+ * @param arg Private data
  * @retval <0 a precedes b
  * @retval  0 a and b are identical
  * @retval >0 b precedes a
  */
-typedef int (*sort_t)(const void *a, const void *b);
+typedef int (*sort_t)(const void *a, const void *b, void *arg);
 
 /**
  * @defgroup sort_mail_api Mail Sorting API

--- a/test/array/mutt_array_api.c
+++ b/test/array/mutt_array_api.c
@@ -107,7 +107,7 @@ static void test_set(struct DummyArray *d, size_t begin, size_t end)
   }
 }
 
-static int gt(const void *a, const void *b)
+static int gt(const void *a, const void *b, void *arg)
 {
   const struct Dummy *da = a;
   const struct Dummy *db = b;
@@ -337,13 +337,13 @@ void test_mutt_array_api(void)
   /* Sorting */
   {
     struct DummyArray empty = ARRAY_HEAD_INITIALIZER;
-    if (!TEST_CHECK(!ARRAY_SORT(&empty, gt)))
+    if (!TEST_CHECK(!ARRAY_SORT(&empty, gt, NULL)))
     {
       TEST_MSG("Expected: false");
       TEST_MSG("Actual  : true");
     }
 
-    if (!TEST_CHECK(ARRAY_SORT(&d, gt)))
+    if (!TEST_CHECK(ARRAY_SORT(&d, gt, NULL)))
     {
       TEST_MSG("Expected: true");
       TEST_MSG("Actual  : false");

--- a/test/config/dump.c
+++ b/test/config/dump.c
@@ -166,17 +166,17 @@ bool test_escape_string(void)
 
 bool test_elem_list_sort(void)
 {
-  // int elem_list_sort(const void *a, const void *b);
+  // int elem_list_sort(const void *a, const void *b, void *arg);
 
   {
     struct HashElem he = { 0 };
-    if (!TEST_CHECK(elem_list_sort(NULL, &he) == 0))
+    if (!TEST_CHECK(elem_list_sort(NULL, &he, NULL) == 0))
       return false;
   }
 
   {
     struct HashElem he = { 0 };
-    if (!TEST_CHECK(elem_list_sort(&he, NULL) == 0))
+    if (!TEST_CHECK(elem_list_sort(&he, NULL, NULL) == 0))
       return false;
   }
 

--- a/test/imap/msg_set.c
+++ b/test/imap/msg_set.c
@@ -64,7 +64,7 @@ void test_sort(void)
       ARRAY_ADD(&uida, data[i]);
     }
 
-    ARRAY_SORT(&uida, imap_sort_uid);
+    ARRAY_SORT(&uida, imap_sort_uid, NULL);
 
     for (int i = 0; i < mutt_array_size(data); i++)
     {


### PR DESCRIPTION
* replace `qsort()` with `mutt_qsort_r()`, passing an additional data parameter where appropriate
* change `ARRAY_SORT` to accept a data parameter and switch it to `mutt_qsort_r()`
* change `sort_t` to a `qsort_r()` compatible definition
* add `@ingroup sort_api` doxygen label to compatible functions

Also see the discussion in https://github.com/neomutt/neomutt/discussions/3952.