### PR TITLE
Use strftime_l() instead of global setlocale() for %{!...}

### DIFF
--- a/copy.h
+++ b/copy.h
@@ -30,6 +30,7 @@
 struct Email;
 struct Mailbox;
 struct Message;
+struct NotifyCallback;
 
 typedef uint16_t CopyMessageFlags;     ///< Flags for mutt_copy_message(), e.g. #MUTT_CM_NOHEADER
 #define MUTT_CM_NO_FLAGS           0   ///< No flags are set
@@ -76,6 +77,7 @@ int mutt_copy_hdr(FILE *fp_in, FILE *fp_out, LOFF_T off_start, LOFF_T off_end, C
 
 int mutt_copy_header(FILE *fp_in, struct Email *e, FILE *fp_out, CopyHeaderFlags chflags, const char *prefix, int wraplen);
 
+int attribution_config_observer(struct NotifyCallback *nc);
 int mutt_copy_message_fp(FILE *fp_out, FILE *fp_in, struct Email *e, CopyMessageFlags cmflags, CopyHeaderFlags chflags, int wraplen);
 int mutt_copy_message   (FILE *fp_out, struct Email *e, struct Message *msg, CopyMessageFlags cmflags, CopyHeaderFlags chflags, int wraplen);
 

--- a/core/neomutt.c
+++ b/core/neomutt.c
@@ -58,7 +58,9 @@ struct NeoMutt *neomutt_new(struct ConfigSet *cs)
   if (n->time_c_locale)
     n->time_c_locale = newlocale(LC_TIME_MASK, "C", n->time_c_locale);
 
-  if (!n->time_c_locale)
+  n->time_attribution_locale = duplocale(LC_GLOBAL_LOCALE);
+
+  if (!n->time_c_locale || !n->time_attribution_locale)
   {
     mutt_error(_("Out of memory")); // LCOV_EXCL_LINE
     mutt_exit(1);                   // LCOV_EXCL_LINE
@@ -91,6 +93,8 @@ void neomutt_free(struct NeoMutt **ptr)
   notify_free(&n->notify);
   if (n->time_c_locale)
     freelocale(n->time_c_locale);
+  if (n->time_attribution_locale)
+    freelocale(n->time_attribution_locale);
 
   FREE(ptr);
 }

--- a/core/neomutt.h
+++ b/core/neomutt.h
@@ -39,12 +39,13 @@ struct ConfigSet;
  */
 struct NeoMutt
 {
-  struct Notify *notify;         ///< Notifications handler
-  struct Notify *notify_resize;  ///< Window resize notifications handler
-  struct Notify *notify_timeout; ///< Timeout notifications handler
-  struct ConfigSubset *sub;      ///< Inherited config items
-  struct AccountList accounts;   ///< List of all Accounts
-  locale_t time_c_locale;        ///< Current locale but LC_TIME=C
+  struct Notify *notify;            ///< Notifications handler
+  struct Notify *notify_resize;     ///< Window resize notifications handler
+  struct Notify *notify_timeout;    ///< Timeout notifications handler
+  struct ConfigSubset *sub;         ///< Inherited config items
+  struct AccountList accounts;      ///< List of all Accounts
+  locale_t time_c_locale;           ///< Current locale but LC_TIME=C
+  locale_t time_attribution_locale; ///< Current locale but LC_TIME=$attribution_locale
 };
 
 extern struct NeoMutt *NeoMutt;

--- a/hdrline.h
+++ b/hdrline.h
@@ -25,6 +25,7 @@
 #define MUTT_HDRLINE_H
 
 #include <stdio.h>
+#include <locale.h>
 #include "format_flags.h"
 
 struct Email;
@@ -74,8 +75,19 @@ enum ToChars
   FLAG_CHAR_TO_REPLY_TO,          ///< Character denoting that the user is in the Reply-To list
 };
 
-void mutt_make_string(char *buf, size_t buflen, int cols, const char *s,
-                      struct Mailbox *m, int inpgr, struct Email *e,
-                      MuttFormatFlags flags, const char *progress);
+void mutt_make_string_tl(char *buf, size_t buflen, int cols, const char *s,
+                         struct Mailbox *m, int inpgr, struct Email *e,
+                         MuttFormatFlags flags, const char *progress, locale_t time_loc);
+
+
+/**
+ * mutt_make_string - Wrapper to mutt_make_string_tl()
+ */
+static inline void mutt_make_string(char *buf, size_t buflen, int cols, const char *s,
+                                    struct Mailbox *m, int inpgr, struct Email *e,
+                                    MuttFormatFlags flags, const char *progress)
+{
+  mutt_make_string_tl(buf, buflen, cols, s, m, inpgr, e, flags, progress, NULL);
+}
 
 #endif /* MUTT_HDRLINE_H */

--- a/main.c
+++ b/main.c
@@ -163,6 +163,7 @@
 #include "question/lib.h"
 #include "send/lib.h"
 #include "alternates.h"
+#include "copy.h"
 #include "external.h"
 #include "globals.h"
 #include "hook.h"
@@ -938,6 +939,7 @@ main
   notify_observer_add(NeoMutt->sub->notify, NT_CONFIG, main_log_observer, NULL);
   notify_observer_add(NeoMutt->sub->notify, NT_CONFIG, main_config_observer, NULL);
   notify_observer_add(NeoMutt->notify, NT_TIMEOUT, main_timeout_observer, NULL);
+  notify_observer_add(NeoMutt->sub->notify, NT_CONFIG, attribution_config_observer, NULL);
 
   if (sendflags & SEND_POSTPONED)
   {

--- a/recvcmd.c
+++ b/recvcmd.c
@@ -28,7 +28,6 @@
  */
 
 #include "config.h"
-#include <locale.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include "mutt/lib.h"
@@ -419,12 +418,10 @@ static void include_header(bool quote, FILE *fp_in, struct Email *e, FILE *fp_ou
     }
     else if (!c_text_flowed)
     {
-      const char *const c_attribution_locale = cs_subset_string(NeoMutt->sub, "attribution_locale");
       const char *const c_indent_string = cs_subset_string(NeoMutt->sub, "indent_string");
-      setlocale(LC_TIME, NONULL(c_attribution_locale));
-      mutt_make_string(prefix2, sizeof(prefix2), 0, NONULL(c_indent_string),
-                       NULL, -1, e, MUTT_FORMAT_NO_FLAGS, NULL);
-      setlocale(LC_TIME, "");
+      mutt_make_string_tl(prefix2, sizeof(prefix2), 0, NONULL(c_indent_string),
+                          NULL, -1, e, MUTT_FORMAT_NO_FLAGS, NULL,
+                          NeoMutt->time_attribution_locale);
     }
     else
     {
@@ -525,12 +522,10 @@ static void attach_forward_bodies(FILE *fp, struct Email *e, struct AttachCtx *a
     }
     else
     {
-      const char *const c_attribution_locale = cs_subset_string(NeoMutt->sub, "attribution_locale");
       const char *const c_indent_string = cs_subset_string(NeoMutt->sub, "indent_string");
-      setlocale(LC_TIME, NONULL(c_attribution_locale));
-      mutt_make_string(prefix, sizeof(prefix), 0, NONULL(c_indent_string), NULL,
-                       -1, e_parent, MUTT_FORMAT_NO_FLAGS, NULL);
-      setlocale(LC_TIME, "");
+      mutt_make_string_tl(prefix, sizeof(prefix), 0, NONULL(c_indent_string),
+                          NULL, -1, e_parent, MUTT_FORMAT_NO_FLAGS, NULL,
+                          NeoMutt->time_attribution_locale);
     }
   }
 
@@ -1024,12 +1019,10 @@ void mutt_attach_reply(FILE *fp, struct Mailbox *m, struct Email *e,
     }
     else
     {
-      const char *const c_attribution_locale = cs_subset_string(NeoMutt->sub, "attribution_locale");
       const char *const c_indent_string = cs_subset_string(NeoMutt->sub, "indent_string");
-      setlocale(LC_TIME, NONULL(c_attribution_locale));
-      mutt_make_string(prefix, sizeof(prefix), 0, NONULL(c_indent_string), m,
-                       -1, e_parent, MUTT_FORMAT_NO_FLAGS, NULL);
-      setlocale(LC_TIME, "");
+      mutt_make_string_tl(prefix, sizeof(prefix), 0, NONULL(c_indent_string), m,
+                          -1, e_parent, MUTT_FORMAT_NO_FLAGS, NULL,
+                          NeoMutt->time_attribution_locale);
     }
 
     state.prefix = prefix;

--- a/send/send.c
+++ b/send/send.c
@@ -29,7 +29,6 @@
 
 #include "config.h"
 #include <errno.h>
-#include <locale.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
@@ -443,13 +442,9 @@ void mutt_forward_intro(struct Email *e, FILE *fp, struct ConfigSubset *sub)
   if (!c_forward_attribution_intro || !fp)
     return;
 
-  const char *const c_attribution_locale = cs_subset_string(sub, "attribution_locale");
-
   char buf[1024] = { 0 };
-  setlocale(LC_TIME, NONULL(c_attribution_locale));
-  mutt_make_string(buf, sizeof(buf), 0, c_forward_attribution_intro, NULL, -1,
-                   e, MUTT_FORMAT_NO_FLAGS, NULL);
-  setlocale(LC_TIME, "");
+  mutt_make_string_tl(buf, sizeof(buf), 0, c_forward_attribution_intro, NULL, -1, e,
+                      MUTT_FORMAT_NO_FLAGS, NULL, NeoMutt->time_attribution_locale);
   fputs(buf, fp);
   fputs("\n\n", fp);
 }
@@ -466,13 +461,9 @@ void mutt_forward_trailer(struct Email *e, FILE *fp, struct ConfigSubset *sub)
   if (!c_forward_attribution_trailer || !fp)
     return;
 
-  const char *const c_attribution_locale = cs_subset_string(sub, "attribution_locale");
-
   char buf[1024] = { 0 };
-  setlocale(LC_TIME, NONULL(c_attribution_locale));
-  mutt_make_string(buf, sizeof(buf), 0, c_forward_attribution_trailer, NULL, -1,
-                   e, MUTT_FORMAT_NO_FLAGS, NULL);
-  setlocale(LC_TIME, "");
+  mutt_make_string_tl(buf, sizeof(buf), 0, c_forward_attribution_trailer, NULL, -1,
+                      e, MUTT_FORMAT_NO_FLAGS, NULL, NeoMutt->time_attribution_locale);
   fputc('\n', fp);
   fputs(buf, fp);
   fputc('\n', fp);
@@ -626,12 +617,9 @@ static void format_attribution(const char *s, struct Email *e, FILE *fp_out,
   if (!s || !fp_out)
     return;
 
-  const char *const c_attribution_locale = cs_subset_string(sub, "attribution_locale");
-
   char buf[1024] = { 0 };
-  setlocale(LC_TIME, NONULL(c_attribution_locale));
-  mutt_make_string(buf, sizeof(buf), 0, s, NULL, -1, e, MUTT_FORMAT_NO_FLAGS, NULL);
-  setlocale(LC_TIME, "");
+  mutt_make_string_tl(buf, sizeof(buf), 0, s, NULL, -1, e, MUTT_FORMAT_NO_FLAGS,
+                      NULL, NeoMutt->time_attribution_locale);
   fputs(buf, fp_out);
   fputc('\n', fp_out);
 }


### PR DESCRIPTION
New ltrace for normal locale-ful format (same as before):
```
gmtime_r(1691438423, 0x7fff5c6b6400)                                                             = {23, 0, 20, 7, 7, 123, 1, 218, 0, 0, "GMT"}
strftime("sie 07", 1024, "%b %d", {23, 0, 20, 7, 7, 123, 1, 218, 0, 0, "GMT"})                   = 6
```

New ltrace for the first locale-free format:
```
gmtime_r(1691438423, 0x7fff5c6b63c0)                                                             = {23, 0, 20, 7, 7, 123, 1, 218, 0, 0, "GMT"}
duplocale(0xffffffffffffffff)                                                                    = 0x55c07ca0a6b0
newlocale(0b100, "C", 0x55c07ca0a6b0)                                                            = 0x55c07c8e7b60
strftime_l("Aug 07", 1024, "%b %d", {23, 0, 20, 7, 7, 123, 1, 218, 0, 0, "GMT"}, 0x55c07c8e7b60) = 6
```

and for subsequent ones:
```
gmtime_r(1691438422, 0x7fff5c6b63c0)                                                             = {22, 0, 20, 7, 7, 123, 1, 218, 0, 0, "GMT"}
strftime_l("Aug 07", 1024, "%b %d", {22, 0, 20, 7, 7, 123, 1, 218, 0, 0, "GMT"}, 0x55c07c8e7b60) = 6
```