### PR TITLE
fix mview leak

### DIFF
--- a/mview.c
+++ b/mview.c
@@ -65,7 +65,8 @@ void mview_free(struct MailboxView **ptr)
   FREE(&mv->pattern);
   mutt_pattern_free(&mv->limit_pattern);
 
-  FREE(ptr);
+  *ptr = NULL;
+  FREE(&mv);
 }
 
 /**


### PR DESCRIPTION
Fix a race condition that caused a `MailboxView` to not be freed.

**Steps**:
- Run NeoMutt with zero config
  `./neomutt -n -F /dev/null`
- Exit NeoMutt

---

`op_quit()` calls `mview_free(shared->mailbox_view)`

`mview_free()` sends a notification that's observed by the `IndexSharedData` which then does `shared->mailbox_view = NULL;`

This clears the very pointer that `mview_free()` was about to `free()`.

Make a copy of the pointer and free _that_ after the notification.