### PR TITLE
help: fix search highlight

### DIFF
--- a/pager/display.c
+++ b/pager/display.c
@@ -1296,7 +1296,11 @@ int display_line(FILE *fp, LOFF_T *bytes_read, struct Line **lines,
   }
 
   if (col < win_pager->state.cols)
+  {
+    const enum ColorId cid = ((line_num % 2) == 0) ? MT_COLOR_STRIPE_ODD : MT_COLOR_STRIPE_EVEN;
+    mutt_curses_set_color_by_id(cid);
     mutt_window_clrtoeol(win_pager);
+  }
 
   /* reset the color back to normal.  This *must* come after the
    * clrtoeol, otherwise the color for this line will not be

--- a/pager/display.c
+++ b/pager/display.c
@@ -150,7 +150,15 @@ static void resolve_color(struct MuttWindow *win, struct Line *lines, int line_n
   }
   else if (!(flags & MUTT_SHOWCOLOR))
   {
-    def_color = *simple_color_get(MT_COLOR_NORMAL);
+    if (flags & MUTT_PAGER_STRIPES)
+    {
+      def_color = *simple_color_get(((line_num % 2) == 0) ? MT_COLOR_STRIPE_ODD :
+                                                            MT_COLOR_STRIPE_EVEN);
+    }
+    else
+    {
+      def_color = *simple_color_get(MT_COLOR_NORMAL);
+    }
   }
   else if ((lines[m].cid == MT_COLOR_HEADER) && lines[m].syntax[0].attr_color)
   {
@@ -1241,17 +1249,7 @@ int display_line(FILE *fp, LOFF_T *bytes_read, struct Line **lines,
   if (flags & MUTT_PAGER_STRIPES)
   {
     const enum ColorId cid = ((line_num % 2) == 0) ? MT_COLOR_STRIPE_ODD : MT_COLOR_STRIPE_EVEN;
-    const struct AttrColor *attr_color = mutt_curses_set_color_by_id(cid);
-
-    memset(&ansi, 0, sizeof(struct AnsiColor));
-    ansi.attr_color = attr_color;
-    ansi.attrs = attr_color->attrs;
-
-    if (attr_color->curses_color)
-    {
-      ansi.fg = attr_color->curses_color->fg;
-      ansi.bg = attr_color->curses_color->bg;
-    }
+    mutt_curses_set_color_by_id(cid);
   }
 
   /* display the line */


### PR DESCRIPTION
The recent change (73d873e42) to add striped highlighting had an unfortunate side-effect.
It masked the search highlighting, which is kinda useful in the help :-)

Here's what the fixed help looks like, with a variety of config settings:

![image](https://github.com/neomutt/neomutt/assets/76760/db848681-3ba3-4ddb-8856-33003f6e3087)

**Config**:
```
color stripe_even default default                      color stripe_even underline default default
color stripe_odd  magenta yellow                       color stripe_odd  underline default default

color stripe_even white color234                       color stripe_even underline default default
color stripe_odd  white black                          color stripe_odd            default default

color stripe_even default color234                     color stripe_even bold default default
color stripe_odd  default default                      color stripe_odd       default default

color stripe_even default default                      color stripe_even cyan    red
color stripe_odd  default default                      color stripe_odd  magenta yellow
       
```