### PR TITLE
force SigWinch after endwin()

### DIFF
--- a/gui/curs_lib.c
+++ b/gui/curs_lib.c
@@ -366,6 +366,7 @@ void mutt_endwin(void)
    * doesn't properly flush the screen without an explicit call.  */
   mutt_refresh();
   endwin();
+  SigWinch = true;
 
   errno = e;
 }


### PR DESCRIPTION
* **What does this PR do?**

I was about to add mutt_resize_screen() when returning from mutt_shell_escape() and call it a day.
But looking at bug #1208, flatcap suggested comparing mutt and neomutt behavior. And to my own shock mutt was
working fine for issues described on #3980.

Debugging mutt I could reproduce the same behavior: SIGWINCH does not trigger when coming back from curses shutdown (eg. mutt_endwin()), but it was working there so I narrowed down to commit 619db54f5133cc788513737ca354f91ab54130fc in mutt tree.
Kevin writes the following:
"Since mutt_reflow_window() needs to be called on a resize, and it's
    possible for programs to block SIGWINCH being sent to Mutt, this is a
    fail-safe to ensure it's run."

I'm not entirely sure about programs blocking SIGWINCH signal, I've tried with several terminals or different WMs but it's obviously a known thing and probably a better fix than mine.

* **What are the relevant issue numbers?**
#3980