### PR TITLE
fix 'from' address when real name isn't set

### DIFF
--- a/send/send.c
+++ b/send/send.c
@@ -1467,21 +1467,21 @@ struct Address *mutt_default_from(struct ConfigSubset *sub)
    */
 
   const struct Address *c_from = cs_subset_address(sub, "from");
-  const bool c_use_domain = cs_subset_bool(sub, "use_domain");
   if (c_from)
   {
     return mutt_addr_copy(c_from);
   }
-  else if (c_use_domain)
+
+  char domain[1024] = { 0 };
+  const char *mailbox = Username;
+  const bool c_use_domain = cs_subset_bool(sub, "use_domain");
+  if (c_use_domain)
   {
-    struct Address *addr = mutt_addr_new();
-    buf_printf(addr->mailbox, "%s@%s", NONULL(Username), NONULL(mutt_fqdn(true, sub)));
-    return addr;
+    snprintf(domain, sizeof(domain), "%s@%s", NONULL(Username), NONULL(mutt_fqdn(true, sub)));
+    mailbox = domain;
   }
-  else
-  {
-    return mutt_addr_create(NULL, Username);
-  }
+
+  return mutt_addr_create(NULL, mailbox);
 }
 
 /**
@@ -2475,7 +2475,8 @@ int mutt_send_message(SendFlags flags, struct Email *e_templ, const char *tempfi
     if (from && !from->personal && !(flags & (SEND_RESEND | SEND_POSTPONED)))
     {
       const char *const c_real_name = cs_subset_string(sub, "real_name");
-      from->personal = buf_new(c_real_name);
+      if (c_real_name)
+        from->personal = buf_new(c_real_name);
     }
   }
 

--- a/send/sendlib.c
+++ b/send/sendlib.c
@@ -931,7 +931,8 @@ int mutt_bounce_message(FILE *fp, struct Mailbox *m, struct Email *e,
   if (!from->personal)
   {
     const char *const c_real_name = cs_subset_string(sub, "real_name");
-    from->personal = buf_new(c_real_name);
+    if (c_real_name)
+      from->personal = buf_new(c_real_name);
   }
 
   mutt_addrlist_qualify(&from_list, fqdn);


### PR DESCRIPTION
When `$from` isn't set, NeoMutt tries to construct a `From:` address using, the user's _username_ and the machine's _hostname_.
Ensure that we have a `Buffer` to put them in.

When `$real_name` isn't set `Address.personal` should be `NULL`.
Ensure we don't allocate an empty `Buffer`.

**Steps**:
- Run NeoMutt with zero config:
  `./neomutt -n -F /dev/null`
- Compose an email

**Expected Behaviour**:
- `From:` field contains `username@hostname.com`

**Actual Behaviour**:
- `From:` field contains `<;`