### PR TITLE
remove unecessary e->env checks

### DIFF
--- a/imap/imap.c
+++ b/imap/imap.c
@@ -1545,8 +1545,7 @@ enum MxStatus imap_sync_mailbox(struct Mailbox *m, bool expunge, bool close)
       /* if the message has been rethreaded or attachments have been deleted
        * we delete the message and reupload it.
        * This works better if we're expunging, of course. */
-      /* TODO: why the e->env check? */
-      if ((e->env && e->env->changed) || e->attach_del)
+      if (e->env->changed || e->attach_del)
       {
         /* L10N: The plural is chosen by the last %d, i.e. the total number */
         if (m->verbose)
@@ -1559,9 +1558,7 @@ enum MxStatus imap_sync_mailbox(struct Mailbox *m, bool expunge, bool close)
         m->append = true;
         mutt_save_message_mbox(m, e, SAVE_MOVE, TRANSFORM_NONE, m);
         m->append = save_append;
-        /* TODO: why the check for e->env?  Is this possible? */
-        if (e->env)
-          e->env->changed = 0;
+        e->env->changed = false;
       }
     }
   }

--- a/maildir/maildir.c
+++ b/maildir/maildir.c
@@ -421,15 +421,12 @@ static int maildir_sync_message(struct Mailbox *m, struct Email *e)
   char suffix[16] = { 0 };
   int rc = 0;
 
-  /* TODO: why the e->env check? */
-  if (e->attach_del || (e->env && e->env->changed))
+  if (e->attach_del || e->env->changed)
   {
     /* when doing attachment deletion/rethreading, fall back to the MH case. */
     if (maildir_rewrite_message(m, e) != 0)
       return -1;
-    /* TODO: why the env check? */
-    if (e->env)
-      e->env->changed = 0;
+    e->env->changed = false;
   }
   else
   {

--- a/maildir/mh.c
+++ b/maildir/mh.c
@@ -449,14 +449,11 @@ static int mh_sync_message(struct Mailbox *m, struct Email *e)
   if (!m || !e)
     return -1;
 
-  /* TODO: why the e->env check? */
-  if (e->attach_del || (e->env && e->env->changed))
+  if (e->attach_del || e->env->changed)
   {
     if (mh_rewrite_message(m, e) != 0)
       return -1;
-    /* TODO: why the env check? */
-    if (e->env)
-      e->env->changed = 0;
+    e->env->changed = false;
   }
 
   return 0;


### PR DESCRIPTION
I ran this through Coverity and it didn't show any new defects. I also tried to follow the callers to see if we didn't initialize the envelope anywhere but that proved impossible.

Do we want to try this out?