### PR TITLE
build: more robust pkgconf check for lua

### DIFF
--- a/auto.def
+++ b/auto.def
@@ -568,7 +568,8 @@ if {[get-define want-sasl]} {
 # Lua
 if {[get-define want-lua]} {
 
-  if {![pkgconf false lua] && ![pkgconf false lua-5.4] && ![pkgconf false lua-5.3] && ![pkgconf false lua-5.2]} {
+  if {![pkgconf false lua] && ![pkgconf false lua-5.4] && ![pkgconf false lua-5.3] && ![pkgconf false lua-5.2] \
+                           && ![pkgconf false lua5.4]  && ![pkgconf false lua5.3]  && ![pkgconf false lua5.2]} {
     user-error "Unable to find LUA"
   }
   define USE_LUA


### PR DESCRIPTION
**What does this PR do?**
Extend the pkgconf check for Lua in auto.def to not only look for lua and lua-5.x, but also for lua5.x as used by some distributions.

I've run into this issue on Gentoo when looking into adding Lua support to the Neomutt ebuild; while `./configure --enable-lua` works fine with older Neomutt releases (e.g. 20220415), it doesn't find the Lua installation when using newer Neomutt releases. Digging into this, it turned out that the root cause is that there are multiple naming conventions for the Lua pkgconf files, so that checking for multiple variants is required. While one could adapt the [Alpine Linux solution](https://git.alpinelinux.org/aports/commit/?id=93d811c319d6479dba4716800d8b809f0b458fe2) for Gentoo, it still seems sensible to also amend the check in Neomutt to resolve this (at least for Neomutt) for other distributions as well.

(After patching auto.def, building Neomutt on Gentoo with Lua support works fine.)