### PR TITLE
fix macOS build

### DIFF
--- a/init.c
+++ b/init.c
@@ -52,6 +52,9 @@
 #include "globals.h" // IWYU pragma: keep
 #include "hook.h"
 #include "keymap.h"
+#ifndef DOMAIN
+#include "conn/lib.h"
+#endif
 #ifdef USE_LUA
 #include "mutt_lua.h"
 #endif


### PR DESCRIPTION
`conn/lib.h` is required in `init.c` to define `getdnsdomainname()`.

Fix the build error reported by @jindraj: https://pastebin.com/EL7PXNCE. Broken in 1c3de6e65.