### PR TITLE
`mailboxes`: add `-label`, `-notify` and `-poll` options

### DIFF
--- a/browser/dlg_browser.c
+++ b/browser/dlg_browser.c
@@ -1080,7 +1080,8 @@ static int browser_config_observer(struct NotifyCallback *nc)
 
   struct EventConfig *ev_c = nc->event_data;
 
-  struct Menu *menu = nc->global_data;
+  struct BrowserPrivateData *priv = nc->global_data;
+  struct Menu *menu = priv->menu;
 
   if (mutt_str_equal(ev_c->name, "browser_sort_dirs_first"))
   {
@@ -1121,15 +1122,15 @@ static int browser_window_observer(struct NotifyCallback *nc)
   if (nc->event_subtype != NT_WINDOW_DELETE)
     return 0;
 
-  struct MuttWindow *win_menu = nc->global_data;
+  struct BrowserPrivateData *priv = nc->global_data;
+  struct MuttWindow *win_menu = priv->menu->win;
+
   struct EventWindow *ev_w = nc->event_data;
   if (ev_w->win != win_menu)
     return 0;
 
-  struct Menu *menu = win_menu->wdata;
-
-  notify_observer_remove(NeoMutt->sub->notify, browser_config_observer, menu);
-  notify_observer_remove(win_menu->notify, browser_window_observer, win_menu);
+  notify_observer_remove(NeoMutt->sub->notify, browser_config_observer, priv);
+  notify_observer_remove(win_menu->notify, browser_window_observer, priv);
 
   mutt_debug(LL_DEBUG5, "window delete done\n");
   return 0;
@@ -1385,8 +1386,8 @@ void dlg_select_file(struct Buffer *file, SelectFileFlags flags,
   struct MuttWindow *win_menu = priv->menu->win;
 
   // NT_COLOR is handled by the SimpleDialog
-  notify_observer_add(NeoMutt->sub->notify, NT_CONFIG, browser_config_observer, priv->menu);
-  notify_observer_add(win_menu->notify, NT_WINDOW, browser_window_observer, win_menu);
+  notify_observer_add(NeoMutt->sub->notify, NT_CONFIG, browser_config_observer, priv);
+  notify_observer_add(win_menu->notify, NT_WINDOW, browser_window_observer, priv);
 
   if (priv->state.is_mailbox_list)
   {

--- a/browser/dlg_browser.c
+++ b/browser/dlg_browser.c
@@ -726,7 +726,7 @@ int examine_directory(struct Mailbox *m, struct Menu *menu, struct BrowserState 
           break;
       }
 
-      if (np && m && mutt_str_equal(np->mailbox->realpath, m->realpath))
+      if (np && m && m->poll_new_mail && mutt_str_equal(np->mailbox->realpath, m->realpath))
       {
         np->mailbox->msg_count = m->msg_count;
         np->mailbox->msg_unread = m->msg_unread;
@@ -797,7 +797,7 @@ int examine_mailboxes(struct Mailbox *m, struct Menu *menu, struct BrowserState 
       if (!np->mailbox)
         continue;
 
-      if (m && mutt_str_equal(np->mailbox->realpath, m->realpath))
+      if (m && m->poll_new_mail && mutt_str_equal(np->mailbox->realpath, m->realpath))
       {
         np->mailbox->msg_count = m->msg_count;
         np->mailbox->msg_unread = m->msg_unread;

--- a/browser/lib.h
+++ b/browser/lib.h
@@ -88,13 +88,15 @@ struct FolderFile
 #ifdef USE_IMAP
   char delim;              ///< Path delimiter
 
-  bool imap        : 1;    ///< This is an IMAP folder
-  bool selectable  : 1;    ///< Folder can be selected
-  bool inferiors   : 1;    ///< Folder has children
+  bool imap          : 1;  ///< This is an IMAP folder
+  bool selectable    : 1;  ///< Folder can be selected
+  bool inferiors     : 1;  ///< Folder has children
 #endif
-  bool has_mailbox : 1;    ///< This is a mailbox
-  bool local       : 1;    ///< Folder is on local filesystem
-  bool tagged      : 1;    ///< Folder is tagged
+  bool has_mailbox   : 1;  ///< This is a mailbox
+  bool local         : 1;  ///< Folder is on local filesystem
+  bool notify_user   : 1;  ///< User will be notified of new mail
+  bool poll_new_mail : 1;  ///< Check mailbox for new mail
+  bool tagged        : 1;  ///< Folder is tagged
 #ifdef USE_NNTP
   struct NntpMboxData *nd; ///< Extra NNTP data
 #endif

--- a/core/mailbox.c
+++ b/core/mailbox.c
@@ -77,6 +77,8 @@ struct Mailbox *mailbox_new(void)
   m->emails = mutt_mem_calloc(m->email_max, sizeof(struct Email *));
   m->v2r = mutt_mem_calloc(m->email_max, sizeof(int));
   m->gen = mailbox_gen();
+  m->notify_user = true;
+  m->poll_new_mail = true;
 
   return m;
 }

--- a/core/mailbox.h
+++ b/core/mailbox.h
@@ -109,9 +109,11 @@ struct Mailbox
   bool changed                : 1;    ///< Mailbox has been modified
   bool dontwrite              : 1;    ///< Don't write the mailbox on close
   bool first_check_stats_done : 1;    ///< True when the check have been done at least one time
+  bool notify_user            : 1;    ///< Notify the user of new mail
   bool peekonly               : 1;    ///< Just taking a glance, revert atime
-  bool verbose                : 1;    ///< Display status messages?
+  bool poll_new_mail          : 1;    ///< Check for new mail
   bool readonly               : 1;    ///< Don't allow changes to the mailbox
+  bool verbose                : 1;    ///< Display status messages?
 
   AclFlags rights;                    ///< ACL bits, see #AclFlags
 

--- a/docs/manual.xml.head
+++ b/docs/manual.xml.head
@@ -6340,22 +6340,47 @@ unignore posted-to:
       </para>
       <cmdsynopsis>
         <command>mailboxes</command>
-        <arg choice="plain">
-          <replaceable class="parameter">mailbox</replaceable>
+        <arg choice="opt">
+          <group choice="opt">
+            <arg choice="plain">
+              <option>-label</option>
+              <replaceable>label</replaceable>
+            </arg>
+            <arg choice="plain">
+              <option>-nolabel</option>
+            </arg>
+          </group>
+          <group choice="opt">
+            <arg choice="plain">
+              <option>-notify</option>
+            </arg>
+            <arg choice="plain">
+              <option>-nonotify</option>
+            </arg>
+          </group>
+          <group choice="opt">
+            <arg choice="plain">
+              <option>-poll</option>
+            </arg>
+            <arg choice="plain">
+              <option>-nopoll</option>
+            </arg>
+          </group>
+          <arg choice="plain">
+            <replaceable class="parameter">mailbox</replaceable>
+          </arg>
         </arg>
-        <arg choice="opt" rep="repeat">
-          <replaceable class="parameter">mailbox</replaceable>
-        </arg>
+        <arg choice="opt" rep="repeat"></arg>
         <command>named-mailboxes</command>
         <arg choice="plain">
-          <replaceable class="parameter">description</replaceable>
+          <replaceable class="parameter">label</replaceable>
           <arg choice="plain">
             <replaceable class="parameter">mailbox</replaceable>
           </arg>
         </arg>
         <group choice="req" rep="repeat">
           <arg choice="plain">
-            <replaceable class="parameter">description</replaceable>
+            <replaceable class="parameter">label</replaceable>
             <arg choice="plain">
               <replaceable class="parameter">mailbox</replaceable>
             </arg>
@@ -6374,6 +6399,27 @@ unignore posted-to:
       <para>
         This command specifies folders which can receive mail and which will be
         checked for new messages periodically.
+      </para>
+      <para>
+        The <literal>-label</literal> argument can be used to specify an
+        alternative label to print in the sidebar or mailbox browser instead
+        of the mailbox path.  A label may be removed via the
+        <literal>-nolabel</literal> argument.  If unspecified, an existing
+        mailbox label will be unchanged.
+      </para>
+      <para>
+        Use <literal>-nonotify</literal> to disable notifying when new mail
+        arrives.  The <literal>-notify</literal> argument can be used to reenable
+        notifying for an existing mailbox.  If unspecified: a new
+        mailbox will notify by default, while an existing mailbox will be
+        unchanged.
+      </para>
+      <para>
+        To disable polling, specify <literal>-nopoll</literal> before the
+        mailbox name.  The <literal>-poll</literal> argument can be used to
+        reenable polling for an existing mailbox.  If unspecified: a new
+        mailbox will poll by default, while an existing mailbox will be
+        unchanged.
       </para>
       <para>
         <emphasis>folder</emphasis> can either be a local file or directory

--- a/docs/neomuttrc.man.head
+++ b/docs/neomuttrc.man.head
@@ -549,8 +549,11 @@ Missing key sequence in \fBunmacro\fP command means unmacro all macros in menus 
 .
 .PP
 .nf
-\fBmailboxes\fP \fImailbox\fP [ \fImailbox\fP ... ]
-\fBnamed-mailboxes\fP \fIdescription\fP \fImailbox\fP [\fIdescription\fP \fImailbox\fP ... ]
+\fBmailboxes\fP [[\fB-label\fP \fIlabel\fP] | \fB-nolabel\fP]
+           [[\fB-notify\fP | \fB-nonotify\fP]
+           [\fB-poll\fP | \fB-nopoll\fP]
+           \fImailbox\fP] [ ... ]
+\fBnamed-mailboxes\fP \fIlabel\fP \fImailbox\fP [\fIlabel\fP \fImailbox\fP ... ]
 \fBunmailboxes\fP { \fB*\fP | \fImailbox\fP ... }
 .fi
 .IP
@@ -558,9 +561,9 @@ The \fBmailboxes\fP specifies folders which can receive mail and which will be
 checked for new messages. When changing folders, pressing space will cycle
 through folders with new mail.
 .IP
-The \fBnamed-mailboxes\fP is an alternative to \fBmailboxes\fP that allows
-adding a description for a mailbox. NeoMutt can be configured to display the
-description instead of the mailbox path.
+The \fBnamed-mailboxes\fP is an alternative to \fBmailboxes\fP \fB-label\fP
+\fIlabel\fP.  NeoMutt can be configured to display the label instead of the
+mailbox path.
 .IP
 The \fBunmailboxes\fP command is used to remove a file name from the list of
 folders which can receive mail. If \(lq\fB*\fP\(rq is specified as the file

--- a/imap/imap.c
+++ b/imap/imap.c
@@ -1104,6 +1104,9 @@ static int imap_status(struct ImapAccountData *adata, struct ImapMboxData *mdata
     return mdata->messages;
   }
 
+  if (adata->mailbox && !adata->mailbox->poll_new_mail)
+    return mdata->messages;
+
   if (adata->capabilities & IMAP_CAP_IMAP4REV1)
   {
     uidvalidity_flag = "UIDVALIDITY";

--- a/mutt_mailbox.c
+++ b/mutt_mailbox.c
@@ -201,18 +201,20 @@ int mutt_mailbox_check(struct Mailbox *m_cur, CheckStatsFlags flags)
   struct MailboxNode *np = NULL;
   STAILQ_FOREACH(np, &ml, entries)
   {
-    if (!np->mailbox->visible)
+    struct Mailbox *m = np->mailbox;
+
+    if (!m->visible)
       continue;
 
     CheckStatsFlags m_flags = flags;
-    if (!np->mailbox->first_check_stats_done && c_mail_check_stats)
+    if (!m->first_check_stats_done && c_mail_check_stats)
     {
       m_flags |= MUTT_MAILBOX_CHECK_FORCE_STATS;
     }
-    mailbox_check(m_cur, np->mailbox, &st_cur, m_flags);
-    if (np->mailbox->has_new)
+    mailbox_check(m_cur, m, &st_cur, m_flags);
+    if (m->has_new)
       MailboxCount++;
-    np->mailbox->first_check_stats_done = true;
+    m->first_check_stats_done = true;
   }
   neomutt_mailboxlist_clear(&ml);
 

--- a/mutt_mailbox.c
+++ b/mutt_mailbox.c
@@ -142,9 +142,17 @@ static void mailbox_check(struct Mailbox *m_cur, struct Mailbox *m_check,
   }
 
   if (!m_check->has_new)
+  {
     m_check->notified = false;
-  else if (!m_check->notified)
-    MailboxNotify++;
+  }
+  else
+  {
+    // pretend that we've already notified for the mailbox
+    if (!m_check->notify_user)
+      m_check->notified = true;
+    else if (!m_check->notified)
+      MailboxNotify++;
+  }
 }
 
 /**
@@ -203,7 +211,7 @@ int mutt_mailbox_check(struct Mailbox *m_cur, CheckStatsFlags flags)
   {
     struct Mailbox *m = np->mailbox;
 
-    if (!m->visible)
+    if (!m->visible || !m->poll_new_mail)
       continue;
 
     CheckStatsFlags m_flags = flags;

--- a/nntp/browse.c
+++ b/nntp/browse.c
@@ -44,12 +44,14 @@
  *
  * | Expando | Description
  * | :------ | :-------------------------------------------------------
+ * | \%a     | Alert: 1 if user is notified of new mail
  * | \%C     | Current newsgroup number
  * | \%d     | Description of newsgroup (becomes from server)
  * | \%f     | Newsgroup name
  * | \%M     | - if newsgroup not allowed for direct post (moderated for example)
  * | \%N     | N if newsgroup is new, u if unsubscribed, blank otherwise
  * | \%n     | Number of new articles in newsgroup
+ * | \%p     | Poll: 1 if Mailbox is checked for new mail
  * | \%s     | Number of unread articles in newsgroup
  */
 const char *group_index_format_str(char *buf, size_t buflen, size_t col, int cols,
@@ -59,9 +61,23 @@ const char *group_index_format_str(char *buf, size_t buflen, size_t col, int col
 {
   char fn[128], fmt[128];
   struct Folder *folder = (struct Folder *) data;
+  bool optional = (flags & MUTT_FORMAT_OPTIONAL);
 
   switch (op)
   {
+    case 'a':
+      if (!optional)
+      {
+        snprintf(fmt, sizeof(fmt), "%%%sd", prec);
+        snprintf(buf, buflen, fmt, folder->ff->notify_user);
+      }
+      else
+      {
+        if (folder->ff->notify_user == 0)
+          optional = false;
+      }
+      break;
+
     case 'C':
       snprintf(fmt, sizeof(fmt), "%%%sd", prec);
       snprintf(buf, buflen, fmt, folder->num + 1);
@@ -126,8 +142,21 @@ const char *group_index_format_str(char *buf, size_t buflen, size_t col, int col
       break;
     }
 
+    case 'p':
+      if (!optional)
+      {
+        snprintf(fmt, sizeof(fmt), "%%%sd", prec);
+        snprintf(buf, buflen, fmt, folder->ff->poll_new_mail);
+      }
+      else
+      {
+        if (folder->ff->poll_new_mail == 0)
+          optional = false;
+      }
+      break;
+
     case 's':
-      if (flags & MUTT_FORMAT_OPTIONAL)
+      if (optional)
       {
         if (folder->ff->nd->unread != 0)
         {

--- a/sidebar/window.c
+++ b/sidebar/window.c
@@ -332,6 +332,7 @@ static int calc_path_depth(const char *mbox, const char *delims, const char **la
  * | Expando | Description
  * | :------ | :-------------------------------------------------------
  * | \%!     | 'n!' Flagged messages
+ * | \%a     | Alert: 1 if user is notified of new mail
  * | \%B     | Name of the mailbox
  * | \%D     | Description of the mailbox
  * | \%d     | Number of deleted messages
@@ -340,6 +341,7 @@ static int calc_path_depth(const char *mbox, const char *delims, const char **la
  * | \%n     | "N" if mailbox has new mail, " " (space) otherwise
  * | \%N     | Number of unread messages in the mailbox
  * | \%o     | Number of old unread messages in the mailbox
+ * | \%p     | Poll: 1 if Mailbox is checked for new mail
  * | \%r     | Number of read messages in the mailbox
  * | \%S     | Size of mailbox (total number of messages)
  * | \%t     | Number of tagged messages
@@ -372,6 +374,19 @@ static const char *sidebar_format_str(char *buf, size_t buflen, size_t col, int 
 
   switch (op)
   {
+    case 'a':
+      if (!optional)
+      {
+        snprintf(fmt, sizeof(fmt), "%%%sd", prec);
+        snprintf(buf, buflen, fmt, m->notify_user);
+      }
+      else
+      {
+        if (m->notify_user == 0)
+          optional = false;
+      }
+      break;
+
     case 'B':
     case 'D':
     {
@@ -453,6 +468,19 @@ static const char *sidebar_format_str(char *buf, size_t buflen, size_t col, int 
       else if ((c && (m_cur->msg_unread - m_cur->msg_new) == 0) || !c)
       {
         optional = false;
+      }
+      break;
+
+    case 'p':
+      if (!optional)
+      {
+        snprintf(fmt, sizeof(fmt), "%%%sd", prec);
+        snprintf(buf, buflen, fmt, m->poll_new_mail);
+      }
+      else
+      {
+        if (m->poll_new_mail == 0)
+          optional = false;
       }
       break;
 


### PR DESCRIPTION
Add new options to the `mailboxes` command (to match upstream).

- `mailboxes -label LABEL FOLDER`
  Add a mailbox with a descriptive label.
  (Equivalent to `named-mailboxes LABEL FOLDER`)

- `mailboxes -nolabel FOLDER`
  Remove a label from an existing mailbox.

- `mailboxes -notify FOLDER`
  Notify the user that new mail has arrived (default behaviour).

- `mailboxes -nonotify FOLDER`
  Do not notify the user of new mail.

- `mailboxes -poll FOLDER`
  Check the mailbox for new mail (default behaviour).

- `mailboxes -nopoll FOLDER`
  Do not check the mailbox for new mail.

These commands can be used at any time, e.g. to change the behaviour.

---

The first three commits are refactoring prep.

- d1f122f84 refactor loop
- 9243be67e browser: unify observers
- 7ec63bb82 browser: add mailbox observers
  This allows the browser to react to Mailbox changes

- fefe6e59d mailboxes: add label/notify/poll options
- cec649b05 add poll/notify expandos to browser/sidebar
  Introduces `%a` (alert/notify) and `%p` (poll)

---

The expandos for the browser/sidebar display 1/0 depending on whether the notify or poll feature is enabled on that mailbox.
This can be used to display icons in the browser/sidebar.

**config**
```conf
set sidebar_format        = "%<p?👁️  &  >%<a?🔔&  >  %D%?F? [%F]?%* %?N?%N/?%?S?%S?"
set mailbox_folder_format = "%<p?👁️  &  >%<a?🔔&  >  %2C %<n?%6n&      > %6m %i"
```

![image](https://github.com/neomutt/neomutt/assets/76760/ea82bc54-f52c-4ef2-9f4c-b0af9b9d58d5)

Mailbox flags can be toggled, e.g.

**config**
```conf
macro index,browser <f1> "<enter-command>mailboxes -nonotify +neo/devel<enter>"
macro index,browser <f2> "<enter-command>mailboxes -notify   +neo/devel<enter>"
macro index,browser <f3> "<enter-command>mailboxes -nopoll   +neo/devel<enter>"
macro index,browser <f4> "<enter-command>mailboxes -poll     +neo/devel<enter>"
```