### PR TITLE
bug: fix limited threads

### DIFF
--- a/index/functions.c
+++ b/index/functions.c
@@ -2834,7 +2834,8 @@ static bool prereq(struct MailboxView *mv, struct Menu *menu, CheckFlags checks)
   }
 
   int index = menu_get_index(menu);
-  if (result && (checks & CHECK_VISIBLE) && (index >= mv->mailbox->vcount))
+  if (result && (checks & CHECK_VISIBLE) &&
+      ((index < 0) || (index >= mv->mailbox->vcount)))
   {
     mutt_error(_("No visible messages"));
     result = false;

--- a/mutt_thread.c
+++ b/mutt_thread.c
@@ -1285,9 +1285,13 @@ void mutt_sort_threads(struct ThreadsContext *tctx, bool init)
  * @param forwards   Direction to search: 'true' forwards, 'false' backwards
  * @param subthreads Search subthreads: 'true' subthread, 'false' not
  * @retval num Index into the virtual email table
+ * @retval  -1 Error
  */
 int mutt_aside_thread(struct Email *e, bool forwards, bool subthreads)
 {
+  if (!e)
+    return -1;
+
   struct MuttThread *cur = NULL;
   struct Email *e_tmp = NULL;
 


### PR DESCRIPTION
Fix crash on `<next-thread>` when the `<limit>`ed view is empty.

Fixes: #3959 

- Fix Index Functions' `prereq()` check
- Make `mutt_aside_thread()` more robust

---

**Steps**:
- Start NeoMutt
- `<limit>qweasdfa<enter>` - no results
- `<next-thread>` or `<previous-thread>`

**Expected Result**:
- Error: "No visible messages"

**Actual Result**:
- Crash