### PR TITLE
use FreeBSD 13.2 in Cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 freebsd_instance:
-  image_family: freebsd-13-1
+  image_family: freebsd-13-2
 
 task:
   only_if: $CIRRUS_BRANCH == "main" || $CIRRUS_PR != ""


### PR DESCRIPTION
This fixes our broken FreeBSD CI builds.